### PR TITLE
style(rccl): adopt NCCL clang-format style and tooling for src/

### DIFF
--- a/projects/rccl/.clang-format
+++ b/projects/rccl/.clang-format
@@ -1,139 +1,113 @@
-# Style file for MLSE Libraries based on the modified rocBLAS style
-
-# Common settings
-BasedOnStyle:  WebKit
-TabWidth:        4
-IndentWidth:     4
-UseTab:          Never
-ColumnLimit: 100
-UseCRLF: false
-
-# Other languages JavaScript, Proto
----
-Language: Json
-DisableFormat: true
-
----
 Language: Cpp
+BasedOnStyle: Google
 
-# http://releases.llvm.org/6.0.1/tools/clang/docs/ClangFormatStyleOptions.html#disabling-formatting-on-a-piece-of-code
-# int formatted_code;
-# // clang-format off
-#     void    unformatted_code  ;
-# // clang-format on
-# void formatted_code_again;
+# NCCL only have ~2% lines longer than 120
+ColumnLimit: 120
 
-DisableFormat: false
-Standard: Cpp11
-
-AccessModifierOffset: -4
-AlignAfterOpenBracket: true
-AlignArrayOfStructures: Right
-AlignConsecutiveAssignments: true
-AlignConsecutiveDeclarations: true
-AlignEscapedNewlines: Left
-AlignOperands: true
-AlignTrailingComments: false
-AllowAllArgumentsOnNextLine: false
-AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortBlocksOnASingleLine: Never
-AllowShortCaseLabelsOnASingleLine: true
-AllowShortFunctionsOnASingleLine: Empty
-AllowShortIfStatementsOnASingleLine: false
-AllowShortLoopsOnASingleLine: false
-AlwaysBreakAfterReturnType: None
-AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: Yes
-BinPackArguments: false
-BinPackParameters: false
-BitFieldColonSpacing: Both
-# Configure each individual brace in BraceWrapping
-BreakBeforeBraces: Custom
-# Control of individual brace wrapping cases
-BraceWrapping:
-    AfterCaseLabel: true
-    AfterClass: true
-    AfterControlStatement: Always
-    AfterEnum: true
-    AfterExternBlock: false
-    AfterFunction: true
-    AfterNamespace: true
-    AfterStruct: true
-    AfterUnion: true
-    BeforeCatch: true
-    BeforeElse: true
-    BeforeLambdaBody: true
-    BeforeWhile: true
-    IndentBraces: false
-    SplitEmptyFunction: false
-    SplitEmptyRecord: false
-    SplitEmptyNamespace: false
-BreakBeforeBinaryOperators: All
-BreakBeforeTernaryOperators: true
-BreakConstructorInitializers: BeforeComma
-BreakInheritanceList: BeforeComma
-BreakStringLiterals: true
-CommentPragmas: '^ IWYU pragma:'
-CompactNamespaces: false
-ConstructorInitializerIndentWidth: 4
-ContinuationIndentWidth: 4
-Cpp11BracedListStyle: true
-DeriveLineEnding: false
-DerivePointerAlignment: false
-EmptyLineAfterAccessModifier: Never
-EmptyLineBeforeAccessModifier: Always
-ExperimentalAutoDetectBinPacking: false
-FixNamespaceComments: true
-ForEachMacros: []
-IfMacros: []
-IncludeBlocks: Preserve
-IndentAccessModifiers: false
-IndentCaseBlocks: true
-IndentCaseLabels: true
-IndentExternBlock: NoIndent
-IndentPPDirectives: BeforeHash
-IndentWrappedFunctionNames: true
-KeepEmptyLinesAtTheStartOfBlocks: true
-LambdaBodyIndentation: Signature
-MacroBlockBegin: ''
-MacroBlockEnd: ''
+# Blank lines
 MaxEmptyLinesToKeep: 1
-NamespaceIndentation: None
-PPIndentWidth: -1
-PackConstructorInitializers: NextLine
-PenaltyBreakBeforeFirstCallParameter: 19
-PenaltyBreakComment: 300
-PenaltyBreakFirstLessLess: 120
-PenaltyBreakString: 1000
-PenaltyExcessCharacter: 1000000
-PenaltyReturnTypeOnItsOwnLine: 60
-PointerAlignment: Left
-QualifierAlignment: Leave
-ReferenceAlignment: Pointer
-ReflowComments: false
-ShortNamespaceLines: 0
-SortIncludes: CaseSensitive
-SortUsingDeclarations: true
-SpaceAfterCStyleCast: false
-SpaceAfterLogicalNot: false
-SpaceAfterTemplateKeyword: false
-SpaceAroundPointerQualifiers: Default
-SpaceBeforeAssignmentOperators: true
-SpaceBeforeCaseColon: false
-SpaceBeforeCpp11BracedList: false
-SpaceBeforeCtorInitializerColon: true
-SpaceBeforeInheritanceColon: true
-SpaceBeforeParens: Never
-SpaceBeforeRangeBasedForLoopColon: true
-SpaceBeforeSquareBrackets: false
-SpaceInEmptyBlock: false
-SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 1
-SpacesInAngles: Never
-SpacesInCStyleCastParentheses: false
-SpacesInConditionalStatement: false
-SpacesInContainerLiterals: true
-SpacesInParentheses: false
-SpacesInSquareBrackets: false
+KeepEmptyLines:
+  AtStartOfFile: false
 
----
+# Indentation Sizes
+IndentWidth: 2
+ContinuationIndentWidth: 2
+# align public:/private: with struct/class
+AccessModifierOffset: -2
+ConstructorInitializerIndentWidth: 2
+UseTab: Never
+
+# Brace style: K&R (Google default — same line)
+BreakBeforeBraces: Attach
+
+# case at same indent level as switch
+IndentCaseLabels: false
+# add extra indentation for compound stmt in case block
+IndentCaseBlocks: true
+
+# Pointer: type-side (int*, not int *)
+PointerAlignment: Left
+
+# Don't align macro backslash, avoids unnecessary reformatting
+AlignEscapedNewlines: DontAlign
+
+# Allow One-liners
+AllowShortIfStatementsOnASingleLine: AllIfsAndElse
+AllowShortLoopsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortEnumsOnASingleLine: false
+
+# Do not allow clang-format to add or remove braces in control statements
+# This help preserving developer's intention on braces
+InsertBraces: false
+RemoveBracesLLVM: false
+
+# template<> -> template <>
+SpaceAfterTemplateKeyword: true
+
+# Namespace bodies: indented (majority of codebase uses indentation inside namespaces)
+NamespaceIndentation: None
+
+## Line Breaking and Wrapping behaviors
+# When args don't fit on one line, break after ( and indent args by ContinuationIndentWidth
+AlignAfterOpenBracket: true
+BreakBeforeCloseBracketBracedList: true
+BreakBeforeInlineASMColon: OnlyMultiline
+AlwaysBreakBeforeMultilineStrings: false
+# pack arguments and parameters tightly
+BinPackArguments: true
+BinPackParameters: BinPack
+PackConstructorInitializers: BinPack
+# binary operators trailing on previous line
+BreakBeforeBinaryOperators: None
+# ? : operators trailing on previous line and never break before ?
+BreakBeforeTernaryOperators: false
+# template <> always on its own line in declaration
+BreakTemplateDeclarations: Yes
+# Penalty tuning
+# increase penalty for early breaking at the opening parenthesis,
+# making BinPack behavior nicely and less likely to break after the opening parenthesis
+PenaltyBreakOpenParenthesis: 33
+
+# AllowAllArgumentsOnNextLine: true
+# AllowAllParametersOfDeclarationOnNextLine: true
+
+# Preprocessor directives: keep at column 0
+IndentPPDirectives: None
+
+# Do not sort or regroup include
+IncludeBlocks: Preserve
+SortIncludes: false
+
+# Don't align other things, reducing unnecessary reformatting
+AlignConsecutiveAssignments: None
+AlignConsecutiveDeclarations: None
+
+# Only reindent comments, do not reflow comments — preserve existing line breaks in comments
+ReflowComments: IndentOnly
+# Trailing inline comments: leave them where they are (don't reposition)
+SpacesBeforeTrailingComments: 1
+AlignTrailingComments:
+  AlignPPAndNotPP: false
+  Kind: Leave # we don't want unnecessarily aligning the all the trailing comments, but Leave option has a bug right now
+
+# struct { int a:1 };
+BitFieldColonSpacing: None
+
+IndentExternBlock: NoIndent
+
+SortUsingDeclarations: Never
+
+# Allow turn-off formatting of oneline or next line with comment start with `// FORMAT-OFF`.
+OneLineFormatOffRegex: ^(// FORMAT-OFF:?)
+
+# Teach clang-format that these user-defined NVML types are types, not variables,
+# so pointer alignment (PointerAlignment: Left) is applied correctly when they appear
+# as a single named pointer parameter in a macro argument, e.g. (Type *name).
+TypeNames:
+- nvmlConfComputeSystemState_t
+- nvmlSystemConfComputeSettings_t
+
+WhitespaceSensitiveMacros:
+- STR
+- STR2

--- a/projects/rccl/.clang-format-ignore
+++ b/projects/rccl/.clang-format-ignore
@@ -1,0 +1,26 @@
+# ignore codes from external projects
+src/include/nvtx3/**
+src/transport/net_ib/gdaki/doca-gpunetio/**
+src/include/gdrwrap.h
+src/include/mlx5/mlx5dvcore.h
+src/include/ibvcore.h
+
+# ignore special files
+src/nccl.h.in
+
+# ignore generated codes
+build/**
+
+# ignore all other directories to avoid accidentally reformatting them
+bindings/**
+contrib/**
+cmake/**
+docs/**
+github/**
+maint/**
+makefile/**
+ompi/**
+pkg/**
+plugins/**
+share/**
+test/**

--- a/projects/rccl/.git-blame-ignore-revs
+++ b/projects/rccl/.git-blame-ignore-revs
@@ -1,0 +1,11 @@
+# Do `git blame --ignore-revs-file .git-blame-ignore-revs` to filter out formatting commits.
+# You can create git command alias for it as
+#   `git config --global alias.bli 'blame --ignore-revs-file .git-blame-ignore-revs'`
+# Then use `git bli` to do git blame with the ignore file.
+#
+# You can also set a per-repo config for blame to use the ignore file
+#   `git config blame.ignoreRevsFile .git-blame-ignore-revs`
+# This will make `git blame` always use the ignore file if run in the repo or its worktree.
+
+# [RCCL] Reformat src/ with clang-format to match NCCL style (AICOMRCCL-1472)
+e446311576247bcb9a69a5c31040a8af19433825

--- a/projects/rccl/cmake/scripts/add_unroll.sh
+++ b/projects/rccl/cmake/scripts/add_unroll.sh
@@ -21,8 +21,8 @@
 HIP_FILE=$1
 
 if [[ "$HIP_FILE" =~ .*/src/device/.*\.h ]]; then
-  perl -pi -e 's/(template<typename T, typename RedOp(?:, (?:typename|int) Proto)?)(, bool isNetOffload.*?)?>/\1, int USE_ACC, int COLL_UNROLL, int Pipeline\2>/g' "$HIP_FILE"
-  perl -pi -e 's/(template<typename T, typename RedOp(?:, (?:typename|int) Proto)?(?:, int RCCLMetadata)?)(, bool isNetOffload.*?)?>/\1, int USE_ACC, int COLL_UNROLL, int Pipeline\2>/g' "$HIP_FILE"
+  perl -pi -e 's/(template\s*<typename T, typename RedOp(?:, (?:typename|int) Proto)?)(, bool isNetOffload.*?)?>/\1, int USE_ACC, int COLL_UNROLL, int Pipeline\2>/g' "$HIP_FILE"
+  perl -pi -e 's/(template\s*<typename T, typename RedOp(?:, (?:typename|int) Proto)?(?:, int RCCLMetadata)?)(, bool isNetOffload.*?)?>/\1, int USE_ACC, int COLL_UNROLL, int Pipeline\2>/g' "$HIP_FILE"
   perl -pi -e 's/(ProtoSimple<[^,]*?,[^,]+?)>/\1, USE_ACC, COLL_UNROLL>/g' "$HIP_FILE"
   perl -pi -e 's/(runRing<T.*?)((, (true|false))?>\()/\1, USE_ACC, COLL_UNROLL\2/g' "$HIP_FILE"
   perl -pi -e 's/(runTreeUpDown<T.*?)>\(/\1, USE_ACC, COLL_UNROLL>(/' "$HIP_FILE"

--- a/projects/rccl/maint/README.md
+++ b/projects/rccl/maint/README.md
@@ -1,0 +1,67 @@
+# Maintenance Scripts for NCCL
+
+This directory contains developer maintenance scripts that are not part of the
+normal NCCL build. Run the scripts from the repository root unless a script says
+otherwise.
+
+## Formatting
+
+NCCL uses `clang-format` for C/C++/CUDA source formatting. The formatting
+scripts operate on source files with these suffixes:
+
+```text
+.cc .cu .cuh .h .h.in
+```
+
+Paths listed in the repository-level `.clang-format-ignore` file are skipped.
+
+### `run-clang-format.sh`
+
+Apply `clang-format` to NCCL source files.
+
+```sh
+./maint/run-clang-format.sh
+./maint/run-clang-format.sh src/transport
+./maint/run-clang-format.sh src/transport/net_ib/common.cc
+```
+
+By default, the script formats files under `src/`. If a file or directory path
+is provided, it formats only that file or files under that directory
+recursively.
+
+Useful options:
+
+```sh
+./maint/run-clang-format.sh --list [path]
+./maint/run-clang-format.sh --diff [path]
+```
+
+The script requires `clang-format` version 22 or newer. Set `CLANG_FORMAT` to
+use a non-default binary:
+
+```sh
+CLANG_FORMAT=/path/to/clang-format ./maint/run-clang-format.sh --diff
+```
+
+## Git Integration
+
+LLVM provides `git-clang-format`, a Git integration script for formatting only
+changed lines. Download it from:
+
+```text
+https://github.com/llvm/llvm-project/blob/main/clang/tools/clang-format/git-clang-format
+```
+
+Follow the instructions in that script: put it somewhere on your `PATH`, make it
+executable, and then use `git clang-format`.
+
+Common examples:
+
+```sh
+git clang-format
+git clang-format --staged
+git clang-format main
+git clang-format --diff main
+```
+
+Run `git clang-format -h` for the full option list.

--- a/projects/rccl/maint/run-clang-format.sh
+++ b/projects/rccl/maint/run-clang-format.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# run-clang-format.sh — Apply clang-format to all NCCL source files.
+#
+# The default is reformatting src/**.
+# Clang-format will ignore any path listed in the top-level .clang-format-ignore file.
+#
+# Usage:
+#   ./run-clang-format.sh [path]            # Apply formatting in-place
+#   ./run-clang-format.sh --list [path]     # Print list of files that would be formatted
+#   ./run-clang-format.sh --diff [path]     # Show unified diff of changes without applying
+
+set -euo pipefail
+
+MIN_VERSION=22
+
+usage() {
+  echo "Usage: $0 [--list | --diff] [path]" >&2
+}
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+MODE=""
+TARGET_PATH="$PWD/src"
+TARGET_SET=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --list | --diff)
+      if [[ -n "$MODE" ]]; then
+        usage
+        exit 1
+      fi
+      MODE="$1"
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --*)
+      usage
+      exit 1
+      ;;
+    *)
+      if [[ "$TARGET_SET" -eq 1 ]]; then
+        usage
+        exit 1
+      fi
+      TARGET_PATH="$1"
+      TARGET_SET=1
+      ;;
+  esac
+  shift
+done
+
+# ---------------------------------------------------------------------------
+# Locate clang-format and verify version
+# ---------------------------------------------------------------------------
+CLANG_FORMAT="${CLANG_FORMAT:-clang-format}"
+
+if ! command -v "$CLANG_FORMAT" &>/dev/null; then
+  echo "ERROR: clang-format not found. Install clang-format >= $MIN_VERSION." >&2
+  exit 2
+fi
+
+VERSION=$("$CLANG_FORMAT" --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 | cut -d. -f1)
+if [[ -z "$VERSION" || "$VERSION" -lt "$MIN_VERSION" ]]; then
+  echo "ERROR: clang-format >= $MIN_VERSION required, found: $("$CLANG_FORMAT" --version)" >&2
+  exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Collect files, excluding vendored directories
+# Top-level .clang-format-ignore controls which files won't be reformatted
+# ---------------------------------------------------------------------------
+FILES=()
+if [[ -f "$TARGET_PATH" ]]; then
+  FILES+=("$TARGET_PATH")
+elif [[ -d "$TARGET_PATH" ]]; then
+  while IFS= read -r f; do
+    FILES+=("$f")
+  done < <(
+    find "$TARGET_PATH" \
+      -type f \
+      \( -name '*.cc' -o -name '*.cu' -o -name '*.cuh' -o -name '*.h' \) \
+      | sort
+  )
+else
+  echo "ERROR: path not found: $TARGET_PATH" >&2
+  exit 1
+fi
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+  echo "No source files found under $TARGET_PATH." >&2
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Mode dispatch
+# ---------------------------------------------------------------------------
+case "$MODE" in
+  --list)
+    echo "Files that would be formatted (${#FILES[@]} total):"
+    for f in "${FILES[@]}"; do
+      echo "  $f"
+    done
+    ;;
+
+  --diff)
+    echo "Showing diff for ${#FILES[@]} files..."
+    ANY=0
+    for f in "${FILES[@]}"; do
+      DIFF=$("$CLANG_FORMAT" --style=file "$f" | diff -u "$f" - || true)
+      if [[ -n "$DIFF" ]]; then
+        echo "--- $f"
+        echo "$DIFF"
+        ANY=1
+      fi
+    done
+    if [[ "$ANY" -eq 0 ]]; then
+      echo "All files already formatted."
+    fi
+    ;;
+
+  "")
+    echo "Formatting ${#FILES[@]} files..."
+    "$CLANG_FORMAT" -i --style=file "${FILES[@]}"
+    echo "Done."
+    ;;
+
+  *)
+    usage
+    exit 1
+    ;;
+esac

--- a/projects/rccl/src/allocator.cc
+++ b/projects/rccl/src/allocator.cc
@@ -11,8 +11,8 @@
 #include "nvtx.h"
 #include "utils.h"
 
-NCCL_API(ncclResult_t, ncclMemAlloc, void **ptr, size_t size);
-ncclResult_t  ncclMemAlloc_impl(void **ptr, size_t size) {
+NCCL_API(ncclResult_t, ncclMemAlloc, void** ptr, size_t size);
+ncclResult_t ncclMemAlloc_impl(void** ptr, size_t size) {
   NCCL_NVTX3_FUNC_RANGE;
   ncclResult_t ret = ncclSuccess;
 
@@ -40,7 +40,7 @@ ncclResult_t  ncclMemAlloc_impl(void **ptr, size_t size) {
 #if CUDART_VERSION >= 12030
     // Query device to see if FABRIC handle support is available
     flag = 0;
-    (void) CUPFN(cuDeviceGetAttribute(&flag, CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED, currentDev));
+    (void)CUPFN(cuDeviceGetAttribute(&flag, CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED, currentDev));
     if (flag) requestedHandleTypes |= CU_MEM_HANDLE_TYPE_FABRIC;
 #endif
 #if defined(HIP_VMM_UNCACHED_MEMORY)
@@ -49,7 +49,7 @@ ncclResult_t  ncclMemAlloc_impl(void **ptr, size_t size) {
     memprop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
 #endif
     memprop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
-    memprop.requestedHandleTypes = (CUmemAllocationHandleType) requestedHandleTypes;
+    memprop.requestedHandleTypes = (CUmemAllocationHandleType)requestedHandleTypes;
     memprop.location.id = currentDev;
 #if HIP_VERSION > 70000000
     // ROCM-2550: Use cuDeviceGetAttribute to check if RDMA support is available
@@ -72,7 +72,7 @@ ncclResult_t  ncclMemAlloc_impl(void **ptr, size_t size) {
       CUresult err = CUPFN(cuMemCreate(&handle, handleSize, &memprop, 0));
       if (err == CUDA_ERROR_NOT_SUPPORTED) {
         requestedHandleTypes &= ~CU_MEM_HANDLE_TYPE_FABRIC;
-        memprop.requestedHandleTypes = (CUmemAllocationHandleType) requestedHandleTypes;
+        memprop.requestedHandleTypes = (CUmemAllocationHandleType)requestedHandleTypes;
         /* Allocate the physical memory on the device */
         CUCHECK(cuMemCreate(&handle, handleSize, &memprop, 0));
       } else if (err != CUDA_SUCCESS) {
@@ -116,8 +116,8 @@ fail:
   goto exit;
 }
 
-NCCL_API(ncclResult_t, ncclMemFree, void *ptr);
-ncclResult_t  ncclMemFree_impl(void *ptr) {
+NCCL_API(ncclResult_t, ncclMemFree, void* ptr);
+ncclResult_t ncclMemFree_impl(void* ptr) {
   NCCL_NVTX3_FUNC_RANGE;
   ncclResult_t ret = ncclSuccess;
   int saveDevice;
@@ -133,7 +133,8 @@ ncclResult_t  ncclMemFree_impl(void *ptr) {
   CUCHECKGOTO(cuPointerGetAttribute((void*)&ptrDev, CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL, (CUdeviceptr)ptr), ret, fail);
   CUDACHECKGOTO(cudaSetDevice((int)ptrDev), ret, fail);
   if (ncclCuMemEnable()) {
-    NCCLCHECKGOTO(ncclCuMemFree(ptr, nullptr), ret, fail); // User facing API, memManager does not need to track user memory. Same as ncclMemAlloc
+    NCCLCHECKGOTO(ncclCuMemFree(ptr, nullptr), ret,
+                  fail); // User facing API, memManager does not need to track user memory. Same as ncclMemAlloc
     goto exit;
   }
 
@@ -171,16 +172,16 @@ static void insertSegment(struct ncclSpace* a, int index, int64_t lo, int64_t hi
   if (a->count + 2 > a->capacity) {
     a->capacity *= 2;
     if (a->capacity == 0) a->capacity = 16;
-    int64_t* cuts1 = (int64_t*)malloc(a->capacity*sizeof(int64_t));
-    for (int i=0; i < index; i++) cuts1[i] = a->cuts[i];
-    for (int i=index; i < a->count; i++) cuts1[i+2] = a->cuts[i];
+    int64_t* cuts1 = (int64_t*)malloc(a->capacity * sizeof(int64_t));
+    for (int i = 0; i < index; i++) cuts1[i] = a->cuts[i];
+    for (int i = index; i < a->count; i++) cuts1[i + 2] = a->cuts[i];
     free(a->cuts);
     a->cuts = cuts1;
   } else {
-    for (int i=a->count-1; index <= i; i--) a->cuts[i+2] = a->cuts[i];
+    for (int i = a->count - 1; index <= i; i--) a->cuts[i + 2] = a->cuts[i];
   }
-  a->cuts[index+0] = lo;
-  a->cuts[index+1] = hi;
+  a->cuts[index + 0] = lo;
+  a->cuts[index + 1] = hi;
   a->count += 2;
 
   // Filter pairs of adjacent repeated values from cuts[]. Since these mark
@@ -193,13 +194,13 @@ static void insertSegment(struct ncclSpace* a, int index, int64_t lo, int64_t hi
   //   [0,1,2] -> [1,2]
   //   [0,0,1,2] -> [1,2]
   int r = index, w = index; // Read and write cursors.
-  int64_t prev = r==0 ? 0 : a->cuts[r-1];
+  int64_t prev = r == 0 ? 0 : a->cuts[r - 1];
   while (r < a->count) {
     int64_t cur = a->cuts[r++];
     a->cuts[w++] = cur;
     if (prev == cur) { // Repeated value is an empty segment which can be deleted.
       // Erase last two cuts or just one if we're at the start.
-      w -= w==1 ? 1 : 2;
+      w -= w == 1 ? 1 : 2;
       // Zeros can only occur at the beginning (due to being sorted). We want to
       // drop any number of zeros, but only even numbers of other repeated values.
       // So set to zero here, which will make prev=0, thus if next value is zero
@@ -212,44 +213,42 @@ static void insertSegment(struct ncclSpace* a, int index, int64_t lo, int64_t hi
   a->count = w;
 }
 
-ncclResult_t ncclSpaceAlloc(
-    struct ncclSpace* a, int64_t limit, int64_t size, int align,
-    int64_t* outOffset
-  ) {
+ncclResult_t ncclSpaceAlloc(struct ncclSpace* a, int64_t limit, int64_t size, int align, int64_t* outOffset) {
   // When allocating we try to locate the first empty segment which can hold
   // the allocation and move its lower cut upward.
-  int i = a->count%2; // First empty segment ends at cuts[i]
+  int i = a->count % 2; // First empty segment ends at cuts[i]
   size_t off;
   while (i <= a->count) {
-    size_t lo = i == 0 ? 0 : a->cuts[i-1];
+    size_t lo = i == 0 ? 0 : a->cuts[i - 1];
     size_t hi = i == a->count ? limit : a->cuts[i];
     off = alignUp(lo, align);
     if (off + size <= hi) {
       *outOffset = off;
       if (i == 0 || off + size == hi) { // Slow path required.
-        insertSegment(a, i, off, off+size);
+        insertSegment(a, i, off, off + size);
       } else { // We can just append to the end of a full segment.
-        a->cuts[i-1] = off + size;
+        a->cuts[i - 1] = off + size;
       }
       return ncclSuccess;
     }
     i += 2; // Next empty segment
   }
-  WARN("Allocation failed. No suitable space found to accommodate size=0x%lx within limit=0x%lx", (long)size, (long)limit);
+  WARN("Allocation failed. No suitable space found to accommodate size=0x%lx within limit=0x%lx", (long)size,
+       (long)limit);
   return ncclInternalError;
 }
 
 ncclResult_t ncclSpaceFree(struct ncclSpace* a, int64_t offset, int64_t size) {
-  if (a->count == 0 || a->cuts[a->count-1] <= offset) {
+  if (a->count == 0 || a->cuts[a->count - 1] <= offset) {
     WARN("No allocation found at offset=0x%lx", (long)offset);
     return ncclInternalError;
   }
 
   // This could be binary search, but since allocate is linear there's no point.
-  int i = 1 - a->count%2; // First full segment ends at cuts[i]
+  int i = 1 - a->count % 2; // First full segment ends at cuts[i]
   while (a->cuts[i] <= offset) i += 2;
 
-  int64_t lo = i==0 ? 0 : a->cuts[i-1];
+  int64_t lo = i == 0 ? 0 : a->cuts[i - 1];
   int64_t hi = a->cuts[i];
 
   if (offset < lo || hi < offset + size) {
@@ -259,11 +258,11 @@ ncclResult_t ncclSpaceFree(struct ncclSpace* a, int64_t offset, int64_t size) {
 
   // First try the two fast cases which just shrink a segment from one side.
   if (i != 0 && lo == offset && offset + size != hi) {
-    a->cuts[i-1] = offset + size; // Bring bottom up.
+    a->cuts[i - 1] = offset + size; // Bring bottom up.
   } else if (lo != offset && offset + size == hi) {
     a->cuts[i] = offset; // Bring top down.
   } else { // Slow path.
-    insertSegment(a, i, offset, offset+size);
+    insertSegment(a, i, offset, offset + size);
   }
   return ncclSuccess;
 }
@@ -297,7 +296,7 @@ ncclResult_t ncclShadowPoolDestruct(struct ncclShadowPool* pool) {
     CUDACHECK(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
 
     if (pool->count != 0) {
-      for (int i=0; i < 1<<pool->hbits; i++) {
+      for (int i = 0; i < 1 << pool->hbits; i++) {
         struct ncclShadowObject* obj = pool->table[i];
         while (obj != nullptr) {
           struct ncclShadowPage* page = obj->page;
@@ -338,10 +337,8 @@ static void hashInsert(struct ncclShadowPool* pool, struct ncclShadowObject* obj
   pool->table[b] = obj;
 }
 
-ncclResult_t ncclShadowPoolAlloc(
-    struct ncclShadowPool* pool, size_t size, void** outDevObj, void** outHostObj,
-    cudaStream_t stream
-  ) {
+ncclResult_t ncclShadowPoolAlloc(struct ncclShadowPool* pool, size_t size, void** outDevObj, void** outHostObj,
+                                 cudaStream_t stream) {
   if (size == 0) {
     if (outDevObj) *outDevObj = nullptr;
     if (outHostObj) *outHostObj = nullptr;
@@ -358,18 +355,19 @@ ncclResult_t ncclShadowPoolAlloc(
     CUDACHECK(cudaMemPoolCreate(&pool->memPool, &props));
 
     pool->hbits = hbits = 4;
-    pool->table = (struct ncclShadowObject**)malloc(sizeof(struct ncclShadowObject*)<<hbits);
-    for (int i=0; i < 1<<hbits; i++) pool->table[i] = nullptr;
+    pool->table = (struct ncclShadowObject**)malloc(sizeof(struct ncclShadowObject*) << hbits);
+    for (int i = 0; i < 1 << hbits; i++) pool->table[i] = nullptr;
   }
 
   // Check for hash table size increase before inserting. Maintain 2:1 object:bucket ratio.
-  if (pool->count+1 > 2<<hbits) {
+  if (pool->count + 1 > 2 << hbits) {
     struct ncclShadowObject** table0 = pool->table;
-    struct ncclShadowObject** table1 = (struct ncclShadowObject**)malloc(sizeof(struct ncclShadowObject*)<<(hbits+1));
+    struct ncclShadowObject** table1 =
+      (struct ncclShadowObject**)malloc(sizeof(struct ncclShadowObject*) << (hbits + 1));
     pool->table = table1;
-    pool->hbits = hbits+1;
-    for (int i1=0; i1 < 2<<hbits; i1++) table1[i1] = nullptr;
-    for (int i0=0; i0 < 1<<hbits; i0++) {
+    pool->hbits = hbits + 1;
+    for (int i1 = 0; i1 < 2 << hbits; i1++) table1[i1] = nullptr;
+    for (int i0 = 0; i0 < 1 << hbits; i0++) {
       struct ncclShadowObject* obj = table0[i0];
       while (obj) {
         struct ncclShadowObject* next = obj->next;
@@ -382,18 +380,18 @@ ncclResult_t ncclShadowPoolAlloc(
   }
 
   struct ncclShadowPage* page;
-  void *devObj;
-  if ((64<<10)/size >= 3) {
+  void* devObj;
+  if ((64 << 10) / size >= 3) {
     int shift = std::max<int>(0, (int)log2Down(size) + 1 - 4);
-    int pageObjSize = ((size + (1<<shift)-1)>>shift)<<shift;
+    int pageObjSize = ((size + (1 << shift) - 1) >> shift) << shift;
     struct ncclShadowPage** pagePtr = &pool->pages;
     while (true) {
       page = *pagePtr;
       if (page == nullptr) {
-        size_t pageSize = std::min<size_t>(64<<10, 64*pageObjSize);
+        size_t pageSize = std::min<size_t>(64 << 10, 64 * pageObjSize);
         page = (struct ncclShadowPage*)malloc(sizeof(struct ncclShadowPage));
         page->objSize = pageObjSize;
-        page->freeMask = uint64_t(-1)>>(64 - pageSize/pageObjSize);
+        page->freeMask = uint64_t(-1) >> (64 - pageSize / pageObjSize);
         page->next = pool->pages;
         pool->pages = page;
         CUDACHECK(cudaMallocFromPoolAsync(&page->devObjs, pageSize, pool->memPool, stream));
@@ -402,7 +400,7 @@ ncclResult_t ncclShadowPoolAlloc(
       }
       if (page->objSize == pageObjSize) {
         int slot = popFirstOneBit(&page->freeMask);
-        devObj = (char*)page->devObjs + slot*pageObjSize;
+        devObj = (char*)page->devObjs + slot * pageObjSize;
         if (page->freeMask == 0) *pagePtr = page->next; // Remove full page from list.
         break;
       }
@@ -414,12 +412,11 @@ ncclResult_t ncclShadowPoolAlloc(
     CUDACHECK(cudaMemsetAsync(devObj, 0, size, stream));
   }
 
-  struct ncclShadowObject* obj = (struct ncclShadowObject*)malloc(
-    sizeof(struct ncclShadowObject) + /*padding=*/alignof(max_align_t)-1 + size
-  );
+  struct ncclShadowObject* obj =
+    (struct ncclShadowObject*)malloc(sizeof(struct ncclShadowObject) + /*padding=*/alignof(max_align_t) - 1 + size);
   obj->page = page;
   obj->devObj = devObj;
-  obj->hostObj = alignUp((char*)(obj+1), alignof(max_align_t));
+  obj->hostObj = alignUp((char*)(obj + 1), alignof(max_align_t));
   memset(obj->hostObj, 0, size);
   hashInsert(pool, obj);
   pool->count += 1;
@@ -448,8 +445,8 @@ ncclResult_t ncclShadowPoolFree(struct ncclShadowPool* pool, void* devObj, cudaS
       obj->page->next = pool->pages;
       pool->pages = obj->page;
     }
-    int slot = ((char*)obj->devObj - (char*)obj->page->devObjs)/obj->page->objSize;
-    obj->page->freeMask |= uint64_t(1)<<slot;
+    int slot = ((char*)obj->devObj - (char*)obj->page->devObjs) / obj->page->objSize;
+    obj->page->freeMask |= uint64_t(1) << slot;
   } else {
     CUDACHECK(cudaFreeAsync(devObj, stream));
   }

--- a/projects/rccl/src/bootstrap.cc
+++ b/projects/rccl/src/bootstrap.cc
@@ -22,12 +22,12 @@
 #include <thread>
 #include <chrono>
 
-#define BOOTSTRAP_N_CHECK_ABORT           10000
-#define BOOTSTRAP_TAG_CONNECT             (0x1 << 31)
-#define BOOTSTRAP_TAG_ALLGATHER           (0x1 << 30)
-#define BOOTSTRAP_TAG_COMMSPLIT           (0x1 << 29)
+#define BOOTSTRAP_N_CHECK_ABORT 10000
+#define BOOTSTRAP_TAG_CONNECT (0x1 << 31)
+#define BOOTSTRAP_TAG_ALLGATHER (0x1 << 30)
+#define BOOTSTRAP_TAG_COMMSPLIT (0x1 << 29)
 #define BOOTSTRAP_TAG_INTRANODE_ALLGATHER (0x1 << 28)
-#define BOOTSTRAP_TAG_GROW_BOUNDARY       (0x1 << 27)
+#define BOOTSTRAP_TAG_GROW_BOUNDARY (0x1 << 27)
 // Tag used to exchange reverse-ring listen handles during bidirectional NET
 // bootstrap setup (fallback path when no piggybacked handle is available).
 // Picked from the non-bit-shifted space so it cannot collide with the
@@ -35,29 +35,29 @@
 static constexpr uint32_t BOOTSTRAP_TAG_BIDIR_REV_HANDLE = 0x7E5E5EB1;
 
 #define BOOTSTRAP_INIT_TIME_CREATE 0
-#define BOOTSTRAP_INIT_TIME_SEND   1
-#define BOOTSTRAP_INIT_TIME_RECV   2
-#define BOOTSTRAP_INIT_TIME_RING   3
-#define BOOTSTRAP_INIT_TIME_TOTAL  4
-#define BOOTSTRAP_INIT_TIME_DELAY  5
-#define BOOTSTRAP_INIT_TIME_N      6
-#define BOOTSTRAP_INIT_ROOT_WAIT   0
-#define BOOTSTRAP_INIT_ROOT_SEND   1
-#define BOOTSTRAP_INIT_ROOT_RECV   2
-#define BOOTSTRAP_INIT_ROOT_N      3
+#define BOOTSTRAP_INIT_TIME_SEND 1
+#define BOOTSTRAP_INIT_TIME_RECV 2
+#define BOOTSTRAP_INIT_TIME_RING 3
+#define BOOTSTRAP_INIT_TIME_TOTAL 4
+#define BOOTSTRAP_INIT_TIME_DELAY 5
+#define BOOTSTRAP_INIT_TIME_N 6
+#define BOOTSTRAP_INIT_ROOT_WAIT 0
+#define BOOTSTRAP_INIT_ROOT_SEND 1
+#define BOOTSTRAP_INIT_ROOT_RECV 2
+#define BOOTSTRAP_INIT_ROOT_N 3
 #define BOOTSTRAP_PROF_OPEN(time) \
-  do {                            \
-    time = clockNano();           \
+  do { \
+    time = clockNano(); \
   } while (0)
 #define BOOTSTRAP_PROF_CLOSE(time) \
-  do {                             \
-    time = clockNano() - time;     \
+  do { \
+    time = clockNano() - time; \
   } while (0)
 
 #define BOOTSTRAP_PID(i, n) (((i) + (n)) % (n))
 // returns the first rank associated to the root. must have root >=0
 // if root >= n_roots, it does NOT assume periodicity
-static int firstRankFromRoot(int root, int n_ranks, int nRoots,int offset) {
+static int firstRankFromRoot(int root, int n_ranks, int nRoots, int offset) {
   if (root == -1) return 0;
   // only distribute the n_ranks - offset on the roots
   n_ranks -= offset;
@@ -67,20 +67,18 @@ static int firstRankFromRoot(int root, int n_ranks, int nRoots,int offset) {
 // if rank >= n_ranks, it does NOT assume periodicity
 static int rootIdFromRank(int rank, int nRanks, int nRoots, int offset) {
   // ranks < offset have no root (id = -1), ranks above the offset will get assigned to their respective root
-  if(nRoots == 0 || rank < offset) return -1;
+  if (nRoots == 0 || rank < offset) return -1;
   nRanks -= offset;
   rank -= offset;
   int rmr = nRanks % nRoots; // rank mod root
   int rpr = nRanks / nRoots; // rank per root
   int D = rmr * (rpr + 1);
-  if (rank < D)
-    return rank / (rpr + 1);
-  else
-    return (rank - D) / rpr + rmr;
+  if (rank < D) return rank / (rpr + 1);
+  else return (rank - D) / rpr + rmr;
 }
 // return the number of child for a root, root will be periodized
 static int nRankFromRoot(int root, int nRanks, int nRoots, int offset) {
-  if(root == -1) return 0;
+  if (root == -1) return 0;
   nRanks -= offset;
   int ir = BOOTSTRAP_PID(root, nRoots);
   int rmr = nRanks % nRoots; // rank mod root
@@ -91,7 +89,7 @@ static int nRankFromRoot(int root, int nRanks, int nRoots, int offset) {
 // root will be periodize, rank will not
 static int localIdFromRoot(int rank, int root, int nRanks, int nRoots, int offset) {
   // any rank for root -1 has a local id that is the rank id
-  if(root == -1) return rank;
+  if (root == -1) return rank;
   int ir = BOOTSTRAP_PID(root, nRoots);
   return rank - firstRankFromRoot(ir, nRanks, nRoots, offset);
 }
@@ -106,14 +104,14 @@ struct bootstrapRootArgs {
 };
 
 /* Init functions */
-static char bootstrapNetIfName[MAX_IF_NAME_SIZE+1];
+static char bootstrapNetIfName[MAX_IF_NAME_SIZE + 1];
 static union ncclSocketAddress bootstrapNetIfAddr;
 static int bootstrapNetInitDone = 0;
 static std::mutex bootstrapNetMutex;
 
 // Net OOB transport (IB/OFI via net plugin): tristate (-1 auto by threshold, 0 off, 1 on).
 // Off by default; opt in explicitly via env var or set to -1 to use the threshold gate.
-NCCL_PARAM(BootstrapNetEnable,"OOB_NET_ENABLE", 0);
+NCCL_PARAM(BootstrapNetEnable, "OOB_NET_ENABLE", 0);
 
 // Bidirectional ring AllGather (N/2 steps).
 //   BOOTSTRAP_BIDIR_ALLGATHER : on/off flag for the socket OOB path. Default on; setting
@@ -127,8 +125,8 @@ NCCL_PARAM(BootstrapNetEnable,"OOB_NET_ENABLE", 0);
 //                               knob is set to -1 (auto). Default 128 ranks (16 nodes
 //                               at 8 ppn), motivated by net-OOB plugin regMr/connect
 //                               setup overhead being too heavy to amortise below that.
-NCCL_PARAM(BootstrapBidirAllGather, "BOOTSTRAP_BIDIR_ALLGATHER",  1);
-NCCL_PARAM(BootstrapBidirNet,       "BOOTSTRAP_BIDIR_NET",        0);
+NCCL_PARAM(BootstrapBidirAllGather, "BOOTSTRAP_BIDIR_ALLGATHER", 1);
+NCCL_PARAM(BootstrapBidirNet, "BOOTSTRAP_BIDIR_NET", 0);
 NCCL_PARAM(BootstrapBidirThreshold, "BOOTSTRAP_BIDIR_THRESHOLD", 128);
 
 // Returns true when net OOB transport (IB/OFI via net plugin) should be used.
@@ -199,9 +197,9 @@ ncclResult_t bootstrapNetInit() {
           return ncclInvalidUsage;
         }
       }
-      char line[SOCKET_NAME_MAXLEN+MAX_IF_NAME_SIZE+2];
+      char line[SOCKET_NAME_MAXLEN + MAX_IF_NAME_SIZE + 2];
       snprintf(line, sizeof(line), " %s:", bootstrapNetIfName);
-      ncclSocketToString(&bootstrapNetIfAddr, line+strlen(line));
+      ncclSocketToString(&bootstrapNetIfAddr, line + strlen(line));
       INFO(NCCL_BOOTSTRAP, "Bootstrap: Using%s", line);
       bootstrapNetInitDone = 1;
     }
@@ -210,7 +208,10 @@ ncclResult_t bootstrapNetInit() {
 }
 
 /* Socket Interface Selection type */
-enum bootstrapInterface_t { findSubnetIf = -1, dontCareIf = -2 };
+enum bootstrapInterface_t {
+  findSubnetIf = -1,
+  dontCareIf = -2
+};
 
 // check abort function
 static ncclResult_t checkAbort(volatile uint32_t* flag, int* cntr) {
@@ -233,8 +234,8 @@ static ncclResult_t netDereg(ncclNet_t* net, void* comm, void** handle) {
   *handle = NULL;
   return ncclSuccess;
 }
-static ncclResult_t netIsend(ncclNet_t* net, void* sendComm, void* data, int size, void* dataHandle, int tag, void** sendReq,
-                             int* done) {
+static ncclResult_t netIsend(ncclNet_t* net, void* sendComm, void* data, int size, void* dataHandle, int tag,
+                             void** sendReq, int* done) {
   if (*done) return ncclSuccess;
   if (!*sendReq) {
     NCCLCHECK(net->isend(sendComm, data, (size_t)size, tag, dataHandle, NULL, sendReq));
@@ -247,8 +248,8 @@ static ncclResult_t netIsend(ncclNet_t* net, void* sendComm, void* data, int siz
   }
   return ncclSuccess;
 }
-static ncclResult_t netIrecv(ncclNet_t* net, void* recvComm, void* data, int size, void* dataHandle, int tag, void** recvReq,
-                             int* done) {
+static ncclResult_t netIrecv(ncclNet_t* net, void* recvComm, void* data, int size, void* dataHandle, int tag,
+                             void** recvReq, int* done) {
   if (*done) return ncclSuccess;
   if (!*recvReq) {
     size_t size64 = size;
@@ -262,8 +263,9 @@ static ncclResult_t netIrecv(ncclNet_t* net, void* recvComm, void* data, int siz
   }
   return ncclSuccess;
 }
-static ncclResult_t netSendRecv(ncclNet_t* net, void* sendComm, void* sendData, int sendSize, void* sendDataHandle, void* recvComm,
-                                void* recvData, int recvSize, void* recvDataHandle, int tag, volatile uint32_t* abortFlag) {
+static ncclResult_t netSendRecv(ncclNet_t* net, void* sendComm, void* sendData, int sendSize, void* sendDataHandle,
+                                void* recvComm, void* recvData, int recvSize, void* recvDataHandle, int tag,
+                                volatile uint32_t* abortFlag) {
   int abortCounter = 0;
   int doneSend = 0, doneRecv = 0;
   void *sendReq = NULL, *recvReq = NULL;
@@ -298,8 +300,7 @@ struct ncclNetOp {
   int done;      // completion flag (set internally)
 };
 
-static ncclResult_t netMultiOp(ncclNet_t* net, struct ncclNetOp* ops, int numOps,
-                               volatile uint32_t* abortFlag) {
+static ncclResult_t netMultiOp(ncclNet_t* net, struct ncclNetOp* ops, int numOps, volatile uint32_t* abortFlag) {
   if (ops == NULL || numOps <= 0) {
     WARN("netMultiOp: invalid arguments ops=%p numOps=%d", ops, numOps);
     return ncclInvalidArgument;
@@ -336,14 +337,16 @@ static ncclResult_t netMultiOp(ncclNet_t* net, struct ncclNetOp* ops, int numOps
       if (ops[i].done) continue;
       void* prevReq = ops[i].req;
       if (ops[i].op == NCCL_NET_OP_SEND) {
-        NCCLCHECK(netIsend(net, ops[i].comm, ops[i].data, ops[i].size,
-                           ops[i].handle, ops[i].tag, &ops[i].req, &ops[i].done));
+        NCCLCHECK(netIsend(net, ops[i].comm, ops[i].data, ops[i].size, ops[i].handle, ops[i].tag, &ops[i].req,
+                           &ops[i].done));
       } else {
-        NCCLCHECK(netIrecv(net, ops[i].comm, ops[i].data, ops[i].size,
-                           ops[i].handle, ops[i].tag, &ops[i].req, &ops[i].done));
+        NCCLCHECK(netIrecv(net, ops[i].comm, ops[i].data, ops[i].size, ops[i].handle, ops[i].tag, &ops[i].req,
+                           &ops[i].done));
       }
-      if (ops[i].done) { completed++; madeProgress = true; }
-      else if (ops[i].req != prevReq) madeProgress = true;
+      if (ops[i].done) {
+        completed++;
+        madeProgress = true;
+      } else if (ops[i].req != prevReq) madeProgress = true;
       if (!ops[i].done && ops[i].req == NULL) allIssued = false;
     }
     if (allIssued && !madeProgress) sched_yield();
@@ -354,8 +357,7 @@ static ncclResult_t netMultiOp(ncclNet_t* net, struct ncclNetOp* ops, int numOps
 // Additional socket based functions, first send the size, then send the message
 static ncclResult_t socketSend(struct ncclSocket* sock, void* data, int size) {
   NCCLCHECK(ncclSocketSend(sock, &size, sizeof(int)));
-  if (size > 0)
-    NCCLCHECK(ncclSocketSend(sock, data, size));
+  if (size > 0) NCCLCHECK(ncclSocketSend(sock, data, size));
   return ncclSuccess;
 }
 static ncclResult_t socketRecv(struct ncclSocket* sock, void* data, int size) {
@@ -366,12 +368,11 @@ static ncclResult_t socketRecv(struct ncclSocket* sock, void* data, int size) {
     return ncclInternalError;
   }
   int actualSize = std::min(recvSize, size);
-  if (actualSize > 0)
-    NCCLCHECK(ncclSocketRecv(sock, data, actualSize));
+  if (actualSize > 0) NCCLCHECK(ncclSocketRecv(sock, data, actualSize));
   return ncclSuccess;
 }
-static ncclResult_t socketSendRecv(struct ncclSocket* sendSock, void* sendData, int sendSize, struct ncclSocket* recvSock,
-                                   void* recvData, int recvSize) {
+static ncclResult_t socketSendRecv(struct ncclSocket* sendSock, void* sendData, int sendSize,
+                                   struct ncclSocket* recvSock, void* recvData, int recvSize) {
   int senderRecvSize;
   NCCLCHECK(ncclSocketSendRecv(sendSock, &sendSize, sizeof(int), recvSock, &senderRecvSize, sizeof(int)));
   if (senderRecvSize > recvSize) {
@@ -385,15 +386,14 @@ static ncclResult_t socketSendRecv(struct ncclSocket* sendSock, void* sendData, 
 static ncclResult_t socketDoubleSendRecv(struct ncclSocketOp ops[4]) {
   // ops synchronously exchange size then asynchronously exchange data in send->recv->send->recv order
   int senderRecvSize1, senderRecvSize2;
-  struct ncclSocketOp sizeOps[4] = {
-    {NCCL_SOCKET_SEND, ops[0].sock, &ops[0].size, sizeof(int), 0},
-    {NCCL_SOCKET_RECV, ops[1].sock, &senderRecvSize1, sizeof(int), 0},
-    {NCCL_SOCKET_SEND, ops[2].sock, &ops[2].size, sizeof(int), 0},
-    {NCCL_SOCKET_RECV, ops[3].sock, &senderRecvSize2, sizeof(int), 0}
-  };
+  struct ncclSocketOp sizeOps[4] = {{NCCL_SOCKET_SEND, ops[0].sock, &ops[0].size, sizeof(int), 0},
+                                    {NCCL_SOCKET_RECV, ops[1].sock, &senderRecvSize1, sizeof(int), 0},
+                                    {NCCL_SOCKET_SEND, ops[2].sock, &ops[2].size, sizeof(int), 0},
+                                    {NCCL_SOCKET_RECV, ops[3].sock, &senderRecvSize2, sizeof(int), 0}};
   NCCLCHECK(ncclSocketMultiOp(sizeOps, 4));
   if (senderRecvSize1 > ops[1].size || senderRecvSize2 > ops[3].size) {
-    WARN("Message truncated : received %d,%d bytes instead of %d,%d", senderRecvSize1, senderRecvSize2, ops[1].size, ops[3].size);
+    WARN("Message truncated : received %d,%d bytes instead of %d,%d", senderRecvSize1, senderRecvSize2, ops[1].size,
+         ops[3].size);
     return ncclInternalError;
   }
   ops[1].size = std::min(ops[1].size, senderRecvSize1);
@@ -427,7 +427,7 @@ struct extInfo {
   union ncclSocketAddress listenRootAddress; // address of my listenSocket for the root
   struct ringConnectInfo connectInfo;
 };
-#define NET_HANDLE(h, rank)    ((h) + (rank * NCCL_NET_HANDLE_MAXSIZE))
+#define NET_HANDLE(h, rank) ((h) + (rank * NCCL_NET_HANDLE_MAXSIZE))
 #define BOOTSTRAP_HANDLE(h, i) ((struct ncclBootstrapHandle*)((char*)h + i * NCCL_UNIQUE_ID_BYTES))
 
 // Bootstrap-side accept wrapper. ncclSocketAccept's default behavior
@@ -445,7 +445,7 @@ static ncclResult_t bootstrapAccept(struct ncclSocket* sock, struct ncclSocket* 
     NCCLCHECK(ncclSocketInit(sock));
     NCCLCHECK(ncclSocketAccept(sock, listenSock, /*retryOnBadMagic=*/false));
     if (sock->state != ncclSocketStateBadMagic) return ncclSuccess;
-    INFO(NCCL_INIT|NCCL_NET, "bootstrap: rejected bad-magic peer connection on listen sock, retrying accept");
+    INFO(NCCL_INIT | NCCL_NET, "bootstrap: rejected bad-magic peer connection on listen sock, retrying accept");
     (void)ncclSocketClose(sock);
     usleep(1000);
   }
@@ -500,7 +500,7 @@ static void* bootstrapRoot(void* rargs) {
       nranks = info.nranks;
       iroot = info.iroot;
       nroots = info.nroots;
-      offset  = info.offset;
+      offset = info.offset;
       // if the number of root > 1, we will receive one extra info from the first local_id of the next root
       n2send = nRankFromRoot(iroot, nranks, nroots, offset);
       // offset>0 automatically means that we need to switch to the multiroot logic
@@ -510,9 +510,10 @@ static void* bootstrapRoot(void* rargs) {
     }
 
     if (nranks != info.nranks || nroots != info.nroots || iroot != info.iroot || offset != info.offset) {
-      WARN("Bootstrap Root : mismatch in info from procs, nranks %d vs %d, nroots %d vs %d, iroot %d vs %d, offset %d vs %d",
-        nranks, info.nranks, nroots, info.nroots, iroot, info.iroot, offset, info.offset);
-        goto out;
+      WARN("Bootstrap Root : mismatch in info from procs, nranks %d vs %d, nroots %d vs %d, iroot %d vs %d, offset %d "
+           "vs %d",
+           nranks, info.nranks, nroots, info.nroots, iroot, info.iroot, offset, info.offset);
+      goto out;
     }
 
     localId = localIdFromRoot(info.rank, iroot, nranks, nroots, offset);
@@ -537,7 +538,8 @@ static void* bootstrapRoot(void* rargs) {
     // address we may already have). For bidir IB we additionally need prev-of-prev's
     // revHandle to be available — otherwise defer to the final loop.
     int prev = (nroots > 1) ? (localId - 1) : BOOTSTRAP_PID(localId - 1, nrecv);
-    if (prev >= 0 && prev < n2send && memcmp(&zeroAddress, &rankAddressesRoot[prev], sizeof(union ncclSocketAddress)) != 0) {
+    if (prev >= 0 && prev < n2send &&
+        memcmp(&zeroAddress, &rankAddressesRoot[prev], sizeof(union ncclSocketAddress)) != 0) {
       int prevprev = (nroots > 1) ? (prev - 1) : BOOTSTRAP_PID(prev - 1, nrecv);
       bool revKnown = (prevprev >= 0 && prevprev < nrecv &&
                        memcmp(&zeroInfo, &rankInfo[prevprev], sizeof(struct ringConnectInfo)) != 0);
@@ -594,16 +596,16 @@ static void* bootstrapRoot(void* rargs) {
     }
   }
   BOOTSTRAP_PROF_CLOSE(timers[BOOTSTRAP_INIT_ROOT_SEND]);
-  TRACE(NCCL_BOOTSTRAP | NCCL_PROFILE, "Root timings (wait %f, recv %f, send %f)", timers[BOOTSTRAP_INIT_ROOT_WAIT] / 1e9, timers[BOOTSTRAP_INIT_ROOT_RECV] / 1e9, timers[BOOTSTRAP_INIT_ROOT_SEND] / 1e9);
+  TRACE(NCCL_BOOTSTRAP | NCCL_PROFILE, "Root timings (wait %f, recv %f, send %f)",
+        timers[BOOTSTRAP_INIT_ROOT_WAIT] / 1e9, timers[BOOTSTRAP_INIT_ROOT_RECV] / 1e9,
+        timers[BOOTSTRAP_INIT_ROOT_SEND] / 1e9);
 out:
   if (listenSock != NULL) {
     (void)ncclSocketClose(listenSock);
     free(listenSock);
   }
-  if (rankInfo)
-    free(rankInfo);
-  if (rankAddressesRoot)
-    free(rankAddressesRoot);
+  if (rankInfo) free(rankInfo);
+  if (rankAddressesRoot) free(rankAddressesRoot);
   free(rargs);
 
   TRACE(NCCL_BOOTSTRAP, "DONE");
@@ -676,10 +678,13 @@ ncclResult_t bcastGrowHandle(struct ncclBootstrapHandle* handle, struct ncclComm
   // Single rank parent already has the handle, no need to broadcast
   if (parent->nRanks == 1) return ncclSuccess;
   if (isRoot) {
-    NCCLCHECK(bootstrapSend(parent->bootstrap, 0, BOOTSTRAP_TAG_GROW_BOUNDARY, handle, sizeof(struct ncclBootstrapHandle)));
-    NCCLCHECK(bootstrapSend(parent->bootstrap, parent->nRanks - 1, BOOTSTRAP_TAG_GROW_BOUNDARY, handle, sizeof(struct ncclBootstrapHandle)));
+    NCCLCHECK(bootstrapSend(parent->bootstrap, 0, BOOTSTRAP_TAG_GROW_BOUNDARY, handle,
+                            sizeof(struct ncclBootstrapHandle)));
+    NCCLCHECK(bootstrapSend(parent->bootstrap, parent->nRanks - 1, BOOTSTRAP_TAG_GROW_BOUNDARY, handle,
+                            sizeof(struct ncclBootstrapHandle)));
   } else {
-    NCCLCHECK(bootstrapRecv(parent->bootstrap, -1, BOOTSTRAP_TAG_GROW_BOUNDARY, handle, sizeof(struct ncclBootstrapHandle)));
+    NCCLCHECK(bootstrapRecv(parent->bootstrap, -1, BOOTSTRAP_TAG_GROW_BOUNDARY, handle,
+                            sizeof(struct ncclBootstrapHandle)));
   }
 
   return ncclSuccess;
@@ -718,7 +723,7 @@ struct bootstrapListen_t {
       char handle[NCCL_NET_HANDLE_MAXSIZE];
       // Second listen handle for the reverse ring (only valid in bidirectional IB bootstrap).
       void* revComm;
-      char  revHandle[NCCL_NET_HANDLE_MAXSIZE];
+      char revHandle[NCCL_NET_HANDLE_MAXSIZE];
     } net;
     struct {
       struct ncclSocket fwd; // forward ring listen
@@ -744,8 +749,8 @@ struct bootstrapState {
 #define STATE_LISTEN(s, f) (s->listen.f)
 
 // helper functions
-static ncclResult_t createListenSocket(struct ncclComm* comm, uint64_t magic, struct ncclSocket* socket, union ncclSocketAddress* addr,
-                                       ncclSocketType type) {
+static ncclResult_t createListenSocket(struct ncclComm* comm, uint64_t magic, struct ncclSocket* socket,
+                                       union ncclSocketAddress* addr, ncclSocketType type) {
   NCCLCHECK(ncclSocketInit(socket, &bootstrapNetIfAddr, magic, type, comm->abortFlag));
   NCCLCHECK(ncclSocketListen(socket));
   NCCLCHECK(ncclSocketGetAddr(socket, addr));
@@ -791,7 +796,8 @@ static ncclResult_t netGetDevice(int rank, struct ncclComm* comm, int* dev) {
           if (!searchNot)
             WARN("no device found matching %s%s, verify NCCL_OOB_NET_IFNAME", searchExact ? "exactly " : "", userIfEnv);
           else
-            WARN("no device found after excluding %s%s, verify NCCL_OOB_NET_IFNAME", searchExact ? "exactly " : "", userIfEnv);
+            WARN("no device found after excluding %s%s, verify NCCL_OOB_NET_IFNAME", searchExact ? "exactly " : "",
+                 userIfEnv);
           return ncclInvalidArgument;
         }
       } else {
@@ -809,38 +815,38 @@ static ncclResult_t netGetDevice(int rank, struct ncclComm* comm, int* dev) {
   return ncclSuccess;
 }
 
-static ncclResult_t netRingConnect(void* ctx, ncclNet_t* net, struct bootstrapListen_t* listen, char peerHandle[NCCL_NET_HANDLE_MAXSIZE],
-                                   void** sendComm, ncclNetDeviceHandle_t** sendDevHandle,
-                                   void** recvComm, ncclNetDeviceHandle_t** recvDevHandle, volatile uint32_t* abortFlag) {
+static ncclResult_t netRingConnect(void* ctx, ncclNet_t* net, struct bootstrapListen_t* listen,
+                                   char peerHandle[NCCL_NET_HANDLE_MAXSIZE], void** sendComm,
+                                   ncclNetDeviceHandle_t** sendDevHandle, void** recvComm,
+                                   ncclNetDeviceHandle_t** recvDevHandle, volatile uint32_t* abortFlag) {
   int abortCounter = 0;
   do {
     NCCLCHECK(checkAbort(abortFlag, &abortCounter));
-    if (!*sendComm)
-      NCCLCHECK(net->connect(ctx, listen->net.dev, peerHandle, sendComm, sendDevHandle));
-    if (!*recvComm)
-      NCCLCHECK(net->accept(listen->net.comm, recvComm, recvDevHandle));
+    if (!*sendComm) NCCLCHECK(net->connect(ctx, listen->net.dev, peerHandle, sendComm, sendDevHandle));
+    if (!*recvComm) NCCLCHECK(net->accept(listen->net.comm, recvComm, recvDevHandle));
   } while (!*sendComm || !*recvComm);
   return ncclSuccess;
 }
 
-static ncclResult_t netRingConnectProgress(void* ctx, ncclNet_t* net, struct bootstrapListen_t* listen, char peerHandle[NCCL_NET_HANDLE_MAXSIZE],
-                                           void** sendComm, ncclNetDeviceHandle_t** sendDevHandle,
-                                           void** recvComm, ncclNetDeviceHandle_t** recvDevHandle, int* done) {
-  if (!*sendComm)
-    NCCLCHECK(net->connect(ctx, listen->net.dev, peerHandle, sendComm, sendDevHandle));
-  if (!*recvComm)
-    NCCLCHECK(net->accept(listen->net.comm, recvComm, recvDevHandle));
+static ncclResult_t netRingConnectProgress(void* ctx, ncclNet_t* net, struct bootstrapListen_t* listen,
+                                           char peerHandle[NCCL_NET_HANDLE_MAXSIZE], void** sendComm,
+                                           ncclNetDeviceHandle_t** sendDevHandle, void** recvComm,
+                                           ncclNetDeviceHandle_t** recvDevHandle, int* done) {
+  if (!*sendComm) NCCLCHECK(net->connect(ctx, listen->net.dev, peerHandle, sendComm, sendDevHandle));
+  if (!*recvComm) NCCLCHECK(net->accept(listen->net.comm, recvComm, recvDevHandle));
   *done = (*sendComm && *recvComm) ? 1 : 0;
   return ncclSuccess;
 }
 
-static ncclResult_t netRingConnectFinish(void* ctx, ncclNet_t* net, struct bootstrapListen_t* listen, char peerHandle[NCCL_NET_HANDLE_MAXSIZE],
-                                         void** sendComm, ncclNetDeviceHandle_t** sendDevHandle,
-                                         void** recvComm, ncclNetDeviceHandle_t** recvDevHandle, volatile uint32_t* abortFlag) {
+static ncclResult_t netRingConnectFinish(void* ctx, ncclNet_t* net, struct bootstrapListen_t* listen,
+                                         char peerHandle[NCCL_NET_HANDLE_MAXSIZE], void** sendComm,
+                                         ncclNetDeviceHandle_t** sendDevHandle, void** recvComm,
+                                         ncclNetDeviceHandle_t** recvDevHandle, volatile uint32_t* abortFlag) {
   int abortCounter = 0, done = 0;
   do {
     NCCLCHECK(checkAbort(abortFlag, &abortCounter));
-    NCCLCHECK(netRingConnectProgress(ctx, net, listen, peerHandle, sendComm, sendDevHandle, recvComm, recvDevHandle, &done));
+    NCCLCHECK(netRingConnectProgress(ctx, net, listen, peerHandle, sendComm, sendDevHandle, recvComm, recvDevHandle,
+                                     &done));
     if (!done) sched_yield();
   } while (!done);
   return ncclSuccess;
@@ -850,9 +856,11 @@ static ncclResult_t netRingConnectFinish(void* ctx, ncclNet_t* net, struct boots
 // TCP connect/accept handshakes with local proxy/P2P socket setup, without adding
 // threads. socketRingConnect() below keeps the old blocking semantics for callers that
 // do not have useful work to overlap (notably bootstrapSplit).
-static ncclResult_t socketRingConnectStart(ncclSocketAddress* addr, struct ncclSocket* sendSocket, struct ncclSocket* listenSock, struct ncclSocket* recvSocket, uint64_t magic, volatile uint32_t* abortFlag) {
+static ncclResult_t socketRingConnectStart(ncclSocketAddress* addr, struct ncclSocket* sendSocket,
+                                           struct ncclSocket* listenSock, struct ncclSocket* recvSocket, uint64_t magic,
+                                           volatile uint32_t* abortFlag) {
   ncclResult_t ret = ncclSuccess;
-  NCCLCHECK(ncclSocketInit(sendSocket, addr, magic, ncclSocketTypeBootstrap, abortFlag, /*asyncFlag*/1));
+  NCCLCHECK(ncclSocketInit(sendSocket, addr, magic, ncclSocketTypeBootstrap, abortFlag, /*asyncFlag*/ 1));
   NCCLCHECK(ncclSocketConnect(sendSocket));
   int oldAsync = listenSock->asyncFlag;
   listenSock->asyncFlag = 1;
@@ -863,7 +871,8 @@ exit:
   return ret;
 }
 
-static ncclResult_t socketRingConnectFinish(struct ncclSocket* sendSocket, struct ncclSocket* recvSocket, volatile uint32_t* abortFlag) {
+static ncclResult_t socketRingConnectFinish(struct ncclSocket* sendSocket, struct ncclSocket* recvSocket,
+                                            volatile uint32_t* abortFlag) {
   int abortCounter = 0;
   int sendReady = 0, recvReady = 0;
   do {
@@ -875,7 +884,9 @@ static ncclResult_t socketRingConnectFinish(struct ncclSocket* sendSocket, struc
   return ncclSuccess;
 }
 
-static ncclResult_t socketRingConnect(ncclSocketAddress* addr, struct ncclSocket* sendSocket, struct ncclSocket* listenSock, struct ncclSocket* recvSocket, uint64_t magic, volatile uint32_t* abortFlag) {
+static ncclResult_t socketRingConnect(ncclSocketAddress* addr, struct ncclSocket* sendSocket,
+                                      struct ncclSocket* listenSock, struct ncclSocket* recvSocket, uint64_t magic,
+                                      volatile uint32_t* abortFlag) {
   NCCLCHECK(socketRingConnectStart(addr, sendSocket, listenSock, recvSocket, magic, abortFlag));
   NCCLCHECK(socketRingConnectFinish(sendSocket, recvSocket, abortFlag));
   return ncclSuccess;
@@ -902,8 +913,7 @@ static ncclResult_t socketRingConnect(ncclSocketAddress* addr, struct ncclSocket
 // (typically because piggyback wasn't available).
 static ncclResult_t bootstrapBidirRingSetupStart(struct ncclComm* comm, struct bootstrapState* state,
                                                  const char* prevRevHandlePiggyback,
-                                                 char prevRevHandleOut[NCCL_NET_HANDLE_MAXSIZE],
-                                                 bool* startedOut) {
+                                                 char prevRevHandleOut[NCCL_NET_HANDLE_MAXSIZE], bool* startedOut) {
   *startedOut = false;
   memset(prevRevHandleOut, 0, NCCL_NET_HANDLE_MAXSIZE);
   bool wantNetBidir = bootstrapBidirEnabled(state->nranks, 1);
@@ -912,14 +922,15 @@ static ncclResult_t bootstrapBidirRingSetupStart(struct ncclComm* comm, struct b
   // Listen on the reverse device. Eager listen in bootstrapInit normally already did
   // this; fall back to in-place listen if some other caller didn't.
   if (STATE_LISTEN(state, net.revComm) == NULL) {
-    NCCLCHECK(state->net->listen(comm->netContext, STATE_LISTEN(state, net.dev),
-                                 STATE_LISTEN(state, net.revHandle), &STATE_LISTEN(state, net.revComm)));
+    NCCLCHECK(state->net->listen(comm->netContext, STATE_LISTEN(state, net.dev), STATE_LISTEN(state, net.revHandle),
+                                 &STATE_LISTEN(state, net.revComm)));
   }
 
   // Without a piggybacked prev revHandle we can't kick off connect() yet — the legacy
   // path needs the forward ring up to do netSendRecv. Caller will fall back.
   if (prevRevHandlePiggyback == NULL) return ncclSuccess;
-  char zeros[NCCL_NET_HANDLE_MAXSIZE]; memset(zeros, 0, NCCL_NET_HANDLE_MAXSIZE);
+  char zeros[NCCL_NET_HANDLE_MAXSIZE];
+  memset(zeros, 0, NCCL_NET_HANDLE_MAXSIZE);
   if (memcmp(prevRevHandlePiggyback, zeros, NCCL_NET_HANDLE_MAXSIZE) == 0) return ncclSuccess;
   memcpy(prevRevHandleOut, prevRevHandlePiggyback, NCCL_NET_HANDLE_MAXSIZE);
 
@@ -928,8 +939,8 @@ static ncclResult_t bootstrapBidirRingSetupStart(struct ncclComm* comm, struct b
   // (proxy/UDS/peer/RAS, and/or the forward-ring connect handshake).
   NCCLCHECK(state->net->connect(comm->netContext, STATE_LISTEN(state, net.dev), prevRevHandleOut,
                                 &STATE_RING(state, net.revSendComm), &STATE_RING(state, net.revSendDevHandle)));
-  NCCLCHECK(state->net->accept(STATE_LISTEN(state, net.revComm),
-                               &STATE_RING(state, net.revRecvComm), &STATE_RING(state, net.revRecvDevHandle)));
+  NCCLCHECK(state->net->accept(STATE_LISTEN(state, net.revComm), &STATE_RING(state, net.revRecvComm),
+                               &STATE_RING(state, net.revRecvDevHandle)));
   *startedOut = true;
   return ncclSuccess;
 }
@@ -952,8 +963,8 @@ static ncclResult_t bootstrapBidirRingSetupFinish(struct ncclComm* comm, struct 
     }
     if (!STATE_RING(state, net.revRecvComm)) {
       void* prevPtr = STATE_RING(state, net.revRecvComm);
-      NCCLCHECK(state->net->accept(STATE_LISTEN(state, net.revComm),
-                                   &STATE_RING(state, net.revRecvComm), &STATE_RING(state, net.revRecvDevHandle)));
+      NCCLCHECK(state->net->accept(STATE_LISTEN(state, net.revComm), &STATE_RING(state, net.revRecvComm),
+                                   &STATE_RING(state, net.revRecvDevHandle)));
       if (STATE_RING(state, net.revRecvComm) != prevPtr) madeProgress = true;
     }
     if (!madeProgress) sched_yield();
@@ -978,8 +989,8 @@ static ncclResult_t bootstrapBidirRingSetup(struct ncclComm* comm, struct bootst
   //    (caller passed NULL prevRevHandlePiggyback or revComm wasn't set up), fall back
   //    to the legacy in-place listen here.
   if (STATE_LISTEN(state, net.revComm) == NULL) {
-    NCCLCHECK(state->net->listen(comm->netContext, STATE_LISTEN(state, net.dev),
-                                 STATE_LISTEN(state, net.revHandle), &STATE_LISTEN(state, net.revComm)));
+    NCCLCHECK(state->net->listen(comm->netContext, STATE_LISTEN(state, net.dev), STATE_LISTEN(state, net.revHandle),
+                                 &STATE_LISTEN(state, net.revComm)));
   }
 
   // 2. Determine prev's revHandle. Best case: piggybacked through the root rendezvous
@@ -997,11 +1008,12 @@ static ncclResult_t bootstrapBidirRingSetup(struct ncclComm* comm, struct bootst
   if (!havePiggyback) {
     char* myRevHandle = STATE_LISTEN(state, net.revHandle);
     void *sendH = NULL, *recvH = NULL;
-    ncclResult_t regRes = netReg(state->net, STATE_RING(state, net.sendComm), myRevHandle,   NCCL_NET_HANDLE_MAXSIZE, &sendH);
-    if (regRes == ncclSuccess) regRes = netReg(state->net, STATE_RING(state, net.recvComm), prevRevHandle, NCCL_NET_HANDLE_MAXSIZE, &recvH);
+    ncclResult_t regRes =
+      netReg(state->net, STATE_RING(state, net.sendComm), myRevHandle, NCCL_NET_HANDLE_MAXSIZE, &sendH);
+    if (regRes == ncclSuccess)
+      regRes = netReg(state->net, STATE_RING(state, net.recvComm), prevRevHandle, NCCL_NET_HANDLE_MAXSIZE, &recvH);
     if (regRes == ncclSuccess) {
-      regRes = netSendRecv(state->net,
-                           STATE_RING(state, net.sendComm), myRevHandle,   NCCL_NET_HANDLE_MAXSIZE, sendH,
+      regRes = netSendRecv(state->net, STATE_RING(state, net.sendComm), myRevHandle, NCCL_NET_HANDLE_MAXSIZE, sendH,
                            STATE_RING(state, net.recvComm), prevRevHandle, NCCL_NET_HANDLE_MAXSIZE, recvH,
                            BOOTSTRAP_TAG_BIDIR_REV_HANDLE, state->abortFlag);
     }
@@ -1014,9 +1026,8 @@ static ncclResult_t bootstrapBidirRingSetup(struct ncclComm* comm, struct bootst
 }
 
 static ncclResult_t ringAllInfo(struct ncclComm* comm, struct bootstrapState* state,
-                                union ncclSocketAddress* peerAddresss,
-                                union ncclSocketAddress* peerProxy, uint64_t* peerUDS,
-                                struct rasRankInit* rasRanks) {
+                                union ncclSocketAddress* peerAddresss, union ncclSocketAddress* peerProxy,
+                                uint64_t* peerUDS, struct rasRankInit* rasRanks) {
   ncclResult_t res = ncclSuccess;
   int rank = comm->rank;
   int nRanks = comm->nRanks;
@@ -1029,28 +1040,20 @@ static ncclResult_t ringAllInfo(struct ncclComm* comm, struct bootstrapState* st
 
   NCCLCHECK(ncclCalloc(&ringData, nRanks));
   // pack
-  if (peerAddresss)
-    memcpy(&(ringData[rank].peerAddress), peerAddresss + rank, sizeof(union ncclSocketAddress));
-  if (peerProxy)
-    memcpy(&(ringData[rank].peerProxy), peerProxy + rank, sizeof(union ncclSocketAddress));
-  if (peerUDS)
-    memcpy(&(ringData[rank].peerUDS), peerUDS + rank, sizeof(uint64_t));
-  if (rasRanks)
-    memcpy(&(ringData[rank].rasRank), rasRanks + rank, sizeof(*rasRanks));
+  if (peerAddresss) memcpy(&(ringData[rank].peerAddress), peerAddresss + rank, sizeof(union ncclSocketAddress));
+  if (peerProxy) memcpy(&(ringData[rank].peerProxy), peerProxy + rank, sizeof(union ncclSocketAddress));
+  if (peerUDS) memcpy(&(ringData[rank].peerUDS), peerUDS + rank, sizeof(uint64_t));
+  if (rasRanks) memcpy(&(ringData[rank].rasRank), rasRanks + rank, sizeof(*rasRanks));
 
   // allgather
   NCCLCHECKGOTO(bootstrapAllGather(state, ringData, sizeof(struct bootstrapRingData)), res, exit);
 
   // unpack
   for (int irank = 0; irank < nRanks; ++irank) {
-    if (peerAddresss)
-      memcpy(peerAddresss + irank, &(ringData[irank].peerAddress), sizeof(union ncclSocketAddress));
-    if (peerProxy)
-      memcpy(peerProxy + irank, &(ringData[irank].peerProxy), sizeof(union ncclSocketAddress));
-    if (peerUDS)
-      memcpy(peerUDS + irank, &(ringData[irank].peerUDS), sizeof(uint64_t));
-    if (rasRanks)
-      memcpy(rasRanks + irank, &(ringData[irank].rasRank), sizeof(*rasRanks));
+    if (peerAddresss) memcpy(peerAddresss + irank, &(ringData[irank].peerAddress), sizeof(union ncclSocketAddress));
+    if (peerProxy) memcpy(peerProxy + irank, &(ringData[irank].peerProxy), sizeof(union ncclSocketAddress));
+    if (peerUDS) memcpy(peerUDS + irank, &(ringData[irank].peerUDS), sizeof(uint64_t));
+    if (rasRanks) memcpy(rasRanks + irank, &(ringData[irank].rasRank), sizeof(*rasRanks));
   }
 
 exit:
@@ -1134,7 +1137,8 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm, s
   if (bootstrapNetEnabledEffective(nranks)) {
     // Create net interface for other ranks to contact me (all gather)
     NCCLCHECK(netGetDevice(rank, comm, &STATE_LISTEN(state, net.dev)));
-    NCCLCHECK(state->net->listen(comm->netContext, STATE_LISTEN(state, net.dev), STATE_LISTEN(state, net.handle), &STATE_LISTEN(state, net.comm)));
+    NCCLCHECK(state->net->listen(comm->netContext, STATE_LISTEN(state, net.dev), STATE_LISTEN(state, net.handle),
+                                 &STATE_LISTEN(state, net.comm)));
     memcpy(info.connectInfo.fwd.handle, STATE_LISTEN(state, net.handle), NCCL_NET_HANDLE_MAXSIZE);
     // [RCCL] Eagerly create the reverse listen if we expect to use net bidir bootstrap.
     // The cost (one IB listen ≈ 1ms) is paid here in parallel with the staggered sendToRoot
@@ -1142,22 +1146,23 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm, s
     // bootstrapBidirRingSetup can skip its own netSendRecv handle exchange (~20ms saving
     // dominated by 4× regMr/deregMr on the net plugin).
     if (wantNetBidir) {
-      NCCLCHECK(state->net->listen(comm->netContext, STATE_LISTEN(state, net.dev),
-                                   STATE_LISTEN(state, net.revHandle), &STATE_LISTEN(state, net.revComm)));
+      NCCLCHECK(state->net->listen(comm->netContext, STATE_LISTEN(state, net.dev), STATE_LISTEN(state, net.revHandle),
+                                   &STATE_LISTEN(state, net.revComm)));
       memcpy(info.connectInfo.revHandle, STATE_LISTEN(state, net.revHandle), NCCL_NET_HANDLE_MAXSIZE);
     }
   } else {
-    NCCLCHECK(createListenSocket(comm, comm->magic, &STATE_LISTEN(state, socket.fwd), &info.connectInfo.fwd.addr, ncclSocketTypeBootstrap));
+    NCCLCHECK(createListenSocket(comm, comm->magic, &STATE_LISTEN(state, socket.fwd), &info.connectInfo.fwd.addr,
+                                 ncclSocketTypeBootstrap));
   }
   // Create socket for root to contact me using the root's magic
   // For grow operations, offset is parent->nRanks - 1 (last existing rank joins the root)
   // For normal init, offset is 0
   int offset = 0;
-  if(comm->isGrow) {
-    if(parent != NULL) {
+  if (comm->isGrow) {
+    if (parent != NULL) {
       offset = parent->nRanks - 1;
     } else {
-      if(handles != NULL) {
+      if (handles != NULL) {
         offset = BOOTSTRAP_HANDLE(handles, 0)->nRanks - 1;
       } else {
         WARN("bootstrapInit: handles and parent are NULL");
@@ -1166,7 +1171,9 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm, s
     }
   }
   int curr_root = rootIdFromRank(rank, nranks, nHandles, offset);
-  if(curr_root >= 0) NCCLCHECK(createListenSocket(comm, BOOTSTRAP_HANDLE(handles, curr_root)->magic, &listenSockRoot, &info.listenRootAddress, ncclSocketTypeBootstrap));
+  if (curr_root >= 0)
+    NCCLCHECK(createListenSocket(comm, BOOTSTRAP_HANDLE(handles, curr_root)->magic, &listenSockRoot,
+                                 &info.listenRootAddress, ncclSocketTypeBootstrap));
   BOOTSTRAP_PROF_CLOSE(timers[BOOTSTRAP_INIT_TIME_CREATE]);
 
   // stagger connection times to avoid an overload of the root
@@ -1187,20 +1194,21 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm, s
   info.rank = rank;
   info.iroot = curr_root;
   info.offset = offset;
-  if(curr_root >= 0) NCCLCHECK(sendToRoot(BOOTSTRAP_HANDLE(handles, curr_root), comm, &info));
-  if(parent && comm->isGrow && rank != 0) {
+  if (curr_root >= 0) NCCLCHECK(sendToRoot(BOOTSTRAP_HANDLE(handles, curr_root), comm, &info));
+  if (parent && comm->isGrow && rank != 0) {
     // Grow: Ranks 1 to N-1 use the parent bootstrap to send connection information to the previous rank
     NCCLCHECK(bootstrapSend(parent->bootstrap, rank - 1, 0, &info.connectInfo, sizeof(info.connectInfo)));
   }
   // if needed, send the connection info to the previous root
   // commGrow with more than = 1 rank in the parent comm is a special case of multiroot
-  if (((comm->isGrow && parent && (parent->nRanks > 1)) || nHandles > 1) && isFirstFromRoot(rank, curr_root, nranks, nHandles, offset)) {
+  if (((comm->isGrow && parent && (parent->nRanks > 1)) || nHandles > 1) &&
+      isFirstFromRoot(rank, curr_root, nranks, nHandles, offset)) {
     int prev_rank = BOOTSTRAP_PID(rank - 1, nranks);
     int prev_root = rootIdFromRank(prev_rank, nranks, nHandles, offset);
     info.rank = prev_rank + 1; // my rank as seen by the previous root
     info.iroot = prev_root;
     // only send if the root is valid, existing rank N-1 will use the bootstrapSend just above
-    if(prev_root >= 0) NCCLCHECK(sendToRoot(BOOTSTRAP_HANDLE(handles, prev_root), comm, &info));
+    if (prev_root >= 0) NCCLCHECK(sendToRoot(BOOTSTRAP_HANDLE(handles, prev_root), comm, &info));
   }
   BOOTSTRAP_PROF_CLOSE(timers[BOOTSTRAP_INIT_TIME_SEND]);
 
@@ -1226,9 +1234,12 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm, s
     int ringConnectDone = 0;
     NCCLCHECK(netRingConnectProgress(comm->netContext, state->net, &state->listen, nextPeer.fwd.handle,
                                      &STATE_RING(state, net.sendComm), &STATE_RING(state, net.sendDevHandle),
-                                     &STATE_RING(state, net.recvComm), &STATE_RING(state, net.recvDevHandle), &ringConnectDone));
+                                     &STATE_RING(state, net.recvComm), &STATE_RING(state, net.recvDevHandle),
+                                     &ringConnectDone));
   } else {
-    NCCLCHECK(socketRingConnectStart(&nextPeer.fwd.addr, &STATE_RING(state, socket.send), &STATE_LISTEN(state, socket.fwd), &STATE_RING(state, socket.recv), comm->magic, state->abortFlag));
+    NCCLCHECK(socketRingConnectStart(&nextPeer.fwd.addr, &STATE_RING(state, socket.send),
+                                     &STATE_LISTEN(state, socket.fwd), &STATE_RING(state, socket.recv), comm->magic,
+                                     state->abortFlag));
   }
 
   // [RCCL] Bidirectional net OOB: kick off the reverse-ring connect()/accept() now so
@@ -1246,14 +1257,18 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm, s
   // in case of failure, those resources will be free'd when calling bootstrapDestroy, so we can return immediatly
   NCCLCHECK(ncclCalloc(&state->peerProxyAddresses, nranks));
   NCCLCHECK(ncclCalloc(&proxySocket, 1));
-  NCCLCHECKGOTO(createListenSocket(comm, comm->magic, proxySocket, state->peerProxyAddresses + rank, ncclSocketTypeProxy), result, fail);
+  NCCLCHECKGOTO(createListenSocket(comm, comm->magic, proxySocket, state->peerProxyAddresses + rank,
+                                   ncclSocketTypeProxy),
+                result, fail);
 
   NCCLCHECKGOTO(ncclCalloc(&state->peerProxyAddressesUDS, nranks), result, fail);
   NCCLCHECKGOTO(getUDS(state->peerProxyAddressesUDS + rank), result, fail);
 
   // create a socket for others to reach out (P2P)
   union ncclSocketAddress peerSocketAddress;
-  NCCLCHECKGOTO(createListenSocket(comm, comm->magic, &STATE_LISTEN(state, peerSocket), &peerSocketAddress, ncclSocketTypeBootstrap), result, fail);
+  NCCLCHECKGOTO(createListenSocket(comm, comm->magic, &STATE_LISTEN(state, peerSocket), &peerSocketAddress,
+                                   ncclSocketTypeBootstrap),
+                result, fail);
   NCCLCHECKGOTO(ncclCalloc(&state->peerP2pAddresses, nranks), result, fail);
   memcpy(state->peerP2pAddresses + rank, &peerSocketAddress, sizeof(union ncclSocketAddress));
 
@@ -1267,11 +1282,11 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm, s
     rasRanks[rank].nvmlDev = comm->nvmlDev;
     rasRanks[rank].hostHash = getHostHash();
     rasRanks[rank].pidHash = getPidHash();
-    if (ncclRasCommInit(comm, rasRanks+rank) != ncclSuccess) {
-      INFO(NCCL_INIT|NCCL_RAS, "Continuing in spite of a RAS initialization error");
+    if (ncclRasCommInit(comm, rasRanks + rank) != ncclSuccess) {
+      INFO(NCCL_INIT | NCCL_RAS, "Continuing in spite of a RAS initialization error");
       // We should still participate in the ringAllInfo below as the peers will be waiting for us.
       // Just make sure that the address is clearly invalid...
-      memset(rasRanks+rank, '\0', sizeof(*rasRanks));
+      memset(rasRanks + rank, '\0', sizeof(*rasRanks));
       performRasAddRanks = false;
     }
   }
@@ -1282,10 +1297,13 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm, s
   if (bootstrapNetEnabledEffective(nranks)) {
     NCCLCHECKGOTO(netRingConnectFinish(comm->netContext, state->net, &state->listen, nextPeer.fwd.handle,
                                        &STATE_RING(state, net.sendComm), &STATE_RING(state, net.sendDevHandle),
-                                       &STATE_RING(state, net.recvComm), &STATE_RING(state, net.recvDevHandle), state->abortFlag),
+                                       &STATE_RING(state, net.recvComm), &STATE_RING(state, net.recvDevHandle),
+                                       state->abortFlag),
                   result, fail);
   } else {
-    NCCLCHECKGOTO(socketRingConnectFinish(&STATE_RING(state, socket.send), &STATE_RING(state, socket.recv), state->abortFlag), result, fail);
+    NCCLCHECKGOTO(socketRingConnectFinish(&STATE_RING(state, socket.send), &STATE_RING(state, socket.recv),
+                                          state->abortFlag),
+                  result, fail);
   }
 
   // Optionally bring up the second (reverse) ring used by the bidirectional bootstrap
@@ -1303,25 +1321,26 @@ ncclResult_t bootstrapInit(int nHandles, void* handles, struct ncclComm* comm, s
   }
 
   BOOTSTRAP_PROF_OPEN(timers[BOOTSTRAP_INIT_TIME_RING]);
-  NCCLCHECKGOTO(ringAllInfo(comm, state, state->peerP2pAddresses, state->peerProxyAddresses, state->peerProxyAddressesUDS, rasRanks), result, fail);
+  NCCLCHECKGOTO(ringAllInfo(comm, state, state->peerP2pAddresses, state->peerProxyAddresses,
+                            state->peerProxyAddressesUDS, rasRanks),
+                result, fail);
   BOOTSTRAP_PROF_CLOSE(timers[BOOTSTRAP_INIT_TIME_RING]);
 
   // Create the service proxy and get the UDS
-  NCCLCHECKGOTO(ncclProxyInit(comm, proxySocket, state->peerProxyAddresses, state->peerProxyAddressesUDS), result, fail);
+  NCCLCHECKGOTO(ncclProxyInit(comm, proxySocket, state->peerProxyAddresses, state->peerProxyAddressesUDS), result,
+                fail);
 
   if (ncclParamRasEnable() == 1 && performRasAddRanks) {
     if (ncclRasAddRanks(rasRanks, nranks) != ncclSuccess)
-      INFO(NCCL_INIT|NCCL_RAS, "Continuing in spite of a RAS initialization error");
+      INFO(NCCL_INIT | NCCL_RAS, "Continuing in spite of a RAS initialization error");
   }
 
   BOOTSTRAP_PROF_CLOSE(timers[BOOTSTRAP_INIT_TIME_TOTAL]);
   TRACE(NCCL_BOOTSTRAP, "rank %d nranks %d - DONE", rank, nranks);
-  INFO(NCCL_BOOTSTRAP | NCCL_PROFILE, "Bootstrap timings total %f (create %f, send %f, recv %f, ring %f, delay %f)", timers[BOOTSTRAP_INIT_TIME_TOTAL] / 1e9,
-       timers[BOOTSTRAP_INIT_TIME_CREATE] / 1e9,
-       timers[BOOTSTRAP_INIT_TIME_SEND] / 1e9,
-       timers[BOOTSTRAP_INIT_TIME_RECV] / 1e9,
-       timers[BOOTSTRAP_INIT_TIME_RING] / 1e9,
-       timers[BOOTSTRAP_INIT_TIME_DELAY] / 1e9);
+  INFO(NCCL_BOOTSTRAP | NCCL_PROFILE, "Bootstrap timings total %f (create %f, send %f, recv %f, ring %f, delay %f)",
+       timers[BOOTSTRAP_INIT_TIME_TOTAL] / 1e9, timers[BOOTSTRAP_INIT_TIME_CREATE] / 1e9,
+       timers[BOOTSTRAP_INIT_TIME_SEND] / 1e9, timers[BOOTSTRAP_INIT_TIME_RECV] / 1e9,
+       timers[BOOTSTRAP_INIT_TIME_RING] / 1e9, timers[BOOTSTRAP_INIT_TIME_DELAY] / 1e9);
 exit:
   return result;
 fail:
@@ -1329,7 +1348,8 @@ fail:
   goto exit;
 }
 
-ncclResult_t bootstrapSplit(uint64_t magic, struct ncclComm* comm, struct ncclComm* parent, int color, int key, int* parentRanks) {
+ncclResult_t bootstrapSplit(uint64_t magic, struct ncclComm* comm, struct ncclComm* parent, int color, int key,
+                            int* parentRanks) {
   ncclResult_t ret = ncclSuccess;
   int rank = comm->rank;
   int nranks = comm->nRanks;
@@ -1354,31 +1374,40 @@ ncclResult_t bootstrapSplit(uint64_t magic, struct ncclComm* comm, struct ncclCo
   // create a handle for the others to reach out to me
   if (bootstrapNetEnabledEffective(nranks)) {
     NCCLCHECKGOTO(netGetDevice(rank, comm, &STATE_LISTEN(state, net.dev)), ret, fail);
-    NCCLCHECKGOTO(state->net->listen(comm->netContext, STATE_LISTEN(state, net.dev), STATE_LISTEN(state, net.handle), &STATE_LISTEN(state, net.comm)), ret, fail);
+    NCCLCHECKGOTO(state->net->listen(comm->netContext, STATE_LISTEN(state, net.dev), STATE_LISTEN(state, net.handle),
+                                     &STATE_LISTEN(state, net.comm)),
+                  ret, fail);
     memcpy(info.fwd.handle, STATE_LISTEN(state, net.handle), NCCL_NET_HANDLE_MAXSIZE);
   } else {
     // create socket for ring neighbor to contact me
-    NCCLCHECK(createListenSocket(comm, comm->magic, &STATE_LISTEN(state, socket.fwd), &info.fwd.addr, ncclSocketTypeBootstrap));
+    NCCLCHECK(createListenSocket(comm, comm->magic, &STATE_LISTEN(state, socket.fwd), &info.fwd.addr,
+                                 ncclSocketTypeBootstrap));
   }
   // create a socket for others to reach out (P2P)
   union ncclSocketAddress peerSocketAddress;
-  NCCLCHECK(createListenSocket(comm, comm->magic, &STATE_LISTEN(state, peerSocket), &peerSocketAddress, ncclSocketTypeBootstrap));
+  NCCLCHECK(createListenSocket(comm, comm->magic, &STATE_LISTEN(state, peerSocket), &peerSocketAddress,
+                               ncclSocketTypeBootstrap));
 
   if (ncclParamRasEnable() == 1) {
     if (ncclRasCommInit(comm, nullptr) != ncclSuccess)
-      INFO(NCCL_INIT|NCCL_RAS, "Continuing in spite of a RAS initialization error");
+      INFO(NCCL_INIT | NCCL_RAS, "Continuing in spite of a RAS initialization error");
   }
 
   // Get addr from next rank using the parent's connections
-  NCCLCHECKGOTO(bootstrapSend(parent->bootstrap, prev, BOOTSTRAP_TAG_COMMSPLIT, &info, sizeof(struct ringConnectInfo)), ret, fail);
-  NCCLCHECKGOTO(bootstrapRecv(parent->bootstrap, next, BOOTSTRAP_TAG_COMMSPLIT, &nextPeer, sizeof(struct ringConnectInfo)), ret, fail);
+  NCCLCHECKGOTO(bootstrapSend(parent->bootstrap, prev, BOOTSTRAP_TAG_COMMSPLIT, &info, sizeof(struct ringConnectInfo)),
+                ret, fail);
+  NCCLCHECKGOTO(bootstrapRecv(parent->bootstrap, next, BOOTSTRAP_TAG_COMMSPLIT, &nextPeer,
+                              sizeof(struct ringConnectInfo)),
+                ret, fail);
   if (bootstrapNetEnabledEffective(nranks)) {
     NCCLCHECKGOTO(netRingConnect(comm->netContext, state->net, &state->listen, nextPeer.fwd.handle,
                                  &STATE_RING(state, net.sendComm), &STATE_RING(state, net.sendDevHandle),
-                                 &STATE_RING(state, net.recvComm), &STATE_RING(state, net.recvDevHandle), state->abortFlag),
+                                 &STATE_RING(state, net.recvComm), &STATE_RING(state, net.recvDevHandle),
+                                 state->abortFlag),
                   ret, fail);
   } else {
-    NCCLCHECK(socketRingConnect(&nextPeer.fwd.addr, &STATE_RING(state, socket.send), &STATE_LISTEN(state, socket.fwd), &STATE_RING(state, socket.recv), comm->magic, state->abortFlag));
+    NCCLCHECK(socketRingConnect(&nextPeer.fwd.addr, &STATE_RING(state, socket.send), &STATE_LISTEN(state, socket.fwd),
+                                &STATE_RING(state, socket.recv), comm->magic, state->abortFlag));
   }
 
   // Mirror the bidirectional ring setup done in bootstrapInit so that split communicators
@@ -1401,13 +1430,17 @@ ncclResult_t bootstrapSplit(uint64_t magic, struct ncclComm* comm, struct ncclCo
     // Create the service proxy and get the UDS
     NCCLCHECKGOTO(ncclCalloc(&proxySocket, 1), ret, fail);
     NCCLCHECKGOTO(getUDS(state->peerProxyAddressesUDS + rank), ret, fail);
-    NCCLCHECKGOTO(createListenSocket(comm, comm->magic, proxySocket, state->peerProxyAddresses + rank, ncclSocketTypeProxy), ret, fail);
-    NCCLCHECKGOTO(ringAllInfo(comm, state, state->peerP2pAddresses, state->peerProxyAddresses, state->peerProxyAddressesUDS, NULL), ret, fail);
+    NCCLCHECKGOTO(createListenSocket(comm, comm->magic, proxySocket, state->peerProxyAddresses + rank,
+                                     ncclSocketTypeProxy),
+                  ret, fail);
+    NCCLCHECKGOTO(ringAllInfo(comm, state, state->peerP2pAddresses, state->peerProxyAddresses,
+                              state->peerProxyAddressesUDS, NULL),
+                  ret, fail);
     NCCLCHECKGOTO(ncclProxyInit(comm, proxySocket, state->peerProxyAddresses, state->peerProxyAddressesUDS), ret, fail);
   }
 
-  TRACE(NCCL_BOOTSTRAP, "bootstrapSplit: comm %p parent %p rank %d nranks %d color %d key %d prev %d next %d - DONE", comm, parent, rank, nranks,
-        color, key, prev, next);
+  TRACE(NCCL_BOOTSTRAP, "bootstrapSplit: comm %p parent %p rank %d nranks %d color %d key %d prev %d next %d - DONE",
+        comm, parent, rank, nranks, color, key, prev, next);
 
 exit:
   return ret;
@@ -1424,8 +1457,10 @@ static ncclResult_t socketConnect(void* commState, int peer, int tag, struct ncc
   ncclResult_t ret = ncclSuccess;
   struct bootstrapState* state = (struct bootstrapState*)commState;
 
-  struct socketAckInfo ack = (struct socketAckInfo){ state->rank, tag };
-  NCCLCHECKGOTO(ncclSocketInit(sock, state->peerP2pAddresses + peer, state->magic, ncclSocketTypeBootstrap, state->abortFlag), ret, fail);
+  struct socketAckInfo ack = (struct socketAckInfo){state->rank, tag};
+  NCCLCHECKGOTO(ncclSocketInit(sock, state->peerP2pAddresses + peer, state->magic, ncclSocketTypeBootstrap,
+                               state->abortFlag),
+                ret, fail);
   NCCLCHECKGOTO(ncclSocketConnect(sock), ret, fail);
   NCCLCHECKGOTO(socketSend(sock, &ack, sizeof(struct socketAckInfo)), ret, fail);
   return ncclSuccess;
@@ -1465,7 +1500,8 @@ static ncclResult_t unexpectedEnqueue(struct bootstrapState* state, int peer, in
   list->next = unex;
   return ncclSuccess;
 }
-static ncclResult_t unexpectedDequeue(struct bootstrapState* state, int peer, int tag, struct ncclSocket* sock, int* found) {
+static ncclResult_t unexpectedDequeue(struct bootstrapState* state, int peer, int tag, struct ncclSocket* sock,
+                                      int* found) {
   struct unexConn* elem = state->unexpectedConnections;
   struct unexConn* prev = NULL;
   *found = 0;
@@ -1532,14 +1568,15 @@ ncclResult_t bootstrapRecv(void* commState, int peer, int tag, void* data, int s
   NCCLCHECK(socketAccept(commState, peer, tag, &sock));
   TRACE(NCCL_BOOTSTRAP, "Receiving tag=%d peer=%d size=%d", tag, peer, size);
   NCCLCHECKGOTO(socketRecv(&sock, ((char*)data), size), ret, fail);
-  NCCLCHECKGOTO(ncclSocketClose(&sock, /*wait*/true), ret, fail);
+  NCCLCHECKGOTO(ncclSocketClose(&sock, /*wait*/ true), ret, fail);
   return ret;
 fail:
   (void)ncclSocketClose(&sock);
   return ret;
 }
 
-static ncclResult_t netRingAllGather(ncclNet_t* net, void* sendComm, void* recvComm, int rank, int nranks, char* data, int size, volatile uint32_t* abortFlag) {
+static ncclResult_t netRingAllGather(ncclNet_t* net, void* sendComm, void* recvComm, int rank, int nranks, char* data,
+                                     int size, volatile uint32_t* abortFlag) {
   ncclResult_t res;
   uint64_t tFirst = 0, tRest = 0;
   void* sendDataHandle = NULL;
@@ -1558,14 +1595,17 @@ static ncclResult_t netRingAllGather(ncclNet_t* net, void* sendComm, void* recvC
     size_t sslice = (rank - i + nranks) % nranks;
     void* recv_data = data + rslice * size;
     void* send_data = data + sslice * size;
-    NCCLCHECKGOTO(netSendRecv(net, sendComm, send_data, size, sendDataHandle, recvComm, recv_data, size, recvDataHandle, tag, abortFlag), res, exit);
+    NCCLCHECKGOTO(netSendRecv(net, sendComm, send_data, size, sendDataHandle, recvComm, recv_data, size, recvDataHandle,
+                              tag, abortFlag),
+                  res, exit);
     if (i == 0) {
       BOOTSTRAP_PROF_CLOSE(tFirst);
       BOOTSTRAP_PROF_OPEN(tRest);
     }
   }
   BOOTSTRAP_PROF_CLOSE(tRest);
-  TRACE(NCCL_BOOTSTRAP | NCCL_PROFILE, "netRingAllGather first message in %f (%f MB/sec), rest in %f (%f MB/sec)", tFirst / 1e9, (size / 1e6) / (tFirst / 1e9), tRest / 1e9, (nranks - 1) * (size / 1e6) / (tRest / 1e9));
+  TRACE(NCCL_BOOTSTRAP | NCCL_PROFILE, "netRingAllGather first message in %f (%f MB/sec), rest in %f (%f MB/sec)",
+        tFirst / 1e9, (size / 1e6) / (tFirst / 1e9), tRest / 1e9, (nranks - 1) * (size / 1e6) / (tRest / 1e9));
 exit:
   // do not fail in case of error, try to deregister as much as possible
   if (sendDataHandle) netDereg(net, sendComm, &sendDataHandle);
@@ -1574,7 +1614,8 @@ exit:
 }
 // Classic unidirectional ring AllGather over the socket OOB path (N-1 rounds).
 // Used when BOOTSTRAP_BIDIR_ALLGATHER=0 is set explicitly.
-static ncclResult_t socketRingAllGatherUnidir(struct ncclSocket* sendSock, struct ncclSocket* recvSock, int rank, int nranks, char* data, int size) {
+static ncclResult_t socketRingAllGatherUnidir(struct ncclSocket* sendSock, struct ncclSocket* recvSock, int rank,
+                                              int nranks, char* data, int size) {
   ncclResult_t res = ncclSuccess;
   uint64_t tFirst = 0, tRest = 0;
   TRACE(NCCL_BOOTSTRAP, "socketRingAllGatherUnidir started");
@@ -1591,7 +1632,9 @@ static ncclResult_t socketRingAllGatherUnidir(struct ncclSocket* sendSock, struc
     }
   }
   BOOTSTRAP_PROF_CLOSE(tRest);
-  TRACE(NCCL_BOOTSTRAP | NCCL_PROFILE, "socketRingAllGatherUnidir first message in %f (%f MB/sec), rest in %f (%f MB/sec)", tFirst / 1e9, (size / 1e6) / (tFirst / 1e9), tRest / 1e9, (nranks - 1) * (size / 1e6) / (tRest / 1e9));
+  TRACE(NCCL_BOOTSTRAP | NCCL_PROFILE,
+        "socketRingAllGatherUnidir first message in %f (%f MB/sec), rest in %f (%f MB/sec)", tFirst / 1e9,
+        (size / 1e6) / (tFirst / 1e9), tRest / 1e9, (nranks - 1) * (size / 1e6) / (tRest / 1e9));
 exit:
   return res;
 }
@@ -1600,8 +1643,8 @@ exit:
 // (TCP is full-duplex). Algorithmic ⌊N/2⌋ steps vs N-1 for unidirectional
 // (for even N the final step is single-directional, so total slices == N-1
 // in both even and odd cases).
-static ncclResult_t socketRingAllGather(struct ncclSocket* nextSock, struct ncclSocket* prevSock,
-                                        int rank, int nranks, char* data, int size) {
+static ncclResult_t socketRingAllGather(struct ncclSocket* nextSock, struct ncclSocket* prevSock, int rank, int nranks,
+                                        char* data, int size) {
   ncclResult_t res = ncclSuccess;
   uint64_t tFirst = 0, tRest = 0;
   TRACE(NCCL_BOOTSTRAP, "socketRingAllGather started: rank=%d nranks=%d", rank, nranks);
@@ -1614,14 +1657,14 @@ static ncclResult_t socketRingAllGather(struct ncclSocket* nextSock, struct nccl
     int sendSliceRing1 = (rank + step) % nranks;
     int recvSliceRing1 = (rank + step + 1) % nranks;
     if (isFinalUnidirectional) {
-      NCCLCHECKGOTO(socketSendRecv(nextSock, data + sendSliceRing0 * size, size, prevSock, data + recvSliceRing0 * size, size), res, exit);
+      NCCLCHECKGOTO(socketSendRecv(nextSock, data + sendSliceRing0 * size, size, prevSock, data + recvSliceRing0 * size,
+                                   size),
+                    res, exit);
     } else {
-      struct ncclSocketOp ops[4] = {
-        {NCCL_SOCKET_SEND, nextSock, data + sendSliceRing0 * size, size, 0},
-        {NCCL_SOCKET_RECV, prevSock, data + recvSliceRing0 * size, size, 0},
-        {NCCL_SOCKET_SEND, prevSock, data + sendSliceRing1 * size, size, 0},
-        {NCCL_SOCKET_RECV, nextSock, data + recvSliceRing1 * size, size, 0}
-      };
+      struct ncclSocketOp ops[4] = {{NCCL_SOCKET_SEND, nextSock, data + sendSliceRing0 * size, size, 0},
+                                    {NCCL_SOCKET_RECV, prevSock, data + recvSliceRing0 * size, size, 0},
+                                    {NCCL_SOCKET_SEND, prevSock, data + sendSliceRing1 * size, size, 0},
+                                    {NCCL_SOCKET_RECV, nextSock, data + recvSliceRing1 * size, size, 0}};
       NCCLCHECKGOTO(socketDoubleSendRecv(ops), res, exit);
     }
     if (step == 0) {
@@ -1635,7 +1678,8 @@ static ncclResult_t socketRingAllGather(struct ncclSocket* nextSock, struct nccl
   // payload, just split across one vs two directions). For the first-step bandwidth we count
   // the two slices actually delivered in that step (vs one in the unidir variant), otherwise
   // the bidir "first MB/sec" would read as half of the true rate.
-  TRACE(NCCL_BOOTSTRAP | NCCL_PROFILE, "socketRingAllGather first message in %f (%f MB/sec), rest in %f (%f MB/sec)", tFirst / 1e9, (2.0 * size / 1e6) / (tFirst / 1e9), tRest / 1e9, (nranks - 1) * (size / 1e6) / (tRest / 1e9));
+  TRACE(NCCL_BOOTSTRAP | NCCL_PROFILE, "socketRingAllGather first message in %f (%f MB/sec), rest in %f (%f MB/sec)",
+        tFirst / 1e9, (2.0 * size / 1e6) / (tFirst / 1e9), tRest / 1e9, (nranks - 1) * (size / 1e6) / (tRest / 1e9));
 exit:
   return res;
 }
@@ -1659,10 +1703,8 @@ exit:
 //   race on memory.
 // - On any failure we still attempt to dereg every successfully-registered handle
 //   to avoid leaking pinned host memory.
-static ncclResult_t netBiDirRingAllGather(ncclNet_t* net,
-                                          void* sendComm, void* recvComm,
-                                          void* revSendComm, void* revRecvComm,
-                                          int rank, int nranks, char* data, int size,
+static ncclResult_t netBiDirRingAllGather(ncclNet_t* net, void* sendComm, void* recvComm, void* revSendComm,
+                                          void* revRecvComm, int rank, int nranks, char* data, int size,
                                           volatile uint32_t* abortFlag) {
   ncclResult_t res = ncclSuccess;
   uint64_t tFirst = 0, tRest = 0;
@@ -1680,25 +1722,25 @@ static ncclResult_t netBiDirRingAllGather(ncclNet_t* net,
   BOOTSTRAP_PROF_OPEN(tFirst);
   for (int step = 0; step < totalSteps; step++) {
     bool isFinalUnidirectional = (step == totalSteps - 1) && (nranks % 2 == 0);
-    int sendSliceRing0 = (rank - step + nranks) % nranks;     // Ring0 send to next
+    int sendSliceRing0 = (rank - step + nranks) % nranks; // Ring0 send to next
     int recvSliceRing0 = (rank - step - 1 + nranks) % nranks; // Ring0 recv from prev
-    int sendSliceRing1 = (rank + step) % nranks;              // Ring1 send to prev
-    int recvSliceRing1 = (rank + step + 1) % nranks;          // Ring1 recv from next
+    int sendSliceRing1 = (rank + step) % nranks; // Ring1 send to prev
+    int recvSliceRing1 = (rank + step + 1) % nranks; // Ring1 recv from next
     if (isFinalUnidirectional) {
       // Final step on even N: only ring0 over the forward QP pair.
-      res = netSendRecv(net, sendComm, data + sendSliceRing0 * size, size, sendH,
-                        recvComm, data + recvSliceRing0 * size, size, recvH,
-                        /*tag*/step, abortFlag);
+      res = netSendRecv(net, sendComm, data + sendSliceRing0 * size, size, sendH, recvComm,
+                        data + recvSliceRing0 * size, size, recvH,
+                        /*tag*/ step, abortFlag);
     } else {
       // Bidirectional step: 4 in-flight ops driven by single-threaded round-robin polling.
       // Tags are kept identical inside one MultiOp call (each comm has its own tag space
       // on IB; collisions between forward/reverse are impossible because they live on
       // different QPs).
       struct ncclNetOp ops[4] = {
-        {NCCL_NET_OP_SEND, sendComm,    data + sendSliceRing0 * size, size, sendH,    /*tag*/step, NULL, 0},
-        {NCCL_NET_OP_RECV, recvComm,    data + recvSliceRing0 * size, size, recvH,    /*tag*/step, NULL, 0},
-        {NCCL_NET_OP_SEND, revSendComm, data + sendSliceRing1 * size, size, revSendH, /*tag*/step, NULL, 0},
-        {NCCL_NET_OP_RECV, revRecvComm, data + recvSliceRing1 * size, size, revRecvH, /*tag*/step, NULL, 0}
+        {NCCL_NET_OP_SEND, sendComm, data + sendSliceRing0 * size, size, sendH, /*tag*/ step, NULL, 0},
+        {NCCL_NET_OP_RECV, recvComm, data + recvSliceRing0 * size, size, recvH, /*tag*/ step, NULL, 0},
+        {NCCL_NET_OP_SEND, revSendComm, data + sendSliceRing1 * size, size, revSendH, /*tag*/ step, NULL, 0},
+        {NCCL_NET_OP_RECV, revRecvComm, data + recvSliceRing1 * size, size, revRecvH, /*tag*/ step, NULL, 0}
       };
       res = netMultiOp(net, ops, 4, abortFlag);
     }
@@ -1712,14 +1754,13 @@ static ncclResult_t netBiDirRingAllGather(ncclNet_t* net,
   // Numerator convention matches socketRingAllGather: per-rank useful AllGather payload
   // (N-1 slices), so the metric is comparable across unidir/bidir variants. First-step
   // numerator is 2*size because the first bidir step delivers two slices (one per direction).
-  TRACE(NCCL_BOOTSTRAP | NCCL_PROFILE,
-        "netBiDirRingAllGather first message in %f (%f MB/sec), rest in %f (%f MB/sec)",
+  TRACE(NCCL_BOOTSTRAP | NCCL_PROFILE, "netBiDirRingAllGather first message in %f (%f MB/sec), rest in %f (%f MB/sec)",
         tFirst / 1e9, (2.0 * size / 1e6) / (tFirst / 1e9), tRest / 1e9, (nranks - 1) * (size / 1e6) / (tRest / 1e9));
 
 cleanup:
   // Best-effort cleanup: try every dereg even if some failed (avoids leaking pinned memory).
-  if (sendH)    netDereg(net, sendComm,    &sendH);
-  if (recvH)    netDereg(net, recvComm,    &recvH);
+  if (sendH) netDereg(net, sendComm, &sendH);
+  if (recvH) netDereg(net, recvComm, &recvH);
   if (revSendH) netDereg(net, revSendComm, &revSendH);
   if (revRecvH) netDereg(net, revRecvComm, &revRecvH);
   return res;
@@ -1739,35 +1780,39 @@ ncclResult_t bootstrapAllGather(void* commState, void* allData, int size) {
     // Take the bidirectional path only when bootstrapBidirEnabled() agrees AND the
     // reverse comms were actually set up (defensive against future code paths that
     // may bypass bootstrapBidirRingSetup, e.g. shrunk/split comms).
-    bool useBidir = bootstrapBidirEnabled(nranks, 1)
-                    && STATE_RING(state, net.revSendComm) != NULL
-                    && STATE_RING(state, net.revRecvComm) != NULL;
+    bool useBidir = bootstrapBidirEnabled(nranks, 1) && STATE_RING(state, net.revSendComm) != NULL &&
+                    STATE_RING(state, net.revRecvComm) != NULL;
     if (useBidir) {
-      NCCLCHECKGOTO(netBiDirRingAllGather(state->net,
-                                          STATE_RING(state, net.sendComm), STATE_RING(state, net.recvComm),
-                                          STATE_RING(state, net.revSendComm), STATE_RING(state, net.revRecvComm),
-                                          rank, nranks, (char*)allData, size, state->abortFlag), res, exit);
+      NCCLCHECKGOTO(netBiDirRingAllGather(state->net, STATE_RING(state, net.sendComm), STATE_RING(state, net.recvComm),
+                                          STATE_RING(state, net.revSendComm), STATE_RING(state, net.revRecvComm), rank,
+                                          nranks, (char*)allData, size, state->abortFlag),
+                    res, exit);
     } else {
-      NCCLCHECKGOTO(netRingAllGather(state->net, STATE_RING(state, net.sendComm), STATE_RING(state, net.recvComm), rank, nranks, (char*)allData, size, state->abortFlag), res, exit);
+      NCCLCHECKGOTO(netRingAllGather(state->net, STATE_RING(state, net.sendComm), STATE_RING(state, net.recvComm), rank,
+                                     nranks, (char*)allData, size, state->abortFlag),
+                    res, exit);
     }
   } else {
     if (bootstrapBidirEnabled(nranks, 0)) {
-      NCCLCHECKGOTO(socketRingAllGather(&STATE_RING(state, socket.send), &STATE_RING(state, socket.recv),
-                                        rank, nranks, (char*)allData, size), res, exit);
+      NCCLCHECKGOTO(socketRingAllGather(&STATE_RING(state, socket.send), &STATE_RING(state, socket.recv), rank, nranks,
+                                        (char*)allData, size),
+                    res, exit);
     } else {
-      NCCLCHECKGOTO(socketRingAllGatherUnidir(&STATE_RING(state, socket.send), &STATE_RING(state, socket.recv), rank, nranks, (char*)allData, size), res, exit);
+      NCCLCHECKGOTO(socketRingAllGatherUnidir(&STATE_RING(state, socket.send), &STATE_RING(state, socket.recv), rank,
+                                              nranks, (char*)allData, size),
+                    res, exit);
     }
   }
 exit:
   BOOTSTRAP_PROF_CLOSE(time);
-  TRACE(NCCL_BOOTSTRAP | NCCL_PROFILE, "bootstrapAllGather for %d B done in %f sec: %f MB/sec", size, time / 1e9, ((size_t)nranks * size / 1e6) / (time / 1e9));
+  TRACE(NCCL_BOOTSTRAP | NCCL_PROFILE, "bootstrapAllGather for %d B done in %f sec: %f MB/sec", size, time / 1e9,
+        ((size_t)nranks * size / 1e6) / (time / 1e9));
   TRACE(NCCL_BOOTSTRAP, "rank %d nranks %d size %d - AllGather DONE", rank, nranks, size);
   return res;
 }
 
 static ncclResult_t bootstrapP2PBarrier(void* commState, int* ranks, int rank, int nranks, int tag) {
-  if (nranks == 1)
-    return ncclSuccess;
+  if (nranks == 1) return ncclSuccess;
   /* Simple [intra] process barrier
    *
    * Based on the dissemination algorithm by Debra Hensgen, Raphael Finkel, and Udi Manbet,
@@ -1831,24 +1876,29 @@ ncclResult_t bootstrapIntraNodeAllGather(void* commState, int* ranks, int rank, 
 }
 
 // [IntraNode] in-place Broadcast
-static ncclResult_t bootstrapP2PBroadcast(void* commState, int* ranks, int rank, int nranks, int root, void* bcastData, int size) {
+static ncclResult_t bootstrapP2PBroadcast(void* commState, int* ranks, int rank, int nranks, int root, void* bcastData,
+                                          int size) {
   if (nranks == 1) return ncclSuccess;
   if (rank == root) {
     for (int i = 0; i < nranks; i++) {
-      if (i != root) NCCLCHECK(bootstrapSend(commState, ranks ? ranks[i] : i, /*tag=*/ranks ? ranks[i] : i, bcastData, size));
+      if (i != root)
+        NCCLCHECK(bootstrapSend(commState, ranks ? ranks[i] : i, /*tag=*/ranks ? ranks[i] : i, bcastData, size));
     }
   } else {
-    NCCLCHECK(bootstrapRecv(commState, ranks ? ranks[root] : root, /*tag=*/ranks ? ranks[rank] : rank, bcastData, size));
+    NCCLCHECK(bootstrapRecv(commState, ranks ? ranks[root] : root, /*tag=*/ranks ? ranks[rank] : rank, bcastData,
+                            size));
   }
   return ncclSuccess;
 }
 
-ncclResult_t bootstrapIntraNodeBroadcast(void* commState, int* ranks, int rank, int nranks, int root, void* bcastData, int size) {
+ncclResult_t bootstrapIntraNodeBroadcast(void* commState, int* ranks, int rank, int nranks, int root, void* bcastData,
+                                         int size) {
   uint64_t time = 0;
   BOOTSTRAP_PROF_OPEN(time);
   NCCLCHECK(bootstrapP2PBroadcast(commState, ranks, rank, nranks, root, bcastData, size));
   BOOTSTRAP_PROF_CLOSE(time);
-  TRACE(NCCL_BOOTSTRAP | NCCL_PROFILE, "bootstrapIntraNodeBroadcast for %d B done in %f sec: %f MB/sec", size, time / 1e9, ((size_t)nranks * size / 1e6) / (time / 1e9));
+  TRACE(NCCL_BOOTSTRAP | NCCL_PROFILE, "bootstrapIntraNodeBroadcast for %d B done in %f sec: %f MB/sec", size,
+        time / 1e9, ((size_t)nranks * size / 1e6) / (time / 1e9));
   return ncclSuccess;
 }
 ncclResult_t bootstrapBroadcast(void* commState, int rank, int nranks, int root, void* bcastData, int size) {
@@ -1861,8 +1911,7 @@ ncclResult_t bootstrapBroadcast(void* commState, int rank, int nranks, int root,
 }
 
 ncclResult_t bootstrapClose(void* commState) {
-  if (commState == NULL)
-    return ncclSuccess;
+  if (commState == NULL) return ncclSuccess;
   struct bootstrapState* state = (struct bootstrapState*)commState;
   int nranks = state->nranks;
   // close unexpected and return an error if we are not aborting and still operations in the pipe
@@ -1880,7 +1929,7 @@ ncclResult_t bootstrapClose(void* commState) {
     // Reverse-direction net comms only exist when bidirectional bootstrap was enabled.
     if (STATE_RING(state, net.revSendComm)) NCCLCHECK(state->net->closeSend(STATE_RING(state, net.revSendComm)));
     if (STATE_RING(state, net.revRecvComm)) NCCLCHECK(state->net->closeRecv(STATE_RING(state, net.revRecvComm)));
-    if (STATE_LISTEN(state, net.revComm))   NCCLCHECK(state->net->closeListen(STATE_LISTEN(state, net.revComm)));
+    if (STATE_LISTEN(state, net.revComm)) NCCLCHECK(state->net->closeListen(STATE_LISTEN(state, net.revComm)));
   } else {
     NCCLCHECK(ncclSocketClose(&STATE_RING(state, socket.send)));
     NCCLCHECK(ncclSocketClose(&STATE_RING(state, socket.recv)));
@@ -1896,8 +1945,7 @@ ncclResult_t bootstrapClose(void* commState) {
 }
 
 ncclResult_t bootstrapAbort(void* commState) {
-  if (commState == NULL)
-    return ncclSuccess;
+  if (commState == NULL) return ncclSuccess;
   struct bootstrapState* state = (struct bootstrapState*)commState;
   // when aborting we need to close the proxy here (maybe?)
   free(state->peerProxyAddresses);

--- a/projects/rccl/src/ce_coll.cc
+++ b/projects/rccl/src/ce_coll.cc
@@ -50,7 +50,8 @@ static int ncclCeBatchAsyncEnable() {
   int supported = ncclCeBatchAsyncSupported();
   if (param > 0 && !supported) {
     if (!warnedUnsupported.exchange(true))
-      WARN("RCCL_CE_BATCH_ASYNC_ENABLE=1 is set but hipMemcpyBatchAsync is not supported at runtime; disabling CE batch path");
+      WARN("RCCL_CE_BATCH_ASYNC_ENABLE=1 is set but hipMemcpyBatchAsync is not supported at runtime; disabling CE "
+           "batch path");
     return 0;
   }
   return param >= 0 ? param : (param == -2 && supported);
@@ -67,7 +68,7 @@ static const uint32_t GRAPH_SYNC_VALUE = 1;
 // Frequency of intra-batch synchronization
 static const uint32_t CE_COLL_INTRA_BATCH_SYNC_FREQ = 8;
 // Message threshold for intra-batch synchronization
-static const uint64_t CE_COLL_INTRA_BATCH_SYNC_MSG_THRESHOLD = 512*1024*1024;
+static const uint64_t CE_COLL_INTRA_BATCH_SYNC_MSG_THRESHOLD = 512 * 1024 * 1024;
 
 static void ceDestroyCopyStreams(struct ncclComm* comm, int nPairs) {
   for (int j = 0; j < nPairs; j++) {
@@ -85,7 +86,7 @@ ncclResult_t ncclCeInit(struct ncclComm* comm) {
 #endif
 
   uint8_t* ceDevBase = nullptr;
-  size_t ceDevBaseSize = alignUp(comm->nRanks*sizeof(uint32_t), 16) * 2;
+  size_t ceDevBaseSize = alignUp(comm->nRanks * sizeof(uint32_t), 16) * 2;
   ncclWindow_vidmem* ceWinDev = nullptr;
   ncclWindow_vidmem* ceWinDevHost = nullptr;
   int i = 0;
@@ -94,13 +95,14 @@ ncclResult_t ncclCeInit(struct ncclComm* comm) {
   NCCLCHECKGOTO(ncclDevrInitOnce(comm), ret, fail);
   // Allocate and register memory for the symmetric memory
   NCCLCHECKGOTO(ncclMemAlloc((void**)&ceDevBase, ceDevBaseSize), ret, fail);
-  NCCLCHECKGOTO(ncclDevrWindowRegisterInGroup(comm, ceDevBase, ceDevBaseSize, NCCL_WIN_COLL_SYMMETRIC, &ceWinDev), ret, fail);
+  NCCLCHECKGOTO(ncclDevrWindowRegisterInGroup(comm, ceDevBase, ceDevBaseSize, NCCL_WIN_COLL_SYMMETRIC, &ceWinDev), ret,
+                fail);
   NCCLCHECKGOTO(ncclShadowPoolToHost(&comm->devrState.shadows, ceWinDev, &ceWinDevHost), ret, fail);
   // Get the ncclDevrWindow from the winHost field
   comm->ceColl.ceSyncWin = (struct ncclDevrWindow*)ceWinDevHost->winHost;
 
   comm->ceColl.baseUCSymReadyOffset = 0;
-  comm->ceColl.baseUCSymComplOffset = alignUp(comm->nRanks*sizeof(uint32_t), 16);
+  comm->ceColl.baseUCSymComplOffset = alignUp(comm->nRanks * sizeof(uint32_t), 16);
   comm->ceColl.baseUCSymReadyPtr = (uint8_t*)comm->ceColl.ceSyncWin->userPtr + comm->ceColl.baseUCSymReadyOffset;
   comm->ceColl.baseUCSymComplPtr = (uint8_t*)comm->ceColl.ceSyncWin->userPtr + comm->ceColl.baseUCSymComplOffset;
   comm->ceColl.ceSeqNum = 0;
@@ -108,15 +110,19 @@ ncclResult_t ncclCeInit(struct ncclComm* comm) {
   comm->ceColl.intraBatchSyncFreq = CE_COLL_INTRA_BATCH_SYNC_FREQ;
   comm->ceColl.intraBatchSyncMsgThreshold = CE_COLL_INTRA_BATCH_SYNC_MSG_THRESHOLD;
   comm->ceColl.nCopyStreams = 0;
-  INFO(NCCL_INIT, "Init CE, rank %d baseUCSymReadyPtr %p, baseUCSymComplPtr %p, seq num %d", comm->rank, comm->ceColl.baseUCSymReadyPtr, comm->ceColl.baseUCSymComplPtr, comm->ceColl.ceSeqNum);
+  INFO(NCCL_INIT, "Init CE, rank %d baseUCSymReadyPtr %p, baseUCSymComplPtr %p, seq num %d", comm->rank,
+       comm->ceColl.baseUCSymReadyPtr, comm->ceColl.baseUCSymComplPtr, comm->ceColl.ceSeqNum);
   {
     int multiStreams = rcclParamCeMultiStreams();
     if (multiStreams > 0) {
       targetStreams = std::min(multiStreams, (int)RCCL_CE_NUM_COPY_STREAMS);
-      INFO(NCCL_INIT, "CE multi-stream enabled: rank %d using %d streams (requested=%d)", comm->rank, targetStreams, multiStreams);
+      INFO(NCCL_INIT, "CE multi-stream enabled: rank %d using %d streams (requested=%d)", comm->rank, targetStreams,
+           multiStreams);
       for (i = 0; i < targetStreams; i++) {
-        CUDACHECKGOTO(cudaStreamCreateWithFlags(&comm->ceColl.copyStreams[i], cudaStreamNonBlocking), ret, fail_ce_stream);
-        CUDACHECKGOTO(cudaEventCreateWithFlags(&comm->ceColl.copyEvents[i], cudaEventDisableTiming), ret, fail_ce_event);
+        CUDACHECKGOTO(cudaStreamCreateWithFlags(&comm->ceColl.copyStreams[i], cudaStreamNonBlocking), ret,
+                      fail_ce_stream);
+        CUDACHECKGOTO(cudaEventCreateWithFlags(&comm->ceColl.copyEvents[i], cudaEventDisableTiming), ret,
+                      fail_ce_event);
         comm->ceColl.nCopyStreams++;
       }
     }
@@ -158,7 +164,6 @@ ncclResult_t ncclCeFinalize(struct ncclComm* comm) {
   // Clean up copy streams and events
   ceDestroyCopyStreams(comm, comm->ceColl.nCopyStreams);
 
-
 exit:
   return ret;
 fail:
@@ -168,9 +173,10 @@ fail:
   goto exit;
 }
 
-bool ncclCeImplemented(ncclFunc_t coll, int/*ncclDevRedOp_t*/ red, ncclDataType_t ty);
+bool ncclCeImplemented(ncclFunc_t coll, int /*ncclDevRedOp_t*/ red, ncclDataType_t ty);
 
-bool ncclCeAvailable(struct ncclComm* comm, ncclFunc_t coll, int/*ncclDevRedOp_t*/ red, ncclDataType_t ty, ncclSymRegType_t winRegType) {
+bool ncclCeAvailable(struct ncclComm* comm, ncclFunc_t coll, int /*ncclDevRedOp_t*/ red, ncclDataType_t ty,
+                     ncclSymRegType_t winRegType) {
   if (!ncclCeImplemented(coll, red, ty)) {
     TRACE(NCCL_TUNING, "Skipping CE collective: not implemented");
     return false;
@@ -190,7 +196,7 @@ bool ncclCeAvailable(struct ncclComm* comm, ncclFunc_t coll, int/*ncclDevRedOp_t
   return true;
 }
 
-bool ncclCeImplemented(ncclFunc_t coll, int/*ncclDevRedOp_t*/ red, ncclDataType_t ty) {
+bool ncclCeImplemented(ncclFunc_t coll, int /*ncclDevRedOp_t*/ red, ncclDataType_t ty) {
   int driverVersion;
   if (ncclCudaDriverVersion(&driverVersion) != ncclSuccess) return false;
 
@@ -213,10 +219,11 @@ bool ncclCeImplemented(ncclFunc_t coll, int/*ncclDevRedOp_t*/ red, ncclDataType_
   return false;
 }
 
-ncclResult_t ncclPrepMCSync(struct ncclComm* comm, bool isComplete, hipStreamBatchMemOpParams* batchParams, size_t* opIdx, cudaStream_t stream) {
+ncclResult_t ncclPrepMCSync(struct ncclComm* comm, bool isComplete, hipStreamBatchMemOpParams* batchParams,
+                            size_t* opIdx, cudaStream_t stream) {
   ncclResult_t ret = ncclSuccess;
 
-  uint32_t* readyPtrs    = (uint32_t*)comm->ceColl.baseUCSymReadyPtr;
+  uint32_t* readyPtrs = (uint32_t*)comm->ceColl.baseUCSymReadyPtr;
   uint32_t* completePtrs = (uint32_t*)comm->ceColl.baseUCSymComplPtr;
 
   bool capturing = ncclCudaGraphValid(comm->planner.capturingGraph);
@@ -234,12 +241,7 @@ ncclResult_t ncclPrepMCSync(struct ncclComm* comm, bool isComplete, hipStreamBat
   NCCLCHECKGOTO(ncclDevrGetLsaTeamPtrMC(comm, comm->ceColl.ceSyncWin, offset, ncclTeamLsa(comm), &mcDstPtr), ret, fail);
 
   // Write our own ready/complete flag to the multi-cast address
-  CUDACHECKGOTO(cudaMemcpyAsync(
-    mcDstPtr,
-    srcPtr,
-    sizeof(uint32_t),
-    cudaMemcpyHostToDevice,
-    stream), ret, fail);
+  CUDACHECKGOTO(cudaMemcpyAsync(mcDstPtr, srcPtr, sizeof(uint32_t), cudaMemcpyHostToDevice, stream), ret, fail);
 
   // Add local wait operations for every other rank
   for (int r = 0; r < comm->nRanks; ++r) {
@@ -258,16 +260,15 @@ fail:
   goto exit;
 }
 
-ncclResult_t ncclPrepUCSync(struct ncclComm* comm, bool isComplete,
-                               hipStreamBatchMemOpParams* batchParams,
-                               size_t* opIdx) {
+ncclResult_t ncclPrepUCSync(struct ncclComm* comm, bool isComplete, hipStreamBatchMemOpParams* batchParams,
+                            size_t* opIdx) {
   ncclResult_t ret = ncclSuccess;
 
 #ifdef ENABLE_FAULT_INJECTION
   NCCLCHECK(ceFaultCheck(comm, CE_FAULT_SYNC_PREP, "ncclPrepUCSync"));
 #endif
 
-  uint32_t* readyPtrs    = (uint32_t*)comm->ceColl.baseUCSymReadyPtr;
+  uint32_t* readyPtrs = (uint32_t*)comm->ceColl.baseUCSymReadyPtr;
   uint32_t* completePtrs = (uint32_t*)comm->ceColl.baseUCSymComplPtr;
 
   bool capturing = ncclCudaGraphValid(comm->planner.capturingGraph);
@@ -277,13 +278,13 @@ ncclResult_t ncclPrepUCSync(struct ncclComm* comm, bool isComplete,
   uint32_t waitValue = capturing ? GRAPH_SYNC_VALUE : currentSeq;
   for (int r = 0; r < comm->nRanks; ++r) {
     if (r == comm->rank) continue;
-    void * peerDstPtr;
+    void* peerDstPtr;
     void* dstPtr = isComplete ? (void*)&completePtrs[comm->rank] : (void*)&readyPtrs[comm->rank];
     size_t offset = (uint8_t*)dstPtr - (uint8_t*)comm->ceColl.ceSyncWin->userPtr;
     NCCLCHECKGOTO(ncclDevrGetLsaRankPtr(comm, comm->ceColl.ceSyncWin, offset, r, &peerDstPtr), ret, fail);
     batchParams[*opIdx] = {};
     batchParams[*opIdx].writeValue.operation = CU_STREAM_MEM_OP_WRITE_VALUE_32;
-    batchParams[*opIdx].writeValue.address  = (CUdeviceptr)peerDstPtr;
+    batchParams[*opIdx].writeValue.address = (CUdeviceptr)peerDstPtr;
     batchParams[*opIdx].writeValue.value = waitValue;
     batchParams[*opIdx].writeValue.flags = CU_STREAM_WRITE_VALUE_DEFAULT;
     (*opIdx)++;
@@ -294,7 +295,7 @@ ncclResult_t ncclPrepUCSync(struct ncclComm* comm, bool isComplete,
     if (r == comm->rank) continue;
     batchParams[*opIdx] = {};
     batchParams[*opIdx].waitValue.operation = CU_STREAM_MEM_OP_WAIT_VALUE_32;
-    batchParams[*opIdx].waitValue.address  = (CUdeviceptr)(isComplete ? (void*)&completePtrs[r] : (void*)&readyPtrs[r]);
+    batchParams[*opIdx].waitValue.address = (CUdeviceptr)(isComplete ? (void*)&completePtrs[r] : (void*)&readyPtrs[r]);
     batchParams[*opIdx].waitValue.value = capturing ? GRAPH_SYNC_VALUE : currentSeq;
     batchParams[*opIdx].waitValue.flags = CU_STREAM_WAIT_VALUE_EQ;
     (*opIdx)++;
@@ -305,7 +306,6 @@ exit:
 fail:
   goto exit;
 }
-
 
 ncclResult_t ncclMemOpSync(struct ncclComm* comm, struct ncclCeCollArgs* args, cudaStream_t stream) {
   ncclResult_t ret = ncclSuccess;
@@ -334,7 +334,8 @@ ncclResult_t ncclMemOpSync(struct ncclComm* comm, struct ncclCeCollArgs* args, c
     for (int i = 0; i < comm->nRanks; i++) {
       batchParams[opIdx] = {};
       batchParams[opIdx].writeValue.operation = CU_STREAM_MEM_OP_WRITE_VALUE_32;
-      batchParams[opIdx].writeValue.address = (CUdeviceptr)(comm->ceColl.useCompletePtr ? (void*)&completePtrs[i] : (void*)&readyPtrs[i]);
+      batchParams[opIdx].writeValue.address =
+        (CUdeviceptr)(comm->ceColl.useCompletePtr ? (void*)&completePtrs[i] : (void*)&readyPtrs[i]);
       batchParams[opIdx].writeValue.value = 0;
       // CU_STREAM_WRITE_VALUE_DEFAULT is a CUDA-specific constant with no HIP equivalent.
       // This field must be initialized to satisfy the CUDA-compatible struct definition,
@@ -410,8 +411,7 @@ ncclResult_t ncclCeLaunchBatchOps(struct ncclComm* comm, struct ncclCeCollArgs* 
   NCCLCHECKGOTO(ncclCudaStreamIsLegacyNull(stream, &isLegacyStream), ret, fail);
 
   // Start CE batch profiling
-  NCCLCHECKGOTO(ncclProfilerStartCeBatchEvent(comm, args, params, stream, &ceBatchHandle),
-                ret, fail);
+  NCCLCHECKGOTO(ncclProfilerStartCeBatchEvent(comm, args, params, stream, &ceBatchHandle), ret, fail);
 
   // Check if there are any operations to perform
   if (params->numOps == 0) goto exit;
@@ -423,15 +423,12 @@ ncclResult_t ncclCeLaunchBatchOps(struct ncclComm* comm, struct ncclCeCollArgs* 
   // cudaMemcpyBatchAsync is not supported during CUDA graph capture or with the
   // legacy null stream (e.g. PyTorch's null stream); fall back to per-op cudaMemcpyAsync.
   if (capturing || isLegacyStream) {
-    for (int i =0; i < params->numOps; i++) {
-      CUDACHECKGOTO(cudaMemcpyAsync(
-        (void*)params->dsts[i],
-        (void*)params->srcs[i],
-        params->sizes[i],
-        cudaMemcpyDeviceToDevice,
-        stream), ret, fail);
+    for (int i = 0; i < params->numOps; i++) {
+      CUDACHECKGOTO(cudaMemcpyAsync((void*)params->dsts[i], (void*)params->srcs[i], params->sizes[i],
+                                    cudaMemcpyDeviceToDevice, stream),
+                    ret, fail);
 
-      if (params->intraBatchSync && ((i+1) % comm->ceColl.intraBatchSyncFreq == 0) && ((i+1) < params->numOps)) {
+      if (params->intraBatchSync && ((i + 1) % comm->ceColl.intraBatchSyncFreq == 0) && ((i + 1) < params->numOps)) {
         NCCLCHECKGOTO(ncclMemOpSync(comm, args, stream), ret, fail);
       }
     }
@@ -440,91 +437,94 @@ ncclResult_t ncclCeLaunchBatchOps(struct ncclComm* comm, struct ncclCeCollArgs* 
   else {
 #ifdef CE_BATCH_ASYNC_SUPPORTED
     if (ncclCeBatchAsyncEnable()) {
-    params->attrs[0] = {};
+      params->attrs[0] = {};
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-    params->attrs[0].srcAccessOrder = hipMemcpySrcAccessOrderStream;
-    params->attrs[0].flags = hipMemcpyFlagPreferOverlapWithCompute;
+      params->attrs[0].srcAccessOrder = hipMemcpySrcAccessOrderStream;
+      params->attrs[0].flags = hipMemcpyFlagPreferOverlapWithCompute;
 #else
-    params->attrs[0].srcAccessOrder = cudaMemcpySrcAccessOrderStream;
-    params->attrs[0].flags = cudaMemcpyFlagPreferOverlapWithCompute;
+      params->attrs[0].srcAccessOrder = cudaMemcpySrcAccessOrderStream;
+      params->attrs[0].flags = cudaMemcpyFlagPreferOverlapWithCompute;
 #endif
-    params->attrIdxs[0] = 0;
-    params->numAttrs = 1;
+      params->attrIdxs[0] = 0;
+      params->numAttrs = 1;
 
-    if (params->intraBatchSync) {
+      if (params->intraBatchSync) {
       // Break into multiple batches with sync between them
-      int batchSize = comm->ceColl.intraBatchSyncFreq;
-      for (int i = 0; i < params->numOps; i += batchSize) {
-        int currentBatchSize = (i + batchSize <= params->numOps) ? batchSize : params->numOps - i;
-        INFO(NCCL_COLL, "CE: rank %d -> Batch path with intraBatchSync (hipMemcpyBatchAsync, intraBatchSync), numOps=%zu, batchSize=%d", comm->rank, params->numOps, currentBatchSize);
+        int batchSize = comm->ceColl.intraBatchSyncFreq;
+        for (int i = 0; i < params->numOps; i += batchSize) {
+          int currentBatchSize = (i + batchSize <= params->numOps) ? batchSize : params->numOps - i;
+          INFO(NCCL_COLL,
+               "CE: rank %d -> Batch path with intraBatchSync (hipMemcpyBatchAsync, intraBatchSync), numOps=%zu, "
+               "batchSize=%d",
+               comm->rank, params->numOps, currentBatchSize);
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+          CUDACHECKGOTO(hipMemcpyBatchAsync(
+#else
+          CUDACHECKGOTO(cudaMemcpyBatchAsync(
+#endif
+                          (void**)&params->dsts[i], (void**)&params->srcs[i], &params->sizes[i], currentBatchSize,
+                          params->attrs, params->attrIdxs, params->numAttrs, nullptr, stream),
+                        ret, fail);
+        // Sync after each batch
+          if (i + batchSize < params->numOps) {
+            NCCLCHECKGOTO(ncclMemOpSync(comm, args, stream), ret, fail);
+          }
+        }
+      } else {
+      // Use single batch for all operations
+        INFO(NCCL_COLL, "CE: rank %d -> Batch path without intraBatchSync (hipMemcpyBatchAsync), numOps=%zu",
+             comm->rank, params->numOps);
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
         CUDACHECKGOTO(hipMemcpyBatchAsync(
 #else
         CUDACHECKGOTO(cudaMemcpyBatchAsync(
 #endif
-          (void**)&params->dsts[i], (void**)&params->srcs[i], &params->sizes[i], currentBatchSize,
-          params->attrs, params->attrIdxs, params->numAttrs, nullptr, stream), ret, fail);
-        // Sync after each batch
-        if (i + batchSize < params->numOps) {
-          NCCLCHECKGOTO(ncclMemOpSync(comm, args, stream), ret, fail);
-        }
+                        (void**)params->dsts, (void**)params->srcs, params->sizes, params->numOps, params->attrs,
+                        params->attrIdxs, params->numAttrs, nullptr, stream),
+                      ret, fail);
       }
-    } else {
-      // Use single batch for all operations
-      INFO(NCCL_COLL, "CE: rank %d -> Batch path without intraBatchSync (hipMemcpyBatchAsync), numOps=%zu", comm->rank, params->numOps);
-#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-      CUDACHECKGOTO(hipMemcpyBatchAsync(
-#else
-      CUDACHECKGOTO(cudaMemcpyBatchAsync(
-#endif
-        (void**)params->dsts, (void**)params->srcs, params->sizes, params->numOps,
-        params->attrs, params->attrIdxs, params->numAttrs, nullptr, stream), ret, fail);
-    }
     } else  // CE batch async disabled — fall through to non-batch paths below
 #endif // CE_BATCH_ASYNC_SUPPORTED
-    if (comm->ceColl.nCopyStreams > 0 && (int)params->numOps > 1 && !params->intraBatchSync) {
-      int nStreams = comm->ceColl.nCopyStreams;
-      int activeStreams = ((int)params->numOps < nStreams) ? (int)params->numOps : nStreams;
-      INFO(NCCL_COLL, "CE: rank %d -> No-Batch Multi-Stream path (%d streams), numOps=%zu", comm->rank, activeStreams, params->numOps);
+      if (comm->ceColl.nCopyStreams > 0 && (int)params->numOps > 1 && !params->intraBatchSync) {
+        int nStreams = comm->ceColl.nCopyStreams;
+        int activeStreams = ((int)params->numOps < nStreams) ? (int)params->numOps : nStreams;
+        INFO(NCCL_COLL, "CE: rank %d -> No-Batch Multi-Stream path (%d streams), numOps=%zu", comm->rank, activeStreams,
+             params->numOps);
 
       // Make copy streams wait on the main stream
-      for (int s = 0; s < activeStreams; s++) {
-        CUDACHECKGOTO(cudaEventRecord(comm->ceColl.copyEvents[s], stream), ret, fail);
-        CUDACHECKGOTO(cudaStreamWaitEvent(comm->ceColl.copyStreams[s], comm->ceColl.copyEvents[s], 0), ret, fail);
-      }
+        for (int s = 0; s < activeStreams; s++) {
+          CUDACHECKGOTO(cudaEventRecord(comm->ceColl.copyEvents[s], stream), ret, fail);
+          CUDACHECKGOTO(cudaStreamWaitEvent(comm->ceColl.copyStreams[s], comm->ceColl.copyEvents[s], 0), ret, fail);
+        }
 
       // Distribute copies round-robin across streams
-      for (int i = 0; i < (int)params->numOps; i++) {
-        int s = i % activeStreams;
-        CUDACHECKGOTO(cudaMemcpyAsync(
-          (void*)params->dsts[i],
-          (void*)params->srcs[i],
-          params->sizes[i],
-          cudaMemcpyDeviceToDevice,
-          comm->ceColl.copyStreams[s]), ret, fail);
-      }
+        for (int i = 0; i < (int)params->numOps; i++) {
+          int s = i % activeStreams;
+          CUDACHECKGOTO(cudaMemcpyAsync((void*)params->dsts[i], (void*)params->srcs[i], params->sizes[i],
+                                        cudaMemcpyDeviceToDevice, comm->ceColl.copyStreams[s]),
+                        ret, fail);
+        }
 
       // Make main stream wait on all copy streams
-      for (int s = 0; s < activeStreams; s++) {
-        CUDACHECKGOTO(cudaEventRecord(comm->ceColl.copyEvents[s], comm->ceColl.copyStreams[s]), ret, fail);
-        CUDACHECKGOTO(cudaStreamWaitEvent(stream, comm->ceColl.copyEvents[s], 0), ret, fail);
-      }
-    } else {
+        for (int s = 0; s < activeStreams; s++) {
+          CUDACHECKGOTO(cudaEventRecord(comm->ceColl.copyEvents[s], comm->ceColl.copyStreams[s]), ret, fail);
+          CUDACHECKGOTO(cudaStreamWaitEvent(stream, comm->ceColl.copyEvents[s], 0), ret, fail);
+        }
+      } else {
       // For older ROCm versions, fall back to individual transfers
-      INFO(NCCL_COLL, "CE: rank %d -> No-Batch Single-Stream path (cudaMemcpyAsync), numOps=%zu", comm->rank, params->numOps);
-      for (int i = 0; i < params->numOps; i++) {
-        CUDACHECKGOTO(cudaMemcpyAsync(
-          (void*)params->dsts[i],
-          (void*)params->srcs[i],
-          params->sizes[i],
-          cudaMemcpyDeviceToDevice,
-          stream), ret, fail);
+        INFO(NCCL_COLL, "CE: rank %d -> No-Batch Single-Stream path (cudaMemcpyAsync), numOps=%zu", comm->rank,
+             params->numOps);
+        for (int i = 0; i < params->numOps; i++) {
+          CUDACHECKGOTO(cudaMemcpyAsync((void*)params->dsts[i], (void*)params->srcs[i], params->sizes[i],
+                                        cudaMemcpyDeviceToDevice, stream),
+                        ret, fail);
 
-        if (params->intraBatchSync && ((i+1) % comm->ceColl.intraBatchSyncFreq == 0) && ((i+1) < params->numOps)) {
-          NCCLCHECKGOTO(ncclMemOpSync(comm, args, stream), ret, fail);
+          if (params->intraBatchSync && ((i + 1) % comm->ceColl.intraBatchSyncFreq == 0) &&
+              ((i + 1) < params->numOps)) {
+            NCCLCHECKGOTO(ncclMemOpSync(comm, args, stream), ret, fail);
+          }
         }
       }
-    }
   }
 
 exit:
@@ -535,9 +535,7 @@ fail:
   goto exit;
 }
 
-
-ncclResult_t ncclCeAllGather(struct ncclComm* comm, struct ncclCeCollArgs* args,
-                             cudaStream_t stream) {
+ncclResult_t ncclCeAllGather(struct ncclComm* comm, struct ncclCeCollArgs* args, cudaStream_t stream) {
   ncclResult_t ret = ncclSuccess;
   const size_t chunkBytes = args->nElts * args->eltSize;
   uint8_t* mySendBuff = (uint8_t*)args->sendBuff;
@@ -571,11 +569,11 @@ ncclResult_t ncclCeAllGather(struct ncclComm* comm, struct ncclCeCollArgs* args,
   }
 
   // Check if we need to perform intra-batch synchronization
-  batchOpsParams.intraBatchSync = (batchOpsParams.numOps > comm->ceColl.intraBatchSyncFreq && chunkBytes*batchOpsParams.numOps >= comm->ceColl.intraBatchSyncMsgThreshold);
+  batchOpsParams.intraBatchSync = (batchOpsParams.numOps > comm->ceColl.intraBatchSyncFreq &&
+                                   chunkBytes * batchOpsParams.numOps >= comm->ceColl.intraBatchSyncMsgThreshold);
 
   // Launch the batch operations
-  NCCLCHECKGOTO(ncclCeLaunchBatchOps(comm, args, &batchOpsParams, stream),
-                ret, fail);
+  NCCLCHECKGOTO(ncclCeLaunchBatchOps(comm, args, &batchOpsParams, stream), ret, fail);
 
   // Ensure all transfers are complete across all ranks
   NCCLCHECKGOTO(ncclMemOpSync(comm, args, stream), ret, fail);
@@ -626,7 +624,8 @@ ncclResult_t ncclCeAlltoAll(struct ncclComm* comm, struct ncclCeCollArgs* args, 
   }
 
   // Check if we need to perform intra-batch synchronization
-  batchOpsParams.intraBatchSync = (batchOpsParams.numOps > comm->ceColl.intraBatchSyncFreq && chunkBytes*batchOpsParams.numOps >= comm->ceColl.intraBatchSyncMsgThreshold);
+  batchOpsParams.intraBatchSync = (batchOpsParams.numOps > comm->ceColl.intraBatchSyncFreq &&
+                                   chunkBytes * batchOpsParams.numOps >= comm->ceColl.intraBatchSyncMsgThreshold);
 
   // Launch the batch operations
   NCCLCHECKGOTO(ncclCeLaunchBatchOps(comm, args, &batchOpsParams, stream), ret, fail);
@@ -755,28 +754,23 @@ ncclResult_t ncclLaunchCeColl(struct ncclComm* comm, struct ncclKernelPlan* plan
   struct ncclCeCollArgs* args = plan->ceCollArgs;
 
   // Start CE collective profiling
-  NCCLCHECKGOTO(ncclProfilerStartCeCollEvent(comm, args, stream),
-                ret, fail);
+  NCCLCHECKGOTO(ncclProfilerStartCeCollEvent(comm, args, stream), ret, fail);
 
   switch (args->func) {
-    case ncclFuncAllGather:
-      NCCLCHECKGOTO(ncclCeAllGather(comm, args, stream),
-                    ret, fail);
-      break;
-    case ncclFuncAlltoAll:
-      NCCLCHECKGOTO(ncclCeAlltoAll(comm, args, stream),
-                    ret, fail);
-      break;
-    case ncclFuncScatter:
-      NCCLCHECKGOTO(ncclCeScatter(comm, args, stream),
-                    ret, fail);
-      break;
-    case ncclFuncGather:
-      NCCLCHECKGOTO(ncclCeGather(comm, args, stream),
-                    ret, fail);
-      break;
-    default:
-      ret = ncclInvalidUsage;
+  case ncclFuncAllGather:
+    NCCLCHECKGOTO(ncclCeAllGather(comm, args, stream), ret, fail);
+    break;
+  case ncclFuncAlltoAll:
+    NCCLCHECKGOTO(ncclCeAlltoAll(comm, args, stream), ret, fail);
+    break;
+  case ncclFuncScatter:
+    NCCLCHECKGOTO(ncclCeScatter(comm, args, stream), ret, fail);
+    break;
+  case ncclFuncGather:
+    NCCLCHECKGOTO(ncclCeGather(comm, args, stream), ret, fail);
+    break;
+  default:
+    ret = ncclInvalidUsage;
   }
 
 exit:

--- a/projects/rccl/src/channel.cc
+++ b/projects/rccl/src/channel.cc
@@ -25,7 +25,8 @@ ncclResult_t initChannel(struct ncclComm* comm, int channelId) {
 
   struct ncclSharedResources* sharedRes = comm->sharedRes;
   cudaStream_t deviceStream;
-  NCCLCHECK(ncclStrongStreamAcquire(ncclCudaGraphNone(comm->config.graphUsageMode), &sharedRes->deviceStream, /*concurrent=*/false, &deviceStream));
+  NCCLCHECK(ncclStrongStreamAcquire(ncclCudaGraphNone(comm->config.graphUsageMode), &sharedRes->deviceStream,
+                                    /*concurrent=*/false, &deviceStream));
 
   if (channel->peers == NULL) {
     // The extra on nRanks+1 is for collnet root (i.e. network)
@@ -43,7 +44,8 @@ ncclResult_t initChannel(struct ncclComm* comm, int channelId) {
 
   if (channel->devPeers == NULL) {
     if (sharedRes->devPeers[channelId] == NULL) {
-      NCCLCHECK(ncclCudaCallocAsync(sharedRes->devPeers + channelId, sharedRes->tpNRanks, deviceStream, comm->memManager, ncclMemOffload));
+      NCCLCHECK(ncclCudaCallocAsync(sharedRes->devPeers + channelId, sharedRes->tpNRanks, deviceStream,
+                                    comm->memManager, ncclMemOffload));
     }
     /* channel->devPeers is not shared, so just free it when calling commFree() */
     NCCLCHECK(ncclCudaCallocAsync(&channel->devPeers, nPeers, deviceStream, comm->memManager, ncclMemOffload));
@@ -62,7 +64,8 @@ ncclResult_t initChannel(struct ncclComm* comm, int channelId) {
   ncclCommPushCudaFree(comm, channel->devRingUserRanks);
 
   /* guarantee addr has been copied into channel->devPeers */
-  NCCLCHECK(ncclStrongStreamRelease(ncclCudaGraphNone(comm->config.graphUsageMode), &sharedRes->deviceStream, /*concurrent=*/false));
+  NCCLCHECK(ncclStrongStreamRelease(ncclCudaGraphNone(comm->config.graphUsageMode), &sharedRes->deviceStream,
+                                    /*concurrent=*/false));
   NCCLCHECK(ncclStrongStreamSynchronize(&sharedRes->deviceStream));
   return ncclSuccess;
 }
@@ -72,13 +75,12 @@ ncclResult_t initNvlsChannel(struct ncclComm* comm, int channelId, struct ncclCo
   struct ncclSharedResources* sharedRes = comm->sharedRes;
   cudaStream_t deviceStream;
 
-  if (channel->nvlsPeers != NULL)
-    return ncclSuccess;
+  if (channel->nvlsPeers != NULL) return ncclSuccess;
 
-  if (channel->id == -1)
-    NCCLCHECK(initChannel(comm, channelId));
+  if (channel->id == -1) NCCLCHECK(initChannel(comm, channelId));
 
-  NCCLCHECK(ncclStrongStreamAcquire(ncclCudaGraphNone(comm->config.graphUsageMode), &sharedRes->deviceStream, /*concurrent=*/false, &deviceStream));
+  NCCLCHECK(ncclStrongStreamAcquire(ncclCudaGraphNone(comm->config.graphUsageMode), &sharedRes->deviceStream,
+                                    /*concurrent=*/false, &deviceStream));
 
   int nvlsRanks = comm->localRanks;
 
@@ -89,7 +91,8 @@ ncclResult_t initNvlsChannel(struct ncclComm* comm, int channelId, struct ncclCo
       int tr = comm->topParentLocalRanks[r];
       uintptr_t addr = (uintptr_t)(parent->channels[channelId].nvlsDevPeers + tr);
       channel->peers[comm->nRanks + 1 + r] = parent->channels[channelId].nvlsPeers + tr;
-      NCCLCHECK(ncclCudaMemcpyAsync((uintptr_t*)(channel->devPeers + comm->nRanks + 1 + r), (uintptr_t*)&addr, 1, deviceStream));
+      NCCLCHECK(ncclCudaMemcpyAsync((uintptr_t*)(channel->devPeers + comm->nRanks + 1 + r), (uintptr_t*)&addr, 1,
+                                    deviceStream));
       channel->devPeersHostPtr[comm->nRanks + 1 + r] = (struct ncclDevChannelPeer*)addr;
       ncclAtomicRefCountIncrement(&parent->channels[channelId].nvlsPeers[tr].refCount);
     }
@@ -99,13 +102,15 @@ ncclResult_t initNvlsChannel(struct ncclComm* comm, int channelId, struct ncclCo
     for (int r = 0; r < nvlsRanks; ++r) {
       uintptr_t addr = (uintptr_t)(channel->nvlsDevPeers + r);
       channel->peers[comm->nRanks + 1 + r] = channel->nvlsPeers + r;
-      NCCLCHECK(ncclCudaMemcpyAsync((uintptr_t*)(channel->devPeers + comm->nRanks + 1 + r), (uintptr_t*)&addr, 1, deviceStream));
+      NCCLCHECK(ncclCudaMemcpyAsync((uintptr_t*)(channel->devPeers + comm->nRanks + 1 + r), (uintptr_t*)&addr, 1,
+                                    deviceStream));
       channel->devPeersHostPtr[comm->nRanks + 1 + r] = (struct ncclDevChannelPeer*)addr;
       ncclAtomicRefCountIncrement(&channel->nvlsPeers[r].refCount);
     }
   }
 
-  NCCLCHECK(ncclStrongStreamRelease(ncclCudaGraphNone(comm->config.graphUsageMode), &sharedRes->deviceStream, /*concurrent=*/false));
+  NCCLCHECK(ncclStrongStreamRelease(ncclCudaGraphNone(comm->config.graphUsageMode), &sharedRes->deviceStream,
+                                    /*concurrent=*/false));
   NCCLCHECK(ncclStrongStreamSynchronize(&sharedRes->deviceStream));
 
   return ncclSuccess;
@@ -117,13 +122,12 @@ ncclResult_t initCollnetChannel(struct ncclComm* comm, int channelId, struct ncc
   uintptr_t addr;
   cudaStream_t deviceStream;
 
-  if (channel->collnetPeers != NULL)
-    return ncclSuccess;
+  if (channel->collnetPeers != NULL) return ncclSuccess;
 
-  if (channel->id == -1)
-    NCCLCHECK(initChannel(comm, channelId));
+  if (channel->id == -1) NCCLCHECK(initChannel(comm, channelId));
 
-  NCCLCHECK(ncclStrongStreamAcquire(ncclCudaGraphNone(comm->config.graphUsageMode), &sharedRes->deviceStream, /*concurrent=*/false, &deviceStream));
+  NCCLCHECK(ncclStrongStreamAcquire(ncclCudaGraphNone(comm->config.graphUsageMode), &sharedRes->deviceStream,
+                                    /*concurrent=*/false, &deviceStream));
 
   if (share) {
     channel->collnetPeers = parent->channels[channelId].collnetPeers;
@@ -143,13 +147,15 @@ ncclResult_t initCollnetChannel(struct ncclComm* comm, int channelId, struct ncc
     ncclAtomicRefCountIncrement(&channel->collnetPeers->refCount);
   }
 
-  NCCLCHECK(ncclStrongStreamRelease(ncclCudaGraphNone(comm->config.graphUsageMode), &sharedRes->deviceStream, /*concurrent=*/false));
+  NCCLCHECK(ncclStrongStreamRelease(ncclCudaGraphNone(comm->config.graphUsageMode), &sharedRes->deviceStream,
+                                    /*concurrent=*/false));
   NCCLCHECK(ncclStrongStreamSynchronize(&sharedRes->deviceStream));
 
   return ncclSuccess;
 }
 
-ncclResult_t freeChannel(struct ncclChannel* channel, int nRanks, int collnetNRanks, int nvlsNRanks, struct ncclComm* comm) {
+ncclResult_t freeChannel(struct ncclChannel* channel, int nRanks, int collnetNRanks, int nvlsNRanks,
+                         struct ncclComm* comm) {
   int nPeers = nRanks + collnetNRanks + nvlsNRanks;
   /* channel peers are only valid when async init thread completes commAlloc() and
    * the channel is initialized with initChannel(); if either is not done, this channel
@@ -162,9 +168,9 @@ ncclResult_t freeChannel(struct ncclChannel* channel, int nRanks, int collnetNRa
     struct ncclChannelPeer* peer = channel->peers[r];
     if (peer) {
       if (ncclAtomicRefCountDecrement(&peer->refCount) == 0) {
-        for (int b=0; b<NCCL_MAX_CONNS; b++) {
-          if (peer->send[b].transportComm) NCCLCHECK(peer->send[b].transportComm->free(comm, peer->send+b));
-          if (peer->recv[b].transportComm) NCCLCHECK(peer->recv[b].transportComm->free(comm, peer->recv+b));
+        for (int b = 0; b < NCCL_MAX_CONNS; b++) {
+          if (peer->send[b].transportComm) NCCLCHECK(peer->send[b].transportComm->free(comm, peer->send + b));
+          if (peer->recv[b].transportComm) NCCLCHECK(peer->recv[b].transportComm->free(comm, peer->recv + b));
         }
         if (r == nRanks) {
           free(channel->collnetPeers);

--- a/projects/rccl/src/collectives.cc
+++ b/projects/rccl/src/collectives.cc
@@ -27,76 +27,121 @@ using namespace rccl;
 
 const char* ncclFuncToString(ncclFunc_t fn) {
   switch (fn) {
-  case ncclFuncAllGather: return "AllGather";
-  case ncclFuncAllReduce: return "AllReduce";
-  case ncclFuncAlltoAll: return "AlltoAll";
-  case ncclFuncBroadcast: return "Broadcast";
-  case ncclFuncGather: return "Gather";
-  case ncclFuncRecv: return "Recv";
-  case ncclFuncReduce: return "Reduce";
-  case ncclFuncReduceScatter: return "ReduceScatter";
-  case ncclFuncScatter: return "Scatter";
-  case ncclFuncSendRecv: return "SendRecv";
-  case ncclFuncSend: return "Send";
-  case ncclFuncPutSignal: return "PutSignal";
-  case ncclFuncSignal: return "Signal";
-  case ncclFuncWaitSignal: return "WaitSignal";
-  default: return "Invalid";
+  case ncclFuncAllGather:
+    return "AllGather";
+  case ncclFuncAllReduce:
+    return "AllReduce";
+  case ncclFuncAlltoAll:
+    return "AlltoAll";
+  case ncclFuncBroadcast:
+    return "Broadcast";
+  case ncclFuncGather:
+    return "Gather";
+  case ncclFuncRecv:
+    return "Recv";
+  case ncclFuncReduce:
+    return "Reduce";
+  case ncclFuncReduceScatter:
+    return "ReduceScatter";
+  case ncclFuncScatter:
+    return "Scatter";
+  case ncclFuncSendRecv:
+    return "SendRecv";
+  case ncclFuncSend:
+    return "Send";
+  case ncclFuncPutSignal:
+    return "PutSignal";
+  case ncclFuncSignal:
+    return "Signal";
+  case ncclFuncWaitSignal:
+    return "WaitSignal";
+  default:
+    return "Invalid";
   }
 }
 
 const char* ncclDevRedOpToString(ncclDevRedOp_t op) {
   switch (op) {
-  case ncclDevSum: return "Sum";
-  case ncclDevProd: return "Prod";
-  case ncclDevMinMax: return "MinMax";
-  case ncclDevPreMulSum: return "PreMulSum";
-  case ncclDevSumPostDiv: return "SumPostDiv";
-  default: return "Unknown";
+  case ncclDevSum:
+    return "Sum";
+  case ncclDevProd:
+    return "Prod";
+  case ncclDevMinMax:
+    return "MinMax";
+  case ncclDevPreMulSum:
+    return "PreMulSum";
+  case ncclDevSumPostDiv:
+    return "SumPostDiv";
+  default:
+    return "Unknown";
   }
 }
 
 const char* ncclDatatypeToString(ncclDataType_t type) {
   switch (type) {
-  case ncclInt8: return "ncclInt8";
-  case ncclInt32: return "ncclInt32";
-  case ncclUint32: return "ncclUint32";
-  case ncclInt64: return "ncclInt64";
-  case ncclUint64: return "ncclUint64";
-  case ncclFloat16: return "ncclFloat16";
-  case ncclFloat32: return "ncclFloat32";
-  case ncclFloat64: return "ncclFloat64";
-  case ncclBfloat16: return "ncclBfloat16";
-  case ncclFloat8e4m3: return "ncclFloat8e4m3";
-  case ncclFloat8e5m2: return "ncclFloat8e5m2";
-  default: return "Unknown";
+  case ncclInt8:
+    return "ncclInt8";
+  case ncclInt32:
+    return "ncclInt32";
+  case ncclUint32:
+    return "ncclUint32";
+  case ncclInt64:
+    return "ncclInt64";
+  case ncclUint64:
+    return "ncclUint64";
+  case ncclFloat16:
+    return "ncclFloat16";
+  case ncclFloat32:
+    return "ncclFloat32";
+  case ncclFloat64:
+    return "ncclFloat64";
+  case ncclBfloat16:
+    return "ncclBfloat16";
+  case ncclFloat8e4m3:
+    return "ncclFloat8e4m3";
+  case ncclFloat8e5m2:
+    return "ncclFloat8e5m2";
+  default:
+    return "Unknown";
   }
 }
 
 const char* ncclAlgoToString(int algo) {
   switch (algo) {
-  case NCCL_ALGO_TREE: return "TREE";
-  case NCCL_ALGO_RING: return "RING";
-  case NCCL_ALGO_COLLNET_DIRECT: return "COLLNET_DIRECT";
-  case NCCL_ALGO_COLLNET_CHAIN: return "COLLNET_CHAIN";
-  case NCCL_ALGO_NVLS: return "NVLS";
-  case NCCL_ALGO_NVLS_TREE: return "NVLS_TREE";
-  case NCCL_ALGO_PAT: return "PAT";
-  default: return "Unknown";
+  case NCCL_ALGO_TREE:
+    return "TREE";
+  case NCCL_ALGO_RING:
+    return "RING";
+  case NCCL_ALGO_COLLNET_DIRECT:
+    return "COLLNET_DIRECT";
+  case NCCL_ALGO_COLLNET_CHAIN:
+    return "COLLNET_CHAIN";
+  case NCCL_ALGO_NVLS:
+    return "NVLS";
+  case NCCL_ALGO_NVLS_TREE:
+    return "NVLS_TREE";
+  case NCCL_ALGO_PAT:
+    return "PAT";
+  default:
+    return "Unknown";
   }
 }
 
 const char* ncclProtoToString(int proto) {
   switch (proto) {
-  case NCCL_PROTO_LL: return "LL";
-  case NCCL_PROTO_LL128: return "LL128";
-  case NCCL_PROTO_SIMPLE: return "SIMPLE";
-  default: return "Unknown";
+  case NCCL_PROTO_LL:
+    return "LL";
+  case NCCL_PROTO_LL128:
+    return "LL128";
+  case NCCL_PROTO_SIMPLE:
+    return "SIMPLE";
+  default:
+    return "Unknown";
   }
 }
 
-NCCL_API(ncclResult_t, ncclAllGather, const void* sendbuff, void* recvbuff, size_t sendcount,
-    ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream);
+NCCL_API(ncclResult_t, ncclAllGather, const void* sendbuff, void* recvbuff, size_t sendcount, ncclDataType_t datatype,
+         ncclComm_t comm, cudaStream_t stream);
 
 // Direct AllGather: posts Send/Recv to every peer (including self) for every
 // rank using the same iteration order on all ranks. Mirrors the AlltoAll
@@ -115,11 +160,12 @@ NCCL_API(ncclResult_t, ncclAllGather, const void* sendbuff, void* recvbuff, size
 //     overhead (ArgsCheck, Recorder, profiler events, group start/end
 //     internal) that previously made cross-rank batch composition fragile at
 //     scale.
-static ncclResult_t rcclDirectAllGather(const void* sendbuff, void* recvbuff, size_t sendcount,
-    ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream) {
-  struct ncclInfo info = { ncclFuncAllGather, "AllGather",
-    sendbuff, recvbuff, sendcount, datatype, ncclSum, 0, comm, stream,
-    ALLGATHER_CHUNKSTEPS, ALLGATHER_SLICESTEPS, nullptr };
+static ncclResult_t rcclDirectAllGather(const void* sendbuff, void* recvbuff, size_t sendcount, ncclDataType_t datatype,
+                                        ncclComm_t comm, cudaStream_t stream) {
+  struct ncclInfo info = {
+    ncclFuncAllGather,    "AllGather",          sendbuff, recvbuff, sendcount, datatype, ncclSum, 0, comm, stream,
+    ALLGATHER_CHUNKSTEPS, ALLGATHER_SLICESTEPS, nullptr
+  };
   info.useDirect = true;
   return ncclEnqueueCheck(&info);
 }
@@ -132,7 +178,9 @@ RCCL_PARAM(DdaThreshold, "DDA_THRESHOLD", (size_t)(67108864));
 // threshold for gfx942; gfx950 uses the user-configurable rcclParamDdaThreshold();
 // all other architectures return false (threshold 0).
 static bool rcclDdaEnabled(const ncclComm* comm, size_t totalBytes, size_t gfx942Default) {
-  if (!rcclParamDdaEnable() || ncclParamLaunchOrderImplicit() || ncclGroupDepth != 0 || comm->nRanks < 8 || comm->symmetricSupport) return false;
+  if (!rcclParamDdaEnable() || ncclParamLaunchOrderImplicit() || ncclGroupDepth != 0 || comm->nRanks < 8 ||
+      comm->symmetricSupport)
+    return false;
   size_t threshold;
   if (IsArchMatch(comm->archName, "gfx942")) {
     threshold = gfx942Default;
@@ -161,15 +209,13 @@ static rcclAllGatherAlgo rcclSelectAllGatherAlgo(struct ncclComm* comm, size_t m
 }
 
 static inline int hierarchicalShuffleNumBlocks(size_t totalBytes) {
-  if (totalBytes <= (size_t)64 * 1024)
-    return 8;
-  if (totalBytes <= (size_t)16 * 1024 * 1024)
-    return 16;
+  if (totalBytes <= (size_t)64 * 1024) return 8;
+  if (totalBytes <= (size_t)16 * 1024 * 1024) return 16;
   return 32;
 }
 
 static ncclResult_t ncclHierarchicalAllGather_Impl(const void* sendbuff, void* recvbuff, size_t sendcount,
-    ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream) {
+                                                   ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream) {
   if (sendcount == 0) return ncclSuccess;
   ncclComm* intraComm = comm->hierarchicalIntraComm;
   ncclComm* interComm = comm->hierarchicalInterComm;
@@ -190,9 +236,19 @@ static ncclResult_t ncclHierarchicalAllGather_Impl(const void* sendbuff, void* r
   if (nNodes <= 16 && rcclUseAllGatherDirect(interComm, interMsgSize)) {
     NCCLCHECK(rcclDirectAllGather(interSendBuff, recvbuff, sendcount, datatype, interComm, stream));
   } else {
-    struct ncclInfo infoInterAG = { ncclFuncAllGather, "HierarchicalAllGather-Inter",
-      interSendBuff, recvbuff, sendcount, datatype, ncclSum, 0, interComm, stream,
-      ALLGATHER_CHUNKSTEPS, ALLGATHER_SLICESTEPS, nullptr };
+    struct ncclInfo infoInterAG = {ncclFuncAllGather,
+                                   "HierarchicalAllGather-Inter",
+                                   interSendBuff,
+                                   recvbuff,
+                                   sendcount,
+                                   datatype,
+                                   ncclSum,
+                                   0,
+                                   interComm,
+                                   stream,
+                                   ALLGATHER_CHUNKSTEPS,
+                                   ALLGATHER_SLICESTEPS,
+                                   nullptr};
     NCCLCHECK(ncclEnqueueCheck(&infoInterAG));
   }
 
@@ -203,11 +259,19 @@ static ncclResult_t ncclHierarchicalAllGather_Impl(const void* sendbuff, void* r
     // Use direct allgather
     NCCLCHECK(rcclDirectAllGather(recvbuff, tempBuffer, intraSendCount, datatype, intraComm, stream));
   } else {
-    struct ncclInfo infoIntraAG = { ncclFuncAllGather, "HierarchicalAllGather-Intra",
-      recvbuff, tempBuffer, intraSendCount, datatype, ncclSum, 0, intraComm, stream,
-      ALLGATHER_CHUNKSTEPS,
-      intraComm->rcclUseOneSlice ? ALLGATHER_SLICESTEPS_SINGLE_NODE : ALLGATHER_SLICESTEPS, nullptr
-    };
+    struct ncclInfo infoIntraAG = {ncclFuncAllGather,
+                                   "HierarchicalAllGather-Intra",
+                                   recvbuff,
+                                   tempBuffer,
+                                   intraSendCount,
+                                   datatype,
+                                   ncclSum,
+                                   0,
+                                   intraComm,
+                                   stream,
+                                   ALLGATHER_CHUNKSTEPS,
+                                   intraComm->rcclUseOneSlice ? ALLGATHER_SLICESTEPS_SINGLE_NODE : ALLGATHER_SLICESTEPS,
+                                   nullptr};
     NCCLCHECK(ncclEnqueueCheck(&infoIntraAG));
   }
 
@@ -215,27 +279,25 @@ static ncclResult_t ncclHierarchicalAllGather_Impl(const void* sendbuff, void* r
   size_t totalAGBytes = (size_t)nNodes * localRanks * rankOffset;
   int numBlocks = hierarchicalShuffleNumBlocks(totalAGBytes);
   int threadsPerBlock = 1024;
-  hierarchicalAGShuffle<<<numBlocks, threadsPerBlock, 0, stream>>>(
-    (const char*)tempBuffer, (char*)recvbuff, rankOffset, nNodes, localRanks);
+  hierarchicalAGShuffle<<<numBlocks, threadsPerBlock, 0, stream>>>((const char*)tempBuffer, (char*)recvbuff, rankOffset,
+                                                                   nNodes, localRanks);
   CUDACHECK(hipGetLastError());
 
   return ncclSuccess;
 }
 
-ncclResult_t ncclAllGather_impl(const void* sendbuff, void* recvbuff, size_t sendcount,
-    ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream) {
+ncclResult_t ncclAllGather_impl(const void* sendbuff, void* recvbuff, size_t sendcount, ncclDataType_t datatype,
+                                ncclComm_t comm, cudaStream_t stream) {
   NVTX3_FUNC_WITH_PARAMS(AllGather, NcclNvtxParamsAllGather,
-    NVTX3_PAYLOAD(comm ? comm->commHash : 0, sendcount * ncclTypeSize(datatype), datatype));
+                         NVTX3_PAYLOAD(comm ? comm->commHash : 0, sendcount * ncclTypeSize(datatype), datatype));
     // RCCL update slice steps for AllGather if single node
-    const bool isGfx950 = IsArchMatch(comm->archName, "gfx950");
+  const bool isGfx950 = IsArchMatch(comm->archName, "gfx950");
 
-    int chunkSteps = (isGfx950 && comm->rcclUseOneSlice)? 1 : ALLGATHER_CHUNKSTEPS;
-    int sliceSteps = comm->rcclUseOneSlice
-      ? (isGfx950 ? 1 : ALLGATHER_SLICESTEPS_SINGLE_NODE)
-      : ALLGATHER_SLICESTEPS;
-  struct ncclInfo info = { ncclFuncAllGather, "AllGather",
-    sendbuff, recvbuff, sendcount, datatype, ncclSum, 0, comm, stream, /* Args */
-    chunkSteps, sliceSteps, nullptr };
+  int chunkSteps = (isGfx950 && comm->rcclUseOneSlice) ? 1 : ALLGATHER_CHUNKSTEPS;
+  int sliceSteps = comm->rcclUseOneSlice ? (isGfx950 ? 1 : ALLGATHER_SLICESTEPS_SINGLE_NODE) : ALLGATHER_SLICESTEPS;
+  struct ncclInfo info = {ncclFuncAllGather, "AllGather", sendbuff, recvbuff, sendcount,
+                          datatype,          ncclSum,     0,        comm,     stream, /* Args */
+                          chunkSteps,        sliceSteps,  nullptr};
   int nRanks, rank;
   NCCLCHECK(ncclCommCount(comm, &nRanks));
   NCCLCHECK(ncclCommUserRank(comm, &rank));
@@ -245,22 +307,18 @@ ncclResult_t ncclAllGather_impl(const void* sendbuff, void* recvbuff, size_t sen
 
   if (rcclDdaEnabled(comm, nRanks * sendcount * ncclTypeSize(datatype), 8388608) &&
       ncclAllGatherDdaIpcEligible(comm, sendbuff, recvbuff, sendcount, datatype)) {
-    NCCLCHECK(ncclAllGatherDdaIpc(
-        sendbuff,
-        recvbuff,
-        sendcount,
-        datatype,
-        comm,
-        stream));
+    NCCLCHECK(ncclAllGatherDdaIpc(sendbuff, recvbuff, sendcount, datatype, comm, stream));
     return ncclSuccess;
   }
   rcclAllGatherAlgo algo = rcclSelectAllGatherAlgo(comm, msgSize);
   switch (algo) {
-    case RCCL_AG_HIERARCHICAL:
+  case RCCL_AG_HIERARCHICAL:
     return ncclHierarchicalAllGather_Impl(sendbuff, recvbuff, sendcount, datatype, comm, stream);
-    case RCCL_AG_DIRECT:
-    INFO(NCCL_TUNING, "RCCL DIRECT ALLGATHER count = %zu, msgSize = %zu, comm = %p, stream = %p, rank = %d, sendbuff = %p, recvbuff = %p",
-      sendcount, msgSize, comm, stream, rank, sendbuff, recvbuff);
+  case RCCL_AG_DIRECT:
+    INFO(NCCL_TUNING,
+         "RCCL DIRECT ALLGATHER count = %zu, msgSize = %zu, comm = %p, stream = %p, rank = %d, sendbuff = %p, recvbuff "
+         "= %p",
+         sendcount, msgSize, comm, stream, rank, sendbuff, recvbuff);
     // Use direct allgather (only when not in a group; in-group use Ring so
     // ncclGroupSimulateEnd gets estimatedTime).
     if (sendcount == 0) return ncclSuccess;
@@ -268,21 +326,21 @@ ncclResult_t ncclAllGather_impl(const void* sendbuff, void* recvbuff, size_t sen
     // P2P tasks (no peer rotation, no in-place self skip).
     info.useDirect = true;
     return ncclEnqueueCheck(&info);
-    case RCCL_AG_RING:
-    default:
-      return ncclEnqueueCheck(&info);
+  case RCCL_AG_RING:
+  default:
+    return ncclEnqueueCheck(&info);
   }
 }
 
 RCCL_PARAM(AlltoAllPivotEnable, "ALL_TO_ALL_PIVOT_ENABLE", 0);
 
-NCCL_API(ncclResult_t, ncclAlltoAll, const void* sendbuff, void* recvbuff, size_t count,
-    ncclDataType_t datatype, ncclComm* comm, cudaStream_t stream);
-ncclResult_t ncclAlltoAll_impl(const void* sendbuff, void* recvbuff, size_t count,
-    ncclDataType_t datatype, ncclComm* comm, cudaStream_t stream) {
+NCCL_API(ncclResult_t, ncclAlltoAll, const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
+         ncclComm* comm, cudaStream_t stream);
+ncclResult_t ncclAlltoAll_impl(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
+                               ncclComm* comm, cudaStream_t stream) {
   NVTX3_FUNC_WITH_PARAMS(AlltoAll, NcclNvtxParamsAlltoAll,
-    NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), datatype));
-  
+                         NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), datatype));
+
   NCCLCHECK(Recorder::instance().record(rrAllToAll, sendbuff, recvbuff, count, datatype, comm, stream));
 
   size_t rankOffset = count * ncclTypeSize(datatype);
@@ -291,51 +349,67 @@ ncclResult_t ncclAlltoAll_impl(const void* sendbuff, void* recvbuff, size_t coun
   struct ncclInfo info;
   if (comm->topo->pivotA2AEnabled && comm->nChannels >= comm->topo->pivotA2ANumBiRings * 2 &&
       rankOffset >= 744 * 1024 && rankAlign != 4 && rcclParamAlltoAllPivotEnable()) {
-      info = { ncclFuncAlltoAllPivot, "AlltoAllPivot",
-        sendbuff, recvbuff, count, datatype, ncclSum, 0, comm, stream, /* Args */
-        ALLTOALL_PIVOT_CHUNKSTEPS, ALLTOALL_PIVOT_SLICESTEPS, nullptr };
+    info = {ncclFuncAlltoAllPivot,
+            "AlltoAllPivot",
+            sendbuff,
+            recvbuff,
+            count,
+            datatype,
+            ncclSum,
+            0,
+            comm,
+            stream, /* Args */
+            ALLTOALL_PIVOT_CHUNKSTEPS,
+            ALLTOALL_PIVOT_SLICESTEPS,
+            nullptr};
   } else {
-      #ifdef ENABLE_ROCSHMEM
-      size_t msgSize = count * ncclTypeSize(datatype) * comm->nRanks;
-      if (rcclUseAlltoAllGda(comm) && msgSize <= comm->rocshmemThreshold) {	
-        struct ncclInfo info = { ncclFuncAlltoAllGda, "AlltoAllGda",
-              sendbuff, recvbuff, count, datatype, ncclSum, 0, comm, stream,
-              ALLTOALL_PIVOT_CHUNKSTEPS, ALLTOALL_PIVOT_SLICESTEPS, nullptr };
-            
-        return ncclEnqueueCheck(&info);
-      }
-      #endif // ENABLE_ROCSHMEM
+#ifdef ENABLE_ROCSHMEM
+    size_t msgSize = count * ncclTypeSize(datatype) * comm->nRanks;
+    if (rcclUseAlltoAllGda(comm) && msgSize <= comm->rocshmemThreshold) {
+      struct ncclInfo info = {ncclFuncAlltoAllGda,
+                              "AlltoAllGda",
+                              sendbuff,
+                              recvbuff,
+                              count,
+                              datatype,
+                              ncclSum,
+                              0,
+                              comm,
+                              stream,
+                              ALLTOALL_PIVOT_CHUNKSTEPS,
+                              ALLTOALL_PIVOT_SLICESTEPS,
+                              nullptr};
+
+      return ncclEnqueueCheck(&info);
+    }
+#endif // ENABLE_ROCSHMEM
 
     if (rcclDdaEnabled(comm, comm->nRanks * count * ncclTypeSize(datatype), 4194304) &&
         ncclAllToAllDdaIpcEligible(comm, sendbuff, recvbuff, count, datatype)) {
-      NCCLCHECK(ncclAllToAllDdaIpc(
-        sendbuff,
-        recvbuff,
-        count,
-        datatype,
-        comm,
-        stream));
+      NCCLCHECK(ncclAllToAllDdaIpc(sendbuff, recvbuff, count, datatype, comm, stream));
       return ncclSuccess;
     }
 
-    info = { ncclFuncAlltoAll, "AlltoAll",
-      sendbuff, recvbuff, count, datatype, ncclSum, 0, comm, stream, /* Args */
-      ALLTOALL_CHUNKSTEPS, ALLTOALL_SLICESTEPS };
+    info = {
+      ncclFuncAlltoAll,    "AlltoAll",         sendbuff, recvbuff, count, datatype, ncclSum, 0, comm, stream, /* Args */
+      ALLTOALL_CHUNKSTEPS, ALLTOALL_SLICESTEPS
+    };
   }
   return ncclEnqueueCheck(&info);
 }
 
-NCCL_API(ncclResult_t, ncclAlltoAllv, const void *sendbuff, const size_t sendcounts[], const size_t sdispls[],
-    void *recvbuff, const size_t recvcounts[], const size_t rdispls[],
-    ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream);
-ncclResult_t ncclAlltoAllv_impl(const void *sendbuff, const size_t sendcounts[], const size_t sdispls[],
-    void *recvbuff, const size_t recvcounts[], const size_t rdispls[],
-    ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream) {
+NCCL_API(ncclResult_t, ncclAlltoAllv, const void* sendbuff, const size_t sendcounts[], const size_t sdispls[],
+         void* recvbuff, const size_t recvcounts[], const size_t rdispls[], ncclDataType_t datatype, ncclComm_t comm,
+         hipStream_t stream);
+ncclResult_t ncclAlltoAllv_impl(const void* sendbuff, const size_t sendcounts[], const size_t sdispls[], void* recvbuff,
+                                const size_t recvcounts[], const size_t rdispls[], ncclDataType_t datatype,
+                                ncclComm_t comm, hipStream_t stream) {
   NVTX3_FUNC_WITH_PARAMS(AlltoAllv, NcclNvtxParamsAlltoAllv,
-    NVTX3_PAYLOAD(comm ? comm->commHash : 0, sendcounts[comm->rank] * ncclTypeSize(datatype),
-      recvcounts[comm->rank] * ncclTypeSize(datatype), datatype));
+                         NVTX3_PAYLOAD(comm ? comm->commHash : 0, sendcounts[comm->rank] * ncclTypeSize(datatype),
+                                       recvcounts[comm->rank] * ncclTypeSize(datatype), datatype));
 
-  NCCLCHECK(Recorder::instance().record(rrAllToAllv, sendbuff, recvbuff, 0, datatype, comm, stream, -1, sendcounts, sdispls, recvcounts, rdispls));
+  NCCLCHECK(Recorder::instance().record(rrAllToAllv, sendbuff, recvbuff, 0, datatype, comm, stream, -1, sendcounts,
+                                        sdispls, recvcounts, rdispls));
 
   int nRanks, rank;
   NCCLCHECK(ncclCommCount(comm, &nRanks));
@@ -346,117 +420,108 @@ ncclResult_t ncclAlltoAllv_impl(const void *sendbuff, const size_t sendcounts[],
   std::vector<size_t> sendcounts1(nRanks);
   std::vector<size_t> recvcounts1(nRanks);
 
-  std::vector<size_t> sizes(4*nRanks);	//4 for sdispl, rdispl, scount, rcount
+  std::vector<size_t> sizes(4 * nRanks); // 4 for sdispl, rdispl, scount, rcount
 #ifdef ENABLE_ROCSHMEM
+  for (int i = 0; i < nRanks; i++) {
+    sdispls1[i] = sdispls[i] * ncclTypeSize(datatype);
+    rdispls1[i] = rdispls[i] * ncclTypeSize(datatype);
+    sendcounts1[i] = sendcounts[i] * ncclTypeSize(datatype);
+    recvcounts1[i] = recvcounts[i] * ncclTypeSize(datatype);
+  }
+
+  size_t count = sdispls1[nRanks - 1] + sendcounts1[nRanks - 1];
+
+  if (comm->enableRocshmem && comm->nNodes > 1 && (comm->nRanks / comm->nNodes == 8)) {
+    INFO(
+      NCCL_INIT,
+      "GDA alltoallv is supported for up to 128MB message size; Use ROCSHMEM_HEAP_SIZE=3GB for GDA support till 512MB");
+
     for (int i = 0; i < nRanks; i++) {
-       sdispls1[i] = sdispls[i] * ncclTypeSize(datatype);
-       rdispls1[i] = rdispls[i] * ncclTypeSize(datatype);
-       sendcounts1[i] = sendcounts[i] * ncclTypeSize(datatype);
-       recvcounts1[i] = recvcounts[i] * ncclTypeSize(datatype);
+      sizes[i] = sendcounts1[i];
+      sizes[nRanks + i] = sdispls1[i];
+      sizes[2 * nRanks + i] = recvcounts1[i];
+      sizes[3 * nRanks + i] = rdispls1[i];
     }
+    count = count / ncclTypeSize(datatype);
 
-    size_t count = sdispls1[nRanks - 1] + sendcounts1[nRanks - 1];
-
-    if (comm->enableRocshmem && comm->nNodes > 1 && (comm->nRanks/comm->nNodes == 8)) {
-        INFO(NCCL_INIT, "GDA alltoallv is supported for up to 128MB message size; Use ROCSHMEM_HEAP_SIZE=3GB for GDA support till 512MB");  
-
-        for (int i = 0; i < nRanks; i++) {
-            sizes[i] = sendcounts1[i];
-            sizes[nRanks + i] = sdispls1[i];
-            sizes[2*nRanks + i] = recvcounts1[i];
-            sizes[3*nRanks + i] = rdispls1[i];
-        }
-        count = count / ncclTypeSize(datatype);
-
-	//use CU for copy-in/copy-out for small <= 128KB sizes
-	//TODO: the threshold could be different for different number of nodes
-	if ((count * ncclTypeSize(datatype)) > 131072) {
-	    void *dest = (char*)comm->sourceRshmem + comm->symId * comm->bufThreshold;
-            CUDACHECK(hipMemcpyAsync(dest, sendbuff, count * ncclTypeSize(datatype),
-               hipMemcpyDeviceToDevice, stream));
-        }
-        struct ncclInfo info = { ncclFuncAlltoAllvGda, "AlltoAllvGda",
-        sendbuff, recvbuff, count, datatype, ncclSum, 0, comm, stream,
-        ALLTOALL_PIVOT_CHUNKSTEPS, ALLTOALL_PIVOT_SLICESTEPS, nullptr };
+    // use CU for copy-in/copy-out for small <= 128KB sizes
+    // TODO: the threshold could be different for different number of nodes
+    if ((count * ncclTypeSize(datatype)) > 131072) {
+      void* dest = (char*)comm->sourceRshmem + comm->symId * comm->bufThreshold;
+      CUDACHECK(hipMemcpyAsync(dest, sendbuff, count * ncclTypeSize(datatype), hipMemcpyDeviceToDevice, stream));
+    }
+    struct ncclInfo info = {ncclFuncAlltoAllvGda,
+                            "AlltoAllvGda",
+                            sendbuff,
+                            recvbuff,
+                            count,
+                            datatype,
+                            ncclSum,
+                            0,
+                            comm,
+                            stream,
+                            ALLTOALL_PIVOT_CHUNKSTEPS,
+                            ALLTOALL_PIVOT_SLICESTEPS,
+                            nullptr};
 #ifdef ENABLE_ROCSHMEM
-        info.sizes = sizes.data();
+    info.sizes = sizes.data();
 #endif
 
-        ncclResult_t ret = ncclEnqueueCheck(&info);
+    ncclResult_t ret = ncclEnqueueCheck(&info);
 
-        if (ret == ncclSuccess && ((count * ncclTypeSize(datatype)) > 131072)) {
-	    void *src = (char*)comm->destRshmem + comm->symId * comm->bufThreshold;
-            CUDACHECK(hipMemcpyAsync(recvbuff, src, count * ncclTypeSize(datatype),
-                    hipMemcpyDeviceToDevice, stream));
-            comm->symId = (comm->symId + 1) % comm->numSymBuf;
-        }
-        return ret;
+    if (ret == ncclSuccess && ((count * ncclTypeSize(datatype)) > 131072)) {
+      void* src = (char*)comm->destRshmem + comm->symId * comm->bufThreshold;
+      CUDACHECK(hipMemcpyAsync(recvbuff, src, count * ncclTypeSize(datatype), hipMemcpyDeviceToDevice, stream));
+      comm->symId = (comm->symId + 1) % comm->numSymBuf;
     }
+    return ret;
+  }
 #endif
 
   Recorder::instance().skip(true);
   NCCLCHECK(ncclGroupStart());
-  for (int r=0; r<nRanks; r++) {
-    NCCLCHECK(ncclSend(
-        ((char*)sendbuff) + sdispls[r]*ncclTypeSize(datatype),
-        sendcounts[r],
-        datatype,
-        r,
-        comm,
-        stream));
-    NCCLCHECK(ncclRecv(
-        ((char*)recvbuff) + rdispls[r]*ncclTypeSize(datatype),
-        recvcounts[r],
-        datatype,
-        r,
-        comm,
-        stream));
+  for (int r = 0; r < nRanks; r++) {
+    NCCLCHECK(ncclSend(((char*)sendbuff) + sdispls[r] * ncclTypeSize(datatype), sendcounts[r], datatype, r, comm,
+                       stream));
+    NCCLCHECK(ncclRecv(((char*)recvbuff) + rdispls[r] * ncclTypeSize(datatype), recvcounts[r], datatype, r, comm,
+                       stream));
   }
   NCCLCHECK(ncclGroupEnd());
   Recorder::instance().skip(false);
   return ncclSuccess;
 }
 
-NCCL_API(ncclResult_t, ncclAllReduce, const void* sendbuff, void* recvbuff, size_t count,
-    ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm, cudaStream_t stream);
-ncclResult_t ncclAllReduce_impl(const void* sendbuff, void* recvbuff, size_t count,
-    ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm, cudaStream_t stream) {
+NCCL_API(ncclResult_t, ncclAllReduce, const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
+         ncclRedOp_t op, ncclComm* comm, cudaStream_t stream);
+ncclResult_t ncclAllReduce_impl(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
+                                ncclRedOp_t op, ncclComm* comm, cudaStream_t stream) {
   NVTX3_FUNC_WITH_PARAMS(AllReduce, NcclNvtxParamsAllReduce,
-    NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), op, datatype));
+                         NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), op, datatype));
 
   // RCCL update slice steps for AllReduce if single node
   const bool isGfx950 = IsArchMatch(comm->archName, "gfx950");
-  int chunkSteps = (isGfx950 && comm->rcclUseOneSlice)? 1 : ALLREDUCE_CHUNKSTEPS;
-  int sliceSteps = comm->rcclUseOneSlice
-      ? (isGfx950 ? 1 : ALLREDUCE_SLICESTEPS_SINGLE_NODE)
-      : ALLREDUCE_SLICESTEPS;
+  int chunkSteps = (isGfx950 && comm->rcclUseOneSlice) ? 1 : ALLREDUCE_CHUNKSTEPS;
+  int sliceSteps = comm->rcclUseOneSlice ? (isGfx950 ? 1 : ALLREDUCE_SLICESTEPS_SINGLE_NODE) : ALLREDUCE_SLICESTEPS;
 
-  struct ncclInfo info = { ncclFuncAllReduce, "AllReduce",
-    sendbuff, recvbuff, count, datatype, op, 0, comm, stream, /* Args */
-    chunkSteps, sliceSteps, nullptr };
+  struct ncclInfo info = {ncclFuncAllReduce, "AllReduce", sendbuff, recvbuff, count,
+                          datatype,          op,          0,        comm,     stream, /* Args */
+                          chunkSteps,        sliceSteps,  nullptr};
 
   NCCLCHECK(Recorder::instance().record(rrAllReduce, info));
 
   if (rcclDdaEnabled(comm, count * ncclTypeSize(datatype), 8388608) &&
       ncclAllReduceDdaIpcEligible(comm, sendbuff, recvbuff, count, datatype, op)) {
-    NCCLCHECK(ncclAllReduceDdaIpc(
-        sendbuff,
-        recvbuff,
-        count,
-        datatype,
-        op,
-        comm,
-        stream));
+    NCCLCHECK(ncclAllReduceDdaIpc(sendbuff, recvbuff, count, datatype, op, comm, stream));
     return ncclSuccess;
   }
 
   return ncclEnqueueCheck(&info);
 }
 
-ncclResult_t ncclAllReduceWithBias_impl(const void* sendbuff, void* recvbuff, size_t count,
-    ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm, cudaStream_t stream, const void* acc) {
+ncclResult_t ncclAllReduceWithBias_impl(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
+                                        ncclRedOp_t op, ncclComm* comm, cudaStream_t stream, const void* acc) {
   NVTX3_FUNC_WITH_PARAMS(AllReduce, NcclNvtxParamsAllReduce,
-    NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), op, datatype));
+                         NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), op, datatype));
 
   if (acc == nullptr) {
     WARN("ncclAllReduceWithBias : acc cannot be nullptr");
@@ -467,92 +532,109 @@ ncclResult_t ncclAllReduceWithBias_impl(const void* sendbuff, void* recvbuff, si
   // similar to changes made to AllReduce earlier
   const bool isGfx950 = IsArchMatch(comm->archName, "gfx950");
   int chunkSteps = (isGfx950 && comm->rcclUseOneSlice) ? 1 : ALLREDUCE_CHUNKSTEPS;
-  int sliceSteps = comm->rcclUseOneSlice
-      ? (isGfx950 ? 1 : ALLREDUCE_SLICESTEPS_SINGLE_NODE)
-      : ALLREDUCE_SLICESTEPS;
+  int sliceSteps = comm->rcclUseOneSlice ? (isGfx950 ? 1 : ALLREDUCE_SLICESTEPS_SINGLE_NODE) : ALLREDUCE_SLICESTEPS;
 
-  struct ncclInfo info = { ncclFuncAllReduce, "AllReduce",
-    sendbuff, recvbuff, count, datatype, op, 0, comm, stream, /* Args */
-    chunkSteps, sliceSteps, acc };
+  struct ncclInfo info = {ncclFuncAllReduce, "AllReduce", sendbuff, recvbuff, count,
+                          datatype,          op,          0,        comm,     stream, /* Args */
+                          chunkSteps,        sliceSteps,  acc};
 
   NCCLCHECK(Recorder::instance().record(rrAllReduceWithBias, info));
 
   return ncclEnqueueCheck(&info);
 }
 
-NCCL_API(ncclResult_t, ncclBroadcast, const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, int root,
-    ncclComm_t comm, cudaStream_t stream);
+NCCL_API(ncclResult_t, ncclBroadcast, const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
+         int root, ncclComm_t comm, cudaStream_t stream);
 ncclResult_t ncclBroadcast_impl(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, int root,
-    ncclComm_t comm, cudaStream_t stream) {
+                                ncclComm_t comm, cudaStream_t stream) {
   NVTX3_FUNC_WITH_PARAMS(Broadcast, NcclNvtxParamsBroadcast,
-    NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), root, datatype));
+                         NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), root, datatype));
 
-  struct ncclInfo info = { ncclFuncBroadcast, "Broadcast",
-    sendbuff, recvbuff, count, datatype, ncclSum, root, comm, stream, /* Args */
-    BROADCAST_CHUNKSTEPS, BROADCAST_SLICESTEPS, nullptr };
+  struct ncclInfo info = {ncclFuncBroadcast,
+                          "Broadcast",
+                          sendbuff,
+                          recvbuff,
+                          count,
+                          datatype,
+                          ncclSum,
+                          root,
+                          comm,
+                          stream, /* Args */
+                          BROADCAST_CHUNKSTEPS,
+                          BROADCAST_SLICESTEPS,
+                          nullptr};
 
   NCCLCHECK(Recorder::instance().record(rrBroadcast, info));
 
   return ncclEnqueueCheck(&info);
 }
 /* Deprecated original "in place" function, similar to MPI */
-NCCL_API(ncclResult_t, ncclBcast, void* buff, size_t count, ncclDataType_t datatype, int root,
-    ncclComm_t comm, cudaStream_t stream);
-ncclResult_t ncclBcast(void* buff, size_t count, ncclDataType_t datatype, int root,
-    ncclComm_t comm, cudaStream_t stream) {
+NCCL_API(ncclResult_t, ncclBcast, void* buff, size_t count, ncclDataType_t datatype, int root, ncclComm_t comm,
+         cudaStream_t stream);
+ncclResult_t ncclBcast(void* buff, size_t count, ncclDataType_t datatype, int root, ncclComm_t comm,
+                       cudaStream_t stream) {
   NCCLCHECK(Recorder::instance().record(rrBcast, buff, buff, count, datatype, comm, stream, root));
   return ncclBroadcast(buff, buff, count, datatype, root, comm, stream);
 }
 
-NCCL_API(ncclResult_t, ncclGather, const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, int root,
-    ncclComm* comm, cudaStream_t stream);
+NCCL_API(ncclResult_t, ncclGather, const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
+         int root, ncclComm* comm, cudaStream_t stream);
 ncclResult_t ncclGather_impl(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, int root,
-    ncclComm* comm, cudaStream_t stream) {
+                             ncclComm* comm, cudaStream_t stream) {
   NVTX3_FUNC_WITH_PARAMS(Gather, NcclNvtxParamsGather,
-    NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), root));
+                         NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), root));
 
   NCCLCHECK(Recorder::instance().record(rrGather, sendbuff, recvbuff, count, datatype, comm, stream, root));
 
-  struct ncclInfo info = { ncclFuncGather, "Gather",
-    sendbuff, recvbuff, count, datatype, ncclSum, root, comm, stream, /* Args */
-    GATHER_CHUNKSTEPS, GATHER_SLICESTEPS };
+  struct ncclInfo info = {ncclFuncGather,    "Gather",         sendbuff, recvbuff, count,
+                          datatype,          ncclSum,          root,     comm,     stream, /* Args */
+                          GATHER_CHUNKSTEPS, GATHER_SLICESTEPS};
   return ncclEnqueueCheck(&info);
 }
 
-NCCL_API(ncclResult_t, ncclReduce, const void* sendbuff, void* recvbuff, size_t count,
-    ncclDataType_t datatype, ncclRedOp_t op, int root, ncclComm_t comm, cudaStream_t stream);
-ncclResult_t ncclReduce_impl(const void* sendbuff, void* recvbuff, size_t count,
-    ncclDataType_t datatype, ncclRedOp_t op, int root, ncclComm_t comm, cudaStream_t stream) {
+NCCL_API(ncclResult_t, ncclReduce, const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
+         ncclRedOp_t op, int root, ncclComm_t comm, cudaStream_t stream);
+ncclResult_t ncclReduce_impl(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
+                             ncclRedOp_t op, int root, ncclComm_t comm, cudaStream_t stream) {
   NVTX3_FUNC_WITH_PARAMS(Reduce, NcclNvtxParamsReduce,
-    NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), root, op, datatype));
+                         NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), root, op, datatype));
 
-  struct ncclInfo info = { ncclFuncReduce, "Reduce",
-    sendbuff, recvbuff, count, datatype, op, root, comm, stream, /* Args */
-    REDUCE_CHUNKSTEPS, REDUCE_SLICESTEPS, nullptr };
+  struct ncclInfo info = {
+    ncclFuncReduce,    "Reduce",          sendbuff, recvbuff, count, datatype, op, root, comm, stream, /* Args */
+    REDUCE_CHUNKSTEPS, REDUCE_SLICESTEPS, nullptr
+  };
 
   NCCLCHECK(Recorder::instance().record(rrReduce, info));
 
   return ncclEnqueueCheck(&info);
 }
 
-
 NCCL_API(ncclResult_t, ncclReduceScatter, const void* sendbuff, void* recvbuff, size_t recvcount,
-    ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm, cudaStream_t stream);
-ncclResult_t ncclReduceScatter_impl(const void* sendbuff, void* recvbuff, size_t recvcount,
-    ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm, cudaStream_t stream) {
+         ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm, cudaStream_t stream);
+ncclResult_t ncclReduceScatter_impl(const void* sendbuff, void* recvbuff, size_t recvcount, ncclDataType_t datatype,
+                                    ncclRedOp_t op, ncclComm* comm, cudaStream_t stream) {
   NVTX3_FUNC_WITH_PARAMS(ReduceScatter, NcclNvtxParamsReduceScatter,
-    NVTX3_PAYLOAD(comm ? comm->commHash : 0, recvcount * ncclTypeSize(datatype), op, datatype));
-    // RCCL update slice steps for ReduceScatter if single node
-    const bool isGfx950 = IsArchMatch(comm->archName, "gfx950");
+                         NVTX3_PAYLOAD(comm ? comm->commHash : 0, recvcount * ncclTypeSize(datatype), op, datatype));
+  // RCCL update slice steps for ReduceScatter if single node
+  const bool isGfx950 = IsArchMatch(comm->archName, "gfx950");
 
-    int chunkSteps = (isGfx950 && comm->rcclUseOneSlice)? 1 : REDUCESCATTER_CHUNKSTEPS;
-    int sliceSteps = comm->rcclUseOneSlice
-      ? (isGfx950 ? 1 : REDUCESCATTER_SLICESTEPS_SINGLE_NODE)
-      : REDUCESCATTER_SLICESTEPS;
+  int chunkSteps = (isGfx950 && comm->rcclUseOneSlice) ? 1 : REDUCESCATTER_CHUNKSTEPS;
+  int sliceSteps =
+    comm->rcclUseOneSlice ? (isGfx950 ? 1 : REDUCESCATTER_SLICESTEPS_SINGLE_NODE) : REDUCESCATTER_SLICESTEPS;
 
-  struct ncclInfo info = { ncclFuncReduceScatter, "ReduceScatter",
-    sendbuff, recvbuff, recvcount, datatype, op, 0, comm, stream, /* Args */
-    chunkSteps, sliceSteps, nullptr };
+  struct ncclInfo info = {ncclFuncReduceScatter,
+                          "ReduceScatter",
+                          sendbuff,
+                          recvbuff,
+                          recvcount,
+                          datatype,
+                          op,
+                          0,
+                          comm,
+                          stream, /* Args */
+                          chunkSteps,
+                          sliceSteps,
+                          nullptr};
 
   int nRanks;
   NCCLCHECK(ncclCommCount(comm, &nRanks));
@@ -560,7 +642,7 @@ ncclResult_t ncclReduceScatter_impl(const void* sendbuff, void* recvbuff, size_t
 
   NCCLCHECK(Recorder::instance().record(rrReduceScatter, info));
 
-  // Reset value forcing direct reduce scatter algorithm 
+  // Reset value forcing direct reduce scatter algorithm
   comm->enableDirectReduceScatter = 0;
 
   // Skip DDA IPC and Direct RS if the symmetric path will handle this op, so they don't collide and deadlock.
@@ -572,35 +654,29 @@ ncclResult_t ncclReduceScatter_impl(const void* sendbuff, void* recvbuff, size_t
     symEligible = ncclSymkAvailable(comm, ncclFuncReduceScatter, symkOp, datatype, recvcount);
   }
 
-  if (!symEligible &&
-      rcclDdaEnabled(comm, nRanks * recvcount * ncclTypeSize(datatype), 8388608) &&
+  if (!symEligible && rcclDdaEnabled(comm, nRanks * recvcount * ncclTypeSize(datatype), 8388608) &&
       ncclReduceScatterDdaIpcEligible(comm, sendbuff, recvbuff, recvcount, datatype, op)) {
-    NCCLCHECK(ncclReduceScatterDdaIpc(
-        sendbuff,
-        recvbuff,
-        recvcount,
-        datatype,
-        op,
-        comm,
-        stream));
+    NCCLCHECK(ncclReduceScatterDdaIpc(sendbuff, recvbuff, recvcount, datatype, op, comm, stream));
     return ncclSuccess;
   }
 
   if (!symEligible && rcclUseReduceScatterDirect(comm, msgSize)) {
-    INFO(NCCL_TUNING, "RCCL DIRECT REDUCE-SCATTER recvcount=%zu msgSize=%zu rank=%d nRanks=%d nNodes=%d comm=%p stream=%p sendbuff=%p recvbuff=%p",
-      recvcount, msgSize, comm->rank, nRanks, comm->nNodes, comm, stream, sendbuff, recvbuff);
+    INFO(NCCL_TUNING,
+         "RCCL DIRECT REDUCE-SCATTER recvcount=%zu msgSize=%zu rank=%d nRanks=%d nNodes=%d comm=%p stream=%p "
+         "sendbuff=%p recvbuff=%p",
+         recvcount, msgSize, comm->rank, nRanks, comm->nNodes, comm, stream, sendbuff, recvbuff);
 
     // Temporary Buffer to store data from each rank
     void* tempbuff = comm->tempBuff;
 
     // Use Direct Reduce Scatter Algorithm
     comm->enableDirectReduceScatter = 1;
-    
+
     if (recvcount == 0) return ncclSuccess;
-    
+
     // Calculate offset into buffers
     size_t offset = recvcount * ncclTypeSize(datatype);
-    
+
     NCCLCHECK(ncclGroupStart());
     for (int i = 0; i < nRanks; i++) {
       int peer = (comm->rank + i) % nRanks;
@@ -609,103 +685,164 @@ ncclResult_t ncclReduceScatter_impl(const void* sendbuff, void* recvbuff, size_t
     }
     NCCLCHECK(ncclGroupEnd());
   }
-  
+
   return ncclEnqueueCheck(&info);
 }
 
-NCCL_API(ncclResult_t, ncclScatter, const void* sendbuff, void* recvbuff, size_t count,
-    ncclDataType_t datatype, int root, ncclComm* comm, cudaStream_t stream);
-ncclResult_t ncclScatter_impl(const void* sendbuff, void* recvbuff, size_t count,
-    ncclDataType_t datatype, int root, ncclComm* comm, cudaStream_t stream) {
+NCCL_API(ncclResult_t, ncclScatter, const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
+         int root, ncclComm* comm, cudaStream_t stream);
+ncclResult_t ncclScatter_impl(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, int root,
+                              ncclComm* comm, cudaStream_t stream) {
   NVTX3_FUNC_WITH_PARAMS(Scatter, NcclNvtxParamsScatter,
-    NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), root, datatype));
+                         NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), root, datatype));
 
   NCCLCHECK(Recorder::instance().record(rrScatter, sendbuff, recvbuff, count, datatype, comm, stream, root));
 
-  struct ncclInfo info = { ncclFuncScatter, "Scatter",
-    sendbuff, recvbuff, count, datatype, ncclSum, root, comm, stream, /* Args */
-    SCATTER_CHUNKSTEPS, SCATTER_SLICESTEPS };
+  struct ncclInfo info = {ncclFuncScatter,    "Scatter",         sendbuff, recvbuff, count,
+                          datatype,           ncclSum,           root,     comm,     stream, /* Args */
+                          SCATTER_CHUNKSTEPS, SCATTER_SLICESTEPS};
   return ncclEnqueueCheck(&info);
 }
 
-NCCL_API(ncclResult_t, ncclSend, const void* sendbuff, size_t count, ncclDataType_t datatype, int peer,
-    ncclComm_t comm, cudaStream_t stream);
-ncclResult_t ncclSend_impl(const void* sendbuff, size_t count, ncclDataType_t datatype, int peer,
-    ncclComm_t comm, cudaStream_t stream) {
+NCCL_API(ncclResult_t, ncclSend, const void* sendbuff, size_t count, ncclDataType_t datatype, int peer, ncclComm_t comm,
+         cudaStream_t stream);
+ncclResult_t ncclSend_impl(const void* sendbuff, size_t count, ncclDataType_t datatype, int peer, ncclComm_t comm,
+                           cudaStream_t stream) {
   NVTX3_FUNC_WITH_PARAMS(Send, NcclNvtxParamsSendRecv,
-    NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), peer, datatype));
+                         NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), peer, datatype));
 
-  struct ncclInfo info = { ncclFuncSend, "Send",
-    NULL, (void*)sendbuff, count, datatype, ncclSum, peer, comm, stream, /* Args */
-    1, 1, nullptr };
+  struct ncclInfo info = {ncclFuncSend,
+                          "Send",
+                          NULL,
+                          (void*)sendbuff,
+                          count,
+                          datatype,
+                          ncclSum,
+                          peer,
+                          comm,
+                          stream, /* Args */
+                          1,
+                          1,
+                          nullptr};
 
   NCCLCHECK(Recorder::instance().record(rrSend, info));
 
   return ncclEnqueueCheck(&info);
 }
 
-NCCL_API(ncclResult_t, ncclRecv, void* recvbuff, size_t count, ncclDataType_t datatype, int peer,
-    ncclComm_t comm, cudaStream_t stream);
-ncclResult_t ncclRecv_impl(void* recvbuff, size_t count, ncclDataType_t datatype, int peer,
-    ncclComm_t comm, cudaStream_t stream) {
+NCCL_API(ncclResult_t, ncclRecv, void* recvbuff, size_t count, ncclDataType_t datatype, int peer, ncclComm_t comm,
+         cudaStream_t stream);
+ncclResult_t ncclRecv_impl(void* recvbuff, size_t count, ncclDataType_t datatype, int peer, ncclComm_t comm,
+                           cudaStream_t stream) {
   NVTX3_FUNC_WITH_PARAMS(Recv, NcclNvtxParamsSendRecv,
-    NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), peer, datatype));
+                         NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), peer, datatype));
 
-  struct ncclInfo info = { ncclFuncRecv, "Recv",
-    NULL, recvbuff, count, datatype, ncclSum, peer, comm, stream, /* Args */
-    1, 1, nullptr };
+  struct ncclInfo info = {ncclFuncRecv,
+                          "Recv",
+                          NULL,
+                          recvbuff,
+                          count,
+                          datatype,
+                          ncclSum,
+                          peer,
+                          comm,
+                          stream, /* Args */
+                          1,
+                          1,
+                          nullptr};
 
   NCCLCHECK(Recorder::instance().record(rrRecv, info));
 
   return ncclEnqueueCheck(&info);
 }
 
-NCCL_API(ncclResult_t, ncclPutSignal, const void* localbuff, size_t count, ncclDataType_t datatype,
-    int peer, ncclWindow_t peerWin, size_t peerWinOffset, int sigIdx, int ctx, unsigned int flags,
-    ncclComm_t comm, cudaStream_t stream);
-ncclResult_t ncclPutSignal_impl(const void* localbuff, size_t count, ncclDataType_t datatype,
-    int peer, ncclWindow_t peerWin, size_t peerWinOffset, int sigIdx, int ctx, unsigned int flags,
-    ncclComm_t comm, cudaStream_t stream) {
+NCCL_API(ncclResult_t, ncclPutSignal, const void* localbuff, size_t count, ncclDataType_t datatype, int peer,
+         ncclWindow_t peerWin, size_t peerWinOffset, int sigIdx, int ctx, unsigned int flags, ncclComm_t comm,
+         cudaStream_t stream);
+ncclResult_t ncclPutSignal_impl(const void* localbuff, size_t count, ncclDataType_t datatype, int peer,
+                                ncclWindow_t peerWin, size_t peerWinOffset, int sigIdx, int ctx, unsigned int flags,
+                                ncclComm_t comm, cudaStream_t stream) {
   NVTX3_FUNC_WITH_PARAMS(PutSignal, NcclNvtxParamsPut,
-    NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), peer, ctx));
+                         NVTX3_PAYLOAD(comm ? comm->commHash : 0, count * ncclTypeSize(datatype), peer, ctx));
 
-  struct ncclInfo info = { ncclFuncPutSignal, "PutSignal",
-    localbuff, NULL, count, datatype, ncclSum, peer, comm, stream, /* Args */
-    1, 1, nullptr, /* chunkSteps, sliceSteps, acc */
-    false, /* useDirect */
-    peerWinOffset, peerWin, sigIdx, ctx, flags, /* peerWinOffset, peerWin, sigIdx, ctx, flags */
-    0, NULL }; /* nDesc, signalDescs */
+  struct ncclInfo info = {ncclFuncPutSignal,
+                          "PutSignal",
+                          localbuff,
+                          NULL,
+                          count,
+                          datatype,
+                          ncclSum,
+                          peer,
+                          comm,
+                          stream, /* Args */
+                          1,
+                          1,
+                          nullptr, /* chunkSteps, sliceSteps, acc */
+                          false, /* useDirect */
+                          peerWinOffset,
+                          peerWin,
+                          sigIdx,
+                          ctx,
+                          flags, /* peerWinOffset, peerWin, sigIdx, ctx, flags */
+                          0,
+                          NULL}; /* nDesc, signalDescs */
   return ncclEnqueueCheck(&info);
 }
 
-NCCL_API(ncclResult_t, ncclSignal, int peer, int sigIdx, int ctx, unsigned int flags,
-    ncclComm_t comm, cudaStream_t stream);
-ncclResult_t ncclSignal_impl(int peer, int sigIdx, int ctx, unsigned int flags,
-    ncclComm_t comm, cudaStream_t stream) {
-  NVTX3_FUNC_WITH_PARAMS(Signal, NcclNvtxParamsSignal,
-    NVTX3_PAYLOAD(comm ? comm->commHash : 0, peer, ctx));
+NCCL_API(ncclResult_t, ncclSignal, int peer, int sigIdx, int ctx, unsigned int flags, ncclComm_t comm,
+         cudaStream_t stream);
+ncclResult_t ncclSignal_impl(int peer, int sigIdx, int ctx, unsigned int flags, ncclComm_t comm, cudaStream_t stream) {
+  NVTX3_FUNC_WITH_PARAMS(Signal, NcclNvtxParamsSignal, NVTX3_PAYLOAD(comm ? comm->commHash : 0, peer, ctx));
 
-  struct ncclInfo info = { ncclFuncSignal, "Signal",
-    NULL, NULL, 0, ncclInt8, ncclSum, peer, comm, stream, /* Args */
-    1, 1, nullptr, /* chunkSteps, sliceSteps, acc */
-    false, /* useDirect */
-    0, NULL, sigIdx, ctx, flags, /* peerWinOffset, peerWin, sigIdx, ctx, flags */
-    0, NULL }; /* nDesc, signalDescs */
+  struct ncclInfo info = {ncclFuncSignal,
+                          "Signal",
+                          NULL,
+                          NULL,
+                          0,
+                          ncclInt8,
+                          ncclSum,
+                          peer,
+                          comm,
+                          stream, /* Args */
+                          1,
+                          1,
+                          nullptr, /* chunkSteps, sliceSteps, acc */
+                          false, /* useDirect */
+                          0,
+                          NULL,
+                          sigIdx,
+                          ctx,
+                          flags, /* peerWinOffset, peerWin, sigIdx, ctx, flags */
+                          0,
+                          NULL}; /* nDesc, signalDescs */
   return ncclEnqueueCheck(&info);
 }
 
-NCCL_API(ncclResult_t, ncclWaitSignal, int nDesc, ncclWaitSignalDesc_t* signalDescs,
-    ncclComm_t comm, cudaStream_t stream);
-ncclResult_t ncclWaitSignal_impl(int nDesc, ncclWaitSignalDesc_t* signalDescs,
-    ncclComm_t comm, cudaStream_t stream) {
-  NVTX3_FUNC_WITH_PARAMS(WaitSignal, NcclNvtxParamsWaitSignal,
-    NVTX3_PAYLOAD(comm ? comm->commHash : 0, nDesc, 0));
+NCCL_API(ncclResult_t, ncclWaitSignal, int nDesc, ncclWaitSignalDesc_t* signalDescs, ncclComm_t comm,
+         cudaStream_t stream);
+ncclResult_t ncclWaitSignal_impl(int nDesc, ncclWaitSignalDesc_t* signalDescs, ncclComm_t comm, cudaStream_t stream) {
+  NVTX3_FUNC_WITH_PARAMS(WaitSignal, NcclNvtxParamsWaitSignal, NVTX3_PAYLOAD(comm ? comm->commHash : 0, nDesc, 0));
 
-  struct ncclInfo info = { ncclFuncWaitSignal, "WaitSignal",
-    NULL, NULL, 0, ncclInt32, ncclSum, 0, comm, stream, /* Args */
-    1, 1, nullptr, /* chunkSteps, sliceSteps, acc */
-    false, /* useDirect */
-    0, NULL, 0, 0, 0, /* peerWinOffset, peerWin, sigIdx, ctx, flags */
-    nDesc, signalDescs }; /* nDesc, signalDescs */
+  struct ncclInfo info = {ncclFuncWaitSignal,
+                          "WaitSignal",
+                          NULL,
+                          NULL,
+                          0,
+                          ncclInt32,
+                          ncclSum,
+                          0,
+                          comm,
+                          stream, /* Args */
+                          1,
+                          1,
+                          nullptr, /* chunkSteps, sliceSteps, acc */
+                          false, /* useDirect */
+                          0,
+                          NULL,
+                          0,
+                          0,
+                          0, /* peerWinOffset, peerWin, sigIdx, ctx, flags */
+                          nDesc,
+                          signalDescs}; /* nDesc, signalDescs */
   return ncclEnqueueCheck(&info);
 }

--- a/projects/rccl/src/commDump.cc
+++ b/projects/rccl/src/commDump.cc
@@ -8,10 +8,8 @@
 #include "archinfo.h"
 #include "profiler.h"
 
-__attribute__ ((visibility("default")))
-ncclResult_t ncclCommDump(
-    const ncclComm_t comm,
-    std::unordered_map<std::string, std::string>& map) {
+__attribute__((visibility("default"))) ncclResult_t ncclCommDump(const ncclComm_t comm,
+                                                                 std::unordered_map<std::string, std::string>& map) {
   (void)map;
   if (comm == nullptr) {
     WARN("ncclCommDump comm is null");

--- a/projects/rccl/src/dda_all_gather_ipc.cu
+++ b/projects/rccl/src/dda_all_gather_ipc.cu
@@ -28,24 +28,17 @@ using nccl_dda_ipc_detail::ddaMaxNBlocksForScratch;
 using nccl_dda_ipc_detail::kDdaNranks;
 
 template <typename T>
-static ncclResult_t ncclAllGatherDdaIpcTyped(
-    const void* sendbuff,
-    void* recvbuff,
-    size_t sendcount,
-    ncclComm* comm,
-    cudaStream_t stream) {
-  if (comm->ddaIpcMemHandler == nullptr || comm->ddaIpcScratch == nullptr ||
-      comm->ddaIpcPeerPtrsDev == nullptr || comm->ddaIpcBarrierState == nullptr) {
+static ncclResult_t ncclAllGatherDdaIpcTyped(const void* sendbuff, void* recvbuff, size_t sendcount, ncclComm* comm,
+                                             cudaStream_t stream) {
+  if (comm->ddaIpcMemHandler == nullptr || comm->ddaIpcScratch == nullptr || comm->ddaIpcPeerPtrsDev == nullptr ||
+      comm->ddaIpcBarrierState == nullptr) {
     return ncclInvalidUsage;
   }
 
   const size_t totalCount = sendcount * comm->nRanks;
   if (totalCount * sizeof(T) > comm->ddaIpcScratchBytes) {
-    WARN(
-        "DDA IPC allgather: send element count %zu needs %zu bytes; comm scratch is %zu bytes",
-        sendcount,
-        totalCount * sizeof(T),
-        comm->ddaIpcScratchBytes);
+    WARN("DDA IPC allgather: send element count %zu needs %zu bytes; comm scratch is %zu bytes", sendcount,
+         totalCount * sizeof(T), comm->ddaIpcScratchBytes);
     return ncclInvalidArgument;
   }
 
@@ -55,21 +48,14 @@ static ncclResult_t ncclAllGatherDdaIpcTyped(
   const auto& grid = gridBlock.first;
   const auto& block = gridBlock.second;
 
-  auto* barrierState =
-      static_cast<DdaIpcBarrierState*>(comm->ddaIpcBarrierState);
+  auto* barrierState = static_cast<DdaIpcBarrierState*>(comm->ddaIpcBarrierState);
   meta::comms::IpcGpuBarrier barrierHost = barrierState->barrierHost;
 
   void* peerPtrsDev = comm->ddaIpcPeerPtrsDev;
   T** d_ipcbuffs = reinterpret_cast<T**>(peerPtrsDev);
 
-  meta::comms::ddaAllGatherIpc<T, kDdaNranks, false>
-      <<<grid, block, 0, stream>>>(
-          d_ipcbuffs,
-          static_cast<T*>(recvbuff),
-          sendcount,
-          static_cast<const T*>(sendbuff),
-          comm->rank,
-          barrierHost);
+  meta::comms::ddaAllGatherIpc<T, kDdaNranks, false><<<grid, block, 0, stream>>>(
+    d_ipcbuffs, static_cast<T*>(recvbuff), sendcount, static_cast<const T*>(sendbuff), comm->rank, barrierHost);
 
   CUDACHECK(cudaGetLastError());
 
@@ -78,17 +64,13 @@ static ncclResult_t ncclAllGatherDdaIpcTyped(
 
 } // namespace
 
-bool ncclAllGatherDdaIpcEligible(
-    ncclComm* comm,
-    const void* sendbuff,
-    void* recvbuff,
-    size_t sendcount,
-    ncclDataType_t datatype) {
+bool ncclAllGatherDdaIpcEligible(ncclComm* comm, const void* sendbuff, void* recvbuff, size_t sendcount,
+                                 ncclDataType_t datatype) {
   if (comm == nullptr || comm->bootstrap == nullptr) {
     return false;
   }
-  if (comm->ddaIpcMemHandler == nullptr || comm->ddaIpcScratch == nullptr ||
-      comm->ddaIpcPeerPtrsDev == nullptr || comm->ddaIpcBarrierState == nullptr) {
+  if (comm->ddaIpcMemHandler == nullptr || comm->ddaIpcScratch == nullptr || comm->ddaIpcPeerPtrsDev == nullptr ||
+      comm->ddaIpcBarrierState == nullptr) {
     return false;
   }
   if (sendcount == 0) {
@@ -100,8 +82,7 @@ bool ncclAllGatherDdaIpcEligible(
   if (comm->nRanks != nccl_dda_ipc_detail::kDdaNranks) {
     return false;
   }
-  if (datatype != ncclFloat32 && datatype != ncclFloat16 &&
-      datatype != ncclBfloat16) {
+  if (datatype != ncclFloat32 && datatype != ncclFloat16 && datatype != ncclBfloat16) {
     return false;
   }
 
@@ -118,19 +99,11 @@ bool ncclAllGatherDdaIpcEligible(
   return true;
 }
 
-ncclResult_t ncclAllGatherDdaIpc(
-    const void* sendbuff,
-    void* recvbuff,
-    size_t sendcount,
-    ncclDataType_t datatype,
-    ncclComm* comm,
-    cudaStream_t stream) {
-  if (datatype != ncclFloat32 && datatype != ncclFloat16 &&
-      datatype != ncclBfloat16) {
+ncclResult_t ncclAllGatherDdaIpc(const void* sendbuff, void* recvbuff, size_t sendcount, ncclDataType_t datatype,
+                                 ncclComm* comm, cudaStream_t stream) {
+  if (datatype != ncclFloat32 && datatype != ncclFloat16 && datatype != ncclBfloat16) {
     return ncclInvalidArgument;
   }
   int typeSize = ncclTypeSize(datatype);
-  return ncclAllGatherDdaIpcTyped<int8_t>(
-      sendbuff, recvbuff, sendcount * typeSize, comm, stream);
+  return ncclAllGatherDdaIpcTyped<int8_t>(sendbuff, recvbuff, sendcount * typeSize, comm, stream);
 }
-

--- a/projects/rccl/src/dda_all_reduce_ipc.cu
+++ b/projects/rccl/src/dda_all_reduce_ipc.cu
@@ -31,79 +31,46 @@ using nccl_dda_ipc_detail::kDdaNranks;
 constexpr size_t kDdaFlatTreeThresholdBytes = 1ULL << 18;
 
 template <typename T>
-static ncclResult_t ncclAllReduceDdaIpcTyped(
-    const void* sendbuff,
-    void* recvbuff,
-    size_t count,
-    ncclComm* comm,
-    cudaStream_t stream) {
-  if (comm->ddaIpcMemHandler == nullptr || comm->ddaIpcScratch == nullptr ||
-      comm->ddaIpcPeerPtrsDev == nullptr || comm->ddaIpcBarrierState == nullptr) {
+static ncclResult_t ncclAllReduceDdaIpcTyped(const void* sendbuff, void* recvbuff, size_t count, ncclComm* comm,
+                                             cudaStream_t stream) {
+  if (comm->ddaIpcMemHandler == nullptr || comm->ddaIpcScratch == nullptr || comm->ddaIpcPeerPtrsDev == nullptr ||
+      comm->ddaIpcBarrierState == nullptr) {
     return ncclInvalidUsage;
   }
   if (count * sizeof(T) > comm->ddaIpcScratchBytes) {
-    WARN(
-        "DDA IPC allreduce: element count %zu needs %zu bytes; comm scratch is %zu bytes",
-        count,
-        count * sizeof(T),
-        comm->ddaIpcScratchBytes);
+    WARN("DDA IPC allreduce: element count %zu needs %zu bytes; comm scratch is %zu bytes", count, count * sizeof(T),
+         comm->ddaIpcScratchBytes);
     return ncclInvalidArgument;
   }
 
   const size_t sizeBytes = count * sizeof(T);
   const unsigned threads = 512;
   const bool wantTree = sizeBytes > kDdaFlatTreeThresholdBytes;
-  const bool treeOk =
-      wantTree && (count % static_cast<size_t>(kDdaNranks) == 0);
+  const bool treeOk = wantTree && (count % static_cast<size_t>(kDdaNranks) == 0);
 
   if (wantTree && !treeOk) {
-    INFO(
-        NCCL_ALL,
-        "DDA IPC: size %zu B > 256KB but count %zu not divisible by %d; using flat kernel",
-        sizeBytes,
-        count,
-        kDdaNranks);
+    INFO(NCCL_ALL, "DDA IPC: size %zu B > 256KB but count %zu not divisible by %d; using flat kernel", sizeBytes, count,
+         kDdaNranks);
   }
 
- 
-  const int nBlocksMax = ddaMaxNBlocksForScratch(); 
+  const int nBlocksMax = ddaMaxNBlocksForScratch();
   auto gridBlock = meta::comms::getGridAndBlockDims(count, sizeof(T), nBlocksMax);
   const auto& grid = gridBlock.first;
   const auto& block = gridBlock.second;
 
-  auto* barrierState =
-      static_cast<DdaIpcBarrierState*>(comm->ddaIpcBarrierState);
+  auto* barrierState = static_cast<DdaIpcBarrierState*>(comm->ddaIpcBarrierState);
   meta::comms::IpcGpuBarrier barrierHost = barrierState->barrierHost;
 
   void* peerPtrsDev = comm->ddaIpcPeerPtrsDev;
   T** d_ipcbuffs = reinterpret_cast<T**>(peerPtrsDev);
 
   if (treeOk) {
-    CUDACHECK(cudaMemcpyAsync(
-        comm->ddaIpcScratch,
-        sendbuff,
-        count * sizeof(T),
-        cudaMemcpyDeviceToDevice,
-        stream));
-    meta::comms::ddaAllReduceTreeIpc<T, kDdaNranks, false>
-        <<<grid, block, 0, stream>>>(
-            d_ipcbuffs,
-            static_cast<T*>(recvbuff),
-            count,
-            static_cast<const T*>(sendbuff),
-            comm->rank,
-            barrierHost,
-            nullptr);
+    CUDACHECK(cudaMemcpyAsync(comm->ddaIpcScratch, sendbuff, count * sizeof(T), cudaMemcpyDeviceToDevice, stream));
+    meta::comms::ddaAllReduceTreeIpc<T, kDdaNranks, false><<<grid, block, 0, stream>>>(
+      d_ipcbuffs, static_cast<T*>(recvbuff), count, static_cast<const T*>(sendbuff), comm->rank, barrierHost, nullptr);
   } else {
-    meta::comms::ddaAllReduceFlatIpc<T, kDdaNranks, false>
-        <<<grid, block, 0, stream>>>(
-            d_ipcbuffs,
-            static_cast<T*>(recvbuff),
-            count,
-            static_cast<const T*>(sendbuff),
-            comm->rank,
-            barrierHost,
-            nullptr);
+    meta::comms::ddaAllReduceFlatIpc<T, kDdaNranks, false><<<grid, block, 0, stream>>>(
+      d_ipcbuffs, static_cast<T*>(recvbuff), count, static_cast<const T*>(sendbuff), comm->rank, barrierHost, nullptr);
   }
 
   CUDACHECK(cudaGetLastError());
@@ -113,18 +80,13 @@ static ncclResult_t ncclAllReduceDdaIpcTyped(
 
 } // namespace
 
-bool ncclAllReduceDdaIpcEligible(
-    ncclComm* comm,
-    const void* sendbuff,
-    void* recvbuff,
-    size_t count,
-    ncclDataType_t datatype,
-    ncclRedOp_t op) {
+bool ncclAllReduceDdaIpcEligible(ncclComm* comm, const void* sendbuff, void* recvbuff, size_t count,
+                                 ncclDataType_t datatype, ncclRedOp_t op) {
   if (comm == nullptr || comm->bootstrap == nullptr) {
     return false;
   }
-  if (comm->ddaIpcMemHandler == nullptr || comm->ddaIpcScratch == nullptr ||
-      comm->ddaIpcPeerPtrsDev == nullptr || comm->ddaIpcBarrierState == nullptr) {
+  if (comm->ddaIpcMemHandler == nullptr || comm->ddaIpcScratch == nullptr || comm->ddaIpcPeerPtrsDev == nullptr ||
+      comm->ddaIpcBarrierState == nullptr) {
     return false;
   }
   if (count == 0) {
@@ -139,8 +101,7 @@ bool ncclAllReduceDdaIpcEligible(
   if (op != ncclSum) {
     return false;
   }
-  if (datatype != ncclFloat32 && datatype != ncclFloat16 &&
-      datatype != ncclBfloat16) {
+  if (datatype != ncclFloat32 && datatype != ncclFloat16 && datatype != ncclBfloat16) {
     return false;
   }
   size_t need = count * 4;
@@ -150,40 +111,31 @@ bool ncclAllReduceDdaIpcEligible(
   if (need > comm->ddaIpcScratchBytes) {
     return false;
   }
-  if ((count *  ncclTypeSize(datatype)) % 16) {
+  if ((count * ncclTypeSize(datatype)) % 16) {
     // 16 byte alignment as we do 16-byte loads in DDA kernel
     return false;
   }
-  if ((count *  ncclTypeSize(datatype)) > kDdaFlatTreeThresholdBytes) {
+  if ((count * ncclTypeSize(datatype)) > kDdaFlatTreeThresholdBytes) {
     if (count % comm->nRanks || ((count / comm->nRanks * ncclTypeSize(datatype)) % 16)) {
       // In two-shot algo, each rank is reduces count/nRanks_ elements so we
       // need to make sure that is 16-byte aligned
       return false;
-    }	
+    }
   }
 
   return true;
 }
 
-ncclResult_t ncclAllReduceDdaIpc(
-    const void* sendbuff,
-    void* recvbuff,
-    size_t count,
-    ncclDataType_t datatype,
-    ncclRedOp_t op,
-    ncclComm* comm,
-    cudaStream_t stream) {
+ncclResult_t ncclAllReduceDdaIpc(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
+                                 ncclRedOp_t op, ncclComm* comm, cudaStream_t stream) {
   (void)op;
   switch (datatype) {
   case ncclFloat32:
-    return ncclAllReduceDdaIpcTyped<float>(
-        sendbuff, recvbuff, count, comm, stream);
+    return ncclAllReduceDdaIpcTyped<float>(sendbuff, recvbuff, count, comm, stream);
   case ncclFloat16:
-    return ncclAllReduceDdaIpcTyped<half>(
-        sendbuff, recvbuff, count, comm, stream);
+    return ncclAllReduceDdaIpcTyped<half>(sendbuff, recvbuff, count, comm, stream);
   case ncclBfloat16:
-    return ncclAllReduceDdaIpcTyped<bf16>(
-        sendbuff, recvbuff, count, comm, stream);
+    return ncclAllReduceDdaIpcTyped<bf16>(sendbuff, recvbuff, count, comm, stream);
   default:
     return ncclInvalidArgument;
   }

--- a/projects/rccl/src/dda_alltoall_ipc.cu
+++ b/projects/rccl/src/dda_alltoall_ipc.cu
@@ -28,24 +28,17 @@ using nccl_dda_ipc_detail::ddaMaxNBlocksForScratch;
 using nccl_dda_ipc_detail::kDdaNranks;
 
 template <typename T>
-static ncclResult_t ncclAllToAllDdaIpcTyped(
-    const void* sendbuff,
-    void* recvbuff,
-    size_t count,
-    ncclComm* comm,
-    cudaStream_t stream) {
-  if (comm->ddaIpcMemHandler == nullptr || comm->ddaIpcScratch == nullptr ||
-      comm->ddaIpcPeerPtrsDev == nullptr || comm->ddaIpcBarrierState == nullptr) {
+static ncclResult_t ncclAllToAllDdaIpcTyped(const void* sendbuff, void* recvbuff, size_t count, ncclComm* comm,
+                                            cudaStream_t stream) {
+  if (comm->ddaIpcMemHandler == nullptr || comm->ddaIpcScratch == nullptr || comm->ddaIpcPeerPtrsDev == nullptr ||
+      comm->ddaIpcBarrierState == nullptr) {
     return ncclInvalidUsage;
   }
 
   const size_t totalCount = count * comm->nRanks;
   if (totalCount * sizeof(T) > comm->ddaIpcScratchBytes) {
-    WARN(
-        "DDA IPC alltoall: total element count %zu needs %zu bytes; comm scratch is %zu bytes",
-        totalCount,
-        totalCount * sizeof(T),
-        comm->ddaIpcScratchBytes);
+    WARN("DDA IPC alltoall: total element count %zu needs %zu bytes; comm scratch is %zu bytes", totalCount,
+         totalCount * sizeof(T), comm->ddaIpcScratchBytes);
     return ncclInvalidArgument;
   }
 
@@ -55,21 +48,14 @@ static ncclResult_t ncclAllToAllDdaIpcTyped(
   const auto& grid = gridBlock.first;
   const auto& block = gridBlock.second;
 
-  auto* barrierState =
-      static_cast<DdaIpcBarrierState*>(comm->ddaIpcBarrierState);
+  auto* barrierState = static_cast<DdaIpcBarrierState*>(comm->ddaIpcBarrierState);
   meta::comms::IpcGpuBarrier barrierHost = barrierState->barrierHost;
 
   void* peerPtrsDev = comm->ddaIpcPeerPtrsDev;
   T** d_ipcbuffs = reinterpret_cast<T**>(peerPtrsDev);
 
-  meta::comms::ddaAllToAllIpc<T, kDdaNranks, false>
-      <<<grid, block, 0, stream>>>(
-          d_ipcbuffs,
-          static_cast<T*>(recvbuff),
-          count,
-          static_cast<const T*>(sendbuff),
-          comm->rank,
-          barrierHost);
+  meta::comms::ddaAllToAllIpc<T, kDdaNranks, false><<<grid, block, 0, stream>>>(
+    d_ipcbuffs, static_cast<T*>(recvbuff), count, static_cast<const T*>(sendbuff), comm->rank, barrierHost);
   CUDACHECK(cudaGetLastError());
 
   return ncclSuccess;
@@ -77,17 +63,13 @@ static ncclResult_t ncclAllToAllDdaIpcTyped(
 
 } // namespace
 
-bool ncclAllToAllDdaIpcEligible(
-    ncclComm* comm,
-    const void* sendbuff,
-    void* recvbuff,
-    size_t count,
-    ncclDataType_t datatype) {
+bool ncclAllToAllDdaIpcEligible(ncclComm* comm, const void* sendbuff, void* recvbuff, size_t count,
+                                ncclDataType_t datatype) {
   if (comm == nullptr || comm->bootstrap == nullptr) {
     return false;
   }
-  if (comm->ddaIpcMemHandler == nullptr || comm->ddaIpcScratch == nullptr ||
-      comm->ddaIpcPeerPtrsDev == nullptr || comm->ddaIpcBarrierState == nullptr) {
+  if (comm->ddaIpcMemHandler == nullptr || comm->ddaIpcScratch == nullptr || comm->ddaIpcPeerPtrsDev == nullptr ||
+      comm->ddaIpcBarrierState == nullptr) {
     return false;
   }
   if (count == 0) {
@@ -99,8 +81,7 @@ bool ncclAllToAllDdaIpcEligible(
   if (comm->nRanks != nccl_dda_ipc_detail::kDdaNranks) {
     return false;
   }
-  if (datatype != ncclFloat32 && datatype != ncclFloat16 &&
-      datatype != ncclBfloat16) {
+  if (datatype != ncclFloat32 && datatype != ncclFloat16 && datatype != ncclBfloat16) {
     return false;
   }
 
@@ -118,19 +99,11 @@ bool ncclAllToAllDdaIpcEligible(
   return true;
 }
 
-ncclResult_t ncclAllToAllDdaIpc(
-    const void* sendbuff,
-    void* recvbuff,
-    size_t count,
-    ncclDataType_t datatype,
-    ncclComm* comm,
-    cudaStream_t stream) {
-
-  if (datatype != ncclFloat32 && datatype != ncclFloat16 &&
-      datatype != ncclBfloat16) {
+ncclResult_t ncclAllToAllDdaIpc(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
+                                ncclComm* comm, cudaStream_t stream) {
+  if (datatype != ncclFloat32 && datatype != ncclFloat16 && datatype != ncclBfloat16) {
     return ncclInvalidArgument;
   }
   int typeSize = ncclTypeSize(datatype);
-  return ncclAllToAllDdaIpcTyped<int8_t>(
-        sendbuff, recvbuff, count * typeSize, comm, stream);
+  return ncclAllToAllDdaIpcTyped<int8_t>(sendbuff, recvbuff, count * typeSize, comm, stream);
 }

--- a/projects/rccl/src/dda_reduce_scatter_ipc.cu
+++ b/projects/rccl/src/dda_reduce_scatter_ipc.cu
@@ -28,24 +28,17 @@ using nccl_dda_ipc_detail::ddaMaxNBlocksForScratch;
 using nccl_dda_ipc_detail::kDdaNranks;
 
 template <typename T>
-static ncclResult_t ncclReduceScatterDdaIpcTyped(
-    const void* sendbuff,
-    void* recvbuff,
-    size_t recvcount,
-    ncclComm* comm,
-    cudaStream_t stream) {
-  if (comm->ddaIpcMemHandler == nullptr || comm->ddaIpcScratch == nullptr ||
-      comm->ddaIpcPeerPtrsDev == nullptr || comm->ddaIpcBarrierState == nullptr) {
+static ncclResult_t ncclReduceScatterDdaIpcTyped(const void* sendbuff, void* recvbuff, size_t recvcount, ncclComm* comm,
+                                                 cudaStream_t stream) {
+  if (comm->ddaIpcMemHandler == nullptr || comm->ddaIpcScratch == nullptr || comm->ddaIpcPeerPtrsDev == nullptr ||
+      comm->ddaIpcBarrierState == nullptr) {
     return ncclInvalidUsage;
   }
 
   const size_t totalCount = recvcount * comm->nRanks;
   if (totalCount * sizeof(T) > comm->ddaIpcScratchBytes) {
-    WARN(
-        "DDA IPC reduce-scatter: total element count %zu needs %zu bytes; comm scratch is %zu bytes",
-        totalCount,
-        totalCount * sizeof(T),
-        comm->ddaIpcScratchBytes);
+    WARN("DDA IPC reduce-scatter: total element count %zu needs %zu bytes; comm scratch is %zu bytes", totalCount,
+         totalCount * sizeof(T), comm->ddaIpcScratchBytes);
     return ncclInvalidArgument;
   }
 
@@ -55,27 +48,15 @@ static ncclResult_t ncclReduceScatterDdaIpcTyped(
   const auto& grid = gridBlock.first;
   const auto& block = gridBlock.second;
 
-  auto* barrierState =
-      static_cast<DdaIpcBarrierState*>(comm->ddaIpcBarrierState);
+  auto* barrierState = static_cast<DdaIpcBarrierState*>(comm->ddaIpcBarrierState);
   meta::comms::IpcGpuBarrier barrierHost = barrierState->barrierHost;
 
   void* peerPtrsDev = comm->ddaIpcPeerPtrsDev;
   T** d_ipcbuffs = reinterpret_cast<T**>(peerPtrsDev);
 
-  CUDACHECK(cudaMemcpyAsync(
-        comm->ddaIpcScratch,
-        sendbuff,
-        totalCount * sizeof(T),
-        cudaMemcpyDeviceToDevice,
-        stream));
-  meta::comms::ddaReduceScatterIpc<T, kDdaNranks, false>
-      <<<grid, block, 0, stream>>>(
-          d_ipcbuffs,
-          static_cast<T*>(recvbuff),
-          recvcount,
-          static_cast<const T*>(sendbuff),
-          comm->rank,
-          barrierHost);
+  CUDACHECK(cudaMemcpyAsync(comm->ddaIpcScratch, sendbuff, totalCount * sizeof(T), cudaMemcpyDeviceToDevice, stream));
+  meta::comms::ddaReduceScatterIpc<T, kDdaNranks, false><<<grid, block, 0, stream>>>(
+    d_ipcbuffs, static_cast<T*>(recvbuff), recvcount, static_cast<const T*>(sendbuff), comm->rank, barrierHost);
   CUDACHECK(cudaGetLastError());
 
   return ncclSuccess;
@@ -83,18 +64,13 @@ static ncclResult_t ncclReduceScatterDdaIpcTyped(
 
 } // namespace
 
-bool ncclReduceScatterDdaIpcEligible(
-    ncclComm* comm,
-    const void* sendbuff,
-    void* recvbuff,
-    size_t recvcount,
-    ncclDataType_t datatype,
-    ncclRedOp_t op) {
+bool ncclReduceScatterDdaIpcEligible(ncclComm* comm, const void* sendbuff, void* recvbuff, size_t recvcount,
+                                     ncclDataType_t datatype, ncclRedOp_t op) {
   if (comm == nullptr || comm->bootstrap == nullptr) {
     return false;
   }
-  if (comm->ddaIpcMemHandler == nullptr || comm->ddaIpcScratch == nullptr ||
-      comm->ddaIpcPeerPtrsDev == nullptr || comm->ddaIpcBarrierState == nullptr) {
+  if (comm->ddaIpcMemHandler == nullptr || comm->ddaIpcScratch == nullptr || comm->ddaIpcPeerPtrsDev == nullptr ||
+      comm->ddaIpcBarrierState == nullptr) {
     return false;
   }
   if (recvcount == 0) {
@@ -109,8 +85,7 @@ bool ncclReduceScatterDdaIpcEligible(
   if (op != ncclSum) {
     return false;
   }
-  if (datatype != ncclFloat32 && datatype != ncclFloat16 &&
-      datatype != ncclBfloat16) {
+  if (datatype != ncclFloat32 && datatype != ncclFloat16 && datatype != ncclBfloat16) {
     return false;
   }
 
@@ -133,27 +108,17 @@ bool ncclReduceScatterDdaIpcEligible(
   return true;
 }
 
-ncclResult_t ncclReduceScatterDdaIpc(
-    const void* sendbuff,
-    void* recvbuff,
-    size_t recvcount,
-    ncclDataType_t datatype,
-    ncclRedOp_t op,
-    ncclComm* comm,
-    cudaStream_t stream) {
+ncclResult_t ncclReduceScatterDdaIpc(const void* sendbuff, void* recvbuff, size_t recvcount, ncclDataType_t datatype,
+                                     ncclRedOp_t op, ncclComm* comm, cudaStream_t stream) {
   (void)op;
   switch (datatype) {
   case ncclFloat32:
-    return ncclReduceScatterDdaIpcTyped<float>(
-        sendbuff, recvbuff, recvcount, comm, stream);
+    return ncclReduceScatterDdaIpcTyped<float>(sendbuff, recvbuff, recvcount, comm, stream);
   case ncclFloat16:
-    return ncclReduceScatterDdaIpcTyped<half>(
-        sendbuff, recvbuff, recvcount, comm, stream);
+    return ncclReduceScatterDdaIpcTyped<half>(sendbuff, recvbuff, recvcount, comm, stream);
   case ncclBfloat16:
-    return ncclReduceScatterDdaIpcTyped<bf16>(
-        sendbuff, recvbuff, recvcount, comm, stream);
+    return ncclReduceScatterDdaIpcTyped<bf16>(sendbuff, recvbuff, recvcount, comm, stream);
   default:
     return ncclInvalidArgument;
   }
 }
-

--- a/projects/rccl/src/debug.cc
+++ b/projects/rccl/src/debug.cc
@@ -33,7 +33,7 @@ static char hostname[1024];
 thread_local int ncclDebugNoWarn = 0;
 char ncclLastError[1024] = ""; // Global string for the last error in human readable form
 __attribute__((visibility("default"))) uint64_t ncclDebugMask = 0;
-FILE *ncclDebugFile = stdout;
+FILE* ncclDebugFile = stdout;
 static pthread_mutex_t ncclDebugLock = PTHREAD_MUTEX_INITIALIZER;
 static std::chrono::steady_clock::time_point ncclEpoch;
 static bool ncclWarnSetDebugInfo = false;
@@ -46,7 +46,7 @@ static ncclResult_t getHostNameForLog(char* hostname, int maxlen, const char del
   ncclResult_t ret = getHostName(hostname, maxlen, delim);
   if (ret != ncclSuccess) return ret;
 
-  for (int i = 0; i < maxlen-1 && hostname[i]; ++i) {
+  for (int i = 0; i < maxlen - 1 && hostname[i]; ++i) {
     // Replace special characters in hostnames with dashes
     switch (hostname[i]) {
     case '%':
@@ -95,10 +95,13 @@ static void ncclDebugInit() {
   const char* ncclDebugSubsysEnv = getEnvFunc("NCCL_DEBUG_SUBSYS");
   if (ncclDebugSubsysEnv != NULL) {
     int invert = 0;
-    if (ncclDebugSubsysEnv[0] == '^') { invert = 1; ncclDebugSubsysEnv++; }
+    if (ncclDebugSubsysEnv[0] == '^') {
+      invert = 1;
+      ncclDebugSubsysEnv++;
+    }
     tempNcclDebugMask = invert ? ~0ULL : 0ULL;
-    char *ncclDebugSubsys = strdup(ncclDebugSubsysEnv);
-    char *subsys = strtok(ncclDebugSubsys, ",");
+    char* ncclDebugSubsys = strdup(ncclDebugSubsysEnv);
+    char* subsys = strtok(ncclDebugSubsys, ",");
     while (subsys != NULL) {
       uint64_t mask = 0;
       if (strcasecmp(subsys, "INIT") == 0) {
@@ -141,7 +144,8 @@ static void ncclDebugInit() {
         mask = NCCL_ALL;
       }
       if (mask) {
-        if (invert) tempNcclDebugMask &= ~mask; else tempNcclDebugMask |= mask;
+        if (invert) tempNcclDebugMask &= ~mask;
+        else tempNcclDebugMask |= mask;
       }
       subsys = strtok(NULL, ",");
     }
@@ -153,34 +157,36 @@ static void ncclDebugInit() {
     int64_t value;
     errno = 0;
     value = strtoll(ncclWarnSetDebugInfoEnv, NULL, 0);
-    if (!errno)
-      ncclWarnSetDebugInfo = value;
+    if (!errno) ncclWarnSetDebugInfo = value;
   }
 
   // Determine which debug levels will have timestamps.
   const char* timestamps = getEnvFunc("NCCL_DEBUG_TIMESTAMP_LEVELS");
   if (timestamps == nullptr) {
-    ncclDebugTimestampLevels = (1<<NCCL_LOG_WARN);
+    ncclDebugTimestampLevels = (1 << NCCL_LOG_WARN);
   } else {
     int invert = 0;
-    if (timestamps[0] == '^') { invert = 1; ++timestamps; }
+    if (timestamps[0] == '^') {
+      invert = 1;
+      ++timestamps;
+    }
     ncclDebugTimestampLevels = invert ? ~0U : 0U;
-    char *timestampsDup = strdup(timestamps);
-    char *level = strtok(timestampsDup, ",");
+    char* timestampsDup = strdup(timestamps);
+    char* level = strtok(timestampsDup, ",");
     while (level != NULL) {
       uint32_t mask = 0;
       if (strcasecmp(level, "ALL") == 0) {
         mask = ~0U;
       } else if (strcasecmp(level, "VERSION") == 0) {
-        mask = (1<<NCCL_LOG_VERSION);
+        mask = (1 << NCCL_LOG_VERSION);
       } else if (strcasecmp(level, "WARN") == 0) {
-        mask = (1<<NCCL_LOG_WARN);
+        mask = (1 << NCCL_LOG_WARN);
       } else if (strcasecmp(level, "INFO") == 0) {
-        mask = (1<<NCCL_LOG_INFO);
+        mask = (1 << NCCL_LOG_INFO);
       } else if (strcasecmp(level, "ABORT") == 0) {
-        mask = (1<<NCCL_LOG_ABORT);
+        mask = (1 << NCCL_LOG_ABORT);
       } else if (strcasecmp(level, "TRACE") == 0) {
-        mask = (1<<NCCL_LOG_TRACE);
+        mask = (1 << NCCL_LOG_TRACE);
       } else {
         // Silently fail.
       }
@@ -198,18 +204,18 @@ static void ncclDebugInit() {
   if (tsFormat == nullptr) tsFormat = "[%F %T] ";
   ncclDebugTimestampSubsecondsStart = -1;
   // Find where the subseconds are in the format.
-  for (int i=0; tsFormat[i] != '\0'; ++i) {
-    if (tsFormat[i]=='%' && tsFormat[i+1]=='%') { // Next two chars are "%"
+  for (int i = 0; tsFormat[i] != '\0'; ++i) {
+    if (tsFormat[i] == '%' && tsFormat[i + 1] == '%') { // Next two chars are "%"
       // Skip the next character, too, and restart checking after that.
       ++i;
       continue;
     }
-    if (tsFormat[i]=='%' &&                               // Found a percentage
-        ('1' <= tsFormat[i+1] && tsFormat[i+1] <= '9') && // Next char is a digit between 1 and 9 inclusive
-        tsFormat[i+2]=='f'                                // Two characters later is an "f"
-        ) {
+    if (tsFormat[i] == '%' &&                               // Found a percentage
+        ('1' <= tsFormat[i + 1] && tsFormat[i + 1] <= '9') && // Next char is a digit between 1 and 9 inclusive
+        tsFormat[i + 2] == 'f'                                // Two characters later is an "f"
+    ) {
       constexpr int replaceLen = sizeof("%Xf") - 1;
-      ncclDebugTimestampSubsecondDigits = tsFormat[i+1] - '0';
+      ncclDebugTimestampSubsecondDigits = tsFormat[i + 1] - '0';
       if (ncclDebugTimestampSubsecondDigits + strlen(tsFormat) - replaceLen > sizeof(ncclDebugTimestampFormat) - 1) {
         // Won't fit; fall back on the default.
         break;
@@ -218,11 +224,11 @@ static void ncclDebugInit() {
       ncclDebugTimestampMaxSubseconds = 1;
 
       memcpy(ncclDebugTimestampFormat, tsFormat, i);
-      for (int j=0; j<ncclDebugTimestampSubsecondDigits; ++j) {
-        ncclDebugTimestampFormat[i+j] = ' ';
+      for (int j = 0; j < ncclDebugTimestampSubsecondDigits; ++j) {
+        ncclDebugTimestampFormat[i + j] = ' ';
         ncclDebugTimestampMaxSubseconds *= 10;
       }
-      strcpy(ncclDebugTimestampFormat+i+ncclDebugTimestampSubsecondDigits, tsFormat+i+replaceLen);
+      strcpy(ncclDebugTimestampFormat + i + ncclDebugTimestampSubsecondDigits, tsFormat + i + replaceLen);
       break;
     }
   }
@@ -235,8 +241,8 @@ static void ncclDebugInit() {
   }
 
   // Replace underscore with spaces... it is hard to put spaces in command line parameters.
-  for (int i=0; ncclDebugTimestampFormat[i] != '\0'; ++i) {
-    if (ncclDebugTimestampFormat[i]=='_') ncclDebugTimestampFormat[i] = ' ';
+  for (int i = 0; ncclDebugTimestampFormat[i] != '\0'; ++i) {
+    if (ncclDebugTimestampFormat[i] == '_') ncclDebugTimestampFormat[i] = ' ';
   }
 
   // Cache pid and hostname
@@ -250,29 +256,29 @@ static void ncclDebugInit() {
   const char* ncclDebugFileEnv = getEnvFunc("NCCL_DEBUG_FILE");
   if (tempNcclDebugLevel > NCCL_LOG_VERSION && ncclDebugFileEnv != NULL) {
     int c = 0;
-    char debugFn[PATH_MAX+1] = "";
-    char *dfn = debugFn;
+    char debugFn[PATH_MAX + 1] = "";
+    char* dfn = debugFn;
     while (ncclDebugFileEnv[c] != '\0' && (dfn - debugFn) < PATH_MAX) {
       if (ncclDebugFileEnv[c++] != '%') {
-        *dfn++ = ncclDebugFileEnv[c-1];
+        *dfn++ = ncclDebugFileEnv[c - 1];
         continue;
       }
       switch (ncclDebugFileEnv[c++]) {
-        case '%': // Double %
-          *dfn++ = '%';
-          break;
-        case 'h': // %h = hostname
-          dfn += snprintf(dfn, PATH_MAX + 1 - (dfn - debugFn), "%s", hostname);
-          break;
-        case 'p': // %p = pid
-          dfn += snprintf(dfn, PATH_MAX + 1 - (dfn - debugFn), "%d", pid);
-          break;
-        default: // Echo everything we don't understand
-          *dfn++ = '%';
-          if ((dfn - debugFn) < PATH_MAX) {
-            *dfn++ = ncclDebugFileEnv[c-1];
-          }
-          break;
+      case '%': // Double %
+        *dfn++ = '%';
+        break;
+      case 'h': // %h = hostname
+        dfn += snprintf(dfn, PATH_MAX + 1 - (dfn - debugFn), "%s", hostname);
+        break;
+      case 'p': // %p = pid
+        dfn += snprintf(dfn, PATH_MAX + 1 - (dfn - debugFn), "%d", pid);
+        break;
+      default: // Echo everything we don't understand
+        *dfn++ = '%';
+        if ((dfn - debugFn) < PATH_MAX) {
+          *dfn++ = ncclDebugFileEnv[c - 1];
+        }
+        break;
       }
       if ((dfn - debugFn) > PATH_MAX) {
         // snprintf wanted to overfill the buffer: set dfn to the end
@@ -283,7 +289,7 @@ static void ncclDebugInit() {
     }
     *dfn = '\0';
     if (debugFn[0] != '\0') {
-      FILE *file = fopen(debugFn, "w");
+      FILE* file = fopen(debugFn, "w");
       if (file != nullptr) {
 #if defined(NCCL_OS_LINUX)
         setlinebuf(file); // disable block buffering
@@ -304,11 +310,14 @@ static void ncclDebugInit() {
  * Also exported to the dynamically loadable Net transport modules so
  * they can share the debugging mechanisms and output files
  */
-void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *filefunc, int line, const char *fmt, ...) {
+void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char* filefunc, int line, const char* fmt, ...) {
   bool locked = false; // Keeps track of the ncclDebugLock state.
   int gotLevel = COMPILER_ATOMIC_LOAD(&ncclDebugLevel, std::memory_order_acquire);
 
-  if (ncclDebugNoWarn != 0 && level == NCCL_LOG_WARN) { level = NCCL_LOG_INFO; flags = ncclDebugNoWarn; }
+  if (ncclDebugNoWarn != 0 && level == NCCL_LOG_WARN) {
+    level = NCCL_LOG_INFO;
+    flags = ncclDebugNoWarn;
+  }
 
   // Save the last error (WARN) as a human readable string
   if (level == NCCL_LOG_WARN) {
@@ -316,13 +325,12 @@ void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *file
     locked = true;
     va_list vargs;
     va_start(vargs, fmt);
-    (void) vsnprintf(ncclLastError, sizeof(ncclLastError), fmt, vargs);
+    (void)vsnprintf(ncclLastError, sizeof(ncclLastError), fmt, vargs);
     va_end(vargs);
   }
 
   if (gotLevel >= 0 && (gotLevel < level || (flags & ncclDebugMask) == 0)) {
-    if (locked)
-      pthread_mutex_unlock(&ncclDebugLock);
+    if (locked) pthread_mutex_unlock(&ncclDebugLock);
     return;
   }
 
@@ -331,8 +339,7 @@ void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *file
     locked = true;
   }
   // From this point on ncclDebugLock is always locked so we don't need to check "locked" anymore.
-  if (ncclDebugLevel < 0)
-    ncclDebugInit();
+  if (ncclDebugLevel < 0) ncclDebugInit();
   if (ncclDebugLevel < level || ((flags & ncclDebugMask) == 0)) {
     pthread_mutex_unlock(&ncclDebugLock);
     return;
@@ -351,7 +358,7 @@ void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *file
   };
 
   // Add the timestamp to the buffer if they are turned on for this level.
-  if (ncclDebugTimestampLevels & (1<<level)) {
+  if (ncclDebugTimestampLevels & (1 << level)) {
     if (ncclDebugTimestampFormat[0] != '\0') {
       struct timespec ts;
       clockRealtime(&ts);
@@ -366,29 +373,28 @@ void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *file
       if (ncclDebugTimestampSubsecondsStart != -1) {
         pformat = localTimestampFormat;   // Need to use the local version which has subseconds
         memcpy(localTimestampFormat, ncclDebugTimestampFormat, ncclDebugTimestampSubsecondsStart);
-        snprintf(localTimestampFormat + ncclDebugTimestampSubsecondsStart,
-                 ncclDebugTimestampSubsecondDigits+1,
+        snprintf(localTimestampFormat + ncclDebugTimestampSubsecondsStart, ncclDebugTimestampSubsecondDigits + 1,
                  "%0*" PRIu64, ncclDebugTimestampSubsecondDigits,
-                 (uint64_t)(nowNs / (1000000000L/ncclDebugTimestampMaxSubseconds)));
-        strcpy(    localTimestampFormat+ncclDebugTimestampSubsecondsStart+ncclDebugTimestampSubsecondDigits,
-               ncclDebugTimestampFormat+ncclDebugTimestampSubsecondsStart+ncclDebugTimestampSubsecondDigits);
+                 (uint64_t)(nowNs / (1000000000L / ncclDebugTimestampMaxSubseconds)));
+        strcpy(localTimestampFormat + ncclDebugTimestampSubsecondsStart + ncclDebugTimestampSubsecondDigits,
+               ncclDebugTimestampFormat + ncclDebugTimestampSubsecondsStart + ncclDebugTimestampSubsecondDigits);
       }
 
       // Format the time. If it runs out of space, fall back on a simpler format.
-      int adv = std::strftime(buffer+len, sizeof(buffer)-len, pformat, &nowTm);
-      if (adv==0 && ncclDebugTimestampFormat[0] != '\0') {
+      int adv = std::strftime(buffer + len, sizeof(buffer) - len, pformat, &nowTm);
+      if (adv == 0 && ncclDebugTimestampFormat[0] != '\0') {
         // Ran out of space. Fall back on the default. This should never fail.
-        adv = std::strftime(buffer+len, sizeof(buffer)-len, "[%F %T] ", &nowTm);
+        adv = std::strftime(buffer + len, sizeof(buffer) - len, "[%F %T] ", &nowTm);
       }
       len += adv;
     }
   }
-  len = std::min(len, sizeof(buffer)-1);  // prevent overflows
+  len = std::min(len, sizeof(buffer) - 1);  // prevent overflows
 
   // Add hostname, pid and tid portion of the log line.
   if (level != NCCL_LOG_VERSION) {
-    len += snprintf(buffer+len, sizeof(buffer)-len, "%s:%d:%d ", hostname, pid, tid);
-    len = std::min(len, sizeof(buffer)-1);  // prevent overflows
+    len += snprintf(buffer + len, sizeof(buffer) - len, "%s:%d:%d ", hostname, pid, tid);
+    len = std::min(len, sizeof(buffer) - 1);  // prevent overflows
   }
 
   int cudaDev = 0;
@@ -398,29 +404,31 @@ void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *file
 
   // Add level specific formatting.
   if (level == NCCL_LOG_WARN) {
-    len += snprintf(buffer+len, sizeof(buffer)-len, "[%d] %s:%d NCCL WARN ", cudaDev, filefunc, line);
-    if (ncclWarnSetDebugInfo) COMPILER_ATOMIC_STORE(&ncclDebugLevel, static_cast<int>(NCCL_LOG_INFO), std::memory_order_release);
+    len += snprintf(buffer + len, sizeof(buffer) - len, "[%d] %s:%d NCCL WARN ", cudaDev, filefunc, line);
+    if (ncclWarnSetDebugInfo)
+      COMPILER_ATOMIC_STORE(&ncclDebugLevel, static_cast<int>(NCCL_LOG_INFO), std::memory_order_release);
   } else if (level == NCCL_LOG_INFO) {
-    len += snprintf(buffer+len, sizeof(buffer)-len, "[%d] NCCL INFO ", cudaDev);
+    len += snprintf(buffer + len, sizeof(buffer) - len, "[%d] NCCL INFO ", cudaDev);
   } else if (level == NCCL_LOG_TRACE && flags == NCCL_CALL) {
-    len += snprintf(buffer+len, sizeof(buffer)-len, "NCCL CALL ");
+    len += snprintf(buffer + len, sizeof(buffer) - len, "NCCL CALL ");
   } else if (level == NCCL_LOG_TRACE) {
     auto delta = std::chrono::steady_clock::now() - ncclEpoch;
-    double timestamp = std::chrono::duration_cast<std::chrono::duration<double>>(delta).count()*1000;
-    len += snprintf(buffer+len, sizeof(buffer)-len, "[%d] %f %s:%d NCCL TRACE ", cudaDev, timestamp, filefunc, line);
+    double timestamp = std::chrono::duration_cast<std::chrono::duration<double>>(delta).count() * 1000;
+    len +=
+      snprintf(buffer + len, sizeof(buffer) - len, "[%d] %f %s:%d NCCL TRACE ", cudaDev, timestamp, filefunc, line);
   } else if (level == NCCL_LOG_ERROR) {
-    len += snprintf(buffer+len, sizeof(buffer)-len, "[%d] [FATAL ERROR]: ", cudaDev);
+    len += snprintf(buffer + len, sizeof(buffer) - len, "[%d] [FATAL ERROR]: ", cudaDev);
   }
-  len = std::min(len, sizeof(buffer)-1);  // prevent overflows
+  len = std::min(len, sizeof(buffer) - 1);  // prevent overflows
 
   // Add the message as given by the call site.
   va_list vargs;
   va_start(vargs, fmt);
-  len += vsnprintf(buffer+len, sizeof(buffer)-len, fmt, vargs);
+  len += vsnprintf(buffer + len, sizeof(buffer) - len, fmt, vargs);
   va_end(vargs);
   // vsnprintf may return len >= sizeof(buffer) in the case of a truncated output.
   // Rewind len so that we can replace the final \0 by "\n"
-  len = std::min(len, sizeof(buffer)-1);  // prevent overflows
+  len = std::min(len, sizeof(buffer) - 1);  // prevent overflows
 
   // Add a newline and write it to the debug file. No terminating null is
   // necessary since we write bytes instead of the string.
@@ -432,9 +440,9 @@ void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *file
 // Non-deprecated version for internal use.
 extern "C"
 #if !defined(NCCL_OS_WINDOWS)
-__attribute__ ((visibility("default")))
+  __attribute__((visibility("default")))
 #endif
-void ncclResetDebugInitInternal() {
+  void ncclResetDebugInitInternal() {
   // Cleans up from a previous ncclDebugInit() and reruns.
   // Use this after changing NCCL_DEBUG and related parameters in the environment.
   pthread_mutex_lock(&ncclDebugLock);
@@ -448,17 +456,15 @@ void ncclResetDebugInitInternal() {
 #undef pncclResetDebugInit
 #endif
 #if defined(NCCL_OS_LINUX)
-__attribute__ ((visibility("default")))
-__attribute__ ((alias("ncclResetDebugInit")))
+__attribute__((visibility("default"))) __attribute__((alias("ncclResetDebugInit")))
 #endif
 void pncclResetDebugInit();
 extern "C"
 #if defined(__GNUC__) || defined(__clang__)
-__attribute__ ((visibility("default")))
-__attribute__ ((weak))
-__attribute__ ((deprecated("ncclResetDebugInit is not supported as part of the NCCL API and will be removed in the future")))
+  __attribute__((visibility("default"))) __attribute__((weak)) __attribute__((
+    deprecated("ncclResetDebugInit is not supported as part of the NCCL API and will be removed in the future")))
 #endif
-void ncclResetDebugInit();
+  void ncclResetDebugInit();
 
 extern "C" void ncclResetDebugInit() {
   // This is now deprecated as part of the NCCL API. It will be removed
@@ -467,10 +473,9 @@ extern "C" void ncclResetDebugInit() {
   ncclResetDebugInitInternal();
 }
 
-
 NCCL_PARAM(SetThreadName, "SET_THREAD_NAME", 0);
 
-void ncclSetThreadName(std::thread& thread, const char *fmt, ...) {
+void ncclSetThreadName(std::thread& thread, const char* fmt, ...) {
   // pthread_setname_np is nonstandard GNU extension
   // needs the following feature test macro
 #ifdef _GNU_SOURCE
@@ -486,7 +491,7 @@ void ncclSetThreadName(std::thread& thread, const char *fmt, ...) {
 
 // [RCCL] Overload for legacy pthread_t-managed threads (net_ib*). Same body
 // as the std::thread version but takes the pthread handle directly.
-void ncclSetThreadName(pthread_t thread, const char *fmt, ...) {
+void ncclSetThreadName(pthread_t thread, const char* fmt, ...) {
 #ifdef _GNU_SOURCE
   if (ncclParamSetThreadName() != 1) return;
   char threadName[NCCL_THREAD_NAMELEN];

--- a/projects/rccl/src/dev_runtime.cc
+++ b/projects/rccl/src/dev_runtime.cc
@@ -33,15 +33,14 @@ NCCL_PARAM(SymReuseSysmemHandles, "SYM_REUSE_SYSMEM_HANDLES", 0);
 extern struct ncclDevCommCompat ncclDevCommCompat_v22902, ncclDevCommCompat_v22907, ncclDevCommCompat_v23000;
 
 // The order of entries in the array shouldn't matter (with the exception of the terminating nullptr)
-static struct ncclDevCommCompat *devCommCompat[] = {
-  &ncclDevCommCompat_v22902, &ncclDevCommCompat_v22907, &ncclDevCommCompat_v23000,
-  nullptr
-};
+static struct ncclDevCommCompat* devCommCompat[] = {&ncclDevCommCompat_v22902, &ncclDevCommCompat_v22907,
+                                                    &ncclDevCommCompat_v23000, nullptr};
 
 // Global window map using intrusive address map
 // Uses ncclDevrWindow directly (vidmem as key, next pointer embedded in struct)
 static std::mutex ncclWindowMapMutex;
-static ncclIntruAddressMap<ncclDevrWindow, struct ncclWindow_vidmem*, &ncclDevrWindow::vidmem, &ncclDevrWindow::next> ncclWindowMap;
+static ncclIntruAddressMap<ncclDevrWindow, struct ncclWindow_vidmem*, &ncclDevrWindow::vidmem, &ncclDevrWindow::next>
+  ncclWindowMap;
 static ncclResult_t symWindowDestroy(struct ncclComm* comm, struct ncclWindow_vidmem* winDev, cudaStream_t stream);
 
 struct multiSegmentGinInfo {
@@ -96,13 +95,13 @@ struct ncclDevrTeam {
 // Helpers at the bottom:
 
 // Find least index such that `arg < sorted[i].key` (least upper bound)
-template<typename Obj, typename Key>
-static int listFindSortedLub(Key Obj::*key, Obj* sorted, int count, Key arg);
+template <typename Obj, typename Key>
+static int listFindSortedLub(Key Obj::* key, Obj* sorted, int count, Key arg);
 
-template<typename Obj>
+template <typename Obj>
 static void listInsert(Obj** list, int* capacity, int* count, int index, Obj val);
 
-template<typename Obj>
+template <typename Obj>
 static void listRemove(Obj* list, int* count, int index);
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -124,8 +123,8 @@ static int computeLsaSize(struct ncclComm* comm) {
   } else {
     // Standard node-based gcd LSA calculation
     int nodeSize = 1;
-    for (int r=1; r < comm->nRanks; r++) {
-      if (comm->rankToNode[r] == comm->rankToNode[r-1]) {
+    for (int r = 1; r < comm->nRanks; r++) {
+      if (comm->rankToNode[r] == comm->rankToNode[r - 1]) {
         nodeSize += 1;
       } else {
         lsaSize = gcd(lsaSize, nodeSize);
@@ -154,8 +153,8 @@ ncclResult_t ncclDevrInitOnce(struct ncclComm* comm) {
   devr->lsaSize = lsaSize;
   devr->nLsaTeams = comm->nRanks / devr->lsaSize;
   devr->lsaSelf = comm->rank % lsaSize;
-  devr->lsaRankList = (int*)malloc(devr->lsaSize*sizeof(int));
-  for (int i=0; i < devr->lsaSize; i++) {
+  devr->lsaRankList = (int*)malloc(devr->lsaSize * sizeof(int));
+  for (int i = 0; i < devr->lsaSize; i++) {
     devr->lsaRankList[i] = comm->rank + (i - devr->lsaSelf);
   }
 
@@ -174,17 +173,18 @@ ncclResult_t ncclDevrInitOnce(struct ncclComm* comm) {
     memProp.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
     memProp.requestedHandleType = ncclCuMemHandleType;
     memProp.location.id = comm->cudaDev;
-    CUCHECKGOTO(cuMemGetAllocationGranularity(&devr->granularity, &memProp, CU_MEM_ALLOC_GRANULARITY_RECOMMENDED), ret, fail_lsaRankList);
+    CUCHECKGOTO(cuMemGetAllocationGranularity(&devr->granularity, &memProp, CU_MEM_ALLOC_GRANULARITY_RECOMMENDED), ret,
+                fail_lsaRankList);
 
     devr->bigSize = ncclParamWinStride();
     if (-devr->bigSize <= 1) {
       devr->bigSize = 1;
-      for (int r=0; r < comm->nRanks; ++r) {
+      for (int r = 0; r < comm->nRanks; ++r) {
         devr->bigSize = std::max<size_t>(devr->bigSize, comm->peerInfo[r].totalGlobalMem);
       }
     }
-    devr->bigSize = alignUp(devr->bigSize, size_t(1)<<32);
-    INFO(NCCL_INIT, "Symmetric VA size=%ldGB", (long)devr->bigSize>>30);
+    devr->bigSize = alignUp(devr->bigSize, size_t(1) << 32);
+    INFO(NCCL_INIT, "Symmetric VA size=%ldGB", (long)devr->bigSize >> 30);
 
     ncclSpaceConstruct(&devr->bigSpace);
   } else {
@@ -263,7 +263,6 @@ ncclResult_t ncclDevrFinalize(struct ncclComm* comm) {
     CUDACHECKIGNORE(cudaStreamDestroy(stream));
   }
 
-
   if (comm->symmetricSupport) {
     symTeamDestroyAll(comm);
     { // delete windowTable
@@ -302,7 +301,7 @@ ncclResult_t ncclDevrFinalize(struct ncclComm* comm) {
       // masking with CUCHECKIGNORE — a regression in the drain path should
       // not be silently swallowed (AICOMRCCL-835).
       CUdeviceptr flatAddr = reinterpret_cast<CUdeviceptr>(devr->lsaFlatBase);
-      CUCHECK(cuMemAddressFree(flatAddr, devr->lsaSize*devr->bigSize));
+      CUCHECK(cuMemAddressFree(flatAddr, devr->lsaSize * devr->bigSize));
     }
     ncclSpaceDestruct(&devr->bigSpace);
   }
@@ -337,10 +336,8 @@ static ncclResult_t symMemorySetAccessForVASegment(struct ncclComm* comm, symLsa
   return ncclSuccess;
 }
 
-static ncclResult_t symMemoryExportSegmentHandle(
-    struct ncclComm* comm, symLsaMessage* msg,
-    CUmemGenericAllocationHandle memHandle, size_t segmentSize
-  ) {
+static ncclResult_t symMemoryExportSegmentHandle(struct ncclComm* comm, symLsaMessage* msg,
+                                                 CUmemGenericAllocationHandle memHandle, size_t segmentSize) {
   ncclResult_t ret = ncclSuccess;
   CUmemAllocationProp prop;
   CUCHECKGOTO(cuMemGetAllocationPropertiesFromHandle(&prop, memHandle), ret, fail);
@@ -355,10 +352,9 @@ fail:
   return ret;
 }
 
-static ncclResult_t symMemoryImportAndMapSegmentHandle(
-    struct ncclComm* comm, int r, CUdeviceptr addr, symLsaMessage* msg,
-    CUmemGenericAllocationHandle memHandle, bool reuseLocal
-  ) {
+static ncclResult_t symMemoryImportAndMapSegmentHandle(struct ncclComm* comm, int r, CUdeviceptr addr,
+                                                       symLsaMessage* msg, CUmemGenericAllocationHandle memHandle,
+                                                       bool reuseLocal) {
   ncclResult_t ret = ncclSuccess;
   struct ncclDevrState* devr = &comm->devrState;
   CUmemGenericAllocationHandle impHandle;
@@ -368,10 +364,13 @@ static ncclResult_t symMemoryImportAndMapSegmentHandle(
     if (ncclCuMemHandleType == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) {
       int fd = -1;
       NCCLCHECKGOTO(ncclProxyClientGetFdBlocking(comm, devr->lsaRankList[r], msg, &fd), ret, fail);
-      CUCHECKGOTO(cuMemImportFromShareableHandle(&impHandle, reinterpret_cast<void*>((uintptr_t)fd), ncclCuMemHandleType), ret, fail);
+      CUCHECKGOTO(cuMemImportFromShareableHandle(&impHandle, reinterpret_cast<void*>((uintptr_t)fd),
+                                                 ncclCuMemHandleType),
+                  ret, fail);
       SYSCHECKGOTO(close(fd), "close", ret, fail);
     } else {
-      CUCHECKGOTO(cuMemImportFromShareableHandle(&impHandle, (void*)&msg->fabricHandle, ncclCuMemHandleType), ret, fail);
+      CUCHECKGOTO(cuMemImportFromShareableHandle(&impHandle, (void*)&msg->fabricHandle, ncclCuMemHandleType), ret,
+                  fail);
     }
   }
   CUCHECKGOTO(cuMemMap(addr, msg->segmentSize, 0, impHandle, 0), ret, fail);
@@ -383,20 +382,21 @@ fail:
   return ret;
 }
 
-static ncclResult_t symMemoryImportAndMapSegmentsForRank(
-    struct ncclComm* comm, int r, symLsaMessage* messages, int maxSegments,
-    int numSegments, CUmemGenericAllocationHandle* memHandles, size_t bigOffset
-  ) {
+static ncclResult_t symMemoryImportAndMapSegmentsForRank(struct ncclComm* comm, int r, symLsaMessage* messages,
+                                                         int maxSegments, int numSegments,
+                                                         CUmemGenericAllocationHandle* memHandles, size_t bigOffset) {
   ncclResult_t ret = ncclSuccess;
   struct ncclDevrState* devr = &comm->devrState;
   uintptr_t base = reinterpret_cast<uintptr_t>(devr->lsaFlatBase);
   uintptr_t addr = base + r * devr->bigSize + bigOffset;
   for (int segment = 0; segment < numSegments; segment++) {
     symLsaMessage* msg = messages + r * maxSegments + segment;
-    bool reuseLocal = (r == devr->lsaSelf) ||
-                      (ncclParamSymReuseSysmemHandles() && msg->type == CU_MEM_LOCATION_TYPE_HOST_NUMA);
-    CUmemGenericAllocationHandle handle = reuseLocal ? memHandles[segment] : (CUmemGenericAllocationHandle) 0ULL;
-    NCCLCHECKGOTO(symMemoryImportAndMapSegmentHandle(comm, r, reinterpret_cast<CUdeviceptr>(addr), msg, handle, reuseLocal), ret, fail);
+    bool reuseLocal =
+      (r == devr->lsaSelf) || (ncclParamSymReuseSysmemHandles() && msg->type == CU_MEM_LOCATION_TYPE_HOST_NUMA);
+    CUmemGenericAllocationHandle handle = reuseLocal ? memHandles[segment] : (CUmemGenericAllocationHandle)0ULL;
+    NCCLCHECKGOTO(symMemoryImportAndMapSegmentHandle(comm, r, reinterpret_cast<CUdeviceptr>(addr), msg, handle,
+                                                     reuseLocal),
+                  ret, fail);
     addr += msg->segmentSize;
   }
 fail:
@@ -421,22 +421,28 @@ static ncclResult_t symMemoryMapLsaTeam(struct ncclComm* comm, struct ncclDevrMe
   for (int segment = 0; segment < numSegments; segment++) {
     symLsaMessage* msg = messages + devr->lsaSelf * maxSegments + segment;
     NCCLCHECKGOTO(symMemoryExportSegmentHandle(comm, msg, mem->memHandles[segment], segmentSizes[segment]), ret, fail);
-    INFO(NCCL_REG, "[%d] Segment %d, Type : %d, numSegments : %d, Segment size : %ld, memHandle : %lld", devr->lsaSelf, segment, msg->type, numSegments, msg->segmentSize, msg->memHandle);
+    INFO(NCCL_REG, "[%d] Segment %d, Type : %d, numSegments : %d, Segment size : %ld, memHandle : %lld", devr->lsaSelf,
+         segment, msg->type, numSegments, msg->segmentSize, msg->memHandle);
   }
 
-  NCCLCHECKGOTO(bootstrapIntraNodeAllGather(comm->bootstrap, devr->lsaRankList, devr->lsaSelf, devr->lsaSize, messages, sizeof(symLsaMessage) * maxSegments), ret, fail);
+  NCCLCHECKGOTO(bootstrapIntraNodeAllGather(comm->bootstrap, devr->lsaRankList, devr->lsaSelf, devr->lsaSize, messages,
+                                            sizeof(symLsaMessage) * maxSegments),
+                ret, fail);
 
   if (devr->lsaFlatBase == nullptr) { // Create on first need.
     CUdeviceptr addr;
-    CUCHECKGOTO(cuMemAddressReserve(&addr, devr->lsaSize*devr->bigSize, NCCL_MAX_PAGE_SIZE, 0, 0), ret, fail);
+    CUCHECKGOTO(cuMemAddressReserve(&addr, devr->lsaSize * devr->bigSize, NCCL_MAX_PAGE_SIZE, 0, 0), ret, fail);
     devr->lsaFlatBase = reinterpret_cast<void*>(addr);
   }
 
   for (int r = 0; r < devr->lsaSize; r++) {
-    NCCLCHECKGOTO(symMemoryImportAndMapSegmentsForRank(comm, r, messages, maxSegments, segmentCounts[r], mem->memHandles, mem->bigOffset), ret, fail);
+    NCCLCHECKGOTO(symMemoryImportAndMapSegmentsForRank(comm, r, messages, maxSegments, segmentCounts[r],
+                                                       mem->memHandles, mem->bigOffset),
+                  ret, fail);
   }
   // Ensure everyone has imported my mem handles.
-  NCCLCHECKGOTO(bootstrapIntraNodeBarrier(comm->bootstrap, devr->lsaRankList, devr->lsaSelf, devr->lsaSize, 0xbeef), ret, fail);
+  NCCLCHECKGOTO(bootstrapIntraNodeBarrier(comm->bootstrap, devr->lsaRankList, devr->lsaSelf, devr->lsaSize, 0xbeef),
+                ret, fail);
 leave:
   free(messages);
   return ret;
@@ -444,39 +450,36 @@ fail:
   goto leave;
 }
 
-static ncclResult_t symBindTeamMemory(
-    struct ncclComm* comm, struct ncclDevrTeam* tm, struct ncclDevrMemory* mem
-  ) {
+static ncclResult_t symBindTeamMemory(struct ncclComm* comm, struct ncclDevrTeam* tm, struct ncclDevrMemory* mem) {
   if (comm->nvlsSupport && tm->mcBasePtr != nullptr) {
-  #if CUDART_VERSION >= 12010
+#if CUDART_VERSION >= 12010
       // Multimem teams are currently unsupported for memory containing CPU-backed physical segments
-      if (mem->globalHasSysmemSegment) {
-        INFO(NCCL_NVLS, "Skipping bind multicast for maxGlobalNumSegments = %d, big=%lx, team {%d x %d}", mem->maxGlobalNumSegments, mem->bigOffset, tm->team.nRanks, tm->team.stride);
-      } else {
-        INFO(NCCL_NVLS, "Binding multicast memory at big=%lx to team {%d x %d}", mem->bigOffset, tm->team.nRanks, tm->team.stride);
-        CUCHECK(cuMulticastBindAddr(tm->mcHandle, mem->bigOffset, reinterpret_cast<CUdeviceptr>(mem->primaryAddr), mem->size, 0));
-      }
-  #endif
+    if (mem->globalHasSysmemSegment) {
+      INFO(NCCL_NVLS, "Skipping bind multicast for maxGlobalNumSegments = %d, big=%lx, team {%d x %d}",
+           mem->maxGlobalNumSegments, mem->bigOffset, tm->team.nRanks, tm->team.stride);
+    } else {
+      INFO(NCCL_NVLS, "Binding multicast memory at big=%lx to team {%d x %d}", mem->bigOffset, tm->team.nRanks,
+           tm->team.stride);
+      CUCHECK(cuMulticastBindAddr(tm->mcHandle, mem->bigOffset, reinterpret_cast<CUdeviceptr>(mem->primaryAddr),
+                                  mem->size, 0));
+    }
+#endif
   }
   return ncclSuccess;
 }
 
-static ncclResult_t symUnbindTeamMemory(
-    struct ncclComm* comm, struct ncclDevrTeam* tm, struct ncclDevrMemory* mem
-  ) {
+static ncclResult_t symUnbindTeamMemory(struct ncclComm* comm, struct ncclDevrTeam* tm, struct ncclDevrMemory* mem) {
   if (comm->nvlsSupport && tm->mcBasePtr != nullptr && !mem->globalHasSysmemSegment) {
-  #if CUDART_VERSION >= 12010
-      CUCHECK(cuMulticastUnbind(tm->mcHandle, comm->cudaDev, mem->bigOffset, mem->size));
-  #endif
+#if CUDART_VERSION >= 12010
+    CUCHECK(cuMulticastUnbind(tm->mcHandle, comm->cudaDev, mem->bigOffset, mem->size));
+#endif
   }
   return ncclSuccess;
 }
 
 // Caller must barrier the team afterward.
-static ncclResult_t symTeamObtain(
-    struct ncclComm* comm, struct ncclTeam team, bool multimem,
-    struct ncclDevrTeam** outTeam
-  ) {
+static ncclResult_t symTeamObtain(struct ncclComm* comm, struct ncclTeam team, bool multimem,
+                                  struct ncclDevrTeam** outTeam) {
   ncclResult_t ret = ncclSuccess;
   struct ncclDevrState* devr = &comm->devrState;
   struct ncclDevrTeam* t = devr->teamHead;
@@ -484,12 +487,12 @@ static ncclResult_t symTeamObtain(
   while (true) {
     if (t == nullptr) {
       teamIsNew = true;
-      t = (struct ncclDevrTeam*)malloc(sizeof(struct ncclDevrTeam) + team.nRanks*sizeof(int));
+      t = (struct ncclDevrTeam*)malloc(sizeof(struct ncclDevrTeam) + team.nRanks * sizeof(int));
       t->team = team;
       t->mcHandle = 0x0;
       t->mcBasePtr = nullptr;
-      for (int i=0; i < team.nRanks; i++) {
-        t->worldRankList[i] = comm->rank + (i - team.rank)*team.stride;
+      for (int i = 0; i < team.nRanks; i++) {
+        t->worldRankList[i] = comm->rank + (i - team.rank) * team.stride;
       }
       break;
     } else if (t->team.rank == team.rank && t->team.nRanks == team.nRanks && t->team.stride == team.stride) {
@@ -510,7 +513,7 @@ static ncclResult_t symTeamObtain(
       ret = ncclInvalidArgument;
       goto fail;
     } else {
-    #if CUDART_VERSION >= 12010
+#if CUDART_VERSION >= 12010
       CUmemGenericAllocationHandle mcHandle = 0;
       CUdeviceptr mcAddr = 0;
       CUmulticastObjectProp mcProp = {};
@@ -521,17 +524,23 @@ static ncclResult_t symTeamObtain(
       mcProp.flags = 0;
       mcProp.size = devr->bigSize;
       if (team.rank == 0) {
-        NCCLCHECKGOTO(ncclNvlsGroupCreate(comm, &mcProp, team.rank, team.nRanks, &mcHandle, shareableHandle), ret, fail);
-        NCCLCHECKGOTO(bootstrapIntraNodeBroadcast(comm->bootstrap, t->worldRankList, team.rank, team.nRanks, 0, shareableHandle, NVLS_HANDLE_SIZE), ret, fail_mcHandle);
+        NCCLCHECKGOTO(ncclNvlsGroupCreate(comm, &mcProp, team.rank, team.nRanks, &mcHandle, shareableHandle), ret,
+                      fail);
+        NCCLCHECKGOTO(bootstrapIntraNodeBroadcast(comm->bootstrap, t->worldRankList, team.rank, team.nRanks, 0,
+                                                  shareableHandle, NVLS_HANDLE_SIZE),
+                      ret, fail_mcHandle);
       } else {
-        NCCLCHECKGOTO(bootstrapIntraNodeBroadcast(comm->bootstrap, t->worldRankList, team.rank, team.nRanks, 0, shareableHandle, NVLS_HANDLE_SIZE), ret, fail);
+        NCCLCHECKGOTO(bootstrapIntraNodeBroadcast(comm->bootstrap, t->worldRankList, team.rank, team.nRanks, 0,
+                                                  shareableHandle, NVLS_HANDLE_SIZE),
+                      ret, fail);
         NCCLCHECKGOTO(ncclNvlsGroupConnect(comm, shareableHandle, t->worldRankList[0], &mcHandle), ret, fail);
       }
 
       CUCHECKGOTO(cuMulticastAddDevice(mcHandle, comm->cudaDev), ret, fail_mcHandle);
       CUCHECKGOTO(cuMemAddressReserve(&mcAddr, devr->bigSize, NCCL_MAX_PAGE_SIZE, 0, 0), ret, fail_mcHandle);
       CUCHECKGOTO(cuMemMap(mcAddr, devr->bigSize, 0, mcHandle, 0), ret, fail_mcHandle_mcAddr);
-      { CUmemAccessDesc accessDesc = {};
+      {
+        CUmemAccessDesc accessDesc = {};
         accessDesc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
         accessDesc.location.id = comm->cudaDev;
         accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
@@ -560,9 +569,9 @@ static ncclResult_t symTeamObtain(
         CUCHECKIGNORE(cuMemRelease(mcHandle));
         goto fail; // silence unused label warning
       }
-    #else
+#else
       goto fail; // silence unused label warning
-    #endif
+#endif
     }
   }
 
@@ -605,8 +614,8 @@ static ncclResult_t symMemoryRegisterGin(struct ncclComm* comm, struct ncclDevrM
   int numSegmentsRegistered = 0;
 
   if (!mem->globalHasSysmemSegment) {
-    NCCLCHECK(ncclGinRegister(comm, mem->primaryAddr, mem->size, mem->ginHostWins, mem->ginDevWins,
-                              mem->winFlags, mem->maxGlobalNumSegments > 1, NCCL_PTR_CUDA));
+    NCCLCHECK(ncclGinRegister(comm, mem->primaryAddr, mem->size, mem->ginHostWins, mem->ginDevWins, mem->winFlags,
+                              mem->maxGlobalNumSegments > 1, NCCL_PTR_CUDA));
     NCCLCHECK(ncclCalloc(&mem->ginSegmentInfos, 1));
     mem->ginSegmentInfos[0].memType = CU_MEM_LOCATION_TYPE_DEVICE;
     mem->ginSegmentInfos[0].segmentSize = mem->size;
@@ -617,7 +626,8 @@ static ncclResult_t symMemoryRegisterGin(struct ncclComm* comm, struct ncclDevrM
     mem->numGinSegments = 1;
   } else {
     if (mem->maxGlobalNumSegments != mem->numSegments) {
-      WARN("Elastic GIN: rank %d has %d segments but another rank has %d segments; all ranks must have identical segment configurations",
+      WARN("Elastic GIN: rank %d has %d segments but another rank has %d segments; all ranks must have identical "
+           "segment configurations",
            comm->rank, mem->numSegments, mem->maxGlobalNumSegments);
       return ncclInvalidUsage;
     }
@@ -634,18 +644,20 @@ static ncclResult_t symMemoryRegisterGin(struct ncclComm* comm, struct ncclDevrM
     NCCLCHECKGOTO(ncclCalloc(&globalPaddedSegmentSizes, (size_t)mem->maxGlobalNumSegments * comm->nRanks), ret, fail);
 
     memcpy(paddedSegmentSizes, mem->segmentSizes, mem->numSegments * sizeof(size_t));
-    memcpy(&globalPaddedSegmentSizes[(size_t)comm->rank * mem->maxGlobalNumSegments],
-           paddedSegmentSizes, sizeof(size_t) * mem->maxGlobalNumSegments);
+    memcpy(&globalPaddedSegmentSizes[(size_t)comm->rank * mem->maxGlobalNumSegments], paddedSegmentSizes,
+           sizeof(size_t) * mem->maxGlobalNumSegments);
 
     NCCLCHECKGOTO(bootstrapAllGather(comm->bootstrap, globalPaddedSegmentSizes,
-                                     sizeof(size_t) * mem->maxGlobalNumSegments), ret, fail);
+                                     sizeof(size_t) * mem->maxGlobalNumSegments),
+                  ret, fail);
 
     for (int rank = 0; rank < comm->nRanks; rank++) {
       for (int seg = 0; seg < mem->numSegments; seg++) {
         if (globalPaddedSegmentSizes[(size_t)rank * mem->maxGlobalNumSegments + seg] != mem->segmentSizes[seg]) {
-          WARN("Elastic GIN: rank %d segment %d size %zu differs from rank %d segment %d size %zu; all ranks must have identical segment configurations",
-               rank, seg, globalPaddedSegmentSizes[(size_t)rank * mem->maxGlobalNumSegments + seg],
-               comm->rank, seg, mem->segmentSizes[seg]);
+          WARN("Elastic GIN: rank %d segment %d size %zu differs from rank %d segment %d size %zu; all ranks must have "
+               "identical segment configurations",
+               rank, seg, globalPaddedSegmentSizes[(size_t)rank * mem->maxGlobalNumSegments + seg], comm->rank, seg,
+               mem->segmentSizes[seg]);
           ret = ncclInvalidUsage;
           goto fail;
         }
@@ -659,9 +671,9 @@ static ncclResult_t symMemoryRegisterGin(struct ncclComm* comm, struct ncclDevrM
       CUmemLocationType locType = segmentTypes[segment];
       int ptrType = (locType == CU_MEM_LOCATION_TYPE_HOST_NUMA) ? NCCL_PTR_HOST : NCCL_PTR_CUDA;
       NCCLCHECKGOTO(ncclGinRegister(comm, (char*)mem->primaryAddr + offset, mem->segmentSizes[segment],
-                                    mem->ginSegmentInfos[segment].ginHostWins,
-                                    mem->ginSegmentInfos[segment].ginDevWins,
-                                    mem->winFlags, mem->maxGlobalNumSegments > 1, ptrType), ret, fail);
+                                    mem->ginSegmentInfos[segment].ginHostWins, mem->ginSegmentInfos[segment].ginDevWins,
+                                    mem->winFlags, mem->maxGlobalNumSegments > 1, ptrType),
+                    ret, fail);
       mem->ginSegmentInfos[segment].segmentSize = mem->segmentSizes[segment];
       mem->ginSegmentInfos[segment].memType = locType;
       numSegmentsRegistered++;
@@ -692,14 +704,16 @@ static ncclResult_t symMemoryRegisterRma(struct ncclComm* comm, struct ncclDevrM
 // On success we take caller's reference on memHandle.
 // Due to multicast binds for each pre-exiting team, this function requires
 // caller do a world barrier before returning to user.
-static ncclResult_t symMemoryObtain(
-    struct ncclComm* comm, CUmemGenericAllocationHandle* memHandles, int numSegments, void* memAddr, size_t size, int winFlags,
-    struct ncclDevrMemory** outMem, bool hasSysmemSegment = false
-  ) {
+static ncclResult_t symMemoryObtain(struct ncclComm* comm, CUmemGenericAllocationHandle* memHandles, int numSegments,
+                                    void* memAddr, size_t size, int winFlags, struct ncclDevrMemory** outMem,
+                                    bool hasSysmemSegment = false) {
   ncclResult_t ret = ncclSuccess;
   struct ncclDevrState* devr = &comm->devrState;
   int64_t bigOffset = 0;
-  struct segmentInfo { int numSegments; bool hasSysmemSegment; };
+  struct segmentInfo {
+    int numSegments;
+    bool hasSysmemSegment;
+  };
   struct segmentInfo* globalSegmentInfo = nullptr;
   const int globalLsaTeamBaseIdx = devr->lsaSize * (comm->rank / devr->lsaSize);
 
@@ -776,7 +790,7 @@ static ncclResult_t symMemoryObtain(
 
   // If our caller doesn't have a VA then we'll use the LSA mapping.
   if (mem->primaryAddr == nullptr) {
-    mem->primaryAddr = (char*)devr->lsaFlatBase + devr->lsaSelf*devr->bigSize + mem->bigOffset;
+    mem->primaryAddr = (char*)devr->lsaFlatBase + devr->lsaSelf * devr->bigSize + mem->bigOffset;
   }
 
   // Bind new memory with each existing team.
@@ -823,13 +837,11 @@ fail_mem:
   }
   free(mem);
   free(globalSegmentInfo);
-//fail:
+// fail:
   return ret;
 }
 
-static void symMemoryDropRef(
-    struct ncclComm* comm, struct ncclDevrMemory* mem
-  ) {
+static void symMemoryDropRef(struct ncclComm* comm, struct ncclDevrMemory* mem) {
   if (mem != nullptr && 0 == --mem->refCount) {
     struct ncclDevrState* devr = &comm->devrState;
     if (devr->ginEnabled) {
@@ -888,17 +900,16 @@ static ncclResult_t symWindowTableInitOnce(struct ncclComm* comm, cudaStream_t s
 
 // Segment windows are used in the multi-segment codepath and need their own shadow pool
 // as they're variable in size.
-static ncclResult_t allocAndPopulateSegmentWindows(
-    struct ncclDevrState* devr, struct ncclDevrMemory* mem,
-    cudaStream_t stream, struct ncclSegmentWindow** outSegmentWindowsDev,
-    struct ncclSegmentWindow** outSegmentWindowsHost) {
+static ncclResult_t allocAndPopulateSegmentWindows(struct ncclDevrState* devr, struct ncclDevrMemory* mem,
+                                                   cudaStream_t stream, struct ncclSegmentWindow** outSegmentWindowsDev,
+                                                   struct ncclSegmentWindow** outSegmentWindowsHost) {
   ncclResult_t ret = ncclSuccess;
   struct ncclSegmentWindow* segmentWindowsDev = nullptr;
   struct ncclSegmentWindow* segmentWindowsHost = nullptr;
 
-  NCCLCHECKGOTO(ncclShadowPoolAlloc(&devr->shadows,
-      sizeof(struct ncclSegmentWindow) * mem->numGinSegments,
-      (void**)&segmentWindowsDev, (void**)&segmentWindowsHost, stream), ret, fail);
+  NCCLCHECKGOTO(ncclShadowPoolAlloc(&devr->shadows, sizeof(struct ncclSegmentWindow) * mem->numGinSegments,
+                                    (void**)&segmentWindowsDev, (void**)&segmentWindowsHost, stream),
+                ret, fail);
 
   if (devr->ginEnabled) {
     for (int segment = 0; segment < mem->numGinSegments; segment++) {
@@ -909,8 +920,9 @@ static ncclResult_t allocAndPopulateSegmentWindows(
       }
     }
     CUDACHECKGOTO(cudaMemcpyAsync(segmentWindowsDev, segmentWindowsHost,
-        sizeof(struct ncclSegmentWindow) * mem->numGinSegments,
-        cudaMemcpyHostToDevice, stream), ret, fail);
+                                  sizeof(struct ncclSegmentWindow) * mem->numGinSegments, cudaMemcpyHostToDevice,
+                                  stream),
+                  ret, fail);
   }
 
   *outSegmentWindowsDev = segmentWindowsDev;
@@ -919,18 +931,14 @@ static ncclResult_t allocAndPopulateSegmentWindows(
 exit:
   return ret;
 fail:
-  if (segmentWindowsDev != nullptr)
-    ncclShadowPoolFree(&devr->shadows, segmentWindowsDev, stream);
+  if (segmentWindowsDev != nullptr) ncclShadowPoolFree(&devr->shadows, segmentWindowsDev, stream);
   goto exit;
 }
 
 // On success we take callers reference on `mem`.
-static ncclResult_t symWindowCreate(
-    struct ncclComm* comm, struct ncclDevrMemory* mem,
-    size_t memOffset, void* userPtr, size_t userSize, int winFlags, void* localReg,
-    struct ncclWindow_vidmem** outWinDev, struct ncclDevrWindow** outWin,
-    cudaStream_t stream
-  ) {
+static ncclResult_t symWindowCreate(struct ncclComm* comm, struct ncclDevrMemory* mem, size_t memOffset, void* userPtr,
+                                    size_t userSize, int winFlags, void* localReg, struct ncclWindow_vidmem** outWinDev,
+                                    struct ncclDevrWindow** outWin, cudaStream_t stream) {
   uintptr_t userAddr = reinterpret_cast<uintptr_t>(userPtr);
   struct ncclDevrState* devr = &comm->devrState;
   struct ncclDevrWindow* win;
@@ -944,7 +952,7 @@ static ncclResult_t symWindowCreate(
   win->localRegHandle = localReg;
   if (userPtr == nullptr) {
     // Null means caller has no VA and will use the lsa team flat VA address.
-    win->userPtr = userPtr = (char*)devr->lsaFlatBase + (devr->lsaSelf*devr->bigSize) + mem->bigOffset;
+    win->userPtr = userPtr = (char*)devr->lsaFlatBase + (devr->lsaSelf * devr->bigSize) + mem->bigOffset;
     userAddr = reinterpret_cast<uintptr_t>(userPtr);
   } else {
     win->userPtr = userPtr;
@@ -955,14 +963,14 @@ static ncclResult_t symWindowCreate(
   NCCLCHECK(ncclShadowPoolAlloc(&devr->shadows, &winDev, &winDevHost, stream));
   win->vidmem = winDev;
   winDevHost->lsaFlatBase = (char*)devr->lsaFlatBase + win->bigOffset;
-  winDevHost->mcOffset4K = win->bigOffset>>12;
-  winDevHost->stride4G = devr->bigSize>>32;
+  winDevHost->mcOffset4K = win->bigOffset >> 12;
+  winDevHost->stride4G = devr->bigSize >> 32;
   winDevHost->lsaRank = devr->lsaSelf;
   winDevHost->worldRank = comm->rank;
   winDevHost->winHost = (void*)win;
-  winDevHost->ginOffset4K = memOffset>>12;
+  winDevHost->ginOffset4K = memOffset >> 12;
   winDevHost->numSegments = mem->numGinSegments;
-  for (int i=0; i < NCCL_GIN_MAX_CONNECTIONS; i++) {
+  for (int i = 0; i < NCCL_GIN_MAX_CONNECTIONS; i++) {
     winDevHost->ginWins[i] = mem->ginDevWins[i];
   }
   struct ncclSegmentWindow* segmentWindowsDev;
@@ -982,12 +990,14 @@ static ncclResult_t symWindowCreate(
       tableHost->entries[i].base = userAddr;
       tableHost->entries[i].size = userSize;
       tableHost->entries[i].window = winDev;
-      CUDACHECK(cudaMemcpyAsync(&tableDev->entries[i], &tableHost->entries[i], sizeof(tableHost->entries[i]), cudaMemcpyHostToDevice, stream));
+      CUDACHECK(cudaMemcpyAsync(&tableDev->entries[i], &tableHost->entries[i], sizeof(tableHost->entries[i]),
+                                cudaMemcpyHostToDevice, stream));
       break;
     }
     if (tableHost->next == nullptr) {
       NCCLCHECK(ncclShadowPoolAlloc<ncclDevCommWindowTable>(&devr->shadows, &tableHost->next, nullptr, stream));
-      CUDACHECK(cudaMemcpyAsync(&tableDev->next, &tableHost->next, sizeof(tableHost->next), cudaMemcpyHostToDevice, stream));
+      CUDACHECK(cudaMemcpyAsync(&tableDev->next, &tableHost->next, sizeof(tableHost->next), cudaMemcpyHostToDevice,
+                                stream));
     }
     tableDev = tableHost->next;
   }
@@ -1017,7 +1027,8 @@ static ncclResult_t symWindowDestroy(struct ncclComm* comm, struct ncclWindow_vi
 
   symMemoryDropRef(comm, winHost->memory);
 
-  { struct ncclDevCommWindowTable* tableDev = devr->windowTable;
+  {
+    struct ncclDevCommWindowTable* tableDev = devr->windowTable;
     while (true) {
       struct ncclDevCommWindowTable* tableHost;
       NCCLCHECKGOTO(ncclShadowPoolToHost(&devr->shadows, tableDev, &tableHost), ret, remove_winSorted);
@@ -1025,7 +1036,8 @@ static ncclResult_t symWindowDestroy(struct ncclComm* comm, struct ncclWindow_vi
       while (i < 32 && tableHost->entries[i].window != winDev) i += 1;
       if (i < 32) {
         memset(&tableHost->entries[i], 0, sizeof(tableHost->entries[i]));
-        CUDACHECKGOTO(cudaMemsetAsync(&tableDev->entries[i], 0, sizeof(tableDev->entries[i]), stream), ret, remove_winSorted);
+        CUDACHECKGOTO(cudaMemsetAsync(&tableDev->entries[i], 0, sizeof(tableDev->entries[i]), stream), ret,
+                      remove_winSorted);
         break;
       }
       if (tableHost->next == nullptr) break; // Error didn't find window in table
@@ -1042,7 +1054,9 @@ static ncclResult_t symWindowDestroy(struct ncclComm* comm, struct ncclWindow_vi
   NCCLCHECKGOTO(ncclCommDeregister(comm, winHost->localRegHandle), ret, remove_winSorted);
 
 remove_winSorted:
-  { int i = listFindSortedLub(&ncclDevrWindowSorted::userAddr, devr->winSorted, devr->winSortedCount, reinterpret_cast<uintptr_t>(winHost->userPtr));
+  {
+    int i = listFindSortedLub(&ncclDevrWindowSorted::userAddr, devr->winSorted, devr->winSortedCount,
+                              reinterpret_cast<uintptr_t>(winHost->userPtr));
     i -= 1; // least upper bound is just after ours.
     listRemove(devr->winSorted, &devr->winSortedCount, i);
   }
@@ -1058,8 +1072,7 @@ fail:
 }
 
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-static void windowCloseIpcPeers(struct ncclComm* comm,
-                                struct ncclDevrWindow* win) {
+static void windowCloseIpcPeers(struct ncclComm* comm, struct ncclDevrWindow* win) {
   if (win->ipcPeerPtrsAllocBase == nullptr) return;
   int teamSelf = comm->devrState.lsaSelf;
   for (int r = 0; r < win->ipcPeerCount; r++) {
@@ -1075,10 +1088,8 @@ static void windowCloseIpcPeers(struct ncclComm* comm,
 //       lsaSize > 1.
 //   (2) inter-node MR via ncclRmaProxyRegister, when hostRmaSupport. Same
 //       call upstream issues from symMemoryRegisterRma.
-static ncclResult_t windowRegisterNonSym(struct ncclComm* comm, void* userPtr,
-                                         size_t userSize, int winFlags,
-                                         void* localRegHandle,
-                                         ncclWindow_t* outWinDev) {
+static ncclResult_t windowRegisterNonSym(struct ncclComm* comm, void* userPtr, size_t userSize, int winFlags,
+                                         void* localRegHandle, ncclWindow_t* outWinDev) {
   struct ExchangeEntry {
     cudaIpcMemHandle_t handle;
     uint64_t hostHash;
@@ -1121,24 +1132,19 @@ static ncclResult_t windowRegisterNonSym(struct ncclComm* comm, void* userPtr,
     size_t allocSize = 0;
     CUdeviceptr userPtrCu = reinterpret_cast<CUdeviceptr>(userPtr);
 
-    if (CUDA_SUCCESS !=
-        cuMemGetAddressRange(&allocBase, &allocSize, userPtrCu)) {
-      WARN("windowRegisterNonSym: cuMemGetAddressRange failed for userPtr=%p",
-           userPtr);
+    if (CUDA_SUCCESS != cuMemGetAddressRange(&allocBase, &allocSize, userPtrCu)) {
+      WARN("windowRegisterNonSym: cuMemGetAddressRange failed for userPtr=%p", userPtr);
       goto fail;
     }
-    size_t userOffset = reinterpret_cast<uintptr_t>(userPtr) -
-                        reinterpret_cast<uintptr_t>(allocBase);
+    size_t userOffset = reinterpret_cast<uintptr_t>(userPtr) - reinterpret_cast<uintptr_t>(allocBase);
 
     peers = (ExchangeEntry*)calloc(teamSize, sizeof(ExchangeEntry));
     if (peers == nullptr) goto fail;
 
     ExchangeEntry* mine = &peers[teamSelf];
-    cudaError_t cerr =
-      cudaIpcGetMemHandle(&mine->handle, reinterpret_cast<void*>(allocBase));
+    cudaError_t cerr = cudaIpcGetMemHandle(&mine->handle, reinterpret_cast<void*>(allocBase));
     if (cerr != cudaSuccess) {
-      WARN("windowRegisterNonSym: cudaIpcGetMemHandle failed: %s",
-           cudaGetErrorString(cerr));
+      WARN("windowRegisterNonSym: cudaIpcGetMemHandle failed: %s", cudaGetErrorString(cerr));
       goto fail;
     }
 
@@ -1148,8 +1154,7 @@ static ncclResult_t windowRegisterNonSym(struct ncclComm* comm, void* userPtr,
     mine->userSize = userSize;
 
     if (ncclSuccess !=
-        bootstrapIntraNodeAllGather(comm->bootstrap, teamRankList, teamSelf,
-                                    teamSize, peers, sizeof(ExchangeEntry))) {
+        bootstrapIntraNodeAllGather(comm->bootstrap, teamRankList, teamSelf, teamSize, peers, sizeof(ExchangeEntry))) {
       WARN("windowRegisterNonSym: bootstrapIntraNodeAllGather failed");
       goto fail;
     }
@@ -1162,8 +1167,7 @@ static ncclResult_t windowRegisterNonSym(struct ncclComm* comm, void* userPtr,
     win->ipcPeerCount = teamSize;
 
     for (int r = 0; r < teamSize; r++) {
-      bool sameProc = (peers[r].hostHash == peers[teamSelf].hostHash) &&
-                      (peers[r].pidHash == peers[teamSelf].pidHash);
+      bool sameProc = (peers[r].hostHash == peers[teamSelf].hostHash) && (peers[r].pidHash == peers[teamSelf].pidHash);
       if (r == teamSelf || sameProc) {
         // Same address space: self reuses userPtr; same-PID cross-thread
         // peers stay nullptr (MVP: no cross-thread peer mapping).
@@ -1176,9 +1180,7 @@ static ncclResult_t windowRegisterNonSym(struct ncclComm* comm, void* userPtr,
         }
       } else {
         void* peerBase = nullptr;
-        cudaError_t orErr =
-          cudaIpcOpenMemHandle(&peerBase, peers[r].handle,
-                               cudaIpcMemLazyEnablePeerAccess);
+        cudaError_t orErr = cudaIpcOpenMemHandle(&peerBase, peers[r].handle, cudaIpcMemLazyEnablePeerAccess);
         if (orErr != cudaSuccess) {
           WARN("windowRegisterNonSym: cudaIpcOpenMemHandle for "
                "teamRank=%d failed: %s",
@@ -1198,9 +1200,7 @@ static ncclResult_t windowRegisterNonSym(struct ncclComm* comm, void* userPtr,
       WARN("windowRegisterNonSym: ncclRmaProxyConnectOnce failed");
       goto fail;
     }
-    if (ncclSuccess != ncclRmaProxyRegister(comm, userPtr, userSize,
-                                            win->rmaHostWins,
-                                            win->rmaDevWins)) {
+    if (ncclSuccess != ncclRmaProxyRegister(comm, userPtr, userSize, win->rmaHostWins, win->rmaDevWins)) {
       WARN("windowRegisterNonSym: ncclRmaProxyRegister failed");
       goto fail;
     }
@@ -1208,14 +1208,12 @@ static ncclResult_t windowRegisterNonSym(struct ncclComm* comm, void* userPtr,
 
   // Stage 3: encode the device-side handle as a shadow pool entry so the
   // kernel/CE resolves winHost via ncclShadowPoolToHost
-  if (cudaSuccess !=
-      cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking)) {
+  if (cudaSuccess != cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking)) {
     WARN("windowRegisterNonSym: cudaStreamCreateWithFlags failed");
     goto fail;
   }
 
-  if (ncclSuccess !=
-      ncclShadowPoolAlloc(&devr->shadows, &winDev, &winDevHost, stream)) {
+  if (ncclSuccess != ncclShadowPoolAlloc(&devr->shadows, &winDev, &winDevHost, stream)) {
     WARN("windowRegisterNonSym: ncclShadowPoolAlloc failed");
     goto fail;
   }
@@ -1226,23 +1224,19 @@ static ncclResult_t windowRegisterNonSym(struct ncclComm* comm, void* userPtr,
   winDevHost->worldRank = comm->rank;
   winDevHost->winHost = (void*)win;
 
-  if (cudaSuccess != cudaMemcpyAsync(winDev, winDevHost, sizeof(*winDevHost),
-                                     cudaMemcpyHostToDevice, stream)) {
+  if (cudaSuccess != cudaMemcpyAsync(winDev, winDevHost, sizeof(*winDevHost), cudaMemcpyHostToDevice, stream)) {
     WARN("windowRegisterNonSym: cudaMemcpyAsync (window header) failed");
     goto fail;
   }
 
   {
     uintptr_t userAddr = reinterpret_cast<uintptr_t>(userPtr);
-    int idx =
-      listFindSortedLub(&ncclDevrWindowSorted::userAddr, devr->winSorted,
-                        devr->winSortedCount, userAddr);
+    int idx = listFindSortedLub(&ncclDevrWindowSorted::userAddr, devr->winSorted, devr->winSortedCount, userAddr);
     struct ncclDevrWindowSorted winSort;
     winSort.userAddr = userAddr;
     winSort.size = userSize;
     winSort.win = win;
-    listInsert(&devr->winSorted, &devr->winSortedCapacity,
-               &devr->winSortedCount, idx, winSort);
+    listInsert(&devr->winSorted, &devr->winSortedCapacity, &devr->winSortedCount, idx, winSort);
   }
 
   CUDACHECKIGNORE(cudaStreamSynchronize(stream));
@@ -1251,13 +1245,11 @@ static ncclResult_t windowRegisterNonSym(struct ncclComm* comm, void* userPtr,
 
   if (doIpc) {
     // Intra-node sync; sym path uses bootstrapBarrier post-mapping.
-    if (ncclSuccess != bootstrapIntraNodeBarrier(comm->bootstrap, teamRankList,
-                                                 teamSelf, teamSize,
-                                                 kNonSymWindowBarrierTag)) {
+    if (ncclSuccess !=
+        bootstrapIntraNodeBarrier(comm->bootstrap, teamRankList, teamSelf, teamSize, kNonSymWindowBarrierTag)) {
       WARN("windowRegisterNonSym: bootstrapIntraNodeBarrier failed");
       // Revert listInsert before falling into shared cleanup.
-      int i = listFindSortedLub(&ncclDevrWindowSorted::userAddr,
-                                devr->winSorted, devr->winSortedCount,
+      int i = listFindSortedLub(&ncclDevrWindowSorted::userAddr, devr->winSorted, devr->winSortedCount,
                                 reinterpret_cast<uintptr_t>(userPtr));
       i -= 1;
       if (i >= 0) listRemove(devr->winSorted, &devr->winSortedCount, i);
@@ -1268,8 +1260,7 @@ static ncclResult_t windowRegisterNonSym(struct ncclComm* comm, void* userPtr,
   INFO(NCCL_INIT,
        "windowRegisterNonSym: backing=%s teamSize=%d nRanks=%d "
        "userPtr=%p size=%zu opened=%d hostRma=%d",
-       doIpc ? "IPC" : (doRma ? "PROXY" : "LOCAL"), teamSize, comm->nRanks,
-       userPtr, userSize, openedCount, (int)doRma);
+       doIpc ? "IPC" : (doRma ? "PROXY" : "LOCAL"), teamSize, comm->nRanks, userPtr, userSize, openedCount, (int)doRma);
 
   free(peers);
   *outWinDev = winDev;
@@ -1284,7 +1275,7 @@ fail:
 
     windowCloseIpcPeers(comm, win);
 
-    // Free the shadow-pool entry if it was allocated 
+    // Free the shadow-pool entry if it was allocated
     if (win->vidmem != nullptr) {
       if (stream == nullptr) {
         CUDACHECKIGNORE(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
@@ -1306,10 +1297,8 @@ fail:
 }
 #endif
 
-ncclResult_t ncclDevrWindowRegisterInGroup(
-    struct ncclComm* comm,
-    void* userPtr, size_t userSize, int winFlags, ncclWindow_t* outWinDev
-  ) {
+ncclResult_t ncclDevrWindowRegisterInGroup(struct ncclComm* comm, void* userPtr, size_t userSize, int winFlags,
+                                           ncclWindow_t* outWinDev) {
   ncclResult_t ret = ncclSuccess;
   CUdeviceptr memAddr = 0;
   size_t memSize = 0;
@@ -1329,9 +1318,7 @@ ncclResult_t ncclDevrWindowRegisterInGroup(
   // RCCL: when sym VMM is unavailable (no cuMem), route through the non-sym
   // helper which lays out IPC for intra-node and proxy/GIN MR for inter-node
   if (!comm->symmetricSupport) {
-    NCCLCHECKGOTO(windowRegisterNonSym(comm, userPtr, userSize, winFlags,
-                                       localRegHandle, outWinDev),
-                  ret, fail_locReg);
+    NCCLCHECKGOTO(windowRegisterNonSym(comm, userPtr, userSize, winFlags, localRegHandle, outWinDev), ret, fail_locReg);
     return ncclSuccess;
   }
 #endif
@@ -1342,30 +1329,39 @@ ncclResult_t ncclDevrWindowRegisterInGroup(
   }
 
   // Get underlying cumem base address and number of mapped physical segments that userPtr spans
-  NCCLCHECKGOTO(ncclCuMemGetAddressRange(reinterpret_cast<CUdeviceptr>(userPtr), userSize, &memAddr, &memSize, &numSegments, &hasSysmemSegment), ret, fail_locReg);
+  NCCLCHECKGOTO(ncclCuMemGetAddressRange(reinterpret_cast<CUdeviceptr>(userPtr), userSize, &memAddr, &memSize,
+                                         &numSegments, &hasSysmemSegment),
+                ret, fail_locReg);
   NCCLCHECKGOTO(ncclCalloc(&memHandles, numSegments), ret, fail_locReg);
 
   if (hasSysmemSegment) {
     if (!ncclParamElasticBufferRegister()) {
-      WARN("VA represented by {userPtr = %p, size = %zu} contains CPU-backed physical segments, but NCCL_ELASTIC_BUFFER_REGISTER is set to 0. Please set NCCL_ELASTIC_BUFFER_REGISTER=1 and retry window registration", userPtr, userSize);
+      WARN("VA represented by {userPtr = %p, size = %zu} contains CPU-backed physical segments, but "
+           "NCCL_ELASTIC_BUFFER_REGISTER is set to 0. Please set NCCL_ELASTIC_BUFFER_REGISTER=1 and retry window "
+           "registration",
+           userPtr, userSize);
       ret = ncclInvalidArgument;
       goto fail_locReg;
     }
 #if CUDART_VERSION >= 12080
     else if (comm->MNNVL) {
-        int multiNodeLsaSupported = 0;
-        CUCHECKGOTO(cuDeviceGetAttribute(&multiNodeLsaSupported, CU_DEVICE_ATTRIBUTE_HOST_NUMA_MULTINODE_IPC_SUPPORTED, comm->cudaDev), ret, fail_locReg);
-        if (!multiNodeLsaSupported) {
-          WARN("VA represented by {userPtr = %p, size = %zu} contains CPU-backed physical segments, but the LSA team does not support multi-node IPC on CPU-backed buffers. Please retry by setting NCCL_MNNVL_ENABLE=0", userPtr, userSize);
-          ret = ncclInvalidArgument;
-          goto fail_locReg;
-        }
+      int multiNodeLsaSupported = 0;
+      CUCHECKGOTO(cuDeviceGetAttribute(&multiNodeLsaSupported, CU_DEVICE_ATTRIBUTE_HOST_NUMA_MULTINODE_IPC_SUPPORTED,
+                                       comm->cudaDev),
+                  ret, fail_locReg);
+      if (!multiNodeLsaSupported) {
+        WARN("VA represented by {userPtr = %p, size = %zu} contains CPU-backed physical segments, but the LSA team "
+             "does not support multi-node IPC on CPU-backed buffers. Please retry by setting NCCL_MNNVL_ENABLE=0",
+             userPtr, userSize);
+        ret = ncclInvalidArgument;
+        goto fail_locReg;
+      }
     }
 #endif
   }
 
   memOffset = reinterpret_cast<uintptr_t>(userPtr) - reinterpret_cast<uintptr_t>(memAddr);
-  if (memOffset%NCCL_WIN_REQUIRED_ALIGNMENT != 0) {
+  if (memOffset % NCCL_WIN_REQUIRED_ALIGNMENT != 0) {
     WARN("Window address must be suitably aligned.");
     ret = ncclInvalidArgument;
     goto fail;
@@ -1374,12 +1370,16 @@ ncclResult_t ncclDevrWindowRegisterInGroup(
   // Retain all handles and validate segment location types
   for (int segment = 0; segment < numSegments; segment++) {
     size_t baseSendSize;
-    CUCHECK(cuMemGetAddressRange(nullptr, &baseSendSize, reinterpret_cast<CUdeviceptr>(reinterpret_cast<char*>(memAddr) + offset)));
-    CUCHECKGOTO(cuMemRetainAllocationHandle(&memHandles[segment], (void *) (reinterpret_cast<char*>(memAddr) + offset)), ret, fail_locReg);
+    CUCHECK(cuMemGetAddressRange(nullptr, &baseSendSize,
+                                 reinterpret_cast<CUdeviceptr>(reinterpret_cast<char*>(memAddr) + offset)));
+    CUCHECKGOTO(cuMemRetainAllocationHandle(&memHandles[segment], (void*)(reinterpret_cast<char*>(memAddr) + offset)),
+                ret, fail_locReg);
     CUmemAllocationProp prop;
     CUCHECKGOTO(cuMemGetAllocationPropertiesFromHandle(&prop, memHandles[segment]), ret, fail_locReg);
     if (prop.location.type != CU_MEM_LOCATION_TYPE_HOST_NUMA && prop.location.type != CU_MEM_LOCATION_TYPE_DEVICE) {
-      WARN("Segment %d has unsupported location type %d. Symmetric memory currently only supports CU_MEM_LOCATION_TYPE_HOST_NUMA and CU_MEM_LOCATION_TYPE_DEVICE.", segment, (int)prop.location.type);
+      WARN("Segment %d has unsupported location type %d. Symmetric memory currently only supports "
+           "CU_MEM_LOCATION_TYPE_HOST_NUMA and CU_MEM_LOCATION_TYPE_DEVICE.",
+           segment, (int)prop.location.type);
       ret = ncclInvalidArgument;
       goto fail_locReg;
     }
@@ -1387,26 +1387,30 @@ ncclResult_t ncclDevrWindowRegisterInGroup(
   }
 
   // Trade cumem handles for ncclDevrMemory*
-  NCCLCHECKGOTO(symMemoryObtain(comm, memHandles, numSegments, (void*)memAddr, memSize, winFlags, &mem, hasSysmemSegment), ret, fail_locReg_memHandle);
+  NCCLCHECKGOTO(symMemoryObtain(comm, memHandles, numSegments, (void*)memAddr, memSize, winFlags, &mem,
+                                hasSysmemSegment),
+                ret, fail_locReg_memHandle);
   memset(memHandles, 0, numSegments * sizeof(*memHandles)); // symMemoryObtain took our reference
 
   CUDACHECKGOTO(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking), ret, fail);
 
-  NCCLCHECKGOTO(symWindowCreate(
-      comm, mem, memOffset, userPtr, userSize, winFlags, localRegHandle, outWinDev, &winHost, stream
-    ), ret, fail_locReg_memHandle_mem_stream);
+  NCCLCHECKGOTO(symWindowCreate(comm, mem, memOffset, userPtr, userSize, winFlags, localRegHandle, outWinDev, &winHost,
+                                stream),
+                ret, fail_locReg_memHandle_mem_stream);
   mem = nullptr; // symWindowCreate took our reference
 
   CUDACHECKGOTO(cudaStreamSynchronize(stream), ret, fail_locReg_memHandle_mem_stream_win);
 
   // symWindowCreate needs barrier.
-  NCCLCHECKGOTO(bootstrapBarrier(comm->bootstrap, comm->rank, comm->nRanks, 0xbeef), ret, fail_locReg_memHandle_mem_stream_win);
+  NCCLCHECKGOTO(bootstrapBarrier(comm->bootstrap, comm->rank, comm->nRanks, 0xbeef), ret,
+                fail_locReg_memHandle_mem_stream_win);
 
   {
     std::lock_guard<std::mutex> lock(ncclWindowMapMutex);
     winHost->comm = comm;
     winHost->next = nullptr;
-    NCCLCHECKGOTO(ncclIntruAddressMapInsert(&ncclWindowMap, *outWinDev, winHost), ret, fail_locReg_memHandle_mem_stream_win);
+    NCCLCHECKGOTO(ncclIntruAddressMapInsert(&ncclWindowMap, *outWinDev, winHost), ret,
+                  fail_locReg_memHandle_mem_stream_win);
     INFO(NCCL_ALLOC, "Inserted window %p into address map, ret=%d", *outWinDev, ret);
   }
 
@@ -1423,7 +1427,9 @@ fail_locReg_memHandle_mem_stream:
   symMemoryDropRef(comm, mem);
 fail_locReg_memHandle:
   for (int idx = 0; idx < numSegments; idx++) {
-    if (memHandles[idx] != 0x0ULL) { CUCHECKIGNORE(cuMemRelease(memHandles[idx])); }
+    if (memHandles[idx] != 0x0ULL) {
+      CUCHECKIGNORE(cuMemRelease(memHandles[idx]));
+    }
   }
   free(memHandles);
 fail_locReg:
@@ -1433,13 +1439,11 @@ fail:
   return ret;
 }
 
-static ncclResult_t deepCopyDevCommRequirements(
-    struct ncclDevCommRequirements const* src,
-    struct ncclDevCommRequirements** dst
-) {
+static ncclResult_t deepCopyDevCommRequirements(struct ncclDevCommRequirements const* src,
+                                                struct ncclDevCommRequirements** dst) {
   ncclResult_t ret = ncclSuccess;
-  struct ncclDevResourceRequirements **dstRes;
-  struct ncclTeamRequirements **dstTeam;
+  struct ncclDevResourceRequirements** dstRes;
+  struct ncclTeamRequirements** dstTeam;
 
   NCCLCHECK(ncclCalloc(dst, 1));
   **dst = NCCL_DEV_COMM_REQUIREMENTS_INITIALIZER;
@@ -1474,9 +1478,7 @@ fail:
   goto exit;
 }
 
-void freeDevCommRequirements(
-    struct ncclDevCommRequirements* reqs
-) {
+void freeDevCommRequirements(struct ncclDevCommRequirements* reqs) {
   if (reqs) {
     while (reqs->resourceRequirementsList) {
       struct ncclDevResourceRequirements* rr_next = reqs->resourceRequirementsList->next;
@@ -1495,9 +1497,8 @@ void freeDevCommRequirements(
 }
 
 bool ncclGinResourcesRequested(struct ncclDevCommRequirements const* reqs) {
-  bool requestedGinResources = reqs->ginSignalCount > 0 || reqs->ginCounterCount > 0 ||
-                               reqs->barrierCount > 0 || reqs->railGinBarrierCount > 0 ||
-                               reqs->worldGinBarrierCount > 0;
+  bool requestedGinResources = reqs->ginSignalCount > 0 || reqs->ginCounterCount > 0 || reqs->barrierCount > 0 ||
+                               reqs->railGinBarrierCount > 0 || reqs->worldGinBarrierCount > 0;
 
   struct ncclDevResourceRequirements* node = reqs->resourceRequirementsList;
   while (!requestedGinResources && node != nullptr) {
@@ -1514,10 +1515,10 @@ static void ncclDevCommGdakiDump(void* handle) {
   struct ncclGinGdakiGPUContext ctx;
   if (cudaMemcpy(&ctx, handle, sizeof(ctx), cudaMemcpyDeviceToHost) == cudaSuccess) {
     printf("    GDAKI qp %p companion qp %p sink buffer lkey %x\n", ctx.gdqp, ctx.companion_gdqp, ctx.sink_buffer_lkey);
-    printf("    GDAKI counters %p rkeys %p lkey %x offset %d\n", ctx.counters_table.buffer,
-        ctx.counters_table.rkeys, ctx.counters_table.lkey, ctx.counters_table.offset);
-    printf("    GDAKI signals  %p rkeys %p lkey %x offset %d\n", ctx.signals_table.buffer,
-        ctx.signals_table.rkeys, ctx.signals_table.lkey, ctx.signals_table.offset);
+    printf("    GDAKI counters %p rkeys %p lkey %x offset %d\n", ctx.counters_table.buffer, ctx.counters_table.rkeys,
+           ctx.counters_table.lkey, ctx.counters_table.offset);
+    printf("    GDAKI signals  %p rkeys %p lkey %x offset %d\n", ctx.signals_table.buffer, ctx.signals_table.rkeys,
+           ctx.signals_table.lkey, ctx.signals_table.offset);
   }
 }
 
@@ -1546,7 +1547,7 @@ void ncclDevCommDump(struct ncclDevComm* devComm) {
   printf(" GIN\n");
   printf("  Mode %s\n", devComm->ginIsRailed ? "Rail" : "Full");
   printf("  Connections %d\n", devComm->ginConnectionCount);
-  for (int c=0; c<devComm->ginConnectionCount; c++) {
+  for (int c = 0; c < devComm->ginConnectionCount; c++) {
     printf("   [%d] %d %p\n", c, devComm->ginNetDeviceTypes[c], devComm->ginHandles[c]);
     if (devComm->ginNetDeviceTypes[c] == NCCL_GIN_TYPE_GDAKI) ncclDevCommGdakiDump(devComm->ginHandles[c]);
     if (devComm->ginNetDeviceTypes[c] == NCCL_GIN_TYPE_PROXY) ncclDevCommProxyDump(devComm->ginHandles[c]);
@@ -1562,11 +1563,9 @@ void ncclDevCommDump(struct ncclDevComm* devComm) {
   printf(" GIN World Barrier signal0 %d\n", devComm->worldGinBarrier.signal0);
 }
 
-ncclResult_t ncclDevrCommCreateInternal(
-    struct ncclComm* comm,
-    struct ncclDevCommRequirements* reqs, struct ncclDevComm* outDevComm, bool isInternal,
-    struct ncclDevCommCompat* devCompat
-  ) {
+ncclResult_t ncclDevrCommCreateInternal(struct ncclComm* comm, struct ncclDevCommRequirements* reqs,
+                                        struct ncclDevComm* outDevComm, bool isInternal,
+                                        struct ncclDevCommCompat* devCompat) {
   ncclResult_t ret = ncclSuccess;
   struct ncclDevrState* devr = &comm->devrState;
   struct ncclTeam world = ncclTeamWorld(comm);
@@ -1597,10 +1596,8 @@ ncclResult_t ncclDevrCommCreateInternal(
   ncclGinConnectionType_t requestedConnectionType = reqs->ginConnectionType;
 
   if (reqs->ginForceEnable) {
-    INFO(NCCL_INIT,
-         "ginForceEnable set to true, defaulting ginConnectionType to NCCL_GIN_CONNECTION_FULL");
-    INFO(NCCL_INIT,
-         "ginForceEnable is being deprecated in favor of explicitly setting ginConnectionType!");
+    INFO(NCCL_INIT, "ginForceEnable set to true, defaulting ginConnectionType to NCCL_GIN_CONNECTION_FULL");
+    INFO(NCCL_INIT, "ginForceEnable is being deprecated in favor of explicitly setting ginConnectionType!");
     requestedConnectionType = NCCL_GIN_CONNECTION_FULL;
   }
 
@@ -1617,7 +1614,8 @@ ncclResult_t ncclDevrCommCreateInternal(
     }
     if (requestedConnectionType == NCCL_GIN_CONNECTION_FULL) {
       if (comm->globalGinSupport == NCCL_GIN_CONNECTION_RAIL) {
-        WARN("User requested GIN connection type NCCL_GIN_CONNECTION_FULL but the communicator supports only NCCL_GIN_CONNECTION_RAIL");
+        WARN("User requested GIN connection type NCCL_GIN_CONNECTION_FULL but the communicator supports only "
+             "NCCL_GIN_CONNECTION_RAIL");
         return ncclInvalidArgument;
       }
     }
@@ -1651,13 +1649,15 @@ ncclResult_t ncclDevrCommCreateInternal(
   outDevComm->lsaRank = devr->lsaSelf;
   outDevComm->lsaSize = devr->lsaSize;
   outDevComm->lsaSize_rcp32 = idivRcp32(devr->lsaSize);
-  outDevComm->ginIsRailed = comm->sharedRes->ginState.ginConnectionType == NCCL_GIN_CONNECTION_RAIL; // false if FULL or NONE
+  outDevComm->ginIsRailed =
+    comm->sharedRes->ginState.ginConnectionType == NCCL_GIN_CONNECTION_RAIL; // false if FULL or NONE
   if (isInternal) outDevComm->abortFlag = comm->abortFlagDev;
 
   NCCLCHECKGOTO(symTeamObtain(comm, lsa, /*multicast=*/reqs->lsaMultimem, &tmLsa), ret, fail);
   outDevComm->lsaMultimem.mcBasePtr = tmLsa->mcBasePtr;
 
-  { struct ncclTeamRequirements* tr = reqs->teamRequirementsList;
+  {
+    struct ncclTeamRequirements* tr = reqs->teamRequirementsList;
     while (tr != nullptr) {
       if (tr->multimem) {
         struct ncclDevrTeam* tm;
@@ -1673,7 +1673,8 @@ ncclResult_t ncclDevrCommCreateInternal(
   // Initialize resources for the hybrid barrier
   ncclLsaBarrierCreateRequirement(lsa, reqs->barrierCount, &outDevComm->hybridLsaBarrier, &hybridLsaBarrierReq);
   hybridLsaBarrierReq.next = resReqsHead;
-  ncclGinBarrierCreateRequirement(comm, ncclTeamRail(comm), reqs->barrierCount, &outDevComm->hybridRailGinBarrier, &hybridRailGinBarrierReq);
+  ncclGinBarrierCreateRequirement(comm, ncclTeamRail(comm), reqs->barrierCount, &outDevComm->hybridRailGinBarrier,
+                                  &hybridRailGinBarrierReq);
   hybridRailGinBarrierReq.next = &hybridLsaBarrierReq;
   resReqsHead = &hybridRailGinBarrierReq;
 
@@ -1681,21 +1682,24 @@ ncclResult_t ncclDevrCommCreateInternal(
   lsaBarReq.next = resReqsHead;
   resReqsHead = &lsaBarReq;
 
-  ncclGinBarrierCreateRequirement(comm, ncclTeamRail(comm), reqs->railGinBarrierCount, &outDevComm->railGinBarrier, &railGinBarrierReq);
+  ncclGinBarrierCreateRequirement(comm, ncclTeamRail(comm), reqs->railGinBarrierCount, &outDevComm->railGinBarrier,
+                                  &railGinBarrierReq);
   railGinBarrierReq.next = resReqsHead;
   resReqsHead = &railGinBarrierReq;
 
-  ncclGinBarrierCreateRequirement(comm, ncclTeamWorld(comm), reqs->worldGinBarrierCount, &outDevComm->worldGinBarrier, &worldGinBarrierReq);
+  ncclGinBarrierCreateRequirement(comm, ncclTeamWorld(comm), reqs->worldGinBarrierCount, &outDevComm->worldGinBarrier,
+                                  &worldGinBarrierReq);
   worldGinBarrierReq.next = resReqsHead;
   resReqsHead = &worldGinBarrierReq;
 
-  { struct ncclDevResourceRequirements* rr = resReqsHead;
+  {
+    struct ncclDevResourceRequirements* rr = resReqsHead;
     bufSizeTotal = 0;
     ginSignalTotal = reqs->ginSignalCount;
     ginCounterTotal = reqs->ginCounterCount;
     while (rr != nullptr) {
       bufSizeTotal = alignUp(bufSizeTotal, std::max<size_t>(128, rr->bufferAlign));
-      if (rr->outBufferHandle != nullptr) *rr->outBufferHandle = bufSizeTotal/128;
+      if (rr->outBufferHandle != nullptr) *rr->outBufferHandle = bufSizeTotal / 128;
       if (rr->outGinSignalStart != nullptr) *rr->outGinSignalStart = ginSignalTotal;
       if (rr->outGinCounterStart != nullptr) *rr->outGinCounterStart = ginCounterTotal;
       bufSizeTotal += rr->bufferSize;
@@ -1703,7 +1707,7 @@ ncclResult_t ncclDevrCommCreateInternal(
       ginCounterTotal += rr->ginCounterCount;
       rr = rr->next;
     }
-    bufSizeTotal= alignUp(bufSizeTotal, 128);
+    bufSizeTotal = alignUp(bufSizeTotal, 128);
     ginSignalShadowsOffset = bufSizeTotal;
     bufSizeTotal += nGinContexts * ginSignalTotal * sizeof(uint64_t); // include signal shadows
     bufSizeTotal = alignUp(bufSizeTotal, devr->granularity);
@@ -1719,12 +1723,12 @@ ncclResult_t ncclDevrCommCreateInternal(
 
   if (ginActivated) {
     // Now update the GIN handles in all existing windows. Registration of memories happened above.
-    for (int i=0; i < devr->winSortedCount; i++) {
+    for (int i = 0; i < devr->winSortedCount; i++) {
       struct ncclDevrWindow* win = devr->winSorted[i].win;
       struct ncclWindow_vidmem* winHost;
       NCCLCHECKGOTO(ncclShadowPoolToHost(&devr->shadows, win->vidmem, &winHost), ret, fail_stream);
-      winHost->ginOffset4K = (win->bigOffset - win->memory->bigOffset)>>12;
-      for (int i=0; i < NCCL_GIN_MAX_CONNECTIONS; i++) {
+      winHost->ginOffset4K = (win->bigOffset - win->memory->bigOffset) >> 12;
+      for (int i = 0; i < NCCL_GIN_MAX_CONNECTIONS; i++) {
         winHost->ginWins[i] = win->memory->ginDevWins[i];
       }
       winHost->numSegments = win->memory->numGinSegments;
@@ -1736,11 +1740,14 @@ ncclResult_t ncclDevrCommCreateInternal(
         struct ncclSegmentWindow* segmentWindowsDev;
         struct ncclSegmentWindow* segmentWindowsHost;
         NCCLCHECKGOTO(ncclShadowPoolFree(&devr->shadows, winHost->ginMultiSegmentWins, stream), ret, fail_stream);
-        NCCLCHECKGOTO(allocAndPopulateSegmentWindows(devr, win->memory, stream,
-            &segmentWindowsDev, &segmentWindowsHost), ret, fail_stream);
+        NCCLCHECKGOTO(allocAndPopulateSegmentWindows(devr, win->memory, stream, &segmentWindowsDev,
+                                                     &segmentWindowsHost),
+                      ret, fail_stream);
         winHost->ginMultiSegmentWins = segmentWindowsDev;
       }
-      CUDACHECKGOTO(cudaMemcpyAsync(win->vidmem, winHost, sizeof(struct ncclWindow_vidmem), cudaMemcpyHostToDevice, stream), ret, fail_stream);
+      CUDACHECKGOTO(cudaMemcpyAsync(win->vidmem, winHost, sizeof(struct ncclWindow_vidmem), cudaMemcpyHostToDevice,
+                                    stream),
+                    ret, fail_stream);
     }
   }
 
@@ -1770,15 +1777,16 @@ ncclResult_t ncclDevrCommCreateInternal(
     memHandle = 0x0; // Reference given to symMemoryObtain
 
     NCCLCHECKGOTO(symWindowCreate( // Requires world barrier afterward.
-      comm, mem, /*memOffset=*/0, nullptr, bufSizeTotal, /*winFlags=*/0,
-      /*localReg=*/nullptr, &outDevComm->resourceWindow, &win,
-      stream), ret, fail_stream_mem);
+                    comm, mem, /*memOffset=*/0, nullptr, bufSizeTotal, /*winFlags=*/0,
+                    /*localReg=*/nullptr, &outDevComm->resourceWindow, &win, stream),
+                  ret, fail_stream_mem);
     mem = nullptr; // Reference given to symWindowCreate
     NCCLCHECKGOTO(ncclShadowPoolToHost(&devr->shadows, win->vidmem, &winHost), ret, fail_stream_mem_win);
     outDevComm->resourceWindow_inlined.lsaFlatBase = winHost->lsaFlatBase;
     outDevComm->resourceWindow_inlined.stride4G = winHost->stride4G;
     outDevComm->resourceWindow_inlined.mcOffset4K = winHost->mcOffset4K;
-    outDevComm->ginSignalShadows = (uint64_t*)add4G((char*)winHost->lsaFlatBase + ginSignalShadowsOffset, winHost->lsaRank*winHost->stride4G);
+    outDevComm->ginSignalShadows =
+      (uint64_t*)add4G((char*)winHost->lsaFlatBase + ginSignalShadowsOffset, winHost->lsaRank * winHost->stride4G);
 
     CUDACHECKGOTO(cudaMemsetAsync(win->userPtr, 0, bufSizeTotal, stream), ret, fail_stream_mem_win);
   }
@@ -1788,7 +1796,7 @@ ncclResult_t ncclDevrCommCreateInternal(
   NCCLCHECKGOTO(bootstrapBarrier(comm->bootstrap, comm->rank, comm->nRanks, 0xbeef), ret, fail_stream_mem_win);
   CUDACHECKGOTO(cudaStreamDestroy(stream), ret, fail_stream_mem_win);
 
-  //ncclDevCommDump(outDevComm);
+  // ncclDevCommDump(outDevComm);
   if (outDevCommPreserve) {
     NCCLCHECKGOTO(devCompat->devCommCopyNewToOld(comm, outDevCommPreserve, outDevComm), ret, fail_stream_mem_win);
   }
@@ -1798,7 +1806,9 @@ fail_stream_mem_win:
   symWindowDestroy(comm, win->vidmem, stream);
   CUDACHECKIGNORE(cudaStreamSynchronize(stream));
 fail_stream_mem:
-  if (memHandle != 0x0) { CUCHECKIGNORE(cuMemRelease(memHandle)); }
+  if (memHandle != 0x0) {
+    CUCHECKIGNORE(cuMemRelease(memHandle));
+  }
   symMemoryDropRef(comm, mem);
 fail_stream:
   CUDACHECKIGNORE(cudaStreamDestroy(stream));
@@ -1808,11 +1818,10 @@ fail:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-NCCL_API(ncclResult_t, ncclCommWindowRegister, ncclComm_t comm, void* ptr, size_t size, ncclWindow_t* win, int winFlags);
-ncclResult_t ncclCommWindowRegister_impl(
-    struct ncclComm* comm, void* userPtr, size_t userSize,
-    struct ncclWindow_vidmem** outWinDev, int winFlags
-  ) {
+NCCL_API(ncclResult_t, ncclCommWindowRegister, ncclComm_t comm, void* ptr, size_t size, ncclWindow_t* win,
+         int winFlags);
+ncclResult_t ncclCommWindowRegister_impl(struct ncclComm* comm, void* userPtr, size_t userSize,
+                                         struct ncclWindow_vidmem** outWinDev, int winFlags) {
   ncclResult_t ret = ncclSuccess;
   int saveDev;
   struct ncclDevrRegTask* task;
@@ -1838,8 +1847,7 @@ ncclResult_t ncclCommWindowRegister_impl(
   // lazy enqueue in rmaTaskAppend, which fires on the first ncclPutSignal/
   // Signal/WaitSignal. ncclRmaCeInit is collective (signals window + bootstrap
   // barrier), so we cannot call it from the non-collective Host API entry point.
-  if (!comm->rmaState.rmaCeState.initialized &&
-      ncclIntruQueueEmpty(&comm->rmaCeInitTaskQueue)) {
+  if (!comm->rmaState.rmaCeState.initialized && ncclIntruQueueEmpty(&comm->rmaCeInitTaskQueue)) {
     struct ncclRmaCeInitTask* ceTask;
     NCCLCHECKGOTO(ncclCalloc(&ceTask, 1), ret, fail);
     ceTask->comm = comm;
@@ -1858,8 +1866,7 @@ fail:
 
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
 // RCCL: deregister mirror of windowRegisterNonSym
-static ncclResult_t windowDeregisterNonSym(struct ncclComm* comm,
-                                           struct ncclWindow_vidmem* winDev) {
+static ncclResult_t windowDeregisterNonSym(struct ncclComm* comm, struct ncclWindow_vidmem* winDev) {
   ncclResult_t ret = ncclSuccess;
   struct ncclDevrState* devr = &comm->devrState;
   cudaStream_t stream = nullptr;
@@ -1868,8 +1875,7 @@ static ncclResult_t windowDeregisterNonSym(struct ncclComm* comm,
 
   // Decode win from winDev via the shadow pool
   struct ncclWindow_vidmem* winDevHost = nullptr;
-  NCCLCHECKGOTO(ncclShadowPoolToHost(&devr->shadows, winDev, &winDevHost),
-                ret, fail);
+  NCCLCHECKGOTO(ncclShadowPoolToHost(&devr->shadows, winDev, &winDevHost), ret, fail);
   win = (struct ncclDevrWindow*)winDevHost->winHost;
 
   // Locate this window's registration. A stale handle (e.g. a second
@@ -1902,10 +1908,8 @@ static ncclResult_t windowDeregisterNonSym(struct ncclComm* comm,
   win->ipcPeerPtrsAllocBase = nullptr;
 
   // Undo stage 3: shadow pool entry.
-  CUDACHECKGOTO(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking),
-                ret, fail);
-  NCCLCHECKGOTO(ncclShadowPoolFree(&devr->shadows, winDev, stream), ret,
-                fail_stream);
+  CUDACHECKGOTO(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking), ret, fail);
+  NCCLCHECKGOTO(ncclShadowPoolFree(&devr->shadows, winDev, stream), ret, fail_stream);
   CUDACHECKIGNORE(cudaStreamSynchronize(stream));
   CUDACHECKIGNORE(cudaStreamDestroy(stream));
   stream = nullptr;
@@ -1954,14 +1958,12 @@ exit:
   return ret;
 }
 
-ncclResult_t ncclDevrFindWindow(
-    struct ncclComm* comm, void const* userPtr, struct ncclDevrWindow** outWin
-  ) {
+ncclResult_t ncclDevrFindWindow(struct ncclComm* comm, void const* userPtr, struct ncclDevrWindow** outWin) {
   struct ncclDevrState* devr = &comm->devrState;
   uintptr_t userAddr = reinterpret_cast<uintptr_t>(userPtr);
   int i = listFindSortedLub(&ncclDevrWindowSorted::userAddr, devr->winSorted, devr->winSortedCount, userAddr);
-  if (0 < i && (userAddr - devr->winSorted[i-1].userAddr < devr->winSorted[i-1].size)) {
-    *outWin = devr->winSorted[i-1].win;
+  if (0 < i && (userAddr - devr->winSorted[i - 1].userAddr < devr->winSorted[i - 1].size)) {
+    *outWin = devr->winSorted[i - 1].win;
   } else {
     *outWin = nullptr;
   }
@@ -1982,13 +1984,14 @@ static ncclResult_t getNcclVersionCompat(int compiledVersion, struct ncclDevComm
 
   if (compiledVersion > NCCL_VERSION_CODE && ncclParamEnableVersionCheck()) {
     char compiledBuf[16], runtimeBuf[16];
-    WARN("NCCL library is too old. This application was compiled with NCCL version %s, but is running with NCCL library version %s.",
+    WARN("NCCL library is too old. This application was compiled with NCCL version %s, but is running with NCCL "
+         "library version %s.",
          ncclVersionToString(compiledVersion, compiledBuf, sizeof(compiledBuf)),
          ncclVersionToString(NCCL_VERSION_CODE, runtimeBuf, sizeof(runtimeBuf)));
     return ncclInvalidUsage;
   }
 
-  struct ncclDevCommCompat *devCompat = nullptr;
+  struct ncclDevCommCompat* devCompat = nullptr;
   for (int i = 0; devCommCompat[i]; i++) {
     if (compiledVersion >= devCommCompat[i]->minVersion && compiledVersion <= devCommCompat[i]->maxVersion) {
       devCompat = devCommCompat[i];
@@ -1997,7 +2000,8 @@ static ncclResult_t getNcclVersionCompat(int compiledVersion, struct ncclDevComm
   }
   if (devCompat == nullptr) {
     char compiledBuf[16], runtimeBuf[16];
-    WARN("NCCL library is not backwards compatible. This application was compiled with NCCL version %s, but is running with NCCL library version %s.",
+    WARN("NCCL library is not backwards compatible. This application was compiled with NCCL version %s, but is running "
+         "with NCCL library version %s.",
          ncclVersionToString(compiledVersion, compiledBuf, sizeof(compiledBuf)),
          ncclVersionToString(NCCL_VERSION_CODE, runtimeBuf, sizeof(runtimeBuf)));
     return ncclInvalidUsage;
@@ -2019,11 +2023,12 @@ ncclResult_t ncclCommQueryProperties(ncclComm_t comm, ncclCommProperties_t* prop
   NCCLCHECK(ncclCommEnsureReady(comm));
 
   if (props->magic != NCCL_API_MAGIC) {
-    WARN("Cannot get communicator properties: ncclCommProperties_t argument must be initialized via NCCL_COMM_PROPERTIES_INITIALIZER");
+    WARN("Cannot get communicator properties: ncclCommProperties_t argument must be initialized via "
+         "NCCL_COMM_PROPERTIES_INITIALIZER");
     return ncclInvalidUsage;
   }
 
-  struct ncclDevCommCompat *devCompat = nullptr;
+  struct ncclDevCommCompat* devCompat = nullptr;
   NCCLCHECK(getNcclVersionCompat(props->version, &devCompat));
 
   props->rank = comm->rank;
@@ -2051,19 +2056,19 @@ ncclResult_t ncclCommQueryProperties(ncclComm_t comm, ncclCommProperties_t* prop
   return ncclSuccess;
 }
 
-NCCL_API(ncclResult_t, ncclDevCommCreate, ncclComm_t comm, ncclDevCommRequirements_t const* reqs, ncclDevComm_t* outDevComm);
-ncclResult_t ncclDevCommCreate(
-    ncclComm_t comm, struct ncclDevCommRequirements const* reqs,
-    struct ncclDevComm* outDevComm
-  ) {
+NCCL_API(ncclResult_t, ncclDevCommCreate, ncclComm_t comm, ncclDevCommRequirements_t const* reqs,
+         ncclDevComm_t* outDevComm);
+ncclResult_t ncclDevCommCreate(ncclComm_t comm, struct ncclDevCommRequirements const* reqs,
+                               struct ncclDevComm* outDevComm) {
   NCCLCHECK(CommCheck(comm, __func__, "comm"));
   NCCLCHECK(PtrCheck(reqs, __func__, "reqs"));
   if (reqs->magic != NCCL_API_MAGIC) {
-    WARN("Cannot create device communicator: ncclDevCommRequirements_t argument must be initialized via NCCL_DEV_COMM_REQUIREMENTS_INITIALIZER");
+    WARN("Cannot create device communicator: ncclDevCommRequirements_t argument must be initialized via "
+         "NCCL_DEV_COMM_REQUIREMENTS_INITIALIZER");
     return ncclInvalidUsage;
   }
 
-  struct ncclDevCommCompat *devCompat = nullptr;
+  struct ncclDevCommCompat* devCompat = nullptr;
   NCCLCHECK(getNcclVersionCompat(reqs->version, &devCompat));
 
   ncclResult_t ret = ncclSuccess;
@@ -2106,14 +2111,12 @@ fail:
 }
 
 NCCL_API(ncclResult_t, ncclDevCommDestroy, ncclComm_t comm, ncclDevComm_t const* devComm);
-ncclResult_t ncclDevCommDestroy(
-    struct ncclComm* comm, struct ncclDevComm const* devComm
-  ) {
+ncclResult_t ncclDevCommDestroy(struct ncclComm* comm, struct ncclDevComm const* devComm) {
   NCCLCHECK(CommCheck(comm, __func__, "comm"));
   NCCLCHECK(PtrCheck(devComm, __func__, "devComm"));
   int saveDev;
   ncclResult_t ret = ncclSuccess;
-  struct ncclDevCommCompat *devCompat = nullptr;
+  struct ncclDevCommCompat* devCompat = nullptr;
   ncclDevComm_t devCommTmp;
 
   if (devComm->magic == NCCL_API_MAGIC) {
@@ -2197,7 +2200,8 @@ ncclResult_t ncclDevrWorldToLsaRank(struct ncclComm* comm, int peerWorldRank, in
 }
 
 // Get the corresponding pointer in another lsa rank's symmetric memory window
-ncclResult_t ncclDevrGetLsaRankPtr(struct ncclComm* comm, struct ncclDevrWindow* winHost, size_t offset, int lsaRank, void** outPtr) {
+ncclResult_t ncclDevrGetLsaRankPtr(struct ncclComm* comm, struct ncclDevrWindow* winHost, size_t offset, int lsaRank,
+                                   void** outPtr) {
   NCCLCHECK(CommCheck(comm, __func__, "comm"));
   NCCLCHECK(PtrCheck(outPtr, __func__, "outPtr"));
 
@@ -2259,7 +2263,8 @@ ncclGinWindow_t ncclDevrGetRmaDevWin(struct ncclDevrWindow* winHost, int ctx) {
 }
 
 // Get the multicast address for a given team
-ncclResult_t ncclDevrGetLsaTeamPtrMC(struct ncclComm* comm, struct ncclDevrWindow* winHost, size_t offset, struct ncclTeam lsaTeam, void** outPtr){
+ncclResult_t ncclDevrGetLsaTeamPtrMC(struct ncclComm* comm, struct ncclDevrWindow* winHost, size_t offset,
+                                     struct ncclTeam lsaTeam, void** outPtr) {
   if (winHost == nullptr || outPtr == nullptr) return ncclInternalError;
 
   if (!comm->nvlsSupport) {
@@ -2276,13 +2281,14 @@ ncclResult_t ncclDevrGetLsaTeamPtrMC(struct ncclComm* comm, struct ncclDevrWindo
   return ncclSuccess;
 }
 
-static ncclResult_t findCommAndHostWindowFromDeviceWindow(ncclWindow_t devWindow, ncclComm_t* foundComm, ncclDevrWindow** hostWindow) {
+static ncclResult_t findCommAndHostWindowFromDeviceWindow(ncclWindow_t devWindow, ncclComm_t* foundComm,
+                                                          ncclDevrWindow** hostWindow) {
   struct ncclDevrWindow* winHost = nullptr;
   std::lock_guard<std::mutex> lock(ncclWindowMapMutex);
   NCCLCHECK(ncclIntruAddressMapFind(&ncclWindowMap, devWindow, &winHost));
   if (winHost == nullptr) {
-    WARN("Could not find communicator matching window %p (map hbits=%d count=%d)",
-         devWindow, ncclWindowMap.base.hbits, ncclWindowMap.base.count);
+    WARN("Could not find communicator matching window %p (map hbits=%d count=%d)", devWindow, ncclWindowMap.base.hbits,
+         ncclWindowMap.base.count);
     return ncclInvalidArgument;
   }
 
@@ -2292,8 +2298,10 @@ static ncclResult_t findCommAndHostWindowFromDeviceWindow(ncclWindow_t devWindow
   return ncclSuccess;
 }
 
-NCCL_API(ncclResult_t, ncclGetMultimemDevicePointer, ncclWindow_t window, size_t offset, ncclMultimemHandle multimem, void** outPtr);
-ncclResult_t ncclGetMultimemDevicePointer (ncclWindow_t window, size_t offset, ncclMultimemHandle multimem, void** outPtr) {
+NCCL_API(ncclResult_t, ncclGetMultimemDevicePointer, ncclWindow_t window, size_t offset, ncclMultimemHandle multimem,
+         void** outPtr);
+ncclResult_t ncclGetMultimemDevicePointer(ncclWindow_t window, size_t offset, ncclMultimemHandle multimem,
+                                          void** outPtr) {
   NCCLCHECK(PtrCheck(window, __func__, "window"));
   NCCLCHECK(PtrCheck(outPtr, __func__, "outPtr"));
   if (multimem.mcBasePtr == nullptr) {
@@ -2313,7 +2321,6 @@ ncclResult_t ncclGetMultimemDevicePointer (ncclWindow_t window, size_t offset, n
   *outPtr = (void*)((uintptr_t)multimem.mcBasePtr + winHost->bigOffset + offset);
   return ncclSuccess;
 }
-
 
 NCCL_API(ncclResult_t, ncclGetLsaMultimemDevicePointer, ncclWindow_t window, size_t offset, void** outPtr);
 ncclResult_t ncclGetLsaMultimemDevicePointer(ncclWindow_t window, size_t offset, void** outPtr) {
@@ -2348,8 +2355,8 @@ ncclResult_t ncclGetLsaDevicePointer(ncclWindow_t window, size_t offset, int lsa
 
   devr = &comm->devrState;
   if (lsaRank < 0 || lsaRank >= devr->lsaSize) {
-    WARN("The provided lsaRank %d is not in the valid lsaSize of [0,%d] for the provided window %p.",
-         lsaRank, devr->lsaSize, window);
+    WARN("The provided lsaRank %d is not in the valid lsaSize of [0,%d] for the provided window %p.", lsaRank,
+         devr->lsaSize, window);
     return ncclInvalidArgument; // In this case the user should know what the lsa size is.
   }
 
@@ -2399,12 +2406,12 @@ ncclResult_t ncclGetPeerDevicePointer(ncclWindow_t window, size_t offset, int pe
 ////////////////////////////////////////////////////////////////////////////////
 
 // Find the least index strictly greater than arg.
-template<typename Obj, typename Key>
-static int listFindSortedLub(Key Obj::*key, Obj* sorted, int count, Key arg) {
+template <typename Obj, typename Key>
+static int listFindSortedLub(Key Obj::* key, Obj* sorted, int count, Key arg) {
   int lo = 0, hi = count;
   while (lo + 16 < hi) {
-    int i = (lo + hi)/2;
-    if (sorted[i].*key <= arg) lo = i+1;
+    int i = (lo + hi) / 2;
+    if (sorted[i].*key <= arg) lo = i + 1;
     else hi = i;
   }
   int i = lo;
@@ -2412,24 +2419,24 @@ static int listFindSortedLub(Key Obj::*key, Obj* sorted, int count, Key arg) {
   return i;
 }
 
-template<typename Obj>
+template <typename Obj>
 static void listInsert(Obj** list, int* capacity, int* count, int index, Obj val) {
   if (*capacity < *count + 1) {
     *capacity *= 2;
     if (*capacity == 0) *capacity = 16;
-    *list = (Obj*)realloc(*list, (*capacity)*sizeof(Obj));
+    *list = (Obj*)realloc(*list, (*capacity) * sizeof(Obj));
   }
   for (int j = *count; j != index; j--) {
-    (*list)[j] = (*list)[j-1];
+    (*list)[j] = (*list)[j - 1];
   }
   (*list)[index] = val;
   *count += 1;
 }
 
-template<typename Obj>
+template <typename Obj>
 static void listRemove(Obj* list, int* count, int index) {
-  for (int i = index; i+1 < *count; i++) {
-    list[i] = list[i+1];
+  for (int i = index; i + 1 < *count; i++) {
+    list[i] = list[i + 1];
   }
   *count -= 1;
 }

--- a/projects/rccl/src/devcomm/devcomm_v22902.cc
+++ b/projects/rccl/src/devcomm/devcomm_v22902.cc
@@ -35,7 +35,6 @@ struct ncclCommProperties_v22902 {
 static_assert(offsetof(struct ncclCommProperties_v22902, ginType) == 34);
 static_assert(sizeof(struct ncclCommProperties_v22902) == 40);
 
-
 struct ncclDevComm_v22902 {
   int rank, nRanks;
   uint32_t nRanks_rcp32;
@@ -84,7 +83,6 @@ static_assert(offsetof(struct ncclDevComm_v22902, ginCounterCount) == 188);
 static_assert(offsetof(struct ncclDevComm_v22902, ginSignalShadows) == 192);
 static_assert(sizeof(struct ncclDevComm_v22902) == 200);
 
-
 static ncclResult_t ncclCommPropertiesFilter_v22902(ncclComm_t comm, struct ncclCommProperties* props) {
   // We don't provide backwards compatibility for GIN with 2.29.2.  If a communicator needs it, we indicate that
   // the Device API is not available.
@@ -108,7 +106,9 @@ static ncclResult_t ncclDevCommRequirementsFilter_v22902(ncclComm_t comm, ncclDe
   }
   if (userRequestedGin) {
     char compiledBuf[16], runtimeBuf[16];
-    WARN("The application was compiled with too old version of NCCL. It was compiled with NCCL version %s, but is running with NCCL library version %s. Because of its use of GIN device kernels, it needs to be recompiled, preferably with the same NCCL version that it will be running with.",
+    WARN("The application was compiled with too old version of NCCL. It was compiled with NCCL version %s, but is "
+         "running with NCCL library version %s. Because of its use of GIN device kernels, it needs to be recompiled, "
+         "preferably with the same NCCL version that it will be running with.",
          ncclVersionToString(reqs->version, compiledBuf, sizeof(compiledBuf)),
          ncclVersionToString(NCCL_VERSION_CODE, runtimeBuf, sizeof(runtimeBuf)));
     return ncclInvalidUsage;
@@ -149,7 +149,8 @@ static ncclResult_t ncclDevCommCopyOldToNew_v22902(ncclComm_t comm, struct ncclD
 }
 
 struct ncclDevCommCompat ncclDevCommCompat_v22902 = {
-  NCCL_VERSION(2, 29, 2), NCCL_VERSION(2, 29, 3), // minVersion, maxVersion
+  NCCL_VERSION(2, 29, 2),
+  NCCL_VERSION(2, 29, 3), // minVersion, maxVersion
   ncclCommPropertiesFilter_v22902,                // commPropertiesFilter
   ncclDevCommRequirementsFilter_v22902,           // devCommRequirementsFilter
   ncclDevCommCopyNewToOld_v22902,                 // devCommCopyNewToOld

--- a/projects/rccl/src/devcomm/devcomm_v22907.cc
+++ b/projects/rccl/src/devcomm/devcomm_v22907.cc
@@ -66,7 +66,6 @@ static_assert(offsetof(struct ncclDevComm_v22907, ginIsRailed) == 208);
 static_assert(offsetof(struct ncclDevComm_v22907, abortFlag) == 216);
 static_assert(sizeof(struct ncclDevComm_v22907) == 224);
 
-
 static ncclResult_t ncclCommPropertiesFilter_v22907(ncclComm_t comm, struct ncclCommProperties* props) {
   // We don't provide backwards compatibility for GIN with 2.29.7.  If a communicator needs it, we indicate that
   // the Device API is not available.
@@ -78,8 +77,8 @@ static ncclResult_t ncclCommPropertiesFilter_v22907(ncclComm_t comm, struct nccl
 }
 
 static ncclResult_t ncclDevCommRequirementsFilter_v22907(ncclComm_t comm, ncclDevCommRequirements_t* reqs) {
-  bool requestedGinResources = reqs->ginSignalCount > 0 || reqs->ginCounterCount > 0 ||
-                               reqs->barrierCount > 0 || reqs->railGinBarrierCount > 0;
+  bool requestedGinResources =
+    reqs->ginSignalCount > 0 || reqs->ginCounterCount > 0 || reqs->barrierCount > 0 || reqs->railGinBarrierCount > 0;
   struct ncclDevResourceRequirements* node = reqs->resourceRequirementsList;
   while (!requestedGinResources && node != nullptr) {
     requestedGinResources = node->ginSignalCount > 0 || node->ginCounterCount > 0;
@@ -87,7 +86,9 @@ static ncclResult_t ncclDevCommRequirementsFilter_v22907(ncclComm_t comm, ncclDe
   }
   if (requestedGinResources && (reqs->ginConnectionType != NCCL_GIN_CONNECTION_NONE || reqs->ginForceEnable)) {
     char compiledBuf[16], runtimeBuf[16];
-    WARN("The application was compiled with too old version of NCCL. It was compiled with NCCL version %s, but is running with NCCL library version %s. Because of its use of GIN device kernels, it needs to be recompiled, preferably with the same NCCL version that it will be running with.",
+    WARN("The application was compiled with too old version of NCCL. It was compiled with NCCL version %s, but is "
+         "running with NCCL library version %s. Because of its use of GIN device kernels, it needs to be recompiled, "
+         "preferably with the same NCCL version that it will be running with.",
          ncclVersionToString(reqs->version, compiledBuf, sizeof(compiledBuf)),
          ncclVersionToString(NCCL_VERSION_CODE, runtimeBuf, sizeof(runtimeBuf)));
     return ncclInvalidUsage;
@@ -109,7 +110,8 @@ static ncclResult_t ncclDevCommCopyNewToOld_v22907(ncclComm_t comm, void* oldDev
 }
 
 struct ncclDevCommCompat ncclDevCommCompat_v22907 = {
-  NCCL_VERSION(2, 29, 5), NCCL_VERSION(2, 29, 7), // minVersion, maxVersion
+  NCCL_VERSION(2, 29, 5),
+  NCCL_VERSION(2, 29, 7), // minVersion, maxVersion
   ncclCommPropertiesFilter_v22907,                // commPropertiesFilter
   ncclDevCommRequirementsFilter_v22907,           // devCommRequirementsFilter
   ncclDevCommCopyNewToOld_v22907,                 // devCommCopyNewToOld

--- a/projects/rccl/src/devcomm/devcomm_v23000.cc
+++ b/projects/rccl/src/devcomm/devcomm_v23000.cc
@@ -8,7 +8,8 @@
 #include "dev_runtime.h"
 
 struct ncclDevCommCompat ncclDevCommCompat_v23000 = {
-  NCCL_VERSION(2, 30, 0), NCCL_VERSION_CODE, // minVersion, maxVersion
+  NCCL_VERSION(2, 30, 0),
+  NCCL_VERSION_CODE, // minVersion, maxVersion
   nullptr,                                   // commPropertiesFilter
   nullptr,                                   // devCommRequirementsFilter
   nullptr,                                   // devCommCopyNewToOld

--- a/projects/rccl/src/device/all_gather.h
+++ b/projects/rccl/src/device/all_gather.h
@@ -10,120 +10,125 @@
 #include "primitives.h"
 
 namespace {
-  template<typename T, typename RedOp, typename Proto, bool isNetOffload = false>
+template <typename T, typename RedOp, typename Proto, bool isNetOffload = false>
 #if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
-  __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
+__device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
 #else
-  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
+__device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
 #endif
 #ifdef ENABLE_WARP_SPEED
-    int warp = threadIdx.x / WARP_SIZE;
-    ncclRing *ring = ncclShmem.warpComm
-        ? &ncclShmem.warpChannel[warp].ring
-        : &ncclShmem.channel.ring;
+  int warp = threadIdx.x / WARP_SIZE;
+  ncclRing* ring = ncclShmem.warpComm ? &ncclShmem.warpChannel[warp].ring : &ncclShmem.channel.ring;
 #else
-    ncclRing *ring = &ncclShmem.channel.ring;
+  ncclRing* ring = &ncclShmem.channel.ring;
 #endif
-    const int *ringRanks = ring->userRanks;
-    const int nranks = ncclShmem.comm.nRanks;
-    ssize_t count, partOffset, partCount, chunkCount;
+  const int* ringRanks = ring->userRanks;
+  const int nranks = ncclShmem.comm.nRanks;
+  ssize_t count, partOffset, partCount, chunkCount;
 #ifdef ENABLE_WARP_SPEED
-    ncclCollCbdPart(work, ncclShmem.warpChannelId[warp], Proto::Id, sizeof(T), &count, &partOffset, &partCount, &chunkCount);
+  ncclCollCbdPart(work, ncclShmem.warpChannelId[warp], Proto::Id, sizeof(T), &count, &partOffset, &partCount,
+                  &chunkCount);
 #else
-    ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &count, &partOffset, &partCount, &chunkCount);
+  ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &count, &partOffset, &partCount, &chunkCount);
 #endif
-    ssize_t offset;
-    ssize_t dataOffset;
-    int nelem;
-    int rankDest;
+  ssize_t offset;
+  ssize_t dataOffset;
+  int nelem;
+  int rankDest;
 
-    int workNthreads;
-    T *inputBuf = (T*)work->sendbuff;
-    T *outputBuf = (T*)work->recvbuff;
+  int workNthreads;
+  T* inputBuf = (T*)work->sendbuff;
+  T* outputBuf = (T*)work->recvbuff;
 
     // If isNetOffload == true, we only use 1 warp to drive Ring algo/network communication
     // and the rest of warps proceed to copy src data into dst buffer in parallel when AG
     // is not in-place.
-    if (isNetOffload) {
-      workNthreads = WARP_SIZE;
-      chunkCount = NCCL_MAX_NET_SIZE;
-    } else {
-      workNthreads = nthreads;
-    }
+  if (isNetOffload) {
+    workNthreads = WARP_SIZE;
+    chunkCount = NCCL_MAX_NET_SIZE;
+  } else {
+    workNthreads = nthreads;
+  }
 
-    if (tid < workNthreads) {
+  if (tid < workNthreads) {
       // Coverity reports that the callee treats &ring->next as an array.  However, due to the use of
       // FanSymmetric<1>, only the first element is ever accessed, so it's fine.
       // coverity[callee_ptr_arith:FALSE]
-      Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0, isNetOffload> prims
-        (tid, workNthreads, &ring->prev, &ring->next, inputBuf, outputBuf, work->redOpArg, 0, work->connIndex, work->connIndex, work, nullptr, isNetOffload ? NCCL_MAX_NET_SIZE : 0);
+    Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0, isNetOffload> prims(
+      tid, workNthreads, &ring->prev, &ring->next, inputBuf, outputBuf, work->redOpArg, 0, work->connIndex,
+      work->connIndex, work, nullptr, isNetOffload ? NCCL_MAX_NET_SIZE : 0);
 
-      for (size_t elemOffset = 0; elemOffset < partCount; elemOffset += chunkCount) {
+    for (size_t elemOffset = 0; elemOffset < partCount; elemOffset += chunkCount) {
         /////////////// begin AllGather steps ///////////////
-        nelem = min(chunkCount, partCount - elemOffset);
-        dataOffset = partOffset + elemOffset;
+      nelem = min(chunkCount, partCount - elemOffset);
+      dataOffset = partOffset + elemOffset;
 
         // step 0: push data to next GPU
-        rankDest = ringRanks[0];
-        offset = dataOffset + rankDest * count;
+      rankDest = ringRanks[0];
+      offset = dataOffset + rankDest * count;
 
-        if ((inputBuf + dataOffset == outputBuf + offset) || isNetOffload) { // In place or onePPN
-          prims.directSend(dataOffset, offset, nelem);
-        } else {
-          prims.directCopySend(dataOffset, offset, nelem);
-        }
+      if ((inputBuf + dataOffset == outputBuf + offset) || isNetOffload) { // In place or onePPN
+        prims.directSend(dataOffset, offset, nelem);
+      } else {
+        prims.directCopySend(dataOffset, offset, nelem);
+      }
 
         // k-2 steps: copy to next GPU
-        for (int j = 1; j < nranks - 1; ++j) {
-          rankDest = ringRanks[nranks - j];
-          offset = dataOffset + rankDest * count;
-          prims.directRecvCopyDirectSend(offset, offset, nelem);
-        }
+      for (int j = 1; j < nranks - 1; ++j) {
+        rankDest = ringRanks[nranks - j];
+        offset = dataOffset + rankDest * count;
+        prims.directRecvCopyDirectSend(offset, offset, nelem);
+      }
 
         // Make final copy from buffer to dest.
-        rankDest = ringRanks[1];
-        offset = dataOffset + rankDest * count;
+      rankDest = ringRanks[1];
+      offset = dataOffset + rankDest * count;
 
         // Final wait/copy.
-        prims.directRecv(offset, nelem);
-
-      }
-    } else if (inputBuf != outputBuf + ringRanks[0] * count) {
-      inputBuf = inputBuf + partOffset;
-      outputBuf = outputBuf + partOffset + ringRanks[0] * count;
-      reduceCopy<COLL_UNROLL, USE_ACC, RedOp, T, 0, 1, 1, 0, 1, 1, /*PreOpSrcs=*/0>
-        (tid - workNthreads, nthreads - workNthreads, work->redOpArg, false, 1, (void**)&inputBuf, 1, (void**)&outputBuf, partCount);
+      prims.directRecv(offset, nelem);
     }
+  } else if (inputBuf != outputBuf + ringRanks[0] * count) {
+    inputBuf = inputBuf + partOffset;
+    outputBuf = outputBuf + partOffset + ringRanks[0] * count;
+    reduceCopy<COLL_UNROLL, USE_ACC, RedOp, T, 0, 1, 1, 0, 1, 1, /*PreOpSrcs=*/0>(
+      tid - workNthreads, nthreads - workNthreads, work->redOpArg, false, 1, (void**)&inputBuf, 1, (void**)&outputBuf,
+      partCount);
+  }
 #if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
     // we have to wait for all warps before we can proceed to the next work;
     // otherwise, we can have contention if next work will use the outputBuf
     // in this work. We use bar 14 to avoid conflicts with prims barrier and
     // __syncthread().
-    if (isNetOffload) barrier_sync(14, nThreads);
+  if (isNetOffload) barrier_sync(14, nThreads);
 #endif
-  }
 }
+} // namespace
 
 #if defined(__gfx942__)  // Use a single slice per simple primitive for a single node on some GFX9 devices.
 #define rcclAllGatherRunRingSimpleProtoImpl(tid, nthreads, work) \
-  if(work->rcclUseOneSlice){ \
-    runRing<T, RedOp, ProtoSimple<ALLGATHER_CHUNKSTEPS/ALLGATHER_SLICESTEPS_SINGLE_NODE, ALLGATHER_SLICESTEPS_SINGLE_NODE>, false>(tid, nthreads, work); \
-  } else{ \
-    runRing<T, RedOp, ProtoSimple<ALLGATHER_CHUNKSTEPS/ALLGATHER_SLICESTEPS, ALLGATHER_SLICESTEPS>, false>(tid, nthreads, work); \
+  if (work->rcclUseOneSlice) { \
+    runRing<T, RedOp, \
+            ProtoSimple<ALLGATHER_CHUNKSTEPS / ALLGATHER_SLICESTEPS_SINGLE_NODE, ALLGATHER_SLICESTEPS_SINGLE_NODE>, \
+            false>(tid, nthreads, work); \
+  } else { \
+    runRing<T, RedOp, ProtoSimple<ALLGATHER_CHUNKSTEPS / ALLGATHER_SLICESTEPS, ALLGATHER_SLICESTEPS>, false>( \
+      tid, nthreads, work); \
   }
 #elif defined(__gfx950__)
 #define rcclAllGatherRunRingSimpleProtoImpl(tid, nthreads, work) \
-  if(work->rcclUseOneSlice){ \
-    runRing<T, RedOp, ProtoSimple<1,1>, false>(tid, nthreads, work); \
-  } else{ \
-    runRing<T, RedOp, ProtoSimple<ALLGATHER_CHUNKSTEPS/ALLGATHER_SLICESTEPS, ALLGATHER_SLICESTEPS>, false>(tid, nthreads, work); \
+  if (work->rcclUseOneSlice) { \
+    runRing<T, RedOp, ProtoSimple<1, 1>, false>(tid, nthreads, work); \
+  } else { \
+    runRing<T, RedOp, ProtoSimple<ALLGATHER_CHUNKSTEPS / ALLGATHER_SLICESTEPS, ALLGATHER_SLICESTEPS>, false>( \
+      tid, nthreads, work); \
   }
 #else
 #define rcclAllGatherRunRingSimpleProtoImpl(tid, nthreads, work) \
-  runRing<T, RedOp, ProtoSimple<ALLGATHER_CHUNKSTEPS/ALLGATHER_SLICESTEPS, ALLGATHER_SLICESTEPS>, false>(tid, nthreads, work);
+  runRing<T, RedOp, ProtoSimple<ALLGATHER_CHUNKSTEPS / ALLGATHER_SLICESTEPS, ALLGATHER_SLICESTEPS>, false>( \
+    tid, nthreads, work);
 #endif
 
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPLE> {
   __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
@@ -131,57 +136,58 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
 #else
     bool isNetOffload = work->isOneRPN && work->netRegUsed;
 #endif
-    if (isNetOffload)
-      runRing<T, RedOp, ProtoSimple<1, 1>, true>(tid, nthreads, work);
-    else{
+    if (isNetOffload) runRing<T, RedOp, ProtoSimple<1, 1>, true>(tid, nthreads, work);
+    else {
       rcclAllGatherRunRingSimpleProtoImpl(tid, nthreads, work);
     }
   }
 };
 
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL> {
   __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
     runRing<T, RedOp, ProtoLL>(tid, nthreads, work);
   }
 };
 
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL128> {
   __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
     runRing<T, RedOp, ProtoLL128>(tid, nthreads, work);
   }
 };
 
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_PAT, NCCL_PROTO_SIMPLE> {
   __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
     using Proto = ProtoSimple<1, 1>;
     const int nranks = ncclShmem.comm.nRanks;
     const int rank = ncclShmem.comm.rank;
     size_t count, channelOffset, channelCount, chunkCount;
-    ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &count, &channelOffset, &channelCount, &chunkCount);
+    ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &count, &channelOffset, &channelCount,
+                    &chunkCount);
 
     static constexpr int nworkers = NCCL_PAT_NWORKERS;
     struct ncclPatShmem* shmem = (struct ncclPatShmem*)ncclScratchForWarp(0);
     uint64_t pollCount = 0;
     (void)pollCount; // unused variable - compiler warning
     __syncthreads(); // Don't start using shared mem until everyone arrives
-    for (int i=tid; i<NCCL_SHMEM_PAT_STEPS; i+=nthreads) shmem->patSteps[i].flags = 0;
+    for (int i = tid; i < NCCL_SHMEM_PAT_STEPS; i += nthreads) shmem->patSteps[i].flags = 0;
     if (tid == 0) shmem->localAccSize = 0;
     if (tid == nworkers) shmem->parallelFactor = 0;
     __syncthreads();
 
     if (tid == nworkers) { // Algo computation thread
-      PatAGAlgorithm<T> patAlgo(chunkCount*sizeof(T), NCCL_STEPS, NCCL_PAT_NWORKERS/WARP_SIZE, channelOffset, channelOffset + channelCount, count, chunkCount, rank, nranks);
+      PatAGAlgorithm<T> patAlgo(chunkCount * sizeof(T), NCCL_STEPS, NCCL_PAT_NWORKERS / WARP_SIZE, channelOffset,
+                                channelOffset + channelCount, count, chunkCount, rank, nranks);
       int parallelFactor = shmem->parallelFactor = patAlgo.getParallelFactor();
       (void)parallelFactor;// unused variable - compiler warning
       int step = 0;
       while (1) {
-        struct ncclPatStep* ps = shmem->patSteps+(step%NCCL_SHMEM_PAT_STEPS);
+        struct ncclPatStep* ps = shmem->patSteps + (step % NCCL_SHMEM_PAT_STEPS);
         int* poll = &ps->flags;
         while (__hip_atomic_load(poll, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_WORKGROUP) != 0) {
-          pollCount++ ;// Wait for workers to be done with step 'step-NCCL_SHMEM_PAT_STEPS'
+          pollCount++;// Wait for workers to be done with step 'step-NCCL_SHMEM_PAT_STEPS'
         }
         patAlgo.getNextOp(ps);
         int last = ps->last;
@@ -189,30 +195,34 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_PAT, NCCL_PROTO_SIMPLE
         if (last == 2) break;
       }
     } else if (tid < nworkers) { // Worker threads
-      T *inputBuf = (T*)work->sendbuff;
-      T *outputBuf = (T*)work->recvbuff;
+      T* inputBuf = (T*)work->sendbuff;
+      T* outputBuf = (T*)work->recvbuff;
       int parallelFactor = 0;
       volatile int* pfPtr = &shmem->parallelFactor;
       while (parallelFactor == 0) parallelFactor = *pfPtr;
 
-      int groupSize = nworkers/(WARP_SIZE*parallelFactor) * WARP_SIZE;
+      int groupSize = nworkers / (WARP_SIZE * parallelFactor) * WARP_SIZE;
       int group = tid / groupSize;
       int nGroups = nworkers / groupSize;
-      int tidInGroup = tid - group*groupSize;
+      int tidInGroup = tid - group * groupSize;
       // We don't use recvPeers/sendPeers so let's pass shmem structs instead
-      Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0> prims
-        (tidInGroup, groupSize, (int*)shmem->recvDims, (int*)shmem->sendDims, inputBuf, outputBuf, work->redOpArg, group, 0, 0, nullptr, nullptr, 0, primsModePatAg);
+      Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0> prims(tidInGroup, groupSize, (int*)shmem->recvDims,
+                                                                          (int*)shmem->sendDims, inputBuf, outputBuf,
+                                                                          work->redOpArg, group, 0, 0, nullptr, nullptr,
+                                                                          0, primsModePatAg);
 
       int step = group;
-      while(1) {
-        struct ncclPatStep* ps = shmem->patSteps+(step%NCCL_SHMEM_PAT_STEPS);
+      while (1) {
+        struct ncclPatStep* ps = shmem->patSteps + (step % NCCL_SHMEM_PAT_STEPS);
         int* poll = &ps->flags;
-        while (__hip_atomic_load(poll, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_WORKGROUP) == 0){
+        while (__hip_atomic_load(poll, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_WORKGROUP) == 0) {
           pollCount++; // Wait for compute thread
         }
         int last = ps->last;
         prims.patCopy(ps, shmem);
-        if (tidInGroup == 0) __hip_atomic_store(poll, 0, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_WORKGROUP); // Return element to compute thread
+        if (tidInGroup == 0)
+          __hip_atomic_store(poll, 0, __ATOMIC_RELEASE,
+                             __HIP_MEMORY_SCOPE_WORKGROUP); // Return element to compute thread
         if (last) break;
         step += nGroups;
       }
@@ -220,21 +230,20 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_PAT, NCCL_PROTO_SIMPLE
   }
 };
 
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPLE> {
-  template<bool BcastSendNotRecv>
+  template <bool BcastSendNotRecv>
   struct Scatterer {
     struct ncclDevWorkColl* work;
     ssize_t chunkSize;
     ssize_t railGridOffset;
 
-    template<int SlicePerChunk, int MinSrcs, int MaxSrcs, int MinDsts, int MaxDsts, int MultimemSrcs, int MultimemDsts>
-    __device__ __forceinline__ void operator()(
-        int tid, int tn, int slice, int maxSliceSize,
-        int nSrcs, void** srcPtrs, int nDsts, void** dstPtrs, int32_t* dstSizes, uint32_t sendDirectFlag, uint32_t recvDirectFlag
-      ) {
-      static_assert(SlicePerChunk==1, "require: SlicePerChunk==1");
-      static_assert(MaxDsts<=1 || MaxSrcs<=1, "require: MaxDsts<=1 || MaxSrcs<=1");
+    template <int SlicePerChunk, int MinSrcs, int MaxSrcs, int MinDsts, int MaxDsts, int MultimemSrcs, int MultimemDsts>
+    __device__ __forceinline__ void operator()(int tid, int tn, int slice, int maxSliceSize, int nSrcs, void** srcPtrs,
+                                               int nDsts, void** dstPtrs, int32_t* dstSizes, uint32_t sendDirectFlag,
+                                               uint32_t recvDirectFlag) {
+      static_assert(SlicePerChunk == 1, "require: SlicePerChunk==1");
+      static_assert(MaxDsts <= 1 || MaxSrcs <= 1, "require: MaxDsts<=1 || MaxSrcs<=1");
 
       struct ncclNvls* nvls = &ncclShmem.channel.nvls;
       int nNodes = ncclShmem.comm.nNodes;
@@ -270,18 +279,18 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
           int outIsDst = (inPlace && rank == ncclShmem.comm.rank) || BcastSendNotRecv || work->regUsed ? 0 : 1;
           if (nSrcs != 0 && outIsDst + nDsts != 0) {
             reduceCopy<ncclCollUnroll(), USE_ACC, RedOp, T,
-              /*MultimemSrcs,MinSrcs,MaxSrcs=*/MultimemSrcs, 1, 1,
-              /*MultimemDsts=*/MultimemDsts, 0 + MultimemDsts + MinDsts, 1 + MaxDsts,
-              /*PreOpSrcs=*/0>
-              (tid, tn, 0, false,
-                /*nSrcs=*/1, [=]__device__(int s/*==0*/) -> void* {
-              return (char*)srcPtrs[src] + railAllOffset;
-            },
-                /*nDsts=*/outIsDst + nDsts, [=]__device__(int d) -> void* {
-              return d < outIsDst ? outbuf + userOneBeg
-                : work->regUsed ? (char*)dstPtrs[d - outIsDst] + userOneBeg
-                : (char*)dstPtrs[d - outIsDst] + railAllOffset;
-            }, delta);
+                       /*MultimemSrcs,MinSrcs,MaxSrcs=*/MultimemSrcs, 1, 1,
+                       /*MultimemDsts=*/MultimemDsts, 0 + MultimemDsts + MinDsts, 1 + MaxDsts,
+                       /*PreOpSrcs=*/0>(
+              tid, tn, 0, false,
+              /*nSrcs=*/1, [=] __device__(int s /*==0*/) -> void* { return (char*)srcPtrs[src] + railAllOffset; },
+              /*nDsts=*/outIsDst + nDsts,
+              [=] __device__(int d) -> void* {
+                return d < outIsDst  ? outbuf + userOneBeg :
+                       work->regUsed ? (char*)dstPtrs[d - outIsDst] + userOneBeg :
+                                       (char*)dstPtrs[d - outIsDst] + railAllOffset;
+              },
+              delta);
           }
           railAllOffset += delta;
           node += 1;
@@ -292,11 +301,11 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
     }
   };
 
-  __device__ __forceinline__ void run(int tid, int/*nthreads*/, struct ncclDevWorkColl* work) {
+  __device__ __forceinline__ void run(int tid, int /*nthreads*/, struct ncclDevWorkColl* work) {
     struct ncclNvls* nvls = &ncclShmem.channel.nvls;
     int nelem;
 
-    const int nThreadsNetSend = work->oneNode ? 0 : (work->netRegUsed ? WARP_SIZE :  6 * WARP_SIZE);
+    const int nThreadsNetSend = work->oneNode ? 0 : (work->netRegUsed ? WARP_SIZE : 6 * WARP_SIZE);
     const int nThreadsGather = work->regUsed ? roundUp(nvls->nHeads << 2, WARP_SIZE) : 8 * WARP_SIZE;
     const int nThreadsBcast = NCCL_MAX_NTHREADS - nThreadsNetSend - nThreadsGather;
 
@@ -307,14 +316,14 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
     if (work->oneNode) {
       const ssize_t rank = ncclShmem.comm.rank;
       size_t count, gridOffset, channelCount, offset, chunkCount;
-      ncclCollCbdPart(work, ncclShmem.channelId, NCCL_PROTO_SIMPLE, sizeof(T), &count, &gridOffset, &channelCount, &chunkCount);
+      ncclCollCbdPart(work, ncclShmem.channelId, NCCL_PROTO_SIMPLE, sizeof(T), &count, &gridOffset, &channelCount,
+                      &chunkCount);
       if (!work->regUsed) {
         if (tid < tidEndGather) {
           // Gather
           using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL>;
-          Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_NVLS_ARITY, 0>, /*Direct=*/1, Proto, 0>
-            prims(tid, nThreadsGather, nvls->up, NULL, NULL, work->recvbuff,
-              work->redOpArg, 0 * Proto::MaxGroupWidth, 1, 1);
+          Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_NVLS_ARITY, 0>, /*Direct=*/1, Proto, 0> prims(
+            tid, nThreadsGather, nvls->up, NULL, NULL, work->recvbuff, work->redOpArg, 0 * Proto::MaxGroupWidth, 1, 1);
           for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
             offset = gridOffset + elemOffset;
             nelem = min(chunkCount, channelCount - elemOffset);
@@ -324,9 +333,10 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
         } else if (tid < tidEndBcast) {
           // Bcast through NVLS
           using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL, 0, 1>;
-          Primitives<T, RedOp, FanAsymmetric<0, 1>, /*Direct=*/0, Proto, 0>
-            prims(tid - tidEndGather, nThreadsBcast, NULL, &nvls->down, work->sendbuff, NULL,
-              work->redOpArg, 3 * Proto::MaxGroupWidth, 0, 0);
+          Primitives<T, RedOp, FanAsymmetric<0, 1>, /*Direct=*/0, Proto, 0> prims(tid - tidEndGather, nThreadsBcast,
+                                                                                  NULL, &nvls->down, work->sendbuff,
+                                                                                  NULL, work->redOpArg,
+                                                                                  3 * Proto::MaxGroupWidth, 0, 0);
           for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
             offset = gridOffset + elemOffset;
             nelem = min(chunkCount, channelCount - elemOffset);
@@ -337,9 +347,8 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
       } else {
         if (tid < tidEndGather) {
           using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL>;
-          Primitives<T, RedOp, FanSymmetric<NCCL_MAX_NVLS_ARITY>, /*Direct=*/0, Proto, 0>
-            prims(tid, nThreadsGather, nvls->up, nvls->up, NULL, NULL,
-              work->redOpArg, 0 * Proto::MaxGroupWidth, 1, 1);
+          Primitives<T, RedOp, FanSymmetric<NCCL_MAX_NVLS_ARITY>, /*Direct=*/0, Proto, 0> prims(
+            tid, nThreadsGather, nvls->up, nvls->up, NULL, NULL, work->redOpArg, 0 * Proto::MaxGroupWidth, 1, 1);
 
           /* used as sync */
           prims.scatter(0, 0, 0, 0, -1, 0);
@@ -349,9 +358,10 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
           }
         } else if (tid < tidEndBcast) {
           using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL, 0, 1>;
-          Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0>
-            prims(tid - tidEndGather, nThreadsBcast, &nvls->down, &nvls->down, work->sendbuff, NULL,
-              work->redOpArg, 1 * Proto::MaxGroupWidth, 0, 0, work);
+          Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0> prims(tid - tidEndGather, nThreadsBcast,
+                                                                              &nvls->down, &nvls->down, work->sendbuff,
+                                                                              NULL, work->redOpArg,
+                                                                              1 * Proto::MaxGroupWidth, 0, 0, work);
           /* used as sync */
           prims.recv(0, 0);
 
@@ -372,10 +382,11 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
       ssize_t chunkCount = work->collnet.chunkCount;
       if (tid < tidEndGather) {
         using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL>;
-        Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_NVLS_ARITY, 0>, /*Direct=*/1, Proto, 0>
-          prims(tid, nThreadsGather, nvls->up, nullptr, nullptr, work->recvbuff,
-            /*redOpArg=*/0, 1 * Proto::MaxGroupWidth, 1, 1, work);
-        for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank; railGridOffset += nChannels * chunkCount) {
+        Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_NVLS_ARITY, 0>, /*Direct=*/1, Proto, 0> prims(
+          tid, nThreadsGather, nvls->up, nullptr, nullptr, work->recvbuff,
+          /*redOpArg=*/0, 1 * Proto::MaxGroupWidth, 1, 1, work);
+        for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank;
+             railGridOffset += nChannels * chunkCount) {
           Scatterer</*BcastSendNotRecv=*/false> scat;
           scat.work = work;
           scat.chunkSize = chunkCount;
@@ -393,12 +404,14 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
           // first unroll 2 steps, then unroll the rest steps when the data is received.
           if (postThread) {
             curSteps = min(2, maxSteps);
-            Primitives<T, RedOp, FanAsymmetric<0, 1>, /*Direct=*/1, ProtoSend, 0>::sendPeerNotify(nvls->out, 1, curSteps);
+            Primitives<T, RedOp, FanAsymmetric<0, 1>, /*Direct=*/1, ProtoSend, 0>::sendPeerNotify(nvls->out, 1,
+                                                                                                  curSteps);
           }
-          Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, ProtoBcast, 0>
-            prims(tid - tidEndGather, nThreadsNetSend + nThreadsBcast, &nvls->out, &nvls->down, nullptr, nullptr,
-              /*redOpArg=*/0, 2 * ProtoBcast::MaxGroupWidth, 0, 0, work);
-          for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank; railGridOffset += nChannels * chunkCount) {
+          Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, ProtoBcast, 0> prims(
+            tid - tidEndGather, nThreadsNetSend + nThreadsBcast, &nvls->out, &nvls->down, nullptr, nullptr,
+            /*redOpArg=*/0, 2 * ProtoBcast::MaxGroupWidth, 0, 0, work);
+          for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank;
+               railGridOffset += nChannels * chunkCount) {
             Scatterer</*BcastSendNotRecv=*/true> scat;
             scat.work = work;
             scat.chunkSize = chunkCount;
@@ -412,10 +425,11 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
         } else {
           if (tid < tidEndNetSend) {
             using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL>;
-            Primitives<T, RedOp, FanAsymmetric<0, 1>, /*Direct=*/0, Proto, 0>
-              prims(tid - tidEndGather, nThreadsNetSend, nullptr, &nvls->out, work->sendbuff, nullptr,
-                /*redOpArg=*/0, 0 * Proto::MaxGroupWidth, 1, 1);
-            for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank; railGridOffset += nChannels * chunkCount) {
+            Primitives<T, RedOp, FanAsymmetric<0, 1>, /*Direct=*/0, Proto, 0> prims(
+              tid - tidEndGather, nThreadsNetSend, nullptr, &nvls->out, work->sendbuff, nullptr,
+              /*redOpArg=*/0, 0 * Proto::MaxGroupWidth, 1, 1);
+            for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank;
+                 railGridOffset += nChannels * chunkCount) {
               ssize_t railAllBeg = railGridOffset + part * chunkCount;
               ssize_t railAllEnd = min(railAllBeg + chunkCount, nNodes * countPerRank);
               ssize_t railOneBeg = ncclShmem.comm.node * countPerRank;
@@ -426,10 +440,11 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
             }
           } else {
             using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL, 0, 1>;
-            Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/0, Proto, 0>
-              prims(tid - tidEndNetSend, nThreadsBcast, &nvls->out, &nvls->down, nullptr, nullptr,
-                /*redOpArg=*/0, 2 * Proto::MaxGroupWidth, 0, 0);
-            for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank; railGridOffset += nChannels * chunkCount) {
+            Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/0, Proto, 0> prims(
+              tid - tidEndNetSend, nThreadsBcast, &nvls->out, &nvls->down, nullptr, nullptr,
+              /*redOpArg=*/0, 2 * Proto::MaxGroupWidth, 0, 0);
+            for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank;
+                 railGridOffset += nChannels * chunkCount) {
               Scatterer</*BcastSendNotRecv=*/true> scat;
               scat.work = work;
               scat.chunkSize = chunkCount;
@@ -443,21 +458,20 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
   }
 };
 
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_PROTO_SIMPLE> {
-  template<bool BcastSendNotRecv>
+  template <bool BcastSendNotRecv>
   struct Scatterer {
     struct ncclDevWorkColl* work;
     ssize_t chunkSize;
     ssize_t railGridOffset;
 
-    template<int SlicePerChunk, int MinSrcs, int MaxSrcs, int MinDsts, int MaxDsts, int MultimemSrcs, int MultimemDsts>
-    __device__ __forceinline__ void operator()(
-        int tid, int tn, int slice, int maxSliceSize,
-        int nSrcs, void** srcPtrs, int nDsts, void** dstPtrs, int32_t* dstSizes, uint32_t sendDirectFlag, uint32_t recvDirectFlag
-      ) {
-      static_assert(SlicePerChunk==1, "require: SlicePerChunk==1");
-      static_assert(MaxDsts<=1 || MaxSrcs<=1, "require: MaxDsts<=1 || MaxSrcs<=1");
+    template <int SlicePerChunk, int MinSrcs, int MaxSrcs, int MinDsts, int MaxDsts, int MultimemSrcs, int MultimemDsts>
+    __device__ __forceinline__ void operator()(int tid, int tn, int slice, int maxSliceSize, int nSrcs, void** srcPtrs,
+                                               int nDsts, void** dstPtrs, int32_t* dstSizes, uint32_t sendDirectFlag,
+                                               uint32_t recvDirectFlag) {
+      static_assert(SlicePerChunk == 1, "require: SlicePerChunk==1");
+      static_assert(MaxDsts <= 1 || MaxSrcs <= 1, "require: MaxDsts<=1 || MaxSrcs<=1");
 
       struct ncclDirect* direct = &ncclShmem.channel.collnetDirect;
       int nNodes = ncclShmem.comm.nNodes;
@@ -465,11 +479,11 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_P
       int part = ncclShmem.channelId - work->channelLo;
       char* inbuf = (char*)work->sendbuff;
       char* outbuf = (char*)work->recvbuff;
-      ssize_t countPerRank = work->collnet.count*sizeof(T);
-      bool inPlace = (inbuf == outbuf + ncclShmem.comm.rank*countPerRank);
+      ssize_t countPerRank = work->collnet.count * sizeof(T);
+      bool inPlace = (inbuf == outbuf + ncclShmem.comm.rank * countPerRank);
 
-      ssize_t railAllBeg = min(railGridOffset + part*chunkSize, nNodes*countPerRank);
-      ssize_t railAllEnd = min(railAllBeg + chunkSize, nNodes*countPerRank);
+      ssize_t railAllBeg = min(railGridOffset + part * chunkSize, nNodes * countPerRank);
+      ssize_t railAllEnd = min(railAllBeg + chunkSize, nNodes * countPerRank);
       int railAllSize = railAllEnd - railAllBeg;
       if (tid < nDsts) dstSizes[tid] = railAllSize;
 
@@ -478,35 +492,39 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_P
       if (BcastSendNotRecv) {
         rail = direct->headRank;
       } else {
-        rail = direct->headRank+1;
+        rail = direct->headRank + 1;
         if (rail == nRails) rail = 0;
       }
       do {
-        int node = railAllBeg/countPerRank;
+        int node = railAllBeg / countPerRank;
         int railAllOffset = 0;
         while (railAllOffset < railAllSize) {
-          ssize_t railOneBeg = node*countPerRank;
+          ssize_t railOneBeg = node * countPerRank;
           ssize_t railOneEnd = railOneBeg + countPerRank;
-          ssize_t railOneOffset = (railAllBeg+railAllOffset) - railOneBeg;
-          int delta = min(railAllEnd, railOneEnd) - (railAllBeg+railAllOffset);
-          int rank = ncclShmem.comm.collNetDenseToUserRank[node*nRails + rail];
-          ssize_t userOneBeg = rank*countPerRank + railOneOffset;
+          ssize_t railOneOffset = (railAllBeg + railAllOffset) - railOneBeg;
+          int delta = min(railAllEnd, railOneEnd) - (railAllBeg + railAllOffset);
+          int rank = ncclShmem.comm.collNetDenseToUserRank[node * nRails + rail];
+          ssize_t userOneBeg = rank * countPerRank + railOneOffset;
           int outIsDst = (inPlace && rank == ncclShmem.comm.rank) ? 0 : 1;
-          if (nSrcs != 0 && outIsDst+nDsts != 0) {
+          if (nSrcs != 0 && outIsDst + nDsts != 0) {
             reduceCopy<ncclCollUnroll(), USE_ACC, RedOp, T,
-                    /*MultimemSrcs,MinSrcs,MaxSrcs=*/0,1,1,
-                    /*MultimemDsts=*/0, 0+MinDsts, 1+MaxDsts,
-                    /*PreOpSrcs=*/0>
-            (tid, tn, 0, false,
-             /*nSrcs=*/1, [=]__device__(int s/*==0*/) -> void* {
-               return work->regUsed && (recvDirectFlag & NCCL_P2P_READ) ? (char*)srcPtrs[src] + userOneBeg : (char*)srcPtrs[src] + railAllOffset;
-             },
-             /*nDsts=*/outIsDst+nDsts, [=]__device__(int d) -> void* {
-               return d < outIsDst ? outbuf + userOneBeg
-                                   : work->regUsed && (sendDirectFlag & NCCL_P2P_WRITE) ? (char*)dstPtrs[d-outIsDst] + userOneBeg
-                                   : (char*)dstPtrs[d-outIsDst] + railAllOffset;
-             },
-             delta);
+                       /*MultimemSrcs,MinSrcs,MaxSrcs=*/0, 1, 1,
+                       /*MultimemDsts=*/0, 0 + MinDsts, 1 + MaxDsts,
+                       /*PreOpSrcs=*/0>(
+              tid, tn, 0, false,
+              /*nSrcs=*/1,
+              [=] __device__(int s /*==0*/) -> void* {
+                return work->regUsed && (recvDirectFlag & NCCL_P2P_READ) ? (char*)srcPtrs[src] + userOneBeg :
+                                                                           (char*)srcPtrs[src] + railAllOffset;
+              },
+              /*nDsts=*/outIsDst + nDsts,
+              [=] __device__(int d) -> void* {
+                return d < outIsDst ? outbuf + userOneBeg :
+                       work->regUsed && (sendDirectFlag & NCCL_P2P_WRITE) ?
+                                      (char*)dstPtrs[d - outIsDst] + userOneBeg :
+                                      (char*)dstPtrs[d - outIsDst] + railAllOffset;
+              },
+              delta);
           }
           railAllOffset += delta;
           node += 1;
@@ -514,15 +532,15 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_P
         src += 1;
         rail += 1;
         if (rail == nRails) rail = 0;
-      } while (!BcastSendNotRecv && src < nRails-1);
+      } while (!BcastSendNotRecv && src < nRails - 1);
     }
   };
 
-  __device__ __forceinline__ void run(int tid, int/*nthreads*/, struct ncclDevWorkColl* work) {
+  __device__ __forceinline__ void run(int tid, int /*nthreads*/, struct ncclDevWorkColl* work) {
     const int part = ncclShmem.channelId - work->channelLo;
     const int nChannels = work->channelHi - work->channelLo + 1;
     struct ncclDirect* direct = &ncclShmem.channel.collnetDirect;
-    int const &nNodes = ncclShmem.comm.nNodes;
+    int const& nNodes = ncclShmem.comm.nNodes;
     ssize_t countPerRank = work->collnet.count;
     size_t chunkSize = work->collnet.chunkCount;
     const int hasDn = (direct->down[0] >= 0) ? 1 : 0;
@@ -530,14 +548,14 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_P
     int nWarps1 = 1;
     int nWarps2 = (isMultiRail ? 2 : 1);
     int nWarps3 = (isMultiRail ? 2 : 0);
-    float denom = float(work->nWarps)/float(nWarps1+nWarps2+nWarps3);
-    nWarps3 = int(denom*nWarps3);
-    nWarps2 = int(denom*nWarps2);
-    nWarps1 = work->nWarps - (nWarps2+nWarps3);
+    float denom = float(work->nWarps) / float(nWarps1 + nWarps2 + nWarps3);
+    nWarps3 = int(denom * nWarps3);
+    nWarps2 = int(denom * nWarps2);
+    nWarps1 = work->nWarps - (nWarps2 + nWarps3);
 
     using Proto = ProtoSimple<1, 1>;
 
-    int tn = nWarps1*WARP_SIZE;
+    int tn = nWarps1 * WARP_SIZE;
     if (tid < tn) {
       if (work->netRegUsed) {
         if (tid == 0) {
@@ -550,10 +568,12 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_P
         __syncwarp();
       } else {
         // Phase 1: send to network
-        Primitives<T, RedOp, FanAsymmetric<0, 1>, /*Direct=*/0, Proto, 0>
-          prims(tid, tn, nullptr, &direct->out, work->sendbuff, nullptr,
-            /*redOpArg=*/0, 0 * Proto::MaxGroupWidth, 1, 1);
-        for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank; railGridOffset += nChannels * chunkSize) {
+        Primitives<T, RedOp, FanAsymmetric<0, 1>, /*Direct=*/0, Proto, 0> prims(tid, tn, nullptr, &direct->out,
+                                                                                work->sendbuff, nullptr,
+                                                                                /*redOpArg=*/0,
+                                                                                0 * Proto::MaxGroupWidth, 1, 1);
+        for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank;
+             railGridOffset += nChannels * chunkSize) {
           ssize_t railAllBeg = railGridOffset + part * chunkSize;
           ssize_t railAllEnd = min(railAllBeg + chunkSize, nNodes * countPerRank);
           ssize_t railOneBeg = ncclShmem.comm.node * countPerRank;
@@ -567,19 +587,21 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_P
     }
     tid -= tn;
 
-    tn = nWarps2*WARP_SIZE;
+    tn = nWarps2 * WARP_SIZE;
     if (tid < tn) {
       if (work->netRegUsed && !hasDn) {
         if (tid == 0) {
-          Primitives<T, RedOp, FanAsymmetric<1, NCCL_MAX_DIRECT_ARITY>, /*Direct=*/0, Proto, 0>::recvPeerNotify(direct->out, 0, 1);
+          Primitives<T, RedOp, FanAsymmetric<1, NCCL_MAX_DIRECT_ARITY>, /*Direct=*/0, Proto, 0>::recvPeerNotify(
+            direct->out, 0, 1);
         }
         __syncwarp();
       } else {
         // Phase 2: Recv network -> deposit output + send to bcast
-        Primitives<T, RedOp, FanAsymmetric<1, NCCL_MAX_DIRECT_ARITY>, /*Direct=*/1, Proto, 0>
-          prims(tid, tn, &direct->out, direct->heads + 1, nullptr, work->recvbuff,
-            /*redOpArg=*/0, 1 * Proto::MaxGroupWidth, 0, 0, work);
-        for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank; railGridOffset += nChannels * chunkSize) {
+        Primitives<T, RedOp, FanAsymmetric<1, NCCL_MAX_DIRECT_ARITY>, /*Direct=*/1, Proto, 0> prims(
+          tid, tn, &direct->out, direct->heads + 1, nullptr, work->recvbuff,
+          /*redOpArg=*/0, 1 * Proto::MaxGroupWidth, 0, 0, work);
+        for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank;
+             railGridOffset += nChannels * chunkSize) {
           Scatterer</*BcastSendNotRecv=*/true> scat;
           scat.work = work;
           scat.chunkSize = chunkSize;
@@ -591,13 +613,14 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_P
     }
     tid -= tn;
 
-    tn = nWarps3*WARP_SIZE;
+    tn = nWarps3 * WARP_SIZE;
     if (tid < tn) {
       // Phase 3: Recv bcast -> deposit output
-      Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_DIRECT_ARITY, 0>, /*Direct=*/1, Proto, 0>
-        prims(tid, tn, direct->heads+1, nullptr, nullptr, work->recvbuff,
-              /*redOpArg=*/0, 2*Proto::MaxGroupWidth, 0, 0, work);
-      for (ssize_t railGridOffset=0; railGridOffset < nNodes*countPerRank; railGridOffset += nChannels*chunkSize) {
+      Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_DIRECT_ARITY, 0>, /*Direct=*/1, Proto, 0> prims(
+        tid, tn, direct->heads + 1, nullptr, nullptr, work->recvbuff,
+        /*redOpArg=*/0, 2 * Proto::MaxGroupWidth, 0, 0, work);
+      for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank;
+           railGridOffset += nChannels * chunkSize) {
         Scatterer</*BcastSendNotRecv=*/false> scat;
         scat.work = work;
         scat.chunkSize = chunkSize;

--- a/projects/rccl/src/device/all_gather_v.h
+++ b/projects/rccl/src/device/all_gather_v.h
@@ -11,28 +11,29 @@
 #include <stdio.h>
 
 namespace {
-  template<typename T, typename RedOp, typename Proto>
-  __device__ __forceinline__ void setDataPtrsHelper(Primitives<T, RedOp, FanSymmetric<1>, 0, Proto, 0, 0>& prims,
-                                                    void const* srcBuf, void* dstBuf, uint64_t redOpArg) {
-    prims.setDataPtrs(srcBuf, dstBuf);
-  }
-
-  template<typename T, typename RedOp>
-  __device__ __forceinline__ void setDataPtrsHelper(Primitives<T, RedOp, FanSymmetric<1>, 0, ProtoSimple<1,1>, 0, 0>& prims,
-                                                    void const* srcBuf, void* dstBuf, uint64_t redOpArg) {
-    prims.setDataPtrs(srcBuf, dstBuf, redOpArg, nullptr, 0, 0);
-  }
+template <typename T, typename RedOp, typename Proto>
+__device__ __forceinline__ void setDataPtrsHelper(Primitives<T, RedOp, FanSymmetric<1>, 0, Proto, 0, 0>& prims,
+                                                  void const* srcBuf, void* dstBuf, uint64_t redOpArg) {
+  prims.setDataPtrs(srcBuf, dstBuf);
 }
 
-template<typename T, typename RedOp, typename Proto>
+template <typename T, typename RedOp>
+__device__ __forceinline__ void setDataPtrsHelper(
+  Primitives<T, RedOp, FanSymmetric<1>, 0, ProtoSimple<1, 1>, 0, 0>& prims, void const* srcBuf, void* dstBuf,
+  uint64_t redOpArg) {
+  prims.setDataPtrs(srcBuf, dstBuf, redOpArg, nullptr, 0, 0);
+}
+} // namespace
+
+template <typename T, typename RedOp, typename Proto>
 __device__ __forceinline__ void runAllGatherV() {
   int tid = threadIdx.x;
   int tn = blockDim.x;
   ncclRing* ring = &ncclShmem.channel.ring;
 
-  ncclDevWorkBcast *works = (ncclDevWorkBcast*)ncclShmem.workStorage;
-  Primitives<int8_t, FuncSum<int8_t>, FanSymmetric<1>, /*Direct=*/0, Proto, 0>
-    prims(tid, tn, &ring->prev, &ring->next, nullptr, nullptr, /*redOpArg=*/0);
+  ncclDevWorkBcast* works = (ncclDevWorkBcast*)ncclShmem.workStorage;
+  Primitives<int8_t, FuncSum<int8_t>, FanSymmetric<1>, /*Direct=*/0, Proto, 0> prims(tid, tn, &ring->prev, &ring->next,
+                                                                                     nullptr, nullptr, /*redOpArg=*/0);
   int w = 0;
 
   while (true) {
@@ -40,15 +41,15 @@ __device__ __forceinline__ void runAllGatherV() {
     int nRanks = ncclShmem.comm.nRanks;
     size_t bytes = works[w].bytes;
     int ringDepth = works[w].ringDepth;
-    void* srcBuf = ringDepth==0 ? works[w].sendbuff : nullptr;
+    void* srcBuf = ringDepth == 0 ? works[w].sendbuff : nullptr;
     void* dstBuf = works[w].recvbuff;
     bool inPlace = srcBuf == dstBuf;
-	  size_t offset = works[w].bytes_done;
-    setDataPtrsHelper(prims, (void const*)srcBuf, (void *)dstBuf, 0);
+    size_t offset = works[w].bytes_done;
+    setDataPtrsHelper(prims, (void const*)srcBuf, (void*)dstBuf, 0);
 
     __syncthreads();
 
-    int wNext = (w+1 == nWorks) ? 0 : w+1;
+    int wNext = (w + 1 == nWorks) ? 0 : w + 1;
 
     size_t chunkBytes = (size_t)works[w].chunkSize;
     size_t delta = min(bytes, chunkBytes);
@@ -60,7 +61,7 @@ __device__ __forceinline__ void runAllGatherV() {
         } else {
           prims.copySend(offset, offset, delta);
         }
-      } else if (ringDepth == nRanks-1) {
+      } else if (ringDepth == nRanks - 1) {
         prims.recv(offset, delta);
       } else {
         prims.recvCopySend(offset, delta);
@@ -87,20 +88,20 @@ __device__ __forceinline__ void runAllGatherV() {
 }
 
 // Specialized for broadcast
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkBatch<ncclFuncAllGatherV, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPLE> {
   __device__ __forceinline__ void run() {
-    using Proto = ProtoSimple<1,1>;
+    using Proto = ProtoSimple<1, 1>;
     runAllGatherV<T, RedOp, Proto>();
   }
 };
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkBatch<ncclFuncAllGatherV, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL> {
   __device__ __forceinline__ void run() {
     runAllGatherV<T, RedOp, ProtoLL>();
   }
 };
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkBatch<ncclFuncAllGatherV, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL128> {
   __device__ __forceinline__ void run() {
     runAllGatherV<T, RedOp, ProtoLL128>();

--- a/projects/rccl/src/device/all_reduce.h
+++ b/projects/rccl/src/device/all_reduce.h
@@ -10,304 +10,288 @@
 #include "primitives.h"
 
 namespace {
-  template<typename T, typename RedOp, typename Proto, int RCCLMetadata>
+template <typename T, typename RedOp, typename Proto, int RCCLMetadata>
 #if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
-  __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
+__device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
 #else
-  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
+__device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
 #endif
 #ifdef ENABLE_WARP_SPEED
-    int warp = threadIdx.x / WARP_SIZE;
-    ncclRing *ring = ncclShmem.warpComm
-        ? &ncclShmem.warpChannel[warp].ring
-        : &ncclShmem.channel.ring;
+  int warp = threadIdx.x / WARP_SIZE;
+  ncclRing* ring = ncclShmem.warpComm ? &ncclShmem.warpChannel[warp].ring : &ncclShmem.channel.ring;
 #else
-    ncclRing *ring = &ncclShmem.channel.ring;
+  ncclRing* ring = &ncclShmem.channel.ring;
 #endif
-    int ringIx = ring->index;
+  int ringIx = ring->index;
 
-    const int nranks = ncclShmem.comm.nRanks;
-    ssize_t size;
-    ssize_t gridOffset;
-    ssize_t channelCount;
-    ssize_t chunkCount;
+  const int nranks = ncclShmem.comm.nRanks;
+  ssize_t size;
+  ssize_t gridOffset;
+  ssize_t channelCount;
+  ssize_t chunkCount;
 #ifdef ENABLE_WARP_SPEED
-    ncclCollCbdPart(work, ncclShmem.warpChannelId[warp], Proto::Id, sizeof(T), &size, &gridOffset, &channelCount, &chunkCount);
+  ncclCollCbdPart(work, ncclShmem.warpChannelId[warp], Proto::Id, sizeof(T), &size, &gridOffset, &channelCount,
+                  &chunkCount);
 #else
-    ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &size, &gridOffset, &channelCount, &chunkCount);
+  ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &size, &gridOffset, &channelCount, &chunkCount);
 #endif
-    const ssize_t loopCount = nranks * chunkCount;
-    ssize_t offset;
-    int nelem;
-    int chunk;
+  const ssize_t loopCount = nranks * chunkCount;
+  ssize_t offset;
+  int nelem;
+  int chunk;
 
     // Coverity reports that the callee treats &ring->next as an array.  However, due to the use of
     // FanSymmetric<1>, only the first element is ever accessed, so it's fine.
     // coverity[callee_ptr_arith:FALSE]
-    Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0, false, RCCLMetadata, Pipeline, USE_ACC> prims
-      (tid, nthreads, &ring->prev, &ring->next, work->sendbuff, work->recvbuff, work->redOpArg, 0, work->connIndex, work->connIndex, work);
+  Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0, false, RCCLMetadata, Pipeline, USE_ACC> prims(
+    tid, nthreads, &ring->prev, &ring->next, work->sendbuff, work->recvbuff, work->redOpArg, 0, work->connIndex,
+    work->connIndex, work);
 
-    for (ssize_t elemOffset = 0; elemOffset < channelCount; elemOffset += loopCount) {
-      ssize_t remCount = channelCount - elemOffset;
-      ssize_t chunkOffset;
+  for (ssize_t elemOffset = 0; elemOffset < channelCount; elemOffset += loopCount) {
+    ssize_t remCount = channelCount - elemOffset;
+    ssize_t chunkOffset;
 
-      if (remCount < loopCount) chunkCount = alignUp(divUp(remCount, nranks), 16/sizeof(T));
+    if (remCount < loopCount) chunkCount = alignUp(divUp(remCount, nranks), 16 / sizeof(T));
 
-      auto modRanks = [&]__device__(int r)->int {
-        return r - (r >= nranks ? nranks : 0);
-      };
+    auto modRanks = [&] __device__(int r) -> int { return r - (r >= nranks ? nranks : 0); };
 
       // step 0: push data to next GPU
-      chunk = modRanks(ringIx + nranks - 1);
-      chunkOffset = chunk * chunkCount;
-      offset = gridOffset + elemOffset + chunkOffset;
-      nelem = (int)min(chunkCount, remCount - chunkOffset);
+    chunk = modRanks(ringIx + nranks - 1);
+    chunkOffset = chunk * chunkCount;
+    offset = gridOffset + elemOffset + chunkOffset;
+    nelem = (int)min(chunkCount, remCount - chunkOffset);
 
-      prims.directSend(offset, offset, nelem);
+    prims.directSend(offset, offset, nelem);
 
       // k-2 steps: reduce and copy to next GPU
 
-      for (int j = 2; j < nranks; ++j) {
-        chunk = modRanks(ringIx + nranks - j);
-        chunkOffset = chunk * chunkCount;
-        offset = gridOffset + elemOffset + chunkOffset;
-        nelem = (int)min(chunkCount, remCount - chunkOffset);
-        prims.directRecvReduceDirectSend(offset, offset, nelem);
-      }
+    for (int j = 2; j < nranks; ++j) {
+      chunk = modRanks(ringIx + nranks - j);
+      chunkOffset = chunk * chunkCount;
+      offset = gridOffset + elemOffset + chunkOffset;
+      nelem = (int)min(chunkCount, remCount - chunkOffset);
+      prims.directRecvReduceDirectSend(offset, offset, nelem);
+    }
 
       // step k-1: reduce this buffer and data, which will produce the final
       // result that we store in this data and push to the next GPU
-      chunk = ringIx + 0;
-      chunkOffset = chunk * chunkCount;
-      offset = gridOffset + elemOffset + chunkOffset;
-      nelem = (int)min(chunkCount, remCount - chunkOffset);
+    chunk = ringIx + 0;
+    chunkOffset = chunk * chunkCount;
+    offset = gridOffset + elemOffset + chunkOffset;
+    nelem = (int)min(chunkCount, remCount - chunkOffset);
 
-      prims.directRecvReduceCopyDirectSend(offset, offset, nelem, /*postOp=*/true);
+    prims.directRecvReduceCopyDirectSend(offset, offset, nelem, /*postOp=*/true);
 
       // k-2 steps: copy to next GPU
-      for (int j = 1; j < nranks - 1; ++j) {
-        chunk = modRanks(ringIx + nranks - j);
-        chunkOffset = chunk * chunkCount;
-        offset = gridOffset + elemOffset + chunkOffset;
-        nelem = (int)min(chunkCount, remCount - chunkOffset);
-        prims.directRecvCopyDirectSend(offset, offset, nelem);
-      }
-
-      // Make final copy from buffer to dest.
-      chunk = modRanks(ringIx + 1);
+    for (int j = 1; j < nranks - 1; ++j) {
+      chunk = modRanks(ringIx + nranks - j);
       chunkOffset = chunk * chunkCount;
       offset = gridOffset + elemOffset + chunkOffset;
       nelem = (int)min(chunkCount, remCount - chunkOffset);
-
-      prims.directRecv(offset, nelem);
-
+      prims.directRecvCopyDirectSend(offset, offset, nelem);
     }
 
+      // Make final copy from buffer to dest.
+    chunk = modRanks(ringIx + 1);
+    chunkOffset = chunk * chunkCount;
+    offset = gridOffset + elemOffset + chunkOffset;
+    nelem = (int)min(chunkCount, remCount - chunkOffset);
+
+    prims.directRecv(offset, nelem);
   }
+}
 
-  template<typename T, typename RedOp, typename Proto>
+template <typename T, typename RedOp, typename Proto>
 #if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
-  __device__ void runTreeUpDown(int tid, int nthreads, struct ncclDevWorkColl* work) {
+__device__ void runTreeUpDown(int tid, int nthreads, struct ncclDevWorkColl* work) {
 #else
-  __device__ __attribute__((noinline)) void runTreeUpDown(int tid, int nthreads, struct ncclDevWorkColl* work) {
+__device__ __attribute__((noinline)) void runTreeUpDown(int tid, int nthreads, struct ncclDevWorkColl* work) {
 #endif
-    ncclTree *tree = &ncclShmem.channel.tree;
-    size_t size;
-    size_t gridOffset;
-    size_t channelCount;
-    size_t chunkCount;
-    ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &size, &gridOffset, &channelCount, &chunkCount);
-    size_t offset;
-    int nelem;
+  ncclTree* tree = &ncclShmem.channel.tree;
+  size_t size;
+  size_t gridOffset;
+  size_t channelCount;
+  size_t chunkCount;
+  ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &size, &gridOffset, &channelCount, &chunkCount);
+  size_t offset;
+  int nelem;
 
-    { // Reduce : max number of recv is 3, max number of send is 1 (binary tree + local)
-      Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_DEV_ARITY, 1>, /*Direct=*/1, Proto, 0, false, 0, Pipeline, USE_ACC> prims
-        (tid, nthreads, tree->down, &tree->up, work->sendbuff, work->recvbuff, work->redOpArg, 0, 0, 0, work);
-
-      if (tree->up == -1) {
-        for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
-          offset = gridOffset + elemOffset;
-          nelem = min(chunkCount, channelCount - elemOffset);
-          prims.directRecvReduceCopy(offset, offset, nelem, /*postOp=*/true);
-        }
-      }
-      else if (tree->down[0] == -1) {
-        for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
-          offset = gridOffset + elemOffset;
-          nelem = min(chunkCount, channelCount - elemOffset);
-          prims.directSend(offset, offset, nelem);
-        }
-      }
-      else {
-        for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
-          offset = gridOffset + elemOffset;
-          nelem = min(chunkCount, channelCount - elemOffset);
-          prims.directRecvReduceDirectSend(offset, offset, nelem);
-        }
-      }
-
-    }
-
-    { // Broadcast : max number of recv is 1, max number of send is 3 (binary tree + local)
-      Primitives<T, RedOp, FanAsymmetric<1, NCCL_MAX_DEV_ARITY>, /*Direct=*/1, Proto, 0, false, 0, Pipeline, USE_ACC> prims
-        (tid, nthreads, &tree->up, tree->down, work->sendbuff, work->recvbuff, work->redOpArg, 0, 0, 0, work);
-
-      if (tree->up == -1) {
-        for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
-          offset = gridOffset + elemOffset;
-          nelem = min(chunkCount, channelCount - elemOffset);
-          prims.directSendFromOutput(offset, nelem);
-        }
-      }
-      else if (tree->down[0] == -1) {
-        for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
-          offset = gridOffset + elemOffset;
-          nelem = min(chunkCount, channelCount - elemOffset);
-          prims.directRecv(offset, nelem);
-        }
-      }
-      else {
-        for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
-          offset = gridOffset + elemOffset;
-          nelem = min(chunkCount, channelCount - elemOffset);
-          prims.directRecvCopyDirectSend(offset, offset, nelem);
-        }
-      }
-
-    }
-
-  }
-
-  template<typename T, typename RedOp, typename Proto>
-#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
-  __device__ void runTreeSplit(int tid, int nthreads, struct ncclDevWorkColl* work) {
-#else
-  __device__ __attribute__((noinline)) void runTreeSplit(int tid, int nthreads, struct ncclDevWorkColl* work) {
-#endif
-    ncclTree *tree = &ncclShmem.channel.tree;
-    size_t size;
-    size_t gridOffset;
-    size_t channelCount;
-    size_t chunkCount;
-    ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &size, &gridOffset, &channelCount, &chunkCount);
-    size_t offset;
-    int nelem;
-    int nthreadsSplit;
-    if (Proto::Id == NCCL_PROTO_SIMPLE) {
-      nthreadsSplit = nthreads/2;
-      if (nthreadsSplit >= 256) nthreadsSplit += 64;
-    } else { // LL & LL128
-      // Receiving from up to 3 sources is more compute intensive than sending
-      // to 3 dests. Use 70% for reduce and 30% for bcast.
-      nthreadsSplit = (nthreads*7/(10*WARP_SIZE))*WARP_SIZE;
-    }
+  { // Reduce : max number of recv is 3, max number of send is 1 (binary tree + local)
+    Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_DEV_ARITY, 1>, /*Direct=*/1, Proto, 0, false, 0, Pipeline, USE_ACC>
+      prims(tid, nthreads, tree->down, &tree->up, work->sendbuff, work->recvbuff, work->redOpArg, 0, 0, 0, work);
 
     if (tree->up == -1) {
-      // Reduce and broadcast. Max number of recv is 2, max number of send is 2
-      Primitives<T, RedOp, FanSymmetric<NCCL_MAX_DEV_ARITY>, /*Direct=*/1, Proto, 0, false, 0, Pipeline, USE_ACC>
-        prims(tid, nthreads, tree->down, tree->down, work->sendbuff, work->recvbuff, work->redOpArg, 0, 0, 0, work);
-
       for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
         offset = gridOffset + elemOffset;
         nelem = min(chunkCount, channelCount - elemOffset);
-        prims.directRecvReduceCopyDirectSend(offset, offset, nelem, /*doPost=*/true);
+        prims.directRecvReduceCopy(offset, offset, nelem, /*postOp=*/true);
       }
-
+    } else if (tree->down[0] == -1) {
+      for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
+        offset = gridOffset + elemOffset;
+        nelem = min(chunkCount, channelCount - elemOffset);
+        prims.directSend(offset, offset, nelem);
+      }
+    } else {
+      for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
+        offset = gridOffset + elemOffset;
+        nelem = min(chunkCount, channelCount - elemOffset);
+        prims.directRecvReduceDirectSend(offset, offset, nelem);
+      }
     }
-    else if (tid < nthreadsSplit) {
+  }
+
+  { // Broadcast : max number of recv is 1, max number of send is 3 (binary tree + local)
+    Primitives<T, RedOp, FanAsymmetric<1, NCCL_MAX_DEV_ARITY>, /*Direct=*/1, Proto, 0, false, 0, Pipeline, USE_ACC>
+      prims(tid, nthreads, &tree->up, tree->down, work->sendbuff, work->recvbuff, work->redOpArg, 0, 0, 0, work);
+
+    if (tree->up == -1) {
+      for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
+        offset = gridOffset + elemOffset;
+        nelem = min(chunkCount, channelCount - elemOffset);
+        prims.directSendFromOutput(offset, nelem);
+      }
+    } else if (tree->down[0] == -1) {
+      for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
+        offset = gridOffset + elemOffset;
+        nelem = min(chunkCount, channelCount - elemOffset);
+        prims.directRecv(offset, nelem);
+      }
+    } else {
+      for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
+        offset = gridOffset + elemOffset;
+        nelem = min(chunkCount, channelCount - elemOffset);
+        prims.directRecvCopyDirectSend(offset, offset, nelem);
+      }
+    }
+  }
+}
+
+template <typename T, typename RedOp, typename Proto>
+#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
+__device__ void runTreeSplit(int tid, int nthreads, struct ncclDevWorkColl* work) {
+#else
+__device__ __attribute__((noinline)) void runTreeSplit(int tid, int nthreads, struct ncclDevWorkColl* work) {
+#endif
+  ncclTree* tree = &ncclShmem.channel.tree;
+  size_t size;
+  size_t gridOffset;
+  size_t channelCount;
+  size_t chunkCount;
+  ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &size, &gridOffset, &channelCount, &chunkCount);
+  size_t offset;
+  int nelem;
+  int nthreadsSplit;
+  if (Proto::Id == NCCL_PROTO_SIMPLE) {
+    nthreadsSplit = nthreads / 2;
+    if (nthreadsSplit >= 256) nthreadsSplit += 64;
+  } else { // LL & LL128
+      // Receiving from up to 3 sources is more compute intensive than sending
+      // to 3 dests. Use 70% for reduce and 30% for bcast.
+    nthreadsSplit = (nthreads * 7 / (10 * WARP_SIZE)) * WARP_SIZE;
+  }
+
+  if (tree->up == -1) {
+      // Reduce and broadcast. Max number of recv is 2, max number of send is 2
+    Primitives<T, RedOp, FanSymmetric<NCCL_MAX_DEV_ARITY>, /*Direct=*/1, Proto, 0, false, 0, Pipeline, USE_ACC> prims(
+      tid, nthreads, tree->down, tree->down, work->sendbuff, work->recvbuff, work->redOpArg, 0, 0, 0, work);
+
+    for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
+      offset = gridOffset + elemOffset;
+      nelem = min(chunkCount, channelCount - elemOffset);
+      prims.directRecvReduceCopyDirectSend(offset, offset, nelem, /*doPost=*/true);
+    }
+
+  } else if (tid < nthreadsSplit) {
       /* Reduce up. Max number of recv is 3, max number of send is 1 (binary tree + local).
-      * Why Direct=1????
-      * Answer: Because despite not performing any direct operations, the ctor
-      * must assume Direct so that it can exchange direct pointers with remote ctors
-      * that are Direct, otherwise it hangs. A cleaner solution would be to seperate
-      * into DirectRecv and DirectSend capabilities, this ctor would have both=0,
-      * but the ctor above for tree roots would be DirectRecv=0 DirectSend=1.
-      */
+     * Why Direct=1????
+     * Answer: Because despite not performing any direct operations, the ctor
+     * must assume Direct so that it can exchange direct pointers with remote ctors
+     * that are Direct, otherwise it hangs. A cleaner solution would be to seperate
+     * into DirectRecv and DirectSend capabilities, this ctor would have both=0,
+     * but the ctor above for tree roots would be DirectRecv=0 DirectSend=1.
+     */
       // Coverity reports that the callee treats &tree->up as an array.  However, due to the use of
       // FanAsymmetric<n, 1>, only the first element is ever accessed, so it's fine.
       // coverity[callee_ptr_arith:FALSE]
-      Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_DEV_ARITY, 1>, /*Direct=*/1, Proto, 0, false, 0, Pipeline, USE_ACC>
-        prims(tid, nthreadsSplit, tree->down, &tree->up, work->sendbuff, work->recvbuff, work->redOpArg, 0*Proto::MaxGroupWidth, 0, 0, work);
+    Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_DEV_ARITY, 1>, /*Direct=*/1, Proto, 0, false, 0, Pipeline, USE_ACC>
+      prims(tid, nthreadsSplit, tree->down, &tree->up, work->sendbuff, work->recvbuff, work->redOpArg,
+            0 * Proto::MaxGroupWidth, 0, 0, work);
 
-      if (tree->down[0] == -1) {
-        for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
-          offset = gridOffset + elemOffset;
-          nelem = min(chunkCount, channelCount - elemOffset);
-          prims.directSend(offset, offset, nelem);
-        }
+    if (tree->down[0] == -1) {
+      for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
+        offset = gridOffset + elemOffset;
+        nelem = min(chunkCount, channelCount - elemOffset);
+        prims.directSend(offset, offset, nelem);
       }
-      else {
-        for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
-          offset = gridOffset + elemOffset;
-          nelem = min(chunkCount, channelCount - elemOffset);
-          prims.directRecvReduceDirectSend(offset, offset, nelem);
-        }
+    } else {
+      for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
+        offset = gridOffset + elemOffset;
+        nelem = min(chunkCount, channelCount - elemOffset);
+        prims.directRecvReduceDirectSend(offset, offset, nelem);
       }
-
     }
-    else {
+
+  } else {
       // Broadcast down. Max number of recv is 1, max number of send is 3 (binary tree + local)
       // Coverity reports that the callee treats &tree->up as an array.  However, due to the use of
       // FanAsymmetric<1, n>, only the first element is ever accessed, so it's fine.
       // coverity[callee_ptr_arith:FALSE]
-      Primitives<T, RedOp, FanAsymmetric<1, NCCL_MAX_DEV_ARITY>, /*Direct=*/1, Proto, 0, false, 0, Pipeline, USE_ACC>
-        prims(tid-nthreadsSplit, nthreads-nthreadsSplit, &tree->up, tree->down, work->sendbuff, work->recvbuff,
-            work->redOpArg, 1*Proto::MaxGroupWidth, 0, 0, work);
+    Primitives<T, RedOp, FanAsymmetric<1, NCCL_MAX_DEV_ARITY>, /*Direct=*/1, Proto, 0, false, 0, Pipeline, USE_ACC>
+      prims(tid - nthreadsSplit, nthreads - nthreadsSplit, &tree->up, tree->down, work->sendbuff, work->recvbuff,
+            work->redOpArg, 1 * Proto::MaxGroupWidth, 0, 0, work);
 
-      if (tree->down[0] == -1) {
-        for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
-          offset = gridOffset + elemOffset;
-          nelem = min(chunkCount, channelCount - elemOffset);
-          prims.directRecv(offset, nelem);
-        }
+    if (tree->down[0] == -1) {
+      for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
+        offset = gridOffset + elemOffset;
+        nelem = min(chunkCount, channelCount - elemOffset);
+        prims.directRecv(offset, nelem);
       }
-      else {
-        for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
-          offset = gridOffset + elemOffset;
-          nelem = min(chunkCount, channelCount - elemOffset);
-          prims.directRecvCopyDirectSend(offset, offset, nelem);
-        }
+    } else {
+      for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
+        offset = gridOffset + elemOffset;
+        nelem = min(chunkCount, channelCount - elemOffset);
+        prims.directRecvCopyDirectSend(offset, offset, nelem);
       }
-
     }
-
   }
 }
+} // namespace
 
 #if defined(__gfx942__) // Use a single slice per simple primitive for a single node on some gfx942 devices.
 #define rcclAllReduceRunRingSimpleProtoImpl(tid, nthreads, work) \
-  if(work->rcclUseOneSlice){ \
-    using Proto = ProtoSimple<ALLREDUCE_CHUNKSTEPS/ALLREDUCE_SLICESTEPS_SINGLE_NODE, ALLREDUCE_SLICESTEPS_SINGLE_NODE>; \
+  if (work->rcclUseOneSlice) { \
+    using Proto = \
+      ProtoSimple<ALLREDUCE_CHUNKSTEPS / ALLREDUCE_SLICESTEPS_SINGLE_NODE, ALLREDUCE_SLICESTEPS_SINGLE_NODE>; \
     runRing<T, RedOp, Proto, RCCL_METADATA_EMPTY>(tid, nthreads, work); \
-  } \
-  else{ \
-    using Proto = ProtoSimple<ALLREDUCE_CHUNKSTEPS/ALLREDUCE_SLICESTEPS, ALLREDUCE_SLICESTEPS>; \
+  } else { \
+    using Proto = ProtoSimple<ALLREDUCE_CHUNKSTEPS / ALLREDUCE_SLICESTEPS, ALLREDUCE_SLICESTEPS>; \
     runRing<T, RedOp, Proto, RCCL_METADATA_EMPTY>(tid, nthreads, work); \
   }
-#elif defined(__gfx950__) // Use a single slice and single step per slice per simple primitive for a single node on some gfx950 devices.
+#elif defined( \
+  __gfx950__) // Use a single slice and single step per slice per simple primitive for a single node on some gfx950 devices.
 #define rcclAllReduceRunRingSimpleProtoImpl(tid, nthreads, work) \
-  if(work->rcclUseOneSlice){ \
+  if (work->rcclUseOneSlice) { \
     using Proto = ProtoSimple<1, 1>; \
     runRing<T, RedOp, Proto, RCCL_METADATA_EMPTY>(tid, nthreads, work); \
-  } \
-  else{ \
-    using Proto = ProtoSimple<ALLREDUCE_CHUNKSTEPS/ALLREDUCE_SLICESTEPS, ALLREDUCE_SLICESTEPS>; \
+  } else { \
+    using Proto = ProtoSimple<ALLREDUCE_CHUNKSTEPS / ALLREDUCE_SLICESTEPS, ALLREDUCE_SLICESTEPS>; \
     runRing<T, RedOp, Proto, RCCL_METADATA_EMPTY>(tid, nthreads, work); \
   }
 #else
 #define rcclAllReduceRunRingSimpleProtoImpl(tid, nthreads, work) \
-  using Proto = ProtoSimple<ALLREDUCE_CHUNKSTEPS/ALLREDUCE_SLICESTEPS, ALLREDUCE_SLICESTEPS>; \
+  using Proto = ProtoSimple<ALLREDUCE_CHUNKSTEPS / ALLREDUCE_SLICESTEPS, ALLREDUCE_SLICESTEPS>; \
   runRing<T, RedOp, Proto, RCCL_METADATA_EMPTY>(tid, nthreads, work);
 #endif
 
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPLE> {
   __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
-   rcclAllReduceRunRingSimpleProtoImpl(tid, nthreads, work);
+    rcclAllReduceRunRingSimpleProtoImpl(tid, nthreads, work);
   }
 };
 
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_TREE, NCCL_PROTO_SIMPLE> {
   __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
     using Proto = ProtoSimple<1, 1>;
@@ -325,23 +309,27 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_TREE, NCCL_PROTO_SIMPL
   }
 };
 
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_PROTO_SIMPLE> {
-  __device__ __forceinline__ void run(int tid, int/*nthreads*/, struct ncclDevWorkColl* work) {
+  __device__ __forceinline__ void run(int tid, int /*nthreads*/, struct ncclDevWorkColl* work) {
     static constexpr int COLLNET_COPY_THREADS = 64;
     const int bid = ncclShmem.channelId - work->channelLo;
     const int nChannels = work->channelHi - work->channelLo + 1;
     struct ncclDirect* direct = &ncclShmem.channel.collnetDirect;
     const ssize_t chunkSize = work->collnet.chunkCount;
     const ssize_t size = work->collnet.count;
-    const ssize_t loopSize = nChannels*direct->nHeads*chunkSize;
+    const ssize_t loopSize = nChannels * direct->nHeads * chunkSize;
 
     const int hasUp = (direct->up[0] >= 0) ? 1 : 0;
     const int hasDn = (direct->down[0] >= 0) ? 1 : 0;
-    const int nThreadsScatter = WARP_SIZE + ((hasUp && hasDn) ? COLLNET_COPY_THREADS : hasUp ? 2*COLLNET_COPY_THREADS : 0);
-    const int nThreadsGather  =             ((hasUp && hasDn) ? COLLNET_COPY_THREADS : hasUp ? 1*COLLNET_COPY_THREADS : 0);
-    const int nThreadsBcast   = WARP_SIZE + ((hasUp && hasDn) ? COLLNET_COPY_THREADS : hasUp ? 0 : 1*COLLNET_COPY_THREADS);
-    const int nThreadsReduce = work->nWarps*WARP_SIZE - nThreadsScatter - nThreadsGather - nThreadsBcast;
+    const int nThreadsScatter = WARP_SIZE + ((hasUp && hasDn) ? COLLNET_COPY_THREADS :
+                                             hasUp            ? 2 * COLLNET_COPY_THREADS :
+                                                                0);
+    const int nThreadsGather = ((hasUp && hasDn) ? COLLNET_COPY_THREADS : hasUp ? 1 * COLLNET_COPY_THREADS : 0);
+    const int nThreadsBcast = WARP_SIZE + ((hasUp && hasDn) ? COLLNET_COPY_THREADS :
+                                           hasUp            ? 0 :
+                                                              1 * COLLNET_COPY_THREADS);
+    const int nThreadsReduce = work->nWarps * WARP_SIZE - nThreadsScatter - nThreadsGather - nThreadsBcast;
     const int tidStartBcast = nThreadsGather;
     const int tidStartScatter = tidStartBcast + nThreadsBcast;
     const int tidStartReduce = tidStartScatter + nThreadsScatter;
@@ -349,14 +337,14 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_P
 
     if (tid >= tidStartScatter && tid < tidStartReduce && hasUp) {
       // Scatter
-      Primitives<T, RedOp, FanAsymmetric<0, NCCL_MAX_DIRECT_ARITY>, /*Direct=*/0, Proto, 0>
-        prims(tid-tidStartScatter, nThreadsScatter, NULL, direct->up, work->sendbuff, work->recvbuff,
-           work->redOpArg, 2*Proto::MaxGroupWidth, 1, 1, work);
+      Primitives<T, RedOp, FanAsymmetric<0, NCCL_MAX_DIRECT_ARITY>, /*Direct=*/0, Proto, 0> prims(
+        tid - tidStartScatter, nThreadsScatter, NULL, direct->up, work->sendbuff, work->recvbuff, work->redOpArg,
+        2 * Proto::MaxGroupWidth, 1, 1, work);
       ssize_t offsetBase, peerOffset;
       ssize_t maxNelems;
       if (work->netRegUsed) {
         offsetBase = bid * chunkSize;
-        maxNelems = size;  // never be the min
+        maxNelems = size; // never be the min
         peerOffset = nChannels * chunkSize;
       } else {
         offsetBase = bid * direct->nHeads * chunkSize;
@@ -376,12 +364,12 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_P
     } else if (tid >= tidStartReduce && direct->out != -1) {
       if (hasDn) {
         // Reduce, send to network
-        Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_DIRECT_ARITY, 1>, /*Direct=*/0, Proto, 0>
-          prims(tid-tidStartReduce, nThreadsReduce, direct->down, &direct->out, work->sendbuff, work->recvbuff,
-             work->redOpArg, 3*Proto::MaxGroupWidth, 1, 1, work);
+        Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_DIRECT_ARITY, 1>, /*Direct=*/0, Proto, 0> prims(
+          tid - tidStartReduce, nThreadsReduce, direct->down, &direct->out, work->sendbuff, work->recvbuff,
+          work->redOpArg, 3 * Proto::MaxGroupWidth, 1, 1, work);
         for (ssize_t gridOffset = 0; gridOffset < size; gridOffset += loopSize) {
-          ssize_t offset = work->netRegUsed ? gridOffset + (bid + direct->headRank * nChannels) * chunkSize
-                                    : gridOffset + (bid * direct->nHeads + direct->headRank) * chunkSize;
+          ssize_t offset = work->netRegUsed ? gridOffset + (bid + direct->headRank * nChannels) * chunkSize :
+                                              gridOffset + (bid * direct->nHeads + direct->headRank) * chunkSize;
           int nelem = min(chunkSize, size - offset);
           prims.recvReduceDirectSend(offset, offset, nelem);
         }
@@ -393,9 +381,10 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_P
           }
           __syncwarp();
         } else {
-          Primitives<T, RedOp, FanAsymmetric<0, 1>, /*Direct=*/1, Proto, 0>
-          prims(tid-tidStartReduce, nThreadsReduce, nullptr, &direct->out, work->sendbuff, work->recvbuff,
-            work->redOpArg, 3*Proto::MaxGroupWidth, 1, 1);
+          Primitives<T, RedOp, FanAsymmetric<0, 1>, /*Direct=*/1, Proto, 0> prims(tid - tidStartReduce, nThreadsReduce,
+                                                                                  nullptr, &direct->out, work->sendbuff,
+                                                                                  work->recvbuff, work->redOpArg,
+                                                                                  3 * Proto::MaxGroupWidth, 1, 1);
           for (ssize_t gridOffset = 0; gridOffset < size; gridOffset += loopSize) {
             ssize_t offset = gridOffset + (bid * direct->nHeads + direct->headRank) * chunkSize;
             int nelem = min(chunkSize, size - offset);
@@ -405,14 +394,14 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_P
       }
     } else if (tid < tidStartBcast && hasUp) {
       // Gather
-      Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_DIRECT_ARITY, 0>, /*Direct=*/0, Proto, 0>
-        prims(tid, nThreadsGather, direct->up, NULL, work->sendbuff, work->recvbuff,
-           work->redOpArg, 0*Proto::MaxGroupWidth, 0, 0, work);
+      Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_DIRECT_ARITY, 0>, /*Direct=*/0, Proto, 0> prims(
+        tid, nThreadsGather, direct->up, NULL, work->sendbuff, work->recvbuff, work->redOpArg, 0 * Proto::MaxGroupWidth,
+        0, 0, work);
       ssize_t offsetBase, peerOffset;
       ssize_t maxNelems;
       if (work->netRegUsed) {
         offsetBase = bid * chunkSize;
-        maxNelems = size;  // never be the min
+        maxNelems = size; // never be the min
         peerOffset = nChannels * chunkSize;
       } else {
         offsetBase = bid * direct->nHeads * chunkSize;
@@ -430,12 +419,12 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_P
         // Coverity complains about a possible overrun inside the class below, but that's actually
         // a false positive.
         // coverity[identity_transfer:FALSE]
-        Primitives<T, RedOp, FanAsymmetric<1, NCCL_MAX_DIRECT_ARITY>, /*Direct=*/0, Proto, 0>
-          prims(tid-tidStartBcast, nThreadsBcast, &direct->out, direct->down, work->sendbuff, work->recvbuff,
-            work->redOpArg, 1*Proto::MaxGroupWidth, 0, 0, work);
+        Primitives<T, RedOp, FanAsymmetric<1, NCCL_MAX_DIRECT_ARITY>, /*Direct=*/0, Proto, 0> prims(
+          tid - tidStartBcast, nThreadsBcast, &direct->out, direct->down, work->sendbuff, work->recvbuff,
+          work->redOpArg, 1 * Proto::MaxGroupWidth, 0, 0, work);
         for (ssize_t gridOffset = 0; gridOffset < size; gridOffset += loopSize) {
-          ssize_t offset = work->netRegUsed ? gridOffset + (bid + direct->headRank * nChannels) * chunkSize
-                                            : gridOffset + (bid * direct->nHeads + direct->headRank) * chunkSize;
+          ssize_t offset = work->netRegUsed ? gridOffset + (bid + direct->headRank * nChannels) * chunkSize :
+                                              gridOffset + (bid * direct->nHeads + direct->headRank) * chunkSize;
           int nelem = min(chunkSize, size - offset);
           prims.directRecvCopyDirectSend(offset, offset, nelem, /*postOp=*/true);
         }
@@ -447,9 +436,10 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_P
           __syncwarp();
         } else {
           // Recv from network (no post thread needed)
-          Primitives<T, RedOp, FanAsymmetric<1, 0>, /*Direct=*/1, Proto, 0>
-            prims(tid - tidStartBcast, nThreadsBcast, &direct->out, nullptr, work->sendbuff, work->recvbuff,
-              work->redOpArg, 1 * Proto::MaxGroupWidth, 0, 0);
+          Primitives<T, RedOp, FanAsymmetric<1, 0>, /*Direct=*/1, Proto, 0> prims(tid - tidStartBcast, nThreadsBcast,
+                                                                                  &direct->out, nullptr, work->sendbuff,
+                                                                                  work->recvbuff, work->redOpArg,
+                                                                                  1 * Proto::MaxGroupWidth, 0, 0);
           for (ssize_t gridOffset = 0; gridOffset < size; gridOffset += loopSize) {
             ssize_t offset = gridOffset + (bid * direct->nHeads + direct->headRank) * chunkSize;
             int nelem = min(chunkSize, size - offset);
@@ -461,22 +451,22 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_P
   }
 };
 
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPLE> {
-  __device__ __forceinline__ void run(int tid, int/*nthreads*/, struct ncclDevWorkColl* work) {
+  __device__ __forceinline__ void run(int tid, int /*nthreads*/, struct ncclDevWorkColl* work) {
     struct ncclNvls* nvls = &ncclShmem.channel.nvls;
     const bool hasOut = nvls->out != -1;
     const int nranks = ncclShmem.comm.nRanks;
-    const int totalWarps = NCCL_MAX_NTHREADS/WARP_SIZE;
+    const int totalWarps = NCCL_MAX_NTHREADS / WARP_SIZE;
     const int bcastWarps = hasOut ? (work->regUsed ? ((totalWarps - 2) >> 1) - 1 : 2) : 0;
     const int reduceWarps = work->regUsed ? (totalWarps - bcastWarps - 2) : (hasOut ? 3 : nranks <= 6 ? 7 : 5);
     const int scatterWarps = work->regUsed ? 1 : (totalWarps - reduceWarps - bcastWarps + 1) >> 1;
     const int gatherWarps = work->regUsed ? 1 : (totalWarps - reduceWarps - bcastWarps) >> 1;
 
-    const int nThreadsScatter = scatterWarps*WARP_SIZE;
-    const int nThreadsGather  = gatherWarps*WARP_SIZE;
-    const int nThreadsReduce = reduceWarps*WARP_SIZE;
-    const int nThreadsBcast  = (bcastWarps)*WARP_SIZE;
+    const int nThreadsScatter = scatterWarps * WARP_SIZE;
+    const int nThreadsGather = gatherWarps * WARP_SIZE;
+    const int nThreadsReduce = reduceWarps * WARP_SIZE;
+    const int nThreadsBcast = (bcastWarps)*WARP_SIZE;
     const int tidEndScatter = nThreadsScatter;
     const int tidEndGather = tidEndScatter + nThreadsGather;
     const int tidEndReduce = tidEndGather + nThreadsReduce;
@@ -484,17 +474,17 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
 
     if (work->oneNode) {
       ssize_t gridOffset, channelCount, chunkSize;
-      ncclCollCbdPart(work, ncclShmem.channelId, NCCL_PROTO_SIMPLE, sizeof(T), (ssize_t*)nullptr, &gridOffset, &channelCount, &chunkSize);
+      ncclCollCbdPart(work, ncclShmem.channelId, NCCL_PROTO_SIMPLE, sizeof(T), (ssize_t*)nullptr, &gridOffset,
+                      &channelCount, &chunkSize);
       const ssize_t loopCount = nvls->nHeads * chunkSize;
-      int remCount = channelCount%(nvls->nHeads*chunkSize);
-      int lastChunkSize = alignUp(divUp(remCount, nvls->nHeads), 16384/sizeof(T));
+      int remCount = channelCount % (nvls->nHeads * chunkSize);
+      int lastChunkSize = alignUp(divUp(remCount, nvls->nHeads), 16384 / sizeof(T));
 
       if (tid < tidEndScatter) {
         // Scatter
         using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL>;
-        Primitives<T, RedOp, FanAsymmetric<0, NCCL_MAX_NVLS_ARITY>, /*Direct=*/1, Proto, 0>
-          prims(tid, nThreadsScatter, NULL, nvls->up, work->sendbuff, NULL,
-            work->redOpArg, 0 * Proto::MaxGroupWidth, 1, 1);
+        Primitives<T, RedOp, FanAsymmetric<0, NCCL_MAX_NVLS_ARITY>, /*Direct=*/1, Proto, 0> prims(
+          tid, nThreadsScatter, NULL, nvls->up, work->sendbuff, NULL, work->redOpArg, 0 * Proto::MaxGroupWidth, 1, 1);
         for (ssize_t elemOffset = 0; elemOffset < channelCount; elemOffset += loopCount) {
           if (channelCount - elemOffset < loopCount) chunkSize = lastChunkSize;
           ssize_t offset = gridOffset + elemOffset;
@@ -504,9 +494,9 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
       } else if (tid < tidEndGather) {
         // Gather
         using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL>;
-        Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_NVLS_ARITY, 0>, /*Direct=*/1, Proto, 0>
-          prims(tid - tidEndScatter, nThreadsGather, nvls->up, NULL, NULL, work->recvbuff,
-            work->redOpArg, 1 * Proto::MaxGroupWidth, 1, 1);
+        Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_NVLS_ARITY, 0>, /*Direct=*/1, Proto, 0> prims(
+          tid - tidEndScatter, nThreadsGather, nvls->up, NULL, NULL, work->recvbuff, work->redOpArg,
+          1 * Proto::MaxGroupWidth, 1, 1);
         for (ssize_t elemOffset = 0; elemOffset < channelCount; elemOffset += loopCount) {
           if (channelCount - elemOffset < loopCount) chunkSize = lastChunkSize;
           ssize_t offset = gridOffset + elemOffset;
@@ -516,9 +506,10 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
       } else if (tid < tidEndReduce && nvls->headRank != -1) {
         // Reduce, broadcast through NVLS
         using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL, 1, 1>;
-        Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0>
-          prims(tid - tidEndGather, nThreadsReduce, &nvls->down, &nvls->down, NULL, NULL,
-            work->redOpArg, 2 * Proto::MaxGroupWidth, 0, 0, work);
+        Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0> prims(tid - tidEndGather, nThreadsReduce,
+                                                                            &nvls->down, &nvls->down, NULL, NULL,
+                                                                            work->redOpArg, 2 * Proto::MaxGroupWidth, 0,
+                                                                            0, work);
         for (ssize_t elemOffset = 0; elemOffset < channelCount; elemOffset += loopCount) {
           ssize_t chunkOffset, offset;
           int nelem;
@@ -539,9 +530,8 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
       if (tid < tidEndScatter) {
         // Scatter
         using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL>;
-        Primitives<T, RedOp, FanAsymmetric<0, NCCL_MAX_NVLS_ARITY>, /*Direct=*/1, Proto, 0>
-          prims(tid, nThreadsScatter, NULL, nvls->up, work->sendbuff, NULL,
-            work->redOpArg, 0 * Proto::MaxGroupWidth, 1, 1);
+        Primitives<T, RedOp, FanAsymmetric<0, NCCL_MAX_NVLS_ARITY>, /*Direct=*/1, Proto, 0> prims(
+          tid, nThreadsScatter, NULL, nvls->up, work->sendbuff, NULL, work->redOpArg, 0 * Proto::MaxGroupWidth, 1, 1);
         for (ssize_t gridOffset = 0; gridOffset < size; gridOffset += loopSize) {
           ssize_t offset = gridOffset + bid * nvls->nHeads * chunkSize;
           int nelem = work->regUsed ? 0 : min(nvls->nHeads * chunkSize, size - offset);
@@ -551,9 +541,9 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
       } else if (tid < tidEndGather) {
         // Gather
         using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL>;
-        Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_NVLS_ARITY, 0>, /*Direct=*/1, Proto, 0>
-          prims(tid - tidEndScatter, nThreadsGather, nvls->up, NULL, NULL, work->recvbuff,
-            work->redOpArg, 1 * Proto::MaxGroupWidth, 1, 1);
+        Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_NVLS_ARITY, 0>, /*Direct=*/1, Proto, 0> prims(
+          tid - tidEndScatter, nThreadsGather, nvls->up, NULL, NULL, work->recvbuff, work->redOpArg,
+          1 * Proto::MaxGroupWidth, 1, 1);
         for (ssize_t gridOffset = 0; gridOffset < size; gridOffset += loopSize) {
           ssize_t offset = gridOffset + bid * nvls->nHeads * chunkSize;
           int nelem = work->regUsed ? 0 : min(nvls->nHeads * chunkSize, size - offset);
@@ -565,12 +555,14 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
         // Coverity complains about a possible overrun inside the class below, but that's actually
         // a false positive.
         // coverity[identity_transfer:FALSE]
-        Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0>
-        prims(tid - tidEndGather, nThreadsReduce, &nvls->down, &nvls->out, NULL, work->recvbuff,
-          work->redOpArg, 2 * Proto::MaxGroupWidth, 0, 1, work);
+        Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0> prims(tid - tidEndGather, nThreadsReduce,
+                                                                            &nvls->down, &nvls->out, NULL,
+                                                                            work->recvbuff, work->redOpArg,
+                                                                            2 * Proto::MaxGroupWidth, 0, 1, work);
         for (ssize_t gridOffset = 0; gridOffset < size; gridOffset += loopSize) {
-          ssize_t offset = work->regUsed && work->netRegUsed ? gridOffset + (nvls->headRank * nChannels + bid) * chunkSize
-                                                             : gridOffset + (bid * nvls->nHeads + nvls->headRank) * chunkSize;
+          ssize_t offset = work->regUsed && work->netRegUsed ?
+                             gridOffset + (nvls->headRank * nChannels + bid) * chunkSize :
+                             gridOffset + (bid * nvls->nHeads + nvls->headRank) * chunkSize;
           int nelem = min(chunkSize, size - offset);
           prims.directRecvDirectSend(offset, offset, nelem);
         }
@@ -580,12 +572,14 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
         // Coverity complains about a possible overrun inside the class below, but that's actually
         // a false positive.
         // coverity[identity_transfer:FALSE]
-        Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0>
-          prims(tid - tidEndReduce, nThreadsBcast, &nvls->out, &nvls->down, NULL, work->recvbuff,
-            work->redOpArg, 3 * Proto::MaxGroupWidth, 0, 0, work);
+        Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0> prims(tid - tidEndReduce, nThreadsBcast,
+                                                                            &nvls->out, &nvls->down, NULL,
+                                                                            work->recvbuff, work->redOpArg,
+                                                                            3 * Proto::MaxGroupWidth, 0, 0, work);
         for (ssize_t gridOffset = 0; gridOffset < size; gridOffset += loopSize) {
-          ssize_t offset = work->regUsed && work->netRegUsed ? gridOffset + (nvls->headRank * nChannels + bid) * chunkSize
-                                                             : gridOffset + (bid * nvls->nHeads + nvls->headRank) * chunkSize;
+          ssize_t offset = work->regUsed && work->netRegUsed ?
+                             gridOffset + (nvls->headRank * nChannels + bid) * chunkSize :
+                             gridOffset + (bid * nvls->nHeads + nvls->headRank) * chunkSize;
           int nelem = min(chunkSize, size - offset);
           prims.directRecvDirectSend(offset, offset, nelem);
         }
@@ -594,31 +588,32 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPL
   }
 };
 
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS_TREE, NCCL_PROTO_SIMPLE> {
-  __device__ __forceinline__ void run(int tid, int/*nthreads*/, struct ncclDevWorkColl* work) {
+  __device__ __forceinline__ void run(int tid, int /*nthreads*/, struct ncclDevWorkColl* work) {
     struct ncclNvls* nvls = &ncclShmem.channel.nvls;
     const int treeUp = nvls->treeUp;
     const int* treeDown = nvls->treeDown;
     ssize_t gridOffset, channelCount, chunkCount;
-    ncclCollCbdPart(work, ncclShmem.channelId, NCCL_PROTO_SIMPLE, sizeof(T), (ssize_t*)nullptr, &gridOffset, &channelCount, &chunkCount);
+    ncclCollCbdPart(work, ncclShmem.channelId, NCCL_PROTO_SIMPLE, sizeof(T), (ssize_t*)nullptr, &gridOffset,
+                    &channelCount, &chunkCount);
     const ssize_t loopCount = nvls->nHeads * chunkCount;
     const int nranks = ncclShmem.comm.nRanks;
     const bool hasUp = treeUp != -1;
-    const int totalWarps = NCCL_MAX_NTHREADS/WARP_SIZE;
+    const int totalWarps = NCCL_MAX_NTHREADS / WARP_SIZE;
     const int bcastWarps = hasUp ? (work->regUsed ? ((totalWarps - 2) >> 1) - 1 : 4) : 0;
     const int reduceWarps = work->regUsed ? (totalWarps - bcastWarps - 2) : (hasUp ? 5 : nranks <= 6 ? 7 : 5);
     const int scatterWarps = work->regUsed ? 1 : (totalWarps - reduceWarps - bcastWarps + 1) >> 1;
     const int gatherWarps = work->regUsed ? 1 : (totalWarps - reduceWarps - bcastWarps) >> 1;
     ssize_t offset;
     int nelem;
-    int remCount = channelCount%(nvls->nHeads*chunkCount);
-    int lastChunkCount = alignUp(divUp(remCount, nvls->nHeads), 16/sizeof(T));
+    int remCount = channelCount % (nvls->nHeads * chunkCount);
+    int lastChunkCount = alignUp(divUp(remCount, nvls->nHeads), 16 / sizeof(T));
 
-    const int nThreadsScatter = scatterWarps*WARP_SIZE;
-    const int nThreadsGather  = gatherWarps*WARP_SIZE;
-    const int nThreadsReduce = reduceWarps*WARP_SIZE;
-    const int nThreadsBcast  = (bcastWarps)*WARP_SIZE;
+    const int nThreadsScatter = scatterWarps * WARP_SIZE;
+    const int nThreadsGather = gatherWarps * WARP_SIZE;
+    const int nThreadsReduce = reduceWarps * WARP_SIZE;
+    const int nThreadsBcast = (bcastWarps)*WARP_SIZE;
     const int tidEndScatter = nThreadsScatter;
     const int tidEndGather = tidEndScatter + nThreadsGather;
     const int tidEndReduce = tidEndGather + nThreadsReduce;
@@ -627,9 +622,8 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS_TREE, NCCL_PROTO_
     if (tid < tidEndScatter) {
       // Scatter
       using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL>;
-      Primitives<T, RedOp, FanAsymmetric<0, NCCL_MAX_NVLS_ARITY>, /*Direct=*/1, Proto, 0>
-        prims(tid, nThreadsScatter, NULL, nvls->up, work->sendbuff, NULL,
-          work->redOpArg, 0 * Proto::MaxGroupWidth, 1, 1);
+      Primitives<T, RedOp, FanAsymmetric<0, NCCL_MAX_NVLS_ARITY>, /*Direct=*/1, Proto, 0> prims(
+        tid, nThreadsScatter, NULL, nvls->up, work->sendbuff, NULL, work->redOpArg, 0 * Proto::MaxGroupWidth, 1, 1);
       for (ssize_t elemOffset = 0; elemOffset < channelCount; elemOffset += loopCount) {
         if (channelCount - elemOffset < loopCount) chunkCount = lastChunkCount;
         offset = gridOffset + elemOffset;
@@ -639,9 +633,9 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS_TREE, NCCL_PROTO_
     } else if (tid < tidEndGather) {
       // Gather
       using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL>;
-      Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_NVLS_ARITY, 0>, /*Direct=*/1, Proto, 0>
-        prims(tid - tidEndScatter, nThreadsGather, nvls->up, NULL, NULL, work->recvbuff,
-          work->redOpArg, 1 * Proto::MaxGroupWidth, 1, 1);
+      Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_NVLS_ARITY, 0>, /*Direct=*/1, Proto, 0> prims(
+        tid - tidEndScatter, nThreadsGather, nvls->up, NULL, NULL, work->recvbuff, work->redOpArg,
+        1 * Proto::MaxGroupWidth, 1, 1);
       for (ssize_t elemOffset = 0; elemOffset < channelCount; elemOffset += loopCount) {
         if (channelCount - elemOffset < loopCount) chunkCount = lastChunkCount;
         offset = gridOffset + elemOffset;
@@ -652,9 +646,10 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS_TREE, NCCL_PROTO_
       if (!hasUp) {
         // Reduce and Broadcast
         using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL, 1, 1>;
-        Primitives<T, RedOp, FanSymmetric<3>, /*Direct=*/1, Proto, 0>
-          prims(tid - tidEndGather, nThreadsReduce, treeDown, treeDown, NULL, NULL,
-            work->redOpArg, 2 * Proto::MaxGroupWidth, 0, 0, work);
+        Primitives<T, RedOp, FanSymmetric<3>, /*Direct=*/1, Proto, 0> prims(tid - tidEndGather, nThreadsReduce,
+                                                                            treeDown, treeDown, NULL, NULL,
+                                                                            work->redOpArg, 2 * Proto::MaxGroupWidth, 0,
+                                                                            0, work);
         for (ssize_t elemOffset = 0; elemOffset < channelCount; elemOffset += loopCount) {
           ssize_t chunkOffset;
           if (channelCount - elemOffset < loopCount) chunkCount = lastChunkCount;
@@ -669,9 +664,10 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS_TREE, NCCL_PROTO_
         // Coverity reports that the callee treats &treeUp as an array.  However, due to the use of
         // FanAsymmetric<3, 1>, only the first element is ever accessed, so it's fine.
         // coverity[callee_ptr_arith:FALSE]
-        Primitives<T, RedOp, FanAsymmetric<3, 1>, /*Direct=*/1, Proto, 0>
-          prims(tid - tidEndGather, nThreadsReduce, treeDown, &treeUp, NULL, NULL,
-            work->redOpArg, 2 * Proto::MaxGroupWidth, 0, 0, work);
+        Primitives<T, RedOp, FanAsymmetric<3, 1>, /*Direct=*/1, Proto, 0> prims(tid - tidEndGather, nThreadsReduce,
+                                                                                treeDown, &treeUp, NULL, NULL,
+                                                                                work->redOpArg,
+                                                                                2 * Proto::MaxGroupWidth, 0, 0, work);
         for (ssize_t elemOffset = 0; elemOffset < channelCount; elemOffset += loopCount) {
           ssize_t chunkOffset;
           if (channelCount - elemOffset < loopCount) chunkCount = lastChunkCount;
@@ -687,9 +683,10 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS_TREE, NCCL_PROTO_
       // Coverity reports that the callee treats &treeUp as an array.  However, due to the use of
       // FanAsymmetric<1, 3>, only the first element is ever accessed, so it's fine.
       // coverity[callee_ptr_arith:FALSE]
-      Primitives<T, RedOp, FanAsymmetric<1, 3>, /*Direct=*/1, Proto, 0>
-        prims(tid - tidEndReduce, nThreadsBcast, &treeUp, treeDown, NULL, NULL,
-          work->redOpArg, 3 * Proto::MaxGroupWidth, 0, 0, work);
+      Primitives<T, RedOp, FanAsymmetric<1, 3>, /*Direct=*/1, Proto, 0> prims(tid - tidEndReduce, nThreadsBcast,
+                                                                              &treeUp, treeDown, NULL, NULL,
+                                                                              work->redOpArg, 3 * Proto::MaxGroupWidth,
+                                                                              0, 0, work);
       for (ssize_t elemOffset = 0; elemOffset < channelCount; elemOffset += loopCount) {
         ssize_t chunkOffset;
         if (channelCount - elemOffset < loopCount) chunkCount = lastChunkCount;
@@ -702,18 +699,18 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_NVLS_TREE, NCCL_PROTO_
   }
 };
 
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_COLLNET_CHAIN, NCCL_PROTO_SIMPLE> {
   __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
     const int bid = ncclShmem.channelId - work->channelLo;
     const int nChannels = work->channelHi - work->channelLo + 1;
-    ncclTree *tree = &ncclShmem.channel.collnetChain;
+    ncclTree* tree = &ncclShmem.channel.collnetChain;
     ssize_t chunkSize = work->collnet.chunkCount;
-    const ssize_t loopSize = int(nChannels*chunkSize);
+    const ssize_t loopSize = int(nChannels * chunkSize);
     const int nranks = ncclShmem.comm.nRanks;
     const ssize_t size = work->collnet.count;
 
-    int nthreadsSplit = nthreads/2;
+    int nthreadsSplit = nthreads / 2;
     if (nthreadsSplit >= 256) nthreadsSplit += 64;
 
     int group, connIndex, send, recv, groupTid, groupNthreads;
@@ -733,7 +730,7 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_COLLNET_CHAIN, NCCL_PR
       recv = tree->up;
       send = tree->down[0];
       groupTid = tid - nthreadsSplit;
-      groupNthreads = nthreads-nthreadsSplit;
+      groupNthreads = nthreads - nthreadsSplit;
     }
 
     if (tid < nthreadsSplit) {
@@ -744,9 +741,9 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_COLLNET_CHAIN, NCCL_PR
           }
           __syncwarp();
         } else {
-          Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0>
-            prims(groupTid, groupNthreads, &recv, &send, work->sendbuff, work->recvbuff,
-              work->redOpArg, group * Proto::MaxGroupWidth, connIndex, connIndex, work);
+          Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0> prims(
+            groupTid, groupNthreads, &recv, &send, work->sendbuff, work->recvbuff, work->redOpArg,
+            group * Proto::MaxGroupWidth, connIndex, connIndex, work);
           for (ssize_t gridOffset = 0; gridOffset < size; gridOffset += loopSize) {
             ssize_t offset = gridOffset + bid * int(chunkSize);
             int nelem = min(chunkSize, size - offset);
@@ -756,9 +753,9 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_COLLNET_CHAIN, NCCL_PR
           // coverity[overrun-call] => Coverity think prims.index can be greater than 1
         }
       } else {
-        Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0>
-          prims(groupTid, groupNthreads, &recv, &send, work->sendbuff, work->recvbuff,
-            work->redOpArg, group * Proto::MaxGroupWidth, connIndex, connIndex, work);
+        Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0> prims(
+          groupTid, groupNthreads, &recv, &send, work->sendbuff, work->recvbuff, work->redOpArg,
+          group * Proto::MaxGroupWidth, connIndex, connIndex, work);
         for (ssize_t gridOffset = 0; gridOffset < size; gridOffset += loopSize) {
           ssize_t offset = gridOffset + bid * int(chunkSize);
           int nelem = min(chunkSize, size - offset);
@@ -767,8 +764,7 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_COLLNET_CHAIN, NCCL_PR
         }
         // coverity[overrun-call] => Coverity think prims.index can be greater than 1
       }
-    }
-    else {
+    } else {
       if (recv == nranks) {
         // I'm the first in the broadcast chain, I need to perform the division (postOp)
         if (send == -1) {
@@ -781,45 +777,45 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_COLLNET_CHAIN, NCCL_PR
             // Coverity reports that the callee treats &send as an array.  However, due to the use of
             // FanSymmetric<1>, only the first element is ever accessed, so it's fine.
             // coverity[callee_ptr_arith:FALSE]
-            Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0>
-              prims(groupTid, groupNthreads, &recv, &send, work->sendbuff, work->recvbuff,
-                work->redOpArg, group * Proto::MaxGroupWidth, connIndex, connIndex, work);
+            Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0> prims(
+              groupTid, groupNthreads, &recv, &send, work->sendbuff, work->recvbuff, work->redOpArg,
+              group * Proto::MaxGroupWidth, connIndex, connIndex, work);
             for (ssize_t gridOffset = 0; gridOffset < size; gridOffset += loopSize) {
               ssize_t offset = gridOffset + bid * int(chunkSize);
               int nelem = min(chunkSize, size - offset);
-              prims.directRecv(offset, nelem, /*postOp*/true);
+              prims.directRecv(offset, nelem, /*postOp*/ true);
             }
           }
         } else {
           // Coverity reports that the callee treats &send as an array.  However, due to the use of
           // FanSymmetric<1>, only the first element is ever accessed, so it's fine.
           // coverity[callee_ptr_arith:FALSE]
-          Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0>
-            prims(groupTid, groupNthreads, &recv, &send, work->sendbuff, work->recvbuff,
-              work->redOpArg, group * Proto::MaxGroupWidth, connIndex, connIndex, work);
+          Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0> prims(
+            groupTid, groupNthreads, &recv, &send, work->sendbuff, work->recvbuff, work->redOpArg,
+            group * Proto::MaxGroupWidth, connIndex, connIndex, work);
           for (ssize_t gridOffset = 0; gridOffset < size; gridOffset += loopSize) {
             ssize_t offset = gridOffset + bid * int(chunkSize);
             int nelem = min(chunkSize, size - offset);
-            prims.directRecvCopyDirectSend(offset, offset, nelem, /*postOp*/true);
+            prims.directRecvCopyDirectSend(offset, offset, nelem, /*postOp*/ true);
           }
         }
       } else {
         // Coverity reports that the callee treats &send as an array.  However, due to the use of
         // FanSymmetric<1>, only the first element is ever accessed, so it's fine.
         // coverity[callee_ptr_arith:FALSE]
-        Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0>
-          prims(groupTid, groupNthreads, &recv, &send, work->sendbuff, work->recvbuff,
-            work->redOpArg, group * Proto::MaxGroupWidth, connIndex, connIndex, work);
+        Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0> prims(
+          groupTid, groupNthreads, &recv, &send, work->sendbuff, work->recvbuff, work->redOpArg,
+          group * Proto::MaxGroupWidth, connIndex, connIndex, work);
         if (send == -1) {
           for (ssize_t gridOffset = 0; gridOffset < size; gridOffset += loopSize) {
-            ssize_t offset = gridOffset + bid*int(chunkSize);
-            int nelem = min(chunkSize, size-offset);
+            ssize_t offset = gridOffset + bid * int(chunkSize);
+            int nelem = min(chunkSize, size - offset);
             prims.directRecv(offset, nelem);
           }
         } else {
           for (ssize_t gridOffset = 0; gridOffset < size; gridOffset += loopSize) {
-            ssize_t offset = gridOffset + bid*int(chunkSize);
-            int nelem = min(chunkSize, size-offset);
+            ssize_t offset = gridOffset + bid * int(chunkSize);
+            int nelem = min(chunkSize, size - offset);
             prims.directRecvCopyDirectSend(offset, offset, nelem);
           }
         }
@@ -828,28 +824,28 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_COLLNET_CHAIN, NCCL_PR
   }
 };
 
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL> {
   __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
     runRing<T, RedOp, ProtoLL, RCCL_METADATA_EMPTY>(tid, nthreads, work);
   }
 };
 
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_TREE, NCCL_PROTO_LL> {
   __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
     runTreeSplit<T, RedOp, ProtoLL>(tid, nthreads, work);
   }
 };
 
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL128> {
   __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
     runRing<T, RedOp, ProtoLL128, RCCL_METADATA_EMPTY>(tid, nthreads, work);
   }
 };
 
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_TREE, NCCL_PROTO_LL128> {
   __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
     runTreeSplit<T, RedOp, ProtoLL128>(tid, nthreads, work);

--- a/projects/rccl/src/device/alltoall_gda.h
+++ b/projects/rccl/src/device/alltoall_gda.h
@@ -11,23 +11,20 @@
 #ifdef ENABLE_ROCSHMEM
 #include <rocshmem/rocshmem.hpp>
 
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAlltoAllGda, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPLE> {
   __device__ __forceinline__ void run(int tid, int nThreads, struct ncclDevWorkColl* work) {
     if (blockIdx.x == 0) {
-        int num_pes = rocshmem::rocshmem_n_pes();
+      int num_pes = rocshmem::rocshmem_n_pes();
 
-        reduceCopy<COLL_UNROLL, USE_ACC, RedOp, T, 0,1, 1, 0, 1, 1, 0>(
-            tid, nThreads, 0, false, 1, (void **)&work->sendbuff, 1, (void **)&work->sndbuff, 
-            (work->size*num_pes));
+      reduceCopy<COLL_UNROLL, USE_ACC, RedOp, T, 0, 1, 1, 0, 1, 1, 0>(
+        tid, nThreads, 0, false, 1, (void**)&work->sendbuff, 1, (void**)&work->sndbuff, (work->size * num_pes));
 
-        rocshmem::rocshmem_char_alltoall_wg(work->team, ((char*)work->tempbuff), ((char*)work->sndbuff), work->size);
+      rocshmem::rocshmem_char_alltoall_wg(work->team, ((char*)work->tempbuff), ((char*)work->sndbuff), work->size);
 
-        reduceCopy<COLL_UNROLL, USE_ACC, RedOp, T, 0,1, 1, 0, 1, 1, 0>(
-            tid, nThreads, 0, false, 1, (void **)&work->tempbuff, 1, (void **)&work->recvbuff, 
-            (work->size*num_pes));
-        }
+      reduceCopy<COLL_UNROLL, USE_ACC, RedOp, T, 0, 1, 1, 0, 1, 1, 0>(
+        tid, nThreads, 0, false, 1, (void**)&work->tempbuff, 1, (void**)&work->recvbuff, (work->size * num_pes));
+    }
   }
 };
 #endif
-

--- a/projects/rccl/src/device/alltoall_pivot.h
+++ b/projects/rccl/src/device/alltoall_pivot.h
@@ -9,75 +9,73 @@
 #include "primitives.h"
 
 namespace {
-  template<typename T, typename RedOp, typename Proto>
+template <typename T, typename RedOp, typename Proto>
 #if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
-  __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
+__device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
 #else
-  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
+__device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
 #endif
-    const int bid = ncclShmem.channelId - work->channelLo;
-    const int nranks = ncclShmem.comm.nRanks;
-    size_t count, partOffset, partCount, chunkCount;
-    ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &count, &partOffset, &partCount, &chunkCount);
+  const int bid = ncclShmem.channelId - work->channelLo;
+  const int nranks = ncclShmem.comm.nRanks;
+  size_t count, partOffset, partCount, chunkCount;
+  ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &count, &partOffset, &partCount, &chunkCount);
 
-    const ncclRing *ring = &ncclShmem.channel.ring;
-    const int num_bi_rings = work->pivotA2ANumBiRings;
-    const int num_uni_rings = num_bi_rings * 2;
-    const int num_chunks = (work->channelHi - work->channelLo + 1) / 2;
-    const int chunk_id = (bid % num_bi_rings) + (bid / num_uni_rings * num_bi_rings);
-    const int elem_size = min(256, count & (~(count) + 1));
-    const ssize_t num_elems = count / elem_size;
-    const int num_padding_chunks = num_elems % num_chunks;
-    const ssize_t chunk_offset = elem_size * (num_elems / num_chunks * chunk_id + (chunk_id < num_padding_chunks ? chunk_id : num_padding_chunks));
-    const ssize_t chunk_size = elem_size * (num_elems / num_chunks + (chunk_id < num_padding_chunks ? 1 : 0));
-    const int pivot_direction = (bid % num_uni_rings) / num_bi_rings;
-    const ssize_t prims_size = chunkCount;
+  const ncclRing* ring = &ncclShmem.channel.ring;
+  const int num_bi_rings = work->pivotA2ANumBiRings;
+  const int num_uni_rings = num_bi_rings * 2;
+  const int num_chunks = (work->channelHi - work->channelLo + 1) / 2;
+  const int chunk_id = (bid % num_bi_rings) + (bid / num_uni_rings * num_bi_rings);
+  const int elem_size = min(256, count & (~(count) + 1));
+  const ssize_t num_elems = count / elem_size;
+  const int num_padding_chunks = num_elems % num_chunks;
+  const ssize_t chunk_offset =
+    elem_size * (num_elems / num_chunks * chunk_id + (chunk_id < num_padding_chunks ? chunk_id : num_padding_chunks));
+  const ssize_t chunk_size = elem_size * (num_elems / num_chunks + (chunk_id < num_padding_chunks ? 1 : 0));
+  const int pivot_direction = (bid % num_uni_rings) / num_bi_rings;
+  const ssize_t prims_size = chunkCount;
 
-    Primitives<T, RedOp, FanSymmetric<1>, 0, Proto, 0> prims
-      (tid, nthreads, &ring->prev, &ring->next, work->sendbuff, work->recvbuff, /*redOpArg(ignored)=*/0);
+  Primitives<T, RedOp, FanSymmetric<1>, 0, Proto, 0> prims(tid, nthreads, &ring->prev, &ring->next, work->sendbuff,
+                                                           work->recvbuff, /*redOpArg(ignored)=*/0);
 
-    for (int num_hops = 0; num_hops <= nranks / 2; num_hops++) {
-      const int src_rank = ring->userRanks[(nranks - num_hops) % nranks];
-      const int dst_rank = ring->userRanks[num_hops];
-      const ssize_t send_offset =
-          dst_rank * count + chunk_offset +
-          (src_rank == dst_rank ? pivot_direction * chunk_size / 2 : 0);
-      const ssize_t recv_offset =
-          src_rank * count + chunk_offset +
-          (src_rank == dst_rank ? pivot_direction * chunk_size / 2 : 0);
-      const ssize_t send_recv_size =
-          src_rank == dst_rank ?
-          (pivot_direction == 0 ? chunk_size / 2 : chunk_size - chunk_size / 2) : chunk_size;
+  for (int num_hops = 0; num_hops <= nranks / 2; num_hops++) {
+    const int src_rank = ring->userRanks[(nranks - num_hops) % nranks];
+    const int dst_rank = ring->userRanks[num_hops];
+    const ssize_t send_offset =
+      dst_rank * count + chunk_offset + (src_rank == dst_rank ? pivot_direction * chunk_size / 2 : 0);
+    const ssize_t recv_offset =
+      src_rank * count + chunk_offset + (src_rank == dst_rank ? pivot_direction * chunk_size / 2 : 0);
+    const ssize_t send_recv_size =
+      src_rank == dst_rank ? (pivot_direction == 0 ? chunk_size / 2 : chunk_size - chunk_size / 2) : chunk_size;
 
-      if (num_hops == 0 && work->sendbuff != work->recvbuff) {
-        const T* sendbuff = (const T*)work->sendbuff + send_offset;
-        T* recvbuff = (T *)work->recvbuff + recv_offset;
-        reduceCopy<COLL_UNROLL, USE_ACC, RedOp, T, 0,1, 1, 0, 1, 1, 0>(
-            tid, nthreads, 0, false, 1, (void **)&sendbuff, 1, (void **)&recvbuff, send_recv_size);
-      } else {
-        for (ssize_t prims_offset = 0; prims_offset < send_recv_size; prims_offset += prims_size) {
-          const int prims_nelem = min(prims_size, send_recv_size - prims_offset);
+    if (num_hops == 0 && work->sendbuff != work->recvbuff) {
+      const T* sendbuff = (const T*)work->sendbuff + send_offset;
+      T* recvbuff = (T*)work->recvbuff + recv_offset;
+      reduceCopy<COLL_UNROLL, USE_ACC, RedOp, T, 0, 1, 1, 0, 1, 1, 0>(tid, nthreads, 0, false, 1, (void**)&sendbuff, 1,
+                                                                      (void**)&recvbuff, send_recv_size);
+    } else {
+      for (ssize_t prims_offset = 0; prims_offset < send_recv_size; prims_offset += prims_size) {
+        const int prims_nelem = min(prims_size, send_recv_size - prims_offset);
 
           // step 0: send
-          prims.send(send_offset + prims_offset, prims_nelem);
+        prims.send(send_offset + prims_offset, prims_nelem);
 
           // num_hops - 1 steps: recv and copy to next gpu
-          for (int i = 0; i < num_hops - 1; i++) {
-            prims.recvSend(prims_nelem);
-          }
+        for (int i = 0; i < num_hops - 1; i++) {
+          prims.recvSend(prims_nelem);
+        }
 
           // final step: recv
-          prims.directRecv(recv_offset + prims_offset, recv_offset + prims_offset, prims_nelem);
-        }
+        prims.directRecv(recv_offset + prims_offset, recv_offset + prims_offset, prims_nelem);
       }
     }
   }
 }
+} // namespace
 
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAlltoAllPivot, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPLE> {
   __device__ __forceinline__ void run(int tid, int nThreads, struct ncclDevWorkColl* work) {
-    using Proto = ProtoSimple<ALLTOALL_PIVOT_CHUNKSTEPS/ALLTOALL_PIVOT_SLICESTEPS, ALLTOALL_PIVOT_SLICESTEPS>;
+    using Proto = ProtoSimple<ALLTOALL_PIVOT_CHUNKSTEPS / ALLTOALL_PIVOT_SLICESTEPS, ALLTOALL_PIVOT_SLICESTEPS>;
     runRing<T, RedOp, Proto>(tid, nThreads, work);
   }
 };

--- a/projects/rccl/src/device/alltoallv_gda.h
+++ b/projects/rccl/src/device/alltoallv_gda.h
@@ -11,37 +11,33 @@
 #ifdef ENABLE_ROCSHMEM
 #include <rocshmem/rocshmem.hpp>
 
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAlltoAllvGda, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPLE> {
   __device__ __forceinline__ void run(int tid, int nThreads, struct ncclDevWorkColl* work) {
-        int num_pes = rocshmem::rocshmem_n_pes();
+    int num_pes = rocshmem::rocshmem_n_pes();
 
-	if (blockIdx.x == 0) {
-        if (work->size <= 131072) {
-           void *src = (T*)work->sendbuff;
-           void *dst = (T*)work->sndbuff;
-           reduceCopy<COLL_UNROLL, USE_ACC, RedOp, T, 0,1, 1, 0, 1, 1, 0>(
-            	tid, nThreads, 0, false, 1, (void **)&src, 1, (void **)&dst,
-            	work->size);
-        }		   
-	   work->sendSizes = (size_t*)work->sizes;
-	   work->sendDispls = (size_t*)work->sizes + num_pes;
-       work->recvSizes = (size_t*)work->sizes + 2 * num_pes;
-       work->recvDispls = (size_t*)work->sizes + 3 * num_pes;
+    if (blockIdx.x == 0) {
+      if (work->size <= 131072) {
+        void* src = (T*)work->sendbuff;
+        void* dst = (T*)work->sndbuff;
+        reduceCopy<COLL_UNROLL, USE_ACC, RedOp, T, 0, 1, 1, 0, 1, 1, 0>(tid, nThreads, 0, false, 1, (void**)&src, 1,
+                                                                        (void**)&dst, work->size);
+      }
+      work->sendSizes = (size_t*)work->sizes;
+      work->sendDispls = (size_t*)work->sizes + num_pes;
+      work->recvSizes = (size_t*)work->sizes + 2 * num_pes;
+      work->recvDispls = (size_t*)work->sizes + 3 * num_pes;
 
-       rocshmem::rocshmem_char_alltoallv_wg(work->team, (char*)work->tempbuff, work->recvSizes, work->recvDispls, 
-			(char*)work->sndbuff, work->sendSizes, work->sendDispls);
+      rocshmem::rocshmem_char_alltoallv_wg(work->team, (char*)work->tempbuff, work->recvSizes, work->recvDispls,
+                                           (char*)work->sndbuff, work->sendSizes, work->sendDispls);
 
-	   if (work->size <= 131072) {
-           void *srcR = (T*)work->tempbuff;
-           void *dstR = (T*)work->recvbuff;
-           reduceCopy<COLL_UNROLL, USE_ACC, RedOp, T, 0,1, 1, 0, 1, 1, 0>(
-            	tid, nThreads, 0, false, 1, (void **)&srcR, 1, (void **)&dstR,
-            	work->size);
-       }
-
-	}
- }
+      if (work->size <= 131072) {
+        void* srcR = (T*)work->tempbuff;
+        void* dstR = (T*)work->recvbuff;
+        reduceCopy<COLL_UNROLL, USE_ACC, RedOp, T, 0, 1, 1, 0, 1, 1, 0>(tid, nThreads, 0, false, 1, (void**)&srcR, 1,
+                                                                        (void**)&dstR, work->size);
+      }
+    }
+  }
 };
 #endif
-

--- a/projects/rccl/src/device/broadcast.h
+++ b/projects/rccl/src/device/broadcast.h
@@ -10,92 +10,93 @@
 #include "primitives.h"
 
 namespace {
-  template<typename T, typename RedOp, typename Proto>
+template <typename T, typename RedOp, typename Proto>
 #if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
-  __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
+__device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
 #else
-  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
+__device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
 #endif
 #ifdef ENABLE_WARP_SPEED
-    int warp = threadIdx.x / WARP_SIZE;
-    ncclRing *ring = ncclShmem.warpComm
-        ? &ncclShmem.warpChannel[warp].ring
-        : &ncclShmem.channel.ring;
+  int warp = threadIdx.x / WARP_SIZE;
+  ncclRing* ring = ncclShmem.warpComm ? &ncclShmem.warpChannel[warp].ring : &ncclShmem.channel.ring;
 #else
-    ncclRing *ring = &ncclShmem.channel.ring;
+  ncclRing* ring = &ncclShmem.channel.ring;
 #endif
-    const int rank = ring->userRanks[0];
-    const int nextRank = ring->userRanks[1];
-    const int root = work->root;
-    ssize_t size;
-    ssize_t chunkCount;
-    ssize_t channelCount;
-    ssize_t gridOffset;
+  const int rank = ring->userRanks[0];
+  const int nextRank = ring->userRanks[1];
+  const int root = work->root;
+  ssize_t size;
+  ssize_t chunkCount;
+  ssize_t channelCount;
+  ssize_t gridOffset;
 #ifdef ENABLE_WARP_SPEED
-    ncclCollCbdPart(work, ncclShmem.warpChannelId[warp], Proto::Id, sizeof(T), &size, &gridOffset, &channelCount, &chunkCount);
+  ncclCollCbdPart(work, ncclShmem.warpChannelId[warp], Proto::Id, sizeof(T), &size, &gridOffset, &channelCount,
+                  &chunkCount);
 #else
-    ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &size, &gridOffset, &channelCount, &chunkCount);
+  ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &size, &gridOffset, &channelCount, &chunkCount);
 #endif
-    size_t offset;
-    int nelem;
-    int workNthreads;
-    bool isNetOffload = work->isOneRPN && work->netRegUsed;
+  size_t offset;
+  int nelem;
+  int workNthreads;
+  bool isNetOffload = work->isOneRPN && work->netRegUsed;
 
-    T *inputBuf = (T*)work->sendbuff;
-    T *outputBuf = (T*)work->recvbuff;
-    workNthreads = isNetOffload ? WARP_SIZE : nthreads;
+  T* inputBuf = (T*)work->sendbuff;
+  T* outputBuf = (T*)work->recvbuff;
+  workNthreads = isNetOffload ? WARP_SIZE : nthreads;
 
-    if (tid < workNthreads) {
+  if (tid < workNthreads) {
       // Coverity reports that the callee treats &ring->next as an array.  However, due to the use of
       // FanSymmetric<1>, only the first element is ever accessed, so it's fine.
       // coverity[callee_ptr_arith:FALSE]
-      Primitives<T, RedOp, FanSymmetric<1>, 1, Proto, 0>
-        prims(tid, workNthreads, &ring->prev, &ring->next, inputBuf, outputBuf, work->redOpArg, 0, work->connIndex, work->connIndex, work);
+    Primitives<T, RedOp, FanSymmetric<1>, 1, Proto, 0> prims(tid, workNthreads, &ring->prev, &ring->next, inputBuf,
+                                                             outputBuf, work->redOpArg, 0, work->connIndex,
+                                                             work->connIndex, work);
 
-      for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
-        offset = gridOffset + elemOffset;
-        nelem = min(chunkCount, channelCount - elemOffset);
+    for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
+      offset = gridOffset + elemOffset;
+      nelem = min(chunkCount, channelCount - elemOffset);
 
-        if (rank == root) {
-          if (inputBuf == outputBuf || isNetOffload) {
-            prims.directSend(offset, offset, nelem);
-          } else {
-            prims.directCopySend(offset, offset, nelem);
-          }
-        } else if (nextRank == root) {
-          prims.directRecv(offset, nelem);
+      if (rank == root) {
+        if (inputBuf == outputBuf || isNetOffload) {
+          prims.directSend(offset, offset, nelem);
         } else {
-          prims.directRecvCopyDirectSend(offset, offset, nelem);
+          prims.directCopySend(offset, offset, nelem);
         }
+      } else if (nextRank == root) {
+        prims.directRecv(offset, nelem);
+      } else {
+        prims.directRecvCopyDirectSend(offset, offset, nelem);
       }
-    } else if (inputBuf != outputBuf && rank == root) {
-      inputBuf = inputBuf + gridOffset;
-      outputBuf = outputBuf + gridOffset;
-      reduceCopy<COLL_UNROLL, 0, RedOp, T, 0, 1, 1, 0, 1, 1, /*PreOpSrcs=*/0>
-        (tid - workNthreads, nthreads - workNthreads, work->redOpArg, false, 1, (void**)&inputBuf, 1, (void**)&outputBuf, channelCount);
     }
-#if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
-    if (isNetOffload) barrier_sync(14, nThreads);
-#endif
+  } else if (inputBuf != outputBuf && rank == root) {
+    inputBuf = inputBuf + gridOffset;
+    outputBuf = outputBuf + gridOffset;
+    reduceCopy<COLL_UNROLL, 0, RedOp, T, 0, 1, 1, 0, 1, 1, /*PreOpSrcs=*/0>(tid - workNthreads, nthreads - workNthreads,
+                                                                            work->redOpArg, false, 1, (void**)&inputBuf,
+                                                                            1, (void**)&outputBuf, channelCount);
   }
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
+  if (isNetOffload) barrier_sync(14, nThreads);
+#endif
 }
+} // namespace
 
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkColl<ncclFuncBroadcast, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPLE> {
   __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
-    using Proto = ProtoSimple<BROADCAST_CHUNKSTEPS/BROADCAST_SLICESTEPS, BROADCAST_SLICESTEPS>;
+    using Proto = ProtoSimple<BROADCAST_CHUNKSTEPS / BROADCAST_SLICESTEPS, BROADCAST_SLICESTEPS>;
     runRing<T, RedOp, Proto>(tid, nthreads, work);
   }
 };
 
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkColl<ncclFuncBroadcast, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL> {
   __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
     runRing<T, RedOp, ProtoLL>(tid, nthreads, work);
   }
 };
 
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkColl<ncclFuncBroadcast, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL128> {
   __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
     runRing<T, RedOp, ProtoLL128>(tid, nthreads, work);

--- a/projects/rccl/src/device/common.cu
+++ b/projects/rccl/src/device/common.cu
@@ -11,7 +11,7 @@
 #ifndef RCCL_DEVICE_LINKER
 __shared__ ncclShmemData ncclShmem;
 #if __CUDA_ARCH__ < 700
-  __shared__ ulong2 ncclShmemPerWarp[ncclShmemScratchWarpSize()*(NCCL_MAX_NTHREADS/WARP_SIZE)/sizeof(ulong2)];
+__shared__ ulong2 ncclShmemPerWarp[ncclShmemScratchWarpSize() * (NCCL_MAX_NTHREADS / WARP_SIZE) / sizeof(ulong2)];
 #endif
 #endif
 
@@ -19,14 +19,17 @@ struct RunWorkNop {
   __device__ void run() {}
 };
 
-__launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__ void ncclDevKernel_Generic_1(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
-  ncclKernelMain<-1, RunWorkNop, /*Unroll*/1>(&argsStorage.args);
+__launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__
+  void ncclDevKernel_Generic_1(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
+  ncclKernelMain<-1, RunWorkNop, /*Unroll*/ 1>(&argsStorage.args);
 }
-__launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__ void ncclDevKernel_Generic_2(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
-  ncclKernelMain<-1, RunWorkNop, /*Unroll*/2>(&argsStorage.args);
+__launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__
+  void ncclDevKernel_Generic_2(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
+  ncclKernelMain<-1, RunWorkNop, /*Unroll*/ 2>(&argsStorage.args);
 }
-__launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__ void ncclDevKernel_Generic_4(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
-  ncclKernelMain<-1, RunWorkNop, /*Unroll*/4>(&argsStorage.args);
+__launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__
+  void ncclDevKernel_Generic_4(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
+  ncclKernelMain<-1, RunWorkNop, /*Unroll*/ 4>(&argsStorage.args);
 }
 
 #if defined(USE_INDIRECT_FUNCTION_CALL) || defined(RCCL_DEVICE_LINKER)

--- a/projects/rccl/src/device/common.h
+++ b/projects/rccl/src/device/common.h
@@ -14,19 +14,26 @@
 #include "reduce_kernel.h"
 #include "device_table.h"
 #include "network/unpack/unpack_defs.h"
-#define NCCL_MAX_DEV_ARITY (NCCL_MAX_TREE_ARITY-1)  // Using balanced tree instead of split tree
+#define NCCL_MAX_DEV_ARITY (NCCL_MAX_TREE_ARITY - 1)  // Using balanced tree instead of split tree
 
 #define __syncwarp()
 
 #if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
 #define STORE(DST, SRC) \
-  { __hip_atomic_store((__attribute__((address_space(1))) __typeof__(*(DST)) *)(DST), (SRC), __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM); }
+  { \
+    __hip_atomic_store((__attribute__((address_space(1))) __typeof__(*(DST))*)(DST), (SRC), __ATOMIC_RELAXED, \
+                       __HIP_MEMORY_SCOPE_SYSTEM); \
+  }
 #elif defined(__GFX9__)
 #define STORE(DST, SRC) \
-  { __atomic_store_n((DST), (SRC), __ATOMIC_RELAXED); }
+  { \
+    __atomic_store_n((DST), (SRC), __ATOMIC_RELAXED); \
+  }
 #else
 #define STORE(DST, SRC) \
-  { __atomic_store_n((DST), (SRC), __ATOMIC_SEQ_CST); }
+  { \
+    __atomic_store_n((DST), (SRC), __ATOMIC_SEQ_CST); \
+  }
 #endif
 
 #define traceKernelLaunch(launch_type, batchIx)
@@ -42,19 +49,19 @@
 #endif
 
 struct ncclShmemGroup {
-  ncclConnInfo *recvConns[NCCL_MAX_ARITY];
-  ncclConnInfo *sendConns[NCCL_MAX_ARITY];
+  ncclConnInfo* recvConns[NCCL_MAX_ARITY];
+  ncclConnInfo* sendConns[NCCL_MAX_ARITY];
   void* userInput;
   void* userOutput;
   void* userAcc;
-  void* srcs[NCCL_MAX_ARITY+1];
-  void* dsts[NCCL_MAX_ARITY+1];
+  void* srcs[NCCL_MAX_ARITY + 1];
+  void* dsts[NCCL_MAX_ARITY + 1];
   void* acc;
   uint64_t barrier;
   union {
     unpackGroupShmem unpack;
   } devicePlugin;
-  int32_t dstSizes[NCCL_MAX_ARITY+1];
+  int32_t dstSizes[NCCL_MAX_ARITY + 1];
   uint64_t redOpArgs;
 };
 
@@ -92,85 +99,90 @@ struct ncclShmemData {
 
 #ifdef RCCL_DEVICE_LINKER
 __shared__ ncclShmemData ncclShmem;
-__shared__ ulong2 ncclShmemPerWarp[ncclShmemScratchWarpSize()*(NCCL_MAX_NTHREADS/WARP_SIZE)/sizeof(ulong2)];
+__shared__ ulong2 ncclShmemPerWarp[ncclShmemScratchWarpSize() * (NCCL_MAX_NTHREADS / WARP_SIZE) / sizeof(ulong2)];
 #else
 extern __shared__ ncclShmemData ncclShmem;
 #if __CUDA_ARCH__ >= 700
-  extern __shared__ ulong2 ncclShmemPerWarp[/*ncclShmemDynamicSize()/sizeof(ulong2)*/];
+extern __shared__ ulong2 ncclShmemPerWarp[/*ncclShmemDynamicSize()/sizeof(ulong2)*/];
 #else
-  extern __shared__ ulong2 ncclShmemPerWarp[ncclShmemScratchWarpSize()*(NCCL_MAX_NTHREADS/WARP_SIZE)/sizeof(ulong2)];
+extern __shared__ ulong2
+  ncclShmemPerWarp[ncclShmemScratchWarpSize() * (NCCL_MAX_NTHREADS / WARP_SIZE) / sizeof(ulong2)];
 #endif
 #endif
 
 #ifdef ENABLE_FAULT_INJECTION
 __device__ inline void insert_random_delay_per_warp() {
-  if ((ncclShmem.faults & RANDOM_DELAY_ON_WARP_START) && (threadIdx.x%WARP_SIZE == 0)) {
-    switch ((wall_clock64()>>(threadIdx.x/WARP_SIZE*2))&0x3) {
-      case 0:
-        __builtin_amdgcn_s_sleep(0);
-        break;
-      case 1:
-        __builtin_amdgcn_s_sleep(8);
-        break;
-      case 2:
-        __builtin_amdgcn_s_sleep(16);
-        break;
-      case 3:
-      default:
-        __builtin_amdgcn_s_sleep(32);
-        break;
+  if ((ncclShmem.faults & RANDOM_DELAY_ON_WARP_START) && (threadIdx.x % WARP_SIZE == 0)) {
+    switch ((wall_clock64() >> (threadIdx.x / WARP_SIZE * 2)) & 0x3) {
+    case 0:
+      __builtin_amdgcn_s_sleep(0);
+      break;
+    case 1:
+      __builtin_amdgcn_s_sleep(8);
+      break;
+    case 2:
+      __builtin_amdgcn_s_sleep(16);
+      break;
+    case 3:
+    default:
+      __builtin_amdgcn_s_sleep(32);
+      break;
     }
   }
 }
 #endif
 
 __device__ inline void* ncclScratchForWarp(int warp) {
-  return (char*)ncclShmemPerWarp + warp*ncclShmemScratchWarpSize();
+  return (char*)ncclShmemPerWarp + warp * ncclShmemScratchWarpSize();
 }
 
 __device__ inline void barrier_sync(int name) {
-  #if 0
+#if 0
   asm volatile("barrier.sync %0;" :: "r"(name) : "memory");
-  #else
-  asm volatile("barrier.sync.aligned %0;" :: "r"(name) : "memory");
-  #endif
+#else
+  asm volatile("barrier.sync.aligned %0;" ::"r"(name) : "memory");
+#endif
 }
 __device__ inline void barrier_sync(int name, int nThreads) {
-  #if 0
+#if 0
   asm volatile("barrier.sync %0, %1;" :: "r"(name), "r"(nThreads) : "memory");
-  #else
-  asm volatile("barrier.sync.aligned %0, %1;" :: "r"(name), "r"(nThreads) : "memory");
-  #endif
+#else
+  asm volatile("barrier.sync.aligned %0, %1;" ::"r"(name), "r"(nThreads) : "memory");
+#endif
 }
 __device__ inline void barrier_sync_aligned(int name) {
-  asm volatile("barrier.sync.aligned %0;" :: "r"(name) : "memory");
+  asm volatile("barrier.sync.aligned %0;" ::"r"(name) : "memory");
 }
 __device__ inline void barrier_sync_aligned(int name, int nThreads) {
-  asm volatile("barrier.sync.aligned %0, %1;" :: "r"(name), "r"(nThreads) : "memory");
+  asm volatile("barrier.sync.aligned %0, %1;" ::"r"(name), "r"(nThreads) : "memory");
 }
 
 __device__ inline bool barrier_red_or(bool vote, int name) {
   int ans;
   asm volatile("{ .reg .pred p;"
-      "  setp.ne.s32 p, %1, 0;"
-      "  barrier.red.or.pred p, %2, p; "
-      "  selp.s32 %0, 1, 0, p; }"
-      : "=r"(ans) : "r"((int)vote), "r"(name) : "memory");
+               "  setp.ne.s32 p, %1, 0;"
+               "  barrier.red.or.pred p, %2, p; "
+               "  selp.s32 %0, 1, 0, p; }"
+               : "=r"(ans)
+               : "r"((int)vote), "r"(name)
+               : "memory");
   return bool(ans);
 }
 __device__ inline bool barrier_red_or(bool vote, int name, int nThreads) {
   int ans;
   asm volatile("{ .reg .pred p;"
-      "  setp.ne.s32 p, %1, 0;"
-      "  barrier.red.or.pred p, %2, %3, p; "
-      "  selp.s32 %0, 1, 0, p; }"
-      : "=r"(ans) : "r"((int)vote), "r"(name), "r"(nThreads) : "memory");
+               "  setp.ne.s32 p, %1, 0;"
+               "  barrier.red.or.pred p, %2, %3, p; "
+               "  selp.s32 %0, 1, 0, p; }"
+               : "=r"(ans)
+               : "r"((int)vote), "r"(name), "r"(nThreads)
+               : "memory");
   return bool(ans);
 }
 
 // Copy 16-byte aligned data. You must call with at least `(bytes+15)/16` threads.
 inline __device__ void copyToShmem16(int tid, void* dst, void const* src, int bytes) {
-  int offset = 16*tid;
+  int offset = 16 * tid;
   if (offset < bytes) {
     ulong2 *src2, *dst2;
     src2 = (ulong2*)((char const*)src + offset);
@@ -181,41 +193,40 @@ inline __device__ void copyToShmem16(int tid, void* dst, void const* src, int by
 }
 
 // Must run with at least 64 threads
-__device__ __forceinline__ void loadWorkBatchToShmem(
-    int tid, int tn, struct ncclDevKernelArgs const* args, int batchIx
-  ) {
-  int lane = tid%WARP_SIZE;
+__device__ __forceinline__ void loadWorkBatchToShmem(int tid, int tn, struct ncclDevKernelArgs const* args,
+                                                     int batchIx) {
+  int lane = tid % WARP_SIZE;
   int workCursor = 0; // num works written in previous loop iterations.
   while (true) {
-    struct ncclDevWorkBatch batch = ((struct ncclDevWorkBatch*)(args+1))[batchIx];
+    struct ncclDevWorkBatch batch = ((struct ncclDevWorkBatch*)(args + 1))[batchIx];
 
     // fnsOfBitset[n] = index of n'th set bit in batch.offsetBitset.
     // PTX has instruction "fns" (find n-th set) but it expands to a lot of SASS,
     // since we know all lanes will be querying the same bitmask we can compute
     // much faster using shared memory.
-    uint8_t* fnsOfBitset = (uint8_t*)ncclScratchForWarp(threadIdx.x/WARP_SIZE);
+    uint8_t* fnsOfBitset = (uint8_t*)ncclScratchForWarp(threadIdx.x / WARP_SIZE);
     int nWorks = 0;
     __syncwarp();
 
     if (WARP_SIZE == 64) {
-      if (uint64_t(batch.offsetBitset) & (1ull<<lane)) {
-        int nWorksBelow = __popcll(uint64_t(batch.offsetBitset) & ((1ull<<lane)-1));
+      if (uint64_t(batch.offsetBitset) & (1ull << lane)) {
+        int nWorksBelow = __popcll(uint64_t(batch.offsetBitset) & ((1ull << lane) - 1));
         fnsOfBitset[nWorksBelow] = lane;
       }
       nWorks = __popcll(uint64_t(batch.offsetBitset));
     } else {
       // WARP_SIZE == 32
-      if (uint32_t(batch.offsetBitset) & (1u<<lane)) {
-        int nWorksBelow = __popc(uint32_t(batch.offsetBitset) & ((1u<<lane)-1));
+      if (uint32_t(batch.offsetBitset) & (1u << lane)) {
+        int nWorksBelow = __popc(uint32_t(batch.offsetBitset) & ((1u << lane) - 1));
         fnsOfBitset[nWorksBelow] = lane;
       }
       int nWorksLow32 = __popc(uint32_t(batch.offsetBitset)); // just of low 32 bits
-      if (uint32_t(batch.offsetBitset>>32) & (1u<<lane)) {
+      if (uint32_t(batch.offsetBitset >> 32) & (1u << lane)) {
         int nWorksBelow = nWorksLow32;
-        nWorksBelow += __popc(uint32_t(batch.offsetBitset>>32) & ((1u<<lane)-1));
+        nWorksBelow += __popc(uint32_t(batch.offsetBitset >> 32) & ((1u << lane) - 1));
         fnsOfBitset[nWorksBelow] = 32 + lane;
       }
-      nWorks = nWorksLow32 + __popc(uint32_t(batch.offsetBitset>>32)); // add high 32 bits
+      nWorks = nWorksLow32 + __popc(uint32_t(batch.offsetBitset >> 32)); // add high 32 bits
     }
 
     int workSize;
@@ -225,28 +236,28 @@ __device__ __forceinline__ void loadWorkBatchToShmem(
     switch (batch.workType) {
     case (int)ncclDevWorkTypeP2p:
       workSize = sizeof(struct ncclDevWorkP2p);
-      nPacks = nWorks*(workSize/16);
-      packInWork = tid%(workSize/16);
-      dstWork = tid/(workSize/16);
+      nPacks = nWorks * (workSize / 16);
+      packInWork = tid % (workSize / 16);
+      dstWork = tid / (workSize / 16);
       break;
     case (int)ncclDevWorkTypeColl:
       workSize = sizeof(struct ncclDevWorkColl);
-      nPacks = nWorks*(workSize/16);
-      packInWork = tid%(workSize/16);
-      dstWork = tid/(workSize/16);
+      nPacks = nWorks * (workSize / 16);
+      packInWork = tid % (workSize / 16);
+      dstWork = tid / (workSize / 16);
       break;
     case (int)ncclDevWorkTypeBcast:
       workSize = sizeof(struct ncclDevWorkBcast);
-      nPacks = nWorks*(workSize/16);
-      packInWork = tid%(workSize/16);
-      dstWork = tid/(workSize/16);
+      nPacks = nWorks * (workSize / 16);
+      packInWork = tid % (workSize / 16);
+      dstWork = tid / (workSize / 16);
       break;
     case (int)ncclDevWorkTypeCollReg:
     default:
       workSize = sizeof(struct ncclDevWorkCollReg);
-      nPacks = nWorks*(workSize/16);
-      packInWork = tid%(workSize/16);
-      dstWork = tid/(workSize/16);
+      nPacks = nWorks * (workSize / 16);
+      packInWork = tid % (workSize / 16);
+      dstWork = tid / (workSize / 16);
       break;
     }
     if (tid == 0) {
@@ -281,15 +292,16 @@ __device__ __forceinline__ void loadWorkBatchToShmem(
       // }
       // memcpy(dst, src, n);
       if (ncclShmem.args.workStorageType == ncclDevWorkStorageTypeArgs) {
-        char* src = (char*)args + (batch.offsetBase + srcWork*workSize + packInWork*16);
+        char* src = (char*)args + (batch.offsetBase + srcWork * workSize + packInWork * 16);
         tmp = *(ulonglong2*)src; // becomes ld.param.v2.u64
       }
       if (ncclShmem.args.workStorageType != ncclDevWorkStorageTypeArgs) {
-        char* src = (char*)ncclShmem.args.workBuf + ((batch.offsetBase + srcWork*workSize + packInWork*16) & ncclShmem.args.workMask);
+        char* src = (char*)ncclShmem.args.workBuf +
+                    ((batch.offsetBase + srcWork * workSize + packInWork * 16) & ncclShmem.args.workMask);
         tmp = *(ulonglong2*)src; // becomes ld.v2.u64
       }
       char* dst = ncclShmem.workStorage;
-      dst += (workCursor + dstWork)*workSize + packInWork*16;
+      dst += (workCursor + dstWork) * workSize + packInWork * 16;
       *(ulonglong2*)dst = tmp;
     }
     workCursor += nWorks;
@@ -321,25 +333,25 @@ __device__ __forceinline__ unsigned long long int globaltimer() {
 #endif
 }
 
-template<ncclFunc_t Fn, typename T, typename RedOp, int Algo, int Proto, int USE_ACC, int COLL_UNROLL, int Pipeline>
+template <ncclFunc_t Fn, typename T, typename RedOp, int Algo, int Proto, int USE_ACC, int COLL_UNROLL, int Pipeline>
 struct RunWorkColl {
   __device__ void run(int tid, int tn, struct ncclDevWorkColl* work) {
     // Put NOT IMPLEMENTED behavior here.
   }
 };
 
-template<ncclFunc_t Fn, typename T, typename RedOp, int Algo, int Proto, int USE_ACC, int COLL_UNROLL, int Pipeline>
+template <ncclFunc_t Fn, typename T, typename RedOp, int Algo, int Proto, int USE_ACC, int COLL_UNROLL, int Pipeline>
 struct RunWorkBatch;
 
 // Specialized for P2p in sendrecv.h
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPLE>;
 
-template<typename T, typename RedOp, int Proto>
+template <typename T, typename RedOp, int Proto>
 struct RunWorkBatch<ncclFuncAllGatherV, T, RedOp, NCCL_ALGO_RING, Proto>;
 
 // Specialized here for non-P2p (Coll and CollReg)
-template<ncclFunc_t Fn, typename T, typename RedOp, int Algo, int Proto,  int USE_ACC, int COLL_UNROLL, int Pipeline>
+template <ncclFunc_t Fn, typename T, typename RedOp, int Algo, int Proto, int USE_ACC, int COLL_UNROLL, int Pipeline>
 struct RunWorkBatch {
   // This __forceinline__ is necessary. The compiler was inserting a function call
   // here from the LL ncclKernel.
@@ -349,8 +361,8 @@ struct RunWorkBatch {
 
     if (RedOpArg<RedOp>::ArgUsed) {
       int nWorks = ncclShmem.nWorks;
-      for (int w=tid; w < nWorks; w += tn) {
-        struct ncclDevWorkColl* work = (ncclDevWorkColl*)(ncclShmem.workStorage + w*ncclShmem.workSize);
+      for (int w = tid; w < nWorks; w += tn) {
+        struct ncclDevWorkColl* work = (ncclDevWorkColl*)(ncclShmem.workStorage + w * ncclShmem.workSize);
         if (work->redOpArgIsPtr) {
           work->redOpArg = RedOpArg<RedOp>::loadArg(reinterpret_cast<void*>(work->redOpArg));
         }
@@ -358,18 +370,21 @@ struct RunWorkBatch {
       __syncthreads();
     }
 
-    #pragma unroll 1
-    for (int w=0; w < ncclShmem.nWorks; w++) {
-      struct ncclDevWorkColl* work = (struct ncclDevWorkColl*)(ncclShmem.workStorage + w*ncclShmem.workSize);
+#pragma unroll 1
+    for (int w = 0; w < ncclShmem.nWorks; w++) {
+      struct ncclDevWorkColl* work = (struct ncclDevWorkColl*)(ncclShmem.workStorage + w * ncclShmem.workSize);
       if (w != 0) {
-        struct ncclDevWorkColl* workPrev = (struct ncclDevWorkColl*)(ncclShmem.workStorage + (w-1)*ncclShmem.workSize);
+        struct ncclDevWorkColl* workPrev =
+          (struct ncclDevWorkColl*)(ncclShmem.workStorage + (w - 1) * ncclShmem.workSize);
         if (work->nWarps != workPrev->nWarps) __syncthreads();
       }
-      int subtn = work->nWarps*WARP_SIZE;
+      int subtn = work->nWarps * WARP_SIZE;
 #ifdef ENABLE_WARP_SPEED
       if (tid < subtn) {
-        if(ncclShmem.warpComm == 0 || Algo != NCCL_ALGO_RING) RunWorkColl<Fn, T, RedOp, Algo, Proto>().run(tid, subtn, work);
-        else if (ncclShmem.warpChannelId[tid / WARP_SIZE] >= 0) RunWorkColl<Fn, T, RedOp, Algo, Proto>().run(tid % WARP_SIZE, WARP_SIZE, work);
+        if (ncclShmem.warpComm == 0 || Algo != NCCL_ALGO_RING)
+          RunWorkColl<Fn, T, RedOp, Algo, Proto>().run(tid, subtn, work);
+        else if (ncclShmem.warpChannelId[tid / WARP_SIZE] >= 0)
+          RunWorkColl<Fn, T, RedOp, Algo, Proto>().run(tid % WARP_SIZE, WARP_SIZE, work);
       }
 #else
       // Coverity reports a possible thread divergence due to not all threads participating in the collective.
@@ -382,13 +397,13 @@ struct RunWorkBatch {
 };
 
 #define START 0
-#define STOP  1
-#define FINI  2
+#define STOP 1
+#define FINI 2
 
 __device__ __forceinline__ bool profilerEnabled(int workItemIdx) {
   return (ncclShmem.workType == ncclDevWorkTypeP2p) ?
-    ((struct ncclDevWorkP2p*)ncclShmem.workStorage)[workItemIdx].profilerEnabled :
-    ((struct ncclDevWorkColl*)ncclShmem.workStorage)[workItemIdx].profilerEnabled;
+           ((struct ncclDevWorkP2p*)ncclShmem.workStorage)[workItemIdx].profilerEnabled :
+           ((struct ncclDevWorkColl*)ncclShmem.workStorage)[workItemIdx].profilerEnabled;
 }
 
 __device__ __forceinline__ void profiler(int action) {
@@ -398,37 +413,41 @@ __device__ __forceinline__ void profiler(int action) {
     if (action == START) {
       for (; wc <= ncclShmem.channel.workCounter + ncclShmem.nWorks; wc++) {
         if (!profilerEnabled(idx++)) continue;
-        ncclShmem.comm.workStarted[ncclShmem.channelId].data[wc%MAX_PROFILER_EVENTS_PER_CHANNEL].timestamp = globaltimer();
-        ncclShmem.comm.workStarted[ncclShmem.channelId].data[wc%MAX_PROFILER_EVENTS_PER_CHANNEL].counter = wc;
+        ncclShmem.comm.workStarted[ncclShmem.channelId].data[wc % MAX_PROFILER_EVENTS_PER_CHANNEL].timestamp =
+          globaltimer();
+        ncclShmem.comm.workStarted[ncclShmem.channelId].data[wc % MAX_PROFILER_EVENTS_PER_CHANNEL].counter = wc;
       }
     } else {
       for (; wc <= ncclShmem.channel.workCounter + ncclShmem.nWorks; wc++) {
         if (!profilerEnabled(idx++)) continue;
-        ncclShmem.comm.workCompleted[ncclShmem.channelId].data[wc%MAX_PROFILER_EVENTS_PER_CHANNEL].timestamp = globaltimer();
-        ncclShmem.comm.workCompleted[ncclShmem.channelId].data[wc%MAX_PROFILER_EVENTS_PER_CHANNEL].counter = wc;
+        ncclShmem.comm.workCompleted[ncclShmem.channelId].data[wc % MAX_PROFILER_EVENTS_PER_CHANNEL].timestamp =
+          globaltimer();
+        ncclShmem.comm.workCompleted[ncclShmem.channelId].data[wc % MAX_PROFILER_EVENTS_PER_CHANNEL].counter = wc;
       }
       ncclShmem.channel.workCounter += ncclShmem.nWorks;
-      if (action == FINI) ((ncclKernelCommAndChannels*)ncclShmem.args.comm)->channels[ncclShmem.channelId].workCounter = ncclShmem.channel.workCounter;
+      if (action == FINI)
+        ((ncclKernelCommAndChannels*)ncclShmem.args.comm)->channels[ncclShmem.channelId].workCounter =
+          ncclShmem.channel.workCounter;
     }
   }
 }
 
-template<int SpecializedFnId, typename SpecializedRunWorkBatch, int COLL_UNROLL>
+template <int SpecializedFnId, typename SpecializedRunWorkBatch, int COLL_UNROLL>
 __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* args) {
   const int tid = threadIdx.x;
   int tn = blockDim.x;
   int x = tid;
   int total = 0, y;
-  int num = MAXCHANNELS/64 > 0 ? MAXCHANNELS/64 : 1;
+  int num = MAXCHANNELS / 64 > 0 ? MAXCHANNELS / 64 : 1;
 #ifdef ENABLE_WARP_SPEED
-  int warpCount    = tn / WARP_SIZE;
-  int localWarpId  = tid / WARP_SIZE;
+  int warpCount = tn / WARP_SIZE;
+  int localWarpId = tid / WARP_SIZE;
   int globalWarpId = (warpCount * blockIdx.x) + localWarpId;
   int laneId = tid % WARP_SIZE;
 #endif
   // Copy kernel args to shmem and then only read those. Otherwise the compiler
   // will end up putting the args into thread local stack which is very wasteful.
-  if (tid < sizeof(ncclDevKernelArgs)/sizeof(uint32_t)) {
+  if (tid < sizeof(ncclDevKernelArgs) / sizeof(uint32_t)) {
     ((uint32_t*)&ncclShmem.args)[tid] = ((uint32_t*)args)[tid];
   }
 
@@ -436,12 +455,12 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
   // is the inverse of counting the number of set bits among the the first n.
   // PTX has the fns instruction which does this but is extremely slow. We can
   // do better when we know all threads are querying the same bitmask.
-  switch (tid/WARP_SIZE) {
+  switch (tid / WARP_SIZE) {
   case 0:
-  //ncclShmem.channelId = blockIdx.x;
+  // ncclShmem.channelId = blockIdx.x;
     for (int i = 0; i < num; i++) {
-      if (args->channelMask.masks[i] & (1ull<<x)) {
-        y = __popcll(args->channelMask.masks[i] & ((1ull<<x)-1));
+      if (args->channelMask.masks[i] & (1ull << x)) {
+        y = __popcll(args->channelMask.masks[i] & ((1ull << x) - 1));
         y = total + y;
         if (blockIdx.x == y) {
           ncclShmem.channelId = x + total;
@@ -450,8 +469,8 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
       }
       if (WARP_SIZE < 64) {
         x = WARP_SIZE + tid;
-        if (args->channelMask.masks[i] & (1ull<<x)) {
-          y = __popcll(args->channelMask.masks[i] & ((1ull<<x)-1));
+        if (args->channelMask.masks[i] & (1ull << x)) {
+          y = __popcll(args->channelMask.masks[i] & ((1ull << x) - 1));
           y = y + total;
           if (blockIdx.x == y) {
             ncclShmem.channelId = x + total;
@@ -465,18 +484,18 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
   case 1:
     if (tid < WARP_SIZE + NCCL_MAX_GROUPS) {
       if (tid == WARP_SIZE) ncclShmem.barrier_pat = 0;
-      ncclShmem.groups[tid-WARP_SIZE].barrier = 0;
+      ncclShmem.groups[tid - WARP_SIZE].barrier = 0;
     }
     break;
   case 2:
 #ifdef ENABLE_FAULT_INJECTION
     /* load faults injection before first sync threads */
-    if (tid == 2*WARP_SIZE) ncclShmem.faults = args->comm->faults;
+    if (tid == 2 * WARP_SIZE) ncclShmem.faults = args->comm->faults;
 #endif
     break;
   case 3:
     /* set abort flag to 0 */
-    if (tid == 3*WARP_SIZE) ncclShmem.aborted = 0;
+    if (tid == 3 * WARP_SIZE) ncclShmem.aborted = 0;
     break;
   default:
     break;
@@ -485,37 +504,45 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
   /* set abort flag to 0 */
   if (tid == 0) {
     ncclShmem.aborted = 0;
-    ncclShmem.channel.workCounter = ((ncclKernelCommAndChannels*)ncclShmem.args.comm)->channels[ncclShmem.channelId].workCounter;
+    ncclShmem.channel.workCounter =
+      ((ncclKernelCommAndChannels*)ncclShmem.args.comm)->channels[ncclShmem.channelId].workCounter;
   }
 
   // Use first 2 warps to load comm and channel, and remaining load work batch.
-  switch (tid/WARP_SIZE) {
+  switch (tid / WARP_SIZE) {
   case 0:
-    { void* dst = &ncclShmem.comm;
+    {
+      void* dst = &ncclShmem.comm;
       void* src = ncclShmem.args.comm;
       int bytes = sizeof(ncclKernelComm);
-      static_assert(sizeof(ncclKernelComm) <= 16*WARP_SIZE, "ncclKernelComm cannot be loaded by a single warp in one insn.");
+      static_assert(sizeof(ncclKernelComm) <= 16 * WARP_SIZE,
+                    "ncclKernelComm cannot be loaded by a single warp in one insn.");
       copyToShmem16(tid, dst, src, bytes);
-    } break;
+    }
+    break;
   case 1:
     { // Get address of channel without incurring indirect load from ncclKernelComm::channels
       void* dst = &ncclShmem.channel;
       void* src = &((ncclKernelCommAndChannels*)ncclShmem.args.comm)->channels[ncclShmem.channelId];
       int bytes = sizeof(ncclDevChannel);
-      static_assert(sizeof(ncclDevChannel) <= 16*WARP_SIZE, "ncclDevChannel cannot be loaded by a single warp in one insn.");
-      copyToShmem16(tid-WARP_SIZE, dst, src, bytes);
-    } break;
+      static_assert(sizeof(ncclDevChannel) <= 16 * WARP_SIZE,
+                    "ncclDevChannel cannot be loaded by a single warp in one insn.");
+      copyToShmem16(tid - WARP_SIZE, dst, src, bytes);
+    }
+    break;
   default:
-    { int subtid = tid - 2*WARP_SIZE;
-      int subtn = tn - 2*WARP_SIZE;
+    {
+      int subtid = tid - 2 * WARP_SIZE;
+      int subtn = tn - 2 * WARP_SIZE;
       // Coverity reports a possible thread divergence due to not all threads participating in the collective.
       // However, the code ensures that the participation is on a per-warp basis.
       // coverity[device_thread_diverged:FALSE]
       loadWorkBatchToShmem(subtid, subtn, args, /*batchIx=*/blockIdx.x);
-    } break;
+    }
+    break;
   }
 #ifdef ENABLE_WARP_SPEED
-  if(tid == 0) {
+  if (tid == 0) {
     ncclShmem.warpComm = args->warpLevelComm;
   }
 #endif
@@ -524,12 +551,13 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
 #ifdef ENABLE_WARP_SPEED
   // Determine per-warp channel assignment for WarpSpeed enablement
   total = 0;
-  if(ncclShmem.warpComm == 1) {  // If warpComm is enabled, assign warps to channels that have the corresponding channel mask enabled
+  if (ncclShmem.warpComm ==
+      1) {  // If warpComm is enabled, assign warps to channels that have the corresponding channel mask enabled
     ncclShmem.warpChannelId[localWarpId] = -1;
-     __syncthreads();
+    __syncthreads();
     for (int i = 0; i < num; i++) {
-      if (args->channelMask.masks[i] & (1ull<<laneId)) {
-        y = __popcll(args->channelMask.masks[i] & ((1ull<<laneId)-1));
+      if (args->channelMask.masks[i] & (1ull << laneId)) {
+        y = __popcll(args->channelMask.masks[i] & ((1ull << laneId) - 1));
         y = total + y;
         if (globalWarpId == y) {
           ncclShmem.warpChannelId[localWarpId] = laneId + total;
@@ -539,16 +567,17 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
       total = total + __popcll(args->channelMask.masks[i]);
     }
     __syncthreads();
-    if(ncclShmem.warpChannelId[localWarpId] >= 0) {
+    if (ncclShmem.warpChannelId[localWarpId] >= 0) {
       void* dst = &ncclShmem.warpChannel[localWarpId];
       void* src = &((ncclKernelCommAndChannels*)ncclShmem.args.comm)->channels[ncclShmem.warpChannelId[localWarpId]];
       int bytes = sizeof(ncclDevChannel);
-      static_assert(sizeof(ncclDevChannel) <= 16*WARP_SIZE, "ncclDevChannel cannot be loaded by a single warp in one insn.");
+      static_assert(sizeof(ncclDevChannel) <= 16 * WARP_SIZE,
+                    "ncclDevChannel cannot be loaded by a single warp in one insn.");
       // assert((tid-localWarpId*WARP_SIZE) >= 0 && (tid-localWarpId*WARP_SIZE) < WARP_SIZE);
-      copyToShmem16(tid-localWarpId*WARP_SIZE, dst, src, bytes);
+      copyToShmem16(tid - localWarpId * WARP_SIZE, dst, src, bytes);
     }
   } else {  // warpComm disabled: skip per-warp channel copy; readers fall back to ncclShmem.channel
-    if(laneId == 0) {
+    if (laneId == 0) {
       ncclShmem.warpChannelId[localWarpId] = ncclShmem.channelId;
     }
   }
@@ -562,19 +591,13 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
     } else {
 #ifndef RCCL_DEVICE_TABLE_OMIT
 #if defined(USE_INDIRECT_FUNCTION_CALL) || defined(RCCL_DEVICE_LINKER)
-      if (COLL_UNROLL == 1)
-        ncclDevFuncTable_1[ncclShmem.funcId]();
-      else if (COLL_UNROLL == 2)
-        ncclDevFuncTable_2[ncclShmem.funcId]();
-      else
-        ncclDevFuncTable_4[ncclShmem.funcId]();
+      if (COLL_UNROLL == 1) ncclDevFuncTable_1[ncclShmem.funcId]();
+      else if (COLL_UNROLL == 2) ncclDevFuncTable_2[ncclShmem.funcId]();
+      else ncclDevFuncTable_4[ncclShmem.funcId]();
 #else
-      if (COLL_UNROLL == 1)
-        NCCL_CALL_FUNCTIONS_1(ncclShmem.funcId);
-      else if (COLL_UNROLL == 2)
-        NCCL_CALL_FUNCTIONS_2(ncclShmem.funcId);
-      else
-        NCCL_CALL_FUNCTIONS_4(ncclShmem.funcId);
+      if (COLL_UNROLL == 1) NCCL_CALL_FUNCTIONS_1(ncclShmem.funcId);
+      else if (COLL_UNROLL == 2) NCCL_CALL_FUNCTIONS_2(ncclShmem.funcId);
+      else NCCL_CALL_FUNCTIONS_4(ncclShmem.funcId);
 #endif
 #endif
     }
@@ -582,18 +605,18 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
     if (ncclShmem.nextBatchIx == -1) break;
     int batchIx = ncclShmem.nextBatchIx;
     __syncthreads();
-    switch (tid/WARP_SIZE) {
-      case 1:
-        if (tid < WARP_SIZE + NCCL_MAX_GROUPS) {
-          if (tid == WARP_SIZE) ncclShmem.barrier_pat = 0;
-          ncclShmem.groups[tid-WARP_SIZE].barrier = 0;
-        }
-        break;
-      default:
-        break;
+    switch (tid / WARP_SIZE) {
+    case 1:
+      if (tid < WARP_SIZE + NCCL_MAX_GROUPS) {
+        if (tid == WARP_SIZE) ncclShmem.barrier_pat = 0;
+        ncclShmem.groups[tid - WARP_SIZE].barrier = 0;
+      }
+      break;
+    default:
+      break;
     }
     profiler(STOP);
-    loadWorkBatchToShmem(tid%WARP_SIZE, tn, args, batchIx);
+    loadWorkBatchToShmem(tid % WARP_SIZE, tn, args, batchIx);
     __syncthreads();
   }
   profiler(FINI);

--- a/projects/rccl/src/device/common_kernel.h
+++ b/projects/rccl/src/device/common_kernel.h
@@ -20,7 +20,9 @@
 #define __syncwarp()
 
 // Define min for ssize_t
-inline __device__ int min(int a, ssize_t b) { return (a < b) ? a : b; }
+inline __device__ int min(int a, ssize_t b) {
+  return (a < b) ? a : b;
+}
 
 inline __device__ int loadInt(int* ptr) {
   int v;
@@ -28,52 +30,49 @@ inline __device__ int loadInt(int* ptr) {
   return v;
 }
 
-template<typename RedFn, typename T, int Unroll, int BytePerPack,
-         int MultimemSrcs, int MinSrcs, int MaxSrcs,
-         int MultimemDsts, int MinDsts, int MaxDsts, int PreOpSrcs,
-         typename IntBytes, typename SrcPtrFn, typename DstPtrFn>
-__device__ __forceinline__ static void reduceCopyPacks(
-    int nThreads, int &thread,
-    uint64_t redArg, bool postOp,
-    int nSrcs, SrcPtrFn const &srcPtrFn, int nDsts, DstPtrFn const &dstPtrFn,
-    IntBytes &nBytesBehind, IntBytes &nBytesAhead
-  ) {
+template <typename RedFn, typename T, int Unroll, int BytePerPack, int MultimemSrcs, int MinSrcs, int MaxSrcs,
+          int MultimemDsts, int MinDsts, int MaxDsts, int PreOpSrcs, typename IntBytes, typename SrcPtrFn,
+          typename DstPtrFn>
+__device__ __forceinline__ static void reduceCopyPacks(int nThreads, int& thread, uint64_t redArg, bool postOp,
+                                                       int nSrcs, SrcPtrFn const& srcPtrFn, int nDsts,
+                                                       DstPtrFn const& dstPtrFn, IntBytes& nBytesBehind,
+                                                       IntBytes& nBytesAhead) {
   static_assert(std::is_signed<IntBytes>::value, "IntBytes must be a signed integral type.");
-  //if (BytePerPack == 0) __trap();
+  // if (BytePerPack == 0) __trap();
 
   // A hunk is the amount of contiguous data a warp consumes per loop iteration
   // assuming all threads partake.
-  constexpr int BytePerHunk = Unroll*WARP_SIZE*BytePerPack;
-  int nWarps = nThreads/WARP_SIZE;
-  int warp = thread/WARP_SIZE;
-  int lane = thread%WARP_SIZE;
+  constexpr int BytePerHunk = Unroll * WARP_SIZE * BytePerPack;
+  int nWarps = nThreads / WARP_SIZE;
+  int warp = thread / WARP_SIZE;
+  int lane = thread % WARP_SIZE;
 
   // This thread's initial position.
-  IntBytes threadBytesBehind = nBytesBehind + (warp*BytePerHunk + lane*BytePerPack);
-  IntBytes threadBytesAhead = nBytesAhead - (warp*BytePerHunk + lane*BytePerPack);
+  IntBytes threadBytesBehind = nBytesBehind + (warp * BytePerHunk + lane * BytePerPack);
+  IntBytes threadBytesAhead = nBytesAhead - (warp * BytePerHunk + lane * BytePerPack);
   // Number of hunks to be consumed over all warps.
-  IntBytes nHunksAhead = nBytesAhead/(BytePerHunk + !BytePerHunk);
+  IntBytes nHunksAhead = nBytesAhead / (BytePerHunk + !BytePerHunk);
   // Advance collective position.
-  nBytesBehind += nHunksAhead*BytePerHunk;
-  nBytesAhead -= nHunksAhead*BytePerHunk;
-  if (Unroll==1 && BytePerPack <= nBytesAhead) {
+  nBytesBehind += nHunksAhead * BytePerHunk;
+  nBytesAhead -= nHunksAhead * BytePerHunk;
+  if (Unroll == 1 && BytePerPack <= nBytesAhead) {
     // Only Unroll=1 can do partial hunks (where not all threads partake).
     nHunksAhead += 1;
-    nBytesBehind += nBytesAhead - (nBytesAhead%(BytePerPack + !BytePerPack));
-    nBytesAhead = nBytesAhead%(BytePerPack + !BytePerPack);
+    nBytesBehind += nBytesAhead - (nBytesAhead % (BytePerPack + !BytePerPack));
+    nBytesAhead = nBytesAhead % (BytePerPack + !BytePerPack);
   }
   nHunksAhead -= warp;
 
   RedFn redFn(redArg);
   uintptr_t minSrcs[MinSrcs + !MinSrcs];
   uintptr_t minDsts[MinDsts + !MinDsts];
-  #pragma unroll
-  for (int s=0; s < MinSrcs; s++) {
+#pragma unroll
+  for (int s = 0; s < MinSrcs; s++) {
     minSrcs[s] = cvta_to_global(srcPtrFn(s)) + threadBytesBehind;
   }
 
-  #pragma unroll
-  for (int d=0; d < MinDsts; d++) {
+#pragma unroll
+  for (int d = 0; d < MinDsts; d++) {
     // Yes, for some template arguments this code will be unreachable.  That's fine.
     // coverity[dead_error_line]
     minDsts[d] = cvta_to_global(dstPtrFn(d)) + threadBytesBehind;
@@ -81,13 +80,13 @@ __device__ __forceinline__ static void reduceCopyPacks(
 
   // We dictate loop termination condition according to whether partial hunks
   // can be handled or not.
-  while (Unroll==1 ? (BytePerPack <= threadBytesAhead) : (0 < nHunksAhead)) {
+  while (Unroll == 1 ? (BytePerPack <= threadBytesAhead) : (0 < nHunksAhead)) {
     BytePack<BytePerPack> acc[Unroll];
 
     // minSrcs[0] cannot be nullptr so we always process it
     {
-      #pragma unroll Unroll
-      for (int u=0; u < Unroll; u++) {
+#pragma unroll Unroll
+      for (int u = 0; u < Unroll; u++) {
         if (0 < MultimemSrcs) {
           // applyLoadMultimem uses relaxed semantics for same reason we use volatile below.
           acc[u] = applyLoadMultimem<RedFn, BytePerPack>(redFn, minSrcs[0]);
@@ -96,18 +95,18 @@ __device__ __forceinline__ static void reduceCopyPacks(
           acc[u] = ld_volatile_global<BytePerPack>(minSrcs[0]);
           if (0 < PreOpSrcs) acc[u] = applyPreOp(redFn, acc[u]);
         }
-        minSrcs[0] += WARP_SIZE*BytePerPack;
+        minSrcs[0] += WARP_SIZE * BytePerPack;
       }
     }
 
-    #pragma unroll Unroll
-    for (int s=1; s < MinSrcs; s++) {
+#pragma unroll Unroll
+    for (int s = 1; s < MinSrcs; s++) {
       // Yes, for some template arguments this code will be unreachable.  That's fine.
       // coverity[dead_error_begin]
       BytePack<BytePerPack> tmp[Unroll];
       // coverity[dead_error_line]
-      #pragma unroll Unroll
-      for (int u=0; u < Unroll; u++) {
+#pragma unroll Unroll
+      for (int u = 0; u < Unroll; u++) {
         if (s < MultimemSrcs) {
           // applyLoadMultimem uses relaxed semantics for same reason we use volatile below.
           // coverity[dead_error_line]
@@ -116,28 +115,28 @@ __device__ __forceinline__ static void reduceCopyPacks(
           // Use volatile loads in case credits are polled for with volatile (instead of acquire).
           tmp[u] = ld_volatile_global<BytePerPack>(minSrcs[s]);
         }
-        minSrcs[s] += WARP_SIZE*BytePerPack;
+        minSrcs[s] += WARP_SIZE * BytePerPack;
       }
-      #pragma unroll Unroll
-      for (int u=0; u < Unroll; u++) {
+#pragma unroll Unroll
+      for (int u = 0; u < Unroll; u++) {
         // coverity[dead_error_line]
         acc[u] = applyReduce(redFn, acc[u], tmp[u]);
       }
     }
 
-    for (int s=MinSrcs; (MinSrcs < MaxSrcs) && (s < MaxSrcs) && (s < nSrcs); s++) {
+    for (int s = MinSrcs; (MinSrcs < MaxSrcs) && (s < MaxSrcs) && (s < nSrcs); s++) {
       uintptr_t src = cvta_to_global(srcPtrFn(s)) + threadBytesBehind;
       BytePack<BytePerPack> tmp[Unroll];
       // Yes, for some template arguments this code will be unreachable.  That's fine.
       // coverity[dead_error_line]
-      #pragma unroll Unroll
-      for (int u=0; u < Unroll; u++) {
+#pragma unroll Unroll
+      for (int u = 0; u < Unroll; u++) {
         // Use volatile loads in case credits are polled for with volatile (instead of acquire).
         tmp[u] = ld_volatile_global<BytePerPack>(src);
-        src += WARP_SIZE*BytePerPack;
+        src += WARP_SIZE * BytePerPack;
       }
-      #pragma unroll Unroll
-      for (int u=0; u < Unroll; u++) {
+#pragma unroll Unroll
+      for (int u = 0; u < Unroll; u++) {
         // Yes, for some template arguments this code will be unreachable.  That's fine.
         // coverity[dead_error_line]
         acc[u] = applyReduce(redFn, acc[u], tmp[u]);
@@ -145,77 +144,72 @@ __device__ __forceinline__ static void reduceCopyPacks(
     }
 
     if (postOp) {
-      #pragma unroll Unroll
-      for (int u=0; u < Unroll; u++)
-        acc[u] = applyPostOp(redFn, acc[u]);
+#pragma unroll Unroll
+      for (int u = 0; u < Unroll; u++) acc[u] = applyPostOp(redFn, acc[u]);
     }
 
-    #pragma unroll Unroll
-    for (int d=0; d < MinDsts; d++) {
-      #pragma unroll Unroll
+#pragma unroll Unroll
+    for (int d = 0; d < MinDsts; d++) {
+#pragma unroll Unroll
       // Yes, for some template arguments this code will be unreachable.  That's fine.
       // coverity[dead_error_begin]
-      for (int u=0; u < Unroll; u++) {
+      for (int u = 0; u < Unroll; u++) {
         // coverity[dead_error_condition]
         if (d < MultimemDsts) {
           multimem_st_global(minDsts[d], acc[u]);
         } else {
           st_global<BytePerPack>(minDsts[d], acc[u]);
         }
-        minDsts[d] += WARP_SIZE*BytePerPack;
+        minDsts[d] += WARP_SIZE * BytePerPack;
       }
     }
-    for (int d=MinDsts; (MinDsts < MaxDsts) && (d < MaxDsts) && (d < nDsts); d++) {
+    for (int d = MinDsts; (MinDsts < MaxDsts) && (d < MaxDsts) && (d < nDsts); d++) {
       uintptr_t dstPtr = cvta_to_global(dstPtrFn(d));
       uintptr_t dst = dstPtr + threadBytesBehind;
-      #pragma unroll Unroll
-      for (int u=0; u < Unroll; u++) {
+#pragma unroll Unroll
+      for (int u = 0; u < Unroll; u++) {
         st_global<BytePerPack>(dst, acc[u]);
-        dst += WARP_SIZE*BytePerPack;
+        dst += WARP_SIZE * BytePerPack;
       }
     }
 
-    nWarps = nThreads/WARP_SIZE;
-    #pragma unroll
-    for (int s=0; s < MinSrcs; s++) {
-      minSrcs[s] += (nWarps-1)*BytePerHunk;
+    nWarps = nThreads / WARP_SIZE;
+#pragma unroll
+    for (int s = 0; s < MinSrcs; s++) {
+      minSrcs[s] += (nWarps - 1) * BytePerHunk;
     }
-    #pragma unroll
+#pragma unroll
     // Yes, for some template arguments this code will be unreachable.  That's fine.
     // coverity[dead_error_line]
-    for (int d=0; d < MinDsts; d++) {
-      minDsts[d] += (nWarps-1)*BytePerHunk;
+    for (int d = 0; d < MinDsts; d++) {
+      minDsts[d] += (nWarps - 1) * BytePerHunk;
     }
-    threadBytesBehind += nWarps*BytePerHunk;
-    threadBytesAhead -= nWarps*BytePerHunk;
+    threadBytesBehind += nWarps * BytePerHunk;
+    threadBytesAhead -= nWarps * BytePerHunk;
     nHunksAhead -= nWarps;
   }
 
-  nWarps = nThreads/WARP_SIZE;
-  warp = thread/WARP_SIZE;
-  lane = thread%WARP_SIZE;
+  nWarps = nThreads / WARP_SIZE;
+  warp = thread / WARP_SIZE;
+  lane = thread % WARP_SIZE;
   // The last loop iteration could have been partial, i.e. not taken by all
   // threads. The threads that weren't included need an extra subtraction to
   // make the value warp uniform.
-  if (Unroll==1 && nHunksAhead > 0) nHunksAhead -= nWarps;
+  if (Unroll == 1 && nHunksAhead > 0) nHunksAhead -= nWarps;
   // Rotate warps so the warp which got the least work here will be warp 0.
   // This effectively assigns: warp = (warp-nHunks+nWarps)%nWarps;
   warp = -nHunksAhead;
-  thread = warp*WARP_SIZE + lane;
+  thread = warp * WARP_SIZE + lane;
 }
 
-template <typename RedFn, typename SrcPtrFn, typename IntBytes, int MultimemSrcs, int MinSrcs, int MaxSrcs, int PreOpSrcs, int Unroll, int BytePerPack>
-__device__ __forceinline__ void loadSources(
-  const RedFn& redFn,
-  const SrcPtrFn& srcPtrFn,
-  IntBytes& globalOffset,
-  uintptr_t* minSrcs,
-  BytePack<BytePerPack> buff[MaxSrcs + !MaxSrcs][Unroll],
-  int nSrcs
-) {
-  #pragma unroll Unroll
+template <typename RedFn, typename SrcPtrFn, typename IntBytes, int MultimemSrcs, int MinSrcs, int MaxSrcs,
+          int PreOpSrcs, int Unroll, int BytePerPack>
+__device__ __forceinline__ void loadSources(const RedFn& redFn, const SrcPtrFn& srcPtrFn, IntBytes& globalOffset,
+                                            uintptr_t* minSrcs, BytePack<BytePerPack> buff[MaxSrcs + !MaxSrcs][Unroll],
+                                            int nSrcs) {
+#pragma unroll Unroll
   for (int s = 0; s < MinSrcs; s++) {
-    #pragma unroll Unroll
+#pragma unroll Unroll
     for (int u = 0; u < Unroll; u++) {
       if (s < MultimemSrcs) {
         buff[s][u] = applyLoadMultimem<RedFn, BytePerPack>(redFn, minSrcs[s]);
@@ -227,7 +221,7 @@ __device__ __forceinline__ void loadSources(
   }
   for (int s = MinSrcs; (MinSrcs < MaxSrcs) && (s < MaxSrcs) && (s < nSrcs); s++) {
     uintptr_t src = cvta_to_global(srcPtrFn(s)) + globalOffset;
-    #pragma unroll Unroll
+#pragma unroll Unroll
     for (int u = 0; u < Unroll; u++) {
       buff[s][u] = ld_volatile_global<BytePerPack>(src);
       src += WARP_SIZE * BytePerPack;
@@ -235,33 +229,33 @@ __device__ __forceinline__ void loadSources(
   }
 }
 
-template <typename RedFn, typename DstPtrFn, typename IntBytes, int MultimemDsts, int MinSrcs, int MaxSrcs, int MinDsts, int MaxDsts, int PreOpSrcs, int Unroll, int BytePerPack>
-  __device__ __forceinline__ void reduceAndStore(
-  RedFn redFn, BytePack<BytePerPack> buff[MaxSrcs + !MaxSrcs][Unroll],
-  uintptr_t *minDsts, bool postOp, int nDsts, DstPtrFn const &dstPtrFn, IntBytes tailThreadBytesBehind, int nSrcs) {
+template <typename RedFn, typename DstPtrFn, typename IntBytes, int MultimemDsts, int MinSrcs, int MaxSrcs, int MinDsts,
+          int MaxDsts, int PreOpSrcs, int Unroll, int BytePerPack>
+__device__ __forceinline__ void reduceAndStore(RedFn redFn, BytePack<BytePerPack> buff[MaxSrcs + !MaxSrcs][Unroll],
+                                               uintptr_t* minDsts, bool postOp, int nDsts, DstPtrFn const& dstPtrFn,
+                                               IntBytes tailThreadBytesBehind, int nSrcs) {
   for (int s = 0; s < MinSrcs; s++) {
-    #pragma unroll Unroll
+#pragma unroll Unroll
     for (int u = 0; u < Unroll; u++) {
       if (s < PreOpSrcs) buff[s][u] = applyPreOp(redFn, buff[s][u]);
       if (s > 0) buff[0][u] = applyReduce(redFn, buff[0][u], buff[s][u]);
     }
   }
   for (int s = MinSrcs; (MinSrcs < MaxSrcs) && (s < MaxSrcs) && (s < nSrcs); s++) {
-    #pragma unroll Unroll
+#pragma unroll Unroll
     for (int u = 0; u < Unroll; u++) {
       if (s < PreOpSrcs) buff[s][u] = applyPreOp(redFn, buff[s][u]);
       buff[0][u] = applyReduce(redFn, buff[0][u], buff[s][u]);
     }
   }
   if (postOp) {
-    #pragma unroll Unroll
-    for (int u = 0; u < Unroll; u++)
-      buff[0][u] = applyPostOp(redFn, buff[0][u]);
+#pragma unroll Unroll
+    for (int u = 0; u < Unroll; u++) buff[0][u] = applyPostOp(redFn, buff[0][u]);
   }
 
-  #pragma unroll Unroll
+#pragma unroll Unroll
   for (int d = 0; d < MinDsts; d++) {
-    #pragma unroll Unroll
+#pragma unroll Unroll
     for (int u = 0; u < Unroll; u++) {
       if (d < MultimemDsts) {
         multimem_st_global(minDsts[d], buff[0][u]);
@@ -274,7 +268,7 @@ template <typename RedFn, typename DstPtrFn, typename IntBytes, int MultimemDsts
   for (int d = MinDsts; (MinDsts < MaxDsts) && (d < MaxDsts) && (d < nDsts); d++) {
     uintptr_t dstPtr = cvta_to_global(dstPtrFn(d));
     uintptr_t dst = dstPtr + tailThreadBytesBehind;
-    #pragma unroll Unroll
+#pragma unroll Unroll
     for (int u = 0; u < Unroll; u++) {
       st_global<BytePerPack>(dst, buff[0][u]);
       dst += WARP_SIZE * BytePerPack;
@@ -282,53 +276,50 @@ template <typename RedFn, typename DstPtrFn, typename IntBytes, int MultimemDsts
   }
 }
 
-template<typename RedFn, typename T, int Unroll, int BytePerPack,
-         int MultimemSrcs, int MinSrcs, int MaxSrcs,
-         int MultimemDsts, int MinDsts, int MaxDsts, int PreOpSrcs,
-         typename IntBytes, typename SrcPtrFn, typename DstPtrFn>
-__device__ __forceinline__ static void reduceCopyPacksPipelined(
-    int nThreads, int &thread,
-    uint64_t redArg, bool postOp,
-    int nSrcs, SrcPtrFn const &srcPtrFn, int nDsts, DstPtrFn const &dstPtrFn,
-    IntBytes &nBytesBehind, IntBytes &nBytesAhead
-  ) {
+template <typename RedFn, typename T, int Unroll, int BytePerPack, int MultimemSrcs, int MinSrcs, int MaxSrcs,
+          int MultimemDsts, int MinDsts, int MaxDsts, int PreOpSrcs, typename IntBytes, typename SrcPtrFn,
+          typename DstPtrFn>
+__device__ __forceinline__ static void reduceCopyPacksPipelined(int nThreads, int& thread, uint64_t redArg, bool postOp,
+                                                                int nSrcs, SrcPtrFn const& srcPtrFn, int nDsts,
+                                                                DstPtrFn const& dstPtrFn, IntBytes& nBytesBehind,
+                                                                IntBytes& nBytesAhead) {
   static_assert(std::is_signed<IntBytes>::value, "IntBytes must be a signed integral type.");
   static_assert(MinSrcs <= MaxSrcs, "MinSrcs must be less than or equal to MaxSrcs.");
-  //if (BytePerPack == 0) __trap();
+  // if (BytePerPack == 0) __trap();
 
   // A hunk is the amount of contiguous data a warp consumes per loop iteration
   // assuming all threads partake.
-  constexpr int BytePerHunk = Unroll*WARP_SIZE*BytePerPack;
-  int nWarps = nThreads/WARP_SIZE;
-  int warp = thread/WARP_SIZE;
-  int lane = thread%WARP_SIZE;
+  constexpr int BytePerHunk = Unroll * WARP_SIZE * BytePerPack;
+  int nWarps = nThreads / WARP_SIZE;
+  int warp = thread / WARP_SIZE;
+  int lane = thread % WARP_SIZE;
 
   // This thread's initial position.
-  IntBytes threadBytesBehind = nBytesBehind + (warp*BytePerHunk + lane*BytePerPack);
-  IntBytes threadBytesAhead = nBytesAhead - (warp*BytePerHunk + lane*BytePerPack);
+  IntBytes threadBytesBehind = nBytesBehind + (warp * BytePerHunk + lane * BytePerPack);
+  IntBytes threadBytesAhead = nBytesAhead - (warp * BytePerHunk + lane * BytePerPack);
   // Number of hunks to be consumed over all warps.
-  IntBytes nHunksAhead = nBytesAhead/(BytePerHunk + !BytePerHunk);
+  IntBytes nHunksAhead = nBytesAhead / (BytePerHunk + !BytePerHunk);
   // Advance collective position.
-  nBytesBehind += nHunksAhead*BytePerHunk;
-  nBytesAhead -= nHunksAhead*BytePerHunk;
-  if (Unroll==1 && BytePerPack <= nBytesAhead) {
+  nBytesBehind += nHunksAhead * BytePerHunk;
+  nBytesAhead -= nHunksAhead * BytePerHunk;
+  if (Unroll == 1 && BytePerPack <= nBytesAhead) {
     // Only Unroll=1 can do partial hunks (where not all threads partake).
     nHunksAhead += 1;
-    nBytesBehind += nBytesAhead - (nBytesAhead%(BytePerPack + !BytePerPack));
-    nBytesAhead = nBytesAhead%(BytePerPack + !BytePerPack);
+    nBytesBehind += nBytesAhead - (nBytesAhead % (BytePerPack + !BytePerPack));
+    nBytesAhead = nBytesAhead % (BytePerPack + !BytePerPack);
   }
   nHunksAhead -= warp;
 
   RedFn redFn(redArg);
   uintptr_t minSrcs[MinSrcs + !MinSrcs];
   uintptr_t minDsts[MinDsts + !MinDsts];
-  #pragma unroll
-  for (int s=0; s < MinSrcs; s++) {
+#pragma unroll
+  for (int s = 0; s < MinSrcs; s++) {
     minSrcs[s] = cvta_to_global(srcPtrFn(s)) + threadBytesBehind;
   }
 
-  #pragma unroll
-  for (int d=0; d < MinDsts; d++) {
+#pragma unroll
+  for (int d = 0; d < MinDsts; d++) {
     // Yes, for some template arguments this code will be unreachable.  That's fine.
     // coverity[dead_error_line]
     minDsts[d] = cvta_to_global(dstPtrFn(d)) + threadBytesBehind;
@@ -339,110 +330,101 @@ __device__ __forceinline__ static void reduceCopyPacksPipelined(
   IntBytes tailThreadBytesBehind;
   // We dictate loop termination condition according to whether partial hunks
   // can be handled or not.
-  while (Unroll==1 ? (BytePerPack <= threadBytesAhead) : (0 < nHunksAhead)) {
-
+  while (Unroll == 1 ? (BytePerPack <= threadBytesAhead) : (0 < nHunksAhead)) {
     // load sources into acc1
     loadSources<RedFn, SrcPtrFn, IntBytes, MultimemSrcs, MinSrcs, MaxSrcs, PreOpSrcs, Unroll, BytePerPack>(
-      redFn, srcPtrFn, threadBytesBehind, minSrcs, acc1, nSrcs
-    );
+      redFn, srcPtrFn, threadBytesBehind, minSrcs, acc1, nSrcs);
 
-    if(tailProcess) {
-      reduceAndStore<RedFn, DstPtrFn, IntBytes, MultimemDsts, MinSrcs, MaxSrcs, MinDsts, MaxDsts, PreOpSrcs, Unroll, BytePerPack>(
-        redFn, acc2, minDsts, postOp, nDsts, dstPtrFn, tailThreadBytesBehind, nSrcs
-      );
+    if (tailProcess) {
+      reduceAndStore<RedFn, DstPtrFn, IntBytes, MultimemDsts, MinSrcs, MaxSrcs, MinDsts, MaxDsts, PreOpSrcs, Unroll,
+                     BytePerPack>(redFn, acc2, minDsts, postOp, nDsts, dstPtrFn, tailThreadBytesBehind, nSrcs);
 
-      #pragma unroll
-      for (int d=0; d < MinDsts; d++) {
-        minDsts[d] += (nWarps-1)*BytePerHunk;
+#pragma unroll
+      for (int d = 0; d < MinDsts; d++) {
+        minDsts[d] += (nWarps - 1) * BytePerHunk;
       }
     }
 
-    #pragma unroll
-    for (int s=0; s < MinSrcs; s++) {
-      minSrcs[s] += (nWarps-1)*BytePerHunk;
+#pragma unroll
+    for (int s = 0; s < MinSrcs; s++) {
+      minSrcs[s] += (nWarps - 1) * BytePerHunk;
     }
-    threadBytesAhead -= nWarps*BytePerHunk;
+    threadBytesAhead -= nWarps * BytePerHunk;
     nHunksAhead -= nWarps;
-    tailProcess = Unroll==1 ? (BytePerPack <= threadBytesAhead) : (0 < nHunksAhead);
+    tailProcess = Unroll == 1 ? (BytePerPack <= threadBytesAhead) : (0 < nHunksAhead);
 
     tailThreadBytesBehind = threadBytesBehind;
-    threadBytesBehind += nWarps*BytePerHunk;
-    if(tailProcess) {
+    threadBytesBehind += nWarps * BytePerHunk;
+    if (tailProcess) {
       loadSources<RedFn, SrcPtrFn, IntBytes, MultimemSrcs, MinSrcs, MaxSrcs, PreOpSrcs, Unroll, BytePerPack>(
-        redFn, srcPtrFn, threadBytesBehind, minSrcs, acc2, nSrcs
-      );
+        redFn, srcPtrFn, threadBytesBehind, minSrcs, acc2, nSrcs);
     }
-    reduceAndStore<RedFn, DstPtrFn, IntBytes, MultimemDsts, MinSrcs, MaxSrcs, MinDsts, MaxDsts, PreOpSrcs, Unroll, BytePerPack>(
-      redFn, acc1, minDsts, postOp, nDsts, dstPtrFn, tailThreadBytesBehind, nSrcs
-    );
+    reduceAndStore<RedFn, DstPtrFn, IntBytes, MultimemDsts, MinSrcs, MaxSrcs, MinDsts, MaxDsts, PreOpSrcs, Unroll,
+                   BytePerPack>(redFn, acc1, minDsts, postOp, nDsts, dstPtrFn, tailThreadBytesBehind, nSrcs);
 
-    if(tailProcess) {
-      #pragma unroll
-      for (int d=0; d < MinDsts; d++) {
-        minDsts[d] += (nWarps-1)*BytePerHunk;
+    if (tailProcess) {
+#pragma unroll
+      for (int d = 0; d < MinDsts; d++) {
+        minDsts[d] += (nWarps - 1) * BytePerHunk;
       }
-      #pragma unroll
-      for (int s=0; s < MinSrcs; s++) {
-        minSrcs[s] += (nWarps-1)*BytePerHunk;
+#pragma unroll
+      for (int s = 0; s < MinSrcs; s++) {
+        minSrcs[s] += (nWarps - 1) * BytePerHunk;
       }
       tailThreadBytesBehind = threadBytesBehind;
-      threadBytesBehind += nWarps*BytePerHunk;
-      threadBytesAhead -= nWarps*BytePerHunk;
+      threadBytesBehind += nWarps * BytePerHunk;
+      threadBytesAhead -= nWarps * BytePerHunk;
       nHunksAhead -= nWarps;
     }
   }
 
-  if(tailProcess) {
-    reduceAndStore<RedFn, DstPtrFn, IntBytes, MultimemDsts, MinSrcs, MaxSrcs, MinDsts, MaxDsts, PreOpSrcs, Unroll, BytePerPack>(
-      redFn, acc2, minDsts, postOp, nDsts, dstPtrFn, tailThreadBytesBehind, nSrcs
-    );
+  if (tailProcess) {
+    reduceAndStore<RedFn, DstPtrFn, IntBytes, MultimemDsts, MinSrcs, MaxSrcs, MinDsts, MaxDsts, PreOpSrcs, Unroll,
+                   BytePerPack>(redFn, acc2, minDsts, postOp, nDsts, dstPtrFn, tailThreadBytesBehind, nSrcs);
   }
-  nWarps = nThreads/WARP_SIZE;
-  warp = thread/WARP_SIZE;
-  lane = thread%WARP_SIZE;
+  nWarps = nThreads / WARP_SIZE;
+  warp = thread / WARP_SIZE;
+  lane = thread % WARP_SIZE;
   // The last loop iteration could have been partial, i.e. not taken by all
   // threads. The threads that weren't included need an extra subtraction to
   // make the value warp uniform.
-  if (Unroll==1 && nHunksAhead > 0) nHunksAhead -= nWarps;
+  if (Unroll == 1 && nHunksAhead > 0) nHunksAhead -= nWarps;
   // Rotate warps so the warp which got the least work here will be warp 0.
   // This effectively assigns: warp = (warp-nHunks+nWarps)%nWarps;
   warp = -nHunksAhead;
-  thread = warp*WARP_SIZE + lane;
+  thread = warp * WARP_SIZE + lane;
 }
 
-template<typename RedFn, typename T, int Unroll, int BytePerPack,
-         int MultimemSrcs, int MinSrcs, int MaxSrcs,
-         int MultimemDsts, int MinDsts, int MaxDsts, int PreOpSrcs,
-         typename IntBytes, typename SrcPtrFn, typename DstPtrFn, typename AccPtrFn>
-__device__ __forceinline__ void reduceCopyPacksWithBias(
-    int nThreads, int &thread,
-    uint64_t redArg, bool postOp,
-    int nSrcs, SrcPtrFn const &srcPtrFn, int nDsts, DstPtrFn const &dstPtrFn,
-    IntBytes &nBytesBehind, IntBytes &nBytesAhead, AccPtrFn const &accPtrFn
-  ) {
+template <typename RedFn, typename T, int Unroll, int BytePerPack, int MultimemSrcs, int MinSrcs, int MaxSrcs,
+          int MultimemDsts, int MinDsts, int MaxDsts, int PreOpSrcs, typename IntBytes, typename SrcPtrFn,
+          typename DstPtrFn, typename AccPtrFn>
+__device__ __forceinline__ void reduceCopyPacksWithBias(int nThreads, int& thread, uint64_t redArg, bool postOp,
+                                                        int nSrcs, SrcPtrFn const& srcPtrFn, int nDsts,
+                                                        DstPtrFn const& dstPtrFn, IntBytes& nBytesBehind,
+                                                        IntBytes& nBytesAhead, AccPtrFn const& accPtrFn) {
   static_assert(std::is_signed<IntBytes>::value, "IntBytes must be a signed integral type.");
-  //if (BytePerPack == 0) __trap();
+  // if (BytePerPack == 0) __trap();
 
   // A hunk is the amount of contiguous data a warp consumes per loop iteration
   // assuming all threads partake.
-  constexpr int BytePerHunk = Unroll*WARP_SIZE*BytePerPack;
-  int nWarps = nThreads/WARP_SIZE;
-  int warp = thread/WARP_SIZE;
-  int lane = thread%WARP_SIZE;
+  constexpr int BytePerHunk = Unroll * WARP_SIZE * BytePerPack;
+  int nWarps = nThreads / WARP_SIZE;
+  int warp = thread / WARP_SIZE;
+  int lane = thread % WARP_SIZE;
 
   // This thread's initial position.
-  IntBytes threadBytesBehind = nBytesBehind + (warp*BytePerHunk + lane*BytePerPack);
-  IntBytes threadBytesAhead = nBytesAhead - (warp*BytePerHunk + lane*BytePerPack);
+  IntBytes threadBytesBehind = nBytesBehind + (warp * BytePerHunk + lane * BytePerPack);
+  IntBytes threadBytesAhead = nBytesAhead - (warp * BytePerHunk + lane * BytePerPack);
   // Number of hunks to be consumed over all warps.
-  IntBytes nHunksAhead = nBytesAhead/(BytePerHunk + !BytePerHunk);
+  IntBytes nHunksAhead = nBytesAhead / (BytePerHunk + !BytePerHunk);
   // Advance collective position.
-  nBytesBehind += nHunksAhead*BytePerHunk;
-  nBytesAhead -= nHunksAhead*BytePerHunk;
-  if (Unroll==1 && BytePerPack <= nBytesAhead) {
+  nBytesBehind += nHunksAhead * BytePerHunk;
+  nBytesAhead -= nHunksAhead * BytePerHunk;
+  if (Unroll == 1 && BytePerPack <= nBytesAhead) {
     // Only Unroll=1 can do partial hunks (where not all threads partake).
     nHunksAhead += 1;
-    nBytesBehind += nBytesAhead - (nBytesAhead%(BytePerPack + !BytePerPack));
-    nBytesAhead = nBytesAhead%(BytePerPack + !BytePerPack);
+    nBytesBehind += nBytesAhead - (nBytesAhead % (BytePerPack + !BytePerPack));
+    nBytesAhead = nBytesAhead % (BytePerPack + !BytePerPack);
   }
   nHunksAhead -= warp;
 
@@ -452,13 +434,13 @@ __device__ __forceinline__ void reduceCopyPacksWithBias(
   uintptr_t accPtr = cvta_to_global(accPtrFn()) + threadBytesBehind;
   BytePack<BytePerPack> bias[Unroll];
 
-  #pragma unroll
-  for (int s=0; s < MinSrcs; s++) {
+#pragma unroll
+  for (int s = 0; s < MinSrcs; s++) {
     minSrcs[s] = cvta_to_global(srcPtrFn(s)) + threadBytesBehind;
   }
 
-  #pragma unroll
-  for (int d=0; d < MinDsts; d++) {
+#pragma unroll
+  for (int d = 0; d < MinDsts; d++) {
     // Yes, for some template arguments this code will be unreachable.  That's fine.
     // coverity[dead_error_line]
     minDsts[d] = cvta_to_global(dstPtrFn(d)) + threadBytesBehind;
@@ -466,13 +448,13 @@ __device__ __forceinline__ void reduceCopyPacksWithBias(
 
   // We dictate loop termination condition according to whether partial hunks
   // can be handled or not.
-  while (Unroll==1 ? (BytePerPack <= threadBytesAhead) : (0 < nHunksAhead)) {
+  while (Unroll == 1 ? (BytePerPack <= threadBytesAhead) : (0 < nHunksAhead)) {
     BytePack<BytePerPack> acc[Unroll];
 
     // minSrcs[0] cannot be nullptr so we always process it
     {
-      #pragma unroll Unroll
-      for (int u=0; u < Unroll; u++) {
+#pragma unroll Unroll
+      for (int u = 0; u < Unroll; u++) {
         if (0 < MultimemSrcs) {
           // applyLoadMultimem uses relaxed semantics for same reason we use volatile below.
           acc[u] = applyLoadMultimem<RedFn, BytePerPack>(redFn, minSrcs[0]);
@@ -481,20 +463,20 @@ __device__ __forceinline__ void reduceCopyPacksWithBias(
           acc[u] = ld_volatile_global<BytePerPack>(minSrcs[0]);
             // coverity[dead_error_condition]
           bias[u] = ld_volatile_global<BytePerPack>(accPtr);
-          accPtr += WARP_SIZE*BytePerPack;
+          accPtr += WARP_SIZE * BytePerPack;
           if (0 < PreOpSrcs) acc[u] = applyPreOp(redFn, acc[u]);
         }
-        minSrcs[0] += WARP_SIZE*BytePerPack;
+        minSrcs[0] += WARP_SIZE * BytePerPack;
       }
     }
 
-    #pragma unroll Unroll
-    for (int s=1; s < MinSrcs; s++) {
+#pragma unroll Unroll
+    for (int s = 1; s < MinSrcs; s++) {
       // Yes, for some template arguments this code will be unreachable.  That's fine.
       // coverity[dead_error_begin]
       BytePack<BytePerPack> tmp[Unroll];
-      #pragma unroll Unroll
-      for (int u=0; u < Unroll; u++) {
+#pragma unroll Unroll
+      for (int u = 0; u < Unroll; u++) {
         if (s < MultimemSrcs) {
           // applyLoadMultimem uses relaxed semantics for same reason we use volatile below.
           // coverity[dead_error_line]
@@ -503,27 +485,27 @@ __device__ __forceinline__ void reduceCopyPacksWithBias(
           // Use volatile loads in case credits are polled for with volatile (instead of acquire).
           tmp[u] = ld_volatile_global<BytePerPack>(minSrcs[s]);
         }
-        minSrcs[s] += WARP_SIZE*BytePerPack;
+        minSrcs[s] += WARP_SIZE * BytePerPack;
       }
-      #pragma unroll Unroll
-      for (int u=0; u < Unroll; u++) {
+#pragma unroll Unroll
+      for (int u = 0; u < Unroll; u++) {
         // coverity[dead_error_line]
         if (s < PreOpSrcs) tmp[u] = applyPreOp(redFn, tmp[u]);
         acc[u] = applyReduce(redFn, acc[u], tmp[u]);
       }
     }
 
-    for (int s=MinSrcs; (MinSrcs < MaxSrcs) && (s < MaxSrcs) && (s < nSrcs); s++) {
+    for (int s = MinSrcs; (MinSrcs < MaxSrcs) && (s < MaxSrcs) && (s < nSrcs); s++) {
       uintptr_t src = cvta_to_global(srcPtrFn(s)) + threadBytesBehind;
       BytePack<BytePerPack> tmp[Unroll];
-      #pragma unroll Unroll
-      for (int u=0; u < Unroll; u++) {
+#pragma unroll Unroll
+      for (int u = 0; u < Unroll; u++) {
         // Use volatile loads in case credits are polled for with volatile (instead of acquire).
         tmp[u] = ld_volatile_global<BytePerPack>(src);
-        src += WARP_SIZE*BytePerPack;
+        src += WARP_SIZE * BytePerPack;
       }
-      #pragma unroll Unroll
-      for (int u=0; u < Unroll; u++) {
+#pragma unroll Unroll
+      for (int u = 0; u < Unroll; u++) {
         // Yes, for some template arguments this code will be unreachable.  That's fine.
         // coverity[dead_error_line]
         if (s < PreOpSrcs) tmp[u] = applyPreOp(redFn, tmp[u]);
@@ -532,92 +514,86 @@ __device__ __forceinline__ void reduceCopyPacksWithBias(
     }
 
     if (postOp) {
-      #pragma unroll Unroll
-      for (int u=0; u < Unroll; u++)
-        acc[u] = applyPostOp(redFn, acc[u]);
+#pragma unroll Unroll
+      for (int u = 0; u < Unroll; u++) acc[u] = applyPostOp(redFn, acc[u]);
     }
 
-    #pragma unroll Unroll
-    for (int d=0; d < MinDsts; d++) {
-      #pragma unroll Unroll
+#pragma unroll Unroll
+    for (int d = 0; d < MinDsts; d++) {
+#pragma unroll Unroll
       // Yes, for some template arguments this code will be unreachable.  That's fine.
       // coverity[dead_error_begin]
-      for (int u=0; u < Unroll; u++) {
+      for (int u = 0; u < Unroll; u++) {
         // coverity[dead_error_condition]
         if (d < MultimemDsts) {
           multimem_st_global(minDsts[d], acc[u]);
         } else {
-          if (d == 0)
-            st_global<BytePerPack>(minDsts[d], applyReduce(redFn, acc[u], bias[u]));
-          else
-            st_global<BytePerPack>(minDsts[d], acc[u]);
+          if (d == 0) st_global<BytePerPack>(minDsts[d], applyReduce(redFn, acc[u], bias[u]));
+          else st_global<BytePerPack>(minDsts[d], acc[u]);
         }
-        minDsts[d] += WARP_SIZE*BytePerPack;
+        minDsts[d] += WARP_SIZE * BytePerPack;
       }
     }
-    for (int d=MinDsts; (MinDsts < MaxDsts) && (d < MaxDsts) && (d < nDsts); d++) {
+    for (int d = MinDsts; (MinDsts < MaxDsts) && (d < MaxDsts) && (d < nDsts); d++) {
       uintptr_t dstPtr = cvta_to_global(dstPtrFn(d));
       uintptr_t dst = dstPtr + threadBytesBehind;
-      #pragma unroll Unroll
-      for (int u=0; u < Unroll; u++) {
+#pragma unroll Unroll
+      for (int u = 0; u < Unroll; u++) {
         st_global<BytePerPack>(dst, acc[u]);
-        dst += WARP_SIZE*BytePerPack;
+        dst += WARP_SIZE * BytePerPack;
       }
     }
 
-    nWarps = nThreads/WARP_SIZE;
-    #pragma unroll
-    for (int s=0; s < MinSrcs; s++) {
-      minSrcs[s] += (nWarps-1)*BytePerHunk;
+    nWarps = nThreads / WARP_SIZE;
+#pragma unroll
+    for (int s = 0; s < MinSrcs; s++) {
+      minSrcs[s] += (nWarps - 1) * BytePerHunk;
     }
-    #pragma unroll
+#pragma unroll
     // Yes, for some template arguments this code will be unreachable.  That's fine.
     // coverity[dead_error_line]
-    for (int d=0; d < MinDsts; d++) {
-      minDsts[d] += (nWarps-1)*BytePerHunk;
+    for (int d = 0; d < MinDsts; d++) {
+      minDsts[d] += (nWarps - 1) * BytePerHunk;
     }
-    accPtr += (nWarps-1)*BytePerHunk;
-    threadBytesBehind += nWarps*BytePerHunk;
-    threadBytesAhead -= nWarps*BytePerHunk;
+    accPtr += (nWarps - 1) * BytePerHunk;
+    threadBytesBehind += nWarps * BytePerHunk;
+    threadBytesAhead -= nWarps * BytePerHunk;
     nHunksAhead -= nWarps;
   }
 
-  nWarps = nThreads/WARP_SIZE;
-  warp = thread/WARP_SIZE;
-  lane = thread%WARP_SIZE;
+  nWarps = nThreads / WARP_SIZE;
+  warp = thread / WARP_SIZE;
+  lane = thread % WARP_SIZE;
   // The last loop iteration could have been partial, i.e. not taken by all
   // threads. The threads that weren't included need an extra subtraction to
   // make the value warp uniform.
-  if (Unroll==1 && nHunksAhead > 0) nHunksAhead -= nWarps;
+  if (Unroll == 1 && nHunksAhead > 0) nHunksAhead -= nWarps;
   // Rotate warps so the warp which got the least work here will be warp 0.
   // This effectively assigns: warp = (warp-nHunks+nWarps)%nWarps;
   warp = -nHunksAhead;
-  thread = warp*WARP_SIZE + lane;
+  thread = warp * WARP_SIZE + lane;
 }
 
-template<int Unroll, int  useAcc, typename RedFn, typename T,
-         int MultimemSrcs, int MinSrcs, int MaxSrcs,
-         int MultimemDsts, int MinDsts, int MaxDsts, int PreOpSrcs,
-         typename IntBytes, int Pipeline, typename SrcPtrFn, typename DstPtrFn, typename AccPtrFn>
-__device__ __forceinline__ void reduceCopy(
-    int thread, int nThreads,
-    uint64_t redArg, bool postOp,
-    int nSrcs, SrcPtrFn const &srcPtrFn, int nDsts, DstPtrFn const &dstPtrFn,
-    IntBytes nElts, AccPtrFn const &accPtrFn
-  ) {
-  static_assert(MultimemSrcs <= MinSrcs && MultimemDsts <= MinDsts, "Multimem pointers cannot exceed respective Min values.");
-  //int nWarps = nThreads/WARP_SIZE;
-  //int warp = thread/WARP_SIZE;
+template <int Unroll, int useAcc, typename RedFn, typename T, int MultimemSrcs, int MinSrcs, int MaxSrcs,
+          int MultimemDsts, int MinDsts, int MaxDsts, int PreOpSrcs, typename IntBytes, int Pipeline, typename SrcPtrFn,
+          typename DstPtrFn, typename AccPtrFn>
+__device__ __forceinline__ void reduceCopy(int thread, int nThreads, uint64_t redArg, bool postOp, int nSrcs,
+                                           SrcPtrFn const& srcPtrFn, int nDsts, DstPtrFn const& dstPtrFn,
+                                           IntBytes nElts, AccPtrFn const& accPtrFn) {
+  static_assert(MultimemSrcs <= MinSrcs && MultimemDsts <= MinDsts,
+                "Multimem pointers cannot exceed respective Min values.");
+  // int nWarps = nThreads/WARP_SIZE;
+  // int warp = thread/WARP_SIZE;
   // If a multimem src is present then our biggest pack size is limited to what
   // is supported for this redfn/type.
   constexpr int BigPackSize = (MultimemSrcs == 0) ? 16 : LoadMultimem_BigPackSize<RedFn>::BigPackSize;
 
-  if (MaxDsts==0) return;
-  if (MinDsts==0 && nDsts==0) return;
+  if (MaxDsts == 0) return;
+  if (MinDsts == 0 && nDsts == 0) return;
 
   IntBytes nBytesBehind = 0;
-  IntBytes nBytesAhead = nElts*sizeof(T);
-  //bool useAcc = accPtrFn() != nullptr;
+  IntBytes nBytesAhead = nElts * sizeof(T);
+  // bool useAcc = accPtrFn() != nullptr;
   // For Dword or larger reads or writes, the two LSBs of the byte-address are ignored, thus forcing Dword
   // alignment.
   constexpr int AlignedPathPackSize = 4;
@@ -625,7 +601,7 @@ __device__ __forceinline__ void reduceCopy(
   if NCCL_IF_CONSTEXPR (BigPackSize > sizeof(T)) {
     // Check that all pointers are AlignedPathPackSize aligned.
     // nSrcs/nDsts never exceed WARP_SIZE, so one check per lane covers all pointers.
-    int lane = thread%WARP_SIZE;
+    int lane = thread % WARP_SIZE;
     bool aligned = true;
     if (lane < nSrcs) aligned &= 0 == cvta_to_global(srcPtrFn(lane)) % AlignedPathPackSize;
     if (lane < nDsts) aligned &= 0 == cvta_to_global(dstPtrFn(lane)) % AlignedPathPackSize;
@@ -634,54 +610,49 @@ __device__ __forceinline__ void reduceCopy(
     if (aligned) {
 #if defined(__gfx90a__)
       if constexpr (useAcc)
-        reduceCopyPacksWithBias<RedFn, T, ((MinSrcs > 1) ? 2 : Unroll), BigPackSize,
-          MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
-          (nThreads, thread, redArg, postOp,
-          nSrcs, srcPtrFn, nDsts, dstPtrFn, nBytesBehind, nBytesAhead, accPtrFn);
+        reduceCopyPacksWithBias<RedFn, T, ((MinSrcs > 1) ? 2 : Unroll), BigPackSize, MultimemSrcs, MinSrcs, MaxSrcs,
+                                MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>(
+          nThreads, thread, redArg, postOp, nSrcs, srcPtrFn, nDsts, dstPtrFn, nBytesBehind, nBytesAhead, accPtrFn);
       else if constexpr (Pipeline)
-        reduceCopyPacksPipelined<RedFn, T, ((MinSrcs > 1) ? 2 : Unroll), BigPackSize,
-          MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
-          (nThreads, thread, redArg, postOp,
-          nSrcs, srcPtrFn, nDsts, dstPtrFn, nBytesBehind, nBytesAhead);
+        reduceCopyPacksPipelined<RedFn, T, ((MinSrcs > 1) ? 2 : Unroll), BigPackSize, MultimemSrcs, MinSrcs, MaxSrcs,
+                                 MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>(
+          nThreads, thread, redArg, postOp, nSrcs, srcPtrFn, nDsts, dstPtrFn, nBytesBehind, nBytesAhead);
       else
-        reduceCopyPacks<RedFn, T, ((MinSrcs > 1) ? 2 : Unroll), BigPackSize,
-          MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
-          (nThreads, thread, redArg, postOp,
-          nSrcs, srcPtrFn, nDsts, dstPtrFn, nBytesBehind, nBytesAhead);
+        reduceCopyPacks<RedFn, T, ((MinSrcs > 1) ? 2 : Unroll), BigPackSize, MultimemSrcs, MinSrcs, MaxSrcs,
+                        MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>(nThreads, thread, redArg, postOp, nSrcs, srcPtrFn,
+                                                                   nDsts, dstPtrFn, nBytesBehind, nBytesAhead);
 #else
       if constexpr (useAcc)
-        reduceCopyPacksWithBias<RedFn, T, Unroll*((MinSrcs == 1 && MinDsts == 1) ? 2 : 1), BigPackSize,
-          MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
-          (nThreads, /*&*/thread, redArg, postOp,
-          nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead, accPtrFn);
-      else if constexpr  (Pipeline)
-        reduceCopyPacksPipelined<RedFn, T, Unroll*((MinSrcs == 1 && MinDsts == 1) ? 2 : 1), BigPackSize,
-        MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
-        (nThreads, /*&*/thread, redArg, postOp,
-         nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead);
+        reduceCopyPacksWithBias<RedFn, T, Unroll*((MinSrcs == 1 && MinDsts == 1) ? 2 : 1), BigPackSize, MultimemSrcs,
+                                MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>(
+          nThreads, /*&*/ thread, redArg, postOp, nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/ nBytesBehind,
+          /*&*/ nBytesAhead, accPtrFn);
+      else if constexpr (Pipeline)
+        reduceCopyPacksPipelined<RedFn, T, Unroll*((MinSrcs == 1 && MinDsts == 1) ? 2 : 1), BigPackSize, MultimemSrcs,
+                                 MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>(
+          nThreads, /*&*/ thread, redArg, postOp, nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/ nBytesBehind,
+          /*&*/ nBytesAhead);
       else
-        reduceCopyPacks<RedFn, T, Unroll*((MinSrcs == 1 && MinDsts == 1) ? 2 : 1), BigPackSize,
-          MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
-          (nThreads, /*&*/thread, redArg, postOp,
-          nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead);
+        reduceCopyPacks<RedFn, T, Unroll*((MinSrcs == 1 && MinDsts == 1) ? 2 : 1), BigPackSize, MultimemSrcs, MinSrcs,
+                        MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>(nThreads, /*&*/ thread, redArg, postOp,
+                                                                            nSrcs, srcPtrFn, nDsts, dstPtrFn,
+                                                                            /*&*/ nBytesBehind, /*&*/ nBytesAhead);
 #endif
       if (nBytesAhead == 0) return;
 
       if constexpr (useAcc)
-        reduceCopyPacksWithBias<RedFn, T, /*Unroll=*/1, BigPackSize,
-          MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
-          (nThreads, /*&*/thread, redArg, postOp,
-          nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead, accPtrFn);
+        reduceCopyPacksWithBias<RedFn, T, /*Unroll=*/1, BigPackSize, MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts,
+                                MinDsts, MaxDsts, PreOpSrcs>(nThreads, /*&*/ thread, redArg, postOp, nSrcs, srcPtrFn,
+                                                             nDsts, dstPtrFn, /*&*/ nBytesBehind, /*&*/ nBytesAhead,
+                                                             accPtrFn);
       else if constexpr (Pipeline)
-        reduceCopyPacksPipelined<RedFn, T, /*Unroll=*/1, BigPackSize,
-          MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
-          (nThreads, /*&*/thread, redArg, postOp,
-          nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead);
+        reduceCopyPacksPipelined<RedFn, T, /*Unroll=*/1, BigPackSize, MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts,
+                                 MinDsts, MaxDsts, PreOpSrcs>(nThreads, /*&*/ thread, redArg, postOp, nSrcs, srcPtrFn,
+                                                              nDsts, dstPtrFn, /*&*/ nBytesBehind, /*&*/ nBytesAhead);
       else
-        reduceCopyPacks<RedFn, T, /*Unroll=*/1, BigPackSize,
-          MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
-          (nThreads, /*&*/thread, redArg, postOp,
-          nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead);
+        reduceCopyPacks<RedFn, T, /*Unroll=*/1, BigPackSize, MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts,
+                        MaxDsts, PreOpSrcs>(nThreads, /*&*/ thread, redArg, postOp, nSrcs, srcPtrFn, nDsts, dstPtrFn,
+                                            /*&*/ nBytesBehind, /*&*/ nBytesAhead);
 
       if (nBytesAhead == 0) return;
     }
@@ -689,113 +660,99 @@ __device__ __forceinline__ void reduceCopy(
 
 /*
  * For gfx90a,
-* Before we had `Unroll/2*(16/sizeof(T))/2`, which does not work with unroll=1
-* as unroll=1; `Unroll/2` = 0, which results in the above expression to 0, and is not supported
-* This was reformulated to `(Unroll*4 + sizeof(T) - 1)/sizeof(T)`
-*
-* Before: `Unroll/2*(16/sizeof(T))/2`
-*         sizeof(T)
-* unroll  1   2   4   8
-*   4     16  8   4   2
-*   2     8   4   2   1
-*   1     0   0   0   0
-*
-* After: `(Unroll*4 + sizeof(T) - 1)/sizeof(T)`
-*         sizeof(T)
-* unroll  1   2   4   8
-*   4     16  8   4   2
-*   2     8   4   2   1
-*   1     4   2   1   1
-*/
+ * Before we had `Unroll/2*(16/sizeof(T))/2`, which does not work with unroll=1
+ * as unroll=1; `Unroll/2` = 0, which results in the above expression to 0, and is not supported
+ * This was reformulated to `(Unroll*4 + sizeof(T) - 1)/sizeof(T)`
+ *
+ * Before: `Unroll/2*(16/sizeof(T))/2`
+ *         sizeof(T)
+ * unroll  1   2   4   8
+ *   4     16  8   4   2
+ *   2     8   4   2   1
+ *   1     0   0   0   0
+ *
+ * After: `(Unroll*4 + sizeof(T) - 1)/sizeof(T)`
+ *         sizeof(T)
+ * unroll  1   2   4   8
+ *   4     16  8   4   2
+ *   2     8   4   2   1
+ *   1     4   2   1   1
+ */
 #if defined(__gfx90a__)
   if (MinSrcs > 1) {
     if constexpr (useAcc)
-      reduceCopyPacksWithBias<RedFn, T, (Unroll*4 + sizeof(T) - 1)/sizeof(T), sizeof(T),
-        MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
-        (nThreads, thread, redArg, postOp,
-        nSrcs, srcPtrFn, nDsts, dstPtrFn, nBytesBehind, nBytesAhead, accPtrFn);
+      reduceCopyPacksWithBias<RedFn, T, (Unroll * 4 + sizeof(T) - 1) / sizeof(T), sizeof(T), MultimemSrcs, MinSrcs,
+                              MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>(
+        nThreads, thread, redArg, postOp, nSrcs, srcPtrFn, nDsts, dstPtrFn, nBytesBehind, nBytesAhead, accPtrFn);
     else if constexpr (Pipeline)
-      reduceCopyPacksPipelined<RedFn, T, (Unroll*4 + sizeof(T) - 1)/sizeof(T), sizeof(T),
-        MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
-        (nThreads, thread, redArg, postOp,
-        nSrcs, srcPtrFn, nDsts, dstPtrFn, nBytesBehind, nBytesAhead);
+      reduceCopyPacksPipelined<RedFn, T, (Unroll * 4 + sizeof(T) - 1) / sizeof(T), sizeof(T), MultimemSrcs, MinSrcs,
+                               MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>(
+        nThreads, thread, redArg, postOp, nSrcs, srcPtrFn, nDsts, dstPtrFn, nBytesBehind, nBytesAhead);
     else
-      reduceCopyPacks<RedFn, T, (Unroll*4 + sizeof(T) - 1)/sizeof(T), sizeof(T),
-        MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
-        (nThreads, thread, redArg, postOp,
-        nSrcs, srcPtrFn, nDsts, dstPtrFn, nBytesBehind, nBytesAhead);
+      reduceCopyPacks<RedFn, T, (Unroll * 4 + sizeof(T) - 1) / sizeof(T), sizeof(T), MultimemSrcs, MinSrcs, MaxSrcs,
+                      MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>(nThreads, thread, redArg, postOp, nSrcs, srcPtrFn,
+                                                                 nDsts, dstPtrFn, nBytesBehind, nBytesAhead);
   } else {
     if constexpr (useAcc)
-      reduceCopyPacksWithBias<RedFn, T, Unroll*(16/sizeof(T))/2, /*BytePerPack=*/sizeof(T),
-        MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
-        (nThreads, /*&*/thread, redArg, postOp,
-        nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead, accPtrFn);
+      reduceCopyPacksWithBias<RedFn, T, Unroll * (16 / sizeof(T)) / 2, /*BytePerPack=*/sizeof(T), MultimemSrcs, MinSrcs,
+                              MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>(nThreads, /*&*/ thread, redArg,
+                                                                                  postOp, nSrcs, srcPtrFn, nDsts,
+                                                                                  dstPtrFn, /*&*/ nBytesBehind,
+                                                                                  /*&*/ nBytesAhead, accPtrFn);
     else if constexpr (Pipeline)
-      reduceCopyPacksPipelined<RedFn, T, Unroll*(16/sizeof(T))/2, /*BytePerPack=*/sizeof(T),
-        MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
-        (nThreads, /*&*/thread, redArg, postOp,
-        nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead);
+      reduceCopyPacksPipelined<RedFn, T, Unroll * (16 / sizeof(T)) / 2, /*BytePerPack=*/sizeof(T), MultimemSrcs,
+                               MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>(
+        nThreads, /*&*/ thread, redArg, postOp, nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/ nBytesBehind,
+        /*&*/ nBytesAhead);
     else
-      reduceCopyPacks<RedFn, T, Unroll*(16/sizeof(T))/2, /*BytePerPack=*/sizeof(T),
-        MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
-        (nThreads, /*&*/thread, redArg, postOp,
-        nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead);
+      reduceCopyPacks<RedFn, T, Unroll * (16 / sizeof(T)) / 2, /*BytePerPack=*/sizeof(T), MultimemSrcs, MinSrcs,
+                      MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>(nThreads, /*&*/ thread, redArg, postOp, nSrcs,
+                                                                          srcPtrFn, nDsts, dstPtrFn, /*&*/ nBytesBehind,
+                                                                          /*&*/ nBytesAhead);
   }
 #else
   if constexpr (useAcc)
-    reduceCopyPacksWithBias<RedFn, T, Unroll*(16/sizeof(T))/2, /*BytePerPack=*/sizeof(T),
-      MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
-      (nThreads, /*&*/thread, redArg, postOp,
-      nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead, accPtrFn);
+    reduceCopyPacksWithBias<RedFn, T, Unroll * (16 / sizeof(T)) / 2, /*BytePerPack=*/sizeof(T), MultimemSrcs, MinSrcs,
+                            MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>(nThreads, /*&*/ thread, redArg, postOp,
+                                                                                nSrcs, srcPtrFn, nDsts, dstPtrFn,
+                                                                                /*&*/ nBytesBehind, /*&*/ nBytesAhead,
+                                                                                accPtrFn);
   else if constexpr (Pipeline)
-    reduceCopyPacksPipelined<RedFn, T, Unroll*(16/sizeof(T))/2, /*BytePerPack=*/sizeof(T),
-      MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
-      (nThreads, /*&*/thread, redArg, postOp,
-      nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead);
+    reduceCopyPacksPipelined<RedFn, T, Unroll * (16 / sizeof(T)) / 2, /*BytePerPack=*/sizeof(T), MultimemSrcs, MinSrcs,
+                             MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>(
+      nThreads, /*&*/ thread, redArg, postOp, nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/ nBytesBehind, /*&*/ nBytesAhead);
   else
-    reduceCopyPacks<RedFn, T, Unroll*(16/sizeof(T))/2, /*BytePerPack=*/sizeof(T),
-      MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
-      (nThreads, /*&*/thread, redArg, postOp,
-      nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead);
+    reduceCopyPacks<RedFn, T, Unroll * (16 / sizeof(T)) / 2, /*BytePerPack=*/sizeof(T), MultimemSrcs, MinSrcs, MaxSrcs,
+                    MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>(nThreads, /*&*/ thread, redArg, postOp, nSrcs, srcPtrFn,
+                                                               nDsts, dstPtrFn, /*&*/ nBytesBehind, /*&*/ nBytesAhead);
 
 #endif
   if (nBytesAhead == 0) return;
 
   if constexpr (useAcc)
-    reduceCopyPacksWithBias<RedFn, T, /*Unroll=*/1, /*BytePerPack=*/sizeof(T),
-      MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
-      (nThreads, /*&*/thread, redArg, postOp,
-      nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead, accPtrFn);
+    reduceCopyPacksWithBias<RedFn, T, /*Unroll=*/1, /*BytePerPack=*/sizeof(T), MultimemSrcs, MinSrcs, MaxSrcs,
+                            MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>(nThreads, /*&*/ thread, redArg, postOp, nSrcs,
+                                                                       srcPtrFn, nDsts, dstPtrFn, /*&*/ nBytesBehind,
+                                                                       /*&*/ nBytesAhead, accPtrFn);
   else if constexpr (Pipeline)
-    reduceCopyPacksPipelined<RedFn, T, /*Unroll=*/1, /*BytePerPack=*/sizeof(T),
-      MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
-      (nThreads, /*&*/thread, redArg, postOp,
-      nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead);
+    reduceCopyPacksPipelined<RedFn, T, /*Unroll=*/1, /*BytePerPack=*/sizeof(T), MultimemSrcs, MinSrcs, MaxSrcs,
+                             MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>(
+      nThreads, /*&*/ thread, redArg, postOp, nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/ nBytesBehind, /*&*/ nBytesAhead);
   else
-    reduceCopyPacks<RedFn, T, /*Unroll=*/1, /*BytePerPack=*/sizeof(T),
-      MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs>
-      (nThreads, /*&*/thread, redArg, postOp,
-      nSrcs, srcPtrFn, nDsts, dstPtrFn, /*&*/nBytesBehind, /*&*/nBytesAhead);
-
+    reduceCopyPacks<RedFn, T, /*Unroll=*/1, /*BytePerPack=*/sizeof(T), MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts,
+                    MinDsts, MaxDsts, PreOpSrcs>(nThreads, /*&*/ thread, redArg, postOp, nSrcs, srcPtrFn, nDsts,
+                                                 dstPtrFn, /*&*/ nBytesBehind, /*&*/ nBytesAhead);
 }
 
-
-template<int Unroll, int useAcc, typename RedFn, typename T,
-         int MultimemSrcs, int MinSrcs, int MaxSrcs,
-         int MultimemDsts, int MinDsts, int MaxDsts, int PreOpSrcs,
-         int Pipeline = 0, typename IntBytes>
-__device__ __forceinline__ void reduceCopy(
-    int thread, int nThreads,
-    uint64_t redArg, bool postOp,
-    int nSrcs, void** srcPtrs, int nDsts, void** dstPtrs,
-    IntBytes nElts, void *accPtr = nullptr
-  ) {
-  reduceCopy<Unroll, useAcc, RedFn, T,
-             MultimemSrcs, MinSrcs, MaxSrcs,
-             MultimemDsts, MinDsts, MaxDsts, PreOpSrcs, IntBytes, Pipeline>
-    (thread, nThreads, redArg, postOp,
-     nSrcs, [=]__device__(int i) { return srcPtrs[i]; },
-     nDsts, [=]__device__(int i) { return dstPtrs[i]; }, nElts, [=]__device__() { return accPtr; });
+template <int Unroll, int useAcc, typename RedFn, typename T, int MultimemSrcs, int MinSrcs, int MaxSrcs,
+          int MultimemDsts, int MinDsts, int MaxDsts, int PreOpSrcs, int Pipeline = 0, typename IntBytes>
+__device__ __forceinline__ void reduceCopy(int thread, int nThreads, uint64_t redArg, bool postOp, int nSrcs,
+                                           void** srcPtrs, int nDsts, void** dstPtrs, IntBytes nElts,
+                                           void* accPtr = nullptr) {
+  reduceCopy<Unroll, useAcc, RedFn, T, MultimemSrcs, MinSrcs, MaxSrcs, MultimemDsts, MinDsts, MaxDsts, PreOpSrcs,
+             IntBytes, Pipeline>(
+    thread, nThreads, redArg, postOp, nSrcs, [=] __device__(int i) { return srcPtrs[i]; }, nDsts,
+    [=] __device__(int i) { return dstPtrs[i]; }, nElts, [=] __device__() { return accPtr; });
 }
 
 #endif // COMMON_KERNEL_H_

--- a/projects/rccl/src/device/hierarchical_ag_shuffle.h
+++ b/projects/rccl/src/device/hierarchical_ag_shuffle.h
@@ -3,19 +3,18 @@
 
 #include <hip/hip_runtime.h>
 
-/* 
-* Shuffle kernel for hierarchical allgather.
-* After inter-node AG and intra-node AG, the data in the temp buffer:
-*   src: [LR0:{N0,N1, ..., Nn}, LR1:{N0,N1, ..., Nn}, ..., LRk:{N0,N1, ..., Nn}]
-* this kernel shuffles the data to the following layout:
-*   dst: [N0:{LR0, LR1, ..., LRk}, N1:{LR0, LR1, ..., LRk}, ..., Nn:{LR0, LR1, ..., LRk}]
-*
-* Uses int4 vectorized copies
-* Work is distributed across blocks via block-strided loop.
-*/
-static __global__ __launch_bounds__(1024)
-void hierarchicalAGShuffle(const char* __restrict__ src, char* __restrict__ dst,
-    size_t rankOffset, int nNodes, int localRanks) {
+/*
+ * Shuffle kernel for hierarchical allgather.
+ * After inter-node AG and intra-node AG, the data in the temp buffer:
+ *   src: [LR0:{N0,N1, ..., Nn}, LR1:{N0,N1, ..., Nn}, ..., LRk:{N0,N1, ..., Nn}]
+ * this kernel shuffles the data to the following layout:
+ *   dst: [N0:{LR0, LR1, ..., LRk}, N1:{LR0, LR1, ..., LRk}, ..., Nn:{LR0, LR1, ..., LRk}]
+ *
+ * Uses int4 vectorized copies
+ * Work is distributed across blocks via block-strided loop.
+ */
+static __global__ __launch_bounds__(1024) void hierarchicalAGShuffle(
+  const char* __restrict__ src, char* __restrict__ dst, size_t rankOffset, int nNodes, int localRanks) {
   int totalPairs = nNodes * localRanks;
   size_t numInt4 = rankOffset / sizeof(int4);
 

--- a/projects/rccl/src/device/network/unpack/unpack.h
+++ b/projects/rccl/src/device/network/unpack/unpack.h
@@ -18,14 +18,13 @@
 
 // #define ALIGNED_LOAD
 
-inline __device__ void load64gpu(const uint64_t* ptr, uint64_t &v) {
-  #if __CUDA_ARCH__ >= 700
-      asm volatile("ld.relaxed.gpu.u64 {%0}, [%1];"
-      : "=l"(v) : "l"(ptr) : "memory");
-  #else
+inline __device__ void load64gpu(const uint64_t* ptr, uint64_t& v) {
+#if __CUDA_ARCH__ >= 700
+  asm volatile("ld.relaxed.gpu.u64 {%0}, [%1];" : "=l"(v) : "l"(ptr) : "memory");
+#else
       // asm volatile("ld.volatile.global.u64 {%0}, [%1];"
       // : "=l"(v) : "l"(ptr) : "memory");
-  #endif
+#endif
 }
 
 #define PAGE_META_SIZE 16
@@ -34,7 +33,7 @@ inline __device__ void load64gpu(const uint64_t* ptr, uint64_t &v) {
 
 // Map internal association of handle with group and peer index (called once at init time)
 inline __device__ void ncclNetDeviceUnpackSetup(void* ohandle, const int group, const int index) {
-  struct unpackNetDeviceHandle* handle = (struct unpackNetDeviceHandle*) ohandle;
+  struct unpackNetDeviceHandle* handle = (struct unpackNetDeviceHandle*)ohandle;
   // coverity[index_parm:FALSE]
   ncclShmem.groups[group].devicePlugin.unpack.g_meta[index] = handle->meta;
   ncclShmem.devicePlugin.unpack.bounce_buf = handle->bounce_buf;
@@ -48,100 +47,109 @@ inline __device__ void ncclNetDeviceIncrementHead(const int group, const int ind
 }
 
 inline __device__ void ncclNetDeviceSaveHead(void* ohandle, const int group, const int index) {
-  struct unpackNetDeviceHandle* handle = (struct unpackNetDeviceHandle*) ohandle;
+  struct unpackNetDeviceHandle* handle = (struct unpackNetDeviceHandle*)ohandle;
   // coverity[index_parm:FALSE]
   handle->head = ncclShmem.groups[group].devicePlugin.unpack.head[index];
 }
 
 template <uint8_t sz>
-inline __device__ void bulkLoad(const int t, const uint32_t len, char* cpy_src, char* cpy_dst, BytePack<sz> *reg, const int w, loadMeta* g_meta, loadMeta* s_meta, uint32_t src_off, uint64_t dst_off){
+inline __device__ void bulkLoad(const int t, const uint32_t len, char* cpy_src, char* cpy_dst, BytePack<sz>* reg,
+                                const int w, loadMeta* g_meta, loadMeta* s_meta, uint32_t src_off, uint64_t dst_off) {
   bulkLoad<1>(t, len, cpy_src, cpy_dst, reg, w, g_meta, s_meta, src_off, dst_off);
 }
 
 template <>
-inline __device__ void bulkLoad<1>(const int t, const uint32_t len, char* cpy_src, char* cpy_dst, BytePack<1> reg[16], const int w, loadMeta* g_meta, loadMeta* s_meta, uint32_t src_off, uint64_t dst_off){
+inline __device__ void bulkLoad<1>(const int t, const uint32_t len, char* cpy_src, char* cpy_dst, BytePack<1> reg[16],
+                                   const int w, loadMeta* g_meta, loadMeta* s_meta, uint32_t src_off,
+                                   uint64_t dst_off) {
   uint64_t data_s;
   for (data_s = t * DATA_LOAD_SIZE; data_s + DATA_LOAD_SIZE - 1 < len; data_s += WARP_SIZE * DATA_LOAD_SIZE) {
-
 #ifdef ALIGNED_LOAD
-    load128 ((uint64_t*)(cpy_src + data_s), reg.u64[0], reg.u64[1]);
+    load128((uint64_t*)(cpy_src + data_s), reg.u64[0], reg.u64[1]);
 #else
 #pragma unroll
-    for (int i=0; i<16; i++) {
+    for (int i = 0; i < 16; i++) {
       reg[i] = ld_volatile_global<1>((uintptr_t)((uint8_t*)(cpy_src + data_s) + i));
     }
 #endif
 
 #pragma unroll
-    for (int i=0; i<16; i++) {
+    for (int i = 0; i < 16; i++) {
       st_global<1>((uintptr_t)((uint8_t*)(cpy_dst + data_s) + i), reg[i]);
     }
   }
 }
 
 template <>
-inline __device__ void bulkLoad<2>(const int t, const uint32_t len, char* cpy_src, char* cpy_dst, BytePack<2> reg[8], const int w, loadMeta* g_meta, loadMeta* s_meta, uint32_t src_off, uint64_t dst_off){
+inline __device__ void bulkLoad<2>(const int t, const uint32_t len, char* cpy_src, char* cpy_dst, BytePack<2> reg[8],
+                                   const int w, loadMeta* g_meta, loadMeta* s_meta, uint32_t src_off,
+                                   uint64_t dst_off) {
   uint64_t data_s;
   for (data_s = t * DATA_LOAD_SIZE; data_s + DATA_LOAD_SIZE - 1 < len; data_s += WARP_SIZE * DATA_LOAD_SIZE) {
 #ifdef ALIGNED_LOAD
-    load128 ((uint64_t*)(cpy_src + data_s), reg.u64[0], reg.u64[1]);
+    load128((uint64_t*)(cpy_src + data_s), reg.u64[0], reg.u64[1]);
 #else
 #pragma unroll
-    for (int i=0; i<8; i++) {
+    for (int i = 0; i < 8; i++) {
       reg[i] = ld_volatile_global<2>((uintptr_t)((uint16_t*)(cpy_src + data_s) + i));
     }
 #endif
 
-
 #pragma unroll
-    for (int i=0; i<8; i++) {
+    for (int i = 0; i < 8; i++) {
       st_global<2>((uintptr_t)((uint16_t*)(cpy_dst + data_s) + i), reg[i]);
     }
   }
 }
 
 template <>
-inline __device__ void bulkLoad<4>(const int t, const uint32_t len, char* cpy_src, char* cpy_dst, BytePack<4> reg[4], const int w, loadMeta* g_meta, loadMeta* s_meta, uint32_t src_off, uint64_t dst_off){
+inline __device__ void bulkLoad<4>(const int t, const uint32_t len, char* cpy_src, char* cpy_dst, BytePack<4> reg[4],
+                                   const int w, loadMeta* g_meta, loadMeta* s_meta, uint32_t src_off,
+                                   uint64_t dst_off) {
   uint64_t data_s;
   for (data_s = t * DATA_LOAD_SIZE; data_s + DATA_LOAD_SIZE - 1 < len; data_s += WARP_SIZE * DATA_LOAD_SIZE) {
 #ifdef ALIGNED_LOAD
-    load128 ((uint64_t*)(cpy_src + data_s), reg.u64[0], reg.u64[1]);
+    load128((uint64_t*)(cpy_src + data_s), reg.u64[0], reg.u64[1]);
 #else
 #pragma unroll
-    for (int i=0; i<4; i++) {
-      reg[i] = ld_volatile_global<4>((uintptr_t)((uint32_t *)(cpy_src + data_s) + i));
+    for (int i = 0; i < 4; i++) {
+      reg[i] = ld_volatile_global<4>((uintptr_t)((uint32_t*)(cpy_src + data_s) + i));
     }
 #endif
 
 #pragma unroll
-    for (int i=0; i<4; i++) {
+    for (int i = 0; i < 4; i++) {
       st_global<4>((uintptr_t)((uint32_t*)(cpy_dst + data_s) + i), reg[i]);
     }
   }
 }
 
 template <>
-inline __device__ void bulkLoad<8>(const int t, const uint32_t len, char* cpy_src, char* cpy_dst, BytePack<8> reg[2], const int w, loadMeta* g_meta, loadMeta* s_meta, uint32_t src_off, uint64_t dst_off){
+inline __device__ void bulkLoad<8>(const int t, const uint32_t len, char* cpy_src, char* cpy_dst, BytePack<8> reg[2],
+                                   const int w, loadMeta* g_meta, loadMeta* s_meta, uint32_t src_off,
+                                   uint64_t dst_off) {
   uint64_t data_s;
   for (data_s = t * DATA_LOAD_SIZE; data_s + DATA_LOAD_SIZE - 1 < len; data_s += WARP_SIZE * DATA_LOAD_SIZE) {
 #ifdef ALIGNED_LOAD
-    load128 ((uint64_t*)(cpy_src + data_s), reg.u64[0], reg.u64[1]);
+    load128((uint64_t*)(cpy_src + data_s), reg.u64[0], reg.u64[1]);
 #else
 #pragma unroll
-    for (int i=0; i<2; i++) {
+    for (int i = 0; i < 2; i++) {
       reg[i] = ld_volatile_global<8>((uintptr_t)((uint64_t*)(cpy_src + data_s) + i));
     }
 #endif
 
 #pragma unroll
-    for (int i=0; i<2; i++) {
+    for (int i = 0; i < 2; i++) {
       st_global<8>((uintptr_t)((uint64_t*)(cpy_dst + data_s) + i), reg[i]);
     }
   }
 }
 
 template <>
-inline __device__ void bulkLoad<16>(const int t, const uint32_t len, char* cpy_src, char* cpy_dst, BytePack<16> reg[1], const int w, loadMeta* g_meta, loadMeta* s_meta, uint32_t src_off, uint64_t dst_off){
+inline __device__ void bulkLoad<16>(const int t, const uint32_t len, char* cpy_src, char* cpy_dst, BytePack<16> reg[1],
+                                    const int w, loadMeta* g_meta, loadMeta* s_meta, uint32_t src_off,
+                                    uint64_t dst_off) {
   uint64_t data_s;
   for (data_s = t * DATA_LOAD_SIZE; data_s + DATA_LOAD_SIZE - 1 < len; data_s += WARP_SIZE * DATA_LOAD_SIZE) {
     reg[0] = ld_volatile_global<16>((uintptr_t)(cpy_src + data_s));
@@ -165,37 +173,38 @@ inline __device__ int ppw(const int nbytes, int nw) {
 // Pack data from the internal iovec to the supplied flat buffer using all the
 // threads
 template <int Recv>
-inline __device__ void ncclNetDeviceUnpack(
-    const int tid, const int tidInBlock, const int nworkers, const int group, int mask, int Src, int workSize);
+inline __device__ void ncclNetDeviceUnpack(const int tid, const int tidInBlock, const int nworkers, const int group,
+                                           int mask, int Src, int workSize);
 
 template <>
-inline __device__ void ncclNetDeviceUnpack</*Recv=*/0>(
-    const int tid, const int tidInBlock, const int nworkers, const int group, int mask, int Src, int workSize) {
+inline __device__ void ncclNetDeviceUnpack</*Recv=*/0>(const int tid, const int tidInBlock, const int nworkers,
+                                                       const int group, int mask, int Src, int workSize) {
   // send unpack empty
 }
 
-inline __device__ void ncclNetDeviceUnpackInner(
-    const int tid, const int tidInBlock, const int nworkers, const int group, const int index,
-    void *src, const int nbytes, const uint64_t step);
+inline __device__ void ncclNetDeviceUnpackInner(const int tid, const int tidInBlock, const int nworkers,
+                                                const int group, const int index, void* src, const int nbytes,
+                                                const uint64_t step);
 
 template <>
-inline __device__ void ncclNetDeviceUnpack</*Recv=*/1>(
-    const int tid, const int tidInBlock, const int nworkers, const int group, int mask, int Src, int workSize) {
-
+inline __device__ void ncclNetDeviceUnpack</*Recv=*/1>(const int tid, const int tidInBlock, const int nworkers,
+                                                       const int group, int mask, int Src, int workSize) {
   while (mask != 0) {
-    int ix = __ffs(mask)-1; // Get the first set bit of the mask (this should correlate to a peer index)
-    mask &= mask-1; // Drop the first set bit of the mask
+    int ix = __ffs(mask) - 1; // Get the first set bit of the mask (this should correlate to a peer index)
+    mask &= mask - 1; // Drop the first set bit of the mask
 
     // Pack data from the internal iovec to the supplied flat srcs buffer using all the threads
     // + Src is necessary in the case of accessing the user buffer directly
-    ncclNetDeviceUnpackInner(tid, tidInBlock, nworkers, group /* in case they need to use split warps shared memory partitioning*/,
-      ix, ncclShmem.groups[group].srcs[ix + Src], workSize, ncclShmem.groups[group].devicePlugin.unpack.head[ix]);
+    ncclNetDeviceUnpackInner(tid, tidInBlock, nworkers,
+                             group /* in case they need to use split warps shared memory partitioning*/, ix,
+                             ncclShmem.groups[group].srcs[ix + Src], workSize,
+                             ncclShmem.groups[group].devicePlugin.unpack.head[ix]);
   }
 }
 
-inline __device__ void ncclNetDeviceUnpackInner(
-    const int tid, const int tidInBlock, const int nworkers, const int group, const int index,
-    void *src, const int nbytes, const uint64_t step) {
+inline __device__ void ncclNetDeviceUnpackInner(const int tid, const int tidInBlock, const int nworkers,
+                                                const int group, const int index, void* src, const int nbytes,
+                                                const uint64_t step) {
   // from src/collectives/device/common_kernel.h
   const int w = tid / WARP_SIZE;        // Warp number
   const int nw = nworkers / WARP_SIZE;  // Number of warps
@@ -213,9 +222,9 @@ inline __device__ void ncclNetDeviceUnpackInner(
   uint64_t meta_cnt;
 
   // hack head use per-warp
-  head          = step;
+  head = step;
   g_meta_struct = ncclShmem.groups[group].devicePlugin.unpack.g_meta[index];
-  bounce_buf    = ncclShmem.devicePlugin.unpack.bounce_buf;
+  bounce_buf = ncclShmem.devicePlugin.unpack.bounce_buf;
 
   __syncwarp();
 
@@ -226,7 +235,8 @@ inline __device__ void ncclNetDeviceUnpackInner(
   // Currently, even/odd groups perform send/recv separately. We don't really need space for send side.
   // Total size is N page per warp * 16 B per page * 20 WARPS max = 320 * N bytes, N == WARP_SHM_PAGE_CNT
   static_assert(ncclShmemScratchWarpSize() >= WARP_SHM_SIZE, "Each warp must have enough scratch space");
-  s_meta = (loadMeta*) ncclScratchForWarp(tidInBlock / WARP_SIZE); // (loadMeta*) (ncclShmem.devicePlugin.unpack.meta + shm_off);
+  s_meta = (loadMeta*)ncclScratchForWarp(tidInBlock /
+                                         WARP_SIZE); // (loadMeta*) (ncclShmem.devicePlugin.unpack.meta + shm_off);
 
   load64gpu(g_meta_struct->cnt + head, meta_cnt);
 
@@ -235,15 +245,14 @@ inline __device__ void ncclNetDeviceUnpackInner(
   // Coverity reports a potential overflow but in reality PPW is tiny so there's no need to store it in an uint64_t.
   // coverity[overflow_before_widen]
   for (uint64_t meta_s = w * PPW; meta_s < meta_cnt; meta_s += nw * PPW) {
-
     uint64_t iter_meta_cnt = meta_cnt - meta_s;
     iter_meta_cnt = iter_meta_cnt < PPW ? iter_meta_cnt : PPW;
 
     // TODO: this load size needs to work if not aligned, but since the two are both 16...
     if (t < PPW * PAGE_META_SIZE / META_LOAD_SIZE && t < iter_meta_cnt) {  // avoid last iter load garbage data
-      load128((const uint64_t*) (g_meta + (meta_s + t)), reg.u64[0], reg.u64[1]);
+      load128((const uint64_t*)(g_meta + (meta_s + t)), reg.u64[0], reg.u64[1]);
 
-      storeShmem128(shmemCvtPtr((uint64_t *)(s_meta + (w * PPW + t))), reg.u64[0], reg.u64[1]);
+      storeShmem128(shmemCvtPtr((uint64_t*)(s_meta + (w * PPW + t))), reg.u64[0], reg.u64[1]);
     }
 
     __syncwarp();
@@ -252,7 +261,7 @@ inline __device__ void ncclNetDeviceUnpackInner(
       int meta_idx = x + w * PPW;
 
       // load page offs
-      loadShmem128(shmemCvtPtr((uint64_t*) (s_meta + meta_idx)), meta.r64[0], meta.r64[1]);
+      loadShmem128(shmemCvtPtr((uint64_t*)(s_meta + meta_idx)), meta.r64[0], meta.r64[1]);
 
       if (meta.len >= DATA_LOAD_SIZE) {
         // fast path, but need to adapt to alignment issue
@@ -261,22 +270,27 @@ inline __device__ void ncclNetDeviceUnpackInner(
         uint8_t align_off = (meta.src_off | meta.dst_off) % DATA_LOAD_SIZE;
         align_off = align_off & -align_off;  // keep the lowest bit
         if (align_off == 0) {  // 0x16
-          bulkLoad<16>(t, meta.len, (char*) bounce_buf + meta.src_off, (char*) src + meta.dst_off, &reg, w, g_meta, s_meta, meta.src_off, meta.dst_off);
+          bulkLoad<16>(t, meta.len, (char*)bounce_buf + meta.src_off, (char*)src + meta.dst_off, &reg, w, g_meta,
+                       s_meta, meta.src_off, meta.dst_off);
         } else if (align_off & 0x8) {
-          bulkLoad<8>(t, meta.len, (char*) bounce_buf + meta.src_off, (char*) src + meta.dst_off, (BytePack<8>*) &reg, w, g_meta, s_meta, meta.src_off, meta.dst_off);
+          bulkLoad<8>(t, meta.len, (char*)bounce_buf + meta.src_off, (char*)src + meta.dst_off, (BytePack<8>*)&reg, w,
+                      g_meta, s_meta, meta.src_off, meta.dst_off);
         } else if (align_off & 0x4) {
-          bulkLoad<4>(t, meta.len, (char*) bounce_buf + meta.src_off, (char*) src + meta.dst_off, (BytePack<4>*) &reg, w, g_meta, s_meta, meta.src_off, meta.dst_off);
+          bulkLoad<4>(t, meta.len, (char*)bounce_buf + meta.src_off, (char*)src + meta.dst_off, (BytePack<4>*)&reg, w,
+                      g_meta, s_meta, meta.src_off, meta.dst_off);
         } else if (align_off & 0x2) {
-          bulkLoad<2>(t, meta.len, (char*) bounce_buf + meta.src_off, (char*) src + meta.dst_off, (BytePack<2>*) &reg, w, g_meta, s_meta, meta.src_off, meta.dst_off);
+          bulkLoad<2>(t, meta.len, (char*)bounce_buf + meta.src_off, (char*)src + meta.dst_off, (BytePack<2>*)&reg, w,
+                      g_meta, s_meta, meta.src_off, meta.dst_off);
         } else { // if (align_off & 0x1)
-          bulkLoad<1>(t, meta.len, (char*) bounce_buf + meta.src_off, (char*) src + meta.dst_off, (BytePack<1>*) &reg, w, g_meta, s_meta, meta.src_off, meta.dst_off);
+          bulkLoad<1>(t, meta.len, (char*)bounce_buf + meta.src_off, (char*)src + meta.dst_off, (BytePack<1>*)&reg, w,
+                      g_meta, s_meta, meta.src_off, meta.dst_off);
         }
       }
 
       // must be less than 16 bytes
       if (t < meta.len % DATA_LOAD_SIZE) {
-        volatile char* cpy_src = (char*) bounce_buf + meta.src_off + (meta.len / DATA_LOAD_SIZE) * DATA_LOAD_SIZE + t;
-        volatile char* cpy_dst = (char*) src        + meta.dst_off + (meta.len / DATA_LOAD_SIZE) * DATA_LOAD_SIZE + t;
+        volatile char* cpy_src = (char*)bounce_buf + meta.src_off + (meta.len / DATA_LOAD_SIZE) * DATA_LOAD_SIZE + t;
+        volatile char* cpy_dst = (char*)src + meta.dst_off + (meta.len / DATA_LOAD_SIZE) * DATA_LOAD_SIZE + t;
         *cpy_dst = *cpy_src;
       }
     }

--- a/projects/rccl/src/device/network/unpack/unpack_defs.h
+++ b/projects/rccl/src/device/network/unpack/unpack_defs.h
@@ -30,8 +30,7 @@ static_assert(sizeof(union loadMeta) == 16, "Must be 16-byte aligned");
 #define NET_UNPACK_MAX_QUEUE_DEPTH 16  // MAX_REQUESTS
 #define NET_UNPACK_MAX_SLICE_SIZE 4194304  // 4MB per Irecv call
 #define SLICE_PAGE_SIZE 4096
-#define NET_UNPACK_MAX_SLICE_PAGES \
-  (NET_UNPACK_MAX_SLICE_SIZE / SLICE_PAGE_SIZE * 2)  // * 2 for slack, wasteful..
+#define NET_UNPACK_MAX_SLICE_PAGES (NET_UNPACK_MAX_SLICE_SIZE / SLICE_PAGE_SIZE * 2)  // * 2 for slack, wasteful..
 
 struct netUnpackMeta {
   loadMeta mem[NCCL_NET_DEVICE_UNPACK_MAX_QUEUE_DEPTH][NET_UNPACK_MAX_SLICE_PAGES];
@@ -39,7 +38,7 @@ struct netUnpackMeta {
 };
 
 struct unpackNetDeviceHandle {
-  struct netUnpackMeta *meta;  // mapped
+  struct netUnpackMeta* meta;  // mapped
   void* bounce_buf;
   uint64_t head;
 };

--- a/projects/rccl/src/device/onerank.cu
+++ b/projects/rccl/src/device/onerank.cu
@@ -19,59 +19,60 @@
 #endif
 
 namespace {
-  template<typename RedOp>
-  __global__ __launch_bounds__(512, 1)
-  void oneRankReduce(void* dst, void* src, void* acc, size_t nElts, uint64_t redOpArg, bool redOpArgIsPtr) {
-    using T = typename RedOp::EltType;
-    int tid = threadIdx.x;
-    int tn = blockDim.x;
-    int bid = blockIdx.x;
-    int bn = gridDim.x;
+template <typename RedOp>
+__global__ __launch_bounds__(512, 1) void oneRankReduce(void* dst, void* src, void* acc, size_t nElts,
+                                                        uint64_t redOpArg, bool redOpArgIsPtr) {
+  using T = typename RedOp::EltType;
+  int tid = threadIdx.x;
+  int tn = blockDim.x;
+  int bid = blockIdx.x;
+  int bn = gridDim.x;
 
     // each block/channel gets a roughly equal segment of 16 byte packs
-    constexpr int EltPerPack = 16/sizeof(T);
-    intptr_t i0 = (bid+0)*alignUp(divUp(nElts, bn), EltPerPack);
-    intptr_t i1 = (bid+1)*alignUp(divUp(nElts, bn), EltPerPack);
-    i0 = min(i0, nElts);
-    i1 = min(i1, nElts);
+  constexpr int EltPerPack = 16 / sizeof(T);
+  intptr_t i0 = (bid + 0) * alignUp(divUp(nElts, bn), EltPerPack);
+  intptr_t i1 = (bid + 1) * alignUp(divUp(nElts, bn), EltPerPack);
+  i0 = min(i0, nElts);
+  i1 = min(i1, nElts);
 
-    if (redOpArgIsPtr) {
-      if (redOpArg%2 != 0) {
-        redOpArg = *reinterpret_cast<uint8_t*>(redOpArg);
-      } else if (redOpArg%4 != 0) {
-        redOpArg = *reinterpret_cast<uint16_t*>(redOpArg);
-      } else if (redOpArg%8 != 0) {
-        redOpArg = *reinterpret_cast<uint32_t*>(redOpArg);
-      } else {
-        redOpArg = *reinterpret_cast<uint64_t*>(redOpArg);
-      }
-    }
-
-    if (acc != nullptr) {
-      void* srcPtr = (T*)src + i0;
-      void* accPtr = (T*)acc + i0;
-      void* dstPtr = (T*)dst + i0;
-      void* srcs[2] = {srcPtr, accPtr};
-      void* dsts[1] = {dstPtr};
-      reduceCopy<COLL_UNROLL, 0, RedOp, T, 0,2,2, 0,1,1, /*PreOpSrcs=*/1>
-        (tid, tn, redOpArg, true, 2, srcs, 1, dsts, i1-i0);
+  if (redOpArgIsPtr) {
+    if (redOpArg % 2 != 0) {
+      redOpArg = *reinterpret_cast<uint8_t*>(redOpArg);
+    } else if (redOpArg % 4 != 0) {
+      redOpArg = *reinterpret_cast<uint16_t*>(redOpArg);
+    } else if (redOpArg % 8 != 0) {
+      redOpArg = *reinterpret_cast<uint32_t*>(redOpArg);
     } else {
-      src = (T*)src + i0;
-      dst = (T*)dst + i0;
-      reduceCopy<COLL_UNROLL, 0, RedOp, T, 0,1,1, 0,1,1, /*PreOpSrcs=*/1>
-        (tid, tn, redOpArg, true, 1, &src, 1, &dst, i1-i0);
+      redOpArg = *reinterpret_cast<uint64_t*>(redOpArg);
     }
   }
-}
 
-ncclResult_t ncclLaunchOneRank(void* dst, void const* src, size_t nElts, struct ncclDevRedOpFull redOp, ncclDataType_t eltType, cudaStream_t stream, void const* acc) {
+  if (acc != nullptr) {
+    void* srcPtr = (T*)src + i0;
+    void* accPtr = (T*)acc + i0;
+    void* dstPtr = (T*)dst + i0;
+    void* srcs[2] = {srcPtr, accPtr};
+    void* dsts[1] = {dstPtr};
+    reduceCopy<COLL_UNROLL, 0, RedOp, T, 0, 2, 2, 0, 1, 1, /*PreOpSrcs=*/1>(tid, tn, redOpArg, true, 2, srcs, 1, dsts,
+                                                                            i1 - i0);
+  } else {
+    src = (T*)src + i0;
+    dst = (T*)dst + i0;
+    reduceCopy<COLL_UNROLL, 0, RedOp, T, 0, 1, 1, 0, 1, 1, /*PreOpSrcs=*/1>(tid, tn, redOpArg, true, 1, &src, 1, &dst,
+                                                                            i1 - i0);
+  }
+}
+} // namespace
+
+ncclResult_t ncclLaunchOneRank(void* dst, void const* src, size_t nElts, struct ncclDevRedOpFull redOp,
+                               ncclDataType_t eltType, cudaStream_t stream, void const* acc) {
   size_t eltSize = ncclTypeSize(eltType);
 
   // handles all_reduce for non-PreMulSum ops
   // for 1 rank, out-of-place is memcpy to self, and in-place is nop
   if (acc == nullptr && redOp.op != ncclDevPreMulSum) {
     if (dst != src) {
-      NCCLCHECK(ncclCudaMemcpyAsync((char*)dst, (char*)src, nElts*eltSize, stream));
+      NCCLCHECK(ncclCudaMemcpyAsync((char*)dst, (char*)src, nElts * eltSize, stream));
     }
     return ncclSuccess;
   }
@@ -92,37 +93,50 @@ ncclResult_t ncclLaunchOneRank(void* dst, void const* src, size_t nElts, struct 
 #define CASE(ncclDataType, dataType) \
   case ncclDataType: \
     switch (redOp.op) { \
-    case ncclDevSum: kernel = (void const*)&oneRankReduce<FuncSum<dataType>>; break; \
-    case ncclDevProd: kernel = (void const*)&oneRankReduce<FuncProd<dataType>>; break; \
-    case ncclDevMinMax: kernel = (void const*)&oneRankReduce<FuncMinMax<dataType>>; break; \
-    case ncclDevPreMulSum: kernel = (void const*)&oneRankReduce<FuncPreMulSum<dataType>>; break; \
-    case ncclDevSumPostDiv: kernel = (void const*)&oneRankReduce<FuncSum<dataType>>; break; \
-    default: return ncclInvalidArgument; \
-    } break;
+    case ncclDevSum: \
+      kernel = (void const*)&oneRankReduce<FuncSum<dataType>>; \
+      break; \
+    case ncclDevProd: \
+      kernel = (void const*)&oneRankReduce<FuncProd<dataType>>; \
+      break; \
+    case ncclDevMinMax: \
+      kernel = (void const*)&oneRankReduce<FuncMinMax<dataType>>; \
+      break; \
+    case ncclDevPreMulSum: \
+      kernel = (void const*)&oneRankReduce<FuncPreMulSum<dataType>>; \
+      break; \
+    case ncclDevSumPostDiv: \
+      kernel = (void const*)&oneRankReduce<FuncSum<dataType>>; \
+      break; \
+    default: \
+      return ncclInvalidArgument; \
+    } \
+    break;
 
   switch (eltType) {
-  CASE(ncclInt8, int8_t)
-  CASE(ncclUint8, uint8_t)
-  CASE(ncclInt32, int32_t)
-  CASE(ncclUint32, uint32_t)
-  CASE(ncclInt64, int64_t)
-  CASE(ncclUint64, uint64_t)
+    CASE(ncclInt8, int8_t)
+    CASE(ncclUint8, uint8_t)
+    CASE(ncclInt32, int32_t)
+    CASE(ncclUint32, uint32_t)
+    CASE(ncclInt64, int64_t)
+    CASE(ncclUint64, uint64_t)
 #if defined(RCCL_FLOAT8)
-  CASE(ncclFloat8e4m3, rccl_float8)
-  CASE(ncclFloat8e5m2, rccl_bfloat8)
+    CASE(ncclFloat8e4m3, rccl_float8)
+    CASE(ncclFloat8e5m2, rccl_bfloat8)
 #endif
-  CASE(ncclFloat16, half)
+    CASE(ncclFloat16, half)
 #if defined(RCCL_BFLOAT16)
-  CASE(ncclBfloat16, hip_bfloat16)
+    CASE(ncclBfloat16, hip_bfloat16)
 #endif
-  CASE(ncclFloat32, float)
-  CASE(ncclFloat64, double)
-  default: return ncclInvalidArgument;
+    CASE(ncclFloat32, float)
+    CASE(ncclFloat64, double)
+  default:
+    return ncclInvalidArgument;
   }
 #undef CASE
 
   dim3 grid = {0, 1, 1};
-  grid.x = std::min(32, (int)divUp(nElts*eltSize, 16<<10));
+  grid.x = std::min(32, (int)divUp(nElts * eltSize, 16 << 10));
   dim3 block = {512, 1, 1};
   void* mutableSrc = const_cast<void*>(src);
   void* mutableAcc = const_cast<void*>(acc);

--- a/projects/rccl/src/device/op128.h
+++ b/projects/rccl/src/device/op128.h
@@ -12,27 +12,33 @@
 
 #include "rccl_ptr.h"
 
-inline __device__ void load128(const uint64_t* ptr, uint64_t &v0, uint64_t &v1) {
+inline __device__ void load128(const uint64_t* ptr, uint64_t& v0, uint64_t& v1) {
 #if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
-  union { v4u v; uint64_t u64[2]; } u;
-  u.v = __builtin_amdgcn_global_load_b128((v4u_gptr) ptr, RCCL_SYSTEM_SYNCSCOPE);
+  union {
+    v4u v;
+    uint64_t u64[2];
+  } u;
+  u.v = __builtin_amdgcn_global_load_b128((v4u_gptr)ptr, RCCL_SYSTEM_SYNCSCOPE);
   v0 = u.u64[0];
   v1 = u.u64[1];
 #else
-  v0 = __builtin_nontemporal_load((u64_gptr) ptr);
-  v1 = __builtin_nontemporal_load((u64_gptr) ptr+1);
+  v0 = __builtin_nontemporal_load((u64_gptr)ptr);
+  v1 = __builtin_nontemporal_load((u64_gptr)ptr + 1);
 #endif
 }
 
 inline __device__ void store128(uint64_t* ptr, uint64_t v0, uint64_t v1) {
 #if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
-  union { v4u v; uint64_t u64[2]; } u;
+  union {
+    v4u v;
+    uint64_t u64[2];
+  } u;
   u.u64[0] = v0;
   u.u64[1] = v1;
-  __builtin_amdgcn_global_store_b128((v4u_gptr) ptr, u.v, RCCL_SYSTEM_SYNCSCOPE);
+  __builtin_amdgcn_global_store_b128((v4u_gptr)ptr, u.v, RCCL_SYSTEM_SYNCSCOPE);
 #else
-  *((u64_gptr) ptr) = v0;
-  *((u64_gptr) ptr + 1) = v1;
+  *((u64_gptr)ptr) = v0;
+  *((u64_gptr)ptr + 1) = v1;
 #endif
 }
 
@@ -40,63 +46,58 @@ inline __device__ uint64_t* shmemCvtPtr(volatile uint64_t* shmemGenericPtr) {
   return (uint64_t*)shmemGenericPtr;
 }
 
-inline __device__ void loadShmem128(uint64_t* shmemAsmPtr, uint64_t &v0, uint64_t &v1) {
+inline __device__ void loadShmem128(uint64_t* shmemAsmPtr, uint64_t& v0, uint64_t& v1) {
   v0 = *(shmemAsmPtr);
-  v1 = *(shmemAsmPtr+1);
+  v1 = *(shmemAsmPtr + 1);
 }
 
 inline __device__ void storeShmem128(uint64_t* shmemAsmPtr, uint64_t v0, uint64_t v1) {
   *(shmemAsmPtr) = v0;
-  *(shmemAsmPtr+1) = v1;
+  *(shmemAsmPtr + 1) = v1;
 }
 
-template<typename T>
-inline __device__ void loadShmemMisaligned128(T *ptr, uint64_t &v0, uint64_t &v1) {
+template <typename T>
+inline __device__ void loadShmemMisaligned128(T* ptr, uint64_t& v0, uint64_t& v1) {
   union {
     uint32_t tmp4[4];
     uint64_t tmp8[2];
   };
-  if(sizeof(T) < 4) {
-    uint32_t *ptr4 = reinterpret_cast<uint32_t*>(reinterpret_cast<uintptr_t>(ptr) & -uintptr_t(4));
-    #pragma unroll
-    for(int e=0; e < 4; e++) {
+  if (sizeof(T) < 4) {
+    uint32_t* ptr4 = reinterpret_cast<uint32_t*>(reinterpret_cast<uintptr_t>(ptr) & -uintptr_t(4));
+#pragma unroll
+    for (int e = 0; e < 4; e++) {
       // Produce 4 bytes of sub-register type by reading 2 4-byte
       // aligned values and shifting.
       uint32_t lo, hi;
-      lo = __builtin_nontemporal_load(ptr4+e+0);
-      hi = __builtin_nontemporal_load(ptr4+e+1);
-      tmp4[e] = __funnelshift_r(lo, hi, 8*(int(reinterpret_cast<uintptr_t>(ptr))%4));
+      lo = __builtin_nontemporal_load(ptr4 + e + 0);
+      hi = __builtin_nontemporal_load(ptr4 + e + 1);
+      tmp4[e] = __funnelshift_r(lo, hi, 8 * (int(reinterpret_cast<uintptr_t>(ptr)) % 4));
     }
-  }
-  else if(sizeof(T) == 4) {
-    #pragma unroll
-    for(int e=0; e < 4; e++)
-      tmp4[e] = __builtin_nontemporal_load(reinterpret_cast<uint32_t*>(ptr)+e);
-  }
-  else /*sizeof(T)==8*/ {
-    #pragma unroll
-    for(int e=0; e < 2; e++)
-      tmp8[e] = __builtin_nontemporal_load(reinterpret_cast<uint64_t*>(ptr)+e);
+  } else if (sizeof(T) == 4) {
+#pragma unroll
+    for (int e = 0; e < 4; e++) tmp4[e] = __builtin_nontemporal_load(reinterpret_cast<uint32_t*>(ptr) + e);
+  } else /*sizeof(T)==8*/ {
+#pragma unroll
+    for (int e = 0; e < 2; e++) tmp8[e] = __builtin_nontemporal_load(reinterpret_cast<uint64_t*>(ptr) + e);
   }
   v0 = tmp8[0];
   v1 = tmp8[1];
 }
 
-
-template<typename T>
+template <typename T>
 __device__ __forceinline__ uint32_t cvta_to_shared(T* ptr) {
   return (uint32_t)(uint64_t)(ptr);
 }
-template<typename T>
+template <typename T>
 __device__ __forceinline__ uintptr_t cvta_to_global(T* ptr) {
   return (uintptr_t)(ptr);
 }
 
-template<typename T>
+template <typename T>
 __device__ __forceinline__ T* cvta_from_shared(uint32_t shptr) {
   return (T*)shptr;
 }
-template<typename T>
+template <typename T>
 __device__ __forceinline__ T* cvta_from_global(uintptr_t gptr) {
   return (T*)gptr;
 }
@@ -104,22 +105,22 @@ __device__ __forceinline__ T* cvta_from_global(uintptr_t gptr) {
 ////////////////////////////////////////////////////////////////////////////////
 // BytePack<Size>: struct of bytes.
 
-template<int Size>
+template <int Size>
 union BytePack;
-template<>
+template <>
 union BytePack<0> {};
-template<>
+template <>
 union BytePack<1> {
   uint8_t u8[1], native;
 };
-template<>
+template <>
 union BytePack<2> {
   BytePack<1> half[2];
   BytePack<1> b1[2];
   uint8_t u8[2];
   uint16_t u16[1], native;
 };
-template<>
+template <>
 union BytePack<4> {
   BytePack<2> half[2];
   BytePack<1> b1[4];
@@ -137,7 +138,7 @@ union BytePack<4> {
     return *this;
   }
 };
-template<>
+template <>
 union BytePack<8> {
   BytePack<4> half[2];
   BytePack<1> b1[8];
@@ -157,7 +158,7 @@ union BytePack<8> {
     return *this;
   }
 };
-template<>
+template <>
 union alignas(16) BytePack<16> {
   BytePack<8> half[2];
   BytePack<1> b1[16];
@@ -180,45 +181,48 @@ union alignas(16) BytePack<16> {
     return *this;
   }
 };
-template<int Size>
+template <int Size>
 union BytePack {
-  BytePack<Size/2> half[2];
+  BytePack<Size / 2> half[2];
   BytePack<1> b1[Size];
-  BytePack<2> b2[Size/2];
-  BytePack<4> b4[Size/4];
-  BytePack<8> b8[Size/8];
-  BytePack<16> b16[Size/16];
+  BytePack<2> b2[Size / 2];
+  BytePack<4> b4[Size / 4];
+  BytePack<8> b8[Size / 8];
+  BytePack<16> b16[Size / 16];
   uint8_t u8[Size];
-  uint16_t u16[Size/2];
-  uint32_t u32[Size/4];
-  uint64_t u64[Size/8];
+  uint16_t u16[Size / 2];
+  uint32_t u32[Size / 4];
+  uint64_t u64[Size / 8];
 
   inline __device__ BytePack<Size>() = default;
   inline __device__ BytePack<Size>(const BytePack<Size>& other) {
     *this = other;
   }
   inline __device__ BytePack<Size>& operator=(const BytePack<Size>& other) {
-    for (int i = 0; i < Size/8; i++) {
+    for (int i = 0; i < Size / 8; i++) {
       u64[i] = other.u64[i];
     }
     return *this;
   }
 };
 
-template<typename T>
+template <typename T>
 struct BytePackOf {
   static constexpr int Size = sizeof(T);
   using Pack = BytePack<Size>;
 };
-template<>
+template <>
 struct BytePackOf<BytePack<0>> {
   static constexpr int Size = 0;
   using Pack = BytePack<0>;
 };
 
-template<typename T>
-__device__ __forceinline__ typename BytePackOf<T>::Pack toPack(T value)  {
-  union { typename BytePackOf<T>::Pack p; T v; };
+template <typename T>
+__device__ __forceinline__ typename BytePackOf<T>::Pack toPack(T value) {
+  union {
+    typename BytePackOf<T>::Pack p;
+    T v;
+  };
   // Coverity recommends the use of std::move here but, given that T is a POD
   // scalar, a plain copy will be just as efficient.
   // coverity[copy_assignment_call]
@@ -226,9 +230,12 @@ __device__ __forceinline__ typename BytePackOf<T>::Pack toPack(T value)  {
   return p;
 }
 
-template<typename T>
-__device__ __forceinline__ T fromPack(typename BytePackOf<T>::Pack pack)  {
-  union { typename BytePackOf<T>::Pack p; T v; };
+template <typename T>
+__device__ __forceinline__ T fromPack(typename BytePackOf<T>::Pack pack) {
+  union {
+    typename BytePackOf<T>::Pack p;
+    T v;
+  };
   p = pack;
   return v;
 }
@@ -236,67 +243,81 @@ __device__ __forceinline__ T fromPack(typename BytePackOf<T>::Pack pack)  {
 ////////////////////////////////////////////////////////////////////////////////
 // Load/store of BytePack<?> using integral addresses.
 
-template<int Size> __device__ BytePack<Size> ld_global(uintptr_t addr);
+template <int Size>
+__device__ BytePack<Size> ld_global(uintptr_t addr);
 // template<int Size> __device__ BytePack<Size> ld_shared(uint32_t addr);
-template<int Size> __device__ BytePack<Size> ld_volatile_global(uintptr_t addr);
+template <int Size>
+__device__ BytePack<Size> ld_volatile_global(uintptr_t addr);
 // template<int Size> __device__ BytePack<Size> ld_volatile_shared(uint32_t addr);
 // template<int Size> __device__ BytePack<Size> ld_relaxed_gpu_global(uintptr_t addr);
-template<int Size> __device__ void st_global(uintptr_t addr, BytePack<Size> value);
+template <int Size>
+__device__ void st_global(uintptr_t addr, BytePack<Size> value);
 // template<int Size> __device__ void st_shared(uint32_t addr, BytePack<Size> value);
 // template<int Size> __device__ void st_relaxed_gpu_global(uintptr_t addr, BytePack<Size> value);
 
-template<> __device__ __forceinline__ BytePack<0> ld_global<0>(uintptr_t addr) { return {}; }
+template <>
+__device__ __forceinline__ BytePack<0> ld_global<0>(uintptr_t addr) {
+  return {};
+}
 // template<> __device__ __forceinline__ BytePack<0> ld_shared<0>(uint32_t addr) { return {}; }
-template<> __device__ __forceinline__ BytePack<0> ld_volatile_global<0>(uintptr_t addr) { return {}; }
+template <>
+__device__ __forceinline__ BytePack<0> ld_volatile_global<0>(uintptr_t addr) {
+  return {};
+}
 // template<> __device__ __forceinline__ BytePack<0> ld_volatile_shared<0>(uint32_t addr) { return {}; }
 // template<> __device__ __forceinline__ BytePack<0> ld_relaxed_gpu_global<0>(uintptr_t addr) { return {}; }
-template<> __device__ __forceinline__ void st_global<0>(uintptr_t addr, BytePack<0> value) {}
+template <>
+__device__ __forceinline__ void st_global<0>(uintptr_t addr, BytePack<0> value) {}
 // template<> __device__ __forceinline__ void st_shared<0>(uint32_t addr, BytePack<0> value) {}
 // template<> __device__ __forceinline__ void st_relaxed_gpu_global<0>(uintptr_t addr, BytePack<0> value) {}
 
 // Used to define implementations for above prototypes.
-#define DEFINE_ld_st__size_space_hip_atomic(bytes, data_cxx_ty, data_ptx_ty, data_reg_ty, space, addr_cxx_ty, addr_reg_ty) \
-  template<> \
+#define DEFINE_ld_st__size_space_hip_atomic(bytes, data_cxx_ty, data_ptx_ty, data_reg_ty, space, addr_cxx_ty, \
+                                            addr_reg_ty) \
+  template <> \
   __device__ __forceinline__ BytePack<bytes> ld_##space<bytes>(addr_cxx_ty addr) { \
     data_cxx_ty tmp; \
-    tmp = *((__attribute__((address_space(1))) data_cxx_ty *)addr); \
+    tmp = *((__attribute__((address_space(1))) data_cxx_ty*)addr); \
     BytePack<bytes> ans; \
     ans.native = tmp; \
     return ans; \
   } \
-  template<> \
+  template <> \
   __device__ __forceinline__ BytePack<bytes> ld_volatile_##space<bytes>(addr_cxx_ty addr) { \
     data_cxx_ty tmp; \
-    tmp =  __hip_atomic_load((__attribute__((address_space(1))) data_cxx_ty *)addr, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM); \
+    tmp = __hip_atomic_load((__attribute__((address_space(1))) data_cxx_ty*)addr, __ATOMIC_RELAXED, \
+                            __HIP_MEMORY_SCOPE_SYSTEM); \
     BytePack<bytes> ans; \
     ans.native = tmp; \
     return ans; \
   } \
-  template<> \
+  template <> \
   __device__ __forceinline__ void st_##space<bytes>(addr_cxx_ty addr, BytePack<bytes> value) { \
-    __hip_atomic_store((__attribute__((address_space(1))) data_cxx_ty *)addr, value.native, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM); \
+    __hip_atomic_store((__attribute__((address_space(1))) data_cxx_ty*)addr, value.native, __ATOMIC_RELAXED, \
+                       __HIP_MEMORY_SCOPE_SYSTEM); \
   }
 
-#define DEFINE_ld_st__size_space_fallback(bytes, data_cxx_ty, data_ptx_ty, data_reg_ty, space, addr_cxx_ty, addr_reg_ty) \
-  template<> \
+#define DEFINE_ld_st__size_space_fallback(bytes, data_cxx_ty, data_ptx_ty, data_reg_ty, space, addr_cxx_ty, \
+                                          addr_reg_ty) \
+  template <> \
   __device__ __forceinline__ BytePack<bytes> ld_##space<bytes>(addr_cxx_ty addr) { \
     data_cxx_ty tmp; \
-    tmp = *((__attribute__((address_space(1))) data_cxx_ty *)addr); \
+    tmp = *((__attribute__((address_space(1))) data_cxx_ty*)addr); \
     BytePack<bytes> ans; \
     ans.native = tmp; \
     return ans; \
   } \
-  template<> \
+  template <> \
   __device__ __forceinline__ BytePack<bytes> ld_volatile_##space<bytes>(addr_cxx_ty addr) { \
     data_cxx_ty tmp; \
-    tmp = __builtin_nontemporal_load((__attribute__((address_space(1))) data_cxx_ty *)addr); \
+    tmp = __builtin_nontemporal_load((__attribute__((address_space(1))) data_cxx_ty*)addr); \
     BytePack<bytes> ans; \
     ans.native = tmp; \
     return ans; \
   } \
-  template<> \
+  template <> \
   __device__ __forceinline__ void st_##space<bytes>(addr_cxx_ty addr, BytePack<bytes> value) { \
-    __builtin_nontemporal_store(value.native, (__attribute__((address_space(1))) data_cxx_ty *)addr); \
+    __builtin_nontemporal_store(value.native, (__attribute__((address_space(1))) data_cxx_ty*)addr); \
   }
 
 #if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
@@ -330,59 +351,55 @@ template<> __device__ __forceinline__ void st_global<0>(uintptr_t addr, BytePack
 
 #define DEFINE_ld_st__size(bytes, data_cxx_ty, data_ptx_ty, data_reg_ty) \
   DEFINE_ld_st__size_space(bytes, data_cxx_ty, data_ptx_ty, data_reg_ty, global, uintptr_t, l)
-  // DEFINE_ld_st__size_space(bytes, data_cxx_ty, data_ptx_ty, data_reg_ty, shared, uint32_t, r)
-  // DEFINE_ld_st_gpu_relaxed__size(bytes, data_cxx_ty, data_ptx_ty, data_reg_ty)
+// DEFINE_ld_st__size_space(bytes, data_cxx_ty, data_ptx_ty, data_reg_ty, shared, uint32_t, r)
+// DEFINE_ld_st_gpu_relaxed__size(bytes, data_cxx_ty, data_ptx_ty, data_reg_ty)
 
 // Single-byte types use 4-byte registers since there is no 1-byte register
 // character for asm blocks. See https://docs.nvidia.com/cuda/inline-ptx-assembly/index.html#constraints
-DEFINE_ld_st__size(1, uint8_t, b8, r)
-DEFINE_ld_st__size(2, uint16_t, b16, h)
-DEFINE_ld_st__size(4, uint32_t, b32, r)
-DEFINE_ld_st__size(8, uint64_t, b64, l)
-
+DEFINE_ld_st__size(1, uint8_t, b8, r) DEFINE_ld_st__size(2, uint16_t, b16, h) DEFINE_ld_st__size(4, uint32_t, b32, r)
+  DEFINE_ld_st__size(8, uint64_t, b64, l)
 #undef DEFINE_ld_st__size_space
 #undef DEFINE_ld_st__size_space_hip_atomic
 #undef DEFINE_ld_st__size_space_fallback
 #undef DEFINE_ld_st__size
 
-
-__device__ __forceinline__ void store16global(uintptr_t addr, BytePack<16> value){  
-  #if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
-    // System scope store that bypasses the hardware caches, should generate global_store_dwordx4 instruction with sc0 and sc1 bits set to 1 on gfx942/gfx950. 
-    __builtin_amdgcn_global_store_b128((v4u_gptr) addr, value.v4u, RCCL_SYSTEM_SYNCSCOPE); 
-  #elif defined(__gfx950__)
-    *(v4u_gptr) addr = value.v4u;
-  #else
-    __builtin_nontemporal_store(value.u64[0], (u64_gptr) addr);
-    __builtin_nontemporal_store(value.u64[1], (u64_gptr) addr + 1);
-  #endif
+    __device__ __forceinline__ void store16global(uintptr_t addr, BytePack<16> value) {
+#if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
+  // System scope store that bypasses the hardware caches, should generate global_store_dwordx4 instruction with sc0 and sc1 bits set to 1 on gfx942/gfx950.
+  __builtin_amdgcn_global_store_b128((v4u_gptr)addr, value.v4u, RCCL_SYSTEM_SYNCSCOPE);
+#elif defined(__gfx950__)
+  *(v4u_gptr)addr = value.v4u;
+#else
+  __builtin_nontemporal_store(value.u64[0], (u64_gptr)addr);
+  __builtin_nontemporal_store(value.u64[1], (u64_gptr)addr + 1);
+#endif
 }
 
-__device__ __forceinline__ BytePack<16> load16global(uintptr_t addr){
+__device__ __forceinline__ BytePack<16> load16global(uintptr_t addr) {
   BytePack<16> ans;
-  #if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
-    // System scope load that bypasses the hardware caches, should generate global_load_dwordx4 instruction with sc0 and sc1 bits set to 1 on gfx942/gfx950.
-    ans.v4u = __builtin_amdgcn_global_load_b128((v4u_gptr) addr, RCCL_SYSTEM_SYNCSCOPE);
-  #else
-    *(u64_gptr) ans.u64 = __builtin_nontemporal_load((u64_gptr)addr); 
-    *((u64_gptr) ans.u64+1) = __builtin_nontemporal_load((u64_gptr)addr+1);
-  #endif
+#if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
+  // System scope load that bypasses the hardware caches, should generate global_load_dwordx4 instruction with sc0 and sc1 bits set to 1 on gfx942/gfx950.
+  ans.v4u = __builtin_amdgcn_global_load_b128((v4u_gptr)addr, RCCL_SYSTEM_SYNCSCOPE);
+#else
+  *(u64_gptr)ans.u64 = __builtin_nontemporal_load((u64_gptr)addr);
+  *((u64_gptr)ans.u64 + 1) = __builtin_nontemporal_load((u64_gptr)addr + 1);
+#endif
   return ans;
 }
 
 #define DEFINE_ld_st_16__space(space, addr_cxx_ty, addr_reg_ty) \
-  template<> \
+  template <> \
   __device__ __forceinline__ BytePack<16> ld_##space<16>(addr_cxx_ty addr) { \
     BytePack<16> ans; \
     ans.u64[0] = *((uint64_t*)addr); \
-    ans.u64[1] = *((uint64_t*)addr+1); \
+    ans.u64[1] = *((uint64_t*)addr + 1); \
     return ans; \
   } \
-  template<> \
+  template <> \
   __device__ __forceinline__ BytePack<16> ld_volatile_##space<16>(addr_cxx_ty addr) { \
     return load16##space(addr); \
   } \
-  template<> \
+  template <> \
   __device__ __forceinline__ void st_##space<16>(addr_cxx_ty addr, BytePack<16> value) { \
     store16##space(addr, value); \
   }
@@ -391,137 +408,149 @@ DEFINE_ld_st_16__space(global, uintptr_t, l)
 // DEFINE_ld_st_16__space(shared, uint32_t, r)
 #undef DEFINE_ld_st_16
 
-// template<>
-// __device__ __forceinline__ BytePack<16> ld_relaxed_gpu_global<16>(uintptr_t addr) {
-//   BytePack<16> ans;
-//   asm volatile("ld." PTX_relaxed_gpu ".global.v2.b64 {%0,%1}, [%2];" : "=l"(ans.u64[0]), "=l"(ans.u64[1]) : "l"(addr) : "memory");
-//   return ans;
-// }
-// template<>
-// __device__ __forceinline__ void st_relaxed_gpu_global<16>(uintptr_t addr, BytePack<16> value) {
-//   asm volatile("st." PTX_relaxed_gpu ".global.v2.b64 [%0], {%1,%2};" :: "l"(addr), "l"(value.u64[0]), "l"(value.u64[1]) : "memory");
-// }
+  // template<>
+  // __device__ __forceinline__ BytePack<16> ld_relaxed_gpu_global<16>(uintptr_t addr) {
+  //   BytePack<16> ans;
+  //   asm volatile("ld." PTX_relaxed_gpu ".global.v2.b64 {%0,%1}, [%2];" : "=l"(ans.u64[0]), "=l"(ans.u64[1]) : "l"(addr) : "memory");
+  //   return ans;
+  // }
+  // template<>
+  // __device__ __forceinline__ void st_relaxed_gpu_global<16>(uintptr_t addr, BytePack<16> value) {
+  //   asm volatile("st." PTX_relaxed_gpu ".global.v2.b64 [%0], {%1,%2};" :: "l"(addr), "l"(value.u64[0]), "l"(value.u64[1]) : "memory");
+  // }
 
-// #undef PTX_relaxed_gpu
+  // #undef PTX_relaxed_gpu
 
-////////////////////////////////////////////////////////////////////////////////
-// Atomic load/store using c++ pointers.
+  ////////////////////////////////////////////////////////////////////////////////
+  // Atomic load/store using c++ pointers.
 
-__device__ __forceinline__ uint64_t ld_volatile_global(uint64_t *ptr) {
+  __device__ __forceinline__ uint64_t ld_volatile_global(uint64_t* ptr) {
   uint64_t ans;
-  ans = __hip_atomic_load((__attribute__((address_space(1)))uint64_t *)ptr, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+  ans =
+    __hip_atomic_load((__attribute__((address_space(1))) uint64_t*)ptr, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
   return ans;
 }
-__device__ __forceinline__ uint64_t ld_relaxed_sys_global(uint64_t *ptr) {
+__device__ __forceinline__ uint64_t ld_relaxed_sys_global(uint64_t* ptr) {
   uint64_t ans;
-  ans = __hip_atomic_load((__attribute__((address_space(1)))uint64_t *)ptr, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+  ans =
+    __hip_atomic_load((__attribute__((address_space(1))) uint64_t*)ptr, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
   return ans;
 }
 
 // __device__ __forceinline__ uint64_t ld_relaxed_gpu_global(uint64_t *ptr) {
-  // uint64_t ans;
-  // #if __CUDA_ARCH__ >= 700
-  //   asm volatile("ld.relaxed.gpu.global.u64 %0, [%1];" : "=l"(ans) : "l"(cvta_to_global(ptr)) : "memory");
-  // #else
-  //   asm volatile("ld.volatile.global.u64 %0, [%1];" : "=l"(ans) : "l"(cvta_to_global(ptr)) : "memory");
-  // #endif
+// uint64_t ans;
+// #if __CUDA_ARCH__ >= 700
+//   asm volatile("ld.relaxed.gpu.global.u64 %0, [%1];" : "=l"(ans) : "l"(cvta_to_global(ptr)) : "memory");
+// #else
+//   asm volatile("ld.volatile.global.u64 %0, [%1];" : "=l"(ans) : "l"(cvta_to_global(ptr)) : "memory");
+// #endif
 //   return ans;
 // }
 
-__device__ __forceinline__ uint64_t ld_acquire_sys_global(uint64_t *ptr) {
+__device__ __forceinline__ uint64_t ld_acquire_sys_global(uint64_t* ptr) {
   uint64_t ans;
-  ans = __hip_atomic_load((__attribute__((address_space(1)))uint64_t *)ptr, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_SYSTEM);
+  ans =
+    __hip_atomic_load((__attribute__((address_space(1))) uint64_t*)ptr, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_SYSTEM);
   return ans;
 }
 
-__device__ __forceinline__ void st_volatile_global(uint64_t *ptr, uint64_t val) {
-  __hip_atomic_store((__attribute__((address_space(1)))uint64_t *)ptr, val, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+__device__ __forceinline__ void st_volatile_global(uint64_t* ptr, uint64_t val) {
+  __hip_atomic_store((__attribute__((address_space(1))) uint64_t*)ptr, val, __ATOMIC_RELAXED,
+                     __HIP_MEMORY_SCOPE_SYSTEM);
 }
-__device__ __forceinline__ void st_relaxed_sys_global(uint64_t *ptr, uint64_t val) {
-  __hip_atomic_store((__attribute__((address_space(1)))uint64_t *)ptr, val, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+__device__ __forceinline__ void st_relaxed_sys_global(uint64_t* ptr, uint64_t val) {
+  __hip_atomic_store((__attribute__((address_space(1))) uint64_t*)ptr, val, __ATOMIC_RELAXED,
+                     __HIP_MEMORY_SCOPE_SYSTEM);
 }
-__device__ __forceinline__ void st_release_sys_global(uint64_t *ptr, uint64_t val) {
-  __hip_atomic_store((__attribute__((address_space(1)))uint64_t *)ptr, val, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_SYSTEM);
+__device__ __forceinline__ void st_release_sys_global(uint64_t* ptr, uint64_t val) {
+  __hip_atomic_store((__attribute__((address_space(1))) uint64_t*)ptr, val, __ATOMIC_RELEASE,
+                     __HIP_MEMORY_SCOPE_SYSTEM);
 }
 
 __device__ __forceinline__ void fence_acq_rel_sys() {
-    //asm volatile("membar.sys;" ::: "memory");
+  // asm volatile("membar.sys;" ::: "memory");
 }
 __device__ __forceinline__ void fence_acq_rel_gpu() {
-    //asm volatile("membar.gl;" ::: "memory");
+  // asm volatile("membar.gl;" ::: "memory");
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 // Multimem stores of BytePack<?>.
 
-template<int Size>
+template <int Size>
 __device__ __forceinline__ void multimem_st_global(uintptr_t addr, BytePack<Size> val);
 
 #if __CUDA_ARCH__ >= 900 && CUDART_VERSION >= 12010
-template<>
+template <>
 __device__ __forceinline__ void multimem_st_global<0>(uintptr_t addr, BytePack<0> val) {
   // nop
 }
-template<>
+template <>
 __device__ __forceinline__ void multimem_st_global<1>(uintptr_t addr, BytePack<1> val) {
-  asm volatile("st.global.b8 [%0], %1;" :: "l"(addr), "r"((uint32_t)val.native) : "memory");
+  asm volatile("st.global.b8 [%0], %1;" ::"l"(addr), "r"((uint32_t)val.native) : "memory");
 }
-template<>
+template <>
 __device__ __forceinline__ void multimem_st_global<2>(uintptr_t addr, BytePack<2> val) {
-  asm volatile("st.global.b16 [%0], %1;" :: "l"(addr), "h"(val.native) : "memory");
+  asm volatile("st.global.b16 [%0], %1;" ::"l"(addr), "h"(val.native) : "memory");
 }
-template<>
+template <>
 __device__ __forceinline__ void multimem_st_global<4>(uintptr_t addr, BytePack<4> val) {
-  asm volatile("multimem.st.global.b32 [%0], %1;" :: "l"(addr), "r"(val.native) : "memory");
+  asm volatile("multimem.st.global.b32 [%0], %1;" ::"l"(addr), "r"(val.native) : "memory");
 }
-template<>
+template <>
 __device__ __forceinline__ void multimem_st_global<8>(uintptr_t addr, BytePack<8> val) {
-  asm volatile("multimem.st.global.b64 [%0], %1;" :: "l"(addr), "l"(val.native) : "memory");
+  asm volatile("multimem.st.global.b64 [%0], %1;" ::"l"(addr), "l"(val.native) : "memory");
 }
-template<>
+template <>
 __device__ __forceinline__ void multimem_st_global<16>(uintptr_t addr, BytePack<16> val) {
-  asm volatile("multimem.st.global.v4.f32 [%0], {%1,%2,%3,%4};"
-    :: "l"(addr), "r"(val.u32[0]), "r"(val.u32[1]), "r"(val.u32[2]), "r"(val.u32[3])
-    : "memory");
+  asm volatile("multimem.st.global.v4.f32 [%0], {%1,%2,%3,%4};" ::"l"(addr), "r"(val.u32[0]), "r"(val.u32[1]),
+               "r"(val.u32[2]), "r"(val.u32[3])
+               : "memory");
 }
 #else
-template<int Size>
+template <int Size>
 __device__ __forceinline__ void multimem_st_global(uintptr_t addr, BytePack<Size> val) {
   // nop
 }
 #endif
 
 // Load pack starting at index in array. Ignore elements past end (length of array).
-template<typename Pack, typename T>
+template <typename Pack, typename T>
 __device__ __forceinline__ Pack loadPack(T* ptr, int ix, int end) {
   constexpr int Size = sizeof(Pack);
   ptr += ix;
   int n = end - ix;
   if (alignof(T) == Size && sizeof(T) == Size) {
     return *(Pack*)ptr;
-  } else if ((Size+3)/4 + 1 < Size/sizeof(T)) {
-    union { Pack ans; uint32_t part[Size/4+1]; };
+  } else if ((Size + 3) / 4 + 1 < Size / sizeof(T)) {
+    union {
+      Pack ans;
+      uint32_t part[Size / 4 + 1];
+    };
     int misalign = reinterpret_cast<uintptr_t>(ptr) % 4;
     uint32_t* down = reinterpret_cast<uint32_t*>(reinterpret_cast<uintptr_t>(ptr) & -uintptr_t(4));
     // ndiv holds the number of aligned 4-byte loads needed to cover the entire input
-    int ndiv = (n*sizeof(T)+misalign+3)/4;
-    int imax = min(Size/4 + (misalign > 0), ndiv);
+    int ndiv = (n * sizeof(T) + misalign + 3) / 4;
+    int imax = min(Size / 4 + (misalign > 0), ndiv);
     int i;
-    #pragma unroll
-    for (i=0; i < Size/4 + 1; i++) {
+#pragma unroll
+    for (i = 0; i < Size / 4 + 1; i++) {
       if (i < imax) part[i] = down[i];
     }
     if (misalign > 0) {
-      #pragma unroll
-      for (i=0; i < Size/4; i++) {
-        part[i] = __funnelshift_r(part[i], part[i+1], 8*misalign);
+#pragma unroll
+      for (i = 0; i < Size / 4; i++) {
+        part[i] = __funnelshift_r(part[i], part[i + 1], 8 * misalign);
       }
     }
     return ans;
   } else {
-    union { Pack ans; BytePack<sizeof(T)> part[Size/sizeof(T)]; };
-    #pragma unroll
-    for (int i=0; i < Size/sizeof(T); i++) {
+    union {
+      Pack ans;
+      BytePack<sizeof(T)> part[Size / sizeof(T)];
+    };
+#pragma unroll
+    for (int i = 0; i < Size / sizeof(T); i++) {
       if (i < 1 || i < n) part[i] = ((BytePack<sizeof(T)>*)ptr)[i];
     }
     return ans;
@@ -529,15 +558,18 @@ __device__ __forceinline__ Pack loadPack(T* ptr, int ix, int end) {
 }
 
 // Store pack starting at index in array. Ignore elements past end (length of array).
-template<typename Pack, typename T>
+template <typename Pack, typename T>
 __device__ __forceinline__ void storePack(T* ptr, int ix, int end, Pack val) {
   constexpr int Size = sizeof(Pack);
-  union { Pack tmp; BytePack<sizeof(T)> part[Size/sizeof(T)]; };
+  union {
+    Pack tmp;
+    BytePack<sizeof(T)> part[Size / sizeof(T)];
+  };
   tmp = val;
   ptr += ix;
   int n = end - ix;
-  #pragma unroll
-  for (int i=0; i < Size/sizeof(T); i++) {
+#pragma unroll
+  for (int i = 0; i < Size / sizeof(T); i++) {
     if (i < 1 || i < n) ((BytePack<sizeof(T)>*)ptr)[i] = part[i];
   }
 }
@@ -546,63 +578,62 @@ __device__ __forceinline__ void storePack(T* ptr, int ix, int end, Pack val) {
 // Warp-uniform memory copy from shared address (not generic) to global memory.
 // The number of bytes copied is `min(MaxBytes, nBytesAhead)`, a negative value
 // is interpeted as zero. EltSize is the guaranteed alignment of the addresses and sizes.
-template<int EltSize, int MaxBytes, bool Multimem, typename IntBytes>
-__device__ __forceinline__ void copyGlobalShared_WarpUnrolled(
-    int lane, uintptr_t dstAddr, uint32_t srcAddr, IntBytes nBytesAhead
-  ) {
+template <int EltSize, int MaxBytes, bool Multimem, typename IntBytes>
+__device__ __forceinline__ void copyGlobalShared_WarpUnrolled(int lane, uintptr_t dstAddr, uint32_t srcAddr,
+                                                              IntBytes nBytesAhead) {
   static_assert(std::is_signed<IntBytes>::value, "`IntBytes` must be a signed integral type.");
   int nBytes = min(nBytesAhead, (IntBytes)MaxBytes);
-  int nFrontBytes = min(nBytes, (16 - int(dstAddr%16))%16);
-  int nMiddleBytes = (nBytes-nFrontBytes) & -16;
-  int nBackBytes = (nBytes-nFrontBytes) % 16;
+  int nFrontBytes = min(nBytes, (16 - int(dstAddr % 16)) % 16);
+  int nMiddleBytes = (nBytes - nFrontBytes) & -16;
+  int nBackBytes = (nBytes - nFrontBytes) % 16;
 
-  { int backLane = WARP_SIZE-1 - lane;
-    bool hasFront = lane*EltSize < nFrontBytes;
-    bool hasBack = backLane*EltSize < nBackBytes;
-    int offset = hasFront ? lane*EltSize : (nBytes - (backLane+1)*EltSize);
+  {
+    int backLane = WARP_SIZE - 1 - lane;
+    bool hasFront = lane * EltSize < nFrontBytes;
+    bool hasBack = backLane * EltSize < nBackBytes;
+    int offset = hasFront ? lane * EltSize : (nBytes - (backLane + 1) * EltSize);
     if (hasFront | hasBack) {
-      BytePack<EltSize> tmp = ld_shared<EltSize>(srcAddr+offset);
+      BytePack<EltSize> tmp = ld_shared<EltSize>(srcAddr + offset);
       // Can't use multimem_st since it doesn't support EltSize==2
-      st_global<EltSize>(dstAddr+offset, tmp);
+      st_global<EltSize>(dstAddr + offset, tmp);
     }
   }
 
   srcAddr += nFrontBytes;
-  int srcMisalign = EltSize < 4 ? (srcAddr%4) : 0;
-  srcAddr += -srcMisalign + lane*16;
-  dstAddr += nFrontBytes + lane*16;
-  nMiddleBytes -= lane*16;
-  #pragma unroll
-  for (int u=0; u < divUp(MaxBytes, WARP_SIZE*16); u++) {
+  int srcMisalign = EltSize < 4 ? (srcAddr % 4) : 0;
+  srcAddr += -srcMisalign + lane * 16;
+  dstAddr += nFrontBytes + lane * 16;
+  nMiddleBytes -= lane * 16;
+#pragma unroll
+  for (int u = 0; u < divUp(MaxBytes, WARP_SIZE * 16); u++) {
     if (nMiddleBytes <= 0) break;
     union {
       BytePack<4> b4[4];
       BytePack<16> b16;
     };
-    b4[0] = ld_shared<4>(srcAddr + 0*4);
-    b4[1] = ld_shared<4>(srcAddr + 1*4);
-    b4[2] = ld_shared<4>(srcAddr + 2*4);
-    b4[3] = ld_shared<4>(srcAddr + 3*4);
+    b4[0] = ld_shared<4>(srcAddr + 0 * 4);
+    b4[1] = ld_shared<4>(srcAddr + 1 * 4);
+    b4[2] = ld_shared<4>(srcAddr + 2 * 4);
+    b4[3] = ld_shared<4>(srcAddr + 3 * 4);
     if (srcMisalign != 0) {
-      BytePack<4> b4_4 = ld_shared<4>(srcAddr + 4*4);
-      b4[0].native = __funnelshift_r(b4[0].native, b4[1].native, srcMisalign*8);
-      b4[1].native = __funnelshift_r(b4[1].native, b4[2].native, srcMisalign*8);
-      b4[2].native = __funnelshift_r(b4[2].native, b4[3].native, srcMisalign*8);
-      b4[3].native = __funnelshift_r(b4[3].native, b4_4.native, srcMisalign*8);
+      BytePack<4> b4_4 = ld_shared<4>(srcAddr + 4 * 4);
+      b4[0].native = __funnelshift_r(b4[0].native, b4[1].native, srcMisalign * 8);
+      b4[1].native = __funnelshift_r(b4[1].native, b4[2].native, srcMisalign * 8);
+      b4[2].native = __funnelshift_r(b4[2].native, b4[3].native, srcMisalign * 8);
+      b4[3].native = __funnelshift_r(b4[3].native, b4_4.native, srcMisalign * 8);
     }
     if (Multimem) multimem_st_global<16>(dstAddr, b16);
-    else          st_global<16>(dstAddr, b16);
+    else st_global<16>(dstAddr, b16);
 
-    srcAddr += WARP_SIZE*16;
-    dstAddr += WARP_SIZE*16;
-    nMiddleBytes -= WARP_SIZE*16;
+    srcAddr += WARP_SIZE * 16;
+    dstAddr += WARP_SIZE * 16;
+    nMiddleBytes -= WARP_SIZE * 16;
   }
 }
 #else
-template<int EltSize, int MaxBytes, bool Multimem, typename IntBytes>
-__device__ __forceinline__ void copyGlobalShared_WarpUnrolled(
-    int lane, uintptr_t dstAddr, uint32_t srcAddr, IntBytes nBytesAhead
-  ) {
+template <int EltSize, int MaxBytes, bool Multimem, typename IntBytes>
+__device__ __forceinline__ void copyGlobalShared_WarpUnrolled(int lane, uintptr_t dstAddr, uint32_t srcAddr,
+                                                              IntBytes nBytesAhead) {
   // nop
 }
 #endif

--- a/projects/rccl/src/device/primitives.h
+++ b/projects/rccl/src/device/primitives.h
@@ -16,37 +16,41 @@
 #include "common.h"
 
 #define NCCL_SPINS_BEFORE_CHECK_ABORT 10000
-#define barrier_generic(__THREAD_FENCE, NWORKERS, BARRIER_NEXT, BARRIERS_PTR) do { \
-  if (nthreads == threadsPerBlock) { \
-    __THREAD_FENCE; __builtin_amdgcn_s_barrier(); \
-  } else { \
-    /**const int w = threadIdx.x/WARP_SIZE //unused variable - compiler warning**/;\
-    const int wid = threadIdx.x%WARP_SIZE; \
-    if (wid == 0) { \
-      (BARRIER_NEXT) += (NWORKERS) / WARP_SIZE; \
+#define barrier_generic(__THREAD_FENCE, NWORKERS, BARRIER_NEXT, BARRIERS_PTR) \
+  do { \
+    if (nthreads == threadsPerBlock) { \
       __THREAD_FENCE; \
-      __hip_atomic_fetch_add((BARRIERS_PTR), 1, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_WORKGROUP); \
-      int spins = 0; \
-      int rate_limit = 50; \
-      while (__hip_atomic_load((BARRIERS_PTR), __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_WORKGROUP) < (BARRIER_NEXT)) { \
-        spins++; \
-        if (spins == NCCL_SPINS_BEFORE_CHECK_ABORT) { \
-          if (__atomic_load_n(ncclShmem.comm.abortFlag, __ATOMIC_SEQ_CST)) { \
-            ncclShmem.aborted = 1; \
-            break; \
+      __builtin_amdgcn_s_barrier(); \
+    } else { \
+      /**const int w = threadIdx.x/WARP_SIZE //unused variable - compiler warning**/; \
+      const int wid = threadIdx.x % WARP_SIZE; \
+      if (wid == 0) { \
+        (BARRIER_NEXT) += (NWORKERS) / WARP_SIZE; \
+        __THREAD_FENCE; \
+        __hip_atomic_fetch_add((BARRIERS_PTR), 1, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_WORKGROUP); \
+        int spins = 0; \
+        int rate_limit = 50; \
+        while (__hip_atomic_load((BARRIERS_PTR), __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_WORKGROUP) < (BARRIER_NEXT)) { \
+          spins++; \
+          if (spins == NCCL_SPINS_BEFORE_CHECK_ABORT) { \
+            if (__atomic_load_n(ncclShmem.comm.abortFlag, __ATOMIC_SEQ_CST)) { \
+              ncclShmem.aborted = 1; \
+              break; \
+            } \
+            spins = 0; \
           } \
-          spins = 0; \
+          if (spins == 0 && rate_limit > 0) { \
+            rate_limit--; \
+            traceData(__LINE__, threadIdx.x, \
+                      __hip_atomic_load((BARRIERS_PTR), __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_WORKGROUP), \
+                      (BARRIER_NEXT)); \
+          } \
+          __builtin_amdgcn_s_sleep(1); \
         } \
-        if (spins == 0 && rate_limit > 0) { \
-          rate_limit--; \
-          traceData(__LINE__, threadIdx.x, __hip_atomic_load((BARRIERS_PTR), __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_WORKGROUP), (BARRIER_NEXT)); \
-        } \
-        __builtin_amdgcn_s_sleep(1); \
+        __asm__ __volatile__("s_wakeup"); \
       } \
-      __asm__ __volatile__("s_wakeup"); \
     } \
-  } \
-} while (0)
+  } while (0)
 
 /* Protocol classes: ProtoSimple, ProtoLL, ProtoLL128
  * We use these as template args to the Primtiives class instead of integral
@@ -55,7 +59,8 @@
  * to how that protocol operates with a consistent interface so that our
  * algorithm code can operate protocol parametrically.
  */
-template<int SlicePerChunk_1, int StepPerSlice_1, int useAcc, int Unroll_1, int MultimemSrcs_1 = 0, int MultimemDsts_1 = 0>
+template <int SlicePerChunk_1, int StepPerSlice_1, int useAcc, int Unroll_1, int MultimemSrcs_1 = 0,
+          int MultimemDsts_1 = 0>
 struct ProtoSimple {
   static constexpr int Id = NCCL_PROTO_SIMPLE;
   static constexpr int SlicePerChunk = SlicePerChunk_1;
@@ -66,7 +71,7 @@ struct ProtoSimple {
 
   // Data bytes (no flags etc) in one step of the fifo queue.
   __device__ static int calcBytePerStep() {
-    return ncclShmem.comm.buffSizes[NCCL_PROTO_SIMPLE]/NCCL_STEPS;
+    return ncclShmem.comm.buffSizes[NCCL_PROTO_SIMPLE] / NCCL_STEPS;
   }
   // Granularity of data bytes transferred per thread.
   __device__ static int calcBytePerGrain() {
@@ -81,7 +86,7 @@ struct ProtoLL {
 
   // Data bytes (no flags etc) in one step of the fifo queue.
   __device__ static int calcBytePerStep() {
-    return ncclShmem.comm.buffSizes[NCCL_PROTO_LL]/NCCL_STEPS/2; // Half is data
+    return ncclShmem.comm.buffSizes[NCCL_PROTO_LL] / NCCL_STEPS / 2; // Half is data
   }
   // Granularity of data bytes transferred per thread.
   __device__ static int calcBytePerGrain() {
@@ -96,11 +101,11 @@ struct ProtoLL128 {
 
   // Data bytes (no flags etc) in one step of the fifo queue.
   __device__ static int calcBytePerStep() {
-    return (ncclShmem.comm.buffSizes[NCCL_PROTO_LL128]/NCCL_STEPS)*NCCL_LL128_DATAELEMS/NCCL_LL128_LINEELEMS;
+    return (ncclShmem.comm.buffSizes[NCCL_PROTO_LL128] / NCCL_STEPS) * NCCL_LL128_DATAELEMS / NCCL_LL128_LINEELEMS;
   }
   // Granularity of data bytes transferred per thread.
   __device__ static int calcBytePerGrain() {
-    return NCCL_LL128_SHMEM_ELEMS_PER_THREAD*NCCL_LL128_DATAELEMS*sizeof(uint64_t)/NCCL_LL128_LINEELEMS;
+    return NCCL_LL128_SHMEM_ELEMS_PER_THREAD * NCCL_LL128_DATAELEMS * sizeof(uint64_t) / NCCL_LL128_LINEELEMS;
   }
   // Group width is how many consecutive group values a subchannel occupies.
   static constexpr int MaxGroupWidth = 1;
@@ -112,36 +117,45 @@ struct ProtoLL128 {
  * stores one value at runtime. This optimization save 32-bit register, but more
  * importantly uses fewer predicate registers when unrolling loops.
  */
-template<int MaxRecv_, int MaxSend_>
+template <int MaxRecv_, int MaxSend_>
 struct FanAsymmetric {
   static constexpr int MaxRecv = MaxRecv_, MaxSend = MaxSend_;
   int nr, ns;
   FanAsymmetric() = default;
-  __device__ FanAsymmetric(int nrecv, int nsend): nr(nrecv), ns(nsend) {
+  __device__ FanAsymmetric(int nrecv, int nsend) : nr(nrecv), ns(nsend) {
     // assert(nrecv <= MaxRecv && nsend <= MaxSend);
   }
-  __device__ int nrecv() const { return MaxRecv ? nr : 0; }
-  __device__ int nsend() const { return MaxSend ? ns : 0; }
+  __device__ int nrecv() const {
+    return MaxRecv ? nr : 0;
+  }
+  __device__ int nsend() const {
+    return MaxSend ? ns : 0;
+  }
 };
 
-template<int MaxArity>
+template <int MaxArity>
 struct FanSymmetric {
   static constexpr int MaxRecv = MaxArity, MaxSend = MaxArity;
   int n;
   FanSymmetric() = default;
-  __device__ FanSymmetric(int nrecv, int nsend): n(nrecv) {
+  __device__ FanSymmetric(int nrecv, int nsend) : n(nrecv) {
     // assert(nrecv == nsend && nrecv <= MaxArity);
   }
-  __device__ int nrecv() const { return n; }
-  __device__ int nsend() const { return n; }
+  __device__ int nrecv() const {
+    return n;
+  }
+  __device__ int nsend() const {
+    return n;
+  }
 };
 
 // The primitives class. Specialized per protocol in the other headers.
-template<typename T, typename RedOp, typename Fan, int Direct, typename Proto, int P2p, bool isNetOffload = false, int Metadata = RCCL_METADATA_EMPTY, int Pipeline = 0, int useAcc = 0>
+template <typename T, typename RedOp, typename Fan, int Direct, typename Proto, int P2p, bool isNetOffload = false,
+          int Metadata = RCCL_METADATA_EMPTY, int Pipeline = 0, int useAcc = 0>
 class Primitives;
 
 // Used by LL & LL128 to implement direct members in the naive way.
-template<typename RealPrimitives>
+template <typename RealPrimitives>
 struct PrimitivesWithoutDirect {
   __device__ void directSend(intptr_t inpIx, intptr_t outIx, int eltN) {
     static_cast<RealPrimitives*>(this)->send(inpIx, eltN);
@@ -152,28 +166,30 @@ struct PrimitivesWithoutDirect {
   __device__ void directRecv(intptr_t outIx, int eltN) {
     static_cast<RealPrimitives*>(this)->recv(outIx, eltN, /*postOp=*/false);
   }
-  __device__ void directCopySend(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp=false) {
+  __device__ void directCopySend(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp = false) {
     static_cast<RealPrimitives*>(this)->copySend(inpIx, outIx, eltN, postOp);
   }
-  __device__ void directRecvCopyDirectSend(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp=false) {
+  __device__ void directRecvCopyDirectSend(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp = false) {
     static_cast<RealPrimitives*>(this)->recvCopySend(outIx, eltN, /*postOp=*/false);
   }
-  __device__ void directRecvDirectSend(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp=false) {
+  __device__ void directRecvDirectSend(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp = false) {
     return;
   }
-  __device__ void recvReduceCopyDirectSend(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp=false) {
+  __device__ void recvReduceCopyDirectSend(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp = false) {
     // Direct is only for the send part
     static_cast<RealPrimitives*>(this)->recvReduceCopySend(inpIx, outIx, eltN, postOp);
   }
-  __device__ __forceinline__ void directRecvReduceDirectSend(intptr_t inpIx, intptr_t outIx, ssize_t eltN, bool postOp=false) {
+  __device__ __forceinline__ void directRecvReduceDirectSend(intptr_t inpIx, intptr_t outIx, ssize_t eltN,
+                                                             bool postOp = false) {
     static_cast<RealPrimitives*>(this)->recvReduceSend(inpIx, eltN);
   }
-  __device__ __forceinline__ void directRecvReduceCopyDirectSend(intptr_t inpIx, intptr_t outIx, ssize_t eltN, bool postOp=false) {
+  __device__ __forceinline__ void directRecvReduceCopyDirectSend(intptr_t inpIx, intptr_t outIx, ssize_t eltN,
+                                                                 bool postOp = false) {
     static_cast<RealPrimitives*>(this)->recvReduceCopySend(inpIx, outIx, eltN, postOp);
   }
 };
 
-__device__ inline int checkAbort(int &abortCache, const int abortValue, int &spins) {
+__device__ inline int checkAbort(int& abortCache, const int abortValue, int& spins) {
   if (abortCache & abortValue) return 1;
   if (++spins < NCCL_SPINS_BEFORE_CHECK_ABORT) return 0;
   spins = 0;

--- a/projects/rccl/src/device/prims_ll.h
+++ b/projects/rccl/src/device/prims_ll.h
@@ -7,10 +7,11 @@
  ************************************************************************/
 
 #include "rccl_ptr.h"
-template<typename T, typename RedOp, typename Fan, int Direct, int P2p, bool isNetOffload, int Metadata, int Pipeline, int useAcc>
-class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pipeline, useAcc>:
-    public PrimitivesWithoutDirect<Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pipeline, useAcc>> {
-
+template <typename T, typename RedOp, typename Fan, int Direct, int P2p, bool isNetOffload, int Metadata, int Pipeline,
+          int useAcc>
+class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pipeline, useAcc>
+  : public PrimitivesWithoutDirect<
+      Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pipeline, useAcc>> {
   // In the case of Fan::MaxRecv == 0, we need to force MaxRecv to 1 for this to compile
   // This is because of a recv buffer which is allocated to MaxRecv length in send-only cases.
   static constexpr int MaxRecv = Fan::MaxRecv > 1 ? Fan::MaxRecv : 1;
@@ -20,7 +21,7 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
 #else
   static constexpr int MaxSend = Fan::MaxSend;
 #endif
-  static constexpr int Input=0, Output=1, Acc=2;
+  static constexpr int Input = 0, Output = 1, Acc = 2;
   RedOp redOp;
   const int tid;
   const int nthreads;
@@ -29,7 +30,7 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
   const int threadsPerBlock;
   const int stepLines;
   Fan fan;
-  T *userBufs[3];
+  T* userBufs[3];
   struct ncclConnInfo* recvConn = NULL;
   volatile uint64_t* recvConnHeadPtr = NULL;
   uint64_t recvConnHead;
@@ -45,12 +46,24 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
   union ncclLLFifoLine* recvBuff[MaxRecv];
   union ncclLLFifoLine* sendBuff[MaxSend];
 
-  inline __device__ int recvOffset(int i) { return (recvStep[i]%NCCL_STEPS)*stepLines; }
-  inline __device__ int sendOffset(int i) { return (sendStep[i]%NCCL_STEPS)*stepLines; }
-  inline __device__ union ncclLLFifoLine* recvPtr(int i) { return recvBuff[i]+recvOffset(i); }
-  inline __device__ union ncclLLFifoLine* sendPtr(int i) { return sendBuff[i]+sendOffset(i); }
-  inline __device__ uint32_t recvFlag(int i) { return NCCL_LL_FLAG(recvStep[i]+1); }
-  inline __device__ uint32_t sendFlag(int i) { return NCCL_LL_FLAG(sendStep[i]+1); }
+  inline __device__ int recvOffset(int i) {
+    return (recvStep[i] % NCCL_STEPS) * stepLines;
+  }
+  inline __device__ int sendOffset(int i) {
+    return (sendStep[i] % NCCL_STEPS) * stepLines;
+  }
+  inline __device__ union ncclLLFifoLine* recvPtr(int i) {
+    return recvBuff[i] + recvOffset(i);
+  }
+  inline __device__ union ncclLLFifoLine* sendPtr(int i) {
+    return sendBuff[i] + sendOffset(i);
+  }
+  inline __device__ uint32_t recvFlag(int i) {
+    return NCCL_LL_FLAG(recvStep[i] + 1);
+  }
+  inline __device__ uint32_t sendFlag(int i) {
+    return NCCL_LL_FLAG(sendStep[i] + 1);
+  }
 
   uint64_t* barriers;
   uint64_t barrier_next = 0;
@@ -58,23 +71,23 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
   inline __device__ void barrier() {
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
     if (nthreads != WARP_SIZE)
-      #if defined(__gfx942__) || (defined(__gfx950__) && defined(HIP_HOST_UNCACHED_MEMORY))
-        barrier_generic(__threadfence_block(), nthreads, barrier_next, barriers);
-      #else
-        barrier_generic(__threadfence(), nthreads, barrier_next, barriers);
-      #endif
+#if defined(__gfx942__) || (defined(__gfx950__) && defined(HIP_HOST_UNCACHED_MEMORY))
+      barrier_generic(__threadfence_block(), nthreads, barrier_next, barriers);
+#else
+      barrier_generic(__threadfence(), nthreads, barrier_next, barriers);
+#endif
 #else
     if (nthreads == WARP_SIZE) {
       __syncwarp();
     } else {
-      barrier_sync(15-group, nthreads);
+      barrier_sync(15 - group, nthreads);
     }
 #endif
   }
 
   int abort = 0;
 
-  __device__ inline int checkAbort(int &abortCache, const int abortValue, int &spins) {
+  __device__ inline int checkAbort(int& abortCache, const int abortValue, int& spins) {
     if (abortCache == 0 && ++spins == NCCL_SPINS_BEFORE_CHECK_ABORT) {
       int abort = __atomic_load_n((ncclShmem.comm.abortFlag), __ATOMIC_SEQ_CST);
       spins = 0;
@@ -91,12 +104,14 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
       int spins = 0;
       while (sendConnHeadCache + NCCL_STEPS < sendConnHead + 1) {
         __builtin_amdgcn_s_sleep(1);
-        sendConnHeadCache = atomicAdd((unsigned long long *)sendConnHeadPtr, 0);
+        sendConnHeadCache = atomicAdd((unsigned long long*)sendConnHeadPtr, 0);
         if (checkAbort(abort, 1, spins)) break;
       }
       if (sendConnFifo) {
-        int size = ((sendConnHead & NCCL_LL_CLEAN_MASK) == NCCL_LL_CLEAN_MASK) ? stepLines*sizeof(union ncclLLFifoLine) : nbytes;
-        sendConnFifo[sendConnHead%NCCL_STEPS].size = size;
+        int size = ((sendConnHead & NCCL_LL_CLEAN_MASK) == NCCL_LL_CLEAN_MASK) ?
+                     stepLines * sizeof(union ncclLLFifoLine) :
+                     nbytes;
+        sendConnFifo[sendConnHead % NCCL_STEPS].size = size;
       }
       sendConnHead += 1;
     }
@@ -115,7 +130,7 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
     // LL Cleanup : write all flags in the slice to make sure we don't have
     // data corruption when flag loops over.
     if ((sendStep[i] & NCCL_LL_CLEAN_MASK) == NCCL_LL_CLEAN_MASK) {
-      for (int o = offset; o<stepLines; o+=nthreads) storeLL(sendPtr(i)+o, 0, sendFlag(i));
+      for (int o = offset; o < stepLines; o += nthreads) storeLL(sendPtr(i) + o, 0, sendFlag(i));
     }
     sendStep[i]++;
   }
@@ -124,27 +139,35 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
     union ncclLLFifoLine* src = recvPtr(i) + offset;
     uint32_t flag = recvFlag(i);
     uint32_t data1, flag1, data2, flag2;
-    (void)data1; (void)flag1; (void)data2; (void)flag2; // unused variable - compiler warning
+    (void)data1;
+    (void)flag1;
+    (void)data2;
+    (void)flag2; // unused variable - compiler warning
     int spins = 0;
 
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
     union ncclLLFifoLine i4;
     do {
 #ifdef __GFX11__
-      asm volatile ("global_load_b128 %0, %1, off glc slc dlc\n"
-        "s_waitcnt vmcnt(0)\n" : "=v"(i4.i4) : "v"(&src->i4));
+      asm volatile("global_load_b128 %0, %1, off glc slc dlc\n"
+                   "s_waitcnt vmcnt(0)\n"
+                   : "=v"(i4.i4)
+                   : "v"(&src->i4));
 #elif RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
       i4.v4u = __builtin_amdgcn_global_load_b128((v4u_gptr)src->v, RCCL_SYSTEM_SYNCSCOPE);
 #else
       *((u64_gptr)i4.v) = __builtin_nontemporal_load((u64_gptr)src->v);
-      *((u64_gptr)i4.v + 1) = __builtin_nontemporal_load((u64_gptr)src->v+1);
+      *((u64_gptr)i4.v + 1) = __builtin_nontemporal_load((u64_gptr)src->v + 1);
 #endif
       if (checkAbort(abort, 1, spins)) break;
     } while ((i4.flag1 != flag) || (i4.flag2 != flag));
     uint64_t val64 = (uint64_t)(i4.data1) + (((uint64_t)i4.data2) << 32);
 #else
     do {
-      asm volatile("ld.volatile.global.v4.u32 {%0,%1,%2,%3}, [%4];" : "=r"(data1), "=r"(flag1), "=r"(data2), "=r"(flag2) : "l"(&src->i4) : "memory");
+      asm volatile("ld.volatile.global.v4.u32 {%0,%1,%2,%3}, [%4];"
+                   : "=r"(data1), "=r"(flag1), "=r"(data2), "=r"(flag2)
+                   : "l"(&src->i4)
+                   : "memory");
       if (checkAbort(abort, 1, spins)) break;
     } while ((flag1 != flag) || (flag2 != flag));
     uint64_t val64 = data1 + (((uint64_t)data2) << 32);
@@ -153,31 +176,36 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
     return val64;
   }
 
-  template<int BeginIx>
-  __device__ void readLLBeginAll(int offset, ncclLLFifoLine(&line)[MaxRecv]) {
-    #pragma unroll
-    for (int i=BeginIx; i < MaxRecv; i++) {
+  template <int BeginIx>
+  __device__ void readLLBeginAll(int offset, ncclLLFifoLine (&line)[MaxRecv]) {
+#pragma unroll
+    for (int i = BeginIx; i < MaxRecv; i++) {
       // Yes, for some template arguments this code will be unreachable.  That's fine.
       // coverity[dead_error_line]
       if (i < fan.nrecv()) {
         union ncclLLFifoLine* src = recvPtr(i) + offset;
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
 #ifdef __GFX11__
-        asm volatile ("global_load_b128 %0, %1, off glc slc dlc\n"
-          "s_waitcnt vmcnt(0)\n" : "=v"(line[i].i4) : "v"(&src->i4));
+        asm volatile("global_load_b128 %0, %1, off glc slc dlc\n"
+                     "s_waitcnt vmcnt(0)\n"
+                     : "=v"(line[i].i4)
+                     : "v"(&src->i4));
 #elif RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
         line[i].v4u = __builtin_amdgcn_global_load_b128((v4u_gptr)src->v, RCCL_SYSTEM_SYNCSCOPE);
 #else
         line[i].v[0] = __builtin_nontemporal_load(src->v);
-        line[i].v[1] = __builtin_nontemporal_load(src->v+1);
+        line[i].v[1] = __builtin_nontemporal_load(src->v + 1);
 #endif
 #else
-        asm volatile("ld.volatile.global.v4.u32 {%0,%1,%2,%3}, [%4];" : "=r"(line[i].data1), "=r"(line[i].flag1), "=r"(line[i].data2), "=r"(line[i].flag2) : "l"(&src->i4) : "memory");
+        asm volatile("ld.volatile.global.v4.u32 {%0,%1,%2,%3}, [%4];"
+                     : "=r"(line[i].data1), "=r"(line[i].flag1), "=r"(line[i].data2), "=r"(line[i].flag2)
+                     : "l"(&src->i4)
+                     : "memory");
 #endif
       }
     }
   }
-  __device__ uint64_t readLLFinish(int offset, ncclLLFifoLine(&line)[MaxRecv], int i) {
+  __device__ uint64_t readLLFinish(int offset, ncclLLFifoLine (&line)[MaxRecv], int i) {
     union ncclLLFifoLine* src = recvPtr(i) + offset;
     uint32_t flag = recvFlag(i);
     int spins = 0;
@@ -185,19 +213,24 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
     do {
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
 #ifdef __GFX11__
-      asm volatile ("global_load_b128 %0, %1, off glc slc dlc\n"
-        "s_waitcnt vmcnt(0)\n" : "=v"(line[i].i4) : "v"(&src->i4));
+      asm volatile("global_load_b128 %0, %1, off glc slc dlc\n"
+                   "s_waitcnt vmcnt(0)\n"
+                   : "=v"(line[i].i4)
+                   : "v"(&src->i4));
 #elif RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
       line[i].v4u = __builtin_amdgcn_global_load_b128((v4u_gptr)src->v, RCCL_SYSTEM_SYNCSCOPE);
 #else
       line[i].v[0] = __builtin_nontemporal_load((u64_gptr)src->v);
-      line[i].v[1] = __builtin_nontemporal_load((u64_gptr)src->v+1);
+      line[i].v[1] = __builtin_nontemporal_load((u64_gptr)src->v + 1);
 #endif
 #else
-      asm volatile("ld.volatile.global.v4.u32 {%0,%1,%2,%3}, [%4];" : "=r"(line[i].data1), "=r"(line[i].flag1), "=r"(line[i].data2), "=r"(line[i].flag2) : "l"(&src->i4) : "memory");
+      asm volatile("ld.volatile.global.v4.u32 {%0,%1,%2,%3}, [%4];"
+                   : "=r"(line[i].data1), "=r"(line[i].flag1), "=r"(line[i].data2), "=r"(line[i].flag2)
+                   : "l"(&src->i4)
+                   : "memory");
 #endif
       if (checkAbort(abort, 1, spins)) break;
-    } while(line[i].flag1 != flag || line[i].flag2 != flag);
+    } while (line[i].flag1 != flag || line[i].flag2 != flag);
     uint64_t val64 = line[i].data1 + (((uint64_t)line[i].data2) << 32);
 
     return val64;
@@ -210,30 +243,34 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
     i4.flag1 = flag;
     i4.data2 = (val >> 32);
     i4.flag2 = flag;
-    #if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
+#if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
     // System scope store that bypasses the hardware caches, should generate global_store_dwordx4 instruction with sc0 and sc1 bits set to 1 on gfx942/gfx950.
-    __builtin_amdgcn_global_store_b128((v4u_gptr) dst->v, i4.v4u, RCCL_SYSTEM_SYNCSCOPE);
-    #else
-#if defined(__gfx1200__) ||  defined(__gfx1201__)
-    __hip_atomic_store((u64_gptr) dst->v,   i4.v[0], __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
-    __hip_atomic_store((u64_gptr) dst->v+1, i4.v[1], __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_SYSTEM);
+    __builtin_amdgcn_global_store_b128((v4u_gptr)dst->v, i4.v4u, RCCL_SYSTEM_SYNCSCOPE);
 #else
-    *((u64_gptr) dst->v) = *((u64_gptr) i4.v);
-    *((u64_gptr) dst->v+1) = *((u64_gptr) i4.v+1);
+#if defined(__gfx1200__) || defined(__gfx1201__)
+    __hip_atomic_store((u64_gptr)dst->v, i4.v[0], __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+    __hip_atomic_store((u64_gptr)dst->v + 1, i4.v[1], __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_SYSTEM);
+#else
+    *((u64_gptr)dst->v) = *((u64_gptr)i4.v);
+    *((u64_gptr)dst->v + 1) = *((u64_gptr)i4.v + 1);
 #endif
-    #endif
+#endif
 #if defined(__gfx950__) && ROCM_VERSION < 70002
-    __builtin_amdgcn_fence(__ATOMIC_RELEASE, ""); // flush cache on gfx950 if ROCr fix for hipHostMallocUncached is not available (ROCm version < 7.0.2)
+    __builtin_amdgcn_fence(
+      __ATOMIC_RELEASE,
+      ""); // flush cache on gfx950 if ROCr fix for hipHostMallocUncached is not available (ROCm version < 7.0.2)
 #endif
 #else
-    asm volatile("st.volatile.global.v4.u32 [%0], {%1,%2,%3,%4};" :: "l"(&dst->i4), "r"((uint32_t)val), "r"(flag), "r"((uint32_t)(val >> 32)), "r"(flag) : "memory");
+    asm volatile("st.volatile.global.v4.u32 [%0], {%1,%2,%3,%4};" ::"l"(&dst->i4), "r"((uint32_t)val), "r"(flag),
+                 "r"((uint32_t)(val >> 32)), "r"(flag)
+                 : "memory");
 #endif
   }
 
-  static constexpr int EltPerLine = sizeof(uint64_t)/sizeof(T);
+  static constexpr int EltPerLine = sizeof(uint64_t) / sizeof(T);
 
-  template<typename U>
-  __device__ static U load(U *src) {
+  template <typename U>
+  __device__ static U load(U* src) {
     union {
       U elt;
       uint8_t u1;
@@ -243,28 +280,32 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
     };
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
 #if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
-    if(sizeof(U) == 1)
-      u1 = __hip_atomic_load((__attribute__((address_space(1))) uint8_t*)src, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
-    else if(sizeof(U) == 2)
-      u2 = __hip_atomic_load((__attribute__((address_space(1))) uint16_t*)src, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
-    else if(sizeof(U) == 4)
-      u4 = __hip_atomic_load((__attribute__((address_space(1))) uint32_t*)src, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+    if (sizeof(U) == 1)
+      u1 =
+        __hip_atomic_load((__attribute__((address_space(1))) uint8_t*)src, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+    else if (sizeof(U) == 2)
+      u2 = __hip_atomic_load((__attribute__((address_space(1))) uint16_t*)src, __ATOMIC_RELAXED,
+                             __HIP_MEMORY_SCOPE_SYSTEM);
+    else if (sizeof(U) == 4)
+      u4 = __hip_atomic_load((__attribute__((address_space(1))) uint32_t*)src, __ATOMIC_RELAXED,
+                             __HIP_MEMORY_SCOPE_SYSTEM);
     else
-      u8 = __hip_atomic_load((__attribute__((address_space(1))) uint64_t*)src, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+      u8 = __hip_atomic_load((__attribute__((address_space(1))) uint64_t*)src, __ATOMIC_RELAXED,
+                             __HIP_MEMORY_SCOPE_SYSTEM);
 #else
-    if(sizeof(U) == 1)
+    if (sizeof(U) == 1)
 #ifdef __GFX11__
       u1 = __atomic_load_n((uint8_t*)src, __ATOMIC_RELAXED);
 #else
       u1 = __builtin_nontemporal_load((u8_gptr)src);
 #endif
-    else if(sizeof(U) == 2)
+    else if (sizeof(U) == 2)
 #ifdef __GFX11__
       u2 = __atomic_load_n((uint16_t*)src, __ATOMIC_RELAXED);
 #else
       u2 = __builtin_nontemporal_load((u16_gptr)src);
 #endif
-    else if(sizeof(U) == 4)
+    else if (sizeof(U) == 4)
 #ifdef __GFX11__
       u4 = __atomic_load_n((uint32_t*)src, __ATOMIC_RELAXED);
 #else
@@ -278,20 +319,16 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
 #endif
 #endif
 #else
-    if(sizeof(U) == 1)
-      asm volatile("ld.volatile.global.b8 %0,[%1];" : "=r"(u4) : "l"(src) : "memory");
-    else if(sizeof(U) == 2)
-      asm volatile("ld.volatile.global.b16 %0,[%1];" : "=h"(u2) : "l"(src) : "memory");
-    else if(sizeof(U) == 4)
-      asm volatile("ld.volatile.global.b32 %0,[%1];" : "=r"(u4) : "l"(src) : "memory");
-    else
-      asm volatile("ld.volatile.global.b64 %0,[%1];" : "=l"(u8) : "l"(src) : "memory");
+    if (sizeof(U) == 1) asm volatile("ld.volatile.global.b8 %0,[%1];" : "=r"(u4) : "l"(src) : "memory");
+    else if (sizeof(U) == 2) asm volatile("ld.volatile.global.b16 %0,[%1];" : "=h"(u2) : "l"(src) : "memory");
+    else if (sizeof(U) == 4) asm volatile("ld.volatile.global.b32 %0,[%1];" : "=r"(u4) : "l"(src) : "memory");
+    else asm volatile("ld.volatile.global.b64 %0,[%1];" : "=l"(u8) : "l"(src) : "memory");
 #endif
     return elt;
   }
 
-  template<typename U>
-  __device__ static void store(U *dst, U val) {
+  template <typename U>
+  __device__ static void store(U* dst, U val) {
     union {
       U elt;
       uint8_t u1;
@@ -302,36 +339,34 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
     elt = val;
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
 #if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
-    if(sizeof(U) == 1)
-      __hip_atomic_store((__attribute__((address_space(1))) uint8_t*)dst, u1, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
-    else if(sizeof(U) == 2)
-      __hip_atomic_store((__attribute__((address_space(1))) uint16_t*)dst, u2, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
-    else if(sizeof(U) == 4)
-      __hip_atomic_store((__attribute__((address_space(1))) uint32_t*)dst, u4, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+    if (sizeof(U) == 1)
+      __hip_atomic_store((__attribute__((address_space(1))) uint8_t*)dst, u1, __ATOMIC_RELAXED,
+                         __HIP_MEMORY_SCOPE_SYSTEM);
+    else if (sizeof(U) == 2)
+      __hip_atomic_store((__attribute__((address_space(1))) uint16_t*)dst, u2, __ATOMIC_RELAXED,
+                         __HIP_MEMORY_SCOPE_SYSTEM);
+    else if (sizeof(U) == 4)
+      __hip_atomic_store((__attribute__((address_space(1))) uint32_t*)dst, u4, __ATOMIC_RELAXED,
+                         __HIP_MEMORY_SCOPE_SYSTEM);
     else
-      __hip_atomic_store((__attribute__((address_space(1))) uint64_t*)dst, u8, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+      __hip_atomic_store((__attribute__((address_space(1))) uint64_t*)dst, u8, __ATOMIC_RELAXED,
+                         __HIP_MEMORY_SCOPE_SYSTEM);
 #else
-    if(sizeof(U) == 1)
-      __builtin_nontemporal_store(u1, (uint8_t*)dst);
-    else if(sizeof(U) == 2)
-      __builtin_nontemporal_store(u2, (uint16_t*)dst);
-    else if(sizeof(U) == 4)
-      __builtin_nontemporal_store(u4, (uint32_t*)dst);
-    else
-      __builtin_nontemporal_store(u8, (uint64_t*)dst);
+    if (sizeof(U) == 1) __builtin_nontemporal_store(u1, (uint8_t*)dst);
+    else if (sizeof(U) == 2) __builtin_nontemporal_store(u2, (uint16_t*)dst);
+    else if (sizeof(U) == 4) __builtin_nontemporal_store(u4, (uint32_t*)dst);
+    else __builtin_nontemporal_store(u8, (uint64_t*)dst);
 #if defined(__gfx950__) && ROCM_VERSION < 70002
-    __builtin_amdgcn_fence(__ATOMIC_RELEASE, ""); // flush cache on gfx950 if ROCr fix for hipHostMallocUncached is not available (ROCm version < 7.0.2)
+    __builtin_amdgcn_fence(
+      __ATOMIC_RELEASE,
+      ""); // flush cache on gfx950 if ROCr fix for hipHostMallocUncached is not available (ROCm version < 7.0.2)
 #endif
 #endif
 #else
-    if(sizeof(U) == 1)
-      asm volatile("st.volatile.global.b8 [%0],%1;" :: "l"(dst), "r"(u4) : "memory");
-    else if(sizeof(U) == 2)
-      asm volatile("st.volatile.global.b16 [%0],%1;" :: "l"(dst), "h"(u2) : "memory");
-    else if(sizeof(U) == 4)
-      asm volatile("st.volatile.global.b32 [%0],%1;" :: "l"(dst), "r"(u4) : "memory");
-    else
-      asm volatile("st.volatile.global.b64 [%0],%1;" :: "l"(dst), "l"(u8) : "memory");
+    if (sizeof(U) == 1) asm volatile("st.volatile.global.b8 [%0],%1;" ::"l"(dst), "r"(u4) : "memory");
+    else if (sizeof(U) == 2) asm volatile("st.volatile.global.b16 [%0],%1;" ::"l"(dst), "h"(u2) : "memory");
+    else if (sizeof(U) == 4) asm volatile("st.volatile.global.b32 [%0],%1;" ::"l"(dst), "r"(u4) : "memory");
+    else asm volatile("st.volatile.global.b64 [%0],%1;" ::"l"(dst), "l"(u8) : "memory");
 #endif
   }
 
@@ -343,39 +378,37 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
       T elt[EltPerLine];
     };
 
-    __device__ void loadBegin(T *src, int eltN) {
+    __device__ void loadBegin(T* src, int eltN) {
       if (sizeof(T) <= 2) {
-        misalign = reinterpret_cast<uintptr_t>(src)%4;
-        uint32_t *p = reinterpret_cast<uint32_t*>(reinterpret_cast<uintptr_t>(src) & -uintptr_t(4));
-        u4[0] = load(p+0);
-        u4[1] = misalign + eltN*sizeof(T) > 4 ? load(p+1) : 0;
+        misalign = reinterpret_cast<uintptr_t>(src) % 4;
+        uint32_t* p = reinterpret_cast<uint32_t*>(reinterpret_cast<uintptr_t>(src) & -uintptr_t(4));
+        u4[0] = load(p + 0);
+        u4[1] = misalign + eltN * sizeof(T) > 4 ? load(p + 1) : 0;
         // u4[2] would be simpler, but that throws warnings on some compilers
-        u4[sizeof(T) <= 2 ? 2 : 0] = misalign + eltN*sizeof(T) > 8 ? load(p+2) : 0;
-      }
-      else {
-        #pragma unroll
-        for(int i=0; i < EltPerLine; i++) {
+        u4[sizeof(T) <= 2 ? 2 : 0] = misalign + eltN * sizeof(T) > 8 ? load(p + 2) : 0;
+      } else {
+#pragma unroll
+        for (int i = 0; i < EltPerLine; i++) {
           // Yes, for some template arguments this code will be unreachable.  That's fine.
           // coverity[dead_error_line]
-          if(i==0 || i < eltN)
-            elt[i] = load(src + i);
+          if (i == 0 || i < eltN) elt[i] = load(src + i);
         }
       }
     }
 
     __device__ uint64_t loadFinish() {
       if (sizeof(T) <= 2) {
-        u4[0] = __funnelshift_r(u4[0], u4[1], 8*misalign);
+        u4[0] = __funnelshift_r(u4[0], u4[1], 8 * misalign);
         // u4[2] would be simpler, but that throws warnings on some compilers
-        u4[1] = __funnelshift_r(u4[1], u4[sizeof(T) <= 2 ? 2 : 0], 8*misalign);
+        u4[1] = __funnelshift_r(u4[1], u4[sizeof(T) <= 2 ? 2 : 0], 8 * misalign);
       }
       return u8;
     }
   };
 
-  __device__ void storeData(T *dst, uint64_t val, int eltN) {
-    if (__all((reinterpret_cast<uintptr_t>(dst) & (sizeof(T) - 1)) == 0 && sizeof(T) * eltN == sizeof(val))){
-      *((u64_gptr) dst) = val;
+  __device__ void storeData(T* dst, uint64_t val, int eltN) {
+    if (__all((reinterpret_cast<uintptr_t>(dst) & (sizeof(T) - 1)) == 0 && sizeof(T) * eltN == sizeof(val))) {
+      *((u64_gptr)dst) = val;
       return;
     }
     union {
@@ -383,12 +416,12 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
       T elt[EltPerLine];
     };
     u8 = val;
-    #pragma unroll
-    for(int i=0; i < EltPerLine; i++) {
+#pragma unroll
+    for (int i = 0; i < EltPerLine; i++) {
       // Yes, for some template arguments this code will be unreachable.  That's fine.
       // coverity[dead_error_line]
-      if (i==0 || i < eltN)
-        //store(dst+i, elt[i]);
+      if (i == 0 || i < eltN)
+        // store(dst+i, elt[i]);
         dst[i] = elt[i];
     }
   }
@@ -397,20 +430,20 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
   __device__ void LLGenericOp(intptr_t srcIx, intptr_t dstIx, int nelem, bool postOp) {
     constexpr int SRC = SrcBuf != -1 ? 1 : 0;
     constexpr int DST = DstBuf != -1 ? 1 : 0;
-    T *srcElts = SrcBuf == -1 ? nullptr : userBufs[SrcBuf] + srcIx;
-    T *dstElts = DstBuf == -1 ? nullptr : userBufs[DstBuf] + dstIx;
-    T *accElts = (DstBuf == -1 || !useAcc) ? nullptr : userBufs[Acc] + dstIx;
+    T* srcElts = SrcBuf == -1 ? nullptr : userBufs[SrcBuf] + srcIx;
+    T* dstElts = DstBuf == -1 ? nullptr : userBufs[DstBuf] + dstIx;
+    T* accElts = (DstBuf == -1 || !useAcc) ? nullptr : userBufs[Acc] + dstIx;
 
     // Always waitSend in case of cleanup
     nelem = nelem < 0 ? 0 : nelem;
-    if (SEND) waitSend(divUp(nelem, EltPerLine)*sizeof(ncclLLFifoLine));
+    if (SEND) waitSend(divUp(nelem, EltPerLine) * sizeof(ncclLLFifoLine));
 
-    nelem -= tid*EltPerLine;
-    srcElts += tid*EltPerLine;
-    dstElts += tid*EltPerLine;
-    if (accElts != nullptr) accElts += tid*EltPerLine;
+    nelem -= tid * EltPerLine;
+    srcElts += tid * EltPerLine;
+    dstElts += tid * EltPerLine;
+    if (accElts != nullptr) accElts += tid * EltPerLine;
     int offset = tid;
-    int eltPerTrip = nthreads*EltPerLine;
+    int eltPerTrip = nthreads * EltPerLine;
     while (nelem > 0) {
       int eltInLine = EltPerLine < nelem ? EltPerLine : nelem;
 
@@ -431,10 +464,10 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
       }
       if (RECV) {
         data = !SRC ? peerData : applyReduce(redOp, peerData, data);
-        #pragma unroll MaxRecv
+#pragma unroll MaxRecv
         // Yes, for some template arguments this code will be unreachable.  That's fine.
         // coverity[dead_error_line]
-        for (int i=1; i < MaxRecv && i < fan.nrecv(); i++) {
+        for (int i = 1; i < MaxRecv && i < fan.nrecv(); i++) {
           peerData = readLLFinish(offset, line, i);
           data = applyReduce(redOp, peerData, data);
         }
@@ -446,9 +479,8 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
       if (SEND) {
         // Yes, for some template arguments this code will be unreachable.  That's fine.
         // coverity[dead_error_line]
-        for (int i=1; i < MaxSend && i < fan.nsend(); i++)
-          storeLL(sendPtr(i)+offset, data, sendFlag(i));
-        storeLL(sendPtr(0)+offset, data, sendFlag(0));
+        for (int i = 1; i < MaxSend && i < fan.nsend(); i++) storeLL(sendPtr(i) + offset, data, sendFlag(i));
+        storeLL(sendPtr(0) + offset, data, sendFlag(0));
       }
       if (DST) {
         if (accElts != nullptr) {
@@ -466,14 +498,13 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
     }
 
     if (RECV) {
-      for (int i=0; i < MaxRecv; i++) incRecv(i);
+      for (int i = 0; i < MaxRecv; i++) incRecv(i);
       postRecv();
     }
     if (SEND) {
       // Yes, for some template arguments this code will be unreachable.  That's fine.
       // coverity[dead_error_line]
-      for (int i=1; i < MaxSend && i < fan.nsend(); i++)
-        incSend(i, offset);
+      for (int i = 1; i < MaxSend && i < fan.nsend(); i++) incSend(i, offset);
       incSend(0, offset);
     }
   }
@@ -484,7 +515,7 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
     if (wid == i) recvConn = conn;
   }
   __device__ __forceinline__ void loadRecvSync() {
-    if (tid >= nthreads-WARP_SIZE && wid < fan.nrecv()) {
+    if (tid >= nthreads - WARP_SIZE && wid < fan.nrecv()) {
       recvConnHeadPtr = recvConn->head;
       recvConnHead = recvConn->step;
     }
@@ -505,25 +536,20 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
   }
 
 public:
-  __device__  Primitives(
-      const int tid, const int nthreads, int const *recvPeers, int const *sendPeers,
-      void const *inputBuf, void *outputBuf, uint64_t redOpArg, uint8_t group=0,
-      uint8_t connIndexRecv=0, uint8_t connIndexSend=0, struct ncclDevWorkColl* e = nullptr,
-      bool ipcReg = false, bool netReg = false, int stepSize_ = 0
-    ):
-    redOp(redOpArg),
-    tid(tid), nthreads(nthreads), wid(tid%WARP_SIZE), group(group), threadsPerBlock(blockDim.x),
-    stepLines(ncclShmem.comm.buffSizes[NCCL_PROTO_LL]/NCCL_STEPS/sizeof(ncclLLFifoLine)) {
+  __device__ Primitives(const int tid, const int nthreads, int const* recvPeers, int const* sendPeers,
+                        void const* inputBuf, void* outputBuf, uint64_t redOpArg, uint8_t group = 0,
+                        uint8_t connIndexRecv = 0, uint8_t connIndexSend = 0, struct ncclDevWorkColl* e = nullptr,
+                        bool ipcReg = false, bool netReg = false, int stepSize_ = 0)
+    : redOp(redOpArg), tid(tid), nthreads(nthreads), wid(tid % WARP_SIZE), group(group), threadsPerBlock(blockDim.x),
+      stepLines(ncclShmem.comm.buffSizes[NCCL_PROTO_LL] / NCCL_STEPS / sizeof(ncclLLFifoLine)) {
 #ifdef ENABLE_WARP_SPEED
-    auto *channel = ncclShmem.warpComm
-        ? &ncclShmem.warpChannel[threadIdx.x / WARP_SIZE]
-        : &ncclShmem.channel;
+    auto* channel = ncclShmem.warpComm ? &ncclShmem.warpChannel[threadIdx.x / WARP_SIZE] : &ncclShmem.channel;
 #else
-    auto *channel = &ncclShmem.channel;
+    auto* channel = &ncclShmem.channel;
 #endif
     barriers = &ncclShmem.groups[group].barrier;
     // If we are going to support oneshot collNet + LL, then we would need to add connector index here
-    int nrecv=0, nsend=0;
+    int nrecv = 0, nsend = 0;
     // We compare with Fan::MaxRecv here because this->MaxRecv is always at least 1
     // Yes, for some template arguments this code will be unreachable.  That's fine.
     // coverity[dead_error_line]
@@ -546,25 +572,22 @@ public:
     setDataPtrs(inputBuf, outputBuf, e != nullptr ? e->acc : nullptr);
   }
 
-  __forceinline__ __device__ Primitives(
-      int tid, int nthreads, int const *recvPeers, int const *sendPeers,
-      void const *inputBuf, void *outputBuf, uint64_t redOpArg, uint8_t group,
-      uint8_t connIndexRecv, uint8_t connIndexSend, struct ncclDevWorkColl* collWork,
-      struct ncclDevWorkP2p* p2pWork, int stepSize_ = 0, int mode = primsModeDefault
-    ): Primitives(tid, nthreads, recvPeers, sendPeers, inputBuf, outputBuf, redOpArg, group,
-                  connIndexRecv, connIndexSend, collWork) {}
+  __forceinline__ __device__ Primitives(int tid, int nthreads, int const* recvPeers, int const* sendPeers,
+                                        void const* inputBuf, void* outputBuf, uint64_t redOpArg, uint8_t group,
+                                        uint8_t connIndexRecv, uint8_t connIndexSend, struct ncclDevWorkColl* collWork,
+                                        struct ncclDevWorkP2p* p2pWork, int stepSize_ = 0, int mode = primsModeDefault)
+    : Primitives(tid, nthreads, recvPeers, sendPeers, inputBuf, outputBuf, redOpArg, group, connIndexRecv,
+                 connIndexSend, collWork) {}
 
   __device__ ~Primitives() {
     // Save steps for the next operation
-    if (tid >= nthreads-WARP_SIZE && wid < fan.nrecv())
-      recvConn->step = recvConnHead;
-    if (tid < fan.nsend())
-      sendConn->step = sendConnHead;
+    if (tid >= nthreads - WARP_SIZE && wid < fan.nrecv()) recvConn->step = recvConnHead;
+    if (tid < fan.nsend()) sendConn->step = sendConnHead;
     // Ensure all steps written back
     barrier();
   }
 
-  __device__ void setDataPtrs(void const *inputBuf, void *outputBuf, void const *acc = nullptr) {
+  __device__ void setDataPtrs(void const* inputBuf, void* outputBuf, void const* acc = nullptr) {
     userBufs[Input] = (T*)inputBuf;
     userBufs[Output] = (T*)outputBuf;
     userBufs[Acc] = (T*)acc;
@@ -581,22 +604,22 @@ public:
   __device__ void sendFromOutput(intptr_t outIx, int eltN) {
     LLGenericOp<0, 1, Output, -1>(outIx, -1, eltN, false);
   }
-  __device__ void recv(intptr_t outIx, int eltN, bool postOp=false) {
+  __device__ void recv(intptr_t outIx, int eltN, bool postOp = false) {
     LLGenericOp<1, 0, -1, Output>(-1, outIx, eltN, postOp);
   }
   __device__ void recvReduceSend(intptr_t inpIx, int eltN) {
     LLGenericOp<1, 1, Input, -1>(inpIx, -1, eltN, false);
   }
-  __device__ void recvReduceCopy(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp=false) {
+  __device__ void recvReduceCopy(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp = false) {
     LLGenericOp<1, 0, Input, Output>(inpIx, outIx, eltN, postOp);
   }
-  __device__ void copySend(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp=false) {
+  __device__ void copySend(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp = false) {
     LLGenericOp<0, 1, Input, Output>(inpIx, outIx, eltN, postOp);
   }
-  __device__ void recvCopySend(intptr_t outIx, int eltN, bool postOp=false) {
+  __device__ void recvCopySend(intptr_t outIx, int eltN, bool postOp = false) {
     LLGenericOp<1, 1, -1, Output>(-1, outIx, eltN, postOp);
   }
-  __device__ void recvReduceCopySend(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp=false) {
+  __device__ void recvReduceCopySend(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp = false) {
     LLGenericOp<1, 1, Input, Output>(inpIx, outIx, eltN, postOp);
   }
   __device__ void recvSend(int eltN) {

--- a/projects/rccl/src/device/prims_ll128.h
+++ b/projects/rccl/src/device/prims_ll128.h
@@ -6,7 +6,7 @@
  * See LICENSE.txt for license information
  ************************************************************************/
 
-#define NCCL_LL128_FLAGTHREAD (NCCL_LL128_LINEELEMS-1)
+#define NCCL_LL128_FLAGTHREAD (NCCL_LL128_LINEELEMS - 1)
 
 #ifndef RCCL_USE_WBINVL1_VOL
 #if defined(__GFX8__) || defined(__gfx906__) || defined(__gfx908__) || defined(__gfx90a__)
@@ -16,12 +16,14 @@
 #endif
 #endif
 
-template<typename T, typename RedOp, typename Fan, int Direct, int P2p, bool isNetOffload, int Metadata, int Pipeline, int useAcc>
-class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata, Pipeline, useAcc>:
-  public PrimitivesWithoutDirect<Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata, Pipeline, useAcc>> {
-
+template <typename T, typename RedOp, typename Fan, int Direct, int P2p, bool isNetOffload, int Metadata, int Pipeline,
+          int useAcc>
+class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata, Pipeline, useAcc>
+  : public PrimitivesWithoutDirect<
+      Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata, Pipeline, useAcc>> {
   static constexpr int MaxRecv = Fan::MaxRecv, MaxSend = Fan::MaxSend;
-  static constexpr int Input=0, Output=1, Acc=2;;
+  static constexpr int Input = 0, Output = 1, Acc = 2;
+  ;
   RedOp redOp;
   const int tid;
   const int nthreads;
@@ -33,7 +35,7 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata,
   const int group;
   const int threadsPerBlock;
   Fan fan;
-  T *userBufs[3];
+  T* userBufs[3];
   struct ncclConnInfo* recvConn = NULL;
   volatile uint64_t* recvConnHeadPtr = NULL;
   uint64_t recvConnHead;
@@ -51,12 +53,24 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata,
   uint64_t* recvBuff[MaxRecv];
   uint64_t* sendBuff[MaxSend];
 
-  inline __device__ int recvOffset(int i) { return (recvStep[i]%NCCL_STEPS)*stepSize; }
-  inline __device__ int sendOffset(int i) { return (sendStep[i]%NCCL_STEPS)*stepSize; }
-  inline __device__ uint64_t* recvPtr(int i) { return recvBuff[i]+recvOffset(i); }
-  inline __device__ uint64_t* sendPtr(int i) { return sendBuff[i]+sendOffset(i); }
-  inline __device__ uint64_t recvFlag(int i) { return recvStep[i]+1; }
-  inline __device__ uint64_t sendFlag(int i) { return sendStep[i]+1; }
+  inline __device__ int recvOffset(int i) {
+    return (recvStep[i] % NCCL_STEPS) * stepSize;
+  }
+  inline __device__ int sendOffset(int i) {
+    return (sendStep[i] % NCCL_STEPS) * stepSize;
+  }
+  inline __device__ uint64_t* recvPtr(int i) {
+    return recvBuff[i] + recvOffset(i);
+  }
+  inline __device__ uint64_t* sendPtr(int i) {
+    return sendBuff[i] + sendOffset(i);
+  }
+  inline __device__ uint64_t recvFlag(int i) {
+    return recvStep[i] + 1;
+  }
+  inline __device__ uint64_t sendFlag(int i) {
+    return sendStep[i] + 1;
+  }
 
   uint64_t* barriers;
   uint64_t barrier_next = 0;
@@ -64,20 +78,20 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata,
 
   inline __device__ void barrier() {
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-  if (nthreads != WARP_SIZE)
-    #if defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1250__)
+    if (nthreads != WARP_SIZE)
+#if defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1250__)
       barrier_generic(__threadfence_block(), nthreads, barrier_next, barriers);
-    #else
-      barrier_generic(__threadfence(), nthreads, barrier_next, barriers);
-    #endif
 #else
-   barrier_sync(15-group, nthreads);
+      barrier_generic(__threadfence(), nthreads, barrier_next, barriers);
+#endif
+#else
+    barrier_sync(15 - group, nthreads);
 #endif
   }
 
   int abort = 0;
 
-  __device__ inline int checkAbort(int &abortCache, const int abortValue, int &spins) {
+  __device__ inline int checkAbort(int& abortCache, const int abortValue, int& spins) {
     if (abortCache == 0 && ++spins == NCCL_SPINS_BEFORE_CHECK_ABORT) {
       int abort = __atomic_load_n((ncclShmem.comm.abortFlag), __ATOMIC_SEQ_CST);
       spins = 0;
@@ -98,7 +112,7 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata,
         if (checkAbort(abort, 1, spins)) break;
       }
       if (sendConnFifo) {
-        sendConnFifo[sendStep[wid]%NCCL_STEPS].size = nbytes;
+        sendConnFifo[sendStep[wid] % NCCL_STEPS].size = nbytes;
       }
       sendConnHead += 1;
     }
@@ -121,138 +135,133 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata,
       } else {
         __threadfence_system();
       }
-      STORE((unsigned long long *)sendConnTailPtr, sendConnTail += 1);
+      STORE((unsigned long long*)sendConnTailPtr, sendConnTail += 1);
     }
   }
 
-  template<int WordPerThread>
-  __device__ __forceinline__ void loadRegsBegin(uint64_t(&regs)[WordPerThread], T const *src, int eltN) {
-    constexpr int EltPer16B = 16/sizeof(T);
+  template <int WordPerThread>
+  __device__ __forceinline__ void loadRegsBegin(uint64_t (&regs)[WordPerThread], T const* src, int eltN) {
+    constexpr int EltPer16B = 16 / sizeof(T);
     // Parametrize the warp-local addressing on the LL128 line geometry.
     // The literals "16" and "4" originally hard-coded 2*LINEELEMS and
     // LINEELEMS/2 for the 64-byte-line case; gfx1250 doubles LINEELEMS
     // (128-byte non-tearing line) so the stride and flag-subgroup width
     // both double accordingly.
     constexpr int LineElems = NCCL_LL128_LINEELEMS;
-    constexpr int LineSkip = 2*WARP_SIZE/LineElems;
-    int ix[WordPerThread/2];
-    #pragma unroll
-    for(int g=0; g < WordPerThread/2; g++) {
-      ix[g] = g*WARP_SIZE - LineSkip*(g/2) + wid - (g%2)*(wid/(LineElems/2));
+    constexpr int LineSkip = 2 * WARP_SIZE / LineElems;
+    int ix[WordPerThread / 2];
+#pragma unroll
+    for (int g = 0; g < WordPerThread / 2; g++) {
+      ix[g] = g * WARP_SIZE - LineSkip * (g / 2) + wid - (g % 2) * (wid / (LineElems / 2));
     }
-    if(reinterpret_cast<uintptr_t>(src)%16 == 0) {
+    if (reinterpret_cast<uintptr_t>(src) % 16 == 0) {
       /* We are aligned to 16 bytes, so load directly to registers no shmem.
        * Flag threads load half as much data which gets shuffled to the even
        * registers during Finish. The point of splitting into two phases is to
        * defer that shuffle, which incurs a dependency stall, until after other
        * memops are launched by the caller.
        */
-      #pragma unroll
-      for(int g=0; g < WordPerThread/2; g++) {
-        if(!flagThread || g%2==0) {
-          if(ix[g]*EltPer16B < eltN)
-            load128((uint64_t*)(src + ix[g]*EltPer16B), regs[2*g+0], regs[2*g+1]);
+#pragma unroll
+      for (int g = 0; g < WordPerThread / 2; g++) {
+        if (!flagThread || g % 2 == 0) {
+          if (ix[g] * EltPer16B < eltN) load128((uint64_t*)(src + ix[g] * EltPer16B), regs[2 * g + 0], regs[2 * g + 1]);
         }
       }
-    }
-    else {
+    } else {
       // Not aligned. Stage the smallest 16 byte aligned region subsuming the
       // buffer into shmem.
       int misalignment = reinterpret_cast<uintptr_t>(src) % 16;
-      uint64_t *src8 = reinterpret_cast<uint64_t*>(reinterpret_cast<uintptr_t>(src) & -uintptr_t(16));
-      uint64_t *shm8 = shmemCvtPtr((uint64_t*)ncclScratchForWarp(warpInBlock));
-      #pragma unroll
-      for(int g=0; g < WordPerThread/2; g++)
-        if((g*WARP_SIZE + wid)*16 < misalignment + eltN*sizeof(T))
-          load128(src8 + 2*(g*WARP_SIZE + wid), regs[2*g+0], regs[2*g+1]);
-      #pragma unroll
-      for(int g=0; g < WordPerThread/2; g++)
-        storeShmem128(shm8 + 2*(g*WARP_SIZE + wid), regs[2*g+0], regs[2*g+1]);
+      uint64_t* src8 = reinterpret_cast<uint64_t*>(reinterpret_cast<uintptr_t>(src) & -uintptr_t(16));
+      uint64_t* shm8 = shmemCvtPtr((uint64_t*)ncclScratchForWarp(warpInBlock));
+#pragma unroll
+      for (int g = 0; g < WordPerThread / 2; g++)
+        if ((g * WARP_SIZE + wid) * 16 < misalignment + eltN * sizeof(T))
+          load128(src8 + 2 * (g * WARP_SIZE + wid), regs[2 * g + 0], regs[2 * g + 1]);
+#pragma unroll
+      for (int g = 0; g < WordPerThread / 2; g++)
+        storeShmem128(shm8 + 2 * (g * WARP_SIZE + wid), regs[2 * g + 0], regs[2 * g + 1]);
 
       __syncwarp();
 
       // Now load from shmem stage to regs. Preserve the same pre-shuffled layout
       // as the aligned case since Finish() will be applied regardless.
-      T *shm = (T*)shm8 + misalignment/sizeof(T);
-      #pragma unroll
-      for(int g=0; g < WordPerThread/2; g++) {
+      T* shm = (T*)shm8 + misalignment / sizeof(T);
+#pragma unroll
+      for (int g = 0; g < WordPerThread / 2; g++) {
         // int ix = g*WARP_SIZE - 16*(g/2) + wid - (g%2)*(wid/4);
-        if(!flagThread || g%2==0) {
-          if(ix[g]*EltPer16B < eltN)
-            loadShmemMisaligned128(shm + ix[g]*EltPer16B, regs[2*g+0], regs[2*g+1]);
+        if (!flagThread || g % 2 == 0) {
+          if (ix[g] * EltPer16B < eltN)
+            loadShmemMisaligned128(shm + ix[g] * EltPer16B, regs[2 * g + 0], regs[2 * g + 1]);
         }
       }
     }
   }
 
-  template<int WordPerThread>
-  __device__ __forceinline__ void loadRegsFinish(uint64_t(&regs)[WordPerThread]) {
+  template <int WordPerThread>
+  __device__ __forceinline__ void loadRegsFinish(uint64_t (&regs)[WordPerThread]) {
     // Move data out of flag registers into the vacant registers.
-    #pragma unroll
-    for (int g=1; g < WordPerThread/2; g+=2) {
-      if (flagThread) regs[2*g] = regs[2*g-1];
+#pragma unroll
+    for (int g = 1; g < WordPerThread / 2; g += 2) {
+      if (flagThread) regs[2 * g] = regs[2 * g - 1];
     }
   }
 
-  template<int WordPerThread>
-  __device__ __forceinline__ void storeRegs(T *dst, uint64_t(&regs)[WordPerThread], int eltN) {
-    constexpr int EltPer16B = 16/sizeof(T);
+  template <int WordPerThread>
+  __device__ __forceinline__ void storeRegs(T* dst, uint64_t (&regs)[WordPerThread], int eltN) {
+    constexpr int EltPer16B = 16 / sizeof(T);
     // Reverse Finish() register permuatation.
-    #pragma unroll
-    for (int g=1; g < WordPerThread/2; g+=2) {
-      if (flagThread) regs[2*g-1] = regs[2*g];
+#pragma unroll
+    for (int g = 1; g < WordPerThread / 2; g += 2) {
+      if (flagThread) regs[2 * g - 1] = regs[2 * g];
     }
 
     // Write to dst if 4-byte aligned, shmem otherwise.
-    int misalignment = reinterpret_cast<uintptr_t>(dst)%16;
-    uint64_t *shm8 = shmemCvtPtr((uint64_t*)ncclScratchForWarp(warpInBlock));
+    int misalignment = reinterpret_cast<uintptr_t>(dst) % 16;
+    uint64_t* shm8 = shmemCvtPtr((uint64_t*)ncclScratchForWarp(warpInBlock));
     constexpr int LineElems = NCCL_LL128_LINEELEMS;
-    constexpr int LineSkip = 2*WARP_SIZE/LineElems;
-    #pragma unroll
-    for(int g=0; g < WordPerThread/2; g++) {
-      int ix = g*WARP_SIZE - LineSkip*(g/2) + wid - (g%2)*(wid/(LineElems/2));
-      if (!flagThread || g%2==0) {
-        if(misalignment == 0 && (ix+1)*EltPer16B <= eltN)
-          store128((uint64_t*)(dst + ix*EltPer16B), regs[2*g+0], regs[2*g+1]);
-        else
-          storeShmem128(shm8+2*ix, regs[2*g+0], regs[2*g+1]);
+    constexpr int LineSkip = 2 * WARP_SIZE / LineElems;
+#pragma unroll
+    for (int g = 0; g < WordPerThread / 2; g++) {
+      int ix = g * WARP_SIZE - LineSkip * (g / 2) + wid - (g % 2) * (wid / (LineElems / 2));
+      if (!flagThread || g % 2 == 0) {
+        if (misalignment == 0 && (ix + 1) * EltPer16B <= eltN)
+          store128((uint64_t*)(dst + ix * EltPer16B), regs[2 * g + 0], regs[2 * g + 1]);
+        else storeShmem128(shm8 + 2 * ix, regs[2 * g + 0], regs[2 * g + 1]);
       }
     }
     __syncwarp();
     // Write rest from shmem to dst. No need to coalesce stores to 16-bytes,
     // the hardware keeps up fine.
-    T *shm = (T*)ncclScratchForWarp(warpInBlock);
+    T* shm = (T*)ncclScratchForWarp(warpInBlock);
     int skip = misalignment == 0 ? eltN & -EltPer16B : 0;
-    for(int i=skip+wid; i < eltN; i += WARP_SIZE)
-      dst[i] = shm[i];
+    for (int i = skip + wid; i < eltN; i += WARP_SIZE) dst[i] = shm[i];
   }
 
-  #define WARP_MASK 0xffffffff
+#define WARP_MASK 0xffffffff
 
   template <int ELEMS_PER_THREAD, int RECV, int SEND, int SrcBuf, int DstBuf>
-  __device__ __forceinline__ void recvReduceSendCopy(uint64_t(&v)[ELEMS_PER_THREAD], int ll128Offset, bool postOp) {
+  __device__ __forceinline__ void recvReduceSendCopy(uint64_t (&v)[ELEMS_PER_THREAD], int ll128Offset, bool postOp) {
     constexpr int SRC = SrcBuf != -1 ? 1 : 0;
     uint64_t vr[ELEMS_PER_THREAD];
 
     __syncwarp();
     /************************ Wait first recv ********************/
     if (RECV) {
-      uint64_t* ptr = recvPtr(0)+ll128Offset;
+      uint64_t* ptr = recvPtr(0) + ll128Offset;
       uint64_t flag = recvFlag(0);
       bool needReload;
       int spins = 0;
       do {
         needReload = false;
-        #pragma unroll
-        for (int u=0; u<ELEMS_PER_THREAD; u+=2) {
-          load128(ptr+u*WARP_SIZE, vr[u], vr[u+1]);
-          needReload |= flagThread && (vr[u+1] != flag);
+#pragma unroll
+        for (int u = 0; u < ELEMS_PER_THREAD; u += 2) {
+          load128(ptr + u * WARP_SIZE, vr[u], vr[u + 1]);
+          needReload |= flagThread && (vr[u + 1] != flag);
         }
         needReload &= (0 == checkAbort(abort, 1, spins));
       } while (__any(needReload));
-      #pragma unroll
-      for (int u=0; u<ELEMS_PER_THREAD; u+=2)
-        load128(ptr+u*WARP_SIZE, vr[u], vr[u+1]);
+#pragma unroll
+      for (int u = 0; u < ELEMS_PER_THREAD; u += 2) load128(ptr + u * WARP_SIZE, vr[u], vr[u + 1]);
     }
 
     /************* Finish register load **************/
@@ -261,11 +270,10 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata,
       // peer's data with memory loads of src data.
       loadRegsFinish(v);
       if (SrcBuf == Input) {
-        #pragma unroll
-        for (int u=0; u<ELEMS_PER_THREAD; u+=2) {
+#pragma unroll
+        for (int u = 0; u < ELEMS_PER_THREAD; u += 2) {
           v[u] = applyPreOp(redOp, v[u]);
-          if (!flagThread)
-            v[u+1] = applyPreOp(redOp, v[u+1]);
+          if (!flagThread) v[u + 1] = applyPreOp(redOp, v[u + 1]);
         }
       }
     }
@@ -273,48 +281,47 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata,
     /************************ Recv rest *********************/
     if (RECV) {
       { // Consume data from first recv
-        #pragma unroll
-        for (int u=0; u<ELEMS_PER_THREAD; u+=2) {
-          v[u]   = SRC ? applyReduce(redOp, vr[u], v[u]) : vr[u];
-          v[u+1] = SRC ? applyReduce(redOp, vr[u+1], v[u+1]) : vr[u+1];
+#pragma unroll
+        for (int u = 0; u < ELEMS_PER_THREAD; u += 2) {
+          v[u] = SRC ? applyReduce(redOp, vr[u], v[u]) : vr[u];
+          v[u + 1] = SRC ? applyReduce(redOp, vr[u + 1], v[u + 1]) : vr[u + 1];
         }
       }
 
       // Yes, for some template arguments this code will be unreachable.  That's fine.
       // coverity[dead_error_line]
-      for (int i=1; i<MaxRecv && i<fan.nrecv(); i++) {
+      for (int i = 1; i < MaxRecv && i < fan.nrecv(); i++) {
         uint64_t flag = recvFlag(i);
-        uint64_t* ptr = recvPtr(i)+ll128Offset;
+        uint64_t* ptr = recvPtr(i) + ll128Offset;
         bool needReload;
         int spins = 0;
         do {
           needReload = false;
-          #pragma unroll
-          for (int u=0; u<ELEMS_PER_THREAD; u+=2) {
-            load128(ptr+u*WARP_SIZE, vr[u], vr[u+1]);
-            needReload |= flagThread && (vr[u+1] != flag);
+#pragma unroll
+          for (int u = 0; u < ELEMS_PER_THREAD; u += 2) {
+            load128(ptr + u * WARP_SIZE, vr[u], vr[u + 1]);
+            needReload |= flagThread && (vr[u + 1] != flag);
           }
           needReload &= (0 == checkAbort(abort, 1, spins));
         } while (__any(needReload));
 
-        #pragma unroll
-        for (int u=0; u<ELEMS_PER_THREAD; u+=2)
-          load128(ptr+u*WARP_SIZE, vr[u], vr[u+1]);
+#pragma unroll
+        for (int u = 0; u < ELEMS_PER_THREAD; u += 2) load128(ptr + u * WARP_SIZE, vr[u], vr[u + 1]);
 
-        #pragma unroll
-        for (int u=0; u<ELEMS_PER_THREAD; u+=2) {
-          v[u]   = applyReduce(redOp, vr[u], v[u]);
-          v[u+1] = applyReduce(redOp, vr[u+1], v[u+1]);
+#pragma unroll
+        for (int u = 0; u < ELEMS_PER_THREAD; u += 2) {
+          v[u] = applyReduce(redOp, vr[u], v[u]);
+          v[u + 1] = applyReduce(redOp, vr[u + 1], v[u + 1]);
         }
       }
     }
     /********************** End Recv ************************/
 
     if (postOp) {
-      #pragma unroll
-      for (int u=0; u<ELEMS_PER_THREAD; u+=2) {
-        v[u]   = applyPostOp(redOp, v[u]);
-        v[u+1] = applyPostOp(redOp, v[u+1]);
+#pragma unroll
+      for (int u = 0; u < ELEMS_PER_THREAD; u += 2) {
+        v[u] = applyPostOp(redOp, v[u]);
+        v[u + 1] = applyPostOp(redOp, v[u + 1]);
       }
     }
 
@@ -325,45 +332,46 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata,
     if (SEND) {
       // Yes, for some template arguments this code will be unreachable.  That's fine.
       // coverity[dead_error_line]
-      for (int i=1; i<MaxSend && i<fan.nsend(); i++) {
+      for (int i = 1; i < MaxSend && i < fan.nsend(); i++) {
         uint64_t flag = sendFlag(i);
-        uint64_t* ptr = sendPtr(i)+ll128Offset;
-        #pragma unroll
-        for (int u=0; u<ELEMS_PER_THREAD; u+=2) {
-          store128(ptr+u*WARP_SIZE, v[u], flagThread ? flag : v[u+1]);
+        uint64_t* ptr = sendPtr(i) + ll128Offset;
+#pragma unroll
+        for (int u = 0; u < ELEMS_PER_THREAD; u += 2) {
+          store128(ptr + u * WARP_SIZE, v[u], flagThread ? flag : v[u + 1]);
         }
       }
       uint64_t flag = sendFlag(0);
-      uint64_t* ptr = sendPtr(0)+ll128Offset;
-      #pragma unroll
-      for (int u=0; u<ELEMS_PER_THREAD; u+=2) {
-        store128(ptr+u*WARP_SIZE, v[u], flagThread ? flag : v[u+1]);
+      uint64_t* ptr = sendPtr(0) + ll128Offset;
+#pragma unroll
+      for (int u = 0; u < ELEMS_PER_THREAD; u += 2) {
+        store128(ptr + u * WARP_SIZE, v[u], flagThread ? flag : v[u + 1]);
       }
     }
     /********************** End Send ************************/
   }
 
-  static constexpr int WireWordPerSlice = WARP_SIZE*NCCL_LL128_SHMEM_ELEMS_PER_THREAD;
-  static constexpr int DataEltPerSlice = (WireWordPerSlice - WireWordPerSlice/NCCL_LL128_LINEELEMS)*(sizeof(uint64_t)/sizeof(T));
+  static constexpr int WireWordPerSlice = WARP_SIZE * NCCL_LL128_SHMEM_ELEMS_PER_THREAD;
+  static constexpr int DataEltPerSlice =
+    (WireWordPerSlice - WireWordPerSlice / NCCL_LL128_LINEELEMS) * (sizeof(uint64_t) / sizeof(T));
 
   template <int RECV, int SEND, int SrcBuf, int DstBuf>
   __device__ __forceinline__ void GenericOp(intptr_t srcIx, intptr_t dstIx, int nelem, bool postOp) {
     constexpr int SRC = SrcBuf != -1 ? 1 : 0;
     constexpr int DST = DstBuf != -1 ? 1 : 0;
-    T const *srcPtr = SrcBuf == -1 ? nullptr : userBufs[SrcBuf] + srcIx;
-    T       *dstPtr = DstBuf == -1 ? nullptr : userBufs[DstBuf] + dstIx;
-    T       *accPtr = (DstBuf == -1 || !useAcc) ? nullptr : userBufs[Acc] + dstIx;
-    int wireOffset = WireWordPerSlice*warp + 2*wid;
-    const int nwarps = nthreads/WARP_SIZE;
+    T const* srcPtr = SrcBuf == -1 ? nullptr : userBufs[SrcBuf] + srcIx;
+    T* dstPtr = DstBuf == -1 ? nullptr : userBufs[DstBuf] + dstIx;
+    T* accPtr = (DstBuf == -1 || !useAcc) ? nullptr : userBufs[Acc] + dstIx;
+    int wireOffset = WireWordPerSlice * warp + 2 * wid;
+    const int nwarps = nthreads / WARP_SIZE;
     nelem = nelem < 0 ? 0 : nelem;
 
-    if (SEND) waitSend(divUp(nelem, DataEltPerSlice)*WireWordPerSlice*sizeof(uint64_t));
+    if (SEND) waitSend(divUp(nelem, DataEltPerSlice) * WireWordPerSlice * sizeof(uint64_t));
     barrier();
 
-    nelem -= DataEltPerSlice*warp;
-    srcPtr += DataEltPerSlice*warp;
-    dstPtr += DataEltPerSlice*warp;
-    if (accPtr != nullptr) accPtr += DataEltPerSlice*warp;
+    nelem -= DataEltPerSlice * warp;
+    srcPtr += DataEltPerSlice * warp;
+    dstPtr += DataEltPerSlice * warp;
+    if (accPtr != nullptr) accPtr += DataEltPerSlice * warp;
     while (nelem > 0) {
       const int eltInSlice = min(nelem, DataEltPerSlice);
       uint64_t regs[NCCL_LL128_SHMEM_ELEMS_PER_THREAD];
@@ -374,26 +382,28 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata,
           uint64_t accRegs[NCCL_LL128_SHMEM_ELEMS_PER_THREAD];
           loadRegsBegin(accRegs, accPtr, eltInSlice);
           loadRegsFinish(accRegs);
-          accPtr += DataEltPerSlice*nwarps;
-          #pragma unroll
-          for (int u=0; u<NCCL_LL128_SHMEM_ELEMS_PER_THREAD; u++) {
+          accPtr += DataEltPerSlice * nwarps;
+#pragma unroll
+          for (int u = 0; u < NCCL_LL128_SHMEM_ELEMS_PER_THREAD; u++) {
             regs[u] = applyReduce(redOp, accRegs[u], regs[u]);
           }
         }
         storeRegs(dstPtr, regs, eltInSlice);
       }
 
-      wireOffset += WireWordPerSlice*nwarps;
-      srcPtr += DataEltPerSlice*nwarps;
-      dstPtr += DataEltPerSlice*nwarps;
-      nelem -= DataEltPerSlice*nwarps;
+      wireOffset += WireWordPerSlice * nwarps;
+      srcPtr += DataEltPerSlice * nwarps;
+      dstPtr += DataEltPerSlice * nwarps;
+      nelem -= DataEltPerSlice * nwarps;
     }
 
     barrier();
 
-    if (SEND) for (int i=0; i < MaxSend; i++) sendStep[i] += 1;
+    if (SEND)
+      for (int i = 0; i < MaxSend; i++) sendStep[i] += 1;
     if (SEND) postSend();
-    if (RECV) for (int i=0; i < MaxRecv; i++) recvStep[i] += 1;
+    if (RECV)
+      for (int i = 0; i < MaxRecv; i++) recvStep[i] += 1;
     if (RECV) postRecv();
   }
 
@@ -403,7 +413,7 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata,
     if (wid == i) recvConn = conn;
   }
   __device__ __forceinline__ void loadRecvSync() {
-    if (tid >= nthreads-WARP_SIZE && wid < fan.nrecv()) {
+    if (tid >= nthreads - WARP_SIZE && wid < fan.nrecv()) {
       recvConnHeadPtr = recvConn->head;
       recvConnHead = recvConn->step;
     }
@@ -421,7 +431,7 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata,
       sendConnHead = sendConn->step;
       sendConnFifo = sendConn->connFifo;
     }
-    if (tid >= nthreads-WARP_SIZE && wid<fan.nsend()) {
+    if (tid >= nthreads - WARP_SIZE && wid < fan.nsend()) {
       if (sendConn->connFifo) {
         sendConnTailPtr = sendConn->tail;
         sendConnTail = sendConn->step;
@@ -430,27 +440,22 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata,
   }
 
 public:
-  __device__ Primitives(
-      const int tid, const int nthreads, int const *recvPeers, int const *sendPeers,
-      void const *inputBuf, void *outputBuf, uint64_t redOpArg, uint8_t group=0,
-      uint8_t connIndexRecv=0, uint8_t connIndexSend=0, struct ncclDevWorkColl* e = nullptr,
-      bool ipcReg = false, bool netReg = false, int stepSize_ = 0
-    ):
-    redOp(redOpArg),
-    tid(tid), nthreads(nthreads), wid(tid%WARP_SIZE),                                /*compiler warnings*/
-    stepSize(ncclShmem.comm.buffSizes[NCCL_PROTO_LL128]/NCCL_STEPS/sizeof(uint64_t)),
-    warp(tid/WARP_SIZE), warpInBlock(threadIdx.x/WARP_SIZE), 
-    flagThread((tid % (NCCL_LL128_LINEELEMS/2)) == (NCCL_LL128_LINEELEMS/2 - 1)),
-    group(group), threadsPerBlock(blockDim.x){
+  __device__ Primitives(const int tid, const int nthreads, int const* recvPeers, int const* sendPeers,
+                        void const* inputBuf, void* outputBuf, uint64_t redOpArg, uint8_t group = 0,
+                        uint8_t connIndexRecv = 0, uint8_t connIndexSend = 0, struct ncclDevWorkColl* e = nullptr,
+                        bool ipcReg = false, bool netReg = false, int stepSize_ = 0)
+    : redOp(redOpArg), tid(tid), nthreads(nthreads), wid(tid % WARP_SIZE), /*compiler warnings*/
+      stepSize(ncclShmem.comm.buffSizes[NCCL_PROTO_LL128] / NCCL_STEPS / sizeof(uint64_t)), warp(tid / WARP_SIZE),
+      warpInBlock(threadIdx.x / WARP_SIZE),
+      flagThread((tid % (NCCL_LL128_LINEELEMS / 2)) == (NCCL_LL128_LINEELEMS / 2 - 1)), group(group),
+      threadsPerBlock(blockDim.x) {
 #ifdef ENABLE_WARP_SPEED
-    auto *channel = ncclShmem.warpComm
-        ? &ncclShmem.warpChannel[warpInBlock]
-        : &ncclShmem.channel;
+    auto* channel = ncclShmem.warpComm ? &ncclShmem.warpChannel[warpInBlock] : &ncclShmem.channel;
 #else
-    auto *channel = &ncclShmem.channel;
+    auto* channel = &ncclShmem.channel;
 #endif
     barriers = &ncclShmem.groups[group].barrier;
-    int nrecv=0, nsend=0;
+    int nrecv = 0, nsend = 0;
     while (nrecv < MaxRecv && recvPeers[nrecv] >= 0) {
       loadRecvConn(&channel->peers[recvPeers[nrecv]]->recv[connIndexRecv], nrecv);
       nrecv++;
@@ -476,25 +481,22 @@ public:
 #endif
   }
 
-  __forceinline__ __device__ Primitives(
-      int tid, int nthreads, int const *recvPeers, int const *sendPeers,
-      void const *inputBuf, void *outputBuf, uint64_t redOpArg, uint8_t group,
-      uint8_t connIndexRecv, uint8_t connIndexSend, struct ncclDevWorkColl* collWork,
-      struct ncclDevWorkP2p* p2pWork, int stepSize_ = 0, int mode = primsModeDefault
-    ): Primitives(tid, nthreads, recvPeers, sendPeers, inputBuf, outputBuf, redOpArg, group,
-                  connIndexRecv, connIndexSend, collWork) {}
+  __forceinline__ __device__ Primitives(int tid, int nthreads, int const* recvPeers, int const* sendPeers,
+                                        void const* inputBuf, void* outputBuf, uint64_t redOpArg, uint8_t group,
+                                        uint8_t connIndexRecv, uint8_t connIndexSend, struct ncclDevWorkColl* collWork,
+                                        struct ncclDevWorkP2p* p2pWork, int stepSize_ = 0, int mode = primsModeDefault)
+    : Primitives(tid, nthreads, recvPeers, sendPeers, inputBuf, outputBuf, redOpArg, group, connIndexRecv,
+                 connIndexSend, collWork) {}
 
   __device__ ~Primitives() {
     // Save steps for the next operation
-    if (tid >= nthreads-WARP_SIZE && wid < fan.nrecv())
-      recvConn->step = recvConnHead;
-    if (tid < fan.nsend())
-      sendConn->step = sendConnHead;
+    if (tid >= nthreads - WARP_SIZE && wid < fan.nrecv()) recvConn->step = recvConnHead;
+    if (tid < fan.nsend()) sendConn->step = sendConnHead;
     // Ensure all steps written back
     barrier();
   }
 
-  __device__ void setDataPtrs(void const *inputBuf, void *outputBuf, void const *acc = nullptr) {
+  __device__ void setDataPtrs(void const* inputBuf, void* outputBuf, void const* acc = nullptr) {
     userBufs[Input] = (T*)inputBuf;
     userBufs[Output] = (T*)outputBuf;
     userBufs[Acc] = (T*)acc;
@@ -507,27 +509,26 @@ public:
 
   __device__ void send(intptr_t inpIx, int eltN) {
     GenericOp<0, 1, Input, -1>(inpIx, -1, eltN, false);
-
   }
   __device__ void sendFromOutput(intptr_t outIx, int eltN) {
     GenericOp<0, 1, Output, -1>(outIx, -1, eltN, false);
   }
-  __device__ void recv(intptr_t outIx, int eltN, bool postOp=false) {
+  __device__ void recv(intptr_t outIx, int eltN, bool postOp = false) {
     GenericOp<1, 0, -1, Output>(-1, outIx, eltN, postOp);
   }
   __device__ void recvReduceSend(intptr_t inpIx, int eltN) {
     GenericOp<1, 1, Input, -1>(inpIx, -1, eltN, false);
   }
-  __device__ void recvReduceCopy(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp=false) {
+  __device__ void recvReduceCopy(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp = false) {
     GenericOp<1, 0, Input, Output>(inpIx, outIx, eltN, postOp);
   }
-  __device__ void copySend(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp=false) {
+  __device__ void copySend(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp = false) {
     GenericOp<0, 1, Input, Output>(inpIx, outIx, eltN, postOp);
   }
-  __device__ void recvCopySend(intptr_t outIx, int eltN, bool postOp=false) {
+  __device__ void recvCopySend(intptr_t outIx, int eltN, bool postOp = false) {
     GenericOp<1, 1, -1, Output>(-1, outIx, eltN, postOp);
   }
-  __device__ void recvReduceCopySend(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp=false) {
+  __device__ void recvReduceCopySend(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp = false) {
     GenericOp<1, 1, Input, Output>(inpIx, outIx, eltN, postOp);
   }
   __device__ void recvSend(int eltN) {

--- a/projects/rccl/src/device/prims_simple.h
+++ b/projects/rccl/src/device/prims_simple.h
@@ -16,28 +16,17 @@ enum primsMode {
   primsModePatAg = 2
 };
 
-template<typename T, typename RedOp, typename Fan, int Direct,
-         int SlicePerChunk, int StepPerSlice, int Unroll, int P2p, int MultimemSrcs, int MultimemDsts, bool isNetOffload, int Metadata, int Pipeline, int useAcc>
-class Primitives<
-    T, RedOp, Fan, Direct, ProtoSimple<SlicePerChunk, StepPerSlice, useAcc, Unroll, MultimemSrcs, MultimemDsts>, P2p, isNetOffload, Metadata, Pipeline, useAcc
-  > {
+template <typename T, typename RedOp, typename Fan, int Direct, int SlicePerChunk, int StepPerSlice, int Unroll,
+          int P2p, int MultimemSrcs, int MultimemDsts, bool isNetOffload, int Metadata, int Pipeline, int useAcc>
+class Primitives<T, RedOp, Fan, Direct,
+                 ProtoSimple<SlicePerChunk, StepPerSlice, useAcc, Unroll, MultimemSrcs, MultimemDsts>, P2p,
+                 isNetOffload, Metadata, Pipeline, useAcc> {
   static constexpr int MaxRecv = Fan::MaxRecv, MaxSend = Fan::MaxSend;
-  static constexpr int Input=0, Output=1;
-  static constexpr int RoleInput = 0x01,
-                       RoleOutput = 0x02,
-                       RoleWaitRecv = 0x04,
-                       RoleWaitSend = 0x08,
-                       RolePostSend = 0x10,
-                       RolePostRecv = 0x20,
-                       Aborted = 0x40,
-                       NetRegMode = 0x80,
-                       ConnFifoEnabled = 0x100,
-                       DirectWrite = 0x200,
-                       DirectRead = 0x400,
-                       PatMode = 0x800,
-                       NvlsMinPolling = 0x1000,
-                       NetDeviceUnpack = 0x2000,
-                       AnyNetDeviceUnpack = 0x4000;
+  static constexpr int Input = 0, Output = 1;
+  static constexpr int RoleInput = 0x01, RoleOutput = 0x02, RoleWaitRecv = 0x04, RoleWaitSend = 0x08,
+                       RolePostSend = 0x10, RolePostRecv = 0x20, Aborted = 0x40, NetRegMode = 0x80,
+                       ConnFifoEnabled = 0x100, DirectWrite = 0x200, DirectRead = 0x400, PatMode = 0x800,
+                       NvlsMinPolling = 0x1000, NetDeviceUnpack = 0x2000, AnyNetDeviceUnpack = 0x4000;
   const int tid, tidInBlock;
   const int nthreads;
   int nworkers;
@@ -52,10 +41,10 @@ class Primitives<
   struct ncclConnFifo* connFifo = NULL;
   T* connEltsFifo;
   T* directBuff = NULL;
-  uint64_t *connStepPtr;
+  uint64_t* connStepPtr;
   uint64_t connStepCache; // Cache last seen value of (*connStepPtr)
-  int      connStepSize; // Connection step size
-  void*    netDeviceHandle;
+  int connStepSize; // Connection step size
+  void* netDeviceHandle;
   uint64_t accSize;
   uint32_t* next_hdp_reg;
   uint64_t* barriers;
@@ -67,29 +56,27 @@ class Primitives<
 
   // Don't use barrier 0 as it's used by the final sync
   inline __device__ void barrier() {
-    if (nthreads == WARP_SIZE)
-      __syncwarp();
+    if (nthreads == WARP_SIZE) __syncwarp();
     else
       // To be revisited for correctness on gfx1250
-      #if defined(__gfx942__) || defined(__gfx950__)
-        barrier_generic(__threadfence_block(), nworkers, barrier_next, barriers);
-      #else
-        barrier_generic(__threadfence(), nworkers, barrier_next, barriers);
-      #endif
+#if defined(__gfx942__) || defined(__gfx950__)
+      barrier_generic(__threadfence_block(), nworkers, barrier_next, barriers);
+#else
+      barrier_generic(__threadfence(), nworkers, barrier_next, barriers);
+#endif
   }
   inline __device__ void subBarrier() {
     if (nworkers == WARP_SIZE) __syncwarp();
-    else
-      barrier();
+    else barrier();
   }
 
   inline __device__ void patBarrier() {
     // To be revisited for correctness on gfx1250
-    #if defined(__gfx942__) || defined(__gfx950__)
-      barrier_generic(__threadfence_block(), NCCL_PAT_NWORKERS, barrier_next_pat, barriers_pat);
-    #else
-      barrier_generic(__threadfence(), NCCL_PAT_NWORKERS, barrier_next_pat, barriers_pat);
-    #endif
+#if defined(__gfx942__) || defined(__gfx950__)
+    barrier_generic(__threadfence_block(), NCCL_PAT_NWORKERS, barrier_next_pat, barriers_pat);
+#else
+    barrier_generic(__threadfence(), NCCL_PAT_NWORKERS, barrier_next_pat, barriers_pat);
+#endif
   }
 
   inline __device__ void barrierAny() {
@@ -101,13 +88,16 @@ class Primitives<
   }
 
   inline __device__ uint64_t loadStepValue(uint64_t* ptr) {
-    #if __CUDA_ARCH__ >= 900 && CUDART_VERSION >= 12010
+#if __CUDA_ARCH__ >= 900 && CUDART_VERSION >= 12010
     if (flags & NvlsMinPolling) {
       uint64_t ans;
-      asm volatile("multimem.ld_reduce.acquire.sys.global.min.u64 %0, [%1];" : "=l"(ans) : "l"(cvta_to_global(ptr)) : "memory");
+      asm volatile("multimem.ld_reduce.acquire.sys.global.min.u64 %0, [%1];"
+                   : "=l"(ans)
+                   : "l"(cvta_to_global(ptr))
+                   : "memory");
       return ans;
     }
-    #endif
+#endif
     // volatile is faster than acquire but not as correct. Make sure reduceCopy
     // loads data using volatile so it doesn't see stale data in L1.
     //
@@ -135,60 +125,57 @@ class Primitives<
         __builtin_amdgcn_s_sleep(1);
         connStepCache = loadStepValue(connStepPtr);
         if (checkAbort(flags, Aborted, spins)) break;
-        //if (spins == 0) printf("r=%d b=%d t=%d SPUN OUT got=%d want=%d\n", ncclShmem.comm.rank, blockIdx.x, threadIdx.x, int(connStepCache + (isSendNotRecv ? NCCL_STEPS : 0)), int(step+StepPerSlice));
+        // if (spins == 0) printf("r=%d b=%d t=%d SPUN OUT got=%d want=%d\n", ncclShmem.comm.rank, blockIdx.x, threadIdx.x, int(connStepCache + (isSendNotRecv ? NCCL_STEPS : 0)), int(step+StepPerSlice));
         if (spins == 0 && repeat > 0) {
-          repeat --;
-          traceData(__LINE__, threadIdx.x, int(connStepCache + (isSendNotRecv ? NCCL_STEPS : 0)), int(step+StepPerSlice));
+          repeat--;
+          traceData(__LINE__, threadIdx.x, int(connStepCache + (isSendNotRecv ? NCCL_STEPS : 0)),
+                    int(step + StepPerSlice));
         }
       }
       __asm__ __volatile__("s_wakeup");
     }
 
-    if (flags & (Recv*RoleWaitRecv | Send*RoleWaitSend)) {
+    if (flags & (Recv * RoleWaitRecv | Send * RoleWaitSend)) {
       if ((flags & ConnFifoEnabled) && (flags & (Send * RoleWaitSend)))
-        connFifo[step%NCCL_STEPS].size = nelts*sizeof(T);
+        connFifo[step % NCCL_STEPS].size = nelts * sizeof(T);
 
-      void **ptrs = isSendNotRecv ? (ncclShmem.groups[group].dsts + Dst)
-                                  : (ncclShmem.groups[group].srcs + Src);
+      void** ptrs = isSendNotRecv ? (ncclShmem.groups[group].dsts + Dst) : (ncclShmem.groups[group].srcs + Src);
       if ((flags & NetRegMode) && ((!isSendNotRecv && DirectRecv) || (isSendNotRecv && DirectSend))) {
         if (P2p) {
           ptrs[index] = NULL;
         } else {
           if (isSendNotRecv) {
-            if (!Recv)
-              ptrs[index] = NULL;
-            else
-              ptrs[index] = (T*)ncclShmem.groups[group].userOutput + dstIx + offset;
+            if (!Recv) ptrs[index] = NULL;
+            else ptrs[index] = (T*)ncclShmem.groups[group].userOutput + dstIx + offset;
           } else {
             ptrs[index] = (T*)ncclShmem.groups[group].userOutput + srcIx + offset;
           }
         }
-      } else if ((flags & ConnFifoEnabled) && connFifo[step%NCCL_STEPS].mode == NCCL_MODE_OFFSET) {
-        ptrs[index] = connEltsFifo + loadInt(&connFifo[step%NCCL_STEPS].offset)/sizeof(T);
+      } else if ((flags & ConnFifoEnabled) && connFifo[step % NCCL_STEPS].mode == NCCL_MODE_OFFSET) {
+        ptrs[index] = connEltsFifo + loadInt(&connFifo[step % NCCL_STEPS].offset) / sizeof(T);
       } else if (isSendNotRecv && DirectSend) {
         // directBuff is only assigned by setDataPtrs when (Direct && ipcReg);
         // when Direct=1 but no buffer was registered, it stays NULL and using
         // it as a base would compute an invalid GPU address.
         if ((flags & DirectWrite) && directBuff != nullptr) {
           ptrs[index] = directBuff + dstIx + offset;
-        } else if ((flags & DirectRead) && directBuff != nullptr) {  // empty send
+        } else if ((flags & DirectRead) && directBuff != nullptr) { // empty send
           ptrs[index] = nullptr;
         } else {
-          ptrs[index] = connEltsFifo + (step%NCCL_STEPS)*connStepSize;
+          ptrs[index] = connEltsFifo + (step % NCCL_STEPS) * connStepSize;
         }
       } else if (!isSendNotRecv && DirectRecv) {
         if ((flags & DirectRead) && directBuff != nullptr) {
           ptrs[index] = directBuff + srcIx + offset;
         } else if ((flags & DirectWrite) && directBuff != nullptr) {
-          ptrs[index] = directBuff + dstIx + offset;  // send to next from my output buffer
+          ptrs[index] = directBuff + dstIx + offset; // send to next from my output buffer
         } else {
-          ptrs[index] = connEltsFifo + (step%NCCL_STEPS)*connStepSize;
+          ptrs[index] = connEltsFifo + (step % NCCL_STEPS) * connStepSize;
         }
-      }
-      else {
+      } else {
         // Yes, for some template arguments this code will be unreachable.  That's fine.
         // coverity[dead_error_line]
-        ptrs[index] = connEltsFifo + (step%NCCL_STEPS)*connStepSize;
+        ptrs[index] = connEltsFifo + (step % NCCL_STEPS) * connStepSize;
       }
       if (flags & NetDeviceUnpack) {
         ncclNetDeviceIncrementHead(group, index);
@@ -197,7 +184,7 @@ class Primitives<
     }
   }
 
-  template<int Recv, int Send>
+  template <int Recv, int Send>
   inline __device__ void postPeer(bool dataStored) {
     if (skip_fence) {
       __atomic_signal_fence(__ATOMIC_SEQ_CST);
@@ -212,120 +199,108 @@ class Primitives<
       __threadfence_system();
     }
 
-    if ((flags & Send*RolePostSend) && next_hdp_reg)
-      STORE((unsigned int *)next_hdp_reg, 0x1);
+    if ((flags & Send * RolePostSend) && next_hdp_reg) STORE((unsigned int*)next_hdp_reg, 0x1);
 
-    if (flags & (Recv*RolePostRecv | Send*RolePostSend)) {
+    if (flags & (Recv * RolePostRecv | Send * RolePostSend)) {
       step += StepPerSlice;
       STORE(connStepPtr, step);
     }
   }
 
   template <int DirectRecv1, int DirectSend1, int Recv, int Send, int SrcBuf, int DstBuf>
-  __device__ __forceinline__ void genericOp(
-      intptr_t srcIx, intptr_t dstIx, int nelem, bool postOp
-    ) {
+  __device__ __forceinline__ void genericOp(intptr_t srcIx, intptr_t dstIx, int nelem, bool postOp) {
     constexpr int DirectRecv = /*1 &&*/ Direct && DirectRecv1;
     constexpr int DirectSend = /*1 &&*/ Direct && DirectSend1;
     constexpr int Src = SrcBuf != -1;
     constexpr int Dst = DstBuf != -1;
 
     nelem = nelem < 0 ? 0 : nelem;
-    int sliceSize = stepSize*StepPerSlice;
-    sliceSize = max(divUp(nelem, 16*SlicePerChunk)*16, sliceSize/32);
+    int sliceSize = stepSize * StepPerSlice;
+    sliceSize = max(divUp(nelem, 16 * SlicePerChunk) * 16, sliceSize / 32);
     int slice = 0;
     int offset = 0;
 
     if (tid < nworkers && offset < nelem && !isNetOffload) {
-      // Worker-only loop for non-empty slices. Non-workers and empty slices are
-      // processed in the loop following this if block. The benefit of splitting
-      // the loop like this is we pull two branches out of the critical path.
-      // Using "number of branch insns (taken or not) encountered dynamically"
-      // as the performance metric, then:
-      //   perf_orig = 2*numslices
-      //   perf_new = 2+numslices
-      // So the new code and old code behave the same for numslices=2, and for
-      // numslices>2 the new code is superior. And note that in the case
-      // numslices=1, the loop is trivially unrollable (single iteration) so we
-      // don't incur that that tail branch and we still have perf_new=2.
-      //
-      // ORIGINAL CODE:
-      //   unrolled for(slices) {
-      //     if(worker) { // This branch removed
-      //       wait();
-      //       subBarrier();
-      //       if(slice not empty) // This branch removed
-      //         ReduceCopyMulti();
-      //     }
-      //     barrier();
-      //     post();
-      //   } // Since we no longer unroll, new branch added here
-      #pragma unroll 1
+// Worker-only loop for non-empty slices. Non-workers and empty slices are
+// processed in the loop following this if block. The benefit of splitting
+// the loop like this is we pull two branches out of the critical path.
+// Using "number of branch insns (taken or not) encountered dynamically"
+// as the performance metric, then:
+//   perf_orig = 2*numslices
+//   perf_new = 2+numslices
+// So the new code and old code behave the same for numslices=2, and for
+// numslices>2 the new code is superior. And note that in the case
+// numslices=1, the loop is trivially unrollable (single iteration) so we
+// don't incur that that tail branch and we still have perf_new=2.
+//
+// ORIGINAL CODE:
+//   unrolled for(slices) {
+//     if(worker) { // This branch removed
+//       wait();
+//       subBarrier();
+//       if(slice not empty) // This branch removed
+//         ReduceCopyMulti();
+//     }
+//     barrier();
+//     post();
+//   } // Since we no longer unroll, new branch added here
+#pragma unroll 1
       do {
-        sliceSize = sliceSize < nelem-offset ? sliceSize : nelem-offset;
+        sliceSize = sliceSize < nelem - offset ? sliceSize : nelem - offset;
         if (tid == 0) {
           T* userInput = (T*)ncclShmem.groups[group].userInput;
           T* userOutput = (T*)ncclShmem.groups[group].userOutput;
-          if (Src) ncclShmem.groups[group].srcs[0] = (SrcBuf==Input ? userInput : userOutput) + srcIx + offset;
-          if (Dst) ncclShmem.groups[group].dsts[0] = (DstBuf==Input ? userInput : userOutput) + dstIx + offset;
+          if (Src) ncclShmem.groups[group].srcs[0] = (SrcBuf == Input ? userInput : userOutput) + srcIx + offset;
+          if (Dst) ncclShmem.groups[group].dsts[0] = (DstBuf == Input ? userInput : userOutput) + dstIx + offset;
           T* userAcc = (T*)ncclShmem.groups[group].userAcc;
           ncclShmem.groups[group].acc = (Dst && userAcc != nullptr) ? userAcc + dstIx + offset : nullptr;
         }
         waitPeer<DirectRecv, DirectSend, Recv, Send, Src, Dst>(srcIx, dstIx, offset, sliceSize);
         subBarrier();
         /* if user abort the kernel, we don't need to actually perform copy/reduce; just set size
-        * to 0 to avoid unnecessary workload. */
+         * to 0 to avoid unnecessary workload. */
         int workSize = ncclShmem.aborted ? 0 : sliceSize;
         if (flags & AnyNetDeviceUnpack) {
-          ncclNetDeviceUnpack<Recv>(tid, tidInBlock, nworkers, group, ncclShmem.groups[group].devicePlugin.unpack.unpackNetDeviceIndexMask, Src, workSize);
+          ncclNetDeviceUnpack<Recv>(tid, tidInBlock, nworkers, group,
+                                    ncclShmem.groups[group].devicePlugin.unpack.unpackNetDeviceIndexMask, Src,
+                                    workSize);
           // Sync here to make sure all workers are reading from the updated srcs)
           subBarrier();
         }
 
-        if (DirectRecv && ncclShmem.groups[group].srcs[0] == ncclShmem.groups[group].dsts[0]
+        if (DirectRecv &&
+            ncclShmem.groups[group].srcs[0] == ncclShmem.groups[group].dsts[0]
             /* NVLS can have srcs[0] == dsts[0], but we cannot enter this "if branch",
-            * so we need to check whether MultimemSrcs and MultimemDsts are 0. */
+             * so we need to check whether MultimemSrcs and MultimemDsts are 0. */
             && MultimemSrcs == 0 && MultimemDsts == 0 && !Src) {
           // We can only have one direct receive. Since srcs[0] == dstPtr+offset, skip one copy
           if (Send && Dst && ncclShmem.groups[group].srcs[0] != ncclShmem.groups[group].dsts[1]) {
-
-            reduceCopy<Unroll, useAcc && Dst, RedOp, T, 0, 1, 1, 0, 1, MaxSend, /*PreOpSrcs*/0>
-              (tid, nworkers, /*redArg*/0, /*postOp*/false,
-              1, ncclShmem.groups[group].srcs,
-              fan.nsend(), ncclShmem.groups[group].dsts+1,
-              workSize);
-
+            reduceCopy<Unroll, useAcc && Dst, RedOp, T, 0, 1, 1, 0, 1, MaxSend, /*PreOpSrcs*/ 0>(
+              tid, nworkers, /*redArg*/ 0, /*postOp*/ false, 1, ncclShmem.groups[group].srcs, fan.nsend(),
+              ncclShmem.groups[group].dsts + 1, workSize);
           }
         } else if (DirectSend && !DirectRecv && SrcBuf != Input && ncclShmem.groups[group].dsts[Dst] == nullptr) {
           // For broadcast in CollNet to do empty send
 
-          reduceCopy<Unroll, useAcc && Dst, RedOp, T, 0, 1, 1, 0, 1, 1, /*PreOpSrcs*/0>
-            (tid, nworkers, ncclShmem.groups[group].redOpArgs, postOp,
-            Recv, ncclShmem.groups[group].srcs,
-            Dst, ncclShmem.groups[group].dsts,
-            workSize);
+          reduceCopy<Unroll, useAcc && Dst, RedOp, T, 0, 1, 1, 0, 1, 1, /*PreOpSrcs*/ 0>(
+            tid, nworkers, ncclShmem.groups[group].redOpArgs, postOp, Recv, ncclShmem.groups[group].srcs, Dst,
+            ncclShmem.groups[group].dsts, workSize);
 
         } else if (ncclShmem.groups[group].srcs[0] && ncclShmem.groups[group].dsts[0]) {
-
-          constexpr int PreOpSrcs = SrcBuf != Input ? 0 :
-                                    DirectRecv*MaxRecv == NCCL_MAX_DIRECT_ARITY ? (1+NCCL_MAX_DIRECT_ARITY) : 1;
+          constexpr int PreOpSrcs = SrcBuf != Input                               ? 0 :
+                                    DirectRecv * MaxRecv == NCCL_MAX_DIRECT_ARITY ? (1 + NCCL_MAX_DIRECT_ARITY) :
+                                                                                    1;
           if (Send && Dst && ncclShmem.groups[group].dsts[1] == nullptr) {
             // this case should only be directCopySend() with registered buffers and send to net peer
-            reduceCopy<Unroll, useAcc && Dst, RedOp, T,
-              0, Recv + Src, Recv * MaxRecv + Src,
-              0, 1, 1, PreOpSrcs, Pipeline>
-              (tid, nworkers, ncclShmem.groups[group].redOpArgs, postOp,
-                Recv * fan.nrecv() + Src, ncclShmem.groups[group].srcs,
-                1, ncclShmem.groups[group].dsts,
-                workSize);
+            reduceCopy<Unroll, useAcc && Dst, RedOp, T, 0, Recv + Src, Recv * MaxRecv + Src, 0, 1, 1, PreOpSrcs,
+                       Pipeline>(tid, nworkers, ncclShmem.groups[group].redOpArgs, postOp, Recv * fan.nrecv() + Src,
+                                 ncclShmem.groups[group].srcs, 1, ncclShmem.groups[group].dsts, workSize);
           } else {
-            reduceCopy<Unroll, useAcc && Dst, RedOp, T,
-              MultimemSrcs, Recv + Src, Recv * MaxRecv + Src,
-              MultimemDsts, Send + Dst, Send * MaxSend + Dst, PreOpSrcs, Pipeline>
-              (tid, nworkers, ncclShmem.groups[group].redOpArgs, postOp,
-                Recv * fan.nrecv() + Src, ncclShmem.groups[group].srcs,
-                Send * fan.nsend() + Dst, ncclShmem.groups[group].dsts,
-                workSize, ncclShmem.groups[group].acc);
+            reduceCopy<Unroll, useAcc && Dst, RedOp, T, MultimemSrcs, Recv + Src, Recv * MaxRecv + Src, MultimemDsts,
+                       Send + Dst, Send * MaxSend + Dst, PreOpSrcs, Pipeline>(
+              tid, nworkers, ncclShmem.groups[group].redOpArgs, postOp, Recv * fan.nrecv() + Src,
+              ncclShmem.groups[group].srcs, Send * fan.nsend() + Dst, ncclShmem.groups[group].dsts, workSize,
+              ncclShmem.groups[group].acc);
           }
 
         } else {
@@ -343,13 +318,13 @@ class Primitives<
       } while (slice < SlicePerChunk && offset < nelem);
     }
 
-    // Non-workers come straight here. Workers too but only once the remaining
-    // slices are all empty. Since empty slices are the uncommon case, and
-    // worker perf is the limiter, perf-wise this loop is effectively unentered,
-    // hence just a single branch insn.
-    #pragma unroll 1
+// Non-workers come straight here. Workers too but only once the remaining
+// slices are all empty. Since empty slices are the uncommon case, and
+// worker perf is the limiter, perf-wise this loop is effectively unentered,
+// hence just a single branch insn.
+#pragma unroll 1
     while (slice < SlicePerChunk) {
-      sliceSize = sliceSize < nelem-offset ? sliceSize : nelem-offset;
+      sliceSize = sliceSize < nelem - offset ? sliceSize : nelem - offset;
       { // Only workers could have Wait roles so we know the slice must be empty
         // since we've exited the loop above.
         waitPeer<DirectRecv, DirectSend, Recv, Send, Src, Dst>(0, 0, 0, sliceSize);
@@ -365,9 +340,8 @@ class Primitives<
 public:
   static inline __device__ void sendPeerNotify(int peer, int connIndex, int steps) {
 #ifdef ENABLE_WARP_SPEED
-    ncclDevChannelPeer* peerPtr = ncclShmem.warpComm
-        ? ncclShmem.warpChannel[threadIdx.x/WARP_SIZE].peers[peer]
-        : ncclShmem.channel.peers[peer];
+    ncclDevChannelPeer* peerPtr =
+      ncclShmem.warpComm ? ncclShmem.warpChannel[threadIdx.x / WARP_SIZE].peers[peer] : ncclShmem.channel.peers[peer];
 #else
     ncclDevChannelPeer* peerPtr = ncclShmem.channel.peers[peer];
 #endif
@@ -378,9 +352,8 @@ public:
   static inline __device__ void recvPeerNotify(int peer, int connIndex, int steps) {
     int spins = 0;
 #ifdef ENABLE_WARP_SPEED
-    ncclDevChannelPeer* peerPtr = ncclShmem.warpComm
-        ? ncclShmem.warpChannel[threadIdx.x/WARP_SIZE].peers[peer]
-        : ncclShmem.channel.peers[peer];
+    ncclDevChannelPeer* peerPtr =
+      ncclShmem.warpComm ? ncclShmem.warpChannel[threadIdx.x / WARP_SIZE].peers[peer] : ncclShmem.channel.peers[peer];
 #else
     ncclDevChannelPeer* peerPtr = ncclShmem.channel.peers[peer];
 #endif
@@ -392,47 +365,44 @@ public:
     }
   }
 
-  template<int Recv, int Send, typename Fn>
-  __device__ __forceinline__ void process(Fn &&fn, uint32_t sendDirectFlag = 0, uint32_t recvDirectFlag = 0) {
-    #pragma unroll 1
-    for (int slice=0; slice < SlicePerChunk; slice++) {
+  template <int Recv, int Send, typename Fn>
+  __device__ __forceinline__ void process(Fn&& fn, uint32_t sendDirectFlag = 0, uint32_t recvDirectFlag = 0) {
+#pragma unroll 1
+    for (int slice = 0; slice < SlicePerChunk; slice++) {
       if (tid < nworkers) {
         int nsend, nrecv;
-        if (flags & (Recv*RoleWaitRecv | Send*RoleWaitSend)) {
+        if (flags & (Recv * RoleWaitRecv | Send * RoleWaitSend)) {
           const bool isSendNotRecv = (Send && Recv) ? (flags & RoleWaitSend) : Send;
           int spins = 0;
           while (connStepCache + (isSendNotRecv ? NCCL_STEPS : 0) < step + StepPerSlice) {
             connStepCache = loadStepValue(connStepPtr);
             if (checkAbort(flags, Aborted, spins)) break;
           }
-          void **ptrs = isSendNotRecv ? ncclShmem.groups[group].dsts
-                                      : ncclShmem.groups[group].srcs;
-          if ((flags & ConnFifoEnabled) && connFifo[step%NCCL_STEPS].mode == NCCL_MODE_OFFSET) {
-            int offset = loadInt(&connFifo[step%NCCL_STEPS].offset);
-            ptrs[index] = connEltsFifo + offset/sizeof(T);
+          void** ptrs = isSendNotRecv ? ncclShmem.groups[group].dsts : ncclShmem.groups[group].srcs;
+          if ((flags & ConnFifoEnabled) && connFifo[step % NCCL_STEPS].mode == NCCL_MODE_OFFSET) {
+            int offset = loadInt(&connFifo[step % NCCL_STEPS].offset);
+            ptrs[index] = connEltsFifo + offset / sizeof(T);
           } else if (Direct && fn.work->regUsed) {
             if (isSendNotRecv) {
               if (flags & DirectWrite) {
                 ptrs[index] = directBuff;
-              } else if (flags & DirectRead) {  // empty send
+              } else if (flags & DirectRead) { // empty send
                 ptrs[index] = nullptr;
               } else {
-                ptrs[index] = connEltsFifo + (step%NCCL_STEPS)*connStepSize;
+                ptrs[index] = connEltsFifo + (step % NCCL_STEPS) * connStepSize;
               }
             } else {
               if (flags & DirectRead) {
                 ptrs[index] = directBuff;
               } else if (flags & DirectWrite) {
-                if (Send)
-                  ptrs[index] = directBuff;  // send to next from my output buffer
-                else
-                  ptrs[index] = nullptr;
+                if (Send) ptrs[index] = directBuff; // send to next from my output buffer
+                else ptrs[index] = nullptr;
               } else {
-                ptrs[index] = connEltsFifo + (step%NCCL_STEPS)*connStepSize;
+                ptrs[index] = connEltsFifo + (step % NCCL_STEPS) * connStepSize;
               }
             }
           } else {
-            ptrs[index] = connEltsFifo + (step%NCCL_STEPS)*connStepSize;
+            ptrs[index] = connEltsFifo + (step % NCCL_STEPS) * connStepSize;
           }
         }
         subBarrier();
@@ -447,26 +417,25 @@ public:
         } else {
           nsend = fan.nsend();
         }
-        fn.template operator()<SlicePerChunk, 0, Recv*MaxRecv, 0, Send*MaxSend, MultimemSrcs, MultimemDsts>
-          (tid, nworkers, slice, stepSize * StepPerSlice,
-            nrecv, ncclShmem.groups[group].srcs,
-            nsend, ncclShmem.groups[group].dsts, ncclShmem.groups[group].dstSizes, sendDirectFlag, recvDirectFlag);
+        fn.template operator()<SlicePerChunk, 0, Recv * MaxRecv, 0, Send * MaxSend, MultimemSrcs, MultimemDsts>(
+          tid, nworkers, slice, stepSize * StepPerSlice, nrecv, ncclShmem.groups[group].srcs, nsend,
+          ncclShmem.groups[group].dsts, ncclShmem.groups[group].dstSizes, sendDirectFlag, recvDirectFlag);
       }
       barrier();
       int32_t dstSize = 0;
-      if (flags & Send*RolePostSend) {
+      if (flags & Send * RolePostSend) {
         // Yes, for some template arguments this code will be unreachable.  That's fine.
         // coverity[dead_error_begin]
         dstSize = ncclShmem.groups[group].dstSizes[index];
         ncclShmem.groups[group].dstSizes[index] = 0;
-        if (flags & ConnFifoEnabled) connFifo[step%NCCL_STEPS].size = dstSize*sizeof(T);
+        if (flags & ConnFifoEnabled) connFifo[step % NCCL_STEPS].size = dstSize * sizeof(T);
       }
       barrier();
-      if (flags & (Recv*(RoleWaitRecv|RolePostRecv) | Send*(RoleWaitSend|RolePostSend))) {
+      if (flags & (Recv * (RoleWaitRecv | RolePostRecv) | Send * (RoleWaitSend | RolePostSend))) {
         step += StepPerSlice;
       }
-      if (flags & (Recv*RolePostRecv | Send*RolePostSend)) {
-        if (Send && (!Recv || (flags & RolePostSend)) && (dstSize!=0 || (flags&ConnFifoEnabled))) {
+      if (flags & (Recv * RolePostRecv | Send * RolePostSend)) {
+        if (Send && (!Recv || (flags & RolePostSend)) && (dstSize != 0 || (flags & ConnFifoEnabled))) {
           fence_acq_rel_sys();
         }
         st_relaxed_sys_global(connStepPtr, step);
@@ -479,57 +448,62 @@ private:
   // skip: my own rank order in the buffer chunks
   // shift: peer offset to avoid all ranks sending to or receiving from same peer
   template <int DirectRecv1, int DirectSend1, int Recv, int Send>
-  __device__ __forceinline__ void
-  ScatterGatherOp(intptr_t inpIx, intptr_t outIx, ssize_t totalElem, int peerElem, ssize_t peerOffset, int skip, int shift, bool postOp) {
+  __device__ __forceinline__ void ScatterGatherOp(intptr_t inpIx, intptr_t outIx, ssize_t totalElem, int peerElem,
+                                                  ssize_t peerOffset, int skip, int shift, bool postOp) {
     constexpr int DirectRecv = /*1 &&*/ Direct && DirectRecv1;
     constexpr int DirectSend = /*1 &&*/ Direct && DirectSend1;
     int offset = 0; // slice offset
-    int sliceSize = stepSize*StepPerSlice;
-    int dataSize = max(DIVUP(peerElem, 16*SlicePerChunk)*16, sliceSize/32);  // per-peer slice size
+    int sliceSize = stepSize * StepPerSlice;
+    int dataSize = max(DIVUP(peerElem, 16 * SlicePerChunk) * 16, sliceSize / 32); // per-peer slice size
 
-    #pragma unroll 1
-    for (int slice=0; slice<SlicePerChunk; ++slice) {
-      ssize_t realSize = max(0, min(dataSize, peerElem-offset));
+#pragma unroll 1
+    for (int slice = 0; slice < SlicePerChunk; ++slice) {
+      ssize_t realSize = max(0, min(dataSize, peerElem - offset));
       bool fenceNeeded = false;
       if (tid < nworkers) {
         if (Send) {
           // Scatter pre-scales data of input buffer only in non-Direct case
           constexpr int PreOpSrcs = DirectSend ? 0 : 1;
-          if (tid==0) ncclShmem.groups[group].srcs[0] = (T*)ncclShmem.groups[group].userInput + inpIx + offset;
+          if (tid == 0) ncclShmem.groups[group].srcs[0] = (T*)ncclShmem.groups[group].userInput + inpIx + offset;
           // realSize is not accurate here; but intra-node does not rely on sizes FIFO
           waitPeer<0, DirectSend, 0, 1, 1, 0>(0, inpIx, offset, realSize);
           subBarrier();
-          #pragma unroll 1
+#pragma unroll 1
           // Loop over peers
-          for (int j=0; j<fan.nsend(); j++) {
-            int i = (j+shift)%fan.nsend();
-            ssize_t pOffset = i*peerOffset;
+          for (int j = 0; j < fan.nsend(); j++) {
+            int i = (j + shift) % fan.nsend();
+            ssize_t pOffset = i * peerOffset;
             // Skip the data I am responsible of reducing myself
             if (skip >= 0 && i >= skip) pOffset += peerOffset;
             void* src0 = (T*)ncclShmem.groups[group].srcs[0] + pOffset;
-            ssize_t realPeerSize = min(realSize, totalElem-pOffset);
+            ssize_t realPeerSize = min(realSize, totalElem - pOffset);
             if (realPeerSize > 0 && ncclShmem.groups[group].dsts[i] != nullptr) {
-              reduceCopy<Unroll, useAcc, RedOp, T, 0, 1, 1, 0, 1, 1, PreOpSrcs>(tid, nworkers, ncclShmem.groups[group].redOpArgs, false, 1, &src0, 1, ncclShmem.groups[group].dsts+i, realPeerSize);
+              reduceCopy<Unroll, useAcc, RedOp, T, 0, 1, 1, 0, 1, 1, PreOpSrcs>(
+                tid, nworkers, ncclShmem.groups[group].redOpArgs, false, 1, &src0, 1, ncclShmem.groups[group].dsts + i,
+                realPeerSize);
               // Mark for threadfence at the end
               fenceNeeded |= true;
             }
           }
         } else if (Recv) {
-          if (tid==0) ncclShmem.groups[group].dsts[0] = (T*)ncclShmem.groups[group].userOutput + outIx + offset;
-          ssize_t pOffset = index*peerOffset;
+          if (tid == 0) ncclShmem.groups[group].dsts[0] = (T*)ncclShmem.groups[group].userOutput + outIx + offset;
+          ssize_t pOffset = index * peerOffset;
           if (skip >= 0 && index >= skip) pOffset += peerOffset;
           // Adjust remote index with peer offset in case we are directly pulling from peer's output buffer
-          waitPeer<DirectRecv, 0, 1, 0, 0, 1>(outIx+pOffset, outIx+pOffset, offset, realSize);
+          waitPeer<DirectRecv, 0, 1, 0, 0, 1>(outIx + pOffset, outIx + pOffset, offset, realSize);
           subBarrier();
-          #pragma unroll 1
-          for (int j=0; j<fan.nrecv(); j++) {
-            int i = (j+shift)%fan.nrecv();
-            pOffset = i*peerOffset;
+#pragma unroll 1
+          for (int j = 0; j < fan.nrecv(); j++) {
+            int i = (j + shift) % fan.nrecv();
+            pOffset = i * peerOffset;
             if (skip >= 0 && i >= skip) pOffset += peerOffset;
             void* dst0 = (T*)ncclShmem.groups[group].dsts[0] + pOffset;
-            ssize_t realPeerSize = min(realSize, totalElem-pOffset);
+            ssize_t realPeerSize = min(realSize, totalElem - pOffset);
             if (DirectRecv && ncclShmem.groups[group].srcs[i] == dst0) realPeerSize = 0;
-            if (realPeerSize > 0) reduceCopy<Unroll, useAcc, RedOp, T, 0,1,1, 0,1,1, /*PreOpSrcs=*/0>(tid, nworkers, ncclShmem.groups[group].redOpArgs, postOp, 1, ncclShmem.groups[group].srcs+i, 1, &dst0, realPeerSize);
+            if (realPeerSize > 0)
+              reduceCopy<Unroll, useAcc, RedOp, T, 0, 1, 1, 0, 1, 1, /*PreOpSrcs=*/0>(
+                tid, nworkers, ncclShmem.groups[group].redOpArgs, postOp, 1, ncclShmem.groups[group].srcs + i, 1, &dst0,
+                realPeerSize);
           }
         }
       }
@@ -539,7 +513,8 @@ private:
     }
   }
 
-  __device__ __forceinline__ void loadRecvConn(ncclDevChannelPeer *peer, int connIndex, uint32_t direct, int ipcRegFlag, int netRegFlag) {
+  __device__ __forceinline__ void loadRecvConn(ncclDevChannelPeer* peer, int connIndex, uint32_t direct, int ipcRegFlag,
+                                               int netRegFlag) {
     conn = &peer->recv[connIndex];
     if (conn->netDeviceHandle.netDeviceType == NCCL_NET_DEVICE_UNPACK) {
       // handle must be a device ptr
@@ -549,17 +524,19 @@ private:
       flags |= NetDeviceUnpack;
     }
     step = conn->step;
-    step = roundUp(step, SlicePerChunk*StepPerSlice);
+    step = roundUp(step, SlicePerChunk * StepPerSlice);
     if (flags & RolePostRecv) {
       connStepPtr = conn->head;
       STORE(connStepPtr, step); // Return credits in case we rounded up.
     }
     if (flags & RoleWaitRecv) {
-      if ((flags & PatMode) == 0) ncclShmem.groups[group].recvConns[index] = conn; // WaitRecv role saves since that's who needs it in setDataPtrs()
+      if ((flags & PatMode) == 0)
+        ncclShmem.groups[group].recvConns[index] =
+          conn; // WaitRecv role saves since that's who needs it in setDataPtrs()
       flags |= (conn->flags & NCCL_NVLS_MIN_POLL) ? NvlsMinPolling : 0;
       connStepPtr = conn->tail;
       connStepCache = loadStepValue(connStepPtr);
-      connStepSize = conn->stepSize/sizeof(T);
+      connStepSize = conn->stepSize / sizeof(T);
       connEltsFifo = (T*)conn->buffs[NCCL_PROTO_SIMPLE];
       if (conn->connFifo != nullptr) {
         flags |= ConnFifoEnabled;
@@ -591,10 +568,11 @@ private:
     }
   }
 
-  __device__ __forceinline__ void loadSendConn(ncclDevChannelPeer *peer, int connIndex, uint32_t direct, int ipcRegFlag, int netRegFlag) {
+  __device__ __forceinline__ void loadSendConn(ncclDevChannelPeer* peer, int connIndex, uint32_t direct, int ipcRegFlag,
+                                               int netRegFlag) {
     conn = &peer->send[connIndex];
     step = conn->step;
-    step = roundUp(step, SlicePerChunk*StepPerSlice);
+    step = roundUp(step, SlicePerChunk * StepPerSlice);
 
     connFifo = conn->connFifo;
     if (connFifo != nullptr) flags |= ConnFifoEnabled;
@@ -605,11 +583,13 @@ private:
       connEltsFifo = (T*)conn->buffs[NCCL_PROTO_SIMPLE];
     }
     if (flags & RoleWaitSend) {
-      if ((flags & PatMode) == 0) ncclShmem.groups[group].sendConns[index] = conn; // WaitSend role saves since that's who needs it in setDataPtrs()
+      if ((flags & PatMode) == 0)
+        ncclShmem.groups[group].sendConns[index] =
+          conn; // WaitSend role saves since that's who needs it in setDataPtrs()
       flags |= (conn->flags & NCCL_NVLS_MIN_POLL) ? NvlsMinPolling : 0;
       connStepPtr = conn->head;
       connStepCache = loadStepValue(connStepPtr);
-      connStepSize = conn->stepSize/sizeof(T);
+      connStepSize = conn->stepSize / sizeof(T);
       connEltsFifo = (T*)conn->buffs[NCCL_PROTO_SIMPLE];
       if (Direct) {
         if (ipcRegFlag) {
@@ -618,7 +598,7 @@ private:
             if (P2p) {
               flags |= conn->flags & NCCL_P2P_WRITE ? DirectWrite : DirectRead;
             } else if (connIndex == 1 && direct) {
-              flags |= DirectRead;  // scatter-reduce use direct pull
+              flags |= DirectRead; // scatter-reduce use direct pull
             } else {
               flags |= direct & NCCL_P2P_READ ? DirectRead : DirectWrite;
             }
@@ -637,588 +617,631 @@ private:
   }
 
 public:
-  __forceinline__ __device__ Primitives(
-      int tid, int nthreads, int const *recvPeers, int const *sendPeers,
-      void const *inputBuf, void *outputBuf, uint64_t redOpArg, uint8_t group=0,
-      uint8_t connIndexRecv = 0, uint8_t connIndexSend = 0, struct ncclDevWorkColl* collWork = nullptr,
-      struct ncclDevWorkP2p* p2pWork = nullptr, int stepSize_ = 0, int mode = primsModeDefault
-    ):
-    tid(tid), tidInBlock(threadIdx.x), nthreads(nthreads), /*compiler warnings*/
+  __forceinline__ __device__ Primitives(int tid, int nthreads, int const* recvPeers, int const* sendPeers,
+                                        void const* inputBuf, void* outputBuf, uint64_t redOpArg, uint8_t group = 0,
+                                        uint8_t connIndexRecv = 0, uint8_t connIndexSend = 0,
+                                        struct ncclDevWorkColl* collWork = nullptr,
+                                        struct ncclDevWorkP2p* p2pWork = nullptr, int stepSize_ = 0,
+                                        int mode = primsModeDefault)
+    : tid(tid), tidInBlock(threadIdx.x), nthreads(nthreads), /*compiler warnings*/
 #ifdef ENABLE_WARP_SPEED
-    stepSize(stepSize_ == 0 ? ncclShmem.comm.buffSizes[NCCL_PROTO_SIMPLE]/NCCL_STEPS/sizeof(T) : stepSize_), group(ncclShmem.warpComm? tidInBlock / WARP_SIZE : group), threadsPerBlock(blockDim.x){
+      stepSize(stepSize_ == 0 ? ncclShmem.comm.buffSizes[NCCL_PROTO_SIMPLE] / NCCL_STEPS / sizeof(T) : stepSize_),
+      group(ncclShmem.warpComm ? tidInBlock / WARP_SIZE : group), threadsPerBlock(blockDim.x){
 #else
-    stepSize(stepSize_ == 0 ? ncclShmem.comm.buffSizes[NCCL_PROTO_SIMPLE]/NCCL_STEPS/sizeof(T) : stepSize_), group(group), threadsPerBlock(blockDim.x){
+      stepSize(stepSize_ == 0 ? ncclShmem.comm.buffSizes[NCCL_PROTO_SIMPLE] / NCCL_STEPS / sizeof(T) : stepSize_),
+      group(group), threadsPerBlock(blockDim.x) {
 #endif
-    barriers = &ncclShmem.groups[group].barrier;
-    // PAT uses the same barrier for each group
-    barriers_pat = &ncclShmem.barrier_pat;
-    this->nworkers = nthreads;
+                                                                    barriers = &ncclShmem.groups[group].barrier;
+  // PAT uses the same barrier for each group
+  barriers_pat = &ncclShmem.barrier_pat;
+  this->nworkers = nthreads;
 #ifdef ENABLE_WARP_SPEED
-    auto *channel = ncclShmem.warpComm
-        ? &ncclShmem.warpChannel[tidInBlock/WARP_SIZE]
-        : &ncclShmem.channel;
+  auto* channel = ncclShmem.warpComm ? &ncclShmem.warpChannel[tidInBlock / WARP_SIZE] : &ncclShmem.channel;
 #else
-    auto *channel = &ncclShmem.channel;
+    auto* channel = &ncclShmem.channel;
 #endif
-    int peer = -1;
-    flags = 0;
-    index = -1;
-    if (mode == primsModeDefault) { // Connect to ranks in sendPeers/recvPeers
-      // // For send operations, we need an extra warp to overlap the threadfence and the copy
-      // this->nworkers = nthreads - (MaxSend > 0 && nthreads >= NCCL_SIMPLE_EXTRA_GROUP_IF_NTHREADS_GE ? WARP_SIZE : 0);
+  int peer = -1;
+  flags = 0;
+  index = -1;
+  if (mode == primsModeDefault) { // Connect to ranks in sendPeers/recvPeers
+    // // For send operations, we need an extra warp to overlap the threadfence and the copy
+    // this->nworkers = nthreads - (MaxSend > 0 && nthreads >= NCCL_SIMPLE_EXTRA_GROUP_IF_NTHREADS_GE ? WARP_SIZE : 0);
 
-      int nrecv=0, nsend=0;
-      // Yes, for some template arguments this code will be unreachable.  That's fine.
-      // coverity[dead_error_line]
-      while (nrecv < MaxRecv && recvPeers[nrecv] != -1) nrecv++;
-      // coverity[dead_error_line]
-      while (nsend < MaxSend && sendPeers[nsend] != -1) nsend++;
-      this->fan = Fan(nrecv, nsend);
+    int nrecv = 0, nsend = 0;
+    // Yes, for some template arguments this code will be unreachable.  That's fine.
+    // coverity[dead_error_line]
+    while (nrecv < MaxRecv && recvPeers[nrecv] != -1) nrecv++;
+    // coverity[dead_error_line]
+    while (nsend < MaxSend && sendPeers[nsend] != -1) nsend++;
+    this->fan = Fan(nrecv, nsend);
 
-      constexpr int ThreadPerSync =
-        MaxSend >= 16 || MaxRecv >= 16 ? 32 : // NVLS may have an arity > 8. In that case increase the size of the groups
-        MaxSend >= 8 || MaxRecv >= 8 ? 16 :
+    constexpr int ThreadPerSync =
+      MaxSend >= 16 || MaxRecv >= 16 ?
+        32 : // NVLS may have an arity > 8. In that case increase the size of the groups
+        MaxSend >= 8 || MaxRecv >= 8 ?
+        16 :
         8; // Allows for all roles (WaitRecv/WaitSend/PostRecv/PostSend) within a single warp
-      static_assert(MaxSend <= ThreadPerSync && MaxRecv <= ThreadPerSync, "Not enough threads to cover all peers");
+    static_assert(MaxSend <= ThreadPerSync && MaxRecv <= ThreadPerSync, "Not enough threads to cover all peers");
 
-      assert(2*(nrecv+nsend) <= nthreads); // Ensure no thread is assigned more than one role.
-      // Coverity assumes that index will equal tid based on the line below, but it doesn't consider the setting
-      // of flags.  This results in multiple false positive overruns being reported here and in all_reduce.h.
-      // Unfortunately, we've been unsuccessful in trying to silence them with a single directive here so
-      // instead it's being done at the callers.
-      // coverity[assignment:FALSE]
-      if      (tid < nrecv)                 { flags |= RoleWaitRecv; index = tid; }
-      // Yes, for some template arguments this code will be unreachable.  That's fine.
-      // coverity[dead_error_begin]
-      else if (tid < nrecv+nsend)           { flags |= RoleWaitSend; index = tid-nrecv; }
-      else if (nthreads-nsend <= tid)       { flags |= RolePostSend; index = tid-(nthreads-nsend); }
-      else if (nthreads-nrecv-nsend <= tid) { flags |= RolePostRecv; index = tid-(nthreads-nrecv-nsend); }
-
-      if (flags & (RoleWaitRecv|RolePostRecv)) peer = recvPeers[index];
-      if (flags & (RoleWaitSend|RolePostSend)) peer = sendPeers[index];
-
-      // Coverity thinks that index could be -1 here but that's not actually the case.
-      // coverity[negative_returns:FALSE]
-      int sendIpcReg;
-      int recvIpcReg;
-      int sendNetReg;
-      int recvNetReg;
-      if (P2p) {
-        sendIpcReg = p2pWork ? p2pWork->sendIpcReg : 0;
-        recvIpcReg = p2pWork ? p2pWork->recvIpcReg : 0;
-        sendNetReg = p2pWork ? p2pWork->sendNetReg : 0;
-        recvNetReg = p2pWork ? p2pWork->recvNetReg : 0;
-      } else {
-        recvIpcReg = sendIpcReg = collWork ? collWork->regUsed : 0;
-        recvNetReg = sendNetReg = collWork ? collWork->netRegUsed : 0;
-      }
-
-      // coverity[overrun-call] => Coverity think prims.index can be greater than 1
-      if (flags & (RoleWaitRecv|RolePostRecv)) loadRecvConn(channel->peers[peer], connIndexRecv, collWork ? collWork->direct : 0, recvIpcReg, recvNetReg);
-      // coverity[overrun-call] => Coverity think prims.index can be greater than 1
-      if (flags & (RoleWaitSend|RolePostSend)) loadSendConn(channel->peers[peer], connIndexSend, collWork ? collWork->direct : 0, sendIpcReg, sendNetReg);
-
-      // if (barrierAny(flags & NetDeviceUnpack)) {
-      //   flags |= AnyNetDeviceUnpack;
-      //   // RoleWaitRecv starts at tid=0, so this creates the bitmask of which recv peers
-      //   // have NetDeviceUnpack.
-      //   uint32_t mask = __ballot_sync(~0u, ((flags & RoleWaitRecv) && (flags & NetDeviceUnpack)) ? 1 : 0);
-      //   if (tid == 0) {
-      //     ncclShmem.groups[this->group].devicePlugin.unpack.unpackNetDeviceIndexMask = mask;
-      //   }
-      // }
-
-      // coverity[negative_returns:FALSE] => coverity thinks that index could be -1 but that's not actually the case
-      // coverity[var_deref_model] => coverity thinks work can dereferenced if NULL but this is not the case
-      setDataPtrs(inputBuf, outputBuf, redOpArg, (struct ncclDevWorkCollReg*)collWork, sendIpcReg || recvIpcReg, peer, collWork != nullptr ? collWork->acc : nullptr);
-      // coverity[uninit_member] => coverity thinks fan.n is not initialized
-    } else if (mode == primsModePatRs || mode == primsModePatAg) { // Connect to all ranks +/- 2^n
-      flags |= PatMode;
-      const int roles[5] = { RoleWaitRecv, RolePostRecv, RoleWaitSend, RolePostSend, RoleInput | RoleOutput };
-      if (tid < 5) flags |= roles[tid];
-
-      int nranks = ncclShmem.comm.nRanks;
-      if (tid < 32 && ((1UL<<tid) < nranks)) {
-        int rank = ncclShmem.comm.rank;
-        uint32_t delta = 1 << tid;
-        // Load recv peer
-        int recvPeer = mode == primsModePatRs ? (rank - delta + nranks) % nranks : (rank + delta) % nranks;
-        struct ncclPatPeer* peer = ((struct ncclPatPeer*)recvPeers)+tid;
-        struct ncclConnInfo* conn = peer->conn = channel->peers[recvPeer]->recv+connIndexRecv;
-        peer->step = conn->step;
-        peer->buff = conn->buffs[NCCL_PROTO_SIMPLE];
-        peer->stepCache = loadStepValue(peer->tailPtr = conn->tail);
-        peer->headPtr = conn->head;
-        peer->accSize = 0;
-        peer->connStepSize = conn->stepSize/sizeof(T);
-        // Load send peer
-        int sendPeer = mode == primsModePatAg ? (rank - delta + nranks) % nranks : (rank + delta) % nranks;
-        peer = ((struct ncclPatPeer*)sendPeers)+tid;
-        conn = peer->conn = channel->peers[sendPeer]->send+connIndexSend;
-        peer->step = conn->step;
-        peer->connFifo = conn->connFifo;
-        peer->buff = conn->buffs[NCCL_PROTO_SIMPLE];
-        peer->stepCache = loadStepValue(peer->headPtr = conn->head);
-        peer->tailPtr = conn->tail;
-        peer->accSize = 0;
-        peer->connStepSize = conn->stepSize/sizeof(T);
-      }
-      if (tid==0) {
-        ncclShmem.groups[group].userInput = (void*)inputBuf;
-        ncclShmem.groups[group].userOutput = (void*)outputBuf;
-        ncclShmem.groups[group].redOpArgs = redOpArg;  // scaler for local input
-      }
-      patBarrier();
+    assert(2 * (nrecv + nsend) <= nthreads); // Ensure no thread is assigned more than one role.
+    // Coverity assumes that index will equal tid based on the line below, but it doesn't consider the setting
+    // of flags.  This results in multiple false positive overruns being reported here and in all_reduce.h.
+    // Unfortunately, we've been unsuccessful in trying to silence them with a single directive here so
+    // instead it's being done at the callers.
+    // coverity[assignment:FALSE]
+    if (tid < nrecv) {
+      flags |= RoleWaitRecv;
+      index = tid;
     }
+    // Yes, for some template arguments this code will be unreachable.  That's fine.
+    // coverity[dead_error_begin]
+    else if (tid < nrecv + nsend) {
+      flags |= RoleWaitSend;
+      index = tid - nrecv;
+    } else if (nthreads - nsend <= tid) {
+      flags |= RolePostSend;
+      index = tid - (nthreads - nsend);
+    } else if (nthreads - nrecv - nsend <= tid) {
+      flags |= RolePostRecv;
+      index = tid - (nthreads - nrecv - nsend);
+    }
+
+    if (flags & (RoleWaitRecv | RolePostRecv)) peer = recvPeers[index];
+    if (flags & (RoleWaitSend | RolePostSend)) peer = sendPeers[index];
+
+    // Coverity thinks that index could be -1 here but that's not actually the case.
+    // coverity[negative_returns:FALSE]
+    int sendIpcReg;
+    int recvIpcReg;
+    int sendNetReg;
+    int recvNetReg;
+    if (P2p) {
+      sendIpcReg = p2pWork ? p2pWork->sendIpcReg : 0;
+      recvIpcReg = p2pWork ? p2pWork->recvIpcReg : 0;
+      sendNetReg = p2pWork ? p2pWork->sendNetReg : 0;
+      recvNetReg = p2pWork ? p2pWork->recvNetReg : 0;
+    } else {
+      recvIpcReg = sendIpcReg = collWork ? collWork->regUsed : 0;
+      recvNetReg = sendNetReg = collWork ? collWork->netRegUsed : 0;
+    }
+
+    // coverity[overrun-call] => Coverity think prims.index can be greater than 1
+    if (flags & (RoleWaitRecv | RolePostRecv))
+      loadRecvConn(channel->peers[peer], connIndexRecv, collWork ? collWork->direct : 0, recvIpcReg, recvNetReg);
+    // coverity[overrun-call] => Coverity think prims.index can be greater than 1
+    if (flags & (RoleWaitSend | RolePostSend))
+      loadSendConn(channel->peers[peer], connIndexSend, collWork ? collWork->direct : 0, sendIpcReg, sendNetReg);
+
+    // if (barrierAny(flags & NetDeviceUnpack)) {
+    //   flags |= AnyNetDeviceUnpack;
+    //   // RoleWaitRecv starts at tid=0, so this creates the bitmask of which recv peers
+    //   // have NetDeviceUnpack.
+    //   uint32_t mask = __ballot_sync(~0u, ((flags & RoleWaitRecv) && (flags & NetDeviceUnpack)) ? 1 : 0);
+    //   if (tid == 0) {
+    //     ncclShmem.groups[this->group].devicePlugin.unpack.unpackNetDeviceIndexMask = mask;
+    //   }
+    // }
+
+    // coverity[negative_returns:FALSE] => coverity thinks that index could be -1 but that's not actually the case
+    // coverity[var_deref_model] => coverity thinks work can dereferenced if NULL but this is not the case
+    setDataPtrs(inputBuf, outputBuf, redOpArg, (struct ncclDevWorkCollReg*)collWork, sendIpcReg || recvIpcReg, peer,
+                collWork != nullptr ? collWork->acc : nullptr);
+    // coverity[uninit_member] => coverity thinks fan.n is not initialized
+  } else if (mode == primsModePatRs || mode == primsModePatAg) { // Connect to all ranks +/- 2^n
+    flags |= PatMode;
+    const int roles[5] = {RoleWaitRecv, RolePostRecv, RoleWaitSend, RolePostSend, RoleInput | RoleOutput};
+    if (tid < 5) flags |= roles[tid];
+
+    int nranks = ncclShmem.comm.nRanks;
+    if (tid < 32 && ((1UL << tid) < nranks)) {
+      int rank = ncclShmem.comm.rank;
+      uint32_t delta = 1 << tid;
+      // Load recv peer
+      int recvPeer = mode == primsModePatRs ? (rank - delta + nranks) % nranks : (rank + delta) % nranks;
+      struct ncclPatPeer* peer = ((struct ncclPatPeer*)recvPeers) + tid;
+      struct ncclConnInfo* conn = peer->conn = channel->peers[recvPeer]->recv + connIndexRecv;
+      peer->step = conn->step;
+      peer->buff = conn->buffs[NCCL_PROTO_SIMPLE];
+      peer->stepCache = loadStepValue(peer->tailPtr = conn->tail);
+      peer->headPtr = conn->head;
+      peer->accSize = 0;
+      peer->connStepSize = conn->stepSize / sizeof(T);
+      // Load send peer
+      int sendPeer = mode == primsModePatAg ? (rank - delta + nranks) % nranks : (rank + delta) % nranks;
+      peer = ((struct ncclPatPeer*)sendPeers) + tid;
+      conn = peer->conn = channel->peers[sendPeer]->send + connIndexSend;
+      peer->step = conn->step;
+      peer->connFifo = conn->connFifo;
+      peer->buff = conn->buffs[NCCL_PROTO_SIMPLE];
+      peer->stepCache = loadStepValue(peer->headPtr = conn->head);
+      peer->tailPtr = conn->tail;
+      peer->accSize = 0;
+      peer->connStepSize = conn->stepSize / sizeof(T);
+    }
+    if (tid == 0) {
+      ncclShmem.groups[group].userInput = (void*)inputBuf;
+      ncclShmem.groups[group].userOutput = (void*)outputBuf;
+      ncclShmem.groups[group].redOpArgs = redOpArg; // scaler for local input
+    }
+    patBarrier();
+  }
 #if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
-    skip_fence = !ncclShmem.comm.gfx9CheapFenceOff;
+  skip_fence = !ncclShmem.comm.gfx9CheapFenceOff;
 #else
     // The cheap post-peer fence is only safe with global DWORDX4 builtins
     // (system-scope cache-bypassing stores); otherwise always use the full fence.
     skip_fence = false;
 #endif
+}
+
+__forceinline__ __device__ ~Primitives() {
+  if (flags & PatMode) return;
+  // Save steps for the next operation
+  if (flags & (RolePostSend | RolePostRecv)) conn->step = step;
+  if ((flags & NetRegMode) && (flags & RoleWaitSend)) {
+    // Make sure we wait until the proxy has sent data before we return.
+    // We don't want the next CUDA kernel to overwrite the send buffer which
+    // was accessed directly.
+    uint64_t prevStep = step - StepPerSlice;
+    volatile ssize_t* ptr = &(connFifo[prevStep % NCCL_STEPS].size);
+    int spins = 0;
+    while (*ptr != -1)
+      if (checkAbort(flags, Aborted, spins)) break;
   }
 
-  __forceinline__ __device__ ~Primitives() {
-    if (flags&PatMode) return;
-    // Save steps for the next operation
-    if (flags & (RolePostSend|RolePostRecv)) conn->step = step;
-    if ((flags & NetRegMode) && (flags & RoleWaitSend)) {
-      // Make sure we wait until the proxy has sent data before we return.
-      // We don't want the next CUDA kernel to overwrite the send buffer which
-      // was accessed directly.
-      uint64_t prevStep = step - StepPerSlice;
-      volatile ssize_t* ptr = &(connFifo[prevStep%NCCL_STEPS].size);
-      int spins = 0;
-      while (*ptr != -1) if (checkAbort(flags, Aborted, spins)) break;
-    }
-
-    if (flags & NetDeviceUnpack) {
-      ncclNetDeviceSaveHead(netDeviceHandle, group, index);
-    }
-
-    // Make sure all threads are done writing back conn->step and done using
-    // ncclShmem.groups[group]
-    barrier();
-
-    if ((flags & DirectRead) && (flags & RoleWaitSend) && P2p) {
-      // For sendrecv DirectRead, sender needs to wait for receiver reading data from src.
-      // This has to be done after barrier() since post thread might have contention with
-      // this check.
-      int spins = 0;
-      volatile uint64_t* tail = conn->tail;
-      volatile uint64_t* head = conn->head;
-      while (*tail > *head) if (checkAbort(flags, Aborted, spins)) break;
-    }
+  if (flags & NetDeviceUnpack) {
+    ncclNetDeviceSaveHead(netDeviceHandle, group, index);
   }
 
-  __device__ void setDataPtrs(void const *inputBuf, void *outputBuf, uint64_t redOpArg, struct ncclDevWorkCollReg* work, uint8_t ipcReg, int peer, void const *acc) {
-    if (tid==0) {
-      ncclShmem.groups[group].userInput = (void*)inputBuf;
-      ncclShmem.groups[group].userOutput = (void*)outputBuf;
-      ncclShmem.groups[group].userAcc = (void*)acc;
-      ncclShmem.groups[group].redOpArgs = redOpArg;  // scaler for local input
-    }
+  // Make sure all threads are done writing back conn->step and done using
+  // ncclShmem.groups[group]
+  barrier();
 
-    if (Direct && ipcReg) {
-      bool recvProvider = (flags & RoleWaitRecv) && (flags & DirectWrite);
-      bool sendAcceptor = (flags & RoleWaitSend) && (flags & DirectWrite);
-      bool sendProvider = (flags & RoleWaitSend) && (flags & DirectRead); // sender provides direct buffer (to be fetched)
-      bool recvAcceptor = (flags & RoleWaitRecv) && (flags & DirectRead); // receiver accepts direct buffer
-      if (recvProvider) {
-        int spins = 0;
-        void* volatile* slot = ncclShmem.groups[group].recvConns[index]->ptrExchange;
-        // Wait for consumer to consume previous value before trampling it.
-        if (slot) {
-          T* exchgPtr;
-          directBuff = (T*)outputBuf;
-          while ((void *)atomicAdd((unsigned long long *) slot,0) != nullptr && !checkAbort(flags, Aborted, spins));
-          if (P2p) {
-            exchgPtr = (T*)outputBuf;
-          } else {
-            // For cross-clique P2P, use peer rank directly to avoid localRank conflicts between cliques
-            int localPeer = ncclShmem.comm.p2pCrossClique ? peer : ncclShmem.comm.rankToLocalRank[peer];
-            // coverity[deref_parm:FALSE] => work cannot be NULL if ipcReg != NULL
+  if ((flags & DirectRead) && (flags & RoleWaitSend) && P2p) {
+    // For sendrecv DirectRead, sender needs to wait for receiver reading data from src.
+    // This has to be done after barrier() since post thread might have contention with
+    // this check.
+    int spins = 0;
+    volatile uint64_t* tail = conn->tail;
+    volatile uint64_t* head = conn->head;
+    while (*tail > *head)
+      if (checkAbort(flags, Aborted, spins)) break;
+  }
+}
+
+__device__ void setDataPtrs(void const* inputBuf, void* outputBuf, uint64_t redOpArg, struct ncclDevWorkCollReg* work,
+                            uint8_t ipcReg, int peer, void const* acc) {
+  if (tid == 0) {
+    ncclShmem.groups[group].userInput = (void*)inputBuf;
+    ncclShmem.groups[group].userOutput = (void*)outputBuf;
+    ncclShmem.groups[group].userAcc = (void*)acc;
+    ncclShmem.groups[group].redOpArgs = redOpArg; // scaler for local input
+  }
+
+  if (Direct && ipcReg) {
+    bool recvProvider = (flags & RoleWaitRecv) && (flags & DirectWrite);
+    bool sendAcceptor = (flags & RoleWaitSend) && (flags & DirectWrite);
+    bool sendProvider = (flags & RoleWaitSend) && (flags & DirectRead); // sender provides direct buffer (to be fetched)
+    bool recvAcceptor = (flags & RoleWaitRecv) && (flags & DirectRead); // receiver accepts direct buffer
+    if (recvProvider) {
+      int spins = 0;
+      void* volatile* slot = ncclShmem.groups[group].recvConns[index]->ptrExchange;
+      // Wait for consumer to consume previous value before trampling it.
+      if (slot) {
+        T* exchgPtr;
+        directBuff = (T*)outputBuf;
+        while ((void*)atomicAdd((unsigned long long*)slot, 0) != nullptr && !checkAbort(flags, Aborted, spins));
+        if (P2p) {
+          exchgPtr = (T*)outputBuf;
+        } else {
+          // For cross-clique P2P, use peer rank directly to avoid localRank conflicts between cliques
+          int localPeer = ncclShmem.comm.p2pCrossClique ? peer : ncclShmem.comm.rankToLocalRank[peer];
+          // coverity[deref_parm:FALSE] => work cannot be NULL if ipcReg != NULL
+          exchgPtr = (T*)(work->coll.recvbuffOffset + work->coll.recvbuffRmtAddrs[localPeer]);
+        }
+        *slot = reinterpret_cast<void*>(exchgPtr);
+      }
+    }
+    if (sendAcceptor) {
+      int spins = 0;
+      void* volatile* slot = ncclShmem.groups[group].sendConns[index]->ptrExchange;
+      void* ptr;
+      while (slot) {
+        ptr = (void*)atomicAdd((unsigned long long*)slot, 0);
+        if (ptr != nullptr || checkAbort(flags, Aborted, spins)) break;
+      }
+
+      if (slot) {
+        directBuff = reinterpret_cast<T*>(ptr);
+        *slot = nullptr;
+      } else {
+        // coverity[var_deref_op]
+        directBuff = (T*)work->dnOutputs[index];
+      }
+    }
+    if (sendProvider) {
+      int spins = 0;
+      void* volatile* slot = ncclShmem.groups[group].sendConns[index]->ptrExchange;
+      volatile uint64_t* argSlot0 = ncclShmem.groups[group].sendConns[index]->redOpArgExchange;
+      volatile uint64_t* argSlot1 = ncclShmem.groups[group].sendConns[index]->redOpArgExchange + 1;
+      // Wait for consumer to consume previous value before trampling it.
+      if (slot && argSlot0 && argSlot1) {
+        T* exchgPtr;
+        while (((void*)atomicAdd((unsigned long long*)slot, 0) != nullptr || *argSlot0 != 0 || *argSlot1 != 0) &&
+               !checkAbort(flags, Aborted, spins));
+        // If there is no recv, then we are directly pulling from input buffer (e.g. directScatter)
+        // Otherwise, we are pulling from output buffer (e.g. recvCopyDirectSend)
+        directBuff = MaxRecv == 0 ? (T*)inputBuf : (T*)outputBuf;
+        if (P2p) {
+          exchgPtr = MaxRecv == 0 ? (T*)inputBuf : (T*)outputBuf;
+        } else {
+          // For cross-clique P2P, use peer rank directly to avoid localRank conflicts between cliques
+          int localPeer = ncclShmem.comm.p2pCrossClique ? peer : ncclShmem.comm.rankToLocalRank[peer];
+          if (MaxRecv == 0)
+            // coverity[var_deref_op]
+            exchgPtr = (T*)(work->coll.sendbuffOffset + work->coll.sendbuffRmtAddrs[localPeer]);
+          else
+            // coverity[var_deref_op]
             exchgPtr = (T*)(work->coll.recvbuffOffset + work->coll.recvbuffRmtAddrs[localPeer]);
-          }
-          *slot = reinterpret_cast<void*>(exchgPtr);
-        }
-      }
-      if (sendAcceptor) {
-        int spins = 0;
-        void* volatile* slot = ncclShmem.groups[group].sendConns[index]->ptrExchange;
-        void* ptr;
-        while (slot) {
-          ptr = (void *)atomicAdd((unsigned long long *) slot,0);
-          if (ptr != nullptr || checkAbort(flags, Aborted, spins)) break;
         }
 
-        if (slot) {
-          directBuff = reinterpret_cast<T*>(ptr);
-          *slot = nullptr;
-        } else {
-          // coverity[var_deref_op]
-          directBuff = (T*)work->dnOutputs[index];
-        }
-      }
-      if (sendProvider) {
-        int spins = 0;
-        void* volatile* slot = ncclShmem.groups[group].sendConns[index]->ptrExchange;
-        volatile uint64_t* argSlot0 = ncclShmem.groups[group].sendConns[index]->redOpArgExchange;
-        volatile uint64_t* argSlot1 = ncclShmem.groups[group].sendConns[index]->redOpArgExchange + 1;
-        // Wait for consumer to consume previous value before trampling it.
-        if (slot && argSlot0 && argSlot1) {
-          T* exchgPtr;
-          while (((void *)atomicAdd((unsigned long long *) slot,0) != nullptr || *argSlot0 != 0 || *argSlot1 != 0) && !checkAbort(flags, Aborted, spins));
-          // If there is no recv, then we are directly pulling from input buffer (e.g. directScatter)
-          // Otherwise, we are pulling from output buffer (e.g. recvCopyDirectSend)
-          directBuff = MaxRecv == 0 ? (T*)inputBuf : (T*)outputBuf;
-          if (P2p) {
-            exchgPtr = MaxRecv == 0 ? (T*)inputBuf : (T*)outputBuf;
-          } else {
-            // For cross-clique P2P, use peer rank directly to avoid localRank conflicts between cliques
-            int localPeer = ncclShmem.comm.p2pCrossClique ? peer : ncclShmem.comm.rankToLocalRank[peer];
-            if (MaxRecv == 0)
-              // coverity[var_deref_op]
-              exchgPtr = (T*)(work->coll.sendbuffOffset + work->coll.sendbuffRmtAddrs[localPeer]);
-            else
-              // coverity[var_deref_op]
-              exchgPtr = (T*)(work->coll.recvbuffOffset + work->coll.recvbuffRmtAddrs[localPeer]);
-          }
-
-          // Exchange pre-scalers for use in direct pull
-          *argSlot0 = (uint64_t(1) << 32) | (uint32_t)redOpArg;
-          *argSlot1 = (uint64_t(1) << 32) | (uint32_t)(redOpArg >> 32);
-          *slot = reinterpret_cast<T*>(exchgPtr);
-        }
-      }
-      if (recvAcceptor) {
-        int spins = 0;
-        void* volatile* slot = ncclShmem.groups[group].recvConns[index]->ptrExchange;
-        volatile uint64_t* argSlot0 = ncclShmem.groups[group].recvConns[index]->redOpArgExchange;
-        volatile uint64_t* argSlot1 = ncclShmem.groups[group].recvConns[index]->redOpArgExchange + 1;
-        void* ptr;
-        while (slot) {
-          ptr = (void *)atomicAdd((unsigned long long *) slot,0);
-          if (ptr != nullptr || checkAbort(flags, Aborted, spins)) break;
-        }
-
-        if (slot && argSlot0 && argSlot1) {
-          directBuff = reinterpret_cast<T*>(ptr);
-          *argSlot0 = 0; *argSlot1 = 0;
-          *slot = nullptr;
-        } else {
-          // Coverity complains about work being possibly NULL below.  However, slot
-          // being NULL means that the NVLS buffer is registered (regUsed == 1)
-          // so work can't be NULL in this code path.
-          // coverity[var_deref_op]
-          directBuff = (T*)work->dnInputs[index];
-        }
+        // Exchange pre-scalers for use in direct pull
+        *argSlot0 = (uint64_t(1) << 32) | (uint32_t)redOpArg;
+        *argSlot1 = (uint64_t(1) << 32) | (uint32_t)(redOpArg >> 32);
+        *slot = reinterpret_cast<T*>(exchgPtr);
       }
     }
-  }
-
-  __device__ void moveDataPtrs(intptr_t delta) {
-    if (tid==0) {
-      ncclShmem.groups[group].userInput = (T*)ncclShmem.groups[group].userInput + delta;
-      ncclShmem.groups[group].userOutput = (T*)ncclShmem.groups[group].userOutput + delta;
-    }
-  }
-
-  __device__ __forceinline__ void setDataPtrs(void const *inputBuf, void *outputBuf = nullptr) {
-    if (tid==0) {
-      ncclShmem.groups[group].userInput = (T*)inputBuf;
-      ncclShmem.groups[group].userOutput = (T*)outputBuf;
-    }
-  }
-
-  __device__ __forceinline__ void send(intptr_t inpIx, int eltN) {
-    genericOp<0, 0, 0, 1, Input, -1>(inpIx, -1, eltN, false);
-  }
-  __device__ __forceinline__ void sendFromOutput(intptr_t outIx, int eltN) {
-    genericOp<0, 0, 0, 1, Output, -1>(outIx, -1, eltN, false);
-  }
-  __device__ __forceinline__ void directSend(intptr_t inpIx, intptr_t outIx, int eltN) {
-    genericOp<0, 1, 0, 1, Input, -1>(inpIx, outIx, eltN, false);
-  }
-  __device__ __forceinline__ void directSendFromOutput(intptr_t outIx, int eltN) {
-    genericOp<0, 1, 0, 1, Output, -1>(outIx, outIx, eltN, false);
-  }
-
-  __device__ __forceinline__ void recv(intptr_t outIx, int eltN, bool postOp=false) {
-    genericOp<0, 0, 1, 0, -1, Output>(-1, outIx, eltN, postOp);
-  }
-  __device__ __forceinline__ void directRecv(intptr_t outIx, int eltN, bool postOp=false) {
-    genericOp<1, 0, 1, 0, -1, Output>(outIx, outIx, eltN, postOp);
-  }
-  __device__ __forceinline__ void directRecvCopy(intptr_t inpIx, intptr_t outIx, int eltN) {
-    genericOp<1, 0, 1, 0, -1, Output>(inpIx, outIx, eltN, /*postOp=*/false);
-  }
-
-  __device__ __forceinline__ void copySend(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp=false) {
-    genericOp<0, 0, 0, 1, Input, Output>(inpIx, outIx, eltN, postOp);
-  }
-  __device__ __forceinline__ void directCopySend(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp=false) {
-    genericOp<0, 1, 0, 1, Input, Output>(inpIx, outIx, eltN, postOp);
-  }
-
-  __device__ __forceinline__ void recvSend(int eltN, bool postOp=false) {
-    genericOp<0, 0, 1, 1, -1, -1>(-1, -1, eltN, postOp);
-  }
-  __device__ __forceinline__ void recvCopySend(intptr_t outIx, int eltN, bool postOp=false) {
-    genericOp<0, 0, 1, 1, -1, Output>(-1, outIx, eltN, postOp);
-  }
-  __device__ __forceinline__ void directRecvCopyDirectSend(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp=false) {
-    genericOp<1, 1, 1, 1, -1, Output>(inpIx, outIx, eltN, postOp);
-  }
-  __device__ __forceinline__ void directRecvDirectSend(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp=false) {
-    genericOp<1, 1, 1, 1, -1, -1>(inpIx, outIx, eltN, postOp);
-  }
-  __device__ __forceinline__ void recvDirectSend(intptr_t outIx, int eltN, bool postOp=false) {
-    genericOp<0, 1, 1, 1, -1, -1>(-1, outIx, eltN, postOp);
-  }
-  __device__ __forceinline__ void directRecvSend(intptr_t outIx, int eltN, bool postOp=false) {
-    genericOp<1, 0, 1, 1, -1, -1>(outIx, outIx, eltN, postOp);
-  }
-  __device__ __forceinline__ void recvCopyDirectSend(intptr_t outIx, int eltN, bool postOp=false) {
-    genericOp<0, 1, 1, 1, -1, Output>(-1, outIx, eltN, postOp);
-  }
-
-  __device__ __forceinline__ void recvReduceCopy(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp=false) {
-    genericOp<0, 0, 1, 0, Input, Output>(inpIx, outIx, eltN, postOp);
-  }
-  __device__ __forceinline__ void directRecvReduceCopy(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp=false) {
-    genericOp<1, 0, 1, 0, Input, Output>(inpIx, outIx, eltN, postOp);
-  }
-
-  __device__ __forceinline__ void recvReduceSend(intptr_t inpIx, int eltN, bool postOp=false) {
-    genericOp<0, 0, 1, 1, Input, -1>(inpIx, -1, eltN, postOp);
-  }
-  __device__ __forceinline__ void directRecvReduceSend(intptr_t inpIx, int eltN, bool postOp=false) {
-    genericOp<1, 0, 1, 1, Input, -1>(inpIx, -1, eltN, postOp);
-  }
-  __device__ __forceinline__ void recvReduceDirectSend(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp=false) {
-    genericOp<0, 1, 1, 1, Input, -1>(inpIx, outIx, eltN, postOp);
-  }
-  __device__ __forceinline__ void directRecvReduceDirectSend(intptr_t inpIx, intptr_t outIx, ssize_t eltN, bool postOp=false) {
-    genericOp<1, 1, 1, 1, Input, -1>(inpIx, outIx, eltN, postOp);
-  }
-
-  __device__ __forceinline__ void recvReduceCopySend(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp=false) {
-    genericOp<0, 0, 1, 1, Input, Output>(inpIx, outIx, eltN, postOp);
-  }
-  __device__ __forceinline__ void recvReduceCopyDirectSend(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp=false) {
-    // Direct is only for the send part
-    genericOp<0, 1, 1, 1, Input, Output>(inpIx, outIx, eltN, postOp);
-  }
-  __device__ __forceinline__ void directRecvReduceCopyDirectSend(intptr_t inpIx, intptr_t outIx, ssize_t eltN, bool postOp=false) {
-    genericOp<1, 1, 1, 1, Input, Output>(inpIx, outIx, eltN, postOp);
-  }
-
-  __device__ __forceinline__ void
-  scatter(intptr_t inpIx, ssize_t totalElem, int peerElem, ssize_t peerOffset, int skip, int shift) {
-    ScatterGatherOp<0, 0, 0, 1>(inpIx, -1, totalElem, peerElem, peerOffset, skip, shift, /*postOp=*/false);
-  }
-  __device__ __forceinline__ void
-  directScatter(intptr_t inpIx, ssize_t totalElem, int peerElem, ssize_t peerOffset, int skip, int shift) {
-    ScatterGatherOp<0, 1, 0, 1>(inpIx, -1, totalElem, peerElem, peerOffset, skip, shift, /*postOp=*/false);
-  }
-
-  __device__ __forceinline__ void
-  gather(intptr_t outIx, ssize_t totalElem, int peerElem, ssize_t peerOffset, int skip, int shift, bool postOp=false) {
-    ScatterGatherOp<0, 0, 1, 0>(-1, outIx, totalElem, peerElem, peerOffset, skip, shift, postOp);
-  }
-  __device__ __forceinline__ void
-  directGather(intptr_t outIx, ssize_t totalElem, int peerElem, ssize_t peerOffset, int skip, int shift) {
-    ScatterGatherOp<1, 0, 1, 0>(-1, outIx, totalElem, peerElem, peerOffset, skip, shift, /*postOp=*/false);
-  }
-
-  __device__ __forceinline__ void patReduce(struct ncclPatStep* ps, struct ncclPatShmem* shmem) {
-    if (ps->flags & PatSkipped) { patBarrier(); patBarrier(); return; } // Skipped
-    int nelem = ps->nelem < 0 ? 0 : ps->nelem;
-    T* userInput = (T*)ncclShmem.groups[group].userInput;
-    T* userOutput = (T*)ncclShmem.groups[group].userOutput;
-
-    bool recv = ps->recvDim >= 0 && (flags & (RolePostRecv|RoleWaitRecv));
-    bool send = ps->sendDim >= 0 && (flags & (RolePostSend|RoleWaitSend));
-    bool postRecv = ps->postRecv && recv;
-    bool postSend = ps->postSend && send;
-    struct ncclPatPeer* peer = NULL;
-    if (recv) {
-      peer = shmem->recvDims+ps->recvDim;
-      step = peer->step;
-    }
-    if (send) {
-      peer = shmem->sendDims+ps->sendDim;
-      step = peer->step;
-    }
-
-    if (recv && (flags & RoleWaitRecv)) {
-      ncclShmem.groups[group].srcs[0] = ((T*)peer->buff) + (step%NCCL_STEPS)*peer->connStepSize + ps->recvOffset;
+    if (recvAcceptor) {
       int spins = 0;
-      while (peer->stepCache < step + StepPerSlice) {
-        peer->stepCache = loadStepValue(peer->tailPtr);
-        if (checkAbort(flags, Aborted, spins)) break;
+      void* volatile* slot = ncclShmem.groups[group].recvConns[index]->ptrExchange;
+      volatile uint64_t* argSlot0 = ncclShmem.groups[group].recvConns[index]->redOpArgExchange;
+      volatile uint64_t* argSlot1 = ncclShmem.groups[group].recvConns[index]->redOpArgExchange + 1;
+      void* ptr;
+      while (slot) {
+        ptr = (void*)atomicAdd((unsigned long long*)slot, 0);
+        if (ptr != nullptr || checkAbort(flags, Aborted, spins)) break;
       }
-    }
-    if (send && (flags & RoleWaitSend)) {
-      int spins = 0;
-      while (peer->stepCache + NCCL_STEPS < step + ps->stepOffset + StepPerSlice) {
-        peer->stepCache = loadStepValue(peer->headPtr);
-        if (checkAbort(flags, Aborted, spins)) break;
-      }
-      ncclShmem.groups[group].dsts[0] = ((T*)peer->buff) + ((step+ps->stepOffset)%NCCL_STEPS)*peer->connStepSize + ps->sendOffset;
-      if (peer->accSize < ps->sendOffset + nelem + (step+ps->stepOffset)*peer->connStepSize) {
-        // New data, add our own data to it.
-        ncclShmem.groups[group].srcs[1] = userInput + ps->inpIx;
+
+      if (slot && argSlot0 && argSlot1) {
+        directBuff = reinterpret_cast<T*>(ptr);
+        *argSlot0 = 0;
+        *argSlot1 = 0;
+        *slot = nullptr;
       } else {
-        // There is already data in there, accumulate instead of writing to it.
-        ncclShmem.groups[group].srcs[1] = ncclShmem.groups[group].dsts[0];
+        // Coverity complains about work being possibly NULL below.  However, slot
+        // being NULL means that the NVLS buffer is registered (regUsed == 1)
+        // so work can't be NULL in this code path.
+        // coverity[var_deref_op]
+        directBuff = (T*)work->dnInputs[index];
       }
-    }
-    long long int localAccSize = shmem->localAccSize;
-    if (ps->sendDim < 0 && (flags & RoleOutput)) { // Destination is our own local buffer
-      ncclShmem.groups[group].dsts[0] = userOutput + ps->outIx;
-      if (localAccSize < ps->outIx + nelem) {
-        // New data, add our own data to it.
-        ncclShmem.groups[group].srcs[1] = userInput + ps->inpIx;
-        localAccSize = ps->outIx + nelem;
-      } else {
-        // There is already data in there, accumulate instead of writing to it.
-        ncclShmem.groups[group].srcs[1] = ncclShmem.groups[group].dsts[0];
-      }
-    }
-    patBarrier();
-    int nSrcs = 2;
-    void** srcs = ncclShmem.groups[group].srcs;
-    if (ps->recvDim < 0) { srcs++; nSrcs--; } // No peer to receive from, remove one source
-
-    int workSize = ncclShmem.aborted ? 0 : nelem;
-
-    reduceCopy<Unroll, useAcc, RedOp, T, 0, 1, 2, 0, 1, 1, /*PreOpSrcs*/0>
-      (tid, nthreads, ncclShmem.groups[group].redOpArgs, /*postOp=*/false,
-      nSrcs, srcs, 1, ncclShmem.groups[group].dsts, workSize);
-
-    // Store conn step here inside the two barriers to make sure next reload will see the update.
-    if (postSend && (flags & RolePostSend)) {
-      if (peer->connFifo) {
-        peer->connFifo[step%NCCL_STEPS].size = (ps->sendOffset + nelem)*sizeof(T);
-      }
-      peer->step = step += StepPerSlice;
-      st_relaxed_sys_global(&peer->conn->step, step);
-    }
-    if (postRecv && (flags & RolePostRecv)) {
-      peer->step = step += StepPerSlice;
-      st_relaxed_sys_global(&peer->conn->step, step); // Also save in global mem for next op
-    }
-
-    // Update accSize
-    if (ps->sendDim < 0 && (flags & RoleOutput)) atomicMax(&shmem->localAccSize, localAccSize);
-    if (ps->sendDim >= 0 && (flags & RoleWaitSend)) atomicMax(&peer->accSize, ps->sendOffset + nelem + (step+ps->stepOffset)*peer->connStepSize);
-
-    patBarrier();
-
-    if (postSend && (flags & RolePostSend)) {
-      if (nelem > 0 || peer->connFifo) fence_acq_rel_sys();
-      st_relaxed_sys_global(peer->tailPtr, step);
-    }
-    if (postRecv && (flags & RolePostRecv)) {
-      st_relaxed_sys_global(peer->headPtr, step);
     }
   }
+}
 
-  __device__ __forceinline__ void patCopy(struct ncclPatStep* ps, struct ncclPatShmem* shmem) {
-    if (ps->flags & PatSkipped) { patBarrier(); patBarrier(); return; } // Skipped
-    int nelem = ps->nelem < 0 ? 0 : ps->nelem;
-    T* userInput = (T*)ncclShmem.groups[group].userInput;
-    T* userOutput = (T*)ncclShmem.groups[group].userOutput;
+__device__ void moveDataPtrs(intptr_t delta) {
+  if (tid == 0) {
+    ncclShmem.groups[group].userInput = (T*)ncclShmem.groups[group].userInput + delta;
+    ncclShmem.groups[group].userOutput = (T*)ncclShmem.groups[group].userOutput + delta;
+  }
+}
 
-    bool recv = ps->recvDim >= 0 && (flags & (RolePostRecv|RoleWaitRecv));
-    bool send = ps->sendDim >= 0 && (flags & (RolePostSend|RoleWaitSend));
-    bool postRecv = ps->postRecv && recv;
-    bool postSend = ps->postSend && send;
-    struct ncclPatPeer* peer = NULL;
-    if (recv) {
-      peer = shmem->recvDims+ps->recvDim;
-      step = peer->step;
-    }
-    if (send) {
-      peer = shmem->sendDims+ps->sendDim;
-      step = peer->step;
-    }
+__device__ __forceinline__ void setDataPtrs(void const* inputBuf, void* outputBuf = nullptr) {
+  if (tid == 0) {
+    ncclShmem.groups[group].userInput = (T*)inputBuf;
+    ncclShmem.groups[group].userOutput = (T*)outputBuf;
+  }
+}
 
-    if (recv && (flags & RoleWaitRecv)) {
-      ncclShmem.groups[group].srcs[0] = ((T*)peer->buff) + ((step+ps->stepOffset)%NCCL_STEPS)*peer->connStepSize + ps->recvOffset;
-      int spins = 0;
-      while (peer->stepCache < step + ps->stepOffset + StepPerSlice) {
-        peer->stepCache = loadStepValue(peer->tailPtr);
-        if (checkAbort(flags, Aborted, spins)) break;
-      }
-      if (peer->accSize < ps->recvOffset + nelem + (step+ps->stepOffset)*peer->connStepSize) {
-        // New data, copy to our output buffer.
-        ncclShmem.groups[group].dsts[1] = userOutput + ps->outIx;
-      } else {
-        ncclShmem.groups[group].dsts[1] = ncclShmem.groups[group].srcs[0]; // Already done
-      }
-    }
-    if (send && (flags & RoleWaitSend)) {
-      int spins = 0;
-      while (peer->stepCache + NCCL_STEPS < step + StepPerSlice) {
-        peer->stepCache = loadStepValue(peer->headPtr);
-        if (checkAbort(flags, Aborted, spins)) break;
-      }
-      ncclShmem.groups[group].dsts[0] = ((T*)peer->buff) + (step%NCCL_STEPS)*peer->connStepSize + ps->sendOffset;
-    }
-    long long int localAccSize = shmem->localAccSize;
-    if (ps->recvDim < 0 && (flags & RoleInput)) { // Source is our own local buffer
-      ncclShmem.groups[group].srcs[0] = userInput + ps->inpIx;
-      if (localAccSize < ps->inpIx + nelem) {
-        // New data, copy to our output buffer.
-        ncclShmem.groups[group].dsts[1] = userOutput + ps->outIx;
-        localAccSize = ps->inpIx + nelem;
-      } else {
-        // Already done
-        ncclShmem.groups[group].dsts[1] = ncclShmem.groups[group].srcs[0];
-      }
-    }
+__device__ __forceinline__ void send(intptr_t inpIx, int eltN) {
+  genericOp<0, 0, 0, 1, Input, -1>(inpIx, -1, eltN, false);
+}
+__device__ __forceinline__ void sendFromOutput(intptr_t outIx, int eltN) {
+  genericOp<0, 0, 0, 1, Output, -1>(outIx, -1, eltN, false);
+}
+__device__ __forceinline__ void directSend(intptr_t inpIx, intptr_t outIx, int eltN) {
+  genericOp<0, 1, 0, 1, Input, -1>(inpIx, outIx, eltN, false);
+}
+__device__ __forceinline__ void directSendFromOutput(intptr_t outIx, int eltN) {
+  genericOp<0, 1, 0, 1, Output, -1>(outIx, outIx, eltN, false);
+}
+
+__device__ __forceinline__ void recv(intptr_t outIx, int eltN, bool postOp = false) {
+  genericOp<0, 0, 1, 0, -1, Output>(-1, outIx, eltN, postOp);
+}
+__device__ __forceinline__ void directRecv(intptr_t outIx, int eltN, bool postOp = false) {
+  genericOp<1, 0, 1, 0, -1, Output>(outIx, outIx, eltN, postOp);
+}
+__device__ __forceinline__ void directRecvCopy(intptr_t inpIx, intptr_t outIx, int eltN) {
+  genericOp<1, 0, 1, 0, -1, Output>(inpIx, outIx, eltN, /*postOp=*/false);
+}
+
+__device__ __forceinline__ void copySend(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp = false) {
+  genericOp<0, 0, 0, 1, Input, Output>(inpIx, outIx, eltN, postOp);
+}
+__device__ __forceinline__ void directCopySend(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp = false) {
+  genericOp<0, 1, 0, 1, Input, Output>(inpIx, outIx, eltN, postOp);
+}
+
+__device__ __forceinline__ void recvSend(int eltN, bool postOp = false) {
+  genericOp<0, 0, 1, 1, -1, -1>(-1, -1, eltN, postOp);
+}
+__device__ __forceinline__ void recvCopySend(intptr_t outIx, int eltN, bool postOp = false) {
+  genericOp<0, 0, 1, 1, -1, Output>(-1, outIx, eltN, postOp);
+}
+__device__ __forceinline__ void directRecvCopyDirectSend(intptr_t inpIx, intptr_t outIx, int eltN,
+                                                         bool postOp = false) {
+  genericOp<1, 1, 1, 1, -1, Output>(inpIx, outIx, eltN, postOp);
+}
+__device__ __forceinline__ void directRecvDirectSend(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp = false) {
+  genericOp<1, 1, 1, 1, -1, -1>(inpIx, outIx, eltN, postOp);
+}
+__device__ __forceinline__ void recvDirectSend(intptr_t outIx, int eltN, bool postOp = false) {
+  genericOp<0, 1, 1, 1, -1, -1>(-1, outIx, eltN, postOp);
+}
+__device__ __forceinline__ void directRecvSend(intptr_t outIx, int eltN, bool postOp = false) {
+  genericOp<1, 0, 1, 1, -1, -1>(outIx, outIx, eltN, postOp);
+}
+__device__ __forceinline__ void recvCopyDirectSend(intptr_t outIx, int eltN, bool postOp = false) {
+  genericOp<0, 1, 1, 1, -1, Output>(-1, outIx, eltN, postOp);
+}
+
+__device__ __forceinline__ void recvReduceCopy(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp = false) {
+  genericOp<0, 0, 1, 0, Input, Output>(inpIx, outIx, eltN, postOp);
+}
+__device__ __forceinline__ void directRecvReduceCopy(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp = false) {
+  genericOp<1, 0, 1, 0, Input, Output>(inpIx, outIx, eltN, postOp);
+}
+
+__device__ __forceinline__ void recvReduceSend(intptr_t inpIx, int eltN, bool postOp = false) {
+  genericOp<0, 0, 1, 1, Input, -1>(inpIx, -1, eltN, postOp);
+}
+__device__ __forceinline__ void directRecvReduceSend(intptr_t inpIx, int eltN, bool postOp = false) {
+  genericOp<1, 0, 1, 1, Input, -1>(inpIx, -1, eltN, postOp);
+}
+__device__ __forceinline__ void recvReduceDirectSend(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp = false) {
+  genericOp<0, 1, 1, 1, Input, -1>(inpIx, outIx, eltN, postOp);
+}
+__device__ __forceinline__ void directRecvReduceDirectSend(intptr_t inpIx, intptr_t outIx, ssize_t eltN,
+                                                           bool postOp = false) {
+  genericOp<1, 1, 1, 1, Input, -1>(inpIx, outIx, eltN, postOp);
+}
+
+__device__ __forceinline__ void recvReduceCopySend(intptr_t inpIx, intptr_t outIx, int eltN, bool postOp = false) {
+  genericOp<0, 0, 1, 1, Input, Output>(inpIx, outIx, eltN, postOp);
+}
+__device__ __forceinline__ void recvReduceCopyDirectSend(intptr_t inpIx, intptr_t outIx, int eltN,
+                                                         bool postOp = false) {
+  // Direct is only for the send part
+  genericOp<0, 1, 1, 1, Input, Output>(inpIx, outIx, eltN, postOp);
+}
+__device__ __forceinline__ void directRecvReduceCopyDirectSend(intptr_t inpIx, intptr_t outIx, ssize_t eltN,
+                                                               bool postOp = false) {
+  genericOp<1, 1, 1, 1, Input, Output>(inpIx, outIx, eltN, postOp);
+}
+
+__device__ __forceinline__ void scatter(intptr_t inpIx, ssize_t totalElem, int peerElem, ssize_t peerOffset, int skip,
+                                        int shift) {
+  ScatterGatherOp<0, 0, 0, 1>(inpIx, -1, totalElem, peerElem, peerOffset, skip, shift, /*postOp=*/false);
+}
+__device__ __forceinline__ void directScatter(intptr_t inpIx, ssize_t totalElem, int peerElem, ssize_t peerOffset,
+                                              int skip, int shift) {
+  ScatterGatherOp<0, 1, 0, 1>(inpIx, -1, totalElem, peerElem, peerOffset, skip, shift, /*postOp=*/false);
+}
+
+__device__ __forceinline__ void gather(intptr_t outIx, ssize_t totalElem, int peerElem, ssize_t peerOffset, int skip,
+                                       int shift, bool postOp = false) {
+  ScatterGatherOp<0, 0, 1, 0>(-1, outIx, totalElem, peerElem, peerOffset, skip, shift, postOp);
+}
+__device__ __forceinline__ void directGather(intptr_t outIx, ssize_t totalElem, int peerElem, ssize_t peerOffset,
+                                             int skip, int shift) {
+  ScatterGatherOp<1, 0, 1, 0>(-1, outIx, totalElem, peerElem, peerOffset, skip, shift, /*postOp=*/false);
+}
+
+__device__ __forceinline__ void patReduce(struct ncclPatStep* ps, struct ncclPatShmem* shmem) {
+  if (ps->flags & PatSkipped) {
     patBarrier();
-    int nDsts = 2;
-    void** dsts = ncclShmem.groups[group].dsts;
-    if (ps->sendDim < 0) { dsts++; nDsts--; } // No peer to send to, remove one dest
-    if (ncclShmem.groups[group].srcs[0] == ncclShmem.groups[group].dsts[1]) nDsts--; // In-place or already done.
-
-    int workSize = ncclShmem.aborted ? 0 : nelem;
-
-    reduceCopy<Unroll, useAcc, RedOp, T, 0, 1, 1, 0, 1, 2, /*PreOpSrcs*/0>
-      (tid, nthreads, ncclShmem.groups[group].redOpArgs, /*postOp=*/false,
-      1, ncclShmem.groups[group].srcs, nDsts, dsts, workSize);
-
-    // Store conn step here inside the two barriers to make sure next reload will see the update.
-    if (postSend && (flags & RolePostSend)) {
-      if (peer->connFifo) {
-        peer->connFifo[step%NCCL_STEPS].size = (ps->sendOffset + nelem)*sizeof(T);
-      }
-      peer->step = step += StepPerSlice;
-      st_relaxed_sys_global(&peer->conn->step, step);
-    }
-    if (postRecv && (flags & RolePostRecv)) {
-      peer->step = step += StepPerSlice;
-      st_relaxed_sys_global(&peer->conn->step, step); // Also save in global mem for next op
-    }
-
-    // Update accSize
-    if (ps->recvDim < 0 && (flags & RoleInput)) atomicMax(&shmem->localAccSize, localAccSize);
-    if (ps->recvDim >= 0 && (flags & RoleWaitRecv)) atomicMax(&peer->accSize, ps->recvOffset + nelem + (step+ps->stepOffset)*peer->connStepSize);
-
     patBarrier();
+    return;
+  } // Skipped
+  int nelem = ps->nelem < 0 ? 0 : ps->nelem;
+  T* userInput = (T*)ncclShmem.groups[group].userInput;
+  T* userOutput = (T*)ncclShmem.groups[group].userOutput;
 
-    if (postSend && (flags & RolePostSend)) {
-      if (nelem > 0 || peer->connFifo) fence_acq_rel_sys();
-      st_relaxed_sys_global(peer->tailPtr, step);
-    }
-    if (postRecv && (flags & RolePostRecv)) {
-      st_relaxed_sys_global(peer->headPtr, step);
-    }
+  bool recv = ps->recvDim >= 0 && (flags & (RolePostRecv | RoleWaitRecv));
+  bool send = ps->sendDim >= 0 && (flags & (RolePostSend | RoleWaitSend));
+  bool postRecv = ps->postRecv && recv;
+  bool postSend = ps->postSend && send;
+  struct ncclPatPeer* peer = NULL;
+  if (recv) {
+    peer = shmem->recvDims + ps->recvDim;
+    step = peer->step;
+  }
+  if (send) {
+    peer = shmem->sendDims + ps->sendDim;
+    step = peer->step;
   }
 
-};
+  if (recv && (flags & RoleWaitRecv)) {
+    ncclShmem.groups[group].srcs[0] = ((T*)peer->buff) + (step % NCCL_STEPS) * peer->connStepSize + ps->recvOffset;
+    int spins = 0;
+    while (peer->stepCache < step + StepPerSlice) {
+      peer->stepCache = loadStepValue(peer->tailPtr);
+      if (checkAbort(flags, Aborted, spins)) break;
+    }
+  }
+  if (send && (flags & RoleWaitSend)) {
+    int spins = 0;
+    while (peer->stepCache + NCCL_STEPS < step + ps->stepOffset + StepPerSlice) {
+      peer->stepCache = loadStepValue(peer->headPtr);
+      if (checkAbort(flags, Aborted, spins)) break;
+    }
+    ncclShmem.groups[group].dsts[0] =
+      ((T*)peer->buff) + ((step + ps->stepOffset) % NCCL_STEPS) * peer->connStepSize + ps->sendOffset;
+    if (peer->accSize < ps->sendOffset + nelem + (step + ps->stepOffset) * peer->connStepSize) {
+      // New data, add our own data to it.
+      ncclShmem.groups[group].srcs[1] = userInput + ps->inpIx;
+    } else {
+      // There is already data in there, accumulate instead of writing to it.
+      ncclShmem.groups[group].srcs[1] = ncclShmem.groups[group].dsts[0];
+    }
+  }
+  long long int localAccSize = shmem->localAccSize;
+  if (ps->sendDim < 0 && (flags & RoleOutput)) { // Destination is our own local buffer
+    ncclShmem.groups[group].dsts[0] = userOutput + ps->outIx;
+    if (localAccSize < ps->outIx + nelem) {
+      // New data, add our own data to it.
+      ncclShmem.groups[group].srcs[1] = userInput + ps->inpIx;
+      localAccSize = ps->outIx + nelem;
+    } else {
+      // There is already data in there, accumulate instead of writing to it.
+      ncclShmem.groups[group].srcs[1] = ncclShmem.groups[group].dsts[0];
+    }
+  }
+  patBarrier();
+  int nSrcs = 2;
+  void** srcs = ncclShmem.groups[group].srcs;
+  if (ps->recvDim < 0) {
+    srcs++;
+    nSrcs--;
+  } // No peer to receive from, remove one source
+
+  int workSize = ncclShmem.aborted ? 0 : nelem;
+
+  reduceCopy<Unroll, useAcc, RedOp, T, 0, 1, 2, 0, 1, 1, /*PreOpSrcs*/ 0>(tid, nthreads,
+                                                                          ncclShmem.groups[group].redOpArgs,
+                                                                          /*postOp=*/false, nSrcs, srcs, 1,
+                                                                          ncclShmem.groups[group].dsts, workSize);
+
+  // Store conn step here inside the two barriers to make sure next reload will see the update.
+  if (postSend && (flags & RolePostSend)) {
+    if (peer->connFifo) {
+      peer->connFifo[step % NCCL_STEPS].size = (ps->sendOffset + nelem) * sizeof(T);
+    }
+    peer->step = step += StepPerSlice;
+    st_relaxed_sys_global(&peer->conn->step, step);
+  }
+  if (postRecv && (flags & RolePostRecv)) {
+    peer->step = step += StepPerSlice;
+    st_relaxed_sys_global(&peer->conn->step, step); // Also save in global mem for next op
+  }
+
+  // Update accSize
+  if (ps->sendDim < 0 && (flags & RoleOutput)) atomicMax(&shmem->localAccSize, localAccSize);
+  if (ps->sendDim >= 0 && (flags & RoleWaitSend))
+    atomicMax(&peer->accSize, ps->sendOffset + nelem + (step + ps->stepOffset) * peer->connStepSize);
+
+  patBarrier();
+
+  if (postSend && (flags & RolePostSend)) {
+    if (nelem > 0 || peer->connFifo) fence_acq_rel_sys();
+    st_relaxed_sys_global(peer->tailPtr, step);
+  }
+  if (postRecv && (flags & RolePostRecv)) {
+    st_relaxed_sys_global(peer->headPtr, step);
+  }
+}
+
+__device__ __forceinline__ void patCopy(struct ncclPatStep* ps, struct ncclPatShmem* shmem) {
+  if (ps->flags & PatSkipped) {
+    patBarrier();
+    patBarrier();
+    return;
+  } // Skipped
+  int nelem = ps->nelem < 0 ? 0 : ps->nelem;
+  T* userInput = (T*)ncclShmem.groups[group].userInput;
+  T* userOutput = (T*)ncclShmem.groups[group].userOutput;
+
+  bool recv = ps->recvDim >= 0 && (flags & (RolePostRecv | RoleWaitRecv));
+  bool send = ps->sendDim >= 0 && (flags & (RolePostSend | RoleWaitSend));
+  bool postRecv = ps->postRecv && recv;
+  bool postSend = ps->postSend && send;
+  struct ncclPatPeer* peer = NULL;
+  if (recv) {
+    peer = shmem->recvDims + ps->recvDim;
+    step = peer->step;
+  }
+  if (send) {
+    peer = shmem->sendDims + ps->sendDim;
+    step = peer->step;
+  }
+
+  if (recv && (flags & RoleWaitRecv)) {
+    ncclShmem.groups[group].srcs[0] =
+      ((T*)peer->buff) + ((step + ps->stepOffset) % NCCL_STEPS) * peer->connStepSize + ps->recvOffset;
+    int spins = 0;
+    while (peer->stepCache < step + ps->stepOffset + StepPerSlice) {
+      peer->stepCache = loadStepValue(peer->tailPtr);
+      if (checkAbort(flags, Aborted, spins)) break;
+    }
+    if (peer->accSize < ps->recvOffset + nelem + (step + ps->stepOffset) * peer->connStepSize) {
+      // New data, copy to our output buffer.
+      ncclShmem.groups[group].dsts[1] = userOutput + ps->outIx;
+    } else {
+      ncclShmem.groups[group].dsts[1] = ncclShmem.groups[group].srcs[0]; // Already done
+    }
+  }
+  if (send && (flags & RoleWaitSend)) {
+    int spins = 0;
+    while (peer->stepCache + NCCL_STEPS < step + StepPerSlice) {
+      peer->stepCache = loadStepValue(peer->headPtr);
+      if (checkAbort(flags, Aborted, spins)) break;
+    }
+    ncclShmem.groups[group].dsts[0] = ((T*)peer->buff) + (step % NCCL_STEPS) * peer->connStepSize + ps->sendOffset;
+  }
+  long long int localAccSize = shmem->localAccSize;
+  if (ps->recvDim < 0 && (flags & RoleInput)) { // Source is our own local buffer
+    ncclShmem.groups[group].srcs[0] = userInput + ps->inpIx;
+    if (localAccSize < ps->inpIx + nelem) {
+      // New data, copy to our output buffer.
+      ncclShmem.groups[group].dsts[1] = userOutput + ps->outIx;
+      localAccSize = ps->inpIx + nelem;
+    } else {
+      // Already done
+      ncclShmem.groups[group].dsts[1] = ncclShmem.groups[group].srcs[0];
+    }
+  }
+  patBarrier();
+  int nDsts = 2;
+  void** dsts = ncclShmem.groups[group].dsts;
+  if (ps->sendDim < 0) {
+    dsts++;
+    nDsts--;
+  } // No peer to send to, remove one dest
+  if (ncclShmem.groups[group].srcs[0] == ncclShmem.groups[group].dsts[1]) nDsts--; // In-place or already done.
+
+  int workSize = ncclShmem.aborted ? 0 : nelem;
+
+  reduceCopy<Unroll, useAcc, RedOp, T, 0, 1, 1, 0, 1, 2, /*PreOpSrcs*/ 0>(
+    tid, nthreads, ncclShmem.groups[group].redOpArgs, /*postOp=*/false, 1, ncclShmem.groups[group].srcs, nDsts, dsts,
+    workSize);
+
+  // Store conn step here inside the two barriers to make sure next reload will see the update.
+  if (postSend && (flags & RolePostSend)) {
+    if (peer->connFifo) {
+      peer->connFifo[step % NCCL_STEPS].size = (ps->sendOffset + nelem) * sizeof(T);
+    }
+    peer->step = step += StepPerSlice;
+    st_relaxed_sys_global(&peer->conn->step, step);
+  }
+  if (postRecv && (flags & RolePostRecv)) {
+    peer->step = step += StepPerSlice;
+    st_relaxed_sys_global(&peer->conn->step, step); // Also save in global mem for next op
+  }
+
+  // Update accSize
+  if (ps->recvDim < 0 && (flags & RoleInput)) atomicMax(&shmem->localAccSize, localAccSize);
+  if (ps->recvDim >= 0 && (flags & RoleWaitRecv))
+    atomicMax(&peer->accSize, ps->recvOffset + nelem + (step + ps->stepOffset) * peer->connStepSize);
+
+  patBarrier();
+
+  if (postSend && (flags & RolePostSend)) {
+    if (nelem > 0 || peer->connFifo) fence_acq_rel_sys();
+    st_relaxed_sys_global(peer->tailPtr, step);
+  }
+  if (postRecv && (flags & RolePostRecv)) {
+    st_relaxed_sys_global(peer->headPtr, step);
+  }
+}
+}
+;

--- a/projects/rccl/src/device/reduce.h
+++ b/projects/rccl/src/device/reduce.h
@@ -10,81 +10,81 @@
 #include "primitives.h"
 
 namespace {
-  template<typename T, typename RedOp, typename Proto>
+template <typename T, typename RedOp, typename Proto>
 #if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
-  __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
+__device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
 #else
-  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
+__device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
 #endif
 #ifdef ENABLE_WARP_SPEED
-    int warp = threadIdx.x / WARP_SIZE;
-    ncclRing *ring = ncclShmem.warpComm
-        ? &ncclShmem.warpChannel[warp].ring
-        : &ncclShmem.channel.ring;
+  int warp = threadIdx.x / WARP_SIZE;
+  ncclRing* ring = ncclShmem.warpComm ? &ncclShmem.warpChannel[warp].ring : &ncclShmem.channel.ring;
 #else
-    ncclRing *ring = &ncclShmem.channel.ring;
+  ncclRing* ring = &ncclShmem.channel.ring;
 #endif
-    const int nranks = ncclShmem.comm.nRanks;
-    const int rank = ncclShmem.comm.rank;
-    const int prevRank = ring->userRanks[nranks-1];
-    const int root = work->root;
-    size_t chunkCount;
-    size_t channelCount;
-    size_t gridOffset;
+  const int nranks = ncclShmem.comm.nRanks;
+  const int rank = ncclShmem.comm.rank;
+  const int prevRank = ring->userRanks[nranks - 1];
+  const int root = work->root;
+  size_t chunkCount;
+  size_t channelCount;
+  size_t gridOffset;
 #ifdef ENABLE_WARP_SPEED
-    ncclCollCbdPart(work, ncclShmem.warpChannelId[warp], Proto::Id, sizeof(T), (size_t*)nullptr, &gridOffset, &channelCount, &chunkCount);
+  ncclCollCbdPart(work, ncclShmem.warpChannelId[warp], Proto::Id, sizeof(T), (size_t*)nullptr, &gridOffset,
+                  &channelCount, &chunkCount);
 #else
-    ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), (size_t*)nullptr, &gridOffset, &channelCount, &chunkCount);
+  ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), (size_t*)nullptr, &gridOffset, &channelCount,
+                  &chunkCount);
 #endif
-    size_t offset;
-    int nelem;
+  size_t offset;
+  int nelem;
 
     // Coverity reports that the callee treats &ring->next as an array.  However, due to the use of
     // FanSymmetric<1>, only the first element is ever accessed, so it's fine.
     // coverity[callee_ptr_arith:FALSE]
-    Primitives<T, RedOp, FanSymmetric<1>, 0, Proto, 0, false, 0, Pipeline>
-      prims(tid, nthreads, &ring->prev, &ring->next, work->sendbuff, work->recvbuff, work->redOpArg, 0, work->connIndex, work->connIndex);
+  Primitives<T, RedOp, FanSymmetric<1>, 0, Proto, 0, false, 0, Pipeline> prims(tid, nthreads, &ring->prev, &ring->next,
+                                                                               work->sendbuff, work->recvbuff,
+                                                                               work->redOpArg, 0, work->connIndex,
+                                                                               work->connIndex);
 
-    if (prevRank == root) {
-      for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
-        offset = gridOffset + elemOffset;
-        nelem = min(chunkCount, channelCount - elemOffset);
-        prims.send(offset, nelem);
-      }
+  if (prevRank == root) {
+    for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
+      offset = gridOffset + elemOffset;
+      nelem = min(chunkCount, channelCount - elemOffset);
+      prims.send(offset, nelem);
     }
-    else if (rank == root) {
-      for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
-        offset = gridOffset + elemOffset;
-        nelem = min(chunkCount, channelCount - elemOffset);
-        prims.recvReduceCopy(offset, offset, nelem, /*postOp=*/true);
-      }
+  } else if (rank == root) {
+    for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
+      offset = gridOffset + elemOffset;
+      nelem = min(chunkCount, channelCount - elemOffset);
+      prims.recvReduceCopy(offset, offset, nelem, /*postOp=*/true);
     }
-    else {
-      for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
-        offset = gridOffset + elemOffset;
-        nelem = min(chunkCount, channelCount - elemOffset);
-        prims.recvReduceSend(offset, nelem);
-      }
+  } else {
+    for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
+      offset = gridOffset + elemOffset;
+      nelem = min(chunkCount, channelCount - elemOffset);
+      prims.recvReduceSend(offset, nelem);
     }
   }
 }
+} // namespace
 
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkColl<ncclFuncReduce, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPLE> {
   __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
-    using Proto = ProtoSimple<REDUCE_CHUNKSTEPS/REDUCE_SLICESTEPS, REDUCE_SLICESTEPS>;
+    using Proto = ProtoSimple<REDUCE_CHUNKSTEPS / REDUCE_SLICESTEPS, REDUCE_SLICESTEPS>;
     runRing<T, RedOp, Proto>(tid, nthreads, work);
   }
 };
 
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkColl<ncclFuncReduce, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL> {
   __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
     runRing<T, RedOp, ProtoLL>(tid, nthreads, work);
   }
 };
 
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkColl<ncclFuncReduce, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL128> {
   __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
     runRing<T, RedOp, ProtoLL128>(tid, nthreads, work);

--- a/projects/rccl/src/device/reduce_kernel.h
+++ b/projects/rccl/src/device/reduce_kernel.h
@@ -106,8 +106,8 @@ struct RedOpArg<FuncMinMax<T>> {
 
 template <typename A, typename B, int EltPerPackA>
 struct Apply_Cast/*{
-      static BytePack<EltPerPackA*sizeof(B)/sizeof(A)> cast(BytePack<EltPerPackA*sizeof(A)> a);
-    }*/
+       static BytePack<EltPerPackA*sizeof(B)/sizeof(A)> cast(BytePack<EltPerPackA*sizeof(A)> a);
+     }*/
   ;
 
 template <typename Fn, int EltPerPack>
@@ -119,27 +119,27 @@ struct Apply_Reduce /*{
   ;
 template <typename Fn, int EltPerPack>
 struct Apply_PreOp/*{
-      static constexpr bool IsIdentity;
-      static BytePack<EltPerPack*sizeof(T)> preOp(Fn fn, BytePack<EltPerPack*sizeof(T)> a);
-    }*/
+       static constexpr bool IsIdentity;
+       static BytePack<EltPerPack*sizeof(T)> preOp(Fn fn, BytePack<EltPerPack*sizeof(T)> a);
+     }*/
   ;
 template <typename Fn, int EltPerPack>
 struct Apply_PostOp/*{
-      static constexpr bool IsIdentity;
-      static BytePack<EltPerPack*sizeof(T)> postOp(Fn fn, BytePack<EltPerPack*sizeof(T)> a);
-    }*/
+       static constexpr bool IsIdentity;
+       static BytePack<EltPerPack*sizeof(T)> postOp(Fn fn, BytePack<EltPerPack*sizeof(T)> a);
+     }*/
   ;
 template <typename Fn>
 struct LoadMultimem_BigPackSize/*{
-      // If non-zero, then this and sizeof(T) are valid pack sizes for LoadMultimem,
-      // otherwise there are no valid pack sizes for LoadMultimem.
-      static constexpr int BigPackSize = 0;
-    }*/
+       // If non-zero, then this and sizeof(T) are valid pack sizes for LoadMultimem,
+       // otherwise there are no valid pack sizes for LoadMultimem.
+       static constexpr int BigPackSize = 0;
+     }*/
   ;
 template <typename Fn, int BytePerPack>
 struct Apply_LoadMultimem/*{
-      static BytePack<BytePerPack> load(Fn fn, uintptr_t addr);
-    }*/
+       static BytePack<BytePerPack> load(Fn fn, uintptr_t addr);
+     }*/
   ;
 
 // Helpers for dealing with BytePack<0>'s

--- a/projects/rccl/src/device/reduce_kernel.h
+++ b/projects/rccl/src/device/reduce_kernel.h
@@ -6,7 +6,6 @@
  * See LICENSE.txt for license information
  ************************************************************************/
 
-
 #ifndef NCCL_REDUCE_KERNEL_H_
 #define NCCL_REDUCE_KERNEL_H_
 
@@ -17,24 +16,24 @@
 
 #include "rccl_float8.h"
 
-template<typename T>
-struct IsFloatingPoint: std::false_type {};
-template<>
-struct IsFloatingPoint<half>: std::true_type {};
+template <typename T>
+struct IsFloatingPoint : std::false_type {};
+template <>
+struct IsFloatingPoint<half> : std::true_type {};
 #if defined(RCCL_BFLOAT16)
-template<>
-struct IsFloatingPoint<hip_bfloat16>: std::true_type {};
+template <>
+struct IsFloatingPoint<hip_bfloat16> : std::true_type {};
 #endif
 #if defined(RCCL_FLOAT8)
-template<>
-struct IsFloatingPoint<rccl_float8>: std::true_type {};
-template<>
-struct IsFloatingPoint<rccl_bfloat8>: std::true_type {};
+template <>
+struct IsFloatingPoint<rccl_float8> : std::true_type {};
+template <>
+struct IsFloatingPoint<rccl_bfloat8> : std::true_type {};
 #endif
-template<>
-struct IsFloatingPoint<float>: std::true_type {};
-template<>
-struct IsFloatingPoint<double>: std::true_type {};
+template <>
+struct IsFloatingPoint<float> : std::true_type {};
+template <>
+struct IsFloatingPoint<double> : std::true_type {};
 
 ////////////////////////////////////////////////////////////////////////////////
 // The reduction function classes. All classes must:
@@ -42,41 +41,57 @@ struct IsFloatingPoint<double>: std::true_type {};
 //  2. Have constructor taking no arguments (default constructible).
 //  3. Have constructor taking `uint64_t opArg`.
 
-template<typename T>
-struct FuncCopy { using EltType = T; __device__ __forceinline__ FuncCopy(uint64_t opArg=0) {}; };
-template<typename T>
-struct FuncSum  { using EltType = T; __device__ __forceinline__ FuncSum(uint64_t opArg=0) {}; };
-template<typename T>
-struct FuncProd { using EltType = T; __device__ __forceinline__ FuncProd(uint64_t opArg=0) {}; };
+template <typename T>
+struct FuncCopy {
+  using EltType = T;
+  __device__ __forceinline__ FuncCopy(uint64_t opArg = 0) {};
+};
+template <typename T>
+struct FuncSum {
+  using EltType = T;
+  __device__ __forceinline__ FuncSum(uint64_t opArg = 0) {};
+};
+template <typename T>
+struct FuncProd {
+  using EltType = T;
+  __device__ __forceinline__ FuncProd(uint64_t opArg = 0) {};
+};
 
-template<typename T>
+template <typename T>
 struct FuncMinMax {
   using EltType = T;
   BytePack<sizeof(T)> xormask; // only used by integers
   bool isMinNotMax; // only used by floats
-  __device__ __forceinline__ FuncMinMax(uint64_t opArg=0) {
+  __device__ __forceinline__ FuncMinMax(uint64_t opArg = 0) {
     xormask.native = opArg;
-    isMinNotMax = (opArg&1)==0;
+    isMinNotMax = (opArg & 1) == 0;
   }
 };
 
-template<typename T> struct FuncPreMulSum;
-template<typename T> struct FuncSumPostDiv;
+template <typename T>
+struct FuncPreMulSum;
+template <typename T>
+struct FuncSumPostDiv;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Trait class for handling the reduction argument.
 
-template<typename Fn>
+template <typename Fn>
 struct RedOpArg { // default case: no argument
   static constexpr bool ArgUsed = false;
-  __device__ __forceinline__ static uint64_t loadArg(void *ptr) { return 0; }
+  __device__ __forceinline__ static uint64_t loadArg(void* ptr) {
+    return 0;
+  }
 };
 
-template<typename T>
+template <typename T>
 struct RedOpArg<FuncMinMax<T>> {
   static constexpr bool ArgUsed = true;
-  __device__ __forceinline__ static uint64_t loadArg(void *ptr) {
-    union { uint64_t u64; T val; };
+  __device__ __forceinline__ static uint64_t loadArg(void* ptr) {
+    union {
+      uint64_t u64;
+      T val;
+    };
     u64 = 0;
     val = *(T*)ptr;
     return u64;
@@ -89,75 +104,90 @@ struct RedOpArg<FuncMinMax<T>> {
 // of elements. These classes are intended to be specialized for specific
 // combinations of reduction function and pack size.
 
-template<typename A, typename B, int EltPerPackA>
+template <typename A, typename B, int EltPerPackA>
 struct Apply_Cast/*{
-  static BytePack<EltPerPackA*sizeof(B)/sizeof(A)> cast(BytePack<EltPerPackA*sizeof(A)> a);
-}*/;
+      static BytePack<EltPerPackA*sizeof(B)/sizeof(A)> cast(BytePack<EltPerPackA*sizeof(A)> a);
+    }*/
+  ;
 
-template<typename Fn, int EltPerPack>
+template <typename Fn, int EltPerPack>
 struct Apply_Reduce /*{
   static BytePack<EltPerPack*sizeof(T)> reduce(
     Fn fn, BytePack<EltPerPack*sizeof(T)> a, BytePack<EltPerPack*sizeof(T)> b
   );
-}*/;
-template<typename Fn, int EltPerPack>
+}*/
+  ;
+template <typename Fn, int EltPerPack>
 struct Apply_PreOp/*{
-  static constexpr bool IsIdentity;
-  static BytePack<EltPerPack*sizeof(T)> preOp(Fn fn, BytePack<EltPerPack*sizeof(T)> a);
-}*/;
-template<typename Fn, int EltPerPack>
+      static constexpr bool IsIdentity;
+      static BytePack<EltPerPack*sizeof(T)> preOp(Fn fn, BytePack<EltPerPack*sizeof(T)> a);
+    }*/
+  ;
+template <typename Fn, int EltPerPack>
 struct Apply_PostOp/*{
-  static constexpr bool IsIdentity;
-  static BytePack<EltPerPack*sizeof(T)> postOp(Fn fn, BytePack<EltPerPack*sizeof(T)> a);
-}*/;
-template<typename Fn>
+      static constexpr bool IsIdentity;
+      static BytePack<EltPerPack*sizeof(T)> postOp(Fn fn, BytePack<EltPerPack*sizeof(T)> a);
+    }*/
+  ;
+template <typename Fn>
 struct LoadMultimem_BigPackSize/*{
-  // If non-zero, then this and sizeof(T) are valid pack sizes for LoadMultimem,
-  // otherwise there are no valid pack sizes for LoadMultimem.
-  static constexpr int BigPackSize = 0;
-}*/;
-template<typename Fn, int BytePerPack>
+      // If non-zero, then this and sizeof(T) are valid pack sizes for LoadMultimem,
+      // otherwise there are no valid pack sizes for LoadMultimem.
+      static constexpr int BigPackSize = 0;
+    }*/
+  ;
+template <typename Fn, int BytePerPack>
 struct Apply_LoadMultimem/*{
-  static BytePack<BytePerPack> load(Fn fn, uintptr_t addr);
-}*/;
-
+      static BytePack<BytePerPack> load(Fn fn, uintptr_t addr);
+    }*/
+  ;
 
 // Helpers for dealing with BytePack<0>'s
-template<typename A, typename B, int EltPerPack>
-struct Apply_Cast_MaybeEmpty: Apply_Cast<A, B, EltPerPack> {};
-template<typename A, typename B>
+template <typename A, typename B, int EltPerPack>
+struct Apply_Cast_MaybeEmpty : Apply_Cast<A, B, EltPerPack> {};
+template <typename A, typename B>
 struct Apply_Cast_MaybeEmpty<A, B, /*EltPerPack=*/0> {
-  __device__ constexpr static BytePack<0> cast(BytePack<0> a) { return {}; }
+  __device__ constexpr static BytePack<0> cast(BytePack<0> a) {
+    return {};
+  }
 };
 
-template<typename Fn, int EltPerPack>
-struct Apply_Reduce_MaybeEmpty: Apply_Reduce<Fn, EltPerPack> {};
-template<typename Fn>
+template <typename Fn, int EltPerPack>
+struct Apply_Reduce_MaybeEmpty : Apply_Reduce<Fn, EltPerPack> {};
+template <typename Fn>
 struct Apply_Reduce_MaybeEmpty<Fn, 0> {
-  __device__ constexpr static BytePack<0> reduce(Fn fn, BytePack<0> a, BytePack<0> b) { return {}; }
+  __device__ constexpr static BytePack<0> reduce(Fn fn, BytePack<0> a, BytePack<0> b) {
+    return {};
+  }
 };
 
-template<typename Fn, int EltPerPack>
-struct Apply_PreOp_MaybeEmpty: Apply_PreOp<Fn, EltPerPack> {};
-template<typename Fn>
+template <typename Fn, int EltPerPack>
+struct Apply_PreOp_MaybeEmpty : Apply_PreOp<Fn, EltPerPack> {};
+template <typename Fn>
 struct Apply_PreOp_MaybeEmpty<Fn, 0> {
   static constexpr bool IsIdentity = true;
-  __device__ constexpr static BytePack<0> preOp(Fn fn, BytePack<0> a) { return {}; }
+  __device__ constexpr static BytePack<0> preOp(Fn fn, BytePack<0> a) {
+    return {};
+  }
 };
 
-template<typename Fn, int EltPerPack>
-struct Apply_PostOp_MaybeEmpty: Apply_PostOp<Fn, EltPerPack> {};
-template<typename Fn>
+template <typename Fn, int EltPerPack>
+struct Apply_PostOp_MaybeEmpty : Apply_PostOp<Fn, EltPerPack> {};
+template <typename Fn>
 struct Apply_PostOp_MaybeEmpty<Fn, 0> {
   static constexpr bool IsIdentity = true;
-  __device__ constexpr static BytePack<0> postOp(Fn fn, BytePack<0> a) { return {}; }
+  __device__ constexpr static BytePack<0> postOp(Fn fn, BytePack<0> a) {
+    return {};
+  }
 };
 
-template<typename Fn, int BytePerPack>
-struct Apply_LoadMultimem_MaybeEmpty: Apply_LoadMultimem<Fn, BytePerPack> {};
-template<typename Fn>
+template <typename Fn, int BytePerPack>
+struct Apply_LoadMultimem_MaybeEmpty : Apply_LoadMultimem<Fn, BytePerPack> {};
+template <typename Fn>
 struct Apply_LoadMultimem_MaybeEmpty<Fn, 0> {
-  __device__ constexpr static BytePack<0> load(Fn fn, uintptr_t addr) { return {}; }
+  __device__ constexpr static BytePack<0> load(Fn fn, uintptr_t addr) {
+    return {};
+  }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -166,36 +196,30 @@ struct Apply_LoadMultimem_MaybeEmpty<Fn, 0> {
 // uint32_t, etc.), and will return a new pack where each element has been
 // transformed appropriately.
 
-template<typename A, typename B, typename PackA>
-__device__ __forceinline__ BytePack<BytePackOf<PackA>::Size*sizeof(B)/sizeof(A)> applyCast(PackA a) {
-  return Apply_Cast_MaybeEmpty<A, B, BytePackOf<PackA>::Size/sizeof(A)>::cast(toPack(a));
+template <typename A, typename B, typename PackA>
+__device__ __forceinline__ BytePack<BytePackOf<PackA>::Size * sizeof(B) / sizeof(A)> applyCast(PackA a) {
+  return Apply_Cast_MaybeEmpty<A, B, BytePackOf<PackA>::Size / sizeof(A)>::cast(toPack(a));
 }
 
-template<typename Fn, typename Pack>
+template <typename Fn, typename Pack>
 __device__ __forceinline__ Pack applyReduce(Fn fn, Pack a, Pack b) {
-  return fromPack<Pack>(
-    Apply_Reduce_MaybeEmpty<Fn, BytePackOf<Pack>::Size/sizeof(typename Fn::EltType)>
-      ::reduce(fn, toPack(a), toPack(b))
-  );
+  return fromPack<Pack>(Apply_Reduce_MaybeEmpty<Fn, BytePackOf<Pack>::Size / sizeof(typename Fn::EltType)>::reduce(
+    fn, toPack(a), toPack(b)));
 }
 
-template<typename Fn, typename Pack>
+template <typename Fn, typename Pack>
 __device__ __forceinline__ Pack applyPreOp(Fn fn, Pack a) {
   return fromPack<Pack>(
-    Apply_PreOp_MaybeEmpty<Fn, BytePackOf<Pack>::Size/sizeof(typename Fn::EltType)>
-      ::preOp(fn, toPack(a))
-  );
+    Apply_PreOp_MaybeEmpty<Fn, BytePackOf<Pack>::Size / sizeof(typename Fn::EltType)>::preOp(fn, toPack(a)));
 }
 
-template<typename Fn, typename Pack>
+template <typename Fn, typename Pack>
 __device__ __forceinline__ Pack applyPostOp(Fn fn, Pack a) {
   return fromPack<Pack>(
-    Apply_PostOp_MaybeEmpty<Fn, BytePackOf<Pack>::Size/sizeof(typename Fn::EltType)>
-      ::postOp(fn, toPack(a))
-  );
+    Apply_PostOp_MaybeEmpty<Fn, BytePackOf<Pack>::Size / sizeof(typename Fn::EltType)>::postOp(fn, toPack(a)));
 }
 
-template<typename Fn, int BytePerPack>
+template <typename Fn, int BytePerPack>
 __device__ __forceinline__ BytePack<BytePerPack> applyLoadMultimem(Fn fn, uintptr_t addr) {
   return Apply_LoadMultimem_MaybeEmpty<Fn, BytePerPack>::load(fn, addr);
 }
@@ -203,74 +227,74 @@ __device__ __forceinline__ BytePack<BytePerPack> applyLoadMultimem(Fn fn, uintpt
 ////////////////////////////////////////////////////////////////////////////////
 // Apply_Cast
 
-template<typename A, typename B, int EltPerPack>
+template <typename A, typename B, int EltPerPack>
 struct Apply_Cast {
-  __device__ __forceinline__ static BytePack<EltPerPack*sizeof(B)> cast(BytePack<EltPerPack*sizeof(A)> a) {
-    BytePack<EltPerPack*sizeof(B)> b;
-    b.half[0] = Apply_Cast<A, B, EltPerPack/2>::cast(a.half[0]);
-    b.half[1] = Apply_Cast<A, B, EltPerPack/2>::cast(a.half[1]);
+  __device__ __forceinline__ static BytePack<EltPerPack * sizeof(B)> cast(BytePack<EltPerPack * sizeof(A)> a) {
+    BytePack<EltPerPack * sizeof(B)> b;
+    b.half[0] = Apply_Cast<A, B, EltPerPack / 2>::cast(a.half[0]);
+    b.half[1] = Apply_Cast<A, B, EltPerPack / 2>::cast(a.half[1]);
     return b;
   }
 };
 
-template<typename A, typename B>
+template <typename A, typename B>
 struct Apply_Cast<A, B, /*EltPerPack=*/1> {
   __device__ __forceinline__ static BytePack<sizeof(B)> cast(BytePack<sizeof(A)> a) {
     return toPack(B(fromPack<A>(a)));
   }
 };
 
-template<>
+template <>
 struct Apply_Cast<__half, float, /*EltPerPack=*/1> {
   __device__ __forceinline__ static BytePack<sizeof(float)> cast(BytePack<sizeof(__half)> a) {
     return toPack(__half2float(fromPack<__half>(a)));
   }
 };
-template<>
+template <>
 struct Apply_Cast<float, __half, /*EltPerPack=*/1> {
   __device__ __forceinline__ static BytePack<sizeof(__half)> cast(BytePack<sizeof(float)> a) {
     return toPack(__float2half_rn(fromPack<float>(a)));
   }
 };
 
-template<>
+template <>
 struct Apply_Cast<__half, float, /*EltPerPack=*/2> {
-  __device__ __forceinline__ static BytePack<4*2> cast(BytePack<2*2> a) {
+  __device__ __forceinline__ static BytePack<4 * 2> cast(BytePack<2 * 2> a) {
     return toPack(__half22float2(fromPack<__half2>(a)));
   }
 };
-template<>
+template <>
 struct Apply_Cast<float, __half, /*EltPerPack=*/2> {
-  __device__ __forceinline__ static BytePack<2*2> cast(BytePack<4*2> a) {
+  __device__ __forceinline__ static BytePack<2 * 2> cast(BytePack<4 * 2> a) {
     return toPack(__float22half2_rn(fromPack<float2>(a)));
   }
 };
 
 #if defined(__CUDA_BF16_TYPES_EXIST__) && (CUDART_RUNTIME >= 12000 || __CUDA_ARCH__ >= 800)
-template<>
+template <>
 struct Apply_Cast<__nv_bfloat16, float, /*EltPerPack=*/2> {
-  __device__ __forceinline__ static BytePack<4*2> cast(BytePack<2*2> a) {
+  __device__ __forceinline__ static BytePack<4 * 2> cast(BytePack<2 * 2> a) {
     return toPack(__bfloat1622float2(fromPack<__nv_bfloat162>(a)));
   }
 };
-template<>
-struct Apply_Cast<float ,__nv_bfloat16, /*EltPerPack=*/2> {
-  __device__ __forceinline__ static BytePack<2*2> cast(BytePack<4*2> a) {
+template <>
+struct Apply_Cast<float, __nv_bfloat16, /*EltPerPack=*/2> {
+  __device__ __forceinline__ static BytePack<2 * 2> cast(BytePack<4 * 2> a) {
     return toPack(__float22bfloat162_rn(fromPack<float2>(a)));
   }
 };
 #endif
 
 #define EASY_CAST(A, B, EltPerPack, VecA, VecB) \
-  template<> \
+  template <> \
   struct Apply_Cast<A, B, EltPerPack> { \
-    __device__ __forceinline__ static BytePack<sizeof(B)*EltPerPack> cast(BytePack<sizeof(A)*EltPerPack> a) { \
+    __device__ __forceinline__ static BytePack<sizeof(B) * EltPerPack> cast(BytePack<sizeof(A) * EltPerPack> a) { \
       return toPack(VecB(fromPack<VecA>(a))); \
     } \
   }; \
-  template<> \
+  template <> \
   struct Apply_Cast<B, A, EltPerPack> { \
-    __device__ __forceinline__ static BytePack<sizeof(A)*EltPerPack> cast(BytePack<sizeof(B)*EltPerPack> b) { \
+    __device__ __forceinline__ static BytePack<sizeof(A) * EltPerPack> cast(BytePack<sizeof(B) * EltPerPack> b) { \
       return toPack(VecA(fromPack<VecB>(b))); \
     } \
   };
@@ -288,10 +312,10 @@ EASY_CAST(__nv_fp8_e4m3, float, 4, __nv_fp8x4_e4m3, float4)
 // Apply_Reduce
 
 // Nonsensical base case
-template<typename Fn>
+template <typename Fn>
 struct Apply_Reduce<Fn, /*EltPerPack=*/0> {
   __device__ __forceinline__ static BytePack<0> reduce(Fn fn, BytePack<0> a, BytePack<0> b) {
-    return  {};
+    return {};
   }
 };
 
@@ -299,56 +323,60 @@ struct Apply_Reduce<Fn, /*EltPerPack=*/0> {
 // all elements in a pack of any size, by breaking it into halves. Eventually
 // we'll hit a base case (a more specific template specialization which takes
 // precedence).
-template<typename Fn, int EltPerPack>
+template <typename Fn, int EltPerPack>
 struct Apply_Reduce {
-  template<int Size>
+  template <int Size>
   __device__ __forceinline__ static BytePack<Size> reduce(Fn fn, BytePack<Size> a, BytePack<Size> b) {
-    a.half[0] = Apply_Reduce<Fn, EltPerPack/2>::reduce(fn, a.half[0], b.half[0]);
-    a.half[1] = Apply_Reduce<Fn, EltPerPack/2>::reduce(fn, a.half[1], b.half[1]);
+    a.half[0] = Apply_Reduce<Fn, EltPerPack / 2>::reduce(fn, a.half[0], b.half[0]);
+    a.half[1] = Apply_Reduce<Fn, EltPerPack / 2>::reduce(fn, a.half[1], b.half[1]);
     return a;
   }
 };
 
 // Base case definitions (EltPerPack == 1)
-template<typename T>
+template <typename T>
 struct Apply_Reduce<FuncCopy<T>, /*EltPerPack=*/1> {
-  __device__ __forceinline__ static BytePack<sizeof(T)> reduce(FuncCopy<T> fn, BytePack<sizeof(T)> a, BytePack<sizeof(T)> b) {
+  __device__ __forceinline__ static BytePack<sizeof(T)> reduce(FuncCopy<T> fn, BytePack<sizeof(T)> a,
+                                                               BytePack<sizeof(T)> b) {
     return a;
   }
 };
-template<typename T>
+template <typename T>
 struct Apply_Reduce<FuncSum<T>, /*EltPerPack=*/1> {
-  __device__ __forceinline__ static BytePack<sizeof(T)> reduce(FuncSum<T> fn, BytePack<sizeof(T)> a, BytePack<sizeof(T)> b) {
+  __device__ __forceinline__ static BytePack<sizeof(T)> reduce(FuncSum<T> fn, BytePack<sizeof(T)> a,
+                                                               BytePack<sizeof(T)> b) {
     return toPack<T>(fromPack<T>(a) + fromPack<T>(b));
   }
 };
-template<typename T>
+template <typename T>
 struct Apply_Reduce<FuncProd<T>, /*EltPerPack=*/1> {
-  __device__ __forceinline__ static BytePack<sizeof(T)> reduce(FuncProd<T> fn, BytePack<sizeof(T)> a, BytePack<sizeof(T)> b) {
+  __device__ __forceinline__ static BytePack<sizeof(T)> reduce(FuncProd<T> fn, BytePack<sizeof(T)> a,
+                                                               BytePack<sizeof(T)> b) {
     return toPack<T>(fromPack<T>(a) * fromPack<T>(b));
   }
 };
-template<typename T>
+template <typename T>
 struct Apply_Reduce<FuncMinMax<T>, /*EltPerPack=*/1> {
-  __device__ __forceinline__ static BytePack<sizeof(T)> reduce(FuncMinMax<T> fn, BytePack<sizeof(T)> a, BytePack<sizeof(T)> b) {
+  __device__ __forceinline__ static BytePack<sizeof(T)> reduce(FuncMinMax<T> fn, BytePack<sizeof(T)> a,
+                                                               BytePack<sizeof(T)> b) {
     return (a.native ^ fn.xormask.native) < (b.native ^ fn.xormask.native) ? a : b;
   }
 };
 
 // Optimizations for specfic types and element count combinations:
-template<>
+template <>
 struct Apply_Reduce<FuncSum<uint8_t>, /*EltPerPack=*/4> {
   __device__ __forceinline__ static BytePack<4> reduce(FuncSum<uint8_t> fn, BytePack<4> a, BytePack<4> b) {
     constexpr uint32_t even = 0x00ff00ffu;
-    uint32_t x = (a.native &  even) + (b.native &  even);
+    uint32_t x = (a.native & even) + (b.native & even);
     uint32_t y = (a.native & ~even) + (b.native & ~even);
-    //a.native = (x & even) | (y & ~even);
+    // a.native = (x & even) | (y & ~even);
     a.native = __byte_perm(x, y, 0x7250);
     return a;
   }
 };
 
-template<>
+template <>
 struct Apply_Reduce<FuncMinMax<uint8_t>, /*EltPerPack=*/4> {
   __device__ static BytePack<4> reduce(FuncMinMax<uint8_t> fn, BytePack<4> a, BytePack<4> b) {
     constexpr uint32_t ones = 0x01010101u;
@@ -359,10 +387,10 @@ struct Apply_Reduce<FuncMinMax<uint8_t>, /*EltPerPack=*/4> {
     uint32_t ax = a.native ^ x;
     uint32_t bx = b.native ^ x;
     // Use 9-bit arithmetic to compute d=a-b
-    uint32_t d0 = (ax    & even) + (~bx      & even) + ones;
-    uint32_t d1 = (ax>>8 & even) + (~(bx>>8) & even) + ones;
+    uint32_t d0 = (ax & even) + (~bx & even) + ones;
+    uint32_t d1 = (ax >> 8 & even) + (~(bx >> 8) & even) + ones;
     // Move sign bit of each 9-bit delta into the least bit of origin byte
-    //uint32_t s = (d0>>8 & ones & even) | (d1 & ones & ~even);
+    // uint32_t s = (d0>>8 & ones & even) | (d1 & ones & ~even);
     uint32_t s = __byte_perm(d0, d1, 0x7351) & ones;
     // Broadcast least bit across whole byte
     s *= 0xffu;
@@ -388,11 +416,10 @@ struct Apply_Reduce<FuncMinMax<uint8_t>, /*EltPerPack=*/4> {
 // };
 
 #define SPECIALIZE_REDUCE(Fn, T, EltPerPack, Vec, expr_of_fn_x_y) \
-  template<> \
+  template <> \
   struct Apply_Reduce<Fn<T>, EltPerPack> { \
-    __device__ __forceinline__ static BytePack<sizeof(Vec)> reduce( \
-        Fn<T> fn, BytePack<sizeof(Vec)> a, BytePack<sizeof(Vec)> b \
-      ) { \
+    __device__ __forceinline__ static BytePack<sizeof(Vec)> reduce(Fn<T> fn, BytePack<sizeof(Vec)> a, \
+                                                                   BytePack<sizeof(Vec)> b) { \
       Vec x = fromPack<Vec>(a); \
       Vec y = fromPack<Vec>(b); \
       return toPack<Vec>(expr_of_fn_x_y); \
@@ -406,47 +433,54 @@ SPECIALIZE_REDUCE(FuncMinMax, half, 1, half, fn.isMinNotMax ? __hmin(x, y) : __h
 
 #if defined(RCCL_BFLOAT16)
 #if __CUDA_ARCH__ >= 800
-  SPECIALIZE_REDUCE(FuncSum, __nv_bfloat16, 1, __nv_bfloat16, __hadd(x, y))
+SPECIALIZE_REDUCE(FuncSum, __nv_bfloat16, 1, __nv_bfloat16, __hadd(x, y))
   // coverity[copy_constructor_call]
-  SPECIALIZE_REDUCE(FuncSum, __nv_bfloat16, 2, __nv_bfloat162, __hadd2(x, y))
-  SPECIALIZE_REDUCE(FuncProd, __nv_bfloat16, 1, __nv_bfloat16, __hmul(x, y))
+SPECIALIZE_REDUCE(FuncSum, __nv_bfloat16, 2, __nv_bfloat162, __hadd2(x, y))
+SPECIALIZE_REDUCE(FuncProd, __nv_bfloat16, 1, __nv_bfloat16, __hmul(x, y))
   // coverity[copy_constructor_call]
-  SPECIALIZE_REDUCE(FuncProd, __nv_bfloat16, 2, __nv_bfloat162, __hmul2(x, y))
-  SPECIALIZE_REDUCE(FuncMinMax, __nv_bfloat16, 1, __nv_bfloat16, fn.isMinNotMax ? __hmin(x, y) : __hmax(x, y))
+SPECIALIZE_REDUCE(FuncProd, __nv_bfloat16, 2, __nv_bfloat162, __hmul2(x, y))
+SPECIALIZE_REDUCE(FuncMinMax, __nv_bfloat16, 1, __nv_bfloat16, fn.isMinNotMax ? __hmin(x, y) : __hmax(x, y))
   // coverity[copy_constructor_call]
-  SPECIALIZE_REDUCE(FuncMinMax, __nv_bfloat16, 2, __nv_bfloat162, fn.isMinNotMax ? __hmin2(x, y) : __hmax2(x, y))
+SPECIALIZE_REDUCE(FuncMinMax, __nv_bfloat16, 2, __nv_bfloat162, fn.isMinNotMax ? __hmin2(x, y) : __hmax2(x, y))
 #else
-  SPECIALIZE_REDUCE(FuncSum, hip_bfloat16, 1, hip_bfloat16, (hip_bfloat16)((float)(x) + (float)(y)))
-  SPECIALIZE_REDUCE(FuncProd, hip_bfloat16, 1, hip_bfloat16, (hip_bfloat16)((float)(x) * (float)(y)))
-  SPECIALIZE_REDUCE(FuncMinMax, hip_bfloat16, 1, hip_bfloat16, (hip_bfloat16)(fn.isMinNotMax ? fminf((float)(x), (float)(y)) : fmaxf((float)(x), (float)(y))))
+SPECIALIZE_REDUCE(FuncSum, hip_bfloat16, 1, hip_bfloat16, (hip_bfloat16)((float)(x) + (float)(y)))
+SPECIALIZE_REDUCE(FuncProd, hip_bfloat16, 1, hip_bfloat16, (hip_bfloat16)((float)(x) * (float)(y)))
+SPECIALIZE_REDUCE(FuncMinMax, hip_bfloat16, 1, hip_bfloat16,
+                  (hip_bfloat16)(fn.isMinNotMax ? fminf((float)(x), (float)(y)) : fmaxf((float)(x), (float)(y))))
 #endif
 #endif
 
 #if defined(RCCL_FLOAT8)
 #if __CUDA_ARCH__ >= 900
-  SPECIALIZE_REDUCE(FuncSum, __nv_fp8_e4m3, 1, __nv_fp8_e4m3, __nv_fp8_e4m3(__hadd(__half(x),__half(y))))
-  SPECIALIZE_REDUCE(FuncSum, __nv_fp8_e4m3, 2, __nv_fp8x2_e4m3, __nv_fp8x2_e4m3(__hadd2(__half2(x),__half2(y))))
-  SPECIALIZE_REDUCE(FuncProd, __nv_fp8_e4m3, 1, __nv_fp8_e4m3, __nv_fp8_e4m3(__hmul(__half(x),__half(y))))
-  SPECIALIZE_REDUCE(FuncProd, __nv_fp8_e4m3, 2, __nv_fp8x2_e4m3, __nv_fp8x2_e4m3(__hmul2(__half2(x),__half2(y))))
-  SPECIALIZE_REDUCE(FuncMinMax, __nv_fp8_e4m3, 1, __nv_fp8_e4m3, __nv_fp8_e4m3(fn.isMinNotMax ? __hmin(__half(x),__half(y)) : __hmax(__half(x),__half(y))))
-  SPECIALIZE_REDUCE(FuncMinMax, __nv_fp8_e4m3, 2, __nv_fp8x2_e4m3, __nv_fp8x2_e4m3(fn.isMinNotMax ? __hmin2(__half2(x),__half2(y)) : __hmax2(__half2(x),__half2(y))))
+SPECIALIZE_REDUCE(FuncSum, __nv_fp8_e4m3, 1, __nv_fp8_e4m3, __nv_fp8_e4m3(__hadd(__half(x), __half(y))))
+SPECIALIZE_REDUCE(FuncSum, __nv_fp8_e4m3, 2, __nv_fp8x2_e4m3, __nv_fp8x2_e4m3(__hadd2(__half2(x), __half2(y))))
+SPECIALIZE_REDUCE(FuncProd, __nv_fp8_e4m3, 1, __nv_fp8_e4m3, __nv_fp8_e4m3(__hmul(__half(x), __half(y))))
+SPECIALIZE_REDUCE(FuncProd, __nv_fp8_e4m3, 2, __nv_fp8x2_e4m3, __nv_fp8x2_e4m3(__hmul2(__half2(x), __half2(y))))
+SPECIALIZE_REDUCE(FuncMinMax, __nv_fp8_e4m3, 1, __nv_fp8_e4m3,
+                  __nv_fp8_e4m3(fn.isMinNotMax ? __hmin(__half(x), __half(y)) : __hmax(__half(x), __half(y))))
+SPECIALIZE_REDUCE(FuncMinMax, __nv_fp8_e4m3, 2, __nv_fp8x2_e4m3,
+                  __nv_fp8x2_e4m3(fn.isMinNotMax ? __hmin2(__half2(x), __half2(y)) : __hmax2(__half2(x), __half2(y))))
 
-  SPECIALIZE_REDUCE(FuncSum, __nv_fp8_e5m2, 1, __nv_fp8_e5m2, __nv_fp8_e5m2(__hadd(__half(x),__half(y))))
-  SPECIALIZE_REDUCE(FuncSum, __nv_fp8_e5m2, 2, __nv_fp8x2_e5m2, __nv_fp8x2_e5m2(__hadd2(__half2(x),__half2(y))))
-  SPECIALIZE_REDUCE(FuncProd, __nv_fp8_e5m2, 1, __nv_fp8_e5m2, __nv_fp8_e5m2(__hmul(__half(x),__half(y))))
-  SPECIALIZE_REDUCE(FuncProd, __nv_fp8_e5m2, 2, __nv_fp8x2_e5m2, __nv_fp8x2_e5m2(__hmul2(__half2(x),__half2(y))))
-  SPECIALIZE_REDUCE(FuncMinMax, __nv_fp8_e5m2, 1, __nv_fp8_e5m2, __nv_fp8_e5m2(fn.isMinNotMax ? __hmin(__half(x), __half(y)) : __hmax(__half(x), __half(y))))
-  SPECIALIZE_REDUCE(FuncMinMax, __nv_fp8_e5m2, 2, __nv_fp8x2_e5m2, __nv_fp8x2_e5m2(fn.isMinNotMax ? __hmin2(__half2(x), __half2(y)) : __hmax2(__half2(x), __half2(y))))
+SPECIALIZE_REDUCE(FuncSum, __nv_fp8_e5m2, 1, __nv_fp8_e5m2, __nv_fp8_e5m2(__hadd(__half(x), __half(y))))
+SPECIALIZE_REDUCE(FuncSum, __nv_fp8_e5m2, 2, __nv_fp8x2_e5m2, __nv_fp8x2_e5m2(__hadd2(__half2(x), __half2(y))))
+SPECIALIZE_REDUCE(FuncProd, __nv_fp8_e5m2, 1, __nv_fp8_e5m2, __nv_fp8_e5m2(__hmul(__half(x), __half(y))))
+SPECIALIZE_REDUCE(FuncProd, __nv_fp8_e5m2, 2, __nv_fp8x2_e5m2, __nv_fp8x2_e5m2(__hmul2(__half2(x), __half2(y))))
+SPECIALIZE_REDUCE(FuncMinMax, __nv_fp8_e5m2, 1, __nv_fp8_e5m2,
+                  __nv_fp8_e5m2(fn.isMinNotMax ? __hmin(__half(x), __half(y)) : __hmax(__half(x), __half(y))))
+SPECIALIZE_REDUCE(FuncMinMax, __nv_fp8_e5m2, 2, __nv_fp8x2_e5m2,
+                  __nv_fp8x2_e5m2(fn.isMinNotMax ? __hmin2(__half2(x), __half2(y)) : __hmax2(__half2(x), __half2(y))))
 #else
-  SPECIALIZE_REDUCE(FuncSum, rccl_float8, 1, rccl_float8, hadd(x,y))
-  SPECIALIZE_REDUCE(FuncSum, rccl_float8, 2, fp8x2_storage_t, hadd2(x,y))
-  SPECIALIZE_REDUCE(FuncProd, rccl_float8, 1, rccl_float8, rccl_float8(float(x) * float(y)))
-  SPECIALIZE_REDUCE(FuncMinMax, rccl_float8, 1, rccl_float8, rccl_float8(fn.isMinNotMax ? fminf(float(x), float(y)) : fmaxf(float(x), float(y))))
-  
-  SPECIALIZE_REDUCE(FuncSum, rccl_bfloat8, 1, rccl_bfloat8, hadd_b(x,y))
-  SPECIALIZE_REDUCE(FuncSum, rccl_bfloat8, 2, fp8x2_storage_t, hadd2_b(x,y))
-  SPECIALIZE_REDUCE(FuncProd, rccl_bfloat8, 1, rccl_bfloat8, rccl_bfloat8(float(x) * float(y)))
-  SPECIALIZE_REDUCE(FuncMinMax, rccl_bfloat8, 1, rccl_bfloat8, rccl_bfloat8(fn.isMinNotMax ? fminf(float(x), float(y)) : fmaxf(float(x), float(y))))
+SPECIALIZE_REDUCE(FuncSum, rccl_float8, 1, rccl_float8, hadd(x, y))
+SPECIALIZE_REDUCE(FuncSum, rccl_float8, 2, fp8x2_storage_t, hadd2(x, y))
+SPECIALIZE_REDUCE(FuncProd, rccl_float8, 1, rccl_float8, rccl_float8(float(x) * float(y)))
+SPECIALIZE_REDUCE(FuncMinMax, rccl_float8, 1, rccl_float8,
+                  rccl_float8(fn.isMinNotMax ? fminf(float(x), float(y)) : fmaxf(float(x), float(y))))
+
+SPECIALIZE_REDUCE(FuncSum, rccl_bfloat8, 1, rccl_bfloat8, hadd_b(x, y))
+SPECIALIZE_REDUCE(FuncSum, rccl_bfloat8, 2, fp8x2_storage_t, hadd2_b(x, y))
+SPECIALIZE_REDUCE(FuncProd, rccl_bfloat8, 1, rccl_bfloat8, rccl_bfloat8(float(x) * float(y)))
+SPECIALIZE_REDUCE(FuncMinMax, rccl_bfloat8, 1, rccl_bfloat8,
+                  rccl_bfloat8(fn.isMinNotMax ? fminf(float(x), float(y)) : fmaxf(float(x), float(y))))
 #endif
 #endif
 
@@ -456,32 +490,32 @@ SPECIALIZE_REDUCE(FuncMinMax, half, 1, half, fn.isMinNotMax ? __hmin(x, y) : __h
 // Apply_PreOp
 
 // General recursive definition (EltPerPack > 1)
-template<typename Fn, int EltPerPack>
+template <typename Fn, int EltPerPack>
 struct Apply_PreOp {
-  static constexpr bool IsIdentity = Apply_PreOp<Fn, EltPerPack/2>::IsIdentity;
-  template<int Size>
+  static constexpr bool IsIdentity = Apply_PreOp<Fn, EltPerPack / 2>::IsIdentity;
+  template <int Size>
   __device__ __forceinline__ static BytePack<Size> preOp(Fn fn, BytePack<Size> a) {
     if NCCL_IF_CONSTEXPR (!IsIdentity) {
       // The `if (!IsIdentity)` condition is not strictly necessary, but it may help
       // compiler in that it won't have to tear a register apart for no reason
       // just to put it back together again.
-      a.half[0] = Apply_PreOp<Fn, EltPerPack/2>::preOp(fn, a.half[0]);
-      a.half[1] = Apply_PreOp<Fn, EltPerPack/2>::preOp(fn, a.half[1]);
+      a.half[0] = Apply_PreOp<Fn, EltPerPack / 2>::preOp(fn, a.half[0]);
+      a.half[1] = Apply_PreOp<Fn, EltPerPack / 2>::preOp(fn, a.half[1]);
     }
     return a;
   }
 };
 // Base case definition (EltPerPack == 1), by default is identity function.
-template<typename Fn>
+template <typename Fn>
 struct Apply_PreOp<Fn, /*EltPerPack=*/1> {
   static constexpr bool IsIdentity = true;
-  template<int Size>
+  template <int Size>
   __device__ __forceinline__ static BytePack<Size> preOp(Fn fn, BytePack<Size> a) {
     return a;
   }
 };
 // Base case definition (EltPerPack == 0), is nonsense!
-template<typename Fn>
+template <typename Fn>
 struct Apply_PreOp<Fn, /*EltPerPack=*/0> {
   static constexpr bool IsIdentity = true;
   __device__ __forceinline__ static BytePack<0> preOp(Fn fn, BytePack<0> a) {
@@ -493,32 +527,32 @@ struct Apply_PreOp<Fn, /*EltPerPack=*/0> {
 // Apply_PostOp
 
 // General recursive definition (EltPerPack > 1)
-template<typename Fn, int EltPerPack>
+template <typename Fn, int EltPerPack>
 struct Apply_PostOp {
-  static constexpr bool IsIdentity = Apply_PostOp<Fn, EltPerPack/2>::IsIdentity;
-  template<int Size>
+  static constexpr bool IsIdentity = Apply_PostOp<Fn, EltPerPack / 2>::IsIdentity;
+  template <int Size>
   __device__ __forceinline__ static BytePack<Size> postOp(Fn fn, BytePack<Size> a) {
     if NCCL_IF_CONSTEXPR (!IsIdentity) {
       // The `if (!IsIdentity)` condition is not strictly necessary, but it may help
       // compiler in that it won't have to tear a register apart for no reason
       // just to put it back together again.
-      a.half[0] = Apply_PostOp<Fn, EltPerPack/2>::postOp(fn, a.half[0]);
-      a.half[1] = Apply_PostOp<Fn, EltPerPack/2>::postOp(fn, a.half[1]);
+      a.half[0] = Apply_PostOp<Fn, EltPerPack / 2>::postOp(fn, a.half[0]);
+      a.half[1] = Apply_PostOp<Fn, EltPerPack / 2>::postOp(fn, a.half[1]);
     }
     return a;
   }
 };
 // Base case definition (EltPerPack == 1), by default is identity function.
-template<typename Fn>
+template <typename Fn>
 struct Apply_PostOp<Fn, /*EltPerPack=*/1> {
   static constexpr bool IsIdentity = true;
-  template<int Size>
+  template <int Size>
   __device__ __forceinline__ static BytePack<Size> postOp(Fn fn, BytePack<Size> a) {
     return a;
   }
 };
 // Base case definition (EltPerPack == 0), is nonsense!
-template<typename Fn>
+template <typename Fn>
 struct Apply_PostOp<Fn, /*EltPerPack=*/0> {
   static constexpr bool IsIdentity = true;
   __device__ __forceinline__ static BytePack<0> postOp(Fn fn, BytePack<0> a) {
@@ -526,15 +560,17 @@ struct Apply_PostOp<Fn, /*EltPerPack=*/0> {
   }
 };
 
-
 ////////////////////////////////////////////////////////////////////////////////
 // FuncPreMulSum
 
-template<typename T>
+template <typename T>
 struct RedOpArg<FuncPreMulSum<T>> {
   static constexpr bool ArgUsed = true;
-  __device__ __forceinline__ static uint64_t loadArg(void *ptr) {
-    union { uint64_t u64; T val; };
+  __device__ __forceinline__ static uint64_t loadArg(void* ptr) {
+    union {
+      uint64_t u64;
+      T val;
+    };
     u64 = 0;
     val = *(T*)ptr;
     return u64;
@@ -542,26 +578,32 @@ struct RedOpArg<FuncPreMulSum<T>> {
 };
 
 // General definition for all integral types, float, and double.
-template<typename T>
+template <typename T>
 struct FuncPreMulSum {
   using EltType = T;
   T scalar;
-  __device__ __forceinline__ FuncPreMulSum(uint64_t opArg=0) {
-    union { uint64_t u64; T val; };
+  __device__ __forceinline__ FuncPreMulSum(uint64_t opArg = 0) {
+    union {
+      uint64_t u64;
+      T val;
+    };
     u64 = opArg;
     scalar = val;
   }
 };
 
-template<>
+template <>
 // Coverity recommends the users of this type to use std::move in certain cases but,
 // given that half is a scalar, a plain copy will be just as efficient.
 // coverity[moveable_type]
 struct FuncPreMulSum<half> {
   using EltType = half;
   half2 scalar;
-  __device__ __forceinline__ FuncPreMulSum(uint64_t opArg=0) {
-    union { uint64_t u64; __half val; };
+  __device__ __forceinline__ FuncPreMulSum(uint64_t opArg = 0) {
+    union {
+      uint64_t u64;
+      __half val;
+    };
     u64 = opArg;
     scalar.x = val;
     scalar.y = val;
@@ -569,99 +611,118 @@ struct FuncPreMulSum<half> {
 };
 
 #if defined(RCCL_BFLOAT16)
-  template<>
+template <>
   // Coverity recommends the users of this type to use std::move in certain cases but,
   // given that __nv_bfloat16 is a scalar, a plain copy will be just as efficient.
   // coverity[moveable_type]
-  struct FuncPreMulSum<hip_bfloat16> {
-    using EltType = hip_bfloat16;
-  #if __CUDA_ARCH__ >= 800
-    __nv_bfloat162 scalar;
-    __device__ __forceinline__ FuncPreMulSum(uint64_t opArg=0) {
-      union { uint64_t u64; __nv_bfloat16 val; };
-      u64 = opArg;
-      scalar.x = val;
-      scalar.y = val;
-    }
-  #else
-    float scalar;
-    __device__ __forceinline__ FuncPreMulSum(uint64_t opArg=0) {
-      union { uint64_t u64; hip_bfloat16 val; };
-      u64 = opArg;
-      scalar = (float)(val);
-    }
-  #endif
-  };
+struct FuncPreMulSum<hip_bfloat16> {
+  using EltType = hip_bfloat16;
+#if __CUDA_ARCH__ >= 800
+  __nv_bfloat162 scalar;
+  __device__ __forceinline__ FuncPreMulSum(uint64_t opArg = 0) {
+    union {
+      uint64_t u64;
+      __nv_bfloat16 val;
+    };
+    u64 = opArg;
+    scalar.x = val;
+    scalar.y = val;
+  }
+#else
+  float scalar;
+  __device__ __forceinline__ FuncPreMulSum(uint64_t opArg = 0) {
+    union {
+      uint64_t u64;
+      hip_bfloat16 val;
+    };
+    u64 = opArg;
+    scalar = (float)(val);
+  }
+#endif
+};
 #endif
 
 #if defined(RCCL_FLOAT8)
 #if __CUDA_ARCH__ >= 900
-  template<>
-  struct FuncPreMulSum<__nv_fp8_e4m3> {
-    using EltType = __nv_fp8_e4m3;
-    __half2 scalar2;
-    __device__ __forceinline__ FuncPreMulSum(uint64_t opArg) {
-      union { uint64_t u64; __nv_fp8_storage_t val; };
-      u64 = opArg;
-      scalar2.x = __half(__nv_cvt_fp8_to_halfraw(val, __NV_E4M3));
-      scalar2.y = scalar2.x;
-    }
-  };
+template <>
+struct FuncPreMulSum<__nv_fp8_e4m3> {
+  using EltType = __nv_fp8_e4m3;
+  __half2 scalar2;
+  __device__ __forceinline__ FuncPreMulSum(uint64_t opArg) {
+    union {
+      uint64_t u64;
+      __nv_fp8_storage_t val;
+    };
+    u64 = opArg;
+    scalar2.x = __half(__nv_cvt_fp8_to_halfraw(val, __NV_E4M3));
+    scalar2.y = scalar2.x;
+  }
+};
 
-  template<>
-  struct FuncPreMulSum<__nv_fp8_e5m2> {
-    using EltType = __nv_fp8_e5m2;
-    __half2 scalar2;
-    __device__ __forceinline__ FuncPreMulSum(uint64_t opArg) {
-      union { uint64_t u64; __nv_fp8_storage_t val; };
-      u64 = opArg;
-      scalar2.x = __half(__nv_cvt_fp8_to_halfraw(val, __NV_E5M2));
-      scalar2.y = scalar2.x;
-    }
-  };
+template <>
+struct FuncPreMulSum<__nv_fp8_e5m2> {
+  using EltType = __nv_fp8_e5m2;
+  __half2 scalar2;
+  __device__ __forceinline__ FuncPreMulSum(uint64_t opArg) {
+    union {
+      uint64_t u64;
+      __nv_fp8_storage_t val;
+    };
+    u64 = opArg;
+    scalar2.x = __half(__nv_cvt_fp8_to_halfraw(val, __NV_E5M2));
+    scalar2.y = scalar2.x;
+  }
+};
 #else
-  template<>
-  struct FuncPreMulSum<rccl_float8> {
+template <>
+struct FuncPreMulSum<rccl_float8> {
     // Change these to switch between all prescale, all postscale, or both by sqrt(N).
     // Obviously, the only invalid combination is both true. An improvement would be
     // make this parameterized as a build time setting and passed here through
     // preprocessor definitions.
-    using EltType = rccl_float8;
-    float scalar;
-    __device__ FuncPreMulSum(uint64_t opArg=0) {
-      union { uint64_t u64; rccl_float8 val; };
-      u64 = opArg;
-      scalar = (float)(val);
-    }
-  };
+  using EltType = rccl_float8;
+  float scalar;
+  __device__ FuncPreMulSum(uint64_t opArg = 0) {
+    union {
+      uint64_t u64;
+      rccl_float8 val;
+    };
+    u64 = opArg;
+    scalar = (float)(val);
+  }
+};
 
-  template<>
-  struct FuncPreMulSum<rccl_bfloat8> {
+template <>
+struct FuncPreMulSum<rccl_bfloat8> {
     // Change these to switch between all prescale, all postscale, or both by sqrt(N).
     // Obviously, the only invalid combination is both true. An improvement would be
     // make this parameterized as a build time setting and passed here through
     // preprocessor definitions.
-    using EltType = rccl_bfloat8;
-    float scalar;
-    __device__ FuncPreMulSum(uint64_t opArg=0) {
-      union { uint64_t u64; rccl_bfloat8 val; };
-      u64 = opArg;
-      scalar = (float)(val);
-    }
-  };
+  using EltType = rccl_bfloat8;
+  float scalar;
+  __device__ FuncPreMulSum(uint64_t opArg = 0) {
+    union {
+      uint64_t u64;
+      rccl_bfloat8 val;
+    };
+    u64 = opArg;
+    scalar = (float)(val);
+  }
+};
 #endif
 #endif
 
-template<typename T, int EltPerPack>
+template <typename T, int EltPerPack>
 struct Apply_Reduce<FuncPreMulSum<T>, EltPerPack> {
-  __device__ __forceinline__ static BytePack<EltPerPack*sizeof(T)> reduce(FuncPreMulSum<T> fn, BytePack<EltPerPack*sizeof(T)> a, BytePack<EltPerPack*sizeof(T)> b) {
+  __device__ __forceinline__ static BytePack<EltPerPack * sizeof(T)> reduce(
+    FuncPreMulSum<T> fn, BytePack<EltPerPack * sizeof(T)> a, BytePack<EltPerPack * sizeof(T)> b) {
     // FuncPreMulSum reduce dispatches to FuncSum.
     return Apply_Reduce<FuncSum<T>, EltPerPack>::reduce(FuncSum<T>(), a, b);
   }
 };
 
 // PreOp of FuncPreMulSum for integral types, float, and double.
-template<typename T>
+template <typename T>
 struct Apply_PreOp<FuncPreMulSum<T>, /*EltPerPack=*/1> {
   static constexpr bool IsIdentity = false;
   __device__ __forceinline__ static BytePack<sizeof(T)> preOp(FuncPreMulSum<T> fn, BytePack<sizeof(T)> a) {
@@ -672,51 +733,49 @@ struct Apply_PreOp<FuncPreMulSum<T>, /*EltPerPack=*/1> {
 ////////////////////////////////////////////////////////////////////////////////
 // Apply_PreOp of FuncPreMulSum for float16.
 
-template<>
+template <>
 struct Apply_PreOp<FuncPreMulSum<half>, /*EltPerPack=*/1> {
   static constexpr bool IsIdentity = false;
   __device__ __forceinline__ static BytePack<sizeof(half)> preOp(FuncPreMulSum<half> fn, BytePack<sizeof(half)> a) {
-      return toPack<half>(__hmul(fromPack<half>(a), fn.scalar.x));
+    return toPack<half>(__hmul(fromPack<half>(a), fn.scalar.x));
   }
 };
 #if __CUDA_ARCH__ >= 530 && __CUDA_ARCH__ != 610
-  template<>
-  struct Apply_PreOp<FuncPreMulSum<half>, /*EltPerPack=*/2> {
-    static constexpr bool IsIdentity = false;
-    __device__ __forceinline__ static BytePack<sizeof(half2)> preOp(FuncPreMulSum<half> fn, BytePack<sizeof(half2)> a) {
-      return toPack<half2>(__hmul2(fromPack<half2>(a), fn.scalar));
-    }
-  };
+template <>
+struct Apply_PreOp<FuncPreMulSum<half>, /*EltPerPack=*/2> {
+  static constexpr bool IsIdentity = false;
+  __device__ __forceinline__ static BytePack<sizeof(half2)> preOp(FuncPreMulSum<half> fn, BytePack<sizeof(half2)> a) {
+    return toPack<half2>(__hmul2(fromPack<half2>(a), fn.scalar));
+  }
+};
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
 // Apply_PreOp of FuncPreMulSum for bfloat16.
 
 #if defined(RCCL_BFLOAT16)
-  template<>
-  struct Apply_PreOp<FuncPreMulSum<hip_bfloat16>, /*EltPerPack=*/1> {
-    static constexpr bool IsIdentity = false;
-    __device__ __forceinline__ static BytePack<sizeof(hip_bfloat16)> preOp(
-        FuncPreMulSum<hip_bfloat16> fn, BytePack<sizeof(hip_bfloat16)> a
-      ) {
-      #if __CUDA_ARCH__ >= 800
-        return toPack<__nv_bfloat16>(__hmul(fromPack<__nv_bfloat16>(a), fn.scalar.x));
-      #else
-        return toPack<hip_bfloat16>((hip_bfloat16)((float)(fromPack<hip_bfloat16>(a)) * fn.scalar));
-      #endif
-    }
-  };
-  #if __CUDA_ARCH__ >= 800
-    template<>
-    struct Apply_PreOp<FuncPreMulSum<hip_bfloat16>, /*EltPerPack=*/2> {
-      static constexpr bool IsIdentity = false;
-      __device__ __forceinline__ static BytePack<sizeof(__nv_bfloat162)> preOp(
-          FuncPreMulSum<__nv_bfloat16> fn, BytePack<sizeof(__nv_bfloat162)> a
-        ) {
-        return toPack<__nv_bfloat162>(__hmul2(fromPack<__nv_bfloat162>(a), fn.scalar));
-      }
-    };
-  #endif
+template <>
+struct Apply_PreOp<FuncPreMulSum<hip_bfloat16>, /*EltPerPack=*/1> {
+  static constexpr bool IsIdentity = false;
+  __device__ __forceinline__ static BytePack<sizeof(hip_bfloat16)> preOp(FuncPreMulSum<hip_bfloat16> fn,
+                                                                         BytePack<sizeof(hip_bfloat16)> a) {
+#if __CUDA_ARCH__ >= 800
+    return toPack<__nv_bfloat16>(__hmul(fromPack<__nv_bfloat16>(a), fn.scalar.x));
+#else
+    return toPack<hip_bfloat16>((hip_bfloat16)((float)(fromPack<hip_bfloat16>(a)) * fn.scalar));
+#endif
+  }
+};
+#if __CUDA_ARCH__ >= 800
+template <>
+struct Apply_PreOp<FuncPreMulSum<hip_bfloat16>, /*EltPerPack=*/2> {
+  static constexpr bool IsIdentity = false;
+  __device__ __forceinline__ static BytePack<sizeof(__nv_bfloat162)> preOp(FuncPreMulSum<__nv_bfloat16> fn,
+                                                                           BytePack<sizeof(__nv_bfloat162)> a) {
+    return toPack<__nv_bfloat162>(__hmul2(fromPack<__nv_bfloat162>(a), fn.scalar));
+  }
+};
+#endif
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -724,87 +783,84 @@ struct Apply_PreOp<FuncPreMulSum<half>, /*EltPerPack=*/1> {
 
 #if defined(RCCL_FLOAT8)
 #if __CUDA_ARCH__ >= 900
-  template<>
-  struct Apply_PreOp<FuncPreMulSum<__nv_fp8_e4m3>, /*EltPerPack=*/1> {
-    static constexpr bool IsIdentity = false;
-    __device__ __forceinline__ static BytePack<sizeof(__nv_fp8_e4m3)> preOp(
-        FuncPreMulSum<__nv_fp8_e4m3> fn, BytePack<sizeof(__nv_fp8_e4m3)> a
-      ) {
-      return toPack<__nv_fp8_e4m3>(__nv_fp8_e4m3(__hmul(__half(fromPack<__nv_fp8_e4m3>(a)), fn.scalar2.x)));
-    }
-  };
-  template<>
-  struct Apply_PreOp<FuncPreMulSum<__nv_fp8_e4m3>, /*EltPerPack=*/2> {
-    static constexpr bool IsIdentity = false;
-    __device__ __forceinline__ static BytePack<sizeof(__nv_fp8x2_e4m3)> preOp(
-        FuncPreMulSum<__nv_fp8_e4m3> fn, BytePack<sizeof(__nv_fp8x2_e4m3)> a
-      ) {
-      return toPack<__nv_fp8x2_e4m3>(__nv_fp8x2_e4m3(__hmul2(__half2(fromPack<__nv_fp8x2_e4m3>(a)), fn.scalar2)));
-    }
-  };
+template <>
+struct Apply_PreOp<FuncPreMulSum<__nv_fp8_e4m3>, /*EltPerPack=*/1> {
+  static constexpr bool IsIdentity = false;
+  __device__ __forceinline__ static BytePack<sizeof(__nv_fp8_e4m3)> preOp(FuncPreMulSum<__nv_fp8_e4m3> fn,
+                                                                          BytePack<sizeof(__nv_fp8_e4m3)> a) {
+    return toPack<__nv_fp8_e4m3>(__nv_fp8_e4m3(__hmul(__half(fromPack<__nv_fp8_e4m3>(a)), fn.scalar2.x)));
+  }
+};
+template <>
+struct Apply_PreOp<FuncPreMulSum<__nv_fp8_e4m3>, /*EltPerPack=*/2> {
+  static constexpr bool IsIdentity = false;
+  __device__ __forceinline__ static BytePack<sizeof(__nv_fp8x2_e4m3)> preOp(FuncPreMulSum<__nv_fp8_e4m3> fn,
+                                                                            BytePack<sizeof(__nv_fp8x2_e4m3)> a) {
+    return toPack<__nv_fp8x2_e4m3>(__nv_fp8x2_e4m3(__hmul2(__half2(fromPack<__nv_fp8x2_e4m3>(a)), fn.scalar2)));
+  }
+};
 
-  template<>
-  struct Apply_PreOp<FuncPreMulSum<__nv_fp8_e5m2>, /*EltPerPack=*/1> {
-    static constexpr bool IsIdentity = false;
-    __device__ __forceinline__ static BytePack<sizeof(__nv_fp8_e5m2)> preOp(
-        FuncPreMulSum<__nv_fp8_e5m2> fn, BytePack<sizeof(__nv_fp8_e5m2)> a
-      ) {
-      return toPack<__nv_fp8_e5m2>(__nv_fp8_e5m2(__hmul(__half(fromPack<__nv_fp8_e5m2>(a)), fn.scalar2.x)));
-    }
-  };
-  template<>
-  struct Apply_PreOp<FuncPreMulSum<__nv_fp8_e5m2>, /*EltPerPack=*/2> {
-    static constexpr bool IsIdentity = false;
-    __device__ __forceinline__ static BytePack<sizeof(__nv_fp8x2_e5m2)> preOp(
-        FuncPreMulSum<__nv_fp8_e5m2> fn, BytePack<sizeof(__nv_fp8x2_e5m2)> a
-      ) {
-      return toPack<__nv_fp8x2_e5m2>(__nv_fp8x2_e5m2(__hmul2(__half2(fromPack<__nv_fp8x2_e5m2>(a)), fn.scalar2)));
-    }
-  };
+template <>
+struct Apply_PreOp<FuncPreMulSum<__nv_fp8_e5m2>, /*EltPerPack=*/1> {
+  static constexpr bool IsIdentity = false;
+  __device__ __forceinline__ static BytePack<sizeof(__nv_fp8_e5m2)> preOp(FuncPreMulSum<__nv_fp8_e5m2> fn,
+                                                                          BytePack<sizeof(__nv_fp8_e5m2)> a) {
+    return toPack<__nv_fp8_e5m2>(__nv_fp8_e5m2(__hmul(__half(fromPack<__nv_fp8_e5m2>(a)), fn.scalar2.x)));
+  }
+};
+template <>
+struct Apply_PreOp<FuncPreMulSum<__nv_fp8_e5m2>, /*EltPerPack=*/2> {
+  static constexpr bool IsIdentity = false;
+  __device__ __forceinline__ static BytePack<sizeof(__nv_fp8x2_e5m2)> preOp(FuncPreMulSum<__nv_fp8_e5m2> fn,
+                                                                            BytePack<sizeof(__nv_fp8x2_e5m2)> a) {
+    return toPack<__nv_fp8x2_e5m2>(__nv_fp8x2_e5m2(__hmul2(__half2(fromPack<__nv_fp8x2_e5m2>(a)), fn.scalar2)));
+  }
+};
 #else
-  template<>
-  struct Apply_PreOp<FuncPreMulSum<rccl_float8>, /*EltPerPack=*/1> {
-    static constexpr bool IsIdentity = false;
+template <>
+struct Apply_PreOp<FuncPreMulSum<rccl_float8>, /*EltPerPack=*/1> {
+  static constexpr bool IsIdentity = false;
 
-    __device__ static BytePack<sizeof(rccl_float8)> preOp(
-        FuncPreMulSum<rccl_float8> fn, BytePack<sizeof(rccl_float8)> a
-      ) {
-        return toPack<rccl_float8>(rccl_float8(float(fromPack<rccl_float8>(a)) * float(fn.scalar)));
-    }
-  };
+  __device__ static BytePack<sizeof(rccl_float8)> preOp(FuncPreMulSum<rccl_float8> fn,
+                                                        BytePack<sizeof(rccl_float8)> a) {
+    return toPack<rccl_float8>(rccl_float8(float(fromPack<rccl_float8>(a)) * float(fn.scalar)));
+  }
+};
 
-  template<>
-  struct Apply_PreOp<FuncPreMulSum<rccl_bfloat8>, /*EltPerPack=*/1> {
-    static constexpr bool IsIdentity = false;
+template <>
+struct Apply_PreOp<FuncPreMulSum<rccl_bfloat8>, /*EltPerPack=*/1> {
+  static constexpr bool IsIdentity = false;
 
-    __device__ static BytePack<sizeof(rccl_bfloat8)> preOp(
-        FuncPreMulSum<rccl_bfloat8> fn, BytePack<sizeof(rccl_bfloat8)> a
-      ) {
-        return toPack<rccl_bfloat8>(rccl_bfloat8(float(fromPack<rccl_bfloat8>(a)) * float(fn.scalar)));
-    }
-  };
+  __device__ static BytePack<sizeof(rccl_bfloat8)> preOp(FuncPreMulSum<rccl_bfloat8> fn,
+                                                         BytePack<sizeof(rccl_bfloat8)> a) {
+    return toPack<rccl_bfloat8>(rccl_bfloat8(float(fromPack<rccl_bfloat8>(a)) * float(fn.scalar)));
+  }
+};
 #endif
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
 // FuncSumPostDiv
 
-template<typename T>
+template <typename T>
 struct RedOpArg<FuncSumPostDiv<T>> {
   static constexpr bool ArgUsed = true;
-  __device__ __forceinline__ static uint64_t loadArg(void *ptr) {
+  __device__ __forceinline__ static uint64_t loadArg(void* ptr) {
     return *(uint64_t*)ptr;
   }
 };
 
 #if defined(__CUDA_BF16_TYPES_EXIST__)
-template<>
+template <>
 struct FuncSumPostDiv<__nv_bfloat16> {
   using EltType = __nv_bfloat16;
 #if __CUDA_ARCH__ >= 800
   __nv_bfloat162 scalar;
   __device__ __forceinline__ FuncSumPostDiv(uint64_t opArg) {
-    union { uint64_t u64; __nv_bfloat16 val; };
+    union {
+      uint64_t u64;
+      __nv_bfloat16 val;
+    };
     u64 = opArg;
     scalar.x = val;
     scalar.y = val;
@@ -812,7 +868,10 @@ struct FuncSumPostDiv<__nv_bfloat16> {
 #else
   float scalar;
   __device__ __forceinline__ FuncSumPostDiv(uint64_t opArg) {
-    union { uint64_t u64; __nv_bfloat16 val; };
+    union {
+      uint64_t u64;
+      __nv_bfloat16 val;
+    };
     u64 = opArg;
     scalar = __bfloat162float(val);
   }
@@ -820,44 +879,56 @@ struct FuncSumPostDiv<__nv_bfloat16> {
 };
 #endif
 
-template<>
+template <>
 struct FuncSumPostDiv<half> {
   using EltType = half;
 #if __CUDA_ARCH__ >= 530 && __CUDA_ARCH__ != 610
   __half2 scalar;
-  __device__ __forceinline__ FuncSumPostDiv(uint64_t opArg=0) {
-    union { uint64_t u64; __half val; };
+  __device__ __forceinline__ FuncSumPostDiv(uint64_t opArg = 0) {
+    union {
+      uint64_t u64;
+      __half val;
+    };
     u64 = opArg;
     scalar.x = val;
     scalar.y = val;
   }
 #else
   float scalar;
-  __device__ __forceinline__ FuncSumPostDiv(uint64_t opArg=0) {
-    union { uint64_t u64; __half val; };
+  __device__ __forceinline__ FuncSumPostDiv(uint64_t opArg = 0) {
+    union {
+      uint64_t u64;
+      __half val;
+    };
     u64 = opArg;
     scalar = (float)val;
   }
 #endif
 };
 
-template<>
+template <>
 struct FuncSumPostDiv<float> {
   using EltType = float;
   float scalar;
   __device__ __forceinline__ FuncSumPostDiv(uint64_t opArg) {
-    union { uint64_t u64; float val; };
+    union {
+      uint64_t u64;
+      float val;
+    };
     u64 = opArg;
     scalar = val;
   }
 };
 
-template<>
+template <>
 struct FuncSumPostDiv<double> {
   using EltType = double;
   double scalar;
   __device__ __forceinline__ FuncSumPostDiv(uint64_t opArg) {
-    union { uint64_t u64; double val; };
+    union {
+      uint64_t u64;
+      double val;
+    };
     u64 = opArg;
     scalar = val;
   }
@@ -865,24 +936,30 @@ struct FuncSumPostDiv<double> {
 
 #if defined(__CUDA_FP8_TYPES_EXIST__)
 #if __CUDA_ARCH__ >= 900
-template<>
+template <>
 struct FuncSumPostDiv<__nv_fp8_e4m3> {
   using EltType = __nv_fp8_e4m3;
   __half2 scalar2;
   __device__ __forceinline__ FuncSumPostDiv(uint64_t opArg) {
-    union { uint64_t u64; __nv_fp8_storage_t val; };
+    union {
+      uint64_t u64;
+      __nv_fp8_storage_t val;
+    };
     u64 = opArg;
     scalar2.x = __half(__nv_cvt_fp8_to_halfraw(val, __NV_E4M3));
     scalar2.y = scalar2.x;
   }
 };
 
-template<>
+template <>
 struct FuncSumPostDiv<__nv_fp8_e5m2> {
   using EltType = __nv_fp8_e5m2;
   __half2 scalar2;
   __device__ __forceinline__ FuncSumPostDiv(uint64_t opArg) {
-    union { uint64_t u64; __nv_fp8_storage_t val; };
+    union {
+      uint64_t u64;
+      __nv_fp8_storage_t val;
+    };
     u64 = opArg;
     scalar2.x = __half(__nv_cvt_fp8_to_halfraw(val, __NV_E5M2));
     scalar2.y = scalar2.x;
@@ -895,46 +972,55 @@ struct FuncSumPostDiv<__nv_fp8_e5m2> {
 // FuncSumPostDiv for the raw ROCm float types exists only so the GIN kernel's mmRed
 // (Red<rawT> srcRedMc) is a constructible type; its reduce/postOp are never invoked on
 // ROCm (non-multimem), where avg is accumulated in a float AccT via srcRedUc.
-template<>
+template <>
 struct FuncSumPostDiv<hip_bfloat16> {
   using EltType = hip_bfloat16;
   float scalar;
-  __device__ __forceinline__ FuncSumPostDiv(uint64_t opArg=0) {
-    union { uint64_t u64; float val; };
+  __device__ __forceinline__ FuncSumPostDiv(uint64_t opArg = 0) {
+    union {
+      uint64_t u64;
+      float val;
+    };
     u64 = opArg;
     scalar = val;
   }
 };
-template<>
+template <>
 struct FuncSumPostDiv<rccl_float8> {
   using EltType = rccl_float8;
   float scalar;
-  __device__ __forceinline__ FuncSumPostDiv(uint64_t opArg=0) {
-    union { uint64_t u64; float val; };
+  __device__ __forceinline__ FuncSumPostDiv(uint64_t opArg = 0) {
+    union {
+      uint64_t u64;
+      float val;
+    };
     u64 = opArg;
     scalar = val;
   }
 };
-template<>
+template <>
 struct FuncSumPostDiv<rccl_bfloat8> {
   using EltType = rccl_bfloat8;
   float scalar;
-  __device__ __forceinline__ FuncSumPostDiv(uint64_t opArg=0) {
-    union { uint64_t u64; float val; };
+  __device__ __forceinline__ FuncSumPostDiv(uint64_t opArg = 0) {
+    union {
+      uint64_t u64;
+      float val;
+    };
     u64 = opArg;
     scalar = val;
   }
 };
 #endif
 
-template<typename T>
+template <typename T>
 struct Divider {
   __device__ __forceinline__ static T divide(T dividend, T divisor) {
     return dividend / divisor;
   }
 };
 
-template<>
+template <>
 struct Divider<uint64_t> {
   __device__ __forceinline__ static uint64_t divide(uint64_t dividend, uint64_t divisor) {
     if (divisor == 0) {
@@ -944,7 +1030,7 @@ struct Divider<uint64_t> {
     uint64_t quotient = 0;
     uint64_t remainder = 0;
 
-    #pragma unroll 64
+#pragma unroll 64
     for (int i = 63; i >= 0; --i) {
       remainder = (remainder << 1) | ((dividend >> i) & 1);
       if (remainder >= divisor) {
@@ -956,23 +1042,23 @@ struct Divider<uint64_t> {
     return quotient;
   }
 };
-  
-template<typename T>
+
+template <typename T>
 struct FuncSumPostDiv {
   static_assert(T(0) < T(-1), "FuncSumPostDiv is only for implementing ncclAvg on uint types.");
   using EltType = T;
-  using UintType = typename std::conditional<sizeof(T)==8, uint64_t, uint32_t>::type;
+  using UintType = typename std::conditional<sizeof(T) == 8, uint64_t, uint32_t>::type;
   uint32_t divisor:31, isSigned:1;
   UintType recip;
 
-  __device__ __forceinline__ FuncSumPostDiv(uint64_t opArg=0) {
+  __device__ __forceinline__ FuncSumPostDiv(uint64_t opArg = 0) {
     isSigned = opArg & 1;
     divisor = opArg >> 1;
     recip = Divider<UintType>::divide(UintType(-1), divisor);
   }
   __device__ __forceinline__ T divide(T x) {
     // x is negative iff we are in signed mode and the top bit is set
-    bool xneg = isSigned && (x & ~(T(-1)>>1));
+    bool xneg = isSigned && (x & ~(T(-1) >> 1));
     // Compute abs(x):
     // T(-x) vs -T(x) is critical. We have to negate then truncate the bits. Consider
     // if we are doing signed 8-bit types, thus T=uint8_t. The value -1 is encoded
@@ -980,48 +1066,50 @@ struct FuncSumPostDiv {
     // gives 0xffffff01, but T(-0xff) is 0x1, and that is the abs value we want.
     UintType xabs = xneg ? T(-x) : x;
     // Compute quotient by multiplying by reciprical.
-    UintType q = sizeof(T)==8 ? __umul64hi(xabs, recip) : __umulhi(xabs, recip);
+    UintType q = sizeof(T) == 8 ? __umul64hi(xabs, recip) : __umulhi(xabs, recip);
     // Quotient may be off by one so do a fixup.
-    if (xabs - q*divisor >= divisor) q += 1;
+    if (xabs - q * divisor >= divisor) q += 1;
     // If original x was negative then we have to negate it back since we were
     // working with its abs val.
     return xneg ? -T(q) : T(q);
   }
 };
 
-template<typename T, int EltPerPack>
-struct Apply_Reduce<FuncSumPostDiv<T>, EltPerPack>:
-    Apply_Reduce<FuncSum<T>, EltPerPack> {
-  __device__ __forceinline__ static BytePack<EltPerPack*sizeof(T)> reduce(FuncSumPostDiv<T> fn, BytePack<EltPerPack*sizeof(T)> a, BytePack<EltPerPack*sizeof(T)> b) {
+template <typename T, int EltPerPack>
+struct Apply_Reduce<FuncSumPostDiv<T>, EltPerPack> : Apply_Reduce<FuncSum<T>, EltPerPack> {
+  __device__ __forceinline__ static BytePack<EltPerPack * sizeof(T)> reduce(
+    FuncSumPostDiv<T> fn, BytePack<EltPerPack * sizeof(T)> a, BytePack<EltPerPack * sizeof(T)> b) {
     // FuncSumPostDiv reduce dispatches to FuncSum.
     return Apply_Reduce<FuncSum<T>, EltPerPack>::reduce(FuncSum<T>(), a, b);
   }
 };
 
-
 // Confusingly, these functions multiply by the scalar, not divide by it. This is okay because we set the scalar to be
 // 1/n when creating the FuncSumPostDiv object.
-template<>
+template <>
 struct Apply_PostOp<FuncSumPostDiv<float>, /*EltPerPack=*/1> {
   static constexpr bool IsIdentity = false;
-  __device__ __forceinline__ static BytePack<sizeof(float)> postOp(FuncSumPostDiv<float> fn, BytePack<sizeof(float)> a) {
+  __device__ __forceinline__ static BytePack<sizeof(float)> postOp(FuncSumPostDiv<float> fn,
+                                                                   BytePack<sizeof(float)> a) {
     return toPack<float>(fromPack<float>(a) * fn.scalar);
   }
 };
 
-template<>
+template <>
 struct Apply_PostOp<FuncSumPostDiv<double>, /*EltPerPack=*/1> {
   static constexpr bool IsIdentity = false;
-  __device__ __forceinline__ static BytePack<sizeof(double)> postOp(FuncSumPostDiv<double> fn, BytePack<sizeof(double)> a) {
+  __device__ __forceinline__ static BytePack<sizeof(double)> postOp(FuncSumPostDiv<double> fn,
+                                                                    BytePack<sizeof(double)> a) {
     return toPack<double>(fromPack<double>(a) * fn.scalar);
   }
 };
 
 #if defined(__CUDA_BF16_TYPES_EXIST__)
-template<>
+template <>
 struct Apply_PostOp<FuncSumPostDiv<__nv_bfloat16>, /*EltPerPack=*/1> {
   static constexpr bool IsIdentity = false;
-  __device__ __forceinline__ static BytePack<sizeof(__nv_bfloat16)> postOp(FuncSumPostDiv<__nv_bfloat16> fn, BytePack<sizeof(__nv_bfloat16)> a) {
+  __device__ __forceinline__ static BytePack<sizeof(__nv_bfloat16)> postOp(FuncSumPostDiv<__nv_bfloat16> fn,
+                                                                           BytePack<sizeof(__nv_bfloat16)> a) {
 #if __CUDA_ARCH__ >= 800
     return toPack<__nv_bfloat16>(__hmul(fromPack<__nv_bfloat16>(a), fn.scalar.x));
 #else
@@ -1031,17 +1119,18 @@ struct Apply_PostOp<FuncSumPostDiv<__nv_bfloat16>, /*EltPerPack=*/1> {
 };
 
 #if __CUDA_ARCH__ >= 800
-template<>
+template <>
 struct Apply_PostOp<FuncSumPostDiv<__nv_bfloat16>, /*EltPerPack=*/2> {
   static constexpr bool IsIdentity = false;
-  __device__ __forceinline__ static BytePack<sizeof(__nv_bfloat162)> postOp(FuncSumPostDiv<__nv_bfloat16> fn, BytePack<sizeof(__nv_bfloat162)> a) {
+  __device__ __forceinline__ static BytePack<sizeof(__nv_bfloat162)> postOp(FuncSumPostDiv<__nv_bfloat16> fn,
+                                                                            BytePack<sizeof(__nv_bfloat162)> a) {
     return toPack<__nv_bfloat162>(__hmul2(fromPack<__nv_bfloat162>(a), fn.scalar));
   }
 };
 #endif // __CUDA_ARCH__ >= 800
 #endif
 
-template<>
+template <>
 struct Apply_PostOp<FuncSumPostDiv<half>, /*EltPerPack=*/1> {
   static constexpr bool IsIdentity = false;
   __device__ __forceinline__ static BytePack<sizeof(half)> postOp(FuncSumPostDiv<half> fn, BytePack<sizeof(half)> a) {
@@ -1054,58 +1143,54 @@ struct Apply_PostOp<FuncSumPostDiv<half>, /*EltPerPack=*/1> {
 };
 
 #if __CUDA_ARCH__ >= 530 && __CUDA_ARCH__ != 610
-  template<>
-  struct Apply_PostOp<FuncSumPostDiv<half>, /*EltPerPack=*/2> {
-    static constexpr bool IsIdentity = false;
-    __device__ __forceinline__ static BytePack<sizeof(half2)> postOp(FuncSumPostDiv<half> fn, BytePack<sizeof(half2)> a) {
-      return toPack<half2>(__hmul2(fromPack<half2>(a), fn.scalar));
-    }
-  };
+template <>
+struct Apply_PostOp<FuncSumPostDiv<half>, /*EltPerPack=*/2> {
+  static constexpr bool IsIdentity = false;
+  __device__ __forceinline__ static BytePack<sizeof(half2)> postOp(FuncSumPostDiv<half> fn, BytePack<sizeof(half2)> a) {
+    return toPack<half2>(__hmul2(fromPack<half2>(a), fn.scalar));
+  }
+};
 #endif
 
 #if defined(__CUDA_FP8_TYPES_EXIST__)
 #if __CUDA_ARCH__ >= 900
-  template<>
-  struct Apply_PostOp<FuncSumPostDiv<__nv_fp8_e4m3>, /*EltPerPack=*/1> {
-    static constexpr bool IsIdentity = false;
-    __device__ __forceinline__ static BytePack<sizeof(__nv_fp8_e4m3)> postOp(
-        FuncSumPostDiv<__nv_fp8_e4m3> fn, BytePack<sizeof(__nv_fp8_e4m3)> a
-      ) {
-      return toPack<__nv_fp8_e4m3>(__nv_fp8_e4m3(__hmul(__half(fromPack<__nv_fp8_e4m3>(a)), fn.scalar2.x)));
-    }
-  };
-  template<>
-  struct Apply_PostOp<FuncSumPostDiv<__nv_fp8_e4m3>, /*EltPerPack=*/2> {
-    static constexpr bool IsIdentity = false;
-    __device__ __forceinline__ static BytePack<sizeof(__nv_fp8x2_e4m3)> postOp(
-        FuncSumPostDiv<__nv_fp8_e4m3> fn, BytePack<sizeof(__nv_fp8x2_e4m3)> a
-      ) {
-      return toPack<__nv_fp8x2_e4m3>(__nv_fp8x2_e4m3(__hmul2(__half2(fromPack<__nv_fp8x2_e4m3>(a)), fn.scalar2)));
-    }
-  };
+template <>
+struct Apply_PostOp<FuncSumPostDiv<__nv_fp8_e4m3>, /*EltPerPack=*/1> {
+  static constexpr bool IsIdentity = false;
+  __device__ __forceinline__ static BytePack<sizeof(__nv_fp8_e4m3)> postOp(FuncSumPostDiv<__nv_fp8_e4m3> fn,
+                                                                           BytePack<sizeof(__nv_fp8_e4m3)> a) {
+    return toPack<__nv_fp8_e4m3>(__nv_fp8_e4m3(__hmul(__half(fromPack<__nv_fp8_e4m3>(a)), fn.scalar2.x)));
+  }
+};
+template <>
+struct Apply_PostOp<FuncSumPostDiv<__nv_fp8_e4m3>, /*EltPerPack=*/2> {
+  static constexpr bool IsIdentity = false;
+  __device__ __forceinline__ static BytePack<sizeof(__nv_fp8x2_e4m3)> postOp(FuncSumPostDiv<__nv_fp8_e4m3> fn,
+                                                                             BytePack<sizeof(__nv_fp8x2_e4m3)> a) {
+    return toPack<__nv_fp8x2_e4m3>(__nv_fp8x2_e4m3(__hmul2(__half2(fromPack<__nv_fp8x2_e4m3>(a)), fn.scalar2)));
+  }
+};
 
-  template<>
-  struct Apply_PostOp<FuncSumPostDiv<__nv_fp8_e5m2>, /*EltPerPack=*/1> {
-    static constexpr bool IsIdentity = false;
-    __device__ __forceinline__ static BytePack<sizeof(__nv_fp8_e5m2)> postOp(
-        FuncSumPostDiv<__nv_fp8_e5m2> fn, BytePack<sizeof(__nv_fp8_e5m2)> a
-      ) {
-      return toPack<__nv_fp8_e5m2>(__nv_fp8_e5m2(__hmul(__half(fromPack<__nv_fp8_e5m2>(a)), fn.scalar2.x)));
-    }
-  };
-  template<>
-  struct Apply_PostOp<FuncSumPostDiv<__nv_fp8_e5m2>, /*EltPerPack=*/2> {
-    static constexpr bool IsIdentity = false;
-    __device__ __forceinline__ static BytePack<sizeof(__nv_fp8x2_e5m2)> postOp(
-        FuncSumPostDiv<__nv_fp8_e5m2> fn, BytePack<sizeof(__nv_fp8x2_e5m2)> a
-      ) {
-      return toPack<__nv_fp8x2_e5m2>(__nv_fp8x2_e5m2(__hmul2(__half2(fromPack<__nv_fp8x2_e5m2>(a)), fn.scalar2)));
-    }
-  };
+template <>
+struct Apply_PostOp<FuncSumPostDiv<__nv_fp8_e5m2>, /*EltPerPack=*/1> {
+  static constexpr bool IsIdentity = false;
+  __device__ __forceinline__ static BytePack<sizeof(__nv_fp8_e5m2)> postOp(FuncSumPostDiv<__nv_fp8_e5m2> fn,
+                                                                           BytePack<sizeof(__nv_fp8_e5m2)> a) {
+    return toPack<__nv_fp8_e5m2>(__nv_fp8_e5m2(__hmul(__half(fromPack<__nv_fp8_e5m2>(a)), fn.scalar2.x)));
+  }
+};
+template <>
+struct Apply_PostOp<FuncSumPostDiv<__nv_fp8_e5m2>, /*EltPerPack=*/2> {
+  static constexpr bool IsIdentity = false;
+  __device__ __forceinline__ static BytePack<sizeof(__nv_fp8x2_e5m2)> postOp(FuncSumPostDiv<__nv_fp8_e5m2> fn,
+                                                                             BytePack<sizeof(__nv_fp8x2_e5m2)> a) {
+    return toPack<__nv_fp8x2_e5m2>(__nv_fp8x2_e5m2(__hmul2(__half2(fromPack<__nv_fp8x2_e5m2>(a)), fn.scalar2)));
+  }
+};
 #endif
 #endif
 
-template<typename T>
+template <typename T>
 struct Apply_PostOp<FuncSumPostDiv<T>, /*EltPerPack=*/1> {
   static constexpr bool IsIdentity = false;
   __device__ __forceinline__ static BytePack<sizeof(T)> postOp(FuncSumPostDiv<T> fn, BytePack<sizeof(T)> a) {
@@ -1133,15 +1218,15 @@ struct Apply_PostOp<FuncSumPostDiv<T>, /*EltPerPack=*/1> {
 #define PtxAcc_for_f32
 #define PtxAcc_for_f64
 #if CUDART_VERSION >= 12020
-  #define PtxAcc_for_f16 ".acc::f32"
-  #define PtxAcc_for_bf16 ".acc::f32"
-  #define PtxAcc_for_f16x2 ".acc::f32"
-  #define PtxAcc_for_bf16x2 ".acc::f32"
+#define PtxAcc_for_f16 ".acc::f32"
+#define PtxAcc_for_bf16 ".acc::f32"
+#define PtxAcc_for_f16x2 ".acc::f32"
+#define PtxAcc_for_bf16x2 ".acc::f32"
 #else
-  #define PtxAcc_for_f16
-  #define PtxAcc_for_bf16
-  #define PtxAcc_for_f16x2
-  #define PtxAcc_for_bf16x2
+#define PtxAcc_for_f16
+#define PtxAcc_for_bf16
+#define PtxAcc_for_f16x2
+#define PtxAcc_for_bf16x2
 #endif
 #define PtxAcc_for_e4m3 ".acc::f16"
 #define PtxAcc_for_e5m2 ".acc::f16"
@@ -1149,31 +1234,34 @@ struct Apply_PostOp<FuncSumPostDiv<T>, /*EltPerPack=*/1> {
 #define PtxAcc_for_e5m2x4 ".acc::f16"
 
 #define DEFINE_Apply_LoadMultimem_sum(T, ptx_ty, PackSize) \
-  template<> \
+  template <> \
   struct Apply_LoadMultimem<FuncSum<T>, PackSize> { \
     __device__ __forceinline__ static BytePack<PackSize> load(FuncSum<T> fn, uintptr_t addr) { \
       BytePack<RegSize_for_size_##PackSize> reg; \
       asm volatile("multimem.ld_reduce.relaxed.sys.global.add" PtxAcc_for_##ptx_ty "." #ptx_ty " %0, [%1];" \
-        : "=" RegCode_for_size_##PackSize(reg.native) \
-        : "l"(addr) : "memory"); \
+                   : "=" RegCode_for_size_##PackSize(reg.native) \
+                   : "l"(addr) \
+                   : "memory"); \
       BytePack<PackSize> ans; \
       ans.native = reg.native; \
       return ans; \
     } \
   };
 #define DEFINE_Apply_LoadMultimem_minmax(T, ptx_ty, PackSize) \
-  template<> \
+  template <> \
   struct Apply_LoadMultimem<FuncMinMax<T>, PackSize> { \
     __device__ __forceinline__ static BytePack<PackSize> load(FuncMinMax<T> fn, uintptr_t addr) { \
       BytePack<RegSize_for_size_##PackSize> reg; \
       if (fn.isMinNotMax) { \
         asm volatile("multimem.ld_reduce.relaxed.sys.global.min." #ptx_ty " %0, [%1];" \
-          : "=" RegCode_for_size_##PackSize(reg.native) \
-          : "l"(addr) : "memory"); \
+                     : "=" RegCode_for_size_##PackSize(reg.native) \
+                     : "l"(addr) \
+                     : "memory"); \
       } else { \
         asm volatile("multimem.ld_reduce.relaxed.sys.global.max." #ptx_ty " %0, [%1];" \
-          : "=" RegCode_for_size_##PackSize(reg.native) \
-          : "l"(addr) : "memory"); \
+                     : "=" RegCode_for_size_##PackSize(reg.native) \
+                     : "l"(addr) \
+                     : "memory"); \
       } \
       BytePack<PackSize> ans; \
       ans.native = reg.native; \
@@ -1182,77 +1270,92 @@ struct Apply_PostOp<FuncSumPostDiv<T>, /*EltPerPack=*/1> {
   };
 
 #define DEFINE_Apply_LoadMultimem_sum_v4(T, ptx_ty, VecEltSize) \
-  template<> \
-  struct Apply_LoadMultimem<FuncSum<T>, 4*(VecEltSize)> { \
-    static constexpr int PackSize = 4*(VecEltSize); \
+  template <> \
+  struct Apply_LoadMultimem<FuncSum<T>, 4 * (VecEltSize)> { \
+    static constexpr int PackSize = 4 * (VecEltSize); \
     __device__ __forceinline__ static BytePack<PackSize> load(FuncSum<T> fn, uintptr_t addr) { \
-      union { BytePack<PackSize> ans; BytePack<VecEltSize> elts[4]; }; \
-      asm volatile("multimem.ld_reduce.relaxed.sys.global.add" PtxAcc_for_##ptx_ty ".v4." #ptx_ty " {%0,%1,%2,%3}, [%4];" \
-        : "=" RegCode_for_size_##VecEltSize(elts[0].native), \
-          "=" RegCode_for_size_##VecEltSize(elts[1].native), \
-          "=" RegCode_for_size_##VecEltSize(elts[2].native), \
-          "=" RegCode_for_size_##VecEltSize(elts[3].native) \
-        : "l"(addr) : "memory"); \
+      union { \
+        BytePack<PackSize> ans; \
+        BytePack<VecEltSize> elts[4]; \
+      }; \
+      asm volatile( \
+        "multimem.ld_reduce.relaxed.sys.global.add" PtxAcc_for_##ptx_ty ".v4." #ptx_ty " {%0,%1,%2,%3}, [%4];" \
+        : "=" RegCode_for_size_##VecEltSize(elts[0].native), "=" RegCode_for_size_##VecEltSize(elts[1].native), \
+          "=" RegCode_for_size_##VecEltSize(elts[2].native), "=" RegCode_for_size_##VecEltSize(elts[3].native) \
+        : "l"(addr) \
+        : "memory"); \
       return ans; \
     } \
   };
 #define DEFINE_Apply_LoadMultimem_minmax_v4(T, ptx_ty, VecEltSize) \
-  template<> \
-  struct Apply_LoadMultimem<FuncMinMax<T>, 4*(VecEltSize)> { \
-    static constexpr int PackSize = 4*(VecEltSize); \
+  template <> \
+  struct Apply_LoadMultimem<FuncMinMax<T>, 4 * (VecEltSize)> { \
+    static constexpr int PackSize = 4 * (VecEltSize); \
     __device__ __forceinline__ static BytePack<PackSize> load(FuncMinMax<T> fn, uintptr_t addr) { \
-      union { BytePack<PackSize> ans; BytePack<VecEltSize> elts[4]; }; \
+      union { \
+        BytePack<PackSize> ans; \
+        BytePack<VecEltSize> elts[4]; \
+      }; \
       if (fn.isMinNotMax) { \
         asm volatile("multimem.ld_reduce.relaxed.sys.global.min.v4." #ptx_ty " {%0,%1,%2,%3}, [%4];" \
-          : "=" RegCode_for_size_##VecEltSize(elts[0].native), \
-            "=" RegCode_for_size_##VecEltSize(elts[1].native), \
-            "=" RegCode_for_size_##VecEltSize(elts[2].native), \
-            "=" RegCode_for_size_##VecEltSize(elts[3].native) \
-          : "l"(addr) : "memory"); \
+                     : "=" RegCode_for_size_##VecEltSize(elts[0].native), \
+                       "=" RegCode_for_size_##VecEltSize(elts[1].native), \
+                       "=" RegCode_for_size_##VecEltSize(elts[2].native), \
+                       "=" RegCode_for_size_##VecEltSize(elts[3].native) \
+                     : "l"(addr) \
+                     : "memory"); \
       } else { \
         asm volatile("multimem.ld_reduce.relaxed.sys.global.max.v4." #ptx_ty " {%0,%1,%2,%3}, [%4];" \
-          : "=" RegCode_for_size_##VecEltSize(elts[0].native), \
-            "=" RegCode_for_size_##VecEltSize(elts[1].native), \
-            "=" RegCode_for_size_##VecEltSize(elts[2].native), \
-            "=" RegCode_for_size_##VecEltSize(elts[3].native) \
-          : "l"(addr) : "memory"); \
+                     : "=" RegCode_for_size_##VecEltSize(elts[0].native), \
+                       "=" RegCode_for_size_##VecEltSize(elts[1].native), \
+                       "=" RegCode_for_size_##VecEltSize(elts[2].native), \
+                       "=" RegCode_for_size_##VecEltSize(elts[3].native) \
+                     : "l"(addr) \
+                     : "memory"); \
       } \
       return ans; \
     } \
   };
 
 #define DEFINE_Apply_LoadMultimem_sum_v4_and_xparts(T, ptx_ty, VecEltSize) \
-  DEFINE_Apply_LoadMultimem_sum_v4(T, ptx_ty, VecEltSize) \
-  template<> \
+  DEFINE_Apply_LoadMultimem_sum_v4(T, ptx_ty, VecEltSize) template <> \
   struct Apply_LoadMultimem<FuncSum<T>, sizeof(T)> { \
     __device__ __forceinline__ static BytePack<sizeof(T)> load(FuncSum<T> fn, uintptr_t addr) { \
-      union { BytePack<VecEltSize> tmp; BytePack<sizeof(T)> elts[(VecEltSize)/sizeof(T)]; }; \
+      union { \
+        BytePack<VecEltSize> tmp; \
+        BytePack<sizeof(T)> elts[(VecEltSize) / sizeof(T)]; \
+      }; \
       asm volatile("multimem.ld_reduce.relaxed.sys.global.add" PtxAcc_for_##ptx_ty "." #ptx_ty " %0, [%1];" \
-        : "=" RegCode_for_size_##VecEltSize(tmp.native) \
-        : "l"(addr & -uintptr_t(VecEltSize)) : "memory"); \
-      return elts[(addr/sizeof(T))%((VecEltSize)/sizeof(T))]; \
+                   : "=" RegCode_for_size_##VecEltSize(tmp.native) \
+                   : "l"(addr & -uintptr_t(VecEltSize)) \
+                   : "memory"); \
+      return elts[(addr / sizeof(T)) % ((VecEltSize) / sizeof(T))]; \
     } \
   };
 #define DEFINE_Apply_LoadMultimem_minmax_v4_and_xparts(T, ptx_ty, VecEltSize) \
-  DEFINE_Apply_LoadMultimem_minmax_v4(T, ptx_ty, VecEltSize) \
-  template<> \
+  DEFINE_Apply_LoadMultimem_minmax_v4(T, ptx_ty, VecEltSize) template <> \
   struct Apply_LoadMultimem<FuncMinMax<T>, sizeof(T)> { \
     __device__ __forceinline__ static BytePack<sizeof(T)> load(FuncMinMax<T> fn, uintptr_t addr) { \
-      union { BytePack<VecEltSize> tmp; BytePack<sizeof(T)> elts[(VecEltSize)/sizeof(T)]; }; \
+      union { \
+        BytePack<VecEltSize> tmp; \
+        BytePack<sizeof(T)> elts[(VecEltSize) / sizeof(T)]; \
+      }; \
       if (fn.isMinNotMax) { \
         asm volatile("multimem.ld_reduce.relaxed.sys.global.min." #ptx_ty " %0, [%1];" \
-          : "=" RegCode_for_size_##VecEltSize(tmp.native) \
-          : "l"(addr & -uintptr_t(VecEltSize)) : "memory"); \
+                     : "=" RegCode_for_size_##VecEltSize(tmp.native) \
+                     : "l"(addr & -uintptr_t(VecEltSize)) \
+                     : "memory"); \
       } else { \
         asm volatile("multimem.ld_reduce.relaxed.sys.global.max." #ptx_ty " %0, [%1];" \
-          : "=" RegCode_for_size_##VecEltSize(tmp.native) \
-          : "l"(addr & -uintptr_t(VecEltSize)) : "memory"); \
+                     : "=" RegCode_for_size_##VecEltSize(tmp.native) \
+                     : "l"(addr & -uintptr_t(VecEltSize)) \
+                     : "memory"); \
       } \
-      return elts[(addr/sizeof(T))%((VecEltSize)/sizeof(T))]; \
+      return elts[(addr / sizeof(T)) % ((VecEltSize) / sizeof(T))]; \
     } \
   };
 
-template<typename Fn, int BytePerPack>
+template <typename Fn, int BytePerPack>
 struct Apply_LoadMultimem {
   __device__ __forceinline__ static BytePack<BytePerPack> load(Fn fn, uintptr_t addr) {
     //__trap();
@@ -1261,74 +1364,68 @@ struct Apply_LoadMultimem {
 };
 
 #if __CUDA_ARCH__ >= 900 && CUDART_VERSION >= 12010
-  template<typename Fn>
-  struct LoadMultimem_BigPackSize {
-    using T = typename Fn::EltType;
-    static constexpr bool IsSum = std::is_same<Fn, FuncSum<T>>::value ||
-                                  std::is_same<Fn, FuncPreMulSum<T>>::value ||
-                                  std::is_same<Fn, FuncSumPostDiv<T>>::value;
-    static constexpr bool IsMinMax = std::is_same<Fn, FuncMinMax<T>>::value;
-    static constexpr bool IsFloat = IsFloatingPoint<T>::value;
-    static constexpr int BigPackSize =
-      IsFloat && IsSum && sizeof(T) < 8 ? 16 :
-      IsFloat && IsSum ? sizeof(T) :
-      IsFloat && IsMinMax && sizeof(T)==2 ? 16 :
-      !IsFloat && (IsSum||IsMinMax) && sizeof(T)>=4 ? sizeof(T) :
-      /*multimem.ld_reduce not supported:*/ 0;
-  };
+template <typename Fn>
+struct LoadMultimem_BigPackSize {
+  using T = typename Fn::EltType;
+  static constexpr bool IsSum = std::is_same<Fn, FuncSum<T>>::value || std::is_same<Fn, FuncPreMulSum<T>>::value ||
+                                std::is_same<Fn, FuncSumPostDiv<T>>::value;
+  static constexpr bool IsMinMax = std::is_same<Fn, FuncMinMax<T>>::value;
+  static constexpr bool IsFloat = IsFloatingPoint<T>::value;
+  static constexpr int BigPackSize = IsFloat && IsSum && sizeof(T) < 8     ? 16 :
+                                     IsFloat && IsSum                      ? sizeof(T) :
+                                     IsFloat && IsMinMax && sizeof(T) == 2 ? 16 :
+                                     !IsFloat && (IsSum || IsMinMax) && sizeof(T) >= 4 ?
+                                                                             sizeof(T) :
+                                                                             /*multimem.ld_reduce not supported:*/ 0;
+};
 
-  DEFINE_Apply_LoadMultimem_sum(uint32_t, u32, 4)
-  DEFINE_Apply_LoadMultimem_minmax(uint32_t, u32, 4)
+DEFINE_Apply_LoadMultimem_sum(uint32_t, u32, 4) DEFINE_Apply_LoadMultimem_minmax(uint32_t, u32, 4)
 
-  DEFINE_Apply_LoadMultimem_sum(int32_t, s32, 4)
-  DEFINE_Apply_LoadMultimem_minmax(int32_t, s32, 4)
+  DEFINE_Apply_LoadMultimem_sum(int32_t, s32, 4) DEFINE_Apply_LoadMultimem_minmax(int32_t, s32, 4)
 
-  DEFINE_Apply_LoadMultimem_sum(uint64_t, u64, 8)
-  DEFINE_Apply_LoadMultimem_minmax(uint64_t, u64, 8)
+    DEFINE_Apply_LoadMultimem_sum(uint64_t, u64, 8) DEFINE_Apply_LoadMultimem_minmax(uint64_t, u64, 8)
 
-  DEFINE_Apply_LoadMultimem_sum(int64_t, u64, 8)
-  DEFINE_Apply_LoadMultimem_minmax(int64_t, s64, 8)
+      DEFINE_Apply_LoadMultimem_sum(int64_t, u64, 8) DEFINE_Apply_LoadMultimem_minmax(int64_t, s64, 8)
 
-  DEFINE_Apply_LoadMultimem_sum(float, f32, 4)
-  DEFINE_Apply_LoadMultimem_sum_v4(float, f32, 4)
+        DEFINE_Apply_LoadMultimem_sum(float, f32, 4) DEFINE_Apply_LoadMultimem_sum_v4(float, f32, 4)
 
-  DEFINE_Apply_LoadMultimem_sum(double, f64, 8)
+          DEFINE_Apply_LoadMultimem_sum(double, f64, 8)
 
-  DEFINE_Apply_LoadMultimem_sum_v4_and_xparts(half, f16x2, 4)
-  DEFINE_Apply_LoadMultimem_minmax_v4_and_xparts(half, f16x2, 4)
+            DEFINE_Apply_LoadMultimem_sum_v4_and_xparts(half, f16x2, 4)
+              DEFINE_Apply_LoadMultimem_minmax_v4_and_xparts(half, f16x2, 4)
+#if defined(RCCL_BFLOAT16)
+                DEFINE_Apply_LoadMultimem_sum_v4_and_xparts(hip_bfloat16, bf16x2, 4)
+                  DEFINE_Apply_LoadMultimem_minmax_v4_and_xparts(hip_bfloat16, bf16x2, 4)
+#endif
 
-  #if defined(RCCL_BFLOAT16)
-    DEFINE_Apply_LoadMultimem_sum_v4_and_xparts(hip_bfloat16, bf16x2, 4)
-    DEFINE_Apply_LoadMultimem_minmax_v4_and_xparts(hip_bfloat16, bf16x2, 4)
-  #endif
-
-  #if defined(RCCL_BFLOAT16)
-    #if NCCL_CUDA_ARCH_SPECIFIC == 1000 || NCCL_CUDA_ARCH_SPECIFIC == 1010 || NCCL_CUDA_ARCH_FAMILY_SPECIFIC == 1000 || NCCL_CUDA_ARCH_FAMILY_SPECIFIC == 1010 || NCCL_CUDA_ARCH_SPECIFIC == 1200 || NCCL_CUDA_ARCH_SPECIFIC == 1210
-      DEFINE_Apply_LoadMultimem_sum_v4_and_xparts(__nv_fp8_e4m3, e4m3x4, 4)
-      DEFINE_Apply_LoadMultimem_minmax_v4_and_xparts(__nv_fp8_e4m3, e4m3x4, 4)
-      DEFINE_Apply_LoadMultimem_sum_v4_and_xparts(__nv_fp8_e5m2, e5m2x4, 4)
-      DEFINE_Apply_LoadMultimem_minmax_v4_and_xparts(__nv_fp8_e5m2, e5m2x4, 4)
-    #else
-      DEFINE_Apply_LoadMultimem_sum_v4_and_xparts(rccl_float8, e4m3x4, 4)
-      DEFINE_Apply_LoadMultimem_minmax_v4_and_xparts(rccl_float8, e4m3x4, 4)
-      DEFINE_Apply_LoadMultimem_sum_v4_and_xparts(rccl_bfloat8, e5m2x4, 4)
-      DEFINE_Apply_LoadMultimem_minmax_v4_and_xparts(rccl_bfloat8, e5m2x4, 4)
-    #endif
-  #endif
+#if defined(RCCL_BFLOAT16)
+#if NCCL_CUDA_ARCH_SPECIFIC == 1000 || NCCL_CUDA_ARCH_SPECIFIC == 1010 || NCCL_CUDA_ARCH_FAMILY_SPECIFIC == 1000 || \
+  NCCL_CUDA_ARCH_FAMILY_SPECIFIC == 1010 || NCCL_CUDA_ARCH_SPECIFIC == 1200 || NCCL_CUDA_ARCH_SPECIFIC == 1210
+                    DEFINE_Apply_LoadMultimem_sum_v4_and_xparts(__nv_fp8_e4m3, e4m3x4, 4)
+                      DEFINE_Apply_LoadMultimem_minmax_v4_and_xparts(__nv_fp8_e4m3, e4m3x4, 4)
+                        DEFINE_Apply_LoadMultimem_sum_v4_and_xparts(__nv_fp8_e5m2, e5m2x4, 4)
+                          DEFINE_Apply_LoadMultimem_minmax_v4_and_xparts(__nv_fp8_e5m2, e5m2x4, 4)
+#else
+                    DEFINE_Apply_LoadMultimem_sum_v4_and_xparts(rccl_float8, e4m3x4, 4)
+                      DEFINE_Apply_LoadMultimem_minmax_v4_and_xparts(rccl_float8, e4m3x4, 4)
+                        DEFINE_Apply_LoadMultimem_sum_v4_and_xparts(rccl_bfloat8, e5m2x4, 4)
+                          DEFINE_Apply_LoadMultimem_minmax_v4_and_xparts(rccl_bfloat8, e5m2x4, 4)
+#endif
+#endif
 
   // FuncSumPostDiv multimem: load with FuncSum (add)
-  template<typename T, int PackSize>
+  template <typename T, int PackSize>
   struct Apply_LoadMultimem<FuncSumPostDiv<T>, PackSize> {
-    static constexpr int EltPerPack = PackSize / (int)sizeof(T);
-    __device__ __forceinline__ static BytePack<PackSize> load(FuncSumPostDiv<T> fn, uintptr_t addr) {
-      return Apply_LoadMultimem<FuncSum<T>, PackSize>::load(FuncSum<T>(), addr);
-    }
-  };
+  static constexpr int EltPerPack = PackSize / (int)sizeof(T);
+  __device__ __forceinline__ static BytePack<PackSize> load(FuncSumPostDiv<T> fn, uintptr_t addr) {
+    return Apply_LoadMultimem<FuncSum<T>, PackSize>::load(FuncSum<T>(), addr);
+  }
+};
 #else
-  template<typename Fn>
-  struct LoadMultimem_BigPackSize {
-    static constexpr int BigPackSize = 0;
-  };
+template <typename Fn>
+struct LoadMultimem_BigPackSize {
+  static constexpr int BigPackSize = 0;
+};
 #endif
 
 #undef DEFINE_Apply_LoadMultimem

--- a/projects/rccl/src/device/reduce_scatter.h
+++ b/projects/rccl/src/device/reduce_scatter.h
@@ -10,209 +10,209 @@
 #include "primitives.h"
 
 namespace {
-  template<typename T, typename RedOp, typename Proto>
+template <typename T, typename RedOp, typename Proto>
 #if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
-  __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
+__device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
 #else
-  __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
+__device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
 #endif
     // Step 0: Setup
-    size_t msgSize = work->count * sizeof(T) * ncclShmem.comm.nRanks;
-    if (work->enableDirectReduceScatter &&
-        msgSize <= (size_t)work->directReduceScatterLimitBytes) {
-
-      const int nRanks = ncclShmem.comm.nRanks;
-      const ssize_t numElements = work->count;
+  size_t msgSize = work->count * sizeof(T) * ncclShmem.comm.nRanks;
+  if (work->enableDirectReduceScatter && msgSize <= (size_t)work->directReduceScatterLimitBytes) {
+    const int nRanks = ncclShmem.comm.nRanks;
+    const ssize_t numElements = work->count;
 
       // Calculate Offset to utilize multiple channels
-      ssize_t elementsPerBlock = numElements / gridDim.x;
-      ssize_t remainderElements = numElements % gridDim.x;
+    ssize_t elementsPerBlock = numElements / gridDim.x;
+    ssize_t remainderElements = numElements % gridDim.x;
       // Calculate the number of elements per block for each block
       // The first n blocks get 1 extra element to account for the remainder (n = remainderElements)
-      ssize_t numElementsPerBlock = elementsPerBlock + (blockIdx.x < remainderElements ? 1 : 0);
-      ssize_t channelOffset = blockIdx.x * elementsPerBlock + min((ssize_t)blockIdx.x, remainderElements);
+    ssize_t numElementsPerBlock = elementsPerBlock + (blockIdx.x < remainderElements ? 1 : 0);
+    ssize_t channelOffset = blockIdx.x * elementsPerBlock + min((ssize_t)blockIdx.x, remainderElements);
 
-      T* recvbuff = (T*)work->recvbuff;
-      T* dst = recvbuff + channelOffset;
-      constexpr int MaxSrcs = 64;
+    T* recvbuff = (T*)work->recvbuff;
+    T* dst = recvbuff + channelOffset;
+    constexpr int MaxSrcs = 64;
 
-      void** srcPtrs = (void**)ncclScratchForWarp(0);
+    void** srcPtrs = (void**)ncclScratchForWarp(0);
 
       // Step 1: Reduce first MaxSrcs ranks directly into recvbuff
+    if (tid == 0) {
+      int srcIdx = 0;
+      for (int r = 0; r < min(nRanks, MaxSrcs); r++) {
+        srcPtrs[srcIdx++] = (void*)((T*)work->tempBuff + r * numElements + channelOffset);
+      }
+    }
+    __syncthreads();
+
+    void* dstPtrs[1] = {(void*)dst};
+    if (tid < nthreads) {
+      reduceCopy<COLL_UNROLL, USE_ACC, RedOp, T, 0, 1, MaxSrcs, 0, 1, 1, 0>(tid, nthreads,
+                                                                            ncclShmem.groups[0].redOpArgs, false,
+                                                                            min(nRanks, MaxSrcs), srcPtrs, 1, dstPtrs,
+                                                                            numElementsPerBlock);
+    }
+    __syncthreads();
+
+      // Step 2: For remaining ranks, reduce in batches accumulating into recvbuff
+    int firstBatch = min(nRanks, MaxSrcs);
+    int remaining = nRanks - firstBatch;
+    int startRank = firstBatch;
+    while (remaining > 0) {
+      int ranksThisPass = min(remaining, MaxSrcs - 1);
       if (tid == 0) {
         int srcIdx = 0;
-        for (int r = 0; r < min(nRanks, MaxSrcs); r++) {
+        srcPtrs[srcIdx++] = (void*)dst; // carry forward previous sum from recvbuff
+        for (int r = startRank; r < startRank + ranksThisPass; r++) {
           srcPtrs[srcIdx++] = (void*)((T*)work->tempBuff + r * numElements + channelOffset);
         }
       }
       __syncthreads();
 
-      void* dstPtrs[1] = { (void*)dst };
+      int nSrcs = ranksThisPass + 1;
+      dstPtrs[0] = (void*)dst;
       if (tid < nthreads) {
-        reduceCopy<COLL_UNROLL, USE_ACC, RedOp, T,
-                  0, 1, MaxSrcs, 0, 1, 1, 0>
-          (tid, nthreads, ncclShmem.groups[0].redOpArgs,
-          false, min(nRanks, MaxSrcs), srcPtrs, 1, dstPtrs, numElementsPerBlock);
+        reduceCopy<COLL_UNROLL, USE_ACC, RedOp, T, 0, 1, MaxSrcs, 0, 1, 1, 0>(
+          tid, nthreads, ncclShmem.groups[0].redOpArgs, false, nSrcs, srcPtrs, 1, dstPtrs, numElementsPerBlock);
       }
       __syncthreads();
 
-      // Step 2: For remaining ranks, reduce in batches accumulating into recvbuff
-      int firstBatch = min(nRanks, MaxSrcs);
-      int remaining = nRanks - firstBatch;
-      int startRank = firstBatch;
-      while (remaining > 0) {
-        int ranksThisPass = min(remaining, MaxSrcs - 1);
-        if (tid == 0) {
-          int srcIdx = 0;
-          srcPtrs[srcIdx++] = (void*)dst; // carry forward previous sum from recvbuff
-          for (int r = startRank; r < startRank + ranksThisPass; r++) {
-            srcPtrs[srcIdx++] = (void*)((T*)work->tempBuff + r * numElements + channelOffset);
-          }
-        }
-        __syncthreads();
-
-        int nSrcs = ranksThisPass + 1;
-        dstPtrs[0] = (void*)dst;
-        if (tid < nthreads) {
-          reduceCopy<COLL_UNROLL, USE_ACC, RedOp, T,
-                    0, 1, MaxSrcs, 0, 1, 1, 0>
-            (tid, nthreads, ncclShmem.groups[0].redOpArgs,
-            false, nSrcs, srcPtrs, 1, dstPtrs, numElementsPerBlock);
-        }
-        __syncthreads();
-
-        remaining -= ranksThisPass;
-        startRank += ranksThisPass;
-      }
-    } else {
-  #ifdef ENABLE_WARP_SPEED
-      int warp = threadIdx.x / WARP_SIZE;
-      ncclRing *ring = ncclShmem.warpComm
-          ? &ncclShmem.warpChannel[warp].ring
-          : &ncclShmem.channel.ring;
-  #else
-      ncclRing *ring = &ncclShmem.channel.ring;
-  #endif
-      int const *ringRanks = ring->userRanks;
-      const int nranks = ncclShmem.comm.nRanks; 
-      size_t count;
-      size_t gridOffset;
-      size_t channelCount;
-      size_t chunkCount;
-  #ifdef ENABLE_WARP_SPEED
-      ncclCollCbdPart(work, ncclShmem.warpChannelId[warp], Proto::Id, sizeof(T), &count, &gridOffset, &channelCount, &chunkCount);
-  #else
-      ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &count, &gridOffset, &channelCount, &chunkCount);
-  #endif
-      size_t offset;
-      size_t dataOffset;
-      uint32_t nelem;
-      int rankDest;
+      remaining -= ranksThisPass;
+      startRank += ranksThisPass;
+    }
+  } else {
+#ifdef ENABLE_WARP_SPEED
+    int warp = threadIdx.x / WARP_SIZE;
+    ncclRing* ring = ncclShmem.warpComm ? &ncclShmem.warpChannel[warp].ring : &ncclShmem.channel.ring;
+#else
+    ncclRing* ring = &ncclShmem.channel.ring;
+#endif
+    int const* ringRanks = ring->userRanks;
+    const int nranks = ncclShmem.comm.nRanks;
+    size_t count;
+    size_t gridOffset;
+    size_t channelCount;
+    size_t chunkCount;
+#ifdef ENABLE_WARP_SPEED
+    ncclCollCbdPart(work, ncclShmem.warpChannelId[warp], Proto::Id, sizeof(T), &count, &gridOffset, &channelCount,
+                    &chunkCount);
+#else
+    ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &count, &gridOffset, &channelCount, &chunkCount);
+#endif
+    size_t offset;
+    size_t dataOffset;
+    uint32_t nelem;
+    int rankDest;
 
       // Coverity reports that the callee treats &ring->next as an array.  However, due to the use of
       // FanSymmetric<1>, only the first element is ever accessed, so it's fine.
       // coverity[callee_ptr_arith:FALSE]
-      Primitives<T, RedOp, FanSymmetric<1>, 0, Proto, 0, false, 0, Pipeline>
-        prims(tid, nthreads, &ring->prev, &ring->next, work->sendbuff, work->recvbuff, work->redOpArg, 0, work->connIndex, work->connIndex);
+    Primitives<T, RedOp, FanSymmetric<1>, 0, Proto, 0, false, 0, Pipeline> prims(tid, nthreads, &ring->prev,
+                                                                                 &ring->next, work->sendbuff,
+                                                                                 work->recvbuff, work->redOpArg, 0,
+                                                                                 work->connIndex, work->connIndex);
 
-      for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
-        nelem = min(chunkCount, channelCount - elemOffset);
+    for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
+      nelem = min(chunkCount, channelCount - elemOffset);
 
-        dataOffset = gridOffset + elemOffset;
+      dataOffset = gridOffset + elemOffset;
         /////////////// begin ReduceScatter steps ///////////////
         // step 0: push data to next GPU
-        rankDest = ringRanks[nranks-1];
-        offset = dataOffset + rankDest * count;
-        prims.send(offset, nelem);
+      rankDest = ringRanks[nranks - 1];
+      offset = dataOffset + rankDest * count;
+      prims.send(offset, nelem);
         // k-2 steps: reduce and copy to next GPU
-        for (int j=2; j<nranks; ++j) {
-          rankDest = ringRanks[nranks-j];
-          offset = dataOffset + rankDest * count;
-          prims.recvReduceSend(offset, nelem);
-        }
+      for (int j = 2; j < nranks; ++j) {
+        rankDest = ringRanks[nranks - j];
+        offset = dataOffset + rankDest * count;
+        prims.recvReduceSend(offset, nelem);
+      }
 
         // step k-1: reduce this buffer and data, which will produce the final result
-        rankDest = ringRanks[0];
-        offset = dataOffset + rankDest * count;
-        prims.recvReduceCopy(offset, dataOffset, nelem, /*postOp=*/true);
-      }
+      rankDest = ringRanks[0];
+      offset = dataOffset + rankDest * count;
+      prims.recvReduceCopy(offset, dataOffset, nelem, /*postOp=*/true);
     }
   }
 }
+} // namespace
 
 #if defined(__gfx942__)  // Use a single slice per simple primitive for a single node on some GFX9 devices.
 #define rcclReduceScatterRunRingSimpleProtoImpl(tid, nthreads, work) \
-  if(work->rcclUseOneSlice){ \
-    using Proto = ProtoSimple<REDUCESCATTER_CHUNKSTEPS/REDUCESCATTER_SLICESTEPS_SINGLE_NODE, REDUCESCATTER_SLICESTEPS_SINGLE_NODE>; \
+  if (work->rcclUseOneSlice) { \
+    using Proto = ProtoSimple<REDUCESCATTER_CHUNKSTEPS / REDUCESCATTER_SLICESTEPS_SINGLE_NODE, \
+                              REDUCESCATTER_SLICESTEPS_SINGLE_NODE>; \
     runRing<T, RedOp, Proto>(tid, nthreads, work); \
-  } else{ \
-    using Proto = ProtoSimple<REDUCESCATTER_CHUNKSTEPS/REDUCESCATTER_SLICESTEPS, REDUCESCATTER_SLICESTEPS>; \
+  } else { \
+    using Proto = ProtoSimple<REDUCESCATTER_CHUNKSTEPS / REDUCESCATTER_SLICESTEPS, REDUCESCATTER_SLICESTEPS>; \
     runRing<T, RedOp, Proto>(tid, nthreads, work); \
   }
 #elif defined(__gfx950__)
 #define rcclReduceScatterRunRingSimpleProtoImpl(tid, nthreads, work) \
-  if(work->rcclUseOneSlice){ \
-    using Proto = ProtoSimple<1,1>; \
+  if (work->rcclUseOneSlice) { \
+    using Proto = ProtoSimple<1, 1>; \
     runRing<T, RedOp, Proto>(tid, nthreads, work); \
-  } else{ \
-    using Proto = ProtoSimple<REDUCESCATTER_CHUNKSTEPS/REDUCESCATTER_SLICESTEPS, REDUCESCATTER_SLICESTEPS>; \
+  } else { \
+    using Proto = ProtoSimple<REDUCESCATTER_CHUNKSTEPS / REDUCESCATTER_SLICESTEPS, REDUCESCATTER_SLICESTEPS>; \
     runRing<T, RedOp, Proto>(tid, nthreads, work); \
   }
 #else
 #define rcclReduceScatterRunRingSimpleProtoImpl(tid, nthreads, work) \
-  using Proto = ProtoSimple<REDUCESCATTER_CHUNKSTEPS/REDUCESCATTER_SLICESTEPS, REDUCESCATTER_SLICESTEPS>; \
+  using Proto = ProtoSimple<REDUCESCATTER_CHUNKSTEPS / REDUCESCATTER_SLICESTEPS, REDUCESCATTER_SLICESTEPS>; \
   runRing<T, RedOp, Proto>(tid, nthreads, work);
 #endif
 
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPLE> {
   __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
     rcclReduceScatterRunRingSimpleProtoImpl(tid, nthreads, work);
   }
 };
 
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL> {
   __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
     runRing<T, RedOp, ProtoLL>(tid, nthreads, work);
   }
 };
 
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL128> {
   __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
     runRing<T, RedOp, ProtoLL128>(tid, nthreads, work);
   }
 };
 
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_PAT, NCCL_PROTO_SIMPLE> {
   __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
     using Proto = ProtoSimple<1, 1>;
     const int nranks = ncclShmem.comm.nRanks;
     const int rank = ncclShmem.comm.rank;
     size_t count, channelOffset, channelCount, chunkCount;
-    ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &count, &channelOffset, &channelCount, &chunkCount);
+    ncclCollCbdPart(work, ncclShmem.channelId, Proto::Id, sizeof(T), &count, &channelOffset, &channelCount,
+                    &chunkCount);
 
     static constexpr int nworkers = NCCL_PAT_NWORKERS;
     struct ncclPatShmem* shmem = (struct ncclPatShmem*)ncclScratchForWarp(0);
-    //uint64_t pollCount = 0; unused variable - compiler warning
+    // uint64_t pollCount = 0; unused variable - compiler warning
     __syncthreads(); // Don't start using shared mem until everyone arrives
-    for (int i=tid; i<NCCL_SHMEM_PAT_STEPS; i+=nthreads) shmem->patSteps[i].flags = 0;
+    for (int i = tid; i < NCCL_SHMEM_PAT_STEPS; i += nthreads) shmem->patSteps[i].flags = 0;
     if (tid == 0) shmem->localAccSize = 0;
     if (tid == nworkers) shmem->parallelFactor = 0;
     __syncthreads();
 
     if (tid == nworkers) { // Algo computation thread
-      PatRSAlgorithm<T> patAlgo(chunkCount*sizeof(T), NCCL_STEPS, NCCL_PAT_NWORKERS/WARP_SIZE, channelOffset, channelOffset + channelCount, count, chunkCount, rank, nranks);
+      PatRSAlgorithm<T> patAlgo(chunkCount * sizeof(T), NCCL_STEPS, NCCL_PAT_NWORKERS / WARP_SIZE, channelOffset,
+                                channelOffset + channelCount, count, chunkCount, rank, nranks);
       int parallelFactor = shmem->parallelFactor = patAlgo.getParallelFactor();
       (void)parallelFactor;// unused variable - compiler warning
       int step = 0;
       while (1) {
-        struct ncclPatStep* ps = shmem->patSteps+(step%NCCL_SHMEM_PAT_STEPS);
+        struct ncclPatStep* ps = shmem->patSteps + (step % NCCL_SHMEM_PAT_STEPS);
         int* poll = &ps->flags;
-        while (__hip_atomic_load(poll, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_WORKGROUP) != 0){
-          //pollCount++;// unused variable - compiler warning // Wait for workers to be done with step 'step-NCCL_SHMEM_PAT_STEPS'
+        while (__hip_atomic_load(poll, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_WORKGROUP) != 0) {
+          // pollCount++;// unused variable - compiler warning // Wait for workers to be done with step 'step-NCCL_SHMEM_PAT_STEPS'
         }
         patAlgo.getNextOp(ps);
         int last = ps->last;
@@ -220,30 +220,33 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_PAT, NCCL_PROTO_SI
         if (last == 2) break;
       }
     } else if (tid < nworkers) { // Worker threads
-      T *inputBuf = (T*)work->sendbuff;
-      T *outputBuf = (T*)work->recvbuff;
+      T* inputBuf = (T*)work->sendbuff;
+      T* outputBuf = (T*)work->recvbuff;
       int parallelFactor = 0;
       volatile int* pfPtr = &shmem->parallelFactor;
       while (parallelFactor == 0) parallelFactor = *pfPtr;
 
-      int groupSize = nworkers/(WARP_SIZE*parallelFactor) * WARP_SIZE;
+      int groupSize = nworkers / (WARP_SIZE * parallelFactor) * WARP_SIZE;
       int group = tid / groupSize;
       int nGroups = nworkers / groupSize;
-      int tidInGroup = tid - group*groupSize;
+      int tidInGroup = tid - group * groupSize;
       // We don't use recvPeers/sendPeers so let's pass shmem structs instead
-      Primitives<T, RedOp, FanSymmetric<1>, 0, Proto, 0, false, 0, Pipeline> prims
-        (tidInGroup, groupSize, (int*)shmem->recvDims, (int*)shmem->sendDims, inputBuf, outputBuf, work->redOpArg, group, 0, 0, nullptr, nullptr, 0, primsModePatRs);
+      Primitives<T, RedOp, FanSymmetric<1>, 0, Proto, 0, false, 0, Pipeline> prims(
+        tidInGroup, groupSize, (int*)shmem->recvDims, (int*)shmem->sendDims, inputBuf, outputBuf, work->redOpArg, group,
+        0, 0, nullptr, nullptr, 0, primsModePatRs);
 
       int step = group;
-      while(1) {
-        struct ncclPatStep* ps = shmem->patSteps+(step%NCCL_SHMEM_PAT_STEPS);
+      while (1) {
+        struct ncclPatStep* ps = shmem->patSteps + (step % NCCL_SHMEM_PAT_STEPS);
         int* poll = &ps->flags;
         while (__hip_atomic_load(poll, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_WORKGROUP) == 0) {
-          //pollCount++; // unused variable - compiler warning // Wait for compute thread
+          // pollCount++; // unused variable - compiler warning // Wait for compute thread
         }
         int last = ps->last;
         prims.patReduce(ps, shmem);
-        if (tidInGroup == 0) __hip_atomic_store(poll, 0, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_WORKGROUP); // Return element to compute thread
+        if (tidInGroup == 0)
+          __hip_atomic_store(poll, 0, __ATOMIC_RELEASE,
+                             __HIP_MEMORY_SCOPE_WORKGROUP); // Return element to compute thread
         if (last) break;
         step += nGroups;
       }
@@ -251,19 +254,18 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_PAT, NCCL_PROTO_SI
   }
 };
 
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_SIMPLE> {
-  template<bool ReduceSendNotRecv>
+  template <bool ReduceSendNotRecv>
   struct Scatterer {
     struct ncclDevWorkColl* work;
     int chunkCount;
     ssize_t railGridOffset;
 
-    template<int SlicePerChunk, int MinSrcs, int MaxSrcs, int MinDsts, int MaxDsts, int MultimemSrcs, int MultimemDsts>
-    __device__ __forceinline__ void operator()(
-        int tid, int tn, int slice, int maxSliceSize,
-        int nSrcs, void** srcPtrs, int nDsts, void** dstPtrs, int32_t* dstSizes, uint32_t sendDirectFlag, uint32_t recvDirectFlag
-      ) {
+    template <int SlicePerChunk, int MinSrcs, int MaxSrcs, int MinDsts, int MaxDsts, int MultimemSrcs, int MultimemDsts>
+    __device__ __forceinline__ void operator()(int tid, int tn, int slice, int maxSliceSize, int nSrcs, void** srcPtrs,
+                                               int nDsts, void** dstPtrs, int32_t* dstSizes, uint32_t sendDirectFlag,
+                                               uint32_t recvDirectFlag) {
       static_assert(SlicePerChunk == 1, "require: SlicePerChunk==1");
       static_assert(MaxDsts <= 1 || MaxSrcs <= 1, "require: MaxDsts<=1 || MaxSrcs<=1");
 
@@ -299,18 +301,17 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_S
           ssize_t userOneBeg = rank * countPerRank + railOneOffset;
           if (nDsts != 0) {
             reduceCopy<ncclCollUnroll(), USE_ACC, RedOp, T,
-              /*MultimemSrcs=*/MultimemSrcs, 1, 1 + MaxSrcs,
-              /*MultimemDsts,MinDsts,MaxDsts=*/MultimemDsts, 1, 1,
-              /*PreOpSrcs=*/1>
-              (tid, tn, work->redOpArg, false,
-                /*nSrcs=*/nSrcs, [=]__device__(int s) {
-              return work->regUsed ? (T*)srcPtrs[s] + userOneBeg :
-                !ReduceSendNotRecv ? (T*)srcPtrs[s] + railAllOffset:
-                (T*)inbuf + userOneBeg;
-            },
-                /*nDsts=*/1, [=]__device__(int d/*==0*/) {
-              return (T*)dstPtrs[dst] + railAllOffset;
-            }, delta);
+                       /*MultimemSrcs=*/MultimemSrcs, 1, 1 + MaxSrcs,
+                       /*MultimemDsts,MinDsts,MaxDsts=*/MultimemDsts, 1, 1,
+                       /*PreOpSrcs=*/1>(
+              tid, tn, work->redOpArg, false,
+              /*nSrcs=*/nSrcs,
+              [=] __device__(int s) {
+                return work->regUsed      ? (T*)srcPtrs[s] + userOneBeg :
+                       !ReduceSendNotRecv ? (T*)srcPtrs[s] + railAllOffset :
+                                            (T*)inbuf + userOneBeg;
+              },
+              /*nDsts=*/1, [=] __device__(int d /*==0*/) { return (T*)dstPtrs[dst] + railAllOffset; }, delta);
           }
           railAllOffset += delta;
           node += 1;
@@ -321,14 +322,14 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_S
     }
   };
 
-  __device__ __forceinline__ void run(int tid, int/*nthreads*/, struct ncclDevWorkColl* work) {
+  __device__ __forceinline__ void run(int tid, int /*nthreads*/, struct ncclDevWorkColl* work) {
     struct ncclNvls* nvls = &ncclShmem.channel.nvls;
     int nelem;
 
     /* if we are direct NVLS, we only need to allocate 1 warp to scatter for sync;
      * if not, based on #ranks, we allocate 7 or 5 warps to reduce to saturate bandwidth
      * and the rest are allocated to scatter. */
-    const int nThreadsNetRecv = work->oneNode ? 0 : (work->netRegUsed ? WARP_SIZE :  6 * WARP_SIZE);
+    const int nThreadsNetRecv = work->oneNode ? 0 : (work->netRegUsed ? WARP_SIZE : 6 * WARP_SIZE);
     const int nThreadsScatter = work->regUsed ? roundUp(nvls->nHeads << 2, WARP_SIZE) : 8 * WARP_SIZE;
     const int nThreadsReduce = NCCL_MAX_NTHREADS - nThreadsNetRecv - nThreadsScatter;
     const int tidEndNetRecv = nThreadsNetRecv;
@@ -339,14 +340,14 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_S
       const int rank = ncclShmem.comm.rank;
       size_t offset;
       size_t count, gridOffset, channelCount, chunkCount;
-      ncclCollCbdPart(work, ncclShmem.channelId, NCCL_PROTO_SIMPLE, sizeof(T), &count, &gridOffset, &channelCount, &chunkCount);
+      ncclCollCbdPart(work, ncclShmem.channelId, NCCL_PROTO_SIMPLE, sizeof(T), &count, &gridOffset, &channelCount,
+                      &chunkCount);
       if (!work->regUsed) {
         if (tid < tidEndScatter) {
           // Scatter
           using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL>;
-          Primitives<T, RedOp, FanAsymmetric<0, NCCL_MAX_NVLS_ARITY>, /*Direct=*/0, Proto, 0>
-            prims(tid, nThreadsScatter, NULL, nvls->up, work->sendbuff, NULL,
-              work->redOpArg, 0 * Proto::MaxGroupWidth, 1, 1);
+          Primitives<T, RedOp, FanAsymmetric<0, NCCL_MAX_NVLS_ARITY>, /*Direct=*/0, Proto, 0> prims(
+            tid, nThreadsScatter, NULL, nvls->up, work->sendbuff, NULL, work->redOpArg, 0 * Proto::MaxGroupWidth, 1, 1);
           for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
             offset = gridOffset + elemOffset;
             nelem = min(chunkCount, channelCount - elemOffset);
@@ -356,9 +357,10 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_S
         } else if (tid < tidEndReduce) {
           // Reduce through NVLS
           using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL, 1, 0>;
-          Primitives<T, RedOp, FanAsymmetric<1, 0>, /*Direct=*/0, Proto, 0>
-            prims(tid - tidEndScatter, nThreadsReduce, &nvls->down, NULL, NULL, work->recvbuff,
-              work->redOpArg, 3 * Proto::MaxGroupWidth, 0, 0);
+          Primitives<T, RedOp, FanAsymmetric<1, 0>, /*Direct=*/0, Proto, 0> prims(tid - tidEndScatter, nThreadsReduce,
+                                                                                  &nvls->down, NULL, NULL,
+                                                                                  work->recvbuff, work->redOpArg,
+                                                                                  3 * Proto::MaxGroupWidth, 0, 0);
           for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
             offset = gridOffset + elemOffset;
             nelem = min(chunkCount, channelCount - elemOffset);
@@ -369,9 +371,8 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_S
         if (tid < tidEndScatter) {
           // Scatter
           using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL>;
-          Primitives<T, RedOp, FanSymmetric<NCCL_MAX_NVLS_ARITY>, /*Direct=*/0, Proto, 0>
-            prims(tid, nThreadsScatter, nvls->up, nvls->up, NULL, NULL,
-              work->redOpArg, 0 * Proto::MaxGroupWidth, 1, 1);
+          Primitives<T, RedOp, FanSymmetric<NCCL_MAX_NVLS_ARITY>, /*Direct=*/0, Proto, 0> prims(
+            tid, nThreadsScatter, nvls->up, nvls->up, NULL, NULL, work->redOpArg, 0 * Proto::MaxGroupWidth, 1, 1);
           for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
             prims.scatter(0, 0, 0, 0, -1, 0);
           }
@@ -381,9 +382,10 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_S
         } else if (tid < tidEndReduce) {
           // Reduce through NVLS
           using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL, 1, 0>;
-          Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0>
-            prims(tid - tidEndScatter, nThreadsReduce, &nvls->down, &nvls->down, NULL, work->recvbuff,
-              work->redOpArg, 3 * Proto::MaxGroupWidth, 0, 0, work);
+          Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0> prims(tid - tidEndScatter, nThreadsReduce,
+                                                                              &nvls->down, &nvls->down, NULL,
+                                                                              work->recvbuff, work->redOpArg,
+                                                                              3 * Proto::MaxGroupWidth, 0, 0, work);
           for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
             size_t outOffset = gridOffset + elemOffset;
             size_t inpOffset = outOffset + rank * count;
@@ -414,10 +416,12 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_S
           }
           __syncwarp();
         } else {
-          Primitives<T, RedOp, FanAsymmetric<1, 0>, /*Direct=*/0, Proto, 0>
-            prims(tid, nThreadsNetRecv, &nvls->out, nullptr, nullptr, work->recvbuff,
-              work->redOpArg, 0 * Proto::MaxGroupWidth, 0, 0);
-          for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank; railGridOffset += nChannels * chunkCount) {
+          Primitives<T, RedOp, FanAsymmetric<1, 0>, /*Direct=*/0, Proto, 0> prims(tid, nThreadsNetRecv, &nvls->out,
+                                                                                  nullptr, nullptr, work->recvbuff,
+                                                                                  work->redOpArg,
+                                                                                  0 * Proto::MaxGroupWidth, 0, 0);
+          for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank;
+               railGridOffset += nChannels * chunkCount) {
             ssize_t railAllBeg = railGridOffset + part * chunkCount;
             ssize_t railAllEnd = min(railAllBeg + chunkCount, nNodes * countPerRank);
             ssize_t railOneBeg = ncclShmem.comm.node * countPerRank;
@@ -430,10 +434,11 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_S
       } else {
         if (tid < tidEndScatter) {
           using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL>;
-          Primitives<T, RedOp, FanAsymmetric<0, NCCL_MAX_NVLS_ARITY>, /*Direct=*/1, Proto, 0>
-            prims(tid - tidEndNetRecv, nThreadsScatter, nullptr, nvls->up, work->sendbuff, nullptr,
-              work->redOpArg, 1 * Proto::MaxGroupWidth, 1, 1, work);
-          for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank; railGridOffset += nChannels * chunkCount) {
+          Primitives<T, RedOp, FanAsymmetric<0, NCCL_MAX_NVLS_ARITY>, /*Direct=*/1, Proto, 0> prims(
+            tid - tidEndNetRecv, nThreadsScatter, nullptr, nvls->up, work->sendbuff, nullptr, work->redOpArg,
+            1 * Proto::MaxGroupWidth, 1, 1, work);
+          for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank;
+               railGridOffset += nChannels * chunkCount) {
             Scatterer</*ReduceSendNotRecv=*/true> scat;
             scat.work = work;
             scat.chunkCount = chunkCount;
@@ -442,10 +447,12 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_S
           }
         } else if (tid < tidEndReduce) {
           using Proto = ProtoSimple<1, 1, USE_ACC, COLL_UNROLL, 1, 0>;
-          Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0>
-            prims(tid - tidEndScatter, nThreadsReduce, &nvls->down, &nvls->out, nullptr, nullptr,
-              work->redOpArg, 2 * Proto::MaxGroupWidth, 0, 1, work);
-          for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank; railGridOffset += nChannels * chunkCount) {
+          Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0> prims(tid - tidEndScatter, nThreadsReduce,
+                                                                              &nvls->down, &nvls->out, nullptr, nullptr,
+                                                                              work->redOpArg, 2 * Proto::MaxGroupWidth,
+                                                                              0, 1, work);
+          for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank;
+               railGridOffset += nChannels * chunkCount) {
             Scatterer</*ReduceSendNotRecv=*/false> scat;
             scat.work = work;
             scat.chunkCount = chunkCount;
@@ -458,21 +465,20 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_NVLS, NCCL_PROTO_S
   }
 };
 
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NCCL_PROTO_SIMPLE> {
-  template<bool ReduceSendNotRecv>
+  template <bool ReduceSendNotRecv>
   struct Scatterer {
     struct ncclDevWorkColl* work;
     int chunkSize;
     ssize_t railGridOffset;
 
-    template<int SlicePerChunk, int MinSrcs, int MaxSrcs, int MinDsts, int MaxDsts, int MultimemSrcs, int MultimemDsts>
-    __device__ __forceinline__ void operator()(
-        int tid, int tn, int slice, int maxSliceSize,
-        int nSrcs, void** srcPtrs, int nDsts, void** dstPtrs, int32_t* dstSizes, uint32_t sendDirectFlag, uint32_t recvDirectFlag
-      ) {
-      static_assert(SlicePerChunk==1, "require: SlicePerChunk==1");
-      static_assert(MaxDsts<=1 || MaxSrcs<=1, "require: MaxDsts<=1 || MaxSrcs<=1");
+    template <int SlicePerChunk, int MinSrcs, int MaxSrcs, int MinDsts, int MaxDsts, int MultimemSrcs, int MultimemDsts>
+    __device__ __forceinline__ void operator()(int tid, int tn, int slice, int maxSliceSize, int nSrcs, void** srcPtrs,
+                                               int nDsts, void** dstPtrs, int32_t* dstSizes, uint32_t sendDirectFlag,
+                                               uint32_t recvDirectFlag) {
+      static_assert(SlicePerChunk == 1, "require: SlicePerChunk==1");
+      static_assert(MaxDsts <= 1 || MaxSrcs <= 1, "require: MaxDsts<=1 || MaxSrcs<=1");
 
       struct ncclDirect* direct = &ncclShmem.channel.collnetDirect;
       int nNodes = ncclShmem.comm.nNodes;
@@ -481,8 +487,8 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NC
       void* inbuf = (void*)work->sendbuff;
       ssize_t countPerRank = work->collnet.count;
 
-      ssize_t railAllBeg = min(railGridOffset + part*chunkSize, nNodes*countPerRank);
-      ssize_t railAllEnd = min(railAllBeg + chunkSize, nNodes*countPerRank);
+      ssize_t railAllBeg = min(railGridOffset + part * chunkSize, nNodes * countPerRank);
+      ssize_t railAllEnd = min(railAllBeg + chunkSize, nNodes * countPerRank);
       int railAllSize = railAllEnd - railAllBeg;
       if (tid < nDsts) dstSizes[tid] = railAllSize;
 
@@ -491,35 +497,32 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NC
       if (!ReduceSendNotRecv) {
         rail = direct->headRank;
       } else {
-        rail = direct->headRank+1;
+        rail = direct->headRank + 1;
         if (rail == nRails) rail = 0;
       }
       do {
-        int node = railAllBeg/countPerRank;
+        int node = railAllBeg / countPerRank;
         int railAllOffset = 0;
         while (railAllOffset < railAllSize) {
-          ssize_t railOneBeg = node*countPerRank;
+          ssize_t railOneBeg = node * countPerRank;
           ssize_t railOneEnd = railOneBeg + countPerRank;
-          ssize_t railOneOffset = (railAllBeg+railAllOffset) - railOneBeg;
-          int delta = min(railAllEnd, railOneEnd) - (railAllBeg+railAllOffset);
-          int rank = ncclShmem.comm.collNetDenseToUserRank[node*nRails + rail];
-          ssize_t userOneBeg = rank*countPerRank + railOneOffset;
+          ssize_t railOneOffset = (railAllBeg + railAllOffset) - railOneBeg;
+          int delta = min(railAllEnd, railOneEnd) - (railAllBeg + railAllOffset);
+          int rank = ncclShmem.comm.collNetDenseToUserRank[node * nRails + rail];
+          ssize_t userOneBeg = rank * countPerRank + railOneOffset;
           if (nDsts != 0) {
             reduceCopy<ncclCollUnroll(), USE_ACC, RedOp, T,
-                     /*MultimemSrcs=*/0, 1+MinSrcs, 1+MaxSrcs,
-                     /*MultimemDsts,MinDsts,MaxDsts=*/0,1,1,
-                     /*PreOpSrcs=*/1>
-            (tid, tn, work->redOpArg, false,
-             /*nSrcs=*/1+nSrcs, [=]__device__(int s) {
-               return s==0 ? (T*)inbuf + userOneBeg
-                           : work->regUsed && (recvDirectFlag & NCCL_P2P_READ)
-                           ? (T*)srcPtrs[s-1] + userOneBeg
-                           : (T*)srcPtrs[s-1] + railAllOffset;
-             },
-             /*nDsts=*/1, [=]__device__(int d/*==0*/) {
-               return (T*)dstPtrs[dst] + railAllOffset;
-             },
-             delta);
+                       /*MultimemSrcs=*/0, 1 + MinSrcs, 1 + MaxSrcs,
+                       /*MultimemDsts,MinDsts,MaxDsts=*/0, 1, 1,
+                       /*PreOpSrcs=*/1>(
+              tid, tn, work->redOpArg, false,
+              /*nSrcs=*/1 + nSrcs,
+              [=] __device__(int s) {
+                return s == 0                                            ? (T*)inbuf + userOneBeg :
+                       work->regUsed && (recvDirectFlag & NCCL_P2P_READ) ? (T*)srcPtrs[s - 1] + userOneBeg :
+                                                                           (T*)srcPtrs[s - 1] + railAllOffset;
+              },
+              /*nDsts=*/1, [=] __device__(int d /*==0*/) { return (T*)dstPtrs[dst] + railAllOffset; }, delta);
           }
           railAllOffset += delta;
           node += 1;
@@ -527,7 +530,7 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NC
         dst += 1;
         rail += 1;
         if (rail == nRails) rail = 0;
-      } while (ReduceSendNotRecv && dst < nRails-1);
+      } while (ReduceSendNotRecv && dst < nRails - 1);
     }
   };
 
@@ -535,7 +538,7 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NC
     const int part = ncclShmem.channelId - work->channelLo;
     const int nChannels = work->channelHi - work->channelLo + 1;
     struct ncclDirect* direct = &ncclShmem.channel.collnetDirect;
-    int const &nNodes = ncclShmem.comm.nNodes;
+    int const& nNodes = ncclShmem.comm.nNodes;
     ssize_t chunkSize = int(work->collnet.chunkCount);
     ssize_t countPerRank = work->collnet.count;
     const int hasDn = (direct->down[0] >= 0) ? 1 : 0;
@@ -545,20 +548,20 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NC
     int nWarps1 = (isMultiRail ? 2 : 0);
     int nWarps2 = (isMultiRail ? 2 : 1);
     int nWarps3 = 1;
-    float denom = float(work->nWarps)/float(nWarps1+nWarps2+nWarps3);
-    nWarps3 = int(denom*nWarps3);
-    nWarps2 = int(denom*nWarps2);
-    nWarps1 = work->nWarps - (nWarps2+nWarps3);
+    float denom = float(work->nWarps) / float(nWarps1 + nWarps2 + nWarps3);
+    nWarps3 = int(denom * nWarps3);
+    nWarps2 = int(denom * nWarps2);
+    nWarps1 = work->nWarps - (nWarps2 + nWarps3);
 
     using Proto = ProtoSimple<1, 1>;
 
-    int tn = nWarps1*WARP_SIZE;
+    int tn = nWarps1 * WARP_SIZE;
     if (tid < tn) {
       // Phase 1: Scatter inputs to peers
-      Primitives<T, RedOp, FanAsymmetric<0, NCCL_MAX_DIRECT_ARITY>, /*Direct=*/0, Proto, 0>
-        prims(tid, tn, nullptr, direct->heads+1, work->sendbuff, nullptr,
-              work->redOpArg, 0*Proto::MaxGroupWidth, 1, 1);
-      for (ssize_t railGridOffset=0; railGridOffset < nNodes*countPerRank; railGridOffset += nChannels*chunkSize) {
+      Primitives<T, RedOp, FanAsymmetric<0, NCCL_MAX_DIRECT_ARITY>, /*Direct=*/0, Proto, 0> prims(
+        tid, tn, nullptr, direct->heads + 1, work->sendbuff, nullptr, work->redOpArg, 0 * Proto::MaxGroupWidth, 1, 1);
+      for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank;
+           railGridOffset += nChannels * chunkSize) {
         Scatterer</*ReduceSendNotRecv=*/true> scat;
         scat.work = work;
         scat.chunkSize = chunkSize;
@@ -569,19 +572,20 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NC
     }
     tid -= tn;
 
-    tn = nWarps2*WARP_SIZE;
+    tn = nWarps2 * WARP_SIZE;
     if (tid < tn) {
       if (work->netRegUsed && !hasDn) {
         if (tid == 0) {
-          Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_DIRECT_ARITY, 1>, /*Direct=*/0, Proto, 0>::sendPeerNotify(direct->out, 1, 1);
+          Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_DIRECT_ARITY, 1>, /*Direct=*/0, Proto, 0>::sendPeerNotify(
+            direct->out, 1, 1);
         }
         __syncwarp();
       } else {
         // Phase 2: Reduce from peers + local input -> send to network
-        Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_DIRECT_ARITY, 1>, /*Direct=*/0, Proto, 0>
-          prims(tid, tn, direct->heads + 1, &direct->out, nullptr, nullptr,
-            work->redOpArg, 1 * Proto::MaxGroupWidth, 1, 1);
-        for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank; railGridOffset += nChannels * chunkSize) {
+        Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_DIRECT_ARITY, 1>, /*Direct=*/0, Proto, 0> prims(
+          tid, tn, direct->heads + 1, &direct->out, nullptr, nullptr, work->redOpArg, 1 * Proto::MaxGroupWidth, 1, 1);
+        for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank;
+             railGridOffset += nChannels * chunkSize) {
           Scatterer</*ReduceSendNotRecv=*/false> scat;
           scat.work = work;
           scat.chunkSize = chunkSize;
@@ -593,7 +597,7 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NC
     }
     tid -= tn;
 
-    tn = nWarps3*WARP_SIZE;
+    tn = nWarps3 * WARP_SIZE;
     if (tid < tn) {
       if (work->netRegUsed) {
         if (tid == 0) {
@@ -603,10 +607,10 @@ struct RunWorkColl<ncclFuncReduceScatter, T, RedOp, NCCL_ALGO_COLLNET_DIRECT, NC
         __syncwarp();
       } else {
         // Phase 3: recv from network
-        Primitives<T, RedOp, FanAsymmetric<1, 0>, /*Direct=*/0, Proto, 0>
-          prims(tid, tn, &direct->out, nullptr, nullptr, work->recvbuff,
-            work->redOpArg, 2 * Proto::MaxGroupWidth, 0, 0);
-        for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank; railGridOffset += nChannels * chunkSize) {
+        Primitives<T, RedOp, FanAsymmetric<1, 0>, /*Direct=*/0, Proto, 0> prims(
+          tid, tn, &direct->out, nullptr, nullptr, work->recvbuff, work->redOpArg, 2 * Proto::MaxGroupWidth, 0, 0);
+        for (ssize_t railGridOffset = 0; railGridOffset < nNodes * countPerRank;
+             railGridOffset += nChannels * chunkSize) {
           ssize_t railAllBeg = railGridOffset + part * chunkSize;
           ssize_t railAllEnd = min(railAllBeg + chunkSize, nNodes * countPerRank);
           ssize_t railOneBeg = ncclShmem.comm.node * countPerRank;

--- a/projects/rccl/src/device/sendrecv.h
+++ b/projects/rccl/src/device/sendrecv.h
@@ -9,100 +9,99 @@
 #include "collectives.h"
 #include "primitives.h"
 
-template<typename T, typename RedOp>
+template <typename T, typename RedOp>
 struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPLE> {
-  static_assert(sizeof(T)==1, "SendRecv only works on single byte types T.");
+  static_assert(sizeof(T) == 1, "SendRecv only works on single byte types T.");
 
-  template<typename Proto>
+  template <typename Proto>
   __device__ void runSend(int tid, int tn, int group, struct ncclDevWorkP2p* work) {
     size_t bytes = work->sendBytes;
     bool useLargeChunk = (work->sendIpcReg && ncclShmem.comm.isAllNvlink) || work->sendNetReg;
     int chunkSize = useLargeChunk ? NCCL_MAX_NET_SIZE : u32fp8Decode(work->sendChunkSize_u32fp8);
     int stepSize = useLargeChunk ? NCCL_MAX_NET_SIZE : ncclShmem.comm.p2pChunkSize;
 
-    Primitives<T, RedOp, FanAsymmetric<0, 1>, /*Direct=*/1, Proto, 1>
-      prims(tid, tn, nullptr, &work->sendRank, work->sendAddr, nullptr,
-            /*redOpArg(ignored)=*/0, group, work->sendConnIndex, work->sendConnIndex, nullptr, work, stepSize);
+    Primitives<T, RedOp, FanAsymmetric<0, 1>, /*Direct=*/1, Proto, 1> prims(
+      tid, tn, nullptr, &work->sendRank, work->sendAddr, nullptr,
+      /*redOpArg(ignored)=*/0, group, work->sendConnIndex, work->sendConnIndex, nullptr, work, stepSize);
 
     size_t cursor = 0;
     do {
-      int n = min(size_t(chunkSize), bytes-cursor);
+      int n = min(size_t(chunkSize), bytes - cursor);
       prims.directSend(cursor, cursor, n);
       cursor += n;
     } while (cursor < bytes);
-
   }
 
-  template<typename Proto>
+  template <typename Proto>
   __device__ void runRecv(int tid, int tn, int group, struct ncclDevWorkP2p* work) {
     size_t bytes = work->recvBytes;
     bool useLargeChunk = (work->recvIpcReg && ncclShmem.comm.isAllNvlink) || work->recvNetReg;
     int chunkSize = useLargeChunk ? NCCL_MAX_NET_SIZE : u32fp8Decode(work->recvChunkSize_u32fp8);
     int stepSize = useLargeChunk ? NCCL_MAX_NET_SIZE : ncclShmem.comm.p2pChunkSize;
 
-    Primitives<T, RedOp, FanAsymmetric<1, 0>, /*Direct=*/1, Proto, 1>
-      prims(tid, tn, &work->recvRank, nullptr, nullptr, work->recvAddr,
-            /*redOpArg(ignored)=*/0, group, work->recvConnIndex, work->recvConnIndex, nullptr, work, stepSize);
+    Primitives<T, RedOp, FanAsymmetric<1, 0>, /*Direct=*/1, Proto, 1> prims(
+      tid, tn, &work->recvRank, nullptr, nullptr, work->recvAddr,
+      /*redOpArg(ignored)=*/0, group, work->recvConnIndex, work->recvConnIndex, nullptr, work, stepSize);
 
     size_t cursor = 0;
     do {
-      int n = min(size_t(chunkSize), bytes-cursor);
+      int n = min(size_t(chunkSize), bytes - cursor);
       prims.directRecv(cursor, n);
       cursor += n;
     } while (cursor < bytes);
-
   }
 
 #if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
-  __device__  void run() {
+  __device__ void run(){
 #else
-  __device__  __attribute__((noinline)) void run() {
+  __device__ __attribute__((noinline)) void run() {
 #endif
     const int tid = threadIdx.x;
-    const int tn = blockDim.x;
-    const int wid = tid/WARP_SIZE;
-    const int nWarps = tn/WARP_SIZE;
-    const int lane = tid%WARP_SIZE;
+  const int tn = blockDim.x;
+  const int wid = tid / WARP_SIZE;
+  const int nWarps = tn / WARP_SIZE;
+  const int lane = tid % WARP_SIZE;
 
-    struct Shared {
-      uint32_t workSendMask; // bitmasks of which work indices have send/recv
-      uint32_t workRecvMask;
-    };
-    Shared* shared = (Shared*)ncclScratchForWarp(0);
+  struct Shared {
+    uint32_t workSendMask; // bitmasks of which work indices have send/recv
+    uint32_t workRecvMask;
+  };
+  Shared* shared = (Shared*)ncclScratchForWarp(0);
 
-    struct ncclDevWorkP2p* works = (ncclDevWorkP2p*)ncclShmem.workStorage;
-    int nWorks = ncclShmem.nWorks;
+  struct ncclDevWorkP2p* works = (ncclDevWorkP2p*)ncclShmem.workStorage;
+  int nWorks = ncclShmem.nWorks;
 
-    if (wid == 0) {
+  if (wid == 0) {
       // Modify the memory range of each work[] to reflect this channel's
       // partition of the work. Since integer divides are very heavy it's
       // best to do them all in one warp.
-      int workIx = lane%16;
-      int isSend = lane < 16 ? 0 : 1;
-      bool hasWork = false;
-      if (workIx < nWorks) {
-        struct ncclDevWorkP2p* work = &works[workIx];
-        size_t bytes = isSend ? work->sendBytes : work->recvBytes;
-        int nParts = isSend ? work->nSendChannels : work->nRecvChannels;
-        int part = ncclP2pChannelToPart(work->nP2pChannels, work->channelBase, ncclShmem.channelId, ncclShmem.comm.p2pnChannelsPerPeer,
-          ncclShmem.comm.nNodes, ncclShmem.comm.p2pChannelShiftSize);
-        hasWork = (part < nParts);
-        if (nParts != 0) {
-          size_t partBeg, partEnd;
-          ncclP2pPartBounds(nParts, part, bytes, &partBeg, &partEnd);
-          (isSend ? work->sendAddr : work->recvAddr) = (char*)(isSend ? work->sendAddr : work->recvAddr) + partBeg;
-          (isSend ? work->sendBytes : work->recvBytes) = partEnd - partBeg;
-        }
+    int workIx = lane % 16;
+    int isSend = lane < 16 ? 0 : 1;
+    bool hasWork = false;
+    if (workIx < nWorks) {
+      struct ncclDevWorkP2p* work = &works[workIx];
+      size_t bytes = isSend ? work->sendBytes : work->recvBytes;
+      int nParts = isSend ? work->nSendChannels : work->nRecvChannels;
+      int part = ncclP2pChannelToPart(work->nP2pChannels, work->channelBase, ncclShmem.channelId,
+                                      ncclShmem.comm.p2pnChannelsPerPeer, ncclShmem.comm.nNodes,
+                                      ncclShmem.comm.p2pChannelShiftSize);
+      hasWork = (part < nParts);
+      if (nParts != 0) {
+        size_t partBeg, partEnd;
+        ncclP2pPartBounds(nParts, part, bytes, &partBeg, &partEnd);
+        (isSend ? work->sendAddr : work->recvAddr) = (char*)(isSend ? work->sendAddr : work->recvAddr) + partBeg;
+        (isSend ? work->sendBytes : work->recvBytes) = partEnd - partBeg;
       }
+    }
       // Coverity reports a possible thread divergence due to not all threads participating in the collective.
       // However, the code ensures that the participation is on a per-warp basis.
       // coverity[device_thread_diverged:FALSE]
-      uint32_t mask = __ballot(hasWork);
-      if (lane == 0) {
-        shared->workSendMask = mask>>16;
-        shared->workRecvMask = mask & 0xffff;
-      }
+    uint32_t mask = __ballot(hasWork);
+    if (lane == 0) {
+      shared->workSendMask = mask >> 16;
+      shared->workRecvMask = mask & 0xffff;
     }
+  }
 
     // The fastest way to compute a warp uniform division x/y in [0,32) is to
     // use each lane to guess a solution and count the ones that don't exceed
@@ -113,90 +112,91 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
     //   __float2int_rd(__fdividef(float(x),float(y))).
 
     // nWarpPerWork = nWarps/nWorks
-    int nWarpPerWork = __popcll(__ballot(nWorks*(lane+1) <= nWarps));
-    int nRecvWarpPerWork = nWarpPerWork/2;
-    int nSendWarpPerWork = nWarpPerWork - nRecvWarpPerWork;
+  int nWarpPerWork = __popcll(__ballot(nWorks * (lane + 1) <= nWarps));
+  int nRecvWarpPerWork = nWarpPerWork / 2;
+  int nSendWarpPerWork = nWarpPerWork - nRecvWarpPerWork;
     // This might reduce nWarpPerWork which is probably desirable. It is better
     // to have a balanced number of reading and writing threads even if that
     // leaves warps unused.
-    nWarpPerWork = nSendWarpPerWork + nRecvWarpPerWork;
+  nWarpPerWork = nSendWarpPerWork + nRecvWarpPerWork;
     // The work index this warp belongs to: workIx = wid/nWarpPerWork
-    int workIx = __popcll(__ballot((lane+1)*nWarpPerWork <= wid));
+  int workIx = __popcll(__ballot((lane + 1) * nWarpPerWork <= wid));
 
-    __syncthreads(); // Wait for works[] and shared->* to be updated by warp=0
+  __syncthreads(); // Wait for works[] and shared->* to be updated by warp=0
 
-    uint32_t workSendMask = shared->workSendMask;
-    uint32_t workRecvMask = shared->workRecvMask;
+  uint32_t workSendMask = shared->workSendMask;
+  uint32_t workRecvMask = shared->workRecvMask;
 
-    __syncthreads(); // release scratch space used by shared->*
-    if (nWorks <= workIx) return;
+  __syncthreads(); // release scratch space used by shared->*
+  if (nWorks <= workIx) return;
 
     // Thread range for whole work (send & recv combined)
-    int subtid = tid - workIx*nWarpPerWork*WARP_SIZE;
-    int subtn = nWarpPerWork*WARP_SIZE;
+  int subtid = tid - workIx * nWarpPerWork * WARP_SIZE;
+  int subtn = nWarpPerWork * WARP_SIZE;
 
     // A send primtive of sufficient size requires 2 cuda barrier ids.
-    constexpr int nSendWarpsForExtraGroup = NCCL_SIMPLE_EXTRA_GROUP_IF_NTHREADS_GE/WARP_SIZE;
+  constexpr int nSendWarpsForExtraGroup = NCCL_SIMPLE_EXTRA_GROUP_IF_NTHREADS_GE / WARP_SIZE;
     // Count up all group ids used below this workIx:
-    int group, extra;
+  int group, extra;
     // Each recv gets one group id:
-    group = __popcll(workRecvMask & ((1<<workIx)-1));
+  group = __popcll(workRecvMask & ((1 << workIx) - 1));
     // Sends accompanying recvs get one and maybe an extra:
-    extra = (nSendWarpPerWork >= nSendWarpsForExtraGroup) ? 1 : 0;
-    group += __popcll((workSendMask & workRecvMask) & ((1<<workIx)-1))*(1+extra);
+  extra = (nSendWarpPerWork >= nSendWarpsForExtraGroup) ? 1 : 0;
+  group += __popcll((workSendMask & workRecvMask) & ((1 << workIx) - 1)) * (1 + extra);
     // Sends without recvs use more warps so compute extra accordingly:
-    extra = (nWarpPerWork >= nSendWarpsForExtraGroup) ? 1 : 0;
-    group += __popcll((workSendMask & ~workRecvMask) & ((1<<workIx)-1))*(1+extra);
+  extra = (nWarpPerWork >= nSendWarpsForExtraGroup) ? 1 : 0;
+  group += __popcll((workSendMask & ~workRecvMask) & ((1 << workIx) - 1)) * (1 + extra);
 
-    struct ncclDevWorkP2p* work = &works[workIx];
-    bool hasSend = 1 & (workSendMask>>workIx);
-    bool hasRecv = 1 & (workRecvMask>>workIx);
-    bool isCopy = work->sendRank == ncclShmem.comm.rank;
-    bool isSend = !hasRecv || (hasSend && subtid < nSendWarpPerWork*WARP_SIZE);
+  struct ncclDevWorkP2p* work = &works[workIx];
+  bool hasSend = 1 & (workSendMask >> workIx);
+  bool hasRecv = 1 & (workRecvMask >> workIx);
+  bool isCopy = work->sendRank == ncclShmem.comm.rank;
+  bool isSend = !hasRecv || (hasSend && subtid < nSendWarpPerWork * WARP_SIZE);
 
-    if (!isCopy && hasSend && hasRecv) {
+  if (!isCopy && hasSend && hasRecv) {
       // Translate thread ids to reflect just this send or recv as opposed to whole work.
-      if (isSend) {
-        subtn = nSendWarpPerWork*WARP_SIZE;
-      } else {
-        subtid -= nSendWarpPerWork*WARP_SIZE;
-        subtn = nRecvWarpPerWork*WARP_SIZE;
-        group += 1 + (nSendWarpPerWork >= nSendWarpsForExtraGroup ? 1 : 0);
-      }
-    }
-
-    if (isCopy) {
-#if defined(__gfx942__) || defined(__gfx950__)
-      reduceCopy<COLL_UNROLL*2, 0, RedOp, T, 0,1,1, 0,1,1, /*PreOpSrcs=*/0>
-        (subtid, subtn, 0, false, 1, &work->sendAddr, 1, &work->recvAddr, (ssize_t)work->sendBytes);
-#else
-      reduceCopy<COLL_UNROLL, 0, RedOp, T, 0,1,1, 0,1,1, /*PreOpSrcs=*/0>
-        (subtid, subtn, 0, false, 1, &work->sendAddr, 1, &work->recvAddr, (ssize_t)work->sendBytes);
-#endif
-    } else if (isSend) {
-      if (work->sendProtoLL) {
-        runSend<ProtoLL>(subtid, subtn, group, work);
-      } else {
-#if defined(__gfx90a__)
-        runSend<ProtoSimple<1,1,0,8>>(subtid, subtn, group, work);
-#elif defined(__gfx908__) || defined(__gfx942__) || defined(__gfx950__)
-        runSend<ProtoSimple<1,1,0,4>>(subtid, subtn, group, work);
-#else
-        runSend<ProtoSimple<1,1>>(subtid, subtn, group, work);
-#endif
-      }
+    if (isSend) {
+      subtn = nSendWarpPerWork * WARP_SIZE;
     } else {
-      if (work->recvProtoLL) {
-        runRecv<ProtoLL>(subtid, subtn, group, work);
-      } else {
-#if defined(__gfx90a__)
-        runRecv<ProtoSimple<1,1,0,8>>(subtid, subtn, group, work);
-#elif defined(__gfx908__) || defined(__gfx942__) || defined(__gfx950__)
-        runRecv<ProtoSimple<1,1,0,4>>(subtid, subtn, group, work);
-#else
-        runRecv<ProtoSimple<1,1>>(subtid, subtn, group, work);
-#endif
-      }
+      subtid -= nSendWarpPerWork * WARP_SIZE;
+      subtn = nRecvWarpPerWork * WARP_SIZE;
+      group += 1 + (nSendWarpPerWork >= nSendWarpsForExtraGroup ? 1 : 0);
     }
   }
-};
+
+  if (isCopy) {
+#if defined(__gfx942__) || defined(__gfx950__)
+    reduceCopy<COLL_UNROLL * 2, 0, RedOp, T, 0, 1, 1, 0, 1, 1, /*PreOpSrcs=*/0>(
+      subtid, subtn, 0, false, 1, &work->sendAddr, 1, &work->recvAddr, (ssize_t)work->sendBytes);
+#else
+      reduceCopy<COLL_UNROLL, 0, RedOp, T, 0, 1, 1, 0, 1, 1, /*PreOpSrcs=*/0>(
+        subtid, subtn, 0, false, 1, &work->sendAddr, 1, &work->recvAddr, (ssize_t)work->sendBytes);
+#endif
+  } else if (isSend) {
+    if (work->sendProtoLL) {
+      runSend<ProtoLL>(subtid, subtn, group, work);
+    } else {
+#if defined(__gfx90a__)
+      runSend<ProtoSimple<1, 1, 0, 8>>(subtid, subtn, group, work);
+#elif defined(__gfx908__) || defined(__gfx942__) || defined(__gfx950__)
+        runSend<ProtoSimple<1, 1, 0, 4>>(subtid, subtn, group, work);
+#else
+      runSend<ProtoSimple<1, 1>>(subtid, subtn, group, work);
+#endif
+    }
+  } else {
+    if (work->recvProtoLL) {
+      runRecv<ProtoLL>(subtid, subtn, group, work);
+    } else {
+#if defined(__gfx90a__)
+      runRecv<ProtoSimple<1, 1, 0, 8>>(subtid, subtn, group, work);
+#elif defined(__gfx908__) || defined(__gfx942__) || defined(__gfx950__)
+        runRecv<ProtoSimple<1, 1, 0, 4>>(subtid, subtn, group, work);
+#else
+      runRecv<ProtoSimple<1, 1>>(subtid, subtn, group, work);
+#endif
+    }
+  }
+}
+}
+;

--- a/projects/rccl/src/device/symmetric/all_gather.cuh
+++ b/projects/rccl/src/device/symmetric/all_gather.cuh
@@ -1,33 +1,31 @@
 // Modification Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
-// SPDX-License-Identifier: MIT 
+// SPDX-License-Identifier: MIT
 
 #include "sym_kernels.h"
 #include "symmetric/kernel.h"
 #include "symmetric/primitives.h"
 
-template<int BytePerPack, int UnrollPacks, int UnrollPeers, bool EnableTma>
-static __device__ void bcastDeep(
-    ncclSymkArgsHandler const& handler, int tn, int t,
-    bool waitNeeded, ncclLsaBarrierSession<ncclCoopCta>& bar,
-    ncclSymPtr<char> input, ncclSymPtr<char> output, bool inPlace, int nIters
-  ) {
+template <int BytePerPack, int UnrollPacks, int UnrollPeers, bool EnableTma>
+static __device__ void bcastDeep(ncclSymkArgsHandler const& handler, int tn, int t, bool waitNeeded,
+                                 ncclLsaBarrierSession<ncclCoopCta>& bar, ncclSymPtr<char> input,
+                                 ncclSymPtr<char> output, bool inPlace, int nIters) {
   using Pack = BytePack<BytePerPack>;
-  int wn = tn/WARP_SIZE;
-  int w = t/WARP_SIZE;
-  int lane = t%WARP_SIZE;
+  int wn = tn / WARP_SIZE;
+  int w = t / WARP_SIZE;
+  int lane = t % WARP_SIZE;
   int const& rank = handler.comm.rank;
   int const& nRanks = handler.comm.nRanks;
-  constexpr size_t tileSize = UnrollPacks*WARP_SIZE*BytePerPack;
+  constexpr size_t tileSize = UnrollPacks * WARP_SIZE * BytePerPack;
 
-  Pack* inpPacks = (Pack*)input.localPtr() + intptr_t(w)*UnrollPacks*WARP_SIZE + (EnableTma ? 0 : lane);
-  ncclSymPtr<Pack> outPacks = (ncclSymPtr<Pack>)output + intptr_t(w)*UnrollPacks*WARP_SIZE + (EnableTma ? 0 : lane);
+  Pack* inpPacks = (Pack*)input.localPtr() + intptr_t(w) * UnrollPacks * WARP_SIZE + (EnableTma ? 0 : lane);
+  ncclSymPtr<Pack> outPacks = (ncclSymPtr<Pack>)output + intptr_t(w) * UnrollPacks * WARP_SIZE + (EnableTma ? 0 : lane);
   Pack tmp[UnrollPacks];
 
   int lw = threadIdx.x / WARP_SIZE;
   extern __shared__ char smemScratch[];
   using tmaSmemStruct_t = tmaSmemStruct<Pack, UnrollPacks>;
   constexpr int smemSizePerWarp = ncclTmaShmemScratchWarpSize();
-  tmaSmemStruct_t* tmaSmem = reinterpret_cast<tmaSmemStruct_t*>(smemScratch+lw*smemSizePerWarp);
+  tmaSmemStruct_t* tmaSmem = reinterpret_cast<tmaSmemStruct_t*>(smemScratch + lw * smemSizePerWarp);
   bool skip = false; // all lanes issue loads/stores
 
   if NCCL_IF_CONSTEXPR (EnableTma) {
@@ -46,12 +44,13 @@ static __device__ void bcastDeep(
       if (lane == 0) {
         cp_async_bulk_global_to_shared(tmaSmem->buff[0], inpPacks, &tmaSmem->bar, tileSize);
         __mbarrier_token_t token = barrier_arrive1_tx_relaxed(&tmaSmem->bar, tileSize);
-        while (!barrier_try_wait_token_relaxed(&tmaSmem->bar, token)) {}
+        while (!barrier_try_wait_token_relaxed(&tmaSmem->bar, token)) {
+        }
       }
     } else {
-      #pragma unroll
-      for (int u=0; u < UnrollPacks; u++) {
-        tmp[u] = inpPacks[u*WARP_SIZE];
+#pragma unroll
+      for (int u = 0; u < UnrollPacks; u++) {
+        tmp[u] = inpPacks[u * WARP_SIZE];
       }
     }
   }
@@ -63,21 +62,19 @@ static __device__ void bcastDeep(
       int dr = inPlace ? 1 : 0;
       int r = rank + dr;
       if (r == nRanks) r = 0;
-      #pragma unroll 2
-      for (int partial=0; partial <= 1 && !skip; partial++) {
-        #pragma unroll 1
-        for (int i = 0;
-             partial ? i < 1 : (dr + UnrollPeers <= nRanks);
-             partial ? i++ : (dr += UnrollPeers)) {
-          #pragma unroll
-          for (int ur=0; ur < UnrollPeers-partial; ur++) {
+#pragma unroll 2
+      for (int partial = 0; partial <= 1 && !skip; partial++) {
+#pragma unroll 1
+        for (int i = 0; partial ? i < 1 : (dr + UnrollPeers <= nRanks); partial ? i++ : (dr += UnrollPeers)) {
+#pragma unroll
+          for (int ur = 0; ur < UnrollPeers - partial; ur++) {
             if (partial && dr == nRanks) break;
             if NCCL_IF_CONSTEXPR (EnableTma) {
               cp_async_bulk_shared_to_global(outPacks.lsaPtr(r), tmaSmem->buff[0], tileSize);
             } else {
-              #pragma unroll UnrollPacks
-              for (int u=0; u < UnrollPacks; u++) {
-                outPacks.lsaPtr(r)[u*WARP_SIZE] = tmp[u];
+#pragma unroll UnrollPacks
+              for (int u = 0; u < UnrollPacks; u++) {
+                outPacks.lsaPtr(r)[u * WARP_SIZE] = tmp[u];
               }
             }
             if (++r == nRanks) r = 0;
@@ -90,144 +87,129 @@ static __device__ void bcastDeep(
           }
         }
       }
-      inpPacks += intptr_t(wn)*UnrollPacks*WARP_SIZE;
-      outPacks += intptr_t(wn)*UnrollPacks*WARP_SIZE;
+      inpPacks += intptr_t(wn) * UnrollPacks * WARP_SIZE;
+      outPacks += intptr_t(wn) * UnrollPacks * WARP_SIZE;
       nIters -= wn;
       if (nIters <= 0) break;
       if NCCL_IF_CONSTEXPR (EnableTma) {
         if (lane == 0) {
           cp_async_bulk_global_to_shared(tmaSmem->buff[0], inpPacks, &tmaSmem->bar, tileSize);
           __mbarrier_token_t token = barrier_arrive1_tx_relaxed(&tmaSmem->bar, tileSize);
-          while (!barrier_try_wait_token_relaxed(&tmaSmem->bar, token)) {}
+          while (!barrier_try_wait_token_relaxed(&tmaSmem->bar, token)) {
+          }
         }
       } else {
-        #pragma unroll
-        for (int u=0; u < UnrollPacks; u++) {
-          tmp[u] = inpPacks[u*WARP_SIZE];
+#pragma unroll
+        for (int u = 0; u < UnrollPacks; u++) {
+          tmp[u] = inpPacks[u * WARP_SIZE];
         }
       }
     }
   }
 }
 
-template<int UnrollPeers, typename T>
-static __device__ void bcastEnds(
-    ncclSymkArgsHandler const& handler, int tn, int t,
-    ncclSymPtr<T> input, ncclSymPtr<T> output, bool inPlace, size_t nElts, uint32_t nPreElts, size_t nSufElts
-  ) {
+template <int UnrollPeers, typename T>
+static __device__ void bcastEnds(ncclSymkArgsHandler const& handler, int tn, int t, ncclSymPtr<T> input,
+                                 ncclSymPtr<T> output, bool inPlace, size_t nElts, uint32_t nPreElts, size_t nSufElts) {
   int const& rank = handler.comm.rank;
   int const& nRanks = handler.comm.nRanks;
   BytePack<sizeof(T)>* inpPacks = (BytePack<sizeof(T)>*)input.localPtr();
   ncclSymPtr<BytePack<sizeof(T)>> outPacks = (ncclSymPtr<BytePack<sizeof(T)>>)output;
-  #pragma unroll 1
-  for (size_t i = t; i < nPreElts+nSufElts; i += tn) {
-    size_t elt = i < nPreElts ? i : nElts-nPreElts-nSufElts+i;
+#pragma unroll 1
+  for (size_t i = t; i < nPreElts + nSufElts; i += tn) {
+    size_t elt = i < nPreElts ? i : nElts - nPreElts - nSufElts + i;
     BytePack<sizeof(T)> tmp = inpPacks[elt];
     int dr = inPlace ? 1 : 0;
     int r = rank + dr;
     if (r == nRanks) r = 0;
-    #pragma unroll 1
+#pragma unroll 1
     for (; dr + UnrollPeers <= nRanks; dr += UnrollPeers) {
-      #pragma unroll UnrollPeers
-      for (int u=0; u < UnrollPeers; u++) {
+#pragma unroll UnrollPeers
+      for (int u = 0; u < UnrollPeers; u++) {
         outPacks.lsaPtr(r)[elt] = tmp;
         if (++r == nRanks) r = 0;
       }
     }
-    #pragma unroll UnrollPeers
-    for (int u=0; u < UnrollPeers; u++) {
-      if (dr+u == nRanks) break;
+#pragma unroll UnrollPeers
+    for (int u = 0; u < UnrollPeers; u++) {
+      if (dr + u == nRanks) break;
       outPacks.lsaPtr(r)[elt] = tmp;
       if (++r == nRanks) r = 0;
     }
   }
 }
 
-template<typename T, bool EnableTma>
-static __device__ void bcast(
-    ncclSymkArgsHandler const& handler, int tn, int t, int nBlocks,
-    bool waitNeeded, ncclLsaBarrierSession<ncclCoopCta>& bar,
-    ncclSymPtr<T> input, ncclSymPtr<T> output, size_t nElts
-  ) {
+template <typename T, bool EnableTma>
+static __device__ void bcast(ncclSymkArgsHandler const& handler, int tn, int t, int nBlocks, bool waitNeeded,
+                             ncclLsaBarrierSession<ncclCoopCta>& bar, ncclSymPtr<T> input, ncclSymPtr<T> output,
+                             size_t nElts) {
   bool inPlace = (input == output);
-  size_t nBytes = nElts*sizeof(T);
+  size_t nBytes = nElts * sizeof(T);
   uint32_t nBlocks_rcp32 = nccl::utility::idivRcp32_upto64(nBlocks);
 
   uint32_t alignment = uint32_t(input.offset - output.offset);
-  uint32_t nPreBytes = (EnableTma && alignment%256 == 0) ? (256 - input.offset)%256
-                                                         : (16 - input.offset)%16;
+  uint32_t nPreBytes = (EnableTma && alignment % 256 == 0) ? (256 - input.offset) % 256 : (16 - input.offset) % 16;
   nPreBytes = min((size_t)nPreBytes, nBytes);
   uintptr_t cursor = nPreBytes;
 
   constexpr int MinWarpPerBlock = 4;
 
-  if (alignment%16 == 0) {
+  if (alignment % 16 == 0) {
     constexpr int BytePerPack = 16, UnrollPacks = 4, UnrollPeers = 2;
-    constexpr int BytePerChunk = MinWarpPerBlock*UnrollPacks*WARP_SIZE*BytePerPack;
-    uint32_t chunks = (nBytes-cursor)/BytePerChunk;
+    constexpr int BytePerChunk = MinWarpPerBlock * UnrollPacks * WARP_SIZE * BytePerPack;
+    uint32_t chunks = (nBytes - cursor) / BytePerChunk;
     chunks -= imodFast32(chunks, nBlocks, nBlocks_rcp32);
     if (chunks != 0) {
-      uintptr_t cursorAfter = cursor + uintptr_t(chunks)*BytePerChunk;
-      bcastDeep<BytePerPack, UnrollPacks, UnrollPeers, EnableTma>(
-        handler, tn, t, waitNeeded, bar,
-        (ncclSymPtr<char>)input + cursor,
-        (ncclSymPtr<char>)output + cursor,
-        inPlace, chunks*MinWarpPerBlock
-      );
+      uintptr_t cursorAfter = cursor + uintptr_t(chunks) * BytePerChunk;
+      bcastDeep<BytePerPack, UnrollPacks, UnrollPeers, EnableTma>(handler, tn, t, waitNeeded, bar,
+                                                                  (ncclSymPtr<char>)input + cursor,
+                                                                  (ncclSymPtr<char>)output + cursor, inPlace,
+                                                                  chunks * MinWarpPerBlock);
       cursor = cursorAfter;
       waitNeeded = false;
     }
   }
 
-  if (sizeof(T) == 4 || (sizeof(T) < 4 && alignment%4 == 0)) {
+  if (sizeof(T) == 4 || (sizeof(T) < 4 && alignment % 4 == 0)) {
     constexpr int BytePerPack = 4, UnrollPacks = 4, UnrollPeers = 4;
-    constexpr int BytePerChunk = MinWarpPerBlock*UnrollPacks*WARP_SIZE*BytePerPack;
-    uint32_t chunks = (nBytes-cursor)/BytePerChunk;
+    constexpr int BytePerChunk = MinWarpPerBlock * UnrollPacks * WARP_SIZE * BytePerPack;
+    uint32_t chunks = (nBytes - cursor) / BytePerChunk;
     chunks -= imodFast32(chunks, nBlocks, nBlocks_rcp32);
     if (chunks != 0) {
-      uintptr_t cursorAfter = cursor + uintptr_t(chunks)*BytePerChunk;
+      uintptr_t cursorAfter = cursor + uintptr_t(chunks) * BytePerChunk;
       bcastDeep<(sizeof(T) <= BytePerPack ? BytePerPack : 0), UnrollPacks, UnrollPeers, false>(
-        handler, tn, t, waitNeeded, bar,
-        (ncclSymPtr<char>)input + cursor,
-        (ncclSymPtr<char>)output + cursor,
-        inPlace, chunks*MinWarpPerBlock
-      );
+        handler, tn, t, waitNeeded, bar, (ncclSymPtr<char>)input + cursor, (ncclSymPtr<char>)output + cursor, inPlace,
+        chunks * MinWarpPerBlock);
       cursor = cursorAfter;
       waitNeeded = false;
     }
   }
 
-  if (waitNeeded)
-    bar.wait(ncclCoopCta(), NCCL_MEM_ORDER_RELAXED);
+  if (waitNeeded) bar.wait(ncclCoopCta(), NCCL_MEM_ORDER_RELAXED);
 
   constexpr int UnrollPeers = 8;
-  size_t nSufElts = (nBytes-cursor)/sizeof(T);
-  bcastEnds<UnrollPeers>(handler, tn, t, input, output, inPlace, nElts, nPreBytes/sizeof(T), nSufElts);
+  size_t nSufElts = (nBytes - cursor) / sizeof(T);
+  bcastEnds<UnrollPeers>(handler, tn, t, input, output, inPlace, nElts, nPreBytes / sizeof(T), nSufElts);
 }
 
-template<bool EnableTma>
+template <bool EnableTma>
 __device__ __forceinline__ void ncclSymkRun_AllGather_ST_impl(ncclSymkDevWorkArgs const* args) {
   ncclSymkArgsHandler handler{args};
-  ncclLsaBarrierSession<ncclCoopCta> bar{
-    ncclCoopCta(), handler.comm, ncclTeamTagLsa(), blockIdx.x
-  };
+  ncclLsaBarrierSession<ncclCoopCta> bar{ncclCoopCta(), handler.comm, ncclTeamTagLsa(), blockIdx.x};
   int const& rank = handler.comm.rank;
 
   bar.arrive(ncclCoopCta(), NCCL_MEM_ORDER_RELAXED);
 
   bool waitNeeded = true;
-  handler.forEachWork<char>(
-      [&]__device__(int block, int nBlocks, size_t nElts, size_t nAllElts,
-                    ncclSymPtr<char> input, ncclSymPtr<char> output) {
+  handler.forEachWork<char>([&] __device__(int block, int nBlocks, size_t nElts, size_t nAllElts,
+                                           ncclSymPtr<char> input, ncclSymPtr<char> output) {
         // Threads numbered over rank.
-        int bt = flattenIx(threadIdx.x%WARP_SIZE, WARP_SIZE,
-                           block, nBlocks,
-                           threadIdx.x/WARP_SIZE, blockDim.x/WARP_SIZE);
-        int btn = nBlocks*blockDim.x;
-        bcast<char, EnableTma>(handler, btn, bt, nBlocks, waitNeeded, bar, input, output + rank*nAllElts, nElts);
-        waitNeeded = false;
-      }
-    );
+    int bt =
+      flattenIx(threadIdx.x % WARP_SIZE, WARP_SIZE, block, nBlocks, threadIdx.x / WARP_SIZE, blockDim.x / WARP_SIZE);
+    int btn = nBlocks * blockDim.x;
+    bcast<char, EnableTma>(handler, btn, bt, nBlocks, waitNeeded, bar, input, output + rank * nAllElts, nElts);
+    waitNeeded = false;
+  });
 
   bar.sync(ncclCoopCta(), NCCL_MEM_ORDER_RELEASE);
 }
@@ -240,27 +222,22 @@ __device__ __forceinline__ void ncclSymkRun_AllGather_TmaST(ncclSymkDevWorkArgs 
   ncclSymkRun_AllGather_ST_impl</*EnableTma=*/true>(args);
 }
 
-template<bool EnableTma>
+template <bool EnableTma>
 __device__ __forceinline__ void ncclSymkRun_AllGather_STMC_impl(ncclSymkDevWorkArgs const* args) {
   ncclSymkArgsHandler handler{args};
-  ncclLsaBarrierSession<ncclCoopCta> bar(
-    ncclCoopCta(), handler.comm, ncclTeamTagLsa(), blockIdx.x, /*multimem=*/true
-  );
+  ncclLsaBarrierSession<ncclCoopCta> bar(ncclCoopCta(), handler.comm, ncclTeamTagLsa(), blockIdx.x, /*multimem=*/true);
   int const& rank = handler.comm.rank;
 
   bar.sync(ncclCoopCta(), NCCL_MEM_ORDER_RELAXED);
 
-  handler.forEachWork<char>(
-      [&]__device__(int block, int nBlocks, size_t nElts, size_t nAllElts,
-                    ncclSymPtr<char> input, ncclSymPtr<char> output) {
+  handler.forEachWork<char>([&] __device__(int block, int nBlocks, size_t nElts, size_t nAllElts,
+                                           ncclSymPtr<char> input, ncclSymPtr<char> output) {
         // Round robin memory to blocks.
-        int t = flattenIx(threadIdx.x%WARP_SIZE, WARP_SIZE,
-                          block, nBlocks,
-                          threadIdx.x/WARP_SIZE, blockDim.x/WARP_SIZE);
-        int tn = nBlocks*blockDim.x;
-        bcastMultimem<char, EnableTma>(handler, tn, t, input, output + rank*nAllElts, nElts);
-      }
-    );
+    int t =
+      flattenIx(threadIdx.x % WARP_SIZE, WARP_SIZE, block, nBlocks, threadIdx.x / WARP_SIZE, blockDim.x / WARP_SIZE);
+    int tn = nBlocks * blockDim.x;
+    bcastMultimem<char, EnableTma>(handler, tn, t, input, output + rank * nAllElts, nElts);
+  });
 
   bar.sync(ncclCoopCta(), NCCL_MEM_ORDER_RELEASE);
 }
@@ -273,111 +250,114 @@ __device__ __forceinline__ void ncclSymkRun_AllGather_TmaSTMC(ncclSymkDevWorkArg
   ncclSymkRun_AllGather_STMC_impl</*EnableTma=*/true>(args);
 }
 
-template<typename EltType>
-static __device__ void allgather_LL_body(
-    ncclSymkArgsHandler& handler, ncclLLA2ASession<ncclCoopCta>& lla2a,
-    EltType* input, EltType* output, int nElts, int nPacks, int nStrideElts
-  ) {
+template <typename EltType>
+static __device__ void allgather_LL_body(ncclSymkArgsHandler& handler, ncclLLA2ASession<ncclCoopCta>& lla2a,
+                                         EltType* input, EltType* output, int nElts, int nPacks, int nStrideElts) {
   using Pack = BytePack<8>;
-  constexpr int EltPerPack = 8/sizeof(EltType);
+  constexpr int EltPerPack = 8 / sizeof(EltType);
   int const& rank = handler.comm.rank;
   int const& nRanks = handler.comm.nRanks;
   int t = threadIdx.x;
   constexpr int tn = ncclSymkMaxThreads;
 
-  #pragma unroll 1
+#pragma unroll 1
   while (0 < nElts) {
     int nIterPacks = min(nPacks, tn);
     if (t < nIterPacks) {
-      Pack x = loadPack<Pack>(input, t*EltPerPack, nElts);
-      lla2a.bcast(/*slot=*/nIterPacks*rank + t, x);
+      Pack x = loadPack<Pack>(input, t * EltPerPack, nElts);
+      lla2a.bcast(/*slot=*/nIterPacks * rank + t, x);
     }
 
-    int tn_div_nPacks = tn/nIterPacks;
-    int tn_mod_nPacks = tn%nIterPacks;
-    int peer = t/nIterPacks;
-    int pack = t%nIterPacks;
-    #if 1
+    int tn_div_nPacks = tn / nIterPacks;
+    int tn_mod_nPacks = tn % nIterPacks;
+    int peer = t / nIterPacks;
+    int pack = t % nIterPacks;
+#if 1
       // NOTE: Unrolling speedup on eos nranks=8 size=64K: 5.7us vs 6.7us
-      constexpr int Unroll = 4;
-      #pragma unroll 1
-      for (int i = t; i < (nRanks*nIterPacks & -(Unroll*tn)); i += Unroll*tn) {
-        Pack got[Unroll];
-        lla2a.template recvUnrolled<Unroll, Unroll>(i, Unroll, tn, /*&*/got);
-        #pragma unroll
-        for (int u=0; u < Unroll; u++) {
-          storePack<Pack>(output + peer*nStrideElts, pack*EltPerPack, nElts, got[u]);
-          peer += tn_div_nPacks;
-          pack += tn_mod_nPacks;
-          if (nIterPacks <= pack) { peer += 1; pack -= nIterPacks; }
-        }
-      }
-
-      int i = (nRanks*nIterPacks & -(Unroll*tn)) + t;
-      int n = (nRanks*nIterPacks)/tn % Unroll;
-      if (i + n*tn < nRanks*nIterPacks) n += 1;
-      if (n != 0) {
-        Pack got[Unroll];
-        lla2a.template recvUnrolled<1, Unroll>(i, n, tn, /*&*/got);
-        #pragma unroll
-        for (int u=0; u < Unroll; u++) {
-          if (u != 0 && u == n) break;
-          storePack(output + peer*nStrideElts, pack*EltPerPack, nElts, got[u]);
-          peer += tn_div_nPacks;
-          pack += tn_mod_nPacks;
-          if (nIterPacks <= pack) { peer += 1; pack -= nIterPacks; }
-        }
-      }
-    #else
-      // The non-unrolled but "obviously correct" implementation for reference.
-      #pragma unroll 1
-      for (int i = t; i < nRanks*nIterPacks; i += tn) {
-        Pack got = lla2a.template recv<Pack>(i);
-        storePack(output + peer*nStrideElts, pack*EltPerPack, nElts, got);
+    constexpr int Unroll = 4;
+#pragma unroll 1
+    for (int i = t; i < (nRanks * nIterPacks & -(Unroll * tn)); i += Unroll * tn) {
+      Pack got[Unroll];
+      lla2a.template recvUnrolled<Unroll, Unroll>(i, Unroll, tn, /*&*/ got);
+#pragma unroll
+      for (int u = 0; u < Unroll; u++) {
+        storePack<Pack>(output + peer * nStrideElts, pack * EltPerPack, nElts, got[u]);
         peer += tn_div_nPacks;
         pack += tn_mod_nPacks;
-        if (nIterPacks <= pack) { peer += 1; pack -= nIterPacks; }
+        if (nIterPacks <= pack) {
+          peer += 1;
+          pack -= nIterPacks;
+        }
       }
-    #endif
+    }
+
+    int i = (nRanks * nIterPacks & -(Unroll * tn)) + t;
+    int n = (nRanks * nIterPacks) / tn % Unroll;
+    if (i + n * tn < nRanks * nIterPacks) n += 1;
+    if (n != 0) {
+      Pack got[Unroll];
+      lla2a.template recvUnrolled<1, Unroll>(i, n, tn, /*&*/ got);
+#pragma unroll
+      for (int u = 0; u < Unroll; u++) {
+        if (u != 0 && u == n) break;
+        storePack(output + peer * nStrideElts, pack * EltPerPack, nElts, got[u]);
+        peer += tn_div_nPacks;
+        pack += tn_mod_nPacks;
+        if (nIterPacks <= pack) {
+          peer += 1;
+          pack -= nIterPacks;
+        }
+      }
+    }
+#else
+      // The non-unrolled but "obviously correct" implementation for reference.
+#pragma unroll 1
+    for (int i = t; i < nRanks * nIterPacks; i += tn) {
+      Pack got = lla2a.template recv<Pack>(i);
+      storePack(output + peer * nStrideElts, pack * EltPerPack, nElts, got);
+      peer += tn_div_nPacks;
+      pack += tn_mod_nPacks;
+      if (nIterPacks <= pack) {
+        peer += 1;
+        pack -= nIterPacks;
+      }
+    }
+#endif
 
     lla2a.endEpoch(ncclCoopCta());
 
-    input += tn*EltPerPack;
-    output += tn*EltPerPack;
-    nElts -= tn*EltPerPack;
+    input += tn * EltPerPack;
+    output += tn * EltPerPack;
+    nElts -= tn * EltPerPack;
     nPacks -= tn;
   }
 }
 
 static __device__ void ncclSymkRun_AllGather_LL_impl(ncclSymkDevWorkArgs const* args, bool multimem) {
   ncclSymkArgsHandler handler{args};
-  ncclLLA2ASession<ncclCoopCta> lla2a(
-    ncclCoopCta(), handler.comm, ncclTeamLsa(handler.comm), handler.lsaLLA2A, blockIdx.x, /*maxElts=*/ncclSymkMaxThreads, multimem, handler.comm.lsaMultimem
-  );
+  ncclLLA2ASession<ncclCoopCta> lla2a(ncclCoopCta(), handler.comm, ncclTeamLsa(handler.comm), handler.lsaLLA2A,
+                                      blockIdx.x, /*maxElts=*/ncclSymkMaxThreads, multimem, handler.comm.lsaMultimem);
 
   using Pack = BytePack<8>;
   constexpr int BytePerPack = 8;
 
-  handler.singleWork<char>(
-      [&]__device__(int nElts, int nAllElts,
-                    ncclSymPtr<char> input, ncclSymPtr<char> output) {
-        int nPacks = divUp(nElts, BytePerPack);
+  handler.singleWork<char>([&] __device__(int nElts, int nAllElts, ncclSymPtr<char> input, ncclSymPtr<char> output) {
+    int nPacks = divUp(nElts, BytePerPack);
 
-        char* blockInput = input.localPtr();
-        char* blockOutput = output.localPtr();
+    char* blockInput = input.localPtr();
+    char* blockOutput = output.localPtr();
 
-        uint32_t lowBits = nAllElts;
-        lowBits |= (uintptr_t)blockInput;
-        lowBits |= (uintptr_t)blockOutput;
-        if (__builtin_expect(lowBits%8 == 0, true)) {
+    uint32_t lowBits = nAllElts;
+    lowBits |= (uintptr_t)blockInput;
+    lowBits |= (uintptr_t)blockOutput;
+    if (__builtin_expect(lowBits % 8 == 0, true)) {
           // NOTE: Specializing for 8-byte alignment in one case help at size=65K: 8.9us vs 5.6us
-          allgather_LL_body(handler, lla2a, (BytePack<8>*)blockInput, (BytePack<8>*)blockOutput,
-                            nElts/8, nPacks, nAllElts/8);
-        } else {
-          allgather_LL_body(handler, lla2a, blockInput, blockOutput, nElts, nPacks, nAllElts);
-        }
-      }
-    );
+      allgather_LL_body(handler, lla2a, (BytePack<8>*)blockInput, (BytePack<8>*)blockOutput, nElts / 8, nPacks,
+                        nAllElts / 8);
+    } else {
+      allgather_LL_body(handler, lla2a, blockInput, blockOutput, nElts, nPacks, nAllElts);
+    }
+  });
 }
 
 __device__ __forceinline__ void ncclSymkRun_AllGather_LL(ncclSymkDevWorkArgs const* args) {

--- a/projects/rccl/src/device/symmetric/all_gather_gin.cuh
+++ b/projects/rccl/src/device/symmetric/all_gather_gin.cuh
@@ -26,72 +26,71 @@ __device__ __forceinline__ void ncclSymkRun_AllGather_RailRing_LsaSTMC(struct nc
 
   bar.sync(cta, cuda::memory_order_relaxed, ncclGinFenceLevel::Relaxed);
 
-  handler.template forEachWorkNoFusion<uint8_t>(
-    [&]__device__(size_t nElts, size_t nAllElts, ncclSymPtr<uint8_t> input, ncclSymPtr<uint8_t> output) {
-      if (threadIdx.x < ringThreads) {
-        ncclCoopWarpSpan warps(0, 1, 0);
-        for (int step = 0; step < rail.nRanks - 1; step++) {
-          int dataPeer = (rail.rank - step + rail.nRanks) % rail.nRanks;
-          int dgrank = ncclTeamRankToWorld(handler.comm, rail, dataPeer);
-          size_t remainingElts = nElts;
-          size_t offset = 0;
-          if (dataPeer == rail.rank) {
-            while (remainingElts) {
-              size_t chunkElts = min(remainingElts, size_t(chunkSize));
+  handler.template forEachWorkNoFusion<uint8_t>([&] __device__(size_t nElts, size_t nAllElts, ncclSymPtr<uint8_t> input,
+                                                               ncclSymPtr<uint8_t> output) {
+    if (threadIdx.x < ringThreads) {
+      ncclCoopWarpSpan warps(0, 1, 0);
+      for (int step = 0; step < rail.nRanks - 1; step++) {
+        int dataPeer = (rail.rank - step + rail.nRanks) % rail.nRanks;
+        int dgrank = ncclTeamRankToWorld(handler.comm, rail, dataPeer);
+        size_t remainingElts = nElts;
+        size_t offset = 0;
+        if (dataPeer == rail.rank) {
+          while (remainingElts) {
+            size_t chunkElts = min(remainingElts, size_t(chunkSize));
               // Send data chunk to next peer in ring
-              gin.put(rail, nextPeer, output + dgrank * nAllElts + offset,
-                input + offset, chunkElts,
-                ncclGin_SignalInc{ railSignals + rail.rank }, ncclGin_None{}, warps);
-              offset += chunkElts;
-              remainingElts -= chunkElts;
-            }
-          } else {
-            while (remainingElts) {
-              size_t chunkElts = min(remainingElts, size_t(chunkSize));
+            gin.put(rail, nextPeer, output + dgrank * nAllElts + offset, input + offset, chunkElts,
+                    ncclGin_SignalInc{railSignals + rail.rank}, ncclGin_None{}, warps);
+            offset += chunkElts;
+            remainingElts -= chunkElts;
+          }
+        } else {
+          while (remainingElts) {
+            size_t chunkElts = min(remainingElts, size_t(chunkSize));
               // Wait for ready signal from next peer before sending
-              gin.waitSignal(warps, railSignals + prevPeer, localSignalValue + 1, 32);
+            gin.waitSignal(warps, railSignals + prevPeer, localSignalValue + 1, 32);
               // Send data chunk to next peer in ring
-              gin.put(rail, nextPeer, output + dgrank * nAllElts + offset,
-                output + dgrank * nAllElts + offset, chunkElts,
-                ncclGin_SignalInc{ railSignals + rail.rank }, ncclGin_None{}, warps);
-              offset += chunkElts;
-              remainingElts -= chunkElts;
-              localSignalValue++;
-            }
+            gin.put(rail, nextPeer, output + dgrank * nAllElts + offset, output + dgrank * nAllElts + offset, chunkElts,
+                    ncclGin_SignalInc{railSignals + rail.rank}, ncclGin_None{}, warps);
+            offset += chunkElts;
+            remainingElts -= chunkElts;
+            localSignalValue++;
           }
         }
-        gin.flush(warps);
-      } else {
-        ncclCoopWarpSpan warps(1, blockDim.x / WARP_SIZE - 1, 1);
+      }
+      gin.flush(warps);
+    } else {
+      ncclCoopWarpSpan warps(1, blockDim.x / WARP_SIZE - 1, 1);
         // Loop through rail ranks starting from itself
-        for (int step = 0; step < rail.nRanks; step++) {
-          int dataPeer = (rail.rank - step + rail.nRanks) % rail.nRanks;
-          int dgrank = ncclTeamRankToWorld(handler.comm, rail, dataPeer);
-          size_t remainingElts = nElts;
-          size_t offset = 0;
-          if (dataPeer == rail.rank) {
-            while (remainingElts) {
-              size_t chunkElts = min(remainingElts, size_t(chunkSize));
+      for (int step = 0; step < rail.nRanks; step++) {
+        int dataPeer = (rail.rank - step + rail.nRanks) % rail.nRanks;
+        int dgrank = ncclTeamRankToWorld(handler.comm, rail, dataPeer);
+        size_t remainingElts = nElts;
+        size_t offset = 0;
+        if (dataPeer == rail.rank) {
+          while (remainingElts) {
+            size_t chunkElts = min(remainingElts, size_t(chunkSize));
               // Put self rank's data
-              bcastMultimem(handler, warps.num_threads(), warps.thread_rank(), input + offset, output + dgrank * nAllElts + offset, chunkElts);
-              offset += chunkElts;
-              remainingElts -= chunkElts;
-            }
-          } else {
-            while (remainingElts) {
-              size_t chunkElts = min(remainingElts, size_t(chunkSize));
+            bcastMultimem(handler, warps.num_threads(), warps.thread_rank(), input + offset,
+                          output + dgrank * nAllElts + offset, chunkElts);
+            offset += chunkElts;
+            remainingElts -= chunkElts;
+          }
+        } else {
+          while (remainingElts) {
+            size_t chunkElts = min(remainingElts, size_t(chunkSize));
               // Wait for signal from other peers before putting their data
-              gin.waitSignal(warps, railSignals + prevPeer, localSignalValue + 1, 32);
-              bcastMultimem(handler, warps.num_threads(), warps.thread_rank(), output + dgrank * nAllElts + offset, output + dgrank * nAllElts + offset, chunkElts);
-              offset += chunkElts;
-              remainingElts -= chunkElts;
-              localSignalValue++;
-            }
+            gin.waitSignal(warps, railSignals + prevPeer, localSignalValue + 1, 32);
+            bcastMultimem(handler, warps.num_threads(), warps.thread_rank(), output + dgrank * nAllElts + offset,
+                          output + dgrank * nAllElts + offset, chunkElts);
+            offset += chunkElts;
+            remainingElts -= chunkElts;
+            localSignalValue++;
           }
         }
       }
     }
-  );
+  });
 
   // update the shadow signal value
   if (threadIdx.x == ringThreads) {

--- a/projects/rccl/src/device/symmetric/all_reduce.cuh
+++ b/projects/rccl/src/device/symmetric/all_reduce.cuh
@@ -6,35 +6,33 @@
 #include "symmetric/kernel.h"
 #include "symmetric/primitives.h"
 
-template<int BytePerPack, int UnrollPacks, int UnrollPeers, typename T, bool EnableTma, typename Red>
-static __device__ __forceinline__ void allreduceDeep(
-    ncclSymkArgsHandler const& handler, int tn, int t,
-    bool waitNeeded, ncclLsaBarrierSession<ncclCoopCta>& bar,
-    Red red, ncclSymPtr<char> input, ncclSymPtr<char> output, int32_t nIters
-  ) {
+template <int BytePerPack, int UnrollPacks, int UnrollPeers, typename T, bool EnableTma, typename Red>
+static __device__ __forceinline__ void allreduceDeep(ncclSymkArgsHandler const& handler, int tn, int t, bool waitNeeded,
+                                                     ncclLsaBarrierSession<ncclCoopCta>& bar, Red red,
+                                                     ncclSymPtr<char> input, ncclSymPtr<char> output, int32_t nIters) {
   using Pack = BytePack<BytePerPack>;
   using Acc = typename Red::EltType;
-  using AccPack = BytePack<BytePerPack*sizeof(Acc)/sizeof(T)>;
+  using AccPack = BytePack<BytePerPack * sizeof(Acc) / sizeof(T)>;
 
   ncclTeam world = ncclTeamWorld(handler.comm);
-  int wn = tn/WARP_SIZE;
-  int w = t/WARP_SIZE;
-  int lane = t%WARP_SIZE;
+  int wn = tn / WARP_SIZE;
+  int w = t / WARP_SIZE;
+  int lane = t % WARP_SIZE;
   int const& rank = handler.comm.rank;
   int const& nRanks = handler.comm.nRanks;
-  constexpr size_t tilePack = UnrollPacks*WARP_SIZE;
-  constexpr size_t tileSize = tilePack*BytePerPack;
+  constexpr size_t tilePack = UnrollPacks * WARP_SIZE;
+  constexpr size_t tileSize = tilePack * BytePerPack;
   size_t tmaSize;
 
-  ncclSymPtr<Pack> inpPacks = (ncclSymPtr<Pack>)input + intptr_t(w)*UnrollPacks*WARP_SIZE + (EnableTma ? 0 : lane);
-  ncclSymPtr<Pack> outPacks = (ncclSymPtr<Pack>)output + intptr_t(w)*UnrollPacks*WARP_SIZE + (EnableTma ? 0 : lane);
+  ncclSymPtr<Pack> inpPacks = (ncclSymPtr<Pack>)input + intptr_t(w) * UnrollPacks * WARP_SIZE + (EnableTma ? 0 : lane);
+  ncclSymPtr<Pack> outPacks = (ncclSymPtr<Pack>)output + intptr_t(w) * UnrollPacks * WARP_SIZE + (EnableTma ? 0 : lane);
   Pack acc0[UnrollPacks];
 
   int lw = threadIdx.x / WARP_SIZE;
   extern __shared__ char smemScratch[];
   using tmaSmemStruct_t = tmaSmemStruct<Pack, UnrollPacks, UnrollPeers>;
   constexpr int smemSizePerWarp = ncclTmaShmemScratchWarpSize();
-  tmaSmemStruct_t* tmaSmem = reinterpret_cast<tmaSmemStruct_t*>(smemScratch+lw*smemSizePerWarp);
+  tmaSmemStruct_t* tmaSmem = reinterpret_cast<tmaSmemStruct_t*>(smemScratch + lw * smemSizePerWarp);
 
   if NCCL_IF_CONSTEXPR (EnableTma) {
     if (lane == 0) {
@@ -49,15 +47,14 @@ static __device__ __forceinline__ void allreduceDeep(
         cp_async_bulk_global_to_shared(tmaSmem->buff[0], inpPacks.peerPtr(world, rank), &tmaSmem->bar, tileSize);
       }
     } else {
-      #pragma unroll
-      for (int u=0; u < UnrollPacks; u++) {
-        acc0[u] = inpPacks.peerPtr(world, rank)[u*WARP_SIZE];
+#pragma unroll
+      for (int u = 0; u < UnrollPacks; u++) {
+        acc0[u] = inpPacks.peerPtr(world, rank)[u * WARP_SIZE];
       }
     }
   }
 
-  if (waitNeeded)
-    bar.wait(ncclCoopCta(), NCCL_MEM_ORDER_RELAXED);
+  if (waitNeeded) bar.wait(ncclCoopCta(), NCCL_MEM_ORDER_RELAXED);
 
   if (0 < nIters) {
     while (true) {
@@ -65,27 +62,29 @@ static __device__ __forceinline__ void allreduceDeep(
       AccPack acc1[UnrollPacks];
       int r = rank;
       if (++r == nRanks) r = 0;
-      { Pack tmp1[UnrollPacks];
+      {
+        Pack tmp1[UnrollPacks];
         if NCCL_IF_CONSTEXPR (EnableTma) {
           if (lane == 0) {
             cp_async_bulk_global_to_shared(tmaSmem->buff[1], inpPacks.peerPtr(world, r), &tmaSmem->bar, tileSize);
             tmaSize += tileSize;
             __mbarrier_token_t token = barrier_arrive1_tx_relaxed(&tmaSmem->bar, tmaSize);
-            while (!barrier_try_wait_token_relaxed(&tmaSmem->bar, token)) {}
+            while (!barrier_try_wait_token_relaxed(&tmaSmem->bar, token)) {
+            }
             tmaSize = 0;
           }
           __syncwarp();
         } else {
-          #pragma unroll
-          for (int u=0; u < UnrollPacks; u++) {
-            tmp1[u] = inpPacks.peerPtr(world, r)[u*WARP_SIZE];
+#pragma unroll
+          for (int u = 0; u < UnrollPacks; u++) {
+            tmp1[u] = inpPacks.peerPtr(world, r)[u * WARP_SIZE];
           }
         }
-        #pragma unroll
-        for (int u=0; u < UnrollPacks; u++) {
+#pragma unroll
+        for (int u = 0; u < UnrollPacks; u++) {
           if NCCL_IF_CONSTEXPR (EnableTma) {
-            acc0[u] = tmaSmem->buff[0][lane+WARP_SIZE*u];
-            tmp1[u] = tmaSmem->buff[1][lane+WARP_SIZE*u];
+            acc0[u] = tmaSmem->buff[0][lane + WARP_SIZE * u];
+            tmp1[u] = tmaSmem->buff[1][lane + WARP_SIZE * u];
           }
           acc1[u] = applyReduce(red, applyCast<T, Acc>(acc0[u]), applyCast<T, Acc>(tmp1[u]));
         }
@@ -94,12 +93,10 @@ static __device__ __forceinline__ void allreduceDeep(
       if (++r == nRanks) r = 0;
 
       int dr = 2;
-      #pragma unroll 2
-      for (int partial=0; partial <= 1; partial++) {
-        #pragma unroll 1
-        for (int i = 0;
-             partial ? i < 1 : (dr + UnrollPeers <= nRanks);
-             partial ? i++ : (dr += UnrollPeers)) {
+#pragma unroll 2
+      for (int partial = 0; partial <= 1; partial++) {
+#pragma unroll 1
+        for (int i = 0; partial ? i < 1 : (dr + UnrollPeers <= nRanks); partial ? i++ : (dr += UnrollPeers)) {
           if (partial && dr == nRanks) break;
 
           Pack tmp1[UnrollPeers][UnrollPacks];
@@ -108,18 +105,18 @@ static __device__ __forceinline__ void allreduceDeep(
             __syncwarp();
           }
 
-          #pragma unroll
-          for (int ur=0; ur < UnrollPeers-partial; ur++) {
-            if (partial && ur!=0 && dr+ur == nRanks) break;
+#pragma unroll
+          for (int ur = 0; ur < UnrollPeers - partial; ur++) {
+            if (partial && ur != 0 && dr + ur == nRanks) break;
             if NCCL_IF_CONSTEXPR (EnableTma) {
               if (lane == 0) {
                 cp_async_bulk_global_to_shared(tmaSmem->buff[ur], inpPacks.peerPtr(world, r), &tmaSmem->bar, tileSize);
                 tmaSize += tileSize;
               }
             } else {
-              #pragma unroll UnrollPacks
-              for (int u=0; u < UnrollPacks; u++) {
-                tmp1[ur][u] = inpPacks.peerPtr(world, r)[u*WARP_SIZE];
+#pragma unroll UnrollPacks
+              for (int u = 0; u < UnrollPacks; u++) {
+                tmp1[ur][u] = inpPacks.peerPtr(world, r)[u * WARP_SIZE];
               }
             }
             if (++r == nRanks) r = 0;
@@ -127,19 +124,20 @@ static __device__ __forceinline__ void allreduceDeep(
           if NCCL_IF_CONSTEXPR (EnableTma) {
             if (lane == 0) {
               __mbarrier_token_t token = barrier_arrive1_tx_relaxed(&tmaSmem->bar, tmaSize);
-              while (!barrier_try_wait_token_relaxed(&tmaSmem->bar, token)) {}
+              while (!barrier_try_wait_token_relaxed(&tmaSmem->bar, token)) {
+              }
               tmaSize = 0;
             }
             // threads wait for peers' data to reach shared memory before starting the reduction
             __syncwarp();
           }
-          #pragma unroll
-          for (int ur=0; ur < UnrollPeers-partial; ur++) {
-            if (partial && ur!=0 && dr+ur == nRanks) break;
-            #pragma unroll UnrollPacks
-            for (int u=0; u < UnrollPacks; u++) {
+#pragma unroll
+          for (int ur = 0; ur < UnrollPeers - partial; ur++) {
+            if (partial && ur != 0 && dr + ur == nRanks) break;
+#pragma unroll UnrollPacks
+            for (int u = 0; u < UnrollPacks; u++) {
               if NCCL_IF_CONSTEXPR (EnableTma) {
-                tmp1[ur][u] = tmaSmem->buff[ur][lane+WARP_SIZE*u];
+                tmp1[ur][u] = tmaSmem->buff[ur][lane + WARP_SIZE * u];
               }
               acc1[u] = applyReduce(red, acc1[u], applyCast<T, Acc>(tmp1[ur][u]));
             }
@@ -147,10 +145,10 @@ static __device__ __forceinline__ void allreduceDeep(
         }
       }
 
-      #pragma unroll
-      for (int u=0; u < UnrollPacks; u++) {
+#pragma unroll
+      for (int u = 0; u < UnrollPacks; u++) {
         if NCCL_IF_CONSTEXPR (EnableTma) {
-          tmaSmem->buff[0][lane+WARP_SIZE*u] = applyCast<Acc, T>(acc1[u]);
+          tmaSmem->buff[0][lane + WARP_SIZE * u] = applyCast<Acc, T>(acc1[u]);
         } else {
           acc0[u] = applyCast<Acc, T>(acc1[u]);
         }
@@ -164,23 +162,21 @@ static __device__ __forceinline__ void allreduceDeep(
 
       dr = 0;
       r = rank;
-      #pragma unroll 2
-      for (int partial=0; partial <= 1; partial++) {
-        #pragma unroll 1
-        for (int i = 0;
-             partial ? i < 1 : (dr + UnrollPeers <= nRanks);
-             partial ? i++ : (dr += UnrollPeers)) {
-          #pragma unroll
-          for (int ur=0; ur < UnrollPeers-partial; ur++) {
+#pragma unroll 2
+      for (int partial = 0; partial <= 1; partial++) {
+#pragma unroll 1
+        for (int i = 0; partial ? i < 1 : (dr + UnrollPeers <= nRanks); partial ? i++ : (dr += UnrollPeers)) {
+#pragma unroll
+          for (int ur = 0; ur < UnrollPeers - partial; ur++) {
             if (partial && dr == nRanks) break;
             if NCCL_IF_CONSTEXPR (EnableTma) {
               if (lane == 0) {
                 cp_async_bulk_shared_to_global(outPacks.peerPtr(world, r), tmaSmem->buff[0], tileSize);
               }
             } else {
-              #pragma unroll UnrollPacks
-              for (int u=0; u < UnrollPacks; u++) {
-                outPacks.peerPtr(world, r)[u*WARP_SIZE] = acc0[u];
+#pragma unroll UnrollPacks
+              for (int u = 0; u < UnrollPacks; u++) {
+                outPacks.peerPtr(world, r)[u * WARP_SIZE] = acc0[u];
               }
             }
             if (++r == nRanks) r = 0;
@@ -195,8 +191,8 @@ static __device__ __forceinline__ void allreduceDeep(
         __syncwarp();
       }
 
-      inpPacks += intptr_t(wn)*UnrollPacks*WARP_SIZE;
-      outPacks += intptr_t(wn)*UnrollPacks*WARP_SIZE;
+      inpPacks += intptr_t(wn) * UnrollPacks * WARP_SIZE;
+      outPacks += intptr_t(wn) * UnrollPacks * WARP_SIZE;
       nIters -= wn;
       if (nIters <= 0) break;
 
@@ -206,21 +202,19 @@ static __device__ __forceinline__ void allreduceDeep(
           cp_async_bulk_global_to_shared(tmaSmem->buff[0], inpPacks.peerPtr(world, rank), &tmaSmem->bar, tileSize);
         }
       } else {
-        #pragma unroll
-        for (int u=0; u < UnrollPacks; u++) {
-          acc0[u] = inpPacks.peerPtr(world, rank)[u*WARP_SIZE];
+#pragma unroll
+        for (int u = 0; u < UnrollPacks; u++) {
+          acc0[u] = inpPacks.peerPtr(world, rank)[u * WARP_SIZE];
         }
       }
     }
   }
 }
 
-template<int UnrollPeers, typename Red, typename T>
-static __device__ __forceinline__ void allreduceEnds(
-    ncclSymkArgsHandler const& handler, int tn, int t, Red red,
-    ncclSymPtr<T> input, ncclSymPtr<T> output,
-    size_t nElts, uint32_t nPreElts, size_t nSufElts
-  ) {
+template <int UnrollPeers, typename Red, typename T>
+static __device__ __forceinline__ void allreduceEnds(ncclSymkArgsHandler const& handler, int tn, int t, Red red,
+                                                     ncclSymPtr<T> input, ncclSymPtr<T> output, size_t nElts,
+                                                     uint32_t nPreElts, size_t nSufElts) {
   using Acc = typename Red::EltType;
 
   ncclTeam world = ncclTeamWorld(handler.comm);
@@ -230,28 +224,26 @@ static __device__ __forceinline__ void allreduceEnds(
   ncclSymPtr<BytePack<sizeof(T)>> inpPacks = (ncclSymPtr<BytePack<sizeof(T)>>)input;
   ncclSymPtr<BytePack<sizeof(T)>> outPacks = (ncclSymPtr<BytePack<sizeof(T)>>)output;
 
-  #pragma unroll 1
-  for (size_t i = t; i < nPreElts+nSufElts; i += tn) {
-    size_t elt = i < nPreElts ? i : nElts-nSufElts-nPreElts+i;
+#pragma unroll 1
+  for (size_t i = t; i < nPreElts + nSufElts; i += tn) {
+    size_t elt = i < nPreElts ? i : nElts - nSufElts - nPreElts + i;
     BytePack<sizeof(T)> acc0 = inpPacks.peerPtr(world, rank)[elt];
     BytePack<sizeof(Acc)> acc1;
     BytePack<sizeof(T)> tmp[UnrollPeers];
     int dr = 1;
-    int r = rank+1;
+    int r = rank + 1;
     if (nRanks == r) r = 0;
     bool first = true;
 
-    #pragma unroll 2
-    for (int partial=0; partial <= 1; partial++) {
-      #pragma unroll 1
-      for (int j = 0;
-           partial ? j < 1 : (dr + UnrollPeers <= nRanks);
-           partial ? j++ : (dr += UnrollPeers)) {
+#pragma unroll 2
+    for (int partial = 0; partial <= 1; partial++) {
+#pragma unroll 1
+      for (int j = 0; partial ? j < 1 : (dr + UnrollPeers <= nRanks); partial ? j++ : (dr += UnrollPeers)) {
         if (partial && dr == nRanks) break;
 
-        #pragma unroll
-        for (int u=0; u < UnrollPeers-partial; u++) {
-          if (partial && u!=0 && dr+u == nRanks) break;
+#pragma unroll
+        for (int u = 0; u < UnrollPeers - partial; u++) {
+          if (partial && u != 0 && dr + u == nRanks) break;
           tmp[u] = inpPacks.peerPtr(world, r)[elt];
           r += 1;
           if (r == nRanks) r = 0;
@@ -260,9 +252,9 @@ static __device__ __forceinline__ void allreduceEnds(
           first = false;
           acc1 = applyCast<T, Acc>(acc0);
         }
-        #pragma unroll
-        for (int u=0; u < UnrollPeers-partial; u++) {
-          if (partial && u!=0 && dr+u == nRanks) break;
+#pragma unroll
+        for (int u = 0; u < UnrollPeers - partial; u++) {
+          if (partial && u != 0 && dr + u == nRanks) break;
           acc1 = applyReduce(red, acc1, applyCast<T, Acc>(tmp[u]));
         }
       }
@@ -271,15 +263,13 @@ static __device__ __forceinline__ void allreduceEnds(
     acc0 = applyCast<Acc, T>(acc1);
     dr = 0;
     r = rank;
-    #pragma unroll 2
-    for (int partial=0; partial <= 1; partial++) {
-      #pragma unroll 1
-      for (int j=0;
-           partial ? j < 1 : (dr + UnrollPeers <= nRanks);
-           partial ? j++ : (dr += UnrollPeers)) {
-        #pragma unroll
-        for (int u=0; u < UnrollPeers-partial; u++) {
-          if (partial && dr+u == nRanks) break;
+#pragma unroll 2
+    for (int partial = 0; partial <= 1; partial++) {
+#pragma unroll 1
+      for (int j = 0; partial ? j < 1 : (dr + UnrollPeers <= nRanks); partial ? j++ : (dr += UnrollPeers)) {
+#pragma unroll
+        for (int u = 0; u < UnrollPeers - partial; u++) {
+          if (partial && dr + u == nRanks) break;
           outPacks.peerPtr(world, r)[elt] = acc0;
           r += 1;
           if (r == nRanks) r = 0;
@@ -289,74 +279,64 @@ static __device__ __forceinline__ void allreduceEnds(
   }
 }
 
-template<typename Red, typename T, bool EnableTma>
-static __device__ void allreduce(
-    ncclSymkArgsHandler const& handler, int tn, int t, int nBlocks,
-    bool waitNeeded, ncclLsaBarrierSession<ncclCoopCta>& bar,
-    Red red, ncclSymPtr<T> input, ncclSymPtr<T> output, size_t nElts
-  ) {
+template <typename Red, typename T, bool EnableTma>
+static __device__ void allreduce(ncclSymkArgsHandler const& handler, int tn, int t, int nBlocks, bool waitNeeded,
+                                 ncclLsaBarrierSession<ncclCoopCta>& bar, Red red, ncclSymPtr<T> input,
+                                 ncclSymPtr<T> output, size_t nElts) {
   int const& nRanks = handler.comm.nRanks;
   int const& nRanks_rcp32 = handler.nRanks_rcp32;
-  size_t nBytes = nElts*sizeof(T);
+  size_t nBytes = nElts * sizeof(T);
   uint32_t nBlocks_rcp32 = nccl::utility::idivRcp32_upto64(nBlocks);
   uint32_t nRanks_nBlocks_rcp32 = nccl::utility::imulRcp32(nRanks, nRanks_rcp32, nBlocks, nBlocks_rcp32);
 
-  uint32_t nPreBytes = (16u - input.offset)%16u;
+  uint32_t nPreBytes = (16u - input.offset) % 16u;
   nPreBytes = min((size_t)nPreBytes, nBytes);
   uintptr_t cursor = nPreBytes;
 
   constexpr int MinWarpPerBlock = 4;
 
-  if ((input.offset - output.offset)%16 == 0) {
+  if ((input.offset - output.offset) % 16 == 0) {
     constexpr int BytePerPack = 16, UnrollPacks = EnableTma ? 8 : 4, UnrollPeers = 2;
-    constexpr int BytePerChunk = MinWarpPerBlock*UnrollPacks*WARP_SIZE*BytePerPack;
-    uint32_t chunks = (nBytes-cursor)/BytePerChunk;
-    chunks -= imodFast32(chunks, nRanks*nBlocks, nRanks_nBlocks_rcp32);
+    constexpr int BytePerChunk = MinWarpPerBlock * UnrollPacks * WARP_SIZE * BytePerPack;
+    uint32_t chunks = (nBytes - cursor) / BytePerChunk;
+    chunks -= imodFast32(chunks, nRanks * nBlocks, nRanks_nBlocks_rcp32);
     if (chunks != 0) {
-      uintptr_t cursorAfter = cursor + uintptr_t(chunks)*BytePerChunk;
-      allreduceDeep<BytePerPack, UnrollPacks, UnrollPeers, T, EnableTma>(
-        handler, tn, t, waitNeeded, bar, red,
-        (ncclSymPtr<char>)input + cursor,
-        (ncclSymPtr<char>)output + cursor,
-        chunks*MinWarpPerBlock
-      );
+      uintptr_t cursorAfter = cursor + uintptr_t(chunks) * BytePerChunk;
+      allreduceDeep<BytePerPack, UnrollPacks, UnrollPeers, T, EnableTma>(handler, tn, t, waitNeeded, bar, red,
+                                                                         (ncclSymPtr<char>)input + cursor,
+                                                                         (ncclSymPtr<char>)output + cursor,
+                                                                         chunks * MinWarpPerBlock);
       cursor = cursorAfter;
       waitNeeded = false;
     }
   }
 
-  if (sizeof(T) == 4 || (sizeof(T) < 4 && (input.offset - output.offset)%4 == 0)) {
+  if (sizeof(T) == 4 || (sizeof(T) < 4 && (input.offset - output.offset) % 4 == 0)) {
     constexpr int BytePerPack = 4, UnrollPacks = 4, UnrollPeers = 4;
-    constexpr int BytePerChunk = MinWarpPerBlock*UnrollPacks*WARP_SIZE*BytePerPack;
-    uint32_t chunks = (nBytes-cursor)/BytePerChunk;
-    chunks -= imodFast32(chunks, nRanks*nBlocks, nRanks_nBlocks_rcp32);
+    constexpr int BytePerChunk = MinWarpPerBlock * UnrollPacks * WARP_SIZE * BytePerPack;
+    uint32_t chunks = (nBytes - cursor) / BytePerChunk;
+    chunks -= imodFast32(chunks, nRanks * nBlocks, nRanks_nBlocks_rcp32);
     if (chunks != 0) {
-      uintptr_t cursorAfter = cursor + uintptr_t(chunks)*BytePerChunk;
-      allreduceDeep<(sizeof(T) <= BytePerPack ? BytePerPack : 0), UnrollPacks, UnrollPeers, T, /*EnableTma*/false>(
-        handler, tn, t, waitNeeded, bar, red,
-        (ncclSymPtr<char>)input + cursor,
-        (ncclSymPtr<char>)output + cursor,
-        chunks*MinWarpPerBlock
-      );
+      uintptr_t cursorAfter = cursor + uintptr_t(chunks) * BytePerChunk;
+      allreduceDeep<(sizeof(T) <= BytePerPack ? BytePerPack : 0), UnrollPacks, UnrollPeers, T, /*EnableTma*/ false>(
+        handler, tn, t, waitNeeded, bar, red, (ncclSymPtr<char>)input + cursor, (ncclSymPtr<char>)output + cursor,
+        chunks * MinWarpPerBlock);
       cursor = cursorAfter;
       waitNeeded = false;
     }
   }
 
-  if (waitNeeded)
-    bar.wait(ncclCoopCta(), NCCL_MEM_ORDER_RELAXED);
+  if (waitNeeded) bar.wait(ncclCoopCta(), NCCL_MEM_ORDER_RELAXED);
 
   constexpr int UnrollPeers = 8;
-  size_t nSufElts = (nBytes-cursor)/sizeof(T);
-  allreduceEnds<UnrollPeers>(handler, tn, t, red, input, output, nElts, nPreBytes/sizeof(T), nSufElts);
+  size_t nSufElts = (nBytes - cursor) / sizeof(T);
+  allreduceEnds<UnrollPeers>(handler, tn, t, red, input, output, nElts, nPreBytes / sizeof(T), nSufElts);
 }
 
-template<template<typename> typename Red, typename T, bool EnableTma>
+template <template <typename> typename Red, typename T, bool EnableTma>
 __device__ __forceinline__ void ncclSymkRun_AllReduce_RSxLD_AGxST_impl(ncclSymkDevWorkArgs const* args) {
   ncclSymkArgsHandler handler{args};
-  ncclLsaBarrierSession<ncclCoopCta> bar{
-    ncclCoopCta(), handler.comm, ncclTeamTagLsa(), blockIdx.x
-  };
+  ncclLsaBarrierSession<ncclCoopCta> bar{ncclCoopCta(), handler.comm, ncclTeamTagLsa(), blockIdx.x};
 
   Red<typename ncclSymkAccumType<Red, T, /*nvls=*/false>::Type> red(handler.devWork->redOpArg);
 
@@ -366,71 +346,65 @@ __device__ __forceinline__ void ncclSymkRun_AllReduce_RSxLD_AGxST_impl(ncclSymkD
   bar.arrive(ncclCoopCta(), NCCL_MEM_ORDER_RELAXED);
 
   bool waitNeeded = true;
-  handler.forEachWork<T>(
-      [&]__device__(int block, int nBlocks, size_t nElts, size_t nAllElts,
-                    ncclSymPtr<T> input, ncclSymPtr<T> output) {
+  handler.forEachWork<T>([&] __device__(int block, int nBlocks, size_t nElts, size_t nAllElts, ncclSymPtr<T> input,
+                                        ncclSymPtr<T> output) {
         // Threads numbered globally such that we round robin warps by rank then block.
-        int gt = flattenIx(threadIdx.x%WARP_SIZE, WARP_SIZE,
-                           rank, nRanks,
-                           block, nBlocks,
-                           threadIdx.x/WARP_SIZE, blockDim.x/WARP_SIZE);
-        int gtn = nRanks*nBlocks*blockDim.x;
+    int gt = flattenIx(threadIdx.x % WARP_SIZE, WARP_SIZE, rank, nRanks, block, nBlocks, threadIdx.x / WARP_SIZE,
+                       blockDim.x / WARP_SIZE);
+    int gtn = nRanks * nBlocks * blockDim.x;
 
-        allreduce<decltype(red), T, EnableTma>(handler, gtn, gt, nBlocks, waitNeeded, bar, red, input, output, nElts);
+    allreduce<decltype(red), T, EnableTma>(handler, gtn, gt, nBlocks, waitNeeded, bar, red, input, output, nElts);
 
-        waitNeeded = false;
-      }
-    );
+    waitNeeded = false;
+  });
 
   bar.sync(ncclCoopCta(), NCCL_MEM_ORDER_RELEASE);
 }
 
-template<template<typename> typename Red, typename T>
+template <template <typename> typename Red, typename T>
 __device__ __forceinline__ void ncclSymkRun_AllReduce_RSxLD_AGxST(ncclSymkDevWorkArgs const* args) {
   ncclSymkRun_AllReduce_RSxLD_AGxST_impl<Red, T, /*EnableTma=*/false>(args);
 }
 
-template<template<typename> typename Red, typename T>
+template <template <typename> typename Red, typename T>
 __device__ __forceinline__ void ncclSymkRun_AllReduce_RSxTmaLD_AGxTmaST(ncclSymkDevWorkArgs const* args) {
   ncclSymkRun_AllReduce_RSxLD_AGxST_impl<Red, T, /*EnableTma=*/true>(args);
 }
 
-template<typename Red, typename T>
-static __device__ void allreduceMultimem(
-    int tn, int t, Red red, T* input, T* output, size_t nElts
-  ) {
+template <typename Red, typename T>
+static __device__ void allreduceMultimem(int tn, int t, Red red, T* input, T* output, size_t nElts) {
   uintptr_t inputUptr = reinterpret_cast<uintptr_t>(input);
   uintptr_t outputUptr = reinterpret_cast<uintptr_t>(output);
-  size_t nBytes = nElts*sizeof(T);
+  size_t nBytes = nElts * sizeof(T);
 
   constexpr int BytePerPack = LoadMultimem_BigPackSize<Red>::BigPackSize;
-  uint32_t nPreBytes = (BytePerPack - inputUptr)%BytePerPack;
+  uint32_t nPreBytes = (BytePerPack - inputUptr) % BytePerPack;
   nPreBytes = min((size_t)nPreBytes, nBytes);
   uintptr_t nSufBytes;
 
-  if (alignof(T) == BytePerPack || (inputUptr-outputUptr)%BytePerPack == 0) {
-    constexpr int UnrollPacks = 16*8/BytePerPack;
-    constexpr int BytePerChunk = UnrollPacks*WARP_SIZE*BytePerPack;
+  if (alignof(T) == BytePerPack || (inputUptr - outputUptr) % BytePerPack == 0) {
+    constexpr int UnrollPacks = 16 * 8 / BytePerPack;
+    constexpr int BytePerChunk = UnrollPacks * WARP_SIZE * BytePerPack;
     uintptr_t cursor = nPreBytes;
-    int nChunks = (nBytes-cursor)/BytePerChunk;
-    uintptr_t cursorAfter = cursor + uintptr_t(nChunks)*BytePerChunk;
+    int nChunks = (nBytes - cursor) / BytePerChunk;
+    uintptr_t cursorAfter = cursor + uintptr_t(nChunks) * BytePerChunk;
     nSufBytes = nBytes - cursorAfter;
-    cursor += (t/WARP_SIZE)*UnrollPacks*WARP_SIZE*BytePerPack;
-    cursor += (t%WARP_SIZE)*BytePerPack;
-    int nIters = nChunks - t/WARP_SIZE;
-    #pragma unroll 1
+    cursor += (t / WARP_SIZE) * UnrollPacks * WARP_SIZE * BytePerPack;
+    cursor += (t % WARP_SIZE) * BytePerPack;
+    int nIters = nChunks - t / WARP_SIZE;
+#pragma unroll 1
     while (0 < nIters) {
       BytePack<BytePerPack> tmp[UnrollPacks];
-      #pragma unroll
-      for (int u=0; u < UnrollPacks; u++) {
-        tmp[u] = applyLoadMultimem<Red, BytePerPack>(red, inputUptr + cursor + u*WARP_SIZE*BytePerPack);
+#pragma unroll
+      for (int u = 0; u < UnrollPacks; u++) {
+        tmp[u] = applyLoadMultimem<Red, BytePerPack>(red, inputUptr + cursor + u * WARP_SIZE * BytePerPack);
       }
-      #pragma unroll
-      for (int u=0; u < UnrollPacks; u++) {
-        multimem_st_global(outputUptr + cursor + u*WARP_SIZE*BytePerPack, tmp[u]);
+#pragma unroll
+      for (int u = 0; u < UnrollPacks; u++) {
+        multimem_st_global(outputUptr + cursor + u * WARP_SIZE * BytePerPack, tmp[u]);
       }
-      cursor += tn*UnrollPacks*BytePerPack;
-      nIters -= tn/WARP_SIZE;
+      cursor += tn * UnrollPacks * BytePerPack;
+      nIters -= tn / WARP_SIZE;
     }
   } else {
     nPreBytes = 0;
@@ -438,20 +412,18 @@ static __device__ void allreduceMultimem(
   }
 
   // Get the prefix+suffix element one at a time.
-  #pragma unroll 4
-  for (uintptr_t i = t*sizeof(T); i < nPreBytes + nSufBytes; i += tn*sizeof(T)) {
-    uintptr_t cursor = i < nPreBytes ? i : nBytes-nSufBytes+(i-nPreBytes);
+#pragma unroll 4
+  for (uintptr_t i = t * sizeof(T); i < nPreBytes + nSufBytes; i += tn * sizeof(T)) {
+    uintptr_t cursor = i < nPreBytes ? i : nBytes - nSufBytes + (i - nPreBytes);
     BytePack<sizeof(T)> val = applyLoadMultimem<Red, sizeof(T)>(red, inputUptr + cursor);
     multimem_st_global(outputUptr + cursor, val);
   }
 }
 
-template<template<typename> typename Red, typename T>
+template <template <typename> typename Red, typename T>
 __device__ __forceinline__ void ncclSymkRun_AllReduce_RSxLDMC_AGxSTMC(ncclSymkDevWorkArgs const* args) {
   ncclSymkArgsHandler handler{args};
-  ncclLsaBarrierSession<ncclCoopCta> bar{
-    ncclCoopCta(), handler.comm, ncclTeamTagLsa(), blockIdx.x, /*multimem=*/true
-  };
+  ncclLsaBarrierSession<ncclCoopCta> bar{ncclCoopCta(), handler.comm, ncclTeamTagLsa(), blockIdx.x, /*multimem=*/true};
 
   Red<typename ncclSymkAccumType<Red, T, /*nvls=*/true>::Type> red(handler.devWork->redOpArg);
 
@@ -461,30 +433,24 @@ __device__ __forceinline__ void ncclSymkRun_AllReduce_RSxLDMC_AGxSTMC(ncclSymkDe
 
   bar.sync(ncclCoopCta(), NCCL_MEM_ORDER_RELAXED);
 
-  handler.forEachWork<T>(
-      [&]__device__(int block, int nBlocks, size_t nElts, size_t nAllElts,
-                    ncclSymPtr<T> input, ncclSymPtr<T> output) {
+  handler.forEachWork<T>([&] __device__(int block, int nBlocks, size_t nElts, size_t nAllElts, ncclSymPtr<T> input,
+                                        ncclSymPtr<T> output) {
         // Threads numbered globally such that we round robin warps by rank then block.
-        int gt = flattenIx(threadIdx.x%WARP_SIZE, WARP_SIZE,
-                           rank, nRanks,
-                           block, nBlocks,
-                           threadIdx.x/WARP_SIZE, blockDim.x/WARP_SIZE);
-        int gtn = nRanks*nBlocks*blockDim.x;
+    int gt = flattenIx(threadIdx.x % WARP_SIZE, WARP_SIZE, rank, nRanks, block, nBlocks, threadIdx.x / WARP_SIZE,
+                       blockDim.x / WARP_SIZE);
+    int gtn = nRanks * nBlocks * blockDim.x;
 
-        allreduceMultimem(gtn, gt, red, input.multimemPtr(multimem), output.multimemPtr(multimem), nElts);
-      }
-    );
+    allreduceMultimem(gtn, gt, red, input.multimemPtr(multimem), output.multimemPtr(multimem), nElts);
+  });
 
   bar.sync(ncclCoopCta(), NCCL_MEM_ORDER_RELEASE);
 }
 
-template<template<typename> typename Red, typename T>
+template <template <typename> typename Red, typename T>
 __device__ __forceinline__ void ncclSymkRun_AllReduce_AGxLL_R_impl(ncclSymkDevWorkArgs const* args, bool multimem) {
   ncclSymkArgsHandler handler{args};
-  ncclLLA2ASession<ncclCoopCta> lla2a(
-    ncclCoopCta(), handler.comm, ncclTeamLsa(handler.comm), handler.lsaLLA2A,
-    blockIdx.x, ncclSymkMaxThreads, multimem, handler.comm.lsaMultimem
-  );
+  ncclLLA2ASession<ncclCoopCta> lla2a(ncclCoopCta(), handler.comm, ncclTeamLsa(handler.comm), handler.lsaLLA2A,
+                                      blockIdx.x, ncclSymkMaxThreads, multimem, handler.comm.lsaMultimem);
 
   int const& rank = handler.comm.rank;
   int const& nRanks = handler.comm.nRanks;
@@ -492,83 +458,70 @@ __device__ __forceinline__ void ncclSymkRun_AllReduce_AGxLL_R_impl(ncclSymkDevWo
   Red<Acc> red(handler.devWork->redOpArg);
 
   using Pack = BytePack<8>;
-  using AccPack = BytePack<8*sizeof(Acc)/sizeof(T)>;
-  constexpr int EltPerPack = 8/sizeof(T);
+  using AccPack = BytePack<8 * sizeof(Acc) / sizeof(T)>;
+  constexpr int EltPerPack = 8 / sizeof(T);
 
-  handler.singleWork<T>(
-      [&]__device__(int nElts, int nAllElts,
-                    ncclSymPtr<T> inputPtr, ncclSymPtr<T> outputPtr) {
-        int nPacks = divUp(nElts, EltPerPack);
+  handler.singleWork<T>([&] __device__(int nElts, int nAllElts, ncclSymPtr<T> inputPtr, ncclSymPtr<T> outputPtr) {
+    int nPacks = divUp(nElts, EltPerPack);
 
-        T* input = (T*)inputPtr.localPtr();
-        T* output = (T*)outputPtr.localPtr();
+    T* input = (T*)inputPtr.localPtr();
+    T* output = (T*)outputPtr.localPtr();
 
-        bool packAligned = 8 <= alignof(T) || (nElts*sizeof(T) | (uintptr_t)input | (uintptr_t)output)%8 == 0;
+    bool packAligned = 8 <= alignof(T) || (nElts * sizeof(T) | (uintptr_t)input | (uintptr_t)output) % 8 == 0;
 
-        ncclCoopCta cta;
-        int t = threadIdx.x;
-        int tn = ncclSymkMaxThreads;
+    ncclCoopCta cta;
+    int t = threadIdx.x;
+    int tn = ncclSymkMaxThreads;
 
-        if (__builtin_expect(packAligned, true)) {
-          #pragma unroll 1
-          while (0 < nPacks) {
-            if (t < nPacks) {
-              int nIterPacks = min(nPacks, tn);
-              Pack inp = loadPack<Pack>((Pack*)input, t, nPacks);
-              lla2a.bcast(/*slot=*/nIterPacks*rank + t, inp);
-              AccPack out = lla2a.template recvReduce</*Unroll=*/8, Pack>(
-                /*slotStart=*/t, /*slotCount=*/nRanks, /*slotStride=*/nIterPacks,
-                /*eltToAcc=*/[&] __device__ (Pack x)->AccPack {
-                  return applyCast<T, Acc>(x);
-                },
-                /*reduce=*/[&] __device__ (AccPack a, AccPack b)->AccPack {
-                  return applyReduce(red, a, b);
-                }
-              );
-              storePack((Pack*)output, t, nPacks, applyCast<Acc, T>(out));
-            }
-            lla2a.endEpoch(cta);
-
-            input += tn*EltPerPack;
-            output += tn*EltPerPack;
-            nPacks -= tn;
-          }
-        } else {
-          #pragma unroll 1
-          while (0 < nElts) {
-            if (t*EltPerPack < nElts) {
-              int nIterPacks = min(nPacks, tn);
-              Pack inp = loadPack<Pack>(input, t*EltPerPack, nElts);
-              lla2a.bcast(/*slot=*/nIterPacks*rank + t, inp);
-              AccPack out = lla2a.template recvReduce</*Unroll=*/8, Pack>(
-                /*slotStart=*/t, /*slotCount=*/nRanks, /*slotStride=*/nIterPacks,
-                /*eltToAcc=*/[&] __device__ (Pack x)->AccPack {
-                  return applyCast<T, Acc>(x);
-                },
-                /*reduce=*/[&] __device__ (AccPack a, AccPack b)->AccPack {
-                  return applyReduce(red, a, b);
-                }
-              );
-              storePack(output, t*EltPerPack, nElts, applyCast<Acc, T>(out));
-            }
-            lla2a.endEpoch(cta);
-
-            input += tn*EltPerPack;
-            output += tn*EltPerPack;
-            nElts -= tn*EltPerPack;
-            nPacks -= tn;
-          }
+    if (__builtin_expect(packAligned, true)) {
+#pragma unroll 1
+      while (0 < nPacks) {
+        if (t < nPacks) {
+          int nIterPacks = min(nPacks, tn);
+          Pack inp = loadPack<Pack>((Pack*)input, t, nPacks);
+          lla2a.bcast(/*slot=*/nIterPacks * rank + t, inp);
+          AccPack out = lla2a.template recvReduce</*Unroll=*/8, Pack>(
+            /*slotStart=*/t, /*slotCount=*/nRanks, /*slotStride=*/nIterPacks,
+            /*eltToAcc=*/[&] __device__(Pack x) -> AccPack { return applyCast<T, Acc>(x); },
+            /*reduce=*/[&] __device__(AccPack a, AccPack b) -> AccPack { return applyReduce(red, a, b); });
+          storePack((Pack*)output, t, nPacks, applyCast<Acc, T>(out));
         }
+        lla2a.endEpoch(cta);
+
+        input += tn * EltPerPack;
+        output += tn * EltPerPack;
+        nPacks -= tn;
       }
-    );
+    } else {
+#pragma unroll 1
+      while (0 < nElts) {
+        if (t * EltPerPack < nElts) {
+          int nIterPacks = min(nPacks, tn);
+          Pack inp = loadPack<Pack>(input, t * EltPerPack, nElts);
+          lla2a.bcast(/*slot=*/nIterPacks * rank + t, inp);
+          AccPack out = lla2a.template recvReduce</*Unroll=*/8, Pack>(
+            /*slotStart=*/t, /*slotCount=*/nRanks, /*slotStride=*/nIterPacks,
+            /*eltToAcc=*/[&] __device__(Pack x) -> AccPack { return applyCast<T, Acc>(x); },
+            /*reduce=*/[&] __device__(AccPack a, AccPack b) -> AccPack { return applyReduce(red, a, b); });
+          storePack(output, t * EltPerPack, nElts, applyCast<Acc, T>(out));
+        }
+        lla2a.endEpoch(cta);
+
+        input += tn * EltPerPack;
+        output += tn * EltPerPack;
+        nElts -= tn * EltPerPack;
+        nPacks -= tn;
+      }
+    }
+  });
 }
 
-template<template<typename> typename Red, typename T>
+template <template <typename> typename Red, typename T>
 __device__ __forceinline__ void ncclSymkRun_AllReduce_AGxLL_R(ncclSymkDevWorkArgs const* args) {
   ncclSymkRun_AllReduce_AGxLL_R_impl<Red, T>(args, /*multimem=*/false);
 }
 
-template<template<typename> typename Red, typename T>
+template <template <typename> typename Red, typename T>
 __device__ __forceinline__ void ncclSymkRun_AllReduce_AGxLLMC_R(ncclSymkDevWorkArgs const* args) {
   ncclSymkRun_AllReduce_AGxLL_R_impl<Red, T>(args, /*multimem=*/true);
 }

--- a/projects/rccl/src/device/symmetric/data_ops.cuh
+++ b/projects/rccl/src/device/symmetric/data_ops.cuh
@@ -10,46 +10,57 @@ struct GenMemTag {}; // Generic memory (either global or shared)
 
 // Like CUDA's __ldcs() except works for all types T and handles smem so long as
 // it is tagged accurately.
-template<typename T>
-static __device__ __forceinline__ T ldcs(GenMemTag, T *p) {
+template <typename T>
+static __device__ __forceinline__ T ldcs(GenMemTag, T* p) {
   return *p;
 }
-template<typename T>
-static __device__ __forceinline__ T ldcs(SMemTag, T *p) {
+template <typename T>
+static __device__ __forceinline__ T ldcs(SMemTag, T* p) {
   __builtin_assume(__isShared(p));
   return *p;
 }
-template<typename T>
-static __device__ __forceinline__ T ldcs(GMemTag, T *p) {
+template <typename T>
+static __device__ __forceinline__ T ldcs(GMemTag, T* p) {
   union {
     T x;
     uint8_t u8[sizeof(T)];
-    uint16_t u16[(sizeof(T)+2-1)/2];
-    uint32_t u32[(sizeof(T)+4-1)/4];
-    uint64_t u64[(sizeof(T)+8-1)/8];
-    uint4 u32v4[(sizeof(T)+16-1)/16];
+    uint16_t u16[(sizeof(T) + 2 - 1) / 2];
+    uint32_t u32[(sizeof(T) + 4 - 1) / 4];
+    uint64_t u64[(sizeof(T) + 8 - 1) / 8];
+    uint4 u32v4[(sizeof(T) + 16 - 1) / 16];
   };
 #if defined(__HIP_PLATFORM_AMD__)
   // HIP has no __ldcs(); use clang non-temporal loads, dispatched on alignof(T).
   if constexpr (alignof(T) == 1) {
-    for (int i=0; i < sizeof(T)/1; i++) u8[i] = __builtin_nontemporal_load((uint8_t*)p + i);
+    for (int i = 0; i < sizeof(T) / 1; i++) u8[i] = __builtin_nontemporal_load((uint8_t*)p + i);
   } else if constexpr (alignof(T) == 2) {
-    for (int i=0; i < sizeof(T)/2; i++) u16[i] = __builtin_nontemporal_load((uint16_t*)p + i);
+    for (int i = 0; i < sizeof(T) / 2; i++) u16[i] = __builtin_nontemporal_load((uint16_t*)p + i);
   } else if constexpr (alignof(T) == 4) {
-    for (int i=0; i < sizeof(T)/4; i++) u32[i] = __builtin_nontemporal_load((uint32_t*)p + i);
+    for (int i = 0; i < sizeof(T) / 4; i++) u32[i] = __builtin_nontemporal_load((uint32_t*)p + i);
   } else if constexpr (alignof(T) == 8 || alignof(T) == 16) {
-    for (int i=0; i < sizeof(T)/8; i++) u64[i] = __builtin_nontemporal_load((uint64_t*)p + i);
+    for (int i = 0; i < sizeof(T) / 8; i++) u64[i] = __builtin_nontemporal_load((uint64_t*)p + i);
   } else {
     __builtin_unreachable();
   }
 #else
   switch (alignof(T)) {
-  case 1: for (int i=0; i < sizeof(T)/1; i++) u8[i] = __ldcs((uint8_t*)p + i); break;
-  case 2: for (int i=0; i < sizeof(T)/2; i++) u16[i] = __ldcs((uint16_t*)p + i); break;
-  case 4: for (int i=0; i < sizeof(T)/4; i++) u32[i] = __ldcs((uint32_t*)p + i); break;
-  case 8: for (int i=0; i < sizeof(T)/8; i++) u64[i] = __ldcs((uint64_t*)p + i); break;
-  case 16: for (int i=0; i < sizeof(T)/16; i++) u32v4[i] = __ldcs((uint4*)p + i); break;
-  default: __builtin_unreachable();
+  case 1:
+    for (int i = 0; i < sizeof(T) / 1; i++) u8[i] = __ldcs((uint8_t*)p + i);
+    break;
+  case 2:
+    for (int i = 0; i < sizeof(T) / 2; i++) u16[i] = __ldcs((uint16_t*)p + i);
+    break;
+  case 4:
+    for (int i = 0; i < sizeof(T) / 4; i++) u32[i] = __ldcs((uint32_t*)p + i);
+    break;
+  case 8:
+    for (int i = 0; i < sizeof(T) / 8; i++) u64[i] = __ldcs((uint64_t*)p + i);
+    break;
+  case 16:
+    for (int i = 0; i < sizeof(T) / 16; i++) u32v4[i] = __ldcs((uint4*)p + i);
+    break;
+  default:
+    __builtin_unreachable();
   }
 #endif
   return x;
@@ -57,47 +68,58 @@ static __device__ __forceinline__ T ldcs(GMemTag, T *p) {
 
 // Like CUDA's __stcs() except works for all types T and handles smem so long as
 // it is tagged accurately.
-template<typename T>
-static __device__ __forceinline__ void stcs(GenMemTag, T *p, T val) {
+template <typename T>
+static __device__ __forceinline__ void stcs(GenMemTag, T* p, T val) {
   *p = val;
 }
-template<typename T>
-static __device__ __forceinline__ void stcs(SMemTag, T *p, T val) {
+template <typename T>
+static __device__ __forceinline__ void stcs(SMemTag, T* p, T val) {
   __builtin_assume(__isShared(p));
   *p = val;
 }
-template<typename T>
-static __device__ __forceinline__ void stcs(GMemTag, T *p, T val) {
+template <typename T>
+static __device__ __forceinline__ void stcs(GMemTag, T* p, T val) {
   union {
     T x;
     uint8_t u8[sizeof(T)];
-    uint16_t u16[(sizeof(T)+2-1)/2];
-    uint32_t u32[(sizeof(T)+4-1)/4];
-    uint64_t u64[(sizeof(T)+8-1)/8];
-    uint4 u32v4[(sizeof(T)+16-1)/16];
+    uint16_t u16[(sizeof(T) + 2 - 1) / 2];
+    uint32_t u32[(sizeof(T) + 4 - 1) / 4];
+    uint64_t u64[(sizeof(T) + 8 - 1) / 8];
+    uint4 u32v4[(sizeof(T) + 16 - 1) / 16];
   };
   x = val;
 #if defined(__HIP_PLATFORM_AMD__)
   // HIP has no __stcs(); use clang non-temporal stores (value, ptr), dispatched on alignof(T).
   if constexpr (alignof(T) == 1) {
-    for (int i=0; i < sizeof(T)/1; i++) __builtin_nontemporal_store(u8[i], (uint8_t*)p + i);
+    for (int i = 0; i < sizeof(T) / 1; i++) __builtin_nontemporal_store(u8[i], (uint8_t*)p + i);
   } else if constexpr (alignof(T) == 2) {
-    for (int i=0; i < sizeof(T)/2; i++) __builtin_nontemporal_store(u16[i], (uint16_t*)p + i);
+    for (int i = 0; i < sizeof(T) / 2; i++) __builtin_nontemporal_store(u16[i], (uint16_t*)p + i);
   } else if constexpr (alignof(T) == 4) {
-    for (int i=0; i < sizeof(T)/4; i++) __builtin_nontemporal_store(u32[i], (uint32_t*)p + i);
+    for (int i = 0; i < sizeof(T) / 4; i++) __builtin_nontemporal_store(u32[i], (uint32_t*)p + i);
   } else if constexpr (alignof(T) == 8 || alignof(T) == 16) {
-    for (int i=0; i < sizeof(T)/8; i++) __builtin_nontemporal_store(u64[i], (uint64_t*)p + i);
+    for (int i = 0; i < sizeof(T) / 8; i++) __builtin_nontemporal_store(u64[i], (uint64_t*)p + i);
   } else {
     __builtin_unreachable();
   }
 #else
   switch (alignof(T)) {
-  case 1: for (int i=0; i < sizeof(T)/1; i++) __stcs((uint8_t*)p + i, u8[i]); break;
-  case 2: for (int i=0; i < sizeof(T)/2; i++) __stcs((uint16_t*)p + i, u16[i]); break;
-  case 4: for (int i=0; i < sizeof(T)/4; i++) __stcs((uint32_t*)p + i, u32[i]); break;
-  case 8: for (int i=0; i < sizeof(T)/8; i++) __stcs((uint64_t*)p + i, u64[i]); break;
-  case 16: for (int i=0; i < sizeof(T)/16; i++) __stcs((uint4*)p + i, u32v4[i]); break;
-  default: __builtin_unreachable();
+  case 1:
+    for (int i = 0; i < sizeof(T) / 1; i++) __stcs((uint8_t*)p + i, u8[i]);
+    break;
+  case 2:
+    for (int i = 0; i < sizeof(T) / 2; i++) __stcs((uint16_t*)p + i, u16[i]);
+    break;
+  case 4:
+    for (int i = 0; i < sizeof(T) / 4; i++) __stcs((uint32_t*)p + i, u32[i]);
+    break;
+  case 8:
+    for (int i = 0; i < sizeof(T) / 8; i++) __stcs((uint64_t*)p + i, u64[i]);
+    break;
+  case 16:
+    for (int i = 0; i < sizeof(T) / 16; i++) __stcs((uint4*)p + i, u32v4[i]);
+    break;
+  default:
+    __builtin_unreachable();
   }
 #endif
 }
@@ -106,73 +128,76 @@ static __device__ __forceinline__ void stcs(GMemTag, T *p, T val) {
 // down to pack alignment so it begins with unused padding elements equal in
 // number to how misaligned the buffer is. The last pack may alias out of bounds
 // elements. If it is completely out of bounds it will not be loaded.
-template<typename Pack, int nPacks, typename MemTag, typename Elt>
+template <typename Pack, int nPacks, typename MemTag, typename Elt>
 static __device__ __forceinline__ void loadPacks(
-    Pack(&packs)[nPacks],
-    MemTag mem,
-    unsigned eltsAlignMin, // (Compile time) Minimum byte alignment of elts. Zero = infinitely aligned.
-    Elt* elts, // The element buffer. Need not be aligned.
-    int nElts, // Total number of elements so we can tell what is legal to load.
-    int padElts, // Number of misaligned elements in first pack.
-    int packIx, // Index of our first pack (typically coop.thread_rank()).
-    int stride, // Index stride of packs (typically coop.size()).
-    bool lastEmpty // Is our last pack completely out of bounds.
-  ) {
-  constexpr int nEltPerPack = sizeof(Pack)/sizeof(Elt);
-  bool eltsAligned = sizeof(Pack)-1 <= eltsAlignMin-1 || reinterpret_cast<uintptr_t>(elts)%sizeof(Pack) == 0;
+  Pack (&packs)[nPacks], MemTag mem,
+  unsigned eltsAlignMin, // (Compile time) Minimum byte alignment of elts. Zero = infinitely aligned.
+  Elt* elts, // The element buffer. Need not be aligned.
+  int nElts, // Total number of elements so we can tell what is legal to load.
+  int padElts, // Number of misaligned elements in first pack.
+  int packIx, // Index of our first pack (typically coop.thread_rank()).
+  int stride, // Index stride of packs (typically coop.size()).
+  bool lastEmpty // Is our last pack completely out of bounds.
+) {
+  constexpr int nEltPerPack = sizeof(Pack) / sizeof(Elt);
+  bool eltsAligned = sizeof(Pack) - 1 <= eltsAlignMin - 1 || reinterpret_cast<uintptr_t>(elts) % sizeof(Pack) == 0;
   if (__builtin_expect(padElts == 0 && eltsAligned, true)) {
-    #pragma unroll nPacks
-    for (int p=0; p < nPacks; p++) {
-      if (p < nPacks-1 || !lastEmpty) {
-        packs[p] = ldcs(mem, (Pack*)elts + packIx + p*stride);
+#pragma unroll nPacks
+    for (int p = 0; p < nPacks; p++) {
+      if (p < nPacks - 1 || !lastEmpty) {
+        packs[p] = ldcs(mem, (Pack*)elts + packIx + p * stride);
       }
     }
   } else {
     Pack stage[nPacks];
-    #pragma unroll 16/nEltPerPack
-    for (int p=0; p < nPacks; p++) {
-      union { Pack tmp; Elt elt[nEltPerPack]; };
+#pragma unroll 16 / nEltPerPack
+    for (int p = 0; p < nPacks; p++) {
+      union {
+        Pack tmp;
+        Elt elt[nEltPerPack];
+      };
       tmp = {};
-      #pragma unroll 8
-      for (int pe=0; pe < nEltPerPack; pe++) {
-        int e = -padElts + (packIx + p*stride)*nEltPerPack + pe;
+#pragma unroll 8
+      for (int pe = 0; pe < nEltPerPack; pe++) {
+        int e = -padElts + (packIx + p * stride) * nEltPerPack + pe;
         // if (0 <= e && e < nElts)
         if (unsigned(e) < unsigned(nElts)) elt[pe] = ldcs(mem, elts + e);
       }
       stage[p] = tmp;
     }
-    #pragma unroll
-    for (int p=0; p < nPacks; p++) packs[p] = stage[p];
+#pragma unroll
+    for (int p = 0; p < nPacks; p++) packs[p] = stage[p];
   }
 }
 
 // Reverse of loadPacks except the destination buffer alignemnt has no assumed
 // relationship with the number of padding elements.
-template<typename Pack, int nPacks, typename MemTag, typename Elt>
-static __device__ __forceinline__ void storePacks(
-    Pack(&packs)[nPacks], MemTag mem, unsigned eltsAlignMin, Elt* elts,
-    int nElts, int padElts, int packIx, int stride, bool lastEmpty
-  ) {
-  constexpr int nEltPerPack = sizeof(Pack)/sizeof(Elt);
-  bool eltsAligned = sizeof(Pack)-1 <= eltsAlignMin-1 || reinterpret_cast<uintptr_t>(elts)%sizeof(Pack) == 0;
+template <typename Pack, int nPacks, typename MemTag, typename Elt>
+static __device__ __forceinline__ void storePacks(Pack (&packs)[nPacks], MemTag mem, unsigned eltsAlignMin, Elt* elts,
+                                                  int nElts, int padElts, int packIx, int stride, bool lastEmpty) {
+  constexpr int nEltPerPack = sizeof(Pack) / sizeof(Elt);
+  bool eltsAligned = sizeof(Pack) - 1 <= eltsAlignMin - 1 || reinterpret_cast<uintptr_t>(elts) % sizeof(Pack) == 0;
   if (__builtin_expect(padElts == 0 && eltsAligned, true)) {
-    #pragma unroll nPacks
-    for (int p=0; p < nPacks; p++) {
-      if (p < nPacks-1 || !lastEmpty) {
-        stcs(mem, (Pack*)elts + packIx + p*stride, packs[p]);
+#pragma unroll nPacks
+    for (int p = 0; p < nPacks; p++) {
+      if (p < nPacks - 1 || !lastEmpty) {
+        stcs(mem, (Pack*)elts + packIx + p * stride, packs[p]);
       }
     }
   } else {
     Pack stage[nPacks];
-    #pragma unroll
-    for (int p=0; p < nPacks; p++) stage[p] = packs[p];
-    #pragma unroll 16/nEltPerPack
-    for (int p=0; p < nPacks; p++) {
-      union { Pack tmp; Elt elt[nEltPerPack]; };
+#pragma unroll
+    for (int p = 0; p < nPacks; p++) stage[p] = packs[p];
+#pragma unroll 16 / nEltPerPack
+    for (int p = 0; p < nPacks; p++) {
+      union {
+        Pack tmp;
+        Elt elt[nEltPerPack];
+      };
       tmp = stage[p];
-      #pragma unroll 8
-      for (int pe=0; pe < nEltPerPack; pe++) {
-        int e = -padElts + (packIx + p*stride)*nEltPerPack + pe;
+#pragma unroll 8
+      for (int pe = 0; pe < nEltPerPack; pe++) {
+        int e = -padElts + (packIx + p * stride) * nEltPerPack + pe;
         // if (0 <= e && e < nElts)
         if (unsigned(e) < unsigned(nElts)) stcs(mem, elts + e, elt[pe]);
       }
@@ -180,37 +205,33 @@ static __device__ __forceinline__ void storePacks(
   }
 }
 
-template<typename Elt, template<typename> typename Red,
-         typename Acc, typename AccPack, int UnrollData, typename GetSrcFn>
-static __device__ __forceinline__ void accumulateLoads(
-    Red<Acc> red, bool inPlace, AccPack(&accs)[UnrollData], int stride, bool lastPackEmpty,
-    int nSrcs, GetSrcFn getSrc
-  ) {
+template <typename Elt, template <typename> typename Red, typename Acc, typename AccPack, int UnrollData,
+          typename GetSrcFn>
+static __device__ __forceinline__ void accumulateLoads(Red<Acc> red, bool inPlace, AccPack (&accs)[UnrollData],
+                                                       int stride, bool lastPackEmpty, int nSrcs, GetSrcFn getSrc) {
   using EltPack = ncclDecayType_t<decltype(*getSrc(0))>;
-  static_assert(sizeof(Acc)/sizeof(Elt) == sizeof(AccPack)/sizeof(EltPack), "Required");
-  constexpr int UnrollSrcs = 4*16 < sizeof(AccPack)*UnrollData ? 2 :
-                             1*16 <= sizeof(AccPack)*UnrollData ? 4 :
-                             8;
+  static_assert(sizeof(Acc) / sizeof(Elt) == sizeof(AccPack) / sizeof(EltPack), "Required");
+  constexpr int UnrollSrcs = 4 * 16 < sizeof(AccPack) * UnrollData ? 2 : 1 * 16 <= sizeof(AccPack) * UnrollData ? 4 : 8;
   int srcIx = 0;
   bool accValid = inPlace;
-  #pragma unroll 1
+#pragma unroll 1
   while (srcIx + UnrollSrcs <= nSrcs) {
     EltPack tmp[UnrollSrcs][UnrollData] = {};
-    #pragma unroll UnrollSrcs
-    for (int su=0; su < UnrollSrcs; su++) {
+#pragma unroll UnrollSrcs
+    for (int su = 0; su < UnrollSrcs; su++) {
       EltPack* srcPtr = getSrc(srcIx + su);
-      #pragma unroll UnrollData
-      for (int du=0; du < UnrollData; du++) {
-        if (du != UnrollData-1 || !lastPackEmpty) {
-          tmp[su][du] = ldcs(GMemTag(), srcPtr + du*stride);
+#pragma unroll UnrollData
+      for (int du = 0; du < UnrollData; du++) {
+        if (du != UnrollData - 1 || !lastPackEmpty) {
+          tmp[su][du] = ldcs(GMemTag(), srcPtr + du * stride);
         }
       }
     }
-    #pragma unroll UnrollSrcs
-    for (int su=0; su < UnrollSrcs; su++) {
-      #pragma unroll UnrollData
-      for (int du=0; du < UnrollData; du++) {
-        if (du != UnrollData-1 || !lastPackEmpty) {
+#pragma unroll UnrollSrcs
+    for (int su = 0; su < UnrollSrcs; su++) {
+#pragma unroll UnrollData
+      for (int du = 0; du < UnrollData; du++) {
+        if (du != UnrollData - 1 || !lastPackEmpty) {
           AccPack a = fromPack<AccPack>(applyCast<Elt, Acc>(tmp[su][du]));
           accs[du] = su == 0 && !accValid ? a : applyReduce(red, accs[du], a);
         }
@@ -221,25 +242,25 @@ static __device__ __forceinline__ void accumulateLoads(
   }
 
   if (srcIx < nSrcs) {
-    EltPack tmp[UnrollSrcs-1 ? UnrollSrcs-1 : 1][UnrollData] = {};
-    #pragma unroll (UnrollSrcs-1 ? UnrollSrcs-1 : 1)
-    for (int su=0; su < UnrollSrcs-1; su++) {
+    EltPack tmp[UnrollSrcs - 1 ? UnrollSrcs - 1 : 1][UnrollData] = {};
+#pragma unroll(UnrollSrcs - 1 ? UnrollSrcs - 1 : 1)
+    for (int su = 0; su < UnrollSrcs - 1; su++) {
       EltPack* srcPtr = getSrc(srcIx + su);
       if (!(su != 0 && nSrcs <= srcIx + su)) {
-        #pragma unroll UnrollData
-        for (int du=0; du < UnrollData; du++) {
-          if (du != UnrollData-1 || !lastPackEmpty) {
-            tmp[su][du] = ldcs(GMemTag(), srcPtr + du*stride);
+#pragma unroll UnrollData
+        for (int du = 0; du < UnrollData; du++) {
+          if (du != UnrollData - 1 || !lastPackEmpty) {
+            tmp[su][du] = ldcs(GMemTag(), srcPtr + du * stride);
           }
         }
       }
     }
-    #pragma unroll (UnrollSrcs-1 ? UnrollSrcs-1 : 1)
-    for (int su=0; su < UnrollSrcs-1; su++) {
+#pragma unroll(UnrollSrcs - 1 ? UnrollSrcs - 1 : 1)
+    for (int su = 0; su < UnrollSrcs - 1; su++) {
       if (su != 0 && nSrcs <= srcIx + su) break;
-      #pragma unroll UnrollData
-      for (int du=0; du < UnrollData; du++) {
-        if (du != UnrollData-1 || !lastPackEmpty) {
+#pragma unroll UnrollData
+      for (int du = 0; du < UnrollData; du++) {
+        if (du != UnrollData - 1 || !lastPackEmpty) {
           AccPack a = fromPack<AccPack>(applyCast<Elt, Acc>(tmp[su][du]));
           accs[du] = su == 0 && !accValid ? a : applyReduce(red, accs[du], a);
         }
@@ -255,21 +276,18 @@ static __device__ inline unsigned getWorstPackCount(unsigned nElts, unsigned nEl
   //   nElts=2 --> nPacks=2
   //   nElts=nEltPerPack+1 --> nPacks=2
   //   nElts=nEltPerPack+2 --> nPacks=3
-  return (nElts + 2*(nEltPerPack-1))/nEltPerPack;
+  return (nElts + 2 * (nEltPerPack - 1)) / nEltPerPack;
 }
 
-template<typename Coop, typename DstSpace, typename GetDst,
-         template<typename> typename Red, typename Acc,
-         typename GetSrc, typename GetSrcPtrMasked>
- __device__ void reduceBatch(
-    Coop coop, bool inPlace, int nBatch, int nElts,
-    DstSpace dstMem, unsigned dstAlignMin, /*(int i)->DstT* */GetDst getDst,
-    Red<Acc> red, int nSrcs, /*(int i, int srcIx)->SrcT* */GetSrc getSrc,
+template <typename Coop, typename DstSpace, typename GetDst, template <typename> typename Red, typename Acc,
+          typename GetSrc, typename GetSrcPtrMasked>
+__device__ void reduceBatch(Coop coop, bool inPlace, int nBatch, int nElts, DstSpace dstMem, unsigned dstAlignMin,
+                            /*(int i)->DstT* */ GetDst getDst, Red<Acc> red, int nSrcs,
+                            /*(int i, int srcIx)->SrcT* */ GetSrc getSrc,
     // srcPtrCommonMask: All srcs must have matching values of srcPtr & srcPtrCommonMask
-    unsigned srcPtrCommonMask,
-    // getSrcPtrMasked: The common srcPtr & srcPtrCommonMask value shared by all srcs in group
-    /*(int i)->unsigned*/GetSrcPtrMasked getSrcPtrMasked
-  ) {
+                            unsigned srcPtrCommonMask,
+                            // getSrcPtrMasked: The common srcPtr & srcPtrCommonMask value shared by all srcs in group
+                            /*(int i)->unsigned*/ GetSrcPtrMasked getSrcPtrMasked) {
   using DstT = ncclDecayType_t<decltype(*getDst(0))>;
   using SrcT = ncclDecayType_t<decltype(*getSrc(0, 0))>;
   static_assert(sizeof(SrcT) <= sizeof(DstT), "Required");
@@ -278,59 +296,55 @@ template<typename Coop, typename DstSpace, typename GetDst,
   int t = coop.thread_rank();
 
   using SrcPack = BytePack<16>;
-  constexpr unsigned nEltPerPack = 16/sizeof(SrcT);
-  using DstPack = BytePack<sizeof(SrcPack)*sizeof(DstT)/sizeof(SrcT)>;
-  using AccPack = BytePack<sizeof(SrcPack)*sizeof(Acc)/sizeof(SrcT)>;
+  constexpr unsigned nEltPerPack = 16 / sizeof(SrcT);
+  using DstPack = BytePack<sizeof(SrcPack) * sizeof(DstT) / sizeof(SrcT)>;
+  using AccPack = BytePack<sizeof(SrcPack) * sizeof(Acc) / sizeof(SrcT)>;
 
   // Handle source elements as packs if:
   // 1. All sources share a sufficient common alignment to support pack access.
   // 2. There is enough for every thread to have one.
-  if (!(NCCL_CUDA_ARCH == 900 && sizeof(SrcT) == 1) && (
-      sizeof(SrcT) == sizeof(SrcPack) ||
-      (/*1*/sizeof(SrcPack)-1 <= srcPtrCommonMask &&
-       /*2*/tn*(int)sizeof(SrcPack) <= nBatch*nElts*(int)sizeof(SrcT))
-  )) {
+  if (!(NCCL_CUDA_ARCH == 900 && sizeof(SrcT) == 1) &&
+      (sizeof(SrcT) == sizeof(SrcPack) || (/*1*/ sizeof(SrcPack) - 1 <= srcPtrCommonMask &&
+                                           /*2*/ tn * (int)sizeof(SrcPack) <= nBatch * nElts * (int)sizeof(SrcT)))) {
     int nPacks = getWorstPackCount(nElts, nEltPerPack);
     constexpr int UnrollData = 4;
-    constexpr int nPackPerBlob = UnrollData*32; // A blob is a whole warp's worth of unrolled packs
-    int nBlobs = unsigned(nPacks)/nPackPerBlob;
-    #pragma unroll 1
-    for (int row = unsigned(t)/32; row < nBatch*nBlobs; row += unsigned(tn)/32) {
-      int batchIx = unsigned(row)/unsigned(nBlobs);
-      int blobIx = unsigned(row)%unsigned(nBlobs);
-      int padElts = (getSrcPtrMasked(batchIx) % sizeof(SrcPack))/sizeof(SrcT);
+    constexpr int nPackPerBlob = UnrollData * 32; // A blob is a whole warp's worth of unrolled packs
+    int nBlobs = unsigned(nPacks) / nPackPerBlob;
+#pragma unroll 1
+    for (int row = unsigned(t) / 32; row < nBatch * nBlobs; row += unsigned(tn) / 32) {
+      int batchIx = unsigned(row) / unsigned(nBlobs);
+      int blobIx = unsigned(row) % unsigned(nBlobs);
+      int padElts = (getSrcPtrMasked(batchIx) % sizeof(SrcPack)) / sizeof(SrcT);
       DstT* dstPtr = getDst(batchIx);
 
-      int lane = unsigned(t)%32;
-      int packIx = blobIx*nPackPerBlob + lane;
-      bool lastPackEmpty = padElts + nElts <= (packIx + (UnrollData-1)*32)*nEltPerPack;
+      int lane = unsigned(t) % 32;
+      int packIx = blobIx * nPackPerBlob + lane;
+      bool lastPackEmpty = padElts + nElts <= (packIx + (UnrollData - 1) * 32) * nEltPerPack;
       AccPack acc[UnrollData] = {};
       if (inPlace) {
         DstPack dstVal[UnrollData];
         loadPacks(dstVal, dstMem, dstAlignMin, dstPtr, nElts, padElts, packIx, 32, lastPackEmpty);
-        #pragma unroll
-        for (int u=0; u < UnrollData; u++) acc[u] = applyCast<DstT, Acc>(dstVal[u]);
+#pragma unroll
+        for (int u = 0; u < UnrollData; u++) acc[u] = applyCast<DstT, Acc>(dstVal[u]);
       }
-      accumulateLoads<SrcT>(
-        red, inPlace, acc, /*stride=*/32, lastPackEmpty, nSrcs,
-        [&]__device__(int srcIx)->SrcPack* {
-          return (SrcPack*)(getSrc(batchIx, srcIx) - padElts) + packIx;
-        }
-      );
+      accumulateLoads<SrcT>(red, inPlace, acc, /*stride=*/32, lastPackEmpty, nSrcs,
+                            [&] __device__(int srcIx) -> SrcPack* {
+                              return (SrcPack*)(getSrc(batchIx, srcIx) - padElts) + packIx;
+                            });
       DstPack dstVal[UnrollData];
-      #pragma unroll
-      for (int u=0; u < UnrollData; u++) dstVal[u] = applyCast<Acc, DstT>(acc[u]);
+#pragma unroll
+      for (int u = 0; u < UnrollData; u++) dstVal[u] = applyCast<Acc, DstT>(acc[u]);
       storePacks(dstVal, dstMem, dstAlignMin, dstPtr, nElts, padElts, packIx, 32, lastPackEmpty);
     }
-    int nRemPacks = nPacks - nBlobs*nPackPerBlob;
-    #pragma unroll 1
-    for (int row = t; row < nBatch*nRemPacks; row += tn) {
-      int batchIx = unsigned(row)/unsigned(nRemPacks);
-      int packIx = nBlobs*nPackPerBlob + unsigned(row)%unsigned(nRemPacks);
-      int padElts = (getSrcPtrMasked(batchIx) % sizeof(SrcPack))/sizeof(SrcT);
+    int nRemPacks = nPacks - nBlobs * nPackPerBlob;
+#pragma unroll 1
+    for (int row = t; row < nBatch * nRemPacks; row += tn) {
+      int batchIx = unsigned(row) / unsigned(nRemPacks);
+      int packIx = nBlobs * nPackPerBlob + unsigned(row) % unsigned(nRemPacks);
+      int padElts = (getSrcPtrMasked(batchIx) % sizeof(SrcPack)) / sizeof(SrcT);
       DstT* dstPtr = getDst(batchIx);
 
-      bool packEmpty = padElts + nElts <= packIx*nEltPerPack;
+      bool packEmpty = padElts + nElts <= packIx * nEltPerPack;
       packEmpty = __builtin_expect(packEmpty, false);
       if (!packEmpty) {
         AccPack acc[1];
@@ -339,58 +353,45 @@ template<typename Coop, typename DstSpace, typename GetDst,
           loadPacks(dstVal, dstMem, dstAlignMin, dstPtr, nElts, padElts, packIx, tn, false);
           acc[0] = applyCast<DstT, Acc>(dstVal[0]);
         }
-        accumulateLoads<SrcT>(
-          red, inPlace, acc, /*stride(no data unroll)=*/0, /*lastPackEmpty=*/false, nSrcs,
-          [&]__device__(int srcIx)->SrcPack* {
-            return (SrcPack*)(getSrc(batchIx, srcIx) - padElts) + packIx;
-          }
-        );
+        accumulateLoads<SrcT>(red, inPlace, acc, /*stride(no data unroll)=*/0, /*lastPackEmpty=*/false, nSrcs,
+                              [&] __device__(int srcIx) -> SrcPack* {
+                                return (SrcPack*)(getSrc(batchIx, srcIx) - padElts) + packIx;
+                              });
         DstPack dstVal[1] = {applyCast<Acc, DstT>(acc[0])};
         storePacks(dstVal, dstMem, dstAlignMin, dstPtr, nElts, padElts, packIx, tn, false);
       }
     }
   } else {
-    #pragma unroll 1
-    for (int row = t; row < nBatch*nElts; row += tn) {
-      int batchIx = unsigned(row)/unsigned(nElts);
-      int eltIx = unsigned(row)%unsigned(nElts);
+#pragma unroll 1
+    for (int row = t; row < nBatch * nElts; row += tn) {
+      int batchIx = unsigned(row) / unsigned(nElts);
+      int eltIx = unsigned(row) % unsigned(nElts);
       DstT* dstPtr = getDst(batchIx);
       Acc acc[1];
       if (inPlace) acc[0] = (Acc)ldcs(dstMem, dstPtr + eltIx);
-      accumulateLoads<SrcT>(
-        red, inPlace, acc, /*stride(no data unroll)=*/0, /*lastPackEmpty=*/false, nSrcs,
-        [&]__device__(int srcIx)->SrcT* {
-          return getSrc(batchIx, srcIx) + eltIx;
-        }
-      );
+      accumulateLoads<SrcT>(red, inPlace, acc, /*stride(no data unroll)=*/0, /*lastPackEmpty=*/false, nSrcs,
+                            [&] __device__(int srcIx) -> SrcT* { return getSrc(batchIx, srcIx) + eltIx; });
       stcs(dstMem, dstPtr + eltIx, (DstT)acc[0]);
     }
   }
 }
 
-template<typename Coop, template<typename> typename Red, typename Acc,
-         typename DstSpace, typename DstT, typename GetSrc>
-static __device__ void reduce(
-    Coop coop, Red<Acc> red, bool inPlace, int nElts,
-    DstSpace dstMem, unsigned dstAlignMin, DstT* dst,
-    int nSrcs, unsigned srcPtrCommonMask, unsigned srcPtrMasked,
-    /*(int srcIx)->SrcT* */ GetSrc getSrc
-  ) {
-  reduceBatch(coop, inPlace, /*nBatch=*/1, nElts,
-    dstMem, dstAlignMin, [=]__device__(int d)->DstT* { return dst; },
-    red, nSrcs, [&]__device__(int d, int s) { return getSrc(s); },
-    srcPtrCommonMask,
-    /*getSrcPtrMasked=*/[=]__device__(int d)->unsigned { return srcPtrMasked; }
-  );
+template <typename Coop, template <typename> typename Red, typename Acc, typename DstSpace, typename DstT,
+          typename GetSrc>
+static __device__ void reduce(Coop coop, Red<Acc> red, bool inPlace, int nElts, DstSpace dstMem, unsigned dstAlignMin,
+                              DstT* dst, int nSrcs, unsigned srcPtrCommonMask, unsigned srcPtrMasked,
+                              /*(int srcIx)->SrcT* */ GetSrc getSrc) {
+  reduceBatch(
+    coop, inPlace, /*nBatch=*/1, nElts, dstMem, dstAlignMin, [=] __device__(int d) -> DstT* { return dst; }, red, nSrcs,
+    [&] __device__(int d, int s) { return getSrc(s); }, srcPtrCommonMask,
+    /*getSrcPtrMasked=*/[=] __device__(int d) -> unsigned { return srcPtrMasked; });
 }
 
-template<typename Coop, typename DstSpace, typename GetDst,
-         template<typename> typename Red, typename SrcT, typename GetSrc>
- __device__ void reduceMultimemBatch(
-    Coop coop, int nBatch, int nElts,
-    DstSpace dstMem, unsigned dstAlignMin, /*(int i)->DstT* */ GetDst getDst,
-    Red<SrcT> srcRed, /*(int i)->SrcT* */ GetSrc getSrc
-  ) {
+template <typename Coop, typename DstSpace, typename GetDst, template <typename> typename Red, typename SrcT,
+          typename GetSrc>
+__device__ void reduceMultimemBatch(Coop coop, int nBatch, int nElts, DstSpace dstMem, unsigned dstAlignMin,
+                                    /*(int i)->DstT* */ GetDst getDst, Red<SrcT> srcRed,
+                                    /*(int i)->SrcT* */ GetSrc getSrc) {
   using DstT = ncclDecayType_t<decltype(*getDst(0))>;
   using SrcT_1 = ncclDecayType_t<decltype(*getSrc(0))>;
   static_assert(sizeof(SrcT_1) == sizeof(SrcT), "Required");
@@ -400,89 +401,84 @@ template<typename Coop, typename DstSpace, typename GetDst,
   int t = coop.thread_rank();
 
   using SrcPack = BytePack<LoadMultimem_BigPackSize<Red<SrcT>>::BigPackSize>;
-  constexpr int nEltPerPack = sizeof(SrcPack)/sizeof(SrcT);
-  using DstPack = BytePack<sizeof(SrcPack)*sizeof(DstT)/sizeof(SrcT)>;
+  constexpr int nEltPerPack = sizeof(SrcPack) / sizeof(SrcT);
+  using DstPack = BytePack<sizeof(SrcPack) * sizeof(DstT) / sizeof(SrcT)>;
 
   // Handle source elements as packs if there is enough for every thread to have one.
-  if (sizeof(SrcT) == sizeof(SrcPack) || tn*(int)sizeof(SrcPack) <= nBatch*nElts*(int)sizeof(SrcT)) {
+  if (sizeof(SrcT) == sizeof(SrcPack) || tn * (int)sizeof(SrcPack) <= nBatch * nElts * (int)sizeof(SrcT)) {
     int nPacks = getWorstPackCount(nElts, nEltPerPack);
     constexpr int UnrollData = 4;
-    constexpr int nPackPerBlob = UnrollData*32; // A blob is a whole warp's worth of unrolled packs
-    int nBlobs = unsigned(nPacks)/nPackPerBlob;
-    #pragma unroll 1
-    for (int row = unsigned(t)/32; row < nBatch*nBlobs; row += unsigned(tn)/32) {
-      int batchIx = unsigned(row)/unsigned(nBlobs);
-      int blobIx = unsigned(row)%unsigned(nBlobs);
+    constexpr int nPackPerBlob = UnrollData * 32; // A blob is a whole warp's worth of unrolled packs
+    int nBlobs = unsigned(nPacks) / nPackPerBlob;
+#pragma unroll 1
+    for (int row = unsigned(t) / 32; row < nBatch * nBlobs; row += unsigned(tn) / 32) {
+      int batchIx = unsigned(row) / unsigned(nBlobs);
+      int blobIx = unsigned(row) % unsigned(nBlobs);
       DstT* dstPtr = getDst(batchIx);
       SrcT* srcPtr = getSrc(batchIx);
-      int padElts = (reinterpret_cast<uintptr_t>(srcPtr) % sizeof(SrcPack))/sizeof(SrcT);
+      int padElts = (reinterpret_cast<uintptr_t>(srcPtr) % sizeof(SrcPack)) / sizeof(SrcT);
 
-      int lane = unsigned(t)%32;
-      int packIx = blobIx*nPackPerBlob + lane;
-      bool lastPackEmpty = padElts + nElts <= (packIx + (UnrollData-1)*32)*nEltPerPack;
+      int lane = unsigned(t) % 32;
+      int packIx = blobIx * nPackPerBlob + lane;
+      bool lastPackEmpty = padElts + nElts <= (packIx + (UnrollData - 1) * 32) * nEltPerPack;
       SrcPack* srcPackPtr = (SrcPack*)(srcPtr - padElts) + packIx;
       SrcPack srcVal[UnrollData] = {};
-      #pragma unroll
-      for (int u=0; u < UnrollData; u++) {
-        if (u < UnrollData-1 || !lastPackEmpty) {
-          srcVal[u] = applyLoadMultimem<Red<SrcT>, sizeof(SrcPack)>(
-            srcRed, reinterpret_cast<uintptr_t>(srcPackPtr + u*32)
-          );
+#pragma unroll
+      for (int u = 0; u < UnrollData; u++) {
+        if (u < UnrollData - 1 || !lastPackEmpty) {
+          srcVal[u] =
+            applyLoadMultimem<Red<SrcT>, sizeof(SrcPack)>(srcRed, reinterpret_cast<uintptr_t>(srcPackPtr + u * 32));
         }
       }
       DstPack dstVal[UnrollData];
-      #pragma unroll
-      for (int u=0; u < UnrollData; u++) dstVal[u] = applyCast<SrcT, DstT>(srcVal[u]);
+#pragma unroll
+      for (int u = 0; u < UnrollData; u++) dstVal[u] = applyCast<SrcT, DstT>(srcVal[u]);
       storePacks(dstVal, dstMem, dstAlignMin, dstPtr, nElts, padElts, packIx, 32, lastPackEmpty);
     }
-    int nRemPacks = nPacks - nBlobs*nPackPerBlob;
-    #pragma unroll 1
-    for (int row = t; row < nBatch*nRemPacks; row += tn) {
-      int batchIx = unsigned(row)/unsigned(nRemPacks);
-      int packIx = nBlobs*nPackPerBlob + unsigned(row)%unsigned(nRemPacks);
+    int nRemPacks = nPacks - nBlobs * nPackPerBlob;
+#pragma unroll 1
+    for (int row = t; row < nBatch * nRemPacks; row += tn) {
+      int batchIx = unsigned(row) / unsigned(nRemPacks);
+      int packIx = nBlobs * nPackPerBlob + unsigned(row) % unsigned(nRemPacks);
       DstT* dstPtr = getDst(batchIx);
       SrcT* srcPtr = getSrc(batchIx);
-      int padElts = (reinterpret_cast<uintptr_t>(srcPtr) % sizeof(SrcPack))/sizeof(SrcT);
+      int padElts = (reinterpret_cast<uintptr_t>(srcPtr) % sizeof(SrcPack)) / sizeof(SrcT);
 
-      bool packEmpty = padElts + nElts <= packIx*nEltPerPack;
+      bool packEmpty = padElts + nElts <= packIx * nEltPerPack;
       packEmpty = __builtin_expect(packEmpty, false);
       if (!packEmpty) {
         SrcPack* srcPackPtr = (SrcPack*)(srcPtr - padElts) + packIx;
-        SrcPack srcVal = applyLoadMultimem<Red<SrcT>, sizeof(SrcPack)>(
-          srcRed, reinterpret_cast<uintptr_t>(srcPackPtr)
-        );
+        SrcPack srcVal = applyLoadMultimem<Red<SrcT>, sizeof(SrcPack)>(srcRed, reinterpret_cast<uintptr_t>(srcPackPtr));
         DstPack dstVal[1] = {applyCast<SrcT, DstT>(srcVal)};
         storePacks(dstVal, dstMem, dstAlignMin, dstPtr, nElts, padElts, packIx, tn, false);
       }
     }
   } else {
-    #pragma unroll 1
-    for (int row = t; row < nBatch*nElts; ) {
-      int batchIx = unsigned(row)/unsigned(nElts);
-      int eltIx = unsigned(row)%unsigned(nElts);
+#pragma unroll 1
+    for (int row = t; row < nBatch * nElts;) {
+      int batchIx = unsigned(row) / unsigned(nElts);
+      int eltIx = unsigned(row) % unsigned(nElts);
       DstT* dstPtr = getDst(batchIx) + eltIx;
       SrcT* srcPtr = getSrc(batchIx) + eltIx;
       constexpr int UnrollData = 4;
       // Test if the whole warp can be unrolled within the same run of elts
       // by testing if both lane 0 and 31 are in our run.
-      int lane = unsigned(t)%32;
-      if ((0 <= eltIx-lane) && (eltIx-lane + 31 + 1 + (UnrollData-1)*tn <= nElts)) {
+      int lane = unsigned(t) % 32;
+      if ((0 <= eltIx - lane) && (eltIx - lane + 31 + 1 + (UnrollData - 1) * tn <= nElts)) {
         SrcT srcVal[UnrollData] = {};
-        #pragma unroll
-        for (int u=0; u < UnrollData; u++) {
-          srcVal[u] = fromPack<SrcT>(applyLoadMultimem<Red<SrcT>, sizeof(SrcT)>(
-            srcRed, reinterpret_cast<uintptr_t>(srcPtr + u*tn)
-          ));
+#pragma unroll
+        for (int u = 0; u < UnrollData; u++) {
+          srcVal[u] = fromPack<SrcT>(
+            applyLoadMultimem<Red<SrcT>, sizeof(SrcT)>(srcRed, reinterpret_cast<uintptr_t>(srcPtr + u * tn)));
         }
-        #pragma unroll
-        for (int u=0; u < UnrollData; u++) {
-          stcs(dstMem, dstPtr + u*tn, (DstT)srcVal[u]);
+#pragma unroll
+        for (int u = 0; u < UnrollData; u++) {
+          stcs(dstMem, dstPtr + u * tn, (DstT)srcVal[u]);
         }
-        row += UnrollData*tn;
+        row += UnrollData * tn;
       } else {
-        SrcT srcVal = fromPack<SrcT>(applyLoadMultimem<Red<SrcT>, sizeof(SrcT)>(
-          srcRed, reinterpret_cast<uintptr_t>(srcPtr)
-        ));
+        SrcT srcVal =
+          fromPack<SrcT>(applyLoadMultimem<Red<SrcT>, sizeof(SrcT)>(srcRed, reinterpret_cast<uintptr_t>(srcPtr)));
         stcs(dstMem, dstPtr, (DstT)srcVal);
         row += tn;
       }
@@ -491,34 +487,28 @@ template<typename Coop, typename DstSpace, typename GetDst,
 }
 
 // reduceLsa helpers sum symmetric elements from whole LSA team.
-template<typename Coop, typename DstSpace, typename GetDst,
-         template<typename> typename Red, typename Acc, typename SrcT, typename GetSrcOffset>
-static __device__ void reduceLsaBatch(
-    Coop coop, int nBatch, int nElts,
-    DstSpace dstMem, unsigned dstAlignMin, /*(int i)->DstT* */GetDst getDst,
-    Red<Acc> srcRedUc, Red<SrcT> srcRedMc,
-    ncclSymPtr<SrcT> srcBase, /*(int i)->size_t*/GetSrcOffset getSrcOffset,
-    ncclDevComm const& comm, BoolTag</*multimem=*/true> multimemTrue
-  ) {
+template <typename Coop, typename DstSpace, typename GetDst, template <typename> typename Red, typename Acc,
+          typename SrcT, typename GetSrcOffset>
+static __device__ void reduceLsaBatch(Coop coop, int nBatch, int nElts, DstSpace dstMem, unsigned dstAlignMin,
+                                      /*(int i)->DstT* */ GetDst getDst, Red<Acc> srcRedUc, Red<SrcT> srcRedMc,
+                                      ncclSymPtr<SrcT> srcBase, /*(int i)->size_t*/ GetSrcOffset getSrcOffset,
+                                      ncclDevComm const& comm, BoolTag</*multimem=*/true> multimemTrue) {
   SrcT* srcPtr = srcBase.lsaMultimemPtr(comm);
   reduceMultimemBatch(coop, nBatch, nElts, dstMem, dstAlignMin, getDst, srcRedMc,
-    /*getSrc=*/[&]__device__(int i) { return srcPtr + getSrcOffset(i); }
-  );
+                      /*getSrc=*/[&] __device__(int i) { return srcPtr + getSrcOffset(i); });
 }
-template<typename Coop, typename DstSpace, typename GetDst,
-         template<typename> typename Red, typename Acc, typename SrcT, typename GetSrcOffset>
-static __device__ void reduceLsaBatch(
-    Coop coop, int nBatch, int nElts,
-    DstSpace dstMem, unsigned dstAlignMin, /*(int i)->DstT* */GetDst getDst,
-    Red<Acc> srcRedUc, Red<SrcT> srcRedMc,
-    ncclSymPtr<SrcT> srcBase, /*(int i)->size_t*/GetSrcOffset getSrcOffset,
-    ncclDevComm const& comm, BoolTag</*multimem=*/false> multimemFalse
-  ) {
+template <typename Coop, typename DstSpace, typename GetDst, template <typename> typename Red, typename Acc,
+          typename SrcT, typename GetSrcOffset>
+static __device__ void reduceLsaBatch(Coop coop, int nBatch, int nElts, DstSpace dstMem, unsigned dstAlignMin,
+                                      /*(int i)->DstT* */ GetDst getDst, Red<Acc> srcRedUc, Red<SrcT> srcRedMc,
+                                      ncclSymPtr<SrcT> srcBase, /*(int i)->size_t*/ GetSrcOffset getSrcOffset,
+                                      ncclDevComm const& comm, BoolTag</*multimem=*/false> multimemFalse) {
   ncclTeam lsa = ncclTeamLsa(comm);
   ncclLsaPointerGetter<SrcT> getLsaPtr{srcBase};
-  reduceBatch(coop, /*inPlace=*/false, nBatch, nElts,
-    dstMem, dstAlignMin, getDst, srcRedUc, lsa.nRanks,
-    /*getSrcOffset=*/[&]__device__(int i, int s)->SrcT* {
+  reduceBatch(
+    coop, /*inPlace=*/false, nBatch, nElts, dstMem, dstAlignMin, getDst, srcRedUc, lsa.nRanks,
+    /*getSrcOffset=*/
+    [&] __device__(int i, int s) -> SrcT* {
       int r = lsa.rank + s;
       if (lsa.nRanks <= r) r -= lsa.nRanks;
       // This could be `srcBase.lsaPtr(r) + getSrcOffset(i)` but by using the
@@ -529,74 +519,70 @@ static __device__ void reduceLsaBatch(
       return getLsaPtr(r) + getSrcOffset(i);
     },
     /*srcPtrCommonMask=*/-1u, // LSA is 4GB common
-    /*getSrcPtrMasked=*/[&]__device__(int i)->unsigned {
+    /*getSrcPtrMasked=*/
+    [&] __device__(int i) -> unsigned {
       __builtin_assume(srcBase.offset % alignof(SrcT) == 0);
-      return unsigned(srcBase.offset + getSrcOffset(i)*sizeof(SrcT));
-    }
-  );
+      return unsigned(srcBase.offset + getSrcOffset(i) * sizeof(SrcT));
+    });
 }
 
-template<typename Coop,
-         typename DstSpace, typename DstT,
-         template<typename> typename Red, typename Acc, typename SrcT,
-         bool multimem>
-static __device__ void reduceLsa(
-    Coop coop, int nElts,
-    DstSpace dstMem, unsigned dstAlignMin, DstT* dstPtr,
-    Red<Acc> srcRedUc, Red<SrcT> srcRedMc, ncclSymPtr<SrcT> srcPtr,
-    ncclDevComm const& comm, BoolTag<multimem> multimemTag
-  ) {
-  reduceLsaBatch(coop, /*nBatch=*/1, nElts,
-    dstMem, dstAlignMin, [=]__device__(int)->DstT* { return dstPtr; },
-    srcRedUc, srcRedMc, srcPtr,
-    /*getSrcOffset=*/[=]__device__(int)->int { return 0; },
-    comm, multimemTag);
+template <typename Coop, typename DstSpace, typename DstT, template <typename> typename Red, typename Acc,
+          typename SrcT, bool multimem>
+static __device__ void reduceLsa(Coop coop, int nElts, DstSpace dstMem, unsigned dstAlignMin, DstT* dstPtr,
+                                 Red<Acc> srcRedUc, Red<SrcT> srcRedMc, ncclSymPtr<SrcT> srcPtr,
+                                 ncclDevComm const& comm, BoolTag<multimem> multimemTag) {
+  reduceLsaBatch(
+    coop, /*nBatch=*/1, nElts, dstMem, dstAlignMin, [=] __device__(int) -> DstT* { return dstPtr; }, srcRedUc, srcRedMc,
+    srcPtr,
+    /*getSrcOffset=*/[=] __device__(int) -> int { return 0; }, comm, multimemTag);
 }
 
-template<typename Coop, typename DstT, typename SrcT, typename Transform>
-static __device__ void copy(
-    Coop coop, int nElts, GMemTag dstMem, DstT* dst, SMemTag srcMem, SrcT* src, Transform transformFn
-  ) {
+template <typename Coop, typename DstT, typename SrcT, typename Transform>
+static __device__ void copy(Coop coop, int nElts, GMemTag dstMem, DstT* dst, SMemTag srcMem, SrcT* src,
+                            Transform transformFn) {
   static_assert(sizeof(DstT) <= sizeof(SrcT), "Required");
   __builtin_assume(__isShared(src));
   int tn = coop.size();
   int t = coop.thread_rank();
 
-  constexpr int nEltPerPack = 16/sizeof(DstT);
+  constexpr int nEltPerPack = 16 / sizeof(DstT);
   using DstPack = BytePack<16>;
-  using SrcPack = BytePack<16*sizeof(SrcT)/sizeof(DstT)>;
-  int nPreElts = (16 - reinterpret_cast<uintptr_t>(dst))%16/sizeof(DstT);
-  int nSufElts = reinterpret_cast<uintptr_t>(dst + nElts)%16/sizeof(DstT);
-  int nPacks = (nElts-nPreElts-nSufElts)/nEltPerPack;
-  unsigned srcAlign16 = reinterpret_cast<uintptr_t>(src + nPreElts)%16;
+  using SrcPack = BytePack<16 * sizeof(SrcT) / sizeof(DstT)>;
+  int nPreElts = (16 - reinterpret_cast<uintptr_t>(dst)) % 16 / sizeof(DstT);
+  int nSufElts = reinterpret_cast<uintptr_t>(dst + nElts) % 16 / sizeof(DstT);
+  int nPacks = (nElts - nPreElts - nSufElts) / nEltPerPack;
+  unsigned srcAlign16 = reinterpret_cast<uintptr_t>(src + nPreElts) % 16;
 
   if (srcAlign16 == 0) {
-    // TODO: When SrcT==DstT we can replace loop with single `cp.async.bulk`
-    #pragma unroll 1
+// TODO: When SrcT==DstT we can replace loop with single `cp.async.bulk`
+#pragma unroll 1
     for (int p = t; p < nPacks; p += tn) {
       SrcPack srcPack = ((SrcPack*)(src + nPreElts))[p];
-      stcs(GMemTag(), (DstPack*)(dst + nPreElts) + p,  applyCast<SrcT, DstT>(transformFn(srcPack)));
+      stcs(GMemTag(), (DstPack*)(dst + nPreElts) + p, applyCast<SrcT, DstT>(transformFn(srcPack)));
     }
   } else {
-    unsigned srcAlign4 = srcAlign16%4;
+    unsigned srcAlign4 = srcAlign16 % 4;
     uint32_t* srcWords = reinterpret_cast<uint32_t*>(reinterpret_cast<uintptr_t>(src + nPreElts) & -uintptr_t(4));
-    #pragma unroll 1
+#pragma unroll 1
     for (int p = t; p < nPacks; p += tn) {
-      constexpr int nWordPerPack = sizeof(SrcPack)/4;
-      union { SrcPack srcPack; uint32_t w[nWordPerPack + 1]; };
+      constexpr int nWordPerPack = sizeof(SrcPack) / 4;
+      union {
+        SrcPack srcPack;
+        uint32_t w[nWordPerPack + 1];
+      };
       int i;
-      #pragma unroll
-      for (i = 0; i < nWordPerPack; i++) w[i] = (srcWords + p*nWordPerPack)[i];
+#pragma unroll
+      for (i = 0; i < nWordPerPack; i++) w[i] = (srcWords + p * nWordPerPack)[i];
       if (srcAlign4 != 0) {
         w[i] = srcWords[i];
-        #pragma unroll
-        for (i = 0; i < nWordPerPack; i++) w[i] = __funnelshift_r(w[i], w[i+1], 8*srcAlign4);
+#pragma unroll
+        for (i = 0; i < nWordPerPack; i++) w[i] = __funnelshift_r(w[i], w[i + 1], 8 * srcAlign4);
       }
-      stcs(GMemTag(), (DstPack*)(dst + nPreElts) + p,  applyCast<SrcT, DstT>(transformFn(srcPack)));
+      stcs(GMemTag(), (DstPack*)(dst + nPreElts) + p, applyCast<SrcT, DstT>(transformFn(srcPack)));
     }
   }
 
-  #pragma unroll 1
+#pragma unroll 1
   for (int i = t; i < nPreElts + nSufElts; i += tn) {
     int e = i < nPreElts ? i : nElts - nSufElts + (i - nPreElts);
     stcs(GMemTag(), dst + e, (DstT)(transformFn((src[e]))));

--- a/projects/rccl/src/device/symmetric/gin_scratch.h
+++ b/projects/rccl/src/device/symmetric/gin_scratch.h
@@ -7,9 +7,9 @@
 #ifndef _NCCL_DEVICE_GIN_SCRATCH_H_
 #define _NCCL_DEVICE_GIN_SCRATCH_H_
 #if 1 // When this file is not in "nccl_device/"
-  #include "nccl_device.h"
+#include "nccl_device.h"
 #else // When this file is public in "nccl_device/"
-  #include "core.h"
+#include "core.h"
 #endif
 
 struct ncclGinOutboxHandle;
@@ -19,24 +19,21 @@ constexpr int ncclGinScratchMaxBufs_log2 = /*log2(512)=*/9;
 constexpr int ncclGinScratchMaxBufsPerPeer_log2 = /*log2(4)=*/2;
 
 NCCL_EXTERN_C __host__ ncclResult_t ncclGinOutboxCreateRequirement(
-  int nBlocks, int size_log2,
-  ncclGinOutboxHandle* outHandle, ncclDevResourceRequirements* outReq
-);
+  int nBlocks, int size_log2, ncclGinOutboxHandle* outHandle, ncclDevResourceRequirements* outReq);
 
 NCCL_EXTERN_C __host__ ncclResult_t ncclGinInboxA2ACreateRequirement(
-  ncclTeam peers, int nBlocks, int size_log2,
-  ncclGinInboxA2AHandle* outHandle, ncclDevResourceRequirements* outReq
-);
+  ncclTeam peers, int nBlocks, int size_log2, ncclGinInboxA2AHandle* outHandle, ncclDevResourceRequirements* outReq);
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop, unsigned ginBackendMask>
+template <typename Coop, unsigned ginBackendMask>
 struct ncclGinOutboxSession_internal;
 
 struct ncclGinScratch_GetBufPtr;
 
-template<typename Coop, unsigned ginBackendMask = NCCL_GIN_BACKEND_MASK_ALL>
-struct ncclGinOutboxSession: ncclGinOutboxSession_internal<Coop, ginBackendMask> {
-  NCCL_DEVICE_INLINE ncclGinOutboxSession(Coop, ncclGin_BackendMask<ginBackendMask> const&, ncclGinOutboxHandle handle, uint32_t index);
+template <typename Coop, unsigned ginBackendMask = NCCL_GIN_BACKEND_MASK_ALL>
+struct ncclGinOutboxSession : ncclGinOutboxSession_internal<Coop, ginBackendMask> {
+  NCCL_DEVICE_INLINE ncclGinOutboxSession(Coop, ncclGin_BackendMask<ginBackendMask> const&, ncclGinOutboxHandle handle,
+                                          uint32_t index);
   NCCL_DEVICE_INLINE ~ncclGinOutboxSession();
 
   ncclGinOutboxSession(ncclGinOutboxSession const&) = delete; // non-copyable
@@ -45,9 +42,9 @@ struct ncclGinOutboxSession: ncclGinOutboxSession_internal<Coop, ginBackendMask>
   // threads in Coop but that can be partitioned across multiple subcoop's of which
   // exactly one must have subcoopIsNonTrivial=true. That is the one which will
   // do the heavy work.
-  template<typename SubCoop>
-  NCCL_DEVICE_INLINE void apportion(Coop, SubCoop, bool subcoopIsNonTrivial, int nBufs_log2, bool deferSync=false);
-  template<typename SubCoop>
+  template <typename SubCoop>
+  NCCL_DEVICE_INLINE void apportion(Coop, SubCoop, bool subcoopIsNonTrivial, int nBufs_log2, bool deferSync = false);
+  template <typename SubCoop>
   NCCL_DEVICE_INLINE void waitBufs(SubCoop, int i0, int n);
   NCCL_DEVICE_INLINE ncclSymPtr<char> getBuf(int i) const;
   NCCL_DEVICE_INLINE ncclGinScratch_GetBufPtr make_getBufPtr(int i0) const;
@@ -57,14 +54,15 @@ struct ncclGinOutboxSession: ncclGinOutboxSession_internal<Coop, ginBackendMask>
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop, unsigned ginBackendMask>
+template <typename Coop, unsigned ginBackendMask>
 struct ncclGinInboxA2ASession_internal;
 
 struct ncclGinInboxA2A_GetBufPtr;
 
-template<typename Coop, unsigned ginBackendMask = NCCL_GIN_BACKEND_MASK_ALL>
-struct ncclGinInboxA2ASession: ncclGinInboxA2ASession_internal<Coop, ginBackendMask> {
-  NCCL_DEVICE_INLINE ncclGinInboxA2ASession(Coop, ncclGin_BackendMask<ginBackendMask> const&, ncclTeam team, ncclGinInboxA2AHandle, uint32_t index);
+template <typename Coop, unsigned ginBackendMask = NCCL_GIN_BACKEND_MASK_ALL>
+struct ncclGinInboxA2ASession : ncclGinInboxA2ASession_internal<Coop, ginBackendMask> {
+  NCCL_DEVICE_INLINE ncclGinInboxA2ASession(Coop, ncclGin_BackendMask<ginBackendMask> const&, ncclTeam team,
+                                            ncclGinInboxA2AHandle, uint32_t index);
   NCCL_DEVICE_INLINE ~ncclGinInboxA2ASession();
 
   ncclGinInboxA2ASession(ncclGinInboxA2ASession const&) = delete; // non-copyable
@@ -75,29 +73,27 @@ struct ncclGinInboxA2ASession: ncclGinInboxA2ASession_internal<Coop, ginBackendM
   // must already be synced with threads doing waitRecvs/finishRecvs from the previous
   // round.
   // Required: nBufs_log2 <= ncclGinScratchMaxBufs_log2
-  template<typename SubCoop>
+  template <typename SubCoop>
   NCCL_DEVICE_INLINE void apportion(Coop, SubCoop, bool subcoopIsNonTrivial, int nBufs_log2);
 
   // When `stepLtPeers=true` we require `step < team.nRanks-1`
-  NCCL_DEVICE_INLINE int getSendPeer(int step, bool stepLtPeers=false) const;
-  NCCL_DEVICE_INLINE int getRecvPeer(int step, bool stepLtPeers=false) const;
+  NCCL_DEVICE_INLINE int getSendPeer(int step, bool stepLtPeers = false) const;
+  NCCL_DEVICE_INLINE int getRecvPeer(int step, bool stepLtPeers = false) const;
 
   NCCL_DEVICE_INLINE ncclSymPtr<char> getBuf(int step) const;
   NCCL_DEVICE_INLINE ncclGinScratch_GetBufPtr make_getBufPtr(int step0) const;
 
   // Post sends for steps [step0, step0+nSteps). The lambdas take index in [0, nSteps).
-  template<typename SubCoop, typename GetPtr, typename GetEltCount, typename GetCompletion>
-  NCCL_DEVICE_INLINE void postSends(
-    SubCoop, int step0, int nSteps,
-    /*(int index, int peer)->ncclSymPtr<T>*/GetPtr getPtr,
-    /*(int index, int peer)->int*/GetEltCount getEltCount,
-    /*(int index, int peer)->ncclGin_???*/GetCompletion getCompletion
-  );
+  template <typename SubCoop, typename GetPtr, typename GetEltCount, typename GetCompletion>
+  NCCL_DEVICE_INLINE void postSends(SubCoop, int step0, int nSteps,
+                                    /*(int index, int peer)->ncclSymPtr<T>*/ GetPtr getPtr,
+                                    /*(int index, int peer)->int*/ GetEltCount getEltCount,
+                                    /*(int index, int peer)->ncclGin_???*/ GetCompletion getCompletion);
   // Wait for recvs for steps [step0, step0+nSteps).
-  template<typename SubCoop>
+  template <typename SubCoop>
   NCCL_DEVICE_INLINE void waitRecvs(SubCoop, int step0, int nSteps);
   // Finish recvs for steps [step0, step0+nSteps).
-  template<typename SubCoop>
+  template <typename SubCoop>
   NCCL_DEVICE_INLINE void finishRecvs(SubCoop, int step0, int nSteps);
 
   // Move to next round of steps.

--- a/projects/rccl/src/device/symmetric/gin_scratch__funcs.h
+++ b/projects/rccl/src/device/symmetric/gin_scratch__funcs.h
@@ -13,17 +13,16 @@
 // ncclGinOutboxSession:
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop, unsigned ginBackendMask>
+template <typename Coop, unsigned ginBackendMask>
 NCCL_DEVICE_INLINE ncclGinOutboxSession<Coop, ginBackendMask>::ncclGinOutboxSession(
-    Coop coop, ncclGin_BackendMask<ginBackendMask> const& gin, ncclGinOutboxHandle handle, uint32_t index
-  ):
-  ncclGinOutboxSession_internal<Coop, ginBackendMask>{coop, gin.comm, gin, handle, (int)index} {
+  Coop coop, ncclGin_BackendMask<ginBackendMask> const& gin, ncclGinOutboxHandle handle, uint32_t index)
+  : ncclGinOutboxSession_internal<Coop, ginBackendMask>{coop, gin.comm, gin, handle, (int)index} {
   this->state = this->getStatePtr()->unpadded;
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop, unsigned ginBackendMask>
+template <typename Coop, unsigned ginBackendMask>
 NCCL_DEVICE_INLINE ncclGinOutboxSession<Coop, ginBackendMask>::~ncclGinOutboxSession() {
   if (this->coop.thread_rank() == 0) {
     this->getStatePtr()->unpadded = this->state;
@@ -33,19 +32,18 @@ NCCL_DEVICE_INLINE ncclGinOutboxSession<Coop, ginBackendMask>::~ncclGinOutboxSes
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop, unsigned ginBackendMask>
-template<typename SubCoop>
+template <typename Coop, unsigned ginBackendMask>
+template <typename SubCoop>
 NCCL_DEVICE_INLINE void ncclGinOutboxSession<Coop, ginBackendMask>::apportion(
-    Coop, SubCoop subcoop, bool subcoopIsNonTrivial, int nBufs_log2_next, bool deferSync
-  ) {
+  Coop, SubCoop subcoop, bool subcoopIsNonTrivial, int nBufs_log2_next, bool deferSync) {
   int nBufs_log2_cur = this->state.nBufs_log2;
   if (nBufs_log2_cur != nBufs_log2_next) {
     if (subcoopIsNonTrivial) {
-      #pragma unroll 1
-      for (int i = subcoop.thread_rank(); i < (1<<nBufs_log2_cur); i += subcoop.size()) {
+#pragma unroll 1
+      for (int i = subcoop.thread_rank(); i < (1 << nBufs_log2_cur); i += subcoop.size()) {
         uint32_t id = this->state.cursor + i;
         ncclGinCounter_t ctr = this->handle.counter0 + (this->block << ncclGinScratchMaxBufs_log2);
-        ctr += id & (1<<nBufs_log2_cur)-1;
+        ctr += id & (1 << nBufs_log2_cur) - 1;
         uint32_t val = id >> nBufs_log2_cur;
         this->gin.waitCounter(ncclCoopThread(), ctr, val, ncclGinOutboxState::CursorBits);
         this->gin.resetCounter(ctr);
@@ -59,14 +57,14 @@ NCCL_DEVICE_INLINE void ncclGinOutboxSession<Coop, ginBackendMask>::apportion(
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop, unsigned ginBackendMask>
-template<typename SubCoop>
+template <typename Coop, unsigned ginBackendMask>
+template <typename SubCoop>
 NCCL_DEVICE_INLINE void ncclGinOutboxSession<Coop, ginBackendMask>::waitBufs(SubCoop subcoop, int i0, int n) {
-  #pragma unroll 1
-  for (int i=subcoop.thread_rank(); i < n; i += subcoop.size()) {
+#pragma unroll 1
+  for (int i = subcoop.thread_rank(); i < n; i += subcoop.size()) {
     uint32_t id = this->state.cursor + i0 + i;
     ncclGinCounter_t ctr = this->handle.counter0 + (this->block << ncclGinScratchMaxBufs_log2);
-    ctr += id & (1<<this->state.nBufs_log2)-1;
+    ctr += id & (1 << this->state.nBufs_log2) - 1;
     uint32_t val = id >> this->state.nBufs_log2;
     this->gin.waitCounter(ncclCoopThread(), ctr, val, ncclGinOutboxState::CursorBits);
   }
@@ -74,21 +72,21 @@ NCCL_DEVICE_INLINE void ncclGinOutboxSession<Coop, ginBackendMask>::waitBufs(Sub
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop, unsigned ginBackendMask>
+template <typename Coop, unsigned ginBackendMask>
 NCCL_DEVICE_INLINE ncclSymPtr<char> ncclGinOutboxSession<Coop, ginBackendMask>::getBuf(int i) const {
   uint32_t id = this->state.cursor + i;
   int nBufs_log2 = this->state.nBufs_log2;
   ncclSymPtr<char> bufs = (ncclSymPtr<char>)(this->getStateSymPtr() + 1);
-  return bufs + ((id & (1<<nBufs_log2)-1) << (this->handle.size_log2 - nBufs_log2));
+  return bufs + ((id & (1 << nBufs_log2) - 1) << (this->handle.size_log2 - nBufs_log2));
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop, unsigned ginBackendMask>
-NCCL_DEVICE_INLINE  ncclGinScratch_GetBufPtr ncclGinOutboxSession<Coop, ginBackendMask>::make_getBufPtr(int i0) const {
+template <typename Coop, unsigned ginBackendMask>
+NCCL_DEVICE_INLINE ncclGinScratch_GetBufPtr ncclGinOutboxSession<Coop, ginBackendMask>::make_getBufPtr(int i0) const {
   ncclGinScratch_GetBufPtr ret;
   ret.bufs = (char*)(this->getStatePtr() + 1);
-  ret.nBufs_minus_1 = (1<<this->state.nBufs_log2)-1;
+  ret.nBufs_minus_1 = (1 << this->state.nBufs_log2) - 1;
   ret.bufSize_log2 = this->handle.size_log2 - this->state.nBufs_log2;
   ret.cursor = this->state.cursor + i0;
   return ret;
@@ -96,32 +94,30 @@ NCCL_DEVICE_INLINE  ncclGinScratch_GetBufPtr ncclGinOutboxSession<Coop, ginBacke
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop, unsigned ginBackendMask>
+template <typename Coop, unsigned ginBackendMask>
 NCCL_DEVICE_INLINE ncclGinCounter_t ncclGinOutboxSession<Coop, ginBackendMask>::getCounter(int i) const {
   uint32_t id = this->state.cursor + i;
   ncclGinCounter_t ctr = this->handle.counter0 + (this->block << ncclGinScratchMaxBufs_log2);
-  return ctr + (id & (1<<this->state.nBufs_log2)-1);
+  return ctr + (id & (1 << this->state.nBufs_log2) - 1);
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop, unsigned ginBackendMask>
+template <typename Coop, unsigned ginBackendMask>
 NCCL_DEVICE_INLINE void ncclGinOutboxSession<Coop, ginBackendMask>::advance(Coop, int n) {
   this->state.cursor += n;
 }
 #endif
 
-
 ////////////////////////////////////////////////////////////////////////////////
 // ncclGinInboxA2ASession:
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop, unsigned ginBackendMask>
+template <typename Coop, unsigned ginBackendMask>
 NCCL_DEVICE_INLINE ncclGinInboxA2ASession<Coop, ginBackendMask>::ncclGinInboxA2ASession(
-    Coop coop, ncclGin_BackendMask<ginBackendMask> const& gin, ncclTeam team, ncclGinInboxA2AHandle handle, uint32_t index
-  ):
-  ncclGinInboxA2ASession_internal<Coop, ginBackendMask>
-    {coop, gin.comm, gin, team, handle, (int)index} {
+  Coop coop, ncclGin_BackendMask<ginBackendMask> const& gin, ncclTeam team, ncclGinInboxA2AHandle handle,
+  uint32_t index)
+  : ncclGinInboxA2ASession_internal<Coop, ginBackendMask>{coop, gin.comm, gin, team, handle, (int)index} {
   this->nPeers = team.nRanks - 1;
   this->state = this->getStatePtr()->unpadded;
   // The `index` to `context` relationship must be 1:1.
@@ -131,7 +127,7 @@ NCCL_DEVICE_INLINE ncclGinInboxA2ASession<Coop, ginBackendMask>::ncclGinInboxA2A
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop, unsigned ginBackendMask>
+template <typename Coop, unsigned ginBackendMask>
 NCCL_DEVICE_INLINE ncclGinInboxA2ASession<Coop, ginBackendMask>::~ncclGinInboxA2ASession() {
   if (this->coop.thread_rank() == 0) {
     this->getStatePtr()->unpadded = this->state;
@@ -141,20 +137,19 @@ NCCL_DEVICE_INLINE ncclGinInboxA2ASession<Coop, ginBackendMask>::~ncclGinInboxA2
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop, unsigned ginBackendMask>
-template<typename SubCoop>
+template <typename Coop, unsigned ginBackendMask>
+template <typename SubCoop>
 NCCL_DEVICE_INLINE void ncclGinInboxA2ASession<Coop, ginBackendMask>::apportion(
-    Coop coop, SubCoop subcoop, bool subcoopIsNonTrivial, int nBufs_log2_next
-  ) {
+  Coop coop, SubCoop subcoop, bool subcoopIsNonTrivial, int nBufs_log2_next) {
   int nBufs_log2_cur = this->state.nBufs_log2_plus_1 - 1;
   if (nBufs_log2_cur != nBufs_log2_next) {
     if (subcoopIsNonTrivial) {
       // Send initial C2S's for all bufs for next (+1) phase.
       int nPeers = this->nPeers;
-      int nBufs = 1<<nBufs_log2_next;
+      int nBufs = 1 << nBufs_log2_next;
       uint32_t nBufs_div_nPeers, nBufs_mod_nPeers;
       idivmodFast32(&nBufs_div_nPeers, &nBufs_mod_nPeers, nBufs, nPeers, this->handle.nPeers_rcp32);
-      #pragma unroll 1
+#pragma unroll 1
       for (int step = subcoop.thread_rank(); step < min(nPeers, nBufs); step += subcoop.size()) {
         int credits = nBufs_div_nPeers + (step < (int)nBufs_mod_nPeers ? 1 : 0);
         this->sendC2S(/*phaseDelta=*/+1, step, /*step_lt_nPeers=*/true, credits);
@@ -175,33 +170,34 @@ NCCL_DEVICE_INLINE void ncclGinInboxA2ASession<Coop, ginBackendMask>::apportion(
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop, unsigned ginBackendMask>
+template <typename Coop, unsigned ginBackendMask>
 NCCL_DEVICE_INLINE int ncclGinInboxA2ASession<Coop, ginBackendMask>::getSendPeer(int step, bool step_lt_nPeers) const {
   return this->getPeer(/*sendNotRecv=*/true, step, step_lt_nPeers);
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop, unsigned ginBackendMask>
+template <typename Coop, unsigned ginBackendMask>
 NCCL_DEVICE_INLINE int ncclGinInboxA2ASession<Coop, ginBackendMask>::getRecvPeer(int step, bool step_lt_nPeers) const {
   return this->getPeer(/*sendNotRecv=*/false, step, step_lt_nPeers);
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop, unsigned ginBackendMask>
+template <typename Coop, unsigned ginBackendMask>
 NCCL_DEVICE_INLINE ncclSymPtr<char> ncclGinInboxA2ASession<Coop, ginBackendMask>::getBuf(int step) const {
   return this->getBufSymPtr(this->state.monoStep + step);
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop, unsigned ginBackendMask>
-NCCL_DEVICE_INLINE ncclGinScratch_GetBufPtr ncclGinInboxA2ASession<Coop, ginBackendMask>::make_getBufPtr(int step0) const {
+template <typename Coop, unsigned ginBackendMask>
+NCCL_DEVICE_INLINE ncclGinScratch_GetBufPtr ncclGinInboxA2ASession<Coop, ginBackendMask>::make_getBufPtr(
+  int step0) const {
   int nBufs_log2 = this->state.nBufs_log2_plus_1 - 1;
   ncclGinScratch_GetBufPtr ret;
   ret.bufs = this->getBufsPtr();
-  ret.nBufs_minus_1 = (1<<nBufs_log2)-1;
+  ret.nBufs_minus_1 = (1 << nBufs_log2) - 1;
   ret.bufSize_log2 = this->handle.size_log2 - nBufs_log2;
   ret.cursor = this->state.monoStep + step0;
   return ret;
@@ -209,13 +205,12 @@ NCCL_DEVICE_INLINE ncclGinScratch_GetBufPtr ncclGinInboxA2ASession<Coop, ginBack
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop, unsigned ginBackendMask>
-template<typename SubCoop, typename GetPtr, typename GetEltCount, typename GetCompletion>
+template <typename Coop, unsigned ginBackendMask>
+template <typename SubCoop, typename GetPtr, typename GetEltCount, typename GetCompletion>
 NCCL_DEVICE_INLINE void ncclGinInboxA2ASession<Coop, ginBackendMask>::postSends(
-    SubCoop subcoop, int step0, int nSteps, GetPtr getPtr, GetEltCount getEltCount, GetCompletion getCompletion
-  ) {
-  #pragma unroll 1
-  for (int i=subcoop.thread_rank(); i < nSteps; i += subcoop.size()) {
+  SubCoop subcoop, int step0, int nSteps, GetPtr getPtr, GetEltCount getEltCount, GetCompletion getCompletion) {
+#pragma unroll 1
+  for (int i = subcoop.thread_rank(); i < nSteps; i += subcoop.size()) {
     int step = step0 + i;
     uint32_t monoStep = this->state.monoStep + step;
     this->waitC2S(step);
@@ -224,37 +219,34 @@ NCCL_DEVICE_INLINE void ncclGinInboxA2ASession<Coop, ginBackendMask>::postSends(
     auto srcPtr = getPtr(i, peer);
     int nElts = getEltCount(i, peer);
     this->gin.put(this->team, peer,
-      /*dst=*/this->getBufSymPtr(monoStep), /*src=*/(ncclSymPtr<char>)srcPtr,
-      /*size=*/nElts*(int)sizeof(typename decltype(srcPtr)::ElementType),
-      ncclGin_SignalInc{this->getR2RSignal(monoStep)},
-      getCompletion(i, peer));
+                  /*dst=*/this->getBufSymPtr(monoStep), /*src=*/(ncclSymPtr<char>)srcPtr,
+                  /*size=*/nElts * (int)sizeof(typename decltype(srcPtr)::ElementType),
+                  ncclGin_SignalInc{this->getR2RSignal(monoStep)}, getCompletion(i, peer));
   }
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop, unsigned ginBackendMask>
-template<typename SubCoop>
-NCCL_DEVICE_INLINE void ncclGinInboxA2ASession<Coop, ginBackendMask>::waitRecvs(
-    SubCoop subcoop, int step0, int nSteps
-  ) {
-  #pragma unroll 1
-  for (int i=subcoop.thread_rank(); i < nSteps; i += subcoop.size()) {
+template <typename Coop, unsigned ginBackendMask>
+template <typename SubCoop>
+NCCL_DEVICE_INLINE void ncclGinInboxA2ASession<Coop, ginBackendMask>::waitRecvs(SubCoop subcoop, int step0,
+                                                                                int nSteps) {
+#pragma unroll 1
+  for (int i = subcoop.thread_rank(); i < nSteps; i += subcoop.size()) {
     this->waitR2R(this->state.monoStep + step0 + i);
   }
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop, unsigned ginBackendMask>
-template<typename SubCoop>
-NCCL_DEVICE_INLINE void ncclGinInboxA2ASession<Coop, ginBackendMask>::finishRecvs(
-    SubCoop subcoop, int step0, int nSteps
-  ) {
+template <typename Coop, unsigned ginBackendMask>
+template <typename SubCoop>
+NCCL_DEVICE_INLINE void ncclGinInboxA2ASession<Coop, ginBackendMask>::finishRecvs(SubCoop subcoop, int step0,
+                                                                                  int nSteps) {
   int nBufs_log2 = this->state.nBufs_log2_plus_1 - 1;
-  int nBufs_mod_nPeers = imodFast32(1<<nBufs_log2, this->nPeers, this->handle.nPeers_rcp32);
-  #pragma unroll 1
-  for (int i=subcoop.thread_rank(); i < nSteps; i += subcoop.size()) {
+  int nBufs_mod_nPeers = imodFast32(1 << nBufs_log2, this->nPeers, this->handle.nPeers_rcp32);
+#pragma unroll 1
+  for (int i = subcoop.thread_rank(); i < nSteps; i += subcoop.size()) {
     // Determine next step that will alias the buffer of this step.
     int step = step0 + i; // guaranteed: step < nPeers
     int nextStep = step + nBufs_mod_nPeers;
@@ -265,7 +257,7 @@ NCCL_DEVICE_INLINE void ncclGinInboxA2ASession<Coop, ginBackendMask>::finishRecv
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop, unsigned ginBackendMask>
+template <typename Coop, unsigned ginBackendMask>
 NCCL_DEVICE_INLINE void ncclGinInboxA2ASession<Coop, ginBackendMask>::endRound(Coop coop) {
   this->state.monoRound += 1;
   this->state.monoStep += this->nPeers;

--- a/projects/rccl/src/device/symmetric/gin_scratch__types.h
+++ b/projects/rccl/src/device/symmetric/gin_scratch__types.h
@@ -8,12 +8,12 @@
 #ifndef _NCCL_DEVICE_GIN__SCRATCH_A2A__TYPES_H_
 #define _NCCL_DEVICE_GIN__SCRATCH_A2A__TYPES_H_
 #if 1 // When this file is not in "nccl_device/impl/"
-  #include "gin_scratch.h"
+#include "gin_scratch.h"
 #else // When this file is public in "nccl_device/impl/"
-  #include "../gin_scratch.h"
-  #include "core__types.h"
-  #include "ptr__types.h"
-  #include "../utility.h"
+#include "../gin_scratch.h"
+#include "core__types.h"
+#include "ptr__types.h"
+#include "../utility.h"
 #endif
 
 struct ncclGinOutboxHandle {
@@ -24,9 +24,9 @@ struct ncclGinOutboxHandle {
 
 #if __cplusplus
 struct alignas(128) ncclGinOutboxState {
-  static constexpr int CursorBits = 32-5;
+  static constexpr int CursorBits = 32 - 5;
   struct Unpadded {
-    uint32_t nBufs_log2:5, cursor:CursorBits;
+    uint32_t nBufs_log2:5, cursor : CursorBits;
   } unpadded;
 };
 #endif
@@ -41,7 +41,7 @@ struct ncclGinInboxA2AHandle {
 #if __cplusplus
 struct alignas(128) ncclGinInboxA2AState {
   static constexpr int RoundBits = 16;
-  //static constexpr int RoundBits = ncclGinScratchMaxBufsPerPeer_log2 + 1;
+  // static constexpr int RoundBits = ncclGinScratchMaxBufsPerPeer_log2 + 1;
   static_assert(ncclGinScratchMaxBufsPerPeer_log2 + 1 <= RoundBits, "Required");
   struct Unpadded {
     // Memory to ensure the same buffers aren't controlled with different contexts.
@@ -70,7 +70,7 @@ struct ncclGinScratch_GetBufPtr {
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop, unsigned ginBackendMask>
+template <typename Coop, unsigned ginBackendMask>
 struct ncclGinOutboxSession_internal {
   Coop coop;
   ncclDevComm const& comm;
@@ -81,19 +81,21 @@ struct ncclGinOutboxSession_internal {
 
   NCCL_DEVICE_INLINE ncclGinOutboxState* getStatePtr() const {
     char* p = (char*)ncclGetResourceBufferLocalPointer(comm, handle.bufHandle);
-    p += block*size_t((int)sizeof(ncclGinOutboxState) + alignUp(1<<handle.size_log2, (int)alignof(ncclGinOutboxState)));
+    p += block *
+         size_t((int)sizeof(ncclGinOutboxState) + alignUp(1 << handle.size_log2, (int)alignof(ncclGinOutboxState)));
     return (ncclGinOutboxState*)p;
   }
   NCCL_DEVICE_INLINE ncclSymPtr<ncclGinOutboxState> getStateSymPtr() const {
     ncclSymPtr<char> p = ncclGetResourceBuffer(comm, handle.bufHandle);
-    p += block*size_t((int)sizeof(ncclGinOutboxState) + alignUp(1<<handle.size_log2, (int)alignof(ncclGinOutboxState)));
+    p += block *
+         size_t((int)sizeof(ncclGinOutboxState) + alignUp(1 << handle.size_log2, (int)alignof(ncclGinOutboxState)));
     return (ncclSymPtr<ncclGinOutboxState>)p;
   }
 };
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop, unsigned ginBackendMask>
+template <typename Coop, unsigned ginBackendMask>
 struct ncclGinInboxA2ASession_internal {
   Coop coop;
   ncclDevComm const& comm;
@@ -106,37 +108,40 @@ struct ncclGinInboxA2ASession_internal {
 
   NCCL_DEVICE_INLINE ncclGinInboxA2AState* getStatePtr() const {
     char* p = (char*)ncclGetResourceBufferLocalPointer(comm, handle.bufHandle);
-    p += block*size_t((int)sizeof(ncclGinInboxA2AState) + alignUp(1<<handle.size_log2, (int)alignof(ncclGinInboxA2AState)));
+    p += block *
+         size_t((int)sizeof(ncclGinInboxA2AState) + alignUp(1 << handle.size_log2, (int)alignof(ncclGinInboxA2AState)));
     return (ncclGinInboxA2AState*)p;
   }
 
   NCCL_DEVICE_INLINE ncclSymPtr<char> getBufSymPtr(uint32_t monoStep) const {
     ncclSymPtr<char> p = ncclGetResourceBuffer(comm, handle.bufHandle);
-    p += block*size_t((int)sizeof(ncclGinInboxA2AState) + alignUp(1<<handle.size_log2, (int)alignof(ncclGinInboxA2AState)));
+    p += block *
+         size_t((int)sizeof(ncclGinInboxA2AState) + alignUp(1 << handle.size_log2, (int)alignof(ncclGinInboxA2AState)));
     p += sizeof(ncclGinInboxA2AState);
     int nBufs_log2 = state.nBufs_log2_plus_1 - 1;
     uint32_t nBufs = 1 << nBufs_log2;
     uint32_t bufSize_log2 = handle.size_log2 - nBufs_log2;
-    return p + ((monoStep & nBufs-1) << bufSize_log2);
+    return p + ((monoStep & nBufs - 1) << bufSize_log2);
   }
   NCCL_DEVICE_INLINE char* getBufsPtr() const {
     char* p = (char*)ncclGetResourceBufferLocalPointer(comm, handle.bufHandle);
-    p += block*size_t((int)sizeof(ncclGinInboxA2AState) + alignUp(1<<handle.size_log2, (int)alignof(ncclGinInboxA2AState)));
+    p += block *
+         size_t((int)sizeof(ncclGinInboxA2AState) + alignUp(1 << handle.size_log2, (int)alignof(ncclGinInboxA2AState)));
     p += sizeof(ncclGinInboxA2AState);
     return p;
   }
 
   NCCL_DEVICE_INLINE ncclGinSignal_t getSignal0(int phaseDelta) const {
     ncclGinSignal_t signal0 = handle.signals;
-    signal0 += (4*block + unsigned(state.phase + phaseDelta)%4)*(nPeers + (1<<ncclGinScratchMaxBufs_log2));
+    signal0 += (4 * block + unsigned(state.phase + phaseDelta) % 4) * (nPeers + (1 << ncclGinScratchMaxBufs_log2));
     return signal0;
   }
-  template<typename SubCoop>
+  template <typename SubCoop>
   NCCL_DEVICE_INLINE void resetSignals(SubCoop subcoop, int phaseDelta) {
-    int nSigs = nPeers + (1<<ncclGinScratchMaxBufs_log2);
+    int nSigs = nPeers + (1 << ncclGinScratchMaxBufs_log2);
     ncclGinSignal_t sig0 = getSignal0(phaseDelta);
-    #pragma unroll 1
-    for (int i=subcoop.thread_rank(); i < nSigs; i += subcoop.size()) {
+#pragma unroll 1
+    for (int i = subcoop.thread_rank(); i < nSigs; i += subcoop.size()) {
       this->gin.resetSignal(sig0 + i);
     }
   }
@@ -146,7 +151,7 @@ struct ncclGinInboxA2ASession_internal {
   }
   NCCL_DEVICE_INLINE ncclGinSignal_t getR2RSignal(uint32_t monoStep) const {
     int nBufs = 1 << (state.nBufs_log2_plus_1 - 1);
-    return getSignal0(/*phaseDelta=*/0) + nPeers + (monoStep & (nBufs-1));
+    return getSignal0(/*phaseDelta=*/0) + nPeers + (monoStep & (nBufs - 1));
   }
 
   NCCL_DEVICE_INLINE void waitC2S(uint32_t step) const {
@@ -159,14 +164,14 @@ struct ncclGinInboxA2ASession_internal {
     int nBufs_log2 = state.nBufs_log2_plus_1 - 1;
     uint32_t desired = 1 + (monoStep >> nBufs_log2);
     gin.waitSignal(ncclCoopThread(), getR2RSignal(monoStep), desired,
-                   /*bits=*/32-ncclGinScratchMaxBufs_log2);
+                   /*bits=*/32 - ncclGinScratchMaxBufs_log2);
   }
 
   NCCL_DEVICE_INLINE int getPeer(bool sendNotRecv, int step, bool step_lt_nPeers) const {
     if (!step_lt_nPeers) step = imodFast32(step, nPeers, handle.nPeers_rcp32);
     int sign = sendNotRecv ? 1 : -1;
-    int peer = team.rank + sign*(1 + step);
-    if (unsigned(team.nRanks) <= unsigned(peer)) peer += -sign*team.nRanks;
+    int peer = team.rank + sign * (1 + step);
+    if (unsigned(team.nRanks) <= unsigned(peer)) peer += -sign * team.nRanks;
     return peer;
   }
 

--- a/projects/rccl/src/device/symmetric/kernel.cuh
+++ b/projects/rccl/src/device/symmetric/kernel.cuh
@@ -1,21 +1,21 @@
 // Modification Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
-// SPDX-License-Identifier: MIT 
+// SPDX-License-Identifier: MIT
 
 #ifndef NCCL_DEVICE_SYMMETRIC_KERNEL_H_
 #define NCCL_DEVICE_SYMMETRIC_KERNEL_H_
 
 #include "sym_kernels.h"
 
-template<template<typename> typename Red, typename T>
+template <template <typename> typename Red, typename T>
 __device__ __forceinline__ void ncclSymkRun_AllReduce_AGxLL_R(struct ncclSymkDevWorkArgs const* args);
-template<template<typename> typename Red, typename T>
+template <template <typename> typename Red, typename T>
 __device__ __forceinline__ void ncclSymkRun_AllReduce_AGxLLMC_R(struct ncclSymkDevWorkArgs const* args);
 
-template<template<typename> typename Red, typename T>
+template <template <typename> typename Red, typename T>
 __device__ __forceinline__ void ncclSymkRun_AllReduce_RSxLD_AGxST(struct ncclSymkDevWorkArgs const* args);
-template<template<typename> typename Red, typename T>
+template <template <typename> typename Red, typename T>
 __device__ __forceinline__ void ncclSymkRun_AllReduce_RSxLDMC_AGxSTMC(struct ncclSymkDevWorkArgs const* args);
-template<template<typename> typename Red, typename T>
+template <template <typename> typename Red, typename T>
 __device__ __forceinline__ void ncclSymkRun_AllReduce_RSxTmaLD_AGxTmaST(struct ncclSymkDevWorkArgs const* args);
 
 __device__ __forceinline__ void ncclSymkRun_AllGather_LL(struct ncclSymkDevWorkArgs const* args);
@@ -25,18 +25,18 @@ __device__ __forceinline__ void ncclSymkRun_AllGather_STMC(struct ncclSymkDevWor
 __device__ __forceinline__ void ncclSymkRun_AllGather_TmaST(struct ncclSymkDevWorkArgs const* args);
 __device__ __forceinline__ void ncclSymkRun_AllGather_TmaSTMC(struct ncclSymkDevWorkArgs const* args);
 
-template<template<typename> typename Red, typename T>
+template <template <typename> typename Red, typename T>
 __device__ __forceinline__ void ncclSymkRun_ReduceScatter_LL(struct ncclSymkDevWorkArgs const* args);
-template<template<typename> typename Red, typename T>
+template <template <typename> typename Red, typename T>
 __device__ __forceinline__ void ncclSymkRun_ReduceScatter_LD(struct ncclSymkDevWorkArgs const* args);
-template<template<typename> typename Red, typename T>
+template <template <typename> typename Red, typename T>
 __device__ __forceinline__ void ncclSymkRun_ReduceScatter_LDMC(struct ncclSymkDevWorkArgs const* args);
-template<template<typename> typename Red, typename T>
+template <template <typename> typename Red, typename T>
 __device__ __forceinline__ void ncclSymkRun_ReduceScatter_TmaLD(struct ncclSymkDevWorkArgs const* args);
 
-template<template<typename> typename Red, typename T>
+template <template <typename> typename Red, typename T>
 __device__ __forceinline__ void ncclSymkRun_ReduceScatter_RailA2A_LsaLD(struct ncclSymkDevWorkArgs const* args);
-template<template<typename> typename Red, typename T>
+template <template <typename> typename Red, typename T>
 __device__ __forceinline__ void ncclSymkRun_ReduceScatter_RailA2A_LsaLDMC(struct ncclSymkDevWorkArgs const* args);
 
 __device__ __forceinline__ void ncclSymkRun_AllGather_RailRing_LsaSTMC(struct ncclSymkDevWorkArgs const* args);

--- a/projects/rccl/src/device/symmetric/primitives.cuh
+++ b/projects/rccl/src/device/symmetric/primitives.cuh
@@ -1,5 +1,5 @@
 // Modification Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
-// SPDX-License-Identifier: MIT 
+// SPDX-License-Identifier: MIT
 
 #ifndef NCCL_DEVICE_SYMMETRIC_PRIMITIVES_H_
 #define NCCL_DEVICE_SYMMETRIC_PRIMITIVES_H_
@@ -12,9 +12,9 @@
 #include "common.h"
 #include "tma_ptx.h"
 
-template<typename Pack, int UnrollPacks, int UnrollPeers = 1>
+template <typename Pack, int UnrollPacks, int UnrollPeers = 1>
 struct tmaSmemStruct {
-  alignas(16) Pack buff[UnrollPeers][UnrollPacks*WARP_SIZE];
+  alignas(16) Pack buff[UnrollPeers][UnrollPacks * WARP_SIZE];
   alignas(8) __mbarrier_t bar;
 };
 
@@ -39,44 +39,61 @@ static __device__ __forceinline__ bool __isShared(const void* p) {
 #define NCCL_GRID_CONSTANT
 #endif
 
-template<bool val> struct BoolTag { static constexpr bool value = val; };
+template <bool val>
+struct BoolTag {
+  static constexpr bool value = val;
+};
 
 // A cheap approximation of std::decay
-template<typename T> struct ncclDecayType { using Type = T; };
-template<typename T> struct ncclDecayType<T&> { using Type = T; };
-template<typename T> struct ncclDecayType<T&&> { using Type = T; };
-template<typename T> struct ncclDecayType<T const> { using Type = T; };
-template<typename T> struct ncclDecayType<T volatile> { using Type = T; };
+template <typename T>
+struct ncclDecayType {
+  using Type = T;
+};
+template <typename T>
+struct ncclDecayType<T&> {
+  using Type = T;
+};
+template <typename T>
+struct ncclDecayType<T&&> {
+  using Type = T;
+};
+template <typename T>
+struct ncclDecayType<T const> {
+  using Type = T;
+};
+template <typename T>
+struct ncclDecayType<T volatile> {
+  using Type = T;
+};
 
-template<typename T>
+template <typename T>
 using ncclDecayType_t = typename ncclDecayType<T>::Type;
-
 
 // flattenIx(pos0, dim0, pos1, dim1, pos2, dim2, ...)
 // Given a position vector `pos` in a rectangular index space with lengths in the `dim`
 // vector, flatten that down to a linear index. The fastest moving dimension is given first.
-__device__ __forceinline__ int flattenIx() { return 0; }
-
-template<typename Int0, typename Int1, typename ...Ints>
-static __device__ Int0 flattenIx(Int0 pos, Int1 size, Ints ...more) {
-  return pos + size*flattenIx(more...);
+__device__ __forceinline__ int flattenIx() {
+  return 0;
 }
 
-template<typename T>
-static __device__ void partitionElts(
-    unsigned nParts, unsigned part,
-    size_t* nElts, ncclSymPtr<T>* inPtr, ncclSymPtr<T>* outPtr
-  ) {
-  constexpr int eltPerB16 = 16/sizeof(T);
-  size_t nB16 = (*nElts + eltPerB16-1)/eltPerB16;
-  size_t beginB16 = part*(nB16/nParts) + min(part, uint32_t(nB16%nParts));
-  *inPtr += beginB16*eltPerB16;
-  *outPtr += beginB16*eltPerB16;
-  if (part < nParts-1) {
-    nB16 = nB16/nParts + (part < nB16%nParts ? 1 : 0);
-    *nElts = nB16*eltPerB16;
+template <typename Int0, typename Int1, typename... Ints>
+static __device__ Int0 flattenIx(Int0 pos, Int1 size, Ints... more) {
+  return pos + size * flattenIx(more...);
+}
+
+template <typename T>
+static __device__ void partitionElts(unsigned nParts, unsigned part, size_t* nElts, ncclSymPtr<T>* inPtr,
+                                     ncclSymPtr<T>* outPtr) {
+  constexpr int eltPerB16 = 16 / sizeof(T);
+  size_t nB16 = (*nElts + eltPerB16 - 1) / eltPerB16;
+  size_t beginB16 = part * (nB16 / nParts) + min(part, uint32_t(nB16 % nParts));
+  *inPtr += beginB16 * eltPerB16;
+  *outPtr += beginB16 * eltPerB16;
+  if (part < nParts - 1) {
+    nB16 = nB16 / nParts + (part < nB16 % nParts ? 1 : 0);
+    *nElts = nB16 * eltPerB16;
   } else {
-    *nElts = *nElts - beginB16*eltPerB16;
+    *nElts = *nElts - beginB16 * eltPerB16;
   }
 }
 
@@ -92,27 +109,24 @@ struct ncclSymkArgsHandler {
   struct ncclSymkDevWork* devWork;
   uint32_t nRanks_rcp32;
 
-  __device__ ncclSymkArgsHandler(ncclSymkDevWorkArgs const* args):
-    comm(args->kcomm.devComm),
-    lsaLLA2A(args->kcomm.lsaLLA2A),
-    ginOutbox(args->kcomm.ginOutbox),
-    ginInboxRail(args->kcomm.ginInboxRail),
-    ginCounterPerBlock(args->kcomm.ginCounterPerBlock),
-    ginSyncHandle(args->kcomm.ginSyncHandle) {
+  __device__ ncclSymkArgsHandler(ncclSymkDevWorkArgs const* args)
+    : comm(args->kcomm.devComm), lsaLLA2A(args->kcomm.lsaLLA2A), ginOutbox(args->kcomm.ginOutbox),
+      ginInboxRail(args->kcomm.ginInboxRail), ginCounterPerBlock(args->kcomm.ginCounterPerBlock),
+      ginSyncHandle(args->kcomm.ginSyncHandle) {
     channelWorkRange = args->getWorkRange();
 
     devWork = args->getWorks(args->nMaxChannels);
     nRanks_rcp32 = comm.nRanks_rcp32;
   }
 
-  template<typename T>
+  template <typename T>
   __device__ void getWorkRange(int block, uint16_t& workLo, size_t& indexLo, uint16_t& workHi, size_t& indexHi) {
     constexpr int EltPerCell = NCCL_SYM_KERNEL_CELL_SIZE / sizeof(T);
     uint32_t fracLo, fracHi;
 
     // Where the work begins
-    workLo = (block==0) ? 0 : channelWorkRange[block-1].workHi; // start where predecessor ends
-    fracLo = (block==0) ? 0 : channelWorkRange[block-1].fracHi + 1;
+    workLo = (block == 0) ? 0 : channelWorkRange[block - 1].workHi; // start where predecessor ends
+    fracLo = (block == 0) ? 0 : channelWorkRange[block - 1].fracHi + 1;
     // If the predecessor ended on the work boundary, then we step to the beginning of the next work.
     // This ensures we never have empty parts.
     if (fracLo == 0x10000) {
@@ -129,7 +143,7 @@ struct ncclSymkArgsHandler {
     indexHi = min(((fracHi * divUp(dwHi.nElts, EltPerCell)) >> 16) * EltPerCell, dwHi.nElts);
   }
 
-  template<typename T>
+  template <typename T>
   __device__ void getWorkRangeFused(int blockIdx, int w, int& block, int& nBlocks, size_t& indexLo, size_t& indexHi) {
     constexpr int EltPerCell = NCCL_SYM_KERNEL_CELL_SIZE / sizeof(T);
     struct ncclSymkDevWork const& dw = devWork[w];
@@ -138,23 +152,25 @@ struct ncclSymkArgsHandler {
 
     block = blockIdx - dw.sChannelId;
     nBlocks = dw.nChannels;
-    lastBlock = dw.sChannelId+dw.nChannels-1;
+    lastBlock = dw.sChannelId + dw.nChannels - 1;
 
     // Where the work begins
-    fracLo = (dw.sChannelId>0 && channelWorkRange[dw.sChannelId-1].workHi == w) ? ((channelWorkRange[dw.sChannelId-1].fracHi + 1) & 0xFFFF) : 0;
+    fracLo = (dw.sChannelId > 0 && channelWorkRange[dw.sChannelId - 1].workHi == w) ?
+               ((channelWorkRange[dw.sChannelId - 1].fracHi + 1) & 0xFFFF) :
+               0;
     indexLo = ((fracLo * divUp(dw.nElts, EltPerCell)) >> 16) * EltPerCell;
     fracHi = (channelWorkRange[lastBlock].workHi == w) ? channelWorkRange[lastBlock].fracHi + 1 : 0x10000;
     indexHi = min(((fracHi * divUp(dw.nElts, EltPerCell)) >> 16) * EltPerCell, dw.nElts);
   }
 
-  template<typename T, typename Fn>
+  template <typename T, typename Fn>
   __device__ void forEachWork(Fn const& fn) {
     uint16_t workLo, workHi;
     size_t indexLo, indexHi;
 
     getWorkRange<T>(blockIdx.x, workLo, indexLo, workHi, indexHi);
 
-    #pragma unroll 1
+#pragma unroll 1
     for (int w = workLo; w <= workHi; w++) {
       struct ncclSymkDevWork const& dw = devWork[w];
       size_t const& nAllElts = dw.nElts;
@@ -177,7 +193,7 @@ struct ncclSymkArgsHandler {
     }
   }
 
-  template<typename T, typename Fn>
+  template <typename T, typename Fn>
   __device__ void singleWork(Fn const& fn) {
     uint16_t w;
     size_t indexLo, indexHi;
@@ -186,51 +202,75 @@ struct ncclSymkArgsHandler {
 
     struct ncclSymkDevWork const& dw = devWork[w];
 
-    fn(indexHi - indexLo, dw.nElts,
-       ncclSymPtr<T>(dw.inputWin, dw.inputOff) + indexLo,
+    fn(indexHi - indexLo, dw.nElts, ncclSymPtr<T>(dw.inputWin, dw.inputOff) + indexLo,
        ncclSymPtr<T>(dw.outputWin, dw.outputOff) + indexLo);
   }
 
-  template<typename T, typename Fn>
-    __device__ void forEachWorkNoFusion(Fn const& fn) {
-      uint16_t workLo, workHi;
-      size_t indexLo, indexHi;
+  template <typename T, typename Fn>
+  __device__ void forEachWorkNoFusion(Fn const& fn) {
+    uint16_t workLo, workHi;
+    size_t indexLo, indexHi;
 
-      getWorkRange<T>(blockIdx.x, workLo, indexLo, workHi, indexHi);
+    getWorkRange<T>(blockIdx.x, workLo, indexLo, workHi, indexHi);
 
-      #pragma unroll 1
-      for (int w = workLo; w <= workHi; w++) {
-        struct ncclSymkDevWork const& dw = devWork[w];
-        size_t const& nAllElts = dw.nElts;
-        size_t currentIndexLo, currentIndexHi;
-        currentIndexLo = (w > workLo) ? 0 : indexLo;
-        currentIndexHi = (w < workHi) ? nAllElts : indexHi;
+#pragma unroll 1
+    for (int w = workLo; w <= workHi; w++) {
+      struct ncclSymkDevWork const& dw = devWork[w];
+      size_t const& nAllElts = dw.nElts;
+      size_t currentIndexLo, currentIndexHi;
+      currentIndexLo = (w > workLo) ? 0 : indexLo;
+      currentIndexHi = (w < workHi) ? nAllElts : indexHi;
 
-        fn(currentIndexHi - currentIndexLo, nAllElts,
-           ncclSymPtr<T>(dw.inputWin, dw.inputOff) + currentIndexLo,
-           ncclSymPtr<T>(dw.outputWin, dw.outputOff) + currentIndexLo);
-      }
+      fn(currentIndexHi - currentIndexLo, nAllElts, ncclSymPtr<T>(dw.inputWin, dw.inputOff) + currentIndexLo,
+         ncclSymPtr<T>(dw.outputWin, dw.outputOff) + currentIndexLo);
+    }
   }
 };
-}
+} // namespace
 
-template<template<typename> typename Red, typename T, bool nvls>
-struct ncclSymkAccumType { using Type = T; };
+template <template <typename> typename Red, typename T, bool nvls>
+struct ncclSymkAccumType {
+  using Type = T;
+};
 
 // Only Red's whose opArg is invariant w.r.t. the datatype can have a different
 // accumulator type. At the moment this excludes integer min/max, sumpostdiv,
 // and premulsum.
-template<> struct ncclSymkAccumType<FuncSum, __half, false> { using Type = float; };
-template<> struct ncclSymkAccumType<FuncSumPostDiv, __half, false> { using Type = float; };
+template <>
+struct ncclSymkAccumType<FuncSum, __half, false> {
+  using Type = float;
+};
+template <>
+struct ncclSymkAccumType<FuncSumPostDiv, __half, false> {
+  using Type = float;
+};
 #if defined(__CUDA_BF16_TYPES_EXIST__)
-template<> struct ncclSymkAccumType<FuncSum, __nv_bfloat16, false> { using Type = float; };
-template<> struct ncclSymkAccumType<FuncSumPostDiv, __nv_bfloat16, false> { using Type = float; };
+template <>
+struct ncclSymkAccumType<FuncSum, __nv_bfloat16, false> {
+  using Type = float;
+};
+template <>
+struct ncclSymkAccumType<FuncSumPostDiv, __nv_bfloat16, false> {
+  using Type = float;
+};
 #endif
 #if defined(__CUDA_FP8_TYPES_EXIST__)
-template<> struct ncclSymkAccumType<FuncSum, __nv_fp8_e4m3, false> { using Type = float; };
-template<> struct ncclSymkAccumType<FuncSum, __nv_fp8_e5m2, false> { using Type = float; };
-template<> struct ncclSymkAccumType<FuncSumPostDiv, __nv_fp8_e4m3, false> { using Type = __half; };
-template<> struct ncclSymkAccumType<FuncSumPostDiv, __nv_fp8_e5m2, false> { using Type = __half; };
+template <>
+struct ncclSymkAccumType<FuncSum, __nv_fp8_e4m3, false> {
+  using Type = float;
+};
+template <>
+struct ncclSymkAccumType<FuncSum, __nv_fp8_e5m2, false> {
+  using Type = float;
+};
+template <>
+struct ncclSymkAccumType<FuncSumPostDiv, __nv_fp8_e4m3, false> {
+  using Type = __half;
+};
+template <>
+struct ncclSymkAccumType<FuncSumPostDiv, __nv_fp8_e5m2, false> {
+  using Type = __half;
+};
 #endif
 #if defined(__HIP_PLATFORM_AMD__)
 // The upstream bf16/fp8 specializations above are gated behind
@@ -238,103 +278,149 @@ template<> struct ncclSymkAccumType<FuncSumPostDiv, __nv_fp8_e5m2, false> { usin
 // RCCL device types. bf16 and fp8 both reduce in a float accumulator: the fp8
 // software type used on non-fp8 arches (e.g. gfx908) has no __half conversion, so
 // fp8 accumulates in float (which casts cleanly on every arch).
-template<> struct ncclSymkAccumType<FuncSumPostDiv, hip_bfloat16, false> { using Type = float; };
-template<> struct ncclSymkAccumType<FuncSumPostDiv, rccl_float8, false> { using Type = float; };
-template<> struct ncclSymkAccumType<FuncSumPostDiv, rccl_bfloat8, false> { using Type = float; };
+template <>
+struct ncclSymkAccumType<FuncSumPostDiv, hip_bfloat16, false> {
+  using Type = float;
+};
+template <>
+struct ncclSymkAccumType<FuncSumPostDiv, rccl_float8, false> {
+  using Type = float;
+};
+template <>
+struct ncclSymkAccumType<FuncSumPostDiv, rccl_bfloat8, false> {
+  using Type = float;
+};
 #endif
 
 // Accumulator type held in smem for GIN algos.
-template<template<typename> typename Red, typename T>
-struct ncclSymkGinAccumType { using Type = T; };
+template <template <typename> typename Red, typename T>
+struct ncclSymkGinAccumType {
+  using Type = T;
+};
 
-template<> struct ncclSymkGinAccumType<FuncSum, __half> { using Type = float; };
-template<> struct ncclSymkGinAccumType<FuncSumPostDiv, __half> { using Type = float; };
+template <>
+struct ncclSymkGinAccumType<FuncSum, __half> {
+  using Type = float;
+};
+template <>
+struct ncclSymkGinAccumType<FuncSumPostDiv, __half> {
+  using Type = float;
+};
 #if defined(__CUDA_BF16_TYPES_EXIST__)
-template<> struct ncclSymkGinAccumType<FuncSum, __nv_bfloat16> { using Type = float; };
-template<> struct ncclSymkGinAccumType<FuncSumPostDiv, __nv_bfloat16> { using Type = float; };
+template <>
+struct ncclSymkGinAccumType<FuncSum, __nv_bfloat16> {
+  using Type = float;
+};
+template <>
+struct ncclSymkGinAccumType<FuncSumPostDiv, __nv_bfloat16> {
+  using Type = float;
+};
 #endif
 
 #if defined(__CUDA_FP8_TYPES_EXIST__)
 // fp8 types accumulate in fp16. Multimem algo sends fp8 on wire because it's
 // impossible to get fp16 accumulator from switch. Non-multimem sends fp16 to
 // give users a higher precision alternative.
-template<> struct ncclSymkGinAccumType<FuncSum, __nv_fp8_e4m3> { using Type = __half; };
-template<> struct ncclSymkGinAccumType<FuncSum, __nv_fp8_e5m2> { using Type = __half; };
-template<> struct ncclSymkGinAccumType<FuncSumPostDiv, __nv_fp8_e4m3> { using Type = __half; };
-template<> struct ncclSymkGinAccumType<FuncSumPostDiv, __nv_fp8_e5m2> { using Type = __half; };
+template <>
+struct ncclSymkGinAccumType<FuncSum, __nv_fp8_e4m3> {
+  using Type = __half;
+};
+template <>
+struct ncclSymkGinAccumType<FuncSum, __nv_fp8_e5m2> {
+  using Type = __half;
+};
+template <>
+struct ncclSymkGinAccumType<FuncSumPostDiv, __nv_fp8_e4m3> {
+  using Type = __half;
+};
+template <>
+struct ncclSymkGinAccumType<FuncSumPostDiv, __nv_fp8_e5m2> {
+  using Type = __half;
+};
 #endif
 
 #if defined(__HIP_PLATFORM_AMD__)
 // avg reduces in float on ROCm: raw bf16/fp8 have no FuncSumPostDiv, but FuncSumPostDiv<float> does.
-template<> struct ncclSymkGinAccumType<FuncSumPostDiv, hip_bfloat16> { using Type = float; };
-template<> struct ncclSymkGinAccumType<FuncSumPostDiv, rccl_float8>  { using Type = float; };
-template<> struct ncclSymkGinAccumType<FuncSumPostDiv, rccl_bfloat8> { using Type = float; };
+template <>
+struct ncclSymkGinAccumType<FuncSumPostDiv, hip_bfloat16> {
+  using Type = float;
+};
+template <>
+struct ncclSymkGinAccumType<FuncSumPostDiv, rccl_float8> {
+  using Type = float;
+};
+template <>
+struct ncclSymkGinAccumType<FuncSumPostDiv, rccl_bfloat8> {
+  using Type = float;
+};
 #endif
 
-static __device__ __forceinline__ void tmaLoadStoreMc(void* dest, void* smem, void* source, size_t size, __mbarrier_t* bar) {
+static __device__ __forceinline__ void tmaLoadStoreMc(void* dest, void* smem, void* source, size_t size,
+                                                      __mbarrier_t* bar) {
   cp_async_bulk_global_to_shared(smem, source, bar, size);
   __mbarrier_token_t token = barrier_arrive1_tx_relaxed(bar, size);
-  while (!barrier_try_wait_token_relaxed(bar, token)) {}
+  while (!barrier_try_wait_token_relaxed(bar, token)) {
+  }
   multimem_cp_async_bulk_shared_to_global(dest, smem, size);
   cp_async_bulk_commit_group();
   cp_async_bulk_wait_all_read();
 }
 
 // TODO: move this into data_ops.cuh
-template<typename T, bool EnableTma = false>
-static __device__ void bcastMultimem(
-    ncclSymkArgsHandler& handler, int tn, int t, ncclSymPtr<T> input, ncclSymPtr<T> output, size_t nElts
-  ) {
-  size_t nBytes = nElts*sizeof(T);
+template <typename T, bool EnableTma = false>
+static __device__ void bcastMultimem(ncclSymkArgsHandler& handler, int tn, int t, ncclSymPtr<T> input,
+                                     ncclSymPtr<T> output, size_t nElts) {
+  size_t nBytes = nElts * sizeof(T);
   uintptr_t inputUptr = reinterpret_cast<uintptr_t>(input.localPtr());
   uintptr_t outputUptr = reinterpret_cast<uintptr_t>(output.multimemPtr(handler.comm.lsaMultimem));
   uint32_t alignment = uint32_t(inputUptr - outputUptr);
-  uint32_t nPreBytes = (EnableTma && alignment%256 == 0) ? (256 - input.offset)%256
-                                                         : (16 - input.offset)%16;
+  uint32_t nPreBytes = (EnableTma && alignment % 256 == 0) ? (256 - input.offset) % 256 : (16 - input.offset) % 16;
   nPreBytes = min((size_t)nPreBytes, nBytes);
   uintptr_t nSufBytes;
 
-  int lane = t%WARP_SIZE;
+  int lane = t % WARP_SIZE;
   int lw = threadIdx.x / WARP_SIZE;
   extern __shared__ char smemScratch[];
 
-  if (alignment%16 == 0) {
+  if (alignment % 16 == 0) {
     constexpr int BytePerPack = 16, UnrollPacks = 8;
-    constexpr int BytePerChunk = UnrollPacks*WARP_SIZE*BytePerPack;
+    constexpr int BytePerChunk = UnrollPacks * WARP_SIZE * BytePerPack;
     uintptr_t cursor = nPreBytes;
-    uint32_t nChunks = (nBytes-cursor)/BytePerChunk;
-    uintptr_t cursorAfter = cursor + uintptr_t(nChunks)*BytePerChunk;
+    uint32_t nChunks = (nBytes - cursor) / BytePerChunk;
+    uintptr_t cursorAfter = cursor + uintptr_t(nChunks) * BytePerChunk;
 
     // Initialize share memory pointer and barrier
-    constexpr size_t tileSize = UnrollPacks*WARP_SIZE*BytePerPack;
+    constexpr size_t tileSize = UnrollPacks * WARP_SIZE * BytePerPack;
     using tmaSmemStruct_t = tmaSmemStruct<BytePack<BytePerPack>, UnrollPacks>;
     constexpr int smemSizePerWarp = ncclTmaShmemScratchWarpSize();
-    tmaSmemStruct_t* tmaSmem = reinterpret_cast<tmaSmemStruct_t*>(smemScratch+lw*smemSizePerWarp);
+    tmaSmemStruct_t* tmaSmem = reinterpret_cast<tmaSmemStruct_t*>(smemScratch + lw * smemSizePerWarp);
     if NCCL_IF_CONSTEXPR (EnableTma) {
       if (lane == 0) __mbarrier_init(&tmaSmem->bar, 1);
     }
 
     nSufBytes = nBytes - cursorAfter;
-    cursor += (t/WARP_SIZE)*UnrollPacks*WARP_SIZE*BytePerPack;
-    cursor += (t%WARP_SIZE)*BytePerPack;
-    int nIters = nChunks - t/WARP_SIZE;
-    #pragma unroll 1
+    cursor += (t / WARP_SIZE) * UnrollPacks * WARP_SIZE * BytePerPack;
+    cursor += (t % WARP_SIZE) * BytePerPack;
+    int nIters = nChunks - t / WARP_SIZE;
+#pragma unroll 1
     while (0 < nIters) {
       if NCCL_IF_CONSTEXPR (EnableTma) {
-        if (lane == 0) tmaLoadStoreMc((void*)(outputUptr+cursor), tmaSmem->buff[0], (void*)(inputUptr+cursor), tileSize, &tmaSmem->bar);
+        if (lane == 0)
+          tmaLoadStoreMc((void*)(outputUptr + cursor), tmaSmem->buff[0], (void*)(inputUptr + cursor), tileSize,
+                         &tmaSmem->bar);
       } else {
         BytePack<BytePerPack> tmp[UnrollPacks];
-        #pragma unroll
-        for (int u=0; u < UnrollPacks; u++) {
-          tmp[u] = *reinterpret_cast<BytePack<BytePerPack>*>(inputUptr + cursor + u*WARP_SIZE*BytePerPack);
+#pragma unroll
+        for (int u = 0; u < UnrollPacks; u++) {
+          tmp[u] = *reinterpret_cast<BytePack<BytePerPack>*>(inputUptr + cursor + u * WARP_SIZE * BytePerPack);
         }
-        #pragma unroll
-        for (int u=0; u < UnrollPacks; u++) {
-          multimem_st_global(outputUptr + cursor + u*WARP_SIZE*BytePerPack, tmp[u]);
+#pragma unroll
+        for (int u = 0; u < UnrollPacks; u++) {
+          multimem_st_global(outputUptr + cursor + u * WARP_SIZE * BytePerPack, tmp[u]);
         }
       }
-      cursor += tn*UnrollPacks*BytePerPack;
-      nIters -= tn/WARP_SIZE;
+      cursor += tn * UnrollPacks * BytePerPack;
+      nIters -= tn / WARP_SIZE;
     }
   } else {
     nPreBytes = 0;
@@ -342,30 +428,29 @@ static __device__ void bcastMultimem(
   }
 
   // Get the prefix+suffix element one at a time.
-  #pragma unroll 4
-  for (uintptr_t i = t*sizeof(T); i < nPreBytes + nSufBytes; i += tn*sizeof(T)) {
-    uintptr_t cursor = i < nPreBytes ? i : nBytes-nSufBytes+(i-nPreBytes);
+#pragma unroll 4
+  for (uintptr_t i = t * sizeof(T); i < nPreBytes + nSufBytes; i += tn * sizeof(T)) {
+    uintptr_t cursor = i < nPreBytes ? i : nBytes - nSufBytes + (i - nPreBytes);
     BytePack<sizeof(T)> val = *reinterpret_cast<BytePack<sizeof(T)>*>(inputUptr + cursor);
     multimem_st_global(outputUptr + cursor, val);
-
   }
 }
 
 extern __shared__ ulong2 ncclSymkSmem[];
 
 static __device__ void ncclSymkSmemPartition_help(int bumper) {}
-template<typename T, typename ...More>
-static __device__ void ncclSymkSmemPartition_help(int bumper, T** ptr, int size, More ...more) {
-  T *ans = reinterpret_cast<T*>(ncclSymkSmem + bumper);
+template <typename T, typename... More>
+static __device__ void ncclSymkSmemPartition_help(int bumper, T** ptr, int size, More... more) {
+  T* ans = reinterpret_cast<T*>(ncclSymkSmem + bumper);
   __builtin_assume(__isShared(ans)); // Let compiler know this is shared memory (reinterpret_cast obscured as much).
   __builtin_assume_aligned(ans, sizeof(ulong2));
   *ptr = ans;
-  bumper += (size*sizeof(T) + sizeof(ulong2)-1)/sizeof(ulong2);
+  bumper += (size * sizeof(T) + sizeof(ulong2) - 1) / sizeof(ulong2);
   ncclSymkSmemPartition_help(bumper, more...);
 }
 
-template<typename ...Arg>
-static __device__ void ncclSymkSmemPartition(Arg ...args) {
+template <typename... Arg>
+static __device__ void ncclSymkSmemPartition(Arg... args) {
   ncclSymkSmemPartition_help(/*bumper=*/0, args...);
 }
 
@@ -373,7 +458,7 @@ static __device__ void ncclSymkSmemPartition(Arg ...args) {
 // Extensions to nccl_device.h needed to help compiler make good SASS:
 ////////////////////////////////////////////////////////////////////////////////
 
-template<typename T>
+template <typename T>
 struct ncclLsaPointerGetter {
   void* base;
   uint32_t stride4G;
@@ -383,7 +468,7 @@ struct ncclLsaPointerGetter {
     stride4G = nccl::utility::loadConst(&ptr.window->stride4G);
   }
   __device__ T* operator()(int lsaPeer) const {
-    return (T*)nccl::utility::add4G(base, lsaPeer*stride4G);
+    return (T*)nccl::utility::add4G(base, lsaPeer * stride4G);
   }
 };
 #endif // NCCL_DEVICE_SYMMETRIC_PRIMITIVES_H_

--- a/projects/rccl/src/device/symmetric/reduce_scatter.cuh
+++ b/projects/rccl/src/device/symmetric/reduce_scatter.cuh
@@ -1,38 +1,36 @@
 // Modification Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
-// SPDX-License-Identifier: MIT 
+// SPDX-License-Identifier: MIT
 
 #include "sym_kernels.h"
 #include "symmetric/kernel.h"
 #include "symmetric/primitives.h"
 
-template<int BytePerPack, int UnrollPacks, int UnrollPeers, typename T, bool EnableTma, typename Red>
-static __device__ void reduceDeep(
-    ncclSymkArgsHandler const& handler, int tn, int t,
-    bool waitNeeded, ncclLsaBarrierSession<ncclCoopCta>& bar,
-    Red red, ncclSymPtr<char> input, ncclSymPtr<char> output, int32_t nIters
-  ) {
+template <int BytePerPack, int UnrollPacks, int UnrollPeers, typename T, bool EnableTma, typename Red>
+static __device__ void reduceDeep(ncclSymkArgsHandler const& handler, int tn, int t, bool waitNeeded,
+                                  ncclLsaBarrierSession<ncclCoopCta>& bar, Red red, ncclSymPtr<char> input,
+                                  ncclSymPtr<char> output, int32_t nIters) {
   using Pack = BytePack<BytePerPack>;
   using Acc = typename Red::EltType;
-  using AccPack = BytePack<BytePerPack*sizeof(Acc)/sizeof(T)>;
+  using AccPack = BytePack<BytePerPack * sizeof(Acc) / sizeof(T)>;
 
   ncclTeam world = ncclTeamWorld(handler.comm);
-  int wn = tn/WARP_SIZE;
-  int w = t/WARP_SIZE;
-  int lane = t%WARP_SIZE;
+  int wn = tn / WARP_SIZE;
+  int w = t / WARP_SIZE;
+  int lane = t % WARP_SIZE;
   int const& rank = handler.comm.rank;
   int const& nRanks = handler.comm.nRanks;
-  constexpr size_t tilePack = UnrollPacks*WARP_SIZE;
+  constexpr size_t tilePack = UnrollPacks * WARP_SIZE;
   constexpr size_t tileSize = tilePack * BytePerPack;
   size_t tmaSize;
-  ncclSymPtr<Pack> inpPacks = (ncclSymPtr<Pack>)input + intptr_t(w)*UnrollPacks*WARP_SIZE + (EnableTma ? 0 : lane);
-  ncclSymPtr<Pack> outPacks = (ncclSymPtr<Pack>)output + intptr_t(w)*UnrollPacks*WARP_SIZE + (EnableTma ? 0 : lane);
+  ncclSymPtr<Pack> inpPacks = (ncclSymPtr<Pack>)input + intptr_t(w) * UnrollPacks * WARP_SIZE + (EnableTma ? 0 : lane);
+  ncclSymPtr<Pack> outPacks = (ncclSymPtr<Pack>)output + intptr_t(w) * UnrollPacks * WARP_SIZE + (EnableTma ? 0 : lane);
   Pack acc0[UnrollPacks];
 
   int lw = threadIdx.x / WARP_SIZE;
   extern __shared__ char smemScratch[];
   using tmaSmemStruct_t = tmaSmemStruct<Pack, UnrollPacks, UnrollPeers>;
   constexpr int smemSizePerWarp = ncclTmaShmemScratchWarpSize();
-  tmaSmemStruct_t* tmaSmem = reinterpret_cast<tmaSmemStruct_t*>(smemScratch+lw*smemSizePerWarp);
+  tmaSmemStruct_t* tmaSmem = reinterpret_cast<tmaSmemStruct_t*>(smemScratch + lw * smemSizePerWarp);
 
   if NCCL_IF_CONSTEXPR (EnableTma) {
     if (lane == 0) {
@@ -47,9 +45,9 @@ static __device__ void reduceDeep(
         cp_async_bulk_global_to_shared(tmaSmem->buff[0], inpPacks.peerPtr(world, rank), &tmaSmem->bar, tileSize);
       }
     } else {
-      #pragma unroll
-      for (int u=0; u < UnrollPacks; u++) {
-        acc0[u] = inpPacks.peerPtr(world, rank)[u*WARP_SIZE];
+#pragma unroll
+      for (int u = 0; u < UnrollPacks; u++) {
+        acc0[u] = inpPacks.peerPtr(world, rank)[u * WARP_SIZE];
       }
     }
   }
@@ -60,29 +58,31 @@ static __device__ void reduceDeep(
     while (true) {
       if NCCL_IF_CONSTEXPR (EnableTma) tmaSize = tileSize;
       AccPack acc1[UnrollPacks];
-      int r = rank+1;
+      int r = rank + 1;
       if (r == nRanks) r = 0;
-      { Pack tmp1[UnrollPacks];
+      {
+        Pack tmp1[UnrollPacks];
         if NCCL_IF_CONSTEXPR (EnableTma) {
           if (lane == 0) {
             cp_async_bulk_global_to_shared(tmaSmem->buff[1], inpPacks.peerPtr(world, r), &tmaSmem->bar, tileSize);
             tmaSize += tileSize;
             __mbarrier_token_t token = barrier_arrive1_tx_relaxed(&tmaSmem->bar, tmaSize);
-            while (!barrier_try_wait_token_relaxed(&tmaSmem->bar, token)) {}
+            while (!barrier_try_wait_token_relaxed(&tmaSmem->bar, token)) {
+            }
             tmaSize = 0;
           }
           __syncwarp();
         } else {
-          #pragma unroll
-          for (int u=0; u < UnrollPacks; u++) {
-            tmp1[u] = inpPacks.peerPtr(world, r)[u*WARP_SIZE];
+#pragma unroll
+          for (int u = 0; u < UnrollPacks; u++) {
+            tmp1[u] = inpPacks.peerPtr(world, r)[u * WARP_SIZE];
           }
         }
-        #pragma unroll
-        for (int u=0; u < UnrollPacks; u++) {
+#pragma unroll
+        for (int u = 0; u < UnrollPacks; u++) {
           if NCCL_IF_CONSTEXPR (EnableTma) {
-            acc0[u] = tmaSmem->buff[0][lane+WARP_SIZE*u];
-            tmp1[u] = tmaSmem->buff[1][lane+WARP_SIZE*u];
+            acc0[u] = tmaSmem->buff[0][lane + WARP_SIZE * u];
+            tmp1[u] = tmaSmem->buff[1][lane + WARP_SIZE * u];
           }
           acc1[u] = applyReduce(red, applyCast<T, Acc>(acc0[u]), applyCast<T, Acc>(tmp1[u]));
         }
@@ -92,12 +92,10 @@ static __device__ void reduceDeep(
       if (r == nRanks) r = 0;
 
       int dr = 2;
-      #pragma unroll 2
-      for (int partial=0; partial <= 1; partial++) {
-        #pragma unroll 1
-        for (int i = 0;
-             partial ? i < 1 : (dr + UnrollPeers <= nRanks);
-             partial ? i++ : (dr += UnrollPeers)) {
+#pragma unroll 2
+      for (int partial = 0; partial <= 1; partial++) {
+#pragma unroll 1
+        for (int i = 0; partial ? i < 1 : (dr + UnrollPeers <= nRanks); partial ? i++ : (dr += UnrollPeers)) {
           if (partial && dr == nRanks) break;
 
           Pack tmp1[UnrollPeers][UnrollPacks];
@@ -106,18 +104,18 @@ static __device__ void reduceDeep(
             __syncwarp();
           }
 
-          #pragma unroll
-          for (int ur=0; ur < UnrollPeers-partial; ur++) {
-            if (partial && ur!=0 && dr+ur == nRanks) break;
+#pragma unroll
+          for (int ur = 0; ur < UnrollPeers - partial; ur++) {
+            if (partial && ur != 0 && dr + ur == nRanks) break;
             if NCCL_IF_CONSTEXPR (EnableTma) {
               if (lane == 0) {
                 cp_async_bulk_global_to_shared(tmaSmem->buff[ur], inpPacks.peerPtr(world, r), &tmaSmem->bar, tileSize);
                 tmaSize += tileSize;
               }
             } else {
-              #pragma unroll UnrollPacks
-              for (int u=0; u < UnrollPacks; u++) {
-                tmp1[ur][u] = inpPacks.peerPtr(world, r)[u*WARP_SIZE];
+#pragma unroll UnrollPacks
+              for (int u = 0; u < UnrollPacks; u++) {
+                tmp1[ur][u] = inpPacks.peerPtr(world, r)[u * WARP_SIZE];
               }
             }
             r += 1;
@@ -126,19 +124,20 @@ static __device__ void reduceDeep(
           if NCCL_IF_CONSTEXPR (EnableTma) {
             if (lane == 0) {
               __mbarrier_token_t token = barrier_arrive1_tx_relaxed(&tmaSmem->bar, tmaSize);
-              while (!barrier_try_wait_token_relaxed(&tmaSmem->bar, token)) {}
+              while (!barrier_try_wait_token_relaxed(&tmaSmem->bar, token)) {
+              }
               tmaSize = 0;
             }
             // threads wait for peers' data to reach shared memory before starting the reduction
             __syncwarp();
           }
-          #pragma unroll
-          for (int ur=0; ur < UnrollPeers-partial; ur++) {
-            if (partial && ur!=0 && dr+ur == nRanks) break;
-            #pragma unroll UnrollPacks
-            for (int u=0; u < UnrollPacks; u++) {
+#pragma unroll
+          for (int ur = 0; ur < UnrollPeers - partial; ur++) {
+            if (partial && ur != 0 && dr + ur == nRanks) break;
+#pragma unroll UnrollPacks
+            for (int u = 0; u < UnrollPacks; u++) {
               if NCCL_IF_CONSTEXPR (EnableTma) {
-                tmp1[ur][u] = tmaSmem->buff[ur][lane+WARP_SIZE*u];
+                tmp1[ur][u] = tmaSmem->buff[ur][lane + WARP_SIZE * u];
               }
               acc1[u] = applyReduce(red, acc1[u], applyCast<T, Acc>(tmp1[ur][u]));
             }
@@ -146,15 +145,15 @@ static __device__ void reduceDeep(
         }
       }
 
-      #pragma unroll
-      for (int u=0; u < UnrollPacks; u++) {
+#pragma unroll
+      for (int u = 0; u < UnrollPacks; u++) {
         acc1[u] = applyPostOp(red, acc1[u]);
       }
 
-      #pragma unroll
-      for (int u=0; u < UnrollPacks; u++) {
+#pragma unroll
+      for (int u = 0; u < UnrollPacks; u++) {
         if NCCL_IF_CONSTEXPR (EnableTma) {
-          tmaSmem->buff[0][lane+WARP_SIZE*u] = applyCast<Acc, T>(acc1[u]);
+          tmaSmem->buff[0][lane + WARP_SIZE * u] = applyCast<Acc, T>(acc1[u]);
         } else {
           acc0[u] = applyCast<Acc, T>(acc1[u]);
         }
@@ -174,12 +173,12 @@ static __device__ void reduceDeep(
         // threads wait for shared memory to be consumed by async proxy before reusing it
         __syncwarp();
       } else {
-        #pragma unroll UnrollPacks
-        for (int u=0; u < UnrollPacks; u++) outPacks.localPtr()[u*WARP_SIZE] = acc0[u];
+#pragma unroll UnrollPacks
+        for (int u = 0; u < UnrollPacks; u++) outPacks.localPtr()[u * WARP_SIZE] = acc0[u];
       }
 
-      inpPacks += intptr_t(wn)*UnrollPacks*WARP_SIZE;
-      outPacks += intptr_t(wn)*UnrollPacks*WARP_SIZE;
+      inpPacks += intptr_t(wn) * UnrollPacks * WARP_SIZE;
+      outPacks += intptr_t(wn) * UnrollPacks * WARP_SIZE;
       nIters -= wn;
       if (nIters <= 0) break;
 
@@ -189,21 +188,18 @@ static __device__ void reduceDeep(
         }
       } else {
         // Load data for next iteration.
-        #pragma unroll
-        for (int u=0; u < UnrollPacks; u++) {
-          acc0[u] = inpPacks.peerPtr(world, rank)[u*WARP_SIZE];
+#pragma unroll
+        for (int u = 0; u < UnrollPacks; u++) {
+          acc0[u] = inpPacks.peerPtr(world, rank)[u * WARP_SIZE];
         }
       }
     }
   }
 }
 
-template<int UnrollPeers, typename Red, typename T>
-static __device__ void reduceEnds(
-    ncclSymkArgsHandler const& handler, int tn, int t, Red red,
-    ncclSymPtr<T> input, ncclSymPtr<T> output,
-    size_t nElts, uint32_t nPreElts, size_t nSufElts
-  ) {
+template <int UnrollPeers, typename Red, typename T>
+static __device__ void reduceEnds(ncclSymkArgsHandler const& handler, int tn, int t, Red red, ncclSymPtr<T> input,
+                                  ncclSymPtr<T> output, size_t nElts, uint32_t nPreElts, size_t nSufElts) {
   using Acc = typename Red::EltType;
 
   ncclTeam world = ncclTeamWorld(handler.comm);
@@ -212,28 +208,26 @@ static __device__ void reduceEnds(
 
   ncclSymPtr<BytePack<sizeof(T)>> inpPacks = (ncclSymPtr<BytePack<sizeof(T)>>)input;
   ncclSymPtr<BytePack<sizeof(T)>> outPacks = (ncclSymPtr<BytePack<sizeof(T)>>)output;
-  #pragma unroll 1
-  for (size_t i = t; i < nPreElts+nSufElts; i += tn) {
-    size_t elt = i < nPreElts ? i : nElts-nSufElts-nPreElts+i;
+#pragma unroll 1
+  for (size_t i = t; i < nPreElts + nSufElts; i += tn) {
+    size_t elt = i < nPreElts ? i : nElts - nSufElts - nPreElts + i;
     BytePack<sizeof(T)> acc0 = inpPacks.peerPtr(world, rank)[elt];
     BytePack<sizeof(Acc)> acc1;
     BytePack<sizeof(T)> tmp[UnrollPeers];
     int dr = 1;
-    int r = rank+1;
+    int r = rank + 1;
     if (nRanks == r) r = 0;
     bool first = true;
 
-    #pragma unroll 2
-    for (int partial=0; partial <= 1; partial++) {
-      #pragma unroll 1
-      for (int j = 0;
-           partial ? j < 1 : (dr + UnrollPeers <= nRanks);
-           partial ? j++ : (dr += UnrollPeers)) {
+#pragma unroll 2
+    for (int partial = 0; partial <= 1; partial++) {
+#pragma unroll 1
+      for (int j = 0; partial ? j < 1 : (dr + UnrollPeers <= nRanks); partial ? j++ : (dr += UnrollPeers)) {
         if (partial && dr == nRanks) break;
 
-        #pragma unroll
-        for (int u=0; u < UnrollPeers-partial; u++) {
-          if (partial && u!=0 && dr+u == nRanks) break;
+#pragma unroll
+        for (int u = 0; u < UnrollPeers - partial; u++) {
+          if (partial && u != 0 && dr + u == nRanks) break;
           tmp[u] = inpPacks.peerPtr(world, r)[elt];
           r += 1;
           if (r == nRanks) r = 0;
@@ -242,9 +236,9 @@ static __device__ void reduceEnds(
           first = false;
           acc1 = applyCast<T, Acc>(acc0);
         }
-        #pragma unroll
-        for (int u=0; u < UnrollPeers-partial; u++) {
-          if (partial && u!=0 && dr+u == nRanks) break;
+#pragma unroll
+        for (int u = 0; u < UnrollPeers - partial; u++) {
+          if (partial && u != 0 && dr + u == nRanks) break;
           acc1 = applyReduce(red, acc1, applyCast<T, Acc>(tmp[u]));
         }
       }
@@ -256,144 +250,133 @@ static __device__ void reduceEnds(
   }
 }
 
-template<typename Red, typename T, bool EnableTma>
-static __device__ void reduce(
-    ncclSymkArgsHandler const& handler, int tn, int t, int nBlocks,
-    bool waitNeeded, ncclLsaBarrierSession<ncclCoopCta>& bar,
-    Red red, ncclSymPtr<T> input, ncclSymPtr<T> output, size_t nElts
-  ) {
+template <typename Red, typename T, bool EnableTma>
+static __device__ void reduce(ncclSymkArgsHandler const& handler, int tn, int t, int nBlocks, bool waitNeeded,
+                              ncclLsaBarrierSession<ncclCoopCta>& bar, Red red, ncclSymPtr<T> input,
+                              ncclSymPtr<T> output, size_t nElts) {
   int const& nRanks = handler.comm.nRanks;
   int const& nRanks_rcp32 = handler.nRanks_rcp32;
   uint32_t nBlocks_rcp32 = nccl::utility::idivRcp32_upto64(nBlocks);
   uint32_t nRanks_nBlocks_rcp32 = nccl::utility::imulRcp32(nRanks, nRanks_rcp32, nBlocks, nBlocks_rcp32);
 
   uint32_t alignment = uint32_t(input.offset - output.offset);
-  size_t nBytes = nElts*sizeof(T);
+  size_t nBytes = nElts * sizeof(T);
 
-  uint32_t nPreBytes = (16u - input.offset)%16u;
+  uint32_t nPreBytes = (16u - input.offset) % 16u;
   nPreBytes = min((size_t)nPreBytes, nBytes);
   uintptr_t cursor = nPreBytes;
 
   constexpr int MinWarpPerBlock = 4;
 
-  if (alignment%16 == 0) {
+  if (alignment % 16 == 0) {
     constexpr int BytePerPack = 16, UnrollPacks = EnableTma ? 8 : 4, UnrollPeers = 2;
-    constexpr int BytePerChunk = MinWarpPerBlock*UnrollPacks*WARP_SIZE*BytePerPack;
-    uint32_t chunks = (nBytes-cursor)/BytePerChunk;
-    chunks -= imodFast32(chunks, nRanks*nBlocks, nRanks_nBlocks_rcp32);
+    constexpr int BytePerChunk = MinWarpPerBlock * UnrollPacks * WARP_SIZE * BytePerPack;
+    uint32_t chunks = (nBytes - cursor) / BytePerChunk;
+    chunks -= imodFast32(chunks, nRanks * nBlocks, nRanks_nBlocks_rcp32);
     if (chunks != 0) {
-      uintptr_t cursorAfter = cursor + uintptr_t(chunks)*BytePerChunk;
-      reduceDeep<BytePerPack, UnrollPacks, UnrollPeers, T, EnableTma>(
-        handler, tn, t, waitNeeded, bar, red,
-        (ncclSymPtr<char>)input + cursor, (ncclSymPtr<char>)output + cursor,
-        chunks*MinWarpPerBlock
-      );
+      uintptr_t cursorAfter = cursor + uintptr_t(chunks) * BytePerChunk;
+      reduceDeep<BytePerPack, UnrollPacks, UnrollPeers, T, EnableTma>(handler, tn, t, waitNeeded, bar, red,
+                                                                      (ncclSymPtr<char>)input + cursor,
+                                                                      (ncclSymPtr<char>)output + cursor,
+                                                                      chunks * MinWarpPerBlock);
       cursor = cursorAfter;
       waitNeeded = false;
     }
   }
 
-  if (sizeof(T) == 4 || (sizeof(T) < 4 && alignment%4 == 0)) {
+  if (sizeof(T) == 4 || (sizeof(T) < 4 && alignment % 4 == 0)) {
     constexpr int BytePerPack = 4, UnrollPacks = 4, UnrollPeers = 4;
-    constexpr int BytePerChunk = MinWarpPerBlock*UnrollPacks*WARP_SIZE*BytePerPack;
-    uint32_t chunks = (nBytes-cursor)/BytePerChunk;
-    chunks -= imodFast32(chunks, nRanks*nBlocks, nRanks_nBlocks_rcp32);
+    constexpr int BytePerChunk = MinWarpPerBlock * UnrollPacks * WARP_SIZE * BytePerPack;
+    uint32_t chunks = (nBytes - cursor) / BytePerChunk;
+    chunks -= imodFast32(chunks, nRanks * nBlocks, nRanks_nBlocks_rcp32);
     if (chunks != 0) {
-      uintptr_t cursorAfter = cursor + uintptr_t(chunks)*BytePerChunk;
+      uintptr_t cursorAfter = cursor + uintptr_t(chunks) * BytePerChunk;
       reduceDeep<(sizeof(T) <= BytePerPack ? BytePerPack : 0), UnrollPacks, UnrollPeers, T, false>(
-        handler, tn, t, waitNeeded, bar, red,
-        (ncclSymPtr<char>)input + cursor, (ncclSymPtr<char>)output + cursor,
-        chunks*MinWarpPerBlock
-      );
+        handler, tn, t, waitNeeded, bar, red, (ncclSymPtr<char>)input + cursor, (ncclSymPtr<char>)output + cursor,
+        chunks * MinWarpPerBlock);
       cursor = cursorAfter;
       waitNeeded = false;
     }
   }
 
-  if (waitNeeded)
-    bar.wait(ncclCoopCta(), NCCL_MEM_ORDER_RELAXED);
+  if (waitNeeded) bar.wait(ncclCoopCta(), NCCL_MEM_ORDER_RELAXED);
 
   constexpr int UnrollPeers = 8;
-  size_t nSufElts = (nBytes-cursor)/sizeof(T);
-  reduceEnds<UnrollPeers>(handler, tn, t, red, input, output, nElts, nPreBytes/sizeof(T), nSufElts);
+  size_t nSufElts = (nBytes - cursor) / sizeof(T);
+  reduceEnds<UnrollPeers>(handler, tn, t, red, input, output, nElts, nPreBytes / sizeof(T), nSufElts);
 }
 
-template<template<typename> typename Red, typename T, bool EnableTma>
+template <template <typename> typename Red, typename T, bool EnableTma>
 __device__ __forceinline__ void ncclSymkRun_ReduceScatter_LD_impl(ncclSymkDevWorkArgs const* args) {
   ncclSymkArgsHandler handler{args};
-  ncclLsaBarrierSession<ncclCoopCta> bar{
-    ncclCoopCta(), handler.comm, ncclTeamTagLsa(), blockIdx.x
-  };
+  ncclLsaBarrierSession<ncclCoopCta> bar{ncclCoopCta(), handler.comm, ncclTeamTagLsa(), blockIdx.x};
   Red<typename ncclSymkAccumType<Red, T, /*nvls=*/false>::Type> red(handler.devWork->redOpArg);
   int const& rank = handler.comm.rank;
 
   bar.arrive(ncclCoopCta(), NCCL_MEM_ORDER_RELAXED);
 
   bool waitNeeded = true;
-  handler.forEachWork<T>(
-      [&]__device__(int block, int nBlocks, size_t nElts, size_t nAllElts,
-                    ncclSymPtr<T> input, ncclSymPtr<T> output) {
+  handler.forEachWork<T>([&] __device__(int block, int nBlocks, size_t nElts, size_t nAllElts, ncclSymPtr<T> input,
+                                        ncclSymPtr<T> output) {
         // Round robin warps over blocks.
-        int t = flattenIx(threadIdx.x%WARP_SIZE, WARP_SIZE,
-                          block, nBlocks,
-                          threadIdx.x/WARP_SIZE, blockDim.x/WARP_SIZE);
-        int tn = nBlocks*blockDim.x;
+    int t =
+      flattenIx(threadIdx.x % WARP_SIZE, WARP_SIZE, block, nBlocks, threadIdx.x / WARP_SIZE, blockDim.x / WARP_SIZE);
+    int tn = nBlocks * blockDim.x;
 
-        reduce<decltype(red), T, EnableTma>(handler, tn, t, nBlocks, waitNeeded, bar, red, input + rank*nAllElts, output, nElts);
+    reduce<decltype(red), T, EnableTma>(handler, tn, t, nBlocks, waitNeeded, bar, red, input + rank * nAllElts, output,
+                                        nElts);
 
-        waitNeeded = false;
-      }
-    );
+    waitNeeded = false;
+  });
 
   bar.sync(ncclCoopCta(), NCCL_MEM_ORDER_RELEASE);
 }
 
-template<template<typename> typename Red, typename T>
+template <template <typename> typename Red, typename T>
 __device__ __forceinline__ void ncclSymkRun_ReduceScatter_LD(ncclSymkDevWorkArgs const* args) {
   ncclSymkRun_ReduceScatter_LD_impl<Red, T, /*EnableTma=*/false>(args);
 }
 
-template<template<typename> typename Red, typename T>
+template <template <typename> typename Red, typename T>
 __device__ __forceinline__ void ncclSymkRun_ReduceScatter_TmaLD(ncclSymkDevWorkArgs const* args) {
   ncclSymkRun_ReduceScatter_LD_impl<Red, T, /*EnableTma=*/true>(args);
 }
 
-template<typename Red, typename T>
-static __device__ void reduceMultimem(
-    int tn, int t, Red red, T* input, T* output, size_t nElts
-  ) {
+template <typename Red, typename T>
+static __device__ void reduceMultimem(int tn, int t, Red red, T* input, T* output, size_t nElts) {
   uintptr_t inputUptr = reinterpret_cast<uintptr_t>(input);
   uintptr_t outputUptr = reinterpret_cast<uintptr_t>(output);
-  size_t nBytes = nElts*sizeof(T);
+  size_t nBytes = nElts * sizeof(T);
 
   constexpr int BytePerPack = LoadMultimem_BigPackSize<Red>::BigPackSize;
-  uint32_t nPreBytes = (BytePerPack - inputUptr)%BytePerPack;
+  uint32_t nPreBytes = (BytePerPack - inputUptr) % BytePerPack;
   nPreBytes = min((size_t)nPreBytes, nBytes);
   uintptr_t nSufBytes;
 
-  if (sizeof(T) == BytePerPack || (inputUptr-outputUptr)%BytePerPack == 0) {
-    constexpr int UnrollPacks = 8*(16/BytePerPack);
-    constexpr int BytePerChunk = UnrollPacks*WARP_SIZE*BytePerPack;
+  if (sizeof(T) == BytePerPack || (inputUptr - outputUptr) % BytePerPack == 0) {
+    constexpr int UnrollPacks = 8 * (16 / BytePerPack);
+    constexpr int BytePerChunk = UnrollPacks * WARP_SIZE * BytePerPack;
     uintptr_t cursor = nPreBytes;
-    uint32_t nChunks = (nBytes-cursor)/BytePerChunk;
-    uintptr_t cursorAfter = cursor + uintptr_t(nChunks)*BytePerChunk;
+    uint32_t nChunks = (nBytes - cursor) / BytePerChunk;
+    uintptr_t cursorAfter = cursor + uintptr_t(nChunks) * BytePerChunk;
     nSufBytes = nBytes - cursorAfter;
-    cursor += (t/WARP_SIZE)*UnrollPacks*WARP_SIZE*BytePerPack;
-    cursor += (t%WARP_SIZE)*BytePerPack;
-    int nIters = nChunks - t/WARP_SIZE;
-    #pragma unroll 1
+    cursor += (t / WARP_SIZE) * UnrollPacks * WARP_SIZE * BytePerPack;
+    cursor += (t % WARP_SIZE) * BytePerPack;
+    int nIters = nChunks - t / WARP_SIZE;
+#pragma unroll 1
     while (0 < nIters) {
       BytePack<BytePerPack> tmp[UnrollPacks];
-      #pragma unroll
-      for (int u=0; u < UnrollPacks; u++) {
-        tmp[u] = applyPostOp(red, applyLoadMultimem<Red, BytePerPack>(red, inputUptr + cursor + u*WARP_SIZE*BytePerPack));
+#pragma unroll
+      for (int u = 0; u < UnrollPacks; u++) {
+        tmp[u] =
+          applyPostOp(red, applyLoadMultimem<Red, BytePerPack>(red, inputUptr + cursor + u * WARP_SIZE * BytePerPack));
       }
-      #pragma unroll
-      for (int u=0; u < UnrollPacks; u++) {
-        *reinterpret_cast<BytePack<BytePerPack>*>(outputUptr + cursor + u*WARP_SIZE*BytePerPack) = tmp[u];
+#pragma unroll
+      for (int u = 0; u < UnrollPacks; u++) {
+        *reinterpret_cast<BytePack<BytePerPack>*>(outputUptr + cursor + u * WARP_SIZE * BytePerPack) = tmp[u];
       }
-      cursor += tn*UnrollPacks*BytePerPack;
-      nIters -= tn/WARP_SIZE;
+      cursor += tn * UnrollPacks * BytePerPack;
+      nIters -= tn / WARP_SIZE;
     }
   } else {
     nPreBytes = 0;
@@ -401,20 +384,18 @@ static __device__ void reduceMultimem(
   }
 
   // Get the prefix+suffix element one at a time.
-  #pragma unroll 4
-  for (uintptr_t i = t*sizeof(T); i < nPreBytes + nSufBytes; i += tn*sizeof(T)) {
-    uintptr_t cursor = i < nPreBytes ? i : nBytes-nSufBytes+(i-nPreBytes);
+#pragma unroll 4
+  for (uintptr_t i = t * sizeof(T); i < nPreBytes + nSufBytes; i += tn * sizeof(T)) {
+    uintptr_t cursor = i < nPreBytes ? i : nBytes - nSufBytes + (i - nPreBytes);
     BytePack<sizeof(T)> val = applyPostOp(red, applyLoadMultimem<Red, sizeof(T)>(red, inputUptr + cursor));
     *reinterpret_cast<BytePack<sizeof(T)>*>(outputUptr + cursor) = val;
   }
 }
 
-template<template<typename> typename Red, typename T>
+template <template <typename> typename Red, typename T>
 __device__ __forceinline__ void ncclSymkRun_ReduceScatter_LDMC(ncclSymkDevWorkArgs const* args) {
   ncclSymkArgsHandler handler{args};
-  ncclLsaBarrierSession<ncclCoopCta> bar{
-    ncclCoopCta(), handler.comm, ncclTeamTagLsa(), blockIdx.x, /*multimem=*/true
-  };
+  ncclLsaBarrierSession<ncclCoopCta> bar{ncclCoopCta(), handler.comm, ncclTeamTagLsa(), blockIdx.x, /*multimem=*/true};
   Red<typename ncclSymkAccumType<Red, T, /*nvls=*/true>::Type> red(handler.devWork->redOpArg);
 
   int const& rank = handler.comm.rank;
@@ -422,31 +403,29 @@ __device__ __forceinline__ void ncclSymkRun_ReduceScatter_LDMC(ncclSymkDevWorkAr
 
   bar.sync(ncclCoopCta(), NCCL_MEM_ORDER_RELEASE);
 
-  handler.forEachWork<T>(
-      [&]__device__(int block, int nBlocks, size_t nElts, size_t nAllElts,
-                    ncclSymPtr<T> input, ncclSymPtr<T> output) {
+  handler.forEachWork<T>([&] __device__(int block, int nBlocks, size_t nElts, size_t nAllElts, ncclSymPtr<T> input,
+                                        ncclSymPtr<T> output) {
         // Round robin warps over blocks.
-        int t = flattenIx(threadIdx.x%WARP_SIZE, WARP_SIZE,
-                          block, nBlocks,
-                          threadIdx.x/WARP_SIZE, blockDim.x/WARP_SIZE);
-        int tn = nBlocks*blockDim.x;
+    int t =
+      flattenIx(threadIdx.x % WARP_SIZE, WARP_SIZE, block, nBlocks, threadIdx.x / WARP_SIZE, blockDim.x / WARP_SIZE);
+    int tn = nBlocks * blockDim.x;
 
-        reduceMultimem(tn, t, red, input.multimemPtr(multimem) + rank*nAllElts, output.localPtr(), nElts);
-      }
-    );
+    reduceMultimem(tn, t, red, input.multimemPtr(multimem) + rank * nAllElts, output.localPtr(), nElts);
+  });
 
   bar.sync(ncclCoopCta(), NCCL_MEM_ORDER_RELEASE);
 }
 
 // T is user type, EltType is the most aligned type
-template<typename T, typename Red, typename EltType>
-__device__ __forceinline__ void ncclSymkRun_ReduceScatter_LL_body(
-    ncclSymkArgsHandler& handler, ncclLLA2ASession<ncclCoopCta>& lla2a,
-    Red red, EltType* input, EltType* output, int nElts, int nPacks, int nStrideElts) {
+template <typename T, typename Red, typename EltType>
+__device__ __forceinline__ void ncclSymkRun_ReduceScatter_LL_body(ncclSymkArgsHandler& handler,
+                                                                  ncclLLA2ASession<ncclCoopCta>& lla2a, Red red,
+                                                                  EltType* input, EltType* output, int nElts,
+                                                                  int nPacks, int nStrideElts) {
   using Pack = BytePack<8>;
   using Acc = typename Red::EltType;
-  using AccPack = BytePack<8*sizeof(Acc)/sizeof(T)>;
-  constexpr int EltPerPack = 8/sizeof(EltType);
+  using AccPack = BytePack<8 * sizeof(Acc) / sizeof(T)>;
+  constexpr int EltPerPack = 8 / sizeof(EltType);
 
   int const& nRanks = handler.comm.nRanks;
   int const& rank = handler.comm.rank;
@@ -454,72 +433,66 @@ __device__ __forceinline__ void ncclSymkRun_ReduceScatter_LL_body(
   constexpr int tn = ncclSymkMaxThreads;
   ncclCoopCta cta;
 
-  #pragma unroll 1
+#pragma unroll 1
   while (0 < nElts) {
     int nIterPacks = min(nPacks, tn);
-    int tn_div_nPacks = tn/nIterPacks;
-    int tn_mod_nPacks = tn%nIterPacks;
-    int peer = t/nIterPacks;
-    int pack = t%nIterPacks;
+    int tn_div_nPacks = tn / nIterPacks;
+    int tn_mod_nPacks = tn % nIterPacks;
+    int peer = t / nIterPacks;
+    int pack = t % nIterPacks;
 
-    #pragma unroll 1
-    for (int i = t; i < nRanks*nIterPacks; i += tn) {
-      Pack got = loadPack<Pack>(input + peer*nStrideElts, pack*EltPerPack, nElts);
-      lla2a.send(peer, rank*nIterPacks + pack, got);
+#pragma unroll 1
+    for (int i = t; i < nRanks * nIterPacks; i += tn) {
+      Pack got = loadPack<Pack>(input + peer * nStrideElts, pack * EltPerPack, nElts);
+      lla2a.send(peer, rank * nIterPacks + pack, got);
       peer += tn_div_nPacks;
       pack += tn_mod_nPacks;
-      if (nIterPacks <= pack) { peer += 1; pack -= nIterPacks; }
+      if (nIterPacks <= pack) {
+        peer += 1;
+        pack -= nIterPacks;
+      }
     }
 
     if (t < nIterPacks) {
       AccPack got = lla2a.template recvReduce</*Unroll=*/8, Pack>(
         /*slotStart=*/t, /*slotCount=*/nRanks, /*slotStride=*/nIterPacks,
-        /*eltToAcc=*/[&] __device__ (Pack x)->AccPack {
-          return applyCast<T, Acc>(x);
-        },
-        /*reduce=*/[&] __device__ (AccPack a, AccPack b)->AccPack {
-          return applyReduce(red, a, b);
-        }
-      );
+        /*eltToAcc=*/[&] __device__(Pack x) -> AccPack { return applyCast<T, Acc>(x); },
+        /*reduce=*/[&] __device__(AccPack a, AccPack b) -> AccPack { return applyReduce(red, a, b); });
       got = applyPostOp(red, got);
-      storePack(output, t*EltPerPack, nElts, applyCast<Acc, T>(got));
+      storePack(output, t * EltPerPack, nElts, applyCast<Acc, T>(got));
     }
     lla2a.endEpoch(cta);
 
-    input += tn*EltPerPack;
-    output += tn*EltPerPack;
-    nElts -= tn*EltPerPack;
+    input += tn * EltPerPack;
+    output += tn * EltPerPack;
+    nElts -= tn * EltPerPack;
     nPacks -= tn;
   }
 }
 
-template<template<typename> typename Red, typename T>
+template <template <typename> typename Red, typename T>
 __device__ __forceinline__ void ncclSymkRun_ReduceScatter_LL(ncclSymkDevWorkArgs const* args) {
   ncclSymkArgsHandler handler{args};
-  ncclLLA2ASession<ncclCoopCta> lla2a(
-    ncclCoopCta(), handler.comm, ncclTeamLsa(handler.comm), handler.lsaLLA2A, blockIdx.x, ncclSymkMaxThreads
-  );
+  ncclLLA2ASession<ncclCoopCta> lla2a(ncclCoopCta(), handler.comm, ncclTeamLsa(handler.comm), handler.lsaLLA2A,
+                                      blockIdx.x, ncclSymkMaxThreads);
   Red<typename ncclSymkAccumType<Red, T, /*nvls=*/false>::Type> red(handler.devWork->redOpArg);
   using Pack = BytePack<8>;
-  constexpr int EltPerPack = 8/sizeof(T);
+  constexpr int EltPerPack = 8 / sizeof(T);
 
-  handler.singleWork<T>(
-      [&]__device__(int nElts, int nAllElts,
-                    ncclSymPtr<T> inputPtr, ncclSymPtr<T> outputPtr) {
-        int nPacks = divUp(nElts, EltPerPack);
+  handler.singleWork<T>([&] __device__(int nElts, int nAllElts, ncclSymPtr<T> inputPtr, ncclSymPtr<T> outputPtr) {
+    int nPacks = divUp(nElts, EltPerPack);
 
-        T* input = (T*)inputPtr.localPtr();
-        T* output = (T*)outputPtr.localPtr();
+    T* input = (T*)inputPtr.localPtr();
+    T* output = (T*)outputPtr.localPtr();
 
-        uint32_t lowBits = nAllElts*sizeof(T);
-        lowBits |= (uintptr_t)input;
-        lowBits |= (uintptr_t)output;
-        if (__builtin_expect(lowBits%8 == 0, true)) {
-          ncclSymkRun_ReduceScatter_LL_body<T>(handler, lla2a, red, (Pack*)input, (Pack*)output,
-                                               nPacks, nPacks, divUp(nAllElts, EltPerPack));
-        } else {
-          ncclSymkRun_ReduceScatter_LL_body<T>(handler, lla2a, red, input, output, nElts, nPacks, nAllElts);
-        }
-      }
-    );
+    uint32_t lowBits = nAllElts * sizeof(T);
+    lowBits |= (uintptr_t)input;
+    lowBits |= (uintptr_t)output;
+    if (__builtin_expect(lowBits % 8 == 0, true)) {
+      ncclSymkRun_ReduceScatter_LL_body<T>(handler, lla2a, red, (Pack*)input, (Pack*)output, nPacks, nPacks,
+                                           divUp(nAllElts, EltPerPack));
+    } else {
+      ncclSymkRun_ReduceScatter_LL_body<T>(handler, lla2a, red, input, output, nElts, nPacks, nAllElts);
+    }
+  });
 }

--- a/projects/rccl/src/device/symmetric/reduce_scatter_gin.cuh
+++ b/projects/rccl/src/device/symmetric/reduce_scatter_gin.cuh
@@ -10,7 +10,7 @@
 #include "data_ops.cuh"
 #endif
 
-template<template<typename> typename Red, typename T, bool multimem>
+template <template <typename> typename Red, typename T, bool multimem>
 static __device__ void rsAlgoHier(ncclSymkDevWorkArgs const* args, BoolTag<multimem> multimemTag) {
   ncclCoopCta cta;
   ncclSymkArgsHandler handler{args};
@@ -25,32 +25,30 @@ static __device__ void rsAlgoHier(ncclSymkDevWorkArgs const* args, BoolTag<multi
 
   // Use WARP_SIZE, not a hardcoded 32, so warp partitioning is correct on AMD's 64-lane wavefronts.
 #if defined(__HIP_PLATFORM_AMD__)
-  int nWorkWarps = blockDim.x/WARP_SIZE - 2;
+  int nWorkWarps = blockDim.x / WARP_SIZE - 2;
 #else
-  int nWorkWarps = blockDim.x/32 - 2;
+  int nWorkWarps = blockDim.x / 32 - 2;
 #endif
   int stage0_nWorkWarps;
   if (lsa.nRanks == 1) {
     stage0_nWorkWarps = 0; // Stage 0 just posts sends so no workers.
   } else {
     // Only count reads because they dominate writes.
-    int stage0_work = lsa.nRanks == 1 ? 0 : (multimem ? 1 : lsa.nRanks)*(rail.nRanks-1);
-    int stage1_work = (multimem ? 1 : lsa.nRanks) + rail.nRanks-1;
-    stage0_nWorkWarps = __float2int_rn(__fdividef(nWorkWarps*stage0_work, stage0_work + stage1_work));
-    stage0_nWorkWarps = min(stage0_nWorkWarps, nWorkWarps-1); // Stage 1 requires at least 1 worker.
+    int stage0_work = lsa.nRanks == 1 ? 0 : (multimem ? 1 : lsa.nRanks) * (rail.nRanks - 1);
+    int stage1_work = (multimem ? 1 : lsa.nRanks) + rail.nRanks - 1;
+    stage0_nWorkWarps = __float2int_rn(__fdividef(nWorkWarps * stage0_work, stage0_work + stage1_work));
+    stage0_nWorkWarps = min(stage0_nWorkWarps, nWorkWarps - 1); // Stage 1 requires at least 1 worker.
   }
 
   // 2 stage pipeline, one coop per stage.
 #if defined(__HIP_PLATFORM_AMD__)
-  int stage = threadIdx.x/WARP_SIZE < 1 + stage0_nWorkWarps ? 0 : 1;
+  int stage = threadIdx.x / WARP_SIZE < 1 + stage0_nWorkWarps ? 0 : 1;
 #else
-  int stage = threadIdx.x/32 < 1 + stage0_nWorkWarps ? 0 : 1;
+  int stage = threadIdx.x / 32 < 1 + stage0_nWorkWarps ? 0 : 1;
 #endif
-  ncclCoopWarpSpan coopStage{
-    /*warp0=*/stage == 0 ? 0 : 1 + stage0_nWorkWarps,
-    /*nWarps=*/1 + (stage == 0 ? stage0_nWorkWarps : nWorkWarps-stage0_nWorkWarps),
-    /*id=*/stage
-  };
+  ncclCoopWarpSpan coopStage{/*warp0=*/stage == 0 ? 0 : 1 + stage0_nWorkWarps,
+                             /*nWarps=*/1 + (stage == 0 ? stage0_nWorkWarps : nWorkWarps - stage0_nWorkWarps),
+                             /*id=*/stage};
   // Within each stage we have 2 roles: GIN warp, worker warps.
 #if defined(__HIP_PLATFORM_AMD__)
   bool roleIsWorker = WARP_SIZE <= coopStage.thread_rank();
@@ -69,10 +67,9 @@ static __device__ void rsAlgoHier(ncclSymkDevWorkArgs const* args, BoolTag<multi
   // Construct outbox only for stage=0 when lsa peers exist.
   alignas(ncclGinOutboxSession<ncclCoopWarpSpan>) char outbox_storage[sizeof(ncclGinOutboxSession<ncclCoopWarpSpan>)];
   ncclGinOutboxSession<ncclCoopWarpSpan>& outbox =
-    stage == 0 && lsa.nRanks != 1
-      ? *::new(&outbox_storage) ncclGinOutboxSession<ncclCoopWarpSpan>
-        {coopStage, gin, handler.ginOutbox, blockIdx.x}
-      : reinterpret_cast<ncclGinOutboxSession<ncclCoopWarpSpan>&>(outbox_storage);
+    stage == 0 && lsa.nRanks != 1 ?
+      *::new (&outbox_storage) ncclGinOutboxSession<ncclCoopWarpSpan>{coopStage, gin, handler.ginOutbox, blockIdx.x} :
+      reinterpret_cast<ncclGinOutboxSession<ncclCoopWarpSpan>&>(outbox_storage);
 
   __shared__ int totalSends;
   if (stage == 0 && !roleIsWorker && lsa.nRanks == 1) {
@@ -86,218 +83,206 @@ static __device__ void rsAlgoHier(ncclSymkDevWorkArgs const* args, BoolTag<multi
     coopRole.sync();
   }
 
-  ncclGinInboxA2ASession<ncclCoopCta> inbox
-    {cta, gin, rail, handler.ginInboxRail, blockIdx.x};
+  ncclGinInboxA2ASession<ncclCoopCta> inbox{cta, gin, rail, handler.ginInboxRail, blockIdx.x};
 
-  ncclLsaBarrierSession<ncclCoopCta> lsaBar
-    {cta, handler.comm, ncclTeamTagLsa(), blockIdx.x, multimem};
+  ncclLsaBarrierSession<ncclCoopCta> lsaBar{cta, handler.comm, ncclTeamTagLsa(), blockIdx.x, multimem};
   lsaBar.sync(cta, cuda::memory_order_relaxed);
 
-  int maxChunkElts = args->maxDynamicSmem/sizeof(AccT);
+  int maxChunkElts = args->maxDynamicSmem / sizeof(AccT);
 
-  handler.template forEachWorkNoFusion<T>(
-    [&]__device__(size_t nElts, size_t nAllElts, ncclSymPtr<T> input, ncclSymPtr<T> output) {
-      AccT* accum;
-      ncclSymkSmemPartition(&accum, maxChunkElts);
+  handler.template forEachWorkNoFusion<T>([&] __device__(size_t nElts, size_t nAllElts, ncclSymPtr<T> input,
+                                                         ncclSymPtr<T> output) {
+    AccT* accum;
+    ncclSymkSmemPartition(&accum, maxChunkElts);
 
-      int chunkBytes_log2 = log2Up(nElts) + log2Up(sizeof(T));
+    int chunkBytes_log2 = log2Up(nElts) + log2Up(sizeof(T));
 
       // Chunk size should not be larger than what host dictates and 1/2 of
       // total capacity so we enjoy some pipeline overlap. This is a soft constraint
       // because chunks which are too big can always be partially used.
-      int maxChunkBytes_log2 = min(
-        log2Up(maxChunkElts) + log2Up(sizeof(T)),
-        handler.ginInboxRail.size_log2-1);
-      chunkBytes_log2 = min(chunkBytes_log2, maxChunkBytes_log2);
+    int maxChunkBytes_log2 = min(log2Up(maxChunkElts) + log2Up(sizeof(T)), handler.ginInboxRail.size_log2 - 1);
+    chunkBytes_log2 = min(chunkBytes_log2, maxChunkBytes_log2);
 
       // Chunk size must not be so small that the chunk count exceeds either the
       // per peer number or total number. This is a hard constraint imposed
       // by inbox credit logic so we enforce after the max chunk size.
-      int minChunkBytes_log2 = handler.ginInboxRail.size_log2 - min(
-        log2Down(rail.nRanks-1) + ncclGinScratchMaxBufsPerPeer_log2,
-        ncclGinScratchMaxBufs_log2);
-      chunkBytes_log2 = max(chunkBytes_log2, minChunkBytes_log2);
+    int minChunkBytes_log2 =
+      handler.ginInboxRail.size_log2 -
+      min(log2Down(rail.nRanks - 1) + ncclGinScratchMaxBufsPerPeer_log2, ncclGinScratchMaxBufs_log2);
+    chunkBytes_log2 = max(chunkBytes_log2, minChunkBytes_log2);
 
-      int nBufs_log2 = handler.ginInboxRail.size_log2 - chunkBytes_log2;
+    int nBufs_log2 = handler.ginInboxRail.size_log2 - chunkBytes_log2;
 
-      maxChunkElts = min(maxChunkElts, (1u<<chunkBytes_log2)/(unsigned)sizeof(T));
+    maxChunkElts = min(maxChunkElts, (1u << chunkBytes_log2) / (unsigned)sizeof(T));
 
-      auto nop = []__device__(auto...) {};
-      auto skeleton = [&]__device__(auto initFn, auto stepFn, auto finishFn) {
-        size_t loopElts = nElts;
-        ncclSymPtr<T> loopInput = input;
-        ncclSymPtr<T> loopOutput = output;
-        #pragma unroll 1
-        while (loopElts != 0) {
-          int nChunkElts = min(loopElts, (size_t)maxChunkElts);
-          int nSteps = min(rail.nRanks-1, 1<<(nBufs_log2-1));
-          int step = 0;
-          initFn(nChunkElts, loopInput);
-          do {
-            nSteps = min(nSteps, rail.nRanks-1 - step);
-            stepFn(step, nSteps, nChunkElts, loopInput);
-            step += nSteps;
-          } while (step != rail.nRanks-1);
-          finishFn(nChunkElts, loopOutput);
-          inbox.endRound(cta);
-          loopInput += nChunkElts;
-          loopOutput += nChunkElts;
-          loopElts -= nChunkElts;
-        }
-      };
+    auto nop = [] __device__(auto...) {};
+    auto skeleton = [&] __device__(auto initFn, auto stepFn, auto finishFn) {
+      size_t loopElts = nElts;
+      ncclSymPtr<T> loopInput = input;
+      ncclSymPtr<T> loopOutput = output;
+#pragma unroll 1
+      while (loopElts != 0) {
+        int nChunkElts = min(loopElts, (size_t)maxChunkElts);
+        int nSteps = min(rail.nRanks - 1, 1 << (nBufs_log2 - 1));
+        int step = 0;
+        initFn(nChunkElts, loopInput);
+        do {
+          nSteps = min(nSteps, rail.nRanks - 1 - step);
+          stepFn(step, nSteps, nChunkElts, loopInput);
+          step += nSteps;
+        } while (step != rail.nRanks - 1);
+        finishFn(nChunkElts, loopOutput);
+        inbox.endRound(cta);
+        loopInput += nChunkElts;
+        loopOutput += nChunkElts;
+        loopElts -= nChunkElts;
+      }
+    };
 
-      if (stage == 0) { // !!! Pipeline Stage 0 !!!
-        inbox.apportion(cta, /*subcoop=*/coopStage, /*subcoopIsNonTrivial=*/false, nBufs_log2);
-        if (lsa.nRanks != 1) {
-          outbox.apportion(coopStage, /*subcoop=*/coopRole, /*subcoopIsNonTrivial=*/roleIsWorker, nBufs_log2, /*deferSync=*/true);
-        }
+    if (stage == 0) { // !!! Pipeline Stage 0 !!!
+      inbox.apportion(cta, /*subcoop=*/coopStage, /*subcoopIsNonTrivial=*/false, nBufs_log2);
+      if (lsa.nRanks != 1) {
+        outbox.apportion(coopStage, /*subcoop=*/coopRole, /*subcoopIsNonTrivial=*/roleIsWorker, nBufs_log2,
+                         /*deferSync=*/true);
+      }
 
         // Generalize worker and non-worker logic with compile time BoolTag to differentiate.
-        auto stage0_impl = [&](/*BoolTag<roleIsWorker>*/auto roleIsWorker_tag) {
+      auto stage0_impl = [&](/*BoolTag<roleIsWorker>*/ auto roleIsWorker_tag) {
           // Shadow runtime value with compile time value.
-          constexpr bool roleIsWorker = roleIsWorker_tag.value;
-          skeleton(
-            /*initFn*/[&]__device__(int nChunkElts, ncclSymPtr<T> inPtr)->void {
-              if (!roleIsWorker) {
-                if (coopRole.thread_rank() == 0) {
+        constexpr bool roleIsWorker = roleIsWorker_tag.value;
+        skeleton(
+            /*initFn*/
+          [&] __device__(int nChunkElts, ncclSymPtr<T> inPtr) -> void {
+            if (!roleIsWorker) {
+              if (coopRole.thread_rank() == 0) {
 #if defined(__HIP_PLATFORM_AMD__)
                   // Portable replacement for upstream's NVPTX red.shared.add asm (no amdgcn equiv).
-                  atomicAdd(&totalSends, rail.nRanks-1);
+                atomicAdd(&totalSends, rail.nRanks - 1);
 #else
                   // totalSends += rail.nRanks-1;
-                  #if __CUDA_ARCH__ >= 700
-                  asm volatile("red.relaxed.shared.add.s32 [%0],%1;" :: "r"((uint32_t)__cvta_generic_to_shared(&totalSends)), "r"(rail.nRanks-1) : "memory");
-                  #else
-                  __trap();
-                  #endif
+#if __CUDA_ARCH__ >= 700
+                asm volatile(
+                  "red.relaxed.shared.add.s32 [%0],%1;" ::"r"((uint32_t)__cvta_generic_to_shared(&totalSends)),
+                  "r"(rail.nRanks - 1)
+                  : "memory");
+#else
+                __trap();
 #endif
-                }
-              } else {
+#endif
+              }
+            } else {
                 // outbox.apportion() was told to defer sync so that we don't sync
                 // the whole stage. We sync just this warp.
-                coopRole.sync();
-              }
-            },
-            /*stepFn=*/[&]__device__(int step0, int nSteps, int nChunkElts, ncclSymPtr<T> inPtr)->void {
-              auto getInputOffset = [&]__device__(int step)->size_t {
-                int peer = inbox.getSendPeer(step, /*step_lt_nPeers=*/true);
-                int dstWorld = ncclTeamRankToTeam(world, rail, peer);
-                return dstWorld*nAllElts;
-              };
+              coopRole.sync();
+            }
+          },
+            /*stepFn=*/
+          [&] __device__(int step0, int nSteps, int nChunkElts, ncclSymPtr<T> inPtr) -> void {
+            auto getInputOffset = [&] __device__(int step) -> size_t {
+              int peer = inbox.getSendPeer(step, /*step_lt_nPeers=*/true);
+              int dstWorld = ncclTeamRankToTeam(world, rail, peer);
+              return dstWorld * nAllElts;
+            };
 
-              if (lsa.nRanks != 1) { // No need to process data when we can send from input buf.
-                if (roleIsWorker) {
+            if (lsa.nRanks != 1) { // No need to process data when we can send from input buf.
+              if (roleIsWorker) {
                   // Wait for outbox bufs to free up. Since outbox advances with each call of this
                   // function we always index starting at 0.
-                  outbox.waitBufs(coopRole, 0, nSteps);
-                  coopRole.sync();
+                outbox.waitBufs(coopRole, 0, nSteps);
+                coopRole.sync();
                   // Make `outbox.getBufPtr()` as cheap as possible within reduction loop.
-                  auto outbox_getBufPtr = outbox.make_getBufPtr(0);
-                  reduceLsaBatch(coopRole, /*nBatch=*/nSteps, nChunkElts,
-                    /*dstMem=*/GMemTag(), /*dstAlignMin=*/16,
-                    /*getDst=*/[&]__device__(int i)->T* {
-                      return (T*)outbox_getBufPtr(i);
-                    },
-                    /*srcRedUc=*/red, /*srcRedMc=*/mmRed, /*srcBase=*/inPtr,
-                    /*getSrcOffset=*/[&]__device__(int i)->size_t {
-                      return getInputOffset(step0 + i);
-                    },
-                    handler.comm, multimemTag
-                  );
-                }
-                coopStage.sync();
+                auto outbox_getBufPtr = outbox.make_getBufPtr(0);
+                reduceLsaBatch(
+                  coopRole, /*nBatch=*/nSteps, nChunkElts,
+                  /*dstMem=*/GMemTag(), /*dstAlignMin=*/16,
+                  /*getDst=*/[&] __device__(int i) -> T* { return (T*)outbox_getBufPtr(i); },
+                  /*srcRedUc=*/red, /*srcRedMc=*/mmRed, /*srcBase=*/inPtr,
+                  /*getSrcOffset=*/[&] __device__(int i) -> size_t { return getInputOffset(step0 + i); }, handler.comm,
+                  multimemTag);
               }
+              coopStage.sync();
+            }
 
-              if (!roleIsWorker) {
-                inbox.postSends(coopRole, step0, nSteps,
-                  /*getPtr*/[&]__device__(int i, int peer) {
-                    return lsa.nRanks == 1 ? inPtr + getInputOffset(step0 + i)
-                                           : (ncclSymPtr<T>)outbox.getBuf(i);
-                  },
-                  /*getEltCount*/[&]__device__(int i, int peer) {
-                    return nChunkElts;
-                  },
-                  /*getCompletion*/[&]__device__(int i, int peer) {
-                    return ncclGin_CounterInc{
-                      lsa.nRanks == 1 ? handler.ginCounterPerBlock + blockIdx.x
-                                      : outbox.getCounter(i)
-                    };
-                  }
-                );
-              }
+            if (!roleIsWorker) {
+              inbox.postSends(
+                coopRole, step0, nSteps,
+                  /*getPtr*/
+                [&] __device__(int i, int peer) {
+                  return lsa.nRanks == 1 ? inPtr + getInputOffset(step0 + i) : (ncclSymPtr<T>)outbox.getBuf(i);
+                },
+                /*getEltCount*/ [&] __device__(int i, int peer) { return nChunkElts; },
+                  /*getCompletion*/
+                [&] __device__(int i, int peer) {
+                  return ncclGin_CounterInc{lsa.nRanks == 1 ? handler.ginCounterPerBlock + blockIdx.x :
+                                                              outbox.getCounter(i)};
+                });
+            }
 
-              if (lsa.nRanks != 1) {
+            if (lsa.nRanks != 1) {
                 // We advance outbox with every iteration because it is only guaranteed
                 // to have `nSteps` buffers. If we advanced it after the step loop it
                 // would need rail.nRanks-1 buffers.
-                outbox.advance(coopStage, nSteps);
-              }
-            },
-            /*finishFn=*/nop
-          );
-        };
+              outbox.advance(coopStage, nSteps);
+            }
+          },
+          /*finishFn=*/nop);
+      };
 
         // Instantiate stage0_impl specialized to each case of roleIsWorker.
-        if (!roleIsWorker) stage0_impl(BoolTag</*roleIsWorker=*/false>());
-        else stage0_impl(BoolTag</*roleIsWorker=*/true>());
+      if (!roleIsWorker) stage0_impl(BoolTag</*roleIsWorker=*/false>());
+      else stage0_impl(BoolTag</*roleIsWorker=*/true>());
 
-      } else { // !!! Pipeline Stage 1 !!!
+    } else { // !!! Pipeline Stage 1 !!!
 
         // Generalize worker and non-worker logic with compile time BoolTag to differentiate.
-        auto stage1_impl = [&]__device__(/*BoolTag<roleIsWorker>*/auto roleIsWorker_tag)->void {
-          constexpr bool roleIsWorker = roleIsWorker_tag.value;
-          inbox.apportion(cta, /*subcoop=*/coopRole, /*subcoopIsNonTrivial=*/!roleIsWorker, nBufs_log2);
-          coopStage.sync();
+      auto stage1_impl = [&] __device__(/*BoolTag<roleIsWorker>*/ auto roleIsWorker_tag) -> void {
+        constexpr bool roleIsWorker = roleIsWorker_tag.value;
+        inbox.apportion(cta, /*subcoop=*/coopRole, /*subcoopIsNonTrivial=*/!roleIsWorker, nBufs_log2);
+        coopStage.sync();
 
-          skeleton(
-            /*initFn*/[&]__device__(int nChunkElts, ncclSymPtr<T> inPtr)->void {
-              if (roleIsWorker) {
-                reduceLsa(coopRole, nChunkElts,
-                  /*dstMem=*/SMemTag(), /*dstAlignMin=*/16, /*dstPtr=*/accum,
-                  /*srcRedUc=*/red, /*srcRedMc=*/mmRed,
-                  /*srcPtr=*/inPtr + world.rank*nAllElts,
-                  handler.comm, multimemTag
-                );
-              }
-            },
-            /*stepFn*/[&]__device__(int step0, int nSteps, int nChunkElts, ncclSymPtr<T> inPtr)->void {
-              if (roleIsWorker) {
-                inbox.waitRecvs(coopRole, step0, nSteps);
-                coopRole.sync();
-                // Make `inbox.getBufPtr()` as cheap as possible within reduction loop.
-                auto inbox_getBufPtr = inbox.make_getBufPtr(step0);
-                reduce(coopRole, red, /*inPlace=*/true, nChunkElts,
-                  /*dstMem=*/SMemTag(), /*dstAlignMin=*/16, /*dst=*/accum,
-                  /*nSrcs=*/nSteps, /*srcPtrCommonMask=*/16-1, /*srcPtrMasked=*/0,
-                  /*getSrc=*/[&]__device__(int s)->T* {
-                    return (T*)inbox_getBufPtr(s);
-                  }
-                );
-              }
-              coopStage.sync();
-              if (!roleIsWorker) {
-                inbox.finishRecvs(coopRole, step0, nSteps);
-              }
-            },
-            /*finishFn*/[&]__device__(int nChunkElts, ncclSymPtr<T> outPtr)->void {
-              if (roleIsWorker) {
-                copy(coopRole, nChunkElts,
-                  /*dstMem=*/GMemTag(), /*dst=*/outPtr.localPtr(),
-                  /*srcMem=*/SMemTag(), /*src=*/accum,
-                  [&]__device__(auto x) { return applyPostOp(red, x); }
-                );
-                coopRole.sync(); // prevent initFn from trampling accum
-              }
+        skeleton(
+            /*initFn*/
+          [&] __device__(int nChunkElts, ncclSymPtr<T> inPtr) -> void {
+            if (roleIsWorker) {
+              reduceLsa(coopRole, nChunkElts,
+                        /*dstMem=*/SMemTag(), /*dstAlignMin=*/16, /*dstPtr=*/accum,
+                        /*srcRedUc=*/red, /*srcRedMc=*/mmRed,
+                        /*srcPtr=*/inPtr + world.rank * nAllElts, handler.comm, multimemTag);
             }
-          );
-        };
+          },
+            /*stepFn*/
+          [&] __device__(int step0, int nSteps, int nChunkElts, ncclSymPtr<T> inPtr) -> void {
+            if (roleIsWorker) {
+              inbox.waitRecvs(coopRole, step0, nSteps);
+              coopRole.sync();
+                // Make `inbox.getBufPtr()` as cheap as possible within reduction loop.
+              auto inbox_getBufPtr = inbox.make_getBufPtr(step0);
+              reduce(coopRole, red, /*inPlace=*/true, nChunkElts,
+                     /*dstMem=*/SMemTag(), /*dstAlignMin=*/16, /*dst=*/accum,
+                     /*nSrcs=*/nSteps, /*srcPtrCommonMask=*/16 - 1, /*srcPtrMasked=*/0,
+                     /*getSrc=*/[&] __device__(int s) -> T* { return (T*)inbox_getBufPtr(s); });
+            }
+            coopStage.sync();
+            if (!roleIsWorker) {
+              inbox.finishRecvs(coopRole, step0, nSteps);
+            }
+          },
+            /*finishFn*/
+          [&] __device__(int nChunkElts, ncclSymPtr<T> outPtr) -> void {
+            if (roleIsWorker) {
+              copy(coopRole, nChunkElts,
+                   /*dstMem=*/GMemTag(), /*dst=*/outPtr.localPtr(),
+                   /*srcMem=*/SMemTag(), /*src=*/accum, [&] __device__(auto x) { return applyPostOp(red, x); });
+              coopRole.sync(); // prevent initFn from trampling accum
+            }
+          });
+      };
 
         // Instantiate stage1_impl specialized to each case of roleIsWorker.
-        if (!roleIsWorker) stage1_impl(BoolTag</*roleIsWorker=*/false>());
-        else stage1_impl(BoolTag</*roleIsWorker=*/true>());
-      }
+      if (!roleIsWorker) stage1_impl(BoolTag</*roleIsWorker=*/false>());
+      else stage1_impl(BoolTag</*roleIsWorker=*/true>());
     }
-  );
+  });
 
   if (stage == 0) {
     if (lsa.nRanks == 1) {
@@ -316,11 +301,11 @@ static __device__ void rsAlgoHier(ncclSymkDevWorkArgs const* args, BoolTag<multi
   lsaBar.sync(cta, cuda::memory_order_relaxed);
 }
 
-template<template<typename> typename Red, typename T>
+template <template <typename> typename Red, typename T>
 __device__ __forceinline__ void ncclSymkRun_ReduceScatter_RailA2A_LsaLD(ncclSymkDevWorkArgs const* args) {
   rsAlgoHier<Red, T>(args, /*multimem=*/BoolTag<false>{});
 }
-template<template<typename> typename Red, typename T>
+template <template <typename> typename Red, typename T>
 __device__ __forceinline__ void ncclSymkRun_ReduceScatter_RailA2A_LsaLDMC(ncclSymkDevWorkArgs const* args) {
   rsAlgoHier<Red, T>(args, /*multimem=*/BoolTag<true>{});
 }

--- a/projects/rccl/src/device/symmetric/tma_ptx.cuh
+++ b/projects/rccl/src/device/symmetric/tma_ptx.cuh
@@ -21,30 +21,25 @@ inline __device__ void cp_async_bulk_global_to_shared(void* dest, void* src, __m
   uint64_t gmem_ptr = static_cast<uint64_t>(__cvta_generic_to_global(src));
   uint32_t smem_barrier_ptr = static_cast<uint32_t>(__cvta_generic_to_shared(barrier));
 
-  asm volatile(
-    "cp.async.bulk.shared::cluster.global.mbarrier::complete_tx::bytes [%0], [%1], %2, [%3];\n"
-    :
-    : "r"(smem_ptr),
-      "l"(gmem_ptr),
-      "r"(size),
-      "r"(smem_barrier_ptr)
-    : "memory");
+  asm volatile("cp.async.bulk.shared::cluster.global.mbarrier::complete_tx::bytes [%0], [%1], %2, [%3];\n"
+               :
+               : "r"(smem_ptr), "l"(gmem_ptr), "r"(size), "r"(smem_barrier_ptr)
+               : "memory");
 }
 
-inline __device__ void fence_proxy_async(void) { asm volatile("fence.proxy.async.shared::cta;" ::: "memory");}
+inline __device__ void fence_proxy_async(void) {
+  asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+}
 
 inline __device__ void cp_async_bulk_shared_to_global(void* dest, void* src, int size) {
   // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-cp-async-bulk
   uint64_t dest_gmem_ptr = static_cast<uint64_t>(__cvta_generic_to_global(dest));
   uint32_t src_smem_ptr = static_cast<uint32_t>(__cvta_generic_to_shared(src));
 
-  asm volatile(
-    "cp.async.bulk.global.shared::cta.bulk_group [%0], [%1], %2;\n"
-    :
-    : "l"(dest_gmem_ptr),
-      "r"(src_smem_ptr),
-      "r"(size)
-    : "memory");
+  asm volatile("cp.async.bulk.global.shared::cta.bulk_group [%0], [%1], %2;\n"
+               :
+               : "l"(dest_gmem_ptr), "r"(src_smem_ptr), "r"(size)
+               : "memory");
 }
 
 inline __device__ void multimem_cp_async_bulk_shared_to_global(void* dest, void* src, int size) {
@@ -59,9 +54,7 @@ inline __device__ void multimem_cp_async_bulk_shared_to_global(void* dest, void*
     "cp.async.bulk.global.shared::cta.bulk_group [%0], [%1], %2;\n"
 #endif
     :
-    : "l"(dest_gmem_ptr),
-      "r"(src_smem_ptr),
-      "r"(size)
+    : "l"(dest_gmem_ptr), "r"(src_smem_ptr), "r"(size)
     : "memory");
 }
 
@@ -100,8 +93,7 @@ inline __device__ bool barrier_try_wait_token_relaxed(__mbarrier_t* barrier, __m
                "selp.b32 %0, 1, 0, p;\n\t"
                "}"
                : "=r"(__ready)
-               : "r"(static_cast<unsigned int>(__cvta_generic_to_shared(barrier))),
-                 "l"(token)
+               : "r"(static_cast<unsigned int>(__cvta_generic_to_shared(barrier))), "l"(token)
                : "memory");
   return __ready;
 }
@@ -115,7 +107,9 @@ inline __device__ void cp_async_bulk_global_to_shared(void* dest, void* src, __m
   return;
 }
 
-inline __device__ void fence_proxy_async(void) { return; }
+inline __device__ void fence_proxy_async(void) {
+  return;
+}
 
 inline __device__ void cp_async_bulk_shared_to_global(void* dest, void* src, int size) {
   return;

--- a/projects/rccl/src/device_buffer.cc
+++ b/projects/rccl/src/device_buffer.cc
@@ -18,19 +18,17 @@
 namespace meta::comms {
 
 // Helper macro for catching HIP errors
-#define HIP_CALL(cmd)                                                                   \
-    do {                                                                                \
-        hipError_t error = (cmd);                                                       \
-        if (error != hipSuccess)                                                        \
-        {                                                                               \
-            std::cerr << "Encountered HIP error (" << hipGetErrorString(error)          \
-                      << ") at line " << __LINE__ << " in file " << __FILE__ << "\n";   \
-        }                                                                               \
-    } while (0)
+#define HIP_CALL(cmd) \
+  do { \
+    hipError_t error = (cmd); \
+    if (error != hipSuccess) { \
+      std::cerr << "Encountered HIP error (" << hipGetErrorString(error) << ") at line " << __LINE__ << " in file " \
+                << __FILE__ << "\n"; \
+    } \
+  } while (0)
 
 DeviceBuffer::DeviceBuffer(std::size_t size) : size_(size) {
-  
-#if defined(HIP_UNCACHED_MEMORY)  
+#if defined(HIP_UNCACHED_MEMORY)
   HIP_CALL(hipExtMallocWithFlags((void**)&ptr_, size, hipDeviceMallocUncached));
 #else
   HIP_CALL(hipExtMallocWithFlags((void**)&ptr_, size, hipDeviceMallocFinegrained));
@@ -43,8 +41,7 @@ DeviceBuffer::~DeviceBuffer() {
   }
 }
 
-DeviceBuffer::DeviceBuffer(DeviceBuffer&& other) noexcept
-    : ptr_(other.ptr_), size_(other.size_) {
+DeviceBuffer::DeviceBuffer(DeviceBuffer&& other) noexcept : ptr_(other.ptr_), size_(other.size_) {
   other.ptr_ = nullptr;
   other.size_ = 0;
 }

--- a/projects/rccl/src/enhcompat.cc
+++ b/projects/rccl/src/enhcompat.cc
@@ -7,23 +7,34 @@
 
 /* Define weak symbols used to allow libnccl_static.a to work with older libcudart_static.a */
 
-enum cudaError_t { cudaErrorStubLibrary = 34 };
+enum cudaError_t {
+  cudaErrorStubLibrary = 34
+};
 
 extern "C" {
 
-cudaError_t cudaStreamGetCaptureInfo_v2(...)         __attribute__((visibility("hidden"))) __attribute((weak));
-cudaError_t cudaStreamGetCaptureInfo_v2(...)         { return cudaErrorStubLibrary; }
+cudaError_t cudaStreamGetCaptureInfo_v2(...) __attribute__((visibility("hidden"))) __attribute((weak));
+cudaError_t cudaStreamGetCaptureInfo_v2(...) {
+  return cudaErrorStubLibrary;
+}
 
-cudaError_t cudaUserObjectCreate(...)                __attribute__((visibility("hidden"))) __attribute((weak));
-cudaError_t cudaUserObjectCreate(...)                { return cudaErrorStubLibrary; }
+cudaError_t cudaUserObjectCreate(...) __attribute__((visibility("hidden"))) __attribute((weak));
+cudaError_t cudaUserObjectCreate(...) {
+  return cudaErrorStubLibrary;
+}
 
-cudaError_t cudaGraphRetainUserObject(...)           __attribute__((visibility("hidden"))) __attribute((weak));
-cudaError_t cudaGraphRetainUserObject(...)           { return cudaErrorStubLibrary; }
+cudaError_t cudaGraphRetainUserObject(...) __attribute__((visibility("hidden"))) __attribute((weak));
+cudaError_t cudaGraphRetainUserObject(...) {
+  return cudaErrorStubLibrary;
+}
 
 cudaError_t cudaStreamUpdateCaptureDependencies(...) __attribute__((visibility("hidden"))) __attribute((weak));
-cudaError_t cudaStreamUpdateCaptureDependencies(...) { return cudaErrorStubLibrary; }
+cudaError_t cudaStreamUpdateCaptureDependencies(...) {
+  return cudaErrorStubLibrary;
+}
 
-cudaError_t cudaGetDriverEntryPoint(...)             __attribute__((visibility("hidden"))) __attribute((weak));
-cudaError_t cudaGetDriverEntryPoint(...)             { return cudaErrorStubLibrary; }
-
+cudaError_t cudaGetDriverEntryPoint(...) __attribute__((visibility("hidden"))) __attribute((weak));
+cudaError_t cudaGetDriverEntryPoint(...) {
+  return cudaErrorStubLibrary;
+}
 }

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -49,32 +49,35 @@ struct ncclKernelMatch {
   bool specialized;
 };
 
-
 #define ncclGetKernelIndex(p_comm) ((p_comm)->unroll)
 static ncclKernelMatch const ncclKerns[3] = {
-  {(void*)ncclDevKernel_Generic_1, true},
-  {(void*)ncclDevKernel_Generic_2, true},
-  {(void*)ncclDevKernel_Generic_4, true}
+  {(void*)ncclDevKernel_Generic_1, true}, {(void*)ncclDevKernel_Generic_2, true}, {(void*)ncclDevKernel_Generic_4, true}
 };
 
-static int rcclProtoGrainSize(int proto, ncclComm *comm){
+static int rcclProtoGrainSize(int proto, ncclComm* comm) {
   switch (proto) {
-    case NCCL_PROTO_LL: return 16;
-    case NCCL_PROTO_LL128: return comm->WarpSize*NCCL_LL128_SHMEM_ELEMS_PER_THREAD*comm->ll128DataElems*sizeof(uint64_t)/comm->ll128LineElems;
-    case NCCL_PROTO_SIMPLE: return 512;
-    default: return -1;
+  case NCCL_PROTO_LL:
+    return 16;
+  case NCCL_PROTO_LL128:
+    return comm->WarpSize * NCCL_LL128_SHMEM_ELEMS_PER_THREAD * comm->ll128DataElems * sizeof(uint64_t) /
+           comm->ll128LineElems;
+  case NCCL_PROTO_SIMPLE:
+    return 512;
+  default:
+    return -1;
   }
 }
 
 /* Copy of ncclShmemScratchWarpSize */
 constexpr int rcclShmemScratchWarpSize(int cudaArch = NCCL_CUDA_ARCH, int WarpSize = 32) {
   return (max_constexpr<int>(
-      /*LL    */0,
-      /*LL128 */(NCCL_LL128_SHMEM_ELEMS_PER_THREAD*WarpSize)*sizeof(uint64_t),
-      /*SIMPLE*/(ncclCollUnroll(cudaArch)*WarpSize + 1)*16,
+            /*LL    */ 0,
+            /*LL128 */ (NCCL_LL128_SHMEM_ELEMS_PER_THREAD * WarpSize) * sizeof(uint64_t),
+            /*SIMPLE*/ (ncclCollUnroll(cudaArch) * WarpSize + 1) * 16,
       // NVLS needs an extra 16B to read unaligned data.
-      /*NVLS  */WarpSize*(cudaArch >= 900 ? ncclNvlsUnrollBytes(cudaArch) : 0) + 16
-    ) + 15) & -16; // pad to 16 bytes
+            /*NVLS  */ WarpSize * (cudaArch >= 900 ? ncclNvlsUnrollBytes(cudaArch) : 0) + 16) +
+          15) &
+         -16; // pad to 16 bytes
 }
 
 /* Copy of ncclShmemDynamicSize */
@@ -87,16 +90,16 @@ constexpr int rcclShmemDynamicSize(int cudaArch = NCCL_CUDA_ARCH, int WarpSize =
   return 0;
 #else
   const int maxNthreads = (cudaArch == 950) ? RCCL_GFX950_MAX_NTHREADS : RCCL_DEFAULT_MAX_NTHREADS;
-  return cudaArch < 700 ? 0 : rcclShmemScratchWarpSize(cudaArch, WarpSize)*(maxNthreads/WarpSize);
+  return cudaArch < 700 ? 0 : rcclShmemScratchWarpSize(cudaArch, WarpSize) * (maxNthreads / WarpSize);
 #endif
 }
 
 NCCL_PARAM(L1SharedMemoryCarveout, "L1_SHARED_MEMORY_CARVEOUT", 0);
-NCCL_PARAM(SymCeThreshold, "SYM_CE_THRESHOLD", 8*1024*1024);
+NCCL_PARAM(SymCeThreshold, "SYM_CE_THRESHOLD", 8 * 1024 * 1024);
 
 // Returns maximum kernel stack size of all CUDA kernels
 ncclResult_t ncclInitKernelsForDevice(int cudaArch, int maxSharedMem, size_t* maxStackSize) {
-  constexpr int KernelCount = sizeof(ncclKerns)/sizeof(ncclKerns[0]);
+  constexpr int KernelCount = sizeof(ncclKerns) / sizeof(ncclKerns[0]);
   ncclResult_t result = ncclSuccess;
 
   if (maxStackSize) *maxStackSize = 0;
@@ -109,10 +112,10 @@ ncclResult_t ncclInitKernelsForDevice(int cudaArch, int maxSharedMem, size_t* ma
   int ncclMaxSharedMem = rcclShmemDynamicSize(cudaArch, WarpSize);
 
 #ifdef GENERATE_SYM_KERNELS
-  for (int sym=0; sym <= 1; sym++) {
-    int kcount = sym==0 ? KernelCount : ncclSymkKernelCount;
-    for (int k=0; k < kcount; k++) {
-      void* fn = sym==0 ? ncclKerns[k].kernelFn : ncclSymkKernelList[k];
+  for (int sym = 0; sym <= 1; sym++) {
+    int kcount = sym == 0 ? KernelCount : ncclSymkKernelCount;
+    for (int k = 0; k < kcount; k++) {
+      void* fn = sym == 0 ? ncclKerns[k].kernelFn : ncclSymkKernelList[k];
 #else
   for (int k = 0; k < KernelCount; k++) {
     void* fn = ncclKerns[k].kernelFn;
@@ -126,9 +129,8 @@ ncclResult_t ncclInitKernelsForDevice(int cudaArch, int maxSharedMem, size_t* ma
         if (attr.localSizeBytes > *maxStackSize) *maxStackSize = attr.localSizeBytes;
       }
       if (carveout) {
-        CUDACHECKGOTO(cudaFuncSetAttribute(fn,
-          cudaFuncAttributePreferredSharedMemoryCarveout, carveout),
-          result, ignore1);
+        CUDACHECKGOTO(cudaFuncSetAttribute(fn, cudaFuncAttributePreferredSharedMemoryCarveout, carveout), result,
+                      ignore1);
       ignore1:;
       }
 #ifdef GENERATE_SYM_KERNELS
@@ -137,23 +139,21 @@ ncclResult_t ncclInitKernelsForDevice(int cudaArch, int maxSharedMem, size_t* ma
         // so device (args->maxDynamicSmem) and launch (plan->kernelDynSmem) agree; matches upstream.
         int dynSmem = maxSharedMem - attr.sharedSizeBytes;
         if (dynSmem < 0) dynSmem = 0;
-        CUDACHECKGOTO(cudaFuncSetAttribute(fn,
-          cudaFuncAttributeMaxDynamicSharedMemorySize, dynSmem),
-          result, next_kernel);
+        CUDACHECKGOTO(cudaFuncSetAttribute(fn, cudaFuncAttributeMaxDynamicSharedMemorySize, dynSmem), result,
+                      next_kernel);
         ncclSymkKernelMaxDynamicSmem[k] = dynSmem;
         continue; // sym kernels skip the non-symmetric ncclMaxSharedMem path
       }
 #endif
       if (ncclMaxSharedMem != 0) {
         int sharedMemSize = ncclMaxSharedMem;
-        if (sharedMemSize > (maxSharedMem-attr.sharedSizeBytes)) {
-          WARN("cudaArch %d ncclMaxSharedMem %d exceeds device/fn maxSharedMem %zu",
-               cudaArch, sharedMemSize, maxSharedMem-attr.sharedSizeBytes);
+        if (sharedMemSize > (maxSharedMem - attr.sharedSizeBytes)) {
+          WARN("cudaArch %d ncclMaxSharedMem %d exceeds device/fn maxSharedMem %zu", cudaArch, sharedMemSize,
+               maxSharedMem - attr.sharedSizeBytes);
           return ncclSystemError;
         }
-        CUDACHECKGOTO(cudaFuncSetAttribute(fn,
-          cudaFuncAttributeMaxDynamicSharedMemorySize, sharedMemSize),
-          result, next_kernel);
+        CUDACHECKGOTO(cudaFuncSetAttribute(fn, cudaFuncAttributeMaxDynamicSharedMemorySize, sharedMemSize), result,
+                      next_kernel);
       }
     next_kernel:;
     }
@@ -168,11 +168,16 @@ ncclResult_t ncclInitKernelsForDevice(int cudaArch, int maxSharedMem, size_t* ma
 
 static inline int ncclFuncTrafficPerByte(ncclFunc_t func, int nRanks) {
   switch (func) {
-  case ncclFuncAllReduce: return 2;
-  case ncclFuncAllGather: return nRanks;
-  case ncclFuncReduceScatter: return nRanks;
-  case ncclFuncAlltoAllvGda: return nRanks;
-  default: return 1;
+  case ncclFuncAllReduce:
+    return 2;
+  case ncclFuncAllGather:
+    return nRanks;
+  case ncclFuncReduceScatter:
+    return nRanks;
+  case ncclFuncAlltoAllvGda:
+    return nRanks;
+  default:
+    return 1;
   }
 }
 
@@ -191,11 +196,9 @@ static ncclResult_t addProxyOpIfNeeded(struct ncclComm* comm, struct ncclKernelP
   return ncclSuccess;
 }
 
-static void addWorkBatchToPlan(
-    struct ncclComm* comm, struct ncclKernelPlan* plan, int channelId,
-    enum ncclDevWorkType workType, int devFuncId, uint32_t workOffset,
-    int p2pRound = -1, bool batchP2P = false
-  ) {
+static void addWorkBatchToPlan(struct ncclComm* comm, struct ncclKernelPlan* plan, int channelId,
+                               enum ncclDevWorkType workType, int devFuncId, uint32_t workOffset, int p2pRound = -1,
+                               bool batchP2P = false) {
   ncclKernelPlanner::WipPlan::Channel* chan = &comm->planner.wipPlan.channels[channelId];
   size_t workSize = ncclDevWorkSize(workType);
   // Conditions causing us to create a new blank batch.
@@ -213,19 +216,21 @@ static void addWorkBatchToPlan(
     newBatch |= NCCL_MAX_DEV_WORK_BATCH_BYTES < chan->wipBatch.workBytes + workSize;
     if (workType == ncclDevWorkTypeP2p) {
       newBatch |= !chan->wipBatch.batchP2P;
-      newBatch |= (comm->nNodes > 2 && batchP2P)? (chan->wipBatch.nP2ps == NCCL_MAX_DEV_WORK_P2P_PER_BATCH) : (chan->wipBatch.nP2ps == 1);
-      for (int i=0; i < chan->wipBatch.nP2ps; i++) {
+      newBatch |= (comm->nNodes > 2 && batchP2P) ? (chan->wipBatch.nP2ps == NCCL_MAX_DEV_WORK_P2P_PER_BATCH) :
+                                                   (chan->wipBatch.nP2ps == 1);
+      for (int i = 0; i < chan->wipBatch.nP2ps; i++) {
         newBatch |= p2pRound == chan->wipBatch.p2pRounds[i];
         // Make sure we only aggregate p2p operations within the same p2p round epoch (one epoch is NCCL_MAX_DEV_WORK_P2P_PER_BATCH ops).
         // This enforces uniform batching accross ranks in the communicator and prevents hangs.
-        newBatch |= (p2pRound / NCCL_MAX_DEV_WORK_P2P_PER_BATCH) != (chan->wipBatch.p2pRounds[i] / NCCL_MAX_DEV_WORK_P2P_PER_BATCH);
+        newBatch |= (p2pRound / NCCL_MAX_DEV_WORK_P2P_PER_BATCH) !=
+                    (chan->wipBatch.p2pRounds[i] / NCCL_MAX_DEV_WORK_P2P_PER_BATCH);
       }
     }
   }
   // Conditions causing us to create an extension batch (prev->nextExtends=1)
   uint32_t offset = newBatch ? 0 : (workOffset - batch->offsetBase);
-  bool extendBatch = 63*workSize < offset;
-  extendBatch |= 0 != offset%workSize;
+  bool extendBatch = 63 * workSize < offset;
+  extendBatch |= 0 != offset % workSize;
   if (newBatch || extendBatch) {
     if (!newBatch) batch->nextExtends = extendBatch; // Extending the previous batch.
     struct ncclWorkBatchList* batchNode = ncclMemoryStackAlloc<ncclWorkBatchList>(&comm->memScoped);
@@ -253,14 +258,13 @@ static void addWorkBatchToPlan(
     }
     plan->nWorkBatches += 1;
   }
-  batch->offsetBitset |= 1ull<<(offset/workSize);
+  batch->offsetBitset |= 1ull << (offset / workSize);
   chan->wipBatch.workBytes += workSize;
   if (workType == ncclDevWorkTypeP2p) {
-    //if batching is enabled (RCCL_P2P_BATCH_ENABLE=1),
-    //but this op is not eligible for batching with other ops (i.e. alltoallv where sendBytes != recvBytes),
+    // if batching is enabled (RCCL_P2P_BATCH_ENABLE=1),
+    // but this op is not eligible for batching with other ops (i.e. alltoallv where sendBytes != recvBytes),
     // mark eligibility/ineligibility so that future ops that may be eligible, are not batched with ineligible ones
-    if(chan->wipBatch.nP2ps == 0)
-      chan->wipBatch.batchP2P = batchP2P;
+    if (chan->wipBatch.nP2ps == 0) chan->wipBatch.batchP2P = batchP2P;
     // We need to ensure that a single batch doesn't have multiple p2p's
     // of the same round since they would use the same connections.
     chan->wipBatch.p2pRounds[chan->wipBatch.nP2ps++] = p2pRound;
@@ -270,7 +274,7 @@ static void addWorkBatchToPlan(
 static void finishPlan(struct ncclComm* comm, struct ncclKernelPlan* plan) {
   ncclKernelPlanner::WipPlan::Channel* wipChannels = comm->planner.wipPlan.channels;
   size_t workBytes = plan->workBytes;
-  size_t batchBytes = plan->nWorkBatches*sizeof(struct ncclDevWorkBatch);
+  size_t batchBytes = plan->nWorkBatches * sizeof(struct ncclDevWorkBatch);
 
   if (plan->isSymColl) return;
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
@@ -285,7 +289,8 @@ static void finishPlan(struct ncclComm* comm, struct ncclKernelPlan* plan) {
   plan->kernelArgsSize += (plan->workStorageType == ncclDevWorkStorageTypeArgs) ? workBytes : 0;
   plan->kernelArgsSize = max(plan->kernelArgsSize, sizeof(ncclDevKernelArgsDefaultStorage));
   plan->kernelArgsSize = alignUp(plan->kernelArgsSize, 16);
-  plan->kernelArgs = (struct ncclDevKernelArgs*)ncclMemoryStackAlloc(&comm->memScoped, plan->kernelArgsSize, /*align=*/16);
+  plan->kernelArgs =
+    (struct ncclDevKernelArgs*)ncclMemoryStackAlloc(&comm->memScoped, plan->kernelArgsSize, /*align=*/16);
   plan->kernelArgs->comm = comm->devComm;
   plan->kernelArgs->channelMask = plan->channelMask;
   plan->kernelArgs->workStorageType = plan->workStorageType;
@@ -298,7 +303,7 @@ static void finishPlan(struct ncclComm* comm, struct ncclKernelPlan* plan) {
   // over the channels in ascending order until they're exhausted.
   struct channelMasks hasBatchMask = plan->channelMask;
   struct ncclDevWorkBatch* batchPrev[MAXCHANNELS] = {}; // {0...}
-  struct ncclDevWorkBatch* batchZero = (struct ncclDevWorkBatch*)(plan->kernelArgs+1);
+  struct ncclDevWorkBatch* batchZero = (struct ncclDevWorkBatch*)(plan->kernelArgs + 1);
 
   // [RCCL] Preparing batchZero slightly different to support > 64 Channels
   //        Need to ensure that all channels are processed first before dealing with
@@ -308,7 +313,7 @@ static void finishPlan(struct ncclComm* comm, struct ncclKernelPlan* plan) {
   while (!done) {
     done = 1;
     for (int c = 0; c < MAXCHANNELS; c++) {
-      if (hasBatchMask.masks[c / 64] & (1ULL << (c%64))) {
+      if (hasBatchMask.masks[c / 64] & (1ULL << (c % 64))) {
         if (!ncclIntruQueueEmpty(&wipChannels[c].workBatchQueue)) {
           struct ncclWorkBatchList* batchNode = ncclIntruQueueDequeue(&wipChannels[c].workBatchQueue);
           if (batchPrev[c] != nullptr) {
@@ -318,7 +323,7 @@ static void finishPlan(struct ncclComm* comm, struct ncclKernelPlan* plan) {
           batchZero[batchIx++] = batchNode->batch;
         }
         if (ncclIntruQueueEmpty(&wipChannels[c].workBatchQueue)) {
-          hasBatchMask.masks[c / 64] ^= (1ULL << (c%64));
+          hasBatchMask.masks[c / 64] ^= (1ULL << (c % 64));
         } else {
           done = 0;
         }
@@ -331,12 +336,12 @@ static void finishPlan(struct ncclComm* comm, struct ncclKernelPlan* plan) {
   uint64_t headIds[MAXCHANNELS];
   int nHeads = 0;
   int channelUbound = 0;
-  for (int c=0; c < MAXCHANNELS; c++) {
+  for (int c = 0; c < MAXCHANNELS; c++) {
     struct ncclProxyOp* op = ncclIntruQueueHead(&wipChannels[c].proxyOpQueue);
     headIds[c] = op ? op->opCount : uint64_t(-1);
     if (op) nHeads += 1;
     if (op) plan->hasProxyOps = true;
-    if (op) channelUbound = c+1;
+    if (op) channelUbound = c + 1;
   }
   // Phase 2: Dequeue from planner->channels[c], enqueue in merged order to plan
   while (nHeads != 0) {
@@ -344,10 +349,13 @@ static void finishPlan(struct ncclComm* comm, struct ncclKernelPlan* plan) {
     uint64_t minId = uint64_t(-1);
     // Find channel with least proxy-op id. We store the heads[c]->opCount in
     // headIds[c] to remove indirect loads from this loop.
-    for (int c1=0; c1 < channelUbound; c1++) {
+    for (int c1 = 0; c1 < channelUbound; c1++) {
       uint64_t id = headIds[c1];
-      id = (id>>1 | id<<63); // Move tag bit to order collectives before p2p's
-      if (id < minId) { c = c1; minId = id; }
+      id = (id >> 1 | id << 63); // Move tag bit to order collectives before p2p's
+      if (id < minId) {
+        c = c1;
+        minId = id;
+      }
     }
     struct ncclProxyOp* op = ncclIntruQueueDequeue(&wipChannels[c].proxyOpQueue);
     struct ncclProxyOp* opNext = ncclIntruQueueHead(&wipChannels[c].proxyOpQueue);
@@ -364,24 +372,19 @@ NCCL_PARAM(GraphRegister, "GRAPH_REGISTER", 0);
 #endif
 
 static ncclResult_t getCollNetSupport(struct ncclComm* comm, struct ncclTaskColl* task, int* collNetSupport);
-rccl_static ncclResult_t getAlgoInfo(
-  struct ncclComm* comm, struct ncclTaskColl* task,
-  int collNetSupport, int nvlsSupport, int numPipeOps, ncclSimInfo_t* simInfo = NULL
-);
-static ncclResult_t calcCollChunking(
-  struct ncclComm* comm, struct ncclTaskColl* task, int nChannels, size_t nBytes,
-  /*outputs*/uint32_t* outChunkSize, uint32_t* outDirectFlags, struct ncclProxyOp* proxyOp
-);
+rccl_static ncclResult_t getAlgoInfo(struct ncclComm* comm, struct ncclTaskColl* task, int collNetSupport,
+                                     int nvlsSupport, int numPipeOps, ncclSimInfo_t* simInfo = NULL);
+static ncclResult_t calcCollChunking(struct ncclComm* comm, struct ncclTaskColl* task, int nChannels, size_t nBytes,
+                                     /*outputs*/ uint32_t* outChunkSize, uint32_t* outDirectFlags,
+                                     struct ncclProxyOp* proxyOp);
 
 struct ncclKernelPlanBudget {
   ssize_t inArgsBytes; // Space available within kernel args struct
   ssize_t outArgsBytes; // Space available outside of args struct (fifo or persistent buf)
 };
 
-bool ncclTestBudget(
-    struct ncclKernelPlanBudget* budget, int nWorkBatches, ssize_t workBytes
-  ) {
-  ssize_t batchBytes = nWorkBatches*sizeof(struct ncclDevWorkBatch);
+bool ncclTestBudget(struct ncclKernelPlanBudget* budget, int nWorkBatches, ssize_t workBytes) {
+  ssize_t batchBytes = nWorkBatches * sizeof(struct ncclDevWorkBatch);
   bool ok = false;
   ok |= (batchBytes + workBytes <= budget->inArgsBytes);
   ok |= (batchBytes <= budget->inArgsBytes) && (workBytes <= budget->outArgsBytes);
@@ -390,7 +393,7 @@ bool ncclTestBudget(
 
 ncclResult_t ncclTasksRegAndEnqueue(struct ncclComm* comm) {
   struct ncclKernelPlanner* planner = &comm->planner;
-  struct ncclTaskColl *task;
+  struct ncclTaskColl* task;
   task = ncclIntruQueueHead(&planner->collTaskQueue);
   while (task != nullptr) {
     // Build a ncclDevWorkColl[Reg?] struct for each task.
@@ -423,21 +426,21 @@ ncclResult_t ncclTasksRegAndEnqueue(struct ncclComm* comm) {
     devWork.opCount = task->opCount;
 #ifdef ENABLE_ROCSHMEM
     if (comm->enableRocshmem && (task->func == ncclFuncAlltoAllGda || task->func == ncclFuncAlltoAllvGda)) {
-        devWork.enableRocshmem = comm->enableRocshmem;
-        devWork.team = comm->team_reduce_world_dup;
+      devWork.enableRocshmem = comm->enableRocshmem;
+      devWork.team = comm->team_reduce_world_dup;
 
-        devWork.sndbuff = (void*)((char*)comm->sourceRshmem + comm->symId * comm->bufThreshold);
-        devWork.tempbuff = (void*)((char*)comm->destRshmem + comm->symId * comm->bufThreshold);
+      devWork.sndbuff = (void*)((char*)comm->sourceRshmem + comm->symId * comm->bufThreshold);
+      devWork.tempbuff = (void*)((char*)comm->destRshmem + comm->symId * comm->bufThreshold);
 
-	if (task->func == ncclFuncAlltoAllGda || (task->func == ncclFuncAlltoAllvGda && (task->count <= 131072))) {
-            comm->symId = (comm->symId + 1) % comm->numSymBuf;
-	}
+      if (task->func == ncclFuncAlltoAllGda || (task->func == ncclFuncAlltoAllvGda && (task->count <= 131072))) {
+        comm->symId = (comm->symId + 1) % comm->numSymBuf;
+      }
 
-        devWork.size = task->count;
-	if (task->func == ncclFuncAlltoAllvGda) {
-            devWork.rank = comm->rank;
-            devWork.sizes = task->sizes;
-        }
+      devWork.size = task->count;
+      if (task->func == ncclFuncAlltoAllvGda) {
+        devWork.rank = comm->rank;
+        devWork.sizes = task->sizes;
+      }
     }
 #endif
     // Direct Reduce Scatter
@@ -453,7 +456,7 @@ ncclResult_t ncclTasksRegAndEnqueue(struct ncclComm* comm) {
         } else if (comm->nNodes == 2) {
           directReduceScatterLimit = std::min(directReduceScatterLimit, (int64_t)2097152);
         }
-        devWork.directReduceScatterLimitBytes = (uint32_t) directReduceScatterLimit;
+        devWork.directReduceScatterLimitBytes = (uint32_t)directReduceScatterLimit;
       } else {
         devWork.directReduceScatterLimitBytes = (uint32_t)0;
       }
@@ -465,10 +468,8 @@ ncclResult_t ncclTasksRegAndEnqueue(struct ncclComm* comm) {
     devWork.isOneRPN = comm->isOneRPN;
     devWork.netRegUsed = devWork.regUsed = 0;
     devWork.profilerEnabled = ncclProfilerPluginLoaded() && (task->eActivationMask & ncclProfileKernelCh);
-    if (task->regBufType & NCCL_NET_REG_BUFFER)
-      devWork.netRegUsed = 1;
-    if (task->regBufType & (NCCL_IPC_REG_BUFFER | NCCL_NVLS_REG_BUFFER))
-      devWork.regUsed = 1;
+    if (task->regBufType & NCCL_NET_REG_BUFFER) devWork.netRegUsed = 1;
+    if (task->regBufType & (NCCL_IPC_REG_BUFFER | NCCL_NVLS_REG_BUFFER)) devWork.regUsed = 1;
 
     if (task->regBufType & NCCL_NVLS_REG_BUFFER) {
       struct ncclDevWorkCollReg workReg = {};
@@ -479,14 +480,14 @@ ncclResult_t ncclTasksRegAndEnqueue(struct ncclComm* comm) {
       workNode = ncclMemoryStackAllocInlineArray<ncclWorkList, ncclDevWorkCollReg>(&comm->memScoped, 1);
       workNode->workType = ncclDevWorkTypeCollReg;
       workNode->size = sizeof(struct ncclDevWorkCollReg);
-      memcpy((void*)(workNode+1), (void*)&workReg, workNode->size);
+      memcpy((void*)(workNode + 1), (void*)&workReg, workNode->size);
     } else {
       workNode = ncclMemoryStackAllocInlineArray<ncclWorkList, ncclDevWorkColl>(&comm->memScoped, 1);
       workNode->workType = ncclDevWorkTypeColl;
       workNode->size = sizeof(struct ncclDevWorkColl);
-      memcpy((void*)(workNode+1), (void*)&devWork, workNode->size);
+      memcpy((void*)(workNode + 1), (void*)&devWork, workNode->size);
     }
-next:
+  next:
     ncclIntruQueueEnqueue(&planner->collWorkQueue, workNode);
     task = task->next;
   }
@@ -503,15 +504,17 @@ ncclResult_t ncclPrepareTasks(struct ncclComm* comm, bool* algoNeedConnect, bool
   // Put bcast tasks into collSorter if there's only one bcast peer
   if (planner->bcast_info.BcastPeers == 1) {
     while (!ncclIntruQueueEmpty(&planner->peers[planner->bcast_info.minBcastPeer].bcastQueue)) {
-      struct ncclTaskBcast* bcastTask = ncclIntruQueueDequeue(&planner->peers[planner->bcast_info.minBcastPeer].bcastQueue);
-      struct ncclTaskColl *t = ncclMemoryPoolAlloc<struct ncclTaskColl>(&comm->memPool_ncclTaskColl, &comm->memPermanent);
+      struct ncclTaskBcast* bcastTask =
+        ncclIntruQueueDequeue(&planner->peers[planner->bcast_info.minBcastPeer].bcastQueue);
+      struct ncclTaskColl* t =
+        ncclMemoryPoolAlloc<struct ncclTaskColl>(&comm->memPool_ncclTaskColl, &comm->memPermanent);
       t->func = ncclFuncBroadcast;
       t->sendbuff = bcastTask->sendbuff;
       t->recvbuff = bcastTask->recvbuff;
       t->count = bcastTask->count;
       t->root = bcastTask->root;
       t->datatype = bcastTask->datatype;
-      t->trafficBytes = t->count*ncclFuncTrafficPerByte(t->func, comm->nRanks);
+      t->trafficBytes = t->count * ncclFuncTrafficPerByte(t->func, comm->nRanks);
       t->chunkSteps = BROADCAST_CHUNKSTEPS;
       t->sliceSteps = BROADCAST_SLICESTEPS;
       ncclTaskCollSorterInsert(&planner->collSorter, t, t->trafficBytes);
@@ -526,9 +529,9 @@ ncclResult_t ncclPrepareTasks(struct ncclComm* comm, bool* algoNeedConnect, bool
   // Tasks from the sorter come out ordered size descending.
   struct ncclTaskColl* task = ncclTaskCollSorterDequeueAll(&planner->collSorter);
   // Tasks are assembled by (fn,op,ty) size ascending.
-  struct ncclTaskColl* tasksByFnOpTy[ncclNumFuncs*ncclNumDevRedOps*ncclNumTypes];
+  struct ncclTaskColl* tasksByFnOpTy[ncclNumFuncs * ncclNumDevRedOps * ncclNumTypes];
   memset(tasksByFnOpTy, 0, sizeof(tasksByFnOpTy));
-  int fnOpTyIndices[ncclNumFuncs*ncclNumDevRedOps*ncclNumTypes];
+  int fnOpTyIndices[ncclNumFuncs * ncclNumDevRedOps * ncclNumTypes];
   int fnOpTyCount = 0;
 
   // Skip symmetric kernels for cross-clique
@@ -539,7 +542,7 @@ ncclResult_t ncclPrepareTasks(struct ncclComm* comm, bool* algoNeedConnect, bool
   // Walk the size sorted tasks, binning them by (fn,op,ty).
   while (task != nullptr) {
     struct ncclTaskColl* next = task->next;
-    int index = ((int)task->func*ncclNumDevRedOps + (int)task->opDev.op)*ncclNumTypes + (int)task->datatype;
+    int index = ((int)task->func * ncclNumDevRedOps + (int)task->opDev.op) * ncclNumTypes + (int)task->datatype;
     // Add to set of (fn,op,ty) indices on first occurrence
     if (tasksByFnOpTy[index] == nullptr) fnOpTyIndices[fnOpTyCount++] = index;
     // Add to LIFO for this (fn,op,ty)
@@ -552,11 +555,12 @@ ncclResult_t ncclPrepareTasks(struct ncclComm* comm, bool* algoNeedConnect, bool
   // Walk (fn,op,ty) bins, compute algo and proto etc. Then bin them by their
   // scheduling constraints (collnet x nvls).
   struct ncclIntruQueue<struct ncclTaskColl, &ncclTaskColl::next> collBins[2][2] = {};
-  for (int cursor=0; cursor < fnOpTyCount; cursor++) {
+  for (int cursor = 0; cursor < fnOpTyCount; cursor++) {
     struct ncclTaskColl* aggBeg = tasksByFnOpTy[fnOpTyIndices[cursor]];
     int collNetSupport = 0;
     NCCLCHECK(ncclGetCollNetSupport(comm, aggBeg, &collNetSupport));
-    int nvlsSupport = comm->nvlsSupport && (ncclNvlsSupported(aggBeg->opDev.op, aggBeg->datatype) || aggBeg->func == ncclFuncAllGather);
+    int nvlsSupport =
+      comm->nvlsSupport && (ncclNvlsSupported(aggBeg->opDev.op, aggBeg->datatype) || aggBeg->func == ncclFuncAllGather);
     // Crudely estimate number of tasks per channel. This is using the wrong number
     // of channels for NVLS algos, but knowing the algo requires having this value,
     // so either be crude our iterate until fixed point, we chose the former.
@@ -565,31 +569,33 @@ ncclResult_t ncclPrepareTasks(struct ncclComm* comm, bool* algoNeedConnect, bool
       struct ncclTaskColl* aggEnd = aggBeg->next;
       struct ncclTaskColl agg = *aggBeg;
       // We aggregate operations that are within 4X size of each other.
-      while (aggEnd != nullptr && aggEnd->trafficBytes < 4*aggBeg->trafficBytes) {
+      while (aggEnd != nullptr && aggEnd->trafficBytes < 4 * aggBeg->trafficBytes) {
         agg.count += aggEnd->count;
         agg.trafficBytes += aggEnd->trafficBytes;
         aggEnd = aggEnd->next;
       }
 
       NCCLCHECK(getAlgoInfo(comm, &agg, collNetSupport, nvlsSupport, nTasksPerChannel, simInfo));
-      if(agg.func==ncclFuncAllReduce && agg.acc != nullptr)
-        agg.devFuncId = ncclDevFuncId(agg.func, agg.opDev.op, agg.datatype, agg.algorithm, agg.protocol, 1, agg.pipeline);
+      if (agg.func == ncclFuncAllReduce && agg.acc != nullptr)
+        agg.devFuncId =
+          ncclDevFuncId(agg.func, agg.opDev.op, agg.datatype, agg.algorithm, agg.protocol, 1, agg.pipeline);
       else
-        agg.devFuncId = ncclDevFuncId(agg.func, agg.opDev.op, agg.datatype, agg.algorithm, agg.protocol, 0, agg.pipeline);
+        agg.devFuncId =
+          ncclDevFuncId(agg.func, agg.opDev.op, agg.datatype, agg.algorithm, agg.protocol, 0, agg.pipeline);
       if (agg.devFuncId < 0) {
         WARN("%s: unsupported collective. Please ensure the collective has been enabled in build.", __func__);
         return ncclInvalidUsage;
       }
 
       if (!rcclIsArchSupportedForFunc(&agg, comm->archName)) {
-        WARN("%s: unsupported architecture (%s) for collective %s(%s, %s, %s, %s, Acc=%d, Pipeline=%d).",
-          __func__, comm->archName,
-          ncclFuncToString(agg.func), ncclAlgoToString(agg.algorithm), ncclProtoToString(agg.protocol),
-          ncclDevRedOpToString(agg.opDev.op), ncclDatatypeToString(agg.datatype), (agg.acc != nullptr), agg.pipeline);
+        WARN("%s: unsupported architecture (%s) for collective %s(%s, %s, %s, %s, Acc=%d, Pipeline=%d).", __func__,
+             comm->archName, ncclFuncToString(agg.func), ncclAlgoToString(agg.algorithm),
+             ncclProtoToString(agg.protocol), ncclDevRedOpToString(agg.opDev.op), ncclDatatypeToString(agg.datatype),
+             (agg.acc != nullptr), agg.pipeline);
         return ncclInvalidUsage;
       }
 
-      int isCollnet=0, isNvls=0;
+      int isCollnet = 0, isNvls = 0;
       switch (agg.algorithm) {
       case NCCL_ALGO_NVLS:
       case NCCL_ALGO_NVLS_TREE:
@@ -626,8 +632,8 @@ ncclResult_t ncclPrepareTasks(struct ncclComm* comm, bool* algoNeedConnect, bool
   // Concatenate `collBins[*][*]` together into final list `planner->collTaskQueue`.
   // Collnet is the outer dimension since that affects how we divide over the
   // channels.
-  for (int isCollnet=0; isCollnet <= 1; isCollnet++) {
-    for (int isNvls=0; isNvls <= 1; isNvls++) {
+  for (int isCollnet = 0; isCollnet <= 1; isCollnet++) {
+    for (int isNvls = 0; isNvls <= 1; isNvls++) {
       ncclIntruQueueTransfer(&planner->collTaskQueue, &collBins[isCollnet][isNvls]);
     }
   }
@@ -646,7 +652,8 @@ ncclResult_t ncclPrepareTasks(struct ncclComm* comm, bool* algoNeedConnect, bool
     ncclRegisterCollNvlsBuffers(comm, task, regBufSend, regBufRecv, &planner->collCleanupQueue, &regNeedConnect);
 
     if (comm->runtimeConn && comm->initAlgoChannels[task->algorithm] == false) {
-      if (task->algorithm == NCCL_ALGO_NVLS_TREE && comm->initAlgoChannels[NCCL_ALGO_NVLS] == false && regNeedConnect == true) {
+      if (task->algorithm == NCCL_ALGO_NVLS_TREE && comm->initAlgoChannels[NCCL_ALGO_NVLS] == false &&
+          regNeedConnect == true) {
         comm->initAlgoChannels[NCCL_ALGO_NVLS] = true;
         algoNeedConnect[NCCL_ALGO_NVLS] = true;
       }
@@ -673,10 +680,8 @@ ncclResult_t ncclPrepareTasks(struct ncclComm* comm, bool* algoNeedConnect, bool
       devWork.oneNode = (comm->nNodes == 1);
       devWork.netRegUsed = devWork.regUsed = 0;
       devWork.profilerEnabled = ncclProfilerPluginLoaded() && (task->eActivationMask & ncclProfileKernelCh);
-      if (task->regBufType & NCCL_NET_REG_BUFFER)
-        devWork.netRegUsed = 1;
-      if (task->regBufType & (NCCL_IPC_REG_BUFFER | NCCL_NVLS_REG_BUFFER))
-        devWork.regUsed = 1;
+      if (task->regBufType & NCCL_NET_REG_BUFFER) devWork.netRegUsed = 1;
+      if (task->regBufType & (NCCL_IPC_REG_BUFFER | NCCL_NVLS_REG_BUFFER)) devWork.regUsed = 1;
       devWork.pivotA2ANumBiRings = comm->topo->pivotA2ANumBiRings;
       devWork.opCount = task->opCount;
 
@@ -738,7 +743,8 @@ ncclResult_t ncclAddProxyOpIfNeeded(struct ncclComm* comm, struct ncclKernelPlan
   return ncclSuccess;
 }
 
-static ncclResult_t addProfilerProxyOpIfNeeded(struct ncclComm* comm, struct ncclKernelPlan* plan, struct ncclProxyOp* op) {
+static ncclResult_t addProfilerProxyOpIfNeeded(struct ncclComm* comm, struct ncclKernelPlan* plan,
+                                               struct ncclProxyOp* op) {
   int tmp = op->pattern;
   op->pattern = ncclPatternProfiler;
   ncclResult_t ret = ncclAddProxyOpIfNeeded(comm, plan, op);
@@ -748,16 +754,15 @@ static ncclResult_t addProfilerProxyOpIfNeeded(struct ncclComm* comm, struct ncc
 
 RCCL_PARAM(IntraNetThreshold, "INTRANET_THRESHOLD", 8388608);
 
-static ncclResult_t scheduleCollTasksToPlan(
-    struct ncclComm* comm, struct ncclKernelPlan* plan, struct ncclKernelPlanBudget* budget
-  ) {
+static ncclResult_t scheduleCollTasksToPlan(struct ncclComm* comm, struct ncclKernelPlan* plan,
+                                            struct ncclKernelPlanBudget* budget) {
   struct ncclKernelPlanner* planner = &comm->planner;
   // Estimate number of tasks that will fit in this plan.
   int nPlanColls = 0;
-  size_t trafficBytes[2*2] = {0, 0, 0, 0}; // [collnet][nvls]
-  int nChannels[2*2] = {0, 0, 0, 0}; // [collnet][nvls]
-  int const nMaxChannels[2*2] = {comm->nChannels, comm->nvlsChannels, // [collnet][nvls]
-                                 comm->nChannels, std::min(comm->nChannels, comm->nvlsChannels)};
+  size_t trafficBytes[2 * 2] = {0, 0, 0, 0}; // [collnet][nvls]
+  int nChannels[2 * 2] = {0, 0, 0, 0}; // [collnet][nvls]
+  int const nMaxChannels[2 * 2] = {comm->nChannels, comm->nvlsChannels, // [collnet][nvls]
+                                   comm->nChannels, std::min(comm->nChannels, comm->nvlsChannels)};
   constexpr size_t MinTrafficPerChannel = 16 << 10;
   do {
     size_t workBytes = 0;
@@ -769,7 +774,7 @@ static ncclResult_t scheduleCollTasksToPlan(
 
       nPlanColls += 1;
       workBytes += workNode->size;
-      int kind = 2*task->isCollnet + task->isNvls;
+      int kind = 2 * task->isCollnet + task->isNvls;
       trafficBytes[kind] += std::max(MinTrafficPerChannel, task->trafficBytes);
       nChannels[kind] += task->nMaxChannels;
       nChannels[kind] = std::min(nChannels[kind], nMaxChannels[kind]);
@@ -786,16 +791,16 @@ static ncclResult_t scheduleCollTasksToPlan(
 
 #ifdef ENABLE_TRACE
   size_t channelCounts[MAXCHANNELS];
-  for (int c=0; c<MAXCHANNELS; c++) channelCounts[c] = 0;
+  for (int c = 0; c < MAXCHANNELS; c++) channelCounts[c] = 0;
 #endif
 
-  while (nPlanColls!=0 && !ncclIntruQueueEmpty(&planner->collTaskQueue)) {
+  while (nPlanColls != 0 && !ncclIntruQueueEmpty(&planner->collTaskQueue)) {
     struct ncclTaskColl* task = ncclIntruQueueHead(&planner->collTaskQueue);
     struct ncclWorkList* workNode = ncclIntruQueueHead(&planner->collWorkQueue);
-    struct ncclDevWorkColl* devWork = (struct ncclDevWorkColl*)(workNode+1);
+    struct ncclDevWorkColl* devWork = (struct ncclDevWorkColl*)(workNode + 1);
     size_t elementSize = ncclTypeSize(task->datatype);
 
-    int kind = 2*task->isCollnet + task->isNvls;
+    int kind = 2 * task->isCollnet + task->isNvls;
     if (kind != kindPrev) {
       trafficPerChannel = std::max<size_t>(MinTrafficPerChannel, divUp(trafficBytes[kind] / nChannels[kind], 16) * 16);
       kindPrev = kind;
@@ -810,22 +815,22 @@ static ncclResult_t scheduleCollTasksToPlan(
         return ncclSuccess;
       }
 
-      size_t globalBytesPerElement = elementSize*ncclFuncMaxSendRecvCount(task->func, comm->nRanks, 1);
+      size_t globalBytesPerElement = elementSize * ncclFuncMaxSendRecvCount(task->func, comm->nRanks, 1);
       struct ncclProxyOp proxyOp;
-      uint32_t chunkSize, directFlags=0;
-      size_t nBytes = globalBytesPerElement*task->count;
+      uint32_t chunkSize, directFlags = 0;
+      size_t nBytes = globalBytesPerElement * task->count;
       NCCLCHECK(calcCollChunking(comm, task, nChannels, nBytes, &chunkSize, &directFlags, &proxyOp));
       devWork->channelLo = 0;
-      devWork->channelHi = nChannels-1;
+      devWork->channelHi = nChannels - 1;
       // RCCL: CollNet path never set task->nChannels; profiler received 0.
       // Clamp to UINT8_MAX: ENABLE_WARP_SPEED pushes MAXCHANNELS to 512 which wraps uint8.
       task->nChannels = (nChannels <= UINT8_MAX) ? (uint8_t)nChannels : UINT8_MAX;
       devWork->collnet.count = task->count;
-      devWork->collnet.chunkCount = chunkSize/ncclTypeSize(task->datatype);
+      devWork->collnet.chunkCount = chunkSize / ncclTypeSize(task->datatype);
       devWork->direct = directFlags;
 
-      uint64_t proxyOpId = uint64_t(plan->collOpCount++)<<1 | 0;
-      for (int c=devWork->channelLo; c <= (int)devWork->channelHi; c++) {
+      uint64_t proxyOpId = uint64_t(plan->collOpCount++) << 1 | 0;
+      for (int c = devWork->channelLo; c <= (int)devWork->channelHi; c++) {
         proxyOp.channelId = c;
         proxyOp.opCount = proxyOpId;
         proxyOp.task.coll = task;
@@ -837,32 +842,32 @@ static ncclResult_t scheduleCollTasksToPlan(
         // for Direct Reduce Scatter (DRS), we don't need to add proxy op
         bool isDRS = task->func == ncclFuncReduceScatter && comm->enableDirectReduceScatter;
         if (!isDRS && task->func != ncclFuncAlltoAllGda && task->func != ncclFuncAlltoAllvGda) {
-            NCCLCHECK(addProxyOpIfNeeded(comm, plan, &proxyOp));
-            NCCLCHECK(addProfilerProxyOpIfNeeded(comm, plan, &proxyOp));
+          NCCLCHECK(addProxyOpIfNeeded(comm, plan, &proxyOp));
+          NCCLCHECK(addProfilerProxyOpIfNeeded(comm, plan, &proxyOp));
         }
       }
     } else { // not task->isCollnet
       int trafficPerByte = ncclFuncTrafficPerByte(task->func, comm->nRanks);
       if (task->protocol == NCCL_PROTO_LL) trafficPerByte *= 4;
       size_t cellSize = divUp(divUp(MinTrafficPerChannel, (size_t)trafficPerByte), 16) * 16;
-      int elementsPerCell = cellSize/elementSize;
-      size_t cells = divUp(task->count*elementSize, cellSize);
-      size_t trafficPerElement = elementSize*trafficPerByte;
-      size_t trafficPerCell = cellSize*trafficPerByte;
+      int elementsPerCell = cellSize / elementSize;
+      size_t cells = divUp(task->count * elementSize, cellSize);
+      size_t trafficPerElement = elementSize * trafficPerByte;
+      size_t trafficPerCell = cellSize * trafficPerByte;
       size_t cellsPerChannel = std::min(cells, divUp(trafficPerChannel, trafficPerCell));
       size_t cellsLo;
-      if (channelId+1 == nMaxChannels[kind]) { // On last channel everything goes to "lo"
+      if (channelId + 1 == nMaxChannels[kind]) { // On last channel everything goes to "lo"
         cellsLo = cells;
       } else {
-        cellsLo = std::min(cells, divUp((trafficPerChannel-currentTraffic),trafficPerCell));
+        cellsLo = std::min(cells, divUp((trafficPerChannel - currentTraffic), trafficPerCell));
       }
-      int nMidChannels = (cells-cellsLo)/cellsPerChannel;
-      size_t cellsHi = (cells-cellsLo)%cellsPerChannel;
-      int nChannels = (cellsLo!=0 ? 1 : 0) + nMidChannels + (cellsHi!=0 ? 1 : 0);
+      int nMidChannels = (cells - cellsLo) / cellsPerChannel;
+      size_t cellsHi = (cells - cellsLo) % cellsPerChannel;
+      int nChannels = (cellsLo != 0 ? 1 : 0) + nMidChannels + (cellsHi != 0 ? 1 : 0);
       if (nMaxChannels[kind] < channelId + nChannels) { // Overflowed available channels
         nMidChannels = nMaxChannels[kind] - channelId - 2;
-        cellsPerChannel = (cells-cellsLo)/(nMidChannels+1);
-        cellsHi = cellsPerChannel + (cells-cellsLo)%(nMidChannels+1);
+        cellsPerChannel = (cells - cellsLo) / (nMidChannels + 1);
+        cellsHi = cellsPerChannel + (cells - cellsLo) % (nMidChannels + 1);
       }
       if (cellsHi == 0 && nMidChannels != 0) {
         cellsHi = cellsPerChannel;
@@ -870,20 +875,25 @@ static ncclResult_t scheduleCollTasksToPlan(
       }
       if (cellsLo == 0) { // Least channel skipped. Make the next channel the new least.
         channelId += 1;
-        if (nMidChannels == 0) { cellsLo = cellsHi; cellsHi = 0; }
-        else { cellsLo = cellsPerChannel; nMidChannels -= 1; }
+        if (nMidChannels == 0) {
+          cellsLo = cellsHi;
+          cellsHi = 0;
+        } else {
+          cellsLo = cellsPerChannel;
+          nMidChannels -= 1;
+        }
       }
-      size_t countMid = nMidChannels!=0 ? cellsPerChannel*elementsPerCell : 0;
-      size_t countLo = cellsLo*elementsPerCell;
-      size_t countHi = cellsHi*elementsPerCell;
-      (countHi != 0 ? countHi : countLo) -= cells*elementsPerCell - task->count;
+      size_t countMid = nMidChannels != 0 ? cellsPerChannel * elementsPerCell : 0;
+      size_t countLo = cellsLo * elementsPerCell;
+      size_t countHi = cellsHi * elementsPerCell;
+      (countHi != 0 ? countHi : countLo) -= cells * elementsPerCell - task->count;
 
-      nChannels = (countLo!=0 ? 1 : 0) + nMidChannels + (cellsHi!=0 ? 1 : 0);
+      nChannels = (countLo != 0 ? 1 : 0) + nMidChannels + (cellsHi != 0 ? 1 : 0);
       // Update number of channels propagated to the profiler
 #ifdef ENABLE_WARP_SPEED
       task->nChannels = nChannels;
 #else
-      task->nChannels = (uint8_t) nChannels;
+      task->nChannels = (uint8_t)nChannels;
 #endif
       // Ensure room for worst case of one new batch per channel
       if (!ncclTestBudget(budget, plan->nWorkBatches + nChannels, plan->workBytes + workNode->size)) {
@@ -891,17 +901,17 @@ static ncclResult_t scheduleCollTasksToPlan(
       }
 
       devWork->channelLo = channelId;
-      devWork->channelHi = channelId + nChannels-1;
+      devWork->channelHi = channelId + nChannels - 1;
       devWork->cbd.countLo = countLo;
       devWork->cbd.countMid = countMid;
       devWork->cbd.countHi = countHi;
 
       // calcCollChunking() uses global bytes instead of traffic which differs
       // in that allreduce isn't multiplied by 2.
-      size_t globalBytesPerElement = elementSize*ncclFuncMaxSendRecvCount(task->func, comm->nRanks, 1);
+      size_t globalBytesPerElement = elementSize * ncclFuncMaxSendRecvCount(task->func, comm->nRanks, 1);
       struct ncclProxyOp proxyOpLo, proxyOpMid, proxyOpHi;
 
-      size_t nBytes = globalBytesPerElement*task->count;
+      size_t nBytes = globalBytesPerElement * task->count;
       devWork->connIndex = 0;
       if (task->protocol == NCCL_PROTO_SIMPLE && task->algorithm == NCCL_ALGO_RING) {
         if (comm->useIntraNet && nBytes > rcclParamIntraNetThreshold()) {
@@ -909,41 +919,44 @@ static ncclResult_t scheduleCollTasksToPlan(
         }
       }
 
-      uint32_t chunkSize, directFlags=0;
+      uint32_t chunkSize, directFlags = 0;
       size_t grainSize = rcclProtoGrainSize(task->protocol, comm);
 
       if (countLo != 0) {
-        NCCLCHECK(calcCollChunking(comm, task, /*nChannels=*/1, globalBytesPerElement*countLo, &chunkSize, &directFlags, &proxyOpLo));
-        devWork->cbd.chunkGrainsLo = chunkSize/grainSize;
+        NCCLCHECK(calcCollChunking(comm, task, /*nChannels=*/1, globalBytesPerElement * countLo, &chunkSize,
+                                   &directFlags, &proxyOpLo));
+        devWork->cbd.chunkGrainsLo = chunkSize / grainSize;
       }
       if (countHi != 0) {
-        NCCLCHECK(calcCollChunking(comm, task, /*nChannels=*/1, globalBytesPerElement*countHi, &chunkSize, &directFlags, &proxyOpHi));
-        devWork->cbd.chunkGrainsHi = chunkSize/grainSize;
+        NCCLCHECK(calcCollChunking(comm, task, /*nChannels=*/1, globalBytesPerElement * countHi, &chunkSize,
+                                   &directFlags, &proxyOpHi));
+        devWork->cbd.chunkGrainsHi = chunkSize / grainSize;
       }
       if (nMidChannels != 0) {
-        NCCLCHECK(calcCollChunking(comm, task, /*nChannels=*/1, globalBytesPerElement*countMid, &chunkSize, &directFlags, &proxyOpMid));
-        devWork->cbd.chunkGrainsMid = chunkSize/grainSize;
+        NCCLCHECK(calcCollChunking(comm, task, /*nChannels=*/1, globalBytesPerElement * countMid, &chunkSize,
+                                   &directFlags, &proxyOpMid));
+        devWork->cbd.chunkGrainsMid = chunkSize / grainSize;
       }
       devWork->direct = directFlags;
 
       // Update the current channel and vacant traffic budget.
       if (countHi != 0) {
-        channelId += nChannels-1;
-        currentTraffic = cellsHi*elementsPerCell*trafficPerElement;
+        channelId += nChannels - 1;
+        currentTraffic = cellsHi * elementsPerCell * trafficPerElement;
       } else if (nMidChannels != 0) {
         channelId += nChannels;
         currentTraffic = 0;
       } else {
-        currentTraffic += cellsLo*elementsPerCell*trafficPerElement;
+        currentTraffic += cellsLo * elementsPerCell * trafficPerElement;
       }
 
-      if (currentTraffic >= trafficPerChannel && channelId+1 != nMaxChannels[kind]) {
+      if (currentTraffic >= trafficPerChannel && channelId + 1 != nMaxChannels[kind]) {
         channelId += 1;
         currentTraffic = 0;
       }
 
-      uint64_t proxyOpId = uint64_t(plan->collOpCount++)<<1 | 0;
-      for (int c=devWork->channelLo; c <= (int)devWork->channelHi; c++) {
+      uint64_t proxyOpId = uint64_t(plan->collOpCount++) << 1 | 0;
+      for (int c = devWork->channelLo; c <= (int)devWork->channelHi; c++) {
         struct ncclProxyOp* proxyOp;
         if (c == (int)devWork->channelLo) {
           proxyOp = &proxyOpLo;
@@ -965,11 +978,23 @@ static ncclResult_t scheduleCollTasksToPlan(
         proxyOp->ringAlgo = NULL;
         if (proxyOp->reg && task->algorithm == NCCL_ALGO_RING && (task->recvNetHandles[c] || task->sendNetHandles[c])) {
           if (task->func == ncclFuncAllGather) {
-            proxyOp->ringAlgo = new RingAGAlgorithm(task->sendbuff, task->recvbuff, comm->nRanks, comm->channels[c].ring.userRanks, proxyOp->chunkSteps, proxyOp->sliceSteps, proxyOp->chunkSize, proxyOp->sliceSize, proxyOp->loopOffset, proxyOp->channelSize, elementSize, task->count * elementSize, task->sendNetHandles[c], task->recvNetHandles[c], task->srecvNetHandles[c]);
+            proxyOp->ringAlgo =
+              new RingAGAlgorithm(task->sendbuff, task->recvbuff, comm->nRanks, comm->channels[c].ring.userRanks,
+                                  proxyOp->chunkSteps, proxyOp->sliceSteps, proxyOp->chunkSize, proxyOp->sliceSize,
+                                  proxyOp->loopOffset, proxyOp->channelSize, elementSize, task->count * elementSize,
+                                  task->sendNetHandles[c], task->recvNetHandles[c], task->srecvNetHandles[c]);
           } else if (task->func == ncclFuncAllReduce) {
-            proxyOp->ringAlgo = new RingARAlgorithm(task->sendbuff, task->recvbuff, comm->nRanks, comm->channels[c].ring.index, proxyOp->chunkSteps, proxyOp->sliceSteps, proxyOp->chunkSize, proxyOp->sliceSize, proxyOp->loopOffset, proxyOp->channelSize, elementSize, task->sendNetHandles[c], task->recvNetHandles[c], task->srecvNetHandles[c]);
+            proxyOp->ringAlgo =
+              new RingARAlgorithm(task->sendbuff, task->recvbuff, comm->nRanks, comm->channels[c].ring.index,
+                                  proxyOp->chunkSteps, proxyOp->sliceSteps, proxyOp->chunkSize, proxyOp->sliceSize,
+                                  proxyOp->loopOffset, proxyOp->channelSize, elementSize, task->sendNetHandles[c],
+                                  task->recvNetHandles[c], task->srecvNetHandles[c]);
           } else if (task->func == ncclFuncBroadcast) {
-            proxyOp->ringAlgo = new RingBCAlgorithm(task->sendbuff, task->recvbuff, comm->rank, task->root, comm->nRanks, comm->channels[c].ring.userRanks, proxyOp->chunkSteps, proxyOp->sliceSteps, proxyOp->chunkSize, proxyOp->sliceSize, proxyOp->loopOffset, proxyOp->channelSize, task->sendNetHandles[c], task->recvNetHandles[c], task->srecvNetHandles[c]);
+            proxyOp->ringAlgo =
+              new RingBCAlgorithm(task->sendbuff, task->recvbuff, comm->rank, task->root, comm->nRanks,
+                                  comm->channels[c].ring.userRanks, proxyOp->chunkSteps, proxyOp->sliceSteps,
+                                  proxyOp->chunkSize, proxyOp->sliceSize, proxyOp->loopOffset, proxyOp->channelSize,
+                                  task->sendNetHandles[c], task->recvNetHandles[c], task->srecvNetHandles[c]);
           }
           proxyOp->ringAlgo->incRefCount();
         }
@@ -989,8 +1014,8 @@ static ncclResult_t scheduleCollTasksToPlan(
         // for Direct Reduce Scatter (DRS), we don't need to add proxy op
         bool isDRS = task->func == ncclFuncReduceScatter && comm->enableDirectReduceScatter;
         if (!isDRS && task->func != ncclFuncAlltoAllGda && task->func != ncclFuncAlltoAllvGda) {
-            NCCLCHECK(addProxyOpIfNeeded(comm, plan, proxyOp));
-            NCCLCHECK(addProfilerProxyOpIfNeeded(comm, plan, proxyOp));
+          NCCLCHECK(addProxyOpIfNeeded(comm, plan, proxyOp));
+          NCCLCHECK(addProfilerProxyOpIfNeeded(comm, plan, proxyOp));
         }
       }
     }
@@ -998,9 +1023,9 @@ static ncclResult_t scheduleCollTasksToPlan(
     for (int c = devWork->channelLo; c <= devWork->channelHi; ++c) {
       int maskIdx = c / 64;
       int relativeIdx = c % 64;
-      plan->channelMask.masks[maskIdx] |= (1ull<<relativeIdx);
+      plan->channelMask.masks[maskIdx] |= (1ull << relativeIdx);
     }
-    //plan->channelMask.masks[channelId/64] |= (2ull<<devWork->channelHi) - (1ull<<devWork->channelLo);
+    // plan->channelMask.masks[channelId/64] |= (2ull<<devWork->channelHi) - (1ull<<devWork->channelLo);
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
     plan->threadPerBlock = task->nWarps * comm->WarpSize;
 #else
@@ -1014,37 +1039,37 @@ static ncclResult_t scheduleCollTasksToPlan(
     plan->groupApiEventHandle = task->groupApiEventHandle;
 
     if (comm->rank == 0) {
-      INFO(NCCL_TUNING, "%s: %ld Bytes -> Algo %s proto %s channel{Lo..Hi}={%d..%d}",
-        ncclFuncToString(task->func), task->count * ncclTypeSize(task->datatype), ncclAlgoToString(task->algorithm),
-        ncclProtoToString(task->protocol), devWork->channelLo, devWork->channelHi);
+      INFO(NCCL_TUNING, "%s: %ld Bytes -> Algo %s proto %s channel{Lo..Hi}={%d..%d}", ncclFuncToString(task->func),
+           task->count * ncclTypeSize(task->datatype), ncclAlgoToString(task->algorithm),
+           ncclProtoToString(task->protocol), devWork->channelLo, devWork->channelHi);
 
       if (task->isCollnet) {
-        TRACE(NCCL_COLL, "Collective %s(%s, %s, %s, %s) count=%ld devFuncId=%d channel{Lo..Hi}={%d..%d} count=%ld chunkCount=%d",
-          ncclFuncToString(task->func), ncclDevRedOpToString(task->opDev.op),
-          ncclDatatypeToString(task->datatype), ncclAlgoToString(task->algorithm),
-          ncclProtoToString(task->protocol),
-          (long)task->count, task->devFuncId, devWork->channelLo, devWork->channelHi,
-          (long)devWork->collnet.count, devWork->collnet.chunkCount);
+        TRACE(NCCL_COLL,
+              "Collective %s(%s, %s, %s, %s) count=%ld devFuncId=%d channel{Lo..Hi}={%d..%d} count=%ld chunkCount=%d",
+              ncclFuncToString(task->func), ncclDevRedOpToString(task->opDev.op), ncclDatatypeToString(task->datatype),
+              ncclAlgoToString(task->algorithm), ncclProtoToString(task->protocol), (long)task->count, task->devFuncId,
+              devWork->channelLo, devWork->channelHi, (long)devWork->collnet.count, devWork->collnet.chunkCount);
       } else {
-        TRACE(NCCL_COLL, "Collective %s(%s, %s, %s, %s) count=%ld devFuncId=%d channel{Lo..Hi}={%d..%d} count{Lo,Mid,Hi}={%ld,%ld,%ld} chunkBytes{Lo,Mid,Hi}={%d,%d,%d}",
-          ncclFuncToString(task->func), ncclDevRedOpToString(task->opDev.op),
-          ncclDatatypeToString(task->datatype), ncclAlgoToString(task->algorithm),
-          ncclProtoToString(task->protocol),
-          (long)task->count, task->devFuncId, devWork->channelLo, devWork->channelHi,
-          (long)devWork->cbd.countLo, (long)devWork->cbd.countMid, (long)devWork->cbd.countHi,
-          int(devWork->cbd.chunkGrainsLo*rcclProtoGrainSize(task->protocol, comm)),
-          int(devWork->cbd.chunkGrainsMid*rcclProtoGrainSize(task->protocol, comm)),
-          int(devWork->cbd.chunkGrainsHi*rcclProtoGrainSize(task->protocol, comm)));
-          // channel traffic counter
+        TRACE(NCCL_COLL,
+              "Collective %s(%s, %s, %s, %s) count=%ld devFuncId=%d channel{Lo..Hi}={%d..%d} "
+              "count{Lo,Mid,Hi}={%ld,%ld,%ld} chunkBytes{Lo,Mid,Hi}={%d,%d,%d}",
+              ncclFuncToString(task->func), ncclDevRedOpToString(task->opDev.op), ncclDatatypeToString(task->datatype),
+              ncclAlgoToString(task->algorithm), ncclProtoToString(task->protocol), (long)task->count, task->devFuncId,
+              devWork->channelLo, devWork->channelHi, (long)devWork->cbd.countLo, (long)devWork->cbd.countMid,
+              (long)devWork->cbd.countHi, int(devWork->cbd.chunkGrainsLo * rcclProtoGrainSize(task->protocol, comm)),
+              int(devWork->cbd.chunkGrainsMid * rcclProtoGrainSize(task->protocol, comm)),
+              int(devWork->cbd.chunkGrainsHi * rcclProtoGrainSize(task->protocol, comm)));
+        // channel traffic counter
 #ifdef ENABLE_TRACE
-          channelCounts[devWork->channelLo] += (long)devWork->cbd.countLo;
-          if (devWork->channelLo != devWork->channelHi) channelCounts[devWork->channelHi] += (long)devWork->cbd.countHi;
-          for (int c=devWork->channelLo+1; c<devWork->channelHi; c++) channelCounts[c] += (long)devWork->cbd.countMid;
+        channelCounts[devWork->channelLo] += (long)devWork->cbd.countLo;
+        if (devWork->channelLo != devWork->channelHi) channelCounts[devWork->channelHi] += (long)devWork->cbd.countHi;
+        for (int c = devWork->channelLo + 1; c < devWork->channelHi; c++)
+          channelCounts[c] += (long)devWork->cbd.countMid;
 #endif
       }
     }
 
-    for (int i=0; i < task->nCleanupQueueElts; i++) {
+    for (int i = 0; i < task->nCleanupQueueElts; i++) {
       ncclIntruQueueEnqueue(&plan->cleanupQueue, ncclIntruQueueDequeue(&planner->collCleanupQueue));
     }
     ncclIntruQueueDequeue(&planner->collTaskQueue);
@@ -1059,8 +1084,8 @@ static ncclResult_t scheduleCollTasksToPlan(
 #ifdef ENABLE_TRACE
   char line[1024];
   int offset = 0;
-  for (int c=0; c<MAXCHANNELS; c++) {
-    sprintf(line+offset, "%ld ", channelCounts[c]);
+  for (int c = 0; c < MAXCHANNELS; c++) {
+    sprintf(line + offset, "%ld ", channelCounts[c]);
     offset = strlen(line);
   }
   TRACE(NCCL_COLL, "Channel traffic counts: %s", line);
@@ -1073,7 +1098,6 @@ NCCL_PARAM(P2pLLThreshold, "P2P_LL_THRESHOLD", 8192);
 RCCL_PARAM(P2pNetThreshold, "P2P_NET_THRESHOLD", 131072);
 NCCL_PARAM(ChunkSize, "CHUNK_SIZE", 0);
 
-
 // Need this temporary parameter to disable p2p batching to avoid some dips at 4MB - 32 MB message size at large scale
 // This parameter must be removed after further investigation,
 // Note that NCCL enables batching by default and it is needed to achieve perf for with smaller messages <= 4MB
@@ -1081,8 +1105,8 @@ NCCL_PARAM(ChunkSize, "CHUNK_SIZE", 0);
 // previously, p2p-batching was causing regression on all node-counts for larger message sizes (64KB "per-rank")
 // we want to auto-enable only for gfx950 paired with a non-AINIC NIC, so we use
 // rcclEffectiveP2pBatchEnable helper to branch based on arch and NIC type.
-RCCL_PARAM(P2pBatchEnable,    "P2P_BATCH_ENABLE",    -1);
-RCCL_PARAM(P2pBatchThreshold, "P2P_BATCH_THRESHOLD", 1 << 16);  // 64k per-rank message size
+RCCL_PARAM(P2pBatchEnable, "P2P_BATCH_ENABLE", -1);
+RCCL_PARAM(P2pBatchThreshold, "P2P_BATCH_THRESHOLD", 1 << 16); // 64k per-rank message size
 
 static int rcclEffectiveP2pBatchEnable(struct ncclComm* comm) {
   auto userInput = rcclParamP2pBatchEnable();
@@ -1095,14 +1119,10 @@ static int rcclEffectiveP2pBatchEnable(struct ncclComm* comm) {
 // and sizeof(ncclDevWorkP2p) in work budget. "sendRank" and "recvRank" must
 // match the corresponding values for this round of the p2p schedule (no -1's).
 // No-op's are encoded with a -1 size.
-static ncclResult_t addP2pToPlan(
-    struct ncclComm* comm, struct ncclKernelPlan* plan,
-    int nChannelsMin, int nChannelsMax, int p2pRound,
-    int sendRank, void* sendAddr, ssize_t sendBytes,
-    int recvRank, void* recvAddr, ssize_t recvBytes,
-    uint64_t sendOpCount, uint64_t recvOpCount,
-    const int planTotalTasks[], struct ncclTaskP2p** p2pTasks
-  ) {
+static ncclResult_t addP2pToPlan(struct ncclComm* comm, struct ncclKernelPlan* plan, int nChannelsMin, int nChannelsMax,
+                                 int p2pRound, int sendRank, void* sendAddr, ssize_t sendBytes, int recvRank,
+                                 void* recvAddr, ssize_t recvBytes, uint64_t sendOpCount, uint64_t recvOpCount,
+                                 const int planTotalTasks[], struct ncclTaskP2p** p2pTasks) {
   ncclResult_t ret = ncclSuccess;
   int connIndex[2] = {1, 1};
   bool selfSend = (sendRank == comm->rank);
@@ -1116,31 +1136,34 @@ static ncclResult_t addP2pToPlan(
   auto batchP2PEnableEnv = rcclEffectiveP2pBatchEnable(comm);
   auto p2pBatchThreshold = rcclParamP2pBatchThreshold();
   bool belowThreshold = (recvBytes <= p2pBatchThreshold) && (sendBytes <= p2pBatchThreshold);
-  bool batchP2P =  batchP2PEnableEnv && (sendBytes == recvBytes) && (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950") && comm->nNodes >= 16 ? belowThreshold : true);
-  //ncclP2pChannelBaseForRound now computes channel-base based on batching enablement (env. variable RCCL_P2P_BATCH_ENABLE=1)
-  //but batching is only applicable if msg size is below threshold which is not checked below
-  //this causes perf. dips in some cases but also boosts in other cases even when no batching happens because msg size is above threshold
-  //replacing line below with ncclP2pChannelBaseForRound(comm, p2pRound, batchP2P) can cause issues due to taskAppend calling the same routine where no threshold info is available
-  //channel base computed in taskAppend and here must be the same, but in taskAppend the call happens once and is cached for later usage, which is why it wouldn't be consistent with the call below
+  bool batchP2P =
+    batchP2PEnableEnv && (sendBytes == recvBytes) &&
+    (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950") && comm->nNodes >= 16 ? belowThreshold : true);
+  // ncclP2pChannelBaseForRound now computes channel-base based on batching enablement (env. variable RCCL_P2P_BATCH_ENABLE=1)
+  // but batching is only applicable if msg size is below threshold which is not checked below
+  // this causes perf. dips in some cases but also boosts in other cases even when no batching happens because msg size is above threshold
+  // replacing line below with ncclP2pChannelBaseForRound(comm, p2pRound, batchP2P) can cause issues due to taskAppend calling the same routine where no threshold info is available
+  // channel base computed in taskAppend and here must be the same, but in taskAppend the call happens once and is cached for later usage, which is why it wouldn't be consistent with the call below
   uint8_t base = ncclP2pChannelBaseForRound(comm, p2pRound, batchP2PEnableEnv);
   struct ncclProxyOp proxyOps[2] = {};
   int nProxyOps = selfSend ? 0 : 2;
   if (comm->p2pNet) {
     for (int dir = 0; dir <= 1; dir++) {
-      if (bytes[dir] > rcclParamP2pNetThreshold())
-        connIndex[dir] = NCCL_CONN_IDX_P2P_NET;
+      if (bytes[dir] > rcclParamP2pNetThreshold()) connIndex[dir] = NCCL_CONN_IDX_P2P_NET;
     }
   }
 
   if (!selfSend) {
-    for (int part=0; part < nChannelsMax; part++) {
-      int channelId = ncclP2pChannelForPart(comm->p2pnChannels, base, part, nChannelsMax, comm->nNodes, comm->p2pChannelShiftSize);
+    for (int part = 0; part < nChannelsMax; part++) {
+      int channelId =
+        ncclP2pChannelForPart(comm->p2pnChannels, base, part, nChannelsMax, comm->nNodes, comm->p2pChannelShiftSize);
       struct ncclChannelPeer** channelPeers = comm->channels[channelId].peers;
-      for (int dir=0; dir <= 1; dir++) {
+      for (int dir = 0; dir <= 1; dir++) {
         int peerRank = dir ? sendRank : recvRank;
-        struct ncclConnector* conn = dir ? &channelPeers[peerRank]->send[connIndex[dir]]
-                                         : &channelPeers[peerRank]->recv[connIndex[dir]];
-        protoLL[dir] &= conn->conn.buffs[NCCL_PROTO_LL] != nullptr && !IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx12");
+        struct ncclConnector* conn =
+          dir ? &channelPeers[peerRank]->send[connIndex[dir]] : &channelPeers[peerRank]->recv[connIndex[dir]];
+        protoLL[dir] &=
+          conn->conn.buffs[NCCL_PROTO_LL] != nullptr && !IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx12");
         network[dir] |= conn->transportComm == (dir ? &netTransport.send : &netTransport.recv);
         proxySameProcess[dir] &= conn->proxyConn.sameProcess;
       }
@@ -1158,18 +1181,18 @@ static ncclResult_t addP2pToPlan(
   bool netRegistered[2] = {false, false};
   bool ipcRegistered[2] = {false, false};
 
-  for (int dir=0; dir < 2; dir++) { // 0=recv, 1=send
+  for (int dir = 0; dir < 2; dir++) { // 0=recv, 1=send
     // Assume SIMPLE protocol to start with to determine number of channels
     stepSize[dir] = comm->p2pChunkSize;
 
     if (bytes[dir] == -1) nChannels[dir] = 0;
     else if (bytes[dir] == 0) nChannels[dir] = 1;
     else {
-      ssize_t minPartSize = comm->nNodes > 1 ? stepSize[dir]/2 : stepSize[dir]/8;
-      ssize_t maxPartSize = comm->nNodes > 1 ? stepSize[dir]   : stepSize[dir]*32;
+      ssize_t minPartSize = comm->nNodes > 1 ? stepSize[dir] / 2 : stepSize[dir] / 8;
+      ssize_t maxPartSize = comm->nNodes > 1 ? stepSize[dir] : stepSize[dir] * 32;
       nChannels[dir] = std::min<int>(nChannelsMin, divUp(bytes[dir], minPartSize));
       size_t partSize = std::max(minPartSize, divUp(bytes[dir], nChannels[dir]));
-      while (partSize > maxPartSize && nChannels[dir] <= nChannelsMax/2) {
+      while (partSize > maxPartSize && nChannels[dir] <= nChannelsMax / 2) {
         nChannels[dir] *= 2;
         partSize = divUp(bytes[dir], nChannels[dir]);
       }
@@ -1178,11 +1201,10 @@ static ncclResult_t addP2pToPlan(
     if (p2pTasks[dir]) p2pTasks[dir]->nChannels = nChannels[dir];
 
     // Select protocol (LL vs SIMPLE) used based on payload per channel
-    if (bytes[dir] != -1)
-      protoLL[dir] &= bytes[dir] <= nChannels[dir] * ncclParamP2pLLThreshold();
+    if (bytes[dir] != -1) protoLL[dir] &= bytes[dir] <= nChannels[dir] * ncclParamP2pLLThreshold();
     protocol[dir] = protoLL[dir] ? NCCL_PROTO_LL : NCCL_PROTO_SIMPLE;
 
-    stepSize[dir] = comm->buffSizes[protocol[dir]]/NCCL_STEPS;
+    stepSize[dir] = comm->buffSizes[protocol[dir]] / NCCL_STEPS;
     if (protocol[dir] == NCCL_PROTO_SIMPLE) stepSize[dir] = comm->p2pChunkSize;
     chunkSize[dir] = stepSize[dir];
     if (paramChunkSize != 0) {
@@ -1190,7 +1212,7 @@ static ncclResult_t addP2pToPlan(
     } else if (network[dir]) {
       // Tune chunk size for the network
       if (protocol[dir] == NCCL_PROTO_SIMPLE && bytes[dir] < stepSize[dir]) chunkSize[dir] /= 4;
-      else if (bytes[dir] < 8*stepSize[dir]) chunkSize[dir] /= 2;
+      else if (bytes[dir] < 8 * stepSize[dir]) chunkSize[dir] /= 2;
     }
 
     chunkDataSize[dir] = chunkSize[dir];
@@ -1206,13 +1228,15 @@ static ncclResult_t addP2pToPlan(
         int regFlag = 0;
         NCCLCHECKGOTO(ncclCalloc(&handles[dir], nChannelsMax), ret, cleanup);
         for (int part = 0; part < nChannelsMax; part++) {
-          int channelId = ncclP2pChannelForPart(comm->p2pnChannels, base, part, nChannelsMax, comm->nNodes, comm->p2pChannelShiftSize);
+          int channelId = ncclP2pChannelForPart(comm->p2pnChannels, base, part, nChannelsMax, comm->nNodes,
+                                                comm->p2pChannelShiftSize);
           struct ncclChannelPeer** channelPeers = comm->channels[channelId].peers;
           int peerRank = dir ? sendRank : recvRank;
-          struct ncclConnector* conn = dir ? &channelPeers[peerRank]->send[connIndex[dir]]
-            : &channelPeers[peerRank]->recv[connIndex[dir]];
+          struct ncclConnector* conn =
+            dir ? &channelPeers[peerRank]->send[connIndex[dir]] : &channelPeers[peerRank]->recv[connIndex[dir]];
           if (conn->conn.flags & NCCL_DIRECT_NIC)
-            ncclRegisterP2pNetBuffer(comm, addrs[dir], bytes[dir], conn, &regFlag, &handles[dir][part], &plan->cleanupQueue);
+            ncclRegisterP2pNetBuffer(comm, addrs[dir], bytes[dir], conn, &regFlag, &handles[dir][part],
+                                     &plan->cleanupQueue);
           if (!regFlag) break;
         }
         netRegistered[dir] = regFlag ? true : false;
@@ -1220,14 +1244,17 @@ static ncclResult_t addP2pToPlan(
     } else if (bytes[dir] > 0 && addrs[dir] && protocol[dir] == NCCL_PROTO_SIMPLE && !selfSend) {
       int peerRank = dir ? sendRank : recvRank;
       int regFlag = 0;
-      int channelId = ncclP2pChannelForPart(comm->p2pnChannels, base, 0, nChannelsMax, comm->nNodes, comm->p2pChannelShiftSize);
+      int channelId =
+        ncclP2pChannelForPart(comm->p2pnChannels, base, 0, nChannelsMax, comm->nNodes, comm->p2pChannelShiftSize);
       struct ncclChannelPeer** channelPeers = comm->channels[channelId].peers;
-      struct ncclConnector* conn = dir ? &channelPeers[peerRank]->send[connIndex[dir]]
-        : &channelPeers[peerRank]->recv[connIndex[dir]];
+      struct ncclConnector* conn =
+        dir ? &channelPeers[peerRank]->send[connIndex[dir]] : &channelPeers[peerRank]->recv[connIndex[dir]];
       void* regAddr = NULL;
       if (conn->conn.flags & (NCCL_P2P_WRITE | NCCL_P2P_READ)) {
         // We require users registering buffers on both sides
-        NCCLCHECKGOTO(ncclRegisterP2pIpcBuffer(comm, addrs[dir], bytes[dir], peerRank, &regFlag, &regAddr, &plan->cleanupQueue), ret, cleanup);
+        NCCLCHECKGOTO(ncclRegisterP2pIpcBuffer(comm, addrs[dir], bytes[dir], peerRank, &regFlag, &regAddr,
+                                               &plan->cleanupQueue),
+                      ret, cleanup);
         if (regFlag) {
           if (dir == 0 && (conn->conn.flags & NCCL_P2P_WRITE)) recvAddr = regAddr;
           else if (dir == 1 && (conn->conn.flags & NCCL_P2P_READ)) sendAddr = regAddr;
@@ -1239,11 +1266,11 @@ static ncclResult_t addP2pToPlan(
     if (bytes[dir] == -1) nChannels[dir] = 0;
     else if (bytes[dir] == 0) nChannels[dir] = 1;
     else {
-      ssize_t minPartSize = comm->nNodes > 1 ? stepSize[dir]/2 : stepSize[dir]/8;
-      ssize_t maxPartSize = comm->nNodes > 1 ? stepSize[dir]   : stepSize[dir]*32;
+      ssize_t minPartSize = comm->nNodes > 1 ? stepSize[dir] / 2 : stepSize[dir] / 8;
+      ssize_t maxPartSize = comm->nNodes > 1 ? stepSize[dir] : stepSize[dir] * 32;
       nChannels[dir] = std::min<int>(nChannelsMin, divUp(bytes[dir], minPartSize));
       size_t partSize = std::max(minPartSize, divUp(bytes[dir], nChannels[dir]));
-      while (partSize > maxPartSize && nChannels[dir] <= nChannelsMax/2) {
+      while (partSize > maxPartSize && nChannels[dir] <= nChannelsMax / 2) {
         nChannels[dir] *= 2;
         partSize = divUp(bytes[dir], nChannels[dir]);
       }
@@ -1262,7 +1289,7 @@ static ncclResult_t addP2pToPlan(
   plan->workBytes += sizeof(struct ncclDevWorkP2p);
 
   struct ncclDevWorkP2p* work;
-  work = (struct ncclDevWorkP2p*)(workNode+1);
+  work = (struct ncclDevWorkP2p*)(workNode + 1);
   work->nP2pChannels = comm->p2pnChannels;
   work->channelBase = base;
   work->nSendChannels = nChannels[1];
@@ -1272,7 +1299,7 @@ static ncclResult_t addP2pToPlan(
   work->sendChunkSize_u32fp8 = chunkDataSize_u32fp8[1];
   work->sendRank = sendRank;
   work->sendAddr = sendAddr;
-  work->sendBytes = sendBytes==-1 ? 0 : sendBytes;
+  work->sendBytes = sendBytes == -1 ? 0 : sendBytes;
   work->sendConnIndex = connIndex[1];
   work->sendOpCount = sendOpCount;
   work->nRecvChannels = nChannels[0];
@@ -1282,12 +1309,13 @@ static ncclResult_t addP2pToPlan(
   work->recvChunkSize_u32fp8 = chunkDataSize_u32fp8[0];
   work->recvRank = recvRank;
   work->recvAddr = recvAddr;
-  work->recvBytes = recvBytes==-1 ? 0 : recvBytes;
-  work->profilerEnabled = ncclProfilerPluginLoaded() && ((p2pTasks[0] ? p2pTasks[0] : p2pTasks[1])->eActivationMask & ncclProfileKernelCh);
+  work->recvBytes = recvBytes == -1 ? 0 : recvBytes;
+  work->profilerEnabled =
+    ncclProfilerPluginLoaded() && ((p2pTasks[0] ? p2pTasks[0] : p2pTasks[1])->eActivationMask & ncclProfileKernelCh);
   work->recvConnIndex = connIndex[0];
   work->recvOpCount = recvOpCount;
 
-  for (int dir=0; dir < nProxyOps; dir++) {
+  for (int dir = 0; dir < nProxyOps; dir++) {
     struct ncclProxyOp* op = &proxyOps[dir];
     op->root = dir ? sendRank : recvRank;
     op->sliceSteps = 1;
@@ -1305,7 +1333,7 @@ static ncclResult_t addP2pToPlan(
     op->eActivationMask = p2pTasks[dir] ? p2pTasks[dir]->eActivationMask : 0;
     op->connIndex = connIndex[dir];
     if (ncclProfilerProxyDiagEnabled()) {
-      op->coll =  dir ? ncclFuncSend : ncclFuncRecv;
+      op->coll = dir ? ncclFuncSend : ncclFuncRecv;
     }
     // The following are modified per channel part in addWorkToChannels():
     // op->buffer, op->nbytes, op->nsteps = ...;
@@ -1321,10 +1349,11 @@ static ncclResult_t addP2pToPlan(
   maxConcurrent = comm->p2pnChannels / nChannelsMax * NCCL_MAX_DEV_WORK_P2P_PER_BATCH;
   concurrentTasks[0] = std::min(planTotalTasks[0], maxConcurrent);
   concurrentTasks[1] = std::min(planTotalTasks[1], maxConcurrent);
-  for (int part=0; part < nChannelsMax; part++) {
+  for (int part = 0; part < nChannelsMax; part++) {
     int incWorkCounter = -1;
-    int channelId = ncclP2pChannelForPart(comm->p2pnChannels, base, part, comm->p2pnChannelsPerPeer, comm->nNodes, comm->p2pChannelShiftSize);
-    plan->channelMask.masks[channelId/64] |= uint64_t(1)<<(channelId%64);
+    int channelId = ncclP2pChannelForPart(comm->p2pnChannels, base, part, comm->p2pnChannelsPerPeer, comm->nNodes,
+                                          comm->p2pChannelShiftSize);
+    plan->channelMask.masks[channelId / 64] |= uint64_t(1) << (channelId % 64);
     // Add batch first.
     int funcIdx = ncclDevFuncId_P2p();
     addWorkBatchToPlan(comm, plan, channelId, ncclDevWorkTypeP2p, funcIdx, workOffset, p2pRound, batchP2P);
@@ -1333,7 +1362,7 @@ static ncclResult_t addP2pToPlan(
       return ncclInvalidUsage;
     }
     // Add proxy ops.
-    for (int dir=0; dir < nProxyOps; dir++) {
+    for (int dir = 0; dir < nProxyOps; dir++) {
       // Partition steps across channels.
       int nParts = dir ? work->nSendChannels : work->nRecvChannels;
       void* addr = dir ? work->sendAddr : work->recvAddr;
@@ -1357,8 +1386,8 @@ static ncclResult_t addP2pToPlan(
           proxyOps[dir].nbytes = partEnd - partBeg;
           proxyOps[dir].nsteps = DIVUP(proxyOps[dir].nbytes, NCCL_MAX_NET_SIZE);
         } else {
-          proxyOps[dir].nsteps = divUp(partEnd-partBeg, chunkDataSize);
-          proxyOps[dir].nbytes = std::min(partEnd-partBeg, chunkDataSize);
+          proxyOps[dir].nsteps = divUp(partEnd - partBeg, chunkDataSize);
+          proxyOps[dir].nbytes = std::min(partEnd - partBeg, chunkDataSize);
         }
         if (proxyOps[dir].protocol == NCCL_PROTO_LL) {
           proxyOps[dir].nbytes *= 2;
@@ -1376,7 +1405,7 @@ static ncclResult_t addP2pToPlan(
         // Calculate the opCount after adding batch since then the batch count will
         // equal one plus the batch index this p2p settled in.
         proxyOps[dir].channelId = channelId;
-        proxyOps[dir].opCount = uint64_t(comm->planner.wipPlan.channels[channelId].nWorkBatchesP2p)<<1 | 1;
+        proxyOps[dir].opCount = uint64_t(comm->planner.wipPlan.channels[channelId].nWorkBatchesP2p) << 1 | 1;
         proxyOps[dir].nChannels = nChannels[dir];
         proxyOps[dir].nPeers = concurrentTasks[dir];
         NCCLCHECKGOTO(ncclAddProxyOpIfNeeded(comm, plan, &proxyOps[dir]), ret, cleanup);
@@ -1393,16 +1422,15 @@ cleanup:
 static int calcP2pChannelCount(size_t totalSize, int minChannels, int maxChannels, size_t minSize, size_t maxSize) {
   size_t size = std::max(minSize, divUp(totalSize, minChannels));
   int nChannels = minChannels;
-  while (size > maxSize && nChannels <= maxChannels/2) {
+  while (size > maxSize && nChannels <= maxChannels / 2) {
     nChannels *= 2;
     size = divUp(totalSize, nChannels);
   }
   return nChannels;
 }
 
-static ncclResult_t scheduleP2pTasksToPlan(
-    struct ncclComm* comm, int* p2pEpoch, int* p2pRound, struct ncclKernelPlan* plan, struct ncclKernelPlanBudget* budget
-  ) {
+static ncclResult_t scheduleP2pTasksToPlan(struct ncclComm* comm, int* p2pEpoch, int* p2pRound,
+                                           struct ncclKernelPlan* plan, struct ncclKernelPlanBudget* budget) {
   int nRanks = comm->nRanks;
   struct ncclKernelPlanner::Peer* peers = comm->planner.peers;
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
@@ -1420,7 +1448,7 @@ static ncclResult_t scheduleP2pTasksToPlan(
   int nChannelsMax = comm->p2pnChannelsPerPeer;
   int nChannelsMin = nChannelsMax;
   // Try to use all channels, but one channel per operation.
-  while (nChannelsMin*nRanks > comm->p2pnChannels && nChannelsMin > 1) nChannelsMin /= 2;
+  while (nChannelsMin * nRanks > comm->p2pnChannels && nChannelsMin > 1) nChannelsMin /= 2;
 
   // Save the total count of send/recv tasks in the plan
   int planTotalTasks[2] = {comm->planner.nTasksP2pRecv, comm->planner.nTasksP2pSend};
@@ -1459,11 +1487,14 @@ static ncclResult_t scheduleP2pTasksToPlan(
         comm->planner.nTasksP2pRecv -= 1;
       } else {
         // Ensure room for worst case of one new batch per channel.
-        if (!ncclTestBudget(budget, plan->nWorkBatches+nChannelsMax, plan->workBytes + sizeof(struct ncclDevWorkP2p))) {
+        if (!ncclTestBudget(budget, plan->nWorkBatches + nChannelsMax,
+                            plan->workBytes + sizeof(struct ncclDevWorkP2p))) {
           return ncclSuccess;
         }
-        struct ncclTaskP2p* p2pTasks[2] = { recv, send };
-        NCCLCHECK(addP2pToPlan(comm, plan, nChannelsMin, nChannelsMax, *p2pRound, sendRank, sendBuff, sendBytes, recvRank, recvBuff, recvBytes, send ? send->opCount : 0, recv ? recv->opCount : 0, planTotalTasks, p2pTasks));
+        struct ncclTaskP2p* p2pTasks[2] = {recv, send};
+        NCCLCHECK(addP2pToPlan(comm, plan, nChannelsMin, nChannelsMax, *p2pRound, sendRank, sendBuff, sendBytes,
+                               recvRank, recvBuff, recvBytes, send ? send->opCount : 0, recv ? recv->opCount : 0,
+                               planTotalTasks, p2pTasks));
         if (send != nullptr) {
           ncclIntruQueueDequeue(&peers[sendRank].sendQueue);
           // Profiler - We can overwrite groupAPI event handles here since all operations here belong to the same group
@@ -1482,7 +1513,7 @@ static ncclResult_t scheduleP2pTasksToPlan(
         }
       }
     }
-    *p2pRound=0;
+    *p2pRound = 0;
     (*p2pEpoch)++;
   }
   return ncclSuccess;
@@ -1510,9 +1541,11 @@ static ncclResult_t waitWorkFifoAvailable(struct ncclComm* comm, uint32_t desire
       if (warned == 0 && count == 100000 && comm->rank == 0) {
         warned = 1;
         WARN("Waiting for work FIFO to become available. "
-            "Work fifo exhaustion can happen in large scale/high iteration count of alltoall. "
-            "In order to increase work FIFO size, set NCCL_WORK_FIFO_BYTES to higher number (current: %" PRId32 ").\n\n"
-            "RCCL continues to retry...", comm->workFifoBytes);
+             "Work fifo exhaustion can happen in large scale/high iteration count of alltoall. "
+             "In order to increase work FIFO size, set NCCL_WORK_FIFO_BYTES to higher number (current: %" PRId32
+             ").\n\n"
+             "RCCL continues to retry...",
+             comm->workFifoBytes);
       }
     }
   }
@@ -1520,26 +1553,24 @@ static ncclResult_t waitWorkFifoAvailable(struct ncclComm* comm, uint32_t desire
 }
 
 namespace {
-  struct uploadWork_cleanup_t {
-    struct ncclCommEventCallback base;
-    void *hostBuf;
-  };
-  ncclResult_t uploadWork_cleanup_fn(
-      struct ncclComm* comm, struct ncclCommEventCallback* cb
-    ) {
-    struct uploadWork_cleanup_t* me = (struct uploadWork_cleanup_t*)cb;
-    ncclOsAlignedFree(me->hostBuf);
-    CUDACHECK(cudaEventDestroy(me->base.event));
-    free(me);
-    return ncclSuccess;
-  }
+struct uploadWork_cleanup_t {
+  struct ncclCommEventCallback base;
+  void* hostBuf;
+};
+ncclResult_t uploadWork_cleanup_fn(struct ncclComm* comm, struct ncclCommEventCallback* cb) {
+  struct uploadWork_cleanup_t* me = (struct uploadWork_cleanup_t*)cb;
+  ncclOsAlignedFree(me->hostBuf);
+  CUDACHECK(cudaEventDestroy(me->base.event));
+  free(me);
+  return ncclSuccess;
 }
+} // namespace
 
 static ncclResult_t uploadWork(struct ncclComm* comm, struct ncclKernelPlan* plan) {
   if (plan->isSymColl || plan->isCeColl || plan->isRma) return ncclSuccess;
 
   size_t workBytes = plan->workBytes;
-  size_t batchBytes = plan->nWorkBatches*sizeof(struct ncclDevWorkBatch);
+  size_t batchBytes = plan->nWorkBatches * sizeof(struct ncclDevWorkBatch);
   void* fifoBufHost;
   uint32_t fifoCursor, fifoMask;
 
@@ -1553,19 +1584,19 @@ static ncclResult_t uploadWork(struct ncclComm* comm, struct ncclKernelPlan* pla
   case ncclDevWorkStorageTypeFifo:
     fifoBufHost = comm->workFifoBuf;
     fifoCursor = comm->workFifoProduced;
-    fifoMask = comm->workFifoBytes-1;
+    fifoMask = comm->workFifoBytes - 1;
     NCCLCHECK(waitWorkFifoAvailable(comm, fifoCursor + workBytes));
     plan->kernelArgs->workBuf = comm->workFifoBufDev;
     break;
   case ncclDevWorkStorageTypePersistent:
-    // We rely on 16-byte alignment. Use aligned alloc when available (C++11+ or MSVC with /std:c++11+).
-    // MSVC keeps __cplusplus at 199711L
-    #if (__cplusplus >= 201103L) || (defined(_MSC_VER) && _MSVC_LANG >= 201103L)
+// We rely on 16-byte alignment. Use aligned alloc when available (C++11+ or MSVC with /std:c++11+).
+// MSVC keeps __cplusplus at 199711L
+#if (__cplusplus >= 201103L) || (defined(_MSC_VER) && _MSVC_LANG >= 201103L)
     fifoBufHost = ncclOsAlignedAlloc(16, ROUNDUP(workBytes, 16));
-    #else
+#else
     static_assert(16 <= alignof(max_align_t), "We rely on 16-byte alignment.");
     fifoBufHost = malloc(workBytes);
-    #endif
+#endif
     if (fifoBufHost == nullptr) {
       WARN("Failed to allocate %zu bytes for work FIFO buffer", workBytes);
       return ncclSystemError;
@@ -1583,8 +1614,8 @@ static ncclResult_t uploadWork(struct ncclComm* comm, struct ncclKernelPlan* pla
   //  ncclDevWorkStorageTypeArgs: offset from beginning of kernel args
   //  ncclDevWorkStorageTypeFifo: offset from base of fifo
   //  ncclDevWorkStorageTypePersistent: no translation since our dedicated buffer will also begin at zero.
-  struct ncclDevWorkBatch* batchZero = (struct ncclDevWorkBatch*)(plan->kernelArgs+1);
-  for (int b=0; b < plan->nWorkBatches; b++) {
+  struct ncclDevWorkBatch* batchZero = (struct ncclDevWorkBatch*)(plan->kernelArgs + 1);
+  for (int b = 0; b < plan->nWorkBatches; b++) {
     batchZero[b].offsetBase += fifoCursor;
   }
 
@@ -1592,13 +1623,9 @@ static ncclResult_t uploadWork(struct ncclComm* comm, struct ncclKernelPlan* pla
   struct ncclWorkList* workNode = ncclIntruQueueHead(&plan->workQueue);
   while (workNode != nullptr) {
     char* dst = (char*)fifoBufHost;
-    char* src = (char*)(workNode+1);
+    char* src = (char*)(workNode + 1);
     for (int n = workNode->size; n != 0; n -= 16) {
-      memcpy(
-        COMPILER_ASSUME_ALIGNED(dst + (fifoCursor & fifoMask), 16),
-        COMPILER_ASSUME_ALIGNED(src, 16),
-        16
-      );
+      memcpy(COMPILER_ASSUME_ALIGNED(dst + (fifoCursor & fifoMask), 16), COMPILER_ASSUME_ALIGNED(src, 16), 16);
       fifoCursor += 16;
       src += 16;
     }
@@ -1611,7 +1638,8 @@ static ncclResult_t uploadWork(struct ncclComm* comm, struct ncclKernelPlan* pla
     if (comm->workFifoBufGdrHandle != nullptr) wc_store_fence();
     break;
   case ncclDevWorkStorageTypePersistent:
-    { ncclResult_t result = ncclSuccess;
+    {
+      ncclResult_t result = ncclSuccess;
       struct uploadWork_cleanup_t* cleanup = nullptr;
       cudaStreamCaptureMode mode = cudaStreamCaptureModeRelaxed;
       void* fifoBufDev = nullptr;
@@ -1621,7 +1649,9 @@ static ncclResult_t uploadWork(struct ncclComm* comm, struct ncclKernelPlan* pla
 
       // Acquire deviceStream. Since the user's graph will be launched later and it also
       // acquires the deviceStream, it will observe this upload.
-      NCCLCHECKGOTO(ncclStrongStreamAcquire(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->deviceStream, /*concurrent=*/false, &deviceStream), result, fail);
+      NCCLCHECKGOTO(ncclStrongStreamAcquire(ncclCudaGraphNone(comm->config.graphUsageMode),
+                                            &comm->sharedRes->deviceStream, /*concurrent=*/false, &deviceStream),
+                    result, fail);
 
       CUDACHECKGOTO(cudaMallocAsync(&fifoBufDev, workBytes, comm->memPool, deviceStream), result, fail);
       plan->workBufPersistent = fifoBufDev;
@@ -1637,9 +1667,11 @@ static ncclResult_t uploadWork(struct ncclComm* comm, struct ncclKernelPlan* pla
       cleanup->base.fn = uploadWork_cleanup_fn;
       cleanup->base.event = memcpyDone;
       cleanup->hostBuf = fifoBufHost;
-      ncclIntruQueueEnqueue(&comm->eventCallbackQueue, (struct ncclCommEventCallback *)cleanup);
+      ncclIntruQueueEnqueue(&comm->eventCallbackQueue, (struct ncclCommEventCallback*)cleanup);
 
-      NCCLCHECKGOTO(ncclStrongStreamRelease(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->deviceStream, /*concurrent=*/false), result, fail);
+      NCCLCHECKGOTO(ncclStrongStreamRelease(ncclCudaGraphNone(comm->config.graphUsageMode),
+                                            &comm->sharedRes->deviceStream, /*concurrent=*/false),
+                    result, fail);
       NCCLCHECKGOTO(ncclCommPollEventCallbacks(comm, /*waitSome=*/false), result, fail);
 
     finish_scope:
@@ -1648,13 +1680,15 @@ static ncclResult_t uploadWork(struct ncclComm* comm, struct ncclKernelPlan* pla
     fail:
       if (!cleanup) ncclOsAlignedFree(fifoBufHost);
       goto finish_scope;
-    } break;
-  default: break;
+    }
+    break;
+  default:
+    break;
   }
   return ncclSuccess;
 }
 
-static int geteActivationMask(struct ncclProxyOp * op) {
+static int geteActivationMask(struct ncclProxyOp* op) {
   if (ncclFuncSendRecv <= op->coll && op->coll <= ncclFuncRecv) {
     return op->task.p2p->eActivationMask;
   }
@@ -1664,7 +1698,7 @@ static int geteActivationMask(struct ncclProxyOp * op) {
   return op->task.coll->eActivationMask;
 }
 
-static void *gettaskEventHandle(struct ncclProxyOp * op) {
+static void* gettaskEventHandle(struct ncclProxyOp* op) {
   if (ncclFuncSendRecv <= op->coll && op->coll <= ncclFuncRecv) {
     return op->task.p2p->eventHandle;
   }
@@ -1695,11 +1729,11 @@ static ncclResult_t uploadProxyOps(struct ncclComm* comm, struct ncclKernelPlan*
     if (oldId & 1) { // p2p
       // opCount is monotonic increasing within a plan's channel so just
       // remember last value to compute max.
-      p2pOpBump[op->channelId] = (oldId>>1) + 1; // +1 to ensure next plan doesn't collide
-      op->opCount = (comm->sharedRes->p2pOpCount[op->channelId]<<1) + oldId;
+      p2pOpBump[op->channelId] = (oldId >> 1) + 1; // +1 to ensure next plan doesn't collide
+      op->opCount = (comm->sharedRes->p2pOpCount[op->channelId] << 1) + oldId;
       hasp2p = 1;
     } else { // coll
-      op->opCount = (collOpCount<<1) + oldId;
+      op->opCount = (collOpCount << 1) + oldId;
     }
 
     NCCLCHECK(ncclProxySaveOp(comm, op, nullptr));
@@ -1708,7 +1742,7 @@ static ncclResult_t uploadProxyOps(struct ncclComm* comm, struct ncclKernelPlan*
   }
 
   if (hasp2p) {
-    for (int c=0; c < MAXCHANNELS; c++) {
+    for (int c = 0; c < MAXCHANNELS; c++) {
       // Advance channel's p2pOpCount by number of p2p's in this plan channel.
       comm->sharedRes->p2pOpCount[c] += p2pOpBump[c];
     }
@@ -1720,8 +1754,8 @@ static ncclResult_t hostStreamPlanTask(struct ncclComm* comm, struct ncclKernelP
   NCCLCHECK(ncclProfilerStartGroupEvent(plan));
   NCCLCHECK(ncclProfilerStartTaskEvents(plan));
   if (ncclIntruQueueHead(&plan->proxyOpQueue)) {
-    	NCCLCHECK(uploadProxyOps(comm, plan));
-    	NCCLCHECK(ncclProxyStart(comm));
+    NCCLCHECK(uploadProxyOps(comm, plan));
+    NCCLCHECK(ncclProxyStart(comm));
   }
   NCCLCHECK(ncclProfilerStopTaskEvents(plan));
   NCCLCHECK(ncclProfilerStopGroupEvent(plan));
@@ -1732,7 +1766,7 @@ static ncclResult_t hostStreamPlanTask(struct ncclComm* comm, struct ncclKernelP
   return ncclSuccess;
 }
 
-static void HIPRT_CB hostStreamPlanCallback(void *plan_) {
+static void HIPRT_CB hostStreamPlanCallback(void* plan_) {
   NCCL_NVTX3_FUNC_RANGE;
   struct ncclKernelPlan* plan = (struct ncclKernelPlan*)plan_;
   ncclResult_t result = hostStreamPlanTask(plan->comm, plan);
@@ -1819,18 +1853,23 @@ static void persistentDestructor(void* plans_) {
 NCCL_PARAM(LaunchOrderImplicit, "LAUNCH_ORDER_IMPLICIT", 0);
 
 namespace {
-  enum ncclImplicitOrder {
-    ncclImplicitOrderNone,
-    ncclImplicitOrderSerial,
-    ncclImplicitOrderLaunch
-  };
-}
+enum ncclImplicitOrder {
+  ncclImplicitOrderNone,
+  ncclImplicitOrderSerial,
+  ncclImplicitOrderLaunch
+};
+} // namespace
 
-static ncclResult_t getImplicitOrder(enum ncclImplicitOrder *mode, bool capturing, int driver=-1) {
+static ncclResult_t getImplicitOrder(enum ncclImplicitOrder* mode, bool capturing, int driver = -1) {
   if (ncclParamLaunchOrderImplicit()) {
 #if !defined(__HIP_PLATFORM_AMD__) || !defined(__HIPCC__)
-    if (driver < 0) { NCCLCHECK(ncclCudaDriverVersion(&driver)); }
-    if (capturing && driver < 12090) { *mode = ncclImplicitOrderSerial; return ncclSuccess; }
+    if (driver < 0) {
+      NCCLCHECK(ncclCudaDriverVersion(&driver));
+    }
+    if (capturing && driver < 12090) {
+      *mode = ncclImplicitOrderSerial;
+      return ncclSuccess;
+    }
     *mode = 12030 <= std::min<int>(CUDART_VERSION, driver) ? ncclImplicitOrderLaunch : ncclImplicitOrderSerial;
 #else
     *mode = ncclImplicitOrderSerial;
@@ -1849,22 +1888,21 @@ ncclResult_t ncclLaunchPrepare(struct ncclComm* comm) {
   // Operations from different plans will not be batched together. A new batch will be created for each new plan that is used to schedule the ops (see ncclAddWorkBatchToPlan).
   // For p2p ops, we further guarantee that ops from different epochs will not be batched together (to avoid hangs).
   // The p2pEpoch value is incremented in scheduleP2pTasksToPlan and its value is carried over from one plan to another (even if not strictly required)
-  int nPlans = 0, p2pEpoch=0, p2pRound=0;
+  int nPlans = 0, p2pEpoch = 0, p2pRound = 0;
 
   if (planner->nTasksColl + planner->nTasksP2p + planner->nTasksBcast != 0 ||
-      !ncclIntruQueueEmpty(&planner->collSymTaskQueue) ||
-      !ncclIntruQueueEmpty(&planner->collCeTaskQueue) ||
+      !ncclIntruQueueEmpty(&planner->collSymTaskQueue) || !ncclIntruQueueEmpty(&planner->collCeTaskQueue) ||
       planner->nTasksRma != 0) {
     do {
       memset(&planner->wipPlan, 0, sizeof(planner->wipPlan));
 
-      struct ncclKernelPlan* plan = ncclMemoryPoolAlloc<struct ncclKernelPlan>(&comm->memPool_ncclKernelPlan, &comm->memPermanent);
+      struct ncclKernelPlan* plan =
+        ncclMemoryPoolAlloc<struct ncclKernelPlan>(&comm->memPool_ncclKernelPlan, &comm->memPermanent);
       plan->comm = comm;
       plan->reclaimer.fn = reclaimPlan;
       plan->persistent = persistent;
       // finishPlan() promotes ncclDevWorkStorageType[Fifo|Persistent]->Args if the work can fit.
-      plan->workStorageType = persistent ? ncclDevWorkStorageTypePersistent
-                                         : ncclDevWorkStorageTypeFifo;
+      plan->workStorageType = persistent ? ncclDevWorkStorageTypePersistent : ncclDevWorkStorageTypeFifo;
 
       if (planner->nTasksRma != 0) {
         NCCLCHECKGOTO(scheduleRmaTasksToPlan(comm, plan), result, failure);
@@ -1889,8 +1927,8 @@ ncclResult_t ncclLaunchPrepare(struct ncclComm* comm) {
 
         if (comm->rank == 0) {
           const char* nvlsSync = comm->nvlsSupport ? "; CE synchronization with NVLS" : "";
-          INFO(NCCL_TUNING, "%s [Copy Engine]: %ld Bytes -> cudaMemcpy%s",
-            ncclFuncToString(task->func), task->count * ncclTypeSize(task->datatype), nvlsSync);
+          INFO(NCCL_TUNING, "%s [Copy Engine]: %ld Bytes -> cudaMemcpy%s", ncclFuncToString(task->func),
+               task->count * ncclTypeSize(task->datatype), nvlsSync);
         }
 
         ncclIntruQueueEnqueue(&planner->planQueue, plan);
@@ -1900,12 +1938,11 @@ ncclResult_t ncclLaunchPrepare(struct ncclComm* comm) {
       } else {
         if (!ncclIntruQueueEmpty(&planner->collSymTaskQueue)) {
           NCCLCHECKGOTO(ncclSymmetricTaskScheduler(comm, &planner->collSymTaskQueue, plan), result, failure);
-        }
-        else {
+        } else {
           struct ncclKernelPlanBudget budget;
           budget.inArgsBytes = comm->workArgsBytes - sizeof(struct ncclDevKernelArgs);
           // Non-persistent kernels fill up at most half of our fifo per kernel.
-          budget.outArgsBytes = plan->persistent ? (1<<30) : comm->workFifoBytes/2;
+          budget.outArgsBytes = plan->persistent ? (1 << 30) : comm->workFifoBytes / 2;
 
           // Drain coll tasks first. This is essential since we partition tasks based
           // on the work budget and p2p work isn't collective. If we were to drain p2p
@@ -1930,8 +1967,7 @@ ncclResult_t ncclLaunchPrepare(struct ncclComm* comm) {
         }
       }
     } while (planner->nTasksColl + planner->nTasksP2p + planner->nTasksBcast != 0 ||
-             !ncclIntruQueueEmpty(&planner->collSymTaskQueue) ||
-             !ncclIntruQueueEmpty(&planner->collCeTaskQueue) ||
+             !ncclIntruQueueEmpty(&planner->collSymTaskQueue) || !ncclIntruQueueEmpty(&planner->collCeTaskQueue) ||
              planner->nTasksRma != 0);
 
     struct ncclKernelPlan* planHead = ncclIntruQueueHead(&planner->planQueue);
@@ -1941,11 +1977,13 @@ ncclResult_t ncclLaunchPrepare(struct ncclComm* comm) {
 
     cudaStream_t launchStream = planner->streams->stream;
     cudaStream_t deviceStream, launchOrder;
-    NCCLCHECKGOTO(ncclStrongStreamAcquire(planner->capturingGraph, &comm->sharedRes->deviceStream, /*concurrent=*/false, &deviceStream), result, failure);
+    NCCLCHECKGOTO(ncclStrongStreamAcquire(planner->capturingGraph, &comm->sharedRes->deviceStream, /*concurrent=*/false,
+                                          &deviceStream),
+                  result, failure);
 
     if (persistent || planner->numStreams != 1) {
       // userStream[0] waits on each userStream[i]...
-      for (struct ncclCudaStreamList* l=planner->streams->next; l != nullptr; l = l->next) {
+      for (struct ncclCudaStreamList* l = planner->streams->next; l != nullptr; l = l->next) {
         CUDACHECKGOTO(cudaEventRecord(comm->sharedRes->scratchEvent, l->stream), result, failure);
         CUDACHECKGOTO(cudaStreamWaitEvent(launchStream, comm->sharedRes->scratchEvent, 0), result, failure);
       }
@@ -1973,21 +2011,26 @@ ncclResult_t ncclLaunchPrepare(struct ncclComm* comm) {
       // required if this is a graph capture, non-captured cannot be concurrent because that would violate
       // deterministic program order of launches.
       bool concurrent = capturing;
-      NCCLCHECKGOTO(ncclStrongStreamAcquire(planner->capturingGraph, &comm->context->launchOrder, concurrent, &launchOrder), result, failure);
+      NCCLCHECKGOTO(ncclStrongStreamAcquire(planner->capturingGraph, &comm->context->launchOrder, concurrent,
+                                            &launchOrder),
+                    result, failure);
       NCCLCHECKGOTO(ncclStreamWaitStream(launchStream, launchOrder, comm->sharedRes->scratchEvent), result, failure);
     }
 
-    if (!persistent && comm->sharedRes->persistentRefs) status = CUDACLEARERROR(cudaEventQuery(comm->sharedRes->hostStream.serialEvent));
+    if (!persistent && comm->sharedRes->persistentRefs)
+      status = CUDACLEARERROR(cudaEventQuery(comm->sharedRes->hostStream.serialEvent));
     if (persistent || ncclCudaLaunchBlocking || status == cudaErrorNotReady) {
       // We have to launch host tasks to push proxy args. We are careful to only
       // do this if necessary since host tasks impose a high performance cost in CUDA.
       bool acquired = false;
       cudaStream_t hostStream;
-      for (struct ncclKernelPlan* plan=planHead; plan != nullptr; plan = plan->next) {
+      for (struct ncclKernelPlan* plan = planHead; plan != nullptr; plan = plan->next) {
         if (plan->hasProxyOps) {
           if (!acquired) {
             acquired = true;
-            NCCLCHECKGOTO(ncclStrongStreamAcquire(planner->capturingGraph, &comm->sharedRes->hostStream, /*concurrent=*/false, &hostStream), result, failure);
+            NCCLCHECKGOTO(ncclStrongStreamAcquire(planner->capturingGraph, &comm->sharedRes->hostStream,
+                                                  /*concurrent=*/false, &hostStream),
+                          result, failure);
           }
           plan->isHostCbEnq = true;
           CUDACHECKGOTO(cudaLaunchHostFunc(hostStream, hostStreamPlanCallback, plan), result, failure);
@@ -1996,14 +2039,17 @@ ncclResult_t ncclLaunchPrepare(struct ncclComm* comm) {
       if (acquired) {
         // Make to-be-launched kernels dependent on just-launched host stream tasks.
         NCCLCHECKGOTO(ncclStreamWaitStream(launchStream, hostStream, comm->sharedRes->scratchEvent), result, failure);
-        NCCLCHECKGOTO(ncclStrongStreamRelease(planner->capturingGraph, &comm->sharedRes->hostStream, /*concurrent=*/false), result, failure);
+        NCCLCHECKGOTO(ncclStrongStreamRelease(planner->capturingGraph, &comm->sharedRes->hostStream,
+                                              /*concurrent=*/false),
+                      result, failure);
       }
     }
 
     if (persistent) {
       comm->sharedRes->persistentRefs += nPlans;
       comm->localPersistentRefs += nPlans;
-      NCCLCHECKGOTO(ncclCudaGraphAddDestructor(planner->capturingGraph, persistentDestructor, (void*)planHead), result, failure);
+      NCCLCHECKGOTO(ncclCudaGraphAddDestructor(planner->capturingGraph, persistentDestructor, (void*)planHead), result,
+                    failure);
     }
   }
 failure:
@@ -2027,12 +2073,13 @@ ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan
   ncclResult_t ret = ncclSuccess;
   struct ncclKernelPlanner* planner = &comm->planner;
   int nChannels = 0;
-  for (int i = 0; i < MAXCHANNELS/64; i++)
-    nChannels += countOneBits(plan->channelMask.masks[i]);
+  for (int i = 0; i < MAXCHANNELS / 64; i++) nChannels += countOneBits(plan->channelMask.masks[i]);
   void* sym = plan->kernelFn;
 #ifdef ENABLE_WARP_SPEED
   int warpsPerBlock = plan->threadPerBlock / comm->WarpSize;
-  nChannels = rcclWarpSpeedSupported(comm, plan) ? (nChannels / warpsPerBlock + ((nChannels % warpsPerBlock) != 0 ? 1 : 0)) : nChannels; // each CU can handle warpsPerBlock
+  nChannels = rcclWarpSpeedSupported(comm, plan) ?
+                (nChannels / warpsPerBlock + ((nChannels % warpsPerBlock) != 0 ? 1 : 0)) :
+                nChannels; // each CU can handle warpsPerBlock
 #endif
   dim3 grid = {(unsigned)nChannels, 1, 1};
   dim3 block = {(unsigned)plan->threadPerBlock, 1, 1};
@@ -2041,11 +2088,8 @@ ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan
 
   NCCLCHECK(ncclProfilerStartKernelLaunchEvent(plan, launchStream));
 
-  void* extra[] = {
-    CU_LAUNCH_PARAM_BUFFER_POINTER, plan->kernelArgs,
-    CU_LAUNCH_PARAM_BUFFER_SIZE, &plan->kernelArgsSize,
-    CU_LAUNCH_PARAM_END
-  };
+  void* extra[] = {CU_LAUNCH_PARAM_BUFFER_POINTER, plan->kernelArgs, CU_LAUNCH_PARAM_BUFFER_SIZE, &plan->kernelArgsSize,
+                   CU_LAUNCH_PARAM_END};
 
   auto event = latency_profiler::collTraceAquireEventBaseline(plan, launchStream);
 
@@ -2057,7 +2101,9 @@ ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan
 
   if (planner->numStreams == 1 && !plan->persistent) {
     latency_profiler::collTraceRecordStartEvent(comm, launchStream, event.get());
-    CUCHECKGOTO(cuLaunchKernel(fn, grid.x, grid.y, grid.z, block.x, block.y, block.z, smem, launchStream, nullptr, extra), ret, do_return);
+    CUCHECKGOTO(cuLaunchKernel(fn, grid.x, grid.y, grid.z, block.x, block.y, block.z, smem, launchStream, nullptr,
+                               extra),
+                ret, do_return);
     // doneEvent is recorded lazily by ncclLaunchPrepare on a detected stream change; no
     // per-launch hipEventRecord is needed here. lastStream/lastStreamValid bookkeeping is
     // still required so the next call's ncclLaunchPrepare can detect that change.
@@ -2069,7 +2115,7 @@ ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan
 
 #if !defined(__HIP_PLATFORM_AMD__) || !defined(__HIPCC__)
   if (CUDART_VERSION >= 11080 && driverVersion >= 11080) {
-  #if CUDART_VERSION >= 11080
+#if CUDART_VERSION >= 11080
     int compCap = comm->compCap;
     unsigned int clusterSize = (compCap >= 90) ? comm->config.cgaClusterSize : 0;
 
@@ -2094,14 +2140,14 @@ ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan
       launchAttrs[attrs].id = CU_LAUNCH_ATTRIBUTE_CLUSTER_SCHEDULING_POLICY_PREFERENCE;
       launchAttrs[attrs++].value.clusterSchedulingPolicyPreference = CU_CLUSTER_SCHEDULING_POLICY_SPREAD;
     }
-    #if CUDART_VERSION >= 12000
+#if CUDART_VERSION >= 12000
     if (compCap >= 90 && driverVersion >= 12000) {
       // Set the NCCL Mem Sync domain on CUDA 12.0 and later (sm90)
       launchAttrs[attrs].id = CU_LAUNCH_ATTRIBUTE_MEM_SYNC_DOMAIN;
-      launchAttrs[attrs++].value.memSyncDomain = (CUlaunchMemSyncDomain) ncclParamMemSyncDomain();
+      launchAttrs[attrs++].value.memSyncDomain = (CUlaunchMemSyncDomain)ncclParamMemSyncDomain();
     }
-    #endif
-    #if CUDART_VERSION >= 12030
+#endif
+#if CUDART_VERSION >= 12030
     enum ncclImplicitOrder implicitOrder;
     NCCLCHECKGOTO(getImplicitOrder(&implicitOrder, plan->persistent, driverVersion), ret, do_return);
     if (implicitOrder == ncclImplicitOrderLaunch) {
@@ -2115,14 +2161,14 @@ ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan
       launchAttrs[attrs].value.programmaticStreamSerializationAllowed = 1;
       attrs++;
     }
-    #endif
-    #if CUDART_VERSION >= 13000
+#endif
+#if CUDART_VERSION >= 13000
     if (compCap >= 100 && driverVersion >= 13000) {
       launchAttrs[attrs].id = CU_LAUNCH_ATTRIBUTE_NVLINK_UTIL_CENTRIC_SCHEDULING;
       launchAttrs[attrs].value.nvlinkUtilCentricScheduling = comm->config.nvlinkCentricSched;
       attrs++;
     }
-    #endif
+#endif
     launchConfig.gridDimX = grid.x;
     launchConfig.gridDimY = grid.y;
     launchConfig.gridDimZ = grid.z;
@@ -2137,17 +2183,20 @@ ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan
     latency_profiler::collTraceRecordStartEvent(comm, launchStream, event.get());
     CUCHECKGOTO(cuLaunchKernelEx(&launchConfig, fn, nullptr, extra), ret, do_return);
     latency_profiler::collTraceRecordEndEvent(comm, plan, launchStream, std::move(event));
-  #endif
+#endif
   } else {
     // Standard kernel launch
     latency_profiler::collTraceRecordStartEvent(comm, launchStream, event.get());
-    CUCHECKGOTO(cuLaunchKernel(fn, grid.x, grid.y, grid.z, block.x, block.y, block.z, smem, launchStream, nullptr, extra), ret, do_return);
+    CUCHECKGOTO(cuLaunchKernel(fn, grid.x, grid.y, grid.z, block.x, block.y, block.z, smem, launchStream, nullptr,
+                               extra),
+                ret, do_return);
     latency_profiler::collTraceRecordEndEvent(comm, plan, launchStream, std::move(event));
   }
 #endif
   // Standard kernel launch
   latency_profiler::collTraceRecordStartEvent(comm, launchStream, event.get());
-  CUCHECKGOTO(cuLaunchKernel(fn, grid.x, grid.y, grid.z, block.x, block.y, block.z, smem, launchStream, nullptr, extra), ret, do_return);
+  CUCHECKGOTO(cuLaunchKernel(fn, grid.x, grid.y, grid.z, block.x, block.y, block.z, smem, launchStream, nullptr, extra),
+              ret, do_return);
   latency_profiler::collTraceRecordEndEvent(comm, plan, launchStream, std::move(event));
   // Mirror fast-path bookkeeping so the next ncclLaunchPrepare can detect stream-change.
   // doneEvent is recorded lazily by ncclLaunchPrepare in the stream-change branch.
@@ -2175,20 +2224,18 @@ ncclResult_t ncclLaunchKernelAfter_NoCuda(struct ncclComm* comm, struct ncclKern
 }
 
 namespace {
-  struct KernelFinishCallback {
-    struct ncclCommEventCallback base;
-    uint32_t workFifoConsumed;
-  };
-  ncclResult_t KernelFinishCallback_fn(
-      struct ncclComm* comm, struct ncclCommEventCallback* cb
-    ) {
-    struct KernelFinishCallback* me = (struct KernelFinishCallback*)cb;
-    comm->workFifoConsumed = me->workFifoConsumed;
-    CUDACHECK(cudaEventDestroy(me->base.event));
-    free(me);
-    return ncclSuccess;
-  }
+struct KernelFinishCallback {
+  struct ncclCommEventCallback base;
+  uint32_t workFifoConsumed;
+};
+ncclResult_t KernelFinishCallback_fn(struct ncclComm* comm, struct ncclCommEventCallback* cb) {
+  struct KernelFinishCallback* me = (struct KernelFinishCallback*)cb;
+  comm->workFifoConsumed = me->workFifoConsumed;
+  CUDACHECK(cudaEventDestroy(me->base.event));
+  free(me);
+  return ncclSuccess;
 }
+} // namespace
 
 ncclResult_t ncclLaunchFinish(struct ncclComm* comm) {
   struct ncclKernelPlanner* planner = &comm->planner;
@@ -2202,7 +2249,7 @@ ncclResult_t ncclLaunchFinish(struct ncclComm* comm) {
     cudaStream_t deviceStream, launchOrder;
     cudaEvent_t finishedEvent = comm->sharedRes->scratchEvent;
 
-    if (comm->workFifoProduced - comm->workFifoProducedLastRecorded > comm->workFifoBytes/8) {
+    if (comm->workFifoProduced - comm->workFifoProducedLastRecorded > comm->workFifoBytes / 8) {
       comm->workFifoProducedLastRecorded = comm->workFifoProduced;
       struct KernelFinishCallback* cb;
       NCCLCHECK(ncclCalloc(&cb, 1));
@@ -2217,7 +2264,8 @@ ncclResult_t ncclLaunchFinish(struct ncclComm* comm) {
     if (capturing || planner->numStreams != 1 || ncclParamLaunchOrderImplicit()) {
       CUDACHECK(cudaEventRecord(finishedEvent, launchStream));
       // deviceStream waits on userStream[0]
-      NCCLCHECK(ncclStrongStreamAcquiredWorkStream(planner->capturingGraph, &comm->sharedRes->deviceStream, /*concurrent=*/false, &deviceStream));
+      NCCLCHECK(ncclStrongStreamAcquiredWorkStream(planner->capturingGraph, &comm->sharedRes->deviceStream,
+                                                   /*concurrent=*/false, &deviceStream));
 
       // We know that deviceStream is strictly behind the launchStream because launchStream
       // synced with it before kernel launch. This allows us to to see deviceStream waiting
@@ -2229,7 +2277,7 @@ ncclResult_t ncclLaunchFinish(struct ncclComm* comm) {
       NCCLCHECK(ncclStreamAdvanceToEvent(planner->capturingGraph, deviceStream, finishedEvent));
 
       // Each userStream[i] waits on userStream[0]
-      for (struct ncclCudaStreamList* l=planner->streams->next; l != nullptr; l = l->next) {
+      for (struct ncclCudaStreamList* l = planner->streams->next; l != nullptr; l = l->next) {
         CUDACHECK(cudaStreamWaitEvent(l->stream, finishedEvent, 0));
       }
     }
@@ -2239,9 +2287,11 @@ ncclResult_t ncclLaunchFinish(struct ncclComm* comm) {
       // As in ncclLaunchPrepare, strong stream can be non-concurrent when non-captured.
       bool concurrent = capturing;
       // Incorporate launch event into per-device (context) launch order.
-      NCCLCHECK(ncclStrongStreamAcquiredWorkStream(planner->capturingGraph, &comm->context->launchOrder, concurrent, &launchOrder));
+      NCCLCHECK(ncclStrongStreamAcquiredWorkStream(planner->capturingGraph, &comm->context->launchOrder, concurrent,
+                                                   &launchOrder));
       // If we don't have launch events (requires CUDA 12.3) then just use completion event (serialize execution).
-      CUDACHECK(cudaStreamWaitEvent(launchOrder, implicitOrder == ncclImplicitOrderLaunch ? comm->sharedRes->launchEvent : finishedEvent));
+      CUDACHECK(cudaStreamWaitEvent(
+        launchOrder, implicitOrder == ncclImplicitOrderLaunch ? comm->sharedRes->launchEvent : finishedEvent));
       // Release launchOrder as acquired in ncclLaunchPrepare()
       NCCLCHECK(ncclStrongStreamRelease(planner->capturingGraph, &comm->context->launchOrder, concurrent));
     }
@@ -2255,9 +2305,7 @@ ncclResult_t ncclLaunchFinish(struct ncclComm* comm) {
 /* Enqueueing system : computation of kernel and proxy operations parameters */
 /*****************************************************************************/
 
-ncclResult_t ncclGetCollNetSupport(
-    struct ncclComm* comm, struct ncclTaskColl* info, int* collNetSupport
-  ) {
+ncclResult_t ncclGetCollNetSupport(struct ncclComm* comm, struct ncclTaskColl* info, int* collNetSupport) {
   // Translate ncclAvg and PreMulSum
   ncclRedOp_t netOp = info->opHost;
   if (info->opDev.op == ncclDevPreMulSum || info->opDev.op == ncclDevSumPostDiv) {
@@ -2286,29 +2334,31 @@ static void initCollCostTable(float** collCostTable) {
 }
 
 // numPipeOps: number of pipelined ops. Can be greater than 1 in aggregation mode. Used to adjust latency.
-static ncclResult_t updateCollCostTable(
-    struct ncclComm* comm, struct ncclTaskColl* info, size_t nBytes,
-    int collNetSupport, int nvlsSupport, int numPipeOps,
-    int userAlgoInput,
-    float** collCostTable) {
+static ncclResult_t updateCollCostTable(struct ncclComm* comm, struct ncclTaskColl* info, size_t nBytes,
+                                        int collNetSupport, int nvlsSupport, int numPipeOps, int userAlgoInput,
+                                        float** collCostTable) {
   float (*table)[NCCL_NUM_PROTOCOLS] = (float (*)[NCCL_NUM_PROTOCOLS])collCostTable;
 
-  if (comm->nRanks == 1 || info->func == ncclFuncAlltoAllPivot || info->func == ncclFuncAlltoAllGda || info->func == ncclFuncAlltoAllvGda) {
+  if (comm->nRanks == 1 || info->func == ncclFuncAlltoAllPivot || info->func == ncclFuncAlltoAllGda ||
+      info->func == ncclFuncAlltoAllvGda) {
     table[NCCL_ALGO_RING][NCCL_PROTO_SIMPLE] = 0.0;
     return ncclSuccess;
   }
 
-  for (int a=0; a<NCCL_NUM_ALGORITHMS; a++) {
+  for (int a = 0; a < NCCL_NUM_ALGORITHMS; a++) {
     if ((a == NCCL_ALGO_COLLNET_DIRECT || a == NCCL_ALGO_COLLNET_CHAIN) && collNetSupport != 1) continue;
     // CollNetDirect is only supported for up to 8 local GPUs
-    if (a == NCCL_ALGO_COLLNET_DIRECT && comm->maxLocalRanks > NCCL_MAX_DIRECT_ARITY+1) continue;
+    if (a == NCCL_ALGO_COLLNET_DIRECT && comm->maxLocalRanks > NCCL_MAX_DIRECT_ARITY + 1) continue;
     // Disable CollNet Chain for more than 8 local GPUs
-    if (a == NCCL_ALGO_COLLNET_CHAIN && comm->maxLocalRanks > NCCL_MAX_DIRECT_ARITY+1) continue;
-    if ((a == NCCL_ALGO_NVLS || a == NCCL_ALGO_NVLS_TREE) && (!nvlsSupport || (info->func != ncclFuncAllReduce && comm->localRanks > NCCL_MAX_NVLS_ARITY))) continue;
+    if (a == NCCL_ALGO_COLLNET_CHAIN && comm->maxLocalRanks > NCCL_MAX_DIRECT_ARITY + 1) continue;
+    if ((a == NCCL_ALGO_NVLS || a == NCCL_ALGO_NVLS_TREE) &&
+        (!nvlsSupport || (info->func != ncclFuncAllReduce && comm->localRanks > NCCL_MAX_NVLS_ARITY)))
+      continue;
     if (a == NCCL_ALGO_NVLS && collNetSupport != 1 && comm->nNodes > 1) continue;
     /* Tree reduceScatter doesn't support scaling yet */
-    if (a == NCCL_ALGO_PAT && info->func == ncclFuncReduceScatter
-        && (info->opDev.op == ncclDevPreMulSum || info->opDev.op == ncclDevSumPostDiv)) continue;
+    if (a == NCCL_ALGO_PAT && info->func == ncclFuncReduceScatter &&
+        (info->opDev.op == ncclDevPreMulSum || info->opDev.op == ncclDevSumPostDiv))
+      continue;
     if (a == NCCL_ALGO_PAT && (info->func == ncclFuncReduceScatter || info->func == ncclFuncAllGather)) {
       if (!userAlgoInput) {
         int nNodes = comm->nNodes;
@@ -2332,7 +2382,7 @@ static ncclResult_t updateCollCostTable(
       userProtoInput = !protoEnv ? 0 : 1;
       userProtoInputCached = true;
     }
-    for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
+    for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) {
       if (p == NCCL_PROTO_LL128 && !(comm->topo->type & RCCL_TOPO_XGMI_ALL) && !userProtoInput) {
         table[a][p] = NCCL_ALGO_PROTO_IGNORE;
         continue;
@@ -2354,17 +2404,15 @@ static ncclResult_t updateCollCostTable(
 extern int64_t ncclParamMinNchannels();
 extern int64_t ncclParamMaxNchannels();
 
-static ncclResult_t topoGetAlgoInfo(
-    struct ncclComm* comm, struct ncclTaskColl* info, size_t nBytes,
-    float** collCostTable, ncclSimInfo_t* simInfo
-  ) {
+static ncclResult_t topoGetAlgoInfo(struct ncclComm* comm, struct ncclTaskColl* info, size_t nBytes,
+                                    float** collCostTable, ncclSimInfo_t* simInfo) {
   float (*table)[NCCL_NUM_PROTOCOLS] = (float (*)[NCCL_NUM_PROTOCOLS])collCostTable;
 
   float minTime = FLT_MAX;
   int algorithm = info->algorithm = NCCL_ALGO_UNDEF;
   int protocol = info->protocol = NCCL_PROTO_UNDEF;
-  for (int a=0; a<NCCL_NUM_ALGORITHMS; a++) {
-    for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
+  for (int a = 0; a < NCCL_NUM_ALGORITHMS; a++) {
+    for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) {
       if (table[a][p] == NCCL_ALGO_PROTO_IGNORE) continue;
       if (table[a][p] >= 0.0 && table[a][p] < minTime) {
         algorithm = a;
@@ -2373,12 +2421,12 @@ static ncclResult_t topoGetAlgoInfo(
       }
     }
   }
-  if(algorithm == NCCL_ALGO_UNDEF){
-    INFO(NCCL_INIT,"Optimal algorithm is not found in collCostTable, Setting it a default value NCCL_ALGO_RING");
+  if (algorithm == NCCL_ALGO_UNDEF) {
+    INFO(NCCL_INIT, "Optimal algorithm is not found in collCostTable, Setting it a default value NCCL_ALGO_RING");
     algorithm = NCCL_ALGO_RING;
   }
-  if(protocol == NCCL_PROTO_UNDEF){
-    INFO(NCCL_INIT,"Optimal protocol is not found in collCostTable, Setting it a default value NCCL_PROTO_SIMPLE");
+  if (protocol == NCCL_PROTO_UNDEF) {
+    INFO(NCCL_INIT, "Optimal protocol is not found in collCostTable, Setting it a default value NCCL_PROTO_SIMPLE");
     protocol = NCCL_PROTO_SIMPLE;
   }
 
@@ -2402,7 +2450,8 @@ static ncclResult_t topoGetAlgoInfo(
     if (protoEnv) {
       snprintf(ncclProtoEnvStr, 1023, " NCCL_PROTO was set to %s.", protoEnv);
     }
-    WARN("No algorithm/protocol available for function %s with datatype %s.%s%s", ncclFuncToString(info->func), ncclDatatypeToString(info->datatype), ncclAlgoEnvStr, ncclProtoEnvStr);
+    WARN("No algorithm/protocol available for function %s with datatype %s.%s%s", ncclFuncToString(info->func),
+         ncclDatatypeToString(info->datatype), ncclAlgoEnvStr, ncclProtoEnvStr);
     return (algoEnv || protoEnv) ? ncclInvalidUsage : ncclInternalError;
   }
   // Honor Tuner config if available
@@ -2414,11 +2463,13 @@ static ncclResult_t topoGetAlgoInfo(
   TRACE(NCCL_COLL, "%ld Bytes -> Algo %d proto %d time %f", nBytes, info->algorithm, info->protocol, time);
   int nc = comm->nChannels;
 #ifdef ENABLE_WARP_SPEED
-  if(comm->topo->warpSpeedEnabled) {
+  if (comm->topo->warpSpeedEnabled) {
     nc /= comm->warpSpeedChannelMultiplier;
     // Temporary check as we reduce CU usage for all collectives
     // TODO: Remove this condition after optimizing all collectives
-    if(IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950") && comm->nNodes == 1 && comm->nRanks == 8 && info->func != ncclFuncAllReduce && info->func != ncclFuncAllGather && info->func != ncclFuncReduceScatter && ncclParamMaxNchannels() < 0) {
+    if (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950") && comm->nNodes == 1 && comm->nRanks == 8 &&
+        info->func != ncclFuncAllReduce && info->func != ncclFuncAllGather && info->func != ncclFuncReduceScatter &&
+        ncclParamMaxNchannels() < 0) {
       nc *= 2;
     }
   }
@@ -2430,8 +2481,8 @@ static ncclResult_t topoGetAlgoInfo(
     int ncSwitch = 16;
     bool flag = true;
     while (ncSwitch >= 1 && flag) {
-      while ((flag = nBytes < nc*nt*comm->channels[0].collnetDirect.nHeads*threadThreshold) && nc > ncSwitch) {
-        if (nc == ncSwitch+ncSwitch/2) threadThreshold /= 2;
+      while ((flag = nBytes < nc * nt * comm->channels[0].collnetDirect.nHeads * threadThreshold) && nc > ncSwitch) {
+        if (nc == ncSwitch + ncSwitch / 2) threadThreshold /= 2;
         nc--;
       }
       ncSwitch /= 2;
@@ -2461,8 +2512,8 @@ static ncclResult_t topoGetAlgoInfo(
     int minNChannels = ncclParamMinNchannels();
     // Ring/Tree channel tuning
     INFO(NCCL_TUNING, "minNChannels:%i", minNChannels);
-    if(nBytes < nc * nt * threadThreshold && nc > minNChannels){
-      nc = std::max(1,std::max(minNChannels,(int)(nBytes/std::max(1,nt * threadThreshold))));
+    if (nBytes < nc * nt * threadThreshold && nc > minNChannels) {
+      nc = std::max(1, std::max(minNChannels, (int)(nBytes / std::max(1, nt * threadThreshold))));
     }
     INFO(NCCL_TUNING, "post-adjustment based on threadThreshold:%i nBytes:%lu nc:%i", threadThreshold, nBytes, nc);
     rcclOverrideChannels(comm, info->func, nBytes, nc);
@@ -2470,14 +2521,14 @@ static ncclResult_t topoGetAlgoInfo(
 
 #ifdef ENABLE_ROCSHMEM
   if (info->func == ncclFuncAlltoAllvGda || info->func == ncclFuncAlltoAllGda) {
-      nc = 1;
+    nc = 1;
   }
 #endif
 
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
 #else
   if (info->algorithm != NCCL_ALGO_NVLS && info->algorithm != NCCL_ALGO_NVLS_TREE &&
-    info->algorithm != NCCL_ALGO_COLLNET_DIRECT) {
+      info->algorithm != NCCL_ALGO_COLLNET_DIRECT) {
     while (nBytes < nc * nt * threadThreshold) {
       if (nt % 128 == 0) nt /= 2;
       else break;
@@ -2486,19 +2537,17 @@ static ncclResult_t topoGetAlgoInfo(
   if (info->protocol == NCCL_PROTO_SIMPLE) {
     if (info->algorithm == NCCL_ALGO_RING) nt += comm->WarpSize; // Extra warp for sync
     // More threads or sync warps needed due to split thread model
-    if (info->algorithm == NCCL_ALGO_TREE) nt += 4*comm->WarpSize;
+    if (info->algorithm == NCCL_ALGO_TREE) nt += 4 * comm->WarpSize;
   }
-  nt = nt/comm->WarpSize < 3 ? 3*comm->WarpSize : nt;
+  nt = nt / comm->WarpSize < 3 ? 3 * comm->WarpSize : nt;
 #endif
   if (info->func == ncclFuncAllReduce && comm->topo->pivotA2ANumBiRings == 3) {
     static int userTuneInput = -2;
     if (userTuneInput == -2) {
-      const char *protoStr = getenv("NCCL_PROTO");
-      const char *algoStr = getenv("NCCL_ALGO");
-      if (!protoStr && !algoStr)
-        userTuneInput = 0;
-      else
-        userTuneInput = 1;
+      const char* protoStr = getenv("NCCL_PROTO");
+      const char* algoStr = getenv("NCCL_ALGO");
+      if (!protoStr && !algoStr) userTuneInput = 0;
+      else userTuneInput = 1;
     }
     info->nMaxChannels = nc;
     if (!userTuneInput) {
@@ -2527,15 +2576,15 @@ static ncclResult_t topoGetAlgoInfo(
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
 #else
   if (info->algorithm == NCCL_ALGO_TREE) nt = NCCL_MAX_NTHREADS; // Tree now uses all threads always.
-  if (info->algorithm == NCCL_ALGO_PAT)  nt = NCCL_MAX_NTHREADS;
+  if (info->algorithm == NCCL_ALGO_PAT) nt = NCCL_MAX_NTHREADS;
 #endif
   rcclOptThreadBlockSize(comm, info, nBytes, nt);
-  info->nWarps = nt/comm->WarpSize;
+  info->nWarps = nt / comm->WarpSize;
   rcclOverrideAlgorithm(ncclAlgoStr, table, info);
   rcclOverrideProtocol(ncclProtoStr, table, info);
 #ifdef ENABLE_WARP_SPEED
   NCCLCHECK(rcclSetWarpSpeedAuto(comm, info, nBytes));
-  if(info->useWarpSpeed) {
+  if (info->useWarpSpeed) {
     rcclSetWarpSpeedCUs(comm, info->algorithm, info->nWarps * comm->WarpSize, nc);
   }
   info->nMaxChannels = nc;
@@ -2547,10 +2596,9 @@ static ncclResult_t topoGetAlgoInfo(
 // Call the plugin first. Let it set algo+proto, and/or nChannels.
 // Then, topoGetAlgoInfo will set algo/proto if not set, then nChannels and nThreads based on algo/proto.
 // Finally, nChannels will be overriden by the plugin setting.
-rccl_static ncclResult_t getAlgoInfo(
-    struct ncclComm* comm, struct ncclTaskColl* info,
-    int collNetSupport, int nvlsSupport, int numPipeOps, ncclSimInfo_t* simInfo/* = NULL*/
-  ) {
+rccl_static ncclResult_t getAlgoInfo(struct ncclComm* comm, struct ncclTaskColl* info, int collNetSupport,
+                                     int nvlsSupport, int numPipeOps, ncclSimInfo_t* simInfo /* = NULL*/
+) {
   size_t elementSize = ncclTypeSize(info->datatype);
   size_t nBytes = elementSize * ncclFuncMaxSendRecvCount(info->func, comm->nRanks, info->count);
   struct ncclReg* regSendBuf = NULL;
@@ -2569,45 +2617,51 @@ rccl_static ncclResult_t getAlgoInfo(
     const char* algoEnv = ncclGetEnv("NCCL_ALGO");
     userAlgoInput = !algoEnv ? 0 : 1;
   }
-  initCollCostTable((float **)collCostTable);
-  NCCLCHECK(updateCollCostTable(comm, info, nBytes, collNetSupport, nvlsSupport, numPipeOps, userAlgoInput, (float **)collCostTable));
+  initCollCostTable((float**)collCostTable);
+  NCCLCHECK(updateCollCostTable(comm, info, nBytes, collNetSupport, nvlsSupport, numPipeOps, userAlgoInput,
+                                (float**)collCostTable));
   if (comm->tuner != NULL) {
     NCCLCHECK(ncclRegFind(comm, info->sendbuff, sendbuffSize, &regSendBuf));
     NCCLCHECK(ncclRegFind(comm, info->recvbuff, recvbuffSize, &regRecvBuf));
     NCCLCHECK(ncclRegLocalIsValid(regSendBuf, &isSendValid));
     NCCLCHECK(ncclRegLocalIsValid(regRecvBuf, &isRecvValid));
-    regBuff = (regSendBuf && regRecvBuf && isSendValid && isRecvValid) || (ncclCudaGraphValid(comm->planner.capturingGraph) && ncclParamGraphRegister());
-    NCCLCHECK(comm->tuner->getCollInfo(
-          comm->tunerContext, info->func, nBytes,
-          numPipeOps, (float **)collCostTable, NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS,
-          regBuff, &nMaxChannels));
-    NCCLCHECK(topoGetAlgoInfo(comm, info, nBytes, (float **)collCostTable, simInfo));
+    regBuff = (regSendBuf && regRecvBuf && isSendValid && isRecvValid) ||
+              (ncclCudaGraphValid(comm->planner.capturingGraph) && ncclParamGraphRegister());
+    NCCLCHECK(comm->tuner->getCollInfo(comm->tunerContext, info->func, nBytes, numPipeOps, (float**)collCostTable,
+                                       NCCL_NUM_ALGORITHMS, NCCL_NUM_PROTOCOLS, regBuff, &nMaxChannels));
+    NCCLCHECK(topoGetAlgoInfo(comm, info, nBytes, (float**)collCostTable, simInfo));
   } else {
-    NCCLCHECK(topoGetAlgoInfo(comm, info, nBytes, (float **)collCostTable, simInfo));
-    //override algo, tree doesn't work with fewer than 64 bytes
+    NCCLCHECK(topoGetAlgoInfo(comm, info, nBytes, (float**)collCostTable, simInfo));
+    // override algo, tree doesn't work with fewer than 64 bytes
     size_t sizePerRank = rcclGetSizePerRank(info->func, nBytes, comm->nRanks);
-    if (!userAlgoInput && IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950") && comm->nNodes == 1 && (info->func == ncclFuncAllReduce) && sizePerRank >= 64 && sizePerRank <= 262144){
+    if (!userAlgoInput && IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950") && comm->nNodes == 1 &&
+        (info->func == ncclFuncAllReduce) && sizePerRank >= 64 && sizePerRank <= 262144) {
       info->algorithm = NCCL_ALGO_TREE;
       info->protocol = NCCL_PROTO_LL;
     }
 
-    if(!userAlgoInput && (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx1200") || IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx1201")) && comm->nNodes == 1 && (info->func == ncclFuncAllReduce)) {
-       info->algorithm = NCCL_ALGO_RING; // for Navi RING algo always performs better than Tree based on data.
+    if (!userAlgoInput &&
+        (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx1200") ||
+         IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx1201")) &&
+        comm->nNodes == 1 && (info->func == ncclFuncAllReduce)) {
+      info->algorithm = NCCL_ALGO_RING; // for Navi RING algo always performs better than Tree based on data.
     }
 
     // NCCL_CTA_POLICY_EFFICIENCY requires user (non-symmetric) buffer registration (currently unsupported with MNNVL)
-    if (comm->config.CTAPolicy == NCCL_CTA_POLICY_EFFICIENCY && !userAlgoInput && ncclGetEnv("NCCL_PROTO") == NULL && !comm->MNNVL) {
+    if (comm->config.CTAPolicy == NCCL_CTA_POLICY_EFFICIENCY && !userAlgoInput && ncclGetEnv("NCCL_PROTO") == NULL &&
+        !comm->MNNVL) {
       // make algorithm selection based on buffer registration
       // there can be other specialized policies for algorithms and protocols pickup in the future
       NCCLCHECK(ncclRegFind(comm, info->sendbuff, sendbuffSize, &regSendBuf));
       NCCLCHECK(ncclRegFind(comm, info->recvbuff, recvbuffSize, &regRecvBuf));
       NCCLCHECK(ncclRegLocalIsValid(regSendBuf, &isSendValid));
       NCCLCHECK(ncclRegLocalIsValid(regRecvBuf, &isRecvValid));
-      regBuff = (regSendBuf && regRecvBuf && isSendValid && isRecvValid) || (ncclCudaGraphValid(comm->planner.capturingGraph) && ncclParamGraphRegister());
+      regBuff = (regSendBuf && regRecvBuf && isSendValid && isRecvValid) ||
+                (ncclCudaGraphValid(comm->planner.capturingGraph) && ncclParamGraphRegister());
       if (regBuff && (info->func == ncclFuncAllGather || info->func == ncclFuncReduceScatter)) {
         if ((comm->nNodes > 1 && collNetSupport && nvlsSupport) || (comm->nNodes == 1 && nvlsSupport)) {
           int recChannels = info->nMaxChannels + 1; // RCCL: We can revisit this logic later.
-          //RCCL: NCCLCHECK(ncclNvlsRegResourcesQuery(comm, info, &recChannels));
+          // RCCL: NCCLCHECK(ncclNvlsRegResourcesQuery(comm, info, &recChannels));
           if (recChannels <= info->nMaxChannels) {
             info->algorithm = NCCL_ALGO_NVLS;
             info->protocol = NCCL_PROTO_SIMPLE;
@@ -2626,10 +2680,8 @@ rccl_static ncclResult_t getAlgoInfo(
 // External entry point matching the declaration in include/enqueue.h.
 // Forwards to RCCL's getAlgoInfo so out-of-TU callers (e.g. the scheduler
 // sources synced from upstream NCCL) can link.
-ncclResult_t ncclGetAlgoInfo(
-    struct ncclComm* comm, struct ncclTaskColl* task,
-    int collNetSupport, int nvlsSupport, int numPipeOps, ncclSimInfo_t* simInfo
-  ) {
+ncclResult_t ncclGetAlgoInfo(struct ncclComm* comm, struct ncclTaskColl* task, int collNetSupport, int nvlsSupport,
+                             int numPipeOps, ncclSimInfo_t* simInfo) {
   return getAlgoInfo(comm, task, collNetSupport, nvlsSupport, numPipeOps, simInfo);
 }
 
@@ -2638,16 +2690,14 @@ ncclResult_t ncclGetAlgoInfo(
 // RCCL's equivalents (static addWorkBatchToPlan, file-local ncclKerns table)
 // aren't reachable from sources synced verbatim from upstream NCCL.
 
-void ncclAddWorkBatchToPlan(
-    struct ncclComm* comm, struct ncclKernelPlan* plan, int channelId,
-    enum ncclDevWorkType workType, int devFuncId, uint32_t workOffset,
-    int /*p2pEpoch*/, int p2pRound, bool /*newBatch*/
-  ) {
+void ncclAddWorkBatchToPlan(struct ncclComm* comm, struct ncclKernelPlan* plan, int channelId,
+                            enum ncclDevWorkType workType, int devFuncId, uint32_t workOffset, int /*p2pEpoch*/,
+                            int p2pRound, bool /*newBatch*/
+) {
   // RCCL's static addWorkBatchToPlan determines new-batch internally from
   // chan->workBatchQueue.tail and has no notion of p2pEpoch. Forwarding the
   // remaining args matches the call patterns at enqueue.cc:835, :985, :1329.
-  addWorkBatchToPlan(comm, plan, channelId, workType, devFuncId, workOffset,
-                     p2pRound, /*batchP2P=*/false);
+  addWorkBatchToPlan(comm, plan, channelId, workType, devFuncId, workOffset, p2pRound, /*batchP2P=*/false);
 }
 
 void ncclPlanSetDefaultKernel(struct ncclComm* comm, struct ncclKernelPlan* plan) {
@@ -2655,10 +2705,9 @@ void ncclPlanSetDefaultKernel(struct ncclComm* comm, struct ncclKernelPlan* plan
   plan->kernelSpecialized = ncclKerns[ncclGetKernelIndex(comm)].specialized;
 }
 
-static ncclResult_t calcCollChunking(
-    struct ncclComm* comm, struct ncclTaskColl* info, int nChannels, size_t nBytes,
-    /*outputs*/uint32_t* outChunkSize, uint32_t* outDirectFlags, struct ncclProxyOp* proxyOp
-  ) {
+static ncclResult_t calcCollChunking(struct ncclComm* comm, struct ncclTaskColl* info, int nChannels, size_t nBytes,
+                                     /*outputs*/ uint32_t* outChunkSize, uint32_t* outDirectFlags,
+                                     struct ncclProxyOp* proxyOp) {
   ncclPattern_t pattern;
   size_t grainSize = rcclProtoGrainSize(info->protocol, comm);
 
@@ -2670,18 +2719,16 @@ static ncclResult_t calcCollChunking(
     pattern = info->algorithm == NCCL_ALGO_TREE ? ncclPatternTreeUp : ncclPatternPipelineTo;
     break;
   case ncclFuncReduceScatter:
-    pattern =
-      info->algorithm == NCCL_ALGO_PAT ? ncclPatternPatUp :
-      info->algorithm == NCCL_ALGO_NVLS ? ncclPatternNvls :
-      info->algorithm == NCCL_ALGO_COLLNET_DIRECT ? ncclPatternCollnetDirect :
-      ncclPatternRing;
+    pattern = info->algorithm == NCCL_ALGO_PAT            ? ncclPatternPatUp :
+              info->algorithm == NCCL_ALGO_NVLS           ? ncclPatternNvls :
+              info->algorithm == NCCL_ALGO_COLLNET_DIRECT ? ncclPatternCollnetDirect :
+                                                            ncclPatternRing;
     break;
   case ncclFuncAllGather:
-    pattern =
-      info->algorithm == NCCL_ALGO_PAT ? ncclPatternPatDown :
-      info->algorithm == NCCL_ALGO_NVLS ? ncclPatternNvls :
-      info->algorithm == NCCL_ALGO_COLLNET_DIRECT ? ncclPatternCollnetDirect :
-      ncclPatternRing;
+    pattern = info->algorithm == NCCL_ALGO_PAT            ? ncclPatternPatDown :
+              info->algorithm == NCCL_ALGO_NVLS           ? ncclPatternNvls :
+              info->algorithm == NCCL_ALGO_COLLNET_DIRECT ? ncclPatternCollnetDirect :
+                                                            ncclPatternRing;
     break;
   case ncclFuncAlltoAllPivot:
     pattern = ncclPatternRing;
@@ -2693,13 +2740,12 @@ static ncclResult_t calcCollChunking(
     pattern = ncclPatternRing;
     break;
   case ncclFuncAllReduce:
-    pattern =
-      info->algorithm == NCCL_ALGO_NVLS ? ncclPatternNvls :
-      info->algorithm == NCCL_ALGO_NVLS_TREE ? ncclPatternNvlsTree :
-      info->algorithm == NCCL_ALGO_COLLNET_DIRECT ? ncclPatternCollnetDirect :
-      info->algorithm == NCCL_ALGO_COLLNET_CHAIN ? ncclPatternCollnetChain :
-      info->algorithm == NCCL_ALGO_TREE ? ncclPatternTreeUpDown :
-      ncclPatternRingTwice;
+    pattern = info->algorithm == NCCL_ALGO_NVLS           ? ncclPatternNvls :
+              info->algorithm == NCCL_ALGO_NVLS_TREE      ? ncclPatternNvlsTree :
+              info->algorithm == NCCL_ALGO_COLLNET_DIRECT ? ncclPatternCollnetDirect :
+              info->algorithm == NCCL_ALGO_COLLNET_CHAIN  ? ncclPatternCollnetChain :
+              info->algorithm == NCCL_ALGO_TREE           ? ncclPatternTreeUpDown :
+                                                            ncclPatternRingTwice;
     break;
   default:
     WARN("Unknown pattern for collective %d algorithm %d", info->func, info->algorithm);
@@ -2708,10 +2754,10 @@ static ncclResult_t calcCollChunking(
 
   int nstepsPerLoop, nchunksPerLoop;
   size_t loopOffset = 0;
-  int stepSize   = comm->buffSizes[info->protocol]/NCCL_STEPS;
+  int stepSize = comm->buffSizes[info->protocol] / NCCL_STEPS;
   int chunkSteps = (info->protocol == NCCL_PROTO_SIMPLE && info->algorithm == NCCL_ALGO_RING) ? info->chunkSteps : 1;
   int sliceSteps = (info->protocol == NCCL_PROTO_SIMPLE && info->algorithm == NCCL_ALGO_RING) ? info->sliceSteps : 1;
-  int chunkSize = stepSize*chunkSteps;
+  int chunkSize = stepSize * chunkSteps;
   if (info->protocol == NCCL_PROTO_LL) chunkSize /= 2;
   if (info->protocol == NCCL_PROTO_LL128) chunkSize = (chunkSize / comm->ll128LineElems) * comm->ll128DataElems;
   // Buffer-based ceiling; plugins may increase chunk size up to this limit.
@@ -2720,35 +2766,48 @@ static ncclResult_t calcCollChunking(
   if (info->algorithm == NCCL_ALGO_TREE && info->protocol == NCCL_PROTO_SIMPLE) {
     if (pattern == ncclPatternTreeUpDown) {
       // Optimize chunkSize / nSteps
-      while(nBytes / (nChannels * chunkSize) < comm->channels[0].tree.depth*8 && chunkSize > 131072) chunkSize /=2;
-      while(nBytes / (nChannels * chunkSize) < comm->channels[0].tree.depth*4 && chunkSize > 65536) chunkSize /=2;
-      while(nBytes / (nChannels * chunkSize) < comm->channels[0].tree.depth && chunkSize > 32768) chunkSize /=2;
+      while (nBytes / (nChannels * chunkSize) < comm->channels[0].tree.depth * 8 && chunkSize > 131072) chunkSize /= 2;
+      while (nBytes / (nChannels * chunkSize) < comm->channels[0].tree.depth * 4 && chunkSize > 65536) chunkSize /= 2;
+      while (nBytes / (nChannels * chunkSize) < comm->channels[0].tree.depth && chunkSize > 32768) chunkSize /= 2;
     }
   } else if (info->algorithm == NCCL_ALGO_RING && info->protocol == NCCL_PROTO_SIMPLE) {
     if (pattern == ncclPatternPipelineFrom || pattern == ncclPatternPipelineTo) {
       // Optimize chunkSize / nSteps
-      while(nBytes / (nChannels * chunkSize) < 64 && chunkSize > 262144) chunkSize /= 2;
-      while(nBytes / (nChannels * chunkSize) < 32 && chunkSize > 131072) chunkSize /= 2;
-      while(nBytes / (nChannels * chunkSize) < 16 && chunkSize > 65536) chunkSize /= 2;
-      while(nBytes / (nChannels * chunkSize) < 8 && chunkSize > 32768) chunkSize /= 2;
+      while (nBytes / (nChannels * chunkSize) < 64 && chunkSize > 262144) chunkSize /= 2;
+      while (nBytes / (nChannels * chunkSize) < 32 && chunkSize > 131072) chunkSize /= 2;
+      while (nBytes / (nChannels * chunkSize) < 16 && chunkSize > 65536) chunkSize /= 2;
+      while (nBytes / (nChannels * chunkSize) < 8 && chunkSize > 32768) chunkSize /= 2;
     }
   } else if (info->algorithm == NCCL_ALGO_COLLNET_DIRECT) {
     // Optimize chunkSize / nSteps
-    while (nBytes / (nChannels * comm->channels[0].collnetDirect.nHeads * chunkSize) < comm->channels[0].collnetDirect.depth * 64 && chunkSize > 131072) chunkSize /= 2;
-    while (nBytes / (nChannels * comm->channels[0].collnetDirect.nHeads * chunkSize) < comm->channels[0].collnetDirect.depth * 8 && chunkSize > 65536) chunkSize /= 2;
-    while (nBytes / (nChannels * comm->channels[0].collnetDirect.nHeads * chunkSize) < comm->channels[0].collnetDirect.depth * 8 && chunkSize > 32768) chunkSize /= 2;
+    while (nBytes / (nChannels * comm->channels[0].collnetDirect.nHeads * chunkSize) <
+             comm->channels[0].collnetDirect.depth * 64 &&
+           chunkSize > 131072)
+      chunkSize /= 2;
+    while (nBytes / (nChannels * comm->channels[0].collnetDirect.nHeads * chunkSize) <
+             comm->channels[0].collnetDirect.depth * 8 &&
+           chunkSize > 65536)
+      chunkSize /= 2;
+    while (nBytes / (nChannels * comm->channels[0].collnetDirect.nHeads * chunkSize) <
+             comm->channels[0].collnetDirect.depth * 8 &&
+           chunkSize > 32768)
+      chunkSize /= 2;
   } else if (info->algorithm == NCCL_ALGO_COLLNET_CHAIN) {
     stepSize = comm->buffSizes[NCCL_PROTO_SIMPLE] / NCCL_STEPS;
     chunkSize = std::min(256 * 1024, stepSize * chunkSteps);
-    while (nBytes / (nChannels * chunkSize) < comm->channels[0].collnetChain.depth * 64 && chunkSize > 131072) chunkSize /= 2;
-    while (nBytes / (nChannels * chunkSize) < comm->channels[0].collnetChain.depth * 8 && chunkSize > 65536) chunkSize /= 2;
+    while (nBytes / (nChannels * chunkSize) < comm->channels[0].collnetChain.depth * 64 && chunkSize > 131072)
+      chunkSize /= 2;
+    while (nBytes / (nChannels * chunkSize) < comm->channels[0].collnetChain.depth * 8 && chunkSize > 65536)
+      chunkSize /= 2;
     while (nBytes / (nChannels * chunkSize) < comm->channels[0].collnetChain.depth && chunkSize > 32768) chunkSize /= 2;
   } else if (info->algorithm == NCCL_ALGO_NVLS) {
-    if ((info->regBufType & NCCL_NVLS_REG_BUFFER) && (info->func == ncclFuncAllGather || info->func == ncclFuncReduceScatter)) {
+    if ((info->regBufType & NCCL_NVLS_REG_BUFFER) &&
+        (info->func == ncclFuncAllGather || info->func == ncclFuncReduceScatter)) {
       chunkSize = comm->buffSizes[NCCL_PROTO_SIMPLE] / NCCL_STEPS;
     } else {
       int maxChunkSize = comm->nvlsChunkSize;
-      if (comm->nNodes > 1 && comm->bandwidths[ncclFuncAllReduce][NCCL_ALGO_NVLS][NCCL_PROTO_SIMPLE] < 150) maxChunkSize = 32768;
+      if (comm->nNodes > 1 && comm->bandwidths[ncclFuncAllReduce][NCCL_ALGO_NVLS][NCCL_PROTO_SIMPLE] < 150)
+        maxChunkSize = 32768;
       if (chunkSize > maxChunkSize) chunkSize = maxChunkSize;
       // Use uint64_t so that concurrentOps*chunkSize*X does not overflow.
       // However, nChannels * comm->channels[0].nvls.nHeads should easily fit in 32 bits.
@@ -2771,16 +2830,16 @@ static ncclResult_t calcCollChunking(
   } else if (info->algorithm == NCCL_ALGO_TREE && info->protocol == NCCL_PROTO_LL128) {
     int nNodes = comm->nNodes;
     float ppn = comm->nRanks / (float)nNodes;
-    float nstepsLL128 = 1+log2i(nNodes) + 0.1*ppn;
+    float nstepsLL128 = 1 + log2i(nNodes) + 0.1 * ppn;
     // Yes, we are OK with the division on the left side of the < operand being integer.
     // coverity[integer_division]
-    while (nBytes / (nChannels*chunkSize) < nstepsLL128*64/ppn && chunkSize > 131072) chunkSize /= 2;
+    while (nBytes / (nChannels * chunkSize) < nstepsLL128 * 64 / ppn && chunkSize > 131072) chunkSize /= 2;
     // coverity[integer_division]
-    while (nBytes / (nChannels*chunkSize) < nstepsLL128*16/ppn && chunkSize > 32768) chunkSize /= 2;
+    while (nBytes / (nChannels * chunkSize) < nstepsLL128 * 16 / ppn && chunkSize > 32768) chunkSize /= 2;
   } else if (info->func == ncclFuncAllGather && info->algorithm == NCCL_ALGO_PAT) {
-    while (chunkSize*nChannels*32 > nBytes && chunkSize > 65536) chunkSize /= 2;
+    while (chunkSize * nChannels * 32 > nBytes && chunkSize > 65536) chunkSize /= 2;
   } else if (info->func == ncclFuncReduceScatter && info->algorithm == NCCL_ALGO_PAT) {
-    while (chunkSize*nChannels*16 > nBytes && chunkSize > 65536) chunkSize /= 2;
+    while (chunkSize * nChannels * 16 > nBytes && chunkSize > 65536) chunkSize /= 2;
   }
 
   // Compute directFlags of work struct.
@@ -2792,11 +2851,11 @@ static ncclResult_t calcCollChunking(
 
   if (comm->tuner != nullptr && comm->tuner->getChunkSize != nullptr) {
     size_t tunerChunkSize = chunkSize;
-    NCCLCHECK(comm->tuner->getChunkSize(comm->tunerContext, info->func, nBytes,
-                                        info->algorithm, info->protocol, nChannels, &tunerChunkSize));
+    NCCLCHECK(comm->tuner->getChunkSize(comm->tunerContext, info->func, nBytes, info->algorithm, info->protocol,
+                                        nChannels, &tunerChunkSize));
     if (tunerChunkSize > (size_t)bufferMaxChunkSize) {
-      INFO(NCCL_TUNING, "%s: tuner chunk size %zu exceeds buffer max %d, clamping",
-           ncclFuncToString(info->func), tunerChunkSize, bufferMaxChunkSize);
+      INFO(NCCL_TUNING, "%s: tuner chunk size %zu exceeds buffer max %d, clamping", ncclFuncToString(info->func),
+           tunerChunkSize, bufferMaxChunkSize);
       tunerChunkSize = bufferMaxChunkSize;
     }
     chunkSize = (int)tunerChunkSize;
@@ -2816,21 +2875,26 @@ static ncclResult_t calcCollChunking(
     nstepsPerLoop = nchunksPerLoop = 1;
     break;
   case ncclPatternNvls:
-    nstepsPerLoop = 1; nchunksPerLoop = comm->channels[0].nvls.nHeads;
+    nstepsPerLoop = 1;
+    nchunksPerLoop = comm->channels[0].nvls.nHeads;
     loopOffset = nChannels * chunkSize * comm->channels[0].nvls.headRank;
     break;
   case ncclPatternCollnetDirect:
-    nstepsPerLoop = 1; nchunksPerLoop = comm->channels[0].collnetDirect.nHeads;
+    nstepsPerLoop = 1;
+    nchunksPerLoop = comm->channels[0].collnetDirect.nHeads;
     loopOffset = nChannels * chunkSize * comm->channels[0].collnetDirect.headRank;
     break;
   case ncclPatternRing:
-    nstepsPerLoop = comm->nRanks-1; nchunksPerLoop = comm->nRanks;
+    nstepsPerLoop = comm->nRanks - 1;
+    nchunksPerLoop = comm->nRanks;
     break;
   case ncclPatternRingTwice:
-    nstepsPerLoop = 2*(comm->nRanks-1); nchunksPerLoop = comm->nRanks;
+    nstepsPerLoop = 2 * (comm->nRanks - 1);
+    nchunksPerLoop = comm->nRanks;
     break;
   case ncclPatternNvlsTree:
-    nstepsPerLoop = 1; nchunksPerLoop = comm->channels[0].nvls.nHeads;
+    nstepsPerLoop = 1;
+    nchunksPerLoop = comm->channels[0].nvls.nHeads;
     break;
   default:
     WARN("Unknown pattern %d", pattern);
@@ -2838,7 +2902,7 @@ static ncclResult_t calcCollChunking(
   }
 
   // Compute nSteps for proxies
-  size_t loopSize = size_t(nChannels)*nchunksPerLoop*chunkSize;
+  size_t loopSize = size_t(nChannels) * nchunksPerLoop * chunkSize;
   int nLoops = (int)DIVUP(nBytes, loopSize);
   memset(proxyOp, 0, sizeof(*proxyOp));
   proxyOp->nsteps = nstepsPerLoop * nLoops * chunkSteps;
@@ -2864,11 +2928,12 @@ static ncclResult_t calcCollChunking(
   // This is used by P2P to reduce the receive buffer size. We don't use it in collectives
   // because some protocols need to transmit more than the total size, plus they sometimes
   // round up
-  proxyOp->nbytes = stepSize*sliceSteps;
+  proxyOp->nbytes = stepSize * sliceSteps;
 
   if (info->regBufType & NCCL_NET_REG_BUFFER) {
     proxyOp->reg = 1;
-    if (info->algorithm == NCCL_ALGO_COLLNET_DIRECT || info->algorithm == NCCL_ALGO_NVLS || info->algorithm == NCCL_ALGO_COLLNET_CHAIN) {
+    if (info->algorithm == NCCL_ALGO_COLLNET_DIRECT || info->algorithm == NCCL_ALGO_NVLS ||
+        info->algorithm == NCCL_ALGO_COLLNET_CHAIN) {
       if (proxyOp->isOneRPN) {
         proxyOp->nsteps = 1;
         proxyOp->loopOffset = 0;
@@ -2914,7 +2979,7 @@ static ncclResult_t calcCollChunking(
     proxyOp->specifics.collnetDirect.nNodes = comm->nNodes;
     proxyOp->specifics.collnetDirect.node = comm->node;
     if (info->func == ncclFuncAllGather || info->func == ncclFuncReduceScatter) {
-      proxyOp->specifics.collnetDirect.sizePerRank = info->count*ncclTypeSize(info->datatype);
+      proxyOp->specifics.collnetDirect.sizePerRank = info->count * ncclTypeSize(info->datatype);
     }
   }
 
@@ -2955,83 +3020,94 @@ static ncclResult_t calcCollChunking(
   return ncclSuccess;
 }
 
-static ncclResult_t hostToDevRedOp(
-    ncclDevRedOpFull *opFull, ncclRedOp_t op, ncclDataType_t datatype, ncclComm *comm
-  ) {
+static ncclResult_t hostToDevRedOp(ncclDevRedOpFull* opFull, ncclRedOp_t op, ncclDataType_t datatype, ncclComm* comm) {
   union {
-    int8_t   i8; uint8_t   u8;
-    int32_t i32; uint32_t u32;
-    int64_t i64; uint64_t u64;
-    __half f16; float f32; double f64;
-    #if defined(RCCL_BFLOAT16)
-      hip_bfloat16 bf16;
-    #endif
-    #if defined(RCCL_FLOAT8)
-      rccl_float8 f8;
-      rccl_bfloat8 bf8;
-    #endif
-    void *ptr;
+    int8_t i8;
+    uint8_t u8;
+    int32_t i32;
+    uint32_t u32;
+    int64_t i64;
+    uint64_t u64;
+    __half f16;
+    float f32;
+    double f64;
+#if defined(RCCL_BFLOAT16)
+    hip_bfloat16 bf16;
+#endif
+#if defined(RCCL_FLOAT8)
+    rccl_float8 f8;
+    rccl_bfloat8 bf8;
+#endif
+    void* ptr;
   };
   u64 = 0;
   opFull->scalarArgIsPtr = false;
   opFull->proxyOp = op;
 
-  int nbits = 8*ncclTypeSize(datatype);
+  int nbits = 8 * ncclTypeSize(datatype);
   if (nbits <= 0) return ncclInvalidArgument;
-  uint64_t allBits = uint64_t(-1)>>(64-nbits);
-  uint64_t signBit = allBits^(allBits>>1);
+  uint64_t allBits = uint64_t(-1) >> (64 - nbits);
+  uint64_t signBit = allBits ^ (allBits >> 1);
   bool datatype_signed = false;
 
   switch (int(op)) {
-  case ncclSum:  opFull->op = ncclDevSum;  break;
-  case ncclProd: opFull->op = ncclDevProd; break;
+  case ncclSum:
+    opFull->op = ncclDevSum;
+    break;
+  case ncclProd:
+    opFull->op = ncclDevProd;
+    break;
   case ncclMin:
   case ncclMax:
     opFull->op = ncclDevMinMax;
     opFull->scalarArg = 0;
     // The xormask used by ncclFuncMinMax<[u]int> is the XOR of the sign bit
     // for signed (opposed to unsigned) types and all the bits for max (opposed to min).
-    if (datatype==ncclInt8 || datatype==ncclInt32 || datatype==ncclInt64) {
+    if (datatype == ncclInt8 || datatype == ncclInt32 || datatype == ncclInt64) {
       opFull->scalarArg ^= signBit;
     }
     opFull->scalarArg ^= (op == ncclMax) ? allBits : 0;
     break;
   case ncclAvg:
     switch ((int)datatype) {
-    case ncclInt8:  case ncclInt32:  case ncclInt64:
+    case ncclInt8:
+    case ncclInt32:
+    case ncclInt64:
       datatype_signed = true;
       // no break, we want to fall through...
-    case ncclUint8: case ncclUint32: case ncclUint64:
+    case ncclUint8:
+    case ncclUint32:
+    case ncclUint64:
       opFull->op = ncclDevSumPostDiv;
-      u64 = comm->nRanks<<1 | datatype_signed;
+      u64 = comm->nRanks << 1 | datatype_signed;
       break;
-    #if defined(RCCL_FLOAT8)
+#if defined(RCCL_FLOAT8)
     case ncclFloat8e4m3:
       opFull->op = ncclDevPreMulSum;
-      f8 = static_cast<rccl_float8>(float(1.0/comm->nRanks));
+      f8 = static_cast<rccl_float8>(float(1.0 / comm->nRanks));
       break;
     case ncclFloat8e5m2:
       opFull->op = ncclDevPreMulSum;
-      bf8 = static_cast<rccl_bfloat8>(float(1.0/comm->nRanks));
+      bf8 = static_cast<rccl_bfloat8>(float(1.0 / comm->nRanks));
       break;
-    #endif
+#endif
     case ncclFloat16:
       opFull->op = ncclDevPreMulSum;
-      f16 = __float2half(float(1.0/comm->nRanks)); // __double2half not supported pre CUDA 11.x
+      f16 = __float2half(float(1.0 / comm->nRanks)); // __double2half not supported pre CUDA 11.x
       break;
-    #if defined(RCCL_BFLOAT16)
+#if defined(RCCL_BFLOAT16)
     case ncclBfloat16:
       opFull->op = ncclDevPreMulSum;
-      bf16 = (hip_bfloat16)(float(1.0/comm->nRanks));
+      bf16 = (hip_bfloat16)(float(1.0 / comm->nRanks));
       break;
-    #endif
+#endif
     case ncclFloat32:
       opFull->op = ncclDevPreMulSum;
-      f32 = float(1.0/comm->nRanks);
+      f32 = float(1.0 / comm->nRanks);
       break;
     case ncclFloat64:
       opFull->op = ncclDevPreMulSum;
-      f64 = 1.0/comm->nRanks;
+      f64 = 1.0 / comm->nRanks;
       break;
     }
     opFull->scalarArgIsPtr = false;
@@ -3039,7 +3115,7 @@ static ncclResult_t hostToDevRedOp(
     break;
   default: // user created
     int ix = int(ncclUserRedOpMangle(comm, op)) - int(ncclNumOps);
-    ncclUserRedOp *user = &comm->userRedOps[ix];
+    ncclUserRedOp* user = &comm->userRedOps[ix];
     if (datatype != user->datatype) {
       WARN("Data type supplied to user-created ncclRedOp_t does not match type "
            "given to reduction operation");
@@ -3052,7 +3128,7 @@ static ncclResult_t hostToDevRedOp(
 }
 
 static ncclResult_t ncclPlannerSetCapturingGraph(struct ncclComm* comm, struct ncclInfo* info) {
-  struct ncclKernelPlanner *planner = &comm->planner;
+  struct ncclKernelPlanner* planner = &comm->planner;
   if (info->stream != planner->streamRecent || planner->streams == nullptr) {
     planner->streamRecent = info->stream;
     struct ncclCudaStreamList* l = planner->streams;
@@ -3061,7 +3137,8 @@ static ncclResult_t ncclPlannerSetCapturingGraph(struct ncclComm* comm, struct n
         struct ncclCudaGraph graph;
         NCCLCHECK(ncclCudaGetCapturingGraph(&graph, info->stream, comm->config.graphUsageMode));
         if (planner->streams != nullptr && !ncclCudaGraphSame(planner->capturingGraph, graph)) {
-          WARN("Streams given to a communicator within a NCCL group must either be all uncaptured or all captured by the same graph.");
+          WARN("Streams given to a communicator within a NCCL group must either be all uncaptured or all captured by "
+               "the same graph.");
           return ncclInvalidUsage;
         }
         planner->capturingGraph = graph; // C++ struct assignment
@@ -3073,27 +3150,19 @@ static ncclResult_t ncclPlannerSetCapturingGraph(struct ncclComm* comm, struct n
         planner->numStreams++;
         break;
       }
-      if (l->stream == info->stream)
-        break; // Already seen stream.
+      if (l->stream == info->stream) break; // Already seen stream.
       l = l->next;
     }
   }
   return ncclSuccess;
 }
 
-static ncclResult_t p2pTaskAppend(
-    struct ncclComm* comm,
-    struct ncclInfo* info,
-    ncclFunc_t coll,
-    ncclFunc_t collAPI,
-    void* buff,
-    size_t count,
-    ncclDataType_t datatype,
-    int peer, bool allowUB) {
-  struct ncclKernelPlanner *planner = &comm->planner;
+static ncclResult_t p2pTaskAppend(struct ncclComm* comm, struct ncclInfo* info, ncclFunc_t coll, ncclFunc_t collAPI,
+                                  void* buff, size_t count, ncclDataType_t datatype, int peer, bool allowUB) {
+  struct ncclKernelPlanner* planner = &comm->planner;
 
   // Determine peer and basic parameters.
-  ssize_t nBytes = count*ncclTypeSize(datatype);
+  ssize_t nBytes = count * ncclTypeSize(datatype);
   bool isSendNotRecv = coll == ncclFuncSend;
 
   // Must be in thread local group before tasks can be alloc'd in `comm->memScoped`.
@@ -3119,14 +3188,10 @@ static ncclResult_t p2pTaskAppend(
   p2p->eActivationMask = ncclProfilerApiState.eActivationMask;
   p2p->groupApiEventHandle = ncclProfilerApiState.groupApiEventHandle;
   p2p->p2pApiEventHandle = ncclProfilerApiState.p2pApiEventHandle;
-  ncclIntruQueueEnqueue(
-    isSendNotRecv ? &planner->peers[peer].sendQueue : &planner->peers[peer].recvQueue,
-    p2p);
+  ncclIntruQueueEnqueue(isSendNotRecv ? &planner->peers[peer].sendQueue : &planner->peers[peer].recvQueue, p2p);
   planner->nTasksP2p += 1;
-  if (isSendNotRecv)
-    planner->nTasksP2pSend += 1;
-  else
-    planner->nTasksP2pRecv += 1;
+  if (isSendNotRecv) planner->nTasksP2pSend += 1;
+  else planner->nTasksP2pRecv += 1;
 
   // Mark channels that need pre-connect
   if (comm->rank != peer) {
@@ -3134,15 +3199,14 @@ static ncclResult_t p2pTaskAppend(
       // planner->peers[peer].send/recvSeen is private to each comm, so we need to set it anyway.
       (isSendNotRecv ? planner->peers[peer].sendSeen : planner->peers[peer].recvSeen) = true;
       int round = 0;
-      while (peer != (isSendNotRecv ? comm->p2pSchedule[round].sendRank
-                                    : comm->p2pSchedule[round].recvRank)) {
+      while (peer != (isSendNotRecv ? comm->p2pSchedule[round].sendRank : comm->p2pSchedule[round].recvRank)) {
         round += 1;
       }
       uint8_t base = ncclP2pChannelBaseForRound(comm, round, rcclEffectiveP2pBatchEnable(comm));
 
-
-      for (int c=0; c < comm->p2pnChannelsPerPeer; c++) {
-        int channelId = ncclP2pChannelForPart(comm->p2pnChannels, base, c, comm->p2pnChannelsPerPeer, comm->nNodes, comm->p2pChannelShiftSize);
+      for (int c = 0; c < comm->p2pnChannelsPerPeer; c++) {
+        int channelId = ncclP2pChannelForPart(comm->p2pnChannels, base, c, comm->p2pnChannelsPerPeer, comm->nNodes,
+                                              comm->p2pChannelShiftSize);
         if (isSendNotRecv) {
           if (comm->channels[channelId].peers[peer]->send[1].hasSeen == 0) { // P2P uses only 1 connector
             // the send/recv connector is shared among split shared comms. We need to set hasSeen to
@@ -3151,13 +3215,14 @@ static ncclResult_t p2pTaskAppend(
             comm->channels[channelId].peers[peer]->send[1].hasSeen = 1;
             comm->channels[channelId].peers[peer]->send[1].p2pOnly = 1;
             // comm->connectSend[peer] |= (1UL<<channelId);
-            comm->connectSend[peer].masks[channelId/64] |= (1UL<<(channelId%64));
+            comm->connectSend[peer].masks[channelId / 64] |= (1UL << (channelId % 64));
             ncclGroupCommPreconnect(comm);
           }
           if (comm->p2pNet && comm->channels[channelId].peers[peer]->send[NCCL_CONN_IDX_P2P_NET].hasSeen == 0) {
             comm->channels[channelId].peers[peer]->send[1].hasSeen = 1;
-            //comm->connectSend[peer+comm->nRanks*NCCL_CONN_IDX_P2P_NET] |= (1UL<<channelId);
-            comm->connectSend[peer+comm->nRanks*NCCL_CONN_IDX_P2P_NET].masks[channelId/64] |= (1UL<<(channelId%64));
+            // comm->connectSend[peer+comm->nRanks*NCCL_CONN_IDX_P2P_NET] |= (1UL<<channelId);
+            comm->connectSend[peer + comm->nRanks * NCCL_CONN_IDX_P2P_NET].masks[channelId / 64] |=
+              (1UL << (channelId % 64));
             ncclGroupCommPreconnect(comm);
           }
         } else {
@@ -3165,13 +3230,14 @@ static ncclResult_t p2pTaskAppend(
             comm->channels[channelId].peers[peer]->recv[1].hasSeen = 1;
             comm->channels[channelId].peers[peer]->recv[1].p2pOnly = 1;
             // comm->connectRecv[peer] |= (1UL<<channelId);
-            comm->connectRecv[peer].masks[channelId/64] |= (1UL<<(channelId%64));
+            comm->connectRecv[peer].masks[channelId / 64] |= (1UL << (channelId % 64));
             ncclGroupCommPreconnect(comm);
           }
           if (comm->p2pNet && comm->channels[channelId].peers[peer]->recv[NCCL_CONN_IDX_P2P_NET].hasSeen == 0) {
             comm->channels[channelId].peers[peer]->recv[1].hasSeen = 1;
-            //comm->connectRecv[peer+comm->nRanks*NCCL_CONN_IDX_P2P_NET] |= (1UL<<channelId);
-            comm->connectRecv[peer+comm->nRanks*NCCL_CONN_IDX_P2P_NET].masks[channelId/64] |= (1UL<<(channelId%64));
+            // comm->connectRecv[peer+comm->nRanks*NCCL_CONN_IDX_P2P_NET] |= (1UL<<channelId);
+            comm->connectRecv[peer + comm->nRanks * NCCL_CONN_IDX_P2P_NET].masks[channelId / 64] |=
+              (1UL << (channelId % 64));
             ncclGroupCommPreconnect(comm);
           }
         }
@@ -3182,11 +3248,8 @@ static ncclResult_t p2pTaskAppend(
   return ncclSuccess;
 }
 
-static ncclResult_t collTaskAppend(
-    struct ncclComm* comm,
-    struct ncclInfo* info,
-    struct ncclDevRedOpFull opDev) {
-  struct ncclKernelPlanner *planner = &comm->planner;
+static ncclResult_t collTaskAppend(struct ncclComm* comm, struct ncclInfo* info, struct ncclDevRedOpFull opDev) {
+  struct ncclKernelPlanner* planner = &comm->planner;
 
   // Must be in thread local group before tasks can be alloc'd in `comm->memScoped`.
   ncclGroupCommJoin(info->comm, ncclGroupTaskTypeCollective);
@@ -3219,12 +3282,13 @@ static ncclResult_t collTaskAppend(
 #endif
 
   size_t elementSize = ncclTypeSize(t->datatype);
-  if (t->func == ncclFuncAllGather || t->func == ncclFuncBroadcast || t->func == ncclFuncAlltoAllPivot || t->func == ncclFuncAlltoAllGda || t->func == ncclFuncAlltoAllvGda) {
+  if (t->func == ncclFuncAllGather || t->func == ncclFuncBroadcast || t->func == ncclFuncAlltoAllPivot ||
+      t->func == ncclFuncAlltoAllGda || t->func == ncclFuncAlltoAllvGda) {
     t->count *= elementSize;
     t->datatype = ncclInt8;
     elementSize = 1;
   }
-  t->trafficBytes = t->count*elementSize*ncclFuncTrafficPerByte(t->func, comm->nRanks);
+  t->trafficBytes = t->count * elementSize * ncclFuncTrafficPerByte(t->func, comm->nRanks);
   t->opHost = info->op;
   t->opDev = opDev; // C++ struct assignment
   t->chunkSteps = info->chunkSteps;
@@ -3241,13 +3305,9 @@ static ncclResult_t collTaskAppend(
   return ncclSuccess;
 }
 
-static ncclResult_t ceCollTaskAppend(
-    struct ncclComm* comm,
-    struct ncclInfo* info,
-    struct ncclDevrWindow* sendWin,
-    struct ncclDevrWindow* recvWin,
-    struct ncclDevRedOpFull opDev) {
-  struct ncclKernelPlanner *planner = &comm->planner;
+static ncclResult_t ceCollTaskAppend(struct ncclComm* comm, struct ncclInfo* info, struct ncclDevrWindow* sendWin,
+                                     struct ncclDevrWindow* recvWin, struct ncclDevRedOpFull opDev) {
+  struct ncclKernelPlanner* planner = &comm->planner;
 
   // Check if CE needs initialization
   if (comm->ceColl.baseUCSymReadyPtr == NULL && ncclIntruQueueEmpty(&comm->ceInitTaskQueue)) {
@@ -3281,7 +3341,7 @@ static ncclResult_t ceCollTaskAppend(
     t->datatype = ncclInt8;
     elementSize = 1;
   }
-  t->trafficBytes = t->count*elementSize*ncclFuncTrafficPerByte(t->func, comm->nRanks);
+  t->trafficBytes = t->count * elementSize * ncclFuncTrafficPerByte(t->func, comm->nRanks);
   t->opHost = info->op;
   t->opDev = opDev; // C++ struct assignment
   t->chunkSteps = info->chunkSteps;
@@ -3298,10 +3358,8 @@ static ncclResult_t ceCollTaskAppend(
   return ncclSuccess;
 }
 
-static ncclResult_t rmaTaskAppend(
-  struct ncclComm* comm,
-  struct ncclInfo* info) {
-  struct ncclKernelPlanner *planner = &comm->planner;
+static ncclResult_t rmaTaskAppend(struct ncclComm* comm, struct ncclInfo* info) {
+  struct ncclKernelPlanner* planner = &comm->planner;
 
   void const* srcBuff = info->sendbuff;
 
@@ -3314,8 +3372,8 @@ static ncclResult_t rmaTaskAppend(
   int driverVersion;
   NCCLCHECK(ncclCudaDriverVersion(&driverVersion));
   if (driverVersion < 12050) {
-    WARN("One-sided RMA requires CUDA driver 12.5 or later (found %d.%d).",
-      driverVersion / 1000, (driverVersion % 1000) / 10);
+    WARN("One-sided RMA requires CUDA driver 12.5 or later (found %d.%d).", driverVersion / 1000,
+         (driverVersion % 1000) / 10);
     return ncclInvalidUsage;
   }
 #endif
@@ -3372,18 +3430,17 @@ static ncclResult_t rmaTaskAppend(
       WARN("ncclPutSignal: srcBuff is not inside a registered ncclWindow");
       return ncclInvalidArgument;
     }
-    if (comm->symmetricSupport &&
-        !(srcWinHost->winFlags & NCCL_WIN_COLL_SYMMETRIC)) {
+    if (comm->symmetricSupport && !(srcWinHost->winFlags & NCCL_WIN_COLL_SYMMETRIC)) {
       WARN("ncclPutSignal: srcWinHost is not in a valid symmetric window");
       return ncclInvalidArgument;
     }
     srcWinOffset = (char*)srcBuff - (char*)srcWinHost->userPtr;
 
     // Relevant for symmetric window only
-    bool isMultiSegment = (comm->symmetricSupport)
-                       && (ncclDevrWindowIsMultiSegment(srcWinHost) || ncclDevrWindowIsMultiSegment(peerWinHost));
-    bool hasSysmemSegment = (comm->symmetricSupport)
-                       && (ncclDevrWindowHasSysmemSegment(srcWinHost) || ncclDevrWindowHasSysmemSegment(peerWinHost));
+    bool isMultiSegment = (comm->symmetricSupport) &&
+                          (ncclDevrWindowIsMultiSegment(srcWinHost) || ncclDevrWindowIsMultiSegment(peerWinHost));
+    bool hasSysmemSegment = (comm->symmetricSupport) &&
+                            (ncclDevrWindowHasSysmemSegment(srcWinHost) || ncclDevrWindowHasSysmemSegment(peerWinHost));
 
     if (isMultiSegment) {
       WARN("ncclPutSignal currently does not support VAs backed by multiple physical cuMem segments");
@@ -3393,15 +3450,13 @@ static ncclResult_t rmaTaskAppend(
       WARN("ncclPutSignal currently does not support VAs with host-backed cuMem segments");
       return ncclInvalidArgument;
     }
-  }
-  else if (info->coll == ncclFuncSignal) {
+  } else if (info->coll == ncclFuncSignal) {
     // Check if count is valid
     if (info->count != 0) {
       WARN("ncclSignal: count must be 0");
       return ncclInvalidArgument;
     }
-  }
-  else if (info->coll == ncclFuncWaitSignal) {
+  } else if (info->coll == ncclFuncWaitSignal) {
     // Check if signalDescs is valid
     if (info->signalDescs == NULL || info->nDesc == 0) {
       WARN("ncclWaitSignal: invalid arguments");
@@ -3418,16 +3473,14 @@ static ncclResult_t rmaTaskAppend(
         return ncclInvalidArgument;
       }
       if (info->signalDescs[i].ctx != 0) {
-        WARN("ncclWaitSignal: descriptor %d has invalid context %d (must be 0)",
-             i, info->signalDescs[i].ctx);
+        WARN("ncclWaitSignal: descriptor %d has invalid context %d (must be 0)", i, info->signalDescs[i].ctx);
         return ncclInvalidArgument;
       }
     }
   }
 
   // Check if RMA CE needs initialization
-  if (!comm->rmaState.rmaCeState.initialized &&
-      ncclIntruQueueEmpty(&comm->rmaCeInitTaskQueue)) {
+  if (!comm->rmaState.rmaCeState.initialized && ncclIntruQueueEmpty(&comm->rmaCeInitTaskQueue)) {
     struct ncclRmaCeInitTask* ceTask;
     NCCLCHECK(ncclCalloc(&ceTask, 1));
     ceTask->comm = comm;
@@ -3438,7 +3491,6 @@ static ncclResult_t rmaTaskAppend(
   // Must be in thread local group before tasks can be alloc'd in `comm->memScoped`.
   ncclGroupCommJoin(info->comm, ncclGroupTaskTypeCollective);
   NCCLCHECK(ncclPlannerSetCapturingGraph(comm, info));
-
 
   // Handle WaitSignal separately
   if (info->coll == ncclFuncWaitSignal) {
@@ -3471,7 +3523,6 @@ static ncclResult_t rmaTaskAppend(
     ncclIntruQueueEnqueue(&planner->rmaTaskQueues[t->ctx], t);
 
   } else if (info->coll == ncclFuncPutSignal || info->coll == ncclFuncSignal) {
-
     // Calculate total bytes for the operation
     size_t totalBytes = info->count * ncclTypeSize(info->datatype);
 
@@ -3489,9 +3540,7 @@ static ncclResult_t rmaTaskAppend(
       struct ncclTaskRma* t = ncclMemoryPoolAlloc<struct ncclTaskRma>(&comm->memPool_ncclTaskRma, &comm->memPermanent);
 
       // Calculate chunk-specific size and offsets
-      size_t chunkBytes = (chunkIdx == numChunks - 1)
-                          ? (totalBytes - chunkIdx * chunkSize)
-                          : chunkSize;
+      size_t chunkBytes = (chunkIdx == numChunks - 1) ? (totalBytes - chunkIdx * chunkSize) : chunkSize;
 
       size_t chunkOffset = chunkIdx * chunkSize;
 
@@ -3537,7 +3586,8 @@ static ncclResult_t taskAppend(struct ncclComm* comm, struct ncclInfo* info) {
   ncclFunc_t collAPI = info->coll;
 
   if (info->coll == ncclFuncSend || info->coll == ncclFuncRecv) {
-    NCCLCHECK(p2pTaskAppend(comm, info, info->coll, collAPI, (void*)info->recvbuff, info->count, info->datatype, info->root, true));
+    NCCLCHECK(p2pTaskAppend(comm, info, info->coll, collAPI, (void*)info->recvbuff, info->count, info->datatype,
+                            info->root, true));
   } else if (info->coll == ncclFuncPutSignal || info->coll == ncclFuncSignal || info->coll == ncclFuncWaitSignal) {
     NCCLCHECK(rmaTaskAppend(comm, info));
   } else {
@@ -3545,7 +3595,8 @@ static ncclResult_t taskAppend(struct ncclComm* comm, struct ncclInfo* info) {
     if (info->count == 0) return ncclSuccess;
 
     if (info->datatype == ncclFloat8e4m3 || info->datatype == ncclFloat8e5m2) {
-      if (comm->minCompCap < 90 && info->coll != ncclFuncAllGather && info->coll != ncclFuncBroadcast && info->coll != ncclFuncAlltoAll && info->coll != ncclFuncScatter && info->coll != ncclFuncGather) {
+      if (comm->minCompCap < 90 && info->coll != ncclFuncAllGather && info->coll != ncclFuncBroadcast &&
+          info->coll != ncclFuncAlltoAll && info->coll != ncclFuncScatter && info->coll != ncclFuncGather) {
         WARN("FP8 reduction support begins with sm90 capable devices.");
         return ncclInvalidArgument;
       }
@@ -3557,7 +3608,8 @@ static ncclResult_t taskAppend(struct ncclComm* comm, struct ncclInfo* info) {
     NCCLCHECK(hostToDevRedOp(&opDev, info->op, info->datatype, comm));
 
     if (comm->nRanks == 1) {
-      NCCLCHECK(ncclLaunchOneRank(info->recvbuff, info->sendbuff, info->count, opDev, info->datatype, info->stream, info->acc));
+      NCCLCHECK(ncclLaunchOneRank(info->recvbuff, info->sendbuff, info->count, opDev, info->datatype, info->stream,
+                                  info->acc));
       return ncclSuccess;
     } else {
       struct ncclDevrWindow* sendWin;
@@ -3587,30 +3639,41 @@ static ncclResult_t taskAppend(struct ncclComm* comm, struct ncclInfo* info) {
         NCCLCHECK(ncclCudaGetCapturingGraph(&graph, info->stream, comm->config.graphUsageMode));
         captured = ncclCudaGraphValid(graph);
         if (info->coll == ncclFuncAlltoAll) {
-          NCCLCHECK(ncclRegFind(comm, info->sendbuff, comm->nRanks * info->count * ncclTypeSize(info->datatype), &sendReg));
-          NCCLCHECK(ncclRegFind(comm, info->recvbuff, comm->nRanks * info->count * ncclTypeSize(info->datatype), &recvReg));
+          NCCLCHECK(ncclRegFind(comm, info->sendbuff, comm->nRanks * info->count * ncclTypeSize(info->datatype),
+                                &sendReg));
+          NCCLCHECK(ncclRegFind(comm, info->recvbuff, comm->nRanks * info->count * ncclTypeSize(info->datatype),
+                                &recvReg));
           allowUB = captured || (sendReg != NULL && recvReg != NULL);
-          for (int r=0; r<comm->nRanks; r++) {
-            NCCLCHECK(p2pTaskAppend(comm, info, ncclFuncSend, collAPI, (void*)((char*)info->sendbuff+r*info->count*ncclTypeSize(info->datatype)), info->count, info->datatype, r, allowUB));
-            NCCLCHECK(p2pTaskAppend(comm, info, ncclFuncRecv, collAPI, (void*)((char*)info->recvbuff+r*info->count*ncclTypeSize(info->datatype)), info->count, info->datatype, r, allowUB));
+          for (int r = 0; r < comm->nRanks; r++) {
+            NCCLCHECK(p2pTaskAppend(comm, info, ncclFuncSend, collAPI,
+                                    (void*)((char*)info->sendbuff + r * info->count * ncclTypeSize(info->datatype)),
+                                    info->count, info->datatype, r, allowUB));
+            NCCLCHECK(p2pTaskAppend(comm, info, ncclFuncRecv, collAPI,
+                                    (void*)((char*)info->recvbuff + r * info->count * ncclTypeSize(info->datatype)),
+                                    info->count, info->datatype, r, allowUB));
           }
         } else if (info->coll == ncclFuncAllGather && info->useDirect) {
           NCCLCHECK(ncclRegFind(comm, info->sendbuff, info->count * ncclTypeSize(info->datatype), &sendReg));
-          NCCLCHECK(ncclRegFind(comm, info->recvbuff, comm->nRanks * info->count * ncclTypeSize(info->datatype), &recvReg));
+          NCCLCHECK(ncclRegFind(comm, info->recvbuff, comm->nRanks * info->count * ncclTypeSize(info->datatype),
+                                &recvReg));
           allowUB = captured || (sendReg != NULL && recvReg != NULL);
           size_t rankOffset = info->count * ncclTypeSize(info->datatype);
-          for (int r=0; r<comm->nRanks; r++) {
-            NCCLCHECK(p2pTaskAppend(comm, info, ncclFuncSend, collAPI, (void*)info->sendbuff, info->count, info->datatype, r, allowUB));
-            NCCLCHECK(p2pTaskAppend(comm, info, ncclFuncRecv, collAPI, (void*)((char*)info->recvbuff + r*rankOffset), info->count, info->datatype, r, allowUB));
+          for (int r = 0; r < comm->nRanks; r++) {
+            NCCLCHECK(p2pTaskAppend(comm, info, ncclFuncSend, collAPI, (void*)info->sendbuff, info->count,
+                                    info->datatype, r, allowUB));
+            NCCLCHECK(p2pTaskAppend(comm, info, ncclFuncRecv, collAPI, (void*)((char*)info->recvbuff + r * rankOffset),
+                                    info->count, info->datatype, r, allowUB));
           }
-        } else if (info->coll == ncclFuncGather){
+        } else if (info->coll == ncclFuncGather) {
           size_t offset = 0;
           allowUB = captured;
-          NCCLCHECK(p2pTaskAppend(comm, info, ncclFuncSend, collAPI, (void*)info->sendbuff, info->count, info->datatype, info->root, allowUB));
+          NCCLCHECK(p2pTaskAppend(comm, info, ncclFuncSend, collAPI, (void*)info->sendbuff, info->count, info->datatype,
+                                  info->root, allowUB));
           if (comm->rank == info->root) {
-            for (int r=0; r<comm->nRanks; r++) {
+            for (int r = 0; r < comm->nRanks; r++) {
               void* buff = (void*)((char*)info->recvbuff + offset);
-              NCCLCHECK(p2pTaskAppend(comm, info, ncclFuncRecv, collAPI, buff, info->count, info->datatype, r, allowUB));
+              NCCLCHECK(p2pTaskAppend(comm, info, ncclFuncRecv, collAPI, buff, info->count, info->datatype, r,
+                                      allowUB));
               offset += info->count * ncclTypeSize(info->datatype);
             }
           }
@@ -3620,12 +3683,15 @@ static ncclResult_t taskAppend(struct ncclComm* comm, struct ncclInfo* info) {
           if (comm->rank == info->root) {
             for (int r = 0; r < comm->nRanks; r++) {
               void* buff = (void*)((char*)info->sendbuff + offset);
-              NCCLCHECK(p2pTaskAppend(comm, info, ncclFuncSend, collAPI, buff, info->count, info->datatype, r, allowUB));
+              NCCLCHECK(p2pTaskAppend(comm, info, ncclFuncSend, collAPI, buff, info->count, info->datatype, r,
+                                      allowUB));
               offset += info->count * ncclTypeSize(info->datatype);
             }
           }
-          NCCLCHECK(p2pTaskAppend(comm, info, ncclFuncRecv, collAPI, (void*)info->recvbuff, info->count, info->datatype, info->root, allowUB));
-        } else if (ceAvailable && comm->symmetricSupport && info->coll == ncclFuncAllGather && info->count > ncclParamSymCeThreshold() && comm->minCompCap >= 100 && comm->isAllDirectNvlink) {
+          NCCLCHECK(p2pTaskAppend(comm, info, ncclFuncRecv, collAPI, (void*)info->recvbuff, info->count, info->datatype,
+                                  info->root, allowUB));
+        } else if (ceAvailable && comm->symmetricSupport && info->coll == ncclFuncAllGather &&
+                   info->count > ncclParamSymCeThreshold() && comm->minCompCap >= 100 && comm->isAllDirectNvlink) {
           // Use CE for Allgather on Blackwell with size > 8MB
           NCCLCHECK(ceCollTaskAppend(comm, info, sendWin, recvWin, opDev));
         } else {
@@ -3658,8 +3724,7 @@ ncclResult_t ncclEnqueueCheck(struct ncclInfo* info) {
   NCCLCHECKGOTO(ncclCommEnsureReady(info->comm), ret, fail);
 
   if (__atomic_load_n(&info->comm->revokedFlag, __ATOMIC_ACQUIRE)) {
-    WARN("%s: communicator %p has been revoked; no new collectives may be enqueued",
-         info->opName, info->comm);
+    WARN("%s: communicator %p has been revoked; no new collectives may be enqueued", info->opName, info->comm);
     ret = ncclInvalidUsage;
     goto fail;
   }
@@ -3670,12 +3735,16 @@ ncclResult_t ncclEnqueueCheck(struct ncclInfo* info) {
   }
   NCCLCHECKGOTO(ArgsCheck(info), ret, fail);
 
-  INFO(NCCL_COLL,"%s: opCount %lx sendbuff %p recvbuff %p acc %p count %zu datatype %d op %d root %d comm %p [nranks=%d] stream %p task %d globalrank %d",
-        info->opName, info->comm->opCount, info->sendbuff, info->recvbuff, info->acc, info->count,
-        info->datatype, info->op, info->root, info->comm, info->comm->nRanks, info->stream,
-        info->comm->planner.nTasksP2p + info->comm->planner.nTasksColl,
-        info->comm->localRankToRank[info->comm->localRank]);
-  TRACE_CALL("nccl%s(%" PRIx64 ",%" PRIx64 ",%zu,%d,%d,%d,%p,%p)", info->opName, reinterpret_cast<int64_t>(info->sendbuff), reinterpret_cast<int64_t>(info->recvbuff), info->count, info->datatype, info->op, info->root, info->comm, info->stream);
+  INFO(NCCL_COLL,
+       "%s: opCount %lx sendbuff %p recvbuff %p acc %p count %zu datatype %d op %d root %d comm %p [nranks=%d] stream "
+       "%p task %d globalrank %d",
+       info->opName, info->comm->opCount, info->sendbuff, info->recvbuff, info->acc, info->count, info->datatype,
+       info->op, info->root, info->comm, info->comm->nRanks, info->stream,
+       info->comm->planner.nTasksP2p + info->comm->planner.nTasksColl,
+       info->comm->localRankToRank[info->comm->localRank]);
+  TRACE_CALL("nccl%s(%" PRIx64 ",%" PRIx64 ",%zu,%d,%d,%d,%p,%p)", info->opName,
+             reinterpret_cast<int64_t>(info->sendbuff), reinterpret_cast<int64_t>(info->recvbuff), info->count,
+             info->datatype, info->op, info->root, info->comm, info->stream);
 
   NCCLCHECKGOTO(taskAppend(info->comm, info), ret, fail);
 
@@ -3685,35 +3754,38 @@ exit:
   NCCLCHECK(ncclGroupEndInternal());
   /* if depth is 1, ncclGroupEndInternal() will trigger group ops. The state can change
    * so we have to check state here. */
-  if (info->comm && !info->comm->config.blocking) { NCCLCHECK(ncclCommGetAsyncError(info->comm, &ret)); }
+  if (info->comm && !info->comm->config.blocking) {
+    NCCLCHECK(ncclCommGetAsyncError(info->comm, &ret));
+  }
   return ret;
 fail:
-  if (info->comm && !info->comm->config.blocking) (void) ncclCommSetAsyncError(info->comm, ret);
+  if (info->comm && !info->comm->config.blocking) (void)ncclCommSetAsyncError(info->comm, ret);
   goto exit;
 }
 
-NCCL_API(ncclResult_t, ncclRedOpCreatePreMulSum, ncclRedOp_t *op, void *scalar, ncclDataType_t datatype, ncclScalarResidence_t residence, ncclComm_t comm);
-ncclResult_t ncclRedOpCreatePreMulSum_impl(ncclRedOp_t *op, void *scalar, ncclDataType_t datatype, ncclScalarResidence_t residence, ncclComm_t comm) {
+NCCL_API(ncclResult_t, ncclRedOpCreatePreMulSum, ncclRedOp_t* op, void* scalar, ncclDataType_t datatype,
+         ncclScalarResidence_t residence, ncclComm_t comm);
+ncclResult_t ncclRedOpCreatePreMulSum_impl(ncclRedOp_t* op, void* scalar, ncclDataType_t datatype,
+                                           ncclScalarResidence_t residence, ncclComm_t comm) {
   NCCLCHECK(CommCheck(comm, "ncclRedOpCreatePreMulSum", "comm"));
   /* join init thread before creating PreMulSum op. */
   NCCLCHECK(ncclCommEnsureReady(comm));
 
   if (comm->userRedOpFreeHead == comm->userRedOpCapacity) {
     // double capacity and resize
-    int cap = 2*comm->userRedOpCapacity;
+    int cap = 2 * comm->userRedOpCapacity;
     if (cap < 4) cap = 4;
-    ncclUserRedOp *ops = new ncclUserRedOp[cap];
+    ncclUserRedOp* ops = new ncclUserRedOp[cap];
     if (comm->userRedOpCapacity > 0)
-      std::memcpy(ops, comm->userRedOps, comm->userRedOpCapacity*sizeof(ncclUserRedOp));
-    for(int ix=comm->userRedOpCapacity; ix < cap; ix++)
-      ops[ix].freeNext = ix + 1;
+      std::memcpy(ops, comm->userRedOps, comm->userRedOpCapacity * sizeof(ncclUserRedOp));
+    for (int ix = comm->userRedOpCapacity; ix < cap; ix++) ops[ix].freeNext = ix + 1;
     delete[] comm->userRedOps;
     comm->userRedOps = ops;
     comm->userRedOpCapacity = cap;
   }
   // pop from free list
   int ix = comm->userRedOpFreeHead;
-  ncclUserRedOp *user = &comm->userRedOps[ix];
+  ncclUserRedOp* user = &comm->userRedOps[ix];
   comm->userRedOpFreeHead = user->freeNext;
 
   user->freeNext = -1; // allocated

--- a/projects/rccl/src/gin/gin_host.cc
+++ b/projects/rccl/src/gin/gin_host.cc
@@ -58,14 +58,14 @@ ncclResult_t setLocalGinType(struct ncclComm* comm) {
 
   if (comm->compCap < 70) {
     /* GIN only supported for Volta and later */
-    INFO(NCCL_INIT, "Compute Capability (%d) is not sufficient to enable GIN.  Require Volta (70) or newer.",comm->compCap);
+    INFO(NCCL_INIT, "Compute Capability (%d) is not sufficient to enable GIN.  Require Volta (70) or newer.",
+         comm->compCap);
     return ncclSuccess;
   }
 
   ncclNetProperties_t props;
   NCCLCHECK(ginState.ncclGin->getProperties(0, &props));
-  if (props.netDeviceType == NCCL_NET_DEVICE_GIN_PROXY ||
-      props.netDeviceType == NCCL_NET_DEVICE_GIN_GDAKI) {
+  if (props.netDeviceType == NCCL_NET_DEVICE_GIN_PROXY || props.netDeviceType == NCCL_NET_DEVICE_GIN_GDAKI) {
     // NOTE: The following cast is valid because ncclGinType_t variant values
     // should match NCCL_NET_DEVICE_GIN_* values from `enum ncclNetDeviceType`.
     ginState.ginType = static_cast<ncclGinType_t>(props.netDeviceType);
@@ -76,8 +76,7 @@ ncclResult_t setLocalGinType(struct ncclComm* comm) {
     }
     return ncclSuccess;
   }
-  WARN("Cannot get gin type: ncclGin is not null but net device type (%d) is not a gin type",
-       props.netDeviceType);
+  WARN("Cannot get gin type: ncclGin is not null but net device type (%d) is not a gin type", props.netDeviceType);
   return ncclInternalError;
 }
 
@@ -88,11 +87,11 @@ void* ncclGinProgress(struct ncclGinState* ginState_) {
     if (ginState->ginProgress == 1) {
       struct ncclGinStateDevComm* dc = ginState->devComms;
       while (dc) {
-        for (int n=0; n<ginState->ginCommCount; n++) {
+        for (int n = 0; n < ginState->ginCommCount; n++) {
           ncclResult_t ret = ginState->ncclGin->ginProgress(dc->ginCtx[n]);
           if (ret != ncclSuccess) {
             COMPILER_ATOMIC_STORE(&ginState->asyncResult, ret, std::memory_order_release);
-            INFO(NCCL_ALL,"%s:%d -> %d [GIN Progress Thread]", __FILE__, __LINE__, ret);
+            INFO(NCCL_ALL, "%s:%d -> %d [GIN Progress Thread]", __FILE__, __LINE__, ret);
             ginState->ginProgress = -2;
             return NULL;
           }
@@ -106,7 +105,7 @@ void* ncclGinProgress(struct ncclGinState* ginState_) {
     } else if (ginState->ginProgress == 0) {
       ginState->cond.wait(lock);
     } else {
-      INFO(NCCL_ALL,"%s:%d -> [GIN Progress Thread] state unknown %d", __FILE__, __LINE__, ginState->ginProgress);
+      INFO(NCCL_ALL, "%s:%d -> [GIN Progress Thread] state unknown %d", __FILE__, __LINE__, ginState->ginProgress);
       ginState->ginProgress = -2;
       return NULL;
     }
@@ -194,20 +193,17 @@ ncclResult_t ncclGinConnectOnce(struct ncclComm* comm) {
 
   for (int n = 0; n < ginState->ginCommCount; n++) {
     void* listenComm;
-    NCCLCHECKGOTO(
-      ginState->ncclGin->listen(ginState->ginInstance, localGinDevs[n%nLocalGinDevs],
-                                allHandles + NCCL_NET_HANDLE_MAXSIZE * comm->rank, &listenComm),
-      ret, fail);
+    NCCLCHECKGOTO(ginState->ncclGin->listen(ginState->ginInstance, localGinDevs[n % nLocalGinDevs],
+                                            allHandles + NCCL_NET_HANDLE_MAXSIZE * comm->rank, &listenComm),
+                  ret, fail);
 
-    NCCLCHECKGOTO(ginState->ncclGin->getProperties(localGinDevs[n%nLocalGinDevs], ginState->ginProps+n),
-      ret, fail);
+    NCCLCHECKGOTO(ginState->ncclGin->getProperties(localGinDevs[n % nLocalGinDevs], ginState->ginProps + n), ret, fail);
 
-    NCCLCHECKGOTO(bootstrapAllGather(comm->bootstrap, allHandles, NCCL_NET_HANDLE_MAXSIZE), ret,
-                  fail);
+    NCCLCHECKGOTO(bootstrapAllGather(comm->bootstrap, allHandles, NCCL_NET_HANDLE_MAXSIZE), ret, fail);
 
-    NCCLCHECKGOTO(ginState->ncclGin->connect(comm->ginContext, handles, nGinRanks, myGinRank,
-          listenComm, ginState->ginComms + n),
-        ret, fail);
+    NCCLCHECKGOTO(ginState->ncclGin->connect(comm->ginContext, handles, nGinRanks, myGinRank, listenComm,
+                                             ginState->ginComms + n),
+                  ret, fail);
 
     NCCLCHECKGOTO(ginState->ncclGin->closeListen(listenComm), ret, fail);
   }
@@ -222,17 +218,14 @@ exit:
   if (ret == ncclSuccess) ginState->connected = true;
   return ret;
 fail:
-  if (allHandles)
-    free(allHandles);
-  if (handles)
-    free(handles);
-  if (ginCommCountHandles)
-    free(ginCommCountHandles);
+  if (allHandles) free(allHandles);
+  if (handles) free(handles);
+  if (ginCommCountHandles) free(ginCommCountHandles);
   goto exit;
 }
 
 ncclResult_t ncclGinDevCommSetup(struct ncclComm* comm, struct ncclDevCommRequirements const* reqs,
-    struct ncclDevComm* devComm) {
+                                 struct ncclDevComm* devComm) {
   struct ncclGinState* ginState = &comm->sharedRes->ginState;
 
   devComm->ginSignalCount = reqs->ginSignalCount;
@@ -252,25 +245,22 @@ ncclResult_t ncclGinDevCommSetup(struct ncclComm* comm, struct ncclDevCommRequir
 
   nContextsTotal = ROUNDUP(nContextsTotal, ginState->ginCommCount);
   int nContextsPerComm = nContextsTotal / ginState->ginCommCount;
-  INFO(NCCL_INIT, "devCommCreate: creating %d contexts: %d GIN connections with %d contexts each (%d contexts total requested)",
-      nContextsTotal, ginState->ginCommCount, nContextsPerComm, reqs->ginContextCount);
+  INFO(NCCL_INIT,
+       "devCommCreate: creating %d contexts: %d GIN connections with %d contexts each (%d contexts total requested)",
+       nContextsTotal, ginState->ginCommCount, nContextsPerComm, reqs->ginContextCount);
 
   struct ncclGinStateDevComm* ginStateDevComm = NULL;
   NCCLCHECK(ncclCalloc(&ginStateDevComm, 1));
   ginStateDevComm->contextCount = nContextsTotal;
   ncclResult_t ret = ncclSuccess;
 
-  ncclGinConfig_t ginConfig = {
-    reqs->ginSignalCount,
-    reqs->ginCounterCount,
-    nContextsPerComm,
-    reqs->ginQueueDepth,
-    reqs->ginTrafficClass != NCCL_CONFIG_UNDEF_INT ? reqs->ginTrafficClass : comm->config.trafficClass
-  };
+  ncclGinConfig_t ginConfig = {reqs->ginSignalCount, reqs->ginCounterCount, nContextsPerComm, reqs->ginQueueDepth,
+                               reqs->ginTrafficClass != NCCL_CONFIG_UNDEF_INT ? reqs->ginTrafficClass :
+                                                                                comm->config.trafficClass};
 
   for (int n = 0; n < ginState->ginCommCount; n++) {
-    NCCLCHECKGOTO(ginState->ncclGin->createContext(
-                    ginState->ginComms[n], &ginConfig, &ginStateDevComm->ginCtx[n], &ginStateDevComm->devHandles[n]),
+    NCCLCHECKGOTO(ginState->ncclGin->createContext(ginState->ginComms[n], &ginConfig, &ginStateDevComm->ginCtx[n],
+                                                   &ginStateDevComm->devHandles[n]),
                   ret, end);
     devComm->ginNetDeviceTypes[n] = ginStateDevComm->devHandles[n]->netDeviceType;
     devComm->ginHandles[n] = ginStateDevComm->devHandles[n]->handle;
@@ -290,16 +280,15 @@ ncclResult_t ncclGinDevCommSetup(struct ncclComm* comm, struct ncclDevCommRequir
     if (last) {
       while (last->next) last = last->next;
       last->next = ginStateDevComm;
-     } else {
+    } else {
       ginState->devComms = ginStateDevComm;
     }
   }
 
 end:
   if (ret != ncclSuccess) {
-    for (int n=0; n<ginState->ginCommCount; n++) {
-      if (ginStateDevComm->ginCtx[n])
-        ginState->ncclGin->destroyContext(ginStateDevComm->ginCtx[n]);
+    for (int n = 0; n < ginState->ginCommCount; n++) {
+      if (ginStateDevComm->ginCtx[n]) ginState->ncclGin->destroyContext(ginStateDevComm->ginCtx[n]);
     }
     free(ginStateDevComm);
   }
@@ -309,7 +298,7 @@ end:
 ncclResult_t ncclGinDevCommFree(struct ncclComm* comm, struct ncclDevComm const* devComm) {
   // Find the resource associated with this devComm. Use the gin handle as key.
   struct ncclGinState* ginState = &comm->sharedRes->ginState;
-  struct ncclGinStateDevComm* dc = ginState->devComms, *prevDc = NULL;
+  struct ncclGinStateDevComm *dc = ginState->devComms, *prevDc = NULL;
   while (1) {
     if (dc == NULL) {
       WARN("Dev comm not found\n");
@@ -359,8 +348,8 @@ ncclResult_t ncclGinHostFinalize(struct ncclComm* comm) {
 
 ncclResult_t ncclGinRegister(struct ncclComm* comm, void* address, size_t size,
                              void* ginHostWins[NCCL_GIN_MAX_CONNECTIONS],
-                             ncclGinWindow_t ginDevWins[NCCL_GIN_MAX_CONNECTIONS],
-                             int winFlags, bool multiSegment, int memType) {
+                             ncclGinWindow_t ginDevWins[NCCL_GIN_MAX_CONNECTIONS], int winFlags, bool multiSegment,
+                             int memType) {
   struct ncclGinState* ginState = &comm->sharedRes->ginState;
   if (multiSegment) {
     // Multi-segment GIN registration requires DMABUF support on all GIN connections
@@ -373,8 +362,8 @@ ncclResult_t ncclGinRegister(struct ncclComm* comm, void* address, size_t size,
   }
   int mrFlags = (winFlags & NCCL_WIN_STRICT_ORDERING) ? NCCL_NET_MR_FLAG_FORCE_SO : 0;
   for (int n = 0; n < ginState->ginCommCount; n++) {
-    NCCLCHECK(ginState->ncclGin->regMrSym(ginState->ginComms[n], address, size, memType, mrFlags,
-                                          &ginHostWins[n], &ginDevWins[n]));
+    NCCLCHECK(ginState->ncclGin->regMrSym(ginState->ginComms[n], address, size, memType, mrFlags, &ginHostWins[n],
+                                          &ginDevWins[n]));
     if (ginHostWins[n] == NULL) {
       WARN("rank %d - GIN Symmetric register failed: buff %p, size %ld", comm->rank, address, size);
       return ncclSystemError;

--- a/projects/rccl/src/gin/gin_host_proxy.cc
+++ b/projects/rccl/src/gin/gin_host_proxy.cc
@@ -22,7 +22,7 @@ struct ginProxyGfdState {
   ncclGinProxyOp_t op;
   uint16_t counterId;
   int done;
-  void *request;
+  void* request;
 };
 
 // a member might be on the GPU, if it has a *GdrHandle counterpart
@@ -31,42 +31,42 @@ struct ginProxyHostGpuCtx {
   size_t queueSize;
 
   // size = nRanks * queueSize
-  ncclGinProxyGfd_t *queues;
-  void *cisGdrHandle;
+  ncclGinProxyGfd_t* queues;
+  void* cisGdrHandle;
   // Produced Indices, one per rank. Only accessed by the GPU side, here only for freeing
   uint32_t* pis;
   // Consumed Indices, one per rank
-  uint32_t *cis;
+  uint32_t* cis;
   // to decrease the number of reads/writes to cis which might be on the GPU
-  uint32_t *cisShadow;
+  uint32_t* cisShadow;
   // Seen Indices one per rank
-  uint32_t *sis;
+  uint32_t* sis;
 
   // same size as queues
-  struct ginProxyGfdState *states;
+  struct ginProxyGfdState* states;
   // same size as queues
-  uint64_t *inlines;
+  uint64_t* inlines;
   // inlines is registered as a memory region with the GIN plugin
-  void *inlinesMhandle;
-  void *inlinesGinHandle;
+  void* inlinesMhandle;
+  void* inlinesGinHandle;
 };
 
 struct ginProxyCtx {
-  void *collComm;
+  void* collComm;
   int nRanks;
-  ncclNetDeviceHandle_t *devHandle;
+  ncclNetDeviceHandle_t* devHandle;
 
   // GPU queues, if GDR on the GPU, else on the CPU
   // Queue size, must be a power of 2
-  struct ginProxyHostGpuCtx *hostGpuCtx;
+  struct ginProxyHostGpuCtx* hostGpuCtx;
 
-  void *countersGdrHandle;
-  uint64_t *counters;
-  uint64_t *countersDev;
+  void* countersGdrHandle;
+  uint64_t* counters;
+  uint64_t* countersDev;
   CUmemGenericAllocationHandle signalsCumemhandle;
-  void *signalsMhandle;
-  void *signalsGinHandle;
-  uint64_t *signalsDev;
+  void* signalsMhandle;
+  void* signalsGinHandle;
+  uint64_t* signalsDev;
   bool hasError;
   int nContexts;
   int nCountersPerContext;
@@ -81,8 +81,7 @@ struct ginProxyCtx {
 // [RCCL] Upstream's GIN backend dispatch pointer (v2.30.3-1); set to *proxyGin at init (see ginBackend = *proxyGin).
 static ncclGin_t* ginBackend;
 
-static ncclResult_t getDmaBufFd(void *addr, size_t length, int *fd,
-                                bool forceNonDataDirect = false) {
+static ncclResult_t getDmaBufFd(void* addr, size_t length, int* fd, bool forceNonDataDirect = false) {
   if (ncclParamDmaBufEnable() == 0) return ncclInvalidUsage;
 
   // GIN's symmetric windows are cuMem/VMM allocations registered with the NIC via ibv_reg_dmabuf_mr.
@@ -94,9 +93,9 @@ static ncclResult_t getDmaBufFd(void *addr, size_t length, int *fd,
 
 #if CUDA_VERSION >= 12080
   if (ncclParamIbDataDirect() && !forceNonDataDirect) {
-    CUresult status = pfn_cuMemGetHandleForAddressRange(
-      (void *)fd, (CUdeviceptr)addr, alignedSize, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
-      CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE);
+    CUresult status =
+      pfn_cuMemGetHandleForAddressRange((void*)fd, (CUdeviceptr)addr, alignedSize, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
+                                        CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE);
     if (status == CUDA_SUCCESS) return ncclSuccess;
   }
 #endif
@@ -104,10 +103,10 @@ static ncclResult_t getDmaBufFd(void *addr, size_t length, int *fd,
 #if defined(__HIP_PLATFORM_AMD__)
   // Direct call: hipified to hipMemGetHandleForAddressRange on HIP at build time.
   // Same pattern as transport/net.cc and transport/coll_net.cc.
-  CUresult status = cuMemGetHandleForAddressRange((void *)fd, (CUdeviceptr)addr, alignedSize,
-                                                  CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0);
+  CUresult status =
+    cuMemGetHandleForAddressRange((void*)fd, (CUdeviceptr)addr, alignedSize, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0);
 #else
-  CUresult status = pfn_cuMemGetHandleForAddressRange((void *)fd, (CUdeviceptr)addr, alignedSize,
+  CUresult status = pfn_cuMemGetHandleForAddressRange((void*)fd, (CUdeviceptr)addr, alignedSize,
                                                       CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0);
 #endif
   if (status == CUDA_SUCCESS) return ncclSuccess;
@@ -116,26 +115,24 @@ static ncclResult_t getDmaBufFd(void *addr, size_t length, int *fd,
   return ncclInvalidUsage;
 }
 
-static ncclResult_t proxyGinPollCompletions(void *collComm,
-                                            struct ginProxyCtx *ctx,
-                                            struct ginProxyHostGpuCtx *hostGpuCtx) {
+static ncclResult_t proxyGinPollCompletions(void* collComm, struct ginProxyCtx* ctx,
+                                            struct ginProxyHostGpuCtx* hostGpuCtx) {
   for (int targetRank = 0; targetRank < ctx->nRanks; targetRank++) {
     // loop on all seen but unconsumed GFDs
     for (uint32_t i = hostGpuCtx->cisShadow[targetRank]; i < hostGpuCtx->sis[targetRank]; i++) {
       uint32_t idx = i & (hostGpuCtx->queueSize - 1);
-      struct ginProxyGfdState *state =
-        &hostGpuCtx->states[targetRank * hostGpuCtx->queueSize + idx];
+      struct ginProxyGfdState* state = &hostGpuCtx->states[targetRank * hostGpuCtx->queueSize + idx];
       // no need to poll if already done
       if (!state->done) {
         ncclResult_t res = ginBackend->test(collComm, state->request, &state->done);
         if (res != ncclSuccess) {
-            ctx->hasError = true;
-            WARN("Error on GFD test %d - stateIdx: %lu, request: %p", res, state - hostGpuCtx->states, state->request);
-            return res;
+          ctx->hasError = true;
+          WARN("Error on GFD test %d - stateIdx: %lu, request: %p", res, state - hostGpuCtx->states, state->request);
+          return res;
         }
         if (state->done) {
-          TRACE(NCCL_NET, "GFD completed - contextId: %d, stateIdx: %lu, request: %p", hostGpuCtx->contextId, state - hostGpuCtx->states,
-                state->request);
+          TRACE(NCCL_NET, "GFD completed - contextId: %d, stateIdx: %lu, request: %p", hostGpuCtx->contextId,
+                state - hostGpuCtx->states, state->request);
           // update the counter specified in the GFD
           if (state->op & ncclGinProxyOpWithCounter) {
             // Atomic load and atomic store are used here to ensure that they are volatile.
@@ -144,10 +141,8 @@ static ncclResult_t proxyGinPollCompletions(void *collComm,
             int contextId = hostGpuCtx->contextId;
             uint64_t* counterPtr = &ctx->counters[contextId * ctx->nCountersPerContext + state->counterId];
             uint64_t oldValue = COMPILER_ATOMIC_LOAD(counterPtr, std::memory_order_relaxed);
-            COMPILER_ATOMIC_STORE(counterPtr, oldValue + 1,
-                              std::memory_order_relaxed);
-            TRACE(NCCL_NET, "Updated counter %d to %ld for context %d", state->counterId,
-                  *counterPtr, contextId);
+            COMPILER_ATOMIC_STORE(counterPtr, oldValue + 1, std::memory_order_relaxed);
+            TRACE(NCCL_NET, "Updated counter %d to %ld for context %d", state->counterId, *counterPtr, contextId);
           }
         }
       }
@@ -155,8 +150,9 @@ static ncclResult_t proxyGinPollCompletions(void *collComm,
       if (state->done && i == hostGpuCtx->cisShadow[targetRank]) {
         // tell the GPU that we have consumed the GFD
         COMPILER_ATOMIC_STORE(&hostGpuCtx->cis[targetRank], ++hostGpuCtx->cisShadow[targetRank],
-                          std::memory_order_relaxed);
-        TRACE(NCCL_NET, "Updated cis[%u] to %u for context %d", targetRank, hostGpuCtx->cisShadow[targetRank], hostGpuCtx->contextId);
+                              std::memory_order_relaxed);
+        TRACE(NCCL_NET, "Updated cis[%u] to %u for context %d", targetRank, hostGpuCtx->cisShadow[targetRank],
+              hostGpuCtx->contextId);
       }
     }
   }
@@ -164,24 +160,25 @@ static ncclResult_t proxyGinPollCompletions(void *collComm,
   return ncclSuccess;
 }
 
-static inline uint64_t extractSignalVal(ncclGinProxyGfd_t *gfd) {
+static inline uint64_t extractSignalVal(ncclGinProxyGfd_t* gfd) {
   uint64_t signalVal = gfd->qword[ncclGinProxyGfdCompletion].completion.signalValLow;
   signalVal |= (uint64_t)gfd->qword[ncclGinProxyGfdSignalVal].signalVal.signalValLow2 << 16;
   signalVal |= (uint64_t)gfd->qword[ncclGinProxyGfdSignalVal].signalVal.signalValHigh << 32;
   return signalVal;
 }
 
-static ncclGinProxyOp_t extractOp(ncclGinProxyGfd_t *gfd) {
+static ncclGinProxyOp_t extractOp(ncclGinProxyGfd_t* gfd) {
   return (ncclGinProxyOp_t)gfd->qword[ncclGinProxyGfdHeaderExt].headerExt.op;
 }
 
-static int proxyGinPollGfd(struct ginProxyCtx *ctx, ginProxyHostGpuCtx *hostGpuCtx, int targetRank,
-                           ncclGinProxyGfd_t *gfd, struct ginProxyGfdState **state) {
-  ncclGinProxyGfd_t *q = hostGpuCtx->queues + targetRank * hostGpuCtx->queueSize;
+static int proxyGinPollGfd(struct ginProxyCtx* ctx, ginProxyHostGpuCtx* hostGpuCtx, int targetRank,
+                           ncclGinProxyGfd_t* gfd, struct ginProxyGfdState** state) {
+  ncclGinProxyGfd_t* q = hostGpuCtx->queues + targetRank * hostGpuCtx->queueSize;
   uint32_t idx = hostGpuCtx->sis[targetRank] & (hostGpuCtx->queueSize - 1);
   ncclGinProxyQword_t qword;
 #if defined(__HIP_PLATFORM_AMD__)
-  uint64_t *headerPtr = (uint64_t *)__builtin_assume_aligned(&q[idx].qword[ncclGinProxyGfdHeader].raw, alignof(uint64_t));
+  uint64_t* headerPtr =
+    (uint64_t*)__builtin_assume_aligned(&q[idx].qword[ncclGinProxyGfdHeader].raw, alignof(uint64_t));
   qword.raw = __atomic_load_n(headerPtr, __ATOMIC_RELAXED);
 #else
   COMPILER_ATOMIC_LOAD_DEST(&q[idx].qword[ncclGinProxyGfdHeader].raw, &qword.raw, std::memory_order_relaxed);
@@ -195,7 +192,7 @@ static int proxyGinPollGfd(struct ginProxyCtx *ctx, ginProxyHostGpuCtx *hostGpuC
   // Wait for and copy the other qwords.
   for (int k = 1; k < ncclGinProxyGfdQwords; k++) {
 #if defined(__HIP_PLATFORM_AMD__)
-    uint64_t *qwordPtr = (uint64_t *)__builtin_assume_aligned(&q[idx].qword[k].raw, alignof(uint64_t));
+    uint64_t* qwordPtr = (uint64_t*)__builtin_assume_aligned(&q[idx].qword[k].raw, alignof(uint64_t));
     do {
       qword.raw = __atomic_load_n(qwordPtr, __ATOMIC_RELAXED);
     } while (qword.flag.v == 0);
@@ -236,10 +233,8 @@ static int proxyGinPollGfd(struct ginProxyCtx *ctx, ginProxyHostGpuCtx *hostGpuC
         "GFD on context %d to target PE %d raw idx: %u, idx: %u - op: %#lx, size: %lu, srcOff: %lu, dstOff: %lu, "
         "srcHandle: %lu, dstHandle: %lu, counterId: %u, signalId: %u, stateIdx: %u",
         hostGpuCtx->contextId, targetRank, hostGpuCtx->sis[targetRank], idx, extractOp(gfd),
-        gfd->qword[ncclGinProxyGfdHeader].header.size,
-        gfd->qword[ncclGinProxyGfdSrcOff].srcOff.srcOff,
-        gfd->qword[ncclGinProxyGfdDstOff].dstOff.dstOff,
-        gfd->qword[ncclGinProxyGfdSrcHandle].srcHandle.srcHandle,
+        gfd->qword[ncclGinProxyGfdHeader].header.size, gfd->qword[ncclGinProxyGfdSrcOff].srcOff.srcOff,
+        gfd->qword[ncclGinProxyGfdDstOff].dstOff.dstOff, gfd->qword[ncclGinProxyGfdSrcHandle].srcHandle.srcHandle,
         gfd->qword[ncclGinProxyGfdDstHandle].dstHandle.dstHandle,
         gfd->qword[ncclGinProxyGfdCompletion].completion.counterId,
         gfd->qword[ncclGinProxyGfdCompletion].completion.signalId, stateIdx);
@@ -249,7 +244,7 @@ static int proxyGinPollGfd(struct ginProxyCtx *ctx, ginProxyHostGpuCtx *hostGpuC
   return 1;
 }
 
-static int mapGfdOpToSignalOp(ncclGinProxyGfd_t *gfd) {
+static int mapGfdOpToSignalOp(ncclGinProxyGfd_t* gfd) {
   // Mask down to the signal-op bits only. WithInline and WithCounter are
   // orthogonal modifiers and must be excluded -- otherwise an inline put
   // with SignalInc (op = Put|WithInline|WithSignalInc) masks down and falls
@@ -258,45 +253,43 @@ static int mapGfdOpToSignalOp(ncclGinProxyGfd_t *gfd) {
   ncclGinProxyOp_t op = extractOp(gfd);
   uint8_t signalOp = op & (ncclGinProxyOpWithSignalInc | ncclGinProxyOpWithSignalAdd);
   switch (signalOp) {
-    case ncclGinProxyOpWithSignalInc:
-      return NCCL_NET_SIGNAL_OP_INC;
-    case ncclGinProxyOpWithSignalAdd:
-      return NCCL_NET_SIGNAL_OP_ADD;
-    default:
-      return -1;
+  case ncclGinProxyOpWithSignalInc:
+    return NCCL_NET_SIGNAL_OP_INC;
+  case ncclGinProxyOpWithSignalAdd:
+    return NCCL_NET_SIGNAL_OP_ADD;
+  default:
+    return -1;
   }
 }
 
-static ncclResult_t proxyGinProcessGfd(struct ginProxyCtx *ctx,
-                                       struct ginProxyHostGpuCtx *hostGpuCtx, int targetRank,
-                                       ncclGinProxyGfd_t *gfd, struct ginProxyGfdState *state) {
+static ncclResult_t proxyGinProcessGfd(struct ginProxyCtx* ctx, struct ginProxyHostGpuCtx* hostGpuCtx, int targetRank,
+                                       ncclGinProxyGfd_t* gfd, struct ginProxyGfdState* state) {
   int signalOp;
   uint64_t signalVal;
 
   // Handle VA Signal operations (signal-only, no PUT)
   if (extractOp(gfd) & ncclGinProxyOpVASignal) {
     uint64_t signalOff = gfd->qword[ncclGinProxyGfdVASignalOff].vaSignalOff.vaSignalOff;
-    void *signalHandle = (void *)(uint64_t)gfd->qword[ncclGinProxyGfdVASignalHandle].vaSignalHandle.vaSignalHandle;
+    void* signalHandle = (void*)(uint64_t)gfd->qword[ncclGinProxyGfdVASignalHandle].vaSignalHandle.vaSignalHandle;
     signalVal = extractSignalVal(gfd);
     signalOp = mapGfdOpToSignalOp(gfd);
-    NCCLCHECK(ginBackend->iputSignal(ctx->ginCtx, hostGpuCtx->contextId, 0, nullptr, 0, 0, nullptr,
-                                  targetRank, signalOff, signalHandle, signalVal,
-                                  signalOp, &state->request));
+    NCCLCHECK(ginBackend->iputSignal(ctx->ginCtx, hostGpuCtx->contextId, 0, nullptr, 0, 0, nullptr, targetRank,
+                                     signalOff, signalHandle, signalVal, signalOp, &state->request));
     return ncclSuccess;
   }
 
   if (extractOp(gfd) & ncclGinProxyOpGet) {
     uint64_t srcOff = gfd->qword[ncclGinProxyGfdSrcOff].srcOff.srcOff;
-    void *srcHandle = (void *)(uint64_t)gfd->qword[ncclGinProxyGfdSrcHandle].srcHandle.srcHandle;
+    void* srcHandle = (void*)(uint64_t)gfd->qword[ncclGinProxyGfdSrcHandle].srcHandle.srcHandle;
     uint64_t dstOff = gfd->qword[ncclGinProxyGfdDstOff].dstOff.dstOff;
-    void *dstHandle = (void *)(uint64_t)gfd->qword[ncclGinProxyGfdDstHandle].dstHandle.dstHandle;
+    void* dstHandle = (void*)(uint64_t)gfd->qword[ncclGinProxyGfdDstHandle].dstHandle.dstHandle;
     uint64_t size = gfd->qword[ncclGinProxyGfdHeader].header.size;
     if (!ginBackend->iget) {
       WARN("GIN plugin does not support GET");
       return ncclInvalidUsage;
     }
     NCCLCHECK(ginBackend->iget(ctx->ginCtx, hostGpuCtx->contextId, srcOff, srcHandle, size, dstOff, dstHandle,
-                              targetRank, &state->request));
+                               targetRank, &state->request));
     return ncclSuccess;
   }
 
@@ -305,7 +298,8 @@ static ncclResult_t proxyGinProcessGfd(struct ginProxyCtx *ctx,
       WARN("GIN plugin does not support FLUSH");
       return ncclInvalidUsage;
     }
-    NCCLCHECK(ginBackend->iflush(ctx->ginCtx, hostGpuCtx->contextId, ctx->signalsGinHandle, targetRank,&state->request));
+    NCCLCHECK(ginBackend->iflush(ctx->ginCtx, hostGpuCtx->contextId, ctx->signalsGinHandle, targetRank,
+                                 &state->request));
     if (state->request == NULL) {
       state->done = 1;
     }
@@ -314,53 +308,52 @@ static ncclResult_t proxyGinProcessGfd(struct ginProxyCtx *ctx,
 
   uint64_t size = gfd->qword[ncclGinProxyGfdHeader].header.size;
   uint64_t srcOff;
-  void *srcHandle;
+  void* srcHandle;
   if (extractOp(gfd) & ncclGinProxyOpWithInline) {
     // `gfd` is a stack-local copy filled by proxyGinPollGfd, not a pointer
     // into hostGpuCtx->queues, so we cannot do `gfd - hostGpuCtx->queues` to
     // recover its slot index. Recover it from `state` instead, which is a
     // real heap pointer (`*state = &hostGpuCtx->states[stateIdx]`).
     size_t slotIdx = state - hostGpuCtx->states;
-    uint64_t *inlineVal = &hostGpuCtx->inlines[slotIdx];
+    uint64_t* inlineVal = &hostGpuCtx->inlines[slotIdx];
     srcOff = slotIdx * sizeof(uint64_t);
     // reconstruct the inline value from the two qwords
     *inlineVal = gfd->qword[ncclGinProxyGfdInlineLow].inlineLow.inlineValLow;
-    if (size > 4)
-      *inlineVal |= (uint64_t)gfd->qword[ncclGinProxyGfdInlineLow].inlineLow.inlineValLow2 << 32;
-    if (size > 6)
-      *inlineVal |= (uint64_t)gfd->qword[ncclGinProxyGfdInlineHigh].inlineHigh.inlineValHigh << 48;
+    if (size > 4) *inlineVal |= (uint64_t)gfd->qword[ncclGinProxyGfdInlineLow].inlineLow.inlineValLow2 << 32;
+    if (size > 6) *inlineVal |= (uint64_t)gfd->qword[ncclGinProxyGfdInlineHigh].inlineHigh.inlineValHigh << 48;
     srcHandle = hostGpuCtx->inlinesMhandle;
   } else {
     srcOff = gfd->qword[ncclGinProxyGfdSrcOff].srcOff.srcOff;
-    srcHandle = (void *)(uint64_t)gfd->qword[ncclGinProxyGfdSrcHandle].srcHandle.srcHandle;
+    srcHandle = (void*)(uint64_t)gfd->qword[ncclGinProxyGfdSrcHandle].srcHandle.srcHandle;
   }
   uint64_t dstOff = gfd->qword[ncclGinProxyGfdDstOff].dstOff.dstOff;
-  void *dstHandle = (void *)(uint64_t)gfd->qword[ncclGinProxyGfdDstHandle].dstHandle.dstHandle;
+  void* dstHandle = (void*)(uint64_t)gfd->qword[ncclGinProxyGfdDstHandle].dstHandle.dstHandle;
 
   ncclGinProxyOp_t op = extractOp(gfd);
   switch (op & ncclGinProxyOpBaseMask) {
-    case ncclGinProxyOpPut:
-      signalOp = mapGfdOpToSignalOp(gfd);
-      if (signalOp == -1) {
+  case ncclGinProxyOpPut:
+    signalOp = mapGfdOpToSignalOp(gfd);
+    if (signalOp == -1) {
         // First cast from 63 bits to 64 bits and then to void * to avoid warnings
-        NCCLCHECK(ginBackend->iput(ctx->ginCtx, hostGpuCtx->contextId, srcOff, srcHandle, size, dstOff, dstHandle,
-                                targetRank, &state->request));
-      } else {
+      NCCLCHECK(ginBackend->iput(ctx->ginCtx, hostGpuCtx->contextId, srcOff, srcHandle, size, dstOff, dstHandle,
+                                 targetRank, &state->request));
+    } else {
         // Reconstruct the signal value
-        signalVal = extractSignalVal(gfd);
-        uint64_t signalOff = (gfd->qword[ncclGinProxyGfdCompletion].completion.signalId +
-                              hostGpuCtx->contextId * ctx->nSignalsPerContext) * sizeof(uint64_t);
-        NCCLCHECK(ginBackend->iputSignal(ctx->ginCtx, hostGpuCtx->contextId, srcOff, srcHandle, size, dstOff, dstHandle,
-                                      targetRank, signalOff, ctx->signalsGinHandle, signalVal,
-                                      signalOp, &state->request));
-      }
-      break;
-    default:
+      signalVal = extractSignalVal(gfd);
+      uint64_t signalOff =
+        (gfd->qword[ncclGinProxyGfdCompletion].completion.signalId + hostGpuCtx->contextId * ctx->nSignalsPerContext) *
+        sizeof(uint64_t);
+      NCCLCHECK(ginBackend->iputSignal(ctx->ginCtx, hostGpuCtx->contextId, srcOff, srcHandle, size, dstOff, dstHandle,
+                                       targetRank, signalOff, ctx->signalsGinHandle, signalVal, signalOp,
+                                       &state->request));
+    }
+    break;
+  default:
       // this error should already have been checked in pollGfd
-      assert(0);
+    assert(0);
   }
-  TRACE(NCCL_NET, "GFD submitted into GIN plugin - contextId: %d, stateIdx: %lu, request: %p",
-        hostGpuCtx->contextId, state - hostGpuCtx->states, state->request);
+  TRACE(NCCL_NET, "GFD submitted into GIN plugin - contextId: %d, stateIdx: %lu, request: %p", hostGpuCtx->contextId,
+        state - hostGpuCtx->states, state->request);
   return ncclSuccess;
 }
 
@@ -395,8 +388,8 @@ struct ncclGinProxyCollComm {
   void* collComm;
 };
 
-static ncclResult_t ncclGinProxyConnect(void* ctx, void* handles[], int nranks, int rank,
-                                 void* listenComm, void** collComm) {
+static ncclResult_t ncclGinProxyConnect(void* ctx, void* handles[], int nranks, int rank, void* listenComm,
+                                        void** collComm) {
   ncclResult_t ret = ncclSuccess;
   struct ncclGinProxyCollComm* cComm = NULL;
   struct ncclGinProxyListenComm* lComm = (struct ncclGinProxyListenComm*)listenComm;
@@ -420,8 +413,8 @@ static ncclResult_t ncclGinProxyCloseColl(void* collComm) {
 
 // Check if the GIN plugin supports DMA-BUF, if so we can try to get the DMA-BUF handle from CUDA,
 // if that fails we fallback to non-DMA-BUF
-static ncclResult_t ncclGinProxyRegMrSym(void* ginCtx, void* addr, size_t size, int type,
-                                         uint64_t mrFlags, void** mhandle, void **ginHandle) {
+static ncclResult_t ncclGinProxyRegMrSym(void* ginCtx, void* addr, size_t size, int type, uint64_t mrFlags,
+                                         void** mhandle, void** ginHandle) {
   struct ncclGinProxyCollComm* cComm = (struct ncclGinProxyCollComm*)ginCtx;
   if (type == NCCL_PTR_HOST) {
     NCCLCHECK(ginBackend->regMrSym(cComm->collComm, addr, size, type, mrFlags, mhandle, ginHandle));
@@ -432,8 +425,8 @@ static ncclResult_t ncclGinProxyRegMrSym(void* ginCtx, void* addr, size_t size, 
       int dmabufFd = -1;
       dmabufResult = getDmaBufFd(addr, size, &dmabufFd);
       if (dmabufResult == ncclSuccess) {
-        registrationResult = ginBackend->regMrSymDmaBuf(cComm->collComm, addr, size, type, 0, dmabufFd,
-                                                     mrFlags, mhandle, ginHandle);
+        registrationResult =
+          ginBackend->regMrSymDmaBuf(cComm->collComm, addr, size, type, 0, dmabufFd, mrFlags, mhandle, ginHandle);
         close(dmabufFd);
       }
       if (registrationResult != ncclSuccess) {
@@ -442,8 +435,8 @@ static ncclResult_t ncclGinProxyRegMrSym(void* ginCtx, void* addr, size_t size, 
         dmabufFd = -1;
         dmabufResult = getDmaBufFd(addr, size, &dmabufFd, true);
         if (dmabufResult == ncclSuccess) {
-          NCCLCHECK(ginBackend->regMrSymDmaBuf(cComm->collComm, addr, size, type, 0, dmabufFd,
-                                            mrFlags, mhandle, ginHandle));
+          NCCLCHECK(ginBackend->regMrSymDmaBuf(cComm->collComm, addr, size, type, 0, dmabufFd, mrFlags, mhandle,
+                                               ginHandle));
           close(dmabufFd);
         }
       }
@@ -466,18 +459,18 @@ static ncclResult_t ncclGinProxyDeregMrSym(void* collComm, void* mhandle) {
   return ncclSuccess;
 }
 
+static uint64_t isPowerOfTwo(uint64_t n) {
+  return (n > 0) && ((n & (n - 1)) == 0);
+}
 
-static uint64_t isPowerOfTwo(uint64_t n) { return (n > 0) && ((n & (n - 1)) == 0); }
-
-static ncclResult_t ncclGinProxyCreateContext(void* collComm, ncclGinConfig_t* config,
-                                       void **outGinCtx, ncclNetDeviceHandle_t **outDevHandle) {
+static ncclResult_t ncclGinProxyCreateContext(void* collComm, ncclGinConfig_t* config, void** outGinCtx,
+                                              ncclNetDeviceHandle_t** outDevHandle) {
   struct ncclGinProxyCollComm* cComm = (struct ncclGinProxyCollComm*)collComm;
-  ncclGinProxyGpuCtx_t *devGpuCtxArray_h = nullptr;
+  ncclGinProxyGpuCtx_t* devGpuCtxArray_h = nullptr;
 
-  if (!ncclGdrCopy)
-    INFO(NCCL_NET, "GIN Proxy will not be using GDRCopy");
+  if (!ncclGdrCopy) INFO(NCCL_NET, "GIN Proxy will not be using GDRCopy");
 
-  struct ginProxyCtx *proxyCtx = NULL;
+  struct ginProxyCtx* proxyCtx = NULL;
   NCCLCHECK(ncclCalloc(&proxyCtx, 1));
 
   proxyCtx->collComm = cComm->collComm;
@@ -500,22 +493,19 @@ static ncclResult_t ncclGinProxyCreateContext(void* collComm, ncclGinConfig_t* c
     queueSize = maxRequests;
   }
   if (queueSize < 1) {
-    INFO(NCCL_NET,
-         "NCCL_GIN_PROXY_QUEUE_SIZE is less than 1, using the default/maximum value instead");
+    INFO(NCCL_NET, "NCCL_GIN_PROXY_QUEUE_SIZE is less than 1, using the default/maximum value instead");
     queueSize = maxRequests;
   }
   if (!isPowerOfTwo(queueSize)) {
-    INFO(
-      NCCL_NET,
-      "NCCL_GIN_PROXY_QUEUE_SIZE is not a power of two, using the default/maximum value instead");
+    INFO(NCCL_NET, "NCCL_GIN_PROXY_QUEUE_SIZE is not a power of two, using the default/maximum value instead");
     queueSize = maxRequests;
   }
 
   if (config->nCounters) {
     // Allocate the counters on the GPU or CPU depending on GDR
-    NCCLCHECK(allocMemCPUAccessible(&proxyCtx->counters, &proxyCtx->countersDev,
-                                    config->nCounters * nContexts, CU_MEMHOSTALLOC_WRITECOMBINED,
-                                    &proxyCtx->countersGdrHandle, (struct ncclMemManager*)nullptr));
+    NCCLCHECK(allocMemCPUAccessible(&proxyCtx->counters, &proxyCtx->countersDev, config->nCounters * nContexts,
+                                    CU_MEMHOSTALLOC_WRITECOMBINED, &proxyCtx->countersGdrHandle,
+                                    (struct ncclMemManager*)nullptr));
   }
   proxyCtx->nCountersPerContext = config->nCounters;
 
@@ -524,19 +514,18 @@ static ncclResult_t ncclGinProxyCreateContext(void* collComm, ncclGinConfig_t* c
   // signals.
   if (config->nSignals) {
     size_t signalsBufSize = config->nSignals * nContexts * sizeof(uint64_t);
-    NCCLCHECK(ncclCuMemAlloc((void **)&proxyCtx->signalsDev, &proxyCtx->signalsCumemhandle,
-                             CU_MEM_HANDLE_TYPE_NONE, signalsBufSize, NULL));
+    NCCLCHECK(ncclCuMemAlloc((void**)&proxyCtx->signalsDev, &proxyCtx->signalsCumemhandle, CU_MEM_HANDLE_TYPE_NONE,
+                             signalsBufSize, NULL));
     CUDACHECK(cudaMemset(proxyCtx->signalsDev, 0, signalsBufSize));
-    NCCLCHECK(ncclGinProxyRegMrSym(collComm, proxyCtx->signalsDev, signalsBufSize,
-                                   NCCL_PTR_CUDA, NCCL_NET_MR_FLAG_FORCE_SO,
-                                   &proxyCtx->signalsMhandle, &proxyCtx->signalsGinHandle));
+    NCCLCHECK(ncclGinProxyRegMrSym(collComm, proxyCtx->signalsDev, signalsBufSize, NCCL_PTR_CUDA,
+                                   NCCL_NET_MR_FLAG_FORCE_SO, &proxyCtx->signalsMhandle, &proxyCtx->signalsGinHandle));
   }
   proxyCtx->nSignalsPerContext = config->nSignals;
 
   NCCLCHECK(ncclCalloc(&proxyCtx->hostGpuCtx, nContexts));
   NCCLCHECK(ncclCalloc(&devGpuCtxArray_h, nContexts));
   for (int contextId = 0; contextId < nContexts; contextId++) {
-    struct ginProxyHostGpuCtx *hostGpuCtx = proxyCtx->hostGpuCtx + contextId;
+    struct ginProxyHostGpuCtx* hostGpuCtx = proxyCtx->hostGpuCtx + contextId;
     hostGpuCtx->contextId = contextId;
     hostGpuCtx->queueSize = queueSize;
     size_t queuesLength = hostGpuCtx->queueSize * cComm->nRanks;
@@ -544,12 +533,11 @@ static ncclResult_t ncclGinProxyCreateContext(void* collComm, ncclGinConfig_t* c
     NCCLCHECK(ncclCalloc(&hostGpuCtx->cisShadow, cComm->nRanks));
     NCCLCHECK(ncclCalloc(&hostGpuCtx->sis, cComm->nRanks));
     NCCLCHECK(ncclCalloc(&hostGpuCtx->inlines, queuesLength));
-    NCCLCHECK(ncclGinProxyRegMrSym(collComm, hostGpuCtx->inlines,
-                                   queuesLength * sizeof(uint64_t), NCCL_PTR_HOST, 0,
+    NCCLCHECK(ncclGinProxyRegMrSym(collComm, hostGpuCtx->inlines, queuesLength * sizeof(uint64_t), NCCL_PTR_HOST, 0,
                                    &hostGpuCtx->inlinesMhandle, &hostGpuCtx->inlinesGinHandle));
     NCCLCHECK(ncclCudaCalloc(&hostGpuCtx->pis, cComm->nRanks, NULL));
 
-    ncclGinProxyGpuCtx_t *devGpuCtx_h = devGpuCtxArray_h + contextId;
+    ncclGinProxyGpuCtx_t* devGpuCtx_h = devGpuCtxArray_h + contextId;
     devGpuCtx_h->nranks = cComm->nRanks;
     devGpuCtx_h->queueSize = hostGpuCtx->queueSize;
     devGpuCtx_h->counters = proxyCtx->countersDev + contextId * config->nCounters;
@@ -558,23 +546,22 @@ static ncclResult_t ncclGinProxyCreateContext(void* collComm, ncclGinConfig_t* c
 
     // Allocate the GFD queues, CIs, counters, signals and test/wait variables on the either the CPU
     // or GPU.
-    NCCLCHECK(allocMemCPUAccessible(&hostGpuCtx->queues, &devGpuCtx_h->queues, queuesLength, 0, NULL,
-                                    NULL, true /*forceHost*/));
-    NCCLCHECK(allocMemCPUAccessible(&hostGpuCtx->cis, &devGpuCtx_h->cis, cComm->nRanks,
-                                    CU_MEMHOSTALLOC_WRITECOMBINED, &hostGpuCtx->cisGdrHandle,
-                                    (struct ncclMemManager*)nullptr));
+    NCCLCHECK(allocMemCPUAccessible(&hostGpuCtx->queues, &devGpuCtx_h->queues, queuesLength, 0, NULL, NULL,
+                                    true /*forceHost*/));
+    NCCLCHECK(allocMemCPUAccessible(&hostGpuCtx->cis, &devGpuCtx_h->cis, cComm->nRanks, CU_MEMHOSTALLOC_WRITECOMBINED,
+                                    &hostGpuCtx->cisGdrHandle, (struct ncclMemManager*)nullptr));
   }
 
-  ncclGinProxyGpuCtx_t *devGpuCtx_d = NULL;
+  ncclGinProxyGpuCtx_t* devGpuCtx_d = NULL;
   NCCLCHECK(ncclCudaCalloc(&devGpuCtx_d, nContexts, NULL));
   // Copy the proxy's devGpuCtx to the GPU
   NCCLCHECK(ncclCudaMemcpy(devGpuCtx_d, devGpuCtxArray_h, nContexts));
 
-  ncclNetDeviceHandle_t *devHandle = NULL;
+  ncclNetDeviceHandle_t* devHandle = NULL;
   NCCLCHECK(ncclCalloc(&devHandle, 1));
   devHandle->netDeviceType = NCCL_NET_DEVICE_GIN_PROXY;
   devHandle->netDeviceVersion = NCCL_GIN_PROXY_VERSION;
-  devHandle->handle = (void *)devGpuCtx_d;
+  devHandle->handle = (void*)devGpuCtx_d;
   devHandle->size = 0;
   devHandle->needsProxyProgress = 1;
 
@@ -588,9 +575,9 @@ static ncclResult_t ncclGinProxyCreateContext(void* collComm, ncclGinConfig_t* c
   return ncclSuccess;
 }
 
-static ncclResult_t ncclGinProxyDestroyContext(void *ginCtx) {
+static ncclResult_t ncclGinProxyDestroyContext(void* ginCtx) {
   if (!ginCtx) return ncclSuccess;
-  struct ginProxyCtx *ctx = (struct ginProxyCtx *)ginCtx;
+  struct ginProxyCtx* ctx = (struct ginProxyCtx*)ginCtx;
 
   NCCLCHECK(ginBackend->destroyContext(ctx->ginCtx));
 
@@ -600,14 +587,13 @@ static ncclResult_t ncclGinProxyDestroyContext(void *ginCtx) {
       NCCLCHECK(freeMemCPUAccessible(ctx->counters, ctx->countersGdrHandle, NULL));
 
     // Free signals
-    if (ctx->collComm && ctx->signalsMhandle)
-      ginBackend->deregMrSym(ctx->collComm, ctx->signalsMhandle);
+    if (ctx->collComm && ctx->signalsMhandle) ginBackend->deregMrSym(ctx->collComm, ctx->signalsMhandle);
     if (ctx->signalsDev) NCCLCHECK(ncclCudaFree(ctx->signalsDev, NULL));
 
     // Free hostGpuCtx and its allocations
     if (ctx->hostGpuCtx) {
       for (int contextId = 0; contextId < ctx->nContexts; contextId++) {
-        struct ginProxyHostGpuCtx *hostGpuCtx = ctx->hostGpuCtx + contextId;
+        struct ginProxyHostGpuCtx* hostGpuCtx = ctx->hostGpuCtx + contextId;
         if (hostGpuCtx->cisShadow) free(hostGpuCtx->cisShadow);
         if (hostGpuCtx->sis) free(hostGpuCtx->sis);
         if (hostGpuCtx->pis) NCCLCHECK(ncclCudaFree(hostGpuCtx->pis, NULL));
@@ -622,9 +608,9 @@ static ncclResult_t ncclGinProxyDestroyContext(void *ginCtx) {
       free(ctx->hostGpuCtx);
     }
 
-    ncclNetDeviceHandle_t *devHandle = (ncclNetDeviceHandle_t *)ctx->devHandle;
+    ncclNetDeviceHandle_t* devHandle = (ncclNetDeviceHandle_t*)ctx->devHandle;
     if (devHandle) {
-      if (devHandle->handle) NCCLCHECK(ncclCudaFree((void *)devHandle->handle, NULL));
+      if (devHandle->handle) NCCLCHECK(ncclCudaFree((void*)devHandle->handle, NULL));
       free(devHandle);
     }
 
@@ -634,19 +620,18 @@ static ncclResult_t ncclGinProxyDestroyContext(void *ginCtx) {
   return ncclSuccess;
 }
 
-static ncclResult_t ncclGinProxyProgress(void *ginCtx) {
-  struct ginProxyCtx *ctx = (struct ginProxyCtx *)ginCtx;
+static ncclResult_t ncclGinProxyProgress(void* ginCtx) {
+  struct ginProxyCtx* ctx = (struct ginProxyCtx*)ginCtx;
 
   for (int contextId = 0; contextId < ctx->nContexts; contextId++) {
-    struct ginProxyHostGpuCtx *hostGpuCtx = ctx->hostGpuCtx + contextId;
+    struct ginProxyHostGpuCtx* hostGpuCtx = ctx->hostGpuCtx + contextId;
     NCCLCHECK(proxyGinPollCompletions(ctx->collComm, ctx, hostGpuCtx));
     for (int targetRank = 0; targetRank < ctx->nRanks; targetRank++) {
       // Poll on the GFD queue
       ncclGinProxyGfd_t gfd;
-      struct ginProxyGfdState *state = NULL;
+      struct ginProxyGfdState* state = NULL;
       if (proxyGinPollGfd(ctx, hostGpuCtx, targetRank, &gfd, &state)) {
-        ncclResult_t ret =
-          proxyGinProcessGfd(ctx, hostGpuCtx, targetRank, &gfd, state);
+        ncclResult_t ret = proxyGinProcessGfd(ctx, hostGpuCtx, targetRank, &gfd, state);
         if (ret) ctx->hasError = ret;
         NCCLCHECK(ret);
       }
@@ -657,15 +642,15 @@ static ncclResult_t ncclGinProxyProgress(void *ginCtx) {
   return ncclSuccess;
 }
 
-static ncclResult_t ncclGinProxyQueryLastError(void *ginCtx, bool *hasError) {
-  struct ginProxyCtx *ctx = (struct ginProxyCtx *)ginCtx;
+static ncclResult_t ncclGinProxyQueryLastError(void* ginCtx, bool* hasError) {
+  struct ginProxyCtx* ctx = (struct ginProxyCtx*)ginCtx;
   *hasError = ctx->hasError;
   if (ctx->hasError == ncclSuccess && ginBackend->queryLastError)
     NCCLCHECK(ginBackend->queryLastError(ginCtx, hasError));
   return ncclSuccess;
 }
 
-ncclGin_t ncclGinProxy {
+ncclGin_t ncclGinProxy{
   NULL, // Will map directly to the plugin: name
   NULL, // Will map directly to the plugin: init()
   NULL, // Will map directly to the plugin: devices()

--- a/projects/rccl/src/graph/connect.cc
+++ b/projects/rccl/src/graph/connect.cc
@@ -25,7 +25,8 @@
 ncclResult_t ncclTopoReconcileGrowChannels(struct ncclComm* comm, int* value) {
 #if defined(TOPO_EXPL)
   // topo_expl does not link the bootstrap layer and never grows comms.
-  (void)comm; (void)value;
+  (void)comm;
+  (void)value;
   return ncclSuccess;
 #else
   int* perRank = NULL;
@@ -39,7 +40,6 @@ ncclResult_t ncclTopoReconcileGrowChannels(struct ncclComm* comm, int* value) {
 #endif
 }
 
-
 /******************************************************************/
 /********************* Internode connection ***********************/
 /******************************************************************/
@@ -52,22 +52,22 @@ ncclResult_t ncclTopoReconcileGrowChannels(struct ncclComm* comm, int* value) {
  *
  * PRE-CONDITIONS & ASSUMPTIONS:
  * 1. Topology Detection: The hardware (PCIe/NVLink) must already be scanned into comm->topo.
- * 2. Graph Calculation: graphs[algo]->intra must be pre-populated. This function assumes 
- * the 'intra' array contains local global ranks in their optimal traversal order, 
+ * 2. Graph Calculation: graphs[algo]->intra must be pre-populated. This function assumes
+ * the 'intra' array contains local global ranks in their optimal traversal order,
  * indexed by [channel * localRanks + i].
- * 3. Rank Identity: comm->rank must be set. The function "finds" itself in the intra 
+ * 3. Rank Identity: comm->rank must be set. The function "finds" itself in the intra
  * list to identify its immediate neighbors.
- * 4. Resource Allocation: comm->channels must be allocated with enough space for 
+ * 4. Resource Allocation: comm->channels must be allocated with enough space for
  * channel duplication (typically 2 * nChannels).
  *
  * LOGIC DETAILS:
- * - Intra-node Mapping: Iterates through local GPUs to identify neighbors for Ring, 
+ * - Intra-node Mapping: Iterates through local GPUs to identify neighbors for Ring,
  * Tree, and CollNet algorithms.
- * - Channel Duplication (Factor of 2): Clones the first N channels into the next N 
- * slots. This maximizes bandwidth by utilizing multiple SMs and hardware paths 
- * for the same logical operation, pushing utilization closer to physical limits 
+ * - Channel Duplication (Factor of 2): Clones the first N channels into the next N
+ * slots. This maximizes bandwidth by utilizing multiple SMs and hardware paths
+ * for the same logical operation, pushing utilization closer to physical limits
  * without over-congesting hardware command queues.
- * - NVLS Setup: Identifies unique "Head" ranks for NVLink Switch groups to coordinate 
+ * - NVLS Setup: Identifies unique "Head" ranks for NVLink Switch groups to coordinate
  * multi-GPU data movement.
  *
  * CAVEATS:
@@ -80,14 +80,15 @@ ncclResult_t ncclTopoReconcileGrowChannels(struct ncclComm* comm, int* value) {
  * @param topoRanks[out] Scratchpad structure to store identified neighbor ranks.
  * @return          ncclSuccess on successful mapping, or internal error on failure.
  */
-ncclResult_t ncclTopoPreset(struct ncclComm* comm, struct ncclTopoGraph* (&graphs)[NCCL_NUM_ALGORITHMS], struct ncclTopoRanks* topoRanks) {
+ncclResult_t ncclTopoPreset(struct ncclComm* comm, struct ncclTopoGraph* (&graphs)[NCCL_NUM_ALGORITHMS],
+                            struct ncclTopoRanks* topoRanks) {
   // --- NULL Pointer & Basic State Checks ---
   if (comm == NULL || graphs == NULL || topoRanks == NULL) return ncclInvalidArgument;
   if (comm->topo == NULL) {
     WARN("TopoPreset: Communicator state is incomplete");
     return ncclInternalError;
   }
-  
+
   int rank = comm->rank;
   int localRanks = comm->topo->nodes[GPU].count;
   int nChannels = comm->nChannels;
@@ -109,7 +110,10 @@ ncclResult_t ncclTopoPreset(struct ncclComm* comm, struct ncclTopoGraph* (&graph
   bool rankFound = false;
   int* firstRing = graphs[NCCL_ALGO_RING]->intra;
   for (int i = 0; i < localRanks; i++) {
-    if (firstRing[i] == rank) { rankFound = true; break; }
+    if (firstRing[i] == rank) {
+      rankFound = true;
+      break;
+    }
   }
   if (!rankFound) {
     WARN("TopoPreset: Local rank %d not found in intra-node graph. Topology misconfiguration.", rank);
@@ -121,7 +125,7 @@ ncclResult_t ncclTopoPreset(struct ncclComm* comm, struct ncclTopoGraph* (&graph
 
   // ---- POISONING / INITIALIZATION ---
   // set all the uninitialized topoRanks rank values to -1 , 0 from calloc is ambiguous with rank 0
-  for (int c=0; c< MAXCHANNELS; c++) {
+  for (int c = 0; c < MAXCHANNELS; c++) {
     topoRanks->ringNext[c] = topoRanks->ringPrev[c] = -1;
     topoRanks->ringSend[c] = topoRanks->ringRecv[c] = -1;
     topoRanks->treeToParent[c] = -1;
@@ -129,11 +133,11 @@ ncclResult_t ncclTopoPreset(struct ncclComm* comm, struct ncclTopoGraph* (&graph
     topoRanks->treeToChild1[c] = -1;
     topoRanks->nvlsHeads[c] = -1; // Align NVLS with Tree/Ring sentinels
 
-    struct ncclChannel* channel = comm->channels+c;
+    struct ncclChannel* channel = comm->channels + c;
     channel->ring.prev = channel->ring.next = -1;
     channel->tree.up = -1;
     channel->collnetChain.up = -1;
-    for (int i=0; i<NCCL_MAX_TREE_ARITY; i++)  {
+    for (int i = 0; i < NCCL_MAX_TREE_ARITY; i++) {
       channel->tree.down[i] = -1;
       channel->collnetChain.down[i] = -1;
     }
@@ -141,48 +145,48 @@ ncclResult_t ncclTopoPreset(struct ncclComm* comm, struct ncclTopoGraph* (&graph
     channel->collnetDirect.headRank = -1;
     channel->collnetDirect.nHeads = 0;
     channel->collnetDirect.shift = 0;
-    for (int i=0; i<NCCL_MAX_DIRECT_ARITY+1; i++) channel->collnetDirect.heads[i] = -1;
-    for (int i=0; i<NCCL_MAX_DIRECT_ARITY; i++)  {
+    for (int i = 0; i < NCCL_MAX_DIRECT_ARITY + 1; i++) channel->collnetDirect.heads[i] = -1;
+    for (int i = 0; i < NCCL_MAX_DIRECT_ARITY; i++) {
       channel->collnetDirect.up[i] = -1;
       channel->collnetDirect.down[i] = -1;
-    } 
+    }
   }
 
-  for (int c=0; c<nChannels; c++) {
-    struct ncclChannel* channel = comm->channels+c;
+  for (int c = 0; c < nChannels; c++) {
+    struct ncclChannel* channel = comm->channels + c;
 
-    int* ringIntra = graphs[NCCL_ALGO_RING]->intra+c*localRanks;
-    int* treeIntra = graphs[NCCL_ALGO_TREE]->intra+c*localRanks;
-    int* collNetIntra = graphs[NCCL_ALGO_COLLNET_CHAIN]->intra+c*localRanks;
+    int* ringIntra = graphs[NCCL_ALGO_RING]->intra + c * localRanks;
+    int* treeIntra = graphs[NCCL_ALGO_TREE]->intra + c * localRanks;
+    int* collNetIntra = graphs[NCCL_ALGO_COLLNET_CHAIN]->intra + c * localRanks;
 
-    for (int i=0; i<localRanks; i++) {
+    for (int i = 0; i < localRanks; i++) {
       if (ringIntra[i] == rank) {
         topoRanks->ringRecv[c] = ringIntra[0];
-        topoRanks->ringSend[c] = ringIntra[localRanks-1];
-        topoRanks->ringPrev[c] = (i == 0) ? -1 : ringIntra[i-1];
-        topoRanks->ringNext[c] = (i == localRanks-1) ? -1 : ringIntra[i+1];
+        topoRanks->ringSend[c] = ringIntra[localRanks - 1];
+        topoRanks->ringPrev[c] = (i == 0) ? -1 : ringIntra[i - 1];
+        topoRanks->ringNext[c] = (i == localRanks - 1) ? -1 : ringIntra[i + 1];
       }
       if (treeIntra[i] == rank) {
         int parentIndex = 0;
-        int child0Index = ( graphs[NCCL_ALGO_TREE]->pattern == NCCL_TOPO_PATTERN_TREE ) ? 0 : 1;
-        int child1Index = ( graphs[NCCL_ALGO_TREE]->pattern == NCCL_TOPO_PATTERN_SPLIT_TREE ) ? 1 : 0;
+        int child0Index = (graphs[NCCL_ALGO_TREE]->pattern == NCCL_TOPO_PATTERN_TREE) ? 0 : 1;
+        int child1Index = (graphs[NCCL_ALGO_TREE]->pattern == NCCL_TOPO_PATTERN_SPLIT_TREE) ? 1 : 0;
 
         topoRanks->treeToParent[c] = treeIntra[parentIndex];
         topoRanks->treeToChild0[c] = treeIntra[child0Index];
         topoRanks->treeToChild1[c] = treeIntra[child1Index];
-        channel->tree.up         = (i == 0) ? -1 : treeIntra[i-1];
-        channel->tree.down[0]    = (i == localRanks-1) ? -1 : treeIntra[i+1];
+        channel->tree.up = (i == 0) ? -1 : treeIntra[i - 1];
+        channel->tree.down[0] = (i == localRanks - 1) ? -1 : treeIntra[i + 1];
       }
       if (collNetIntra[i] == rank) {
-        channel->collnetChain.up      = (i == 0) ? comm->nRanks : collNetIntra[i-1];
-        channel->collnetChain.down[0] = (i == localRanks-1) ? -1 : collNetIntra[i+1];
+        channel->collnetChain.up = (i == 0) ? comm->nRanks : collNetIntra[i - 1];
+        channel->collnetChain.down[0] = (i == localRanks - 1) ? -1 : collNetIntra[i + 1];
       }
     }
   }
   // Duplicate channels trees
   struct ncclChannel* channel0 = comm->channels;
-  struct ncclChannel* channel1 = (nChannels > MAXCHANNELS/2) ? 0 : channel0+nChannels;
-  if (channel1) memcpy(channel1, channel0, nChannels*sizeof(struct ncclChannel));
+  struct ncclChannel* channel1 = (nChannels > MAXCHANNELS / 2) ? 0 : channel0 + nChannels;
+  if (channel1) memcpy(channel1, channel0, nChannels * sizeof(struct ncclChannel));
 
   // Get nvls heads and the number of heads. Duplicate head is not allowed.
   for (int c = 0; c < graphs[NCCL_ALGO_NVLS]->nChannels; ++c) {
@@ -205,19 +209,17 @@ ncclResult_t ncclTopoPreset(struct ncclComm* comm, struct ncclTopoGraph* (&graph
 }
 
 bool isRankHere(const char* s, int start, int end, int rank) {
-  if (end <= start || start < 0 || end < 0)
-    return false;
+  if (end <= start || start < 0 || end < 0) return false;
   int num = 0;
   while (start < end) {
     char currChar = s[start];
     if (isdigit(currChar)) {
       num = num * 10 + (currChar - '0');
-      if (isdigit(s[start+1])) {
+      if (isdigit(s[start + 1])) {
         start++;
         continue;
       }
-    }
-    else if (currChar == '(' || currChar == ')') {
+    } else if (currChar == '(' || currChar == ')') {
       start++;
       num = 0;
       continue;
@@ -228,29 +230,27 @@ bool isRankHere(const char* s, int start, int end, int rank) {
   return false;
 }
 
-ncclResult_t ncclTreeBasePostset(struct ncclComm* comm,
-    struct ncclTopoGraph* treeGraph) {
-  int x=0;
-  for (int i=0;  treeGraph->treeBase[i][0]!=0; i++)
-  {
-    x=i+1;
+ncclResult_t ncclTreeBasePostset(struct ncclComm* comm, struct ncclTopoGraph* treeGraph) {
+  int x = 0;
+  for (int i = 0; treeGraph->treeBase[i][0] != 0; i++) {
+    x = i + 1;
   }
-  if( treeGraph->treeBase[0][0] == 0) return ncclSuccess;
+  if (treeGraph->treeBase[0][0] == 0) return ncclSuccess;
   int nChannels = comm->nChannels;
-  //int localRanks = comm->topo->nodes[GPU].count; // unused variable - compiler warning
-  //new tree
-  for (int c=0; c<nChannels; c++) { // in here
-    int buff = c%x;
-    char tempString[NCCL_TOPO_MAX_NODES*4];
-    int ko=0;
+  // int localRanks = comm->topo->nodes[GPU].count; // unused variable - compiler warning
+  // new tree
+  for (int c = 0; c < nChannels; c++) { // in here
+    int buff = c % x;
+    char tempString[NCCL_TOPO_MAX_NODES * 4];
+    int ko = 0;
     while (treeGraph->treeBase[buff][ko] != 0) {
       tempString[ko] = treeGraph->treeBase[buff][ko];
       ko++;
     }
-    tempString[ko]=0;
+    tempString[ko] = 0;
     int start = 0;
     int curRank = comm->rank;
-    struct ncclChannel* channel = comm->channels+c;
+    struct ncclChannel* channel = comm->channels + c;
     int end = 0;
     while (tempString[end] != 0) end++;
     int parent = -1;
@@ -258,8 +258,7 @@ ncclResult_t ncclTreeBasePostset(struct ncclComm* comm,
     while (start < end) {
       int num = 0, num_found = 0;
       start++;
-      while (start < end && tempString[start] != '('
-         && tempString[start] != ')') {
+      while (start < end && tempString[start] != '(' && tempString[start] != ')') {
         int num_here = (int)(tempString[start] - '0');
         num = num * 10 + num_here;
         start = start + 1;
@@ -272,11 +271,10 @@ ncclResult_t ncclTreeBasePostset(struct ncclComm* comm,
           int or_start = start;
           int child = -1;
           channel->tree.down[childId] = -1;
-          if (or_start >= end -1) continue;
-          num=0;
+          if (or_start >= end - 1) continue;
+          num = 0;
           or_start++;
-          while (tempString[or_start] != 0 && tempString[or_start] != '('
-             && tempString[or_start] != ')') {
+          while (tempString[or_start] != 0 && tempString[or_start] != '(' && tempString[or_start] != ')') {
             int num_here = (int)(tempString[or_start] - '0');
             num = num * 10 + num_here;
             or_start++;
@@ -284,8 +282,8 @@ ncclResult_t ncclTreeBasePostset(struct ncclComm* comm,
           child = num;
           // find next child start
           while (start < end) {
-            if (tempString[start] == '(' ) depth++;
-            else if(tempString[start] == ')') depth--;
+            if (tempString[start] == '(') depth++;
+            else if (tempString[start] == ')') depth--;
             if (depth == 0) break; // next child
             start++;
           }
@@ -294,16 +292,15 @@ ncclResult_t ncclTreeBasePostset(struct ncclComm* comm,
           // get kids, update numbers, get out of this string
         }
         break;
-      }
-      else { //go to the next one
+      } else { // go to the next one
         parent = num;
         int start_c = start;
         int end_c = start_c;
         while (end_c < end) {
           int depth = 0;
           while (end_c < end) {
-            if (tempString[end_c] == '(' ) depth++;
-            else if(tempString[end_c] == ')') depth--;
+            if (tempString[end_c] == '(') depth++;
+            else if (tempString[end_c] == ')') depth--;
             if (depth == 0) break; // next child
             end_c++;
           }
@@ -311,15 +308,13 @@ ncclResult_t ncclTreeBasePostset(struct ncclComm* comm,
             start = start_c;
             end = end_c;
             break;
-          }
-          else {
+          } else {
             end_c++;
             start_c = end_c;
           }
         }
       }
     }
-
   }
   return ncclSuccess;
 }
@@ -328,7 +323,7 @@ static void generateWalecki(int nNodes, int channel, int* order) {
   if (nNodes <= 0 || !order) return;
 
   // For Walecki, if N is even, we treat it as (N-1) nodes + 1 fixed pivot
-  int m = (nNodes % 2) ? nNodes : (nNodes - 1) ;
+  int m = (nNodes % 2) ? nNodes : (nNodes - 1);
   int left = 0;
   int right = m - 1;
 
@@ -343,116 +338,116 @@ static void generateWalecki(int nNodes, int channel, int* order) {
     }
     order[i] = val;
   }
-  if( nNodes % 2 == 0) {
+  if (nNodes % 2 == 0) {
     order[nNodes - 1] = nNodes - 1;
   }
 }
 
 /**
- * This function takes number of nodes in a fully connected graph and number target channels, and generates upto nChannel Hamiltonian cycles 
+ * This function takes number of nodes in a fully connected graph and number target channels, and generates upto nChannel Hamiltonian cycles
  * In this function we initially generate Walecki Construction depending on (nNodes mod 2), upto nNodes / 2 channels. Then, based on edge usage
  * heuristic, we construct rest of the cycles.
- * 
+ *
  * Assumptions : nodeOrder is pointer to flattened 2D array of size nNodes*nChannels*sizeof(int), and is pre-allocated before invoking this function.
  */
 static ncclResult_t generateGreedyNodeOrder(int nNodes, uint8_t nChannels, int* nodeOrder) {
     // --- SAFETY CHECK: Guard against invalid cluster sizes ---
-    if (nNodes <= 0 || nChannels <= 0 || nodeOrder == NULL) return ncclInvalidArgument;
+  if (nNodes <= 0 || nChannels <= 0 || nodeOrder == NULL) return ncclInvalidArgument;
     // Handle degenerate cases (N=1, N=2) where Hamiltonian diversity is impossible
-    if (nNodes < 3) {
-        for (int c = 0; c < nChannels; c++) {
-            for (int n = 0; n < nNodes; n++) {
-                nodeOrder[c * nNodes + n] = n;
-            }
-        }
-        return ncclSuccess;
-    }
-
-    if (nChannels <= (nNodes / 2)) {
-        for (int c = 0; c < nChannels; c++) {
-            generateWalecki(nNodes, c, &nodeOrder[c * nNodes]);
-        }
-        return ncclSuccess;
-    }
-
-    // Choose to augment with Greedy approach only if nNodes/2 channels are not sufficient. Most systems 
-    // do not execute below code as we have MAXCHANNELS = 128.
-    // Optimization: uint8_t is sufficient for nChannels <= 255, In RCCL we limit it to 128 channels now. 
-    uint8_t* edgeUsage = (uint8_t*)calloc(nNodes * nNodes, sizeof(uint8_t));
-    uint8_t* visited = (uint8_t*)malloc(nNodes * sizeof(uint8_t));
-
-    if (!edgeUsage || !visited) {
-        if (edgeUsage) free(edgeUsage);
-        if (visited) free(visited);
-        WARN("Unable to allocate memory with malloc/calloc");
-        return ncclInternalError;
-    }
-
-    int startNode = 0;
+  if (nNodes < 3) {
     for (int c = 0; c < nChannels; c++) {
-        if (c < nNodes / 2) {
-            generateWalecki(nNodes, c, &nodeOrder[c * nNodes]);
-            for (int i = 0; i < nNodes; i++) {
-                int u = nodeOrder[c * nNodes + i];
-                int v = nodeOrder[c * nNodes + ((i + 1) % nNodes)];
-                edgeUsage[u * nNodes + v]++;
-            }
-            continue;
-        }
-        //Set all non-visited
-        memset(visited, 0, nNodes * sizeof(uint8_t));
-        // Only to reduce the pressure on starting node 
-        startNode = (startNode + 1) % nNodes;
-        int curr = startNode;
-        nodeOrder[c * nNodes + 0] = curr;
-        visited[curr] = 1;
-
-        for (int step = 1; step < nNodes; step++) {
-            int bestNext = -1;
-            int minCost = INT_MAX;
-
-            for (int next = 0; next < nNodes; next++) {
-                if (!visited[next]) {
-                    int cost = (int)edgeUsage[curr * nNodes + next];
-
-                    // Without this check, a greedy algorithm might pick a "cheap" bestNext for the second-to-last
-                    // node, but that node might have a very "expensive" (heavily used) link back to the start.
-                    if (step == nNodes - 1) {
-                        cost += (int)edgeUsage[next * nNodes + startNode];
-                    }
-
-                    if (cost < minCost) {
-                        minCost = cost;
-                        bestNext = next;
-                    }
-                }
-            }
-            nodeOrder[c * nNodes + step] = bestNext;
-            visited[bestNext] = 1;
-            edgeUsage[curr * nNodes + bestNext]++;
-            curr = bestNext;
-        }
-        edgeUsage[curr * nNodes + startNode]++;
+      for (int n = 0; n < nNodes; n++) {
+        nodeOrder[c * nNodes + n] = n;
+      }
     }
-    free(visited);
-    free(edgeUsage);
     return ncclSuccess;
+  }
+
+  if (nChannels <= (nNodes / 2)) {
+    for (int c = 0; c < nChannels; c++) {
+      generateWalecki(nNodes, c, &nodeOrder[c * nNodes]);
+    }
+    return ncclSuccess;
+  }
+
+    // Choose to augment with Greedy approach only if nNodes/2 channels are not sufficient. Most systems
+    // do not execute below code as we have MAXCHANNELS = 128.
+    // Optimization: uint8_t is sufficient for nChannels <= 255, In RCCL we limit it to 128 channels now.
+  uint8_t* edgeUsage = (uint8_t*)calloc(nNodes * nNodes, sizeof(uint8_t));
+  uint8_t* visited = (uint8_t*)malloc(nNodes * sizeof(uint8_t));
+
+  if (!edgeUsage || !visited) {
+    if (edgeUsage) free(edgeUsage);
+    if (visited) free(visited);
+    WARN("Unable to allocate memory with malloc/calloc");
+    return ncclInternalError;
+  }
+
+  int startNode = 0;
+  for (int c = 0; c < nChannels; c++) {
+    if (c < nNodes / 2) {
+      generateWalecki(nNodes, c, &nodeOrder[c * nNodes]);
+      for (int i = 0; i < nNodes; i++) {
+        int u = nodeOrder[c * nNodes + i];
+        int v = nodeOrder[c * nNodes + ((i + 1) % nNodes)];
+        edgeUsage[u * nNodes + v]++;
+      }
+      continue;
+    }
+        // Set all non-visited
+    memset(visited, 0, nNodes * sizeof(uint8_t));
+        // Only to reduce the pressure on starting node
+    startNode = (startNode + 1) % nNodes;
+    int curr = startNode;
+    nodeOrder[c * nNodes + 0] = curr;
+    visited[curr] = 1;
+
+    for (int step = 1; step < nNodes; step++) {
+      int bestNext = -1;
+      int minCost = INT_MAX;
+
+      for (int next = 0; next < nNodes; next++) {
+        if (!visited[next]) {
+          int cost = (int)edgeUsage[curr * nNodes + next];
+
+          // Without this check, a greedy algorithm might pick a "cheap" bestNext for the second-to-last
+          // node, but that node might have a very "expensive" (heavily used) link back to the start.
+          if (step == nNodes - 1) {
+            cost += (int)edgeUsage[next * nNodes + startNode];
+          }
+
+          if (cost < minCost) {
+            minCost = cost;
+            bestNext = next;
+          }
+        }
+      }
+      nodeOrder[c * nNodes + step] = bestNext;
+      visited[bestNext] = 1;
+      edgeUsage[curr * nNodes + bestNext]++;
+      curr = bestNext;
+    }
+    edgeUsage[curr * nNodes + startNode]++;
+  }
+  free(visited);
+  free(edgeUsage);
+  return ncclSuccess;
 }
 
 /**
  * This is a helper function for debug logs
- * 
- * @param comm     [in] ncclComm, read only variable 
+ *
+ * @param comm     [in] ncclComm, read only variable
  * @param ringRecv [in] integer array of size >= MAXCHANNELS*nNodes
  * @param ringSend [in] integer array of size >= MAXCHANNELS*nNodes
  */
-static  ncclResult_t printRecvSendLocalRanks(const struct ncclComm* comm, const int* ringRecv, const int* ringSend) {
+static ncclResult_t printRecvSendLocalRanks(const struct ncclComm* comm, const int* ringRecv, const int* ringSend) {
   int nChannels = comm->nChannels;
   int nNodes = comm->nNodes;
   char buff[2048] = "";
   int offset = 0;
   int inc;
-  int numChannels = (nChannels > MAXCHANNELS/2) ? 2 * nChannels : nChannels;
+  int numChannels = (nChannels > MAXCHANNELS / 2) ? 2 * nChannels : nChannels;
 
   for (int c = 0; c < numChannels; c++) {
     sprintf(buff + offset, "     %02d%n", c, &inc);
@@ -463,9 +458,9 @@ static  ncclResult_t printRecvSendLocalRanks(const struct ncclComm* comm, const 
   for (int n = 0; n < nNodes; n++) {
     offset = 0;
     for (int c = 0; c < nChannels; c++) {
-      int recvRank = comm->rankToLocalRank[ringRecv[c*comm->nNodes+n]];
-      int sendRank = comm->rankToLocalRank[ringSend[c*comm->nNodes+n]];
-      sprintf(buff + offset, " %02d->%02d%n",  recvRank, sendRank, &inc);
+      int recvRank = comm->rankToLocalRank[ringRecv[c * comm->nNodes + n]];
+      int sendRank = comm->rankToLocalRank[ringSend[c * comm->nNodes + n]];
+      sprintf(buff + offset, " %02d->%02d%n", recvRank, sendRank, &inc);
       offset += inc;
     }
     INFO(NCCL_GRAPH, "[RINGS] %s", buff);
@@ -474,27 +469,30 @@ static  ncclResult_t printRecvSendLocalRanks(const struct ncclComm* comm, const 
 }
 
 /**
- * connectRingsLoadBalanced : Assumes every node has entry and exit ranks (ringRecv[channel][node] and ringSend[channel][node]) 
- * among all the ranks its holds i.e local ranks. This function internally constructs Walecki + heuristic edge usage 
+ * connectRingsLoadBalanced : Assumes every node has entry and exit ranks (ringRecv[channel][node] and ringSend[channel][node])
+ * among all the ranks its holds i.e local ranks. This function internally constructs Walecki + heuristic edge usage
  * based Hamiltonian cycles ( where node in the graph correspond to physical nodes )
  * For example for a 4 node system with 6 channels, we create [[0,2,1,3],[1,0,2,3],[1,2,0,3],[2,0,1,3],[3,0,1,2],[0,3,2,1]] as rings
  * Each of the edge is used twice. This roughly gives Good network load balancing, assuming that all the nodes is P2P connected (via Switch)
- * Iterates over all nodes [0 to nNodes-1] 
+ * Iterates over all nodes [0 to nNodes-1]
  */
 
-static ncclResult_t connectRingsLoadBalanced(struct ncclComm* comm, int* ringRecv, int* ringSend, int* ringPrev, int* ringNext) {
+static ncclResult_t connectRingsLoadBalanced(struct ncclComm* comm, int* ringRecv, int* ringSend, int* ringPrev,
+                                             int* ringNext) {
   int nChannels = comm->nChannels;
   int nNodes = comm->nNodes;
   int nRanks = comm->nRanks;
-  if( nChannels <= 0 || nNodes <= 0 || nRanks <= 0 ) return ncclInvalidArgument;
+  if (nChannels <= 0 || nNodes <= 0 || nRanks <= 0) return ncclInvalidArgument;
 
   // 1. Allocate flat memory for nodeOrder [nChannels * nNodes]
   int* nodeOrder = nullptr;
   NCCLCHECK(ncclCalloc(&nodeOrder, nChannels * nNodes));
 
   // Note: generateGreedyNodeOrder needs to handle the flat indexing (c * nNodes + i)
-  if ( nChannels > MAXCHANNELS || nChannels >= 255 ) {
-    WARN(" generateGreedyNodeOrder is implemented with an assumption nChannels [=%d] < 255 as an optimization. Update the implementaion to accept uint16/32 for nChannels ",nChannels );
+  if (nChannels > MAXCHANNELS || nChannels >= 255) {
+    WARN(" generateGreedyNodeOrder is implemented with an assumption nChannels [=%d] < 255 as an optimization. Update "
+         "the implementaion to accept uint16/32 for nChannels ",
+         nChannels);
   }
 
   // 2. Populate the Diverse/Greedy Node Order
@@ -506,15 +504,15 @@ static ncclResult_t connectRingsLoadBalanced(struct ncclComm* comm, int* ringRec
     int* c_send = ringSend + c * nNodes;
     int* c_prev = ringPrev + c * nRanks;
     int* c_next = ringNext + c * nRanks;
-    
+
     // Current channel's node sequence
     int* c_order = nodeOrder + (c * nNodes);
 
     for (int i = 0; i < nNodes; i++) {
       // Find the physical nodes in the logical ring sequence
       int pNodeIdx = c_order[(i - 1 + nNodes) % nNodes]; // Physical Prev Node ID
-      int cNodeIdx = c_order[i];                         // Physical Curr Node ID
-      int nNodeIdx = c_order[(i + 1) % nNodes];          // Physical Next Node ID
+      int cNodeIdx = c_order[i]; // Physical Curr Node ID
+      int nNodeIdx = c_order[(i + 1) % nNodes]; // Physical Next Node ID
 
       // Link: Previous Node's EXIT rank -> Current Node's ENTRY rank
       // recv[cNodeIdx] gives the rank on the current node that receives from outside
@@ -529,9 +527,8 @@ static ncclResult_t connectRingsLoadBalanced(struct ncclComm* comm, int* ringRec
   free(nodeOrder);
 
   // [RCCL] Print off the recv/send local ranks per node, per channel
-  if (comm->rank == 0)
-  {
-    printRecvSendLocalRanks(comm,ringRecv,ringSend);
+  if (comm->rank == 0) {
+    printRecvSendLocalRanks(comm, ringRecv, ringSend);
   }
 
   return ncclSuccess;
@@ -539,40 +536,39 @@ static ncclResult_t connectRingsLoadBalanced(struct ncclComm* comm, int* ringRec
 
 /**
  * connectRings: Assumes every node has entry and exit (ringRecv[channel][node] and ringSend[channel][node]) rank
- * among all the ranks its holds i.e local ranks. This function assumes node i and ((i + 1) mod nNodes) as logically 
+ * among all the ranks its holds i.e local ranks. This function assumes node i and ((i + 1) mod nNodes) as logically
  * adjacent and connects previous node exit -> current node entry  and current node exit to next node entry.
- * Iterates over all nodes [0 to nNodes-1] 
+ * Iterates over all nodes [0 to nNodes-1]
  */
 static ncclResult_t connectRings(struct ncclComm* comm, int* ringRecv, int* ringSend, int* ringPrev, int* ringNext) {
   int nChannels = comm->nChannels;
   int nNodes = comm->nNodes;
-  for (int c=0; c<nChannels; c++) {
-    int* recv = ringRecv+c*comm->nNodes;
-    int* send = ringSend+c*comm->nNodes;
-    int* prev = ringPrev+c*comm->nRanks;
-    int* next = ringNext+c*comm->nRanks;
-    for (int n=0; n<nNodes; n++) {
+  for (int c = 0; c < nChannels; c++) {
+    int* recv = ringRecv + c * comm->nNodes;
+    int* send = ringSend + c * comm->nNodes;
+    int* prev = ringPrev + c * comm->nRanks;
+    int* next = ringNext + c * comm->nRanks;
+    for (int n = 0; n < nNodes; n++) {
       int recvRank = recv[n];
-      int prevSendRank = send[(n-1+nNodes)%nNodes];
+      int prevSendRank = send[(n - 1 + nNodes) % nNodes];
       prev[recvRank] = prevSendRank;
       int sendRank = send[n];
-      int nextRecvRank = recv[(n+1)%nNodes];
+      int nextRecvRank = recv[(n + 1) % nNodes];
       next[sendRank] = nextRecvRank;
     }
   }
 
   // [RCCL] Print off the recv/send local ranks per node, per channel
-  if (comm->rank == 0)
-  {
-    printRecvSendLocalRanks(comm,ringRecv,ringSend);
+  if (comm->rank == 0) {
+    printRecvSendLocalRanks(comm, ringRecv, ringSend);
   }
 
   return ncclSuccess;
 }
 
 static ncclResult_t getIndexes(int* ranks, int* indexes, int nNodes) {
- for (int n=0; n<nNodes; n++) indexes[n] = ranks[n];
- return ncclSuccess;
+  for (int n = 0; n < nNodes; n++) indexes[n] = ranks[n];
+  return ncclSuccess;
 }
 
 static ncclResult_t setTreeUp(struct ncclTree* tree, int* indexes, int u) {
@@ -593,90 +589,90 @@ static ncclResult_t setTreeDown(struct ncclTree* tree, int* indexes, int d) {
   return ncclSuccess;
 }
 
-static ncclResult_t connectTrees(struct ncclComm* comm, int* treeToParent, int* treeToChild0, int* treeToChild1, int* treePatterns) {
-
+static ncclResult_t connectTrees(struct ncclComm* comm, int* treeToParent, int* treeToChild0, int* treeToChild1,
+                                 int* treePatterns) {
   // gfx942/gfx950/gfx1250 use the doubled channel limit (2*CHANNEL_LIMIT)
   const int channelLimit = (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942") ||
                             IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950") ||
-                            IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx1250")) ? 2*CHANNEL_LIMIT : CHANNEL_LIMIT;
+                            IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx1250")) ?
+                             2 * CHANNEL_LIMIT :
+                             CHANNEL_LIMIT;
   const int nChannels = (comm->nChannels > channelLimit) ? comm->nChannels / 2 : comm->nChannels;
   const int nNodes = comm->nNodes, node = comm->node;
   // Compute tree depth. Not an exact value but a good approximation in most
   // cases
-  int depth = comm->nRanks/nNodes - 1 + log2i(nNodes);
+  int depth = comm->nRanks / nNodes - 1 + log2i(nNodes);
 
   int t0u, t0d0, t0d1, t0ChildType = 0, t1u, t1d0, t1d1, t1ChildType = 0;
-  int* ttp, *ttc0, *ttc1;
+  int *ttp, *ttc0, *ttc1;
   NCCLCHECK(ncclGetDtree(nNodes, node, &t0u, &t0d0, &t0d1, &t0ChildType, &t1u, &t1d0, &t1d1, &t1ChildType));
   if (nChannels == comm->nChannels) {
-    for (int c=0; c<nChannels; c++) {
-       struct ncclChannel* channel0 = comm->channels+c;
-       struct ncclChannel* channel1 = channel0+nChannels;
-       ttp = treeToParent+c*comm->nNodes;
-       ttc0 = treeToChild0+c*comm->nNodes;
-       ttc1 = treeToChild1+c*comm->nNodes;
-       if (comm->rank == ttp[node]) {
-         NCCLCHECK(setTreeUp(&channel0->tree, t0ChildType == 0 ? ttc0 : ttc1, t0u));
-         NCCLCHECK(setTreeUp(&channel1->tree, t1ChildType == 0 ? ttc0 : ttc1, t1u));
-       }
-       if (comm->rank == ttc0[node]) {
-         NCCLCHECK(setTreeDown(&channel0->tree, ttp, t0d0));
-         NCCLCHECK(setTreeDown(&channel1->tree, ttp, t1d0));
-       }
-       if (comm->rank == ttc1[node]) {
-         NCCLCHECK(setTreeDown(&channel0->tree, ttp, t0d1));
-         NCCLCHECK(setTreeDown(&channel1->tree, ttp, t1d1));
-       }
-       if (comm->rank == ttp[node] ||
-           comm->rank == ttc0[node] ||
-           comm->rank == ttc1[node]) {
-         INFO(NCCL_GRAPH, "Tree %d : %d -> %d -> %d/%d/%d", c,           channel0->tree.up, comm->rank, channel0->tree.down[0], channel0->tree.down[1], channel0->tree.down[2]);
-         INFO(NCCL_GRAPH, "Tree %d : %d -> %d -> %d/%d/%d", c+nChannels, channel1->tree.up, comm->rank, channel1->tree.down[0], channel1->tree.down[1], channel1->tree.down[2]);
-       }
-       channel0->tree.depth = channel1->tree.depth = depth;
+    for (int c = 0; c < nChannels; c++) {
+      struct ncclChannel* channel0 = comm->channels + c;
+      struct ncclChannel* channel1 = channel0 + nChannels;
+      ttp = treeToParent + c * comm->nNodes;
+      ttc0 = treeToChild0 + c * comm->nNodes;
+      ttc1 = treeToChild1 + c * comm->nNodes;
+      if (comm->rank == ttp[node]) {
+        NCCLCHECK(setTreeUp(&channel0->tree, t0ChildType == 0 ? ttc0 : ttc1, t0u));
+        NCCLCHECK(setTreeUp(&channel1->tree, t1ChildType == 0 ? ttc0 : ttc1, t1u));
+      }
+      if (comm->rank == ttc0[node]) {
+        NCCLCHECK(setTreeDown(&channel0->tree, ttp, t0d0));
+        NCCLCHECK(setTreeDown(&channel1->tree, ttp, t1d0));
+      }
+      if (comm->rank == ttc1[node]) {
+        NCCLCHECK(setTreeDown(&channel0->tree, ttp, t0d1));
+        NCCLCHECK(setTreeDown(&channel1->tree, ttp, t1d1));
+      }
+      if (comm->rank == ttp[node] || comm->rank == ttc0[node] || comm->rank == ttc1[node]) {
+        INFO(NCCL_GRAPH, "Tree %d : %d -> %d -> %d/%d/%d", c, channel0->tree.up, comm->rank, channel0->tree.down[0],
+             channel0->tree.down[1], channel0->tree.down[2]);
+        INFO(NCCL_GRAPH, "Tree %d : %d -> %d -> %d/%d/%d", c + nChannels, channel1->tree.up, comm->rank,
+             channel1->tree.down[0], channel1->tree.down[1], channel1->tree.down[2]);
+      }
+      channel0->tree.depth = channel1->tree.depth = depth;
     }
   } else {
-    for (int c=0; c<nChannels; c++) {
-       struct ncclChannel* channel0 = comm->channels+c;
-       ttp = treeToParent+c*comm->nNodes;
-       ttc0 = treeToChild0+c*comm->nNodes;
-       ttc1 = treeToChild1+c*comm->nNodes;
-       if (comm->rank == ttp[node]) {
-         NCCLCHECK(setTreeUp(&channel0->tree, t0ChildType == 0 ? ttc0 : ttc1, t0u));
-       }
-       if (comm->rank == ttc0[node]) {
-         NCCLCHECK(setTreeDown(&channel0->tree, ttp, t0d0));
-       }
-       if (comm->rank == ttc1[node]) {
-         NCCLCHECK(setTreeDown(&channel0->tree, ttp, t0d1));
-       }
-       if (comm->rank == ttp[node] ||
-           comm->rank == ttc0[node] ||
-           comm->rank == ttc1[node]) {
-         INFO(NCCL_GRAPH, "Tree %d : %d -> %d -> %d/%d/%d", c,           channel0->tree.up, comm->rank, channel0->tree.down[0], channel0->tree.down[1], channel0->tree.down[2]);
-       }
-       channel0->tree.depth = depth;
+    for (int c = 0; c < nChannels; c++) {
+      struct ncclChannel* channel0 = comm->channels + c;
+      ttp = treeToParent + c * comm->nNodes;
+      ttc0 = treeToChild0 + c * comm->nNodes;
+      ttc1 = treeToChild1 + c * comm->nNodes;
+      if (comm->rank == ttp[node]) {
+        NCCLCHECK(setTreeUp(&channel0->tree, t0ChildType == 0 ? ttc0 : ttc1, t0u));
+      }
+      if (comm->rank == ttc0[node]) {
+        NCCLCHECK(setTreeDown(&channel0->tree, ttp, t0d0));
+      }
+      if (comm->rank == ttc1[node]) {
+        NCCLCHECK(setTreeDown(&channel0->tree, ttp, t0d1));
+      }
+      if (comm->rank == ttp[node] || comm->rank == ttc0[node] || comm->rank == ttc1[node]) {
+        INFO(NCCL_GRAPH, "Tree %d : %d -> %d -> %d/%d/%d", c, channel0->tree.up, comm->rank, channel0->tree.down[0],
+             channel0->tree.down[1], channel0->tree.down[2]);
+      }
+      channel0->tree.depth = depth;
     }
-    for (int c=nChannels; c<nChannels*2; c++) {
-       struct ncclChannel* channel1 = comm->channels+c;
-       ttp = treeToParent+c*comm->nNodes;
-       ttc0 = treeToChild0+c*comm->nNodes;
-       ttc1 = treeToChild1+c*comm->nNodes;
-       if (comm->rank == ttp[node]) {
-         NCCLCHECK(setTreeUp(&channel1->tree, t1ChildType == 0 ? ttc0 : ttc1, t1u));
-       }
-       if (comm->rank == ttc0[node]) {
-         NCCLCHECK(setTreeDown(&channel1->tree, ttp, t1d0));
-       }
-       if (comm->rank == ttc1[node]) {
-         NCCLCHECK(setTreeDown(&channel1->tree, ttp, t1d1));
-       }
-       if (comm->rank == ttp[node] ||
-           comm->rank == ttc0[node] ||
-           comm->rank == ttc1[node]) {
-         INFO(NCCL_GRAPH, "Tree %d : %d -> %d -> %d/%d/%d", c+nChannels, channel1->tree.up, comm->rank, channel1->tree.down[0], channel1->tree.down[1], channel1->tree.down[2]);
-       }
-       channel1->tree.depth = depth;
+    for (int c = nChannels; c < nChannels * 2; c++) {
+      struct ncclChannel* channel1 = comm->channels + c;
+      ttp = treeToParent + c * comm->nNodes;
+      ttc0 = treeToChild0 + c * comm->nNodes;
+      ttc1 = treeToChild1 + c * comm->nNodes;
+      if (comm->rank == ttp[node]) {
+        NCCLCHECK(setTreeUp(&channel1->tree, t1ChildType == 0 ? ttc0 : ttc1, t1u));
+      }
+      if (comm->rank == ttc0[node]) {
+        NCCLCHECK(setTreeDown(&channel1->tree, ttp, t1d0));
+      }
+      if (comm->rank == ttc1[node]) {
+        NCCLCHECK(setTreeDown(&channel1->tree, ttp, t1d1));
+      }
+      if (comm->rank == ttp[node] || comm->rank == ttc0[node] || comm->rank == ttc1[node]) {
+        INFO(NCCL_GRAPH, "Tree %d : %d -> %d -> %d/%d/%d", c + nChannels, channel1->tree.up, comm->rank,
+             channel1->tree.down[0], channel1->tree.down[1], channel1->tree.down[2]);
+      }
+      channel1->tree.depth = depth;
     }
   }
   return ncclSuccess;
@@ -686,61 +682,64 @@ static ncclResult_t connectCollNet(struct ncclComm* comm, struct ncclTopoGraph* 
   int rank = comm->rank;
   int localRanks = comm->localRanks;
   int nHeads = 0;
-  int *heads;
+  int* heads;
   NCCLCHECK(ncclCalloc(&heads, localRanks));
   // Find all head ranks
   // Head index is always 0
-  for (int c=0; c<collNetGraph->nChannels; c++) {
-    int* collNetIntra = collNetGraph->intra+c*localRanks;
+  for (int c = 0; c < collNetGraph->nChannels; c++) {
+    int* collNetIntra = collNetGraph->intra + c * localRanks;
     int head = collNetIntra[0];
-    for (int h=0; h<nHeads; h++) if (heads[h] == head) head = -1;
+    for (int h = 0; h < nHeads; h++)
+      if (heads[h] == head) head = -1;
     if (head != -1) heads[nHeads++] = collNetIntra[0];
   }
   // For all channels
-  for (int c=0; c<comm->nChannels; c++) {
-    struct ncclChannel* channel = comm->channels+c;
+  for (int c = 0; c < comm->nChannels; c++) {
+    struct ncclChannel* channel = comm->channels + c;
     char line[1024];
     sprintf(line, "CollNetDirect channel %d rank %d ", c, rank);
     int nDown = 0;
-    for (int i=0; i<nHeads; i++) {
+    for (int i = 0; i < nHeads; i++) {
       if (rank == heads[i]) { // is head
         channel->collnetDirect.headRank = i; // Mark the index for deciding offset in the CUDA kernel
         channel->collnetDirect.out = comm->nRanks; // Set root of collnetDirect to id nranks
-        int* collNetIntra = collNetGraph->intra+i*localRanks;
-        sprintf(line+strlen(line), "down ");
-        for (int r=0; r<localRanks; r++) {
+        int* collNetIntra = collNetGraph->intra + i * localRanks;
+        sprintf(line + strlen(line), "down ");
+        for (int r = 0; r < localRanks; r++) {
           if (collNetIntra[r] == rank) continue;
-          channel->collnetDirect.down[nDown++] = collNetIntra[r];  // connect to all peers
-          sprintf(line+strlen(line), " %d ", collNetIntra[r]);
+          channel->collnetDirect.down[nDown++] = collNetIntra[r]; // connect to all peers
+          sprintf(line + strlen(line), " %d ", collNetIntra[r]);
         }
-        sprintf(line+strlen(line), "nDown %d ", nDown);
+        sprintf(line + strlen(line), "nDown %d ", nDown);
         break;
       }
     }
     // Connect to all heads
     int nUp = 0;
-    sprintf(line+strlen(line), "up ");
-    for (int h=0; h<nHeads; h++) {
+    sprintf(line + strlen(line), "up ");
+    for (int h = 0; h < nHeads; h++) {
       if (rank == heads[h]) continue;
       channel->collnetDirect.up[nUp++] = heads[h];
-      sprintf(line+strlen(line), " %d ", heads[h]);
+      sprintf(line + strlen(line), " %d ", heads[h]);
     }
-    sprintf(line+strlen(line), "heads ");
+    sprintf(line + strlen(line), "heads ");
     { // heads[] is the list of heads ordered in head order startubg with self
       int h0 = (channel->collnetDirect.headRank == -1) ? 0 : channel->collnetDirect.headRank;
-      for (int h1=0; h1 < nHeads; h1++) {
-        int h = (h0+h1)%nHeads;
+      for (int h1 = 0; h1 < nHeads; h1++) {
+        int h = (h0 + h1) % nHeads;
         channel->collnetDirect.heads[h1] = heads[h];
-        sprintf(line+strlen(line), " %d ", heads[h]);
+        sprintf(line + strlen(line), " %d ", heads[h]);
       }
     }
     channel->collnetDirect.nHeads = nHeads;
     // nHeads should always be greater than 0.
     // coverity[divide_by_zero]
-    channel->collnetDirect.shift = (rank%localRanks)%nHeads; // Shift by intraRank so that leaves don't send to same head simultaneously
+    channel->collnetDirect.shift =
+      (rank % localRanks) % nHeads; // Shift by intraRank so that leaves don't send to same head simultaneously
     channel->collnetDirect.depth = (nUp == 0 && nDown == 0) ? 1 : 2;
-    sprintf(line+strlen(line), "nUp %d nHeads %d ", nUp, nHeads);
-    sprintf(line+strlen(line), "headRank %d out %d shift %d", channel->collnetDirect.headRank, channel->collnetDirect.out, channel->collnetDirect.shift);
+    sprintf(line + strlen(line), "nUp %d nHeads %d ", nUp, nHeads);
+    sprintf(line + strlen(line), "headRank %d out %d shift %d", channel->collnetDirect.headRank,
+            channel->collnetDirect.out, channel->collnetDirect.shift);
     INFO(NCCL_GRAPH, "%s", line);
   }
   free(heads);
@@ -758,13 +757,13 @@ static ncclResult_t connectNvls(struct ncclComm* comm, int* nvlsHeads, int nHead
     if (nvlsHeads[h * comm->nNodes + comm->node] == comm->rank) headRank = h;
   }
 
-  for (int c=0; c<comm->nvlsChannels; c++) {
-    struct ncclChannel* channel = comm->channels+c;
+  for (int c = 0; c < comm->nvlsChannels; c++) {
+    struct ncclChannel* channel = comm->channels + c;
     channel->nvls.nHeads = nHeads;
-    for (int h=0; h<nHeads; h++) channel->nvls.up[h] = comm->nRanks+1+h;
-    for (int h=nHeads; h<NCCL_MAX_NVLS_ARITY; h++) channel->nvls.up[h] = -1;
-    channel->nvls.down = comm->nRanks+1+headRank;
-    channel->nvls.out = -1;       // NVLS+SHARP not yet implemented.
+    for (int h = 0; h < nHeads; h++) channel->nvls.up[h] = comm->nRanks + 1 + h;
+    for (int h = nHeads; h < NCCL_MAX_NVLS_ARITY; h++) channel->nvls.up[h] = -1;
+    channel->nvls.down = comm->nRanks + 1 + headRank;
+    channel->nvls.out = -1; // NVLS+SHARP not yet implemented.
     channel->nvls.headRank = headRank;
     channel->nvls.treeUp = channel->nvls.treeDown[0] = channel->nvls.treeDown[1] = channel->nvls.treeDown[2] = -1;
     if (comm->config.collnetEnable && channel->nvls.headRank != -1) channel->nvls.out = comm->nRanks;
@@ -774,32 +773,31 @@ static ncclResult_t connectNvls(struct ncclComm* comm, int* nvlsHeads, int nHead
   // Connect Trees
   int tree0Parent, tree0Child0, tree0Child1, tree1Parent, tree1Child0, tree1Child1;
   int pc0, pc1; // ignored
-  NCCLCHECK(ncclGetDtree(comm->nNodes, comm->node,
-        &tree0Parent, &tree0Child0, &tree0Child1, &pc0,
-        &tree1Parent, &tree1Child0, &tree1Child1, &pc1));
+  NCCLCHECK(ncclGetDtree(comm->nNodes, comm->node, &tree0Parent, &tree0Child0, &tree0Child1, &pc0, &tree1Parent,
+                         &tree1Child0, &tree1Child1, &pc1));
 
   int* heads = NULL;
-  int treeUp[2] = { -1, -1 };
-  int treeDown0[2] = { -1, -1 };
-  int treeDown1[2] = { -1, -1 };
+  int treeUp[2] = {-1, -1};
+  int treeDown0[2] = {-1, -1};
+  int treeDown1[2] = {-1, -1};
 
   if (comm->node == 0) {
-    for (int h=0; h<nHeads; h++) {
+    for (int h = 0; h < nHeads; h++) {
       char line[1024];
       sprintf(line, "NVLS Head %2d:", h);
-      heads = nvlsHeads+h*comm->nNodes;
-      for (int n=0; n<comm->nNodes && n<20; n++) {
-        sprintf(line+strlen(line), " %2d", heads[n]);
+      heads = nvlsHeads + h * comm->nNodes;
+      for (int n = 0; n < comm->nNodes && n < 20; n++) {
+        sprintf(line + strlen(line), " %2d", heads[n]);
       }
       INFO(NCCL_INIT, "%s", line);
     }
   }
 
   // Find the heads where I'm the head rank and retain tree up/down
-  for (int h=0; h<nHeads; h++) {
-    heads = nvlsHeads+h*comm->nNodes;
+  for (int h = 0; h < nHeads; h++) {
+    heads = nvlsHeads + h * comm->nNodes;
     if (heads[comm->node] == comm->rank) {
-      treeUp[0] = tree0Parent == -1 ? -1: heads[tree0Parent];
+      treeUp[0] = tree0Parent == -1 ? -1 : heads[tree0Parent];
       treeDown0[0] = tree0Child0 == -1 ? -1 : heads[tree0Child0];
       treeDown1[0] = tree0Child1 == -1 ? -1 : heads[tree0Child1];
       treeUp[1] = tree1Parent == -1 ? -1 : heads[tree1Parent];
@@ -810,20 +808,20 @@ static ncclResult_t connectNvls(struct ncclComm* comm, int* nvlsHeads, int nHead
   }
   // Set prev/next in all channels (NVLS compute channels work
   // orthogonally to NVLS search channels).
-  for (int c=0; c<comm->nvlsChannels; c++) {
-    struct ncclChannel* channel = comm->channels+c;
-    channel->nvls.treeUp = treeUp[c%2];
+  for (int c = 0; c < comm->nvlsChannels; c++) {
+    struct ncclChannel* channel = comm->channels + c;
+    channel->nvls.treeUp = treeUp[c % 2];
     channel->nvls.treeDown[0] = channel->nvls.down;
     int ix = 1;
-    if (treeDown0[c%2] != -1) channel->nvls.treeDown[ix++] = treeDown0[c%2];
-    if (treeDown1[c%2] != -1) channel->nvls.treeDown[ix] = treeDown1[c%2];
+    if (treeDown0[c % 2] != -1) channel->nvls.treeDown[ix++] = treeDown0[c % 2];
+    if (treeDown1[c % 2] != -1) channel->nvls.treeDown[ix] = treeDown1[c % 2];
   }
 
   struct ncclNvls* nvls0 = &comm->channels[0].nvls;
   struct ncclNvls* nvls1 = &comm->channels[1].nvls;
-  INFO(NCCL_GRAPH, "NVLS Trees : %d/%d/%d->%d->%d %d/%d/%d->%d->%d",
-      nvls0->treeDown[0], nvls0->treeDown[1], nvls0->treeDown[2], comm->rank, nvls0->treeUp,
-      nvls1->treeDown[0], nvls1->treeDown[1], nvls1->treeDown[2], comm->rank, nvls1->treeUp);
+  INFO(NCCL_GRAPH, "NVLS Trees : %d/%d/%d->%d->%d %d/%d/%d->%d->%d", nvls0->treeDown[0], nvls0->treeDown[1],
+       nvls0->treeDown[2], comm->rank, nvls0->treeUp, nvls1->treeDown[0], nvls1->treeDown[1], nvls1->treeDown[2],
+       comm->rank, nvls1->treeUp);
   return ncclSuccess;
 }
 
@@ -839,7 +837,7 @@ int ncclMinNchannels() {
   if (ncclParamMinNrings() != -2) minNchannels = ncclParamMinNrings();
   if (ncclParamMinNchannels() != -2) minNchannels = ncclParamMinNchannels();
   if (minNchannels > MAXCHANNELS) {
-    INFO(NCCL_GRAPH|NCCL_ENV, "User asked for a minimum of %d channels, limiting to %d", minNchannels, MAXCHANNELS);
+    INFO(NCCL_GRAPH | NCCL_ENV, "User asked for a minimum of %d channels, limiting to %d", minNchannels, MAXCHANNELS);
     minNchannels = MAXCHANNELS;
   }
   if (minNchannels < 0) minNchannels = 0;
@@ -855,7 +853,7 @@ int ncclMaxNchannels() {
   maxNchannels = std::min(maxNchannels, ncclDevMaxChannelsForArgsBytes(ncclParamWorkArgsBytes()));
   if (maxNchannels > MAXCHANNELS) maxNchannels = MAXCHANNELS;
   if (maxNchannels < 1) {
-    INFO(NCCL_GRAPH|NCCL_ENV, "User asked for a maximum of %d channels, setting it to 1", maxNchannels);
+    INFO(NCCL_GRAPH | NCCL_ENV, "User asked for a maximum of %d channels, setting it to 1", maxNchannels);
     maxNchannels = 1;
   }
   return maxNchannels;
@@ -864,10 +862,10 @@ int ncclMaxNchannels() {
 static int copyChannels(struct ncclComm* comm, int start, int end, int* ringPrev, int* ringNext) {
   int nranks = comm->nRanks;
   int c;
-  for (c=start; c<end; c++) {
-    memcpy(ringPrev+c*nranks, ringPrev+(c-start)*nranks, nranks*sizeof(int));
-    memcpy(ringNext+c*nranks, ringNext+(c-start)*nranks, nranks*sizeof(int));
-    memcpy(comm->channels+c, comm->channels+c-start, sizeof(struct ncclChannel));
+  for (c = start; c < end; c++) {
+    memcpy(ringPrev + c * nranks, ringPrev + (c - start) * nranks, nranks * sizeof(int));
+    memcpy(ringNext + c * nranks, ringNext + (c - start) * nranks, nranks * sizeof(int));
+    memcpy(comm->channels + c, comm->channels + c - start, sizeof(struct ncclChannel));
   }
   return c;
 }
@@ -878,14 +876,12 @@ void exchangeValues(int* v0, int* v1) {
   *v0 = tmp;
 }
 
-int getTreeNodeParity(int treeDir, int nNodes, int node)
-{
+int getTreeNodeParity(int treeDir, int nNodes, int node) {
   if (node == -1) return -1;
 
   int parentNodes[2], child0Nodes[2], child1Nodes[2], childTypes[2];
-  ncclGetDtree(nNodes, node,
-               &parentNodes[0], &child0Nodes[0], &child1Nodes[0], &childTypes[0],
-               &parentNodes[1], &child0Nodes[1], &child1Nodes[1], &childTypes[1]);
+  ncclGetDtree(nNodes, node, &parentNodes[0], &child0Nodes[0], &child1Nodes[0], &childTypes[0], &parentNodes[1],
+               &child0Nodes[1], &child1Nodes[1], &childTypes[1]);
 
   // Uptree and downtree have different parity
   if (parentNodes[treeDir] == -1) return treeDir;
@@ -895,8 +891,7 @@ int getTreeNodeParity(int treeDir, int nNodes, int node)
 }
 
 // [RCCL] Build rail-optimized trees
-ncclResult_t connectRailOptimizedTrees(struct ncclComm* comm, int* treeToParent, int* treeToChild0, int* treeToChild1)
-{
+ncclResult_t connectRailOptimizedTrees(struct ncclComm* comm, int* treeToParent, int* treeToChild0, int* treeToChild1) {
   INFO(NCCL_GRAPH, "Building rail-optimized trees for %d nodes", comm->nNodes);
 
   /* Rail-optimized trees are implemented in RCCL via a set of specially crafted complimentary
@@ -930,14 +925,13 @@ ncclResult_t connectRailOptimizedTrees(struct ncclComm* comm, int* treeToParent,
 
   const int nChannels = (comm->nChannels / 2);
   const int nNodes = comm->nNodes, node = comm->node, rank = comm->rank;
-  const int depth = comm->nRanks/nNodes - 1 + log2i(nNodes);
+  const int depth = comm->nRanks / nNodes - 1 + log2i(nNodes);
   const int nGpus = comm->topo->nodes[GPU].count;
   struct ncclTopoGraph* treeGraph = &comm->graphs[NCCL_ALGO_TREE];
 
   // Compute parent/child nodes for this current node, for uptree and downtree
   int parentNodes[2], child0Nodes[2], child1Nodes[2], childTypes[2];
-  NCCLCHECK(ncclGetDtree(nNodes, node,
-                         &parentNodes[0], &child0Nodes[0], &child1Nodes[0], &childTypes[0],
+  NCCLCHECK(ncclGetDtree(nNodes, node, &parentNodes[0], &child0Nodes[0], &child1Nodes[0], &childTypes[0],
                          &parentNodes[1], &child0Nodes[1], &child1Nodes[1], &childTypes[1]));
 
   // Loop over up-tree / down-tree
@@ -950,7 +944,7 @@ ncclResult_t connectRailOptimizedTrees(struct ncclComm* comm, int* treeToParent,
     int* treeToChild = (childTypes[treeDir] == 0) ? treeToChild0 : treeToChild1;
 
     // Compute the parity for nodes for this tree direction
-    int nodeParity   = getTreeNodeParity(treeDir, nNodes, node);
+    int nodeParity = getTreeNodeParity(treeDir, nNodes, node);
     int parentParity = getTreeNodeParity(treeDir, nNodes, parentNode);
     int child0Parity = getTreeNodeParity(treeDir, nNodes, child0Node);
     int child1Parity = getTreeNodeParity(treeDir, nNodes, child1Node);
@@ -976,12 +970,11 @@ ncclResult_t connectRailOptimizedTrees(struct ncclComm* comm, int* treeToParent,
         std::swap(rankToChild1[0], rankToChild1[1]);
 
         // Swap NICs
-        std::swap(treeGraph->inter[ch0 * 2    ], treeGraph->inter[ch1 * 2    ]);
+        std::swap(treeGraph->inter[ch0 * 2], treeGraph->inter[ch1 * 2]);
         std::swap(treeGraph->inter[ch0 * 2 + 1], treeGraph->inter[ch1 * 2 + 1]);
 
         // Swap lines
-        for (int j = 0; j < nGpus; j++)
-          std::swap(treeGraph->intra[ch0 * nGpus + j], treeGraph->intra[ch1 * nGpus + j]);
+        for (int j = 0; j < nGpus; j++) std::swap(treeGraph->intra[ch0 * nGpus + j], treeGraph->intra[ch1 * nGpus + j]);
       }
 
       // Connect ranks that connect to other nodes for each of the two channels
@@ -1003,14 +996,9 @@ ncclResult_t connectRailOptimizedTrees(struct ncclComm* comm, int* treeToParent,
           int child1Channel = (child1Parity + i) % 2 == 0 ? ch0 : ch1;
           setTreeDown(&channel[i]->tree, treeToParent + child1Channel * nNodes, child1Node);
         }
-        if (rank == rankToParent[i] ||
-            rank == rankToChild0[i] ||
-            rank == rankToChild1[i]) {
-          INFO(NCCL_GRAPH, "Tree %d : %d -> %d -> %d/%d/%d", (i == 0 ? ch0 : ch1),
-               channel[i]->tree.up, rank,
-               channel[i]->tree.down[0],
-               channel[i]->tree.down[1],
-               channel[i]->tree.down[2]);
+        if (rank == rankToParent[i] || rank == rankToChild0[i] || rank == rankToChild1[i]) {
+          INFO(NCCL_GRAPH, "Tree %d : %d -> %d -> %d/%d/%d", (i == 0 ? ch0 : ch1), channel[i]->tree.up, rank,
+               channel[i]->tree.down[0], channel[i]->tree.down[1], channel[i]->tree.down[2]);
         }
       }
     }
@@ -1022,9 +1010,9 @@ ncclResult_t connectRailOptimizedTrees(struct ncclComm* comm, int* treeToParent,
  * Check if search actually filled all requested channels
  * It is expected that these structures are filled by individual ranks followed by bootstrap allgather.
  * gfx1151 having 1-GPU/node communicating via ethernet is special case
- * But call to this function is a safety net for all architectures, and is idempotent, This only 
+ * But call to this function is a safety net for all architectures, and is idempotent, This only
  * handles Ring and Trees
- */ 
+ */
 static ncclResult_t repairMissingChannels(struct ncclTopoRanks** allTopoRanks, int nranks, int nChannels) {
   for (int r = 0; r < nranks; r++) {
     for (int c = 1; c < nChannels; c++) {
@@ -1039,8 +1027,7 @@ static ncclResult_t repairMissingChannels(struct ncclTopoRanks** allTopoRanks, i
       }
 
       // 2. TREE REPAIR: Trees use -1 as the 'None' sentinel
-      if (allTopoRanks[r]->treeToParent[c] == -1 && 
-          allTopoRanks[r]->treeToChild0[c] == -1) {
+      if (allTopoRanks[r]->treeToParent[c] == -1 && allTopoRanks[r]->treeToChild0[c] == -1) {
         allTopoRanks[r]->treeToParent[c] = allTopoRanks[r]->treeToParent[0];
         allTopoRanks[r]->treeToChild0[c] = allTopoRanks[r]->treeToChild0[0];
         allTopoRanks[r]->treeToChild1[c] = allTopoRanks[r]->treeToChild1[0];
@@ -1054,15 +1041,18 @@ static ncclResult_t repairMissingChannels(struct ncclTopoRanks** allTopoRanks, i
 NCCL_PARAM(UnpackDoubleNChannels, "UNPACK_DOUBLE_NCHANNELS", 1);
 RCCL_PARAM(OutputTrees, "OUTPUT_TREES", 0);
 
-ncclResult_t ncclTopoPostset(struct ncclComm* comm, int* firstRanks, int* treePatterns, struct ncclTopoRanks** allTopoRanks, int* rings, struct ncclTopoGraph** graphs, struct ncclComm* parent, int nc) {
+ncclResult_t ncclTopoPostset(struct ncclComm* comm, int* firstRanks, int* treePatterns,
+                             struct ncclTopoRanks** allTopoRanks, int* rings, struct ncclTopoGraph** graphs,
+                             struct ncclComm* parent, int nc) {
   // Gather data from all ranks
   ncclResult_t ret = ncclSuccess;
-  int *ringRecv = NULL, *ringSend = NULL, *ringPrev = NULL, *ringNext = NULL, *treeToParent = NULL, *treeToChild0 = NULL, *treeToChild1 = NULL, *nvlsHeads = NULL;
+  int *ringRecv = NULL, *ringSend = NULL, *ringPrev = NULL, *ringNext = NULL, *treeToParent = NULL,
+      *treeToChild0 = NULL, *treeToChild1 = NULL, *nvlsHeads = NULL;
   int nranks = comm->nRanks;
   int nNodes = comm->nNodes;
   int nChannels = comm->nChannels;
   int minHeadNum = INT_MAX;
-  int shared = parent && parent->nvlsSupport  && parent->shareResources;
+  int shared = parent && parent->nvlsSupport && parent->shareResources;
   int maxChannels;
   int minNchannels, maxNchannels;
   int duplicateCount = 1;
@@ -1075,16 +1065,16 @@ ncclResult_t ncclTopoPostset(struct ncclComm* comm, int* firstRanks, int* treePa
   const bool isGfx950 = IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950");
 #endif
   const bool isGfx1250 = IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx1250");
-  NCCLCHECK(ncclCalloc(&ringRecv, nNodes*MAXCHANNELS));
-  NCCLCHECKGOTO(ncclCalloc(&ringSend, nNodes*MAXCHANNELS), ret, fail);
-  NCCLCHECKGOTO(ncclCalloc(&ringPrev, nranks*MAXCHANNELS), ret, fail);
-  NCCLCHECKGOTO(ncclCalloc(&ringNext, nranks*MAXCHANNELS), ret, fail);
-  NCCLCHECKGOTO(ncclCalloc(&treeToParent, nNodes*MAXCHANNELS), ret, fail);
-  NCCLCHECKGOTO(ncclCalloc(&treeToChild0, nNodes*MAXCHANNELS), ret, fail);
-  NCCLCHECKGOTO(ncclCalloc(&treeToChild1, nNodes*MAXCHANNELS), ret, fail);
-  NCCLCHECKGOTO(ncclCalloc(&nvlsHeads, nNodes*MAXCHANNELS), ret, fail);
-  
-  NCCLCHECK(repairMissingChannels(allTopoRanks,nranks,nChannels));
+  NCCLCHECK(ncclCalloc(&ringRecv, nNodes * MAXCHANNELS));
+  NCCLCHECKGOTO(ncclCalloc(&ringSend, nNodes * MAXCHANNELS), ret, fail);
+  NCCLCHECKGOTO(ncclCalloc(&ringPrev, nranks * MAXCHANNELS), ret, fail);
+  NCCLCHECKGOTO(ncclCalloc(&ringNext, nranks * MAXCHANNELS), ret, fail);
+  NCCLCHECKGOTO(ncclCalloc(&treeToParent, nNodes * MAXCHANNELS), ret, fail);
+  NCCLCHECKGOTO(ncclCalloc(&treeToChild0, nNodes * MAXCHANNELS), ret, fail);
+  NCCLCHECKGOTO(ncclCalloc(&treeToChild1, nNodes * MAXCHANNELS), ret, fail);
+  NCCLCHECKGOTO(ncclCalloc(&nvlsHeads, nNodes * MAXCHANNELS), ret, fail);
+
+  NCCLCHECK(repairMissingChannels(allTopoRanks, nranks, nChannels));
   // Alternate rings to avoid crossing rails.
   // CrossNic values could be not the same on all nodes as it depends on the number of net devs and the NVLink bandwidth.
   // Therefore, it's only done if the rank obtained a solution with crossNic=2.
@@ -1092,35 +1082,34 @@ ncclResult_t ncclTopoPostset(struct ncclComm* comm, int* firstRanks, int* treePa
     for (int r = 0; r < comm->nRanks; r++) {
       if (allTopoRanks[r]->crossNicRing == 2 && (comm->rankToNode[r] % 2) == 1) {
         // Exchange rings
-        for (int c=0; c<nChannels; c+=2) {
-          exchangeValues(allTopoRanks[r]->ringRecv+c, allTopoRanks[r]->ringRecv+(c^1));
-          exchangeValues(allTopoRanks[r]->ringSend+c, allTopoRanks[r]->ringSend+(c^1));
-          exchangeValues(allTopoRanks[r]->ringPrev+c, allTopoRanks[r]->ringPrev+(c^1));
-          exchangeValues(allTopoRanks[r]->ringNext+c, allTopoRanks[r]->ringNext+(c^1));
+        for (int c = 0; c < nChannels; c += 2) {
+          exchangeValues(allTopoRanks[r]->ringRecv + c, allTopoRanks[r]->ringRecv + (c ^ 1));
+          exchangeValues(allTopoRanks[r]->ringSend + c, allTopoRanks[r]->ringSend + (c ^ 1));
+          exchangeValues(allTopoRanks[r]->ringPrev + c, allTopoRanks[r]->ringPrev + (c ^ 1));
+          exchangeValues(allTopoRanks[r]->ringNext + c, allTopoRanks[r]->ringNext + (c ^ 1));
         }
       }
     }
   }
 
-  for (int c=0; c<nChannels;c++) {
-    for (int n=0; n<nNodes; n++) {
+  for (int c = 0; c < nChannels; c++) {
+    for (int n = 0; n < nNodes; n++) {
       int r = firstRanks[n];
-      ringRecv[c*nNodes+n] = allTopoRanks[r]->ringRecv[c];
-      ringSend[c*nNodes+n] = allTopoRanks[r]->ringSend[c];
-      treeToParent[c*nNodes+n] = allTopoRanks[r]->treeToParent[c];
-      treeToChild0[c*nNodes+n] = allTopoRanks[r]->treeToChild0[c];
-      treeToChild1[c*nNodes+n] = allTopoRanks[r]->treeToChild1[c];
+      ringRecv[c * nNodes + n] = allTopoRanks[r]->ringRecv[c];
+      ringSend[c * nNodes + n] = allTopoRanks[r]->ringSend[c];
+      treeToParent[c * nNodes + n] = allTopoRanks[r]->treeToParent[c];
+      treeToChild0[c * nNodes + n] = allTopoRanks[r]->treeToChild0[c];
+      treeToChild1[c * nNodes + n] = allTopoRanks[r]->treeToChild1[c];
     }
-    for (int r=0; r<nranks; r++) {
-      ringPrev[c*nranks+r] = allTopoRanks[r]->ringPrev[c];
-      ringNext[c*nranks+r] = allTopoRanks[r]->ringNext[c];
+    for (int r = 0; r < nranks; r++) {
+      ringPrev[c * nranks + r] = allTopoRanks[r]->ringPrev[c];
+      ringNext[c * nranks + r] = allTopoRanks[r]->ringNext[c];
     }
   }
 
   for (int n = 0; n < nNodes; n++) {
     int r = firstRanks[n];
-    if (minHeadNum > allTopoRanks[r]->nvlsHeadNum)
-      minHeadNum = allTopoRanks[r]->nvlsHeadNum;
+    if (minHeadNum > allTopoRanks[r]->nvlsHeadNum) minHeadNum = allTopoRanks[r]->nvlsHeadNum;
   }
 
   for (int c = 0; c < minHeadNum; c++) {
@@ -1129,18 +1118,17 @@ ncclResult_t ncclTopoPostset(struct ncclComm* comm, int* firstRanks, int* treePa
       nvlsHeads[c * nNodes + n] = allTopoRanks[r]->nvlsHeads[c];
     }
   }
- 
+
   /**
    * The following if/else assumes cluster is homogeneous w.r.t gfx arch
    * Ideally All the ranks should have consensus on to graphs.
    */
-  if ( IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx1151") ) {
+  if (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx1151")) {
     NCCLCHECK(connectRingsLoadBalanced(comm, ringRecv, ringSend, ringPrev, ringNext));
   } else {
     // Connect rings and trees. This should also duplicate the channels.
     NCCLCHECK(connectRings(comm, ringRecv, ringSend, ringPrev, ringNext));
   }
-  
 
   // [RCCL] Connect rail-optimized trees
   if (comm->topo->useRailOptimizedTrees) {
@@ -1152,19 +1140,17 @@ ncclResult_t ncclTopoPostset(struct ncclComm* comm, int* firstRanks, int* treePa
   // Dump graphviz-friendly trees
   if (rcclParamOutputTrees()) {
     int rank = comm->rank;
-    char color[8][16] =
-      {"red", "orange", "yellow", "yellowgreen", "green", "cyan", "deepskyblue", "violet"};
+    char color[8][16] = {"red", "orange", "yellow", "yellowgreen", "green", "cyan", "deepskyblue", "violet"};
 
     for (int i = 0; i < comm->nChannels; i++) {
       INFO(NCCL_GRAPH, "[TREE] %d.%d [style=filled, fillcolor=%s]", i, rank, color[rank % comm->localRanks]);
       for (int j = 0; j < 3; j++) {
         if (comm->channels[i].tree.down[j] != -1) {
-	  bool sameNode = (comm->rankToNode[rank] == comm->rankToNode[comm->channels[i].tree.down[j]]);
-          INFO(NCCL_GRAPH, "[TREE] %d.%d->%d.%d [style=%s,width=10,color=%s,label=\"%s\"]",
-	       i, rank, i, comm->channels[i].tree.down[j],
-	       sameNode ? "solid" : "dashed",
-	       sameNode ? "black" : color[rank % comm->localRanks],
-	       sameNode ? ""  : (std::string("N") + std::to_string(graphs[NCCL_ALGO_TREE]->inter[i*2+1])).c_str());
+          bool sameNode = (comm->rankToNode[rank] == comm->rankToNode[comm->channels[i].tree.down[j]]);
+          INFO(NCCL_GRAPH, "[TREE] %d.%d->%d.%d [style=%s,width=10,color=%s,label=\"%s\"]", i, rank, i,
+               comm->channels[i].tree.down[j], sameNode ? "solid" : "dashed",
+               sameNode ? "black" : color[rank % comm->localRanks],
+               sameNode ? "" : (std::string("N") + std::to_string(graphs[NCCL_ALGO_TREE]->inter[i * 2 + 1])).c_str());
         }
       }
     }
@@ -1174,8 +1160,9 @@ ncclResult_t ncclTopoPostset(struct ncclComm* comm, int* firstRanks, int* treePa
   // pre-gfx942 GPUs are capped at 2*CHANNEL_LIMIT
   maxChannels = (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942") ||
                  IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950") ||
-                 IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx1250"))
-                 ? std::min(comm->topo->nodes[GPU].nodes[0].gpu.cu, MAXCHANNELS) : 2*CHANNEL_LIMIT;
+                 IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx1250")) ?
+                  std::min(comm->topo->nodes[GPU].nodes[0].gpu.cu, MAXCHANNELS) :
+                  2 * CHANNEL_LIMIT;
 
   if (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950") && comm->nNodes > 1) {
     int userMax = ncclParamMaxNchannels();
@@ -1210,11 +1197,11 @@ ncclResult_t ncclTopoPostset(struct ncclComm* comm, int* firstRanks, int* treePa
   // Get number of channels after duplication
 #ifdef ENABLE_WARP_SPEED
   channelMultiplier = comm->warpSpeedChannelMultiplier = wsEnabled ? rcclGetMaxWarpsPerBlock(comm) : 1;
-  if(wsEnabled) {
+  if (wsEnabled) {
     // If user didn't override, use requested channels; otherwise keep capped max.
     if (!userUpdatedMaxChannels) {
       maxNchannels = nc * comm->nChannels * channelMultiplier;
-      nc = singleNode? maxNchannels : std::min(maxNchannels, maxChannels);
+      nc = singleNode ? maxNchannels : std::min(maxNchannels, maxChannels);
     } else {
       nc = maxNchannels = std::min(adjustedMaxNchannels * channelMultiplier, MAXCHANNELS);
     }
@@ -1224,27 +1211,28 @@ ncclResult_t ncclTopoPostset(struct ncclComm* comm, int* firstRanks, int* treePa
       // Remove when all collectives have been optimized
       nc /= 2;
     }
-    INFO(NCCL_TUNING, "WarpSpeed enabled: warpSpeedChannelMultiplier %d, maxNchannels %d, nc %d",
-        channelMultiplier, maxNchannels, nc);
+    INFO(NCCL_TUNING, "WarpSpeed enabled: warpSpeedChannelMultiplier %d, maxNchannels %d, nc %d", channelMultiplier,
+         maxNchannels, nc);
   } else {
-    maxChannels = std::min((singleNode ? (isGfx950 ? RCCL_MI3XX_MAX_SINGLE_NODE_CHANNELS * 2 : RCCL_MI3XX_MAX_SINGLE_NODE_CHANNELS)
-                       : RCCL_MI3XX_MAX_MULTI_NODE_CHANNELS),
-                 maxChannels);
+    maxChannels = std::min(
+      (singleNode ? (isGfx950 ? RCCL_MI3XX_MAX_SINGLE_NODE_CHANNELS * 2 : RCCL_MI3XX_MAX_SINGLE_NODE_CHANNELS) :
+                    RCCL_MI3XX_MAX_MULTI_NODE_CHANNELS),
+      maxChannels);
     maxNchannels = std::min((int)ncclMaxNchannels(), maxChannels);
-    nc = std::min(maxNchannels/comm->nChannels, nc);
+    nc = std::min(maxNchannels / comm->nChannels, nc);
     nc *= comm->nChannels;
   }
 #else
   maxNchannels = std::min((int)ncclMaxNchannels(), maxChannels);
-  nc = std::min(maxNchannels/comm->nChannels, nc);
+  nc = std::min(maxNchannels / comm->nChannels, nc);
   nc *= comm->nChannels;
 #endif
   // Set ring prev/next for my rank
-  for (int c=0; c<nChannels; c++) {
-    struct ncclChannel* channel0 = comm->channels+c;
-    struct ncclChannel* channel1 = channel0+nChannels;
-    channel0->ring.prev = ringPrev[c*nranks+comm->rank];
-    channel0->ring.next = ringNext[c*nranks+comm->rank];
+  for (int c = 0; c < nChannels; c++) {
+    struct ncclChannel* channel0 = comm->channels + c;
+    struct ncclChannel* channel1 = channel0 + nChannels;
+    channel0->ring.prev = ringPrev[c * nranks + comm->rank];
+    channel0->ring.next = ringNext[c * nranks + comm->rank];
 
     if (c + nChannels < MAXCHANNELS) {
       channel1->ring.prev = channel0->ring.prev;
@@ -1253,34 +1241,36 @@ ncclResult_t ncclTopoPostset(struct ncclComm* comm, int* firstRanks, int* treePa
   }
 
   // Duplication should be complete now
-  nChannels = comm->nChannels = std::min(maxChannels, (nChannels <= maxChannels/2) ? nChannels*2 : nChannels);
+  nChannels = comm->nChannels = std::min(maxChannels, (nChannels <= maxChannels / 2) ? nChannels * 2 : nChannels);
   // Setup CollNet
   if (comm->config.collnetEnable) {
     struct ncclTopoGraph* collNetChainGraph = graphs[NCCL_ALGO_COLLNET_CHAIN];
     // Add more channels to saturate intra-node bandwidth, except the 1 PPN case
     if (collNetChainGraph->bwIntra > collNetChainGraph->bwInter && comm->nRanks > comm->nNodes) {
-      int collNetNchannels = std::min(maxChannels, nChannels+nChannels/2);
+      int collNetNchannels = std::min(maxChannels, nChannels + nChannels / 2);
       nChannels = comm->nChannels = copyChannels(comm, nChannels, collNetNchannels, ringPrev, ringNext);
     }
 
     for (int c = 0; c < comm->nChannels; c++) {
-      comm->channels[c].collnetChain.depth = comm->nRanks/comm->nNodes;
+      comm->channels[c].collnetChain.depth = comm->nRanks / comm->nNodes;
     }
 
-    if (comm->maxLocalRanks <= NCCL_MAX_DIRECT_ARITY+1) {
+    if (comm->maxLocalRanks <= NCCL_MAX_DIRECT_ARITY + 1) {
       NCCLCHECKGOTO(connectCollNet(comm, graphs[NCCL_ALGO_COLLNET_DIRECT]), ret, fail);
     }
   }
 
   // Use 4 compute channels per search channel to reach peak BW on <8 PPN
-  if (comm->minCompCap >= 90 && comm->nNodes > 1 && graphs[NCCL_ALGO_RING]->bwIntra > 45.0 && 2*nChannels <= maxChannels) {
-     nChannels = comm->nChannels = copyChannels(comm, nChannels, 2*nChannels, ringPrev, ringNext);
+  if (comm->minCompCap >= 90 && comm->nNodes > 1 && graphs[NCCL_ALGO_RING]->bwIntra > 45.0 &&
+      2 * nChannels <= maxChannels) {
+    nChannels = comm->nChannels = copyChannels(comm, nChannels, 2 * nChannels, ringPrev, ringNext);
   }
 
   // Double the number of channels when using unpack networking (greater than 1 node)
   // We won't automatically double past 16 channels, users can specify 32 if they want
-  if (comm->netDeviceType == NCCL_NET_DEVICE_UNPACK && comm->nNodes > 1 && nChannels < 16 && ncclParamUnpackDoubleNChannels()) {
-     nChannels = comm->nChannels = copyChannels(comm, nChannels, 2*nChannels, ringPrev, ringNext);
+  if (comm->netDeviceType == NCCL_NET_DEVICE_UNPACK && comm->nNodes > 1 && nChannels < 16 &&
+      ncclParamUnpackDoubleNChannels()) {
+    nChannels = comm->nChannels = copyChannels(comm, nChannels, 2 * nChannels, ringPrev, ringNext);
   }
 
   minNchannels = ncclMinNchannels();
@@ -1302,11 +1292,18 @@ ncclResult_t ncclTopoPostset(struct ncclComm* comm, int* firstRanks, int* treePa
   // We permit combining max, then min, to only use the first channels, then duplicate them.
   if (comm->sharedRes->owner != comm) {
     /* child comm #channels cannot exceed top parent #channels. */
-    nChannels = comm->nChannels = std::min(std::min(std::min(ncclMaxNchannels() * channelMultiplier, nChannels), comm->config.maxCTAs), comm->sharedRes->tpNChannels);
-    nChannels = comm->nChannels = copyChannels(comm, nChannels, std::min(std::max(minNchannels, std::max(nc, comm->config.minCTAs)), comm->sharedRes->tpNChannels), ringPrev, ringNext);
+    nChannels = comm->nChannels =
+      std::min(std::min(std::min(ncclMaxNchannels() * channelMultiplier, nChannels), comm->config.maxCTAs),
+               comm->sharedRes->tpNChannels);
+    nChannels = comm->nChannels =
+      copyChannels(comm, nChannels,
+                   std::min(std::max(minNchannels, std::max(nc, comm->config.minCTAs)), comm->sharedRes->tpNChannels),
+                   ringPrev, ringNext);
   } else {
-    nChannels = comm->nChannels = std::min(std::min(ncclMaxNchannels() * channelMultiplier, nChannels), comm->config.maxCTAs);
-    nChannels = comm->nChannels = copyChannels(comm, nChannels, std::max(minNchannels, std::max(nc, comm->config.minCTAs)), ringPrev, ringNext);
+    nChannels = comm->nChannels =
+      std::min(std::min(ncclMaxNchannels() * channelMultiplier, nChannels), comm->config.maxCTAs);
+    nChannels = comm->nChannels =
+      copyChannels(comm, nChannels, std::max(minNchannels, std::max(nc, comm->config.minCTAs)), ringPrev, ringNext);
   }
 
   if (comm->isGrow) {

--- a/projects/rccl/src/graph/paths.cc
+++ b/projects/rccl/src/graph/paths.cc
@@ -22,10 +22,11 @@ struct ncclTopoNodeList {
   int count;
 };
 
-static ncclResult_t getPath(struct ncclTopoSystem* system, struct ncclTopoNode* node, int t, int64_t id, struct ncclTopoLinkList** path) {
-  for (int i=0; i<system->nodes[t].count; i++) {
+static ncclResult_t getPath(struct ncclTopoSystem* system, struct ncclTopoNode* node, int t, int64_t id,
+                            struct ncclTopoLinkList** path) {
+  for (int i = 0; i < system->nodes[t].count; i++) {
     if (system->nodes[t].nodes[i].id == id) {
-      *path = node->paths[t]+i;
+      *path = node->paths[t] + i;
       return ncclSuccess;
     }
   }
@@ -37,14 +38,15 @@ NCCL_PARAM(NvbDisable, "NVB_DISABLE", 0);
 
 static ncclResult_t ncclTopoSetPaths(struct ncclTopoNode* baseNode, struct ncclTopoSystem* system) {
   if (baseNode->paths[baseNode->type] == NULL) {
-    NCCLCHECK(ncclCalloc(baseNode->paths+baseNode->type, system->nodes[baseNode->type].count));
-    for (int i=0; i<system->nodes[baseNode->type].count; i++) baseNode->paths[baseNode->type][i].type = PATH_DIS;
+    NCCLCHECK(ncclCalloc(baseNode->paths + baseNode->type, system->nodes[baseNode->type].count));
+    for (int i = 0; i < system->nodes[baseNode->type].count; i++) baseNode->paths[baseNode->type][i].type = PATH_DIS;
   }
 
   // breadth-first search to set all paths to that node in the system
   struct ncclTopoNodeList nodeList;
-  struct ncclTopoNodeList nextNodeList = { { 0 }, 0 };
-  nodeList.count = 1; nodeList.list[0] = baseNode;
+  struct ncclTopoNodeList nextNodeList = {{0}, 0};
+  nodeList.count = 1;
+  nodeList.list[0] = baseNode;
   struct ncclTopoLinkList* basePath;
   NCCLCHECK(getPath(system, baseNode, baseNode->type, baseNode->id, &basePath));
   basePath->count = 0;
@@ -53,16 +55,17 @@ static ncclResult_t ncclTopoSetPaths(struct ncclTopoNode* baseNode, struct ncclT
 
   while (nodeList.count) {
     nextNodeList.count = 0;
-    for (int n=0; n<nodeList.count; n++) {
+    for (int n = 0; n < nodeList.count; n++) {
       struct ncclTopoNode* node = nodeList.list[n];
       struct ncclTopoLinkList* path;
       NCCLCHECK(getPath(system, node, baseNode->type, baseNode->id, &path));
-      for (int l=0; l<node->nlinks; l++) {
-        struct ncclTopoLink* link = node->links+l;
+      for (int l = 0; l < node->nlinks; l++) {
+        struct ncclTopoLink* link = node->links + l;
         struct ncclTopoNode* remNode = link->remNode;
         if (remNode->paths[baseNode->type] == NULL) {
-          NCCLCHECK(ncclCalloc(remNode->paths+baseNode->type, system->nodes[baseNode->type].count));
-          for (int i=0; i<system->nodes[baseNode->type].count; i++) remNode->paths[baseNode->type][i].type = PATH_DIS;
+          NCCLCHECK(ncclCalloc(remNode->paths + baseNode->type, system->nodes[baseNode->type].count));
+          for (int i = 0; i < system->nodes[baseNode->type].count; i++)
+            remNode->paths[baseNode->type][i].type = PATH_DIS;
         }
         struct ncclTopoLinkList* remPath;
         NCCLCHECK(getPath(system, remNode, baseNode->type, baseNode->id, &remPath));
@@ -75,24 +78,25 @@ static ncclResult_t ncclTopoSetPaths(struct ncclTopoNode* baseNode, struct ncclT
 
         int pathMaxLength = (baseNode->type == GPU) ? 2 : 1;
         ncclTopoNode* baseDevNode = (baseNode->type == GPU) ? baseNode->gpu.parent : baseNode;
-        if (node != baseDevNode && node->type == DEV && (link->type != LINK_LOC || remNode->type!=GPU) &&
-            (ncclParamNvbDisable() || link->type != LINK_NVL || remNode->type != DEV || path->count > pathMaxLength)) continue;
+        if (node != baseDevNode && node->type == DEV && (link->type != LINK_LOC || remNode->type != GPU) &&
+            (ncclParamNvbDisable() || link->type != LINK_NVL || remNode->type != DEV || path->count > pathMaxLength))
+          continue;
 
         if ((remPath->bw == 0 || remPath->count > path->count) && remPath->bw < bw) {
           // Find reverse link
-          for (int l=0; l<remNode->nlinks; l++) {
+          for (int l = 0; l < remNode->nlinks; l++) {
             if (remNode->links[l].remNode == node && remNode->links[l].type == link->type) {
-              remPath->list[0] = remNode->links+l;
+              remPath->list[0] = remNode->links + l;
               break;
             }
           }
           if (remPath->list[0] == NULL) {
-            WARN("Failed to find reverse path from remNode %d/%lx nlinks %d to node %d/%lx",
-                remNode->type, remNode->id, remNode->nlinks, node->type, node->id);
+            WARN("Failed to find reverse path from remNode %d/%lx nlinks %d to node %d/%lx", remNode->type, remNode->id,
+                 remNode->nlinks, node->type, node->id);
             return ncclInternalError;
           }
           // Copy the rest of the path
-          for (int i=0; i<path->count; i++) remPath->list[i+1] = path->list[i];
+          for (int i = 0; i < path->count; i++) remPath->list[i + 1] = path->list[i];
           remPath->count = path->count + 1;
           remPath->bw = bw;
 
@@ -104,7 +108,7 @@ static ncclResult_t ncclTopoSetPaths(struct ncclTopoNode* baseNode, struct ncclT
           // Consider a path going through the CPU as PATH_PHB
           if (link->type == LINK_PCI && (node->type == CPU || link->remNode->type == CPU)) type = PATH_PHB;
           // Set 1 hop NVLink as NVB
-          //if (node->type == GPU && path->type == PATH_NVL && type == PATH_NVL && remPath->count > 1) type = PATH_NVB;
+          // if (node->type == GPU && path->type == PATH_NVL && type == PATH_NVL && remPath->count > 1) type = PATH_NVB;
 
           remPath->type = std::max(path->type, type);
 
@@ -112,7 +116,8 @@ static ncclResult_t ncclTopoSetPaths(struct ncclTopoNode* baseNode, struct ncclT
           // Disallow GPUs as intermediate steps for now
           if (remNode->type != GPU) {
             int i;
-            for (i=0; i<nextNodeList.count; i++) if (nextNodeList.list[i] == remNode) break;
+            for (i = 0; i < nextNodeList.count; i++)
+              if (nextNodeList.list[i] == remNode) break;
             if (i == nextNodeList.count) nextNodeList.list[nextNodeList.count++] = remNode;
           }
         }
@@ -127,26 +132,33 @@ static void printNodePaths(struct ncclTopoSystem* system, struct ncclTopoNode* n
   const int linesize = 2048;
   char line[linesize];
 #ifdef ENABLE_TRACE
-  INFO(NCCL_GRAPH, "Paths from %s/%lx-%lx :", topoNodeTypeStr[node->type], NCCL_TOPO_ID_SYSTEM_ID(node->id), NCCL_TOPO_ID_LOCAL_ID(node->id));
+  INFO(NCCL_GRAPH, "Paths from %s/%lx-%lx :", topoNodeTypeStr[node->type], NCCL_TOPO_ID_SYSTEM_ID(node->id),
+       NCCL_TOPO_ID_LOCAL_ID(node->id));
 #else
-  snprintf(line, linesize, "%s/%lx-%lx :", topoNodeTypeStr[node->type], NCCL_TOPO_ID_SYSTEM_ID(node->id), NCCL_TOPO_ID_LOCAL_ID(node->id));
+  snprintf(line, linesize, "%s/%lx-%lx :", topoNodeTypeStr[node->type], NCCL_TOPO_ID_SYSTEM_ID(node->id),
+           NCCL_TOPO_ID_LOCAL_ID(node->id));
   int offset = strlen(line);
 #endif
-  for (int t=0; t<NCCL_TOPO_NODE_TYPES; t++) {
+  for (int t = 0; t < NCCL_TOPO_NODE_TYPES; t++) {
     if (node->paths[t] == NULL) continue;
-    for (int n = 0; n<system->nodes[t].count; n++) {
+    for (int n = 0; n < system->nodes[t].count; n++) {
 #ifdef ENABLE_TRACE
       line[0] = 0;
       int offset = 0;
-      for (int i=0; i<node->paths[t][n].count; i++) {
+      for (int i = 0; i < node->paths[t][n].count; i++) {
         struct ncclTopoLink* link = node->paths[t][n].list[i];
         struct ncclTopoNode* remNode = link->remNode;
-        snprintf(line+offset, linesize-offset, "--%s(%g)->%s/%lx-%lx", topoLinkTypeStr[link->type], link->bw, topoNodeTypeStr[remNode->type], NCCL_TOPO_ID_SYSTEM_ID(remNode->id), NCCL_TOPO_ID_LOCAL_ID(remNode->id));
+        snprintf(line + offset, linesize - offset, "--%s(%g)->%s/%lx-%lx", topoLinkTypeStr[link->type], link->bw,
+                 topoNodeTypeStr[remNode->type], NCCL_TOPO_ID_SYSTEM_ID(remNode->id),
+                 NCCL_TOPO_ID_LOCAL_ID(remNode->id));
         offset = strlen(line);
       }
       INFO(NCCL_GRAPH, "%s (%f)", line, node->paths[t][n].bw);
 #else
-      snprintf(line+offset, linesize-offset, "%s/%lx-%lx (%d/%.1f/%s) ", topoNodeTypeStr[t], NCCL_TOPO_ID_SYSTEM_ID(system->nodes[t].nodes[n].id), NCCL_TOPO_ID_LOCAL_ID(system->nodes[t].nodes[n].id), node->paths[t][n].count, node->paths[t][n].bw, topoPathTypeStr[node->paths[t][n].type]);
+      snprintf(line + offset, linesize - offset, "%s/%lx-%lx (%d/%.1f/%s) ", topoNodeTypeStr[t],
+               NCCL_TOPO_ID_SYSTEM_ID(system->nodes[t].nodes[n].id),
+               NCCL_TOPO_ID_LOCAL_ID(system->nodes[t].nodes[n].id), node->paths[t][n].count, node->paths[t][n].bw,
+               topoPathTypeStr[node->paths[t][n].type]);
       offset = strlen(line);
 #endif
     }
@@ -157,14 +169,14 @@ static void printNodePaths(struct ncclTopoSystem* system, struct ncclTopoNode* n
 }
 
 ncclResult_t ncclTopoPrintPaths(struct ncclTopoSystem* system) {
-  for (int i=0; i<system->nodes[GPU].count; i++) {
-    printNodePaths(system, system->nodes[GPU].nodes+i);
+  for (int i = 0; i < system->nodes[GPU].count; i++) {
+    printNodePaths(system, system->nodes[GPU].nodes + i);
   }
-  for (int i=0; i<system->nodes[NET].count; i++) {
-    printNodePaths(system, system->nodes[NET].nodes+i);
+  for (int i = 0; i < system->nodes[NET].count; i++) {
+    printNodePaths(system, system->nodes[NET].nodes + i);
   }
-  for (int i=0; i<system->nodes[GIN].count; i++) {
-    printNodePaths(system, system->nodes[GIN].nodes+i);
+  for (int i = 0; i < system->nodes[GIN].count; i++) {
+    printNodePaths(system, system->nodes[GIN].nodes + i);
   }
   return ncclSuccess;
 }
@@ -174,7 +186,7 @@ ncclResult_t ncclGetLocalCpu(struct ncclTopoSystem* system, int gpu, int* retCpu
   int minHops = 0;
   int localCpu = -1;
   struct ncclTopoLinkList* paths = system->nodes[GPU].nodes[gpu].paths[CPU];
-  for (int c=0; c<system->nodes[CPU].count; c++) {
+  for (int c = 0; c < system->nodes[CPU].count; c++) {
     int hops = paths[c].count;
     if (hops > 0 && (minHops == 0 || hops < minHops)) {
       localCpu = c;
@@ -189,22 +201,24 @@ ncclResult_t ncclGetLocalCpu(struct ncclTopoSystem* system, int gpu, int* retCpu
   return ncclSuccess;
 }
 
-static int mergePathType(int type0, int type1){
-  int max = std::max(type0,type1);
-  int min = std::min(type0,type1);
-  if(max == PATH_PHB && min == PATH_C2C) return PATH_P2C;
+static int mergePathType(int type0, int type1) {
+  int max = std::max(type0, type1);
+  int min = std::min(type0, type1);
+  if (max == PATH_PHB && min == PATH_C2C) return PATH_P2C;
   else return max;
 }
 
 static ncclResult_t addInterStep(struct ncclTopoSystem* system, int tx, int ix, int t1, int i1, int t2, int i2) {
-  struct ncclTopoNode* cpuNode = system->nodes[tx].nodes+ix;
-  struct ncclTopoNode* srcNode = system->nodes[t1].nodes+i1;
+  struct ncclTopoNode* cpuNode = system->nodes[tx].nodes + ix;
+  struct ncclTopoNode* srcNode = system->nodes[t1].nodes + i1;
 
-  int l=0;
+  int l = 0;
   // Node 1 -> CPU
-  for (int i=0; i<srcNode->paths[tx][ix].count; i++) srcNode->paths[t2][i2].list[l++] = srcNode->paths[tx][ix].list[i];
+  for (int i = 0; i < srcNode->paths[tx][ix].count; i++)
+    srcNode->paths[t2][i2].list[l++] = srcNode->paths[tx][ix].list[i];
   // CPU -> Node 2
-  for (int i=0; i<cpuNode->paths[t2][i2].count; i++) srcNode->paths[t2][i2].list[l++] = cpuNode->paths[t2][i2].list[i];
+  for (int i = 0; i < cpuNode->paths[t2][i2].count; i++)
+    srcNode->paths[t2][i2].list[l++] = cpuNode->paths[t2][i2].list[i];
 
   // Update path characteristics
   srcNode->paths[t2][i2].count = l;
@@ -216,10 +230,10 @@ static ncclResult_t addInterStep(struct ncclTopoSystem* system, int tx, int ix, 
 
 // Remove/free all paths
 static void ncclTopoRemovePaths(struct ncclTopoSystem* system) {
-  for (int t1=0; t1<NCCL_TOPO_NODE_TYPES; t1++) {
-    for (int n=0; n<system->nodes[t1].count; n++) {
-      struct ncclTopoNode* node = system->nodes[t1].nodes+n;
-      for (int t2=0; t2<NCCL_TOPO_NODE_TYPES; t2++) {
+  for (int t1 = 0; t1 < NCCL_TOPO_NODE_TYPES; t1++) {
+    for (int n = 0; n < system->nodes[t1].count; n++) {
+      struct ncclTopoNode* node = system->nodes[t1].nodes + n;
+      for (int t2 = 0; t2 < NCCL_TOPO_NODE_TYPES; t2++) {
         if (node->paths[t2]) free(node->paths[t2]);
         node->paths[t2] = NULL;
       }
@@ -227,7 +241,7 @@ static void ncclTopoRemovePaths(struct ncclTopoSystem* system) {
   }
 }
 
-static const int levelsOldToNew[] = { PATH_LOC, PATH_PIX, PATH_PXB, PATH_PHB, PATH_SYS, PATH_SYS };
+static const int levelsOldToNew[] = {PATH_LOC, PATH_PIX, PATH_PXB, PATH_PHB, PATH_SYS, PATH_SYS};
 ncclResult_t ncclGetLevel(int* level, const char* disableEnv, const char* levelEnv) {
   if (*level == -1) {
     int l = -1;
@@ -242,7 +256,7 @@ ncclResult_t ncclGetLevel(int* level, const char* disableEnv, const char* levelE
     if (l == -1) {
       const char* str = ncclGetEnv(levelEnv);
       if (str) {
-        for (int i=0; i<=PATH_SYS; i++) {
+        for (int i = 0; i <= PATH_SYS; i++) {
           if (strcmp(str, topoPathTypeStr[i]) == 0) {
             l = i;
             break;
@@ -254,7 +268,7 @@ ncclResult_t ncclGetLevel(int* level, const char* disableEnv, const char* levelE
         // maxOldLevel is a quick check to handle out of bounds (based on the length of levelsOldToNew)
         if (l == -1 && str[0] >= '0' && str[0] <= '9') {
           int oldLevel = strtol(str, NULL, 0);
-          const int maxOldLevel = sizeof(levelsOldToNew)/sizeof(int) - 1;
+          const int maxOldLevel = sizeof(levelsOldToNew) / sizeof(int) - 1;
           if (oldLevel > maxOldLevel) oldLevel = maxOldLevel;
           l = levelsOldToNew[oldLevel];
         }
@@ -273,18 +287,16 @@ static int ncclTopoUserP2pLevel = -1; // Initially "uninitialized".  When initia
 // Gets the user-provided value of NCCL_P2P_LEVEL/NCCL_P2P_DISABLE.  If the user did not provide any, the value
 // of the "level" argument is left unchanged.
 ncclResult_t ncclGetUserP2pLevel(int* level) {
-  if (ncclTopoUserP2pLevel == -1)
-    NCCLCHECK(ncclGetLevel(&ncclTopoUserP2pLevel, "NCCL_P2P_DISABLE", "NCCL_P2P_LEVEL"));
-  if (ncclTopoUserP2pLevel != -2)
-    *level = ncclTopoUserP2pLevel;
+  if (ncclTopoUserP2pLevel == -1) NCCLCHECK(ncclGetLevel(&ncclTopoUserP2pLevel, "NCCL_P2P_DISABLE", "NCCL_P2P_LEVEL"));
+  if (ncclTopoUserP2pLevel != -2) *level = ncclTopoUserP2pLevel;
   return ncclSuccess;
 }
 
 // Tests two ranks for CUDA P2P connectivity.
 // *cudaP2p returns 1 if CUDA P2P between the ranks is supported.
 // *p2p returns 1 only if the distance between the ranks is no greater than NCCL_P2P_LEVEL.  The connection may go through an intermediate rank.
-ncclResult_t ncclTopoCheckP2p(struct ncclComm* comm, struct ncclTopoSystem* system, int rank1, int rank2,
-                              int* p2p, int *read, int* intermediateRank, int* cudaP2p) {
+ncclResult_t ncclTopoCheckP2p(struct ncclComm* comm, struct ncclTopoSystem* system, int rank1, int rank2, int* p2p,
+                              int* read, int* intermediateRank, int* cudaP2p) {
   int mnnvl = 0;
   struct ncclPeerInfo* info1 = NULL;
   struct ncclPeerInfo* info2 = NULL;
@@ -295,16 +307,21 @@ ncclResult_t ncclTopoCheckP2p(struct ncclComm* comm, struct ncclTopoSystem* syst
 
   // Rule out different nodes / isolated containers
   if (comm) {
-    info1 = comm->peerInfo+rank1;
-    info2 = comm->peerInfo+rank2;
+    info1 = comm->peerInfo + rank1;
+    info2 = comm->peerInfo + rank2;
     if (info1->hostHash != info2->hostHash) {
       if (comm->MNNVL) {
         NCCLCHECK(ncclTopoCheckMNNVL(comm, info1, info2, &mnnvl));
-        TRACE(NCCL_GRAPH, "ncclTopoCheckP2p rank%d->rank%d: cross-node, MNNVL=%d mnnvl=%d", rank1, rank2, comm->MNNVL, mnnvl);
+        TRACE(NCCL_GRAPH, "ncclTopoCheckP2p rank%d->rank%d: cross-node, MNNVL=%d mnnvl=%d", rank1, rank2, comm->MNNVL,
+              mnnvl);
         if (mnnvl < 0) {
           // Force enable CUDA P2P for cross-clique (NCCL_MNNVL_CROSS_CLIQUE=1)
-          if (p2p) { *p2p = 1; }
-          if (cudaP2p) { *cudaP2p = 1; }
+          if (p2p) {
+            *p2p = 1;
+          }
+          if (cudaP2p) {
+            *cudaP2p = 1;
+          }
           return ncclSuccess;
         }
         if (!mnnvl) return ncclSuccess;
@@ -320,23 +337,23 @@ ncclResult_t ncclTopoCheckP2p(struct ncclComm* comm, struct ncclTopoSystem* syst
   // Get GPUs from topology
   int g1, g2;
   NCCLCHECK(ncclTopoRankToIndex(system, rank1, &g1, /*showWarn=*/true));
-  struct ncclTopoNode* gpu1 = system->nodes[GPU].nodes+g1;
+  struct ncclTopoNode* gpu1 = system->nodes[GPU].nodes + g1;
   if (ncclTopoRankToIndex(system, rank2, &g2, /*showWarn=*/false) == ncclInternalError) {
     // GPU not found, we can't use p2p.
     // For MNNVL cross-node pairs, rank2 may live on a remote node and never be added to the local
     // system topology — this is expected. Warn only if MNNVL is enabled so operators can diagnose
     // cases where a clique peer is unexpectedly absent.
     if (comm && comm->MNNVL)
-      WARN("ncclTopoCheckP2p rank%d->rank%d: rank%d not in local topology (MNNVL active), returning p2p=0", rank1, rank2, rank2);
-    else
-      TRACE(NCCL_GRAPH, "ncclTopoCheckP2p rank%d->rank%d: rank2 not in topology, returning p2p=0", rank1, rank2);
+      WARN("ncclTopoCheckP2p rank%d->rank%d: rank%d not in local topology (MNNVL active), returning p2p=0", rank1,
+           rank2, rank2);
+    else TRACE(NCCL_GRAPH, "ncclTopoCheckP2p rank%d->rank%d: rank2 not in topology, returning p2p=0", rank1, rank2);
     return ncclSuccess;
   }
-  #if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
   int intermediateIndex = -1;
-  #endif
+#endif
   // Set intermediate GPU rank, if routing through an intermediate GPU.
-  struct ncclTopoLinkList* path = gpu1->paths[GPU]+g2;
+  struct ncclTopoLinkList* path = gpu1->paths[GPU] + g2;
   // xGMI fabric routes non-adjacent GPU pairs directly in hardware, so a
   // software GPU relay is unnecessary and slower.
 #if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
@@ -345,7 +362,8 @@ ncclResult_t ncclTopoCheckP2p(struct ncclComm* comm, struct ncclTopoSystem* syst
     struct ncclTopoNode* intermediateNode = path->list[1]->remNode;
     if (intermediateNode->type == DEV) {
       int interRank;
-      NCCLCHECK(ncclTopoDevToRank(system, NCCL_TOPO_ID_SYSTEM_ID(intermediateNode->id), intermediateNode->dev.dev, /*warn=*/true, &interRank));
+      NCCLCHECK(ncclTopoDevToRank(system, NCCL_TOPO_ID_SYSTEM_ID(intermediateNode->id), intermediateNode->dev.dev,
+                                  /*warn=*/true, &interRank));
       NCCLCHECK(ncclTopoRankToIndex(system, interRank, &intermediateIndex, true));
       if (intermediateRank) *intermediateRank = interRank;
     }
@@ -377,7 +395,7 @@ ncclResult_t ncclTopoCheckP2p(struct ncclComm* comm, struct ncclTopoSystem* syst
 #if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
   if (*p2p == 1) {
     if (checkNvml) {
-      int indexes[3] = {-1,-1,-1};
+      int indexes[3] = {-1, -1, -1};
       int verticeN = 0;
       NCCLCHECK(ncclNvmlEnsureInitialized());
 
@@ -385,19 +403,25 @@ ncclResult_t ncclTopoCheckP2p(struct ncclComm* comm, struct ncclTopoSystem* syst
       if (intermediateIndex != -1) indexes[verticeN++] = system->nodes[GPU].nodes[intermediateIndex].gpu.dev;
       indexes[verticeN++] = system->nodes[GPU].nodes[g2].gpu.dev;
 
-      for (int i=1; i < verticeN; i++) {
+      for (int i = 1; i < verticeN; i++) {
         nvmlGpuP2PStatus_t status;
-        status = ncclNvmlDevicePairs[indexes[i-1]][indexes[i-0]].p2pStatusRead;
+        status = ncclNvmlDevicePairs[indexes[i - 1]][indexes[i - 0]].p2pStatusRead;
         bool good = status == NVML_P2P_STATUS_OK;
-        status = ncclNvmlDevicePairs[indexes[i-1]][indexes[i-0]].p2pStatusWrite;
+        status = ncclNvmlDevicePairs[indexes[i - 1]][indexes[i - 0]].p2pStatusWrite;
         good &= status == NVML_P2P_STATUS_OK;
         if (!good) {
           if (!ncclParamIgnoreDisabledP2p()) {
             if (path->type <= PATH_NVB) {
-              WARN("P2P is disabled between NVLINK connected GPUs %d and %d. This should not be the case given their connectivity, and is probably due to a hardware issue. If you still want to proceed, you can set NCCL_IGNORE_DISABLED_P2P=1.", indexes[i-1], indexes[i-0]);
+              WARN("P2P is disabled between NVLINK connected GPUs %d and %d. This should not be the case given their "
+                   "connectivity, and is probably due to a hardware issue. If you still want to proceed, you can set "
+                   "NCCL_IGNORE_DISABLED_P2P=1.",
+                   indexes[i - 1], indexes[i - 0]);
               return ncclUnhandledCudaError;
             } else if (path->type < PATH_SYS) {
-              INFO(NCCL_INIT, "P2P is disabled between connected GPUs %d and %d. You can repress this message with NCCL_IGNORE_DISABLED_P2P=1.", indexes[i-1], indexes[i-0]);
+              INFO(NCCL_INIT,
+                   "P2P is disabled between connected GPUs %d and %d. You can repress this message with "
+                   "NCCL_IGNORE_DISABLED_P2P=1.",
+                   indexes[i - 1], indexes[i - 0]);
             }
           }
           *p2p = 0;
@@ -408,7 +432,7 @@ ncclResult_t ncclTopoCheckP2p(struct ncclComm* comm, struct ncclTopoSystem* syst
 #endif
 
   if (path->type == PATH_NVL) {
-    struct ncclTopoNode* gpu2 = system->nodes[GPU].nodes+g2;
+    struct ncclTopoNode* gpu2 = system->nodes[GPU].nodes + g2;
     // Enable P2P Read for Ampere/NVLink only
     if (read && (gpu1->gpu.cudaCompCap == gpu2->gpu.cudaCompCap) && (gpu1->gpu.cudaCompCap == 80)) *read = 1;
   }
@@ -437,7 +461,8 @@ ncclResult_t ncclTopoCheckP2p(struct ncclComm* comm, struct ncclTopoSystem* syst
 }
 
 // MNNVL: Check whether peers are in the same fabric cluster and clique
-ncclResult_t ncclTopoCheckMNNVL(struct ncclComm* comm, struct ncclPeerInfo* info1, struct ncclPeerInfo* info2, int* ret) {
+ncclResult_t ncclTopoCheckMNNVL(struct ncclComm* comm, struct ncclPeerInfo* info1, struct ncclPeerInfo* info2,
+                                int* ret) {
   *ret = 0;
   auto fabricInfo1 = &info1->fabricInfo;
   auto fabricInfo2 = &info2->fabricInfo;
@@ -450,8 +475,8 @@ ncclResult_t ncclTopoCheckMNNVL(struct ncclComm* comm, struct ncclPeerInfo* info
   // Same UUID required. Within same UUID: either same clique OR cross-clique enabled
   if ((memcmp(fabricInfo1->clusterUuid, fabricInfo2->clusterUuid, NVML_GPU_FABRIC_UUID_LEN) == 0) &&
       (comm->p2pCrossClique || fabricInfo1->cliqueId == fabricInfo2->cliqueId)) {
-    TRACE(NCCL_NET, "MNNVL rank %d matching peer %d 0x%lx UUID %lx.%lx cliqueId 0x%x/0x%x crossClique %d",
-         info1->rank, info2->rank, info2->busId, uuid0, uuid1, fabricInfo1->cliqueId, fabricInfo2->cliqueId, comm->p2pCrossClique);
+    TRACE(NCCL_NET, "MNNVL rank %d matching peer %d 0x%lx UUID %lx.%lx cliqueId 0x%x/0x%x crossClique %d", info1->rank,
+          info2->rank, info2->busId, uuid0, uuid1, fabricInfo1->cliqueId, fabricInfo2->cliqueId, comm->p2pCrossClique);
     // Return -1 for cross-clique (different clique but same UUID) to force CUDA P2P
     *ret = (comm->p2pCrossClique && fabricInfo1->cliqueId != fabricInfo2->cliqueId) ? -1 : 1;
   }
@@ -460,24 +485,25 @@ ncclResult_t ncclTopoCheckMNNVL(struct ncclComm* comm, struct ncclPeerInfo* info
 
 NCCL_PARAM(NetGdrRead, "NET_GDR_READ", -2);
 int ncclTopoUserGdrLevel = -1;
-const char* ncclTopoGdrModeStr[ncclTopoGdrModeNum] = { "Disabled", "Default", "PCI" };
+const char* ncclTopoGdrModeStr[ncclTopoGdrModeNum] = {"Disabled", "Default", "PCI"};
 
 // On C2C platforms use GDRDMA on NICs which are connected to the CPUs
 NCCL_PARAM(NetGdrC2c, "NET_GDR_C2C", 1);
 
-ncclResult_t ncclTopoCheckGdr(struct ncclTopoSystem* system, int rank, int64_t netId, int read, enum ncclTopoGdrMode* gdrMode) {
+ncclResult_t ncclTopoCheckGdr(struct ncclTopoSystem* system, int rank, int64_t netId, int read,
+                              enum ncclTopoGdrMode* gdrMode) {
   *gdrMode = ncclTopoGdrModeDisable;
 
   // Get GPU and NET
   int n, g;
   NCCLCHECK(ncclTopoIdToIndex(system, NET, netId, &n));
-  struct ncclTopoNode* net = system->nodes[NET].nodes+n;
+  struct ncclTopoNode* net = system->nodes[NET].nodes + n;
   NCCLCHECK(ncclTopoRankToIndex(system, rank, &g, /*showWarn=*/true));
-  struct ncclTopoNode* gpu = system->nodes[GPU].nodes+g;
+  struct ncclTopoNode* gpu = system->nodes[GPU].nodes + g;
 #ifdef ENABLE_TRACE
   char gpuNetMsg[1024] = "";
-  snprintf(gpuNetMsg, sizeof(gpuNetMsg), "GPU/%ld-%ld (rank %d) - NET/%ld-%ld (", NCCL_TOPO_ID_SYSTEM_ID(gpu->id), NCCL_TOPO_ID_LOCAL_ID(gpu->id), rank,
-           NCCL_TOPO_ID_SYSTEM_ID(net->id), NCCL_TOPO_ID_LOCAL_ID(net->id));
+  snprintf(gpuNetMsg, sizeof(gpuNetMsg), "GPU/%ld-%ld (rank %d) - NET/%ld-%ld (", NCCL_TOPO_ID_SYSTEM_ID(gpu->id),
+           NCCL_TOPO_ID_LOCAL_ID(gpu->id), rank, NCCL_TOPO_ID_SYSTEM_ID(net->id), NCCL_TOPO_ID_LOCAL_ID(net->id));
 #endif
 
   // Check that both the NIC and GPUs support it
@@ -495,7 +521,7 @@ ncclResult_t ncclTopoCheckGdr(struct ncclTopoSystem* system, int rank, int64_t n
       // Since we don't know whether there are other communicators,
       // it's better to keep things local if we have a single GPU.
       if (system->nodes[GPU].count == 1) nvlink = 1;
-      for (int i=0; i<system->nodes[GPU].count; i++) {
+      for (int i = 0; i < system->nodes[GPU].count; i++) {
         if (i == g) continue;
         if (gpu->paths[GPU][i].type == PATH_NVL) {
           nvlink = 1;
@@ -518,12 +544,12 @@ ncclResult_t ncclTopoCheckGdr(struct ncclTopoSystem* system, int rank, int64_t n
       int i, d1 = -1, d2 = -1;
       for (i = 0; i < system->nodes[CPU].count; i++)
         if (system->nodes[GPU].nodes[g].paths[CPU][i].count == 2) break;
-      if (i <system->nodes[CPU].count) d1 = system->nodes[CPU].nodes[i].id;
+      if (i < system->nodes[CPU].count) d1 = system->nodes[CPU].nodes[i].id;
       for (i = 0; i < system->nodes[CPU].count; i++)
         if (system->nodes[NET].nodes[n].paths[CPU][i].count == 2) break;
-      if (i <system->nodes[CPU].count) d2 = system->nodes[CPU].nodes[i].id;
+      if (i < system->nodes[CPU].count) d2 = system->nodes[CPU].nodes[i].id;
       if (d1 != -1 && d2 != -1 && d1 == d2 &&
-        (system->nodes[GPU].nodes[g].id & 0xf0000) == (system->nodes[NET].nodes[n].net.busId & 0xf0000)) {
+          (system->nodes[GPU].nodes[g].id & 0xf0000) == (system->nodes[NET].nodes[n].net.busId & 0xf0000)) {
         netGdrLevel = PATH_PHB;
       }
     }
@@ -535,16 +561,18 @@ ncclResult_t ncclTopoCheckGdr(struct ncclTopoSystem* system, int rank, int64_t n
     int proxyRank;
     NCCLCHECK(ncclTopoGetIntermediateRank(system, gpu->gpu.rank, netId, &proxyRank));
     NCCLCHECK(ncclTopoRankToIndex(system, proxyRank, &g, /*showWarn=*/true));
-    gpu = system->nodes[GPU].nodes+g;
+    gpu = system->nodes[GPU].nodes + g;
     distance = gpu->paths[NET][n].type;
 #ifdef ENABLE_TRACE
-    snprintf(gpuNetMsg+strlen(gpuNetMsg), sizeof(gpuNetMsg)-strlen(gpuNetMsg), " using PXN via GPU/%ld-%ld, ", NCCL_TOPO_ID_SYSTEM_ID(gpu->id), NCCL_TOPO_ID_LOCAL_ID(gpu->id));
+    snprintf(gpuNetMsg + strlen(gpuNetMsg), sizeof(gpuNetMsg) - strlen(gpuNetMsg), " using PXN via GPU/%ld-%ld, ",
+             NCCL_TOPO_ID_SYSTEM_ID(gpu->id), NCCL_TOPO_ID_LOCAL_ID(gpu->id));
 #endif
   }
 
   if (distance > netGdrLevel) {
 #ifdef ENABLE_TRACE
-    snprintf(gpuNetMsg + strlen(gpuNetMsg), sizeof(gpuNetMsg) - strlen(gpuNetMsg), "distance %d > %d)", distance, netGdrLevel);
+    snprintf(gpuNetMsg + strlen(gpuNetMsg), sizeof(gpuNetMsg) - strlen(gpuNetMsg), "distance %d > %d)", distance,
+             netGdrLevel);
     TRACE(NCCL_GRAPH | NCCL_NET, "GPU Direct RDMA Disabled for %s", gpuNetMsg);
 #endif
     return ncclSuccess;
@@ -557,13 +585,14 @@ ncclResult_t ncclTopoCheckGdr(struct ncclTopoSystem* system, int rank, int64_t n
   else *gdrMode = ncclTopoGdrModeDefault;
 
 #ifdef ENABLE_TRACE
-  snprintf(gpuNetMsg + strlen(gpuNetMsg), sizeof(gpuNetMsg) - strlen(gpuNetMsg), "distance %d <= %d, read %d, mode %s)", distance, netGdrLevel, read, ncclTopoGdrModeStr[*gdrMode]);
+  snprintf(gpuNetMsg + strlen(gpuNetMsg), sizeof(gpuNetMsg) - strlen(gpuNetMsg), "distance %d <= %d, read %d, mode %s)",
+           distance, netGdrLevel, read, ncclTopoGdrModeStr[*gdrMode]);
   TRACE(NCCL_GRAPH | NCCL_NET, "GPU Direct RDMA Enabled for %s", gpuNetMsg);
 #endif
   return ncclSuccess;
 }
 
-ncclResult_t ncclTopoIsGdrAvail(struct ncclTopoSystem* system, int rank, bool *avail) {
+ncclResult_t ncclTopoIsGdrAvail(struct ncclTopoSystem* system, int rank, bool* avail) {
   int netNum = system->nodes[NET].count;
   enum ncclTopoGdrMode useGdr = ncclTopoGdrModeDisable;
   *avail = false;
@@ -587,7 +616,8 @@ ncclResult_t ncclTopoIsGdrAvail(struct ncclTopoSystem* system, int rank, bool *a
 NCCL_PARAM(NetForceFlush, "NET_FORCE_FLUSH", 0);
 
 // Based on the system topology, determine whether an explicit iflush is needed on the GDR recv path.
-ncclResult_t ncclTopoNeedFlush(struct ncclComm* comm, int64_t netId, int netDev, int rank, bool netManaged, enum ncclTopoFlushType* flush) {
+ncclResult_t ncclTopoNeedFlush(struct ncclComm* comm, int64_t netId, int netDev, int rank, bool netManaged,
+                               enum ncclTopoFlushType* flush) {
   *flush = ncclTopoFlushAlways;
   ncclNetProperties_t props;
   NCCLCHECK(comm->ncclNet->getProperties(netDev, &props));
@@ -598,7 +628,7 @@ ncclResult_t ncclTopoNeedFlush(struct ncclComm* comm, int64_t netId, int netDev,
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
   *flush = netManaged ? ncclTopoFlushNone : ncclTopoFlushAlways;
 #else
-  struct ncclTopoNode* gpu = system->nodes[GPU].nodes+g; // unused variable - compiler warning
+  struct ncclTopoNode* gpu = system->nodes[GPU].nodes + g; // unused variable - compiler warning
   // Flush is required on Ampere and earlier
   if (gpu->gpu.cudaCompCap >= 90) {
     *flush = ncclTopoFlushNone;
@@ -630,8 +660,8 @@ ncclResult_t ncclTopoCheckNet(struct ncclTopoSystem* system, int rank1, int rank
   }
 
   *net = 1;
-  struct ncclTopoNode* gpu1 = system->nodes[GPU].nodes+g1;
-  struct ncclTopoNode* gpu2 = system->nodes[GPU].nodes+g2;
+  struct ncclTopoNode* gpu1 = system->nodes[GPU].nodes + g1;
+  struct ncclTopoNode* gpu2 = system->nodes[GPU].nodes + g2;
   float speed = gpu1->paths[GPU][g2].bw;
 
   // Now check the speed each GPU can access the network through PXB or better.
@@ -640,13 +670,13 @@ ncclResult_t ncclTopoCheckNet(struct ncclTopoSystem* system, int rank1, int rank
   // a zero netSpeed on either side means MNNVL P2P is preferred over RDMA for that pair.
   // NET remains a valid fallback when both GPUs have local NICs and sufficient bandwidth.
   float netSpeed1 = 0, netSpeed2 = 0;
-  for (int n=0; n<system->nodes[NET].count; n++) {
+  for (int n = 0; n < system->nodes[NET].count; n++) {
     if (gpu1->paths[NET] != NULL) {
-      struct ncclTopoLinkList* path = gpu1->paths[NET]+n;
+      struct ncclTopoLinkList* path = gpu1->paths[NET] + n;
       if (path->type <= PATH_PXB && path->bw > netSpeed1) netSpeed1 = path->bw;
     }
     if (gpu2->paths[NET] != NULL) {
-      struct ncclTopoLinkList* path = gpu2->paths[NET]+n;
+      struct ncclTopoLinkList* path = gpu2->paths[NET] + n;
       if (path->type <= PATH_PXB && path->bw > netSpeed2) netSpeed2 = path->bw;
     }
   }
@@ -656,15 +686,19 @@ ncclResult_t ncclTopoCheckNet(struct ncclTopoSystem* system, int rank1, int rank
   return ncclSuccess;
 }
 
-ncclResult_t ncclTopoGetIntermediateRank(struct ncclTopoSystem* system, int rank, int64_t netId, int* intermediateRank) {
+ncclResult_t ncclTopoGetIntermediateRank(struct ncclTopoSystem* system, int rank, int64_t netId,
+                                         int* intermediateRank) {
   // Get GPU and NET
   int n, g;
   NCCLCHECK(ncclTopoIdToIndex(system, NET, netId, &n));
   NCCLCHECK(ncclTopoRankToIndex(system, rank, &g, /*showWarn=*/true));
-  struct ncclTopoNode* gpu = system->nodes[GPU].nodes+g;
+  struct ncclTopoNode* gpu = system->nodes[GPU].nodes + g;
   // Remote GPUs (MNNVL) have no NET paths allocated; they have no local NICs so no intermediate rank
-  if (gpu->paths[NET] == NULL) { *intermediateRank = -1; return ncclSuccess; }
-  struct ncclTopoLinkList* path = gpu->paths[NET]+n;
+  if (gpu->paths[NET] == NULL) {
+    *intermediateRank = -1;
+    return ncclSuccess;
+  }
+  struct ncclTopoLinkList* path = gpu->paths[NET] + n;
   if (path->type == PATH_PXN) {
     // PXN path follows GPU-DEV-NVS-..., start from the first NVS node and find the first DEV in the path
     int i = 1;
@@ -673,7 +707,7 @@ ncclResult_t ncclTopoGetIntermediateRank(struct ncclTopoSystem* system, int rank
 
     // Select the first GPU on the device found to be the PXN intermediate rank
     if (node->type == DEV) {
-      for (int i=0; i<node->nlinks; i++) {
+      for (int i = 0; i < node->nlinks; i++) {
         if (node->links[i].remNode->type == GPU) {
           node = node->links[i].remNode;
           break;
@@ -684,7 +718,8 @@ ncclResult_t ncclTopoGetIntermediateRank(struct ncclTopoSystem* system, int rank
       WARN("Could not find intermediate GPU between GPU rank %d and NIC %lx", rank, netId);
       return ncclInternalError;
     }
-    NCCLCHECK(ncclTopoDevToRank(system, NCCL_TOPO_ID_SYSTEM_ID(node->id), node->gpu.dev, /*warn=*/true, intermediateRank));
+    NCCLCHECK(ncclTopoDevToRank(system, NCCL_TOPO_ID_SYSTEM_ID(node->id), node->gpu.dev, /*warn=*/true,
+                                intermediateRank));
   } else {
     *intermediateRank = rank;
   }
@@ -720,7 +755,7 @@ ncclResult_t ncclTopoGetPxnRanks(struct ncclComm* comm, int** intermediateRanks,
 
   int nr = 0;
   int* ranks = NULL;
-  for (int rank=0; rank<comm->nRanks; rank++) {
+  for (int rank = 0; rank < comm->nRanks; rank++) {
     int64_t netId;
     int proxyRank;
     NCCLCHECK(ncclTopoGetNetDev(comm, comm->rank, NULL, 0, rank, &netId, NULL, &proxyRank));
@@ -729,11 +764,11 @@ ncclResult_t ncclTopoGetPxnRanks(struct ncclComm* comm, int** intermediateRanks,
     NCCLCHECK(ncclTopoCheckGdr(comm->topo, comm->rank, netId, 1, &useGdr));
     if (useGdr == ncclTopoGdrModeDisable) continue;
     int found = 0;
-    for (int r=0; r<nr; r++) {
+    for (int r = 0; r < nr; r++) {
       if (ranks[r] == proxyRank) found = 1;
     }
     if (!found) {
-      NCCLCHECK(ncclRealloc(&ranks, nr, nr+1));
+      NCCLCHECK(ncclRealloc(&ranks, nr, nr + 1));
       ranks[nr++] = proxyRank;
     }
   }
@@ -747,16 +782,17 @@ static bool rcclPathOverride(struct ncclTopoSystem* system, uint64_t distance) {
 
   for (i = 0; i < system->nodes[GPU].count; i++) {
     for (j = 0; j < system->nodes[NET].count; j++) {
-      if ((system->nodes[NET].nodes[j].net.busId - system->nodes[GPU].nodes[i].id == distance) || (system->nodes[GPU].nodes[i].id - system->nodes[NET].nodes[j].net.busId == distance))
+      if ((system->nodes[NET].nodes[j].net.busId - system->nodes[GPU].nodes[i].id == distance) ||
+          (system->nodes[GPU].nodes[i].id - system->nodes[NET].nodes[j].net.busId == distance))
         break;
     }
-    if (j >= system->nodes[NET].count)
-      break;
+    if (j >= system->nodes[NET].count) break;
   }
   if (i >= system->nodes[GPU].count) {
     for (i = 0; i < system->nodes[GPU].count; i++) {
       for (j = 0; j < system->nodes[NET].count; j++) {
-        if ((system->nodes[NET].nodes[j].net.busId - system->nodes[GPU].nodes[i].id == distance) || (system->nodes[GPU].nodes[i].id - system->nodes[NET].nodes[j].net.busId == distance))
+        if ((system->nodes[NET].nodes[j].net.busId - system->nodes[GPU].nodes[i].id == distance) ||
+            (system->nodes[GPU].nodes[i].id - system->nodes[NET].nodes[j].net.busId == distance))
           system->nodes[GPU].nodes[i].paths[NET][j].type = PATH_PXB;
       }
     }
@@ -768,22 +804,22 @@ static bool rcclPathOverride(struct ncclTopoSystem* system, uint64_t distance) {
 
 // Rewrite GPU<->NIC paths of type `fromType` to `toType` when the two devices share a PCI domain.
 static void rcclRewriteSameDomainNetPaths(struct ncclTopoSystem* system, int fromType, int toType) {
-  for (int g=0; g<system->nodes[GPU].count; g++) {
-    struct ncclTopoNode* gpu = system->nodes[GPU].nodes+g;
+  for (int g = 0; g < system->nodes[GPU].count; g++) {
+    struct ncclTopoNode* gpu = system->nodes[GPU].nodes + g;
     int64_t gpuBusId = NCCL_TOPO_ID_LOCAL_ID(gpu->id);
     int64_t gpuDomain = NCCL_BUSID_DOMAIN(gpuBusId);
-    for (int n=0; n<system->nodes[NET].count; n++) {
-      struct ncclTopoNode* net = system->nodes[NET].nodes+n;
+    for (int n = 0; n < system->nodes[NET].count; n++) {
+      struct ncclTopoNode* net = system->nodes[NET].nodes + n;
       // Skip uninitialized/invalid busIds (raw id 0), but allow domain 0000:
       // it is a valid PCI domain and must still match.
       if (gpuBusId == 0 || net->net.busId == 0) continue;
       if (gpuDomain != NCCL_BUSID_DOMAIN(net->net.busId)) continue;
       if (gpu->paths[NET] && gpu->paths[NET][n].type == fromType) {
         gpu->paths[NET][n].type = toType;
-        INFO(NCCL_GRAPH, "Rewrote same-domain GPU %d -> NET %d path %d->%d (domain 0x%04lx)", g, n, fromType, toType, (unsigned long)gpuDomain);
+        INFO(NCCL_GRAPH, "Rewrote same-domain GPU %d -> NET %d path %d->%d (domain 0x%04lx)", g, n, fromType, toType,
+             (unsigned long)gpuDomain);
       }
-      if (net->paths[GPU] && net->paths[GPU][g].type == fromType)
-        net->paths[GPU][g].type = toType;
+      if (net->paths[GPU] && net->paths[GPU][g].type == fromType) net->paths[GPU][g].type = toType;
     }
   }
 }
@@ -797,43 +833,42 @@ ncclResult_t ncclTopoComputePaths(struct ncclTopoSystem* system, struct ncclComm
   ncclTopoRemovePaths(system);
 
   // Set direct paths to CPUs. We need them in many cases.
-  for (int c=0; c<system->nodes[CPU].count; c++) {
-    NCCLCHECK(ncclTopoSetPaths(system->nodes[CPU].nodes+c, system));
+  for (int c = 0; c < system->nodes[CPU].count; c++) {
+    NCCLCHECK(ncclTopoSetPaths(system->nodes[CPU].nodes + c, system));
   }
 
   // Set direct paths to DEVs, needed in the graph search.
-  for (int d=0; d<system->nodes[DEV].count; d++) {
-    NCCLCHECK(ncclTopoSetPaths(system->nodes[DEV].nodes+d, system));
+  for (int d = 0; d < system->nodes[DEV].count; d++) {
+    NCCLCHECK(ncclTopoSetPaths(system->nodes[DEV].nodes + d, system));
   }
 
   // Set direct paths to GPUs.
-  for (int g=0; g<system->nodes[GPU].count; g++) {
-    NCCLCHECK(ncclTopoSetPaths(system->nodes[GPU].nodes+g, system));
+  for (int g = 0; g < system->nodes[GPU].count; g++) {
+    NCCLCHECK(ncclTopoSetPaths(system->nodes[GPU].nodes + g, system));
   }
 
   // Set direct paths to NICs.
-  for (int n=0; n<system->nodes[NET].count; n++) {
-    NCCLCHECK(ncclTopoSetPaths(system->nodes[NET].nodes+n, system));
+  for (int n = 0; n < system->nodes[NET].count; n++) {
+    NCCLCHECK(ncclTopoSetPaths(system->nodes[NET].nodes + n, system));
   }
 
   // Set direct paths to GIN devices.
-  for (int n=0; n<system->nodes[GIN].count; n++) {
-    NCCLCHECK(ncclTopoSetPaths(system->nodes[GIN].nodes+n, system));
+  for (int n = 0; n < system->nodes[GIN].count; n++) {
+    NCCLCHECK(ncclTopoSetPaths(system->nodes[GIN].nodes + n, system));
   }
 
   // Set direct paths to NVSwitches.
-  for (int n=0; n<system->nodes[NVS].count; n++) {
-    NCCLCHECK(ncclTopoSetPaths(system->nodes[NVS].nodes+n, system));
+  for (int n = 0; n < system->nodes[NVS].count; n++) {
+    NCCLCHECK(ncclTopoSetPaths(system->nodes[NVS].nodes + n, system));
   }
 
-  if (system->nodes[GPU].count > 0 &&
-      IsArchMatch(system->nodes[GPU].nodes[0].gpu.gcn, "gfx1250")) {
+  if (system->nodes[GPU].count > 0 && IsArchMatch(system->nodes[GPU].nodes[0].gpu.gcn, "gfx1250")) {
     rcclRewriteSameDomainNetPaths(system, PATH_PHB, PATH_PXB);
   }
 
   // Update path for GPUs when we don't want to / can't use GPU Direct P2P
-  for (int g=0; g<system->nodes[GPU].count; g++) {
-    for (int p=0; p<system->nodes[GPU].count; p++) {
+  for (int g = 0; g < system->nodes[GPU].count; g++) {
+    for (int p = 0; p < system->nodes[GPU].count; p++) {
       int p2p;
       NCCLCHECK(ncclTopoCheckP2p(comm, system, system->nodes[GPU].nodes[p].gpu.rank,
                                  system->nodes[GPU].nodes[g].gpu.rank, &p2p, NULL, NULL, NULL));
@@ -847,10 +882,10 @@ ncclResult_t ncclTopoComputePaths(struct ncclTopoSystem* system, struct ncclComm
 
     if (comm == NULL) continue;
     // Remove GPUs we can't (or don't want to) communicate with through P2P or SHM
-    struct ncclPeerInfo* dstInfo = comm->peerInfo+system->nodes[GPU].nodes[g].gpu.rank;
-    for (int p=0; p<system->nodes[GPU].count; p++) {
+    struct ncclPeerInfo* dstInfo = comm->peerInfo + system->nodes[GPU].nodes[g].gpu.rank;
+    for (int p = 0; p < system->nodes[GPU].count; p++) {
       if (p == g) continue;
-      struct ncclPeerInfo* srcInfo = comm->peerInfo+system->nodes[GPU].nodes[p].gpu.rank;
+      struct ncclPeerInfo* srcInfo = comm->peerInfo + system->nodes[GPU].nodes[p].gpu.rank;
       int p2p;
       NCCLCHECK(ncclTransports[TRANSPORT_P2P]->canConnect(&p2p, comm, NULL, srcInfo, dstInfo));
       if (p2p == 0) {
@@ -894,30 +929,31 @@ ncclResult_t ncclTopoComputePaths(struct ncclTopoSystem* system, struct ncclComm
 #endif
     int arch, vendor, model;
     NCCLCHECK(ncclTopoCpuType(system, &arch, &vendor, &model));
-    if (arch == NCCL_TOPO_CPU_ARCH_X86 && vendor == NCCL_TOPO_CPU_VENDOR_INTEL &&
-      (IsArchMatch(system->nodes[GPU].nodes[0].gpu.gcn, "gfx942") || IsArchMatch(system->nodes[GPU].nodes[0].gpu.gcn, "gfx950")) &&
+    if (
+      arch == NCCL_TOPO_CPU_ARCH_X86 && vendor == NCCL_TOPO_CPU_VENDOR_INTEL &&
+      (IsArchMatch(system->nodes[GPU].nodes[0].gpu.gcn, "gfx942") ||
+       IsArchMatch(system->nodes[GPU].nodes[0].gpu.gcn, "gfx950")) &&
       ((system->nodes[GPU].count == 8 && system->nodes[NET].count == 8 && system->nodes[GPU].count == system->nRanks) ||
-      (system->nodes[GPU].count != system->nRanks))) {
-      if (!rcclPathOverride(system, 0x100000) && !rcclPathOverride(system, 0x1000))
-        rcclPathOverride(system, 0xff00000);
+       (system->nodes[GPU].count != system->nRanks))) {
+      if (!rcclPathOverride(system, 0x100000) && !rcclPathOverride(system, 0x1000)) rcclPathOverride(system, 0xff00000);
     }
 #if !defined(TOPO_EXPL)
   }
 #endif
 
   // Update paths for NICs (no GPU Direct, PXN, ...)
-  for (int n=0; n<system->nodes[NET].count; n++) {
-    struct ncclTopoNode* netNode = system->nodes[NET].nodes+n;
+  for (int n = 0; n < system->nodes[NET].count; n++) {
+    struct ncclTopoNode* netNode = system->nodes[NET].nodes + n;
 
-    for (int g=0; g<system->nodes[GPU].count; g++) {
+    for (int g = 0; g < system->nodes[GPU].count; g++) {
       // Check whether we can access the NIC through another NVLink-connected GPU (PXN)
-      struct ncclTopoNode* gpu = system->nodes[GPU].nodes+g;
+      struct ncclTopoNode* gpu = system->nodes[GPU].nodes + g;
       if (ncclPxnDisable(comm) != 1) {
         int localGpuIndex;
         NCCLCHECK(ncclTopoGetLocalGpu(system, netNode->id, &localGpuIndex));
         if (localGpuIndex != g && localGpuIndex != -1) {
           // PXN = PCI + NVLink.
-          struct ncclTopoNode* peerNode = system->nodes[GPU].nodes+localGpuIndex;
+          struct ncclTopoNode* peerNode = system->nodes[GPU].nodes + localGpuIndex;
           enum ncclTopoGdrMode gdrMode;
           NCCLCHECK(ncclTopoCheckGdr(system, peerNode->gpu.rank, netNode->id, 1, &gdrMode));
           // Only use PXN for NIC n if remote GPU p ...
@@ -954,8 +990,8 @@ ncclResult_t ncclTopoComputePaths(struct ncclTopoSystem* system, struct ncclComm
   }
 
   // Pre-compute NET local gpus to accelerate search
-  for (int n=0; n<system->nodes[NET].count; n++) {
-    struct ncclTopoNode* net = system->nodes[NET].nodes+n;
+  for (int n = 0; n < system->nodes[NET].count; n++) {
+    struct ncclTopoNode* net = system->nodes[NET].nodes + n;
     NCCLCHECK(ncclTopoGetLocalGpu(system, net->id, &net->net.localGpu));
   }
   return ncclSuccess;
@@ -965,8 +1001,8 @@ RCCL_PARAM(EnableIntranet, "ENABLE_INTRANET", -2);
 
 ncclResult_t ncclTopoTrimSystem(struct ncclTopoSystem* system, struct ncclComm* comm) {
   ncclResult_t ret = ncclSuccess;
-  int *domains;
-  int64_t *ids = NULL;
+  int* domains;
+  int64_t* ids = NULL;
   int myDomain = 0;
   int ngpus = system->nodes[GPU].count;
   int remove = 1;
@@ -980,19 +1016,20 @@ ncclResult_t ncclTopoTrimSystem(struct ncclTopoSystem* system, struct ncclComm* 
   // for clique peers and this block becomes redundant.
   {
     if (comm->MNNVL && comm->peerInfo != NULL) {
-      INFO(NCCL_GRAPH, "ncclTopoTrimSystem: MNNVL enabled, checking clique membership for %d ranks (cliqueSize %d)", comm->nRanks, comm->clique.size);
+      INFO(NCCL_GRAPH, "ncclTopoTrimSystem: MNNVL enabled, checking clique membership for %d ranks (cliqueSize %d)",
+           comm->nRanks, comm->clique.size);
     }
 
-    for (int g=0; g<system->nodes[GPU].count; g++) {
-      struct ncclTopoNode* gpu = system->nodes[GPU].nodes+g;
+    for (int g = 0; g < system->nodes[GPU].count; g++) {
+      struct ncclTopoNode* gpu = system->nodes[GPU].nodes + g;
       domains[g] = g;
       ids[g] = gpu->id;
-      for (int p=0; p<g; p++) {
+      for (int p = 0; p < g; p++) {
         bool sameCliqueP2p = false;
         // MNNVL clique peers have no topology path (PATH_DIS) but are reachable via IFoE fabric.
         // Treat them as same domain so they are not trimmed from the topology.
         if (comm->MNNVL && comm->peerInfo != NULL) {
-          struct ncclTopoNode* peerGpu = system->nodes[GPU].nodes+p;
+          struct ncclTopoNode* peerGpu = system->nodes[GPU].nodes + p;
           // Use rank as direct index into peerInfo — avoids busId key collisions across nodes
           // where two hosts can have GPUs at the same PCI bus address.
           int rank1 = gpu->gpu.rank, rank2 = peerGpu->gpu.rank;
@@ -1001,8 +1038,10 @@ ncclResult_t ncclTopoTrimSystem(struct ncclTopoSystem* system, struct ncclComm* 
             NCCLCHECKGOTO(ncclTopoCheckMNNVL(comm, &comm->peerInfo[rank1], &comm->peerInfo[rank2], &mnnvl), ret, fail);
             if (mnnvl) {
               sameCliqueP2p = true;
-              TRACE(NCCL_GRAPH, "ncclTopoTrimSystem: GPU %lx and GPU %lx are MNNVL clique peers, merging into domain %d",
-                    NCCL_TOPO_ID_LOCAL_ID(gpu->id), NCCL_TOPO_ID_LOCAL_ID(peerGpu->id), std::min(domains[g], domains[p]));
+              TRACE(NCCL_GRAPH,
+                    "ncclTopoTrimSystem: GPU %lx and GPU %lx are MNNVL clique peers, merging into domain %d",
+                    NCCL_TOPO_ID_LOCAL_ID(gpu->id), NCCL_TOPO_ID_LOCAL_ID(peerGpu->id),
+                    std::min(domains[g], domains[p]));
             }
           }
         }
@@ -1014,13 +1053,14 @@ ncclResult_t ncclTopoTrimSystem(struct ncclTopoSystem* system, struct ncclComm* 
     }
   }
 
-  for (int i=0; i<ngpus; i++) {
+  for (int i = 0; i < ngpus; i++) {
     if (domains[i] == myDomain) continue;
     struct ncclTopoNode* gpu = NULL;
     int g;
-    for (g=0; g<system->nodes[GPU].count /* This one varies over the loops */; g++) {
-      gpu = system->nodes[GPU].nodes+g;
-      if (gpu->id == ids[i]) break; else gpu=NULL;
+    for (g = 0; g < system->nodes[GPU].count /* This one varies over the loops */; g++) {
+      gpu = system->nodes[GPU].nodes + g;
+      if (gpu->id == ids[i]) break;
+      else gpu = NULL;
     }
     if (gpu == NULL) {
       WARN("Could not find id %lx", ids[i]);
@@ -1031,8 +1071,8 @@ ncclResult_t ncclTopoTrimSystem(struct ncclTopoSystem* system, struct ncclComm* 
   }
 
   // trim low speed port on same NIC
-  for (int i = 0; i < system->nodes[NET].count; i ++) {
-    for (int j = 0; j < system->nodes[NET].count; j ++) {
+  for (int i = 0; i < system->nodes[NET].count; i++) {
+    for (int j = 0; j < system->nodes[NET].count; j++) {
       if (i == j) continue;
       if (system->nodes[NET].nodes[i].net.asic == system->nodes[NET].nodes[j].net.asic) {
         if (system->nodes[NET].nodes[i].net.bw > system->nodes[NET].nodes[j].net.bw)
@@ -1042,14 +1082,12 @@ ncclResult_t ncclTopoTrimSystem(struct ncclTopoSystem* system, struct ncclComm* 
   }
   do {
     int n;
-    for (n=0; n<system->nodes[NET].count; n++) {
+    for (n = 0; n < system->nodes[NET].count; n++) {
       if (system->nodes[NET].nodes[n].net.bw == 0) break;
     }
-    if (n<system->nodes[NET].count) {
+    if (n < system->nodes[NET].count) {
       NCCLCHECKGOTO(ncclTopoRemoveNode(system, NET, n), ret, fail);
-    }
-    else
-      break;
+    } else break;
   } while (system->nodes[NET].count);
 
   // detect if all GPUs are connected by XGMI
@@ -1085,7 +1123,7 @@ ncclResult_t ncclTopoTrimSystem(struct ncclTopoSystem* system, struct ncclComm* 
 
   comm->localRanks = system->nodes[GPU].count;
   if (system->nodes[GPU].count == comm->nRanks && remove) {
-    for (int n=system->nodes[NET].count-1; n>=0; n--)
+    for (int n = system->nodes[NET].count - 1; n >= 0; n--)
       NCCLCHECKGOTO(ncclTopoRemoveNode(system, NET, n), ret, fail);
   }
   system->inter = system->nodes[GPU].count == comm->nRanks ? 0 : 1;
@@ -1102,9 +1140,10 @@ void ncclTopoFree(struct ncclTopoSystem* system) {
   free(system);
 }
 
-NCCL_PARAM(P2pPerChannelNetBw, "P2P_PER_CHANNEL_NET_BW", /*GB/s*/14);
+NCCL_PARAM(P2pPerChannelNetBw, "P2P_PER_CHANNEL_NET_BW", /*GB/s*/ 14);
 
-static ncclResult_t ncclTopoGetNchannels(struct ncclComm* comm, int g /*local gpu index*/, int peerRank, int* nChannels) {
+static ncclResult_t ncclTopoGetNchannels(struct ncclComm* comm, int g /*local gpu index*/, int peerRank,
+                                         int* nChannels) {
   int peer;
   struct ncclTopoSystem* system = comm->topo;
   struct ncclTopoLinkList* path = NULL;
@@ -1115,12 +1154,15 @@ static ncclResult_t ncclTopoGetNchannels(struct ncclComm* comm, int g /*local gp
       return ncclSuccess;
     }
     // Local rank
-    path = system->nodes[GPU].nodes[peer].paths[GPU]+g;
+    path = system->nodes[GPU].nodes[peer].paths[GPU] + g;
     if (path->type == PATH_NVL) {
       float nvlBw = ncclTopoXGMISpeed(system->nodes[GPU].nodes[g].gpu.gcn);
       *nChannels = ((IsArchMatch(system->nodes[GPU].nodes[0].gpu.gcn, "gfx942") ||
                      IsArchMatch(system->nodes[GPU].nodes[0].gpu.gcn, "gfx950") ||
-                     IsArchMatch(system->nodes[GPU].nodes[0].gpu.gcn, "gfx1250")) ? 4 : 2) * std::max(1, (int)(path->bw / nvlBw));
+                     IsArchMatch(system->nodes[GPU].nodes[0].gpu.gcn, "gfx1250")) ?
+                      4 :
+                      2) *
+                   std::max(1, (int)(path->bw / nvlBw));
     } else {
       *nChannels = 2;
     }
@@ -1131,13 +1173,18 @@ static ncclResult_t ncclTopoGetNchannels(struct ncclComm* comm, int g /*local gp
     if (comm && comm->MNNVL) {
       bool isMnnvlPeer = false;
       for (int ci = 0; ci < comm->clique.size; ci++) {
-        if (comm->clique.ranks[ci] == peerRank) { isMnnvlPeer = true; break; }
+        if (comm->clique.ranks[ci] == peerRank) {
+          isMnnvlPeer = true;
+          break;
+        }
       }
       if (isMnnvlPeer) {
         float nvlBw = ncclTopoXGMISpeed(system->nodes[GPU].nodes[g].gpu.gcn);
         *nChannels = ((IsArchMatch(system->nodes[GPU].nodes[0].gpu.gcn, "gfx942") ||
                        IsArchMatch(system->nodes[GPU].nodes[0].gpu.gcn, "gfx950") ||
-                       IsArchMatch(system->nodes[GPU].nodes[0].gpu.gcn, "gfx1250")) ? 4 : 2);
+                       IsArchMatch(system->nodes[GPU].nodes[0].gpu.gcn, "gfx1250")) ?
+                        4 :
+                        2);
         // MNNVL fabric runs at one XGMI link width per direction; no bw multiplier here.
         (void)nvlBw;
         return ncclSuccess;
@@ -1177,7 +1224,7 @@ ncclResult_t ncclTopoComputeP2pChannelsPerPeer(struct ncclComm* comm) {
     if (nChannels >= 0) minChannels = std::min(minChannels, nChannels);
   }
   comm->p2pnChannelsPerPeer = minChannels;
-  comm->p2pMaxPeers = (comm->config.maxP2pPeers == NCCL_CONFIG_UNDEF_INT)? comm->nRanks: comm->config.maxP2pPeers;
+  comm->p2pMaxPeers = (comm->config.maxP2pPeers == NCCL_CONFIG_UNDEF_INT) ? comm->nRanks : comm->config.maxP2pPeers;
   return ncclSuccess;
 }
 
@@ -1185,7 +1232,8 @@ ncclResult_t ncclTopoComputeP2pChannels(struct ncclComm* comm) {
   /* here we already honor comm->max/minCTAs for p2pnChannels. */
   if (comm->sharedRes->owner != comm) {
     comm->p2pnChannels = std::min(comm->nChannels, (int)ncclParamMaxP2pNChannels());
-    comm->p2pnChannels = std::min(std::max(comm->p2pnChannels, (int)ncclParamMinP2pNChannels()), comm->sharedRes->tpP2pNChannels);
+    comm->p2pnChannels =
+      std::min(std::max(comm->p2pnChannels, (int)ncclParamMinP2pNChannels()), comm->sharedRes->tpP2pNChannels);
   } else {
     comm->p2pnChannels = std::min(comm->nChannels, (int)ncclParamMaxP2pNChannels());
     comm->p2pnChannels = std::max(comm->p2pnChannels, (int)ncclParamMinP2pNChannels());
@@ -1196,14 +1244,17 @@ ncclResult_t ncclTopoComputeP2pChannels(struct ncclComm* comm) {
 
   int arch, vendor, model;
   NCCLCHECK(ncclTopoCpuType(comm->topo, &arch, &vendor, &model));
-  if (arch == NCCL_TOPO_CPU_ARCH_X86 && vendor == NCCL_TOPO_CPU_VENDOR_INTEL && !(comm->topo->type & RCCL_TOPO_XGMI_ALL)) {
+  if (arch == NCCL_TOPO_CPU_ARCH_X86 && vendor == NCCL_TOPO_CPU_VENDOR_INTEL &&
+      !(comm->topo->type & RCCL_TOPO_XGMI_ALL)) {
     // Adjust P2P channels on Intel platform
     comm->p2pnChannelsPerPeer = 8;
     comm->p2pnChannels = 8;
-  } else if (comm->topo->nodes[GPU].count == comm->topo->nRanks && (comm->topo->type & RCCL_TOPO_4P2H_ROME) && !(comm->topo->type & RCCL_TOPO_GDR_ALL) && !(comm->topo->type & RCCL_TOPO_XGMI_ALL)) {
+  } else if (comm->topo->nodes[GPU].count == comm->topo->nRanks && (comm->topo->type & RCCL_TOPO_4P2H_ROME) &&
+             !(comm->topo->type & RCCL_TOPO_GDR_ALL) && !(comm->topo->type & RCCL_TOPO_XGMI_ALL)) {
     // Adjust P2P channels on Rome
     comm->p2pnChannelsPerPeer = 2;
-    comm->p2pnChannels = std::min(pow2Up(comm->p2pnChannels), pow2Down(ncclDevMaxChannelsForArgsBytes(ncclParamWorkArgsBytes())));
+    comm->p2pnChannels =
+      std::min(pow2Up(comm->p2pnChannels), pow2Down(ncclDevMaxChannelsForArgsBytes(ncclParamWorkArgsBytes())));
   } else {
     // Round to next pow2 nChannelsPerPeer and nChannels
     comm->p2pnChannelsPerPeer = pow2Up(minChannels);
@@ -1211,27 +1262,37 @@ ncclResult_t ncclTopoComputeP2pChannels(struct ncclComm* comm) {
     if (comm->topo->nodes[GPU].count == comm->topo->nRanks &&
         (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942") ||
          IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950") ||
-         IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx1250"))) comm->p2pnChannelsPerPeer *= 2;
+         IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx1250")))
+      comm->p2pnChannelsPerPeer *= 2;
     // p2pnChannels must be >= p2pnChannelsPerPeer: the device-side inverse
     // ncclP2pChannelToPart cannot recover part indices >= nP2pChannels, so
     // higher parts silently alias onto lower ones and produce wrong data
     // (seen on MI455 2x1p1g alltoall when topology fallback yields 2 channels
     // but the gfx1250 single-node doubling above asks for 4 parts per peer).
-    comm->p2pnChannels = std::min(std::max(pow2Up(comm->p2pnChannels), pow2Up(comm->p2pnChannelsPerPeer)), 4*CHANNEL_LIMIT);
+    comm->p2pnChannels =
+      std::min(std::max(pow2Up(comm->p2pnChannels), pow2Up(comm->p2pnChannelsPerPeer)), 4 * CHANNEL_LIMIT);
     // p2pnChannelsPerPeer cannot be greater than MAXCHANNELS
     // Capping the comm->p2pnChannels to 32 for send/recv based collectives on multi-node MI350 (2 and 4 nodes)
-    if (((comm->nNodes == 2 && comm->topo->nRanks == 16) || (comm->nNodes == 4 && comm->topo->nRanks == 32)) && (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950"))) comm->p2pnChannels = std::min(comm->p2pnChannels, 32);
+    if (((comm->nNodes == 2 && comm->topo->nRanks == 16) || (comm->nNodes == 4 && comm->topo->nRanks == 32)) &&
+        (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950")))
+      comm->p2pnChannels = std::min(comm->p2pnChannels, 32);
     // Capping the comm->p2pnChannels to 16 for send/recv based collectives with half-subscription (4 GPUs per node) multi-node MI350 (2 and 4 nodes)
-    if (((comm->nNodes == 2 && comm->topo->nRanks == 8) || (comm->nNodes == 4 && comm->topo->nRanks == 16)) && (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950"))) comm->p2pnChannels = std::min(comm->p2pnChannels, 16);
+    if (((comm->nNodes == 2 && comm->topo->nRanks == 8) || (comm->nNodes == 4 && comm->topo->nRanks == 16)) &&
+        (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950")))
+      comm->p2pnChannels = std::min(comm->p2pnChannels, 16);
     // Opt-in P2P CU reduction on gfx950 (MI350) at scale: cap p2pnChannels to 16 when nNodes >= 16
-    if (ncclParamP2pCuReduceScaleEnable() && comm->nNodes >= 16 && IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950")) comm->p2pnChannels = std::min(comm->p2pnChannels, 16);
+    if (ncclParamP2pCuReduceScaleEnable() && comm->nNodes >= 16 &&
+        IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950"))
+      comm->p2pnChannels = std::min(comm->p2pnChannels, 16);
     comm->p2pnChannelsPerPeer = std::min(comm->p2pnChannelsPerPeer, MAXCHANNELS);
   }
 
   if (comm->nNodes > 1 && comm->config.nChannelsPerNetPeer == NCCL_CONFIG_UNDEF_INT) {
     // In the case of >1 NVLD (and the user didn't set nChannelsPerNetPeer), the network is the bottleneck.
     // Reduce the number of channels per host to avoid going above p2pnChannels to fit all the peers within a single round.
-    while (comm->p2pnChannelsPerPeer * divUp(comm->nRanks, NCCL_MAX_DEV_WORK_P2P_PER_BATCH) >= comm->p2pnChannels && comm->p2pnChannelsPerPeer > 1) comm->p2pnChannelsPerPeer /= 2;
+    while (comm->p2pnChannelsPerPeer * divUp(comm->nRanks, NCCL_MAX_DEV_WORK_P2P_PER_BATCH) >= comm->p2pnChannels &&
+           comm->p2pnChannelsPerPeer > 1)
+      comm->p2pnChannelsPerPeer /= 2;
   } else {
     comm->p2pnChannelsPerPeer = std::min(comm->p2pnChannelsPerPeer, comm->p2pnChannels);
   }
@@ -1250,7 +1311,7 @@ ncclResult_t ncclTopoComputeP2pChannels(struct ncclComm* comm) {
   }
 
   // Init channels that weren't used so far
-  for (int c=comm->nChannels; c<std::max(comm->nChannels, comm->p2pnChannels); c++) NCCLCHECK(initChannel(comm, c));
+  for (int c = comm->nChannels; c < std::max(comm->nChannels, comm->p2pnChannels); c++) NCCLCHECK(initChannel(comm, c));
 
   return ncclSuccess;
 }
@@ -1259,10 +1320,10 @@ ncclResult_t ncclTopoGetNvbGpus(struct ncclTopoSystem* system, int rank, int* nr
   int ngpus = system->nodes[GPU].count;
   NCCLCHECK(ncclCalloc(ranks, ngpus));
   int nvbGpus = 0;
-  for (int g=0; g<ngpus; g++) {
-    struct ncclTopoNode* gpu = system->nodes[GPU].nodes+g;
+  for (int g = 0; g < ngpus; g++) {
+    struct ncclTopoNode* gpu = system->nodes[GPU].nodes + g;
     if (gpu->gpu.rank != rank) continue;
-    for (int p=0; p<ngpus; p++) {
+    for (int p = 0; p < ngpus; p++) {
       if (gpu->paths[GPU][p].type == PATH_NVB) {
         (*ranks)[nvbGpus++] = system->nodes[GPU].nodes[p].gpu.rank;
       }
@@ -1274,10 +1335,10 @@ ncclResult_t ncclTopoGetNvbGpus(struct ncclTopoSystem* system, int rank, int* nr
 
 ncclResult_t ncclTopoGetGpuMinPath(struct ncclTopoSystem* system, int type, int* min) {
   int minPath = PATH_SYS;
-  for (int i=0; i<system->nodes[GPU].count; i++) {
+  for (int i = 0; i < system->nodes[GPU].count; i++) {
     struct ncclTopoLinkList* paths = system->nodes[GPU].nodes[i].paths[type];
     if (paths == NULL) continue;
-    for (int j=0; j<system->nodes[type].count; j++) {
+    for (int j = 0; j < system->nodes[type].count; j++) {
       if (type == GPU && i == j) continue;
       minPath = std::min(minPath, paths[j].type);
     }
@@ -1288,10 +1349,10 @@ ncclResult_t ncclTopoGetGpuMinPath(struct ncclTopoSystem* system, int type, int*
 
 ncclResult_t ncclTopoGetGpuMaxPath(struct ncclTopoSystem* system, int type, int* max) {
   int maxPath = PATH_LOC;
-  for (int i=0; i<system->nodes[GPU].count; i++) {
+  for (int i = 0; i < system->nodes[GPU].count; i++) {
     struct ncclTopoLinkList* paths = system->nodes[GPU].nodes[i].paths[type];
     if (paths == NULL) continue;
-    for (int j=0; j<system->nodes[type].count; j++) {
+    for (int j = 0; j < system->nodes[type].count; j++) {
       if (type == GPU && i == j) continue;
       maxPath = std::max(maxPath, paths[j].type);
     }
@@ -1325,11 +1386,11 @@ ncclResult_t ncclTopoSplitNvLink(struct ncclTopoSystem* system, int* splitNvLink
   int *nvlDomain = NULL, *nvlDomainCount = NULL;
   // Compute NVLink domains
   NCCLCHECKGOTO(ncclCalloc(&nvlDomain, system->nodes[GPU].count), res, exit);
-  for (int g=0; g<system->nodes[GPU].count; g++) nvlDomain[g] = g;
-  for (int g=0; g<system->nodes[GPU].count; g++) {
-    struct ncclTopoNode* gpu = system->nodes[GPU].nodes+g;
+  for (int g = 0; g < system->nodes[GPU].count; g++) nvlDomain[g] = g;
+  for (int g = 0; g < system->nodes[GPU].count; g++) {
+    struct ncclTopoNode* gpu = system->nodes[GPU].nodes + g;
     int domain = nvlDomain[g];
-    for (int p=g+1; p<system->nodes[GPU].count; p++) {
+    for (int p = g + 1; p < system->nodes[GPU].count; p++) {
       if (gpu->paths[GPU][p].type == PATH_NVL) {
         nvlDomain[p] = domain;
       }
@@ -1337,17 +1398,17 @@ ncclResult_t ncclTopoSplitNvLink(struct ncclTopoSystem* system, int* splitNvLink
   }
   // Compute number of GPUs per NVLink domain.
   NCCLCHECKGOTO(ncclCalloc(&nvlDomainCount, system->nodes[GPU].count), res, exit);
-  for (int g=0; g<system->nodes[GPU].count; g++) {
+  for (int g = 0; g < system->nodes[GPU].count; g++) {
     nvlDomainCount[nvlDomain[g]]++;
   }
   // Count the number of NVLink domains
-  for (int g=0; g<system->nodes[GPU].count; g++) {
+  for (int g = 0; g < system->nodes[GPU].count; g++) {
     if (nvlDomainCount[g] > 1) nvlDomains++;
   }
   *splitNvLink = nvlDomains == 2 ? 1 : 0;
 
 exit:
-  if(nvlDomain) free(nvlDomain);
-  if(nvlDomainCount) free(nvlDomainCount);
+  if (nvlDomain) free(nvlDomain);
+  if (nvlDomainCount) free(nvlDomainCount);
   return res;
 }

--- a/projects/rccl/src/graph/rings.cc
+++ b/projects/rccl/src/graph/rings.cc
@@ -7,17 +7,17 @@
 
 #include "core.h"
 
-#include <stdio.h>      
-#include <stdlib.h>     
-#include <stdint.h>    
-#include <string.h> 
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
 
 void dumpLine(int* values, int nranks, const char* prefix) {
   constexpr int line_length = 128;
   char line[line_length];
-  int num_width = snprintf(nullptr, 0, "%d", nranks-1);  // safe as per "man snprintf"
+  int num_width = snprintf(nullptr, 0, "%d", nranks - 1);  // safe as per "man snprintf"
   int n = snprintf(line, line_length, "%s", prefix);
-  for (int i = 0; i < nranks && n < line_length-1; i++) {
+  for (int i = 0; i < nranks && n < line_length - 1; i++) {
     n += snprintf(line + n, line_length - n, " %*d", num_width, values[i]);
     // At this point n may be more than line_length-1, so don't use it
     // for indexing into "line".
@@ -26,7 +26,7 @@ void dumpLine(int* values, int nranks, const char* prefix) {
     // Sprintf wanted to write more than would fit in the buffer. Assume
     // line_length is at least 4 and replace the end with "..." to
     // indicate that it was truncated.
-    snprintf(line+line_length-4, 4, "...");
+    snprintf(line + line_length - 4, 4, "...");
   }
   INFO(NCCL_INIT, "%s", line);
 }
@@ -37,7 +37,7 @@ ncclResult_t ncclBuildRings(int nrings, int* rings, int rank, int nranks, int* p
   int rankFoundSize = DIVUP(nranks, 64);
   NCCLCHECK(ncclCalloc(&rankFound, rankFoundSize));
 
-  for (int r=0; r<nrings; r++) {
+  for (int r = 0; r < nrings; r++) {
     char prefix[40];
     /*sprintf(prefix, "[%d] Channel %d Prev : ", rank, r);
     dumpLine(prev+r*nranks, nranks, prefix);
@@ -45,30 +45,33 @@ ncclResult_t ncclBuildRings(int nrings, int* rings, int rank, int nranks, int* p
     dumpLine(next+r*nranks, nranks, prefix);*/
 
     int current = rank;
-    for (int i=0; i<nranks; i++) {
-      rankFound[current/64] |= (1ULL<<(current%64));
-      rings[r*nranks+i] = current;
-      current = next[r*nranks+current];
+    for (int i = 0; i < nranks; i++) {
+      rankFound[current / 64] |= (1ULL << (current % 64));
+      rings[r * nranks + i] = current;
+      current = next[r * nranks + current];
     }
     snprintf(prefix, sizeof(prefix), "Channel %02d/%02d :", r, nrings);
-    if (rank == 0) dumpLine(rings+r*nranks, nranks, prefix);
+    if (rank == 0) dumpLine(rings + r * nranks, nranks, prefix);
     if (current != rank) {
       WARN("Error : ring %d does not loop back to start (%d != %d)", r, current, rank);
       ret = ncclInternalError;
       goto end;
     }
     // Check that all ranks are there
-    for (int i=0; i<nranks; i++) {
-      uint64_t bits = rankFound[i/64], mask = 1ULL<<(i%64);
+    for (int i = 0; i < nranks; i++) {
+      uint64_t bits = rankFound[i / 64], mask = 1ULL << (i % 64);
       // Fast check 64 ranks at a time
-      if (mask == 1 && bits == 0xffffffffffffffff) { i += 63; continue; }
+      if (mask == 1 && bits == 0xffffffffffffffff) {
+        i += 63;
+        continue;
+      }
       if ((bits & mask) == 0) {
         WARN("Error : ring %d does not contain rank %d", r, i);
         ret = ncclInternalError;
         goto end;
       }
     }
-    memset(rankFound, 0, rankFoundSize*sizeof(uint64_t));
+    memset(rankFound, 0, rankFoundSize * sizeof(uint64_t));
   }
 end:
   free(rankFound);
@@ -77,30 +80,31 @@ end:
 
 /**
  * rcclBuildRings: Functionally same as ncclBuildRings, Linearizes linked-list neighbor pointers into a rank array.
- * This function converts 'next' and 'prev' adjacency arrays into a flat list 
+ * This function converts 'next' and 'prev' adjacency arrays into a flat list
  * of ranks (a ring) for each communication channel.
  *
  * PRE-CONDITIONS & ASSUMPTIONS:
- * 1. Global Connectivity: It assumes that 'next' and 'prev' arrays represent 
+ * 1. Global Connectivity: It assumes that 'next' and 'prev' arrays represent
  * a complete graph of all 'nranks' global participants.
- * 2. Array Sizing: 
+ * 2. Array Sizing:
  * - 'rings' must be allocated to at least (nrings * nranks * sizeof(int)).
  * - 'prev' and 'next' must be (nrings * nranks) in size.
- * 3. Identity: 'rank' must be the global rank of the local process, and 
+ * 3. Identity: 'rank' must be the global rank of the local process, and
  * 0 <= rank < nranks.
- * 4. Path Discovery: It assumes the caller has already performed topology search 
+ * 4. Path Discovery: It assumes the caller has already performed topology search
  * to populate 'next' and 'prev' such that they form a Hamiltonian cycle.
  *
  * DESCRIPTION:
  * - Loop-back: Ensures the ring returns to the starting rank after exactly 'nranks' steps.
  * - Full Coverage: Ensures no rank is skipped or duplicated (O(N) check).
  * - Bi-directional: Verifies that 'prev' and 'next' are perfect mirrors.
- * - O( nRings * nRanks ) Algorithmic complexity 
+ * - O( nRings * nRanks ) Algorithmic complexity
  */
 ncclResult_t rcclBuildRings(int nrings, int* rings, int rank, int nranks, int* prev, int* next) {
   // Use a stack-allocated buffer for O(N) validation.
   // If nranks > 1024, consider using malloc/free
-  if( (nrings < 0) || (rank < 0) ||  (nranks < 0) || ( rings == NULL) || (prev == NULL) || (next == NULL)) return ncclInvalidArgument;
+  if ((nrings < 0) || (rank < 0) || (nranks < 0) || (rings == NULL) || (prev == NULL) || (next == NULL))
+    return ncclInvalidArgument;
   ncclResult_t res = ncclSuccess;
   uint8_t* found = (uint8_t*)malloc(nranks * sizeof(uint8_t));
   if (found == NULL) return ncclInternalError;
@@ -135,11 +139,11 @@ ncclResult_t rcclBuildRings(int nrings, int* rings, int rank, int nranks, int* p
       // --- The Consistency Check ---
       int next_rank = current_next[current];
       if (next_rank >= 0 && next_rank < nranks) {
-        // Verify that if I think 'next_rank' is my next, 
+        // Verify that if I think 'next_rank' is my next,
         // 'next_rank' must think I am its previous.
         if (current_prev[next_rank] != current) {
-          WARN("Ring %d: Asymmetric link! Rank %d -> %d, but %d -> %d", 
-               r, current, next_rank, next_rank, current_prev[next_rank]);
+          WARN("Ring %d: Asymmetric link! Rank %d -> %d, but %d -> %d", r, current, next_rank, next_rank,
+               current_prev[next_rank]);
           res = ncclInternalError;
           goto exit;
         }
@@ -176,6 +180,6 @@ ncclResult_t rcclBuildRings(int nrings, int* rings, int rank, int nranks, int* p
     }
   }
 exit:
-  if(found) free(found);
+  if (found) free(found);
   return res;
 }

--- a/projects/rccl/src/graph/rome_models.cc
+++ b/projects/rccl/src/graph/rome_models.cc
@@ -41,888 +41,2811 @@ struct rcclRomeModel {
   int64_t nicIds[NCCL_TOPO_MAX_NODES];
   int64_t gpuNuma[NCCL_TOPO_MAX_NODES];
   int64_t nicNuma[NCCL_TOPO_MAX_NODES];
-  uint8_t connMatrix[NCCL_TOPO_MAX_NODES*NCCL_TOPO_MAX_NODES];
-  uint8_t gdrLevel[NCCL_TOPO_MAX_NODES*NCCL_TOPO_MAX_NODES];
-  const char *pattern;
-  const char *ringBase;
-  const char *ringTail2;  // Lines to use for node N-2 if the total number of nodes is odd
-  const char *ringTail1;  // Lines to use for node N-1 if the total number of nodes is odd
-  const char *options;
-  const char *treeBase;
-  const char *treeRail;
+  uint8_t connMatrix[NCCL_TOPO_MAX_NODES * NCCL_TOPO_MAX_NODES];
+  uint8_t gdrLevel[NCCL_TOPO_MAX_NODES * NCCL_TOPO_MAX_NODES];
+  const char* pattern;
+  const char* ringBase;
+  const char* ringTail2;  // Lines to use for node N-2 if the total number of nodes is odd
+  const char* ringTail1;  // Lines to use for node N-1 if the total number of nodes is odd
+  const char* options;
+  const char* treeBase;
+  const char* treeRail;
 };
 
 static struct rcclRomeModel rome_model_22 = {
-  .nGpus = 8, .nCpus = 4, .nNics = 1, .nLinks = 2,
-  .gpuIds = { 0x3000, 0x43000, 0x26000, 0xc3000, 0x83000, 0x23000, 0xc6000, 0xa3000, },
-  .nicIds = { 0xe1000, },
-  .gpuNuma = { 1, 0, 1, 2, 3, 1, 2, 3, },
-  .nicNuma = { 2, },
-  .connMatrix = { 0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, },
-  .gdrLevel = { PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_SYS, PATH_SYS, PATH_PHB, PATH_SYS, },
+  .nGpus = 8,
+  .nCpus = 4,
+  .nNics = 1,
+  .nLinks = 2,
+  .gpuIds =
+    {
+      0x3000,
+      0x43000,
+      0x26000,
+      0xc3000,
+      0x83000,
+      0x23000,
+      0xc6000,
+      0xa3000,
+    },
+  .nicIds =
+    {
+      0xe1000,
+    },
+  .gpuNuma =
+    {
+      1,
+      0,
+      1,
+      2,
+      3,
+      1,
+      2,
+      3,
+    },
+  .nicNuma =
+    {
+      2,
+    },
+  .connMatrix =
+    {
+      0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1,
+      0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0,
+    },
+  .gdrLevel =
+    {
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_PHB,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_PHB,
+      PATH_SYS,
+    },
   .pattern = "10302120",
   .ringBase = "7 4 5 3 1 0 6 2|4 7 3 5 0 1 2 6",
   .options = "",
 };
 
 static struct rcclRomeModel rome_model_25 = {
-  .nGpus = 8, .nCpus = 4, .nNics = 2, .nLinks = 2,
-  .gpuIds = { 0x43000, 0x23000, 0x26000, 0x3000, 0xe3000, 0xc3000, 0xc6000, 0x83000, },
-  .nicIds = { 0x61000, 0xa1000, },
-  .gpuNuma = { 0, 1, 1, 1, 2, 2, 2, 3, },
-  .nicNuma = { 0, 3, },
-  .connMatrix = { 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 1, 0, },
-  .gdrLevel = { PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, },
+  .nGpus = 8,
+  .nCpus = 4,
+  .nNics = 2,
+  .nLinks = 2,
+  .gpuIds =
+    {
+      0x43000,
+      0x23000,
+      0x26000,
+      0x3000,
+      0xe3000,
+      0xc3000,
+      0xc6000,
+      0x83000,
+    },
+  .nicIds =
+    {
+      0x61000,
+      0xa1000,
+    },
+  .gpuNuma =
+    {
+      0,
+      1,
+      1,
+      1,
+      2,
+      2,
+      2,
+      3,
+    },
+  .nicNuma =
+    {
+      0,
+      3,
+    },
+  .connMatrix =
+    {
+      0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 1, 0,
+    },
+  .gdrLevel =
+    {
+      PATH_PHB,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_PHB,
+    },
   .pattern = "11303011",
   .ringBase = "2 1 0 3 6 7 5 4|7 6 4 5 1 2 3 0",
   .options = "",
 };
 
 static struct rcclRomeModel rome_model_27 = {
-  .nGpus = 8, .nCpus = 4, .nNics = 2, .nLinks = 2,
-  .gpuIds = { 0x43000, 0x23000, 0x26000, 0x3000, 0xe3000, 0xc3000, 0xc6000, 0x83000, },
-  .nicIds = { 0x61000, 0xa1000, },
-  .gpuNuma = { 0, 1, 1, 1, 2, 2, 2, 3, },
-  .nicNuma = { 0, 3, },
-  .connMatrix = { 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, },
-  .gdrLevel = { PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, },
+  .nGpus = 8,
+  .nCpus = 4,
+  .nNics = 2,
+  .nLinks = 2,
+  .gpuIds =
+    {
+      0x43000,
+      0x23000,
+      0x26000,
+      0x3000,
+      0xe3000,
+      0xc3000,
+      0xc6000,
+      0x83000,
+    },
+  .nicIds =
+    {
+      0x61000,
+      0xa1000,
+    },
+  .gpuNuma =
+    {
+      0,
+      1,
+      1,
+      1,
+      2,
+      2,
+      2,
+      3,
+    },
+  .nicNuma =
+    {
+      0,
+      3,
+    },
+  .connMatrix =
+    {
+      0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0,
+      0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0,
+    },
+  .gdrLevel =
+    {
+      PATH_PHB,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_PHB,
+    },
   .pattern = "11303011",
   .ringBase = "0 6 2 3 1 7 5 4|7 1 4 5 6 0 3 2",
   .options = "",
 };
 
 static struct rcclRomeModel rome_model_29 = {
-  .nGpus = 8, .nCpus = 4, .nNics = 1, .nLinks = 3,
-  .gpuIds = { 0x43000, 0x23000, 0x26000, 0x3000, 0xc3000, 0xc6000, 0xa3000, 0x83000, },
-  .nicIds = { 0xe1000, },
-  .gpuNuma = { 0, 1, 1, 1, 2, 2, 3, 3, },
-  .nicNuma = { 2, },
-  .connMatrix = { 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, },
-  .gdrLevel = { PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, },
+  .nGpus = 8,
+  .nCpus = 4,
+  .nNics = 1,
+  .nLinks = 3,
+  .gpuIds =
+    {
+      0x43000,
+      0x23000,
+      0x26000,
+      0x3000,
+      0xc3000,
+      0xc6000,
+      0xa3000,
+      0x83000,
+    },
+  .nicIds =
+    {
+      0xe1000,
+    },
+  .gpuNuma =
+    {
+      0,
+      1,
+      1,
+      1,
+      2,
+      2,
+      3,
+      3,
+    },
+  .nicNuma =
+    {
+      2,
+    },
+  .connMatrix =
+    {
+      0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0,
+    },
+  .gdrLevel =
+    {
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_PHB,
+      PATH_PHB,
+      PATH_SYS,
+      PATH_SYS,
+    },
   .pattern = "10302120",
   .ringBase = "6 5 7 4 0 1 3 2|6 4 7 5 2 3 1 0",
   .options = "",
 };
 
 static struct rcclRomeModel rome_model_31 = {
-  .nGpus = 8, .nCpus = 8, .nNics = 2, .nLinks = 2,
-  .gpuIds = { 0x43000, 0x23000, 0x26000, 0x3000, 0xe3000, 0xc3000, 0xc6000, 0x83000, },
-  .nicIds = { 0x61000, 0xa1000, },
-  .gpuNuma = { 1, 2, 2, 3, 4, 5, 5, 7, },
-  .nicNuma = { 0, 6, },
-  .connMatrix = { 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 1, 0, },
-  .gdrLevel = { PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, },
+  .nGpus = 8,
+  .nCpus = 8,
+  .nNics = 2,
+  .nLinks = 2,
+  .gpuIds =
+    {
+      0x43000,
+      0x23000,
+      0x26000,
+      0x3000,
+      0xe3000,
+      0xc3000,
+      0xc6000,
+      0x83000,
+    },
+  .nicIds =
+    {
+      0x61000,
+      0xa1000,
+    },
+  .gpuNuma =
+    {
+      1,
+      2,
+      2,
+      3,
+      4,
+      5,
+      5,
+      7,
+    },
+  .nicNuma =
+    {
+      0,
+      6,
+    },
+  .connMatrix =
+    {
+      0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 1, 0,
+    },
+  .gdrLevel =
+    {
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+    },
   .pattern = "0110201010200110",
   .ringBase = "1 2 3 0 6 4 5 7|4 6 7 5 2 1 0 3",
   .options = "",
 };
 
 static struct rcclRomeModel rome_model_33 = {
-  .nGpus = 8, .nCpus = 8, .nNics = 2, .nLinks = 2,
-  .gpuIds = { 0x43000, 0x23000, 0x26000, 0x3000, 0xe3000, 0xc3000, 0xc6000, 0x83000, },
-  .nicIds = { 0x61000, 0xa1000, },
-  .gpuNuma = { 1, 2, 2, 3, 4, 5, 5, 7, },
-  .nicNuma = { 0, 6, },
-  .connMatrix = { 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, },
-  .gdrLevel = { PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, },
+  .nGpus = 8,
+  .nCpus = 8,
+  .nNics = 2,
+  .nLinks = 2,
+  .gpuIds =
+    {
+      0x43000,
+      0x23000,
+      0x26000,
+      0x3000,
+      0xe3000,
+      0xc3000,
+      0xc6000,
+      0x83000,
+    },
+  .nicIds =
+    {
+      0x61000,
+      0xa1000,
+    },
+  .gpuNuma =
+    {
+      1,
+      2,
+      2,
+      3,
+      4,
+      5,
+      5,
+      7,
+    },
+  .nicNuma =
+    {
+      0,
+      6,
+    },
+  .connMatrix =
+    {
+      0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0,
+      0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0,
+    },
+  .gdrLevel =
+    {
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+    },
   .pattern = "0110201010200110",
   .ringBase = "1 4 5 7 0 3 2 6|4 1 7 5 6 2 3 0",
   .options = "",
 };
 
 static struct rcclRomeModel rome_model_30 = {
-  .nGpus = 8, .nCpus = 8, .nNics = 0, .nLinks = 2,
-  .gpuIds = { 0x43000, 0x23000, 0x26000, 0x3000, 0xe3000, 0xc3000, 0xc6000, 0x83000, },
-  .nicIds = { },
-  .gpuNuma = { 1, 2, 2, 3, 4, 5, 5, 7, },
-  .nicNuma = { },
-  .connMatrix = { 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 1, 0, },
-  .gdrLevel = { },
+  .nGpus = 8,
+  .nCpus = 8,
+  .nNics = 0,
+  .nLinks = 2,
+  .gpuIds =
+    {
+      0x43000,
+      0x23000,
+      0x26000,
+      0x3000,
+      0xe3000,
+      0xc3000,
+      0xc6000,
+      0x83000,
+    },
+  .nicIds = {},
+  .gpuNuma =
+    {
+      1,
+      2,
+      2,
+      3,
+      4,
+      5,
+      5,
+      7,
+    },
+  .nicNuma = {},
+  .connMatrix =
+    {
+      0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 1, 0,
+    },
+  .gdrLevel = {},
   .pattern = "0010201010200010",
   .ringBase = "3 0 1 2 6 7 5 4|2 1 0 3 7 6 4 5",
   .options = "",
 };
 
 static struct rcclRomeModel rome_model_32 = {
-  .nGpus = 8, .nCpus = 8, .nNics = 0, .nLinks = 2,
-  .gpuIds = { 0x43000, 0x23000, 0x26000, 0x3000, 0xe3000, 0xc3000, 0xc6000, 0x83000, },
-  .nicIds = { },
-  .gpuNuma = { 1, 2, 2, 3, 4, 5, 5, 7, },
-  .nicNuma = { },
-  .connMatrix = { 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, },
-  .gdrLevel = { },
+  .nGpus = 8,
+  .nCpus = 8,
+  .nNics = 0,
+  .nLinks = 2,
+  .gpuIds =
+    {
+      0x43000,
+      0x23000,
+      0x26000,
+      0x3000,
+      0xe3000,
+      0xc3000,
+      0xc6000,
+      0x83000,
+    },
+  .nicIds = {},
+  .gpuNuma =
+    {
+      1,
+      2,
+      2,
+      3,
+      4,
+      5,
+      5,
+      7,
+    },
+  .nicNuma = {},
+  .connMatrix =
+    {
+      0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0,
+      0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0,
+    },
+  .gdrLevel = {},
   .pattern = "0010201010200010",
   .ringBase = "0 6 2 3 4 5 7 1|3 2 6 0 1 7 5 4",
   .options = "",
 };
 
 static struct rcclRomeModel rome_model_24 = {
-  .nGpus = 8, .nCpus = 4, .nNics = 0, .nLinks = 2,
-  .gpuIds = { 0x43000, 0x23000, 0x26000, 0x3000, 0xe3000, 0xc3000, 0xc6000, 0x83000, },
-  .nicIds = { },
-  .gpuNuma = { 0, 1, 1, 1, 2, 2, 2, 3, },
-  .nicNuma = { },
-  .connMatrix = { 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 1, 0, },
-  .gdrLevel = { },
+  .nGpus = 8,
+  .nCpus = 4,
+  .nNics = 0,
+  .nLinks = 2,
+  .gpuIds =
+    {
+      0x43000,
+      0x23000,
+      0x26000,
+      0x3000,
+      0xe3000,
+      0xc3000,
+      0xc6000,
+      0x83000,
+    },
+  .nicIds = {},
+  .gpuNuma =
+    {
+      0,
+      1,
+      1,
+      1,
+      2,
+      2,
+      2,
+      3,
+    },
+  .nicNuma = {},
+  .connMatrix =
+    {
+      0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 1, 0,
+    },
+  .gdrLevel = {},
   .pattern = "10303010",
   .ringBase = "0 1 2 3 5 7 6 4|1 0 3 2 7 5 4 6",
   .options = "",
 };
 
 static struct rcclRomeModel rome_model_26 = {
-  .nGpus = 8, .nCpus = 4, .nNics = 0, .nLinks = 2,
-  .gpuIds = { 0x43000, 0x23000, 0x26000, 0x3000, 0xe3000, 0xc3000, 0xc6000, 0x83000, },
-  .nicIds = { },
-  .gpuNuma = { 0, 1, 1, 1, 2, 2, 2, 3, },
-  .nicNuma = { },
-  .connMatrix = { 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, },
-  .gdrLevel = { },
+  .nGpus = 8,
+  .nCpus = 4,
+  .nNics = 0,
+  .nLinks = 2,
+  .gpuIds =
+    {
+      0x43000,
+      0x23000,
+      0x26000,
+      0x3000,
+      0xe3000,
+      0xc3000,
+      0xc6000,
+      0x83000,
+    },
+  .nicIds = {},
+  .gpuNuma =
+    {
+      0,
+      1,
+      1,
+      1,
+      2,
+      2,
+      2,
+      3,
+    },
+  .nicNuma = {},
+  .connMatrix =
+    {
+      0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0,
+      0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0,
+    },
+  .gdrLevel = {},
   .pattern = "10303010",
   .ringBase = "4 5 7 1 0 3 2 6|3 0 6 2 1 7 5 4",
   .options = "",
 };
 
 static struct rcclRomeModel rome_model_23 = {
-  .nGpus = 8, .nCpus = 4, .nNics = 0, .nLinks = 2,
-  .gpuIds = { 0x43000, 0x23000, 0x26000, 0x3000, 0xc3000, 0xc6000, 0xa3000, 0x83000, },
-  .nicIds = { },
-  .gpuNuma = { 0, 1, 1, 1, 2, 2, 3, 3, },
-  .nicNuma = { },
-  .connMatrix = { 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, },
-  .gdrLevel = { },
+  .nGpus = 8,
+  .nCpus = 4,
+  .nNics = 0,
+  .nLinks = 2,
+  .gpuIds =
+    {
+      0x43000,
+      0x23000,
+      0x26000,
+      0x3000,
+      0xc3000,
+      0xc6000,
+      0xa3000,
+      0x83000,
+    },
+  .nicIds = {},
+  .gpuNuma =
+    {
+      0,
+      1,
+      1,
+      1,
+      2,
+      2,
+      3,
+      3,
+    },
+  .nicNuma = {},
+  .connMatrix =
+    {
+      0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0,
+      0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0,
+    },
+  .gdrLevel = {},
   .pattern = "10302020",
   .ringBase = "1 7 6 4 5 2 0 3|2 5 3 0 4 6 7 1",
   .options = "",
 };
 
 static struct rcclRomeModel rome_model_38 = {
-  .nGpus = 8, .nCpus = 7, .nNics = 0, .nLinks = 2,
-  .gpuIds = { 0x43000, 0x23000, 0x26000, 0x3000, 0xc3000, 0xc6000, 0xa3000, 0x83000, },
-  .nicIds = { },
-  .gpuNuma = { 1, 2, 2, 3, 5, 5, 6, 7, },
-  .nicNuma = { },
-  .connMatrix = { 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, },
-  .gdrLevel = { },
+  .nGpus = 8,
+  .nCpus = 7,
+  .nNics = 0,
+  .nLinks = 2,
+  .gpuIds =
+    {
+      0x43000,
+      0x23000,
+      0x26000,
+      0x3000,
+      0xc3000,
+      0xc6000,
+      0xa3000,
+      0x83000,
+    },
+  .nicIds = {},
+  .gpuNuma =
+    {
+      1,
+      2,
+      2,
+      3,
+      5,
+      5,
+      6,
+      7,
+    },
+  .nicNuma = {},
+  .connMatrix =
+    {
+      0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0,
+      0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0,
+    },
+  .gdrLevel = {},
   .pattern = "10201000201010",
   .ringBase = "6 7 1 4 3 5 2 0|0 2 5 3 4 1 7 6",
   .options = "",
 };
 
 static struct rcclRomeModel rome_model_28 = {
-  .nGpus = 8, .nCpus = 4, .nNics = 0, .nLinks = 3,
-  .gpuIds = { 0x43000, 0x23000, 0x26000, 0x3000, 0xc3000, 0xc6000, 0xa3000, 0x83000, },
-  .nicIds = { },
-  .gpuNuma = { 0, 1, 1, 1, 2, 2, 3, 3, },
-  .nicNuma = { },
-  .connMatrix = { 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, },
-  .gdrLevel = { },
+  .nGpus = 8,
+  .nCpus = 4,
+  .nNics = 0,
+  .nLinks = 3,
+  .gpuIds =
+    {
+      0x43000,
+      0x23000,
+      0x26000,
+      0x3000,
+      0xc3000,
+      0xc6000,
+      0xa3000,
+      0x83000,
+    },
+  .nicIds = {},
+  .gpuNuma =
+    {
+      0,
+      1,
+      1,
+      1,
+      2,
+      2,
+      3,
+      3,
+    },
+  .nicNuma = {},
+  .connMatrix =
+    {
+      0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0,
+    },
+  .gdrLevel = {},
   .pattern = "10302020",
   .ringBase = "0 3 2 1 4 5 6 7|7 6 5 4 1 2 3 0|0 2 5 7 4 6 3 1|1 3 6 4 7 5 2 0",
   .options = "",
 };
 
 static struct rcclRomeModel rome_model_40 = {
-  .nGpus = 8, .nCpus = 4, .nNics = 1, .nLinks = 3,
-  .gpuIds = { 0x43000, 0x23000, 0x26000, 0x3000, 0xc3000, 0xc6000, 0xa3000, 0x83000, },
-  .nicIds = { 0xe1000, },
-  .gpuNuma = { 0, 1, 1, 1, 2, 2, 3, 3, },
-  .nicNuma = { 2, },
-  .connMatrix = { 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, },
-  .gdrLevel = { PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, },
+  .nGpus = 8,
+  .nCpus = 4,
+  .nNics = 1,
+  .nLinks = 3,
+  .gpuIds =
+    {
+      0x43000,
+      0x23000,
+      0x26000,
+      0x3000,
+      0xc3000,
+      0xc6000,
+      0xa3000,
+      0x83000,
+    },
+  .nicIds =
+    {
+      0xe1000,
+    },
+  .gpuNuma =
+    {
+      0,
+      1,
+      1,
+      1,
+      2,
+      2,
+      3,
+      3,
+    },
+  .nicNuma =
+    {
+      2,
+    },
+  .connMatrix =
+    {
+      0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0,
+      0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0,
+    },
+  .gdrLevel =
+    {
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_PHB,
+      PATH_PHB,
+      PATH_SYS,
+      PATH_SYS,
+    },
   .pattern = "10302120",
   .ringBase = "6 7 1 4 0 5 3 2|7 6 4 1 0 2 3 5",
   .options = "",
 };
 
 static struct rcclRomeModel rome_model_42 = {
-  .nGpus = 8, .nCpus = 7, .nNics = 1, .nLinks = 3,
-  .gpuIds = { 0x43000, 0x23000, 0x26000, 0x3000, 0xc3000, 0xc6000, 0xa3000, 0x83000, },
-  .nicIds = { 0xe1000, },
-  .gpuNuma = { 1, 2, 2, 3, 5, 5, 6, 7, },
-  .nicNuma = { 4, },
-  .connMatrix = { 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, },
-  .gdrLevel = { PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, },
+  .nGpus = 8,
+  .nCpus = 7,
+  .nNics = 1,
+  .nLinks = 3,
+  .gpuIds =
+    {
+      0x43000,
+      0x23000,
+      0x26000,
+      0x3000,
+      0xc3000,
+      0xc6000,
+      0xa3000,
+      0x83000,
+    },
+  .nicIds =
+    {
+      0xe1000,
+    },
+  .gpuNuma =
+    {
+      1,
+      2,
+      2,
+      3,
+      5,
+      5,
+      6,
+      7,
+    },
+  .nicNuma =
+    {
+      4,
+    },
+  .connMatrix =
+    {
+      0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0,
+      0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0,
+    },
+  .gdrLevel =
+    {
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+    },
   .pattern = "10201001201010",
   .ringBase = "7 4 6 1 3 0 2 5|6 4 7 1 3 2 5 0",
   .options = "",
 };
 
 static struct rcclRomeModel rome_model_44 = {
-  .nGpus = 8, .nCpus = 4, .nNics = 1, .nLinks = 3,
-  .gpuIds = { 0x63000, 0x43000, 0x27000, 0x3000, 0xe3000, 0xc3000, 0xa3000, 0x83000, },
-  .nicIds = { 0xc4000, },
-  .gpuNuma = { 0, 0, 1, 1, 2, 2, 3, 3, },
-  .nicNuma = { 2, },
-  .connMatrix = { 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, },
-  .gdrLevel = { PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, },
+  .nGpus = 8,
+  .nCpus = 4,
+  .nNics = 1,
+  .nLinks = 3,
+  .gpuIds =
+    {
+      0x63000,
+      0x43000,
+      0x27000,
+      0x3000,
+      0xe3000,
+      0xc3000,
+      0xa3000,
+      0x83000,
+    },
+  .nicIds =
+    {
+      0xc4000,
+    },
+  .gpuNuma =
+    {
+      0,
+      0,
+      1,
+      1,
+      2,
+      2,
+      3,
+      3,
+    },
+  .nicNuma =
+    {
+      2,
+    },
+  .connMatrix =
+    {
+      0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0,
+    },
+  .gdrLevel =
+    {
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_PHB,
+      PATH_PHB,
+      PATH_SYS,
+      PATH_SYS,
+    },
   .pattern = "20202120",
   .ringBase = "5 4 7 6 2 1 3 0|5 6 7 4 1 0 2 3",
   .options = "",
 };
 
 static struct rcclRomeModel rome_model_45 = {
-  .nGpus = 8, .nCpus = 7, .nNics = 0, .nLinks = 3,
-  .gpuIds = { 0x43000, 0x23000, 0x26000, 0x3000, 0xc3000, 0xc6000, 0xa3000, 0x83000, },
-  .nicIds = { },
-  .gpuNuma = { 1, 2, 2, 3, 5, 5, 6, 7, },
-  .nicNuma = { },
-  .connMatrix = { 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, },
-  .gdrLevel = { },
+  .nGpus = 8,
+  .nCpus = 7,
+  .nNics = 0,
+  .nLinks = 3,
+  .gpuIds =
+    {
+      0x43000,
+      0x23000,
+      0x26000,
+      0x3000,
+      0xc3000,
+      0xc6000,
+      0xa3000,
+      0x83000,
+    },
+  .nicIds = {},
+  .gpuNuma =
+    {
+      1,
+      2,
+      2,
+      3,
+      5,
+      5,
+      6,
+      7,
+    },
+  .nicNuma = {},
+  .connMatrix =
+    {
+      0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0,
+    },
+  .gdrLevel = {},
   .pattern = "10201000201010",
   .ringBase = "0 1 2 3 4 5 6 7|0 2 5 7 4 6 1 3|0 3 1 6 4 7 5 2|0 7 6 5 4 3 2 1",
   .options = "",
 };
 
 static struct rcclRomeModel rome_model_46 = {
-  .nGpus = 8, .nCpus = 7, .nNics = 1, .nLinks = 3,
-  .gpuIds = { 0x43000, 0x23000, 0x26000, 0x3000, 0xc3000, 0xc6000, 0xa3000, 0x83000, },
-  .nicIds = { 0xe1000, },
-  .gpuNuma = { 1, 2, 2, 3, 5, 5, 6, 7, },
-  .nicNuma = { 4, },
-  .connMatrix = { 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, },
-  .gdrLevel = { PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, },
+  .nGpus = 8,
+  .nCpus = 7,
+  .nNics = 1,
+  .nLinks = 3,
+  .gpuIds =
+    {
+      0x43000,
+      0x23000,
+      0x26000,
+      0x3000,
+      0xc3000,
+      0xc6000,
+      0xa3000,
+      0x83000,
+    },
+  .nicIds =
+    {
+      0xe1000,
+    },
+  .gpuNuma =
+    {
+      1,
+      2,
+      2,
+      3,
+      5,
+      5,
+      6,
+      7,
+    },
+  .nicNuma =
+    {
+      4,
+    },
+  .connMatrix =
+    {
+      0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0,
+    },
+  .gdrLevel =
+    {
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+    },
   .pattern = "10201001201010",
   .ringBase = "6 5 7 4 1 2 3 0|7 4 6 5 1 0 3 2",
   .options = "",
 };
 
 static struct rcclRomeModel rome_model_48 = {
-  .nGpus = 8, .nCpus = 4, .nNics = 0, .nLinks = 3,
-  .gpuIds = { 0x4a000, 0x50000, 0xa000, 0xf000, 0xcb000, 0xd1000, 0x8a000, 0x90000, },
-  .nicIds = { },
-  .gpuNuma = { 0, 0, 1, 1, 2, 2, 3, 3, },
-  .nicNuma = { },
-  .connMatrix = { 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, },
-  .gdrLevel = { },
+  .nGpus = 8,
+  .nCpus = 4,
+  .nNics = 0,
+  .nLinks = 3,
+  .gpuIds =
+    {
+      0x4a000,
+      0x50000,
+      0xa000,
+      0xf000,
+      0xcb000,
+      0xd1000,
+      0x8a000,
+      0x90000,
+    },
+  .nicIds = {},
+  .gpuNuma =
+    {
+      0,
+      0,
+      1,
+      1,
+      2,
+      2,
+      3,
+      3,
+    },
+  .nicNuma = {},
+  .connMatrix =
+    {
+      0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0,
+    },
+  .gdrLevel = {},
   .pattern = "20202020",
   .ringBase = "0 1 2 3 4 5 6 7|7 6 5 4 3 2 1 0|0 1 2 3 4 5 6 7|7 6 5 4 3 2 1 0",
   .options = "",
 };
 
 static struct rcclRomeModel rome_model_49 = {
-  .nGpus = 8, .nCpus = 4, .nNics = 4, .nLinks = 3,
-  .gpuIds = { 0x4a000, 0x50000, 0xa000, 0xf000, 0xcb000, 0xd1000, 0x8a000, 0x90000, },
-  .nicIds = { 0x45000, 0x13000, 0xc6000, 0x85000, },
-  .gpuNuma = { 0, 0, 1, 1, 2, 2, 3, 3, },
-  .nicNuma = { 0, 1, 2, 3, },
-  .connMatrix = { 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, },
-  .gdrLevel = { PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB, },
+  .nGpus = 8,
+  .nCpus = 4,
+  .nNics = 4,
+  .nLinks = 3,
+  .gpuIds =
+    {
+      0x4a000,
+      0x50000,
+      0xa000,
+      0xf000,
+      0xcb000,
+      0xd1000,
+      0x8a000,
+      0x90000,
+    },
+  .nicIds =
+    {
+      0x45000,
+      0x13000,
+      0xc6000,
+      0x85000,
+    },
+  .gpuNuma =
+    {
+      0,
+      0,
+      1,
+      1,
+      2,
+      2,
+      3,
+      3,
+    },
+  .nicNuma =
+    {
+      0,
+      1,
+      2,
+      3,
+    },
+  .connMatrix =
+    {
+      0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0,
+    },
+  .gdrLevel =
+    {
+      PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB,
+      PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB,
+      PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB,
+    },
   .pattern = "21212121",
   .ringBase = "N0 0 1 2 3 4 5 6 7 N3|N3 7 6 5 4 3 2 1 0 N0|N1 2 3 0 1 6 7 4 5 N2|N2 5 4 7 6 1 0 3 2 N1",
   .options = "",
 };
 
 static struct rcclRomeModel rome_model_52 = {
-  .nGpus = 8, .nCpus = 1, .nNics = 0, .nLinks = 3,
-  .gpuIds = { 0xc1000, 0xc5000, 0xc9000, 0xcd000, 0xd1000, 0xd5000, 0xd9000, 0xdd000, },
-  .nicIds = { },
-  .gpuNuma = { 0, 0, 0, 0, 0, 0, 0, 0, },
-  .nicNuma = { },
-  .connMatrix = { 0, 1, 1, 0, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 1, 1, 0, },
-  .gdrLevel = { },
+  .nGpus = 8,
+  .nCpus = 1,
+  .nNics = 0,
+  .nLinks = 3,
+  .gpuIds =
+    {
+      0xc1000,
+      0xc5000,
+      0xc9000,
+      0xcd000,
+      0xd1000,
+      0xd5000,
+      0xd9000,
+      0xdd000,
+    },
+  .nicIds = {},
+  .gpuNuma =
+    {
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+    },
+  .nicNuma = {},
+  .connMatrix =
+    {
+      0, 1, 1, 0, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1,
+      0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 1, 1, 0,
+    },
+  .gdrLevel = {},
   .pattern = "80",
   .ringBase = "0 1 3 2 4 5 7 6|6 7 5 4 2 3 1 0|0 1 5 4 6 7 3 2|2 3 7 6 4 5 1 0",
   .options = "",
 };
 
 static struct rcclRomeModel rome_model_53 = {
-  .nGpus = 8, .nCpus = 4, .nNics = 4, .nLinks = 3,
-  .gpuIds = { 0x4a000, 0x50000, 0xa000, 0xf000, 0xcb000, 0xd1000, 0x8a000, 0x90000, },
-  .nicIds = { 0x45000, 0x13000, 0xc6000, 0x85000, },
-  .gpuNuma = { 1, 1, 3, 3, 5, 5, 7, 7, },
-  .nicNuma = { 1, 3, 5, 7, },
-  .connMatrix = { 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, },
-  .gdrLevel = { PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB, },
+  .nGpus = 8,
+  .nCpus = 4,
+  .nNics = 4,
+  .nLinks = 3,
+  .gpuIds =
+    {
+      0x4a000,
+      0x50000,
+      0xa000,
+      0xf000,
+      0xcb000,
+      0xd1000,
+      0x8a000,
+      0x90000,
+    },
+  .nicIds =
+    {
+      0x45000,
+      0x13000,
+      0xc6000,
+      0x85000,
+    },
+  .gpuNuma =
+    {
+      1,
+      1,
+      3,
+      3,
+      5,
+      5,
+      7,
+      7,
+    },
+  .nicNuma =
+    {
+      1,
+      3,
+      5,
+      7,
+    },
+  .connMatrix =
+    {
+      0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0,
+    },
+  .gdrLevel =
+    {
+      PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB,
+      PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB,
+      PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB,
+    },
   .pattern = "21212121",
   .ringBase = "N0 0 1 2 3 4 5 6 7 N3|N3 7 6 5 4 3 2 1 0 N0|N1 2 3 0 1 6 7 4 5 N2|N2 5 4 7 6 1 0 3 2 N1",
   .options = "",
 };
 
 static struct rcclRomeModel rome_model_43 = {
-  .nGpus = 8, .nCpus = 4, .nNics = 0, .nLinks = 3,
-  .gpuIds = { 0x63000, 0x43000, 0x27000, 0x3000, 0xe3000, 0xc3000, 0xa3000, 0x83000, },
-  .nicIds = { },
-  .gpuNuma = { 0, 0, 1, 1, 2, 2, 3, 3, },
-  .nicNuma = { },
-  .connMatrix = { 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, },
-  .gdrLevel = { },
+  .nGpus = 8,
+  .nCpus = 4,
+  .nNics = 0,
+  .nLinks = 3,
+  .gpuIds =
+    {
+      0x63000,
+      0x43000,
+      0x27000,
+      0x3000,
+      0xe3000,
+      0xc3000,
+      0xa3000,
+      0x83000,
+    },
+  .nicIds = {},
+  .gpuNuma =
+    {
+      0,
+      0,
+      1,
+      1,
+      2,
+      2,
+      3,
+      3,
+    },
+  .nicNuma = {},
+  .connMatrix =
+    {
+      0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0,
+    },
+  .gdrLevel = {},
   .pattern = "20202020",
-  .ringBase = "0 1 2 3 4 5 6 7|0 2 5 7 4 6 1 3|0 3 1 6 4 7 5 2|0 7 6 5 4 3 2 1|0 1 2 3 4 5 6 7|0 2 5 7 4 6 1 3|0 3 1 6 4 7 5 2|0 7 6 5 4 3 2 1|0 1 2 3 4 5 6 7|0 2 5 7 4 6 1 3|0 3 1 6 4 7 5 2|0 7 6 5 4 3 2 1",
+  .ringBase = "0 1 2 3 4 5 6 7|0 2 5 7 4 6 1 3|0 3 1 6 4 7 5 2|0 7 6 5 4 3 2 1|0 1 2 3 4 5 6 7|0 2 5 7 4 6 1 3|0 3 1 6 "
+              "4 7 5 2|0 7 6 5 4 3 2 1|0 1 2 3 4 5 6 7|0 2 5 7 4 6 1 3|0 3 1 6 4 7 5 2|0 7 6 5 4 3 2 1",
   .options = "treeDefined=1",
-  .treeBase = "(2(5(6(7(4))))(3(0(1))))|(2(5(7(6(4))))(0(1(3))))|(2(5(7(4(6))))(1(3(0))))|(6(1(0(2(3))))(7(4(5))))|(6(1(2(0(3))))(4(5(7))))|(6(1(0(3(2))))(5(7(4))))|(1(6(7(5(4))))(2(3(0))))|(1(6(4(7(5))))(3(2(0))))|(1(6(5(4(7))))(3(0(2))))|(5(2(3(1(0))))(4(6(7))))|(5(2(0(3(1))))(6(4(7))))|(5(2(1(0(3))))(4(7(6))))",
+  .treeBase = "(2(5(6(7(4))))(3(0(1))))|(2(5(7(6(4))))(0(1(3))))|(2(5(7(4(6))))(1(3(0))))|(6(1(0(2(3))))(7(4(5))))|(6("
+              "1(2(0(3))))(4(5(7))))|(6(1(0(3(2))))(5(7(4))))|(1(6(7(5(4))))(2(3(0))))|(1(6(4(7(5))))(3(2(0))))|(1(6(5("
+              "4(7))))(3(0(2))))|(5(2(3(1(0))))(4(6(7))))|(5(2(0(3(1))))(6(4(7))))|(5(2(1(0(3))))(4(7(6))))",
 };
 
 static struct rcclRomeModel rome_model_55 = {
-  .nGpus = 8, .nCpus = 4, .nNics = 0, .nLinks = 3,
-  .gpuIds = { 0x100000, 0x200000, 0x300000, 0x400000, 0x500000, 0x600000, 0x700000, 0x800000, },
-  .nicIds = { },
-  .gpuNuma = { 0, 0, 1, 1, 2, 2, 3, 3, },
-  .nicNuma = { },
-  .connMatrix = { 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, },
-  .gdrLevel = { },
+  .nGpus = 8,
+  .nCpus = 4,
+  .nNics = 0,
+  .nLinks = 3,
+  .gpuIds =
+    {
+      0x100000,
+      0x200000,
+      0x300000,
+      0x400000,
+      0x500000,
+      0x600000,
+      0x700000,
+      0x800000,
+    },
+  .nicIds = {},
+  .gpuNuma =
+    {
+      0,
+      0,
+      1,
+      1,
+      2,
+      2,
+      3,
+      3,
+    },
+  .nicNuma = {},
+  .connMatrix =
+    {
+      0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0,
+    },
+  .gdrLevel = {},
   .pattern = "20202020",
   .ringBase = "0 1 2 3 4 5 6 7|7 6 5 4 3 2 1 0|2 3 0 1 6 7 4 5|5 4 7 6 1 0 3 2",
   .options = "",
 };
 
 static struct rcclRomeModel rome_model_56 = {
-  .nGpus = 16, .nCpus = 4, .nNics = 0, .nLinks = 4,
-  .gpuIds = { 0x4e000, 0x51000, 0x56000, 0x59000, 0xe000, 0x11000, 0x16000, 0x19000, 0xcf000, 0xd2000, 0xd7000, 0xda000, 0x8f000, 0x92000, 0x97000, 0x9a000, },
-  .nicIds = { },
-  .gpuNuma = { 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, },
-  .nicNuma = { },
-  .connMatrix = { 0, 4, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 4, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 2, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 4, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 1, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 4, 0, },
-  .gdrLevel = { },
+  .nGpus = 16,
+  .nCpus = 4,
+  .nNics = 0,
+  .nLinks = 4,
+  .gpuIds =
+    {
+      0x4e000,
+      0x51000,
+      0x56000,
+      0x59000,
+      0xe000,
+      0x11000,
+      0x16000,
+      0x19000,
+      0xcf000,
+      0xd2000,
+      0xd7000,
+      0xda000,
+      0x8f000,
+      0x92000,
+      0x97000,
+      0x9a000,
+    },
+  .nicIds = {},
+  .gpuNuma =
+    {
+      0,
+      0,
+      0,
+      0,
+      1,
+      1,
+      1,
+      1,
+      2,
+      2,
+      2,
+      2,
+      3,
+      3,
+      3,
+      3,
+    },
+  .nicNuma = {},
+  .connMatrix =
+    {
+      0, 4, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 4, 0,
+      0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 4, 0, 0, 0, 0,
+      0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 1, 1,
+      0, 0, 0, 0, 2, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 4, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 4, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      1, 4, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 1, 0, 0, 4, 0,
+      0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 4, 0,
+    },
+  .gdrLevel = {},
   .pattern = "40404040",
-  .ringBase = "0 1 3 2 6 7 15 14 10 11 9 8 12 13 5 4|0 1 2 3 7 6 13 12 8 9 10 11 15 14 5 4|0 2 3 7 6 14 15 11 10 8 9 13 12 4 5 1|4 5 13 12 8 9 11 10 14 15 7 6 2 3 1 0|4 5 14 15 11 10 9 8 12 13 6 7 3 2 1 0|1 5 4 12 13 9 8 10 11 15 14 6 7 3 2 0",
+  .ringBase = "0 1 3 2 6 7 15 14 10 11 9 8 12 13 5 4|0 1 2 3 7 6 13 12 8 9 10 11 15 14 5 4|0 2 3 7 6 14 15 11 10 8 9 "
+              "13 12 4 5 1|4 5 13 12 8 9 11 10 14 15 7 6 2 3 1 0|4 5 14 15 11 10 9 8 12 13 6 7 3 2 1 0|1 5 4 12 13 9 8 "
+              "10 11 15 14 6 7 3 2 0",
   .options = "pivotA2AEnabled=1,pivotA2ANumBiRings=3,tuning=1,treeDefined=1",
-  .treeBase= "(0(1(3(2(6(7(15(14(10))))))))(4(5(13(12(8(9(11))))))))|(2(3(7(6(13(12(8(9(10))))))))(1(0(4(5(14(15(11))))))))|(14(15(11(10(8(9(13(12(4))))))))(6(7(3(2(0(1(5))))))))|(10(11(9(8(12(13(5(4(0))))))))(14(15(7(6(2(3(1))))))))|(10(11(15(14(5(4(0(1(2))))))))(9(8(12(13(6(7(3))))))))|(4(5(1(0(2(3(7(6(14))))))))(12(13(9(8(10(11(15))))))))|(6(7(15(14(10(11(9(8(12))))))))(2(3(1(0(4(5(13))))))))|(13(12(8(9(10(11(15(14(5))))))))(6(7(3(2(1(0(4))))))))|(8(9(13(12(4(5(1(0(2))))))))(10(11(15(14(6(7(3))))))))|(12(13(5(4(0(1(3(2(6))))))))(8(9(11(10(14(15(7))))))))|(5(4(0(1(2(3(7(6(13))))))))(14(15(11(10(9(8(12))))))))|(2(3(7(6(14(15(11(10(8))))))))(0(1(5(4(12(13(9))))))))",
+  .treeBase =
+    "(0(1(3(2(6(7(15(14(10))))))))(4(5(13(12(8(9(11))))))))|(2(3(7(6(13(12(8(9(10))))))))(1(0(4(5(14(15(11))))))))|(14("
+    "15(11(10(8(9(13(12(4))))))))(6(7(3(2(0(1(5))))))))|(10(11(9(8(12(13(5(4(0))))))))(14(15(7(6(2(3(1))))))))|(10(11("
+    "15(14(5(4(0(1(2))))))))(9(8(12(13(6(7(3))))))))|(4(5(1(0(2(3(7(6(14))))))))(12(13(9(8(10(11(15))))))))|(6(7(15(14("
+    "10(11(9(8(12))))))))(2(3(1(0(4(5(13))))))))|(13(12(8(9(10(11(15(14(5))))))))(6(7(3(2(1(0(4))))))))|(8(9(13(12(4(5("
+    "1(0(2))))))))(10(11(15(14(6(7(3))))))))|(12(13(5(4(0(1(3(2(6))))))))(8(9(11(10(14(15(7))))))))|(5(4(0(1(2(3(7(6("
+    "13))))))))(14(15(11(10(9(8(12))))))))|(2(3(7(6(14(15(11(10(8))))))))(0(1(5(4(12(13(9))))))))",
 };
 
 static struct rcclRomeModel rome_model_58 = {
-  .nGpus = 8, .nCpus = 3, .nNics = 0, .nLinks = 3,
-  .gpuIds = { 0xc1000, 0xc6000, 0xc9000, 0xce000, 0xd1000, 0xd6000, 0xd9000, 0xde000, },
-  .nicIds = { },
-  .gpuNuma = { 3, 3, 1, 1, 0, 0, 0, 0, },
-  .nicNuma = { },
-  .connMatrix = { 0, 1, 1, 0, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 1, 1, 0, },
-  .gdrLevel = { },
+  .nGpus = 8,
+  .nCpus = 3,
+  .nNics = 0,
+  .nLinks = 3,
+  .gpuIds =
+    {
+      0xc1000,
+      0xc6000,
+      0xc9000,
+      0xce000,
+      0xd1000,
+      0xd6000,
+      0xd9000,
+      0xde000,
+    },
+  .nicIds = {},
+  .gpuNuma =
+    {
+      3,
+      3,
+      1,
+      1,
+      0,
+      0,
+      0,
+      0,
+    },
+  .nicNuma = {},
+  .connMatrix =
+    {
+      0, 1, 1, 0, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1,
+      0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 1, 1, 0,
+    },
+  .gdrLevel = {},
   .pattern = "402020",
   .ringBase = "0 1 3 2 4 5 7 6|6 7 5 4 2 3 1 0|0 1 5 4 6 7 3 2|2 3 7 6 4 5 1 0",
   .options = "",
 };
 
 static struct rcclRomeModel rome_model_59 = {
-  .nGpus = 16, .nCpus = 4, .nNics = 8, .nLinks = 4,
-  .gpuIds = { 0x4e000, 0x51000, 0x56000, 0x59000, 0xe000, 0x11000, 0x16000, 0x19000, 0xcf000, 0xd2000, 0xd7000, 0xda000, 0x8f000, 0x92000, 0x97000, 0x9a000, },
-  .nicIds = { 0x4b000, 0x5a000, 0xb000, 0x1a000, 0xcc000, 0xdb000, 0x8c000, 0x9b000, },
-  .gpuNuma = { 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, },
-  .nicNuma = { 0, 0, 1, 1, 2, 2, 3, 3, },
-  .connMatrix = { 0, 4, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 4, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 2, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 4, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 1, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 4, 0, },
-  .gdrLevel = { PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, },
+  .nGpus = 16,
+  .nCpus = 4,
+  .nNics = 8,
+  .nLinks = 4,
+  .gpuIds =
+    {
+      0x4e000,
+      0x51000,
+      0x56000,
+      0x59000,
+      0xe000,
+      0x11000,
+      0x16000,
+      0x19000,
+      0xcf000,
+      0xd2000,
+      0xd7000,
+      0xda000,
+      0x8f000,
+      0x92000,
+      0x97000,
+      0x9a000,
+    },
+  .nicIds =
+    {
+      0x4b000,
+      0x5a000,
+      0xb000,
+      0x1a000,
+      0xcc000,
+      0xdb000,
+      0x8c000,
+      0x9b000,
+    },
+  .gpuNuma =
+    {
+      0,
+      0,
+      0,
+      0,
+      1,
+      1,
+      1,
+      1,
+      2,
+      2,
+      2,
+      2,
+      3,
+      3,
+      3,
+      3,
+    },
+  .nicNuma =
+    {
+      0,
+      0,
+      1,
+      1,
+      2,
+      2,
+      3,
+      3,
+    },
+  .connMatrix =
+    {
+      0, 4, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 4, 0,
+      0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 4, 0, 0, 0, 0,
+      0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 1, 1,
+      0, 0, 0, 0, 2, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 4, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 4, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      1, 4, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 1, 0, 0, 4, 0,
+      0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 4, 0,
+    },
+  .gdrLevel =
+    {
+      PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS,
+      PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS,
+      PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS,
+      PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS,
+      PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB, PATH_PXB,
+      PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS,
+      PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_SYS,
+      PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS,
+      PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS,
+      PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB,
+      PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS,
+      PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB,
+    },
   .pattern = "42424242",
-  .ringBase = "N4 9 8 12 13 5 4 0 1 3 2 6 7 15 14 10 11 N5|N1 3 2 6 7 15 14 10 11 9 8 12 13 5 4 0 1 N0|N3 7 6 2 3 1 0 4 5 13 12 8 9 11 10 14 15 N7|N7 15 14 10 11 9 8 12 13 5 4 0 1 3 2 6 7 N3|N5 11 10 14 15 7 6 2 3 1 0 4 5 13 12 8 9 N4|N0 1 0 4 5 13 12 8 9 11 10 14 15 7 6 2 3 N1|N3 6 7 3 2 1 0 4 5 14 15 11 10 9 8 12 13 N6|N7 14 15 11 10 9 8 12 13 6 7 3 2 1 0 4 5 N2|N2 5 4 0 1 2 3 7 6 13 12 8 9 10 11 15 14 N7|N6 13 12 8 9 10 11 15 14 5 4 0 1 2 3 7 6 N3|N4 8 9 13 12 4 5 1 0 2 3 7 6 14 15 11 10 N5|N5 10 11 15 14 6 7 3 2 0 1 5 4 12 13 9 8 N4|N6 12 13 9 8 10 11 15 14 6 7 3 2 0 1 5 4 N2|N2 4 5 1 0 2 3 7 6 14 15 11 10 8 9 13 12 N6|N1 2 3 7 6 14 15 11 10 8 9 13 12 4 5 1 0 N0|N0 0 1 5 4 12 13 9 8 10 11 15 14 6 7 3 2 N1|N5 10 11 9 8 12 13 5 4 0 1 3 2 6 7 15 14 N7|N3 6 7 15 14 10 11 9 8 12 13 5 4 0 1 3 2 N1|N1 2 3 1 0 4 5 13 12 8 9 11 10 14 15 7 6 N3|N7 14 15 7 6 2 3 1 0 4 5 13 12 8 9 11 10 N5|N0 0 1 2 3 7 6 13 12 8 9 10 11 15 14 5 4 N2|N4 8 9 10 11 15 14 5 4 0 1 2 3 7 6 13 12 N6|N3 7 6 13 12 8 9 10 11 15 14 5 4 0 1 2 3 N1|N1 3 2 1 0 4 5 14 15 11 10 9 8 12 13 6 7 N3|N6 12 13 6 7 3 2 1 0 4 5 14 15 11 10 9 8 N4|N2 4 5 14 15 11 10 9 8 12 13 6 7 3 2 1 0 N0|N0 1 0 2 3 7 6 14 15 11 10 8 9 13 12 4 5 N2|N6 13 12 4 5 1 0 2 3 7 6 14 15 11 10 8 9 N4|N5 11 10 8 9 13 12 4 5 1 0 2 3 7 6 14 15 N7|N2 5 4 12 13 9 8 10 11 15 14 6 7 3 2 0 1 N0|N7 15 14 6 7 3 2 0 1 5 4 12 13 9 8 10 11 N5|N4 9 8 10 11 15 14 6 7 3 2 0 1 5 4 12 13 N6",
+  .ringBase =
+    "N4 9 8 12 13 5 4 0 1 3 2 6 7 15 14 10 11 N5|N1 3 2 6 7 15 14 10 11 9 8 12 13 5 4 0 1 N0|N3 7 6 2 3 1 0 4 5 13 12 "
+    "8 9 11 10 14 15 N7|N7 15 14 10 11 9 8 12 13 5 4 0 1 3 2 6 7 N3|N5 11 10 14 15 7 6 2 3 1 0 4 5 13 12 8 9 N4|N0 1 0 "
+    "4 5 13 12 8 9 11 10 14 15 7 6 2 3 N1|N3 6 7 3 2 1 0 4 5 14 15 11 10 9 8 12 13 N6|N7 14 15 11 10 9 8 12 13 6 7 3 2 "
+    "1 0 4 5 N2|N2 5 4 0 1 2 3 7 6 13 12 8 9 10 11 15 14 N7|N6 13 12 8 9 10 11 15 14 5 4 0 1 2 3 7 6 N3|N4 8 9 13 12 4 "
+    "5 1 0 2 3 7 6 14 15 11 10 N5|N5 10 11 15 14 6 7 3 2 0 1 5 4 12 13 9 8 N4|N6 12 13 9 8 10 11 15 14 6 7 3 2 0 1 5 4 "
+    "N2|N2 4 5 1 0 2 3 7 6 14 15 11 10 8 9 13 12 N6|N1 2 3 7 6 14 15 11 10 8 9 13 12 4 5 1 0 N0|N0 0 1 5 4 12 13 9 8 "
+    "10 11 15 14 6 7 3 2 N1|N5 10 11 9 8 12 13 5 4 0 1 3 2 6 7 15 14 N7|N3 6 7 15 14 10 11 9 8 12 13 5 4 0 1 3 2 N1|N1 "
+    "2 3 1 0 4 5 13 12 8 9 11 10 14 15 7 6 N3|N7 14 15 7 6 2 3 1 0 4 5 13 12 8 9 11 10 N5|N0 0 1 2 3 7 6 13 12 8 9 10 "
+    "11 15 14 5 4 N2|N4 8 9 10 11 15 14 5 4 0 1 2 3 7 6 13 12 N6|N3 7 6 13 12 8 9 10 11 15 14 5 4 0 1 2 3 N1|N1 3 2 1 "
+    "0 4 5 14 15 11 10 9 8 12 13 6 7 N3|N6 12 13 6 7 3 2 1 0 4 5 14 15 11 10 9 8 N4|N2 4 5 14 15 11 10 9 8 12 13 6 7 3 "
+    "2 1 0 N0|N0 1 0 2 3 7 6 14 15 11 10 8 9 13 12 4 5 N2|N6 13 12 4 5 1 0 2 3 7 6 14 15 11 10 8 9 N4|N5 11 10 8 9 13 "
+    "12 4 5 1 0 2 3 7 6 14 15 N7|N2 5 4 12 13 9 8 10 11 15 14 6 7 3 2 0 1 N0|N7 15 14 6 7 3 2 0 1 5 4 12 13 9 8 10 11 "
+    "N5|N4 9 8 10 11 15 14 6 7 3 2 0 1 5 4 12 13 N6",
   .options = "tuning=4,ll128Enabled=1,baseBw=161.4",
 };
 
 static struct rcclRomeModel rome_model_62 = {
-  .nGpus = 8, .nCpus = 4, .nNics = 0, .nLinks = 3,
-  .gpuIds = { 0xc1000, 0xc6000, 0xc9000, 0xce000, 0xd1000, 0xd6000, 0xd9000, 0xde000, },
-  .nicIds = { },
-  .gpuNuma = { 3, 3, 1, 1, 0, 0, 2, 2, },
-  .nicNuma = { },
-  .connMatrix = { 0, 1, 1, 0, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 1, 1, 0, },
-  .gdrLevel = { },
+  .nGpus = 8,
+  .nCpus = 4,
+  .nNics = 0,
+  .nLinks = 3,
+  .gpuIds =
+    {
+      0xc1000,
+      0xc6000,
+      0xc9000,
+      0xce000,
+      0xd1000,
+      0xd6000,
+      0xd9000,
+      0xde000,
+    },
+  .nicIds = {},
+  .gpuNuma =
+    {
+      3,
+      3,
+      1,
+      1,
+      0,
+      0,
+      2,
+      2,
+    },
+  .nicNuma = {},
+  .connMatrix =
+    {
+      0, 1, 1, 0, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1,
+      0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 1, 1, 0,
+    },
+  .gdrLevel = {},
   .pattern = "20202020",
   .ringBase = "0 1 3 2 4 5 7 6|6 7 5 4 2 3 1 0|0 1 5 4 6 7 3 2|2 3 7 6 4 5 1 0",
   .options = "",
 };
 
 static struct rcclRomeModel rome_model_63 = {
-  .nGpus = 8, .nCpus = 4, .nNics = 4, .nLinks = 3,
-  .gpuIds = { 0xc1000, 0xc6000, 0xc9000, 0xce000, 0xd1000, 0xd6000, 0xd9000, 0xde000, },
-  .nicIds = { 0xc5000, 0xcd000, 0xd5000, 0xdd000, },
-  .gpuNuma = { 3, 3, 1, 1, 0, 0, 2, 2, },
-  .nicNuma = { 3, 1, 0, 2, },
-  .connMatrix = { 0, 1, 1, 0, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 1, 1, 0, },
-  .gdrLevel = { PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, },
+  .nGpus = 8,
+  .nCpus = 4,
+  .nNics = 4,
+  .nLinks = 3,
+  .gpuIds =
+    {
+      0xc1000,
+      0xc6000,
+      0xc9000,
+      0xce000,
+      0xd1000,
+      0xd6000,
+      0xd9000,
+      0xde000,
+    },
+  .nicIds =
+    {
+      0xc5000,
+      0xcd000,
+      0xd5000,
+      0xdd000,
+    },
+  .gpuNuma =
+    {
+      3,
+      3,
+      1,
+      1,
+      0,
+      0,
+      2,
+      2,
+    },
+  .nicNuma =
+    {
+      3,
+      1,
+      0,
+      2,
+    },
+  .connMatrix =
+    {
+      0, 1, 1, 0, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1,
+      0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 1, 1, 0,
+    },
+  .gdrLevel =
+    {
+      PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB,
+      PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB,
+      PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB,
+    },
   .pattern = "21212121",
-  .ringBase = "N0 0 1 5 4 6 7 3 2 N1|N1 2 3 7 6 4 5 1 0 N0|N3 7 6 0 1 3 2 4 5 N2|N2 5 4 2 3 1 0 6 7 N3|N0 0 1 5 4 6 7 3 2 N1|N1 2 3 7 6 4 5 1 0 N0|N3 7 6 0 1 3 2 4 5 N2|N2 5 4 2 3 1 0 6 7 N3",
+  .ringBase = "N0 0 1 5 4 6 7 3 2 N1|N1 2 3 7 6 4 5 1 0 N0|N3 7 6 0 1 3 2 4 5 N2|N2 5 4 2 3 1 0 6 7 N3|N0 0 1 5 4 6 7 "
+              "3 2 N1|N1 2 3 7 6 4 5 1 0 N0|N3 7 6 0 1 3 2 4 5 N2|N2 5 4 2 3 1 0 6 7 N3",
   .options = "tuning=3",
 };
 
 static struct rcclRomeModel rome_model_65 = {
-  .nGpus = 16, .nCpus = 4, .nNics = 8, .nLinks = 4,
-  .gpuIds = { 0x4e000, 0x51000, 0x56000, 0x59000, 0xe000, 0x11000, 0x16000, 0x19000, 0xcf000, 0xd2000, 0xd7000, 0xda000, 0x8f000, 0x92000, 0x97000, 0x9a000, },
-  .nicIds = { 0x4b000, 0x5a000, 0xb000, 0x1a000, 0xcc000, 0xdb000, 0x8c000, 0x9b000, },
-  .gpuNuma = { 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, },
-  .nicNuma = { 0, 0, 1, 1, 2, 2, 3, 3, },
-  .connMatrix = { 0, 4, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 4, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 2, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 4, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 1, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 4, 0, },
-  .gdrLevel = { PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, },
+  .nGpus = 16,
+  .nCpus = 4,
+  .nNics = 8,
+  .nLinks = 4,
+  .gpuIds =
+    {
+      0x4e000,
+      0x51000,
+      0x56000,
+      0x59000,
+      0xe000,
+      0x11000,
+      0x16000,
+      0x19000,
+      0xcf000,
+      0xd2000,
+      0xd7000,
+      0xda000,
+      0x8f000,
+      0x92000,
+      0x97000,
+      0x9a000,
+    },
+  .nicIds =
+    {
+      0x4b000,
+      0x5a000,
+      0xb000,
+      0x1a000,
+      0xcc000,
+      0xdb000,
+      0x8c000,
+      0x9b000,
+    },
+  .gpuNuma =
+    {
+      0,
+      0,
+      0,
+      0,
+      1,
+      1,
+      1,
+      1,
+      2,
+      2,
+      2,
+      2,
+      3,
+      3,
+      3,
+      3,
+    },
+  .nicNuma =
+    {
+      0,
+      0,
+      1,
+      1,
+      2,
+      2,
+      3,
+      3,
+    },
+  .connMatrix =
+    {
+      0, 4, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 4, 0,
+      0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 4, 0, 0, 0, 0,
+      0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 1, 1,
+      0, 0, 0, 0, 2, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 4, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 4, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      1, 4, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 1, 0, 0, 4, 0,
+      0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 4, 0,
+    },
+  .gdrLevel =
+    {
+      PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS,
+      PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS,
+      PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS,
+      PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS,
+      PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PHB,
+      PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS,
+      PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_SYS,
+      PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS,
+      PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS,
+      PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB,
+      PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS,
+      PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB,
+    },
   .pattern = "42424242",
-  .ringBase = "N4 9 8 12 13 5 4 0 1 3 2 6 7 15 14 10 11 N5|N1 3 2 6 7 15 14 10 11 9 8 12 13 5 4 0 1 N0|N3 7 6 2 3 1 0 4 5 13 12 8 9 11 10 14 15 N7|N7 15 14 10 11 9 8 12 13 5 4 0 1 3 2 6 7 N3|N5 11 10 14 15 7 6 2 3 1 0 4 5 13 12 8 9 N4|N0 1 0 4 5 13 12 8 9 11 10 14 15 7 6 2 3 N1|N3 6 7 3 2 1 0 4 5 14 15 11 10 9 8 12 13 N6|N7 14 15 11 10 9 8 12 13 6 7 3 2 1 0 4 5 N2|N2 5 4 0 1 2 3 7 6 13 12 8 9 10 11 15 14 N7|N6 13 12 8 9 10 11 15 14 5 4 0 1 2 3 7 6 N3|N4 8 9 13 12 4 5 1 0 2 3 7 6 14 15 11 10 N5|N5 10 11 15 14 6 7 3 2 0 1 5 4 12 13 9 8 N4|N6 12 13 9 8 10 11 15 14 6 7 3 2 0 1 5 4 N2|N2 4 5 1 0 2 3 7 6 14 15 11 10 8 9 13 12 N6|N1 2 3 7 6 14 15 11 10 8 9 13 12 4 5 1 0 N0|N0 0 1 5 4 12 13 9 8 10 11 15 14 6 7 3 2 N1|N5 10 11 9 8 12 13 5 4 0 1 3 2 6 7 15 14 N7|N3 6 7 15 14 10 11 9 8 12 13 5 4 0 1 3 2 N1|N1 2 3 1 0 4 5 13 12 8 9 11 10 14 15 7 6 N3|N7 14 15 7 6 2 3 1 0 4 5 13 12 8 9 11 10 N5|N0 0 1 2 3 7 6 13 12 8 9 10 11 15 14 5 4 N2|N4 8 9 10 11 15 14 5 4 0 1 2 3 7 6 13 12 N6|N3 7 6 13 12 8 9 10 11 15 14 5 4 0 1 2 3 N1|N1 3 2 1 0 4 5 14 15 11 10 9 8 12 13 6 7 N3|N6 12 13 6 7 3 2 1 0 4 5 14 15 11 10 9 8 N4|N2 4 5 14 15 11 10 9 8 12 13 6 7 3 2 1 0 N0|N0 1 0 2 3 7 6 14 15 11 10 8 9 13 12 4 5 N2|N6 13 12 4 5 1 0 2 3 7 6 14 15 11 10 8 9 N4|N5 11 10 8 9 13 12 4 5 1 0 2 3 7 6 14 15 N7|N2 5 4 12 13 9 8 10 11 15 14 6 7 3 2 0 1 N0|N7 15 14 6 7 3 2 0 1 5 4 12 13 9 8 10 11 N5|N4 9 8 10 11 15 14 6 7 3 2 0 1 5 4 12 13 N6",
+  .ringBase =
+    "N4 9 8 12 13 5 4 0 1 3 2 6 7 15 14 10 11 N5|N1 3 2 6 7 15 14 10 11 9 8 12 13 5 4 0 1 N0|N3 7 6 2 3 1 0 4 5 13 12 "
+    "8 9 11 10 14 15 N7|N7 15 14 10 11 9 8 12 13 5 4 0 1 3 2 6 7 N3|N5 11 10 14 15 7 6 2 3 1 0 4 5 13 12 8 9 N4|N0 1 0 "
+    "4 5 13 12 8 9 11 10 14 15 7 6 2 3 N1|N3 6 7 3 2 1 0 4 5 14 15 11 10 9 8 12 13 N6|N7 14 15 11 10 9 8 12 13 6 7 3 2 "
+    "1 0 4 5 N2|N2 5 4 0 1 2 3 7 6 13 12 8 9 10 11 15 14 N7|N6 13 12 8 9 10 11 15 14 5 4 0 1 2 3 7 6 N3|N4 8 9 13 12 4 "
+    "5 1 0 2 3 7 6 14 15 11 10 N5|N5 10 11 15 14 6 7 3 2 0 1 5 4 12 13 9 8 N4|N6 12 13 9 8 10 11 15 14 6 7 3 2 0 1 5 4 "
+    "N2|N2 4 5 1 0 2 3 7 6 14 15 11 10 8 9 13 12 N6|N1 2 3 7 6 14 15 11 10 8 9 13 12 4 5 1 0 N0|N0 0 1 5 4 12 13 9 8 "
+    "10 11 15 14 6 7 3 2 N1|N5 10 11 9 8 12 13 5 4 0 1 3 2 6 7 15 14 N7|N3 6 7 15 14 10 11 9 8 12 13 5 4 0 1 3 2 N1|N1 "
+    "2 3 1 0 4 5 13 12 8 9 11 10 14 15 7 6 N3|N7 14 15 7 6 2 3 1 0 4 5 13 12 8 9 11 10 N5|N0 0 1 2 3 7 6 13 12 8 9 10 "
+    "11 15 14 5 4 N2|N4 8 9 10 11 15 14 5 4 0 1 2 3 7 6 13 12 N6|N3 7 6 13 12 8 9 10 11 15 14 5 4 0 1 2 3 N1|N1 3 2 1 "
+    "0 4 5 14 15 11 10 9 8 12 13 6 7 N3|N6 12 13 6 7 3 2 1 0 4 5 14 15 11 10 9 8 N4|N2 4 5 14 15 11 10 9 8 12 13 6 7 3 "
+    "2 1 0 N0|N0 1 0 2 3 7 6 14 15 11 10 8 9 13 12 4 5 N2|N6 13 12 4 5 1 0 2 3 7 6 14 15 11 10 8 9 N4|N5 11 10 8 9 13 "
+    "12 4 5 1 0 2 3 7 6 14 15 N7|N2 5 4 12 13 9 8 10 11 15 14 6 7 3 2 0 1 N0|N7 15 14 6 7 3 2 0 1 5 4 12 13 9 8 10 11 "
+    "N5|N4 9 8 10 11 15 14 6 7 3 2 0 1 5 4 12 13 N6",
   .options = "tuning=4,ll128Enabled=1,baseBw=161.4",
 };
 
 static struct rcclRomeModel rome_model_66 = {
-  .nGpus = 8, .nCpus = 2, .nNics = 0, .nLinks = 3,
-  .gpuIds = { 0x29000, 0x2c000, 0x2f000, 0x32000, 0xad000, 0xb0000, 0xb3000, 0xb6000, },
-  .nicIds = { },
-  .gpuNuma = { 1, 1, 1, 1, 3, 3, 3, 3, },
-  .nicNuma = { },
-  .connMatrix = { 0, 4, 0, 0, 2, 0, 1, 0, 4, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 4, 1, 0, 2, 0, 0, 1, 4, 0, 0, 1, 0, 0, 2, 0, 1, 0, 0, 4, 0, 0, 0, 0, 0, 1, 4, 0, 0, 1, 1, 0, 2, 0, 0, 0, 0, 4, 0, 1, 0, 0, 0, 1, 4, 0, },
-  .gdrLevel = { },
+  .nGpus = 8,
+  .nCpus = 2,
+  .nNics = 0,
+  .nLinks = 3,
+  .gpuIds =
+    {
+      0x29000,
+      0x2c000,
+      0x2f000,
+      0x32000,
+      0xad000,
+      0xb0000,
+      0xb3000,
+      0xb6000,
+    },
+  .nicIds = {},
+  .gpuNuma =
+    {
+      1,
+      1,
+      1,
+      1,
+      3,
+      3,
+      3,
+      3,
+    },
+  .nicNuma = {},
+  .connMatrix =
+    {
+      0, 4, 0, 0, 2, 0, 1, 0, 4, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 4, 1, 0, 2, 0, 0, 1, 4, 0, 0, 1, 0, 0,
+      2, 0, 1, 0, 0, 4, 0, 0, 0, 0, 0, 1, 4, 0, 0, 1, 1, 0, 2, 0, 0, 0, 0, 4, 0, 1, 0, 0, 0, 1, 4, 0,
+    },
+  .gdrLevel = {},
   .pattern = "4040",
   .ringBase = "0 6 7 5 4 2 3 1|1 3 2 4 5 7 6 0|0 1 7 6 2 3 5 4|4 5 3 2 6 7 1 0",
   .options = "disableNumaMatching=1,tuning=2",
 };
 
 static struct rcclRomeModel rome_model_67 = {
-  .nGpus = 8, .nCpus = 2, .nNics = 4, .nLinks = 3,
-  .gpuIds = { 0x29000, 0x2c000, 0x2f000, 0x32000, 0xad000, 0xb0000, 0xb3000, 0xb6000, },
-  .nicIds = { 0x1d000, 0x1e000, 0xa1000, 0xa2000, },
-  .gpuNuma = { 1, 1, 1, 1, 3, 3, 3, 3, },
-  .nicNuma = { 1, 1, 3, 3, },
-  .connMatrix = { 0, 4, 0, 0, 2, 0, 1, 0, 4, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 4, 1, 0, 2, 0, 0, 1, 4, 0, 0, 1, 0, 0, 2, 0, 1, 0, 0, 4, 0, 0, 0, 0, 0, 1, 4, 0, 0, 1, 1, 0, 2, 0, 0, 0, 0, 4, 0, 1, 0, 0, 0, 1, 4, 0, },
-  .gdrLevel = { PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, },
+  .nGpus = 8,
+  .nCpus = 2,
+  .nNics = 4,
+  .nLinks = 3,
+  .gpuIds =
+    {
+      0x29000,
+      0x2c000,
+      0x2f000,
+      0x32000,
+      0xad000,
+      0xb0000,
+      0xb3000,
+      0xb6000,
+    },
+  .nicIds =
+    {
+      0x1d000,
+      0x1e000,
+      0xa1000,
+      0xa2000,
+    },
+  .gpuNuma =
+    {
+      1,
+      1,
+      1,
+      1,
+      3,
+      3,
+      3,
+      3,
+    },
+  .nicNuma =
+    {
+      1,
+      1,
+      3,
+      3,
+    },
+  .connMatrix =
+    {
+      0, 4, 0, 0, 2, 0, 1, 0, 4, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 4, 1, 0, 2, 0, 0, 1, 4, 0, 0, 1, 0, 0,
+      2, 0, 1, 0, 0, 4, 0, 0, 0, 0, 0, 1, 4, 0, 0, 1, 1, 0, 2, 0, 0, 0, 0, 4, 0, 1, 0, 0, 0, 1, 4, 0,
+    },
+  .gdrLevel =
+    {
+      PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB, PATH_PXB,
+      PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB,
+      PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB,
+    },
   .pattern = "4242",
-  .ringBase = "N3 7 6 0 1 3 2 4 5 N2|N2 5 4 2 3 1 0 6 7 N3|N1 2 3 5 4 0 1 7 6 N3|N2 4 5 3 2 6 7 1 0 N0|N1 3 2 4 5 7 6 0 1 N0|N0 1 0 6 7 5 4 2 3 N1|N0 0 1 7 6 2 3 5 4 N2|N3 6 7 1 0 4 5 3 2 N1",
+  .ringBase = "N3 7 6 0 1 3 2 4 5 N2|N2 5 4 2 3 1 0 6 7 N3|N1 2 3 5 4 0 1 7 6 N3|N2 4 5 3 2 6 7 1 0 N0|N1 3 2 4 5 7 6 "
+              "0 1 N0|N0 1 0 6 7 5 4 2 3 N1|N0 0 1 7 6 2 3 5 4 N2|N3 6 7 1 0 4 5 3 2 N1",
   .options = "disableNumaMatching=1,tuning=2",
 };
 
 static struct rcclRomeModel rome_model_68 = {
-  .nGpus = 16, .nCpus = 1, .nNics = 16, .nLinks = 3,
-  .gpuIds = { 0xcf000, 0xd4000, 0xd5000, 0xd6000, 0xd0000, 0xd1000, 0xd2000, 0xd3000, 0xf0000, 0xf1000, 0xf2000, 0xf3000, 0xf4000, 0xf5000, 0xf6000, 0xf7000, },
-  .nicIds = { 0xcd000, 0xc8000, 0xc9000, 0xcb000, 0xcc000, 0xce000, 0xc7000, 0xca000, 0xe8000, 0xe9000, 0xea000, 0xeb000, 0xec000, 0xed000, 0xee000, 0xef000, },
-  .gpuNuma = { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, },
-  .nicNuma = { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, },
-  .connMatrix = { 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, },
-  .gdrLevel = { PATH_PIX, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PIX, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, PATH_PIX, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PIX, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PIX, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PIX, PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PIX, PATH_PXB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PIX, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PIX, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PIX, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, PATH_PIX, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PIX, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PIX, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PIX, PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PIX, PATH_PXB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PIX, },
+  .nGpus = 16,
+  .nCpus = 1,
+  .nNics = 16,
+  .nLinks = 3,
+  .gpuIds =
+    {
+      0xcf000,
+      0xd4000,
+      0xd5000,
+      0xd6000,
+      0xd0000,
+      0xd1000,
+      0xd2000,
+      0xd3000,
+      0xf0000,
+      0xf1000,
+      0xf2000,
+      0xf3000,
+      0xf4000,
+      0xf5000,
+      0xf6000,
+      0xf7000,
+    },
+  .nicIds =
+    {
+      0xcd000,
+      0xc8000,
+      0xc9000,
+      0xcb000,
+      0xcc000,
+      0xce000,
+      0xc7000,
+      0xca000,
+      0xe8000,
+      0xe9000,
+      0xea000,
+      0xeb000,
+      0xec000,
+      0xed000,
+      0xee000,
+      0xef000,
+    },
+  .gpuNuma =
+    {
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+    },
+  .nicNuma =
+    {
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+    },
+  .connMatrix =
+    {
+      0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+      1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
+      1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0,
+    },
+  .gdrLevel =
+    {
+      PATH_PIX, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_PHB,
+      PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PIX, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB,
+      PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB,
+      PATH_PXB, PATH_PIX, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB,
+      PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PIX, PATH_PXB, PATH_PXB, PATH_PXB,
+      PATH_PXB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB,
+      PATH_PXB, PATH_PXB, PATH_PIX, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB,
+      PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PIX, PATH_PXB, PATH_PXB,
+      PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, PATH_PXB,
+      PATH_PXB, PATH_PXB, PATH_PXB, PATH_PIX, PATH_PXB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB,
+      PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PIX, PATH_PHB,
+      PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB,
+      PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PIX, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB,
+      PATH_PXB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PIX,
+      PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB,
+      PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, PATH_PIX, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB,
+      PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, PATH_PXB,
+      PATH_PIX, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB,
+      PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PIX, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PHB,
+      PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB,
+      PATH_PXB, PATH_PIX, PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB,
+      PATH_PHB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PIX, PATH_PXB, PATH_PHB, PATH_PHB,
+      PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB, PATH_PXB,
+      PATH_PXB, PATH_PXB, PATH_PIX,
+    },
   .pattern = "@@",
-  .ringBase = "N0 0 1 2 3 N3 N4 4 5 6 7 N7 N8 8 9 10 11 N11 N12 12 13 14 15 N15|N15 15 14 13 12 N12 N11 11 10 9 8 N8 N7 7 6 5 4 N4 N3 3 2 1 0 N0|N1 1 3 0 2 N2 N5 5 7 4 6 N6 N9 9 11 8 10 N10 N13 13 15 12 14 N14|N14 14 12 15 13 N13 N10 10 8 11 9 N9 N6 6 4 7 5 N5 N2 2 0 3 1 N1|N0 0 1 2 3 N3 N4 4 5 6 7 N7 N8 8 9 10 11 N11 N12 12 13 14 15 N15|N15 15 14 13 12 N12 N11 11 10 9 8 N8 N7 7 6 5 4 N4 N3 3 2 1 0 N0|N1 1 3 0 2 N2 N5 5 7 4 6 N6 N9 9 11 8 10 N10 N13 13 15 12 14 N14|N14 14 12 15 13 N13 N10 10 8 11 9 N9 N6 6 4 7 5 N5 N2 2 0 3 1 N1",
+  .ringBase =
+    "N0 0 1 2 3 N3 N4 4 5 6 7 N7 N8 8 9 10 11 N11 N12 12 13 14 15 N15|N15 15 14 13 12 N12 N11 11 10 9 8 N8 N7 7 6 5 4 "
+    "N4 N3 3 2 1 0 N0|N1 1 3 0 2 N2 N5 5 7 4 6 N6 N9 9 11 8 10 N10 N13 13 15 12 14 N14|N14 14 12 15 13 N13 N10 10 8 11 "
+    "9 N9 N6 6 4 7 5 N5 N2 2 0 3 1 N1|N0 0 1 2 3 N3 N4 4 5 6 7 N7 N8 8 9 10 11 N11 N12 12 13 14 15 N15|N15 15 14 13 12 "
+    "N12 N11 11 10 9 8 N8 N7 7 6 5 4 N4 N3 3 2 1 0 N0|N1 1 3 0 2 N2 N5 5 7 4 6 N6 N9 9 11 8 10 N10 N13 13 15 12 14 "
+    "N14|N14 14 12 15 13 N13 N10 10 8 11 9 N9 N6 6 4 7 5 N5 N2 2 0 3 1 N1",
   .options = "",
 };
 
 static struct rcclRomeModel rome_model_71 = {
-  .nGpus = 8, .nCpus = 2, .nNics = 0, .nLinks = 3,
-  .gpuIds = { 0x32000, 0x35000, 0x11000, 0x14000, 0xae000, 0xb3000, 0x8e000, 0x93000, },
-  .nicIds = { },
-  .gpuNuma = { 0, 0, 0, 0, 1, 1, 1, 1, },
-  .nicNuma = { },
-  .connMatrix = { 0, 4, 1, 0, 0, 0, 2, 0, 4, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 4, 2, 0, 0, 0, 0, 1, 4, 0, 0, 0, 0, 1, 0, 0, 2, 0, 0, 4, 1, 0, 0, 1, 0, 0, 4, 0, 0, 1, 2, 0, 0, 0, 1, 0, 0, 4, 0, 0, 0, 1, 0, 1, 4, 0, },
-  .gdrLevel = { },
+  .nGpus = 8,
+  .nCpus = 2,
+  .nNics = 0,
+  .nLinks = 3,
+  .gpuIds =
+    {
+      0x32000,
+      0x35000,
+      0x11000,
+      0x14000,
+      0xae000,
+      0xb3000,
+      0x8e000,
+      0x93000,
+    },
+  .nicIds = {},
+  .gpuNuma =
+    {
+      0,
+      0,
+      0,
+      0,
+      1,
+      1,
+      1,
+      1,
+    },
+  .nicNuma = {},
+  .connMatrix =
+    {
+      0, 4, 1, 0, 0, 0, 2, 0, 4, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 4, 2, 0, 0, 0, 0, 1, 4, 0, 0, 0, 0, 1,
+      0, 0, 2, 0, 0, 4, 1, 0, 0, 1, 0, 0, 4, 0, 0, 1, 2, 0, 0, 0, 1, 0, 0, 4, 0, 0, 0, 1, 0, 1, 4, 0,
+    },
+  .gdrLevel = {},
   .pattern = "4040",
   .ringBase = "0 1 3 2 4 5 7 6|6 7 5 4 2 3 1 0|0 1 5 4 2 3 7 6|6 7 3 2 4 5 1 0",
   .options = "disableNumaMatching=1,tuning=2",
 };
 
 static struct rcclRomeModel rome_model_72 = {
-  .nGpus = 8, .nCpus = 2, .nNics = 4, .nLinks = 3,
-  .gpuIds = { 0x32000, 0x35000, 0x11000, 0x14000, 0xae000, 0xb3000, 0x8e000, 0x93000, },
-  .nicIds = { 0x1d000, 0x1e000, 0xa0000, 0xa1000, },
-  .gpuNuma = { 0, 0, 0, 0, 1, 1, 1, 1, },
-  .nicNuma = { 0, 0, 1, 1, },
-  .connMatrix = { 0, 4, 1, 0, 0, 0, 2, 0, 4, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 4, 2, 0, 0, 0, 0, 1, 4, 0, 0, 0, 0, 1, 0, 0, 2, 0, 0, 4, 1, 0, 0, 1, 0, 0, 4, 0, 0, 1, 2, 0, 0, 0, 1, 0, 0, 4, 0, 0, 0, 1, 0, 1, 4, 0, },
-  .gdrLevel = { PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, },
+  .nGpus = 8,
+  .nCpus = 2,
+  .nNics = 4,
+  .nLinks = 3,
+  .gpuIds =
+    {
+      0x32000,
+      0x35000,
+      0x11000,
+      0x14000,
+      0xae000,
+      0xb3000,
+      0x8e000,
+      0x93000,
+    },
+  .nicIds =
+    {
+      0x1d000,
+      0x1e000,
+      0xa0000,
+      0xa1000,
+    },
+  .gpuNuma =
+    {
+      0,
+      0,
+      0,
+      0,
+      1,
+      1,
+      1,
+      1,
+    },
+  .nicNuma =
+    {
+      0,
+      0,
+      1,
+      1,
+    },
+  .connMatrix =
+    {
+      0, 4, 1, 0, 0, 0, 2, 0, 4, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 4, 2, 0, 0, 0, 0, 1, 4, 0, 0, 0, 0, 1,
+      0, 0, 2, 0, 0, 4, 1, 0, 0, 1, 0, 0, 4, 0, 0, 1, 2, 0, 0, 0, 1, 0, 0, 4, 0, 0, 0, 1, 0, 1, 4, 0,
+    },
+  .gdrLevel =
+    {
+      PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PHB,
+      PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB,
+      PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB,
+    },
   .pattern = "4242",
-  .ringBase = "N0 0 1 3 2 4 5 7 6 N3|N1 2 3 1 0 6 7 5 4 N2|N3 7 6 0 1 5 4 2 3 N1|N0 1 0 6 7 3 2 4 5 N2|N2 4 5 7 6 0 1 3 2 N1|N3 6 7 5 4 2 3 1 0 N0|N2 5 4 2 3 7 6 0 1 N0|N1 3 2 4 5 1 0 6 7 N3",
+  .ringBase = "N0 0 1 3 2 4 5 7 6 N3|N1 2 3 1 0 6 7 5 4 N2|N3 7 6 0 1 5 4 2 3 N1|N0 1 0 6 7 3 2 4 5 N2|N2 4 5 7 6 0 1 "
+              "3 2 N1|N3 6 7 5 4 2 3 1 0 N0|N2 5 4 2 3 7 6 0 1 N0|N1 3 2 4 5 1 0 6 7 N3",
   .options = "disableNumaMatching=1,tuning=2",
 };
 
 static struct rcclRomeModel rome_model_73 = {
-  .nGpus = 8, .nCpus = 4, .nNics = 0, .nLinks = 3,
-  .gpuIds = { 0xc1000, 0xc6000, 0xc9000, 0xce000, 0xd1000, 0xd6000, 0xd9000, 0xde000, },
-  .nicIds = { },
-  .gpuNuma = { 3, 3, 1, 1, 0, 0, 2, 2, },
-  .nicNuma = { },
-  .connMatrix = { 0, 4, 1, 0, 0, 0, 2, 0, 4, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 4, 2, 0, 0, 0, 0, 1, 4, 0, 0, 0, 0, 1, 0, 0, 2, 0, 0, 4, 1, 0, 0, 1, 0, 0, 4, 0, 0, 1, 2, 0, 0, 0, 1, 0, 0, 4, 0, 0, 0, 1, 0, 1, 4, 0, },
-  .gdrLevel = { },
+  .nGpus = 8,
+  .nCpus = 4,
+  .nNics = 0,
+  .nLinks = 3,
+  .gpuIds =
+    {
+      0xc1000,
+      0xc6000,
+      0xc9000,
+      0xce000,
+      0xd1000,
+      0xd6000,
+      0xd9000,
+      0xde000,
+    },
+  .nicIds = {},
+  .gpuNuma =
+    {
+      3,
+      3,
+      1,
+      1,
+      0,
+      0,
+      2,
+      2,
+    },
+  .nicNuma = {},
+  .connMatrix =
+    {
+      0, 4, 1, 0, 0, 0, 2, 0, 4, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 4, 2, 0, 0, 0, 0, 1, 4, 0, 0, 0, 0, 1,
+      0, 0, 2, 0, 0, 4, 1, 0, 0, 1, 0, 0, 4, 0, 0, 1, 2, 0, 0, 0, 1, 0, 0, 4, 0, 0, 0, 1, 0, 1, 4, 0,
+    },
+  .gdrLevel = {},
   .pattern = "20202020",
   .ringBase = "0 1 3 2 4 5 7 6|6 7 5 4 2 3 1 0|0 1 5 4 6 7 3 2|2 3 7 6 4 5 1 0",
   .options = "",
 };
 
 static struct rcclRomeModel rome_model_74 = {
-  .nGpus = 8, .nCpus = 4, .nNics = 4, .nLinks = 3,
-  .gpuIds = { 0xc1000, 0xc6000, 0xc9000, 0xce000, 0xd1000, 0xd6000, 0xd9000, 0xde000, },
-  .nicIds = { 0xc5000, 0xcd000, 0xd5000, 0xdd000, },
-  .gpuNuma = { 3, 3, 1, 1, 0, 0, 2, 2, },
-  .nicNuma = { 3, 1, 0, 2, },
-  .connMatrix = { 0, 4, 1, 0, 0, 0, 2, 0, 4, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 4, 2, 0, 0, 0, 0, 1, 4, 0, 0, 0, 0, 1, 0, 0, 2, 0, 0, 4, 1, 0, 0, 1, 0, 0, 4, 0, 0, 1, 2, 0, 0, 0, 1, 0, 0, 4, 0, 0, 0, 1, 0, 1, 4, 0, },
-  .gdrLevel = { PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, },
+  .nGpus = 8,
+  .nCpus = 4,
+  .nNics = 4,
+  .nLinks = 3,
+  .gpuIds =
+    {
+      0xc1000,
+      0xc6000,
+      0xc9000,
+      0xce000,
+      0xd1000,
+      0xd6000,
+      0xd9000,
+      0xde000,
+    },
+  .nicIds =
+    {
+      0xc5000,
+      0xcd000,
+      0xd5000,
+      0xdd000,
+    },
+  .gpuNuma =
+    {
+      3,
+      3,
+      1,
+      1,
+      0,
+      0,
+      2,
+      2,
+    },
+  .nicNuma =
+    {
+      3,
+      1,
+      0,
+      2,
+    },
+  .connMatrix =
+    {
+      0, 4, 1, 0, 0, 0, 2, 0, 4, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 4, 2, 0, 0, 0, 0, 1, 4, 0, 0, 0, 0, 1,
+      0, 0, 2, 0, 0, 4, 1, 0, 0, 1, 0, 0, 4, 0, 0, 1, 2, 0, 0, 0, 1, 0, 0, 4, 0, 0, 0, 1, 0, 1, 4, 0,
+    },
+  .gdrLevel =
+    {
+      PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB,
+      PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB,
+      PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB,
+    },
   .pattern = "21212121",
-  .ringBase = "N0 0 1 5 4 6 7 3 2 N1|N1 2 3 7 6 4 5 1 0 N0|N3 7 6 0 1 3 2 4 5 N2|N2 5 4 2 3 1 0 6 7 N3|N0 0 1 5 4 6 7 3 2 N1|N1 2 3 7 6 4 5 1 0 N0|N3 7 6 0 1 3 2 4 5 N2|N2 5 4 2 3 1 0 6 7 N3",
+  .ringBase = "N0 0 1 5 4 6 7 3 2 N1|N1 2 3 7 6 4 5 1 0 N0|N3 7 6 0 1 3 2 4 5 N2|N2 5 4 2 3 1 0 6 7 N3|N0 0 1 5 4 6 7 "
+              "3 2 N1|N1 2 3 7 6 4 5 1 0 N0|N3 7 6 0 1 3 2 4 5 N2|N2 5 4 2 3 1 0 6 7 N3",
   .options = "tuning=3",
 };
 
 static struct rcclRomeModel rome_model_76 = {
-  .nGpus = 8, .nCpus = 2, .nNics = 8, .nLinks = 3,
-  .gpuIds = { 0x32000, 0x35000, 0x11000, 0x14000, 0xae000, 0xb3000, 0x8e000, 0x93000, },
-  .nicIds = { 0x26000, 0x2d000, 0x5000, 0xc000, 0xab000, 0xb4000, 0x8b000, 0x94000, },
-  .gpuNuma = { 1, 1, 1, 1, 3, 3, 3, 3, },
-  .nicNuma = { 1, 1, 1, 1, 3, 3, 3, 3, },
-  .connMatrix = { 0, 4, 1, 0, 0, 0, 2, 0, 4, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 4, 2, 0, 0, 0, 0, 1, 4, 0, 0, 0, 0, 1, 0, 0, 2, 0, 0, 4, 1, 0, 0, 1, 0, 0, 4, 0, 0, 1, 2, 0, 0, 0, 1, 0, 0, 4, 0, 0, 0, 1, 0, 1, 4, 0, },
-  .gdrLevel = { PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, },
+  .nGpus = 8,
+  .nCpus = 2,
+  .nNics = 8,
+  .nLinks = 3,
+  .gpuIds =
+    {
+      0x32000,
+      0x35000,
+      0x11000,
+      0x14000,
+      0xae000,
+      0xb3000,
+      0x8e000,
+      0x93000,
+    },
+  .nicIds =
+    {
+      0x26000,
+      0x2d000,
+      0x5000,
+      0xc000,
+      0xab000,
+      0xb4000,
+      0x8b000,
+      0x94000,
+    },
+  .gpuNuma =
+    {
+      1,
+      1,
+      1,
+      1,
+      3,
+      3,
+      3,
+      3,
+    },
+  .nicNuma =
+    {
+      1,
+      1,
+      1,
+      1,
+      3,
+      3,
+      3,
+      3,
+    },
+  .connMatrix =
+    {
+      0, 4, 1, 0, 0, 0, 2, 0, 4, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 4, 2, 0, 0, 0, 0, 1, 4, 0, 0, 0, 0, 1,
+      0, 0, 2, 0, 0, 4, 1, 0, 0, 1, 0, 0, 4, 0, 0, 1, 2, 0, 0, 0, 1, 0, 0, 4, 0, 0, 0, 1, 0, 1, 4, 0,
+    },
+  .gdrLevel =
+    {
+      PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB, PATH_PHB,
+      PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS,
+      PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS,
+      PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS,
+      PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PXB,
+      PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB,
+    },
   .pattern = "4444",
-  .ringBase = "N0 0 1 3 2 4 5 7 6 N6|N2 2 3 1 0 6 7 5 4 N4|N5 5 4 2 3 7 6 0 1 N1|N1 1 0 6 7 3 2 4 5 N5|N4 4 5 7 6 0 1 3 2 N2|N2 2 3 1 0 6 7 5 4 N4|N0 0 1 5 4 2 3 7 6 N6|N3 3 2 4 5 1 0 6 7 N7|N4 4 5 7 6 0 1 3 2 N2|N6 6 7 5 4 2 3 1 0 N0|N7 7 6 0 1 5 4 2 3 N3|N6 6 7 3 2 4 5 1 0 N0|N3 3 2 0 1 5 4 6 7 N7|N1 1 0 2 3 7 6 4 5 N5|N5 5 4 6 7 3 2 0 1 N1|N7 7 6 4 5 1 0 2 3 N3",
+  .ringBase = "N0 0 1 3 2 4 5 7 6 N6|N2 2 3 1 0 6 7 5 4 N4|N5 5 4 2 3 7 6 0 1 N1|N1 1 0 6 7 3 2 4 5 N5|N4 4 5 7 6 0 1 "
+              "3 2 N2|N2 2 3 1 0 6 7 5 4 N4|N0 0 1 5 4 2 3 7 6 N6|N3 3 2 4 5 1 0 6 7 N7|N4 4 5 7 6 0 1 3 2 N2|N6 6 7 5 "
+              "4 2 3 1 0 N0|N7 7 6 0 1 5 4 2 3 N3|N6 6 7 3 2 4 5 1 0 N0|N3 3 2 0 1 5 4 6 7 N7|N1 1 0 2 3 7 6 4 5 N5|N5 "
+              "5 4 6 7 3 2 0 1 N1|N7 7 6 4 5 1 0 2 3 N3",
   .options = "disableNumaMatching=1,tuning=3",
 };
 
 static struct rcclRomeModel rome_model_79 = {
-  .nGpus = 8, .nCpus = 2, .nNics = 0, .nLinks = 7,
-  .gpuIds = { 0x1d000, 0x2e000, 0x3f000, 0x61000, 0x9f000, 0xaf000, 0xbf000, 0xdf000, },
-  .nicIds = { },
-  .gpuNuma = { 0, 0, 0, 0, 1, 1, 1, 1, },
-  .nicNuma = { },
-  .connMatrix = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, },
-  .gdrLevel = { },
+  .nGpus = 8,
+  .nCpus = 2,
+  .nNics = 0,
+  .nLinks = 7,
+  .gpuIds =
+    {
+      0x1d000,
+      0x2e000,
+      0x3f000,
+      0x61000,
+      0x9f000,
+      0xaf000,
+      0xbf000,
+      0xdf000,
+    },
+  .nicIds = {},
+  .gpuNuma =
+    {
+      0,
+      0,
+      0,
+      0,
+      1,
+      1,
+      1,
+      1,
+    },
+  .nicNuma = {},
+  .connMatrix =
+    {
+      0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1,
+      1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0,
+    },
+  .gdrLevel = {},
   .pattern = "4040",
-  .ringBase = "0 1 2 3 4 5 6 7|0 1 2 3 4 5 7 6|0 2 4 1 3 6 5 7|0 2 4 6 1 7 3 5|0 3 1 5 2 7 4 6|0 3 5 1 6 2 7 4|0 4 1 7 3 6 2 5|7 6 5 4 3 2 1 0|6 7 5 4 3 2 1 0|7 5 6 3 1 4 2 0|5 3 7 1 6 4 2 0|6 4 7 2 5 1 3 0|4 7 2 6 1 5 3 0|5 2 6 3 7 1 4 0|0 1 2 3 4 5 6 7|0 1 2 3 4 5 7 6|0 2 4 1 3 6 5 7|0 2 4 6 1 7 3 5|0 3 1 5 2 7 4 6|0 3 5 1 6 2 7 4|0 4 1 7 3 6 2 5|7 6 5 4 3 2 1 0|6 7 5 4 3 2 1 0|7 5 6 3 1 4 2 0|5 3 7 1 6 4 2 0|6 4 7 2 5 1 3 0|4 7 2 6 1 5 3 0|5 2 6 3 7 1 4 0",
+  .ringBase =
+    "0 1 2 3 4 5 6 7|0 1 2 3 4 5 7 6|0 2 4 1 3 6 5 7|0 2 4 6 1 7 3 5|0 3 1 5 2 7 4 6|0 3 5 1 6 2 7 4|0 4 1 7 3 6 2 5|7 "
+    "6 5 4 3 2 1 0|6 7 5 4 3 2 1 0|7 5 6 3 1 4 2 0|5 3 7 1 6 4 2 0|6 4 7 2 5 1 3 0|4 7 2 6 1 5 3 0|5 2 6 3 7 1 4 0|0 1 "
+    "2 3 4 5 6 7|0 1 2 3 4 5 7 6|0 2 4 1 3 6 5 7|0 2 4 6 1 7 3 5|0 3 1 5 2 7 4 6|0 3 5 1 6 2 7 4|0 4 1 7 3 6 2 5|7 6 5 "
+    "4 3 2 1 0|6 7 5 4 3 2 1 0|7 5 6 3 1 4 2 0|5 3 7 1 6 4 2 0|6 4 7 2 5 1 3 0|4 7 2 6 1 5 3 0|5 2 6 3 7 1 4 0",
   .options = "noCpuCheck=1,tuning=5,disableNumaMatching=1",
 };
 
 static struct rcclRomeModel rome_model_80 = {
-  .nGpus = 4, .nCpus = 4, .nNics = 4, .nLinks = 3,
-  .gpuIds = { 0x82000, 0xc2000, 0x2000, 0x42000, },
-  .nicIds = { 0x81000, 0xc1000, 0x1000, 0x41000, },
-  .gpuNuma = { 2, 3, 0, 1, },
-  .nicNuma = { 2, 3, 0, 1, },
-  .connMatrix = { 0, 2, 2, 2, 2, 0, 2, 2, 2, 2, 0, 2, 2, 2, 2, 0, },
-  .gdrLevel = { PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, },
+  .nGpus = 4,
+  .nCpus = 4,
+  .nNics = 4,
+  .nLinks = 3,
+  .gpuIds =
+    {
+      0x82000,
+      0xc2000,
+      0x2000,
+      0x42000,
+    },
+  .nicIds =
+    {
+      0x81000,
+      0xc1000,
+      0x1000,
+      0x41000,
+    },
+  .gpuNuma =
+    {
+      2,
+      3,
+      0,
+      1,
+    },
+  .nicNuma =
+    {
+      2,
+      3,
+      0,
+      1,
+    },
+  .connMatrix =
+    {
+      0,
+      2,
+      2,
+      2,
+      2,
+      0,
+      2,
+      2,
+      2,
+      2,
+      0,
+      2,
+      2,
+      2,
+      2,
+      0,
+    },
+  .gdrLevel =
+    {
+      PATH_PHB,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_PHB,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_PHB,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_SYS,
+      PATH_PHB,
+    },
   .pattern = "11111111",
-  .ringBase = "N2 2 3 0 1 N1|N0 0 1 3 2 N2|N0 0 2 1 3 N3|N3 3 1 0 2 N2|N3 3 1 2 0 N0|N1 1 0 3 2 N2|N1 1 2 3 0 N0|N2 2 0 1 3 N3|N3 3 0 2 1 N1|N2 2 3 1 0 N0|N1 1 2 0 3 N3|N0 0 3 2 1 N1",
+  .ringBase = "N2 2 3 0 1 N1|N0 0 1 3 2 N2|N0 0 2 1 3 N3|N3 3 1 0 2 N2|N3 3 1 2 0 N0|N1 1 0 3 2 N2|N1 1 2 3 0 N0|N2 2 "
+              "0 1 3 N3|N3 3 0 2 1 N1|N2 2 3 1 0 N0|N1 1 2 0 3 N3|N0 0 3 2 1 N1",
   .options = "",
 };
 
 static struct rcclRomeModel rome_model_81 = {
-  .nGpus = 8, .nCpus = 2, .nNics = 8, .nLinks = 7,
-  .gpuIds     = { 0xc000, 0x22000, 0x38000, 0x5c000, 0x9f000, 0xaf000, 0xbf000, 0xdf000, },
-  .nicIds     = { 0x7000, 0x1d000, 0x33000, 0x57000, 0x9a000, 0xaa000, 0xba000, 0xda000, },
-  .gpuNuma    = { 0, 0, 0, 0, 1, 1, 1, 1, },
-  .nicNuma    = { 0, 0, 0, 0, 1, 1, 1, 1, },
-  .connMatrix = { 0, 1, 1, 1, 1, 1, 1, 1,
-                  1, 0, 1, 1, 1, 1, 1, 1,
-                  1, 1, 0, 1, 1, 1, 1, 1,
-                  1, 1, 1, 0, 1, 1, 1, 1,
-                  1, 1, 1, 1, 0, 1, 1, 1,
-                  1, 1, 1, 1, 1, 0, 1, 1,
-                  1, 1, 1, 1, 1, 1, 0, 1,
-                  1, 1, 1, 1, 1, 1, 1, 0, },
-  .gdrLevel   = {PATH_PXB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS,
-                 PATH_PHB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS,
-                 PATH_PHB, PATH_PHB, PATH_PXB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS,
-                 PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS,
-                 PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PHB, PATH_PHB, PATH_PHB,
-                 PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PXB, PATH_PHB, PATH_PHB,
-                 PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PHB,
-                 PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, },
-  .pattern    = "4444",
-  .ringBase   = "N0 0 1 2 3 4 5 6 7 N7|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N2 2 5 0 3 6 1 7 4 N4|"
-                "N3 3 7 0 4 2 1 6 5 N5|"
-                "N4 4 6 2 7 3 0 5 1 N1|"
-                "N5 5 4 7 1 3 2 6 0 N0|"
-                "N6 6 3 1 4 0 7 5 2 N2|"
-                "N7 7 2 0 6 4 1 5 3 N3|"
+  .nGpus = 8,
+  .nCpus = 2,
+  .nNics = 8,
+  .nLinks = 7,
+  .gpuIds =
+    {
+      0xc000,
+      0x22000,
+      0x38000,
+      0x5c000,
+      0x9f000,
+      0xaf000,
+      0xbf000,
+      0xdf000,
+    },
+  .nicIds =
+    {
+      0x7000,
+      0x1d000,
+      0x33000,
+      0x57000,
+      0x9a000,
+      0xaa000,
+      0xba000,
+      0xda000,
+    },
+  .gpuNuma =
+    {
+      0,
+      0,
+      0,
+      0,
+      1,
+      1,
+      1,
+      1,
+    },
+  .nicNuma =
+    {
+      0,
+      0,
+      0,
+      0,
+      1,
+      1,
+      1,
+      1,
+    },
+  .connMatrix =
+    {
+      0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1,
+      1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0,
+    },
+  .gdrLevel =
+    {
+      PATH_PXB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PXB, PATH_PHB,
+      PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PHB, PATH_SYS, PATH_SYS,
+      PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS,
+      PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS,
+      PATH_PHB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PXB,
+      PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB,
+    },
+  .pattern = "4444",
+  .ringBase = "N0 0 1 2 3 4 5 6 7 N7|"
+              "N1 1 0 2 4 3 5 7 6 N6|"
+              "N2 2 5 0 3 6 1 7 4 N4|"
+              "N3 3 7 0 4 2 1 6 5 N5|"
+              "N4 4 6 2 7 3 0 5 1 N1|"
+              "N5 5 4 7 1 3 2 6 0 N0|"
+              "N6 6 3 1 4 0 7 5 2 N2|"
+              "N7 7 2 0 6 4 1 5 3 N3|"
 
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N2 2 5 0 3 6 1 7 4 N4|"
-                "N3 3 7 0 4 2 1 6 5 N5|"
-                "N4 4 6 2 7 3 0 5 1 N1|"
-                "N5 5 4 7 1 3 2 6 0 N0|"
-                "N6 6 3 1 4 0 7 5 2 N2|"
-                "N7 7 2 0 6 4 1 5 3 N3|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
+              "N1 1 0 2 4 3 5 7 6 N6|"
+              "N2 2 5 0 3 6 1 7 4 N4|"
+              "N3 3 7 0 4 2 1 6 5 N5|"
+              "N4 4 6 2 7 3 0 5 1 N1|"
+              "N5 5 4 7 1 3 2 6 0 N0|"
+              "N6 6 3 1 4 0 7 5 2 N2|"
+              "N7 7 2 0 6 4 1 5 3 N3|"
+              "N0 0 1 2 3 4 5 6 7 N7|"
 
-                "N2 2 5 0 3 6 1 7 4 N4|"
-                "N3 3 7 0 4 2 1 6 5 N5|"
-                "N4 4 6 2 7 3 0 5 1 N1|"
-                "N5 5 4 7 1 3 2 6 0 N0|"
-                "N6 6 3 1 4 0 7 5 2 N2|"
-                "N7 7 2 0 6 4 1 5 3 N3|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
+              "N2 2 5 0 3 6 1 7 4 N4|"
+              "N3 3 7 0 4 2 1 6 5 N5|"
+              "N4 4 6 2 7 3 0 5 1 N1|"
+              "N5 5 4 7 1 3 2 6 0 N0|"
+              "N6 6 3 1 4 0 7 5 2 N2|"
+              "N7 7 2 0 6 4 1 5 3 N3|"
+              "N0 0 1 2 3 4 5 6 7 N7|"
+              "N1 1 0 2 4 3 5 7 6 N6|"
 
-                "N3 3 7 0 4 2 1 6 5 N5|"
-                "N4 4 6 2 7 3 0 5 1 N1|"
-                "N5 5 4 7 1 3 2 6 0 N0|"
-                "N6 6 3 1 4 0 7 5 2 N2|"
-                "N7 7 2 0 6 4 1 5 3 N3|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N2 2 5 0 3 6 1 7 4 N4|"
+              "N3 3 7 0 4 2 1 6 5 N5|"
+              "N4 4 6 2 7 3 0 5 1 N1|"
+              "N5 5 4 7 1 3 2 6 0 N0|"
+              "N6 6 3 1 4 0 7 5 2 N2|"
+              "N7 7 2 0 6 4 1 5 3 N3|"
+              "N0 0 1 2 3 4 5 6 7 N7|"
+              "N1 1 0 2 4 3 5 7 6 N6|"
+              "N2 2 5 0 3 6 1 7 4 N4|"
 
-                "N4 4 6 2 7 3 0 5 1 N1|"
-                "N5 5 4 7 1 3 2 6 0 N0|"
-                "N6 6 3 1 4 0 7 5 2 N2|"
-                "N7 7 2 0 6 4 1 5 3 N3|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N2 2 5 0 3 6 1 7 4 N4|"
-                "N3 3 7 0 4 2 1 6 5 N5|"
+              "N4 4 6 2 7 3 0 5 1 N1|"
+              "N5 5 4 7 1 3 2 6 0 N0|"
+              "N6 6 3 1 4 0 7 5 2 N2|"
+              "N7 7 2 0 6 4 1 5 3 N3|"
+              "N0 0 1 2 3 4 5 6 7 N7|"
+              "N1 1 0 2 4 3 5 7 6 N6|"
+              "N2 2 5 0 3 6 1 7 4 N4|"
+              "N3 3 7 0 4 2 1 6 5 N5|"
 
-                "N5 5 4 7 1 3 2 6 0 N0|"
-                "N6 6 3 1 4 0 7 5 2 N2|"
-                "N7 7 2 0 6 4 1 5 3 N3|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N2 2 5 0 3 6 1 7 4 N4|"
-                "N3 3 7 0 4 2 1 6 5 N5|"
-                "N4 4 6 2 7 3 0 5 1 N1|"
+              "N5 5 4 7 1 3 2 6 0 N0|"
+              "N6 6 3 1 4 0 7 5 2 N2|"
+              "N7 7 2 0 6 4 1 5 3 N3|"
+              "N0 0 1 2 3 4 5 6 7 N7|"
+              "N1 1 0 2 4 3 5 7 6 N6|"
+              "N2 2 5 0 3 6 1 7 4 N4|"
+              "N3 3 7 0 4 2 1 6 5 N5|"
+              "N4 4 6 2 7 3 0 5 1 N1|"
 
-                "N6 6 3 1 4 0 7 5 2 N2|"
-                "N7 7 2 0 6 4 1 5 3 N3|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N2 2 5 0 3 6 1 7 4 N4|"
-                "N3 3 7 0 4 2 1 6 5 N5|"
-                "N4 4 6 2 7 3 0 5 1 N1|"
-                "N5 5 4 7 1 3 2 6 0 N0|"
+              "N6 6 3 1 4 0 7 5 2 N2|"
+              "N7 7 2 0 6 4 1 5 3 N3|"
+              "N0 0 1 2 3 4 5 6 7 N7|"
+              "N1 1 0 2 4 3 5 7 6 N6|"
+              "N2 2 5 0 3 6 1 7 4 N4|"
+              "N3 3 7 0 4 2 1 6 5 N5|"
+              "N4 4 6 2 7 3 0 5 1 N1|"
+              "N5 5 4 7 1 3 2 6 0 N0|"
 
-                "N7 7 2 0 6 4 1 5 3 N3|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N2 2 5 0 3 6 1 7 4 N4|"
-                "N3 3 7 0 4 2 1 6 5 N5|"
-                "N4 4 6 2 7 3 0 5 1 N1|"
-                "N5 5 4 7 1 3 2 6 0 N0|"
-                "N6 6 3 1 4 0 7 5 2 N2|",
+              "N7 7 2 0 6 4 1 5 3 N3|"
+              "N0 0 1 2 3 4 5 6 7 N7|"
+              "N1 1 0 2 4 3 5 7 6 N6|"
+              "N2 2 5 0 3 6 1 7 4 N4|"
+              "N3 3 7 0 4 2 1 6 5 N5|"
+              "N4 4 6 2 7 3 0 5 1 N1|"
+              "N5 5 4 7 1 3 2 6 0 N0|"
+              "N6 6 3 1 4 0 7 5 2 N2|",
 
-  .ringTail2  = "N7 7 4 1 3 2 0 6 5 N5|"
-                "N6 6 3 0 7 5 1 4 2 N2|"
-                "N4 4 6 2 1 7 0 5 3 N3|"
-                "N5 5 2 7 3 1 6 0 4 N4|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N2 2 5 0 3 6 4 7 1 N1|"
-                "N3 3 7 2 6 1 5 4 0 N0|"
+  .ringTail2 = "N7 7 4 1 3 2 0 6 5 N5|"
+               "N6 6 3 0 7 5 1 4 2 N2|"
+               "N4 4 6 2 1 7 0 5 3 N3|"
+               "N5 5 2 7 3 1 6 0 4 N4|"
+               "N1 1 0 2 4 3 5 7 6 N6|"
+               "N0 0 1 2 3 4 5 6 7 N7|"
+               "N2 2 5 0 3 6 4 7 1 N1|"
+               "N3 3 7 2 6 1 5 4 0 N0|"
 
-                "N6 6 3 0 7 5 1 4 2 N2|"
-                "N4 4 6 2 1 7 0 5 3 N3|"
-                "N5 5 2 7 3 1 6 0 4 N4|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N2 2 5 0 3 6 4 7 1 N1|"
-                "N3 3 7 2 6 1 5 4 0 N0|"
-                "N7 7 4 1 3 2 0 6 5 N5|"
+               "N6 6 3 0 7 5 1 4 2 N2|"
+               "N4 4 6 2 1 7 0 5 3 N3|"
+               "N5 5 2 7 3 1 6 0 4 N4|"
+               "N1 1 0 2 4 3 5 7 6 N6|"
+               "N0 0 1 2 3 4 5 6 7 N7|"
+               "N2 2 5 0 3 6 4 7 1 N1|"
+               "N3 3 7 2 6 1 5 4 0 N0|"
+               "N7 7 4 1 3 2 0 6 5 N5|"
 
-                "N4 4 6 2 1 7 0 5 3 N3|"
-                "N5 5 2 7 3 1 6 0 4 N4|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N2 2 5 0 3 6 4 7 1 N1|"
-                "N3 3 7 2 6 1 5 4 0 N0|"
-                "N7 7 4 1 3 2 0 6 5 N5|"
-                "N6 6 3 0 7 5 1 4 2 N2|"
+               "N4 4 6 2 1 7 0 5 3 N3|"
+               "N5 5 2 7 3 1 6 0 4 N4|"
+               "N1 1 0 2 4 3 5 7 6 N6|"
+               "N0 0 1 2 3 4 5 6 7 N7|"
+               "N2 2 5 0 3 6 4 7 1 N1|"
+               "N3 3 7 2 6 1 5 4 0 N0|"
+               "N7 7 4 1 3 2 0 6 5 N5|"
+               "N6 6 3 0 7 5 1 4 2 N2|"
 
-                "N5 5 2 7 3 1 6 0 4 N4|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N2 2 5 0 3 6 4 7 1 N1|"
-                "N3 3 7 2 6 1 5 4 0 N0|"
-                "N7 7 4 1 3 2 0 6 5 N5|"
-                "N6 6 3 0 7 5 1 4 2 N2|"
-                "N4 4 6 2 1 7 0 5 3 N3|"
+               "N5 5 2 7 3 1 6 0 4 N4|"
+               "N1 1 0 2 4 3 5 7 6 N6|"
+               "N0 0 1 2 3 4 5 6 7 N7|"
+               "N2 2 5 0 3 6 4 7 1 N1|"
+               "N3 3 7 2 6 1 5 4 0 N0|"
+               "N7 7 4 1 3 2 0 6 5 N5|"
+               "N6 6 3 0 7 5 1 4 2 N2|"
+               "N4 4 6 2 1 7 0 5 3 N3|"
 
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N2 2 5 0 3 6 4 7 1 N1|"
-                "N3 3 7 2 6 1 5 4 0 N0|"
-                "N7 7 4 1 3 2 0 6 5 N5|"
-                "N6 6 3 0 7 5 1 4 2 N2|"
-                "N4 4 6 2 1 7 0 5 3 N3|"
-                "N5 5 2 7 3 1 6 0 4 N4|"
+               "N1 1 0 2 4 3 5 7 6 N6|"
+               "N0 0 1 2 3 4 5 6 7 N7|"
+               "N2 2 5 0 3 6 4 7 1 N1|"
+               "N3 3 7 2 6 1 5 4 0 N0|"
+               "N7 7 4 1 3 2 0 6 5 N5|"
+               "N6 6 3 0 7 5 1 4 2 N2|"
+               "N4 4 6 2 1 7 0 5 3 N3|"
+               "N5 5 2 7 3 1 6 0 4 N4|"
 
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N2 2 5 0 3 6 4 7 1 N1|"
-                "N3 3 7 2 6 1 5 4 0 N0|"
-                "N7 7 4 1 3 2 0 6 5 N5|"
-                "N6 6 3 0 7 5 1 4 2 N2|"
-                "N4 4 6 2 1 7 0 5 3 N3|"
-                "N5 5 2 7 3 1 6 0 4 N4|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
+               "N0 0 1 2 3 4 5 6 7 N7|"
+               "N2 2 5 0 3 6 4 7 1 N1|"
+               "N3 3 7 2 6 1 5 4 0 N0|"
+               "N7 7 4 1 3 2 0 6 5 N5|"
+               "N6 6 3 0 7 5 1 4 2 N2|"
+               "N4 4 6 2 1 7 0 5 3 N3|"
+               "N5 5 2 7 3 1 6 0 4 N4|"
+               "N1 1 0 2 4 3 5 7 6 N6|"
 
-                "N2 2 5 0 3 6 4 7 1 N1|"
-                "N3 3 7 2 6 1 5 4 0 N0|"
-                "N7 7 4 1 3 2 0 6 5 N5|"
-                "N6 6 3 0 7 5 1 4 2 N2|"
-                "N4 4 6 2 1 7 0 5 3 N3|"
-                "N5 5 2 7 3 1 6 0 4 N4|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
+               "N2 2 5 0 3 6 4 7 1 N1|"
+               "N3 3 7 2 6 1 5 4 0 N0|"
+               "N7 7 4 1 3 2 0 6 5 N5|"
+               "N6 6 3 0 7 5 1 4 2 N2|"
+               "N4 4 6 2 1 7 0 5 3 N3|"
+               "N5 5 2 7 3 1 6 0 4 N4|"
+               "N1 1 0 2 4 3 5 7 6 N6|"
+               "N0 0 1 2 3 4 5 6 7 N7|"
 
-                "N3 3 7 2 6 1 5 4 0 N0|"
-                "N7 7 4 1 3 2 0 6 5 N5|"
-                "N6 6 3 0 7 5 1 4 2 N2|"
-                "N4 4 6 2 1 7 0 5 3 N3|"
-                "N5 5 2 7 3 1 6 0 4 N4|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N2 2 5 0 3 6 4 7 1 N1|",
+               "N3 3 7 2 6 1 5 4 0 N0|"
+               "N7 7 4 1 3 2 0 6 5 N5|"
+               "N6 6 3 0 7 5 1 4 2 N2|"
+               "N4 4 6 2 1 7 0 5 3 N3|"
+               "N5 5 2 7 3 1 6 0 4 N4|"
+               "N1 1 0 2 4 3 5 7 6 N6|"
+               "N0 0 1 2 3 4 5 6 7 N7|"
+               "N2 2 5 0 3 6 4 7 1 N1|",
 
+  .ringTail1 = "N5 5 4 2 7 1 6 3 0 N0|"
+               "N2 2 5 0 3 7 4 6 1 N1|"
+               "N3 3 6 4 0 5 1 7 2 N2|"
+               "N4 4 7 0 6 5 2 1 3 N3|"
+               "N6 6 2 0 7 5 3 1 4 N4|"
+               "N7 7 3 2 6 0 4 1 5 N5|"
+               "N1 1 0 2 4 3 5 7 6 N6|"
+               "N0 0 1 2 3 4 5 6 7 N7|"
 
-  .ringTail1  = "N5 5 4 2 7 1 6 3 0 N0|"
-                "N2 2 5 0 3 7 4 6 1 N1|"
-                "N3 3 6 4 0 5 1 7 2 N2|"
-                "N4 4 7 0 6 5 2 1 3 N3|"
-                "N6 6 2 0 7 5 3 1 4 N4|"
-                "N7 7 3 2 6 0 4 1 5 N5|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
+               "N2 2 5 0 3 7 4 6 1 N1|"
+               "N3 3 6 4 0 5 1 7 2 N2|"
+               "N4 4 7 0 6 5 2 1 3 N3|"
+               "N6 6 2 0 7 5 3 1 4 N4|"
+               "N7 7 3 2 6 0 4 1 5 N5|"
+               "N1 1 0 2 4 3 5 7 6 N6|"
+               "N0 0 1 2 3 4 5 6 7 N7|"
+               "N5 5 4 2 7 1 6 3 0 N0|"
 
-                "N2 2 5 0 3 7 4 6 1 N1|"
-                "N3 3 6 4 0 5 1 7 2 N2|"
-                "N4 4 7 0 6 5 2 1 3 N3|"
-                "N6 6 2 0 7 5 3 1 4 N4|"
-                "N7 7 3 2 6 0 4 1 5 N5|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N5 5 4 2 7 1 6 3 0 N0|"
+               "N3 3 6 4 0 5 1 7 2 N2|"
+               "N4 4 7 0 6 5 2 1 3 N3|"
+               "N6 6 2 0 7 5 3 1 4 N4|"
+               "N7 7 3 2 6 0 4 1 5 N5|"
+               "N1 1 0 2 4 3 5 7 6 N6|"
+               "N0 0 1 2 3 4 5 6 7 N7|"
+               "N5 5 4 2 7 1 6 3 0 N0|"
+               "N2 2 5 0 3 7 4 6 1 N1|"
 
-                "N3 3 6 4 0 5 1 7 2 N2|"
-                "N4 4 7 0 6 5 2 1 3 N3|"
-                "N6 6 2 0 7 5 3 1 4 N4|"
-                "N7 7 3 2 6 0 4 1 5 N5|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N5 5 4 2 7 1 6 3 0 N0|"
-                "N2 2 5 0 3 7 4 6 1 N1|"
+               "N4 4 7 0 6 5 2 1 3 N3|"
+               "N6 6 2 0 7 5 3 1 4 N4|"
+               "N7 7 3 2 6 0 4 1 5 N5|"
+               "N1 1 0 2 4 3 5 7 6 N6|"
+               "N0 0 1 2 3 4 5 6 7 N7|"
+               "N5 5 4 2 7 1 6 3 0 N0|"
+               "N2 2 5 0 3 7 4 6 1 N1|"
+               "N3 3 6 4 0 5 1 7 2 N2|"
 
-                "N4 4 7 0 6 5 2 1 3 N3|"
-                "N6 6 2 0 7 5 3 1 4 N4|"
-                "N7 7 3 2 6 0 4 1 5 N5|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N5 5 4 2 7 1 6 3 0 N0|"
-                "N2 2 5 0 3 7 4 6 1 N1|"
-                "N3 3 6 4 0 5 1 7 2 N2|"
+               "N6 6 2 0 7 5 3 1 4 N4|"
+               "N7 7 3 2 6 0 4 1 5 N5|"
+               "N1 1 0 2 4 3 5 7 6 N6|"
+               "N0 0 1 2 3 4 5 6 7 N7|"
+               "N5 5 4 2 7 1 6 3 0 N0|"
+               "N2 2 5 0 3 7 4 6 1 N1|"
+               "N3 3 6 4 0 5 1 7 2 N2|"
+               "N4 4 7 0 6 5 2 1 3 N3|"
 
-                "N6 6 2 0 7 5 3 1 4 N4|"
-                "N7 7 3 2 6 0 4 1 5 N5|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N5 5 4 2 7 1 6 3 0 N0|"
-                "N2 2 5 0 3 7 4 6 1 N1|"
-                "N3 3 6 4 0 5 1 7 2 N2|"
-                "N4 4 7 0 6 5 2 1 3 N3|"
+               "N7 7 3 2 6 0 4 1 5 N5|"
+               "N1 1 0 2 4 3 5 7 6 N6|"
+               "N0 0 1 2 3 4 5 6 7 N7|"
+               "N5 5 4 2 7 1 6 3 0 N0|"
+               "N2 2 5 0 3 7 4 6 1 N1|"
+               "N3 3 6 4 0 5 1 7 2 N2|"
+               "N4 4 7 0 6 5 2 1 3 N3|"
+               "N6 6 2 0 7 5 3 1 4 N4|"
 
-                "N7 7 3 2 6 0 4 1 5 N5|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N5 5 4 2 7 1 6 3 0 N0|"
-                "N2 2 5 0 3 7 4 6 1 N1|"
-                "N3 3 6 4 0 5 1 7 2 N2|"
-                "N4 4 7 0 6 5 2 1 3 N3|"
-                "N6 6 2 0 7 5 3 1 4 N4|"
+               "N1 1 0 2 4 3 5 7 6 N6|"
+               "N0 0 1 2 3 4 5 6 7 N7|"
+               "N5 5 4 2 7 1 6 3 0 N0|"
+               "N2 2 5 0 3 7 4 6 1 N1|"
+               "N3 3 6 4 0 5 1 7 2 N2|"
+               "N4 4 7 0 6 5 2 1 3 N3|"
+               "N6 6 2 0 7 5 3 1 4 N4|"
+               "N7 7 3 2 6 0 4 1 5 N5|"
 
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N5 5 4 2 7 1 6 3 0 N0|"
-                "N2 2 5 0 3 7 4 6 1 N1|"
-                "N3 3 6 4 0 5 1 7 2 N2|"
-                "N4 4 7 0 6 5 2 1 3 N3|"
-                "N6 6 2 0 7 5 3 1 4 N4|"
-                "N7 7 3 2 6 0 4 1 5 N5|"
+               "N0 0 1 2 3 4 5 6 7 N7|"
+               "N5 5 4 2 7 1 6 3 0 N0|"
+               "N2 2 5 0 3 7 4 6 1 N1|"
+               "N3 3 6 4 0 5 1 7 2 N2|"
+               "N4 4 7 0 6 5 2 1 3 N3|"
+               "N6 6 2 0 7 5 3 1 4 N4|"
+               "N7 7 3 2 6 0 4 1 5 N5|"
+               "N1 1 0 2 4 3 5 7 6 N6|",
 
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N5 5 4 2 7 1 6 3 0 N0|"
-                "N2 2 5 0 3 7 4 6 1 N1|"
-                "N3 3 6 4 0 5 1 7 2 N2|"
-                "N4 4 7 0 6 5 2 1 3 N3|"
-                "N6 6 2 0 7 5 3 1 4 N4|"
-                "N7 7 3 2 6 0 4 1 5 N5|"
-                "N1 1 0 2 4 3 5 7 6 N6|",
+  .options = "noCpuCheck=1,tuning=5,ll128Enabled=1,disableNumaMatching=1",
 
-  .options    = "noCpuCheck=1,tuning=5,ll128Enabled=1,disableNumaMatching=1",
+  .treeRail = "N0 0 1 2 4 3 6 5 7 N1|"
+              "N1 1 0 4 7 3 5 2 6 N0|"
+              "N2 2 3 0 5 6 1 7 4 N3|"
+              "N3 3 2 7 0 6 4 1 5 N2|"
+              "N4 4 5 1 6 0 3 7 2 N5|"
+              "N5 5 4 6 2 0 7 1 3 N4|"
+              "N6 6 7 5 3 4 0 2 1 N7|"
+              "N7 7 6 3 1 4 2 5 0 N6|"
 
-  .treeRail   = "N0 0 1 2 4 3 6 5 7 N1|"
-                "N1 1 0 4 7 3 5 2 6 N0|"
-                "N2 2 3 0 5 6 1 7 4 N3|"
-                "N3 3 2 7 0 6 4 1 5 N2|"
-                "N4 4 5 1 6 0 3 7 2 N5|"
-                "N5 5 4 6 2 0 7 1 3 N4|"
-                "N6 6 7 5 3 4 0 2 1 N7|"
-                "N7 7 6 3 1 4 2 5 0 N6|"
+              "N2 2 3 0 5 6 1 7 4 N3|"
+              "N3 3 2 7 0 6 4 1 5 N2|"
+              "N4 4 5 1 6 0 3 7 2 N5|"
+              "N5 5 4 6 2 0 7 1 3 N4|"
+              "N6 6 7 5 3 4 0 2 1 N7|"
+              "N7 7 6 3 1 4 2 5 0 N6|"
+              "N0 0 1 2 4 3 6 5 7 N1|"
+              "N1 1 0 4 7 3 5 2 6 N0|"
 
-                "N2 2 3 0 5 6 1 7 4 N3|"
-                "N3 3 2 7 0 6 4 1 5 N2|"
-                "N4 4 5 1 6 0 3 7 2 N5|"
-                "N5 5 4 6 2 0 7 1 3 N4|"
-                "N6 6 7 5 3 4 0 2 1 N7|"
-                "N7 7 6 3 1 4 2 5 0 N6|"
-                "N0 0 1 2 4 3 6 5 7 N1|"
-                "N1 1 0 4 7 3 5 2 6 N0|"
+              "N4 4 5 1 6 0 3 7 2 N5|"
+              "N5 5 4 6 2 0 7 1 3 N4|"
+              "N6 6 7 5 3 4 0 2 1 N7|"
+              "N7 7 6 3 1 4 2 5 0 N6|"
+              "N0 0 1 2 4 3 6 5 7 N1|"
+              "N1 1 0 4 7 3 5 2 6 N0|"
+              "N2 2 3 0 5 6 1 7 4 N3|"
+              "N3 3 2 7 0 6 4 1 5 N2|"
 
-                "N4 4 5 1 6 0 3 7 2 N5|"
-                "N5 5 4 6 2 0 7 1 3 N4|"
-                "N6 6 7 5 3 4 0 2 1 N7|"
-                "N7 7 6 3 1 4 2 5 0 N6|"
-                "N0 0 1 2 4 3 6 5 7 N1|"
-                "N1 1 0 4 7 3 5 2 6 N0|"
-                "N2 2 3 0 5 6 1 7 4 N3|"
-                "N3 3 2 7 0 6 4 1 5 N2|"
+              "N6 6 7 5 3 4 0 2 1 N7|"
+              "N7 7 6 3 1 4 2 5 0 N6|"
+              "N0 0 1 2 4 3 6 5 7 N1|"
+              "N1 1 0 4 7 3 5 2 6 N0|"
+              "N2 2 3 0 5 6 1 7 4 N3|"
+              "N3 3 2 7 0 6 4 1 5 N2|"
+              "N4 4 5 1 6 0 3 7 2 N5|"
+              "N5 5 4 6 2 0 7 1 3 N4|"
 
-                "N6 6 7 5 3 4 0 2 1 N7|"
-                "N7 7 6 3 1 4 2 5 0 N6|"
-                "N0 0 1 2 4 3 6 5 7 N1|"
-                "N1 1 0 4 7 3 5 2 6 N0|"
-                "N2 2 3 0 5 6 1 7 4 N3|"
-                "N3 3 2 7 0 6 4 1 5 N2|"
-                "N4 4 5 1 6 0 3 7 2 N5|"
-                "N5 5 4 6 2 0 7 1 3 N4|"
+              "N0 0 1 2 4 3 6 5 7 N1|"
+              "N1 1 0 4 7 3 5 2 6 N0|"
+              "N2 2 3 0 5 6 1 7 4 N3|"
+              "N3 3 2 7 0 6 4 1 5 N2|"
+              "N4 4 5 1 6 0 3 7 2 N5|"
+              "N5 5 4 6 2 0 7 1 3 N4|"
+              "N6 6 7 5 3 4 0 2 1 N7|"
+              "N7 7 6 3 1 4 2 5 0 N6|"
 
-                "N0 0 1 2 4 3 6 5 7 N1|"
-                "N1 1 0 4 7 3 5 2 6 N0|"
-                "N2 2 3 0 5 6 1 7 4 N3|"
-                "N3 3 2 7 0 6 4 1 5 N2|"
-                "N4 4 5 1 6 0 3 7 2 N5|"
-                "N5 5 4 6 2 0 7 1 3 N4|"
-                "N6 6 7 5 3 4 0 2 1 N7|"
-                "N7 7 6 3 1 4 2 5 0 N6|"
+              "N2 2 3 0 5 6 1 7 4 N3|"
+              "N3 3 2 7 0 6 4 1 5 N2|"
+              "N4 4 5 1 6 0 3 7 2 N5|"
+              "N5 5 4 6 2 0 7 1 3 N4|"
+              "N6 6 7 5 3 4 0 2 1 N7|"
+              "N7 7 6 3 1 4 2 5 0 N6|"
+              "N0 0 1 2 4 3 6 5 7 N1|"
+              "N1 1 0 4 7 3 5 2 6 N0|"
 
-                "N2 2 3 0 5 6 1 7 4 N3|"
-                "N3 3 2 7 0 6 4 1 5 N2|"
-                "N4 4 5 1 6 0 3 7 2 N5|"
-                "N5 5 4 6 2 0 7 1 3 N4|"
-                "N6 6 7 5 3 4 0 2 1 N7|"
-                "N7 7 6 3 1 4 2 5 0 N6|"
-                "N0 0 1 2 4 3 6 5 7 N1|"
-                "N1 1 0 4 7 3 5 2 6 N0|"
+              "N4 4 5 1 6 0 3 7 2 N5|"
+              "N5 5 4 6 2 0 7 1 3 N4|"
+              "N6 6 7 5 3 4 0 2 1 N7|"
+              "N7 7 6 3 1 4 2 5 0 N6|"
+              "N0 0 1 2 4 3 6 5 7 N1|"
+              "N1 1 0 4 7 3 5 2 6 N0|"
+              "N2 2 3 0 5 6 1 7 4 N3|"
+              "N3 3 2 7 0 6 4 1 5 N2|"
 
-                "N4 4 5 1 6 0 3 7 2 N5|"
-                "N5 5 4 6 2 0 7 1 3 N4|"
-                "N6 6 7 5 3 4 0 2 1 N7|"
-                "N7 7 6 3 1 4 2 5 0 N6|"
-                "N0 0 1 2 4 3 6 5 7 N1|"
-                "N1 1 0 4 7 3 5 2 6 N0|"
-                "N2 2 3 0 5 6 1 7 4 N3|"
-                "N3 3 2 7 0 6 4 1 5 N2|"
-
-                "N6 6 7 5 3 4 0 2 1 N7|"
-                "N7 7 6 3 1 4 2 5 0 N6|"
-                "N0 0 1 2 4 3 6 5 7 N1|"
-                "N1 1 0 4 7 3 5 2 6 N0|"
-                "N2 2 3 0 5 6 1 7 4 N3|"
-                "N3 3 2 7 0 6 4 1 5 N2|"
-                "N4 4 5 1 6 0 3 7 2 N5|"
-                "N5 5 4 6 2 0 7 1 3 N4|",
+              "N6 6 7 5 3 4 0 2 1 N7|"
+              "N7 7 6 3 1 4 2 5 0 N6|"
+              "N0 0 1 2 4 3 6 5 7 N1|"
+              "N1 1 0 4 7 3 5 2 6 N0|"
+              "N2 2 3 0 5 6 1 7 4 N3|"
+              "N3 3 2 7 0 6 4 1 5 N2|"
+              "N4 4 5 1 6 0 3 7 2 N5|"
+              "N5 5 4 6 2 0 7 1 3 N4|",
 };
 
 static struct rcclRomeModel rome_model_84 = {
-  .nGpus = 8, .nCpus = 2, .nNics = 16, .nLinks = 7,
-  .gpuIds = { 0x11000, 0x2f000, 0x46000, 0x5d000, 0x8b000, 0xaa000, 0xc2000, 0xda000, },
-  .nicIds = { 0xc000, 0xc000, 0x2a000, 0x2a000, 0x41000, 0x41000, 0x58000, 0x58000, 0x86000, 0x86000, 0xa5000, 0xa5000, 0xbd000, 0xbd000, 0xd5000, 0xd5000, },
-  .gpuNuma = { 0, 0, 0, 0, 1, 1, 1, 1, },
-  .nicNuma = { 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, },
-  .connMatrix = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, },
-  .gdrLevel = { PATH_PXB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, },
+  .nGpus = 8,
+  .nCpus = 2,
+  .nNics = 16,
+  .nLinks = 7,
+  .gpuIds =
+    {
+      0x11000,
+      0x2f000,
+      0x46000,
+      0x5d000,
+      0x8b000,
+      0xaa000,
+      0xc2000,
+      0xda000,
+    },
+  .nicIds =
+    {
+      0xc000,
+      0xc000,
+      0x2a000,
+      0x2a000,
+      0x41000,
+      0x41000,
+      0x58000,
+      0x58000,
+      0x86000,
+      0x86000,
+      0xa5000,
+      0xa5000,
+      0xbd000,
+      0xbd000,
+      0xd5000,
+      0xd5000,
+    },
+  .gpuNuma =
+    {
+      0,
+      0,
+      0,
+      0,
+      1,
+      1,
+      1,
+      1,
+    },
+  .nicNuma =
+    {
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+    },
+  .connMatrix =
+    {
+      0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1,
+      1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0,
+    },
+  .gdrLevel =
+    {
+      PATH_PXB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PHB, PATH_PHB,
+      PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS,
+      PATH_SYS, PATH_SYS, PATH_PHB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB,
+      PATH_PHB, PATH_PXB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PHB,
+      PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS,
+      PATH_SYS, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS,
+      PATH_SYS, PATH_SYS, PATH_PXB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB,
+      PATH_PHB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PXB, PATH_PHB, PATH_PHB,
+      PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS,
+      PATH_SYS, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB,
+      PATH_PXB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_SYS,
+      PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB,
+    },
   .pattern = "4848",
-  .ringBase = "N0 0 1 2 3 4 5 6 7 N14|N2 1 0 2 4 3 5 7 6 N12|N4 2 5 0 3 7 1 6 4 N8|N6 3 6 1 5 2 7 4 0 N0|N8 4 7 0 6 5 1 3 2 N4|N10 5 4 6 3 0 7 2 1 N2|N12 6 2 0 4 1 7 5 3 N6|N14 7 3 1 4 2 6 0 5 N10|N1 0 1 2 3 4 5 6 7 N15|N3 1 0 2 4 3 5 7 6 N13|N5 2 5 0 3 7 1 6 4 N9|N7 3 6 1 5 2 7 4 0 N1|N9 4 7 0 6 5 1 3 2 N5|N11 5 4 6 3 0 7 2 1 N3|N13 6 2 0 4 1 7 5 3 N7|N15 7 3 1 4 2 6 0 5 N11",
+  .ringBase = "N0 0 1 2 3 4 5 6 7 N14|N2 1 0 2 4 3 5 7 6 N12|N4 2 5 0 3 7 1 6 4 N8|N6 3 6 1 5 2 7 4 0 N0|N8 4 7 0 6 5 "
+              "1 3 2 N4|N10 5 4 6 3 0 7 2 1 N2|N12 6 2 0 4 1 7 5 3 N6|N14 7 3 1 4 2 6 0 5 N10|N1 0 1 2 3 4 5 6 7 "
+              "N15|N3 1 0 2 4 3 5 7 6 N13|N5 2 5 0 3 7 1 6 4 N9|N7 3 6 1 5 2 7 4 0 N1|N9 4 7 0 6 5 1 3 2 N5|N11 5 4 6 "
+              "3 0 7 2 1 N3|N13 6 2 0 4 1 7 5 3 N7|N15 7 3 1 4 2 6 0 5 N11",
   .options = "noCpuCheck=1,tuning=5",
 };
 
 static struct rcclRomeModel rome_model_85 = {
-  .nGpus = 8, .nCpus = 2, .nNics = 4, .nLinks = 3,
-  .gpuIds = { 0x32000, 0x35000, 0x11000, 0x14000, 0xae000, 0xb3000, 0x8e000, 0x93000, },
-  .nicIds = { 0x2d000, 0x5000, 0xab000, 0x94000, },
-  .gpuNuma = { 0, 0, 0, 0, 1, 1, 1, 1, },
-  .nicNuma = { 0, 0, 1, 1, },
-  .connMatrix = { 0, 4, 1, 0, 0, 0, 2, 0, 4, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 4, 2, 0, 0, 0, 0, 1, 4, 0, 0, 0, 0, 1, 0, 0, 2, 0, 0, 4, 1, 0, 0, 1, 0, 0, 4, 0, 0, 1, 2, 0, 0, 0, 1, 0, 0, 4, 0, 0, 0, 1, 0, 1, 4, 0, },
-  .gdrLevel = { PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, },
+  .nGpus = 8,
+  .nCpus = 2,
+  .nNics = 4,
+  .nLinks = 3,
+  .gpuIds =
+    {
+      0x32000,
+      0x35000,
+      0x11000,
+      0x14000,
+      0xae000,
+      0xb3000,
+      0x8e000,
+      0x93000,
+    },
+  .nicIds =
+    {
+      0x2d000,
+      0x5000,
+      0xab000,
+      0x94000,
+    },
+  .gpuNuma =
+    {
+      0,
+      0,
+      0,
+      0,
+      1,
+      1,
+      1,
+      1,
+    },
+  .nicNuma =
+    {
+      0,
+      0,
+      1,
+      1,
+    },
+  .connMatrix =
+    {
+      0, 4, 1, 0, 0, 0, 2, 0, 4, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 4, 2, 0, 0, 0, 0, 1, 4, 0, 0, 0, 0, 1,
+      0, 0, 2, 0, 0, 4, 1, 0, 0, 1, 0, 0, 4, 0, 0, 1, 2, 0, 0, 0, 1, 0, 0, 4, 0, 0, 0, 1, 0, 1, 4, 0,
+    },
+  .gdrLevel =
+    {
+      PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PXB,
+      PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB,
+      PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB,
+    },
   .pattern = "4242",
-  .ringBase = "N0 0 1 3 2 4 5 7 6 N3|N1 2 3 1 0 6 7 5 4 N2|N3 7 6 0 1 5 4 2 3 N1|N0 1 0 6 7 3 2 4 5 N2|N2 4 5 7 6 0 1 3 2 N1|N3 6 7 5 4 2 3 1 0 N0|N2 5 4 2 3 7 6 0 1 N0|N1 3 2 4 5 1 0 6 7 N3",
+  .ringBase = "N0 0 1 3 2 4 5 7 6 N3|N1 2 3 1 0 6 7 5 4 N2|N3 7 6 0 1 5 4 2 3 N1|N0 1 0 6 7 3 2 4 5 N2|N2 4 5 7 6 0 1 "
+              "3 2 N1|N3 6 7 5 4 2 3 1 0 N0|N2 5 4 2 3 7 6 0 1 N0|N1 3 2 4 5 1 0 6 7 N3",
   .options = "tuning=2",
 };
 
 static struct rcclRomeModel rome_model_87 = {
-  .nGpus = 8, .nCpus = 2, .nNics = 4, .nLinks = 7,
-  .gpuIds = { 0xa000, 0x80000, 0xa4000, 0xc8000, 0x10b000, 0x181000, 0x1a5000, 0x1c9000, },
-  .nicIds = { 0xc9000, 0x1a2000, 0x108000, 0x81000, },
-  .gpuNuma = { 0, 0, 0, 0, 1, 1, 1, 1, },
-  .nicNuma = { 0, 1, 1, 0, },
-  .connMatrix = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, },
-  .gdrLevel = { PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, },
+  .nGpus = 8,
+  .nCpus = 2,
+  .nNics = 4,
+  .nLinks = 7,
+  .gpuIds =
+    {
+      0xa000,
+      0x80000,
+      0xa4000,
+      0xc8000,
+      0x10b000,
+      0x181000,
+      0x1a5000,
+      0x1c9000,
+    },
+  .nicIds =
+    {
+      0xc9000,
+      0x1a2000,
+      0x108000,
+      0x81000,
+    },
+  .gpuNuma =
+    {
+      0,
+      0,
+      0,
+      0,
+      1,
+      1,
+      1,
+      1,
+    },
+  .nicNuma =
+    {
+      0,
+      1,
+      1,
+      0,
+    },
+  .connMatrix =
+    {
+      0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1,
+      1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0,
+    },
+  .gdrLevel =
+    {
+      PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS,
+      PATH_SYS, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PHB,
+      PATH_PHB, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS,
+    },
   .pattern = "4242",
   .ringBase = "N3 0 1 2 3 4 5 6 7 N1|"
               "N3 1 0 2 4 3 5 7 6 N1|"
@@ -1142,87 +3065,131 @@ static struct rcclRomeModel rome_model_87 = {
 
   .options = "noCpuCheck=1,netOverride=1,tuning=5,ll128Enabled=1",
 
-  .treeRail =  "N3 0 1 2 4 3 6 5 7 N1|"
-               "N3 1 0 4 7 3 5 2 6 N1|"
-               "N0 2 3 0 5 6 1 7 4 N2|"
-               "N0 3 2 7 0 6 4 1 5 N2|"
-               "N2 4 5 1 6 0 3 7 2 N3|"
-               "N2 5 4 6 2 0 7 1 3 N3|"
-               "N1 6 7 5 3 4 0 2 1 N0|"
-               "N1 7 6 3 1 4 2 5 0 N0|"
+  .treeRail = "N3 0 1 2 4 3 6 5 7 N1|"
+              "N3 1 0 4 7 3 5 2 6 N1|"
+              "N0 2 3 0 5 6 1 7 4 N2|"
+              "N0 3 2 7 0 6 4 1 5 N2|"
+              "N2 4 5 1 6 0 3 7 2 N3|"
+              "N2 5 4 6 2 0 7 1 3 N3|"
+              "N1 6 7 5 3 4 0 2 1 N0|"
+              "N1 7 6 3 1 4 2 5 0 N0|"
 
-               "N0 2 3 0 5 6 1 7 4 N2|"
-               "N0 3 2 7 0 6 4 1 5 N2|"
-               "N2 4 5 1 6 0 3 7 2 N3|"
-               "N2 5 4 6 2 0 7 1 3 N3|"
-               "N1 6 7 5 3 4 0 2 1 N0|"
-               "N1 7 6 3 1 4 2 5 0 N0|"
-               "N3 0 1 2 4 3 6 5 7 N1|"
-               "N3 1 0 4 7 3 5 2 6 N1|"
+              "N0 2 3 0 5 6 1 7 4 N2|"
+              "N0 3 2 7 0 6 4 1 5 N2|"
+              "N2 4 5 1 6 0 3 7 2 N3|"
+              "N2 5 4 6 2 0 7 1 3 N3|"
+              "N1 6 7 5 3 4 0 2 1 N0|"
+              "N1 7 6 3 1 4 2 5 0 N0|"
+              "N3 0 1 2 4 3 6 5 7 N1|"
+              "N3 1 0 4 7 3 5 2 6 N1|"
 
-               "N2 4 5 1 6 0 3 7 2 N3|"
-               "N2 5 4 6 2 0 7 1 3 N3|"
-               "N1 6 7 5 3 4 0 2 1 N0|"
-               "N1 7 6 3 1 4 2 5 0 N0|"
-               "N3 0 1 2 4 3 6 5 7 N1|"
-               "N3 1 0 4 7 3 5 2 6 N1|"
-               "N0 2 3 0 5 6 1 7 4 N2|"
-               "N0 3 2 7 0 6 4 1 5 N2|"
+              "N2 4 5 1 6 0 3 7 2 N3|"
+              "N2 5 4 6 2 0 7 1 3 N3|"
+              "N1 6 7 5 3 4 0 2 1 N0|"
+              "N1 7 6 3 1 4 2 5 0 N0|"
+              "N3 0 1 2 4 3 6 5 7 N1|"
+              "N3 1 0 4 7 3 5 2 6 N1|"
+              "N0 2 3 0 5 6 1 7 4 N2|"
+              "N0 3 2 7 0 6 4 1 5 N2|"
 
-               "N1 6 7 5 3 4 0 2 1 N0|"
-               "N1 7 6 3 1 4 2 5 0 N0|"
-               "N3 0 1 2 4 3 6 5 7 N1|"
-               "N3 1 0 4 7 3 5 2 6 N1|"
-               "N0 2 3 0 5 6 1 7 4 N2|"
-               "N0 3 2 7 0 6 4 1 5 N2|"
-               "N2 4 5 1 6 0 3 7 2 N3|"
-               "N2 5 4 6 2 0 7 1 3 N3|"
+              "N1 6 7 5 3 4 0 2 1 N0|"
+              "N1 7 6 3 1 4 2 5 0 N0|"
+              "N3 0 1 2 4 3 6 5 7 N1|"
+              "N3 1 0 4 7 3 5 2 6 N1|"
+              "N0 2 3 0 5 6 1 7 4 N2|"
+              "N0 3 2 7 0 6 4 1 5 N2|"
+              "N2 4 5 1 6 0 3 7 2 N3|"
+              "N2 5 4 6 2 0 7 1 3 N3|"
 
-               "N3 0 1 2 4 3 6 5 7 N1|"
-               "N3 1 0 4 7 3 5 2 6 N1|"
-               "N0 2 3 0 5 6 1 7 4 N2|"
-               "N0 3 2 7 0 6 4 1 5 N2|"
-               "N2 4 5 1 6 0 3 7 2 N3|"
-               "N2 5 4 6 2 0 7 1 3 N3|"
-               "N1 6 7 5 3 4 0 2 1 N0|"
-               "N1 7 6 3 1 4 2 5 0 N0|"
+              "N3 0 1 2 4 3 6 5 7 N1|"
+              "N3 1 0 4 7 3 5 2 6 N1|"
+              "N0 2 3 0 5 6 1 7 4 N2|"
+              "N0 3 2 7 0 6 4 1 5 N2|"
+              "N2 4 5 1 6 0 3 7 2 N3|"
+              "N2 5 4 6 2 0 7 1 3 N3|"
+              "N1 6 7 5 3 4 0 2 1 N0|"
+              "N1 7 6 3 1 4 2 5 0 N0|"
 
-               "N0 2 3 0 5 6 1 7 4 N2|"
-               "N0 3 2 7 0 6 4 1 5 N2|"
-               "N2 4 5 1 6 0 3 7 2 N3|"
-               "N2 5 4 6 2 0 7 1 3 N3|"
-               "N1 6 7 5 3 4 0 2 1 N0|"
-               "N1 7 6 3 1 4 2 5 0 N0|"
-               "N3 0 1 2 4 3 6 5 7 N1|"
-               "N3 1 0 4 7 3 5 2 6 N1|"
+              "N0 2 3 0 5 6 1 7 4 N2|"
+              "N0 3 2 7 0 6 4 1 5 N2|"
+              "N2 4 5 1 6 0 3 7 2 N3|"
+              "N2 5 4 6 2 0 7 1 3 N3|"
+              "N1 6 7 5 3 4 0 2 1 N0|"
+              "N1 7 6 3 1 4 2 5 0 N0|"
+              "N3 0 1 2 4 3 6 5 7 N1|"
+              "N3 1 0 4 7 3 5 2 6 N1|"
 
-               "N2 4 5 1 6 0 3 7 2 N3|"
-               "N2 5 4 6 2 0 7 1 3 N3|"
-               "N1 6 7 5 3 4 0 2 1 N0|"
-               "N1 7 6 3 1 4 2 5 0 N0|"
-               "N3 0 1 2 4 3 6 5 7 N1|"
-               "N3 1 0 4 7 3 5 2 6 N1|"
-               "N0 2 3 0 5 6 1 7 4 N2|"
-               "N0 3 2 7 0 6 4 1 5 N2|"
+              "N2 4 5 1 6 0 3 7 2 N3|"
+              "N2 5 4 6 2 0 7 1 3 N3|"
+              "N1 6 7 5 3 4 0 2 1 N0|"
+              "N1 7 6 3 1 4 2 5 0 N0|"
+              "N3 0 1 2 4 3 6 5 7 N1|"
+              "N3 1 0 4 7 3 5 2 6 N1|"
+              "N0 2 3 0 5 6 1 7 4 N2|"
+              "N0 3 2 7 0 6 4 1 5 N2|"
 
-               "N1 6 7 5 3 4 0 2 1 N0|"
-               "N1 7 6 3 1 4 2 5 0 N0|"
-               "N3 0 1 2 4 3 6 5 7 N1|"
-               "N3 1 0 4 7 3 5 2 6 N1|"
-               "N0 2 3 0 5 6 1 7 4 N2|"
-               "N0 3 2 7 0 6 4 1 5 N2|"
-               "N2 4 5 1 6 0 3 7 2 N3|"
-               "N2 5 4 6 2 0 7 1 3 N3|",
+              "N1 6 7 5 3 4 0 2 1 N0|"
+              "N1 7 6 3 1 4 2 5 0 N0|"
+              "N3 0 1 2 4 3 6 5 7 N1|"
+              "N3 1 0 4 7 3 5 2 6 N1|"
+              "N0 2 3 0 5 6 1 7 4 N2|"
+              "N0 3 2 7 0 6 4 1 5 N2|"
+              "N2 4 5 1 6 0 3 7 2 N3|"
+              "N2 5 4 6 2 0 7 1 3 N3|",
 };
 
 static struct rcclRomeModel rome_model_88 = {
-  .nGpus = 8, .nCpus = 2, .nNics = 4, .nLinks = 7,
-  .gpuIds = { 0x5000, 0x25000, 0x45000, 0x65000, 0x85000, 0xa5000, 0xc5000, 0xe5000, },
-  .nicIds = { 0x9000, 0x49000, 0x89000, 0xc9000, },
-  .gpuNuma = { 0, 0, 0, 0, 1, 1, 1, 1, },
-  .nicNuma = { 0, 0, 1, 1, },
-  .connMatrix = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, },
-  .gdrLevel = { PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, },
+  .nGpus = 8,
+  .nCpus = 2,
+  .nNics = 4,
+  .nLinks = 7,
+  .gpuIds =
+    {
+      0x5000,
+      0x25000,
+      0x45000,
+      0x65000,
+      0x85000,
+      0xa5000,
+      0xc5000,
+      0xe5000,
+    },
+  .nicIds =
+    {
+      0x9000,
+      0x49000,
+      0x89000,
+      0xc9000,
+    },
+  .gpuNuma =
+    {
+      0,
+      0,
+      0,
+      0,
+      1,
+      1,
+      1,
+      1,
+    },
+  .nicNuma =
+    {
+      0,
+      0,
+      1,
+      1,
+    },
+  .connMatrix =
+    {
+      0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1,
+      1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0,
+    },
+  .gdrLevel =
+    {
+      PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PXB,
+      PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB,
+      PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB,
+    },
   .pattern = "4242",
   .ringBase = "N0 0 1 2 3 4 5 6 7 N3|"
               "N0 1 0 2 4 3 5 7 6 N3|"
@@ -1444,318 +3411,358 @@ static struct rcclRomeModel rome_model_88 = {
 };
 
 static struct rcclRomeModel rome_model_89 = {
-  .nGpus = 8, .nCpus = 2, .nNics = 8, .nLinks = 7,
-  .gpuIds     = { 0xc000, 0x22000, 0x38000, 0x5c000, 0x9f000, 0xaf000, 0xbf000, 0xdf000, },
-  .nicIds     = { 0x7000, 0x1d000, 0x33000, 0x57000, 0x9a000, 0xaa000, 0xba000, 0xda000, },
-  .gpuNuma    = { 0, 0, 0, 0, 1, 1, 1, 1, },
-  .nicNuma    = { 0, 0, 0, 0, 1, 1, 1, 1, },
-  .connMatrix = { 0, 1, 1, 1, 1, 1, 1, 1,
-                  1, 0, 1, 1, 1, 1, 1, 1,
-                  1, 1, 0, 1, 1, 1, 1, 1,
-                  1, 1, 1, 0, 1, 1, 1, 1,
-                  1, 1, 1, 1, 0, 1, 1, 1,
-                  1, 1, 1, 1, 1, 0, 1, 1,
-                  1, 1, 1, 1, 1, 1, 0, 1,
-                  1, 1, 1, 1, 1, 1, 1, 0, },
-  .gdrLevel   = {PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS,
-                 PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS,
-                 PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS,
-                 PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS,
-                 PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB,
-                 PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB,
-                 PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB,
-                 PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, },
-  .pattern    = "4444",
-  .ringBase   = "N0 0 1 2 3 4 5 6 7 N7|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N2 2 5 0 3 6 1 7 4 N4|"
-                "N3 3 7 0 4 2 1 6 5 N5|"
-                "N4 4 6 2 7 3 0 5 1 N1|"
-                "N5 5 4 7 1 3 2 6 0 N0|"
-                "N6 6 3 1 4 0 7 5 2 N2|"
-                "N7 7 2 0 6 4 1 5 3 N3|"
+  .nGpus = 8,
+  .nCpus = 2,
+  .nNics = 8,
+  .nLinks = 7,
+  .gpuIds =
+    {
+      0xc000,
+      0x22000,
+      0x38000,
+      0x5c000,
+      0x9f000,
+      0xaf000,
+      0xbf000,
+      0xdf000,
+    },
+  .nicIds =
+    {
+      0x7000,
+      0x1d000,
+      0x33000,
+      0x57000,
+      0x9a000,
+      0xaa000,
+      0xba000,
+      0xda000,
+    },
+  .gpuNuma =
+    {
+      0,
+      0,
+      0,
+      0,
+      1,
+      1,
+      1,
+      1,
+    },
+  .nicNuma =
+    {
+      0,
+      0,
+      0,
+      0,
+      1,
+      1,
+      1,
+      1,
+    },
+  .connMatrix =
+    {
+      0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1,
+      1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0,
+    },
+  .gdrLevel =
+    {
+      PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB, PATH_PHB,
+      PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS,
+      PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS,
+      PATH_SYS, PATH_SYS, PATH_SYS, PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS,
+      PATH_PXB, PATH_PXB, PATH_PHB, PATH_PHB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PXB,
+      PATH_PXB, PATH_SYS, PATH_SYS, PATH_SYS, PATH_SYS, PATH_PHB, PATH_PHB, PATH_PXB, PATH_PXB,
+    },
+  .pattern = "4444",
+  .ringBase = "N0 0 1 2 3 4 5 6 7 N7|"
+              "N1 1 0 2 4 3 5 7 6 N6|"
+              "N2 2 5 0 3 6 1 7 4 N4|"
+              "N3 3 7 0 4 2 1 6 5 N5|"
+              "N4 4 6 2 7 3 0 5 1 N1|"
+              "N5 5 4 7 1 3 2 6 0 N0|"
+              "N6 6 3 1 4 0 7 5 2 N2|"
+              "N7 7 2 0 6 4 1 5 3 N3|"
 
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N2 2 5 0 3 6 1 7 4 N4|"
-                "N3 3 7 0 4 2 1 6 5 N5|"
-                "N4 4 6 2 7 3 0 5 1 N1|"
-                "N5 5 4 7 1 3 2 6 0 N0|"
-                "N6 6 3 1 4 0 7 5 2 N2|"
-                "N7 7 2 0 6 4 1 5 3 N3|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
+              "N1 1 0 2 4 3 5 7 6 N6|"
+              "N2 2 5 0 3 6 1 7 4 N4|"
+              "N3 3 7 0 4 2 1 6 5 N5|"
+              "N4 4 6 2 7 3 0 5 1 N1|"
+              "N5 5 4 7 1 3 2 6 0 N0|"
+              "N6 6 3 1 4 0 7 5 2 N2|"
+              "N7 7 2 0 6 4 1 5 3 N3|"
+              "N0 0 1 2 3 4 5 6 7 N7|"
 
-                "N2 2 5 0 3 6 1 7 4 N4|"
-                "N3 3 7 0 4 2 1 6 5 N5|"
-                "N4 4 6 2 7 3 0 5 1 N1|"
-                "N5 5 4 7 1 3 2 6 0 N0|"
-                "N6 6 3 1 4 0 7 5 2 N2|"
-                "N7 7 2 0 6 4 1 5 3 N3|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
+              "N2 2 5 0 3 6 1 7 4 N4|"
+              "N3 3 7 0 4 2 1 6 5 N5|"
+              "N4 4 6 2 7 3 0 5 1 N1|"
+              "N5 5 4 7 1 3 2 6 0 N0|"
+              "N6 6 3 1 4 0 7 5 2 N2|"
+              "N7 7 2 0 6 4 1 5 3 N3|"
+              "N0 0 1 2 3 4 5 6 7 N7|"
+              "N1 1 0 2 4 3 5 7 6 N6|"
 
-                "N3 3 7 0 4 2 1 6 5 N5|"
-                "N4 4 6 2 7 3 0 5 1 N1|"
-                "N5 5 4 7 1 3 2 6 0 N0|"
-                "N6 6 3 1 4 0 7 5 2 N2|"
-                "N7 7 2 0 6 4 1 5 3 N3|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N2 2 5 0 3 6 1 7 4 N4|"
+              "N3 3 7 0 4 2 1 6 5 N5|"
+              "N4 4 6 2 7 3 0 5 1 N1|"
+              "N5 5 4 7 1 3 2 6 0 N0|"
+              "N6 6 3 1 4 0 7 5 2 N2|"
+              "N7 7 2 0 6 4 1 5 3 N3|"
+              "N0 0 1 2 3 4 5 6 7 N7|"
+              "N1 1 0 2 4 3 5 7 6 N6|"
+              "N2 2 5 0 3 6 1 7 4 N4|"
 
-                "N4 4 6 2 7 3 0 5 1 N1|"
-                "N5 5 4 7 1 3 2 6 0 N0|"
-                "N6 6 3 1 4 0 7 5 2 N2|"
-                "N7 7 2 0 6 4 1 5 3 N3|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N2 2 5 0 3 6 1 7 4 N4|"
-                "N3 3 7 0 4 2 1 6 5 N5|"
+              "N4 4 6 2 7 3 0 5 1 N1|"
+              "N5 5 4 7 1 3 2 6 0 N0|"
+              "N6 6 3 1 4 0 7 5 2 N2|"
+              "N7 7 2 0 6 4 1 5 3 N3|"
+              "N0 0 1 2 3 4 5 6 7 N7|"
+              "N1 1 0 2 4 3 5 7 6 N6|"
+              "N2 2 5 0 3 6 1 7 4 N4|"
+              "N3 3 7 0 4 2 1 6 5 N5|"
 
-                "N5 5 4 7 1 3 2 6 0 N0|"
-                "N6 6 3 1 4 0 7 5 2 N2|"
-                "N7 7 2 0 6 4 1 5 3 N3|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N2 2 5 0 3 6 1 7 4 N4|"
-                "N3 3 7 0 4 2 1 6 5 N5|"
-                "N4 4 6 2 7 3 0 5 1 N1|"
+              "N5 5 4 7 1 3 2 6 0 N0|"
+              "N6 6 3 1 4 0 7 5 2 N2|"
+              "N7 7 2 0 6 4 1 5 3 N3|"
+              "N0 0 1 2 3 4 5 6 7 N7|"
+              "N1 1 0 2 4 3 5 7 6 N6|"
+              "N2 2 5 0 3 6 1 7 4 N4|"
+              "N3 3 7 0 4 2 1 6 5 N5|"
+              "N4 4 6 2 7 3 0 5 1 N1|"
 
-                "N6 6 3 1 4 0 7 5 2 N2|"
-                "N7 7 2 0 6 4 1 5 3 N3|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N2 2 5 0 3 6 1 7 4 N4|"
-                "N3 3 7 0 4 2 1 6 5 N5|"
-                "N4 4 6 2 7 3 0 5 1 N1|"
-                "N5 5 4 7 1 3 2 6 0 N0|"
+              "N6 6 3 1 4 0 7 5 2 N2|"
+              "N7 7 2 0 6 4 1 5 3 N3|"
+              "N0 0 1 2 3 4 5 6 7 N7|"
+              "N1 1 0 2 4 3 5 7 6 N6|"
+              "N2 2 5 0 3 6 1 7 4 N4|"
+              "N3 3 7 0 4 2 1 6 5 N5|"
+              "N4 4 6 2 7 3 0 5 1 N1|"
+              "N5 5 4 7 1 3 2 6 0 N0|"
 
-                "N7 7 2 0 6 4 1 5 3 N3|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N2 2 5 0 3 6 1 7 4 N4|"
-                "N3 3 7 0 4 2 1 6 5 N5|"
-                "N4 4 6 2 7 3 0 5 1 N1|"
-                "N5 5 4 7 1 3 2 6 0 N0|"
-                "N6 6 3 1 4 0 7 5 2 N2|",
+              "N7 7 2 0 6 4 1 5 3 N3|"
+              "N0 0 1 2 3 4 5 6 7 N7|"
+              "N1 1 0 2 4 3 5 7 6 N6|"
+              "N2 2 5 0 3 6 1 7 4 N4|"
+              "N3 3 7 0 4 2 1 6 5 N5|"
+              "N4 4 6 2 7 3 0 5 1 N1|"
+              "N5 5 4 7 1 3 2 6 0 N0|"
+              "N6 6 3 1 4 0 7 5 2 N2|",
 
-  .ringTail2  = "N7 7 4 1 3 2 0 6 5 N5|"
-                "N6 6 3 0 7 5 1 4 2 N2|"
-                "N4 4 6 2 1 7 0 5 3 N3|"
-                "N5 5 2 7 3 1 6 0 4 N4|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N2 2 5 0 3 6 4 7 1 N1|"
-                "N3 3 7 2 6 1 5 4 0 N0|"
+  .ringTail2 = "N7 7 4 1 3 2 0 6 5 N5|"
+               "N6 6 3 0 7 5 1 4 2 N2|"
+               "N4 4 6 2 1 7 0 5 3 N3|"
+               "N5 5 2 7 3 1 6 0 4 N4|"
+               "N1 1 0 2 4 3 5 7 6 N6|"
+               "N0 0 1 2 3 4 5 6 7 N7|"
+               "N2 2 5 0 3 6 4 7 1 N1|"
+               "N3 3 7 2 6 1 5 4 0 N0|"
 
-                "N6 6 3 0 7 5 1 4 2 N2|"
-                "N4 4 6 2 1 7 0 5 3 N3|"
-                "N5 5 2 7 3 1 6 0 4 N4|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N2 2 5 0 3 6 4 7 1 N1|"
-                "N3 3 7 2 6 1 5 4 0 N0|"
-                "N7 7 4 1 3 2 0 6 5 N5|"
+               "N6 6 3 0 7 5 1 4 2 N2|"
+               "N4 4 6 2 1 7 0 5 3 N3|"
+               "N5 5 2 7 3 1 6 0 4 N4|"
+               "N1 1 0 2 4 3 5 7 6 N6|"
+               "N0 0 1 2 3 4 5 6 7 N7|"
+               "N2 2 5 0 3 6 4 7 1 N1|"
+               "N3 3 7 2 6 1 5 4 0 N0|"
+               "N7 7 4 1 3 2 0 6 5 N5|"
 
-                "N4 4 6 2 1 7 0 5 3 N3|"
-                "N5 5 2 7 3 1 6 0 4 N4|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N2 2 5 0 3 6 4 7 1 N1|"
-                "N3 3 7 2 6 1 5 4 0 N0|"
-                "N7 7 4 1 3 2 0 6 5 N5|"
-                "N6 6 3 0 7 5 1 4 2 N2|"
+               "N4 4 6 2 1 7 0 5 3 N3|"
+               "N5 5 2 7 3 1 6 0 4 N4|"
+               "N1 1 0 2 4 3 5 7 6 N6|"
+               "N0 0 1 2 3 4 5 6 7 N7|"
+               "N2 2 5 0 3 6 4 7 1 N1|"
+               "N3 3 7 2 6 1 5 4 0 N0|"
+               "N7 7 4 1 3 2 0 6 5 N5|"
+               "N6 6 3 0 7 5 1 4 2 N2|"
 
-                "N5 5 2 7 3 1 6 0 4 N4|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N2 2 5 0 3 6 4 7 1 N1|"
-                "N3 3 7 2 6 1 5 4 0 N0|"
-                "N7 7 4 1 3 2 0 6 5 N5|"
-                "N6 6 3 0 7 5 1 4 2 N2|"
-                "N4 4 6 2 1 7 0 5 3 N3|"
+               "N5 5 2 7 3 1 6 0 4 N4|"
+               "N1 1 0 2 4 3 5 7 6 N6|"
+               "N0 0 1 2 3 4 5 6 7 N7|"
+               "N2 2 5 0 3 6 4 7 1 N1|"
+               "N3 3 7 2 6 1 5 4 0 N0|"
+               "N7 7 4 1 3 2 0 6 5 N5|"
+               "N6 6 3 0 7 5 1 4 2 N2|"
+               "N4 4 6 2 1 7 0 5 3 N3|"
 
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N2 2 5 0 3 6 4 7 1 N1|"
-                "N3 3 7 2 6 1 5 4 0 N0|"
-                "N7 7 4 1 3 2 0 6 5 N5|"
-                "N6 6 3 0 7 5 1 4 2 N2|"
-                "N4 4 6 2 1 7 0 5 3 N3|"
-                "N5 5 2 7 3 1 6 0 4 N4|"
+               "N1 1 0 2 4 3 5 7 6 N6|"
+               "N0 0 1 2 3 4 5 6 7 N7|"
+               "N2 2 5 0 3 6 4 7 1 N1|"
+               "N3 3 7 2 6 1 5 4 0 N0|"
+               "N7 7 4 1 3 2 0 6 5 N5|"
+               "N6 6 3 0 7 5 1 4 2 N2|"
+               "N4 4 6 2 1 7 0 5 3 N3|"
+               "N5 5 2 7 3 1 6 0 4 N4|"
 
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N2 2 5 0 3 6 4 7 1 N1|"
-                "N3 3 7 2 6 1 5 4 0 N0|"
-                "N7 7 4 1 3 2 0 6 5 N5|"
-                "N6 6 3 0 7 5 1 4 2 N2|"
-                "N4 4 6 2 1 7 0 5 3 N3|"
-                "N5 5 2 7 3 1 6 0 4 N4|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
+               "N0 0 1 2 3 4 5 6 7 N7|"
+               "N2 2 5 0 3 6 4 7 1 N1|"
+               "N3 3 7 2 6 1 5 4 0 N0|"
+               "N7 7 4 1 3 2 0 6 5 N5|"
+               "N6 6 3 0 7 5 1 4 2 N2|"
+               "N4 4 6 2 1 7 0 5 3 N3|"
+               "N5 5 2 7 3 1 6 0 4 N4|"
+               "N1 1 0 2 4 3 5 7 6 N6|"
 
-                "N2 2 5 0 3 6 4 7 1 N1|"
-                "N3 3 7 2 6 1 5 4 0 N0|"
-                "N7 7 4 1 3 2 0 6 5 N5|"
-                "N6 6 3 0 7 5 1 4 2 N2|"
-                "N4 4 6 2 1 7 0 5 3 N3|"
-                "N5 5 2 7 3 1 6 0 4 N4|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
+               "N2 2 5 0 3 6 4 7 1 N1|"
+               "N3 3 7 2 6 1 5 4 0 N0|"
+               "N7 7 4 1 3 2 0 6 5 N5|"
+               "N6 6 3 0 7 5 1 4 2 N2|"
+               "N4 4 6 2 1 7 0 5 3 N3|"
+               "N5 5 2 7 3 1 6 0 4 N4|"
+               "N1 1 0 2 4 3 5 7 6 N6|"
+               "N0 0 1 2 3 4 5 6 7 N7|"
 
-                "N3 3 7 2 6 1 5 4 0 N0|"
-                "N7 7 4 1 3 2 0 6 5 N5|"
-                "N6 6 3 0 7 5 1 4 2 N2|"
-                "N4 4 6 2 1 7 0 5 3 N3|"
-                "N5 5 2 7 3 1 6 0 4 N4|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N2 2 5 0 3 6 4 7 1 N1|",
+               "N3 3 7 2 6 1 5 4 0 N0|"
+               "N7 7 4 1 3 2 0 6 5 N5|"
+               "N6 6 3 0 7 5 1 4 2 N2|"
+               "N4 4 6 2 1 7 0 5 3 N3|"
+               "N5 5 2 7 3 1 6 0 4 N4|"
+               "N1 1 0 2 4 3 5 7 6 N6|"
+               "N0 0 1 2 3 4 5 6 7 N7|"
+               "N2 2 5 0 3 6 4 7 1 N1|",
 
+  .ringTail1 = "N5 5 4 2 7 1 6 3 0 N0|"
+               "N2 2 5 0 3 7 4 6 1 N1|"
+               "N3 3 6 4 0 5 1 7 2 N2|"
+               "N4 4 7 0 6 5 2 1 3 N3|"
+               "N6 6 2 0 7 5 3 1 4 N4|"
+               "N7 7 3 2 6 0 4 1 5 N5|"
+               "N1 1 0 2 4 3 5 7 6 N6|"
+               "N0 0 1 2 3 4 5 6 7 N7|"
 
-  .ringTail1  = "N5 5 4 2 7 1 6 3 0 N0|"
-                "N2 2 5 0 3 7 4 6 1 N1|"
-                "N3 3 6 4 0 5 1 7 2 N2|"
-                "N4 4 7 0 6 5 2 1 3 N3|"
-                "N6 6 2 0 7 5 3 1 4 N4|"
-                "N7 7 3 2 6 0 4 1 5 N5|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
+               "N2 2 5 0 3 7 4 6 1 N1|"
+               "N3 3 6 4 0 5 1 7 2 N2|"
+               "N4 4 7 0 6 5 2 1 3 N3|"
+               "N6 6 2 0 7 5 3 1 4 N4|"
+               "N7 7 3 2 6 0 4 1 5 N5|"
+               "N1 1 0 2 4 3 5 7 6 N6|"
+               "N0 0 1 2 3 4 5 6 7 N7|"
+               "N5 5 4 2 7 1 6 3 0 N0|"
 
-                "N2 2 5 0 3 7 4 6 1 N1|"
-                "N3 3 6 4 0 5 1 7 2 N2|"
-                "N4 4 7 0 6 5 2 1 3 N3|"
-                "N6 6 2 0 7 5 3 1 4 N4|"
-                "N7 7 3 2 6 0 4 1 5 N5|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N5 5 4 2 7 1 6 3 0 N0|"
+               "N3 3 6 4 0 5 1 7 2 N2|"
+               "N4 4 7 0 6 5 2 1 3 N3|"
+               "N6 6 2 0 7 5 3 1 4 N4|"
+               "N7 7 3 2 6 0 4 1 5 N5|"
+               "N1 1 0 2 4 3 5 7 6 N6|"
+               "N0 0 1 2 3 4 5 6 7 N7|"
+               "N5 5 4 2 7 1 6 3 0 N0|"
+               "N2 2 5 0 3 7 4 6 1 N1|"
 
-                "N3 3 6 4 0 5 1 7 2 N2|"
-                "N4 4 7 0 6 5 2 1 3 N3|"
-                "N6 6 2 0 7 5 3 1 4 N4|"
-                "N7 7 3 2 6 0 4 1 5 N5|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N5 5 4 2 7 1 6 3 0 N0|"
-                "N2 2 5 0 3 7 4 6 1 N1|"
+               "N4 4 7 0 6 5 2 1 3 N3|"
+               "N6 6 2 0 7 5 3 1 4 N4|"
+               "N7 7 3 2 6 0 4 1 5 N5|"
+               "N1 1 0 2 4 3 5 7 6 N6|"
+               "N0 0 1 2 3 4 5 6 7 N7|"
+               "N5 5 4 2 7 1 6 3 0 N0|"
+               "N2 2 5 0 3 7 4 6 1 N1|"
+               "N3 3 6 4 0 5 1 7 2 N2|"
 
-                "N4 4 7 0 6 5 2 1 3 N3|"
-                "N6 6 2 0 7 5 3 1 4 N4|"
-                "N7 7 3 2 6 0 4 1 5 N5|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N5 5 4 2 7 1 6 3 0 N0|"
-                "N2 2 5 0 3 7 4 6 1 N1|"
-                "N3 3 6 4 0 5 1 7 2 N2|"
+               "N6 6 2 0 7 5 3 1 4 N4|"
+               "N7 7 3 2 6 0 4 1 5 N5|"
+               "N1 1 0 2 4 3 5 7 6 N6|"
+               "N0 0 1 2 3 4 5 6 7 N7|"
+               "N5 5 4 2 7 1 6 3 0 N0|"
+               "N2 2 5 0 3 7 4 6 1 N1|"
+               "N3 3 6 4 0 5 1 7 2 N2|"
+               "N4 4 7 0 6 5 2 1 3 N3|"
 
-                "N6 6 2 0 7 5 3 1 4 N4|"
-                "N7 7 3 2 6 0 4 1 5 N5|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N5 5 4 2 7 1 6 3 0 N0|"
-                "N2 2 5 0 3 7 4 6 1 N1|"
-                "N3 3 6 4 0 5 1 7 2 N2|"
-                "N4 4 7 0 6 5 2 1 3 N3|"
+               "N7 7 3 2 6 0 4 1 5 N5|"
+               "N1 1 0 2 4 3 5 7 6 N6|"
+               "N0 0 1 2 3 4 5 6 7 N7|"
+               "N5 5 4 2 7 1 6 3 0 N0|"
+               "N2 2 5 0 3 7 4 6 1 N1|"
+               "N3 3 6 4 0 5 1 7 2 N2|"
+               "N4 4 7 0 6 5 2 1 3 N3|"
+               "N6 6 2 0 7 5 3 1 4 N4|"
 
-                "N7 7 3 2 6 0 4 1 5 N5|"
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N5 5 4 2 7 1 6 3 0 N0|"
-                "N2 2 5 0 3 7 4 6 1 N1|"
-                "N3 3 6 4 0 5 1 7 2 N2|"
-                "N4 4 7 0 6 5 2 1 3 N3|"
-                "N6 6 2 0 7 5 3 1 4 N4|"
+               "N1 1 0 2 4 3 5 7 6 N6|"
+               "N0 0 1 2 3 4 5 6 7 N7|"
+               "N5 5 4 2 7 1 6 3 0 N0|"
+               "N2 2 5 0 3 7 4 6 1 N1|"
+               "N3 3 6 4 0 5 1 7 2 N2|"
+               "N4 4 7 0 6 5 2 1 3 N3|"
+               "N6 6 2 0 7 5 3 1 4 N4|"
+               "N7 7 3 2 6 0 4 1 5 N5|"
 
-                "N1 1 0 2 4 3 5 7 6 N6|"
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N5 5 4 2 7 1 6 3 0 N0|"
-                "N2 2 5 0 3 7 4 6 1 N1|"
-                "N3 3 6 4 0 5 1 7 2 N2|"
-                "N4 4 7 0 6 5 2 1 3 N3|"
-                "N6 6 2 0 7 5 3 1 4 N4|"
-                "N7 7 3 2 6 0 4 1 5 N5|"
+               "N0 0 1 2 3 4 5 6 7 N7|"
+               "N5 5 4 2 7 1 6 3 0 N0|"
+               "N2 2 5 0 3 7 4 6 1 N1|"
+               "N3 3 6 4 0 5 1 7 2 N2|"
+               "N4 4 7 0 6 5 2 1 3 N3|"
+               "N6 6 2 0 7 5 3 1 4 N4|"
+               "N7 7 3 2 6 0 4 1 5 N5|"
+               "N1 1 0 2 4 3 5 7 6 N6|",
 
-                "N0 0 1 2 3 4 5 6 7 N7|"
-                "N5 5 4 2 7 1 6 3 0 N0|"
-                "N2 2 5 0 3 7 4 6 1 N1|"
-                "N3 3 6 4 0 5 1 7 2 N2|"
-                "N4 4 7 0 6 5 2 1 3 N3|"
-                "N6 6 2 0 7 5 3 1 4 N4|"
-                "N7 7 3 2 6 0 4 1 5 N5|"
-                "N1 1 0 2 4 3 5 7 6 N6|",
+  .options = "noCpuCheck=1,tuning=5,ll128Enabled=1,disableNumaMatching=1",
 
-  .options    = "noCpuCheck=1,tuning=5,ll128Enabled=1,disableNumaMatching=1",
+  .treeRail = "N0 0 1 2 4 3 6 5 7 N1|"
+              "N1 1 0 4 7 3 5 2 6 N0|"
+              "N2 2 3 0 5 6 1 7 4 N3|"
+              "N3 3 2 7 0 6 4 1 5 N2|"
+              "N4 4 5 1 6 0 3 7 2 N5|"
+              "N5 5 4 6 2 0 7 1 3 N4|"
+              "N6 6 7 5 3 4 0 2 1 N7|"
+              "N7 7 6 3 1 4 2 5 0 N6|"
 
-  .treeRail   = "N0 0 1 2 4 3 6 5 7 N1|"
-                "N1 1 0 4 7 3 5 2 6 N0|"
-                "N2 2 3 0 5 6 1 7 4 N3|"
-                "N3 3 2 7 0 6 4 1 5 N2|"
-                "N4 4 5 1 6 0 3 7 2 N5|"
-                "N5 5 4 6 2 0 7 1 3 N4|"
-                "N6 6 7 5 3 4 0 2 1 N7|"
-                "N7 7 6 3 1 4 2 5 0 N6|"
+              "N2 2 3 0 5 6 1 7 4 N3|"
+              "N3 3 2 7 0 6 4 1 5 N2|"
+              "N4 4 5 1 6 0 3 7 2 N5|"
+              "N5 5 4 6 2 0 7 1 3 N4|"
+              "N6 6 7 5 3 4 0 2 1 N7|"
+              "N7 7 6 3 1 4 2 5 0 N6|"
+              "N0 0 1 2 4 3 6 5 7 N1|"
+              "N1 1 0 4 7 3 5 2 6 N0|"
 
-                "N2 2 3 0 5 6 1 7 4 N3|"
-                "N3 3 2 7 0 6 4 1 5 N2|"
-                "N4 4 5 1 6 0 3 7 2 N5|"
-                "N5 5 4 6 2 0 7 1 3 N4|"
-                "N6 6 7 5 3 4 0 2 1 N7|"
-                "N7 7 6 3 1 4 2 5 0 N6|"
-                "N0 0 1 2 4 3 6 5 7 N1|"
-                "N1 1 0 4 7 3 5 2 6 N0|"
+              "N4 4 5 1 6 0 3 7 2 N5|"
+              "N5 5 4 6 2 0 7 1 3 N4|"
+              "N6 6 7 5 3 4 0 2 1 N7|"
+              "N7 7 6 3 1 4 2 5 0 N6|"
+              "N0 0 1 2 4 3 6 5 7 N1|"
+              "N1 1 0 4 7 3 5 2 6 N0|"
+              "N2 2 3 0 5 6 1 7 4 N3|"
+              "N3 3 2 7 0 6 4 1 5 N2|"
 
-                "N4 4 5 1 6 0 3 7 2 N5|"
-                "N5 5 4 6 2 0 7 1 3 N4|"
-                "N6 6 7 5 3 4 0 2 1 N7|"
-                "N7 7 6 3 1 4 2 5 0 N6|"
-                "N0 0 1 2 4 3 6 5 7 N1|"
-                "N1 1 0 4 7 3 5 2 6 N0|"
-                "N2 2 3 0 5 6 1 7 4 N3|"
-                "N3 3 2 7 0 6 4 1 5 N2|"
+              "N6 6 7 5 3 4 0 2 1 N7|"
+              "N7 7 6 3 1 4 2 5 0 N6|"
+              "N0 0 1 2 4 3 6 5 7 N1|"
+              "N1 1 0 4 7 3 5 2 6 N0|"
+              "N2 2 3 0 5 6 1 7 4 N3|"
+              "N3 3 2 7 0 6 4 1 5 N2|"
+              "N4 4 5 1 6 0 3 7 2 N5|"
+              "N5 5 4 6 2 0 7 1 3 N4|"
 
-                "N6 6 7 5 3 4 0 2 1 N7|"
-                "N7 7 6 3 1 4 2 5 0 N6|"
-                "N0 0 1 2 4 3 6 5 7 N1|"
-                "N1 1 0 4 7 3 5 2 6 N0|"
-                "N2 2 3 0 5 6 1 7 4 N3|"
-                "N3 3 2 7 0 6 4 1 5 N2|"
-                "N4 4 5 1 6 0 3 7 2 N5|"
-                "N5 5 4 6 2 0 7 1 3 N4|"
+              "N0 0 1 2 4 3 6 5 7 N1|"
+              "N1 1 0 4 7 3 5 2 6 N0|"
+              "N2 2 3 0 5 6 1 7 4 N3|"
+              "N3 3 2 7 0 6 4 1 5 N2|"
+              "N4 4 5 1 6 0 3 7 2 N5|"
+              "N5 5 4 6 2 0 7 1 3 N4|"
+              "N6 6 7 5 3 4 0 2 1 N7|"
+              "N7 7 6 3 1 4 2 5 0 N6|"
 
-                "N0 0 1 2 4 3 6 5 7 N1|"
-                "N1 1 0 4 7 3 5 2 6 N0|"
-                "N2 2 3 0 5 6 1 7 4 N3|"
-                "N3 3 2 7 0 6 4 1 5 N2|"
-                "N4 4 5 1 6 0 3 7 2 N5|"
-                "N5 5 4 6 2 0 7 1 3 N4|"
-                "N6 6 7 5 3 4 0 2 1 N7|"
-                "N7 7 6 3 1 4 2 5 0 N6|"
+              "N2 2 3 0 5 6 1 7 4 N3|"
+              "N3 3 2 7 0 6 4 1 5 N2|"
+              "N4 4 5 1 6 0 3 7 2 N5|"
+              "N5 5 4 6 2 0 7 1 3 N4|"
+              "N6 6 7 5 3 4 0 2 1 N7|"
+              "N7 7 6 3 1 4 2 5 0 N6|"
+              "N0 0 1 2 4 3 6 5 7 N1|"
+              "N1 1 0 4 7 3 5 2 6 N0|"
 
-                "N2 2 3 0 5 6 1 7 4 N3|"
-                "N3 3 2 7 0 6 4 1 5 N2|"
-                "N4 4 5 1 6 0 3 7 2 N5|"
-                "N5 5 4 6 2 0 7 1 3 N4|"
-                "N6 6 7 5 3 4 0 2 1 N7|"
-                "N7 7 6 3 1 4 2 5 0 N6|"
-                "N0 0 1 2 4 3 6 5 7 N1|"
-                "N1 1 0 4 7 3 5 2 6 N0|"
+              "N4 4 5 1 6 0 3 7 2 N5|"
+              "N5 5 4 6 2 0 7 1 3 N4|"
+              "N6 6 7 5 3 4 0 2 1 N7|"
+              "N7 7 6 3 1 4 2 5 0 N6|"
+              "N0 0 1 2 4 3 6 5 7 N1|"
+              "N1 1 0 4 7 3 5 2 6 N0|"
+              "N2 2 3 0 5 6 1 7 4 N3|"
+              "N3 3 2 7 0 6 4 1 5 N2|"
 
-                "N4 4 5 1 6 0 3 7 2 N5|"
-                "N5 5 4 6 2 0 7 1 3 N4|"
-                "N6 6 7 5 3 4 0 2 1 N7|"
-                "N7 7 6 3 1 4 2 5 0 N6|"
-                "N0 0 1 2 4 3 6 5 7 N1|"
-                "N1 1 0 4 7 3 5 2 6 N0|"
-                "N2 2 3 0 5 6 1 7 4 N3|"
-                "N3 3 2 7 0 6 4 1 5 N2|"
-
-                "N6 6 7 5 3 4 0 2 1 N7|"
-                "N7 7 6 3 1 4 2 5 0 N6|"
-                "N0 0 1 2 4 3 6 5 7 N1|"
-                "N1 1 0 4 7 3 5 2 6 N0|"
-                "N2 2 3 0 5 6 1 7 4 N3|"
-                "N3 3 2 7 0 6 4 1 5 N2|"
-                "N4 4 5 1 6 0 3 7 2 N5|"
-                "N5 5 4 6 2 0 7 1 3 N4|",
+              "N6 6 7 5 3 4 0 2 1 N7|"
+              "N7 7 6 3 1 4 2 5 0 N6|"
+              "N0 0 1 2 4 3 6 5 7 N1|"
+              "N1 1 0 4 7 3 5 2 6 N0|"
+              "N2 2 3 0 5 6 1 7 4 N3|"
+              "N3 3 2 7 0 6 4 1 5 N2|"
+              "N4 4 5 1 6 0 3 7 2 N5|"
+              "N5 5 4 6 2 0 7 1 3 N4|",
 };
 
 static struct rcclRomeModel romeTopoModels[] = {
@@ -1818,13 +3825,14 @@ RCCL_PARAM(ModelReversalDisable, "MODEL_REVERSAL_DISABLE", 0);
  * Rings with a non-matching number of gpus are ignored so we can provide
  * rings for multiple cases.
  */
-ncclResult_t parseGraph(const char* str, struct ncclTopoSystem* system, struct ncclTopoGraph* graph, int* gpu_map, int* net_map, int reverse) {
+ncclResult_t parseGraph(const char* str, struct ncclTopoSystem* system, struct ncclTopoGraph* graph, int* gpu_map,
+                        int* net_map, int reverse) {
   int gpus[NCCL_TOPO_MAX_NODES];
   int nChannels = 0;
   int gpu = 0;
   int offset = 0;
   int status = 0; // 0 : between numbers, 1 : inside number, 2: start NET, 3: inside NET
-  int nets[NCCL_TOPO_MAX_NODES*2];
+  int nets[NCCL_TOPO_MAX_NODES * 2];
   int net_offset = 0, net_count = 0;
   int ngpus = system->nodes[GPU].count;
   int nnets = system->nodes[NET].count;
@@ -1840,82 +3848,79 @@ ncclResult_t parseGraph(const char* str, struct ncclTopoSystem* system, struct n
       int digit = str[offset] - '0';
       if (digit >= 0 && digit <= 9) {
         switch (status) {
-          case 0:
-            gpus[gpu] = digit;
-            status = 1;
-            break;
-          case 1:
-            gpus[gpu] = gpus[gpu]*10+digit;
-            break;
-          case 2:
-            nets[net_offset] = digit+'N';
-            status = 3;
-            break;
-          case 3:
-            nets[net_offset] = (nets[net_offset]-'N')*10+digit+'N';
-            break;
+        case 0:
+          gpus[gpu] = digit;
+          status = 1;
+          break;
+        case 1:
+          gpus[gpu] = gpus[gpu] * 10 + digit;
+          break;
+        case 2:
+          nets[net_offset] = digit + 'N';
+          status = 3;
+          break;
+        case 3:
+          nets[net_offset] = (nets[net_offset] - 'N') * 10 + digit + 'N';
+          break;
         }
       } else {
         if (status == 1) {
           gpu++;
-          net_offset = 2*gpu-1;
+          net_offset = 2 * gpu - 1;
           if (gpu > NCCL_TOPO_MAX_NODES) goto end;
         } else if (status == 2 || status == 3) {
           net_offset++;
           net_count++;
-          if (net_offset > ngpus*2) goto end;
+          if (net_offset > ngpus * 2) goto end;
         }
         status = 0;
         if (str[offset] == '|' || str[offset] == '\0') {
           // Ignore if ngpus doesn't match
           if (gpu != ngpus) goto newchannel;
           // Ignore if net_count is not 0 or odd number
-          if (net_count && net_count%2) goto newchannel;
+          if (net_count && net_count % 2) goto newchannel;
 
-          for (int r=0; r<ngpus; r++) {
+          for (int r = 0; r < ngpus; r++) {
             int g = gpus[r];
             // Ignore if gpus are out of bounds
             if (g < 0 || g >= ngpus) goto newchannel;
             // Ignore if gpus are duplicate
-            for (int i=0; i<r; i++)
+            for (int i = 0; i < r; i++)
               if (gpus[i] == g) goto newchannel;
             // find rocm-smi id if needed
             if (gpu_map) g = gpu_map[g];
             // Translate gpu numbers into ranks
             int j = 0;
             for (j = 0; j < ngpus; j++)
-              if (g == system->nodes[GPU].nodes[j].gpu.dev)
-                break;
+              if (g == system->nodes[GPU].nodes[j].gpu.dev) break;
             if (j < ngpus) {
-              int idx = (nChannels*ngpus) + (reverse ? ngpus - 1 - r : r);
+              int idx = (nChannels * ngpus) + (reverse ? ngpus - 1 - r : r);
               graph->intra[idx] = system->nodes[GPU].nodes[j].gpu.rank;
-            }
-            else
-              return ncclInternalError;
+            } else return ncclInternalError;
           }
 
           if (net_count) {
-            for (int i = 0; net_map && i < ngpus*2; i++) {
-              if (nets[i]-'N' < 0 || nets[i]-'N' >= nnets) continue;
-              nets[i] = net_map[nets[i]-'N']+'N';
+            for (int i = 0; net_map && i < ngpus * 2; i++) {
+              if (nets[i] - 'N' < 0 || nets[i] - 'N' >= nnets) continue;
+              nets[i] = net_map[nets[i] - 'N'] + 'N';
             }
             // Swap input/output NICs if reversed
             if (reverse) {
               int t = nets[0];
-              nets[0] = nets[ngpus*2-1];
-              nets[ngpus*2-1] = t;
+              nets[0] = nets[ngpus * 2 - 1];
+              nets[ngpus * 2 - 1] = t;
             }
-            memcpy(&graph->intraNets[ngpus*nChannels*2], nets, ngpus*2*sizeof(int));
+            memcpy(&graph->intraNets[ngpus * nChannels * 2], nets, ngpus * 2 * sizeof(int));
             graph->nIntraChannels++;
-            if (nets[0]-'N' >= nnets || nets[ngpus*2-1]-'N' >= nnets) goto newchannel;
-            graph->inter[nChannels*2] = nets[0]-'N';
-            graph->inter[nChannels*2+1] = nets[ngpus*2-1]-'N';
+            if (nets[0] - 'N' >= nnets || nets[ngpus * 2 - 1] - 'N' >= nnets) goto newchannel;
+            graph->inter[nChannels * 2] = nets[0] - 'N';
+            graph->inter[nChannels * 2 + 1] = nets[ngpus * 2 - 1] - 'N';
           } else if (nnets) {
-            graph->inter[nChannels*2] = system->nodes[NET].nodes[nChannels%nnets].id;
-            graph->inter[nChannels*2+1] = system->nodes[NET].nodes[(nChannels+1)%nnets].id;
+            graph->inter[nChannels * 2] = system->nodes[NET].nodes[nChannels % nnets].id;
+            graph->inter[nChannels * 2 + 1] = system->nodes[NET].nodes[(nChannels + 1) % nnets].id;
           }
           nChannels++;
-newchannel:
+        newchannel:
           gpu = 0;
           net_offset = 0;
           net_count = 0;
@@ -1925,12 +3930,12 @@ newchannel:
   } while (str[offset++] != 0);
 end:
   graph->nChannels = nChannels;
-  graph->bwIntra = graph->bwInter = system->totalBw/nChannels;
+  graph->bwIntra = graph->bwInter = system->totalBw / nChannels;
   if (graph->id == 1) {
-    for (int i=0; i<graph->nChannels; i++) {
+    for (int i = 0; i < graph->nChannels; i++) {
       int64_t netId;
-      ncclTopoGetLocalNet(system, graph->intra[i*ngpus+1], i, &netId, nullptr);
-      graph->inter[i*2+1] = netId;
+      ncclTopoGetLocalNet(system, graph->intra[i * ngpus + 1], i, &netId, nullptr);
+      graph->inter[i * 2 + 1] = netId;
     }
   }
 
@@ -1946,15 +3951,15 @@ end:
   return ncclSuccess;
 }
 
-
 /* Parse user defined treeBase for complicated trees. Format is like :
  * "(4(2(3)(1))(6(5)))"
  *
  * Rings with a non-matching number of gpus are ignored so we can provide
  * rings for multiple cases.
  */
-ncclResult_t parseGraphLight(const char* str, struct ncclTopoSystem* system, struct ncclTopoGraph* graph, int* gpu_map) {
-  int gpus[NCCL_TOPO_MAX_NODES]; //transcribe/change according to gpu_map
+ncclResult_t parseGraphLight(const char* str, struct ncclTopoSystem* system, struct ncclTopoGraph* graph,
+                             int* gpu_map) {
+  int gpus[NCCL_TOPO_MAX_NODES]; // transcribe/change according to gpu_map
   int gpu = 0;
   int offset = 0;
   int start_offset = offset;
@@ -1964,18 +3969,18 @@ ncclResult_t parseGraphLight(const char* str, struct ncclTopoSystem* system, str
   }
   int status = 0; // 0 : between numbers, 1 : inside number
   int ngpus = system->nodes[GPU].count;
-  int x=0;
+  int x = 0;
   do {
     int digit = str[offset] - '0';
     if (digit >= 0 && digit <= 9) {
       switch (status) {
-        case 0:
-          gpus[gpu] = digit;
-          status = 1;
-          break;
-        case 1:
-          gpus[gpu] = gpus[gpu]*10+digit;
-          break;
+      case 0:
+        gpus[gpu] = digit;
+        status = 1;
+        break;
+      case 1:
+        gpus[gpu] = gpus[gpu] * 10 + digit;
+        break;
       }
     } else {
       if (status == 1) {
@@ -1984,14 +3989,13 @@ ncclResult_t parseGraphLight(const char* str, struct ncclTopoSystem* system, str
       status = 0;
       if (str[offset] == '|' || str[offset] == 0) {
         int r = 0, y = 0;
-        while(start_offset < offset) {
+        while (start_offset < offset) {
         // for (int r=0; r<gpu; r++) {
           if (str[start_offset] == '(' || str[start_offset] == ')') {
             graph->treeBase[x][y] = str[start_offset];
             y++;
             start_offset++;
-          }
-          else {
+          } else {
             int g = gpus[r];
             // remap if needed
             if (gpu_map) g = gpu_map[g];
@@ -1999,28 +4003,23 @@ ncclResult_t parseGraphLight(const char* str, struct ncclTopoSystem* system, str
             int j = 0;
             // Translate gpu numbers into ranks
             for (j = 0; j < ngpus; j++)
-              if (g == system->nodes[GPU].nodes[j].gpu.dev)
-                break;
-            if (j < ngpus)
-            {
+              if (g == system->nodes[GPU].nodes[j].gpu.dev) break;
+            if (j < ngpus) {
               while (str[start_offset] != '(' && str[start_offset] != ')') start_offset++;
               char number_str[10];
               sprintf(number_str, "%d", g);
-              int k=0;
+              int k = 0;
               while (number_str[k] != 0) {
-                graph->treeBase[x][y]=number_str[k];
+                graph->treeBase[x][y] = number_str[k];
                 y++;
                 k++;
               }
-            }
-            else
-              return ncclInternalError;
+            } else return ncclInternalError;
           }
-
         }
         graph->treeBase[x][y] = 0;
         x++;
-        gpu=0;
+        gpu = 0;
         start_offset = offset + 1;
       }
     }
@@ -2029,14 +4028,12 @@ ncclResult_t parseGraphLight(const char* str, struct ncclTopoSystem* system, str
   return ncclSuccess;
 }
 
-
-
 #define MAX_OPT_TOKENS 10
 extern const char* topoPathTypeStr[];
 
-static void parseOptions(struct ncclTopoSystem* system, const char *options) {
+static void parseOptions(struct ncclTopoSystem* system, const char* options) {
   if (strcmp(options, "")) {
-    char *str_temp = (char *)malloc(strlen(options) + 1);
+    char* str_temp = (char*)malloc(strlen(options) + 1);
     if (str_temp == nullptr) {
       WARN("Failed to allocate memory for options parsing");
       return;
@@ -2047,33 +4044,31 @@ static void parseOptions(struct ncclTopoSystem* system, const char *options) {
     char* state;
     tokens[numTokens] = strtok_r(str_temp, "=, ", &state);
     numTokens++;
-    while (tokens[numTokens-1] != NULL && numTokens < MAX_OPT_TOKENS)
-        tokens[numTokens++] = strtok_r(NULL, "=, ", &state);
-    for (int i = 0; i < numTokens/2; i++) {
-      if (strcmp(tokens[i*2], "netGdrLevel") == 0) {
+    while (tokens[numTokens - 1] != NULL && numTokens < MAX_OPT_TOKENS)
+      tokens[numTokens++] = strtok_r(NULL, "=, ", &state);
+    for (int i = 0; i < numTokens / 2; i++) {
+      if (strcmp(tokens[i * 2], "netGdrLevel") == 0) {
         int j;
         for (j = 0; j <= PATH_SYS; j++) {
-          if (strcmp(tokens[i*2+1], topoPathTypeStr[j]) == 0)
-            break;
+          if (strcmp(tokens[i * 2 + 1], topoPathTypeStr[j]) == 0) break;
         }
-        if (j <= PATH_SYS)
-          system->netGdrLevel = j;
+        if (j <= PATH_SYS) system->netGdrLevel = j;
         else {
           system->netGdrLevel = -2;
-          WARN("invalid netGdrLevel: %s", tokens[i*2+1]);
+          WARN("invalid netGdrLevel: %s", tokens[i * 2 + 1]);
         }
-      } else if (strcmp(tokens[i*2], "pivotA2AEnabled") == 0) {
-        system->pivotA2AEnabled = (bool)atol(tokens[i*2+1]);
-      } else if (strcmp(tokens[i*2], "pivotA2ANumBiRings") == 0) {
-        system->pivotA2ANumBiRings = atol(tokens[i*2+1]);
-      } else if (strcmp(tokens[i*2], "tuning") == 0) {
-        system->tuning = atol(tokens[i*2+1]);
-      } else if (strcmp(tokens[i*2], "ll128Enabled") == 0) {
-        system->ll128Enabled = (bool)atol(tokens[i*2+1]);
-      } else if (strcmp(tokens[i*2], "baseBw") == 0) {
-        system->baseBw = std::stof(tokens[i*2+1]);
-      } else if (strcmp(tokens[i*2], "treeDefined") == 0) {
-        system->treeDefined = (bool)atol(tokens[i*2+1]);
+      } else if (strcmp(tokens[i * 2], "pivotA2AEnabled") == 0) {
+        system->pivotA2AEnabled = (bool)atol(tokens[i * 2 + 1]);
+      } else if (strcmp(tokens[i * 2], "pivotA2ANumBiRings") == 0) {
+        system->pivotA2ANumBiRings = atol(tokens[i * 2 + 1]);
+      } else if (strcmp(tokens[i * 2], "tuning") == 0) {
+        system->tuning = atol(tokens[i * 2 + 1]);
+      } else if (strcmp(tokens[i * 2], "ll128Enabled") == 0) {
+        system->ll128Enabled = (bool)atol(tokens[i * 2 + 1]);
+      } else if (strcmp(tokens[i * 2], "baseBw") == 0) {
+        system->baseBw = std::stof(tokens[i * 2 + 1]);
+      } else if (strcmp(tokens[i * 2], "treeDefined") == 0) {
+        system->treeDefined = (bool)atol(tokens[i * 2 + 1]);
       }
     }
     free(str_temp);
@@ -2091,9 +4086,9 @@ static ncclResult_t rcclTopoSetPresetRomeModelIdx(struct ncclTopoSystem* system,
   return ncclSuccess;
 }
 
-static bool checkOption(const char *options, const char *name) {
+static bool checkOption(const char* options, const char* name) {
   if (strcmp(options, "")) {
-    char *str_temp = (char *)malloc(strlen(options) + 1);
+    char* str_temp = (char*)malloc(strlen(options) + 1);
     if (str_temp == nullptr) {
       WARN("Failed to allocate memory for options checking");
       return false;
@@ -2104,13 +4099,13 @@ static bool checkOption(const char *options, const char *name) {
     char* state;
     tokens[numTokens] = strtok_r(str_temp, "=, ", &state);
     numTokens++;
-    while (tokens[numTokens-1] != NULL && numTokens < MAX_OPT_TOKENS)
-        tokens[numTokens++] = strtok_r(NULL, "=, ", &state);
+    while (tokens[numTokens - 1] != NULL && numTokens < MAX_OPT_TOKENS)
+      tokens[numTokens++] = strtok_r(NULL, "=, ", &state);
 
     bool result = false;
-    for (int i = 0; i < numTokens/2; i++) {
-      if (strcmp(tokens[i*2], name) == 0) {
-        result = (bool)atol(tokens[i*2+1]);
+    for (int i = 0; i < numTokens / 2; i++) {
+      if (strcmp(tokens[i * 2], name) == 0) {
+        result = (bool)atol(tokens[i * 2 + 1]);
         break;
       }
     }
@@ -2121,41 +4116,48 @@ static bool checkOption(const char *options, const char *name) {
 }
 
 ncclResult_t parseChordalRing(struct ncclTopoSystem* system, struct ncclTopoGraph* graph) {
-  static const char *ringBase = "0 1 2 3 5 4 7 6|0 2 4 1 7 3 6 5|0 3 1 5 7 2 6 4|0 6 7 4 5 3 2 1|0 5 6 3 7 1 4 2|0 4 6 2 7 5 1 3";
+  static const char* ringBase =
+    "0 1 2 3 5 4 7 6|0 2 4 1 7 3 6 5|0 3 1 5 7 2 6 4|0 6 7 4 5 3 2 1|0 5 6 3 7 1 4 2|0 4 6 2 7 5 1 3";
   int id[8], dist[8];
   int i;
 
   int ngpus = system->nodes[GPU].count;
-  if (ngpus != 8)
-    return ncclSuccess;
+  if (ngpus != 8) return ncclSuccess;
   // validate chordal ring and calculate distance
-  for (i=0; i<ngpus; i++) {
-    struct ncclTopoNode* node = system->nodes[GPU].nodes+i;
+  for (i = 0; i < ngpus; i++) {
+    struct ncclTopoNode* node = system->nodes[GPU].nodes + i;
     if (node->paths[GPU] == NULL) continue;
-    int sum = ngpus*(ngpus-1)/2 - node->gpu.dev;
+    int sum = ngpus * (ngpus - 1) / 2 - node->gpu.dev;
     int count = 0;
-    for (int n = 0; n<ngpus; n++) {
+    for (int n = 0; n < ngpus; n++) {
       // Direct XGMI neighbor: post NCCL-2.30 a direct GPU->GPU path is GPU-DEV-DEV-GPU (count<=3).
       struct ncclTopoLinkList* path = node->paths[GPU] + n;
       if (path->type != PATH_NVL || path->count > 3) continue;
       sum -= system->nodes[GPU].nodes[n].gpu.dev;
-      count ++;
+      count++;
     }
-    if(count != ngpus-2 || sum < 0 || sum > ngpus-1) {
+    if (count != ngpus - 2 || sum < 0 || sum > ngpus - 1) {
       return ncclSuccess;
     }
     dist[i] = sum;
   }
   // remap GPU ids
-  for (i = 0; i<ngpus; i++) id[i] = i;
-  for (i = 0; i<ngpus; i++) {
-    if (dist[i] == ngpus-1-i) continue;
+  for (i = 0; i < ngpus; i++) id[i] = i;
+  for (i = 0; i < ngpus; i++) {
+    if (dist[i] == ngpus - 1 - i) continue;
     int j, m, n, temp;
-    for (j=i+1; j < ngpus; j++)
-      if(dist[j] == ngpus-1-i) break;
-    m = dist[i]; n = dist[j]; dist[i] = n; dist[j] = m;
-    temp = id[m]; id[m] = id[n]; id[n] = temp; temp =dist[m];
-    dist[m] = dist[n]; dist[n] = temp;
+    for (j = i + 1; j < ngpus; j++)
+      if (dist[j] == ngpus - 1 - i) break;
+    m = dist[i];
+    n = dist[j];
+    dist[i] = n;
+    dist[j] = m;
+    temp = id[m];
+    id[m] = id[n];
+    id[n] = temp;
+    temp = dist[m];
+    dist[m] = dist[n];
+    dist[n] = temp;
   }
   // create chordal ring based on reference and remapped ids
   system->type |= RCCL_TOPO_CR8G;
@@ -2164,26 +4166,31 @@ ncclResult_t parseChordalRing(struct ncclTopoSystem* system, struct ncclTopoGrap
     int *intra, *used;
     graph->nChannels = system->nodes[NET].count;
     NCCLCHECK(ncclCalloc(&intra, ngpus));
-    NCCLCHECK(ncclCalloc(&used,system->nodes[NET].count));
+    NCCLCHECK(ncclCalloc(&used, system->nodes[NET].count));
     for (int n = 0; n < system->nodes[NET].count; n++) {
-      graph->inter[n*2] = graph->inter[n*2+1] = n;
-      struct ncclTopoNode* net = system->nodes[NET].nodes+n;
+      graph->inter[n * 2] = graph->inter[n * 2 + 1] = n;
+      struct ncclTopoNode* net = system->nodes[NET].nodes + n;
       struct ncclTopoLinkList* paths = net->paths[GPU];
       // find the first unsed GPU that is closest to NIC
       int f, m;
       for (f = 0; f < ngpus; f++) {
-        int j = 0; for (j = 0; j < n; j++) if(used[j] == system->nodes[GPU].nodes[f].gpu.rank) break;
-        if(j >= n) break;
+        int j = 0;
+        for (j = 0; j < n; j++)
+          if (used[j] == system->nodes[GPU].nodes[f].gpu.rank) break;
+        if (j >= n) break;
       }
       for (int i = 0; i < ngpus; i++) {
-        int j = 0; for (j = 0; j < n; j++) if(used[j] == system->nodes[GPU].nodes[i].gpu.rank) break;
+        int j = 0;
+        for (j = 0; j < n; j++)
+          if (used[j] == system->nodes[GPU].nodes[i].gpu.rank) break;
         if (j < n) continue;
         if (paths[i].count < paths[f].count) f = i;
       }
-      for (m = 0; m<ngpus; m++) if (graph->intra[n*ngpus+m] == system->nodes[GPU].nodes[f].gpu.rank) break;
-      used[n] = graph->intra[n*ngpus+m];
-      for (int i = 0; i < ngpus; i++) intra[i] = graph->intra[n*ngpus+((i+m)%ngpus)];
-      for (int i = 0; i < ngpus; i++) graph->intra[n*ngpus+i] = intra[i];
+      for (m = 0; m < ngpus; m++)
+        if (graph->intra[n * ngpus + m] == system->nodes[GPU].nodes[f].gpu.rank) break;
+      used[n] = graph->intra[n * ngpus + m];
+      for (int i = 0; i < ngpus; i++) intra[i] = graph->intra[n * ngpus + ((i + m) % ngpus)];
+      for (int i = 0; i < ngpus; i++) graph->intra[n * ngpus + i] = intra[i];
     }
     free(used);
     free(intra);
@@ -2191,9 +4198,8 @@ ncclResult_t parseChordalRing(struct ncclTopoSystem* system, struct ncclTopoGrap
   return ncclSuccess;
 }
 
-
-static ncclResult_t parseRomeSystem(struct ncclTopoSystem* system, struct rcclRomeModel* romeTopo,
-                                    char *pattern, int *devids) {
+static ncclResult_t parseRomeSystem(struct ncclTopoSystem* system, struct rcclRomeModel* romeTopo, char* pattern,
+                                    int* devids) {
   pattern[0] = 0; // pattern will be NULL for invalid topology
   romeTopo->nGpus = system->nodes[GPU].count;
   romeTopo->nCpus = system->nodes[CPU].count;
@@ -2205,9 +4211,9 @@ static ncclResult_t parseRomeSystem(struct ncclTopoSystem* system, struct rcclRo
     int dev;
   };
 
-  auto cmpIds = [](const void * g1, const void * g2) {
-    struct ncclGpuIdHIP *s1 = (struct ncclGpuIdHIP*)g1;
-    struct ncclGpuIdHIP *s2 = (struct ncclGpuIdHIP*)g2;
+  auto cmpIds = [](const void* g1, const void* g2) {
+    struct ncclGpuIdHIP* s1 = (struct ncclGpuIdHIP*)g1;
+    struct ncclGpuIdHIP* s2 = (struct ncclGpuIdHIP*)g2;
     return s1->dev - s2->dev;
   };
 
@@ -2216,9 +4222,9 @@ static ncclResult_t parseRomeSystem(struct ncclTopoSystem* system, struct rcclRo
     uint64_t numa;
   };
 
-  auto cmpNuma = [](const void * g1, const void * g2) {
-    struct ncclCpuNuma *s1 = (struct ncclCpuNuma*)g1;
-    struct ncclCpuNuma *s2 = (struct ncclCpuNuma*)g2;
+  auto cmpNuma = [](const void* g1, const void* g2) {
+    struct ncclCpuNuma* s1 = (struct ncclCpuNuma*)g1;
+    struct ncclCpuNuma* s2 = (struct ncclCpuNuma*)g2;
     return (int)(s1->numa - s2->numa);
   };
 
@@ -2227,35 +4233,35 @@ static ncclResult_t parseRomeSystem(struct ncclTopoSystem* system, struct rcclRo
     uint64_t id;
   };
 
-  auto cmpNets = [](const void * g1, const void * g2) {
-    struct ncclNetId *s1 = (struct ncclNetId*)g1;
-    struct ncclNetId *s2 = (struct ncclNetId*)g2;
+  auto cmpNets = [](const void* g1, const void* g2) {
+    struct ncclNetId* s1 = (struct ncclNetId*)g1;
+    struct ncclNetId* s2 = (struct ncclNetId*)g2;
     return (int)(s1->id - s2->id);
   };
 
   // sort GPU devices by HIP device ID
   struct ncclGpuIdHIP gpu_scores[NCCL_TOPO_MAX_NODES];
-  for (int i = 0; i < romeTopo->nGpus; i ++) {
+  for (int i = 0; i < romeTopo->nGpus; i++) {
     gpu_scores[i].g = i;
     gpu_scores[i].dev = system->nodes[GPU].nodes[i].gpu.dev;
   }
   qsort(gpu_scores, romeTopo->nGpus, sizeof(struct ncclGpuIdHIP), cmpIds);
   // sort CPU devices by NUMA id
   struct ncclCpuNuma cpu_scores[NCCL_TOPO_MAX_NODES];
-  for (int i = 0; i < romeTopo->nCpus; i ++) {
+  for (int i = 0; i < romeTopo->nCpus; i++) {
     cpu_scores[i].c = i;
     cpu_scores[i].numa = system->nodes[CPU].nodes[i].id;
   }
   qsort(cpu_scores, romeTopo->nCpus, sizeof(struct ncclCpuNuma), cmpNuma);
   // sort NET devices by id
   struct ncclNetId net_scores[NCCL_TOPO_MAX_NODES];
-  for (int i = 0; i < romeTopo->nNics; i ++) {
+  for (int i = 0; i < romeTopo->nNics; i++) {
     net_scores[i].n = i;
     net_scores[i].id = system->nodes[NET].nodes[i].net.dev;
   }
   qsort(net_scores, romeTopo->nNics, sizeof(struct ncclNetId), cmpNets);
 
-  for (int i = 0; i < romeTopo->nGpus; i ++) {
+  for (int i = 0; i < romeTopo->nGpus; i++) {
     int gpu, n, m, distance;
     gpu = gpu_scores[i].g;
     romeTopo->gpuIds[i] = system->nodes[GPU].nodes[gpu].id;
@@ -2269,17 +4275,17 @@ static ncclResult_t parseRomeSystem(struct ncclTopoSystem* system, struct rcclRo
     }
     if (m < romeTopo->nCpus) romeTopo->gpuNuma[i] = system->nodes[CPU].nodes[m].id;
 
-    struct ncclTopoNode* node = system->nodes[GPU].nodes+gpu;
+    struct ncclTopoNode* node = system->nodes[GPU].nodes + gpu;
     if (node->paths[GPU] == NULL) continue;
     int count = 0;
     for (n = 0; n < romeTopo->nGpus; n++) {
-      romeTopo->connMatrix[i*romeTopo->nGpus+n] = 0;
-      struct ncclTopoLinkList *path = node->paths[GPU] + gpu_scores[n].g;
+      romeTopo->connMatrix[i * romeTopo->nGpus + n] = 0;
+      struct ncclTopoLinkList* path = node->paths[GPU] + gpu_scores[n].g;
       // Only count direct XGMI links: since NCCL 2.30, GPU->GPU routes via DEV nodes, so direct is
       // count==3 and indirect count==4. Counting indirect breaks Rome matching on sparse topos.
       if (path->type != PATH_NVL || path->count > 3) continue;
-      romeTopo->connMatrix[i*romeTopo->nGpus+n] = path->bw/ncclTopoXGMISpeed(node->gpu.gcn);
-      count ++;
+      romeTopo->connMatrix[i * romeTopo->nGpus + n] = path->bw / ncclTopoXGMISpeed(node->gpu.gcn);
+      count++;
     }
     if (romeTopo->nLinks < count) romeTopo->nLinks = count;
   }
@@ -2307,14 +4313,13 @@ static ncclResult_t parseRomeSystem(struct ncclTopoSystem* system, struct rcclRo
       if (romeTopo->gpuNuma[j] == id) g++;
     for (int j = 0; j < romeTopo->nNics; j++)
       if (romeTopo->nicNuma[j] == id) n++;
-    pattern[i*2] = '0' + g;
-    pattern[i*2+1] = '0' + n;
+    pattern[i * 2] = '0' + g;
+    pattern[i * 2 + 1] = '0' + n;
   }
-  pattern[romeTopo->nCpus*2] = 0;
+  pattern[romeTopo->nCpus * 2] = 0;
 
   if (devids)
-    for (int i = 0; i<romeTopo->nGpus; i++)
-       devids[i] = gpu_scores[i].dev;
+    for (int i = 0; i < romeTopo->nGpus; i++) devids[i] = gpu_scores[i].dev;
 
   // compute gdr level matrix
   for (int i = 0; i < romeTopo->nNics; i++) {
@@ -2323,7 +4328,8 @@ static ncclResult_t parseRomeSystem(struct ncclTopoSystem* system, struct rcclRo
       int g = gpu_scores[j].g;
       struct ncclTopoNode* gpuNode = &system->nodes[GPU].nodes[g];
       // paths[NET] is null when the GPU has no topology path to any NET node (e.g. remote NICs in MNNVL)
-      romeTopo->gdrLevel[i*romeTopo->nGpus+j] = (gpuNode->paths[NET] != NULL) ? gpuNode->paths[NET][n].type : PATH_DIS;
+      romeTopo->gdrLevel[i * romeTopo->nGpus + j] =
+        (gpuNode->paths[NET] != NULL) ? gpuNode->paths[NET][n].type : PATH_DIS;
     }
   }
 
@@ -2336,26 +4342,28 @@ static ncclResult_t parseRomeSystem(struct ncclTopoSystem* system, struct rcclRo
       return ncclSuccess;
     }
     fprintf(file, "static struct rcclRomeModel rome_model_ = {\n");
-    fprintf(file, "  .nGpus = %d, .nCpus = %d, .nNics = %d, .nLinks = %d,\n", romeTopo->nGpus, romeTopo->nCpus, romeTopo->nNics, romeTopo->nLinks);
+    fprintf(file, "  .nGpus = %d, .nCpus = %d, .nNics = %d, .nLinks = %d,\n", romeTopo->nGpus, romeTopo->nCpus,
+            romeTopo->nNics, romeTopo->nLinks);
     fprintf(file, "  .gpuIds = { ");
-    for (int i = 0; i < romeTopo->nGpus; i ++) fprintf(file, "0x%lx, ", romeTopo->gpuIds[i]);
+    for (int i = 0; i < romeTopo->nGpus; i++) fprintf(file, "0x%lx, ", romeTopo->gpuIds[i]);
     fprintf(file, "},\n");
     fprintf(file, "  .nicIds = { ");
-    for (int i = 0; i < romeTopo->nNics; i ++) fprintf(file, "0x%lx, ", romeTopo->nicIds[i]);
+    for (int i = 0; i < romeTopo->nNics; i++) fprintf(file, "0x%lx, ", romeTopo->nicIds[i]);
     fprintf(file, "},\n");
     fprintf(file, "  .gpuNuma = { ");
-    for (int i = 0; i < romeTopo->nGpus; i ++) fprintf(file, "%ld, ", romeTopo->gpuNuma[i]);
+    for (int i = 0; i < romeTopo->nGpus; i++) fprintf(file, "%ld, ", romeTopo->gpuNuma[i]);
     fprintf(file, "},\n");
     fprintf(file, "  .nicNuma = { ");
-    for (int i = 0; i < romeTopo->nNics; i ++) fprintf(file, "%ld, ", romeTopo->nicNuma[i]);
+    for (int i = 0; i < romeTopo->nNics; i++) fprintf(file, "%ld, ", romeTopo->nicNuma[i]);
     fprintf(file, "},\n");
     fprintf(file, "  .connMatrix = { ");
-    for (int i = 0; i < romeTopo->nGpus; i ++)
-      for (int n = 0; n < romeTopo->nGpus; n++) fprintf(file, "%d, ", romeTopo->connMatrix[i*romeTopo->nGpus+n]);
+    for (int i = 0; i < romeTopo->nGpus; i++)
+      for (int n = 0; n < romeTopo->nGpus; n++) fprintf(file, "%d, ", romeTopo->connMatrix[i * romeTopo->nGpus + n]);
     fprintf(file, "},\n");
     fprintf(file, "  .gdrLevel = { ");
-    for (int i = 0; i < romeTopo->nNics; i ++)
-      for (int n = 0; n < romeTopo->nGpus; n++) fprintf(file, "PATH_%s, ", topoPathTypeStr[romeTopo->gdrLevel[i*romeTopo->nGpus+n]]);
+    for (int i = 0; i < romeTopo->nNics; i++)
+      for (int n = 0; n < romeTopo->nGpus; n++)
+        fprintf(file, "PATH_%s, ", topoPathTypeStr[romeTopo->gdrLevel[i * romeTopo->nGpus + n]]);
     fprintf(file, "},\n");
     fprintf(file, "  .pattern = \"%s\",\n", pattern);
     fprintf(file, "  .ringBase = \"\",\n");
@@ -2366,8 +4374,9 @@ static ncclResult_t parseRomeSystem(struct ncclTopoSystem* system, struct rcclRo
   return ncclSuccess;
 }
 
-static bool permuteGpuIds(int *g, int n, int last, struct rcclRomeModel* ref, struct rcclRomeModel* topo, int* time, bool nbio, bool ignore_numa) {
-  (*time) ++;
+static bool permuteGpuIds(int* g, int n, int last, struct rcclRomeModel* ref, struct rcclRomeModel* topo, int* time,
+                          bool nbio, bool ignore_numa) {
+  (*time)++;
   if (n == last) {
     int i, j;
     // match GPU numa
@@ -2379,8 +4388,8 @@ static bool permuteGpuIds(int *g, int n, int last, struct rcclRomeModel* ref, st
     // match XGMI connection
     for (i = 0; i < ref->nGpus; i++) {
       for (j = 0; j < ref->nGpus; j++) {
-        if (ref->connMatrix[i*ref->nGpus+j] != topo->connMatrix[g[i]*ref->nGpus+g[j]]) break;
-        if ((ref->gpuIds[i]-ref->gpuIds[j])*(topo->gpuIds[g[i]]-topo->gpuIds[g[j]]) < 0) break;
+        if (ref->connMatrix[i * ref->nGpus + j] != topo->connMatrix[g[i] * ref->nGpus + g[j]]) break;
+        if ((ref->gpuIds[i] - ref->gpuIds[j]) * (topo->gpuIds[g[i]] - topo->gpuIds[g[j]]) < 0) break;
       }
       if (j < ref->nGpus) break;
     }
@@ -2390,10 +4399,10 @@ static bool permuteGpuIds(int *g, int n, int last, struct rcclRomeModel* ref, st
       for (i = 0; i < ref->nGpus; i++) {
         for (j = 0; j < ref->nGpus; j++) {
           if (i == j) continue;
-          bool nbio_ref = (ref->gpuIds[i]&0xf0000) == (ref->gpuIds[j]&0xf0000);
-          bool nbio_topo = (topo->gpuIds[g[i]]&0xf0000) == (topo->gpuIds[g[j]]&0xf0000);
+          bool nbio_ref = (ref->gpuIds[i] & 0xf0000) == (ref->gpuIds[j] & 0xf0000);
+          bool nbio_topo = (topo->gpuIds[g[i]] & 0xf0000) == (topo->gpuIds[g[j]] & 0xf0000);
           if (nbio_ref != nbio_topo) break;
-          if (nbio_ref && ((ref->gpuIds[i]-ref->gpuIds[j])*(topo->gpuIds[g[i]]-topo->gpuIds[g[j]]) < 0)) break;
+          if (nbio_ref && ((ref->gpuIds[i] - ref->gpuIds[j]) * (topo->gpuIds[g[i]] - topo->gpuIds[g[j]]) < 0)) break;
         }
         if (j < ref->nGpus) break;
       }
@@ -2403,15 +4412,16 @@ static bool permuteGpuIds(int *g, int n, int last, struct rcclRomeModel* ref, st
   } else {
     for (int i = n; i <= last; i++) {
       std::swap(g[n], g[i]);
-      if (permuteGpuIds(g, n+1, last, ref, topo, time, nbio, ignore_numa)) return true;
+      if (permuteGpuIds(g, n + 1, last, ref, topo, time, nbio, ignore_numa)) return true;
       std::swap(g[n], g[i]);
     }
   }
   return false;
 }
 
-static bool permuteNetIds(int *n, int *g, int s, int last, struct rcclRomeModel* ref, struct rcclRomeModel* topo, int* time, bool ignore_numa) {
-  (*time) ++;
+static bool permuteNetIds(int* n, int* g, int s, int last, struct rcclRomeModel* ref, struct rcclRomeModel* topo,
+                          int* time, bool ignore_numa) {
+  (*time)++;
   if (s == last) {
     int i, j;
     // match NET numa
@@ -2425,12 +4435,12 @@ static bool permuteNetIds(int *n, int *g, int s, int last, struct rcclRomeModel*
     for (i = 0; i < ref->nNics; i++) {
       for (j = 0; j < ref->nGpus; j++) {
         // enabling PXN override paths over PHB and SYS
-        if (topo->gdrLevel[n[i]*ref->nGpus+g[j]] == PATH_PXN) continue;
+        if (topo->gdrLevel[n[i] * ref->nGpus + g[j]] == PATH_PXN) continue;
         // treat PIX and PXB as same
-        if ((ref->gdrLevel[i*ref->nGpus+j] == PATH_PXB && topo->gdrLevel[n[i]*ref->nGpus+g[j]] == PATH_PIX) ||
-          (ref->gdrLevel[i*ref->nGpus+j] == PATH_PIX && topo->gdrLevel[n[i]*ref->nGpus+g[j]] == PATH_PXB))
+        if ((ref->gdrLevel[i * ref->nGpus + j] == PATH_PXB && topo->gdrLevel[n[i] * ref->nGpus + g[j]] == PATH_PIX) ||
+            (ref->gdrLevel[i * ref->nGpus + j] == PATH_PIX && topo->gdrLevel[n[i] * ref->nGpus + g[j]] == PATH_PXB))
           continue;
-        if (ref->gdrLevel[i*ref->nGpus+j] != topo->gdrLevel[n[i]*ref->nGpus+g[j]]) break;
+        if (ref->gdrLevel[i * ref->nGpus + j] != topo->gdrLevel[n[i] * ref->nGpus + g[j]]) break;
       }
       if (j < ref->nGpus) break;
     }
@@ -2439,30 +4449,26 @@ static bool permuteNetIds(int *n, int *g, int s, int last, struct rcclRomeModel*
   } else {
     for (int i = s; i <= last; i++) {
       std::swap(n[s], n[i]);
-      if (permuteNetIds(n, g, s+1, last, ref, topo, time, ignore_numa)) return true;
+      if (permuteNetIds(n, g, s + 1, last, ref, topo, time, ignore_numa)) return true;
       std::swap(n[s], n[i]);
     }
   }
   return false;
 }
 
-int checkAlltoallWidth(struct rcclRomeModel *romeTopo) {
+int checkAlltoallWidth(struct rcclRomeModel* romeTopo) {
   int i, width = 0;
   for (i = 0; i < romeTopo->nGpus; i++) {
     int j;
     for (j = 0; j < romeTopo->nGpus; j++) {
       if (i == j) continue;
-      if (romeTopo->connMatrix[i*romeTopo->nGpus+j] == 0)
-        break;
-      if (width == 0)
-        width = romeTopo->connMatrix[i*romeTopo->nGpus+j];
-      else if (width != romeTopo->connMatrix[i*romeTopo->nGpus+j])
-        break;
+      if (romeTopo->connMatrix[i * romeTopo->nGpus + j] == 0) break;
+      if (width == 0) width = romeTopo->connMatrix[i * romeTopo->nGpus + j];
+      else if (width != romeTopo->connMatrix[i * romeTopo->nGpus + j]) break;
     }
     if (j < romeTopo->nGpus) break;
   }
-  if (i < romeTopo->nGpus)
-    width = 0;
+  if (i < romeTopo->nGpus) width = 0;
   return width;
 }
 
@@ -2486,22 +4492,19 @@ static void applyNetOverride(struct ncclTopoSystem* system, const char* options)
       if (system->nodes[GPU].nodes[j].paths[NET][i].type == PATH_PXB) {
         int k;
         for (k = 0; k < system->nodes[GPU].count; k++) {
-          if (k != j &&
-            system->nodes[GPU].nodes[k].gpu.dev/2 == system->nodes[GPU].nodes[j].gpu.dev/2)
-            break;
+          if (k != j && system->nodes[GPU].nodes[k].gpu.dev / 2 == system->nodes[GPU].nodes[j].gpu.dev / 2) break;
         }
-        if (k < system->nodes[GPU].count)
-          system->nodes[GPU].nodes[k].paths[NET][i].type = PATH_PXB;
+        if (k < system->nodes[GPU].count) system->nodes[GPU].nodes[k].paths[NET][i].type = PATH_PXB;
       }
     }
   }
 }
 
-ncclResult_t parseA2a8P(struct ncclTopoSystem* system, struct ncclTopoGraph* graph, const char *ringBase) {
+ncclResult_t parseA2a8P(struct ncclTopoSystem* system, struct ncclTopoGraph* graph, const char* ringBase) {
   constexpr int NUMA_CPUS = 2;
   constexpr int NUMA_GPUS = 4;
   constexpr int NUMA_PERMUTE_COUNT = 24;
-  constexpr int TOTAL_PERMUTE_COUNT = (NUMA_PERMUTE_COUNT*NUMA_PERMUTE_COUNT);
+  constexpr int TOTAL_PERMUTE_COUNT = (NUMA_PERMUTE_COUNT * NUMA_PERMUTE_COUNT);
 
   int i;
 
@@ -2523,7 +4526,7 @@ ncclResult_t parseA2a8P(struct ncclTopoSystem* system, struct ncclTopoGraph* gra
   if (!isAlltoall) return ncclSuccess;
 
   int *g8, n[NCCL_TOPO_MAX_NODES];
-  int *all_gpu_permutations = (int *)malloc(TOTAL_PERMUTE_COUNT*NUMA_CPUS*NUMA_GPUS*sizeof(int));
+  int* all_gpu_permutations = (int*)malloc(TOTAL_PERMUTE_COUNT * NUMA_CPUS * NUMA_GPUS * sizeof(int));
   if (all_gpu_permutations == nullptr) {
     WARN("Failed to allocate memory for GPU permutations");
     return ncclSystemError;
@@ -2531,14 +4534,14 @@ ncclResult_t parseA2a8P(struct ncclTopoSystem* system, struct ncclTopoGraph* gra
   struct timeval tvs, tve;
   gettimeofday(&tvs, NULL);
   std::vector<int> r(ngpus), g(ngpus), rdm(ngpus);
-  for (i = 0; i < sizeof(romeTopoModels)/sizeof(romeTopoModels[0]); i++) {
+  for (i = 0; i < sizeof(romeTopoModels) / sizeof(romeTopoModels[0]); i++) {
     if (romeTopo.nCpus != romeTopoModels[i].nCpus || romeTopo.nGpus != romeTopoModels[i].nGpus ||
-      romeTopo.nNics != romeTopoModels[i].nNics || romeTopo.nLinks != romeTopoModels[i].nLinks) continue;
+        romeTopo.nNics != romeTopoModels[i].nNics || romeTopo.nLinks != romeTopoModels[i].nLinks)
+      continue;
     if (strcmp(romeTopoModels[i].pattern, pattern)) continue;
     int j;
     int numa_gpu_permutations[NUMA_CPUS][NUMA_PERMUTE_COUNT][NUMA_GPUS];
-    if (isAlltoall != checkAlltoallWidth(romeTopoModels+i))
-      continue;
+    if (isAlltoall != checkAlltoallWidth(romeTopoModels + i)) continue;
     // permute GPUs for each CPU NUMA nodes
     for (j = 0; j < ncpus; j++) {
       int ngpusPerNuma = 0, cnt = 0, npermute = 0;
@@ -2551,70 +4554,71 @@ ncclResult_t parseA2a8P(struct ncclTopoSystem* system, struct ncclTopoGraph* gra
       // init GPU mapping
       for (int k = 0; k < ngpus; k++) {
         if (romeTopo.gpuNuma[k] != j) continue;
-        g[(2+cnt++)%ngpusPerNuma] = k;
+        g[(2 + cnt++) % ngpusPerNuma] = k;
       }
-      std::sort(g.begin(), g.begin()+ngpusPerNuma);
+      std::sort(g.begin(), g.begin() + ngpusPerNuma);
       do {
-        for (int n = 0; n < ngpusPerNuma; n++)
-          numa_gpu_permutations[j][npermute][n] = g[n];
+        for (int n = 0; n < ngpusPerNuma; n++) numa_gpu_permutations[j][npermute][n] = g[n];
         npermute++;
-      } while (std::next_permutation(g.begin(), g.begin()+ngpusPerNuma));
+      } while (std::next_permutation(g.begin(), g.begin() + ngpusPerNuma));
       if (npermute != NUMA_PERMUTE_COUNT) break;
     }
     if (j < ncpus) continue;
     // permute GPUs for all CPU NUMA nodes
     for (int a = 0; a < NUMA_PERMUTE_COUNT; a++) {
       for (int b = 0; b < NUMA_PERMUTE_COUNT; b++) {
-        uint64_t offset = a*NUMA_PERMUTE_COUNT+b;
-        //offset = (offset+TOTAL_PERMUTE_COUNT/2)%TOTAL_PERMUTE_COUNT;
-        offset *= (NUMA_CPUS*NUMA_GPUS);
-        memcpy(all_gpu_permutations+offset, &numa_gpu_permutations[0][a][0], NUMA_GPUS*sizeof(int));
-        memcpy(all_gpu_permutations+offset+NUMA_GPUS, &numa_gpu_permutations[1][b][0], NUMA_GPUS*sizeof(int));
+        uint64_t offset = a * NUMA_PERMUTE_COUNT + b;
+        // offset = (offset+TOTAL_PERMUTE_COUNT/2)%TOTAL_PERMUTE_COUNT;
+        offset *= (NUMA_CPUS * NUMA_GPUS);
+        memcpy(all_gpu_permutations + offset, &numa_gpu_permutations[0][a][0], NUMA_GPUS * sizeof(int));
+        memcpy(all_gpu_permutations + offset + NUMA_GPUS, &numa_gpu_permutations[1][b][0], NUMA_GPUS * sizeof(int));
       }
     }
     // match all GPUs' XGMI connection
     int p;
     for (p = 0; p < TOTAL_PERMUTE_COUNT; p++) {
-      g8 = all_gpu_permutations+p*NUMA_CPUS*NUMA_GPUS;
+      g8 = all_gpu_permutations + p * NUMA_CPUS * NUMA_GPUS;
       int k;
       for (k = 0; k < romeTopoModels[i].nGpus; k++) {
         int m;
         for (m = 0; m < romeTopoModels[i].nGpus; m++) {
-          if (romeTopoModels[i].connMatrix[k*romeTopoModels[i].nGpus+m] != romeTopo.connMatrix[g8[k]*romeTopoModels[i].nGpus+g8[m]]) break;
+          if (romeTopoModels[i].connMatrix[k * romeTopoModels[i].nGpus + m] !=
+              romeTopo.connMatrix[g8[k] * romeTopoModels[i].nGpus + g8[m]])
+            break;
         }
         if (m < romeTopoModels[i].nGpus) break;
       }
       if (k < romeTopoModels[i].nGpus) continue;
-      //printf("found match %d: ", p); for (int n = 0; n < NUMA_CPUS*NUMA_GPUS; n++) printf("%d ", g8[n]); printf("\n");
+      // printf("found match %d: ", p); for (int n = 0; n < NUMA_CPUS*NUMA_GPUS; n++) printf("%d ", g8[n]); printf("\n");
       if (nnets > 1) {
         // permute NET IDs
         int time = 0;
-        for (int m = 0; m < nnets; m++) n[m] = (m+2)%nnets;
-        if (permuteNetIds(n, g8, 0, nnets-1, romeTopoModels+i, &romeTopo, &time, false)) break;
+        for (int m = 0; m < nnets; m++) n[m] = (m + 2) % nnets;
+        if (permuteNetIds(n, g8, 0, nnets - 1, romeTopoModels + i, &romeTopo, &time, false)) break;
       } else break;
     }
     if (p < TOTAL_PERMUTE_COUNT) break;
   }
   gettimeofday(&tve, NULL);
-  if (i >= sizeof(romeTopoModels)/sizeof(romeTopoModels[0])) {
-    //printf("No solution in %.2fms\n", t);
+  if (i >= sizeof(romeTopoModels) / sizeof(romeTopoModels[0])) {
+    // printf("No solution in %.2fms\n", t);
     return ncclSuccess;
   }
-  for (int m = 0; m<ngpus; m++) rdm[m] = devids[g8[m]];
+  for (int m = 0; m < ngpus; m++) rdm[m] = devids[g8[m]];
 
   char line[1024];
-  //sprintf(line, "Found matching Rome model index %d in %.2fms with GPU mapping: ", i, t);
+  // sprintf(line, "Found matching Rome model index %d in %.2fms with GPU mapping: ", i, t);
   sprintf(line, "Found matching Rome model index %d with GPU mapping: ", i);
   int offset = strlen(line);
   for (int k = 0; k < ngpus; k++) {
-    sprintf(line+offset, "%d ", rdm[k]);
+    sprintf(line + offset, "%d ", rdm[k]);
     offset = strlen(line);
   }
   if (nnets > 1) {
-    sprintf(line+offset, "NET mapping: ");
+    sprintf(line + offset, "NET mapping: ");
     offset = strlen(line);
     for (int k = 0; k < nnets; k++) {
-      sprintf(line+offset, "%d ", n[k]);
+      sprintf(line + offset, "%d ", n[k]);
       offset = strlen(line);
     }
   }
@@ -2628,23 +4632,24 @@ ncclResult_t parseA2a8P(struct ncclTopoSystem* system, struct ncclTopoGraph* gra
     // Attempt to use rail-optimized rings if they exist
     if (system->nHosts % 2 == 0) {
       // For even number of nodes, alternate forward/reverse on ringBase
-      NCCLCHECK(parseGraph(ringBase != nullptr ? ringBase : romeTopoModels[i].ringBase, system, graph, rdm.data(), nnets > 1 ? n : NULL, system->hostIdx % 2));
-    }
-    else {
+      NCCLCHECK(parseGraph(ringBase != nullptr ? ringBase : romeTopoModels[i].ringBase, system, graph, rdm.data(),
+                           nnets > 1 ? n : NULL, system->hostIdx % 2));
+    } else {
       // For odd number of nodes, check first to see if ringTail1 and ringTail2 are defined
       if (system->nHosts == 1 || romeTopoModels[i].ringTail1 == nullptr || romeTopoModels[i].ringTail2 == nullptr) {
         if (system->nHosts > 1)
-          INFO(NCCL_GRAPH, "[WARN] Dropping back due to lack of support for odd-number of nodes for model index %d\n", i);
-        NCCLCHECK(parseGraph(ringBase != nullptr ? ringBase : romeTopoModels[i].ringBase, system, graph, rdm.data(), nnets > 1 ? n : NULL, system->hostIdx % 2));
-      }
-      else
-      {
+          INFO(NCCL_GRAPH, "[WARN] Dropping back due to lack of support for odd-number of nodes for model index %d\n",
+               i);
+        NCCLCHECK(parseGraph(ringBase != nullptr ? ringBase : romeTopoModels[i].ringBase, system, graph, rdm.data(),
+                             nnets > 1 ? n : NULL, system->hostIdx % 2));
+      } else {
         if (system->hostIdx == (system->nHosts - 1)) {
           NCCLCHECK(parseGraph(romeTopoModels[i].ringTail1, system, graph, rdm.data(), nnets > 1 ? n : NULL, 0));
         } else if (system->hostIdx == (system->nHosts - 2)) {
           NCCLCHECK(parseGraph(romeTopoModels[i].ringTail2, system, graph, rdm.data(), nnets > 1 ? n : NULL, 0));
         } else {
-          NCCLCHECK(parseGraph(ringBase != nullptr ? ringBase : romeTopoModels[i].ringBase, system, graph, rdm.data(), nnets > 1 ? n : NULL, system->hostIdx % 2));
+          NCCLCHECK(parseGraph(ringBase != nullptr ? ringBase : romeTopoModels[i].ringBase, system, graph, rdm.data(),
+                               nnets > 1 ? n : NULL, system->hostIdx % 2));
         }
       }
     }
@@ -2654,7 +4659,6 @@ ncclResult_t parseA2a8P(struct ncclTopoSystem* system, struct ncclTopoGraph* gra
     // Check if rail-optimized trees have been defined
     system->useRailOptimizedTrees = false;
     if (romeTopoModels[i].treeRail != nullptr && !rcclParamDisableRailTrees()) {
-
       // If so, parse the lines in advanced
       // These lines will be modified appropriately during ncclTopoPostset
       NCCLCHECK(parseGraph(romeTopoModels[i].treeRail, system, graph, g8, nnets > 1 ? n : NULL, 0));
@@ -2672,7 +4676,8 @@ ncclResult_t parseA2a8P(struct ncclTopoSystem* system, struct ncclTopoGraph* gra
 
     if (!graph->nChannels) {
       // Fall back to tree from ringBase
-      NCCLCHECK(parseGraph(ringBase != nullptr ? ringBase : romeTopoModels[i].ringBase, system, graph, rdm.data(), nnets > 1 ? n : NULL, 0));
+      NCCLCHECK(parseGraph(ringBase != nullptr ? ringBase : romeTopoModels[i].ringBase, system, graph, rdm.data(),
+                           nnets > 1 ? n : NULL, 0));
     }
     applyNetOverride(system, romeTopoModels[i].options);
     break;
@@ -2687,16 +4692,14 @@ ncclResult_t parseA2a8P(struct ncclTopoSystem* system, struct ncclTopoGraph* gra
   return ncclSuccess;
 }
 
-ncclResult_t parseRome4P2H(struct ncclTopoSystem* system, struct ncclTopoGraph* graph, const char *ringBase) {
+ncclResult_t parseRome4P2H(struct ncclTopoSystem* system, struct ncclTopoGraph* graph, const char* ringBase) {
   int i;
 
   int ngpus = system->nodes[GPU].count;
   int nnets = system->nodes[NET].count;
 
   // Only support ring and tree graphs
-  if (graph->pattern != NCCL_TOPO_PATTERN_RING &&
-      graph->pattern != NCCL_TOPO_PATTERN_BALANCED_TREE)
-    return ncclSuccess;
+  if (graph->pattern != NCCL_TOPO_PATTERN_RING && graph->pattern != NCCL_TOPO_PATTERN_BALANCED_TREE) return ncclSuccess;
 
   if (ngpus > 8) return ncclSuccess;
   // only valid on Rome
@@ -2713,7 +4716,7 @@ ncclResult_t parseRome4P2H(struct ncclTopoSystem* system, struct ncclTopoGraph* 
   if (ngpus > 4 && romeTopo.nLinks) system->type |= RCCL_TOPO_4P2H_ROME;
 
   // detect multiple NICs per GPU
-  int nnetspergpu = (nnets%ngpus == 0) ? nnets/ngpus : 0;
+  int nnetspergpu = (nnets % ngpus == 0) ? nnets / ngpus : 0;
 
   int g[NCCL_TOPO_MAX_NODES], n[NCCL_TOPO_MAX_NODES], rdm[NCCL_TOPO_MAX_NODES];
   int time = 0;
@@ -2724,24 +4727,28 @@ ncclResult_t parseRome4P2H(struct ncclTopoSystem* system, struct ncclTopoGraph* 
   bool match_nbio = true;
   for (i = 0; i < romeTopo.nGpus; i++) {
     int cpu, gpu;
-    NCCLCHECK(ncclTopoIdToIndex(system, CPU,  romeTopo.gpuNuma[i], &cpu));
-    NCCLCHECK(ncclTopoIdToIndex(system, GPU,  romeTopo.gpuIds[i], &gpu));
+    NCCLCHECK(ncclTopoIdToIndex(system, CPU, romeTopo.gpuNuma[i], &cpu));
+    NCCLCHECK(ncclTopoIdToIndex(system, GPU, romeTopo.gpuIds[i], &gpu));
     if (system->nodes[GPU].nodes[gpu].paths[CPU][cpu].count > 2) break;
   }
   if (i < romeTopo.nGpus) match_nbio = false;
 
-  for (i = 0; i < sizeof(romeTopoModels)/sizeof(romeTopoModels[0]); i++) {
+  for (i = 0; i < sizeof(romeTopoModels) / sizeof(romeTopoModels[0]); i++) {
     bool ignore_cpu = checkOption(romeTopoModels[i].options, "noCpuCheck");
-    if (!ignore_cpu && (arch != NCCL_TOPO_CPU_ARCH_X86 || vendor != NCCL_TOPO_CPU_VENDOR_AMD || model != NCCL_TOPO_CPU_MODEL_AMD_ROME))
+    if (!ignore_cpu &&
+        (arch != NCCL_TOPO_CPU_ARCH_X86 || vendor != NCCL_TOPO_CPU_VENDOR_AMD || model != NCCL_TOPO_CPU_MODEL_AMD_ROME))
       continue;
     bool ignore_numa = checkOption(romeTopoModels[i].options, "disableNumaMatching");
     if (!ignore_numa && romeTopo.nCpus != romeTopoModels[i].nCpus) continue;
-    if (romeTopo.nGpus != romeTopoModels[i].nGpus ||
-      romeTopo.nNics != romeTopoModels[i].nNics || romeTopo.nLinks != romeTopoModels[i].nLinks) continue;
+    if (romeTopo.nGpus != romeTopoModels[i].nGpus || romeTopo.nNics != romeTopoModels[i].nNics ||
+        romeTopo.nLinks != romeTopoModels[i].nLinks)
+      continue;
     if (!ignore_numa && strcmp(romeTopoModels[i].pattern, pattern)) continue;
     // permute GPU IDs
-    for (int j = 0; j < ngpus; j++) g[j] = (j+2)%ngpus;
-    if (!permuteGpuIds(g, 0, ngpus-1, romeTopoModels+i, &romeTopo, &time, ignore_cpu ? false : match_nbio, ignore_numa)) continue;
+    for (int j = 0; j < ngpus; j++) g[j] = (j + 2) % ngpus;
+    if (!permuteGpuIds(g, 0, ngpus - 1, romeTopoModels + i, &romeTopo, &time, ignore_cpu ? false : match_nbio,
+                       ignore_numa))
+      continue;
     if (nnetspergpu > 1) {
       int found = 0;
       // initialize nics mapping
@@ -2761,8 +4768,8 @@ ncclResult_t parseRome4P2H(struct ncclTopoSystem* system, struct ncclTopoGraph* 
           // check GDR
           for (g = 0; g < ngpus; g++) {
             // enabling PXN override paths over PHB and SYS
-            if (romeTopo.gdrLevel[k*ngpus+g] == PATH_PXN) continue;
-            if (romeTopoModels[i].gdrLevel[j*ngpus+g] != romeTopo.gdrLevel[k*ngpus+g]) break;
+            if (romeTopo.gdrLevel[k * ngpus + g] == PATH_PXN) continue;
+            if (romeTopoModels[i].gdrLevel[j * ngpus + g] != romeTopo.gdrLevel[k * ngpus + g]) break;
           }
           if (g >= ngpus) break;
         }
@@ -2778,31 +4785,31 @@ ncclResult_t parseRome4P2H(struct ncclTopoSystem* system, struct ncclTopoGraph* 
     } else {
       if (nnets > 1) {
         // permute NET IDs
-        for (int j = 0; j < nnets; j++) n[j] = (j+2)%nnets;
-        if (permuteNetIds(n, g, 0, nnets-1, romeTopoModels+i, &romeTopo, &time, ignore_numa)) break;
+        for (int j = 0; j < nnets; j++) n[j] = (j + 2) % nnets;
+        if (permuteNetIds(n, g, 0, nnets - 1, romeTopoModels + i, &romeTopo, &time, ignore_numa)) break;
       } else break;
     }
   }
   gettimeofday(&tve, NULL);
-  if (i >= sizeof(romeTopoModels)/sizeof(romeTopoModels[0])) {
-    //printf("No solution in %.2fms (%d iter)\n", t, time);
+  if (i >= sizeof(romeTopoModels) / sizeof(romeTopoModels[0])) {
+    // printf("No solution in %.2fms (%d iter)\n", t, time);
     return ncclSuccess;
   }
-  for (int m = 0; m<ngpus; m++) rdm[m] = devids[g[m]];
+  for (int m = 0; m < ngpus; m++) rdm[m] = devids[g[m]];
 
   char line[1024];
-  //sprintf(line, "Found matching Rome model index %d in %.2fms (%d iter) with GPU mapping: ", i, t, time);
+  // sprintf(line, "Found matching Rome model index %d in %.2fms (%d iter) with GPU mapping: ", i, t, time);
   sprintf(line, "Found matching Rome model index %d with GPU mapping: ", i);
   int offset = strlen(line);
   for (int k = 0; k < ngpus; k++) {
-    sprintf(line+offset, "%d ", rdm[k]);
+    sprintf(line + offset, "%d ", rdm[k]);
     offset = strlen(line);
   }
   if (nnets > 1) {
-    sprintf(line+offset, "NET mapping: ");
+    sprintf(line + offset, "NET mapping: ");
     offset = strlen(line);
     for (int k = 0; k < nnets; k++) {
-      sprintf(line+offset, "%d ", n[k]);
+      sprintf(line + offset, "%d ", n[k]);
       offset = strlen(line);
     }
   }
@@ -2816,23 +4823,24 @@ ncclResult_t parseRome4P2H(struct ncclTopoSystem* system, struct ncclTopoGraph* 
     // Attempt to use rail-optimized rings if they exist
     if (system->nHosts % 2 == 0) {
       // For even number of nodes, alternate forward/reverse on ringBase
-      NCCLCHECK(parseGraph(ringBase != nullptr ? ringBase : romeTopoModels[i].ringBase, system, graph, rdm, nnets > 1 ? n : NULL, system->hostIdx % 2));
-    }
-    else {
+      NCCLCHECK(parseGraph(ringBase != nullptr ? ringBase : romeTopoModels[i].ringBase, system, graph, rdm,
+                           nnets > 1 ? n : NULL, system->hostIdx % 2));
+    } else {
       // For odd number of nodes, check first to see if ringTail1 and ringTail2 are defined
       if (system->nHosts == 1 || romeTopoModels[i].ringTail1 == nullptr || romeTopoModels[i].ringTail2 == nullptr) {
         if (system->nHosts > 1)
-          INFO(NCCL_GRAPH, "[WARN] Dropping back due to lack of support for odd-number of nodes for model index %d\n", i);
-        NCCLCHECK(parseGraph(ringBase != nullptr ? ringBase : romeTopoModels[i].ringBase, system, graph, rdm, nnets > 1 ? n : NULL, system->hostIdx % 2));
-      }
-      else
-      {
+          INFO(NCCL_GRAPH, "[WARN] Dropping back due to lack of support for odd-number of nodes for model index %d\n",
+               i);
+        NCCLCHECK(parseGraph(ringBase != nullptr ? ringBase : romeTopoModels[i].ringBase, system, graph, rdm,
+                             nnets > 1 ? n : NULL, system->hostIdx % 2));
+      } else {
         if (system->hostIdx == (system->nHosts - 1)) {
           NCCLCHECK(parseGraph(romeTopoModels[i].ringTail1, system, graph, rdm, nnets > 1 ? n : NULL, 0));
         } else if (system->hostIdx == (system->nHosts - 2)) {
           NCCLCHECK(parseGraph(romeTopoModels[i].ringTail2, system, graph, rdm, nnets > 1 ? n : NULL, 0));
         } else {
-          NCCLCHECK(parseGraph(ringBase != nullptr ? ringBase : romeTopoModels[i].ringBase, system, graph, rdm, nnets > 1 ? n : NULL, system->hostIdx % 2));
+          NCCLCHECK(parseGraph(ringBase != nullptr ? ringBase : romeTopoModels[i].ringBase, system, graph, rdm,
+                               nnets > 1 ? n : NULL, system->hostIdx % 2));
         }
       }
     }
@@ -2844,7 +4852,8 @@ ncclResult_t parseRome4P2H(struct ncclTopoSystem* system, struct ncclTopoGraph* 
 
     if (!graph->nChannels) {
       // Fall back to tree from ringBase
-      NCCLCHECK(parseGraph(ringBase != nullptr ? ringBase : romeTopoModels[i].ringBase, system, graph, rdm, nnets > 1 ? n : NULL, 0));
+      NCCLCHECK(parseGraph(ringBase != nullptr ? ringBase : romeTopoModels[i].ringBase, system, graph, rdm,
+                           nnets > 1 ? n : NULL, 0));
     }
     applyNetOverride(system, romeTopoModels[i].options);
     break;
@@ -2859,7 +4868,8 @@ ncclResult_t parse1H16P(struct ncclTopoSystem* system, struct ncclTopoGraph* gra
   constexpr int NUMA_CPUS = 4;
   constexpr int NUMA_GPUS = 4;
   constexpr int NUMA_PERMUTE_COUNT = 24;
-  constexpr int TOTAL_PERMUTE_COUNT = (NUMA_PERMUTE_COUNT*NUMA_PERMUTE_COUNT*NUMA_PERMUTE_COUNT*NUMA_PERMUTE_COUNT);
+  constexpr int TOTAL_PERMUTE_COUNT =
+    (NUMA_PERMUTE_COUNT * NUMA_PERMUTE_COUNT * NUMA_PERMUTE_COUNT * NUMA_PERMUTE_COUNT);
 
   int i;
 
@@ -2876,14 +4886,14 @@ ncclResult_t parse1H16P(struct ncclTopoSystem* system, struct ncclTopoGraph* gra
   // number of GPUs and NICs on each numa node is used as first screening pattern
   struct rcclRomeModel romeTopo;
   char pattern[256];
-  int devids[NUMA_CPUS*NUMA_GPUS];
+  int devids[NUMA_CPUS * NUMA_GPUS];
   NCCLCHECK(parseRomeSystem(system, &romeTopo, pattern, devids));
 
   // only match for system with 16 GPUs
   if (ngpus != 16 || ncpus != NUMA_CPUS) return ncclSuccess;
 
-  int *g16, n[NCCL_TOPO_MAX_NODES], rdm[NUMA_GPUS*NUMA_CPUS];
-  int *all_gpu_permutations = (int *)malloc(TOTAL_PERMUTE_COUNT*NUMA_CPUS*NUMA_GPUS*sizeof(int));
+  int *g16, n[NCCL_TOPO_MAX_NODES], rdm[NUMA_GPUS * NUMA_CPUS];
+  int* all_gpu_permutations = (int*)malloc(TOTAL_PERMUTE_COUNT * NUMA_CPUS * NUMA_GPUS * sizeof(int));
   if (all_gpu_permutations == nullptr) {
     WARN("Failed to allocate memory for GPU permutations");
     return ncclSystemError;
@@ -2891,9 +4901,10 @@ ncclResult_t parse1H16P(struct ncclTopoSystem* system, struct ncclTopoGraph* gra
   struct timeval tvs, tve;
   gettimeofday(&tvs, NULL);
   std::vector<int> r(ngpus), g(ngpus);
-  for (i = 0; i < sizeof(romeTopoModels)/sizeof(romeTopoModels[0]); i++) {
+  for (i = 0; i < sizeof(romeTopoModels) / sizeof(romeTopoModels[0]); i++) {
     if (romeTopo.nCpus != romeTopoModels[i].nCpus || romeTopo.nGpus != romeTopoModels[i].nGpus ||
-      romeTopo.nNics != romeTopoModels[i].nNics || romeTopo.nLinks != romeTopoModels[i].nLinks) continue;
+        romeTopo.nNics != romeTopoModels[i].nNics || romeTopo.nLinks != romeTopoModels[i].nLinks)
+      continue;
     if (strcmp(romeTopoModels[i].pattern, pattern)) continue;
     int j;
     int numa_gpu_permutations[NUMA_CPUS][NUMA_PERMUTE_COUNT][NUMA_GPUS];
@@ -2909,14 +4920,13 @@ ncclResult_t parse1H16P(struct ncclTopoSystem* system, struct ncclTopoGraph* gra
       // init GPU mapping
       for (int k = 0; k < ngpus; k++) {
         if (romeTopo.gpuNuma[k] != j) continue;
-        g[(2+cnt++)%ngpusPerNuma] = k;
+        g[(2 + cnt++) % ngpusPerNuma] = k;
       }
-      std::sort(g.begin(), g.begin()+ngpusPerNuma);
+      std::sort(g.begin(), g.begin() + ngpusPerNuma);
       do {
-        for (int n = 0; n < ngpusPerNuma; n++)
-          numa_gpu_permutations[j][npermute][n] = g[n];
+        for (int n = 0; n < ngpusPerNuma; n++) numa_gpu_permutations[j][npermute][n] = g[n];
         npermute++;
-      } while (std::next_permutation(g.begin(), g.begin()+ngpusPerNuma));
+      } while (std::next_permutation(g.begin(), g.begin() + ngpusPerNuma));
       if (npermute != NUMA_PERMUTE_COUNT) break;
     }
     if (j < ncpus) continue;
@@ -2925,13 +4935,15 @@ ncclResult_t parse1H16P(struct ncclTopoSystem* system, struct ncclTopoGraph* gra
       for (int b = 0; b < NUMA_PERMUTE_COUNT; b++) {
         for (int c = 0; c < NUMA_PERMUTE_COUNT; c++) {
           for (int d = 0; d < NUMA_PERMUTE_COUNT; d++) {
-            uint64_t offset = ((a*NUMA_PERMUTE_COUNT+b)*NUMA_PERMUTE_COUNT+c)*NUMA_PERMUTE_COUNT+d;
-            //offset = (offset+TOTAL_PERMUTE_COUNT/2)%TOTAL_PERMUTE_COUNT;
-            offset *= (NUMA_CPUS*NUMA_GPUS);
-            memcpy(all_gpu_permutations+offset, &numa_gpu_permutations[0][a][0], NUMA_GPUS*sizeof(int));
-            memcpy(all_gpu_permutations+offset+NUMA_GPUS, &numa_gpu_permutations[1][b][0], NUMA_GPUS*sizeof(int));
-            memcpy(all_gpu_permutations+offset+NUMA_GPUS*2, &numa_gpu_permutations[2][c][0], NUMA_GPUS*sizeof(int));
-            memcpy(all_gpu_permutations+offset+NUMA_GPUS*3, &numa_gpu_permutations[3][d][0], NUMA_GPUS*sizeof(int));
+            uint64_t offset = ((a * NUMA_PERMUTE_COUNT + b) * NUMA_PERMUTE_COUNT + c) * NUMA_PERMUTE_COUNT + d;
+            // offset = (offset+TOTAL_PERMUTE_COUNT/2)%TOTAL_PERMUTE_COUNT;
+            offset *= (NUMA_CPUS * NUMA_GPUS);
+            memcpy(all_gpu_permutations + offset, &numa_gpu_permutations[0][a][0], NUMA_GPUS * sizeof(int));
+            memcpy(all_gpu_permutations + offset + NUMA_GPUS, &numa_gpu_permutations[1][b][0], NUMA_GPUS * sizeof(int));
+            memcpy(all_gpu_permutations + offset + NUMA_GPUS * 2, &numa_gpu_permutations[2][c][0],
+                   NUMA_GPUS * sizeof(int));
+            memcpy(all_gpu_permutations + offset + NUMA_GPUS * 3, &numa_gpu_permutations[3][d][0],
+                   NUMA_GPUS * sizeof(int));
           }
         }
       }
@@ -2939,46 +4951,48 @@ ncclResult_t parse1H16P(struct ncclTopoSystem* system, struct ncclTopoGraph* gra
     // match all GPUs' XGMI connection
     int p;
     for (p = 0; p < TOTAL_PERMUTE_COUNT; p++) {
-      g16 = all_gpu_permutations+p*NUMA_CPUS*NUMA_GPUS;
+      g16 = all_gpu_permutations + p * NUMA_CPUS * NUMA_GPUS;
       int k;
       for (k = 0; k < romeTopoModels[i].nGpus; k++) {
         int m;
         for (m = 0; m < romeTopoModels[i].nGpus; m++) {
-          if (romeTopoModels[i].connMatrix[k*romeTopoModels[i].nGpus+m] != romeTopo.connMatrix[g16[k]*romeTopoModels[i].nGpus+g16[m]]) break;
+          if (romeTopoModels[i].connMatrix[k * romeTopoModels[i].nGpus + m] !=
+              romeTopo.connMatrix[g16[k] * romeTopoModels[i].nGpus + g16[m]])
+            break;
         }
         if (m < romeTopoModels[i].nGpus) break;
       }
       if (k < romeTopoModels[i].nGpus) continue;
-      //printf("found match %d: ", p); for (int n = 0; n < NUMA_CPUS*NUMA_GPUS; n++) printf("%d ", g16[n]); printf("\n");
+      // printf("found match %d: ", p); for (int n = 0; n < NUMA_CPUS*NUMA_GPUS; n++) printf("%d ", g16[n]); printf("\n");
       if (nnets > 1) {
         // permute NET IDs
         int time = 0;
-        for (int m = 0; m < nnets; m++) n[m] = (m+2)%nnets;
-        if (permuteNetIds(n, g16, 0, nnets-1, romeTopoModels+i, &romeTopo, &time, false)) break;
+        for (int m = 0; m < nnets; m++) n[m] = (m + 2) % nnets;
+        if (permuteNetIds(n, g16, 0, nnets - 1, romeTopoModels + i, &romeTopo, &time, false)) break;
       } else break;
     }
     if (p < TOTAL_PERMUTE_COUNT) break;
   }
   gettimeofday(&tve, NULL);
-  if (i >= sizeof(romeTopoModels)/sizeof(romeTopoModels[0])) {
-    //printf("No solution in %.2fms\n", t);
+  if (i >= sizeof(romeTopoModels) / sizeof(romeTopoModels[0])) {
+    // printf("No solution in %.2fms\n", t);
     return ncclSuccess;
   }
-  for (int m = 0; m<ngpus; m++) rdm[m] = devids[g16[m]];
+  for (int m = 0; m < ngpus; m++) rdm[m] = devids[g16[m]];
 
   char line[1024];
-  //sprintf(line, "Found matching Rome model index %d in %.2fms with GPU mapping: ", i, t);
+  // sprintf(line, "Found matching Rome model index %d in %.2fms with GPU mapping: ", i, t);
   sprintf(line, "Found matching Rome model index %d with GPU mapping: ", i);
   int offset = strlen(line);
   for (int k = 0; k < ngpus; k++) {
-    sprintf(line+offset, "%d ", rdm[k]);
+    sprintf(line + offset, "%d ", rdm[k]);
     offset = strlen(line);
   }
   if (nnets > 1) {
-    sprintf(line+offset, "NET mapping: ");
+    sprintf(line + offset, "NET mapping: ");
     offset = strlen(line);
     for (int k = 0; k < nnets; k++) {
-      sprintf(line+offset, "%d ", n[k]);
+      sprintf(line + offset, "%d ", n[k]);
       offset = strlen(line);
     }
   }
@@ -2999,7 +5013,7 @@ ncclResult_t parse1H16P(struct ncclTopoSystem* system, struct ncclTopoGraph* gra
   return ncclSuccess;
 }
 
-ncclResult_t find_gpu_hives(int *g_hives, int *ng_hives, struct rcclRomeModel *romeTopo) {
+ncclResult_t find_gpu_hives(int* g_hives, int* ng_hives, struct rcclRomeModel* romeTopo) {
   const int ngpus = romeTopo->nGpus;
   const int gpus_per_hive = romeTopo->nLinks + 1;
   const int nhives = ngpus / gpus_per_hive;
@@ -3009,9 +5023,9 @@ ncclResult_t find_gpu_hives(int *g_hives, int *ng_hives, struct rcclRomeModel *r
     int j, h;
     for (j = 0; j < nhives; j++) {
       if (ng_hives[j]) {
-        if (romeTopo->connMatrix[i*ngpus+g_hives[j*gpus_per_hive]]) {
-          g_hives[j*gpus_per_hive+ng_hives[j]] = i;
-          ng_hives[j] ++;
+        if (romeTopo->connMatrix[i * ngpus + g_hives[j * gpus_per_hive]]) {
+          g_hives[j * gpus_per_hive + ng_hives[j]] = i;
+          ng_hives[j]++;
           break;
         }
       }
@@ -3019,18 +5033,16 @@ ncclResult_t find_gpu_hives(int *g_hives, int *ng_hives, struct rcclRomeModel *r
     if (j >= nhives) {
       for (h = 0; h < nhives; h++) {
         if (ng_hives[h] == 0) {
-          g_hives[h*gpus_per_hive] = i;
+          g_hives[h * gpus_per_hive] = i;
           ng_hives[h]++;
           break;
         }
       }
-      if (h >= nhives)
-        return ncclInternalError;
+      if (h >= nhives) return ncclInternalError;
     }
   }
   for (int i = 0; i < nhives; i++) {
-    if (ng_hives[i] != gpus_per_hive)
-      return ncclInternalError;
+    if (ng_hives[i] != gpus_per_hive) return ncclInternalError;
   }
   return ncclSuccess;
 }
@@ -3051,26 +5063,22 @@ ncclResult_t parse4H4P(struct ncclTopoSystem* system, struct ncclTopoGraph* grap
   // number of GPUs and NICs on each numa node is used as first screening pattern
   struct rcclRomeModel romeTopo;
   char pattern[256];
-  int devids[HIVE_GPUS*NUM_HIVES];
+  int devids[HIVE_GPUS * NUM_HIVES];
   NCCLCHECK(parseRomeSystem(system, &romeTopo, pattern, devids));
 
   // only match for system with 16 GPUs
-  if (ngpus != NUM_HIVES*HIVE_GPUS || nnets != NUM_HIVES*HIVE_GPUS) return ncclSuccess;
+  if (ngpus != NUM_HIVES * HIVE_GPUS || nnets != NUM_HIVES * HIVE_GPUS) return ncclSuccess;
 
   std::vector<int> g_hives(ngpus), n_hives(nnets);
   int ng_hives[NUM_HIVES];
-  int rdm[NUM_HIVES*HIVE_GPUS];
+  int rdm[NUM_HIVES * HIVE_GPUS];
 
   // try to sort GPUs into hives
-  for (int i = 0; i < NUM_HIVES; i++)
-    ng_hives[i] = 0;
-  for (int i = 0; i < nnets; i++)
-    n_hives[i] = -1;
-  for (int i = 0; i < ngpus; i++)
-    g_hives[i] = -1;
+  for (int i = 0; i < NUM_HIVES; i++) ng_hives[i] = 0;
+  for (int i = 0; i < nnets; i++) n_hives[i] = -1;
+  for (int i = 0; i < ngpus; i++) g_hives[i] = -1;
 
-  if (find_gpu_hives(g_hives.data(), ng_hives, &romeTopo))
-    return ncclSuccess;
+  if (find_gpu_hives(g_hives.data(), ng_hives, &romeTopo)) return ncclSuccess;
 
   for (int i = 0; i < NUM_HIVES; i++)
     if (ng_hives[i] != 4) return ncclSuccess;
@@ -3078,7 +5086,7 @@ ncclResult_t parse4H4P(struct ncclTopoSystem* system, struct ncclTopoGraph* grap
   for (int i = 0; i < nnets; i++) {
     int j;
     for (j = 0; j < ngpus; j++) {
-      if(romeTopo.gdrLevel[i*nnets+g_hives[j]] == PATH_PIX) {
+      if (romeTopo.gdrLevel[i * nnets + g_hives[j]] == PATH_PIX) {
         n_hives[j] = i;
         break;
       }
@@ -3091,20 +5099,20 @@ ncclResult_t parse4H4P(struct ncclTopoSystem* system, struct ncclTopoGraph* grap
   for (int i = 0; i < ngpus; i++)
     if (g_hives[i] == -1) return ncclSuccess;
 
-  for (int m = 0; m<ngpus; m++) rdm[m] = devids[g_hives[m]];
+  for (int m = 0; m < ngpus; m++) rdm[m] = devids[g_hives[m]];
 
   char line[1024];
   sprintf(line, "Found matching Rome model 4P4H with GPU mapping: ");
   int offset = strlen(line);
   for (int k = 0; k < ngpus; k++) {
-    sprintf(line+offset, "%d ", rdm[k]);
+    sprintf(line + offset, "%d ", rdm[k]);
     offset = strlen(line);
   }
   if (nnets > 1) {
-    sprintf(line+offset, "NET mapping: ");
+    sprintf(line + offset, "NET mapping: ");
     offset = strlen(line);
     for (int k = 0; k < nnets; k++) {
-      sprintf(line+offset, "%d ", n_hives[k]);
+      sprintf(line + offset, "%d ", n_hives[k]);
       offset = strlen(line);
     }
   }
@@ -3121,37 +5129,70 @@ ncclResult_t parse4H4P(struct ncclTopoSystem* system, struct ncclTopoGraph* grap
 }
 
 static struct rcclRomeModel gio16gColumbaModel = {
-  .nGpus = 16, .nCpus = 2, .nNics = 0, .nLinks = 7,
-  .gpuIds = { 0x24000, 0x2a000, 0x37000, 0x3d000, 0x4a000, 0x50000, 0x5d000, 0x63000, 0xaf000, 0xb5000, 0xc2000, 0xc8000, 0xd5000, 0xdb000, 0xe8000, 0xee000, },
-  .nicIds = { },
-  .gpuNuma = { 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, },
-  .nicNuma = { },
-  .connMatrix = { 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0,
-                  1, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0,
-                  1, 1, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0,
-                  1, 1, 1, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0,
-                  1, 1, 1, 1, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0,
-                  1, 1, 1, 1, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0,
-                  1, 1, 1, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
-                  1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                  0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1,
-                  0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 1, 1, 1, 1,
-                  0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 1, 1, 1, 1,
-                  0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 1, 1, 1, 1,
-                  0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 1, 1, 1,
-                  0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 1, 1,
-                  0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 1,
-                  0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0, },
-  .gdrLevel = { },
+  .nGpus = 16,
+  .nCpus = 2,
+  .nNics = 0,
+  .nLinks = 7,
+  .gpuIds =
+    {
+      0x24000,
+      0x2a000,
+      0x37000,
+      0x3d000,
+      0x4a000,
+      0x50000,
+      0x5d000,
+      0x63000,
+      0xaf000,
+      0xb5000,
+      0xc2000,
+      0xc8000,
+      0xd5000,
+      0xdb000,
+      0xe8000,
+      0xee000,
+    },
+  .nicIds = {},
+  .gpuNuma =
+    {
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+    },
+  .nicNuma = {},
+  .connMatrix =
+    {
+      0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 1,
+      1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 1, 1, 1, 0, 0,
+      0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0,
+      0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0,
+      0, 0, 0, 0, 1, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+      1, 1, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0,
+      1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0,
+    },
+  .gdrLevel = {},
   .pattern = "8080",
   .ringBase = "0 1 2 3 4 5 7 6 12 13 14 15 8 9 11 10"
-            "| 2 7 3 5 1 6 0 4 14 9 15 10 13 11 12 8"
-            "| 1 3 0 7 4 6 2 5 13 15 11 8 10 14 12 9"
-            "| 3 6 5 0 2 4 1 7 15 12 10 9 13 8 14 11"
-            "| 10 11 9 8 15 14 13 12 6 7 5 4 3 2 1 0"
-            "| 8 12 11 13 10 15 9 14 4 0 6 1 5 3 7 2"
-            "| 9 12 14 10 8 11 15 13 5 2 6 4 7 0 3 1"
-            "| 11 14 8 13 9 10 12 15 7 1 4 2 0 5 6 3",
+              "| 2 7 3 5 1 6 0 4 14 9 15 10 13 11 12 8"
+              "| 1 3 0 7 4 6 2 5 13 15 11 8 10 14 12 9"
+              "| 3 6 5 0 2 4 1 7 15 12 10 9 13 8 14 11"
+              "| 10 11 9 8 15 14 13 12 6 7 5 4 3 2 1 0"
+              "| 8 12 11 13 10 15 9 14 4 0 6 1 5 3 7 2"
+              "| 9 12 14 10 8 11 15 13 5 2 6 4 7 0 3 1"
+              "| 11 14 8 13 9 10 12 15 7 1 4 2 0 5 6 3",
   .options = "",
 };
 
@@ -3159,38 +5200,36 @@ ncclResult_t parseGIOTopos(struct ncclTopoSystem* system, struct ncclTopoGraph* 
   ncclResult_t r;
   constexpr int NGPUS = 16;
   constexpr int NHIVES = 2;
-  constexpr int GPUS_PER_HIVE = NGPUS/NHIVES;
+  constexpr int GPUS_PER_HIVE = NGPUS / NHIVES;
   const int ngpus = system->nodes[GPU].count;
   const int ncpus = system->nodes[CPU].count;
   const int nnets = system->nodes[NET].count;
 
-  if (ngpus < NGPUS || ncpus > 2 || nnets != 0)
-    return ncclSuccess;
+  if (ngpus < NGPUS || ncpus > 2 || nnets != 0) return ncclSuccess;
 
   struct rcclRomeModel romeTopo;
   char pattern[256];
   int devids[NGPUS];
   NCCLCHECK(parseRomeSystem(system, &romeTopo, pattern, devids));
 
-  if (romeTopo.nLinks + 1 != GPUS_PER_HIVE)
-    return ncclSuccess;
+  if (romeTopo.nLinks + 1 != GPUS_PER_HIVE) return ncclSuccess;
 
   int g_hives[NGPUS], ng_hives[NHIVES], rdm[NGPUS];
   memset(ng_hives, 0, sizeof(ng_hives));
   memset(g_hives, -1, sizeof(g_hives));
   NCCLCHECKGOTO(find_gpu_hives(g_hives, ng_hives, &romeTopo), r, exit);
 
-  for (int m = 0; m<ngpus; m++) rdm[m] = devids[g_hives[m]];
+  for (int m = 0; m < ngpus; m++) rdm[m] = devids[g_hives[m]];
 
   char line[1024];
   int offset;
   sprintf(line, "Found GigaIO rome topo, gpu_mapping: ");
   offset = strlen(line);
   for (int k = 0; k < ngpus; k++) {
-    sprintf(line+offset, "%d ", g_hives[k]);
+    sprintf(line + offset, "%d ", g_hives[k]);
     offset = strlen(line);
   }
-  INFO(NCCL_GRAPH,"%s", line);
+  INFO(NCCL_GRAPH, "%s", line);
 
   system->type |= RCCL_TOPO_4P2H_ROME;
 

--- a/projects/rccl/src/graph/rome_models.h
+++ b/projects/rccl/src/graph/rome_models.h
@@ -23,13 +23,14 @@ THE SOFTWARE.
 #ifndef RCCL_ROME_MODELS_H_
 #define RCCL_ROME_MODELS_H_
 
-ncclResult_t parseGraph(const char* str, struct ncclTopoSystem* system, struct ncclTopoGraph* graph, int* gpu_map, int* net_map, int reverse);
+ncclResult_t parseGraph(const char* str, struct ncclTopoSystem* system, struct ncclTopoGraph* graph, int* gpu_map,
+                        int* net_map, int reverse);
 ncclResult_t parseGraphLight(const char* str, struct ncclTopoSystem* system, struct ncclTopoGraph* graph, int* gpu_map);
-ncclResult_t parseRome4P2H(struct ncclTopoSystem* system, struct ncclTopoGraph* graph2, const char *ringBase);
+ncclResult_t parseRome4P2H(struct ncclTopoSystem* system, struct ncclTopoGraph* graph2, const char* ringBase);
 ncclResult_t parseChordalRing(struct ncclTopoSystem* system, struct ncclTopoGraph* graph);
 ncclResult_t parse1H16P(struct ncclTopoSystem* system, struct ncclTopoGraph* graph);
 ncclResult_t parse4H4P(struct ncclTopoSystem* system, struct ncclTopoGraph* graph);
-ncclResult_t parseA2a8P(struct ncclTopoSystem* system, struct ncclTopoGraph* graph, const char *ringBase);
+ncclResult_t parseA2a8P(struct ncclTopoSystem* system, struct ncclTopoGraph* graph, const char* ringBase);
 ncclResult_t parseGIOTopos(struct ncclTopoSystem* system, struct ncclTopoGraph* graph);
 
 #endif

--- a/projects/rccl/src/graph/rome_topo_consensus.cc
+++ b/projects/rccl/src/graph/rome_topo_consensus.cc
@@ -11,11 +11,9 @@
 #if defined(__GNUC__) || defined(__clang__)
 __attribute__((visibility("default")))
 #endif
-ncclResult_t rcclCheckRomeTopoModelIdxConsensus(
-  int nranks,
-  std::function<int(int)> getRomeTopoModelIdx,
-  std::function<const char*(int)> getHostname,
-  std::function<uint64_t(int)> getHostHash) {
+ncclResult_t rcclCheckRomeTopoModelIdxConsensus(int nranks, std::function<int(int)> getRomeTopoModelIdx,
+                                                std::function<const char*(int)> getHostname,
+                                                std::function<uint64_t(int)> getHostHash) {
   if (nranks <= 0) return ncclSuccess;
 
   std::unordered_map<int, std::pair<int, int>> tallies; // modelIdx -> (vote count, first rank)
@@ -47,7 +45,9 @@ ncclResult_t rcclCheckRomeTopoModelIdxConsensus(
     if (getRomeTopoModelIdx(r) != refIdx) nDisagree++;
   }
   if (nDisagree > 0) {
-    WARN("RCCL FATAL: mismatched Rome preset topology model index across ranks; all ranks must agree for precomputed graphs (voted refIdx %d from %d of %d ranks).", refIdx, refVotes, nranks);
+    WARN("RCCL FATAL: mismatched Rome preset topology model index across ranks; all ranks must agree for precomputed "
+         "graphs (voted refIdx %d from %d of %d ranks).",
+         refIdx, refVotes, nranks);
     std::unordered_map<uint64_t, int> lowestMismatchRankByHost;
     lowestMismatchRankByHost.reserve(nranks);
     for (int r = 0; r < nranks; r++) {

--- a/projects/rccl/src/graph/rome_topo_consensus.h
+++ b/projects/rccl/src/graph/rome_topo_consensus.h
@@ -12,10 +12,8 @@
 
 /* Plurality vote on romeTopoModelIdx across ranks; all ranks must match the winner.
  * Callers supply getters so this stays independent of ncclComm / allGatherInfo. */
-ncclResult_t rcclCheckRomeTopoModelIdxConsensus(
-  int nranks,
-  std::function<int(int /*rank*/)> getRomeTopoModelIdx,
-  std::function<const char*(int /*rank*/)> getHostname,
-  std::function<uint64_t(int /*rank*/)> getHostHash);
+ncclResult_t rcclCheckRomeTopoModelIdxConsensus(int nranks, std::function<int(int /*rank*/)> getRomeTopoModelIdx,
+                                                std::function<const char*(int /*rank*/)> getHostname,
+                                                std::function<uint64_t(int /*rank*/)> getHostHash);
 
 #endif

--- a/projects/rccl/src/graph/search.cc
+++ b/projects/rccl/src/graph/search.cc
@@ -23,8 +23,8 @@ NCCL_PARAM(CrossNic, "CROSS_NIC", 2);
 static float getMaxBw(struct ncclTopoSystem* system, struct ncclTopoNode* dev, int type) {
   float maxBw = 0.0;
   if (dev->paths[type] == NULL) return maxBw; // no paths to nodes of this type (e.g. remote NICs in MNNVL)
-  for (int i=0; i<system->nodes[type].count; i++) {
-    struct ncclTopoLinkList* path = dev->paths[type]+i;
+  for (int i = 0; i < system->nodes[type].count; i++) {
+    struct ncclTopoLinkList* path = dev->paths[type] + i;
     float bw = path->bw;
     if (path->count == 0) continue;
     maxBw = std::max(maxBw, bw);
@@ -33,8 +33,8 @@ static float getMaxBw(struct ncclTopoSystem* system, struct ncclTopoNode* dev, i
 }
 static float getTotalBw(struct ncclTopoSystem* system, struct ncclTopoNode* dev) {
   float nvlinkBw = 0.0, pciBw = 0.0;
-  for (int l=0; l<dev->nlinks; l++) {
-    struct ncclTopoLink* link = dev->links+l;
+  for (int l = 0; l < dev->nlinks; l++) {
+    struct ncclTopoLink* link = dev->links + l;
     if (link->type == LINK_NVL) nvlinkBw += link->bw;
     if (link->type == LINK_PCI) pciBw = link->bw;
   }
@@ -49,8 +49,8 @@ ncclResult_t ncclTopoSearchInit(struct ncclTopoSystem* system) {
     system->totalBw = LOC_BW;
     return ncclSuccess;
   }
-  for (int d=0; d<system->nodes[DEV].count; d++) {
-    struct ncclTopoNode* dev = system->nodes[DEV].nodes+d;
+  for (int d = 0; d < system->nodes[DEV].count; d++) {
+    struct ncclTopoNode* dev = system->nodes[DEV].nodes + d;
     system->maxBw = std::max(system->maxBw, getMaxBw(system, dev, inter ? NET : DEV));
     system->totalBw = std::max(system->totalBw, getTotalBw(system, dev));
   }
@@ -66,9 +66,10 @@ ncclResult_t ncclTopoComputeCommCPU(struct ncclComm* comm) {
   return ncclSuccess;
 }
 
-static ncclResult_t findRevLink(struct ncclTopoNode* node1, struct ncclTopoNode* node2, int type, struct ncclTopoLink** revLink) {
-  for (int l=0; l<node2->nlinks; l++) {
-    struct ncclTopoLink* link = node2->links+l;
+static ncclResult_t findRevLink(struct ncclTopoNode* node1, struct ncclTopoNode* node2, int type,
+                                struct ncclTopoLink** revLink) {
+  for (int l = 0; l < node2->nlinks; l++) {
+    struct ncclTopoLink* link = node2->links + l;
     if (link->remNode == node1 && link->type == type) {
       *revLink = link;
       return ncclSuccess;
@@ -79,16 +80,16 @@ static ncclResult_t findRevLink(struct ncclTopoNode* node1, struct ncclTopoNode*
 }
 
 // This is unfortunately needed since manipulating floats often results in rounding errors.
-#define SUB_ROUND(a, b) (a = roundf((a-b)*1000)/1000)
+#define SUB_ROUND(a, b) (a = roundf((a - b) * 1000) / 1000)
 
-static ncclResult_t followPath(struct ncclTopoLinkList* path, struct ncclTopoNode* start, int maxSteps, float bw, int* steps) {
+static ncclResult_t followPath(struct ncclTopoLinkList* path, struct ncclTopoNode* start, int maxSteps, float bw,
+                               int* steps) {
   float pciBw = bw;
-  for (int step=0; step<path->count; step++) {
+  for (int step = 0; step < path->count; step++) {
     struct ncclTopoNode* node = path->list[step]->remNode;
     if (node->type == CPU) {
       // Account for P2P inefficiency through Intel CPU RC
-      if (path->type == PATH_PHB && start->type == GPU &&
-          node->cpu.arch == NCCL_TOPO_CPU_ARCH_X86 &&
+      if (path->type == PATH_PHB && start->type == GPU && node->cpu.arch == NCCL_TOPO_CPU_ARCH_X86 &&
           node->cpu.vendor == NCCL_TOPO_CPU_VENDOR_INTEL) {
         pciBw = INTEL_P2P_OVERHEAD(bw);
       }
@@ -96,14 +97,14 @@ static ncclResult_t followPath(struct ncclTopoLinkList* path, struct ncclTopoNod
   }
 
   struct ncclTopoNode* node = start;
-  for (int step=0; step<maxSteps; step++) {
+  for (int step = 0; step < maxSteps; step++) {
     struct ncclTopoLink* link = path->list[step];
     struct ncclTopoLink* revLink = NULL;
     float fwBw = link->type == LINK_PCI ? pciBw : bw;
     float revBw = 0;
     if (link->remNode->type == DEV && link->remNode->dev.cudaCompCap < 80 && start->type != GPU) {
       if (revLink == NULL) NCCLCHECK(findRevLink(node, link->remNode, link->type, &revLink));
-      revBw += fwBw/8;
+      revBw += fwBw / 8;
     }
     if (link->remNode->type == CPU && link->remNode->cpu.arch == NCCL_TOPO_CPU_ARCH_POWER && link->type == LINK_NVL) {
       if (revLink == NULL) NCCLCHECK(findRevLink(node, link->remNode, link->type, &revLink));
@@ -112,7 +113,10 @@ static ncclResult_t followPath(struct ncclTopoLinkList* path, struct ncclTopoNod
     // Coverity thinks that revLink could be NULL below.  However, we access it only if revBw is non-0, and the
     // logic of the code is that revBw can become non-0 only if revLink is non-NULL (see the "if" statement right above).
     // coverity[var_deref_op]
-    if (link->bw < fwBw || (revBw && revLink->bw < revBw)) { *steps = step; return ncclSuccess; }
+    if (link->bw < fwBw || (revBw && revLink->bw < revBw)) {
+      *steps = step;
+      return ncclSuccess;
+    }
     SUB_ROUND(link->bw, fwBw);
     if (revBw) SUB_ROUND(revLink->bw, revBw);
     node = link->remNode;
@@ -122,14 +126,15 @@ static ncclResult_t followPath(struct ncclTopoLinkList* path, struct ncclTopoNod
 }
 
 // Try to go from node type1/index1 to no type2/index2. mult indicates whether we are counting the bandwidth (1) or undoing (-1).
-static ncclResult_t ncclTopoFollowPath(struct ncclTopoSystem* system, struct ncclTopoGraph* graph, int type1, int index1, int type2, int index2, float mult, struct ncclTopoNode** node) {
+static ncclResult_t ncclTopoFollowPath(struct ncclTopoSystem* system, struct ncclTopoGraph* graph, int type1,
+                                       int index1, int type2, int index2, float mult, struct ncclTopoNode** node) {
   // First handle easy cases
-  *node = system->nodes[type2].nodes+index2;
+  *node = system->nodes[type2].nodes + index2;
   if (type1 == -1) return ncclSuccess;
-  struct ncclTopoNode* node1 = system->nodes[type1].nodes+index1;
-  struct ncclTopoLinkList* path = node1->paths[type2]+index2;
-  struct ncclTopoNode* node2 = system->nodes[type2].nodes+index2;
-  struct ncclTopoLinkList* revPath = node2->paths[type1]+index1;
+  struct ncclTopoNode* node1 = system->nodes[type1].nodes + index1;
+  struct ncclTopoLinkList* path = node1->paths[type2] + index2;
+  struct ncclTopoNode* node2 = system->nodes[type2].nodes + index2;
+  struct ncclTopoLinkList* revPath = node2->paths[type1] + index1;
 
   if (path == NULL) {
     WARN("No path computed to go from %s/%d to %s/%d", topoNodeTypeStr[type1], index1, topoNodeTypeStr[type2], index2);
@@ -144,10 +149,11 @@ static ncclResult_t ncclTopoFollowPath(struct ncclTopoSystem* system, struct ncc
 
   if (path->type >= PATH_DIS) return ncclSuccess;
   if (mult == 1 && (path->type > type)) return ncclSuccess;
-  if (mult == 1 && (graph->pattern == NCCL_TOPO_PATTERN_BALANCED_TREE ||
-        graph->pattern == NCCL_TOPO_PATTERN_TREE ||
-        graph->pattern == NCCL_TOPO_PATTERN_SPLIT_TREE) &&
-      (revPath->type > type)) return ncclSuccess;
+  if (mult == 1 &&
+      (graph->pattern == NCCL_TOPO_PATTERN_BALANCED_TREE || graph->pattern == NCCL_TOPO_PATTERN_TREE ||
+       graph->pattern == NCCL_TOPO_PATTERN_SPLIT_TREE) &&
+      (revPath->type > type))
+    return ncclSuccess;
 
   bw *= mult;
 
@@ -157,8 +163,8 @@ static ncclResult_t ncclTopoFollowPath(struct ncclTopoSystem* system, struct ncc
   if (step < path->count) goto rewind;
 
   // Enough bandwidth : return destination node.
-  graph->nHops += mult*path->count;
-  *node = system->nodes[type2].nodes+index2;
+  graph->nHops += mult * path->count;
+  *node = system->nodes[type2].nodes + index2;
   return ncclSuccess;
 
 rewind:
@@ -169,12 +175,12 @@ rewind:
 
 static int gpuPciBw(struct ncclTopoNode* gpu) {
   struct ncclTopoNode* dev = gpu->gpu.parent;
-  for (int l=0; l<dev->nlinks; l++) {
-    struct ncclTopoLink* gpuLink = dev->links+l;
+  for (int l = 0; l < dev->nlinks; l++) {
+    struct ncclTopoLink* gpuLink = dev->links + l;
     if (gpuLink->type != LINK_PCI) continue;
     struct ncclTopoNode* pci = gpuLink->remNode;
-    for (int l=0; l<pci->nlinks; l++) {
-      struct ncclTopoLink* pciLink = pci->links+l;
+    for (int l = 0; l < pci->nlinks; l++) {
+      struct ncclTopoLink* pciLink = pci->links + l;
       if (pciLink->remNode != dev) continue;
       return std::min(gpuLink->bw, pciLink->bw);
     }
@@ -185,18 +191,18 @@ static int gpuPciBw(struct ncclTopoNode* gpu) {
 /* Choose the order in which we try next GPUs. This is critical for the search
   to quickly converge to the best solution even if it eventually times out. */
 struct ncclGpuScore {
-  int g;             // Retain the index
-  int startIndex;    // Least important
+  int g; // Retain the index
+  int startIndex; // Least important
   int intraNhops;
   int intraBw;
   int interNhops;
   int interPciBw;
-  int interBw;    // Most important
+  int interBw; // Most important
 };
 
-static int cmpScore(const void * g1, const void * g2) {
-  struct ncclGpuScore *s1 = (struct ncclGpuScore*)g1;
-  struct ncclGpuScore *s2 = (struct ncclGpuScore*)g2;
+static int cmpScore(const void* g1, const void* g2) {
+  struct ncclGpuScore* s1 = (struct ncclGpuScore*)g1;
+  struct ncclGpuScore* s2 = (struct ncclGpuScore*)g2;
   int d;
   if ((d = (s2->interBw - s1->interBw))) return d;
   if ((d = (s2->interPciBw - s1->interPciBw))) return d;
@@ -209,14 +215,14 @@ static int cmpScore(const void * g1, const void * g2) {
 static int cmpIntraScores(struct ncclGpuScore* scores, int count) {
   int intraBw = scores[0].intraBw;
   int intraNhops = scores[0].intraNhops;
-  for (int i=1; i<count; i++) {
+  for (int i = 1; i < count; i++) {
     if (scores[i].intraBw != intraBw || scores[i].intraNhops != intraNhops) return 1;
   }
   return 0;
 }
 
 static ncclResult_t getGpuIndex(struct ncclTopoSystem* system, int rank, int* index) {
-  for (int g=0; g<system->nodes[GPU].count; g++) {
+  for (int g = 0; g < system->nodes[GPU].count; g++) {
     if (system->nodes[GPU].nodes[g].gpu.rank == rank) {
       *index = g;
       return ncclSuccess;
@@ -227,7 +233,7 @@ static ncclResult_t getGpuIndex(struct ncclTopoSystem* system, int rank, int* in
 }
 
 static ncclResult_t getNetIndex(struct ncclTopoSystem* system, int64_t id, int* index) {
-  for (int n=0; n<system->nodes[NET].count; n++) {
+  for (int n = 0; n < system->nodes[NET].count; n++) {
     if (system->nodes[NET].nodes[n].id == id) {
       *index = n;
       return ncclSuccess;
@@ -237,27 +243,29 @@ static ncclResult_t getNetIndex(struct ncclTopoSystem* system, int64_t id, int* 
   return ncclInternalError;
 }
 
-static ncclResult_t getNetPaths(struct ncclTopoSystem* system, struct ncclTopoGraph* graph, struct ncclTopoLinkList** netPaths) {
-  int64_t netId = graph->inter[graph->nChannels*2];
+static ncclResult_t getNetPaths(struct ncclTopoSystem* system, struct ncclTopoGraph* graph,
+                                struct ncclTopoLinkList** netPaths) {
+  int64_t netId = graph->inter[graph->nChannels * 2];
   int n;
   NCCLCHECK(getNetIndex(system, netId, &n));
-  *netPaths=system->nodes[NET].nodes[n].paths[GPU];
+  *netPaths = system->nodes[NET].nodes[n].paths[GPU];
   return ncclSuccess;
 }
 
-ncclResult_t ncclTopoSearchNextGpuSort(struct ncclTopoSystem* system, struct ncclTopoGraph* graph, struct ncclTopoNode* gpu, int* next, int* countPtr, int sortNet) {
-  const uint64_t flag = 1ULL<<(graph->nChannels);
+ncclResult_t ncclTopoSearchNextGpuSort(struct ncclTopoSystem* system, struct ncclTopoGraph* graph,
+                                       struct ncclTopoNode* gpu, int* next, int* countPtr, int sortNet) {
+  const uint64_t flag = 1ULL << (graph->nChannels);
   int ngpus = system->nodes[GPU].count;
   struct ncclTopoLinkList* paths = gpu->paths[GPU];
   struct ncclTopoLinkList* netPaths = NULL;
   if (sortNet) NCCLCHECK(getNetPaths(system, graph, &netPaths));
 
   struct ncclGpuScore scores[NCCL_TOPO_MAX_NODES];
-  memset(scores, 0, ngpus*sizeof(struct ncclGpuScore));
-  int start = gpu-system->nodes[GPU].nodes;
+  memset(scores, 0, ngpus * sizeof(struct ncclGpuScore));
+  int start = gpu - system->nodes[GPU].nodes;
   int count = 0;
-  for (int i=1; i<ngpus; i++) {
-    int g = (start+i)%ngpus;
+  for (int i = 1; i < ngpus; i++) {
+    int g = (start + i) % ngpus;
     if (paths[g].count == 0) continue; // There is no path to that GPU
     if (system->nodes[GPU].nodes[g].used & flag) continue;
     scores[count].g = g;
@@ -266,7 +274,7 @@ ncclResult_t ncclTopoSearchNextGpuSort(struct ncclTopoSystem* system, struct ncc
     scores[count].intraBw = paths[g].bw;
     if (netPaths) {
       scores[count].interNhops = netPaths[g].count;
-      scores[count].interPciBw = gpuPciBw(system->nodes[GPU].nodes+g);
+      scores[count].interPciBw = gpuPciBw(system->nodes[GPU].nodes + g);
       scores[count].interBw = netPaths[g].bw;
     }
     count++;
@@ -277,35 +285,39 @@ ncclResult_t ncclTopoSearchNextGpuSort(struct ncclTopoSystem* system, struct ncc
 
   // Check if all have the same intra-node score in which case we go reverse for sortNet = -1
   if (sortNet == -1 && cmpIntraScores(scores, count) == 0) {
-    for (int i=0; i<count; i++) next[i] = scores[count-1-i].g;
+    for (int i = 0; i < count; i++) next[i] = scores[count - 1 - i].g;
   } else {
-    for (int i=0; i<count; i++) next[i] = scores[i].g;
+    for (int i = 0; i < count; i++) next[i] = scores[i].g;
   }
 
   *countPtr = count;
 
   if (system->nodes[NVS].count) {
     // NVSwitches prefer when we talk to a limited set of peers. Try to use neighbors first.
-    int index = gpu-system->nodes[GPU].nodes;
+    int index = gpu - system->nodes[GPU].nodes;
     int i;
-    int prevGpu = (index-1+ngpus)%ngpus;
-    int nextGpu = (index+1)%ngpus;
+    int prevGpu = (index - 1 + ngpus) % ngpus;
+    int nextGpu = (index + 1) % ngpus;
     int firstGpus[2];
     int firstGpuCount = 0;
     if (graph->pattern == NCCL_TOPO_PATTERN_RING) {
-      firstGpus[0] = nextGpu; firstGpus[1] = prevGpu; firstGpuCount = 2;
-    } else if (graph->pattern == NCCL_TOPO_PATTERN_SPLIT_TREE ||
-        graph->pattern == NCCL_TOPO_PATTERN_BALANCED_TREE) {
-      firstGpus[0] = prevGpu; firstGpus[1] = nextGpu; firstGpuCount = 2;
+      firstGpus[0] = nextGpu;
+      firstGpus[1] = prevGpu;
+      firstGpuCount = 2;
+    } else if (graph->pattern == NCCL_TOPO_PATTERN_SPLIT_TREE || graph->pattern == NCCL_TOPO_PATTERN_BALANCED_TREE) {
+      firstGpus[0] = prevGpu;
+      firstGpus[1] = nextGpu;
+      firstGpuCount = 2;
     } else {
-      firstGpus[0] = nextGpu; firstGpuCount = 1;
+      firstGpus[0] = nextGpu;
+      firstGpuCount = 1;
     }
     if (nextGpu == prevGpu && firstGpuCount == 2) firstGpuCount = 1;
     int firstGpuRealCount = 0;
-    for (int g=0; g<firstGpuCount; g++) {
-      for (i=0; i<count && next[i] != firstGpus[g]; i++);
-      if (i<count) {
-        for (; i>0; i--) next[i] = next[i-1];
+    for (int g = 0; g < firstGpuCount; g++) {
+      for (i = 0; i < count && next[i] != firstGpus[g]; i++);
+      if (i < count) {
+        for (; i > 0; i--) next[i] = next[i - 1];
         next[0] = firstGpus[g];
         firstGpuRealCount++;
       }
@@ -315,13 +327,14 @@ ncclResult_t ncclTopoSearchNextGpuSort(struct ncclTopoSystem* system, struct ncc
   return ncclSuccess;
 }
 
-ncclResult_t ncclTopoSearchRec(struct ncclTopoSystem* system, struct ncclTopoGraph* graph, struct ncclTopoGraph* saveGraph, int* time);
+ncclResult_t ncclTopoSearchRec(struct ncclTopoSystem* system, struct ncclTopoGraph* graph,
+                               struct ncclTopoGraph* saveGraph, int* time);
 
 // Try to keep all searchs within one second
-#define NCCL_SEARCH_GLOBAL_TIMEOUT (1ULL<<19)
-#define NCCL_SEARCH_TIMEOUT (1<<14)
-#define NCCL_SEARCH_TIMEOUT_TREE (1<<14)
-#define NCCL_SEARCH_TIMEOUT_SAMECHANNELS (1<<8)
+#define NCCL_SEARCH_GLOBAL_TIMEOUT (1ULL << 19)
+#define NCCL_SEARCH_TIMEOUT (1 << 14)
+#define NCCL_SEARCH_TIMEOUT_TREE (1 << 14)
+#define NCCL_SEARCH_TIMEOUT_SAMECHANNELS (1 << 8)
 
 #define FORCED_ORDER_PCI 1
 #define FORCED_ORDER_REPLAY 2
@@ -330,18 +343,23 @@ ncclResult_t ncclTopoReplayGetGpu(struct ncclTopoSystem* system, struct ncclTopo
   *g = -1;
   if (graph->nChannels == 0) return ncclInternalError;
   int ngpus = system->nodes[GPU].count;
-  int nextRank = graph->intra[(graph->nChannels-1)*ngpus+step+1];
-  for (int i=0; i<ngpus; i++) if (system->nodes[GPU].nodes[i].gpu.rank == nextRank) {
-    *g = i;
-    return ncclSuccess;
-  }
+  int nextRank = graph->intra[(graph->nChannels - 1) * ngpus + step + 1];
+  for (int i = 0; i < ngpus; i++)
+    if (system->nodes[GPU].nodes[i].gpu.rank == nextRank) {
+      *g = i;
+      return ncclSuccess;
+    }
   return ncclInternalError;
 }
 
-ncclResult_t ncclTopoSearchRecGpu(struct ncclTopoSystem* system, struct ncclTopoGraph* graph, struct ncclTopoGraph* saveGraph, struct ncclTopoNode* gpu, int step, int backToNet, int backToFirstRank, int forcedOrder, int *time);
+ncclResult_t ncclTopoSearchRecGpu(struct ncclTopoSystem* system, struct ncclTopoGraph* graph,
+                                  struct ncclTopoGraph* saveGraph, struct ncclTopoNode* gpu, int step, int backToNet,
+                                  int backToFirstRank, int forcedOrder, int* time);
 
-ncclResult_t ncclTopoSearchTryGpu(struct ncclTopoSystem* system, struct ncclTopoGraph* graph, struct ncclTopoGraph* saveGraph, int step, int backToNet, int backToFirstRank, int forcedOrder, int *time, int type, int index, int g) {
-  const uint64_t flag = 1ULL<<(graph->nChannels);
+ncclResult_t ncclTopoSearchTryGpu(struct ncclTopoSystem* system, struct ncclTopoGraph* graph,
+                                  struct ncclTopoGraph* saveGraph, int step, int backToNet, int backToFirstRank,
+                                  int forcedOrder, int* time, int type, int index, int g) {
+  const uint64_t flag = 1ULL << (graph->nChannels);
   struct ncclTopoNode* gpu;
   NCCLCHECK(ncclTopoFollowPath(system, graph, type, index, GPU, g, 1, &gpu));
   if (gpu) {
@@ -356,22 +374,20 @@ ncclResult_t ncclTopoSearchTryGpu(struct ncclTopoSystem* system, struct ncclTopo
 static int ncclTopoCountXGMI(struct ncclTopoSystem* system, struct ncclTopoGraph* graph) {
   int ngpus = system->nodes[GPU].count;
   int count = 0;
-  for (int c=0; c<graph->nChannels; c++) {
-    for (int i=0; i<ngpus; i++) {
-      int g = graph->intra[ngpus*c+i];
-      int n = graph->intra[ngpus*c+((i+1)%ngpus)];
-      struct ncclTopoNode *node;
+  for (int c = 0; c < graph->nChannels; c++) {
+    for (int i = 0; i < ngpus; i++) {
+      int g = graph->intra[ngpus * c + i];
+      int n = graph->intra[ngpus * c + ((i + 1) % ngpus)];
+      struct ncclTopoNode* node;
       int j;
-      for (j=0; j<ngpus; j++)
+      for (j = 0; j < ngpus; j++)
         if (system->nodes[GPU].nodes[j].gpu.rank == g) break;
-      if (j<ngpus) {
-        node = system->nodes[GPU].nodes+j;
-        for (int k = 0; k<system->nodes[GPU].count; k++) {
+      if (j < ngpus) {
+        node = system->nodes[GPU].nodes + j;
+        for (int k = 0; k < system->nodes[GPU].count; k++) {
           // Direct XGMI link: post NCCL-2.30 a direct GPU->GPU path is GPU-DEV-DEV-GPU (count<=3).
           struct ncclTopoLinkList* path = node->paths[GPU] + k;
-          if (path->type == PATH_NVL && path->count <= 3
-              && system->nodes[GPU].nodes[k].gpu.rank == n)
-            count ++;
+          if (path->type == PATH_NVL && path->count <= 3 && system->nodes[GPU].nodes[k].gpu.rank == n) count++;
         }
       }
     }
@@ -379,7 +395,8 @@ static int ncclTopoCountXGMI(struct ncclTopoSystem* system, struct ncclTopoGraph
   return count;
 }
 
-ncclResult_t ncclTopoSearchTryCollnetDirect(struct ncclTopoSystem* system, struct ncclTopoGraph* graph, struct ncclTopoGraph* saveGraph, int g, int ngpus, int *time) {
+ncclResult_t ncclTopoSearchTryCollnetDirect(struct ncclTopoSystem* system, struct ncclTopoGraph* graph,
+                                            struct ncclTopoGraph* saveGraph, int g, int ngpus, int* time) {
   int fwdg = 0;
   int bwdg = 0;
   struct ncclTopoNode* gpu = NULL;
@@ -415,10 +432,11 @@ ncclResult_t ncclTopoSearchTryCollnetDirect(struct ncclTopoSystem* system, struc
   return ncclSuccess;
 }
 
-ncclResult_t ncclTopoSearchTryNvls(struct ncclTopoSystem* system, struct ncclTopoGraph* graph, struct ncclTopoGraph* saveGraph, int g, int ngpus, int *time) {
+ncclResult_t ncclTopoSearchTryNvls(struct ncclTopoSystem* system, struct ncclTopoGraph* graph,
+                                   struct ncclTopoGraph* saveGraph, int g, int ngpus, int* time) {
   struct ncclTopoNode* nvs;
   struct ncclTopoNode* gpu;
-  int d0=0; // See if there is enough bandwidth for NVS->GPU traffic
+  int d0 = 0; // See if there is enough bandwidth for NVS->GPU traffic
   do {
     NCCLCHECK(ncclTopoFollowPath(system, graph, NVS, 0, GPU, d0, d0 == g ? 2 : 1, &gpu));
     d0++;
@@ -426,7 +444,7 @@ ncclResult_t ncclTopoSearchTryNvls(struct ncclTopoSystem* system, struct ncclTop
   if (gpu == NULL) {
     d0--;
   } else {
-    int d1=0; // See if there is enough bandwidth for GPU->NVS traffic
+    int d1 = 0; // See if there is enough bandwidth for GPU->NVS traffic
     do {
       NCCLCHECK(ncclTopoFollowPath(system, graph, GPU, d1, NVS, 0, d1 == g ? 2 : 1, &nvs));
       d1++;
@@ -448,33 +466,37 @@ ncclResult_t ncclTopoSearchTryNvls(struct ncclTopoSystem* system, struct ncclTop
   return ncclSuccess;
 }
 
-ncclResult_t ncclTopoCompareGraphs(struct ncclTopoSystem* system, struct ncclTopoGraph* graph, struct ncclTopoGraph* refGraph, int* copy) {
+ncclResult_t ncclTopoCompareGraphs(struct ncclTopoSystem* system, struct ncclTopoGraph* graph,
+                                   struct ncclTopoGraph* refGraph, int* copy) {
   // 1. Try to get the same nChannels between Rings and Trees
   if (graph->nChannels < graph->minChannels) return ncclSuccess;
 
-  if (graph->pattern == NCCL_TOPO_PATTERN_NVLS) { // NVLS channels correspond to GPUs pulling from NVLS. So the more the better.
+  if (graph->pattern ==
+      NCCL_TOPO_PATTERN_NVLS) { // NVLS channels correspond to GPUs pulling from NVLS. So the more the better.
     if (graph->nChannels > refGraph->nChannels && graph->nChannels <= system->nodes[GPU].count) *copy = 1;
-    if (graph->nChannels*graph->bwInter > refGraph->nChannels*refGraph->bwInter) *copy = 1;
+    if (graph->nChannels * graph->bwInter > refGraph->nChannels * refGraph->bwInter) *copy = 1;
     return ncclSuccess;
   }
   // 2. Try to get better bandwidth
-  if (graph->nChannels*graph->bwIntra > refGraph->nChannels*refGraph->bwIntra) {
+  if (graph->nChannels * graph->bwIntra > refGraph->nChannels * refGraph->bwIntra) {
     *copy = 1;
     return ncclSuccess;
   }
-  if (graph->nChannels*graph->bwIntra < refGraph->nChannels*refGraph->bwIntra) return ncclSuccess;
+  if (graph->nChannels * graph->bwIntra < refGraph->nChannels * refGraph->bwIntra) return ncclSuccess;
 
   // 3. Less hops
-  if (graph->pattern == refGraph->pattern && graph->crossNic == refGraph->crossNic && graph->nHops < refGraph->nHops) *copy = 1;
+  if (graph->pattern == refGraph->pattern && graph->crossNic == refGraph->crossNic && graph->nHops < refGraph->nHops)
+    *copy = 1;
 
   // 4. Prefer graph with more XGMI connections
-  if (graph->nChannels == refGraph->nChannels
-    && ncclTopoCountXGMI(system, refGraph) < ncclTopoCountXGMI(system, graph)) *copy = 1;
+  if (graph->nChannels == refGraph->nChannels && ncclTopoCountXGMI(system, refGraph) < ncclTopoCountXGMI(system, graph))
+    *copy = 1;
   return ncclSuccess;
 }
 
 // Add the preferred NICs ordered by GPU first
-static ncclResult_t ncclTopoPrefNetsGpuFirst(struct ncclTopoSystem* system, int gpu, int nets[NCCL_TOPO_MAX_NODES], int* netCount) {
+static ncclResult_t ncclTopoPrefNetsGpuFirst(struct ncclTopoSystem* system, int gpu, int nets[NCCL_TOPO_MAX_NODES],
+                                             int* netCount) {
   const int nGpus = (gpu == -1) ? system->nodes[GPU].count : 1;
   int gpuCount = nGpus;
   int gpuIds[NCCL_TOPO_MAX_NODES];
@@ -483,8 +505,7 @@ static ncclResult_t ncclTopoPrefNetsGpuFirst(struct ncclTopoSystem* system, int 
   std::fill(firstNets, firstNets + NCCL_TOPO_MAX_NODES, -1);
   if (gpu == -1)
     for (int g = 0; g < nGpus; g++) gpuIds[g] = g;
-  else
-    gpuIds[0] = gpu;
+  else gpuIds[0] = gpu;
 
   for (int c = 0; c < MAXCHANNELS; c++) {
     for (int g = 0; g < nGpus; g++) {
@@ -495,11 +516,15 @@ static ncclResult_t ncclTopoPrefNetsGpuFirst(struct ncclTopoSystem* system, int 
       // Skip remote GPUs (MNNVL): paths[NET] is null, they have no local NICs on this node.
       // gpuIds[g] is set to -1 before gpuCount-- so the guard above prevents double-decrement
       // on subsequent channel iterations; gpuCount is decremented exactly once per GPU (≥ 0 always).
-      if (gpu->paths[NET] == NULL) { gpuIds[g] = -1; gpuCount--; continue; }
+      if (gpu->paths[NET] == NULL) {
+        gpuIds[g] = -1;
+        gpuCount--;
+        continue;
+      }
       NCCLCHECK(ncclTopoGetLocalNet(system, gpu->gpu.rank, c, &netId, NULL));
       NCCLCHECK(ncclTopoIdToIndex(system, NET, netId, &localNet));
       // store the first net found for each GPU in case of duplicates
-      if(c == 0) firstNets[g] = localNet;
+      if (c == 0) firstNets[g] = localNet;
       // if the NET has already been returned for channel 0, that GPU is done
       if (c > 0 && firstNets[g] == localNet) {
         gpuIds[g] = -1;
@@ -517,7 +542,8 @@ static ncclResult_t ncclTopoPrefNetsGpuFirst(struct ncclTopoSystem* system, int 
 }
 
 // Add the preferred NICs ordered by channels first
-static ncclResult_t ncclTopoPrefNetsChannelFirst(struct ncclTopoSystem* system, int gpu, int nets[NCCL_TOPO_MAX_NODES], int* netCount) {
+static ncclResult_t ncclTopoPrefNetsChannelFirst(struct ncclTopoSystem* system, int gpu, int nets[NCCL_TOPO_MAX_NODES],
+                                                 int* netCount) {
   for (int g = 0; g < system->nodes[GPU].count; g++) {
     if (gpu != -1 && gpu != g) continue;
     int localNetCount = 0, localNets[MAXCHANNELS];
@@ -551,7 +577,8 @@ static ncclResult_t ncclTopoPrefNetsChannelFirst(struct ncclTopoSystem* system, 
 // 1. First gather the preferred NETs for each of the GPU(s), based on the NETDEVS_POLICY and the connection.
 // 2. If the NETDEV_policy allows it, add all the other NETs satisfying typeInter but not already in the list of preferred NETs.
 NCCL_PARAM(ScatterEnable, "MNNVL_SCATTER_NETS_ENABLE", 1);
-ncclResult_t ncclTopoSelectNets(struct ncclTopoSystem* system, int typeInter, int gpu, int nets[NCCL_TOPO_MAX_NODES], int* netCountRet) {
+ncclResult_t ncclTopoSelectNets(struct ncclTopoSystem* system, int typeInter, int gpu, int nets[NCCL_TOPO_MAX_NODES],
+                                int* netCountRet) {
   ncclResult_t ret = ncclSuccess;
   int netCount = 0;
 
@@ -574,20 +601,20 @@ ncclResult_t ncclTopoSelectNets(struct ncclTopoSystem* system, int typeInter, in
   if (netCount >= maxDevCount) goto exit;
 
   // Then add others satisfying typeInter
-  for (int t=0; t <= typeInter; t++) {
+  for (int t = 0; t <= typeInter; t++) {
     for (int g = 0; g < system->nodes[GPU].count; g++) {
       // do not consider this GPU is it's not the GPU we asked for
       if (gpu != -1 && gpu != g) continue;
       int localNetCount = 0, localNets[MAXCHANNELS];
-      struct ncclTopoNode* gpu = system->nodes[GPU].nodes+g;
+      struct ncclTopoNode* gpu = system->nodes[GPU].nodes + g;
       struct ncclTopoLinkList* paths = gpu->paths[NET];
       // Skip remote GPUs (MNNVL): paths[NET] is null, they have no local NICs
       if (paths == NULL) continue;
-      for (int n=0; n<system->nodes[NET].count && n<MAXCHANNELS; n++) {
+      for (int n = 0; n < system->nodes[NET].count && n < MAXCHANNELS; n++) {
         if (paths[n].type == t) localNets[localNetCount++] = n;
       }
       // Append NICs to list
-      for (int i=0; i<localNetCount; i++) {
+      for (int i = 0; i < localNetCount; i++) {
         int n = localNets[i];
         int found = 0;
         while (found < netCount && nets[found] != n) found++;
@@ -604,8 +631,9 @@ exit:
 
 NCCL_PARAM(MnnvlRailPerHost, "MNNVL_RAIL_PER_HOST", 0);
 
-static bool ncclTopoSearchCheckNet(struct ncclTopoSystem* system, struct ncclTopoGraph* graph, struct ncclTopoNode* startNet, int n, int step) {
-  struct ncclTopoNode* net = system->nodes[NET].nodes+n;
+static bool ncclTopoSearchCheckNet(struct ncclTopoSystem* system, struct ncclTopoGraph* graph,
+                                   struct ncclTopoNode* startNet, int n, int step) {
+  struct ncclTopoNode* net = system->nodes[NET].nodes + n;
   if (graph->pattern == NCCL_TOPO_PATTERN_TREE && net->id != startNet->id) return false; // Trees are symmetric
   if (graph->pattern == NCCL_TOPO_PATTERN_RING && graph->crossNic == 2) {
     if (graph->nChannels & 1 && net->id != graph->inter[(graph->nChannels - 1) * 2]) return false;
@@ -617,11 +645,15 @@ static bool ncclTopoSearchCheckNet(struct ncclTopoSystem* system, struct ncclTop
       if (net->net.asic != startNet->net.asic || net->net.port != startNet->net.port) return false;
     }
   }
-  if (graph->pattern == NCCL_TOPO_PATTERN_BALANCED_TREE && step != 0 && net->id != graph->inter[graph->nChannels*2+1]) return false;
+  if (graph->pattern == NCCL_TOPO_PATTERN_BALANCED_TREE && step != 0 &&
+      net->id != graph->inter[graph->nChannels * 2 + 1])
+    return false;
   return true;
 }
 
-ncclResult_t ncclTopoSearchRecGpu(struct ncclTopoSystem* system, struct ncclTopoGraph* graph, struct ncclTopoGraph* saveGraph, struct ncclTopoNode* gpu, int step, int backToNet, int backToFirstRank, int forcedOrder, int *time) {
+ncclResult_t ncclTopoSearchRecGpu(struct ncclTopoSystem* system, struct ncclTopoGraph* graph,
+                                  struct ncclTopoGraph* saveGraph, struct ncclTopoNode* gpu, int step, int backToNet,
+                                  int backToFirstRank, int forcedOrder, int* time) {
   if ((*time) <= 0) return ncclSuccess;
   (*time)--;
 
@@ -641,18 +673,18 @@ ncclResult_t ncclTopoSearchRecGpu(struct ncclTopoSystem* system, struct ncclTopo
     graph->nChannels--;
     return ncclSuccess;
   }
-  graph->intra[graph->nChannels*ngpus+step] = gpu->gpu.rank;
+  graph->intra[graph->nChannels * ngpus + step] = gpu->gpu.rank;
   int g = gpu - system->nodes[GPU].nodes;
   int nets[NCCL_TOPO_MAX_NODES];
   if (step == backToNet) {
     // first get back to NIC
     if (system->inter) {
       int startNetIndex;
-      NCCLCHECK(getNetIndex(system, graph->inter[graph->nChannels*2], &startNetIndex));
-      struct ncclTopoNode* startNet = system->nodes[NET].nodes+startNetIndex;
+      NCCLCHECK(getNetIndex(system, graph->inter[graph->nChannels * 2], &startNetIndex));
+      struct ncclTopoNode* startNet = system->nodes[NET].nodes + startNetIndex;
       int netCount;
       NCCLCHECK(ncclTopoSelectNets(system, graph->typeInter, g, nets, &netCount));
-      for (int i=0; i<netCount; i++) {
+      for (int i = 0; i < netCount; i++) {
         int n = nets[i];
         if (!ncclTopoSearchCheckNet(system, graph, startNet, n, step)) continue;
         // Balanced Tree : count half of the bandwidth on first two GPUs
@@ -668,8 +700,9 @@ ncclResult_t ncclTopoSearchRecGpu(struct ncclTopoSystem* system, struct ncclTopo
         NCCLCHECK(ncclTopoFollowPath(system, graph, GPU, g, NET, n, 1, &net));
         graph->bwInter = bwInterSave;
         if (net) {
-          graph->inter[graph->nChannels*2+1] = net->id;
-          NCCLCHECK(ncclTopoSearchRecGpu(system, graph, saveGraph, gpu, step, nextBackToNet, backToFirstRank, forcedOrder, time));
+          graph->inter[graph->nChannels * 2 + 1] = net->id;
+          NCCLCHECK(ncclTopoSearchRecGpu(system, graph, saveGraph, gpu, step, nextBackToNet, backToFirstRank,
+                                         forcedOrder, time));
 
           if (graph->pattern == NCCL_TOPO_PATTERN_BALANCED_TREE) graph->bwInter /= 2;
           NCCLCHECK(ncclTopoFollowPath(system, graph, GPU, g, NET, n, -1, &net));
@@ -681,30 +714,34 @@ ncclResult_t ncclTopoSearchRecGpu(struct ncclTopoSystem* system, struct ncclTopo
     NCCLCHECK(ncclTopoSearchTryNvls(system, graph, saveGraph, g, ngpus, time));
   } else if (graph->pattern == NCCL_TOPO_PATTERN_COLLNET_DIRECT) {
     NCCLCHECK(ncclTopoSearchTryCollnetDirect(system, graph, saveGraph, g, ngpus, time));
-  } else if (step < system->nodes[GPU].count-1) {
+  } else if (step < system->nodes[GPU].count - 1) {
     // Go to next GPU
     int next[NCCL_TOPO_MAX_NODES];
     int count;
     if (forcedOrder == FORCED_ORDER_PCI) { // Try the PCI order
-      next[0] = step+1;
+      next[0] = step + 1;
       count = 1;
     } else if (forcedOrder == FORCED_ORDER_REPLAY) { // Try last channel order
       NCCLCHECK(ncclTopoReplayGetGpu(system, graph, step, next));
       count = 1;
     } else { // Normal search
-      NCCLCHECK(ncclTopoSearchNextGpuSort(system, graph, gpu, next, &count, backToNet == -1 ? 0 : backToNet == step+1 ? 1 : -1 ));
+      NCCLCHECK(ncclTopoSearchNextGpuSort(system, graph, gpu, next, &count,
+                                          backToNet == -1       ? 0 :
+                                          backToNet == step + 1 ? 1 :
+                                                                  -1));
     }
-    for (int i=0; i<count; i++) {
-      NCCLCHECK(ncclTopoSearchTryGpu(system, graph, saveGraph, step+1, backToNet, backToFirstRank, forcedOrder, time, GPU, g, next[i]));
+    for (int i = 0; i < count; i++) {
+      NCCLCHECK(ncclTopoSearchTryGpu(system, graph, saveGraph, step + 1, backToNet, backToFirstRank, forcedOrder, time,
+                                     GPU, g, next[i]));
     }
   } else if (step == backToFirstRank) {
     // Find first GPU and loop back to it
     int p;
-    NCCLCHECK(getGpuIndex(system, graph->intra[graph->nChannels*ngpus], &p));
+    NCCLCHECK(getGpuIndex(system, graph->intra[graph->nChannels * ngpus], &p));
     struct ncclTopoNode* firstGpu;
     NCCLCHECK(ncclTopoFollowPath(system, graph, GPU, g, GPU, p, 1, &firstGpu));
     if (firstGpu) {
-      NCCLCHECK(ncclTopoSearchRecGpu(system, graph, saveGraph, firstGpu, step+1, backToNet, -1, forcedOrder, time));
+      NCCLCHECK(ncclTopoSearchRecGpu(system, graph, saveGraph, firstGpu, step + 1, backToNet, -1, forcedOrder, time));
       NCCLCHECK(ncclTopoFollowPath(system, graph, GPU, g, GPU, p, -1, &firstGpu));
     }
   } else {
@@ -714,25 +751,28 @@ ncclResult_t ncclTopoSearchRecGpu(struct ncclTopoSystem* system, struct ncclTopo
   return ncclSuccess;
 }
 
-ncclResult_t ncclTopoSearchRecNet(struct ncclTopoSystem* system, struct ncclTopoGraph* graph, struct ncclTopoGraph* saveGraph, int backToNet, int backToFirstRank, int* time) {
+ncclResult_t ncclTopoSearchRecNet(struct ncclTopoSystem* system, struct ncclTopoGraph* graph,
+                                  struct ncclTopoGraph* saveGraph, int backToNet, int backToFirstRank, int* time) {
   const int bw = graph->bwInter;
   int nets[NCCL_TOPO_MAX_NODES];
   int netCount;
   int graphFound = 0;
   NCCLCHECK(ncclTopoSelectNets(system, graph->typeInter, -1, nets, &netCount));
-  for (int i=0; i<netCount; i++) {
-    if ((graph->pattern == NCCL_TOPO_PATTERN_NVLS || graph->pattern == NCCL_TOPO_PATTERN_COLLNET_DIRECT) && graphFound) break;
-    int n = nets[(graph->nChannels+i)%netCount];
-    struct ncclTopoNode* net = system->nodes[NET].nodes+n;
+  for (int i = 0; i < netCount; i++) {
+    if ((graph->pattern == NCCL_TOPO_PATTERN_NVLS || graph->pattern == NCCL_TOPO_PATTERN_COLLNET_DIRECT) && graphFound)
+      break;
+    int n = nets[(graph->nChannels + i) % netCount];
+    struct ncclTopoNode* net = system->nodes[NET].nodes + n;
     if (graph->collNet && net->net.collSupport == 0) continue;
     if (net->net.bw < bw) continue;
-    if (graph->pattern == NCCL_TOPO_PATTERN_RING && graph->crossNic == 2
-        && (graph->nChannels & 1) && net->id != graph->inter[(graph->nChannels-1)*2+1]) continue;
+    if (graph->pattern == NCCL_TOPO_PATTERN_RING && graph->crossNic == 2 && (graph->nChannels & 1) &&
+        net->id != graph->inter[(graph->nChannels - 1) * 2 + 1])
+      continue;
 
-    graph->inter[graph->nChannels*2] = net->id;
+    graph->inter[graph->nChannels * 2] = net->id;
     graph->latencyInter = net->net.latency;
 
-    for (int i=0; i<system->nodes[NET].count; i++) {
+    for (int i = 0; i < system->nodes[NET].count; i++) {
       if ((system->nodes[NET].nodes[i].net.asic == net->net.asic) &&
           (system->nodes[NET].nodes[i].net.port == net->net.port)) {
         system->nodes[NET].nodes[i].net.bw -= bw;
@@ -753,7 +793,8 @@ ncclResult_t ncclTopoSearchRecNet(struct ncclTopoSystem* system, struct ncclTopo
             }
           }
           if (!duplicate) {
-            NCCLCHECK(ncclTopoSearchTryGpu(system, graph, saveGraph, 0, backToNet, backToFirstRank, 0, time, NET, n, gpu));
+            NCCLCHECK(ncclTopoSearchTryGpu(system, graph, saveGraph, 0, backToNet, backToFirstRank, 0, time, NET, n,
+                                           gpu));
             graphFound = 1;
           }
         }
@@ -763,14 +804,15 @@ ncclResult_t ncclTopoSearchRecNet(struct ncclTopoSystem* system, struct ncclTopo
         // Try to replay the last channel
         int g;
         NCCLCHECK(ncclTopoReplayGetGpu(system, graph, -1, &g));
-        NCCLCHECK(ncclTopoSearchTryGpu(system, graph, saveGraph, 0, backToNet, backToFirstRank, FORCED_ORDER_REPLAY, time, NET, n, g));
+        NCCLCHECK(ncclTopoSearchTryGpu(system, graph, saveGraph, 0, backToNet, backToFirstRank, FORCED_ORDER_REPLAY,
+                                       time, NET, n, g));
       } else {
         if (graph->nChannels == 0 && system->nodes[NVS].count == 0) {
           // Always try the PCI order first to set a reference, but don't count in the timeout nor let it run for long
           struct ncclTopoLinkList* paths = net->paths[GPU];
           int f = 0, f_gdr = 0;
           // find the first GPU that is closest to NIC
-          for (int i = 0; i<system->nodes[GPU].count; i++) {
+          for (int i = 0; i < system->nodes[GPU].count; i++) {
             if (paths[i].count <= paths[f].count) {
               // prefer GPU direct RDMA
               enum ncclTopoGdrMode useGdr;
@@ -782,14 +824,16 @@ ncclResult_t ncclTopoSearchRecNet(struct ncclTopoSystem* system, struct ncclTopo
             }
           }
           int t = 1 << 10;
-          NCCLCHECK(ncclTopoSearchTryGpu(system, graph, saveGraph, 0, backToNet, backToFirstRank, FORCED_ORDER_PCI, &t, NET, n, 0));
+          NCCLCHECK(ncclTopoSearchTryGpu(system, graph, saveGraph, 0, backToNet, backToFirstRank, FORCED_ORDER_PCI, &t,
+                                         NET, n, 0));
           if (t == -1) *time = -1;
         }
 
         // Then try the most local GPUs
         int localGpu = net->net.localGpu;
         if (localGpu != -1) {
-          NCCLCHECK(ncclTopoSearchTryGpu(system, graph, saveGraph, 0, backToNet, backToFirstRank, 0, time, NET, n, localGpu));
+          NCCLCHECK(ncclTopoSearchTryGpu(system, graph, saveGraph, 0, backToNet, backToFirstRank, 0, time, NET, n,
+                                         localGpu));
         }
         int localGpus[NCCL_TOPO_MAX_NODES], localGpuCount, pathType;
         NCCLCHECK(ncclTopoGetLocal(system, NET, n, GPU, localGpus, &localGpuCount, &pathType));
@@ -797,12 +841,13 @@ ncclResult_t ncclTopoSearchRecNet(struct ncclTopoSystem* system, struct ncclTopo
         if (pathType == PATH_DIS) continue;
         for (int g = 0; g < localGpuCount; ++g) {
           if (localGpus[g] == localGpu) continue; // We already tried this one
-          NCCLCHECK(ncclTopoSearchTryGpu(system, graph, saveGraph, 0, backToNet, backToFirstRank, 0, time, NET, n, localGpus[g]));
+          NCCLCHECK(ncclTopoSearchTryGpu(system, graph, saveGraph, 0, backToNet, backToFirstRank, 0, time, NET, n,
+                                         localGpus[g]));
         }
       }
     }
 
-    for (int i=0; i<system->nodes[NET].count; i++) {
+    for (int i = 0; i < system->nodes[NET].count; i++) {
       if ((system->nodes[NET].nodes[i].net.asic == net->net.asic) &&
           (system->nodes[NET].nodes[i].net.port == net->net.port)) {
         system->nodes[NET].nodes[i].net.bw += bw;
@@ -813,37 +858,38 @@ ncclResult_t ncclTopoSearchRecNet(struct ncclTopoSystem* system, struct ncclTopo
 }
 
 /* Search Patterns
-*
-*     Intra-node
-* Ring            : GPU a -> GPU b -> .. -> GPU x -> GPU a
-* (=Split Tree Loop)
-* Tree            : GPU a -> GPU b -> .. -> GPU x
-* (=Split Tree)
-*
-*     Inter-node
-* Ring            : NET n -> GPU a -> GPU b -> .. -> GPU x -> NET n (or m if crossNic)
-* Tree            : NET n -> GPU a -> GPU b -> .. -> GPU x
-*                              `--> NET n (or m if crossNic)
-* Split Tree      : NET n -> GPU a -> GPU b -> .. -> GPU x
-*                                       `--> NET n (or m if crossNic)
-* Split Tree Loop : NET n -> GPU a -> GPU b -> .. -> GPU x -> GPU a
-*                                       `--> NET n (or m if crossNic)
-*/
+ *
+ *     Intra-node
+ * Ring            : GPU a -> GPU b -> .. -> GPU x -> GPU a
+ * (=Split Tree Loop)
+ * Tree            : GPU a -> GPU b -> .. -> GPU x
+ * (=Split Tree)
+ *
+ *     Inter-node
+ * Ring            : NET n -> GPU a -> GPU b -> .. -> GPU x -> NET n (or m if crossNic)
+ * Tree            : NET n -> GPU a -> GPU b -> .. -> GPU x
+ *                              `--> NET n (or m if crossNic)
+ * Split Tree      : NET n -> GPU a -> GPU b -> .. -> GPU x
+ *                                       `--> NET n (or m if crossNic)
+ * Split Tree Loop : NET n -> GPU a -> GPU b -> .. -> GPU x -> GPU a
+ *                                       `--> NET n (or m if crossNic)
+ */
 ncclResult_t ncclTopoSearchParams(struct ncclTopoSystem* system, int pattern, int* backToNet, int* backToFirstRank) {
   if (system->nodes[NET].count && system->nodes[GPU].count != system->nRanks) {
-    if (pattern == NCCL_TOPO_PATTERN_RING) *backToNet = system->nodes[GPU].count-1;
+    if (pattern == NCCL_TOPO_PATTERN_RING) *backToNet = system->nodes[GPU].count - 1;
     else if (pattern == NCCL_TOPO_PATTERN_SPLIT_TREE) *backToNet = 1;
     else *backToNet = 0;
     *backToFirstRank = -1;
   } else {
     *backToNet = -1;
-    if (pattern == NCCL_TOPO_PATTERN_RING) *backToFirstRank = system->nodes[GPU].count-1;
+    if (pattern == NCCL_TOPO_PATTERN_RING) *backToFirstRank = system->nodes[GPU].count - 1;
     else *backToFirstRank = -1;
   }
   return ncclSuccess;
 }
 
-ncclResult_t ncclTopoSearchRec(struct ncclTopoSystem* system, struct ncclTopoGraph* graph, struct ncclTopoGraph* saveGraph, int* time) {
+ncclResult_t ncclTopoSearchRec(struct ncclTopoSystem* system, struct ncclTopoGraph* graph,
+                               struct ncclTopoGraph* saveGraph, int* time) {
   int backToNet, backToFirstRank;
   NCCLCHECK(ncclTopoSearchParams(system, graph->pattern, &backToNet, &backToFirstRank));
   if (system->nodes[NET].count && system->nodes[GPU].count != system->nRanks) {
@@ -852,20 +898,23 @@ ncclResult_t ncclTopoSearchRec(struct ncclTopoSystem* system, struct ncclTopoGra
   } else {
     // Intra-node only.
     if (graph->pattern == NCCL_TOPO_PATTERN_NVLS) {
-      NCCLCHECK(ncclTopoSearchTryGpu(system, graph, saveGraph, 0, backToNet, backToFirstRank, 0, time, -1, -1, graph->nChannels));
+      NCCLCHECK(ncclTopoSearchTryGpu(system, graph, saveGraph, 0, backToNet, backToFirstRank, 0, time, -1, -1,
+                                     graph->nChannels));
       return ncclSuccess;
     } else if (graph->nChannels == 0) {
       // Try PCI order first
-      NCCLCHECK(ncclTopoSearchTryGpu(system, graph, saveGraph, 0, backToNet, backToFirstRank, FORCED_ORDER_PCI, time, -1, -1, 0));
+      NCCLCHECK(ncclTopoSearchTryGpu(system, graph, saveGraph, 0, backToNet, backToFirstRank, FORCED_ORDER_PCI, time,
+                                     -1, -1, 0));
     } else {
       // Also try to replay previous channel
       int g;
       NCCLCHECK(ncclTopoReplayGetGpu(system, graph, -1, &g));
-      NCCLCHECK(ncclTopoSearchTryGpu(system, graph, saveGraph, 0, backToNet, backToFirstRank, FORCED_ORDER_REPLAY, time, -1, -1, g));
+      NCCLCHECK(ncclTopoSearchTryGpu(system, graph, saveGraph, 0, backToNet, backToFirstRank, FORCED_ORDER_REPLAY, time,
+                                     -1, -1, g));
     }
     if (graph->sameChannels == 0 || graph->nChannels == 0) {
       // Finally, try all other possibilities unless we are forced to use the same channels
-      for (int g=0; g<system->nodes[GPU].count; g++) {
+      for (int g = 0; g < system->nodes[GPU].count; g++) {
         NCCLCHECK(ncclTopoSearchTryGpu(system, graph, saveGraph, 0, backToNet, backToFirstRank, 0, time, -1, -1, g));
       }
     }
@@ -877,25 +926,17 @@ ncclResult_t ncclTopoSearchRec(struct ncclTopoSystem* system, struct ncclTopoGra
 /* User defined graph from XML file */
 /************************************/
 
-struct kvDict kvDictLinkType[] = {
-  { "LOC", PATH_LOC },
-  { "NVL", PATH_NVL },
-  { "NVB", PATH_NVB },
-  { "PIX", PATH_PIX },
-  { "PXB", PATH_PXB },
-  { "P2C", PATH_P2C },
-  { "PXN", PATH_PXN },
-  { "PHB", PATH_PHB },
-  { "SYS", PATH_SYS },
-  { NULL, 0 }
-};
+struct kvDict kvDictLinkType[] = {{"LOC", PATH_LOC}, {"NVL", PATH_NVL}, {"NVB", PATH_NVB}, {"PIX", PATH_PIX},
+                                  {"PXB", PATH_PXB}, {"P2C", PATH_P2C}, {"PXN", PATH_PXN}, {"PHB", PATH_PHB},
+                                  {"SYS", PATH_SYS}, {NULL, 0}};
 
-ncclResult_t ncclTopoGetChannelFromXml(struct ncclXmlNode *xmlChannel, int c, struct ncclTopoSystem* system, struct ncclTopoGraph* graph) {
+ncclResult_t ncclTopoGetChannelFromXml(struct ncclXmlNode* xmlChannel, int c, struct ncclTopoSystem* system,
+                                       struct ncclTopoGraph* graph) {
   int ngpus = system->nodes[GPU].count;
-  int64_t* inter = graph->inter+2*c;
-  int* intra = graph->intra+ngpus*c;
-  int n=0, g=0;
-  for (int s=0; s<xmlChannel->nSubs; s++) {
+  int64_t* inter = graph->inter + 2 * c;
+  int* intra = graph->intra + ngpus * c;
+  int n = 0, g = 0;
+  for (int s = 0; s < xmlChannel->nSubs; s++) {
     struct ncclXmlNode* sub = xmlChannel->subs[s];
     int64_t dev;
     const char* str;
@@ -910,9 +951,10 @@ ncclResult_t ncclTopoGetChannelFromXml(struct ncclXmlNode *xmlChannel, int c, st
       if (rankIndex != -1) {
         rank = strtol(sub->attrs[rankIndex].value, NULL, 0);
       } else {
-        for (int g=0; g<ngpus; g++) {
+        for (int g = 0; g < ngpus; g++) {
           int systemId = NCCL_TOPO_ID_SYSTEM_ID(system->nodes[GPU].nodes[g].gpu.parent->id);
-          if (NCCL_TOPO_ID(systemId, system->nodes[GPU].nodes[g].gpu.dev) == dev) rank = system->nodes[GPU].nodes[g].gpu.rank;
+          if (NCCL_TOPO_ID(systemId, system->nodes[GPU].nodes[g].gpu.dev) == dev)
+            rank = system->nodes[GPU].nodes[g].gpu.rank;
         }
         if (rank == -1) {
           WARN("XML Import Channel : dev %ld not found.", dev);
@@ -924,7 +966,8 @@ ncclResult_t ncclTopoGetChannelFromXml(struct ncclXmlNode *xmlChannel, int c, st
   }
   return ncclSuccess;
 }
-ncclResult_t ncclTopoGetGraphFromXmlSub(struct ncclXmlNode *xmlGraph, struct ncclTopoSystem* system, struct ncclTopoGraph* graph, int* nChannels) {
+ncclResult_t ncclTopoGetGraphFromXmlSub(struct ncclXmlNode* xmlGraph, struct ncclTopoSystem* system,
+                                        struct ncclTopoGraph* graph, int* nChannels) {
   int id;
   NCCLCHECK(xmlGetAttrInt(xmlGraph, "id", &id));
   if (graph->id != id) return ncclSuccess;
@@ -947,35 +990,37 @@ ncclResult_t ncclTopoGetGraphFromXmlSub(struct ncclXmlNode *xmlGraph, struct ncc
   NCCLCHECK(xmlGetAttr(xmlGraph, "typeinter", &str));
   NCCLCHECK(kvConvertToInt(str, &graph->typeInter, kvDictLinkType));
   NCCLCHECK(xmlGetAttrInt(xmlGraph, "samechannels", &graph->sameChannels));
-  for (int s=0; s<xmlGraph->nSubs; s++) {
+  for (int s = 0; s < xmlGraph->nSubs; s++) {
     NCCLCHECK(ncclTopoGetChannelFromXml(xmlGraph->subs[s], s, system, graph));
   }
   *nChannels = xmlGraph->nSubs;
   return ncclSuccess;
 }
-ncclResult_t ncclTopoGetGraphFromXml(struct ncclXmlNode *xmlGraphs, struct ncclTopoSystem* system, struct ncclTopoGraph* graph, int* nChannels) {
-  for (int s=0; s<xmlGraphs->nSubs; s++) {
+ncclResult_t ncclTopoGetGraphFromXml(struct ncclXmlNode* xmlGraphs, struct ncclTopoSystem* system,
+                                     struct ncclTopoGraph* graph, int* nChannels) {
+  for (int s = 0; s < xmlGraphs->nSubs; s++) {
     NCCLCHECK(ncclTopoGetGraphFromXmlSub(xmlGraphs->subs[s], system, graph, nChannels));
   }
   return ncclSuccess;
 }
 
 /* And the reverse : graph->xml */
-ncclResult_t ncclTopoGetXmlFromChannel(struct ncclTopoGraph* graph, int c, struct ncclTopoSystem* system, struct ncclXml *xml, struct ncclXmlNode* parent) {
+ncclResult_t ncclTopoGetXmlFromChannel(struct ncclTopoGraph* graph, int c, struct ncclTopoSystem* system,
+                                       struct ncclXml* xml, struct ncclXmlNode* parent) {
   struct ncclXmlNode* xmlChannel;
   int ngpus = system->nodes[GPU].count;
-  int64_t* inter = graph->inter+2*c;
-  int* intra = graph->intra+ngpus*c;
+  int64_t* inter = graph->inter + 2 * c;
+  int* intra = graph->intra + ngpus * c;
   NCCLCHECK(xmlAddNode(xml, parent, "channel", &xmlChannel));
   struct ncclXmlNode* node;
   if (system->inter) {
     NCCLCHECK(xmlAddNode(xml, xmlChannel, "net", &node));
     NCCLCHECK(xmlSetAttrLong(node, "dev", inter[0]));
   }
-  for (int g=0; g<ngpus; g++) {
+  for (int g = 0; g < ngpus; g++) {
     NCCLCHECK(xmlAddNode(xml, xmlChannel, "gpu", &node));
     int64_t dev = -1;
-    for (int i=0; i<ngpus; i++) {
+    for (int i = 0; i < ngpus; i++) {
       if (system->nodes[GPU].nodes[i].gpu.rank == intra[g]) {
         int systemId = NCCL_TOPO_ID_SYSTEM_ID(system->nodes[GPU].nodes[i].id);
         dev = NCCL_TOPO_ID(systemId, system->nodes[GPU].nodes[i].gpu.dev);
@@ -995,7 +1040,8 @@ ncclResult_t ncclTopoGetXmlFromChannel(struct ncclTopoGraph* graph, int c, struc
   }
   return ncclSuccess;
 }
-ncclResult_t ncclTopoGetXmlFromGraph(struct ncclTopoGraph* graph, struct ncclTopoSystem* system, struct ncclXml *xml, struct ncclXmlNode* parent) {
+ncclResult_t ncclTopoGetXmlFromGraph(struct ncclTopoGraph* graph, struct ncclTopoSystem* system, struct ncclXml* xml,
+                                     struct ncclXmlNode* parent) {
   struct ncclXmlNode* xmlGraph;
   NCCLCHECK(xmlAddNode(xml, parent, "graph", &xmlGraph));
   NCCLCHECK(xmlSetAttrInt(xmlGraph, "id", graph->id));
@@ -1011,17 +1057,18 @@ ncclResult_t ncclTopoGetXmlFromGraph(struct ncclTopoGraph* graph, struct ncclTop
   NCCLCHECK(kvConvertToStr(graph->typeInter, &str, kvDictLinkType));
   NCCLCHECK(xmlSetAttr(xmlGraph, "typeinter", str));
   NCCLCHECK(xmlSetAttrInt(xmlGraph, "samechannels", graph->sameChannels));
-  for (int c=0; c<graph->nChannels; c++) {
+  for (int c = 0; c < graph->nChannels; c++) {
     NCCLCHECK(ncclTopoGetXmlFromChannel(graph, c, system, xml, xmlGraph));
   }
   return ncclSuccess;
 }
-ncclResult_t ncclTopoGetXmlFromGraphs(int ngraphs, struct ncclTopoGraph** graphs, struct ncclTopoSystem* system, struct ncclXml *xml) {
+ncclResult_t ncclTopoGetXmlFromGraphs(int ngraphs, struct ncclTopoGraph** graphs, struct ncclTopoSystem* system,
+                                      struct ncclXml* xml) {
   xml->maxIndex = 0;
   struct ncclXmlNode* xmlGraphs;
   NCCLCHECK(xmlAddNode(xml, NULL, "graphs", &xmlGraphs));
   NCCLCHECK(xmlSetAttrInt(xmlGraphs, "version", NCCL_GRAPH_XML_VERSION));
-  for (int g=0; g<ngraphs; g++) {
+  for (int g = 0; g < ngraphs; g++) {
     NCCLCHECK(ncclTopoGetXmlFromGraph(graphs[g], system, xml, xmlGraphs));
   }
   return ncclSuccess;
@@ -1033,9 +1080,9 @@ ncclResult_t ncclTopoDupChannels(struct ncclTopoGraph* graph, int ccMin, int ngp
   if (graph->bwIntra < 25.0) return ncclSuccess;
   if (ccMin > 80 && graph->bwIntra < 50.0 && graph->nChannels > 4) return ncclSuccess;
 
-  int dupChannels = std::min(graph->nChannels*2, graph->maxChannels);
-  memcpy(graph->intra+graph->nChannels*ngpus, graph->intra, (dupChannels-graph->nChannels)*ngpus*sizeof(int));
-  memcpy(graph->inter+graph->nChannels*2,graph->inter, (dupChannels-graph->nChannels)*2*sizeof(int64_t));
+  int dupChannels = std::min(graph->nChannels * 2, graph->maxChannels);
+  memcpy(graph->intra + graph->nChannels * ngpus, graph->intra, (dupChannels - graph->nChannels) * ngpus * sizeof(int));
+  memcpy(graph->inter + graph->nChannels * 2, graph->inter, (dupChannels - graph->nChannels) * 2 * sizeof(int64_t));
   graph->bwIntra /= DIVUP(dupChannels, graph->nChannels);
   graph->bwInter /= DIVUP(dupChannels, graph->nChannels);
   graph->nChannels = dupChannels;
@@ -1043,28 +1090,33 @@ ncclResult_t ncclTopoDupChannels(struct ncclTopoGraph* graph, int ccMin, int ngp
 }
 
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-float speedArrayIntra[] = { 48.0, 24.0, 20.0, 18.0, 15.0, 12.0, 10.0, 9.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.4, 1.2, 0.24, 0.12 };
-float speedArrayInter[] = { 48.0, 24.0, 20.0, 18.0, 15.0, 12.0, 10.0, 9.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.4, 1.2, 0.24, 0.12 };
-#define NSPEEDSINTRA (sizeof(speedArrayIntra)/sizeof(float))
-#define NSPEEDSINTER (sizeof(speedArrayInter)/sizeof(float))
+float speedArrayIntra[] = {48.0, 24.0, 20.0, 18.0, 15.0, 12.0, 10.0, 9.0, 7.0,
+                           6.0,  5.0,  4.0,  3.0,  2.4,  1.2,  0.24, 0.12};
+float speedArrayInter[] = {48.0, 24.0, 20.0, 18.0, 15.0, 12.0, 10.0, 9.0, 7.0,
+                           6.0,  5.0,  4.0,  3.0,  2.4,  1.2,  0.24, 0.12};
+#define NSPEEDSINTRA (sizeof(speedArrayIntra) / sizeof(float))
+#define NSPEEDSINTER (sizeof(speedArrayInter) / sizeof(float))
 #else
-float speedArrayIntra[] = { 40.0, 30.0, 20.0, 18.0, 15.0, 12.0, 10.0, 9.0, 7.0, 6.0, 5.0, 4.0, 3.0 };
-float speedArrayInter[] = { 48.0, 30.0, 28.0, 24.0, 20.0, 18.0, 15.0, 12.0, 10.0, 9.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.4, 1.2, 0.24, 0.12 };
-#define NSPEEDSINTRA (sizeof(speedArrayIntra)/sizeof(float))
-#define NSPEEDSINTER (sizeof(speedArrayInter)/sizeof(float))
+float speedArrayIntra[] = {40.0, 30.0, 20.0, 18.0, 15.0, 12.0, 10.0, 9.0, 7.0, 6.0, 5.0, 4.0, 3.0};
+float speedArrayInter[] = {48.0, 30.0, 28.0, 24.0, 20.0, 18.0, 15.0, 12.0, 10.0, 9.0,
+                           7.0,  6.0,  5.0,  4.0,  3.0,  2.4,  1.2,  0.24, 0.12};
+#define NSPEEDSINTRA (sizeof(speedArrayIntra) / sizeof(float))
+#define NSPEEDSINTER (sizeof(speedArrayInter) / sizeof(float))
 #endif
 
-float sm90SpeedArrayIntra[] = { 60.0, 50.0, 40.0, 30.0, 24.0, 20.0, 15.0, 12.0, 11.0, 6.0, 3.0 };
-float sm90SpeedArrayInter[] = { 48.0, 45.0, 42.0, 40.0, 30.0, 24.0, 22.0, 20.0, 17.5, 15.0, 12.0, 6.0, 3.0, 2.4, 1.2, 0.24, 0.12 };
-#define NSPEEDSINTRA_SM90 (sizeof(sm90SpeedArrayIntra)/sizeof(float))
-#define NSPEEDSINTER_SM90 (sizeof(sm90SpeedArrayInter)/sizeof(float))
+float sm90SpeedArrayIntra[] = {60.0, 50.0, 40.0, 30.0, 24.0, 20.0, 15.0, 12.0, 11.0, 6.0, 3.0};
+float sm90SpeedArrayInter[] = {48.0, 45.0, 42.0, 40.0, 30.0, 24.0, 22.0, 20.0, 17.5,
+                               15.0, 12.0, 6.0,  3.0,  2.4,  1.2,  0.24, 0.12};
+#define NSPEEDSINTRA_SM90 (sizeof(sm90SpeedArrayIntra) / sizeof(float))
+#define NSPEEDSINTER_SM90 (sizeof(sm90SpeedArrayInter) / sizeof(float))
 
 RCCL_PARAM(ModelMatchingDisable, "MODEL_MATCHING_DISABLE", 0);
 
-float sm100SpeedArrayIntra[] = { 90.0, 80.0, 70.0, 60.0, 50.0, 45.0, 40.0, 30.0, 24.0, 20.0, 19.0, 18.0 };
-float sm100SpeedArrayInter[] = { 96.0, 48.0, 45.1, 42.0, 40.0, 30.0, 24.0, 22.0, 20.0, 17.5, 15.0, 12.0, 6.0, 3.0, 2.4, 1.2, 0.24, 0.12 };
-#define NSPEEDSINTRA_SM100 (sizeof(sm100SpeedArrayIntra)/sizeof(float))
-#define NSPEEDSINTER_SM100 (sizeof(sm100SpeedArrayInter)/sizeof(float))
+float sm100SpeedArrayIntra[] = {90.0, 80.0, 70.0, 60.0, 50.0, 45.0, 40.0, 30.0, 24.0, 20.0, 19.0, 18.0};
+float sm100SpeedArrayInter[] = {96.0, 48.0, 45.1, 42.0, 40.0, 30.0, 24.0, 22.0, 20.0,
+                                17.5, 15.0, 12.0, 6.0,  3.0,  2.4,  1.2,  0.24, 0.12};
+#define NSPEEDSINTRA_SM100 (sizeof(sm100SpeedArrayIntra) / sizeof(float))
+#define NSPEEDSINTER_SM100 (sizeof(sm100SpeedArrayInter) / sizeof(float))
 
 ncclResult_t ncclTopoCheckCrossNicSupport(bool* supported) {
   *supported = (ncclParamCrossNic() != 0);
@@ -1096,9 +1148,10 @@ ncclResult_t ncclTopoCompute(ncclTopoSystem* system, struct ncclTopoGraph* graph
   int ngpus = system->nodes[GPU].count;
   int ndevs = system->nodes[DEV].count;
   int crossNic = (system->nodes[NET].count > 1) &&
-  (graph->pattern == NCCL_TOPO_PATTERN_RING ||
-          graph->pattern == NCCL_TOPO_PATTERN_BALANCED_TREE ||
-          graph->pattern == NCCL_TOPO_PATTERN_SPLIT_TREE) ? ncclParamCrossNic() : 0;
+                     (graph->pattern == NCCL_TOPO_PATTERN_RING || graph->pattern == NCCL_TOPO_PATTERN_BALANCED_TREE ||
+                      graph->pattern == NCCL_TOPO_PATTERN_SPLIT_TREE) ?
+                   ncclParamCrossNic() :
+                   0;
   graph->crossNic = crossNic == 1 ? 1 : 0;
   graph->bwIntra = graph->bwInter = 0;
   graph->latencyInter = 0;
@@ -1120,7 +1173,7 @@ ncclResult_t ncclTopoCompute(ncclTopoSystem* system, struct ncclTopoGraph* graph
   graph->typeInter = minTypeInter;
   graph->nChannels = 0;
   graph->nIntraChannels = 0;
-  memset(graph->intraNets, 0, MAXCHANNELS*NCCL_TOPO_MAX_NODES*2*sizeof(int));
+  memset(graph->intraNets, 0, MAXCHANNELS * NCCL_TOPO_MAX_NODES * 2 * sizeof(int));
   int trySameChannels = graph->pattern == NCCL_TOPO_PATTERN_NVLS ? 0 : 1;
   graph->sameChannels = trySameChannels;
 
@@ -1147,14 +1200,15 @@ ncclResult_t ncclTopoCompute(ncclTopoSystem* system, struct ncclTopoGraph* graph
     // user supplied topo
     if (strTrees) {
       NCCLCHECK(parseGraphLight(strTrees, system, graph, NULL));
-      system->treeDefined=true;
+      system->treeDefined = true;
     } else {
       // For even number of nodes, alternate forward/reverse on ringBase
       NCCLCHECK(parseGraph(str, system, graph, NULL, NULL,
-        graph->pattern == NCCL_TOPO_PATTERN_RING ? system->hostIdx % 2 : 0));
+                           graph->pattern == NCCL_TOPO_PATTERN_RING ? system->hostIdx % 2 : 0));
       int arch, vendor, model;
       NCCLCHECK(ncclTopoCpuType(system, &arch, &vendor, &model));
-      if (graph->nChannels && arch == NCCL_TOPO_CPU_ARCH_X86 && vendor == NCCL_TOPO_CPU_VENDOR_AMD && model == NCCL_TOPO_CPU_MODEL_AMD_ROME) {
+      if (graph->nChannels && arch == NCCL_TOPO_CPU_ARCH_X86 && vendor == NCCL_TOPO_CPU_VENDOR_AMD &&
+          model == NCCL_TOPO_CPU_MODEL_AMD_ROME) {
         system->type |= RCCL_TOPO_4P2H_ROME;
       }
     }
@@ -1166,7 +1220,7 @@ ncclResult_t ncclTopoCompute(ncclTopoSystem* system, struct ncclTopoGraph* graph
     NCCLCHECK(parseA2a8P(system, graph, nullptr));
     if (graph->nChannels) return ncclSuccess;
     // try to match Rome 4P2H
-    const char *remap_str = getenv("NCCL_RINGS_REMAP");
+    const char* remap_str = getenv("NCCL_RINGS_REMAP");
     NCCLCHECK(parseRome4P2H(system, graph, remap_str));
     if (graph->nChannels) return ncclSuccess;
     // try to match 1H16P
@@ -1184,14 +1238,18 @@ ncclResult_t ncclTopoCompute(ncclTopoSystem* system, struct ncclTopoGraph* graph
     // limit single node max channels when searching ring graph on Rome
     graph->maxChannels = 2;
   }
-  if (ngpus == 1) if (graph->pattern != NCCL_TOPO_PATTERN_RING) graph->pattern = NCCL_TOPO_PATTERN_TREE;
+  if (ngpus == 1)
+    if (graph->pattern != NCCL_TOPO_PATTERN_RING) graph->pattern = NCCL_TOPO_PATTERN_TREE;
 
   if (graph->pattern == NCCL_TOPO_PATTERN_NVLS && (system->nodes[NVS].count == 0 || ccMin < 90)) return ncclSuccess;
   // NVLS and COLLNET_DIRECT search must have ngpus heads at most.
-  if (graph->pattern == NCCL_TOPO_PATTERN_NVLS) graph->maxChannels = std::min(NCCL_MAX_NVLS_ARITY, system->nodes[GPU].count);
-  if (graph->pattern == NCCL_TOPO_PATTERN_COLLNET_DIRECT) graph->maxChannels = std::min(NCCL_MAX_DIRECT_ARITY+1, system->nodes[GPU].count);
+  if (graph->pattern == NCCL_TOPO_PATTERN_NVLS)
+    graph->maxChannels = std::min(NCCL_MAX_NVLS_ARITY, system->nodes[GPU].count);
+  if (graph->pattern == NCCL_TOPO_PATTERN_COLLNET_DIRECT)
+    graph->maxChannels = std::min(NCCL_MAX_DIRECT_ARITY + 1, system->nodes[GPU].count);
 
-  if (ngpus == 1) if (graph->pattern != NCCL_TOPO_PATTERN_RING) graph->pattern = NCCL_TOPO_PATTERN_TREE;
+  if (ngpus == 1)
+    if (graph->pattern != NCCL_TOPO_PATTERN_RING) graph->pattern = NCCL_TOPO_PATTERN_TREE;
 
   if (system->inter == 0 && graph->pattern == NCCL_TOPO_PATTERN_NVLS) {
     // Force intra-node NVLS algorithm to pull evenly from all GPUs.
@@ -1226,15 +1284,18 @@ ncclResult_t ncclTopoCompute(ncclTopoSystem* system, struct ncclTopoGraph* graph
   float totalBw = system->totalBw;
 
   // algo other than RING do not need to close to the starting NET, so increase the NVLink bw artificially
-  if (ndevs > 1 && graph->pattern != NCCL_TOPO_PATTERN_RING) totalBw *= ndevs*1.0/(ndevs-1);
+  if (ndevs > 1 && graph->pattern != NCCL_TOPO_PATTERN_RING) totalBw *= ndevs * 1.0 / (ndevs - 1);
 
-  while ((speedArray[speedIndex] > maxBw || speedArray[speedIndex]*graph->minChannels > totalBw) && speedIndex < nspeeds-1) speedIndex++;
+  while ((speedArray[speedIndex] > maxBw || speedArray[speedIndex] * graph->minChannels > totalBw) &&
+         speedIndex < nspeeds - 1)
+    speedIndex++;
   tmpGraph.bwIntra = tmpGraph.bwInter = speedArray[speedIndex];
   int64_t globalTimeout = NCCL_SEARCH_GLOBAL_TIMEOUT;
 
 search:
-  int time = tmpGraph.sameChannels ? NCCL_SEARCH_TIMEOUT_SAMECHANNELS :
-    tmpGraph.pattern == NCCL_TOPO_PATTERN_TREE ? NCCL_SEARCH_TIMEOUT_TREE : NCCL_SEARCH_TIMEOUT;
+  int time = tmpGraph.sameChannels                      ? NCCL_SEARCH_TIMEOUT_SAMECHANNELS :
+             tmpGraph.pattern == NCCL_TOPO_PATTERN_TREE ? NCCL_SEARCH_TIMEOUT_TREE :
+                                                          NCCL_SEARCH_TIMEOUT;
   tmpGraph.nChannels = 0;
   globalTimeout -= time;
 
@@ -1252,14 +1313,14 @@ search:
 #endif
   // Optimal solution, stop here
   if (time == -1) goto done;
-  if (graph->nChannels*graph->bwInter >= system->totalBw) goto done;
+  if (graph->nChannels * graph->bwInter >= system->totalBw) goto done;
 
   if (pass == 1) {
     // First pass, we don't have a solution yet ; try other options
 
     // Try having different channels (except when going through AMD CPUs)
-    if (tmpGraph.sameChannels == 1 &&
-        !(cpuArch == NCCL_TOPO_CPU_ARCH_X86 && cpuVendor == NCCL_TOPO_CPU_VENDOR_AMD && tmpGraph.typeIntra == PATH_SYS)) {
+    if (tmpGraph.sameChannels == 1 && !(cpuArch == NCCL_TOPO_CPU_ARCH_X86 && cpuVendor == NCCL_TOPO_CPU_VENDOR_AMD &&
+                                        tmpGraph.typeIntra == PATH_SYS)) {
       tmpGraph.sameChannels = 0;
       goto search;
     }
@@ -1283,14 +1344,15 @@ search:
     }
     tmpGraph.typeIntra = minTypeIntra;
 
-    if (system->inter && tmpGraph.typeInter < maxTypeInter && (graph->nChannels == 0 || tmpGraph.typeInter < graph->typeInter || tmpGraph.typeInter < PATH_PXN)) {
+    if (system->inter && tmpGraph.typeInter < maxTypeInter &&
+        (graph->nChannels == 0 || tmpGraph.typeInter < graph->typeInter || tmpGraph.typeInter < PATH_PXN)) {
       tmpGraph.typeInter += 1;
       if (tmpGraph.typeInter < PATH_DIS) goto search;
     }
     tmpGraph.typeInter = minTypeInter;
 
-    if (crossNic == 2 && tmpGraph.crossNic == 0
-        && (graph->pattern == NCCL_TOPO_PATTERN_RING || graph->pattern == NCCL_TOPO_PATTERN_BALANCED_TREE)) {
+    if (crossNic == 2 && tmpGraph.crossNic == 0 &&
+        (graph->pattern == NCCL_TOPO_PATTERN_RING || graph->pattern == NCCL_TOPO_PATTERN_BALANCED_TREE)) {
       // Try again with crossNic if permitted
       tmpGraph.crossNic = 2;
       goto search;
@@ -1298,14 +1360,13 @@ search:
     tmpGraph.crossNic = crossNic == 1 ? 1 : 0;
 
     // Decrease bw until we find a solution
-    if ((speedIndex < nspeeds-1) && (graph->nChannels == 0 || (speedArray[speedIndex+1]/graph->bwInter > .49))) {
+    if ((speedIndex < nspeeds - 1) && (graph->nChannels == 0 || (speedArray[speedIndex + 1] / graph->bwInter > .49))) {
       tmpGraph.bwInter = tmpGraph.bwIntra = speedArray[++speedIndex];
       goto search;
     }
     speedIndex = 0;
-    while (speedArray[speedIndex] > maxBw && speedIndex < nspeeds-1) speedIndex++;
+    while (speedArray[speedIndex] > maxBw && speedIndex < nspeeds - 1) speedIndex++;
     tmpGraph.bwIntra = tmpGraph.bwInter = speedArray[speedIndex];
-
   }
 
 done:
@@ -1315,7 +1376,7 @@ done:
     NCCLCHECK(ncclTopoDupChannels(graph, ccMin, ngpus));
     memcpy(&tmpGraph, graph, sizeof(tmpGraph));
     speedIndex = 0;
-    while (speedArray[speedIndex] > graph->bwInter && speedIndex < nspeeds-1) speedIndex++;
+    while (speedArray[speedIndex] > graph->bwInter && speedIndex < nspeeds - 1) speedIndex++;
     tmpGraph.bwIntra = tmpGraph.bwInter = speedArray[speedIndex];
     tmpGraph.minChannels = graph->nChannels;
     pass = 2;
@@ -1328,11 +1389,12 @@ done:
         // increase bw for Ring
         tmpGraph.bwIntra = tmpGraph.bwInter = speedArray[--speedIndex];
         goto search;
-      } else if (graph->pattern == NCCL_TOPO_PATTERN_NVLS && tmpGraph.bwInter == graph->bwInter && tmpGraph.bwInter < tmpGraph.bwIntra*2) {
+      } else if (graph->pattern == NCCL_TOPO_PATTERN_NVLS && tmpGraph.bwInter == graph->bwInter &&
+                 tmpGraph.bwInter < tmpGraph.bwIntra * 2) {
         tmpGraph.minChannels = tmpGraph.maxChannels = graph->nChannels;
         tmpGraph.bwInter = speedArray[--speedIndex];
         goto search;
-      } else if (tmpGraph.bwIntra == graph->bwIntra && tmpGraph.bwIntra < tmpGraph.bwInter*2) {
+      } else if (tmpGraph.bwIntra == graph->bwIntra && tmpGraph.bwIntra < tmpGraph.bwInter * 2) {
         // increase bwIntra for trees (2 nodes or collnet)
         tmpGraph.bwIntra = speedArray[--speedIndex];
         goto search;
@@ -1347,13 +1409,13 @@ done:
     int netCount;
 
     INFO(NCCL_GRAPH, "Could not find a path for pattern %d, falling back to simple order", graph->pattern);
-    for (int i=0; i<ngpus; i++) graph->intra[i] = system->nodes[GPU].nodes[i].gpu.rank;
+    for (int i = 0; i < ngpus; i++) graph->intra[i] = system->nodes[GPU].nodes[i].gpu.rank;
     graph->bwIntra = 0.1;
     graph->typeIntra = PATH_SYS;
 
     NCCLCHECK(ncclTopoSelectNets(system, /*typeInter =*/-1, /*gpu =*/0, nets, &netCount));
     graph->inter[0] = (netCount > 0 ? system->nodes[NET].nodes[nets[0]].id : -1);
-    NCCLCHECK(ncclTopoSelectNets(system, /*typeInter =*/-1, /*gpu =*/ngpus-1, nets, &netCount));
+    NCCLCHECK(ncclTopoSelectNets(system, /*typeInter =*/-1, /*gpu =*/ngpus - 1, nets, &netCount));
     graph->inter[1] = (netCount > 0 ? system->nodes[NET].nodes[nets[0]].id : -1);
     if (graph->inter[0] != -1 && graph->inter[1] != -1) {
       graph->bwInter = 0.1;
@@ -1372,37 +1434,42 @@ done:
 #define CHARS_PER_GPU_ENTRY 48
 
 ncclResult_t ncclTopoPrintGraph(struct ncclTopoSystem* system, struct ncclTopoGraph* graph) {
-  INFO(NCCL_GRAPH, "Pattern %d, crossNic %d, nChannels %d, bw %f/%f, type %s/%s, sameChannels %d", graph->pattern, graph->crossNic, graph->nChannels, graph->bwIntra, graph->bwInter, topoPathTypeStr[graph->typeIntra], topoPathTypeStr[graph->typeInter], graph->sameChannels);
+  INFO(NCCL_GRAPH, "Pattern %d, crossNic %d, nChannels %d, bw %f/%f, type %s/%s, sameChannels %d", graph->pattern,
+       graph->crossNic, graph->nChannels, graph->bwIntra, graph->bwInter, topoPathTypeStr[graph->typeIntra],
+       topoPathTypeStr[graph->typeInter], graph->sameChannels);
   int ngpus = system->nodes[GPU].count;
 
   char* line = (char*)malloc(ngpus * CHARS_PER_GPU_ENTRY);
-  for (int c=0; c<graph->nChannels; c++) {
+  for (int c = 0; c < graph->nChannels; c++) {
     sprintf(line, "%2d :", c);
     int offset = strlen(line);
     if (system->nodes[NET].count > 0 && system->nodes[GPU].count != system->nRanks && !graph->nIntraChannels) {
-      sprintf(line+offset, " %s/%lx-%lx", topoNodeTypeStr[NET], NCCL_TOPO_ID_SYSTEM_ID(graph->inter[2*c]), NCCL_TOPO_ID_LOCAL_ID(graph->inter[2*c]));
+      sprintf(line + offset, " %s/%lx-%lx", topoNodeTypeStr[NET], NCCL_TOPO_ID_SYSTEM_ID(graph->inter[2 * c]),
+              NCCL_TOPO_ID_LOCAL_ID(graph->inter[2 * c]));
       offset = strlen(line);
     }
-    for (int i=0; i<ngpus; i++) {
-      int n = graph->intraNets[(ngpus*c+i)*2]-'N';
-      if(n >= 0 && n < system->nodes[NET].count) {
-        sprintf(line+offset, " NET/%d", n);
+    for (int i = 0; i < ngpus; i++) {
+      int n = graph->intraNets[(ngpus * c + i) * 2] - 'N';
+      if (n >= 0 && n < system->nodes[NET].count) {
+        sprintf(line + offset, " NET/%d", n);
         offset = strlen(line);
       }
       int g;
       ncclTopoRankToIndex(system, graph->intra[ngpus * c + i], &g, true);
       int64_t topoId = system->nodes[GPU].nodes[g].id;
-      sprintf(line + offset, " %s/%lx-%lx", topoNodeTypeStr[GPU], NCCL_TOPO_ID_SYSTEM_ID(topoId), NCCL_TOPO_ID_LOCAL_ID(topoId));
+      sprintf(line + offset, " %s/%lx-%lx", topoNodeTypeStr[GPU], NCCL_TOPO_ID_SYSTEM_ID(topoId),
+              NCCL_TOPO_ID_LOCAL_ID(topoId));
       offset = strlen(line);
-      n = graph->intraNets[(ngpus*c+i)*2+1]-'N';
-      if(n >= 0 && n < system->nodes[NET].count) {
-        sprintf(line+offset, " NET/%d", n);
+      n = graph->intraNets[(ngpus * c + i) * 2 + 1] - 'N';
+      if (n >= 0 && n < system->nodes[NET].count) {
+        sprintf(line + offset, " NET/%d", n);
         offset = strlen(line);
       }
       if (graph->id == 3) break; // NVLS graphs only use the first GPU
     }
     if (system->nodes[NET].count > 0 && system->nodes[GPU].count != system->nRanks && !graph->nIntraChannels) {
-      sprintf(line+offset, " %s/%lx-%lx", topoNodeTypeStr[NET], NCCL_TOPO_ID_SYSTEM_ID(graph->inter[2*c+1]), NCCL_TOPO_ID_LOCAL_ID(graph->inter[2*c+1]));
+      sprintf(line + offset, " %s/%lx-%lx", topoNodeTypeStr[NET], NCCL_TOPO_ID_SYSTEM_ID(graph->inter[2 * c + 1]),
+              NCCL_TOPO_ID_LOCAL_ID(graph->inter[2 * c + 1]));
       offset = strlen(line);
     }
     INFO(NCCL_GRAPH, "%s", line);
@@ -1458,16 +1525,17 @@ fail:
 // 0: don't use PXN for P2P, 1: use PXN if needed, 2: use PXN as much as possible to maximize aggregation
 NCCL_PARAM(P2pPxnLevel, "P2P_PXN_LEVEL", 2);
 
-ncclResult_t ncclTopoGetNetDev(struct ncclComm* comm, int rank, struct ncclTopoGraph* graph, int channelId, int peerRank, int64_t* id, int* dev, int* proxyRank) {
+ncclResult_t ncclTopoGetNetDev(struct ncclComm* comm, int rank, struct ncclTopoGraph* graph, int channelId,
+                               int peerRank, int64_t* id, int* dev, int* proxyRank) {
   int64_t netId = -1;
   int netDev = -1;
   if (graph) {
     // Honor the net device in the graph
-    int channel = channelId%graph->nChannels;
+    int channel = channelId % graph->nChannels;
     int ngpus = comm->topo->nodes[GPU].count;
-    int index = graph->intra[channel*ngpus] == rank ? 0 : 1;
+    int index = graph->intra[channel * ngpus] == rank ? 0 : 1;
     if (graph->pattern != NCCL_TOPO_PATTERN_NVLS) {
-      netId = graph->inter[channel*2+index];
+      netId = graph->inter[channel * 2 + index];
     } else {
       NCCLCHECK(getNvlsNetDev(comm, graph, channelId, &netId));
     }
@@ -1490,7 +1558,8 @@ ncclResult_t ncclTopoGetNetDev(struct ncclComm* comm, int rank, struct ncclTopoG
       // Find local NIC number close to local nvmlDev
       int nvmlDev = comm->peerInfo[peerRank].nvmlDev;
       int localRank;
-      if (ncclTopoDevToRank(comm->topo, comm->topo->systemId, nvmlDev, /*warn=*/false, &localRank) != ncclSuccess) return ncclSuccess;
+      if (ncclTopoDevToRank(comm->topo, comm->topo->systemId, nvmlDev, /*warn=*/false, &localRank) != ncclSuccess)
+        return ncclSuccess;
       NCCLCHECK(ncclTopoGetLocalNet(comm->topo, localRank, channelId, &netId, &netDev));
 
       // Check that device exists on our node
@@ -1502,7 +1571,7 @@ ncclResult_t ncclTopoGetNetDev(struct ncclComm* comm, int rank, struct ncclTopoG
         int g, n;
         NCCLCHECK(ncclTopoRankToIndex(comm->topo, rank, &g, /*showWarn=*/true));
         NCCLCHECK(ncclTopoIdToIndex(comm->topo, NET, netId, &n));
-        struct ncclTopoNode* gpu = comm->topo->nodes[GPU].nodes+g;
+        struct ncclTopoNode* gpu = comm->topo->nodes[GPU].nodes + g;
         // No need to check for GDR here, PATH_PXN is only set if GDR is enabled between the peer GPU and the NET.
         if (gpu->paths[NET][n].type <= PATH_PXN) {
           if (dev) *dev = netDev;
@@ -1516,11 +1585,12 @@ ncclResult_t ncclTopoGetNetDev(struct ncclComm* comm, int rank, struct ncclTopoG
         NCCLCHECK(ncclTopoRankToIndex(comm->topo, rank, &g1, /*showWarn=*/true));
         NCCLCHECK(ncclTopoGetLocalGpu(comm->topo, netId, &g2));
         if (g2 != -1) {
-          struct ncclTopoNode* peerGpu = comm->topo->nodes[GPU].nodes+g2;
+          struct ncclTopoNode* peerGpu = comm->topo->nodes[GPU].nodes + g2;
           int pxnType = ncclParamPxnC2c() ? PATH_P2C : PATH_PXB;
           enum ncclTopoGdrMode gdrMode;
           NCCLCHECK(ncclTopoCheckGdr(comm->topo, peerGpu->gpu.rank, netId, 0, &gdrMode));
-          if (peerGpu->paths[GPU][g1].type <= PATH_NVL && peerGpu->paths[NET][n].type <= pxnType && (gdrMode != ncclTopoGdrModeDisable)) {
+          if (peerGpu->paths[GPU][g1].type <= PATH_NVL && peerGpu->paths[NET][n].type <= pxnType &&
+              (gdrMode != ncclTopoGdrModeDisable)) {
             *proxyRank = peerGpu->gpu.rank;
             if (dev) *dev = netDev;
             if (id) *id = netId;
@@ -1533,37 +1603,39 @@ ncclResult_t ncclTopoGetNetDev(struct ncclComm* comm, int rank, struct ncclTopoG
   return ncclSuccess;
 }
 
-ncclResult_t ncclTopoGetIntraNetDev(struct ncclTopoSystem* system, int rank, struct ncclTopoGraph* graph, int channelId, int type, int64_t* id, int* dev) {
+ncclResult_t ncclTopoGetIntraNetDev(struct ncclTopoSystem* system, int rank, struct ncclTopoGraph* graph, int channelId,
+                                    int type, int64_t* id, int* dev) {
   if (dev) *dev = -1;
-  if (id)  *id  = -1;
+  if (id) *id = -1;
   if (graph && graph->nIntraChannels) {
     int n1 = -1;
     int ngpus = system->nodes[GPU].count;
     int nnets = system->nodes[NET].count;
-    int chan = channelId%graph->nIntraChannels;
+    int chan = channelId % graph->nIntraChannels;
     for (int i = 0; i < ngpus; i++) {
-      if (graph->intra[ngpus*chan+i] == rank) {
-        n1 = graph->intraNets[(ngpus*chan+i)*2+type]-'N';
+      if (graph->intra[ngpus * chan + i] == rank) {
+        n1 = graph->intraNets[(ngpus * chan + i) * 2 + type] - 'N';
         break;
       }
     }
     if (n1 >= 0 && n1 < nnets) {
       if (dev) *dev = n1;
-      if (id)  *id  = NCCL_TOPO_ID(system->systemId, n1);
+      if (id) *id = NCCL_TOPO_ID(system->systemId, n1);
     }
   }
   return ncclSuccess;
 }
 
-ncclResult_t ncclTopoGetLinkType(struct ncclTopoSystem* system, int cudaDev1, int cudaDev2, bool* isXGMI, int maxInter, int nInter, int *inter) {
-  int interGpus[MAX_XGMI_INTER_GPUS+1];
+ncclResult_t ncclTopoGetLinkType(struct ncclTopoSystem* system, int cudaDev1, int cudaDev2, bool* isXGMI, int maxInter,
+                                 int nInter, int* inter) {
+  int interGpus[MAX_XGMI_INTER_GPUS + 1];
   int ngpus = system->nodes[GPU].count;
   *isXGMI = false;
   // check for direct XGMI connection
-  for (int i=0; i<ngpus; i++) {
+  for (int i = 0; i < ngpus; i++) {
     if (system->nodes[GPU].nodes[i].gpu.dev == cudaDev1) {
-      struct ncclTopoNode *node = system->nodes[GPU].nodes+i;
-      for (int k = 0; k<system->nodes[GPU].count; k++) {
+      struct ncclTopoNode* node = system->nodes[GPU].nodes + i;
+      for (int k = 0; k < system->nodes[GPU].count; k++) {
         if (system->nodes[GPU].nodes[k].gpu.dev == cudaDev2) {
           // NCCL 2.30 routes GPU->GPU through DEV nodes, so detect XGMI via path type (not a single hop).
           if (node->paths[GPU][k].count > 0 && node->paths[GPU][k].type == PATH_NVL) {
@@ -1580,30 +1652,30 @@ ncclResult_t ncclTopoGetLinkType(struct ncclTopoSystem* system, int cudaDev1, in
     // check if there are intermediate GPUs that are connected to both
     bool res1, res2, res3;
     int j;
-    for (j=0; j<nInter; j++) {
-      ncclTopoGetLinkType(system, inter[j], inter[j+1], &res1, 0);
+    for (j = 0; j < nInter; j++) {
+      ncclTopoGetLinkType(system, inter[j], inter[j + 1], &res1, 0);
       if (!res1) break;
     }
-    if (j<nInter) return ncclSuccess;
+    if (j < nInter) return ncclSuccess;
     if (nInter > 0 && inter != nullptr) {
       ncclTopoGetLinkType(system, inter[nInter], cudaDev2, &res2, 0);
       if (res2) {
         *isXGMI = true;
         return ncclSuccess;
       }
-      memcpy(interGpus+1, inter+1, sizeof(int)*nInter);
+      memcpy(interGpus + 1, inter + 1, sizeof(int) * nInter);
     }
     interGpus[0] = cudaDev1;
     // add one more intermediate GPU recursively util reaching max depth
     nInter++;
-    if (nInter+2 > ngpus || nInter > MAX_XGMI_INTER_GPUS || nInter > maxInter) return ncclSuccess;
-    for (int i=0; i<ngpus; i++) {
+    if (nInter + 2 > ngpus || nInter > MAX_XGMI_INTER_GPUS || nInter > maxInter) return ncclSuccess;
+    for (int i = 0; i < ngpus; i++) {
       int dev = system->nodes[GPU].nodes[i].gpu.dev;
       // skip duplicated GPU
       if (dev == cudaDev2) continue;
-      for (j=0; j<nInter; j++)
+      for (j = 0; j < nInter; j++)
         if (dev == interGpus[j]) break;
-      if (j<nInter) continue;
+      if (j < nInter) continue;
       // check connectivity with intermediate GPUs
       interGpus[nInter] = dev;
       ncclTopoGetLinkType(system, cudaDev1, cudaDev2, &res3, maxInter, nInter, interGpus);

--- a/projects/rccl/src/graph/topo.cc
+++ b/projects/rccl/src/graph/topo.cc
@@ -28,13 +28,13 @@
 #define BUSID_SIZE (sizeof("0000:00:00.0"))
 #define BUSID_REDUCED_SIZE (sizeof("0000:00"))
 
-const char* topoNodeTypeStr[] = { "GPU", "PCI", "NVS", "CPU", "NIC", "NET", "GIN", "DEV" };
+const char* topoNodeTypeStr[] = {"GPU", "PCI", "NVS", "CPU", "NIC", "NET", "GIN", "DEV"};
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-const char* topoLinkTypeStr[] = { "LOC", "XGMI", "",    "C2C", "PCI",    "",    "",    "",    "", "SYS", "NET" };
-const char* topoPathTypeStr[] = { "LOC", "XGMI", "NVB", "C2C", "PIX", "PXB", "P2C", "PXN", "PHB", "SYS", "NET", "DIS" };
+const char* topoLinkTypeStr[] = {"LOC", "XGMI", "", "C2C", "PCI", "", "", "", "", "SYS", "NET"};
+const char* topoPathTypeStr[] = {"LOC", "XGMI", "NVB", "C2C", "PIX", "PXB", "P2C", "PXN", "PHB", "SYS", "NET", "DIS"};
 #else
-const char* topoLinkTypeStr[] = { "LOC", "NVL", "",    "C2C", "PCI",    "",    "",    "",    "", "SYS", "NET" };
-const char* topoPathTypeStr[] = { "LOC", "NVL", "NVB", "C2C", "PIX", "PXB", "P2C", "PXN", "PHB", "SYS", "NET", "DIS" };
+const char* topoLinkTypeStr[] = {"LOC", "NVL", "", "C2C", "PCI", "", "", "", "", "SYS", "NET"};
+const char* topoPathTypeStr[] = {"LOC", "NVL", "NVB", "C2C", "PIX", "PXB", "P2C", "PXN", "PHB", "SYS", "NET", "DIS"};
 #endif
 
 /******************************************************************/
@@ -47,12 +47,10 @@ static ncclResult_t findLocalCpu(struct ncclTopoNode* node, struct ncclTopoNode*
     *cpu = node;
     return ncclSuccess;
   }
-  for (int l=0; l<node->nlinks; l++) {
+  for (int l = 0; l < node->nlinks; l++) {
     // Go up the PCI tree to find the CPU. Follow only PCI switches.
-    if (node->links[l].type == LINK_PCI
-	&& node->links[l].remNode != from
-	&& (node->links[l].remNode->type == PCI
-	    || node->links[l].remNode->type == CPU)) {
+    if (node->links[l].type == LINK_PCI && node->links[l].remNode != from &&
+        (node->links[l].remNode->type == PCI || node->links[l].remNode->type == CPU)) {
       NCCLCHECK(findLocalCpu(node->links[l].remNode, cpu, node));
     }
     if (*cpu != NULL) return ncclSuccess;
@@ -74,17 +72,16 @@ static ncclResult_t ncclTopoGetInterCpuBw(struct ncclTopoNode* cpu, float* bw) {
     return ncclSuccess;
   }
   if (cpu->cpu.arch == NCCL_TOPO_CPU_ARCH_X86 && cpu->cpu.vendor == NCCL_TOPO_CPU_VENDOR_INTEL) {
-    *bw =
-      cpu->cpu.model == NCCL_TOPO_CPU_MODEL_INTEL_ERP ? ERP_QPI_BW :
-      cpu->cpu.model == NCCL_TOPO_CPU_MODEL_INTEL_SRP ? SRP_QPI_BW :
-      cpu->cpu.model == NCCL_TOPO_CPU_MODEL_INTEL_SKL ? SKL_QPI_BW :
-      BDW_QPI_BW;
+    *bw = cpu->cpu.model == NCCL_TOPO_CPU_MODEL_INTEL_ERP ? ERP_QPI_BW :
+          cpu->cpu.model == NCCL_TOPO_CPU_MODEL_INTEL_SRP ? SRP_QPI_BW :
+          cpu->cpu.model == NCCL_TOPO_CPU_MODEL_INTEL_SKL ? SKL_QPI_BW :
+                                                            BDW_QPI_BW;
   }
   if (cpu->cpu.arch == NCCL_TOPO_CPU_ARCH_X86 && cpu->cpu.vendor == NCCL_TOPO_CPU_VENDOR_AMD) {
     *bw = AMD_BW;
   }
   if (cpu->cpu.arch == NCCL_TOPO_CPU_ARCH_X86 && cpu->cpu.vendor == NCCL_TOPO_CPU_VENDOR_ZHAOXIN) {
-    *bw = cpu->cpu.model ==  NCCL_TOPO_CPU_MODEL_YONGFENG ? YONGFENG_ZPI_BW : ZPI_BW;
+    *bw = cpu->cpu.model == NCCL_TOPO_CPU_MODEL_YONGFENG ? YONGFENG_ZPI_BW : ZPI_BW;
   }
   return ncclSuccess;
 }
@@ -97,9 +94,9 @@ enum ncclNvLinkDeviceType {
 };
 
 ncclResult_t ncclTopoGetNode(struct ncclTopoSystem* system, struct ncclTopoNode** node, int type, uint64_t id) {
-  for (int i=0; i<system->nodes[type].count; i++) {
+  for (int i = 0; i < system->nodes[type].count; i++) {
     if (system->nodes[type].nodes[i].id == id) {
-      *node = system->nodes[type].nodes+i;
+      *node = system->nodes[type].nodes + i;
       return ncclSuccess;
     }
   }
@@ -111,7 +108,7 @@ ncclResult_t ncclTopoCreateNode(struct ncclTopoSystem* system, struct ncclTopoNo
     WARN("Error : tried to create too many nodes of type %d", type);
     return ncclInternalError;
   }
-  struct ncclTopoNode* n = system->nodes[type].nodes+system->nodes[type].count;
+  struct ncclTopoNode* n = system->nodes[type].nodes + system->nodes[type].count;
   system->nodes[type].count++;
   n->type = type;
   n->id = id;
@@ -137,26 +134,26 @@ ncclResult_t ncclTopoCreateNode(struct ncclTopoSystem* system, struct ncclTopoNo
 }
 
 ncclResult_t ncclTopoRemoveNode(struct ncclTopoSystem* system, int type, int index) {
-  struct ncclTopoNode* delNode = system->nodes[type].nodes+index;
-  for (int t=0; t<NCCL_TOPO_NODE_TYPES; t++) {
+  struct ncclTopoNode* delNode = system->nodes[type].nodes + index;
+  for (int t = 0; t < NCCL_TOPO_NODE_TYPES; t++) {
     free(delNode->paths[t]);
-    for (int n=0; n<system->nodes[t].count; n++) {
-      struct ncclTopoNode* node = system->nodes[t].nodes+n;
+    for (int n = 0; n < system->nodes[t].count; n++) {
+      struct ncclTopoNode* node = system->nodes[t].nodes + n;
       if (node == delNode) continue;
-      for (int l=0; l<node->nlinks; l++) {
-        while (l<node->nlinks && node->links[l].remNode == delNode) {
-          memmove(node->links+l, node->links+l+1, (node->nlinks-l-1)*sizeof(struct ncclTopoLink));
+      for (int l = 0; l < node->nlinks; l++) {
+        while (l < node->nlinks && node->links[l].remNode == delNode) {
+          memmove(node->links + l, node->links + l + 1, (node->nlinks - l - 1) * sizeof(struct ncclTopoLink));
           node->nlinks--;
         }
-        if (l<node->nlinks && node->links[l].remNode->type == type && node->links[l].remNode >= delNode) {
+        if (l < node->nlinks && node->links[l].remNode->type == type && node->links[l].remNode >= delNode) {
           node->links[l].remNode--;
         }
       }
     }
   }
   if (type == DEV) {
-    for (int n=0; n<system->nodes[GPU].count; n++) {
-      struct ncclTopoNode* gpu = system->nodes[GPU].nodes+n;
+    for (int n = 0; n < system->nodes[GPU].count; n++) {
+      struct ncclTopoNode* gpu = system->nodes[GPU].nodes + n;
       if (gpu->gpu.parent == delNode) {
         gpu->gpu.parent = NULL;
       } else if (gpu->gpu.parent > delNode) {
@@ -164,7 +161,7 @@ ncclResult_t ncclTopoRemoveNode(struct ncclTopoSystem* system, int type, int ind
       }
     }
   }
-  memmove(delNode, delNode+1, (system->nodes[type].count-index-1)*sizeof(struct ncclTopoNode));
+  memmove(delNode, delNode + 1, (system->nodes[type].count - index - 1) * sizeof(struct ncclTopoNode));
   system->nodes[type].count--;
   return ncclSuccess;
 }
@@ -188,8 +185,8 @@ ncclResult_t ncclTopoConnectNodes(struct ncclTopoNode* node, struct ncclTopoNode
   struct ncclTopoLink linkSave;
   memcpy(&linkSave, link, sizeof(struct ncclTopoLink));
   while (link != node->links) {
-    if ((link-1)->bw >= linkSave.bw) break;
-    memcpy(link, link-1, sizeof(struct ncclTopoLink));
+    if ((link - 1)->bw >= linkSave.bw) break;
+    memcpy(link, link - 1, sizeof(struct ncclTopoLink));
     link--;
   }
   memcpy(link, &linkSave, sizeof(struct ncclTopoLink));
@@ -202,13 +199,13 @@ ncclResult_t ncclTopoConnectNodes(struct ncclTopoNode* node, struct ncclTopoNode
 // NCCL take wrong topology decisions.
 int getBcmGen(uint64_t id, int level) {
   if ((id & 0xfffffffffffff000) == 0x1000c0101000a000) return 4;
-  if ((id & 0xfffffffffffff000) == (0x1000c03010000000 | level*0x1000)) return 5;
+  if ((id & 0xfffffffffffff000) == (0x1000c03010000000 | level * 0x1000)) return 5;
   return 0;
 }
 ncclResult_t ncclTopoFlattenBcmSwitches(struct ncclTopoSystem* system) {
   ncclResult_t ret = ncclSuccess;
-  for (int s=0; s<system->nodes[PCI].count; s++) {
-    struct ncclTopoNode* pciSwitch = system->nodes[PCI].nodes+s;
+  for (int s = 0; s < system->nodes[PCI].count; s++) {
+    struct ncclTopoNode* pciSwitch = system->nodes[PCI].nodes + s;
     int gen = getBcmGen(pciSwitch->pci.device, 0);
     // Flatten Gen4 PEX switches in base mode
     if (gen) {
@@ -216,26 +213,27 @@ ncclResult_t ncclTopoFlattenBcmSwitches(struct ncclTopoSystem* system) {
       int64_t* subSwIds;
       NCCLCHECK(ncclCalloc(&subSwIds, pciSwitch->nlinks));
       int subs = 0;
-      for (int l=0; l<pciSwitch->nlinks; l++) {
+      for (int l = 0; l < pciSwitch->nlinks; l++) {
         struct ncclTopoNode* sub = pciSwitch->links[l].remNode;
         // Only fuse sub switches with the same device ID.
         if (sub->type != PCI || getBcmGen(sub->pci.device, 1) != gen) continue;
         // Save sub switch for later
         subSwIds[subs++] = sub->id;
         // Remove link to that sub switch
-        memmove(pciSwitch->links+l, pciSwitch->links+l+1, (pciSwitch->nlinks-l-1)*(sizeof(struct ncclTopoLink)));
+        memmove(pciSwitch->links + l, pciSwitch->links + l + 1,
+                (pciSwitch->nlinks - l - 1) * (sizeof(struct ncclTopoLink)));
         pciSwitch->nlinks--;
         // Don't increase l for the next iteration as we just shifted all links by one.
         l--;
       }
 
-      for (int s=0; s<subs; s++) {
+      for (int s = 0; s < subs; s++) {
         // Find sub switch (system->nodes[PCI].nodes is changing every time we remove a node)
         int index;
         NCCLCHECKGOTO(ncclTopoIdToIndex(system, PCI, subSwIds[s], &index), ret, fail);
-        struct ncclTopoNode* sub = system->nodes[PCI].nodes+index;
+        struct ncclTopoNode* sub = system->nodes[PCI].nodes + index;
         // Connect all sub PCI devices to the parent switch
-        for (int l=0; l<sub->nlinks; l++) {
+        for (int l = 0; l < sub->nlinks; l++) {
           struct ncclTopoNode* remNode = sub->links[l].remNode;
           if (remNode == pciSwitch) continue;
           // Add link from parent PCI switch -> PCI device
@@ -244,10 +242,10 @@ ncclResult_t ncclTopoFlattenBcmSwitches(struct ncclTopoSystem* system) {
             ret = ncclInternalError;
             goto fail;
           }
-          memcpy(pciSwitch->links+pciSwitch->nlinks, sub->links+l, sizeof(struct ncclTopoLink));
+          memcpy(pciSwitch->links + pciSwitch->nlinks, sub->links + l, sizeof(struct ncclTopoLink));
           pciSwitch->nlinks++;
           // Update link from PCI device -> parent PCI switch
-          for (int rl=0; rl<remNode->nlinks; rl++) {
+          for (int rl = 0; rl < remNode->nlinks; rl++) {
             if (remNode->links[rl].remNode == sub) {
               remNode->links[rl].remNode = pciSwitch;
               break;
@@ -262,7 +260,7 @@ ncclResult_t ncclTopoFlattenBcmSwitches(struct ncclTopoSystem* system) {
       // Restart, as system->nodes[PCI].nodes has changed.
       s = -1;  // Will be incremented to 0 in the next loop iteration
       continue;
-fail:
+    fail:
       free(subSwIds);
       return ret;
     }
@@ -272,10 +270,10 @@ fail:
 
 ncclResult_t ncclTopoConnectCpus(struct ncclTopoSystem* system) {
   // And connect all CPU nodes together
-  for (int n=0; n<system->nodes[CPU].count; n++) {
-    struct ncclTopoNode* cpu1 = system->nodes[CPU].nodes+n;
-    for (int p=0; p<system->nodes[CPU].count; p++) {
-      struct ncclTopoNode* cpu2 = system->nodes[CPU].nodes+p;
+  for (int n = 0; n < system->nodes[CPU].count; n++) {
+    struct ncclTopoNode* cpu1 = system->nodes[CPU].nodes + n;
+    for (int p = 0; p < system->nodes[CPU].count; p++) {
+      struct ncclTopoNode* cpu2 = system->nodes[CPU].nodes + p;
       if (n == p || (NCCL_TOPO_ID_SYSTEM_ID(cpu1->id) != NCCL_TOPO_ID_SYSTEM_ID(cpu2->id))) continue;
       float bw;
       NCCLCHECK(ncclTopoGetInterCpuBw(cpu1, &bw));
@@ -287,34 +285,45 @@ ncclResult_t ncclTopoConnectCpus(struct ncclTopoSystem* system) {
 
 static ncclResult_t ncclTopoPrintRec(struct ncclTopoNode* node, struct ncclTopoNode* prevNode, char* line, int offset) {
   if (node->type == GPU) {
-    sprintf(line+offset, "%s/%lx-%lx (%d)", topoNodeTypeStr[node->type], NCCL_TOPO_ID_SYSTEM_ID(node->id), NCCL_TOPO_ID_LOCAL_ID(node->id), node->gpu.rank);
+    sprintf(line + offset, "%s/%lx-%lx (%d)", topoNodeTypeStr[node->type], NCCL_TOPO_ID_SYSTEM_ID(node->id),
+            NCCL_TOPO_ID_LOCAL_ID(node->id), node->gpu.rank);
   } else if (node->type == CPU) {
-    sprintf(line+offset, "%s/%lx-%lx (%d/%d/%d)", topoNodeTypeStr[node->type], NCCL_TOPO_ID_SYSTEM_ID(node->id), NCCL_TOPO_ID_LOCAL_ID(node->id), node->cpu.arch, node->cpu.vendor, node->cpu.model);
+    sprintf(line + offset, "%s/%lx-%lx (%d/%d/%d)", topoNodeTypeStr[node->type], NCCL_TOPO_ID_SYSTEM_ID(node->id),
+            NCCL_TOPO_ID_LOCAL_ID(node->id), node->cpu.arch, node->cpu.vendor, node->cpu.model);
   } else if (node->type == PCI) {
-    sprintf(line+offset, "%s/%lx-%lx (%lx)", topoNodeTypeStr[node->type], NCCL_TOPO_ID_SYSTEM_ID(node->id), NCCL_TOPO_ID_LOCAL_ID(node->id), node->pci.device);
+    sprintf(line + offset, "%s/%lx-%lx (%lx)", topoNodeTypeStr[node->type], NCCL_TOPO_ID_SYSTEM_ID(node->id),
+            NCCL_TOPO_ID_LOCAL_ID(node->id), node->pci.device);
   } else if (node->type == DEV) {
-    sprintf(line+offset, "%s/%lx-%lx (%lx)", topoNodeTypeStr[node->type], NCCL_TOPO_ID_SYSTEM_ID(node->id), NCCL_TOPO_ID_LOCAL_ID(node->id), node->dev.device);
+    sprintf(line + offset, "%s/%lx-%lx (%lx)", topoNodeTypeStr[node->type], NCCL_TOPO_ID_SYSTEM_ID(node->id),
+            NCCL_TOPO_ID_LOCAL_ID(node->id), node->dev.device);
   } else {
-    sprintf(line+offset, "%s/%lx-%lx", topoNodeTypeStr[node->type], NCCL_TOPO_ID_SYSTEM_ID(node->id), NCCL_TOPO_ID_LOCAL_ID(node->id));
+    sprintf(line + offset, "%s/%lx-%lx", topoNodeTypeStr[node->type], NCCL_TOPO_ID_SYSTEM_ID(node->id),
+            NCCL_TOPO_ID_LOCAL_ID(node->id));
   }
   INFO(NCCL_GRAPH, "%s", line);
-  for (int i=0; i<offset; i++) line[i] = ' ';
+  for (int i = 0; i < offset; i++) line[i] = ' ';
 
-  for (int l=0; l<node->nlinks; l++) {
-    struct ncclTopoLink* link = node->links+l;
+  for (int l = 0; l < node->nlinks; l++) {
+    struct ncclTopoLink* link = node->links + l;
     if (link->type == LINK_LOC) {
-      sprintf(line+offset, "+ %s[%2.1f] - %s/%lx-%lx", topoLinkTypeStr[link->type], link->bw, topoNodeTypeStr[link->remNode->type], NCCL_TOPO_ID_SYSTEM_ID(link->remNode->id), NCCL_TOPO_ID_LOCAL_ID(link->remNode->id));
+      sprintf(line + offset, "+ %s[%2.1f] - %s/%lx-%lx", topoLinkTypeStr[link->type], link->bw,
+              topoNodeTypeStr[link->remNode->type], NCCL_TOPO_ID_SYSTEM_ID(link->remNode->id),
+              NCCL_TOPO_ID_LOCAL_ID(link->remNode->id));
       INFO(NCCL_GRAPH, "%s", line);
     } else if (link->type != LINK_PCI || link->remNode != prevNode) {
-      sprintf(line+offset, "+ %s[%2.1f] - ", topoLinkTypeStr[link->type], link->bw);
+      sprintf(line + offset, "+ %s[%2.1f] - ", topoLinkTypeStr[link->type], link->bw);
       int nextOffset = strlen(line);
       if (link->type == LINK_PCI) {
         NCCLCHECK(ncclTopoPrintRec(link->remNode, node, line, nextOffset));
       } else {
         if (link->remNode->type == NET) {
-          sprintf(line+nextOffset, "%s/%lx-%lx (%d/%lx/%d/%f)", topoNodeTypeStr[link->remNode->type], NCCL_TOPO_ID_SYSTEM_ID(link->remNode->id), NCCL_TOPO_ID_LOCAL_ID(link->remNode->id), link->remNode->net.collSupport, link->remNode->net.asic, link->remNode->net.port, link->remNode->net.bw);
+          sprintf(line + nextOffset, "%s/%lx-%lx (%d/%lx/%d/%f)", topoNodeTypeStr[link->remNode->type],
+                  NCCL_TOPO_ID_SYSTEM_ID(link->remNode->id), NCCL_TOPO_ID_LOCAL_ID(link->remNode->id),
+                  link->remNode->net.collSupport, link->remNode->net.asic, link->remNode->net.port,
+                  link->remNode->net.bw);
         } else {
-          sprintf(line+nextOffset, "%s/%lx-%lx", topoNodeTypeStr[link->remNode->type], NCCL_TOPO_ID_SYSTEM_ID(link->remNode->id), NCCL_TOPO_ID_LOCAL_ID(link->remNode->id));
+          sprintf(line + nextOffset, "%s/%lx-%lx", topoNodeTypeStr[link->remNode->type],
+                  NCCL_TOPO_ID_SYSTEM_ID(link->remNode->id), NCCL_TOPO_ID_LOCAL_ID(link->remNode->id));
         }
         INFO(NCCL_GRAPH, "%s", line);
       }
@@ -326,7 +335,7 @@ static ncclResult_t ncclTopoPrintRec(struct ncclTopoNode* node, struct ncclTopoN
 ncclResult_t ncclTopoPrint(struct ncclTopoSystem* s) {
   INFO(NCCL_GRAPH, "=== System : maxBw %2.1f totalBw %2.1f ===", s->maxBw, s->totalBw);
   char line[2048];
-  for (int n=0; n<s->nodes[CPU].count; n++) NCCLCHECK(ncclTopoPrintRec(s->nodes[CPU].nodes+n, NULL, line, 0));
+  for (int n = 0; n < s->nodes[CPU].count; n++) NCCLCHECK(ncclTopoPrintRec(s->nodes[CPU].nodes + n, NULL, line, 0));
   INFO(NCCL_GRAPH, "==========================================");
   NCCLCHECK(ncclTopoPrintPaths(s));
   return ncclSuccess;
@@ -335,20 +344,20 @@ ncclResult_t ncclTopoPrint(struct ncclTopoSystem* s) {
 static ncclResult_t ncclTopoSort(struct ncclTopoNode* node, struct ncclTopoNode* upNode) {
   // Shift all links to have upLink as last link
   if (upNode) {
-    int l=0;
+    int l = 0;
     while (node->links[l].remNode != upNode) l++;
     struct ncclTopoLink upLink;
-    memcpy(&upLink, node->links+l, sizeof(struct ncclTopoLink));
-    while (node->links[l+1].remNode) {
-      memcpy(node->links+l, node->links+l+1, sizeof(struct ncclTopoLink));
+    memcpy(&upLink, node->links + l, sizeof(struct ncclTopoLink));
+    while (node->links[l + 1].remNode) {
+      memcpy(node->links + l, node->links + l + 1, sizeof(struct ncclTopoLink));
       l++;
     }
-    memcpy(node->links+l, &upLink, sizeof(struct ncclTopoLink));
+    memcpy(node->links + l, &upLink, sizeof(struct ncclTopoLink));
   }
 
   // Recursively sort the PCI tree
-  for (int l=0; l<node->nlinks; l++) {
-    struct ncclTopoLink* link = node->links+l;
+  for (int l = 0; l < node->nlinks; l++) {
+    struct ncclTopoLink* link = node->links + l;
     if (link->type == LINK_PCI && link->remNode != upNode) NCCLCHECK(ncclTopoSort(link->remNode, node));
   }
   return ncclSuccess;
@@ -360,16 +369,16 @@ static ncclResult_t ncclTopoSort(struct ncclTopoNode* node, struct ncclTopoNode*
 // 3. PCI up
 // 4. SYS (already the case)
 ncclResult_t ncclTopoSortSystem(struct ncclTopoSystem* system) {
-  for (int n=0; n<system->nodes[CPU].count; n++) NCCLCHECK(ncclTopoSort(system->nodes[CPU].nodes+n, NULL));
+  for (int n = 0; n < system->nodes[CPU].count; n++) NCCLCHECK(ncclTopoSort(system->nodes[CPU].nodes + n, NULL));
   return ncclSuccess;
 }
 
 // Minimum network BW of a single device accessible by rank.
 // Note: This function does not sum up the bw over multiple NICs if many are accessible.
 ncclResult_t ncclTopoGetMinNetBw(struct ncclTopoSystem* system, int rank, float* bw) {
-  int g=0;
-  while(g < system->nodes[GPU].count && system->nodes[GPU].nodes[g].gpu.rank != rank) g++;
-  if(g == system->nodes[GPU].count) return ncclInternalError;
+  int g = 0;
+  while (g < system->nodes[GPU].count && system->nodes[GPU].nodes[g].gpu.rank != rank) g++;
+  if (g == system->nodes[GPU].count) return ncclInternalError;
 
   // GPUs with no reachable NET node have a minimum net bw of 0.
   int localNets[NCCL_TOPO_MAX_NODES];
@@ -390,14 +399,15 @@ ncclResult_t ncclTopoGetMinNetBw(struct ncclTopoSystem* system, int rank, float*
     if (c == 0) firstNetId = netId;
     else if (netId == firstNetId) break;
 
-    minBw = std::min(minBw , system->nodes[GPU].nodes[g].paths[NET][net].bw);
+    minBw = std::min(minBw, system->nodes[GPU].nodes[g].paths[NET][net].bw);
   }
   // if no net is found, return 0 as a minimum bw
   *bw = (minBw < FLT_MAX) ? minBw : 0.0;
   return ncclSuccess;
 }
 
-ncclResult_t ncclTopoAddNet(struct ncclXmlNode* xmlNet, struct ncclTopoSystem* system, struct ncclTopoNode* nic, int systemId, int64_t busId) {
+ncclResult_t ncclTopoAddNet(struct ncclXmlNode* xmlNet, struct ncclTopoSystem* system, struct ncclTopoNode* nic,
+                            int systemId, int64_t busId) {
   int dev;
   NCCLCHECK(xmlGetAttrInt(xmlNet, "dev", &dev));
 
@@ -409,7 +419,6 @@ ncclResult_t ncclTopoAddNet(struct ncclXmlNode* xmlNet, struct ncclTopoSystem* s
   // if not guid is present use the net->id unique id instead, which will be unique within the node/NVLD
   NCCLCHECK(xmlGetAttr(xmlNet, "guid", &str));
   net->net.asic = (str) ? strtoull(str, NULL, 16) : netId;
-
 
   int mbps;
   NCCLCHECKNOWARN(xmlGetAttrIntDefault(xmlNet, "speed", &mbps, 0), NCCL_GRAPH);
@@ -444,7 +453,8 @@ ncclResult_t ncclTopoAddNet(struct ncclXmlNode* xmlNet, struct ncclTopoSystem* s
 // from the NET plugin: GIN devices live in system->nodes[GIN] (parallel to
 // system->nodes[NET]) and are looked up by ncclTopoGetLocalGinDev for
 // device-API kernels (-D 3 / -D 4 in rccl-tests).
-ncclResult_t ncclTopoAddGin(struct ncclXmlNode* xmlNet, struct ncclTopoSystem* system, struct ncclTopoNode* nic, int systemId) {
+ncclResult_t ncclTopoAddGin(struct ncclXmlNode* xmlNet, struct ncclTopoSystem* system, struct ncclTopoNode* nic,
+                            int systemId) {
   int dev;
   NCCLCHECK(xmlGetAttrInt(xmlNet, "dev", &dev));
 
@@ -463,8 +473,9 @@ ncclResult_t ncclTopoAddGin(struct ncclXmlNode* xmlNet, struct ncclTopoSystem* s
   return ncclSuccess;
 }
 
-ncclResult_t ncclTopoAddNic(struct ncclXmlNode* xmlNic, struct ncclTopoSystem* system, struct ncclTopoNode* nic, int systemId, int64_t busId) {
-  for (int s=0; s<xmlNic->nSubs; s++) {
+ncclResult_t ncclTopoAddNic(struct ncclXmlNode* xmlNic, struct ncclTopoSystem* system, struct ncclTopoNode* nic,
+                            int systemId, int64_t busId) {
+  for (int s = 0; s < xmlNic->nSubs; s++) {
     struct ncclXmlNode* xmlNet = xmlNic->subs[s];
     if (strcmp(xmlNet->name, "net") != 0) continue;
     int index;
@@ -495,8 +506,8 @@ ncclResult_t ncclTopoAddGpu(struct ncclXmlNode* xmlGpu, struct ncclTopoSystem* s
   const char* gcnArchName;
   NCCLCHECK(xmlGetAttr(xmlGpu, "gcn", &gcnArch));
   convertGcnArchToGcnArchName(gcnArch, &gcnArchName);
-  strncpy(gpu->gpu.gcn, gcnArchName, GCN_ARCH_NAME_LEN-1);
-  gpu->gpu.gcn[GCN_ARCH_NAME_LEN-1] = '\0';
+  strncpy(gpu->gpu.gcn, gcnArchName, GCN_ARCH_NAME_LEN - 1);
+  gpu->gpu.gcn[GCN_ARCH_NAME_LEN - 1] = '\0';
   rcclHipDeviceArch_t arch;
   NCCLCHECK(xmlGetAttrInt(xmlGpu, "arch", &arch.value));
   memcpy(&gpu->gpu.arch, &arch.arch, sizeof(hipDeviceArch_t));
@@ -525,12 +536,27 @@ static ncclResult_t ncclTopoGetIntDevice(struct ncclXmlNode* xmlPci, uint64_t* d
 #define PCI_BRIDGE_DEVICE_CLASS "0x060400"
 
 // struct kvDict kvDictPciClass[] = { { PCI_BRIDGE_DEVICE_CLASS, PCI }, {"0x080100", /*CX8 data direct*/PCI}, { "0x068000", NVS }, { "0x068001", CPU }, { "0x03", GPU }, { "0x02", NIC }, { NULL, PCI /* Default fallback value */ } };
-struct kvDict kvDictPciClass[] = { { PCI_BRIDGE_DEVICE_CLASS, PCI }, { "0x068000", NVS }, { "0x068001", CPU }, { "0x03", GPU }, { "0x02", NIC }, { "0x120000", GPU }, { NULL, PCI /* Default fallback value */ } };
-struct kvDict kvDictPciGen[] = {
-  { "2.5 GT/s", 15 }, { "5 GT/s", 30 }, { "8 GT/s", 60 }, { "16 GT/s", 120 }, { "32 GT/s", 240 }, /* Kernel 5.6 and earlier */
-  { "2.5 GT/s PCIe", 15 }, { "5.0 GT/s PCIe", 30 }, { "8.0 GT/s PCIe", 60 }, { "16.0 GT/s PCIe", 120 }, { "32.0 GT/s PCIe", 240 }, { "64.0 GT/s PCIe", 480 },
-  { NULL, 60 /* Default fallback */ } }; // x100 Mbps per lane
-ncclResult_t ncclTopoAddPci(struct ncclXmlNode* xmlPci, struct ncclTopoSystem* system, struct ncclTopoNode* parent, int systemId, int numaId) {
+struct kvDict kvDictPciClass[] = {{PCI_BRIDGE_DEVICE_CLASS, PCI},
+                                  {"0x068000", NVS},
+                                  {"0x068001", CPU},
+                                  {"0x03", GPU},
+                                  {"0x02", NIC},
+                                  {"0x120000", GPU},
+                                  {NULL, PCI /* Default fallback value */}};
+struct kvDict kvDictPciGen[] = {{"2.5 GT/s", 15},
+                                {"5 GT/s", 30},
+                                {"8 GT/s", 60},
+                                {"16 GT/s", 120},
+                                {"32 GT/s", 240}, /* Kernel 5.6 and earlier */
+                                {"2.5 GT/s PCIe", 15},
+                                {"5.0 GT/s PCIe", 30},
+                                {"8.0 GT/s PCIe", 60},
+                                {"16.0 GT/s PCIe", 120},
+                                {"32.0 GT/s PCIe", 240},
+                                {"64.0 GT/s PCIe", 480},
+                                {NULL, 60 /* Default fallback */}}; // x100 Mbps per lane
+ncclResult_t ncclTopoAddPci(struct ncclXmlNode* xmlPci, struct ncclTopoSystem* system, struct ncclTopoNode* parent,
+                            int systemId, int numaId) {
   const char* str;
 
   int type;
@@ -573,7 +599,8 @@ ncclResult_t ncclTopoAddPci(struct ncclXmlNode* xmlPci, struct ncclTopoSystem* s
       }
     }
 
-    NCCLCHECK(ncclTopoCreateNode(system, &node, GPU, NCCL_TOPO_ID(systemId, NCCL_TOPO_GPU_LOCAL_ID(busId, localRankOnDev))));
+    NCCLCHECK(ncclTopoCreateNode(system, &node, GPU,
+                                 NCCL_TOPO_ID(systemId, NCCL_TOPO_GPU_LOCAL_ID(busId, localRankOnDev))));
     NCCLCHECK(ncclTopoAddGpu(xmlGpu, system, node));
     node->gpu.parent = gpudeviceNode;
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
@@ -606,7 +633,7 @@ ncclResult_t ncclTopoAddPci(struct ncclXmlNode* xmlPci, struct ncclTopoSystem* s
     NCCLCHECK(ncclTopoCreateNode(system, &node, type, NCCL_TOPO_ID(systemId, busId)));
     NCCLCHECK(ncclTopoGetIntDevice(xmlPci, &node->pci.device));
 
-    for (int s=0; s<xmlPci->nSubs; s++) {
+    for (int s = 0; s < xmlPci->nSubs; s++) {
       struct ncclXmlNode* xmlSubPci = xmlPci->subs[s];
       if (strcmp(xmlSubPci->name, "pcilink") != 0) { // PCI links will be added later
         NCCLCHECK(ncclTopoAddPci(xmlSubPci, system, node, systemId, numaId));
@@ -623,26 +650,32 @@ ncclResult_t ncclTopoAddPci(struct ncclXmlNode* xmlPci, struct ncclTopoSystem* s
     if (width == 0) width = 16;
     NCCLCHECK(kvConvertToInt(str, &speed, kvDictPciGen)); // Values in 100Mbps, per lane (we want GB/s in the end)
 
-    NCCLCHECK(ncclTopoConnectNodes(node, parent, LINK_PCI, width*speed/80.0));
-    NCCLCHECK(ncclTopoConnectNodes(parent, node, LINK_PCI, width*speed/80.0));
+    NCCLCHECK(ncclTopoConnectNodes(node, parent, LINK_PCI, width * speed / 80.0));
+    NCCLCHECK(ncclTopoConnectNodes(parent, node, LINK_PCI, width * speed / 80.0));
   }
   return ncclSuccess;
 }
 
-struct kvDict kvDictCpuArch[] = { { "x86_64", NCCL_TOPO_CPU_ARCH_X86 }, { "arm64", NCCL_TOPO_CPU_ARCH_ARM }, { "ppc64", NCCL_TOPO_CPU_ARCH_POWER }, { NULL, 0 } };
-struct kvDict kvDictCpuVendor[] = { { "GenuineIntel", NCCL_TOPO_CPU_VENDOR_INTEL }, { "AuthenticAMD", NCCL_TOPO_CPU_VENDOR_AMD }, { "CentaurHauls", NCCL_TOPO_CPU_VENDOR_ZHAOXIN }, { "  Shanghai  ", NCCL_TOPO_CPU_VENDOR_ZHAOXIN }, { NULL, 0 } };
+struct kvDict kvDictCpuArch[] = {
+  {"x86_64", NCCL_TOPO_CPU_ARCH_X86}, {"arm64", NCCL_TOPO_CPU_ARCH_ARM}, {"ppc64", NCCL_TOPO_CPU_ARCH_POWER}, {NULL, 0}
+};
+struct kvDict kvDictCpuVendor[] = {{"GenuineIntel", NCCL_TOPO_CPU_VENDOR_INTEL},
+                                   {"AuthenticAMD", NCCL_TOPO_CPU_VENDOR_AMD},
+                                   {"CentaurHauls", NCCL_TOPO_CPU_VENDOR_ZHAOXIN},
+                                   {"  Shanghai  ", NCCL_TOPO_CPU_VENDOR_ZHAOXIN},
+                                   {NULL, 0}};
 
 ncclResult_t ncclGetSystemId(struct ncclTopoSystem* system, struct ncclXmlNode* xmlCpu, int* systemIdPtr) {
   const char* hostHashStr;
   NCCLCHECK(xmlGetAttr(xmlCpu, "host_hash", &hostHashStr));
   uint64_t hostHash = hostHashStr ? strtoull(hostHashStr, NULL, 16) : 0;
   int systemId;
-  for (systemId=0; systemId<system->nHosts; systemId++) if (system->hostHashes[systemId] == hostHash) break;
+  for (systemId = 0; systemId < system->nHosts; systemId++)
+    if (system->hostHashes[systemId] == hostHash) break;
   if (systemId == system->nHosts) system->hostHashes[system->nHosts++] = hostHash;
   *systemIdPtr = systemId;
   return ncclSuccess;
 }
-
 
 ncclResult_t ncclTopoAddCpu(struct ncclXmlNode* xmlCpu, struct ncclTopoSystem* system) {
   int numaId;
@@ -666,11 +699,10 @@ ncclResult_t ncclTopoAddCpu(struct ncclXmlNode* xmlCpu, struct ncclTopoSystem* s
       int familyId, modelId;
       NCCLCHECK(xmlGetAttrInt(xmlCpu, "familyid", &familyId));
       NCCLCHECK(xmlGetAttrInt(xmlCpu, "modelid", &modelId));
-      cpu->cpu.model =
-        (familyId == 6 && modelId >= 0xCF) ? NCCL_TOPO_CPU_MODEL_INTEL_ERP :
-        (familyId == 6 && modelId >= 0x8F) ? NCCL_TOPO_CPU_MODEL_INTEL_SRP :
-        (familyId == 6 && modelId >= 0x55) ? NCCL_TOPO_CPU_MODEL_INTEL_SKL :
-        NCCL_TOPO_CPU_MODEL_INTEL_BDW;
+      cpu->cpu.model = (familyId == 6 && modelId >= 0xCF) ? NCCL_TOPO_CPU_MODEL_INTEL_ERP :
+                       (familyId == 6 && modelId >= 0x8F) ? NCCL_TOPO_CPU_MODEL_INTEL_SRP :
+                       (familyId == 6 && modelId >= 0x55) ? NCCL_TOPO_CPU_MODEL_INTEL_SKL :
+                                                            NCCL_TOPO_CPU_MODEL_INTEL_BDW;
     } else if (cpu->cpu.vendor == NCCL_TOPO_CPU_VENDOR_ZHAOXIN) {
       int familyId, modelId;
       NCCLCHECK(xmlGetAttrInt(xmlCpu, "familyid", &familyId));
@@ -682,10 +714,11 @@ ncclResult_t ncclTopoAddCpu(struct ncclXmlNode* xmlCpu, struct ncclTopoSystem* s
       NCCLCHECK(xmlGetAttrInt(xmlCpu, "familyid", &familyId));
       NCCLCHECK(xmlGetAttrInt(xmlCpu, "modelid", &modelId));
       // Treat "Milan" also as "Rome"
-      cpu->cpu.model = ((familyId == 143 && modelId >= 49) || familyId == 175) ? NCCL_TOPO_CPU_MODEL_AMD_ROME : NCCL_TOPO_CPU_MODEL_AMD_ZEN;
+      cpu->cpu.model = ((familyId == 143 && modelId >= 49) || familyId == 175) ? NCCL_TOPO_CPU_MODEL_AMD_ROME :
+                                                                                 NCCL_TOPO_CPU_MODEL_AMD_ZEN;
     }
   }
-  for (int s=0; s<xmlCpu->nSubs; s++) {
+  for (int s = 0; s < xmlCpu->nSubs; s++) {
     struct ncclXmlNode* node = xmlCpu->subs[s];
     if (strcmp(node->name, "pci") == 0) NCCLCHECK(ncclTopoAddPci(node, system, cpu, systemId, numaId));
     if (strcmp(node->name, "nic") == 0) {
@@ -706,7 +739,7 @@ ncclResult_t ncclTopoAddCpu(struct ncclXmlNode* xmlCpu, struct ncclTopoSystem* s
 
 static bool ncclTopoXmlIsPrimaryGpuForDev(const struct ncclXmlNode* xmlGpu) {
   // Only the first GPU entry (rank) for a given device (physical GPU) should contribute links.
-  for (int s=0; s<xmlGpu->parent->nSubs; s++) {
+  for (int s = 0; s < xmlGpu->parent->nSubs; s++) {
     const struct ncclXmlNode* sib = xmlGpu->parent->subs[s];
     if (sib == xmlGpu) break;
     if (strcmp(sib->name, "gpu") == 0) return false;
@@ -723,7 +756,8 @@ static bool ncclTopoXmlIsPrimaryGpuForDev(const struct ncclXmlNode* xmlGpu) {
 // the DEV nodes too (mirrors ncclTopoAddNvLinks below). XGMI link BW is keyed on the GCN
 // arch string (not cudaCompCap), so we read it from devNode->dev.gcn, which ncclTopoAddPci
 // populates from the device's first GPU rank.
-ncclResult_t ncclTopoAddXGMI(struct ncclXmlNode* node, struct ncclTopoSystem* system, const char* parentBusId, int systemId) {
+ncclResult_t ncclTopoAddXGMI(struct ncclXmlNode* node, struct ncclTopoSystem* system, const char* parentBusId,
+                             int systemId) {
   if (strcmp(node->name, "xgmi") == 0) {
     if (!ncclTopoXmlIsPrimaryGpuForDev(node->parent)) return ncclSuccess;
     struct ncclTopoNode* devNode = NULL;
@@ -761,9 +795,9 @@ ncclResult_t ncclTopoAddXGMI(struct ncclXmlNode* node, struct ncclTopoSystem* sy
     }
     if (remote) {
       float nvlSpeed = ncclTopoXGMISpeed(devNode->dev.gcn);
-      NCCLCHECK(ncclTopoConnectNodes(devNode, remote, LINK_NVL, count*nvlSpeed));
+      NCCLCHECK(ncclTopoConnectNodes(devNode, remote, LINK_NVL, count * nvlSpeed));
       if (targetType != GPU) {
-        NCCLCHECK(ncclTopoConnectNodes(remote, devNode, LINK_NVL, count*nvlSpeed));
+        NCCLCHECK(ncclTopoConnectNodes(remote, devNode, LINK_NVL, count * nvlSpeed));
       }
     }
   } else {
@@ -772,14 +806,15 @@ ncclResult_t ncclTopoAddXGMI(struct ncclXmlNode* node, struct ncclTopoSystem* sy
     }
     const char* busId;
     NCCLCHECK(xmlGetAttr(node, "busid", &busId));
-    for (int s=0; s<node->nSubs; s++) {
+    for (int s = 0; s < node->nSubs; s++) {
       NCCLCHECK(ncclTopoAddXGMI(node->subs[s], system, busId ? busId : parentBusId, systemId));
     }
   }
   return ncclSuccess;
 }
 #else
-ncclResult_t ncclTopoAddNvLinks(struct ncclXmlNode* node, struct ncclTopoSystem* system, const char* parentBusId, int systemId) {
+ncclResult_t ncclTopoAddNvLinks(struct ncclXmlNode* node, struct ncclTopoSystem* system, const char* parentBusId,
+                                int systemId) {
   if (strcmp(node->name, "nvlink") == 0) {
     if (!ncclTopoXmlIsPrimaryGpuForDev(node->parent)) return ncclSuccess;
     struct ncclTopoNode* devNode = NULL;
@@ -817,9 +852,9 @@ ncclResult_t ncclTopoAddNvLinks(struct ncclXmlNode* node, struct ncclTopoSystem*
     }
     if (remote) {
       float nvlBw = ncclTopoNVLinkBw(devNode->dev.cudaCompCap);
-      NCCLCHECK(ncclTopoConnectNodes(devNode, remote, LINK_NVL, count*nvlBw));
+      NCCLCHECK(ncclTopoConnectNodes(devNode, remote, LINK_NVL, count * nvlBw));
       if (targetType != GPU) {
-        NCCLCHECK(ncclTopoConnectNodes(remote, devNode, LINK_NVL, count*nvlBw));
+        NCCLCHECK(ncclTopoConnectNodes(remote, devNode, LINK_NVL, count * nvlBw));
       }
     }
   } else {
@@ -828,7 +863,7 @@ ncclResult_t ncclTopoAddNvLinks(struct ncclXmlNode* node, struct ncclTopoSystem*
     }
     const char* busId;
     NCCLCHECK(xmlGetAttr(node, "busid", &busId));
-    for (int s=0; s<node->nSubs; s++) {
+    for (int s = 0; s < node->nSubs; s++) {
       NCCLCHECK(ncclTopoAddNvLinks(node->subs[s], system, busId ? busId : parentBusId, systemId));
     }
   }
@@ -836,7 +871,8 @@ ncclResult_t ncclTopoAddNvLinks(struct ncclXmlNode* node, struct ncclTopoSystem*
 }
 #endif
 
-ncclResult_t ncclTopoAddPciLinks(struct ncclXmlNode* node, struct ncclTopoSystem* system, const char* parentBusId, int systemId) {
+ncclResult_t ncclTopoAddPciLinks(struct ncclXmlNode* node, struct ncclTopoSystem* system, const char* parentBusId,
+                                 int systemId) {
   if (strcmp(node->name, "pcilink") == 0) {
     struct ncclTopoNode* pci = NULL;
     int64_t pBusId;
@@ -860,15 +896,15 @@ ncclResult_t ncclTopoAddPciLinks(struct ncclXmlNode* node, struct ncclTopoSystem
     }
     const char* busId;
     NCCLCHECK(xmlGetAttr(node, "busid", &busId));
-    for (int s=0; s<node->nSubs; s++) {
+    for (int s = 0; s < node->nSubs; s++) {
       NCCLCHECK(ncclTopoAddPciLinks(node->subs[s], system, busId ? busId : parentBusId, systemId));
     }
   }
   return ncclSuccess;
 }
 
-
-ncclResult_t ncclTopoAddC2c(struct ncclXmlNode* node, struct ncclTopoSystem* system, const char* parentBusId, int systemId) {
+ncclResult_t ncclTopoAddC2c(struct ncclXmlNode* node, struct ncclTopoSystem* system, const char* parentBusId,
+                            int systemId) {
   if (strcmp(node->name, "c2c") == 0) {
     if (!ncclTopoXmlIsPrimaryGpuForDev(node->parent)) return ncclSuccess;
     struct ncclTopoNode* gpu = NULL;
@@ -884,7 +920,7 @@ ncclResult_t ncclTopoAddC2c(struct ncclXmlNode* node, struct ncclTopoSystem* sys
     NCCLCHECK(xmlGetAttrInt(node, "count", &count));
     int bw = 0;
     NCCLCHECK(xmlGetAttrInt(node, "bw", &bw));
-    double c2cBw = (bw*count)/1000.0;
+    double c2cBw = (bw * count) / 1000.0;
     struct ncclTopoNode* cpu = NULL;
     NCCLCHECK(findLocalCpu(gpu, &cpu, NULL));
     if (cpu == NULL) return ncclSuccess;
@@ -896,20 +932,21 @@ ncclResult_t ncclTopoAddC2c(struct ncclXmlNode* node, struct ncclTopoSystem* sys
     }
     const char* busId;
     NCCLCHECK(xmlGetAttr(node, "busid", &busId));
-    for (int s=0; s<node->nSubs; s++) {
+    for (int s = 0; s < node->nSubs; s++) {
       NCCLCHECK(ncclTopoAddC2c(node->subs[s], system, busId ? busId : parentBusId, systemId));
     }
   }
   return ncclSuccess;
 }
 
-ncclResult_t ncclTopoGetSystemFromXml(struct ncclXml* xml, struct ncclTopoSystem** topoSystem, const uint64_t localHostHash) {
+ncclResult_t ncclTopoGetSystemFromXml(struct ncclXml* xml, struct ncclTopoSystem** topoSystem,
+                                      const uint64_t localHostHash) {
   NCCLCHECK(ncclCalloc(topoSystem, 1));
   struct ncclTopoSystem* system = *topoSystem;
   system->romeTopoModelIdx = RCCL_ROME_TOPO_PRESET_MODEL_IDX_NONE;
   struct ncclXmlNode* topNode;
   NCCLCHECK(xmlFindTag(xml, "system", &topNode));
-  for (int s=0; s<topNode->nSubs; s++) {
+  for (int s = 0; s < topNode->nSubs; s++) {
     struct ncclXmlNode* node = topNode->subs[s];
     if (strcmp(node->name, "cpu") == 0) NCCLCHECK(ncclTopoAddCpu(node, *topoSystem));
   }
@@ -917,8 +954,8 @@ ncclResult_t ncclTopoGetSystemFromXml(struct ncclXml* xml, struct ncclTopoSystem
   int systemId = 0;
   while (systemId < system->nHosts && system->hostHashes[systemId] != localHostHash) systemId++;
   system->systemId = systemId;
-  if(systemId == system->nHosts){
-    WARN("localHostHash = 0x%lx not found in the list of system hostHashes",localHostHash);
+  if (systemId == system->nHosts) {
+    WARN("localHostHash = 0x%lx not found in the list of system hostHashes", localHostHash);
     return ncclInvalidArgument;
   }
 
@@ -975,13 +1012,12 @@ static ncclResult_t xmlInitAttrFloat(struct ncclXmlNode* node, const char* attrN
 }
 
 ncclResult_t ncclTopoRefreshBcmP2pLinks(void) {
-  //refresh the switch topology by reading the link below
-  FILE *fp = fopen("/sys/kernel/pci_switch_link/refresh_switch_toplogy", "r");
+  // refresh the switch topology by reading the link below
+  FILE* fp = fopen("/sys/kernel/pci_switch_link/refresh_switch_toplogy", "r");
   if (fp != NULL) {
     int tmp;
     size_t r = fread(&tmp, sizeof(tmp), 1, fp);
-    if (r != 1)
-      INFO(NCCL_GRAPH, "Failed to read refresh_switch_toplogy");
+    if (r != 1) INFO(NCCL_GRAPH, "Failed to read refresh_switch_toplogy");
     fclose(fp);
   }
   return ncclSuccess;
@@ -1103,8 +1139,8 @@ ncclResult_t ncclTopoGetPath(ncclXmlNode** nodes, int nNodes, int* path, ncclXml
       for (int i = 0; i < nNodes; i++) {
         parents[i].pop();
       }
-    // Check multi-port while we still have the mismatched parents
-    // For multi-port to be true, all parents (peers) must have the busId attribute with all but the last character matching
+      // Check multi-port while we still have the mismatched parents
+      // For multi-port to be true, all parents (peers) must have the busId attribute with all but the last character matching
     } else {
       int multiPort = 1;
       const char* tempBusId;
@@ -1120,7 +1156,7 @@ ncclResult_t ncclTopoGetPath(ncclXmlNode** nodes, int nNodes, int* path, ncclXml
                 multiPort = 0;
                 break;
               }
-              if (strncmp(busId, tempBusId, strlen(busId)-1) != 0) {
+              if (strncmp(busId, tempBusId, strlen(busId) - 1) != 0) {
                 multiPort = 0;
                 break;
               }
@@ -1143,7 +1179,7 @@ ncclResult_t ncclTopoGetPath(ncclXmlNode** nodes, int nNodes, int* path, ncclXml
 
   if (common == NULL) {
     *path = PATH_DIS;
-  } else if (strcmp(common->name,"system") == 0) {
+  } else if (strcmp(common->name, "system") == 0) {
     *path = PATH_SYS;
   } else if (strcmp(common->name, "cpu") == 0) {
     *path = PATH_PHB;
@@ -1164,7 +1200,8 @@ out:
   return ncclSuccess;
 }
 
-ncclResult_t ncclTopoMakeUniqueBusId(struct ncclXml* xml, char* busId, struct ncclXmlNode** pciNode, struct ncclXmlNode* parent) {
+ncclResult_t ncclTopoMakeUniqueBusId(struct ncclXml* xml, char* busId, struct ncclXmlNode** pciNode,
+                                     struct ncclXmlNode* parent) {
   int i = 0;
   int64_t rBusId;
   NCCLCHECK(busIdToInt64(busId, &rBusId));
@@ -1222,7 +1259,8 @@ ncclResult_t ncclTopoMakePciParent(struct ncclXml* xml, struct ncclXmlNode** par
   return ncclSuccess;
 }
 
-ncclResult_t ncclTopoMakeVnic(struct ncclXml* xml, struct ncclTopoNetInfo* netInfo, ncclNetVDeviceProps_t* vProps, struct ncclXmlNode** physNetNodes) {
+ncclResult_t ncclTopoMakeVnic(struct ncclXml* xml, struct ncclTopoNetInfo* netInfo, ncclNetVDeviceProps_t* vProps,
+                              struct ncclXmlNode** physNetNodes) {
   if (vProps->ndevs > netInfo->maxDevsPerNic) {
     WARN("TOPO/NET : Tried to merge too many NICs. %d > %d", vProps->ndevs, netInfo->maxDevsPerNic);
     return ncclInternalError;
@@ -1237,10 +1275,12 @@ ncclResult_t ncclTopoMakeVnic(struct ncclXml* xml, struct ncclTopoNetInfo* netIn
   // Trigger the merge, then get the new device's properties
   int vDevIndex = 0;
   ncclResult_t ret;
-  NOWARN(ret = netInfo->makeVDevice(&vDevIndex, vProps), NCCL_GRAPH|NCCL_INIT|NCCL_NET);
+  NOWARN(ret = netInfo->makeVDevice(&vDevIndex, vProps), NCCL_GRAPH | NCCL_INIT | NCCL_NET);
   if (ret != ncclSuccess) {
-    INFO(NCCL_GRAPH|NCCL_INIT|NCCL_NET, "TOPO/NET : Tried merging multiple devices together and failed. vProps={ndevs=%d, devs=[%d %d %d %d]}. Set NCCL_NET_MERGE_LEVEL=LOC to disable NIC fusion.",
-      vProps->ndevs, vProps->devs[0], vProps->devs[1], vProps->devs[2], vProps->devs[3]);
+    INFO(NCCL_GRAPH | NCCL_INIT | NCCL_NET,
+         "TOPO/NET : Tried merging multiple devices together and failed. vProps={ndevs=%d, devs=[%d %d %d %d]}. Set "
+         "NCCL_NET_MERGE_LEVEL=LOC to disable NIC fusion.",
+         vProps->ndevs, vProps->devs[0], vProps->devs[1], vProps->devs[2], vProps->devs[3]);
     return ret;
   }
 
@@ -1255,12 +1295,13 @@ ncclResult_t ncclTopoMakeVnic(struct ncclXml* xml, struct ncclTopoNetInfo* netIn
   return ncclSuccess;
 }
 
-ncclResult_t ncclTopoForceMerge(struct ncclXml* xml, struct ncclTopoNetInfo* netInfo, int* placedDevs, ncclNetProperties_t* propsList, struct ncclXmlNode** physNetNodes, int nPhysDevs) {
+ncclResult_t ncclTopoForceMerge(struct ncclXml* xml, struct ncclTopoNetInfo* netInfo, int* placedDevs,
+                                ncclNetProperties_t* propsList, struct ncclXmlNode** physNetNodes, int nPhysDevs) {
   ncclResult_t ret = ncclSuccess;
   const char* str = netInfo->forceMerge;
   INFO(NCCL_ENV | NCCL_NET, "TOPO/NET : Force-fusing NICs using NCCL_NET_FORCE_MERGE=%s", str);
   char* ncStr;
-  NCCLCHECK(ncclCalloc(&ncStr, strlen(str)+1));
+  NCCLCHECK(ncclCalloc(&ncStr, strlen(str) + 1));
   strcpy(ncStr, str);
   char* semi_token;
   char* semi = strtok_r(ncStr, ";", &semi_token);
@@ -1269,8 +1310,10 @@ ncclResult_t ncclTopoForceMerge(struct ncclXml* xml, struct ncclTopoNetInfo* net
     struct netIf userIfs[NCCL_NET_MAX_DEVS_PER_NIC];
     int nUserIfs = parseStringList(semi, userIfs, NCCL_NET_MAX_DEVS_PER_NIC);
     if (nUserIfs == 0) {
-      INFO(NCCL_NET, "NET/IB : Invalid NCCL_NET_FORCE_MERGE specified %s. Couldn't parse substring %s. Please provide a semicolon-delimited list of comma-delimited NIC groups.",
-        ncStr, semi);
+      INFO(NCCL_NET,
+           "NET/IB : Invalid NCCL_NET_FORCE_MERGE specified %s. Couldn't parse substring %s. Please provide a "
+           "semicolon-delimited list of comma-delimited NIC groups.",
+           ncStr, semi);
       continue;
     }
 
@@ -1282,14 +1325,14 @@ ncclResult_t ncclTopoForceMerge(struct ncclXml* xml, struct ncclTopoNetInfo* net
     }
 
     if (vProps.ndevs != nUserIfs) {
-      WARN("TOPO/NET : Only matched %d devices, %d requested from %s",
-        vProps.ndevs, nUserIfs, semi);
+      WARN("TOPO/NET : Only matched %d devices, %d requested from %s", vProps.ndevs, nUserIfs, semi);
       ret = ncclInvalidUsage;
       goto fail;
     }
 
     if (vProps.ndevs > netInfo->maxDevsPerNic) {
-      WARN("Specified fused NIC %s which has too many devices (%d). Max %d", semi, vProps.ndevs, netInfo->maxDevsPerNic);
+      WARN("Specified fused NIC %s which has too many devices (%d). Max %d", semi, vProps.ndevs,
+           netInfo->maxDevsPerNic);
       ret = ncclInvalidUsage;
       goto fail;
     }
@@ -1306,7 +1349,8 @@ ncclResult_t ncclTopoForceMerge(struct ncclXml* xml, struct ncclTopoNetInfo* net
       goto fail;
     }
 
-    semi = strtok_r(NULL, ";", &semi_token);;
+    semi = strtok_r(NULL, ";", &semi_token);
+    ;
   }
 
 exit:
@@ -1316,19 +1360,20 @@ fail:
   goto exit;
 }
 
-ncclResult_t ncclTopoAutoMerge(struct ncclXml* xml, struct ncclTopoNetInfo* netInfo, int* placedDevs, ncclNetProperties_t* propsList, struct ncclXmlNode** physNetNodes, int nPhysDevs) {
+ncclResult_t ncclTopoAutoMerge(struct ncclXml* xml, struct ncclTopoNetInfo* netInfo, int* placedDevs,
+                               ncclNetProperties_t* propsList, struct ncclXmlNode** physNetNodes, int nPhysDevs) {
   // Compute the path type between each device
   int* paths = NULL;
   ncclResult_t res = ncclSuccess;
-  ncclCalloc(&paths, nPhysDevs*nPhysDevs);
-  TRACE(NCCL_GRAPH, "Allocated %d paths", nPhysDevs*nPhysDevs);
+  ncclCalloc(&paths, nPhysDevs * nPhysDevs);
+  TRACE(NCCL_GRAPH, "Allocated %d paths", nPhysDevs * nPhysDevs);
   for (int i = 0; i < nPhysDevs; i++) {
     for (int j = 0; j < nPhysDevs; j++) {
       struct ncclXmlNode* nodes[2];
       nodes[0] = physNetNodes[i];
       nodes[1] = physNetNodes[j];
       struct ncclXmlNode* parent;
-      NCCLCHECKGOTO(ncclTopoGetPath(nodes, 2, &paths[i*nPhysDevs + j], &parent), res, out);
+      NCCLCHECKGOTO(ncclTopoGetPath(nodes, 2, &paths[i * nPhysDevs + j], &parent), res, out);
     }
   }
 
@@ -1346,11 +1391,10 @@ ncclResult_t ncclTopoAutoMerge(struct ncclXml* xml, struct ncclTopoNetInfo* netI
       // Select each unplaced device "j" which is at most "mergeLevel" distance from "i", but not equal to "i"
       // (Don't merge the same device with itself)
       for (int j = 0; j < nPhysDevs; j++) {
-        if (paths[i*nPhysDevs + j] <= netInfo->mergeLevel &&
-        placedDevs[j] == 0 && j != i) {
+        if (paths[i * nPhysDevs + j] <= netInfo->mergeLevel && placedDevs[j] == 0 && j != i) {
           vProps.devs[vProps.ndevs++] = j;
           placedDevs[j] = 1;
-          TRACE(NCCL_GRAPH, "Placed dev %d path=%d", j, paths[i*nPhysDevs + j] );
+          TRACE(NCCL_GRAPH, "Placed dev %d path=%d", j, paths[i * nPhysDevs + j]);
         }
         if (vProps.ndevs == netInfo->maxDevsPerNic) break;
       }
@@ -1366,14 +1410,15 @@ ncclResult_t ncclTopoAutoMerge(struct ncclXml* xml, struct ncclTopoNetInfo* netI
       // Mark all as unplaced and increase their distance to disconnected (PATH_DIS)
       // Set i to 0 to restart the automatic merging process and ensure all are placed
       if (ret != ncclSuccess) {
-        INFO(NCCL_GRAPH|NCCL_INIT|NCCL_NET, "Marking physical devices as unplaced, increasing distance and restarting search.");
+        INFO(NCCL_GRAPH | NCCL_INIT | NCCL_NET,
+             "Marking physical devices as unplaced, increasing distance and restarting search.");
         placedDevs[i] = 0;
         TRACE(NCCL_GRAPH, "Setting dev %d as unplaced, keeping distance -> self as PATH_LOC", i);
         for (int k = 1; k < vProps.ndevs; k++) {
           int dev = vProps.devs[k];
           placedDevs[dev] = 0;
-          paths[i*nPhysDevs + dev] = PATH_DIS;
-          paths[dev*nPhysDevs + i] = PATH_DIS;
+          paths[i * nPhysDevs + dev] = PATH_DIS;
+          paths[dev * nPhysDevs + i] = PATH_DIS;
           TRACE(NCCL_GRAPH, "Setting dev %d as unplaced, setting distance -> %d as PATH_DIS", dev, i);
         }
         i = 0;
@@ -1386,20 +1431,12 @@ out:
   return res;
 }
 
-struct kvDict nicPathKvList[] = {
-  { "LOC",  PATH_LOC },
-  { "PORT", PATH_PORT },
-  { "PIX",  PATH_PIX },
-  { "PXB",  PATH_PXB },
-  { "P2C",  PATH_P2C },
-  { "PXN",  PATH_PXN },
-  { "PHB",  PATH_PHB },
-  { "SYS",  PATH_SYS },
-  { NULL, 0 }
-};
+struct kvDict nicPathKvList[] = {{"LOC", PATH_LOC}, {"PORT", PATH_PORT}, {"PIX", PATH_PIX},
+                                 {"PXB", PATH_PXB}, {"P2C", PATH_P2C},   {"PXN", PATH_PXN},
+                                 {"PHB", PATH_PHB}, {"SYS", PATH_SYS},   {NULL, 0}};
 
-
-ncclResult_t ncclTopoFindLinkWidthRec(ncclXmlNode* node, ncclXmlNode** physNetNodes, int ndevs, int* foundPhysNet, int* linkWidth) {
+ncclResult_t ncclTopoFindLinkWidthRec(ncclXmlNode* node, ncclXmlNode** physNetNodes, int ndevs, int* foundPhysNet,
+                                      int* linkWidth) {
   int myLinkWidth = 0;
   if (strcmp(node->name, "pci") == 0) {
     NCCLCHECK(xmlGetAttrInt(node, "link_width", &myLinkWidth));
@@ -1431,15 +1468,18 @@ ncclResult_t ncclTopoFindLinkWidthRec(ncclXmlNode* node, ncclXmlNode** physNetNo
   if (*foundPhysNet == 0) {
     // No child NICs were found, do not accrue any detected link_width
     *linkWidth = 0;
-    INFO(NCCL_GRAPH, "Did not find child net device. Returning link_width=%d totalChildLinkWidth=%d", *linkWidth, totalChildLinkWidth);
+    INFO(NCCL_GRAPH, "Did not find child net device. Returning link_width=%d totalChildLinkWidth=%d", *linkWidth,
+         totalChildLinkWidth);
   } else if (totalChildLinkWidth == 0) {
     // If A child NIC was found but no link_width was detected among children, assign the link_width to mine (I am the first pci node right above the physNetNode).
     *linkWidth = myLinkWidth;
-    INFO(NCCL_GRAPH, "Found child net device for %s. Returning link_width=%d totalChildLinkWidth=%d", node->name, *linkWidth, totalChildLinkWidth);
+    INFO(NCCL_GRAPH, "Found child net device for %s. Returning link_width=%d totalChildLinkWidth=%d", node->name,
+         *linkWidth, totalChildLinkWidth);
   } else {
-  // Standard recursive accrual of link_width. The link_width is either the bottleneck of this PCI node's width or the sum of its children's width.
+    // Standard recursive accrual of link_width. The link_width is either the bottleneck of this PCI node's width or the sum of its children's width.
     *linkWidth = myLinkWidth > 0 ? std::min(myLinkWidth, totalChildLinkWidth) : totalChildLinkWidth;
-    INFO(NCCL_GRAPH, "Found child net device for %s. Returning link_width=%d totalChildLinkWidth=%d", node->name, *linkWidth, totalChildLinkWidth);
+    INFO(NCCL_GRAPH, "Found child net device for %s. Returning link_width=%d totalChildLinkWidth=%d", node->name,
+         *linkWidth, totalChildLinkWidth);
   }
 
   return ncclSuccess;
@@ -1484,7 +1524,8 @@ ncclResult_t ncclTopoWidenLinks(ncclXmlNode** physNetNodes, int ndevs, ncclXmlNo
   return ncclSuccess;
 }
 
-ncclResult_t ncclTopoGetVNicParent(struct ncclXml* xml, ncclResult_t (*getProperties)(int, ncclNetProperties_t*), ncclNetVDeviceProps_t* vProps, ncclXmlNode** parent) {
+ncclResult_t ncclTopoGetVNicParent(struct ncclXml* xml, ncclResult_t (*getProperties)(int, ncclNetProperties_t*),
+                                   ncclNetVDeviceProps_t* vProps, ncclXmlNode** parent) {
   ncclNetProperties_t props[NCCL_NET_MAX_DEVS_PER_NIC];
   ncclXmlNode* physNetNodes[NCCL_NET_MAX_DEVS_PER_NIC];
   for (int i = 0; i < vProps->ndevs; i++) {
@@ -1492,7 +1533,7 @@ ncclResult_t ncclTopoGetVNicParent(struct ncclXml* xml, ncclResult_t (*getProper
     struct ncclXmlNode* physNetNode;
     NCCLCHECK(xmlFindTagKv(xml, "net", &physNetNode, "name", props[i].name));
     physNetNodes[i] = physNetNode;
-    TRACE(NCCL_GRAPH, "Re-found physical ncclNet node %d %s", i,  props[i].name);
+    TRACE(NCCL_GRAPH, "Re-found physical ncclNet node %d %s", i, props[i].name);
   }
 
   int path = PATH_LOC;
@@ -1551,10 +1592,11 @@ ncclResult_t ncclTopoMakeVNics(struct ncclXml* xml, struct ncclTopoNetInfo* netI
     struct ncclXmlNode* physNetNode;
     NCCLCHECKGOTO(xmlFindTagKv(xml, "net", &physNetNode, "name", props[i].name), res, out);
     physNetNodes[i] = physNetNode;
-    TRACE(NCCL_GRAPH, "Found physical ncclNet node %d %s", i,  props[i].name);
+    TRACE(NCCL_GRAPH, "Found physical ncclNet node %d %s", i, props[i].name);
   }
 
-  if (netInfo->forceMerge) NCCLCHECKGOTO(ncclTopoForceMerge(xml, netInfo, placedDevs, props, physNetNodes, physicalDevs), res, out);
+  if (netInfo->forceMerge)
+    NCCLCHECKGOTO(ncclTopoForceMerge(xml, netInfo, placedDevs, props, physNetNodes, physicalDevs), res, out);
   NCCLCHECKGOTO(ncclTopoAutoMerge(xml, netInfo, placedDevs, props, physNetNodes, physicalDevs), res, out);
 
 out:
@@ -1564,7 +1606,8 @@ out:
   return res;
 }
 
-static ncclResult_t ncclTopoPopulateNics(ncclXml* xml, int startIndex, int endIndex, struct ncclTopoNetInfo* netInfo, int virtualNics) {
+static ncclResult_t ncclTopoPopulateNics(ncclXml* xml, int startIndex, int endIndex, struct ncclTopoNetInfo* netInfo,
+                                         int virtualNics) {
   for (int n = startIndex; n < endIndex; n++) {
     ncclNetProperties_t props;
     NCCLCHECK(netInfo->getProperties(n, &props));
@@ -1586,15 +1629,18 @@ static ncclResult_t ncclTopoPopulateNics(ncclXml* xml, int startIndex, int endIn
     NCCLCHECK(xmlSetAttrInt(netNode, "keep", 1));
     int dev;
     xmlGetAttrIntDefault(netNode, "dev", &dev, -1);
-    if (dev != -1 && dev != n) INFO(NCCL_GRAPH, "TOPO/NET : Changing %s dev index from %d to %d", netInfo->name, dev, n);
+    if (dev != -1 && dev != n)
+      INFO(NCCL_GRAPH, "TOPO/NET : Changing %s dev index from %d to %d", netInfo->name, dev, n);
     NCCLCHECK(xmlSetAttrInt(netNode, "dev", n));
     NCCLCHECK(xmlInitAttrInt(netNode, "latency", props.latency));
     NCCLCHECK(xmlInitAttrInt(netNode, "speed", props.speed));
     NCCLCHECK(xmlInitAttrInt(netNode, "port", props.port));
     NCCLCHECK(xmlInitAttrUint64(netNode, "guid", props.guid));
     NCCLCHECK(xmlInitAttrInt(netNode, "maxconn", props.maxComms));
-    bool gdrSupport = (props.ptrSupport & NCCL_PTR_CUDA) || (netInfo->dmaBufSupport && (props.ptrSupport & NCCL_PTR_DMABUF));
-    INFO(NCCL_NET,"NET/%s : GPU Direct RDMA %s for HCA %d '%s'", netInfo->name, gdrSupport ? "Enabled" : "Disabled", n, props.name);
+    bool gdrSupport =
+      (props.ptrSupport & NCCL_PTR_CUDA) || (netInfo->dmaBufSupport && (props.ptrSupport & NCCL_PTR_DMABUF));
+    INFO(NCCL_NET, "NET/%s : GPU Direct RDMA %s for HCA %d '%s'", netInfo->name, gdrSupport ? "Enabled" : "Disabled", n,
+         props.name);
     NCCLCHECK(xmlInitAttrInt(netNode, "gdr", gdrSupport));
 
     // Do not overwrite the "net" attribute and guarantees that a dev with net=1 will be unchanged
@@ -1612,7 +1658,8 @@ static ncclResult_t ncclTopoPopulateNics(ncclXml* xml, int startIndex, int endIn
     NCCLCHECK(xmlGetAttr(netNode, "gin", &ginAttr));
     NCCLCHECK(xmlGetAttr(netNode, "coll", &colAttr));
     NCCLCHECK(xmlGetAttr(netNode, "keep", &keepAttr));
-    INFO(NCCL_GRAPH, "ncclTopoPopulateNics : Filled %s in topo with pciPath=%s net=%s gin=%s keep=%s coll=%s", props.name, props.pciPath, netAttr, ginAttr, keepAttr, colAttr);
+    INFO(NCCL_GRAPH, "ncclTopoPopulateNics : Filled %s in topo with pciPath=%s net=%s gin=%s keep=%s coll=%s",
+         props.name, props.pciPath, netAttr, ginAttr, keepAttr, colAttr);
   }
 
   return ncclSuccess;
@@ -1706,53 +1753,53 @@ ncclResult_t ncclTopoGetSystem(struct ncclComm* comm, struct ncclTopoSystem** sy
   // Auto-detect NICs if needed, net/gin/collnet share the same xml/graph nodes.
   // Start with gin, then with collnet so that they precedence.
   {
-      std::lock_guard<std::mutex> lock(netMutex);
-      INFO(NCCL_GRAPH, "TOPO/NET : Importing network plugins to topology");
-      ncclGin_t* gin = comm->sharedRes->ginState.ncclGin;
-      if (gin) {
-        netInfo.net = 0;
-        netInfo.coll = 0;
-        netInfo.gin = 1;
-        netInfo.netPluginIndex = comm->ginPluginIndex;
-        netInfo.dmaBufSupport = comm->dmaBufSupport;
-        netInfo.getDevCount = ncclGinGetDevCount;
-        netInfo.name = gin->name;
-        netInfo.getProperties = gin->getProperties;
-        netInfo.makeVDevice = NULL;
-        netInfo.devices = gin->devices;
-        NCCLCHECKGOTO(ncclTopoProcessNet(xml, dumpXmlFile, &netInfo), ret, fail);
-      }
-      if (collNetSupport(comm)) {
-        netInfo.net = 0;
-        netInfo.coll = 1;
-        netInfo.gin = 0;
-        netInfo.netPluginIndex = comm->netPluginIndex;
-        netInfo.maxDevsPerNic = (comm->ncclNetVer >= 12) ? NCCL_NET_MAX_DEVS_PER_NIC : NCCL_NET_MAX_DEVS_PER_NIC_V11;
-        netInfo.dmaBufSupport = comm->dmaBufSupport;
-        netInfo.getDevCount = ncclCollNetGetDevCount;
-        netInfo.setVirtDevCount = ncclCollNetSetVirtDevCount;
-        netInfo.name = comm->ncclCollNet->name;
-        netInfo.getProperties = comm->ncclCollNet->getProperties;
-        netInfo.makeVDevice = comm->ncclCollNet->makeVDevice;
-        netInfo.devices = comm->ncclCollNet->devices;
-        NCCLCHECK(ncclTopoGetFusionEnv(&netInfo.mergeLevel, &netInfo.forceMerge));
-        NCCLCHECKGOTO(ncclTopoProcessNet(xml, dumpXmlFile, &netInfo), ret, fail);
-      }
-
-      netInfo.net = 1;
+    std::lock_guard<std::mutex> lock(netMutex);
+    INFO(NCCL_GRAPH, "TOPO/NET : Importing network plugins to topology");
+    ncclGin_t* gin = comm->sharedRes->ginState.ncclGin;
+    if (gin) {
+      netInfo.net = 0;
       netInfo.coll = 0;
+      netInfo.gin = 1;
+      netInfo.netPluginIndex = comm->ginPluginIndex;
+      netInfo.dmaBufSupport = comm->dmaBufSupport;
+      netInfo.getDevCount = ncclGinGetDevCount;
+      netInfo.name = gin->name;
+      netInfo.getProperties = gin->getProperties;
+      netInfo.makeVDevice = NULL;
+      netInfo.devices = gin->devices;
+      NCCLCHECKGOTO(ncclTopoProcessNet(xml, dumpXmlFile, &netInfo), ret, fail);
+    }
+    if (collNetSupport(comm)) {
+      netInfo.net = 0;
+      netInfo.coll = 1;
       netInfo.gin = 0;
       netInfo.netPluginIndex = comm->netPluginIndex;
       netInfo.maxDevsPerNic = (comm->ncclNetVer >= 12) ? NCCL_NET_MAX_DEVS_PER_NIC : NCCL_NET_MAX_DEVS_PER_NIC_V11;
       netInfo.dmaBufSupport = comm->dmaBufSupport;
-      netInfo.getDevCount = ncclNetGetDevCount;
-      netInfo.setVirtDevCount = ncclNetSetVirtDevCount;
-      netInfo.name = comm->ncclNet->name;
-      netInfo.getProperties = comm->ncclNet->getProperties;
-      netInfo.makeVDevice = comm->ncclNet->makeVDevice;
-      netInfo.devices = comm->ncclNet->devices;
+      netInfo.getDevCount = ncclCollNetGetDevCount;
+      netInfo.setVirtDevCount = ncclCollNetSetVirtDevCount;
+      netInfo.name = comm->ncclCollNet->name;
+      netInfo.getProperties = comm->ncclCollNet->getProperties;
+      netInfo.makeVDevice = comm->ncclCollNet->makeVDevice;
+      netInfo.devices = comm->ncclCollNet->devices;
       NCCLCHECK(ncclTopoGetFusionEnv(&netInfo.mergeLevel, &netInfo.forceMerge));
       NCCLCHECKGOTO(ncclTopoProcessNet(xml, dumpXmlFile, &netInfo), ret, fail);
+    }
+
+    netInfo.net = 1;
+    netInfo.coll = 0;
+    netInfo.gin = 0;
+    netInfo.netPluginIndex = comm->netPluginIndex;
+    netInfo.maxDevsPerNic = (comm->ncclNetVer >= 12) ? NCCL_NET_MAX_DEVS_PER_NIC : NCCL_NET_MAX_DEVS_PER_NIC_V11;
+    netInfo.dmaBufSupport = comm->dmaBufSupport;
+    netInfo.getDevCount = ncclNetGetDevCount;
+    netInfo.setVirtDevCount = ncclNetSetVirtDevCount;
+    netInfo.name = comm->ncclNet->name;
+    netInfo.getProperties = comm->ncclNet->getProperties;
+    netInfo.makeVDevice = comm->ncclNet->makeVDevice;
+    netInfo.devices = comm->ncclNet->devices;
+    NCCLCHECK(ncclTopoGetFusionEnv(&netInfo.mergeLevel, &netInfo.forceMerge));
+    NCCLCHECKGOTO(ncclTopoProcessNet(xml, dumpXmlFile, &netInfo), ret, fail);
   }
 
   // Remove XML branches which don't have a node with keep="1" (typically when importing a topology)
@@ -1769,30 +1816,31 @@ ncclResult_t ncclTopoGetSystem(struct ncclComm* comm, struct ncclTopoSystem** sy
     NCCLCHECKGOTO(ncclCalloc(&localRanks, comm->nRanks), ret, fail);
     for (int i = 0; i < comm->nRanks; i++) {
       if (comm->peerInfo[i].hostHash == comm->peerInfo[comm->rank].hostHash) {
-        if (i == comm->rank)
-          localRank = nLocalRanks;
+        if (i == comm->rank) localRank = nLocalRanks;
         localRanks[nLocalRanks++] = i;
       }
     }
   }
   NCCLCHECKGOTO(ncclCalloc(&mem, nLocalRanks * xmlMemSize(NCCL_TOPO_XML_MAX_NODES)), ret, fail);
-  rankXml = (struct ncclXml*)(mem+xmlMemSize(NCCL_TOPO_XML_MAX_NODES)*localRank);
+  rankXml = (struct ncclXml*)(mem + xmlMemSize(NCCL_TOPO_XML_MAX_NODES) * localRank);
   memcpy(rankXml, xml, xmlMemSize(NCCL_TOPO_XML_MAX_NODES));
   NCCLCHECKGOTO(ncclTopoConvertXml(rankXml, (uintptr_t)xml->nodes, 1), ret, fail);
   // nLocalRanks can't actually be 0, or we wouldn't be running at all...
   // coverity[divide_by_zero]
-  NCCLCHECKGOTO(bootstrapIntraNodeAllGather(comm->bootstrap, localRanks, localRank, nLocalRanks, mem, xmlMemSize(NCCL_TOPO_XML_MAX_NODES)), ret, fail);
+  NCCLCHECKGOTO(bootstrapIntraNodeAllGather(comm->bootstrap, localRanks, localRank, nLocalRanks, mem,
+                                            xmlMemSize(NCCL_TOPO_XML_MAX_NODES)),
+                ret, fail);
   if (comm->MNNVL) {
     // Ensure that we have enough room when fusing topos from multiple nodes.
     free(xml);
     xml = NULL;
-    NCCLCHECKGOTO(xmlAlloc(&xml, nLocalRanks*NCCL_TOPO_XML_MAX_NODES), ret, fail);
+    NCCLCHECKGOTO(xmlAlloc(&xml, nLocalRanks * NCCL_TOPO_XML_MAX_NODES), ret, fail);
   } else {
     // In the intra-node case there's no need to enlarge the topo xml.
     xml->maxIndex = 0;
   }
   for (int i = 0; i < nLocalRanks; i++) {
-    struct ncclXml* peerXml = (struct ncclXml*)(mem+xmlMemSize(NCCL_TOPO_XML_MAX_NODES)*i);
+    struct ncclXml* peerXml = (struct ncclXml*)(mem + xmlMemSize(NCCL_TOPO_XML_MAX_NODES) * i);
     NCCLCHECKGOTO(ncclTopoConvertXml(peerXml, (uintptr_t)peerXml->nodes, 0), ret, fail);
     NCCLCHECKGOTO(ncclTopoFuseXml(xml, peerXml), ret, fail);
   }
@@ -1815,13 +1863,16 @@ fail:
 }
 
 ncclResult_t ncclTopoGetLocal(struct ncclTopoSystem* system, int type, int index, int resultType,
-                                     int locals[NCCL_TOPO_MAX_NODES], int* localCount, int* pathType) {
+                              int locals[NCCL_TOPO_MAX_NODES], int* localCount, int* pathType) {
   int minType = PATH_DIS;
   float maxBw = 0;
   int count = 0;
   struct ncclTopoLinkList* paths = system->nodes[type].nodes[index].paths[resultType];
-  if (paths == NULL) { *localCount = 0; return ncclSuccess; }
-  for (int i=0; i<system->nodes[resultType].count; i++) {
+  if (paths == NULL) {
+    *localCount = 0;
+    return ncclSuccess;
+  }
+  for (int i = 0; i < system->nodes[resultType].count; i++) {
     if (paths[i].bw > maxBw || (paths[i].bw == maxBw && paths[i].type < minType)) {
       maxBw = paths[i].bw;
       minType = paths[i].type;
@@ -1842,7 +1893,7 @@ ncclResult_t ncclTopoGetLocal(struct ncclTopoSystem* system, int type, int index
   return ncclSuccess;
 }
 
-ncclResult_t getLocalNetCountByBw(struct ncclTopoSystem* system, int gpu, int *count, float* bw) {
+ncclResult_t getLocalNetCountByBw(struct ncclTopoSystem* system, int gpu, int* count, float* bw) {
   // Assuming BW to CPU reflects the GPU bandwidth via P2P or C2C.
   // Caveat, this could be wrong if there is a PCIe switch, and a narrower link to the CPU.
   int c;
@@ -1858,12 +1909,12 @@ ncclResult_t getLocalNetCountByBw(struct ncclTopoSystem* system, int gpu, int *c
     int64_t netId;
     NCCLCHECK(ncclTopoGetLocalNet(system, rank, c, &netId, NULL));
     NCCLCHECK(ncclTopoIdToIndex(system, NET, netId, &net));
-    if(c == 0) firstNetId = netId;
-    else if(firstNetId == netId) break;
+    if (c == 0) firstNetId = netId;
+    else if (firstNetId == netId) break;
 
     totalNetBw += system->nodes[GPU].nodes[gpu].paths[NET][net].bw;
     netCountByBw++;
-    if(totalNetBw >= gpuBw) break;
+    if (totalNetBw >= gpuBw) break;
   }
   *count = netCountByBw;
   *bw = totalNetBw;
@@ -1888,8 +1939,7 @@ static void getNetDevsPolicyOnce() {
     }
     if (netDevsPolicy == NETDEVS_POLICY_UNDEF)
       INFO(NCCL_ENV, "Unable to recognize NCCL_NETDEVS_POLICY=%s, using NCCL_NETDEVS_POLICY_AUTO instead.", envStr);
-    else
-      INFO(NCCL_ENV, "NCCL_NETDEVS_POLICY set by environment to %s", envStr);
+    else INFO(NCCL_ENV, "NCCL_NETDEVS_POLICY set by environment to %s", envStr);
   }
   if (netDevsPolicy == NETDEVS_POLICY_UNDEF) netDevsPolicy = NETDEVS_POLICY_AUTO;
 }
@@ -1906,14 +1956,15 @@ ncclResult_t ncclTopoGetNetDevsPolicy(enum netDevsPolicy* policy, int* policyNum
   return ncclSuccess;
 }
 
-ncclResult_t ncclTopoGetLocalNetType(struct ncclTopoSystem* system, int type, int rank, int channelId, int64_t* id, int* dev) {
+ncclResult_t ncclTopoGetLocalNetType(struct ncclTopoSystem* system, int type, int rank, int channelId, int64_t* id,
+                                     int* dev) {
   int gpu;
   NCCLCHECK(ncclTopoRankToIndex(system, rank, &gpu, /*showWarn=*/true));
 
   int localNets[NCCL_TOPO_MAX_NODES];
   int localNetCount;
   NCCLCHECK(ncclTopoGetLocal(system, GPU, gpu, type, localNets, &localNetCount, NULL));
-  if (localNetCount==0) {
+  if (localNetCount == 0) {
 #if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
     WARN("Could not find any local path from gpu %d to net.", gpu);
 #endif
@@ -1940,9 +1991,9 @@ ncclResult_t ncclTopoGetLocalNetType(struct ncclTopoSystem* system, int type, in
 
   int net = system->nodes[GPU].nodes[gpu].gpu.dev;
   if (isPow2(localNetCount)) net = mirrorBits(net, localNetCount);
-  net += channelId%(netsPerGpu);
-  if (id) *id = system->nodes[type].nodes[localNets[net%localNetCount]].id;
-  if (dev) *dev = system->nodes[type].nodes[localNets[net%localNetCount]].net.dev;
+  net += channelId % (netsPerGpu);
+  if (id) *id = system->nodes[type].nodes[localNets[net % localNetCount]].id;
+  if (dev) *dev = system->nodes[type].nodes[localNets[net % localNetCount]].net.dev;
   return ncclSuccess;
 }
 ncclResult_t ncclTopoGetLocalNet(struct ncclTopoSystem* system, int rank, int channelId, int64_t* id, int* dev) {
@@ -1953,8 +2004,8 @@ ncclResult_t ncclTopoGetLocalGinDev(struct ncclTopoSystem* system, int rank, int
 }
 
 ncclResult_t ncclTopoGetLocalGinDevs(struct ncclComm* comm, int* localGinDevs, int* localGinCount) {
-  for (int c=0; c<NCCL_TOPO_MAX_NODES; c++) {
-    NCCLCHECK(ncclTopoGetLocalGinDev(comm->topo, comm->rank, c, NULL, localGinDevs+c));
+  for (int c = 0; c < NCCL_TOPO_MAX_NODES; c++) {
+    NCCLCHECK(ncclTopoGetLocalGinDev(comm->topo, comm->rank, c, NULL, localGinDevs + c));
     if (c > 0 && localGinDevs[c] == localGinDevs[0]) {
       *localGinCount = c;
       break;
@@ -1973,10 +2024,10 @@ ncclResult_t ncclTopoGetLocalGpu(struct ncclTopoSystem* system, int64_t netId, i
   NCCLCHECK(ncclTopoGetLocal(system, NET, netIndex, GPU, localGpus, &localGpuCount, NULL));
 
   int foundGpu = -1;
-  for (int c=0; c<MAXCHANNELS; c++) {
-    for (int lg=0; lg<localGpuCount; lg++) {
+  for (int c = 0; c < MAXCHANNELS; c++) {
+    for (int lg = 0; lg < localGpuCount; lg++) {
       int g = localGpus[lg];
-      struct ncclTopoNode* gpu = system->nodes[GPU].nodes+g;
+      struct ncclTopoNode* gpu = system->nodes[GPU].nodes + g;
       int64_t id;
       NCCLCHECK(ncclTopoGetLocalNet(system, gpu->gpu.rank, c, &id, NULL));
       if (netId == id) {
@@ -2004,12 +2055,12 @@ ncclResult_t ncclTopoCpuType(struct ncclTopoSystem* system, int* arch, int* vend
 NCCL_PARAM(IgnoreCpuAffinity, "IGNORE_CPU_AFFINITY", 0);
 
 ncclResult_t ncclTopoGetCpuAffinity(struct ncclTopoSystem* system, int rank, ncclAffinity* affinity) {
-  struct ncclTopoNode* cpu = NULL, *gpu = NULL;
+  struct ncclTopoNode *cpu = NULL, *gpu = NULL;
   int gpuIndex, cpuIndex;
   NCCLCHECK(ncclTopoRankToIndex(system, rank, &gpuIndex, /*showWarn=*/true));
   NCCLCHECK(ncclGetLocalCpu(system, gpuIndex, &cpuIndex));
-  gpu = system->nodes[GPU].nodes+gpuIndex;
-  cpu = system->nodes[CPU].nodes+cpuIndex;
+  gpu = system->nodes[GPU].nodes + gpuIndex;
+  cpu = system->nodes[CPU].nodes + cpuIndex;
 
   // Query the CPU affinity set we were provided
   ncclAffinity mask;
@@ -2067,7 +2118,7 @@ ncclResult_t ncclTopoGetCompCap(struct ncclTopoSystem* system, int* ccMin, int* 
   if (system->nodes[DEV].count == 0) return ncclInternalError;
   int min, max;
   min = max = system->nodes[DEV].nodes[0].dev.cudaCompCap;
-  for (int g=1; g<system->nodes[DEV].count; g++) {
+  for (int g = 1; g < system->nodes[DEV].count; g++) {
     min = std::min(min, system->nodes[DEV].nodes[g].dev.cudaCompCap);
     max = std::max(max, system->nodes[DEV].nodes[g].dev.cudaCompCap);
   }
@@ -2091,16 +2142,15 @@ ncclResult_t ncclCheckMultiRank(struct ncclComm* comm) {
   int firstRankOnHost = -1;
   comm->isMultiRankGpu = false;
 
-  for (int i=0; i<comm->nRanks; i++) {
+  for (int i = 0; i < comm->nRanks; i++) {
     if (comm->peerInfo[i].hostHash == comm->peerInfo[rank].hostHash) {
       if (firstRankOnHost == -1) firstRankOnHost = i;
       int64_t bus = comm->peerInfo[i].busId;
-      for (int j=0; j<numRanksFound; ++j) {
+      for (int j = 0; j < numRanksFound; ++j) {
         if (bus == gpuFoundBusIds[j]) {
           comm->isMultiRankGpu = true;
           if (rank == firstRankOnHost) {
-            INFO(NCCL_INIT, "Detected ranks %d and %d sharing GPU with bus %lX on this node",
-                 gpuFoundRanks[j], i, bus);
+            INFO(NCCL_INIT, "Detected ranks %d and %d sharing GPU with bus %lX on this node", gpuFoundRanks[j], i, bus);
           }
         }
       }
@@ -2115,7 +2165,8 @@ ncclResult_t ncclCheckMultiRank(struct ncclComm* comm) {
     }
   }
 
-  if ((firstRankOnHost == -1 || firstRankOnHost == rank) && comm->isMultiRankGpu && ncclParamMultiRankGpuEnable() == 0) {
+  if ((firstRankOnHost == -1 || firstRankOnHost == rank) && comm->isMultiRankGpu &&
+      ncclParamMultiRankGpuEnable() == 0) {
     WARN("Multiple ranks detected using the same GPU on this node."
          " Set NCCL_MULTI_RANK_GPU_ENABLE=1 to enable this"
          " configuration.");

--- a/projects/rccl/src/graph/topo.h
+++ b/projects/rccl/src/graph/topo.h
@@ -42,7 +42,7 @@
 
 // Intel CPU convert GPU P2P traffic into 64B PCI TLPs, so GPU
 // to GPU traffic consumes more PCI bandwidth.
-#define INTEL_P2P_OVERHEAD(bw) (bw*6/5)
+#define INTEL_P2P_OVERHEAD(bw) (bw * 6 / 5)
 
 #define NCCL_TOPO_NODE_TYPES 8
 #define GPU 0
@@ -79,7 +79,7 @@ struct ncclTopoLink {
 };
 // Allows for up to 32 NICs per node on GB200-NVL72
 #define NCCL_TOPO_MAX_LINKS 576
-#define NCCL_TOPO_MAX_HOPS (NCCL_TOPO_MAX_NODES*NCCL_TOPO_NODE_TYPES)
+#define NCCL_TOPO_MAX_HOPS (NCCL_TOPO_MAX_NODES * NCCL_TOPO_NODE_TYPES)
 
 struct ncclTopoLinkList {
   struct ncclTopoLink* list[NCCL_TOPO_MAX_HOPS];
@@ -96,21 +96,21 @@ struct ncclTopoLinkList {
 #define NCCL_TOPO_LOCAL_NIC_ID(numaid, busid) (((int64_t)numaid << 56) + busid)
 #define NCCL_TOPO_ID(systemid, localid) (((int64_t)systemid << 56) + (localid & NCCL_TOPO_ID_LOCAL_ID_MASK))
 #define NCCL_TOPO_GPU_LOCAL_RANK_SHIFT 40
-#define NCCL_TOPO_GPU_LOCAL_ID(busId, localRankOnDev) ((((uint64_t)(localRankOnDev)) << 40) | ((busId) & ((((uint64_t)1)<<40)-1)))
+#define NCCL_TOPO_GPU_LOCAL_ID(busId, localRankOnDev) \
+  ((((uint64_t)(localRankOnDev)) << 40) | ((busId) & ((((uint64_t)1) << 40) - 1)))
 
-#define RCCL_TOPO_CR8G      1
+#define RCCL_TOPO_CR8G 1
 #define RCCL_TOPO_4P2H_ROME 2
-#define RCCL_TOPO_GDR_ALL   4
-#define RCCL_TOPO_16P1H     8
+#define RCCL_TOPO_GDR_ALL 4
+#define RCCL_TOPO_16P1H 8
 #define RCCL_TOPO_FORCE_INTRA 16
-#define RCCL_TOPO_XGMI_ALL  32
+#define RCCL_TOPO_XGMI_ALL 32
 
 /* Rome preset graph: index into romeTopoModels[] in rome_models.cc, or sentinel below. */
 #define RCCL_ROME_TOPO_PRESET_MODEL_IDX_NONE (-1)
 #define RCCL_ROME_TOPO_PRESET_MODEL_IDX_GIO_COLUMBA (1000000)
 /* parse4H4P() applies rome_model_68 directly; this tags the preset, not romeTopoModels[]. */
 #define RCCL_ROME_TOPO_PRESET_MODEL_IDX_4H4P (1000001)
-
 
 #define GCN_ARCH_NAME_LEN 16
 
@@ -128,14 +128,14 @@ struct ncclTopoNode {
       hipDeviceArch_t arch;
       int cu;
       struct ncclTopoNode* parent; // parent DEV node
-    }gpu;
+    } gpu;
     struct {
       uint64_t device;  // Same as pci.device, a combination of vendor, device, subsystem_vendor and subsystem_device
       int dev; // NVML dev number
       int cudaCompCap;
       int gdrSupport;
       char gcn[GCN_ARCH_NAME_LEN]; // RCCL: GCN arch mirrored from the device's GPU rank, used for XGMI link BW
-    }dev;
+    } dev;
     struct {
       int dev; // Plugin dev number
       uint64_t pciId;
@@ -148,16 +148,16 @@ struct ncclTopoNode {
       int maxChannels;
       int localGpu;
       int64_t busId;
-    }net;
+    } net;
     struct {
       int arch;
       int vendor;
       int model;
       ncclAffinity affinity;
-    }cpu;
+    } cpu;
     struct {
       uint64_t device;
-    }pci;
+    } pci;
   };
   int nlinks;
   struct ncclTopoLink links[NCCL_TOPO_MAX_LINKS];
@@ -241,8 +241,10 @@ ncclResult_t ncclTopoGetFusionEnv(int* mergeLevel, const char** forceMerge);
 #define NCCL_TOPO_XML_MAX_NODES 8192
 #define NCCL_GRAPH_XML_MAX_NODES 8192
 ncclResult_t ncclTopoGetSystemFromXml(struct ncclXml* xml, struct ncclTopoSystem** topoSystem, uint64_t localHostHash);
-ncclResult_t ncclTopoGetGraphFromXml(struct ncclXmlNode *xmlGraphs, struct ncclTopoSystem* system, struct ncclTopoGraph* graph, int* nChannels);
-ncclResult_t ncclTopoGetXmlFromGraphs(int ngraphs, struct ncclTopoGraph** graphs, struct ncclTopoSystem* system, struct ncclXml *xml);
+ncclResult_t ncclTopoGetGraphFromXml(struct ncclXmlNode* xmlGraphs, struct ncclTopoSystem* system,
+                                     struct ncclTopoGraph* graph, int* nChannels);
+ncclResult_t ncclTopoGetXmlFromGraphs(int ngraphs, struct ncclTopoGraph** graphs, struct ncclTopoSystem* system,
+                                      struct ncclXml* xml);
 
 ncclResult_t ncclTopoGetCompCap(struct ncclTopoSystem* system, int* ccMin, int* ccMax);
 ncclResult_t ncclTopoGetMinNetBw(struct ncclTopoSystem* system, int rank, float* bw);
@@ -251,7 +253,7 @@ void rcclApplyTuningOverrides(struct ncclTopoSystem* system);
 
 static ncclResult_t ncclTopoIdToIndex(struct ncclTopoSystem* system, int type, int64_t id, int* index) {
   *index = -1;
-  for (int i=0; i<system->nodes[type].count; i++) {
+  for (int i = 0; i < system->nodes[type].count; i++) {
     if (system->nodes[type].nodes[i].id == id) {
       *index = i;
       return ncclSuccess;
@@ -262,7 +264,7 @@ static ncclResult_t ncclTopoIdToIndex(struct ncclTopoSystem* system, int type, i
 
 static ncclResult_t ncclTopoRankToIndex(struct ncclTopoSystem* system, int rank, int* index, bool showWarn) {
   *index = -1;
-  for (int i=0; i<system->nodes[GPU].count; i++) {
+  for (int i = 0; i < system->nodes[GPU].count; i++) {
     if (system->nodes[GPU].nodes[i].gpu.rank == rank) {
       *index = i;
       return ncclSuccess;
@@ -274,8 +276,9 @@ static ncclResult_t ncclTopoRankToIndex(struct ncclTopoSystem* system, int rank,
 
 static ncclResult_t ncclTopoDevToRank(struct ncclTopoSystem* system, int systemId, int dev, bool warn, int* rank) {
   *rank = -1;
-  for (int i=0; i<system->nodes[GPU].count; i++) {
-    if (NCCL_TOPO_ID_SYSTEM_ID(system->nodes[GPU].nodes[i].id) != systemId) continue; // Only consider GPUs on the given node
+  for (int i = 0; i < system->nodes[GPU].count; i++) {
+    if (NCCL_TOPO_ID_SYSTEM_ID(system->nodes[GPU].nodes[i].id) != systemId)
+      continue; // Only consider GPUs on the given node
     if (system->nodes[GPU].nodes[i].gpu.dev == dev) {
       *rank = system->nodes[GPU].nodes[i].gpu.rank;
       return ncclSuccess;
@@ -289,7 +292,7 @@ extern struct kvDict nicPathKvList[];
 
 static ncclResult_t ncclTopoIdToNetDev(struct ncclTopoSystem* system, int64_t id, int* netDev) {
   *netDev = -1;
-  for (int i=0; i<system->nodes[NET].count; i++) {
+  for (int i = 0; i < system->nodes[NET].count; i++) {
     if (system->nodes[NET].nodes[i].id == id) {
       *netDev = system->nodes[NET].nodes[i].net.dev;
       return ncclSuccess;
@@ -301,37 +304,32 @@ static ncclResult_t ncclTopoIdToNetDev(struct ncclTopoSystem* system, int64_t id
 
 // Returns XGMI speed in GB/s
 static float ncclTopoXGMISpeed(const char* gcn) {
-  if (IsArchMatch(gcn, "gfx90a"))
-    return MI200_XGMI_WIDTH;
-  else if (IsArchMatch(gcn, "gfx942"))
-    return GFX94X_XGMI_WIDTH;
-  else if (IsArchMatch(gcn, "gfx95"))
-    return GFX95X_XGMI_WIDTH;
-  else if (IsArchMatch(gcn, "gfx1250"))
-    return GFX125X_XGMI_WIDTH;
-  else
-    return VEGA_XGMI_WIDTH;
+  if (IsArchMatch(gcn, "gfx90a")) return MI200_XGMI_WIDTH;
+  else if (IsArchMatch(gcn, "gfx942")) return GFX94X_XGMI_WIDTH;
+  else if (IsArchMatch(gcn, "gfx95")) return GFX95X_XGMI_WIDTH;
+  else if (IsArchMatch(gcn, "gfx1250")) return GFX125X_XGMI_WIDTH;
+  else return VEGA_XGMI_WIDTH;
 }
 
 // Returns NVLink bw in GB/s
 static float ncclTopoNVLinkBw(int cudaCompCap) {
-  return
-    cudaCompCap >= 100 ? SM100_NVLINK_BW :
-    cudaCompCap >= 90 ? SM90_NVLINK_BW :
-    cudaCompCap == 86 ? SM86_NVLINK_BW :
-    cudaCompCap >= 80 ? SM80_NVLINK_BW :
-    cudaCompCap >= 70 ? SM70_NVLINK_BW :
-    cudaCompCap >= 60 ? SM60_NVLINK_BW :
-    SM80_NVLINK_BW;
+  return cudaCompCap >= 100 ? SM100_NVLINK_BW :
+         cudaCompCap >= 90  ? SM90_NVLINK_BW :
+         cudaCompCap == 86  ? SM86_NVLINK_BW :
+         cudaCompCap >= 80  ? SM80_NVLINK_BW :
+         cudaCompCap >= 70  ? SM70_NVLINK_BW :
+         cudaCompCap >= 60  ? SM60_NVLINK_BW :
+                              SM80_NVLINK_BW;
 }
 
 // Mirror bits
 static bool isPow2(int val) {
-  return (val & (val-1)) == 0;
+  return (val & (val - 1)) == 0;
 }
 static int mirrorBits(int val, int pow2) {
   int mirror = 0;
-  for (int b=1, mb=(pow2>>1); b<pow2; b<<=1, mb>>=1) if (val & b) mirror |= mb;
+  for (int b = 1, mb = (pow2 >> 1); b < pow2; b <<= 1, mb >>= 1)
+    if (val & b) mirror |= mb;
   return mirror;
 }
 #endif

--- a/projects/rccl/src/graph/trees.cc
+++ b/projects/rccl/src/graph/trees.cc
@@ -7,7 +7,7 @@
 
 #include "nccl.h"
 
-#define RANK_TO_INDEX(r) (rank > root ? rank-1 : rank)
+#define RANK_TO_INDEX(r) (rank > root ? rank - 1 : rank)
 
 /* Btree which alternates leaves and nodes.
  * Assumes root is 0, which conveniently builds a tree on powers of two,
@@ -32,7 +32,7 @@
 ncclResult_t ncclGetBtree(int nranks, int rank, int* u, int* d0, int* d1, int* parentChildType) {
   int up, down0, down1;
   int bit;
-  for (bit=1; bit<nranks; bit<<=1) {
+  for (bit = 1; bit < nranks; bit <<= 1) {
     if (bit & rank) break;
   }
 
@@ -52,15 +52,16 @@ ncclResult_t ncclGetBtree(int nranks, int rank, int* u, int* d0, int* d1, int* p
 
   int lowbit = bit >> 1;
   // down0 is always within bounds
-  down0 = lowbit == 0 ? -1 : rank-lowbit;
+  down0 = lowbit == 0 ? -1 : rank - lowbit;
 
-  down1 = lowbit == 0 ? -1 : rank+lowbit;
+  down1 = lowbit == 0 ? -1 : rank + lowbit;
   // Make sure down1 is within bounds
   while (down1 >= nranks) {
-    down1 = lowbit == 0 ? -1 : rank+lowbit;
+    down1 = lowbit == 0 ? -1 : rank + lowbit;
     lowbit >>= 1;
   }
-  *d0 = down0; *d1 = down1;
+  *d0 = down0;
+  *d1 = down1;
 
   return ncclSuccess;
 }
@@ -86,25 +87,26 @@ ncclResult_t ncclGetBtree(int nranks, int rank, int* u, int* d0, int* d1, int* p
  *    / \     / \     /  \         / \     / \     /  \
  *   1   3   5   7   9   11       2   4   6   8  10   12
  */
-ncclResult_t ncclGetDtree(int nranks, int rank, int* s0, int* d0_0, int* d0_1, int* parentChildType0, int* s1, int* d1_0, int* d1_1, int* parentChildType1) {
+ncclResult_t ncclGetDtree(int nranks, int rank, int* s0, int* d0_0, int* d0_1, int* parentChildType0, int* s1,
+                          int* d1_0, int* d1_1, int* parentChildType1) {
   // First tree ... use a btree
   ncclGetBtree(nranks, rank, s0, d0_0, d0_1, parentChildType0);
   // Second tree ... mirror or shift
   if (nranks % 2 == 1) {
     // shift
-    int shiftrank = (rank-1+nranks) % nranks;
+    int shiftrank = (rank - 1 + nranks) % nranks;
     int u, d0, d1;
     ncclGetBtree(nranks, shiftrank, &u, &d0, &d1, parentChildType1);
-    *s1 = u == -1 ? -1 : (u+1) % nranks;
-    *d1_0 = d0 == -1 ? -1 : (d0+1) % nranks;
-    *d1_1 = d1 == -1 ? -1 : (d1+1) % nranks;
+    *s1 = u == -1 ? -1 : (u + 1) % nranks;
+    *d1_0 = d0 == -1 ? -1 : (d0 + 1) % nranks;
+    *d1_1 = d1 == -1 ? -1 : (d1 + 1) % nranks;
   } else {
     // mirror
     int u, d0, d1;
-    ncclGetBtree(nranks, nranks-1-rank, &u, &d0, &d1, parentChildType1);
-    *s1 = u == -1 ? -1 : nranks-1-u;
-    *d1_0 = d0 == -1 ? -1 : nranks-1-d0;
-    *d1_1 = d1 == -1 ? -1 : nranks-1-d1;
+    ncclGetBtree(nranks, nranks - 1 - rank, &u, &d0, &d1, parentChildType1);
+    *s1 = u == -1 ? -1 : nranks - 1 - u;
+    *d1_0 = d0 == -1 ? -1 : nranks - 1 - d0;
+    *d1_1 = d1 == -1 ? -1 : nranks - 1 - d1;
   }
   return ncclSuccess;
 }

--- a/projects/rccl/src/graph/tuning.cc
+++ b/projects/rccl/src/graph/tuning.cc
@@ -1,4 +1,3 @@
-
 /*************************************************************************
  * Copyright (c) 2016-2022, NVIDIA CORPORATION. All rights reserved.
  * Modifications Copyright (c) 2019-2022 Advanced Micro Devices, Inc. All rights reserved.
@@ -19,13 +18,13 @@ static int getNthreads(const char* name, int env, int min, int max, int def, int
   int nt = env;
   if (nt > 0) {
     if (nt % WarpSize != 0) {
-      INFO(NCCL_GRAPH|NCCL_ENV, "Invalid %s %d (must be a multiple of %d)", name, nt, WarpSize);
+      INFO(NCCL_GRAPH | NCCL_ENV, "Invalid %s %d (must be a multiple of %d)", name, nt, WarpSize);
       nt = max;
     } else if (nt > max) {
-      INFO(NCCL_GRAPH|NCCL_ENV, "Invalid %s %d (maximum %d).", name, nt, max);
+      INFO(NCCL_GRAPH | NCCL_ENV, "Invalid %s %d (maximum %d).", name, nt, max);
       nt = max;
     } else if (nt < min) {
-      INFO(NCCL_GRAPH|NCCL_ENV, "Invalid %s %d (minimum %d).", name, nt, min);
+      INFO(NCCL_GRAPH | NCCL_ENV, "Invalid %s %d (minimum %d).", name, nt, min);
       nt = min;
     }
   } else {
@@ -53,7 +52,8 @@ static int getNthreads(const char* name, int env, int min, int max, int def, int
 //
 //     NCCL_PROTO="^LL128;allreduce:LL128"
 // Enable everything but LL128, but only LL128 for allreduce.
-ncclResult_t parseList(const char* str, const char* prefixElems[], int nprefixes, const char* elems[], int nelems, int* list) {
+ncclResult_t parseList(const char* str, const char* prefixElems[], int nprefixes, const char* elems[], int nelems,
+                       int* list) {
   ncclResult_t ret = ncclSuccess;
   char* fullStr = strdup(str);
   char* tmpFullStr;
@@ -80,29 +80,32 @@ ncclResult_t parseList(const char* str, const char* prefixElems[], int nprefixes
 
     int unset, set;
     if (elemList[0] == '^') {
-      unset = 1; set = 0; elemList++;
+      unset = 1;
+      set = 0;
+      elemList++;
     } else {
-      unset = 0; set = 1;
+      unset = 0;
+      set = 1;
     }
 
     bool foundPrefix = false;
-    for (int p=0; p<nprefixes; p++) {
+    for (int p = 0; p < nprefixes; p++) {
       if (prefix && strcasecmp(prefix, prefixElems[p]) != 0) continue;
       foundPrefix = true;
-      for (int e=0; e<nelems; e++) list[p*nelems+e] = unset;
+      for (int e = 0; e < nelems; e++) list[p * nelems + e] = unset;
 
       tokStr = strdup(elemList);
       char* tmpStr;
       char* elem = strtok_r(tokStr, ",", &tmpStr);
       while (elem) {
         int e;
-        for (e=0; e<nelems; e++) {
+        for (e = 0; e < nelems; e++) {
           if (strcasecmp(elem, elems[e]) == 0) {
-            list[p*nelems+e] = set;
+            list[p * nelems + e] = set;
             break;
           }
         }
-        if (e==nelems) {
+        if (e == nelems) {
           WARN("Unrecognized element token \"%s\" when parsing \"%s\"", elem, str);
           ret = ncclInvalidUsage;
           goto fail;
@@ -134,10 +137,11 @@ fail:
 
 // Latencies in us, Bandwidths in GB/s
 // Tree { LL, LL128, Simple } , Ring { LL, LL128, Simple }
-static const float baseLat  [NCCL_NUM_ALGORITHMS][NCCL_NUM_PROTOCOLS] = {
-      { 12.0, 12.0, 17.0 }, { 12.0, 12.0, 17.0 },   // Tree, Ring
-      { 12.0, 12.0, 17.0 }, { 12.0, 12.0, 17.0 },   // Collnet Direct, Chain
-      {    0,    0,    0 }, {    0,    0,    0 }};  // NVLS, NVLS Tree
+static const float baseLat[NCCL_NUM_ALGORITHMS][NCCL_NUM_PROTOCOLS] = {
+  {12.0, 12.0, 17.0}, {12.0, 12.0, 17.0},   // Tree, Ring
+  {12.0, 12.0, 17.0}, {12.0, 12.0, 17.0},   // Collnet Direct, Chain
+  {0, 0, 0},          {0, 0, 0}
+};  // NVLS, NVLS Tree
 
 // NVLink, PCI, Network
 #define NCCL_HW_NVLINK 0
@@ -149,8 +153,8 @@ static const float baseLat  [NCCL_NUM_ALGORITHMS][NCCL_NUM_PROTOCOLS] = {
 #define RCCL_FACTOR_TABLE_MAX_INDEX (RCCL_FACTOR_TABLE_SIZE - 1)
 #endif
 struct tuningModel {
-  float hwLat [3][NCCL_NUM_ALGORITHMS][NCCL_NUM_PROTOCOLS];
-  float bwRatio [2][NCCL_NUM_ALGORITHMS][NCCL_NUM_PROTOCOLS];
+  float hwLat[3][NCCL_NUM_ALGORITHMS][NCCL_NUM_PROTOCOLS];
+  float bwRatio[2][NCCL_NUM_ALGORITHMS][NCCL_NUM_PROTOCOLS];
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
   float treeCorrectionFactor[NCCL_NUM_PROTOCOLS][RCCL_FACTOR_TABLE_SIZE];
   float ringCorrectionFactor[NCCL_NUM_PROTOCOLS][RCCL_FACTOR_TABLE_SIZE];
@@ -159,428 +163,849 @@ struct tuningModel {
   float ringCorrectionFactor[NCCL_NUM_PROTOCOLS][27];
 #endif
   uint64_t llProtoRanges[RCCL_TUNABLE_COLLS][NCCL_NUM_PROTOCOLS - 1][RCCL_PROTOCOL_ENTRY_SIZE];
-  uint64_t channelThresholds[RCCL_TUNABLE_COLLS][RCCL_CHANNELS_TUNABLE_ENTRIES][3]; //for each collective, set for 5 channel-counts: 2,4,8,16,32,40,48,56,64, {min,max,nchannels}
+  uint64_t
+    channelThresholds[RCCL_TUNABLE_COLLS][RCCL_CHANNELS_TUNABLE_ENTRIES]
+                     [3]; // for each collective, set for 5 channel-counts: 2,4,8,16,32,40,48,56,64, {min,max,nchannels}
 };
 
-
-static struct tuningModel tuning_model_0 {
-  .hwLat = {
-    /* NVLINK */
-    { /* Tree (LL/LL128/Simple)*/ { 0.8, 1.4, 2.5 }, /* Ring (LL/LL128/Simple)*/ { 0.8, 2.2, 3.6 }, /* CollNetDirect (Simple)*/ { 0.0, 0.0, 0.8 }, /* CollNetChain (Simple)*/ { 0.0, 0.0, 1.4 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 3.6} },
-    /* PCI */
-    { /* Tree (LL/LL128/Simple)*/ { 2.2, 2.2, 5.7 }, /* Ring (LL/LL128/Simple)*/ { 2.2, 2.2, 5.7 }, /* CollNetDirect (Simple)*/ { 0.0, 0.0, 5.7 }, /* CollNetChain (Simple)*/ { 0.0, 0.0, 5.7 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 5.7} },
-    /* NET */
-    { /* Tree (LL/LL128/Simple)*/ { 11.8, 18.2, 20.8 }, /* Ring (LL/LL128/Simple)*/ { 9.5, 19.8, 15.1 }, /* CollNetDirect (Simple)*/ { 0.0, 0.0, 11.8 }, /* CollNetChain (Simple)*/ { 0.0, 0.0, 18.2 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 15.1} },
-  },
-
-  .bwRatio = {
-    /* 2 nodes */
-    { /* Tree (LL/LL128/Simple)*/ { 0.04, 0.22, 0.91 }, /* Ring (LL/LL128/Simple)*/ { 0.04, 0.34, 1.00 }, /* CollNetDirect (Simple)*/ { 0.00, 0.00, 1.00 }, /* CollNetChain (Simple)*/ { 0.00, 0.00, 1.00 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 0} },
-    /* more than 2 nodes */
-    { /* Tree (LL/LL128/Simple)*/ { 0.04, 0.22, 0.95 }, /* Ring (LL/LL128/Simple)*/ { 0.04, 0.34, 1.00 }, /* CollNetDirect (Simple)*/ { 0.00, 0.00, 1.00 }, /* CollNetChain (Simple)*/ { 0.00, 0.00, 1.00 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 1.00} },
-  },
-
-  .treeCorrectionFactor = {
-    { 0.1, 0.2, 0.1, 0.1, 0.9, 0.3, 0.4, 0.1, 0.2, 0.4, 0.2, 0.1, 0.3, 0.3, 0.2, 0.2, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, },
-    { 0.1, 0.3, 1.0, 0.1, 0.5, 1.0, 0.9, 1.0, 1.0, 1.0, 0.3, 0.1, 0.4, 0.5, 0.5, 0.4, 0.4, 0.3, 0.3, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, },
-    { 0.2, 1.0, 0.1, 0.1, 0.7, 0.2, 0.4, 0.1, 0.1, 0.3, 0.4, 0.3, 0.6, 0.8, 1.0, 1.0, 1.0, 1.0, 0.9, 0.8, 0.8, 0.8, 0.8, 0.8, 0.9, 0.9, 0.9, },
-  },
-
-  .ringCorrectionFactor = {
-    { 0.1, 0.1, 0.1, 0.1, 0.1, 0.2, 0.4, 0.2, 0.3, 0.5, 0.3, 0.1, 0.5, 0.5, 0.3, 0.2, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, },
-    { 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.3, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.8, 0.7, 0.5, 0.4, 0.4, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, },
-    { 1.0, 0.8, 0.2, 1.0, 1.0, 0.3, 1.0, 0.1, 0.1, 0.2, 0.2, 0.1, 0.5, 1.0, 0.8, 0.8, 1.0, 0.9, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, },
-  },
-
-  .llProtoRanges = {{{RCCL_LL_LIMITS_UNDEFINED}}},
-  .channelThresholds  = {{{CHAN_THRESHOLDS_UNDEFINED}}},
-};
-
-static struct tuningModel tuning_model_1 {
+static struct tuningModel tuning_model_0{
   .hwLat =
-  { /* NVLINK */
-    { /* Tree (LL/LL128/Simple)*/ { 1.5, 1.5, 4.5 }, /* Ring (LL/LL128/Simple)*/ { 1.5, 1.5, 4.5 }, /* CollNetDirect (Simple)*/ { 0.0, 0.0, 4.5 }, /* CollNetChain (Simple)*/ { 0.0, 0.0, 4.5 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 0} },
-    /* PCI */
-    { /* Tree (LL/LL128/Simple)*/ { 2.2, 2.2, 5.7 }, /* Ring (LL/LL128/Simple)*/ { 2.2, 2.2, 5.7 }, /* CollNetDirect (Simple)*/ { 0.0, 0.0, 5.7 }, /* CollNetChain (Simple)*/ { 0.0, 0.0, 5.7 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 0} },
-    /* NET */
-    { /* Tree (LL/LL128/Simple)*/ { 33.0, 33.0, 15.8 }, /* Ring (LL/LL128/Simple)*/ { 5.1, 5.1, 68.8 }, /* CollNetDirect (Simple)*/ { 0.0, 0.0, 15.8 }, /* CollNetChain (Simple)*/ { 0.0, 0.0, 15.8 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 0} },
-  },
+    {
+      /* NVLINK */
+      {/* Tree (LL/LL128/Simple)*/ {0.8, 1.4, 2.5}, /* Ring (LL/LL128/Simple)*/ {0.8, 2.2, 3.6},
+       /* CollNetDirect (Simple)*/ {0.0, 0.0, 0.8}, /* CollNetChain (Simple)*/ {0.0, 0.0, 1.4}, /* NVLS */ {0, 0, 0},
+       /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 3.6}},
+      /* PCI */
+      {/* Tree (LL/LL128/Simple)*/ {2.2, 2.2, 5.7}, /* Ring (LL/LL128/Simple)*/ {2.2, 2.2, 5.7},
+       /* CollNetDirect (Simple)*/ {0.0, 0.0, 5.7}, /* CollNetChain (Simple)*/ {0.0, 0.0, 5.7}, /* NVLS */ {0, 0, 0},
+       /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 5.7}},
+      /* NET */
+      {/* Tree (LL/LL128/Simple)*/ {11.8, 18.2, 20.8}, /* Ring (LL/LL128/Simple)*/ {9.5, 19.8, 15.1},
+       /* CollNetDirect (Simple)*/ {0.0, 0.0, 11.8}, /* CollNetChain (Simple)*/ {0.0, 0.0, 18.2}, /* NVLS */ {0, 0, 0},
+       /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 15.1}},
+    },
 
   .bwRatio =
-  { /* 2 nodes */
-    { /* Tree (LL/LL128/Simple)*/ { 0.12, 1.00, 0.99 }, /* Ring (LL/LL128/Simple)*/ { 0.12, 1.00, 1.00 }, /* CollNetDirect (Simple)*/ { 0.00, 0.00, 1.00 }, /* CollNetChain (Simple)*/ { 0.00, 0.00, 1.00 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 0} },
-    /* more than 2 nodes */
-    { /* Tree (LL/LL128/Simple)*/ { 0.15, 1.00, 0.42 }, /* Ring (LL/LL128/Simple)*/ { 0.20, 1.00, 1.00 }, /* CollNetDirect (Simple)*/ { 0.00, 0.00, 1.00 }, /* CollNetChain (Simple)*/ { 0.00, 0.00, 1.00 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 0} },
-  },
+    {
+      /* 2 nodes */
+      {/* Tree (LL/LL128/Simple)*/ {0.04, 0.22, 0.91}, /* Ring (LL/LL128/Simple)*/ {0.04, 0.34, 1.00},
+       /* CollNetDirect (Simple)*/ {0.00, 0.00, 1.00}, /* CollNetChain (Simple)*/ {0.00, 0.00, 1.00},
+       /* NVLS */ {0, 0, 0}, /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 0}},
+      /* more than 2 nodes */
+      {/* Tree (LL/LL128/Simple)*/ {0.04, 0.22, 0.95}, /* Ring (LL/LL128/Simple)*/ {0.04, 0.34, 1.00},
+       /* CollNetDirect (Simple)*/ {0.00, 0.00, 1.00}, /* CollNetChain (Simple)*/ {0.00, 0.00, 1.00},
+       /* NVLS */ {0, 0, 0}, /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 1.00}},
+    },
 
-  .treeCorrectionFactor = {
-    { 0.5, 0.4, 0.7, 0.6, 1.0, 1.0, 0.5, 0.4, 0.1, 0.5, 0.4, 0.6, 1.0, 1.0, 1.0, 1.0, 1.0, 0.8, 0.6, 0.5, 0.4, 0.4, 0.3, 0.2, 0.1, 0.1, 0.1, },
-    { 0.5, 0.4, 0.7, 0.6, 1.0, 1.0, 0.5, 0.4, 0.1, 0.5, 0.4, 0.6, 1.0, 1.0, 1.0, 1.0, 1.0, 0.8, 0.6, 0.5, 0.4, 0.4, 0.3, 0.2, 0.1, 0.1, 0.1, },
-    { 0.1, 0.1, 0.1, 0.1, 0.1, 0.3, 0.4, 0.5, 0.1, 0.6, 1.0, 1.0, 1.0, 0.6, 0.5, 0.7, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.7, 0.5, 0.3, 0.3, },
-  },
+  .treeCorrectionFactor =
+    {
+      {
+        0.1, 0.2, 0.1, 0.1, 0.9, 0.3, 0.4, 0.1, 0.2, 0.4, 0.2, 0.1, 0.3, 0.3,
+        0.2, 0.2, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1,
+      },
+      {
+        0.1, 0.3, 1.0, 0.1, 0.5, 1.0, 0.9, 1.0, 1.0, 1.0, 0.3, 0.1, 0.4, 0.5,
+        0.5, 0.4, 0.4, 0.3, 0.3, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2,
+      },
+      {
+        0.2, 1.0, 0.1, 0.1, 0.7, 0.2, 0.4, 0.1, 0.1, 0.3, 0.4, 0.3, 0.6, 0.8,
+        1.0, 1.0, 1.0, 1.0, 0.9, 0.8, 0.8, 0.8, 0.8, 0.8, 0.9, 0.9, 0.9,
+      },
+    },
 
-  .ringCorrectionFactor = {
-    { 1.0, 0.5, 1.0, 1.0, 0.6, 0.7, 1.0, 1.0, 0.2, 1.0, 0.9, 0.7, 1.0, 1.0, 1.0, 0.9, 0.9, 0.8, 0.8, 0.7, 0.6, 0.5, 0.5, 0.3, 0.2, 0.1, 0.1, },
-    { 1.0, 0.5, 1.0, 1.0, 0.6, 0.7, 1.0, 1.0, 0.2, 1.0, 0.9, 0.7, 1.0, 1.0, 1.0, 0.9, 0.9, 0.8, 0.8, 0.7, 0.6, 0.5, 0.5, 0.3, 0.2, 0.1, 0.1, },
-    { 0.3, 1.0, 0.3, 0.1, 0.1, 0.1, 0.3, 0.7, 1.0, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.2, 0.3, 0.5, 0.9, 1.0, 1.0, 1.0, 1.0, },
-  },
-
-  .llProtoRanges = {{{RCCL_LL_LIMITS_UNDEFINED}}},
-  .channelThresholds  = {{{CHAN_THRESHOLDS_UNDEFINED}}},
-};
-
-static struct tuningModel tuning_model_2 {
-  .hwLat = {
-    /* NVLINK */
-    { /* Tree (LL/LL128/Simple)*/ { 1.5, 1.5, 4.5 }, /* Ring (LL/LL128/Simple)*/ { 1.5, 1.5, 4.5 }, /* CollNetDirect (Simple)*/ { 0.0, 0.0, 4.5 }, /* CollNetChain (Simple)*/ { 0.0, 0.0, 4.5 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 0} },
-    /* PCI */
-    { /* Tree (LL/LL128/Simple)*/ { 2.2, 2.2, 5.7 }, /* Ring (LL/LL128/Simple)*/ { 2.2, 2.2, 5.7 }, /* CollNetDirect (Simple)*/ { 0.0, 0.0, 5.7 }, /* CollNetChain (Simple)*/ { 0.0, 0.0, 5.7 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 0} },
-    /* NET */
-    { /* Tree (LL/LL128/Simple)*/ { 27.9, 27.9, 15.8 }, /* Ring (LL/LL128/Simple)*/ { 12.1, 12.1, 68.8 }, /* CollNetDirect (Simple)*/ { 0.0, 0.0, 15.8 }, /* CollNetChain (Simple)*/ { 0.0, 0.0, 15.8 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 0} },
-  },
-
-  .bwRatio = {
-    /* 2 nodes */
-    { /* Tree (LL/LL128/Simple)*/ { 0.07, 1.00, 0.99 }, /* Ring (LL/LL128/Simple)*/ { 0.08, 1.00, 1.00 }, /* CollNetDirect (Simple)*/ { 0.00, 0.00, 1.00 }, /* CollNetChain (Simple)*/ { 0.00, 0.00, 1.00 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 0} },
-    /* more than 2 nodes */
-    { /* Tree (LL/LL128/Simple)*/ { 0.07, 1.00, 0.42 }, /* Ring (LL/LL128/Simple)*/ { 0.08, 1.00, 1.00 }, /* CollNetDirect (Simple)*/ { 0.00, 0.00, 1.00 }, /* CollNetChain (Simple)*/ { 0.00, 0.00, 1.00 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 0} },
-  },
-
-  .treeCorrectionFactor = {
-    { 0.1, 0.4, 0.3, 0.3, 0.2, 0.4, 0.5, 0.1, 0.1, 0.6, 0.7, 0.7, 0.8, 1.0, 0.9, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, },
-    { 0.1, 0.4, 0.3, 0.3, 0.2, 0.4, 0.5, 0.1, 0.1, 0.6, 0.7, 0.7, 0.8, 1.0, 0.9, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, },
-    { 1.0, 0.1, 0.1, 0.1, 0.1, 0.2, 0.3, 0.5, 0.1, 0.6, 0.9, 0.8, 0.7, 0.9, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.7, 0.9, 0.9, 1.0, 1.0, 1.0, },
-  },
-
-  .ringCorrectionFactor = {
-    { 0.1, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.4, 1.0, 1.0, 1.0, 1.0, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, },
-    { 0.1, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.4, 1.0, 1.0, 1.0, 1.0, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, },
-    { 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 0.2, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.2, 0.4, 0.5, 0.6, 0.9, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, },
-  },
+  .ringCorrectionFactor =
+    {
+      {
+        0.1, 0.1, 0.1, 0.1, 0.1, 0.2, 0.4, 0.2, 0.3, 0.5, 0.3, 0.1, 0.5, 0.5,
+        0.3, 0.2, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1,
+      },
+      {
+        0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.3, 1.0, 1.0, 1.0, 1.0,
+        1.0, 1.0, 0.8, 0.7, 0.5, 0.4, 0.4, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3,
+      },
+      {
+        1.0, 0.8, 0.2, 1.0, 1.0, 0.3, 1.0, 0.1, 0.1, 0.2, 0.2, 0.1, 0.5, 1.0,
+        0.8, 0.8, 1.0, 0.9, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+      },
+    },
 
   .llProtoRanges = {{{RCCL_LL_LIMITS_UNDEFINED}}},
-  .channelThresholds  = {{{CHAN_THRESHOLDS_UNDEFINED}}},
-};
-
-static struct tuningModel tuning_model_3 {
-  .hwLat = {
-    /* NVLINK */
-    { /* Tree (LL/LL128/Simple)*/ { 0.8, 0.0, 2.5 }, /* Ring (LL/LL128/Simple)*/ { 0.8, 0.0, 3.6 }, /* CollNetDirect (Simple)*/ { 0.0, 0.0, 0.8 }, /* CollNetChain (Simple)*/ { 0.0, 0.0, 0.0 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 0} },
-    /* PCI */
-    { /* Tree (LL/LL128/Simple)*/ { 2.2, 2.2, 5.7 }, /* Ring (LL/LL128/Simple)*/ { 2.2, 2.2, 5.7 }, /* CollNetDirect (Simple)*/ { 0.0, 0.0, 5.7 }, /* CollNetChain (Simple)*/ { 0.0, 0.0, 5.7 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 0} },
-    /* NET */
-    { /* Tree (LL/LL128/Simple)*/ { 12.5, 0.0, 22.4 }, /* Ring (LL/LL128/Simple)*/ { 9.5, 0.0, 19.8 }, /* CollNetDirect (Simple)*/ { 0.0, 0.0, 12.5 }, /* CollNetChain (Simple)*/ { 0.0, 0.0, 0.0 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 0} },
-  },
-
-  .bwRatio = {
-    /* 2 nodes */
-    { /* Tree (LL/LL128/Simple)*/ { 0.20, 0.00, 1.75 }, /* Ring (LL/LL128/Simple)*/ { 0.20, 0.00, 1.00 }, /* CollNetDirect (Simple)*/ { 0.00, 0.00, 1.00 }, /* CollNetChain (Simple)*/ { 0.00, 0.00, 1.00 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 0} },
-    /* more than 2 nodes */
-    { /* Tree (LL/LL128/Simple)*/ { 0.20, 0.00, 0.96 }, /* Ring (LL/LL128/Simple)*/ { 0.20, 0.00, 1.00 }, /* CollNetDirect (Simple)*/ { 0.00, 0.00, 1.00 }, /* CollNetChain (Simple)*/ { 0.00, 0.00, 1.00 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 0} },
-  },
-
-  .treeCorrectionFactor = {
-    { 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 1.0, 0.2, 1.0, 0.9, 1.0, 0.6, 0.4, 0.6, 0.4, 0.3, 0.3, 0.3, 0.3, 0.3, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, },
-    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, },
-    { 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.1, 0.1, 0.1, 0.2, 1.0, 0.8, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.8, 0.7, 0.8, 0.9, 0.7, 0.7, },
-  },
-
-  .ringCorrectionFactor = {
-    { 0.1, 0.1, 0.1, 0.1, 0.1, 0.3, 0.1, 0.2, 0.1, 0.4, 0.4, 0.2, 0.2, 0.3, 0.7, 0.5, 0.4, 0.3, 0.3, 0.3, 0.3, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, },
-    { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, },
-    { 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.5, 1.0, 0.1, 0.3, 0.1, 0.1, 0.1, 0.2, 0.2, 0.2, 0.3, 0.4, 0.7, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, },
-  },
-
-  .llProtoRanges = {{{RCCL_LL_LIMITS_UNDEFINED}}},
-  .channelThresholds  = {{{CHAN_THRESHOLDS_UNDEFINED}}},
-};
-
-static struct tuningModel tuning_model_4 {
-  .hwLat = {
-    /* NVLINK */
-    { /* Tree (LL/LL128/Simple)*/ { 0.8, 1.4, 2.5 }, /* Ring (LL/LL128/Simple)*/ { 0.8, 2.2, 3.6 }, /* CollNetDirect (Simple)*/ { 0.8, 1.4, 2.5 }, /* CollNetChain (Simple)*/ { 0.8, 1.4, 2.5 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 0} },
-    /* PCI */
-    { /* Tree (LL/LL128/Simple)*/ { 2.2, 2.2, 5.7 }, /* Ring (LL/LL128/Simple)*/ { 2.2, 2.2, 5.7 }, /* CollNetDirect (Simple)*/ { 0.0, 0.0, 5.7 }, /* CollNetChain (Simple)*/ { 0.0, 0.0, 5.7 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 0} },
-    /* NET */
-    { /* Tree (LL/LL128/Simple)*/ { 32.2, 34.4, 47.6 }, /* Ring (LL/LL128/Simple)*/ { 35.4, 87.8, 209.2 }, /* CollNetDirect (Simple)*/ { 0.0, 0.0, 47.6 }, /* CollNetChain (Simple)*/ { 0.0, 0.0, 47.6 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 0} },
-  },
-
-  .bwRatio = {
-    /* 2 nodes */
-    { /* Tree (LL/LL128/Simple)*/ { 0.16, 1.09, 1.61 }, /* Ring (LL/LL128/Simple)*/ { 0.15, 0.41, 1.00 }, /* CollNetDirect (Simple)*/ { 0.00, 0.00, 1.00 }, /* CollNetChain (Simple)*/ { 0.00, 0.00, 1.00 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 0} },
-    /* more than 2 nodes */
-    { /* Tree (LL/LL128/Simple)*/ { 0.16, 1.09, 1.08 }, /* Ring (LL/LL128/Simple)*/ { 0.15, 0.41, 1.00 }, /* CollNetDirect (Simple)*/ { 0.00, 0.00, 1.00 }, /* CollNetChain (Simple)*/ { 0.00, 0.00, 1.00 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 0} },
-  },
-
-  .treeCorrectionFactor = {
-    { 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 0.1, 0.1, 0.2, 0.4, 0.6, 0.5, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, },
-    { 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.2, 0.1, 0.1, 0.2, 1.0, 0.5, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, },
-    { 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.8, 0.4, 0.3, 0.3, 0.1, 0.1, 1.0, 1.0, 0.7, 0.5, 0.6, 0.5, 0.6, 0.6, 0.5, 0.6, 0.6, 0.6, 0.7, },
-  },
-
-  .ringCorrectionFactor = {
-    { 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.2, 0.2, 0.1, 0.3, 0.1, 0.1, 0.1, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, },
-    { 0.4, 0.5, 0.5, 0.4, 0.4, 0.4, 0.4, 0.2, 0.2, 0.1, 0.3, 1.0, 1.0, 0.7, 0.8, 0.5, 1.0, 1.0, 1.0, 1.0, 1.0, 0.9, 0.8, 0.5, 0.4, 0.3, 0.3, },
-    { 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 1.0, 0.8, 0.5, 0.1, 0.7, 0.2, 0.4, 0.4, 0.6, 0.7, 0.9, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, },
-  },
-
-  .llProtoRanges = {{{RCCL_LL_LIMITS_UNDEFINED}}},
-  .channelThresholds  = {{{CHAN_THRESHOLDS_UNDEFINED}}},
-};
-
-static struct tuningModel tuning_model_5 {
-  .hwLat = {
-    /* NVLINK */
-    { /* Tree (LL/LL128/Simple)*/ { 0.9, 0.9, 2.3 }, /* Ring (LL/LL128/Simple)*/ { 0.8, 0.8, 2.1 }, /* CollNetDirect (Simple)*/ { 0.0, 0.0, 0.9 }, /* CollNetChain (Simple)*/ { 0.0, 0.0, 0.0 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 0} },
-    /* PCI */
-    { /* Tree (LL/LL128/Simple)*/ { 2.2, 2.2, 5.7 }, /* Ring (LL/LL128/Simple)*/ { 2.2, 2.2, 5.7 }, /* CollNetDirect (Simple)*/ { 0.0, 0.0, 5.7 }, /* CollNetChain (Simple)*/ { 0.0, 0.0, 5.7 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 5.7} },
-    /* NET */
-    { /* Tree (LL/LL128/Simple)*/ { 10.5, 10.5, 25.0 }, /* Ring (LL/LL128/Simple)*/ { 9.5, 9.5, 320.0 }, /* CollNetDirect (Simple)*/ { 0.0, 0.0, 10.5 }, /* CollNetChain (Simple)*/ { 0.0, 0.0, 0.0 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 320.0} },
-  },
-
-  .bwRatio = {
-    /* 2 nodes */
-    { /* Tree (LL/LL128/Simple)*/ { 0.06, 0.06, 0.11 }, /* Ring (LL/LL128/Simple)*/ { 0.08, 0.08, 1.00 }, /* CollNetDirect (Simple)*/ { 0.00, 0.00, 1.00 }, /* CollNetChain (Simple)*/ { 0.00, 0.00, 1.00 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 0} },
-    /* more than 2 nodes */
-    { /* Tree (LL/LL128/Simple)*/ { 0.06, 0.06, 0.59 }, /* Ring (LL/LL128/Simple)*/ { 0.08, 0.08, 1.00 }, /* CollNetDirect (Simple)*/ { 0.00, 0.00, 1.00 }, /* CollNetChain (Simple)*/ { 0.00, 0.00, 1.00 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 1.00} },
-  },
-
-  .treeCorrectionFactor = {                                                                    /*16M 32M  64M  128M 256M 512M  1G   2G  4G */
-    { 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 1.0, 1.0, 1.0, 1.0, 0.6, 1.0, 0.9, 1.0, 1.0, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, },
-    { 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 1.0, 1.0, 1.0, 1.0, 0.6, 1.0, 0.9, 1.0, 1.0, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, },
-    { 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.7, 1.0, 1.0, 1.0, 1.0, 1.0, 0.7, 0.7, 0.5, 0.6, 0.6, 0.6, },
-  },
-
-  .ringCorrectionFactor = {
-    { 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 0.2, 1.0, 0.4, 0.4, 0.1, 0.2, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, },
-    { 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 0.2, 1.0, 0.4, 0.4, 0.1, 0.2, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, },
-    { 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.7, 0.2, 1.0, 1.0, 1.0, },
-  },
-  // Follow order in RcclTunableColls
-  .llProtoRanges = {
-    /*ReduceScatter*/
-    {/*LL (min/max/factor/thread_threshold)*/ {0, 655360, 1, 16}, /*LL64/128 (min/max/factor/thread_threshold)*/ {131072, 3211264, 1, 64}},
-    /*AllGather*/
-    {/*LL (min/max/factor/thread_threshold)*/ {0, 98304,  1, 16}, /*LL64/128 (min/max/factor/thread_threshold)*/ {98304, 5046272, 1, 64}},
-    /*AllReduce*/
-    {/*LL (min/max/factor/thread_threshold)*/ {0, 524288, 1, 0},/*LL64/128 (min/max/factor/thread_threshold)*/ {524288, 4415057, 3145728, 0}},
-    /*Reduce*/
-    {/*LL (min/max/factor/thread_threshold)*/ {0, 4096, 1, 0},/*LL64/128 (min/max/factor/thread_threshold)*/ {4096, 16777216, 1, 0}},
-    /*Broadcast*/
-    {/*LL (min/max/factor/thread_threshold)*/ {0, 8192, 1, 0},/*LL64/128 (min/max/factor/thread_threshold)*/ {8192, 33554432, 1, 0}},
-  },
-
-  .channelThresholds  = {{{CHAN_THRESHOLDS_UNDEFINED}}},
-
-};
-
-static struct tuningModel tuning_model_6 {
-  .hwLat = {
-    /* NVLINK */
-    { /* Tree (LL/LL128/Simple)*/ { 0.9, 0.9, 2.3 }, /* Ring (LL/LL128/Simple)*/ { 0.8, 0.8, 2.1 }, /* CollNetDirect (Simple)*/ { 0.0, 0.0, 0.9 }, /* CollNetChain (Simple)*/ { 0.0, 0.0, 0.0 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 0} },
-    /* PCI */
-    { /* Tree (LL/LL128/Simple)*/ { 2.2, 2.2, 5.7 }, /* Ring (LL/LL128/Simple)*/ { 2.2, 2.2, 5.7 }, /* CollNetDirect (Simple)*/ { 0.0, 0.0, 5.7 }, /* CollNetChain (Simple)*/ { 0.0, 0.0, 5.7 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 5.7} },
-    /* NET */
-    { /* Tree (LL/LL128/Simple)*/ { 10.5, 10.5, 25.0 }, /* Ring (LL/LL128/Simple)*/ { 9.5, 9.5, 320.0 }, /* CollNetDirect (Simple)*/ { 0.0, 0.0, 10.5 }, /* CollNetChain (Simple)*/ { 0.0, 0.0, 0.0 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 320.0} },
-  },
-
-  .bwRatio = {
-    /* 2 nodes */
-    { /* Tree (LL/LL128/Simple)*/ { 0.06, 0.06, 0.11 }, /* Ring (LL/LL128/Simple)*/ { 0.08, 0.08, 1.00 }, /* CollNetDirect (Simple)*/ { 0.00, 0.00, 1.00 }, /* CollNetChain (Simple)*/ { 0.00, 0.00, 1.00 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 0} },
-    /* more than 2 nodes */
-    { /* Tree (LL/LL128/Simple)*/ { 0.06, 0.06, 0.59 }, /* Ring (LL/LL128/Simple)*/ { 0.08, 0.08, 1.00 }, /* CollNetDirect (Simple)*/ { 0.00, 0.00, 1.00 }, /* CollNetChain (Simple)*/ { 0.00, 0.00, 1.00 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 1.00} },
-  },
-
-  .treeCorrectionFactor = {                                                                    /*16M 32M  64M  128M 256M 512M  1G   2G  4G */
-    { 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 1.0, 1.0, 1.0, 1.0, 0.6, 1.0, 0.9, 1.0, 1.0, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, },
-    { 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 1.0, 1.0, 1.0, 1.0, 0.6, 1.0, 0.9, 1.0, 1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 1.0, 0.1, 0.9, 0.9, 0.1, 0.1, },
-    { 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.7, 1.0, 0.1, 0.1, 0.1, 0.1, 0.1, 0.7, 0.15, 0.6, 0.7, 0.6, },
-  },
-
-  .ringCorrectionFactor = {
-    { 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 0.2, 1.0, 0.4, 0.4, 0.1, 0.2, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, },
-    { 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 0.2, 1.0, 0.4, 0.4, 0.1, 0.2, 0.1, 0.1, 0.1, 0.1, 5.5, 0.1, 0.1, 1.0, 1.0, },
-    { 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.9, 0.1, 1.0, 0.1, 0.6, 1.0, 1.0, },
-  },
-  // Follow order in RcclTunableColls
-  .llProtoRanges = {
-    /*ReduceScatter*/
-    {/*LL (min/max/factor/thread_threshold)*/ {0, 65536, 1, 16}, /*LL64/128 (min/max/factor/thread_threshold)*/ {65536, 8388608, 1, 64}},
-    /*AllGather*/
-    {/*LL (min/max/factor/thread_threshold)*/ {0, 65536,  1, 16}, /*LL64/128 (min/max/factor/thread_threshold)*/ {65536, 8388608, 1, 64}},
-    /*AllReduce*/
-    {/*LL (min/max/factor/thread_threshold)*/ {0, 262144, 1, 0},/*LL64/128 (min/max/factor/thread_threshold)*/ {262144, 70640910, 3145728, 0}},
-    /*Reduce*/
-    {/*LL (min/max/factor/thread_threshold)*/ {0, 16383, 1, 0},/*LL64/128 (min/max/factor/thread_threshold)*/ {16383, 16777216, 1, 0}},
-    /*Broadcast*/
-    {/*LL (min/max/factor/thread_threshold)*/ {0, 2048, 1, 0},/*LL64/128 (min/max/factor/thread_threshold)*/ {2048, 16777216, 1, 0}},
-  },
-
-    .channelThresholds  = {
-    // For each collective, define minMax per-rank size threshold for 32,40,48,56,64 channels
-    /*ReduceScatter*/ {{512, 1024, 2},{1024, 2048, 4},{2048, 4096, 8},{4096, 65536, 16}, {65536, 262144, 32}, {262144, 524288, 40}, {524288, 1048576, 48}, {1048576, 2097152, 56}, {2097152, 268435457, 64}},
-    /*AllGather*/     {{2048, 4096, 2},{4096, 8192, 4},{8192, 16384, 8},{16384, 262144, 16},{262144, 524288, 32}, {524288, 1048576, 40}, {1,1, 48}, {1048576, 4194304, 56}, {4194304, 268435457, 64}},
-    /*AllReduce*/     {{0,0,0},{0,0,0},{0,0,0},{0,0,0},{0,0,0}, {0,0,0}, {0,0,0}, {0,0,0}, {0,0,0}},
-  },
-};
-
-static struct tuningModel tuning_model_7 {
-  .hwLat = {
-    /* NVLINK */
-    { /* Tree (LL/LL128/Simple)*/ { 0.8, 1.4, 2.5 }, /* Ring (LL/LL128/Simple)*/ { 0.8, 2.2, 3.6 }, /* CollNetDirect (Simple)*/ { 0.0, 0.0, 0.8 }, /* CollNetChain (Simple)*/ { 0.0, 0.0, 1.4 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 3.6} },
-    /* PCI */
-    { /* Tree (LL/LL128/Simple)*/ { 2.2, 2.2, 5.7 }, /* Ring (LL/LL128/Simple)*/ { 2.2, 2.2, 5.7 }, /* CollNetDirect (Simple)*/ { 0.0, 0.0, 5.7 }, /* CollNetChain (Simple)*/ { 0.0, 0.0, 5.7 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 5.7} },
-    /* NET */
-    { /* Tree (LL/LL128/Simple)*/ { 11.8, 18.2, 20.8 }, /* Ring (LL/LL128/Simple)*/ { 9.5, 19.8, 15.1 }, /* CollNetDirect (Simple)*/ { 0.0, 0.0, 11.8 }, /* CollNetChain (Simple)*/ { 0.0, 0.0, 18.2 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 15.1} },
-  },
-
-  .bwRatio = {
-    /* 2 nodes */
-    { /* Tree (LL/LL128/Simple)*/ { 0.62, 0.62, 1.61}, /* Ring (LL/LL128/Simple)*/ { 0.20, 0.20, 1.00 }, /* CollNetDirect (Simple)*/ { 0.00, 0.00, 1.00 }, /* CollNetChain (Simple)*/ { 0.00, 0.00, 1.00 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 0} },
-    /* more than 2 nodes */
-    { /* Tree (LL/LL128/Simple)*/ { 0.62, 0.62, 1.61}, /* Ring (LL/LL128/Simple)*/ { 0.20, 0.20, 1.00}, /* CollNetDirect (Simple)*/ { 0.00, 0.00, 1.00 }, /* CollNetChain (Simple)*/ { 0.00, 0.00, 1.00 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 1.00} },
-  },
-
-  .treeCorrectionFactor = {
-    { 0.1, 0.2, 0.1, 0.1, 0.9, 0.3, 0.4, 0.1, 0.2, 0.4, 0.2, 0.1, 0.3, 0.3, 0.2, 0.2, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, },
-    { 0.1, 0.3, 1.0, 0.1, 0.5, 1.0, 0.9, 1.0, 1.0, 1.0, 0.3, 0.1, 0.4, 0.5, 0.5, 0.4, 0.4, 0.3, 0.3, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, },
-    { 0.2, 1.0, 0.1, 0.1, 0.7, 0.2, 0.4, 0.1, 0.1, 0.3, 0.4, 0.3, 0.6, 0.8, 1.0, 1.0, 1.0, 1.0, 1.0, 0.85, 0.85, 0.83, 0.8, 0.82, 0.84, 0.85, 0.85},
-  },
-
-  .ringCorrectionFactor = {
-    { 0.1, 0.1, 0.1, 0.1, 0.1, 0.2, 0.4, 0.2, 0.3, 0.5, 0.3, 0.1, 0.5, 0.5, 0.3, 0.2, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, },
-    { 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.3, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.8, 0.7, 0.5, 0.4, 0.4, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, },
-    { 1.0, 0.8, 0.2, 1.0, 1.0, 0.3, 1.0, 0.1, 0.1, 0.2, 0.2, 0.1, 0.5, 1.0, 0.8, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,},
-  },
-  // Follow order in RcclTunableColls
-  .llProtoRanges = {
-    /*ReduceScatter*/
-    {/*LL (min/max/factor/thread_threshold)*/ {0, 32768, 1, 16}, /*LL64/128 (min/max/factor/thread_threshold)*/ {32768, 32768, 1, 64}},
-    /*AllGather*/
-    {/*LL (min/max/factor/thread_threshold)*/ {0, 32768,  1, 16}, /*LL64/128 (min/max/factor/thread_threshold)*/ {32768, 32768, 1, 64}},
-    /*AllReduce*/
-    {/*LL (min/max/factor/thread_threshold)*/ {0, 32768, 1, 0},/*LL64/128 (min/max/factor/thread_threshold)*/ {32768, 32768, 3145728, 0}},
-    /*Reduce*/
-    {/*LL (min/max/factor/thread_threshold)*/ {0, 0, 1, 0},/*LL64/128 (min/max/factor/thread_threshold)*/ {16383, 16383, 1, 0}},
-    /*Broadcast*/
-    {/*LL (min/max/factor/thread_threshold)*/ {0, 32768, 1, 0},/*LL64/128 (min/max/factor/thread_threshold)*/ {32768, 32768, 1, 0}},
-  },
-
-    .channelThresholds  = {
-    // For each collective, define minMax per-rank size threshold for 32,40,48,56,64 channels
-    /*ReduceScatter*/ {{512, 1024, 2},{1024, 2048, 4},{2048, 4096, 8},{4096, 65536, 16}, {65536, 262144, 32}, {262144, 524288, 40}, {1,1, 48}, {524288, 1048576, 56}, {1048576, 268435457, 64}},
-    /*AllGather*/     {{2048, 4096, 2},{4096, 8192, 4},{8192, 16384, 8},{16384, 262144, 16},{262144, 524288, 32}, {524288, 1048576, 40}, {1,1, 48}, {1048576, 4194304, 56}, {4194304, 268435457, 64}},
-    /*AllReduce*/     {{0,0,0},{0,0,0},{0,0,0},{0,0,0},{0,0,0}, {0,0,0}, {0,0,0}, {0,0,0}, {0,0,0}},
-  },
-};
-
-static struct tuningModel tuning_model_8 {
-  .hwLat = {
-    /* NVLINK */
-    { /* Tree (LL/LL128/Simple)*/ { 0.9, 0.9, 2.3 }, /* Ring (LL/LL128/Simple)*/ { 0.8, 0.8, 2.1 }, /* CollNetDirect (Simple)*/ { 0.0, 0.0, 0.9 }, /* CollNetChain (Simple)*/ { 0.0, 0.0, 0.0 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 0} },
-    /* PCI */
-    { /* Tree (LL/LL128/Simple)*/ { 2.2, 2.2, 5.7 }, /* Ring (LL/LL128/Simple)*/ { 2.2, 2.2, 5.7 }, /* CollNetDirect (Simple)*/ { 0.0, 0.0, 5.7 }, /* CollNetChain (Simple)*/ { 0.0, 0.0, 5.7 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 0} },
-    /* NET */
-    { /* Tree (LL/LL128/Simple)*/ { 10.5, 10.5, 25.0 }, /* Ring (LL/LL128/Simple)*/ { 9.5, 9.5, 320.0 }, /* CollNetDirect (Simple)*/ { 0.0, 0.0, 10.5 }, /* CollNetChain (Simple)*/ { 0.0, 0.0, 0.0 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 0} },
-  },
-
-  .bwRatio = {
-    /* 2 nodes */
-    { /* Tree (LL/LL128/Simple)*/ { 0.06, 0.06, 0.11 }, /* Ring (LL/LL128/Simple)*/ { 0.08, 0.08, 1.00 }, /* CollNetDirect (Simple)*/ { 0.00, 0.00, 1.00 }, /* CollNetChain (Simple)*/ { 0.00, 0.00, 1.00 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 0} },
-    /* more than 2 nodes */
-    { /* Tree (LL/LL128/Simple)*/ { 0.06, 0.06, 0.59 }, /* Ring (LL/LL128/Simple)*/ { 0.08, 0.08, 1.00 }, /* CollNetDirect (Simple)*/ { 0.00, 0.00, 1.00 }, /* CollNetChain (Simple)*/ { 0.00, 0.00, 1.00 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 0} },
-  },
-
-  .treeCorrectionFactor = {
-    { 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 1.0, 1.0, 1.0, 1.0, 0.6, 1.0, 0.9, 1.0, 1.0, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, },
-    { 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 1.0, 1.0, 1.0, 1.0, 0.6, 1.0, 0.9, 1.0, 1.0, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, },
-    { 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.7, 1.0, 1.0, 1.0, 1.0, 1.0, 0.7, 0.7, 0.5, 0.6, 0.6, 0.6, },
-  },
-
-  .ringCorrectionFactor = {
-    { 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 0.2, 1.0, 0.4, 0.4, 0.1, 0.2, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, },
-    { 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 0.2, 1.0, 0.4, 0.4, 0.1, 0.2, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, },
-    { 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 0.8, 1.0, 1.0, 1.0, },
-  },
-  // Follow order in RcclTunableColls
-  .llProtoRanges = {
-    /*ReduceScatter*/
-    {/*LL (min/max/factor/thread_threshold)*/ {0, 655360, 1, 16}, /*LL64/128 (min/max/factor/thread_threshold)*/ {131072, 3211264, 1, 64}},
-    /*AllGather*/
-    {/*LL (min/max/factor/thread_threshold)*/ {0, 98304,  1, 16}, /*LL64/128 (min/max/factor/thread_threshold)*/ {98304, 5046272, 1, 64}},
-    /*AllReduce*/
-    {/*LL (min/max/factor/thread_threshold)*/ {0, 524288, 1, 0},/*LL64/128 (min/max/factor/thread_threshold)*/ {524288, 9437184, 3145728, 0}},
-    /*Reduce*/
-  {/*LL (min/max/factor/thread_threshold)*/ {0, 4096, 1, 0},/*LL64/128 (min/max/factor/thread_threshold)*/ {4096, 16777216, 1, 0}},
-  /*Broadcast*/
-  {/*LL (min/max/factor/thread_threshold)*/ {0, 8192, 1, 0},/*LL64/128 (min/max/factor/thread_threshold)*/ {8192, 33554432, 1, 0}},
-  },
   .channelThresholds = {{{CHAN_THRESHOLDS_UNDEFINED}}},
 };
 
-static struct tuningModel tuning_model_9 {
-     .hwLat = {
-    /* NVLINK */
-    { /* Tree (LL/LL128/Simple)*/ { 0.8, 1.4, 2.5 }, /* Ring (LL/LL128/Simple)*/ { 0.8, 2.2, 3.6 }, /* CollNetDirect (Simple)*/ { 0.0, 0.0, 0.8 }, /* CollNetChain (Simple)*/ { 0.0, 0.0, 1.4 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 3.6} },
-    /* PCI */
-    { /* Tree (LL/LL128/Simple)*/ { 2.2, 2.2, 5.7 }, /* Ring (LL/LL128/Simple)*/ { 2.2, 2.2, 5.7 }, /* CollNetDirect (Simple)*/ { 0.0, 0.0, 5.7 }, /* CollNetChain (Simple)*/ { 0.0, 0.0, 5.7 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 5.7} },
-    /* NET */
-    { /* Tree (LL/LL128/Simple)*/ { 57.89, 57.89, 77.33 }, /* Ring (LL/LL128/Simple)*/ { 64.74, 64.74, 100.95 }, /* CollNetDirect (Simple)*/ { 0.0, 0.0, 11.8 }, /* CollNetChain (Simple)*/ { 0.0, 0.0, 18.2 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 15.1} },
-  },
+static struct tuningModel tuning_model_1{
+  .hwLat =
+    {
+      /* NVLINK */
+      {/* Tree (LL/LL128/Simple)*/ {1.5, 1.5, 4.5}, /* Ring (LL/LL128/Simple)*/ {1.5, 1.5, 4.5},
+       /* CollNetDirect (Simple)*/ {0.0, 0.0, 4.5}, /* CollNetChain (Simple)*/ {0.0, 0.0, 4.5}, /* NVLS */ {0, 0, 0},
+       /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 0}},
+      /* PCI */
+      {/* Tree (LL/LL128/Simple)*/ {2.2, 2.2, 5.7}, /* Ring (LL/LL128/Simple)*/ {2.2, 2.2, 5.7},
+       /* CollNetDirect (Simple)*/ {0.0, 0.0, 5.7}, /* CollNetChain (Simple)*/ {0.0, 0.0, 5.7}, /* NVLS */ {0, 0, 0},
+       /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 0}},
+      /* NET */
+      {/* Tree (LL/LL128/Simple)*/ {33.0, 33.0, 15.8}, /* Ring (LL/LL128/Simple)*/ {5.1, 5.1, 68.8},
+       /* CollNetDirect (Simple)*/ {0.0, 0.0, 15.8}, /* CollNetChain (Simple)*/ {0.0, 0.0, 15.8}, /* NVLS */ {0, 0, 0},
+       /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 0}},
+    },
 
-  .bwRatio = {
-    /* 1 node */
-    { /* Tree (LL/LL128/Simple)*/ { 0.051, 0.22, 0.64}, /* Ring (LL/LL128/Simple)*/ { 0.74, 0.34, 1.00 }, /* CollNetDirect (Simple)*/ { 0.00, 0.00, 1.00 }, /* CollNetChain (Simple)*/ { 0.00, 0.00, 1.00 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 0} },
-    /* >= 2 Nodes */
-    { /* Tree (LL/LL128/Simple)*/ { 0.33, 0.33, 0.99}, /* Ring (LL/LL128/Simple)*/ { 0.14, 0.14, 1.00}, /* CollNetDirect (Simple)*/ { 0.00, 0.00, 1.00 }, /* CollNetChain (Simple)*/ { 0.00, 0.00, 1.00 }, /* NVLS */ { 0, 0, 0 }, /* NVLS Tree */ { 0, 0, 0 }, /* PAT */ { 0, 0, 1.00} },
-  },
+  .bwRatio =
+    {
+      /* 2 nodes */
+      {/* Tree (LL/LL128/Simple)*/ {0.12, 1.00, 0.99}, /* Ring (LL/LL128/Simple)*/ {0.12, 1.00, 1.00},
+       /* CollNetDirect (Simple)*/ {0.00, 0.00, 1.00}, /* CollNetChain (Simple)*/ {0.00, 0.00, 1.00},
+       /* NVLS */ {0, 0, 0}, /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 0}},
+      /* more than 2 nodes */
+      {/* Tree (LL/LL128/Simple)*/ {0.15, 1.00, 0.42}, /* Ring (LL/LL128/Simple)*/ {0.20, 1.00, 1.00},
+       /* CollNetDirect (Simple)*/ {0.00, 0.00, 1.00}, /* CollNetChain (Simple)*/ {0.00, 0.00, 1.00},
+       /* NVLS */ {0, 0, 0}, /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 0}},
+    },
 
-  .treeCorrectionFactor = {
-    { 0.01, 0.01, 0.02, 0.03, 0.06, 0.014, 0.03, 0.07, 0.14, 0.28, 0.55, 0.67, 0.77, 0.95, 0.99, 0.99, 1.0, 0.90, 0.91, 0.98, 0.97, 0.99, 0.98, 0.99, 0.98, 0.99, 0.61, },
-    { 0.01, 0.01, 0.02, 0.03, 0.06, 0.014, 0.03, 0.07, 0.14, 0.28, 0.55, 0.67, 0.77, 0.95, 0.99, 0.99, 1.0, 0.90, 0.91, 0.98, 0.97, 0.99, 0.98, 0.99, 0.98, 0.99, 0.61, },
-    { 0.05, 0.05, 0.03, 0.18, 0.05, 0.08, 0.16, 0.15, 0.06, 0.08, 0.20, 0.41, 0.47, 0.55, 0.64, 0.65, 0.65, 0.64, 0.66, 0.61, 0.66, 0.64, 0.65, 0.65, 0.66, 0.66, 0.66, },
-  },
+  .treeCorrectionFactor =
+    {
+      {
+        0.5, 0.4, 0.7, 0.6, 1.0, 1.0, 0.5, 0.4, 0.1, 0.5, 0.4, 0.6, 1.0, 1.0,
+        1.0, 1.0, 1.0, 0.8, 0.6, 0.5, 0.4, 0.4, 0.3, 0.2, 0.1, 0.1, 0.1,
+      },
+      {
+        0.5, 0.4, 0.7, 0.6, 1.0, 1.0, 0.5, 0.4, 0.1, 0.5, 0.4, 0.6, 1.0, 1.0,
+        1.0, 1.0, 1.0, 0.8, 0.6, 0.5, 0.4, 0.4, 0.3, 0.2, 0.1, 0.1, 0.1,
+      },
+      {
+        0.1, 0.1, 0.1, 0.1, 0.1, 0.3, 0.4, 0.5, 0.1, 0.6, 1.0, 1.0, 1.0, 0.6,
+        0.5, 0.7, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.7, 0.5, 0.3, 0.3,
+      },
+    },
 
-  .ringCorrectionFactor = {
-    { 0.07, 0.05, 0.08, 0.14, 0.2, 0.43, 0.25, 0.17, 0.4, 0.6, 1.0, 0.98, 0.89, 0.83, 0.89, 0.92, 0.86, 0.97, 0.95, 0.98, 0.92, 0.92, 0.32, 0.95, 0.94, 0.62, 0.65, },
-    { 0.07, 0.05, 0.08, 0.14, 0.2, 0.43, 0.25, 0.17, 0.4, 0.6, 1.0, 0.98, 0.89, 0.83, 0.89, 0.92, 0.86, 0.97, 0.95, 0.98, 0.92, 0.92, 0.32, 0.95, 0.94, 0.62, 0.65, },
-    { 1.0, 1.0, 1.0, 0.02, 0.04, 0.06, 0.1, 0.2, 0.05, 0.1, 0.2, 0.44, 0.74, 0.72, 0.7, 0.68, 0.67, 0.65, 0.67, 0.67, 0.67, 0.68, 0.68, 0.68, 0.68, 0.68, 0.67,},
-  },
+  .ringCorrectionFactor =
+    {
+      {
+        1.0, 0.5, 1.0, 1.0, 0.6, 0.7, 1.0, 1.0, 0.2, 1.0, 0.9, 0.7, 1.0, 1.0,
+        1.0, 0.9, 0.9, 0.8, 0.8, 0.7, 0.6, 0.5, 0.5, 0.3, 0.2, 0.1, 0.1,
+      },
+      {
+        1.0, 0.5, 1.0, 1.0, 0.6, 0.7, 1.0, 1.0, 0.2, 1.0, 0.9, 0.7, 1.0, 1.0,
+        1.0, 0.9, 0.9, 0.8, 0.8, 0.7, 0.6, 0.5, 0.5, 0.3, 0.2, 0.1, 0.1,
+      },
+      {
+        0.3, 1.0, 0.3, 0.1, 0.1, 0.1, 0.3, 0.7, 1.0, 0.2, 0.1, 0.1, 0.1, 0.1,
+        0.1, 0.1, 0.1, 0.1, 0.1, 0.2, 0.3, 0.5, 0.9, 1.0, 1.0, 1.0, 1.0,
+      },
+    },
+
+  .llProtoRanges = {{{RCCL_LL_LIMITS_UNDEFINED}}},
+  .channelThresholds = {{{CHAN_THRESHOLDS_UNDEFINED}}},
+};
+
+static struct tuningModel tuning_model_2{
+  .hwLat =
+    {
+      /* NVLINK */
+      {/* Tree (LL/LL128/Simple)*/ {1.5, 1.5, 4.5}, /* Ring (LL/LL128/Simple)*/ {1.5, 1.5, 4.5},
+       /* CollNetDirect (Simple)*/ {0.0, 0.0, 4.5}, /* CollNetChain (Simple)*/ {0.0, 0.0, 4.5}, /* NVLS */ {0, 0, 0},
+       /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 0}},
+      /* PCI */
+      {/* Tree (LL/LL128/Simple)*/ {2.2, 2.2, 5.7}, /* Ring (LL/LL128/Simple)*/ {2.2, 2.2, 5.7},
+       /* CollNetDirect (Simple)*/ {0.0, 0.0, 5.7}, /* CollNetChain (Simple)*/ {0.0, 0.0, 5.7}, /* NVLS */ {0, 0, 0},
+       /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 0}},
+      /* NET */
+      {/* Tree (LL/LL128/Simple)*/ {27.9, 27.9, 15.8}, /* Ring (LL/LL128/Simple)*/ {12.1, 12.1, 68.8},
+       /* CollNetDirect (Simple)*/ {0.0, 0.0, 15.8}, /* CollNetChain (Simple)*/ {0.0, 0.0, 15.8}, /* NVLS */ {0, 0, 0},
+       /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 0}},
+    },
+
+  .bwRatio =
+    {
+      /* 2 nodes */
+      {/* Tree (LL/LL128/Simple)*/ {0.07, 1.00, 0.99}, /* Ring (LL/LL128/Simple)*/ {0.08, 1.00, 1.00},
+       /* CollNetDirect (Simple)*/ {0.00, 0.00, 1.00}, /* CollNetChain (Simple)*/ {0.00, 0.00, 1.00},
+       /* NVLS */ {0, 0, 0}, /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 0}},
+      /* more than 2 nodes */
+      {/* Tree (LL/LL128/Simple)*/ {0.07, 1.00, 0.42}, /* Ring (LL/LL128/Simple)*/ {0.08, 1.00, 1.00},
+       /* CollNetDirect (Simple)*/ {0.00, 0.00, 1.00}, /* CollNetChain (Simple)*/ {0.00, 0.00, 1.00},
+       /* NVLS */ {0, 0, 0}, /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 0}},
+    },
+
+  .treeCorrectionFactor =
+    {
+      {
+        0.1, 0.4, 0.3, 0.3, 0.2, 0.4, 0.5, 0.1, 0.1, 0.6, 0.7, 0.7, 0.8, 1.0,
+        0.9, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2,
+      },
+      {
+        0.1, 0.4, 0.3, 0.3, 0.2, 0.4, 0.5, 0.1, 0.1, 0.6, 0.7, 0.7, 0.8, 1.0,
+        0.9, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2,
+      },
+      {
+        1.0, 0.1, 0.1, 0.1, 0.1, 0.2, 0.3, 0.5, 0.1, 0.6, 0.9, 0.8, 0.7, 0.9,
+        1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.7, 0.9, 0.9, 1.0, 1.0, 1.0,
+      },
+    },
+
+  .ringCorrectionFactor =
+    {
+      {
+        0.1, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.4, 1.0, 1.0, 1.0, 1.0, 0.7,
+        0.6, 0.5, 0.4, 0.3, 0.2, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1,
+      },
+      {
+        0.1, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.4, 1.0, 1.0, 1.0, 1.0, 0.7,
+        0.6, 0.5, 0.4, 0.3, 0.2, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1,
+      },
+      {
+        0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 0.2, 0.2, 0.1, 0.1, 0.1,
+        0.1, 0.1, 0.2, 0.4, 0.5, 0.6, 0.9, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+      },
+    },
+
+  .llProtoRanges = {{{RCCL_LL_LIMITS_UNDEFINED}}},
+  .channelThresholds = {{{CHAN_THRESHOLDS_UNDEFINED}}},
+};
+
+static struct tuningModel tuning_model_3{
+  .hwLat =
+    {
+      /* NVLINK */
+      {/* Tree (LL/LL128/Simple)*/ {0.8, 0.0, 2.5}, /* Ring (LL/LL128/Simple)*/ {0.8, 0.0, 3.6},
+       /* CollNetDirect (Simple)*/ {0.0, 0.0, 0.8}, /* CollNetChain (Simple)*/ {0.0, 0.0, 0.0}, /* NVLS */ {0, 0, 0},
+       /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 0}},
+      /* PCI */
+      {/* Tree (LL/LL128/Simple)*/ {2.2, 2.2, 5.7}, /* Ring (LL/LL128/Simple)*/ {2.2, 2.2, 5.7},
+       /* CollNetDirect (Simple)*/ {0.0, 0.0, 5.7}, /* CollNetChain (Simple)*/ {0.0, 0.0, 5.7}, /* NVLS */ {0, 0, 0},
+       /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 0}},
+      /* NET */
+      {/* Tree (LL/LL128/Simple)*/ {12.5, 0.0, 22.4}, /* Ring (LL/LL128/Simple)*/ {9.5, 0.0, 19.8},
+       /* CollNetDirect (Simple)*/ {0.0, 0.0, 12.5}, /* CollNetChain (Simple)*/ {0.0, 0.0, 0.0}, /* NVLS */ {0, 0, 0},
+       /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 0}},
+    },
+
+  .bwRatio =
+    {
+      /* 2 nodes */
+      {/* Tree (LL/LL128/Simple)*/ {0.20, 0.00, 1.75}, /* Ring (LL/LL128/Simple)*/ {0.20, 0.00, 1.00},
+       /* CollNetDirect (Simple)*/ {0.00, 0.00, 1.00}, /* CollNetChain (Simple)*/ {0.00, 0.00, 1.00},
+       /* NVLS */ {0, 0, 0}, /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 0}},
+      /* more than 2 nodes */
+      {/* Tree (LL/LL128/Simple)*/ {0.20, 0.00, 0.96}, /* Ring (LL/LL128/Simple)*/ {0.20, 0.00, 1.00},
+       /* CollNetDirect (Simple)*/ {0.00, 0.00, 1.00}, /* CollNetChain (Simple)*/ {0.00, 0.00, 1.00},
+       /* NVLS */ {0, 0, 0}, /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 0}},
+    },
+
+  .treeCorrectionFactor =
+    {
+      {
+        0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 1.0, 0.2, 1.0, 0.9, 1.0, 0.6, 0.4,
+        0.6, 0.4, 0.3, 0.3, 0.3, 0.3, 0.3, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2,
+      },
+      {
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+      },
+      {
+        1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.1, 0.1, 0.1, 0.2, 1.0, 0.8, 1.0, 1.0,
+        1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.8, 0.7, 0.8, 0.9, 0.7, 0.7,
+      },
+    },
+
+  .ringCorrectionFactor =
+    {
+      {
+        0.1, 0.1, 0.1, 0.1, 0.1, 0.3, 0.1, 0.2, 0.1, 0.4, 0.4, 0.2, 0.2, 0.3,
+        0.7, 0.5, 0.4, 0.3, 0.3, 0.3, 0.3, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2,
+      },
+      {
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+      },
+      {
+        0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.5, 1.0, 0.1, 0.3, 0.1, 0.1, 0.1,
+        0.2, 0.2, 0.2, 0.3, 0.4, 0.7, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+      },
+    },
+
+  .llProtoRanges = {{{RCCL_LL_LIMITS_UNDEFINED}}},
+  .channelThresholds = {{{CHAN_THRESHOLDS_UNDEFINED}}},
+};
+
+static struct tuningModel tuning_model_4{
+  .hwLat =
+    {
+      /* NVLINK */
+      {/* Tree (LL/LL128/Simple)*/ {0.8, 1.4, 2.5}, /* Ring (LL/LL128/Simple)*/ {0.8, 2.2, 3.6},
+       /* CollNetDirect (Simple)*/ {0.8, 1.4, 2.5}, /* CollNetChain (Simple)*/ {0.8, 1.4, 2.5}, /* NVLS */ {0, 0, 0},
+       /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 0}},
+      /* PCI */
+      {/* Tree (LL/LL128/Simple)*/ {2.2, 2.2, 5.7}, /* Ring (LL/LL128/Simple)*/ {2.2, 2.2, 5.7},
+       /* CollNetDirect (Simple)*/ {0.0, 0.0, 5.7}, /* CollNetChain (Simple)*/ {0.0, 0.0, 5.7}, /* NVLS */ {0, 0, 0},
+       /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 0}},
+      /* NET */
+      {/* Tree (LL/LL128/Simple)*/ {32.2, 34.4, 47.6}, /* Ring (LL/LL128/Simple)*/ {35.4, 87.8, 209.2},
+       /* CollNetDirect (Simple)*/ {0.0, 0.0, 47.6}, /* CollNetChain (Simple)*/ {0.0, 0.0, 47.6}, /* NVLS */ {0, 0, 0},
+       /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 0}},
+    },
+
+  .bwRatio =
+    {
+      /* 2 nodes */
+      {/* Tree (LL/LL128/Simple)*/ {0.16, 1.09, 1.61}, /* Ring (LL/LL128/Simple)*/ {0.15, 0.41, 1.00},
+       /* CollNetDirect (Simple)*/ {0.00, 0.00, 1.00}, /* CollNetChain (Simple)*/ {0.00, 0.00, 1.00},
+       /* NVLS */ {0, 0, 0}, /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 0}},
+      /* more than 2 nodes */
+      {/* Tree (LL/LL128/Simple)*/ {0.16, 1.09, 1.08}, /* Ring (LL/LL128/Simple)*/ {0.15, 0.41, 1.00},
+       /* CollNetDirect (Simple)*/ {0.00, 0.00, 1.00}, /* CollNetChain (Simple)*/ {0.00, 0.00, 1.00},
+       /* NVLS */ {0, 0, 0}, /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 0}},
+    },
+
+  .treeCorrectionFactor =
+    {
+      {
+        0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 0.1, 0.1, 0.2, 0.4, 0.6,
+        0.5, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1,
+      },
+      {
+        0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.2, 0.1, 0.1, 0.2, 1.0,
+        0.5, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2,
+      },
+      {
+        1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.8, 0.4, 0.3, 0.3, 0.1, 0.1,
+        1.0, 1.0, 0.7, 0.5, 0.6, 0.5, 0.6, 0.6, 0.5, 0.6, 0.6, 0.6, 0.7,
+      },
+    },
+
+  .ringCorrectionFactor =
+    {
+      {
+        0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.2, 0.2, 0.1,
+        0.3, 0.1, 0.1, 0.1, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1,
+      },
+      {
+        0.4, 0.5, 0.5, 0.4, 0.4, 0.4, 0.4, 0.2, 0.2, 0.1, 0.3, 1.0, 1.0, 0.7,
+        0.8, 0.5, 1.0, 1.0, 1.0, 1.0, 1.0, 0.9, 0.8, 0.5, 0.4, 0.3, 0.3,
+      },
+      {
+        0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 1.0, 0.8, 0.5, 0.1,
+        0.7, 0.2, 0.4, 0.4, 0.6, 0.7, 0.9, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+      },
+    },
+
+  .llProtoRanges = {{{RCCL_LL_LIMITS_UNDEFINED}}},
+  .channelThresholds = {{{CHAN_THRESHOLDS_UNDEFINED}}},
+};
+
+static struct tuningModel tuning_model_5{
+  .hwLat =
+    {
+      /* NVLINK */
+      {/* Tree (LL/LL128/Simple)*/ {0.9, 0.9, 2.3}, /* Ring (LL/LL128/Simple)*/ {0.8, 0.8, 2.1},
+       /* CollNetDirect (Simple)*/ {0.0, 0.0, 0.9}, /* CollNetChain (Simple)*/ {0.0, 0.0, 0.0}, /* NVLS */ {0, 0, 0},
+       /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 0}},
+      /* PCI */
+      {/* Tree (LL/LL128/Simple)*/ {2.2, 2.2, 5.7}, /* Ring (LL/LL128/Simple)*/ {2.2, 2.2, 5.7},
+       /* CollNetDirect (Simple)*/ {0.0, 0.0, 5.7}, /* CollNetChain (Simple)*/ {0.0, 0.0, 5.7}, /* NVLS */ {0, 0, 0},
+       /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 5.7}},
+      /* NET */
+      {/* Tree (LL/LL128/Simple)*/ {10.5, 10.5, 25.0}, /* Ring (LL/LL128/Simple)*/ {9.5, 9.5, 320.0},
+       /* CollNetDirect (Simple)*/ {0.0, 0.0, 10.5}, /* CollNetChain (Simple)*/ {0.0, 0.0, 0.0}, /* NVLS */ {0, 0, 0},
+       /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 320.0}},
+    },
+
+  .bwRatio =
+    {
+      /* 2 nodes */
+      {/* Tree (LL/LL128/Simple)*/ {0.06, 0.06, 0.11}, /* Ring (LL/LL128/Simple)*/ {0.08, 0.08, 1.00},
+       /* CollNetDirect (Simple)*/ {0.00, 0.00, 1.00}, /* CollNetChain (Simple)*/ {0.00, 0.00, 1.00},
+       /* NVLS */ {0, 0, 0}, /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 0}},
+      /* more than 2 nodes */
+      {/* Tree (LL/LL128/Simple)*/ {0.06, 0.06, 0.59}, /* Ring (LL/LL128/Simple)*/ {0.08, 0.08, 1.00},
+       /* CollNetDirect (Simple)*/ {0.00, 0.00, 1.00}, /* CollNetChain (Simple)*/ {0.00, 0.00, 1.00},
+       /* NVLS */ {0, 0, 0}, /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 1.00}},
+    },
+
+  .treeCorrectionFactor =
+    {
+      /*16M 32M  64M  128M 256M 512M  1G   2G  4G */
+      {
+        0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 1.0, 1.0, 1.0, 1.0, 0.6, 1.0, 0.9,
+        1.0, 1.0, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1,
+      },
+      {
+        0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 1.0, 1.0, 1.0, 1.0, 0.6, 1.0, 0.9,
+        1.0, 1.0, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1,
+      },
+      {
+        0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1,
+        0.1, 0.7, 1.0, 1.0, 1.0, 1.0, 1.0, 0.7, 0.7, 0.5, 0.6, 0.6, 0.6,
+      },
+    },
+
+  .ringCorrectionFactor =
+    {
+      {
+        0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 0.2, 1.0,
+        0.4, 0.4, 0.1, 0.2, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1,
+      },
+      {
+        0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 0.2, 1.0,
+        0.4, 0.4, 0.1, 0.2, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1,
+      },
+      {
+        0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1,
+        0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.7, 0.2, 1.0, 1.0, 1.0,
+      },
+    },
   // Follow order in RcclTunableColls
-  .llProtoRanges = {
-    /*ReduceScatter*/
-    {/*LL (min/max/factor/thread_threshold)*/ {0, 8192, 1, 16}, /*LL64/128 (min/max/factor/thread_threshold)*/ {8192, 8192, 1, 32}},
-    /*AllGather*/
-    {/*LL (min/max/factor/thread_threshold)*/ {0, 4096,  1, 16}, /*LL64/128 (min/max/factor/thread_threshold)*/ {4096, 4096, 1, 32}},
-    /*AllReduce*/
-    {/*LL (min/max/factor/thread_threshold)*/ {0, 32768, 1, 0},/*LL64/128 (min/max/factor/thread_threshold)*/ {32768, 32768, 1, 0}},
-    /*Reduce*/
-    {/*LL (min/max/factor/thread_threshold)*/ {0, 4096, 1, 0},/*LL64/128 (min/max/factor/thread_threshold)*/ {4096, 4096, 1, 0}},
-    /*Broadcast*/
-    {/*LL (min/max/factor/thread_threshold)*/ {0, 8192, 1, 0},/*LL64/128 (min/max/factor/thread_threshold)*/ {8192, 8192, 1, 0}},
-  },
+  .llProtoRanges =
+    {
+      /*ReduceScatter*/
+      {/*LL (min/max/factor/thread_threshold)*/ {0, 655360, 1, 16},
+       /*LL64/128 (min/max/factor/thread_threshold)*/ {131072, 3211264, 1, 64}},
+      /*AllGather*/
+      {/*LL (min/max/factor/thread_threshold)*/ {0, 98304, 1, 16},
+       /*LL64/128 (min/max/factor/thread_threshold)*/ {98304, 5046272, 1, 64}},
+      /*AllReduce*/
+      {/*LL (min/max/factor/thread_threshold)*/ {0, 524288, 1, 0},
+       /*LL64/128 (min/max/factor/thread_threshold)*/ {524288, 4415057, 3145728, 0}},
+      /*Reduce*/
+      {/*LL (min/max/factor/thread_threshold)*/ {0, 4096, 1, 0},
+       /*LL64/128 (min/max/factor/thread_threshold)*/ {4096, 16777216, 1, 0}},
+      /*Broadcast*/
+      {/*LL (min/max/factor/thread_threshold)*/ {0, 8192, 1, 0},
+       /*LL64/128 (min/max/factor/thread_threshold)*/ {8192, 33554432, 1, 0}},
+    },
 
-    .channelThresholds  = {
+  .channelThresholds = {{{CHAN_THRESHOLDS_UNDEFINED}}},
+
+};
+
+static struct tuningModel tuning_model_6{
+  .hwLat =
+    {
+      /* NVLINK */
+      {/* Tree (LL/LL128/Simple)*/ {0.9, 0.9, 2.3}, /* Ring (LL/LL128/Simple)*/ {0.8, 0.8, 2.1},
+       /* CollNetDirect (Simple)*/ {0.0, 0.0, 0.9}, /* CollNetChain (Simple)*/ {0.0, 0.0, 0.0}, /* NVLS */ {0, 0, 0},
+       /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 0}},
+      /* PCI */
+      {/* Tree (LL/LL128/Simple)*/ {2.2, 2.2, 5.7}, /* Ring (LL/LL128/Simple)*/ {2.2, 2.2, 5.7},
+       /* CollNetDirect (Simple)*/ {0.0, 0.0, 5.7}, /* CollNetChain (Simple)*/ {0.0, 0.0, 5.7}, /* NVLS */ {0, 0, 0},
+       /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 5.7}},
+      /* NET */
+      {/* Tree (LL/LL128/Simple)*/ {10.5, 10.5, 25.0}, /* Ring (LL/LL128/Simple)*/ {9.5, 9.5, 320.0},
+       /* CollNetDirect (Simple)*/ {0.0, 0.0, 10.5}, /* CollNetChain (Simple)*/ {0.0, 0.0, 0.0}, /* NVLS */ {0, 0, 0},
+       /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 320.0}},
+    },
+
+  .bwRatio =
+    {
+      /* 2 nodes */
+      {/* Tree (LL/LL128/Simple)*/ {0.06, 0.06, 0.11}, /* Ring (LL/LL128/Simple)*/ {0.08, 0.08, 1.00},
+       /* CollNetDirect (Simple)*/ {0.00, 0.00, 1.00}, /* CollNetChain (Simple)*/ {0.00, 0.00, 1.00},
+       /* NVLS */ {0, 0, 0}, /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 0}},
+      /* more than 2 nodes */
+      {/* Tree (LL/LL128/Simple)*/ {0.06, 0.06, 0.59}, /* Ring (LL/LL128/Simple)*/ {0.08, 0.08, 1.00},
+       /* CollNetDirect (Simple)*/ {0.00, 0.00, 1.00}, /* CollNetChain (Simple)*/ {0.00, 0.00, 1.00},
+       /* NVLS */ {0, 0, 0}, /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 1.00}},
+    },
+
+  .treeCorrectionFactor =
+    {
+      /*16M 32M  64M  128M 256M 512M  1G   2G  4G */
+      {
+        0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 1.0, 1.0, 1.0, 1.0, 0.6, 1.0, 0.9,
+        1.0, 1.0, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1,
+      },
+      {
+        0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 1.0, 1.0, 1.0, 1.0, 0.6, 1.0, 0.9,
+        1.0, 1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 1.0, 0.1, 0.9, 0.9, 0.1, 0.1,
+      },
+      {
+        0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1,  0.1, 0.1, 0.1, 0.1,
+        0.1, 0.7, 1.0, 0.1, 0.1, 0.1, 0.1, 0.1, 0.7, 0.15, 0.6, 0.7, 0.6,
+      },
+    },
+
+  .ringCorrectionFactor =
+    {
+      {
+        0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 0.2, 1.0,
+        0.4, 0.4, 0.1, 0.2, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1,
+      },
+      {
+        0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 0.2, 1.0,
+        0.4, 0.4, 0.1, 0.2, 0.1, 0.1, 0.1, 0.1, 5.5, 0.1, 0.1, 1.0, 1.0,
+      },
+      {
+        0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1,
+        0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.9, 0.1, 1.0, 0.1, 0.6, 1.0, 1.0,
+      },
+    },
+  // Follow order in RcclTunableColls
+  .llProtoRanges =
+    {
+      /*ReduceScatter*/
+      {/*LL (min/max/factor/thread_threshold)*/ {0, 65536, 1, 16},
+       /*LL64/128 (min/max/factor/thread_threshold)*/ {65536, 8388608, 1, 64}},
+      /*AllGather*/
+      {/*LL (min/max/factor/thread_threshold)*/ {0, 65536, 1, 16},
+       /*LL64/128 (min/max/factor/thread_threshold)*/ {65536, 8388608, 1, 64}},
+      /*AllReduce*/
+      {/*LL (min/max/factor/thread_threshold)*/ {0, 262144, 1, 0},
+       /*LL64/128 (min/max/factor/thread_threshold)*/ {262144, 70640910, 3145728, 0}},
+      /*Reduce*/
+      {/*LL (min/max/factor/thread_threshold)*/ {0, 16383, 1, 0},
+       /*LL64/128 (min/max/factor/thread_threshold)*/ {16383, 16777216, 1, 0}},
+      /*Broadcast*/
+      {/*LL (min/max/factor/thread_threshold)*/ {0, 2048, 1, 0},
+       /*LL64/128 (min/max/factor/thread_threshold)*/ {2048, 16777216, 1, 0}},
+    },
+
+  .channelThresholds = {
     // For each collective, define minMax per-rank size threshold for 32,40,48,56,64 channels
-    /*ReduceScatter*/ {{1, 67108864, 1},{67108864, 17179869184, 2},{0, 0, 0},{0,0,0},{0,0,0}, {0,0,0}, {0,0,0}, {0,0,0}, {0,0,0}},
-    /*AllGather*/     {{1, 8388608, 1},{8388608, 17179869184, 2},{0, 0, 0},{0, 0, 0},{0,0,0}, {0,0,0}, {0,0,0}, {0,0,0}, {0,0,0}},
-    /*AllReduce*/     {{1,4194304,2},{4194304,17179869184,3},{0,0,0},{0,0,0},{0,0,0}, {0,0,0}, {0,0,0}, {0,0,0}, {0,0,0}},
-    /*Reduce*/        {{1,8388608,1},{8388608,17179869184,2},{0,0,0},{0,0,0},{0,0,0}, {0,0,0}, {0,0,0}, {0,0,0}, {0,0,0}},
-    /*Broadcast*/     {{1,524288,1},{524288,17179869184,2},{0,0,0},{0,0,0},{0,0,0}, {0,0,0}, {0,0,0}, {0,0,0}, {0,0,0}},
+    /*ReduceScatter*/ {{512, 1024, 2},
+                       {1024, 2048, 4},
+                       {2048, 4096, 8},
+                       {4096, 65536, 16},
+                       {65536, 262144, 32},
+                       {262144, 524288, 40},
+                       {524288, 1048576, 48},
+                       {1048576, 2097152, 56},
+                       {2097152, 268435457, 64}},
+    /*AllGather*/
+    {{2048, 4096, 2},
+     {4096, 8192, 4},
+     {8192, 16384, 8},
+     {16384, 262144, 16},
+     {262144, 524288, 32},
+     {524288, 1048576, 40},
+     {1, 1, 48},
+     {1048576, 4194304, 56},
+     {4194304, 268435457, 64}},
+    /*AllReduce*/ {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}},
+  },
+};
+
+static struct tuningModel tuning_model_7{
+  .hwLat =
+    {
+      /* NVLINK */
+      {/* Tree (LL/LL128/Simple)*/ {0.8, 1.4, 2.5}, /* Ring (LL/LL128/Simple)*/ {0.8, 2.2, 3.6},
+       /* CollNetDirect (Simple)*/ {0.0, 0.0, 0.8}, /* CollNetChain (Simple)*/ {0.0, 0.0, 1.4}, /* NVLS */ {0, 0, 0},
+       /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 3.6}},
+      /* PCI */
+      {/* Tree (LL/LL128/Simple)*/ {2.2, 2.2, 5.7}, /* Ring (LL/LL128/Simple)*/ {2.2, 2.2, 5.7},
+       /* CollNetDirect (Simple)*/ {0.0, 0.0, 5.7}, /* CollNetChain (Simple)*/ {0.0, 0.0, 5.7}, /* NVLS */ {0, 0, 0},
+       /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 5.7}},
+      /* NET */
+      {/* Tree (LL/LL128/Simple)*/ {11.8, 18.2, 20.8}, /* Ring (LL/LL128/Simple)*/ {9.5, 19.8, 15.1},
+       /* CollNetDirect (Simple)*/ {0.0, 0.0, 11.8}, /* CollNetChain (Simple)*/ {0.0, 0.0, 18.2}, /* NVLS */ {0, 0, 0},
+       /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 15.1}},
+    },
+
+  .bwRatio =
+    {
+      /* 2 nodes */
+      {/* Tree (LL/LL128/Simple)*/ {0.62, 0.62, 1.61}, /* Ring (LL/LL128/Simple)*/ {0.20, 0.20, 1.00},
+       /* CollNetDirect (Simple)*/ {0.00, 0.00, 1.00}, /* CollNetChain (Simple)*/ {0.00, 0.00, 1.00},
+       /* NVLS */ {0, 0, 0}, /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 0}},
+      /* more than 2 nodes */
+      {/* Tree (LL/LL128/Simple)*/ {0.62, 0.62, 1.61}, /* Ring (LL/LL128/Simple)*/ {0.20, 0.20, 1.00},
+       /* CollNetDirect (Simple)*/ {0.00, 0.00, 1.00}, /* CollNetChain (Simple)*/ {0.00, 0.00, 1.00},
+       /* NVLS */ {0, 0, 0}, /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 1.00}},
+    },
+
+  .treeCorrectionFactor =
+    {
+      {
+        0.1, 0.2, 0.1, 0.1, 0.9, 0.3, 0.4, 0.1, 0.2, 0.4, 0.2, 0.1, 0.3, 0.3,
+        0.2, 0.2, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1,
+      },
+      {
+        0.1, 0.3, 1.0, 0.1, 0.5, 1.0, 0.9, 1.0, 1.0, 1.0, 0.3, 0.1, 0.4, 0.5,
+        0.5, 0.4, 0.4, 0.3, 0.3, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2,
+      },
+      {0.2, 1.0, 0.1, 0.1, 0.7, 0.2,  0.4,  0.1,  0.1, 0.3,  0.4,  0.3,  0.6, 0.8,
+       1.0, 1.0, 1.0, 1.0, 1.0, 0.85, 0.85, 0.83, 0.8, 0.82, 0.84, 0.85, 0.85},
+    },
+
+  .ringCorrectionFactor =
+    {
+      {
+        0.1, 0.1, 0.1, 0.1, 0.1, 0.2, 0.4, 0.2, 0.3, 0.5, 0.3, 0.1, 0.5, 0.5,
+        0.3, 0.2, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1,
+      },
+      {
+        0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.3, 1.0, 1.0, 1.0, 1.0,
+        1.0, 1.0, 0.8, 0.7, 0.5, 0.4, 0.4, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3,
+      },
+      {
+        1.0, 0.8, 0.2, 1.0, 1.0, 0.3, 1.0, 0.1, 0.1, 0.2, 0.2, 0.1, 0.5, 1.0,
+        0.8, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+      },
+    },
+  // Follow order in RcclTunableColls
+  .llProtoRanges =
+    {
+      /*ReduceScatter*/
+      {/*LL (min/max/factor/thread_threshold)*/ {0, 32768, 1, 16},
+       /*LL64/128 (min/max/factor/thread_threshold)*/ {32768, 32768, 1, 64}},
+      /*AllGather*/
+      {/*LL (min/max/factor/thread_threshold)*/ {0, 32768, 1, 16},
+       /*LL64/128 (min/max/factor/thread_threshold)*/ {32768, 32768, 1, 64}},
+      /*AllReduce*/
+      {/*LL (min/max/factor/thread_threshold)*/ {0, 32768, 1, 0},
+       /*LL64/128 (min/max/factor/thread_threshold)*/ {32768, 32768, 3145728, 0}},
+      /*Reduce*/
+      {/*LL (min/max/factor/thread_threshold)*/ {0, 0, 1, 0},
+       /*LL64/128 (min/max/factor/thread_threshold)*/ {16383, 16383, 1, 0}},
+      /*Broadcast*/
+      {/*LL (min/max/factor/thread_threshold)*/ {0, 32768, 1, 0},
+       /*LL64/128 (min/max/factor/thread_threshold)*/ {32768, 32768, 1, 0}},
+    },
+
+  .channelThresholds = {
+    // For each collective, define minMax per-rank size threshold for 32,40,48,56,64 channels
+    /*ReduceScatter*/ {{512, 1024, 2},
+                       {1024, 2048, 4},
+                       {2048, 4096, 8},
+                       {4096, 65536, 16},
+                       {65536, 262144, 32},
+                       {262144, 524288, 40},
+                       {1, 1, 48},
+                       {524288, 1048576, 56},
+                       {1048576, 268435457, 64}},
+    /*AllGather*/
+    {{2048, 4096, 2},
+     {4096, 8192, 4},
+     {8192, 16384, 8},
+     {16384, 262144, 16},
+     {262144, 524288, 32},
+     {524288, 1048576, 40},
+     {1, 1, 48},
+     {1048576, 4194304, 56},
+     {4194304, 268435457, 64}},
+    /*AllReduce*/ {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}},
+  },
+};
+
+static struct tuningModel tuning_model_8{
+  .hwLat =
+    {
+      /* NVLINK */
+      {/* Tree (LL/LL128/Simple)*/ {0.9, 0.9, 2.3}, /* Ring (LL/LL128/Simple)*/ {0.8, 0.8, 2.1},
+       /* CollNetDirect (Simple)*/ {0.0, 0.0, 0.9}, /* CollNetChain (Simple)*/ {0.0, 0.0, 0.0}, /* NVLS */ {0, 0, 0},
+       /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 0}},
+      /* PCI */
+      {/* Tree (LL/LL128/Simple)*/ {2.2, 2.2, 5.7}, /* Ring (LL/LL128/Simple)*/ {2.2, 2.2, 5.7},
+       /* CollNetDirect (Simple)*/ {0.0, 0.0, 5.7}, /* CollNetChain (Simple)*/ {0.0, 0.0, 5.7}, /* NVLS */ {0, 0, 0},
+       /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 0}},
+      /* NET */
+      {/* Tree (LL/LL128/Simple)*/ {10.5, 10.5, 25.0}, /* Ring (LL/LL128/Simple)*/ {9.5, 9.5, 320.0},
+       /* CollNetDirect (Simple)*/ {0.0, 0.0, 10.5}, /* CollNetChain (Simple)*/ {0.0, 0.0, 0.0}, /* NVLS */ {0, 0, 0},
+       /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 0}},
+    },
+
+  .bwRatio =
+    {
+      /* 2 nodes */
+      {/* Tree (LL/LL128/Simple)*/ {0.06, 0.06, 0.11}, /* Ring (LL/LL128/Simple)*/ {0.08, 0.08, 1.00},
+       /* CollNetDirect (Simple)*/ {0.00, 0.00, 1.00}, /* CollNetChain (Simple)*/ {0.00, 0.00, 1.00},
+       /* NVLS */ {0, 0, 0}, /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 0}},
+      /* more than 2 nodes */
+      {/* Tree (LL/LL128/Simple)*/ {0.06, 0.06, 0.59}, /* Ring (LL/LL128/Simple)*/ {0.08, 0.08, 1.00},
+       /* CollNetDirect (Simple)*/ {0.00, 0.00, 1.00}, /* CollNetChain (Simple)*/ {0.00, 0.00, 1.00},
+       /* NVLS */ {0, 0, 0}, /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 0}},
+    },
+
+  .treeCorrectionFactor =
+    {
+      {
+        0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 1.0, 1.0, 1.0, 1.0, 0.6, 1.0, 0.9,
+        1.0, 1.0, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1,
+      },
+      {
+        0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 1.0, 1.0, 1.0, 1.0, 0.6, 1.0, 0.9,
+        1.0, 1.0, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1,
+      },
+      {
+        0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1,
+        0.1, 0.7, 1.0, 1.0, 1.0, 1.0, 1.0, 0.7, 0.7, 0.5, 0.6, 0.6, 0.6,
+      },
+    },
+
+  .ringCorrectionFactor =
+    {
+      {
+        0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 0.2, 1.0,
+        0.4, 0.4, 0.1, 0.2, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1,
+      },
+      {
+        0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 0.2, 1.0,
+        0.4, 0.4, 0.1, 0.2, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1,
+      },
+      {
+        0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1,
+        0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 1.0, 0.8, 1.0, 1.0, 1.0,
+      },
+    },
+  // Follow order in RcclTunableColls
+  .llProtoRanges =
+    {
+      /*ReduceScatter*/
+      {/*LL (min/max/factor/thread_threshold)*/ {0, 655360, 1, 16},
+       /*LL64/128 (min/max/factor/thread_threshold)*/ {131072, 3211264, 1, 64}},
+      /*AllGather*/
+      {/*LL (min/max/factor/thread_threshold)*/ {0, 98304, 1, 16},
+       /*LL64/128 (min/max/factor/thread_threshold)*/ {98304, 5046272, 1, 64}},
+      /*AllReduce*/
+      {/*LL (min/max/factor/thread_threshold)*/ {0, 524288, 1, 0},
+       /*LL64/128 (min/max/factor/thread_threshold)*/ {524288, 9437184, 3145728, 0}},
+      /*Reduce*/
+      {/*LL (min/max/factor/thread_threshold)*/ {0, 4096, 1, 0},
+       /*LL64/128 (min/max/factor/thread_threshold)*/ {4096, 16777216, 1, 0}},
+      /*Broadcast*/
+      {/*LL (min/max/factor/thread_threshold)*/ {0, 8192, 1, 0},
+       /*LL64/128 (min/max/factor/thread_threshold)*/ {8192, 33554432, 1, 0}},
+    },
+  .channelThresholds = {{{CHAN_THRESHOLDS_UNDEFINED}}},
+};
+
+static struct tuningModel tuning_model_9{
+  .hwLat =
+    {
+      /* NVLINK */
+      {/* Tree (LL/LL128/Simple)*/ {0.8, 1.4, 2.5}, /* Ring (LL/LL128/Simple)*/ {0.8, 2.2, 3.6},
+       /* CollNetDirect (Simple)*/ {0.0, 0.0, 0.8}, /* CollNetChain (Simple)*/ {0.0, 0.0, 1.4}, /* NVLS */ {0, 0, 0},
+       /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 3.6}},
+      /* PCI */
+      {/* Tree (LL/LL128/Simple)*/ {2.2, 2.2, 5.7}, /* Ring (LL/LL128/Simple)*/ {2.2, 2.2, 5.7},
+       /* CollNetDirect (Simple)*/ {0.0, 0.0, 5.7}, /* CollNetChain (Simple)*/ {0.0, 0.0, 5.7}, /* NVLS */ {0, 0, 0},
+       /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 5.7}},
+      /* NET */
+      {/* Tree (LL/LL128/Simple)*/ {57.89, 57.89, 77.33}, /* Ring (LL/LL128/Simple)*/ {64.74, 64.74, 100.95},
+       /* CollNetDirect (Simple)*/ {0.0, 0.0, 11.8}, /* CollNetChain (Simple)*/ {0.0, 0.0, 18.2}, /* NVLS */ {0, 0, 0},
+       /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 15.1}},
+    },
+
+  .bwRatio =
+    {
+      /* 1 node */
+      {/* Tree (LL/LL128/Simple)*/ {0.051, 0.22, 0.64}, /* Ring (LL/LL128/Simple)*/ {0.74, 0.34, 1.00},
+       /* CollNetDirect (Simple)*/ {0.00, 0.00, 1.00}, /* CollNetChain (Simple)*/ {0.00, 0.00, 1.00},
+       /* NVLS */ {0, 0, 0}, /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 0}},
+      /* >= 2 Nodes */
+      {/* Tree (LL/LL128/Simple)*/ {0.33, 0.33, 0.99}, /* Ring (LL/LL128/Simple)*/ {0.14, 0.14, 1.00},
+       /* CollNetDirect (Simple)*/ {0.00, 0.00, 1.00}, /* CollNetChain (Simple)*/ {0.00, 0.00, 1.00},
+       /* NVLS */ {0, 0, 0}, /* NVLS Tree */ {0, 0, 0}, /* PAT */ {0, 0, 1.00}},
+    },
+
+  .treeCorrectionFactor =
+    {
+      {
+        0.01, 0.01, 0.02, 0.03, 0.06, 0.014, 0.03, 0.07, 0.14, 0.28, 0.55, 0.67, 0.77, 0.95,
+        0.99, 0.99, 1.0,  0.90, 0.91, 0.98,  0.97, 0.99, 0.98, 0.99, 0.98, 0.99, 0.61,
+      },
+      {
+        0.01, 0.01, 0.02, 0.03, 0.06, 0.014, 0.03, 0.07, 0.14, 0.28, 0.55, 0.67, 0.77, 0.95,
+        0.99, 0.99, 1.0,  0.90, 0.91, 0.98,  0.97, 0.99, 0.98, 0.99, 0.98, 0.99, 0.61,
+      },
+      {
+        0.05, 0.05, 0.03, 0.18, 0.05, 0.08, 0.16, 0.15, 0.06, 0.08, 0.20, 0.41, 0.47, 0.55,
+        0.64, 0.65, 0.65, 0.64, 0.66, 0.61, 0.66, 0.64, 0.65, 0.65, 0.66, 0.66, 0.66,
+      },
+    },
+
+  .ringCorrectionFactor =
+    {
+      {
+        0.07, 0.05, 0.08, 0.14, 0.2,  0.43, 0.25, 0.17, 0.4,  0.6,  1.0,  0.98, 0.89, 0.83,
+        0.89, 0.92, 0.86, 0.97, 0.95, 0.98, 0.92, 0.92, 0.32, 0.95, 0.94, 0.62, 0.65,
+      },
+      {
+        0.07, 0.05, 0.08, 0.14, 0.2,  0.43, 0.25, 0.17, 0.4,  0.6,  1.0,  0.98, 0.89, 0.83,
+        0.89, 0.92, 0.86, 0.97, 0.95, 0.98, 0.92, 0.92, 0.32, 0.95, 0.94, 0.62, 0.65,
+      },
+      {
+        1.0, 1.0,  1.0,  0.02, 0.04, 0.06, 0.1,  0.2,  0.05, 0.1,  0.2,  0.44, 0.74, 0.72,
+        0.7, 0.68, 0.67, 0.65, 0.67, 0.67, 0.67, 0.68, 0.68, 0.68, 0.68, 0.68, 0.67,
+      },
+    },
+  // Follow order in RcclTunableColls
+  .llProtoRanges =
+    {
+      /*ReduceScatter*/
+      {/*LL (min/max/factor/thread_threshold)*/ {0, 8192, 1, 16},
+       /*LL64/128 (min/max/factor/thread_threshold)*/ {8192, 8192, 1, 32}},
+      /*AllGather*/
+      {/*LL (min/max/factor/thread_threshold)*/ {0, 4096, 1, 16},
+       /*LL64/128 (min/max/factor/thread_threshold)*/ {4096, 4096, 1, 32}},
+      /*AllReduce*/
+      {/*LL (min/max/factor/thread_threshold)*/ {0, 32768, 1, 0},
+       /*LL64/128 (min/max/factor/thread_threshold)*/ {32768, 32768, 1, 0}},
+      /*Reduce*/
+      {/*LL (min/max/factor/thread_threshold)*/ {0, 4096, 1, 0},
+       /*LL64/128 (min/max/factor/thread_threshold)*/ {4096, 4096, 1, 0}},
+      /*Broadcast*/
+      {/*LL (min/max/factor/thread_threshold)*/ {0, 8192, 1, 0},
+       /*LL64/128 (min/max/factor/thread_threshold)*/ {8192, 8192, 1, 0}},
+    },
+
+  .channelThresholds = {
+    // For each collective, define minMax per-rank size threshold for 32,40,48,56,64 channels
+    /*ReduceScatter*/ {{1, 67108864, 1},
+                       {67108864, 17179869184, 2},
+                       {0, 0, 0},
+                       {0, 0, 0},
+                       {0, 0, 0},
+                       {0, 0, 0},
+                       {0, 0, 0},
+                       {0, 0, 0},
+                       {0, 0, 0}},
+    /*AllGather*/
+    {{1, 8388608, 1},
+     {8388608, 17179869184, 2},
+     {0, 0, 0},
+     {0, 0, 0},
+     {0, 0, 0},
+     {0, 0, 0},
+     {0, 0, 0},
+     {0, 0, 0},
+     {0, 0, 0}},
+    /*AllReduce*/
+    {{1, 4194304, 2},
+     {4194304, 17179869184, 3},
+     {0, 0, 0},
+     {0, 0, 0},
+     {0, 0, 0},
+     {0, 0, 0},
+     {0, 0, 0},
+     {0, 0, 0},
+     {0, 0, 0}},
+    /*Reduce*/
+    {{1, 8388608, 1},
+     {8388608, 17179869184, 2},
+     {0, 0, 0},
+     {0, 0, 0},
+     {0, 0, 0},
+     {0, 0, 0},
+     {0, 0, 0},
+     {0, 0, 0},
+     {0, 0, 0}},
+    /*Broadcast*/
+    {{1, 524288, 1},
+     {524288, 17179869184, 2},
+     {0, 0, 0},
+     {0, 0, 0},
+     {0, 0, 0},
+     {0, 0, 0},
+     {0, 0, 0},
+     {0, 0, 0},
+     {0, 0, 0}},
   },
 };
 
 static struct tuningModel rcclTuningModel[] = {
-  tuning_model_0,
-  tuning_model_1,
-  tuning_model_2,
-  tuning_model_3,
-  tuning_model_4,
-  tuning_model_5,
-  tuning_model_6,
-  tuning_model_7,
-  tuning_model_8,
-  tuning_model_9,
+  tuning_model_0, tuning_model_1, tuning_model_2, tuning_model_3, tuning_model_4,
+  tuning_model_5, tuning_model_6, tuning_model_7, tuning_model_8, tuning_model_9,
 };
 
 #if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
@@ -597,45 +1022,60 @@ static const float nvlsEfficiency[NCCL_NUM_COMPCAPS] = {
 static const ncclTunerConstants_t ncclTunerConstantsDefaults = {
   // baseLatencies
   {
-    {  6.8, 14.0,  8.4 }, {  6.6, 14.0,  8.4 },  // Tree, Ring
-    {    0,    0,    0 }, {    0,    0,    0 },  // Collnet Direct, Chain
-    {    0,    0,    0 }, {    0,    0,    0 },  // NVLS, NVLS Tree
-    {  8.0,  8.0,  8.0 }                         // PAT
+    {6.8, 14.0, 8.4},
+    {6.6, 14.0, 8.4}, // Tree, Ring
+    {0, 0, 0},
+    {0, 0, 0}, // Collnet Direct, Chain
+    {0, 0, 0},
+    {0, 0, 0}, // NVLS, NVLS Tree
+    {8.0, 8.0, 8.0} // PAT
   },
   // hwLatencies
   {
-  /* NVLINK */
-  { { 0.6, 1.25, 4.0 }, { 0.6, 1.9, 3.4 }, /* Tree (LL/LL128/Simple), Ring (LL/LL128/Simple)*/
-    {  0,    0, 3.7 }, {  0,   0,  2.8 }, /* CollNetDirect (LL/LL128/Simple), CollNetChain (LL/LL128/Simple)*/
-    {  0,    0,  25 }, {  0,   0,  25 }, /* NVLS (LL/LL128/Simple), NVLSTree (LL/LL128/Simple)*/
-    {  0,    0, 4.0 } /* PAT (LL/LL128/Simple)*/
+    /* NVLINK */
+    {
+      {0.6, 1.25, 4.0},
+      {0.6, 1.9, 3.4}, /* Tree (LL/LL128/Simple), Ring (LL/LL128/Simple)*/
+      {0, 0, 3.7},
+      {0, 0, 2.8}, /* CollNetDirect (LL/LL128/Simple), CollNetChain (LL/LL128/Simple)*/
+      {0, 0, 25},
+      {0, 0, 25}, /* NVLS (LL/LL128/Simple), NVLSTree (LL/LL128/Simple)*/
+      {0, 0, 4.0} /* PAT (LL/LL128/Simple)*/
     },
-  /* PCI */
-  { { 1.0, 1.9, 4.0 }, { 1.0, 2.5, 5.7 }, /* Tree (LL/LL128/Simple), Ring (LL/LL128/Simple)*/
-    {  0,    0, 3.7 }, {  0,   0,  2.8 }, /* CollNetDirect (LL/LL128/Simple), CollNetChain (LL/LL128/Simple)*/
-    {  0,    0,   0 }, {  0,   0,    0 }, /* NVLS (LL/LL128/Simple), NVLSTree (LL/LL128/Simple)*/
-    {  0,    0, 4.0 } /* PAT (LL/LL128/Simple)*/
+    /* PCI */
+    {
+      {1.0, 1.9, 4.0},
+      {1.0, 2.5, 5.7}, /* Tree (LL/LL128/Simple), Ring (LL/LL128/Simple)*/
+      {0, 0, 3.7},
+      {0, 0, 2.8}, /* CollNetDirect (LL/LL128/Simple), CollNetChain (LL/LL128/Simple)*/
+      {0, 0, 0},
+      {0, 0, 0}, /* NVLS (LL/LL128/Simple), NVLSTree (LL/LL128/Simple)*/
+      {0, 0, 4.0} /* PAT (LL/LL128/Simple)*/
     },
-  /* NET */
-  { { 5.0, 8.5, 14 }, { 2.7, 4.0, 14.0 }, /* Tree (LL/LL128/Simple), Ring (LL/LL128/Simple)*/
-    {   0,   0, 31 }, {   0,   0,   30 }, /* CollNetDirect (LL/LL128/Simple), CollNetChain (LL/LL128/Simple)*/
-    {   0,   0, 18 }, {   0,   0,   14 }, /* NVLS (LL/LL128/Simple), NVLSTree (LL/LL128/Simple)*/
-    {   0,   0, 14 } /* PAT (LL/LL128/Simple)*/
+    /* NET */
+    {
+      {5.0, 8.5, 14},
+      {2.7, 4.0, 14.0}, /* Tree (LL/LL128/Simple), Ring (LL/LL128/Simple)*/
+      {0, 0, 31},
+      {0, 0, 30}, /* CollNetDirect (LL/LL128/Simple), CollNetChain (LL/LL128/Simple)*/
+      {0, 0, 18},
+      {0, 0, 14}, /* NVLS (LL/LL128/Simple), NVLSTree (LL/LL128/Simple)*/
+      {0, 0, 14} /* PAT (LL/LL128/Simple)*/
     },
   },
   // llMaxBws
   {
-     {39.0, 39.0, 20.4}, /* Volta-N1/Intel-N2/Intel-N4) */
-     {87.7, 22.5 /*avg of ring & tree*/, 19.0}, /* Ampere-N1/AMD-N2/AMD-N4) */
-     {141.0, 45.0 /*avg of ring & tree*/, 35.0}, /* Hopper-N1/AMD-N2/AMD-N4) */
-     {2*141.0, 2*45.0 /*avg of ring & tree*/, 2*35.0}, /* Blackwell-N1/AMD-N2/AMD-N4) */
+    {39.0, 39.0, 20.4}, /* Volta-N1/Intel-N2/Intel-N4) */
+    {87.7, 22.5 /*avg of ring & tree*/, 19.0}, /* Ampere-N1/AMD-N2/AMD-N4) */
+    {141.0, 45.0 /*avg of ring & tree*/, 35.0}, /* Hopper-N1/AMD-N2/AMD-N4) */
+    {2 * 141.0, 2 * 45.0 /*avg of ring & tree*/, 2 * 35.0}, /* Blackwell-N1/AMD-N2/AMD-N4) */
   },
   // perChMaxRingLL128Bws
   {
     {20.0, 20.0, 20.0}, /* Volta (N1/N2/N4) */
     {20.0, 20.0, 20.0}, /* Ampere (N1/N2/N4) */
     {36.7, 36.7, 36.7}, /* Hopper (N1/N2/N4) */
-    {2*36.7, 2*36.7, 2*36.7}, /* Blackwell (N1/N2/N4) */
+    {2 * 36.7, 2 * 36.7, 2 * 36.7}, /* Blackwell (N1/N2/N4) */
   },
   // perChMaxTreeLL128Bws
   {
@@ -667,7 +1107,7 @@ static int ncclPatEnable(struct ncclComm* comm) {
   if (comm->minCompCap < 60) return 0; // Need SM60 or higher for CUDA atomics
 #endif
   if (comm->nNodes != comm->nRanks) return 0; // PAT only supports 1 GPU per node
-  if (comm->netDeviceType != NCCL_NET_DEVICE_HOST) return 0;   // PAT doesn't support net device offload
+  if (comm->netDeviceType != NCCL_NET_DEVICE_HOST) return 0; // PAT doesn't support net device offload
   return 1;
 }
 
@@ -684,21 +1124,18 @@ static float getNetOverhead(struct ncclComm* comm) {
 NCCL_PARAM(Ll128C2c, "LL128_C2C", 1);
 
 ncclResult_t ncclTopoInitTunerConstants(struct ncclComm* comm) {
-
   comm->tunerConstants = ncclTunerConstantsDefaults;
 
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
   for (int hw = 0; hw < NCCL_NUM_HW_LINKS; hw++)
     for (int a = 0; a < NCCL_NUM_ALGORITHMS; a++)
       for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++)
-        comm->tunerConstants.hwLatencies[hw][a][p] =
-          rcclTuningModel[comm->topo->tuning].hwLat[hw][a][p];
+        comm->tunerConstants.hwLatencies[hw][a][p] = rcclTuningModel[comm->topo->tuning].hwLat[hw][a][p];
 
   for (int n = 0; n < 2; n++) // 0 = <=2 nodes, 1 = >2 nodes
     for (int a = 0; a < NCCL_NUM_ALGORITHMS; a++)
       for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++)
-        comm->tunerConstants.bwRatio[n][a][p] =
-          rcclTuningModel[comm->topo->tuning].bwRatio[n][a][p];
+        comm->tunerConstants.bwRatio[n][a][p] = rcclTuningModel[comm->topo->tuning].bwRatio[n][a][p];
 #endif
 
   return ncclSuccess;
@@ -708,90 +1145,106 @@ ncclResult_t ncclTopoTuneModel(struct ncclComm* comm, int minCompCap, int maxCom
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
   static int rcclMaxThreads[NCCL_NUM_PROTOCOLS] = {0};
   if (rcclMaxThreads[NCCL_PROTO_SIMPLE] == 0) rcclGetMaxNthreads(comm, rcclMaxThreads);
-  static int maxNthreads      = rcclMaxThreads[NCCL_PROTO_SIMPLE];
+  static int maxNthreads = rcclMaxThreads[NCCL_PROTO_SIMPLE];
   static int maxLL128Nthreads = rcclMaxThreads[NCCL_PROTO_LL128];
-  static int maxLLThreads     = rcclMaxThreads[NCCL_PROTO_LL];
-  int simpleDefaultThreads = (graphs[NCCL_ALGO_RING]->bwIntra*graphs[NCCL_ALGO_RING]->nChannels <= PCI_BW) ? 256 : maxNthreads;
-    comm->maxThreads[NCCL_ALGO_RING][NCCL_PROTO_SIMPLE] = getNthreads("NCCL_NTHREADS", ncclParamNthreads(), 4*comm->WarpSize, maxNthreads, simpleDefaultThreads, comm->WarpSize);
+  static int maxLLThreads = rcclMaxThreads[NCCL_PROTO_LL];
+  int simpleDefaultThreads =
+    (graphs[NCCL_ALGO_RING]->bwIntra * graphs[NCCL_ALGO_RING]->nChannels <= PCI_BW) ? 256 : maxNthreads;
+  comm->maxThreads[NCCL_ALGO_RING][NCCL_PROTO_SIMPLE] = getNthreads(
+    "NCCL_NTHREADS", ncclParamNthreads(), 4 * comm->WarpSize, maxNthreads, simpleDefaultThreads, comm->WarpSize);
   comm->maxThreads[NCCL_ALGO_TREE][NCCL_PROTO_SIMPLE] = comm->maxThreads[NCCL_ALGO_COLLNET_DIRECT][NCCL_PROTO_SIMPLE] =
-    getNthreads("NCCL_NTHREADS", ncclParamNthreads(), 4*comm->WarpSize, maxNthreads, maxNthreads, comm->WarpSize);
-  comm->maxThreads[NCCL_ALGO_RING][NCCL_PROTO_LL] = comm->maxThreads[NCCL_ALGO_TREE][NCCL_PROTO_LL] = comm->maxThreads[NCCL_ALGO_COLLNET_DIRECT][NCCL_PROTO_LL] =
-    getNthreads("NCCL_NTHREADS", ncclParamNthreads(), 4*comm->WarpSize, maxNthreads, maxLLThreads, comm->WarpSize);
-  comm->maxThreads[NCCL_ALGO_RING][NCCL_PROTO_LL128] = comm->maxThreads[NCCL_ALGO_TREE][NCCL_PROTO_LL128] =
-    getNthreads("NCCL_LL128_NTHREADS", ncclParamLl128Nthreads(), 4*comm->WarpSize, maxLL128Nthreads, maxLL128Nthreads, comm->WarpSize);
-#else
-  int simpleDefaultThreads = (graphs[NCCL_ALGO_RING]->bwIntra*graphs[NCCL_ALGO_RING]->nChannels <= PCI_BW) ? 256 : NCCL_MAX_NTHREADS;
-    comm->maxThreads[NCCL_ALGO_RING][NCCL_PROTO_SIMPLE] = getNthreads("NCCL_NTHREADS", ncclParamNthreads(), 2*WARP_SIZE, NCCL_SIMPLE_MAX_NTHREADS, simpleDefaultThreads);
-  comm->maxThreads[NCCL_ALGO_TREE][NCCL_PROTO_SIMPLE] =
-    getNthreads("NCCL_NTHREADS", ncclParamNthreads(), 2*WARP_SIZE, NCCL_SIMPLE_MAX_NTHREADS, NCCL_SIMPLE_MAX_NTHREADS);
-  comm->maxThreads[NCCL_ALGO_COLLNET_DIRECT][NCCL_PROTO_SIMPLE] =
-    comm->maxThreads[NCCL_ALGO_COLLNET_CHAIN][NCCL_PROTO_SIMPLE] =
-    comm->maxThreads[NCCL_ALGO_NVLS][NCCL_PROTO_SIMPLE] =
-    comm->maxThreads[NCCL_ALGO_NVLS_TREE][NCCL_PROTO_SIMPLE] = NCCL_MAX_NTHREADS;
+    getNthreads("NCCL_NTHREADS", ncclParamNthreads(), 4 * comm->WarpSize, maxNthreads, maxNthreads, comm->WarpSize);
   comm->maxThreads[NCCL_ALGO_RING][NCCL_PROTO_LL] = comm->maxThreads[NCCL_ALGO_TREE][NCCL_PROTO_LL] =
-    getNthreads("NCCL_NTHREADS", ncclParamNthreads(), 2*WARP_SIZE, NCCL_LL_MAX_NTHREADS, NCCL_LL_MAX_NTHREADS);
+    comm->maxThreads[NCCL_ALGO_COLLNET_DIRECT][NCCL_PROTO_LL] =
+      getNthreads("NCCL_NTHREADS", ncclParamNthreads(), 4 * comm->WarpSize, maxNthreads, maxLLThreads, comm->WarpSize);
   comm->maxThreads[NCCL_ALGO_RING][NCCL_PROTO_LL128] = comm->maxThreads[NCCL_ALGO_TREE][NCCL_PROTO_LL128] =
-    getNthreads("NCCL_LL128_NTHREADS", ncclParamLl128Nthreads(), NCCL_LL128_MAX_NTHREADS/4, NCCL_LL128_MAX_NTHREADS, NCCL_LL128_MAX_NTHREADS);
+    getNthreads("NCCL_LL128_NTHREADS", ncclParamLl128Nthreads(), 4 * comm->WarpSize, maxLL128Nthreads, maxLL128Nthreads,
+                comm->WarpSize);
+#else
+  int simpleDefaultThreads =
+    (graphs[NCCL_ALGO_RING]->bwIntra * graphs[NCCL_ALGO_RING]->nChannels <= PCI_BW) ? 256 : NCCL_MAX_NTHREADS;
+  comm->maxThreads[NCCL_ALGO_RING][NCCL_PROTO_SIMPLE] =
+    getNthreads("NCCL_NTHREADS", ncclParamNthreads(), 2 * WARP_SIZE, NCCL_SIMPLE_MAX_NTHREADS, simpleDefaultThreads);
+  comm->maxThreads[NCCL_ALGO_TREE][NCCL_PROTO_SIMPLE] = getNthreads("NCCL_NTHREADS", ncclParamNthreads(), 2 * WARP_SIZE,
+                                                                    NCCL_SIMPLE_MAX_NTHREADS, NCCL_SIMPLE_MAX_NTHREADS);
+  comm->maxThreads[NCCL_ALGO_COLLNET_DIRECT][NCCL_PROTO_SIMPLE] =
+    comm->maxThreads[NCCL_ALGO_COLLNET_CHAIN][NCCL_PROTO_SIMPLE] = comm->maxThreads[NCCL_ALGO_NVLS][NCCL_PROTO_SIMPLE] =
+      comm->maxThreads[NCCL_ALGO_NVLS_TREE][NCCL_PROTO_SIMPLE] = NCCL_MAX_NTHREADS;
+  comm->maxThreads[NCCL_ALGO_RING][NCCL_PROTO_LL] = comm->maxThreads[NCCL_ALGO_TREE][NCCL_PROTO_LL] =
+    getNthreads("NCCL_NTHREADS", ncclParamNthreads(), 2 * WARP_SIZE, NCCL_LL_MAX_NTHREADS, NCCL_LL_MAX_NTHREADS);
+  comm->maxThreads[NCCL_ALGO_RING][NCCL_PROTO_LL128] = comm->maxThreads[NCCL_ALGO_TREE][NCCL_PROTO_LL128] =
+    getNthreads("NCCL_LL128_NTHREADS", ncclParamLl128Nthreads(), NCCL_LL128_MAX_NTHREADS / 4, NCCL_LL128_MAX_NTHREADS,
+                NCCL_LL128_MAX_NTHREADS);
 #endif
 
   int nNodes = comm->nNodes;
   int nRanks = comm->nRanks;
   if (nRanks <= 1) return ncclSuccess;
 #if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
-  int compCapIndex = minCompCap >= 100 ? NCCL_BLACKWELL_COMPCAP_IDX : (minCompCap >= 90 ? NCCL_HOPPER_COMPCAP_IDX : minCompCap >= 80 ? NCCL_AMPERE_COMPCAP_IDX : NCCL_VOLTA_COMPCAP_IDX);
-  int index2 = nNodes <= 2 ? nNodes-1 : 2;
+  int compCapIndex = minCompCap >= 100 ? NCCL_BLACKWELL_COMPCAP_IDX :
+                                         (minCompCap >= 90 ? NCCL_HOPPER_COMPCAP_IDX :
+                                          minCompCap >= 80 ? NCCL_AMPERE_COMPCAP_IDX :
+                                                             NCCL_VOLTA_COMPCAP_IDX);
+  int index2 = nNodes <= 2 ? nNodes - 1 : 2;
   // LL: for single node, we look at GPU type; for multi-node, we look at CPU type
   int index1 = nNodes == 1 ? compCapIndex :
-               (comm->cpuVendor == NCCL_TOPO_CPU_VENDOR_AMD || comm->cpuVendor == NCCL_TOPO_CPU_VENDOR_MIXED) ? 1 : 0;
+               (comm->cpuVendor == NCCL_TOPO_CPU_VENDOR_AMD || comm->cpuVendor == NCCL_TOPO_CPU_VENDOR_MIXED) ? 1 :
+                                                                                                                0;
   double llMaxBw = comm->tunerConstants.llMaxBws[index1][index2];
   double perChMaxTreeBw = comm->tunerConstants.perChMaxTreeBws[compCapIndex][index2];
   double perChMaxRingLL128Bw = comm->tunerConstants.perChMaxRingLL128Bws[compCapIndex][index2];
   double perChMaxTreeLL128Bw = comm->tunerConstants.perChMaxTreeLL128Bws[compCapIndex][index2];
   double perChMaxNVLSTreeBw = comm->tunerConstants.perChMaxNVLSTreeBws[compCapIndex][index2];
   // De-penalize Tree/Simple latency on Power systems to favor Tree than Ring
-  if (comm->cpuArch == NCCL_TOPO_CPU_ARCH_POWER) comm->tunerConstants.hwLatencies[NCCL_HW_PCI][NCCL_ALGO_TREE][NCCL_PROTO_SIMPLE] = comm->tunerConstants.hwLatencies[NCCL_HW_PCI][NCCL_ALGO_RING][NCCL_PROTO_SIMPLE];
+  if (comm->cpuArch == NCCL_TOPO_CPU_ARCH_POWER)
+    comm->tunerConstants.hwLatencies[NCCL_HW_PCI][NCCL_ALGO_TREE][NCCL_PROTO_SIMPLE] =
+      comm->tunerConstants.hwLatencies[NCCL_HW_PCI][NCCL_ALGO_RING][NCCL_PROTO_SIMPLE];
 #endif
   float ppn = (float)nRanks / nNodes;
 
   int intraHw[NCCL_NUM_ALGORITHMS], hw[NCCL_NUM_ALGORITHMS];
-  for (int a=0; a<NCCL_NUM_ALGORITHMS; a++) intraHw[a] = graphs[a]->typeIntra == LINK_NVL ? NCCL_HW_NVLINK : NCCL_HW_PCI;
-  for (int a=0; a<NCCL_NUM_ALGORITHMS; a++) hw[a] = nNodes == 1 ? intraHw[a] : NCCL_HW_NET;
-  INFO(NCCL_INIT,"RCCL Tuning index:%d",comm->topo->tuning);
-  memcpy(comm->minMaxLLRange,
-        rcclTuningModel[comm->topo->tuning].llProtoRanges,
-        sizeof(rcclTuningModel[comm->topo->tuning].llProtoRanges));
+  for (int a = 0; a < NCCL_NUM_ALGORITHMS; a++)
+    intraHw[a] = graphs[a]->typeIntra == LINK_NVL ? NCCL_HW_NVLINK : NCCL_HW_PCI;
+  for (int a = 0; a < NCCL_NUM_ALGORITHMS; a++) hw[a] = nNodes == 1 ? intraHw[a] : NCCL_HW_NET;
+  INFO(NCCL_INIT, "RCCL Tuning index:%d", comm->topo->tuning);
+  memcpy(comm->minMaxLLRange, rcclTuningModel[comm->topo->tuning].llProtoRanges,
+         sizeof(rcclTuningModel[comm->topo->tuning].llProtoRanges));
 
-  memcpy(comm->minMaxChannelThresholds,
-        rcclTuningModel[comm->topo->tuning].channelThresholds,
-        sizeof(rcclTuningModel[comm->topo->tuning].channelThresholds));
+  memcpy(comm->minMaxChannelThresholds, rcclTuningModel[comm->topo->tuning].channelThresholds,
+         sizeof(rcclTuningModel[comm->topo->tuning].channelThresholds));
 
-  for (int coll=0; coll<NCCL_NUM_FUNCTIONS; coll++) {
-    int nsteps = coll == ncclFuncAllReduce ? 2*(nRanks-1) :
-      coll == ncclFuncReduceScatter || coll == ncclFuncAllGather ? nRanks-1 :
-      nRanks;
+  for (int coll = 0; coll < NCCL_NUM_FUNCTIONS; coll++) {
+    int nsteps = coll == ncclFuncAllReduce                                  ? 2 * (nRanks - 1) :
+                 coll == ncclFuncReduceScatter || coll == ncclFuncAllGather ? nRanks - 1 :
+                                                                              nRanks;
 
-    for (int a=0; a<NCCL_NUM_ALGORITHMS; a++) {
+    for (int a = 0; a < NCCL_NUM_ALGORITHMS; a++) {
       if ((coll == ncclFuncBroadcast || coll == ncclFuncReduce) && a != NCCL_ALGO_RING) continue;
-      if ((coll == ncclFuncReduceScatter || coll == ncclFuncAllGather)
-          && a != NCCL_ALGO_PAT && a != NCCL_ALGO_RING
-          && a != NCCL_ALGO_NVLS && a != NCCL_ALGO_COLLNET_DIRECT) continue;
+      if ((coll == ncclFuncReduceScatter || coll == ncclFuncAllGather) && a != NCCL_ALGO_PAT && a != NCCL_ALGO_RING &&
+          a != NCCL_ALGO_NVLS && a != NCCL_ALGO_COLLNET_DIRECT)
+        continue;
       if (coll == ncclFuncAllReduce && a == NCCL_ALGO_PAT) continue;
 
-      for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
-        if (a == NCCL_ALGO_TREE && p == NCCL_PROTO_SIMPLE && (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942") || IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950")) && comm->topo->nodes[GPU].count == comm->topo->nRanks) continue;
+      for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) {
+        if (a == NCCL_ALGO_TREE && p == NCCL_PROTO_SIMPLE &&
+            (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942") ||
+             IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950")) &&
+            comm->topo->nodes[GPU].count == comm->topo->nRanks)
+          continue;
         if ((a == NCCL_ALGO_NVLS || a == NCCL_ALGO_NVLS_TREE) && p != NCCL_PROTO_SIMPLE) continue;
-        if ((coll == ncclFuncReduceScatter || coll == ncclFuncAllGather)
-            && a == NCCL_ALGO_PAT && (p != NCCL_PROTO_SIMPLE || ncclPatEnable(comm) == 0)) continue;
+        if ((coll == ncclFuncReduceScatter || coll == ncclFuncAllGather) && a == NCCL_ALGO_PAT &&
+            (p != NCCL_PROTO_SIMPLE || ncclPatEnable(comm) == 0))
+          continue;
         int collnet = (a == NCCL_ALGO_COLLNET_DIRECT || a == NCCL_ALGO_COLLNET_CHAIN) ? 1 : 0;
         float bw = nNodes <= 2 || collnet ? graphs[a]->bwIntra : graphs[a]->bwInter;
 #if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
-        if (a == NCCL_ALGO_NVLS_TREE || a == NCCL_ALGO_NVLS)
-        {
+        if (a == NCCL_ALGO_NVLS_TREE || a == NCCL_ALGO_NVLS) {
           // NVLS/NVLStree needs at least 2 channels
-          if (graphs[a]->nChannels < 2 ) continue;
+          if (graphs[a]->nChannels < 2) continue;
           // Convert to NVLS busBW/channel
-          float intraBw = graphs[a]->bwIntra * nvlsEfficiency[compCapIndex] * (graphs[a]->nChannels - 1) / graphs[a]->nChannels;
-	        // AllReduce pipelines two operations.
+          float intraBw =
+            graphs[a]->bwIntra * nvlsEfficiency[compCapIndex] * (graphs[a]->nChannels - 1) / graphs[a]->nChannels;
+          // AllReduce pipelines two operations.
           if (coll == ncclFuncAllReduce) {
             intraBw *= 2.0f;
           } else {
@@ -799,24 +1252,34 @@ ncclResult_t ncclTopoTuneModel(struct ncclComm* comm, int minCompCap, int maxCom
           }
           // Handle 2 node case of NVLSTree
           float interBw = graphs[a]->bwInter * ((nNodes <= 2 && a == NCCL_ALGO_NVLS_TREE) ? 2 : 1);
-          bw = std::min( {intraBw, interBw, a == NCCL_ALGO_NVLS_TREE ? (float)perChMaxNVLSTreeBw : std::numeric_limits<float>::max()} );
+          bw = std::min({intraBw, interBw,
+                         a == NCCL_ALGO_NVLS_TREE ? (float)perChMaxNVLSTreeBw : std::numeric_limits<float>::max()});
         };
 #endif
         float busBw = graphs[a]->nChannels * bw;
 
         // Various model refinements
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-        if (nNodes <= 2)
-          busBw *= comm->tunerConstants.bwRatio[0][a][p];
-        else
-          busBw *= comm->tunerConstants.bwRatio[1][a][p];
-        if (a == NCCL_ALGO_RING && p == NCCL_PROTO_LL && (coll == ncclFuncBroadcast || coll == ncclFuncReduce) && (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942") || IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950")) && comm->topo->nodes[GPU].count == comm->topo->nRanks) { busBw = busBw * 1.65; }
+        if (nNodes <= 2) busBw *= comm->tunerConstants.bwRatio[0][a][p];
+        else busBw *= comm->tunerConstants.bwRatio[1][a][p];
+        if (a == NCCL_ALGO_RING && p == NCCL_PROTO_LL && (coll == ncclFuncBroadcast || coll == ncclFuncReduce) &&
+            (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942") ||
+             IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950")) &&
+            comm->topo->nodes[GPU].count == comm->topo->nRanks) {
+          busBw = busBw * 1.65;
+        }
 #else
-        if (a == NCCL_ALGO_RING && p == NCCL_PROTO_LL) { busBw = std::min(llMaxBw, busBw * .5); }
-        if (a == NCCL_ALGO_RING && p == NCCL_PROTO_LL128) busBw = std::min(busBw * (0.92 /*120.0/128.0*/), graphs[a]->nChannels*perChMaxRingLL128Bw);
-        if (a == NCCL_ALGO_TREE && coll == ncclFuncAllReduce) busBw = std::min(busBw*.92, graphs[a]->nChannels*perChMaxTreeBw);
-        if (a == NCCL_ALGO_TREE && p == NCCL_PROTO_LL) busBw = std::min(busBw*1.0/3.8, llMaxBw);
-        if (a == NCCL_ALGO_TREE && p == NCCL_PROTO_LL128) busBw = std::min(busBw * (nNodes == 1 ? 7.0/9.0 : 120.0/128.0), graphs[a]->nChannels*perChMaxTreeLL128Bw);
+        if (a == NCCL_ALGO_RING && p == NCCL_PROTO_LL) {
+          busBw = std::min(llMaxBw, busBw * .5);
+        }
+        if (a == NCCL_ALGO_RING && p == NCCL_PROTO_LL128)
+          busBw = std::min(busBw * (0.92 /*120.0/128.0*/), graphs[a]->nChannels * perChMaxRingLL128Bw);
+        if (a == NCCL_ALGO_TREE && coll == ncclFuncAllReduce)
+          busBw = std::min(busBw * .92, graphs[a]->nChannels * perChMaxTreeBw);
+        if (a == NCCL_ALGO_TREE && p == NCCL_PROTO_LL) busBw = std::min(busBw * 1.0 / 3.8, llMaxBw);
+        if (a == NCCL_ALGO_TREE && p == NCCL_PROTO_LL128)
+          busBw =
+            std::min(busBw * (nNodes == 1 ? 7.0 / 9.0 : 120.0 / 128.0), graphs[a]->nChannels * perChMaxTreeLL128Bw);
         if (a == NCCL_ALGO_TREE && comm->maxTreePattern == NCCL_TOPO_PATTERN_TREE) busBw *= .85;
         if (a == NCCL_ALGO_PAT) busBw *= .75;
         if (a == NCCL_ALGO_COLLNET_DIRECT && p != NCCL_PROTO_SIMPLE) busBw = 0;  // Not used
@@ -826,22 +1289,24 @@ ncclResult_t ncclTopoTuneModel(struct ncclComm* comm, int minCompCap, int maxCom
             busBw = ppn * std::min(graphs[a]->bwIntra, graphs[a]->bwInter * 0.9f);
           } else {
             // Collnet+Direct requires all GPUs to have a local NIC to work at full speed
-            float factor = ppn / (1.0*graphs[a]->nChannels); // GPU/NIC ratio
-            factor -= (factor-1)/2;
+            float factor = ppn / (1.0 * graphs[a]->nChannels); // GPU/NIC ratio
+            factor -= (factor - 1) / 2;
             busBw /= factor;
             if (minCompCap >= 90) busBw *= .85;
           }
         }
         // disable collnet for allgather/reducescatter if #localranks > #heads
         // AllGather/ReduceScatter requires 1:1 GPU:NIC
-        if ((a == NCCL_ALGO_NVLS || a == NCCL_ALGO_COLLNET_DIRECT) && p == NCCL_PROTO_SIMPLE && (coll == ncclFuncAllGather || coll == ncclFuncReduceScatter) && comm->nNodes > 1) {
+        if ((a == NCCL_ALGO_NVLS || a == NCCL_ALGO_COLLNET_DIRECT) && p == NCCL_PROTO_SIMPLE &&
+            (coll == ncclFuncAllGather || coll == ncclFuncReduceScatter) && comm->nNodes > 1) {
           int nHeads = 0;
-          if (coll == ncclFuncAllGather && comm->nNodes > 1 && (!comm->ncclCollNet || !comm->ncclCollNet->iallgather)) busBw = 0.0f;
-          if (coll == ncclFuncReduceScatter && comm->nNodes > 1 && (!comm->ncclCollNet || !comm->ncclCollNet->ireducescatter)) busBw = 0.0f;
-          if (comm->config.collnetEnable)
-            nHeads = comm->collNetHeadsNum;
-          else
+          if (coll == ncclFuncAllGather && comm->nNodes > 1 && (!comm->ncclCollNet || !comm->ncclCollNet->iallgather))
             busBw = 0.0f;
+          if (coll == ncclFuncReduceScatter && comm->nNodes > 1 &&
+              (!comm->ncclCollNet || !comm->ncclCollNet->ireducescatter))
+            busBw = 0.0f;
+          if (comm->config.collnetEnable) nHeads = comm->collNetHeadsNum;
+          else busBw = 0.0f;
           if (busBw > 0.0f) {
             for (int r = 0; r < comm->nRanks; r++) {
               int node = comm->rankToNode[r];
@@ -863,7 +1328,8 @@ ncclResult_t ncclTopoTuneModel(struct ncclComm* comm, int minCompCap, int maxCom
         comm->bandwidths[coll][a][p] = busBw;
         comm->latencies[coll][a][p] = baseLat[a][p];
         float intraLat = comm->tunerConstants.hwLatencies[intraHw[a]][a][p];
-        float interLat =  ppn == 1 ? comm->tunerConstants.hwLatencies[NCCL_HW_NET][NCCL_ALGO_TREE][p] : comm->tunerConstants.hwLatencies[NCCL_HW_NET][a][p];
+        float interLat = ppn == 1 ? comm->tunerConstants.hwLatencies[NCCL_HW_NET][NCCL_ALGO_TREE][p] :
+                                    comm->tunerConstants.hwLatencies[NCCL_HW_NET][a][p];
         interLat += graphs[a]->latencyInter;
         // Also add the flush extra latency
         if (p == NCCL_PROTO_SIMPLE) interLat += graphs[a]->latencyInter;
@@ -874,8 +1340,11 @@ ncclResult_t ncclTopoTuneModel(struct ncclComm* comm, int minCompCap, int maxCom
             if (graphs[a]->sameChannels) {
               comm->latencies[coll][a][p] += lat;
             } else {
-              if (p == NCCL_PROTO_SIMPLE) lat = comm->tunerConstants.hwLatencies[hw[a]][NCCL_ALGO_TREE][p]; // Add some chunk latency, waiting for proper chunk modeling
-              comm->latencies[coll][a][p] += nsteps*lat;
+              if (p == NCCL_PROTO_SIMPLE)
+                lat =
+                  comm->tunerConstants
+                    .hwLatencies[hw[a]][NCCL_ALGO_TREE][p]; // Add some chunk latency, waiting for proper chunk modeling
+              comm->latencies[coll][a][p] += nsteps * lat;
             }
           } else {
             // Inter-node rings still have to launch nsteps * net overhead.
@@ -885,26 +1354,27 @@ ncclResult_t ncclTopoTuneModel(struct ncclComm* comm, int minCompCap, int maxCom
               if (p == NCCL_PROTO_SIMPLE) netOverhead *= 3;
             }
             intraLat = std::max(intraLat, netOverhead);
-            int nInterSteps = nNodes == 1 ? 0 : coll == ncclFuncAllReduce ? 2*(nNodes-1) : nNodes-1;
-            comm->latencies[coll][a][p] += (nsteps-nInterSteps)*intraLat + nInterSteps*interLat;
+            int nInterSteps = nNodes == 1 ? 0 : coll == ncclFuncAllReduce ? 2 * (nNodes - 1) : nNodes - 1;
+            comm->latencies[coll][a][p] += (nsteps - nInterSteps) * intraLat + nInterSteps * interLat;
           }
         } else if (a == NCCL_ALGO_TREE) {
           if (coll == ncclFuncAllReduce) {
-            comm->latencies[coll][a][p] +=
-              2 * ((nRanks/nNodes-1) * intraLat + log2i(nNodes) * interLat);
+            comm->latencies[coll][a][p] += 2 * ((nRanks / nNodes - 1) * intraLat + log2i(nNodes) * interLat);
           }
         } else if (a == NCCL_ALGO_COLLNET_DIRECT) {
           comm->latencies[coll][a][p] +=
-            2 * (std::min(1, (nRanks/nNodes-1)) * intraLat + (nRanks/nNodes-1) * 0.4) + interLat;  // Add 0.4 us arity serialization latency
+            2 * (std::min(1, (nRanks / nNodes - 1)) * intraLat + (nRanks / nNodes - 1) * 0.4) +
+            interLat; // Add 0.4 us arity serialization latency
         } else if (a == NCCL_ALGO_COLLNET_CHAIN) {
-          comm->latencies[coll][a][p] += 2 * (nRanks/nNodes-1) * intraLat + interLat;
+          comm->latencies[coll][a][p] += 2 * (nRanks / nNodes - 1) * intraLat + interLat;
         } else if (a == NCCL_ALGO_NVLS) {
           if (nNodes > 1) comm->latencies[coll][a][p] += comm->tunerConstants.hwLatencies[NCCL_HW_NET][a][p];
         } else if (a == NCCL_ALGO_NVLS_TREE) {
-          comm->latencies[coll][a][p] += 2*(nNodes-1)*comm->tunerConstants.hwLatencies[NCCL_HW_NET][a][p];
+          comm->latencies[coll][a][p] += 2 * (nNodes - 1) * comm->tunerConstants.hwLatencies[NCCL_HW_NET][a][p];
         } else if (a == NCCL_ALGO_PAT) {
           if (coll == ncclFuncAllGather || coll == ncclFuncReduceScatter) {
-            comm->latencies[coll][a][p] += log2i(nNodes) * (interLat/3.5) // Log latency
+            comm->latencies[coll][a][p] +=
+              log2i(nNodes) * (interLat / 3.5) // Log latency
               + nRanks * 2.8; // Still a linear part; hopefully we'll manage to remove it at some point.
           }
         }
@@ -914,52 +1384,54 @@ ncclResult_t ncclTopoTuneModel(struct ncclComm* comm, int minCompCap, int maxCom
 
   // Protocols/Algorithms enable/disable, and user overrides.
   // All are enabled except ll128 which is enabled by default only in certain cases.
-  int protoEnable[NCCL_NUM_FUNCTIONS*NCCL_NUM_PROTOCOLS];
-  int algoEnable[NCCL_NUM_FUNCTIONS*NCCL_NUM_ALGORITHMS];
-  for (int f=0; f<NCCL_NUM_FUNCTIONS; f++) {
-    for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
-      protoEnable[f*NCCL_NUM_PROTOCOLS+p] = p == NCCL_PROTO_LL128 ? 2 : 1;
+  int protoEnable[NCCL_NUM_FUNCTIONS * NCCL_NUM_PROTOCOLS];
+  int algoEnable[NCCL_NUM_FUNCTIONS * NCCL_NUM_ALGORITHMS];
+  for (int f = 0; f < NCCL_NUM_FUNCTIONS; f++) {
+    for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) {
+      protoEnable[f * NCCL_NUM_PROTOCOLS + p] = p == NCCL_PROTO_LL128 ? 2 : 1;
     }
-    for (int a=0; a<NCCL_NUM_ALGORITHMS; a++) {
-      algoEnable[f*NCCL_NUM_ALGORITHMS+a] = 1;
+    for (int a = 0; a < NCCL_NUM_ALGORITHMS; a++) {
+      algoEnable[f * NCCL_NUM_ALGORITHMS + a] = 1;
     }
   }
 
-  const char *protoStr = ncclGetEnv("NCCL_PROTO");
+  const char* protoStr = ncclGetEnv("NCCL_PROTO");
   if (protoStr) {
     INFO(NCCL_ENV, "NCCL_PROTO set by environment to %s", protoStr);
     NCCLCHECK(parseList(protoStr, ncclFuncStr, NCCL_NUM_FUNCTIONS, ncclProtoStr, NCCL_NUM_PROTOCOLS, protoEnable));
   }
-  const char *algoStr = ncclGetEnv("NCCL_ALGO");
+  const char* algoStr = ncclGetEnv("NCCL_ALGO");
   if (algoStr) {
     INFO(NCCL_ENV, "NCCL_ALGO set by environment to %s", algoStr);
     NCCLCHECK(parseList(algoStr, ncclFuncStr, NCCL_NUM_FUNCTIONS, ncclAlgoStr, NCCL_NUM_ALGORITHMS, algoEnable));
   }
 
-  if (comm->rank == 0 && (algoStr||protoStr)) {
+  if (comm->rank == 0 && (algoStr || protoStr)) {
     constexpr int strLength = 1024;
     char funcAlgoProtoTuningStr[strLength];
     int offset = 0;
-    offset += snprintf(funcAlgoProtoTuningStr+offset, std::max(0, strLength-offset), "\n     Function | ");
-    for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
-      offset += snprintf(funcAlgoProtoTuningStr+offset, std::max(0, strLength-offset), "%8s  ", ncclProtoStr[p]);
+    offset += snprintf(funcAlgoProtoTuningStr + offset, std::max(0, strLength - offset), "\n     Function | ");
+    for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) {
+      offset += snprintf(funcAlgoProtoTuningStr + offset, std::max(0, strLength - offset), "%8s  ", ncclProtoStr[p]);
     }
-    offset += snprintf(funcAlgoProtoTuningStr+offset, std::max(0, strLength-offset), " | ");
-    for (int a=0; a<NCCL_NUM_ALGORITHMS; a++) {
-      offset += snprintf(funcAlgoProtoTuningStr+offset, std::max(0, strLength-offset), "%13s  ", ncclAlgoStr[a]);
+    offset += snprintf(funcAlgoProtoTuningStr + offset, std::max(0, strLength - offset), " | ");
+    for (int a = 0; a < NCCL_NUM_ALGORITHMS; a++) {
+      offset += snprintf(funcAlgoProtoTuningStr + offset, std::max(0, strLength - offset), "%13s  ", ncclAlgoStr[a]);
     }
-    offset += snprintf(funcAlgoProtoTuningStr+offset, std::max(0, strLength-offset), "\n");
+    offset += snprintf(funcAlgoProtoTuningStr + offset, std::max(0, strLength - offset), "\n");
 
-    for (int f=0; f<NCCL_NUM_FUNCTIONS; f++) {
-      offset += snprintf(funcAlgoProtoTuningStr+offset, std::max(0, strLength-offset), "%13s | ", ncclFuncStr[f]);
-      for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
-        offset += snprintf(funcAlgoProtoTuningStr+offset, std::max(0, strLength-offset), "%8d  ", protoEnable[f*NCCL_NUM_PROTOCOLS+p]);
+    for (int f = 0; f < NCCL_NUM_FUNCTIONS; f++) {
+      offset += snprintf(funcAlgoProtoTuningStr + offset, std::max(0, strLength - offset), "%13s | ", ncclFuncStr[f]);
+      for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) {
+        offset += snprintf(funcAlgoProtoTuningStr + offset, std::max(0, strLength - offset), "%8d  ",
+                           protoEnable[f * NCCL_NUM_PROTOCOLS + p]);
       }
-      offset += snprintf(funcAlgoProtoTuningStr+offset, std::max(0, strLength-offset), " | ");
-      for (int a=0; a<NCCL_NUM_ALGORITHMS; a++) {
-        offset += snprintf(funcAlgoProtoTuningStr+offset, std::max(0, strLength-offset), "%13d  ", algoEnable[f*NCCL_NUM_ALGORITHMS+a]);
+      offset += snprintf(funcAlgoProtoTuningStr + offset, std::max(0, strLength - offset), " | ");
+      for (int a = 0; a < NCCL_NUM_ALGORITHMS; a++) {
+        offset += snprintf(funcAlgoProtoTuningStr + offset, std::max(0, strLength - offset), "%13d  ",
+                           algoEnable[f * NCCL_NUM_ALGORITHMS + a]);
       }
-      offset += snprintf(funcAlgoProtoTuningStr+offset, std::max(0, strLength-offset), "\n");
+      offset += snprintf(funcAlgoProtoTuningStr + offset, std::max(0, strLength - offset), "\n");
     }
 
     INFO(NCCL_ENV, "Enabled NCCL Func/Proto/Algo Matrix:%s", funcAlgoProtoTuningStr);
@@ -968,104 +1440,109 @@ ncclResult_t ncclTopoTuneModel(struct ncclComm* comm, int minCompCap, int maxCom
   int nvsCount = 0;
   NCCLCHECK(ncclTopoGetNvsCount(comm->topo, &nvsCount));
 
-  for (int f=0; f<NCCL_NUM_FUNCTIONS; f++) {
-    for (int a=0; a<NCCL_NUM_ALGORITHMS; a++) {
+  for (int f = 0; f < NCCL_NUM_FUNCTIONS; f++) {
+    for (int a = 0; a < NCCL_NUM_ALGORITHMS; a++) {
       int disable = 0;
       // Disable NVLS Tree on a single node
       if (comm->nNodes == 1 && a == NCCL_ALGO_NVLS_TREE) disable = 1;
       // Disable Collnet+Direct, Collnet+Chain or Collnet+NVLS if collnet is not supported.
       if (comm->config.collnetEnable == 0 &&
-          (a == NCCL_ALGO_COLLNET_DIRECT ||
-           a == NCCL_ALGO_COLLNET_CHAIN ||
-           (a == NCCL_ALGO_NVLS && comm->nNodes > 1))) disable = 1;
+          (a == NCCL_ALGO_COLLNET_DIRECT || a == NCCL_ALGO_COLLNET_CHAIN || (a == NCCL_ALGO_NVLS && comm->nNodes > 1)))
+        disable = 1;
       // Disable CollNet+Direct if not on an NVSwitch system
       if (nvsCount == 0 && a == NCCL_ALGO_COLLNET_DIRECT) disable = 1;
-      if (disable) algoEnable[f*NCCL_NUM_ALGORITHMS+a] = 0;
+      if (disable) algoEnable[f * NCCL_NUM_ALGORITHMS + a] = 0;
     }
   }
 
-  for (int c=0; c<NCCL_NUM_FUNCTIONS; c++) for (int a=0; a<NCCL_NUM_ALGORITHMS; a++) for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
-    int pEnable = protoEnable[c*NCCL_NUM_PROTOCOLS+p];
-    if (pEnable != 0 && p == NCCL_PROTO_LL128) {
+  for (int c = 0; c < NCCL_NUM_FUNCTIONS; c++)
+    for (int a = 0; a < NCCL_NUM_ALGORITHMS; a++)
+      for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) {
+        int pEnable = protoEnable[c * NCCL_NUM_PROTOCOLS + p];
+        if (pEnable != 0 && p == NCCL_PROTO_LL128) {
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
 #if defined(ENABLE_LL128)
-      // protoEnable[LL128] starts at 2 (tentative default-on); explicit
-      // NCCL_PROTO=LL128 from the user sets it to 1. Preserve that signal so
-      // the path/arch/ll128Enabled gate below doesn't silently downgrade a
-      // user-requested LL128 (e.g. multi-node MNNVL where typeInter > PXB).
-      const bool userOptedInLL128 = (pEnable == 1);
-      const char* gcn = comm->topo->nodes[GPU].nodes[0].gpu.gcn;
-      const bool archOk = IsArchMatch(gcn, "gfx90a") ||
-                          IsArchMatch(gcn, "gfx942") ||
-                          IsArchMatch(gcn, "gfx950") ||
-                          IsArchMatch(gcn, "gfx1250");
-      // Enable LL128 by default only on gfx90a with available tuning table
-      pEnable = (graphs[a]->typeInter <= PATH_PXB) && graphs[a]->typeIntra <= PATH_NVL &&
-        (archOk && comm->topo->ll128Enabled) ? 1 : 0;
-      // Restore an explicit NCCL_PROTO=LL128 only when the arch supports LL128
-      // (the path-check is what we want to override, not the arch gate); on
-      // unsupported archs let dispatch fall back rather than failing later in
-      // rcclIsArchSupportedForFunc.
-      if (pEnable == 0 && userOptedInLL128 && archOk) pEnable = 1;
+          // protoEnable[LL128] starts at 2 (tentative default-on); explicit
+          // NCCL_PROTO=LL128 from the user sets it to 1. Preserve that signal so
+          // the path/arch/ll128Enabled gate below doesn't silently downgrade a
+          // user-requested LL128 (e.g. multi-node MNNVL where typeInter > PXB).
+          const bool userOptedInLL128 = (pEnable == 1);
+          const char* gcn = comm->topo->nodes[GPU].nodes[0].gpu.gcn;
+          const bool archOk = IsArchMatch(gcn, "gfx90a") || IsArchMatch(gcn, "gfx942") || IsArchMatch(gcn, "gfx950") ||
+                              IsArchMatch(gcn, "gfx1250");
+          // Enable LL128 by default only on gfx90a with available tuning table
+          pEnable = (graphs[a]->typeInter <= PATH_PXB) && graphs[a]->typeIntra <= PATH_NVL &&
+                        (archOk && comm->topo->ll128Enabled) ?
+                      1 :
+                      0;
+          // Restore an explicit NCCL_PROTO=LL128 only when the arch supports LL128
+          // (the path-check is what we want to override, not the arch gate); on
+          // unsupported archs let dispatch fall back rather than failing later in
+          // rcclIsArchSupportedForFunc.
+          if (pEnable == 0 && userOptedInLL128 && archOk) pEnable = 1;
 #else
-      pEnable = 0;
+          pEnable = 0;
 #endif
 #else
-      pEnable = 1;
-      if (ncclParamLl128C2c() && minCompCap >= 90) {
+          pEnable = 1;
+          if (ncclParamLl128C2c() && minCompCap >= 90) {
         // Enable LL128 by default only on Hopper/Blackwell for all connections up to P2C and PXN.
-        pEnable &= (graphs[a]->typeInter <= PATH_PXN);
-      } else {
-        // Enable LL128 only up to PXB. Don't enable LL128 over PxN because PxN can encapsulate PxB or P2C links.
-        pEnable &= (graphs[a]->typeInter <= PATH_PXB);
-        if (!ncclParamLl128C2c() && minCompCap >= 90)
-          INFO(NCCL_GRAPH, "Disabling LL128 over all PxN connections (PXB and C2C). This ensures that no C2C link will be used by LL128.");
-      }
-      pEnable &= (graphs[a]->typeIntra <= PATH_NVB);
-      // Enable LL128 for interoperability between GPUs with different compcap (Hopper and above)
-      pEnable &= (minCompCap == maxCompCap || minCompCap >= 90);
-      pEnable &= !(minCompCap < 70 || (minCompCap == 90 && CUDART_VERSION == 11080 && c == ncclFuncAllReduce && a == NCCL_ALGO_RING && comm->nRanks == 2));
+            pEnable &= (graphs[a]->typeInter <= PATH_PXN);
+          } else {
+            // Enable LL128 only up to PXB. Don't enable LL128 over PxN because PxN can encapsulate PxB or P2C links.
+            pEnable &= (graphs[a]->typeInter <= PATH_PXB);
+            if (!ncclParamLl128C2c() && minCompCap >= 90)
+              INFO(NCCL_GRAPH, "Disabling LL128 over all PxN connections (PXB and C2C). This ensures that no C2C link "
+                               "will be used by LL128.");
+          }
+          pEnable &= (graphs[a]->typeIntra <= PATH_NVB);
+          // Enable LL128 for interoperability between GPUs with different compcap (Hopper and above)
+          pEnable &= (minCompCap == maxCompCap || minCompCap >= 90);
+          pEnable &= !(minCompCap < 70 || (minCompCap == 90 && CUDART_VERSION == 11080 && c == ncclFuncAllReduce &&
+                                           a == NCCL_ALGO_RING && comm->nRanks == 2));
 #endif
-    }
-    if (pEnable == 0) comm->bandwidths[c][a][p] = 0;
-    if (algoEnable[c*NCCL_NUM_ALGORITHMS+a] == 0) comm->bandwidths[c][a][p] = 0;
-  }
+        }
+        if (pEnable == 0) comm->bandwidths[c][a][p] = 0;
+        if (algoEnable[c * NCCL_NUM_ALGORITHMS + a] == 0) comm->bandwidths[c][a][p] = 0;
+      }
 
   if (comm->rank == 0) {
     constexpr int lineLen = 1024;
     char line[lineLen];
     int offset = 0;
-    for (int block=0; block<DIVUP(NCCL_NUM_ALGORITHMS, 3); block++) {
+    for (int block = 0; block < DIVUP(NCCL_NUM_ALGORITHMS, 3); block++) {
       offset = snprintf(line, lineLen, "  Algorithm   |");
-      for (int ba=0; ba<3; ba++) {
-        int a = block*3+ba;
+      for (int ba = 0; ba < 3; ba++) {
+        int a = block * 3 + ba;
         if (a >= NCCL_NUM_ALGORITHMS) continue;
-        offset += snprintf(line+offset, std::max(0, lineLen-offset), " %14s   %14s   %14s |", "", ncclAlgoStr[a], "");
+        offset +=
+          snprintf(line + offset, std::max(0, lineLen - offset), " %14s   %14s   %14s |", "", ncclAlgoStr[a], "");
       }
       INFO(NCCL_TUNING, "%s", line);
       offset = snprintf(line, lineLen, "  Protocol    |");
-      for (int ba=0; ba<3; ba++) {
-        for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
-          offset += snprintf(line+offset, std::max(0, lineLen-offset), " %14s |", ncclProtoStr[p]);
+      for (int ba = 0; ba < 3; ba++) {
+        for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) {
+          offset += snprintf(line + offset, std::max(0, lineLen - offset), " %14s |", ncclProtoStr[p]);
         }
       }
       INFO(NCCL_TUNING, "%s", line);
       offset = snprintf(line, lineLen, " Max NThreads |");
-      for (int ba=0; ba<3; ba++) {
-        int a = block*3+ba;
+      for (int ba = 0; ba < 3; ba++) {
+        int a = block * 3 + ba;
         if (a >= NCCL_NUM_ALGORITHMS) continue;
-        for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
-          offset += snprintf(line+offset, std::max(0, lineLen-offset), " %14d |", comm->maxThreads[a][p]);
+        for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) {
+          offset += snprintf(line + offset, std::max(0, lineLen - offset), " %14d |", comm->maxThreads[a][p]);
         }
       }
       INFO(NCCL_TUNING, "%s", line);
-      for (int c=0; c<NCCL_NUM_FUNCTIONS; c++) {
+      for (int c = 0; c < NCCL_NUM_FUNCTIONS; c++) {
         offset = snprintf(line, lineLen, "%13s |", ncclFuncStr[c]);
-        for (int ba=0; ba<3; ba++) {
-          int a = block*3+ba;
+        for (int ba = 0; ba < 3; ba++) {
+          int a = block * 3 + ba;
           if (a >= NCCL_NUM_ALGORITHMS) continue;
-          for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
-            offset += snprintf(line+offset, std::max(0, lineLen-offset), "%8.1f/%6.1f |", comm->latencies[c][a][p], comm->bandwidths[c][a][p]);
+          for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) {
+            offset += snprintf(line + offset, std::max(0, lineLen - offset), "%8.1f/%6.1f |", comm->latencies[c][a][p],
+                               comm->bandwidths[c][a][p]);
           }
         }
         INFO(NCCL_TUNING, "%s", line);
@@ -1074,7 +1551,7 @@ ncclResult_t ncclTopoTuneModel(struct ncclComm* comm, int minCompCap, int maxCom
   }
 
   // Set per-thread amount of work before we increase nThreads and nChannels
-  for (int a=0; a<NCCL_NUM_ALGORITHMS; a++) {
+  for (int a = 0; a < NCCL_NUM_ALGORITHMS; a++) {
     comm->threadThresholds[a][NCCL_PROTO_LL] = NCCL_LL_THREAD_THRESHOLD;
     comm->threadThresholds[a][NCCL_PROTO_LL128] = NCCL_LL128_THREAD_THRESHOLD;
     comm->threadThresholds[a][NCCL_PROTO_SIMPLE] = NCCL_SIMPLE_THREAD_THRESHOLD;
@@ -1087,24 +1564,22 @@ ncclResult_t ncclTopoTuneModel(struct ncclComm* comm, int minCompCap, int maxCom
   const char* str = ncclGetEnv("NCCL_THREAD_THRESHOLDS");
   if (str) {
     INFO(NCCL_ENV, "NCCL_THREAD_THRESHOLDS set by environment to %s", str);
-    ssize_t t[2][NCCL_NUM_PROTOCOLS] = {{ -2, -2, -2 }, { -2, -2, -2 }};
-    sscanf(str, "%ld %ld %ld %ld %ld %ld", t[0], t[0]+1, t[0]+2, t[1], t[1]+1, t[1]+2);
-    for (int a=0; a<2; a++) {
-      for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
+    ssize_t t[2][NCCL_NUM_PROTOCOLS] = {{-2, -2, -2}, {-2, -2, -2}};
+    sscanf(str, "%ld %ld %ld %ld %ld %ld", t[0], t[0] + 1, t[0] + 2, t[1], t[1] + 1, t[1] + 2);
+    for (int a = 0; a < 2; a++) {
+      for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) {
         if (t[a][p] >= 0) comm->threadThresholds[a][p] = t[a][p];
       }
     }
   }
 
   INFO(NCCL_INIT, "threadThresholds %ld/%ld/%ld | %ld/%ld/%ld | %ld | %ld",
-      comm->threadThresholds[NCCL_ALGO_TREE][NCCL_PROTO_LL],
-      comm->threadThresholds[NCCL_ALGO_TREE][NCCL_PROTO_LL128],
-      comm->threadThresholds[NCCL_ALGO_TREE][NCCL_PROTO_SIMPLE],
-      comm->threadThresholds[NCCL_ALGO_RING][NCCL_PROTO_LL],
-      comm->threadThresholds[NCCL_ALGO_RING][NCCL_PROTO_LL128],
-      comm->threadThresholds[NCCL_ALGO_RING][NCCL_PROTO_SIMPLE],
-      comm->threadThresholds[NCCL_ALGO_COLLNET_DIRECT][NCCL_PROTO_SIMPLE],
-      comm->threadThresholds[NCCL_ALGO_COLLNET_CHAIN][NCCL_PROTO_SIMPLE]);
+       comm->threadThresholds[NCCL_ALGO_TREE][NCCL_PROTO_LL], comm->threadThresholds[NCCL_ALGO_TREE][NCCL_PROTO_LL128],
+       comm->threadThresholds[NCCL_ALGO_TREE][NCCL_PROTO_SIMPLE], comm->threadThresholds[NCCL_ALGO_RING][NCCL_PROTO_LL],
+       comm->threadThresholds[NCCL_ALGO_RING][NCCL_PROTO_LL128],
+       comm->threadThresholds[NCCL_ALGO_RING][NCCL_PROTO_SIMPLE],
+       comm->threadThresholds[NCCL_ALGO_COLLNET_DIRECT][NCCL_PROTO_SIMPLE],
+       comm->threadThresholds[NCCL_ALGO_COLLNET_CHAIN][NCCL_PROTO_SIMPLE]);
   return ncclSuccess;
 }
 
@@ -1112,34 +1587,38 @@ ncclResult_t ncclTopoTuneModel(struct ncclComm* comm, int minCompCap, int maxCom
 // factor is not ideal but works quite well. Powers of two, 64 B to 256MB.
 #if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
 static float treeCorrectionFactor[NCCL_NUM_PROTOCOLS][24] = {
-  { 1.0, 1.0, 1.0, 1.0,  .9,  .8,  .7,  .7,  .7,  .7,  .6,  .5,  .4,  .4,  .5,  .6,  .7,  .8,  .9, 1.0, 1.0, 1.0, 1.0, 1.0 },
-  { 1.0, 1.0, 1.0, 1.0, 1.0,  .9,  .8,  .8,  .8,  .7,  .6,  .6,  .6,  .6,  .6,  .6,  .8,  .9,  .9,  .9,  .9, 1.0, 1.0, 1.0 },
-  {  .9,  .9,  .9,  .9,  .9,  .9,  .9,  .8,  .7,  .6,  .6,  .5,  .5,  .5,  .5,  .6,  .7,  .8,  .7,  .7,  .8,  .9,  .9,  .9 }
+  {1.0, 1.0, 1.0, 1.0, .9, .8, .7, .7, .7, .7, .6, .5, .4, .4, .5, .6, .7, .8, .9, 1.0, 1.0, 1.0, 1.0, 1.0},
+  {1.0, 1.0, 1.0, 1.0, 1.0, .9, .8, .8, .8, .7, .6, .6, .6, .6, .6, .6, .8, .9, .9, .9, .9, 1.0, 1.0, 1.0},
+  {.9, .9, .9, .9, .9, .9, .9, .8, .7, .6, .6, .5, .5, .5, .5, .6, .7, .8, .7, .7, .8, .9, .9, .9}
 };
 #endif
 
-ncclResult_t ncclTopoGetAlgoTime(struct ncclComm* comm, int coll, int algorithm, int protocol, size_t nBytes, int numPipeOps, float* time) {
+ncclResult_t ncclTopoGetAlgoTime(struct ncclComm* comm, int coll, int algorithm, int protocol, size_t nBytes,
+                                 int numPipeOps, float* time) {
   float bw = comm->bandwidths[coll][algorithm][protocol];
   float lat = comm->latencies[coll][algorithm][protocol];
 
   if (bw == 0) {
-    *time = -1.0; return ncclSuccess;
+    *time = -1.0;
+    return ncclSuccess;
   }
-  int logSize = log2i(nBytes>>6);
+  int logSize = log2i(nBytes >> 6);
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
   logSize = std::max(0, std::min(RCCL_FACTOR_TABLE_MAX_INDEX, logSize));
   if (algorithm == NCCL_ALGO_TREE) {
     bw *= rcclTuningModel[comm->topo->tuning].treeCorrectionFactor[protocol][logSize];
-  }
-  else if (algorithm == NCCL_ALGO_RING && comm->nNodes > 1) {
+  } else if (algorithm == NCCL_ALGO_RING && comm->nNodes > 1) {
     bw *= rcclTuningModel[comm->topo->tuning].ringCorrectionFactor[protocol][logSize];
   }
 
 #else
-  if (algorithm == NCCL_ALGO_TREE && coll == ncclFuncAllReduce && logSize >= 0 && logSize < 23) bw *= treeCorrectionFactor[protocol][logSize];
-  if (algorithm == NCCL_ALGO_NVLS_TREE && coll == ncclFuncAllReduce && logSize >= 0 && logSize < 24 && comm->minCompCap >= 100 && comm->cpuArch == NCCL_TOPO_CPU_ARCH_X86) bw *= treeCorrectionFactor[protocol][logSize];
-  if (algorithm == NCCL_ALGO_RING && protocol == NCCL_PROTO_SIMPLE && comm->nNodes > 1
-      && coll == ncclFuncAllReduce && nBytes/(comm->nChannels*comm->nRanks) >= 64) {
+  if (algorithm == NCCL_ALGO_TREE && coll == ncclFuncAllReduce && logSize >= 0 && logSize < 23)
+    bw *= treeCorrectionFactor[protocol][logSize];
+  if (algorithm == NCCL_ALGO_NVLS_TREE && coll == ncclFuncAllReduce && logSize >= 0 && logSize < 24 &&
+      comm->minCompCap >= 100 && comm->cpuArch == NCCL_TOPO_CPU_ARCH_X86)
+    bw *= treeCorrectionFactor[protocol][logSize];
+  if (algorithm == NCCL_ALGO_RING && protocol == NCCL_PROTO_SIMPLE && comm->nNodes > 1 && coll == ncclFuncAllReduce &&
+      nBytes / (comm->nChannels * comm->nRanks) >= 64) {
     lat *= comm->minCompCap < 80 ? 1.9 : 1.4; // Plateau effect of ring
   }
 #endif
@@ -1154,26 +1633,22 @@ ncclResult_t ncclTopoGetAlgoTime(struct ncclComm* comm, int coll, int algorithm,
  */
 int rcclGetTuningIndexForArch(const char* gfxarch) {
   static const std::vector<std::pair<std::string, int>> tuningIndexMap = {
-    {"gfx906", 0}, {"gfx908", 0}, {"gfx90a", 0}, {"gfx942", 5}, {"gfx950", 6},
-    {"gfx1030", 0},
-    {"gfx1100", 0}, {"gfx1101", 0}, {"gfx1102", 0}, {"gfx1151", 9},
-    {"gfx1200", 7}, {"gfx1201", 7}
+    {"gfx906", 0},  {"gfx908", 0},  {"gfx90a", 0},  {"gfx942", 5},  {"gfx950", 6},  {"gfx1030", 0},
+    {"gfx1100", 0}, {"gfx1101", 0}, {"gfx1102", 0}, {"gfx1151", 9}, {"gfx1200", 7}, {"gfx1201", 7}
   };
 
   static const std::vector<std::pair<std::string, int>> tuningIndexMapAINIC = {
-    {"gfx906", 0}, {"gfx908", 0}, {"gfx90a", 0}, {"gfx942", 8},
-    {"gfx950", 6}, {"gfx1030", 0}, {"gfx1100", 0}, {"gfx1102", 0},
-    {"gfx1200", 7}, {"gfx1201", 7}
+    {"gfx906", 0},  {"gfx908", 0},  {"gfx90a", 0},  {"gfx942", 8},  {"gfx950", 6},
+    {"gfx1030", 0}, {"gfx1100", 0}, {"gfx1102", 0}, {"gfx1200", 7}, {"gfx1201", 7}
   };
 
   if (gfxarch == nullptr) return 0;
   std::string arch(gfxarch);
   auto nicInfo = rcclPrimaryNic();
-  const auto & tuningMap = (nicInfo.type == rcclIBNicTypeAINIC) ? tuningIndexMapAINIC : tuningIndexMap;
+  const auto& tuningMap = (nicInfo.type == rcclIBNicTypeAINIC) ? tuningIndexMapAINIC : tuningIndexMap;
   for (const auto& p : tuningMap) {
     const std::string& prefix = p.first;
-    if (arch.size() >= prefix.size() &&
-        arch.compare(0, prefix.size(), prefix) == 0) {
+    if (arch.size() >= prefix.size() && arch.compare(0, prefix.size(), prefix) == 0) {
       return p.second;
     }
   }
@@ -1182,12 +1657,12 @@ int rcclGetTuningIndexForArch(const char* gfxarch) {
 
 void rcclApplyTuningOverrides(struct ncclTopoSystem* system) {
   auto nicInfo = rcclPrimaryNic();
-  if(IsArchMatch(system->nodes[GPU].nodes[0].gpu.gcn, "gfx950")){
+  if (IsArchMatch(system->nodes[GPU].nodes[0].gpu.gcn, "gfx950")) {
     system->tuning = 6;
   }
 
   if (nicInfo.type == rcclIBNicTypeAINIC) {
-    if (IsArchMatch(system->nodes[GPU].nodes[0].gpu.gcn, "gfx942")){
+    if (IsArchMatch(system->nodes[GPU].nodes[0].gpu.gcn, "gfx942")) {
       system->tuning = 8;
     }
   }

--- a/projects/rccl/src/graph/xml.cc
+++ b/projects/rccl/src/graph/xml.cc
@@ -35,7 +35,7 @@
 typedef ncclResult_t (*xmlHandlerFunc_t)(FILE*, struct ncclXml*, struct ncclXmlNode*);
 
 struct xmlHandler {
-  const char * name;
+  const char* name;
   xmlHandlerFunc_t func;
 };
 
@@ -57,7 +57,7 @@ ncclResult_t xmlGetValue(FILE* file, char* value, char* last) {
     int o = 0;
     do {
       value[o] = c;
-      if (o == MAX_STR_LEN-1) {
+      if (o == MAX_STR_LEN - 1) {
         value[o] = '\0';
         WARN("Error : value %s too long (max %d)", value, MAX_STR_LEN);
         return ncclInternalError;
@@ -78,14 +78,14 @@ ncclResult_t xmlGetValue(FILE* file, char* value, char* last) {
   do {
     NCCLCHECK(xmlGetChar(file, &c));
     value[o] = c;
-    if (o == MAX_STR_LEN-1) {
+    if (o == MAX_STR_LEN - 1) {
       value[o] = '\0';
       WARN("Error : value %s too long (max %d)", value, MAX_STR_LEN);
       return ncclInternalError;
     }
     o++;
   } while (c != quote);
-  value[o-1] = '\0';
+  value[o - 1] = '\0';
   NCCLCHECK(xmlGetChar(file, last));
   return ncclSuccess;
 }
@@ -105,27 +105,32 @@ ncclResult_t xmlGetToken(FILE* file, char* name, char* value, char* last) {
       return xmlGetValue(file, value, last);
     }
     ptr[o] = c;
-    if (o == MAX_STR_LEN-1) {
+    if (o == MAX_STR_LEN - 1) {
       ptr[o] = '\0';
       WARN("Error : name %s too long (max %d)", ptr, MAX_STR_LEN);
       return ncclInternalError;
     }
     o++;
   } while (c != ' ' && c != '>' && c != '/' && c != '\n' && c != '\r');
-  ptr[o-1] = '\0';
+  ptr[o - 1] = '\0';
   *last = c;
   return ncclSuccess;
 }
 
 // Shift the 3-chars string by one char and append c at the end
-#define SHIFT_APPEND(s, c) do { s[0]=s[1]; s[1]=s[2]; s[2]=c; } while(0)
+#define SHIFT_APPEND(s, c) \
+  do { \
+    s[0] = s[1]; \
+    s[1] = s[2]; \
+    s[2] = c; \
+  } while (0)
 ncclResult_t xmlSkipComment(FILE* file, char* start, char next) {
   // Start from something neutral with \0 at the end.
   char end[4] = "...";
 
   // Inject all trailing chars from previous reads. We don't need
   // to check for --> here because there cannot be a > in the name.
-  for (int i=0; i<strlen(start); i++) SHIFT_APPEND(end, start[i]);
+  for (int i = 0; i < strlen(start); i++) SHIFT_APPEND(end, start[i]);
   SHIFT_APPEND(end, next);
 
   // Stop when we find "-->"
@@ -155,7 +160,7 @@ ncclResult_t xmlGetNode(FILE* file, struct ncclXmlNode* node) {
 
   // Check for comments
   if (strncmp(node->name, "!--", 3) == 0) {
-    NCCLCHECK(xmlSkipComment(file, node->name+3, c));
+    NCCLCHECK(xmlSkipComment(file, node->name + 3, c));
     return xmlGetNode(file, node);
   }
 
@@ -195,14 +200,15 @@ ncclResult_t xmlGetNode(FILE* file, struct ncclXmlNode* node) {
   return ncclSuccess;
 }
 
-ncclResult_t xmlLoadSub(FILE* file, struct ncclXml* xml, struct ncclXmlNode* head, struct xmlHandler handlers[], int nHandlers) {
+ncclResult_t xmlLoadSub(FILE* file, struct ncclXml* xml, struct ncclXmlNode* head, struct xmlHandler handlers[],
+                        int nHandlers) {
   if (head && head->type == NODE_TYPE_SINGLE) return ncclSuccess;
   while (1) {
     if (xml->maxIndex == xml->maxNodes) {
       WARN("Error : XML parser is limited to %d nodes", xml->maxNodes);
       return ncclInternalError;
     }
-    struct ncclXmlNode* node = xml->nodes+xml->maxIndex;
+    struct ncclXmlNode* node = xml->nodes + xml->maxIndex;
     memset(node, 0, sizeof(struct ncclXmlNode));
     NCCLCHECK(xmlGetNode(file, node));
     if (node->type == NODE_TYPE_NONE) {
@@ -222,7 +228,7 @@ ncclResult_t xmlLoadSub(FILE* file, struct ncclXml* xml, struct ncclXmlNode* hea
       return ncclSuccess;
     }
     int found = 0;
-    for (int h=0; h<nHandlers; h++) {
+    for (int h = 0; h < nHandlers; h++) {
       if (strcmp(node->name, handlers[h].name) == 0) {
         if (head) {
           if (head->nSubs == MAX_SUBS) {
@@ -253,35 +259,37 @@ ncclResult_t xmlLoadSub(FILE* file, struct ncclXml* xml, struct ncclXmlNode* hea
 // exp == 1 -- serialize; exp == 0 -- deserialize
 ncclResult_t ncclTopoConvertXml(struct ncclXml* xml, uintptr_t base, int exp) {
   for (int n = 0; n < xml->maxIndex; n++) {
-    struct ncclXmlNode *node = &xml->nodes[n];
+    struct ncclXmlNode* node = &xml->nodes[n];
 
     // For "parent", we shift the base by 1 so that we can distinguish actual
     // NULL pointers from pointers pointing to the first node.
     if (node->parent)
-      node->parent = (struct ncclXmlNode *) (exp ? ((uintptr_t)node->parent - base + 1) : (base - 1 + (uintptr_t)node->parent));
+      node->parent =
+        (struct ncclXmlNode*)(exp ? ((uintptr_t)node->parent - base + 1) : (base - 1 + (uintptr_t)node->parent));
 
     for (int s = 0; s < node->nSubs; s++) {
-      node->subs[s] = (struct ncclXmlNode *) (exp ? ((uintptr_t)node->subs[s] - base) : (base + (uintptr_t)node->subs[s]));
+      node->subs[s] =
+        (struct ncclXmlNode*)(exp ? ((uintptr_t)node->subs[s] - base) : (base + (uintptr_t)node->subs[s]));
     }
   }
   return ncclSuccess;
 }
 
 ncclResult_t ncclTopoDumpXmlRec(int indent, FILE* file, struct ncclXmlNode* node) {
-  for (int i=0; i<indent; i++) fprintf(file, " ");
+  for (int i = 0; i < indent; i++) fprintf(file, " ");
   fprintf(file, "<%s", node->name);
 
-  for (int a=0; a<node->nAttrs; a++) {
+  for (int a = 0; a < node->nAttrs; a++) {
     fprintf(file, " %s=\"%s\"", node->attrs[a].key, node->attrs[a].value);
   }
   if (node->nSubs == 0) {
     fprintf(file, "/>\n");
   } else {
     fprintf(file, ">\n");
-    for (int s=0; s<node->nSubs; s++) {
-      NCCLCHECK(ncclTopoDumpXmlRec(indent+2, file, node->subs[s]));
+    for (int s = 0; s < node->nSubs; s++) {
+      NCCLCHECK(ncclTopoDumpXmlRec(indent + 2, file, node->subs[s]));
     }
-    for (int i=0; i<indent; i++) fprintf(file, " ");
+    for (int i = 0; i < indent; i++) fprintf(file, " ");
     fprintf(file, "</%s>\n", node->name);
   }
   return ncclSuccess;
@@ -290,7 +298,7 @@ ncclResult_t ncclTopoDumpXmlRec(int indent, FILE* file, struct ncclXmlNode* node
 ncclResult_t ncclTopoDumpXmlToFile(const char* xmlTopoFile, struct ncclXml* xml) {
   FILE* file = fopen(xmlTopoFile, "w");
   if (file == NULL) {
-    INFO(NCCL_GRAPH|NCCL_ENV, "Unable to open %s, not dumping topology.", xmlTopoFile);
+    INFO(NCCL_GRAPH | NCCL_ENV, "Unable to open %s, not dumping topology.", xmlTopoFile);
     return ncclSuccess;
   }
   NCCLCHECK(ncclTopoDumpXmlRec(0, file, xml->nodes));
@@ -298,7 +306,8 @@ ncclResult_t ncclTopoDumpXmlToFile(const char* xmlTopoFile, struct ncclXml* xml)
   return ncclSuccess;
 }
 
-static ncclResult_t xmlTopoFuseXmlRecursive(struct ncclXml* dst, struct ncclXmlNode* dstParent, struct ncclXmlNode* srcParent) {
+static ncclResult_t xmlTopoFuseXmlRecursive(struct ncclXml* dst, struct ncclXmlNode* dstParent,
+                                            struct ncclXmlNode* srcParent) {
   for (int i = 0; i < srcParent->nSubs; i++) {
     struct ncclXmlNode* srcNode = srcParent->subs[i];
     struct ncclXmlNode* dstNode;
@@ -329,7 +338,6 @@ ncclResult_t ncclTopoFuseXml(struct ncclXml* dst, struct ncclXml* src) {
   return ncclSuccess;
 }
 
-
 /****************************************/
 /* Parser rules for our specific format */
 /****************************************/
@@ -350,9 +358,9 @@ ncclResult_t ncclTopoXmlLoadC2c(FILE* file, struct ncclXml* xml, struct ncclXmlN
 }
 ncclResult_t ncclTopoXmlLoadGpu(FILE* file, struct ncclXml* xml, struct ncclXmlNode* head) {
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-  struct xmlHandler handlers[] = { { "xgmi", ncclTopoXmlLoadNvlink } };
+  struct xmlHandler handlers[] = {{"xgmi", ncclTopoXmlLoadNvlink}};
 #else
-  struct xmlHandler handlers[] = { { "nvlink", ncclTopoXmlLoadNvlink }, { "c2c", ncclTopoXmlLoadC2c } };
+  struct xmlHandler handlers[] = {{"nvlink", ncclTopoXmlLoadNvlink}, {"c2c", ncclTopoXmlLoadC2c}};
 #endif
   NCCLCHECK(xmlLoadSub(file, xml, head, handlers, 2));
   return ncclSuccess;
@@ -364,19 +372,22 @@ ncclResult_t ncclTopoXmlLoadNet(FILE* file, struct ncclXml* xml, struct ncclXmlN
 }
 
 ncclResult_t ncclTopoXmlLoadNic(FILE* file, struct ncclXml* xml, struct ncclXmlNode* head) {
-  struct xmlHandler handlers[] = { { "net", ncclTopoXmlLoadNet } };
+  struct xmlHandler handlers[] = {{"net", ncclTopoXmlLoadNet}};
   NCCLCHECK(xmlLoadSub(file, xml, head, handlers, 1));
   return ncclSuccess;
 }
 
 ncclResult_t ncclTopoXmlLoadPci(FILE* file, struct ncclXml* xml, struct ncclXmlNode* head) {
-  struct xmlHandler handlers[] = { { "pci", ncclTopoXmlLoadPci }, { "gpu", ncclTopoXmlLoadGpu }, { "nic", ncclTopoXmlLoadNic}, { "pcilink", ncclTopoXmlLoadPciLink} };
+  struct xmlHandler handlers[] = {{"pci", ncclTopoXmlLoadPci},
+                                  {"gpu", ncclTopoXmlLoadGpu},
+                                  {"nic", ncclTopoXmlLoadNic},
+                                  {"pcilink", ncclTopoXmlLoadPciLink}};
   NCCLCHECK(xmlLoadSub(file, xml, head, handlers, 4));
   return ncclSuccess;
 }
 
 ncclResult_t ncclTopoXmlLoadCpu(FILE* file, struct ncclXml* xml, struct ncclXmlNode* head) {
-  struct xmlHandler handlers[] = { { "pci", ncclTopoXmlLoadPci }, { "nic", ncclTopoXmlLoadNic } };
+  struct xmlHandler handlers[] = {{"pci", ncclTopoXmlLoadPci}, {"nic", ncclTopoXmlLoadNic}};
   NCCLCHECK(xmlLoadSub(file, xml, head, handlers, 2));
   return ncclSuccess;
 }
@@ -396,7 +407,7 @@ ncclResult_t ncclTopoXmlLoadSystem(FILE* file, struct ncclXml* xml, struct ncclX
     INFO(NCCL_GRAPH, "Loading unnamed topology");
   }
 
-  struct xmlHandler handlers[] = { { "cpu", ncclTopoXmlLoadCpu } };
+  struct xmlHandler handlers[] = {{"cpu", ncclTopoXmlLoadCpu}};
   NCCLCHECK(xmlLoadSub(file, xml, head, handlers, 1));
   return ncclSuccess;
 }
@@ -405,12 +416,12 @@ ncclResult_t ncclTopoGetXmlFromFile(const char* xmlTopoFile, struct ncclXml* xml
   FILE* file = fopen(xmlTopoFile, "r");
   if (file == NULL) {
     if (warn) {
-      INFO(NCCL_GRAPH|NCCL_ENV, "Could not open XML topology file %s : %s", xmlTopoFile, strerror(errno));
+      INFO(NCCL_GRAPH | NCCL_ENV, "Could not open XML topology file %s : %s", xmlTopoFile, strerror(errno));
     }
     return ncclSuccess;
   }
   INFO(NCCL_GRAPH, "Loading topology file %s", xmlTopoFile);
-  struct xmlHandler handlers[] = { { "system", ncclTopoXmlLoadSystem } };
+  struct xmlHandler handlers[] = {{"system", ncclTopoXmlLoadSystem}};
   xml->maxIndex = 0;
   NCCLCHECK(xmlLoadSub(file, xml, NULL, handlers, 1));
   fclose(file);
@@ -425,14 +436,14 @@ ncclResult_t ncclTopoGetXmlFromFile(const char* xmlTopoFile, struct ncclXml* xml
 #define BUSID_SIZE (sizeof("0000:00:00.0"))
 #define BUSID_REDUCED_SIZE (sizeof("0000:00"))
 static void memcpylower(char* dst, const char* src, const size_t size) {
-  for (int i=0; i<size; i++) dst[i] = tolower(src[i]);
+  for (int i = 0; i < size; i++) dst[i] = tolower(src[i]);
 }
 static ncclResult_t getPciPath(const char* busId, char** path) {
   char busPath[] = "/sys/class/pci_bus/0000:00/../../0000:00:00.0";
-  memcpylower(busPath+sizeof("/sys/class/pci_bus/")-1, busId, BUSID_REDUCED_SIZE-1);
-  memcpylower(busPath+sizeof("/sys/class/pci_bus/0000:00/../../")-1, busId, BUSID_SIZE-2);
+  memcpylower(busPath + sizeof("/sys/class/pci_bus/") - 1, busId, BUSID_REDUCED_SIZE - 1);
+  memcpylower(busPath + sizeof("/sys/class/pci_bus/0000:00/../../") - 1, busId, BUSID_SIZE - 2);
   // override PCIe device function ID in CPX mode
-  busPath[sizeof("/sys/class/pci_bus/0000:00/../../")+BUSID_SIZE-3] = '0';
+  busPath[sizeof("/sys/class/pci_bus/0000:00/../../") + BUSID_SIZE - 3] = '0';
   *path = ncclOsRealpath(busPath, NULL);
   if (*path == NULL) {
     WARN("Could not find real path of %s", busPath);
@@ -445,17 +456,17 @@ static ncclResult_t getBcmLinks(const char* busId, int* nlinks, char** peers) {
   *nlinks = 0;
   *peers = NULL;
   char dirPath[] = "/sys/kernel/pci_switch_link/virtual_switch_links/0000:00:00.0";
-  memcpylower(dirPath+sizeof("/sys/kernel/pci_switch_link/virtual_switch_links/")-1, busId, BUSID_SIZE-1);
-  DIR *dir = opendir(dirPath);
+  memcpylower(dirPath + sizeof("/sys/kernel/pci_switch_link/virtual_switch_links/") - 1, busId, BUSID_SIZE - 1);
+  DIR* dir = opendir(dirPath);
   if (dir) {
     struct dirent* file;
     while ((file = readdir(dir)) != NULL) {
-      if (strlen(file->d_name) != BUSID_SIZE-1) continue;
+      if (strlen(file->d_name) != BUSID_SIZE - 1) continue;
       char* path;
       if (getPciPath(file->d_name, &path) == ncclSystemError) continue;
       free(path);
-      NCCLCHECK(ncclRealloc(peers, (*nlinks)*BUSID_SIZE, ((*nlinks)+1)*BUSID_SIZE));
-      memcpy((*peers)+BUSID_SIZE*(*nlinks)++, file->d_name, BUSID_SIZE);
+      NCCLCHECK(ncclRealloc(peers, (*nlinks) * BUSID_SIZE, ((*nlinks) + 1) * BUSID_SIZE));
+      memcpy((*peers) + BUSID_SIZE * (*nlinks)++, file->d_name, BUSID_SIZE);
     }
     closedir(dir);
   }
@@ -469,7 +480,7 @@ ncclResult_t ncclTopoGetStrFromSys(const char* path, const char* fileName, char*
   FILE* file;
   if ((file = fopen(filePath, "r")) != NULL) {
     while (feof(file) == 0 && ferror(file) == 0 && offset < MAX_STR_LEN) {
-      int len = fread(strValue+offset, 1, MAX_STR_LEN-offset, file);
+      int len = fread(strValue + offset, 1, MAX_STR_LEN - offset, file);
       offset += len;
     }
     fclose(file);
@@ -478,15 +489,18 @@ ncclResult_t ncclTopoGetStrFromSys(const char* path, const char* fileName, char*
     strValue[0] = '\0';
     INFO(NCCL_GRAPH, "Topology detection : could not read %s, ignoring", filePath);
   } else {
-    strValue[offset-1] = '\0';
+    strValue[offset - 1] = '\0';
   }
   return ncclSuccess;
 }
 
-ncclResult_t ncclTopoSetAttrFromSys(struct ncclXmlNode* pciNode, const char* path, const char* fileName, const char* attrName) {
+ncclResult_t ncclTopoSetAttrFromSys(struct ncclXmlNode* pciNode, const char* path, const char* fileName,
+                                    const char* attrName) {
   char strValue[MAX_STR_LEN];
   NCCLCHECK(ncclTopoGetStrFromSys(path, fileName, strValue));
-  if (strValue[0] != '\0') { NCCLCHECK(xmlSetAttr(pciNode, attrName, strValue)); }
+  if (strValue[0] != '\0') {
+    NCCLCHECK(xmlSetAttr(pciNode, attrName, strValue));
+  }
   TRACE(NCCL_GRAPH, "Read from sys %s/%s -> %s=%s", path, fileName, attrName, strValue);
   return ncclSuccess;
 }
@@ -586,7 +600,8 @@ int checkBDFFormat(char* bdf) {
   if ((bdf[4] != ':') || (bdf[7] != ':') || (bdf[10] != '.')) return 0;
   if ((isHex(bdf[0]) == 0) || (isHex(bdf[1]) == 0) || (isHex(bdf[2]) == 0) || (isHex(bdf[3]) == 0) ||
       (isHex(bdf[5]) == 0) || (isHex(bdf[6]) == 0) || (isHex(bdf[8]) == 0) || (isHex(bdf[9]) == 0) ||
-      (isHex(bdf[11]) == 0)) return 0;
+      (isHex(bdf[11]) == 0))
+    return 0;
   return 1;
 }
 
@@ -632,11 +647,10 @@ ncclResult_t ncclTopoGetXmlFromSys(struct ncclXmlNode* pciNode, struct ncclXml* 
       char portSpeedStr[MAX_STR_LEN];
       float portSpeed = FLT_MAX;
       NCCLCHECKGOTO(ncclTopoGetStrFromSys(path, "../max_link_speed", portSpeedStr), ret, exit);
-      if (portSpeedStr[0])
-        sscanf(portSpeedStr, "%f GT/s", &portSpeed);
-      else
-        portSpeed = deviceSpeed;
-      NCCLCHECKGOTO(xmlSetAttr(pciNode, "link_speed", portSpeed < deviceSpeed ? portSpeedStr : deviceSpeedStr), ret, exit);
+      if (portSpeedStr[0]) sscanf(portSpeedStr, "%f GT/s", &portSpeed);
+      else portSpeed = deviceSpeed;
+      NCCLCHECKGOTO(xmlSetAttr(pciNode, "link_speed", portSpeed < deviceSpeed ? portSpeedStr : deviceSpeedStr), ret,
+                    exit);
     } else {
       NCCLCHECKGOTO(xmlSetAttr(pciNode, "link_speed", ""), ret, exit);
     }
@@ -649,10 +663,8 @@ ncclResult_t ncclTopoGetXmlFromSys(struct ncclXmlNode* pciNode, struct ncclXml* 
       int deviceWidth = strtol(strValue, NULL, 0);
       NCCLCHECKGOTO(ncclTopoGetStrFromSys(path, "../max_link_width", strValue), ret, exit);
       int portWidth;
-      if (strValue[0])
-        portWidth = strtol(strValue, NULL, 0);
-      else
-        portWidth = deviceWidth;
+      if (strValue[0]) portWidth = strtol(strValue, NULL, 0);
+      else portWidth = deviceWidth;
       NCCLCHECKGOTO(xmlSetAttrInt(pciNode, "link_width", std::min(deviceWidth, portWidth)), ret, exit);
     } else {
       NCCLCHECKGOTO(xmlSetAttr(pciNode, "link_width", ""), ret, exit);
@@ -663,8 +675,8 @@ ncclResult_t ncclTopoGetXmlFromSys(struct ncclXmlNode* pciNode, struct ncclXml* 
   if (vendor != NULL && strcmp(vendor, "0x1000") == 0) { // BCM switch, look for P2P connections
     int nlinks;
     NCCLCHECKGOTO(getBcmLinks(busId, &nlinks, &peers), ret, exit);
-    for (int l=0; l<nlinks; l++) {
-      char* target = peers+l*BUSID_SIZE;
+    for (int l = 0; l < nlinks; l++) {
+      char* target = peers + l * BUSID_SIZE;
       struct ncclXmlNode* linkNode;
       NCCLCHECKGOTO(xmlGetSubKv(pciNode, "pcilink", &linkNode, "target", target), ret, exit);
       if (linkNode == NULL) {
@@ -689,14 +701,14 @@ ncclResult_t ncclTopoGetXmlFromSys(struct ncclXmlNode* pciNode, struct ncclXml* 
       // switch, or stop if we reach a CPU root complex.
       int slashCount = 0;
       int parentOffset;
-      for (parentOffset = strlen(path)-1; parentOffset>0; parentOffset--) {
+      for (parentOffset = strlen(path) - 1; parentOffset > 0; parentOffset--) {
         if (path[parentOffset] == '/') {
           slashCount++;
           path[parentOffset] = '\0';
           int start = parentOffset - 1;
-          while (start>0 && path[start] != '/') start--;
+          while (start > 0 && path[start] != '/') start--;
           // Check whether the parent path looks like "BBBB:BB:DD.F" or not.
-          if (checkBDFFormat(path+start+1) == 0) {
+          if (checkBDFFormat(path + start + 1) == 0) {
             // This a CPU root complex. Create a CPU tag and stop there.
             struct ncclXmlNode* topNode;
             NCCLCHECKGOTO(xmlFindTag(xml, "system", &topNode), ret, exit);
@@ -708,12 +720,12 @@ ncclResult_t ncclTopoGetXmlFromSys(struct ncclXmlNode* pciNode, struct ncclXml* 
             }
           } else if (slashCount == 2) {
             // Continue on the upper PCI switch
-            for (int i = strlen(path)-1; i>0; i--) {
+            for (int i = strlen(path) - 1; i > 0; i--) {
               if (path[i] == '/') {
-                NCCLCHECKGOTO(xmlFindTagKv(xml, "pci", &parent, "busid", path+i+1), ret, exit);
+                NCCLCHECKGOTO(xmlFindTagKv(xml, "pci", &parent, "busid", path + i + 1), ret, exit);
                 if (parent == NULL) {
                   NCCLCHECKGOTO(xmlAddNode(xml, NULL, "pci", &parent), ret, exit);
-                  NCCLCHECKGOTO(xmlSetAttr(parent, "busid", path+i+1), ret, exit);
+                  NCCLCHECKGOTO(xmlSetAttr(parent, "busid", path + i + 1), ret, exit);
                 }
                 break;
               }
@@ -742,17 +754,20 @@ ncclResult_t ncclTopoGetXmlFromSys(struct ncclXmlNode* pciNode, struct ncclXml* 
     int subIndex = parent->nSubs;
     const char* newBusId;
     NCCLCHECKGOTO(xmlGetAttrStr(pciNode, "busid", &newBusId), ret, exit);
-    for (int s=0; s<parent->nSubs; s++) {
+    for (int s = 0; s < parent->nSubs; s++) {
       const char* busId;
       NCCLCHECKGOTO(xmlGetAttr(parent->subs[s], "busid", &busId), ret, exit);
-      if (busId != NULL && strcmp(newBusId, busId) < 0) { subIndex = s; break; }
+      if (busId != NULL && strcmp(newBusId, busId) < 0) {
+        subIndex = s;
+        break;
+      }
     }
     if (parent->nSubs == MAX_SUBS) {
       WARN("Error : XML parser is limited to %d subnodes", MAX_SUBS);
       ret = ncclInternalError;
       goto exit;
     }
-    for (int s = parent->nSubs; s > subIndex; s--) parent->subs[s] = parent->subs[s-1];
+    for (int s = parent->nSubs; s > subIndex; s--) parent->subs[s] = parent->subs[s - 1];
     parent->subs[subIndex] = pciNode;
     parent->nSubs++;
   }
@@ -767,7 +782,8 @@ exit:
   return ret;
 }
 
-ncclResult_t ncclTopoGetXmlFromGpu(struct ncclXmlNode* pciNode, uint32_t rocmDev, struct ncclXml* xml, struct ncclXmlNode** gpuNodeRet) {
+ncclResult_t ncclTopoGetXmlFromGpu(struct ncclXmlNode* pciNode, uint32_t rocmDev, struct ncclXml* xml,
+                                   struct ncclXmlNode** gpuNodeRet) {
   struct ncclXmlNode* gpuNode = NULL;
   NCCLCHECK(xmlGetSub(pciNode, "gpu", &gpuNode));
   if (gpuNode == NULL) NCCLCHECK(xmlAddNode(xml, pciNode, "gpu", &gpuNode));
@@ -780,7 +796,10 @@ ncclResult_t ncclTopoGetXmlFromGpu(struct ncclXmlNode* pciNode, uint32_t rocmDev
     NCCLCHECK(xmlSetAttrInt(gpuNode, "dev", rocmDev));
   }
   NCCLCHECK(xmlGetAttrInt(gpuNode, "dev", &dev));
-  if (dev == -1) { *gpuNodeRet = NULL; return ncclSuccess; }
+  if (dev == -1) {
+    *gpuNodeRet = NULL;
+    return ncclSuccess;
+  }
 
   NCCLCHECK(xmlGetAttrIndex(gpuNode, "sm", &index));
   if (index == -1) {
@@ -797,8 +816,8 @@ ncclResult_t ncclTopoGetXmlFromGpu(struct ncclXmlNode* pciNode, uint32_t rocmDev
   if (index == -1) {
     hipDeviceProp_t devProp;
     CUDACHECK(hipGetDeviceProperties(&devProp, 0));
-    //extract only the releveant info from the gcnArchName attribute
-    //e.g.: convert "gfx908:sramecc+:xnack-" to "gfx908"
+    // extract only the releveant info from the gcnArchName attribute
+    // e.g.: convert "gfx908:sramecc+:xnack-" to "gfx908"
     char gcnArchNameSubstr[128];
     GcnArchNameFormat(devProp.gcnArchName, gcnArchNameSubstr);
     gcn = gcnArchNameSubstr;
@@ -807,7 +826,7 @@ ncclResult_t ncclTopoGetXmlFromGpu(struct ncclXmlNode* pciNode, uint32_t rocmDev
   NCCLCHECK(xmlGetAttr(gpuNode, "gcn", &gcn));
   convertGcnArchToGcnArchName(gcn, &gcnArchName);
   if (gcn != gcnArchName) {
-     NCCLCHECK(xmlSetAttr(gpuNode, "gcn", gcnArchName));
+    NCCLCHECK(xmlSetAttr(gpuNode, "gcn", gcnArchName));
   }
 
   rcclHipDeviceArch_t arch;
@@ -833,7 +852,7 @@ ncclResult_t ncclTopoGetXmlFromGpu(struct ncclXmlNode* pciNode, uint32_t rocmDev
     uint32_t deviceCnt;
 #ifdef USE_AMDSMI
     NCCLCHECK(amd_smi_getNumDevice(&deviceCnt));
-    for (int i=0; i<deviceCnt; i++) {
+    for (int i = 0; i < deviceCnt; i++) {
       if (i != dev) {
         amdsmi_link_type_t amdsmi_type;
         int hops, count;
@@ -842,7 +861,7 @@ ncclResult_t ncclTopoGetXmlFromGpu(struct ncclXmlNode* pciNode, uint32_t rocmDev
             char busIdStr[] = "00000000:00:00.0";
             NCCLCHECK(amd_smi_getDevicePciBusIdString(i, busIdStr, sizeof(busIdStr)));
             char lowerId[NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE];
-            for (int c=0; c<NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE; c++) {
+            for (int c = 0; c < NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE; c++) {
               lowerId[c] = tolower(busIdStr[c]);
               if (busIdStr[c] == 0) break;
             }
@@ -858,7 +877,7 @@ ncclResult_t ncclTopoGetXmlFromGpu(struct ncclXmlNode* pciNode, uint32_t rocmDev
     }
 #else
     NCCLCHECK(rocm_smi_getNumDevice(&deviceCnt));
-    for (int i=0; i<deviceCnt; i++) {
+    for (int i = 0; i < deviceCnt; i++) {
       if (i != dev) {
         RSMI_IO_LINK_TYPE rsmi_type;
         int hops, count;
@@ -867,7 +886,7 @@ ncclResult_t ncclTopoGetXmlFromGpu(struct ncclXmlNode* pciNode, uint32_t rocmDev
             char busIdStr[] = "00000000:00:00.0";
             NCCLCHECK(rocm_smi_getDevicePciBusIdString(i, busIdStr, sizeof(busIdStr)));
             char lowerId[NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE];
-            for (int c=0; c<NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE; c++) {
+            for (int c = 0; c < NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE; c++) {
               lowerId[c] = tolower(busIdStr[c]);
               if (busIdStr[c] == 0) break;
             }
@@ -891,10 +910,12 @@ ncclResult_t ncclTopoGetXmlFromGpu(struct ncclXmlNode* pciNode, uint32_t rocmDev
       maxNvLinks = 0;
     }
 
-    for (int l=0; l<maxNvLinks; ++l) {
+    for (int l = 0; l < maxNvLinks; ++l) {
       // Check whether we can use this NVLink for P2P
       unsigned canP2P;
-      if ((ncclNvmlDeviceGetNvLinkCapability(nvmlDev, l, NVML_NVLINK_CAP_P2P_SUPPORTED, &canP2P) != ncclSuccess) || !canP2P) continue;
+      if ((ncclNvmlDeviceGetNvLinkCapability(nvmlDev, l, NVML_NVLINK_CAP_P2P_SUPPORTED, &canP2P) != ncclSuccess) ||
+          !canP2P)
+        continue;
 
       // Make sure the Nvlink is up. The previous call should have trained the link.
       nvmlEnableState_t isActive = NVML_FEATURE_DISABLED;
@@ -905,11 +926,11 @@ ncclResult_t ncclTopoGetXmlFromGpu(struct ncclXmlNode* pciNode, uint32_t rocmDev
         fv.scopeId = l;
         // fv.value will contain NV_FEATURE_ENABLED or NV_FEATURE_DISABLED
         if ((ncclNvmlDeviceGetFieldValues(nvmlDev, 1, &fv) == ncclSuccess) && (fv.nvmlReturn == NVML_SUCCESS))
-          isActive = (nvmlEnableState_t) fv.value.uiVal;
+          isActive = (nvmlEnableState_t)fv.value.uiVal;
       } else /* FALLTHRU to GetNvLinkState if before SM90 */
 #endif
       {
-        (void) ncclNvmlDeviceGetNvLinkState(nvmlDev, l, &isActive);
+        (void)ncclNvmlDeviceGetNvLinkState(nvmlDev, l, &isActive);
       }
       if (isActive != NVML_FEATURE_ENABLED) continue;
 
@@ -921,7 +942,7 @@ ncclResult_t ncclTopoGetXmlFromGpu(struct ncclXmlNode* pciNode, uint32_t rocmDev
       // PCI system path is in lower case
       char* p = remoteProc.busId;
       char lowerId[NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE];
-      for (int c=0; c<NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE; c++) {
+      for (int c = 0; c < NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE; c++) {
         lowerId[c] = tolower(p[c]);
         if (p[c] == 0) break;
       }
@@ -934,7 +955,7 @@ ncclResult_t ncclTopoGetXmlFromGpu(struct ncclXmlNode* pciNode, uint32_t rocmDev
       } else {
         int count;
         NCCLCHECK(xmlGetAttrInt(nvlNode, "count", &count));
-        NCCLCHECK(xmlSetAttrInt(nvlNode, "count", count+1));
+        NCCLCHECK(xmlSetAttrInt(nvlNode, "count", count + 1));
       }
     }
 #endif
@@ -943,39 +964,37 @@ ncclResult_t ncclTopoGetXmlFromGpu(struct ncclXmlNode* pciNode, uint32_t rocmDev
   struct ncclXmlNode* c2cNode = NULL;
   NCCLCHECK(xmlGetSub(gpuNode, "c2c", &c2cNode));
   if (c2cNode == NULL) {
-      if (sm >= 90) {
-        int c2cLinksCount = 0;
-        nvmlFieldValue_t fv;
-        fv.fieldId = NVML_FI_DEV_C2C_LINK_COUNT;
-        if ((ncclNvmlDeviceGetFieldValues(nvmlDev, 1, &fv) == ncclSuccess) && (fv.nvmlReturn == NVML_SUCCESS)) {
-          c2cLinksCount = fv.value.uiVal;
-          int bw = 0;
-	  int count = 0;
-          for (int l=0; l<c2cLinksCount; l++) {
-            nvmlFieldValue_t fvs[2];
-            fvs[0].fieldId = NVML_FI_DEV_C2C_LINK_GET_STATUS;
-            fvs[0].scopeId = l;
-            fvs[1].fieldId = NVML_FI_DEV_C2C_LINK_GET_MAX_BW;
-            fvs[1].scopeId = l;
-            if ((ncclNvmlDeviceGetFieldValues(nvmlDev, 2, fvs) == ncclSuccess) &&
-                (fvs[0].nvmlReturn == NVML_SUCCESS) &&
-                (fvs[0].value.uiVal == 1) &&
-                (fvs[1].nvmlReturn == NVML_SUCCESS)) {
-              bw = fvs[1].value.uiVal;
-	      count++;
-            }
-          }
-          if (count > 0) {
-            NCCLCHECK(xmlAddNode(xml, gpuNode, "c2c", &c2cNode));
-            NCCLCHECK(xmlSetAttrInt(c2cNode, "bw", bw));
-            NCCLCHECK(xmlSetAttrInt(c2cNode, "count", count));
+    if (sm >= 90) {
+      int c2cLinksCount = 0;
+      nvmlFieldValue_t fv;
+      fv.fieldId = NVML_FI_DEV_C2C_LINK_COUNT;
+      if ((ncclNvmlDeviceGetFieldValues(nvmlDev, 1, &fv) == ncclSuccess) && (fv.nvmlReturn == NVML_SUCCESS)) {
+        c2cLinksCount = fv.value.uiVal;
+        int bw = 0;
+        int count = 0;
+        for (int l = 0; l < c2cLinksCount; l++) {
+          nvmlFieldValue_t fvs[2];
+          fvs[0].fieldId = NVML_FI_DEV_C2C_LINK_GET_STATUS;
+          fvs[0].scopeId = l;
+          fvs[1].fieldId = NVML_FI_DEV_C2C_LINK_GET_MAX_BW;
+          fvs[1].scopeId = l;
+          if ((ncclNvmlDeviceGetFieldValues(nvmlDev, 2, fvs) == ncclSuccess) && (fvs[0].nvmlReturn == NVML_SUCCESS) &&
+              (fvs[0].value.uiVal == 1) && (fvs[1].nvmlReturn == NVML_SUCCESS)) {
+            bw = fvs[1].value.uiVal;
+            count++;
           }
         }
+        if (count > 0) {
+          NCCLCHECK(xmlAddNode(xml, gpuNode, "c2c", &c2cNode));
+          NCCLCHECK(xmlSetAttrInt(c2cNode, "bw", bw));
+          NCCLCHECK(xmlSetAttrInt(c2cNode, "count", count));
+        }
       }
+    }
   }
 #endif
   // Fill target classes
-  for (int s=0; s<gpuNode->nSubs; s++) {
+  for (int s = 0; s < gpuNode->nSubs; s++) {
     struct ncclXmlNode* sub = gpuNode->subs[s];
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
     if (strcmp(sub->name, "xgmi") != 0) continue;
@@ -1044,13 +1063,14 @@ ncclResult_t ncclTopoGetSubsystem(const char* sysPath, char* subSys) {
   } else {
     int offset;
     for (offset = strlen(path); offset > 0 && path[offset] != '/'; offset--);
-    strcpy(subSys, path+offset+1);
+    strcpy(subSys, path + offset + 1);
     free(path);
   }
   return ncclSuccess;
 }
 
-ncclResult_t ncclTopoFillNet(struct ncclXml* xml, const char* tagName, const char* pciPath, const char* netName, struct ncclXmlNode** netNode, struct ncclXmlNode* forceParent) {
+ncclResult_t ncclTopoFillNet(struct ncclXml* xml, const char* tagName, const char* pciPath, const char* netName,
+                             struct ncclXmlNode** netNode, struct ncclXmlNode* forceParent) {
   NCCLCHECK(xmlFindTagKv(xml, tagName, netNode, "name", netName));
 
   if (*netNode != NULL) return ncclSuccess;
@@ -1065,7 +1085,9 @@ ncclResult_t ncclTopoFillNet(struct ncclXml* xml, const char* tagName, const cha
       NCCLCHECK(ncclTopoGetSubsystem(pciSysPath, subSystem));
       // This is not a PCI device (virtual, usb, ...).
       if (strcmp(subSystem, "pci") != 0 && !forceParent) {
-        INFO(NCCL_NET | NCCL_GRAPH, "Topology detection: network path (name = %s) %s is not a PCI device (%s). Attaching to first CPU", netName, pciSysPath, subSystem);
+        INFO(NCCL_NET | NCCL_GRAPH,
+             "Topology detection: network path (name = %s) %s is not a PCI device (%s). Attaching to first CPU",
+             netName, pciSysPath, subSystem);
         pciSysPath = NULL;
       }
     }
@@ -1108,10 +1130,10 @@ ncclResult_t ncclTopoTrimXmlRec(struct ncclXmlNode* node, int* keep) {
     struct ncclXmlNode** subs = NULL;
     NCCLCHECK(ncclCalloc(&subs, MAX_SUBS));
     int nSubs = node->nSubs;
-    memcpy(subs, node->subs, node->nSubs*sizeof(struct ncclXmlNode*));
+    memcpy(subs, node->subs, node->nSubs * sizeof(struct ncclXmlNode*));
     *keep = 0;
     ncclResult_t subsRes = ncclSuccess;
-    for (int s=0; s<nSubs; s++) {
+    for (int s = 0; s < nSubs; s++) {
       int k = 0;
       subsRes = ncclTopoTrimXmlRec(subs[s], &k);
       if (subsRes != ncclSuccess) {
@@ -1123,7 +1145,8 @@ ncclResult_t ncclTopoTrimXmlRec(struct ncclXmlNode* node, int* keep) {
     NCCLCHECK(subsRes);
     // Remove node if it has no children and no keep attribute
     if (*keep == 0 && // Trim PCI switches, CPUs with no used GPU/NIC under them, or pruned NICs
-        (strcmp(node->name, "pci") == 0 || strcmp(node->name, "cpu") == 0 || strcmp(node->name, "nic") == 0 || strcmp(node->name, "net") == 0)) {
+        (strcmp(node->name, "pci") == 0 || strcmp(node->name, "cpu") == 0 || strcmp(node->name, "nic") == 0 ||
+         strcmp(node->name, "net") == 0)) {
 #ifdef ENABLE_TRACE
       const char* name;
       const char* busid;
@@ -1157,13 +1180,13 @@ ncclResult_t ncclTopoXmlGraphLoadNet(FILE* file, struct ncclXml* xml, struct ncc
 }
 
 ncclResult_t ncclTopoXmlGraphLoadChannel(FILE* file, struct ncclXml* xml, struct ncclXmlNode* head) {
-  struct xmlHandler handlers[] = { { "net", ncclTopoXmlGraphLoadNet }, { "gpu", ncclTopoXmlGraphLoadGpu } };
+  struct xmlHandler handlers[] = {{"net", ncclTopoXmlGraphLoadNet}, {"gpu", ncclTopoXmlGraphLoadGpu}};
   NCCLCHECK(xmlLoadSub(file, xml, head, handlers, 2));
   return ncclSuccess;
 }
 
 ncclResult_t ncclTopoXmlGraphLoadGraph(FILE* file, struct ncclXml* xml, struct ncclXmlNode* head) {
-  struct xmlHandler handlers[] = { { "channel", ncclTopoXmlGraphLoadChannel } };
+  struct xmlHandler handlers[] = {{"channel", ncclTopoXmlGraphLoadChannel}};
   NCCLCHECK(xmlLoadSub(file, xml, head, handlers, 1));
   return ncclSuccess;
 }
@@ -1180,7 +1203,7 @@ ncclResult_t ncclTopoXmlGraphLoadGraphs(FILE* file, struct ncclXml* xmlGraph, st
   if (name != NULL) INFO(NCCL_GRAPH, "Loading graphs for topology %s", name);
   else INFO(NCCL_GRAPH, "Loading graphs");
 
-  struct xmlHandler handlers[] = { { "graph", ncclTopoXmlGraphLoadGraph } };
+  struct xmlHandler handlers[] = {{"graph", ncclTopoXmlGraphLoadGraph}};
   NCCLCHECK(xmlLoadSub(file, xmlGraph, head, handlers, 1));
   return ncclSuccess;
 }
@@ -1191,7 +1214,7 @@ ncclResult_t ncclTopoGetXmlGraphFromFile(const char* xmlGraphFile, struct ncclXm
     WARN("Could not open XML graph file %s : %s", xmlGraphFile, strerror(errno));
     return ncclSystemError;
   }
-  struct xmlHandler handlers[] = { { "graphs", ncclTopoXmlGraphLoadGraphs } };
+  struct xmlHandler handlers[] = {{"graphs", ncclTopoXmlGraphLoadGraphs}};
   xml->maxIndex = 0;
   NCCLCHECK(xmlLoadSub(file, xml, NULL, handlers, 1));
   fclose(file);
@@ -1236,7 +1259,8 @@ ncclResult_t xmlGetNode(FILE* file, struct ncclXmlNode* node) {
   return ncclSuccess;
 }
 
-ncclResult_t xmlLoadSub(FILE* file, struct ncclXml* xml, struct ncclXmlNode* head, struct xmlHandler handlers[], int nHandlers) {
+ncclResult_t xmlLoadSub(FILE* file, struct ncclXml* xml, struct ncclXmlNode* head, struct xmlHandler handlers[],
+                        int nHandlers) {
   (void)file;
   (void)xml;
   (void)head;
@@ -1348,7 +1372,8 @@ ncclResult_t ncclTopoGetStrFromSys(const char* path, const char* fileName, char*
   return ncclSuccess;
 }
 
-ncclResult_t ncclTopoSetAttrFromSys(struct ncclXmlNode* pciNode, const char* path, const char* fileName, const char* attrName) {
+ncclResult_t ncclTopoSetAttrFromSys(struct ncclXmlNode* pciNode, const char* path, const char* fileName,
+                                    const char* attrName) {
   (void)pciNode;
   (void)path;
   (void)fileName;
@@ -1385,7 +1410,8 @@ ncclResult_t ncclTopoGetXmlFromSys(struct ncclXmlNode* pciNode, struct ncclXml* 
   return ncclSuccess;
 }
 
-ncclResult_t ncclTopoGetXmlFromGpu(struct ncclXmlNode* pciNode, nvmlDevice_t nvmlDev, struct ncclXml* xml, struct ncclXmlNode** gpuNodeRet) {
+ncclResult_t ncclTopoGetXmlFromGpu(struct ncclXmlNode* pciNode, nvmlDevice_t nvmlDev, struct ncclXml* xml,
+                                   struct ncclXmlNode** gpuNodeRet) {
   (void)pciNode;
   (void)nvmlDev;
   (void)xml;
@@ -1406,7 +1432,8 @@ ncclResult_t ncclTopoGetSubsystem(const char* sysPath, char* subSys) {
   return ncclSuccess;
 }
 
-ncclResult_t ncclTopoFillNet(struct ncclXml* xml, const char* tagName, const char* pciPath, const char* netName, struct ncclXmlNode** netNode, struct ncclXmlNode* forceParent) {
+ncclResult_t ncclTopoFillNet(struct ncclXml* xml, const char* tagName, const char* pciPath, const char* netName,
+                             struct ncclXmlNode** netNode, struct ncclXmlNode* forceParent) {
   (void)xml;
   (void)tagName;
   (void)pciPath;

--- a/projects/rccl/src/graph/xml.h
+++ b/projects/rccl/src/graph/xml.h
@@ -19,7 +19,7 @@
 // A few constraints to make the implementation easy
 #define MAX_STR_LEN 255
 #define MAX_ATTR_COUNT 16
-#define MAX_SUBS 512	//Changed the value from 128 to 512 for CPX mode
+#define MAX_SUBS 512 // Changed the value from 128 to 512 for CPX mode
 
 #define NODE_TYPE_NONE 0
 #define NODE_TYPE_OPEN 1
@@ -27,11 +27,11 @@
 #define NODE_TYPE_SINGLE 3
 
 struct ncclXmlNode {
-  char name[MAX_STR_LEN+1];
+  char name[MAX_STR_LEN + 1];
   struct {
-    char key[MAX_STR_LEN+1];
-    char value[MAX_STR_LEN+1];
-  } attrs[MAX_ATTR_COUNT+1]; // Need an extra one to consume extra params
+    char key[MAX_STR_LEN + 1];
+    char value[MAX_STR_LEN + 1];
+  } attrs[MAX_ATTR_COUNT + 1]; // Need an extra one to consume extra params
   int nAttrs;
   int type;
   struct ncclXmlNode* parent;
@@ -53,7 +53,8 @@ ncclResult_t ncclTopoGetXmlGraphFromFile(const char* xmlGraphFile, struct ncclXm
 
 /* Auto-detect functions */
 ncclResult_t ncclTopoFillGpu(struct ncclXml* xml, const char* busId, struct ncclXmlNode** gpuNode);
-ncclResult_t ncclTopoFillNet(struct ncclXml* xml, const char* tagName, const char* pciPath, const char* netName, struct ncclXmlNode** netNode, struct ncclXmlNode* forceParent=NULL);
+ncclResult_t ncclTopoFillNet(struct ncclXml* xml, const char* tagName, const char* pciPath, const char* netName,
+                             struct ncclXmlNode** netNode, struct ncclXmlNode* forceParent = NULL);
 
 /* Remove unneeded parts */
 ncclResult_t ncclTopoTrimXml(struct ncclXml* xml);
@@ -71,7 +72,7 @@ ncclResult_t ncclTopoGetStrFromSys(const char* path, const char* fileName, char*
 /**************/
 
 static size_t xmlMemSize(int maxNodes) {
-  return offsetof(struct ncclXml, nodes) + sizeof(struct ncclXmlNode)*maxNodes;
+  return offsetof(struct ncclXml, nodes) + sizeof(struct ncclXmlNode) * maxNodes;
 }
 static ncclResult_t xmlAlloc(struct ncclXml** xml, int maxNodes) {
   char* mem;
@@ -84,7 +85,7 @@ static ncclResult_t xmlAlloc(struct ncclXml** xml, int maxNodes) {
 static ncclResult_t xmlGetAttrIndex(struct ncclXmlNode* node, const char* attrName, int* index) {
   *index = -1;
   const int nAttrs = node->nAttrs;
-  for (int a=0; a<nAttrs; a++) {
+  for (int a = 0; a < nAttrs; a++) {
     if (strncmp(node->attrs[a].key, attrName, MAX_STR_LEN) == 0) {
       *index = a;
       return ncclSuccess;
@@ -129,7 +130,8 @@ static ncclResult_t xmlGetAttrUint64(struct ncclXmlNode* node, const char* attrN
   return ncclSuccess;
 }
 
-static ncclResult_t xmlGetAttrUint64Default(struct ncclXmlNode* node, const char* attrName, uint64_t* value, uint64_t defaultValue) {
+static ncclResult_t xmlGetAttrUint64Default(struct ncclXmlNode* node, const char* attrName, uint64_t* value,
+                                            uint64_t defaultValue) {
   const char* str;
   NCCLCHECK(xmlGetAttr(node, attrName, &str));
   *value = str ? strtoull(str, NULL, 0) : defaultValue;
@@ -150,7 +152,8 @@ static ncclResult_t xmlGetAttrFloat(struct ncclXmlNode* node, const char* attrNa
   return ncclSuccess;
 }
 
-static ncclResult_t xmlGetAttrFloatDefault(struct ncclXmlNode* node, const char* attrName, float* value, float defaultValue) {
+static ncclResult_t xmlGetAttrFloatDefault(struct ncclXmlNode* node, const char* attrName, float* value,
+                                           float defaultValue) {
   const char* str;
   NCCLCHECK(xmlGetAttr(node, attrName, &str));
   *value = str ? strtof(str, NULL) : defaultValue;
@@ -159,8 +162,8 @@ static ncclResult_t xmlGetAttrFloatDefault(struct ncclXmlNode* node, const char*
 
 static ncclResult_t xmlFindTag(struct ncclXml* xml, const char* tagName, struct ncclXmlNode** node) {
   *node = NULL;
-  for (int i=0; i<xml->maxIndex; i++) {
-    struct ncclXmlNode* n = xml->nodes+i;
+  for (int i = 0; i < xml->maxIndex; i++) {
+    struct ncclXmlNode* n = xml->nodes + i;
     if (strcmp(n->name, tagName) == 0) {
       *node = n;
       return ncclSuccess;
@@ -169,10 +172,11 @@ static ncclResult_t xmlFindTag(struct ncclXml* xml, const char* tagName, struct 
   return ncclSuccess;
 }
 
-static ncclResult_t xmlFindNextTag(struct ncclXml* xml, const char* tagName, struct ncclXmlNode* prev, struct ncclXmlNode** node) {
+static ncclResult_t xmlFindNextTag(struct ncclXml* xml, const char* tagName, struct ncclXmlNode* prev,
+                                   struct ncclXmlNode** node) {
   *node = NULL;
-  for (int i=prev-xml->nodes+1; i<xml->maxIndex; i++) {
-    struct ncclXmlNode* n = xml->nodes+i;
+  for (int i = prev - xml->nodes + 1; i < xml->maxIndex; i++) {
+    struct ncclXmlNode* n = xml->nodes + i;
     if (strcmp(n->name, tagName) == 0) {
       *node = n;
       return ncclSuccess;
@@ -181,10 +185,11 @@ static ncclResult_t xmlFindNextTag(struct ncclXml* xml, const char* tagName, str
   return ncclSuccess;
 }
 
-static ncclResult_t xmlFindTagKv(struct ncclXml* xml, const char* tagName, struct ncclXmlNode** node, const char* attrName, const char* attrValue) {
+static ncclResult_t xmlFindTagKv(struct ncclXml* xml, const char* tagName, struct ncclXmlNode** node,
+                                 const char* attrName, const char* attrValue) {
   *node = NULL;
-  for (int i=0; i<xml->maxIndex; i++) {
-    struct ncclXmlNode* n = xml->nodes+i;
+  for (int i = 0; i < xml->maxIndex; i++) {
+    struct ncclXmlNode* n = xml->nodes + i;
     if (strcmp(n->name, tagName) == 0) {
       const char* value;
       NCCLCHECK(xmlGetAttr(n, attrName, &value));
@@ -197,19 +202,19 @@ static ncclResult_t xmlFindTagKv(struct ncclXml* xml, const char* tagName, struc
   return ncclSuccess;
 }
 
-static ncclResult_t xmlFindNode(struct ncclXmlNode* parentNode, struct ncclXmlNode* searchNode, struct ncclXmlNode** node) {
+static ncclResult_t xmlFindNode(struct ncclXmlNode* parentNode, struct ncclXmlNode* searchNode,
+                                struct ncclXmlNode** node) {
   *node = NULL;
   // Search for the node at the current level only.
-  for (int i=0; i<parentNode->nSubs; i++) {
+  for (int i = 0; i < parentNode->nSubs; i++) {
     struct ncclXmlNode* n = parentNode->subs[i];
     if (strcmp(n->name, searchNode->name) == 0 && n->type == searchNode->type && n->nAttrs == searchNode->nAttrs) {
       int a;
       // Ensure that all the attributes are the same.
-      for (a=0; a<searchNode->nAttrs; a++) {
+      for (a = 0; a < searchNode->nAttrs; a++) {
         const char* val;
         NCCLCHECK(xmlGetAttr(n, searchNode->attrs[a].key, &val));
-        if (!val || strcmp(val, searchNode->attrs[a].value))
-          break;
+        if (!val || strcmp(val, searchNode->attrs[a].value)) break;
       }
       if (a == searchNode->nAttrs) {
         *node = n;
@@ -235,7 +240,7 @@ static ncclResult_t xmlSetAttr(struct ncclXmlNode* node, const char* attrName, c
 
 static ncclResult_t xmlPrintNodeRecursive(struct ncclXmlNode* node, const char* name) {
   while (node) {
-    char line[1024*8];
+    char line[1024 * 8];
     int cursor = 0;
     snprintf(line, sizeof(line), "<name=%s", node->name);
     for (int i = 0; i < node->nAttrs; i++) {
@@ -249,7 +254,6 @@ static ncclResult_t xmlPrintNodeRecursive(struct ncclXmlNode* node, const char* 
   }
   return ncclSuccess;
 }
-
 
 static ncclResult_t xmlSetAttrIfUnset(struct ncclXmlNode* node, const char* attrName, const char* value) {
   int index;
@@ -303,9 +307,9 @@ static ncclResult_t xmlUnsetAttr(struct ncclXmlNode* node, const char* attrName)
   int index;
   NCCLCHECK(xmlGetAttrIndex(node, attrName, &index));
   if (index == -1) return ncclSuccess;
-  for (int i=index+1; i<node->nAttrs; i++) {
-    strcpy(node->attrs[i-1].key, node->attrs[i].key);
-    strcpy(node->attrs[i-1].value, node->attrs[i].value);
+  for (int i = index + 1; i < node->nAttrs; i++) {
+    strcpy(node->attrs[i - 1].key, node->attrs[i].key);
+    strcpy(node->attrs[i - 1].value, node->attrs[i].value);
   }
   node->nAttrs--;
   return ncclSuccess;
@@ -313,7 +317,7 @@ static ncclResult_t xmlUnsetAttr(struct ncclXmlNode* node, const char* attrName)
 
 static ncclResult_t xmlGetSub(struct ncclXmlNode* node, const char* subName, struct ncclXmlNode** sub) {
   *sub = NULL;
-  for (int s=0; s<node->nSubs; s++) {
+  for (int s = 0; s < node->nSubs; s++) {
     if (strcmp(node->subs[s]->name, subName) == 0) {
       *sub = node->subs[s];
       return ncclSuccess;
@@ -322,9 +326,10 @@ static ncclResult_t xmlGetSub(struct ncclXmlNode* node, const char* subName, str
   return ncclSuccess;
 }
 
-static ncclResult_t xmlGetSubKv(struct ncclXmlNode* node, const char* subName, struct ncclXmlNode** sub, const char* attrName, const char* attrValue) {
+static ncclResult_t xmlGetSubKv(struct ncclXmlNode* node, const char* subName, struct ncclXmlNode** sub,
+                                const char* attrName, const char* attrValue) {
   *sub = NULL;
-  for (int s=0; s<node->nSubs; s++) {
+  for (int s = 0; s < node->nSubs; s++) {
     struct ncclXmlNode* subNode = node->subs[s];
     if (strcmp(subNode->name, subName) == 0) {
       const char* value;
@@ -337,19 +342,21 @@ static ncclResult_t xmlGetSubKv(struct ncclXmlNode* node, const char* subName, s
   }
   return ncclSuccess;
 }
-static ncclResult_t xmlGetSubKvInt(struct ncclXmlNode* node, const char* subName, struct ncclXmlNode** sub, const char* attrName, const int attrValue) {
+static ncclResult_t xmlGetSubKvInt(struct ncclXmlNode* node, const char* subName, struct ncclXmlNode** sub,
+                                   const char* attrName, const int attrValue) {
   char strValue[10];
   snprintf(strValue, 10, "%d", attrValue);
   NCCLCHECK(xmlGetSubKv(node, subName, sub, attrName, strValue));
   return ncclSuccess;
 }
 
-static ncclResult_t xmlAddNode(struct ncclXml* xml, struct ncclXmlNode* parent, const char* subName, struct ncclXmlNode** sub) {
+static ncclResult_t xmlAddNode(struct ncclXml* xml, struct ncclXmlNode* parent, const char* subName,
+                               struct ncclXmlNode** sub) {
   if (xml->maxIndex == xml->maxNodes) {
     WARN("Error : too many XML nodes (max %d)", xml->maxNodes);
     return ncclInternalError;
   }
-  struct ncclXmlNode* s = xml->nodes+xml->maxIndex++;
+  struct ncclXmlNode* s = xml->nodes + xml->maxIndex++;
   s->nSubs = 0;
   s->nAttrs = 0;
   *sub = s;
@@ -371,9 +378,9 @@ static ncclResult_t xmlRemoveNode(struct ncclXmlNode* node) {
   struct ncclXmlNode* parent = node->parent;
   if (parent == NULL) return ncclSuccess;
   int shift = 0;
-  for (int s=0; s<parent->nSubs; s++) {
+  for (int s = 0; s < parent->nSubs; s++) {
     if (parent->subs[s] == node) shift = 1;
-    else if (shift) parent->subs[s-1] = parent->subs[s];
+    else if (shift) parent->subs[s - 1] = parent->subs[s];
   }
   parent->nSubs--;
   return ncclSuccess;
@@ -384,7 +391,7 @@ static ncclResult_t xmlAddTree(struct ncclXml* dst, struct ncclXmlNode* parent, 
     WARN("Error : too many XML nodes (max %d)", dst->maxNodes);
     return ncclInternalError;
   }
-  struct ncclXmlNode* dstNode = dst->nodes+dst->maxIndex++;
+  struct ncclXmlNode* dstNode = dst->nodes + dst->maxIndex++;
   *dstNode = *srcNode;
   dstNode->parent = parent;
   if (parent) {
@@ -396,11 +403,9 @@ static ncclResult_t xmlAddTree(struct ncclXml* dst, struct ncclXmlNode* parent, 
   }
   dstNode->nSubs = 0;
   // Recursively copy the subtree(s)
-  for (int i=0; i<srcNode->nSubs; i++)
-    NCCLCHECK(xmlAddTree(dst, dstNode, srcNode->subs[i]));
+  for (int i = 0; i < srcNode->nSubs; i++) NCCLCHECK(xmlAddTree(dst, dstNode, srcNode->subs[i]));
   return ncclSuccess;
 }
-
 
 // Dictionary for STR -> INT conversions. No dictionary size information,
 // there needs to be a last element with str == NULL.
@@ -446,7 +451,6 @@ static ncclResult_t kvConvertToStr(int value, const char** str, struct kvDict* d
 typedef union {
   hipDeviceArch_t arch;
   int value;
-  static_assert(sizeof(hipDeviceArch_t) == sizeof(int),
-      "value must be the same size of hipDeviceArch_t.");
+  static_assert(sizeof(hipDeviceArch_t) == sizeof(int), "value must be the same size of hipDeviceArch_t.");
 } rcclHipDeviceArch_t;
 #endif

--- a/projects/rccl/src/group.cc
+++ b/projects/rccl/src/group.cc
@@ -36,12 +36,8 @@ thread_local struct ncclIntruQueue<struct ncclAsyncJob, &ncclAsyncJob::next> ncc
 thread_local int ncclGroupBlocking = -1; /* default mode */
 void* ncclAsyncJobMain(void* arg);
 
-ncclResult_t ncclAsyncLaunch(
-    struct ncclAsyncJob* job,
-    ncclResult_t(*func)(struct ncclAsyncJob*),
-    void(*undo)(struct ncclAsyncJob*),
-    void(*destructor)(void*), ncclComm_t comm
-  ) {
+ncclResult_t ncclAsyncLaunch(struct ncclAsyncJob* job, ncclResult_t (*func)(struct ncclAsyncJob*),
+                             void (*undo)(struct ncclAsyncJob*), void (*destructor)(void*), ncclComm_t comm) {
   ncclResult_t ret = ncclSuccess;
 
   job->destroyFlag = comm->destroyFlag;
@@ -84,7 +80,7 @@ void* ncclAsyncJobMain(void* arg) {
   struct ncclAsyncJob* job = (struct ncclAsyncJob*)arg;
   job->result = job->func(job);
   if (job->result != ncclSuccess) {
-    INFO(NCCL_INIT,"%s:%d -> %d [Async thread]", __FILE__, __LINE__, job->result);
+    INFO(NCCL_INIT, "%s:%d -> %d [Async thread]", __FILE__, __LINE__, job->result);
   }
   COMPILER_ATOMIC_STORE(&job->state, static_cast<ncclGroupJobState_t>(ncclGroupJobDone), std::memory_order_release);
   return arg;
@@ -163,9 +159,11 @@ ncclResult_t ncclP2PPreconnectFunc(struct ncclAsyncJob* job_) {
   NCCLCHECK(ncclTransportP2pSetup(comm, NULL, 1));
   if (comm->p2pNet) NCCLCHECK(ncclTransportP2pSetup(comm, NULL, NCCL_CONN_IDX_P2P_NET));
   if (mode != cudaStreamCaptureModeRelaxed) CUDACHECK(cudaThreadExchangeStreamCaptureMode(&mode));
-  INFO(NCCL_INIT, "rank %d/%d cudaDev %d nvmlDev %d busId %#llx commId 0x%016llx Send/Recv P2P transport setup complete (p2pNet=%d)",
-    comm->rank, comm->nRanks, comm->cudaDev, comm->nvmlDev,
-    (unsigned long long)comm->busId, (unsigned long long)comm->commHash, comm->p2pNet ? 1 : 0);
+  INFO(
+    NCCL_INIT,
+    "rank %d/%d cudaDev %d nvmlDev %d busId %#llx commId 0x%016llx Send/Recv P2P transport setup complete (p2pNet=%d)",
+    comm->rank, comm->nRanks, comm->cudaDev, comm->nvmlDev, (unsigned long long)comm->busId,
+    (unsigned long long)comm->commHash, comm->p2pNet ? 1 : 0);
   return ncclSuccess;
 }
 
@@ -173,39 +171,47 @@ static ncclResult_t ncclCollPreconnect(struct ncclComm* comm, bool* algoNeedConn
   for (int i = 0; i < NCCL_NUM_ALGORITHMS; ++i) {
     if (algoNeedConnect[i]) {
       switch (i) {
-        case NCCL_ALGO_RING: {
+      case NCCL_ALGO_RING:
+        {
           NCCLCHECK(ncclTransportRingConnect(comm));
           break;
         }
-        case NCCL_ALGO_TREE: {
+      case NCCL_ALGO_TREE:
+        {
           NCCLCHECK(ncclTransportTreeConnect(comm));
           break;
         }
-        case NCCL_ALGO_NVLS: {
+      case NCCL_ALGO_NVLS:
+        {
           /* If we are using NVLS_TREE algo, we must mark NVLS algo to set up
            * NVLS intra-node buffer */
           NCCLCHECK(ncclNvlsBufferSetup(comm));
           break;
         }
-        case NCCL_ALGO_NVLS_TREE: {
+      case NCCL_ALGO_NVLS_TREE:
+        {
           NCCLCHECK(ncclNvlsTreeConnect(comm));
           break;
         }
-        case NCCL_ALGO_COLLNET_CHAIN: {
+      case NCCL_ALGO_COLLNET_CHAIN:
+        {
           NCCLCHECK(ncclCollNetChainBufferSetup(comm));
           break;
         }
-        case NCCL_ALGO_COLLNET_DIRECT: {
+      case NCCL_ALGO_COLLNET_DIRECT:
+        {
           NCCLCHECK(ncclCollNetDirectBufferSetup(comm));
           break;
         }
-        case NCCL_ALGO_PAT: {
+      case NCCL_ALGO_PAT:
+        {
           NCCLCHECK(ncclTransportPatConnect(comm));
           break;
         }
         // Yes, it's a dead code.  That's fine...
         // coverity[dead_error_begin]
-        default: {
+      default:
+        {
           NCCLCHECK(ncclInternalError);
         }
       }
@@ -219,7 +225,7 @@ ncclResult_t ncclPrepareTasksAndCollPreconnectFunc(struct ncclAsyncJob* job_) {
   struct ncclComm* comm = job->comm;
   bool needConnect;
   bool algoNeedConnect[NCCL_NUM_ALGORITHMS];
-  memset(algoNeedConnect, 0, sizeof(bool)*NCCL_NUM_ALGORITHMS);
+  memset(algoNeedConnect, 0, sizeof(bool) * NCCL_NUM_ALGORITHMS);
   CUDACHECK(cudaSetDevice(comm->cudaDev));
   if (!job_->isThreadMain && ncclOsCpuCount(comm->cpuAffinity)) ncclOsSetAffinity(comm->cpuAffinity);
   NCCLCHECK(ncclPrepareTasks(comm, algoNeedConnect, &needConnect, job->simInfo));
@@ -292,17 +298,15 @@ ncclResult_t ncclCommGroupRegisterSymmetric(struct ncclAsyncJob* job_) {
 
   while (!ncclIntruQueueEmpty(&comm->devrState.regTaskQueue)) {
     struct ncclDevrRegTask* task = ncclIntruQueueDequeue(&comm->devrState.regTaskQueue);
-    NCCLCHECKGOTO(ncclDevrWindowRegisterInGroup(
-      comm, task->userPtr, task->userSize, task->winFlags, task->outWinDev),
-      ret, fail);
+    NCCLCHECKGOTO(ncclDevrWindowRegisterInGroup(comm, task->userPtr, task->userSize, task->winFlags, task->outWinDev),
+                  ret, fail);
     free(task);
   }
 
   while (!ncclIntruQueueEmpty(&comm->devrState.commCreateTaskQueue)) {
     struct ncclDevrCommCreateTask* task = ncclIntruQueueDequeue(&comm->devrState.commCreateTaskQueue);
-    NCCLCHECKGOTO(ncclDevrCommCreateInternal(
-      comm, task->reqs, task->outDevComm, /*isInternal=*/false, task->devCompat),
-      ret, fail);
+    NCCLCHECKGOTO(ncclDevrCommCreateInternal(comm, task->reqs, task->outDevComm, /*isInternal=*/false, task->devCompat),
+                  ret, fail);
     freeDevCommRequirements(task->reqs); // free additional task memory for reqs
     free(task);
   }
@@ -446,7 +450,7 @@ static void reclaimPlannerState(struct ncclComm* comm) {
   comm->preconnectNext = reinterpret_cast<struct ncclComm*>(0x1);
   // connectSend/connectRecv are allocated as comm->nRanks * NCCL_MAX_CONNS
   for (int i = 0; i < comm->nRanks * NCCL_MAX_CONNS; i++) {
-    for (int j = 0; j < MAXCHANNELS/64; j++) {
+    for (int j = 0; j < MAXCHANNELS / 64; j++) {
       comm->connectSend[i].masks[j] = 0UL;
       comm->connectRecv[i].masks[j] = 0UL;
     }
@@ -489,7 +493,9 @@ static void reclaimPlannerState(struct ncclComm* comm) {
   }
 }
 
-static void groupCleanup(struct ncclComm** groupCommHeadPtr, struct ncclIntruQueue<struct ncclAsyncJob, &ncclAsyncJob::next>* asyncJobsPtr, ncclResult_t error) {
+static void groupCleanup(struct ncclComm** groupCommHeadPtr,
+                         struct ncclIntruQueue<struct ncclAsyncJob, &ncclAsyncJob::next>* asyncJobsPtr,
+                         ncclResult_t error) {
   struct ncclComm* comm;
   for (int type = 0; type < ncclGroupTaskTypeNum; ++type) {
     comm = groupCommHeadPtr[type];
@@ -500,7 +506,7 @@ static void groupCleanup(struct ncclComm** groupCommHeadPtr, struct ncclIntruQue
       if (type == ncclGroupTaskTypeCollective) {
         reclaimPlannerState(comm);
 
-	{ // Reset comm->planner to empty.
+        { // Reset comm->planner to empty.
           ncclKernelPlanner::Peer* tmp = comm->planner.peers;
           ncclIntruQueue<ncclTaskRma, &ncclTaskRma::next>* tmpRmaQueues = comm->planner.rmaTaskQueues;
           int numRmaCtx = comm->config.numRmaCtx;
@@ -508,7 +514,8 @@ static void groupCleanup(struct ncclComm** groupCommHeadPtr, struct ncclIntruQue
           memset(&comm->planner, 0, sizeof(comm->planner));
 
           comm->planner.peers = tmp;
-          if (comm->planner.peers != NULL) memset(comm->planner.peers, 0, comm->nRanks * sizeof(comm->planner.peers[0]));
+          if (comm->planner.peers != NULL)
+            memset(comm->planner.peers, 0, comm->nRanks * sizeof(comm->planner.peers[0]));
        //   comm->planner.bcast_info.minBcastPeer = INT_MAX;
        //   comm->planner.bcast_info.maxBcastPeer = INT_MIN;
 
@@ -520,8 +527,7 @@ static void groupCleanup(struct ncclComm** groupCommHeadPtr, struct ncclIntruQue
           }
         }
       }
-      if (!comm->config.blocking)
-        (void)ncclCommSetAsyncError(comm, error);
+      if (!comm->config.blocking) (void)ncclCommSetAsyncError(comm, error);
       comm = next;
     }
   }
@@ -529,8 +535,7 @@ static void groupCleanup(struct ncclComm** groupCommHeadPtr, struct ncclIntruQue
   /* reset everything */
   while (!ncclIntruQueueEmpty(asyncJobsPtr)) {
     struct ncclAsyncJob* job = ncclIntruQueueDequeue(asyncJobsPtr);
-    if (!job->destroyFlag && job->comm && !job->comm->config.blocking)
-      (void) ncclCommSetAsyncError(job->comm, error);
+    if (!job->destroyFlag && job->comm && !job->comm->config.blocking) (void)ncclCommSetAsyncError(job->comm, error);
     if (job->undo) job->undo(job);
     if (job->destructor) job->destructor((void*)job);
   }
@@ -538,7 +543,8 @@ static void groupCleanup(struct ncclComm** groupCommHeadPtr, struct ncclIntruQue
   return;
 }
 
-static ncclResult_t asyncJobLaunch(struct ncclIntruQueue<struct ncclAsyncJob, &ncclAsyncJob::next> *asyncJobsMain, volatile bool *groupAbortFlag) {
+static ncclResult_t asyncJobLaunch(struct ncclIntruQueue<struct ncclAsyncJob, &ncclAsyncJob::next>* asyncJobsMain,
+                                   volatile bool* groupAbortFlag) {
   ncclResult_t ret = ncclSuccess;
   bool jobsDone = false;
   bool errorJobAbortFlag = false;
@@ -579,7 +585,8 @@ static ncclResult_t asyncJobLaunch(struct ncclIntruQueue<struct ncclAsyncJob, &n
           assert(state == ncclGroupJobJoined);
         }
 
-        if (!job->destroyFlag && (COMPILER_ATOMIC_LOAD(groupAbortFlag, std::memory_order_acquire) || errorJobAbortFlag == true)) {
+        if (!job->destroyFlag &&
+            (COMPILER_ATOMIC_LOAD(groupAbortFlag, std::memory_order_acquire) || errorJobAbortFlag == true)) {
           COMPILER_ATOMIC_STORE(job->abortFlag, uint32_t(1), std::memory_order_release);
           COMPILER_ATOMIC_STORE(job->abortFlagDev, uint32_t(1), std::memory_order_release);
           if (job->childAbortFlag) {
@@ -620,7 +627,9 @@ static void ncclGroupSymmetricJobFree(void* _job) {
   delete job;
 }
 
-static ncclResult_t ncclPrepareTasksAndCollPreconnect(struct ncclComm* comm, ncclSimInfo_t* simInfo, struct ncclIntruQueue<struct ncclAsyncJob, &ncclAsyncJob::next>* asyncCollJobs) {
+static ncclResult_t ncclPrepareTasksAndCollPreconnect(
+  struct ncclComm* comm, ncclSimInfo_t* simInfo,
+  struct ncclIntruQueue<struct ncclAsyncJob, &ncclAsyncJob::next>* asyncCollJobs) {
   if (ncclParamSingleProcMemRegEnable()) {
     struct ncclPrepareTasksAndCollPreconnectJob* job;
     NEW_NOTHROW(job, ncclPrepareTasksAndCollPreconnectJob);
@@ -663,13 +672,13 @@ static ncclResult_t ncclPrepareTasksAndCollPreconnect(struct ncclComm* comm, ncc
   return ncclSuccess;
 }
 
-static ncclResult_t groupLaunch(struct ncclAsyncJob *job_, ncclSimInfo_t* simInfo = NULL) {
+static ncclResult_t groupLaunch(struct ncclAsyncJob* job_, ncclSimInfo_t* simInfo = NULL) {
   ncclResult_t ret = ncclSuccess;
-  struct ncclGroupJob *gjob = (struct ncclGroupJob*) job_;
-  struct ncclComm **groupCommHeadMain = gjob->groupCommHead;
-  struct ncclComm *groupCommPreconnectHeadMain = gjob->groupCommPreconnectHead;
-  struct ncclIntruQueue<struct ncclAsyncJob, &ncclAsyncJob::next> *asyncJobsMain = &gjob->asyncJobs;
-  bool *groupAbortFlag = &gjob->abortFlag;
+  struct ncclGroupJob* gjob = (struct ncclGroupJob*)job_;
+  struct ncclComm** groupCommHeadMain = gjob->groupCommHead;
+  struct ncclComm* groupCommPreconnectHeadMain = gjob->groupCommPreconnectHead;
+  struct ncclIntruQueue<struct ncclAsyncJob, &ncclAsyncJob::next>* asyncJobsMain = &gjob->asyncJobs;
+  bool* groupAbortFlag = &gjob->abortFlag;
 
   if (!simInfo && groupCommPreconnectHeadMain != nullptr) {
     struct ncclComm* comm = groupCommPreconnectHeadMain;
@@ -683,7 +692,7 @@ static ncclResult_t groupLaunch(struct ncclAsyncJob *job_, ncclSimInfo_t* simInf
       job->base.abortFlag = comm->abortFlag;
       job->base.abortFlagDev = comm->abortFlagDev;
       job->comm = comm;
-      ncclIntruQueueEnqueue(asyncJobsMain,  (struct ncclAsyncJob*)job);
+      ncclIntruQueueEnqueue(asyncJobsMain, (struct ncclAsyncJob*)job);
 
       struct ncclComm* next = comm->preconnectNext;
       comm->preconnectNext = reinterpret_cast<struct ncclComm*>(0x1);
@@ -793,8 +802,9 @@ static ncclResult_t groupLaunch(struct ncclAsyncJob *job_, ncclSimInfo_t* simInf
 
   while (!ncclIntruQueueEmpty(asyncJobsMain)) {
     struct ncclAsyncJob* job = ncclIntruQueueDequeue(asyncJobsMain);
-    if (!job->destroyFlag && job->comm && !job->comm->config.blocking && groupCommHeadMain[ncclGroupTaskTypeCollective] == nullptr)
-      (void) ncclCommSetAsyncError(job->comm, ret);
+    if (!job->destroyFlag && job->comm && !job->comm->config.blocking &&
+        groupCommHeadMain[ncclGroupTaskTypeCollective] == nullptr)
+      (void)ncclCommSetAsyncError(job->comm, ret);
     if (job->destructor) job->destructor((void*)job);
   }
 
@@ -828,7 +838,7 @@ fail:
   goto exit;
 }
 
-static ncclResult_t groupLaunchNonBlocking(struct ncclAsyncJob *job_) {
+static ncclResult_t groupLaunchNonBlocking(struct ncclAsyncJob* job_) {
   return groupLaunch(job_ /* estimatedTime = NULL */);
 }
 

--- a/projects/rccl/src/include/algorithms/CollCommon.h
+++ b/projects/rccl/src/include/algorithms/CollCommon.h
@@ -32,21 +32,18 @@ using bf16 = __nv_bfloat16;
 using bf162 = __nv_bfloat162;
 #endif
 
-
 namespace meta::comms {
 
 template <typename T>
-inline constexpr bool is_supported_type_v =
-    (std::is_same<T, float>::value || std::is_same<T, half>::value ||
-     std::is_same<T, int8_t>::value || std::is_same<T, bf16>::value
+inline constexpr bool is_supported_type_v = (std::is_same<T, float>::value || std::is_same<T, half>::value ||
+                                             std::is_same<T, int8_t>::value || std::is_same<T, bf16>::value
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIP_PLATFORM_HCC__)
-     || std::is_same<T, __hip_bfloat16>::value
+                                             || std::is_same<T, __hip_bfloat16>::value
 #endif
-    );
+);
 
 template <typename T>
-static inline __device__ uint32_t
-vecElementAdd(const uint32_t& a, const uint32_t& b) {
+static inline __device__ uint32_t vecElementAdd(const uint32_t& a, const uint32_t& b) {
   static_assert(is_supported_type_v<T>, "dda: unsupported element type");
   if constexpr (std::is_same<T, float>::value) {
     const float* x = reinterpret_cast<const float*>(&a);
@@ -91,33 +88,22 @@ static inline __device__ uint4 vecElementAdd(const uint4& a, const uint4& b) {
 }
 
 template <typename T>
-static inline __device__ void copyFromSrcToDest(
-    const T* __restrict__ srcbuff,
-    T* __restrict__ destbuff,
-    const size_t idxStart,
-    const size_t idxEnd,
-    const size_t idxStride) {
+static inline __device__ void copyFromSrcToDest(const T* __restrict__ srcbuff, T* __restrict__ destbuff,
+                                                const size_t idxStart, const size_t idxEnd, const size_t idxStride) {
   static_assert(is_supported_type_v<T>, "dda: unsupported element type");
   for (size_t idx = idxStart; idx < idxEnd; idx += idxStride) {
-    *reinterpret_cast<uint4*>(&destbuff[idx]) =
-        reinterpret_cast<const uint4*>(&srcbuff[idx])[0];
+    *reinterpret_cast<uint4*>(&destbuff[idx]) = reinterpret_cast<const uint4*>(&srcbuff[idx])[0];
   }
 }
 
 template <typename T, int NRANKS, bool hasAcc>
-static inline __device__ void reduceScatter(
-    T* const* __restrict__ ipcbuffs,
-    T* __restrict__ destbuff,
-    const T* __restrict__ acc,
-    int selfRank,
-    const size_t idxStart,
-    const size_t idxEnd,
-    const size_t idxStride,
-    int pattern) {
+static inline __device__ void reduceScatter(T* const* __restrict__ ipcbuffs, T* __restrict__ destbuff,
+                                            const T* __restrict__ acc, int selfRank, const size_t idxStart,
+                                            const size_t idxEnd, const size_t idxStride, int pattern) {
   static_assert(is_supported_type_v<T>, "dda: unsupported element type");
   for (size_t idx = idxStart; idx < idxEnd; idx += idxStride) {
     // pattern = 2 performs reduce (one-shot)
-    // pattern = 1 performs reduce-scatter (two-shot)	  
+    // pattern = 1 performs reduce-scatter (two-shot)
     size_t srcIdx = (pattern == 2) ? idx : (idx + selfRank * idxEnd);
     size_t destIdx = (pattern == 1) ? (idx + selfRank * idxEnd) : idx;
 
@@ -127,31 +113,23 @@ static inline __device__ void reduceScatter(
     }
 
     uint4 srcVals[2];
-    *reinterpret_cast<uint4*>(&srcVals[0]) =
-        reinterpret_cast<const uint4*>(&ipcbuffs[0][srcIdx])[0];
+    *reinterpret_cast<uint4*>(&srcVals[0]) = reinterpret_cast<const uint4*>(&ipcbuffs[0][srcIdx])[0];
 #pragma unroll NRANKS - 1
     for (int r = 0; r < NRANKS - 1; ++r) {
       *reinterpret_cast<uint4*>(&srcVals[(r + 1) & 1]) =
-          reinterpret_cast<const uint4*>(
-              &ipcbuffs[(r + 1) % NRANKS][srcIdx])[0];
+        reinterpret_cast<const uint4*>(&ipcbuffs[(r + 1) % NRANKS][srcIdx])[0];
       sum = vecElementAdd<T>(sum, srcVals[r & 1]);
     }
     sum = vecElementAdd<T>(sum, srcVals[(NRANKS - 1) & 1]);
 
-    *reinterpret_cast<uint4*>(&destbuff[destIdx]) =
-        *reinterpret_cast<const uint4*>(&sum);
+    *reinterpret_cast<uint4*>(&destbuff[destIdx]) = *reinterpret_cast<const uint4*>(&sum);
   }
 }
 
 template <typename T, int NRANKS>
-static inline __device__ void allGather(
-    T* const* __restrict__ ipcbuffs,
-    T* __restrict__ destbuff,
-    int selfRank,
-    const size_t idxStart,
-    const size_t idxEnd,
-    const size_t idxStride,
-    bool enable_offset) {
+static inline __device__ void allGather(T* const* __restrict__ ipcbuffs, T* __restrict__ destbuff, int selfRank,
+                                        const size_t idxStart, const size_t idxEnd, const size_t idxStride,
+                                        bool enable_offset) {
   static_assert(is_supported_type_v<T>, "dda: unsupported element type");
   for (size_t idx = idxStart; idx < idxEnd; idx += idxStride) {
 #pragma unroll NRANKS
@@ -164,8 +142,7 @@ static inline __device__ void allGather(
       } else {
         srcIdx = static_cast<int>(idx);
       }
-      *reinterpret_cast<uint4*>(&destbuff[destIdx]) =
-          reinterpret_cast<const uint4*>(&ipcbuffs[srcRank][srcIdx])[0];
+      *reinterpret_cast<uint4*>(&destbuff[destIdx]) = reinterpret_cast<const uint4*>(&ipcbuffs[srcRank][srcIdx])[0];
     }
   }
 }
@@ -178,13 +155,11 @@ inline uint32_t divRoundUp(size_t a, size_t b) {
   return y;
 }
 
-constexpr uint32_t
-calcBlockCount(size_t numThreads, size_t threadsPerBlock, size_t maxBlocks) {
+constexpr uint32_t calcBlockCount(size_t numThreads, size_t threadsPerBlock, size_t maxBlocks) {
   const auto uNumThreads = static_cast<uint64_t>(numThreads);
   const auto uThreadsPerBlock = static_cast<uint64_t>(threadsPerBlock);
   // Overflow safe variant of (a + b - 1) / b
-  const uint64_t blocks =
-      uNumThreads / uThreadsPerBlock + (uNumThreads % uThreadsPerBlock != 0);
+  const uint64_t blocks = uNumThreads / uThreadsPerBlock + (uNumThreads % uThreadsPerBlock != 0);
   uint32_t y = static_cast<uint32_t>(std::min(blocks, maxBlocks));
   if (y == 0) {
     y = 1;
@@ -192,13 +167,11 @@ calcBlockCount(size_t numThreads, size_t threadsPerBlock, size_t maxBlocks) {
   return y;
 }
 
-inline std::pair<dim3, dim3>
-getGridAndBlockDims(size_t count, int typeSize, size_t maxBlocks) {
+inline std::pair<dim3, dim3> getGridAndBlockDims(size_t count, int typeSize, size_t maxBlocks) {
   constexpr uint32_t kThreadsPerWarp = 64;
   constexpr uint32_t kThreadsPerBlock = 512;
 
-  const uint32_t elementsPerThread =
-      16 / typeSize; // we do 16 Byte load in kernel
+  const uint32_t elementsPerThread = 16 / typeSize; // we do 16 Byte load in kernel
 
   const uint32_t elementsPerWarp = elementsPerThread * kThreadsPerWarp;
 
@@ -209,11 +182,9 @@ getGridAndBlockDims(size_t count, int typeSize, size_t maxBlocks) {
     blocks.x = 1;
   } else {
     auto warpsRequired = divRoundUp(count, elementsPerWarp);
-    blocks.x = calcBlockCount(
-        divRoundUp(count, elementsPerThread), kThreadsPerBlock, maxBlocks);
+    blocks.x = calcBlockCount(divRoundUp(count, elementsPerThread), kThreadsPerBlock, maxBlocks);
     auto warpsPerBlock = divRoundUp(warpsRequired, blocks.x);
-    auto threadsPerBlock =
-        std::min<uint32_t>(kThreadsPerBlock, warpsPerBlock * kThreadsPerWarp);
+    auto threadsPerBlock = std::min<uint32_t>(kThreadsPerBlock, warpsPerBlock * kThreadsPerWarp);
     threads.x = threadsPerBlock;
   }
 

--- a/projects/rccl/src/include/algorithms/all_gather/all_gather_dda.h
+++ b/projects/rccl/src/include/algorithms/all_gather/all_gather_dda.h
@@ -19,13 +19,8 @@ template <typename T, int NRANKS, bool hasAcc>
 #if defined(USE_ROCM)
 __launch_bounds__(512)
 #endif
-__global__ void ddaAllGatherIpc(
-    T* const* __restrict__ ipcbuffs,
-    T* __restrict__ recvbuff,
-    size_t count,
-    const T* __restrict__ sendbuff,
-    int selfRank,
-    IpcGpuBarrier barrier) {
+  __global__ void ddaAllGatherIpc(T* const* __restrict__ ipcbuffs, T* __restrict__ recvbuff, size_t count,
+                                  const T* __restrict__ sendbuff, int selfRank, IpcGpuBarrier barrier) {
 
   const size_t countPerRank = count;
   constexpr auto countPerThread = sizeof(uint4) / sizeof(T);
@@ -37,20 +32,14 @@ __global__ void ddaAllGatherIpc(
 
   // It is expensive to launch hipMemcpyAsync on ROCm
   // Move data copy here. Each block copies part of sendbuff data
-  copyFromSrcToDest<T>(
-      sendbuff, ipcbuffs[selfRank], idxStart, idxEnd, idxStride);
+  copyFromSrcToDest<T>(sendbuff, ipcbuffs[selfRank], idxStart, idxEnd, idxStride);
 
-  barrier.syncOnSameBlockIdx<
-      true /* hasPreviousMemAccess */,
-      true /* hasSubsequentMemAccess */>();
+  barrier.syncOnSameBlockIdx<true /* hasPreviousMemAccess */, true /* hasSubsequentMemAccess */>();
 
-  allGather<T, NRANKS>(
-      ipcbuffs, recvbuff, selfRank, idxStart, idxEnd, idxStride, false);
+  allGather<T, NRANKS>(ipcbuffs, recvbuff, selfRank, idxStart, idxEnd, idxStride, false);
 
   // barrier to ensure remote ranks won't free their buffers until I'm done
-  barrier.syncOnSameBlockIdx<
-      true /* hasPreviousMemAccess */,
-      false /* hasSubsequentMemAccess */>();
+  barrier.syncOnSameBlockIdx<true /* hasPreviousMemAccess */, false /* hasSubsequentMemAccess */>();
 }
 
 } // namespace meta::comms

--- a/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda.h
+++ b/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda.h
@@ -18,14 +18,9 @@ template <typename T, int NRANKS, bool hasAcc>
 #if defined(USE_ROCM)
 __launch_bounds__(512)
 #endif
-__global__ void ddaAllReduceFlatIpc(
-    T* const* __restrict__ ipcbuffs,
-    T* __restrict__ recvbuff,
-    size_t count,
-    const T* __restrict__ sendbuff,
-    int selfRank,
-    IpcGpuBarrier barrier,
-    const T* __restrict__ acc) {
+  __global__ void ddaAllReduceFlatIpc(T* const* __restrict__ ipcbuffs, T* __restrict__ recvbuff, size_t count,
+                                      const T* __restrict__ sendbuff, int selfRank, IpcGpuBarrier barrier,
+                                      const T* __restrict__ acc) {
   constexpr auto countPerThread = sizeof(uint4) / sizeof(T);
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
 
@@ -33,37 +28,24 @@ __global__ void ddaAllReduceFlatIpc(
   const auto idxEnd = count;
   const auto idxStride = gridDim.x * blockDim.x * countPerThread;
 
-  copyFromSrcToDest<T>(
-      sendbuff, ipcbuffs[selfRank], idxStart, idxEnd, idxStride);
+  copyFromSrcToDest<T>(sendbuff, ipcbuffs[selfRank], idxStart, idxEnd, idxStride);
 
-  barrier.syncOnSameBlockIdx<
-      true /* hasPreviousMemAccess */,
-      true /* hasSubsequentMemAccess */>();
+  barrier.syncOnSameBlockIdx<true /* hasPreviousMemAccess */, true /* hasSubsequentMemAccess */>();
 
   // pattern=2: full reduce into recvbuff (one-shot, not scatter)
-  reduceScatter<T, NRANKS, hasAcc>(
-      ipcbuffs, recvbuff, acc, selfRank, idxStart, idxEnd, idxStride, 2);
+  reduceScatter<T, NRANKS, hasAcc>(ipcbuffs, recvbuff, acc, selfRank, idxStart, idxEnd, idxStride, 2);
 
-  barrier.syncOnSameBlockIdx<
-      true /* hasPreviousMemAccess */,
-      false /* hasSubsequentMemAccess */>();
+  barrier.syncOnSameBlockIdx<true /* hasPreviousMemAccess */, false /* hasSubsequentMemAccess */>();
 }
 
 template <typename T, int NRANKS, bool hasAcc>
 #if defined(USE_ROCM)
 __launch_bounds__(512)
 #endif
-__global__ void ddaAllReduceTreeIpc(
-    T* const* __restrict__ ipcbuffs,
-    T* __restrict__ recvbuff,
-    size_t count,
-    const T* __restrict__ sendbuff,
-    int selfRank,
-    IpcGpuBarrier barrier,
-    const T* __restrict__ acc) {
-  barrier.syncOnSameBlockIdx<
-      false /* hasPreviousMemAccess */,
-      true /* hasSubsequentMemAccess */>();
+  __global__ void ddaAllReduceTreeIpc(T* const* __restrict__ ipcbuffs, T* __restrict__ recvbuff, size_t count,
+                                      const T* __restrict__ sendbuff, int selfRank, IpcGpuBarrier barrier,
+                                      const T* __restrict__ acc) {
+  barrier.syncOnSameBlockIdx<false /* hasPreviousMemAccess */, true /* hasSubsequentMemAccess */>();
 
   const size_t countPerRank = count / NRANKS;
   constexpr auto countPerThread = sizeof(uint4) / sizeof(T);
@@ -73,26 +55,13 @@ __global__ void ddaAllReduceTreeIpc(
   const auto idxEnd = countPerRank;
   const size_t idxStride = gridDim.x * blockDim.x * countPerThread;
 
-  reduceScatter<T, NRANKS, hasAcc>(
-      ipcbuffs,
-      ipcbuffs[selfRank],
-      acc,
-      selfRank,
-      idxStart,
-      idxEnd,
-      idxStride,
-      1);
+  reduceScatter<T, NRANKS, hasAcc>(ipcbuffs, ipcbuffs[selfRank], acc, selfRank, idxStart, idxEnd, idxStride, 1);
 
-  barrier.syncOnSameBlockIdx<
-      true /* hasPreviousMemAccess */,
-      true /* hasSubsequentMemAccess */>();
+  barrier.syncOnSameBlockIdx<true /* hasPreviousMemAccess */, true /* hasSubsequentMemAccess */>();
 
-  allGather<T, NRANKS>(
-      ipcbuffs, recvbuff, selfRank, idxStart, idxEnd, idxStride, true);
+  allGather<T, NRANKS>(ipcbuffs, recvbuff, selfRank, idxStart, idxEnd, idxStride, true);
 
-  barrier.syncOnSameBlockIdx<
-      true /* hasPreviousMemAccess */,
-      false /* hasSubsequentMemAccess */>();
+  barrier.syncOnSameBlockIdx<true /* hasPreviousMemAccess */, false /* hasSubsequentMemAccess */>();
 }
 
 } // namespace meta::comms

--- a/projects/rccl/src/include/algorithms/alltoall/alltoall_dda.h
+++ b/projects/rccl/src/include/algorithms/alltoall/alltoall_dda.h
@@ -19,13 +19,8 @@ template <typename T, int NRANKS, bool hasAcc>
 #if defined(USE_ROCM)
 __launch_bounds__(512)
 #endif
-    __global__ void ddaAllToAllIpc(
-        T* const* __restrict__ ipcbuffs,
-        T* __restrict__ recvbuff,
-        size_t count,
-        const T* __restrict__ sendbuff,
-        int selfRank,
-        IpcGpuBarrier barrier) {
+  __global__ void ddaAllToAllIpc(T* const* __restrict__ ipcbuffs, T* __restrict__ recvbuff, size_t count,
+                                 const T* __restrict__ sendbuff, int selfRank, IpcGpuBarrier barrier) {
   // use uint4 to do 16-byte loads to maximize memory efficiency
   // We assume that count % countPerThread == 0. This assumption is enforced
   // before kernel launch
@@ -41,12 +36,9 @@ __launch_bounds__(512)
 
   // It is expensive to launch hipMemcpyAsync on ROCm
   // Move data copy here. Each block copies part of sendbuff data
-  copyFromSrcToDest<T>(
-      sendbuff, ipcbuffs[selfRank], idxStart, copyCount, idxStride);
+  copyFromSrcToDest<T>(sendbuff, ipcbuffs[selfRank], idxStart, copyCount, idxStride);
 
-  barrier.syncOnSameBlockIdx<
-      true /* hasPreviousMemAccess */,
-      true /* hasSubsequentMemAccess */>();
+  barrier.syncOnSameBlockIdx<true /* hasPreviousMemAccess */, true /* hasSubsequentMemAccess */>();
 
   for (size_t idx = idxStart; idx < idxEnd; idx += idxStride) {
 #pragma unroll NRANKS
@@ -54,16 +46,12 @@ __launch_bounds__(512)
       int srcRank = r;
       int srcIdx = idx + selfRank * idxEnd;
       int destIdx = idx + r * idxEnd;
-      *reinterpret_cast<uint4*>(&recvbuff[destIdx]) =
-          reinterpret_cast<const uint4*>(&ipcbuffs[srcRank][srcIdx])[0];
+      *reinterpret_cast<uint4*>(&recvbuff[destIdx]) = reinterpret_cast<const uint4*>(&ipcbuffs[srcRank][srcIdx])[0];
     }
   }
 
   // barrier to ensure remote ranks won't free their buffers until I'm done
-  barrier.syncOnSameBlockIdx<
-      true /* hasPreviousMemAccess */,
-      false /* hasSubsequentMemAccess */>();
+  barrier.syncOnSameBlockIdx<true /* hasPreviousMemAccess */, false /* hasSubsequentMemAccess */>();
 }
 
 } // namespace meta::comms
-

--- a/projects/rccl/src/include/algorithms/reduce_scatter/reduce_scatter_dda.h
+++ b/projects/rccl/src/include/algorithms/reduce_scatter/reduce_scatter_dda.h
@@ -18,17 +18,10 @@ template <typename T, int NRANKS, bool hasAcc>
 #if defined(USE_ROCM)
 __launch_bounds__(512)
 #endif
-__global__ void ddaReduceScatterIpc(
-    T* const* __restrict__ ipcbuffs,
-    T* __restrict__ recvbuff,
-    size_t count,
-    const T* __restrict__ sendbuff,
-    int selfRank,
-    IpcGpuBarrier barrier) {
+  __global__ void ddaReduceScatterIpc(T* const* __restrict__ ipcbuffs, T* __restrict__ recvbuff, size_t count,
+                                      const T* __restrict__ sendbuff, int selfRank, IpcGpuBarrier barrier) {
 
-  barrier.syncOnSameBlockIdx<
-      false /* hasPreviousMemAccess */,
-      true /* hasSubsequentMemAccess */>();
+  barrier.syncOnSameBlockIdx<false /* hasPreviousMemAccess */, true /* hasSubsequentMemAccess */>();
 
   constexpr auto countPerThread = sizeof(uint4) / sizeof(T);
   const auto gtIdx = blockDim.x * blockIdx.x + threadIdx.x;
@@ -37,13 +30,9 @@ __global__ void ddaReduceScatterIpc(
   const auto idxEnd = count;
   const auto idxStride = gridDim.x * blockDim.x * countPerThread;
 
-  reduceScatter<T, NRANKS, hasAcc>(
-      ipcbuffs, recvbuff, nullptr, selfRank, idxStart, idxEnd, idxStride, 0);
+  reduceScatter<T, NRANKS, hasAcc>(ipcbuffs, recvbuff, nullptr, selfRank, idxStart, idxEnd, idxStride, 0);
 
-  barrier.syncOnSameBlockIdx<
-      true /* hasPreviousMemAccess */,
-      false /* hasSubsequentMemAccess */>();
+  barrier.syncOnSameBlockIdx<true /* hasPreviousMemAccess */, false /* hasSubsequentMemAccess */>();
 }
-
 
 } // namespace meta::comms

--- a/projects/rccl/src/include/alloc.h
+++ b/projects/rccl/src/include/alloc.h
@@ -53,22 +53,26 @@ inline void rcclShutdownHandler() {
 
 inline void rcclRegisterShutdownHandler() {
   static std::once_flag once;
-  std::call_once(once, []() {
-    atexit(rcclShutdownHandler);
-  });
+  std::call_once(once, []() { atexit(rcclShutdownHandler); });
 }
 uint64_t clockNano(); // from utils.h with which we have a circular dependency
 
-template<typename T>
-constexpr size_t ncclSizeOfT() { return sizeof(T); }
-template<>
-constexpr size_t ncclSizeOfT<void>() { return 1; }
+template <typename T>
+constexpr size_t ncclSizeOfT() {
+  return sizeof(T);
+}
+template <>
+constexpr size_t ncclSizeOfT<void>() {
+  return 1;
+}
 
 // C++14-compatible wrapper that captures function pointers through template parameters.
 template <typename FunctionPtr, FunctionPtr Function>
 struct ncclDeleterWrapper {
   template <typename... Args>
-  constexpr auto operator()(Args &&...args) const { return Function(std::forward<Args>(args)...); }
+  constexpr auto operator()(Args&&... args) const {
+    return Function(std::forward<Args>(args)...);
+  }
 }; // struct ncclDeleterWrapper
 
 using ncclDeleterFree = ncclDeleterWrapper<decltype(&std::free), std::free>;
@@ -84,7 +88,7 @@ struct ncclSideStream {
 
 inline std::unordered_map<int64_t, ncclSideStream> sideStream;
 inline pthread_mutex_t sideStreamLock = PTHREAD_MUTEX_INITIALIZER;
-extern ncclResult_t getBusId(int cudaDev, int64_t *busId);
+extern ncclResult_t getBusId(int cudaDev, int64_t* busId);
 
 static inline ncclResult_t ncclCreateSideStream(int cudaDev) {
   ncclResult_t res = ncclSuccess;
@@ -93,14 +97,13 @@ static inline ncclResult_t ncclCreateSideStream(int cudaDev) {
   pthread_mutex_lock(&sideStreamLock);
   if (auto it = sideStream.find(busId); it != sideStream.end()) {
     it->second.refCount++;
-    INFO(NCCL_ALLOC, "Side stream %p of dev %d busid %lx inc count to %ld",
-      it->second.stream, cudaDev, busId, it->second.refCount);
+    INFO(NCCL_ALLOC, "Side stream %p of dev %d busid %lx inc count to %ld", it->second.stream, cudaDev, busId,
+         it->second.refCount);
   } else {
     cudaStream_t stream;
     CUDACHECKGOTO(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking), res, fail);
     sideStream.emplace(busId, ncclSideStream{stream, 1});
-    INFO(NCCL_ALLOC, "Created side stream %p of dev %d busid %lx",
-      stream, cudaDev, busId);
+    INFO(NCCL_ALLOC, "Created side stream %p of dev %d busid %lx", stream, cudaDev, busId);
   }
 fail:
   pthread_mutex_unlock(&sideStreamLock);
@@ -114,14 +117,13 @@ static inline ncclResult_t ncclDestroySideStream(int cudaDev) {
   pthread_mutex_lock(&sideStreamLock);
   if (auto it = sideStream.find(busId); it != sideStream.end()) {
     it->second.refCount--;
-    if (it->second.refCount== 0) {
-      INFO(NCCL_ALLOC, "Destroyed side stream %p of dev %d busid %lx",
-        it->second.stream, cudaDev, busId);
+    if (it->second.refCount == 0) {
+      INFO(NCCL_ALLOC, "Destroyed side stream %p of dev %d busid %lx", it->second.stream, cudaDev, busId);
       CUDACHECKGOTO(cudaStreamDestroy(it->second.stream), res, fail);
       sideStream.erase(it);
     } else {
-      INFO(NCCL_ALLOC, "Side stream %p of dev %d busid %lx dec count to %ld",
-        it->second.stream, cudaDev, busId, it->second.refCount);
+      INFO(NCCL_ALLOC, "Side stream %p of dev %d busid %lx dec count to %ld", it->second.stream, cudaDev, busId,
+           it->second.refCount);
     }
   } else {
     WARN("Side stream of dev %d busid %lx was not found for destroy", cudaDev, busId);
@@ -131,7 +133,7 @@ fail:
   return res;
 };
 
-static inline ncclResult_t getSideStream(cudaStream_t *stream) {
+static inline ncclResult_t getSideStream(cudaStream_t* stream) {
   int cudaDev;
   int64_t busId;
   CUDACHECK(cudaGetDevice(&cudaDev));
@@ -139,8 +141,8 @@ static inline ncclResult_t getSideStream(cudaStream_t *stream) {
   pthread_mutex_lock(&sideStreamLock);
   if (auto it = sideStream.find(busId); it != sideStream.end()) {
     *stream = it->second.stream;
-    INFO(NCCL_ALLOC, "Found side stream %p of dev %d busid %lx count %ld",
-      it->second.stream, cudaDev, busId, it->second.refCount);
+    INFO(NCCL_ALLOC, "Found side stream %p of dev %d busid %lx count %ld", it->second.stream, cudaDev, busId,
+         it->second.refCount);
   } else {
     *stream = 0;
     WARN("Side stream of dev %d busid %lx was not found", cudaDev, busId);
@@ -151,7 +153,7 @@ static inline ncclResult_t getSideStream(cudaStream_t *stream) {
 
 #if CUDART_VERSION >= 12020 || ROCM_VERSION >= 71200
 
-static inline ncclResult_t ncclCuMemHostAlloc(void** ptr, CUmemGenericAllocationHandle *handlep, size_t size) {
+static inline ncclResult_t ncclCuMemHostAlloc(void** ptr, CUmemGenericAllocationHandle* handlep, size_t size) {
   ncclResult_t result = ncclSuccess;
   size_t granularity = 0;
   CUdevice currentDev;
@@ -212,7 +214,8 @@ static inline ncclResult_t ncclCuMemHostAlloc(void** ptr, CUmemGenericAllocation
   CUCHECKGOTO(cuMemSetAccess((CUdeviceptr)*ptr, size, &accessDesc, 1), result, fail);
 
   if (handlep) *handlep = handle;
-  INFO(NCCL_ALLOC, "CUMEM Host Alloc Size %zi pointer %p handle %p numa %d dev %d granularity %ld", size, *ptr, (void*)(uintptr_t)handle, cpuNumaNodeId, cudaDev, granularity);
+  INFO(NCCL_ALLOC, "CUMEM Host Alloc Size %zi pointer %p handle %p numa %d dev %d granularity %ld", size, *ptr,
+       (void*)(uintptr_t)handle, cpuNumaNodeId, cudaDev, granularity);
   return result;
 fail:
   WARN("ncclCuMemHostAlloc failed (size %zu, dev %d): cleaning up partial allocation", size, cudaDev);
@@ -256,7 +259,7 @@ static inline ncclResult_t ncclCuMemHostFree(void* ptr) {
 #endif  /* CUDART_VERSION >= 12020 */
 
 template <typename T>
-ncclResult_t ncclCudaHostCallocDebug(T** ptr, size_t nelem, const char *filefunc, int line) {
+ncclResult_t ncclCudaHostCallocDebug(T** ptr, size_t nelem, const char* filefunc, int line) {
   ncclResult_t result = ncclSuccess;
   cudaStreamCaptureMode mode = cudaStreamCaptureModeRelaxed;
   *ptr = nullptr;
@@ -266,22 +269,25 @@ ncclResult_t ncclCudaHostCallocDebug(T** ptr, size_t nelem, const char *filefunc
   if (nelem > 0) {
     if (managed) {
 #if defined(HIP_UNCACHED_MEMORY)
-      CUDACHECKGOTO(hipExtMallocWithFlags((void**)ptr, nelem*ncclSizeOfT<T>(), hipDeviceMallocUncached), result, finish);
+      CUDACHECKGOTO(hipExtMallocWithFlags((void**)ptr, nelem * ncclSizeOfT<T>(), hipDeviceMallocUncached), result,
+                    finish);
 #else
-      CUDACHECKGOTO(hipExtMallocWithFlags((void**)ptr, nelem*ncclSizeOfT<T>(), hipDeviceMallocFinegrained), result, finish);
+      CUDACHECKGOTO(hipExtMallocWithFlags((void**)ptr, nelem * ncclSizeOfT<T>(), hipDeviceMallocFinegrained), result,
+                    finish);
 #endif
     } else
 #if defined(HIP_HOST_UNCACHED_MEMORY)
-      CUDACHECKGOTO(hipHostMalloc(ptr, nelem*ncclSizeOfT<T>(), cudaHostAllocMapped | hipHostMallocUncached), result, finish);
+      CUDACHECKGOTO(hipHostMalloc(ptr, nelem * ncclSizeOfT<T>(), cudaHostAllocMapped | hipHostMallocUncached), result,
+                    finish);
 #else
-      CUDACHECKGOTO(hipHostMalloc(ptr, nelem*ncclSizeOfT<T>(), cudaHostAllocMapped), result, finish);
+      CUDACHECKGOTO(hipHostMalloc(ptr, nelem * ncclSizeOfT<T>(), cudaHostAllocMapped), result, finish);
 #endif
-    memset(*ptr, 0, nelem*ncclSizeOfT<T>());
+    memset(*ptr, 0, nelem * ncclSizeOfT<T>());
   }
 finish:
   CUDACHECK(cudaThreadExchangeStreamCaptureMode(&mode));
-  if (*ptr == nullptr && nelem > 0) WARN("Failed to CUDA host alloc %ld bytes", nelem*ncclSizeOfT<T>());
-  INFO(NCCL_ALLOC, "%s:%d Cuda Host Alloc Size %ld pointer %p", filefunc, line, nelem*ncclSizeOfT<T>(), *ptr);
+  if (*ptr == nullptr && nelem > 0) WARN("Failed to CUDA host alloc %ld bytes", nelem * ncclSizeOfT<T>());
+  INFO(NCCL_ALLOC, "%s:%d Cuda Host Alloc Size %ld pointer %p", filefunc, line, nelem * ncclSizeOfT<T>(), *ptr);
   return result;
 }
 
@@ -299,15 +305,15 @@ static inline ncclResult_t ncclCudaHostFree(void* ptr) {
 #define ncclCudaHostCalloc(...) ncclCudaHostCallocDebug(__VA_ARGS__, __FILE__, __LINE__)
 
 template <typename T>
-ncclResult_t ncclCallocDebug(T** ptr, size_t nelem, const char *filefunc, int line) {
+ncclResult_t ncclCallocDebug(T** ptr, size_t nelem, const char* filefunc, int line) {
   if (nelem > 0) {
-    T* p = (T*)malloc(nelem*ncclSizeOfT<T>());
+    T* p = (T*)malloc(nelem * ncclSizeOfT<T>());
     if (p == NULL) {
-      WARN("Failed to malloc %ld bytes", nelem*ncclSizeOfT<T>());
+      WARN("Failed to malloc %ld bytes", nelem * ncclSizeOfT<T>());
       return ncclSystemError;
     }
-    //INFO(NCCL_ALLOC, "%s:%d malloc Size %ld pointer %p", filefunc, line, nelem*ncclSizeOfT<T>(), p);
-    memset((void*)p, 0, nelem*ncclSizeOfT<T>());
+    // INFO(NCCL_ALLOC, "%s:%d malloc Size %ld pointer %p", filefunc, line, nelem*ncclSizeOfT<T>(), p);
+    memset((void*)p, 0, nelem * ncclSizeOfT<T>());
     *ptr = p;
   } else {
     *ptr = NULL;
@@ -316,7 +322,7 @@ ncclResult_t ncclCallocDebug(T** ptr, size_t nelem, const char *filefunc, int li
 }
 
 template <typename T>
-ncclResult_t ncclCallocDebug(ncclUniquePtr<T>& ptr, size_t nelem, const char *filefunc, int line) {
+ncclResult_t ncclCallocDebug(ncclUniquePtr<T>& ptr, size_t nelem, const char* filefunc, int line) {
   typename ncclUniquePtr<T>::pointer p = nullptr;
   ncclResult_t result = ncclCallocDebug(&p, nelem, filefunc, line);
   ptr.reset(p);
@@ -324,7 +330,7 @@ ncclResult_t ncclCallocDebug(ncclUniquePtr<T>& ptr, size_t nelem, const char *fi
 }
 
 template <typename T>
-ncclResult_t ncclCallocDebug(ncclUniqueArrayPtr<T>& ptr, size_t nelem, const char *filefunc, int line) {
+ncclResult_t ncclCallocDebug(ncclUniqueArrayPtr<T>& ptr, size_t nelem, const char* filefunc, int line) {
   typename ncclUniqueArrayPtr<T>::pointer p = nullptr;
   ncclResult_t result = ncclCallocDebug(&p, nelem, filefunc, line);
   ptr.reset(p);
@@ -339,20 +345,21 @@ ncclResult_t ncclRealloc(T** ptr, size_t oldNelem, size_t nelem) {
   if (nelem < oldNelem || (oldp == NULL && oldNelem > 0)) return ncclInternalError;
   if (nelem == oldNelem) return ncclSuccess;
 
-  T* p = (T*)malloc(nelem*ncclSizeOfT<T>());
+  T* p = (T*)malloc(nelem * ncclSizeOfT<T>());
   if (p == NULL) {
-    WARN("Failed to malloc %ld bytes", nelem*ncclSizeOfT<T>());
+    WARN("Failed to malloc %ld bytes", nelem * ncclSizeOfT<T>());
     return ncclSystemError;
   }
   if (oldp && oldNelem) memcpy(p, oldp, oldNelem * ncclSizeOfT<T>());
   if (oldp) free(oldp);
-  memset(p+oldNelem, 0, (nelem-oldNelem)*ncclSizeOfT<T>());
+  memset(p + oldNelem, 0, (nelem - oldNelem) * ncclSizeOfT<T>());
   *ptr = (T*)p;
-  INFO(NCCL_ALLOC, "Mem Realloc old size %ld, new size %ld pointer %p", oldNelem*ncclSizeOfT<T>(), nelem*ncclSizeOfT<T>(), *ptr);
+  INFO(NCCL_ALLOC, "Mem Realloc old size %ld, new size %ld pointer %p", oldNelem * ncclSizeOfT<T>(),
+       nelem * ncclSizeOfT<T>(), *ptr);
   return ncclSuccess;
 }
 
-struct __attribute__ ((aligned(64))) allocationTracker {
+struct __attribute__((aligned(64))) allocationTracker {
   union {
     struct {
       uint64_t totalAlloc;
@@ -372,9 +379,8 @@ extern struct allocationTracker allocTracker[];
 // [RCCL] Helper introduced upstream in NCCL 2.29.7 -- maps a virtual address
 // range to a physical allocation and grants RW access on the given device.
 // Used by mem_manager.cc and the per-allocator helpers below.
-static inline ncclResult_t ncclCuMemMapAndSetAccess(void *ptr, size_t size,
-  CUmemGenericAllocationHandle handle,
-  int cudaDev) {
+static inline ncclResult_t ncclCuMemMapAndSetAccess(void* ptr, size_t size, CUmemGenericAllocationHandle handle,
+                                                    int cudaDev) {
   ncclResult_t result = ncclSuccess;
   CUCHECK(cuMemMap((CUdeviceptr)ptr, size, 0, handle, 0));
   CUmemAccessDesc accessDesc = {};
@@ -386,7 +392,7 @@ static inline ncclResult_t ncclCuMemMapAndSetAccess(void *ptr, size_t size,
 }
 
 // ncclCuMemAllocAddr takes memory handle and size and returns the mapped address pointer
-static inline ncclResult_t ncclCuMemAllocAddr(void **ptr, CUmemGenericAllocationHandle *handleIn, size_t size) {
+static inline ncclResult_t ncclCuMemAllocAddr(void** ptr, CUmemGenericAllocationHandle* handleIn, size_t size) {
   ncclResult_t result = ncclSuccess;
   size_t granularity = 0;
   CUmemAllocationProp prop = {};
@@ -399,7 +405,7 @@ static inline ncclResult_t ncclCuMemAllocAddr(void **ptr, CUmemGenericAllocation
   CUCHECK(cuMemGetAllocationGranularity(&granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM));
   ALIGN_SIZE(size, granularity);
   /* Reserve a virtual address range */
-  CUCHECKGOTO(cuMemAddressReserve((CUdeviceptr *)ptr, size, granularity, 0, 0), result, fail);
+  CUCHECKGOTO(cuMemAddressReserve((CUdeviceptr*)ptr, size, granularity, 0, 0), result, fail);
   addressReserved = true;
   /* Map the virtual address range to the physical allocation */
   CUCHECKGOTO(cuMemMap((CUdeviceptr)*ptr, size, 0, *handleIn, 0), result, fail);
@@ -411,10 +417,11 @@ static inline ncclResult_t ncclCuMemAllocAddr(void **ptr, CUmemGenericAllocation
   CUCHECKGOTO(cuMemSetAccess((CUdeviceptr)*ptr, size, &accessDesc, 1), result, fail);
   TRACE(NCCL_ALLOC, "CuMem Map Size %zu pointer %p handle %p", size, *ptr, (void*)(uintptr_t)*handleIn);
   if (cudaDev < MAX_ALLOC_TRACK_NGPU) {
-     __atomic_fetch_add(&allocTracker[cudaDev].totalAlloc, 1, __ATOMIC_RELAXED);
-     __atomic_fetch_add(&allocTracker[cudaDev].totalAllocSize, size, __ATOMIC_RELAXED);
+    __atomic_fetch_add(&allocTracker[cudaDev].totalAlloc, 1, __ATOMIC_RELAXED);
+    __atomic_fetch_add(&allocTracker[cudaDev].totalAllocSize, size, __ATOMIC_RELAXED);
   }
-  INFO(NCCL_ALLOC, "ncclCuMemAllocAddr: Memory used = %ld on device = %d", allocTracker[cudaDev].totalAllocSize, cudaDev);
+  INFO(NCCL_ALLOC, "ncclCuMemAllocAddr: Memory used = %ld on device = %d", allocTracker[cudaDev].totalAllocSize,
+       cudaDev);
   return result;
 fail:
   WARN("ncclCuMemAllocAddr failed (size %zu, dev %d): cleaning up partial allocation", size, cudaDev);
@@ -424,7 +431,7 @@ fail:
   return result;
 }
 
-static inline ncclResult_t ncclCuMemFreeAddr(void *ptr, struct ncclMemManager* manager, int numSegments = 1) {
+static inline ncclResult_t ncclCuMemFreeAddr(void* ptr, struct ncclMemManager* manager, int numSegments = 1) {
   if (ptr == NULL) return ncclSuccess;
   // Check if process is shutting down to avoid use-after-free in HIP runtime
   if (rcclShutdownFlag().load(std::memory_order_acquire)) {
@@ -464,14 +471,14 @@ static inline ncclResult_t ncclCuMemFreeAddr(void *ptr, struct ncclMemManager* m
   trackSize *= -1;
   CUDACHECK(hipGetDevice(&dev));
   if (dev < MAX_ALLOC_TRACK_NGPU) {
-     __atomic_fetch_add(&allocTracker[dev].totalAlloc, -1, __ATOMIC_RELAXED);
-     __atomic_fetch_add(&allocTracker[dev].totalAllocSize, trackSize, __ATOMIC_RELAXED);
+    __atomic_fetch_add(&allocTracker[dev].totalAlloc, -1, __ATOMIC_RELAXED);
+    __atomic_fetch_add(&allocTracker[dev].totalAllocSize, trackSize, __ATOMIC_RELAXED);
   }
   INFO(NCCL_ALLOC, "ncclCuMemFreeAddr: Memory used = %ld on device = %d", allocTracker[dev].totalAllocSize, dev);
   return result;
 }
 
-static inline ncclResult_t ncclCuMemAlloc(void **ptr, CUmemGenericAllocationHandle *handlep,
+static inline ncclResult_t ncclCuMemAlloc(void** ptr, CUmemGenericAllocationHandle* handlep,
                                           CUmemAllocationHandleType type, size_t size,
                                           struct ncclMemManager* manager = nullptr,
                                           ncclMemType_t memType = ncclMemPersist) {
@@ -513,7 +520,7 @@ static inline ncclResult_t ncclCuMemAlloc(void **ptr, CUmemGenericAllocationHand
   CUCHECKGOTO(cuMemCreate(&handle, size, &prop, 0), result, fail);
   handleCreated = true;
   /* Reserve a virtual address range */
-  CUCHECKGOTO(cuMemAddressReserve((CUdeviceptr *)ptr, size, granularity, 0, 0), result, fail);
+  CUCHECKGOTO(cuMemAddressReserve((CUdeviceptr*)ptr, size, granularity, 0, 0), result, fail);
   addressReserved = true;
   /* Map the virtual address range to the physical allocation */
   CUCHECKGOTO(cuMemMap((CUdeviceptr)*ptr, size, 0, handle, 0), result, fail);
@@ -538,9 +545,9 @@ static inline ncclResult_t ncclCuMemAlloc(void **ptr, CUmemGenericAllocationHand
     CUDACHECKGOTO(cudaStreamCreateWithFlags(&zeroStream, cudaStreamNonBlocking), result, restoreCapMode);
     CUDACHECKGOTO(cudaMemsetAsync(*ptr, 0, size, zeroStream), result, destroyStream);
     CUDACHECKGOTO(cudaStreamSynchronize(zeroStream), result, destroyStream);
-destroyStream:
+  destroyStream:
     CUDACHECK(cudaStreamDestroy(zeroStream));
-restoreCapMode:
+  restoreCapMode:
     CUDACHECK(cudaThreadExchangeStreamCaptureMode(&capMode));
     if (result != ncclSuccess) goto fail;
   }
@@ -552,8 +559,8 @@ restoreCapMode:
   }
 
   if (cudaDev < MAX_ALLOC_TRACK_NGPU) {
-     __atomic_fetch_add(&allocTracker[cudaDev].totalAlloc, 1, __ATOMIC_RELAXED);
-     __atomic_fetch_add(&allocTracker[cudaDev].totalAllocSize, size, __ATOMIC_RELAXED);
+    __atomic_fetch_add(&allocTracker[cudaDev].totalAlloc, 1, __ATOMIC_RELAXED);
+    __atomic_fetch_add(&allocTracker[cudaDev].totalAllocSize, size, __ATOMIC_RELAXED);
   }
   INFO(NCCL_ALLOC, "ncclCuMemAlloc: Memory used = %ld on device = %d", allocTracker[cudaDev].totalAllocSize, cudaDev);
   return result;
@@ -566,7 +573,7 @@ fail:
   return result;
 }
 
-static inline ncclResult_t ncclCuMemFree(void *ptr, struct ncclMemManager* manager, int numSegments = 1) {
+static inline ncclResult_t ncclCuMemFree(void* ptr, struct ncclMemManager* manager, int numSegments = 1) {
   if (ptr == NULL) return ncclSuccess;
   // Check if process is shutting down to avoid use-after-free in HIP runtime
   if (rcclShutdownFlag().load(std::memory_order_acquire)) {
@@ -591,10 +598,10 @@ static inline ncclResult_t ncclCuMemFree(void *ptr, struct ncclMemManager* manag
     // ROCM-2696: Proper initialization of base and size is required for cuMemGetAddressRange
     // base is dereferenced in cuMemGetAddressRange without checking for nullptr
     CUdeviceptr base = nullptr;
-    // RCCL: cast through char* before pointer arithmetic 
+    // RCCL: cast through char* before pointer arithmetic
     CUCHECK(cuMemGetAddressRange(&base, &segmentSize, (CUdeviceptr)((char*)ptr + totalSize)));
-    TRACE(NCCL_ALLOC, "CuMem Free Size %zu pointer %p handle %p segment %d numSegments %d",
-          segmentSize, ptr, (void*)(uintptr_t)handle, segment, numSegments);
+    TRACE(NCCL_ALLOC, "CuMem Free Size %zu pointer %p handle %p segment %d numSegments %d", segmentSize, ptr,
+          (void*)(uintptr_t)handle, segment, numSegments);
     CUCHECK(cuMemUnmap((CUdeviceptr)((char*)ptr + totalSize), segmentSize));
     CUCHECK(cuMemRelease(handle));
     totalSize += segmentSize;
@@ -610,15 +617,17 @@ static inline ncclResult_t ncclCuMemFree(void *ptr, struct ncclMemManager* manag
   int dev;
   CUDACHECK(hipGetDevice(&dev));
   if (dev < MAX_ALLOC_TRACK_NGPU) {
-     __atomic_fetch_add(&allocTracker[dev].totalAlloc, -1, __ATOMIC_RELAXED);
-     __atomic_fetch_add(&allocTracker[dev].totalAllocSize, -(int64_t)totalSize, __ATOMIC_RELAXED);
+    __atomic_fetch_add(&allocTracker[dev].totalAlloc, -1, __ATOMIC_RELAXED);
+    __atomic_fetch_add(&allocTracker[dev].totalAllocSize, -(int64_t)totalSize, __ATOMIC_RELAXED);
   }
   INFO(NCCL_ALLOC, "ncclCuMemFree: Memory used = %ld on device = %d", allocTracker[dev].totalAllocSize, dev);
   return result;
 }
 
 // Get the base and size of all segments that span a given user buffer
-static inline ncclResult_t ncclCuMemGetAddressRange(CUdeviceptr userBuff, size_t userBuffSize, CUdeviceptr* mappedPtrBase, size_t* totalMappedBufferSize, int* numSegments, bool* hasSysmemSegment = nullptr) {
+static inline ncclResult_t ncclCuMemGetAddressRange(CUdeviceptr userBuff, size_t userBuffSize,
+                                                    CUdeviceptr* mappedPtrBase, size_t* totalMappedBufferSize,
+                                                    int* numSegments, bool* hasSysmemSegment = nullptr) {
   *totalMappedBufferSize = 0;
   *mappedPtrBase = 0;
   if (numSegments) *numSegments = 0;
@@ -638,7 +647,7 @@ static inline ncclResult_t ncclCuMemGetAddressRange(CUdeviceptr userBuff, size_t
     if (hasSysmemSegment != nullptr && *hasSysmemSegment == false) {
       CUmemGenericAllocationHandle handle;
       CUmemAllocationProp prop;
-      CUCHECK(cuMemRetainAllocationHandle(&handle, (void *) mappedPtrEnd));
+      CUCHECK(cuMemRetainAllocationHandle(&handle, (void*)mappedPtrEnd));
       CUCHECK(cuMemGetAllocationPropertiesFromHandle(&prop, handle));
 #if defined(__HIP_PLATFORM_AMD__)
 #if ROCM_VERSION >= 71200
@@ -681,77 +690,76 @@ static inline ncclResult_t ncclCuMemGetAddressRange(CUdeviceptr userBuff, size_t
 
 extern int ncclCuMemEnable();
 
-static inline ncclResult_t ncclCuMemAlloc(void **ptr, void *handlep, int type, size_t size,
-                                          struct ncclMemManager* manager,
-                                          ncclMemType_t memType = ncclMemPersist) {
+static inline ncclResult_t ncclCuMemAlloc(void** ptr, void* handlep, int type, size_t size,
+                                          struct ncclMemManager* manager, ncclMemType_t memType = ncclMemPersist) {
   WARN("CUMEM requires ROCM_VERSION >= 7.0.0");
   return ncclInternalError;
 }
-static inline ncclResult_t ncclCuMemFree(void *ptr, struct ncclMemManager* manager, int numSegments = 1) {
-  WARN("CUMEM requires ROCM_VERSION >= 7.0.0");
-  return ncclInternalError;
-}
-
-static inline ncclResult_t ncclCuMemAllocAddr(void **ptr, CUmemGenericAllocationHandle *handleIn, size_t size) {
+static inline ncclResult_t ncclCuMemFree(void* ptr, struct ncclMemManager* manager, int numSegments = 1) {
   WARN("CUMEM requires ROCM_VERSION >= 7.0.0");
   return ncclInternalError;
 }
 
-static inline ncclResult_t ncclCuMemFreeAddr(void *ptr, struct ncclMemManager* manager, int numSegments = 1) {
+static inline ncclResult_t ncclCuMemAllocAddr(void** ptr, CUmemGenericAllocationHandle* handleIn, size_t size) {
   WARN("CUMEM requires ROCM_VERSION >= 7.0.0");
   return ncclInternalError;
 }
 
-static inline ncclResult_t ncclCuMemGetAddressRange(CUdeviceptr userBuff, size_t userBuffSize, CUdeviceptr* mappedPtrBase, size_t* totalMappedBufferSize, int* numSegments) {
+static inline ncclResult_t ncclCuMemFreeAddr(void* ptr, struct ncclMemManager* manager, int numSegments = 1) {
   WARN("CUMEM requires ROCM_VERSION >= 7.0.0");
   return ncclInternalError;
 }
 
-static inline ncclResult_t ncclCuMemMapAndSetAccess(void *ptr, size_t size,
-  CUmemGenericAllocationHandle handle, int cudaDev) {
+static inline ncclResult_t ncclCuMemGetAddressRange(CUdeviceptr userBuff, size_t userBuffSize,
+                                                    CUdeviceptr* mappedPtrBase, size_t* totalMappedBufferSize,
+                                                    int* numSegments) {
+  WARN("CUMEM requires ROCM_VERSION >= 7.0.0");
+  return ncclInternalError;
+}
+
+static inline ncclResult_t ncclCuMemMapAndSetAccess(void* ptr, size_t size, CUmemGenericAllocationHandle handle,
+                                                    int cudaDev) {
   WARN("CUMEM requires ROCM_VERSION >= 7.0.0");
   return ncclInternalError;
 }
 #endif
 
 template <typename T>
-ncclResult_t ncclCudaMallocDebug(T** ptr, size_t nelem, const char *filefunc, int line,
-                                 struct ncclMemManager* manager,
-                                 ncclMemType_t memType = ncclMemPersist,
-                                 unsigned int flags = hipDeviceMallocDefault) {
+ncclResult_t ncclCudaMallocDebug(T** ptr, size_t nelem, const char* filefunc, int line, struct ncclMemManager* manager,
+                                 ncclMemType_t memType = ncclMemPersist, unsigned int flags = hipDeviceMallocDefault) {
   ncclResult_t result = ncclSuccess;
   cudaStreamCaptureMode mode = cudaStreamCaptureModeRelaxed;
   *ptr = nullptr;
   CUDACHECK(cudaThreadExchangeStreamCaptureMode(&mode));
   if (nelem > 0) {
     if (ncclCuMemEnable()) {
-      NCCLCHECKGOTO(ncclCuMemAlloc((void **)ptr, NULL, ncclCuMemHandleType, nelem*ncclSizeOfT<T>(), manager, memType), result, finish);
+      NCCLCHECKGOTO(ncclCuMemAlloc((void**)ptr, NULL, ncclCuMemHandleType, nelem * ncclSizeOfT<T>(), manager, memType),
+                    result, finish);
     } else {
-      CUDACHECKGOTO(hipExtMallocWithFlags((void**)ptr, nelem*ncclSizeOfT<T>(), flags), result, finish);
+      CUDACHECKGOTO(hipExtMallocWithFlags((void**)ptr, nelem * ncclSizeOfT<T>(), flags), result, finish);
     }
   }
 finish:
   CUDACHECK(cudaThreadExchangeStreamCaptureMode(&mode));
-  if (*ptr == nullptr && nelem > 0) WARN("Failed to CUDA malloc %ld bytes", nelem*ncclSizeOfT<T>());
+  if (*ptr == nullptr && nelem > 0) WARN("Failed to CUDA malloc %ld bytes", nelem * ncclSizeOfT<T>());
   else {
-     int dev;
-     CUDACHECK(hipGetDevice(&dev));
-     if (dev < MAX_ALLOC_TRACK_NGPU) {
-        __atomic_fetch_add(&allocTracker[dev].totalAlloc, 1, __ATOMIC_RELAXED);
-        __atomic_fetch_add(&allocTracker[dev].totalAllocSize, nelem*ncclSizeOfT<T>(), __ATOMIC_RELAXED);
-     }
-     INFO(NCCL_ALLOC, "ncclCudaMallocDebug: Memory used = %ld on device = %d", allocTracker[dev].totalAllocSize, dev);
+    int dev;
+    CUDACHECK(hipGetDevice(&dev));
+    if (dev < MAX_ALLOC_TRACK_NGPU) {
+      __atomic_fetch_add(&allocTracker[dev].totalAlloc, 1, __ATOMIC_RELAXED);
+      __atomic_fetch_add(&allocTracker[dev].totalAllocSize, nelem * ncclSizeOfT<T>(), __ATOMIC_RELAXED);
+    }
+    INFO(NCCL_ALLOC, "ncclCudaMallocDebug: Memory used = %ld on device = %d", allocTracker[dev].totalAllocSize, dev);
   }
-  INFO(NCCL_ALLOC, "%s:%d Cuda Alloc Size %ld pointer %p flags %d", filefunc, line, nelem*ncclSizeOfT<T>(), *ptr, flags);
+  INFO(NCCL_ALLOC, "%s:%d Cuda Alloc Size %ld pointer %p flags %d", filefunc, line, nelem * ncclSizeOfT<T>(), *ptr,
+       flags);
   return result;
 }
 #define ncclCudaMalloc(ptr, nelem, ...) ncclCudaMallocDebug(ptr, nelem, __FILE__, __LINE__, ##__VA_ARGS__)
 
 template <typename T>
-ncclResult_t ncclCudaCallocDebug(T** ptr, size_t nelem, const char *filefunc, int line,
-                                 struct ncclMemManager* manager,
-                                 ncclMemType_t memType = ncclMemPersist,
-                                 unsigned int flags = hipDeviceMallocDefault) {
+ncclResult_t ncclCudaCallocDebug(T** ptr, size_t nelem, const char* filefunc, int line, struct ncclMemManager* manager,
+                                 ncclMemType_t memType = ncclMemPersist, unsigned int flags = hipDeviceMallocDefault) {
   ncclResult_t result = ncclSuccess;
   cudaStreamCaptureMode mode = cudaStreamCaptureModeRelaxed;
   *ptr = nullptr;
@@ -763,30 +771,30 @@ ncclResult_t ncclCudaCallocDebug(T** ptr, size_t nelem, const char *filefunc, in
     cudaStream_t stream, sidestream;
     NCCLCHECK(getSideStream(&sidestream));
     stream = sidestream;
-    if (sidestream == nullptr)
-      CUDACHECK(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
+    if (sidestream == nullptr) CUDACHECK(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
     if (ncclCuMemEnable()) {
-      NCCLCHECKGOTO(ncclCuMemAlloc((void **)ptr, NULL, ncclCuMemHandleType, nelem*ncclSizeOfT<T>(), manager, memType), result, finish);
+      NCCLCHECKGOTO(ncclCuMemAlloc((void**)ptr, NULL, ncclCuMemHandleType, nelem * ncclSizeOfT<T>(), manager, memType),
+                    result, finish);
     } else {
-      CUDACHECKGOTO(hipExtMallocWithFlags((void**)ptr, nelem*ncclSizeOfT<T>(), flags), result, finish);
+      CUDACHECKGOTO(hipExtMallocWithFlags((void**)ptr, nelem * ncclSizeOfT<T>(), flags), result, finish);
     }
-    CUDACHECKGOTO(cudaMemsetAsync(*ptr, 0, nelem*ncclSizeOfT<T>(), stream), result, finish);
+    CUDACHECKGOTO(cudaMemsetAsync(*ptr, 0, nelem * ncclSizeOfT<T>(), stream), result, finish);
     CUDACHECKGOTO(cudaStreamSynchronize(stream), result, finish);
-    if (sidestream == nullptr)
-      CUDACHECKGOTO(cudaStreamDestroy(stream), result, finish);
+    if (sidestream == nullptr) CUDACHECKGOTO(cudaStreamDestroy(stream), result, finish);
   }
 finish:
   CUDACHECK(cudaThreadExchangeStreamCaptureMode(&mode));
-  if (*ptr == nullptr && nelem > 0) WARN("Failed to CUDA calloc %ld bytes", nelem*ncclSizeOfT<T>());
+  if (*ptr == nullptr && nelem > 0) WARN("Failed to CUDA calloc %ld bytes", nelem * ncclSizeOfT<T>());
   else {
-      CUDACHECK(hipGetDevice(&dev));
-      if (dev < MAX_ALLOC_TRACK_NGPU) {
-    	 __atomic_fetch_add(&allocTracker[dev].totalAlloc, 1, __ATOMIC_RELAXED);
-    	 __atomic_fetch_add(&allocTracker[dev].totalAllocSize, nelem*ncclSizeOfT<T>(), __ATOMIC_RELAXED);
-      }
-      INFO(NCCL_ALLOC, "ncclCudaCallocDebug: Memory used = %ld on device = %d", allocTracker[dev].totalAllocSize, dev);
+    CUDACHECK(hipGetDevice(&dev));
+    if (dev < MAX_ALLOC_TRACK_NGPU) {
+      __atomic_fetch_add(&allocTracker[dev].totalAlloc, 1, __ATOMIC_RELAXED);
+      __atomic_fetch_add(&allocTracker[dev].totalAllocSize, nelem * ncclSizeOfT<T>(), __ATOMIC_RELAXED);
+    }
+    INFO(NCCL_ALLOC, "ncclCudaCallocDebug: Memory used = %ld on device = %d", allocTracker[dev].totalAllocSize, dev);
   }
-  INFO(NCCL_ALLOC, "%s:%d Cuda Alloc Size %ld pointer %p flags %d", filefunc, line, nelem*ncclSizeOfT<T>(), *ptr, flags);
+  INFO(NCCL_ALLOC, "%s:%d Cuda Alloc Size %ld pointer %p flags %d", filefunc, line, nelem * ncclSizeOfT<T>(), *ptr,
+       flags);
   return result;
 }
 #define ncclCudaCalloc(ptr, nelem, ...) ncclCudaCallocDebug(ptr, nelem, __FILE__, __LINE__, ##__VA_ARGS__)
@@ -799,23 +807,20 @@ finish:
 // the HIP allocator path yet. This way new upstream call sites compile
 // without forcing every old AMD call site to change.
 template <typename T>
-ncclResult_t ncclCudaMallocDebug(const char *filefunc, int line, T** ptr, size_t nelem,
-                                 struct ncclMemManager* /*manager*/,
-                                 ncclMemType_t /*memType*/ = ncclMemPersist) {
+ncclResult_t ncclCudaMallocDebug(const char* filefunc, int line, T** ptr, size_t nelem,
+                                 struct ncclMemManager* /*manager*/, ncclMemType_t /*memType*/ = ncclMemPersist) {
   return ncclCudaMallocDebug(filefunc, line, ptr, nelem);
 }
 
 template <typename T>
-ncclResult_t ncclCudaCallocDebug(const char *filefunc, int line, T** ptr, size_t nelem,
-                                 struct ncclMemManager* /*manager*/,
-                                 ncclMemType_t /*memType*/ = ncclMemPersist) {
+ncclResult_t ncclCudaCallocDebug(const char* filefunc, int line, T** ptr, size_t nelem,
+                                 struct ncclMemManager* /*manager*/, ncclMemType_t /*memType*/ = ncclMemPersist) {
   return ncclCudaCallocDebug(filefunc, line, ptr, nelem);
 }
 
 template <typename T>
-ncclResult_t ncclCudaCallocAsyncDebug(T** ptr, size_t nelem, hipStream_t stream, const char *filefunc, int line,
-                                      struct ncclMemManager* manager,
-                                      ncclMemType_t memType = ncclMemPersist,
+ncclResult_t ncclCudaCallocAsyncDebug(T** ptr, size_t nelem, hipStream_t stream, const char* filefunc, int line,
+                                      struct ncclMemManager* manager, ncclMemType_t memType = ncclMemPersist,
                                       unsigned int flags = hipDeviceMallocDefault) {
   ncclResult_t result = ncclSuccess;
   cudaStreamCaptureMode mode = cudaStreamCaptureModeRelaxed;
@@ -825,35 +830,36 @@ ncclResult_t ncclCudaCallocAsyncDebug(T** ptr, size_t nelem, hipStream_t stream,
   CUDACHECK(cudaThreadExchangeStreamCaptureMode(&mode));
   if (nelem > 0) {
     if (ncclCuMemEnable()) {
-      NCCLCHECKGOTO(ncclCuMemAlloc((void **)ptr, NULL, ncclCuMemHandleType, nelem*ncclSizeOfT<T>(), manager, memType), result, finish);
+      NCCLCHECKGOTO(ncclCuMemAlloc((void**)ptr, NULL, ncclCuMemHandleType, nelem * ncclSizeOfT<T>(), manager, memType),
+                    result, finish);
     } else {
-      CUDACHECKGOTO(hipExtMallocWithFlags((void**)ptr, nelem*ncclSizeOfT<T>(), flags), result, finish);
+      CUDACHECKGOTO(hipExtMallocWithFlags((void**)ptr, nelem * ncclSizeOfT<T>(), flags), result, finish);
     }
-    CUDACHECKGOTO(cudaMemsetAsync(*ptr, 0, nelem*ncclSizeOfT<T>(), stream), result, finish);
+    CUDACHECKGOTO(cudaMemsetAsync(*ptr, 0, nelem * ncclSizeOfT<T>(), stream), result, finish);
   }
 finish:
   CUDACHECK(cudaThreadExchangeStreamCaptureMode(&mode));
-  if (*ptr == nullptr && nelem > 0) WARN("Failed to CUDA calloc async %ld bytes", nelem*ncclSizeOfT<T>());
+  if (*ptr == nullptr && nelem > 0) WARN("Failed to CUDA calloc async %ld bytes", nelem * ncclSizeOfT<T>());
   else {
-     CUDACHECK(hipGetDevice(&dev));
-     if (dev < MAX_ALLOC_TRACK_NGPU) {
-       __atomic_fetch_add(&allocTracker[dev].totalAlloc, 1, __ATOMIC_RELAXED);
-       __atomic_fetch_add(&allocTracker[dev].totalAllocSize, nelem*ncclSizeOfT<T>(), __ATOMIC_RELAXED);
-     }
-     INFO(NCCL_ALLOC, "ncclCudaCallocDebug: Memory used = %ld on device = %d", allocTracker[dev].totalAllocSize, dev);
+    CUDACHECK(hipGetDevice(&dev));
+    if (dev < MAX_ALLOC_TRACK_NGPU) {
+      __atomic_fetch_add(&allocTracker[dev].totalAlloc, 1, __ATOMIC_RELAXED);
+      __atomic_fetch_add(&allocTracker[dev].totalAllocSize, nelem * ncclSizeOfT<T>(), __ATOMIC_RELAXED);
+    }
+    INFO(NCCL_ALLOC, "ncclCudaCallocDebug: Memory used = %ld on device = %d", allocTracker[dev].totalAllocSize, dev);
   }
-  INFO(NCCL_ALLOC, "%s:%d Cuda Alloc Size %ld pointer %p flags %d", filefunc, line, nelem*ncclSizeOfT<T>(), *ptr, flags);
+  INFO(NCCL_ALLOC, "%s:%d Cuda Alloc Size %ld pointer %p flags %d", filefunc, line, nelem * ncclSizeOfT<T>(), *ptr,
+       flags);
   return result;
 }
-#define ncclCudaCallocAsync(ptr, nelem, stream, ...) ncclCudaCallocAsyncDebug(ptr, nelem, stream, __FILE__, __LINE__, ##__VA_ARGS__)
+#define ncclCudaCallocAsync(ptr, nelem, stream, ...) \
+  ncclCudaCallocAsyncDebug(ptr, nelem, stream, __FILE__, __LINE__, ##__VA_ARGS__)
 
 // [RCCL] Manager/memType overload for ncclCudaCallocAsyncDebug; see the note
 // above ncclCudaMallocDebug for rationale.
 template <typename T>
-ncclResult_t ncclCudaCallocAsyncDebug(const char *filefunc, int line, T** ptr, size_t nelem,
-                                      hipStream_t stream,
-                                      struct ncclMemManager* /*manager*/,
-                                      ncclMemType_t /*memType*/ = ncclMemPersist) {
+ncclResult_t ncclCudaCallocAsyncDebug(const char* filefunc, int line, T** ptr, size_t nelem, hipStream_t stream,
+                                      struct ncclMemManager* /*manager*/, ncclMemType_t /*memType*/ = ncclMemPersist) {
   return ncclCudaCallocAsyncDebug(filefunc, line, ptr, nelem, stream);
 }
 
@@ -866,12 +872,10 @@ ncclResult_t ncclCudaMemcpy(T* dst, T* src, size_t nelem) {
   cudaStream_t stream, sidestream;
   NCCLCHECK(getSideStream(&sidestream));
   stream = sidestream;
-  if (sidestream == nullptr)
-    CUDACHECKGOTO(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking), result, finish);
+  if (sidestream == nullptr) CUDACHECKGOTO(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking), result, finish);
   NCCLCHECKGOTO(ncclCudaMemcpyAsync(dst, src, nelem, stream), result, finish);
   CUDACHECKGOTO(cudaStreamSynchronize(stream), result, finish);
-  if (sidestream == nullptr)
-    CUDACHECKGOTO(cudaStreamDestroy(stream), result, finish);
+  if (sidestream == nullptr) CUDACHECKGOTO(cudaStreamDestroy(stream), result, finish);
 finish:
   CUDACHECK(cudaThreadExchangeStreamCaptureMode(&mode));
   return result;
@@ -898,7 +902,7 @@ ncclResult_t ncclCudaMemcpyAsync(T* dst, T* src, size_t nelem, cudaStream_t stre
   ncclResult_t result = ncclSuccess;
   cudaStreamCaptureMode mode = cudaStreamCaptureModeRelaxed;
   CUDACHECK(cudaThreadExchangeStreamCaptureMode(&mode));
-  CUDACHECKGOTO(cudaMemcpyAsync(dst, src, nelem*ncclSizeOfT<T>(), cudaMemcpyDefault, stream), result, finish);
+  CUDACHECKGOTO(cudaMemcpyAsync(dst, src, nelem * ncclSizeOfT<T>(), cudaMemcpyDefault, stream), result, finish);
 finish:
   CUDACHECK(cudaThreadExchangeStreamCaptureMode(&mode));
   return result;
@@ -929,26 +933,26 @@ ncclResult_t ncclCudaFree(T* ptr, struct ncclMemManager* manager, int numSegment
 
   // get the size of the allocation for tracking
   {
-     CUdeviceptr baseAddress;
-     size_t retrievedSize;
+    CUdeviceptr baseAddress;
+    size_t retrievedSize;
 
-     CUDACHECK(cuMemGetAddressRange(&baseAddress, &retrievedSize, ptr));
-     retrievedSize *= -1;
+    CUDACHECK(cuMemGetAddressRange(&baseAddress, &retrievedSize, ptr));
+    retrievedSize *= -1;
 
-     if (ptr == baseAddress) {
-        int dev;
-        CUDACHECK(hipGetDevice(&dev));
-        if (dev < MAX_ALLOC_TRACK_NGPU) {
-           __atomic_fetch_add(&allocTracker[dev].totalAlloc, -1, __ATOMIC_RELAXED);
-           __atomic_fetch_add(&allocTracker[dev].totalAllocSize, retrievedSize, __ATOMIC_RELAXED);
-        }
-        INFO(NCCL_ALLOC, "ncclCudaFree: Memory used = %ld on device = %d", allocTracker[dev].totalAllocSize, dev);
-     }
+    if (ptr == baseAddress) {
+      int dev;
+      CUDACHECK(hipGetDevice(&dev));
+      if (dev < MAX_ALLOC_TRACK_NGPU) {
+        __atomic_fetch_add(&allocTracker[dev].totalAlloc, -1, __ATOMIC_RELAXED);
+        __atomic_fetch_add(&allocTracker[dev].totalAllocSize, retrievedSize, __ATOMIC_RELAXED);
+      }
+      INFO(NCCL_ALLOC, "ncclCudaFree: Memory used = %ld on device = %d", allocTracker[dev].totalAllocSize, dev);
+    }
   }
 
   CUDACHECK(cudaThreadExchangeStreamCaptureMode(&mode));
   if (ncclCuMemEnable()) {
-    NCCLCHECKGOTO(ncclCuMemFree((void *)ptr, manager, numSegments), result, finish);
+    NCCLCHECKGOTO(ncclCuMemFree((void*)ptr, manager, numSegments), result, finish);
   } else {
     if (numSegments > 1) {
       result = ncclUnhandledCudaError;
@@ -965,7 +969,7 @@ finish:
 // Allocate memory to be potentially ibv_reg_mr'd. This needs to be
 // allocated on separate pages as those pages will be marked DONTFORK
 // and if they are shared, that could cause a crash in a child process
-inline ncclResult_t ncclIbMallocDebug(void** ptr, size_t size, const char *filefunc, int line) {
+inline ncclResult_t ncclIbMallocDebug(void** ptr, size_t size, const char* filefunc, int line) {
   if (size > 0) {
     void* p = NULL;
     size_t page_size = ncclOsGetPageSize();
@@ -989,6 +993,5 @@ inline ncclResult_t ncclIbMallocDebug(void** ptr, size_t size, const char *filef
   return ncclSuccess;
 }
 #define ncclIbMalloc(...) ncclIbMallocDebug(__VA_ARGS__, __FILE__, __LINE__)
-
 
 #endif

--- a/projects/rccl/src/include/allocator.h
+++ b/projects/rccl/src/include/allocator.h
@@ -25,9 +25,9 @@ struct ncclSpace {
 
 void ncclSpaceConstruct(struct ncclSpace* a);
 void ncclSpaceDestruct(struct ncclSpace* a);
-ncclResult_t ncclSpaceAlloc(struct ncclSpace* a, int64_t spaceLimit, int64_t objSize, int objAlign, int64_t* outObjOffset);
+ncclResult_t ncclSpaceAlloc(struct ncclSpace* a, int64_t spaceLimit, int64_t objSize, int objAlign,
+                            int64_t* outObjOffset);
 ncclResult_t ncclSpaceFree(struct ncclSpace* a, int64_t objOffset, int64_t objSize);
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // ncclShadowPool: Allocates device-side objects, their host-side shadows, and
@@ -44,12 +44,14 @@ struct ncclShadowPool {
 
 void ncclShadowPoolConstruct(struct ncclShadowPool*);
 ncclResult_t ncclShadowPoolDestruct(struct ncclShadowPool*);
-ncclResult_t ncclShadowPoolAlloc(struct ncclShadowPool*, size_t size, void** outDevObj, void** outHostObj, cudaStream_t stream);
+ncclResult_t ncclShadowPoolAlloc(struct ncclShadowPool*, size_t size, void** outDevObj, void** outHostObj,
+                                 cudaStream_t stream);
 ncclResult_t ncclShadowPoolFree(struct ncclShadowPool*, void* devObj, cudaStream_t stream);
 ncclResult_t ncclShadowPoolToHost(struct ncclShadowPool*, void* devObj, void** outHostObj);
 
-template<typename T>
-static inline ncclResult_t ncclShadowPoolAlloc(struct ncclShadowPool* pool, T** outDevObj, T** outHostObj, cudaStream_t stream) {
+template <typename T>
+static inline ncclResult_t ncclShadowPoolAlloc(struct ncclShadowPool* pool, T** outDevObj, T** outHostObj,
+                                               cudaStream_t stream) {
   void* devObj;
   void* hostObj;
   ncclResult_t got = ncclShadowPoolAlloc(pool, sizeof(T), &devObj, &hostObj, stream);
@@ -58,7 +60,7 @@ static inline ncclResult_t ncclShadowPoolAlloc(struct ncclShadowPool* pool, T** 
   return got;
 }
 
-template<typename T>
+template <typename T>
 static inline ncclResult_t ncclShadowPoolToHost(struct ncclShadowPool* pool, T* devObj, T** hostObj) {
   return ncclShadowPoolToHost(pool, (void*)devObj, (void**)hostObj);
 }

--- a/projects/rccl/src/include/alt_rsmi.h
+++ b/projects/rccl/src/include/alt_rsmi.h
@@ -35,32 +35,31 @@
  ** file or not. The values have to be identical however
  */
 typedef enum _ARSMI_IO_LINK_TYPE {
-  ARSMI_IOLINK_TYPE_UNDEFINED      = 0,          //!< unknown type.
+  ARSMI_IOLINK_TYPE_UNDEFINED = 0,          //!< unknown type.
   ARSMI_IOLINK_TYPE_PCIEXPRESS,                  //!< PCI Express
   ARSMI_IOLINK_TYPE_XGMI,                        //!< XGMI
   ARSMI_IOLINK_TYPE_NUMIOLINKTYPES,              //!< Number of IO Link types
-  ARSMI_IOLINK_TYPE_SIZE           = 0xFFFFFFFF  //!< Max of IO Link types
+  ARSMI_IOLINK_TYPE_SIZE = 0xFFFFFFFF  //!< Max of IO Link types
 } ARSMI_IO_LINK_TYPE;
 
 struct ARSMI_linkInfo {
-    uint32_t src_node;
-    uint32_t dst_node;
-    uint64_t hops;
-    ARSMI_IO_LINK_TYPE type;
-    uint64_t weight;
-    uint64_t min_bandwidth;
-    uint64_t max_bandwidth;
+  uint32_t src_node;
+  uint32_t dst_node;
+  uint64_t hops;
+  ARSMI_IO_LINK_TYPE type;
+  uint64_t weight;
+  uint64_t min_bandwidth;
+  uint64_t max_bandwidth;
 };
 typedef struct ARSMI_linkInfo ARSMI_linkInfo;
 
-int ARSMI_init (void);
-int ARSMI_get_num_devices (uint32_t *num_devices);
-int ARSMI_dev_pci_id_get(uint32_t dv_ind, uint64_t *bdfid);
-int ARSMI_topo_get_link_info(uint32_t dv_ind_src, uint32_t dv_ind_dst,
-                             ARSMI_linkInfo *info);
+int ARSMI_init(void);
+int ARSMI_get_num_devices(uint32_t* num_devices);
+int ARSMI_dev_pci_id_get(uint32_t dv_ind, uint64_t* bdfid);
+int ARSMI_topo_get_link_info(uint32_t dv_ind_src, uint32_t dv_ind_dst, ARSMI_linkInfo* info);
 
 // Firmware version - reads MEC firmware from sysfs
-int ARSMI_get_fw_version(uint32_t dv_ind, uint64_t *fw_version);
+int ARSMI_get_fw_version(uint32_t dv_ind, uint64_t* fw_version);
 
 /*
  * Fabric support via /sys/class/drm/<card>/device/ualink/
@@ -70,44 +69,44 @@ int ARSMI_get_fw_version(uint32_t dv_ind, uint64_t *fw_version);
  */
 
 typedef enum {
-    ARSMI_FABRIC_TYPE_UALOE   = 0,
-    ARSMI_FABRIC_TYPE_UALLINK = 1,
-    ARSMI_FABRIC_TYPE_UNKNOWN = 2
+  ARSMI_FABRIC_TYPE_UALOE = 0,
+  ARSMI_FABRIC_TYPE_UALLINK = 1,
+  ARSMI_FABRIC_TYPE_UNKNOWN = 2
 } ARSMI_fabric_type_t;
 
 typedef enum {
-    ARSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNCONFIGURED = 0,
-    ARSMI_FABRIC_ACCELERATOR_VPOD_STATE_CONFIGURED   = 1,
-    ARSMI_FABRIC_ACCELERATOR_VPOD_STATE_READY        = 2,
-    ARSMI_FABRIC_ACCELERATOR_VPOD_STATE_ACTIVE       = 3,
-    ARSMI_FABRIC_ACCELERATOR_VPOD_STATE_ERROR        = 4,
-    ARSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNKNOWN      = 5
+  ARSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNCONFIGURED = 0,
+  ARSMI_FABRIC_ACCELERATOR_VPOD_STATE_CONFIGURED = 1,
+  ARSMI_FABRIC_ACCELERATOR_VPOD_STATE_READY = 2,
+  ARSMI_FABRIC_ACCELERATOR_VPOD_STATE_ACTIVE = 3,
+  ARSMI_FABRIC_ACCELERATOR_VPOD_STATE_ERROR = 4,
+  ARSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNKNOWN = 5
 } ARSMI_fabric_accelerator_vpod_state_t;
 
 typedef enum {
-    ARSMI_FABRIC_NPA_ADDRESS_MODE_SOURCE_ALIASING       = 0,
-    ARSMI_FABRIC_NPA_ADDRESS_MODE_SOURCE_IDENTIFICATION = 1,
-    ARSMI_FABRIC_NPA_ADDRESS_MODE_UNKNOWN               = 2
+  ARSMI_FABRIC_NPA_ADDRESS_MODE_SOURCE_ALIASING = 0,
+  ARSMI_FABRIC_NPA_ADDRESS_MODE_SOURCE_IDENTIFICATION = 1,
+  ARSMI_FABRIC_NPA_ADDRESS_MODE_UNKNOWN = 2
 } ARSMI_fabric_npa_address_mode_t;
 
 struct ARSMI_fabricInfo {
-    int                                  supported;   /* 1 if UALoE or UALLink and state is ready/active */
-    ARSMI_fabric_type_t                  fabric_type;
-    ARSMI_fabric_accelerator_vpod_state_t accel_state;
-    ARSMI_fabric_npa_address_mode_t      addr_mode;
-    uint32_t  accel_id;
-    uint8_t   ppod_id[16];   /* 128-bit UUID, binary (parsed from sysfs hex string) */
-    uint32_t  ppod_size;
-    uint32_t  bandwidth;     /* Mb/s */
-    uint32_t  latency;       /* ns */
-    uint32_t  vpod_id;
-    uint32_t  vpod_size;
+  int supported;   /* 1 if UALoE or UALLink and state is ready/active */
+  ARSMI_fabric_type_t fabric_type;
+  ARSMI_fabric_accelerator_vpod_state_t accel_state;
+  ARSMI_fabric_npa_address_mode_t addr_mode;
+  uint32_t accel_id;
+  uint8_t ppod_id[16];   /* 128-bit UUID, binary (parsed from sysfs hex string) */
+  uint32_t ppod_size;
+  uint32_t bandwidth;     /* Mb/s */
+  uint32_t latency;       /* ns */
+  uint32_t vpod_id;
+  uint32_t vpod_size;
 };
 
 /* Read fabric info for device dv_ind from /sys/class/drm/<card>/device/ualink/.
  * Returns 0 on success, ENODEV if no ualink directory exists for that device,
  * EINVAL on bad arguments. */
-int ARSMI_get_fabric_info(uint32_t dv_ind, struct ARSMI_fabricInfo *info);
+int ARSMI_get_fabric_info(uint32_t dv_ind, struct ARSMI_fabricInfo* info);
 
 const char* ARSMI_fabric_telem_id_to_string(uint64_t telem_id);
 

--- a/projects/rccl/src/include/amdsmi_wrap.h
+++ b/projects/rccl/src/include/amdsmi_wrap.h
@@ -24,18 +24,18 @@
  ************************************************************************/
 
 #if __has_include(<amd_smi/amdsmi.h>)
-  #define AMDSMI_DIRECT 1
-  #include <amd_smi/amdsmi.h>
+#define AMDSMI_DIRECT 1
+#include <amd_smi/amdsmi.h>
 #else
-  #define AMDSMI_DIRECT 0
+#define AMDSMI_DIRECT 0
   // amdsmi.h not in include path: fabric API cannot be used directly either,
   // regardless of what the CMake probe detected.
-  #undef AMDSMI_FABRIC_DIRECT
-  #define AMDSMI_FABRIC_DIRECT 0
+#undef AMDSMI_FABRIC_DIRECT
+#define AMDSMI_FABRIC_DIRECT 0
 #endif
 
 #ifndef AMDSMI_FABRIC_DIRECT
-  #define AMDSMI_FABRIC_DIRECT 0
+#define AMDSMI_FABRIC_DIRECT 0
 #endif
 
 #if !AMDSMI_DIRECT
@@ -43,253 +43,241 @@
  * Pre-UALoE AMDSMI Definitions
  ************************************************************************/
 typedef enum {
-    AMDSMI_FW_ID_SMU = 1,                   /**< System Management Unit (power management,
-                                                 clock control, thermal monitoring, etc...) */
-    AMDSMI_FW_ID_FIRST = AMDSMI_FW_ID_SMU,
-    AMDSMI_FW_ID_CP_CE,                     //!< Compute Processor - Command_Engine (fetch, decode, dispatch)
-    AMDSMI_FW_ID_CP_PFP,                    //!< Compute Processor - Pixel Front End Processor (pixelating process)
-    AMDSMI_FW_ID_CP_ME,                     //!< Compute Processor - Micro Engine (specialize processing)
-    AMDSMI_FW_ID_CP_MEC_JT1,                //!< Compute Processor - Micro Engine Controler Job Table 1 (queues, scheduling)
-    AMDSMI_FW_ID_CP_MEC_JT2,                //!< Compute Processor - Micro Engine Controler Job Table 2 (queues, scheduling)
-    AMDSMI_FW_ID_CP_MEC1,                   //!< Compute Processor - Micro Engine Controler 1 (scheduling, managing resources)
-    AMDSMI_FW_ID_CP_MEC2,                   //!< Compute Processor - Micro Engine Controler 2 (scheduling, managing resources)
-    AMDSMI_FW_ID_RLC,                       //!< Rasterizer and L2 Cache (rasterization processs)
-    AMDSMI_FW_ID_SDMA0,                     //!< System Direct Memory Access 0 (high speed data transfers)
-    AMDSMI_FW_ID_SDMA1,                     //!< System Direct Memory Access 1 (high speed data transfers)
-    AMDSMI_FW_ID_SDMA2,                     //!< System Direct Memory Access 2 (high speed data transfers)
-    AMDSMI_FW_ID_SDMA3,                     //!< System Direct Memory Access 3 (high speed data transfers)
-    AMDSMI_FW_ID_SDMA4,                     //!< System Direct Memory Access 4 (high speed data transfers)
-    AMDSMI_FW_ID_SDMA5,                     //!< System Direct Memory Access 5 (high speed data transfers)
-    AMDSMI_FW_ID_SDMA6,                     //!< System Direct Memory Access 6 (high speed data transfers)
-    AMDSMI_FW_ID_SDMA7,                     //!< System Direct Memory Access 7 (high speed data transfers)
-    AMDSMI_FW_ID_VCN,                       //!< Video Core Next (encoding and decoding)
-    AMDSMI_FW_ID_UVD,                       //!< Unified Video Decoder (decode specific video formats)
-    AMDSMI_FW_ID_VCE,                       //!< Video Coding Engine (Encoding video)
-    AMDSMI_FW_ID_ISP,                       //!< Image Signal Processor (processing raw image data from sensors)
-    AMDSMI_FW_ID_DMCU_ERAM,                 //!< Digital Micro Controller Unit - Embedded RAM (memory used by DMU)
-    AMDSMI_FW_ID_DMCU_ISR,                  //!< Digital Micro Controller Unit - Interrupt Service Routine (interrupt handlers)
-    AMDSMI_FW_ID_RLC_RESTORE_LIST_GPM_MEM,  //!< Rasterizier and L2 Cache Restore List Graphics Processor Memory
-    AMDSMI_FW_ID_RLC_RESTORE_LIST_SRM_MEM,  //!< Rasterizier and L2 Cache Restore List System RAM Memory
-    AMDSMI_FW_ID_RLC_RESTORE_LIST_CNTL,     //!< Rasterizier and L2 Cache Restore List Control
-    AMDSMI_FW_ID_RLC_V,                     //!< Rasterizier and L2 Cache Virtual memory
-    AMDSMI_FW_ID_MMSCH,                     //!< Multi-Media Shader Hardware Scheduler
-    AMDSMI_FW_ID_PSP_SYSDRV,                //!< Platform Security Processor System Driver
-    AMDSMI_FW_ID_PSP_SOSDRV,                //!< Platform Security Processor Secure Operating System Driver
-    AMDSMI_FW_ID_PSP_TOC,                   //!< Platform Security Processor Table of Contents
-    AMDSMI_FW_ID_PSP_KEYDB,                 //!< Platform Security Processor Table of Contents
-    AMDSMI_FW_ID_DFC,                       //!< Data Fabric Controler (bandwidth and coherency)
-    AMDSMI_FW_ID_PSP_SPL,                   //!< Platform Security Processor Secure Program Loader
-    AMDSMI_FW_ID_DRV_CAP,                   //!< Driver Capabilities (capabilities, features)
-    AMDSMI_FW_ID_MC,                        //!< Memory Contoller (RAM and VRAM)
-    AMDSMI_FW_ID_PSP_BL,                    //!< Platform Security Processor Bootloader (initial firmware)
-    AMDSMI_FW_ID_CP_PM4,                    //!< Compute Processor Packet Processor 4 (processing command packets)
-    AMDSMI_FW_ID_RLC_P,                     //!< Rasterizier and L2 Cache Partition
-    AMDSMI_FW_ID_SEC_POLICY_STAGE2,         //!< Security Policy Stage 2 (security features)
-    AMDSMI_FW_ID_REG_ACCESS_WHITELIST,      //!< Register Access Whitelist (Prevent unathorizied access)
-    AMDSMI_FW_ID_IMU_DRAM,                  //!< Input/Output Memory Management Unit - Dynamic RAM
-    AMDSMI_FW_ID_IMU_IRAM,                  //!< Input/Output Memory Management Unit - Instruction RAM
-    AMDSMI_FW_ID_SDMA_TH0,                  //!< System Direct Memory Access - Thread Handler 0
-    AMDSMI_FW_ID_SDMA_TH1,                  //!< System Direct Memory Access - Thread Handler 1
-    AMDSMI_FW_ID_CP_MES,                    //!< Compute Processor - Micro Engine Scheduler
-    AMDSMI_FW_ID_MES_KIQ,                   //!< Micro Engine Scheduler - Kernel Indirect Queue
-    AMDSMI_FW_ID_MES_STACK,                 //!< Micro Engine Scheduler - Stack
-    AMDSMI_FW_ID_MES_THREAD1,               //!< Micro Engine Scheduler - Thread 1
-    AMDSMI_FW_ID_MES_THREAD1_STACK,         //!< Micro Engine Scheduler - Thread 1 Stack
-    AMDSMI_FW_ID_RLX6,                      //!< Hardware Block RLX6
-    AMDSMI_FW_ID_RLX6_DRAM_BOOT,            //!< Hardware Block RLX6 - Dynamic Ram Boot
-    AMDSMI_FW_ID_RS64_ME,                   //!< Hardware Block RS64 - Micro Engine
-    AMDSMI_FW_ID_RS64_ME_P0_DATA,           //!< Hardware Block RS64 - Micro Engine Partition 0 Data
-    AMDSMI_FW_ID_RS64_ME_P1_DATA,           //!< Hardware Block RS64 - Micro Engine Partition 1 Data
-    AMDSMI_FW_ID_RS64_PFP,                  //!< Hardware Block RS64 - Pixel Front End Processor
-    AMDSMI_FW_ID_RS64_PFP_P0_DATA,          //!< Hardware Block RS64 - Pixel Front End Processor Partition 0 Data
-    AMDSMI_FW_ID_RS64_PFP_P1_DATA,          //!< Hardware Block RS64 - Pixel Front End Processor Partition 1 Data
-    AMDSMI_FW_ID_RS64_MEC,                  //!< Hardware Block RS64 - Micro Engine Controller
-    AMDSMI_FW_ID_RS64_MEC_P0_DATA,          //!< Hardware Block RS64 - Micro Engine Controller Partition 0 Data
-    AMDSMI_FW_ID_RS64_MEC_P1_DATA,          //!< Hardware Block RS64 - Micro Engine Controller Partition 1 Data
-    AMDSMI_FW_ID_RS64_MEC_P2_DATA,          //!< Hardware Block RS64 - Micro Engine Controller Partition 2 Data
-    AMDSMI_FW_ID_RS64_MEC_P3_DATA,          //!< Hardware Block RS64 - Micro Engine Controller Partition 3 Data
-    AMDSMI_FW_ID_PPTABLE,                   //!< Power Policy Table (power management policies)
-    AMDSMI_FW_ID_PSP_SOC,                   //!< Platform Security Processor - System On a Chip
-    AMDSMI_FW_ID_PSP_DBG,                   //!< Platform Security Processor - Debug
-    AMDSMI_FW_ID_PSP_INTF,                  //!< Platform Security Processor - Interface
-    AMDSMI_FW_ID_RLX6_CORE1,                //!< Hardware Block RLX6 - Core 1
-    AMDSMI_FW_ID_RLX6_DRAM_BOOT_CORE1,      //!< Hardware Block RLX6 Core 1 - Dynamic RAM Boot
-    AMDSMI_FW_ID_RLCV_LX7,                  //!< Hardware Block RLCV - Subsystem LX7
-    AMDSMI_FW_ID_RLC_SAVE_RESTORE_LIST,     //!< Rasterizier and L2 Cache - Save Restore List
-    AMDSMI_FW_ID_ASD,                       //!< Asynchronous Shader Dispatcher
-    AMDSMI_FW_ID_TA_RAS,                    //!< Trusted Applications - Reliablity Availability and Serviceability
-    AMDSMI_FW_ID_TA_XGMI,                   //!< Trusted Applications - Reliablity XGMI
-    AMDSMI_FW_ID_RLC_SRLG,                  //!< Rasterizier and L2 Cache - Shared Resource Local Group
-    AMDSMI_FW_ID_RLC_SRLS,                  //!< Rasterizier and L2 Cache - Shared Resource Local Segment
-    AMDSMI_FW_ID_PM,                        //!< Power Management Firmware
-    AMDSMI_FW_ID_DMCU,                      //!< Display Micro-Controller Unit
-    AMDSMI_FW_ID_PLDM_BUNDLE,               //!< Platform Level Data Model Firmware Bundle
-    AMDSMI_FW_ID__MAX
+  AMDSMI_FW_ID_SMU = 1,                   /**< System Management Unit (power management,
+clock control, thermal monitoring, etc...) */
+  AMDSMI_FW_ID_FIRST = AMDSMI_FW_ID_SMU,
+  AMDSMI_FW_ID_CP_CE,                     //!< Compute Processor - Command_Engine (fetch, decode, dispatch)
+  AMDSMI_FW_ID_CP_PFP,                    //!< Compute Processor - Pixel Front End Processor (pixelating process)
+  AMDSMI_FW_ID_CP_ME,                     //!< Compute Processor - Micro Engine (specialize processing)
+  AMDSMI_FW_ID_CP_MEC_JT1, //!< Compute Processor - Micro Engine Controler Job Table 1 (queues, scheduling)
+  AMDSMI_FW_ID_CP_MEC_JT2, //!< Compute Processor - Micro Engine Controler Job Table 2 (queues, scheduling)
+  AMDSMI_FW_ID_CP_MEC1, //!< Compute Processor - Micro Engine Controler 1 (scheduling, managing resources)
+  AMDSMI_FW_ID_CP_MEC2, //!< Compute Processor - Micro Engine Controler 2 (scheduling, managing resources)
+  AMDSMI_FW_ID_RLC, //!< Rasterizer and L2 Cache (rasterization processs)
+  AMDSMI_FW_ID_SDMA0, //!< System Direct Memory Access 0 (high speed data transfers)
+  AMDSMI_FW_ID_SDMA1, //!< System Direct Memory Access 1 (high speed data transfers)
+  AMDSMI_FW_ID_SDMA2, //!< System Direct Memory Access 2 (high speed data transfers)
+  AMDSMI_FW_ID_SDMA3, //!< System Direct Memory Access 3 (high speed data transfers)
+  AMDSMI_FW_ID_SDMA4, //!< System Direct Memory Access 4 (high speed data transfers)
+  AMDSMI_FW_ID_SDMA5, //!< System Direct Memory Access 5 (high speed data transfers)
+  AMDSMI_FW_ID_SDMA6, //!< System Direct Memory Access 6 (high speed data transfers)
+  AMDSMI_FW_ID_SDMA7, //!< System Direct Memory Access 7 (high speed data transfers)
+  AMDSMI_FW_ID_VCN, //!< Video Core Next (encoding and decoding)
+  AMDSMI_FW_ID_UVD, //!< Unified Video Decoder (decode specific video formats)
+  AMDSMI_FW_ID_VCE, //!< Video Coding Engine (Encoding video)
+  AMDSMI_FW_ID_ISP, //!< Image Signal Processor (processing raw image data from sensors)
+  AMDSMI_FW_ID_DMCU_ERAM, //!< Digital Micro Controller Unit - Embedded RAM (memory used by DMU)
+  AMDSMI_FW_ID_DMCU_ISR, //!< Digital Micro Controller Unit - Interrupt Service Routine (interrupt handlers)
+  AMDSMI_FW_ID_RLC_RESTORE_LIST_GPM_MEM, //!< Rasterizier and L2 Cache Restore List Graphics Processor Memory
+  AMDSMI_FW_ID_RLC_RESTORE_LIST_SRM_MEM, //!< Rasterizier and L2 Cache Restore List System RAM Memory
+  AMDSMI_FW_ID_RLC_RESTORE_LIST_CNTL, //!< Rasterizier and L2 Cache Restore List Control
+  AMDSMI_FW_ID_RLC_V, //!< Rasterizier and L2 Cache Virtual memory
+  AMDSMI_FW_ID_MMSCH, //!< Multi-Media Shader Hardware Scheduler
+  AMDSMI_FW_ID_PSP_SYSDRV, //!< Platform Security Processor System Driver
+  AMDSMI_FW_ID_PSP_SOSDRV, //!< Platform Security Processor Secure Operating System Driver
+  AMDSMI_FW_ID_PSP_TOC, //!< Platform Security Processor Table of Contents
+  AMDSMI_FW_ID_PSP_KEYDB, //!< Platform Security Processor Table of Contents
+  AMDSMI_FW_ID_DFC, //!< Data Fabric Controler (bandwidth and coherency)
+  AMDSMI_FW_ID_PSP_SPL, //!< Platform Security Processor Secure Program Loader
+  AMDSMI_FW_ID_DRV_CAP, //!< Driver Capabilities (capabilities, features)
+  AMDSMI_FW_ID_MC, //!< Memory Contoller (RAM and VRAM)
+  AMDSMI_FW_ID_PSP_BL, //!< Platform Security Processor Bootloader (initial firmware)
+  AMDSMI_FW_ID_CP_PM4, //!< Compute Processor Packet Processor 4 (processing command packets)
+  AMDSMI_FW_ID_RLC_P, //!< Rasterizier and L2 Cache Partition
+  AMDSMI_FW_ID_SEC_POLICY_STAGE2, //!< Security Policy Stage 2 (security features)
+  AMDSMI_FW_ID_REG_ACCESS_WHITELIST, //!< Register Access Whitelist (Prevent unathorizied access)
+  AMDSMI_FW_ID_IMU_DRAM, //!< Input/Output Memory Management Unit - Dynamic RAM
+  AMDSMI_FW_ID_IMU_IRAM, //!< Input/Output Memory Management Unit - Instruction RAM
+  AMDSMI_FW_ID_SDMA_TH0, //!< System Direct Memory Access - Thread Handler 0
+  AMDSMI_FW_ID_SDMA_TH1, //!< System Direct Memory Access - Thread Handler 1
+  AMDSMI_FW_ID_CP_MES, //!< Compute Processor - Micro Engine Scheduler
+  AMDSMI_FW_ID_MES_KIQ, //!< Micro Engine Scheduler - Kernel Indirect Queue
+  AMDSMI_FW_ID_MES_STACK, //!< Micro Engine Scheduler - Stack
+  AMDSMI_FW_ID_MES_THREAD1, //!< Micro Engine Scheduler - Thread 1
+  AMDSMI_FW_ID_MES_THREAD1_STACK, //!< Micro Engine Scheduler - Thread 1 Stack
+  AMDSMI_FW_ID_RLX6, //!< Hardware Block RLX6
+  AMDSMI_FW_ID_RLX6_DRAM_BOOT, //!< Hardware Block RLX6 - Dynamic Ram Boot
+  AMDSMI_FW_ID_RS64_ME, //!< Hardware Block RS64 - Micro Engine
+  AMDSMI_FW_ID_RS64_ME_P0_DATA, //!< Hardware Block RS64 - Micro Engine Partition 0 Data
+  AMDSMI_FW_ID_RS64_ME_P1_DATA, //!< Hardware Block RS64 - Micro Engine Partition 1 Data
+  AMDSMI_FW_ID_RS64_PFP, //!< Hardware Block RS64 - Pixel Front End Processor
+  AMDSMI_FW_ID_RS64_PFP_P0_DATA, //!< Hardware Block RS64 - Pixel Front End Processor Partition 0 Data
+  AMDSMI_FW_ID_RS64_PFP_P1_DATA, //!< Hardware Block RS64 - Pixel Front End Processor Partition 1 Data
+  AMDSMI_FW_ID_RS64_MEC, //!< Hardware Block RS64 - Micro Engine Controller
+  AMDSMI_FW_ID_RS64_MEC_P0_DATA, //!< Hardware Block RS64 - Micro Engine Controller Partition 0 Data
+  AMDSMI_FW_ID_RS64_MEC_P1_DATA, //!< Hardware Block RS64 - Micro Engine Controller Partition 1 Data
+  AMDSMI_FW_ID_RS64_MEC_P2_DATA, //!< Hardware Block RS64 - Micro Engine Controller Partition 2 Data
+  AMDSMI_FW_ID_RS64_MEC_P3_DATA, //!< Hardware Block RS64 - Micro Engine Controller Partition 3 Data
+  AMDSMI_FW_ID_PPTABLE, //!< Power Policy Table (power management policies)
+  AMDSMI_FW_ID_PSP_SOC, //!< Platform Security Processor - System On a Chip
+  AMDSMI_FW_ID_PSP_DBG, //!< Platform Security Processor - Debug
+  AMDSMI_FW_ID_PSP_INTF, //!< Platform Security Processor - Interface
+  AMDSMI_FW_ID_RLX6_CORE1, //!< Hardware Block RLX6 - Core 1
+  AMDSMI_FW_ID_RLX6_DRAM_BOOT_CORE1, //!< Hardware Block RLX6 Core 1 - Dynamic RAM Boot
+  AMDSMI_FW_ID_RLCV_LX7, //!< Hardware Block RLCV - Subsystem LX7
+  AMDSMI_FW_ID_RLC_SAVE_RESTORE_LIST, //!< Rasterizier and L2 Cache - Save Restore List
+  AMDSMI_FW_ID_ASD, //!< Asynchronous Shader Dispatcher
+  AMDSMI_FW_ID_TA_RAS, //!< Trusted Applications - Reliablity Availability and Serviceability
+  AMDSMI_FW_ID_TA_XGMI, //!< Trusted Applications - Reliablity XGMI
+  AMDSMI_FW_ID_RLC_SRLG, //!< Rasterizier and L2 Cache - Shared Resource Local Group
+  AMDSMI_FW_ID_RLC_SRLS, //!< Rasterizier and L2 Cache - Shared Resource Local Segment
+  AMDSMI_FW_ID_PM, //!< Power Management Firmware
+  AMDSMI_FW_ID_DMCU, //!< Display Micro-Controller Unit
+  AMDSMI_FW_ID_PLDM_BUNDLE, //!< Platform Level Data Model Firmware Bundle
+  AMDSMI_FW_ID__MAX
 } amdsmi_fw_block_t;
 
 typedef union {
-    struct bdf_ {
-        uint64_t function_number : 3;
-        uint64_t device_number : 5;
-        uint64_t bus_number : 8;
-        uint64_t domain_number : 48;
-    } bdf;
-    struct {
-        uint64_t function_number : 3;
-        uint64_t device_number : 5;
-        uint64_t bus_number : 8;
-        uint64_t domain_number : 48;
-    };
-    uint64_t as_uint;
+  struct bdf_ {
+    uint64_t function_number:3;
+    uint64_t device_number:5;
+    uint64_t bus_number:8;
+    uint64_t domain_number:48;
+  } bdf;
+  struct {
+    uint64_t function_number:3;
+    uint64_t device_number:5;
+    uint64_t bus_number:8;
+    uint64_t domain_number:48;
+  };
+  uint64_t as_uint;
 } amdsmi_bdf_t;
 
 typedef struct {
-    uint8_t num_fw_info;
-    struct fw_info_list_ {
-        amdsmi_fw_block_t fw_id;
-        uint64_t fw_version;
-        uint64_t reserved[2];
-    } fw_info_list[AMDSMI_FW_ID__MAX];
-    uint32_t reserved[7];
+  uint8_t num_fw_info;
+  struct fw_info_list_ {
+    amdsmi_fw_block_t fw_id;
+    uint64_t fw_version;
+    uint64_t reserved[2];
+  } fw_info_list[AMDSMI_FW_ID__MAX];
+  uint32_t reserved[7];
 } amdsmi_fw_info_t;
 
 typedef enum {
-    AMDSMI_STATUS_SUCCESS = 0,              //!< Call succeeded
-    // Library usage errors
-    AMDSMI_STATUS_INVAL = 1,                //!< Invalid parameters
-    AMDSMI_STATUS_NOT_SUPPORTED = 2,        //!< Command not supported
-    AMDSMI_STATUS_NOT_YET_IMPLEMENTED = 3,  //!< Not implemented yet
-    AMDSMI_STATUS_FAIL_LOAD_MODULE = 4,     //!< Fail to load lib
-    AMDSMI_STATUS_FAIL_LOAD_SYMBOL = 5,     //!< Fail to load symbol
-    AMDSMI_STATUS_DRM_ERROR = 6,            //!< Error when call libdrm
-    AMDSMI_STATUS_API_FAILED = 7,           //!< API call failed
-    AMDSMI_STATUS_TIMEOUT = 8,              //!< Timeout in API call
-    AMDSMI_STATUS_RETRY = 9,                //!< Retry operation
-    AMDSMI_STATUS_NO_PERM = 10,             //!< Permission Denied
-    AMDSMI_STATUS_INTERRUPT = 11,           //!< An interrupt occurred during execution of function
-    AMDSMI_STATUS_IO = 12,                  //!< I/O Error
-    AMDSMI_STATUS_ADDRESS_FAULT = 13,       //!< Bad address
-    AMDSMI_STATUS_FILE_ERROR = 14,          //!< Problem accessing a file
-    AMDSMI_STATUS_OUT_OF_RESOURCES = 15,    //!< Not enough memory
-    AMDSMI_STATUS_INTERNAL_EXCEPTION = 16,  //!< An internal exception was caught
-    AMDSMI_STATUS_INPUT_OUT_OF_BOUNDS = 17, //!< The provided input is out of allowable or safe range
-    AMDSMI_STATUS_INIT_ERROR = 18,          //!< An error occurred when initializing internal data structures
-    AMDSMI_STATUS_REFCOUNT_OVERFLOW = 19,   //!< An internal reference counter exceeded INT32_MAX
-    AMDSMI_STATUS_DIRECTORY_NOT_FOUND = 20, //!< Error when a directory is not found, maps to ENOTDIR
-    // Processor related errors
-    AMDSMI_STATUS_BUSY = 30,                //!< Processor busy
-    AMDSMI_STATUS_NOT_FOUND = 31,           //!< Processor Not found
-    AMDSMI_STATUS_NOT_INIT = 32,            //!< Processor not initialized
-    AMDSMI_STATUS_NO_SLOT = 33,             //!< No more free slot
-    AMDSMI_STATUS_DRIVER_NOT_LOADED = 34,   //!< Processor driver not loaded
-    // Data and size errors
-    AMDSMI_STATUS_MORE_DATA = 39,           //!< There is more data than the buffer size the user passed
-    AMDSMI_STATUS_NO_DATA = 40,             //!< No data was found for a given input
-    AMDSMI_STATUS_INSUFFICIENT_SIZE = 41,   //!< Not enough resources were available for the operation
-    AMDSMI_STATUS_UNEXPECTED_SIZE = 42,     //!< An unexpected amount of data was read
-    AMDSMI_STATUS_UNEXPECTED_DATA = 43,     //!< The data read or provided to function is not what was expected
-    //esmi errors
-    AMDSMI_STATUS_NON_AMD_CPU = 44,         //!< System has different cpu than AMD
-    AMDSMI_STATUS_NO_ENERGY_DRV = 45,       //!< Energy driver not found
-    AMDSMI_STATUS_NO_MSR_DRV = 46,          //!< MSR driver not found
-    AMDSMI_STATUS_NO_HSMP_DRV = 47,         //!< HSMP driver not found
-    AMDSMI_STATUS_NO_HSMP_SUP = 48,         //!< HSMP not supported
-    AMDSMI_STATUS_NO_HSMP_MSG_SUP = 49,     //!< HSMP message/feature not supported
-    AMDSMI_STATUS_HSMP_TIMEOUT = 50,        //!< HSMP message timed out
-    AMDSMI_STATUS_NO_DRV = 51,              //!< No Energy and HSMP driver present
-    AMDSMI_STATUS_FILE_NOT_FOUND = 52,      //!< file or directory not found
-    AMDSMI_STATUS_ARG_PTR_NULL = 53,        //!< Parsed argument is invalid
-    AMDSMI_STATUS_AMDGPU_RESTART_ERR = 54,  //!< AMDGPU restart failed
-    AMDSMI_STATUS_SETTING_UNAVAILABLE = 55, //!< Setting is not available
-    AMDSMI_STATUS_CORRUPTED_EEPROM = 56,    //!< EEPROM is corrupted
-    // General errors
-    AMDSMI_STATUS_MAP_ERROR = 0xFFFFFFFE,     //!< The internal library error did not map to a status code
-    AMDSMI_STATUS_UNKNOWN_ERROR = 0xFFFFFFFF  //!< An unknown error occurred
+  AMDSMI_STATUS_SUCCESS = 0, //!< Call succeeded
+  // Library usage errors
+  AMDSMI_STATUS_INVAL = 1, //!< Invalid parameters
+  AMDSMI_STATUS_NOT_SUPPORTED = 2, //!< Command not supported
+  AMDSMI_STATUS_NOT_YET_IMPLEMENTED = 3, //!< Not implemented yet
+  AMDSMI_STATUS_FAIL_LOAD_MODULE = 4, //!< Fail to load lib
+  AMDSMI_STATUS_FAIL_LOAD_SYMBOL = 5, //!< Fail to load symbol
+  AMDSMI_STATUS_DRM_ERROR = 6, //!< Error when call libdrm
+  AMDSMI_STATUS_API_FAILED = 7, //!< API call failed
+  AMDSMI_STATUS_TIMEOUT = 8, //!< Timeout in API call
+  AMDSMI_STATUS_RETRY = 9, //!< Retry operation
+  AMDSMI_STATUS_NO_PERM = 10, //!< Permission Denied
+  AMDSMI_STATUS_INTERRUPT = 11, //!< An interrupt occurred during execution of function
+  AMDSMI_STATUS_IO = 12, //!< I/O Error
+  AMDSMI_STATUS_ADDRESS_FAULT = 13, //!< Bad address
+  AMDSMI_STATUS_FILE_ERROR = 14, //!< Problem accessing a file
+  AMDSMI_STATUS_OUT_OF_RESOURCES = 15, //!< Not enough memory
+  AMDSMI_STATUS_INTERNAL_EXCEPTION = 16, //!< An internal exception was caught
+  AMDSMI_STATUS_INPUT_OUT_OF_BOUNDS = 17, //!< The provided input is out of allowable or safe range
+  AMDSMI_STATUS_INIT_ERROR = 18, //!< An error occurred when initializing internal data structures
+  AMDSMI_STATUS_REFCOUNT_OVERFLOW = 19, //!< An internal reference counter exceeded INT32_MAX
+  AMDSMI_STATUS_DIRECTORY_NOT_FOUND = 20, //!< Error when a directory is not found, maps to ENOTDIR
+  // Processor related errors
+  AMDSMI_STATUS_BUSY = 30, //!< Processor busy
+  AMDSMI_STATUS_NOT_FOUND = 31, //!< Processor Not found
+  AMDSMI_STATUS_NOT_INIT = 32, //!< Processor not initialized
+  AMDSMI_STATUS_NO_SLOT = 33, //!< No more free slot
+  AMDSMI_STATUS_DRIVER_NOT_LOADED = 34, //!< Processor driver not loaded
+  // Data and size errors
+  AMDSMI_STATUS_MORE_DATA = 39, //!< There is more data than the buffer size the user passed
+  AMDSMI_STATUS_NO_DATA = 40, //!< No data was found for a given input
+  AMDSMI_STATUS_INSUFFICIENT_SIZE = 41, //!< Not enough resources were available for the operation
+  AMDSMI_STATUS_UNEXPECTED_SIZE = 42, //!< An unexpected amount of data was read
+  AMDSMI_STATUS_UNEXPECTED_DATA = 43, //!< The data read or provided to function is not what was expected
+  // esmi errors
+  AMDSMI_STATUS_NON_AMD_CPU = 44, //!< System has different cpu than AMD
+  AMDSMI_STATUS_NO_ENERGY_DRV = 45, //!< Energy driver not found
+  AMDSMI_STATUS_NO_MSR_DRV = 46, //!< MSR driver not found
+  AMDSMI_STATUS_NO_HSMP_DRV = 47, //!< HSMP driver not found
+  AMDSMI_STATUS_NO_HSMP_SUP = 48, //!< HSMP not supported
+  AMDSMI_STATUS_NO_HSMP_MSG_SUP = 49, //!< HSMP message/feature not supported
+  AMDSMI_STATUS_HSMP_TIMEOUT = 50, //!< HSMP message timed out
+  AMDSMI_STATUS_NO_DRV = 51, //!< No Energy and HSMP driver present
+  AMDSMI_STATUS_FILE_NOT_FOUND = 52, //!< file or directory not found
+  AMDSMI_STATUS_ARG_PTR_NULL = 53, //!< Parsed argument is invalid
+  AMDSMI_STATUS_AMDGPU_RESTART_ERR = 54, //!< AMDGPU restart failed
+  AMDSMI_STATUS_SETTING_UNAVAILABLE = 55, //!< Setting is not available
+  AMDSMI_STATUS_CORRUPTED_EEPROM = 56, //!< EEPROM is corrupted
+  // General errors
+  AMDSMI_STATUS_MAP_ERROR = 0xFFFFFFFE, //!< The internal library error did not map to a status code
+  AMDSMI_STATUS_UNKNOWN_ERROR = 0xFFFFFFFF //!< An unknown error occurred
 } amdsmi_status_t;
 
-#define AMDSMI_MAX_STRING_LENGTH          256  //!< Maximum length for string buffers
+#define AMDSMI_MAX_STRING_LENGTH 256 //!< Maximum length for string buffers
 
-typedef void *amdsmi_processor_handle;
-typedef void *amdsmi_socket_handle;
+typedef void* amdsmi_processor_handle;
+typedef void* amdsmi_socket_handle;
 typedef struct {
-    uint32_t drm_render; //!< the render node under /sys/class/drm/renderD*
-    uint32_t drm_card;   //!< the graphic card device under /sys/class/drm/card*
-    uint32_t hsa_id;     //!< the HSA enumeration ID
-    uint32_t hip_id;     //!< the HIP enumeration ID
-    char hip_uuid[AMDSMI_MAX_STRING_LENGTH];  //!< the HIP unique identifer
+  uint32_t drm_render; //!< the render node under /sys/class/drm/renderD*
+  uint32_t drm_card; //!< the graphic card device under /sys/class/drm/card*
+  uint32_t hsa_id; //!< the HSA enumeration ID
+  uint32_t hip_id; //!< the HIP enumeration ID
+  char hip_uuid[AMDSMI_MAX_STRING_LENGTH]; //!< the HIP unique identifer
 } amdsmi_enumeration_info_t;
 
 typedef enum {
-    AMDSMI_PROCESSOR_TYPE_UNKNOWN = 0,   //!< Unknown processor type
-    AMDSMI_PROCESSOR_TYPE_AMD_GPU,       //!< AMD Graphics processor type
-    AMDSMI_PROCESSOR_TYPE_AMD_CPU,       //!< AMD CPU processor type, a physical component that holds the CPU
-    AMDSMI_PROCESSOR_TYPE_NON_AMD_GPU,   //!< Non-AMD Graphics processor type
-    AMDSMI_PROCESSOR_TYPE_NON_AMD_CPU,   //!< Non-AMD CPU processor type
-    AMDSMI_PROCESSOR_TYPE_AMD_CPU_CORE,  //!< AMD CPU-Core processor type, individual processing units within the CPU
-    AMDSMI_PROCESSOR_TYPE_AMD_APU,       //!< AMD Accelerated processor type, GPU and CPU on a single die
-    AMDSMI_PROCESSOR_TYPE_AMD_NIC        //!< AMD Network Interface Card processor type
+  AMDSMI_PROCESSOR_TYPE_UNKNOWN = 0, //!< Unknown processor type
+  AMDSMI_PROCESSOR_TYPE_AMD_GPU, //!< AMD Graphics processor type
+  AMDSMI_PROCESSOR_TYPE_AMD_CPU, //!< AMD CPU processor type, a physical component that holds the CPU
+  AMDSMI_PROCESSOR_TYPE_NON_AMD_GPU, //!< Non-AMD Graphics processor type
+  AMDSMI_PROCESSOR_TYPE_NON_AMD_CPU, //!< Non-AMD CPU processor type
+  AMDSMI_PROCESSOR_TYPE_AMD_CPU_CORE, //!< AMD CPU-Core processor type, individual processing units within the CPU
+  AMDSMI_PROCESSOR_TYPE_AMD_APU, //!< AMD Accelerated processor type, GPU and CPU on a single die
+  AMDSMI_PROCESSOR_TYPE_AMD_NIC //!< AMD Network Interface Card processor type
 } processor_type_t;
 
 typedef enum {
-    AMDSMI_LINK_TYPE_INTERNAL = 0,        //!< Internal Link Type, within chip
-    AMDSMI_LINK_TYPE_PCIE = 1,            //!< Peripheral Component Interconnect Express Link Type
-    AMDSMI_LINK_TYPE_XGMI = 2,            //!< GPU Memory Interconnect (multi GPU communication)
-    AMDSMI_LINK_TYPE_NOT_APPLICABLE = 3,  //!< Not Applicable Link Type
-    AMDSMI_LINK_TYPE_UNKNOWN = 4          //!< Unknown Link Type
+  AMDSMI_LINK_TYPE_INTERNAL = 0, //!< Internal Link Type, within chip
+  AMDSMI_LINK_TYPE_PCIE = 1, //!< Peripheral Component Interconnect Express Link Type
+  AMDSMI_LINK_TYPE_XGMI = 2, //!< GPU Memory Interconnect (multi GPU communication)
+  AMDSMI_LINK_TYPE_NOT_APPLICABLE = 3, //!< Not Applicable Link Type
+  AMDSMI_LINK_TYPE_UNKNOWN = 4 //!< Unknown Link Type
 } amdsmi_link_type_t;
 
 typedef struct {
-    uint32_t major;     //!< Major version
-    uint32_t minor;     //!< Minor version
-    uint32_t release;   //!< Patch, build or stepping version
-    const char *build;  //!< Full Build version string
+  uint32_t major; //!< Major version
+  uint32_t minor; //!< Minor version
+  uint32_t release; //!< Patch, build or stepping version
+  const char* build; //!< Full Build version string
 } amdsmi_version_t;
 
 typedef enum {
-    AMDSMI_INIT_ALL_PROCESSORS = 0xFFFFFFFF,  //!< Initialize all processors
-    AMDSMI_INIT_AMD_CPUS       = (1 << 0),    //!< Initialize AMD CPUS
-    AMDSMI_INIT_AMD_GPUS       = (1 << 1),    //!< Initialize AMD GPUS
-    AMDSMI_INIT_NON_AMD_CPUS   = (1 << 2),    //!< Initialize Non-AMD CPUS
-    AMDSMI_INIT_NON_AMD_GPUS   = (1 << 3),    //!< Initialize Non-AMD GPUS
-    AMDSMI_INIT_AMD_APUS       = (AMDSMI_INIT_AMD_CPUS | AMDSMI_INIT_AMD_GPUS),
-                                              //!< Initialize AMD CPUS and GPUS (Default option)
-    AMDSMI_INIT_AMD_NICS       = (1 << 4)     //!< Initialize NICs
+  AMDSMI_INIT_ALL_PROCESSORS = 0xFFFFFFFF, //!< Initialize all processors
+  AMDSMI_INIT_AMD_CPUS = (1 << 0), //!< Initialize AMD CPUS
+  AMDSMI_INIT_AMD_GPUS = (1 << 1), //!< Initialize AMD GPUS
+  AMDSMI_INIT_NON_AMD_CPUS = (1 << 2), //!< Initialize Non-AMD CPUS
+  AMDSMI_INIT_NON_AMD_GPUS = (1 << 3), //!< Initialize Non-AMD GPUS
+  AMDSMI_INIT_AMD_APUS = (AMDSMI_INIT_AMD_CPUS | AMDSMI_INIT_AMD_GPUS),
+  //!< Initialize AMD CPUS and GPUS (Default option)
+  AMDSMI_INIT_AMD_NICS = (1 << 4) //!< Initialize NICs
 } amdsmi_init_flags_t;
 
-amdsmi_status_t
-amdsmi_init(uint64_t init_flags);
-amdsmi_status_t
-amdsmi_status_code_to_string(amdsmi_status_t status, const char **status_string);
-amdsmi_status_t
-amdsmi_get_socket_handles(uint32_t *socket_count, amdsmi_socket_handle* socket_handles);
-amdsmi_status_t
-amdsmi_get_processor_handles(amdsmi_socket_handle socket_handle,
-                                    uint32_t *processor_count,
-                                    amdsmi_processor_handle* processor_handles);
-amdsmi_status_t
-amdsmi_get_processor_type(amdsmi_processor_handle processor_handle, processor_type_t* processor_type);
+amdsmi_status_t amdsmi_init(uint64_t init_flags);
+amdsmi_status_t amdsmi_status_code_to_string(amdsmi_status_t status, const char** status_string);
+amdsmi_status_t amdsmi_get_socket_handles(uint32_t* socket_count, amdsmi_socket_handle* socket_handles);
+amdsmi_status_t amdsmi_get_processor_handles(amdsmi_socket_handle socket_handle, uint32_t* processor_count,
+                                             amdsmi_processor_handle* processor_handles);
+amdsmi_status_t amdsmi_get_processor_type(amdsmi_processor_handle processor_handle, processor_type_t* processor_type);
 
-amdsmi_status_t
-amdsmi_get_gpu_enumeration_info(amdsmi_processor_handle processor_handle, amdsmi_enumeration_info_t *info);
+amdsmi_status_t amdsmi_get_gpu_enumeration_info(amdsmi_processor_handle processor_handle,
+                                                amdsmi_enumeration_info_t* info);
 
-amdsmi_status_t
-amdsmi_get_gpu_bdf_id(amdsmi_processor_handle processor_handle, uint64_t *bdfid);
+amdsmi_status_t amdsmi_get_gpu_bdf_id(amdsmi_processor_handle processor_handle, uint64_t* bdfid);
 
-amdsmi_status_t
-amdsmi_get_processor_handle_from_bdf(amdsmi_bdf_t bdf, amdsmi_processor_handle* processor_handle);
+amdsmi_status_t amdsmi_get_processor_handle_from_bdf(amdsmi_bdf_t bdf, amdsmi_processor_handle* processor_handle);
 
-amdsmi_status_t
-amdsmi_topo_get_link_type(amdsmi_processor_handle processor_handle_src,
-                          amdsmi_processor_handle processor_handle_dst,
-                          uint64_t *hops, amdsmi_link_type_t *type);
-amdsmi_status_t
-amdsmi_topo_get_link_weight(amdsmi_processor_handle processor_handle_src, amdsmi_processor_handle processor_handle_dst,
-                            uint64_t *weight);
-amdsmi_status_t
-amdsmi_get_minmax_bandwidth_between_processors(amdsmi_processor_handle processor_handle_src,
-                                                amdsmi_processor_handle processor_handle_dst,
-                                                uint64_t *min_bandwidth,
-                                                uint64_t *max_bandwidth);
+amdsmi_status_t amdsmi_topo_get_link_type(amdsmi_processor_handle processor_handle_src,
+                                          amdsmi_processor_handle processor_handle_dst, uint64_t* hops,
+                                          amdsmi_link_type_t* type);
+amdsmi_status_t amdsmi_topo_get_link_weight(amdsmi_processor_handle processor_handle_src,
+                                            amdsmi_processor_handle processor_handle_dst, uint64_t* weight);
+amdsmi_status_t amdsmi_get_minmax_bandwidth_between_processors(amdsmi_processor_handle processor_handle_src,
+                                                               amdsmi_processor_handle processor_handle_dst,
+                                                               uint64_t* min_bandwidth, uint64_t* max_bandwidth);
 
 #endif // !AMDSMI_DIRECT
 
@@ -305,63 +293,63 @@ amdsmi_get_minmax_bandwidth_between_processors(amdsmi_processor_handle processor
  * @brief Fabric telemetry categories
  */
 typedef enum {
-    AMDSMI_FABRIC_TELEMETRY_CATEGORY_UNKNOWN         = 0xFFFFFFFF,
-    AMDSMI_FABRIC_TELEMETRY_CATEGORY_UALOE           = 0, //!< UALOE telemetry
-    AMDSMI_FABRIC_TELEMETRY_CATEGORY_SWITCH          = 1, //!< Switch telemetry
-    AMDSMI_FABRIC_TELEMETRY_CATEGORY_CRYPTO          = 2, //!< Crypto telemetry
-    AMDSMI_FABRIC_TELEMETRY_CATEGORY_PFC             = 3, //!< PFC telemetry
-    AMDSMI_FABRIC_TELEMETRY_CATEGORY_NETPORT         = 4, //!< Network Port telemetry
-    AMDSMI_FABRIC_TELEMETRY_CATEGORY_DERIVED_UALOE   = 5, //!< Derived UALOE telemetry
-    AMDSMI_FABRIC_TELEMETRY_CATEGORY_DERIVED_NETPORT = 6, //!< Derived Network Port telemetry
-    AMDSMI_FABRIC_TELEMETRY_CATEGORY_MAX             = 7  //!< Maximum number of categories
+  AMDSMI_FABRIC_TELEMETRY_CATEGORY_UNKNOWN = 0xFFFFFFFF,
+  AMDSMI_FABRIC_TELEMETRY_CATEGORY_UALOE = 0, //!< UALOE telemetry
+  AMDSMI_FABRIC_TELEMETRY_CATEGORY_SWITCH = 1, //!< Switch telemetry
+  AMDSMI_FABRIC_TELEMETRY_CATEGORY_CRYPTO = 2, //!< Crypto telemetry
+  AMDSMI_FABRIC_TELEMETRY_CATEGORY_PFC = 3, //!< PFC telemetry
+  AMDSMI_FABRIC_TELEMETRY_CATEGORY_NETPORT = 4, //!< Network Port telemetry
+  AMDSMI_FABRIC_TELEMETRY_CATEGORY_DERIVED_UALOE = 5, //!< Derived UALOE telemetry
+  AMDSMI_FABRIC_TELEMETRY_CATEGORY_DERIVED_NETPORT = 6, //!< Derived Network Port telemetry
+  AMDSMI_FABRIC_TELEMETRY_CATEGORY_MAX = 7 //!< Maximum number of categories
 } amdsmi_fabric_telemetry_category_t;
 
 /**
  * @brief Fabric telemetry category bitmask constructor
  */
-#define AMDSMI_FABRIC_TELEMETRY_CATEGORY_MASK(cat) (1U << AMDSMI_FABRIC_TELEMETRY_CATEGORY_ ## cat)
+#define AMDSMI_FABRIC_TELEMETRY_CATEGORY_MASK(cat) (1U << AMDSMI_FABRIC_TELEMETRY_CATEGORY_##cat)
 
 /**
  * @brief Fabric telemetry item structure
  */
 typedef struct {
-    uint64_t id;      //!< Identifier of the telemetry item
-    uint64_t value;   //!< Value of the telemetry item
+  uint64_t id; //!< Identifier of the telemetry item
+  uint64_t value; //!< Value of the telemetry item
 } amdsmi_fabric_telemetry_item_t;
 
 /**
  * @brief Fabric textual label structure
  */
 typedef struct {
-    char text[32];  //!< Textual label content
+  char text[32]; //!< Textual label content
 } amdsmi_fabric_label_t;
 
 /**
  * @brief Fabric telemetry instance structure
  */
 typedef struct {
-    amdsmi_fabric_label_t name;               //!< Name for this instance
-    unsigned logical_idx;                     //!< Logical index for this instance
-    unsigned item_count;                      //!< Number of telemetry items in the set
-    amdsmi_fabric_telemetry_item_t *items;    //!< Pointer to array of telemetry items
+  amdsmi_fabric_label_t name; //!< Name for this instance
+  unsigned logical_idx; //!< Logical index for this instance
+  unsigned item_count; //!< Number of telemetry items in the set
+  amdsmi_fabric_telemetry_item_t* items; //!< Pointer to array of telemetry items
 } amdsmi_fabric_telemetry_instance_t;
 
 /**
  * @brief Fabric telemetry dataset structure
  */
 typedef struct {
-    amdsmi_fabric_telemetry_category_t category;  //!< Telemetry category
-    uint64_t generation_count;                    //!< Sequence number incremented each time telemetry is written
-    struct timespec timestamp;                    //!< UTC timestamp seconds since epoch
-    unsigned instance_count;                      //!< Number of instances for this category
-    amdsmi_fabric_telemetry_instance_t *instances;   //!< Pointer to array of telemetry instances
+  amdsmi_fabric_telemetry_category_t category; //!< Telemetry category
+  uint64_t generation_count; //!< Sequence number incremented each time telemetry is written
+  struct timespec timestamp; //!< UTC timestamp seconds since epoch
+  unsigned instance_count; //!< Number of instances for this category
+  amdsmi_fabric_telemetry_instance_t* instances; //!< Pointer to array of telemetry instances
 } amdsmi_fabric_telemetry_dataset_t;
 
 /**
  * @brief Fabric telemetry structure
  */
 typedef struct {
-    amdsmi_fabric_telemetry_dataset_t *datasets[AMDSMI_FABRIC_TELEMETRY_CATEGORY_MAX];
+  amdsmi_fabric_telemetry_dataset_t* datasets[AMDSMI_FABRIC_TELEMETRY_CATEGORY_MAX];
 } amdsmi_fabric_telemetry_t;
 
 #define AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE 32
@@ -371,64 +359,64 @@ typedef struct {
  * @brief Fabric type
  */
 typedef enum {
-    AMDSMI_FABRIC_TYPE_UALOE,
-    AMDSMI_FABRIC_TYPE_UALLINK,
-    AMDSMI_FABRIC_TYPE_UNKNOWN
+  AMDSMI_FABRIC_TYPE_UALOE,
+  AMDSMI_FABRIC_TYPE_UALLINK,
+  AMDSMI_FABRIC_TYPE_UNKNOWN
 } amdsmi_fabric_type_t;
 
 /**
  * @brief Fabric NPA address mode
  */
 typedef enum {
-    AMDSMI_FABRIC_NPA_ADDRESS_MODE_SOURCE_ALIASING,
-    AMDSMI_FABRIC_NPA_ADDRESS_MODE_SOURCE_IDENTIFICATION,
-    AMDSMI_FABRIC_NPA_ADDRESS_MODE_UNKNOWN
+  AMDSMI_FABRIC_NPA_ADDRESS_MODE_SOURCE_ALIASING,
+  AMDSMI_FABRIC_NPA_ADDRESS_MODE_SOURCE_IDENTIFICATION,
+  AMDSMI_FABRIC_NPA_ADDRESS_MODE_UNKNOWN
 } amdsmi_fabric_npa_address_mode_t;
 
 /**
  * @brief Fabric accelerator vPoD state
  */
 typedef enum {
-    AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNCONFIGURED,
-    AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_CONFIGURED,
-    AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_READY,
-    AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_ACTIVE,
-    AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_ERROR,
-    AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNKNOWN
+  AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNCONFIGURED,
+  AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_CONFIGURED,
+  AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_READY,
+  AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_ACTIVE,
+  AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_ERROR,
+  AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNKNOWN
 } amdsmi_fabric_accelerator_vpod_state_t;
 
 /**
  * @brief Fabric device configuration information (version 1)
  */
 typedef struct {
-    uint32_t accelerator_id; //!< Accelerator identifier (range 0 to 1023)
-    amdsmi_fabric_type_t fabric_type; //!< UALOE or UALLINK
-    uint32_t bandwidth; //!< Station bandwidth share in Mb/s
-    uint32_t latency; //!< Latency in nanoseconds
-    uint8_t ppod_id[16]; //!< Physical PoD Identifier (128-bit UUID)
-    uint32_t ppod_size; //!< Physical PoD size
-    uint32_t vpod_id; //!< Virtual PoD Identifier
-    uint32_t vpod_size; //!< Virtual PoD size
-    uint32_t vpod_active_accelerators[AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE];
-    uint32_t local_accelerators[AMDSMI_FABRIC_MAX_LOCAL_GPUS]; //!< Local Accelerator IDs
-    amdsmi_fabric_npa_address_mode_t addr_mode; //!< Source aliasing or identification mode
-    amdsmi_fabric_accelerator_vpod_state_t accel_state; //!< Accelerator vPoD State
+  uint32_t accelerator_id; //!< Accelerator identifier (range 0 to 1023)
+  amdsmi_fabric_type_t fabric_type; //!< UALOE or UALLINK
+  uint32_t bandwidth; //!< Station bandwidth share in Mb/s
+  uint32_t latency; //!< Latency in nanoseconds
+  uint8_t ppod_id[16]; //!< Physical PoD Identifier (128-bit UUID)
+  uint32_t ppod_size; //!< Physical PoD size
+  uint32_t vpod_id; //!< Virtual PoD Identifier
+  uint32_t vpod_size; //!< Virtual PoD size
+  uint32_t vpod_active_accelerators[AMDSMI_FABRIC_ACTIVE_ACCELERATORS_BITMAP_SIZE];
+  uint32_t local_accelerators[AMDSMI_FABRIC_MAX_LOCAL_GPUS]; //!< Local Accelerator IDs
+  amdsmi_fabric_npa_address_mode_t addr_mode; //!< Source aliasing or identification mode
+  amdsmi_fabric_accelerator_vpod_state_t accel_state; //!< Accelerator vPoD State
 } amdsmi_fabric_info_v1_t;
 
 typedef struct {
-    uint32_t version;
-    union fabric_info_ {
-        amdsmi_fabric_info_v1_t v1;
-    } fabric_version;
+  uint32_t version;
+  union fabric_info_ {
+    amdsmi_fabric_info_v1_t v1;
+  } fabric_version;
 } amdsmi_fabric_info_ver_t;
 
 /**
  * @brief Fabric device information structure
  */
 typedef struct {
-    amdsmi_bdf_t bdf;      //!< BDF of the Fabric device
-    amdsmi_fabric_info_ver_t fabric_info;
-    uint32_t reserved[15];
+  amdsmi_bdf_t bdf; //!< BDF of the Fabric device
+  amdsmi_fabric_info_ver_t fabric_info;
+  uint32_t reserved[15];
 } amdsmi_fabric_info_t;
 
 /*************************************************************************
@@ -452,8 +440,7 @@ typedef struct {
  *
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */
-amdsmi_status_t amdsmi_get_gpu_fabric_info(amdsmi_processor_handle processor_handle,
-                                           amdsmi_fabric_info_t* info);
+amdsmi_status_t amdsmi_get_gpu_fabric_info(amdsmi_processor_handle processor_handle, amdsmi_fabric_info_t* info);
 
 /**
  *  @brief Get string name for a telemetry item ID
@@ -489,16 +476,16 @@ const char* amdsmi_fabric_telem_id_to_string(uint64_t telem_id);
 #define AMDSMI_FABRIC_INFO_CURRENT_VERSION AMDSMI_FABRIC_INFO_VERSION_1
 
 struct amdsmiFabricDeviceInfo {
-    bool fabricSupported;                           //!< Whether UALoE fabric is available
-    amdsmi_fabric_type_t fabricType;                //!< Fabric type (UALOE or UALLINK)
-    amdsmi_fabric_accelerator_vpod_state_t state;   //!< Accelerator vPOD state
-    uint32_t acceleratorId;                         //!< Accelerator ID in fabric
-    uint32_t bandwidth;                             //!< Bandwidth in Mb/s
-    uint32_t latency;                               //!< Latency in nanoseconds
-    uint8_t  clusterUuid[16];                       //!< Physical POD ID (128-bit UUID)
-    uint32_t ppodSize;                              //!< Physical POD size
-    uint32_t cliqueId;                              //!< Virtual POD ID
-    uint32_t vpodSize;                              //!< Virtual POD size
+  bool fabricSupported; //!< Whether UALoE fabric is available
+  amdsmi_fabric_type_t fabricType; //!< Fabric type (UALOE or UALLINK)
+  amdsmi_fabric_accelerator_vpod_state_t state; //!< Accelerator vPOD state
+  uint32_t acceleratorId; //!< Accelerator ID in fabric
+  uint32_t bandwidth; //!< Bandwidth in Mb/s
+  uint32_t latency; //!< Latency in nanoseconds
+  uint8_t clusterUuid[16]; //!< Physical POD ID (128-bit UUID)
+  uint32_t ppodSize; //!< Physical POD size
+  uint32_t cliqueId; //!< Virtual POD ID
+  uint32_t vpodSize; //!< Virtual POD size
 };
 
 // Sized to match NCCL_MAX_LOCAL_RANKS so every local GPU can cache fabric info.
@@ -515,7 +502,7 @@ ncclResult_t amd_smi_shutdown();
 ncclResult_t amd_smi_getNumDevice(uint32_t* num_devs);
 ncclResult_t amd_smi_getDevicePciBusIdString(uint32_t deviceIndex, char* pciBusId, size_t len);
 ncclResult_t amd_smi_getDeviceIndexByPciBusId(const char* pciBusId, uint32_t* deviceIndex);
-ncclResult_t amd_smi_getLinkInfo(int srcDev, int dstDev, amdsmi_link_type_t* type, int *hops, int *count);
+ncclResult_t amd_smi_getLinkInfo(int srcDev, int dstDev, amdsmi_link_type_t* type, int* hops, int* count);
 ncclResult_t amd_smi_getFirmwareVersion(uint32_t deviceIndex, uint64_t* fwVersion);
 /*************************************************************************
  * UALoE Fabric Wrapper Functions
@@ -566,8 +553,7 @@ ncclResult_t amd_smi_getFabricDeviceInfo(uint32_t deviceIndex, struct amdsmiFabr
  * @param[out] telemetry Pointer to allocated telemetry structure
  * @return ncclResult_t ncclSuccess on success
  */
-ncclResult_t amd_smi_allocFabricTelemetry(uint32_t deviceIndex,
-                                          uint32_t categoryMask,
+ncclResult_t amd_smi_allocFabricTelemetry(uint32_t deviceIndex, uint32_t categoryMask,
                                           amdsmi_fabric_telemetry_t** telemetry);
 
 /**
@@ -577,8 +563,7 @@ ncclResult_t amd_smi_allocFabricTelemetry(uint32_t deviceIndex,
  * @param[in,out] telemetry Pre-allocated telemetry structure to populate
  * @return ncclResult_t ncclSuccess on success
  */
-ncclResult_t amd_smi_getFabricTelemetryData(uint32_t deviceIndex,
-                                            amdsmi_fabric_telemetry_t* telemetry);
+ncclResult_t amd_smi_getFabricTelemetryData(uint32_t deviceIndex, amdsmi_fabric_telemetry_t* telemetry);
 
 /**
  * @brief Free fabric telemetry storage
@@ -587,8 +572,7 @@ ncclResult_t amd_smi_getFabricTelemetryData(uint32_t deviceIndex,
  * @param[in] telemetry Telemetry structure to free
  * @return ncclResult_t ncclSuccess on success
  */
-ncclResult_t amd_smi_freeFabricTelemetry(uint32_t deviceIndex,
-                                         amdsmi_fabric_telemetry_t* telemetry);
+ncclResult_t amd_smi_freeFabricTelemetry(uint32_t deviceIndex, amdsmi_fabric_telemetry_t* telemetry);
 
 /**
  * @brief Get string name for a telemetry item ID

--- a/projects/rccl/src/include/api_trace.h
+++ b/projects/rccl/src/include/api_trace.h
@@ -34,86 +34,64 @@
 #define RCCL_API_TRACE_VERSION_PATCH 7
 
 #if !defined(RCCL_EXTERN_C_INIT)
-#    ifdef __cplusplus
-#        define RCCL_EXTERN_C_INIT                                                       \
-            extern "C"                                                                   \
-            {
-#    else
-#        define RCCL_EXTERN_C_INIT
-#    endif
+#ifdef __cplusplus
+#define RCCL_EXTERN_C_INIT extern "C" {
+#else
+#define RCCL_EXTERN_C_INIT
+#endif
 #endif
 
 #if !defined(RCCL_EXTERN_C_FINI)
-#    ifdef __cplusplus
-#        define RCCL_EXTERN_C_FINI }
-#    else
-#        define RCCL_EXTERN_C_FINI
-#    endif
+#ifdef __cplusplus
+#define RCCL_EXTERN_C_FINI }
+#else
+#define RCCL_EXTERN_C_FINI
+#endif
 #endif
 
 RCCL_EXTERN_C_INIT
 
 typedef uint64_t rccl_range_id_t;
-typedef ncclResult_t (*ncclAllGather_fn_t)(const void* sendbuff, void* recvbuff,
-                                           size_t sendcount, ncclDataType_t datatype,
-                                           ncclComm_t comm, hipStream_t stream);
-typedef ncclResult_t (*ncclAllReduce_fn_t)(const void* sendbuff, void* recvbuff,
-                                           size_t count, ncclDataType_t datatype,
-                                           ncclRedOp_t op, struct ncclComm* comm,
-                                           hipStream_t stream);
-typedef ncclResult_t (*ncclAllReduceWithBias_fn_t)(const void* sendbuff, void* recvbuff,
-                                           size_t count, ncclDataType_t datatype,
-                                           ncclRedOp_t op, struct ncclComm* comm,
-                                           hipStream_t stream, const void* acc);
-typedef ncclResult_t (*ncclAlltoAll_fn_t)(const void* sendbuff, void* recvbuff,
-                                          size_t count, ncclDataType_t datatype,
+typedef ncclResult_t (*ncclAllGather_fn_t)(const void* sendbuff, void* recvbuff, size_t sendcount,
+                                           ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream);
+typedef ncclResult_t (*ncclAllReduce_fn_t)(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
+                                           ncclRedOp_t op, struct ncclComm* comm, hipStream_t stream);
+typedef ncclResult_t (*ncclAllReduceWithBias_fn_t)(const void* sendbuff, void* recvbuff, size_t count,
+                                                   ncclDataType_t datatype, ncclRedOp_t op, struct ncclComm* comm,
+                                                   hipStream_t stream, const void* acc);
+typedef ncclResult_t (*ncclAlltoAll_fn_t)(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
                                           ncclComm_t comm, hipStream_t stream);
-typedef ncclResult_t (*ncclAlltoAllv_fn_t)(
-    const void* sendbuff, const size_t sendcounts[], const size_t sdispls[],
-    void* recvbuff, const size_t recvcounts[], const size_t rdispls[],
-    ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream);
-typedef ncclResult_t (*ncclBroadcast_fn_t)(const void* sendbuff, void* recvbuff,
-                                           size_t count, ncclDataType_t datatype,
-                                           int root, ncclComm_t comm,
-                                           hipStream_t stream);
-typedef ncclResult_t (*ncclGather_fn_t)(const void* sendbuff, void* recvbuff,
-                                        size_t sendcount, ncclDataType_t datatype,
+typedef ncclResult_t (*ncclAlltoAllv_fn_t)(const void* sendbuff, const size_t sendcounts[], const size_t sdispls[],
+                                           void* recvbuff, const size_t recvcounts[], const size_t rdispls[],
+                                           ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream);
+typedef ncclResult_t (*ncclBroadcast_fn_t)(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
+                                           int root, ncclComm_t comm, hipStream_t stream);
+typedef ncclResult_t (*ncclGather_fn_t)(const void* sendbuff, void* recvbuff, size_t sendcount, ncclDataType_t datatype,
                                         int root, ncclComm_t comm, hipStream_t stream);
-typedef ncclResult_t (*ncclReduce_fn_t)(const void* sendbuff, void* recvbuff,
-                                        size_t count, ncclDataType_t datatype,
-                                        ncclRedOp_t op, int root, ncclComm_t comm,
-                                        hipStream_t stream);
-typedef ncclResult_t (*ncclReduceScatter_fn_t)(const void* sendbuff, void* recvbuff,
-                                               size_t recvcount, ncclDataType_t datatype,
-                                               ncclRedOp_t op, struct ncclComm* comm,
+typedef ncclResult_t (*ncclReduce_fn_t)(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
+                                        ncclRedOp_t op, int root, ncclComm_t comm, hipStream_t stream);
+typedef ncclResult_t (*ncclReduceScatter_fn_t)(const void* sendbuff, void* recvbuff, size_t recvcount,
+                                               ncclDataType_t datatype, ncclRedOp_t op, struct ncclComm* comm,
                                                hipStream_t stream);
-typedef ncclResult_t (*ncclScatter_fn_t)(const void* sendbuff, void* recvbuff,
-                                         size_t recvcount, ncclDataType_t datatype,
-                                         int root, ncclComm_t comm, hipStream_t stream);
-typedef ncclResult_t (*ncclSend_fn_t)(const void* sendbuff, size_t count,
-                                      ncclDataType_t datatype, int peer, ncclComm_t comm,
+typedef ncclResult_t (*ncclScatter_fn_t)(const void* sendbuff, void* recvbuff, size_t recvcount,
+                                         ncclDataType_t datatype, int root, ncclComm_t comm, hipStream_t stream);
+typedef ncclResult_t (*ncclSend_fn_t)(const void* sendbuff, size_t count, ncclDataType_t datatype, int peer,
+                                      ncclComm_t comm, hipStream_t stream);
+typedef ncclResult_t (*ncclRecv_fn_t)(void* recvbuff, size_t count, ncclDataType_t datatype, int peer, ncclComm_t comm,
                                       hipStream_t stream);
-typedef ncclResult_t (*ncclRecv_fn_t)(void* recvbuff, size_t count,
-                                      ncclDataType_t datatype, int peer, ncclComm_t comm,
-                                      hipStream_t stream);
-typedef ncclResult_t (*ncclRedOpCreatePreMulSum_fn_t)(ncclRedOp_t* op, void* scalar,
-                                                      ncclDataType_t        datatype,
-                                                      ncclScalarResidence_t residence,
-                                                      ncclComm_t            comm);
+typedef ncclResult_t (*ncclRedOpCreatePreMulSum_fn_t)(ncclRedOp_t* op, void* scalar, ncclDataType_t datatype,
+                                                      ncclScalarResidence_t residence, ncclComm_t comm);
 typedef ncclResult_t (*ncclRedOpDestroy_fn_t)(ncclRedOp_t op, ncclComm_t comm);
 typedef ncclResult_t (*ncclGroupStart_fn_t)();
 typedef ncclResult_t (*ncclGroupEnd_fn_t)();
 typedef ncclResult_t (*ncclGetVersion_fn_t)(int* version);
 typedef ncclResult_t (*ncclGetUniqueId_fn_t)(ncclUniqueId* out);
 
-typedef ncclResult_t (*ncclCommInitRank_fn_t)(ncclComm_t* newcomm, int nranks,
-                                              ncclUniqueId commId, int myrank);
+typedef ncclResult_t (*ncclCommInitRank_fn_t)(ncclComm_t* newcomm, int nranks, ncclUniqueId commId, int myrank);
 
-typedef ncclResult_t (*ncclCommInitAll_fn_t)(ncclComm_t* comms, int ndev,
-                                             const int* devlist);
+typedef ncclResult_t (*ncclCommInitAll_fn_t)(ncclComm_t* comms, int ndev, const int* devlist);
 
-typedef ncclResult_t (*ncclCommInitRankConfig_fn_t)(ncclComm_t* comm, int nranks,
-                                                    ncclUniqueId commId, int myrank,
+typedef ncclResult_t (*ncclCommInitRankConfig_fn_t)(ncclComm_t* comm, int nranks, ncclUniqueId commId, int myrank,
                                                     ncclConfig_t* config);
 
 typedef ncclResult_t (*ncclCommFinalize_fn_t)(ncclComm_t comm);
@@ -124,19 +102,17 @@ typedef ncclResult_t (*ncclCommAbort_fn_t)(ncclComm_t comm);
 
 typedef ncclResult_t (*ncclCommRevoke_fn_t)(ncclComm_t comm, int revokeFlags);
 
-typedef ncclResult_t (*ncclCommShrink_fn_t)(ncclComm_t comm, int* excludeRanksList,
-                                            int excludeRanksCount, ncclComm_t *newcomm,
-                                            ncclConfig_t* config, int shrinkFlags);
+typedef ncclResult_t (*ncclCommShrink_fn_t)(ncclComm_t comm, int* excludeRanksList, int excludeRanksCount,
+                                            ncclComm_t* newcomm, ncclConfig_t* config, int shrinkFlags);
 
-typedef ncclResult_t (*ncclCommSplit_fn_t)(ncclComm_t comm, int color, int key,
-                                           ncclComm_t* newcomm, ncclConfig_t* config);
+typedef ncclResult_t (*ncclCommSplit_fn_t)(ncclComm_t comm, int color, int key, ncclComm_t* newcomm,
+                                           ncclConfig_t* config);
 
 typedef const char* (*ncclGetErrorString_fn_t)(ncclResult_t code);
 
 typedef const char* (*ncclGetLastError_fn_t)(const ncclComm_t comm);
 
-typedef ncclResult_t (*ncclCommGetAsyncError_fn_t)(ncclComm_t    comm,
-                                                   ncclResult_t* asyncError);
+typedef ncclResult_t (*ncclCommGetAsyncError_fn_t)(ncclComm_t comm, ncclResult_t* asyncError);
 
 typedef ncclResult_t (*ncclCommCount_fn_t)(const ncclComm_t comm, int* count);
 
@@ -148,23 +124,21 @@ typedef ncclResult_t (*ncclMemAlloc_fn_t)(void** ptr, size_t size);
 
 typedef ncclResult_t (*ncclMemFree_fn_t)(void* ptr);
 
-typedef ncclResult_t (*mscclLoadAlgo_fn_t)(const char*        mscclAlgoFilePath,
-                                           mscclAlgoHandle_t* mscclAlgoHandle, int rank);
+typedef ncclResult_t (*mscclLoadAlgo_fn_t)(const char* mscclAlgoFilePath, mscclAlgoHandle_t* mscclAlgoHandle, int rank);
 
-typedef ncclResult_t (*mscclRunAlgo_fn_t)(
-    const void* sendBuff, const size_t sendCounts[], const size_t sDisPls[],
-    void* recvBuff, const size_t recvCounts[], const size_t rDisPls[], size_t count,
-    ncclDataType_t dataType, int root, int peer, ncclRedOp_t op,
-    mscclAlgoHandle_t mscclAlgoHandle, ncclComm_t comm, hipStream_t stream);
+typedef ncclResult_t (*mscclRunAlgo_fn_t)(const void* sendBuff, const size_t sendCounts[], const size_t sDisPls[],
+                                          void* recvBuff, const size_t recvCounts[], const size_t rDisPls[],
+                                          size_t count, ncclDataType_t dataType, int root, int peer, ncclRedOp_t op,
+                                          mscclAlgoHandle_t mscclAlgoHandle, ncclComm_t comm, hipStream_t stream);
 
 typedef ncclResult_t (*mscclUnloadAlgo_fn_t)(mscclAlgoHandle_t mscclAlgoHandle);
 
-typedef ncclResult_t (*ncclCommRegister_fn_t)(const ncclComm_t comm, void* buff,
-                                              size_t size, void** handle);
+typedef ncclResult_t (*ncclCommRegister_fn_t)(const ncclComm_t comm, void* buff, size_t size, void** handle);
 
 typedef ncclResult_t (*ncclCommDeregister_fn_t)(const ncclComm_t comm, void* handle);
 
-typedef ncclResult_t (*ncclCommWindowRegister_fn_t)(ncclComm_t comm, void* userPtr, size_t userSize, ncclWindow_t* outWinDev, int winFlags);
+typedef ncclResult_t (*ncclCommWindowRegister_fn_t)(ncclComm_t comm, void* userPtr, size_t userSize,
+                                                    ncclWindow_t* outWinDev, int winFlags);
 
 typedef ncclResult_t (*ncclCommWindowDeregister_fn_t)(ncclComm_t comm, ncclWindow_t win);
 
@@ -174,78 +148,76 @@ typedef ncclResult_t (*ncclCommResume_fn_t)(ncclComm_t comm);
 
 typedef ncclResult_t (*ncclCommMemStats_fn_t)(ncclComm_t comm, ncclCommMemStat_t stat, uint64_t* value);
 
-typedef ncclResult_t (*ncclPutSignal_fn_t)(const void* localbuff, size_t count, ncclDataType_t datatype,
-    int peer, ncclWindow_t peerWin, size_t peerWinOffset,
-    int sigIdx, int ctx, unsigned int flags, ncclComm_t comm, hipStream_t stream);
+typedef ncclResult_t (*ncclPutSignal_fn_t)(const void* localbuff, size_t count, ncclDataType_t datatype, int peer,
+                                           ncclWindow_t peerWin, size_t peerWinOffset, int sigIdx, int ctx,
+                                           unsigned int flags, ncclComm_t comm, hipStream_t stream);
 
-typedef ncclResult_t (*ncclSignal_fn_t)(int peer, int sigIdx, int ctx, unsigned int flags,
-    ncclComm_t comm, hipStream_t stream);
+typedef ncclResult_t (*ncclSignal_fn_t)(int peer, int sigIdx, int ctx, unsigned int flags, ncclComm_t comm,
+                                        hipStream_t stream);
 
-typedef ncclResult_t (*ncclWaitSignal_fn_t)(int nDesc, ncclWaitSignalDesc_t* signalDescs,
-    ncclComm_t comm, hipStream_t stream);
+typedef ncclResult_t (*ncclWaitSignal_fn_t)(int nDesc, ncclWaitSignalDesc_t* signalDescs, ncclComm_t comm,
+                                            hipStream_t stream);
 
 typedef ncclResult_t (*ncclCommGetUniqueId_fn_t)(ncclComm_t comm, ncclUniqueId* uniqueId);
 
-typedef ncclResult_t (*ncclCommGrow_fn_t)(ncclComm_t comm, int nRanks,
-                                          const ncclUniqueId* uniqueId, int rank,
+typedef ncclResult_t (*ncclCommGrow_fn_t)(ncclComm_t comm, int nRanks, const ncclUniqueId* uniqueId, int rank,
                                           ncclComm_t* newcomm, ncclConfig_t* config);
 
-typedef struct rcclApiFuncTable
-{
+typedef struct rcclApiFuncTable {
     // ADD NEW FUNCTIONS AT BOTTOM ONLY
-    uint64_t                      size;
-    ncclAllGather_fn_t            ncclAllGather_fn;
-    ncclAllReduce_fn_t            ncclAllReduce_fn;
-    ncclAlltoAll_fn_t             ncclAllToAll_fn;
-    ncclAlltoAllv_fn_t            ncclAllToAllv_fn;
-    ncclBroadcast_fn_t            ncclBroadcast_fn;
-    ncclGather_fn_t               ncclGather_fn;
-    ncclReduce_fn_t               ncclReduce_fn;
-    ncclReduceScatter_fn_t        ncclReduceScatter_fn;
-    ncclScatter_fn_t              ncclScatter_fn;
-    ncclSend_fn_t                 ncclSend_fn;
-    ncclRecv_fn_t                 ncclRecv_fn;
-    ncclRedOpCreatePreMulSum_fn_t ncclRedOpCreatePreMulSum_fn;
-    ncclRedOpDestroy_fn_t         ncclRedOpDestroy_fn;
-    ncclGroupStart_fn_t           ncclGroupStart_fn;
-    ncclGroupEnd_fn_t             ncclGroupEnd_fn;
-    ncclGetVersion_fn_t           ncclGetVersion_fn;
-    ncclGetUniqueId_fn_t          ncclGetUniqueId_fn;
-    ncclCommInitRank_fn_t         ncclCommInitRank_fn;
-    ncclCommInitAll_fn_t          ncclCommInitAll_fn;
-    ncclCommInitRankConfig_fn_t   ncclCommInitRankConfig_fn;
-    ncclCommFinalize_fn_t         ncclCommFinalize_fn;
-    ncclCommDestroy_fn_t          ncclCommDestroy_fn;
-    ncclCommAbort_fn_t            ncclCommAbort_fn;
-    ncclCommSplit_fn_t            ncclCommSplit_fn;
-    ncclGetErrorString_fn_t       ncclGetErrorString_fn;
-    ncclGetLastError_fn_t         ncclGetLastError_fn;
-    ncclCommGetAsyncError_fn_t    ncclCommGetAsyncError_fn;
-    ncclCommCount_fn_t            ncclCommCount_fn;
-    ncclCommCuDevice_fn_t         ncclCommCuDevice_fn;
-    ncclCommUserRank_fn_t         ncclCommUserRank_fn;
-    ncclMemAlloc_fn_t             ncclMemAlloc_fn;
-    ncclMemFree_fn_t              ncclMemFree_fn;
-    mscclLoadAlgo_fn_t            mscclLoadAlgo_fn;
-    mscclRunAlgo_fn_t             mscclRunAlgo_fn;
-    mscclUnloadAlgo_fn_t          mscclUnloadAlgo_fn;
-    ncclCommRegister_fn_t         ncclCommRegister_fn;
-    ncclCommDeregister_fn_t       ncclCommDeregister_fn;
-    ncclAllReduceWithBias_fn_t    ncclAllReduceWithBias_fn;
-    ncclCommShrink_fn_t           ncclCommShrink_fn;
-    ncclCommWindowRegister_fn_t   ncclCommWindowRegister_fn;
-    ncclCommWindowDeregister_fn_t ncclCommWindowDeregister_fn;
-    ncclAlltoAll_fn_t             ncclAlltoAll_fn;
-    ncclAlltoAllv_fn_t            ncclAlltoAllv_fn;
-    ncclCommRevoke_fn_t           ncclCommRevoke_fn;
-    ncclCommSuspend_fn_t          ncclCommSuspend_fn;
-    ncclCommResume_fn_t           ncclCommResume_fn;
-    ncclCommMemStats_fn_t         ncclCommMemStats_fn;
-    ncclPutSignal_fn_t            ncclPutSignal_fn;
-    ncclSignal_fn_t               ncclSignal_fn;
-    ncclWaitSignal_fn_t           ncclWaitSignal_fn;
-    ncclCommGetUniqueId_fn_t      ncclCommGetUniqueId_fn;
-    ncclCommGrow_fn_t             ncclCommGrow_fn;
+  uint64_t size;
+  ncclAllGather_fn_t ncclAllGather_fn;
+  ncclAllReduce_fn_t ncclAllReduce_fn;
+  ncclAlltoAll_fn_t ncclAllToAll_fn;
+  ncclAlltoAllv_fn_t ncclAllToAllv_fn;
+  ncclBroadcast_fn_t ncclBroadcast_fn;
+  ncclGather_fn_t ncclGather_fn;
+  ncclReduce_fn_t ncclReduce_fn;
+  ncclReduceScatter_fn_t ncclReduceScatter_fn;
+  ncclScatter_fn_t ncclScatter_fn;
+  ncclSend_fn_t ncclSend_fn;
+  ncclRecv_fn_t ncclRecv_fn;
+  ncclRedOpCreatePreMulSum_fn_t ncclRedOpCreatePreMulSum_fn;
+  ncclRedOpDestroy_fn_t ncclRedOpDestroy_fn;
+  ncclGroupStart_fn_t ncclGroupStart_fn;
+  ncclGroupEnd_fn_t ncclGroupEnd_fn;
+  ncclGetVersion_fn_t ncclGetVersion_fn;
+  ncclGetUniqueId_fn_t ncclGetUniqueId_fn;
+  ncclCommInitRank_fn_t ncclCommInitRank_fn;
+  ncclCommInitAll_fn_t ncclCommInitAll_fn;
+  ncclCommInitRankConfig_fn_t ncclCommInitRankConfig_fn;
+  ncclCommFinalize_fn_t ncclCommFinalize_fn;
+  ncclCommDestroy_fn_t ncclCommDestroy_fn;
+  ncclCommAbort_fn_t ncclCommAbort_fn;
+  ncclCommSplit_fn_t ncclCommSplit_fn;
+  ncclGetErrorString_fn_t ncclGetErrorString_fn;
+  ncclGetLastError_fn_t ncclGetLastError_fn;
+  ncclCommGetAsyncError_fn_t ncclCommGetAsyncError_fn;
+  ncclCommCount_fn_t ncclCommCount_fn;
+  ncclCommCuDevice_fn_t ncclCommCuDevice_fn;
+  ncclCommUserRank_fn_t ncclCommUserRank_fn;
+  ncclMemAlloc_fn_t ncclMemAlloc_fn;
+  ncclMemFree_fn_t ncclMemFree_fn;
+  mscclLoadAlgo_fn_t mscclLoadAlgo_fn;
+  mscclRunAlgo_fn_t mscclRunAlgo_fn;
+  mscclUnloadAlgo_fn_t mscclUnloadAlgo_fn;
+  ncclCommRegister_fn_t ncclCommRegister_fn;
+  ncclCommDeregister_fn_t ncclCommDeregister_fn;
+  ncclAllReduceWithBias_fn_t ncclAllReduceWithBias_fn;
+  ncclCommShrink_fn_t ncclCommShrink_fn;
+  ncclCommWindowRegister_fn_t ncclCommWindowRegister_fn;
+  ncclCommWindowDeregister_fn_t ncclCommWindowDeregister_fn;
+  ncclAlltoAll_fn_t ncclAlltoAll_fn;
+  ncclAlltoAllv_fn_t ncclAlltoAllv_fn;
+  ncclCommRevoke_fn_t ncclCommRevoke_fn;
+  ncclCommSuspend_fn_t ncclCommSuspend_fn;
+  ncclCommResume_fn_t ncclCommResume_fn;
+  ncclCommMemStats_fn_t ncclCommMemStats_fn;
+  ncclPutSignal_fn_t ncclPutSignal_fn;
+  ncclSignal_fn_t ncclSignal_fn;
+  ncclWaitSignal_fn_t ncclWaitSignal_fn;
+  ncclCommGetUniqueId_fn_t ncclCommGetUniqueId_fn;
+  ncclCommGrow_fn_t ncclCommGrow_fn;
     // ADD NEW FUNCTIONS HERE ONLY
 } rcclApiFuncTable;
 

--- a/projects/rccl/src/include/archinfo.h
+++ b/projects/rccl/src/include/archinfo.h
@@ -31,13 +31,13 @@ THE SOFTWARE.
 #include <hip/hip_runtime.h>
 */
 
-void GcnArchNameFormat(char *gcnArchName, char* out);
+void GcnArchNameFormat(char* gcnArchName, char* out);
 void convertGcnArchToGcnArchName(const char* gcnArch, const char** gcnArchName);
 int GetGcnArchName(int deviceId, char* out);
 double GetDeviceWallClockRateInKhz(int deviceId);
 bool IsArchMatch(char const* arch, char const* target);
 
-/* Host Code: Must match NCCL_LL128_LINESIZE / NCCL_LL128_LINEELEMS in device 
+/* Host Code: Must match NCCL_LL128_LINESIZE / NCCL_LL128_LINEELEMS in device
  * code for the same arch. */
 inline int rcclLL128LineElemsFromArch(char const* arch) {
   return IsArchMatch(arch, "gfx1250") ? 128 / (int)sizeof(uint64_t) : 64 / (int)sizeof(uint64_t);

--- a/projects/rccl/src/include/bitops.h
+++ b/projects/rccl/src/include/bitops.h
@@ -13,132 +13,141 @@
 #include "compiler.h"
 
 #if !__NVCC__
-  #ifndef __host__
-    #define __host__
-  #endif
-  #ifndef __device__
-    #define __device__
-  #endif
+#ifndef __host__
+#define __host__
+#endif
+#ifndef __device__
+#define __device__
+#endif
 #endif
 
-template<typename Int>
-constexpr static __host__ __device__ Int minval(Int a) { return a; }
-template<typename Int, typename ...More>
-constexpr static __host__ __device__ Int minval(Int a, Int b, More ...more) {
-  #if __CUDA_ARCH__
-    return minval(min(a, b), more...);
-  #else
-    return minval(a < b ? a : b, more...);
-  #endif
+template <typename Int>
+constexpr static __host__ __device__ Int minval(Int a) {
+  return a;
+}
+template <typename Int, typename... More>
+constexpr static __host__ __device__ Int minval(Int a, Int b, More... more) {
+#if __CUDA_ARCH__
+  return minval(min(a, b), more...);
+#else
+  return minval(a < b ? a : b, more...);
+#endif
 }
 
-template<typename Int>
-constexpr static __host__ __device__ Int maxval(Int a) { return a; }
-template<typename Int, typename ...More>
-constexpr static __host__ __device__ Int maxval(Int a, Int b, More ...more) {
-  #if __CUDA_ARCH__
-    return maxval(max(a, b), more...);
-  #else
-    return maxval(a > b ? a : b, more...);
-  #endif
+template <typename Int>
+constexpr static __host__ __device__ Int maxval(Int a) {
+  return a;
+}
+template <typename Int, typename... More>
+constexpr static __host__ __device__ Int maxval(Int a, Int b, More... more) {
+#if __CUDA_ARCH__
+  return maxval(max(a, b), more...);
+#else
+  return maxval(a > b ? a : b, more...);
+#endif
 }
 
 #define BIT(x) (1UL << (x))
 #define MASK(x) ((1UL << x) - 1UL)
 
-#define DIVUP(x, y) \
-    (((x)+(y)-1)/(y))
+#define DIVUP(x, y) (((x) + (y) - 1) / (y))
 
-#define ROUNDUP(x, y) \
-    (DIVUP((x), (y))*(y))
+#define ROUNDUP(x, y) (DIVUP((x), (y)) * (y))
 
-#define ALIGN_POWER(x, y) \
-    ((x) > (y) ? ROUNDUP(x, y) : ((y)/((y)/(x))))
+#define ALIGN_POWER(x, y) ((x) > (y) ? ROUNDUP(x, y) : ((y) / ((y) / (x))))
 
-#define ALIGN_SIZE(size, align) \
-  size = ((size + (align) - 1) / (align)) * (align);
+#define ALIGN_SIZE(size, align) size = ((size + (align) - 1) / (align)) * (align);
 
-template<typename X, typename Y, typename Z = decltype(X()+Y())>
+template <typename X, typename Y, typename Z = decltype(X() + Y())>
 static __host__ __device__ constexpr Z divUp(X x, Y y) {
-  return (x+y-1)/y;
+  return (x + y - 1) / y;
 }
 
-template<typename X, typename Y, typename Z = decltype(X()+Y())>
+template <typename X, typename Y, typename Z = decltype(X() + Y())>
 static __host__ __device__ constexpr Z roundUp(X x, Y y) {
-  return (x+y-1) - (x+y-1)%y;
+  return (x + y - 1) - (x + y - 1) % y;
 }
-template<typename X, typename Y, typename Z = decltype(X()+Y())>
+template <typename X, typename Y, typename Z = decltype(X() + Y())>
 static __host__ __device__ constexpr Z roundDown(X x, Y y) {
-  return x - x%y;
+  return x - x % y;
 }
 
 // assumes second argument is a power of 2
-template<typename X, typename Y, typename Z = decltype(X()+Y())>
+template <typename X, typename Y, typename Z = decltype(X() + Y())>
 static __host__ __device__ constexpr Z alignUp(X x, Y a) {
-  return (x + a-1) & ((Z)0 - Z(a));
+  return (x + a - 1) & ((Z)0 - Z(a));
 }
-template<typename T>
+template <typename T>
 static __host__ __device__ T* alignUp(T* x, size_t a) {
   static_assert(sizeof(T) == 1, "Only single byte types allowed.");
-  return reinterpret_cast<T*>((reinterpret_cast<uintptr_t>(x) + a-1) & ((uintptr_t)0 - (uintptr_t)(a)));
+  return reinterpret_cast<T*>((reinterpret_cast<uintptr_t>(x) + a - 1) & ((uintptr_t)0 - (uintptr_t)(a)));
 }
 
 // assumes second argument is a power of 2
-template<typename X, typename Y, typename Z = decltype(X()+Y())>
+template <typename X, typename Y, typename Z = decltype(X() + Y())>
 static __host__ __device__ constexpr Z alignDown(X x, Y a) {
   return x & ((Z)0 - Z(a));
 }
 
-template<typename T>
+template <typename T>
 static __host__ __device__ T* alignDown(T* x, size_t a) {
   static_assert(sizeof(T) == 1, "Only single byte types allowed.");
   return reinterpret_cast<T*>(reinterpret_cast<uintptr_t>(x) & ((uintptr_t)0 - (uintptr_t)(a)));
 }
 
-template<typename Int>
+template <typename Int>
 constexpr __host__ __device__ bool isPow2(Int x) {
-  return (x & (x-1)) == 0;
+  return (x & (x - 1)) == 0;
 }
 
-template<typename T>
+template <typename T>
 static __host__ __device__ T add4G(T base, int delta4G) {
-  union { T tmp; uint32_t u32[2]; };
+  union {
+    T tmp;
+    uint32_t u32[2];
+  };
   tmp = base;
   u32[1] += delta4G;
   return tmp;
 }
 
-template<typename T>
+template <typename T>
 static __host__ __device__ T incWrap4G(T ptr, uint32_t delta4G, uint32_t lo4G, uint32_t hi4G) {
-  union { T tmp; uint32_t u32[2]; };
+  union {
+    T tmp;
+    uint32_t u32[2];
+  };
   tmp = ptr;
   u32[1] += delta4G;
-  if (u32[1] >= hi4G) u32[1] -= hi4G-lo4G;
+  if (u32[1] >= hi4G) u32[1] -= hi4G - lo4G;
   return tmp;
 }
 
-template<typename T>
+template <typename T>
 static __host__ __device__ T decWrap4G(T ptr, uint32_t delta4G, uint32_t lo4G, uint32_t hi4G) {
-  union { T tmp; uint32_t u32[2]; };
+  union {
+    T tmp;
+    uint32_t u32[2];
+  };
   tmp = ptr;
   u32[1] -= delta4G;
-  if (u32[1] < lo4G) u32[1] += hi4G-lo4G;
+  if (u32[1] < lo4G) u32[1] += hi4G - lo4G;
   return tmp;
 }
 
 // Produce the reciprocal of x for use in idivByRcp
 constexpr __host__ __device__ uint32_t idivRcp32(uint32_t x) {
-  return uint32_t(uint64_t(0x100000000)/x);
+  return uint32_t(uint64_t(0x100000000) / x);
 }
 constexpr __host__ __device__ uint64_t idivRcp64(uint64_t x) {
-  return uint64_t(-1)/x + isPow2(x);
+  return uint64_t(-1) / x + isPow2(x);
 }
 
 static __host__ __device__ uint32_t mul32hi(uint32_t a, uint32_t b) {
 #if __CUDA_ARCH__
   return __umulhi(a, b);
 #else
-  return uint64_t(a)*b >> 32;
+  return uint64_t(a) * b >> 32;
 #endif
 }
 static __host__ __device__ uint64_t mul64hi(uint64_t a, uint64_t b) {
@@ -147,7 +156,7 @@ static __host__ __device__ uint64_t mul64hi(uint64_t a, uint64_t b) {
 #elif defined(NCCL_OS_WINDOWS)
   return __umulh(a, b);
 #else
-  return (uint64_t)(((unsigned __int128)a)*b >> 64);
+  return (uint64_t)(((unsigned __int128)a) * b >> 64);
 #endif
 }
 
@@ -157,37 +166,43 @@ static __host__ __device__ uint32_t imulRcp32(uint32_t x, uint32_t xrcp, uint32_
   if (xrcp == 0) return yrcp;
   if (yrcp == 0) return xrcp;
   uint32_t rcp = mul32hi(xrcp, yrcp);
-  uint32_t rem = 0u - x*y*rcp;
-  if (x*y <= rem) rcp += 1;
+  uint32_t rem = 0u - x * y * rcp;
+  if (x * y <= rem) rcp += 1;
   return rcp;
 }
 static __host__ __device__ uint64_t imulRcp64(uint64_t x, uint64_t xrcp, uint64_t y, uint64_t yrcp) {
   if (xrcp == 0) return yrcp;
   if (yrcp == 0) return xrcp;
   uint64_t rcp = mul64hi(xrcp, yrcp);
-  uint64_t rem = 0ULL - x*y*rcp;
-  if (x*y <= rem) rcp += 1;
+  uint64_t rem = 0ULL - x * y * rcp;
+  if (x * y <= rem) rcp += 1;
   return rcp;
 }
 
 // Fast integer division where divisor has precomputed reciprocal.
 // idivFast(x, y, idivRcp(y)) == x/y
-static __host__ __device__ void idivmodFast32(uint32_t *quo, uint32_t *rem, uint32_t x, uint32_t y, uint32_t yrcp) {
+static __host__ __device__ void idivmodFast32(uint32_t* quo, uint32_t* rem, uint32_t x, uint32_t y, uint32_t yrcp) {
   uint32_t q = x, r = 0;
   if (yrcp != 0) {
     q = mul32hi(x, yrcp);
-    r = x - y*q;
-    if (r >= y) { q += 1; r -= y; }
+    r = x - y * q;
+    if (r >= y) {
+      q += 1;
+      r -= y;
+    }
   }
   *quo = q;
   *rem = r;
 }
-static __host__ __device__ void idivmodFast64(uint64_t *quo, uint64_t *rem, uint64_t x, uint64_t y, uint64_t yrcp) {
+static __host__ __device__ void idivmodFast64(uint64_t* quo, uint64_t* rem, uint64_t x, uint64_t y, uint64_t yrcp) {
   uint64_t q = x, r = 0;
   if (yrcp != 0) {
     q = mul64hi(x, yrcp);
-    r = x - y*q;
-    if (r >= y) { q += 1; r -= y; }
+    r = x - y * q;
+    if (r >= y) {
+      q += 1;
+      r -= y;
+    }
   }
   *quo = q;
   *rem = r;
@@ -215,7 +230,7 @@ static __host__ __device__ uint64_t imodFast64(uint64_t x, uint64_t y, uint64_t 
   return r;
 }
 
-template<typename Int>
+template <typename Int>
 static __host__ __device__ int countOneBits(Int x) {
 #if __CUDA_ARCH__
   if (sizeof(Int) <= sizeof(unsigned int)) {
@@ -241,7 +256,7 @@ static __host__ __device__ int countOneBits(Int x) {
 }
 
 // Returns index of first one bit or returns -1 if mask is zero.
-template<typename Int>
+template <typename Int>
 static __host__ __device__ int firstOneBit(Int mask) {
   int i;
 #if __CUDA_ARCH__
@@ -263,25 +278,25 @@ static __host__ __device__ int firstOneBit(Int mask) {
     static_assert(sizeof(Int) <= sizeof(long long), "Unsupported integer size.");
   }
 #endif
-  return i-1;
+  return i - 1;
 }
 
-template<typename Int>
+template <typename Int>
 static __host__ __device__ int popFirstOneBit(Int* mask) {
   Int tmp = *mask;
-  *mask &= *mask-1;
+  *mask &= *mask - 1;
   return firstOneBit(tmp);
 }
 
-template<typename Int>
+template <typename Int>
 static __host__ __device__ int log2Down(Int x) {
   int w, n;
 #if __CUDA_ARCH__
   if (sizeof(Int) <= sizeof(int)) {
-    w = 8*sizeof(int);
+    w = 8 * sizeof(int);
     n = __clz((int)x);
   } else if (sizeof(Int) <= sizeof(long long)) {
-    w = 8*sizeof(long long);
+    w = 8 * sizeof(long long);
     n = __clzll((long long)x);
   } else {
     static_assert(sizeof(Int) <= sizeof(long long), "Unsupported integer size.");
@@ -290,31 +305,31 @@ static __host__ __device__ int log2Down(Int x) {
   if (x == 0) {
     return -1;
   } else if (sizeof(Int) <= sizeof(unsigned int)) {
-    w = 8*sizeof(unsigned int);
+    w = 8 * sizeof(unsigned int);
     n = COMPILER_CLZ((unsigned int)x);
   } else if (sizeof(Int) <= sizeof(unsigned long)) {
-    w = 8*sizeof(unsigned long);
+    w = 8 * sizeof(unsigned long);
     n = COMPILER_CLZL((unsigned long)x);
   } else if (sizeof(Int) <= sizeof(unsigned long long)) {
-    w = 8*sizeof(unsigned long long);
+    w = 8 * sizeof(unsigned long long);
     n = COMPILER_CLZLL((unsigned long long)x);
   } else {
     static_assert(sizeof(Int) <= sizeof(unsigned long long), "Unsupported integer size.");
   }
 #endif
-  return (w-1)-n;
+  return (w - 1) - n;
 }
 
-template<typename Int>
+template <typename Int>
 static __host__ __device__ int log2Up(Int x) {
   int w, n;
   if (x != 0) x -= 1;
 #if __CUDA_ARCH__
   if (sizeof(Int) <= sizeof(int)) {
-    w = 8*sizeof(int);
+    w = 8 * sizeof(int);
     n = __clz((int)x);
   } else if (sizeof(Int) <= sizeof(long long)) {
-    w = 8*sizeof(long long);
+    w = 8 * sizeof(long long);
     n = __clzll((long long)x);
   } else {
     static_assert(sizeof(Int) <= sizeof(long long), "Unsupported integer size.");
@@ -323,83 +338,127 @@ static __host__ __device__ int log2Up(Int x) {
   if (x == 0) {
     return 0;
   } else if (sizeof(Int) <= sizeof(unsigned int)) {
-    w = 8*sizeof(unsigned int);
+    w = 8 * sizeof(unsigned int);
     n = COMPILER_CLZ((unsigned int)x);
   } else if (sizeof(Int) <= sizeof(unsigned long)) {
-    w = 8*sizeof(unsigned long);
+    w = 8 * sizeof(unsigned long);
     n = COMPILER_CLZL((unsigned long)x);
   } else if (sizeof(Int) <= sizeof(unsigned long long)) {
-    w = 8*sizeof(unsigned long long);
+    w = 8 * sizeof(unsigned long long);
     n = COMPILER_CLZLL((unsigned long long)x);
   } else {
     static_assert(sizeof(Int) <= sizeof(unsigned long long), "Unsupported integer size.");
   }
 #endif
-  return w-n;
+  return w - n;
 }
 
-template<typename Int>
+template <typename Int>
 static __host__ __device__ Int pow2Up(Int x) {
-  return Int(1)<<log2Up(x);
+  return Int(1) << log2Up(x);
 }
 
-template<typename Int>
+template <typename Int>
 static __host__ __device__ Int pow2Down(Int x) {
   // True, log2Down can return -1, but we don't normally pass 0 as an argument...
   // coverity[negative_shift]
-  return Int(1)<<log2Down(x);
+  return Int(1) << log2Down(x);
 }
 
-template<typename UInt, int nSubBits>
+template <typename UInt, int nSubBits>
 static __host__ __device__ UInt reverseSubBits(UInt x) {
-  if (nSubBits >= 16 && 8*sizeof(UInt) == nSubBits) {
-    switch (8*sizeof(UInt)) {
-    case 16: x = COMPILER_BSWAP16(x); break;
-    case 32: x = COMPILER_BSWAP32(x); break;
-    case 64: x = COMPILER_BSWAP64(x); break;
-    default: static_assert(8*sizeof(UInt) <= 64, "Unsupported integer type.");
+  if (nSubBits >= 16 && 8 * sizeof(UInt) == nSubBits) {
+    switch (8 * sizeof(UInt)) {
+    case 16:
+      x = COMPILER_BSWAP16(x);
+      break;
+    case 32:
+      x = COMPILER_BSWAP32(x);
+      break;
+    case 64:
+      x = COMPILER_BSWAP64(x);
+      break;
+    default:
+      static_assert(8 * sizeof(UInt) <= 64, "Unsupported integer type.");
     }
     return reverseSubBits<UInt, 8>(x);
   } else if (nSubBits <= 1) {
     return x;
   } else {
-    UInt m = UInt(-1)/((UInt(1)<<(nSubBits/2))+1);
-    x = (x & m)<<(nSubBits/2) | (x & ~m)>>(nSubBits/2);
-    return reverseSubBits<UInt, nSubBits/2>(x);
+    UInt m = UInt(-1) / ((UInt(1) << (nSubBits / 2)) + 1);
+    x = (x & m) << (nSubBits / 2) | (x & ~m) >> (nSubBits / 2);
+    return reverseSubBits<UInt, nSubBits / 2>(x);
   }
 }
 
-template<typename T> struct ncclToUnsigned;
-template<> struct ncclToUnsigned<char> { using type = unsigned char; };
-template<> struct ncclToUnsigned<signed char> { using type = unsigned char; };
-template<> struct ncclToUnsigned<unsigned char> { using type = unsigned char; };
-template<> struct ncclToUnsigned<signed short> { using type = unsigned short; };
-template<> struct ncclToUnsigned<unsigned short> { using type = unsigned short; };
-template<> struct ncclToUnsigned<signed int> { using type = unsigned int; };
-template<> struct ncclToUnsigned<unsigned int> { using type = unsigned int; };
-template<> struct ncclToUnsigned<signed long> { using type = unsigned long; };
-template<> struct ncclToUnsigned<unsigned long> { using type = unsigned long; };
-template<> struct ncclToUnsigned<signed long long> { using type = unsigned long long; };
-template<> struct ncclToUnsigned<unsigned long long> { using type = unsigned long long; };
+template <typename T>
+struct ncclToUnsigned;
+template <>
+struct ncclToUnsigned<char> {
+  using type = unsigned char;
+};
+template <>
+struct ncclToUnsigned<signed char> {
+  using type = unsigned char;
+};
+template <>
+struct ncclToUnsigned<unsigned char> {
+  using type = unsigned char;
+};
+template <>
+struct ncclToUnsigned<signed short> {
+  using type = unsigned short;
+};
+template <>
+struct ncclToUnsigned<unsigned short> {
+  using type = unsigned short;
+};
+template <>
+struct ncclToUnsigned<signed int> {
+  using type = unsigned int;
+};
+template <>
+struct ncclToUnsigned<unsigned int> {
+  using type = unsigned int;
+};
+template <>
+struct ncclToUnsigned<signed long> {
+  using type = unsigned long;
+};
+template <>
+struct ncclToUnsigned<unsigned long> {
+  using type = unsigned long;
+};
+template <>
+struct ncclToUnsigned<signed long long> {
+  using type = unsigned long long;
+};
+template <>
+struct ncclToUnsigned<unsigned long long> {
+  using type = unsigned long long;
+};
 
 // Reverse the bottom nBits bits of x. The top bits will be overwritten with 0's.
-template<typename Int>
+template <typename Int>
 static __host__ __device__ Int reverseBits(Int x, int nBits) {
   using UInt = typename ncclToUnsigned<Int>::type;
-  union { UInt ux; Int sx; };
+  union {
+    UInt ux;
+    Int sx;
+  };
   sx = x;
-  #if __CUDA_ARCH__
-    if (sizeof(Int) <= sizeof(unsigned int)) {
-      ux = __brev(ux);
-    } else if (sizeof(Int) <= sizeof(unsigned long long)) {
-      ux = __brevll(ux);
-    } else {
-      static_assert(sizeof(Int) <= sizeof(unsigned long long), "Unsupported integer type.");
-    }
-  #else
-    ux = reverseSubBits<UInt, 8*sizeof(UInt)>(ux);
-  #endif
-  ux = nBits==0 ? 0 : ux>>(8*sizeof(UInt)-nBits);
+#if __CUDA_ARCH__
+  if (sizeof(Int) <= sizeof(unsigned int)) {
+    ux = __brev(ux);
+  } else if (sizeof(Int) <= sizeof(unsigned long long)) {
+    ux = __brevll(ux);
+  } else {
+    static_assert(sizeof(Int) <= sizeof(unsigned long long), "Unsupported integer type.");
+  }
+#else
+  ux = reverseSubBits<UInt, 8 * sizeof(UInt)>(ux);
+#endif
+  ux = nBits == 0 ? 0 : ux >> (8 * sizeof(UInt) - nBits);
   return sx;
 }
 
@@ -410,24 +469,26 @@ static __host__ __device__ Int reverseBits(Int x, int nBits) {
 
 static __host__ __device__ uint32_t u32fpEncode(uint32_t x, int bitsPerPow2) {
   int log2x;
-  #if __CUDA_ARCH__
-    log2x = 31-__clz(x|1);
-  #else
-    log2x = 31-COMPILER_CLZ(x|1);
-  #endif
-  uint32_t mantissa = x>>(log2x >= bitsPerPow2 ? log2x-bitsPerPow2 : 0) & ((1u<<bitsPerPow2)-1);
-  uint32_t exponent = log2x >= bitsPerPow2 ? log2x-(bitsPerPow2-1) : 0;
-  return exponent<<bitsPerPow2 | mantissa;
+#if __CUDA_ARCH__
+  log2x = 31 - __clz(x | 1);
+#else
+  log2x = 31 - COMPILER_CLZ(x | 1);
+#endif
+  uint32_t mantissa = x >> (log2x >= bitsPerPow2 ? log2x - bitsPerPow2 : 0) & ((1u << bitsPerPow2) - 1);
+  uint32_t exponent = log2x >= bitsPerPow2 ? log2x - (bitsPerPow2 - 1) : 0;
+  return exponent << bitsPerPow2 | mantissa;
 }
 
 static __host__ __device__ uint32_t u32fpDecode(uint32_t x, int bitsPerPow2) {
-  uint32_t exponent = x>>bitsPerPow2;
-  uint32_t mantissa = (x & ((1u<<bitsPerPow2)-1)) | (exponent!=0 ? 0x8 : 0);
+  uint32_t exponent = x >> bitsPerPow2;
+  uint32_t mantissa = (x & ((1u << bitsPerPow2) - 1)) | (exponent != 0 ? 0x8 : 0);
   if (exponent != 0) exponent -= 1;
-  return mantissa<<exponent;
+  return mantissa << exponent;
 }
 
-constexpr uint32_t u32fp8MaxValue() { return 0xf0000000; }
+constexpr uint32_t u32fp8MaxValue() {
+  return 0xf0000000;
+}
 
 static __host__ __device__ uint8_t u32fp8Encode(uint32_t x) {
   return u32fpEncode(x, 3);
@@ -460,7 +521,7 @@ static __host__ __device__ void eatHash(uint64_t acc[2], const void* bytes, size
   }
 }
 
-template<typename T>
+template <typename T>
 static __host__ __device__ void eatHash(uint64_t acc[2], const T* bytes) {
   eatHash(acc, (const void*)bytes, sizeof(T));
 }
@@ -480,7 +541,7 @@ static __host__ __device__ uint64_t getHash(const void* bytes, size_t size) {
   eatHash(acc, bytes, size);
   return digestHash(acc);
 }
-template<typename T>
+template <typename T>
 static __host__ __device__ uint64_t getHash(const T* bytes) {
   return getHash((const void*)bytes, sizeof(T));
 }

--- a/projects/rccl/src/include/bootstrap.h
+++ b/projects/rccl/src/include/bootstrap.h
@@ -16,22 +16,25 @@ struct ncclBootstrapHandle {
   union ncclSocketAddress addr;
   int nRanks; // number of existing ranks
 };
-static_assert(sizeof(struct ncclBootstrapHandle) <= sizeof(ncclUniqueId), "Bootstrap handle is too large to fit inside NCCL unique ID");
+static_assert(sizeof(struct ncclBootstrapHandle) <= sizeof(ncclUniqueId),
+              "Bootstrap handle is too large to fit inside NCCL unique ID");
 
 ncclResult_t bootstrapNetInit();
 ncclResult_t bootstrapCreateRoot(struct ncclBootstrapHandle* handle, bool idFromEnv);
 ncclResult_t bootstrapGetUniqueId(struct ncclBootstrapHandle* handle, struct ncclComm* comm);
 ncclResult_t bcastGrowHandle(struct ncclBootstrapHandle* handle, struct ncclComm* parent, bool isRoot);
 ncclResult_t bootstrapInit(int nHandles, void* handle, struct ncclComm* comm, struct ncclComm* parent);
-ncclResult_t bootstrapSplit(uint64_t magic, struct ncclComm* comm, struct ncclComm* parent, int color, int key, int* parentRanks);
+ncclResult_t bootstrapSplit(uint64_t magic, struct ncclComm* comm, struct ncclComm* parent, int color, int key,
+                            int* parentRanks);
 ncclResult_t bootstrapAllGather(void* commState, void* allData, int size);
 ncclResult_t bootstrapSend(void* commState, int peer, int tag, void* data, int size);
 ncclResult_t bootstrapRecv(void* commState, int peer, int tag, void* data, int size);
 ncclResult_t bootstrapBarrier(void* commState, int rank, int nranks, int tag);
 ncclResult_t bootstrapBroadcast(void* commState, int rank, int nranks, int root, void* bcastData, int size);
-ncclResult_t bootstrapIntraNodeBarrier(void* commState, int *ranks, int rank, int nranks, int tag);
-ncclResult_t bootstrapIntraNodeAllGather(void* commState, int *ranks, int rank, int nranks, void* allData, int size);
-ncclResult_t bootstrapIntraNodeBroadcast(void* commState, int *ranks, int rank, int nranks, int root, void* bcastData, int size);
+ncclResult_t bootstrapIntraNodeBarrier(void* commState, int* ranks, int rank, int nranks, int tag);
+ncclResult_t bootstrapIntraNodeAllGather(void* commState, int* ranks, int rank, int nranks, void* allData, int size);
+ncclResult_t bootstrapIntraNodeBroadcast(void* commState, int* ranks, int rank, int nranks, int root, void* bcastData,
+                                         int size);
 ncclResult_t bootstrapClose(void* commState);
 ncclResult_t bootstrapAbort(void* commState);
 

--- a/projects/rccl/src/include/ce_coll.h
+++ b/projects/rccl/src/include/ce_coll.h
@@ -36,7 +36,7 @@ struct ncclCeColl {
 };
 
 struct ncclCeInitTask {
-  struct ncclCeInitTask *next;
+  struct ncclCeInitTask* next;
   struct ncclComm* comm;
 };
 
@@ -67,9 +67,10 @@ struct ncclCeBatchOpsParams {
 #endif
 };
 
-bool ncclCeAvailable(struct ncclComm* comm, ncclFunc_t coll, int/*ncclDevRedOp_t*/ red, ncclDataType_t ty, ncclSymRegType_t winRegType);
+bool ncclCeAvailable(struct ncclComm* comm, ncclFunc_t coll, int /*ncclDevRedOp_t*/ red, ncclDataType_t ty,
+                     ncclSymRegType_t winRegType);
 
-bool ncclCeImplemented(ncclFunc_t coll, int/*ncclDevRedOp_t*/ red, ncclDataType_t ty);
+bool ncclCeImplemented(ncclFunc_t coll, int /*ncclDevRedOp_t*/ red, ncclDataType_t ty);
 
 ncclResult_t ncclCeInit(struct ncclComm* comm);
 

--- a/projects/rccl/src/include/ce_fault_inject.h
+++ b/projects/rccl/src/include/ce_fault_inject.h
@@ -36,13 +36,13 @@
 // ---------------------------------------------------------------------------
 
 /** Force ncclCeInit() to return ncclSystemError. */
-#define CE_FAULT_INIT        0x01U
+#define CE_FAULT_INIT 0x01U
 
 /** Force ncclPrepUCSync() to return ncclSystemError. */
-#define CE_FAULT_SYNC_PREP   0x02U
+#define CE_FAULT_SYNC_PREP 0x02U
 
 /** Force ncclCeLaunchBatchOps() to return ncclSystemError. */
-#define CE_FAULT_LAUNCH_OP   0x04U
+#define CE_FAULT_LAUNCH_OP 0x04U
 
 // ---------------------------------------------------------------------------
 // Inline implementations – ncclComm is defined in comm.h, ncclResult_t in nccl.h.

--- a/projects/rccl/src/include/channel.h
+++ b/projects/rccl/src/include/channel.h
@@ -13,26 +13,26 @@
 
 bool rcclUseAinic();
 
-RCCL_PARAM_DECLARE(PxnOptQpUsage);  // RCCL_PXN_OPT_QP_USAGE: uses batch stride of comm->maxLocalRanks instead of 1 to reduce QP usage when p2p-batching is disabled
+RCCL_PARAM_DECLARE(
+  PxnOptQpUsage); // RCCL_PXN_OPT_QP_USAGE: uses batch stride of comm->maxLocalRanks instead of 1 to reduce QP usage when p2p-batching is disabled
 
 #include <algorithm>
 
 ncclResult_t initChannel(struct ncclComm* comm, int channelid);
 ncclResult_t initNvlsChannel(struct ncclComm* comm, int channelId, struct ncclComm* parent, bool share);
 ncclResult_t initCollnetChannel(struct ncclComm* comm, int channelId, struct ncclComm* parent, bool share);
-ncclResult_t freeChannel(struct ncclChannel* channel, int nRanks, int collnetNRanks, int nvlsNRanks, struct ncclComm* comm);
+ncclResult_t freeChannel(struct ncclChannel* channel, int nRanks, int collnetNRanks, int nvlsNRanks,
+                         struct ncclComm* comm);
 
 inline uint8_t ncclP2pChannelBaseForRound(struct ncclComm* comm, int p2pRound, int p2pBatchEnable = 0) {
   int base;
   if (comm->nNodes > 1) {
-    int nodeDelta = p2pRound/comm->maxLocalRanks;
-    int localDelta = p2pRound%comm->maxLocalRanks;
+    int nodeDelta = p2pRound / comm->maxLocalRanks;
+    int localDelta = p2pRound % comm->maxLocalRanks;
     int fallbackBatch = (!ncclPxnDisable(comm) && rcclParamPxnOptQpUsage() && rcclUseAinic()) ? comm->maxLocalRanks : 1;
-    int batchSize = (comm->nNodes > 2 && p2pBatchEnable)
-        ? NCCL_MAX_DEV_WORK_P2P_PER_BATCH
-        : fallbackBatch;
-    base = nodeDelta*divUp(comm->maxLocalRanks, batchSize);
-    base += localDelta/batchSize;
+    int batchSize = (comm->nNodes > 2 && p2pBatchEnable) ? NCCL_MAX_DEV_WORK_P2P_PER_BATCH : fallbackBatch;
+    base = nodeDelta * divUp(comm->maxLocalRanks, batchSize);
+    base += localDelta / batchSize;
   } else {
     base = p2pRound;
   }

--- a/projects/rccl/src/include/checks.h
+++ b/projects/rccl/src/include/checks.h
@@ -11,34 +11,36 @@
 #include "debug.h"
 
 // Check CUDA RT calls
-#define CUDACHECK(cmd) do {                                 \
-    cudaError_t err = cmd;                                  \
-    if( err != cudaSuccess ) {                              \
-        return rcclCudaErrorHandler(err);                   \
-    }                                                       \
-} while(false)
+#define CUDACHECK(cmd) \
+  do { \
+    cudaError_t err = cmd; \
+    if (err != cudaSuccess) { \
+      return rcclCudaErrorHandler(err); \
+    } \
+  } while (false)
 
-#define CUDACHECKGOTO(cmd, RES, label) do {                 \
-    cudaError_t err = cmd;                                  \
-    if( err != cudaSuccess ) {                              \
-        RES = rcclCudaErrorHandler(err);                    \
-        goto label;                                         \
-    }                                                       \
-} while(false)
+#define CUDACHECKGOTO(cmd, RES, label) \
+  do { \
+    cudaError_t err = cmd; \
+    if (err != cudaSuccess) { \
+      RES = rcclCudaErrorHandler(err); \
+      goto label; \
+    } \
+  } while (false)
 
 // Report failure but clear error and continue
-#define CUDACHECKIGNORE(cmd) do {  \
-    cudaError_t err = cmd;         \
-    if( err != cudaSuccess ) {     \
-        INFO(NCCL_ALL,"%s:%d Cuda failure '%s'", __FILE__, __LINE__, cudaGetErrorString(err)); \
-        (void) cudaGetLastError(); \
-    }                              \
-} while(false)
+#define CUDACHECKIGNORE(cmd) \
+  do { \
+    cudaError_t err = cmd; \
+    if (err != cudaSuccess) { \
+      INFO(NCCL_ALL, "%s:%d Cuda failure '%s'", __FILE__, __LINE__, cudaGetErrorString(err)); \
+      (void)cudaGetLastError(); \
+    } \
+  } while (false)
 
 // Use inline function to clear CUDA error inside expressions
 static inline cudaError_t cuda_clear(cudaError_t err) {
-  if (err != cudaSuccess)
-    (void)cudaGetLastError();
+  if (err != cudaSuccess) (void)cudaGetLastError();
   return err;
 }
 
@@ -49,196 +51,222 @@ static inline cudaError_t cuda_clear(cudaError_t err) {
 
 #include <errno.h>
 // Check system calls
-#define SYSCHECK(statement, name) do { \
-  int retval; \
-  SYSCHECKSYNC((statement), name, retval); \
-  if (retval == -1) { \
-    WARN("Call to " name " failed: %s", strerror(errno)); \
-    return ncclSystemError; \
-  } \
-} while (false)
+#define SYSCHECK(statement, name) \
+  do { \
+    int retval; \
+    SYSCHECKSYNC((statement), name, retval); \
+    if (retval == -1) { \
+      WARN("Call to " name " failed: %s", strerror(errno)); \
+      return ncclSystemError; \
+    } \
+  } while (false)
 
-#define SYSCHECKSYNC(statement, name, retval) do { \
-  retval = (statement); \
-  if (retval == -1 && (errno == EINTR || errno == EWOULDBLOCK || errno == EAGAIN)) { \
-    INFO(NCCL_ALL,"Call to " name " returned %s, retrying", strerror(errno)); \
-  } else { \
-    break; \
-  } \
-} while(true)
+#define SYSCHECKSYNC(statement, name, retval) \
+  do { \
+    retval = (statement); \
+    if (retval == -1 && (errno == EINTR || errno == EWOULDBLOCK || errno == EAGAIN)) { \
+      INFO(NCCL_ALL, "Call to " name " returned %s, retrying", strerror(errno)); \
+    } else { \
+      break; \
+    } \
+  } while (true)
 
-#define SYSCHECKGOTO(statement, name, RES, label) do { \
-  int retval; \
-  SYSCHECKSYNC((statement), name, retval); \
-  if (retval == -1) { \
-    WARN("Call to " name " failed: %s", strerror(errno)); \
-    RES = ncclSystemError; \
-    goto label; \
-  } \
-} while (0)
+#define SYSCHECKGOTO(statement, name, RES, label) \
+  do { \
+    int retval; \
+    SYSCHECKSYNC((statement), name, retval); \
+    if (retval == -1) { \
+      WARN("Call to " name " failed: %s", strerror(errno)); \
+      RES = ncclSystemError; \
+      goto label; \
+    } \
+  } while (0)
 
 // Pthread calls don't set errno and never return EINTR.
-#define PTHREADCHECK(statement, name) do { \
-  int retval = (statement); \
-  if (retval != 0) { \
-    WARN("Call to " name " failed: %s", strerror(retval)); \
-    return ncclSystemError; \
-  } \
-} while (0)
+#define PTHREADCHECK(statement, name) \
+  do { \
+    int retval = (statement); \
+    if (retval != 0) { \
+      WARN("Call to " name " failed: %s", strerror(retval)); \
+      return ncclSystemError; \
+    } \
+  } while (0)
 
-#define PTHREADCHECKGOTO(statement, name, RES, label) do { \
-  int retval = (statement); \
-  if (retval != 0) { \
-    WARN("Call to " name " failed: %s", strerror(retval)); \
-    RES = ncclSystemError; \
-    goto label; \
-  } \
-} while (0)
+#define PTHREADCHECKGOTO(statement, name, RES, label) \
+  do { \
+    int retval = (statement); \
+    if (retval != 0) { \
+      WARN("Call to " name " failed: %s", strerror(retval)); \
+      RES = ncclSystemError; \
+      goto label; \
+    } \
+  } while (0)
 
-#define NEQCHECK(statement, value) do {   \
-  if ((statement) != value) {             \
-    /* Print the back trace*/             \
-    INFO(NCCL_ALL,"%s:%d -> %d (%s)", __FILE__, __LINE__, ncclSystemError, strerror(errno));    \
-    return ncclSystemError;     \
-  }                             \
-} while (0)
-
-#define NEQCHECKGOTO(statement, value, RES, label) do { \
-  if ((statement) != value) { \
+#define NEQCHECK(statement, value) \
+  do { \
+    if ((statement) != value) { \
     /* Print the back trace*/ \
-    RES = ncclSystemError;    \
-    INFO(NCCL_ALL,"%s:%d -> %d (%s)", __FILE__, __LINE__, RES, strerror(errno));    \
-    goto label; \
-  } \
-} while (0)
+      INFO(NCCL_ALL, "%s:%d -> %d (%s)", __FILE__, __LINE__, ncclSystemError, strerror(errno)); \
+      return ncclSystemError; \
+    } \
+  } while (0)
 
-#define EQCHECK(statement, value) do {    \
-  if ((statement) == value) {             \
-    /* Print the back trace*/             \
-    INFO(NCCL_ALL,"%s:%d -> %d (%s)", __FILE__, __LINE__, ncclSystemError, strerror(errno));    \
-    return ncclSystemError;     \
-  }                             \
-} while (0)
-
-#define EQCHECKGOTO(statement, value, RES, label) do { \
-  if ((statement) == value) { \
+#define NEQCHECKGOTO(statement, value, RES, label) \
+  do { \
+    if ((statement) != value) { \
     /* Print the back trace*/ \
-    RES = ncclSystemError;    \
-    INFO(NCCL_ALL,"%s:%d -> %d (%s)", __FILE__, __LINE__, RES, strerror(errno));    \
-    goto label; \
-  } \
-} while (0)
+      RES = ncclSystemError; \
+      INFO(NCCL_ALL, "%s:%d -> %d (%s)", __FILE__, __LINE__, RES, strerror(errno)); \
+      goto label; \
+    } \
+  } while (0)
+
+#define EQCHECK(statement, value) \
+  do { \
+    if ((statement) == value) { \
+    /* Print the back trace*/ \
+      INFO(NCCL_ALL, "%s:%d -> %d (%s)", __FILE__, __LINE__, ncclSystemError, strerror(errno)); \
+      return ncclSystemError; \
+    } \
+  } while (0)
+
+#define EQCHECKGOTO(statement, value, RES, label) \
+  do { \
+    if ((statement) == value) { \
+    /* Print the back trace*/ \
+      RES = ncclSystemError; \
+      INFO(NCCL_ALL, "%s:%d -> %d (%s)", __FILE__, __LINE__, RES, strerror(errno)); \
+      goto label; \
+    } \
+  } while (0)
 
 // Propagate errors up
-#define NCCLCHECK(call) do { \
-  ncclResult_t RES = call; \
-  if (RES != ncclSuccess && RES != ncclInProgress) { \
+#define NCCLCHECK(call) \
+  do { \
+    ncclResult_t RES = call; \
+    if (RES != ncclSuccess && RES != ncclInProgress) { \
     /* Print the back trace*/ \
-    if (ncclDebugNoWarn == 0) INFO(NCCL_ALL,"%s:%d -> %d", __FILE__, __LINE__, RES);    \
-    return RES; \
-  } \
-} while (0)
+      if (ncclDebugNoWarn == 0) INFO(NCCL_ALL, "%s:%d -> %d", __FILE__, __LINE__, RES); \
+      return RES; \
+    } \
+  } while (0)
 
-#define NCCLCHECKGOTO(call, RES, label) do { \
-  RES = call; \
-  if (RES != ncclSuccess && RES != ncclInProgress) { \
+#define NCCLCHECKGOTO(call, RES, label) \
+  do { \
+    RES = call; \
+    if (RES != ncclSuccess && RES != ncclInProgress) { \
     /* Print the back trace*/ \
-    if (ncclDebugNoWarn == 0) INFO(NCCL_ALL,"%s:%d -> %d", __FILE__, __LINE__, RES);    \
-    goto label; \
-  } \
-} while (0)
+      if (ncclDebugNoWarn == 0) INFO(NCCL_ALL, "%s:%d -> %d", __FILE__, __LINE__, RES); \
+      goto label; \
+    } \
+  } while (0)
 
 // Report failure but continue - useful for cleanup paths where we want to
 // attempt all cleanup steps. Preserves the first error in RES.
-#define NCCLCHECKIGNORE(call, RES) do { \
-  ncclResult_t TMPRES = call; \
-  if (TMPRES != ncclSuccess && TMPRES != ncclInProgress) { \
-    if (ncclDebugNoWarn == 0) INFO(NCCL_ALL,"%s:%d -> %d", __FILE__, __LINE__, TMPRES); \
-    if (RES == ncclSuccess) RES = TMPRES; \
-  } \
-} while (0)
+#define NCCLCHECKIGNORE(call, RES) \
+  do { \
+    ncclResult_t TMPRES = call; \
+    if (TMPRES != ncclSuccess && TMPRES != ncclInProgress) { \
+      if (ncclDebugNoWarn == 0) INFO(NCCL_ALL, "%s:%d -> %d", __FILE__, __LINE__, TMPRES); \
+      if (RES == ncclSuccess) RES = TMPRES; \
+    } \
+  } while (0)
 
-#define NCCLCHECKNOWARN(call, FLAGS) do { \
-  ncclResult_t RES; \
-  NOWARN(RES = call, FLAGS); \
-  if (RES != ncclSuccess && RES != ncclInProgress) { \
-    return RES; \
-  } \
-} while (0)
+#define NCCLCHECKNOWARN(call, FLAGS) \
+  do { \
+    ncclResult_t RES; \
+    NOWARN(RES = call, FLAGS); \
+    if (RES != ncclSuccess && RES != ncclInProgress) { \
+      return RES; \
+    } \
+  } while (0)
 
-#define NCCLCHECKGOTONOWARN(call, RES, label, FLAGS) do { \
-  NOWARN(RES = call, FLAGS); \
-  if (RES != ncclSuccess && RES != ncclInProgress) { \
-    goto label; \
-  } \
-} while (0)
+#define NCCLCHECKGOTONOWARN(call, RES, label, FLAGS) \
+  do { \
+    NOWARN(RES = call, FLAGS); \
+    if (RES != ncclSuccess && RES != ncclInProgress) { \
+      goto label; \
+    } \
+  } while (0)
 
-#define NCCLWAIT(call, cond, abortFlagPtr) do {         \
-  uint32_t* tmpAbortFlag = (abortFlagPtr);     \
-  ncclResult_t RES = call;                \
-  if (RES != ncclSuccess && RES != ncclInProgress) {               \
-    if (ncclDebugNoWarn == 0) INFO(NCCL_ALL,"%s:%d -> %d", __FILE__, __LINE__, RES);    \
-    return ncclInternalError;             \
-  }                                       \
-  if (COMPILER_ATOMIC_LOAD(tmpAbortFlag, std::memory_order_acquire)) NEQCHECK(*tmpAbortFlag, 0); \
-} while (!(cond))
+#define NCCLWAIT(call, cond, abortFlagPtr) \
+  do { \
+    uint32_t* tmpAbortFlag = (abortFlagPtr); \
+    ncclResult_t RES = call; \
+    if (RES != ncclSuccess && RES != ncclInProgress) { \
+      if (ncclDebugNoWarn == 0) INFO(NCCL_ALL, "%s:%d -> %d", __FILE__, __LINE__, RES); \
+      return ncclInternalError; \
+    } \
+    if (COMPILER_ATOMIC_LOAD(tmpAbortFlag, std::memory_order_acquire)) NEQCHECK(*tmpAbortFlag, 0); \
+  } while (!(cond))
 
-#define NCCLWAITGOTO(call, cond, abortFlagPtr, RES, label) do { \
-  uint32_t* tmpAbortFlag = (abortFlagPtr);             \
-  RES = call;                             \
-  if (RES != ncclSuccess && RES != ncclInProgress) {               \
-    if (ncclDebugNoWarn == 0) INFO(NCCL_ALL,"%s:%d -> %d", __FILE__, __LINE__, RES);    \
-    goto label;                           \
-  }                                       \
-  if (COMPILER_ATOMIC_LOAD(tmpAbortFlag, std::memory_order_acquire)) NEQCHECKGOTO(*tmpAbortFlag, 0, RES, label); \
-} while (!(cond))
+#define NCCLWAITGOTO(call, cond, abortFlagPtr, RES, label) \
+  do { \
+    uint32_t* tmpAbortFlag = (abortFlagPtr); \
+    RES = call; \
+    if (RES != ncclSuccess && RES != ncclInProgress) { \
+      if (ncclDebugNoWarn == 0) INFO(NCCL_ALL, "%s:%d -> %d", __FILE__, __LINE__, RES); \
+      goto label; \
+    } \
+    if (COMPILER_ATOMIC_LOAD(tmpAbortFlag, std::memory_order_acquire)) NEQCHECKGOTO(*tmpAbortFlag, 0, RES, label); \
+  } while (!(cond))
 
-#define NCCLCHECKTHREAD(a, args) do { \
-  if (((args)->ret = (a)) != ncclSuccess && (args)->ret != ncclInProgress) { \
-    INFO(NCCL_INIT,"%s:%d -> %d [Async thread]", __FILE__, __LINE__, (args)->ret); \
-    return args; \
-  } \
-} while(0)
+#define NCCLCHECKTHREAD(a, args) \
+  do { \
+    if (((args)->ret = (a)) != ncclSuccess && (args)->ret != ncclInProgress) { \
+      INFO(NCCL_INIT, "%s:%d -> %d [Async thread]", __FILE__, __LINE__, (args)->ret); \
+      return args; \
+    } \
+  } while (0)
 
-#define CUDACHECKTHREAD(a) do { \
-  if ((a) != cudaSuccess) { \
-    INFO(NCCL_INIT,"%s:%d -> %d [Async thread]", __FILE__, __LINE__, args->ret); \
-    args->ret = ncclUnhandledCudaError; \
-    return args; \
-  } \
-} while(0)
+#define CUDACHECKTHREAD(a) \
+  do { \
+    if ((a) != cudaSuccess) { \
+      INFO(NCCL_INIT, "%s:%d -> %d [Async thread]", __FILE__, __LINE__, args->ret); \
+      args->ret = ncclUnhandledCudaError; \
+      return args; \
+    } \
+  } while (0)
 
 // Common thread creation implementation with error handling
-#define STDTHREADCREATE_IMPL(var, func, error_action, ...) do { \
-  try { \
-    (var) = std::thread(func, __VA_ARGS__); \
-  } catch (const std::exception& e) { \
-    WARN("Thread creation failed: %s", e.what()); \
-    error_action; \
-  } \
-} while(0)
+#define STDTHREADCREATE_IMPL(var, func, error_action, ...) \
+  do { \
+    try { \
+      (var) = std::thread(func, __VA_ARGS__); \
+    } catch (const std::exception& e) { \
+      WARN("Thread creation failed: %s", e.what()); \
+      error_action; \
+    } \
+  } while (0)
 
-#define STDTHREADCREATE(var, func, ...) \
-  STDTHREADCREATE_IMPL(var, func, return ncclSystemError, __VA_ARGS__)
+#define STDTHREADCREATE(var, func, ...) STDTHREADCREATE_IMPL(var, func, return ncclSystemError, __VA_ARGS__)
 
 #define STDTHREADCREATE_GOTO(var, func, RES, label, ...) \
-  STDTHREADCREATE_IMPL(var, func, do { RES = ncclSystemError; goto label; } while(0), __VA_ARGS__)
+  STDTHREADCREATE_IMPL( \
+    var, func, \
+    do { \
+      RES = ncclSystemError; \
+      goto label; \
+    } while (0), \
+    __VA_ARGS__)
 
-#define NEW_NOTHROW(var, x) do { \
-  (var) = new (std::nothrow) x{}; \
-  if (!(var)) { \
-    WARN("Allocation failed at %s:%d", __FILE__, __LINE__); \
-    return ncclSystemError; \
-  } \
-} while(0)
+#define NEW_NOTHROW(var, x) \
+  do { \
+    (var) = new (std::nothrow) x{}; \
+    if (!(var)) { \
+      WARN("Allocation failed at %s:%d", __FILE__, __LINE__); \
+      return ncclSystemError; \
+    } \
+  } while (0)
 
-#define NEW_NOTHROW_GOTO(var, x, RES, label) do { \
-  (var) = new (std::nothrow) x{}; \
-  if (!(var)) { \
-    WARN("Allocation failed at %s:%d", __FILE__, __LINE__); \
-    RES = ncclSystemError; \
-    goto label; \
-  } \
-} while(0)
+#define NEW_NOTHROW_GOTO(var, x, RES, label) \
+  do { \
+    (var) = new (std::nothrow) x{}; \
+    if (!(var)) { \
+      WARN("Allocation failed at %s:%d", __FILE__, __LINE__); \
+      RES = ncclSystemError; \
+      goto label; \
+    } \
+  } while (0)
 
 #endif

--- a/projects/rccl/src/include/coll_net.h
+++ b/projects/rccl/src/include/coll_net.h
@@ -15,24 +15,77 @@
 typedef char collNetHandle_t[NCCL_NET_HANDLE_MAXSIZE];
 
 // Translation to external API
-static const char* collNetName(struct ncclComm* comm) { return comm->ncclCollNet->name; }
-static ncclResult_t collNetDevices(struct ncclComm* comm, int* ndev) { NCCLCHECK(comm->ncclCollNet->devices(ndev)); return ncclSuccess; }
-static ncclResult_t collNetGetProperties(struct ncclComm* comm, int dev, ncclNetProperties_t* props) { NCCLCHECK(comm->ncclCollNet->getProperties(dev, props)); return ncclSuccess; }
-static ncclResult_t collNetListen(struct ncclComm* comm, int dev, void* handle, void** listenComm) { NCCLCHECK(comm->ncclCollNet->listen(comm->collNetContext, dev, handle, listenComm)); return ncclSuccess; }
-static ncclResult_t collNetConnect(struct ncclComm* comm, void* handles[], int nranks, int rank, void* listenComm, void** collComm) { NCCLCHECK(comm->ncclCollNet->connect(handles, nranks, rank, listenComm, collComm)); return ncclSuccess; }
-static ncclResult_t collNetReduceSupport(struct ncclComm* comm, ncclDataType_t dataType, ncclRedOp_t redOp, int* supported) { NCCLCHECK(comm->ncclCollNet->reduceSupport(dataType, redOp, supported)); return ncclSuccess; }
-static ncclResult_t collNetRegMr(struct ncclComm* comm, void* collComm, void* data, size_t size, int type, void** mhandle) { NCCLCHECK(comm->ncclCollNet->regMr(collComm, data, size, type, mhandle)); return ncclSuccess; }
+static const char* collNetName(struct ncclComm* comm) {
+  return comm->ncclCollNet->name;
+}
+static ncclResult_t collNetDevices(struct ncclComm* comm, int* ndev) {
+  NCCLCHECK(comm->ncclCollNet->devices(ndev));
+  return ncclSuccess;
+}
+static ncclResult_t collNetGetProperties(struct ncclComm* comm, int dev, ncclNetProperties_t* props) {
+  NCCLCHECK(comm->ncclCollNet->getProperties(dev, props));
+  return ncclSuccess;
+}
+static ncclResult_t collNetListen(struct ncclComm* comm, int dev, void* handle, void** listenComm) {
+  NCCLCHECK(comm->ncclCollNet->listen(comm->collNetContext, dev, handle, listenComm));
+  return ncclSuccess;
+}
+static ncclResult_t collNetConnect(struct ncclComm* comm, void* handles[], int nranks, int rank, void* listenComm,
+                                   void** collComm) {
+  NCCLCHECK(comm->ncclCollNet->connect(handles, nranks, rank, listenComm, collComm));
+  return ncclSuccess;
+}
+static ncclResult_t collNetReduceSupport(struct ncclComm* comm, ncclDataType_t dataType, ncclRedOp_t redOp,
+                                         int* supported) {
+  NCCLCHECK(comm->ncclCollNet->reduceSupport(dataType, redOp, supported));
+  return ncclSuccess;
+}
+static ncclResult_t collNetRegMr(struct ncclComm* comm, void* collComm, void* data, size_t size, int type,
+                                 void** mhandle) {
+  NCCLCHECK(comm->ncclCollNet->regMr(collComm, data, size, type, mhandle));
+  return ncclSuccess;
+}
 /* DMA-BUF support */
-static ncclResult_t collNetRegMrDmaBuf(struct ncclComm* comm, void* collComm, void* data, size_t size, int type, uint64_t offset, int fd, void** mhandle) { NCCLCHECK(comm->ncclCollNet->regMrDmaBuf(collComm, data, size, type, offset, fd, mhandle)); return ncclSuccess; }
-static ncclResult_t collNetDeregMr(struct ncclComm* comm, void* collComm, void* mhandle) { NCCLCHECK(comm->ncclCollNet->deregMr(collComm, mhandle)); return ncclSuccess; }
-static ncclResult_t collNetIallreduce(struct ncclComm* comm, void* collComm, void* sendData, void* recvData, int count, ncclDataType_t dataType, ncclRedOp_t redOp, void* sendMhandle, void* recvMhandle,  void** request) {
-  NCCLCHECK(comm->ncclCollNet->iallreduce(collComm, sendData, recvData, count, dataType, redOp, sendMhandle, recvMhandle, request)); return ncclSuccess; }
-static ncclResult_t collNetIflush(struct ncclComm* comm, void* collComm, void* data, int size, void* mhandle, void** request) { NCCLCHECK(comm->ncclCollNet->iflush(collComm, data, size, mhandle, request)); return ncclSuccess; }
-static ncclResult_t collNetTest(struct ncclComm* comm, void* request, int* done, int* size) { NCCLCHECK(comm->ncclCollNet->test(request, done, size)); return ncclSuccess; }
-static ncclResult_t collNetCloseColl(struct ncclComm* comm, void* collComm) { NCCLCHECK(comm->ncclCollNet->closeColl(collComm)); return ncclSuccess; }
-static ncclResult_t collNetCloseListen(struct ncclComm* comm, void* listenComm) { NCCLCHECK(comm->ncclCollNet->closeListen(listenComm)); return ncclSuccess; }
-static ncclResult_t collNetFinalize(struct ncclComm* comm, void* ctx) { NCCLCHECK(comm->ncclCollNet->finalize(ctx)); return ncclSuccess; }
+static ncclResult_t collNetRegMrDmaBuf(struct ncclComm* comm, void* collComm, void* data, size_t size, int type,
+                                       uint64_t offset, int fd, void** mhandle) {
+  NCCLCHECK(comm->ncclCollNet->regMrDmaBuf(collComm, data, size, type, offset, fd, mhandle));
+  return ncclSuccess;
+}
+static ncclResult_t collNetDeregMr(struct ncclComm* comm, void* collComm, void* mhandle) {
+  NCCLCHECK(comm->ncclCollNet->deregMr(collComm, mhandle));
+  return ncclSuccess;
+}
+static ncclResult_t collNetIallreduce(struct ncclComm* comm, void* collComm, void* sendData, void* recvData, int count,
+                                      ncclDataType_t dataType, ncclRedOp_t redOp, void* sendMhandle, void* recvMhandle,
+                                      void** request) {
+  NCCLCHECK(comm->ncclCollNet->iallreduce(collComm, sendData, recvData, count, dataType, redOp, sendMhandle,
+                                          recvMhandle, request));
+  return ncclSuccess;
+}
+static ncclResult_t collNetIflush(struct ncclComm* comm, void* collComm, void* data, int size, void* mhandle,
+                                  void** request) {
+  NCCLCHECK(comm->ncclCollNet->iflush(collComm, data, size, mhandle, request));
+  return ncclSuccess;
+}
+static ncclResult_t collNetTest(struct ncclComm* comm, void* request, int* done, int* size) {
+  NCCLCHECK(comm->ncclCollNet->test(request, done, size));
+  return ncclSuccess;
+}
+static ncclResult_t collNetCloseColl(struct ncclComm* comm, void* collComm) {
+  NCCLCHECK(comm->ncclCollNet->closeColl(collComm));
+  return ncclSuccess;
+}
+static ncclResult_t collNetCloseListen(struct ncclComm* comm, void* listenComm) {
+  NCCLCHECK(comm->ncclCollNet->closeListen(listenComm));
+  return ncclSuccess;
+}
+static ncclResult_t collNetFinalize(struct ncclComm* comm, void* ctx) {
+  NCCLCHECK(comm->ncclCollNet->finalize(ctx));
+  return ncclSuccess;
+}
 
-static int collNetSupport(struct ncclComm* comm) { return comm->ncclCollNet != nullptr ? 1 : 0; }
+static int collNetSupport(struct ncclComm* comm) {
+  return comm->ncclCollNet != nullptr ? 1 : 0;
+}
 
 #endif

--- a/projects/rccl/src/include/collectives.h
+++ b/projects/rccl/src/include/collectives.h
@@ -14,23 +14,23 @@
 #include "device.h"
 #include "compiler.h"
 
-#define NCCL_MAX_NET_SIZE (1024*1024*1024L) // Rather than send INT_MAX which is 2G-1, send a power of two.
+#define NCCL_MAX_NET_SIZE (1024 * 1024 * 1024L) // Rather than send INT_MAX which is 2G-1, send a power of two.
 
 // CHUNKSIZE must be a multiple of SLICESIZE
 // RCCL: Benchmarking on single node for MI300X showed improved throughput for single node always using
 // a single slice, so we have separate configurations for single node and multi-node.  Single node configs
 // are suffixed with _SINGLE_NODE.
-#define ALLREDUCE_SLICESTEPS (NCCL_STEPS/4)
-#define ALLREDUCE_SLICESTEPS_SINGLE_NODE (NCCL_STEPS/2)
-#define ALLREDUCE_CHUNKSTEPS (NCCL_STEPS/2)
-#define ALLGATHER_SLICESTEPS (NCCL_STEPS/4)
-#define ALLGATHER_SLICESTEPS_SINGLE_NODE (NCCL_STEPS/2)
-#define ALLGATHER_CHUNKSTEPS (NCCL_STEPS/2)
+#define ALLREDUCE_SLICESTEPS (NCCL_STEPS / 4)
+#define ALLREDUCE_SLICESTEPS_SINGLE_NODE (NCCL_STEPS / 2)
+#define ALLREDUCE_CHUNKSTEPS (NCCL_STEPS / 2)
+#define ALLGATHER_SLICESTEPS (NCCL_STEPS / 4)
+#define ALLGATHER_SLICESTEPS_SINGLE_NODE (NCCL_STEPS / 2)
+#define ALLGATHER_CHUNKSTEPS (NCCL_STEPS / 2)
 #define ALLTOALL_SLICESTEPS 1
 #define ALLTOALL_CHUNKSTEPS 1
-#define REDUCESCATTER_SLICESTEPS (NCCL_STEPS/4)
-#define REDUCESCATTER_SLICESTEPS_SINGLE_NODE (NCCL_STEPS/2)
-#define REDUCESCATTER_CHUNKSTEPS (NCCL_STEPS/2)
+#define REDUCESCATTER_SLICESTEPS (NCCL_STEPS / 4)
+#define REDUCESCATTER_SLICESTEPS_SINGLE_NODE (NCCL_STEPS / 2)
+#define REDUCESCATTER_CHUNKSTEPS (NCCL_STEPS / 2)
 #define BROADCAST_SLICESTEPS 1
 #define BROADCAST_CHUNKSTEPS 1
 #define GATHER_SLICESTEPS 1
@@ -40,13 +40,16 @@
 #define REDUCE_SLICESTEPS 1
 #define REDUCE_CHUNKSTEPS 1
 #define NCCL_MAX_SLICE_PER_CHUNK 2  // max value for CHUNKSTEPS/SLICESTEPS, must accord with above
-#define NCCL_MAX_NET_SIZE (1024*1024*1024L) // Rather than send INT_MAX which is 2G-1, send a power of two.
+#define NCCL_MAX_NET_SIZE (1024 * 1024 * 1024L) // Rather than send INT_MAX which is 2G-1, send a power of two.
 #define ALLTOALL_PIVOT_SLICESTEPS 2
 #define ALLTOALL_PIVOT_CHUNKSTEPS 4
 
-static_assert(ALLREDUCE_CHUNKSTEPS == ALLREDUCE_SLICESTEPS_SINGLE_NODE, "ALLREDUCE_CHUNKSTEPS must be equal to ALLREDUCE_SLICESTEPS_SINGLE_NODE");
-static_assert(ALLGATHER_CHUNKSTEPS == ALLGATHER_SLICESTEPS_SINGLE_NODE, "ALLGATHER_CHUNKSTEPS must be equal to ALLGATHER_SLICESTEPS_SINGLE_NODE");
-static_assert(REDUCESCATTER_CHUNKSTEPS == REDUCESCATTER_SLICESTEPS_SINGLE_NODE, "REDUCESCATTER_CHUNKSTEPS must be equal to REDUCESCATTER_SLICESTEPS_SINGLE_NODE");
+static_assert(ALLREDUCE_CHUNKSTEPS == ALLREDUCE_SLICESTEPS_SINGLE_NODE,
+              "ALLREDUCE_CHUNKSTEPS must be equal to ALLREDUCE_SLICESTEPS_SINGLE_NODE");
+static_assert(ALLGATHER_CHUNKSTEPS == ALLGATHER_SLICESTEPS_SINGLE_NODE,
+              "ALLGATHER_CHUNKSTEPS must be equal to ALLGATHER_SLICESTEPS_SINGLE_NODE");
+static_assert(REDUCESCATTER_CHUNKSTEPS == REDUCESCATTER_SLICESTEPS_SINGLE_NODE,
+              "REDUCESCATTER_CHUNKSTEPS must be equal to REDUCESCATTER_SLICESTEPS_SINGLE_NODE");
 
 const char* ncclFuncToString(ncclFunc_t op);
 const char* ncclDevRedOpToString(ncclDevRedOp_t op);
@@ -81,7 +84,7 @@ inline int ncclTypeSize(ncclDataType_t type) {
 
 #define NCCL_MODE_NORMAL 0
 #define NCCL_MODE_OFFSET 1
-#define NCCL_MODE_PTR    2
+#define NCCL_MODE_PTR 2
 struct ncclConnFifo {
   int mode;
   int offset;
@@ -101,11 +104,12 @@ protected:
   ssize_t sliceSize;
   ssize_t loopSize;
   ssize_t channelSize;
-  uint8_t *sendbuff;
-  uint8_t *recvbuff;
-  void *sendMhandle;
-  void *recvMhandle;
-  void *srecvMhandle;
+  uint8_t* sendbuff;
+  uint8_t* recvbuff;
+  void* sendMhandle;
+  void* recvMhandle;
+  void* srecvMhandle;
+
 public:
   // this ring class is used by proxy thread to retrieve the send and recv buffer, size as well as corresponding
   // mem handle based on the current step of the proxy args. The derived ring algo class is AR, AG, and BC which
@@ -113,15 +117,17 @@ public:
   // increase the refCount by incRefCount() since the same ring algo object can be referenced multiple times for send
   // and recv progress. After all steps are done, we decrease the refCount and only delete the ring object when
   // refCount == 0.
-  virtual void getNextSendAddr(int curStep, uint8_t **sendbuffOut, size_t *sizeOut, void **mhandleOut) = 0;
-  virtual void getNextRecvAddr(int curStep, uint8_t **recvbuffOut, size_t *sizeOut, void **mhandleOut) = 0;
+  virtual void getNextSendAddr(int curStep, uint8_t** sendbuffOut, size_t* sizeOut, void** mhandleOut) = 0;
+  virtual void getNextRecvAddr(int curStep, uint8_t** recvbuffOut, size_t* sizeOut, void** mhandleOut) = 0;
   int incRefCount() {
     return (int)COMPILER_ATOMIC_ADD_FETCH(&refCount, 1, std::memory_order_relaxed);
   }
   int decRefCount() {
     return (int)COMPILER_ATOMIC_SUB_FETCH(&refCount, 1, std::memory_order_release);
   }
-  RingAlgorithm() { refCount = 0; }
+  RingAlgorithm() {
+    refCount = 0;
+  }
   virtual ~RingAlgorithm() {};
 };
 
@@ -131,8 +137,9 @@ private:
   int elemSize;
   ssize_t chunkSize;
   int slicePerChunk;
+
 public:
-  void getNextSendAddr(int curStep, uint8_t **sendbuffOut, size_t *sizeOut, void **mhandleOut) {
+  void getNextSendAddr(int curStep, uint8_t** sendbuffOut, size_t* sizeOut, void** mhandleOut) {
     int curLoop = curStep / nStepsPerLoop;
     int curLoopStage = (curStep % nStepsPerLoop) / chunkSteps;
     int chunkStage = curLoopStage % nRanks;
@@ -175,7 +182,7 @@ public:
     return;
   }
 
-  void getNextRecvAddr(int curStep, uint8_t **recvbuffOut, size_t *sizeOut, void **mhandleOut) {
+  void getNextRecvAddr(int curStep, uint8_t** recvbuffOut, size_t* sizeOut, void** mhandleOut) {
     int curLoop = curStep / nStepsPerLoop;
     int curLoopStage = ((curStep + chunkSteps) % nStepsPerLoop) / chunkSteps;
     int chunkStage = curLoopStage % nRanks;
@@ -219,7 +226,9 @@ public:
     return;
   }
 
-  RingARAlgorithm(const void *sendbuff, void *recvbuff, int nRanks, int ringIndex, int chunkSteps, int sliceSteps, size_t chunkSize, size_t sliceSize, size_t gridOffset, size_t channelSize, int elemSize, void *sendMhandle, void *recvMhandle, void *srecvMhandle) {
+  RingARAlgorithm(const void* sendbuff, void* recvbuff, int nRanks, int ringIndex, int chunkSteps, int sliceSteps,
+                  size_t chunkSize, size_t sliceSize, size_t gridOffset, size_t channelSize, int elemSize,
+                  void* sendMhandle, void* recvMhandle, void* srecvMhandle) {
     this->ringIndex = ringIndex;
     this->nRanks = nRanks;
     this->nStepsPerLoop = 2 * (nRanks - 1) * chunkSteps;
@@ -242,12 +251,13 @@ public:
 
 class RingAGAlgorithm : public RingAlgorithm {
 private:
-  int *ringRanks;
+  int* ringRanks;
   int elemSize;
   ssize_t sendSize;
   int slicePerChunk;
+
 public:
-  void getNextSendAddr(int curStep, uint8_t **sendbuffOut, size_t *sizeOut, void **mhandleOut) {
+  void getNextSendAddr(int curStep, uint8_t** sendbuffOut, size_t* sizeOut, void** mhandleOut) {
     int curLoop = curStep / nStepsPerLoop;
     int chunkStage = (curStep % nStepsPerLoop) / chunkSteps;
     int sliceStage = (curStep % chunkSteps) / sliceSteps;
@@ -258,8 +268,8 @@ public:
     ssize_t chunkSize = std::min(loopSize, channelSize - elemOffset);
     ssize_t size;
     int rankDest;
-    uint8_t *buff;
-    void *mhandle;
+    uint8_t* buff;
+    void* mhandle;
 
     curSliceSize = std::max(divUp(chunkSize / elemSize, 16 * slicePerChunk) * 16, sliceSize / elemSize / 32) * elemSize;
     sliceOffset = sliceStage * curSliceSize;
@@ -281,7 +291,7 @@ public:
     return;
   }
 
-  void getNextRecvAddr(int curStep, uint8_t **recvbuffOut, size_t *sizeOut, void **mhandleOut) {
+  void getNextRecvAddr(int curStep, uint8_t** recvbuffOut, size_t* sizeOut, void** mhandleOut) {
     int curLoop = curStep / nStepsPerLoop;
     int chunkStage = ((curStep + chunkSteps) % nStepsPerLoop) / chunkSteps;
     int sliceStage = (curStep % chunkSteps) / sliceSteps;
@@ -309,7 +319,9 @@ public:
     *mhandleOut = recvMhandle;
   }
 
-  RingAGAlgorithm(const void *sendbuff, void *recvbuff, int nRanks, int *ringRanks, int chunkSteps, int sliceSteps, size_t chunkSize, size_t sliceSize, size_t gridOffset, size_t channelSize, int elemSize, size_t sendSize, void *sendMhandle, void *recvMhandle, void *srecvMhandle) {
+  RingAGAlgorithm(const void* sendbuff, void* recvbuff, int nRanks, int* ringRanks, int chunkSteps, int sliceSteps,
+                  size_t chunkSize, size_t sliceSize, size_t gridOffset, size_t channelSize, int elemSize,
+                  size_t sendSize, void* sendMhandle, void* recvMhandle, void* srecvMhandle) {
     this->ringRanks = ringRanks;
     this->nRanks = nRanks;
     this->nStepsPerLoop = (nRanks - 1) * chunkSteps;
@@ -335,16 +347,17 @@ private:
   int root;
   int rank;
   int nextRank;
+
 public:
-  void getNextSendAddr(int curStep, uint8_t **sendbuffOut, size_t *sizeOut, void **mhandleOut) {
+  void getNextSendAddr(int curStep, uint8_t** sendbuffOut, size_t* sizeOut, void** mhandleOut) {
     int curLoop = curStep / nStepsPerLoop;
     int sliceStage = (curStep % chunkSteps) / sliceSteps;
     ssize_t sliceOffset = sliceStage * sliceSize;
     ssize_t offset;
     ssize_t elemOffset = curLoop * loopSize;
     ssize_t size;
-    uint8_t *buff;
-    void *mhandle;
+    uint8_t* buff;
+    void* mhandle;
 
     offset = elemOffset + sliceOffset;
     if (offset >= channelSize) {
@@ -364,7 +377,7 @@ public:
     return;
   }
 
-  void getNextRecvAddr(int curStep, uint8_t **recvbuffOut, size_t *sizeOut, void **mhandleOut) {
+  void getNextRecvAddr(int curStep, uint8_t** recvbuffOut, size_t* sizeOut, void** mhandleOut) {
     int curLoop = curStep / nStepsPerLoop;
     int sliceStage = (curStep % chunkSteps) / sliceSteps;
     ssize_t sliceOffset = sliceStage * sliceSize;
@@ -385,7 +398,9 @@ public:
     return;
   }
 
-  RingBCAlgorithm(const void* sendbuff, void* recvbuff, int rank, int root, int nRanks, int *ringRanks, int chunkSteps, int sliceSteps, size_t chunkSize, size_t sliceSize, size_t gridOffset, size_t channelSize, void *sendMhandle, void *recvMhandle, void *srecvMhandle) {
+  RingBCAlgorithm(const void* sendbuff, void* recvbuff, int rank, int root, int nRanks, int* ringRanks, int chunkSteps,
+                  int sliceSteps, size_t chunkSize, size_t sliceSize, size_t gridOffset, size_t channelSize,
+                  void* sendMhandle, void* recvMhandle, void* srecvMhandle) {
     this->root = root;
     this->rank = rank;
     this->nextRank = ringRanks[1];
@@ -404,15 +419,14 @@ public:
   ~RingBCAlgorithm() {}
 };
 
-#if !defined (__CUDA_ARCH__) || __CUDA_ARCH__ >= 600
+#if !defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 600
 // #include <cuda/atomic>
 #endif
 
 // Need a power of two to ensure it divides by parallelFactor (which is also a power of two)
 #define NCCL_PAT_NWORKERS 128
 
-static constexpr int PatUsed = 0x1,
-                     PatSkipped = 0x2;
+static constexpr int PatUsed = 0x1, PatSkipped = 0x2;
 
 struct ncclPatStep {
   int recvDim, sendDim, recvOffset, sendOffset, stepOffset, postRecv, postSend, nelem, last, flags;
@@ -420,15 +434,15 @@ struct ncclPatStep {
 };
 
 struct ncclPatPeer {
-    uint64_t step;
-    struct ncclConnInfo* conn;
-    struct ncclConnFifo* connFifo;
-    void* buff;
-    uint64_t *headPtr;
-    uint64_t *tailPtr;
-    uint64_t stepCache;
-    long long int accSize;
-    int connStepSize;
+  uint64_t step;
+  struct ncclConnInfo* conn;
+  struct ncclConnFifo* connFifo;
+  void* buff;
+  uint64_t* headPtr;
+  uint64_t* tailPtr;
+  uint64_t stepCache;
+  long long int accSize;
+  int connStepSize;
 };
 
 #define NCCL_SHMEM_PAT_STEPS 32
@@ -440,8 +454,8 @@ struct ncclPatShmem {
   struct ncclPatPeer recvDims[32];
 };
 
-template<typename T>
-class PatRSAlgorithm{
+template <typename T>
+class PatRSAlgorithm {
   size_t offset;
   size_t end;
   size_t count;
@@ -463,17 +477,17 @@ class PatRSAlgorithm{
   int phase;
 
   __device__ __host__ ssize_t min(ssize_t a, ssize_t b) {
-    return (a<b)?a:b;
+    return (a < b) ? a : b;
   }
 
   __device__ __host__ int getNelem() {
-    return min(chunkCount, end-offset);
+    return min(chunkCount, end - offset);
   }
 
   __device__ __host__ int mirrorInvert(int i, int max) {
     int ret = 0;
-    for (int mask=1, imask=max/2; mask<max; mask<<=1, imask>>=1) {
-      if ((i&mask) == 0) ret += imask;
+    for (int mask = 1, imask = max / 2; mask < max; mask <<= 1, imask >>= 1) {
+      if ((i & mask) == 0) ret += imask;
     }
     return ret;
   }
@@ -485,14 +499,14 @@ class PatRSAlgorithm{
 #else
       COMPILER_FFS(i);
 #endif
-    return ffs ? ffs-1 : max;
+    return ffs ? ffs - 1 : max;
   }
 
   __device__ __host__ void resetA() {
     a = 0;
     sendSkipped = stepOffset = 0;
     lastA = aggFactor;
-    if (phase >= 2) lastA /= 2*scale;
+    if (phase >= 2) lastA /= 2 * scale;
     if (phase == 4) lastA = 1;
   }
 
@@ -517,26 +531,27 @@ class PatRSAlgorithm{
   // Return 1 when only upper bits are set. For example, if nrpow2==16 we'll return 1 for 8, 12, 14, 15.
   // A number being in the form of 1111000 implies that the complementary is 0000111 meaning it's a power of 2 minus 1.
   __device__ __host__ int newPeer(int i, int pow2) {
-    //printf("New peer %d/%d -> %d\n", i, pow2, nBitsSet((i ^ (pow2-1)) + 1) == 1 ? 1 : 0);
-    return nBitsSet((i ^ (pow2-1)) + 1) == 1 ? 1 : 0;
+    // printf("New peer %d/%d -> %d\n", i, pow2, nBitsSet((i ^ (pow2-1)) + 1) == 1 ? 1 : 0);
+    return nBitsSet((i ^ (pow2 - 1)) + 1) == 1 ? 1 : 0;
   }
 
 public:
-   __device__ __host__ PatRSAlgorithm(int stepSize, int stepDepth, int maxParallelFactor, size_t offset, size_t end, size_t count, int chunkCount, int rank, int nranks):
-     offset(offset), end(end), count(count), chunkCount(chunkCount), rank(rank), nranks(nranks) {
+  __device__ __host__ PatRSAlgorithm(int stepSize, int stepDepth, int maxParallelFactor, size_t offset, size_t end,
+                                     size_t count, int chunkCount, int rank, int nranks)
+    : offset(offset), end(end), count(count), chunkCount(chunkCount), rank(rank), nranks(nranks) {
     parallelFactor = maxParallelFactor;
-    aggDelta = nrPow2 = (1<<log2Up(nranks));
+    aggDelta = nrPow2 = (1 << log2Up(nranks));
 
     aggFactor = 1;
-    size_t channelSize = end-offset;
-    while (stepSize / (channelSize*sizeof(T)*aggFactor) >= 2 && aggFactor < nranks/2) {
+    size_t channelSize = end - offset;
+    while (stepSize / (channelSize * sizeof(T) * aggFactor) >= 2 && aggFactor < nranks / 2) {
       aggFactor *= 2;
       aggDelta /= 2;
     }
     postFreq = aggFactor;
     if (postFreq < parallelFactor) parallelFactor = postFreq;
     int d = stepDepth;
-    while (d > 1 && aggFactor < nranks/2) {
+    while (d > 1 && aggFactor < nranks / 2) {
       d /= 2;
       aggFactor *= 2;
       aggDelta /= 2;
@@ -558,7 +573,7 @@ public:
     if (a >= lastA) {
       skip = 1;
     } else if (phase == 0) {
-      int s = mirrorInvert(a, lastA)*aggDelta + as;
+      int s = mirrorInvert(a, lastA) * aggDelta + as;
       if (s >= nranks) skip = 1;
       int sendDataRank = (rank + s) % nranks;
       ps->inpIx = sendDataRank * count + offset;
@@ -566,36 +581,39 @@ public:
       ps->sendDim = 0;
       ps->outIx = 0;
       ps->recvOffset = -1;
-      ps->sendOffset = (a%postFreq) * nelem;
-      if (((a%postFreq) + 1 >= postFreq) || (a == lastA-1)) {
+      ps->sendOffset = (a % postFreq) * nelem;
+      if (((a % postFreq) + 1 >= postFreq) || (a == lastA - 1)) {
         ps->postSend = 1;
       } else {
         ps->postSend = 0;
       }
       ps->postRecv = 0;
     } else if (phase == 1) {
-      int s = mirrorInvert(a, lastA)*aggDelta + as;
+      int s = mirrorInvert(a, lastA) * aggDelta + as;
       if (s >= nranks) skip = 1;
       ps->recvDim = firstBitSet(s, nrPow2);
-      ps->sendOffset = (a%postFreq)*nelem;
-      ps->recvOffset = (a%postFreq)*nelem;
+      ps->sendOffset = (a % postFreq) * nelem;
+      ps->recvOffset = (a % postFreq) * nelem;
       ps->postSend = 0;
-      if (ps->recvDim == 0 && (((a%postFreq) + 1 >= postFreq) || (a == lastA-1))) ps->postSend = 1;
-      if (((a%postFreq) + 1 >= postFreq) || (a == lastA-1)) {
+      if (ps->recvDim == 0 && (((a % postFreq) + 1 >= postFreq) || (a == lastA - 1))) ps->postSend = 1;
+      if (((a % postFreq) + 1 >= postFreq) || (a == lastA - 1)) {
         ps->postRecv = 1;
       } else {
         ps->postRecv = 0;
       }
-      s -= (1<<ps->recvDim);
+      s -= (1 << ps->recvDim);
       int recvDataRank = (rank + nranks + s) % nranks;
       ps->inpIx = recvDataRank * count + offset;
       ps->sendDim = s ? firstBitSet(s, nrPow2) : -1;
       if (ps->sendDim == -1) {
         ps->sendOffset = -1;
-      } else if (as - (1<<ps->recvDim) == 0) {
-        if (newPeer(a, aggFactor)) { sendSkipped = a; ps->stepOffset = stepOffset = 0; }
+      } else if (as - (1 << ps->recvDim) == 0) {
+        if (newPeer(a, aggFactor)) {
+          sendSkipped = a;
+          ps->stepOffset = stepOffset = 0;
+        }
         int foffset = a - sendSkipped;
-        ps->sendOffset = (foffset%postFreq)*nelem;
+        ps->sendOffset = (foffset % postFreq) * nelem;
       }
       int recvDim = ps->recvDim;
       if (s < nranks && skip) {
@@ -604,39 +622,39 @@ public:
         ps->postRecv = 0;
         skip = 0;
       }
-      if (recvDim > 0 && (((a-sendSkipped)%postFreq) + 1 >= postFreq) && skip == 0) stepOffset++;
+      if (recvDim > 0 && (((a - sendSkipped) % postFreq) + 1 >= postFreq) && skip == 0) stepOffset++;
     } else if (phase == 2) {
-      int s = (2*mirrorInvert(a, lastA)+1)*scale*aggDelta + 1;
+      int s = (2 * mirrorInvert(a, lastA) + 1) * scale * aggDelta + 1;
       ps->postRecv = 0;
       if (s >= nranks) skip = 1;
       ps->recvDim = 0;
-      ps->postSend = a == lastA-1 ? 1 : 0;
+      ps->postSend = a == lastA - 1 ? 1 : 0;
       s -= 1;
       if (s < nranks && skip) {
         ps->recvDim = -1;
         ps->recvOffset = -1;
         skip = 0;
       } else if (!skip) {
-        int foffset = a + aggFactor - aggFactor/scale;
-        ps->postRecv |= ((foffset+1)%postFreq) == 0 ? 1 : 0;
-        ps->recvOffset = (foffset%postFreq) * nelem;
+        int foffset = a + aggFactor - aggFactor / scale;
+        ps->postRecv |= ((foffset + 1) % postFreq) == 0 ? 1 : 0;
+        ps->recvOffset = (foffset % postFreq) * nelem;
       }
       int recvDataRank = (rank + nranks + s) % nranks;
       ps->inpIx = recvDataRank * count + offset;
       ps->sendDim = s ? firstBitSet(s, nrPow2) : -1;
       int foffset = a;
-      ps->postSend |= ((foffset+1)%postFreq) == 0 ? 1 : 0;
-      ps->sendOffset = (foffset%postFreq) * nelem;
+      ps->postSend |= ((foffset + 1) % postFreq) == 0 ? 1 : 0;
+      ps->sendOffset = (foffset % postFreq) * nelem;
     } else if (phase == 3) {
-      int s = (2*mirrorInvert(a, lastA)+1)*scale*aggDelta;
-      ps->postRecv = a == lastA-1 ? 1 : 0;
+      int s = (2 * mirrorInvert(a, lastA) + 1) * scale * aggDelta;
+      ps->postRecv = a == lastA - 1 ? 1 : 0;
       if (s >= nranks) skip = 1;
       ps->recvDim = firstBitSet(s, nrPow2);
       ps->postSend = 0;
-      s -= (1<<ps->recvDim);
+      s -= (1 << ps->recvDim);
       int foffset = a;
-      ps->postRecv |= (foffset+1)%postFreq == 0 ? 1 : 0;
-      ps->recvOffset = (foffset%postFreq) * nelem;
+      ps->postRecv |= (foffset + 1) % postFreq == 0 ? 1 : 0;
+      ps->recvOffset = (foffset % postFreq) * nelem;
       int recvDataRank = (rank + nranks + s) % nranks;
       ps->inpIx = recvDataRank * count + offset;
       ps->sendDim = s ? firstBitSet(s, nrPow2) : -1;
@@ -646,15 +664,18 @@ public:
         ps->postRecv = 0;
         skip = 0;
       }
-      if (newPeer(a, aggFactor/(2*scale))) { sendSkipped = a; ps->stepOffset = stepOffset = 0; }
+      if (newPeer(a, aggFactor / (2 * scale))) {
+        sendSkipped = a;
+        ps->stepOffset = stepOffset = 0;
+      }
       foffset = a - sendSkipped;
-      if ((foffset%postFreq) + 1 >= postFreq && skip == 0) stepOffset++;
-      ps->sendOffset = ps->sendDim >= 0 ? (foffset%postFreq) * nelem : -1;
+      if ((foffset % postFreq) + 1 >= postFreq && skip == 0) stepOffset++;
+      ps->sendOffset = ps->sendDim >= 0 ? (foffset % postFreq) * nelem : -1;
     } else if (phase == 4) {
       ps->recvDim = 0;
       ps->sendDim = -1;
       ps->inpIx = rank * count + offset;
-      ps->recvOffset = ((aggFactor-1)%postFreq) * nelem;
+      ps->recvOffset = ((aggFactor - 1) % postFreq) * nelem;
       ps->sendOffset = -1;
       ps->postRecv = 1;
       ps->postSend = 0;
@@ -665,12 +686,11 @@ public:
       int p = phase;
       if (p == 1) as--;
       if (p == 3) scale *= 2;
-      phase =
-        p == 0 ? as == 1 ? (aggFactor > 1 ? 2 : 4) : 1 :
-        p == 1 ? as % 2 == 1 ? 0 : 1 :
-        p == 2 ? 3 :
-        p == 3 ? scale < aggFactor ? 2 : 4 :
-        5;
+      phase = p == 0 ? as == 1 ? (aggFactor > 1 ? 2 : 4) : 1 :
+              p == 1 ? as % 2 == 1 ? 0 : 1 :
+              p == 2 ? 3 :
+              p == 3 ? scale < aggFactor ? 2 : 4 :
+                       5;
       if (p == 4) {
         if (offset >= end) {
           ps->last = 2;
@@ -693,8 +713,8 @@ public:
   }
 };
 
-template<typename T>
-class PatAGAlgorithm{
+template <typename T>
+class PatAGAlgorithm {
   size_t offset;
   size_t end;
   size_t count;
@@ -720,17 +740,17 @@ class PatAGAlgorithm{
   int bitZeroStep[32];
 
   __device__ __host__ ssize_t min(ssize_t a, ssize_t b) {
-    return (a<b)?a:b;
+    return (a < b) ? a : b;
   }
 
   __device__ __host__ int getNelem() {
-    return min(chunkCount, end-offset);
+    return min(chunkCount, end - offset);
   }
 
   __device__ __host__ int mirror(int i, int max) {
     int ret = 0;
-    for (int mask=1, imask=max/2; mask<max; mask<<=1, imask>>=1) {
-      if ((i&mask)) ret += imask;
+    for (int mask = 1, imask = max / 2; mask < max; mask <<= 1, imask >>= 1) {
+      if ((i & mask)) ret += imask;
     }
     return ret;
   }
@@ -742,22 +762,22 @@ class PatAGAlgorithm{
 #else
       COMPILER_FFS(i);
 #endif
-    return ffs ? ffs-1 : max;
+    return ffs ? ffs - 1 : max;
   }
 
   __device__ __host__ void resetA() {
     a = 0;
     lastA = aggFactor;
-    if (phase >= 2) lastA /= 2*scale;
+    if (phase >= 2) lastA /= 2 * scale;
   }
 
   __device__ __host__ void reset() {
     nelem = getNelem();
-    scale = aggFactor/2;
+    scale = aggFactor / 2;
     phase = scale ? 2 : 1;
     v = 0;
-    for (int i = 0; i<asDim; i++) {
-      bitCount[i] = asDim-i;
+    for (int i = 0; i < asDim; i++) {
+      bitCount[i] = asDim - i;
       bitZeroStep[i] = 1;
     }
     as = nextAs();
@@ -765,13 +785,13 @@ class PatAGAlgorithm{
   }
 
   __device__ __host__ int nextAs() {
-    for (int d=0; d<asDim; d++) {
-      int p = 1<<d;
+    for (int d = 0; d < asDim; d++) {
+      int p = 1 << d;
       bitCount[d]--;
       if (bitCount[d] == 0) {
         v ^= p;
         bitCount[d] = p;
-        if ((v&p) == 0) {
+        if ((v & p) == 0) {
           bitCount[d] += firstBitSet(bitZeroStep[d], asDim) - 1;
           if (bitCount[d] == 0) {
             v ^= p;
@@ -784,23 +804,23 @@ class PatAGAlgorithm{
     return v;
   }
 
-
 public:
-   __device__ __host__ PatAGAlgorithm(int stepSize, int stepDepth, int maxParallelFactor, size_t offset, size_t end, size_t count, int chunkCount, int rank, int nranks):
-     offset(offset), end(end), count(count), chunkCount(chunkCount), rank(rank), nranks(nranks) {
+  __device__ __host__ PatAGAlgorithm(int stepSize, int stepDepth, int maxParallelFactor, size_t offset, size_t end,
+                                     size_t count, int chunkCount, int rank, int nranks)
+    : offset(offset), end(end), count(count), chunkCount(chunkCount), rank(rank), nranks(nranks) {
     parallelFactor = maxParallelFactor;
-    aggDelta = nrPow2 = (1<<log2Up(nranks));
+    aggDelta = nrPow2 = (1 << log2Up(nranks));
 
     aggFactor = 1;
-    size_t channelSize = end-offset;
-    while (stepSize / (channelSize*sizeof(T)*aggFactor) >= 2 && aggFactor < nranks/2) {
+    size_t channelSize = end - offset;
+    while (stepSize / (channelSize * sizeof(T) * aggFactor) >= 2 && aggFactor < nranks / 2) {
       aggFactor *= 2;
       aggDelta /= 2;
     }
     postFreq = aggFactor;
     if (postFreq < parallelFactor) parallelFactor = postFreq;
     int d = stepDepth;
-    while (d > 1 && aggFactor < nranks/2) {
+    while (d > 1 && aggFactor < nranks / 2) {
       d /= 2;
       aggFactor *= 2;
       aggDelta /= 2;
@@ -822,7 +842,7 @@ public:
     if (a >= lastA) {
       skip = 1;
     } else if (phase == 0) {
-      int s = a*aggDelta + as;
+      int s = a * aggDelta + as;
       if (s >= nranks) skip = 1;
       int recvDataRank = (rank + s) % nranks;
       ps->outIx = recvDataRank * count + offset;
@@ -832,28 +852,32 @@ public:
       ps->sendOffset = -1;
       ps->recvOffset = (a % postFreq) * nelem;
       ps->stepOffset = 0;
-      ps->postRecv = (a % postFreq == postFreq-1) || ((a+1)*aggDelta+as >= nranks) ? 1 : 0;
+      ps->postRecv = (a % postFreq == postFreq - 1) || ((a + 1) * aggDelta + as >= nranks) ? 1 : 0;
       ps->postSend = 0;
-   } else if (phase == 1) {
-      int s = a*aggDelta + as;
+    } else if (phase == 1) {
+      int s = a * aggDelta + as;
       if (s >= nranks) skip = 1;
       ps->sendDim = firstBitSet(s, nrPow2);
-      s -= (1<<ps->sendDim);
+      s -= (1 << ps->sendDim);
       int sendDataRank = (rank + nranks + s) % nranks;
       ps->outIx = sendDataRank * count + offset;
       ps->recvDim = s ? firstBitSet(s, nrPow2) : -1;
       ps->sendOffset = ps->recvOffset = (a % postFreq) * nelem;
-      ps->postSend = (a % postFreq == postFreq-1) || ((a+1)*aggDelta+as >= nranks) ? 1 : 0;
-      ps->postRecv = (ps->sendDim == 0) && ((a % postFreq == postFreq-1) || ((a+1)*aggDelta+as-1 >= nranks)) ? 1 : 0;
-      ps->stepOffset = (ps->sendDim == 0) ? 0 : a/postFreq;
+      ps->postSend = (a % postFreq == postFreq - 1) || ((a + 1) * aggDelta + as >= nranks) ? 1 : 0;
+      ps->postRecv =
+        (ps->sendDim == 0) && ((a % postFreq == postFreq - 1) || ((a + 1) * aggDelta + as - 1 >= nranks)) ? 1 : 0;
+      ps->stepOffset = (ps->sendDim == 0) ? 0 : a / postFreq;
       if (ps->recvDim == -1) {
         ps->recvOffset = -1;
         ps->postRecv = 0;
-      } else if (as - (1<<ps->sendDim) == 0) {
-        int foffset = (a*aggDelta) >> (ps->recvDim+1);
-        ps->recvOffset = (foffset%postFreq)*nelem;
-        ps->postRecv = (ps->sendDim == 0) && ((foffset % postFreq == postFreq-1) || ((((foffset+1)*2)+1)<<ps->recvDim) >= nranks) ? 1 : 0;
-        ps->stepOffset = (ps->sendDim == 0) ? 0 : foffset/postFreq;
+      } else if (as - (1 << ps->sendDim) == 0) {
+        int foffset = (a * aggDelta) >> (ps->recvDim + 1);
+        ps->recvOffset = (foffset % postFreq) * nelem;
+        ps->postRecv = (ps->sendDim == 0) && ((foffset % postFreq == postFreq - 1) ||
+                                              ((((foffset + 1) * 2) + 1) << ps->recvDim) >= nranks) ?
+                         1 :
+                         0;
+        ps->stepOffset = (ps->sendDim == 0) ? 0 : foffset / postFreq;
       }
       if (s < nranks && ps->sendDim == 0 && skip) {
         // Don't forget to receive at least once even if we don't send afterwards
@@ -863,13 +887,13 @@ public:
         skip = 0;
       }
     } else if (phase == 2) {
-      int s = (2*a+1)*scale*aggDelta;
-      ps->postSend = (a % postFreq == postFreq-1) || ((2*(a+1)+1)*scale*aggDelta >= nranks) ? 1 : 0;
+      int s = (2 * a + 1) * scale * aggDelta;
+      ps->postSend = (a % postFreq == postFreq - 1) || ((2 * (a + 1) + 1) * scale * aggDelta >= nranks) ? 1 : 0;
       ps->postRecv = 0;
       if (s >= nranks) skip = 1;
       ps->sendDim = firstBitSet(s, nrPow2);
-      s -= (1<<ps->sendDim);
-      ps->sendOffset = (a%postFreq) * nelem;
+      s -= (1 << ps->sendDim);
+      ps->sendOffset = (a % postFreq) * nelem;
       ps->stepOffset = a / postFreq;
       int sendDataRank = (rank + nranks + s) % nranks;
       ps->outIx = sendDataRank * count + offset;
@@ -877,9 +901,9 @@ public:
       if (ps->recvDim == -1) {
         ps->recvOffset = -1;
       } else {
-        s -= (1<<ps->recvDim);
-        int foffset = (a*2*scale*aggDelta) >> (ps->recvDim+1);
-        ps->recvOffset = (foffset%postFreq)*nelem;
+        s -= (1 << ps->recvDim);
+        int foffset = (a * 2 * scale * aggDelta) >> (ps->recvDim + 1);
+        ps->recvOffset = (foffset % postFreq) * nelem;
         ps->stepOffset = foffset / postFreq;
       }
     }
@@ -887,12 +911,9 @@ public:
     if (a >= lastA && a >= parallelFactor) {
       int p = phase;
       if (p == 2) scale /= 2;
-      phase =
-        p == 2 ? scale ? 2 : 1 :
-        p == 1 ? as % 2 == 1 ? 0 : 1 :
-        1;
+      phase = p == 2 ? scale ? 2 : 1 : p == 1 ? as % 2 == 1 ? 0 : 1 : 1;
       if (p == 0 || (p == 1 && as % 2 == 0)) as = nextAs();
-      if (p == 0 && as == aggDelta/2) {
+      if (p == 0 && as == aggDelta / 2) {
         offset += chunkCount;
         if (offset >= end) {
           ps->last = 2;
@@ -902,7 +923,8 @@ public:
       } else {
         resetA();
       }
-    } else if (phase == 0 && as == 1 && offset + chunkCount >= end && a-1 >= ((lastA-1) / parallelFactor) * parallelFactor) {
+    } else if (phase == 0 && as == 1 && offset + chunkCount >= end &&
+               a - 1 >= ((lastA - 1) / parallelFactor) * parallelFactor) {
       ps->last = 1;
     }
     int flags = PatUsed | (skip ? PatSkipped : 0);

--- a/projects/rccl/src/include/comm.h
+++ b/projects/rccl/src/include/comm.h
@@ -46,10 +46,10 @@
 #else
 #if CUDART_VERSION < 9000
 struct cudaLaunchParams {
-  void *func;
+  void* func;
   dim3 gridDim;
   dim3 blockDim;
-  void **args;
+  void** args;
   size_t sharedMem;
   cudaStream_t stream;
 };
@@ -69,10 +69,10 @@ struct ncclSendMem {
   union {
     struct {
       uint64_t head;
-      char pad1[CACHE_LINE_SIZE-sizeof(uint64_t)];
+      char pad1[CACHE_LINE_SIZE - sizeof(uint64_t)];
       void* ptrExchange;
       uint64_t redOpArgExchange[2];
-      char pad2[CACHE_LINE_SIZE-sizeof(void*)-2*sizeof(uint64_t)];
+      char pad2[CACHE_LINE_SIZE - sizeof(void*) - 2 * sizeof(uint64_t)];
       int offsFifo[NCCL_STEPS];
     };
     char pad3[MEM_ALIGN];
@@ -83,7 +83,7 @@ struct ncclRecvMem {
   union {
     struct {
       uint64_t tail;
-      char pad1[CACHE_LINE_SIZE-sizeof(uint64_t)];
+      char pad1[CACHE_LINE_SIZE - sizeof(uint64_t)];
       struct ncclConnFifo connFifo[NCCL_STEPS];
       int flush; // For GDRCopy-based flush
     };
@@ -91,9 +91,12 @@ struct ncclRecvMem {
   };
 };
 
-enum helperThreadState {ThreadStart, ThreadStop};
+enum helperThreadState {
+  ThreadStart,
+  ThreadStop
+};
 
-#define NCCL_IPC_POOL_SIZE (2*NCCL_MAX_LOCAL_RANKS*NCCL_MAX_OPS)
+#define NCCL_IPC_POOL_SIZE (2 * NCCL_MAX_LOCAL_RANKS * NCCL_MAX_OPS)
 
 struct ncclUserRedOp {
   int freeNext; // -1=allocated, otherwise index of next free entry in array
@@ -109,24 +112,24 @@ struct ncclNodeRanks {
 struct cliqueInfo {
   int id;
   int size;
-  int *ranks;
+  int* ranks;
 };
 
 struct ncclDestructor {
   struct ncclDestructor* next;
   void* obj;
   struct ncclComm* comm;
-  ncclResult_t(*fn)(struct ncclDestructor* me);
+  ncclResult_t (*fn)(struct ncclDestructor* me);
 };
 
 struct ncclCommCallback {
   struct ncclCommCallback* next;
-  ncclResult_t(*fn)(struct ncclComm* comm, struct ncclCommCallback* cb);
+  ncclResult_t (*fn)(struct ncclComm* comm, struct ncclCommCallback* cb);
 };
 struct ncclCommEventCallback {
   struct ncclCommEventCallback* next;
   cudaEvent_t event;
-  ncclResult_t(*fn)(struct ncclComm* comm, struct ncclCommEventCallback* cb);
+  ncclResult_t (*fn)(struct ncclComm* comm, struct ncclCommEventCallback* cb);
 };
 
 struct ncclSharedResources {
@@ -160,10 +163,10 @@ struct ncclSharedResources {
 };
 
  /**
-  * NOTE: This struct contains pointer members. Shallow copies are only intended during early initialization,
-  * before these pointers are populated or before ownership/lifetime of the pointed-to resources matters.
-  * Do not treat an initialized ncclChannel as generally safe to shallow copy.
-  */
+ * NOTE: This struct contains pointer members. Shallow copies are only intended during early initialization,
+ * before these pointers are populated or before ownership/lifetime of the pointed-to resources matters.
+ * Do not treat an initialized ncclChannel as generally safe to shallow copy.
+ */
 struct ncclChannel {
   struct ncclChannelPeer** peers;
   struct ncclDevChannelPeer** devPeers;
@@ -200,7 +203,7 @@ struct alignas(16) ncclWorkList {
 };
 
 struct ncclCollnetHandleList {
-  struct ncclCollnetHandleList *next;
+  struct ncclCollnetHandleList* next;
   void* collnetHandle;
   size_t size;
   const void* buffer;
@@ -260,7 +263,6 @@ struct ncclTaskColl {
   void* eventHandle;
   uint8_t nChannels;
 };
-
 
 struct ncclTaskBcast {
   struct ncclTaskBcast* next;
@@ -389,14 +391,14 @@ struct ncclKernelPlan {
 
 struct ncclTaskCollSorter {
   static constexpr int UnitLog2 = 10; // 1K
-  static constexpr size_t UnitSize = 1<<UnitLog2;
+  static constexpr size_t UnitSize = 1 << UnitLog2;
   static constexpr int MaxLog2 = 30; // 1GB
-  static constexpr size_t MaxSize = 1ull<<MaxLog2;
+  static constexpr size_t MaxSize = 1ull << MaxLog2;
   // Number of bins between powers of 2. For 4 bins, the worst case out-of-order
   // relative magnitude is (5/4)-1 = 25%
   static constexpr int BitsPerPow2 = 2;
-  static constexpr int BinsPerPow2 = 1<<BitsPerPow2;
-  static constexpr int BinCount = 1 + (MaxLog2-UnitLog2)*BinsPerPow2;
+  static constexpr int BinsPerPow2 = 1 << BitsPerPow2;
+  static constexpr int BinCount = 1 + (MaxLog2 - UnitLog2) * BinsPerPow2;
 
   struct ncclTaskColl* head;
   struct ncclTaskColl* tail;
@@ -407,25 +409,23 @@ struct ncclTaskCollSorter {
   struct ncclTaskColl** bins[BinCount];
 };
 
-inline void ncclTaskCollSorterInsert(
-    struct ncclTaskCollSorter* me, struct ncclTaskColl* x, size_t size
-  ) {
+inline void ncclTaskCollSorterInsert(struct ncclTaskCollSorter* me, struct ncclTaskColl* x, size_t size) {
   constexpr int UnitLog2 = ncclTaskCollSorter::UnitLog2;
   constexpr size_t MaxSize = ncclTaskCollSorter::MaxSize;
   constexpr int BitsPerPow2 = ncclTaskCollSorter::BitsPerPow2;
   constexpr int BinCount = ncclTaskCollSorter::BinCount;
   // Value is bounded by MaxSize>>UnitLog2 which fits in uint32_t
-  int bin = u32fpEncode(static_cast<uint32_t>(std::min(MaxSize, size)>>UnitLog2), BitsPerPow2);
-  bin = BinCount-1 - bin; // descending bin
+  int bin = u32fpEncode(static_cast<uint32_t>(std::min(MaxSize, size) >> UnitLog2), BitsPerPow2);
+  bin = BinCount - 1 - bin; // descending bin
 
   if (me->bins[bin] == nullptr) {
     if (me->binEdge <= bin) {
-      me->binEdge = bin+1;
+      me->binEdge = bin + 1;
       me->bins[bin] = me->tail ? &me->tail->next : &me->head;
       me->tail = x;
     } else {
       // Find successor non-empty bin after this one.
-      int succ = bin+1;
+      int succ = bin + 1;
       while (me->bins[succ] == nullptr) succ++;
       // What was our successor's head's previous is now our head's previous.
       me->bins[bin] = me->bins[succ];
@@ -453,7 +453,7 @@ inline struct ncclTaskColl* ncclTaskCollSorterDequeueAll(struct ncclTaskCollSort
 ////////////////////////////////////////////////////////////////////////////////
 
 struct ncclCudaStreamList {
-  struct ncclCudaStreamList *next;
+  struct ncclCudaStreamList* next;
   cudaStream_t stream;
 };
 
@@ -469,7 +469,7 @@ struct ncclKernelPlanner {
     struct ncclIntruQueue<struct ncclTaskBcast, &ncclTaskBcast::next> bcastQueue;
   };
   struct ncclTaskCollSorter collSorter;
-  struct Peer* peers/*[nRanks]*/;
+  struct Peer* peers /*[nRanks]*/;
   int nTasksColl, nTasksP2p, nTasksBcast, nTasksRma;
   int nTasksP2pSend, nTasksP2pRecv;
 
@@ -498,7 +498,7 @@ struct ncclKernelPlanner {
 
   struct ncclIntruQueue<struct ncclTaskColl, &ncclTaskColl::next> collTaskQueue;
   struct ncclIntruQueue<struct ncclTaskColl, &ncclTaskColl::next> collCeTaskQueue;
-  struct ncclIntruQueue<struct ncclTaskRma, &ncclTaskRma::next> *rmaTaskQueues; // Per-context queue for RMA tasks
+  struct ncclIntruQueue<struct ncclTaskRma, &ncclTaskRma::next>* rmaTaskQueues; // Per-context queue for RMA tasks
   struct ncclIntruQueue<struct ncclTaskColl, &ncclTaskColl::next> collSymTaskQueue;
   struct ncclIntruQueue<struct ncclWorkList, &ncclWorkList::next> collWorkQueue;
   struct ncclIntruQueue<struct ncclWorkList, &ncclWorkList::next> tmpCollWorkQueue;
@@ -635,7 +635,8 @@ struct ncclComm {
   bool directMode; // if any process manages more than one local rank
   int cuMemSupport;
 
-  uint64_t magic; // Magic number for all network communication. Not a security key -- only goal is to detect mismatches.
+  uint64_t
+    magic; // Magic number for all network communication. Not a security key -- only goal is to detect mismatches.
 
   uint64_t commHash;
   int rank;    // my rank in the communicator
@@ -730,10 +731,12 @@ struct ncclComm {
   float bandwidths[NCCL_NUM_FUNCTIONS][NCCL_NUM_ALGORITHMS][NCCL_NUM_PROTOCOLS];
   int maxThreads[NCCL_NUM_ALGORITHMS][NCCL_NUM_PROTOCOLS];
   uint64_t minMaxLLRange[RCCL_TUNABLE_COLLS][NCCL_NUM_PROTOCOLS - 1][RCCL_PROTOCOL_ENTRY_SIZE];
-  uint64_t minMaxChannelThresholds[RCCL_TUNABLE_COLLS][RCCL_CHANNELS_TUNABLE_ENTRIES][3]; //for each collective, set for 5 channel-counts: 32,40,48,56,64, the two values for min/max size-threshold
+  uint64_t minMaxChannelThresholds
+    [RCCL_TUNABLE_COLLS][RCCL_CHANNELS_TUNABLE_ENTRIES]
+    [3]; // for each collective, set for 5 channel-counts: 32,40,48,56,64, the two values for min/max size-threshold
 
   /* This attribute can indicate the states of communicators and return code of
-  * asynchronous NCCL operations. */
+   * asynchronous NCCL operations. */
   ncclResult_t asyncResult;
 
   // Flag to ask NCCL kernels to abort
@@ -779,7 +782,7 @@ struct ncclComm {
   int proxyRefCountOld; /* store proxy post-atomic-sub refcount */
   // Whether this communicator uses collNet
   bool isOneRPN;
-  uint8_t collNetSupportMatrix[4/*sum,prod,max,min*/][ncclNumTypes];
+  uint8_t collNetSupportMatrix[4 /*sum,prod,max,min*/][ncclNumTypes];
   int* collNetHeads;
   int collNetHeadsNum;
   int* collNetDenseToUserRank;
@@ -807,7 +810,10 @@ struct ncclComm {
   // Subset of those in groupNext list. Holds 0x1 if not needing preconnect.
   struct ncclComm* preconnectNext;
   int localPersistentRefs; // number of persistent plan-lists capturing this comm
-  struct P2pSchedulePair { int sendRank; int recvRank; } *p2pSchedule;
+  struct P2pSchedulePair {
+    int sendRank;
+    int recvRank;
+  }* p2pSchedule;
 
   struct ncclKernelPlanner planner;
   void* ringTasks; // An array of nRanks pointers used in ring sorting rooted collectives (bcast)
@@ -821,7 +827,7 @@ struct ncclComm {
 
   // user-created reduction ops
   int userRedOpCapacity, userRedOpFreeHead;
-  ncclUserRedOp *userRedOps;
+  ncclUserRedOp* userRedOps;
 
   // Queue of things for the main thread to do
   int reclaimSteps;
@@ -851,7 +857,7 @@ struct ncclComm {
   int finalizeRankCnt;
 
   // group job to support multi-thread FT
-  struct ncclGroupJob *groupJob;
+  struct ncclGroupJob* groupJob;
 
   // Flag indicating if this communicator shares resources with parent or children
   bool shareResources;
@@ -859,7 +865,7 @@ struct ncclComm {
   // Tuning plugin
   int tunerPluginLoaded;
   ncclTuner_t* tuner;
-  void *tunerContext;
+  void* tunerContext;
 
   // Profiler plugin
   void* profilerContext;
@@ -902,8 +908,9 @@ struct ncclComm {
   int unroll;
   // custom collective [RCCL]
   bool enableCustColl;
-  int pxnDisable;  // per-comm PXN-disable cache: RCCL_VALUE_UNSET uninit, RCCL_VALUE_INVALID = arch/env override, otherwise 0/1
-  int p2pNetChunkSize;  // per-comm P2P NET chunk size cache: RCCL_VALUE_UNSET uninit
+  int
+    pxnDisable; // per-comm PXN-disable cache: RCCL_VALUE_UNSET uninit, RCCL_VALUE_INVALID = arch/env override, otherwise 0/1
+  int p2pNetChunkSize; // per-comm P2P NET chunk size cache: RCCL_VALUE_UNSET uninit
   // gfx name from hipDeviceProp_t [RCCL] , Memory resource owned by comm allocated in ncclCommInitRankFunc
   char* archName;
   // multiProcessorCount from hipDeviceProp_t [RCCL]
@@ -934,10 +941,11 @@ struct ncclComm {
 };
 
 static_assert(offsetof(struct ncclComm, startMagic) == 0, "startMagic must be the first field of ncclComm");
-static_assert(offsetof(struct ncclComm, endMagic) == sizeof(struct ncclComm) - sizeof(uint64_t), "endMagic must be the last field of ncclComm");
+static_assert(offsetof(struct ncclComm, endMagic) == sizeof(struct ncclComm) - sizeof(uint64_t),
+              "endMagic must be the last field of ncclComm");
 
 enum ncclLaunchMode {
-  ncclLaunchModeInvalid=0,
+  ncclLaunchModeInvalid = 0,
   ncclLaunchModeParallel,
   ncclLaunchModeGroup
 };
@@ -961,7 +969,7 @@ inline ncclResult_t ncclCommPollCallbacks(struct ncclComm* comm, bool waitSome) 
   return ncclSuccess;
 }
 
-inline ncclResult_t ncclCommPollEventCallbacks(struct ncclComm *comm, bool waitSome) {
+inline ncclResult_t ncclCommPollEventCallbacks(struct ncclComm* comm, bool waitSome) {
   ncclResult_t result = ncclSuccess;
   cudaStreamCaptureMode mode = cudaStreamCaptureModeRelaxed;
   CUDACHECK(cudaThreadExchangeStreamCaptureMode(&mode));
@@ -992,15 +1000,16 @@ inline void ncclCommIntraBarrierIn(struct ncclComm* comm, uint32_t x) {
   int phase = comm->intraBarrierPhase;
   if (comm->intraRanks == 1) {
     // Release everyone (just me).
-    comm->intraBarrierGate = (uint64_t(x)<<32) | (phase^1);
+    comm->intraBarrierGate = (uint64_t(x) << 32) | (phase ^ 1);
   } else {
     struct ncclComm* comm0 = comm->intraComm0;
-    uint64_t count = COMPILER_ATOMIC_ADD_FETCH(&comm0->intraBarrierCounter, (uint64_t(x)<<32) + 1, std::memory_order_release);
+    uint64_t count =
+      COMPILER_ATOMIC_ADD_FETCH(&comm0->intraBarrierCounter, (uint64_t(x) << 32) + 1, std::memory_order_release);
     if (uint32_t(count) == uint32_t(comm->intraRanks)) {
       // Reset.
       COMPILER_ATOMIC_STORE(&comm0->intraBarrierCounter, 0ULL, std::memory_order_relaxed);
       // Release everyone.
-      COMPILER_ATOMIC_STORE(&comm0->intraBarrierGate, (count>>32<<32) | (phase^1), std::memory_order_release);
+      COMPILER_ATOMIC_STORE(&comm0->intraBarrierGate, (count >> 32 << 32) | (phase ^ 1), std::memory_order_release);
     }
   }
 }
@@ -1015,22 +1024,21 @@ inline uint32_t ncclCommIntraBarrierOut(struct ncclComm* comm) {
     uint64_t t0 = clockNano();
     do {
       // Spin vigorously for first 5us.
-      if (clockNano()-t0 >= 5*1000) std::this_thread::yield();
+      if (clockNano() - t0 >= 5 * 1000) std::this_thread::yield();
       gate = COMPILER_ATOMIC_LOAD(&comm0->intraBarrierGate, std::memory_order_relaxed);
     } while ((gate & 1) != phase);
   }
   if (comm->intraRanks != 1) std::atomic_thread_fence(std::memory_order_acquire);
-  return gate>>32;
+  return gate >> 32;
 }
 
 // Scrambles the bits of non-builtin values of ncclRedOp_t according to the
 // communicator memory address. Used to catch bugs so that integer handles
 // associated with this communicator won't collide with handles of other
 // communicatrs. This function is its own inverse.
-static inline ncclRedOp_t ncclUserRedOpMangle(ncclComm *comm, ncclRedOp_t op) {
+static inline ncclRedOp_t ncclUserRedOpMangle(ncclComm* comm, ncclRedOp_t op) {
   // Preserve the built-in values.
-  if(int(op) < int(ncclNumOps))
-    return op;
+  if (int(op) < int(ncclNumOps)) return op;
   uint64_t h = reinterpret_cast<uint64_t>(comm);
   h ^= h >> 32;
   h *= 0x9e3779b97f4a7c13u; // Knuth's 64-bit magical hash constant

--- a/projects/rccl/src/include/compiler.h
+++ b/projects/rccl/src/include/compiler.h
@@ -9,24 +9,24 @@
 #define NCCL_PORTABLE_INTRINSICS_H
 
 #ifdef __cplusplus
-  extern "C++" {
+extern "C++" {
 #endif
 
 #include <atomic>
 
 #ifdef __cplusplus
-  }
+}
 #endif
 
 // Compiler detection macros
 #if defined(__GNUC__) || defined(__clang__)
-  #define NCCL_COMPILER_GCC 1
-  #include "compiler/gcc.h"
+#define NCCL_COMPILER_GCC 1
+#include "compiler/gcc.h"
 #elif defined(_MSC_VER)
-  #define NCCL_COMPILER_MSVC 1
-  #include "compiler/msvc.h"
+#define NCCL_COMPILER_MSVC 1
+#include "compiler/msvc.h"
 #else
-  #error "Unsupported compiler"
+#error "Unsupported compiler"
 #endif
 
 #endif // NCCL_PORTABLE_INTRINSICS_H

--- a/projects/rccl/src/include/compiler/gcc.h
+++ b/projects/rccl/src/include/compiler/gcc.h
@@ -16,23 +16,20 @@
    (order) == std::memory_order_release ? __ATOMIC_RELEASE : \
    (order) == std::memory_order_acq_rel ? __ATOMIC_ACQ_REL : \
    (order) == std::memory_order_seq_cst ? __ATOMIC_SEQ_CST : \
-   __ATOMIC_SEQ_CST)
+                                          __ATOMIC_SEQ_CST)
 
-#define COMPILER_ATOMIC_LOAD(ptr, order) \
-  __atomic_load_n((ptr), NCCL_CONVERT_ORDER(order))
-#define COMPILER_ATOMIC_LOAD_DEST(ptr, dest, order) do { \
-  __atomic_load((ptr), (dest), NCCL_CONVERT_ORDER(order)); \
-} while(0)
-#define COMPILER_ATOMIC_STORE(ptr, val, order) \
-  __atomic_store_n((ptr), (val), NCCL_CONVERT_ORDER(order))
-#define COMPILER_ATOMIC_LOAD_32(ptr, order) \
-  __atomic_load_n((ptr), NCCL_CONVERT_ORDER(order))
-#define COMPILER_ATOMIC_STORE_32(ptr, val, order) \
-  __atomic_store_n((ptr), (val), NCCL_CONVERT_ORDER(order))
-#define COMPILER_ATOMIC_EXCHANGE(ptr, val, order) \
-  __atomic_exchange_n((ptr), (val), NCCL_CONVERT_ORDER(order))
+#define COMPILER_ATOMIC_LOAD(ptr, order) __atomic_load_n((ptr), NCCL_CONVERT_ORDER(order))
+#define COMPILER_ATOMIC_LOAD_DEST(ptr, dest, order) \
+  do { \
+    __atomic_load((ptr), (dest), NCCL_CONVERT_ORDER(order)); \
+  } while (0)
+#define COMPILER_ATOMIC_STORE(ptr, val, order) __atomic_store_n((ptr), (val), NCCL_CONVERT_ORDER(order))
+#define COMPILER_ATOMIC_LOAD_32(ptr, order) __atomic_load_n((ptr), NCCL_CONVERT_ORDER(order))
+#define COMPILER_ATOMIC_STORE_32(ptr, val, order) __atomic_store_n((ptr), (val), NCCL_CONVERT_ORDER(order))
+#define COMPILER_ATOMIC_EXCHANGE(ptr, val, order) __atomic_exchange_n((ptr), (val), NCCL_CONVERT_ORDER(order))
 #define COMPILER_ATOMIC_COMPARE_EXCHANGE(ptr, expected, desired, success_order, failure_order) \
-  __atomic_compare_exchange_n((ptr), (expected), (desired), true, NCCL_CONVERT_ORDER(success_order), NCCL_CONVERT_ORDER(failure_order))
+  __atomic_compare_exchange_n((ptr), (expected), (desired), true, NCCL_CONVERT_ORDER(success_order), \
+                              NCCL_CONVERT_ORDER(failure_order))
 
 #define COMPILER_ATOMIC_FETCH_ADD(ptr, val, order) __atomic_fetch_add((ptr), (val), NCCL_CONVERT_ORDER(order))
 #define COMPILER_ATOMIC_ADD_FETCH(ptr, val, order) __atomic_add_fetch((ptr), (val), NCCL_CONVERT_ORDER(order))

--- a/projects/rccl/src/include/compiler/msvc.h
+++ b/projects/rccl/src/include/compiler/msvc.h
@@ -14,58 +14,57 @@
 // Use standard C++ atomics via reinterpret_cast - this is safe for primitive types
 // since std::atomic<T> has the same size and alignment as T
 
-template<typename T>
+template <typename T>
 static inline T COMPILER_ATOMIC_LOAD_impl(volatile T* ptr, std::memory_order order) {
   return std::atomic_load_explicit(reinterpret_cast<volatile std::atomic<T>*>(ptr), order);
 }
 #define COMPILER_ATOMIC_LOAD(ptr, order) COMPILER_ATOMIC_LOAD_impl(ptr, order)
 
-template<typename T>
+template <typename T>
 static inline void COMPILER_ATOMIC_LOAD_DEST_impl(volatile T* ptr, T* dest, std::memory_order order) {
   *dest = std::atomic_load_explicit(reinterpret_cast<volatile std::atomic<T>*>(ptr), order);
 }
 #define COMPILER_ATOMIC_LOAD_DEST(ptr, dest, order) COMPILER_ATOMIC_LOAD_DEST_impl(ptr, dest, order)
 
-template<typename T>
+template <typename T>
 static inline void COMPILER_ATOMIC_STORE_impl(volatile T* ptr, T val, std::memory_order order) {
   std::atomic_store_explicit(reinterpret_cast<volatile std::atomic<T>*>(ptr), val, order);
 }
 #define COMPILER_ATOMIC_STORE(ptr, val, order) COMPILER_ATOMIC_STORE_impl(ptr, val, order)
 
 // Explicit 32-bit variants (same as generic but fixed type for uint32_t* pointers)
-#define COMPILER_ATOMIC_LOAD_32(ptr, order) \
-  COMPILER_ATOMIC_LOAD_impl(reinterpret_cast<volatile uint32_t*>(ptr), order)
+#define COMPILER_ATOMIC_LOAD_32(ptr, order) COMPILER_ATOMIC_LOAD_impl(reinterpret_cast<volatile uint32_t*>(ptr), order)
 #define COMPILER_ATOMIC_STORE_32(ptr, val, order) \
   COMPILER_ATOMIC_STORE_impl(reinterpret_cast<volatile uint32_t*>(ptr), static_cast<uint32_t>(val), order)
 
-template<typename T>
+template <typename T>
 static inline T COMPILER_ATOMIC_EXCHANGE_impl(volatile T* ptr, T val, std::memory_order order) {
   return std::atomic_exchange_explicit(reinterpret_cast<volatile std::atomic<T>*>(ptr), val, order);
 }
 #define COMPILER_ATOMIC_EXCHANGE(ptr, val, order) COMPILER_ATOMIC_EXCHANGE_impl(ptr, val, order)
 
-template<typename T>
-static inline bool COMPILER_ATOMIC_COMPARE_EXCHANGE_impl(volatile T* ptr, T* expected, T desired,
-    std::memory_order success_order, std::memory_order failure_order) {
-  return std::atomic_compare_exchange_strong_explicit(
-    reinterpret_cast<volatile std::atomic<T>*>(ptr), expected, desired, success_order, failure_order);
+template <typename T>
+static inline bool COMPILER_ATOMIC_COMPARE_EXCHANGE_impl(
+  volatile T* ptr, T* expected, T desired, std::memory_order success_order, std::memory_order failure_order) {
+  return std::atomic_compare_exchange_strong_explicit(reinterpret_cast<volatile std::atomic<T>*>(ptr), expected,
+                                                      desired, success_order, failure_order);
 }
 #define COMPILER_ATOMIC_COMPARE_EXCHANGE(ptr, expected, desired, success_order, failure_order) \
   COMPILER_ATOMIC_COMPARE_EXCHANGE_impl(ptr, expected, desired, success_order, failure_order)
 
-template<typename T>
+template <typename T>
 static inline T COMPILER_ATOMIC_FETCH_ADD_impl(volatile T* ptr, T val, std::memory_order order) {
   return std::atomic_fetch_add_explicit(reinterpret_cast<volatile std::atomic<T>*>(ptr), val, order);
 }
 #define COMPILER_ATOMIC_FETCH_ADD(ptr, val, order) COMPILER_ATOMIC_FETCH_ADD_impl(ptr, val, order)
 
-template<typename T>
+template <typename T>
 static inline T COMPILER_ATOMIC_ADD_FETCH_impl(volatile T* ptr, T val, std::memory_order order) {
   return std::atomic_fetch_add_explicit(reinterpret_cast<volatile std::atomic<T>*>(ptr), val, order) + val;
 }
 #define COMPILER_ATOMIC_ADD_FETCH(ptr, val, order) COMPILER_ATOMIC_ADD_FETCH_impl(ptr, val, order)
 
-template<typename T>
+template <typename T>
 static inline T COMPILER_ATOMIC_SUB_FETCH_impl(volatile T* ptr, T val, std::memory_order order) {
   return std::atomic_fetch_sub_explicit(reinterpret_cast<volatile std::atomic<T>*>(ptr), val, order) - val;
 }

--- a/projects/rccl/src/include/core.h
+++ b/projects/rccl/src/include/core.h
@@ -17,26 +17,15 @@
 
 #if defined(NCCL_OS_LINUX)
 #ifdef PROFAPI
-#define NCCL_API(ret, func, args...)        \
-    extern "C"                              \
-    __attribute__ ((visibility("default"))) \
-    __attribute__ ((alias(#func)))          \
-    ret p##func (args);                     \
-    extern "C"                              \
-    __attribute__ ((visibility("default"))) \
-    __attribute__ ((weak))                  \
-    ret func(args)
+#define NCCL_API(ret, func, args...) \
+  extern "C" __attribute__((visibility("default"))) __attribute__((alias(#func))) ret p##func(args); \
+  extern "C" __attribute__((visibility("default"))) __attribute__((weak)) ret func(args)
 #else
-#define NCCL_API(ret, func, args...)        \
-    extern "C"                              \
-    __attribute__ ((visibility("default"))) \
-    ret func(args)
+#define NCCL_API(ret, func, args...) extern "C" __attribute__((visibility("default"))) ret func(args)
 #endif // end PROFAPI
 #else
 /* Windows and other non-Linux: use standard variadic macro (no visibility attribute) */
-#define NCCL_API(ret, func, ...)            \
-    extern "C"                              \
-    ret func(__VA_ARGS__)
+#define NCCL_API(ret, func, ...) extern "C" ret func(__VA_ARGS__)
 #endif // end NCCL_OS_LINUX
 
 #include "debug.h"

--- a/projects/rccl/src/include/cpuset.h
+++ b/projects/rccl/src/include/cpuset.h
@@ -60,12 +60,12 @@ static char* ncclCpusetToRangeStr(ncclAffinity* mask, char* str, size_t len) {
     }
     // End of a range, add comma between ranges
     if (!isSet && start != -1) {
-      if (cpu-1 == start) {
-        c += snprintf(str+c, len-c, "%s%d", c ? "," : "", start);
+      if (cpu - 1 == start) {
+        c += snprintf(str + c, len - c, "%s%d", c ? "," : "", start);
       } else {
-        c += snprintf(str+c, len-c, "%s%d-%d", c ? "," : "", start, cpu-1);
+        c += snprintf(str + c, len - c, "%s%d-%d", c ? "," : "", start, cpu - 1);
       }
-      if (c >= len-1) break;
+      if (c >= len - 1) break;
       start = -1;
     }
   }

--- a/projects/rccl/src/include/cudawrap.h
+++ b/projects/rccl/src/include/cudawrap.h
@@ -28,51 +28,56 @@ extern CUmemAllocationHandleType ncclCuMemHandleType;
 #define CUPFN(symbol) pfn_##symbol
 
 // Check CUDA PFN driver calls
-#define CUCHECK(cmd) do {				      \
-    CUresult err = pfn_##cmd;				      \
-    if( err != CUDA_SUCCESS ) {				      \
-      const char *errStr;				      \
-      (void) pfn_cuGetErrorString(err, &errStr);	      \
-      WARN("Cuda failure %d '%s'", err, errStr);	      \
-      return ncclUnhandledCudaError;			      \
-    }							      \
-} while(false)
+#define CUCHECK(cmd) \
+  do { \
+    CUresult err = pfn_##cmd; \
+    if (err != CUDA_SUCCESS) { \
+      const char* errStr; \
+      (void)pfn_cuGetErrorString(err, &errStr); \
+      WARN("Cuda failure %d '%s'", err, errStr); \
+      return ncclUnhandledCudaError; \
+    } \
+  } while (false)
 
-#define CUCALL(cmd) do {				      \
-    pfn_##cmd;				                \
-} while(false)
+#define CUCALL(cmd) \
+  do { \
+    pfn_##cmd; \
+  } while (false)
 
-#define CUCHECKGOTO(cmd, res, label) do {		      \
-    CUresult err = pfn_##cmd;				      \
-    if( err != CUDA_SUCCESS ) {				      \
-      const char *errStr;				      \
-      (void) pfn_cuGetErrorString(err, &errStr);	      \
-      WARN("Cuda failure %d '%s'", err, errStr);	      \
-      res = ncclUnhandledCudaError;			      \
-      goto label;					      \
-    }							      \
-} while(false)
+#define CUCHECKGOTO(cmd, res, label) \
+  do { \
+    CUresult err = pfn_##cmd; \
+    if (err != CUDA_SUCCESS) { \
+      const char* errStr; \
+      (void)pfn_cuGetErrorString(err, &errStr); \
+      WARN("Cuda failure %d '%s'", err, errStr); \
+      res = ncclUnhandledCudaError; \
+      goto label; \
+    } \
+  } while (false)
 
 // Report failure but clear error and continue
-#define CUCHECKIGNORE(cmd) do {						\
-    CUresult err = pfn_##cmd;						\
-    if( err != CUDA_SUCCESS ) {						\
-      const char *errStr;						\
-      (void) pfn_cuGetErrorString(err, &errStr);			\
-      INFO(NCCL_ALL,"%s:%d Cuda failure %d '%s'", __FILE__, __LINE__, err, errStr); \
-    }									\
-} while(false)
+#define CUCHECKIGNORE(cmd) \
+  do { \
+    CUresult err = pfn_##cmd; \
+    if (err != CUDA_SUCCESS) { \
+      const char* errStr; \
+      (void)pfn_cuGetErrorString(err, &errStr); \
+      INFO(NCCL_ALL, "%s:%d Cuda failure %d '%s'", __FILE__, __LINE__, err, errStr); \
+    } \
+  } while (false)
 
-#define CUCHECKTHREAD(cmd, args) do {					\
-    CUresult err = pfn_##cmd;						\
-    if (err != CUDA_SUCCESS) {						\
-      INFO(NCCL_INIT,"%s:%d -> %d [Async thread]", __FILE__, __LINE__, err); \
-      args->ret = ncclUnhandledCudaError;				\
-      return args;							\
-    }									\
-} while(0)
+#define CUCHECKTHREAD(cmd, args) \
+  do { \
+    CUresult err = pfn_##cmd; \
+    if (err != CUDA_SUCCESS) { \
+      INFO(NCCL_INIT, "%s:%d -> %d [Async thread]", __FILE__, __LINE__, err); \
+      args->ret = ncclUnhandledCudaError; \
+      return args; \
+    } \
+  } while (0)
 
-#define DECLARE_CUDA_PFN_EXTERN(symbol,version) extern PFN_##symbol##_v##version pfn_##symbol
+#define DECLARE_CUDA_PFN_EXTERN(symbol, version) extern PFN_##symbol##_v##version pfn_##symbol
 
 #if CUDART_VERSION >= 11030
 /* CUDA Driver functions loaded with cuGetProcAddress for versioning */
@@ -139,8 +144,7 @@ inline ncclResult_t ncclCudaStreamIsLegacyNull(cudaStream_t stream, bool* isLega
   unsigned long long nullStreamId, legacyNullStreamId;
   CUDACHECK(cudaStreamGetId(NULL, &nullStreamId));
   CUDACHECK(cudaStreamGetId(cudaStreamLegacy, &legacyNullStreamId));
-  *isLegacy = (stream == cudaStreamLegacy) ||
-              ((stream == NULL) && (nullStreamId == legacyNullStreamId));
+  *isLegacy = (stream == cudaStreamLegacy) || ((stream == NULL) && (nullStreamId == legacyNullStreamId));
 #else
   *isLegacy = (stream == NULL) || (stream == cudaStreamLegacy);
 #endif

--- a/projects/rccl/src/include/dda_all_gather_ipc.h
+++ b/projects/rccl/src/include/dda_all_gather_ipc.h
@@ -15,22 +15,13 @@ struct ncclComm;
 /**
  * Check if DDA allgather is eligible for the given parameters
  */
-bool ncclAllGatherDdaIpcEligible(
-    ncclComm* comm,
-    const void* sendbuff,
-    void* recvbuff,
-    size_t sendcount,
-    ncclDataType_t datatype);
+bool ncclAllGatherDdaIpcEligible(ncclComm* comm, const void* sendbuff, void* recvbuff, size_t sendcount,
+                                 ncclDataType_t datatype);
 
 /**
  * Execute DDA allgather operation using IPC
  */
-ncclResult_t ncclAllGatherDdaIpc(
-    const void* sendbuff,
-    void* recvbuff,
-    size_t sendcount,
-    ncclDataType_t datatype,
-    ncclComm* comm,
-    cudaStream_t stream);
+ncclResult_t ncclAllGatherDdaIpc(const void* sendbuff, void* recvbuff, size_t sendcount, ncclDataType_t datatype,
+                                 ncclComm* comm, cudaStream_t stream);
 
 #endif

--- a/projects/rccl/src/include/dda_all_reduce_ipc.h
+++ b/projects/rccl/src/include/dda_all_reduce_ipc.h
@@ -12,21 +12,10 @@
 
 struct ncclComm;
 
-bool ncclAllReduceDdaIpcEligible(
-    ncclComm* comm,
-    const void* sendbuff,
-    void* recvbuff,
-    size_t count,
-    ncclDataType_t datatype,
-    ncclRedOp_t op);
+bool ncclAllReduceDdaIpcEligible(ncclComm* comm, const void* sendbuff, void* recvbuff, size_t count,
+                                 ncclDataType_t datatype, ncclRedOp_t op);
 
-ncclResult_t ncclAllReduceDdaIpc(
-    const void* sendbuff,
-    void* recvbuff,
-    size_t count,
-    ncclDataType_t datatype,
-    ncclRedOp_t op,
-    ncclComm* comm,
-    cudaStream_t stream);
+ncclResult_t ncclAllReduceDdaIpc(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
+                                 ncclRedOp_t op, ncclComm* comm, cudaStream_t stream);
 
 #endif

--- a/projects/rccl/src/include/dda_alltoall_ipc.h
+++ b/projects/rccl/src/include/dda_alltoall_ipc.h
@@ -15,23 +15,13 @@ struct ncclComm;
 /**
  * Check if DDA alltoall is eligible for the given parameters
  */
-bool ncclAllToAllDdaIpcEligible(
-    ncclComm* comm,
-    const void* sendbuff,
-    void* recvbuff,
-    size_t count,
-    ncclDataType_t datatype);
+bool ncclAllToAllDdaIpcEligible(ncclComm* comm, const void* sendbuff, void* recvbuff, size_t count,
+                                ncclDataType_t datatype);
 
 /**
  * Execute DDA alltoall operation using IPC
  */
-ncclResult_t ncclAllToAllDdaIpc(
-    const void* sendbuff,
-    void* recvbuff,
-    size_t count,
-    ncclDataType_t datatype,
-    ncclComm* comm,
-    cudaStream_t stream);
+ncclResult_t ncclAllToAllDdaIpc(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
+                                ncclComm* comm, cudaStream_t stream);
 
 #endif
-

--- a/projects/rccl/src/include/dda_reduce_scatter_ipc.h
+++ b/projects/rccl/src/include/dda_reduce_scatter_ipc.h
@@ -15,24 +15,13 @@ struct ncclComm;
 /**
  * Check if DDA reduce-scatter is eligible for the given parameters
  */
-bool ncclReduceScatterDdaIpcEligible(
-    ncclComm* comm,
-    const void* sendbuff,
-    void* recvbuff,
-    size_t recvcount,
-    ncclDataType_t datatype,
-    ncclRedOp_t op);
+bool ncclReduceScatterDdaIpcEligible(ncclComm* comm, const void* sendbuff, void* recvbuff, size_t recvcount,
+                                     ncclDataType_t datatype, ncclRedOp_t op);
 
 /**
  * Execute DDA reduce-scatter operation using IPC
  */
-ncclResult_t ncclReduceScatterDdaIpc(
-    const void* sendbuff,
-    void* recvbuff,
-    size_t recvcount,
-    ncclDataType_t datatype,
-    ncclRedOp_t op,
-    ncclComm* comm,
-    cudaStream_t stream);
+ncclResult_t ncclReduceScatterDdaIpc(const void* sendbuff, void* recvbuff, size_t recvcount, ncclDataType_t datatype,
+                                     ncclRedOp_t op, ncclComm* comm, cudaStream_t stream);
 
 #endif

--- a/projects/rccl/src/include/debug.h
+++ b/projects/rccl/src/include/debug.h
@@ -19,15 +19,16 @@
 
 extern int ncclDebugLevel;
 extern uint64_t ncclDebugMask;
-extern FILE *ncclDebugFile;
+extern FILE* ncclDebugFile;
 
 #ifdef NCCL_OS_LINUX
-void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *filefunc, int line, const char *fmt, ...) __attribute__ ((format (printf, 5, 6)));
+void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char* filefunc, int line, const char* fmt, ...)
+  __attribute__((format(printf, 5, 6)));
 #elif defined(NCCL_OS_WINDOWS)
-void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *filefunc, int line, const char *fmt, ...);
+void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char* filefunc, int line, const char* fmt, ...);
 #else
 /* Fallback so headers (e.g. alloc.h via checks.h) compile when OS is not set (e.g. unit tests with MPI). */
-void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char *filefunc, int line, const char *fmt, ...);
+void ncclDebugLog(ncclDebugLogLevel level, unsigned long flags, const char* filefunc, int line, const char* fmt, ...);
 #endif
 
 // Let code temporarily downgrade WARN into INFO
@@ -44,22 +45,22 @@ extern char ncclLastError[];
     ncclDebugNoWarn = FLAGS; \
     (EXPR); \
     ncclDebugNoWarn = oldNoWarn; \
-  } while(0)
+  } while (0)
 
 #define INFO(FLAGS, ...) \
-    do{ \
-        int level = COMPILER_ATOMIC_LOAD(&ncclDebugLevel, std::memory_order_acquire); \
-        if((level >= NCCL_LOG_INFO && ((unsigned long)(FLAGS) & ncclDebugMask)) || (level < 0)) \
-            ncclDebugLog(NCCL_LOG_INFO, (unsigned long)(FLAGS), __func__, __LINE__, __VA_ARGS__); \
-    } while(0)
+  do { \
+    int level = COMPILER_ATOMIC_LOAD(&ncclDebugLevel, std::memory_order_acquire); \
+    if ((level >= NCCL_LOG_INFO && ((unsigned long)(FLAGS) & ncclDebugMask)) || (level < 0)) \
+      ncclDebugLog(NCCL_LOG_INFO, (unsigned long)(FLAGS), __func__, __LINE__, __VA_ARGS__); \
+  } while (0)
 
 #define TRACE_CALL(...) \
-    do { \
-        int level = COMPILER_ATOMIC_LOAD(&ncclDebugLevel, std::memory_order_acquire); \
-        if((level >= NCCL_LOG_TRACE && (NCCL_CALL & ncclDebugMask)) || (level < 0)) { \
-            ncclDebugLog(NCCL_LOG_TRACE, NCCL_CALL, __func__, __LINE__, __VA_ARGS__); \
-        } \
-    } while (0)
+  do { \
+    int level = COMPILER_ATOMIC_LOAD(&ncclDebugLevel, std::memory_order_acquire); \
+    if ((level >= NCCL_LOG_TRACE && (NCCL_CALL & ncclDebugMask)) || (level < 0)) { \
+      ncclDebugLog(NCCL_LOG_TRACE, NCCL_CALL, __func__, __LINE__, __VA_ARGS__); \
+    } \
+  } while (0)
 
 #ifdef ENABLE_TRACE
 #define TRACE(FLAGS, ...) ncclDebugLog(NCCL_LOG_TRACE, (FLAGS), __func__, __LINE__, __VA_ARGS__)
@@ -67,9 +68,9 @@ extern char ncclLastError[];
 #define TRACE(...)
 #endif
 
-void ncclSetThreadName(std::thread& thread, const char *fmt, ...);
+void ncclSetThreadName(std::thread& thread, const char* fmt, ...);
 // [RCCL] Overload for legacy pthread_t-managed threads (e.g. net_ib*).
-void ncclSetThreadName(pthread_t thread, const char *fmt, ...);
+void ncclSetThreadName(pthread_t thread, const char* fmt, ...);
 
 #ifdef __cplusplus
 extern "C" {
@@ -84,20 +85,19 @@ void ncclResetDebugInit();
 
 // RCCL custom error message handling.
 static inline ncclResult_t rcclCudaErrorHandler(cudaError_t err) {
-
     // Print the cuda error
-    ERROR("HIP failure: '%s'", cudaGetErrorString(err));
+  ERROR("HIP failure: '%s'", cudaGetErrorString(err));
 
     // Special error message here:
-    switch (err) {
-    case cudaErrorStreamCaptureInvalidated:
-	    ERROR("Application is trying to use an invalidated stream to launch RCCL kernel. "
-	          "This operation is invalid. RCCL is exiting.");
-	    break;
-    default:
-	    break;
-    }
-    return ncclUnhandledCudaError;
+  switch (err) {
+  case cudaErrorStreamCaptureInvalidated:
+    ERROR("Application is trying to use an invalidated stream to launch RCCL kernel. "
+          "This operation is invalid. RCCL is exiting.");
+    break;
+  default:
+    break;
+  }
+  return ncclUnhandledCudaError;
 }
 
 #endif

--- a/projects/rccl/src/include/dev_runtime.h
+++ b/projects/rccl/src/include/dev_runtime.h
@@ -42,7 +42,7 @@ struct ncclDevrWindowSorted;
 struct ncclDevrTeam;
 
 struct ncclDevrRegTask {
-  struct ncclDevrRegTask *next;
+  struct ncclDevrRegTask* next;
   void* userPtr;
   size_t userSize;
   int winFlags;
@@ -50,7 +50,7 @@ struct ncclDevrRegTask {
 };
 
 struct ncclDevrCommCreateTask {
-  struct ncclDevrCommCreateTask *next;
+  struct ncclDevrCommCreateTask* next;
   struct ncclDevCommRequirements* reqs;
   struct ncclDevComm* outDevComm;
   struct ncclDevCommCompat* devCompat;
@@ -104,23 +104,20 @@ ncclResult_t ncclDevrFinalize(struct ncclComm* comm);
 // If found *outWinHost will be populated and *outWinId >= 0, otherwise *outWinId == -1
 ncclResult_t ncclDevrFindWindow(struct ncclComm* comm, void const* userPtr, struct ncclDevrWindow** outWin);
 
-ncclResult_t ncclDevrWindowRegisterInGroup(
-  struct ncclComm* comm, void* ptr, size_t size, int winFlags, ncclWindow_t* outWinDev
-);
+ncclResult_t ncclDevrWindowRegisterInGroup(struct ncclComm* comm, void* ptr, size_t size, int winFlags,
+                                           ncclWindow_t* outWinDev);
 
-ncclResult_t ncclDevrCommCreateInternal(
-  struct ncclComm* comm, struct ncclDevCommRequirements* reqs, struct ncclDevComm* outDevComm,
-  bool isInternal = false, struct ncclDevCommCompat* devCompat = nullptr
-);
-void freeDevCommRequirements(
-  struct ncclDevCommRequirements* reqs
-);
+ncclResult_t ncclDevrCommCreateInternal(struct ncclComm* comm, struct ncclDevCommRequirements* reqs,
+                                        struct ncclDevComm* outDevComm, bool isInternal = false,
+                                        struct ncclDevCommCompat* devCompat = nullptr);
+void freeDevCommRequirements(struct ncclDevCommRequirements* reqs);
 
 bool ncclDevrWindowIsMultiSegment(struct ncclDevrWindow* win);
 bool ncclDevrWindowHasSysmemSegment(struct ncclDevrWindow* win);
 
 // Get the corresponding pointer in another lsa rank's symmetric memory window
-ncclResult_t ncclDevrGetLsaRankPtr(struct ncclComm* comm, struct ncclDevrWindow* winHost, size_t offset, int lsaRank, void** outPtr);
+ncclResult_t ncclDevrGetLsaRankPtr(struct ncclComm* comm, struct ncclDevrWindow* winHost, size_t offset, int lsaRank,
+                                   void** outPtr);
 
 // Convert a world rank to an LSA rank.
 ncclResult_t ncclDevrWorldToLsaRank(struct ncclComm* comm, int peerWorldRank, int* peerLsaRank);
@@ -129,7 +126,8 @@ ncclResult_t ncclDevrWorldToLsaRank(struct ncclComm* comm, int peerWorldRank, in
 ncclGinWindow_t ncclDevrGetRmaDevWin(struct ncclDevrWindow* winHost, int ctx);
 
 // Get the multicast address for a given team
-ncclResult_t ncclDevrGetLsaTeamPtrMC(struct ncclComm* comm, struct ncclDevrWindow* winHost, size_t offset, struct ncclTeam lsaTeam, void** outPtr);
+ncclResult_t ncclDevrGetLsaTeamPtrMC(struct ncclComm* comm, struct ncclDevrWindow* winHost, size_t offset,
+                                     struct ncclTeam lsaTeam, void** outPtr);
 
 // Copies the devComm data from "rank" to "lsaBarrier".  Assumes the same memory layout at source and destination.
 void ncclDevCommCopyLsaData(void* dstRankPtr, void const* srcRankPtr);

--- a/projects/rccl/src/include/device.h
+++ b/projects/rccl/src/include/device.h
@@ -13,19 +13,19 @@
 #include "rccl_float8.h"
 #if ROCM_VERSION >= 60000
   // This is a workaround for the fact that the old hip_bfloat16.h header file may still be used by some rocm files.
-  // The _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_BFLOAT16_H_ and _HIP_BFLOAT16_H_ macros are defined in the old hip_bfloat16.h header
-  #if !defined(_HIP_INCLUDE_HIP_AMD_DETAIL_HIP_BFLOAT16_H_) && !defined(_HIP_BFLOAT16_H_)
-    #define _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_BFLOAT16_H_
-    #define _HIP_BFLOAT16_H_
-    #include <hip/hip_bf16.h>
-    typedef __hip_bfloat16 hip_bfloat16;
-  #elif ROCM_VERSION >= 70000
-    #include <hip/hip_bf16.h>
-  #else
-    #error "RCCL is not using the correct hip_bf16.h file. Please make sure that the correct header is included!"
-  #endif
+// The _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_BFLOAT16_H_ and _HIP_BFLOAT16_H_ macros are defined in the old hip_bfloat16.h header
+#if !defined(_HIP_INCLUDE_HIP_AMD_DETAIL_HIP_BFLOAT16_H_) && !defined(_HIP_BFLOAT16_H_)
+#define _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_BFLOAT16_H_
+#define _HIP_BFLOAT16_H_
+#include <hip/hip_bf16.h>
+typedef __hip_bfloat16 hip_bfloat16;
+#elif ROCM_VERSION >= 70000
+#include <hip/hip_bf16.h>
 #else
-  #include <hip/hip_bfloat16.h>
+#error "RCCL is not using the correct hip_bf16.h file. Please make sure that the correct header is included!"
+#endif
+#else
+#include <hip/hip_bfloat16.h>
 #endif
 #include "nccl_tuner.h"
 #include "bitops.h"
@@ -40,7 +40,7 @@
 #include <rocshmem/rocshmem.hpp>
 #endif
 
-extern const char* ncclFuncStr[NCCL_NUM_FUNCTIONS+4];
+extern const char* ncclFuncStr[NCCL_NUM_FUNCTIONS + 4];
 
 extern const char* ncclAlgoStr[NCCL_NUM_ALGORITHMS];
 
@@ -50,40 +50,43 @@ extern const char* ncclProtoStr[NCCL_NUM_PROTOCOLS];
 #define NCCL_STEPS 8
 
 #ifdef __CUDA_ARCH__
-  #define NCCL_CUDA_ARCH __CUDA_ARCH__
+#define NCCL_CUDA_ARCH __CUDA_ARCH__
 #else
-  #define NCCL_CUDA_ARCH 0
+#define NCCL_CUDA_ARCH 0
 #endif
 
 #ifdef __CUDA_ARCH_SPECIFIC__
-  #define NCCL_CUDA_ARCH_SPECIFIC __CUDA_ARCH_SPECIFIC__
+#define NCCL_CUDA_ARCH_SPECIFIC __CUDA_ARCH_SPECIFIC__
 #elif defined(__CUDA_ARCH_HAS_FEATURE__)
-  #if __CUDA_ARCH_HAS_FEATURE__(SM90_ALL)
-    #define NCCL_CUDA_ARCH_SPECIFIC 900
-  #elif __CUDA_ARCH_HAS_FEATURE__(SM100_ALL)
-    #define NCCL_CUDA_ARCH_SPECIFIC 1000
-  #elif __CUDA_ARCH_HAS_FEATURE__(SM101_ALL)
-    #define NCCL_CUDA_ARCH_SPECIFIC 1010
-  #elif __CUDA_ARCH_HAS_FEATURE__(SM120_ALL)
-    #define NCCL_CUDA_ARCH_SPECIFIC 1200
-  #else
-    #define NCCL_CUDA_ARCH_SPECIFIC 0
-  #endif
+#if __CUDA_ARCH_HAS_FEATURE__(SM90_ALL)
+#define NCCL_CUDA_ARCH_SPECIFIC 900
+#elif __CUDA_ARCH_HAS_FEATURE__(SM100_ALL)
+#define NCCL_CUDA_ARCH_SPECIFIC 1000
+#elif __CUDA_ARCH_HAS_FEATURE__(SM101_ALL)
+#define NCCL_CUDA_ARCH_SPECIFIC 1010
+#elif __CUDA_ARCH_HAS_FEATURE__(SM120_ALL)
+#define NCCL_CUDA_ARCH_SPECIFIC 1200
 #else
-  #define NCCL_CUDA_ARCH_SPECIFIC 0
+#define NCCL_CUDA_ARCH_SPECIFIC 0
+#endif
+#else
+#define NCCL_CUDA_ARCH_SPECIFIC 0
 #endif
 
 #ifdef __CUDA_ARCH_FAMILY_SPECIFIC__
-  #define NCCL_CUDA_ARCH_FAMILY_SPECIFIC __CUDA_ARCH_FAMILY_SPECIFIC__
+#define NCCL_CUDA_ARCH_FAMILY_SPECIFIC __CUDA_ARCH_FAMILY_SPECIFIC__
 #else
-  #define NCCL_CUDA_ARCH_FAMILY_SPECIFIC 0
+#define NCCL_CUDA_ARCH_FAMILY_SPECIFIC 0
 #endif
 
 #include "nccl_device/net_device.h"
 
 enum ncclDevRedOp_t {
-  ncclDevSum, ncclDevProd, ncclDevMinMax,
-  ncclDevPreMulSum, ncclDevSumPostDiv,
+  ncclDevSum,
+  ncclDevProd,
+  ncclDevMinMax,
+  ncclDevPreMulSum,
+  ncclDevSumPostDiv,
   ncclNumDevRedOps
 };
 struct ncclDevRedOpFull {
@@ -111,33 +114,33 @@ union ncclLLFifoLine {
   uint64_t v[2];
   int4 i4;
 #if defined(__HIP_DEVICE_COMPILE__) && RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
-  v4u v4u;  /* same layout as data1,flag1,data2,flag2 for b128 load/store */
+  v4u v4u; /* same layout as data1,flag1,data2,flag2 for b128 load/store */
 #endif
 };
 
 #if __HIP_DEVICE_COMPILE__
-  #if defined(__GFX9__)
-  #define WARP_SIZE 64
-  #else
-  #define WARP_SIZE 32
-  #endif
-  #if defined (__gfx950__)
-  #define NCCL_MAX_NTHREADS 256
-  #else
-  #define NCCL_MAX_NTHREADS 256
-  #endif
-  // Number of named barriers supported by CUDA
-  #define NCCL_MAX_GROUPS (NCCL_MAX_NTHREADS/WARP_SIZE)
+#if defined(__GFX9__)
+#define WARP_SIZE 64
+#else
+#define WARP_SIZE 32
+#endif
+#if defined(__gfx950__)
+#define NCCL_MAX_NTHREADS 256
+#else
+#define NCCL_MAX_NTHREADS 256
+#endif
+// Number of named barriers supported by CUDA
+#define NCCL_MAX_GROUPS (NCCL_MAX_NTHREADS / WARP_SIZE)
 #else
  /* IMPORTANT Note ragarding WARP_SIZE, NCCL_MAX_NTHREADS and NCCL_MAX_GROUPS:
-  * These should NEVER be referenced by host code in RCCL. It is defined here
-  * solely as a workaround to allow RCCL to compile, since the host still compiles __device__ functions,
-  * and they need to be defined. These __device__ functions will not be called from the host.
-  * The host warp size is handled in src/enqueue.cc by calling hipDeviceGetAttributes(). */
-  #define WARP_SIZE 32
-  #define NCCL_MAX_NTHREADS 256
+ * These should NEVER be referenced by host code in RCCL. It is defined here
+ * solely as a workaround to allow RCCL to compile, since the host still compiles __device__ functions,
+ * and they need to be defined. These __device__ functions will not be called from the host.
+ * The host warp size is handled in src/enqueue.cc by calling hipDeviceGetAttributes(). */
+#define WARP_SIZE 32
+#define NCCL_MAX_NTHREADS 256
   // Number of named barriers supported by CUDA
-  #define NCCL_MAX_GROUPS (NCCL_MAX_NTHREADS/WARP_SIZE)
+#define NCCL_MAX_GROUPS (NCCL_MAX_NTHREADS / WARP_SIZE)
 #endif
 
 #ifdef ENABLE_WARP_SPEED
@@ -147,14 +150,14 @@ union ncclLLFifoLine {
 #endif
 #define CHANNEL_LIMIT 16 // this is used to limit channels for pre MI3xx GPUs
 #define NCCL_MAX_LOCAL_RANKS 72
-#define NCCL_MIN_NTHREADS (4*WARP_SIZE)
+#define NCCL_MIN_NTHREADS (4 * WARP_SIZE)
 #define NCCL_SIMPLE_MAX_NTHREADS NCCL_MAX_NTHREADS
-#define NCCL_SIMPLE_EXTRA_GROUP_IF_NTHREADS_GE (3*WARP_SIZE)
+#define NCCL_SIMPLE_EXTRA_GROUP_IF_NTHREADS_GE (3 * WARP_SIZE)
 #define NCCL_LL_MAX_NTHREADS NCCL_MAX_NTHREADS
 #define NCCL_LL_LINES_PER_THREAD 8
 #ifdef TEST_LL_CLEANUP
 #define NCCL_LL_CLEAN_MASK 0x078 // Set to 0x100 to disable cleanup
-#define NCCL_LL_FLAG_MAX   0x100
+#define NCCL_LL_FLAG_MAX 0x100
 #define NCCL_LL_FLAG(a) ((uint32_t)((a) % NCCL_LL_FLAG_MAX))
 #else
 #define NCCL_LL_CLEAN_MASK 0x7ffffff8
@@ -163,14 +166,14 @@ union ncclLLFifoLine {
 // Make sure the clean mask will last for at least NCCL_NSTEPS
 static_assert(NCCL_LL_CLEAN_MASK % NCCL_STEPS == 0, "Invalid NCCL_LL_CLEAN_MASK value");
 
- /* Note regarding LL128 macros settings in RCCL below:
-  * Device code: NCCL_LL128_LINESIZE is arch-dependent (128 for gfx1250, 64 otherwise).
-  * Host code: Must NOT use these macros for logic as they default to 64. Instead use
-  * rcclLL128LineElemsFromArch() / rcclLL128DataElemsFromArch() (archinfo.h) or
-  * comm->ll128LineElems / comm->ll128DataElems (and proxyState->* in the net proxy). */
+/* Note regarding LL128 macros settings in RCCL below:
+ * Device code: NCCL_LL128_LINESIZE is arch-dependent (128 for gfx1250, 64 otherwise).
+ * Host code: Must NOT use these macros for logic as they default to 64. Instead use
+ * rcclLL128LineElemsFromArch() / rcclLL128DataElemsFromArch() (archinfo.h) or
+ * comm->ll128LineElems / comm->ll128DataElems (and proxyState->* in the net proxy). */
 
 #if __HIP_DEVICE_COMPILE__
-#if defined (__gfx1250__)
+#if defined(__gfx1250__)
 #define NCCL_LL128_LINESIZE 128
 #else
 #define NCCL_LL128_LINESIZE 64
@@ -178,8 +181,8 @@ static_assert(NCCL_LL_CLEAN_MASK % NCCL_STEPS == 0, "Invalid NCCL_LL_CLEAN_MASK 
 #else
 #define NCCL_LL128_LINESIZE 64
 #endif
-#define NCCL_LL128_LINEELEMS (NCCL_LL128_LINESIZE/sizeof(uint64_t))
-#define NCCL_LL128_DATAELEMS (NCCL_LL128_LINEELEMS-1)
+#define NCCL_LL128_LINEELEMS (NCCL_LL128_LINESIZE / sizeof(uint64_t))
+#define NCCL_LL128_DATAELEMS (NCCL_LL128_LINEELEMS - 1)
 
 #define NCCL_LL128_MAX_NTHREADS 256
 #if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
@@ -191,11 +194,11 @@ static_assert(NCCL_LL_CLEAN_MASK % NCCL_STEPS == 0, "Invalid NCCL_LL_CLEAN_MASK 
 #endif
 
 #define NCCL_LL128_SHMEM_ELEMS_PER_THREAD 8
-#define NCCL_LL128_SHMEM_SIZE (NCCL_LL128_SHMEM_ELEMS_PER_THREAD*NCCL_LL128_MAX_NTHREADS)
+#define NCCL_LL128_SHMEM_SIZE (NCCL_LL128_SHMEM_ELEMS_PER_THREAD * NCCL_LL128_MAX_NTHREADS)
 
 #define NCCL_P2P_WRITE 0x01
-#define NCCL_P2P_READ  0x02
-#define NCCL_DIRECT_NIC   0x04
+#define NCCL_P2P_READ 0x02
+#define NCCL_DIRECT_NIC 0x04
 #define NCCL_NVLS_MIN_POLL 0x80
 
 #define NCCL_REGULAR_BUFFER 0x00
@@ -214,27 +217,27 @@ static_assert(NCCL_LL_CLEAN_MASK % NCCL_STEPS == 0, "Invalid NCCL_LL_CLEAN_MASK 
 
 struct ncclConnInfo {
   // Regular comm mechanism
-  char *buffs[NCCL_NUM_PROTOCOLS]; // Local for recv, remote for send
+  char* buffs[NCCL_NUM_PROTOCOLS]; // Local for recv, remote for send
   void* mhandles[NCCL_NUM_PROTOCOLS];
-  uint64_t *tail;     // Local for recv, remote for send
-  uint64_t *head;     // Local for send, remote for recv
+  uint64_t* tail; // Local for recv, remote for send
+  uint64_t* head; // Local for send, remote for recv
 
-  int flags;          // Direct communication / other flags
-  int shared;         // Buffers are shared
-  int stepSize;       // Step size for the SIMPLE buffer
-  void **ptrExchange; // Pointer exchange for direct communication
+  int flags; // Direct communication / other flags
+  int shared; // Buffers are shared
+  int stepSize; // Step size for the SIMPLE buffer
+  void** ptrExchange; // Pointer exchange for direct communication
   uint64_t* redOpArgExchange; // PreOp scaler exchange for direct pull case
 
   struct ncclConnFifo* connFifo; // Used for GPU - Proxy communication
 
-  uint64_t step;      // Keep where we are
+  uint64_t step; // Keep where we are
   uint64_t llLastCleaning;
 
   // GPU's HDP_MEM_FLUSH_ADDR: HDP Memory Coherency Flush Control. This register
   // allows software to explicitly initiate a flush read to HDP memory. See more
   // descriptions in primitives.h.
-  uint32_t* next_hdp_reg;  // Next GPU in ring (for p2p transport use only)
-  uint32_t* curr_hdp_reg;  // Current GPU's HDP register
+  uint32_t* next_hdp_reg; // Next GPU in ring (for p2p transport use only)
+  uint32_t* curr_hdp_reg; // Current GPU's HDP register
   ncclNetDeviceHandle_t netDeviceHandle;
 };
 
@@ -246,7 +249,8 @@ struct ncclProxyConnector {
   int sameProcess;
   int connId; // Server-issued integer handle, used as the wire identifier on subsequent proxy RPCs.
   struct ncclProxyConnection* connection;
-  ncclResult_t (*proxyProgress)(struct ncclProxyState* proxyState, struct ncclProxyArgs*); // Copied from transport if necessary
+  ncclResult_t (*proxyProgress)(struct ncclProxyState* proxyState,
+                                struct ncclProxyArgs*); // Copied from transport if necessary
   ncclResult_t (*proxyGinProgress)(struct ncclProxyState* proxyState);
 };
 
@@ -270,7 +274,7 @@ struct ncclRing {
   // devices. Ordered from current device.
   int* userRanks;
   // Maps a user rank to an internal ring index.
-  int* rankToIndex;  // inverse lookup of userRanks, setup in setupChannel
+  int* rankToIndex; // inverse lookup of userRanks, setup in setupChannel
   int index; // This rank's index in the ring
 };
 
@@ -288,12 +292,12 @@ struct ncclTree {
 struct ncclDirect {
   int depth;
   int out;
-  int nHeads;   // Number of parallel N<->1<->net operations we'll do in parallel; size of up/down
+  int nHeads; // Number of parallel N<->1<->net operations we'll do in parallel; size of up/down
   int headRank; // Index in 0..nHeads-1 I am the head rank of. -1 if I'm not a head rank (no local NIC)
-  int shift;    // Shuffling of send/recv for scatter/gather operations, basically localRank%nHeads
+  int shift; // Shuffling of send/recv for scatter/gather operations, basically localRank%nHeads
   // The heads[...] are guaranteed to be in rotated order start with self:
   //   headRank, (headRank+1)%nHeads, (headRank+2)%nHeads, ...
-  int heads[NCCL_MAX_DIRECT_ARITY+1];
+  int heads[NCCL_MAX_DIRECT_ARITY + 1];
   int up[NCCL_MAX_DIRECT_ARITY];
   int down[NCCL_MAX_DIRECT_ARITY];
 };
@@ -303,7 +307,7 @@ struct ncclDirect {
 #define NCCL_MAX_NVLS_TREE_ARITY 3
 struct ncclNvls {
   int out;
-  int nHeads;   // Number of parallel N<->1<->net operations we'll do in parallel; size of up/down
+  int nHeads; // Number of parallel N<->1<->net operations we'll do in parallel; size of up/down
   int headRank; // Index in 0..nHeads-1 I am the head rank of. -1 if I'm not a head rank (no local NIC)
   int up[NCCL_MAX_NVLS_ARITY];
   int down;
@@ -326,8 +330,8 @@ struct ncclChannelPeer {
 
 struct ncclKernelComm;
 
-#pragma pack(push)  /* push current alignment to stack */
-#pragma pack(8)     /* set alignment to 8 bytes boundary */
+#pragma pack(push) /* push current alignment to stack */
+#pragma pack(8) /* set alignment to 8 bytes boundary */
 
 struct alignas(16) ncclDevWorkP2p {
   void *sendAddr, *recvAddr;
@@ -353,15 +357,16 @@ struct alignas(16) ncclDevWorkP2p {
 };
 
 // Compute the subset of the data transfer corresponding to the given part index.
-inline __host__ __device__ void ncclP2pPartBounds(int nParts, int part, size_t bytes, size_t* partBeg, size_t* partEnd) {
-  size_t partBytes = alignUp(divUp(bytes, nParts), 4<<10);
-  #if __CUDA_ARCH__
-    *partBeg = min((part+0)*partBytes, bytes);
-    *partEnd = min((part+1)*partBytes, bytes);
-  #else
-    *partBeg = std::min<size_t>((part+0)*partBytes, bytes);
-    *partEnd = std::min<size_t>((part+1)*partBytes, bytes);
-  #endif
+inline __host__ __device__ void ncclP2pPartBounds(int nParts, int part, size_t bytes, size_t* partBeg,
+                                                  size_t* partEnd) {
+  size_t partBytes = alignUp(divUp(bytes, nParts), 4 << 10);
+#if __CUDA_ARCH__
+  *partBeg = min((part + 0) * partBytes, bytes);
+  *partEnd = min((part + 1) * partBytes, bytes);
+#else
+  *partBeg = std::min<size_t>((part + 0) * partBytes, bytes);
+  *partEnd = std::min<size_t>((part + 1) * partBytes, bytes);
+#endif
 }
 
 // implemented in channel.h
@@ -370,34 +375,34 @@ inline __host__ uint8_t ncclP2pChannelBaseForRound(struct ncclComm* comm, int p2
 // ncclP2pChannelToPart and ncclP2pChannelForPart are inverses. The device code
 // uses ncclP2pChannelToPart to determine which part "this" channel is responsible for.
 inline __host__ int ncclP2pChannelForPart(int nP2pChannels, int base, int part, int nParts, int nNodes, int shiftSize) {
-  if(shiftSize == -1 && nNodes > 2){
-    //use bit-reversal
-    int nChannelsLog2 = countOneBits(nP2pChannels-1);
+  if (shiftSize == -1 && nNodes > 2) {
+    // use bit-reversal
+    int nChannelsLog2 = countOneBits(nP2pChannels - 1);
     int delta = reverseBits(part, nChannelsLog2);
-    return (base + delta) & (nP2pChannels-1);
-  }
-  else if (nNodes > 2) {
-    //multi-node and shift-size specified -> linear mapping with shiftsize
+    return (base + delta) & (nP2pChannels - 1);
+  } else if (nNodes > 2) {
+    // multi-node and shift-size specified -> linear mapping with shiftsize
     // Only works because nP2pChannels is pow2
-    return (base + ((part + (base>>shiftSize))<<shiftSize)) & (nP2pChannels-1);
+    return (base + ((part + (base >> shiftSize)) << shiftSize)) & (nP2pChannels - 1);
   } else {
-    //this is equivalent to lineart mapping with shiftSize but only when nParts is 2
-    return (base * nParts + part) & (nP2pChannels-1);
+    // this is equivalent to lineart mapping with shiftSize but only when nParts is 2
+    return (base * nParts + part) & (nP2pChannels - 1);
   }
 }
-inline __device__ int ncclP2pChannelToPart(int nP2pChannels, int base, int channel, int nParts, int nNodes, int shiftSize) {
-  if(shiftSize == -1 && nNodes > 2){
-    //use bit-reversal
+inline __device__ int ncclP2pChannelToPart(int nP2pChannels, int base, int channel, int nParts, int nNodes,
+                                           int shiftSize) {
+  if (shiftSize == -1 && nNodes > 2) {
+    // use bit-reversal
     // Only works because nP2pChannels is pow2
-    int nChannelsLog2 = countOneBits(nP2pChannels-1);
-    int delta = (channel-base) & (nP2pChannels-1);
+    int nChannelsLog2 = countOneBits(nP2pChannels - 1);
+    int delta = (channel - base) & (nP2pChannels - 1);
     return reverseBits(delta, nChannelsLog2);
   }
   if (nNodes > 2) {
     // Only works because nP2pChannels is pow2
-    return (((channel - base) - ((base>>shiftSize)<<shiftSize))>>shiftSize) & ((nP2pChannels >> shiftSize)-1);
+    return (((channel - base) - ((base >> shiftSize) << shiftSize)) >> shiftSize) & ((nP2pChannels >> shiftSize) - 1);
   } else {
-    return (channel - base * nParts) & (nP2pChannels-1);
+    return (channel - base * nParts) & (nP2pChannels - 1);
   }
 }
 
@@ -415,7 +420,7 @@ struct alignas(16) ncclDevWorkColl {
   uint16_t pivotA2ANumBiRings:15, profilerEnabled:1;
   void* recvbuff;
   void* sendbuff;
-  void *acc;
+  void* acc;
   uintptr_t sendbuffOffset;
   uintptr_t recvbuffOffset;
   uintptr_t* sendbuffRmtAddrs;
@@ -453,88 +458,86 @@ struct alignas(16) ncclDevWorkColl {
   void* sndbuff;
   int size;
   int rank;
-  size_t *sizes;
-  size_t *sendSizes;
-  size_t *sendDispls;
-  size_t *recvSizes;
-  size_t *recvDispls;
+  size_t* sizes;
+  size_t* sendSizes;
+  size_t* sendDispls;
+  size_t* recvSizes;
+  size_t* recvDispls;
 #endif
 };
 
 struct alignas(16) ncclDevWorkBcast {
   int ringDepth;
   int chunkSize;
-  void *sendbuff;
-  void *recvbuff;
+  void* sendbuff;
+  void* recvbuff;
   size_t bytes;
   size_t bytes_done;
   uint8_t pad[8];
 };
 
 __device__ constexpr int ncclProtoGrainSize(int proto) {
-  return proto == NCCL_PROTO_LL ? 16 :
-        proto == NCCL_PROTO_LL128 ? WARP_SIZE*NCCL_LL128_SHMEM_ELEMS_PER_THREAD/NCCL_LL128_LINEELEMS*NCCL_LL128_DATAELEMS*sizeof(uint64_t) :
-        proto == NCCL_PROTO_SIMPLE ? 512 :
-        -1;
+  return proto == NCCL_PROTO_LL     ? 16 :
+         proto == NCCL_PROTO_LL128  ? WARP_SIZE * NCCL_LL128_SHMEM_ELEMS_PER_THREAD / NCCL_LL128_LINEELEMS *
+                                        NCCL_LL128_DATAELEMS * sizeof(uint64_t) :
+         proto == NCCL_PROTO_SIMPLE ? 512 :
+                                      -1;
 }
 
-template<typename Int>
-__device__ inline void ncclCollCbdPart(
-    struct ncclDevWorkColl* work, uint32_t channelId, int proto, int eltSize,
-    Int* count, Int* partOffset, Int* partCount, Int* chunkCount
-  ) {
-  int eltPerGrain = ncclProtoGrainSize(proto)/eltSize;
+template <typename Int>
+__device__ inline void ncclCollCbdPart(struct ncclDevWorkColl* work, uint32_t channelId, int proto, int eltSize,
+                                       Int* count, Int* partOffset, Int* partCount, Int* chunkCount) {
+  int eltPerGrain = ncclProtoGrainSize(proto) / eltSize;
   int nMidChannels = work->channelHi - work->channelLo - 1;
   // We can assum that nMidChannels<0 implies countMid==0, which let's us assume
   // that countMid*nMidChannels == 0.
   if (count != nullptr) {
-    *count = work->cbd.countLo + work->cbd.countMid*nMidChannels + work->cbd.countHi;
+    *count = work->cbd.countLo + work->cbd.countMid * nMidChannels + work->cbd.countHi;
   }
   if (channelId == work->channelLo) {
     *partOffset = 0;
     *partCount = work->cbd.countLo;
-    *chunkCount = work->cbd.chunkGrainsLo*eltPerGrain;
+    *chunkCount = work->cbd.chunkGrainsLo * eltPerGrain;
   } else if (channelId == work->channelHi) {
-    *partOffset = work->cbd.countLo + nMidChannels*work->cbd.countMid;
+    *partOffset = work->cbd.countLo + nMidChannels * work->cbd.countMid;
     *partCount = work->cbd.countHi;
-    *chunkCount = work->cbd.chunkGrainsHi*eltPerGrain;
+    *chunkCount = work->cbd.chunkGrainsHi * eltPerGrain;
   } else {
     int mid = channelId - work->channelLo - 1;
-    *partOffset = work->cbd.countLo + mid*work->cbd.countMid;
+    *partOffset = work->cbd.countLo + mid * work->cbd.countMid;
     *partCount = work->cbd.countMid;
-    *chunkCount = work->cbd.chunkGrainsMid*eltPerGrain;
+    *chunkCount = work->cbd.chunkGrainsMid * eltPerGrain;
   }
 }
 
 struct alignas(16) ncclDevWorkCollReg {
   struct ncclDevWorkColl coll;
-  void* dnInputs[NCCL_MAX_DIRECT_ARITY+1];
-  void* dnOutputs[NCCL_MAX_DIRECT_ARITY+1];
-  void* upOutputs[NCCL_MAX_DIRECT_ARITY+1];
+  void* dnInputs[NCCL_MAX_DIRECT_ARITY + 1];
+  void* dnOutputs[NCCL_MAX_DIRECT_ARITY + 1];
+  void* upOutputs[NCCL_MAX_DIRECT_ARITY + 1];
 };
 
-enum ncclDevWorkType: uint8_t {
+enum ncclDevWorkType : uint8_t {
   ncclDevWorkTypeP2p,
   ncclDevWorkTypeColl,
   ncclDevWorkTypeCollReg,
-  ncclDevWorkTypeBcast,  // for batched broadcast
+  ncclDevWorkTypeBcast, // for batched broadcast
 };
 
 constexpr size_t ncclDevWorkSize(enum ncclDevWorkType type) {
-  return type == ncclDevWorkTypeP2p ? sizeof(ncclDevWorkP2p) :
-         type == ncclDevWorkTypeColl ? sizeof(ncclDevWorkColl) :
+  return type == ncclDevWorkTypeP2p     ? sizeof(ncclDevWorkP2p) :
+         type == ncclDevWorkTypeColl    ? sizeof(ncclDevWorkColl) :
          type == ncclDevWorkTypeCollReg ? sizeof(ncclDevWorkCollReg) :
-         type == ncclDevWorkTypeBcast ? sizeof(ncclDevWorkBcast): 0;
+         type == ncclDevWorkTypeBcast   ? sizeof(ncclDevWorkBcast) :
+                                          0;
 }
 
 __host__ __device__ constexpr int ncclMaxDevWorkBatchBytes(int cudaArch = NCCL_CUDA_ARCH) {
-  return cudaArch < 800 ? (1<<10) :
-    cudaArch < 900 ? (8<<10) :
-    (16<<10);
+  return cudaArch < 800 ? (1 << 10) : cudaArch < 900 ? (8 << 10) : (16 << 10);
 }
 
 #define NCCL_MAX_DEV_WORK_BATCH_BYTES 192
-#define NCCL_MAX_DEV_WORK_BATCH_COLLS (NCCL_MAX_DEV_WORK_BATCH_BYTES/sizeof(ncclDevWorkColl))
+#define NCCL_MAX_DEV_WORK_BATCH_COLLS (NCCL_MAX_DEV_WORK_BATCH_BYTES / sizeof(ncclDevWorkColl))
 #define NCCL_MAX_DEV_WORK_P2P_PER_BATCH 2
 #define NCCL_MAX_DEV_WORK_P2P_ELEMENTS 2
 struct alignas(16) ncclDevWorkBatch {
@@ -562,9 +565,8 @@ struct ncclDevChannelPeer {
   // instead of the full ncclConnector.
   struct ncclConnInfo send[NCCL_MAX_CONNS];
   struct ncclConnInfo recv[NCCL_MAX_CONNS];
-
 };
-#pragma pack(pop)   /* restore original alignment from stack */
+#pragma pack(pop) /* restore original alignment from stack */
 
 struct alignas(16) ncclDevChannel {
   struct ncclDevChannelPeer** peers;
@@ -604,13 +606,13 @@ struct ncclKernelComm {
   volatile uint32_t* abortFlag;
 
   // Channels, device side
-  struct ncclDevChannel* channels/*[MAXCHANNELS]*/;
+  struct ncclDevChannel* channels /*[MAXCHANNELS]*/;
 
   int* rankToLocalRank;
 
   // Profiler counters
-  struct ncclDevProfiler* workStarted/*[MAXCHANNELS]*/;
-  struct ncclDevProfiler* workCompleted/*[MAXCHANNELS]*/;
+  struct ncclDevProfiler* workStarted /*[MAXCHANNELS]*/;
+  struct ncclDevProfiler* workCompleted /*[MAXCHANNELS]*/;
 
 #ifdef ENABLE_FAULT_INJECTION
   uint64_t faults;
@@ -626,14 +628,14 @@ struct alignas(16) ncclKernelCommAndChannels {
   struct ncclDevChannel channels[MAXCHANNELS];
 };
 
-enum ncclDevWorkStorageType: uint8_t {
-  ncclDevWorkStorageTypeArgs=0,
-  ncclDevWorkStorageTypeFifo=1,
-  ncclDevWorkStorageTypePersistent=2
+enum ncclDevWorkStorageType : uint8_t {
+  ncclDevWorkStorageTypeArgs = 0,
+  ncclDevWorkStorageTypeFifo = 1,
+  ncclDevWorkStorageTypePersistent = 2
 };
 
 struct channelMasks {
-  uint64_t masks[MAXCHANNELS/64];
+  uint64_t masks[MAXCHANNELS / 64];
 };
 
 struct alignas(16) ncclDevKernelArgs {
@@ -649,17 +651,17 @@ struct alignas(16) ncclDevKernelArgs {
   // struct ncclDevWorkBatch batches[];
 };
 
-template<size_t capacity>
+template <size_t capacity>
 struct alignas(16) ncclDevKernelArgsStorage {
   union {
     struct ncclDevKernelArgs args;
-    ulong2 storage[capacity/sizeof(ulong2)];
+    ulong2 storage[capacity / sizeof(ulong2)];
   };
 };
 
-typedef ncclDevKernelArgsStorage<(5<<10)> ncclDevKernelArgs5K;
-typedef ncclDevKernelArgsStorage<(4<<10)> ncclDevKernelArgs4K;
-//typedef ncclDevKernelArgsStorage<(32<<10)-4> ncclDevKernelArgs31K;
+typedef ncclDevKernelArgsStorage<(5 << 10)> ncclDevKernelArgs5K;
+typedef ncclDevKernelArgsStorage<(4 << 10)> ncclDevKernelArgs4K;
+// typedef ncclDevKernelArgsStorage<(32<<10)-4> ncclDevKernelArgs31K;
 
 #ifdef ENABLE_WARP_SPEED
 // needed extra storage for accomodating more channels than 128 for WarpSpeed support
@@ -669,27 +671,32 @@ typedef ncclDevKernelArgs5K ncclDevKernelArgsDefaultStorage;
 #else
 typedef ncclDevKernelArgs4K ncclDevKernelArgsDefaultStorage;
 #endif
-__host__ __device__ constexpr int ncclMaxKernelArgsSize(/*int cudaDriver, */int cudaArch=NCCL_CUDA_ARCH) {
-  //return (cudaArch < 700 || cudaDriver < 12010) ? 4<<10 : (32<<10)-4;
+__host__ __device__ constexpr int ncclMaxKernelArgsSize(/*int cudaDriver, */ int cudaArch = NCCL_CUDA_ARCH) {
+  // return (cudaArch < 700 || cudaDriver < 12010) ? 4<<10 : (32<<10)-4;
   return sizeof(ncclDevKernelArgsDefaultStorage);
 }
 
-template<typename T>
-__host__ __device__ constexpr T min_constexpr(T a) { return a; }
-template<typename T, typename ...Ts>
-__host__ __device__ constexpr T min_constexpr(T a, T b, Ts ...c) {
+template <typename T>
+__host__ __device__ constexpr T min_constexpr(T a) {
+  return a;
+}
+template <typename T, typename... Ts>
+__host__ __device__ constexpr T min_constexpr(T a, T b, Ts... c) {
   return min_constexpr<T>((a < b ? a : b), c...);
 }
 
-template<typename T>
-__host__ __device__ constexpr T max_constexpr(T a) { return a; }
-template<typename T, typename ...Ts>
-__host__ __device__ constexpr T max_constexpr(T a, T b, Ts ...c) {
+template <typename T>
+__host__ __device__ constexpr T max_constexpr(T a) {
+  return a;
+}
+template <typename T, typename... Ts>
+__host__ __device__ constexpr T max_constexpr(T a, T b, Ts... c) {
   return max_constexpr<T>((a > b ? a : b), c...);
 }
 
 constexpr int ncclDevMaxChannelsForArgsBytes(size_t argsBytes) {
-  return (int)min_constexpr<size_t>(MAXCHANNELS, (argsBytes - sizeof(struct ncclDevKernelArgs))/sizeof(struct ncclDevWorkBatch));
+  return (int)min_constexpr<size_t>(MAXCHANNELS,
+                                    (argsBytes - sizeof(struct ncclDevKernelArgs)) / sizeof(struct ncclDevWorkBatch));
 }
 
 // Calculate the unroll factor given:
@@ -697,7 +704,7 @@ constexpr int ncclDevMaxChannelsForArgsBytes(size_t argsBytes) {
 // * insns: max permissible unroll value
 // * bytes: desired number of in-flight bytes per iteration ( = unroll*bytePerPack)
 __host__ __device__ constexpr int ncclCalcUnroll(int bytePerPack, int insns, int bytes) {
-  return min_constexpr(insns, (bytes + bytePerPack-1)/bytePerPack);
+  return min_constexpr(insns, (bytes + bytePerPack - 1) / bytePerPack);
 }
 
 // Note that all unroll value logic should depend on a given cudaArch argument
@@ -710,8 +717,12 @@ __host__ __device__ constexpr int ncclCollUnroll(int cudaArch = NCCL_CUDA_ARCH) 
   return cudaArch >= 800 ? (cudaArch / 100 == 12 ? 6 : 8) : 4;
 }
 
-__host__ __device__ constexpr int ncclNvlsUnrollBytes(int cudaArch = NCCL_CUDA_ARCH) { return 4*16; }
-__host__ __device__ constexpr int ncclNvlsUnrollInsns(int cudaArch = NCCL_CUDA_ARCH) { return 16; }
+__host__ __device__ constexpr int ncclNvlsUnrollBytes(int cudaArch = NCCL_CUDA_ARCH) {
+  return 4 * 16;
+}
+__host__ __device__ constexpr int ncclNvlsUnrollInsns(int cudaArch = NCCL_CUDA_ARCH) {
+  return 16;
+}
 
 __host__ __device__ constexpr int ncclNvlsUnroll(int bytePerPack, int cudaArch = NCCL_CUDA_ARCH) {
   return ncclCalcUnroll(bytePerPack, ncclNvlsUnrollInsns(cudaArch), ncclNvlsUnrollBytes(cudaArch));
@@ -720,12 +731,13 @@ __host__ __device__ constexpr int ncclNvlsUnroll(int bytePerPack, int cudaArch =
 // The amount of dynamic shmem per warp
 __device__ constexpr int ncclShmemScratchWarpSize(int cudaArch = NCCL_CUDA_ARCH) {
   return (max_constexpr<int>(
-      /*LL    */0,
-      /*LL128 */(NCCL_LL128_SHMEM_ELEMS_PER_THREAD*WARP_SIZE)*sizeof(uint64_t),
-      /*SIMPLE*/(ncclCollUnroll(cudaArch)*WARP_SIZE + 1)*16,
-      // NVLS needs an extra 16B to read unaligned data.
-      /*NVLS  */WARP_SIZE*(cudaArch >= 900 ? ncclNvlsUnrollBytes(cudaArch) : 0) + 16
-    ) + 15) & -16; // pad to 16 bytes
+            /*LL    */ 0,
+            /*LL128 */ (NCCL_LL128_SHMEM_ELEMS_PER_THREAD * WARP_SIZE) * sizeof(uint64_t),
+            /*SIMPLE*/ (ncclCollUnroll(cudaArch) * WARP_SIZE + 1) * 16,
+            // NVLS needs an extra 16B to read unaligned data.
+            /*NVLS  */ WARP_SIZE * (cudaArch >= 900 ? ncclNvlsUnrollBytes(cudaArch) : 0) + 16) +
+          15) &
+         -16; // pad to 16 bytes
 }
 
 __host__ __device__ constexpr int ncclTmaShmemScratchWarpSize(void) {
@@ -737,7 +749,7 @@ __host__ __device__ constexpr int ncclTmaShmemScratchWarpSize(void) {
 #else
 // The amount of dynamic shmem per block
 __device__ constexpr int ncclShmemDynamicSize(int cudaArch = NCCL_CUDA_ARCH) {
-  return cudaArch < 700 ? 0 : ncclShmemScratchWarpSize(cudaArch)*(NCCL_MAX_NTHREADS/WARP_SIZE);
+  return cudaArch < 700 ? 0 : ncclShmemScratchWarpSize(cudaArch) * (NCCL_MAX_NTHREADS / WARP_SIZE);
 }
 #endif
 
@@ -752,7 +764,8 @@ extern void* const ncclDevKernelForFunc[/*funcIndex*/];
 extern bool const ncclDevKernelForFuncIsSpecialized[/*funcIndex*/];
 
 // Launch a one-rank reduction on stream.
-ncclResult_t ncclLaunchOneRank(void* dst, void const* src, size_t nElts, struct ncclDevRedOpFull redOp, ncclDataType_t type, cudaStream_t stream, void const* acc = nullptr);
+ncclResult_t ncclLaunchOneRank(void* dst, void const* src, size_t nElts, struct ncclDevRedOpFull redOp,
+                               ncclDataType_t type, cudaStream_t stream, void const* acc = nullptr);
 
 // `ncclNvlsSupported()` needs to be in sync with "func_valid" in "src/device/generate.py"
 inline bool ncclNvlsSupported(int devRedOp, int type) {
@@ -783,32 +796,35 @@ inline int ncclDevFuncId(int coll, int devRedOp, int type, int algo, int proto, 
   // coll, algo, proto, devRedOp, type, acc, pipeline
   // This logic must be in sync with the key generation logic in generate.py
   if (coll == ncclFuncBroadcast) {
-    key = ((uint64_t)(coll     & RCCL_FUNC_ID_MASK) << RCCL_COLL_SHIFT ) |
-          ((uint64_t)(proto    & RCCL_FUNC_ID_MASK) << RCCL_PROTO_SHIFT);
-  } else if (coll == ncclFuncSendRecv || coll == ncclFuncAlltoAllPivot || coll == ncclFuncAlltoAllGda || coll == ncclFuncAlltoAllvGda) {
-    key = ((uint64_t)(coll     & RCCL_FUNC_ID_MASK) << RCCL_COLL_SHIFT );
+    key = ((uint64_t)(coll & RCCL_FUNC_ID_MASK) << RCCL_COLL_SHIFT) |
+          ((uint64_t)(proto & RCCL_FUNC_ID_MASK) << RCCL_PROTO_SHIFT);
+  } else if (coll == ncclFuncSendRecv || coll == ncclFuncAlltoAllPivot || coll == ncclFuncAlltoAllGda ||
+             coll == ncclFuncAlltoAllvGda) {
+    key = ((uint64_t)(coll & RCCL_FUNC_ID_MASK) << RCCL_COLL_SHIFT);
   } else {
-    key = ((uint64_t)(coll     & RCCL_FUNC_ID_MASK) << RCCL_COLL_SHIFT ) |
-          ((uint64_t)(algo     & RCCL_FUNC_ID_MASK) << RCCL_ALGO_SHIFT ) |
-          ((uint64_t)(proto    & RCCL_FUNC_ID_MASK) << RCCL_PROTO_SHIFT) |
+    key = ((uint64_t)(coll & RCCL_FUNC_ID_MASK) << RCCL_COLL_SHIFT) |
+          ((uint64_t)(algo & RCCL_FUNC_ID_MASK) << RCCL_ALGO_SHIFT) |
+          ((uint64_t)(proto & RCCL_FUNC_ID_MASK) << RCCL_PROTO_SHIFT) |
           ((uint64_t)(devRedOp & RCCL_FUNC_ID_MASK) << RCCL_REDOP_SHIFT) |
-          ((uint64_t)(type     & RCCL_FUNC_ID_MASK) << RCCL_DTYPE_SHIFT) |
-          ((uint64_t)(acc      & RCCL_FUNC_ID_MASK) << RCCL_ACC_SHIFT)   |
+          ((uint64_t)(type & RCCL_FUNC_ID_MASK) << RCCL_DTYPE_SHIFT) |
+          ((uint64_t)(acc & RCCL_FUNC_ID_MASK) << RCCL_ACC_SHIFT) |
           ((uint64_t)(pipeline & RCCL_FUNC_ID_MASK) << RCCL_PIPELINE_SHIFT);
   }
   auto it = ncclDevFuncNameToId.find(key);
   if (it != ncclDevFuncNameToId.end()) {
     row = it->second;
   }
-  if(row < 0) {
-    WARN("Fatal error: ncclDevFuncId: %lu not found for coll: %d, algo: %d, proto: %d, devRedOp: %d, type: %d, acc: %d, pipeline: %d", key, coll, algo, proto, devRedOp, type, acc, pipeline);
+  if (row < 0) {
+    WARN("Fatal error: ncclDevFuncId: %lu not found for coll: %d, algo: %d, proto: %d, devRedOp: %d, type: %d, acc: "
+         "%d, pipeline: %d",
+         key, coll, algo, proto, devRedOp, type, acc, pipeline);
     return -1;
   }
   return row;
 }
 
 inline int ncclDevFuncId_P2p() {
-  static int ncclDevFuncIdP2p = ncclDevFuncId(ncclFuncSendRecv, -1 , -1 , NCCL_ALGO_UNDEF, NCCL_PROTO_UNDEF);
+  static int ncclDevFuncIdP2p = ncclDevFuncId(ncclFuncSendRecv, -1, -1, NCCL_ALGO_UNDEF, NCCL_PROTO_UNDEF);
   return ncclDevFuncIdP2p;
 }
 

--- a/projects/rccl/src/include/device_buffer.h
+++ b/projects/rccl/src/include/device_buffer.h
@@ -13,7 +13,7 @@
 namespace meta::comms {
 
 class DeviceBuffer {
- public:
+public:
   explicit DeviceBuffer(std::size_t size);
   ~DeviceBuffer();
 
@@ -22,9 +22,11 @@ class DeviceBuffer {
   DeviceBuffer(DeviceBuffer&& other) noexcept;
   DeviceBuffer& operator=(DeviceBuffer&& other) noexcept;
 
-  void* get() const { return ptr_; }
+  void* get() const {
+    return ptr_;
+  }
 
- private:
+private:
   void* ptr_{nullptr};
   std::size_t size_{0};
 };

--- a/projects/rccl/src/include/enqueue.h
+++ b/projects/rccl/src/include/enqueue.h
@@ -32,23 +32,23 @@ ncclResult_t ncclTasksRegAndEnqueue(struct ncclComm* comm);
 int64_t ncclParamLaunchOrderImplicit();
 
 static inline size_t ncclFuncSendCount(ncclFunc_t func, int nRanks, size_t count) {
-  return func == ncclFuncReduceScatter ? nRanks*count : count;
+  return func == ncclFuncReduceScatter ? nRanks * count : count;
 }
 static inline size_t ncclFuncRecvCount(ncclFunc_t func, int nRanks, size_t count) {
-  return func == ncclFuncAllGather ? nRanks*count : count;
+  return func == ncclFuncAllGather ? nRanks * count : count;
 }
 rccl_static inline size_t ncclFuncMaxSendRecvCount(ncclFunc_t func, int nRanks, size_t count) {
-  return func == ncclFuncAllGather || func == ncclFuncReduceScatter ? nRanks*count : count;
+  return func == ncclFuncAllGather || func == ncclFuncReduceScatter ? nRanks * count : count;
 }
 
 ncclResult_t ncclGetCollNetSupport(struct ncclComm* comm, struct ncclTaskColl* task, int* collNetSupport);
-ncclResult_t ncclGetAlgoInfo(
-  struct ncclComm* comm, struct ncclTaskColl* task,
-  int collNetSupport, int nvlsSupport, int numPipeOps, ncclSimInfo_t* simInfo = NULL
-);
+ncclResult_t ncclGetAlgoInfo(struct ncclComm* comm, struct ncclTaskColl* task, int collNetSupport, int nvlsSupport,
+                             int numPipeOps, ncclSimInfo_t* simInfo = NULL);
 bool ncclTestBudget(struct ncclKernelPlanBudget* budget, int nWorkBatches, ssize_t nWorkBytes);
 
-void ncclAddWorkBatchToPlan(struct ncclComm* comm, struct ncclKernelPlan* plan, int channelId, enum ncclDevWorkType workType, int devFuncId, uint32_t workOffset, int p2pEpoch =-1, int p2pRound = -1, bool newBatch = false);
+void ncclAddWorkBatchToPlan(struct ncclComm* comm, struct ncclKernelPlan* plan, int channelId,
+                            enum ncclDevWorkType workType, int devFuncId, uint32_t workOffset, int p2pEpoch = -1,
+                            int p2pRound = -1, bool newBatch = false);
 
 // RCCL-only shim: sets plan->kernelFn / kernelSpecialized using the file-local
 // ncclKerns table in enqueue.cc, for upstream-style schedulers (e.g.

--- a/projects/rccl/src/include/gin/gin_host.h
+++ b/projects/rccl/src/include/gin/gin_host.h
@@ -59,7 +59,8 @@ ncclResult_t getGlobalRailedGinType(struct ncclComm* comm, ncclGinType_t* ginTyp
 // FIXME change to ncclGinState instead of ncclComm, no need to pass comm
 ncclResult_t ncclGinConnectOnce(struct ncclComm* comm);
 ncclResult_t ncclGinHostFinalize(struct ncclComm* comm);
-ncclResult_t ncclGinDevCommSetup(struct ncclComm* comm, struct ncclDevCommRequirements const* reqs, struct ncclDevComm* devComm);
+ncclResult_t ncclGinDevCommSetup(struct ncclComm* comm, struct ncclDevCommRequirements const* reqs,
+                                 struct ncclDevComm* devComm);
 ncclResult_t ncclGinDevCommFree(struct ncclComm* comm, struct ncclDevComm const* devComm);
 ncclResult_t ncclGinRegister(struct ncclComm* comm, void* address, size_t size,
                              void* ginHostWins[NCCL_GIN_MAX_CONNECTIONS],

--- a/projects/rccl/src/include/gin/gin_host_win_stub.h
+++ b/projects/rccl/src/include/gin/gin_host_win_stub.h
@@ -48,15 +48,21 @@ struct ncclGin {
   ncclResult_t (*getProperties)(int dev, ncclNetProperties_t* props);
   ncclResult_t (*listen)(void* ctx, int dev, void* handle, void** listenComm);
   ncclResult_t (*connect)(void* ctx, void* handles[], int nranks, int rank, void* listenComm, void** collComm);
-  ncclResult_t (*createContext)(void* collComm, ncclGinConfig_t* config, void** ginCtx, ncclNetDeviceHandle_t** devHandle);
-  ncclResult_t (*regMrSym)(void* collComm, void* data, size_t size, int type, uint64_t mrFlags, void** mhandle, void** ginHandle);
-  ncclResult_t (*regMrSymDmaBuf)(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd, uint64_t mrFlags, void** mhandle, void** ginHandle);
+  ncclResult_t (*createContext)(void* collComm, ncclGinConfig_t* config, void** ginCtx,
+                                ncclNetDeviceHandle_t** devHandle);
+  ncclResult_t (*regMrSym)(void* collComm, void* data, size_t size, int type, uint64_t mrFlags, void** mhandle,
+                           void** ginHandle);
+  ncclResult_t (*regMrSymDmaBuf)(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd,
+                                 uint64_t mrFlags, void** mhandle, void** ginHandle);
   ncclResult_t (*deregMrSym)(void* collComm, void* mhandle);
   ncclResult_t (*destroyContext)(void* ginCtx);
   ncclResult_t (*closeColl)(void* collComm);
   ncclResult_t (*closeListen)(void* listenComm);
-  ncclResult_t (*iput)(void* ginCtx, int context, uint64_t srcOff, void* srcMhandle, size_t size, uint64_t dstOff, void* dstMhandle, uint32_t rank, void** request);
-  ncclResult_t (*iputSignal)(void* ginCtx, int context, uint64_t srcOff, void* srcMhandle, size_t size, uint64_t dstOff, void* dstMhandle, uint32_t rank, uint64_t signalOff, void* signalMhandle, uint64_t signalValue, uint32_t signalOp, void** request);
+  ncclResult_t (*iput)(void* ginCtx, int context, uint64_t srcOff, void* srcMhandle, size_t size, uint64_t dstOff,
+                       void* dstMhandle, uint32_t rank, void** request);
+  ncclResult_t (*iputSignal)(void* ginCtx, int context, uint64_t srcOff, void* srcMhandle, size_t size, uint64_t dstOff,
+                             void* dstMhandle, uint32_t rank, uint64_t signalOff, void* signalMhandle,
+                             uint64_t signalValue, uint32_t signalOp, void** request);
   ncclResult_t (*test)(void* collComm, void* request, int* done);
   ncclResult_t (*ginProgress)(void* ginCtx);
   ncclResult_t (*queryLastError)(void* ginCtx, bool* hasError);
@@ -104,12 +110,13 @@ ncclResult_t getGlobalGinType(struct ncclComm* comm, ncclGinType_t* ginType);
 ncclResult_t getGlobalRailedGinType(struct ncclComm* comm, ncclGinType_t* ginType);
 ncclResult_t ncclGinConnectOnce(struct ncclComm* comm);
 ncclResult_t ncclGinHostFinalize(struct ncclComm* comm);
-ncclResult_t ncclGinDevCommSetup(struct ncclComm* comm, struct ncclDevCommRequirements const* reqs, struct ncclDevComm* devComm);
+ncclResult_t ncclGinDevCommSetup(struct ncclComm* comm, struct ncclDevCommRequirements const* reqs,
+                                 struct ncclDevComm* devComm);
 ncclResult_t ncclGinDevCommFree(struct ncclComm* comm, struct ncclDevComm const* devComm);
 ncclResult_t ncclGinRegister(struct ncclComm* comm, void* address, size_t size,
                              void* ginHostWins[NCCL_GIN_MAX_CONNECTIONS],
-                             ncclGinWindow_t ginDevWins[NCCL_GIN_MAX_CONNECTIONS],
-                             int winFlags, bool multiSegment, int memType);
+                             ncclGinWindow_t ginDevWins[NCCL_GIN_MAX_CONNECTIONS], int winFlags, bool multiSegment,
+                             int memType);
 ncclResult_t ncclGinDeregister(struct ncclComm* comm, void* ginHostWins[NCCL_GIN_MAX_CONNECTIONS]);
 ncclResult_t ncclGinQueryLastError(struct ncclGinState* ginState, bool* hasError);
 ncclResult_t ncclGinGetDevCount(int ginPluginIndex, int* nPhysDev, int* nVirtDev);

--- a/projects/rccl/src/include/git_version.h
+++ b/projects/rccl/src/include/git_version.h
@@ -7,6 +7,6 @@
 #ifndef RCCL_GIT_VERSION_H_
 #define RCCL_GIT_VERSION_H_
 
-extern const char *rcclGitHash;
+extern const char* rcclGitHash;
 
 #endif

--- a/projects/rccl/src/include/graph.h
+++ b/projects/rccl/src/include/graph.h
@@ -27,7 +27,7 @@ ncclResult_t ncclTopoReconcileGrowChannels(struct ncclComm* comm, int* value);
 
 struct ncclTopoSystem;
 // Build the topology
-ncclResult_t ncclTopoGetSystem(struct ncclComm* comm, struct ncclTopoSystem** system, const char* dumpXmlFile=NULL);
+ncclResult_t ncclTopoGetSystem(struct ncclComm* comm, struct ncclTopoSystem** system, const char* dumpXmlFile = NULL);
 ncclResult_t ncclTopoSortSystem(struct ncclTopoSystem* system);
 ncclResult_t ncclTopoPrint(struct ncclTopoSystem* system);
 
@@ -45,16 +45,20 @@ ncclResult_t ncclCheckMultiRank(struct ncclComm* comm);
 ncclResult_t ncclTopoComputeCommCPU(struct ncclComm* comm);
 
 // Query topology
-ncclResult_t ncclTopoGetNetDev(struct ncclComm* comm, int rank, struct ncclTopoGraph* graph, int channelId, int peerRank, int64_t* id, int* dev, int* proxyRank);
-ncclResult_t ncclTopoCheckP2p(struct ncclComm* comm, struct ncclTopoSystem* system, int rank1, int rank2, int* p2p, int *read, int* intermediateRank, int* cudaP2p);
-ncclResult_t ncclTopoCheckMNNVL(struct ncclComm* comm, struct ncclPeerInfo* info1, struct ncclPeerInfo* info2, int* ret);
+ncclResult_t ncclTopoGetNetDev(struct ncclComm* comm, int rank, struct ncclTopoGraph* graph, int channelId,
+                               int peerRank, int64_t* id, int* dev, int* proxyRank);
+ncclResult_t ncclTopoCheckP2p(struct ncclComm* comm, struct ncclTopoSystem* system, int rank1, int rank2, int* p2p,
+                              int* read, int* intermediateRank, int* cudaP2p);
+ncclResult_t ncclTopoCheckMNNVL(struct ncclComm* comm, struct ncclPeerInfo* info1, struct ncclPeerInfo* info2,
+                                int* ret);
 enum ncclTopoGdrMode {
   ncclTopoGdrModeDisable = 0,
   ncclTopoGdrModeDefault = 1,
   ncclTopoGdrModePci = 2,
   ncclTopoGdrModeNum = 3
 };
-ncclResult_t ncclTopoCheckGdr(struct ncclTopoSystem* topo, int rank, int64_t netId, int read, enum ncclTopoGdrMode* gdrMode);
+ncclResult_t ncclTopoCheckGdr(struct ncclTopoSystem* topo, int rank, int64_t netId, int read,
+                              enum ncclTopoGdrMode* gdrMode);
 enum ncclTopoFlushType {
   ncclTopoFlushNone = 0,   // no flush needed
   ncclTopoFlushAlways = 1, // flush always needed
@@ -64,9 +68,10 @@ static inline uint32_t ncclGdcPinFlag(enum ncclTopoFlushType flush) {
   if (flush == ncclTopoFlushC2c && ncclGdrPinV2Available()) return GDR_PIN_FLAG_FORCE_PCIE;
   return GDR_PIN_FLAG_DEFAULT;
 }
-ncclResult_t ncclTopoNeedFlush(struct ncclComm* comm, int64_t netId, int netDev, int rank, bool netManaged, enum ncclTopoFlushType* flush);
+ncclResult_t ncclTopoNeedFlush(struct ncclComm* comm, int64_t netId, int netDev, int rank, bool netManaged,
+                               enum ncclTopoFlushType* flush);
 ncclResult_t ncclTopoGetMinNetBw(struct ncclTopoSystem* system, int rank, float* bw);
-ncclResult_t ncclTopoIsGdrAvail(struct ncclTopoSystem* system, int rank, bool *avail);
+ncclResult_t ncclTopoIsGdrAvail(struct ncclTopoSystem* system, int rank, bool* avail);
 ncclResult_t ncclTopoCheckNet(struct ncclTopoSystem* system, int rank1, int rank2, int* net);
 int ncclPxnDisable(struct ncclComm* comm);
 ncclResult_t ncclTopoGetPxnRanks(struct ncclComm* comm, int** intermediateRanks, int* nranks);
@@ -75,8 +80,10 @@ ncclResult_t ncclGetLocalCpu(struct ncclTopoSystem* system, int gpu, int* retCpu
 ncclResult_t ncclGetUserP2pLevel(int* level);
 
 #define MAX_XGMI_INTER_GPUS 4
-ncclResult_t ncclTopoGetIntraNetDev(struct ncclTopoSystem* system, int rank, struct ncclTopoGraph* graph, int channelId, int type, int64_t* id, int* dev);
-ncclResult_t ncclTopoGetLinkType(struct ncclTopoSystem* system, int cudaDev1, int cudaDev2, bool* isXGMI, int maxInter=MAX_XGMI_INTER_GPUS, int nInter=0, int *inter=nullptr);
+ncclResult_t ncclTopoGetIntraNetDev(struct ncclTopoSystem* system, int rank, struct ncclTopoGraph* graph, int channelId,
+                                    int type, int64_t* id, int* dev);
+ncclResult_t ncclTopoGetLinkType(struct ncclTopoSystem* system, int cudaDev1, int cudaDev2, bool* isXGMI,
+                                 int maxInter = MAX_XGMI_INTER_GPUS, int nInter = 0, int* inter = nullptr);
 
 // Find CPU affinity
 ncclResult_t ncclTopoGetCpuAffinity(struct ncclTopoSystem* system, int rank, ncclAffinity* affinity);
@@ -103,7 +110,7 @@ ncclResult_t ncclTopoGetNvsCount(struct ncclTopoSystem* system, int* count);
 ncclResult_t ncclTopoGetLocalNet(struct ncclTopoSystem* system, int rank, int channelId, int64_t* id, int* dev);
 ncclResult_t ncclTopoGetLocalGinDevs(struct ncclComm* comm, int* localGinDevs, int* localGinCount);
 ncclResult_t ncclTopoGetLocalGpu(struct ncclTopoSystem* system, int64_t netId, int* gpuIndex);
-ncclResult_t getLocalNetCountByBw(struct ncclTopoSystem* system, int gpu, int *count, float* bw);
+ncclResult_t getLocalNetCountByBw(struct ncclTopoSystem* system, int gpu, int* count, float* bw);
 
 enum netDevsPolicy {
   NETDEVS_POLICY_AUTO = 0x0,
@@ -115,7 +122,8 @@ ncclResult_t ncclTopoGetNetDevsPolicy(enum netDevsPolicy* policy, int* policyNum
 
 // Allows for up to 32 NICs per node on GB200-NVL72
 #define NCCL_TOPO_MAX_NODES 64
-ncclResult_t ncclTopoGetLocal(struct ncclTopoSystem* system, int type, int index, int resultType, int locals[NCCL_TOPO_MAX_NODES], int* localCount, int* pathType);
+ncclResult_t ncclTopoGetLocal(struct ncclTopoSystem* system, int type, int index, int resultType,
+                              int locals[NCCL_TOPO_MAX_NODES], int* localCount, int* pathType);
 
 // Local (myself)
 #define PATH_LOC 0
@@ -160,12 +168,14 @@ extern const char* topoPathTypeStr[];
 // Init search. Needs to be done before calling ncclTopoCompute
 ncclResult_t ncclTopoSearchInit(struct ncclTopoSystem* system);
 
-#define NCCL_TOPO_PATTERN_BALANCED_TREE 1   // Spread NIC traffic between two GPUs (Tree parent + one child on first GPU, second child on second GPU)
-#define NCCL_TOPO_PATTERN_SPLIT_TREE 2      // Spread NIC traffic between two GPUs (Tree parent on first GPU, tree children on the second GPU)
-#define NCCL_TOPO_PATTERN_TREE 3            // All NIC traffic going to/from the same GPU
-#define NCCL_TOPO_PATTERN_RING 4            // Ring
-#define NCCL_TOPO_PATTERN_NVLS 5            // NVLS+SHARP and NVLS+Tree
-#define NCCL_TOPO_PATTERN_COLLNET_DIRECT 6  // Collnet Direct
+#define NCCL_TOPO_PATTERN_BALANCED_TREE \
+  1 // Spread NIC traffic between two GPUs (Tree parent + one child on first GPU, second child on second GPU)
+#define NCCL_TOPO_PATTERN_SPLIT_TREE \
+  2 // Spread NIC traffic between two GPUs (Tree parent on first GPU, tree children on the second GPU)
+#define NCCL_TOPO_PATTERN_TREE 3 // All NIC traffic going to/from the same GPU
+#define NCCL_TOPO_PATTERN_RING 4 // Ring
+#define NCCL_TOPO_PATTERN_NVLS 5 // NVLS+SHARP and NVLS+Tree
+#define NCCL_TOPO_PATTERN_COLLNET_DIRECT 6 // Collnet Direct
 struct ncclTopoGraph {
   // Input / output
   int id; // ring : 0, tree : 1, collnet : 2, nvls : 3, collnetDirect : 4
@@ -183,11 +193,11 @@ struct ncclTopoGraph {
   int typeInter;
   int sameChannels;
   int nHops;
-  int intra[MAXCHANNELS*NCCL_TOPO_MAX_NODES];
-  int64_t inter[MAXCHANNELS*2];
+  int intra[MAXCHANNELS * NCCL_TOPO_MAX_NODES];
+  int64_t inter[MAXCHANNELS * 2];
   int nIntraChannels;
-  int intraNets[MAXCHANNELS*NCCL_TOPO_MAX_NODES*2];
-  char treeBase[NCCL_TOPO_MAX_NODES][NCCL_TOPO_MAX_NODES*4];
+  int intraNets[MAXCHANNELS * NCCL_TOPO_MAX_NODES * 2];
+  char treeBase[NCCL_TOPO_MAX_NODES][NCCL_TOPO_MAX_NODES * 4];
 };
 ncclResult_t ncclTopoCompute(struct ncclTopoSystem* system, struct ncclTopoGraph* graph);
 
@@ -207,14 +217,17 @@ struct ncclTopoRanks {
   int nvlsHeadNum;
 };
 
-ncclResult_t ncclTopoPreset(struct ncclComm* comm, struct ncclTopoGraph* (&graphs)[NCCL_NUM_ALGORITHMS], struct ncclTopoRanks* topoRanks);
+ncclResult_t ncclTopoPreset(struct ncclComm* comm, struct ncclTopoGraph* (&graphs)[NCCL_NUM_ALGORITHMS],
+                            struct ncclTopoRanks* topoRanks);
 
 ncclResult_t ncclTopoPostset(struct ncclComm* comm, int* firstRanks, int* treePatterns,
-    struct ncclTopoRanks** allTopoRanks, int* rings, struct ncclTopoGraph** graphs, struct ncclComm* parent, int nc);
+                             struct ncclTopoRanks** allTopoRanks, int* rings, struct ncclTopoGraph** graphs,
+                             struct ncclComm* parent, int nc);
 ncclResult_t ncclTreeBasePostset(struct ncclComm* comm, struct ncclTopoGraph* treeGraph);
 
 ncclResult_t ncclTopoInitTunerConstants(struct ncclComm* comm);
 ncclResult_t ncclTopoTuneModel(struct ncclComm* comm, int minCompCap, int maxCompCap, struct ncclTopoGraph** graphs);
-ncclResult_t ncclTopoGetAlgoTime(struct ncclComm* comm, int coll, int algorithm, int protocol, size_t nBytes, int numPipeOps, float* time);
+ncclResult_t ncclTopoGetAlgoTime(struct ncclComm* comm, int coll, int algorithm, int protocol, size_t nBytes,
+                                 int numPipeOps, float* time);
 int rcclGetTuningIndexForArch(const char* gfxarch);
 #endif

--- a/projects/rccl/src/include/group.h
+++ b/projects/rccl/src/include/group.h
@@ -21,25 +21,26 @@ void ncclGroupCommJoin(struct ncclComm* comm, int type);
 void ncclGroupCommPreconnect(struct ncclComm* comm);
 ncclResult_t ncclGroupCommLeave(struct ncclComm* comm);
 ncclResult_t ncclGroupJobAbort(struct ncclGroupJob* groupJob);
-ncclResult_t ncclGroupJobComplete(struct ncclGroupJob *groupJob);
+ncclResult_t ncclGroupJobComplete(struct ncclGroupJob* groupJob);
 
-typedef ncclResult_t(*ncclInitFunc_t)(ncclComm_t* newcomm, int ndev, ncclUniqueId commId, int myrank, int cudaDev);
+typedef ncclResult_t (*ncclInitFunc_t)(ncclComm_t* newcomm, int ndev, ncclUniqueId commId, int myrank, int cudaDev);
 
-ncclResult_t ncclAsyncInit(ncclInitFunc_t func, ncclComm_t* newcomm, int ndev, ncclUniqueId commId, int myrank, int cudaDev);
+ncclResult_t ncclAsyncInit(ncclInitFunc_t func, ncclComm_t* newcomm, int ndev, ncclUniqueId commId, int myrank,
+                           int cudaDev);
 
 typedef enum ncclGroupJobState {
   ncclGroupJobRunning = 0,
-  ncclGroupJobDone    = 1,
-  ncclGroupJobJoined  = 2,
+  ncclGroupJobDone = 1,
+  ncclGroupJobJoined = 2,
 } ncclGroupJobState_t;
 
 struct ncclAsyncJob {
   struct ncclAsyncJob* next;
   std::thread thread;
   ncclResult_t result;
-  ncclResult_t(*func)(struct ncclAsyncJob*);
-  void(*undo)(struct ncclAsyncJob*);
-  void(*destructor)(void*);
+  ncclResult_t (*func)(struct ncclAsyncJob*);
+  void (*undo)(struct ncclAsyncJob*);
+  void (*destructor)(void*);
   ncclGroupJobState_t state;
   uint32_t* abortFlag; /* point to comm abortFlag */
   uint32_t* abortFlagDev; /* point to comm abortFlagDev */
@@ -56,20 +57,16 @@ struct ncclAsyncJob {
   }
 };
 
-ncclResult_t ncclAsyncLaunch(
-  struct ncclAsyncJob* job,
-  ncclResult_t(*func)(struct ncclAsyncJob*),
-  void(*undo)(struct ncclAsyncJob*),
-  void(*destructor)(void*), ncclComm_t comm
-);
+ncclResult_t ncclAsyncLaunch(struct ncclAsyncJob* job, ncclResult_t (*func)(struct ncclAsyncJob*),
+                             void (*undo)(struct ncclAsyncJob*), void (*destructor)(void*), ncclComm_t comm);
 
 struct ncclGroupJob {
   struct ncclAsyncJob base;
   int groupRefCount;
   bool nonBlockingInit;
   bool joined;
-  struct ncclComm *groupCommHead[ncclGroupTaskTypeNum];
-  struct ncclComm *groupCommPreconnectHead;
+  struct ncclComm* groupCommHead[ncclGroupTaskTypeNum];
+  struct ncclComm* groupCommPreconnectHead;
   ncclResult_t groupError;
   bool abortFlag;
   struct ncclIntruQueue<struct ncclAsyncJob, &ncclAsyncJob::next> asyncJobs;
@@ -105,8 +102,7 @@ inline void ncclGroupCommJoin(struct ncclComm* comm, int type) {
     // the users program order yet insures siblings occur consecutively. This
     // is required by doLaunches() in "group.cc".
     struct ncclComm** pp = &ncclGroupCommHead[type];
-    while (*pp != nullptr && comm->intraComm0 != (*pp)->intraComm0)
-      pp = &(*pp)->groupNext[type];
+    while (*pp != nullptr && comm->intraComm0 != (*pp)->intraComm0) pp = &(*pp)->groupNext[type];
 
     // didn't find its clique, we need to insert it with ascending order based on commHash
     if (*pp == nullptr) {

--- a/projects/rccl/src/include/hip_rocm_version_info.h
+++ b/projects/rccl/src/include/hip_rocm_version_info.h
@@ -28,31 +28,32 @@ THE SOFTWARE.
 
 // HIP version info retrieval
 #if ROCM_VERSION >= 50000
-   #define HIP_BUILD_INFO STR(HIP_VERSION_MAJOR) "." STR(HIP_VERSION_MINOR) "." STR(HIP_VERSION_PATCH) "-" HIP_VERSION_GITHASH
+#define HIP_BUILD_INFO \
+  STR(HIP_VERSION_MAJOR) "." STR(HIP_VERSION_MINOR) "." STR(HIP_VERSION_PATCH) "-" HIP_VERSION_GITHASH
 // HIP Githash info not available in older ROCm versions < 5.0
 #elif ROCM_VERSION >= 40000
-   #define HIP_BUILD_INFO STR(HIP_VERSION_MAJOR) "." STR(HIP_VERSION_MINOR) "." STR(HIP_VERSION_PATCH)
+#define HIP_BUILD_INFO STR(HIP_VERSION_MAJOR) "." STR(HIP_VERSION_MINOR) "." STR(HIP_VERSION_PATCH)
 #else
-   #define HIP_BUILD_INFO "Unknown"
+#define HIP_BUILD_INFO "Unknown"
 #endif
 
-// ROCm version info retrieval  
+// ROCm version info retrieval
 #if ROCM_VERSION >= 60000
    // rocm_version.h moved to rocm/include/rocm-core from ROCm 6.0
-   #include <rocm-core/rocm_version.h>
+#include <rocm-core/rocm_version.h>
 #else
-   // rocm-core/rocm_version.h not present in some ROCm versions < 6.0. 
+   // rocm-core/rocm_version.h not present in some ROCm versions < 6.0.
    // So, including it from rocm/include/rocm_version.h
-   #if ROCM_VERSION >= 50000
-      #include <rocm_version.h>
-      //ROCM_BUILD_INFO not defined in ROCm Versions < 5.50
-      #ifndef ROCM_BUILD_INFO
-         #define ROCM_BUILD_INFO STR(ROCM_VERSION_MAJOR) "." STR(ROCM_VERSION_MINOR) "." STR(ROCM_VERSION_PATCH)
-      #endif
-   //ROCm version info not available for ROCm versions < 5.0
-   #else
-      #define ROCM_BUILD_INFO "Unknown"
-   #endif
+#if ROCM_VERSION >= 50000
+#include <rocm_version.h>
+      // ROCM_BUILD_INFO not defined in ROCm Versions < 5.50
+#ifndef ROCM_BUILD_INFO
+#define ROCM_BUILD_INFO STR(ROCM_VERSION_MAJOR) "." STR(ROCM_VERSION_MINOR) "." STR(ROCM_VERSION_PATCH)
+#endif
+   // ROCm version info not available for ROCm versions < 5.0
+#else
+#define ROCM_BUILD_INFO "Unknown"
+#endif
 #endif
 
 // Header-only helpers for runtime version reporting.
@@ -69,8 +70,7 @@ struct VersionInfo {
 
 // Decode hipRuntimeGetVersion(): MAJOR*10000000 + MINOR*100000 + PATCH.
 inline VersionInfo decodeHipVer(int v) {
-  return VersionInfo{true, (unsigned)(v / 10000000),
-                     (unsigned)((v / 100000) % 100), (unsigned)(v % 100000)};
+  return VersionInfo{true, (unsigned)(v / 10000000), (unsigned)((v / 100000) % 100), (unsigned)(v % 100000)};
 }
 
 inline bool sameVer(const VersionInfo& a, const VersionInfo& b) {
@@ -78,19 +78,15 @@ inline bool sameVer(const VersionInfo& a, const VersionInfo& b) {
 }
 
 // Runtime values appended only when valid and different from compile-time.
-inline std::string fmtExtVer(
-    const std::string& hipBase, const VersionInfo& hipRt, const VersionInfo& hipCt,
-    const std::string& rocmBase, const VersionInfo& rocmRt, const VersionInfo& rocmCt) {
+inline std::string fmtExtVer(const std::string& hipBase, const VersionInfo& hipRt, const VersionInfo& hipCt,
+                             const std::string& rocmBase, const VersionInfo& rocmRt, const VersionInfo& rocmCt) {
   // Determine the maximum width of the base strings for alignment.
   const size_t width = hipBase.size() > rocmBase.size() ? hipBase.size() : rocmBase.size();
-  auto line = [width](const std::string& base, const char* label,
-                      const VersionInfo& rt, const VersionInfo& ct) {
-    if (!rt.valid || sameVer(rt, ct))
-      return base;
+  auto line = [width](const std::string& base, const char* label, const VersionInfo& rt, const VersionInfo& ct) {
+    if (!rt.valid || sameVer(rt, ct)) return base;
     return fmt::format("{:<{}} / {} : {}.{}.{}", base, width, label, rt.major, rt.minor, rt.patch);
   };
-  return line(hipBase,  "HIP runtime ", hipRt,  hipCt) + '\n'
-       + line(rocmBase, "ROCm runtime", rocmRt, rocmCt);
+  return line(hipBase, "HIP runtime ", hipRt, hipCt) + '\n' + line(rocmBase, "ROCm runtime", rocmRt, rocmCt);
 }
 
 #endif

--- a/projects/rccl/src/include/ibvsymbols.h
+++ b/projects/rccl/src/include/ibvsymbols.h
@@ -19,32 +19,36 @@
 /* IB Verbs Function Pointers*/
 struct ncclIbvSymbols {
   int (*ibv_internal_fork_init)(void);
-  struct ibv_device** (*ibv_internal_get_device_list)(int *num_devices);
-  void (*ibv_internal_free_device_list)(struct ibv_device **list);
-  const char * (*ibv_internal_get_device_name)(struct ibv_device *device);
+  struct ibv_device** (*ibv_internal_get_device_list)(int* num_devices);
+  void (*ibv_internal_free_device_list)(struct ibv_device** list);
+  const char* (*ibv_internal_get_device_name)(struct ibv_device* device);
   struct ibv_context* (*ibv_internal_open_device)(struct ibv_device* device);
-  int (*ibv_internal_close_device)(struct ibv_context *context);
-  int (*ibv_internal_get_async_event)(struct ibv_context *context, struct ibv_async_event *event);
-  void (*ibv_internal_ack_async_event)(struct ibv_async_event *event);
-  int (*ibv_internal_query_device)(struct ibv_context *context, struct ibv_device_attr *device_attr);
-  int (*ibv_internal_query_port)(struct ibv_context *context, uint8_t port_num, struct ibv_port_attr *port_attr);
-  int (*ibv_internal_query_gid)(struct ibv_context *context, uint8_t port_num, int index, union ibv_gid *gid);
-  int (*ibv_internal_query_qp)(struct ibv_qp *qp, struct ibv_qp_attr *attr, int attr_mask, struct ibv_qp_init_attr *init_attr);
-  struct ibv_pd * (*ibv_internal_alloc_pd)(struct ibv_context *context);
-  int (*ibv_internal_dealloc_pd)(struct ibv_pd *pd);
-  struct ibv_mr * (*ibv_internal_reg_mr)(struct ibv_pd *pd, void *addr, size_t length, int access);
-  struct ibv_mr * (*ibv_internal_reg_mr_iova2)(struct ibv_pd *pd, void *addr, size_t length, uint64_t iova, unsigned int access);
+  int (*ibv_internal_close_device)(struct ibv_context* context);
+  int (*ibv_internal_get_async_event)(struct ibv_context* context, struct ibv_async_event* event);
+  void (*ibv_internal_ack_async_event)(struct ibv_async_event* event);
+  int (*ibv_internal_query_device)(struct ibv_context* context, struct ibv_device_attr* device_attr);
+  int (*ibv_internal_query_port)(struct ibv_context* context, uint8_t port_num, struct ibv_port_attr* port_attr);
+  int (*ibv_internal_query_gid)(struct ibv_context* context, uint8_t port_num, int index, union ibv_gid* gid);
+  int (*ibv_internal_query_qp)(struct ibv_qp* qp, struct ibv_qp_attr* attr, int attr_mask,
+                               struct ibv_qp_init_attr* init_attr);
+  struct ibv_pd* (*ibv_internal_alloc_pd)(struct ibv_context* context);
+  int (*ibv_internal_dealloc_pd)(struct ibv_pd* pd);
+  struct ibv_mr* (*ibv_internal_reg_mr)(struct ibv_pd* pd, void* addr, size_t length, int access);
+  struct ibv_mr* (*ibv_internal_reg_mr_iova2)(struct ibv_pd* pd, void* addr, size_t length, uint64_t iova,
+                                              unsigned int access);
   /* DMA-BUF support */
-  struct ibv_mr * (*ibv_internal_reg_dmabuf_mr)(struct ibv_pd *pd, uint64_t offset, size_t length, uint64_t iova, int fd, int access);
-  int (*ibv_internal_dereg_mr)(struct ibv_mr *mr);
-  struct ibv_cq * (*ibv_internal_create_cq)(struct ibv_context *context, int cqe, void *cq_context, struct ibv_comp_channel *channel, int comp_vector);
-  int (*ibv_internal_destroy_cq)(struct ibv_cq *cq);
-  struct ibv_qp * (*ibv_internal_create_qp)(struct ibv_pd *pd, struct ibv_qp_init_attr *qp_init_attr);
-  int (*ibv_internal_modify_qp)(struct ibv_qp *qp, struct ibv_qp_attr *attr, int attr_mask);
-  int (*ibv_internal_destroy_qp)(struct ibv_qp *qp);
-  const char * (*ibv_internal_event_type_str)(enum ibv_event_type event);
-  int (*ibv_internal_query_ece)(struct ibv_qp *qp, struct ibv_ece *ece);
-  int (*ibv_internal_set_ece)(struct ibv_qp *qp, struct ibv_ece *ece);
+  struct ibv_mr* (*ibv_internal_reg_dmabuf_mr)(struct ibv_pd* pd, uint64_t offset, size_t length, uint64_t iova, int fd,
+                                               int access);
+  int (*ibv_internal_dereg_mr)(struct ibv_mr* mr);
+  struct ibv_cq* (*ibv_internal_create_cq)(struct ibv_context* context, int cqe, void* cq_context,
+                                           struct ibv_comp_channel* channel, int comp_vector);
+  int (*ibv_internal_destroy_cq)(struct ibv_cq* cq);
+  struct ibv_qp* (*ibv_internal_create_qp)(struct ibv_pd* pd, struct ibv_qp_init_attr* qp_init_attr);
+  int (*ibv_internal_modify_qp)(struct ibv_qp* qp, struct ibv_qp_attr* attr, int attr_mask);
+  int (*ibv_internal_destroy_qp)(struct ibv_qp* qp);
+  const char* (*ibv_internal_event_type_str)(enum ibv_event_type event);
+  int (*ibv_internal_query_ece)(struct ibv_qp* qp, struct ibv_ece* ece);
+  int (*ibv_internal_set_ece)(struct ibv_qp* qp, struct ibv_ece* ece);
 };
 
 /* Constructs IB verbs symbols per rdma-core linking or dynamic loading mode */

--- a/projects/rccl/src/include/ibvwrap.h
+++ b/projects/rccl/src/include/ibvwrap.h
@@ -22,40 +22,45 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-typedef enum ibv_return_enum
-{
-    IBV_SUCCESS = 0,                   //!< The operation was successful
+typedef enum ibv_return_enum {
+  IBV_SUCCESS = 0,                   //!< The operation was successful
 } ibv_return_t;
 
 ncclResult_t wrap_ibv_symbols(void);
 /* NCCL wrappers of IB verbs functions */
 ncclResult_t wrap_ibv_fork_init(void);
-ncclResult_t wrap_ibv_get_device_list(struct ibv_device ***ret, int *num_devices);
-ncclResult_t wrap_ibv_free_device_list(struct ibv_device **list);
-const char *wrap_ibv_get_device_name(struct ibv_device *device);
-ncclResult_t wrap_ibv_open_device(struct ibv_context **ret, struct ibv_device *device);
-ncclResult_t wrap_ibv_close_device(struct ibv_context *context);
-ncclResult_t wrap_ibv_get_async_event(struct ibv_context *context, struct ibv_async_event *event);
-ncclResult_t wrap_ibv_ack_async_event(struct ibv_async_event *event);
-ncclResult_t wrap_ibv_query_device(struct ibv_context *context, struct ibv_device_attr *device_attr);
-ncclResult_t wrap_ibv_query_port(struct ibv_context *context, uint8_t port_num, struct ibv_port_attr *port_attr);
-ncclResult_t wrap_ibv_query_gid(struct ibv_context *context, uint8_t port_num, int index, union ibv_gid *gid);
-ncclResult_t wrap_ibv_query_qp(struct ibv_qp *qp, struct ibv_qp_attr *attr, int attr_mask, struct ibv_qp_init_attr *init_attr);
-ncclResult_t wrap_ibv_alloc_pd(struct ibv_pd **ret, struct ibv_context *context);
-ncclResult_t wrap_ibv_dealloc_pd(struct ibv_pd *pd);
-ncclResult_t wrap_ibv_reg_mr(struct ibv_mr **ret, struct ibv_pd *pd, void *addr, size_t length, int access);
-struct ibv_mr * wrap_direct_ibv_reg_mr(struct ibv_pd *pd, void *addr, size_t length, int access);
-ncclResult_t wrap_ibv_reg_mr_iova2(struct ibv_mr **ret, struct ibv_pd *pd, void *addr, size_t length, uint64_t iova, int access);
+ncclResult_t wrap_ibv_get_device_list(struct ibv_device*** ret, int* num_devices);
+ncclResult_t wrap_ibv_free_device_list(struct ibv_device** list);
+const char* wrap_ibv_get_device_name(struct ibv_device* device);
+ncclResult_t wrap_ibv_open_device(struct ibv_context** ret, struct ibv_device* device);
+ncclResult_t wrap_ibv_close_device(struct ibv_context* context);
+ncclResult_t wrap_ibv_get_async_event(struct ibv_context* context, struct ibv_async_event* event);
+ncclResult_t wrap_ibv_ack_async_event(struct ibv_async_event* event);
+ncclResult_t wrap_ibv_query_device(struct ibv_context* context, struct ibv_device_attr* device_attr);
+ncclResult_t wrap_ibv_query_port(struct ibv_context* context, uint8_t port_num, struct ibv_port_attr* port_attr);
+ncclResult_t wrap_ibv_query_gid(struct ibv_context* context, uint8_t port_num, int index, union ibv_gid* gid);
+ncclResult_t wrap_ibv_query_qp(struct ibv_qp* qp, struct ibv_qp_attr* attr, int attr_mask,
+                               struct ibv_qp_init_attr* init_attr);
+ncclResult_t wrap_ibv_alloc_pd(struct ibv_pd** ret, struct ibv_context* context);
+ncclResult_t wrap_ibv_dealloc_pd(struct ibv_pd* pd);
+ncclResult_t wrap_ibv_reg_mr(struct ibv_mr** ret, struct ibv_pd* pd, void* addr, size_t length, int access);
+struct ibv_mr* wrap_direct_ibv_reg_mr(struct ibv_pd* pd, void* addr, size_t length, int access);
+ncclResult_t wrap_ibv_reg_mr_iova2(struct ibv_mr** ret, struct ibv_pd* pd, void* addr, size_t length, uint64_t iova,
+                                   int access);
 /* DMA-BUF support */
-ncclResult_t wrap_ibv_reg_dmabuf_mr(struct ibv_mr **ret, struct ibv_pd *pd, uint64_t offset, size_t length, uint64_t iova, int fd, int access);
-struct ibv_mr * wrap_direct_ibv_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset, size_t length, uint64_t iova, int fd, int access);
-ncclResult_t wrap_ibv_dereg_mr(struct ibv_mr *mr);
-ncclResult_t wrap_ibv_create_comp_channel(struct ibv_comp_channel **ret, struct ibv_context *context);
-ncclResult_t wrap_ibv_destroy_comp_channel(struct ibv_comp_channel *channel);
-ncclResult_t wrap_ibv_create_cq(struct ibv_cq **ret, struct ibv_context *context, int cqe, void *cq_context, struct ibv_comp_channel *channel, int comp_vector);
-ncclResult_t wrap_ibv_destroy_cq(struct ibv_cq *cq);
-static inline ncclResult_t wrap_ibv_poll_cq(struct ibv_cq *cq, int num_entries, struct ibv_wc *wc, int* num_done) {
-  int done = cq->context->ops.poll_cq(cq, num_entries, wc); /*returns the number of wcs or 0 on success, a negative number otherwise*/
+ncclResult_t wrap_ibv_reg_dmabuf_mr(struct ibv_mr** ret, struct ibv_pd* pd, uint64_t offset, size_t length,
+                                    uint64_t iova, int fd, int access);
+struct ibv_mr* wrap_direct_ibv_reg_dmabuf_mr(struct ibv_pd* pd, uint64_t offset, size_t length, uint64_t iova, int fd,
+                                             int access);
+ncclResult_t wrap_ibv_dereg_mr(struct ibv_mr* mr);
+ncclResult_t wrap_ibv_create_comp_channel(struct ibv_comp_channel** ret, struct ibv_context* context);
+ncclResult_t wrap_ibv_destroy_comp_channel(struct ibv_comp_channel* channel);
+ncclResult_t wrap_ibv_create_cq(struct ibv_cq** ret, struct ibv_context* context, int cqe, void* cq_context,
+                                struct ibv_comp_channel* channel, int comp_vector);
+ncclResult_t wrap_ibv_destroy_cq(struct ibv_cq* cq);
+static inline ncclResult_t wrap_ibv_poll_cq(struct ibv_cq* cq, int num_entries, struct ibv_wc* wc, int* num_done) {
+  int done = cq->context->ops.poll_cq(cq, num_entries,
+                                      wc); /*returns the number of wcs or 0 on success, a negative number otherwise*/
   if (done < 0) {
     WARN("Call to ibv_poll_cq() returned %d", done);
     return ncclSystemError;
@@ -63,19 +68,20 @@ static inline ncclResult_t wrap_ibv_poll_cq(struct ibv_cq *cq, int num_entries, 
   *num_done = done;
   return ncclSuccess;
 }
-ncclResult_t wrap_ibv_create_qp(struct ibv_qp **ret, struct ibv_pd *pd, struct ibv_qp_init_attr *qp_init_attr);
-ncclResult_t wrap_ibv_modify_qp(struct ibv_qp *qp, struct ibv_qp_attr *attr, int attr_mask);
-ncclResult_t wrap_ibv_destroy_qp(struct ibv_qp *qp);
-ncclResult_t wrap_ibv_query_ece(struct ibv_qp *qp, struct ibv_ece *ece, int* supported);
-ncclResult_t wrap_ibv_set_ece(struct ibv_qp *qp, struct ibv_ece *ece, int* supported);
+ncclResult_t wrap_ibv_create_qp(struct ibv_qp** ret, struct ibv_pd* pd, struct ibv_qp_init_attr* qp_init_attr);
+ncclResult_t wrap_ibv_modify_qp(struct ibv_qp* qp, struct ibv_qp_attr* attr, int attr_mask);
+ncclResult_t wrap_ibv_destroy_qp(struct ibv_qp* qp);
+ncclResult_t wrap_ibv_query_ece(struct ibv_qp* qp, struct ibv_ece* ece, int* supported);
+ncclResult_t wrap_ibv_set_ece(struct ibv_qp* qp, struct ibv_ece* ece, int* supported);
 
-static inline ncclResult_t wrap_ibv_create_ah(struct ibv_ah **ret, struct ibv_pd *pd, struct ibv_ah_attr *attr) {
+static inline ncclResult_t wrap_ibv_create_ah(struct ibv_ah** ret, struct ibv_pd* pd, struct ibv_ah_attr* attr) {
   if (ret) *ret = NULL; /*don't leave a stale pointer behind if creation fails*/
   if (ret == NULL || pd == NULL || pd->context == NULL || attr == NULL) {
-    WARN("wrap_ibv_create_ah() called with invalid arguments (ret=%p, pd=%p, context=%p, attr=%p)", ret, pd, pd ? pd->context : NULL, attr);
+    WARN("wrap_ibv_create_ah() called with invalid arguments (ret=%p, pd=%p, context=%p, attr=%p)", ret, pd,
+         pd ? pd->context : NULL, attr);
     return ncclSystemError;
   }
-  struct ibv_ah *ah = pd->context->ops.create_ah(pd, attr); /*returns NULL on failure, with errno set*/
+  struct ibv_ah* ah = pd->context->ops.create_ah(pd, attr); /*returns NULL on failure, with errno set*/
   if (ah == NULL) {
     WARN("ibv_create_ah() failed: %s", strerror(errno));
     return ncclSystemError;
@@ -86,7 +92,7 @@ static inline ncclResult_t wrap_ibv_create_ah(struct ibv_ah **ret, struct ibv_pd
   return ncclSuccess;
 }
 
-static inline ncclResult_t wrap_ibv_destroy_ah(struct ibv_ah *ah) {
+static inline ncclResult_t wrap_ibv_destroy_ah(struct ibv_ah* ah) {
   if (ah == NULL || ah->context == NULL) {
     WARN("wrap_ibv_destroy_ah() called with invalid AH (ah=%p, context=%p)", ah, ah ? ah->context : NULL);
     return ncclSystemError;
@@ -99,8 +105,9 @@ static inline ncclResult_t wrap_ibv_destroy_ah(struct ibv_ah *ah) {
   return ncclSuccess;
 }
 
-static inline ncclResult_t wrap_ibv_post_send(struct ibv_qp *qp, struct ibv_send_wr *wr, struct ibv_send_wr **bad_wr) {
-  int ret = qp->context->ops.post_send(qp, wr, bad_wr); /*returns 0 on success, or the value of errno on failure (which indicates the failure reason)*/
+static inline ncclResult_t wrap_ibv_post_send(struct ibv_qp* qp, struct ibv_send_wr* wr, struct ibv_send_wr** bad_wr) {
+  int ret = qp->context->ops.post_send(
+    qp, wr, bad_wr); /*returns 0 on success, or the value of errno on failure (which indicates the failure reason)*/
   if (ret != IBV_SUCCESS) {
     WARN("ibv_post_send() failed with error %s, Bad WR %p, First WR %p", strerror(ret), wr, *bad_wr);
     return ncclSystemError;
@@ -108,8 +115,9 @@ static inline ncclResult_t wrap_ibv_post_send(struct ibv_qp *qp, struct ibv_send
   return ncclSuccess;
 }
 
-static inline ncclResult_t wrap_ibv_post_recv(struct ibv_qp *qp, struct ibv_recv_wr *wr, struct ibv_recv_wr **bad_wr) {
-  int ret = qp->context->ops.post_recv(qp, wr, bad_wr); /*returns 0 on success, or the value of errno on failure (which indicates the failure reason)*/
+static inline ncclResult_t wrap_ibv_post_recv(struct ibv_qp* qp, struct ibv_recv_wr* wr, struct ibv_recv_wr** bad_wr) {
+  int ret = qp->context->ops.post_recv(
+    qp, wr, bad_wr); /*returns 0 on success, or the value of errno on failure (which indicates the failure reason)*/
   if (ret != IBV_SUCCESS) {
     WARN("ibv_post_recv() failed with error %s", strerror(ret));
     return ncclSystemError;
@@ -117,7 +125,7 @@ static inline ncclResult_t wrap_ibv_post_recv(struct ibv_qp *qp, struct ibv_recv
   return ncclSuccess;
 }
 
-ncclResult_t wrap_ibv_event_type_str(char **ret, enum ibv_event_type event);
+ncclResult_t wrap_ibv_event_type_str(char** ret, enum ibv_event_type event);
 
 // converts a GID into a readable string. On success, returns a non-null pointer to gidStr.
 // NULL is returned if there was an error, with errno set to indicate the error.
@@ -125,7 +133,8 @@ ncclResult_t wrap_ibv_event_type_str(char **ret, enum ibv_event_type event);
 static inline const char* ibvGetGidStr(union ibv_gid* gid, char* gidStr, size_t strLen) {
   // GID is a 16B handle, to convert it to a readable form, we use inet_ntop
   // sizeof(ibv_gid) == sizeof(struct in6_addr), so using AF_INET6
-  static_assert(sizeof(union ibv_gid) == sizeof(struct in6_addr), "the sizeof struct ibv_gid must be the size of struct in6_addr");
+  static_assert(sizeof(union ibv_gid) == sizeof(struct in6_addr),
+                "the sizeof struct ibv_gid must be the size of struct in6_addr");
   return inet_ntop(AF_INET6, gid->raw, gidStr, strLen);
 }
 
@@ -138,4 +147,4 @@ const char* ibvWcOpcodeStr(enum ibv_wc_opcode opcode);
 // Helper function to convert IB work request opcode to string
 const char* ibvWrOpcodeStr(enum ibv_wr_opcode opcode);
 
-#endif //End include guard
+#endif // End include guard

--- a/projects/rccl/src/include/ionic/ionicdvcore.h
+++ b/projects/rccl/src/include/ionic/ionicdvcore.h
@@ -13,8 +13,8 @@
 #include "ibvwrap.h"
 
 enum ionicdv_reg_udma_mask {
-    IONIC_UDMA_MASK_LOW    = 1,
-    IONIC_UDMA_MASK_HIGH   = 2
+  IONIC_UDMA_MASK_LOW = 1,
+  IONIC_UDMA_MASK_HIGH = 2
 };
 
 #endif  // NCCL_IONICDV_CORE_H_

--- a/projects/rccl/src/include/ionic/ionicdvsymbols.h
+++ b/projects/rccl/src/include/ionic/ionicdvsymbols.h
@@ -5,9 +5,9 @@
 #include "nccl.h"
 
 /* Ionic Direct Verbs Function Pointers*/
-struct ncclIonicdvSymbols  {
-  int (*ionicdv_internal_qp_set_gda)(struct ibv_qp *qp, bool enable_send, bool enable_recv);
-  int (*ionicdv_internal_pd_set_udma_mask)(struct ibv_pd *ibpd, uint8_t udma_mask);
+struct ncclIonicdvSymbols {
+  int (*ionicdv_internal_qp_set_gda)(struct ibv_qp* qp, bool enable_send, bool enable_recv);
+  int (*ionicdv_internal_pd_set_udma_mask)(struct ibv_pd* ibpd, uint8_t udma_mask);
 };
 
 /* Constructs ionic direct verbs symbols per rdma-core linking or dynamic loading mode */

--- a/projects/rccl/src/include/ionic/ionicdvwrap.h
+++ b/projects/rccl/src/include/ionic/ionicdvwrap.h
@@ -11,7 +11,7 @@
 
 ncclResult_t wrap_ionicdv_symbols(void);
 /* NCCL wrappers of ionic direct verbs functions */
-ncclResult_t wrap_ionicdv_qp_set_gda(struct ibv_qp *ibqp, bool enable_send, bool enable_recv);
-ncclResult_t wrap_ionicdv_pd_set_udma_mask(struct ibv_pd *ibpd, uint8_t udma_mask);
+ncclResult_t wrap_ionicdv_qp_set_gda(struct ibv_qp* ibqp, bool enable_send, bool enable_recv);
+ncclResult_t wrap_ionicdv_pd_set_udma_mask(struct ibv_pd* ibpd, uint8_t udma_mask);
 
 #endif // NCCL_IONICDVWRAP_H_

--- a/projects/rccl/src/include/ipc_gpu_barrier.h
+++ b/projects/rccl/src/include/ipc_gpu_barrier.h
@@ -21,29 +21,25 @@ namespace meta::comms {
 namespace {
 
 template <std::memory_order Sem>
-__device__ __forceinline__ uint32_t
-cas(uint32_t* addr, uint32_t compare, uint32_t val) {
+__device__ __forceinline__ uint32_t cas(uint32_t* addr, uint32_t compare, uint32_t val) {
 #if !defined(USE_ROCM) && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 600)
   ::cuda::atomic_ref<uint32_t, ::cuda::thread_scope_system> ref(*addr);
   ref.compare_exchange_strong(compare, val, ::cuda::std::memory_order(Sem));
   return compare;
 #elif defined(USE_ROCM) || defined(__HIP_PLATFORM_AMD__)
-  __atomic_compare_exchange_n(
-      addr, &compare, val, false, static_cast<int>(Sem), __ATOMIC_RELAXED);
+  __atomic_compare_exchange_n(addr, &compare, val, false, static_cast<int>(Sem), __ATOMIC_RELAXED);
   return compare;
 #endif
 }
 
 template <std::memory_order Sem>
 __device__ __forceinline__ void putFlag(uint32_t* addr) {
-  while (cas<Sem>(addr, 0, 1) != 0)
-    ;
+  while (cas<Sem>(addr, 0, 1) != 0);
 }
 
 template <std::memory_order Sem>
 __device__ __forceinline__ void waitFlag(uint32_t* addr) {
-  while (cas<Sem>(addr, 1, 0) != 1)
-    ;
+  while (cas<Sem>(addr, 1, 0) != 1);
 }
 
 constexpr int NRANKS = 8;
@@ -51,36 +47,31 @@ constexpr int NRANKS = 8;
 } // namespace
 
 class DeviceMailbox {
- public:
+public:
   using FlagType = uint32_t;
-  static __host__ std::pair<std::unique_ptr<DeviceBuffer>, DeviceMailbox>
-  mallocAndInit(int nRanks, int nBlocks);
+  static __host__ std::pair<std::unique_ptr<DeviceBuffer>, DeviceMailbox> mallocAndInit(int nRanks, int nBlocks);
 
   DeviceMailbox() = default;
 
   __host__ DeviceMailbox(int nRanks, int nBlocks, void* flagsBuf);
 
   __device__ inline void setFlagNoMemFence(int senderRank, int senderBlock) {
-    putFlag<std::memory_order_relaxed>(
-        flags_ + getFlagIdx(senderRank, senderBlock));
+    putFlag<std::memory_order_relaxed>(flags_ + getFlagIdx(senderRank, senderBlock));
   }
 
   __device__ inline void waitFlagNoMemFence(int senderRank, int senderBlock) {
-    waitFlag<std::memory_order_relaxed>(
-        flags_ + getFlagIdx(senderRank, senderBlock));
+    waitFlag<std::memory_order_relaxed>(flags_ + getFlagIdx(senderRank, senderBlock));
   }
 
   __device__ inline void setFlagWithMemFence(int senderRank, int senderBlock) {
-    putFlag<std::memory_order_release>(
-        flags_ + getFlagIdx(senderRank, senderBlock));
+    putFlag<std::memory_order_release>(flags_ + getFlagIdx(senderRank, senderBlock));
   }
 
   __device__ inline void waitFlagWithMemFence(int senderRank, int senderBlock) {
-    waitFlag<std::memory_order_acquire>(
-        flags_ + getFlagIdx(senderRank, senderBlock));
+    waitFlag<std::memory_order_acquire>(flags_ + getFlagIdx(senderRank, senderBlock));
   }
 
- private:
+private:
   int nBlocks_;
   FlagType* flags_;
 
@@ -97,17 +88,12 @@ struct IpcGpuBarrierResources {
 };
 
 class IpcGpuBarrier {
- public:
+public:
   using FlagType = DeviceMailbox::FlagType;
   __host__ IpcGpuBarrier() = default;
 
-  static __host__
-      std::pair<std::unique_ptr<IpcGpuBarrierResources>, IpcGpuBarrier>
-      mallocAndInit(
-          int nRanks,
-          int nBlocks,
-          int selfRank,
-          void* bootstrap);
+  static __host__ std::pair<std::unique_ptr<IpcGpuBarrierResources>, IpcGpuBarrier> mallocAndInit(
+    int nRanks, int nBlocks, int selfRank, void* bootstrap);
 
   template <bool hasPreviousMemAccess, bool hasSubsequentMemAccess>
   __device__ __forceinline__ void syncOnSameBlockIdx() {
@@ -120,10 +106,9 @@ class IpcGpuBarrier {
     static_assert(hasPreviousMemAccess || hasSubsequentMemAccess);
 
     constexpr MemFenceType fenceType =
-        hasPreviousMemAccess && hasSubsequentMemAccess
-        ? MemFenceType::RELEASE_ACQUIRE
-        : (!hasPreviousMemAccess ? MemFenceType::ACQUIRE_ONLY
-                                 : MemFenceType::RELEASE_ONLY);
+      hasPreviousMemAccess && hasSubsequentMemAccess ?
+        MemFenceType::RELEASE_ACQUIRE :
+        (!hasPreviousMemAccess ? MemFenceType::ACQUIRE_ONLY : MemFenceType::RELEASE_ONLY);
 
     if constexpr (hasPreviousMemAccess) {
       __syncthreads();
@@ -147,16 +132,12 @@ class IpcGpuBarrier {
     }
   }
 
- private:
+private:
   int nBlocks_{-1};
   int selfRank_{-1};
   std::array<DeviceMailbox, NRANKS> allMailboxes_;
 
-  __host__ IpcGpuBarrier(
-      int nRanks,
-      int nBlocks,
-      int selfRank,
-      const std::array<DeviceMailbox, NRANKS>& allMailboxes);
+  __host__ IpcGpuBarrier(int nRanks, int nBlocks, int selfRank, const std::array<DeviceMailbox, NRANKS>& allMailboxes);
 };
 
 } // namespace meta::comms

--- a/projects/rccl/src/include/ipc_mem_handler.h
+++ b/projects/rccl/src/include/ipc_mem_handler.h
@@ -28,7 +28,7 @@
  *   NCCLCHECK(handler.getPeerDeviceMemPtr(peerRank, &peerPtr));
  */
 class ncclIpcMemHandler {
- public:
+public:
   ncclIpcMemHandler(void* bootstrap, int rank, int nranks);
   ncclIpcMemHandler(const ncclIpcMemHandler&) = delete;
   ncclIpcMemHandler& operator=(const ncclIpcMemHandler&) = delete;
@@ -40,7 +40,7 @@ class ncclIpcMemHandler {
   ncclResult_t exchangeMemPtrs();
   ncclResult_t getPeerDeviceMemPtr(int peerRank, void** outPeerPtr) const;
 
- private:
+private:
   void* bootstrap_;
   const int rank_;
   const int nranks_;

--- a/projects/rccl/src/include/ipcsocket.h
+++ b/projects/rccl/src/include/ipcsocket.h
@@ -23,14 +23,15 @@ struct ncclIpcSocket {
   volatile uint32_t* abortFlag;
 };
 
-ncclResult_t ncclIpcSocketInit(struct ncclIpcSocket *handle, int rank, uint64_t hash, volatile uint32_t* abortFlag);
-ncclResult_t ncclIpcSocketClose(struct ncclIpcSocket *handle);
+ncclResult_t ncclIpcSocketInit(struct ncclIpcSocket* handle, int rank, uint64_t hash, volatile uint32_t* abortFlag);
+ncclResult_t ncclIpcSocketClose(struct ncclIpcSocket* handle);
 ncclResult_t ncclIpcSocketGetFd(struct ncclIpcSocket* handle, int* fd);
 
-ncclResult_t ncclIpcSocketRecvFd(struct ncclIpcSocket *handle, int *fd);
-ncclResult_t ncclIpcSocketSendFd(struct ncclIpcSocket *handle, const int fd, int rank, uint64_t hash);
+ncclResult_t ncclIpcSocketRecvFd(struct ncclIpcSocket* handle, int* fd);
+ncclResult_t ncclIpcSocketSendFd(struct ncclIpcSocket* handle, const int fd, int rank, uint64_t hash);
 
-ncclResult_t ncclIpcSocketSendMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, const int sendFd, int rank, uint64_t hash);
-ncclResult_t ncclIpcSocketRecvMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, int *recvFd);
+ncclResult_t ncclIpcSocketSendMsg(ncclIpcSocket* handle, void* hdr, int hdrLen, const int sendFd, int rank,
+                                  uint64_t hash);
+ncclResult_t ncclIpcSocketRecvMsg(ncclIpcSocket* handle, void* hdr, int hdrLen, int* recvFd);
 
 #endif /* NCCL_IPCSOCKET_H */

--- a/projects/rccl/src/include/latency_profiler/CollTrace.h
+++ b/projects/rccl/src/include/latency_profiler/CollTrace.h
@@ -31,20 +31,19 @@ struct CollStats;
 // 4) Report to scuba when results buffer is full or every few minutes
 
 class CollTrace {
- public:
+public:
   CollTrace(ncclComm* comm);
   __attribute__((visibility("default"))) ~CollTrace();
 
   void enqueueEvent(std::unique_ptr<CollTraceEvent> event);
 
-  std::unique_ptr<CollTraceEvent> createEvent(
-      CollTraceEvent::EventType type = CollTraceEvent::EventType::COMM);
+  std::unique_ptr<CollTraceEvent> createEvent(CollTraceEvent::EventType type = CollTraceEvent::EventType::COMM);
 
   void recordCurCollResult(int rank, float latencyMs);
 
   void reportIfNeeded(bool checkInterval);
 
- private:
+private:
   EventQueue<CollTraceEvent> eventQueue_;
   std::thread profilingWorkerThread_;
   void* collTraceThreadFn(int cudaDev);

--- a/projects/rccl/src/include/latency_profiler/CollTraceEvent.h
+++ b/projects/rccl/src/include/latency_profiler/CollTraceEvent.h
@@ -22,13 +22,11 @@ struct CudaEventDeleter {
     (void)cudaEventDestroy(e);
   }
 };
-using CudaEventPtr = std::unique_ptr<
-    std::pointer_traits<cudaEvent_t>::element_type,
-    CudaEventDeleter>;
+using CudaEventPtr = std::unique_ptr<std::pointer_traits<cudaEvent_t>::element_type, CudaEventDeleter>;
 
 // a wrapper class for cuda event
 class CudaWaitEvent {
- public:
+public:
   CudaWaitEvent(CudaEventPtr e) : event_(std::move(e)) {}
   ~CudaWaitEvent() {}
 
@@ -39,13 +37,16 @@ class CudaWaitEvent {
   std::shared_ptr<float> getElapsedTimeSinceEvent(CudaWaitEvent* start);
   ncclResult_t waitEventFinish();
 
- private:
+private:
   CudaEventPtr event_;
 };
 
 // Event data structure
 struct CollTraceEvent {
-  enum class EventType { COMM, TERMINATE };
+  enum class EventType {
+    COMM,
+    TERMINATE
+  };
 
   CollTraceInfo coll;
   std::unique_ptr<CudaWaitEvent> start{nullptr};

--- a/projects/rccl/src/include/latency_profiler/CollTraceFunc.h
+++ b/projects/rccl/src/include/latency_profiler/CollTraceFunc.h
@@ -12,7 +12,7 @@
 
 namespace latency_profiler {
 class CollTraceError : public std::runtime_error {
- public:
+public:
   explicit CollTraceError(const std::string& what) : std::runtime_error(what) {}
 };
 
@@ -20,20 +20,12 @@ ncclResult_t collTraceInit(ncclComm* comm);
 
 ncclResult_t collTraceDestroy(ncclComm* comm);
 
-std::unique_ptr<CollTraceEvent> collTraceAquireEventBaseline(
-    ncclKernelPlan* plan,
-    cudaStream_t stream);
+std::unique_ptr<CollTraceEvent> collTraceAquireEventBaseline(ncclKernelPlan* plan, cudaStream_t stream);
 
-ncclResult_t collTraceRecordStartEvent(
-    ncclComm* comm,
-    cudaStream_t launchStream,
-    CollTraceEvent* event);
+ncclResult_t collTraceRecordStartEvent(ncclComm* comm, cudaStream_t launchStream, CollTraceEvent* event);
 
-ncclResult_t collTraceRecordEndEvent(
-    ncclComm* comm,
-    ncclKernelPlan* plan,
-    cudaStream_t launchStream,
-    std::unique_ptr<CollTraceEvent> event);
+ncclResult_t collTraceRecordEndEvent(ncclComm* comm, ncclKernelPlan* plan, cudaStream_t launchStream,
+                                     std::unique_ptr<CollTraceEvent> event);
 
 CollTraceInfo parseCollInfoFromCollTask(const ncclTaskColl& collTask);
 } // namespace latency_profiler

--- a/projects/rccl/src/include/latency_profiler/CollTraceUtils.h
+++ b/projects/rccl/src/include/latency_profiler/CollTraceUtils.h
@@ -21,9 +21,10 @@ struct CollStats {
   const std::string opName;
   const std::string dataType;
   int64_t count;
-  CollStats(const int collId, const int percent, const float minLatencyUs, const float maxLatencyUs, const std::string& opName, const std::string& dataType, const int64_t count) : collId(collId), percent(percent), minLatencyUs(minLatencyUs), maxLatencyUs(maxLatencyUs), opName(opName), dataType(dataType), count(count) {
-
-  }
+  CollStats(const int collId, const int percent, const float minLatencyUs, const float maxLatencyUs,
+            const std::string& opName, const std::string& dataType, const int64_t count)
+    : collId(collId), percent(percent), minLatencyUs(minLatencyUs), maxLatencyUs(maxLatencyUs), opName(opName),
+      dataType(dataType), count(count) {}
 };
 
 struct CollTraceInfo {
@@ -34,15 +35,11 @@ struct CollTraceInfo {
   float latencyMs{-1};
 };
 
-void reportToFile(
-    const std::deque<std::vector<CollStats>>& stats,
-    const std::string& commHash);
+void reportToFile(const std::deque<std::vector<CollStats>>& stats, const std::string& commHash);
 
-std::vector<CollStats> aggregateResults(
-    const std::deque<std::unique_ptr<CollTraceInfo>>& info,
-    const std::vector<float>& latencyAllGather,
-    int RANKS_PER_HOST,
-    int NCCL_COLLTRACE_RECORD_MAX);
+std::vector<CollStats> aggregateResults(const std::deque<std::unique_ptr<CollTraceInfo>>& info,
+                                        const std::vector<float>& latencyAllGather, int RANKS_PER_HOST,
+                                        int NCCL_COLLTRACE_RECORD_MAX);
 
 float getSizeMb(const std::string& dataType, int count);
 

--- a/projects/rccl/src/include/latency_profiler/EventQueue.h
+++ b/projects/rccl/src/include/latency_profiler/EventQueue.h
@@ -18,12 +18,12 @@ namespace latency_profiler {
 
 template <class Element>
 class EventQueue {
- private:
+private:
   std::deque<std::unique_ptr<Element>> queue_;
   std::condition_variable cv_;
   mutable std::mutex mutex_;
 
- public:
+public:
   void push(std::unique_ptr<Element> item) {
     {
       std::lock_guard<std::mutex> lock(mutex_);

--- a/projects/rccl/src/include/mem_manager.h
+++ b/projects/rccl/src/include/mem_manager.h
@@ -26,7 +26,7 @@ extern "C" {
 #define HIP_IPC_HANDLE_SIZE 64
 #endif
 typedef struct hipMemFabricHandle_st {
-    unsigned char data[HIP_IPC_HANDLE_SIZE];
+  unsigned char data[HIP_IPC_HANDLE_SIZE];
 } hipMemFabricHandle_compat_t;
 #else
 typedef hipMemFabricHandle_t hipMemFabricHandle_compat_t;
@@ -48,14 +48,14 @@ struct ncclComm;
 
 // Memory Type for NCCL allocations
 typedef enum {
-  ncclMemPersist  = 0,  // Persistent memory - track stats only, never release/offload
-  ncclMemScratch  = 1,  // Free without saving
-  ncclMemOffload  = 2   // Copy to CPU before free, restore on resume
+  ncclMemPersist = 0,  // Persistent memory - track stats only, never release/offload
+  ncclMemScratch = 1,  // Free without saving
+  ncclMemOffload = 2   // Copy to CPU before free, restore on resume
 } ncclMemType_t;
 
 // Memory entry state
 typedef enum {
-  ncclDynMemStateActive   = 0,  // Memory is allocated and usable
+  ncclDynMemStateActive = 0,  // Memory is allocated and usable
   ncclDynMemStateReleased = 1   // Memory has been released
 } ncclDynMemState_t;
 
@@ -66,78 +66,78 @@ typedef struct ncclDynMemLocalDesc {
   // (ncclProxyClientGetFdBlocking), so we no longer export them upfront. Only FABRIC
   // handles need upfront export since they can be shared directly via messaging.
   union {
-    int                          fd;            // For POSIX_FILE_DESCRIPTOR (unused)
-    hipMemFabricHandle_compat_t  fabricHandle;  // For FABRIC
+    int fd;            // For POSIX_FILE_DESCRIPTOR (unused)
+    hipMemFabricHandle_compat_t fabricHandle;  // For FABRIC
   } shareableHandle;
-  bool                           shareableHandleValid;
+  bool shareableHandleValid;
   // Peer tracking for P2P exports
-  int                            numExportedPeers;
-  int                            exportedPeersCapacity;
-  int*                           exportedPeerRanks;
+  int numExportedPeers;
+  int exportedPeersCapacity;
+  int* exportedPeerRanks;
 } ncclDynMemLocalDesc;
 
 // Imported from peer memory descriptor
 typedef struct ncclDynMemImportDesc {
-  int                            ownerRank;     // Rank that owns the original buffer
-  int                            ownerDev;      // CUDA device of the owner
-  void*                          ownerPtr;      // Owner's virtual address
+  int ownerRank;     // Rank that owns the original buffer
+  int ownerDev;      // CUDA device of the owner
+  void* ownerPtr;      // Owner's virtual address
 } ncclDynMemImportDesc;
 
 // Individual tracked memory entry (only track scratch and offload allocations)
 typedef struct ncclDynMemEntry {
-  void*                            ptr;           // GPU virtual address
-  size_t                           size;          // Allocation size
-  hipMemGenericAllocationHandle_t  handle;        // Physical memory handle
-  hipMemAllocationHandleType       handleType;
-  ncclMemType_t                    memType;
-  ncclDynMemState_t                state;
-  int                              cudaDev;
+  void* ptr;           // GPU virtual address
+  size_t size;          // Allocation size
+  hipMemGenericAllocationHandle_t handle;        // Physical memory handle
+  hipMemAllocationHandleType handleType;
+  ncclMemType_t memType;
+  ncclDynMemState_t state;
+  int cudaDev;
 
   // CPU backup for OFFLOAD type memory
-  void*                            cpuBackup;     // Host memory for offloaded data
+  void* cpuBackup;     // Host memory for offloaded data
 
   // Ownership type and type-specific data
-  bool                             isImportedFromPeer;  // true if this is a peer-imported buffer
+  bool isImportedFromPeer;  // true if this is a peer-imported buffer
   union {
-    ncclDynMemLocalDesc            local;
-    ncclDynMemImportDesc           imported;
+    ncclDynMemLocalDesc local;
+    ncclDynMemImportDesc imported;
   } desc;
 
   // Linked list pointer
-  struct ncclDynMemEntry*          next;
+  struct ncclDynMemEntry* next;
 } ncclDynMemEntry;
 
 // P2P Handle Exchange Structure
 typedef struct ncclDynMemP2pHandleInfo {
-  void*    ptr;
-  int      ownerRank;
-  int      ownerDev;
-  size_t   size;
-  int      handleType;
+  void* ptr;
+  int ownerRank;
+  int ownerDev;
+  size_t size;
+  int handleType;
   union {
-    uint64_t                     handleData;
-    hipMemFabricHandle_compat_t  fabricHandle;
+    uint64_t handleData;
+    hipMemFabricHandle_compat_t fabricHandle;
   };
 } ncclDynMemP2pHandleInfo;
 
 // Memory manager attached to ncclComm
 typedef struct ncclMemManager {
-  ncclDynMemEntry*  entries;  // Linked list of tracked allocations, only track scratch and offload allocations
-  int               numEntries;
-  std::mutex        lock;
-  int               released;
-  int               initialized;
-  int               refCount;
+  ncclDynMemEntry* entries;  // Linked list of tracked allocations, only track scratch and offload allocations
+  int numEntries;
+  std::mutex lock;
+  int released;
+  int initialized;
+  int refCount;
 
-  size_t            totalPersist;
-  size_t            totalPersistImported;
-  size_t            totalScratch;
-  size_t            totalScratchImported;
-  size_t            totalOffload;
-  size_t            totalOffloadImported;
-  size_t            cpuBackupUsage;
+  size_t totalPersist;
+  size_t totalPersistImported;
+  size_t totalScratch;
+  size_t totalScratchImported;
+  size_t totalOffload;
+  size_t totalOffloadImported;
+  size_t cpuBackupUsage;
 
-  int               commCudaDev;
+  int commCudaDev;
 } ncclMemManager;
 
 struct ncclMemManagerTask {
@@ -152,27 +152,14 @@ ncclResult_t ncclMemManagerInit(struct ncclComm* comm);
 ncclResult_t ncclMemManagerDestroy(struct ncclComm* comm);
 
 // Track a new allocation
-ncclResult_t ncclMemTrack(
-  struct ncclMemManager* manager,
-  void* ptr,
-  size_t size,
-  hipMemGenericAllocationHandle_t handle,
-  hipMemAllocationHandleType handleType,
-  ncclMemType_t memType
-);
+ncclResult_t ncclMemTrack(struct ncclMemManager* manager, void* ptr, size_t size,
+                          hipMemGenericAllocationHandle_t handle, hipMemAllocationHandleType handleType,
+                          ncclMemType_t memType);
 
 // Track imported allocation from peer
-ncclResult_t ncclMemTrackImportFromPeer(
-  struct ncclMemManager* manager,
-  void* ptr,
-  size_t size,
-  hipMemGenericAllocationHandle_t handle,
-  hipMemAllocationHandleType handleType,
-  ncclMemType_t memType,
-  int ownerRank,
-  int ownerDev,
-  void* ownerPtr
-);
+ncclResult_t ncclMemTrackImportFromPeer(struct ncclMemManager* manager, void* ptr, size_t size,
+                                        hipMemGenericAllocationHandle_t handle, hipMemAllocationHandleType handleType,
+                                        ncclMemType_t memType, int ownerRank, int ownerDev, void* ownerPtr);
 
 // Untrack allocation
 ncclResult_t ncclMemUntrack(struct ncclMemManager* manager, void* ptr, size_t size);
@@ -197,8 +184,7 @@ ncclResult_t ncclCommMemStats_impl(ncclComm_t comm, ncclCommMemStat_t stat, uint
 // (state==Released). ncclCuMemFree / ncclCudaFree use it to skip the real
 // teardown for Suspended entries while still freeing persistent / untracked
 // pointers on Destroy-while-Suspended.
-static inline bool ncclMemEntryAlreadyReleased(struct ncclMemManager* manager,
-                                               void* ptr) {
+static inline bool ncclMemEntryAlreadyReleased(struct ncclMemManager* manager, void* ptr) {
   if (manager == nullptr) return false;
   if (!__atomic_load_n(&manager->released, __ATOMIC_ACQUIRE)) return false;
   std::lock_guard<std::mutex> lock(manager->lock);

--- a/projects/rccl/src/include/mlx5/mlx5dvsymbols.h
+++ b/projects/rccl/src/include/mlx5/mlx5dvsymbols.h
@@ -18,13 +18,15 @@
 
 /* MLX5 Direct Verbs Function Pointers*/
 struct ncclMlx5dvSymbols {
-  bool (*mlx5dv_internal_is_supported)(struct ibv_device *device);
-  int (*mlx5dv_internal_get_data_direct_sysfs_path)(struct ibv_context *context, char *buf, size_t buf_len);
+  bool (*mlx5dv_internal_is_supported)(struct ibv_device* device);
+  int (*mlx5dv_internal_get_data_direct_sysfs_path)(struct ibv_context* context, char* buf, size_t buf_len);
   /* DMA-BUF support */
-  struct ibv_mr * (*mlx5dv_internal_reg_dmabuf_mr)(struct ibv_pd *pd, uint64_t offset, size_t length, uint64_t iova, int fd, int access, int mlx5_access);
-  int (*mlx5dv_internal_query_device)(struct ibv_context *ctx_in, struct mlx5dv_context *attrs_out);
-  struct ibv_qp *(*mlx5dv_internal_create_qp)(struct ibv_context *context, struct ibv_qp_init_attr_ex *qp_attr, struct mlx5dv_qp_init_attr *mlx5_qp_attr);
-  };
+  struct ibv_mr* (*mlx5dv_internal_reg_dmabuf_mr)(struct ibv_pd* pd, uint64_t offset, size_t length, uint64_t iova,
+                                                  int fd, int access, int mlx5_access);
+  int (*mlx5dv_internal_query_device)(struct ibv_context* ctx_in, struct mlx5dv_context* attrs_out);
+  struct ibv_qp* (*mlx5dv_internal_create_qp)(struct ibv_context* context, struct ibv_qp_init_attr_ex* qp_attr,
+                                              struct mlx5dv_qp_init_attr* mlx5_qp_attr);
+};
 
 /* Constructs MLX5 direct verbs symbols per rdma-core linking or dynamic loading mode */
 ncclResult_t buildMlx5dvSymbols(struct ncclMlx5dvSymbols* mlx5dvSymbols);

--- a/projects/rccl/src/include/mlx5/mlx5dvwrap.h
+++ b/projects/rccl/src/include/mlx5/mlx5dvwrap.h
@@ -21,19 +21,21 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-typedef enum mlx5dv_return_enum
-{
-    MLX5DV_SUCCESS = 0,                   //!< The operation was successful
+typedef enum mlx5dv_return_enum {
+  MLX5DV_SUCCESS = 0,                   //!< The operation was successful
 } mlx5dv_return_t;
 
 ncclResult_t wrap_mlx5dv_symbols(void);
 /* NCCL wrappers of MLX5 direct verbs functions */
-bool wrap_mlx5dv_is_supported(struct ibv_device *device);
-ncclResult_t wrap_mlx5dv_get_data_direct_sysfs_path(struct ibv_context *context, char *buf, size_t buf_len);
+bool wrap_mlx5dv_is_supported(struct ibv_device* device);
+ncclResult_t wrap_mlx5dv_get_data_direct_sysfs_path(struct ibv_context* context, char* buf, size_t buf_len);
 /* DMA-BUF support */
-ncclResult_t wrap_mlx5dv_reg_dmabuf_mr(struct ibv_mr **ret, struct ibv_pd *pd, uint64_t offset, size_t length, uint64_t iova, int fd, int access, int mlx5_access);
-struct ibv_mr * wrap_direct_mlx5dv_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset, size_t length, uint64_t iova, int fd, int access, int mlx5_access);
-ncclResult_t wrap_mlx5dv_query_device(struct ibv_context *ctx_in, struct mlx5dv_context *attrs_out);
-struct ibv_qp *wrap_mlx5dv_create_qp(struct ibv_context *context, struct ibv_qp_init_attr_ex *qp_attr, struct mlx5dv_qp_init_attr *mlx5_qp_attr);
+ncclResult_t wrap_mlx5dv_reg_dmabuf_mr(struct ibv_mr** ret, struct ibv_pd* pd, uint64_t offset, size_t length,
+                                       uint64_t iova, int fd, int access, int mlx5_access);
+struct ibv_mr* wrap_direct_mlx5dv_reg_dmabuf_mr(struct ibv_pd* pd, uint64_t offset, size_t length, uint64_t iova,
+                                                int fd, int access, int mlx5_access);
+ncclResult_t wrap_mlx5dv_query_device(struct ibv_context* ctx_in, struct mlx5dv_context* attrs_out);
+struct ibv_qp* wrap_mlx5dv_create_qp(struct ibv_context* context, struct ibv_qp_init_attr_ex* qp_attr,
+                                     struct mlx5dv_qp_init_attr* mlx5_qp_attr);
 
 #endif // NCCL_MLX5DVWRAP_H_

--- a/projects/rccl/src/include/nccl_common.h
+++ b/projects/rccl/src/include/nccl_common.h
@@ -9,10 +9,10 @@
 #define NCCL_DEBUG_H_
 
 #ifdef NCCL_OS_LINUX
-  // Workaround for libstdc++ trying to force public visibility of std:: symbols.  We don't want to do that in libnccl.so.
-  #include <bits/c++config.h>
-  #undef _GLIBCXX_VISIBILITY
-  #define _GLIBCXX_VISIBILITY(V)
+// Workaround for libstdc++ trying to force public visibility of std:: symbols.  We don't want to do that in libnccl.so.
+#include <bits/c++config.h>
+#undef _GLIBCXX_VISIBILITY
+#define _GLIBCXX_VISIBILITY(V)
 #endif
 
 #include <cstdint>
@@ -20,8 +20,8 @@
 
 // Windows compatibility: define ssize_t if not available
 #ifdef NCCL_OS_WINDOWS
-  #include <BaseTsd.h>
-  typedef SSIZE_T ssize_t;
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
 #endif
 
 typedef enum {
@@ -56,7 +56,8 @@ typedef enum {
   NCCL_ALL = ~0
 } ncclDebugLogSubSys;
 
-typedef void (*ncclDebugLogger_t)(ncclDebugLogLevel level, unsigned long flags, const char *file, int line, const char *fmt, ...);
+typedef void (*ncclDebugLogger_t)(ncclDebugLogLevel level, unsigned long flags, const char* file, int line,
+                                  const char* fmt, ...);
 
 // NCCL core profiler callback for network defined events instrumentation
 enum {
@@ -66,7 +67,8 @@ enum {
   ncclProfilerNetEventUpdateAndStop,
 };
 
-typedef ncclResult_t (*ncclProfilerCallback_t)(void** eHandle, int type, void* pHandle, int64_t pluginId, void* extData);
+typedef ncclResult_t (*ncclProfilerCallback_t)(void** eHandle, int type, void* pHandle, int64_t pluginId,
+                                               void* extData);
 
 #define NCCL_NUM_FUNCTIONS 5 // Send/Recv not included for now
 typedef enum {
@@ -90,6 +92,5 @@ typedef enum {
   ncclFuncWaitSignal = 17,
   ncclNumFuncs = 18
 } ncclFunc_t;
-
 
 #endif

--- a/projects/rccl/src/include/nccl_device/barrier.h
+++ b/projects/rccl/src/include/nccl_device/barrier.h
@@ -13,29 +13,20 @@
 #include "impl/gin_barrier__types.h"
 
 #if __CUDACC__
-template<typename Coop>
+template <typename Coop>
 struct ncclBarrierSession_internal;
 
-template<typename Coop>
-struct ncclBarrierSession: ncclBarrierSession_internal<Coop> {
+template <typename Coop>
+struct ncclBarrierSession : ncclBarrierSession_internal<Coop> {
   // Full featured constructor:
-  NCCL_DEVICE_INLINE ncclBarrierSession(
-    Coop, ncclTeam innerTeam, ncclTeam outerTeam, ncclGin,
-    ncclLsaBarrierHandle innerBarHandle,
-    ncclGinBarrierHandle outerBarHandle,
-    uint32_t index,
-    bool multimem=false, ncclMultimemHandle innerMmHandle={}
-  );
+  NCCL_DEVICE_INLINE ncclBarrierSession(Coop, ncclTeam innerTeam, ncclTeam outerTeam, ncclGin,
+                                        ncclLsaBarrierHandle innerBarHandle, ncclGinBarrierHandle outerBarHandle,
+                                        uint32_t index, bool multimem = false, ncclMultimemHandle innerMmHandle = {});
   // Convenience constructors for baked in teams:
-  NCCL_DEVICE_INLINE ncclBarrierSession(
-    Coop, ncclTeamTagWorld, ncclGin, uint32_t index, bool multimem=false
-  );
-  NCCL_DEVICE_INLINE ncclBarrierSession(
-    Coop, ncclTeamTagLsa, ncclDevComm const&, uint32_t index, bool multimem=false
-  );
-  NCCL_DEVICE_INLINE ncclBarrierSession(
-    Coop, ncclTeamTagRail, ncclGin, uint32_t index
-  );
+  NCCL_DEVICE_INLINE ncclBarrierSession(Coop, ncclTeamTagWorld, ncclGin, uint32_t index, bool multimem = false);
+  NCCL_DEVICE_INLINE ncclBarrierSession(Coop, ncclTeamTagLsa, ncclDevComm const&, uint32_t index,
+                                        bool multimem = false);
+  NCCL_DEVICE_INLINE ncclBarrierSession(Coop, ncclTeamTagRail, ncclGin, uint32_t index);
 
   ncclBarrierSession(ncclBarrierSession const&) = delete; // Sessions are not copyable
 

--- a/projects/rccl/src/include/nccl_device/coop.h
+++ b/projects/rccl/src/include/nccl_device/coop.h
@@ -17,58 +17,60 @@
 //   void Coop::sync();
 
 #if defined(__HIP_DEVICE_COMPILE__)
-  #if defined(__GFX9__)
-  #define WARP_SIZE 64
-  #else
-  #define WARP_SIZE 32
-  #endif
+#if defined(__GFX9__)
+#define WARP_SIZE 64
 #else
-  #define WARP_SIZE 32
+#define WARP_SIZE 32
+#endif
+#else
+#define WARP_SIZE 32
 #endif
 
 #if NCCL_CHECK_CUDACC
 #if defined(__HIP_PLATFORM_AMD__)
 using ncclCoopMask_t = uint64_t;
 static constexpr ncclCoopMask_t ncclCoopFullMask = ~0ull;
-NCCL_DEVICE_INLINE int ncclCoopPopc(ncclCoopMask_t x) { return (int)__popcll(x); }
+NCCL_DEVICE_INLINE int ncclCoopPopc(ncclCoopMask_t x) {
+  return (int)__popcll(x);
+}
 #else
 using ncclCoopMask_t = uint32_t;
 static constexpr ncclCoopMask_t ncclCoopFullMask = ~0u;
-NCCL_DEVICE_INLINE int ncclCoopPopc(ncclCoopMask_t x) { return (int)__popc(x); }
+NCCL_DEVICE_INLINE int ncclCoopPopc(ncclCoopMask_t x) {
+  return (int)__popc(x);
+}
 #endif
 #endif
 
 #if NCCL_CHECK_CUDACC
 struct ncclCoopAny {
-  struct Storage { alignas(alignof(void*)) char space[16]; };
+  struct Storage {
+    alignas(alignof(void*)) char space[16];
+  };
   struct VTable {
-    int(*thread_rank)(void const*);
-    int(*size)(void const*);
-    void(*sync)(void*);
+    int (*thread_rank)(void const*);
+    int (*size)(void const*);
+    void (*sync)(void*);
   };
 
-  template<typename Impl>
+  template <typename Impl>
   __device__ static int thread_rank(void const* o) {
     return static_cast<Impl const*>(o)->thread_rank();
   }
-  template<typename Impl>
+  template <typename Impl>
   __device__ static int size(void const* o) {
     return static_cast<Impl const*>(o)->size();
   }
-  template<typename Impl>
+  template <typename Impl>
   __device__ static void sync(void* o) {
     static_cast<Impl*>(o)->sync();
   }
 
-  template<typename Impl>
+  template <typename Impl>
   __device__ static VTable const* get_vtable() {
     static_assert(sizeof(Impl) <= sizeof(Storage), "Incompatible coop type size");
     static_assert(alignof(Impl) <= alignof(Storage), "Incompatible coop type alignment");
-    static constexpr VTable v = {
-      &thread_rank<Impl>,
-      &size<Impl>,
-      &sync<Impl>
-    };
+    static constexpr VTable v = {&thread_rank<Impl>, &size<Impl>, &sync<Impl>};
     return &v;
   }
 
@@ -79,32 +81,44 @@ struct ncclCoopAny {
   ncclCoopAny(ncclCoopAny&&) = default;
   ncclCoopAny() = default;
 
-  template<typename Impl>
+  template <typename Impl>
   __device__ ncclCoopAny(Impl impl) {
     ::new (&this->storage) Impl(impl);
     this->vtable = get_vtable<Impl>();
   }
 
-  __device__ int thread_rank() const { return vtable->thread_rank(&storage); }
-  __device__ int size() const { return vtable->size(&storage); }
-  __device__ int num_threads() const { return vtable->size(&storage); }
-  __device__ void sync() { vtable->sync(&storage); }
+  __device__ int thread_rank() const {
+    return vtable->thread_rank(&storage);
+  }
+  __device__ int size() const {
+    return vtable->size(&storage);
+  }
+  __device__ int num_threads() const {
+    return vtable->size(&storage);
+  }
+  __device__ void sync() {
+    vtable->sync(&storage);
+  }
 };
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<int nThreadsPow2>
+template <int nThreadsPow2>
 struct ncclCoopTile { // An aligned pow2 set of threads within the warp.
   static_assert(nccl::utility::isPow2(nThreadsPow2) && nThreadsPow2 <= WARP_SIZE, "Condition required");
 
   NCCL_DEVICE_INLINE int thread_rank() const {
     return nccl::utility::lane() % nThreadsPow2;
   }
-  NCCL_DEVICE_INLINE constexpr int size() const { return nThreadsPow2; }
-  NCCL_DEVICE_INLINE constexpr int num_threads() const { return nThreadsPow2; }
+  NCCL_DEVICE_INLINE constexpr int size() const {
+    return nThreadsPow2;
+  }
+  NCCL_DEVICE_INLINE constexpr int num_threads() const {
+    return nThreadsPow2;
+  }
 
   NCCL_DEVICE_INLINE ncclCoopMask_t laneMask() const {
-    return (ncclCoopMask_t(-1)>>(WARP_SIZE-nThreadsPow2))<<(nccl::utility::lane() & -nThreadsPow2);
+    return (ncclCoopMask_t(-1) >> (WARP_SIZE - nThreadsPow2)) << (nccl::utility::lane() & -nThreadsPow2);
   }
   NCCL_DEVICE_INLINE void sync() {
 #if ROCM_VERSION >= 70000
@@ -125,7 +139,7 @@ typedef ncclCoopTile<WARP_SIZE> ncclCoopWarp;
 struct ncclCoopLanes { // Some lanes of this warp.
   ncclCoopMask_t lmask;
 
-  NCCL_DEVICE_INLINE constexpr ncclCoopLanes(ncclCoopMask_t lmask = ncclCoopFullMask): lmask(lmask) {}
+  NCCL_DEVICE_INLINE constexpr ncclCoopLanes(ncclCoopMask_t lmask = ncclCoopFullMask) : lmask(lmask) {}
 
   NCCL_DEVICE_INLINE int thread_rank() const {
     return ncclCoopPopc(lmask & static_cast<ncclCoopMask_t>(nccl::utility::lanemask_lt()));
@@ -151,7 +165,10 @@ struct ncclCoopLanes { // Some lanes of this warp.
 // AMD has no named barriers, so emulate sub-block warp-span sync with a shared,
 // sense-reversing barrier keyed by span id. Init must zero the slots before use.
 constexpr int ncclCoopNamedBarrierSlots = 16; // mirrors CUDA's 16 hardware named barriers (ids 0-15)
-struct ncclCoopNamedBarrierSlot { uint32_t arrive; uint32_t sense; };
+struct ncclCoopNamedBarrierSlot {
+  uint32_t arrive;
+  uint32_t sense;
+};
 
 NCCL_DEVICE_INLINE ncclCoopNamedBarrierSlot* ncclCoopNamedBarrierState() {
   __shared__ ncclCoopNamedBarrierSlot slots[ncclCoopNamedBarrierSlots];
@@ -160,7 +177,10 @@ NCCL_DEVICE_INLINE ncclCoopNamedBarrierSlot* ncclCoopNamedBarrierState() {
 
 NCCL_DEVICE_INLINE void ncclCoopNamedBarrierInit() {
   ncclCoopNamedBarrierSlot* slots = ncclCoopNamedBarrierState();
-  for (int i = threadIdx.x; i < ncclCoopNamedBarrierSlots; i += blockDim.x) { slots[i].arrive = 0; slots[i].sense = 0; }
+  for (int i = threadIdx.x; i < ncclCoopNamedBarrierSlots; i += blockDim.x) {
+    slots[i].arrive = 0;
+    slots[i].sense = 0;
+  }
   __syncthreads();
 }
 #else
@@ -170,26 +190,27 @@ NCCL_DEVICE_INLINE void ncclCoopNamedBarrierInit() {}
 struct ncclCoopWarpSpan {
   uint32_t warp0:8, nWarps:8, id:8;
 
-  NCCL_DEVICE_INLINE constexpr ncclCoopWarpSpan(int warp0, int nWarps, int id):
-    warp0(warp0), nWarps(nWarps), id(id) {
-  }
+  NCCL_DEVICE_INLINE constexpr ncclCoopWarpSpan(int warp0, int nWarps, int id) : warp0(warp0), nWarps(nWarps), id(id) {}
 
   NCCL_DEVICE_INLINE int thread_rank() const {
-    return threadIdx.x - WARP_SIZE*warp0;
+    return threadIdx.x - WARP_SIZE * warp0;
   }
   NCCL_DEVICE_INLINE int size() const {
-    return WARP_SIZE*nWarps;
+    return WARP_SIZE * nWarps;
   }
   NCCL_DEVICE_INLINE int num_threads() const {
-    return WARP_SIZE*nWarps;
+    return WARP_SIZE * nWarps;
   }
 
   NCCL_DEVICE_INLINE void sync() {
-  #if defined(__HIP_PLATFORM_AMD__)
+#if defined(__HIP_PLATFORM_AMD__)
     // __syncthreads() can't sync a subset of warps; emulate a named barrier in software.
     // Single-warp span is lockstep: skip the shared atomic (hot path) and just fence.
     using Atom = cuda::atomic_ref<uint32_t, cuda::thread_scope_block>;
-    if (nWarps <= 1) { cuda::atomic_thread_fence(cuda::memory_order_acq_rel, cuda::thread_scope_block); return; }
+    if (nWarps <= 1) {
+      cuda::atomic_thread_fence(cuda::memory_order_acq_rel, cuda::thread_scope_block);
+      return;
+    }
     ncclCoopNamedBarrierSlot* slot = &ncclCoopNamedBarrierState()[id];
     cuda::atomic_thread_fence(cuda::memory_order_release, cuda::thread_scope_block);
     if ((threadIdx.x % WARP_SIZE) == 0) {  // one leader per warp
@@ -198,14 +219,13 @@ struct ncclCoopWarpSpan {
         Atom{slot->arrive}.store(0u, cuda::memory_order_relaxed);  // last in: reset, flip to release
         Atom{slot->sense}.store(s ^ 1u, cuda::memory_order_release);
       } else {
-        while (Atom{slot->sense}.load(cuda::memory_order_acquire) == s)
-          __builtin_amdgcn_s_sleep(1);
+        while (Atom{slot->sense}.load(cuda::memory_order_acquire) == s) __builtin_amdgcn_s_sleep(1);
       }
     }
     cuda::atomic_thread_fence(cuda::memory_order_acquire, cuda::thread_scope_block);
-  #else
-    asm volatile("barrier.sync %0, %1;" :: "r"(1+id), "r"(32*nWarps) : "memory");
-    __barrier_sync_count(1+id, 32*nWarps);
+#else
+    asm volatile("barrier.sync %0, %1;" ::"r"(1 + id), "r"(32 * nWarps) : "memory");
+    __barrier_sync_count(1 + id, 32 * nWarps);
 #endif
   }
 };
@@ -213,10 +233,18 @@ struct ncclCoopWarpSpan {
 
 #if NCCL_CHECK_CUDACC
 struct ncclCoopCta {
-  NCCL_DEVICE_INLINE int thread_rank() const { return threadIdx.x; }
-  NCCL_DEVICE_INLINE int size() const { return blockDim.x; }
-  NCCL_DEVICE_INLINE int num_threads() const { return blockDim.x; }
-  NCCL_DEVICE_INLINE void sync() { __syncthreads(); }
+  NCCL_DEVICE_INLINE int thread_rank() const {
+    return threadIdx.x;
+  }
+  NCCL_DEVICE_INLINE int size() const {
+    return blockDim.x;
+  }
+  NCCL_DEVICE_INLINE int num_threads() const {
+    return blockDim.x;
+  }
+  NCCL_DEVICE_INLINE void sync() {
+    __syncthreads();
+  }
 };
 #endif
 
@@ -224,7 +252,7 @@ struct ncclCoopCta {
 // NOTE: upstream v2.30 renamed ncclCoopLaneMask -> ncclCoopGetLaneMask; the
 // auto-merged callers (impl/vector__funcs.h, impl/core__funcs.h) use the new
 // name, so adopt it here while keeping RCCL's wave64 ncclCoopMask_t bodies.
-template<int nThreadsPow2>
+template <int nThreadsPow2>
 NCCL_DEVICE_INLINE ncclCoopMask_t ncclCoopGetLaneMask(ncclCoopTile<nThreadsPow2> coop) {
   return coop.laneMask();
 }
@@ -240,21 +268,35 @@ NCCL_DEVICE_INLINE ncclCoopMask_t ncclCoopGetLaneMask(ncclCoopCta coop) {
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<int nThreads>
+template <int nThreads>
 NCCL_DEVICE_INLINE constexpr bool ncclCoopIsThread(ncclCoopTile<nThreads>) {
   return nThreads == 1;
 }
-NCCL_DEVICE_INLINE constexpr bool ncclCoopIsThread(ncclCoopLanes) { return false; }
-NCCL_DEVICE_INLINE constexpr bool ncclCoopIsThread(ncclCoopWarpSpan) { return false; }
-NCCL_DEVICE_INLINE constexpr bool ncclCoopIsThread(ncclCoopCta) { return false; }
+NCCL_DEVICE_INLINE constexpr bool ncclCoopIsThread(ncclCoopLanes) {
+  return false;
+}
+NCCL_DEVICE_INLINE constexpr bool ncclCoopIsThread(ncclCoopWarpSpan) {
+  return false;
+}
+NCCL_DEVICE_INLINE constexpr bool ncclCoopIsThread(ncclCoopCta) {
+  return false;
+}
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<int nThreads>
-NCCL_DEVICE_INLINE constexpr bool ncclCoopWithinWarp(ncclCoopTile<nThreads>) { return true; }
-NCCL_DEVICE_INLINE constexpr bool ncclCoopWithinWarp(ncclCoopLanes) { return true; }
-NCCL_DEVICE_INLINE constexpr bool ncclCoopWithinWarp(ncclCoopWarpSpan) { return false; }
-NCCL_DEVICE_INLINE constexpr bool ncclCoopWithinWarp(ncclCoopCta) { return false; }
+template <int nThreads>
+NCCL_DEVICE_INLINE constexpr bool ncclCoopWithinWarp(ncclCoopTile<nThreads>) {
+  return true;
+}
+NCCL_DEVICE_INLINE constexpr bool ncclCoopWithinWarp(ncclCoopLanes) {
+  return true;
+}
+NCCL_DEVICE_INLINE constexpr bool ncclCoopWithinWarp(ncclCoopWarpSpan) {
+  return false;
+}
+NCCL_DEVICE_INLINE constexpr bool ncclCoopWithinWarp(ncclCoopCta) {
+  return false;
+}
 #endif
 
 #if NCCL_CHECK_CUDACC
@@ -271,38 +313,44 @@ NCCL_DEVICE_INLINE ncclCoopLanes ncclCoopCoalesced() {
 #if NCCL_CHECK_CUDACC
 // Pick threads of our warp that are safe to use collectively given that this
 // is a collective on the provided cooperative group.
-template<typename Coop>
+template <typename Coop>
 NCCL_DEVICE_INLINE ncclCoopTile<WARP_SIZE> ncclCoopCoalesced(Coop) {
   return ncclCoopTile<WARP_SIZE>();
 }
 NCCL_DEVICE_INLINE ncclCoopLanes ncclCoopCoalesced(ncclCoopLanes coop) {
   return coop;
 }
-template<int nThreads>
+template <int nThreads>
 NCCL_DEVICE_INLINE ncclCoopTile<nThreads> ncclCoopCoalesced(ncclCoopTile<nThreads> coop) {
   return coop;
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<int nThreads, typename T>
-NCCL_DEVICE_INLINE T ncclCoopBcast(ncclCoopTile<nThreads>, T value, int root, bool entrySync=true) {
-  constexpr int n = (sizeof(T)+4-1)/4;
-  union { uint32_t u[n]; T v; };
+template <int nThreads, typename T>
+NCCL_DEVICE_INLINE T ncclCoopBcast(ncclCoopTile<nThreads>, T value, int root, bool entrySync = true) {
+  constexpr int n = (sizeof(T) + 4 - 1) / 4;
+  union {
+    uint32_t u[n];
+    T v;
+  };
   v = value;
-  #pragma unroll
-  for (int i=0; i < n; i++) u[i] = __shfl_sync(-1u, u[i], root, nThreads);
+#pragma unroll
+  for (int i = 0; i < n; i++) u[i] = __shfl_sync(-1u, u[i], root, nThreads);
   return v;
 }
-template<typename T>
-NCCL_DEVICE_INLINE T ncclCoopBcast(ncclCoopLanes coop, T value, int root, bool entrySync=true) {
+template <typename T>
+NCCL_DEVICE_INLINE T ncclCoopBcast(ncclCoopLanes coop, T value, int root, bool entrySync = true) {
   uint32_t m = coop.lmask;
-  uint32_t r = root == 0 ? __ffs(m)-1 : __fns(m, 0, 1+root);
-  constexpr int n = (sizeof(T)+4-1)/4;
-  union { uint32_t u[n]; T v; };
+  uint32_t r = root == 0 ? __ffs(m) - 1 : __fns(m, 0, 1 + root);
+  constexpr int n = (sizeof(T) + 4 - 1) / 4;
+  union {
+    uint32_t u[n];
+    T v;
+  };
   v = value;
-  #pragma unroll
-  for (int i=0; i < n; i++) u[i] = __shfl_sync(m, u[i], r);
+#pragma unroll
+  for (int i = 0; i < n; i++) u[i] = __shfl_sync(m, u[i], r);
   return v;
 }
 
@@ -311,8 +359,8 @@ NCCL_DEVICE_INLINE ulong2* ncclCoopBcast_WarpSpan_stash() {
   return stash;
 }
 
-template<typename T>
-NCCL_DEVICE_INLINE T ncclCoopBcast(ncclCoopWarpSpan coop, T value, int root, bool entrySync=true) {
+template <typename T>
+NCCL_DEVICE_INLINE T ncclCoopBcast(ncclCoopWarpSpan coop, T value, int root, bool entrySync = true) {
   static_assert(sizeof(T) <= sizeof(ncclCoopBcast_WarpSpan_stash()[0]), "Required");
   if (entrySync) coop.sync();
   if (coop.thread_rank() == root) *(T*)&ncclCoopBcast_WarpSpan_stash()[coop.id] = value;
@@ -325,8 +373,8 @@ NCCL_DEVICE_INLINE ulong2* ncclCoopBcast_Cta_stash() {
   return &stash;
 }
 
-template<typename T>
-NCCL_DEVICE_INLINE T ncclCoopBcast(ncclCoopCta coop, T value, int root, bool entrySync=true) {
+template <typename T>
+NCCL_DEVICE_INLINE T ncclCoopBcast(ncclCoopCta coop, T value, int root, bool entrySync = true) {
   static_assert(sizeof(T) <= sizeof(*ncclCoopBcast_Cta_stash()), "Required");
   if (entrySync) coop.sync();
   if (coop.thread_rank() == root) *(T*)ncclCoopBcast_Cta_stash() = value;

--- a/projects/rccl/src/include/nccl_device/core.h
+++ b/projects/rccl/src/include/nccl_device/core.h
@@ -47,7 +47,8 @@ struct ncclTeam {
 };
 
 #if __cplusplus
-template<typename T> struct ncclSymPtr;
+template <typename T>
+struct ncclSymPtr;
 #endif
 
 #if __cplusplus
@@ -105,28 +106,29 @@ struct ncclDevCommRequirements {
   int worldGinBarrierCount;
 };
 
-#define NCCL_DEV_COMM_REQUIREMENTS_INITIALIZER {                               \
-    sizeof(ncclDevCommRequirements_t),           /* size */                    \
-    NCCL_API_MAGIC,                              /* magic */                   \
-    NCCL_VERSION_CODE,                           /* version */                 \
+#define NCCL_DEV_COMM_REQUIREMENTS_INITIALIZER \
+  { \
+    sizeof(ncclDevCommRequirements_t),           /* size */ \
+    NCCL_API_MAGIC,                              /* magic */ \
+    NCCL_VERSION_CODE,                           /* version */ \
     nullptr,                                     /* resourceRequirementsList*/ \
-    nullptr,                                     /* teamRequirementsList */    \
-    false,                                       /* lsaMultimem */             \
-    0,                                           /* barrierCount */            \
-    0,                                           /* lsaBarrierCount */         \
-    0,                                           /* railGinBarrierCount */     \
-    0,                                           /* lsaLLA2ABlockCount */      \
-    0,                                           /* lsaLLA2ASlotCount */       \
-    false,                                       /* ginForceEnable */          \
-    4,                                           /* ginContextCount */         \
-    0,                                           /* ginSignalCount */          \
-    0,                                           /* ginCounterCount */         \
-    NCCL_GIN_CONNECTION_NONE,                    /* ginConnectionType */       \
-    false,                                       /* ginExclusiveContexts */    \
-    0,                                           /* ginQueueDepth */           \
-    NCCL_CONFIG_UNDEF_INT,                       /* ginTrafficClass */         \
-    0,                                           /* worldGinBarrierCount */    \
-}
+    nullptr,                                     /* teamRequirementsList */ \
+    false,                                       /* lsaMultimem */ \
+    0,                                           /* barrierCount */ \
+    0,                                           /* lsaBarrierCount */ \
+    0,                                           /* railGinBarrierCount */ \
+    0,                                           /* lsaLLA2ABlockCount */ \
+    0,                                           /* lsaLLA2ASlotCount */ \
+    false,                                       /* ginForceEnable */ \
+    4,                                           /* ginContextCount */ \
+    0,                                           /* ginSignalCount */ \
+    0,                                           /* ginCounterCount */ \
+    NCCL_GIN_CONNECTION_NONE,                    /* ginConnectionType */ \
+    false,                                       /* ginExclusiveContexts */ \
+    0,                                           /* ginQueueDepth */ \
+    NCCL_CONFIG_UNDEF_INT,                       /* ginTrafficClass */ \
+    0,                                           /* worldGinBarrierCount */ \
+  }
 
 struct ncclDevResourceRequirements {
   ncclDevResourceRequirements_t* next;
@@ -145,11 +147,12 @@ struct ncclTeamRequirements {
   ncclMultimemHandle_t* outMultimemHandle; // If non-null, target assigned during ncclDevCommCreate.
 };
 
-#define NCCL_COMM_PROPERTIES_INITIALIZER {                           \
-  sizeof(ncclCommProperties_t),                  /* size */          \
-  NCCL_API_MAGIC,                                /* magic */         \
-  NCCL_VERSION_CODE,                             /* version */       \
-}
+#define NCCL_COMM_PROPERTIES_INITIALIZER \
+  { \
+    sizeof(ncclCommProperties_t),                  /* size */ \
+    NCCL_API_MAGIC,                                /* magic */ \
+    NCCL_VERSION_CODE,                             /* version */ \
+  }
 
 typedef enum {
   NCCL_GIN_TYPE_NONE = 0,
@@ -177,13 +180,17 @@ struct ncclCommProperties {
 };
 
 NCCL_EXTERN_C __host__ ncclResult_t ncclCommQueryProperties(ncclComm_t comm, ncclCommProperties_t* props);
-NCCL_EXTERN_C __host__ ncclResult_t ncclDevCommCreate(ncclComm_t comm, ncclDevCommRequirements_t const* reqs, ncclDevComm_t* outDevComm);
+NCCL_EXTERN_C __host__ ncclResult_t ncclDevCommCreate(ncclComm_t comm, ncclDevCommRequirements_t const* reqs,
+                                                      ncclDevComm_t* outDevComm);
 NCCL_EXTERN_C __host__ ncclResult_t ncclDevCommDestroy(ncclComm_t comm, ncclDevComm_t const* devComm);
 
 NCCL_EXTERN_C __host__ ncclResult_t ncclGetLsaMultimemDevicePointer(ncclWindow_t window, size_t offset, void** outPtr);
-NCCL_EXTERN_C __host__ ncclResult_t ncclGetMultimemDevicePointer(ncclWindow_t window, size_t offset, ncclMultimemHandle_t multimem, void** outPtr);
-NCCL_EXTERN_C __host__ ncclResult_t ncclGetLsaDevicePointer(ncclWindow_t window, size_t offset, int lsaRank, void** outPtr);
-NCCL_EXTERN_C __host__ ncclResult_t ncclGetPeerDevicePointer(ncclWindow_t window, size_t offset, int peer, void** outPtr);
+NCCL_EXTERN_C __host__ ncclResult_t ncclGetMultimemDevicePointer(ncclWindow_t window, size_t offset,
+                                                                 ncclMultimemHandle_t multimem, void** outPtr);
+NCCL_EXTERN_C __host__ ncclResult_t ncclGetLsaDevicePointer(ncclWindow_t window, size_t offset, int lsaRank,
+                                                            void** outPtr);
+NCCL_EXTERN_C __host__ ncclResult_t ncclGetPeerDevicePointer(ncclWindow_t window, size_t offset, int peer,
+                                                             void** outPtr);
 
 ////////////////////////////////////////////////////////////////////////////////
 // Team API:
@@ -250,17 +257,22 @@ NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void* ncclGetLocalPointer(ncclWindow_t w, si
 NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void* ncclGetLsaPointer(ncclWindow_t w, size_t offset, int peer);
 NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void* ncclGetPeerPointer(ncclWindow_t w, size_t offset, int peer);
 NCCL_DEVICE_INLINE void* ncclGetPeerPointer(ncclWindow_t w, size_t offset, ncclTeam tm, int peer);
-NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void* ncclGetMultimemPointer(ncclWindow_t w, size_t offset, ncclMultimemHandle mmHandle);
+NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void* ncclGetMultimemPointer(ncclWindow_t w, size_t offset,
+                                                                 ncclMultimemHandle mmHandle);
 NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void* ncclGetLsaMultimemPointer(ncclWindow_t w, size_t offset, ncclDevComm const&);
 #endif
 
 #if __CUDACC__
 // Convenience for combining ncclGet***Pointer() with resource handle.
 NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void* ncclGetResourceBufferLocalPointer(ncclDevComm const&, ncclDevResourceHandle);
-NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void* ncclGetResourceBufferLsaPointer(ncclDevComm const&, ncclDevResourceHandle, int peer);
-NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void* ncclGetResourceBufferPeerPointer(ncclDevComm const&, ncclDevResourceHandle, ncclTeam, int peer);
-NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void* ncclGetResourceBufferMultimemPointer(ncclDevComm const&, ncclDevResourceHandle, ncclMultimemHandle);
-NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void* ncclGetResourceBufferLsaMultimemPointer(ncclDevComm const&, ncclDevResourceHandle);
+NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void* ncclGetResourceBufferLsaPointer(ncclDevComm const&, ncclDevResourceHandle,
+                                                                          int peer);
+NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void* ncclGetResourceBufferPeerPointer(ncclDevComm const&, ncclDevResourceHandle,
+                                                                           ncclTeam, int peer);
+NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void* ncclGetResourceBufferMultimemPointer(
+  ncclDevComm const&, ncclDevResourceHandle, ncclMultimemHandle);
+NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void* ncclGetResourceBufferLsaMultimemPointer(ncclDevComm const&,
+                                                                                  ncclDevResourceHandle);
 #endif
 
 #endif // _NCCL_DEVICE_CORE_H_

--- a/projects/rccl/src/include/nccl_device/gin.h
+++ b/projects/rccl/src/include/nccl_device/gin.h
@@ -12,38 +12,55 @@
 
 #if NCCL_CHECK_CUDACC
 struct ncclGinCtx; // Definition in nccl_device/gin/gin_device_host_common.h
-template<unsigned> struct ncclGinCtx_M; // ...
+template <unsigned>
+struct ncclGinCtx_M; // ...
 
 struct ncclGinDescriptorSmem; // A type user allocates in __shared__ memory
 
 // Used as completion actions for ncclGinSession::put
 struct ncclGin_None {};
 
-struct ncclGin_VASignalInc { ncclWindow_t signalWindow; size_t signalOffset; };
-struct ncclGin_VASignalAdd { ncclWindow_t signalWindow; size_t signalOffset; uint64_t value; };
+struct ncclGin_VASignalInc {
+  ncclWindow_t signalWindow;
+  size_t signalOffset;
+};
+struct ncclGin_VASignalAdd {
+  ncclWindow_t signalWindow;
+  size_t signalOffset;
+  uint64_t value;
+};
 
-struct ncclGin_SignalAdd { ncclGinSignal_t signal; uint64_t value; };
+struct ncclGin_SignalAdd {
+  ncclGinSignal_t signal;
+  uint64_t value;
+};
 // SignalInc: equivalent to SignalAdd{+1} except it may not be mixed with any
 // other signal operator without intervening signal reset(). Formally: for a
 // given signal, all operations between successive reset()'s of that signal must
 // either all be SignalInc or all not SignalInc.
-struct ncclGin_SignalInc { ncclGinSignal_t signal; };
+struct ncclGin_SignalInc {
+  ncclGinSignal_t signal;
+};
 // Support deferred:
 // struct ncclGin_SignalSet { ncclGinSignal_t signal; uint64_t value; };
-struct ncclGin_CounterInc { ncclGinCounter_t counter; };
+struct ncclGin_CounterInc {
+  ncclGinCounter_t counter;
+};
 
-struct ncclGin_DescriptorSmem { ncclGinDescriptorSmem* descriptor; };
+struct ncclGin_DescriptorSmem {
+  ncclGinDescriptorSmem* descriptor;
+};
 
 // Segment type tags describe the composition of a buffer's physical cuMem segments.
 struct ncclGin_SegmentDevice {};       // all segments are device-backed
 struct ncclGin_SegmentMixed {}; // mix of HOST_NUMA and device-backed segments
 struct ncclGin_SegmentHostNuma {};     // all segments are HOST_NUMA (CPU-backed)
 
-template<unsigned backendMask>
+template <unsigned backendMask>
 struct ncclGin_BackendMask;
 
-template<ncclNetDeviceType backend>
-using ncclGin_BackendOne = ncclGin_BackendMask<(1u<<(int)backend)>;
+template <ncclNetDeviceType backend>
+using ncclGin_BackendOne = ncclGin_BackendMask<(1u << (int)backend)>;
 
 using ncclGin = ncclGin_BackendMask<NCCL_GIN_BACKEND_MASK_ALL>;
 
@@ -67,8 +84,8 @@ struct ncclGin_C {
 };
 
 // Helper init function that wraps placement new
-NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void ncclGin_C_init(
-  ncclGin_C* net, unsigned backendMask, ncclDevComm const& comm, int contextIndex);
+NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void ncclGin_C_init(ncclGin_C* net, unsigned backendMask, ncclDevComm const& comm,
+                                                        int contextIndex);
 
 // Helper init function with explicit resource sharing mode.
 NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void ncclGin_C_initWithResourceSharingMode(
@@ -76,112 +93,60 @@ NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void ncclGin_C_initWithResourceSharingMode(
   ncclGinResourceSharingMode resourceSharingMode);
 
 NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void ncclGinPut(
-  ncclGin_C* net,
-  ncclTeam team, int peer,
-  ncclWindow_t dstWin, size_t dstOffset,
-  ncclWindow_t srcWin, size_t srcOffset, size_t bytes,
-  bool isSignal, ncclGinSignal_t signalId, ncclGinSignalOp_t signalOp, uint64_t signalOpArg,
-  bool isCounter, ncclGinCounter_t counterId,
-  ncclCoopAny coop,
-  bool isDescriptor, ncclGinDescriptorSmem* descriptor,
+  ncclGin_C* net, ncclTeam team, int peer, ncclWindow_t dstWin, size_t dstOffset, ncclWindow_t srcWin, size_t srcOffset,
+  size_t bytes, bool isSignal, ncclGinSignal_t signalId, ncclGinSignalOp_t signalOp, uint64_t signalOpArg,
+  bool isCounter, ncclGinCounter_t counterId, ncclCoopAny coop, bool isDescriptor, ncclGinDescriptorSmem* descriptor,
   cuda::thread_scope givenRelease, cuda::thread_scope requiredRelease);
 
 NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void ncclGinSignal(
-  ncclGin_C* net,
-  ncclTeam team, int peer,
-  bool isSignal, ncclGinSignal_t signalId, ncclGinSignalOp_t signalOp, uint64_t signalOpArg,
-  ncclCoopAny coop,
-  bool isDescriptor, ncclGinDescriptorSmem* descriptor,
+  ncclGin_C* net, ncclTeam team, int peer, bool isSignal, ncclGinSignal_t signalId, ncclGinSignalOp_t signalOp,
+  uint64_t signalOpArg, ncclCoopAny coop, bool isDescriptor, ncclGinDescriptorSmem* descriptor,
   cuda::thread_scope givenRelease, cuda::thread_scope requiredRelease);
 
 NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void ncclGinPut_v2(
-  ncclGin_C* net,
-  ncclTeam team, int peer,
-  ncclWindow_t dstWin, size_t dstOffset,
-  ncclWindow_t srcWin, size_t srcOffset, size_t bytes,
-  bool isSignal, ncclGinSignal_t signalId, ncclGinSignalOp_t signalOp, uint64_t signalOpArg,
-  bool isCounter, ncclGinCounter_t counterId,
-  ncclCoopAny coop,
-  bool isDescriptor, ncclGinDescriptorSmem* descriptor,
-  cuda::thread_scope givenRelease, cuda::thread_scope requiredRelease,
-  uint32_t optFlags);
+  ncclGin_C* net, ncclTeam team, int peer, ncclWindow_t dstWin, size_t dstOffset, ncclWindow_t srcWin, size_t srcOffset,
+  size_t bytes, bool isSignal, ncclGinSignal_t signalId, ncclGinSignalOp_t signalOp, uint64_t signalOpArg,
+  bool isCounter, ncclGinCounter_t counterId, ncclCoopAny coop, bool isDescriptor, ncclGinDescriptorSmem* descriptor,
+  cuda::thread_scope givenRelease, cuda::thread_scope requiredRelease, uint32_t optFlags);
 
 NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void ncclGinSignal_v2(
-  ncclGin_C* net,
-  ncclTeam team, int peer,
-  bool isSignal, ncclGinSignal_t signalId, ncclGinSignalOp_t signalOp, uint64_t signalOpArg,
-  ncclCoopAny coop,
-  bool isDescriptor, ncclGinDescriptorSmem* descriptor,
-  cuda::thread_scope givenRelease, cuda::thread_scope requiredRelease,
-  uint32_t optFlags);
+  ncclGin_C* net, ncclTeam team, int peer, bool isSignal, ncclGinSignal_t signalId, ncclGinSignalOp_t signalOp,
+  uint64_t signalOpArg, ncclCoopAny coop, bool isDescriptor, ncclGinDescriptorSmem* descriptor,
+  cuda::thread_scope givenRelease, cuda::thread_scope requiredRelease, uint32_t optFlags);
 
-NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void ncclGinFlush(
-  ncclGin_C* net,
-  ncclCoopAny coop,
-  cuda::memory_order ord);
+NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void ncclGinFlush(ncclGin_C* net, ncclCoopAny coop, cuda::memory_order ord);
 
-NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE uint64_t ncclGinReadCounter(
-  ncclGin_C* net,
-  ncclGinCounter_t counter,
-  int bits,
-  cuda::memory_order ord);
+NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE uint64_t ncclGinReadCounter(ncclGin_C* net, ncclGinCounter_t counter, int bits,
+                                                                cuda::memory_order ord);
 
-NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void ncclGinWaitCounter(
-  ncclGin_C* net,
-  ncclCoopAny coop,
-  ncclGinCounter_t counter,
-  uint64_t least,
-  int bits,
-  cuda::memory_order ord);
+NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void ncclGinWaitCounter(ncclGin_C* net, ncclCoopAny coop, ncclGinCounter_t counter,
+                                                            uint64_t least, int bits, cuda::memory_order ord);
 
-NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE uint64_t ncclGinReadSignal(
-  ncclGin_C* net,
-  ncclGinSignal_t signal,
-  int bits,
-  cuda::memory_order ord);
+NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE uint64_t ncclGinReadSignal(ncclGin_C* net, ncclGinSignal_t signal, int bits,
+                                                               cuda::memory_order ord);
 
-NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void ncclGinWaitSignal(
-  ncclGin_C* net,
-  ncclCoopAny coop,
-  ncclGinSignal_t signal,
-  uint64_t least,
-  int bits,
-  cuda::memory_order ord);
+NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void ncclGinWaitSignal(ncclGin_C* net, ncclCoopAny coop, ncclGinSignal_t signal,
+                                                           uint64_t least, int bits, cuda::memory_order ord);
 
-NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void ncclGinResetCounter(
-  ncclGin_C* net,
-  ncclGinCounter_t counter);
+NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void ncclGinResetCounter(ncclGin_C* net, ncclGinCounter_t counter);
 
-NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void ncclGinResetSignal(
-  ncclGin_C* net,
-  ncclGinSignal_t signal);
+NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void ncclGinResetSignal(ncclGin_C* net, ncclGinSignal_t signal);
 
 NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void ncclGinPutValue(
-  ncclGin_C* net,
-  ncclTeam team, int peer,
-  ncclWindow_t dstWin, size_t dstOffset,
-  uint64_t value, size_t size,
-  bool isSignal, ncclGinSignal_t signalId, ncclGinSignalOp_t signalOp, uint64_t signalOpArg,
-  ncclCoopAny coop,
-  bool isDescriptor, ncclGinDescriptorSmem* descriptor,
-  cuda::thread_scope givenRelease, cuda::thread_scope requiredRelease);
+  ncclGin_C* net, ncclTeam team, int peer, ncclWindow_t dstWin, size_t dstOffset, uint64_t value, size_t size,
+  bool isSignal, ncclGinSignal_t signalId, ncclGinSignalOp_t signalOp, uint64_t signalOpArg, ncclCoopAny coop,
+  bool isDescriptor, ncclGinDescriptorSmem* descriptor, cuda::thread_scope givenRelease,
+  cuda::thread_scope requiredRelease);
 
 NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE void ncclGinPutValue_v2(
-  ncclGin_C* net,
-  ncclTeam team, int peer,
-  ncclWindow_t dstWin, size_t dstOffset,
-  uint64_t value, size_t size,
-  bool isSignal, ncclGinSignal_t signalId, ncclGinSignalOp_t signalOp, uint64_t signalOpArg,
-  ncclCoopAny coop,
-  bool isDescriptor, ncclGinDescriptorSmem* descriptor,
-  cuda::thread_scope givenRelease, cuda::thread_scope requiredRelease,
-  uint32_t optFlags);
+  ncclGin_C* net, ncclTeam team, int peer, ncclWindow_t dstWin, size_t dstOffset, uint64_t value, size_t size,
+  bool isSignal, ncclGinSignal_t signalId, ncclGinSignalOp_t signalOp, uint64_t signalOpArg, ncclCoopAny coop,
+  bool isDescriptor, ncclGinDescriptorSmem* descriptor, cuda::thread_scope givenRelease,
+  cuda::thread_scope requiredRelease, uint32_t optFlags);
 
-NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE uint64_t* ncclGinGetSignalShadowPtr(
-  ncclGin_C* net,
-  ncclGinSignal_t signal);
+NCCL_IR_EXTERN_C NCCL_DEVICE_INLINE uint64_t* ncclGinGetSignalShadowPtr(ncclGin_C* net, ncclGinSignal_t signal);
 
-template<unsigned backendMask>
+template <unsigned backendMask>
 struct ncclGin_BackendMask {
   ncclDevComm const& comm;
   uint32_t nConnections:8, connectionId:8, _ginBackend:8;
@@ -199,23 +164,18 @@ struct ncclGin_BackendMask {
                                      Coop coop = ncclCoopThread{}, uint32_t optFlags = ncclGinOptFlagsDefault) const;
 
   template <typename Coop = ncclCoopThread, typename DescriptorSmem = ncclGin_None>
-  NCCL_DEVICE_INLINE void wait(ncclGinRequest_t& outRequest,
-                               Coop coop = ncclCoopThread{}, DescriptorSmem descriptor = ncclGin_None{},
+  NCCL_DEVICE_INLINE void wait(ncclGinRequest_t& outRequest, Coop coop = ncclCoopThread{},
+                               DescriptorSmem descriptor = ncclGin_None{},
                                cuda::memory_order ord = cuda::memory_order_acquire) const;
 
-  template<typename Coop = ncclCoopThread,
-           typename DescriptorSmem = ncclGin_None,
-           typename SegmentType = ncclGin_SegmentDevice>
-  NCCL_DEVICE_INLINE void get(
-    ncclTeam, int peer,
-    ncclWindow_t remoteWnd, size_t remoteOffset,
-    ncclWindow_t localWnd, size_t localOffset,
-    size_t bytes, Coop coop = ncclCoopThread{},
-    DescriptorSmem descriptor = ncclGin_None{},
-    uint32_t optFlags = ncclGinOptFlagsDefault,
-    SegmentType bufType = ncclGin_SegmentDevice{}) const;
+  template <typename Coop = ncclCoopThread, typename DescriptorSmem = ncclGin_None,
+            typename SegmentType = ncclGin_SegmentDevice>
+  NCCL_DEVICE_INLINE void get(ncclTeam, int peer, ncclWindow_t remoteWnd, size_t remoteOffset, ncclWindow_t localWnd,
+                              size_t localOffset, size_t bytes, Coop coop = ncclCoopThread{},
+                              DescriptorSmem descriptor = ncclGin_None{}, uint32_t optFlags = ncclGinOptFlagsDefault,
+                              SegmentType bufType = ncclGin_SegmentDevice{}) const;
 
-  template<
+  template <
     // Action to take on peer when put completes. If a signalling action is used
     // then that signal will be visible only after the payload of this put as well as
     // the payloads of preceding puts on this netContext to the same peer are settled.
@@ -228,23 +188,15 @@ struct ncclGin_BackendMask {
     typename DescriptorSmem = ncclGin_None,
     // Use ncclGin_SegmentMixed or ncclGin_SegmentHostNuma when the VA contains
     // CPU-backed (HOST_NUMA) segments
-    typename SegmentType = ncclGin_SegmentDevice
-  >
+    typename SegmentType = ncclGin_SegmentDevice>
   NCCL_DEVICE_INLINE void put(
-    ncclTeam, int peer,
-    ncclWindow_t dstWnd, size_t dstOffset,
-    ncclWindow_t srcWnd, size_t srcOffset, size_t bytes,
-    RemoteAction remoteAction = ncclGin_None{},
-    LocalAction localAction = ncclGin_None{},
-    Coop coop = ncclCoopThread{},
-    DescriptorSmem descriptor = ncclGin_None{},
-    cuda::thread_scope givenRelease = cuda::thread_scope_thread,
-    cuda::thread_scope requiredRelease = cuda::thread_scope_device,
-    uint32_t optFlags = ncclGinOptFlagsDefault,
-    SegmentType bufType = ncclGin_SegmentDevice{}
-  ) const;
+    ncclTeam, int peer, ncclWindow_t dstWnd, size_t dstOffset, ncclWindow_t srcWnd, size_t srcOffset, size_t bytes,
+    RemoteAction remoteAction = ncclGin_None{}, LocalAction localAction = ncclGin_None{}, Coop coop = ncclCoopThread{},
+    DescriptorSmem descriptor = ncclGin_None{}, cuda::thread_scope givenRelease = cuda::thread_scope_thread,
+    cuda::thread_scope requiredRelease = cuda::thread_scope_device, uint32_t optFlags = ncclGinOptFlagsDefault,
+    SegmentType bufType = ncclGin_SegmentDevice{}) const;
 
-  template<
+  template <
     typename T,
     // Action to take on peer when put completes. If a signalling action is used
     // then that signal will be visible only after the payload of this put as well as
@@ -257,72 +209,47 @@ struct ncclGin_BackendMask {
     // Optional smem descriptor space to use. Either ncclGin_{None|DescriptorSmem}
     typename DescriptorSmem = ncclGin_None,
     // One of ncclGin_{SegmentDevice|SegmentMixed|SegmentHostNuma}; use a non-Device tag when the VA contains CPU-backed (HOST_NUMA) segments
-    typename SegmentType = ncclGin_SegmentDevice
-  >
-  NCCL_DEVICE_INLINE void put(
-    ncclTeam, int peer,
-    ncclSymPtr<T> dstElts, ncclSymPtr<T> srcElts, size_t nElts,
-    RemoteAction remoteAction = ncclGin_None{},
-    LocalAction localAction = ncclGin_None{},
-    Coop coop = ncclCoopThread{},
-    DescriptorSmem descriptor = ncclGin_None{},
-    cuda::thread_scope givenRelease = cuda::thread_scope_thread,
-    cuda::thread_scope requiredRelease = cuda::thread_scope_device,
-    uint32_t optFlags = ncclGinOptFlagsDefault,
-    SegmentType bufType = ncclGin_SegmentDevice{}
-  ) const;
+    typename SegmentType = ncclGin_SegmentDevice>
+  NCCL_DEVICE_INLINE void put(ncclTeam, int peer, ncclSymPtr<T> dstElts, ncclSymPtr<T> srcElts, size_t nElts,
+                              RemoteAction remoteAction = ncclGin_None{}, LocalAction localAction = ncclGin_None{},
+                              Coop coop = ncclCoopThread{}, DescriptorSmem descriptor = ncclGin_None{},
+                              cuda::thread_scope givenRelease = cuda::thread_scope_thread,
+                              cuda::thread_scope requiredRelease = cuda::thread_scope_device,
+                              uint32_t optFlags = ncclGinOptFlagsDefault,
+                              SegmentType bufType = ncclGin_SegmentDevice{}) const;
 
-  template<
-    typename T, // requires sizeof(T) <= 8
-    // See put() for all template arguments.
-    typename RemoteAction = ncclGin_None,
-    typename Coop = ncclCoopThread,
-    typename DescriptorSmem = ncclGin_None
-  >
-  NCCL_DEVICE_INLINE void putValue(
-    ncclTeam, int peer,
-    ncclWindow_t dstWnd, size_t dstOffset, T value,
-    RemoteAction remoteAction = ncclGin_None{},
-    Coop coop = ncclCoopThread{},
-    DescriptorSmem descriptor = ncclGin_None{},
-    cuda::thread_scope givenRelease = cuda::thread_scope_thread,
-    cuda::thread_scope requiredRelease = cuda::thread_scope_device,
-    uint32_t optFlags = ncclGinOptFlagsDefault
-  ) const;
+  template <typename T, // requires sizeof(T) <= 8
+            // See put() for all template arguments.
+            typename RemoteAction = ncclGin_None, typename Coop = ncclCoopThread,
+            typename DescriptorSmem = ncclGin_None>
+  NCCL_DEVICE_INLINE void putValue(ncclTeam, int peer, ncclWindow_t dstWnd, size_t dstOffset, T value,
+                                   RemoteAction remoteAction = ncclGin_None{}, Coop coop = ncclCoopThread{},
+                                   DescriptorSmem descriptor = ncclGin_None{},
+                                   cuda::thread_scope givenRelease = cuda::thread_scope_thread,
+                                   cuda::thread_scope requiredRelease = cuda::thread_scope_device,
+                                   uint32_t optFlags = ncclGinOptFlagsDefault) const;
 
-  template<
-    typename T, // requires sizeof(T) <= 8
-    // See put() for all template arguments.
-    typename RemoteAction = ncclGin_None,
-    typename Coop = ncclCoopThread,
-    typename DescriptorSmem = ncclGin_None
-  >
-  NCCL_DEVICE_INLINE void putValue(
-    ncclTeam, int peer,
-    ncclSymPtr<T> dst, T value,
-    RemoteAction remoteAction = ncclGin_None{},
-    Coop coop = ncclCoopThread{},
-    DescriptorSmem descriptor = ncclGin_None{},
-    cuda::thread_scope givenRelease = cuda::thread_scope_thread,
-    cuda::thread_scope requiredRelease = cuda::thread_scope_device,
-    uint32_t optFlags = ncclGinOptFlagsDefault
-  ) const;
+  template <typename T, // requires sizeof(T) <= 8
+            // See put() for all template arguments.
+            typename RemoteAction = ncclGin_None, typename Coop = ncclCoopThread,
+            typename DescriptorSmem = ncclGin_None>
+  NCCL_DEVICE_INLINE void putValue(ncclTeam, int peer, ncclSymPtr<T> dst, T value,
+                                   RemoteAction remoteAction = ncclGin_None{}, Coop coop = ncclCoopThread{},
+                                   DescriptorSmem descriptor = ncclGin_None{},
+                                   cuda::thread_scope givenRelease = cuda::thread_scope_thread,
+                                   cuda::thread_scope requiredRelease = cuda::thread_scope_device,
+                                   uint32_t optFlags = ncclGinOptFlagsDefault) const;
 
-  template<typename RemoteAction,
-           typename Coop = ncclCoopThread,
-           typename DescriptorSmem = ncclGin_None>
-  NCCL_DEVICE_INLINE void signal(
-    ncclTeam, int peer, RemoteAction remoteAction,
-    Coop coop = ncclCoopThread(),
-    DescriptorSmem descriptor = ncclGin_None{},
-    cuda::thread_scope givenRelease = cuda::thread_scope_thread,
-    cuda::thread_scope requiredRelease = cuda::thread_scope_device,
-    uint32_t optFlags = ncclGinOptFlagsDefault
-  ) const;
+  template <typename RemoteAction, typename Coop = ncclCoopThread, typename DescriptorSmem = ncclGin_None>
+  NCCL_DEVICE_INLINE void signal(ncclTeam, int peer, RemoteAction remoteAction, Coop coop = ncclCoopThread(),
+                                 DescriptorSmem descriptor = ncclGin_None{},
+                                 cuda::thread_scope givenRelease = cuda::thread_scope_thread,
+                                 cuda::thread_scope requiredRelease = cuda::thread_scope_device,
+                                 uint32_t optFlags = ncclGinOptFlagsDefault) const;
 
   // All source buffers from put's from any thread in this coop will be safe to reuse.
   // Flush does not guarantee that data has settled in remote memory.
-  template<typename Coop>
+  template <typename Coop>
   NCCL_DEVICE_INLINE void flush(Coop, cuda::memory_order ord = cuda::memory_order_acquire) const;
 
   // Counter and signal wait use "rolling" comparison logic of a given bit-width
@@ -339,10 +266,12 @@ struct ncclGin_BackendMask {
   // Counters are restricted to using a maximum of 56 bits despite that being fewer
   // than a uint64_t can carry.
 
-  NCCL_DEVICE_INLINE uint64_t readCounter(ncclGinCounter_t counter, int bits=56, cuda::memory_order ord = cuda::memory_order_acquire) const;
+  NCCL_DEVICE_INLINE uint64_t readCounter(ncclGinCounter_t counter, int bits = 56,
+                                          cuda::memory_order ord = cuda::memory_order_acquire) const;
 
-  template<typename Coop>
-  NCCL_DEVICE_INLINE void waitCounter(Coop, ncclGinCounter_t counter, uint64_t least, int bits=56, cuda::memory_order ord = cuda::memory_order_acquire) const;
+  template <typename Coop>
+  NCCL_DEVICE_INLINE void waitCounter(Coop, ncclGinCounter_t counter, uint64_t least, int bits = 56,
+                                      cuda::memory_order ord = cuda::memory_order_acquire) const;
 
   // Each signal has a dedicated "shadow" which the user is free to manipulate for
   // any reason. The only calls which manipulate the shadow are `increaseSignalShadow`
@@ -351,28 +280,35 @@ struct ncclGin_BackendMask {
   NCCL_DEVICE_INLINE void increaseSignalShadow(ncclGinSignal_t signal, uint64_t delta) const;
 
   // Returns current value of signal with all but bottom bits set to zero.
-  NCCL_DEVICE_INLINE uint64_t readSignal(ncclGinSignal_t signal, int bits=64, cuda::memory_order ord = cuda::memory_order_acquire) const;
+  NCCL_DEVICE_INLINE uint64_t readSignal(ncclGinSignal_t signal, int bits = 64,
+                                         cuda::memory_order ord = cuda::memory_order_acquire) const;
 
   // Returns current value of VA signal at given window and offset with all but bottom bits set to zero.
-  NCCL_DEVICE_INLINE uint64_t readSignal(ncclWindow_t signalWindow, size_t signalOffset, int bits=64, cuda::memory_order ord = cuda::memory_order_acquire) const;
+  NCCL_DEVICE_INLINE uint64_t readSignal(ncclWindow_t signalWindow, size_t signalOffset, int bits = 64,
+                                         cuda::memory_order ord = cuda::memory_order_acquire) const;
 
   // Wait for signal to meet or exceed value.
-  template<typename Coop>
-  NCCL_DEVICE_INLINE void waitSignal(Coop, ncclGinSignal_t signal, uint64_t least, int bits=64, cuda::memory_order ord = cuda::memory_order_acquire) const;
+  template <typename Coop>
+  NCCL_DEVICE_INLINE void waitSignal(Coop, ncclGinSignal_t signal, uint64_t least, int bits = 64,
+                                     cuda::memory_order ord = cuda::memory_order_acquire) const;
 
   // Wait for VA signal at given window and offset to meet or exceed value.
-  template<typename Coop>
-  NCCL_DEVICE_INLINE void waitSignal(Coop, ncclWindow_t signalWindow, size_t signalOffset, uint64_t least, int bits=64, cuda::memory_order ord = cuda::memory_order_acquire) const;
+  template <typename Coop>
+  NCCL_DEVICE_INLINE void waitSignal(Coop, ncclWindow_t signalWindow, size_t signalOffset, uint64_t least,
+                                     int bits = 64, cuda::memory_order ord = cuda::memory_order_acquire) const;
 
   // Wait for signal to meet or exceed shadow value.
-  template<typename Coop>
-  NCCL_DEVICE_INLINE void waitSignalMeetShadow(Coop, ncclGinSignal_t signal, int bits=64, cuda::memory_order ord = cuda::memory_order_acquire) const;
+  template <typename Coop>
+  NCCL_DEVICE_INLINE void waitSignalMeetShadow(Coop, ncclGinSignal_t signal, int bits = 64,
+                                               cuda::memory_order ord = cuda::memory_order_acquire) const;
 
   // Wait until signal exceeds shadow by `leastDelta` (typically 1), updates shadow
   // with latest value, and returns with `before` equal to previous shadow value
   // and `delta` equal to difference.
-  template<typename Coop, typename Uint>
-  NCCL_DEVICE_INLINE void waitSignalFollowShadow(Coop, ncclGinSignal_t signal, Uint leastDelta, Uint* before, Uint* delta, int bits=64, cuda::memory_order ord = cuda::memory_order_acquire) const;
+  template <typename Coop, typename Uint>
+  NCCL_DEVICE_INLINE void waitSignalFollowShadow(Coop, ncclGinSignal_t signal, Uint leastDelta, Uint* before,
+                                                 Uint* delta, int bits = 64,
+                                                 cuda::memory_order ord = cuda::memory_order_acquire) const;
 
   // Sets to zero. May not race with concurrent modifications to counter.
   NCCL_DEVICE_INLINE void resetCounter(ncclGinCounter_t counter) const;

--- a/projects/rccl/src/include/nccl_device/gin/gdaki/gin_gdaki.h
+++ b/projects/rccl/src/include/nccl_device/gin/gdaki/gin_gdaki.h
@@ -41,21 +41,18 @@ namespace gin {
 namespace gdaki {
 
 NCCL_DEVICE_INLINE uint32_t docaOptFlagsFromGinOptFlags(uint32_t ginOptFlags) {
-  return DOCA_GPUNETIO_VERBS_GPU_CODE_OPT_DEFAULT
-    | (!!(ginOptFlags & ncclGinOptFlagsMaySkipCreditCheck) * DOCA_GPUNETIO_VERBS_GPU_CODE_OPT_SKIP_AVAILABILITY_CHECK)
-    | (!!(ginOptFlags & ncclGinOptFlagsAggregateRequests) * DOCA_GPUNETIO_VERBS_GPU_CODE_OPT_SKIP_DB_RINGING);
+  return DOCA_GPUNETIO_VERBS_GPU_CODE_OPT_DEFAULT |
+         (!!(ginOptFlags & ncclGinOptFlagsMaySkipCreditCheck) *
+          DOCA_GPUNETIO_VERBS_GPU_CODE_OPT_SKIP_AVAILABILITY_CHECK) |
+         (!!(ginOptFlags & ncclGinOptFlagsAggregateRequests) * DOCA_GPUNETIO_VERBS_GPU_CODE_OPT_SKIP_DB_RINGING);
 }
 
 template <enum doca_gpu_dev_verbs_resource_sharing_mode resource_sharing_mode, typename Coop>
-NCCL_DEVICE_INLINE static void putImplMode(ncclGinCtx ctx, Coop coop, int peer, bool hasWins,
-                                              ncclGinWindow_t dstWin, size_t dstOff, ncclGinWindow_t srcWin,
-                                              size_t srcOff, size_t bytes, bool hasSignal,
-                                              size_t signalOffset, __be32 signalKey, ncclGinSignalOp_t signalOp,
-                                              uint64_t signalOpArg, bool hasCounter,
-                                              ncclGinCounter_t counterId, bool hasDescriptor,
-                                              ncclGinDescriptorSmem* descriptor,
-                                              cuda::thread_scope required, cuda::thread_scope given,
-                                              uint32_t optFlags) {
+NCCL_DEVICE_INLINE static void putImplMode(
+  ncclGinCtx ctx, Coop coop, int peer, bool hasWins, ncclGinWindow_t dstWin, size_t dstOff, ncclGinWindow_t srcWin,
+  size_t srcOff, size_t bytes, bool hasSignal, size_t signalOffset, __be32 signalKey, ncclGinSignalOp_t signalOp,
+  uint64_t signalOpArg, bool hasCounter, ncclGinCounter_t counterId, bool hasDescriptor,
+  ncclGinDescriptorSmem* descriptor, cuda::thread_scope required, cuda::thread_scope given, uint32_t optFlags) {
   using nccl::utility::loadConst;
   coop.sync();
   if (coop.thread_rank() == 0) {
@@ -100,14 +97,14 @@ NCCL_DEVICE_INLINE static void putImplMode(ncclGinCtx ctx, Coop coop, int peer, 
     if (hasWins) {
       if (hasSignal && hasCounter) {
         doca_gpu_dev_verbs_put_signal_counter<DOCA_GPUNETIO_VERBS_SIGNAL_OP_ADD, resource_sharing_mode>(
-          qp, raddr, laddr, bytes, sig_raddr, sig_laddr, signalOpArg, companion_qp, counter_raddr,
-          counter_laddr, 1, codeOpt);
+          qp, raddr, laddr, bytes, sig_raddr, sig_laddr, signalOpArg, companion_qp, counter_raddr, counter_laddr, 1,
+          codeOpt);
       } else if (hasSignal) {
         doca_gpu_dev_verbs_put_signal<DOCA_GPUNETIO_VERBS_SIGNAL_OP_ADD, resource_sharing_mode>(
           qp, raddr, laddr, bytes, sig_raddr, sig_laddr, signalOpArg, codeOpt);
       } else if (hasCounter) {
-        doca_gpu_dev_verbs_put_counter<resource_sharing_mode>(
-          qp, raddr, laddr, bytes, companion_qp, counter_raddr, counter_laddr, 1, codeOpt);
+        doca_gpu_dev_verbs_put_counter<resource_sharing_mode>(qp, raddr, laddr, bytes, companion_qp, counter_raddr,
+                                                              counter_laddr, 1, codeOpt);
       } else {
         doca_gpu_dev_verbs_put<resource_sharing_mode>(qp, raddr, laddr, bytes, codeOpt);
       }
@@ -116,8 +113,8 @@ NCCL_DEVICE_INLINE static void putImplMode(ncclGinCtx ctx, Coop coop, int peer, 
         doca_gpu_dev_verbs_signal_counter<DOCA_GPUNETIO_VERBS_SIGNAL_OP_ADD, resource_sharing_mode>(
           qp, sig_raddr, sig_laddr, signalOpArg, companion_qp, counter_raddr, counter_laddr, 1, codeOpt);
       } else {
-        doca_gpu_dev_verbs_signal<DOCA_GPUNETIO_VERBS_SIGNAL_OP_ADD, resource_sharing_mode>(
-          qp, sig_raddr, sig_laddr, signalOpArg, codeOpt);
+        doca_gpu_dev_verbs_signal<DOCA_GPUNETIO_VERBS_SIGNAL_OP_ADD, resource_sharing_mode>(qp, sig_raddr, sig_laddr,
+                                                                                            signalOpArg, codeOpt);
       }
     }
 
@@ -130,41 +127,32 @@ NCCL_DEVICE_INLINE static void putImplMode(ncclGinCtx ctx, Coop coop, int peer, 
 }
 
 template <typename Coop>
-NCCL_DEVICE_INLINE static void putImpl(ncclGinCtx ctx, Coop coop, int peer, bool hasWins,
-                                              ncclGinWindow_t dstWin, size_t dstOff, ncclGinWindow_t srcWin,
-                                              size_t srcOff, size_t bytes, bool hasSignal,
-                                              size_t signalOffset, __be32 signalKey, ncclGinSignalOp_t signalOp,
-                                              uint64_t signalOpArg, bool hasCounter,
-                                              ncclGinCounter_t counterId, bool hasDescriptor,
-                                              ncclGinDescriptorSmem* descriptor,
-                                              cuda::thread_scope required, cuda::thread_scope given,
-                                              uint32_t optFlags) {
+NCCL_DEVICE_INLINE static void putImpl(
+  ncclGinCtx ctx, Coop coop, int peer, bool hasWins, ncclGinWindow_t dstWin, size_t dstOff, ncclGinWindow_t srcWin,
+  size_t srcOff, size_t bytes, bool hasSignal, size_t signalOffset, __be32 signalKey, ncclGinSignalOp_t signalOp,
+  uint64_t signalOpArg, bool hasCounter, ncclGinCounter_t counterId, bool hasDescriptor,
+  ncclGinDescriptorSmem* descriptor, cuda::thread_scope required, cuda::thread_scope given, uint32_t optFlags) {
   switch ((ncclGinResourceSharingMode)ctx.resourceSharingMode) {
-    case NCCL_GIN_RESOURCE_SHARING_CTA:
-      putImplMode<DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_CTA>(
-        ctx, coop, peer, hasWins, dstWin, dstOff, srcWin, srcOff, bytes,
-        hasSignal, signalOffset, signalKey, signalOp, signalOpArg,
-        hasCounter, counterId, hasDescriptor, descriptor,
-        required, given, optFlags);
-      break;
-    default:
-      putImplMode<DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
-        ctx, coop, peer, hasWins, dstWin, dstOff, srcWin, srcOff, bytes,
-        hasSignal, signalOffset, signalKey, signalOp, signalOpArg,
-        hasCounter, counterId, hasDescriptor, descriptor,
-        required, given, optFlags);
-      break;
+  case NCCL_GIN_RESOURCE_SHARING_CTA:
+    putImplMode<DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_CTA>(ctx, coop, peer, hasWins, dstWin, dstOff, srcWin, srcOff,
+                                                               bytes, hasSignal, signalOffset, signalKey, signalOp,
+                                                               signalOpArg, hasCounter, counterId, hasDescriptor,
+                                                               descriptor, required, given, optFlags);
+    break;
+  default:
+    putImplMode<DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(ctx, coop, peer, hasWins, dstWin, dstOff, srcWin, srcOff,
+                                                               bytes, hasSignal, signalOffset, signalKey, signalOp,
+                                                               signalOpArg, hasCounter, counterId, hasDescriptor,
+                                                               descriptor, required, given, optFlags);
+    break;
   }
 }
 
 template <enum doca_gpu_dev_verbs_resource_sharing_mode resource_sharing_mode, typename Coop, typename T>
-NCCL_DEVICE_INLINE static void putValueImplMode(ncclGinCtx ctx, Coop coop, int peer, ncclGinWindow_t dstWin,
-                                      size_t dstOff, T srcData, bool hasSignal,
-                                      size_t signalOffset, __be32 signalKey, ncclGinSignalOp_t signalOp,
-                                      uint64_t signalOpArg, bool hasDescriptor,
-                                      ncclGinDescriptorSmem* descriptor,
-                                      cuda::thread_scope required, cuda::thread_scope given,
-                                      uint32_t optFlags) {
+NCCL_DEVICE_INLINE static void putValueImplMode(
+  ncclGinCtx ctx, Coop coop, int peer, ncclGinWindow_t dstWin, size_t dstOff, T srcData, bool hasSignal,
+  size_t signalOffset, __be32 signalKey, ncclGinSignalOp_t signalOp, uint64_t signalOpArg, bool hasDescriptor,
+  ncclGinDescriptorSmem* descriptor, cuda::thread_scope required, cuda::thread_scope given, uint32_t optFlags) {
   using nccl::utility::loadConst;
 
   coop.sync();
@@ -208,26 +196,24 @@ NCCL_DEVICE_INLINE static void putValueImplMode(ncclGinCtx ctx, Coop coop, int p
 }
 
 template <typename Coop, typename T>
-NCCL_DEVICE_INLINE static void putValueImpl(ncclGinCtx ctx, Coop coop, int peer, ncclGinWindow_t dstWin,
-                                      size_t dstOff, T srcData, bool hasSignal,
-                                      size_t signalOffset, __be32 signalKey, ncclGinSignalOp_t signalOp,
-                                      uint64_t signalOpArg, bool hasDescriptor,
-                                      ncclGinDescriptorSmem* descriptor,
-                                      cuda::thread_scope required, cuda::thread_scope given,
-                                      uint32_t optFlags) {
+NCCL_DEVICE_INLINE static void putValueImpl(ncclGinCtx ctx, Coop coop, int peer, ncclGinWindow_t dstWin, size_t dstOff,
+                                            T srcData, bool hasSignal, size_t signalOffset, __be32 signalKey,
+                                            ncclGinSignalOp_t signalOp, uint64_t signalOpArg, bool hasDescriptor,
+                                            ncclGinDescriptorSmem* descriptor, cuda::thread_scope required,
+                                            cuda::thread_scope given, uint32_t optFlags) {
   switch ((ncclGinResourceSharingMode)ctx.resourceSharingMode) {
-    case NCCL_GIN_RESOURCE_SHARING_CTA:
-      putValueImplMode<DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_CTA>(
-        ctx, coop, peer, dstWin, dstOff, srcData,
-        hasSignal, signalOffset, signalKey, signalOp, signalOpArg,
-        hasDescriptor, descriptor, required, given, optFlags);
-      break;
-    default:
-      putValueImplMode<DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
-        ctx, coop, peer, dstWin, dstOff, srcData,
-        hasSignal, signalOffset, signalKey, signalOp, signalOpArg,
-        hasDescriptor, descriptor, required, given, optFlags);
-      break;
+  case NCCL_GIN_RESOURCE_SHARING_CTA:
+    putValueImplMode<DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_CTA>(ctx, coop, peer, dstWin, dstOff, srcData, hasSignal,
+                                                                    signalOffset, signalKey, signalOp, signalOpArg,
+                                                                    hasDescriptor, descriptor, required, given,
+                                                                    optFlags);
+    break;
+  default:
+    putValueImplMode<DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(ctx, coop, peer, dstWin, dstOff, srcData, hasSignal,
+                                                                    signalOffset, signalKey, signalOp, signalOpArg,
+                                                                    hasDescriptor, descriptor, required, given,
+                                                                    optFlags);
+    break;
   }
 }
 
@@ -239,9 +225,8 @@ template <>
 struct ncclGinApi_Get<NCCL_NET_DEVICE_GIN_GDAKI> {
   template <typename Coop>
   NCCL_DEVICE_INLINE static void call(ncclGinCtx ctx, Coop coop, int peer, ncclGinWindow_t remoteWin, size_t remoteOff,
-                                      ncclGinWindow_t localWin, size_t localOff, size_t bytes,
-                                      bool hasDescriptor, ncclGinDescriptorSmem* descriptor,
-                                      uint32_t optFlags = ncclGinOptFlagsDefault) {
+                                      ncclGinWindow_t localWin, size_t localOff, size_t bytes, bool hasDescriptor,
+                                      ncclGinDescriptorSmem* descriptor, uint32_t optFlags = ncclGinOptFlagsDefault) {
     using nccl::utility::loadConst;
     coop.sync();
     if (coop.thread_rank() == 0) {
@@ -257,8 +242,7 @@ struct ncclGinApi_Get<NCCL_NET_DEVICE_GIN_GDAKI> {
       doca_gpu_dev_verbs_addr uninitialized_daddr{};
       doca_gpu_dev_verbs_ticket_t unused_out_ticket;
       uint32_t codeOpt = nccl::gin::gdaki::docaOptFlagsFromGinOptFlags(optFlags);
-      doca_gpu_dev_verbs_get(
-          qp, raddr, laddr, bytes, uninitialized_daddr, &unused_out_ticket, codeOpt);
+      doca_gpu_dev_verbs_get(qp, raddr, laddr, bytes, uninitialized_daddr, &unused_out_ticket, codeOpt);
     }
     coop.sync();
   }
@@ -275,10 +259,8 @@ struct ncclGinApi_FlushAsync<NCCL_NET_DEVICE_GIN_GDAKI> {
     doca_gpu_dev_verbs_addr daddr;
     daddr.addr = 0;
     daddr.key = loadConst(&gdaki->sink_buffer_lkey);
-    doca_gpu_dev_verbs_mcst<
-        DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU,
-        DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(
-        qp, daddr, &req->docaTicket);
+    doca_gpu_dev_verbs_mcst<DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU, DOCA_GPUNETIO_VERBS_NIC_HANDLER_AUTO>(
+      qp, daddr, &req->docaTicket);
   }
 };
 
@@ -307,15 +289,12 @@ struct ncclGinApi_Wait<NCCL_NET_DEVICE_GIN_GDAKI> {
 template <>
 struct ncclGinApi_Put<NCCL_NET_DEVICE_GIN_GDAKI> {
   template <typename Coop>
-  NCCL_DEVICE_INLINE static void call(ncclGinCtx ctx, Coop coop, int peer, bool hasWins,
-                                      ncclGinWindow_t dstWin, size_t dstOff, ncclGinWindow_t srcWin,
-                                      size_t srcOff, size_t bytes,
-                                      ncclGinSignalDescriptor signal, ncclGinSignalOp_t signalOp,
-                                      uint64_t signalOpArg, bool hasCounter,
-                                      ncclGinCounter_t counterId, bool hasDescriptor,
-                                      ncclGinDescriptorSmem* descriptor,
-                                      cuda::thread_scope required, cuda::thread_scope given,
-                                      uint32_t optFlags = ncclGinOptFlagsDefault) {
+  NCCL_DEVICE_INLINE static void call(ncclGinCtx ctx, Coop coop, int peer, bool hasWins, ncclGinWindow_t dstWin,
+                                      size_t dstOff, ncclGinWindow_t srcWin, size_t srcOff, size_t bytes,
+                                      ncclGinSignalDescriptor signal, ncclGinSignalOp_t signalOp, uint64_t signalOpArg,
+                                      bool hasCounter, ncclGinCounter_t counterId, bool hasDescriptor,
+                                      ncclGinDescriptorSmem* descriptor, cuda::thread_scope required,
+                                      cuda::thread_scope given, uint32_t optFlags = ncclGinOptFlagsDefault) {
     using nccl::utility::loadConst;
     size_t signalOffset = 0;
     __be32 signalKey = 0;
@@ -329,23 +308,18 @@ struct ncclGinApi_Put<NCCL_NET_DEVICE_GIN_GDAKI> {
       signalKey = loadConst(loadConst(&signalMh->rkeys) + peer);
       signalOffset = signal.vaSignal.signalOffset;
     }
-    nccl::gin::gdaki::putImpl(
-      ctx, coop, peer, hasWins, dstWin, dstOff, srcWin, srcOff, bytes,
-      hasSignal, signalOffset, signalKey, signalOp, signalOpArg,
-      hasCounter, counterId, hasDescriptor, descriptor,
-      required, given, optFlags
-    );
+    nccl::gin::gdaki::putImpl(ctx, coop, peer, hasWins, dstWin, dstOff, srcWin, srcOff, bytes, hasSignal, signalOffset,
+                              signalKey, signalOp, signalOpArg, hasCounter, counterId, hasDescriptor, descriptor,
+                              required, given, optFlags);
   }
 };
 
 template <>
 struct ncclGinApi_PutValue<NCCL_NET_DEVICE_GIN_GDAKI> {
   template <typename Coop, typename T>
-  NCCL_DEVICE_INLINE static void call(ncclGinCtx ctx, Coop coop, int peer, ncclGinWindow_t dstWin,
-                                      size_t dstOff, T srcVal,
-                                      ncclGinSignalDescriptor signal, ncclGinSignalOp_t signalOp,
-                                      uint64_t signalOpArg, bool hasDescriptor,
-                                      ncclGinDescriptorSmem* descriptor,
+  NCCL_DEVICE_INLINE static void call(ncclGinCtx ctx, Coop coop, int peer, ncclGinWindow_t dstWin, size_t dstOff,
+                                      T srcVal, ncclGinSignalDescriptor signal, ncclGinSignalOp_t signalOp,
+                                      uint64_t signalOpArg, bool hasDescriptor, ncclGinDescriptorSmem* descriptor,
                                       cuda::thread_scope required, cuda::thread_scope given,
                                       uint32_t optFlags = ncclGinOptFlagsDefault) {
     using nccl::utility::loadConst;
@@ -361,11 +335,8 @@ struct ncclGinApi_PutValue<NCCL_NET_DEVICE_GIN_GDAKI> {
       signalOffset = sizeof(uint64_t) * (signal.indexedSignal.signalId + loadConst(&gdaki->signals_table.offset));
       signalKey = loadConst(loadConst(&gdaki->signals_table.rkeys) + peer);
     }
-    nccl::gin::gdaki::putValueImpl(
-      ctx, coop, peer, dstWin, dstOff, srcVal,
-      hasSignal, signalOffset, signalKey, signalOp, signalOpArg,
-      hasDescriptor, descriptor, required, given, optFlags
-    );
+    nccl::gin::gdaki::putValueImpl(ctx, coop, peer, dstWin, dstOff, srcVal, hasSignal, signalOffset, signalKey,
+                                   signalOp, signalOpArg, hasDescriptor, descriptor, required, given, optFlags);
   }
 };
 
@@ -423,19 +394,19 @@ struct ncclGinApi_Flush<NCCL_NET_DEVICE_GIN_GDAKI> {
 
     if (abortFlag) {
       uint32_t steps = 0;
-      #pragma unroll 1
+#pragma unroll 1
       for (int peer = coop.thread_rank(); peer < ctx.nRanks; peer += coop.size()) {
         int status = EBUSY;
-        uint64_t ticket = doca_gpu_dev_verbs_atomic_read<uint64_t, DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(&qps[peer].sq_rsvd_index);
-        if (ticket == 0)
-          return;
+        uint64_t ticket = doca_gpu_dev_verbs_atomic_read<uint64_t, DOCA_GPUNETIO_VERBS_RESOURCE_SHARING_MODE_GPU>(
+          &qps[peer].sq_rsvd_index);
+        if (ticket == 0) return;
         --ticket;
         while (status != 0 && !testAbort(abortFlag, steps)) {
           status = doca_gpu_dev_verbs_poll_one_cq_at(&qps[peer].cq_sq, ticket);
         }
       }
     } else {
-      #pragma unroll 1
+#pragma unroll 1
       for (int peer = coop.thread_rank(); peer < ctx.nRanks; peer += coop.size()) {
         doca_gpu_dev_verbs_wait(qps + peer);
       }

--- a/projects/rccl/src/include/nccl_device/gin/gdaki/gin_gdaki_device_host_common.h
+++ b/projects/rccl/src/include/nccl_device/gin/gdaki/gin_gdaki_device_host_common.h
@@ -15,15 +15,15 @@
 
 template <typename T>
 struct ncclGinGdakiGlobalGPUBufferTable {
-  T *buffer;
-  __be32 *rkeys;
+  T* buffer;
+  __be32* rkeys;
   __be32 lkey;
   unsigned int offset;
 };
 
 struct ncclGinGdakiGPUContext {
-  struct doca_gpu_dev_verbs_qp *gdqp;
-  struct doca_gpu_dev_verbs_qp *companion_gdqp;
+  struct doca_gpu_dev_verbs_qp* gdqp;
+  struct doca_gpu_dev_verbs_qp* companion_gdqp;
   struct ncclGinGdakiGlobalGPUBufferTable<uint64_t> counters_table;
   struct ncclGinGdakiGlobalGPUBufferTable<uint64_t> signals_table;
 
@@ -32,7 +32,7 @@ struct ncclGinGdakiGPUContext {
 };
 
 struct ncclGinGdakiMemHandle {
-  __be32 *rkeys;
+  __be32* rkeys;
   __be32 lkey;
 };
 

--- a/projects/rccl/src/include/nccl_device/gin/gin_device_common.h
+++ b/projects/rccl/src/include/nccl_device/gin/gin_device_common.h
@@ -37,7 +37,7 @@ enum ncclGinOptFlags {
   ncclGinOptFlagsAggregateRequests = (1 << 1),
 };
 
-#define NCCL_GIN_BACKEND_MASK_ALL                                               \
+#define NCCL_GIN_BACKEND_MASK_ALL \
   (((NCCL_GIN_PROXY_ENABLE) ? 1u : 0u) << (unsigned)NCCL_NET_DEVICE_GIN_PROXY | \
    ((NCCL_GIN_GDAKI_ENABLE) ? 1u : 0u) << (unsigned)NCCL_NET_DEVICE_GIN_GDAKI)
 
@@ -105,33 +105,27 @@ template <ncclNetDeviceType backend>
 struct ncclGinApi_Get {
   template <typename Coop>
   NCCL_DEVICE_INLINE static void call(ncclGinCtx, Coop coop, int peer, ncclGinWindow_t remoteWin, size_t remoteOff,
-                                      ncclGinWindow_t localWin, size_t localOff, size_t bytes,
-                                      bool hasDescriptor, ncclGinDescriptorSmem* descriptor,
-                                      uint32_t optFlags = ncclGinOptFlagsDefault);
+                                      ncclGinWindow_t localWin, size_t localOff, size_t bytes, bool hasDescriptor,
+                                      ncclGinDescriptorSmem* descriptor, uint32_t optFlags = ncclGinOptFlagsDefault);
 };
 
 template <ncclNetDeviceType backend>
 struct ncclGinApi_Put {
   template <typename Coop>
-  NCCL_DEVICE_INLINE static void call(ncclGinCtx, Coop coop, int peer, bool hasWins,
-                                      ncclGinWindow_t dstWin, size_t dstOff, ncclGinWindow_t srcWin,
-                                      size_t srcOff, size_t bytes,
-                                      ncclGinSignalDescriptor signal, ncclGinSignalOp_t signalOp,
-                                      uint64_t signalOpArg, bool hasCounter,
-                                      ncclGinCounter_t counterId, bool hasDescriptor,
-                                      ncclGinDescriptorSmem* descriptor,
-                                      cuda::thread_scope required, cuda::thread_scope given,
-                                      uint32_t optFlags = ncclGinOptFlagsDefault);
+  NCCL_DEVICE_INLINE static void call(ncclGinCtx, Coop coop, int peer, bool hasWins, ncclGinWindow_t dstWin,
+                                      size_t dstOff, ncclGinWindow_t srcWin, size_t srcOff, size_t bytes,
+                                      ncclGinSignalDescriptor signal, ncclGinSignalOp_t signalOp, uint64_t signalOpArg,
+                                      bool hasCounter, ncclGinCounter_t counterId, bool hasDescriptor,
+                                      ncclGinDescriptorSmem* descriptor, cuda::thread_scope required,
+                                      cuda::thread_scope given, uint32_t optFlags = ncclGinOptFlagsDefault);
 };
 
 template <ncclNetDeviceType backend>
 struct ncclGinApi_PutValue {
   template <typename Coop, typename T>
-  NCCL_DEVICE_INLINE static void call(ncclGinCtx, Coop coop, int peer, ncclGinWindow_t dstWin,
-                                      size_t dstOff, T srcData,
-                                      ncclGinSignalDescriptor signal, ncclGinSignalOp_t signalOp,
-                                      uint64_t signalOpArg, bool hasDescriptor,
-                                      ncclGinDescriptorSmem* descriptor,
+  NCCL_DEVICE_INLINE static void call(ncclGinCtx, Coop coop, int peer, ncclGinWindow_t dstWin, size_t dstOff, T srcData,
+                                      ncclGinSignalDescriptor signal, ncclGinSignalOp_t signalOp, uint64_t signalOpArg,
+                                      bool hasDescriptor, ncclGinDescriptorSmem* descriptor,
                                       cuda::thread_scope required, cuda::thread_scope given,
                                       uint32_t optFlags = ncclGinOptFlagsDefault);
 };
@@ -169,17 +163,17 @@ NCCL_DEVICE_INLINE static decltype(auto) ncclGinCallImpl(unsigned beMask, ncclGi
   bool singleton = (beMask & (beMask - 1)) == 0;  // Only one bit set
   switch (singleton ? __popc(beMask - 1) : (int)ctx.backend) {
 #if NCCL_GIN_PROXY_ENABLE
-    case (int)NCCL_NET_DEVICE_GIN_PROXY:
-      if (!(1 & (beMask >> (int)NCCL_NET_DEVICE_GIN_PROXY))) __builtin_unreachable();
-      return ApiFn<NCCL_NET_DEVICE_GIN_PROXY>::call(ctx, static_cast<Arg&&>(arg)...);
+  case (int)NCCL_NET_DEVICE_GIN_PROXY:
+    if (!(1 & (beMask >> (int)NCCL_NET_DEVICE_GIN_PROXY))) __builtin_unreachable();
+    return ApiFn<NCCL_NET_DEVICE_GIN_PROXY>::call(ctx, static_cast<Arg&&>(arg)...);
 #endif
 #if NCCL_GIN_GDAKI_ENABLE
-    case (int)NCCL_NET_DEVICE_GIN_GDAKI:
-      if (!(1 & (beMask >> (int)NCCL_NET_DEVICE_GIN_GDAKI))) __builtin_unreachable();
-      return ApiFn<NCCL_NET_DEVICE_GIN_GDAKI>::call(ctx, static_cast<Arg&&>(arg)...);
+  case (int)NCCL_NET_DEVICE_GIN_GDAKI:
+    if (!(1 & (beMask >> (int)NCCL_NET_DEVICE_GIN_GDAKI))) __builtin_unreachable();
+    return ApiFn<NCCL_NET_DEVICE_GIN_GDAKI>::call(ctx, static_cast<Arg&&>(arg)...);
 #endif
-    default:
-      __builtin_unreachable();
+  default:
+    __builtin_unreachable();
   }
 }
 

--- a/projects/rccl/src/include/nccl_device/gin/gin_device_host_common.h
+++ b/projects/rccl/src/include/nccl_device/gin/gin_device_host_common.h
@@ -17,8 +17,8 @@
 // Keep both names so AMD-side code that still uses the old name continues to compile.
 #define NCCL_GIN_MAX_CONNECTIONS NCCL_GIN_MAX_CONTEXTS
 
-typedef struct ncclGinGpuCtx *ncclGinGpuCtx_t;
-typedef void *ncclGinWindow_t;
+typedef struct ncclGinGpuCtx* ncclGinGpuCtx_t;
+typedef void* ncclGinWindow_t;
 
 typedef enum ncclGinSignalOp_t {
   ncclGinSignalInc = 0,

--- a/projects/rccl/src/include/nccl_device/gin/proxy/gin_proxy.h
+++ b/projects/rccl/src/include/nccl_device/gin/proxy/gin_proxy.h
@@ -8,11 +8,12 @@
 #ifndef _NCCL_DEVICE_GIN_PROXY_H_
 #define _NCCL_DEVICE_GIN_PROXY_H_
 
-//#include <config.h>
+// #include <config.h>
 
 #include <cstdint>
 #include <cuda_runtime.h>
-#if defined(RCCL_DEVICE_LINKER) // Without this, we get a duplicate symbol error when building with the --no-device-linker flag on ROCm 7.13.
+#if defined( \
+  RCCL_DEVICE_LINKER) // Without this, we get a duplicate symbol error when building with the --no-device-linker flag on ROCm 7.13.
 #include <cooperative_groups.h>
 #endif
 #if defined(__HIP_PLATFORM_AMD__)
@@ -36,9 +37,10 @@ namespace gin {
 namespace proxy {
 
 // Chunk size for Gin Proxy GFD operations
-static constexpr size_t DataChunkSize = 1ULL << 30;  // 1 GB
+static constexpr size_t DataChunkSize = 1ULL << 30; // 1 GB
 
-NCCL_DEVICE_INLINE void waitForGfdComplete(ncclGinProxyGpuCtx_t* proxyCtx, uint32_t pe, uint32_t nextGfdIdx, cuda::memory_order ord, uint32_t* abortFlag) {
+NCCL_DEVICE_INLINE void waitForGfdComplete(ncclGinProxyGpuCtx_t* proxyCtx, uint32_t pe, uint32_t nextGfdIdx,
+                                           cuda::memory_order ord, uint32_t* abortFlag) {
   using nccl::utility::loadConst;
   using nccl::utility::rollingLessEq;
   using nccl::utility::testAbort;
@@ -50,7 +52,8 @@ NCCL_DEVICE_INLINE void waitForGfdComplete(ncclGinProxyGpuCtx_t* proxyCtx, uint3
   while (!rollingLessEq<uint32_t>(nextGfdIdx, ci.load(ord)) && !testAbort(abortFlag, steps)) continue;
 }
 
-NCCL_DEVICE_INLINE void flush(ncclGinProxyGpuCtx_t* proxyCtx, uint32_t pe, cuda::memory_order ord, uint32_t* abortFlag) {
+NCCL_DEVICE_INLINE void flush(ncclGinProxyGpuCtx_t* proxyCtx, uint32_t pe, cuda::memory_order ord,
+                              uint32_t* abortFlag) {
   using nccl::utility::loadConst;
   cuda::atomic_ref<uint32_t, cuda::thread_scope_system> pi(loadConst(&proxyCtx->pis)[pe]);
   cuda::atomic_ref<uint32_t, cuda::thread_scope_system> ci(loadConst(&proxyCtx->cis)[pe]);
@@ -59,8 +62,8 @@ NCCL_DEVICE_INLINE void flush(ncclGinProxyGpuCtx_t* proxyCtx, uint32_t pe, cuda:
 }
 
 template <typename Coop>
-NCCL_DEVICE_INLINE void postGfd(Coop coop, ncclGinProxyGpuCtx_t* proxyCtx, ncclGinProxyGfd_t* gfd,
-                                uint32_t pe, uint32_t* gfdIdx = nullptr) {
+NCCL_DEVICE_INLINE void postGfd(Coop coop, ncclGinProxyGpuCtx_t* proxyCtx, ncclGinProxyGfd_t* gfd, uint32_t pe,
+                                uint32_t* gfdIdx = nullptr) {
   using nccl::utility::loadConst;
   cuda::atomic_ref<uint32_t, cuda::thread_scope_system> pi(loadConst(&proxyCtx->pis)[pe]);
   cuda::atomic_ref<uint32_t, cuda::thread_scope_system> ci(loadConst(&proxyCtx->cis)[pe]);
@@ -82,17 +85,19 @@ NCCL_DEVICE_INLINE void postGfd(Coop coop, ncclGinProxyGpuCtx_t* proxyCtx, ncclG
 #pragma unroll
     for (uint8_t i = 0; i < sizeof(ncclGinProxyGfd_t) / sizeof(uint4); i++) {
 #if defined(__HIP_PLATFORM_AMD__)
-  #if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
-      union { v4u vec; uint4 u; } pkt;
+#if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
+      union {
+        v4u vec;
+        uint4 u;
+      } pkt;
       pkt.u = ((uint4*)gfd)[i];
-      __builtin_amdgcn_global_store_b128((v4u_gptr)((uint4*)&q[idx] + i), pkt.vec,
-                                         RCCL_SYSTEM_SYNCSCOPE);
-  #else
+      __builtin_amdgcn_global_store_b128((v4u_gptr)((uint4*)&q[idx] + i), pkt.vec, RCCL_SYSTEM_SYNCSCOPE);
+#else
       uint64_t* p64 = reinterpret_cast<uint64_t*>((uint4*)&q[idx] + i);
       const uint64_t* g64 = reinterpret_cast<const uint64_t*>((uint4*)gfd + i);
       __builtin_nontemporal_store(g64[0], (u64_gptr)(p64 + 0));
       __builtin_nontemporal_store(g64[1], (u64_gptr)(p64 + 1));
-  #endif
+#endif
 #else
       __stwt((uint4*)&q[idx] + i, ((uint4*)gfd)[i]);
 #endif
@@ -103,13 +108,11 @@ NCCL_DEVICE_INLINE void postGfd(Coop coop, ncclGinProxyGpuCtx_t* proxyCtx, ncclG
 template <typename T>
 // Descriptor must be at least GWQ_GFD_SIZE bytes and it should be aligned
 // Assumes little-endian, which is okay.
-__device__ __forceinline__ void buildGfd(ncclGinProxyGfd_t* gfd, ncclGinProxyOp_t op, T srcVal,
-                                         bool hasInline, size_t srcOff, ncclGinWindow_t srcHandle,
-                                         size_t dstOff, ncclGinWindow_t dstHandle, size_t size,
-                                         ncclGinCounter_t counterId, ncclGinSignal_t signalId,
-                                         uint64_t signalVal, ncclGinWindow_t signalWindow,
+__device__ __forceinline__ void buildGfd(ncclGinProxyGfd_t* gfd, ncclGinProxyOp_t op, T srcVal, bool hasInline,
+                                         size_t srcOff, ncclGinWindow_t srcHandle, size_t dstOff,
+                                         ncclGinWindow_t dstHandle, size_t size, ncclGinCounter_t counterId,
+                                         ncclGinSignal_t signalId, uint64_t signalVal, ncclGinWindow_t signalWindow,
                                          size_t signalOff) {
-
   for (int i = 0; i < ncclGinProxyGfdQwords; i++) {
     gfd->qword[i].flag.v = 1;
   }
@@ -126,10 +129,8 @@ __device__ __forceinline__ void buildGfd(ncclGinProxyGfd_t* gfd, ncclGinProxyOp_
     uint64_t srcValBits = 0;
     memcpy(&srcValBits, &srcVal, sizeof(T));
     gfd->qword[ncclGinProxyGfdInlineLow].inlineLow.inlineValLow = (uint32_t)srcValBits;
-    if (sizeof(T) > 4)
-      gfd->qword[ncclGinProxyGfdInlineLow].inlineLow.inlineValLow2 = (uint64_t)srcValBits >> 32;
-    if (sizeof(T) > 6)
-      gfd->qword[ncclGinProxyGfdInlineHigh].inlineHigh.inlineValHigh = (uint64_t)srcValBits >> 48;
+    if (sizeof(T) > 4) gfd->qword[ncclGinProxyGfdInlineLow].inlineLow.inlineValLow2 = (uint64_t)srcValBits >> 32;
+    if (sizeof(T) > 6) gfd->qword[ncclGinProxyGfdInlineHigh].inlineHigh.inlineValHigh = (uint64_t)srcValBits >> 48;
   } else if (op & ncclGinProxyOpVASignal) {
     gfd->qword[ncclGinProxyGfdVASignalOff].vaSignalOff.vaSignalOff = (uint64_t)signalOff;
     gfd->qword[ncclGinProxyGfdVASignalHandle].vaSignalHandle.vaSignalHandle = (uint64_t)signalWindow;
@@ -166,14 +167,16 @@ __device__ __forceinline__ void constructProxyOp(ncclGinProxyOp_t& op, bool isGe
 
   if (signalType != NCCL_GIN_SIGNAL_TYPE_NONE) {
     switch (signalOp) {
-      case ncclGinSignalInc:
-        op = static_cast<ncclGinProxyOp_t>(static_cast<uint16_t>(op) | static_cast<uint16_t>(ncclGinProxyOpWithSignalInc));
-        break;
-      case ncclGinSignalAdd:
-        op = static_cast<ncclGinProxyOp_t>(static_cast<uint16_t>(op) | static_cast<uint16_t>(ncclGinProxyOpWithSignalAdd));
-        break;
-      default:
-        __builtin_unreachable();
+    case ncclGinSignalInc:
+      op =
+        static_cast<ncclGinProxyOp_t>(static_cast<uint16_t>(op) | static_cast<uint16_t>(ncclGinProxyOpWithSignalInc));
+      break;
+    case ncclGinSignalAdd:
+      op =
+        static_cast<ncclGinProxyOp_t>(static_cast<uint16_t>(op) | static_cast<uint16_t>(ncclGinProxyOpWithSignalAdd));
+      break;
+    default:
+      __builtin_unreachable();
     }
   }
   if (signalType == NCCL_GIN_SIGNAL_TYPE_VA) {
@@ -182,26 +185,24 @@ __device__ __forceinline__ void constructProxyOp(ncclGinProxyOp_t& op, bool isGe
   }
   op = static_cast<ncclGinProxyOp_t>(static_cast<uint16_t>(op) | static_cast<uint16_t>(ncclGinProxyOpPut));
   if (hasInline)
-    op = static_cast<ncclGinProxyOp_t>(static_cast<uint16_t>(op) |
-                                       static_cast<uint16_t>(ncclGinProxyOpWithInline));
+    op = static_cast<ncclGinProxyOp_t>(static_cast<uint16_t>(op) | static_cast<uint16_t>(ncclGinProxyOpWithInline));
   if (hasCounter)
-    op = static_cast<ncclGinProxyOp_t>(static_cast<uint16_t>(op) |
-                                       static_cast<uint16_t>(ncclGinProxyOpWithCounter));
+    op = static_cast<ncclGinProxyOp_t>(static_cast<uint16_t>(op) | static_cast<uint16_t>(ncclGinProxyOpWithCounter));
 }
 
 template <typename Coop>
-NCCL_DEVICE_INLINE void get(Coop coop, ncclGinProxyGpuCtx_t* proxyCtx,
-                            int peer, ncclGinWindow_t remoteWnd, size_t remoteOff,
-                            ncclGinWindow_t localWnd, size_t localOff, size_t bytes,
+NCCL_DEVICE_INLINE void get(Coop coop, ncclGinProxyGpuCtx_t* proxyCtx, int peer, ncclGinWindow_t remoteWnd,
+                            size_t remoteOff, ncclGinWindow_t localWnd, size_t localOff, size_t bytes,
                             ncclGinProxyGfd_t* desc) {
   using nccl::gin::proxy::DataChunkSize;
   while (bytes > 0) {
     size_t sendSize = min(bytes, DataChunkSize);
     ncclGinProxyOp_t op;
-    constructProxyOp(op, /*isGet*/true, /*isFlush*/false, /*hasInline*/false, NCCL_GIN_SIGNAL_TYPE_NONE, ncclGinSignalInc, /*hasCounter*/false);
-    nccl::gin::proxy::buildGfd(desc, op, /*srcVal*/0, /*hasInline*/false, remoteOff, remoteWnd,
-                               localOff, localWnd, sendSize, /*counterId*/0, /*signalId*/0,
-                               /*signalVal*/0, nullptr, 0);
+    constructProxyOp(op, /*isGet*/ true, /*isFlush*/ false, /*hasInline*/ false, NCCL_GIN_SIGNAL_TYPE_NONE,
+                     ncclGinSignalInc, /*hasCounter*/ false);
+    nccl::gin::proxy::buildGfd(desc, op, /*srcVal*/ 0, /*hasInline*/ false, remoteOff, remoteWnd, localOff, localWnd,
+                               sendSize, /*counterId*/ 0, /*signalId*/ 0,
+                               /*signalVal*/ 0, nullptr, 0);
     nccl::gin::proxy::postGfd<Coop>(coop, proxyCtx, desc, peer);
     bytes -= sendSize;
     remoteOff += sendSize;
@@ -210,10 +211,9 @@ NCCL_DEVICE_INLINE void get(Coop coop, ncclGinProxyGpuCtx_t* proxyCtx,
 }
 
 template <typename Coop, typename T>
-NCCL_DEVICE_INLINE void put(Coop coop, ncclGinProxyGfd_t* gfd, ncclGinProxyGpuCtx_t* proxyCtx,
-                            int peer, ncclGinWindow_t dstWnd, size_t dstOff, T srcVal,
-                            bool hasInline, ncclGinWindow_t srcWnd, size_t srcOff, size_t bytes,
-                            ncclGinSignalDescriptor signal, ncclGinSignalOp_t signalOp,
+NCCL_DEVICE_INLINE void put(Coop coop, ncclGinProxyGfd_t* gfd, ncclGinProxyGpuCtx_t* proxyCtx, int peer,
+                            ncclGinWindow_t dstWnd, size_t dstOff, T srcVal, bool hasInline, ncclGinWindow_t srcWnd,
+                            size_t srcOff, size_t bytes, ncclGinSignalDescriptor signal, ncclGinSignalOp_t signalOp,
                             uint64_t signalVal, bool hasCounter, ncclGinCounter_t counterId,
                             cuda::thread_scope required, cuda::thread_scope given) {
   // Release the source to system scope before the GFD is published, since the NIC
@@ -230,10 +230,11 @@ NCCL_DEVICE_INLINE void put(Coop coop, ncclGinProxyGfd_t* gfd, ncclGinProxyGpuCt
   using nccl::gin::proxy::DataChunkSize;
   while (bytes > DataChunkSize) {
     ncclGinProxyOp_t op;
-    constructProxyOp(op, /*isGet*/false, /*isFlush*/false, /*hasInline*/false, NCCL_GIN_SIGNAL_TYPE_NONE, signalOp, /*hasCounter*/false);
-    nccl::gin::proxy::buildGfd(gfd, op, /*srcVal*/0, /*hasInline*/false, srcOff, srcWnd,
-                               dstOff, dstWnd, DataChunkSize, /*counterId*/0, /*signalId*/0,
-                               /*signalVal*/0, nullptr, 0);
+    constructProxyOp(op, /*isGet*/ false, /*isFlush*/ false, /*hasInline*/ false, NCCL_GIN_SIGNAL_TYPE_NONE, signalOp,
+                     /*hasCounter*/ false);
+    nccl::gin::proxy::buildGfd(gfd, op, /*srcVal*/ 0, /*hasInline*/ false, srcOff, srcWnd, dstOff, dstWnd,
+                               DataChunkSize, /*counterId*/ 0, /*signalId*/ 0,
+                               /*signalVal*/ 0, nullptr, 0);
     nccl::gin::proxy::postGfd<Coop>(coop, proxyCtx, gfd, peer);
     bytes -= DataChunkSize;
     srcOff += DataChunkSize;
@@ -244,56 +245,56 @@ NCCL_DEVICE_INLINE void put(Coop coop, ncclGinProxyGfd_t* gfd, ncclGinProxyGpuCt
   uint64_t putSignalVal;
   ncclGinSignal_t putSignalId;
   switch (signal.type) {
-    case NCCL_GIN_SIGNAL_TYPE_INDEXED:
-      putSignalType = NCCL_GIN_SIGNAL_TYPE_INDEXED;
-      putSignalVal = signalVal;
-      putSignalId = signal.indexedSignal.signalId;
-      break;
-    case NCCL_GIN_SIGNAL_TYPE_VA: // VA signals must be in a separate GFD. Use no signal during first put.
-    case NCCL_GIN_SIGNAL_TYPE_NONE:
-      putSignalType = NCCL_GIN_SIGNAL_TYPE_NONE;
-      putSignalVal = 0;
-      putSignalId = 0;
-      break;
-    default:
-      __builtin_unreachable();
+  case NCCL_GIN_SIGNAL_TYPE_INDEXED:
+    putSignalType = NCCL_GIN_SIGNAL_TYPE_INDEXED;
+    putSignalVal = signalVal;
+    putSignalId = signal.indexedSignal.signalId;
+    break;
+  case NCCL_GIN_SIGNAL_TYPE_VA: // VA signals must be in a separate GFD. Use no signal during first put.
+  case NCCL_GIN_SIGNAL_TYPE_NONE:
+    putSignalType = NCCL_GIN_SIGNAL_TYPE_NONE;
+    putSignalVal = 0;
+    putSignalId = 0;
+    break;
+  default:
+    __builtin_unreachable();
   }
   if (hasInline || hasCounter || srcWnd != nullptr || putSignalType != NCCL_GIN_SIGNAL_TYPE_NONE) {
     ncclGinProxyOp_t op;
-    constructProxyOp(op, /*isGet*/false, /*isFlush*/false, hasInline, putSignalType, signalOp, hasCounter);
+    constructProxyOp(op, /*isGet*/ false, /*isFlush*/ false, hasInline, putSignalType, signalOp, hasCounter);
     nccl::gin::proxy::buildGfd(gfd, op, srcVal, hasInline, srcOff, srcWnd, dstOff, dstWnd, bytes,
-                              hasCounter ? counterId : 0, putSignalId, putSignalVal, nullptr, 0);
+                               hasCounter ? counterId : 0, putSignalId, putSignalVal, nullptr, 0);
     nccl::gin::proxy::postGfd<Coop>(coop, proxyCtx, gfd, peer);
   }
 
   // Handle additional GFD for VA signals.
   if (signal.type == NCCL_GIN_SIGNAL_TYPE_VA) {
     ncclGinProxyOp_t op;
-    constructProxyOp(op, /*isGet*/false, /*isFlush*/false, /*hasInline*/false, NCCL_GIN_SIGNAL_TYPE_VA, signalOp, /*hasCounter*/false);
-    nccl::gin::proxy::buildGfd(gfd, op, /*srcVal*/0, /*hasInline*/false, 0, nullptr,
-                               0, nullptr, 0, 0, 0, signalVal, signal.vaSignal.signalWindow, signal.vaSignal.signalOffset);
+    constructProxyOp(op, /*isGet*/ false, /*isFlush*/ false, /*hasInline*/ false, NCCL_GIN_SIGNAL_TYPE_VA, signalOp,
+                     /*hasCounter*/ false);
+    nccl::gin::proxy::buildGfd(gfd, op, /*srcVal*/ 0, /*hasInline*/ false, 0, nullptr, 0, nullptr, 0, 0, 0, signalVal,
+                               signal.vaSignal.signalWindow, signal.vaSignal.signalOffset);
     nccl::gin::proxy::postGfd<Coop>(coop, proxyCtx, gfd, peer);
   }
 }
-}  // namespace proxy
-}  // namespace gin
-}  // namespace nccl
+} // namespace proxy
+} // namespace gin
+} // namespace nccl
 
 template <>
 struct ncclGinApi_Get<NCCL_NET_DEVICE_GIN_PROXY> {
   template <typename Coop>
   NCCL_DEVICE_INLINE static void call(ncclGinCtx ctx, Coop coop, int peer, ncclGinWindow_t remoteWin, size_t remoteOff,
-                                      ncclGinWindow_t localWin, size_t localOff, size_t bytes,
-                                      bool hasDescriptor, ncclGinDescriptorSmem* descriptor,
-                                      uint32_t optFlags) {
+                                      ncclGinWindow_t localWin, size_t localOff, size_t bytes, bool hasDescriptor,
+                                      ncclGinDescriptorSmem* descriptor, uint32_t optFlags) {
     ncclGinProxyGfd_t tmpDesc;
     ncclGinProxyGfd_t* desc = hasDescriptor ? (ncclGinProxyGfd_t*)descriptor : &tmpDesc;
     ncclGinProxyGpuCtx_t* proxyCtx = &((ncclGinProxyGpuCtx_t*)ctx.handle)[ctx.contextId];
-    nccl::gin::proxy::get<Coop>(coop, proxyCtx, peer, remoteWin, remoteOff, localWin, localOff, bytes,desc);
+    nccl::gin::proxy::get<Coop>(coop, proxyCtx, peer, remoteWin, remoteOff, localWin, localOff, bytes, desc);
   }
 };
 
-template<>
+template <>
 struct ncclGinApi_FlushAsync<NCCL_NET_DEVICE_GIN_PROXY> {
   NCCL_DEVICE_INLINE static void call(ncclGinCtx ctx, int peer, ncclGinRequest_t* outRequest, uint32_t optFlags) {
     using nccl::utility::loadConst;
@@ -317,9 +318,10 @@ struct ncclGinApi_Wait<NCCL_NET_DEVICE_GIN_PROXY> {
     ncclGinProxyGfd_t* desc = hasDescriptor ? (ncclGinProxyGfd_t*)descriptor : &tmpGfd;
     ncclGinProxyOp_t op;
     uint32_t flushGfdIdx;
-    nccl::gin::proxy::constructProxyOp(op, /*isGet*/false, /*isFlush*/true, /*hasInline*/false, NCCL_GIN_SIGNAL_TYPE_NONE, ncclGinSignalInc, /*hasCounter*/false);
-    nccl::gin::proxy::buildGfd(desc, op, /*srcVal*/0, /*hasInline*/false, 0, nullptr,
-                               0, nullptr, 0, 0, 0, 0, nullptr, 0);
+    nccl::gin::proxy::constructProxyOp(op, /*isGet*/ false, /*isFlush*/ true, /*hasInline*/ false,
+                                       NCCL_GIN_SIGNAL_TYPE_NONE, ncclGinSignalInc, /*hasCounter*/ false);
+    nccl::gin::proxy::buildGfd(desc, op, /*srcVal*/ 0, /*hasInline*/ false, 0, nullptr, 0, nullptr, 0, 0, 0, 0, nullptr,
+                               0);
     nccl::gin::proxy::postGfd(ncclCoopThread(), proxyCtx, desc, ctx.rank, &flushGfdIdx);
     nccl::gin::proxy::waitForGfdComplete(proxyCtx, ctx.rank, flushGfdIdx + 1, ord, abortFlag);
   }
@@ -381,40 +383,33 @@ struct ncclGinApi_Flush<NCCL_NET_DEVICE_GIN_PROXY> {
 template <>
 struct ncclGinApi_Put<NCCL_NET_DEVICE_GIN_PROXY> {
   template <typename Coop>
-  NCCL_DEVICE_INLINE static void call(ncclGinCtx ctx, Coop coop, int peer, bool hasWins,
-                                      ncclGinWindow_t dstWin, size_t dstOff, ncclGinWindow_t srcWin,
-                                      size_t srcOff, size_t bytes,
-                                      ncclGinSignalDescriptor signal, ncclGinSignalOp_t signalOp,
-                                      uint64_t signalOpArg, bool hasCounter,
-                                      ncclGinCounter_t counterId, bool hasDescriptor,
-                                      ncclGinDescriptorSmem* descriptor,
-                                      cuda::thread_scope required, cuda::thread_scope given,
-                                      uint32_t optFlags = ncclGinOptFlagsDefault) {
+  NCCL_DEVICE_INLINE static void call(ncclGinCtx ctx, Coop coop, int peer, bool hasWins, ncclGinWindow_t dstWin,
+                                      size_t dstOff, ncclGinWindow_t srcWin, size_t srcOff, size_t bytes,
+                                      ncclGinSignalDescriptor signal, ncclGinSignalOp_t signalOp, uint64_t signalOpArg,
+                                      bool hasCounter, ncclGinCounter_t counterId, bool hasDescriptor,
+                                      ncclGinDescriptorSmem* descriptor, cuda::thread_scope required,
+                                      cuda::thread_scope given, uint32_t optFlags = ncclGinOptFlagsDefault) {
     ncclGinProxyGfd_t tmpDesc;
     ncclGinProxyGfd_t* desc = hasDescriptor ? (ncclGinProxyGfd_t*)descriptor : &tmpDesc;
     ncclGinProxyGpuCtx_t* proxyCtx = &((ncclGinProxyGpuCtx_t*)ctx.handle)[ctx.contextId];
-    nccl::gin::proxy::put<Coop, uint64_t>(coop, desc, proxyCtx, peer, dstWin, dstOff, 0, false,
-                                          srcWin, srcOff, bytes, signal, signalOp, signalOpArg,
-                                          hasCounter, counterId, required, given);
+    nccl::gin::proxy::put<Coop, uint64_t>(coop, desc, proxyCtx, peer, dstWin, dstOff, 0, false, srcWin, srcOff, bytes,
+                                          signal, signalOp, signalOpArg, hasCounter, counterId, required, given);
   }
 };
 
 template <>
 struct ncclGinApi_PutValue<NCCL_NET_DEVICE_GIN_PROXY> {
   template <typename Coop, typename T>
-  NCCL_DEVICE_INLINE static void call(ncclGinCtx ctx, Coop coop, int peer, ncclGinWindow_t dstWin,
-                                      size_t dstOff, T srcVal,
-                                      ncclGinSignalDescriptor signal, ncclGinSignalOp_t signalOp,
-                                      uint64_t signalOpArg, bool hasDescriptor,
-                                      ncclGinDescriptorSmem* descriptor,
+  NCCL_DEVICE_INLINE static void call(ncclGinCtx ctx, Coop coop, int peer, ncclGinWindow_t dstWin, size_t dstOff,
+                                      T srcVal, ncclGinSignalDescriptor signal, ncclGinSignalOp_t signalOp,
+                                      uint64_t signalOpArg, bool hasDescriptor, ncclGinDescriptorSmem* descriptor,
                                       cuda::thread_scope required, cuda::thread_scope given,
                                       uint32_t optFlags = ncclGinOptFlagsDefault) {
     ncclGinProxyGfd_t tmpDesc;
     ncclGinProxyGfd_t* desc = hasDescriptor ? (ncclGinProxyGfd_t*)descriptor : &tmpDesc;
     ncclGinProxyGpuCtx_t* proxyCtx = &((ncclGinProxyGpuCtx_t*)ctx.handle)[ctx.contextId];
-    nccl::gin::proxy::put<Coop, T>(coop, desc, proxyCtx, peer, dstWin,
-                                   dstOff, srcVal, true, nullptr, 0, sizeof(T), signal,
-                                   signalOp, signalOpArg, false, 0, required, given);
+    nccl::gin::proxy::put<Coop, T>(coop, desc, proxyCtx, peer, dstWin, dstOff, srcVal, true, nullptr, 0, sizeof(T),
+                                   signal, signalOp, signalOpArg, false, 0, required, given);
   }
 };
 

--- a/projects/rccl/src/include/nccl_device/gin/proxy/gin_proxy_device_host_common.h
+++ b/projects/rccl/src/include/nccl_device/gin/proxy/gin_proxy_device_host_common.h
@@ -25,95 +25,93 @@ typedef enum {
   ncclGinProxyOpFlush = 1 << 7,
 } ncclGinProxyOp_t;
 
-static_assert(sizeof(void *) == sizeof(uint64_t) && sizeof(size_t) == sizeof(uint64_t),
+static_assert(sizeof(void*) == sizeof(uint64_t) && sizeof(size_t) == sizeof(uint64_t),
               "The proxy code is built on the assumption that the pointer size is 64 bits and at "
               "most 57 bits are used for the actual pointer.");
 
 typedef union {
   uint64_t raw;
   struct {
-    uint64_t v : 1;
-    uint64_t resv : 63;
+    uint64_t v:1;
+    uint64_t resv:63;
   } __attribute__((packed)) flag;
   struct {
-    uint64_t flag : 1;
-    uint64_t version : 4;
-    uint64_t resv : 2;
-    uint64_t size : 57;
+    uint64_t flag:1;
+    uint64_t version:4;
+    uint64_t resv:2;
+    uint64_t size:57;
   } __attribute__((packed)) header;
   struct {
     // the last bit is the flag, so we support 63 bit VAs
-    uint64_t flag : 1;
-    uint64_t srcOff : 63;
+    uint64_t flag:1;
+    uint64_t srcOff:63;
   } __attribute__((packed)) srcOff;
   struct {
     // the last bit is the flag, so we support 63 bit VAs
-    uint64_t flag : 1;
-    uint64_t srcHandle : 63;
+    uint64_t flag:1;
+    uint64_t srcHandle:63;
   } __attribute__((packed)) srcHandle;
   struct {
     // the last bit is the flag, so we support 63 bit VAs
-    uint64_t flag : 1;
-    uint64_t vaSignalOff : 63;
+    uint64_t flag:1;
+    uint64_t vaSignalOff:63;
   } __attribute__((packed)) vaSignalOff;
   struct {
     // the last bit is the flag, so we support 63 bit VAs
-    uint64_t flag : 1;
-    uint64_t vaSignalHandle : 63;
+    uint64_t flag:1;
+    uint64_t vaSignalHandle:63;
   } __attribute__((packed)) vaSignalHandle;
   struct {
-    uint8_t flag : 1;
-    uint8_t resv : 7;
+    uint8_t flag:1;
+    uint8_t resv:7;
     uint32_t inlineValLow;
     uint16_t inlineValLow2;
   } __attribute__((packed)) inlineLow;
   // inline supports a max of 96 bit / 12 byte values
   struct {
-    uint8_t flag : 1;
-    uint8_t resv : 7;
+    uint8_t flag:1;
+    uint8_t resv:7;
     uint16_t inlineValHigh;
     uint8_t resv1;
     uint32_t resv2;
   } __attribute__((packed)) inlineHigh;
   struct {
     // the last bit is the flag, so we support 63 bit VAs
-    uint64_t flag : 1;
-    uint64_t dstOff : 63;
+    uint64_t flag:1;
+    uint64_t dstOff:63;
   } __attribute__((packed)) dstOff;
   struct {
     // the last bit is the flag, so we support 63 bit VAs
-    uint64_t flag : 1;
-    uint64_t dstHandle : 63;
+    uint64_t flag:1;
+    uint64_t dstHandle:63;
   } __attribute__((packed)) dstHandle;
   struct {
-    uint8_t flag : 1;
+    uint8_t flag:1;
     // We need to keep the size of counterId and signalId in sync with the
     // NCCL_GIN_COUNTER_POOL_SIZE / NCCL_GIN_SIGNAL_POOL_SIZE upper limits
     // in gin_host.cc.
     // must be non-zero if WITH_COUNTER is set
-    uint32_t counterId : 23;
+    uint32_t counterId:23;
     // must be non-zero if WITH_SIGNAL_INC, WITH_SIGNAL_ADD, or WITH_SIGNAL_SET is set
-    uint32_t signalId : 24;
+    uint32_t signalId:24;
     uint16_t signalValLow;
   } __attribute__((packed)) completion;
   struct {
-    uint8_t flag : 1;
-    uint8_t resv : 7;
+    uint8_t flag:1;
+    uint8_t resv:7;
     uint16_t signalValLow2;
     uint32_t signalValHigh;
   } __attribute__((packed)) signalVal;
   struct {
-    uint8_t flag : 1;
-    uint8_t resv : 7;
+    uint8_t flag:1;
+    uint8_t resv:7;
     uint16_t op;
     uint8_t resv2;
     uint32_t resv3;
   } __attribute__((packed)) headerExt;
 } ncclGinProxyQword_t;
-static_assert(sizeof(ncclGinProxyQword_t) == sizeof(uint64_t),
-              "sizeof(ncclGinProxyQword_t) != sizeof(uint64_t)");
-static_assert(NCCL_GIN_PROXY_GFD_VERSION < (1 << 4),
-              "NCCL_GIN_PROXY_GFD_VERSION must be less than 2^4");
+static_assert(sizeof(ncclGinProxyQword_t) == sizeof(uint64_t), "sizeof(ncclGinProxyQword_t) != sizeof(uint64_t)");
+static_assert(NCCL_GIN_PROXY_GFD_VERSION < (1 << 4), "NCCL_GIN_PROXY_GFD_VERSION must be less than 2^4");
 
 typedef enum {
   ncclGinProxyGfdHeader = 0,
@@ -140,13 +138,13 @@ static_assert(sizeof(ncclGinProxyGfd_t) == 128,
 typedef struct {
   int nranks;
   uint32_t queueSize;
-  ncclGinProxyGfd_t *queues;
-  uint32_t *pis;
+  ncclGinProxyGfd_t* queues;
+  uint32_t* pis;
   // The consumer indices will reside in CPU or GPU memory depending on the availability of GDR
-  uint32_t *cis;
+  uint32_t* cis;
 
-  uint64_t *counters;
-  uint64_t *signals;
+  uint64_t* counters;
+  uint64_t* signals;
 } ncclGinProxyGpuCtx_t;
 
 #endif

--- a/projects/rccl/src/include/nccl_device/gin_barrier.h
+++ b/projects/rccl/src/include/nccl_device/gin_barrier.h
@@ -16,18 +16,19 @@
 
 struct ncclGinBarrierHandle;
 
-NCCL_EXTERN_C __host__ ncclResult_t ncclGinBarrierCreateRequirement(ncclComm_t, ncclTeam_t, int nBarriers, ncclGinBarrierHandle_t* outHandle, ncclDevResourceRequirements_t* outReq);
+NCCL_EXTERN_C __host__ ncclResult_t ncclGinBarrierCreateRequirement(
+  ncclComm_t, ncclTeam_t, int nBarriers, ncclGinBarrierHandle_t* outHandle, ncclDevResourceRequirements_t* outReq);
 
 #if NCCL_CHECK_CUDACC
 enum class ncclGinFenceLevel {
   Relaxed
 };
 
-template<typename Coop>
+template <typename Coop>
 struct ncclGinBarrierSession_internal;
 
-template<typename Coop>
-struct ncclGinBarrierSession: ncclGinBarrierSession_internal<Coop> {
+template <typename Coop>
+struct ncclGinBarrierSession : ncclGinBarrierSession_internal<Coop> {
   NCCL_DEVICE_INLINE ncclGinBarrierSession(Coop, ncclGin, ncclTeam, ncclGinBarrierHandle, uint32_t index);
   NCCL_DEVICE_INLINE ncclGinBarrierSession(Coop, ncclGin, ncclTeamTagRail, uint32_t index);
   NCCL_DEVICE_INLINE ncclGinBarrierSession(Coop, ncclGin, ncclTeamTagWorld, uint32_t index);

--- a/projects/rccl/src/include/nccl_device/gin_win_stub.h
+++ b/projects/rccl/src/include/nccl_device/gin_win_stub.h
@@ -21,7 +21,7 @@
 #define NCCL_GIN_BACKEND_MASK_ALL 0u
 
 #if NCCL_CHECK_CUDACC
-template<unsigned backendMask>
+template <unsigned backendMask>
 struct ncclGin_BackendMask {
   ncclDevComm const& comm;
   uint32_t nConnections:8, connectionId:8, _ginBackend:8;
@@ -30,8 +30,8 @@ struct ncclGin_BackendMask {
     : comm(c), nConnections(0), connectionId(0), _ginBackend(0), contextId(0) {}
 };
 
-template<ncclNetDeviceType backend>
-using ncclGin_BackendOne = ncclGin_BackendMask<(1u<<(int)backend)>;
+template <ncclNetDeviceType backend>
+using ncclGin_BackendOne = ncclGin_BackendMask<(1u << (int)backend)>;
 
 using ncclGin = ncclGin_BackendMask<NCCL_GIN_BACKEND_MASK_ALL>;
 #endif
@@ -53,12 +53,8 @@ struct ncclGinSyncHandle {
 };
 
 NCCL_EXTERN_C __host__ ncclResult_t ncclGinOutboxCreateRequirement(
-  int nBlocks, int size_log2,
-  ncclGinOutboxHandle* outHandle, ncclDevResourceRequirements* outReq
-);
+  int nBlocks, int size_log2, ncclGinOutboxHandle* outHandle, ncclDevResourceRequirements* outReq);
 NCCL_EXTERN_C __host__ ncclResult_t ncclGinInboxA2ACreateRequirement(
-  ncclTeam peers, int nBlocks, int size_log2,
-  ncclGinInboxA2AHandle* outHandle, ncclDevResourceRequirements* outReq
-);
+  ncclTeam peers, int nBlocks, int size_log2, ncclGinInboxA2AHandle* outHandle, ncclDevResourceRequirements* outReq);
 
 #endif /* _NCCL_DEVICE_GIN_SESSION_H_ */

--- a/projects/rccl/src/include/nccl_device/hip_compat.h
+++ b/projects/rccl/src/include/nccl_device/hip_compat.h
@@ -21,13 +21,13 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #if defined(__HIPCC__) || defined(__HIP_PLATFORM_AMD__)
-  #define NCCL_HIP_PLATFORM 1
-  #define NCCL_DEVICE_COMPILE 1
+#define NCCL_HIP_PLATFORM 1
+#define NCCL_DEVICE_COMPILE 1
 #elif defined(__CUDACC__)
-  #define NCCL_CUDA_PLATFORM 1
-  #define NCCL_DEVICE_COMPILE 1
+#define NCCL_CUDA_PLATFORM 1
+#define NCCL_DEVICE_COMPILE 1
 #else
-  #define NCCL_DEVICE_COMPILE 0
+#define NCCL_DEVICE_COMPILE 0
 #endif
 
 // Backward-compat aliases for the IR bitcode binding layer (PR #6435).
@@ -53,7 +53,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #if defined(__HIP_PLATFORM_AMD__) && (!defined(ROCM_VERSION) || ROCM_VERSION < 71200)
-  #define CU_MEM_LOCATION_TYPE_HOST_NUMA 3
+#define CU_MEM_LOCATION_TYPE_HOST_NUMA 3
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -61,17 +61,17 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #if NCCL_DEVICE_COMPILE
-  #define NCCL_DEVICE_INLINE __device__ __forceinline__
-  #define NCCL_HOST_DEVICE_INLINE __host__ __device__ __forceinline__
+#define NCCL_DEVICE_INLINE __device__ __forceinline__
+#define NCCL_HOST_DEVICE_INLINE __host__ __device__ __forceinline__
 #else
-  #ifndef __host__
-    #define __host__
-  #endif
-  #ifndef __device__
-    #define __device__
-  #endif
-  #define NCCL_DEVICE_INLINE
-  #define NCCL_HOST_DEVICE_INLINE inline __attribute__((always_inline))
+#ifndef __host__
+#define __host__
+#endif
+#ifndef __device__
+#define __device__
+#endif
+#define NCCL_DEVICE_INLINE
+#define NCCL_HOST_DEVICE_INLINE inline __attribute__((always_inline))
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -82,30 +82,30 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #if defined(__CUDA_ARCH__)
-  #define NCCL_DEVICE_ARCH __CUDA_ARCH__
+#define NCCL_DEVICE_ARCH __CUDA_ARCH__
 #elif defined(__HIP_DEVICE_COMPILE__) && __HIP_DEVICE_COMPILE__
   // Map HIP GFX versions to a comparable value
   // MI200 (gfx90a) and MI300 (gfx942) are roughly Hopper-class
-  #if defined(__gfx942__) || defined(__gfx950__)
-    #define NCCL_DEVICE_ARCH 942  // MI300 class
-  #elif defined(__gfx90a__)
-    #define NCCL_DEVICE_ARCH 90   // MI200 class
-  #elif defined(__gfx908__)
-    #define NCCL_DEVICE_ARCH 80   // MI100 class
-  #else
-    #define NCCL_DEVICE_ARCH 70   // Generic GCN
-  #endif
+#if defined(__gfx942__) || defined(__gfx950__)
+#define NCCL_DEVICE_ARCH 942  // MI300 class
+#elif defined(__gfx90a__)
+#define NCCL_DEVICE_ARCH 90   // MI200 class
+#elif defined(__gfx908__)
+#define NCCL_DEVICE_ARCH 80   // MI100 class
 #else
-  #define NCCL_DEVICE_ARCH 0
+#define NCCL_DEVICE_ARCH 70   // Generic GCN
+#endif
+#else
+#define NCCL_DEVICE_ARCH 0
 #endif
 
 #define NCCL_CHECK_CUDA_ARCH NCCL_DEVICE_ARCH
 
 // Hopper+ features (multimem, etc.) - NVIDIA only
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
-  #define NCCL_ARCH_HAS_MULTIMEM 1
+#define NCCL_ARCH_HAS_MULTIMEM 1
 #else
-  #define NCCL_ARCH_HAS_MULTIMEM 0
+#define NCCL_ARCH_HAS_MULTIMEM 0
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -114,14 +114,14 @@
 
 #if defined(NCCL_HIP_PLATFORM)
   // AMD GPUs use 64-wide waves (or 32 in wave32 mode)
-  #if defined(__GFX10__) || defined(__GFX11__) || defined(__gfx1100__) || \
-      defined(__gfx1101__) || defined(__gfx1102__) || defined(__gfx1200__) || defined(__gfx1201__)
-    #define NCCL_WARP_SIZE 32
-  #else
-    #define NCCL_WARP_SIZE 64
-  #endif
+#if defined(__GFX10__) || defined(__GFX11__) || defined(__gfx1100__) || defined(__gfx1101__) || \
+  defined(__gfx1102__) || defined(__gfx1200__) || defined(__gfx1201__)
+#define NCCL_WARP_SIZE 32
 #else
-  #define NCCL_WARP_SIZE 32
+#define NCCL_WARP_SIZE 64
+#endif
+#else
+#define NCCL_WARP_SIZE 32
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -147,20 +147,25 @@ enum memory_order {
 
 // Thread scope enumeration
 enum thread_scope {
-  thread_scope_thread   = 0,
-  thread_scope_block    = 1,
-  thread_scope_device   = 2,
-  thread_scope_system   = 3
+  thread_scope_thread = 0,
+  thread_scope_block = 1,
+  thread_scope_device = 2,
+  thread_scope_system = 3
 };
 
 // Map thread_scope to HIP memory scope
 NCCL_DEVICE_INLINE constexpr int toHipMemoryScope(thread_scope scope) {
   switch (scope) {
-    case thread_scope_thread: return __HIP_MEMORY_SCOPE_SINGLETHREAD;
-    case thread_scope_block:  return __HIP_MEMORY_SCOPE_WORKGROUP;
-    case thread_scope_device: return __HIP_MEMORY_SCOPE_AGENT;
-    case thread_scope_system: return __HIP_MEMORY_SCOPE_SYSTEM;
-    default:                  return __HIP_MEMORY_SCOPE_SYSTEM;
+  case thread_scope_thread:
+    return __HIP_MEMORY_SCOPE_SINGLETHREAD;
+  case thread_scope_block:
+    return __HIP_MEMORY_SCOPE_WORKGROUP;
+  case thread_scope_device:
+    return __HIP_MEMORY_SCOPE_AGENT;
+  case thread_scope_system:
+    return __HIP_MEMORY_SCOPE_SYSTEM;
+  default:
+    return __HIP_MEMORY_SCOPE_SYSTEM;
   }
 }
 
@@ -170,7 +175,7 @@ NCCL_DEVICE_INLINE constexpr int toHipMemoryScope(thread_scope scope) {
 // Provides cuda::atomic_ref-compatible interface using HIP atomics
 ////////////////////////////////////////////////////////////////////////////////
 
-template<typename T, thread_scope Scope = thread_scope_system>
+template <typename T, thread_scope Scope = thread_scope_system>
 struct atomic_ref {
   T* ptr;
 
@@ -178,12 +183,10 @@ struct atomic_ref {
 
   NCCL_DEVICE_INLINE void store(T val, memory_order order = memory_order_seq_cst) const {
     if constexpr (sizeof(T) == 4) {
-      __hip_atomic_store(reinterpret_cast<unsigned int*>(ptr),
-                         *reinterpret_cast<unsigned int*>(&val),
-                         order, toHipMemoryScope(Scope));
+      __hip_atomic_store(reinterpret_cast<unsigned int*>(ptr), *reinterpret_cast<unsigned int*>(&val), order,
+                         toHipMemoryScope(Scope));
     } else if constexpr (sizeof(T) == 8) {
-      __hip_atomic_store(reinterpret_cast<unsigned long long*>(ptr),
-                         *reinterpret_cast<unsigned long long*>(&val),
+      __hip_atomic_store(reinterpret_cast<unsigned long long*>(ptr), *reinterpret_cast<unsigned long long*>(&val),
                          order, toHipMemoryScope(Scope));
     } else {
       __atomic_store_n(ptr, val, order);
@@ -193,12 +196,11 @@ struct atomic_ref {
   NCCL_DEVICE_INLINE T load(memory_order order = memory_order_seq_cst) const {
     T result;
     if constexpr (sizeof(T) == 4) {
-      unsigned int tmp = __hip_atomic_load(reinterpret_cast<unsigned int*>(ptr),
-                                           order, toHipMemoryScope(Scope));
+      unsigned int tmp = __hip_atomic_load(reinterpret_cast<unsigned int*>(ptr), order, toHipMemoryScope(Scope));
       result = *reinterpret_cast<T*>(&tmp);
     } else if constexpr (sizeof(T) == 8) {
-      unsigned long long tmp = __hip_atomic_load(reinterpret_cast<unsigned long long*>(ptr),
-                                                  order, toHipMemoryScope(Scope));
+      unsigned long long tmp =
+        __hip_atomic_load(reinterpret_cast<unsigned long long*>(ptr), order, toHipMemoryScope(Scope));
       result = *reinterpret_cast<T*>(&tmp);
     } else {
       result = __atomic_load_n(ptr, order);
@@ -219,22 +221,42 @@ struct atomic_ref {
 
 // __builtin_amdgcn_fence requires compile-time constant arguments, so we
 // dispatch order x scope with a helper macro instead of a runtime switch.
-#define NCCL_HIP_FENCE_SCOPE(ORD, scope) do { \
+#define NCCL_HIP_FENCE_SCOPE(ORD, scope) \
+  do { \
     switch (scope) { \
-      case thread_scope_thread:  __atomic_signal_fence(ORD); break; \
-      case thread_scope_block:   __builtin_amdgcn_fence(ORD, "workgroup"); break; \
-      case thread_scope_device:  __builtin_amdgcn_fence(ORD, "agent"); break; \
-      case thread_scope_system: default: __builtin_amdgcn_fence(ORD, ""); break; \
+    case thread_scope_thread: \
+      __atomic_signal_fence(ORD); \
+      break; \
+    case thread_scope_block: \
+      __builtin_amdgcn_fence(ORD, "workgroup"); \
+      break; \
+    case thread_scope_device: \
+      __builtin_amdgcn_fence(ORD, "agent"); \
+      break; \
+    case thread_scope_system: \
+    default: \
+      __builtin_amdgcn_fence(ORD, ""); \
+      break; \
     } \
-  } while(0)
+  } while (0)
 
 NCCL_DEVICE_INLINE void atomic_thread_fence(memory_order order, thread_scope scope = thread_scope_device) {
   switch (order) {
-    case memory_order_relaxed: break;
-    case memory_order_acquire: NCCL_HIP_FENCE_SCOPE(__ATOMIC_ACQUIRE, scope); break;
-    case memory_order_release: NCCL_HIP_FENCE_SCOPE(__ATOMIC_RELEASE, scope); break;
-    case memory_order_acq_rel: NCCL_HIP_FENCE_SCOPE(__ATOMIC_ACQ_REL, scope); break;
-    case memory_order_seq_cst: default: NCCL_HIP_FENCE_SCOPE(__ATOMIC_SEQ_CST, scope); break;
+  case memory_order_relaxed:
+    break;
+  case memory_order_acquire:
+    NCCL_HIP_FENCE_SCOPE(__ATOMIC_ACQUIRE, scope);
+    break;
+  case memory_order_release:
+    NCCL_HIP_FENCE_SCOPE(__ATOMIC_RELEASE, scope);
+    break;
+  case memory_order_acq_rel:
+    NCCL_HIP_FENCE_SCOPE(__ATOMIC_ACQ_REL, scope);
+    break;
+  case memory_order_seq_cst:
+  default:
+    NCCL_HIP_FENCE_SCOPE(__ATOMIC_SEQ_CST, scope);
+    break;
   }
 }
 
@@ -244,20 +266,20 @@ NCCL_DEVICE_INLINE void atomic_thread_fence(memory_order order, thread_scope sco
 
 // Bring into cuda namespace for source compatibility
 namespace cuda {
-  using nccl_hip::memory_order;
-  using nccl_hip::memory_order_relaxed;
-  using nccl_hip::memory_order_acquire;
-  using nccl_hip::memory_order_release;
-  using nccl_hip::memory_order_acq_rel;
-  using nccl_hip::memory_order_seq_cst;
-  using nccl_hip::thread_scope;
-  using nccl_hip::thread_scope_thread;
-  using nccl_hip::thread_scope_block;
-  using nccl_hip::thread_scope_device;
-  using nccl_hip::thread_scope_system;
-  using nccl_hip::atomic_ref;
-  using nccl_hip::atomic_thread_fence;
-}
+using nccl_hip::memory_order;
+using nccl_hip::memory_order_relaxed;
+using nccl_hip::memory_order_acquire;
+using nccl_hip::memory_order_release;
+using nccl_hip::memory_order_acq_rel;
+using nccl_hip::memory_order_seq_cst;
+using nccl_hip::thread_scope;
+using nccl_hip::thread_scope_thread;
+using nccl_hip::thread_scope_block;
+using nccl_hip::thread_scope_device;
+using nccl_hip::thread_scope_system;
+using nccl_hip::atomic_ref;
+using nccl_hip::atomic_thread_fence;
+} // namespace cuda
 
 #else // CUDA platform
 
@@ -286,12 +308,12 @@ NCCL_DEVICE_INLINE int nccl_lane_id() {
 // A 64-bit variant would be needed for full wave64 cooperative groups.
 NCCL_DEVICE_INLINE unsigned int nccl_lanemask_lt() {
   int lane = __lane_id();
-  #if NCCL_WARP_SIZE == 64
-    if (lane >= 32) return 0xFFFFFFFFu;
-    return (1u << lane) - 1;
-  #else
-    return (1u << lane) - 1;
-  #endif
+#if NCCL_WARP_SIZE == 64
+  if (lane >= 32) return 0xFFFFFFFFu;
+  return (1u << lane) - 1;
+#else
+  return (1u << lane) - 1;
+#endif
 }
 
 // Warp sync - AMD CDNA waves execute in lockstep (no divergence-convergence
@@ -340,7 +362,8 @@ NCCL_DEVICE_INLINE int __shfl_sync(unsigned int mask, int val, int srcLane, int 
   (void)mask;
   return __shfl(val, srcLane, width);
 }
-NCCL_DEVICE_INLINE unsigned int __shfl_sync(unsigned int mask, unsigned int val, int srcLane, int width = NCCL_WARP_SIZE) {
+NCCL_DEVICE_INLINE unsigned int __shfl_sync(unsigned int mask, unsigned int val, int srcLane,
+                                            int width = NCCL_WARP_SIZE) {
   (void)mask;
   return __shfl(val, srcLane, width);
 }
@@ -366,7 +389,8 @@ NCCL_DEVICE_INLINE void __syncwarp(unsigned int mask) {
 
 // __barrier_sync_count — CUDA named barrier; HIP only has s_barrier.
 NCCL_DEVICE_INLINE void __barrier_sync_count(int id, int count) {
-  (void)id; (void)count;
+  (void)id;
+  (void)count;
   __syncthreads();
 }
 
@@ -458,7 +482,7 @@ inline uint64_t nccl_umul64hi(uint64_t a, uint64_t b) {
 
 // Load through constant cache (ldg) - HIP doesn't have direct equivalent
 // Just use regular load
-template<typename T>
+template <typename T>
 NCCL_DEVICE_INLINE T nccl_ldg(const T* ptr) {
   return *ptr;
 }
@@ -468,45 +492,56 @@ NCCL_DEVICE_INLINE T nccl_ldg(const T* ptr) {
 // DWORDX4 detection replicated from rccl_ptr.h (hip_compat.h must be
 // self-contained and cannot include rccl_ptr.h).
 #if defined(__HIP_DEVICE_COMPILE__)
-  #if (defined(__gfx942__) || defined(__gfx950__)) \
-      && __has_builtin(__builtin_amdgcn_global_load_b128) \
-      && __has_builtin(__builtin_amdgcn_global_store_b128) \
-      && !defined(DWORDX4_INTRINSICS_FORCE_OFF)
-    #define NCCL_COMPAT_HAVE_DWORDX4 1
-  #else
-    #define NCCL_COMPAT_HAVE_DWORDX4 0
-  #endif
+#if (defined(__gfx942__) || defined(__gfx950__)) && __has_builtin(__builtin_amdgcn_global_load_b128) && \
+  __has_builtin(__builtin_amdgcn_global_store_b128) && !defined(DWORDX4_INTRINSICS_FORCE_OFF)
+#define NCCL_COMPAT_HAVE_DWORDX4 1
 #else
-  #define NCCL_COMPAT_HAVE_DWORDX4 0
+#define NCCL_COMPAT_HAVE_DWORDX4 0
+#endif
+#else
+#define NCCL_COMPAT_HAVE_DWORDX4 0
 #endif
 
 typedef __attribute__((__vector_size__(4 * sizeof(unsigned int)))) unsigned int nccl_compat_v4u;
 typedef __attribute__((address_space(1))) nccl_compat_v4u* nccl_compat_v4u_gptr;
 
 NCCL_DEVICE_INLINE void nccl_st_volatile_v4_u32(void* ptr, uint32_t v0, uint32_t v1, uint32_t v2, uint32_t v3) {
-  union { nccl_compat_v4u vec; uint32_t u32[4]; } u;
-  u.u32[0] = v0; u.u32[1] = v1; u.u32[2] = v2; u.u32[3] = v3;
-  #if NCCL_COMPAT_HAVE_DWORDX4
-    __builtin_amdgcn_global_store_b128((nccl_compat_v4u_gptr)ptr, u.vec, "");
-  #else
-    typedef __attribute__((address_space(1))) uint64_t* u64_gptr_t;
-    uint64_t* p64 = reinterpret_cast<uint64_t*>(ptr);
-    __builtin_nontemporal_store(*reinterpret_cast<uint64_t*>(&u.u32[0]), (u64_gptr_t)p64);
-    __builtin_nontemporal_store(*reinterpret_cast<uint64_t*>(&u.u32[2]), (u64_gptr_t)(p64 + 1));
-  #endif
+  union {
+    nccl_compat_v4u vec;
+    uint32_t u32[4];
+  } u;
+  u.u32[0] = v0;
+  u.u32[1] = v1;
+  u.u32[2] = v2;
+  u.u32[3] = v3;
+#if NCCL_COMPAT_HAVE_DWORDX4
+  __builtin_amdgcn_global_store_b128((nccl_compat_v4u_gptr)ptr, u.vec, "");
+#else
+  typedef __attribute__((address_space(1))) uint64_t* u64_gptr_t;
+  uint64_t* p64 = reinterpret_cast<uint64_t*>(ptr);
+  __builtin_nontemporal_store(*reinterpret_cast<uint64_t*>(&u.u32[0]), (u64_gptr_t)p64);
+  __builtin_nontemporal_store(*reinterpret_cast<uint64_t*>(&u.u32[2]), (u64_gptr_t)(p64 + 1));
+#endif
 }
 
-NCCL_DEVICE_INLINE void nccl_ld_volatile_v4_u32(const void* ptr, uint32_t& v0, uint32_t& v1, uint32_t& v2, uint32_t& v3) {
-  union { nccl_compat_v4u vec; uint32_t u32[4]; } u;
-  #if NCCL_COMPAT_HAVE_DWORDX4
-    u.vec = __builtin_amdgcn_global_load_b128((nccl_compat_v4u_gptr)ptr, "");
-  #else
-    typedef __attribute__((address_space(1))) uint64_t* u64_gptr_t;
-    const uint64_t* p64 = reinterpret_cast<const uint64_t*>(ptr);
-    *reinterpret_cast<uint64_t*>(&u.u32[0]) = __builtin_nontemporal_load((u64_gptr_t)p64);
-    *reinterpret_cast<uint64_t*>(&u.u32[2]) = __builtin_nontemporal_load((u64_gptr_t)(p64 + 1));
-  #endif
-  v0 = u.u32[0]; v1 = u.u32[1]; v2 = u.u32[2]; v3 = u.u32[3];
+NCCL_DEVICE_INLINE void nccl_ld_volatile_v4_u32(const void* ptr, uint32_t& v0, uint32_t& v1, uint32_t& v2,
+                                                uint32_t& v3) {
+  union {
+    nccl_compat_v4u vec;
+    uint32_t u32[4];
+  } u;
+#if NCCL_COMPAT_HAVE_DWORDX4
+  u.vec = __builtin_amdgcn_global_load_b128((nccl_compat_v4u_gptr)ptr, "");
+#else
+  typedef __attribute__((address_space(1))) uint64_t* u64_gptr_t;
+  const uint64_t* p64 = reinterpret_cast<const uint64_t*>(ptr);
+  *reinterpret_cast<uint64_t*>(&u.u32[0]) = __builtin_nontemporal_load((u64_gptr_t)p64);
+  *reinterpret_cast<uint64_t*>(&u.u32[2]) = __builtin_nontemporal_load((u64_gptr_t)(p64 + 1));
+#endif
+  v0 = u.u32[0];
+  v1 = u.u32[1];
+  v2 = u.u32[2];
+  v3 = u.u32[3];
 }
 
 // GPU-scope (agent) acquire fence
@@ -533,20 +568,18 @@ NCCL_DEVICE_INLINE void nccl_multimem_red_relaxed_add_u32(void* ptr) {
 
 #else // CUDA platform
 
-template<typename T>
+template <typename T>
 NCCL_DEVICE_INLINE T nccl_ldg(const T* ptr) {
   return __ldg(ptr);
 }
 
 NCCL_DEVICE_INLINE void nccl_st_volatile_v4_u32(void* ptr, uint32_t v0, uint32_t v1, uint32_t v2, uint32_t v3) {
-  asm volatile("st.volatile.v4.u32 [%0],{%1,%2,%3,%4};" ::
-    "l"(ptr), "r"(v0), "r"(v1), "r"(v2), "r"(v3));
+  asm volatile("st.volatile.v4.u32 [%0],{%1,%2,%3,%4};" ::"l"(ptr), "r"(v0), "r"(v1), "r"(v2), "r"(v3));
 }
 
-NCCL_DEVICE_INLINE void nccl_ld_volatile_v4_u32(const void* ptr, uint32_t& v0, uint32_t& v1, uint32_t& v2, uint32_t& v3) {
-  asm volatile("ld.volatile.v4.u32 {%0,%1,%2,%3},[%4];"
-    : "=r"(v0), "=r"(v1), "=r"(v2), "=r"(v3)
-    : "l"(ptr));
+NCCL_DEVICE_INLINE void nccl_ld_volatile_v4_u32(const void* ptr, uint32_t& v0, uint32_t& v1, uint32_t& v2,
+                                                uint32_t& v3) {
+  asm volatile("ld.volatile.v4.u32 {%0,%1,%2,%3},[%4];" : "=r"(v0), "=r"(v1), "=r"(v2), "=r"(v3) : "l"(ptr));
 }
 
 NCCL_DEVICE_INLINE void nccl_fence_acq_gpu() {
@@ -561,19 +594,19 @@ NCCL_DEVICE_INLINE void nccl_fence_rel_gpu() {
 }
 
 NCCL_DEVICE_INLINE void nccl_multimem_red_release_add_u32(void* ptr) {
-  #if __CUDA_ARCH__ >= 900
-    asm volatile("multimem.red.release.sys.add.u32 [%0],1;" :: "l"(ptr));
-  #else
-    (void)ptr;
-  #endif
+#if __CUDA_ARCH__ >= 900
+  asm volatile("multimem.red.release.sys.add.u32 [%0],1;" ::"l"(ptr));
+#else
+  (void)ptr;
+#endif
 }
 
 NCCL_DEVICE_INLINE void nccl_multimem_red_relaxed_add_u32(void* ptr) {
-  #if __CUDA_ARCH__ >= 900
-    asm volatile("multimem.red.relaxed.sys.add.u32 [%0],1;" :: "l"(ptr));
-  #else
-    (void)ptr;
-  #endif
+#if __CUDA_ARCH__ >= 900
+  asm volatile("multimem.red.relaxed.sys.add.u32 [%0],1;" ::"l"(ptr));
+#else
+  (void)ptr;
+#endif
 }
 
 #endif // NCCL_HIP_PLATFORM
@@ -586,15 +619,21 @@ NCCL_DEVICE_INLINE void nccl_multimem_red_relaxed_add_u32(void* ptr) {
 
 #if defined(NCCL_HIP_PLATFORM) && NCCL_DEVICE_COMPILE
   // Mark features that are not yet implemented for HIP
-  #define NCCL_HIP_NYI(feature) \
-    do { /* NYI: feature */ } while(0)
+#define NCCL_HIP_NYI(feature) \
+  do { /* NYI: feature */ \
+  } while (0)
 
   // Warning for features that have no HIP equivalent
-  #define NCCL_HIP_NO_EQUIVALENT(feature) \
-    do { /* NO HIP EQUIVALENT: feature */ } while(0)
+#define NCCL_HIP_NO_EQUIVALENT(feature) \
+  do { /* NO HIP EQUIVALENT: feature */ \
+  } while (0)
 #else
-  #define NCCL_HIP_NYI(feature) do {} while(0)
-  #define NCCL_HIP_NO_EQUIVALENT(feature) do {} while(0)
+#define NCCL_HIP_NYI(feature) \
+  do { \
+  } while (0)
+#define NCCL_HIP_NO_EQUIVALENT(feature) \
+  do { \
+  } while (0)
 #endif
 
 #endif // _NCCL_DEVICE_HIP_COMPAT_H_

--- a/projects/rccl/src/include/nccl_device/impl/barrier__funcs.h
+++ b/projects/rccl/src/include/nccl_device/impl/barrier__funcs.h
@@ -16,75 +16,59 @@
 #include "../utility.h"
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop>
-NCCL_DEVICE_INLINE ncclBarrierSession<Coop>::ncclBarrierSession(
-    Coop coop, ncclTeam innerTeam, ncclTeam outerTeam, ncclGin gin,
-    ncclLsaBarrierHandle innerHandle, ncclGinBarrierHandle outerHandle,
-    uint32_t index, bool multimem, ncclMultimemHandle innerMmHandle
-  ):
-  ncclBarrierSession_internal<Coop>(coop,
-    nccl::utility::present(gin),
-    nccl::utility::present(coop, gin.comm, innerTeam, innerHandle, index, multimem, innerMmHandle),
-    nccl::utility::present(coop, gin, outerTeam, outerHandle, index)
-  ) {
-}
+template <typename Coop>
+NCCL_DEVICE_INLINE ncclBarrierSession<Coop>::ncclBarrierSession(Coop coop, ncclTeam innerTeam, ncclTeam outerTeam,
+                                                                ncclGin gin, ncclLsaBarrierHandle innerHandle,
+                                                                ncclGinBarrierHandle outerHandle, uint32_t index,
+                                                                bool multimem, ncclMultimemHandle innerMmHandle)
+  : ncclBarrierSession_internal<Coop>(coop, nccl::utility::present(gin),
+                                      nccl::utility::present(coop, gin.comm, innerTeam, innerHandle, index, multimem,
+                                                             innerMmHandle),
+                                      nccl::utility::present(coop, gin, outerTeam, outerHandle, index)) {}
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop>
-NCCL_DEVICE_INLINE ncclBarrierSession<Coop>::ncclBarrierSession(
-    Coop coop, ncclTeamTagWorld, ncclGin gin, uint32_t index, bool multimem
-  ):
-  ncclBarrierSession<Coop>(
-    coop, ncclTeamLsa(gin.comm), ncclTeamRail(gin.comm), gin,
-    gin.comm.hybridLsaBarrier, gin.comm.hybridRailGinBarrier,
-    index, multimem, gin.comm.lsaMultimem
-  ) {
-}
+template <typename Coop>
+NCCL_DEVICE_INLINE ncclBarrierSession<Coop>::ncclBarrierSession(Coop coop, ncclTeamTagWorld, ncclGin gin,
+                                                                uint32_t index, bool multimem)
+  : ncclBarrierSession<Coop>(coop, ncclTeamLsa(gin.comm), ncclTeamRail(gin.comm), gin, gin.comm.hybridLsaBarrier,
+                             gin.comm.hybridRailGinBarrier, index, multimem, gin.comm.lsaMultimem) {}
 #endif
 
 #if __CUDACC__
-template<typename Coop>
-NCCL_DEVICE_INLINE ncclBarrierSession<Coop>::ncclBarrierSession(
-    Coop coop, ncclTeamTagLsa, ncclDevComm const& comm, uint32_t index, bool multimem
-  ):
-  ncclBarrierSession_internal<Coop>(coop,
-    nccl::utility::Absent(),
-    nccl::utility::present(coop, comm, ncclTeamLsa(comm), comm.hybridLsaBarrier, index, multimem, comm.lsaMultimem),
-    nccl::utility::Absent()
-  ) {
-}
+template <typename Coop>
+NCCL_DEVICE_INLINE ncclBarrierSession<Coop>::ncclBarrierSession(Coop coop, ncclTeamTagLsa, ncclDevComm const& comm,
+                                                                uint32_t index, bool multimem)
+  : ncclBarrierSession_internal<Coop>(coop, nccl::utility::Absent(),
+                                      nccl::utility::present(coop, comm, ncclTeamLsa(comm), comm.hybridLsaBarrier,
+                                                             index, multimem, comm.lsaMultimem),
+                                      nccl::utility::Absent()) {}
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop>
-NCCL_DEVICE_INLINE ncclBarrierSession<Coop>::ncclBarrierSession(
-    Coop coop, ncclTeamTagRail, ncclGin gin, uint32_t index
-  ):
-  ncclBarrierSession_internal<Coop>(coop,
-    nccl::utility::present(gin),
-    nccl::utility::Absent(),
-    nccl::utility::present(coop, gin, ncclTeamRail(gin.comm), gin.comm.hybridRailGinBarrier, index)
-  ) {
-}
+template <typename Coop>
+NCCL_DEVICE_INLINE ncclBarrierSession<Coop>::ncclBarrierSession(Coop coop, ncclTeamTagRail, ncclGin gin, uint32_t index)
+  : ncclBarrierSession_internal<Coop>(coop, nccl::utility::present(gin), nccl::utility::Absent(),
+                                      nccl::utility::present(coop, gin, ncclTeamRail(gin.comm),
+                                                             gin.comm.hybridRailGinBarrier, index)) {}
 #endif
 
 #if __CUDACC__
-template<typename Coop>
+template <typename Coop>
 NCCL_DEVICE_INLINE ncclLsaBarrierSession<Coop>& ncclBarrierSession<Coop>::lsaBarrier() {
   return this->innerLsaBar.thing;
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop>
+template <typename Coop>
 NCCL_DEVICE_INLINE ncclGinBarrierSession<Coop>& ncclBarrierSession<Coop>::ginBarrier() {
   return this->outerGinBar.thing;
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop>
+template <typename Coop>
 NCCL_DEVICE_INLINE void ncclBarrierSession<Coop>::sync(Coop, cuda::memory_order ord, ncclGinFenceLevel fence) {
   if (this->innerLsaBar.present) {
     this->innerLsaBar.thing.sync(this->coop, this->outerGinBar.present ? nccl::utility::releaseOrderOf(ord) : ord);
@@ -97,19 +81,16 @@ NCCL_DEVICE_INLINE void ncclBarrierSession<Coop>::sync(Coop, cuda::memory_order 
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop>
-NCCL_DEVICE_INLINE ncclResult_t ncclBarrierSession<Coop>::sync(
-    Coop, cuda::memory_order ord, ncclGinFenceLevel fence, uint64_t timeoutCycles) {
+template <typename Coop>
+NCCL_DEVICE_INLINE ncclResult_t ncclBarrierSession<Coop>::sync(Coop, cuda::memory_order ord, ncclGinFenceLevel fence,
+                                                               uint64_t timeoutCycles) {
   ncclResult_t lsaResult = ncclSuccess, railResult = ncclSuccess;
 
   // Inner LSA barrier (if present) - detects remote CTA/rank issues
   if (this->innerLsaBar.present) {
     uint64_t startCycle = clock64();
     lsaResult = this->innerLsaBar.thing.sync(
-      this->coop,
-      this->outerGinBar.present ? nccl::utility::releaseOrderOf(ord) : ord,
-      timeoutCycles
-    );
+      this->coop, this->outerGinBar.present ? nccl::utility::releaseOrderOf(ord) : ord, timeoutCycles);
     uint64_t elapsed = clock64() - startCycle;
     timeoutCycles -= min(elapsed, timeoutCycles);
     // Because threads within a coop don't synchronize about the timeout condition,
@@ -120,11 +101,7 @@ NCCL_DEVICE_INLINE ncclResult_t ncclBarrierSession<Coop>::sync(
   // Outer GIN barrier (if present) - detects remote GPU/network issues
   if (this->outerGinBar.present) {
     railResult = this->outerGinBar.thing.sync(
-      this->coop,
-      this->innerLsaBar.present ? nccl::utility::acquireOrderOf(ord) : ord,
-      fence,
-      timeoutCycles
-    );
+      this->coop, this->innerLsaBar.present ? nccl::utility::acquireOrderOf(ord) : ord, fence, timeoutCycles);
   }
   return lsaResult != ncclSuccess ? lsaResult : railResult;
 }

--- a/projects/rccl/src/include/nccl_device/impl/barrier__types.h
+++ b/projects/rccl/src/include/nccl_device/impl/barrier__types.h
@@ -11,19 +11,16 @@
 #include "../utility.h"
 
 #if __CUDACC__
-template<typename Coop>
+template <typename Coop>
 struct ncclBarrierSession_internal {
   Coop coop;
   nccl::utility::Optional<ncclGin> gin;
   nccl::utility::Optional<ncclLsaBarrierSession<Coop>> innerLsaBar;
   nccl::utility::Optional<ncclGinBarrierSession<Coop>> outerGinBar;
 
-  template<typename GinInit, typename InnerInit, typename OuterInit>
-  NCCL_DEVICE_INLINE ncclBarrierSession_internal(
-      Coop coop, GinInit ginInit, InnerInit innerInit, OuterInit outerInit
-    ):
-    coop(coop), gin{ginInit}, innerLsaBar{innerInit}, outerGinBar{outerInit} {
-  }
+  template <typename GinInit, typename InnerInit, typename OuterInit>
+  NCCL_DEVICE_INLINE ncclBarrierSession_internal(Coop coop, GinInit ginInit, InnerInit innerInit, OuterInit outerInit)
+    : coop(coop), gin{ginInit}, innerLsaBar{innerInit}, outerGinBar{outerInit} {}
 };
 #endif
 

--- a/projects/rccl/src/include/nccl_device/impl/core__funcs.h
+++ b/projects/rccl/src/include/nccl_device/impl/core__funcs.h
@@ -12,7 +12,7 @@
 #include "ptr__types.h"
 
 #if __cplusplus
-NCCL_HOST_DEVICE_INLINE ncclTeam ncclTeamWorld(ncclDevComm const &comm) {
+NCCL_HOST_DEVICE_INLINE ncclTeam ncclTeamWorld(ncclDevComm const& comm) {
   ncclTeam ans;
   ans.nRanks = comm.nRanks;
   ans.rank = comm.rank;
@@ -22,7 +22,7 @@ NCCL_HOST_DEVICE_INLINE ncclTeam ncclTeamWorld(ncclDevComm const &comm) {
 #endif
 
 #if __cplusplus
-NCCL_HOST_DEVICE_INLINE ncclTeam ncclTeamLsa(ncclDevComm const &comm) {
+NCCL_HOST_DEVICE_INLINE ncclTeam ncclTeamLsa(ncclDevComm const& comm) {
   ncclTeam ans;
   ans.nRanks = comm.lsaSize;
   ans.rank = comm.lsaRank;
@@ -42,62 +42,62 @@ NCCL_HOST_DEVICE_INLINE ncclTeam ncclTeamRail(ncclDevComm const& comm) {
 #endif
 
 NCCL_HOST_DEVICE_INLINE bool ncclTeamRankIsMember(ncclTeam_t a, ncclTeam_t b, int brank) {
-  int wrank = (brank - b.rank)*b.stride;
-  uint32_t adelta = wrank/a.stride;
-  uint32_t amod = wrank%a.stride;
+  int wrank = (brank - b.rank) * b.stride;
+  uint32_t adelta = wrank / a.stride;
+  uint32_t amod = wrank % a.stride;
   int arank = a.rank + adelta;
   return 0 <= arank && arank < a.nRanks && amod == 0;
 }
 
 NCCL_HOST_DEVICE_INLINE int ncclTeamRankToTeam(ncclTeam_t a, ncclTeam_t b, int brank) {
-  int wrank = (brank - b.rank)*b.stride;
-  uint32_t adelta = wrank/a.stride;
-  //uint32_t amod = wrank%a.stride;
+  int wrank = (brank - b.rank) * b.stride;
+  uint32_t adelta = wrank / a.stride;
+  // uint32_t amod = wrank%a.stride;
   int arank = a.rank + adelta;
   return arank;
 }
 
 #if __cplusplus
 NCCL_HOST_DEVICE_INLINE int ncclTeamRankToWorld(ncclDevComm const& comm, ncclTeam tm, int rank) {
-  return comm.rank + (rank - tm.rank)*tm.stride;
+  return comm.rank + (rank - tm.rank) * tm.stride;
 }
 #endif
 
 #if __cplusplus
 NCCL_HOST_DEVICE_INLINE int ncclTeamRankToLsa(ncclDevComm const& comm, ncclTeam tm, int rank) {
-  return comm.lsaRank + (rank - tm.rank)*tm.stride;
+  return comm.lsaRank + (rank - tm.rank) * tm.stride;
 }
 #endif
 
 NCCL_HOST_DEVICE_INLINE ncclTeam_t ncclTeamInnerFactor(ncclTeam_t parent, int innerSize) {
   ncclTeam_t ans;
   ans.nRanks = innerSize;
-  ans.rank = parent.rank%innerSize;
+  ans.rank = parent.rank % innerSize;
   ans.stride = parent.stride;
   return ans;
 }
 
 NCCL_HOST_DEVICE_INLINE ncclTeam_t ncclTeamOuterFactor(ncclTeam_t parent, int innerSize) {
   ncclTeam_t ans;
-  ans.nRanks = parent.nRanks/innerSize;
-  ans.rank = parent.rank/innerSize;
-  ans.stride = parent.stride*innerSize;
+  ans.nRanks = parent.nRanks / innerSize;
+  ans.rank = parent.rank / innerSize;
+  ans.stride = parent.stride * innerSize;
   return ans;
 }
 
 NCCL_HOST_DEVICE_INLINE int ncclTeamRankInDifference(ncclTeam_t parent, ncclTeam_t subset, int index) {
-  int stride = subset.stride/parent.stride;
-  int below = parent.rank - subset.rank*stride;
+  int stride = subset.stride / parent.stride;
+  int below = parent.rank - subset.rank * stride;
   if (stride < 0) {
     stride = -stride;
-    below -= (subset.nRanks-1)*stride;
+    below -= (subset.nRanks - 1) * stride;
   }
   if (index < below) {
     return index;
-  } else if (index-below < (subset.nRanks-1)*(stride-1)) {
-    return below + 1 + ((index-below)/(stride-1))*stride + (index-below)%(stride-1);
+  } else if (index - below < (subset.nRanks - 1) * (stride - 1)) {
+    return below + 1 + ((index - below) / (stride - 1)) * stride + (index - below) % (stride - 1);
   } else {
-    return below + 1 + (subset.nRanks-1)*stride + (index - below - (subset.nRanks-1)*(stride-1));
+    return below + 1 + (subset.nRanks - 1) * stride + (index - below - (subset.nRanks - 1) * (stride - 1));
   }
 }
 
@@ -106,7 +106,7 @@ NCCL_DEVICE_INLINE void* ncclGetLocalPointer(ncclWindow_t w, size_t offset) {
   char* base = nccl::utility::loadConst(&w->lsaFlatBase);
   uint32_t stride4G = nccl::utility::loadConst(&w->stride4G);
   int i = nccl::utility::loadConst(&w->lsaRank);
-  return (void*)(nccl::utility::add4G(base, i*stride4G) + offset);
+  return (void*)(nccl::utility::add4G(base, i * stride4G) + offset);
 }
 #endif
 
@@ -115,7 +115,7 @@ NCCL_DEVICE_INLINE void* ncclGetLsaPointer(ncclWindow_t w, size_t offset, int pe
   char* base = nccl::utility::loadConst(&w->lsaFlatBase);
   uint32_t stride4G = nccl::utility::loadConst(&w->stride4G);
   int i = peer;
-  return (void*)(nccl::utility::add4G(base, i*stride4G) + offset);
+  return (void*)(nccl::utility::add4G(base, i * stride4G) + offset);
 }
 #endif
 
@@ -126,7 +126,7 @@ NCCL_DEVICE_INLINE void* ncclGetPeerPointer(ncclWindow_t w, size_t offset, int p
   int worldRank = nccl::utility::loadConst(&w->worldRank);
   int lsaRank = nccl::utility::loadConst(&w->lsaRank);
   int i = lsaRank + (peer - worldRank);
-  return (void*)(nccl::utility::add4G(base, i*stride4G) + offset);
+  return (void*)(nccl::utility::add4G(base, i * stride4G) + offset);
 }
 #endif
 
@@ -135,15 +135,15 @@ NCCL_DEVICE_INLINE void* ncclGetPeerPointer(ncclWindow_t w, size_t offset, ncclT
   char* base = nccl::utility::loadConst(&w->lsaFlatBase);
   uint32_t stride4G = nccl::utility::loadConst(&w->stride4G);
   int lsaRank = nccl::utility::loadConst(&w->lsaRank);
-  int i = lsaRank + (peer - tm.rank)*tm.stride;
-  return (void*)(nccl::utility::add4G(base, i*stride4G) + offset);
+  int i = lsaRank + (peer - tm.rank) * tm.stride;
+  return (void*)(nccl::utility::add4G(base, i * stride4G) + offset);
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
 NCCL_DEVICE_INLINE void* ncclGetMultimemPointer(ncclWindow_t w, size_t offset, ncclMultimemHandle mm) {
   void* ptr = mm.mcBasePtr;
-  ptr = reinterpret_cast<char(*)[4096]>(ptr) + nccl::utility::loadConst(&w->mcOffset4K);
+  ptr = reinterpret_cast<char (*)[4096]>(ptr) + nccl::utility::loadConst(&w->mcOffset4K);
   return (void*)((char*)ptr + offset);
 }
 #endif
@@ -155,15 +155,15 @@ NCCL_DEVICE_INLINE void* ncclGetLsaMultimemPointer(ncclWindow_t w, size_t offset
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop>
-NCCL_DEVICE_INLINE ncclWindow_t ncclFindWindow(Coop coop, ncclDevComm const& comm, void const *ptr) {
+template <typename Coop>
+NCCL_DEVICE_INLINE ncclWindow_t ncclFindWindow(Coop coop, ncclDevComm const& comm, void const* ptr) {
   using nccl::utility::loadConst;
   auto coalesced = ncclCoopCoalesced(coop);
   ncclDevCommWindowTable* t = comm.windowTable;
   while (true) {
     bool found = false;
     int index = coalesced.thread_rank();
-    #pragma unroll 1
+#pragma unroll 1
     while (index < 32) {
       uintptr_t uptr = reinterpret_cast<uintptr_t>(ptr);
       ncclDevCommWindowTable::Entry e = loadConst(&t->entries[index]);
@@ -177,7 +177,7 @@ NCCL_DEVICE_INLINE ncclWindow_t ncclFindWindow(Coop coop, ncclDevComm const& com
     }
     uint32_t mask = __ballot_sync(ncclCoopGetLaneMask(coalesced), found);
     if (mask != 0) {
-      int source = __popc(mask-1);
+      int source = __popc(mask - 1);
       index = __shfl_sync(ncclCoopGetLaneMask(coalesced), index, source);
       return loadConst(&t->entries[index].window);
     }
@@ -187,15 +187,15 @@ NCCL_DEVICE_INLINE ncclWindow_t ncclFindWindow(Coop coop, ncclDevComm const& com
 #endif
 
 NCCL_HOST_DEVICE_INLINE size_t ncclGetResourceBufferOffset(ncclDevResourceHandle_t h) {
-  return ((size_t)h)*128;
+  return ((size_t)h) * 128;
 }
 
 #if __CUDACC__
 NCCL_DEVICE_INLINE void* ncclGetResourceBufferLocalPointer(ncclDevComm const& comm, ncclDevResourceHandle h) {
   void* lsaFlatBase = comm.resourceWindow_inlined.lsaFlatBase;
   uint32_t stride4G = comm.resourceWindow_inlined.stride4G;
-  void* local = nccl::utility::add4G(lsaFlatBase, comm.lsaRank*stride4G);
-  return (void*)(reinterpret_cast<char(*)[128]>(local) + h);
+  void* local = nccl::utility::add4G(lsaFlatBase, comm.lsaRank * stride4G);
+  return (void*)(reinterpret_cast<char (*)[128]>(local) + h);
 }
 #endif
 
@@ -204,26 +204,28 @@ NCCL_DEVICE_INLINE void* ncclGetResourceBufferLsaPointer(ncclDevComm const& comm
   int r = peer;
   void* lsaFlatBase = comm.resourceWindow_inlined.lsaFlatBase;
   uint32_t stride4G = comm.resourceWindow_inlined.stride4G;
-  void* local = nccl::utility::add4G(lsaFlatBase, r*stride4G);
-  return (void*)(reinterpret_cast<char(*)[128]>(local) + h);
+  void* local = nccl::utility::add4G(lsaFlatBase, r * stride4G);
+  return (void*)(reinterpret_cast<char (*)[128]>(local) + h);
 }
 #endif
 
 #if __CUDACC__
-NCCL_DEVICE_INLINE void* ncclGetResourceBufferPeerPointer(ncclDevComm const& comm, ncclDevResourceHandle h, ncclTeam team, int peer) {
-  int r = comm.lsaRank + (peer - team.rank)*team.stride;
+NCCL_DEVICE_INLINE void* ncclGetResourceBufferPeerPointer(ncclDevComm const& comm, ncclDevResourceHandle h,
+                                                          ncclTeam team, int peer) {
+  int r = comm.lsaRank + (peer - team.rank) * team.stride;
   void* lsaFlatBase = comm.resourceWindow_inlined.lsaFlatBase;
   uint32_t stride4G = comm.resourceWindow_inlined.stride4G;
-  void* local = nccl::utility::add4G(lsaFlatBase, r*stride4G);
-  return (void*)(reinterpret_cast<char(*)[128]>(local) + h);
+  void* local = nccl::utility::add4G(lsaFlatBase, r * stride4G);
+  return (void*)(reinterpret_cast<char (*)[128]>(local) + h);
 }
 #endif
 
 #if __CUDACC__
-NCCL_DEVICE_INLINE void* ncclGetResourceBufferMultimemPointer(ncclDevComm const& comm, ncclDevResourceHandle h, ncclMultimemHandle mm) {
+NCCL_DEVICE_INLINE void* ncclGetResourceBufferMultimemPointer(ncclDevComm const& comm, ncclDevResourceHandle h,
+                                                              ncclMultimemHandle mm) {
   void* ptr = mm.mcBasePtr;
-  ptr = reinterpret_cast<char(*)[4096]>(ptr) + comm.resourceWindow_inlined.mcOffset4K;
-  ptr = reinterpret_cast<char(*)[128]>(ptr) + h;
+  ptr = reinterpret_cast<char (*)[4096]>(ptr) + comm.resourceWindow_inlined.mcOffset4K;
+  ptr = reinterpret_cast<char (*)[128]>(ptr) + h;
   return ptr;
 }
 #endif
@@ -236,7 +238,7 @@ NCCL_DEVICE_INLINE void* ncclGetResourceBufferLsaMultimemPointer(ncclDevComm con
 
 #if __CUDACC__
 NCCL_DEVICE_INLINE ncclSymPtr<char> ncclGetResourceBuffer(ncclDevComm const& comm, ncclDevResourceHandle h) {
-  return ncclSymPtr<char>(comm.resourceWindow, size_t(h)*128);
+  return ncclSymPtr<char>(comm.resourceWindow, size_t(h) * 128);
 }
 #endif
 

--- a/projects/rccl/src/include/nccl_device/impl/core__types.h
+++ b/projects/rccl/src/include/nccl_device/impl/core__types.h
@@ -12,7 +12,7 @@
 #include <cuda.h>
 /* Minimal types instead of nccl_device/gin/gin_device_host_common.h (GIN is Linux-only) */
 #define NCCL_GIN_MAX_CONNECTIONS 4
-typedef void *ncclGinWindow_t;
+typedef void* ncclGinWindow_t;
 #else
 #include "nccl_device/gin/gin_device_host_common.h"
 #endif

--- a/projects/rccl/src/include/nccl_device/impl/gin__funcs.h
+++ b/projects/rccl/src/include/nccl_device/impl/gin__funcs.h
@@ -20,7 +20,7 @@ namespace internal {
 #if NCCL_CHECK_CUDACC
 NCCL_DEVICE_INLINE size_t windowOffsetToGinOffset(ncclWindow_t window, size_t offset) {
   using nccl::utility::loadConst;
-  return 4096*size_t(loadConst(&window->ginOffset4K)) + offset;
+  return 4096 * size_t(loadConst(&window->ginOffset4K)) + offset;
 }
 
 NCCL_DEVICE_INLINE ncclGinWindow_t getGinWindow(ncclWindow_t window, int connectionId) {
@@ -62,8 +62,7 @@ NCCL_DEVICE_INLINE size_t getSegmentChunkSize(size_t srcRemaining, size_t dstRem
   return chunk;
 }
 
-NCCL_DEVICE_INLINE void advanceSegmentCursor(
-    int* seg, size_t* segOffset, size_t chunkSize, size_t segmentSize) {
+NCCL_DEVICE_INLINE void advanceSegmentCursor(int* seg, size_t* segOffset, size_t chunkSize, size_t segmentSize) {
   *segOffset += chunkSize;
   if (*segOffset >= segmentSize) {
     (*seg)++;
@@ -76,56 +75,55 @@ NCCL_DEVICE_INLINE void advanceSegmentCursor(
 } // namespace gin
 } // namespace nccl
 
-
 #if NCCL_CHECK_CUDACC
 // Common initialization helper for GIN backend
-template<typename GinType>
+template <typename GinType>
 NCCL_DEVICE_INLINE void ncclGinInitCommon(GinType* gin, ncclDevComm const& comm, int contextIndex) {
   gin->nConnections = comm.ginConnectionCount;
 
   static_assert(NCCL_GIN_MAX_CONNECTIONS == 4, "Required for following modulo hack to work.");
   // this->connectionId = contextIndex % comm.ginConnectionCount;
-  gin->connectionId = comm.ginConnectionCount == 3
-    ? uint32_t(contextIndex)%3 // 3 is only non power of 2
-    : contextIndex & (comm.ginConnectionCount-1); // powers of 2
+  gin->connectionId = comm.ginConnectionCount == 3 ? uint32_t(contextIndex) % 3 // 3 is only non power of 2
+                                                     :
+                                                     contextIndex & (comm.ginConnectionCount - 1); // powers of 2
   // gin->contextId = contextIndex / comm.ginConnectionCount;
-  gin->contextId = comm.ginConnectionCount == 3
-    ? uint32_t(contextIndex)/3 // 3 is only non power of 2
-    : contextIndex >> (comm.ginConnectionCount==4 ? 2 : comm.ginConnectionCount-1); // powers of 2
+  gin->contextId = comm.ginConnectionCount == 3 ?
+                     uint32_t(contextIndex) / 3 // 3 is only non power of 2
+                     :
+                     contextIndex >> (comm.ginConnectionCount == 4 ? 2 : comm.ginConnectionCount - 1); // powers of 2
 
   gin->_ginBackend = comm.ginNetDeviceTypes[gin->connectionId];
   gin->_ginHandle = comm.ginHandles[gin->connectionId];
   gin->_signalShadows = comm.ginSignalShadows + contextIndex * comm.ginSignalCount;
 }
 
-template<unsigned beMask>
-NCCL_DEVICE_INLINE ncclGin_BackendMask<beMask>::ncclGin_BackendMask(
-    ncclDevComm const& comm, int contextIndex, ncclGinResourceSharingMode resourceSharingMode_):
-  comm(comm), resourceSharingMode(resourceSharingMode_) {
+template <unsigned beMask>
+NCCL_DEVICE_INLINE ncclGin_BackendMask<beMask>::ncclGin_BackendMask(ncclDevComm const& comm, int contextIndex,
+                                                                    ncclGinResourceSharingMode resourceSharingMode_)
+  : comm(comm), resourceSharingMode(resourceSharingMode_) {
   ncclGinInitCommon(this, comm, contextIndex);
 }
 
-NCCL_DEVICE_INLINE ncclGin_C::ncclGin_C(
-    ncclDevComm const& comm, unsigned backendMask, int contextIndex,
-    ncclGinResourceSharingMode resourceSharingMode)
+NCCL_DEVICE_INLINE ncclGin_C::ncclGin_C(ncclDevComm const& comm, unsigned backendMask, int contextIndex,
+                                        ncclGinResourceSharingMode resourceSharingMode)
   : comm(comm), resourceSharingMode(resourceSharingMode), backendMask(backendMask) {
   ncclGinInitCommon(this, comm, contextIndex);
 }
 
-NCCL_DEVICE_INLINE void ncclGin_C_init(
-    ncclGin_C* net, unsigned backendMask, ncclDevComm const& comm, int contextIndex) {
+NCCL_DEVICE_INLINE void ncclGin_C_init(ncclGin_C* net, unsigned backendMask, ncclDevComm const& comm,
+                                       int contextIndex) {
   ::new (net) ncclGin_C(comm, backendMask, contextIndex, NCCL_GIN_RESOURCE_SHARING_GPU);
 }
 
-NCCL_DEVICE_INLINE void ncclGin_C_initWithResourceSharingMode(
-    ncclGin_C* net, unsigned backendMask, ncclDevComm const& comm, int contextIndex,
-    ncclGinResourceSharingMode resourceSharingMode) {
+NCCL_DEVICE_INLINE void ncclGin_C_initWithResourceSharingMode(ncclGin_C* net, unsigned backendMask,
+                                                              ncclDevComm const& comm, int contextIndex,
+                                                              ncclGinResourceSharingMode resourceSharingMode) {
   ::new (net) ncclGin_C(comm, backendMask, contextIndex, resourceSharingMode);
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<unsigned beMask>
+template <unsigned beMask>
 NCCL_DEVICE_INLINE ncclGinCtx_M<beMask> ncclGin_BackendMask<beMask>::_makeCtx() const {
   ncclGinCtx_M<beMask> ans;
   ans.backend = (ncclNetDeviceType)_ginBackend;
@@ -166,24 +164,36 @@ NCCL_DEVICE_INLINE ncclGinCtx ncclGin_C_makeCtx(ncclGin_C* net) {
 // ncclGin descriptor helpers:
 
 #if NCCL_CHECK_CUDACC
-template<typename Descriptor>
-NCCL_DEVICE_INLINE constexpr bool ncclGin_isDescriptor(Descriptor) { return false; }
-template<typename Descriptor>
-NCCL_DEVICE_INLINE constexpr ncclGinDescriptorSmem* ncclGin_getDescriptor(Descriptor) { return nullptr; }
+template <typename Descriptor>
+NCCL_DEVICE_INLINE constexpr bool ncclGin_isDescriptor(Descriptor) {
+  return false;
+}
+template <typename Descriptor>
+NCCL_DEVICE_INLINE constexpr ncclGinDescriptorSmem* ncclGin_getDescriptor(Descriptor) {
+  return nullptr;
+}
 
-NCCL_DEVICE_INLINE constexpr bool ncclGin_isDescriptor(ncclGin_DescriptorSmem) { return true; }
-NCCL_DEVICE_INLINE constexpr ncclGinDescriptorSmem* ncclGin_getDescriptor(ncclGin_DescriptorSmem arg) { return arg.descriptor; }
+NCCL_DEVICE_INLINE constexpr bool ncclGin_isDescriptor(ncclGin_DescriptorSmem) {
+  return true;
+}
+NCCL_DEVICE_INLINE constexpr ncclGinDescriptorSmem* ncclGin_getDescriptor(ncclGin_DescriptorSmem arg) {
+  return arg.descriptor;
+}
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
 // ncclGin signal helpers:
 
 #if NCCL_CHECK_CUDACC
-template<typename RemoteAction>
-NCCL_DEVICE_INLINE constexpr ncclGinSignalOp_t ncclGin_getSignalOp(RemoteAction) { return (ncclGinSignalOp_t)0; }
-template<typename RemoteAction>
-NCCL_DEVICE_INLINE constexpr uint64_t ncclGin_getSignalOpArg(RemoteAction) { return 0; }
-template<typename RemoteAction>
+template <typename RemoteAction>
+NCCL_DEVICE_INLINE constexpr ncclGinSignalOp_t ncclGin_getSignalOp(RemoteAction) {
+  return (ncclGinSignalOp_t)0;
+}
+template <typename RemoteAction>
+NCCL_DEVICE_INLINE constexpr uint64_t ncclGin_getSignalOpArg(RemoteAction) {
+  return 0;
+}
+template <typename RemoteAction>
 NCCL_DEVICE_INLINE constexpr ncclGinSignalDescriptor ncclGin_getSignalDescriptor(ncclGin const&, RemoteAction) {
   ncclGinSignalDescriptor desc{};
   desc.type = NCCL_GIN_SIGNAL_TYPE_NONE;
@@ -192,18 +202,24 @@ NCCL_DEVICE_INLINE constexpr ncclGinSignalDescriptor ncclGin_getSignalDescriptor
 #endif
 
 #if NCCL_CHECK_CUDACC
-NCCL_DEVICE_INLINE constexpr ncclGinSignalDescriptor ncclGin_getSignalDescriptor(ncclGin const& net, ncclGin_SignalInc arg) {
+NCCL_DEVICE_INLINE constexpr ncclGinSignalDescriptor ncclGin_getSignalDescriptor(ncclGin const& net,
+                                                                                 ncclGin_SignalInc arg) {
   ncclGinSignalDescriptor desc{};
   desc.type = NCCL_GIN_SIGNAL_TYPE_INDEXED;
   desc.indexedSignal.signalId = arg.signal;
   return desc;
 }
-NCCL_DEVICE_INLINE constexpr ncclGinSignalOp_t ncclGin_getSignalOp(ncclGin_SignalInc) { return ncclGinSignalInc; }
-NCCL_DEVICE_INLINE constexpr uint64_t ncclGin_getSignalOpArg(ncclGin_SignalInc) { return 1; }
+NCCL_DEVICE_INLINE constexpr ncclGinSignalOp_t ncclGin_getSignalOp(ncclGin_SignalInc) {
+  return ncclGinSignalInc;
+}
+NCCL_DEVICE_INLINE constexpr uint64_t ncclGin_getSignalOpArg(ncclGin_SignalInc) {
+  return 1;
+}
 #endif
 
 #if NCCL_CHECK_CUDACC
-NCCL_DEVICE_INLINE constexpr ncclGinSignalDescriptor ncclGin_getSignalDescriptor(ncclGin const& net, ncclGin_SignalAdd arg) {
+NCCL_DEVICE_INLINE constexpr ncclGinSignalDescriptor ncclGin_getSignalDescriptor(ncclGin const& net,
+                                                                                 ncclGin_SignalAdd arg) {
   ncclGinSignalDescriptor desc{};
   desc.type = NCCL_GIN_SIGNAL_TYPE_INDEXED;
   desc.indexedSignal.signalId = arg.signal;
@@ -212,7 +228,9 @@ NCCL_DEVICE_INLINE constexpr ncclGinSignalDescriptor ncclGin_getSignalDescriptor
 NCCL_DEVICE_INLINE constexpr ncclGinSignalOp_t ncclGin_getSignalOp(ncclGin_SignalAdd) {
   return ncclGinSignalAdd;
 }
-NCCL_DEVICE_INLINE constexpr uint64_t ncclGin_getSignalOpArg(ncclGin_SignalAdd arg) { return arg.value; }
+NCCL_DEVICE_INLINE constexpr uint64_t ncclGin_getSignalOpArg(ncclGin_SignalAdd arg) {
+  return arg.value;
+}
 #endif
 
 #if NCCL_CHECK_CUDACC
@@ -227,7 +245,9 @@ NCCL_DEVICE_INLINE ncclGinSignalDescriptor ncclGin_getSignalDescriptor(ncclGin c
 NCCL_DEVICE_INLINE constexpr ncclGinSignalOp_t ncclGin_getSignalOp(ncclGin_VASignalInc arg) {
   return ncclGinSignalInc;
 }
-NCCL_DEVICE_INLINE constexpr uint64_t ncclGin_getSignalOpArg(ncclGin_VASignalInc arg) { return 1; }
+NCCL_DEVICE_INLINE constexpr uint64_t ncclGin_getSignalOpArg(ncclGin_VASignalInc arg) {
+  return 1;
+}
 #endif
 
 #if NCCL_CHECK_CUDACC
@@ -242,23 +262,32 @@ NCCL_DEVICE_INLINE ncclGinSignalDescriptor ncclGin_getSignalDescriptor(ncclGin c
 NCCL_DEVICE_INLINE constexpr ncclGinSignalOp_t ncclGin_getSignalOp(ncclGin_VASignalAdd arg) {
   return ncclGinSignalAdd;
 }
-NCCL_DEVICE_INLINE constexpr uint64_t ncclGin_getSignalOpArg(ncclGin_VASignalAdd arg) { return arg.value; }
+NCCL_DEVICE_INLINE constexpr uint64_t ncclGin_getSignalOpArg(ncclGin_VASignalAdd arg) {
+  return arg.value;
+}
 #endif
-
 
 ////////////////////////////////////////////////////////////////////////////////
 // ncclGin counter helpers:
 
 #if NCCL_CHECK_CUDACC
-template<typename LocalAction>
-NCCL_DEVICE_INLINE constexpr bool ncclGin_isCounter(LocalAction) { return false; }
-template<typename LocalAction>
-NCCL_DEVICE_INLINE constexpr ncclGinCounter_t ncclGin_getCounterId(ncclGin const&, LocalAction) { return -1u; }
+template <typename LocalAction>
+NCCL_DEVICE_INLINE constexpr bool ncclGin_isCounter(LocalAction) {
+  return false;
+}
+template <typename LocalAction>
+NCCL_DEVICE_INLINE constexpr ncclGinCounter_t ncclGin_getCounterId(ncclGin const&, LocalAction) {
+  return -1u;
+}
 #endif
 
 #if NCCL_CHECK_CUDACC
-NCCL_DEVICE_INLINE constexpr bool ncclGin_isCounter(ncclGin_CounterInc) { return true; }
-NCCL_DEVICE_INLINE constexpr ncclGinCounter_t ncclGin_getCounterId(ncclGin const& net, ncclGin_CounterInc arg) { return arg.counter; }
+NCCL_DEVICE_INLINE constexpr bool ncclGin_isCounter(ncclGin_CounterInc) {
+  return true;
+}
+NCCL_DEVICE_INLINE constexpr ncclGinCounter_t ncclGin_getCounterId(ncclGin const& net, ncclGin_CounterInc arg) {
+  return arg.counter;
+}
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -267,25 +296,25 @@ NCCL_DEVICE_INLINE constexpr ncclGinCounter_t ncclGin_getCounterId(ncclGin const
 // ncclGin bufType helpers:
 
 #if NCCL_CHECK_CUDACC
-NCCL_DEVICE_INLINE constexpr bool ncclGin_isDeviceOnly(ncclGin_SegmentDevice) { return true; }
-NCCL_DEVICE_INLINE constexpr bool ncclGin_isDeviceOnly(ncclGin_SegmentMixed) { return false; }
-NCCL_DEVICE_INLINE constexpr bool ncclGin_isDeviceOnly(ncclGin_SegmentHostNuma) { return false; }
+NCCL_DEVICE_INLINE constexpr bool ncclGin_isDeviceOnly(ncclGin_SegmentDevice) {
+  return true;
+}
+NCCL_DEVICE_INLINE constexpr bool ncclGin_isDeviceOnly(ncclGin_SegmentMixed) {
+  return false;
+}
+NCCL_DEVICE_INLINE constexpr bool ncclGin_isDeviceOnly(ncclGin_SegmentHostNuma) {
+  return false;
+}
 #endif
 ////////////////////////////////////////////////////////////////////////////////
 
 #if NCCL_CHECK_CUDACC
-NCCL_DEVICE_INLINE void ncclGinPut_v2(
-    ncclGin_C* net,
-    ncclTeam team, int peer,
-    ncclWindow_t dstWin, size_t dstOffset,
-    ncclWindow_t srcWin, size_t srcOffset, size_t bytes,
-    bool isSignal, ncclGinSignal_t signalId, ncclGinSignalOp_t signalOp, uint64_t signalOpArg,
-    bool isCounter, ncclGinCounter_t counterId,
-    ncclCoopAny coop,
-    bool isDescriptor, ncclGinDescriptorSmem* descriptor,
-    cuda::thread_scope givenRelease, cuda::thread_scope requiredRelease,
-    uint32_t optFlags
-  ) {
+NCCL_DEVICE_INLINE void ncclGinPut_v2(ncclGin_C* net, ncclTeam team, int peer, ncclWindow_t dstWin, size_t dstOffset,
+                                      ncclWindow_t srcWin, size_t srcOffset, size_t bytes, bool isSignal,
+                                      ncclGinSignal_t signalId, ncclGinSignalOp_t signalOp, uint64_t signalOpArg,
+                                      bool isCounter, ncclGinCounter_t counterId, ncclCoopAny coop, bool isDescriptor,
+                                      ncclGinDescriptorSmem* descriptor, cuda::thread_scope givenRelease,
+                                      cuda::thread_scope requiredRelease, uint32_t optFlags) {
   using nccl::utility::loadConst;
   using nccl::gin::internal::teamRankToGinRank;
   ncclGinCtx ctx = ncclGin_C_makeCtx(net);
@@ -297,103 +326,62 @@ NCCL_DEVICE_INLINE void ncclGinPut_v2(
     signal.indexedSignal.signalId = signalId;
   }
   if (coop.thread_rank() == 0) {
-    ncclGinCall<ncclGinApi_Put>(ctx,
-      ncclCoopThread(), teamRankToGinRank(net->comm, team, peer), /*hasWins=*/true,
-      loadConst(&dstWin->ginWins[net->connectionId]),
-      4096*size_t(loadConst(&dstWin->ginOffset4K)) + dstOffset,
-      loadConst(&srcWin->ginWins[net->connectionId]),
-      4096*size_t(loadConst(&srcWin->ginOffset4K)) + srcOffset, bytes,
-      signal,
-      signalOp,
-      signalOpArg,
-      isCounter,
-      counterId,
-      isDescriptor,
-      descriptor,
-      requiredRelease,
-      givenRelease,
-      optFlags
-    );
+    ncclGinCall<ncclGinApi_Put>(ctx, ncclCoopThread(), teamRankToGinRank(net->comm, team, peer), /*hasWins=*/true,
+                                loadConst(&dstWin->ginWins[net->connectionId]),
+                                4096 * size_t(loadConst(&dstWin->ginOffset4K)) + dstOffset,
+                                loadConst(&srcWin->ginWins[net->connectionId]),
+                                4096 * size_t(loadConst(&srcWin->ginOffset4K)) + srcOffset, bytes, signal, signalOp,
+                                signalOpArg, isCounter, counterId, isDescriptor, descriptor, requiredRelease,
+                                givenRelease, optFlags);
   }
   coop.sync();
 }
 
-NCCL_DEVICE_INLINE void ncclGinPut(
-    ncclGin_C* net,
-    ncclTeam team, int peer,
-    ncclWindow_t dstWin, size_t dstOffset,
-    ncclWindow_t srcWin, size_t srcOffset, size_t bytes,
-    bool isSignal, ncclGinSignal_t signalId, ncclGinSignalOp_t signalOp, uint64_t signalOpArg,
-    bool isCounter, ncclGinCounter_t counterId,
-    ncclCoopAny coop,
-    bool isDescriptor, ncclGinDescriptorSmem* descriptor,
-    cuda::thread_scope givenRelease, cuda::thread_scope requiredRelease
-  ) {
-  ncclGinPut_v2(net, team, peer, dstWin, dstOffset, srcWin, srcOffset, bytes, isSignal, signalId,
-               signalOp, signalOpArg, isCounter, counterId, coop, isDescriptor, descriptor,
-               givenRelease, requiredRelease, ncclGinOptFlagsDefault);
+NCCL_DEVICE_INLINE void ncclGinPut(ncclGin_C* net, ncclTeam team, int peer, ncclWindow_t dstWin, size_t dstOffset,
+                                   ncclWindow_t srcWin, size_t srcOffset, size_t bytes, bool isSignal,
+                                   ncclGinSignal_t signalId, ncclGinSignalOp_t signalOp, uint64_t signalOpArg,
+                                   bool isCounter, ncclGinCounter_t counterId, ncclCoopAny coop, bool isDescriptor,
+                                   ncclGinDescriptorSmem* descriptor, cuda::thread_scope givenRelease,
+                                   cuda::thread_scope requiredRelease) {
+  ncclGinPut_v2(net, team, peer, dstWin, dstOffset, srcWin, srcOffset, bytes, isSignal, signalId, signalOp, signalOpArg,
+                isCounter, counterId, coop, isDescriptor, descriptor, givenRelease, requiredRelease,
+                ncclGinOptFlagsDefault);
 }
 
-template<unsigned beMask>
-template<
-  typename RemoteAction, // one of ncclGin_{None|SignalInc}
-  typename LocalAction, // one of ncclGin_{None|CounterInc}
-  typename Coop,
-  typename DescriptorSmem,
-  typename SegmentType // one of ncclGin_{SegmentDevice|SegmentMixed|SegmentHostNuma}
->
+template <unsigned beMask>
+template <typename RemoteAction, // one of ncclGin_{None|SignalInc}
+          typename LocalAction, // one of ncclGin_{None|CounterInc}
+          typename Coop, typename DescriptorSmem,
+          typename SegmentType // one of ncclGin_{SegmentDevice|SegmentMixed|SegmentHostNuma}
+          >
 NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::put(
-    ncclTeam team, int peer,
-    ncclWindow_t dstWin, size_t dstOffset,
-    ncclWindow_t srcWin, size_t srcOffset, size_t bytes,
-    RemoteAction remoteAction, LocalAction localAction,
-    Coop coop,
-    DescriptorSmem descriptor,
-    cuda::thread_scope givenRelease, cuda::thread_scope requiredRelease,
-    uint32_t optFlags, SegmentType bufType
-  ) const {
+  ncclTeam team, int peer, ncclWindow_t dstWin, size_t dstOffset, ncclWindow_t srcWin, size_t srcOffset, size_t bytes,
+  RemoteAction remoteAction, LocalAction localAction, Coop coop, DescriptorSmem descriptor,
+  cuda::thread_scope givenRelease, cuda::thread_scope requiredRelease, uint32_t optFlags, SegmentType bufType) const {
   using nccl::utility::loadConst;
   using nccl::gin::internal::teamRankToGinRank;
   ncclGinCtx_M<beMask> ctx = this->_makeCtx();
   coop.sync();
   if (coop.thread_rank() == 0) {
     if (ncclGin_isDeviceOnly(bufType)) {
-      ncclGinCall<ncclGinApi_Put>(ctx,
-          ncclCoopThread(), teamRankToGinRank(this->comm, team, peer), /*hasWins=*/true,
-          loadConst(&dstWin->ginWins[this->connectionId]),
-          4096*size_t(loadConst(&dstWin->ginOffset4K)) + dstOffset,
-          loadConst(&srcWin->ginWins[this->connectionId]),
-          4096*size_t(loadConst(&srcWin->ginOffset4K)) + srcOffset, bytes,
-          ncclGin_getSignalDescriptor(*this, remoteAction),
-          ncclGin_getSignalOp(remoteAction),
-          ncclGin_getSignalOpArg(remoteAction),
-          ncclGin_isCounter(localAction),
-          ncclGin_getCounterId(*this, localAction),
-          ncclGin_isDescriptor(descriptor),
-          ncclGin_getDescriptor(descriptor),
-          requiredRelease,
-          givenRelease,
-          optFlags
-          );
+      ncclGinCall<ncclGinApi_Put>(
+        ctx, ncclCoopThread(), teamRankToGinRank(this->comm, team, peer), /*hasWins=*/true,
+        loadConst(&dstWin->ginWins[this->connectionId]), 4096 * size_t(loadConst(&dstWin->ginOffset4K)) + dstOffset,
+        loadConst(&srcWin->ginWins[this->connectionId]), 4096 * size_t(loadConst(&srcWin->ginOffset4K)) + srcOffset,
+        bytes, ncclGin_getSignalDescriptor(*this, remoteAction), ncclGin_getSignalOp(remoteAction),
+        ncclGin_getSignalOpArg(remoteAction), ncclGin_isCounter(localAction), ncclGin_getCounterId(*this, localAction),
+        ncclGin_isDescriptor(descriptor), ncclGin_getDescriptor(descriptor), requiredRelease, givenRelease, optFlags);
     } else {
       if (srcWin->numSegments == 1 && dstWin->numSegments == 1) {
-        ncclGinCall<ncclGinApi_Put>(ctx,
-            ncclCoopThread(), teamRankToGinRank(this->comm, team, peer), /*hasWins=*/true,
-            loadConst(&dstWin->ginWins[this->connectionId]),
-            4096*size_t(loadConst(&dstWin->ginOffset4K)) + dstOffset,
-            loadConst(&srcWin->ginWins[this->connectionId]),
-            4096*size_t(loadConst(&srcWin->ginOffset4K)) + srcOffset, bytes,
-            ncclGin_getSignalDescriptor(*this, remoteAction),
-            ncclGin_getSignalOp(remoteAction),
-            ncclGin_getSignalOpArg(remoteAction),
-            ncclGin_isCounter(localAction),
-            ncclGin_getCounterId(*this, localAction),
-            ncclGin_isDescriptor(descriptor),
-            ncclGin_getDescriptor(descriptor),
-            cuda::thread_scope_system, // for safety, escalate to system regardless of what the user requested
-            givenRelease,
-            optFlags
-            );
+        ncclGinCall<ncclGinApi_Put>(
+          ctx, ncclCoopThread(), teamRankToGinRank(this->comm, team, peer), /*hasWins=*/true,
+          loadConst(&dstWin->ginWins[this->connectionId]), 4096 * size_t(loadConst(&dstWin->ginOffset4K)) + dstOffset,
+          loadConst(&srcWin->ginWins[this->connectionId]), 4096 * size_t(loadConst(&srcWin->ginOffset4K)) + srcOffset,
+          bytes, ncclGin_getSignalDescriptor(*this, remoteAction), ncclGin_getSignalOp(remoteAction),
+          ncclGin_getSignalOpArg(remoteAction), ncclGin_isCounter(localAction),
+          ncclGin_getCounterId(*this, localAction), ncclGin_isDescriptor(descriptor), ncclGin_getDescriptor(descriptor),
+          cuda::thread_scope_system, // for safety, escalate to system regardless of what the user requested
+          givenRelease, optFlags);
       } else {
         // Multi-segment case. The puts are chunked to handle multiple registration entries and src/dst windows that potentially have a different number of segments
         int srcSeg;
@@ -410,30 +398,24 @@ NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::put(
           struct ncclSegmentWindow const& dstSegmentWindow = dstWin->ginMultiSegmentWins[dstSeg];
           struct ncclSegmentWindow const& srcSegmentWindow = srcWin->ginMultiSegmentWins[srcSeg];
           if (!doneSysmemFence && srcSegmentWindow.memType == CU_MEM_LOCATION_TYPE_HOST_NUMA) {
-            localRequiredRelease = cuda::thread_scope_system; // for safety, escalate to system regardless of what the user requested
+            localRequiredRelease =
+              cuda::thread_scope_system; // for safety, escalate to system regardless of what the user requested
             doneSysmemFence = true;
           }
           const size_t srcRemaining = srcSegmentWindow.segmentSize - srcSegOffset;
           const size_t dstRemaining = dstSegmentWindow.segmentSize - dstSegOffset;
           const size_t putSize = nccl::gin::internal::getSegmentChunkSize(srcRemaining, dstRemaining, remaining);
           const bool isLastPut = (remaining == putSize);
-          ncclGinCall<ncclGinApi_Put>(ctx,
-              ncclCoopThread(), teamRankToGinRank(this->comm, team, peer), /*hasWins=*/true,
-              loadConst(&dstWin->ginMultiSegmentWins[dstSeg].ginWins[this->connectionId]),
-              dstSegOffset,
-              loadConst(&srcWin->ginMultiSegmentWins[srcSeg].ginWins[this->connectionId]),
-              srcSegOffset, putSize,
-              isLastPut ? ncclGin_getSignalDescriptor(*this, remoteAction) : ncclGin_getSignalDescriptor(*this, ncclGin_None{}),
-              ncclGin_getSignalOp(remoteAction),
-              ncclGin_getSignalOpArg(remoteAction),
-              isLastPut ? ncclGin_isCounter(localAction) : false,
-              ncclGin_getCounterId(*this, localAction),
-              ncclGin_isDescriptor(descriptor),
-              ncclGin_getDescriptor(descriptor),
-              localRequiredRelease,
-              givenRelease,
-              optFlags
-              );
+          ncclGinCall<ncclGinApi_Put>(
+            ctx, ncclCoopThread(), teamRankToGinRank(this->comm, team, peer), /*hasWins=*/true,
+            loadConst(&dstWin->ginMultiSegmentWins[dstSeg].ginWins[this->connectionId]), dstSegOffset,
+            loadConst(&srcWin->ginMultiSegmentWins[srcSeg].ginWins[this->connectionId]), srcSegOffset, putSize,
+            isLastPut ? ncclGin_getSignalDescriptor(*this, remoteAction) :
+                        ncclGin_getSignalDescriptor(*this, ncclGin_None{}),
+            ncclGin_getSignalOp(remoteAction), ncclGin_getSignalOpArg(remoteAction),
+            isLastPut ? ncclGin_isCounter(localAction) : false, ncclGin_getCounterId(*this, localAction),
+            ncclGin_isDescriptor(descriptor), ncclGin_getDescriptor(descriptor), localRequiredRelease, givenRelease,
+            optFlags);
           remaining -= putSize;
           nccl::gin::internal::advanceSegmentCursor(&srcSeg, &srcSegOffset, putSize, srcSegmentWindow.segmentSize);
           nccl::gin::internal::advanceSegmentCursor(&dstSeg, &dstSegOffset, putSize, dstSegmentWindow.segmentSize);
@@ -447,82 +429,51 @@ NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::put(
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<unsigned beMask>
-template<
-  typename T,
-  typename RemoteAction, // one of ncclGin_{None|SignalInc}
-  typename LocalAction, // one of ncclGin_{None|CounterInc}
-  typename Coop,
-  typename DescriptorSmem,
-  typename SegmentType
->
+template <unsigned beMask>
+template <typename T,
+          typename RemoteAction, // one of ncclGin_{None|SignalInc}
+          typename LocalAction, // one of ncclGin_{None|CounterInc}
+          typename Coop, typename DescriptorSmem, typename SegmentType>
 NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::put(
-    ncclTeam team, int peer,
-    ncclSymPtr<T> dstElts, ncclSymPtr<T> srcElts, size_t nElts,
-    RemoteAction remoteAction, LocalAction localAction,
-    Coop coop,
-    DescriptorSmem descriptor,
-    cuda::thread_scope givenRelease,
-    cuda::thread_scope requiredRelease,
-    uint32_t optFlags, SegmentType bufType
-  ) const {
-  this->put(
-    team, peer, dstElts.window, dstElts.offset, srcElts.window, srcElts.offset, nElts*sizeof(T),
-    remoteAction, localAction, coop, descriptor, givenRelease, requiredRelease, optFlags, bufType
-  );
+  ncclTeam team, int peer, ncclSymPtr<T> dstElts, ncclSymPtr<T> srcElts, size_t nElts, RemoteAction remoteAction,
+  LocalAction localAction, Coop coop, DescriptorSmem descriptor, cuda::thread_scope givenRelease,
+  cuda::thread_scope requiredRelease, uint32_t optFlags, SegmentType bufType) const {
+  this->put(team, peer, dstElts.window, dstElts.offset, srcElts.window, srcElts.offset, nElts * sizeof(T), remoteAction,
+            localAction, coop, descriptor, givenRelease, requiredRelease, optFlags, bufType);
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<unsigned beMask>
-template<
-  typename T,
-  typename RemoteAction, // one of ncclGin_{None|SignalInc}
-  typename Coop,
-  typename DescriptorSmem
->
+template <unsigned beMask>
+template <typename T,
+          typename RemoteAction, // one of ncclGin_{None|SignalInc}
+          typename Coop, typename DescriptorSmem>
 NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::putValue(
-    ncclTeam team, int peer,
-    ncclWindow_t dstWin, size_t dstOffset, T value,
-    RemoteAction remoteAction,
-    Coop coop,
-    DescriptorSmem descriptor,
-    cuda::thread_scope givenRelease,
-    cuda::thread_scope requiredRelease,
-    uint32_t optFlags
-  ) const {
+  ncclTeam team, int peer, ncclWindow_t dstWin, size_t dstOffset, T value, RemoteAction remoteAction, Coop coop,
+  DescriptorSmem descriptor, cuda::thread_scope givenRelease, cuda::thread_scope requiredRelease,
+  uint32_t optFlags) const {
   static_assert(sizeof(T) <= 8, "Required: sizeof(T) <= 8");
   using nccl::utility::loadConst;
   using nccl::gin::internal::teamRankToGinRank;
   coop.sync();
   if (coop.thread_rank() == 0) {
-    ncclGinCall<ncclGinApi_PutValue>(this->_makeCtx(),
-      ncclCoopThread(), teamRankToGinRank(this->comm, team, peer),
-      loadConst(&dstWin->ginWins[this->connectionId]),
-      4096*size_t(loadConst(&dstWin->ginOffset4K)) + dstOffset,
-      value,
-      ncclGin_getSignalDescriptor(*this, remoteAction),
-      ncclGin_getSignalOp(remoteAction),
-      ncclGin_getSignalOpArg(remoteAction),
-      ncclGin_isDescriptor(descriptor),
-      ncclGin_getDescriptor(descriptor),
-      requiredRelease, givenRelease, optFlags
-    );
+    ncclGinCall<ncclGinApi_PutValue>(this->_makeCtx(), ncclCoopThread(), teamRankToGinRank(this->comm, team, peer),
+                                     loadConst(&dstWin->ginWins[this->connectionId]),
+                                     4096 * size_t(loadConst(&dstWin->ginOffset4K)) + dstOffset, value,
+                                     ncclGin_getSignalDescriptor(*this, remoteAction),
+                                     ncclGin_getSignalOp(remoteAction), ncclGin_getSignalOpArg(remoteAction),
+                                     ncclGin_isDescriptor(descriptor), ncclGin_getDescriptor(descriptor),
+                                     requiredRelease, givenRelease, optFlags);
   }
   coop.sync();
 }
 
-NCCL_DEVICE_INLINE void ncclGinPutValue_v2(
-    ncclGin_C* net,
-    ncclTeam team, int peer,
-    ncclWindow_t dstWin, size_t dstOffset,
-    uint64_t value, size_t size,
-    bool isSignal, ncclGinSignal_t signalId, ncclGinSignalOp_t signalOp, uint64_t signalOpArg,
-    ncclCoopAny coop,
-    bool isDescriptor, ncclGinDescriptorSmem* descriptor,
-    cuda::thread_scope givenRelease, cuda::thread_scope requiredRelease,
-    uint32_t optFlags
-  ) {
+NCCL_DEVICE_INLINE void ncclGinPutValue_v2(ncclGin_C* net, ncclTeam team, int peer, ncclWindow_t dstWin,
+                                           size_t dstOffset, uint64_t value, size_t size, bool isSignal,
+                                           ncclGinSignal_t signalId, ncclGinSignalOp_t signalOp, uint64_t signalOpArg,
+                                           ncclCoopAny coop, bool isDescriptor, ncclGinDescriptorSmem* descriptor,
+                                           cuda::thread_scope givenRelease, cuda::thread_scope requiredRelease,
+                                           uint32_t optFlags) {
   using nccl::utility::loadConst;
   using nccl::gin::internal::teamRankToGinRank;
   coop.sync();
@@ -536,119 +487,83 @@ NCCL_DEVICE_INLINE void ncclGinPutValue_v2(
     ncclGinCtx ctx = ncclGin_C_makeCtx(net);
     // Dispatch based on size to call with appropriate type
     if (size == 1) {
-      ncclGinCall<ncclGinApi_PutValue>(ctx,
-        ncclCoopThread(), teamRankToGinRank(net->comm, team, peer),
-        loadConst(&dstWin->ginWins[net->connectionId]),
-        4096*size_t(loadConst(&dstWin->ginOffset4K)) + dstOffset,
-        (uint8_t)value,
-        signal, signalOp, signalOpArg,
-        isDescriptor, descriptor, requiredRelease, givenRelease, optFlags);
+      ncclGinCall<ncclGinApi_PutValue>(ctx, ncclCoopThread(), teamRankToGinRank(net->comm, team, peer),
+                                       loadConst(&dstWin->ginWins[net->connectionId]),
+                                       4096 * size_t(loadConst(&dstWin->ginOffset4K)) + dstOffset, (uint8_t)value,
+                                       signal, signalOp, signalOpArg, isDescriptor, descriptor, requiredRelease,
+                                       givenRelease, optFlags);
     } else if (size == 2) {
-      ncclGinCall<ncclGinApi_PutValue>(ctx,
-        ncclCoopThread(), teamRankToGinRank(net->comm, team, peer),
-        loadConst(&dstWin->ginWins[net->connectionId]),
-        4096*size_t(loadConst(&dstWin->ginOffset4K)) + dstOffset,
-        (uint16_t)value,
-        signal, signalOp, signalOpArg,
-        isDescriptor, descriptor, requiredRelease, givenRelease, optFlags);
+      ncclGinCall<ncclGinApi_PutValue>(ctx, ncclCoopThread(), teamRankToGinRank(net->comm, team, peer),
+                                       loadConst(&dstWin->ginWins[net->connectionId]),
+                                       4096 * size_t(loadConst(&dstWin->ginOffset4K)) + dstOffset, (uint16_t)value,
+                                       signal, signalOp, signalOpArg, isDescriptor, descriptor, requiredRelease,
+                                       givenRelease, optFlags);
     } else if (size == 4) {
-      ncclGinCall<ncclGinApi_PutValue>(ctx,
-        ncclCoopThread(), teamRankToGinRank(net->comm, team, peer),
-        loadConst(&dstWin->ginWins[net->connectionId]),
-        4096*size_t(loadConst(&dstWin->ginOffset4K)) + dstOffset,
-        (uint32_t)value,
-        signal, signalOp, signalOpArg,
-        isDescriptor, descriptor, requiredRelease, givenRelease, optFlags);
+      ncclGinCall<ncclGinApi_PutValue>(ctx, ncclCoopThread(), teamRankToGinRank(net->comm, team, peer),
+                                       loadConst(&dstWin->ginWins[net->connectionId]),
+                                       4096 * size_t(loadConst(&dstWin->ginOffset4K)) + dstOffset, (uint32_t)value,
+                                       signal, signalOp, signalOpArg, isDescriptor, descriptor, requiredRelease,
+                                       givenRelease, optFlags);
     } else {
-      ncclGinCall<ncclGinApi_PutValue>(ctx,
-        ncclCoopThread(), teamRankToGinRank(net->comm, team, peer),
-        loadConst(&dstWin->ginWins[net->connectionId]),
-        4096*size_t(loadConst(&dstWin->ginOffset4K)) + dstOffset,
-        value,
-        signal, signalOp, signalOpArg,
-        isDescriptor, descriptor, requiredRelease, givenRelease, optFlags);
+      ncclGinCall<ncclGinApi_PutValue>(ctx, ncclCoopThread(), teamRankToGinRank(net->comm, team, peer),
+                                       loadConst(&dstWin->ginWins[net->connectionId]),
+                                       4096 * size_t(loadConst(&dstWin->ginOffset4K)) + dstOffset, value, signal,
+                                       signalOp, signalOpArg, isDescriptor, descriptor, requiredRelease, givenRelease,
+                                       optFlags);
     }
   }
   coop.sync();
 }
 
-NCCL_DEVICE_INLINE void ncclGinPutValue(
-    ncclGin_C* net,
-    ncclTeam team, int peer,
-    ncclWindow_t dstWin, size_t dstOffset,
-    uint64_t value, size_t size,
-    bool isSignal, ncclGinSignal_t signalId, ncclGinSignalOp_t signalOp, uint64_t signalOpArg,
-    ncclCoopAny coop,
-    bool isDescriptor, ncclGinDescriptorSmem* descriptor,
-    cuda::thread_scope givenRelease, cuda::thread_scope requiredRelease
-  ) {
-  ncclGinPutValue_v2(net, team, peer, dstWin, dstOffset, value, size, isSignal, signalId, signalOp,
-                    signalOpArg, coop, isDescriptor, descriptor, givenRelease, requiredRelease,
-                    ncclGinOptFlagsDefault);
+NCCL_DEVICE_INLINE void ncclGinPutValue(ncclGin_C* net, ncclTeam team, int peer, ncclWindow_t dstWin, size_t dstOffset,
+                                        uint64_t value, size_t size, bool isSignal, ncclGinSignal_t signalId,
+                                        ncclGinSignalOp_t signalOp, uint64_t signalOpArg, ncclCoopAny coop,
+                                        bool isDescriptor, ncclGinDescriptorSmem* descriptor,
+                                        cuda::thread_scope givenRelease, cuda::thread_scope requiredRelease) {
+  ncclGinPutValue_v2(net, team, peer, dstWin, dstOffset, value, size, isSignal, signalId, signalOp, signalOpArg, coop,
+                     isDescriptor, descriptor, givenRelease, requiredRelease, ncclGinOptFlagsDefault);
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<unsigned beMask>
-template<
-  typename T,
-  typename RemoteAction, // one of ncclGin_{None|SignalInc}
-  typename Coop,
-  typename DescriptorSmem
->
+template <unsigned beMask>
+template <typename T,
+          typename RemoteAction, // one of ncclGin_{None|SignalInc}
+          typename Coop, typename DescriptorSmem>
 NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::putValue(
-    ncclTeam team, int peer,
-    ncclSymPtr<T> dst, T value,
-    RemoteAction remoteAction,
-    Coop coop,
-    DescriptorSmem descriptor,
-    cuda::thread_scope givenRelease,
-    cuda::thread_scope requiredRelease,
-    uint32_t optFlags
-  ) const {
+  ncclTeam team, int peer, ncclSymPtr<T> dst, T value, RemoteAction remoteAction, Coop coop, DescriptorSmem descriptor,
+  cuda::thread_scope givenRelease, cuda::thread_scope requiredRelease, uint32_t optFlags) const {
   static_assert(sizeof(T) <= sizeof(uint64_t), "Required: T must fit into 64 bits");
-  this->putValue(
-    team, peer, dst.window, dst.offset, value, remoteAction, coop, descriptor, givenRelease, requiredRelease, optFlags
-  );
+  this->putValue(team, peer, dst.window, dst.offset, value, remoteAction, coop, descriptor, givenRelease,
+                 requiredRelease, optFlags);
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<unsigned beMask>
-template<typename RemoteAction, typename Coop, typename DescriptorSmem>
-NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::signal(
-    ncclTeam team, int peer, RemoteAction action, Coop coop, DescriptorSmem descriptor,
-    cuda::thread_scope givenRelease,
-    cuda::thread_scope requiredRelease,
-    uint32_t optFlags
-  ) const {
+template <unsigned beMask>
+template <typename RemoteAction, typename Coop, typename DescriptorSmem>
+NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::signal(ncclTeam team, int peer, RemoteAction action, Coop coop,
+                                                            DescriptorSmem descriptor, cuda::thread_scope givenRelease,
+                                                            cuda::thread_scope requiredRelease,
+                                                            uint32_t optFlags) const {
   using nccl::gin::internal::teamRankToGinRank;
   coop.sync();
   if (coop.thread_rank() == 0) {
-    ncclGinCall<ncclGinApi_Put>(this->_makeCtx(),
-      ncclCoopThread(), teamRankToGinRank(this->comm, team, peer),
-      /*hasWins=*/false, nullptr, 0, nullptr, 0, 0,
-      ncclGin_getSignalDescriptor(*this, action),
-      ncclGin_getSignalOp(action),
-      ncclGin_getSignalOpArg(action),
-      /*hasCounter=*/false, 0,
-      ncclGin_isDescriptor(descriptor),
-      ncclGin_getDescriptor(descriptor),
-      requiredRelease, givenRelease, optFlags
-    );
+    ncclGinCall<ncclGinApi_Put>(this->_makeCtx(), ncclCoopThread(), teamRankToGinRank(this->comm, team, peer),
+                                /*hasWins=*/false, nullptr, 0, nullptr, 0, 0,
+                                ncclGin_getSignalDescriptor(*this, action), ncclGin_getSignalOp(action),
+                                ncclGin_getSignalOpArg(action),
+                                /*hasCounter=*/false, 0, ncclGin_isDescriptor(descriptor),
+                                ncclGin_getDescriptor(descriptor), requiredRelease, givenRelease, optFlags);
   }
   coop.sync();
 }
 
-NCCL_DEVICE_INLINE void ncclGinSignal_v2(
-    ncclGin_C* net,
-    ncclTeam team, int peer,
-    bool isSignal, ncclGinSignal_t signalId, ncclGinSignalOp_t signalOp, uint64_t signalOpArg,
-    ncclCoopAny coop,
-    bool isDescriptor, ncclGinDescriptorSmem* descriptor,
-    cuda::thread_scope givenRelease, cuda::thread_scope requiredRelease,
-    uint32_t optFlags
-  ) {
+NCCL_DEVICE_INLINE void ncclGinSignal_v2(ncclGin_C* net, ncclTeam team, int peer, bool isSignal,
+                                         ncclGinSignal_t signalId, ncclGinSignalOp_t signalOp, uint64_t signalOpArg,
+                                         ncclCoopAny coop, bool isDescriptor, ncclGinDescriptorSmem* descriptor,
+                                         cuda::thread_scope givenRelease, cuda::thread_scope requiredRelease,
+                                         uint32_t optFlags) {
   using nccl::gin::internal::teamRankToGinRank;
   coop.sync();
   ncclGinSignalDescriptor signal{};
@@ -659,49 +574,33 @@ NCCL_DEVICE_INLINE void ncclGinSignal_v2(
   }
   if (coop.thread_rank() == 0) {
     ncclGinCtx ctx = ncclGin_C_makeCtx(net);
-    ncclGinCall<ncclGinApi_Put>(ctx,
-      ncclCoopThread(), teamRankToGinRank(net->comm, team, peer),
-      /*hasWins=*/false, nullptr, 0, nullptr, 0, 0,
-      signal,
-      signalOp,
-      signalOpArg,
-      /*hasCounter=*/false, 0,
-      isDescriptor,
-      descriptor,
-      requiredRelease, givenRelease,
-      optFlags
-    );
+    ncclGinCall<ncclGinApi_Put>(ctx, ncclCoopThread(), teamRankToGinRank(net->comm, team, peer),
+                                /*hasWins=*/false, nullptr, 0, nullptr, 0, 0, signal, signalOp, signalOpArg,
+                                /*hasCounter=*/false, 0, isDescriptor, descriptor, requiredRelease, givenRelease,
+                                optFlags);
   }
   coop.sync();
 }
 
-NCCL_DEVICE_INLINE void ncclGinSignal(
-    ncclGin_C* net,
-    ncclTeam team, int peer,
-    bool isSignal, ncclGinSignal_t signalId, ncclGinSignalOp_t signalOp, uint64_t signalOpArg,
-    ncclCoopAny coop,
-    bool isDescriptor, ncclGinDescriptorSmem* descriptor,
-    cuda::thread_scope givenRelease, cuda::thread_scope requiredRelease
-  ) {
-  ncclGinSignal_v2(net, team, peer, isSignal, signalId, signalOp, signalOpArg, coop, isDescriptor,
-                  descriptor, givenRelease, requiredRelease, ncclGinOptFlagsDefault);
+NCCL_DEVICE_INLINE void ncclGinSignal(ncclGin_C* net, ncclTeam team, int peer, bool isSignal, ncclGinSignal_t signalId,
+                                      ncclGinSignalOp_t signalOp, uint64_t signalOpArg, ncclCoopAny coop,
+                                      bool isDescriptor, ncclGinDescriptorSmem* descriptor,
+                                      cuda::thread_scope givenRelease, cuda::thread_scope requiredRelease) {
+  ncclGinSignal_v2(net, team, peer, isSignal, signalId, signalOp, signalOpArg, coop, isDescriptor, descriptor,
+                   givenRelease, requiredRelease, ncclGinOptFlagsDefault);
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<unsigned beMask>
-template<typename Coop>
+template <unsigned beMask>
+template <typename Coop>
 NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::flush(Coop coop, cuda::memory_order ord) const {
   coop.sync();
   ncclGinCall<ncclGinApi_Flush>(this->_makeCtx(), coop, ord, this->comm.abortFlag);
   coop.sync();
 }
 
-NCCL_DEVICE_INLINE void ncclGinFlush(
-    ncclGin_C* net,
-    ncclCoopAny coop,
-    cuda::memory_order ord
-  ) {
+NCCL_DEVICE_INLINE void ncclGinFlush(ncclGin_C* net, ncclCoopAny coop, cuda::memory_order ord) {
   coop.sync();
   ncclGinCtx ctx = ncclGin_C_makeCtx(net);
   ncclGinCall<ncclGinApi_Flush>(ctx, coop, ord, net->comm.abortFlag);
@@ -710,32 +609,25 @@ NCCL_DEVICE_INLINE void ncclGinFlush(
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<unsigned beMask>
-template<typename Coop>
-NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::waitCounter(
-    Coop coop, ncclGinCounter_t counter, uint64_t least, int bits, cuda::memory_order ord
-  ) const {
+template <unsigned beMask>
+template <typename Coop>
+NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::waitCounter(Coop coop, ncclGinCounter_t counter, uint64_t least,
+                                                                 int bits, cuda::memory_order ord) const {
   using nccl::utility::testAbort;
   uint32_t steps = 0;
   coop.sync();
   if (coop.thread_rank() == 0) {
     uint64_t* ptr = ncclGinCall<ncclGinApi_GetCounterPtr>(this->_makeCtx(), counter);
     uint64_t got;
-    #pragma unroll 1
+#pragma unroll 1
     do got = cuda::atomic_ref<uint64_t>{*ptr}.load(ord);
     while (!nccl::utility::rollingLessEq(least, got, bits) && !testAbort(this->comm.abortFlag, steps));
   }
   coop.sync();
 }
 
-NCCL_DEVICE_INLINE void ncclGinWaitCounter(
-    ncclGin_C* net,
-    ncclCoopAny coop,
-    ncclGinCounter_t counter,
-    uint64_t least,
-    int bits,
-    cuda::memory_order ord
-  ) {
+NCCL_DEVICE_INLINE void ncclGinWaitCounter(ncclGin_C* net, ncclCoopAny coop, ncclGinCounter_t counter, uint64_t least,
+                                           int bits, cuda::memory_order ord) {
   using nccl::utility::testAbort;
   uint32_t steps = 0;
   coop.sync();
@@ -743,7 +635,7 @@ NCCL_DEVICE_INLINE void ncclGinWaitCounter(
     ncclGinCtx ctx = ncclGin_C_makeCtx(net);
     uint64_t* ptr = ncclGinCall<ncclGinApi_GetCounterPtr>(ctx, counter);
     uint64_t got;
-    #pragma unroll 1
+#pragma unroll 1
     do got = cuda::atomic_ref<uint64_t>{*ptr}.load(ord);
     while (!nccl::utility::rollingLessEq(least, got, bits) && !testAbort(net->comm.abortFlag, steps));
   }
@@ -752,97 +644,90 @@ NCCL_DEVICE_INLINE void ncclGinWaitCounter(
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<unsigned beMask>
-NCCL_DEVICE_INLINE uint64_t ncclGin_BackendMask<beMask>::readCounter(ncclGinCounter_t counter, int bits, cuda::memory_order ord) const {
+template <unsigned beMask>
+NCCL_DEVICE_INLINE uint64_t ncclGin_BackendMask<beMask>::readCounter(ncclGinCounter_t counter, int bits,
+                                                                     cuda::memory_order ord) const {
   uint64_t* ptr = ncclGinCall<ncclGinApi_GetCounterPtr>(this->_makeCtx(), counter);
-  uint64_t mask = uint64_t(-1)>>(64-bits);
+  uint64_t mask = uint64_t(-1) >> (64 - bits);
   return mask & cuda::atomic_ref<uint64_t>{*ptr}.load(ord);
 }
 
-NCCL_DEVICE_INLINE uint64_t ncclGinReadCounter(
-    ncclGin_C* net,
-    ncclGinCounter_t counter,
-    int bits,
-    cuda::memory_order ord
-  ) {
+NCCL_DEVICE_INLINE uint64_t ncclGinReadCounter(ncclGin_C* net, ncclGinCounter_t counter, int bits,
+                                               cuda::memory_order ord) {
   ncclGinCtx ctx = ncclGin_C_makeCtx(net);
   uint64_t* ptr = ncclGinCall<ncclGinApi_GetCounterPtr>(ctx, counter);
-  uint64_t mask = uint64_t(-1)>>(64-bits);
+  uint64_t mask = uint64_t(-1) >> (64 - bits);
   return mask & cuda::atomic_ref<uint64_t>{*ptr}.load(ord);
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<unsigned beMask>
+template <unsigned beMask>
 NCCL_DEVICE_INLINE uint64_t* ncclGin_BackendMask<beMask>::getSignalShadowPtr(ncclGinSignal_t signal) const {
   return &this->_signalShadows[signal];
 }
 
-NCCL_DEVICE_INLINE uint64_t* ncclGinGetSignalShadowPtr(
-    ncclGin_C* net,
-    ncclGinSignal_t signal
-  ) {
+NCCL_DEVICE_INLINE uint64_t* ncclGinGetSignalShadowPtr(ncclGin_C* net, ncclGinSignal_t signal) {
   return &net->_signalShadows[signal];
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<unsigned beMask>
-NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::increaseSignalShadow(ncclGinSignal_t signal, uint64_t delta) const {
+template <unsigned beMask>
+NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::increaseSignalShadow(ncclGinSignal_t signal,
+                                                                          uint64_t delta) const {
 #if defined(__HIP_PLATFORM_AMD__)
   __hip_atomic_fetch_add(this->_signalShadows + signal, delta, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_WORKGROUP);
 #else
-  asm volatile("red.relaxed.cta.add.u64 [%0],%1;" :: "l"(this->_signalShadows + signal), "l"(delta) : "memory");
+  asm volatile("red.relaxed.cta.add.u64 [%0],%1;" ::"l"(this->_signalShadows + signal), "l"(delta) : "memory");
 #endif
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<unsigned beMask>
-NCCL_DEVICE_INLINE uint64_t ncclGin_BackendMask<beMask>::readSignal(ncclGinSignal_t signal, int bits, cuda::memory_order ord) const {
+template <unsigned beMask>
+NCCL_DEVICE_INLINE uint64_t ncclGin_BackendMask<beMask>::readSignal(ncclGinSignal_t signal, int bits,
+                                                                    cuda::memory_order ord) const {
   uint64_t* ptr = ncclGinCall<ncclGinApi_GetSignalPtr>(this->_makeCtx(), signal);
-  uint64_t mask = uint64_t(-1)>>(64-bits);
+  uint64_t mask = uint64_t(-1) >> (64 - bits);
   return mask & cuda::atomic_ref<uint64_t>{*ptr}.load(ord);
 }
 
-template<unsigned beMask>
-NCCL_DEVICE_INLINE uint64_t ncclGin_BackendMask<beMask>::readSignal(ncclWindow_t signalWindow, size_t signalOffset, int bits, cuda::memory_order ord) const {
+template <unsigned beMask>
+NCCL_DEVICE_INLINE uint64_t ncclGin_BackendMask<beMask>::readSignal(ncclWindow_t signalWindow, size_t signalOffset,
+                                                                    int bits, cuda::memory_order ord) const {
   uint64_t* ptr = (uint64_t*)ncclGetLocalPointer(signalWindow, signalOffset);
-  uint64_t mask = uint64_t(-1)>>(64-bits);
+  uint64_t mask = uint64_t(-1) >> (64 - bits);
   return mask & cuda::atomic_ref<uint64_t>{*ptr}.load(ord);
 }
 
-NCCL_DEVICE_INLINE uint64_t ncclGinReadSignal(
-    ncclGin_C* net,
-    ncclGinSignal_t signal,
-    int bits,
-    cuda::memory_order ord
-  ) {
+NCCL_DEVICE_INLINE uint64_t ncclGinReadSignal(ncclGin_C* net, ncclGinSignal_t signal, int bits,
+                                              cuda::memory_order ord) {
   ncclGinCtx ctx = ncclGin_C_makeCtx(net);
   uint64_t* ptr = ncclGinCall<ncclGinApi_GetSignalPtr>(ctx, signal);
-  uint64_t mask = uint64_t(-1)>>(64-bits);
+  uint64_t mask = uint64_t(-1) >> (64 - bits);
   return mask & cuda::atomic_ref<uint64_t>{*ptr}.load(ord);
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
 
-template<unsigned beMask>
-template<typename Coop, typename DescriptorSmem>
+template <unsigned beMask>
+template <typename Coop, typename DescriptorSmem>
 NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::wait(ncclGinRequest_t& request, Coop coop,
                                                           DescriptorSmem descriptor, cuda::memory_order ord) const {
   coop.sync();
   if (coop.thread_rank() == 0) {
-    ncclGinCall<ncclGinApi_Wait>(this->_makeCtx(), request,
-        ncclGin_isDescriptor(descriptor), ncclGin_getDescriptor(descriptor), ord, this->comm.abortFlag);
+    ncclGinCall<ncclGinApi_Wait>(this->_makeCtx(), request, ncclGin_isDescriptor(descriptor),
+                                 ncclGin_getDescriptor(descriptor), ord, this->comm.abortFlag);
   }
   coop.sync();
 }
 
-template<unsigned beMask>
-template<typename Coop>
-NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::flushAsync(ncclTeam team, uint32_t peer, ncclGinRequest_t* outRequest,
-                                                                Coop coop, uint32_t optFlags) const {
+template <unsigned beMask>
+template <typename Coop>
+NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::flushAsync(
+  ncclTeam team, uint32_t peer, ncclGinRequest_t* outRequest, Coop coop, uint32_t optFlags) const {
   using nccl::gin::internal::teamRankToGinRank;
   coop.sync();
   if (coop.thread_rank() == 0) {
@@ -852,40 +737,31 @@ NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::flushAsync(ncclTeam team, u
   coop.sync();
 }
 
-template<unsigned beMask>
-template<typename Coop, typename DescriptorSmem, typename SegmentType>
-NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::get(
-    ncclTeam team, int peer,
-    ncclWindow_t remoteWnd, size_t remoteOffset,
-    ncclWindow_t localWnd, size_t localOffset,
-    size_t bytes, Coop coop,
-    DescriptorSmem descriptor,
-    uint32_t optFlags, SegmentType bufType) const {
+template <unsigned beMask>
+template <typename Coop, typename DescriptorSmem, typename SegmentType>
+NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::get(ncclTeam team, int peer, ncclWindow_t remoteWnd,
+                                                         size_t remoteOffset, ncclWindow_t localWnd, size_t localOffset,
+                                                         size_t bytes, Coop coop, DescriptorSmem descriptor,
+                                                         uint32_t optFlags, SegmentType bufType) const {
   using nccl::utility::loadConst;
   using nccl::gin::internal::teamRankToGinRank;
   ncclGinCtx_M<beMask> ctx = this->_makeCtx();
   coop.sync();
   if (ncclGin_isDeviceOnly(bufType)) {
-    ncclGinCall<ncclGinApi_Get>(ctx, coop,
-        teamRankToGinRank(this->comm, team, peer),
-        loadConst(&remoteWnd->ginWins[this->connectionId]),
-        4096*size_t(loadConst(&remoteWnd->ginOffset4K)) + remoteOffset,
-        loadConst(&localWnd->ginWins[this->connectionId]),
-        4096*size_t(loadConst(&localWnd->ginOffset4K)) + localOffset, bytes,
-        ncclGin_isDescriptor(descriptor),
-        ncclGin_getDescriptor(descriptor),
-        optFlags);
+    ncclGinCall<ncclGinApi_Get>(ctx, coop, teamRankToGinRank(this->comm, team, peer),
+                                loadConst(&remoteWnd->ginWins[this->connectionId]),
+                                4096 * size_t(loadConst(&remoteWnd->ginOffset4K)) + remoteOffset,
+                                loadConst(&localWnd->ginWins[this->connectionId]),
+                                4096 * size_t(loadConst(&localWnd->ginOffset4K)) + localOffset, bytes,
+                                ncclGin_isDescriptor(descriptor), ncclGin_getDescriptor(descriptor), optFlags);
   } else {
     if (remoteWnd->numSegments == 1 && localWnd->numSegments == 1) {
-      ncclGinCall<ncclGinApi_Get>(ctx, coop,
-          teamRankToGinRank(this->comm, team, peer),
-          loadConst(&remoteWnd->ginWins[this->connectionId]),
-          4096*size_t(loadConst(&remoteWnd->ginOffset4K)) + remoteOffset,
-          loadConst(&localWnd->ginWins[this->connectionId]),
-          4096*size_t(loadConst(&localWnd->ginOffset4K)) + localOffset, bytes,
-          ncclGin_isDescriptor(descriptor),
-          ncclGin_getDescriptor(descriptor),
-          optFlags);
+      ncclGinCall<ncclGinApi_Get>(ctx, coop, teamRankToGinRank(this->comm, team, peer),
+                                  loadConst(&remoteWnd->ginWins[this->connectionId]),
+                                  4096 * size_t(loadConst(&remoteWnd->ginOffset4K)) + remoteOffset,
+                                  loadConst(&localWnd->ginWins[this->connectionId]),
+                                  4096 * size_t(loadConst(&localWnd->ginOffset4K)) + localOffset, bytes,
+                                  ncclGin_isDescriptor(descriptor), ncclGin_getDescriptor(descriptor), optFlags);
     } else {
       // Multi-segment case: chunk the get across separate per-segment registrations
       int remoteSeg, localSeg;
@@ -899,17 +775,15 @@ NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::get(
         const size_t remoteRemaining = remoteSegmentWindow.segmentSize - remoteSegOffset;
         const size_t localRemaining = localSegmentWindow.segmentSize - localSegOffset;
         const size_t getSize = nccl::gin::internal::getSegmentChunkSize(remoteRemaining, localRemaining, remaining);
-        ncclGinCall<ncclGinApi_Get>(ctx, coop,
-            teamRankToGinRank(this->comm, team, peer),
-            loadConst(&remoteWnd->ginMultiSegmentWins[remoteSeg].ginWins[this->connectionId]),
-            remoteSegOffset,
-            loadConst(&localWnd->ginMultiSegmentWins[localSeg].ginWins[this->connectionId]),
-            localSegOffset, getSize,
-            ncclGin_isDescriptor(descriptor),
-            ncclGin_getDescriptor(descriptor),
-            optFlags);
+        ncclGinCall<ncclGinApi_Get>(ctx, coop, teamRankToGinRank(this->comm, team, peer),
+                                    loadConst(&remoteWnd->ginMultiSegmentWins[remoteSeg].ginWins[this->connectionId]),
+                                    remoteSegOffset,
+                                    loadConst(&localWnd->ginMultiSegmentWins[localSeg].ginWins[this->connectionId]),
+                                    localSegOffset, getSize, ncclGin_isDescriptor(descriptor),
+                                    ncclGin_getDescriptor(descriptor), optFlags);
         remaining -= getSize;
-        nccl::gin::internal::advanceSegmentCursor(&remoteSeg, &remoteSegOffset, getSize, remoteSegmentWindow.segmentSize);
+        nccl::gin::internal::advanceSegmentCursor(&remoteSeg, &remoteSegOffset, getSize,
+                                                  remoteSegmentWindow.segmentSize);
         nccl::gin::internal::advanceSegmentCursor(&localSeg, &localSegOffset, getSize, localSegmentWindow.segmentSize);
       }
     }
@@ -917,53 +791,45 @@ NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::get(
   coop.sync();
 }
 
-NCCL_DEVICE_INLINE void ncclGinGet(
-  ncclGin_C* net,
-  ncclTeam team, int peer,
-  ncclWindow_t remoteWnd, size_t remoteOffset,
-  ncclWindow_t localWnd, size_t localOffset, size_t bytes,
-  ncclCoopAny coop,
-  bool isDescriptor,
-  ncclGinDescriptorSmem* descriptor,
-  uint32_t optFlags
-) {
+NCCL_DEVICE_INLINE void ncclGinGet(ncclGin_C* net, ncclTeam team, int peer, ncclWindow_t remoteWnd, size_t remoteOffset,
+                                   ncclWindow_t localWnd, size_t localOffset, size_t bytes, ncclCoopAny coop,
+                                   bool isDescriptor, ncclGinDescriptorSmem* descriptor, uint32_t optFlags) {
   using nccl::utility::loadConst;
   using nccl::gin::internal::teamRankToGinRank;
   coop.sync();
   ncclGinCtx ctx = ncclGin_C_makeCtx(net);
-  ncclGinCall<ncclGinApi_Get>(ctx, coop,
-      teamRankToGinRank(net->comm, team, peer),
-      loadConst(&remoteWnd->ginWins[net->connectionId]),
-      4096*size_t(loadConst(&remoteWnd->ginOffset4K)) + remoteOffset,
-      loadConst(&localWnd->ginWins[net->connectionId]),
-      4096*size_t(loadConst(&localWnd->ginOffset4K)) + localOffset, bytes,
-      ncclGin_isDescriptor(descriptor),
-      ncclGin_getDescriptor(descriptor),
-      optFlags);
+  ncclGinCall<ncclGinApi_Get>(ctx, coop, teamRankToGinRank(net->comm, team, peer),
+                              loadConst(&remoteWnd->ginWins[net->connectionId]),
+                              4096 * size_t(loadConst(&remoteWnd->ginOffset4K)) + remoteOffset,
+                              loadConst(&localWnd->ginWins[net->connectionId]),
+                              4096 * size_t(loadConst(&localWnd->ginOffset4K)) + localOffset, bytes,
+                              ncclGin_isDescriptor(descriptor), ncclGin_getDescriptor(descriptor), optFlags);
   coop.sync();
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<unsigned beMask>
-template<typename Coop>
-NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::waitSignal(Coop coop, ncclGinSignal_t signal, uint64_t least, int bits, cuda::memory_order ord) const {
+template <unsigned beMask>
+template <typename Coop>
+NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::waitSignal(Coop coop, ncclGinSignal_t signal, uint64_t least,
+                                                                int bits, cuda::memory_order ord) const {
   using nccl::utility::testAbort;
   uint32_t steps = 0;
   coop.sync();
   if (coop.thread_rank() == 0) {
     uint64_t* ptr = ncclGinCall<ncclGinApi_GetSignalPtr>(this->_makeCtx(), signal);
     uint64_t got;
-    #pragma unroll 1
+#pragma unroll 1
     do got = cuda::atomic_ref<uint64_t>{*ptr}.load(ord);
     while (!nccl::utility::rollingLessEq(least, got, bits) && !testAbort(this->comm.abortFlag, steps));
   }
   coop.sync();
 }
 
-template<unsigned beMask>
-template<typename Coop>
-NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::waitSignal(Coop coop, ncclWindow_t signalWindow, size_t signalOffset, uint64_t least, int bits, cuda::memory_order ord) const {
+template <unsigned beMask>
+template <typename Coop>
+NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::waitSignal(
+  Coop coop, ncclWindow_t signalWindow, size_t signalOffset, uint64_t least, int bits, cuda::memory_order ord) const {
   using nccl::utility::loadConst;
   using nccl::utility::testAbort;
   uint32_t steps = 0;
@@ -971,7 +837,7 @@ NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::waitSignal(Coop coop, ncclW
   if (coop.thread_rank() == 0) {
     uint64_t* ptr = (uint64_t*)ncclGetLocalPointer(signalWindow, signalOffset);
     uint64_t got;
-    #pragma unroll 1
+#pragma unroll 1
     do {
       got = cuda::atomic_ref<uint64_t>{*ptr}.load(ord);
     } while (!nccl::utility::rollingLessEq(least, got, bits) && !testAbort(this->comm.abortFlag, steps));
@@ -979,14 +845,8 @@ NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::waitSignal(Coop coop, ncclW
   coop.sync();
 }
 
-NCCL_DEVICE_INLINE void ncclGinWaitSignal(
-    ncclGin_C* net,
-    ncclCoopAny coop,
-    ncclGinSignal_t signal,
-    uint64_t least,
-    int bits,
-    cuda::memory_order ord
-  ) {
+NCCL_DEVICE_INLINE void ncclGinWaitSignal(ncclGin_C* net, ncclCoopAny coop, ncclGinSignal_t signal, uint64_t least,
+                                          int bits, cuda::memory_order ord) {
   using nccl::utility::testAbort;
   uint32_t steps = 0;
   coop.sync();
@@ -994,7 +854,7 @@ NCCL_DEVICE_INLINE void ncclGinWaitSignal(
     ncclGinCtx ctx = ncclGin_C_makeCtx(net);
     uint64_t* ptr = ncclGinCall<ncclGinApi_GetSignalPtr>(ctx, signal);
     uint64_t got;
-    #pragma unroll 1
+#pragma unroll 1
     do got = cuda::atomic_ref<uint64_t>{*ptr}.load(ord);
     while (!nccl::utility::rollingLessEq(least, got, bits) && !testAbort(net->comm.abortFlag, steps));
   }
@@ -1003,9 +863,10 @@ NCCL_DEVICE_INLINE void ncclGinWaitSignal(
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<unsigned beMask>
-template<typename Coop>
-NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::waitSignalMeetShadow(Coop coop, ncclGinSignal_t signal, int bits, cuda::memory_order ord) const {
+template <unsigned beMask>
+template <typename Coop>
+NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::waitSignalMeetShadow(Coop coop, ncclGinSignal_t signal, int bits,
+                                                                          cuda::memory_order ord) const {
   using nccl::utility::testAbort;
   uint32_t steps = 0;
   coop.sync();
@@ -1013,7 +874,7 @@ NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::waitSignalMeetShadow(Coop c
     uint64_t* ptr = ncclGinCall<ncclGinApi_GetSignalPtr>(this->_makeCtx(), signal);
     uint64_t least = this->_signalShadows[signal];
     uint64_t got;
-    #pragma unroll 1
+#pragma unroll 1
     do got = cuda::atomic_ref<uint64_t>{*ptr}.load(ord);
     while (!nccl::utility::rollingLessEq(least, got, bits) && !testAbort(this->comm.abortFlag, steps));
   }
@@ -1022,32 +883,35 @@ NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::waitSignalMeetShadow(Coop c
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<unsigned beMask>
-template<typename Coop, typename Uint>
-NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::waitSignalFollowShadow(Coop coop, ncclGinSignal_t signal, Uint leastDelta, Uint* before, Uint* delta, int bits, cuda::memory_order ord) const {
+template <unsigned beMask>
+template <typename Coop, typename Uint>
+NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::waitSignalFollowShadow(Coop coop, ncclGinSignal_t signal,
+                                                                            Uint leastDelta, Uint* before, Uint* delta,
+                                                                            int bits, cuda::memory_order ord) const {
   using nccl::utility::testAbort;
   uint32_t steps = 0;
   coop.sync();
   uint64_t before64 = this->_signalShadows[signal];
 #if defined(__HIP_PLATFORM_AMD__)
-  uint64_t after64 = 0;  // must be zero-initialized, else non-root threads broadcast an indeterminate value and hang
+  uint64_t after64 = 0; // must be zero-initialized, else non-root threads broadcast an indeterminate value and hang
 #else
   uint64_t after64;
 #endif
   if (coop.thread_rank() == 0) {
     uint64_t* ptr = ncclGinCall<ncclGinApi_GetSignalPtr>(this->_makeCtx(), signal);
-    #pragma unroll 1
+#pragma unroll 1
     do after64 = cuda::atomic_ref<uint64_t>{*ptr}.load(ord);
-    while (!nccl::utility::rollingLessEq(before64 + leastDelta, after64, bits) && !testAbort(this->comm.abortFlag, steps));
+    while (!nccl::utility::rollingLessEq(before64 + leastDelta, after64, bits) &&
+           !testAbort(this->comm.abortFlag, steps));
     this->_signalShadows[signal] = after64;
   }
   if (ncclCoopWithinWarp(coop) && bits <= 32) { // do a single __shfl_sync instead of 2
-    uint32_t mask = uint32_t(-1)>>(32-bits);
+    uint32_t mask = uint32_t(-1) >> (32 - bits);
     after64 = ncclCoopBcast(coop, (uint32_t)after64, 0, /*entrySync=*/false);
     *before = (Uint)(mask & before64);
     *delta = (Uint)(mask & (after64 - before64));
   } else {
-    uint64_t mask = uint64_t(-1)>>(64-bits);
+    uint64_t mask = uint64_t(-1) >> (64 - bits);
     after64 = ncclCoopBcast(coop, after64, 0, /*entrySync=*/false);
     *before = (Uint)(mask & before64);
     *delta = (Uint)(mask & (after64 - before64));
@@ -1056,22 +920,19 @@ NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::waitSignalFollowShadow(Coop
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<unsigned beMask>
+template <unsigned beMask>
 NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::resetCounter(ncclGinCounter_t counter) const {
   ncclGinCall<ncclGinApi_ResetCounter>(this->_makeCtx(), counter);
 }
 
-NCCL_DEVICE_INLINE void ncclGinResetCounter(
-    ncclGin_C* net,
-    ncclGinCounter_t counter
-  ) {
+NCCL_DEVICE_INLINE void ncclGinResetCounter(ncclGin_C* net, ncclGinCounter_t counter) {
   ncclGinCtx ctx = ncclGin_C_makeCtx(net);
   ncclGinCall<ncclGinApi_ResetCounter>(ctx, counter);
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<unsigned beMask>
+template <unsigned beMask>
 NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::resetSignal(ncclGinSignal_t signal) const {
   ncclGinSignalDescriptor signalDesc;
   signalDesc.type = NCCL_GIN_SIGNAL_TYPE_INDEXED;
@@ -1080,7 +941,7 @@ NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::resetSignal(ncclGinSignal_t
   this->_signalShadows[signal] = 0;
 }
 
-template<unsigned beMask>
+template <unsigned beMask>
 NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::resetSignal(ncclWindow_t signalWindow, size_t signalOffset) const {
   ncclGinSignalDescriptor signal;
   signal.type = NCCL_GIN_SIGNAL_TYPE_VA;
@@ -1090,10 +951,7 @@ NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::resetSignal(ncclWindow_t si
   ncclGinCall<ncclGinApi_ResetSignal>(this->_makeCtx(), signal);
 }
 
-NCCL_DEVICE_INLINE void ncclGinResetSignal(
-    ncclGin_C* net,
-    ncclGinSignal_t signal
-  ) {
+NCCL_DEVICE_INLINE void ncclGinResetSignal(ncclGin_C* net, ncclGinSignal_t signal) {
   ncclGinCtx ctx = ncclGin_C_makeCtx(net);
   ncclGinSignalDescriptor signalDesc{};
   signalDesc.type = NCCL_GIN_SIGNAL_TYPE_INDEXED;

--- a/projects/rccl/src/include/nccl_device/impl/gin_barrier__funcs.h
+++ b/projects/rccl/src/include/nccl_device/impl/gin_barrier__funcs.h
@@ -11,59 +11,51 @@
 #include "comm__types.h"
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop>
+template <typename Coop>
 NCCL_DEVICE_INLINE ncclGinBarrierSession<Coop>::ncclGinBarrierSession(
-    Coop coop, ncclGin net, ncclTeam team, ncclGinBarrierHandle handle, uint32_t barrierIndex
-  ):
-  ncclGinBarrierSession_internal<Coop>{coop, net, team, handle, (int)barrierIndex} {
+  Coop coop, ncclGin net, ncclTeam team, ncclGinBarrierHandle handle, uint32_t barrierIndex)
+  : ncclGinBarrierSession_internal<Coop>{coop, net, team, handle, (int)barrierIndex} {
   this->signal = handle.signal0 + barrierIndex * team.nRanks;
 }
 
-template<typename Coop>
-NCCL_DEVICE_INLINE ncclGinBarrierSession<Coop>::ncclGinBarrierSession(
-    Coop coop, ncclGin net, ncclTeamTagRail, uint32_t barrierIndex
-  ):
-  ncclGinBarrierSession(coop, net, ncclTeamRail(net.comm), net.comm.railGinBarrier, barrierIndex) {
-}
+template <typename Coop>
+NCCL_DEVICE_INLINE ncclGinBarrierSession<Coop>::ncclGinBarrierSession(Coop coop, ncclGin net, ncclTeamTagRail,
+                                                                      uint32_t barrierIndex)
+  : ncclGinBarrierSession(coop, net, ncclTeamRail(net.comm), net.comm.railGinBarrier, barrierIndex) {}
 
-template<typename Coop>
-NCCL_DEVICE_INLINE ncclGinBarrierSession<Coop>::ncclGinBarrierSession(
-    Coop coop, ncclGin net, ncclTeamTagWorld, uint32_t barrierIndex
-  ):
-  ncclGinBarrierSession(coop, net, ncclTeamWorld(net.comm), net.comm.worldGinBarrier, barrierIndex) {
-}
+template <typename Coop>
+NCCL_DEVICE_INLINE ncclGinBarrierSession<Coop>::ncclGinBarrierSession(Coop coop, ncclGin net, ncclTeamTagWorld,
+                                                                      uint32_t barrierIndex)
+  : ncclGinBarrierSession(coop, net, ncclTeamWorld(net.comm), net.comm.worldGinBarrier, barrierIndex) {}
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop>
-NCCL_DEVICE_INLINE ncclGinBarrierSession<Coop>::~ncclGinBarrierSession() {
-}
+template <typename Coop>
+NCCL_DEVICE_INLINE ncclGinBarrierSession<Coop>::~ncclGinBarrierSession() {}
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop>
-template<bool EnableTimeout>
-NCCL_DEVICE_INLINE ncclResult_t ncclGinBarrierSession_internal<Coop>::syncInternal(Coop, cuda::memory_order ord,
-                                                                      ncclGinFenceLevel fence, uint64_t timeoutCycles) {
+template <typename Coop>
+template <bool EnableTimeout>
+NCCL_DEVICE_INLINE ncclResult_t ncclGinBarrierSession_internal<Coop>::syncInternal(
+  Coop, cuda::memory_order ord, ncclGinFenceLevel fence, uint64_t timeoutCycles) {
   uint64_t startCycle;
   ncclResult_t ret = ncclSuccess;
   this->coop.sync();
   if NCCL_IF_CONSTEXPR (EnableTimeout) {
     startCycle = clock64();
   }
-  #pragma unroll 1
-  for (int i=this->coop.thread_rank(); i < this->team.nRanks-1; i += this->coop.size()) {
+#pragma unroll 1
+  for (int i = this->coop.thread_rank(); i < this->team.nRanks - 1; i += this->coop.size()) {
     // Use a rotating pattern to avoid hot spots
     int peer = 1 + this->team.rank + i;
     if (this->team.nRanks <= peer) peer -= this->team.nRanks;
 
     // Initiate signal
-    this->net.signal(
-      this->team, peer, ncclGin_SignalInc{this->signal + this->team.rank}, ncclCoopThread(), ncclGin_None(),
-      nccl::utility::releaseOrderOf(ord) != cuda::memory_order_relaxed
-        ? cuda::thread_scope_thread
-        : cuda::thread_scope_system
-    );
+    this->net.signal(this->team, peer, ncclGin_SignalInc{this->signal + this->team.rank}, ncclCoopThread(),
+                     ncclGin_None(),
+                     nccl::utility::releaseOrderOf(ord) != cuda::memory_order_relaxed ? cuda::thread_scope_thread :
+                                                                                        cuda::thread_scope_system);
 
     // Load and update barrier state in memory. The load/store should be covered by the GIN signal latency.
     uint32_t* shadowPtr = (uint32_t*)this->net.getSignalShadowPtr(this->signal + peer);
@@ -89,18 +81,17 @@ exit:
 }
 #endif
 
-
 #if NCCL_CHECK_CUDACC
-template<typename Coop>
+template <typename Coop>
 NCCL_DEVICE_INLINE void ncclGinBarrierSession<Coop>::sync(Coop coop, cuda::memory_order ord, ncclGinFenceLevel fence) {
   (void)(this->template syncInternal</*EnableTimeout=*/false>(coop, ord, fence, 0ULL));
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop>
-NCCL_DEVICE_INLINE ncclResult_t ncclGinBarrierSession<Coop>::sync(
-    Coop coop, cuda::memory_order ord, ncclGinFenceLevel fence, uint64_t timeoutCycles) {
+template <typename Coop>
+NCCL_DEVICE_INLINE ncclResult_t ncclGinBarrierSession<Coop>::sync(Coop coop, cuda::memory_order ord,
+                                                                  ncclGinFenceLevel fence, uint64_t timeoutCycles) {
   return this->template syncInternal</*EnableTimeout=*/true>(coop, ord, fence, timeoutCycles);
 }
 #endif

--- a/projects/rccl/src/include/nccl_device/impl/gin_barrier__types.h
+++ b/projects/rccl/src/include/nccl_device/impl/gin_barrier__types.h
@@ -17,7 +17,7 @@ struct ncclGinBarrierHandle {
 };
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop>
+template <typename Coop>
 struct ncclGinBarrierSession_internal {
   Coop coop;
   ncclGin net;
@@ -26,7 +26,7 @@ struct ncclGinBarrierSession_internal {
   int index;
   ncclGinSignal_t signal;
 
-  template<bool EnableTimeout>
+  template <bool EnableTimeout>
   NCCL_DEVICE_INLINE ncclResult_t syncInternal(Coop, cuda::memory_order ord, ncclGinFenceLevel fence,
                                                uint64_t timeoutCycles);
 };

--- a/projects/rccl/src/include/nccl_device/impl/ll_a2a__funcs.h
+++ b/projects/rccl/src/include/nccl_device/impl/ll_a2a__funcs.h
@@ -15,7 +15,10 @@
 #if NCCL_CHECK_CUDACC
 NCCL_DEVICE_INLINE void amdLLA2aStoreLine(uint32_t* dst, uint32_t a0, uint32_t a1, uint32_t a2, uint32_t a3) {
 #if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
-  union { v4u v; uint32_t w[4]; } u;
+  union {
+    v4u v;
+    uint32_t w[4];
+  } u;
   u.w[0] = a0;
   u.w[1] = a1;
   u.w[2] = a2;
@@ -33,7 +36,10 @@ NCCL_DEVICE_INLINE void amdLLA2aStoreLine(uint32_t* dst, uint32_t a0, uint32_t a
 NCCL_DEVICE_INLINE void amdLLA2aLoadLine(const uint32_t* src, uint32_t& o0, uint32_t& o1, uint32_t& o2, uint32_t& o3) {
   asm volatile("" ::: "memory");
 #if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
-  union { v4u v; uint32_t w[4]; } u;
+  union {
+    v4u v;
+    uint32_t w[4];
+  } u;
   u.v = __builtin_amdgcn_global_load_b128((v4u_gptr)src, RCCL_SYSTEM_SYNCSCOPE);
   o0 = u.w[0];
   o1 = u.w[1];
@@ -49,121 +55,118 @@ NCCL_DEVICE_INLINE void amdLLA2aLoadLine(const uint32_t* src, uint32_t& o0, uint
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop>
-NCCL_DEVICE_INLINE ncclLLA2ASession<Coop>::ncclLLA2ASession(
-    Coop coop, ncclDevComm const& comm, ncclTeam team,
-    ncclLLA2AHandle handle, uint32_t block, int maxElts,
-    bool multimem, ncclMultimemHandle mmHandle
-  ):
-  ncclLLA2ASession_internal<Coop>{
-    coop, comm, team, handle, (int)block, /*pitch=*/maxElts,
-    multimem, mmHandle, /*epoch=*/0, /*slotsOffset=*/0
-  } {
+template <typename Coop>
+NCCL_DEVICE_INLINE ncclLLA2ASession<Coop>::ncclLLA2ASession(Coop coop, ncclDevComm const& comm, ncclTeam team,
+                                                            ncclLLA2AHandle handle, uint32_t block, int maxElts,
+                                                            bool multimem, ncclMultimemHandle mmHandle)
+  : ncclLLA2ASession_internal<Coop>{coop,     comm,     team,        handle,           (int)block, /*pitch=*/maxElts,
+                                    multimem, mmHandle, /*epoch=*/0, /*slotsOffset=*/0} {
   uint4* line = (uint4*)ncclGetResourceBufferLocalPointer(comm, handle.bufHandle);
-  line += block*(1 + 2*handle.nSlots);
+  line += block * (1 + 2 * handle.nSlots);
   this->epoch = line->x + 2;
   this->slotsOffset = this->calcSlotOffset();
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop>
+template <typename Coop>
 NCCL_DEVICE_INLINE ncclLLA2ASession<Coop>::~ncclLLA2ASession() {
   uint4* line = (uint4*)ncclGetResourceBufferLocalPointer(this->comm, this->handle.bufHandle);
-  line += this->block*(1 + 2*this->handle.nSlots);
+  line += this->block * (1 + 2 * this->handle.nSlots);
   if (this->coop.thread_rank() == 0) line->x = this->epoch - 2;
   this->coop.sync();
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop>
-template<typename T>
+template <typename Coop>
+template <typename T>
 NCCL_DEVICE_INLINE void ncclLLA2ASession<Coop>::send(int peer, int elt, T data) {
   using nccl::utility::divUp;
-  union { T tmp; uint32_t u32[divUp(sizeof(T), 8)][2]; };
+  union {
+    T tmp;
+    uint32_t u32[divUp(sizeof(T), 8)][2];
+  };
   tmp = data;
   uint4* buf = (uint4*)ncclGetResourceBufferPeerPointer(this->comm, this->handle.bufHandle, this->team, peer);
   buf += this->slotsOffset + elt;
-  #pragma unroll
-  for (int u=0; u < divUp(sizeof(T), 8); u++) {
+#pragma unroll
+  for (int u = 0; u < divUp(sizeof(T), 8); u++) {
 #if defined(__HIP_PLATFORM_AMD__)
     uint32_t* dst = reinterpret_cast<uint32_t*>(buf + u * this->pitch);
     amdLLA2aStoreLine(dst, u32[u][0], (uint32_t)this->epoch, u32[u][1], (uint32_t)this->epoch);
 #else
-    asm volatile("st.volatile.v4.u32 [%0],{%1,%3,%2,%3};" ::
-      "l"(buf + u*this->pitch),
-      "r"(u32[u][0]), "r"(u32[u][1]), "r"(this->epoch)
-    );
+    asm volatile("st.volatile.v4.u32 [%0],{%1,%3,%2,%3};" ::"l"(buf + u * this->pitch), "r"(u32[u][0]), "r"(u32[u][1]),
+                 "r"(this->epoch));
 #endif
   }
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop>
-template<typename T>
+template <typename Coop>
+template <typename T>
 NCCL_DEVICE_INLINE void ncclLLA2ASession<Coop>::bcast(int elt, T data) {
   using nccl::utility::divUp;
   if (this->multimem) {
-    union { T tmp; uint32_t u32[divUp(sizeof(T),8)][2]; };
+    union {
+      T tmp;
+      uint32_t u32[divUp(sizeof(T), 8)][2];
+    };
     tmp = data;
     uint4* bufmc = (uint4*)ncclGetResourceBufferMultimemPointer(this->comm, this->handle.bufHandle, this->mmHandle);
     bufmc += this->slotsOffset + elt;
-    #pragma unroll
-    for (int u=0; u < divUp(sizeof(T), 8); u++) {
+#pragma unroll
+    for (int u = 0; u < divUp(sizeof(T), 8); u++) {
 #if defined(__HIP_PLATFORM_AMD__)
-      uint32_t* dst = reinterpret_cast<uint32_t*>(bufmc + this->pitch*u);
+      uint32_t* dst = reinterpret_cast<uint32_t*>(bufmc + this->pitch * u);
       amdLLA2aStoreLine(dst, u32[u][0], (uint32_t)this->epoch, u32[u][1], (uint32_t)this->epoch);
 #else
-      asm volatile("st.volatile.v4.u32 [%0],{%1,%3,%2,%3};" ::
-        "l"(bufmc + this->pitch*u),
-        "r"(u32[u][0]), "r"(u32[u][1]), "r"(this->epoch)
-      );
+      asm volatile("st.volatile.v4.u32 [%0],{%1,%3,%2,%3};" ::"l"(bufmc + this->pitch * u), "r"(u32[u][0]),
+                   "r"(u32[u][1]), "r"(this->epoch));
 #endif
     }
   } else {
-    union { T tmp; uint32_t u32[divUp(sizeof(T), 8)][2]; };
+    union {
+      T tmp;
+      uint32_t u32[divUp(sizeof(T), 8)][2];
+    };
     tmp = data;
     int dr = 0;
     int r = this->team.rank;
-    #pragma unroll 1
-    for (; dr+8 <= this->team.nRanks; dr += 8) {
-      #pragma unroll
-      for (int ur=0; ur < 8; ur++) {
+#pragma unroll 1
+    for (; dr + 8 <= this->team.nRanks; dr += 8) {
+#pragma unroll
+      for (int ur = 0; ur < 8; ur++) {
         uint4* buf = (uint4*)ncclGetResourceBufferPeerPointer(this->comm, this->handle.bufHandle, this->team, r);
         buf += this->slotsOffset + elt;
-        #pragma unroll
-        for (int u=0; u < divUp(sizeof(T),8); u++) {
+#pragma unroll
+        for (int u = 0; u < divUp(sizeof(T), 8); u++) {
 #if defined(__HIP_PLATFORM_AMD__)
-          uint32_t* dst = reinterpret_cast<uint32_t*>(buf + u*this->pitch);
+          uint32_t* dst = reinterpret_cast<uint32_t*>(buf + u * this->pitch);
           amdLLA2aStoreLine(dst, u32[u][0], (uint32_t)this->epoch, u32[u][1], (uint32_t)this->epoch);
 #else
-          asm volatile("st.volatile.v4.u32 [%0],{%1,%3,%2,%3};" ::
-            "l"(buf + u*this->pitch),
-            "r"(u32[u][0]), "r"(u32[u][1]), "r"(this->epoch)
-          );
+          asm volatile("st.volatile.v4.u32 [%0],{%1,%3,%2,%3};" ::"l"(buf + u * this->pitch), "r"(u32[u][0]),
+                       "r"(u32[u][1]), "r"(this->epoch));
 #endif
         }
         r += 1;
         if (r == this->team.nRanks) r = 0;
       }
     }
-    #pragma unroll
-    for (int ur=0; ur < 8; ur++, dr++) {
+#pragma unroll
+    for (int ur = 0; ur < 8; ur++, dr++) {
       if (dr == this->team.nRanks) break;
       uint4* buf = (uint4*)ncclGetResourceBufferPeerPointer(this->comm, this->handle.bufHandle, this->team, r);
       buf += this->slotsOffset + elt;
-      #pragma unroll
-      for (int u=0; u < divUp(sizeof(T),8); u++) {
+#pragma unroll
+      for (int u = 0; u < divUp(sizeof(T), 8); u++) {
 #if defined(__HIP_PLATFORM_AMD__)
-        uint32_t* dst = reinterpret_cast<uint32_t*>(buf + u*this->pitch);
+        uint32_t* dst = reinterpret_cast<uint32_t*>(buf + u * this->pitch);
         amdLLA2aStoreLine(dst, u32[u][0], (uint32_t)this->epoch, u32[u][1], (uint32_t)this->epoch);
 #else
-        asm volatile("st.volatile.v4.u32 [%0],{%1,%3,%2,%3};" ::
-          "l"(buf + u*this->pitch),
-          "r"(u32[u][0]), "r"(u32[u][1]), "r"(this->epoch)
-        );
+        asm volatile("st.volatile.v4.u32 [%0],{%1,%3,%2,%3};" ::"l"(buf + u * this->pitch), "r"(u32[u][0]),
+                     "r"(u32[u][1]), "r"(this->epoch));
 #endif
       }
       r += 1;
@@ -174,8 +177,8 @@ NCCL_DEVICE_INLINE void ncclLLA2ASession<Coop>::bcast(int elt, T data) {
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop>
-template<typename T>
+template <typename Coop>
+template <typename T>
 NCCL_DEVICE_INLINE T ncclLLA2ASession<Coop>::recv(int elt) {
   T ret[1];
   this->template recvUnrolled</*MinEltCount=*/1, /*MaxEltCount=*/1>(elt, 1, 0, ret);
@@ -184,42 +187,42 @@ NCCL_DEVICE_INLINE T ncclLLA2ASession<Coop>::recv(int elt) {
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop>
-template<int MinEltCount, int MaxEltCount, typename T>
-NCCL_DEVICE_INLINE void ncclLLA2ASession<Coop>::recvUnrolled(int eltStart, int eltCount, int eltStride, T(&elts)[MaxEltCount]) {
+template <typename Coop>
+template <int MinEltCount, int MaxEltCount, typename T>
+NCCL_DEVICE_INLINE void ncclLLA2ASession<Coop>::recvUnrolled(int eltStart, int eltCount, int eltStride,
+                                                             T (&elts)[MaxEltCount]) {
   using nccl::utility::divUp;
   uint4* buf = (uint4*)ncclGetResourceBufferLocalPointer(this->comm, this->handle.bufHandle);
   buf += this->slotsOffset + eltStart;
 
   uint4 tmp[MaxEltCount][divUp(sizeof(T), 8)];
-  #pragma unroll 1
+#pragma unroll 1
   while (true) {
-    #pragma unroll
-    for (int u=0; u < MaxEltCount; u++) {
+#pragma unroll
+    for (int u = 0; u < MaxEltCount; u++) {
       if (u < MinEltCount || u < eltCount) {
-        #pragma unroll
-        for (int v=0; v < divUp(sizeof(T), 8); v++) {
+#pragma unroll
+        for (int v = 0; v < divUp(sizeof(T), 8); v++) {
 #if defined(__HIP_PLATFORM_AMD__)
-          const uint32_t* src = reinterpret_cast<const uint32_t*>(buf + u*eltStride + v*this->pitch);
+          const uint32_t* src = reinterpret_cast<const uint32_t*>(buf + u * eltStride + v * this->pitch);
           uint4 t;
           amdLLA2aLoadLine(src, t.x, t.y, t.z, t.w);
           tmp[u][v] = t;
 #else
           asm volatile("ld.volatile.v4.u32 {%0,%1,%2,%3},[%4];"
-            : "=r"(tmp[u][v].x), "=r"(tmp[u][v].y), "=r"(tmp[u][v].z), "=r"(tmp[u][v].w)
-            : "l"(buf + u*eltStride + v*this->pitch));
+                       : "=r"(tmp[u][v].x), "=r"(tmp[u][v].y), "=r"(tmp[u][v].z), "=r"(tmp[u][v].w)
+                       : "l"(buf + u * eltStride + v * this->pitch));
 #endif
         }
       }
     }
     bool okAll = true;
-    #pragma unroll
-    for (int u=0; u < MaxEltCount; u++) {
-      #pragma unroll
-      for (int v=0; v < divUp(sizeof(T), 8); v++) {
+#pragma unroll
+    for (int u = 0; u < MaxEltCount; u++) {
+#pragma unroll
+      for (int v = 0; v < divUp(sizeof(T), 8); v++) {
         if (u < MinEltCount || u < eltCount) {
-          bool ok = tmp[u][v].y == this->epoch &&
-                    tmp[u][v].w == this->epoch;
+          bool ok = tmp[u][v].y == this->epoch && tmp[u][v].w == this->epoch;
           okAll &= ok;
         }
       }
@@ -227,12 +230,15 @@ NCCL_DEVICE_INLINE void ncclLLA2ASession<Coop>::recvUnrolled(int eltStart, int e
     if (__builtin_expect(okAll, true)) break;
   }
 
-  #pragma unroll
-  for (int u=0; u < MaxEltCount; u++) {
+#pragma unroll
+  for (int u = 0; u < MaxEltCount; u++) {
     if (MinEltCount <= u && u == eltCount) break;
-    union { T val; uint32_t u32[divUp(sizeof(T), 8)][2]; };
-    #pragma unroll
-    for (int v=0; v < divUp(sizeof(T), 8); v++) {
+    union {
+      T val;
+      uint32_t u32[divUp(sizeof(T), 8)][2];
+    };
+#pragma unroll
+    for (int v = 0; v < divUp(sizeof(T), 8); v++) {
       u32[v][0] = tmp[u][v].x;
       u32[v][1] = tmp[u][v].z;
     }
@@ -242,31 +248,31 @@ NCCL_DEVICE_INLINE void ncclLLA2ASession<Coop>::recvUnrolled(int eltStart, int e
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop>
-template<int Unroll, typename Elt, typename EltToAcc, typename Reduce>
-NCCL_DEVICE_INLINE auto ncclLLA2ASession<Coop>::recvReduce(
-    int eltStart, int eltCount, int eltStride, EltToAcc eltToAcc, Reduce reduce
-  ) -> decltype(eltToAcc(nccl::utility::declval<Elt>())) {
+template <typename Coop>
+template <int Unroll, typename Elt, typename EltToAcc, typename Reduce>
+NCCL_DEVICE_INLINE auto ncclLLA2ASession<Coop>::recvReduce(int eltStart, int eltCount, int eltStride, EltToAcc eltToAcc,
+                                                           Reduce reduce)
+  -> decltype(eltToAcc(nccl::utility::declval<Elt>())) {
   using Acc = decltype(eltToAcc(nccl::utility::declval<Elt>()));
   Acc acc;
   int i = 0;
-  #pragma unroll 1
-  for (; i+Unroll <= eltCount; i += Unroll) {
+#pragma unroll 1
+  for (; i + Unroll <= eltCount; i += Unroll) {
     Elt got[Unroll];
-    this->template recvUnrolled</*Min=*/Unroll>(eltStart + i*eltStride, Unroll, eltStride, got);
+    this->template recvUnrolled</*Min=*/Unroll>(eltStart + i * eltStride, Unroll, eltStride, got);
     Acc acc0 = eltToAcc(got[0]);
-    acc = i==0 ? acc0 : reduce(acc, acc0);
-    #pragma unroll
-    for (int j=1; j < Unroll; j++) acc = reduce(acc, eltToAcc(got[j]));
+    acc = i == 0 ? acc0 : reduce(acc, acc0);
+#pragma unroll
+    for (int j = 1; j < Unroll; j++) acc = reduce(acc, eltToAcc(got[j]));
   }
   if (i < eltCount) {
     Elt got[Unroll];
-    this->template recvUnrolled</*Min=*/1>(eltStart + i*eltStride, eltCount-i, eltStride, got);
+    this->template recvUnrolled</*Min=*/1>(eltStart + i * eltStride, eltCount - i, eltStride, got);
     Acc acc0 = eltToAcc(got[0]);
-    acc = i==0 ? acc0 : reduce(acc, acc0);
-    #pragma unroll
-    for (int j=1; j < Unroll-1; j++) {
-      if (i+j < eltCount) acc = reduce(acc, eltToAcc(got[j]));
+    acc = i == 0 ? acc0 : reduce(acc, acc0);
+#pragma unroll
+    for (int j = 1; j < Unroll - 1; j++) {
+      if (i + j < eltCount) acc = reduce(acc, eltToAcc(got[j]));
     }
   }
   return acc;
@@ -274,14 +280,14 @@ NCCL_DEVICE_INLINE auto ncclLLA2ASession<Coop>::recvReduce(
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop>
+template <typename Coop>
 NCCL_DEVICE_INLINE void ncclLLA2ASession<Coop>::endEpoch(Coop) {
   if (__builtin_expect(this->epoch >= -2u, false)) {
     this->coop.sync();
     uint4* buf = (uint4*)ncclGetResourceBufferLocalPointer(this->comm, this->handle.bufHandle);
     buf += this->slotsOffset;
-    #pragma unroll 4
-    for (int i=this->coop.thread_rank(); i < this->handle.nSlots; i += this->coop.size()) {
+#pragma unroll 4
+    for (int i = this->coop.thread_rank(); i < this->handle.nSlots; i += this->coop.size()) {
 #if defined(__HIP_PLATFORM_AMD__)
       amdLLA2aStoreLine(reinterpret_cast<uint32_t*>(buf + i), 0, 0, 0, 0);
 #else

--- a/projects/rccl/src/include/nccl_device/impl/ll_a2a__types.h
+++ b/projects/rccl/src/include/nccl_device/impl/ll_a2a__types.h
@@ -16,7 +16,7 @@ struct ncclLLA2AHandle {
 };
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop>
+template <typename Coop>
 struct ncclLLA2ASession_internal {
   Coop coop;
   ncclDevComm const& comm;
@@ -30,7 +30,7 @@ struct ncclLLA2ASession_internal {
   uint32_t slotsOffset;
 
   NCCL_DEVICE_INLINE uint32_t calcSlotOffset() const {
-    return block*(1 + 2*handle.nSlots) + 1 + (epoch & 1)*handle.nSlots;
+    return block * (1 + 2 * handle.nSlots) + 1 + (epoch & 1) * handle.nSlots;
   }
 };
 #endif

--- a/projects/rccl/src/include/nccl_device/impl/lsa_barrier__funcs.h
+++ b/projects/rccl/src/include/nccl_device/impl/lsa_barrier__funcs.h
@@ -13,59 +13,51 @@
 #include <atomic>
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop>
-NCCL_DEVICE_INLINE ncclLsaBarrierSession<Coop>::ncclLsaBarrierSession(
-    Coop coop, ncclDevComm const& comm, ncclTeam team,
-    ncclLsaBarrierHandle handle, uint32_t index,
-    bool multimem, ncclMultimemHandle mmHandle
-  ):
-  ncclLsaBarrierSession_internal<Coop>{
-    coop, comm, team, handle, (int)index,
+template <typename Coop>
+NCCL_DEVICE_INLINE ncclLsaBarrierSession<Coop>::ncclLsaBarrierSession(Coop coop, ncclDevComm const& comm, ncclTeam team,
+                                                                      ncclLsaBarrierHandle handle, uint32_t index,
+                                                                      bool multimem, ncclMultimemHandle mmHandle)
+  : ncclLsaBarrierSession_internal<Coop>{coop,     comm,       team, handle, (int)index,
 #if CUDART_VERSION >= 12060
-    multimem,
+                                         multimem,
 #else // WAR for an issue with ptxas in CTK < 12.6
     /*multimem=*/false,
 #endif
-    mmHandle, /*epoch=*/0
-  } {
+                                         mmHandle, /*epoch=*/0} {
   uint32_t* state = (uint32_t*)ncclGetResourceBufferLocalPointer(comm, handle.bufHandle);
-  this->epoch = state[(this->multimem ? 0 : 1)*this->handle.nBarriers + this->index];
+  this->epoch = state[(this->multimem ? 0 : 1) * this->handle.nBarriers + this->index];
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop>
-NCCL_DEVICE_INLINE ncclLsaBarrierSession<Coop>::ncclLsaBarrierSession(
-    Coop coop, ncclDevComm const& comm, ncclTeamTagLsa, uint32_t index, bool multimem
-  ): ncclLsaBarrierSession(
-    coop, comm, ncclTeamLsa(comm), comm.lsaBarrier, index, multimem, comm.lsaMultimem
-  ) {
-}
+template <typename Coop>
+NCCL_DEVICE_INLINE ncclLsaBarrierSession<Coop>::ncclLsaBarrierSession(Coop coop, ncclDevComm const& comm,
+                                                                      ncclTeamTagLsa, uint32_t index, bool multimem)
+  : ncclLsaBarrierSession(coop, comm, ncclTeamLsa(comm), comm.lsaBarrier, index, multimem, comm.lsaMultimem) {}
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop>
+template <typename Coop>
 NCCL_DEVICE_INLINE ncclLsaBarrierSession<Coop>::~ncclLsaBarrierSession() {
   uint32_t* state = (uint32_t*)ncclGetResourceBufferLocalPointer(this->comm, this->handle.bufHandle);
   if (this->coop.thread_rank() == 0) {
 #if __CUDA_ARCH__ == 1200 && CUDART_VERSION < 13000
     // WAR for a compiler issue with CTK < 13.0
-    if (this->index == 0)
-      state[(this->multimem ? 0 : 1)*this->handle.nBarriers] = this->epoch;
+    if (this->index == 0) state[(this->multimem ? 0 : 1) * this->handle.nBarriers] = this->epoch;
     else
 #endif
-    state[(this->multimem ? 0 : 1)*this->handle.nBarriers + this->index] = this->epoch;
+      state[(this->multimem ? 0 : 1) * this->handle.nBarriers + this->index] = this->epoch;
   }
   this->coop.sync();
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop>
+template <typename Coop>
 NCCL_DEVICE_INLINE void ncclLsaBarrierSession<Coop>::arrive(Coop, cuda::memory_order order) {
   this->coop.sync();
   if (this->multimem) {
-  #if NCCL_ARCH_HAS_MULTIMEM
+#if NCCL_ARCH_HAS_MULTIMEM
     if (this->coop.thread_rank() == 0) {
       uint32_t* inbox = this->mcInbox(/*multimem=*/true);
       if (nccl::utility::releaseOrderOf(order) != cuda::memory_order_relaxed) {
@@ -74,24 +66,24 @@ NCCL_DEVICE_INLINE void ncclLsaBarrierSession<Coop>::arrive(Coop, cuda::memory_o
         nccl_multimem_red_relaxed_add_u32(inbox);
       }
     }
-  #endif
+#endif
   } else {
     if (this->team.nRanks > 1) {
       cuda::atomic_thread_fence(nccl::utility::releaseOrderOf(order));
     }
-    #pragma unroll 1
-    for (int i = this->coop.thread_rank(); i < this->team.nRanks-1; i += this->coop.size()) {
+#pragma unroll 1
+    for (int i = this->coop.thread_rank(); i < this->team.nRanks - 1; i += this->coop.size()) {
       int peer = i + (this->team.rank <= i ? 1 : 0);
       cuda::atomic_ref<uint32_t> inbox(*this->ucInbox(peer, this->team.rank));
-      inbox.store(this->epoch+1, cuda::memory_order_relaxed);
+      inbox.store(this->epoch + 1, cuda::memory_order_relaxed);
     }
   }
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop>
-template<bool EnableTimeout>
+template <typename Coop>
+template <bool EnableTimeout>
 NCCL_DEVICE_INLINE ncclResult_t ncclLsaBarrierSession_internal<Coop>::waitInternal(Coop, cuda::memory_order order,
                                                                                    uint64_t timeoutCycles) {
   using nccl::utility::testAbort;
@@ -104,13 +96,13 @@ NCCL_DEVICE_INLINE ncclResult_t ncclLsaBarrierSession_internal<Coop>::waitIntern
     steps = 0;
   }
   if (this->multimem) {
-  #if NCCL_ARCH_HAS_MULTIMEM
+#if NCCL_ARCH_HAS_MULTIMEM
     if (this->coop.thread_rank() == 0) {
       cuda::atomic_ref<uint32_t> inbox(*this->mcInbox(/*multimem=*/false));
-      #pragma unroll 1
+#pragma unroll 1
       while (true) {
         uint32_t got = inbox.load(nccl::utility::acquireOrderOf(order));
-        if (got - (this->epoch + this->team.nRanks) <= uint32_t(-1)>>1) break;
+        if (got - (this->epoch + this->team.nRanks) <= uint32_t(-1) >> 1) break;
 
         if NCCL_IF_CONSTEXPR (EnableTimeout) {
           if (clock64() - startCycle >= timeoutCycles) {
@@ -123,16 +115,16 @@ NCCL_DEVICE_INLINE ncclResult_t ncclLsaBarrierSession_internal<Coop>::waitIntern
       }
       this->epoch += this->team.nRanks;
     }
-  #endif
+#endif
   } else {
-    #pragma unroll 1
-    for (int i = this->coop.thread_rank(); i < this->team.nRanks-1; i += this->coop.size()) {
+#pragma unroll 1
+    for (int i = this->coop.thread_rank(); i < this->team.nRanks - 1; i += this->coop.size()) {
       int peer = i + (this->team.rank <= i ? 1 : 0);
       cuda::atomic_ref<uint32_t> inbox(*this->ucInbox(this->team.rank, peer));
-      #pragma unroll 1
+#pragma unroll 1
       while (true) {
         uint32_t got = inbox.load(nccl::utility::acquireOrderOf(order));
-        if (got - (this->epoch + 1) <= uint32_t(-1)>>1) break;
+        if (got - (this->epoch + 1) <= uint32_t(-1) >> 1) break;
 
         if NCCL_IF_CONSTEXPR (EnableTimeout) {
           if (clock64() - startCycle >= timeoutCycles) {
@@ -154,23 +146,23 @@ exit:
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop>
+template <typename Coop>
 NCCL_DEVICE_INLINE void ncclLsaBarrierSession<Coop>::wait(Coop coop, cuda::memory_order order) {
   (void)(this->template waitInternal</*EnableTimeout=*/false>(coop, order, 0ULL));
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop>
-NCCL_DEVICE_INLINE ncclResult_t ncclLsaBarrierSession<Coop>::wait(
-    Coop coop, cuda::memory_order order, uint64_t timeoutCycles) {
+template <typename Coop>
+NCCL_DEVICE_INLINE ncclResult_t ncclLsaBarrierSession<Coop>::wait(Coop coop, cuda::memory_order order,
+                                                                  uint64_t timeoutCycles) {
   this->coop.sync();
   return this->template waitInternal</*EnableTimeout=*/true>(coop, order, timeoutCycles);
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop>
+template <typename Coop>
 NCCL_DEVICE_INLINE void ncclLsaBarrierSession<Coop>::sync(Coop coop, cuda::memory_order order) {
   this->arrive(coop, order);
   this->wait(coop, order);
@@ -178,9 +170,9 @@ NCCL_DEVICE_INLINE void ncclLsaBarrierSession<Coop>::sync(Coop coop, cuda::memor
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop>
-NCCL_DEVICE_INLINE ncclResult_t ncclLsaBarrierSession<Coop>::sync(
-    Coop coop, cuda::memory_order order, uint64_t timeoutCycles) {
+template <typename Coop>
+NCCL_DEVICE_INLINE ncclResult_t ncclLsaBarrierSession<Coop>::sync(Coop coop, cuda::memory_order order,
+                                                                  uint64_t timeoutCycles) {
   this->arrive(coop, order);
   return this->wait(coop, order, timeoutCycles);
 }

--- a/projects/rccl/src/include/nccl_device/impl/lsa_barrier__types.h
+++ b/projects/rccl/src/include/nccl_device/impl/lsa_barrier__types.h
@@ -16,7 +16,7 @@ struct ncclLsaBarrierHandle {
 };
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop>
+template <typename Coop>
 struct ncclLsaBarrierSession_internal {
   Coop coop;
   ncclDevComm const& comm;
@@ -34,15 +34,15 @@ struct ncclLsaBarrierSession_internal {
     } else { // unicast
       state = (uint32_t*)ncclGetResourceBufferLocalPointer(comm, handle.bufHandle);
     }
-    return state + 2*handle.nBarriers + index;
+    return state + 2 * handle.nBarriers + index;
   }
 
   NCCL_DEVICE_INLINE uint32_t* ucInbox(int owner, int peer) {
     uint32_t* state = (uint32_t*)ncclGetResourceBufferPeerPointer(comm, handle.bufHandle, team, owner);
-    return state + 3*handle.nBarriers + index*team.nRanks + peer;
+    return state + 3 * handle.nBarriers + index * team.nRanks + peer;
   }
 
-  template<bool EnableTimeout>
+  template <bool EnableTimeout>
   NCCL_DEVICE_INLINE ncclResult_t waitInternal(Coop, cuda::memory_order order, uint64_t timeoutCycles);
 };
 #endif

--- a/projects/rccl/src/include/nccl_device/impl/multimem__funcs.h
+++ b/projects/rccl/src/include/nccl_device/impl/multimem__funcs.h
@@ -20,248 +20,250 @@ namespace nccl {
 namespace utility {
 
 // Load helper that selects multimem vs LSA and validates support at compile time.
-template<typename Pack, bool UseMultimem, typename RedOp, int Count = Pack::Count>
+template <typename Pack, bool UseMultimem, typename RedOp, int Count = Pack::Count>
 struct LoadImpl {
   NCCL_DEVICE_INLINE static Pack run(const Pack* addr) {
     using PackEltType = typename Pack::EltType;
     static_assert(!UseMultimem || std::is_same<RedOp, OpSum<PackEltType>>::value,
                   "Multimem sources only support OpSum - use LSA sources for custom RedOp");
-    static_assert(!UseMultimem || (!std::is_same<PackEltType, int8_t>::value &&
-                                   !std::is_same<PackEltType, uint8_t>::value),
+    static_assert(!UseMultimem ||
+                    (!std::is_same<PackEltType, int8_t>::value && !std::is_same<PackEltType, uint8_t>::value),
                   "int8_t and uint8_t are not supported for multimem sources - use LSA sources");
-    #if __CUDA_ARCH__ < 900
+#if __CUDA_ARCH__ < 900
     if (UseMultimem) {
       assert(false && "multimem is not supported on architectures < sm_90");
       return Pack{};
     }
-    #else
-    static_assert(!UseMultimem,
-                  "multimem load not implemented for this pack type. "
-                  "A multimem specialization is not possible for this type.");
-    #endif
+#else
+    static_assert(!UseMultimem, "multimem load not implemented for this pack type. "
+                                "A multimem specialization is not possible for this type.");
+#endif
     return *addr;
   }
 };
 
 // Empty packs (0 elements) - just return empty pack
-template<typename Pack, bool UseMultimem, typename RedOp>
+template <typename Pack, bool UseMultimem, typename RedOp>
 struct LoadImpl<Pack, UseMultimem, RedOp, 0> {
   NCCL_DEVICE_INLINE static Pack run(const Pack* addr) {
     return Pack{};
   }
 };
 
-template<typename Pack, bool UseMultimem, typename RedOp>
+template <typename Pack, bool UseMultimem, typename RedOp>
 NCCL_DEVICE_INLINE Pack load(const Pack* addr) {
   return LoadImpl<Pack, UseMultimem, RedOp>::run(addr);
 }
 #if __CUDA_ARCH__ >= 900
 
 // Double precision - single element
-template<>
+template <>
 NCCL_DEVICE_INLINE EltPack<double, 1> load<EltPack<double, 1>, true, OpSum<double>>(const EltPack<double, 1>* addr) {
-    EltPack<double, 1> result;
-    double value;
-    asm volatile("multimem.ld_reduce.global.add.f64 %0, [%1];"
-                 : "=d"(value)
-                 : "l"(__cvta_generic_to_global(addr))
-                 : "memory");
-    result.elts()[0] = value;
-    return result;
-  }
+  EltPack<double, 1> result;
+  double value;
+  asm volatile("multimem.ld_reduce.global.add.f64 %0, [%1];"
+               : "=d"(value)
+               : "l"(__cvta_generic_to_global(addr))
+               : "memory");
+  result.elts()[0] = value;
+  return result;
+}
 
 // Double precision - 2 elements (2 x 64-bit = 128 bits)
 // Note: No 128-bit multimem.ld_reduce for double, use 2 separate .f64 operations
-template<>
+template <>
 NCCL_DEVICE_INLINE EltPack<double, 2> load<EltPack<double, 2>, true, OpSum<double>>(const EltPack<double, 2>* addr) {
-    EltPack<double, 2> result;
-    double* elems = result.elts();
-    const char* base_addr = reinterpret_cast<const char*>(addr);
+  EltPack<double, 2> result;
+  double* elems = result.elts();
+  const char* base_addr = reinterpret_cast<const char*>(addr);
 
     // Load 2 separate f64 values (no vector instruction available)
     // Use unrolled loop calling the 1-element version
-    #pragma unroll
-    for (int i = 0; i < 2; i++) {
-      EltPack<double, 1> loaded = load<EltPack<double, 1>, true, OpSum<double>>(
-          reinterpret_cast<const EltPack<double, 1>*>(base_addr + i * sizeof(double)));
-      elems[i] = loaded.elts()[0];
-    }
-    return result;
+#pragma unroll
+  for (int i = 0; i < 2; i++) {
+    EltPack<double, 1> loaded = load<EltPack<double, 1>, true, OpSum<double>>(
+      reinterpret_cast<const EltPack<double, 1>*>(base_addr + i * sizeof(double)));
+    elems[i] = loaded.elts()[0];
   }
+  return result;
+}
 
 // Float precision - single element
-template<>
+template <>
 NCCL_DEVICE_INLINE EltPack<float, 1> load<EltPack<float, 1>, true, OpSum<float>>(const EltPack<float, 1>* addr) {
-    EltPack<float, 1> result;
-    float value;
-    asm volatile("multimem.ld_reduce.global.add.f32 %0, [%1];"
-                 : "=f"(value)
-                 : "l"(__cvta_generic_to_global(addr))
-                 : "memory");
-    result.elts()[0] = value;
-    return result;
-  }
+  EltPack<float, 1> result;
+  float value;
+  asm volatile("multimem.ld_reduce.global.add.f32 %0, [%1];"
+               : "=f"(value)
+               : "l"(__cvta_generic_to_global(addr))
+               : "memory");
+  result.elts()[0] = value;
+  return result;
+}
 
 // Float precision - 2 elements
-template<>
+template <>
 NCCL_DEVICE_INLINE EltPack<float, 2> load<EltPack<float, 2>, true, OpSum<float>>(const EltPack<float, 2>* addr) {
-    EltPack<float, 2> result;
-    float2 value;
-    asm volatile("multimem.ld_reduce.global.add.v2.f32 {%0, %1}, [%2];"
-                 : "=f"(value.x), "=f"(value.y)
-                 : "l"(__cvta_generic_to_global(addr))
-                 : "memory");
-    result.elts()[0] = value.x;
-    result.elts()[1] = value.y;
-    return result;
-  }
+  EltPack<float, 2> result;
+  float2 value;
+  asm volatile("multimem.ld_reduce.global.add.v2.f32 {%0, %1}, [%2];"
+               : "=f"(value.x), "=f"(value.y)
+               : "l"(__cvta_generic_to_global(addr))
+               : "memory");
+  result.elts()[0] = value.x;
+  result.elts()[1] = value.y;
+  return result;
+}
 
 // Float precision - 4 elements
-template<>
+template <>
 NCCL_DEVICE_INLINE EltPack<float, 4> load<EltPack<float, 4>, true, OpSum<float>>(const EltPack<float, 4>* addr) {
-    EltPack<float, 4> result;
-    float4 value;
-    asm volatile("multimem.ld_reduce.global.add.v4.f32 {%0, %1, %2, %3}, [%4];"
-                 : "=f"(value.x), "=f"(value.y), "=f"(value.z), "=f"(value.w)
-                 : "l"(__cvta_generic_to_global(addr))
-                 : "memory");
-    float* elems = result.elts();
-    elems[0] = value.x;
-    elems[1] = value.y;
-    elems[2] = value.z;
-    elems[3] = value.w;
-    return result;
-  }
+  EltPack<float, 4> result;
+  float4 value;
+  asm volatile("multimem.ld_reduce.global.add.v4.f32 {%0, %1, %2, %3}, [%4];"
+               : "=f"(value.x), "=f"(value.y), "=f"(value.z), "=f"(value.w)
+               : "l"(__cvta_generic_to_global(addr))
+               : "memory");
+  float* elems = result.elts();
+  elems[0] = value.x;
+  elems[1] = value.y;
+  elems[2] = value.z;
+  elems[3] = value.w;
+  return result;
+}
 
 // Half precision - 2 elements (minimum: 2 halves = 32 bits)
-template<>
+template <>
 NCCL_DEVICE_INLINE EltPack<half, 2> load<EltPack<half, 2>, true, OpSum<half>>(const EltPack<half, 2>* addr) {
-    EltPack<half, 2> result;
+  EltPack<half, 2> result;
+  uint32_t raw;
+  asm volatile("multimem.ld_reduce.global.add.acc::f32.f16x2 %0, [%1];"
+               : "=r"(raw)
+               : "l"(__cvta_generic_to_global(addr))
+               : "memory");
+  union {
     uint32_t raw;
-    asm volatile("multimem.ld_reduce.global.add.acc::f32.f16x2 %0, [%1];"
-                 : "=r"(raw)
-                 : "l"(__cvta_generic_to_global(addr))
-                 : "memory");
-    union {
-      uint32_t raw;
-      half elts[2];
-    } packed{raw};
-    result.elts()[0] = packed.elts[0];
-    result.elts()[1] = packed.elts[1];
-    return result;
-  }
+    half elts[2];
+  } packed{raw};
+  result.elts()[0] = packed.elts[0];
+  result.elts()[1] = packed.elts[1];
+  return result;
+}
 
 // Half precision - single element (trick: load as f16x2, extract one half)
-template<>
+template <>
 NCCL_DEVICE_INLINE EltPack<half, 1> load<EltPack<half, 1>, true, OpSum<half>>(const EltPack<half, 1>* addr) {
 #ifndef NCCL_DEVICE_PERMIT_EXPERIMENTAL_CODE
-    assert(false && "Experimental NCCL device code detected; you may accept the risk "
-                    "of this not being available in the future. If you accept that risk, "
-                    "set NCCL_DEVICE_PERMIT_EXPERIMENTAL_CODE during compilation or "
-                    "refactor the code. More details "
-                    "https://docs.nvidia.com/cuda/parallel-thread-execution/#addresses-as-operands");
-    return EltPack<half, 1>{};
+  assert(false && "Experimental NCCL device code detected; you may accept the risk "
+                  "of this not being available in the future. If you accept that risk, "
+                  "set NCCL_DEVICE_PERMIT_EXPERIMENTAL_CODE during compilation or "
+                  "refactor the code. More details "
+                  "https://docs.nvidia.com/cuda/parallel-thread-execution/#addresses-as-operands");
+  return EltPack<half, 1>{};
 #else
     // Align address to 4 bytes for f16x2 load
-    const char* charAddr = reinterpret_cast<const char*>(addr);
-    const size_t offset = reinterpret_cast<size_t>(addr) & 3;
-    const char* alignedAddr = charAddr - offset;
+  const char* charAddr = reinterpret_cast<const char*>(addr);
+  const size_t offset = reinterpret_cast<size_t>(addr) & 3;
+  const char* alignedAddr = charAddr - offset;
     // Load as EltPack<half, 2> and extract the correct half
-    EltPack<half, 2> loaded = load<EltPack<half, 2>, true, OpSum<half>>(
-        reinterpret_cast<const EltPack<half, 2>*>(alignedAddr));
-    EltPack<half, 1> result;
-    const half* loadedElts = loaded.elts();
+  EltPack<half, 2> loaded =
+    load<EltPack<half, 2>, true, OpSum<half>>(reinterpret_cast<const EltPack<half, 2>*>(alignedAddr));
+  EltPack<half, 1> result;
+  const half* loadedElts = loaded.elts();
     // Extract the correct half based on address offset
-    result.elts()[0] = loadedElts[offset / sizeof(half)];
-    return result;
+  result.elts()[0] = loadedElts[offset / sizeof(half)];
+  return result;
 #endif
-  }
+}
 
 // Half precision - 8 elements (8 halves = 128 bits)
-template<>
+template <>
 NCCL_DEVICE_INLINE EltPack<half, 8> load<EltPack<half, 8>, true, OpSum<half>>(const EltPack<half, 8>* addr) {
-    EltPack<half, 8> result;
+  EltPack<half, 8> result;
+  uint32_t raw[4];
+  asm volatile("multimem.ld_reduce.global.add.acc::f32.v4.f16x2 {%0, %1, %2, %3}, [%4];"
+               : "=r"(raw[0]), "=r"(raw[1]), "=r"(raw[2]), "=r"(raw[3])
+               : "l"(__cvta_generic_to_global(addr))
+               : "memory");
+  union {
     uint32_t raw[4];
-    asm volatile("multimem.ld_reduce.global.add.acc::f32.v4.f16x2 {%0, %1, %2, %3}, [%4];"
-                 : "=r"(raw[0]), "=r"(raw[1]), "=r"(raw[2]), "=r"(raw[3])
-                 : "l"(__cvta_generic_to_global(addr))
-                 : "memory");
-    union {
-      uint32_t raw[4];
-      half elts[8];
-    } packed{{raw[0], raw[1], raw[2], raw[3]}};
-    half* out = result.elts();
-    #pragma unroll 8
-    for (int i = 0; i < 8; i++) out[i] = packed.elts[i];
-    return result;
-  }
+    half elts[8];
+  } packed{{raw[0], raw[1], raw[2], raw[3]}};
+  half* out = result.elts();
+#pragma unroll 8
+  for (int i = 0; i < 8; i++) out[i] = packed.elts[i];
+  return result;
+}
 
 #if defined(__CUDA_BF16_TYPES_EXIST__)
 // Bfloat16 precision - 2 elements (minimum: 2 bf16s = 32 bits)
 // Uses bf16x2 multimem instruction (not f16x2 - bf16 has different format than half)
-template<>
-NCCL_DEVICE_INLINE EltPack<__nv_bfloat16, 2> load<EltPack<__nv_bfloat16, 2>, true, OpSum<__nv_bfloat16>>(const EltPack<__nv_bfloat16, 2>* addr) {
-    EltPack<__nv_bfloat16, 2> result;
-    uint32_t raw;
+template <>
+NCCL_DEVICE_INLINE EltPack<__nv_bfloat16, 2> load<EltPack<__nv_bfloat16, 2>, true, OpSum<__nv_bfloat16>>(
+  const EltPack<__nv_bfloat16, 2>* addr) {
+  EltPack<__nv_bfloat16, 2> result;
+  uint32_t raw;
     // Use bf16x2 instruction - bf16 requires its own instruction format
-    asm volatile("multimem.ld_reduce.global.add.acc::f32.bf16x2 %0, [%1];"
-                 : "=r"(raw)
-                 : "l"(__cvta_generic_to_global(addr))
-                 : "memory");
-    union {
-      uint32_t raw;
-      __nv_bfloat16 elts[2];
-    } packed{raw};
-    result.elts()[0] = packed.elts[0];
-    result.elts()[1] = packed.elts[1];
-    return result;
-  }
+  asm volatile("multimem.ld_reduce.global.add.acc::f32.bf16x2 %0, [%1];"
+               : "=r"(raw)
+               : "l"(__cvta_generic_to_global(addr))
+               : "memory");
+  union {
+    uint32_t raw;
+    __nv_bfloat16 elts[2];
+  } packed{raw};
+  result.elts()[0] = packed.elts[0];
+  result.elts()[1] = packed.elts[1];
+  return result;
+}
 
 // Bfloat16 precision - single element (trick: load as bf16x2, extract one bf16)
-template<>
-NCCL_DEVICE_INLINE EltPack<__nv_bfloat16, 1> load<EltPack<__nv_bfloat16, 1>, true, OpSum<__nv_bfloat16>>(const EltPack<__nv_bfloat16, 1>* addr) {
+template <>
+NCCL_DEVICE_INLINE EltPack<__nv_bfloat16, 1> load<EltPack<__nv_bfloat16, 1>, true, OpSum<__nv_bfloat16>>(
+  const EltPack<__nv_bfloat16, 1>* addr) {
 #ifndef NCCL_DEVICE_PERMIT_EXPERIMENTAL_CODE
-    assert(false && "Experimental NCCL device code detected; you may accept the risk "
-                    "of this not being available in the future. If you accept that risk, "
-                    "set NCCL_DEVICE_PERMIT_EXPERIMENTAL_CODE during compilation or "
-                    "refactor the code. More details "
-                    "https://docs.nvidia.com/cuda/parallel-thread-execution/#addresses-as-operands");
-    return EltPack<__nv_bfloat16, 1>{};
+  assert(false && "Experimental NCCL device code detected; you may accept the risk "
+                  "of this not being available in the future. If you accept that risk, "
+                  "set NCCL_DEVICE_PERMIT_EXPERIMENTAL_CODE during compilation or "
+                  "refactor the code. More details "
+                  "https://docs.nvidia.com/cuda/parallel-thread-execution/#addresses-as-operands");
+  return EltPack<__nv_bfloat16, 1>{};
 #else
     // Align address to 4 bytes for bf16x2 load
-    const char* charAddr = reinterpret_cast<const char*>(addr);
-    const size_t offset = reinterpret_cast<size_t>(addr) & 3;
-    const char* alignedAddr = charAddr - offset;
+  const char* charAddr = reinterpret_cast<const char*>(addr);
+  const size_t offset = reinterpret_cast<size_t>(addr) & 3;
+  const char* alignedAddr = charAddr - offset;
     // Load as EltPack<__nv_bfloat16, 2> and extract the correct bf16
-    EltPack<__nv_bfloat16, 2> loaded = load<EltPack<__nv_bfloat16, 2>, true, OpSum<__nv_bfloat16>>(
-        reinterpret_cast<const EltPack<__nv_bfloat16, 2>*>(alignedAddr));
-    EltPack<__nv_bfloat16, 1> result;
-    const __nv_bfloat16* loadedElts = loaded.elts();
+  EltPack<__nv_bfloat16, 2> loaded = load<EltPack<__nv_bfloat16, 2>, true, OpSum<__nv_bfloat16>>(
+    reinterpret_cast<const EltPack<__nv_bfloat16, 2>*>(alignedAddr));
+  EltPack<__nv_bfloat16, 1> result;
+  const __nv_bfloat16* loadedElts = loaded.elts();
     // Extract the correct bf16 based on address offset
-    result.elts()[0] = loadedElts[offset / sizeof(__nv_bfloat16)];
-    return result;
+  result.elts()[0] = loadedElts[offset / sizeof(__nv_bfloat16)];
+  return result;
 #endif
-  }
+}
 
 // Bfloat16 precision - 8 elements (8 bf16s = 128 bits)
-template<>
-NCCL_DEVICE_INLINE EltPack<__nv_bfloat16, 8> load<EltPack<__nv_bfloat16, 8>, true, OpSum<__nv_bfloat16>>(const EltPack<__nv_bfloat16, 8>* addr) {
+template <>
+NCCL_DEVICE_INLINE EltPack<__nv_bfloat16, 8> load<EltPack<__nv_bfloat16, 8>, true, OpSum<__nv_bfloat16>>(
+  const EltPack<__nv_bfloat16, 8>* addr) {
     // Use v4.bf16x2 instruction - bf16 requires its own instruction format
-    EltPack<__nv_bfloat16, 8> result;
+  EltPack<__nv_bfloat16, 8> result;
+  uint32_t raw[4];
+  asm volatile("multimem.ld_reduce.global.add.acc::f32.v4.bf16x2 {%0, %1, %2, %3}, [%4];"
+               : "=r"(raw[0]), "=r"(raw[1]), "=r"(raw[2]), "=r"(raw[3])
+               : "l"(__cvta_generic_to_global(addr))
+               : "memory");
+  union {
     uint32_t raw[4];
-    asm volatile("multimem.ld_reduce.global.add.acc::f32.v4.bf16x2 {%0, %1, %2, %3}, [%4];"
-                 : "=r"(raw[0]), "=r"(raw[1]), "=r"(raw[2]), "=r"(raw[3])
-                 : "l"(__cvta_generic_to_global(addr))
-                 : "memory");
-    union {
-      uint32_t raw[4];
-      __nv_bfloat16 elts[8];
-    } packed{{raw[0], raw[1], raw[2], raw[3]}};
-    __nv_bfloat16* out = result.elts();
-    #pragma unroll 8
-    for (int i = 0; i < 8; i++) out[i] = packed.elts[i];
-    return result;
-  }
+    __nv_bfloat16 elts[8];
+  } packed{{raw[0], raw[1], raw[2], raw[3]}};
+  __nv_bfloat16* out = result.elts();
+#pragma unroll 8
+  for (int i = 0; i < 8; i++) out[i] = packed.elts[i];
+  return result;
+}
 #endif
 
 #if defined(__CUDA_FP8_TYPES_EXIST__)
@@ -272,374 +274,374 @@ NCCL_DEVICE_INLINE EltPack<__nv_bfloat16, 8> load<EltPack<__nv_bfloat16, 8>, tru
 //   - NOT supported on sm_103 (10.3) or other unsupported variants
 // Uses __CUDA_ARCH_FAMILY_SPECIFIC__ and __CUDA_ARCH_SPECIFIC__ when available (CUDA 12.9+)
 // Only define FP8 multimem specializations for supported architectures - otherwise fallback to generic template
-template<>
-NCCL_DEVICE_INLINE EltPack<__nv_fp8_e4m3, 4> load<EltPack<__nv_fp8_e4m3, 4>, true, OpSum<__nv_fp8_e4m3>>(const EltPack<__nv_fp8_e4m3, 4>* addr) {
-    #if (defined(__CUDA_ARCH_SPECIFIC__) && \
-         (__CUDA_ARCH_SPECIFIC__ == 1000 || \
-          __CUDA_ARCH_SPECIFIC__ == 1010 || \
-          __CUDA_ARCH_SPECIFIC__ == 1200 || \
-          __CUDA_ARCH_SPECIFIC__ == 1210)) || \
-        (defined(__CUDA_ARCH_FAMILY_SPECIFIC__) && \
-         (__CUDA_ARCH_FAMILY_SPECIFIC__ == 1000 || \
-          __CUDA_ARCH_FAMILY_SPECIFIC__ == 1010))
-    EltPack<__nv_fp8_e4m3, 4> result;
-    uint32_t raw;
+template <>
+NCCL_DEVICE_INLINE EltPack<__nv_fp8_e4m3, 4> load<EltPack<__nv_fp8_e4m3, 4>, true, OpSum<__nv_fp8_e4m3>>(
+  const EltPack<__nv_fp8_e4m3, 4>* addr) {
+#if (defined(__CUDA_ARCH_SPECIFIC__) && (__CUDA_ARCH_SPECIFIC__ == 1000 || __CUDA_ARCH_SPECIFIC__ == 1010 || \
+                                         __CUDA_ARCH_SPECIFIC__ == 1200 || __CUDA_ARCH_SPECIFIC__ == 1210)) || \
+  (defined(__CUDA_ARCH_FAMILY_SPECIFIC__) && \
+   (__CUDA_ARCH_FAMILY_SPECIFIC__ == 1000 || __CUDA_ARCH_FAMILY_SPECIFIC__ == 1010))
+  EltPack<__nv_fp8_e4m3, 4> result;
+  uint32_t raw;
     // Use e4m3x4 instruction with .acc::f16 accumulation
-    asm volatile("multimem.ld_reduce.global.add.acc::f16.e4m3x4 %0, [%1];"
-                 : "=r"(raw)
-                 : "l"(__cvta_generic_to_global(addr))
-                 : "memory");
-    union {
-      uint32_t raw;
-      __nv_fp8_e4m3 elts[4];
-    } packed{raw};
-    __nv_fp8_e4m3* out = result.elts();
-    #pragma unroll
-    for (int i = 0; i < 4; i++) out[i] = packed.elts[i];
-    return result;
-    #else
-    assert(false && "FP8 multimem is not supported on this architecture.");
-    return EltPack<__nv_fp8_e4m3, 4>{};
-    #endif
-  }
+  asm volatile("multimem.ld_reduce.global.add.acc::f16.e4m3x4 %0, [%1];"
+               : "=r"(raw)
+               : "l"(__cvta_generic_to_global(addr))
+               : "memory");
+  union {
+    uint32_t raw;
+    __nv_fp8_e4m3 elts[4];
+  } packed{raw};
+  __nv_fp8_e4m3* out = result.elts();
+#pragma unroll
+  for (int i = 0; i < 4; i++) out[i] = packed.elts[i];
+  return result;
+#else
+  assert(false && "FP8 multimem is not supported on this architecture.");
+  return EltPack<__nv_fp8_e4m3, 4>{};
+#endif
+}
 
 // FP8 E4M3 precision - 2 elements (trick: load as e4m3x4, extract two fp8s)
-template<>
-NCCL_DEVICE_INLINE EltPack<__nv_fp8_e4m3, 2> load<EltPack<__nv_fp8_e4m3, 2>, true, OpSum<__nv_fp8_e4m3>>(const EltPack<__nv_fp8_e4m3, 2>* addr) {
+template <>
+NCCL_DEVICE_INLINE EltPack<__nv_fp8_e4m3, 2> load<EltPack<__nv_fp8_e4m3, 2>, true, OpSum<__nv_fp8_e4m3>>(
+  const EltPack<__nv_fp8_e4m3, 2>* addr) {
 #ifndef NCCL_DEVICE_PERMIT_EXPERIMENTAL_CODE
-    assert(false && "Experimental NCCL device code detected; you may accept the risk "
-                    "of this not being available in the future. If you accept that risk, "
-                    "set NCCL_DEVICE_PERMIT_EXPERIMENTAL_CODE during compilation or "
-                    "refactor the code. More details "
-                    "https://docs.nvidia.com/cuda/parallel-thread-execution/#addresses-as-operands");
-    return EltPack<__nv_fp8_e4m3, 2>{};
+  assert(false && "Experimental NCCL device code detected; you may accept the risk "
+                  "of this not being available in the future. If you accept that risk, "
+                  "set NCCL_DEVICE_PERMIT_EXPERIMENTAL_CODE during compilation or "
+                  "refactor the code. More details "
+                  "https://docs.nvidia.com/cuda/parallel-thread-execution/#addresses-as-operands");
+  return EltPack<__nv_fp8_e4m3, 2>{};
 #else
     // Align address to 4 bytes for e4m3x4 load
-    const char* charAddr = reinterpret_cast<const char*>(addr);
-    const size_t offset = reinterpret_cast<size_t>(addr) & 3;
-    const char* alignedAddr = charAddr - offset;
+  const char* charAddr = reinterpret_cast<const char*>(addr);
+  const size_t offset = reinterpret_cast<size_t>(addr) & 3;
+  const char* alignedAddr = charAddr - offset;
     // Load as EltPack<__nv_fp8_e4m3, 4> and extract the correct two fp8s
-    EltPack<__nv_fp8_e4m3, 4> loaded = load<EltPack<__nv_fp8_e4m3, 4>, true, OpSum<__nv_fp8_e4m3>>(
-        reinterpret_cast<const EltPack<__nv_fp8_e4m3, 4>*>(alignedAddr));
-    EltPack<__nv_fp8_e4m3, 2> result;
+  EltPack<__nv_fp8_e4m3, 4> loaded = load<EltPack<__nv_fp8_e4m3, 4>, true, OpSum<__nv_fp8_e4m3>>(
+    reinterpret_cast<const EltPack<__nv_fp8_e4m3, 4>*>(alignedAddr));
+  EltPack<__nv_fp8_e4m3, 2> result;
     // Extract the correct two fp8s based on address offset
-    const __nv_fp8_e4m3* loadedElts = loaded.elts();
-    const int startIdx = offset / sizeof(__nv_fp8_e4m3);
-    __nv_fp8_e4m3* resultElts = result.elts();
-    resultElts[0] = loadedElts[startIdx];
-    resultElts[1] = loadedElts[startIdx + 1];
-    return result;
+  const __nv_fp8_e4m3* loadedElts = loaded.elts();
+  const int startIdx = offset / sizeof(__nv_fp8_e4m3);
+  __nv_fp8_e4m3* resultElts = result.elts();
+  resultElts[0] = loadedElts[startIdx];
+  resultElts[1] = loadedElts[startIdx + 1];
+  return result;
 #endif
 }
 
 // FP8 E4M3 precision - single element (trick: load as e4m3x4, extract one fp8)
-template<>
-NCCL_DEVICE_INLINE EltPack<__nv_fp8_e4m3, 1> load<EltPack<__nv_fp8_e4m3, 1>, true, OpSum<__nv_fp8_e4m3>>(const EltPack<__nv_fp8_e4m3, 1>* addr) {
+template <>
+NCCL_DEVICE_INLINE EltPack<__nv_fp8_e4m3, 1> load<EltPack<__nv_fp8_e4m3, 1>, true, OpSum<__nv_fp8_e4m3>>(
+  const EltPack<__nv_fp8_e4m3, 1>* addr) {
 #ifndef NCCL_DEVICE_PERMIT_EXPERIMENTAL_CODE
-    assert(false && "Experimental NCCL device code detected; you may accept the risk "
-                    "of this not being available in the future. If you accept that risk, "
-                    "set NCCL_DEVICE_PERMIT_EXPERIMENTAL_CODE during compilation or "
-                    "refactor the code. More details "
-                    "https://docs.nvidia.com/cuda/parallel-thread-execution/#addresses-as-operands");
-    return EltPack<__nv_fp8_e4m3, 1>{};
+  assert(false && "Experimental NCCL device code detected; you may accept the risk "
+                  "of this not being available in the future. If you accept that risk, "
+                  "set NCCL_DEVICE_PERMIT_EXPERIMENTAL_CODE during compilation or "
+                  "refactor the code. More details "
+                  "https://docs.nvidia.com/cuda/parallel-thread-execution/#addresses-as-operands");
+  return EltPack<__nv_fp8_e4m3, 1>{};
 #else
     // Align address to 4 bytes for e4m3x4 load
-    const char* charAddr = reinterpret_cast<const char*>(addr);
-    const size_t offset = reinterpret_cast<size_t>(addr) & 3;
-    const char* alignedAddr = charAddr - offset;
+  const char* charAddr = reinterpret_cast<const char*>(addr);
+  const size_t offset = reinterpret_cast<size_t>(addr) & 3;
+  const char* alignedAddr = charAddr - offset;
     // Load as EltPack<__nv_fp8_e4m3, 4> and extract the correct fp8
-    EltPack<__nv_fp8_e4m3, 4> loaded = load<EltPack<__nv_fp8_e4m3, 4>, true, OpSum<__nv_fp8_e4m3>>(
-        reinterpret_cast<const EltPack<__nv_fp8_e4m3, 4>*>(alignedAddr));
-    EltPack<__nv_fp8_e4m3, 1> result;
+  EltPack<__nv_fp8_e4m3, 4> loaded = load<EltPack<__nv_fp8_e4m3, 4>, true, OpSum<__nv_fp8_e4m3>>(
+    reinterpret_cast<const EltPack<__nv_fp8_e4m3, 4>*>(alignedAddr));
+  EltPack<__nv_fp8_e4m3, 1> result;
     // Extract the correct fp8 based on address offset
-    const __nv_fp8_e4m3* loadedElts = loaded.elts();
-    result.elts()[0] = loadedElts[offset / sizeof(__nv_fp8_e4m3)];
-    return result;
+  const __nv_fp8_e4m3* loadedElts = loaded.elts();
+  result.elts()[0] = loadedElts[offset / sizeof(__nv_fp8_e4m3)];
+  return result;
 #endif
 }
 
 // FP8 E4M3 precision - 16 elements (16 fp8s = 128 bits)
 // Only define FP8 multimem specializations for supported architectures - otherwise fallback to generic template
-template<>
-NCCL_DEVICE_INLINE EltPack<__nv_fp8_e4m3, 16> load<EltPack<__nv_fp8_e4m3, 16>, true, OpSum<__nv_fp8_e4m3>>(const EltPack<__nv_fp8_e4m3, 16>* addr) {
-    #if (defined(__CUDA_ARCH_SPECIFIC__) && \
-         (__CUDA_ARCH_SPECIFIC__ == 1000 || \
-          __CUDA_ARCH_SPECIFIC__ == 1010 || \
-          __CUDA_ARCH_SPECIFIC__ == 1200 || \
-          __CUDA_ARCH_SPECIFIC__ == 1210)) || \
-        (defined(__CUDA_ARCH_FAMILY_SPECIFIC__) && \
-         (__CUDA_ARCH_FAMILY_SPECIFIC__ == 1000 || \
-          __CUDA_ARCH_FAMILY_SPECIFIC__ == 1010))
-    EltPack<__nv_fp8_e4m3, 16> result;
-    uint32_t raw[4];
+template <>
+NCCL_DEVICE_INLINE EltPack<__nv_fp8_e4m3, 16> load<EltPack<__nv_fp8_e4m3, 16>, true, OpSum<__nv_fp8_e4m3>>(
+  const EltPack<__nv_fp8_e4m3, 16>* addr) {
+#if (defined(__CUDA_ARCH_SPECIFIC__) && (__CUDA_ARCH_SPECIFIC__ == 1000 || __CUDA_ARCH_SPECIFIC__ == 1010 || \
+                                         __CUDA_ARCH_SPECIFIC__ == 1200 || __CUDA_ARCH_SPECIFIC__ == 1210)) || \
+  (defined(__CUDA_ARCH_FAMILY_SPECIFIC__) && \
+   (__CUDA_ARCH_FAMILY_SPECIFIC__ == 1000 || __CUDA_ARCH_FAMILY_SPECIFIC__ == 1010))
+  EltPack<__nv_fp8_e4m3, 16> result;
+  uint32_t raw[4];
     // Use v4.e4m3x4 instruction (4 x e4m3x4 = 16 elements)
-    asm volatile("multimem.ld_reduce.global.add.acc::f16.v4.e4m3x4 {%0, %1, %2, %3}, [%4];"
-                 : "=r"(raw[0]), "=r"(raw[1]), "=r"(raw[2]), "=r"(raw[3])
-                 : "l"(__cvta_generic_to_global(addr))
-                 : "memory");
-    union {
-      uint32_t raw[4];
-      __nv_fp8_e4m3 elts[16];
-    } packed{{raw[0], raw[1], raw[2], raw[3]}};
-    __nv_fp8_e4m3* out = result.elts();
-    #pragma unroll 16
-    for (int i = 0; i < 16; i++) out[i] = packed.elts[i];
-    return result;
-    #else
-    assert(false && "FP8 multimem with is not supported on this architecture.");
-    return EltPack<__nv_fp8_e4m3, 16>{};
-    #endif
-  }
+  asm volatile("multimem.ld_reduce.global.add.acc::f16.v4.e4m3x4 {%0, %1, %2, %3}, [%4];"
+               : "=r"(raw[0]), "=r"(raw[1]), "=r"(raw[2]), "=r"(raw[3])
+               : "l"(__cvta_generic_to_global(addr))
+               : "memory");
+  union {
+    uint32_t raw[4];
+    __nv_fp8_e4m3 elts[16];
+  } packed{{raw[0], raw[1], raw[2], raw[3]}};
+  __nv_fp8_e4m3* out = result.elts();
+#pragma unroll 16
+  for (int i = 0; i < 16; i++) out[i] = packed.elts[i];
+  return result;
+#else
+  assert(false && "FP8 multimem with is not supported on this architecture.");
+  return EltPack<__nv_fp8_e4m3, 16>{};
+#endif
+}
 
 // FP8 E5M2 precision - 4 elements (minimum: 4 fp8s = 32 bits)
 // Uses .acc::f16 accumulation (accumulates to half precision)
-template<>
-NCCL_DEVICE_INLINE EltPack<__nv_fp8_e5m2, 4> load<EltPack<__nv_fp8_e5m2, 4>, true, OpSum<__nv_fp8_e5m2>>(const EltPack<__nv_fp8_e5m2, 4>* addr) {
-    #if (defined(__CUDA_ARCH_SPECIFIC__) && \
-         (__CUDA_ARCH_SPECIFIC__ == 1000 || \
-          __CUDA_ARCH_SPECIFIC__ == 1010 || \
-          __CUDA_ARCH_SPECIFIC__ == 1200 || \
-          __CUDA_ARCH_SPECIFIC__ == 1210)) || \
-        (defined(__CUDA_ARCH_FAMILY_SPECIFIC__) && \
-         (__CUDA_ARCH_FAMILY_SPECIFIC__ == 1000 || \
-          __CUDA_ARCH_FAMILY_SPECIFIC__ == 1010))
-    EltPack<__nv_fp8_e5m2, 4> result;
-    uint32_t raw;
+template <>
+NCCL_DEVICE_INLINE EltPack<__nv_fp8_e5m2, 4> load<EltPack<__nv_fp8_e5m2, 4>, true, OpSum<__nv_fp8_e5m2>>(
+  const EltPack<__nv_fp8_e5m2, 4>* addr) {
+#if (defined(__CUDA_ARCH_SPECIFIC__) && (__CUDA_ARCH_SPECIFIC__ == 1000 || __CUDA_ARCH_SPECIFIC__ == 1010 || \
+                                         __CUDA_ARCH_SPECIFIC__ == 1200 || __CUDA_ARCH_SPECIFIC__ == 1210)) || \
+  (defined(__CUDA_ARCH_FAMILY_SPECIFIC__) && \
+   (__CUDA_ARCH_FAMILY_SPECIFIC__ == 1000 || __CUDA_ARCH_FAMILY_SPECIFIC__ == 1010))
+  EltPack<__nv_fp8_e5m2, 4> result;
+  uint32_t raw;
     // Use e5m2x4 instruction with .acc::f16 accumulation
-    asm volatile("multimem.ld_reduce.global.add.acc::f16.e5m2x4 %0, [%1];"
-                 : "=r"(raw)
-                 : "l"(__cvta_generic_to_global(addr))
-                 : "memory");
-    union {
-      uint32_t raw;
-      __nv_fp8_e5m2 elts[4];
-    } packed{raw};
-    __nv_fp8_e5m2* out = result.elts();
-    #pragma unroll
-    for (int i = 0; i < 4; i++) out[i] = packed.elts[i];
-    return result;
-    #else
-    assert(false && "FP8 multimem with is not supported on this architecture.");
-    return EltPack<__nv_fp8_e5m2, 4>{};
-    #endif
-  }
+  asm volatile("multimem.ld_reduce.global.add.acc::f16.e5m2x4 %0, [%1];"
+               : "=r"(raw)
+               : "l"(__cvta_generic_to_global(addr))
+               : "memory");
+  union {
+    uint32_t raw;
+    __nv_fp8_e5m2 elts[4];
+  } packed{raw};
+  __nv_fp8_e5m2* out = result.elts();
+#pragma unroll
+  for (int i = 0; i < 4; i++) out[i] = packed.elts[i];
+  return result;
+#else
+  assert(false && "FP8 multimem with is not supported on this architecture.");
+  return EltPack<__nv_fp8_e5m2, 4>{};
+#endif
+}
 
 // FP8 E5M2 precision - 2 elements (trick: load as e5m2x4, extract two fp8s)
-template<>
-NCCL_DEVICE_INLINE EltPack<__nv_fp8_e5m2, 2> load<EltPack<__nv_fp8_e5m2, 2>, true, OpSum<__nv_fp8_e5m2>>(const EltPack<__nv_fp8_e5m2, 2>* addr) {
+template <>
+NCCL_DEVICE_INLINE EltPack<__nv_fp8_e5m2, 2> load<EltPack<__nv_fp8_e5m2, 2>, true, OpSum<__nv_fp8_e5m2>>(
+  const EltPack<__nv_fp8_e5m2, 2>* addr) {
 #ifndef NCCL_DEVICE_PERMIT_EXPERIMENTAL_CODE
-    assert(false && "Experimental NCCL device code detected; you may accept the risk "
-                    "of this not being available in the future. If you accept that risk, "
-                    "set NCCL_DEVICE_PERMIT_EXPERIMENTAL_CODE during compilation or "
-                    "refactor the code. More details "
-                    "https://docs.nvidia.com/cuda/parallel-thread-execution/#addresses-as-operands");
-    return EltPack<__nv_fp8_e5m2, 2>{};
+  assert(false && "Experimental NCCL device code detected; you may accept the risk "
+                  "of this not being available in the future. If you accept that risk, "
+                  "set NCCL_DEVICE_PERMIT_EXPERIMENTAL_CODE during compilation or "
+                  "refactor the code. More details "
+                  "https://docs.nvidia.com/cuda/parallel-thread-execution/#addresses-as-operands");
+  return EltPack<__nv_fp8_e5m2, 2>{};
 #else
     // Align address to 4 bytes for e5m2x4 load
-    const char* charAddr = reinterpret_cast<const char*>(addr);
-    const size_t offset = reinterpret_cast<size_t>(addr) & 3;
-    const char* alignedAddr = charAddr - offset;
+  const char* charAddr = reinterpret_cast<const char*>(addr);
+  const size_t offset = reinterpret_cast<size_t>(addr) & 3;
+  const char* alignedAddr = charAddr - offset;
     // Load as EltPack<__nv_fp8_e5m2, 4> and extract the correct two fp8s
-    EltPack<__nv_fp8_e5m2, 4> loaded = load<EltPack<__nv_fp8_e5m2, 4>, true, OpSum<__nv_fp8_e5m2>>(
-        reinterpret_cast<const EltPack<__nv_fp8_e5m2, 4>*>(alignedAddr));
-    EltPack<__nv_fp8_e5m2, 2> result;
+  EltPack<__nv_fp8_e5m2, 4> loaded = load<EltPack<__nv_fp8_e5m2, 4>, true, OpSum<__nv_fp8_e5m2>>(
+    reinterpret_cast<const EltPack<__nv_fp8_e5m2, 4>*>(alignedAddr));
+  EltPack<__nv_fp8_e5m2, 2> result;
     // Extract the correct two fp8s based on address offset
-    const __nv_fp8_e5m2* loadedElts = loaded.elts();
-    const int startIdx = offset / sizeof(__nv_fp8_e5m2);
-    __nv_fp8_e5m2* resultElts = result.elts();
-    resultElts[0] = loadedElts[startIdx];
-    resultElts[1] = loadedElts[startIdx + 1];
-    return result;
+  const __nv_fp8_e5m2* loadedElts = loaded.elts();
+  const int startIdx = offset / sizeof(__nv_fp8_e5m2);
+  __nv_fp8_e5m2* resultElts = result.elts();
+  resultElts[0] = loadedElts[startIdx];
+  resultElts[1] = loadedElts[startIdx + 1];
+  return result;
 #endif
 }
 
 // FP8 E5M2 precision - single element (trick: load as e5m2x4, extract one fp8)
-template<>
-NCCL_DEVICE_INLINE EltPack<__nv_fp8_e5m2, 1> load<EltPack<__nv_fp8_e5m2, 1>, true, OpSum<__nv_fp8_e5m2>>(const EltPack<__nv_fp8_e5m2, 1>* addr) {
+template <>
+NCCL_DEVICE_INLINE EltPack<__nv_fp8_e5m2, 1> load<EltPack<__nv_fp8_e5m2, 1>, true, OpSum<__nv_fp8_e5m2>>(
+  const EltPack<__nv_fp8_e5m2, 1>* addr) {
 #ifndef NCCL_DEVICE_PERMIT_EXPERIMENTAL_CODE
-    assert(false && "Experimental NCCL device code detected; you may accept the risk "
-                    "of this not being available in the future. If you accept that risk, "
-                    "set NCCL_DEVICE_PERMIT_EXPERIMENTAL_CODE during compilation or "
-                    "refactor the code. More details "
-                    "https://docs.nvidia.com/cuda/parallel-thread-execution/#addresses-as-operands");
-    return EltPack<__nv_fp8_e5m2, 1>{};
+  assert(false && "Experimental NCCL device code detected; you may accept the risk "
+                  "of this not being available in the future. If you accept that risk, "
+                  "set NCCL_DEVICE_PERMIT_EXPERIMENTAL_CODE during compilation or "
+                  "refactor the code. More details "
+                  "https://docs.nvidia.com/cuda/parallel-thread-execution/#addresses-as-operands");
+  return EltPack<__nv_fp8_e5m2, 1>{};
 #else
     // Align address to 4 bytes for e5m2x4 load
-    const char* charAddr = reinterpret_cast<const char*>(addr);
-    const size_t offset = reinterpret_cast<size_t>(addr) & 3;
-    const char* alignedAddr = charAddr - offset;
+  const char* charAddr = reinterpret_cast<const char*>(addr);
+  const size_t offset = reinterpret_cast<size_t>(addr) & 3;
+  const char* alignedAddr = charAddr - offset;
     // Load as EltPack<__nv_fp8_e5m2, 4> and extract the correct fp8
-    EltPack<__nv_fp8_e5m2, 4> loaded = load<EltPack<__nv_fp8_e5m2, 4>, true, OpSum<__nv_fp8_e5m2>>(
-        reinterpret_cast<const EltPack<__nv_fp8_e5m2, 4>*>(alignedAddr));
-    EltPack<__nv_fp8_e5m2, 1> result;
+  EltPack<__nv_fp8_e5m2, 4> loaded = load<EltPack<__nv_fp8_e5m2, 4>, true, OpSum<__nv_fp8_e5m2>>(
+    reinterpret_cast<const EltPack<__nv_fp8_e5m2, 4>*>(alignedAddr));
+  EltPack<__nv_fp8_e5m2, 1> result;
     // Extract the correct fp8 based on address offset
-    const __nv_fp8_e5m2* loadedElts = loaded.elts();
-    result.elts()[0] = loadedElts[offset / sizeof(__nv_fp8_e5m2)];
-    return result;
+  const __nv_fp8_e5m2* loadedElts = loaded.elts();
+  result.elts()[0] = loadedElts[offset / sizeof(__nv_fp8_e5m2)];
+  return result;
 #endif
 }
 
 // FP8 E5M2 precision - 16 elements (16 fp8s = 128 bits)
-template<>
-NCCL_DEVICE_INLINE EltPack<__nv_fp8_e5m2, 16> load<EltPack<__nv_fp8_e5m2, 16>, true, OpSum<__nv_fp8_e5m2>>(const EltPack<__nv_fp8_e5m2, 16>* addr) {
-    #if (defined(__CUDA_ARCH_SPECIFIC__) && \
-         (__CUDA_ARCH_SPECIFIC__ == 1000 || \
-          __CUDA_ARCH_SPECIFIC__ == 1010 || \
-          __CUDA_ARCH_SPECIFIC__ == 1200 || \
-          __CUDA_ARCH_SPECIFIC__ == 1210)) || \
-        (defined(__CUDA_ARCH_FAMILY_SPECIFIC__) && \
-         (__CUDA_ARCH_FAMILY_SPECIFIC__ == 1000 || \
-          __CUDA_ARCH_FAMILY_SPECIFIC__ == 1010))
-    EltPack<__nv_fp8_e5m2, 16> result;
-    uint32_t raw[4];
+template <>
+NCCL_DEVICE_INLINE EltPack<__nv_fp8_e5m2, 16> load<EltPack<__nv_fp8_e5m2, 16>, true, OpSum<__nv_fp8_e5m2>>(
+  const EltPack<__nv_fp8_e5m2, 16>* addr) {
+#if (defined(__CUDA_ARCH_SPECIFIC__) && (__CUDA_ARCH_SPECIFIC__ == 1000 || __CUDA_ARCH_SPECIFIC__ == 1010 || \
+                                         __CUDA_ARCH_SPECIFIC__ == 1200 || __CUDA_ARCH_SPECIFIC__ == 1210)) || \
+  (defined(__CUDA_ARCH_FAMILY_SPECIFIC__) && \
+   (__CUDA_ARCH_FAMILY_SPECIFIC__ == 1000 || __CUDA_ARCH_FAMILY_SPECIFIC__ == 1010))
+  EltPack<__nv_fp8_e5m2, 16> result;
+  uint32_t raw[4];
     // Use v4.e5m2x4 instruction (4 x e5m2x4 = 16 elements)
-    asm volatile("multimem.ld_reduce.global.add.acc::f16.v4.e5m2x4 {%0, %1, %2, %3}, [%4];"
-                 : "=r"(raw[0]), "=r"(raw[1]), "=r"(raw[2]), "=r"(raw[3])
-                 : "l"(__cvta_generic_to_global(addr))
-                 : "memory");
-    union {
-      uint32_t raw[4];
-      __nv_fp8_e5m2 elts[16];
-    } packed{{raw[0], raw[1], raw[2], raw[3]}};
-    __nv_fp8_e5m2* out = result.elts();
-    #pragma unroll
-    for (int i = 0; i < 16; i++) out[i] = packed.elts[i];
-    return result;
-    #else
-    assert(false && "FP8 multimem with is not supported on this architecture.");
-    return EltPack<__nv_fp8_e5m2, 16>{};
-    #endif
-  }
+  asm volatile("multimem.ld_reduce.global.add.acc::f16.v4.e5m2x4 {%0, %1, %2, %3}, [%4];"
+               : "=r"(raw[0]), "=r"(raw[1]), "=r"(raw[2]), "=r"(raw[3])
+               : "l"(__cvta_generic_to_global(addr))
+               : "memory");
+  union {
+    uint32_t raw[4];
+    __nv_fp8_e5m2 elts[16];
+  } packed{{raw[0], raw[1], raw[2], raw[3]}};
+  __nv_fp8_e5m2* out = result.elts();
+#pragma unroll
+  for (int i = 0; i < 16; i++) out[i] = packed.elts[i];
+  return result;
+#else
+  assert(false && "FP8 multimem with is not supported on this architecture.");
+  return EltPack<__nv_fp8_e5m2, 16>{};
+#endif
+}
 #endif // __CUDA_FP8_TYPES_EXIST__
 
 // int32_t - single element
-template<>
-NCCL_DEVICE_INLINE EltPack<int32_t, 1> load<EltPack<int32_t, 1>, true, OpSum<int32_t>>(const EltPack<int32_t, 1>* addr) {
-    EltPack<int32_t, 1> result;
-    int32_t value;
-    asm volatile("multimem.ld_reduce.global.add.s32 %0, [%1];"
-                 : "=r"(value)
-                 : "l"(__cvta_generic_to_global(addr))
-                 : "memory");
-    result.elts()[0] = value;
-    return result;
-  }
+template <>
+NCCL_DEVICE_INLINE EltPack<int32_t, 1> load<EltPack<int32_t, 1>, true, OpSum<int32_t>>(
+  const EltPack<int32_t, 1>* addr) {
+  EltPack<int32_t, 1> result;
+  int32_t value;
+  asm volatile("multimem.ld_reduce.global.add.s32 %0, [%1];"
+               : "=r"(value)
+               : "l"(__cvta_generic_to_global(addr))
+               : "memory");
+  result.elts()[0] = value;
+  return result;
+}
 
 // int32_t - 4 elements (4 x 32-bit = 128 bits)
 // Note: No 128-bit multimem.ld_reduce for integers, use 4 separate .s32 operations
-template<>
-NCCL_DEVICE_INLINE EltPack<int32_t, 4> load<EltPack<int32_t, 4>, true, OpSum<int32_t>>(const EltPack<int32_t, 4>* addr) {
-    EltPack<int32_t, 4> result;
-    int32_t* elems = result.elts();
-    const char* base_addr = reinterpret_cast<const char*>(addr);
+template <>
+NCCL_DEVICE_INLINE EltPack<int32_t, 4> load<EltPack<int32_t, 4>, true, OpSum<int32_t>>(
+  const EltPack<int32_t, 4>* addr) {
+  EltPack<int32_t, 4> result;
+  int32_t* elems = result.elts();
+  const char* base_addr = reinterpret_cast<const char*>(addr);
 
     // Load 4 separate s32 values (no vector instruction available)
     // Use unrolled loop calling the 1-element version
-    #pragma unroll
-    for (int i = 0; i < 4; i++) {
-      EltPack<int32_t, 1> loaded = load<EltPack<int32_t, 1>, true, OpSum<int32_t>>(
-          reinterpret_cast<const EltPack<int32_t, 1>*>(base_addr + i * sizeof(int32_t)));
-      elems[i] = loaded.elts()[0];
-    }
-    return result;
+#pragma unroll
+  for (int i = 0; i < 4; i++) {
+    EltPack<int32_t, 1> loaded = load<EltPack<int32_t, 1>, true, OpSum<int32_t>>(
+      reinterpret_cast<const EltPack<int32_t, 1>*>(base_addr + i * sizeof(int32_t)));
+    elems[i] = loaded.elts()[0];
   }
+  return result;
+}
 
 // uint32_t - single element
-template<>
-NCCL_DEVICE_INLINE EltPack<uint32_t, 1> load<EltPack<uint32_t, 1>, true, OpSum<uint32_t>>(const EltPack<uint32_t, 1>* addr) {
-    EltPack<uint32_t, 1> result;
-    uint32_t value;
-    asm volatile("multimem.ld_reduce.global.add.u32 %0, [%1];"
-                 : "=r"(value)
-                 : "l"(__cvta_generic_to_global(addr))
-                 : "memory");
-    result.elts()[0] = value;
-    return result;
-  }
+template <>
+NCCL_DEVICE_INLINE EltPack<uint32_t, 1> load<EltPack<uint32_t, 1>, true, OpSum<uint32_t>>(
+  const EltPack<uint32_t, 1>* addr) {
+  EltPack<uint32_t, 1> result;
+  uint32_t value;
+  asm volatile("multimem.ld_reduce.global.add.u32 %0, [%1];"
+               : "=r"(value)
+               : "l"(__cvta_generic_to_global(addr))
+               : "memory");
+  result.elts()[0] = value;
+  return result;
+}
 
 // uint32_t - 4 elements (4 x 32-bit = 128 bits)
 // Note: No 128-bit multimem.ld_reduce for integers, use 4 separate .u32 operations
-template<>
-NCCL_DEVICE_INLINE EltPack<uint32_t, 4> load<EltPack<uint32_t, 4>, true, OpSum<uint32_t>>(const EltPack<uint32_t, 4>* addr) {
-    EltPack<uint32_t, 4> result;
-    uint32_t* elems = result.elts();
-    const char* base_addr = reinterpret_cast<const char*>(addr);
+template <>
+NCCL_DEVICE_INLINE EltPack<uint32_t, 4> load<EltPack<uint32_t, 4>, true, OpSum<uint32_t>>(
+  const EltPack<uint32_t, 4>* addr) {
+  EltPack<uint32_t, 4> result;
+  uint32_t* elems = result.elts();
+  const char* base_addr = reinterpret_cast<const char*>(addr);
 
     // Load 4 separate u32 values (no vector instruction available)
     // Use unrolled loop calling the 1-element version
-    #pragma unroll
-    for (int i = 0; i < 4; i++) {
-      EltPack<uint32_t, 1> loaded = load<EltPack<uint32_t, 1>, true, OpSum<uint32_t>>(
-          reinterpret_cast<const EltPack<uint32_t, 1>*>(base_addr + i * sizeof(uint32_t)));
-      elems[i] = loaded.elts()[0];
-    }
-    return result;
+#pragma unroll
+  for (int i = 0; i < 4; i++) {
+    EltPack<uint32_t, 1> loaded = load<EltPack<uint32_t, 1>, true, OpSum<uint32_t>>(
+      reinterpret_cast<const EltPack<uint32_t, 1>*>(base_addr + i * sizeof(uint32_t)));
+    elems[i] = loaded.elts()[0];
   }
+  return result;
+}
 
 // int64_t - single element
 // Note: Uses .u64 (add doesn't support .s64 for signed 64-bit)
-template<>
-NCCL_DEVICE_INLINE EltPack<int64_t, 1> load<EltPack<int64_t, 1>, true, OpSum<int64_t>>(const EltPack<int64_t, 1>* addr) {
-    EltPack<int64_t, 1> result;
-    int64_t value;
-    asm volatile("multimem.ld_reduce.global.add.u64 %0, [%1];"
-                 : "=l"(value)
-                 : "l"(__cvta_generic_to_global(addr))
-                 : "memory");
-    result.elts()[0] = value;
-    return result;
-  }
+template <>
+NCCL_DEVICE_INLINE EltPack<int64_t, 1> load<EltPack<int64_t, 1>, true, OpSum<int64_t>>(
+  const EltPack<int64_t, 1>* addr) {
+  EltPack<int64_t, 1> result;
+  int64_t value;
+  asm volatile("multimem.ld_reduce.global.add.u64 %0, [%1];"
+               : "=l"(value)
+               : "l"(__cvta_generic_to_global(addr))
+               : "memory");
+  result.elts()[0] = value;
+  return result;
+}
 
 // int64_t - 2 elements (2 x 64-bit = 128 bits)
 // Note: No 128-bit multimem.ld_reduce for integers, use 2 separate .u64 operations
-template<>
-NCCL_DEVICE_INLINE EltPack<int64_t, 2> load<EltPack<int64_t, 2>, true, OpSum<int64_t>>(const EltPack<int64_t, 2>* addr) {
-    EltPack<int64_t, 2> result;
-    int64_t* elems = result.elts();
-    const char* base_addr = reinterpret_cast<const char*>(addr);
+template <>
+NCCL_DEVICE_INLINE EltPack<int64_t, 2> load<EltPack<int64_t, 2>, true, OpSum<int64_t>>(
+  const EltPack<int64_t, 2>* addr) {
+  EltPack<int64_t, 2> result;
+  int64_t* elems = result.elts();
+  const char* base_addr = reinterpret_cast<const char*>(addr);
 
     // Load 2 separate u64 values (no vector instruction available)
     // Use unrolled loop calling the 1-element version
-    #pragma unroll
-    for (int i = 0; i < 2; i++) {
-      EltPack<int64_t, 1> loaded = load<EltPack<int64_t, 1>, true, OpSum<int64_t>>(
-          reinterpret_cast<const EltPack<int64_t, 1>*>(base_addr + i * sizeof(int64_t)));
-      elems[i] = loaded.elts()[0];
-    }
-    return result;
+#pragma unroll
+  for (int i = 0; i < 2; i++) {
+    EltPack<int64_t, 1> loaded = load<EltPack<int64_t, 1>, true, OpSum<int64_t>>(
+      reinterpret_cast<const EltPack<int64_t, 1>*>(base_addr + i * sizeof(int64_t)));
+    elems[i] = loaded.elts()[0];
   }
+  return result;
+}
 
 // uint64_t - single element
-template<>
-NCCL_DEVICE_INLINE EltPack<uint64_t, 1> load<EltPack<uint64_t, 1>, true, OpSum<uint64_t>>(const EltPack<uint64_t, 1>* addr) {
-    EltPack<uint64_t, 1> result;
-    uint64_t value;
-    asm volatile("multimem.ld_reduce.global.add.u64 %0, [%1];"
-                 : "=l"(value)
-                 : "l"(__cvta_generic_to_global(addr))
-                 : "memory");
-    result.elts()[0] = value;
-    return result;
-  }
+template <>
+NCCL_DEVICE_INLINE EltPack<uint64_t, 1> load<EltPack<uint64_t, 1>, true, OpSum<uint64_t>>(
+  const EltPack<uint64_t, 1>* addr) {
+  EltPack<uint64_t, 1> result;
+  uint64_t value;
+  asm volatile("multimem.ld_reduce.global.add.u64 %0, [%1];"
+               : "=l"(value)
+               : "l"(__cvta_generic_to_global(addr))
+               : "memory");
+  result.elts()[0] = value;
+  return result;
+}
 
 // uint64_t - 2 elements (2 x 64-bit = 128 bits)
 // Note: No 128-bit multimem.ld_reduce for integers, use 2 separate .u64 operations
-template<>
-NCCL_DEVICE_INLINE EltPack<uint64_t, 2> load<EltPack<uint64_t, 2>, true, OpSum<uint64_t>>(const EltPack<uint64_t, 2>* addr) {
-    EltPack<uint64_t, 2> result;
-    uint64_t* elems = result.elts();
-    const char* base_addr = reinterpret_cast<const char*>(addr);
+template <>
+NCCL_DEVICE_INLINE EltPack<uint64_t, 2> load<EltPack<uint64_t, 2>, true, OpSum<uint64_t>>(
+  const EltPack<uint64_t, 2>* addr) {
+  EltPack<uint64_t, 2> result;
+  uint64_t* elems = result.elts();
+  const char* base_addr = reinterpret_cast<const char*>(addr);
 
     // Load 2 separate u64 values (no vector instruction available)
     // Use unrolled loop calling the 1-element version
-    #pragma unroll
-    for (int i = 0; i < 2; i++) {
-      EltPack<uint64_t, 1> loaded = load<EltPack<uint64_t, 1>, true, OpSum<uint64_t>>(
-          reinterpret_cast<const EltPack<uint64_t, 1>*>(base_addr + i * sizeof(uint64_t)));
-      elems[i] = loaded.elts()[0];
-    }
-    return result;
+#pragma unroll
+  for (int i = 0; i < 2; i++) {
+    EltPack<uint64_t, 1> loaded = load<EltPack<uint64_t, 1>, true, OpSum<uint64_t>>(
+      reinterpret_cast<const EltPack<uint64_t, 1>*>(base_addr + i * sizeof(uint64_t)));
+    elems[i] = loaded.elts()[0];
   }
+  return result;
+}
 
 #endif // __CUDA_ARCH__ >= 900
 
@@ -649,7 +651,7 @@ NCCL_DEVICE_INLINE EltPack<uint64_t, 2> load<EltPack<uint64_t, 2>, true, OpSum<u
 #if __CUDA_ARCH__ >= 900
 
 // Typeless byte pack union - allows converting EltPack to typeless bytes
-template<int Bytes>
+template <int Bytes>
 union BytePack {
   char bytes[Bytes];
   uint16_t u16[(Bytes + 1) / 2];
@@ -660,85 +662,85 @@ union BytePack {
 };
 
 // Typeless multimem store - specialized by byte size only
-template<int Bytes>
+template <int Bytes>
 NCCL_DEVICE_INLINE void multimem_st_global(uintptr_t addr, const BytePack<Bytes>& val);
 
-template<>
+template <>
 NCCL_DEVICE_INLINE void multimem_st_global<0>(uintptr_t addr, const BytePack<0>& val) {
   // nop
 }
 
-template<>
+template <>
 NCCL_DEVICE_INLINE void multimem_st_global<1>(uintptr_t addr, const BytePack<1>& val) {
 #ifndef NCCL_DEVICE_PERMIT_EXPERIMENTAL_CODE
-    assert(false && "Experimental NCCL device code detected; you may accept the risk "
-                    "of this not being available in the future. If you accept that risk, "
-                    "set NCCL_DEVICE_PERMIT_EXPERIMENTAL_CODE during compilation or "
-                    "refactor the code. More details "
-                    "https://docs.nvidia.com/cuda/parallel-thread-execution/#multimem-addresses.");
-    return;
+  assert(false && "Experimental NCCL device code detected; you may accept the risk "
+                  "of this not being available in the future. If you accept that risk, "
+                  "set NCCL_DEVICE_PERMIT_EXPERIMENTAL_CODE during compilation or "
+                  "refactor the code. More details "
+                  "https://docs.nvidia.com/cuda/parallel-thread-execution/#multimem-addresses.");
+  return;
 #else
-  asm volatile("st.global.b8 [%0], %1;" :: "l"(addr), "r"((uint32_t)val.bytes[0]) : "memory");
+  asm volatile("st.global.b8 [%0], %1;" ::"l"(addr), "r"((uint32_t)val.bytes[0]) : "memory");
 #endif
 }
 
-template<>
+template <>
 NCCL_DEVICE_INLINE void multimem_st_global<2>(uintptr_t addr, const BytePack<2>& val) {
 #ifndef NCCL_DEVICE_PERMIT_EXPERIMENTAL_CODE
-      assert(false && "Experimental NCCL device code detected; you may accept the risk "
-                    "of this not being available in the future. If you accept that risk, "
-                    "set NCCL_DEVICE_PERMIT_EXPERIMENTAL_CODE during compilation or "
-                    "refactor the code. More details "
-                    "https://docs.nvidia.com/cuda/parallel-thread-execution/#multimem-addresses.");
-    return;
+  assert(false && "Experimental NCCL device code detected; you may accept the risk "
+                  "of this not being available in the future. If you accept that risk, "
+                  "set NCCL_DEVICE_PERMIT_EXPERIMENTAL_CODE during compilation or "
+                  "refactor the code. More details "
+                  "https://docs.nvidia.com/cuda/parallel-thread-execution/#multimem-addresses.");
+  return;
 #else
-  asm volatile("st.global.b16 [%0], %1;" :: "l"(addr), "h"(val.u16[0]) : "memory");
+  asm volatile("st.global.b16 [%0], %1;" ::"l"(addr), "h"(val.u16[0]) : "memory");
 #endif
 }
 
-template<>
+template <>
 NCCL_DEVICE_INLINE void multimem_st_global<4>(uintptr_t addr, const BytePack<4>& val) {
-  asm volatile("multimem.st.global.b32 [%0], %1;" :: "l"(addr), "r"(val.u32[0]) : "memory");
+  asm volatile("multimem.st.global.b32 [%0], %1;" ::"l"(addr), "r"(val.u32[0]) : "memory");
 }
 
-template<>
+template <>
 NCCL_DEVICE_INLINE void multimem_st_global<8>(uintptr_t addr, const BytePack<8>& val) {
-  asm volatile("multimem.st.global.b64 [%0], %1;" :: "l"(addr), "l"(val.u64[0]) : "memory");
+  asm volatile("multimem.st.global.b64 [%0], %1;" ::"l"(addr), "l"(val.u64[0]) : "memory");
 }
 
-template<>
+template <>
 NCCL_DEVICE_INLINE void multimem_st_global<16>(uintptr_t addr, const BytePack<16>& val) {
   // Use v4.f32 for 16 bytes (4 x 32-bit values) - multimem.st requires .f32 qualifier for vectors
-  asm volatile("multimem.st.global.v4.f32 [%0], {%1,%2,%3,%4};"
-               :: "l"(addr), "r"(val.u32[0]), "r"(val.u32[1]), "r"(val.u32[2]), "r"(val.u32[3])
+  asm volatile("multimem.st.global.v4.f32 [%0], {%1,%2,%3,%4};" ::"l"(addr), "r"(val.u32[0]), "r"(val.u32[1]),
+               "r"(val.u32[2]), "r"(val.u32[3])
                : "memory");
 }
 
 #endif // __CUDA_ARCH__ >= 900
 
 // Multimem store - converts EltPack to typeless BytePack
-template<typename Pack>
+template <typename Pack>
 NCCL_DEVICE_INLINE void multimemStore(void* addr, const Pack& pack) {
   // Check architecture requirement
-  #if __CUDA_ARCH__ < 900
-    assert(false && "multimemStore requires CUDA architecture >= 900 (sm_90 or higher)");
-    return;
-  #else
-    const size_t multimem_addr = __cvta_generic_to_global(addr);
+#if __CUDA_ARCH__ < 900
+  assert(false && "multimemStore requires CUDA architecture >= 900 (sm_90 or higher)");
+  return;
+#else
+  const size_t multimem_addr = __cvta_generic_to_global(addr);
     // Convert EltPack to typeless BytePack via union
-    union {
-      Pack eltPack;
-      BytePack<Pack::Bytes> bytePack;
-    } converter;
-    converter.eltPack = pack;
-    multimem_st_global<Pack::Bytes>(multimem_addr, converter.bytePack);
-  #endif
+  union {
+    Pack eltPack;
+    BytePack<Pack::Bytes> bytePack;
+  } converter;
+  converter.eltPack = pack;
+  multimem_st_global<Pack::Bytes>(multimem_addr, converter.bytePack);
+#endif
 }
 
 // Store helper that selects multimem vs LSA at compile time.
 // Use fully qualified name so we always use this namespace's multimemStore even when
 // the TU defines a global multimemStore (e.g. test/perf/multimem_ops.h).
-template<typename Pack, bool UseMultimem>
+template <typename Pack, bool UseMultimem>
 NCCL_DEVICE_INLINE void store(Pack* addr, const Pack& val) {
   if NCCL_IF_CONSTEXPR (UseMultimem) {
     nccl::utility::multimemStore(addr, val);

--- a/projects/rccl/src/include/nccl_device/impl/ptr__funcs.h
+++ b/projects/rccl/src/include/nccl_device/impl/ptr__funcs.h
@@ -13,85 +13,84 @@
 
 #if __cplusplus
 
-template<typename T>
-NCCL_HOST_DEVICE_INLINE constexpr ncclSymPtr<T>::ncclSymPtr(ncclWindow_t window, size_t offset):
-  window(window), offset(offset) {
-}
+template <typename T>
+NCCL_HOST_DEVICE_INLINE constexpr ncclSymPtr<T>::ncclSymPtr(ncclWindow_t window, size_t offset)
+  : window(window), offset(offset) {}
 
-template<typename T>
-template<typename U>
+template <typename T>
+template <typename U>
 NCCL_HOST_DEVICE_INLINE ncclSymPtr<T>::operator ncclSymPtr<U>() const {
   return {window, offset};
 }
 
-template<typename T>
+template <typename T>
 NCCL_HOST_DEVICE_INLINE ncclSymPtr<T>& ncclSymPtr<T>::operator+=(int d) {
   offset = reinterpret_cast<size_t>(reinterpret_cast<T*>(offset) + d);
   return *this;
 }
-template<typename T>
+template <typename T>
 NCCL_HOST_DEVICE_INLINE ncclSymPtr<T>& ncclSymPtr<T>::operator+=(unsigned int d) {
   offset = reinterpret_cast<size_t>(reinterpret_cast<T*>(offset) + d);
   return *this;
 }
 
-template<typename T>
+template <typename T>
 NCCL_HOST_DEVICE_INLINE ncclSymPtr<T>& ncclSymPtr<T>::operator+=(long d) {
   offset = reinterpret_cast<size_t>(reinterpret_cast<T*>(offset) + d);
   return *this;
 }
-template<typename T>
+template <typename T>
 NCCL_HOST_DEVICE_INLINE ncclSymPtr<T>& ncclSymPtr<T>::operator+=(unsigned long d) {
   offset = reinterpret_cast<size_t>(reinterpret_cast<T*>(offset) + d);
   return *this;
 }
 
-template<typename T>
+template <typename T>
 NCCL_HOST_DEVICE_INLINE ncclSymPtr<T>& ncclSymPtr<T>::operator+=(long long d) {
   offset = reinterpret_cast<size_t>(reinterpret_cast<T*>(offset) + d);
   return *this;
 }
-template<typename T>
+template <typename T>
 NCCL_HOST_DEVICE_INLINE ncclSymPtr<T>& ncclSymPtr<T>::operator+=(unsigned long long d) {
   offset = reinterpret_cast<size_t>(reinterpret_cast<T*>(offset) + d);
   return *this;
 }
 
-template<typename T>
+template <typename T>
 NCCL_HOST_DEVICE_INLINE ncclSymPtr<T>& ncclSymPtr<T>::operator-=(int d) {
   offset = reinterpret_cast<size_t>(reinterpret_cast<T*>(offset) - d);
   return *this;
 }
-template<typename T>
+template <typename T>
 NCCL_HOST_DEVICE_INLINE ncclSymPtr<T>& ncclSymPtr<T>::operator-=(unsigned int d) {
   offset = reinterpret_cast<size_t>(reinterpret_cast<T*>(offset) - d);
   return *this;
 }
 
-template<typename T>
+template <typename T>
 NCCL_HOST_DEVICE_INLINE ncclSymPtr<T>& ncclSymPtr<T>::operator-=(long d) {
   offset = reinterpret_cast<size_t>(reinterpret_cast<T*>(offset) - d);
   return *this;
 }
-template<typename T>
+template <typename T>
 NCCL_HOST_DEVICE_INLINE ncclSymPtr<T>& ncclSymPtr<T>::operator-=(unsigned long d) {
   offset = reinterpret_cast<size_t>(reinterpret_cast<T*>(offset) - d);
   return *this;
 }
 
-template<typename T>
+template <typename T>
 NCCL_HOST_DEVICE_INLINE ncclSymPtr<T>& ncclSymPtr<T>::operator-=(long long d) {
   offset = reinterpret_cast<size_t>(reinterpret_cast<T*>(offset) - d);
   return *this;
 }
-template<typename T>
+template <typename T>
 NCCL_HOST_DEVICE_INLINE ncclSymPtr<T>& ncclSymPtr<T>::operator-=(unsigned long long d) {
   offset = reinterpret_cast<size_t>(reinterpret_cast<T*>(offset) - d);
   return *this;
 }
 
 #if NCCL_CHECK_CUDACC
-template<typename T>
+template <typename T>
 NCCL_DEVICE_INLINE T* ncclSymPtr<T>::localPtr() const {
   if (window) {
     return (T*)ncclGetLocalPointer(window, offset);
@@ -102,58 +101,58 @@ NCCL_DEVICE_INLINE T* ncclSymPtr<T>::localPtr() const {
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename T>
+template <typename T>
 NCCL_DEVICE_INLINE T* ncclSymPtr<T>::lsaPtr(int peer) const {
   return (T*)ncclGetLsaPointer(window, offset, peer);
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename T>
+template <typename T>
 NCCL_DEVICE_INLINE T* ncclSymPtr<T>::peerPtr(int peer) const {
   return (T*)ncclGetPeerPointer(window, offset, peer);
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename T>
+template <typename T>
 NCCL_DEVICE_INLINE T* ncclSymPtr<T>::peerPtr(ncclTeam team, int peer) const {
   return (T*)ncclGetPeerPointer(window, offset, team, peer);
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename T>
+template <typename T>
 NCCL_DEVICE_INLINE T* ncclSymPtr<T>::multimemPtr(ncclMultimemHandle mmHandle) const {
   return (T*)ncclGetMultimemPointer(window, offset, mmHandle);
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename T>
+template <typename T>
 NCCL_DEVICE_INLINE T* ncclSymPtr<T>::lsaMultimemPtr(ncclDevComm const& comm) const {
   return (T*)ncclGetLsaMultimemPointer(window, offset, comm);
 }
 #endif
 
-template<typename T, typename Int>
+template <typename T, typename Int>
 NCCL_HOST_DEVICE_INLINE ncclSymPtr<T> operator+(ncclSymPtr<T> p, Int d) {
   return p += d;
 }
-template<typename T, typename Int>
+template <typename T, typename Int>
 NCCL_HOST_DEVICE_INLINE ncclSymPtr<T> operator-(ncclSymPtr<T> p, Int d) {
   return p -= d;
 }
-template<typename T>
+template <typename T>
 NCCL_HOST_DEVICE_INLINE ptrdiff_t operator-(ncclSymPtr<T> a, ncclSymPtr<T> b) {
   return reinterpret_cast<T*>(a.offset) - reinterpret_cast<T*>(b.offset);
 }
 
-template<typename T>
+template <typename T>
 NCCL_HOST_DEVICE_INLINE bool operator==(ncclSymPtr<T> a, ncclSymPtr<T> b) {
   return a.window == b.window && a.offset == b.offset;
 }
-template<typename T>
+template <typename T>
 NCCL_HOST_DEVICE_INLINE bool operator!=(ncclSymPtr<T> a, ncclSymPtr<T> b) {
   return a.window != b.window || a.offset != b.offset;
 }

--- a/projects/rccl/src/include/nccl_device/impl/reduce_copy__funcs.h
+++ b/projects/rccl/src/include/nccl_device/impl/reduce_copy__funcs.h
@@ -37,95 +37,73 @@
 
 // SERIES 1.x - Generic ReduceCopy with RedOp (LSA sources only)
 
-template <typename T, typename Coop, typename SrcLambda, typename DstLambda,
-          typename RedOp, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaReduceLsaCopy(
-    Coop coop,
-    SrcLambda srcLambda, int nSrc,
-    DstLambda dstLambda, int nDst,
-    RedOp const& redOp,
-    IntCount count) {
+template <typename T, typename Coop, typename SrcLambda, typename DstLambda, typename RedOp, typename IntCount,
+          int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaReduceLsaCopy(Coop coop, SrcLambda srcLambda, int nSrc, DstLambda dstLambda, int nDst,
+                                             RedOp const& redOp, IntCount count) {
   // Compute alignment for opaque lambdas with fallback to smaller pack sizes
-  auto alignment = nccl::utility::computeLambdaAlignmentOffsetWithFallback<T>(
-      coop, srcLambda, nSrc, dstLambda, nDst, count);
+  auto alignment =
+    nccl::utility::computeLambdaAlignmentOffsetWithFallback<T>(coop, srcLambda, nSrc, dstLambda, nDst, count);
 
   nccl::utility::reduceCopy<T, RedOp, Coop, false, false, SrcLambda, DstLambda, IntCount, UNROLL>(
-      coop, srcLambda, nSrc, dstLambda, nDst, redOp, count, alignment.alignOffset, alignment.maxPackBytes);
+    coop, srcLambda, nSrc, dstLambda, nDst, redOp, count, alignment.alignOffset, alignment.maxPackBytes);
 }
 
-template <typename T, typename Coop, typename SrcLambda, typename DstLambda,
-          typename RedOp, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaReduceMultimemCopy(
-    Coop coop,
-    SrcLambda srcLambda, int nSrc,
-    DstLambda dstLambda, int nDst,
-    RedOp const& redOp,
-    IntCount count) {
+template <typename T, typename Coop, typename SrcLambda, typename DstLambda, typename RedOp, typename IntCount,
+          int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaReduceMultimemCopy(Coop coop, SrcLambda srcLambda, int nSrc, DstLambda dstLambda,
+                                                  int nDst, RedOp const& redOp, IntCount count) {
   // Compute alignment for opaque lambdas with fallback to smaller pack sizes
-  auto alignment = nccl::utility::computeLambdaAlignmentOffsetWithFallback<T>(
-      coop, srcLambda, nSrc, dstLambda, nDst, count);
+  auto alignment =
+    nccl::utility::computeLambdaAlignmentOffsetWithFallback<T>(coop, srcLambda, nSrc, dstLambda, nDst, count);
 
   nccl::utility::reduceCopy<T, RedOp, Coop, false, true, SrcLambda, DstLambda, IntCount, UNROLL>(
-      coop, srcLambda, nSrc, dstLambda, nDst, redOp, count, alignment.alignOffset, alignment.maxPackBytes);
+    coop, srcLambda, nSrc, dstLambda, nDst, redOp, count, alignment.alignOffset, alignment.maxPackBytes);
 }
 
 // SERIES 2.x - Sum-Specific ReduceCopy
 
-template <typename T, typename Coop, typename SrcLambda, typename DstLambda,
-          typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaReduceSumLsaCopy(
-    Coop coop,
-    SrcLambda srcLambda, int nSrc,
-    DstLambda dstLambda, int nDst,
-    IntCount count) {
+template <typename T, typename Coop, typename SrcLambda, typename DstLambda, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaReduceSumLsaCopy(Coop coop, SrcLambda srcLambda, int nSrc, DstLambda dstLambda, int nDst,
+                                                IntCount count) {
   ncclLsaReduceLsaCopy<T, Coop, SrcLambda, DstLambda, nccl::utility::OpSum<T>, IntCount, UNROLL>(
-      coop, srcLambda, nSrc, dstLambda, nDst, nccl::utility::OpSum<T>{}, count);
+    coop, srcLambda, nSrc, dstLambda, nDst, nccl::utility::OpSum<T>{}, count);
 }
 
 // [ID 2.2] LSA <-> Multimem ReduceSum
-template <typename T, typename Coop, typename SrcLambda, typename DstLambda,
-          typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaReduceSumMultimemCopy(
-    Coop coop,
-    SrcLambda srcLambda, int nSrc,
-    DstLambda dstLambda, int nDst,
-    IntCount count) {
+template <typename T, typename Coop, typename SrcLambda, typename DstLambda, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaReduceSumMultimemCopy(Coop coop, SrcLambda srcLambda, int nSrc, DstLambda dstLambda,
+                                                     int nDst, IntCount count) {
   ncclLsaReduceMultimemCopy<T, Coop, SrcLambda, DstLambda, nccl::utility::OpSum<T>, IntCount, UNROLL>(
-      coop, srcLambda, nSrc, dstLambda, nDst, nccl::utility::OpSum<T>{}, count);
+    coop, srcLambda, nSrc, dstLambda, nDst, nccl::utility::OpSum<T>{}, count);
 }
 
 // [ID 2.3] Multimem <-> LSA ReduceSum
-template <typename T, typename Coop, typename SrcLambda, typename DstLambda,
-          typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclMultimemReduceSumLsaCopy(
-    Coop coop,
-    SrcLambda srcLambda, int nSrc,
-    DstLambda dstLambda, int nDst,
-    IntCount count) {
+template <typename T, typename Coop, typename SrcLambda, typename DstLambda, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclMultimemReduceSumLsaCopy(Coop coop, SrcLambda srcLambda, int nSrc, DstLambda dstLambda,
+                                                     int nDst, IntCount count) {
   // Compute alignment for opaque lambdas with fallback to smaller pack sizes
-  auto alignment = nccl::utility::computeLambdaAlignmentOffsetWithFallback<T>(
-      coop, srcLambda, nSrc, dstLambda, nDst, count);
+  auto alignment =
+    nccl::utility::computeLambdaAlignmentOffsetWithFallback<T>(coop, srcLambda, nSrc, dstLambda, nDst, count);
 
   // Multimem source only supports Sum
   nccl::utility::reduceCopy<T, nccl::utility::OpSum<T>, Coop, true, false, SrcLambda, DstLambda, IntCount, UNROLL>(
-      coop, srcLambda, nSrc, dstLambda, nDst, nccl::utility::OpSum<T>{}, count, alignment.alignOffset, alignment.maxPackBytes);
+    coop, srcLambda, nSrc, dstLambda, nDst, nccl::utility::OpSum<T>{}, count, alignment.alignOffset,
+    alignment.maxPackBytes);
 }
 
 // [ID 2.4] Multimem <-> Multimem ReduceSum
-template <typename T, typename Coop, typename SrcLambda, typename DstLambda,
-          typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclMultimemReduceSumMultimemCopy(
-    Coop coop,
-    SrcLambda srcLambda, int nSrc,
-    DstLambda dstLambda, int nDst,
-    IntCount count) {
+template <typename T, typename Coop, typename SrcLambda, typename DstLambda, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclMultimemReduceSumMultimemCopy(Coop coop, SrcLambda srcLambda, int nSrc, DstLambda dstLambda,
+                                                          int nDst, IntCount count) {
   // Compute alignment for opaque lambdas with fallback to smaller pack sizes
-  auto alignment = nccl::utility::computeLambdaAlignmentOffsetWithFallback<T>(
-      coop, srcLambda, nSrc, dstLambda, nDst, count);
+  auto alignment =
+    nccl::utility::computeLambdaAlignmentOffsetWithFallback<T>(coop, srcLambda, nSrc, dstLambda, nDst, count);
 
   // Both multimem - only supports Sum
   nccl::utility::reduceCopy<T, nccl::utility::OpSum<T>, Coop, true, true, SrcLambda, DstLambda, IntCount, UNROLL>(
-      coop, srcLambda, nSrc, dstLambda, nDst, nccl::utility::OpSum<T>{}, count, alignment.alignOffset, alignment.maxPackBytes);
+    coop, srcLambda, nSrc, dstLambda, nDst, nccl::utility::OpSum<T>{}, count, alignment.alignOffset,
+    alignment.maxPackBytes);
 }
 
 // ============================================================================
@@ -133,55 +111,40 @@ NCCL_DEVICE_INLINE void ncclMultimemReduceSumMultimemCopy(
 // ============================================================================
 
 // [ID 3.1] LSA ReduceSum: N sources -> 1 local destination (lambda-based)
-template<typename T, typename Coop, typename SrcLambda, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaReduceSum(Coop coop,
-                                            SrcLambda srcLambda, int nSrc,
-                                            T* dstPtr,
-                                            IntCount count) {
-  auto dstLambda = [=] __device__ (int /*ignored*/) -> T* {
-    return dstPtr;
-  };
+template <typename T, typename Coop, typename SrcLambda, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaReduceSum(Coop coop, SrcLambda srcLambda, int nSrc, T* dstPtr, IntCount count) {
+  auto dstLambda = [=] __device__(int /*ignored*/) -> T* { return dstPtr; };
   constexpr int nDst = 1;  // Reduce has single destination
-  ncclLsaReduceSumLsaCopy<T, Coop, SrcLambda, decltype(dstLambda), IntCount, UNROLL>(
-      coop, srcLambda, nSrc, dstLambda, nDst, count);
+  ncclLsaReduceSumLsaCopy<T, Coop, SrcLambda, decltype(dstLambda), IntCount, UNROLL>(coop, srcLambda, nSrc, dstLambda,
+                                                                                     nDst, count);
 }
 
 // [ID 3.2a] LSA ReduceSum: N sources from team -> 1 local destination (with ncclSymPtr)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaReduceSum(Coop coop,
-                                            ncclSymPtr<T> src,
-                                            T* dstPtr,
-                                            IntCount count,
-                                            ncclTeam team) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaReduceSum(Coop coop, ncclSymPtr<T> src, T* dstPtr, IntCount count, ncclTeam team) {
   // Create lambda: N sources from team
-  auto srcLambda = [=] __device__ (int i) -> T* {
-    return src.peerPtr(team, i);
-  };
-  auto dstLambda = [=] __device__ (int /*ignored*/) -> T* {
-    return dstPtr;
-  };
+  auto srcLambda = [=] __device__(int i) -> T* { return src.peerPtr(team, i); };
+  auto dstLambda = [=] __device__(int /*ignored*/) -> T* { return dstPtr; };
 
   // LSA translation ensures all peers have the same alignment
   // Only need to check the first pointer (much cheaper than checking all N)
   IntCount alignOffset = 0;
   int maxPackBytes = 16;
   if (count > 0 && team.nRanks > 0) {
-    nccl::utility::computePointerPairAlignmentWithFallback<T>(
-        srcLambda(0), dstLambda(0), count, alignOffset, maxPackBytes);
+    nccl::utility::computePointerPairAlignmentWithFallback<T>(srcLambda(0), dstLambda(0), count, alignOffset,
+                                                              maxPackBytes);
   }
 
   constexpr int nDst = 1;
-  nccl::utility::reduceCopy<T, nccl::utility::OpSum<T>, Coop, false, false, decltype(srcLambda), decltype(dstLambda), IntCount, UNROLL>(
-      coop, srcLambda, team.nRanks, dstLambda, nDst, nccl::utility::OpSum<T>{}, count, alignOffset, maxPackBytes);
+  nccl::utility::reduceCopy<T, nccl::utility::OpSum<T>, Coop, false, false, decltype(srcLambda), decltype(dstLambda),
+                            IntCount, UNROLL>(coop, srcLambda, team.nRanks, dstLambda, nDst, nccl::utility::OpSum<T>{},
+                                              count, alignOffset, maxPackBytes);
 }
 
 // [ID 3.2b] LSA ReduceSum: N sources from devComm -> 1 local destination (with ncclDevComm_t)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaReduceSum(Coop coop,
-                                            ncclSymPtr<T> src,
-                                            T* dstPtr,
-                                            IntCount count,
-                                            ncclDevComm_t devComm) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaReduceSum(Coop coop, ncclSymPtr<T> src, T* dstPtr, IntCount count,
+                                         ncclDevComm_t devComm) {
   // Extract team from devComm
   ncclTeam team = ncclTeamLsa(devComm);
 
@@ -189,13 +152,9 @@ NCCL_DEVICE_INLINE void ncclLsaReduceSum(Coop coop,
 }
 
 // [ID 3.2c] LSA ReduceSum: N sources from window+offset -> 1 local destination (with ncclWindow_t + ncclTeam)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaReduceSum(Coop coop,
-                                            ncclWindow_t window,
-                                            size_t offset,
-                                            T* dstPtr,
-                                            IntCount count,
-                                            ncclTeam team) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaReduceSum(Coop coop, ncclWindow_t window, size_t offset, T* dstPtr, IntCount count,
+                                         ncclTeam team) {
   // Construct ncclSymPtr from window and offset using direct initialization
   ncclSymPtr<T> src{window, offset};
 
@@ -203,13 +162,9 @@ NCCL_DEVICE_INLINE void ncclLsaReduceSum(Coop coop,
 }
 
 // [ID 3.2d] LSA ReduceSum: N sources from window+offset -> 1 local destination (with ncclWindow_t + ncclDevComm_t)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaReduceSum(Coop coop,
-                                            ncclWindow_t window,
-                                            size_t offset,
-                                            T* dstPtr,
-                                            IntCount count,
-                                            ncclDevComm_t devComm) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaReduceSum(Coop coop, ncclWindow_t window, size_t offset, T* dstPtr, IntCount count,
+                                         ncclDevComm_t devComm) {
   // Construct ncclSymPtr from window and offset using direct initialization
   ncclSymPtr<T> src{window, offset};
 
@@ -217,56 +172,38 @@ NCCL_DEVICE_INLINE void ncclLsaReduceSum(Coop coop,
 }
 
 // [ID 3.3a] Multimem ReduceSum: 1 multimem source -> 1 local destination (with ncclSymPtr)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclMultimemReduceSum(Coop coop,
-                                                 ncclSymPtr<T> src,
-                                                 T* dstPtr,
-                                                 IntCount count,
-                                                 ncclMultimemHandle multimemHandle) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclMultimemReduceSum(Coop coop, ncclSymPtr<T> src, T* dstPtr, IntCount count,
+                                              ncclMultimemHandle multimemHandle) {
   // Create lambdas for 1 source and 1 destination
-  auto srcLambda = [=] __device__ (int /*ignored*/) -> T* {
-    return src.multimemPtr(multimemHandle);
-  };
-  auto dstLambda = [=] __device__ (int /*ignored*/) -> T* {
-    return dstPtr;
-  };
+  auto srcLambda = [=] __device__(int /*ignored*/) -> T* { return src.multimemPtr(multimemHandle); };
+  auto dstLambda = [=] __device__(int /*ignored*/) -> T* { return dstPtr; };
 
   // Use the lambda-based function - alignment check is cheap for nSrc=1, nDst=1
   constexpr int nSrc = 1;
   constexpr int nDst = 1;
   ncclMultimemReduceSumLsaCopy<T, Coop, decltype(srcLambda), decltype(dstLambda), IntCount, UNROLL>(
-      coop, srcLambda, nSrc, dstLambda, nDst, count);
+    coop, srcLambda, nSrc, dstLambda, nDst, count);
 }
 
 // [ID 3.3b] Multimem ReduceSum: 1 multimem source -> 1 local destination (with raw pointer)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclMultimemReduceSum(Coop coop,
-                                                 T* mcSrcPtr,
-                                                 T* dstPtr,
-                                                 IntCount count) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclMultimemReduceSum(Coop coop, T* mcSrcPtr, T* dstPtr, IntCount count) {
   // Create lambdas for 1 source and 1 destination
-  auto srcLambda = [=] __device__ (int /*ignored*/) -> T* {
-    return mcSrcPtr;
-  };
-  auto dstLambda = [=] __device__ (int /*ignored*/) -> T* {
-    return dstPtr;
-  };
+  auto srcLambda = [=] __device__(int /*ignored*/) -> T* { return mcSrcPtr; };
+  auto dstLambda = [=] __device__(int /*ignored*/) -> T* { return dstPtr; };
 
   // Use the lambda-based function - alignment check is cheap for nSrc=1, nDst=1
   constexpr int nSrc = 1;
   constexpr int nDst = 1;
   ncclMultimemReduceSumLsaCopy<T, Coop, decltype(srcLambda), decltype(dstLambda), IntCount, UNROLL>(
-      coop, srcLambda, nSrc, dstLambda, nDst, count);
+    coop, srcLambda, nSrc, dstLambda, nDst, count);
 }
 
 // [ID 3.3c] Multimem ReduceSum: 1 multimem source -> 1 local destination (with ncclWindow_t)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclMultimemReduceSum(Coop coop,
-                                                 ncclWindow_t window,
-                                                 size_t offset,
-                                                 T* dstPtr,
-                                                 IntCount count,
-                                                 ncclMultimemHandle multimemHandle) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclMultimemReduceSum(Coop coop, ncclWindow_t window, size_t offset, T* dstPtr, IntCount count,
+                                              ncclMultimemHandle multimemHandle) {
   // Construct ncclSymPtr from window and offset
   ncclSymPtr<T> src{window, offset};
 
@@ -274,44 +211,30 @@ NCCL_DEVICE_INLINE void ncclMultimemReduceSum(Coop coop,
 }
 
 // [ID 3.4] Local ReduceSum: N local chunks -> 1 local destination (lambda-based)
-template<typename T, typename Coop, typename SrcLambda, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLocalReduceSum(Coop coop,
-                                              SrcLambda srcLambda, int nSrc,
-                                              T* dstPtr,
-                                              IntCount count) {
-  auto dstLambda = [=] __device__ (int /*ignored*/) -> T* {
-    return dstPtr;
-  };
+template <typename T, typename Coop, typename SrcLambda, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLocalReduceSum(Coop coop, SrcLambda srcLambda, int nSrc, T* dstPtr, IntCount count) {
+  auto dstLambda = [=] __device__(int /*ignored*/) -> T* { return dstPtr; };
   constexpr int nDst = 1;  // Reduce has single destination
-  ncclLsaReduceSumLsaCopy<T, Coop, SrcLambda, decltype(dstLambda), IntCount, UNROLL>(
-      coop, srcLambda, nSrc, dstLambda, nDst, count);
+  ncclLsaReduceSumLsaCopy<T, Coop, SrcLambda, decltype(dstLambda), IntCount, UNROLL>(coop, srcLambda, nSrc, dstLambda,
+                                                                                     nDst, count);
 }
 
 // [ID 3.5] Local ReduceSum: reduce n chunks separated by displacement
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLocalReduceSum(Coop coop,
-                                              int nSrc,
-                                              T* basePtr,
-                                              size_t displ,
-                                              T* dstPtr,
-                                              IntCount count) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLocalReduceSum(Coop coop, int nSrc, T* basePtr, size_t displ, T* dstPtr, IntCount count) {
   // Fast alignment computation for strided addressing with fallback
   IntCount alignOffset;
   int maxPackBytes;
-  nccl::utility::computeStridedAlignmentWithFallback<T>(
-      basePtr, displ * sizeof(T), count, alignOffset, maxPackBytes);
+  nccl::utility::computeStridedAlignmentWithFallback<T>(basePtr, displ * sizeof(T), count, alignOffset, maxPackBytes);
 
   // Create lambda: n local sources separated by displ
-  auto srcLambda = [=] __device__ (int i) -> T* {
-    return basePtr + i * displ;
-  };
-  auto dstLambda = [=] __device__ (int /*ignored*/) -> T* {
-    return dstPtr;
-  };
+  auto srcLambda = [=] __device__(int i) -> T* { return basePtr + i * displ; };
+  auto dstLambda = [=] __device__(int /*ignored*/) -> T* { return dstPtr; };
 
   constexpr int nDst = 1;
-  nccl::utility::reduceCopy<T, nccl::utility::OpSum<T>, Coop, false, false, decltype(srcLambda), decltype(dstLambda), IntCount, UNROLL>(
-      coop, srcLambda, nSrc, dstLambda, nDst, nccl::utility::OpSum<T>{}, count, alignOffset, maxPackBytes);
+  nccl::utility::reduceCopy<T, nccl::utility::OpSum<T>, Coop, false, false, decltype(srcLambda), decltype(dstLambda),
+                            IntCount, UNROLL>(coop, srcLambda, nSrc, dstLambda, nDst, nccl::utility::OpSum<T>{}, count,
+                                              alignOffset, maxPackBytes);
 }
 
 // ============================================================================
@@ -319,55 +242,39 @@ NCCL_DEVICE_INLINE void ncclLocalReduceSum(Coop coop,
 // ============================================================================
 
 // [ID 4.1] Lambda-based version
-template<typename T, typename Coop, typename DstLambda, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaCopy(Coop coop,
-                                       T* srcPtr,
-                                       DstLambda dstLambda, int nDst,
-                                       IntCount count) {
-  auto srcLambda = [=] __device__ (int /*ignored*/) -> T* {
-    return srcPtr;
-  };
+template <typename T, typename Coop, typename DstLambda, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaCopy(Coop coop, T* srcPtr, DstLambda dstLambda, int nDst, IntCount count) {
+  auto srcLambda = [=] __device__(int /*ignored*/) -> T* { return srcPtr; };
   constexpr int nSrc = 1;  // Copy has single source
-  ncclLsaReduceSumLsaCopy<T, Coop, decltype(srcLambda), DstLambda, IntCount, UNROLL>(
-      coop, srcLambda, nSrc, dstLambda, nDst, count);
+  ncclLsaReduceSumLsaCopy<T, Coop, decltype(srcLambda), DstLambda, IntCount, UNROLL>(coop, srcLambda, nSrc, dstLambda,
+                                                                                     nDst, count);
 }
 
 // [ID 4.2a] LSA Copy: 1 local source -> N destinations (with ncclSymPtr)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaCopy(Coop coop,
-                                       T* srcPtr,
-                                       ncclSymPtr<T> dst,
-                                       IntCount count,
-                                       ncclTeam team) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaCopy(Coop coop, T* srcPtr, ncclSymPtr<T> dst, IntCount count, ncclTeam team) {
   // Create lambda: N destinations to team
-  auto srcLambda = [=] __device__ (int /*ignored*/) -> T* {
-    return srcPtr;
-  };
-  auto dstLambda = [=] __device__ (int i) -> T* {
-    return dst.peerPtr(team, i);
-  };
+  auto srcLambda = [=] __device__(int /*ignored*/) -> T* { return srcPtr; };
+  auto dstLambda = [=] __device__(int i) -> T* { return dst.peerPtr(team, i); };
 
   // LSA translation ensures all peers have the same alignment
   // Only need to check the first pointer (much cheaper than checking all N)
   IntCount alignOffset = 0;
   int maxPackBytes = 16;
   if (count > 0 && team.nRanks > 0) {
-    nccl::utility::computePointerPairAlignmentWithFallback<T>(
-        srcLambda(0), dstLambda(0), count, alignOffset, maxPackBytes);
+    nccl::utility::computePointerPairAlignmentWithFallback<T>(srcLambda(0), dstLambda(0), count, alignOffset,
+                                                              maxPackBytes);
   }
 
   constexpr int nSrc = 1;
-  nccl::utility::reduceCopy<T, nccl::utility::OpSum<T>, Coop, false, false, decltype(srcLambda), decltype(dstLambda), IntCount, UNROLL>(
-      coop, srcLambda, nSrc, dstLambda, team.nRanks, nccl::utility::OpSum<T>{}, count, alignOffset, maxPackBytes);
+  nccl::utility::reduceCopy<T, nccl::utility::OpSum<T>, Coop, false, false, decltype(srcLambda), decltype(dstLambda),
+                            IntCount, UNROLL>(coop, srcLambda, nSrc, dstLambda, team.nRanks, nccl::utility::OpSum<T>{},
+                                              count, alignOffset, maxPackBytes);
 }
 
 // [ID 4.2b] LSA Copy: 1 local source -> N destinations (with ncclDevComm_t)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaCopy(Coop coop,
-                                       T* srcPtr,
-                                       ncclSymPtr<T> dst,
-                                       IntCount count,
-                                       ncclDevComm_t devComm) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaCopy(Coop coop, T* srcPtr, ncclSymPtr<T> dst, IntCount count, ncclDevComm_t devComm) {
   // Extract team from devComm
   ncclTeam team = ncclTeamLsa(devComm);
 
@@ -375,13 +282,9 @@ NCCL_DEVICE_INLINE void ncclLsaCopy(Coop coop,
 }
 
 // [ID 4.2c] LSA Copy: 1 local source -> N destinations (with ncclWindow_t + ncclTeam)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaCopy(Coop coop,
-                                       T* srcPtr,
-                                       ncclWindow_t window,
-                                       size_t offset,
-                                       IntCount count,
-                                       ncclTeam team) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaCopy(Coop coop, T* srcPtr, ncclWindow_t window, size_t offset, IntCount count,
+                                    ncclTeam team) {
   // Construct ncclSymPtr from window and offset
   ncclSymPtr<T> dst{window, offset};
 
@@ -389,13 +292,9 @@ NCCL_DEVICE_INLINE void ncclLsaCopy(Coop coop,
 }
 
 // [ID 4.2d] LSA Copy: 1 local source -> N destinations (with ncclWindow_t + ncclDevComm_t)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaCopy(Coop coop,
-                                       T* srcPtr,
-                                       ncclWindow_t window,
-                                       size_t offset,
-                                       IntCount count,
-                                       ncclDevComm_t devComm) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaCopy(Coop coop, T* srcPtr, ncclWindow_t window, size_t offset, IntCount count,
+                                    ncclDevComm_t devComm) {
   // Construct ncclSymPtr from window and offset
   ncclSymPtr<T> dst{window, offset};
 
@@ -403,56 +302,38 @@ NCCL_DEVICE_INLINE void ncclLsaCopy(Coop coop,
 }
 
 // [ID 4.3a] Multimem Copy: 1 local source -> 1 multimem destination (with ncclSymPtr)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclMultimemCopy(Coop coop,
-                                            T* srcPtr,
-                                            ncclSymPtr<T> dst,
-                                            IntCount count,
-                                            ncclMultimemHandle multimemHandle) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclMultimemCopy(Coop coop, T* srcPtr, ncclSymPtr<T> dst, IntCount count,
+                                         ncclMultimemHandle multimemHandle) {
   // Create lambdas for 1 source and 1 destination
-  auto srcLambda = [=] __device__ (int /*ignored*/) -> T* {
-    return srcPtr;
-  };
-  auto dstLambda = [=] __device__ (int /*ignored*/) -> T* {
-    return dst.multimemPtr(multimemHandle);
-  };
+  auto srcLambda = [=] __device__(int /*ignored*/) -> T* { return srcPtr; };
+  auto dstLambda = [=] __device__(int /*ignored*/) -> T* { return dst.multimemPtr(multimemHandle); };
 
   // Use the lambda-based function - alignment check is cheap for nSrc=1, nDst=1
   constexpr int nSrc = 1;
   constexpr int nDst = 1;
   ncclLsaReduceSumMultimemCopy<T, Coop, decltype(srcLambda), decltype(dstLambda), IntCount, UNROLL>(
-      coop, srcLambda, nSrc, dstLambda, nDst, count);
+    coop, srcLambda, nSrc, dstLambda, nDst, count);
 }
 
 // [ID 4.3b] Multimem Copy: 1 local source -> 1 multimem destination (with raw pointer)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclMultimemCopy(Coop coop,
-                                            T* srcPtr,
-                                            T* mcDstPtr,
-                                            IntCount count) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclMultimemCopy(Coop coop, T* srcPtr, T* mcDstPtr, IntCount count) {
   // Create lambdas for 1 source and 1 destination
-  auto srcLambda = [=] __device__ (int /*ignored*/) -> T* {
-    return srcPtr;
-  };
-  auto dstLambda = [=] __device__ (int /*ignored*/) -> T* {
-    return mcDstPtr;
-  };
+  auto srcLambda = [=] __device__(int /*ignored*/) -> T* { return srcPtr; };
+  auto dstLambda = [=] __device__(int /*ignored*/) -> T* { return mcDstPtr; };
 
   // Use the lambda-based function - alignment check is cheap for nSrc=1, nDst=1
   constexpr int nSrc = 1;
   constexpr int nDst = 1;
   ncclLsaReduceSumMultimemCopy<T, Coop, decltype(srcLambda), decltype(dstLambda), IntCount, UNROLL>(
-      coop, srcLambda, nSrc, dstLambda, nDst, count);
+    coop, srcLambda, nSrc, dstLambda, nDst, count);
 }
 
 // [ID 4.3c] Multimem Copy: 1 local source -> 1 multimem destination (with ncclWindow_t)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclMultimemCopy(Coop coop,
-                                            T* srcPtr,
-                                            ncclWindow_t window,
-                                            size_t offset,
-                                            IntCount count,
-                                            ncclMultimemHandle multimemHandle) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclMultimemCopy(Coop coop, T* srcPtr, ncclWindow_t window, size_t offset, IntCount count,
+                                         ncclMultimemHandle multimemHandle) {
   // Construct ncclSymPtr from window and offset
   ncclSymPtr<T> dst{window, offset};
 
@@ -460,42 +341,28 @@ NCCL_DEVICE_INLINE void ncclMultimemCopy(Coop coop,
 }
 
 // [ID 4.4] Local Copy: 1 source -> N local destinations (lambda-based)
-template<typename T, typename Coop, typename DstLambda, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLocalCopy(Coop coop,
-                                         T* srcPtr,
-                                         DstLambda dstLambda, int nDst,
-                                         IntCount count) {
-  auto srcLambda = [=] __device__ (int /*ignored*/) -> T* {
-    return srcPtr;
-  };
+template <typename T, typename Coop, typename DstLambda, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLocalCopy(Coop coop, T* srcPtr, DstLambda dstLambda, int nDst, IntCount count) {
+  auto srcLambda = [=] __device__(int /*ignored*/) -> T* { return srcPtr; };
   constexpr int nSrc = 1;  // Copy has single source
-  ncclLsaReduceSumLsaCopy<T, Coop, decltype(srcLambda), DstLambda, IntCount, UNROLL>(
-      coop, srcLambda, nSrc, dstLambda, nDst, count);
+  ncclLsaReduceSumLsaCopy<T, Coop, decltype(srcLambda), DstLambda, IntCount, UNROLL>(coop, srcLambda, nSrc, dstLambda,
+                                                                                     nDst, count);
 }
 
 // [ID 4.5] Local Copy: copy to n chunks separated by displacement
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLocalCopy(Coop coop,
-                                         T* srcPtr,
-                                         int nDst,
-                                         T* basePtr,
-                                         size_t displ,
-                                         IntCount count) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLocalCopy(Coop coop, T* srcPtr, int nDst, T* basePtr, size_t displ, IntCount count) {
   // Create lambda: n local destinations separated by displ
-  auto srcLambda = [=] __device__ (int /*ignored*/) -> T* {
-    return srcPtr;
-  };
-  auto dstLambda = [=] __device__ (int i) -> T* {
-    return basePtr + i * displ;
-  };
+  auto srcLambda = [=] __device__(int /*ignored*/) -> T* { return srcPtr; };
+  auto dstLambda = [=] __device__(int i) -> T* { return basePtr + i * displ; };
 
   constexpr int nSrc = 1;
   // Compute alignment across src and all strided destinations
-  auto alignment = nccl::utility::computeLambdaAlignmentOffsetWithFallback<T>(
-      coop, srcLambda, nSrc, dstLambda, nDst, count);
-  nccl::utility::reduceCopy<T, nccl::utility::OpSum<T>, Coop, false, false, decltype(srcLambda), decltype(dstLambda), IntCount, UNROLL>(
-      coop, srcLambda, nSrc, dstLambda, nDst, nccl::utility::OpSum<T>{},
-      count, alignment.alignOffset, alignment.maxPackBytes);
+  auto alignment =
+    nccl::utility::computeLambdaAlignmentOffsetWithFallback<T>(coop, srcLambda, nSrc, dstLambda, nDst, count);
+  nccl::utility::reduceCopy<T, nccl::utility::OpSum<T>, Coop, false, false, decltype(srcLambda), decltype(dstLambda),
+                            IntCount, UNROLL>(coop, srcLambda, nSrc, dstLambda, nDst, nccl::utility::OpSum<T>{}, count,
+                                              alignment.alignOffset, alignment.maxPackBytes);
 }
 
 // ============================================================================
@@ -503,50 +370,38 @@ NCCL_DEVICE_INLINE void ncclLocalCopy(Coop coop,
 // ============================================================================
 
 // [ID 5.1a] LSA ReduceSumCopy: same team for src and dst (most common case)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaReduceSumCopy(Coop coop,
-                                                ncclSymPtr<T> src,
-                                                ncclSymPtr<T> dst,
-                                                IntCount count,
-                                                ncclTeam team) {
-  auto srcLambda = [=] __device__ (int i) -> T* {
-    return src.peerPtr(team, i);
-  };
-  auto dstLambda = [=] __device__ (int i) -> T* {
-    return dst.peerPtr(team, i);
-  };
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaReduceSumCopy(Coop coop, ncclSymPtr<T> src, ncclSymPtr<T> dst, IntCount count,
+                                             ncclTeam team) {
+  auto srcLambda = [=] __device__(int i) -> T* { return src.peerPtr(team, i); };
+  auto dstLambda = [=] __device__(int i) -> T* { return dst.peerPtr(team, i); };
 
   // LSA translation ensures all peers have the same alignment
   // Only need to check the first src and dst pointers (much cheaper than checking all N)
   IntCount alignOffset = 0;
   int maxPackBytes = 16;
   if (count > 0 && team.nRanks > 0) {
-    nccl::utility::computePointerPairAlignmentWithFallback<T>(
-        srcLambda(0), dstLambda(0), count, alignOffset, maxPackBytes);
+    nccl::utility::computePointerPairAlignmentWithFallback<T>(srcLambda(0), dstLambda(0), count, alignOffset,
+                                                              maxPackBytes);
   }
 
-  nccl::utility::reduceCopy<T, nccl::utility::OpSum<T>, Coop, false, false, decltype(srcLambda), decltype(dstLambda), IntCount, UNROLL>(
-      coop, srcLambda, team.nRanks, dstLambda, team.nRanks, nccl::utility::OpSum<T>{}, count, alignOffset, maxPackBytes);
+  nccl::utility::reduceCopy<T, nccl::utility::OpSum<T>, Coop, false, false, decltype(srcLambda), decltype(dstLambda),
+                            IntCount, UNROLL>(coop, srcLambda, team.nRanks, dstLambda, team.nRanks,
+                                              nccl::utility::OpSum<T>{}, count, alignOffset, maxPackBytes);
 }
 
 // [ID 5.1b] LSA ReduceSumCopy: with ncclDevComm_t (extract team)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaReduceSumCopy(Coop coop,
-                                                ncclSymPtr<T> src,
-                                                ncclSymPtr<T> dst,
-                                                IntCount count,
-                                                ncclDevComm_t devComm) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaReduceSumCopy(Coop coop, ncclSymPtr<T> src, ncclSymPtr<T> dst, IntCount count,
+                                             ncclDevComm_t devComm) {
   ncclTeam team = ncclTeamLsa(devComm);
   ncclLsaReduceSumCopy<T, Coop, IntCount, UNROLL>(coop, src, dst, count, team);
 }
 
 // [ID 5.1c] LSA ReduceSumCopy: with windows + ncclTeam
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaReduceSumCopy(Coop coop,
-                                                ncclWindow_t srcWindow, size_t srcOffset,
-                                                ncclWindow_t dstWindow, size_t dstOffset,
-                                                IntCount count,
-                                                ncclTeam team) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaReduceSumCopy(Coop coop, ncclWindow_t srcWindow, size_t srcOffset,
+                                             ncclWindow_t dstWindow, size_t dstOffset, IntCount count, ncclTeam team) {
   // Construct ncclSymPtr from window and offset using direct initialization
   ncclSymPtr<T> src{srcWindow, srcOffset};
   ncclSymPtr<T> dst{dstWindow, dstOffset};
@@ -554,12 +409,10 @@ NCCL_DEVICE_INLINE void ncclLsaReduceSumCopy(Coop coop,
 }
 
 // [ID 5.1d] LSA ReduceSumCopy: with windows + ncclDevComm_t
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaReduceSumCopy(Coop coop,
-                                                ncclWindow_t srcWindow, size_t srcOffset,
-                                                ncclWindow_t dstWindow, size_t dstOffset,
-                                                IntCount count,
-                                                ncclDevComm_t devComm) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaReduceSumCopy(Coop coop, ncclWindow_t srcWindow, size_t srcOffset,
+                                             ncclWindow_t dstWindow, size_t dstOffset, IntCount count,
+                                             ncclDevComm_t devComm) {
   // Construct ncclSymPtr from window and offset using direct initialization
   ncclSymPtr<T> src{srcWindow, srcOffset};
   ncclSymPtr<T> dst{dstWindow, dstOffset};
@@ -567,17 +420,11 @@ NCCL_DEVICE_INLINE void ncclLsaReduceSumCopy(Coop coop,
 }
 
 // [ID 5.1e] LSA ReduceSumCopy: different teams for src and dst (advanced use case)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaReduceSumCopy(Coop coop,
-                                                ncclSymPtr<T> src, ncclTeam srcTeam,
-                                                ncclSymPtr<T> dst, ncclTeam dstTeam,
-                                                IntCount count) {
-  auto srcLambda = [=] __device__ (int i) -> T* {
-    return src.peerPtr(srcTeam, i);
-  };
-  auto dstLambda = [=] __device__ (int i) -> T* {
-    return dst.peerPtr(dstTeam, i);
-  };
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaReduceSumCopy(Coop coop, ncclSymPtr<T> src, ncclTeam srcTeam, ncclSymPtr<T> dst,
+                                             ncclTeam dstTeam, IntCount count) {
+  auto srcLambda = [=] __device__(int i) -> T* { return src.peerPtr(srcTeam, i); };
+  auto dstLambda = [=] __device__(int i) -> T* { return dst.peerPtr(dstTeam, i); };
 
   // LSA translation ensures all peers have the same alignment within each team
   // Always check both src and dst pointers together for relative alignment when both are available
@@ -586,60 +433,46 @@ NCCL_DEVICE_INLINE void ncclLsaReduceSumCopy(Coop coop,
   if (count > 0 && srcTeam.nRanks > 0 && dstTeam.nRanks > 0) {
     void* srcPtr = srcLambda(0);
     void* dstPtr = dstLambda(0);
-    nccl::utility::computePointerPairAlignmentWithFallback<T>(
-        srcPtr, dstPtr, count, alignOffset, maxPackBytes);
+    nccl::utility::computePointerPairAlignmentWithFallback<T>(srcPtr, dstPtr, count, alignOffset, maxPackBytes);
   }
 
-  nccl::utility::reduceCopy<T, nccl::utility::OpSum<T>, Coop, false, false, decltype(srcLambda), decltype(dstLambda), IntCount, UNROLL>(
-      coop, srcLambda, srcTeam.nRanks, dstLambda, dstTeam.nRanks, nccl::utility::OpSum<T>{}, count, alignOffset, maxPackBytes);
+  nccl::utility::reduceCopy<T, nccl::utility::OpSum<T>, Coop, false, false, decltype(srcLambda), decltype(dstLambda),
+                            IntCount, UNROLL>(coop, srcLambda, srcTeam.nRanks, dstLambda, dstTeam.nRanks,
+                                              nccl::utility::OpSum<T>{}, count, alignOffset, maxPackBytes);
 }
 
 // [ID 5.2a] Multimem ReduceSumCopy (with ncclSymPtr)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclMultimemReduceSumCopy(Coop coop,
-                                                     ncclSymPtr<T> src, ncclMultimemHandle srcHandle,
-                                                     ncclSymPtr<T> dst, ncclMultimemHandle dstHandle,
-                                                     IntCount count) {
-  auto srcLambda = [=] __device__ (int /*ignored*/) -> T* {
-    return src.multimemPtr(srcHandle);
-  };
-  auto dstLambda = [=] __device__ (int /*ignored*/) -> T* {
-    return dst.multimemPtr(dstHandle);
-  };
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclMultimemReduceSumCopy(Coop coop, ncclSymPtr<T> src, ncclMultimemHandle srcHandle,
+                                                  ncclSymPtr<T> dst, ncclMultimemHandle dstHandle, IntCount count) {
+  auto srcLambda = [=] __device__(int /*ignored*/) -> T* { return src.multimemPtr(srcHandle); };
+  auto dstLambda = [=] __device__(int /*ignored*/) -> T* { return dst.multimemPtr(dstHandle); };
 
   // Use the lambda-based function - alignment check is cheap for nSrc=1, nDst=1
   constexpr int nSrc = 1;
   constexpr int nDst = 1;
   ncclMultimemReduceSumMultimemCopy<T, Coop, decltype(srcLambda), decltype(dstLambda), IntCount, UNROLL>(
-      coop, srcLambda, nSrc, dstLambda, nDst, count);
+    coop, srcLambda, nSrc, dstLambda, nDst, count);
 }
 
 // [ID 5.2b] Multimem ReduceSumCopy (with raw pointers)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclMultimemReduceSumCopy(Coop coop,
-                                                     T* mcSrcPtr,
-                                                     T* mcDstPtr,
-                                                     IntCount count) {
-  auto srcLambda = [=] __device__ (int /*ignored*/) -> T* {
-    return mcSrcPtr;
-  };
-  auto dstLambda = [=] __device__ (int /*ignored*/) -> T* {
-    return mcDstPtr;
-  };
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclMultimemReduceSumCopy(Coop coop, T* mcSrcPtr, T* mcDstPtr, IntCount count) {
+  auto srcLambda = [=] __device__(int /*ignored*/) -> T* { return mcSrcPtr; };
+  auto dstLambda = [=] __device__(int /*ignored*/) -> T* { return mcDstPtr; };
 
   // Use the lambda-based function - alignment check is cheap for nSrc=1, nDst=1
   constexpr int nSrc = 1;
   constexpr int nDst = 1;
   ncclMultimemReduceSumMultimemCopy<T, Coop, decltype(srcLambda), decltype(dstLambda), IntCount, UNROLL>(
-      coop, srcLambda, nSrc, dstLambda, nDst, count);
+    coop, srcLambda, nSrc, dstLambda, nDst, count);
 }
 
 // [ID 5.2c] Multimem ReduceSumCopy (with ncclWindow_t)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclMultimemReduceSumCopy(Coop coop,
-                                                     ncclWindow_t srcWindow, size_t srcOffset, ncclMultimemHandle srcHandle,
-                                                     ncclWindow_t dstWindow, size_t dstOffset, ncclMultimemHandle dstHandle,
-                                                     IntCount count) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclMultimemReduceSumCopy(Coop coop, ncclWindow_t srcWindow, size_t srcOffset,
+                                                  ncclMultimemHandle srcHandle, ncclWindow_t dstWindow,
+                                                  size_t dstOffset, ncclMultimemHandle dstHandle, IntCount count) {
   // Construct ncclSymPtr from window and offset
   ncclSymPtr<T> src{srcWindow, srcOffset};
   ncclSymPtr<T> dst{dstWindow, dstOffset};
@@ -648,17 +481,11 @@ NCCL_DEVICE_INLINE void ncclMultimemReduceSumCopy(Coop coop,
 }
 
 // [ID 5.3a] LSA source -> Multimem destination
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaReduceSumMultimemCopy(Coop coop,
-                                                        ncclSymPtr<T> src, ncclTeam srcTeam,
-                                                        ncclSymPtr<T> dst, ncclMultimemHandle dstHandle,
-                                                        IntCount count) {
-  auto srcLambda = [=] __device__ (int i) -> T* {
-    return src.peerPtr(srcTeam, i);
-  };
-  auto dstLambda = [=] __device__ (int /*ignored*/) -> T* {
-    return dst.multimemPtr(dstHandle);
-  };
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaReduceSumMultimemCopy(Coop coop, ncclSymPtr<T> src, ncclTeam srcTeam, ncclSymPtr<T> dst,
+                                                     ncclMultimemHandle dstHandle, IntCount count) {
+  auto srcLambda = [=] __device__(int i) -> T* { return src.peerPtr(srcTeam, i); };
+  auto dstLambda = [=] __device__(int /*ignored*/) -> T* { return dst.multimemPtr(dstHandle); };
 
   // LSA and Multimem translation ensure consistent alignment
   // Always check both src and dst pointers together for relative alignment
@@ -667,27 +494,21 @@ NCCL_DEVICE_INLINE void ncclLsaReduceSumMultimemCopy(Coop coop,
   if (count > 0 && srcTeam.nRanks > 0) {
     void* srcPtr = srcLambda(0);
     void* dstPtr = dstLambda(0);
-    nccl::utility::computePointerPairAlignmentWithFallback<T>(
-        srcPtr, dstPtr, count, alignOffset, maxPackBytes);
+    nccl::utility::computePointerPairAlignmentWithFallback<T>(srcPtr, dstPtr, count, alignOffset, maxPackBytes);
   }
 
   constexpr int nDst = 1;
-  nccl::utility::reduceCopy<T, nccl::utility::OpSum<T>, Coop, false, true, decltype(srcLambda), decltype(dstLambda), IntCount, UNROLL>(
-      coop, srcLambda, srcTeam.nRanks, dstLambda, nDst, nccl::utility::OpSum<T>{}, count, alignOffset, maxPackBytes);
+  nccl::utility::reduceCopy<T, nccl::utility::OpSum<T>, Coop, false, true, decltype(srcLambda), decltype(dstLambda),
+                            IntCount, UNROLL>(coop, srcLambda, srcTeam.nRanks, dstLambda, nDst,
+                                              nccl::utility::OpSum<T>{}, count, alignOffset, maxPackBytes);
 }
 
 // [ID 5.3b] LSA source -> Multimem destination (with raw dst pointer)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaReduceSumMultimemCopy(Coop coop,
-                                                        ncclSymPtr<T> src, ncclTeam srcTeam,
-                                                        T* mcDstPtr,
-                                                        IntCount count) {
-  auto srcLambda = [=] __device__ (int i) -> T* {
-    return src.peerPtr(srcTeam, i);
-  };
-  auto dstLambda = [=] __device__ (int /*ignored*/) -> T* {
-    return mcDstPtr;
-  };
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaReduceSumMultimemCopy(Coop coop, ncclSymPtr<T> src, ncclTeam srcTeam, T* mcDstPtr,
+                                                     IntCount count) {
+  auto srcLambda = [=] __device__(int i) -> T* { return src.peerPtr(srcTeam, i); };
+  auto dstLambda = [=] __device__(int /*ignored*/) -> T* { return mcDstPtr; };
 
   // LSA and Multimem translation ensure consistent alignment
   // Always check both src and dst pointers together for relative alignment
@@ -696,27 +517,21 @@ NCCL_DEVICE_INLINE void ncclLsaReduceSumMultimemCopy(Coop coop,
   if (count > 0 && srcTeam.nRanks > 0) {
     void* srcPtr = srcLambda(0);
     void* dstPtr = dstLambda(0);
-    nccl::utility::computePointerPairAlignmentWithFallback<T>(
-        srcPtr, dstPtr, count, alignOffset, maxPackBytes);
+    nccl::utility::computePointerPairAlignmentWithFallback<T>(srcPtr, dstPtr, count, alignOffset, maxPackBytes);
   }
 
   constexpr int nDst = 1;
-  nccl::utility::reduceCopy<T, nccl::utility::OpSum<T>, Coop, false, true, decltype(srcLambda), decltype(dstLambda), IntCount, UNROLL>(
-      coop, srcLambda, srcTeam.nRanks, dstLambda, nDst, nccl::utility::OpSum<T>{}, count, alignOffset, maxPackBytes);
+  nccl::utility::reduceCopy<T, nccl::utility::OpSum<T>, Coop, false, true, decltype(srcLambda), decltype(dstLambda),
+                            IntCount, UNROLL>(coop, srcLambda, srcTeam.nRanks, dstLambda, nDst,
+                                              nccl::utility::OpSum<T>{}, count, alignOffset, maxPackBytes);
 }
 
 // [ID 5.3c] Multimem source -> LSA destination
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclMultimemReduceSumLsaCopy(Coop coop,
-                                                        ncclSymPtr<T> src, ncclMultimemHandle srcHandle,
-                                                        ncclSymPtr<T> dst, ncclTeam dstTeam,
-                                                        IntCount count) {
-  auto srcLambda = [=] __device__ (int /*ignored*/) -> T* {
-    return src.multimemPtr(srcHandle);
-  };
-  auto dstLambda = [=] __device__ (int i) -> T* {
-    return dst.peerPtr(dstTeam, i);
-  };
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclMultimemReduceSumLsaCopy(Coop coop, ncclSymPtr<T> src, ncclMultimemHandle srcHandle,
+                                                     ncclSymPtr<T> dst, ncclTeam dstTeam, IntCount count) {
+  auto srcLambda = [=] __device__(int /*ignored*/) -> T* { return src.multimemPtr(srcHandle); };
+  auto dstLambda = [=] __device__(int i) -> T* { return dst.peerPtr(dstTeam, i); };
 
   // Multimem and LSA translation ensure consistent alignment
   // Always check both src and dst pointers together for relative alignment
@@ -725,27 +540,21 @@ NCCL_DEVICE_INLINE void ncclMultimemReduceSumLsaCopy(Coop coop,
   if (count > 0 && dstTeam.nRanks > 0) {
     void* srcPtr = srcLambda(0);
     void* dstPtr = dstLambda(0);
-    nccl::utility::computePointerPairAlignmentWithFallback<T>(
-        srcPtr, dstPtr, count, alignOffset, maxPackBytes);
+    nccl::utility::computePointerPairAlignmentWithFallback<T>(srcPtr, dstPtr, count, alignOffset, maxPackBytes);
   }
 
   constexpr int nSrc = 1;
-  nccl::utility::reduceCopy<T, nccl::utility::OpSum<T>, Coop, true, false, decltype(srcLambda), decltype(dstLambda), IntCount, UNROLL>(
-      coop, srcLambda, nSrc, dstLambda, dstTeam.nRanks, nccl::utility::OpSum<T>{}, count, alignOffset, maxPackBytes);
+  nccl::utility::reduceCopy<T, nccl::utility::OpSum<T>, Coop, true, false, decltype(srcLambda), decltype(dstLambda),
+                            IntCount, UNROLL>(coop, srcLambda, nSrc, dstLambda, dstTeam.nRanks,
+                                              nccl::utility::OpSum<T>{}, count, alignOffset, maxPackBytes);
 }
 
 // [ID 5.3d] Multimem source -> LSA destination (with raw src pointer)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclMultimemReduceSumLsaCopy(Coop coop,
-                                                        T* mcSrcPtr,
-                                                        ncclSymPtr<T> dst, ncclTeam dstTeam,
-                                                        IntCount count) {
-  auto srcLambda = [=] __device__ (int /*ignored*/) -> T* {
-    return mcSrcPtr;
-  };
-  auto dstLambda = [=] __device__ (int i) -> T* {
-    return dst.peerPtr(dstTeam, i);
-  };
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclMultimemReduceSumLsaCopy(Coop coop, T* mcSrcPtr, ncclSymPtr<T> dst, ncclTeam dstTeam,
+                                                     IntCount count) {
+  auto srcLambda = [=] __device__(int /*ignored*/) -> T* { return mcSrcPtr; };
+  auto dstLambda = [=] __device__(int i) -> T* { return dst.peerPtr(dstTeam, i); };
 
   // Multimem and LSA translation ensure consistent alignment
   // Always check both src and dst pointers together for relative alignment
@@ -754,360 +563,356 @@ NCCL_DEVICE_INLINE void ncclMultimemReduceSumLsaCopy(Coop coop,
   if (count > 0 && dstTeam.nRanks > 0) {
     void* srcPtr = srcLambda(0);
     void* dstPtr = dstLambda(0);
-    nccl::utility::computePointerPairAlignmentWithFallback<T>(
-        srcPtr, dstPtr, count, alignOffset, maxPackBytes);
+    nccl::utility::computePointerPairAlignmentWithFallback<T>(srcPtr, dstPtr, count, alignOffset, maxPackBytes);
   }
 
   constexpr int nSrc = 1;
-  nccl::utility::reduceCopy<T, nccl::utility::OpSum<T>, Coop, true, false, decltype(srcLambda), decltype(dstLambda), IntCount, UNROLL>(
-      coop, srcLambda, nSrc, dstLambda, dstTeam.nRanks, nccl::utility::OpSum<T>{}, count, alignOffset, maxPackBytes);
+  nccl::utility::reduceCopy<T, nccl::utility::OpSum<T>, Coop, true, false, decltype(srcLambda), decltype(dstLambda),
+                            IntCount, UNROLL>(coop, srcLambda, nSrc, dstLambda, dstTeam.nRanks,
+                                              nccl::utility::OpSum<T>{}, count, alignOffset, maxPackBytes);
 }
 
 // [ID 5.4] Local ReduceSumCopy: N local sources -> M local destinations
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLocalReduceSumCopy(Coop coop,
-                                                  int nSrc, T* srcBasePtr, size_t srcDispl,
-                                                  int nDst, T* dstBasePtr, size_t dstDispl,
-                                                  IntCount count) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLocalReduceSumCopy(Coop coop, int nSrc, T* srcBasePtr, size_t srcDispl, int nDst,
+                                               T* dstBasePtr, size_t dstDispl, IntCount count) {
   // Fast alignment computation for strided addressing with fallback
   IntCount alignOffset = count;
   int maxPackBytes = static_cast<int>(sizeof(T));  // Default to scalar if nothing works
 
   // Try each pack size from largest to smallest using explicit template instantiations
-  if (nccl::utility::tryComplexStridedAlignmentForPackSize<T, 16>(
-          srcBasePtr, srcDispl * sizeof(T), dstBasePtr, dstDispl * sizeof(T), alignOffset, maxPackBytes)) {
+  if (nccl::utility::tryComplexStridedAlignmentForPackSize<T, 16>(srcBasePtr, srcDispl * sizeof(T), dstBasePtr,
+                                                                  dstDispl * sizeof(T), alignOffset, maxPackBytes)) {
     // Found working pack size
   } else if (nccl::utility::tryComplexStridedAlignmentForPackSize<T, 4>(
-          srcBasePtr, srcDispl * sizeof(T), dstBasePtr, dstDispl * sizeof(T), alignOffset, maxPackBytes)) {
+               srcBasePtr, srcDispl * sizeof(T), dstBasePtr, dstDispl * sizeof(T), alignOffset, maxPackBytes)) {
     // Found working pack size
   }
 
-  auto srcLambda = [=] __device__ (int i) -> T* {
-    return srcBasePtr + i * srcDispl;
-  };
-  auto dstLambda = [=] __device__ (int i) -> T* {
-    return dstBasePtr + i * dstDispl;
-  };
+  auto srcLambda = [=] __device__(int i) -> T* { return srcBasePtr + i * srcDispl; };
+  auto dstLambda = [=] __device__(int i) -> T* { return dstBasePtr + i * dstDispl; };
 
-  nccl::utility::reduceCopy<T, nccl::utility::OpSum<T>, Coop, false, false, decltype(srcLambda), decltype(dstLambda), IntCount, UNROLL>(
-      coop, srcLambda, nSrc, dstLambda, nDst, nccl::utility::OpSum<T>{}, count, alignOffset, maxPackBytes);
+  nccl::utility::reduceCopy<T, nccl::utility::OpSum<T>, Coop, false, false, decltype(srcLambda), decltype(dstLambda),
+                            IntCount, UNROLL>(coop, srcLambda, nSrc, dstLambda, nDst, nccl::utility::OpSum<T>{}, count,
+                                              alignOffset, maxPackBytes);
 }
 #else // __CUDACC_EXTENDED_LAMBDA__
 
 // SERIES 1.x - Generic ReduceCopy with RedOp (LSA sources only)
-template <typename T, typename Coop, typename SrcLambda, typename DstLambda,
-          typename RedOp, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaReduceLsaCopy(
-    Coop, SrcLambda, int, DstLambda, int, RedOp const&, IntCount) {
+template <typename T, typename Coop, typename SrcLambda, typename DstLambda, typename RedOp, typename IntCount,
+          int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaReduceLsaCopy(Coop, SrcLambda, int, DstLambda, int, RedOp const&, IntCount) {
   // C++11 - C++17 considers this a template invalid cannot have a valid specialation.
   // By making this a dependent static_assert, there may exists an overload of always_false that is true, it is valid.
   // "The validity of a template checked prior to any instantiation."
   // C++20+ may make an exception for static_assert for this exact situation. https://eel.is/c++draft/temp.res#general-6
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
-template <typename T, typename Coop, typename SrcLambda, typename DstLambda,
-          typename RedOp, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaReduceMultimemCopy(
-    Coop, SrcLambda, int, DstLambda, int, RedOp const&, IntCount) {
+template <typename T, typename Coop, typename SrcLambda, typename DstLambda, typename RedOp, typename IntCount,
+          int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaReduceMultimemCopy(Coop, SrcLambda, int, DstLambda, int, RedOp const&, IntCount) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
 // SERIES 2.x - Sum-Specific ReduceCopy (lambda-based foundation)
-template <typename T, typename Coop, typename SrcLambda, typename DstLambda,
-          typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaReduceSumLsaCopy(
-    Coop, SrcLambda, int, DstLambda, int, IntCount) {
+template <typename T, typename Coop, typename SrcLambda, typename DstLambda, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaReduceSumLsaCopy(Coop, SrcLambda, int, DstLambda, int, IntCount) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
-template <typename T, typename Coop, typename SrcLambda, typename DstLambda,
-          typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaReduceSumMultimemCopy(
-    Coop, SrcLambda, int, DstLambda, int, IntCount) {
+template <typename T, typename Coop, typename SrcLambda, typename DstLambda, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaReduceSumMultimemCopy(Coop, SrcLambda, int, DstLambda, int, IntCount) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
-template <typename T, typename Coop, typename SrcLambda, typename DstLambda,
-          typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclMultimemReduceSumLsaCopy(
-    Coop, SrcLambda, int, DstLambda, int, IntCount) {
+template <typename T, typename Coop, typename SrcLambda, typename DstLambda, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclMultimemReduceSumLsaCopy(Coop, SrcLambda, int, DstLambda, int, IntCount) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
-template <typename T, typename Coop, typename SrcLambda, typename DstLambda,
-          typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclMultimemReduceSumMultimemCopy(
-    Coop, SrcLambda, int, DstLambda, int, IntCount) {
+template <typename T, typename Coop, typename SrcLambda, typename DstLambda, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclMultimemReduceSumMultimemCopy(Coop, SrcLambda, int, DstLambda, int, IntCount) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
 // SERIES 3.x - ReduceSum (N->1)
-template<typename T, typename Coop, typename SrcLambda, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaReduceSum(
-    Coop, SrcLambda, int, T*, IntCount) {
+template <typename T, typename Coop, typename SrcLambda, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaReduceSum(Coop, SrcLambda, int, T*, IntCount) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaReduceSum(
-    Coop, ncclSymPtr<T>, T*, IntCount, ncclTeam) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaReduceSum(Coop, ncclSymPtr<T>, T*, IntCount, ncclTeam) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaReduceSum(
-    Coop, ncclSymPtr<T>, T*, IntCount, ncclDevComm_t) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaReduceSum(Coop, ncclSymPtr<T>, T*, IntCount, ncclDevComm_t) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaReduceSum(
-    Coop, ncclWindow_t, size_t, T*, IntCount, ncclTeam) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaReduceSum(Coop, ncclWindow_t, size_t, T*, IntCount, ncclTeam) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaReduceSum(
-    Coop, ncclWindow_t, size_t, T*, IntCount, ncclDevComm_t) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaReduceSum(Coop, ncclWindow_t, size_t, T*, IntCount, ncclDevComm_t) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclMultimemReduceSum(
-    Coop, ncclSymPtr<T>, T*, IntCount, ncclMultimemHandle) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclMultimemReduceSum(Coop, ncclSymPtr<T>, T*, IntCount, ncclMultimemHandle) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
 // 3.3b] Multimem ReduceSum (with raw pointer)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclMultimemReduceSum(
-    Coop, T*, T*, IntCount) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclMultimemReduceSum(Coop, T*, T*, IntCount) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclMultimemReduceSum(
-    Coop, ncclWindow_t, size_t, T*, IntCount, ncclMultimemHandle) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclMultimemReduceSum(Coop, ncclWindow_t, size_t, T*, IntCount, ncclMultimemHandle) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
 // 3.4] Local ReduceSum (lambda-based)
-template<typename T, typename Coop, typename SrcLambda, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLocalReduceSum(
-    Coop, SrcLambda, int, T*, IntCount) {
+template <typename T, typename Coop, typename SrcLambda, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLocalReduceSum(Coop, SrcLambda, int, T*, IntCount) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
 // 3.5] Local ReduceSum (strided)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLocalReduceSum(
-    Coop, int, T*, size_t, T*, IntCount) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLocalReduceSum(Coop, int, T*, size_t, T*, IntCount) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
 // SERIES 4.x - Copy/Broadcast (1->N)
 
 // 4.1] LSA Copy (lambda-based)
-template<typename T, typename Coop, typename DstLambda, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaCopy(
-    Coop, T*, DstLambda, int, IntCount) {
+template <typename T, typename Coop, typename DstLambda, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaCopy(Coop, T*, DstLambda, int, IntCount) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
 // 4.2a] LSA Copy (with ncclSymPtr + team)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaCopy(
-    Coop, T*, ncclSymPtr<T>, IntCount, ncclTeam) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaCopy(Coop, T*, ncclSymPtr<T>, IntCount, ncclTeam) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
 // 4.2b] LSA Copy (with ncclSymPtr + devComm)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaCopy(
-    Coop, T*, ncclSymPtr<T>, IntCount, ncclDevComm_t) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaCopy(Coop, T*, ncclSymPtr<T>, IntCount, ncclDevComm_t) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
 // 4.2c] LSA Copy (with window + offset + team)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaCopy(
-    Coop, T*, ncclWindow_t, size_t, IntCount, ncclTeam) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaCopy(Coop, T*, ncclWindow_t, size_t, IntCount, ncclTeam) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
 // 4.2d] LSA Copy (with window + offset + devComm)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaCopy(
-    Coop, T*, ncclWindow_t, size_t, IntCount, ncclDevComm_t) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaCopy(Coop, T*, ncclWindow_t, size_t, IntCount, ncclDevComm_t) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
 // 4.3a] Multimem Copy (with ncclSymPtr)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclMultimemCopy(
-    Coop, T*, ncclSymPtr<T>, IntCount, ncclMultimemHandle) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclMultimemCopy(Coop, T*, ncclSymPtr<T>, IntCount, ncclMultimemHandle) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
 // 4.3b] Multimem Copy (with raw pointer)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclMultimemCopy(
-    Coop, T*, T*, IntCount) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclMultimemCopy(Coop, T*, T*, IntCount) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
 // 4.3c] Multimem Copy (with window + offset)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclMultimemCopy(
-    Coop, T*, ncclWindow_t, size_t, IntCount, ncclMultimemHandle) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclMultimemCopy(Coop, T*, ncclWindow_t, size_t, IntCount, ncclMultimemHandle) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
 // 4.4] Local Copy (lambda-based)
-template<typename T, typename Coop, typename DstLambda, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLocalCopy(
-    Coop, T*, DstLambda, int, IntCount) {
+template <typename T, typename Coop, typename DstLambda, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLocalCopy(Coop, T*, DstLambda, int, IntCount) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
 // 4.5] Local Copy (strided)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLocalCopy(
-    Coop, T*, int, T*, size_t, IntCount) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLocalCopy(Coop, T*, int, T*, size_t, IntCount) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
 // SERIES 5.x - ReduceSumCopy (N->M)
 
 // 5.1a] LSA ReduceSumCopy (same team)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaReduceSumCopy(
-    Coop, ncclSymPtr<T>, ncclSymPtr<T>, IntCount, ncclTeam) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaReduceSumCopy(Coop, ncclSymPtr<T>, ncclSymPtr<T>, IntCount, ncclTeam) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
 // 5.1b] LSA ReduceSumCopy (with devComm)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaReduceSumCopy(
-    Coop, ncclSymPtr<T>, ncclSymPtr<T>, IntCount, ncclDevComm_t) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaReduceSumCopy(Coop, ncclSymPtr<T>, ncclSymPtr<T>, IntCount, ncclDevComm_t) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
 // 5.1c] LSA ReduceSumCopy (with windows + team)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaReduceSumCopy(
-    Coop, ncclWindow_t, size_t, ncclWindow_t, size_t, IntCount, ncclTeam) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaReduceSumCopy(Coop, ncclWindow_t, size_t, ncclWindow_t, size_t, IntCount, ncclTeam) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
 // 5.1d] LSA ReduceSumCopy (with windows + devComm)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaReduceSumCopy(
-    Coop, ncclWindow_t, size_t, ncclWindow_t, size_t, IntCount, ncclDevComm_t) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaReduceSumCopy(Coop, ncclWindow_t, size_t, ncclWindow_t, size_t, IntCount,
+                                             ncclDevComm_t) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
 // 5.1e] LSA ReduceSumCopy (different teams)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaReduceSumCopy(
-    Coop, ncclSymPtr<T>, ncclTeam, ncclSymPtr<T>, ncclTeam, IntCount) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaReduceSumCopy(Coop, ncclSymPtr<T>, ncclTeam, ncclSymPtr<T>, ncclTeam, IntCount) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
 // 5.2a] Multimem ReduceSumCopy (with ncclSymPtr)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclMultimemReduceSumCopy(
-    Coop, ncclSymPtr<T>, ncclMultimemHandle, ncclSymPtr<T>, ncclMultimemHandle, IntCount) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclMultimemReduceSumCopy(Coop, ncclSymPtr<T>, ncclMultimemHandle, ncclSymPtr<T>,
+                                                  ncclMultimemHandle, IntCount) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
 // 5.2b] Multimem ReduceSumCopy (with raw pointers)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclMultimemReduceSumCopy(
-    Coop, T*, T*, IntCount) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclMultimemReduceSumCopy(Coop, T*, T*, IntCount) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
 // 5.2c] Multimem ReduceSumCopy (with windows)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclMultimemReduceSumCopy(
-    Coop, ncclWindow_t, size_t, ncclMultimemHandle, ncclWindow_t, size_t, ncclMultimemHandle, IntCount) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclMultimemReduceSumCopy(Coop, ncclWindow_t, size_t, ncclMultimemHandle, ncclWindow_t, size_t,
+                                                  ncclMultimemHandle, IntCount) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
 // 5.3a] LSA -> Multimem ReduceSumCopy (with ncclSymPtr)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaReduceSumMultimemCopy(
-    Coop, ncclSymPtr<T>, ncclTeam, ncclSymPtr<T>, ncclMultimemHandle, IntCount) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaReduceSumMultimemCopy(Coop, ncclSymPtr<T>, ncclTeam, ncclSymPtr<T>, ncclMultimemHandle,
+                                                     IntCount) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
 // 5.3b] LSA -> Multimem ReduceSumCopy (with raw dst pointer)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLsaReduceSumMultimemCopy(
-    Coop, ncclSymPtr<T>, ncclTeam, T*, IntCount) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLsaReduceSumMultimemCopy(Coop, ncclSymPtr<T>, ncclTeam, T*, IntCount) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
 // 5.3c] Multimem -> LSA ReduceSumCopy (with ncclSymPtr)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclMultimemReduceSumLsaCopy(
-    Coop, ncclSymPtr<T>, ncclMultimemHandle, ncclSymPtr<T>, ncclTeam, IntCount) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclMultimemReduceSumLsaCopy(Coop, ncclSymPtr<T>, ncclMultimemHandle, ncclSymPtr<T>, ncclTeam,
+                                                     IntCount) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
 // 5.3d] Multimem -> LSA ReduceSumCopy (with raw src pointer)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclMultimemReduceSumLsaCopy(
-    Coop, T*, ncclSymPtr<T>, ncclTeam, IntCount) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclMultimemReduceSumLsaCopy(Coop, T*, ncclSymPtr<T>, ncclTeam, IntCount) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
 // 5.4] Local ReduceSumCopy (strided)
-template<typename T, typename Coop, typename IntCount, int UNROLL>
-NCCL_DEVICE_INLINE void ncclLocalReduceSumCopy(
-    Coop, int, T*, size_t, int, T*, size_t, IntCount) {
+template <typename T, typename Coop, typename IntCount, int UNROLL>
+NCCL_DEVICE_INLINE void ncclLocalReduceSumCopy(Coop, int, T*, size_t, int, T*, size_t, IntCount) {
   static_assert(nccl::utility::always_false<T>::value,
-     "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as compilation flag to enable that API.");
+                "NCCL device API reduce/Copy functions require device side lambdas, please use '--extended-lambda' as "
+                "compilation flag to enable that API.");
 }
 
 #endif // __CUDACC_EXTENDED_LAMBDA__

--- a/projects/rccl/src/include/nccl_device/impl/reduce_copy__impl.h
+++ b/projects/rccl/src/include/nccl_device/impl/reduce_copy__impl.h
@@ -24,18 +24,13 @@ namespace utility {
 
 // Core Loop Implementation
 
-template <int UNROLL_PACKS, int UNROLL_SOURCE, typename T, typename Pack, typename RedOp,
-          typename IntCount, typename Coop, bool srcMultimem, bool dstMultimem,
-          typename SrcLambda, typename DstLambda, bool CHECK_BOUNDS, bool SINGLE_SRC>
-NCCL_DEVICE_INLINE IntCount reduceCopyLoopCoreImpl(
-    Coop coop,
-    SrcLambda srcLambda, int nSrc,
-    DstLambda dstLambda, int nDst,
-    RedOp const& redOp,
-    IntCount totalPacks,
-    IntCount basePackIdx) {
-  static_assert(!SINGLE_SRC || UNROLL_SOURCE == 1,
-                "UNROLL_SOURCE must be 1 when SINGLE_SRC is set");
+template <int UNROLL_PACKS, int UNROLL_SOURCE, typename T, typename Pack, typename RedOp, typename IntCount,
+          typename Coop, bool srcMultimem, bool dstMultimem, typename SrcLambda, typename DstLambda, bool CHECK_BOUNDS,
+          bool SINGLE_SRC>
+NCCL_DEVICE_INLINE IntCount reduceCopyLoopCoreImpl(Coop coop, SrcLambda srcLambda, int nSrc, DstLambda dstLambda,
+                                                   int nDst, RedOp const& redOp, IntCount totalPacks,
+                                                   IntCount basePackIdx) {
+  static_assert(!SINGLE_SRC || UNROLL_SOURCE == 1, "UNROLL_SOURCE must be 1 when SINGLE_SRC is set");
 
   constexpr int warpSize = 32;
   constexpr int coopStride = CoopStride<Coop>::value;
@@ -62,7 +57,7 @@ NCCL_DEVICE_INLINE IntCount reduceCopyLoopCoreImpl(
   if NCCL_IF_CONSTEXPR (!srcMultimem && !CHECK_BOUNDS) {
     if NCCL_IF_CONSTEXPR (SINGLE_SRC) {
       Pack* srcPtr0 = (Pack*)srcLambda(0);
-      #pragma unroll UNROLL_PACKS
+#pragma unroll UNROLL_PACKS
       for (int u = 0; u < UNROLL_PACKS; u++) {
         IntCount packIdx = groupLanePackIdx + u * runtimeStride;
         Pack loaded = srcPtr0[packIdx];
@@ -74,26 +69,27 @@ NCCL_DEVICE_INLINE IntCount reduceCopyLoopCoreImpl(
 
       // Preseed acc[] with source 0 to avoid inner-loop branching.
       Pack* srcPtr = (Pack*)srcLambda(0);
-      #pragma unroll UNROLL_PACKS
+#pragma unroll UNROLL_PACKS
       for (int u = 0; u < UNROLL_PACKS; u++) {
         IntCount packIdx = groupLanePackIdx + u * runtimeStride;
-        acc[u] = castPack<AccEltType, PackEltType, Pack::Count>(srcPtr[packIdx]);;
+        acc[u] = castPack<AccEltType, PackEltType, Pack::Count>(srcPtr[packIdx]);
+        ;
       }
 
       constexpr int srcCount = UNROLL_SOURCE;
-      #pragma unroll UNROLL_SOURCE
+#pragma unroll UNROLL_SOURCE
       for (int srcOffset = 1; srcOffset < srcCount; srcOffset++) {
         Pack* srcPtr = (Pack*)srcLambda(srcOffset);
-        #pragma unroll UNROLL_PACKS
+#pragma unroll UNROLL_PACKS
         for (int u = 0; u < UNROLL_PACKS; u++) {
           IntCount packIdx = groupLanePackIdx + u * runtimeStride;
           loaded[srcOffset][u] = srcPtr[packIdx];
         }
       }
 
-      #pragma unroll UNROLL_PACKS
+#pragma unroll UNROLL_PACKS
       for (int u = 0; u < UNROLL_PACKS; u++) {
-        #pragma unroll UNROLL_SOURCE
+#pragma unroll UNROLL_SOURCE
         for (int srcOffset = 1; srcOffset < srcCount; srcOffset++) {
           AccPackType val = castPack<AccEltType, PackEltType, Pack::Count>(loaded[srcOffset][u]);
           acc[u] = reducePack(accRedOp, acc[u], val);
@@ -102,19 +98,19 @@ NCCL_DEVICE_INLINE IntCount reduceCopyLoopCoreImpl(
 
       // Remaining passes over sources.
       for (int srcBase = UNROLL_SOURCE; srcBase < nSrc; srcBase += UNROLL_SOURCE) {
-        #pragma unroll UNROLL_SOURCE
+#pragma unroll UNROLL_SOURCE
         for (int srcOffset = 0; srcOffset < srcCount; srcOffset++) {
           Pack* srcPtr = (Pack*)srcLambda(srcBase + srcOffset);
-          #pragma unroll UNROLL_PACKS
+#pragma unroll UNROLL_PACKS
           for (int u = 0; u < UNROLL_PACKS; u++) {
             IntCount packIdx = groupLanePackIdx + u * runtimeStride;
             loaded[srcOffset][u] = srcPtr[packIdx];
           }
         }
 
-        #pragma unroll UNROLL_PACKS
+#pragma unroll UNROLL_PACKS
         for (int u = 0; u < UNROLL_PACKS; u++) {
-          #pragma unroll UNROLL_SOURCE
+#pragma unroll UNROLL_SOURCE
           for (int srcOffset = 0; srcOffset < srcCount; srcOffset++) {
             AccPackType val = castPack<AccEltType, PackEltType, Pack::Count>(loaded[srcOffset][u]);
             acc[u] = reducePack(accRedOp, acc[u], val);
@@ -125,7 +121,7 @@ NCCL_DEVICE_INLINE IntCount reduceCopyLoopCoreImpl(
   } else {
     if NCCL_IF_CONSTEXPR (SINGLE_SRC) {
       Pack* srcPtr0 = (Pack*)srcLambda(0);
-      #pragma unroll UNROLL_PACKS
+#pragma unroll UNROLL_PACKS
       for (int u = 0; u < UNROLL_PACKS; u++) {
         IntCount packIdx = groupLanePackIdx + u * runtimeStride;
         if NCCL_IF_CONSTEXPR (CHECK_BOUNDS) {
@@ -141,7 +137,7 @@ NCCL_DEVICE_INLINE IntCount reduceCopyLoopCoreImpl(
 
       // Preseed acc[] with source 0 to avoid inner-loop branching.
       Pack* srcPtr = (Pack*)srcLambda(0);
-      #pragma unroll UNROLL_PACKS
+#pragma unroll UNROLL_PACKS
       for (int u = 0; u < UNROLL_PACKS; u++) {
         IntCount packIdx = groupLanePackIdx + u * runtimeStride;
         if NCCL_IF_CONSTEXPR (CHECK_BOUNDS) {
@@ -153,10 +149,10 @@ NCCL_DEVICE_INLINE IntCount reduceCopyLoopCoreImpl(
       }
 
       constexpr int srcCount = UNROLL_SOURCE;
-      #pragma unroll UNROLL_SOURCE
+#pragma unroll UNROLL_SOURCE
       for (int srcOffset = 1; srcOffset < srcCount; srcOffset++) {
         Pack* srcPtr = (Pack*)srcLambda(srcOffset);
-        #pragma unroll UNROLL_PACKS
+#pragma unroll UNROLL_PACKS
         for (int u = 0; u < UNROLL_PACKS; u++) {
           IntCount packIdx = groupLanePackIdx + u * runtimeStride;
           if NCCL_IF_CONSTEXPR (CHECK_BOUNDS) {
@@ -166,13 +162,13 @@ NCCL_DEVICE_INLINE IntCount reduceCopyLoopCoreImpl(
         }
       }
 
-      #pragma unroll UNROLL_PACKS
+#pragma unroll UNROLL_PACKS
       for (int u = 0; u < UNROLL_PACKS; u++) {
         if NCCL_IF_CONSTEXPR (CHECK_BOUNDS) {
           IntCount packIdx = groupLanePackIdx + u * runtimeStride;
           if (packIdx >= totalPacks) break;
         }
-        #pragma unroll UNROLL_SOURCE
+#pragma unroll UNROLL_SOURCE
         for (int srcOffset = 1; srcOffset < srcCount; srcOffset++) {
           AccPackType val = castPack<AccEltType, PackEltType, Pack::Count>(loaded[srcOffset][u]);
           acc[u] = reducePack(accRedOp, acc[u], val);
@@ -182,10 +178,10 @@ NCCL_DEVICE_INLINE IntCount reduceCopyLoopCoreImpl(
       // Finish remaining sources.
       for (int srcBase = UNROLL_SOURCE; srcBase < nSrc; srcBase += UNROLL_SOURCE) {
         Pack loaded[UNROLL_SOURCE][UNROLL_PACKS];
-        #pragma unroll UNROLL_SOURCE
+#pragma unroll UNROLL_SOURCE
         for (int srcOffset = 0; srcOffset < srcCount; srcOffset++) {
           Pack* srcPtr = (Pack*)srcLambda(srcBase + srcOffset);
-          #pragma unroll UNROLL_PACKS
+#pragma unroll UNROLL_PACKS
           for (int u = 0; u < UNROLL_PACKS; u++) {
             IntCount packIdx = groupLanePackIdx + u * runtimeStride;
             if NCCL_IF_CONSTEXPR (CHECK_BOUNDS) {
@@ -195,13 +191,13 @@ NCCL_DEVICE_INLINE IntCount reduceCopyLoopCoreImpl(
           }
         }
 
-        #pragma unroll UNROLL_PACKS
+#pragma unroll UNROLL_PACKS
         for (int u = 0; u < UNROLL_PACKS; u++) {
           if NCCL_IF_CONSTEXPR (CHECK_BOUNDS) {
             IntCount packIdx = groupLanePackIdx + u * runtimeStride;
             if (packIdx >= totalPacks) break;
           }
-          #pragma unroll UNROLL_SOURCE
+#pragma unroll UNROLL_SOURCE
           for (int srcOffset = 0; srcOffset < srcCount; srcOffset++) {
             AccPackType val = castPack<AccEltType, PackEltType, Pack::Count>(loaded[srcOffset][u]);
             acc[u] = reducePack(accRedOp, acc[u], val);
@@ -215,11 +211,11 @@ NCCL_DEVICE_INLINE IntCount reduceCopyLoopCoreImpl(
   if NCCL_IF_CONSTEXPR (!dstMultimem && !CHECK_BOUNDS) {
     // Fast path: LSA destinations, no bounds checking - optimized for performance
     // Hoist pointer calculations outside inner loop for better instruction scheduling
-    #pragma unroll 4
+#pragma unroll 4
     for (int dstIdx = 0; dstIdx < nDst; dstIdx++) {
       Pack* dstPtr = (Pack*)dstLambda(dstIdx);
       // Explicit unroll with direct memory access - compiler can better schedule instructions
-      #pragma unroll UNROLL_PACKS
+#pragma unroll UNROLL_PACKS
       for (int u = 0; u < UNROLL_PACKS; u++) {
         IntCount packIdx = groupLanePackIdx + u * runtimeStride;
         Pack result = castPack<PackEltType, AccEltType, Pack::Count>(acc[u]);
@@ -228,10 +224,10 @@ NCCL_DEVICE_INLINE IntCount reduceCopyLoopCoreImpl(
     }
   } else {
     // General path: handles multimem and bounds checking
-    #pragma unroll 4
+#pragma unroll 4
     for (int dstIdx = 0; dstIdx < nDst; dstIdx++) {
       Pack* dstPtr = (Pack*)dstLambda(dstIdx);
-      #pragma unroll UNROLL_PACKS
+#pragma unroll UNROLL_PACKS
       for (int u = 0; u < UNROLL_PACKS; u++) {
         IntCount packIdx = groupLanePackIdx + u * runtimeStride;
         if NCCL_IF_CONSTEXPR (CHECK_BOUNDS) {
@@ -252,28 +248,22 @@ NCCL_DEVICE_INLINE IntCount reduceCopyLoopCoreImpl(
   return processedPacks * Pack::Count;
 }
 
-template <int UNROLL_PACKS, typename T, typename Pack, typename RedOp,
-          typename IntCount, typename Coop, bool srcMultimem, bool dstMultimem,
-          typename SrcLambda, typename DstLambda, bool CHECK_BOUNDS>
-NCCL_DEVICE_INLINE IntCount reduceCopyLoopCore(
-    Coop coop,
-    SrcLambda srcLambda, int nSrc,
-    DstLambda dstLambda, int nDst,
-    RedOp const& redOp,
-    IntCount totalPacks,
-    IntCount basePackIdx) {
+template <int UNROLL_PACKS, typename T, typename Pack, typename RedOp, typename IntCount, typename Coop,
+          bool srcMultimem, bool dstMultimem, typename SrcLambda, typename DstLambda, bool CHECK_BOUNDS>
+NCCL_DEVICE_INLINE IntCount reduceCopyLoopCore(Coop coop, SrcLambda srcLambda, int nSrc, DstLambda dstLambda, int nDst,
+                                               RedOp const& redOp, IntCount totalPacks, IntCount basePackIdx) {
   if (nSrc == 1) {
     return reduceCopyLoopCoreImpl<UNROLL_PACKS, /*nSrc=*/1, T, Pack, RedOp, IntCount, Coop, srcMultimem, dstMultimem,
-                           SrcLambda, DstLambda, CHECK_BOUNDS, /*singleSrc=*/true>(
-        coop, srcLambda, 1, dstLambda, nDst, redOp, totalPacks, basePackIdx);
+                                  SrcLambda, DstLambda, CHECK_BOUNDS, /*singleSrc=*/true>(
+      coop, srcLambda, 1, dstLambda, nDst, redOp, totalPacks, basePackIdx);
   } else {
     if (nSrc >= 4 && nSrc % 4 == 0) {
       constexpr int UNROLL_DIV4 = UNROLL_PACKS / 4;
       if NCCL_IF_CONSTEXPR (UNROLL_DIV4 > 0) {
-        constexpr int UNROLL_DIV4_SAFE = (UNROLL_DIV4 > 0) ? UNROLL_DIV4 : 1;  // only needed for dead-code instantiation
-        return reduceCopyLoopCoreImpl<UNROLL_DIV4_SAFE, /*nSrc=*/4, T, Pack, RedOp, IntCount, Coop, srcMultimem, dstMultimem,
-                               SrcLambda, DstLambda, CHECK_BOUNDS, /*singleSrc=*/false>(
-            coop, srcLambda, nSrc, dstLambda, nDst, redOp, totalPacks, basePackIdx);
+        constexpr int UNROLL_DIV4_SAFE = (UNROLL_DIV4 > 0) ? UNROLL_DIV4 : 1; // only needed for dead-code instantiation
+        return reduceCopyLoopCoreImpl<UNROLL_DIV4_SAFE, /*nSrc=*/4, T, Pack, RedOp, IntCount, Coop, srcMultimem,
+                                      dstMultimem, SrcLambda, DstLambda, CHECK_BOUNDS, /*singleSrc=*/false>(
+          coop, srcLambda, nSrc, dstLambda, nDst, redOp, totalPacks, basePackIdx);
       }
     }
     // NOTE: nSrc % 3 and nSrc % 2 specializations marginally improve performance,
@@ -298,20 +288,20 @@ NCCL_DEVICE_INLINE IntCount reduceCopyLoopCore(
     //   }
     // }
     return reduceCopyLoopCoreImpl<UNROLL_PACKS, /*nSrc=*/1, T, Pack, RedOp, IntCount, Coop, srcMultimem, dstMultimem,
-                           SrcLambda, DstLambda, CHECK_BOUNDS, /*singleSrc=*/false>(
-        coop, srcLambda, nSrc, dstLambda, nDst, redOp, totalPacks, basePackIdx);
+                                  SrcLambda, DstLambda, CHECK_BOUNDS, /*singleSrc=*/false>(
+      coop, srcLambda, nSrc, dstLambda, nDst, redOp, totalPacks, basePackIdx);
   }
 }
 
 // Helper struct to calculate loop iteration counts
-template<int UNROLL_PACKS, typename Pack, typename IntCount>
+template <int UNROLL_PACKS, typename Pack, typename IntCount>
 struct ReduceCopyLoopParams {
   IntCount totalPacks;
   IntCount packsPerIteration;
   int effectiveUnrollPacks;
-  IntCount numFullChunks;  // Number of unchecked rounds
-  IntCount remainingPacks;  // Number of packs in checked round
-  IntCount processedElts;  // Number of elements processed (full packs only)
+  IntCount numFullChunks; // Number of unchecked rounds
+  IntCount remainingPacks; // Number of packs in checked round
+  IntCount processedElts; // Number of elements processed (full packs only)
 
   NCCL_DEVICE_INLINE ReduceCopyLoopParams(IntCount count, int coopSize, int stride, int nSrc) {
     if NCCL_IF_CONSTEXPR (Pack::Count > 0) {
@@ -354,15 +344,10 @@ struct ReduceCopyLoopParams {
   }
 };
 
-template <int UNROLL_PACKS, typename T, typename Pack, typename RedOp,
-          typename IntCount, typename Coop, bool srcMultimem, bool dstMultimem,
-          typename SrcLambda, typename DstLambda, bool SkipTail>
-NCCL_DEVICE_INLINE IntCount reduceCopyLoop(
-    Coop coop,
-    SrcLambda srcLambda, int nSrc,
-    DstLambda dstLambda, int nDst,
-    RedOp const& redOp,
-    IntCount count) {
+template <int UNROLL_PACKS, typename T, typename Pack, typename RedOp, typename IntCount, typename Coop,
+          bool srcMultimem, bool dstMultimem, typename SrcLambda, typename DstLambda, bool SkipTail>
+NCCL_DEVICE_INLINE IntCount reduceCopyLoop(Coop coop, SrcLambda srcLambda, int nSrc, DstLambda dstLambda, int nDst,
+                                           RedOp const& redOp, IntCount count) {
   const int coopSize = coop.size();
   constexpr int warpSize = 32;
   constexpr int defaultStride = CoopStride<Coop>::value;
@@ -377,17 +362,17 @@ NCCL_DEVICE_INLINE IntCount reduceCopyLoop(
   IntCount processedElts = 0;
   IntCount basePackIdx = 0;
   while (basePackIdx + params.packsPerIteration <= params.totalPacks) {
-    processedElts += reduceCopyLoopCore<UNROLL_PACKS, T, Pack, RedOp, IntCount, Coop, srcMultimem, dstMultimem,
-                                        SrcLambda, DstLambda, false>(
-        coop, srcLambda, nSrc, dstLambda, nDst, redOp, params.totalPacks, basePackIdx);
+    processedElts +=
+      reduceCopyLoopCore<UNROLL_PACKS, T, Pack, RedOp, IntCount, Coop, srcMultimem, dstMultimem, SrcLambda, DstLambda,
+                         false>(coop, srcLambda, nSrc, dstLambda, nDst, redOp, params.totalPacks, basePackIdx);
     basePackIdx += params.packsPerIteration;
   }
 
   if NCCL_IF_CONSTEXPR (!SkipTail) {
     if (basePackIdx < params.totalPacks) {
-      processedElts += reduceCopyLoopCore<UNROLL_PACKS, T, Pack, RedOp, IntCount, Coop, srcMultimem, dstMultimem,
-                                          SrcLambda, DstLambda, true>(
-          coop, srcLambda, nSrc, dstLambda, nDst, redOp, params.totalPacks, basePackIdx);
+      processedElts +=
+        reduceCopyLoopCore<UNROLL_PACKS, T, Pack, RedOp, IntCount, Coop, srcMultimem, dstMultimem, SrcLambda, DstLambda,
+                           true>(coop, srcLambda, nSrc, dstLambda, nDst, redOp, params.totalPacks, basePackIdx);
     }
   }
   return processedElts;
@@ -395,24 +380,19 @@ NCCL_DEVICE_INLINE IntCount reduceCopyLoop(
 
 // Scalar Loop Implementation (for scalar remainder sections)
 // Uses reduceCopyLoop with EltPack<T, 1> as the Pack type and UNROLL_PACKS=1
-template <typename T, typename RedOp,
-          typename IntCount, typename Coop, bool srcMultimem, bool dstMultimem,
+template <typename T, typename RedOp, typename IntCount, typename Coop, bool srcMultimem, bool dstMultimem,
           typename SrcLambda, typename DstLambda>
-NCCL_DEVICE_INLINE void reduceCopyScalarLoop(
-    Coop coop,
-    SrcLambda srcLambda, int nSrc,
-    DstLambda dstLambda, int nDst,
-    RedOp const& redOp,
-    IntCount count) {
+NCCL_DEVICE_INLINE void reduceCopyScalarLoop(Coop coop, SrcLambda srcLambda, int nSrc, DstLambda dstLambda, int nDst,
+                                             RedOp const& redOp, IntCount count) {
   if (count == 0) return;
 
   // Default scalar path: one element per pack.
   using Pack = EltPack<T, 1>;
-  auto srcScalarLambda = [=] __device__ (int i) -> Pack* {
+  auto srcScalarLambda = [=] __device__(int i) -> Pack* {
     T* basePtr = srcLambda(i);
     return reinterpret_cast<Pack*>(basePtr);
   };
-  auto dstScalarLambda = [=] __device__ (int i) -> Pack* {
+  auto dstScalarLambda = [=] __device__(int i) -> Pack* {
     T* basePtr = dstLambda(i);
     return reinterpret_cast<Pack*>(basePtr);
   };
@@ -421,32 +401,24 @@ NCCL_DEVICE_INLINE void reduceCopyScalarLoop(
   // This handles chunking and bounds checking properly
   constexpr int UNROLL_PACKS = 1;
 
-  reduceCopyLoop<UNROLL_PACKS, T, Pack, RedOp, IntCount, Coop, srcMultimem, dstMultimem,
-                       decltype(srcScalarLambda), decltype(dstScalarLambda), /*skipTail=*/false>(
-      coop, srcScalarLambda, nSrc, dstScalarLambda, nDst, redOp, count);
+  reduceCopyLoop<UNROLL_PACKS, T, Pack, RedOp, IntCount, Coop, srcMultimem, dstMultimem, decltype(srcScalarLambda),
+                 decltype(dstScalarLambda), /*skipTail=*/false>(coop, srcScalarLambda, nSrc, dstScalarLambda, nDst,
+                                                                redOp, count);
 }
 
 // Main Entry Point (Internal - Not Public API)
 
-template <typename T, typename RedOp, typename Coop,
-          bool srcMultimem, bool dstMultimem,
-          typename SrcLambda, typename DstLambda,
-          typename IntCount, int UNROLL_ELTS>
-NCCL_DEVICE_INLINE void reduceCopy(
-    Coop coop,
-    SrcLambda srcLambda, int nSrc,
-    DstLambda dstLambda, int nDst,
-    RedOp const& redOp,
-    IntCount count,
-    IntCount alignOffset = 0,
-    int maxPackBytes = 16) {
-
+template <typename T, typename RedOp, typename Coop, bool srcMultimem, bool dstMultimem, typename SrcLambda,
+          typename DstLambda, typename IntCount, int UNROLL_ELTS>
+NCCL_DEVICE_INLINE void reduceCopy(Coop coop, SrcLambda srcLambda, int nSrc, DstLambda dstLambda, int nDst,
+                                   RedOp const& redOp, IntCount count, IntCount alignOffset = 0,
+                                   int maxPackBytes = 16) {
   // Step 1: Process scalar prefix to achieve alignment (if needed)
   // alignOffset is already computed by the alignment functions - use it directly
   IntCount processedElts = 0;
   if (alignOffset > 0 && alignOffset < count) {
-    reduceCopyScalarLoop<T, RedOp, IntCount, Coop, srcMultimem, dstMultimem>(
-        coop, srcLambda, nSrc, dstLambda, nDst, redOp, alignOffset);
+    reduceCopyScalarLoop<T, RedOp, IntCount, Coop, srcMultimem, dstMultimem>(coop, srcLambda, nSrc, dstLambda, nDst,
+                                                                             redOp, alignOffset);
     processedElts = alignOffset;
   }
 
@@ -457,12 +429,8 @@ NCCL_DEVICE_INLINE void reduceCopy(
   }
 
   // Create lambdas for remaining work
-  auto srcRemaining = [=] __device__ (int i) -> T* {
-    return srcLambda(i) + processedElts;
-  };
-  auto dstRemaining = [=] __device__ (int i) -> T* {
-    return dstLambda(i) + processedElts;
-  };
+  auto srcRemaining = [=] __device__(int i) -> T* { return srcLambda(i) + processedElts; };
+  auto dstRemaining = [=] __device__(int i) -> T* { return dstLambda(i) + processedElts; };
 
   // Check relative alignment of first source and destination pointers (like all_reduce.cuh)
   // all_reduce.cuh checks: (input.offset - output.offset)%16 == 0
@@ -483,15 +451,14 @@ NCCL_DEVICE_INLINE void reduceCopy(
   if (maxPackBytes >= 16 && relOffset16 % 16 == 0 && remainingElts * scalarSize >= 16) {
     using Pack16 = nccl::utility::EltPackForBytes<T, 16>;
     if NCCL_IF_CONSTEXPR (Pack16::Count > 0) {
-      constexpr int UNROLL_PACKS16_RAW = static_cast<int>(
-          safeDiv(UNROLL_ELTS + Pack16::Count - 1, Pack16::Count));
+      constexpr int UNROLL_PACKS16_RAW = static_cast<int>(safeDiv(UNROLL_ELTS + Pack16::Count - 1, Pack16::Count));
       constexpr int UNROLL_PACKS16 = (UNROLL_PACKS16_RAW > 0) ? UNROLL_PACKS16_RAW : 1;
       if NCCL_IF_CONSTEXPR (UNROLL_PACKS16_RAW > 0) {
         IntCount vectorizableElts16 = safeDiv<IntCount>(remainingElts, Pack16::Count) * Pack16::Count;
         if (vectorizableElts16 > 0) {
           vectorizedElts += reduceCopyLoop<UNROLL_PACKS16, T, Pack16, RedOp, IntCount, Coop, srcMultimem, dstMultimem,
-                                          decltype(srcRemaining), decltype(dstRemaining), /*skipTail=*/false>(
-              coop, srcRemaining, nSrc, dstRemaining, nDst, redOp, vectorizableElts16);
+                                           decltype(srcRemaining), decltype(dstRemaining), /*skipTail=*/false>(
+            coop, srcRemaining, nSrc, dstRemaining, nDst, redOp, vectorizableElts16);
         }
       }
     }
@@ -511,7 +478,7 @@ NCCL_DEVICE_INLINE void reduceCopy(
     // Check individual pointer alignment for Pack4 (always 4-byte alignment requirement)
     // getAlignment returns bytes to next aligned address (0 = already aligned)
     using Pack4 = nccl::utility::EltPackForBytes<T, 4>;
-    constexpr unsigned pack4Align = 4;  // Pack4 always requires 4-byte alignment
+    constexpr unsigned pack4Align = 4; // Pack4 always requires 4-byte alignment
     bool srcAligned4 = (srcPtrAfter16 == nullptr) || (nccl::utility::getAlignment(srcPtrAfter16, pack4Align) == 0);
     bool dstAligned4 = (dstPtrAfter16 == nullptr) || (nccl::utility::getAlignment(dstPtrAfter16, pack4Align) == 0);
 
@@ -519,21 +486,16 @@ NCCL_DEVICE_INLINE void reduceCopy(
     if (sizeof(T) == 4 || (sizeof(T) < 4 && relOffset4After16 % 4 == 0 && srcAligned4 && dstAligned4)) {
       if (remainingAfter16 * scalarSize >= 4) {
         if NCCL_IF_CONSTEXPR (Pack4::Count > 0) {
-          constexpr int UNROLL_PACKS4_RAW = static_cast<int>(
-              safeDiv(UNROLL_ELTS + Pack4::Count - 1, Pack4::Count));
+          constexpr int UNROLL_PACKS4_RAW = static_cast<int>(safeDiv(UNROLL_ELTS + Pack4::Count - 1, Pack4::Count));
           constexpr int UNROLL_PACKS4 = (UNROLL_PACKS4_RAW > 0) ? UNROLL_PACKS4_RAW : 1;
           if NCCL_IF_CONSTEXPR (UNROLL_PACKS4_RAW > 0) {
             IntCount vectorizableElts4 = safeDiv<IntCount>(remainingAfter16, Pack4::Count) * Pack4::Count;
             if (vectorizableElts4 > 0) {
-              auto srcAfter16 = [=] __device__ (int i) -> T* {
-                return srcRemaining(i) + vectorizedElts;
-              };
-              auto dstAfter16 = [=] __device__ (int i) -> T* {
-                return dstRemaining(i) + vectorizedElts;
-              };
+              auto srcAfter16 = [=] __device__(int i) -> T* { return srcRemaining(i) + vectorizedElts; };
+              auto dstAfter16 = [=] __device__(int i) -> T* { return dstRemaining(i) + vectorizedElts; };
               vectorizedElts += reduceCopyLoop<UNROLL_PACKS4, T, Pack4, RedOp, IntCount, Coop, srcMultimem, dstMultimem,
-                                              decltype(srcAfter16), decltype(dstAfter16), /*skipTail=*/false>(
-                  coop, srcAfter16, nSrc, dstAfter16, nDst, redOp, vectorizableElts4);
+                                               decltype(srcAfter16), decltype(dstAfter16), /*skipTail=*/false>(
+                coop, srcAfter16, nSrc, dstAfter16, nDst, redOp, vectorizableElts4);
             }
           }
         }
@@ -544,16 +506,12 @@ NCCL_DEVICE_INLINE void reduceCopy(
   // Step 3: Scalar remainder
   IntCount scalarRemainder = remainingElts - vectorizedElts;
   if (scalarRemainder > 0) {
-    auto srcScalar = [=] __device__ (int i) -> T* {
-      return srcRemaining(i) + vectorizedElts;
-    };
-    auto dstScalar = [=] __device__ (int i) -> T* {
-      return dstRemaining(i) + vectorizedElts;
-    };
+    auto srcScalar = [=] __device__(int i) -> T* { return srcRemaining(i) + vectorizedElts; };
+    auto dstScalar = [=] __device__(int i) -> T* { return dstRemaining(i) + vectorizedElts; };
 
     // Process scalar remainder - always use scalar loop with EltPack<T, 1>
-    reduceCopyScalarLoop<T, RedOp, IntCount, Coop, srcMultimem, dstMultimem>(
-        coop, srcScalar, nSrc, dstScalar, nDst, redOp, scalarRemainder);
+    reduceCopyScalarLoop<T, RedOp, IntCount, Coop, srcMultimem, dstMultimem>(coop, srcScalar, nSrc, dstScalar, nDst,
+                                                                             redOp, scalarRemainder);
   }
 }
 

--- a/projects/rccl/src/include/nccl_device/impl/reduce_copy__types.h
+++ b/projects/rccl/src/include/nccl_device/impl/reduce_copy__types.h
@@ -29,14 +29,14 @@ struct OpSum {
 
 // Helper trait to create accumulator reduction operator from RedOp
 // Maps RedOp (e.g., OpSum<T>) to accumulator reduction operator (e.g., OpSum<AccEltType>)
-template<typename RedOp, typename AccEltType>
+template <typename RedOp, typename AccEltType>
 struct AccRedOp {
   // Default: keep RedOp as-is (non-templated operators).
   using Type = RedOp;
 };
 
 // Rebind RedOp<T> to RedOp<AccEltType> when possible.
-template<template<typename> typename Red, typename T, typename AccEltType>
+template <template <typename> typename Red, typename T, typename AccEltType>
 struct AccRedOp<Red<T>, AccEltType> {
   using Type = Red<AccEltType>;
 };
@@ -70,31 +70,31 @@ struct CoopStride<ncclCoopThread> {
 
 #if defined(__CUDA_FP8_TYPES_EXIST__)
 // Specialization for FP8 types - convert to half, add, convert back
-template<>
+template <>
 struct OpSum<__nv_fp8_e4m3> {
   using EltType = __nv_fp8_e4m3;
   NCCL_DEVICE_INLINE __nv_fp8_e4m3 operator()(const __nv_fp8_e4m3& a, const __nv_fp8_e4m3& b) const {
-    #if __CUDA_ARCH__ >= 800
+#if __CUDA_ARCH__ >= 800
       // Use native half addition on architectures that support it
-      return __nv_fp8_e4m3(__hadd(__half(a), __half(b)));
-    #else
+    return __nv_fp8_e4m3(__hadd(__half(a), __half(b)));
+#else
       // Fallback: convert to float, add, convert back
-      return __nv_fp8_e4m3(float(a) + float(b));
-    #endif
+    return __nv_fp8_e4m3(float(a) + float(b));
+#endif
   }
 };
 
-template<>
+template <>
 struct OpSum<__nv_fp8_e5m2> {
   using EltType = __nv_fp8_e5m2;
   NCCL_DEVICE_INLINE __nv_fp8_e5m2 operator()(const __nv_fp8_e5m2& a, const __nv_fp8_e5m2& b) const {
-    #if __CUDA_ARCH__ >= 800
+#if __CUDA_ARCH__ >= 800
       // Use native half addition on architectures that support it
-      return __nv_fp8_e5m2(__hadd(__half(a), __half(b)));
-    #else
+    return __nv_fp8_e5m2(__hadd(__half(a), __half(b)));
+#else
       // Fallback: convert to float, add, convert back
-      return __nv_fp8_e5m2(float(a) + float(b));
-    #endif
+    return __nv_fp8_e5m2(float(a) + float(b));
+#endif
   }
 };
 #endif

--- a/projects/rccl/src/include/nccl_device/impl/vector__funcs.h
+++ b/projects/rccl/src/include/nccl_device/impl/vector__funcs.h
@@ -49,7 +49,7 @@ NCCL_DEVICE_INLINE unsigned computeCommonAlignment(Coop coop, Lambda ptrLambda, 
   // Use efficient warp reduce
   auto lanes = ncclCoopCoalesced(coop);
   unsigned commonAlign = 0;
-  #pragma unroll 1
+#pragma unroll 1
   for (int i = lanes.thread_rank(); i < nPtrs; i += lanes.size()) {
     unsigned align = getAlignment(ptrLambda(i), sizeof(Pack));
     commonAlign = 1 + min(commonAlign - 1, align - 1);
@@ -67,14 +67,11 @@ NCCL_DEVICE_INLINE unsigned computeCommonAlignment(Coop coop, Lambda ptrLambda, 
 #endif
 }
 
-
 // Helper to compute alignment for a specific pack size
 // Returns alignment offset in bytes (0 means aligned)
 template <typename T, int PackBytes, typename Coop, typename SrcLambda, typename DstLambda>
-NCCL_DEVICE_INLINE unsigned computeAlignmentForPackSize(
-    Coop coop,
-    SrcLambda srcLambda, int nSrc,
-    DstLambda dstLambda, int nDst) {
+NCCL_DEVICE_INLINE unsigned computeAlignmentForPackSize(Coop coop, SrcLambda srcLambda, int nSrc, DstLambda dstLambda,
+                                                        int nDst) {
   using Pack = EltPackForBytes<T, PackBytes>;
   unsigned srcAlign = (nSrc > 0) ? computeCommonAlignment<Pack>(coop, srcLambda, nSrc) : 0;
   unsigned dstAlign = (nDst > 0) ? computeCommonAlignment<Pack>(coop, dstLambda, nDst) : 0;
@@ -94,13 +91,9 @@ NCCL_DEVICE_INLINE unsigned computeAlignmentForPackSize(
 // Helper to try alignment for a specific pack size with lambdas
 // Matches all_reduce.cuh: checks both individual alignment and relative alignment
 template <typename T, int PackBytes, typename Coop, typename SrcLambda, typename DstLambda, typename IntCount>
-NCCL_DEVICE_INLINE bool tryLambdaAlignmentForPackSize(
-    Coop coop,
-    SrcLambda srcLambda, int nSrc,
-    DstLambda dstLambda, int nDst,
-    IntCount count,
-    IntCount& alignOffset,
-    int& maxPackBytes) {
+NCCL_DEVICE_INLINE bool tryLambdaAlignmentForPackSize(Coop coop, SrcLambda srcLambda, int nSrc, DstLambda dstLambda,
+                                                      int nDst, IntCount count, IntCount& alignOffset,
+                                                      int& maxPackBytes) {
   constexpr IntCount eltPerPack = PackBytes / sizeof(T);
 
   if (eltPerPack == 0 || count < eltPerPack) {
@@ -116,13 +109,11 @@ NCCL_DEVICE_INLINE bool tryLambdaAlignmentForPackSize(
   if (nSrc > 0 && nDst > 0) {
     uintptr_t refOffset = reinterpret_cast<uintptr_t>(srcLambda(0));
     const int nOthers = (nSrc - 1) + nDst;
-    auto ptrLambda = [&](int i) -> void* {
-      return (i < nSrc - 1) ? srcLambda(i + 1) : dstLambda(i - (nSrc - 1));
-    };
+    auto ptrLambda = [&](int i) -> void* { return (i < nSrc - 1) ? srcLambda(i + 1) : dstLambda(i - (nSrc - 1)); };
 #if __CUDA_ARCH__ >= 800
     auto lanes = ncclCoopCoalesced(coop);
     unsigned allAligned = 1u;
-    #pragma unroll 1
+#pragma unroll 1
     for (int i = lanes.thread_rank(); i < nOthers; i += lanes.size()) {
       uintptr_t ptrOffset = reinterpret_cast<uintptr_t>(ptrLambda(i));
       intptr_t relOffset = static_cast<intptr_t>(ptrOffset) - static_cast<intptr_t>(refOffset);
@@ -170,19 +161,18 @@ struct AlignmentResult {
 // Tries 16, 4 bytes and returns both the offset and the max pack size that works
 template <typename T, typename Coop, typename SrcLambda, typename DstLambda, typename IntCount>
 NCCL_DEVICE_INLINE AlignmentResult<IntCount> computeLambdaAlignmentOffsetWithFallback(
-    Coop coop,
-    SrcLambda srcLambda, int nSrc,
-    DstLambda dstLambda, int nDst,
-    IntCount count) {
+  Coop coop, SrcLambda srcLambda, int nSrc, DstLambda dstLambda, int nDst, IntCount count) {
   AlignmentResult<IntCount> result;
   result.alignOffset = 0;
   result.maxPackBytes = static_cast<int>(sizeof(T));  // Default to scalar if nothing works
 
   // Try each pack size from largest to smallest using explicit template instantiations
-  if (tryLambdaAlignmentForPackSize<T, 16>(coop, srcLambda, nSrc, dstLambda, nDst, count, result.alignOffset, result.maxPackBytes)) {
+  if (tryLambdaAlignmentForPackSize<T, 16>(coop, srcLambda, nSrc, dstLambda, nDst, count, result.alignOffset,
+                                           result.maxPackBytes)) {
     return result;
   }
-  if (tryLambdaAlignmentForPackSize<T, 4>(coop, srcLambda, nSrc, dstLambda, nDst, count, result.alignOffset, result.maxPackBytes)) {
+  if (tryLambdaAlignmentForPackSize<T, 4>(coop, srcLambda, nSrc, dstLambda, nDst, count, result.alignOffset,
+                                          result.maxPackBytes)) {
     return result;
   }
 
@@ -195,11 +185,8 @@ NCCL_DEVICE_INLINE AlignmentResult<IntCount> computeLambdaAlignmentOffsetWithFal
 // Helper to compute alignment for a specific pack size (template parameter)
 // Matches all_reduce.cuh: checks both individual alignment and relative alignment
 template <typename T, int PackBytes, typename IntCount>
-NCCL_DEVICE_INLINE bool tryPointerPairAlignmentForPackSize(
-    void* srcPtr,
-    void* dstPtr,
-    IntCount& alignOffset,
-    int& maxPackBytes) {
+NCCL_DEVICE_INLINE bool tryPointerPairAlignmentForPackSize(void* srcPtr, void* dstPtr, IntCount& alignOffset,
+                                                           int& maxPackBytes) {
   using Pack = EltPackForBytes<T, PackBytes>;
 
   // Check individual alignments
@@ -235,16 +222,11 @@ NCCL_DEVICE_INLINE bool tryPointerPairAlignmentForPackSize(
   return false;
 }
 
-
 // Compute alignment for two pointers with fallback to smaller pack sizes
 // Tries 16, 4 bytes and returns both the offset and the max pack size that works
 template <typename T, typename IntCount>
-NCCL_DEVICE_INLINE void computePointerPairAlignmentWithFallback(
-    void* srcPtr,
-    void* dstPtr,
-    IntCount count,
-    IntCount& alignOffset,
-    int& maxPackBytes) {
+NCCL_DEVICE_INLINE void computePointerPairAlignmentWithFallback(void* srcPtr, void* dstPtr, IntCount count,
+                                                                IntCount& alignOffset, int& maxPackBytes) {
   alignOffset = 0;
   maxPackBytes = static_cast<int>(sizeof(T));  // Default to scalar if nothing works
 
@@ -263,11 +245,8 @@ NCCL_DEVICE_INLINE void computePointerPairAlignmentWithFallback(
 
 // Helper to compute strided alignment for a specific pack size (template parameter)
 template <typename T, int PackBytes, typename IntCount>
-NCCL_DEVICE_INLINE bool tryStridedAlignmentForPackSize(
-    void* basePtr,
-    size_t displ,
-    IntCount& alignOffset,
-    int& maxPackBytes) {
+NCCL_DEVICE_INLINE bool tryStridedAlignmentForPackSize(void* basePtr, size_t displ, IntCount& alignOffset,
+                                                       int& maxPackBytes) {
   using Pack = EltPackForBytes<T, PackBytes>;
 
   // Strided offsets must preserve alignment for all chunks.
@@ -289,12 +268,7 @@ NCCL_DEVICE_INLINE bool tryStridedAlignmentForPackSize(
 // Helper to try complex strided alignment (src and dst) for a specific pack size
 template <typename T, int PackBytes, typename IntCount>
 NCCL_DEVICE_INLINE bool tryComplexStridedAlignmentForPackSize(
-    void* srcBasePtr,
-    size_t srcDispl,
-    void* dstBasePtr,
-    size_t dstDispl,
-    IntCount& alignOffset,
-    int& maxPackBytes) {
+  void* srcBasePtr, size_t srcDispl, void* dstBasePtr, size_t dstDispl, IntCount& alignOffset, int& maxPackBytes) {
   using Pack = EltPackForBytes<T, PackBytes>;
 
   // Compute alignment for source and destination strides
@@ -345,12 +319,8 @@ NCCL_DEVICE_INLINE bool tryComplexStridedAlignmentForPackSize(
 // Compute strided alignment with fallback to smaller pack sizes
 // Tries 16, 4 bytes and returns both the offset and the max pack size that works
 template <typename T, typename IntCount>
-NCCL_DEVICE_INLINE void computeStridedAlignmentWithFallback(
-    void* basePtr,
-    size_t displ,
-    IntCount count,
-    IntCount& alignOffset,
-    int& maxPackBytes) {
+NCCL_DEVICE_INLINE void computeStridedAlignmentWithFallback(void* basePtr, size_t displ, IntCount count,
+                                                            IntCount& alignOffset, int& maxPackBytes) {
   alignOffset = 0;
   maxPackBytes = static_cast<int>(sizeof(T));  // Default to scalar if nothing works
 
@@ -378,7 +348,10 @@ template <typename T, int n>
 struct PackAccess {
   union {
     EltPack<T, n> pack;
-    struct { EltPack<T, n / 2> lo; EltPack<T, n / 2> hi; };
+    struct {
+      EltPack<T, n / 2> lo;
+      EltPack<T, n / 2> hi;
+    };
   };
 };
 
@@ -386,8 +359,12 @@ template <typename T>
 struct PackAccess<T, 1> {
   union {
     EltPack<T, 1> pack;
-    struct { EltPack<T, 1> lo; };
-    struct { EltPack<T, 1> hi; };
+    struct {
+      EltPack<T, 1> lo;
+    };
+    struct {
+      EltPack<T, 1> hi;
+    };
   };
 };
 
@@ -395,14 +372,18 @@ template <typename T>
 struct PackAccess<T, 0> {
   union {
     EltPack<T, 0> pack;
-    struct { EltPack<T, 0> lo; };
-    struct { EltPack<T, 0> hi; };
+    struct {
+      EltPack<T, 0> lo;
+    };
+    struct {
+      EltPack<T, 0> hi;
+    };
   };
 };
 
 // Cast pack from element type X to element type Y
 // Works with EltPack types
-template<typename Y, typename X, int n>
+template <typename Y, typename X, int n>
 NCCL_DEVICE_INLINE EltPack<Y, n> castPack(EltPack<X, n> x) {
   static_assert((n & (n - 1)) == 0, "EltPack requires power-of-two element count");
 
@@ -419,7 +400,7 @@ NCCL_DEVICE_INLINE EltPack<Y, n> castPack(EltPack<X, n> x) {
 }
 
 // Specialization for zero-sized packs
-template<typename Y, typename X>
+template <typename Y, typename X>
 NCCL_DEVICE_INLINE EltPack<Y, 0> castPack(EltPack<X, 0> /* x */) {
   EltPack<Y, 0> result{};
   return result;
@@ -430,14 +411,14 @@ NCCL_DEVICE_INLINE EltPack<Y, 0> castPack(EltPack<X, 0> /* x */) {
 // ============================================================================
 
 // Specialization for half -> float conversion (upcast to accumulation type)
-template<>
+template <>
 NCCL_DEVICE_INLINE EltPack<float, 1> castPack(EltPack<half, 1> x) {
   EltPack<float, 1> out{};
   out.elts()[0] = __half2float(x.elts()[0]);
   return out;
 }
 
-template<>
+template <>
 NCCL_DEVICE_INLINE EltPack<float, 2> castPack(EltPack<half, 2> x) {
   union Half2PackAccess {
     EltPack<half, 2> pack;
@@ -455,14 +436,14 @@ NCCL_DEVICE_INLINE EltPack<float, 2> castPack(EltPack<half, 2> x) {
 }
 
 // Specialization for float -> half conversion (downcast from accumulation type)
-template<>
+template <>
 NCCL_DEVICE_INLINE EltPack<half, 1> castPack(EltPack<float, 1> x) {
   EltPack<half, 1> out{};
   out.elts()[0] = __float2half_rn(x.elts()[0]);  // Round to nearest
   return out;
 }
 
-template<>
+template <>
 NCCL_DEVICE_INLINE EltPack<half, 2> castPack(EltPack<float, 2> x) {
   union Half2PackAccess {
     EltPack<half, 2> pack;
@@ -476,14 +457,14 @@ NCCL_DEVICE_INLINE EltPack<half, 2> castPack(EltPack<float, 2> x) {
 #if defined(__CUDA_BF16_TYPES_EXIST__)
 
 // Specialization for __nv_bfloat16 -> float conversion (upcast to accumulation type)
-template<>
+template <>
 NCCL_DEVICE_INLINE EltPack<float, 1> castPack(EltPack<__nv_bfloat16, 1> x) {
   EltPack<float, 1> out{};
   out.elts()[0] = __bfloat162float(x.elts()[0]);
   return out;
 }
 
-template<>
+template <>
 NCCL_DEVICE_INLINE EltPack<float, 2> castPack(EltPack<__nv_bfloat16, 2> x) {
   union Bf162PackAccess {
     EltPack<__nv_bfloat16, 2> pack;
@@ -501,14 +482,14 @@ NCCL_DEVICE_INLINE EltPack<float, 2> castPack(EltPack<__nv_bfloat16, 2> x) {
 }
 
 // Specialization for float -> __nv_bfloat16 conversion (downcast from accumulation type)
-template<>
+template <>
 NCCL_DEVICE_INLINE EltPack<__nv_bfloat16, 1> castPack(EltPack<float, 1> x) {
   EltPack<__nv_bfloat16, 1> out{};
   out.elts()[0] = __float2bfloat16_rn(x.elts()[0]);  // Round to nearest
   return out;
 }
 
-template<>
+template <>
 NCCL_DEVICE_INLINE EltPack<__nv_bfloat16, 2> castPack(EltPack<float, 2> x) {
   union Bf162PackAccess {
     EltPack<__nv_bfloat16, 2> pack;
@@ -530,7 +511,7 @@ NCCL_DEVICE_INLINE EltPack<__nv_bfloat16, 2> castPack(EltPack<float, 2> x) {
 
 // Specialization for __nv_fp8_e4m3 -> half conversion (upcast to accumulation type)
 // Uses vectorized fp8x2 -> half2 when available for SIMD performance
-template<>
+template <>
 NCCL_DEVICE_INLINE EltPack<half, 1> castPack(EltPack<__nv_fp8_e4m3, 1> x) {
   union HalfRawAccess {
     __half_raw raw;
@@ -549,41 +530,41 @@ NCCL_DEVICE_INLINE EltPack<half, 1> castPack(EltPack<__nv_fp8_e4m3, 1> x) {
   return out;
 }
 
-template<>
+template <>
 NCCL_DEVICE_INLINE EltPack<half, 2> castPack(EltPack<__nv_fp8_e4m3, 2> x) {
-  #if __CUDA_ARCH__ >= 900
-    union Half2RawAccess {
-      __half2_raw raw;
-      half2 val;
-    };
-    union Half2PackAccess {
-      EltPack<half, 2> pack;
-      half2 pair;
-    };
-    union Fp8E4m3Access2 {
-      EltPack<__nv_fp8_e4m3, 2> pack;
-      __nv_fp8x2_storage_t storage2;
-    };
-    Fp8E4m3Access2 in;
-    Half2PackAccess out;
-    in.pack = x;
-    Half2RawAccess h2;
-    h2.raw = __nv_cvt_fp8x2_to_halfraw2(in.storage2, __NV_E4M3);
-    out.pair = h2.val;
-    return out.pack;
-  #else
-    PackAccess<__nv_fp8_e4m3, 2> in;
-    PackAccess<half, 2> out;
-    in.pack = x;
-    out.lo = castPack<half>(in.lo);
-    out.hi = castPack<half>(in.hi);
-    return out.pack;
-  #endif
+#if __CUDA_ARCH__ >= 900
+  union Half2RawAccess {
+    __half2_raw raw;
+    half2 val;
+  };
+  union Half2PackAccess {
+    EltPack<half, 2> pack;
+    half2 pair;
+  };
+  union Fp8E4m3Access2 {
+    EltPack<__nv_fp8_e4m3, 2> pack;
+    __nv_fp8x2_storage_t storage2;
+  };
+  Fp8E4m3Access2 in;
+  Half2PackAccess out;
+  in.pack = x;
+  Half2RawAccess h2;
+  h2.raw = __nv_cvt_fp8x2_to_halfraw2(in.storage2, __NV_E4M3);
+  out.pair = h2.val;
+  return out.pack;
+#else
+  PackAccess<__nv_fp8_e4m3, 2> in;
+  PackAccess<half, 2> out;
+  in.pack = x;
+  out.lo = castPack<half>(in.lo);
+  out.hi = castPack<half>(in.hi);
+  return out.pack;
+#endif
 }
 
 // Specialization for __nv_fp8_e5m2 -> half conversion (upcast to accumulation type)
 // Uses vectorized fp8x2 -> half2 when available for SIMD performance
-template<>
+template <>
 NCCL_DEVICE_INLINE EltPack<half, 1> castPack(EltPack<__nv_fp8_e5m2, 1> x) {
   union HalfRawAccess {
     __half_raw raw;
@@ -602,41 +583,41 @@ NCCL_DEVICE_INLINE EltPack<half, 1> castPack(EltPack<__nv_fp8_e5m2, 1> x) {
   return out;
 }
 
-template<>
+template <>
 NCCL_DEVICE_INLINE EltPack<half, 2> castPack(EltPack<__nv_fp8_e5m2, 2> x) {
-  #if __CUDA_ARCH__ >= 900
-    union Half2RawAccess {
-      __half2_raw raw;
-      half2 val;
-    };
-    union Half2PackAccess {
-      EltPack<half, 2> pack;
-      half2 pair;
-    };
-    union Fp8E5m2Access2 {
-      EltPack<__nv_fp8_e5m2, 2> pack;
-      __nv_fp8x2_storage_t storage2;
-    };
-    Fp8E5m2Access2 in;
-    Half2PackAccess out;
-    in.pack = x;
-    Half2RawAccess h2;
-    h2.raw = __nv_cvt_fp8x2_to_halfraw2(in.storage2, __NV_E5M2);
-    out.pair = h2.val;
-    return out.pack;
-  #else
-    PackAccess<__nv_fp8_e5m2, 2> in;
-    PackAccess<half, 2> out;
-    in.pack = x;
-    out.lo = castPack<half>(in.lo);
-    out.hi = castPack<half>(in.hi);
-    return out.pack;
-  #endif
+#if __CUDA_ARCH__ >= 900
+  union Half2RawAccess {
+    __half2_raw raw;
+    half2 val;
+  };
+  union Half2PackAccess {
+    EltPack<half, 2> pack;
+    half2 pair;
+  };
+  union Fp8E5m2Access2 {
+    EltPack<__nv_fp8_e5m2, 2> pack;
+    __nv_fp8x2_storage_t storage2;
+  };
+  Fp8E5m2Access2 in;
+  Half2PackAccess out;
+  in.pack = x;
+  Half2RawAccess h2;
+  h2.raw = __nv_cvt_fp8x2_to_halfraw2(in.storage2, __NV_E5M2);
+  out.pair = h2.val;
+  return out.pack;
+#else
+  PackAccess<__nv_fp8_e5m2, 2> in;
+  PackAccess<half, 2> out;
+  in.pack = x;
+  out.lo = castPack<half>(in.lo);
+  out.hi = castPack<half>(in.hi);
+  return out.pack;
+#endif
 }
 
 // Specialization for half -> __nv_fp8_e4m3 conversion (downcast from accumulation type)
 // Uses vectorized half2 -> fp8x2 when available for SIMD performance
-template<>
+template <>
 NCCL_DEVICE_INLINE EltPack<__nv_fp8_e4m3, 1> castPack(EltPack<half, 1> x) {
   union HalfRawAccess {
     __half_raw raw;
@@ -653,41 +634,41 @@ NCCL_DEVICE_INLINE EltPack<__nv_fp8_e4m3, 1> castPack(EltPack<half, 1> x) {
   return out.pack;
 }
 
-template<>
+template <>
 NCCL_DEVICE_INLINE EltPack<__nv_fp8_e4m3, 2> castPack(EltPack<half, 2> x) {
-  #if __CUDA_ARCH__ >= 900
-    union Half2RawAccess {
-      __half2_raw raw;
-      half2 val;
-    };
-    union Half2PackAccess {
-      EltPack<half, 2> pack;
-      half2 pair;
-    };
-    Half2PackAccess in;
-    union Fp8E4m3Access2 {
-      EltPack<__nv_fp8_e4m3, 2> pack;
-      __nv_fp8x2_storage_t storage2;
-    };
-    Fp8E4m3Access2 out;
-    in.pack = x;
-    Half2RawAccess h2;
-    h2.val = in.pair;
-    out.storage2 = __nv_cvt_halfraw2_to_fp8x2(h2.raw, __NV_SATFINITE, __NV_E4M3);
-    return out.pack;
-  #else
-    PackAccess<half, 2> in;
-    PackAccess<__nv_fp8_e4m3, 2> out;
-    in.pack = x;
-    out.lo = castPack<__nv_fp8_e4m3>(in.lo);
-    out.hi = castPack<__nv_fp8_e4m3>(in.hi);
-    return out.pack;
-  #endif
+#if __CUDA_ARCH__ >= 900
+  union Half2RawAccess {
+    __half2_raw raw;
+    half2 val;
+  };
+  union Half2PackAccess {
+    EltPack<half, 2> pack;
+    half2 pair;
+  };
+  Half2PackAccess in;
+  union Fp8E4m3Access2 {
+    EltPack<__nv_fp8_e4m3, 2> pack;
+    __nv_fp8x2_storage_t storage2;
+  };
+  Fp8E4m3Access2 out;
+  in.pack = x;
+  Half2RawAccess h2;
+  h2.val = in.pair;
+  out.storage2 = __nv_cvt_halfraw2_to_fp8x2(h2.raw, __NV_SATFINITE, __NV_E4M3);
+  return out.pack;
+#else
+  PackAccess<half, 2> in;
+  PackAccess<__nv_fp8_e4m3, 2> out;
+  in.pack = x;
+  out.lo = castPack<__nv_fp8_e4m3>(in.lo);
+  out.hi = castPack<__nv_fp8_e4m3>(in.hi);
+  return out.pack;
+#endif
 }
 
 // Specialization for half -> __nv_fp8_e5m2 conversion (downcast from accumulation type)
 // Uses vectorized half2 -> fp8x2 when available for SIMD performance
-template<>
+template <>
 NCCL_DEVICE_INLINE EltPack<__nv_fp8_e5m2, 1> castPack(EltPack<half, 1> x) {
   union HalfRawAccess {
     __half_raw raw;
@@ -704,36 +685,36 @@ NCCL_DEVICE_INLINE EltPack<__nv_fp8_e5m2, 1> castPack(EltPack<half, 1> x) {
   return out.pack;
 }
 
-template<>
+template <>
 NCCL_DEVICE_INLINE EltPack<__nv_fp8_e5m2, 2> castPack(EltPack<half, 2> x) {
-  #if __CUDA_ARCH__ >= 900
-    union Half2RawAccess {
-      __half2_raw raw;
-      half2 val;
-    };
-    union Half2PackAccess {
-      EltPack<half, 2> pack;
-      half2 pair;
-    };
-    Half2PackAccess in;
-    union Fp8E5m2Access2 {
-      EltPack<__nv_fp8_e5m2, 2> pack;
-      __nv_fp8x2_storage_t storage2;
-    };
-    Fp8E5m2Access2 out;
-    in.pack = x;
-    Half2RawAccess h2;
-    h2.val = in.pair;
-    out.storage2 = __nv_cvt_halfraw2_to_fp8x2(h2.raw, __NV_SATFINITE, __NV_E5M2);
-    return out.pack;
-  #else
-    PackAccess<half, 2> in;
-    PackAccess<__nv_fp8_e5m2, 2> out;
-    in.pack = x;
-    out.lo = castPack<__nv_fp8_e5m2>(in.lo);
-    out.hi = castPack<__nv_fp8_e5m2>(in.hi);
-    return out.pack;
-  #endif
+#if __CUDA_ARCH__ >= 900
+  union Half2RawAccess {
+    __half2_raw raw;
+    half2 val;
+  };
+  union Half2PackAccess {
+    EltPack<half, 2> pack;
+    half2 pair;
+  };
+  Half2PackAccess in;
+  union Fp8E5m2Access2 {
+    EltPack<__nv_fp8_e5m2, 2> pack;
+    __nv_fp8x2_storage_t storage2;
+  };
+  Fp8E5m2Access2 out;
+  in.pack = x;
+  Half2RawAccess h2;
+  h2.val = in.pair;
+  out.storage2 = __nv_cvt_halfraw2_to_fp8x2(h2.raw, __NV_SATFINITE, __NV_E5M2);
+  return out.pack;
+#else
+  PackAccess<half, 2> in;
+  PackAccess<__nv_fp8_e5m2, 2> out;
+  in.pack = x;
+  out.lo = castPack<__nv_fp8_e5m2>(in.lo);
+  out.hi = castPack<__nv_fp8_e5m2>(in.hi);
+  return out.pack;
+#endif
 }
 
 #endif
@@ -745,7 +726,7 @@ NCCL_DEVICE_INLINE EltPack<__nv_fp8_e5m2, 2> castPack(EltPack<half, 2> x) {
 // Reduce pack using reduction operator
 // Works with EltPack types
 // Operator is taken by const reference.
-template<template<typename> typename Red, typename T, int n>
+template <template <typename> typename Red, typename T, int n>
 NCCL_DEVICE_INLINE EltPack<T, n> reducePack(Red<T> const& red, EltPack<T, n> a, EltPack<T, n> b) {
   static_assert((n & (n - 1)) == 0, "EltPack requires power-of-two element count");
 
@@ -764,7 +745,7 @@ NCCL_DEVICE_INLINE EltPack<T, n> reducePack(Red<T> const& red, EltPack<T, n> a, 
 }
 
 // Specialization for zero-sized packs
-template<template<typename> typename Red, typename T>
+template <template <typename> typename Red, typename T>
 NCCL_DEVICE_INLINE EltPack<T, 0> reducePack(Red<T> const& /* red */, EltPack<T, 0> /* a */, EltPack<T, 0> /* b */) {
   EltPack<T, 0> result{};
   return result;
@@ -773,8 +754,9 @@ NCCL_DEVICE_INLINE EltPack<T, 0> reducePack(Red<T> const& /* red */, EltPack<T, 
 // Specialization for int8_t with OpSum - uses __vadd4 SIMD intrinsic for performance
 // Processes EltPack<int8_t, 4> as unsigned int chunks
 // Note: __vadd4 is only valid for sum reduction, so this specialization is OpSum-specific
-template<>
-NCCL_DEVICE_INLINE EltPack<int8_t, 4> reducePack(OpSum<int8_t> const& /* red */, EltPack<int8_t, 4> a, EltPack<int8_t, 4> b) {
+template <>
+NCCL_DEVICE_INLINE EltPack<int8_t, 4> reducePack(OpSum<int8_t> const& /* red */, EltPack<int8_t, 4> a,
+                                                 EltPack<int8_t, 4> b) {
   union Int8PackAccess4 {
     EltPack<int8_t, 4> pack;
     unsigned int word;
@@ -789,8 +771,9 @@ NCCL_DEVICE_INLINE EltPack<int8_t, 4> reducePack(OpSum<int8_t> const& /* red */,
 }
 
 // Specialization for uint8_t with OpSum - reuses int8_t implementation via union access
-template<int n>
-NCCL_DEVICE_INLINE EltPack<uint8_t, n> reducePack(OpSum<uint8_t> const& red, EltPack<uint8_t, n> a, EltPack<uint8_t, n> b) {
+template <int n>
+NCCL_DEVICE_INLINE EltPack<uint8_t, n> reducePack(OpSum<uint8_t> const& red, EltPack<uint8_t, n> a,
+                                                  EltPack<uint8_t, n> b) {
   static_assert((n & (n - 1)) == 0, "EltPack<uint8_t, n> requires power-of-two element count");
   union PackU8 {
     EltPack<uint8_t, n> u;
@@ -808,53 +791,54 @@ NCCL_DEVICE_INLINE EltPack<uint8_t, n> reducePack(OpSum<uint8_t> const& red, Elt
 
 // Specialization for half with OpSum - uses __hadd2 SIMD intrinsic for performance
 // Architecture check: __CUDA_ARCH__ >= 530 && __CUDA_ARCH__ != 610
-template<>
+template <>
 NCCL_DEVICE_INLINE EltPack<half, 2> reducePack(OpSum<half> const& /* red */, EltPack<half, 2> a, EltPack<half, 2> b) {
-  #if __CUDA_ARCH__ >= 530 && __CUDA_ARCH__ != 610
-    union Half2PackAccess {
-      EltPack<half, 2> pack;
-      half2 pair;
-    };
-    Half2PackAccess aa;
-    Half2PackAccess bb;
-    Half2PackAccess out;
-    aa.pack = a;
-    bb.pack = b;
-    out.pair = __hadd2(aa.pair, bb.pair);
-    return out.pack;
-  #else
-    EltPack<half, 2> out{};
-    OpSum<half> red{};
-    out.elts()[0] = red(a.elts()[0], b.elts()[0]);
-    out.elts()[1] = red(a.elts()[1], b.elts()[1]);
-    return out;
-  #endif
+#if __CUDA_ARCH__ >= 530 && __CUDA_ARCH__ != 610
+  union Half2PackAccess {
+    EltPack<half, 2> pack;
+    half2 pair;
+  };
+  Half2PackAccess aa;
+  Half2PackAccess bb;
+  Half2PackAccess out;
+  aa.pack = a;
+  bb.pack = b;
+  out.pair = __hadd2(aa.pair, bb.pair);
+  return out.pack;
+#else
+  EltPack<half, 2> out{};
+  OpSum<half> red{};
+  out.elts()[0] = red(a.elts()[0], b.elts()[0]);
+  out.elts()[1] = red(a.elts()[1], b.elts()[1]);
+  return out;
+#endif
 }
 
 #if defined(__CUDA_BF16_TYPES_EXIST__)
 // Specialization for __nv_bfloat16 with OpSum - uses __hadd2 SIMD intrinsic
 // Architecture check: __CUDA_ARCH__ >= 530 && __CUDA_ARCH__ != 610
-template<>
-NCCL_DEVICE_INLINE EltPack<__nv_bfloat16, 2> reducePack(OpSum<__nv_bfloat16> const& /* red */, EltPack<__nv_bfloat16, 2> a, EltPack<__nv_bfloat16, 2> b) {
-  #if __CUDA_ARCH__ >= 530 && __CUDA_ARCH__ != 610
-    union Bf16PackAccess2 {
-      EltPack<__nv_bfloat16, 2> pack;
-      __nv_bfloat162 pair;
-    };
-    Bf16PackAccess2 aa;
-    Bf16PackAccess2 bb;
-    Bf16PackAccess2 out;
-    aa.pack = a;
-    bb.pack = b;
-    out.pair = __hadd2(aa.pair, bb.pair);
-    return out.pack;
-  #else
-    EltPack<__nv_bfloat16, 2> out{};
-    OpSum<__nv_bfloat16> red{};
-    out.elts()[0] = red(a.elts()[0], b.elts()[0]);
-    out.elts()[1] = red(a.elts()[1], b.elts()[1]);
-    return out;
-  #endif
+template <>
+NCCL_DEVICE_INLINE EltPack<__nv_bfloat16, 2> reducePack(OpSum<__nv_bfloat16> const& /* red */,
+                                                        EltPack<__nv_bfloat16, 2> a, EltPack<__nv_bfloat16, 2> b) {
+#if __CUDA_ARCH__ >= 530 && __CUDA_ARCH__ != 610
+  union Bf16PackAccess2 {
+    EltPack<__nv_bfloat16, 2> pack;
+    __nv_bfloat162 pair;
+  };
+  Bf16PackAccess2 aa;
+  Bf16PackAccess2 bb;
+  Bf16PackAccess2 out;
+  aa.pack = a;
+  bb.pack = b;
+  out.pair = __hadd2(aa.pair, bb.pair);
+  return out.pack;
+#else
+  EltPack<__nv_bfloat16, 2> out{};
+  OpSum<__nv_bfloat16> red{};
+  out.elts()[0] = red(a.elts()[0], b.elts()[0]);
+  out.elts()[1] = red(a.elts()[1], b.elts()[1]);
+  return out;
+#endif
 }
 #endif
 
@@ -864,4 +848,3 @@ NCCL_DEVICE_INLINE EltPack<__nv_bfloat16, 2> reducePack(OpSum<__nv_bfloat16> con
 #endif // NCCL_CHECK_CUDACC
 
 #endif // _NCCL_DEVICE_VECTOR__FUNCS_H_
-

--- a/projects/rccl/src/include/nccl_device/impl/vector__types.h
+++ b/projects/rccl/src/include/nccl_device/impl/vector__types.h
@@ -16,7 +16,8 @@
 // Forward declaration for sum reduction operator (defined in reduce_copy__types.h)
 namespace nccl {
 namespace utility {
-template<typename T> struct OpSum;
+template <typename T>
+struct OpSum;
 } // namespace utility
 } // namespace nccl
 
@@ -29,7 +30,7 @@ namespace utility {
 // EltPack<T, n>: Typed pack containing n elements of type T (T must be at least 1 byte).
 // Provides both typed element access and untyped byte access for load/store.
 
-template<typename T, int n>
+template <typename T, int n>
 struct EltPack {
   using EltType = T;  // Element type
   static constexpr int Count = n;  // Number of elements
@@ -39,12 +40,16 @@ struct EltPack {
   alignas(Alignment) char bytes[Bytes];
 
   // Element access via reinterpret_cast
-  NCCL_DEVICE_INLINE T* elts() { return reinterpret_cast<T*>(bytes); }
-  NCCL_DEVICE_INLINE const T* elts() const { return reinterpret_cast<const T*>(bytes); }
+  NCCL_DEVICE_INLINE T* elts() {
+    return reinterpret_cast<T*>(bytes);
+  }
+  NCCL_DEVICE_INLINE const T* elts() const {
+    return reinterpret_cast<const T*>(bytes);
+  }
 };
 
 // Specialization for zero-sized packs
-template<typename T>
+template <typename T>
 struct EltPack<T, 0> {
   using EltType = T;  // Element type
   static constexpr int Count = 0;
@@ -52,15 +57,17 @@ struct EltPack<T, 0> {
   static constexpr int Alignment = 1;
   static constexpr char* bytes = nullptr;
 
-  NCCL_DEVICE_INLINE T* elts() { return nullptr; }
-  NCCL_DEVICE_INLINE const T* elts() const { return nullptr; }
+  NCCL_DEVICE_INLINE T* elts() {
+    return nullptr;
+  }
+  NCCL_DEVICE_INLINE const T* elts() const {
+    return nullptr;
+  }
 };
-
-
 
 // Helper: Create EltPack for a given byte size
 // Computes the number of elements that fit in the specified byte size (element size >= 1 byte)
-template<typename T, int Bytes>
+template <typename T, int Bytes>
 using EltPackForBytes = EltPack<T, Bytes / static_cast<int>(sizeof(T))>;
 
 // ============================================================================
@@ -72,37 +79,37 @@ using EltPackForBytes = EltPack<T, Bytes / static_cast<int>(sizeof(T))>;
 // (e.g., min/max don't need wider types, but sum may benefit from wider types).
 
 // Primary template - extracts element type from reduction operator
-template<typename Red>
+template <typename Red>
 struct AccumulateType {
   using Type = typename Red::EltType;  // Default: use operator's element type
 };
 
 // Partial specialization for template template parameters (e.g., OpSum<T>)
 // For most operators, accumulation type equals element type
-template<template<typename> typename Red, typename T>
+template <template <typename> typename Red, typename T>
 struct AccumulateType<Red<T>> {
   using Type = T;  // Default: same type
 };
 
 // Specialize for sum operations that benefit from wider accumulation
-template<>
+template <>
 struct AccumulateType<OpSum<half>> {
   using Type = float;  // half accumulates into float for better precision
 };
 
 #if defined(__CUDA_BF16_TYPES_EXIST__)
-template<>
+template <>
 struct AccumulateType<OpSum<__nv_bfloat16>> {
   using Type = float;  // bfloat16 accumulates into float for better precision
 };
 #endif
 
 #if defined(__CUDA_FP8_TYPES_EXIST__)
-template<>
+template <>
 struct AccumulateType<OpSum<__nv_fp8_e4m3>> {
   using Type = half;  // fp8 accumulates into half precision (matches .acc::f16 in multimem)
 };
-template<>
+template <>
 struct AccumulateType<OpSum<__nv_fp8_e5m2>> {
   using Type = half;  // fp8 accumulates into half precision (matches .acc::f16 in multimem)
 };
@@ -126,18 +133,18 @@ struct MinMultimemType<half> {
 #if defined(__CUDA_BF16_TYPES_EXIST__)
 template <>
 struct MinMultimemType<__nv_bfloat16> {
-  using Type = EltPack<__nv_bfloat16, 2>;  // Minimum multimem type for bfloat16 is EltPack<__nv_bfloat16, 2> (32 bits)
+  using Type = EltPack<__nv_bfloat16, 2>; // Minimum multimem type for bfloat16 is EltPack<__nv_bfloat16, 2> (32 bits)
 };
 #endif
 
 #if defined(__CUDA_FP8_TYPES_EXIST__)
 template <>
 struct MinMultimemType<__nv_fp8_e4m3> {
-  using Type = EltPack<__nv_fp8_e4m3, 4>;  // Minimum multimem type for fp8_e4m3 is EltPack<__nv_fp8_e4m3, 4> (32 bits)
+  using Type = EltPack<__nv_fp8_e4m3, 4>; // Minimum multimem type for fp8_e4m3 is EltPack<__nv_fp8_e4m3, 4> (32 bits)
 };
 template <>
 struct MinMultimemType<__nv_fp8_e5m2> {
-  using Type = EltPack<__nv_fp8_e5m2, 4>;  // Minimum multimem type for fp8_e5m2 is EltPack<__nv_fp8_e5m2, 4> (32 bits)
+  using Type = EltPack<__nv_fp8_e5m2, 4>; // Minimum multimem type for fp8_e5m2 is EltPack<__nv_fp8_e5m2, 4> (32 bits)
 };
 #endif
 

--- a/projects/rccl/src/include/nccl_device/ll_a2a.h
+++ b/projects/rccl/src/include/nccl_device/ll_a2a.h
@@ -13,35 +13,37 @@ struct ncclLLA2AHandle;
 
 NCCL_EXTERN_C __host__ int ncclLLA2ACalcSlots(int maxElts, int maxEltSize);
 
-NCCL_EXTERN_C __host__ ncclResult_t ncclLLA2ACreateRequirement(int nBlocks, int nSlots, ncclLLA2AHandle_t* outHandle, ncclDevResourceRequirements_t* outReq);
+NCCL_EXTERN_C __host__ ncclResult_t ncclLLA2ACreateRequirement(int nBlocks, int nSlots, ncclLLA2AHandle_t* outHandle,
+                                                               ncclDevResourceRequirements_t* outReq);
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop>
+template <typename Coop>
 struct ncclLLA2ASession_internal;
 
-template<typename Coop>
-struct ncclLLA2ASession: ncclLLA2ASession_internal<Coop> {
-  NCCL_DEVICE_INLINE ncclLLA2ASession(Coop, ncclDevComm const&, ncclTeam, ncclLLA2AHandle, uint32_t block, int maxElts, bool multimem=false, ncclMultimemHandle mmHandle={});
+template <typename Coop>
+struct ncclLLA2ASession : ncclLLA2ASession_internal<Coop> {
+  NCCL_DEVICE_INLINE ncclLLA2ASession(Coop, ncclDevComm const&, ncclTeam, ncclLLA2AHandle, uint32_t block, int maxElts,
+                                      bool multimem = false, ncclMultimemHandle mmHandle = {});
 
   NCCL_DEVICE_INLINE ~ncclLLA2ASession();
 
   ncclLLA2ASession(ncclLLA2ASession const&) = delete; // Sessions are not copyable
 
-  template<typename T>
+  template <typename T>
   NCCL_DEVICE_INLINE void send(int peer, int slot, T data);
 
-  template<typename T>
+  template <typename T>
   NCCL_DEVICE_INLINE void bcast(int slot, T data);
 
-  template<typename T>
+  template <typename T>
   NCCL_DEVICE_INLINE T recv(int slot);
 
-  template<int MinEltCount, int MaxEltCount, typename T>
-  NCCL_DEVICE_INLINE void recvUnrolled(int eltStart, int eltCount, int eltStride, T(&vals)[MaxEltCount]);
+  template <int MinEltCount, int MaxEltCount, typename T>
+  NCCL_DEVICE_INLINE void recvUnrolled(int eltStart, int eltCount, int eltStride, T (&vals)[MaxEltCount]);
 
-  template<int Unroll, typename Elt, typename EltToAcc, typename Reduce>
+  template <int Unroll, typename Elt, typename EltToAcc, typename Reduce>
   NCCL_DEVICE_INLINE auto recvReduce(int eltStart, int eltCount, int eltStride, EltToAcc eltToAcc, Reduce red)
-    -> decltype(eltToAcc(nccl::utility::declval<Elt>())) ;
+    -> decltype(eltToAcc(nccl::utility::declval<Elt>()));
 
   // End an alltoall region. For every peer in team you must have done both of the
   // following each of which can be accomplished using any thread in coop:

--- a/projects/rccl/src/include/nccl_device/lsa_barrier.h
+++ b/projects/rccl/src/include/nccl_device/lsa_barrier.h
@@ -13,17 +13,20 @@
 
 struct ncclLsaBarrierHandle;
 
-NCCL_EXTERN_C __host__ ncclResult_t ncclLsaBarrierCreateRequirement(ncclTeam_t, int nBarriers, ncclLsaBarrierHandle_t* outHandle, ncclDevResourceRequirements_t* outReq);
+NCCL_EXTERN_C __host__ ncclResult_t ncclLsaBarrierCreateRequirement(
+  ncclTeam_t, int nBarriers, ncclLsaBarrierHandle_t* outHandle, ncclDevResourceRequirements_t* outReq);
 
 #if NCCL_CHECK_CUDACC
-template<typename Coop>
+template <typename Coop>
 struct ncclLsaBarrierSession_internal;
 
-template<typename Coop>
-struct ncclLsaBarrierSession: ncclLsaBarrierSession_internal<Coop> {
-  NCCL_DEVICE_INLINE ncclLsaBarrierSession(Coop, ncclDevComm const&, ncclTeam, ncclLsaBarrierHandle, uint32_t index, bool multimem=false, ncclMultimemHandle mmHandle={});
+template <typename Coop>
+struct ncclLsaBarrierSession : ncclLsaBarrierSession_internal<Coop> {
+  NCCL_DEVICE_INLINE ncclLsaBarrierSession(Coop, ncclDevComm const&, ncclTeam, ncclLsaBarrierHandle, uint32_t index,
+                                           bool multimem = false, ncclMultimemHandle mmHandle = {});
 
-  NCCL_DEVICE_INLINE ncclLsaBarrierSession(Coop, ncclDevComm const&, ncclTeamTagLsa, uint32_t index, bool multimem=false);
+  NCCL_DEVICE_INLINE ncclLsaBarrierSession(Coop, ncclDevComm const&, ncclTeamTagLsa, uint32_t index,
+                                           bool multimem = false);
 
   NCCL_DEVICE_INLINE ~ncclLsaBarrierSession();
 

--- a/projects/rccl/src/include/nccl_device/net_device.h
+++ b/projects/rccl/src/include/nccl_device/net_device.h
@@ -8,18 +8,18 @@
 #ifndef NCCL_NET_DEVICE_H_
 #define NCCL_NET_DEVICE_H_
 
-#define NCCL_NET_DEVICE_INVALID_VERSION      0x0
-#define NCCL_NET_MTU_SIZE                    4096
+#define NCCL_NET_DEVICE_INVALID_VERSION 0x0
+#define NCCL_NET_MTU_SIZE 4096
 
 // Arbitrary version number - A given NCCL build will only be compatible with a single device networking plugin
 // version. NCCL will check the supplied version number from net->getProperties() and compare to its internal version.
 #define NCCL_NET_DEVICE_UNPACK_VERSION 0x7
 
 typedef enum {
-  NCCL_NET_DEVICE_HOST=0,
-  NCCL_NET_DEVICE_UNPACK=1,
-  NCCL_NET_DEVICE_GIN_PROXY=2,
-  NCCL_NET_DEVICE_GIN_GDAKI=3,
+  NCCL_NET_DEVICE_HOST = 0,
+  NCCL_NET_DEVICE_UNPACK = 1,
+  NCCL_NET_DEVICE_GIN_PROXY = 2,
+  NCCL_NET_DEVICE_GIN_GDAKI = 3,
 } ncclNetDeviceType;
 
 typedef struct {

--- a/projects/rccl/src/include/nccl_device/ptr.h
+++ b/projects/rccl/src/include/nccl_device/ptr.h
@@ -11,15 +11,15 @@
 #include <stdint.h>
 
 #if __cplusplus
-template<typename T>
+template <typename T>
 struct ncclSymPtr {
   using ElementType = T;
   ncclWindow_t window;
   size_t offset;
 
-  NCCL_HOST_DEVICE_INLINE constexpr ncclSymPtr(ncclWindow_t window=nullptr, size_t offset=0);
+  NCCL_HOST_DEVICE_INLINE constexpr ncclSymPtr(ncclWindow_t window = nullptr, size_t offset = 0);
 
-  template<typename U>
+  template <typename U>
   NCCL_HOST_DEVICE_INLINE operator ncclSymPtr<U>() const;
 
   NCCL_HOST_DEVICE_INLINE ncclSymPtr<T>& operator+=(int d);
@@ -36,26 +36,26 @@ struct ncclSymPtr {
   NCCL_HOST_DEVICE_INLINE ncclSymPtr<T>& operator-=(long long d);
   NCCL_HOST_DEVICE_INLINE ncclSymPtr<T>& operator-=(unsigned long long d);
 
-  #if NCCL_CHECK_CUDACC
+#if NCCL_CHECK_CUDACC
   NCCL_DEVICE_INLINE T* localPtr() const;
   NCCL_DEVICE_INLINE T* lsaPtr(int peer) const;
   NCCL_DEVICE_INLINE T* peerPtr(int peer) const;
   NCCL_DEVICE_INLINE T* peerPtr(ncclTeam team, int peer) const;
   NCCL_DEVICE_INLINE T* multimemPtr(ncclMultimemHandle mmHandle) const;
   NCCL_DEVICE_INLINE T* lsaMultimemPtr(ncclDevComm const&) const;
-  #endif
+#endif
 };
 
-template<typename T, typename Int>
+template <typename T, typename Int>
 NCCL_HOST_DEVICE_INLINE ncclSymPtr<T> operator+(ncclSymPtr<T> p, Int d);
-template<typename T, typename Int>
+template <typename T, typename Int>
 NCCL_HOST_DEVICE_INLINE ncclSymPtr<T> operator-(ncclSymPtr<T> p, Int d);
-template<typename T>
+template <typename T>
 NCCL_HOST_DEVICE_INLINE ptrdiff_t operator-(ncclSymPtr<T> a, ncclSymPtr<T> b);
 
-template<typename T, typename Int>
+template <typename T, typename Int>
 NCCL_HOST_DEVICE_INLINE ncclSymPtr<T> operator==(ncclSymPtr<T> a, ncclSymPtr<T> b);
-template<typename T, typename Int>
+template <typename T, typename Int>
 NCCL_HOST_DEVICE_INLINE ncclSymPtr<T> operator!=(ncclSymPtr<T> a, ncclSymPtr<T> b);
 #endif
 

--- a/projects/rccl/src/include/nccl_device/rccl_ptr.h
+++ b/projects/rccl/src/include/nccl_device/rccl_ptr.h
@@ -27,8 +27,8 @@ THE SOFTWARE.
 // Defines a series of global address space pointers.  Casting to these
 // pointers in hot code paths should improve performance since global
 // aperture vector instrutions like global_store_dwordx4 can be used.
-// These are cheaper than flat loads and stores.  
-// Verify the intended effect by inspecting assembly.  If you see 
+// These are cheaper than flat loads and stores.
+// Verify the intended effect by inspecting assembly.  If you see
 // flat in the name of the emitted instruction, something is wrong.
 using u64_gptr = __attribute__((address_space(1))) uint64_t*;
 using u32_gptr = __attribute__((address_space(1))) uint32_t*;
@@ -36,12 +36,13 @@ using u16_gptr = __attribute__((address_space(1))) uint16_t*;
 using u8_gptr = __attribute__((address_space(1))) uint8_t*;
 
 #ifdef __HIP_DEVICE_COMPILE__
-#if (defined(__gfx942__) || defined(__gfx950__)) && __has_builtin(__builtin_amdgcn_global_load_b128) && __has_builtin(__builtin_amdgcn_global_store_b128) && !defined(DWORDX4_INTRINSICS_FORCE_OFF)
+#if (defined(__gfx942__) || defined(__gfx950__)) && __has_builtin(__builtin_amdgcn_global_load_b128) && \
+  __has_builtin(__builtin_amdgcn_global_store_b128) && !defined(DWORDX4_INTRINSICS_FORCE_OFF)
 #define RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS 1
-//#pragma message "RCCL DWORDX4 Builtins Enabled on GFX942/GFX950"
+// #pragma message "RCCL DWORDX4 Builtins Enabled on GFX942/GFX950"
 #else
 #define RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS 0
-//#pragma message "RCCL DWORDX4 Builtins Disabled on GFX942/GFX950"
+// #pragma message "RCCL DWORDX4 Builtins Disabled on GFX942/GFX950"
 #endif
 #else
 #define RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS 0

--- a/projects/rccl/src/include/nccl_device/reduce_copy.h
+++ b/projects/rccl/src/include/nccl_device/reduce_copy.h
@@ -15,159 +15,163 @@
 
 #if NCCL_CHECK_CUDACC
 // SERIES 1.x - Generic ReduceCopy with RedOp (LSA sources only)
-template<typename T, typename Coop, typename SrcLambda, typename DstLambda,
-         typename RedOp, typename IntCount, int UNROLL=4*16/sizeof(T)>
+template <typename T, typename Coop, typename SrcLambda, typename DstLambda, typename RedOp, typename IntCount,
+          int UNROLL = 4 * 16 / sizeof(T)>
 NCCL_DEVICE_INLINE void ncclLsaReduceLsaCopy(Coop, SrcLambda, int, DstLambda, int, RedOp const&, IntCount);
 
-template<typename T, typename Coop, typename SrcLambda, typename DstLambda,
-         typename RedOp, typename IntCount, int UNROLL=4*16/sizeof(T)>
+template <typename T, typename Coop, typename SrcLambda, typename DstLambda, typename RedOp, typename IntCount,
+          int UNROLL = 4 * 16 / sizeof(T)>
 NCCL_DEVICE_INLINE void ncclLsaReduceMultimemCopy(Coop, SrcLambda, int, DstLambda, int, RedOp const&, IntCount);
 
 // SERIES 2.x - Sum-Specific ReduceCopy (lambda-based foundation)
-template<typename T, typename Coop, typename SrcLambda, typename DstLambda,
-         typename IntCount, int UNROLL=4*16/sizeof(T)>
+template <typename T, typename Coop, typename SrcLambda, typename DstLambda, typename IntCount,
+          int UNROLL = 4 * 16 / sizeof(T)>
 NCCL_DEVICE_INLINE void ncclLsaReduceSumLsaCopy(Coop, SrcLambda, int, DstLambda, int, IntCount);
 
-template<typename T, typename Coop, typename SrcLambda, typename DstLambda,
-         typename IntCount, int UNROLL=4*16/sizeof(T)>
+template <typename T, typename Coop, typename SrcLambda, typename DstLambda, typename IntCount,
+          int UNROLL = 4 * 16 / sizeof(T)>
 NCCL_DEVICE_INLINE void ncclLsaReduceSumMultimemCopy(Coop, SrcLambda, int, DstLambda, int, IntCount);
 
-template<typename T, typename Coop, typename SrcLambda, typename DstLambda,
-         typename IntCount, int UNROLL=4*16/sizeof(T)>
+template <typename T, typename Coop, typename SrcLambda, typename DstLambda, typename IntCount,
+          int UNROLL = 4 * 16 / sizeof(T)>
 NCCL_DEVICE_INLINE void ncclMultimemReduceSumLsaCopy(Coop, SrcLambda, int, DstLambda, int, IntCount);
 
-template<typename T, typename Coop, typename SrcLambda, typename DstLambda,
-         typename IntCount, int UNROLL=4*16/sizeof(T)>
+template <typename T, typename Coop, typename SrcLambda, typename DstLambda, typename IntCount,
+          int UNROLL = 4 * 16 / sizeof(T)>
 NCCL_DEVICE_INLINE void ncclMultimemReduceSumMultimemCopy(Coop, SrcLambda, int, DstLambda, int, IntCount);
 
 // SERIES 3.x - ReduceSum (N->1)
-template<typename T, typename Coop, typename SrcLambda, typename IntCount, int UNROLL=4*16/sizeof(T)>
+template <typename T, typename Coop, typename SrcLambda, typename IntCount, int UNROLL = 4 * 16 / sizeof(T)>
 NCCL_DEVICE_INLINE void ncclLsaReduceSum(Coop, SrcLambda, int, T*, IntCount);
 
-template<typename T, typename Coop, typename IntCount, int UNROLL=4*16/sizeof(T)>
+template <typename T, typename Coop, typename IntCount, int UNROLL = 4 * 16 / sizeof(T)>
 NCCL_DEVICE_INLINE void ncclLsaReduceSum(Coop, ncclSymPtr<T>, T*, IntCount, ncclTeam);
 
-template<typename T, typename Coop, typename IntCount, int UNROLL=4*16/sizeof(T)>
+template <typename T, typename Coop, typename IntCount, int UNROLL = 4 * 16 / sizeof(T)>
 NCCL_DEVICE_INLINE void ncclLsaReduceSum(Coop, ncclSymPtr<T>, T*, IntCount, ncclDevComm_t);
 
-template<typename T, typename Coop, typename IntCount, int UNROLL=4*16/sizeof(T)>
+template <typename T, typename Coop, typename IntCount, int UNROLL = 4 * 16 / sizeof(T)>
 NCCL_DEVICE_INLINE void ncclLsaReduceSum(Coop, ncclWindow_t, size_t, T*, IntCount, ncclTeam);
 
-template<typename T, typename Coop, typename IntCount, int UNROLL=4*16/sizeof(T)>
+template <typename T, typename Coop, typename IntCount, int UNROLL = 4 * 16 / sizeof(T)>
 NCCL_DEVICE_INLINE void ncclLsaReduceSum(Coop, ncclWindow_t, size_t, T*, IntCount, ncclDevComm_t);
 
-template<typename T, typename Coop, typename IntCount, int UNROLL=4*16/sizeof(T)>
+template <typename T, typename Coop, typename IntCount, int UNROLL = 4 * 16 / sizeof(T)>
 NCCL_DEVICE_INLINE void ncclMultimemReduceSum(Coop, ncclSymPtr<T>, T*, IntCount, ncclMultimemHandle);
 
 // 3.3b] Multimem ReduceSum (with raw pointer)
-template<typename T, typename Coop, typename IntCount, int UNROLL=4*16/sizeof(T)>
+template <typename T, typename Coop, typename IntCount, int UNROLL = 4 * 16 / sizeof(T)>
 NCCL_DEVICE_INLINE void ncclMultimemReduceSum(Coop, T*, T*, IntCount);
 
-template<typename T, typename Coop, typename IntCount, int UNROLL=4*16/sizeof(T)>
+template <typename T, typename Coop, typename IntCount, int UNROLL = 4 * 16 / sizeof(T)>
 NCCL_DEVICE_INLINE void ncclMultimemReduceSum(Coop, ncclWindow_t, size_t, T*, IntCount, ncclMultimemHandle);
 
 // 3.4] Local ReduceSum (lambda-based)
-template<typename T, typename Coop, typename SrcLambda, typename IntCount, int UNROLL=4*16/sizeof(T)>
+template <typename T, typename Coop, typename SrcLambda, typename IntCount, int UNROLL = 4 * 16 / sizeof(T)>
 NCCL_DEVICE_INLINE void ncclLocalReduceSum(Coop, SrcLambda, int, T*, IntCount);
 
 // 3.5] Local ReduceSum (strided)
-template<typename T, typename Coop, typename IntCount, int UNROLL=4*16/sizeof(T)>
+template <typename T, typename Coop, typename IntCount, int UNROLL = 4 * 16 / sizeof(T)>
 NCCL_DEVICE_INLINE void ncclLocalReduceSum(Coop, int, T*, size_t, T*, IntCount);
 
 // SERIES 4.x - Copy/Broadcast (1->N)
 
 // 4.1] LSA Copy (lambda-based)
-template<typename T, typename Coop, typename DstLambda, typename IntCount, int UNROLL=4*16/sizeof(T)>
+template <typename T, typename Coop, typename DstLambda, typename IntCount, int UNROLL = 4 * 16 / sizeof(T)>
 NCCL_DEVICE_INLINE void ncclLsaCopy(Coop, T*, DstLambda, int, IntCount);
 
 // 4.2a] LSA Copy (with ncclSymPtr + team)
-template<typename T, typename Coop, typename IntCount, int UNROLL=4*16/sizeof(T)>
+template <typename T, typename Coop, typename IntCount, int UNROLL = 4 * 16 / sizeof(T)>
 NCCL_DEVICE_INLINE void ncclLsaCopy(Coop, T*, ncclSymPtr<T>, IntCount, ncclTeam);
 
 // 4.2b] LSA Copy (with ncclSymPtr + devComm)
-template<typename T, typename Coop, typename IntCount, int UNROLL=4*16/sizeof(T)>
+template <typename T, typename Coop, typename IntCount, int UNROLL = 4 * 16 / sizeof(T)>
 NCCL_DEVICE_INLINE void ncclLsaCopy(Coop, T*, ncclSymPtr<T>, IntCount, ncclDevComm_t);
 
 // 4.2c] LSA Copy (with window + offset + team)
-template<typename T, typename Coop, typename IntCount, int UNROLL=4*16/sizeof(T)>
+template <typename T, typename Coop, typename IntCount, int UNROLL = 4 * 16 / sizeof(T)>
 NCCL_DEVICE_INLINE void ncclLsaCopy(Coop, T*, ncclWindow_t, size_t, IntCount, ncclTeam);
 
 // 4.2d] LSA Copy (with window + offset + devComm)
-template<typename T, typename Coop, typename IntCount, int UNROLL=4*16/sizeof(T)>
+template <typename T, typename Coop, typename IntCount, int UNROLL = 4 * 16 / sizeof(T)>
 NCCL_DEVICE_INLINE void ncclLsaCopy(Coop, T*, ncclWindow_t, size_t, IntCount, ncclDevComm_t);
 
 // 4.3a] Multimem Copy (with ncclSymPtr)
-template<typename T, typename Coop, typename IntCount, int UNROLL=4*16/sizeof(T)>
+template <typename T, typename Coop, typename IntCount, int UNROLL = 4 * 16 / sizeof(T)>
 NCCL_DEVICE_INLINE void ncclMultimemCopy(Coop, T*, ncclSymPtr<T>, IntCount, ncclMultimemHandle);
 
 // 4.3b] Multimem Copy (with raw pointer)
-template<typename T, typename Coop, typename IntCount, int UNROLL=4*16/sizeof(T)>
+template <typename T, typename Coop, typename IntCount, int UNROLL = 4 * 16 / sizeof(T)>
 NCCL_DEVICE_INLINE void ncclMultimemCopy(Coop, T*, T*, IntCount);
 
 // 4.3c] Multimem Copy (with window + offset)
-template<typename T, typename Coop, typename IntCount, int UNROLL=4*16/sizeof(T)>
+template <typename T, typename Coop, typename IntCount, int UNROLL = 4 * 16 / sizeof(T)>
 NCCL_DEVICE_INLINE void ncclMultimemCopy(Coop, T*, ncclWindow_t, size_t, IntCount, ncclMultimemHandle);
 
 // 4.4] Local Copy (lambda-based)
-template<typename T, typename Coop, typename DstLambda, typename IntCount, int UNROLL=4*16/sizeof(T)>
+template <typename T, typename Coop, typename DstLambda, typename IntCount, int UNROLL = 4 * 16 / sizeof(T)>
 NCCL_DEVICE_INLINE void ncclLocalCopy(Coop, T*, DstLambda, int, IntCount);
 
 // 4.5] Local Copy (strided)
-template<typename T, typename Coop, typename IntCount, int UNROLL=4*16/sizeof(T)>
+template <typename T, typename Coop, typename IntCount, int UNROLL = 4 * 16 / sizeof(T)>
 NCCL_DEVICE_INLINE void ncclLocalCopy(Coop, T*, int, T*, size_t, IntCount);
 
 // SERIES 5.x - ReduceSumCopy (N->M)
 
 // 5.1a] LSA ReduceSumCopy (same team)
-template<typename T, typename Coop, typename IntCount, int UNROLL=4*16/sizeof(T)>
+template <typename T, typename Coop, typename IntCount, int UNROLL = 4 * 16 / sizeof(T)>
 NCCL_DEVICE_INLINE void ncclLsaReduceSumCopy(Coop, ncclSymPtr<T>, ncclSymPtr<T>, IntCount, ncclTeam);
 
 // 5.1b] LSA ReduceSumCopy (with devComm)
-template<typename T, typename Coop, typename IntCount, int UNROLL=4*16/sizeof(T)>
+template <typename T, typename Coop, typename IntCount, int UNROLL = 4 * 16 / sizeof(T)>
 NCCL_DEVICE_INLINE void ncclLsaReduceSumCopy(Coop, ncclSymPtr<T>, ncclSymPtr<T>, IntCount, ncclDevComm_t);
 
 // 5.1c] LSA ReduceSumCopy (with windows + team)
-template<typename T, typename Coop, typename IntCount, int UNROLL=4*16/sizeof(T)>
+template <typename T, typename Coop, typename IntCount, int UNROLL = 4 * 16 / sizeof(T)>
 NCCL_DEVICE_INLINE void ncclLsaReduceSumCopy(Coop, ncclWindow_t, size_t, ncclWindow_t, size_t, IntCount, ncclTeam);
 
 // 5.1d] LSA ReduceSumCopy (with windows + devComm)
-template<typename T, typename Coop, typename IntCount, int UNROLL=4*16/sizeof(T)>
+template <typename T, typename Coop, typename IntCount, int UNROLL = 4 * 16 / sizeof(T)>
 NCCL_DEVICE_INLINE void ncclLsaReduceSumCopy(Coop, ncclWindow_t, size_t, ncclWindow_t, size_t, IntCount, ncclDevComm_t);
 
 // 5.1e] LSA ReduceSumCopy (different teams)
-template<typename T, typename Coop, typename IntCount, int UNROLL=4*16/sizeof(T)>
+template <typename T, typename Coop, typename IntCount, int UNROLL = 4 * 16 / sizeof(T)>
 NCCL_DEVICE_INLINE void ncclLsaReduceSumCopy(Coop, ncclSymPtr<T>, ncclTeam, ncclSymPtr<T>, ncclTeam, IntCount);
 
 // 5.2a] Multimem ReduceSumCopy (with ncclSymPtr)
-template<typename T, typename Coop, typename IntCount, int UNROLL=4*16/sizeof(T)>
-NCCL_DEVICE_INLINE void ncclMultimemReduceSumCopy(Coop, ncclSymPtr<T>, ncclMultimemHandle, ncclSymPtr<T>, ncclMultimemHandle, IntCount);
+template <typename T, typename Coop, typename IntCount, int UNROLL = 4 * 16 / sizeof(T)>
+NCCL_DEVICE_INLINE void ncclMultimemReduceSumCopy(Coop, ncclSymPtr<T>, ncclMultimemHandle, ncclSymPtr<T>,
+                                                  ncclMultimemHandle, IntCount);
 
 // 5.2b] Multimem ReduceSumCopy (with raw pointers)
-template<typename T, typename Coop, typename IntCount, int UNROLL=4*16/sizeof(T)>
+template <typename T, typename Coop, typename IntCount, int UNROLL = 4 * 16 / sizeof(T)>
 NCCL_DEVICE_INLINE void ncclMultimemReduceSumCopy(Coop, T*, T*, IntCount);
 
 // 5.2c] Multimem ReduceSumCopy (with windows)
-template<typename T, typename Coop, typename IntCount, int UNROLL=4*16/sizeof(T)>
-NCCL_DEVICE_INLINE void ncclMultimemReduceSumCopy(Coop, ncclWindow_t, size_t, ncclMultimemHandle, ncclWindow_t, size_t, ncclMultimemHandle, IntCount);
+template <typename T, typename Coop, typename IntCount, int UNROLL = 4 * 16 / sizeof(T)>
+NCCL_DEVICE_INLINE void ncclMultimemReduceSumCopy(Coop, ncclWindow_t, size_t, ncclMultimemHandle, ncclWindow_t, size_t,
+                                                  ncclMultimemHandle, IntCount);
 
 // 5.3a] LSA -> Multimem ReduceSumCopy (with ncclSymPtr)
-template<typename T, typename Coop, typename IntCount, int UNROLL=4*16/sizeof(T)>
-NCCL_DEVICE_INLINE void ncclLsaReduceSumMultimemCopy(Coop, ncclSymPtr<T>, ncclTeam, ncclSymPtr<T>, ncclMultimemHandle, IntCount);
+template <typename T, typename Coop, typename IntCount, int UNROLL = 4 * 16 / sizeof(T)>
+NCCL_DEVICE_INLINE void ncclLsaReduceSumMultimemCopy(Coop, ncclSymPtr<T>, ncclTeam, ncclSymPtr<T>, ncclMultimemHandle,
+                                                     IntCount);
 
 // 5.3b] LSA -> Multimem ReduceSumCopy (with raw dst pointer)
-template<typename T, typename Coop, typename IntCount, int UNROLL=4*16/sizeof(T)>
+template <typename T, typename Coop, typename IntCount, int UNROLL = 4 * 16 / sizeof(T)>
 NCCL_DEVICE_INLINE void ncclLsaReduceSumMultimemCopy(Coop, ncclSymPtr<T>, ncclTeam, T*, IntCount);
 
 // 5.3c] Multimem -> LSA ReduceSumCopy (with ncclSymPtr)
-template<typename T, typename Coop, typename IntCount, int UNROLL=4*16/sizeof(T)>
-NCCL_DEVICE_INLINE void ncclMultimemReduceSumLsaCopy(Coop, ncclSymPtr<T>, ncclMultimemHandle, ncclSymPtr<T>, ncclTeam, IntCount);
+template <typename T, typename Coop, typename IntCount, int UNROLL = 4 * 16 / sizeof(T)>
+NCCL_DEVICE_INLINE void ncclMultimemReduceSumLsaCopy(Coop, ncclSymPtr<T>, ncclMultimemHandle, ncclSymPtr<T>, ncclTeam,
+                                                     IntCount);
 
 // 5.3d] Multimem -> LSA ReduceSumCopy (with raw src pointer)
-template<typename T, typename Coop, typename IntCount, int UNROLL=4*16/sizeof(T)>
+template <typename T, typename Coop, typename IntCount, int UNROLL = 4 * 16 / sizeof(T)>
 NCCL_DEVICE_INLINE void ncclMultimemReduceSumLsaCopy(Coop, T*, ncclSymPtr<T>, ncclTeam, IntCount);
 
 // 5.4] Local ReduceSumCopy (strided)
-template<typename T, typename Coop, typename IntCount, int UNROLL=4*16/sizeof(T)>
+template <typename T, typename Coop, typename IntCount, int UNROLL = 4 * 16 / sizeof(T)>
 NCCL_DEVICE_INLINE void ncclLocalReduceSumCopy(Coop, int, T*, size_t, int, T*, size_t, IntCount);
 
 #endif // NCCL_CHECK_CUDACC

--- a/projects/rccl/src/include/nccl_device/utility.h
+++ b/projects/rccl/src/include/nccl_device/utility.h
@@ -21,7 +21,7 @@
 // after that point and we'd compile references to types that were never
 // declared in this TU.
 #ifndef NCCL_CHECK_CUDACC
-    #define NCCL_CHECK_CUDACC __CUDACC__
+#define NCCL_CHECK_CUDACC __CUDACC__
 #endif
 
 // NCCL_DEVICE_INLINE / NCCL_HOST_DEVICE_INLINE are provided by hip_compat.h
@@ -29,13 +29,13 @@
 
 // Macro for conditional constexpr support
 #if defined(__cpp_if_constexpr) && __cpp_if_constexpr >= 201606
-  #ifndef NCCL_IF_CONSTEXPR
-    #define NCCL_IF_CONSTEXPR constexpr
-  #endif
+#ifndef NCCL_IF_CONSTEXPR
+#define NCCL_IF_CONSTEXPR constexpr
+#endif
 #else
-  #ifndef NCCL_IF_CONSTEXPR
-    #define NCCL_IF_CONSTEXPR
-  #endif
+#ifndef NCCL_IF_CONSTEXPR
+#define NCCL_IF_CONSTEXPR
+#endif
 #endif
 
 #if __cplusplus
@@ -45,9 +45,9 @@
 #endif
 
 #ifdef __clang_llvm_bitcode_lib__
-  #define NCCL_IR_EXTERN_C extern "C"
+#define NCCL_IR_EXTERN_C extern "C"
 #else
-  #define NCCL_IR_EXTERN_C
+#define NCCL_IR_EXTERN_C
 #endif
 
 #include <stdint.h>
@@ -86,16 +86,16 @@ static NCCL_DEVICE_INLINE bool testAbort(uint32_t* abortFlag, uint32_t& steps) {
   if (++steps < maxSteps) {
     return false;
   } else {
-    volatile uint32_t *ptr = (volatile uint32_t*)abortFlag;
+    volatile uint32_t* ptr = (volatile uint32_t*)abortFlag;
     steps = 0;
     return ptr != nullptr && *ptr != 0;
   }
 }
 #endif
 
-template<typename T>
+template <typename T>
 NCCL_HOST_DEVICE_INLINE T&& declval() noexcept {
-  static_assert(sizeof(T)!=sizeof(T), "You can't evaluate declval.");
+  static_assert(sizeof(T) != sizeof(T), "You can't evaluate declval.");
 }
 
 template <typename>
@@ -103,108 +103,112 @@ struct always_false {
   static constexpr bool value = false;
 };
 
-template<typename T, T value_>
-struct ValueAsType { static constexpr T value = value_; };
+template <typename T, T value_>
+struct ValueAsType {
+  static constexpr T value = value_;
+};
 
 // Returns the value zero but the compiler cannot prove that it is zero so it
 // is useful to inhibit compiler optimizations.
 #if NCCL_CHECK_CUDACC
-template<typename=void>
+template <typename = void>
 NCCL_DEVICE_INLINE int opaqueZero() {
   __device__ static int zero = 0;
   return __ldg(&zero);
 }
 #endif
 
-template<typename X, typename Y, typename Z = decltype(X()+Y())>
+template <typename X, typename Y, typename Z = decltype(X() + Y())>
 NCCL_HOST_DEVICE_INLINE constexpr Z divUp(X x, Y y) {
-  return (x+y-1)/y;
+  return (x + y - 1) / y;
 }
 
-template<typename X, typename Y, typename Z = decltype(X()+Y())>
+template <typename X, typename Y, typename Z = decltype(X() + Y())>
 NCCL_HOST_DEVICE_INLINE constexpr Z roundUp(X x, Y y) {
-  return (x+y-1) - (x+y-1)%y;
+  return (x + y - 1) - (x + y - 1) % y;
 }
-template<typename X, typename Y, typename Z = decltype(X()+Y())>
+template <typename X, typename Y, typename Z = decltype(X() + Y())>
 NCCL_HOST_DEVICE_INLINE constexpr Z roundDown(X x, Y y) {
-  return x - x%y;
+  return x - x % y;
 }
 
 // assumes second argument is a power of 2
-template<typename X, typename Y, typename Z = decltype(X()+Y())>
+template <typename X, typename Y, typename Z = decltype(X() + Y())>
 NCCL_HOST_DEVICE_INLINE constexpr Z alignUp(X x, Y a) {
-  return (x + a-1) & -Z(a);
+  return (x + a - 1) & -Z(a);
 }
-template<typename T>
+template <typename T>
 NCCL_HOST_DEVICE_INLINE T* alignUp(T* x, size_t a) {
   static_assert(sizeof(T) == 1, "Only single byte types allowed.");
-  return reinterpret_cast<T*>((reinterpret_cast<uintptr_t>(x) + a-1) & -uintptr_t(a));
+  return reinterpret_cast<T*>((reinterpret_cast<uintptr_t>(x) + a - 1) & -uintptr_t(a));
 }
-template<typename T>
+template <typename T>
 NCCL_HOST_DEVICE_INLINE void* alignUp(void const* x, size_t a) {
-  return reinterpret_cast<void*>((reinterpret_cast<uintptr_t>(x) + a-1) & -uintptr_t(a));
+  return reinterpret_cast<void*>((reinterpret_cast<uintptr_t>(x) + a - 1) & -uintptr_t(a));
 }
 
 // assumes second argument is a power of 2
-template<typename X, typename Y, typename Z = decltype(X()+int())>
+template <typename X, typename Y, typename Z = decltype(X() + int())>
 NCCL_HOST_DEVICE_INLINE constexpr Z alignDown(X x, Y a) {
   return x & -Z(a);
 }
-template<typename T>
+template <typename T>
 NCCL_HOST_DEVICE_INLINE T* alignDown(T* x, size_t a) {
   static_assert(sizeof(T) == 1, "Only single byte types allowed.");
   return reinterpret_cast<T*>(reinterpret_cast<uintptr_t>(x) & -uintptr_t(a));
 }
-template<typename T>
+template <typename T>
 NCCL_HOST_DEVICE_INLINE void* alignDown(void const* x, size_t a) {
   return reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(x) & -uintptr_t(a));
 }
 
-template<typename T>
+template <typename T>
 NCCL_HOST_DEVICE_INLINE T add4G(T base, int delta4G) {
-  union { uint32_t u32[2]; T tmp; };
+  union {
+    uint32_t u32[2];
+    T tmp;
+  };
   tmp = base;
   u32[1] += delta4G;
   return tmp;
 }
 
-
-template<typename Int>
+template <typename Int>
 NCCL_HOST_DEVICE_INLINE constexpr bool isPow2(Int x) {
-  return (x & (x-1)) == 0;
+  return (x & (x - 1)) == 0;
 }
 
-template<typename Uint>
-NCCL_HOST_DEVICE_INLINE bool rollingLessEq(Uint a, Uint b, int nBits = 8*sizeof(Uint)) {
+template <typename Uint>
+NCCL_HOST_DEVICE_INLINE bool rollingLessEq(Uint a, Uint b, int nBits = 8 * sizeof(Uint)) {
   static_assert(Uint(0) < Uint(-1), "Uint must be unsigned.");
-  Uint m = Uint(-1) >> (8*sizeof(Uint) - nBits);
-  return ((b-a) & m) <= m>>1;
+  Uint m = Uint(-1) >> (8 * sizeof(Uint) - nBits);
+  return ((b - a) & m) <= m >> 1;
 }
-template<typename Uint>
-NCCL_HOST_DEVICE_INLINE bool rollingLessThan(Uint a, Uint b, int nBits = 8*sizeof(Uint)) {
+template <typename Uint>
+NCCL_HOST_DEVICE_INLINE bool rollingLessThan(Uint a, Uint b, int nBits = 8 * sizeof(Uint)) {
   return !rollingLessEq(b, a, nBits);
 }
 
 // Produce the reciprocal of x for use in idivByRcp
 NCCL_HOST_DEVICE_INLINE constexpr uint32_t idivRcp32(uint32_t x) {
-  return uint32_t(-1)/x + isPow2(x);
+  return uint32_t(-1) / x + isPow2(x);
 }
 NCCL_HOST_DEVICE_INLINE constexpr uint64_t idivRcp64(uint64_t x) {
-  return uint64_t(-1)/x + isPow2(x);
+  return uint64_t(-1) / x + isPow2(x);
 }
 
 NCCL_HOST_DEVICE_INLINE uint32_t mul32hi(uint32_t a, uint32_t b) {
 #if NCCL_DEVICE_ARCH
   return nccl_umulhi(a, b);
 #else
-  return uint64_t(a)*b >> 32;
+  return uint64_t(a) * b >> 32;
 #endif
 }
 NCCL_HOST_DEVICE_INLINE uint64_t mul64hi(uint64_t a, uint64_t b) {
 #if NCCL_DEVICE_ARCH
   return nccl_umul64hi(a, b);
 #else
-  return (uint64_t)(((unsigned __int128)a)*b >> 64);
+  return (uint64_t)(((unsigned __int128)a) * b >> 64);
 #endif
 }
 
@@ -214,32 +218,38 @@ NCCL_HOST_DEVICE_INLINE uint32_t imulRcp32(uint32_t x, uint32_t xrcp, uint32_t y
   if (xrcp == 0) return yrcp;
   if (yrcp == 0) return xrcp;
   uint32_t rcp = mul32hi(xrcp, yrcp);
-  uint32_t rem = 0u - x*y*rcp;
-  if (x*y <= rem) rcp += 1;
+  uint32_t rem = 0u - x * y * rcp;
+  if (x * y <= rem) rcp += 1;
   return rcp;
 }
 NCCL_HOST_DEVICE_INLINE uint64_t imulRcp64(uint64_t x, uint64_t xrcp, uint64_t y, uint64_t yrcp) {
   if (xrcp == 0) return yrcp;
   if (yrcp == 0) return xrcp;
   uint64_t rcp = mul64hi(xrcp, yrcp);
-  uint64_t rem = 0ULL - x*y*rcp;
-  if (x*y <= rem) rcp += 1;
+  uint64_t rem = 0ULL - x * y * rcp;
+  if (x * y <= rem) rcp += 1;
   return rcp;
 }
 
 // Fast unsigned integer division where divisor has precomputed reciprocal.
 // idivFast(x, y, idivRcp(y)) == x/y
-NCCL_HOST_DEVICE_INLINE void idivmodFast32(uint32_t *quo, uint32_t *rem, uint32_t x, uint32_t y, uint32_t yrcp) {
+NCCL_HOST_DEVICE_INLINE void idivmodFast32(uint32_t* quo, uint32_t* rem, uint32_t x, uint32_t y, uint32_t yrcp) {
   uint32_t q = yrcp == 0 ? x : mul32hi(x, yrcp);
-  uint32_t r = x - y*q;
-  if (r >= y) { q += 1; r -= y; }
+  uint32_t r = x - y * q;
+  if (r >= y) {
+    q += 1;
+    r -= y;
+  }
   *quo = q;
   *rem = r;
 }
-NCCL_HOST_DEVICE_INLINE void idivmodFast64(uint64_t *quo, uint64_t *rem, uint64_t x, uint64_t y, uint64_t yrcp) {
+NCCL_HOST_DEVICE_INLINE void idivmodFast64(uint64_t* quo, uint64_t* rem, uint64_t x, uint64_t y, uint64_t yrcp) {
   uint64_t q = yrcp == 0 ? x : mul64hi(x, yrcp);
-  uint64_t r = x - y*q;
-  if (r >= y) { q += 1; r -= y; }
+  uint64_t r = x - y * q;
+  if (r >= y) {
+    q += 1;
+    r -= y;
+  }
   *quo = q;
   *rem = r;
 }
@@ -271,23 +281,17 @@ NCCL_HOST_DEVICE_INLINE uint64_t imodFast64(uint64_t x, uint64_t y, uint64_t yrc
 // Pass these to idivFast64() for fast division on the GPU.
 NCCL_DEVICE_INLINE uint64_t idivRcp64_upto64(int x) {
   static constexpr uint64_t table[65] = {
-    idivRcp64(0x01), idivRcp64(0x01), idivRcp64(0x02), idivRcp64(0x03),
-    idivRcp64(0x04), idivRcp64(0x05), idivRcp64(0x06), idivRcp64(0x07),
-    idivRcp64(0x08), idivRcp64(0x09), idivRcp64(0x0a), idivRcp64(0x0b),
-    idivRcp64(0x0c), idivRcp64(0x0d), idivRcp64(0x0e), idivRcp64(0x0f),
-    idivRcp64(0x10), idivRcp64(0x11), idivRcp64(0x12), idivRcp64(0x13),
-    idivRcp64(0x14), idivRcp64(0x15), idivRcp64(0x16), idivRcp64(0x17),
-    idivRcp64(0x18), idivRcp64(0x19), idivRcp64(0x1a), idivRcp64(0x1b),
-    idivRcp64(0x1c), idivRcp64(0x1d), idivRcp64(0x1e), idivRcp64(0x1f),
-    idivRcp64(0x20), idivRcp64(0x21), idivRcp64(0x22), idivRcp64(0x23),
-    idivRcp64(0x24), idivRcp64(0x25), idivRcp64(0x26), idivRcp64(0x27),
-    idivRcp64(0x28), idivRcp64(0x29), idivRcp64(0x2a), idivRcp64(0x2b),
-    idivRcp64(0x2c), idivRcp64(0x2d), idivRcp64(0x2e), idivRcp64(0x2f),
-    idivRcp64(0x30), idivRcp64(0x31), idivRcp64(0x32), idivRcp64(0x33),
-    idivRcp64(0x34), idivRcp64(0x35), idivRcp64(0x36), idivRcp64(0x37),
-    idivRcp64(0x38), idivRcp64(0x39), idivRcp64(0x3a), idivRcp64(0x3b),
-    idivRcp64(0x3c), idivRcp64(0x3d), idivRcp64(0x3e), idivRcp64(0x3f),
-    idivRcp64(0x40)
+    idivRcp64(0x01), idivRcp64(0x01), idivRcp64(0x02), idivRcp64(0x03), idivRcp64(0x04), idivRcp64(0x05),
+    idivRcp64(0x06), idivRcp64(0x07), idivRcp64(0x08), idivRcp64(0x09), idivRcp64(0x0a), idivRcp64(0x0b),
+    idivRcp64(0x0c), idivRcp64(0x0d), idivRcp64(0x0e), idivRcp64(0x0f), idivRcp64(0x10), idivRcp64(0x11),
+    idivRcp64(0x12), idivRcp64(0x13), idivRcp64(0x14), idivRcp64(0x15), idivRcp64(0x16), idivRcp64(0x17),
+    idivRcp64(0x18), idivRcp64(0x19), idivRcp64(0x1a), idivRcp64(0x1b), idivRcp64(0x1c), idivRcp64(0x1d),
+    idivRcp64(0x1e), idivRcp64(0x1f), idivRcp64(0x20), idivRcp64(0x21), idivRcp64(0x22), idivRcp64(0x23),
+    idivRcp64(0x24), idivRcp64(0x25), idivRcp64(0x26), idivRcp64(0x27), idivRcp64(0x28), idivRcp64(0x29),
+    idivRcp64(0x2a), idivRcp64(0x2b), idivRcp64(0x2c), idivRcp64(0x2d), idivRcp64(0x2e), idivRcp64(0x2f),
+    idivRcp64(0x30), idivRcp64(0x31), idivRcp64(0x32), idivRcp64(0x33), idivRcp64(0x34), idivRcp64(0x35),
+    idivRcp64(0x36), idivRcp64(0x37), idivRcp64(0x38), idivRcp64(0x39), idivRcp64(0x3a), idivRcp64(0x3b),
+    idivRcp64(0x3c), idivRcp64(0x3d), idivRcp64(0x3e), idivRcp64(0x3f), idivRcp64(0x40)
   };
   return table[x];
 }
@@ -295,7 +299,7 @@ NCCL_DEVICE_INLINE uint64_t idivRcp64_upto64(int x) {
 
 #if NCCL_DEVICE_COMPILE
 NCCL_DEVICE_INLINE uint32_t idivRcp32_upto64(int x) {
-  return idivRcp64_upto64(x)>>32;
+  return idivRcp64_upto64(x) >> 32;
 }
 #endif
 
@@ -304,56 +308,68 @@ NCCL_DEVICE_INLINE uint32_t idivRcp32_upto64(int x) {
 NCCL_HOST_DEVICE_INLINE constexpr std::memory_order acquireOrderOf(std::memory_order ord) {
   return ord == std::memory_order_release ? std::memory_order_relaxed :
          ord == std::memory_order_acq_rel ? std::memory_order_acquire :
-         ord;
+                                            ord;
 }
 
 NCCL_HOST_DEVICE_INLINE constexpr std::memory_order releaseOrderOf(std::memory_order ord) {
   return ord == std::memory_order_acquire ? std::memory_order_relaxed :
          ord == std::memory_order_acq_rel ? std::memory_order_release :
-         ord;
+                                            ord;
 }
 NCCL_HOST_DEVICE_INLINE constexpr int toAtomicBuiltinOrder(std::memory_order ord) {
   switch (ord) {
-    case std::memory_order_relaxed: return __ATOMIC_RELAXED;
-    case std::memory_order_acquire: return __ATOMIC_ACQUIRE;
-    case std::memory_order_release: return __ATOMIC_RELEASE;
-    case std::memory_order_acq_rel: return __ATOMIC_ACQ_REL;
-    case std::memory_order_seq_cst: return __ATOMIC_SEQ_CST;
-    default: return __ATOMIC_SEQ_CST;
+  case std::memory_order_relaxed:
+    return __ATOMIC_RELAXED;
+  case std::memory_order_acquire:
+    return __ATOMIC_ACQUIRE;
+  case std::memory_order_release:
+    return __ATOMIC_RELEASE;
+  case std::memory_order_acq_rel:
+    return __ATOMIC_ACQ_REL;
+  case std::memory_order_seq_cst:
+    return __ATOMIC_SEQ_CST;
+  default:
+    return __ATOMIC_SEQ_CST;
   }
 }
 
 NCCL_HOST_DEVICE_INLINE constexpr cuda::memory_order acquireOrderOf(cuda::memory_order ord) {
   return ord == cuda::memory_order_release ? cuda::memory_order_relaxed :
          ord == cuda::memory_order_acq_rel ? cuda::memory_order_acquire :
-         ord;
+                                             ord;
 }
 NCCL_HOST_DEVICE_INLINE constexpr cuda::memory_order releaseOrderOf(cuda::memory_order ord) {
   return ord == cuda::memory_order_acquire ? cuda::memory_order_relaxed :
          ord == cuda::memory_order_acq_rel ? cuda::memory_order_release :
-         ord;
+                                             ord;
 }
 
 NCCL_HOST_DEVICE_INLINE constexpr cuda::memory_order toCudaOrder(std::memory_order ord) {
   switch (ord) {
-    case std::memory_order_relaxed: return cuda::memory_order_relaxed;
-    case std::memory_order_acquire: return cuda::memory_order_acquire;
-    case std::memory_order_release: return cuda::memory_order_release;
-    case std::memory_order_acq_rel: return cuda::memory_order_acq_rel;
-    case std::memory_order_seq_cst: return cuda::memory_order_seq_cst;
-    default: return cuda::memory_order_seq_cst;
+  case std::memory_order_relaxed:
+    return cuda::memory_order_relaxed;
+  case std::memory_order_acquire:
+    return cuda::memory_order_acquire;
+  case std::memory_order_release:
+    return cuda::memory_order_release;
+  case std::memory_order_acq_rel:
+    return cuda::memory_order_acq_rel;
+  case std::memory_order_seq_cst:
+    return cuda::memory_order_seq_cst;
+  default:
+    return cuda::memory_order_seq_cst;
   }
 }
 #else
 NCCL_HOST_DEVICE_INLINE constexpr cuda::memory_order acquireOrderOf(cuda::memory_order ord) {
   return ord == cuda::memory_order_release ? cuda::memory_order_relaxed :
          ord == cuda::memory_order_acq_rel ? cuda::memory_order_acquire :
-         ord;
+                                             ord;
 }
 NCCL_HOST_DEVICE_INLINE constexpr cuda::memory_order releaseOrderOf(cuda::memory_order ord) {
   return ord == cuda::memory_order_acquire ? cuda::memory_order_relaxed :
          ord == cuda::memory_order_acq_rel ? cuda::memory_order_release :
-         ord;
+                                             ord;
 }
 #endif
 #endif
@@ -380,7 +396,7 @@ NCCL_DEVICE_INLINE void fenceReleaseGpu() {
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename T>
+template <typename T>
 NCCL_DEVICE_INLINE T atomicLoad(T* ptr, cuda::memory_order ord, cuda::thread_scope scope) {
   switch (scope) {
   case cuda::thread_scope_thread:
@@ -391,13 +407,14 @@ NCCL_DEVICE_INLINE T atomicLoad(T* ptr, cuda::memory_order ord, cuda::thread_sco
     return cuda::atomic_ref<T, cuda::thread_scope_device>{*ptr}.load(ord);
   case cuda::thread_scope_system:
     return cuda::atomic_ref<T, cuda::thread_scope_system>{*ptr}.load(ord);
-  default: __builtin_unreachable();
+  default:
+    __builtin_unreachable();
   }
 }
 #endif
 
 #if NCCL_CHECK_CUDACC
-template<typename T>
+template <typename T>
 NCCL_DEVICE_INLINE void atomicStore(T* ptr, T val, cuda::memory_order ord, cuda::thread_scope scope) {
   switch (scope) {
   case cuda::thread_scope_thread:
@@ -412,7 +429,8 @@ NCCL_DEVICE_INLINE void atomicStore(T* ptr, T val, cuda::memory_order ord, cuda:
   case cuda::thread_scope_system:
     cuda::atomic_ref<T, cuda::thread_scope_system>{*ptr}.store(val, ord);
     break;
-  default: __builtin_unreachable();
+  default:
+    __builtin_unreachable();
   }
 }
 #endif
@@ -428,27 +446,42 @@ NCCL_DEVICE_INLINE unsigned int lanemask_lt() {
 
 #if NCCL_DEVICE_COMPILE
 // Load anything, but cache like its constant memory.
-template<typename T>
-NCCL_DEVICE_INLINE T loadConst(T const *p) {
+template <typename T>
+NCCL_DEVICE_INLINE T loadConst(T const* p) {
   if (alignof(T) == 1) {
-    union { uint8_t part[sizeof(T)]; T ret; };
-    for (int i=0; i < (int)sizeof(T); i++) part[i] = nccl_ldg((uint8_t const*)p + i);
+    union {
+      uint8_t part[sizeof(T)];
+      T ret;
+    };
+    for (int i = 0; i < (int)sizeof(T); i++) part[i] = nccl_ldg((uint8_t const*)p + i);
     return ret;
   } else if (alignof(T) == 2) {
-    union { uint16_t part[sizeof(T)/2]; T ret; };
-    for (int i=0; i < (int)sizeof(T)/2; i++) part[i] = nccl_ldg((uint16_t const*)p + i);
+    union {
+      uint16_t part[sizeof(T) / 2];
+      T ret;
+    };
+    for (int i = 0; i < (int)sizeof(T) / 2; i++) part[i] = nccl_ldg((uint16_t const*)p + i);
     return ret;
   } else if (alignof(T) == 4) {
-    union { uint32_t part[sizeof(T)/4]; T ret; };
-    for (int i=0; i < (int)sizeof(T)/4; i++) part[i] = nccl_ldg((uint32_t const*)p + i);
+    union {
+      uint32_t part[sizeof(T) / 4];
+      T ret;
+    };
+    for (int i = 0; i < (int)sizeof(T) / 4; i++) part[i] = nccl_ldg((uint32_t const*)p + i);
     return ret;
   } else if (alignof(T) == 8) {
-    union { uint64_t part[sizeof(T)/8]; T ret; };
-    for (int i=0; i < (int)sizeof(T)/8; i++) part[i] = nccl_ldg((uint64_t const*)p + i);
+    union {
+      uint64_t part[sizeof(T) / 8];
+      T ret;
+    };
+    for (int i = 0; i < (int)sizeof(T) / 8; i++) part[i] = nccl_ldg((uint64_t const*)p + i);
     return ret;
   } else { // alignof(T) >= 16
-    union { ulonglong2 part[sizeof(T)/16]; T ret; };
-    for (int i=0; i < (int)sizeof(T)/16; i++) part[i] = nccl_ldg((ulonglong2 const*)p + i);
+    union {
+      ulonglong2 part[sizeof(T) / 16];
+      T ret;
+    };
+    for (int i = 0; i < (int)sizeof(T) / 16; i++) part[i] = nccl_ldg((ulonglong2 const*)p + i);
     return ret;
   }
 }
@@ -460,72 +493,74 @@ NCCL_DEVICE_INLINE T loadConst(T const *p) {
 // T::T(Arg...) constructor. An Optional constructed with a Absent will not
 // have its T constructed.
 
-template<int ...vals>
+template <int... vals>
 struct IntSeq {};
 
-template<int n, int m, int ...i>
-struct IntSeqUpTo: IntSeqUpTo<n, m+1, i..., m> {};
-template<int n, int ...i>
-struct IntSeqUpTo<n, n, i...> { using Type = IntSeq<i...>; };
+template <int n, int m, int... i>
+struct IntSeqUpTo : IntSeqUpTo<n, m + 1, i..., m> {};
+template <int n, int... i>
+struct IntSeqUpTo<n, n, i...> {
+  using Type = IntSeq<i...>;
+};
 
 // Present<Arg...>: Packs a list of arguments together to be passed to Optional<T>.
-template<typename ...Arg>
+template <typename... Arg>
 struct Present;
-template<>
+template <>
 struct Present<> {};
-template<typename H, typename ...T>
+template <typename H, typename... T>
 struct Present<H, T...> {
   H h;
   Present<T...> t;
 
-  NCCL_HOST_DEVICE_INLINE Present(H h, Present<T...> t): h(static_cast<H>(h)), t(t) {}
-  NCCL_HOST_DEVICE_INLINE Present(Present const& that): h(static_cast<H>(that.h)), t(that.t) {}
+  NCCL_HOST_DEVICE_INLINE Present(H h, Present<T...> t) : h(static_cast<H>(h)), t(t) {}
+  NCCL_HOST_DEVICE_INLINE Present(Present const& that) : h(static_cast<H>(that.h)), t(that.t) {}
 
   NCCL_HOST_DEVICE_INLINE H get(IntSeq<0>) {
     return static_cast<H>(h);
   }
-  template<int i>
+  template <int i>
   NCCL_HOST_DEVICE_INLINE decltype(auto) get(IntSeq<i>) {
-    return t.get(IntSeq<i-1>{});
+    return t.get(IntSeq<i - 1>{});
   }
 };
 
 NCCL_HOST_DEVICE_INLINE Present<> present() {
   return Present<>{};
 }
-template<typename H, typename ...T>
-NCCL_HOST_DEVICE_INLINE Present<H&&, T&&...> present(H&& h, T&& ...t) {
+template <typename H, typename... T>
+NCCL_HOST_DEVICE_INLINE Present<H&&, T&&...> present(H&& h, T&&... t) {
   return Present<H&&, T&&...>{static_cast<H&&>(h), present(static_cast<T&&>(t)...)};
 }
 
 struct Absent {};
 
-template<typename T>
+template <typename T>
 struct Optional {
   bool present; // Is `thing` constructed.
-  union { T thing; };
+  union {
+    T thing;
+  };
 
   // Construct with absent thing:
-  NCCL_HOST_DEVICE_INLINE constexpr Optional(): present(false) {}
-  NCCL_HOST_DEVICE_INLINE constexpr Optional(Absent): present(false) {}
+  NCCL_HOST_DEVICE_INLINE constexpr Optional() : present(false) {}
+  NCCL_HOST_DEVICE_INLINE constexpr Optional(Absent) : present(false) {}
 
   // Helper constructor
-  template<typename ...Arg, int ...i>
-  NCCL_HOST_DEVICE_INLINE Optional(Present<Arg...> args, IntSeq<i...>):
-    present(true),
-    thing{args.get(IntSeq<i>())...} {
-  }
+  template <typename... Arg, int... i>
+  NCCL_HOST_DEVICE_INLINE Optional(Present<Arg...> args, IntSeq<i...>)
+    : present(true), thing{args.get(IntSeq<i>())...} {}
   // Construct with present thing:
-  template<typename ...Arg>
-  NCCL_HOST_DEVICE_INLINE Optional(Present<Arg...> args):
-    Optional(args, typename IntSeqUpTo<sizeof...(Arg), 0>::Type()) {
-  }
+  template <typename... Arg>
+  NCCL_HOST_DEVICE_INLINE Optional(Present<Arg...> args)
+    : Optional(args, typename IntSeqUpTo<sizeof...(Arg), 0>::Type()) {}
 
   NCCL_HOST_DEVICE_INLINE ~Optional() {
     if (present) thing.~T();
   }
 };
 
-}}
+} // namespace utility
+} // namespace nccl
 #endif // __cplusplus
 #endif

--- a/projects/rccl/src/include/net.h
+++ b/projects/rccl/src/include/net.h
@@ -39,31 +39,31 @@ extern ncclNet_t netIbCast;
 extern ncclResult_t rcclCastNetP2pPolicy(void* handle, int isP2p);
 
 enum rcclIBNicType {
-    rcclIBNicTypeUnknown = -1,
-    rcclIBNicTypeDefault = 0,
-    rcclIBNicTypeMLX = 1,
-    rcclIBNicTypeAINIC = 2,
-    rcclIBNicTypeBNXT2 = 3,
-    rcclIBNicTypeMax = 4
+  rcclIBNicTypeUnknown = -1,
+  rcclIBNicTypeDefault = 0,
+  rcclIBNicTypeMLX = 1,
+  rcclIBNicTypeAINIC = 2,
+  rcclIBNicTypeBNXT2 = 3,
+  rcclIBNicTypeMax = 4
 };
 
 struct rcclIBNicInfo {
-    rcclIBNicType type;
-    int rate;
-    int count;
+  rcclIBNicType type;
+  int rate;
+  int count;
 };
 
 /**
-  * @brief Get the primary NIC info
-  * 
-  * @return rcclIBNicInfo (type, rate, count)
-  */
+ * @brief Get the primary NIC info
+ *
+ * @return rcclIBNicInfo (type, rate, count)
+ */
 extern rcclIBNicInfo rcclPrimaryNic();
 /**
-  * @brief Check if the primary NIC is AINIC
-  * 
-  * @return bool
-  */
+ * @brief Check if the primary NIC is AINIC
+ *
+ * @return bool
+ */
 extern bool rcclUseAinic();
 #endif
 

--- a/projects/rccl/src/include/nvmlwrap.h
+++ b/projects/rccl/src/include/nvmlwrap.h
@@ -10,7 +10,7 @@
 
 #include "nccl.h"
 
-//#define NCCL_NVML_DIRECT 1
+// #define NCCL_NVML_DIRECT 1
 #ifndef NCCL_NVML_DIRECT
 #define NCCL_NVML_DIRECT 0
 #endif
@@ -22,125 +22,116 @@
 
 /* Extracted from nvml.h */
 
-#define NVML_API_VERSION            12
+#define NVML_API_VERSION 12
 
-#define NVML_STRUCT_VERSION(data, ver) (unsigned int)(sizeof(nvml ## data ## _v ## ver ## _t) | \
-                                                      (ver << 24U))
+#define NVML_STRUCT_VERSION(data, ver) (unsigned int)(sizeof(nvml##data##_v##ver##_t) | (ver << 24U))
 
 typedef struct nvmlDevice_st* nvmlDevice_t;
-#define NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE   32
+#define NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE 32
 
-typedef enum nvmlEnableState_enum
-{
-    NVML_FEATURE_DISABLED    = 0,     //!< Feature disabled
-    NVML_FEATURE_ENABLED     = 1      //!< Feature enabled
+typedef enum nvmlEnableState_enum {
+  NVML_FEATURE_DISABLED = 0,     //!< Feature disabled
+  NVML_FEATURE_ENABLED = 1      //!< Feature enabled
 } nvmlEnableState_t;
 
-typedef enum nvmlNvLinkCapability_enum
-{
-    NVML_NVLINK_CAP_P2P_SUPPORTED = 0,     // P2P over NVLink is supported
-    NVML_NVLINK_CAP_SYSMEM_ACCESS = 1,     // Access to system memory is supported
-    NVML_NVLINK_CAP_P2P_ATOMICS   = 2,     // P2P atomics are supported
-    NVML_NVLINK_CAP_SYSMEM_ATOMICS= 3,     // System memory atomics are supported
-    NVML_NVLINK_CAP_SLI_BRIDGE    = 4,     // SLI is supported over this link
-    NVML_NVLINK_CAP_VALID         = 5,     // Link is supported on this device
+typedef enum nvmlNvLinkCapability_enum {
+  NVML_NVLINK_CAP_P2P_SUPPORTED = 0,     // P2P over NVLink is supported
+  NVML_NVLINK_CAP_SYSMEM_ACCESS = 1,     // Access to system memory is supported
+  NVML_NVLINK_CAP_P2P_ATOMICS = 2,     // P2P atomics are supported
+  NVML_NVLINK_CAP_SYSMEM_ATOMICS = 3,     // System memory atomics are supported
+  NVML_NVLINK_CAP_SLI_BRIDGE = 4,     // SLI is supported over this link
+  NVML_NVLINK_CAP_VALID = 5,     // Link is supported on this device
     // should be last
-    NVML_NVLINK_CAP_COUNT
+  NVML_NVLINK_CAP_COUNT
 } nvmlNvLinkCapability_t;
 
-typedef enum nvmlReturn_enum
-{
-    NVML_SUCCESS = 0,                   //!< The operation was successful
-    NVML_ERROR_UNINITIALIZED = 1,       //!< NVML was not first initialized with nvmlInit()
-    NVML_ERROR_INVALID_ARGUMENT = 2,    //!< A supplied argument is invalid
-    NVML_ERROR_NOT_SUPPORTED = 3,       //!< The requested operation is not available on target device
-    NVML_ERROR_NO_PERMISSION = 4,       //!< The current user does not have permission for operation
-    NVML_ERROR_ALREADY_INITIALIZED = 5, //!< Deprecated: Multiple initializations are now allowed through ref counting
-    NVML_ERROR_NOT_FOUND = 6,           //!< A query to find an object was unsuccessful
-    NVML_ERROR_INSUFFICIENT_SIZE = 7,   //!< An input argument is not large enough
-    NVML_ERROR_INSUFFICIENT_POWER = 8,  //!< A device's external power cables are not properly attached
-    NVML_ERROR_DRIVER_NOT_LOADED = 9,   //!< NVIDIA driver is not loaded
-    NVML_ERROR_TIMEOUT = 10,            //!< User provided timeout passed
-    NVML_ERROR_IRQ_ISSUE = 11,          //!< NVIDIA Kernel detected an interrupt issue with a GPU
-    NVML_ERROR_LIBRARY_NOT_FOUND = 12,  //!< NVML Shared Library couldn't be found or loaded
-    NVML_ERROR_FUNCTION_NOT_FOUND = 13, //!< Local version of NVML doesn't implement this function
-    NVML_ERROR_CORRUPTED_INFOROM = 14,  //!< infoROM is corrupted
-    NVML_ERROR_GPU_IS_LOST = 15,        //!< The GPU has fallen off the bus or has otherwise become inaccessible
-    NVML_ERROR_RESET_REQUIRED = 16,     //!< The GPU requires a reset before it can be used again
-    NVML_ERROR_OPERATING_SYSTEM = 17,   //!< The GPU control device has been blocked by the operating system/cgroups
-    NVML_ERROR_LIB_RM_VERSION_MISMATCH = 18,   //!< RM detects a driver/library version mismatch
-    NVML_ERROR_IN_USE = 19,             //!< An operation cannot be performed because the GPU is currently in use
-    NVML_ERROR_UNKNOWN = 999            //!< An internal driver error occurred
+typedef enum nvmlReturn_enum {
+  NVML_SUCCESS = 0,                   //!< The operation was successful
+  NVML_ERROR_UNINITIALIZED = 1,       //!< NVML was not first initialized with nvmlInit()
+  NVML_ERROR_INVALID_ARGUMENT = 2,    //!< A supplied argument is invalid
+  NVML_ERROR_NOT_SUPPORTED = 3,       //!< The requested operation is not available on target device
+  NVML_ERROR_NO_PERMISSION = 4,       //!< The current user does not have permission for operation
+  NVML_ERROR_ALREADY_INITIALIZED = 5, //!< Deprecated: Multiple initializations are now allowed through ref counting
+  NVML_ERROR_NOT_FOUND = 6,           //!< A query to find an object was unsuccessful
+  NVML_ERROR_INSUFFICIENT_SIZE = 7,   //!< An input argument is not large enough
+  NVML_ERROR_INSUFFICIENT_POWER = 8,  //!< A device's external power cables are not properly attached
+  NVML_ERROR_DRIVER_NOT_LOADED = 9,   //!< NVIDIA driver is not loaded
+  NVML_ERROR_TIMEOUT = 10,            //!< User provided timeout passed
+  NVML_ERROR_IRQ_ISSUE = 11,          //!< NVIDIA Kernel detected an interrupt issue with a GPU
+  NVML_ERROR_LIBRARY_NOT_FOUND = 12,  //!< NVML Shared Library couldn't be found or loaded
+  NVML_ERROR_FUNCTION_NOT_FOUND = 13, //!< Local version of NVML doesn't implement this function
+  NVML_ERROR_CORRUPTED_INFOROM = 14,  //!< infoROM is corrupted
+  NVML_ERROR_GPU_IS_LOST = 15,        //!< The GPU has fallen off the bus or has otherwise become inaccessible
+  NVML_ERROR_RESET_REQUIRED = 16,     //!< The GPU requires a reset before it can be used again
+  NVML_ERROR_OPERATING_SYSTEM = 17,   //!< The GPU control device has been blocked by the operating system/cgroups
+  NVML_ERROR_LIB_RM_VERSION_MISMATCH = 18,   //!< RM detects a driver/library version mismatch
+  NVML_ERROR_IN_USE = 19,             //!< An operation cannot be performed because the GPU is currently in use
+  NVML_ERROR_UNKNOWN = 999            //!< An internal driver error occurred
 } nvmlReturn_t;
 
-typedef struct nvmlPciInfo_st
-{
-    char busId[NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE]; //!< The tuple domain:bus:device.function PCI identifier (&amp; NULL terminator)
-    unsigned int domain;             //!< The PCI domain on which the device's bus resides, 0 to 0xffff
-    unsigned int bus;                //!< The bus on which the device resides, 0 to 0xff
-    unsigned int device;             //!< The device's id on the bus, 0 to 31
-    unsigned int pciDeviceId;        //!< The combined 16-bit device id and 16-bit vendor id
+typedef struct nvmlPciInfo_st {
+  char busId
+    [NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE]; //!< The tuple domain:bus:device.function PCI identifier (&amp; NULL terminator)
+  unsigned int domain; //!< The PCI domain on which the device's bus resides, 0 to 0xffff
+  unsigned int bus; //!< The bus on which the device resides, 0 to 0xff
+  unsigned int device; //!< The device's id on the bus, 0 to 31
+  unsigned int pciDeviceId; //!< The combined 16-bit device id and 16-bit vendor id
 
-    // Added in NVML 2.285 API
-    unsigned int pciSubSystemId;     //!< The 32-bit Sub System Device ID
+  // Added in NVML 2.285 API
+  unsigned int pciSubSystemId; //!< The 32-bit Sub System Device ID
 
-    // NVIDIA reserved for internal use only
-    unsigned int reserved0;
-    unsigned int reserved1;
-    unsigned int reserved2;
-    unsigned int reserved3;
+  // NVIDIA reserved for internal use only
+  unsigned int reserved0;
+  unsigned int reserved1;
+  unsigned int reserved2;
+  unsigned int reserved3;
 } nvmlPciInfo_t;
 
 /* P2P Capability Index Status*/
-typedef enum nvmlGpuP2PStatus_enum
-{
-    NVML_P2P_STATUS_OK     = 0,
-    NVML_P2P_STATUS_CHIPSET_NOT_SUPPORED,
-    NVML_P2P_STATUS_GPU_NOT_SUPPORTED,
-    NVML_P2P_STATUS_IOH_TOPOLOGY_NOT_SUPPORTED,
-    NVML_P2P_STATUS_DISABLED_BY_REGKEY,
-    NVML_P2P_STATUS_NOT_SUPPORTED,
-    NVML_P2P_STATUS_UNKNOWN
+typedef enum nvmlGpuP2PStatus_enum {
+  NVML_P2P_STATUS_OK = 0,
+  NVML_P2P_STATUS_CHIPSET_NOT_SUPPORED,
+  NVML_P2P_STATUS_GPU_NOT_SUPPORTED,
+  NVML_P2P_STATUS_IOH_TOPOLOGY_NOT_SUPPORTED,
+  NVML_P2P_STATUS_DISABLED_BY_REGKEY,
+  NVML_P2P_STATUS_NOT_SUPPORTED,
+  NVML_P2P_STATUS_UNKNOWN
 } nvmlGpuP2PStatus_t;
 
 /* P2P Capability Index*/
-typedef enum nvmlGpuP2PCapsIndex_enum
-{
-    NVML_P2P_CAPS_INDEX_READ = 0,
-    NVML_P2P_CAPS_INDEX_WRITE,
-    NVML_P2P_CAPS_INDEX_NVLINK,
-    NVML_P2P_CAPS_INDEX_ATOMICS,
-    NVML_P2P_CAPS_INDEX_PROP,
-    NVML_P2P_CAPS_INDEX_UNKNOWN
+typedef enum nvmlGpuP2PCapsIndex_enum {
+  NVML_P2P_CAPS_INDEX_READ = 0,
+  NVML_P2P_CAPS_INDEX_WRITE,
+  NVML_P2P_CAPS_INDEX_NVLINK,
+  NVML_P2P_CAPS_INDEX_ATOMICS,
+  NVML_P2P_CAPS_INDEX_PROP,
+  NVML_P2P_CAPS_INDEX_UNKNOWN
 } nvmlGpuP2PCapsIndex_t;
 
 /**
  * Represents the type for sample value returned
  */
-typedef enum nvmlValueType_enum
-{
-    NVML_VALUE_TYPE_DOUBLE = 0,
-    NVML_VALUE_TYPE_UNSIGNED_INT = 1,
-    NVML_VALUE_TYPE_UNSIGNED_LONG = 2,
-    NVML_VALUE_TYPE_UNSIGNED_LONG_LONG = 3,
-    NVML_VALUE_TYPE_SIGNED_LONG_LONG = 4,
+typedef enum nvmlValueType_enum {
+  NVML_VALUE_TYPE_DOUBLE = 0,
+  NVML_VALUE_TYPE_UNSIGNED_INT = 1,
+  NVML_VALUE_TYPE_UNSIGNED_LONG = 2,
+  NVML_VALUE_TYPE_UNSIGNED_LONG_LONG = 3,
+  NVML_VALUE_TYPE_SIGNED_LONG_LONG = 4,
 
-    // Keep this last
-    NVML_VALUE_TYPE_COUNT
-}nvmlValueType_t;
-
+  // Keep this last
+  NVML_VALUE_TYPE_COUNT
+} nvmlValueType_t;
 
 /**
  * Union to represent different types of Value
  */
-typedef union nvmlValue_st
-{
-    double dVal;                    //!< If the value is double
-    unsigned int uiVal;             //!< If the value is unsigned int
-    unsigned long ulVal;            //!< If the value is unsigned long
-    unsigned long long ullVal;      //!< If the value is unsigned long long
-    signed long long sllVal;        //!< If the value is signed long long
-}nvmlValue_t;
+typedef union nvmlValue_st {
+  double dVal; //!< If the value is double
+  unsigned int uiVal; //!< If the value is unsigned int
+  unsigned long ulVal; //!< If the value is unsigned long
+  unsigned long long ullVal; //!< If the value is unsigned long long
+  signed long long sllVal; //!< If the value is signed long long
+} nvmlValue_t;
 
 /**
  * Field Identifiers.
@@ -150,64 +141,66 @@ typedef union nvmlValue_st
 
 /* NVLink Speed */
 #define NVML_FI_DEV_NVLINK_SPEED_MBPS_COMMON 90  //!< Common NVLink Speed in MBps for active links
-#define NVML_FI_DEV_NVLINK_LINK_COUNT        91  //!< Number of NVLinks present on the device
+#define NVML_FI_DEV_NVLINK_LINK_COUNT 91  //!< Number of NVLinks present on the device
 
 /**
  * Remote device NVLink ID
  *
  * Link ID needs to be specified in the scopeId field in nvmlFieldValue_t.
  */
-#define NVML_FI_DEV_NVLINK_REMOTE_NVLINK_ID     146 //!< Remote device NVLink ID
+#define NVML_FI_DEV_NVLINK_REMOTE_NVLINK_ID 146 //!< Remote device NVLink ID
 
 /**
  * NVSwitch: connected NVLink count
  */
-#define NVML_FI_DEV_NVSWITCH_CONNECTED_LINK_COUNT   147  //!< Number of NVLinks connected to NVSwitch
+#define NVML_FI_DEV_NVSWITCH_CONNECTED_LINK_COUNT 147  //!< Number of NVLinks connected to NVSwitch
 
-#define NVML_FI_DEV_NVLINK_GET_SPEED                  164
-#define NVML_FI_DEV_NVLINK_GET_STATE                  165
-#define NVML_FI_DEV_NVLINK_GET_VERSION                166
+#define NVML_FI_DEV_NVLINK_GET_SPEED 164
+#define NVML_FI_DEV_NVLINK_GET_STATE 165
+#define NVML_FI_DEV_NVLINK_GET_VERSION 166
 
-#define NVML_FI_DEV_C2C_LINK_COUNT                    170 //!< Number of C2C Links present on the device
-#define NVML_FI_DEV_C2C_LINK_GET_STATUS               171 //!< C2C Link Status 0=INACTIVE 1=ACTIVE
-#define NVML_FI_DEV_C2C_LINK_GET_MAX_BW               172 //!< C2C Link Speed in MBps for active links
+#define NVML_FI_DEV_C2C_LINK_COUNT 170 //!< Number of C2C Links present on the device
+#define NVML_FI_DEV_C2C_LINK_GET_STATUS 171 //!< C2C Link Status 0=INACTIVE 1=ACTIVE
+#define NVML_FI_DEV_C2C_LINK_GET_MAX_BW 172 //!< C2C Link Speed in MBps for active links
 
 #define NVML_FI_MAX 173 //!< One greater than the largest field ID defined above
 
 /**
  * Information for a Field Value Sample
  */
-typedef struct nvmlFieldValue_st
-{
-    unsigned int fieldId;       //!< ID of the NVML field to retrieve. This must be set before any call that uses this struct. See the constants starting with NVML_FI_ above.
-    unsigned int scopeId;       //!< Scope ID can represent data used by NVML depending on fieldId's context. For example, for NVLink throughput counter data, scopeId can represent linkId.
-    long long timestamp;        //!< CPU Timestamp of this value in microseconds since 1970
-    long long latencyUsec;      //!< How long this field value took to update (in usec) within NVML. This may be averaged across several fields that are serviced by the same driver call.
-    nvmlValueType_t valueType;  //!< Type of the value stored in value
-    nvmlReturn_t nvmlReturn;    //!< Return code for retrieving this value. This must be checked before looking at value, as value is undefined if nvmlReturn != NVML_SUCCESS
-    nvmlValue_t value;          //!< Value for this field. This is only valid if nvmlReturn == NVML_SUCCESS
+typedef struct nvmlFieldValue_st {
+  unsigned int
+    fieldId; //!< ID of the NVML field to retrieve. This must be set before any call that uses this struct. See the constants starting with NVML_FI_ above.
+  unsigned int
+    scopeId; //!< Scope ID can represent data used by NVML depending on fieldId's context. For example, for NVLink throughput counter data, scopeId can represent linkId.
+  long long timestamp; //!< CPU Timestamp of this value in microseconds since 1970
+  long long
+    latencyUsec; //!< How long this field value took to update (in usec) within NVML. This may be averaged across several fields that are serviced by the same driver call.
+  nvmlValueType_t valueType; //!< Type of the value stored in value
+  nvmlReturn_t
+    nvmlReturn; //!< Return code for retrieving this value. This must be checked before looking at value, as value is undefined if nvmlReturn != NVML_SUCCESS
+  nvmlValue_t value; //!< Value for this field. This is only valid if nvmlReturn == NVML_SUCCESS
 } nvmlFieldValue_t;
-
 
 #define NVML_GPU_FABRIC_UUID_LEN 16
 
 #define NVML_GPU_FABRIC_STATE_NOT_SUPPORTED 0
-#define NVML_GPU_FABRIC_STATE_NOT_STARTED   1
-#define NVML_GPU_FABRIC_STATE_IN_PROGRESS   2
-#define NVML_GPU_FABRIC_STATE_COMPLETED     3
+#define NVML_GPU_FABRIC_STATE_NOT_STARTED 1
+#define NVML_GPU_FABRIC_STATE_IN_PROGRESS 2
+#define NVML_GPU_FABRIC_STATE_COMPLETED 3
 
 typedef unsigned char nvmlGpuFabricState_t;
 
 typedef struct {
-    unsigned char        clusterUuid[NVML_GPU_FABRIC_UUID_LEN]; //!< Uuid of the cluster to which this GPU belongs
-    nvmlReturn_t         status;                                //!< Error status, if any. Must be checked only if state returns "complete".
-    unsigned int         cliqueId;                              //!< ID of the fabric clique to which this GPU belongs
-    nvmlGpuFabricState_t state;                                 //!< Current state of GPU registration process
+  unsigned char clusterUuid[NVML_GPU_FABRIC_UUID_LEN]; //!< Uuid of the cluster to which this GPU belongs
+  nvmlReturn_t status; //!< Error status, if any. Must be checked only if state returns "complete".
+  unsigned int cliqueId; //!< ID of the fabric clique to which this GPU belongs
+  nvmlGpuFabricState_t state; //!< Current state of GPU registration process
 } nvmlGpuFabricInfo_t;
 
 #define NVML_GPU_FABRIC_HEALTH_MASK_DEGRADED_BW_NOT_SUPPORTED 0
-#define NVML_GPU_FABRIC_HEALTH_MASK_DEGRADED_BW_TRUE          1
-#define NVML_GPU_FABRIC_HEALTH_MASK_DEGRADED_BW_FALSE         2
+#define NVML_GPU_FABRIC_HEALTH_MASK_DEGRADED_BW_TRUE 1
+#define NVML_GPU_FABRIC_HEALTH_MASK_DEGRADED_BW_FALSE 2
 
 #define NVML_GPU_FABRIC_HEALTH_MASK_SHIFT_DEGRADED_BW 0
 #define NVML_GPU_FABRIC_HEALTH_MASK_WIDTH_DEGRADED_BW 0x11
@@ -217,9 +210,8 @@ typedef struct {
  * using the below macro.
  * Ex - NVML_GPU_FABRIC_HEALTH_GET(var, _DEGRADED_BW)
  */
-#define NVML_GPU_FABRIC_HEALTH_GET(var, type)             \
-    (((var) >> NVML_GPU_FABRIC_HEALTH_MASK_SHIFT##type) & \
-     (NVML_GPU_FABRIC_HEALTH_MASK_WIDTH##type))
+#define NVML_GPU_FABRIC_HEALTH_GET(var, type) \
+  (((var) >> NVML_GPU_FABRIC_HEALTH_MASK_SHIFT##type) & (NVML_GPU_FABRIC_HEALTH_MASK_WIDTH##type))
 
 /**
  * GPU Fabric Health Status Mask for various fields can be tested
@@ -227,46 +219,47 @@ typedef struct {
  * Ex - NVML_GPU_FABRIC_HEALTH_TEST(var, _DEGRADED_BW, _TRUE)
  */
 #define NVML_GPU_FABRIC_HEALTH_TEST(var, type, val) \
-    (NVML_GPU_FABRIC_HEALTH_GET(var, type) ==       \
-     NVML_GPU_FABRIC_HEALTH_MASK##type##val)
+  (NVML_GPU_FABRIC_HEALTH_GET(var, type) == NVML_GPU_FABRIC_HEALTH_MASK##type##val)
 
 /**
-* GPU Fabric information (v2).
-*
-* Version 2 adds the \ref nvmlGpuFabricInfo_v2_t.version field
-* to the start of the structure, and the \ref nvmlGpuFabricInfo_v2_t.healthMask
-* field to the end. This structure is not backwards-compatible with
-* \ref nvmlGpuFabricInfo_t.
-*/
+ * GPU Fabric information (v2).
+ *
+ * Version 2 adds the \ref nvmlGpuFabricInfo_v2_t.version field
+ * to the start of the structure, and the \ref nvmlGpuFabricInfo_v2_t.healthMask
+ * field to the end. This structure is not backwards-compatible with
+ * \ref nvmlGpuFabricInfo_t.
+ */
 typedef struct {
-    unsigned int         version;                               //!< Structure version identifier (set to \ref nvmlGpuFabricInfo_v2)
-    unsigned char        clusterUuid[NVML_GPU_FABRIC_UUID_LEN]; //!< Uuid of the cluster to which this GPU belongs
-    nvmlReturn_t         status;                                //!< Error status, if any. Must be checked only if state returns "complete".
-    unsigned int         cliqueId;                              //!< ID of the fabric clique to which this GPU belongs
-    nvmlGpuFabricState_t state;                                 //!< Current state of GPU registration process
-    unsigned int         healthMask;                            //!< GPU Fabric health Status Mask
+  unsigned int version; //!< Structure version identifier (set to \ref nvmlGpuFabricInfo_v2)
+  unsigned char clusterUuid[NVML_GPU_FABRIC_UUID_LEN]; //!< Uuid of the cluster to which this GPU belongs
+  nvmlReturn_t status; //!< Error status, if any. Must be checked only if state returns "complete".
+  unsigned int cliqueId; //!< ID of the fabric clique to which this GPU belongs
+  nvmlGpuFabricState_t state; //!< Current state of GPU registration process
+  unsigned int healthMask; //!< GPU Fabric health Status Mask
 } nvmlGpuFabricInfo_v2_t;
 
 typedef nvmlGpuFabricInfo_v2_t nvmlGpuFabricInfoV_t;
 
 /**
-* Version identifier value for \ref nvmlGpuFabricInfo_v2_t.version.
-*/
+ * Version identifier value for \ref nvmlGpuFabricInfo_v2_t.version.
+ */
 #define nvmlGpuFabricInfo_v2 NVML_STRUCT_VERSION(GpuFabricInfo, 2)
 
 /**
  * Structure to store platform information (v2)
  */
-typedef struct
-{
-    unsigned int version;                       //!< the API version number
-    unsigned char ibGuid[16];                   //!< Infiniband GUID reported by platform (for Blackwell, ibGuid is 8 bytes so indices 8-15 are zero)
-    unsigned char chassisSerialNumber[16];      //!< Serial number of the chassis containing this GPU (for Blackwell it is 13 bytes so indices 13-15 are zero)
-    unsigned char slotNumber;                   //!< The slot number in the chassis containing this GPU (includes switches)
-    unsigned char trayIndex;                    //!< The tray index within the compute slots in the chassis containing this GPU (does not include switches)
-    unsigned char hostId;                       //!< Index of the node within the slot containing this GPU
-    unsigned char peerType;                     //!< Platform indicated NVLink-peer type (e.g. switch present or not)
-    unsigned char moduleId;                     //!< ID of this GPU within the node
+typedef struct {
+  unsigned int version; //!< the API version number
+  unsigned char
+    ibGuid[16]; //!< Infiniband GUID reported by platform (for Blackwell, ibGuid is 8 bytes so indices 8-15 are zero)
+  unsigned char chassisSerialNumber
+    [16]; //!< Serial number of the chassis containing this GPU (for Blackwell it is 13 bytes so indices 13-15 are zero)
+  unsigned char slotNumber; //!< The slot number in the chassis containing this GPU (includes switches)
+  unsigned char
+    trayIndex; //!< The tray index within the compute slots in the chassis containing this GPU (does not include switches)
+  unsigned char hostId; //!< Index of the node within the slot containing this GPU
+  unsigned char peerType; //!< Platform indicated NVLink-peer type (e.g. switch present or not)
+  unsigned char moduleId; //!< ID of this GPU within the node
 } nvmlPlatformInfo_v2_t;
 
 typedef nvmlPlatformInfo_v2_t nvmlPlatformInfo_t;
@@ -276,12 +269,12 @@ typedef nvmlPlatformInfo_v2_t nvmlPlatformInfo_t;
  * Confidential Compute Feature Status values
  */
 #define NVML_CC_SYSTEM_FEATURE_DISABLED 0
-#define NVML_CC_SYSTEM_FEATURE_ENABLED  1
+#define NVML_CC_SYSTEM_FEATURE_ENABLED 1
 
 typedef struct nvmlConfComputeSystemState_st {
-    unsigned int environment;
-    unsigned int ccFeature;
-    unsigned int devToolsMode;
+  unsigned int environment;
+  unsigned int ccFeature;
+  unsigned int devToolsMode;
 } nvmlConfComputeSystemState_t;
 
 /**
@@ -295,11 +288,11 @@ typedef struct nvmlConfComputeSystemState_st {
  * Confidential Compute System settings
  */
 typedef struct {
-    unsigned int version;
-    unsigned int environment;
-    unsigned int ccFeature;
-    unsigned int devToolsMode;
-    unsigned int multiGpuMode;
+  unsigned int version;
+  unsigned int environment;
+  unsigned int ccFeature;
+  unsigned int devToolsMode;
+  unsigned int multiGpuMode;
 } nvmlSystemConfComputeSettings_v1_t;
 
 typedef nvmlSystemConfComputeSettings_v1_t nvmlSystemConfComputeSettings_t;
@@ -321,9 +314,9 @@ extern ncclNvmlDeviceInfo ncclNvmlDevices[ncclNvmlMaxDevices];
 extern ncclNvmlDevicePairInfo ncclNvmlDevicePairs[ncclNvmlMaxDevices][ncclNvmlMaxDevices];
 
 struct ncclNvmlCCStatus {
-    bool CCEnabled;
-    bool multiGpuProtectedPCIE;
-    bool multiGpuNVLE;
+  bool CCEnabled;
+  bool multiGpuProtectedPCIE;
+  bool multiGpuNVLE;
 };
 
 // All ncclNvmlFoo() functions call ncclNvmlEnsureInitialized() implicitly.
@@ -333,15 +326,17 @@ ncclResult_t ncclNvmlEnsureInitialized();
 
 ncclResult_t ncclNvmlDeviceGetHandleByPciBusId(const char* pciBusId, nvmlDevice_t* device);
 ncclResult_t ncclNvmlDeviceGetIndex(nvmlDevice_t device, unsigned* index);
-ncclResult_t ncclNvmlDeviceGetHandleByIndex(unsigned int index, nvmlDevice_t *device);
-ncclResult_t ncclNvmlDeviceGetNvLinkState(nvmlDevice_t device, unsigned int link, nvmlEnableState_t *isActive);
-ncclResult_t ncclNvmlDeviceGetNvLinkRemotePciInfo(nvmlDevice_t device, unsigned int link, nvmlPciInfo_t *pci);
-ncclResult_t ncclNvmlDeviceGetNvLinkCapability(nvmlDevice_t device, unsigned int link, nvmlNvLinkCapability_t capability, unsigned int *capResult);
+ncclResult_t ncclNvmlDeviceGetHandleByIndex(unsigned int index, nvmlDevice_t* device);
+ncclResult_t ncclNvmlDeviceGetNvLinkState(nvmlDevice_t device, unsigned int link, nvmlEnableState_t* isActive);
+ncclResult_t ncclNvmlDeviceGetNvLinkRemotePciInfo(nvmlDevice_t device, unsigned int link, nvmlPciInfo_t* pci);
+ncclResult_t ncclNvmlDeviceGetNvLinkCapability(nvmlDevice_t device, unsigned int link,
+                                               nvmlNvLinkCapability_t capability, unsigned int* capResult);
 ncclResult_t ncclNvmlDeviceGetCudaComputeCapability(nvmlDevice_t device, int* major, int* minor);
-ncclResult_t ncclNvmlDeviceGetP2PStatus(nvmlDevice_t device1, nvmlDevice_t device2, nvmlGpuP2PCapsIndex_t p2pIndex, nvmlGpuP2PStatus_t* p2pStatus);
-ncclResult_t ncclNvmlDeviceGetFieldValues(nvmlDevice_t device, int valuesCount, nvmlFieldValue_t *values);
-ncclResult_t ncclNvmlDeviceGetGpuFabricInfoV(nvmlDevice_t device, nvmlGpuFabricInfoV_t *gpuFabricInfo);
-ncclResult_t ncclNvmlDeviceGetPlatformInfo(nvmlDevice_t device, nvmlPlatformInfo_t *plaformInfo);
-ncclResult_t ncclNvmlGetCCStatus(struct ncclNvmlCCStatus *status);
+ncclResult_t ncclNvmlDeviceGetP2PStatus(nvmlDevice_t device1, nvmlDevice_t device2, nvmlGpuP2PCapsIndex_t p2pIndex,
+                                        nvmlGpuP2PStatus_t* p2pStatus);
+ncclResult_t ncclNvmlDeviceGetFieldValues(nvmlDevice_t device, int valuesCount, nvmlFieldValue_t* values);
+ncclResult_t ncclNvmlDeviceGetGpuFabricInfoV(nvmlDevice_t device, nvmlGpuFabricInfoV_t* gpuFabricInfo);
+ncclResult_t ncclNvmlDeviceGetPlatformInfo(nvmlDevice_t device, nvmlPlatformInfo_t* plaformInfo);
+ncclResult_t ncclNvmlGetCCStatus(struct ncclNvmlCCStatus* status);
 
 #endif // End include guard

--- a/projects/rccl/src/include/nvtx.h
+++ b/projects/rccl/src/include/nvtx.h
@@ -20,32 +20,32 @@
 #endif
 
 // Define all NCCL-provided static schema IDs here (avoid duplicates).
-#define NVTX_SID_CommInitRank         0
-#define NVTX_SID_CommInitAll          1
-#define NVTX_SID_CommDestroy          2 // same schema as NVTX_SID_CommInitRank
-#define NVTX_SID_CommAbort            3 // same schema as NVTX_SID_CommInitRank
-#define NVTX_SID_AllGather            4
-#define NVTX_SID_AllReduce            5
-#define NVTX_SID_AlltoAll             6
-#define NVTX_SID_AlltoAllv            7
-#define NVTX_SID_Broadcast            8
-#define NVTX_SID_Gather               9
-#define NVTX_SID_MSCCL                10
-#define NVTX_SID_ReduceScatter        11
-#define NVTX_SID_Reduce               12
-#define NVTX_SID_Scatter              13
-#define NVTX_SID_Send                 14
-#define NVTX_SID_Recv                 15
-#define NVTX_SID_CommInitRankConfig   16 // same schema as NVTX_SID_CommInitRank
+#define NVTX_SID_CommInitRank 0
+#define NVTX_SID_CommInitAll 1
+#define NVTX_SID_CommDestroy 2 // same schema as NVTX_SID_CommInitRank
+#define NVTX_SID_CommAbort 3 // same schema as NVTX_SID_CommInitRank
+#define NVTX_SID_AllGather 4
+#define NVTX_SID_AllReduce 5
+#define NVTX_SID_AlltoAll 6
+#define NVTX_SID_AlltoAllv 7
+#define NVTX_SID_Broadcast 8
+#define NVTX_SID_Gather 9
+#define NVTX_SID_MSCCL 10
+#define NVTX_SID_ReduceScatter 11
+#define NVTX_SID_Reduce 12
+#define NVTX_SID_Scatter 13
+#define NVTX_SID_Send 14
+#define NVTX_SID_Recv 15
+#define NVTX_SID_CommInitRankConfig 16 // same schema as NVTX_SID_CommInitRank
 #define NVTX_SID_CommInitRankScalable 17 // same schema as NVTX_SID_CommInitRank
-#define NVTX_SID_CommSplit            18
-#define NVTX_SID_CommFinalize         19
-#define NVTX_SID_CommShrink           20
-#define NVTX_SID_CommRevoke           21
-#define NVTX_SID_CommGrow             22
-#define NVTX_SID_PutSignal            23
-#define NVTX_SID_Signal               24
-#define NVTX_SID_WaitSignal           25
+#define NVTX_SID_CommSplit 18
+#define NVTX_SID_CommFinalize 19
+#define NVTX_SID_CommShrink 20
+#define NVTX_SID_CommRevoke 21
+#define NVTX_SID_CommGrow 22
+#define NVTX_SID_PutSignal 23
+#define NVTX_SID_Signal 24
+#define NVTX_SID_WaitSignal 25
 // When adding new schema IDs, DO NOT re-use/overlap with the enum schema ID below!
 
 // Define static schema ID for the reduction operation.
@@ -53,16 +53,17 @@
 
 extern const nvtxDomainHandle_t ncclNvtxDomainHandle;
 
-struct nccl_domain{static constexpr char const* name{"NCCL"};};
+struct nccl_domain {
+  static constexpr char const* name{"NCCL"};
+};
 
 extern int64_t ncclParamNvtxDisable();
 
 /// @brief Register an NVTX payload schema for static-size payloads.
 class payload_schema {
- public:
-  explicit payload_schema(const nvtxPayloadSchemaEntry_t entries[], size_t numEntries,
-    const uint64_t schemaId, const size_t size) noexcept
-  {
+public:
+  explicit payload_schema(const nvtxPayloadSchemaEntry_t entries[], size_t numEntries, const uint64_t schemaId,
+                          const size_t size) noexcept {
     schema_attr.payloadStaticSize = size;
     schema_attr.entries = entries;
     schema_attr.numEntries = numEntries;
@@ -78,21 +79,22 @@ class payload_schema {
   payload_schema& operator=(payload_schema&&) = default;
 
 private:
-  nvtxPayloadSchemaAttr_t schema_attr{
-    NVTX_PAYLOAD_SCHEMA_ATTR_TYPE |
-    NVTX_PAYLOAD_SCHEMA_ATTR_ENTRIES |
-    NVTX_PAYLOAD_SCHEMA_ATTR_NUM_ENTRIES |
-    NVTX_PAYLOAD_SCHEMA_ATTR_STATIC_SIZE |
-    NVTX_PAYLOAD_SCHEMA_ATTR_SCHEMA_ID,
-    nullptr, /* schema name is not needed */
-    NVTX_PAYLOAD_SCHEMA_TYPE_STATIC,
-    NVTX_PAYLOAD_SCHEMA_FLAG_NONE,
-    nullptr, 0, 0, 0, 0, nullptr};
+  nvtxPayloadSchemaAttr_t schema_attr{NVTX_PAYLOAD_SCHEMA_ATTR_TYPE | NVTX_PAYLOAD_SCHEMA_ATTR_ENTRIES |
+                                        NVTX_PAYLOAD_SCHEMA_ATTR_NUM_ENTRIES | NVTX_PAYLOAD_SCHEMA_ATTR_STATIC_SIZE |
+                                        NVTX_PAYLOAD_SCHEMA_ATTR_SCHEMA_ID,
+                                      nullptr, /* schema name is not needed */
+                                      NVTX_PAYLOAD_SCHEMA_TYPE_STATIC,
+                                      NVTX_PAYLOAD_SCHEMA_FLAG_NONE,
+                                      nullptr,
+                                      0,
+                                      0,
+                                      0,
+                                      0,
+                                      nullptr};
 };
 
-class ncclOptionalNvtxScopedRange
-{
- public:
+class ncclOptionalNvtxScopedRange {
+public:
   void push(const nvtx3::event_attributes& attr) noexcept {
     // pushed must not be true already, but it's too expensive to check
     pushed = true;
@@ -112,7 +114,7 @@ class ncclOptionalNvtxScopedRange
   ncclOptionalNvtxScopedRange(ncclOptionalNvtxScopedRange&&) = delete;
   ncclOptionalNvtxScopedRange& operator=(ncclOptionalNvtxScopedRange&&) = delete;
 
- private:
+private:
   bool pushed = false;
 };
 
@@ -126,27 +128,24 @@ class ncclOptionalNvtxScopedRange
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
 #define NVTX3_FUNC_WITH_PARAMS(N, T, P) \
   constexpr uint64_t schemaId = NVTX_PAYLOAD_ENTRY_TYPE_SCHEMA_ID_STATIC_START + NVTX_SID_##N; \
-  static const payload_schema schema{T##Schema, std::extent<decltype(T##Schema)>::value - 1, \
-    schemaId, sizeof(T)}; \
+  static const payload_schema schema{T##Schema, std::extent<decltype(T##Schema)>::value - 1, schemaId, sizeof(T)}; \
   const T _payload = {P}; \
   nvtxPayloadData_t nvtx3_bpl__[] = {{schemaId, sizeof(_payload), &_payload}}; \
-  roctx_scoped_range_in const roctx_range__{T##Schema, nvtx3_bpl__, std::extent<decltype(T##Schema)>::value - 1, "RCCL_" #N};
+  roctx_scoped_range_in const roctx_range__{T##Schema, nvtx3_bpl__, std::extent<decltype(T##Schema)>::value - 1, \
+                                            "RCCL_" #N};
 
-#define NCCL_NVTX3_FUNC_RANGE \
-  roctx_scoped_range_in const roctx_range__(("RCCL_"))
+#define NCCL_NVTX3_FUNC_RANGE roctx_scoped_range_in const roctx_range__(("RCCL_"))
 #else
-#define NVTX3_FUNC_WITH_PARAMS(N, T, P)                                                          \
-  ncclOptionalNvtxScopedRange nvtx3_range__;                                                     \
-  if (!ncclParamNvtxDisable())                                                                   \
-  {                                                                                              \
+#define NVTX3_FUNC_WITH_PARAMS(N, T, P) \
+  ncclOptionalNvtxScopedRange nvtx3_range__; \
+  if (!ncclParamNvtxDisable()) { \
     constexpr uint64_t schemaId = NVTX_PAYLOAD_ENTRY_TYPE_SCHEMA_ID_STATIC_START + NVTX_SID_##N; \
-    static const payload_schema                                                                  \
-        schema{T##Schema, std::extent<decltype(T##Schema)>::value - 1, schemaId, sizeof(T)};     \
-    static ::nvtx3::v1::registered_string_in<nccl_domain> const nvtx3_func_name__{__func__};     \
-    const T _payload = {P};                                                                      \
-    nvtxPayloadData_t nvtx3_bpl__[] = {{schemaId, sizeof(_payload), &_payload}};                 \
-    ::nvtx3::v1::event_attributes const nvtx3_func_attr__{nvtx3_func_name__, nvtx3_bpl__};       \
-    nvtx3_range__.push(nvtx3_func_attr__);                                                       \
+    static const payload_schema schema{T##Schema, std::extent<decltype(T##Schema)>::value - 1, schemaId, sizeof(T)}; \
+    static ::nvtx3::v1::registered_string_in<nccl_domain> const nvtx3_func_name__{__func__}; \
+    const T _payload = {P}; \
+    nvtxPayloadData_t nvtx3_bpl__[] = {{schemaId, sizeof(_payload), &_payload}}; \
+    ::nvtx3::v1::event_attributes const nvtx3_func_attr__{nvtx3_func_name__, nvtx3_bpl__}; \
+    nvtx3_range__.push(nvtx3_func_attr__); \
   }
 
 #define NCCL_NVTX3_FUNC_RANGE \
@@ -162,7 +161,7 @@ class ncclOptionalNvtxScopedRange
 /// @tparam PayloadType Data type of the payload.
 template <typename PayloadType>
 class ncclOptionalNvtxPayloadRange {
- public:
+public:
   void push(const nvtx3::event_attributes& attr) noexcept {
     // pushed must not be true already, but it's too expensive to check
     pushed = true;
@@ -180,8 +179,7 @@ class ncclOptionalNvtxPayloadRange {
     }
   }
 
-  void setPayloadData(const uint64_t schemaId) noexcept
-  {
+  void setPayloadData(const uint64_t schemaId) noexcept {
     payloadData = {schemaId, sizeof(PayloadType), &payload};
   }
 
@@ -199,19 +197,18 @@ class ncclOptionalNvtxPayloadRange {
     return pushed;
   }
 
- private:
+private:
   bool pushed = false;
 };
 
 // Create an NVTX range with the function name as the range name. Use RAII pattern.
 // @param T Type ID of the NVTX payload (pointer for variable-size payloads).
-#define NVTX3_RANGE(T)                                                                       \
-  ncclOptionalNvtxPayloadRange<T> nvtx3_range__;                                             \
-  if (!ncclParamNvtxDisable())                                                               \
-  {                                                                                          \
+#define NVTX3_RANGE(T) \
+  ncclOptionalNvtxPayloadRange<T> nvtx3_range__; \
+  if (!ncclParamNvtxDisable()) { \
     static ::nvtx3::v1::registered_string_in<nccl_domain> const nvtx3_func_name__{__func__}; \
-    ::nvtx3::v1::event_attributes const nvtx3_func_attr__{nvtx3_func_name__};                \
-    nvtx3_range__.push(nvtx3_func_attr__);                                                   \
+    ::nvtx3::v1::event_attributes const nvtx3_func_attr__{nvtx3_func_name__}; \
+    nvtx3_range__.push(nvtx3_func_attr__); \
   }
 
 // Add static-size payload to the NVTX range created with `NVTX3_RANGE()`,
@@ -220,26 +217,28 @@ class ncclOptionalNvtxPayloadRange {
 // @param S name of the used NVTX payload schema.
 // @param P payload parameters/entries
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-#define NVTX3_RANGE_ADD_PAYLOAD(N, S, P) do { \
-  constexpr uint64_t schema_id = NVTX_PAYLOAD_ENTRY_TYPE_SCHEMA_ID_STATIC_START + NVTX_SID_##N; \
-  static const payload_schema schema{S, std::extent<decltype(S)>::value - 1, schema_id, \
-    sizeof(nvtx3_range__.payload)}; \
-  nvtx3_range__.payload = {P}; \
-  nvtx3_range__.setPayloadData(schema_id); \
-  nvtxPayloadData_t nvtx3_bpl__[] = {{schema_id, sizeof(nvtx3_range__.payloadData), &nvtx3_range__.payloadData}}; \
-  roctx_scoped_range_in const roctx_range__{S, nvtx3_bpl__, std::extent<decltype(S)>::value - 1, "RCCL_" #N}; \
-} while (0)
+#define NVTX3_RANGE_ADD_PAYLOAD(N, S, P) \
+  do { \
+    constexpr uint64_t schema_id = NVTX_PAYLOAD_ENTRY_TYPE_SCHEMA_ID_STATIC_START + NVTX_SID_##N; \
+    static const payload_schema schema{S, std::extent<decltype(S)>::value - 1, schema_id, \
+                                       sizeof(nvtx3_range__.payload)}; \
+    nvtx3_range__.payload = {P}; \
+    nvtx3_range__.setPayloadData(schema_id); \
+    nvtxPayloadData_t nvtx3_bpl__[] = {{schema_id, sizeof(nvtx3_range__.payloadData), &nvtx3_range__.payloadData}}; \
+    roctx_scoped_range_in const roctx_range__{S, nvtx3_bpl__, std::extent<decltype(S)>::value - 1, "RCCL_" #N}; \
+  } while (0)
 #else
-#define NVTX3_RANGE_ADD_PAYLOAD(N, S, P) do { \
-  if (!nvtx3_range__.isPushed()) { \
-    break; \
-  } \
-  constexpr uint64_t schema_id = NVTX_PAYLOAD_ENTRY_TYPE_SCHEMA_ID_STATIC_START + NVTX_SID_##N; \
-  static const payload_schema schema{S, std::extent<decltype(S)>::value - 1, schema_id, \
-    sizeof(nvtx3_range__.payload)}; \
-  nvtx3_range__.payload = {P}; \
-  nvtx3_range__.setPayloadData(schema_id); \
-} while (0)
+#define NVTX3_RANGE_ADD_PAYLOAD(N, S, P) \
+  do { \
+    if (!nvtx3_range__.isPushed()) { \
+      break; \
+    } \
+    constexpr uint64_t schema_id = NVTX_PAYLOAD_ENTRY_TYPE_SCHEMA_ID_STATIC_START + NVTX_SID_##N; \
+    static const payload_schema schema{S, std::extent<decltype(S)>::value - 1, schema_id, \
+                                       sizeof(nvtx3_range__.payload)}; \
+    nvtx3_range__.payload = {P}; \
+    nvtx3_range__.setPayloadData(schema_id); \
+  } while (0)
 #endif
 
 extern void initNvtxRegisteredEnums();

--- a/projects/rccl/src/include/nvtx_payload_schemas.h
+++ b/projects/rccl/src/include/nvtx_payload_schemas.h
@@ -11,7 +11,6 @@
 #ifndef NVTX_PAYLOAD_SCHEMAS_H_
 #define NVTX_PAYLOAD_SCHEMAS_H_
 
-
 #include "nccl.h"
 #include "nvtx3/nvToolsExtPayload.h"
 #include "nvtx3/nvToolsExtPayloadHelper.h"
@@ -37,21 +36,16 @@ static constexpr char const* nccl_nvtxMsgSizeRecvStr = "Message size [bytes] (Re
 static constexpr char const* nccl_nvtxReductionOpStrpStr = "Reduction operation";
 static constexpr char const* nccl_nvtxDataTypeStr = "Data type";
 
-NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsCommInitAll, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, commhash, TYPE_UINT64, nccl_nvtxCommStr),
-    (int, ndev, TYPE_INT, "No. of devices")
-  )
-)
+NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(
+  NcclNvtxParamsCommInitAll, static constexpr,
+  NCCL_NVTX_PAYLOAD_ENTRIES((uint64_t, commhash, TYPE_UINT64, nccl_nvtxCommStr),
+                            (int, ndev, TYPE_INT, "No. of devices")))
 
-NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsCommInitRank, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, newcomm, TYPE_UINT64, nccl_nvtxCommStr),
-    (int, nranks, TYPE_INT, nccl_nvtxNranksStr),
-    (int, myrank, TYPE_INT, nccl_nvtxRankStr),
-    (int, cudaDev, TYPE_INT, nccl_nvtxCudaDevStr)
-  )
-)
+NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(
+  NcclNvtxParamsCommInitRank, static constexpr,
+  NCCL_NVTX_PAYLOAD_ENTRIES((uint64_t, newcomm, TYPE_UINT64, nccl_nvtxCommStr),
+                            (int, nranks, TYPE_INT, nccl_nvtxNranksStr), (int, myrank, TYPE_INT, nccl_nvtxRankStr),
+                            (int, cudaDev, TYPE_INT, nccl_nvtxCudaDevStr)))
 // The typedef and payload schema for ncclCommInitRank is also used for,
 // ncclCommInitRankConfig, ncclCommInitRankScalable, ncclCommDestroy, ncclCommAbort, and ncclCommRevoke.
 typedef NcclNvtxParamsCommInitRank NcclNvtxParamsCommInitRankConfig;
@@ -59,168 +53,118 @@ typedef NcclNvtxParamsCommInitRank NcclNvtxParamsCommInitRankScalable;
 typedef NcclNvtxParamsCommInitRank NcclNvtxParamsCommAbort;
 typedef NcclNvtxParamsCommInitRank NcclNvtxParamsCommDestroy;
 
-NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsCommSplit, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, newcomm, TYPE_UINT64, nccl_nvtxCommStr),
-    (uint64_t, parentcomm, TYPE_UINT64, "Parent NCCL communicator ID"),
-    (int, nranks, TYPE_INT, nccl_nvtxNranksStr),
-    (int, myrank, TYPE_INT, nccl_nvtxRankStr),
-    (int, cudaDev, TYPE_INT, nccl_nvtxCudaDevStr),
-    (int, color, TYPE_INT, "Color"),
-    (int, key, TYPE_INT, "Key")
-  )
-)
+NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(
+  NcclNvtxParamsCommSplit, static constexpr,
+  NCCL_NVTX_PAYLOAD_ENTRIES((uint64_t, newcomm, TYPE_UINT64, nccl_nvtxCommStr),
+                            (uint64_t, parentcomm, TYPE_UINT64, "Parent NCCL communicator ID"),
+                            (int, nranks, TYPE_INT, nccl_nvtxNranksStr), (int, myrank, TYPE_INT, nccl_nvtxRankStr),
+                            (int, cudaDev, TYPE_INT, nccl_nvtxCudaDevStr), (int, color, TYPE_INT, "Color"),
+                            (int, key, TYPE_INT, "Key")))
 
-NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsCommShrink, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, newcomm, TYPE_UINT64, nccl_nvtxCommStr),
-    (int, nranks, TYPE_INT, nccl_nvtxNranksStr),
-    (int, myrank, TYPE_INT, nccl_nvtxRankStr),
-    (int, cudaDev, TYPE_INT, nccl_nvtxCudaDevStr),
-    (int, num_exclude, TYPE_INT, "num_exclude")
-  )
-)
+NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(
+  NcclNvtxParamsCommShrink, static constexpr,
+  NCCL_NVTX_PAYLOAD_ENTRIES((uint64_t, newcomm, TYPE_UINT64, nccl_nvtxCommStr),
+                            (int, nranks, TYPE_INT, nccl_nvtxNranksStr), (int, myrank, TYPE_INT, nccl_nvtxRankStr),
+                            (int, cudaDev, TYPE_INT, nccl_nvtxCudaDevStr), (int, num_exclude, TYPE_INT, "num_exclude")))
 
-NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsCommGrow, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, newcomm, TYPE_UINT64, nccl_nvtxCommStr),
-    (uint64_t, parentcomm, TYPE_UINT64, "Parent NCCL communicator ID"),
-    (int, nranks, TYPE_INT, nccl_nvtxNranksStr),
-    (int, myrank, TYPE_INT, nccl_nvtxRankStr),
-    (int, cudaDev, TYPE_INT, nccl_nvtxCudaDevStr)
-  )
-)
+NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(
+  NcclNvtxParamsCommGrow, static constexpr,
+  NCCL_NVTX_PAYLOAD_ENTRIES((uint64_t, newcomm, TYPE_UINT64, nccl_nvtxCommStr),
+                            (uint64_t, parentcomm, TYPE_UINT64, "Parent NCCL communicator ID"),
+                            (int, nranks, TYPE_INT, nccl_nvtxNranksStr), (int, myrank, TYPE_INT, nccl_nvtxRankStr),
+                            (int, cudaDev, TYPE_INT, nccl_nvtxCudaDevStr)))
 
 NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsCommFinalize, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr)
-  )
-)
+                                            NCCL_NVTX_PAYLOAD_ENTRIES((uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr)))
 
 typedef NcclNvtxParamsCommFinalize NcclNvtxParamsCommRevoke;
 
-NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsAllGather, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
-    (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr),
-    (ncclDataType_t, datatype, TYPE_DATATYPE, nccl_nvtxDataTypeStr)
-  )
-)
+NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(
+  NcclNvtxParamsAllGather, static constexpr,
+  NCCL_NVTX_PAYLOAD_ENTRIES((uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
+                            (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr),
+                            (ncclDataType_t, datatype, TYPE_DATATYPE, nccl_nvtxDataTypeStr)))
 
-NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsAlltoAll, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
-    (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr),
-    (ncclDataType_t, datatype, TYPE_DATATYPE, nccl_nvtxDataTypeStr)
-  )
-)
+NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(
+  NcclNvtxParamsAlltoAll, static constexpr,
+  NCCL_NVTX_PAYLOAD_ENTRIES((uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
+                            (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr),
+                            (ncclDataType_t, datatype, TYPE_DATATYPE, nccl_nvtxDataTypeStr)))
 
-NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsAlltoAllv, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
-    (size_t, sendBytes, TYPE_SIZE, nccl_nvtxMsgSizeSendStr),
-    (size_t, recvBytes, TYPE_SIZE, nccl_nvtxMsgSizeRecvStr),
-    (ncclDataType_t, datatype, TYPE_DATATYPE, nccl_nvtxDataTypeStr)
-  )
-)
+NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(
+  NcclNvtxParamsAlltoAllv, static constexpr,
+  NCCL_NVTX_PAYLOAD_ENTRIES((uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
+                            (size_t, sendBytes, TYPE_SIZE, nccl_nvtxMsgSizeSendStr),
+                            (size_t, recvBytes, TYPE_SIZE, nccl_nvtxMsgSizeRecvStr),
+                            (ncclDataType_t, datatype, TYPE_DATATYPE, nccl_nvtxDataTypeStr)))
 
-NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsAllReduce, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
-    (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr),
-    (ncclRedOp_t, op, NCCL_REDOP, nccl_nvtxReductionOpStrpStr),
-    (ncclDataType_t, datatype, TYPE_DATATYPE, nccl_nvtxDataTypeStr)
-  )
-)
+NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(
+  NcclNvtxParamsAllReduce, static constexpr,
+  NCCL_NVTX_PAYLOAD_ENTRIES((uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
+                            (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr),
+                            (ncclRedOp_t, op, NCCL_REDOP, nccl_nvtxReductionOpStrpStr),
+                            (ncclDataType_t, datatype, TYPE_DATATYPE, nccl_nvtxDataTypeStr)))
 
-NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsBroadcast, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
-    (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr),
-    (int, root, TYPE_INT, "Root"),
-    (ncclDataType_t, datatype, TYPE_DATATYPE, nccl_nvtxDataTypeStr)
-  )
-)
+NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(
+  NcclNvtxParamsBroadcast, static constexpr,
+  NCCL_NVTX_PAYLOAD_ENTRIES((uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
+                            (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr), (int, root, TYPE_INT, "Root"),
+                            (ncclDataType_t, datatype, TYPE_DATATYPE, nccl_nvtxDataTypeStr)))
 
-NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsGather, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
-    (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr),
-    (int, root, TYPE_INT, "Root"),
-    (ncclDataType_t, datatype, TYPE_DATATYPE, nccl_nvtxDataTypeStr)
-  )
-)
+NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(
+  NcclNvtxParamsGather, static constexpr,
+  NCCL_NVTX_PAYLOAD_ENTRIES((uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
+                            (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr), (int, root, TYPE_INT, "Root"),
+                            (ncclDataType_t, datatype, TYPE_DATATYPE, nccl_nvtxDataTypeStr)))
 
-NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsReduce, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
-    (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr),
-    (int, root, TYPE_INT, "Root"),
-    (ncclRedOp_t, op, NCCL_REDOP, nccl_nvtxReductionOpStrpStr),
-    (ncclDataType_t, datatype, TYPE_DATATYPE, nccl_nvtxDataTypeStr)
-  )
-)
+NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(
+  NcclNvtxParamsReduce, static constexpr,
+  NCCL_NVTX_PAYLOAD_ENTRIES((uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
+                            (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr), (int, root, TYPE_INT, "Root"),
+                            (ncclRedOp_t, op, NCCL_REDOP, nccl_nvtxReductionOpStrpStr),
+                            (ncclDataType_t, datatype, TYPE_DATATYPE, nccl_nvtxDataTypeStr)))
 
-NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsReduceScatter, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
-    (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr),
-    (ncclRedOp_t, op, NCCL_REDOP, nccl_nvtxReductionOpStrpStr),
-    (ncclDataType_t, datatype, TYPE_DATATYPE, nccl_nvtxDataTypeStr)
-  )
-)
+NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(
+  NcclNvtxParamsReduceScatter, static constexpr,
+  NCCL_NVTX_PAYLOAD_ENTRIES((uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
+                            (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr),
+                            (ncclRedOp_t, op, NCCL_REDOP, nccl_nvtxReductionOpStrpStr),
+                            (ncclDataType_t, datatype, TYPE_DATATYPE, nccl_nvtxDataTypeStr)))
 
-NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsScatter, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
-    (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr),
-    (int, root, TYPE_INT, "Root"),
-    (ncclDataType_t, datatype, TYPE_DATATYPE, nccl_nvtxDataTypeStr)
-  )
-)
+NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(
+  NcclNvtxParamsScatter, static constexpr,
+  NCCL_NVTX_PAYLOAD_ENTRIES((uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
+                            (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr), (int, root, TYPE_INT, "Root"),
+                            (ncclDataType_t, datatype, TYPE_DATATYPE, nccl_nvtxDataTypeStr)))
 
 // Used in NCCL APIs `ncclSend` and `ncclRecv`.
-NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsSendRecv, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
-    (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr),
-    (int, peer, TYPE_INT, "Peer rank"),
-    (ncclDataType_t, datatype, TYPE_DATATYPE, nccl_nvtxDataTypeStr)
-  )
-)
+NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(
+  NcclNvtxParamsSendRecv, static constexpr,
+  NCCL_NVTX_PAYLOAD_ENTRIES((uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
+                            (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr), (int, peer, TYPE_INT, "Peer rank"),
+                            (ncclDataType_t, datatype, TYPE_DATATYPE, nccl_nvtxDataTypeStr)))
 
-NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsMSCCL, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
-    (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr),
-    (ncclRedOp_t, op, NCCL_REDOP, nccl_nvtxReductionOpStrpStr),
-    (ncclDataType_t, datatype, TYPE_DATATYPE, nccl_nvtxDataTypeStr)
-  )
-)
+NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(
+  NcclNvtxParamsMSCCL, static constexpr,
+  NCCL_NVTX_PAYLOAD_ENTRIES((uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
+                            (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr),
+                            (ncclRedOp_t, op, NCCL_REDOP, nccl_nvtxReductionOpStrpStr),
+                            (ncclDataType_t, datatype, TYPE_DATATYPE, nccl_nvtxDataTypeStr)))
 
 NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsPut, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
-    (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr),
-    (int, peer, TYPE_INT, "Peer rank"),
-    (int, ctx, TYPE_INT, "Context ID")
-  )
-)
+                                            NCCL_NVTX_PAYLOAD_ENTRIES((uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
+                                                                      (size_t, bytes, TYPE_SIZE, nccl_nvtxMsgSizeStr),
+                                                                      (int, peer, TYPE_INT, "Peer rank"),
+                                                                      (int, ctx, TYPE_INT, "Context ID")))
 
 NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsSignal, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
-    (int, peer, TYPE_INT, "Peer rank"),
-    (int, ctx, TYPE_INT, "Context ID")
-  )
-)
+                                            NCCL_NVTX_PAYLOAD_ENTRIES((uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
+                                                                      (int, peer, TYPE_INT, "Peer rank"),
+                                                                      (int, ctx, TYPE_INT, "Context ID")))
 
 NCCL_NVTX_DEFINE_STRUCT_WITH_SCHEMA_ENTRIES(NcclNvtxParamsWaitSignal, static constexpr,
-  NCCL_NVTX_PAYLOAD_ENTRIES(
-    (uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
-    (int, npeers, TYPE_INT, "Number of peers"),
-    (int, ctx, TYPE_INT, "Context ID")
-  )
-)
+                                            NCCL_NVTX_PAYLOAD_ENTRIES((uint64_t, comm, TYPE_UINT64, nccl_nvtxCommStr),
+                                                                      (int, npeers, TYPE_INT, "Number of peers"),
+                                                                      (int, ctx, TYPE_INT, "Context ID")))
 
 #endif // end include guard

--- a/projects/rccl/src/include/nvtx_stub.h
+++ b/projects/rccl/src/include/nvtx_stub.h
@@ -9,7 +9,9 @@
 
 #include <nvtx3/nvToolsExtPayload.h>
 
-struct nccl_domain{static constexpr char const* name{"NCCL"};};
+struct nccl_domain {
+  static constexpr char const* name{"NCCL"};
+};
 
 #define NVTX3_FUNC_RANGE_IN(domain)
 #define nvtxNameOsThreadA(syscall, thread)

--- a/projects/rccl/src/include/os.h
+++ b/projects/rccl/src/include/os.h
@@ -44,7 +44,7 @@ void ncclOsSetEnv(const char* name, const char* value);
 /* Dynamic library loading */
 typedef void* ncclOsLibraryHandle;
 #define NCCL_OS_DL_LAZY 0
-#define NCCL_OS_DL_NOW  1
+#define NCCL_OS_DL_NOW 1
 ncclOsLibraryHandle ncclOsDlopen(const char* filename);
 ncclOsLibraryHandle ncclOsDlopen(const char* path, int mode);
 void* ncclOsDlsym(ncclOsLibraryHandle handle, const char* symbol);
@@ -54,18 +54,19 @@ const char* ncclOsDlerror();
 /* Socket functions */
 bool ncclOsSocketIsValid(struct ncclSocket* sock);
 bool ncclOsSocketDescriptorIsValid(ncclSocketDescriptor sock);
-ncclResult_t ncclOsFindInterfaces(const char* prefixList, char* names, union ncclSocketAddress *addrs, int sock_family,
-  int maxIfNameSize, int maxIfs, int* found);
+ncclResult_t ncclOsFindInterfaces(const char* prefixList, char* names, union ncclSocketAddress* addrs, int sock_family,
+                                  int maxIfNameSize, int maxIfs, int* found);
 void ncclOsPollSocket(ncclSocketDescriptor sock, int op);
 ncclResult_t ncclOsSocketPollConnect(struct ncclSocket* sock);
 ncclResult_t ncclOsSocketStartConnect(struct ncclSocket* sock);
 ncclResult_t ncclOsSocketSetFlags(struct ncclSocket* sock);
-ncclResult_t ncclOsSocketProgressOpt(int op, struct ncclSocket* sock, void* ptr, int size, int* offset, int block, int* closed);
+ncclResult_t ncclOsSocketProgressOpt(int op, struct ncclSocket* sock, void* ptr, int size, int* offset, int block,
+                                     int* closed);
 ncclResult_t ncclOsSocketResetFd(struct ncclSocket* sock);
 void ncclOsSocketResetAccept(struct ncclSocket* sock);
 ncclResult_t ncclOsSocketTryAccept(struct ncclSocket* sock);
 
-void ncclOsSetMutexCondShared(std::mutex &mutex, std::condition_variable &cond);
+void ncclOsSetMutexCondShared(std::mutex& mutex, std::condition_variable& cond);
 
 void ncclOsCpuZero(ncclAffinity& affinity);
 int ncclOsCpuCount(const ncclAffinity& affinity);
@@ -103,21 +104,18 @@ struct ncclShmHandleInternal {
 };
 
 /* Initialize the shared memory handle structure */
-void ncclOsShmHandleInit(ncclShmDescriptor shmDesc, char* shmPath, size_t shmSize, size_t realShmSize,
-                         char* hptr, void* dptr, bool create,
-                         struct ncclShmHandleInternal* handle);
+void ncclOsShmHandleInit(ncclShmDescriptor shmDesc, char* shmPath, size_t shmSize, size_t realShmSize, char* hptr,
+                         void* dptr, bool create, struct ncclShmHandleInternal* handle);
 
 /* Create or open shared memory */
-ncclResult_t ncclOsShmOpen(char* shmPath, size_t shmPathSize, size_t shmSize,
-                           void** shmPtr, void** devShmPtr, int refcount,
-                           struct ncclShmHandleInternal** handle);
+ncclResult_t ncclOsShmOpen(char* shmPath, size_t shmPathSize, size_t shmSize, void** shmPtr, void** devShmPtr,
+                           int refcount, struct ncclShmHandleInternal** handle);
 
 /* Close and cleanup shared memory */
 ncclResult_t ncclOsShmClose(struct ncclShmHandleInternal* handle);
 
 /* Unlink shared memory (remove from system) */
 ncclResult_t ncclOsShmUnlink(struct ncclShmHandleInternal* handle);
-
 
 /* NVML */
 ncclResult_t ncclOsNvmlOpen(ncclOsLibraryHandle* handle);

--- a/projects/rccl/src/include/os/linux.h
+++ b/projects/rccl/src/include/os/linux.h
@@ -37,4 +37,3 @@ typedef pid_t ncclPid_t;
 #define NCCL_POLLERR POLLHUP
 
 #endif
-

--- a/projects/rccl/src/include/os/windows.h
+++ b/projects/rccl/src/include/os/windows.h
@@ -27,7 +27,7 @@
 #include <windows.h>
 /* Winsock2 must be included before iphlpapi.h so IP_ADAPTER_ADDRESSES and GetAdaptersAddresses are declared */
 #pragma warning(push)
-#pragma warning(disable: 4005) /* _WINSOCKAPI_ redefinition when we already defined it to avoid winsock.h */
+#pragma warning(disable:4005) /* _WINSOCKAPI_ redefinition when we already defined it to avoid winsock.h */
 #include <winsock2.h>
 #pragma warning(pop)
 #include <ws2ipdef.h>

--- a/projects/rccl/src/include/p2p.h
+++ b/projects/rccl/src/include/p2p.h
@@ -32,7 +32,7 @@
 typedef hipMemFabricHandle_t CUmemFabricHandle;
 // HIP equivalents for CU vmm attribute/location constants used across alloc.h and transport files
 #define CU_DEVICE_ATTRIBUTE_HOST_NUMA_ID hipDeviceAttributeHostNumaId
-#define CU_MEM_LOCATION_TYPE_DEVICE      hipMemLocationTypeDevice
+#define CU_MEM_LOCATION_TYPE_DEVICE hipMemLocationTypeDevice
 #elif CUDART_VERSION < 12030
 // MNNVL: FABRIC handle support lifted from CUDA 12.3 (and used as the HIP
 // fallback whenever HIP_FABRIC_API is not enabled).
@@ -75,11 +75,19 @@ struct ncclIpcRegInfo {
   struct ncclIpcImpInfo impInfo;
 };
 
-ncclResult_t ncclP2pAllocateShareableBuffer(size_t size, int directMap, ncclIpcDesc *ipcDesc, void **ptr, int peerRank = -1, struct ncclMemManager* manager = nullptr, ncclMemType_t memtype = ncclMemPersist);
-ncclResult_t ncclP2pFreeShareableBuffer(ncclIpcDesc *ipcDesc);
-ncclResult_t ncclP2pImportShareableBuffer(struct ncclComm *comm, int peer, size_t size, ncclIpcDesc *ipcDesc, void **devMemPtr, void* ownerPtr = nullptr, ncclMemType_t memType = ncclMemPersist);
-ncclResult_t ncclIpcLocalRegisterBuffer(ncclComm* comm, const void* userbuff, size_t buffSize, int* peerRanks, int nPeers, ncclIpcRegType type, int* regBufFlag, uintptr_t* offsetOut, uintptr_t** peerRmtAddrsOut);
-ncclResult_t ncclIpcGraphRegisterBuffer(ncclComm* comm, const void* userbuff, size_t buffSize, int* peerRanks, int nPeers, ncclIpcRegType type, int* regBufFlag, uintptr_t* offsetOut, uintptr_t** peerRmtAddrsOut, void* cleanupQueuePtr, int* nCleanupQueueElts);
+ncclResult_t ncclP2pAllocateShareableBuffer(size_t size, int directMap, ncclIpcDesc* ipcDesc, void** ptr,
+                                            int peerRank = -1, struct ncclMemManager* manager = nullptr,
+                                            ncclMemType_t memtype = ncclMemPersist);
+ncclResult_t ncclP2pFreeShareableBuffer(ncclIpcDesc* ipcDesc);
+ncclResult_t ncclP2pImportShareableBuffer(struct ncclComm* comm, int peer, size_t size, ncclIpcDesc* ipcDesc,
+                                          void** devMemPtr, void* ownerPtr = nullptr,
+                                          ncclMemType_t memType = ncclMemPersist);
+ncclResult_t ncclIpcLocalRegisterBuffer(ncclComm* comm, const void* userbuff, size_t buffSize, int* peerRanks,
+                                        int nPeers, ncclIpcRegType type, int* regBufFlag, uintptr_t* offsetOut,
+                                        uintptr_t** peerRmtAddrsOut);
+ncclResult_t ncclIpcGraphRegisterBuffer(ncclComm* comm, const void* userbuff, size_t buffSize, int* peerRanks,
+                                        int nPeers, ncclIpcRegType type, int* regBufFlag, uintptr_t* offsetOut,
+                                        uintptr_t** peerRmtAddrsOut, void* cleanupQueuePtr, int* nCleanupQueueElts);
 
 ncclResult_t ncclIpcDeregBuffer(struct ncclComm* comm, struct ncclIpcRegInfo* regInfo);
 

--- a/projects/rccl/src/include/param.h
+++ b/projects/rccl/src/include/param.h
@@ -14,7 +14,7 @@
 const char* userHomeDir();
 void setEnvFile(const char* fileName);
 void initEnv();
-const char *ncclGetEnv(const char *name);
+const char* ncclGetEnv(const char* name);
 
 int64_t ncclLoadParam(char const* env, int64_t deftVal, int64_t uninitialized, int64_t* cache, int8_t* noCache);
 
@@ -30,12 +30,11 @@ int64_t ncclLoadParam(char const* env, int64_t deftVal, int64_t uninitialized, i
     return cache; \
   }
 
-#define RCCL_PARAM_DECLARE(name) \
-int64_t rcclParam##name()
+#define RCCL_PARAM_DECLARE(name) int64_t rcclParam##name()
 
 #define RCCL_PARAM(name, env, deftVal) \
-pthread_mutex_t rcclParamMutex##name = PTHREAD_MUTEX_INITIALIZER; \
-int64_t rcclParam##name() { \
+  pthread_mutex_t rcclParamMutex##name = PTHREAD_MUTEX_INITIALIZER; \
+  int64_t rcclParam##name() { \
     constexpr int64_t uninitialized = INT64_MIN; \
     static_assert(deftVal != uninitialized, "default value cannot be the uninitialized value."); \
     static int64_t cache = uninitialized; \
@@ -49,18 +48,16 @@ int64_t rcclParam##name() { \
 // RCCL_PARAM variant that also accepts the NCCL_ prefix as an alias.
 // Checks RCCL_<env> first; if unset, falls back to NCCL_<env>.
 #define RCCL_PARAM_NCCL_ALIAS(name, env, deftVal) \
-pthread_mutex_t rcclParamMutex##name = PTHREAD_MUTEX_INITIALIZER; \
-int64_t rcclParam##name() { \
+  pthread_mutex_t rcclParamMutex##name = PTHREAD_MUTEX_INITIALIZER; \
+  int64_t rcclParam##name() { \
     constexpr int64_t uninitialized = INT64_MIN; \
     static_assert(deftVal != uninitialized, "default value cannot be the uninitialized value."); \
     static int64_t cache = uninitialized; \
     static int8_t noCache = /*uninitialized*/ -1; \
     if (__builtin_expect(__atomic_load_n(&cache, __ATOMIC_RELAXED) == uninitialized, false)) { \
       const char* _s = ncclGetEnv("RCCL_" env); \
-      if (_s && strlen(_s) > 0) \
-        ncclLoadParam("RCCL_" env, deftVal, uninitialized, &cache, &noCache); \
-      else \
-        ncclLoadParam("NCCL_" env, deftVal, uninitialized, &cache, &noCache); \
+      if (_s && strlen(_s) > 0) ncclLoadParam("RCCL_" env, deftVal, uninitialized, &cache, &noCache); \
+      else ncclLoadParam("NCCL_" env, deftVal, uninitialized, &cache, &noCache); \
     } \
     return cache; \
   }

--- a/projects/rccl/src/include/param/common.h
+++ b/projects/rccl/src/include/param/common.h
@@ -20,11 +20,11 @@ extern "C" {
 #endif
 
 typedef enum {
-  NCCL_PARAM_FLAG_NONE       = 0,
-  NCCL_PARAM_FLAG_PUBLISHED  = 1ULL << 0, // public parameters in NCCL doc
+  NCCL_PARAM_FLAG_NONE = 0,
+  NCCL_PARAM_FLAG_PUBLISHED = 1ULL << 0, // public parameters in NCCL doc
   NCCL_PARAM_FLAG_DEPRECATED = 1ULL << 1,
-  NCCL_PARAM_FLAG_CACHED     = 1ULL << 2, // value cached, subsequent change has no effect
-  NCCL_PARAM_FLAG_UNUSED     = 1ULL << 3 // parameter has no effect
+  NCCL_PARAM_FLAG_CACHED = 1ULL << 2, // value cached, subsequent change has no effect
+  NCCL_PARAM_FLAG_UNUSED = 1ULL << 3 // parameter has no effect
 } ncclParamFlag_t;
 
 // Type IDs for param info. non-integers, non-boolean and non-const-char* is mapped to RAW type.

--- a/projects/rccl/src/include/param/param.h
+++ b/projects/rccl/src/include/param/param.h
@@ -39,15 +39,15 @@
 // Note: NCCL_DEFINE_PARAM is not designed to be put inside of a namespace. This can be
 // changed if there is a need.
 #define DEFINE_NCCL_PARAM(name, type, key, default, flags, parser, desc) \
-  namespace key_guards { struct guard_##key {}; }; \
+  namespace key_guards { \
+  struct guard_##key {}; \
+  }; \
   NCCL_PARAM_COMPILER_EXPORT_SYMBOL extern constexpr char name##Key[] = #key; \
-  NCCL_PARAM_COMPILER_EXPORT_SYMBOL ncclParam<type> name{name##Key, default, parser, #type, flags, \
-                                                         desc};
+  NCCL_PARAM_COMPILER_EXPORT_SYMBOL ncclParam<type> name{name##Key, default, parser, #type, flags, desc};
 
 // Usage: USE_NCCL_PARAM(name, type)
 // name and type must match the DEFINE_NCCL_PARAM.
-#define USE_NCCL_PARAM(name, type) \
-  extern ncclParam<type> name;
+#define USE_NCCL_PARAM(name, type) extern ncclParam<type> name;
 
 // ============================================================================
 // ncclParam Template
@@ -72,16 +72,15 @@ struct ncclParam : public ncclParamInterface {
 
   ~ncclParam() override = default;
 
-  ncclParam(const char* key, T defVal, ncclParamParser<T> parser = {},
-            const char* typeStr = "", uint64_t flags = NCCL_PARAM_FLAG_NONE,
-            const char* desc = "")
-    : info({ncclParamTypeIdOf<T>(), flags, typeStr, key, desc}),
-      defaultValue(defVal), value(defVal), parser(std::move(parser)) {
-      if (!this->parser) {
-        this->parser = ncclParamDefault<T>();
-      }
-      ncclParamRegistry::add(info.key, info, this);
+  ncclParam(const char* key, T defVal, ncclParamParser<T> parser = {}, const char* typeStr = "",
+            uint64_t flags = NCCL_PARAM_FLAG_NONE, const char* desc = "")
+    : info({ncclParamTypeIdOf<T>(), flags, typeStr, key, desc}), defaultValue(defVal), value(defVal),
+      parser(std::move(parser)) {
+    if (!this->parser) {
+      this->parser = ncclParamDefault<T>();
     }
+    ncclParamRegistry::add(info.key, info, this);
+  }
 
   // Prevent copy/move assignment
   ncclParam& operator=(const ncclParam&) = delete;

--- a/projects/rccl/src/include/param/parser_bitset.h
+++ b/projects/rccl/src/include/param/parser_bitset.h
@@ -24,8 +24,7 @@ struct bitsetCtx {
 };
 
 template <typename EnumT, size_t N>
-ncclResult_t bitsetResolve(const void* ctx, const char* input,
-                           std::underlying_type_t<EnumT>& out) {
+ncclResult_t bitsetResolve(const void* ctx, const char* input, std::underlying_type_t<EnumT>& out) {
   using ResultT = std::underlying_type_t<EnumT>;
   if (input == nullptr) return ncclInvalidArgument;
   auto& bc = *static_cast<const bitsetCtx<EnumT, N>*>(ctx);
@@ -40,7 +39,9 @@ ncclResult_t bitsetResolve(const void* ctx, const char* input,
       bool found = false;
       for (const auto& opt : bc.options) {
         if (nccl::param::utils::iequals(opt.name, token)) {
-          res |= static_cast<ResultT>(opt.value); found = true; break;
+          res |= static_cast<ResultT>(opt.value);
+          found = true;
+          break;
         }
       }
       if (!found) return ncclInvalidArgument;
@@ -53,7 +54,9 @@ ncclResult_t bitsetResolve(const void* ctx, const char* input,
 }
 
 template <typename EnumT, size_t N>
-bool bitsetValidate(const void*, const std::underlying_type_t<EnumT>&) { return true; }
+bool bitsetValidate(const void*, const std::underlying_type_t<EnumT>&) {
+  return true;
+}
 
 template <typename EnumT, size_t N>
 std::string bitsetToString(const void* ctx, const std::underlying_type_t<EnumT>& value) {
@@ -97,16 +100,17 @@ template <typename EnumT, size_t N>
 ncclParamParser<std::underlying_type_t<EnumT>> ncclParamBitsetOf(ncclOptionSet<EnumT, N> options,
                                                                  char delimiter = ',') {
   using namespace nccl::param::parser;
-  auto ctx = std::make_shared<bitsetCtx<EnumT, N>>(
-    bitsetCtx<EnumT, N>{std::move(options), delimiter});
+  auto ctx = std::make_shared<bitsetCtx<EnumT, N>>(bitsetCtx<EnumT, N>{std::move(options), delimiter});
   std::string d = "Comma-separated list of:";
   for (const auto& opt : ctx->options) {
     d += "\n        ";
     d += opt.name;
-    if (opt.desc != nullptr) { d += " - "; d += opt.desc; }
+    if (opt.desc != nullptr) {
+      d += " - ";
+      d += opt.desc;
+    }
   }
-  return {bitsetResolve<EnumT, N>, bitsetValidate<EnumT, N>, bitsetToString<EnumT, N>,
-          std::move(ctx), std::move(d)};
+  return {bitsetResolve<EnumT, N>, bitsetValidate<EnumT, N>, bitsetToString<EnumT, N>, std::move(ctx), std::move(d)};
 }
 
 #endif /* PARAM_PARSER_BITSET_H_INCLUDED */

--- a/projects/rccl/src/include/param/parser_common.h
+++ b/projects/rccl/src/include/param/parser_common.h
@@ -17,11 +17,11 @@
 // ncclParamParser: Runtime parser interface ncclParam depends on
 template <typename T>
 struct ncclParamParser {
-  using resolveFn_t  = ncclResult_t(*)(const void*, const char*, T&);
-  using validateFn_t = bool(*)(const void*, const T&);
-  using toStringFn_t = std::string(*)(const void*, const T&);
+  using resolveFn_t = ncclResult_t (*)(const void*, const char*, T&);
+  using validateFn_t = bool (*)(const void*, const T&);
+  using toStringFn_t = std::string (*)(const void*, const T&);
 
-  resolveFn_t  resolveFn  = nullptr;
+  resolveFn_t resolveFn = nullptr;
   validateFn_t validateFn = nullptr;
   toStringFn_t toStringFn = nullptr;
   std::shared_ptr<const void> ctx;  // owns factory state; nullptr for stateless parsers
@@ -37,12 +37,16 @@ struct ncclParamParser {
   std::string toString(const T& val) const {
     return toStringFn(ctx.get(), val);
   }
-  explicit operator bool() const { return resolveFn != nullptr; }
+  explicit operator bool() const {
+    return resolveFn != nullptr;
+  }
 };
 
 // Empty braces yield a null ncclParamParser<T>; the ncclParam constructor
 // detects this and fills from ncclParamDefault<T>().
-#define NCCL_PARAM_DEFAULT {}
+#define NCCL_PARAM_DEFAULT \
+  { \
+  }
 
 // Option Builder for enum or bitset types
 //
@@ -67,9 +71,15 @@ template <typename T, size_t N>
 struct ncclOptionSet {
   std::array<ncclOption<T>, N> options;
 
-  constexpr const ncclOption<T>* begin() const { return options.data(); }
-  constexpr const ncclOption<T>* end() const { return options.data() + N; }
-  constexpr size_t size() const { return N; }
+  constexpr const ncclOption<T>* begin() const {
+    return options.data();
+  }
+  constexpr const ncclOption<T>* end() const {
+    return options.data() + N;
+  }
+  constexpr size_t size() const {
+    return N;
+  }
 };
 
 // makeOption: Create an option (2-arg: no description)
@@ -87,7 +97,7 @@ ncclOption<T> makeOption(const char* name, T value, const char* desc) {
 // makeOptions: Create a fixed-size option set from variadic arguments
 template <typename T, typename... Args>
 auto makeOptions(ncclOption<T> first, Args... rest) -> ncclOptionSet<T, 1 + sizeof...(Args)> {
-    return ncclOptionSet<T, 1 + sizeof...(Args)>{{{first, rest...}}};
+  return ncclOptionSet<T, 1 + sizeof...(Args)>{{{first, rest...}}};
 }
 
 #endif /* PARAM_PARSER_COMMON_H_INCLUDED */

--- a/projects/rccl/src/include/param/parser_default.h
+++ b/projects/rccl/src/include/param/parser_default.h
@@ -21,9 +21,13 @@
 // Primary template - catch all for unsupported types
 template <typename T>
 struct ncclParamParserDefault {
-  static ncclResult_t resolve(const char*, T&) { return ncclInvalidArgument; }
+  static ncclResult_t resolve(const char*, T&) {
+    return ncclInvalidArgument;
+  }
 
-  static bool validate(const T&) { return false; }
+  static bool validate(const T&) {
+    return false;
+  }
 
   static std::string toString(const T&) {
     return "<unsupported>";
@@ -39,12 +43,20 @@ struct ncclParamParserDefault<bool> {
     if (input == nullptr) return ncclInvalidArgument;
     std::string s(input);
     using nccl::param::utils::iequals;
-    if (s == "1" || iequals(s, "T") || iequals(s, "TRUE"))  { out = true;  return ncclSuccess; }
-    if (s == "0" || iequals(s, "F") || iequals(s, "FALSE")) { out = false; return ncclSuccess; }
+    if (s == "1" || iequals(s, "T") || iequals(s, "TRUE")) {
+      out = true;
+      return ncclSuccess;
+    }
+    if (s == "0" || iequals(s, "F") || iequals(s, "FALSE")) {
+      out = false;
+      return ncclSuccess;
+    }
     return ncclInvalidArgument;
   }
 
-  static bool validate(const bool&) { return true; }
+  static bool validate(const bool&) {
+    return true;
+  }
 
   static std::string toString(const bool& value) {
     return value ? "TRUE" : "FALSE";
@@ -63,7 +75,9 @@ struct ncclParamParserDefault<const char*> {
     return ncclSuccess;
   }
 
-  static bool validate(const char* const&) { return true; }
+  static bool validate(const char* const&) {
+    return true;
+  }
 
   static std::string toString(const char* const& value) {
     return value ? std::string(value) : std::string();
@@ -81,13 +95,11 @@ struct ncclIntegerParser {
     errno = 0;
     if NCCL_PARAM_IF_CONSTEXPR (std::is_signed<T>::value) {
       long long val = std::strtoll(input, &endPtr, 10);
-      if (endPtr == input || *endPtr != '\0' || errno == ERANGE || errno == EINVAL)
-        return ncclInvalidArgument;
+      if (endPtr == input || *endPtr != '\0' || errno == ERANGE || errno == EINVAL) return ncclInvalidArgument;
       out = static_cast<T>(val);
     } else {
       unsigned long long val = std::strtoull(input, &endPtr, 10);
-      if (endPtr == input || *endPtr != '\0' || errno == ERANGE || errno == EINVAL)
-        return ncclInvalidArgument;
+      if (endPtr == input || *endPtr != '\0' || errno == ERANGE || errno == EINVAL) return ncclInvalidArgument;
       out = static_cast<T>(val);
     }
     return ncclSuccess;
@@ -105,14 +117,22 @@ struct ncclIntegerParser {
 };
 
 // Explicit specializations for integer types
-template <> struct ncclParamParserDefault<int8_t>   : ncclIntegerParser<int8_t> {};
-template <> struct ncclParamParserDefault<int16_t>  : ncclIntegerParser<int16_t> {};
-template <> struct ncclParamParserDefault<int32_t>  : ncclIntegerParser<int32_t> {};
-template <> struct ncclParamParserDefault<int64_t>  : ncclIntegerParser<int64_t> {};
-template <> struct ncclParamParserDefault<uint8_t>  : ncclIntegerParser<uint8_t> {};
-template <> struct ncclParamParserDefault<uint16_t> : ncclIntegerParser<uint16_t> {};
-template <> struct ncclParamParserDefault<uint32_t> : ncclIntegerParser<uint32_t> {};
-template <> struct ncclParamParserDefault<uint64_t> : ncclIntegerParser<uint64_t> {};
+template <>
+struct ncclParamParserDefault<int8_t> : ncclIntegerParser<int8_t> {};
+template <>
+struct ncclParamParserDefault<int16_t> : ncclIntegerParser<int16_t> {};
+template <>
+struct ncclParamParserDefault<int32_t> : ncclIntegerParser<int32_t> {};
+template <>
+struct ncclParamParserDefault<int64_t> : ncclIntegerParser<int64_t> {};
+template <>
+struct ncclParamParserDefault<uint8_t> : ncclIntegerParser<uint8_t> {};
+template <>
+struct ncclParamParserDefault<uint16_t> : ncclIntegerParser<uint16_t> {};
+template <>
+struct ncclParamParserDefault<uint32_t> : ncclIntegerParser<uint32_t> {};
+template <>
+struct ncclParamParserDefault<uint64_t> : ncclIntegerParser<uint64_t> {};
 
 // ============================================================================
 // nccl::param::parser — adapt static methods to function-pointer signatures
@@ -137,7 +157,10 @@ std::string defaultToString(const void*, const T& val) {
 }
 
 template <typename T>
-struct boundedCtx { T lower; T upper; };
+struct boundedCtx {
+  T lower;
+  T upper;
+};
 
 template <typename T>
 bool boundedValidate(const void* ctx, const T& val) {
@@ -155,13 +178,8 @@ bool boundedValidate(const void* ctx, const T& val) {
 template <typename T>
 const ncclParamParser<T>& ncclParamDefault() {
   using namespace nccl::param::parser;
-  static const ncclParamParser<T> instance{
-    defaultResolve<T>,
-    defaultValidate<T>,
-    defaultToString<T>,
-    nullptr,
-    ncclParamParserDefault<T>::desc
-  };
+  static const ncclParamParser<T> instance{defaultResolve<T>, defaultValidate<T>, defaultToString<T>, nullptr,
+                                           ncclParamParserDefault<T>::desc};
   return instance;
 }
 
@@ -175,10 +193,8 @@ template <typename T>
 ncclParamParser<T> ncclParamBounded(T lower, T upper) {
   using namespace nccl::param::parser;
   auto ctx = std::make_shared<boundedCtx<T>>(boundedCtx<T>{lower, upper});
-  std::string d = "Integer in range [" + std::to_string(lower) + ", " +
-                  std::to_string(upper) + "]";
-  return {defaultResolve<T>, boundedValidate<T>, defaultToString<T>,
-          std::move(ctx), std::move(d)};
+  std::string d = "Integer in range [" + std::to_string(lower) + ", " + std::to_string(upper) + "]";
+  return {defaultResolve<T>, boundedValidate<T>, defaultToString<T>, std::move(ctx), std::move(d)};
 }
 
 template <typename T>

--- a/projects/rccl/src/include/param/parser_enum.h
+++ b/projects/rccl/src/include/param/parser_enum.h
@@ -22,13 +22,18 @@ ncclResult_t oneOfResolve(const void* ctx, const char* input, T& out) {
   std::string token = nccl::param::utils::trim(std::string(input));
   if (token.empty()) return ncclInvalidArgument;
   for (const auto& opt : opts) {
-    if (nccl::param::utils::iequals(opt.name, token)) { out = opt.value; return ncclSuccess; }
+    if (nccl::param::utils::iequals(opt.name, token)) {
+      out = opt.value;
+      return ncclSuccess;
+    }
   }
   return ncclInvalidArgument;
 }
 
 template <typename T, size_t N>
-bool oneOfValidate(const void*, const T&) { return true; }
+bool oneOfValidate(const void*, const T&) {
+  return true;
+}
 
 template <typename T, size_t N>
 std::string oneOfToString(const void* ctx, const T& value) {
@@ -52,10 +57,12 @@ ncclParamParser<T> ncclParamOneOf(ncclOptionSet<T, N> options) {
   for (const auto& opt : *ctx) {
     d += "\n        ";
     d += opt.name;
-    if (opt.desc != nullptr) { d += " - "; d += opt.desc; }
+    if (opt.desc != nullptr) {
+      d += " - ";
+      d += opt.desc;
+    }
   }
-  return {oneOfResolve<T, N>, oneOfValidate<T, N>, oneOfToString<T, N>,
-          std::move(ctx), std::move(d)};
+  return {oneOfResolve<T, N>, oneOfValidate<T, N>, oneOfToString<T, N>, std::move(ctx), std::move(d)};
 }
 
 #endif /* PARAM_PARSER_ENUM_H_INCLUDED */

--- a/projects/rccl/src/include/param/parser_list.h
+++ b/projects/rccl/src/include/param/parser_list.h
@@ -15,7 +15,9 @@ namespace nccl {
 namespace param {
 namespace parser {
 
-struct listOfCtx { char delimiter; };
+struct listOfCtx {
+  char delimiter;
+};
 
 template <typename ContainerT>
 ncclResult_t listOfResolve(const void* ctx, const char* input, ContainerT& out) {
@@ -32,14 +34,18 @@ ncclResult_t listOfResolve(const void* ctx, const char* input, ContainerT& out) 
 }
 
 template <typename ContainerT>
-bool listOfValidate(const void*, const ContainerT&) { return true; }
+bool listOfValidate(const void*, const ContainerT&) {
+  return true;
+}
 
 template <typename ContainerT>
 std::string listOfToString(const void* ctx, const ContainerT& value) {
   auto* lc = static_cast<const listOfCtx*>(ctx);
   std::string s;
   for (const auto& elem : value) {
-    if (!s.empty()) { s += lc->delimiter; }
+    if (!s.empty()) {
+      s += lc->delimiter;
+    }
     s += elem;
   }
   return s;
@@ -56,8 +62,8 @@ ncclParamParser<ContainerT> ncclParamListOf(char delimiter = ',') {
   using namespace nccl::param::parser;
   auto ctx = std::make_shared<listOfCtx>(listOfCtx{delimiter});
   std::string d = std::string("Delimiter-separated list (delimiter='") + delimiter + "')";
-  return {listOfResolve<ContainerT>, listOfValidate<ContainerT>, listOfToString<ContainerT>,
-          std::move(ctx), std::move(d)};
+  return {listOfResolve<ContainerT>, listOfValidate<ContainerT>, listOfToString<ContainerT>, std::move(ctx),
+          std::move(d)};
 }
 
 #endif /* PARAM_PARSER_LIST_H_INCLUDED */

--- a/projects/rccl/src/include/param/utils.h
+++ b/projects/rccl/src/include/param/utils.h
@@ -38,20 +38,20 @@
 #define NCCL_PARAM_COMPILER_EXPORT_SYMBOL
 #define NCCL_PARAM_COMPILER_EXPECT(x, v) (x)
 #else
-  #error "Unsupported compiler"
+#error "Unsupported compiler"
 #endif
 
 template <typename T>
 constexpr ncclParamTypeId_t ncclParamTypeIdOf() noexcept {
-  if NCCL_PARAM_IF_CONSTEXPR (std::is_same<T, int8_t>::value)       return NCCL_PARAM_TYPE_I8;
-  else if NCCL_PARAM_IF_CONSTEXPR (std::is_same<T, int16_t>::value)  return NCCL_PARAM_TYPE_I16;
-  else if NCCL_PARAM_IF_CONSTEXPR (std::is_same<T, int32_t>::value)  return NCCL_PARAM_TYPE_I32;
-  else if NCCL_PARAM_IF_CONSTEXPR (std::is_same<T, int64_t>::value)  return NCCL_PARAM_TYPE_I64;
-  else if NCCL_PARAM_IF_CONSTEXPR (std::is_same<T, uint8_t>::value)  return NCCL_PARAM_TYPE_U8;
+  if NCCL_PARAM_IF_CONSTEXPR (std::is_same<T, int8_t>::value) return NCCL_PARAM_TYPE_I8;
+  else if NCCL_PARAM_IF_CONSTEXPR (std::is_same<T, int16_t>::value) return NCCL_PARAM_TYPE_I16;
+  else if NCCL_PARAM_IF_CONSTEXPR (std::is_same<T, int32_t>::value) return NCCL_PARAM_TYPE_I32;
+  else if NCCL_PARAM_IF_CONSTEXPR (std::is_same<T, int64_t>::value) return NCCL_PARAM_TYPE_I64;
+  else if NCCL_PARAM_IF_CONSTEXPR (std::is_same<T, uint8_t>::value) return NCCL_PARAM_TYPE_U8;
   else if NCCL_PARAM_IF_CONSTEXPR (std::is_same<T, uint16_t>::value) return NCCL_PARAM_TYPE_U16;
   else if NCCL_PARAM_IF_CONSTEXPR (std::is_same<T, uint32_t>::value) return NCCL_PARAM_TYPE_U32;
   else if NCCL_PARAM_IF_CONSTEXPR (std::is_same<T, uint64_t>::value) return NCCL_PARAM_TYPE_U64;
-  else if NCCL_PARAM_IF_CONSTEXPR (std::is_same<T, bool>::value)     return NCCL_PARAM_TYPE_BOOL;
+  else if NCCL_PARAM_IF_CONSTEXPR (std::is_same<T, bool>::value) return NCCL_PARAM_TYPE_BOOL;
   else if NCCL_PARAM_IF_CONSTEXPR (std::is_same<T, const char*>::value) return NCCL_PARAM_TYPE_CSTR;
   else return NCCL_PARAM_TYPE_RAW;
 }
@@ -64,7 +64,10 @@ namespace param {
 namespace utils {
 
 inline std::string flagsStr(uint64_t flags) {
-  static const struct { uint64_t flag; const char* name; } entries[] = {
+  static const struct {
+    uint64_t flag;
+    const char* name;
+  } entries[] = {
     {NCCL_PARAM_FLAG_DEPRECATED, "Deprecated"},
     {NCCL_PARAM_FLAG_CACHED, "Cached"},
     {NCCL_PARAM_FLAG_UNUSED, "Unused"},
@@ -79,27 +82,30 @@ inline std::string flagsStr(uint64_t flags) {
   return result;
 }
 
-inline constexpr const char* srcDefault() { return "Default"; }
-inline constexpr const char* srcEnvPlugin() { return "EnvPlugin"; }
+inline constexpr const char* srcDefault() {
+  return "Default";
+}
+inline constexpr const char* srcEnvPlugin() {
+  return "EnvPlugin";
+}
 
 // simple formatting helper that does
 // std::string s = string_format("Name: %s, type: %s", name, type);
 template <typename... Args>
 std::string stringFormat(const char* fmt, Args... args) {
-    int n = std::snprintf(nullptr, 0, fmt, args...);
-    if (n < 0) return {};
+  int n = std::snprintf(nullptr, 0, fmt, args...);
+  if (n < 0) return {};
 
-    std::vector<char> buf(static_cast<size_t>(n) + 1);
-    std::snprintf(buf.data(), buf.size(), fmt, args...);
-    return std::string(buf.data());
+  std::vector<char> buf(static_cast<size_t>(n) + 1);
+  std::snprintf(buf.data(), buf.size(), fmt, args...);
+  return std::string(buf.data());
 }
 
 // Case-insensitive ASCII compare without allocating.
 inline bool iequals(std::string a, std::string b) {
   if (a.size() != b.size()) return false;
   for (size_t i = 0; i < a.size(); ++i) {
-    if (std::tolower(static_cast<unsigned char>(a[i])) !=
-        std::tolower(static_cast<unsigned char>(b[i]))) {
+    if (std::tolower(static_cast<unsigned char>(a[i])) != std::tolower(static_cast<unsigned char>(b[i]))) {
       return false;
     }
   }
@@ -110,7 +116,7 @@ inline std::string trim(std::string s) {
   size_t start = 0;
   while (start < s.size() && std::isspace(static_cast<unsigned char>(s[start]))) ++start;
   size_t end = s.size();
-  while (end > start && std::isspace(static_cast<unsigned char>(s[end-1]))) --end;
+  while (end > start && std::isspace(static_cast<unsigned char>(s[end - 1]))) --end;
   return s.substr(start, end - start);
 }
 

--- a/projects/rccl/src/include/plugin/gin/gin_v11.h
+++ b/projects/rccl/src/include/plugin/gin/gin_v11.h
@@ -26,10 +26,13 @@ typedef struct {
   ncclResult_t (*connect)(void* ctx, void* handles[], int nranks, int rank, void* listenComm, void** collComm);
   // Create device-side GIN context. devHandle will be passed to device code.
   // This function is not used in GIN_PROXY mode.
-  ncclResult_t (*createContext)(void* collComm, int nSignals, int nCounters, void** ginCtx, ncclNetDeviceHandle_v11_t** devHandle);
+  ncclResult_t (*createContext)(void* collComm, int nSignals, int nCounters, void** ginCtx,
+                                ncclNetDeviceHandle_v11_t** devHandle);
   // Collective memory registration
-  ncclResult_t (*regMrSym)(void* collComm, void* data, size_t size, int type, uint64_t mrFlags, void** mhandle, void **ginHandle);
-  ncclResult_t (*regMrSymDmaBuf)(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd, uint64_t mrFlags, void** mhandle, void **ginHandle);
+  ncclResult_t (*regMrSym)(void* collComm, void* data, size_t size, int type, uint64_t mrFlags, void** mhandle,
+                           void** ginHandle);
+  ncclResult_t (*regMrSymDmaBuf)(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd,
+                                 uint64_t mrFlags, void** mhandle, void** ginHandle);
   ncclResult_t (*deregMrSym)(void* collComm, void* mhandle);
   // Close and free collective comm objects
   ncclResult_t (*destroyContext)(void* ginCtx);
@@ -37,12 +40,11 @@ typedef struct {
   ncclResult_t (*closeListen)(void* listenComm);
 
   // Put operations
-  ncclResult_t (*iput)(void* collComm, uint64_t srcOff, void* srcMhandle, size_t size,
-      uint64_t dstOff, void* dstMhandle, uint32_t rank, void** request);
-  ncclResult_t (*iputSignal)(void* collComm, uint64_t srcOff, void* srcMhandle,
-      size_t size, uint64_t dstOff, void* dstMhandle,
-      uint32_t rank, uint64_t signalOff, void *signalMhandle,
-      uint64_t signalValue, uint32_t signalOp, void** request);
+  ncclResult_t (*iput)(void* collComm, uint64_t srcOff, void* srcMhandle, size_t size, uint64_t dstOff,
+                       void* dstMhandle, uint32_t rank, void** request);
+  ncclResult_t (*iputSignal)(void* collComm, uint64_t srcOff, void* srcMhandle, size_t size, uint64_t dstOff,
+                             void* dstMhandle, uint32_t rank, uint64_t signalOff, void* signalMhandle,
+                             uint64_t signalValue, uint32_t signalOp, void** request);
 
   // Test whether a request is complete.
   ncclResult_t (*test)(void* collComm, void* request, int* done);
@@ -51,7 +53,7 @@ typedef struct {
   ncclResult_t (*ginProgress)(void* collComm);
 
   // Query the last error for the GIN support. Particularly important when ginProgress is not used, to report errors.
-  ncclResult_t (*queryLastError)(void* ginCtx, bool *hasError);
+  ncclResult_t (*queryLastError)(void* ginCtx, bool* hasError);
 
   // Finalize the GIN support
   ncclResult_t (*finalize)(void* ctx);

--- a/projects/rccl/src/include/plugin/gin/gin_v12.h
+++ b/projects/rccl/src/include/plugin/gin/gin_v12.h
@@ -25,14 +25,17 @@ typedef struct {
   ncclResult_t (*listen)(void* ctx, int dev, void* handle, void** listenComm);
   // Create a group for GIN operations. handles have been created
   // using listen() above. rank indicates caller's rank in the collective network.
-  ncclResult_t (*connect)(void* ctx, void* handles[], int nranks, int rank, int nConnections,
-                          int queueDepth, void* listenComm, void** collComm);
+  ncclResult_t (*connect)(void* ctx, void* handles[], int nranks, int rank, int nConnections, int queueDepth,
+                          void* listenComm, void** collComm);
   // Create device-side GIN context. devHandle will be passed to device code.
   // This function is not used in GIN_PROXY mode.
-  ncclResult_t (*createContext)(void* collComm, int nSignals, int nCounters, int nContexts, void** ginCtx, ncclNetDeviceHandle_v11_t** devHandle);
+  ncclResult_t (*createContext)(void* collComm, int nSignals, int nCounters, int nContexts, void** ginCtx,
+                                ncclNetDeviceHandle_v11_t** devHandle);
   // Collective memory registration
-  ncclResult_t (*regMrSym)(void* collComm, void* data, size_t size, int type, uint64_t mrFlags, void** mhandle, void **ginHandle);
-  ncclResult_t (*regMrSymDmaBuf)(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd, uint64_t mrFlags, void** mhandle, void **ginHandle);
+  ncclResult_t (*regMrSym)(void* collComm, void* data, size_t size, int type, uint64_t mrFlags, void** mhandle,
+                           void** ginHandle);
+  ncclResult_t (*regMrSymDmaBuf)(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd,
+                                 uint64_t mrFlags, void** mhandle, void** ginHandle);
   ncclResult_t (*deregMrSym)(void* collComm, void* mhandle);
   // Close and free collective comm objects
   ncclResult_t (*destroyContext)(void* ginCtx);
@@ -40,12 +43,11 @@ typedef struct {
   ncclResult_t (*closeListen)(void* listenComm);
 
   // Put operations
-  ncclResult_t (*iput)(void* collComm, uint64_t srcOff, void* srcMhandle, size_t size,
-      uint64_t dstOff, void* dstMhandle, uint32_t rank, int connectionId, void** request);
-  ncclResult_t (*iputSignal)(void* collComm, uint64_t srcOff, void* srcMhandle,
-      size_t size, uint64_t dstOff, void* dstMhandle,
-      uint32_t rank, uint64_t signalOff, void *signalMhandle,
-      uint64_t signalValue, uint32_t signalOp, int connectionId, void** request);
+  ncclResult_t (*iput)(void* collComm, uint64_t srcOff, void* srcMhandle, size_t size, uint64_t dstOff,
+                       void* dstMhandle, uint32_t rank, int connectionId, void** request);
+  ncclResult_t (*iputSignal)(void* collComm, uint64_t srcOff, void* srcMhandle, size_t size, uint64_t dstOff,
+                             void* dstMhandle, uint32_t rank, uint64_t signalOff, void* signalMhandle,
+                             uint64_t signalValue, uint32_t signalOp, int connectionId, void** request);
 
   // Test whether a request is complete.
   ncclResult_t (*test)(void* collComm, void* request, int* done);
@@ -54,7 +56,7 @@ typedef struct {
   ncclResult_t (*ginProgress)(void* collComm);
 
   // Query the last error for the GIN support. Particularly important when ginProgress is not used, to report errors.
-  ncclResult_t (*queryLastError)(void* ginCtx, bool *hasError);
+  ncclResult_t (*queryLastError)(void* ginCtx, bool* hasError);
 
   // Finalize the GIN support
   ncclResult_t (*finalize)(void* ctx);

--- a/projects/rccl/src/include/plugin/gin/gin_v13.h
+++ b/projects/rccl/src/include/plugin/gin/gin_v13.h
@@ -15,7 +15,7 @@ typedef struct {
   int nContexts;
   int queueDepth;
   int trafficClass;
-}ncclGinConfig_v13_t;
+} ncclGinConfig_v13_t;
 
 typedef struct {
   // Name of the GIN support (mainly for logs)
@@ -33,13 +33,15 @@ typedef struct {
   ncclResult_t (*listen)(void* ctx, int dev, void* handle, void** listenComm);
   // Create a group for GIN operations. handles have been created
   // using listen() above. rank indicates caller's rank in the collective network.
-  ncclResult_t (*connect)(void* ctx, void* handles[], int nranks, int rank,
-                          void* listenComm, void** collComm);
+  ncclResult_t (*connect)(void* ctx, void* handles[], int nranks, int rank, void* listenComm, void** collComm);
   // Create device-side GIN context. devHandle will be passed to device code.
-  ncclResult_t (*createContext)(void* collComm, ncclGinConfig_v13_t* config, void** ginCtx, ncclNetDeviceHandle_v11_t** devHandle);
+  ncclResult_t (*createContext)(void* collComm, ncclGinConfig_v13_t* config, void** ginCtx,
+                                ncclNetDeviceHandle_v11_t** devHandle);
   // Collective memory registration
-  ncclResult_t (*regMrSym)(void* collComm, void* data, size_t size, int type, uint64_t mrFlags, void** mhandle, void **ginHandle);
-  ncclResult_t (*regMrSymDmaBuf)(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd, uint64_t mrFlags, void** mhandle, void **ginHandle);
+  ncclResult_t (*regMrSym)(void* collComm, void* data, size_t size, int type, uint64_t mrFlags, void** mhandle,
+                           void** ginHandle);
+  ncclResult_t (*regMrSymDmaBuf)(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd,
+                                 uint64_t mrFlags, void** mhandle, void** ginHandle);
   ncclResult_t (*deregMrSym)(void* collComm, void* mhandle);
   // Close and free collective comm objects
   ncclResult_t (*destroyContext)(void* ginCtx);
@@ -47,14 +49,13 @@ typedef struct {
   ncclResult_t (*closeListen)(void* listenComm);
 
   // Put operations
-  ncclResult_t (*iput)(void* ginCtx, int context, uint64_t srcOff, void* srcMhandle, size_t size,
-      uint64_t dstOff, void* dstMhandle, uint32_t rank, void** request);
-  ncclResult_t (*iputSignal)(void* ginCtx, int context, uint64_t srcOff, void* srcMhandle,
-      size_t size, uint64_t dstOff, void* dstMhandle,
-      uint32_t rank, uint64_t signalOff, void *signalMhandle,
-      uint64_t signalValue, uint32_t signalOp, void** request);
+  ncclResult_t (*iput)(void* ginCtx, int context, uint64_t srcOff, void* srcMhandle, size_t size, uint64_t dstOff,
+                       void* dstMhandle, uint32_t rank, void** request);
+  ncclResult_t (*iputSignal)(void* ginCtx, int context, uint64_t srcOff, void* srcMhandle, size_t size, uint64_t dstOff,
+                             void* dstMhandle, uint32_t rank, uint64_t signalOff, void* signalMhandle,
+                             uint64_t signalValue, uint32_t signalOp, void** request);
   ncclResult_t (*iget)(void* ginCtx, int context, uint64_t remoteOff, void* remoteMhandle, size_t size,
-      uint64_t localOff, void* localMhandle, uint32_t rank, void** request);
+                       uint64_t localOff, void* localMhandle, uint32_t rank, void** request);
 
   ncclResult_t (*iflush)(void* ginCtx, int context, void* mhandle, uint32_t rank, void** request);
 
@@ -65,7 +66,7 @@ typedef struct {
   ncclResult_t (*ginProgress)(void* ginCtx);
 
   // Query the last error for the GIN support. Particularly important when ginProgress is not used, to report errors.
-  ncclResult_t (*queryLastError)(void* ginCtx, bool *hasError);
+  ncclResult_t (*queryLastError)(void* ginCtx, bool* hasError);
 
   // Finalize the GIN support
   ncclResult_t (*finalize)(void* ctx);

--- a/projects/rccl/src/include/plugin/nccl_gin.h
+++ b/projects/rccl/src/include/plugin/nccl_gin.h
@@ -13,9 +13,8 @@
 #include "nccl_device/net_device.h"
 #include <stdint.h>
 
-
 #define NCCL_GIN_HANDLE_MAXSIZE 128
-#define MAX_GIN_SIZE (1024*1024*1024L) // Rather than send INT_MAX which is 2G-1, send a power of two.
+#define MAX_GIN_SIZE (1024 * 1024 * 1024L) // Rather than send INT_MAX which is 2G-1, send a power of two.
 
 // Max number of ncclNet objects which can live in the same process
 #ifndef NCCL_GIN_MAX_PLUGINS

--- a/projects/rccl/src/include/plugin/nccl_net.h
+++ b/projects/rccl/src/include/plugin/nccl_net.h
@@ -15,13 +15,13 @@
 #include <dlfcn.h>
 
 #define NCCL_NET_HANDLE_MAXSIZE 128
-//Maximum value NCCL can accept for maxP2pBytes and maxCollBytes net properties
-#define NCCL_MAX_NET_SIZE_BYTES (1*1024*1024*1024*1024L)
+// Maximum value NCCL can accept for maxP2pBytes and maxCollBytes net properties
+#define NCCL_MAX_NET_SIZE_BYTES (1 * 1024 * 1024 * 1024 * 1024L)
 #define NCCL_NET_OPTIONAL_RECV_COMPLETION 0x1
 #define NCCL_NET_MULTI_REQUEST 0x2
 
-#define MAX_NET_SIZE (1024*1024*1024L) // Rather than send INT_MAX which is 2G-1, send a power of two.
-#define MAX_COLLNET_SIZE (512*1024*1024L) //Set for initial collent plugins when size was not dynamically queried
+#define MAX_NET_SIZE (1024 * 1024 * 1024L) // Rather than send INT_MAX which is 2G-1, send a power of two.
+#define MAX_COLLNET_SIZE (512 * 1024 * 1024L) // Set for initial collent plugins when size was not dynamically queried
 
 #define NCCL_PTR_HOST 0x1
 #define NCCL_PTR_CUDA 0x2

--- a/projects/rccl/src/include/plugin/nccl_profiler.h
+++ b/projects/rccl/src/include/plugin/nccl_profiler.h
@@ -9,72 +9,72 @@
 #define NCCL_PROFILER_H_
 
 enum {
-  ncclProfileGroup          = (1 << 0),  // group event type
-  ncclProfileColl           = (1 << 1),  // host collective call event type
-  ncclProfileP2p            = (1 << 2),  // host point-to-point call event type
-  ncclProfileProxyOp        = (1 << 3),  // proxy operation event type
-  ncclProfileProxyStep      = (1 << 4),  // proxy step event type
-  ncclProfileProxyCtrl      = (1 << 5),  // proxy control event type
-  ncclProfileKernelCh       = (1 << 6),  // kernel channel event type
-  ncclProfileNetPlugin      = (1 << 7),  // network plugin-defined, events
-  ncclProfileGroupApi       = (1 << 8),  // Group API events
-  ncclProfileCollApi        = (1 << 9),  // Collective API events
-  ncclProfileP2pApi         = (1 << 10), // Point-to-Point API events
-  ncclProfileKernelLaunch   = (1 << 11), // Kernel launch events
+  ncclProfileGroup = (1 << 0),  // group event type
+  ncclProfileColl = (1 << 1),  // host collective call event type
+  ncclProfileP2p = (1 << 2),  // host point-to-point call event type
+  ncclProfileProxyOp = (1 << 3),  // proxy operation event type
+  ncclProfileProxyStep = (1 << 4),  // proxy step event type
+  ncclProfileProxyCtrl = (1 << 5),  // proxy control event type
+  ncclProfileKernelCh = (1 << 6),  // kernel channel event type
+  ncclProfileNetPlugin = (1 << 7),  // network plugin-defined, events
+  ncclProfileGroupApi = (1 << 8),  // Group API events
+  ncclProfileCollApi = (1 << 9),  // Collective API events
+  ncclProfileP2pApi = (1 << 10), // Point-to-Point API events
+  ncclProfileKernelLaunch = (1 << 11), // Kernel launch events
   // CE events (profiler v6)
-  ncclProfileCeColl         = (1 << 12), // CE collective operation
-  ncclProfileCeSync         = (1 << 13), // CE synchronization operation
-  ncclProfileCeBatch        = (1 << 14), // CE batch operation
-  ncclProfileProxyDiag      = (1 << 15), // RCCL: extra proxy FIFO/counter diagnostics (proxy-trace plugin)
+  ncclProfileCeColl = (1 << 12), // CE collective operation
+  ncclProfileCeSync = (1 << 13), // CE synchronization operation
+  ncclProfileCeBatch = (1 << 14), // CE batch operation
+  ncclProfileProxyDiag = (1 << 15), // RCCL: extra proxy FIFO/counter diagnostics (proxy-trace plugin)
 };
 
 typedef enum {
-  ncclProfilerProxyOpSendPosted        = 0,  // deprecated in v4
-  ncclProfilerProxyOpSendRemFifoWait   = 1,  // deprecated in v4
-  ncclProfilerProxyOpSendTransmitted   = 2,  // deprecated in v4
-  ncclProfilerProxyOpSendDone          = 3,  // deprecated in v4
-  ncclProfilerProxyOpRecvPosted        = 4,  // deprecated in v4
-  ncclProfilerProxyOpRecvReceived      = 5,  // deprecated in v4
-  ncclProfilerProxyOpRecvTransmitted   = 6,  // deprecated in v4
-  ncclProfilerProxyOpRecvDone          = 7,  // deprecated in v4
-  ncclProfilerProxyOpInProgress_v4     = 19,
+  ncclProfilerProxyOpSendPosted = 0,  // deprecated in v4
+  ncclProfilerProxyOpSendRemFifoWait = 1,  // deprecated in v4
+  ncclProfilerProxyOpSendTransmitted = 2,  // deprecated in v4
+  ncclProfilerProxyOpSendDone = 3,  // deprecated in v4
+  ncclProfilerProxyOpRecvPosted = 4,  // deprecated in v4
+  ncclProfilerProxyOpRecvReceived = 5,  // deprecated in v4
+  ncclProfilerProxyOpRecvTransmitted = 6,  // deprecated in v4
+  ncclProfilerProxyOpRecvDone = 7,  // deprecated in v4
+  ncclProfilerProxyOpInProgress_v4 = 19,
 
   /* Legacy proxy profiler states */
-  ncclProfilerProxyStepSendGPUWait     = 8,
+  ncclProfilerProxyStepSendGPUWait = 8,
   ncclProfilerProxyStepSendPeerWait_v4 = 20,
-  ncclProfilerProxyStepSendWait        = 9,
-  ncclProfilerProxyStepRecvWait        = 10,
-  ncclProfilerProxyStepRecvFlushWait   = 11,
-  ncclProfilerProxyStepRecvGPUWait     = 12,
+  ncclProfilerProxyStepSendWait = 9,
+  ncclProfilerProxyStepRecvWait = 10,
+  ncclProfilerProxyStepRecvFlushWait = 11,
+  ncclProfilerProxyStepRecvGPUWait = 12,
 
   /* Legacy proxy control states */
-  ncclProfilerProxyCtrlIdle            = 13,
-  ncclProfilerProxyCtrlActive          = 14,
-  ncclProfilerProxyCtrlSleep           = 15,
-  ncclProfilerProxyCtrlWakeup          = 16,
-  ncclProfilerProxyCtrlAppend          = 17,
-  ncclProfilerProxyCtrlAppendEnd       = 18,
+  ncclProfilerProxyCtrlIdle = 13,
+  ncclProfilerProxyCtrlActive = 14,
+  ncclProfilerProxyCtrlSleep = 15,
+  ncclProfilerProxyCtrlWakeup = 16,
+  ncclProfilerProxyCtrlAppend = 17,
+  ncclProfilerProxyCtrlAppendEnd = 18,
 
   /* Network defined event states */
-  ncclProfilerNetPluginUpdate          = 21,
+  ncclProfilerNetPluginUpdate = 21,
 
   /* Kernel event states */
-  ncclProfilerKernelChStop             = 22,
+  ncclProfilerKernelChStop = 22,
 
   /* Group API States */
-  ncclProfilerGroupStartApiStop        = 23,
-  ncclProfilerGroupEndApiStart         = 24,
+  ncclProfilerGroupStartApiStop = 23,
+  ncclProfilerGroupEndApiStart = 24,
 
   /* CE-specific states (v6) */
-  ncclProfilerCeCollStart              = 25,  // CE collective operation begins
-  ncclProfilerCeCollComplete           = 26,  // CE collective operation completes
-  ncclProfilerCeSyncStart              = 27,  // CE synchronization begins
-  ncclProfilerCeSyncComplete           = 28,  // CE synchronization completes
-  ncclProfilerCeBatchStart             = 29,  // CE batch operation begins
-  ncclProfilerCeBatchComplete          = 30,  // CE batch operation completes
+  ncclProfilerCeCollStart = 25,  // CE collective operation begins
+  ncclProfilerCeCollComplete = 26,  // CE collective operation completes
+  ncclProfilerCeSyncStart = 27,  // CE synchronization begins
+  ncclProfilerCeSyncComplete = 28,  // CE synchronization completes
+  ncclProfilerCeBatchStart = 29,  // CE batch operation begins
+  ncclProfilerCeBatchComplete = 30,  // CE batch operation completes
 
   /* RCCL proxy-trace plugin: opaque counter/timestamp payload in ncclProfilerEventStateArgs_t.proxyDiag */
-  ncclProfilerProxyDiagUpdate          = 31,
+  ncclProfilerProxyDiagUpdate = 31,
 } ncclProfilerEventState_t;
 
 typedef ncclProfilerEventState_t ncclProfilerEventState_v1_t;
@@ -99,12 +99,12 @@ typedef ncclProfiler_v6_t ncclProfiler_t;
 typedef ncclProfilerEventDescr_v6_t ncclProfilerEventDescr_t;
 typedef ncclProfilerEventStateArgs_v6_t ncclProfilerEventStateArgs_t;
 
-#define NCCL_PROFILER_NET_VER_BITS  (16)
-#define NCCL_PROFILER_NET_VER_MASK  (~0U >> NCCL_PROFILER_NET_VER_BITS)
+#define NCCL_PROFILER_NET_VER_BITS (16)
+#define NCCL_PROFILER_NET_VER_MASK (~0U >> NCCL_PROFILER_NET_VER_BITS)
 #define NCCL_PROFILER_NET_TYPE_MASK (~0U << NCCL_PROFILER_NET_VER_BITS)
 
 typedef enum {
-  NCCL_PROFILER_NET_TYPE_IB   = (1U << NCCL_PROFILER_NET_VER_BITS),
+  NCCL_PROFILER_NET_TYPE_IB = (1U << NCCL_PROFILER_NET_VER_BITS),
   NCCL_PROFILER_NET_TYPE_SOCK = (2U << NCCL_PROFILER_NET_VER_BITS),
 } ncclProfilerNetType;
 

--- a/projects/rccl/src/include/plugin/net/net_v10.h
+++ b/projects/rccl/src/include/plugin/net/net_v10.h
@@ -20,7 +20,6 @@ typedef struct {
   int trafficClass;
 } ncclNetCommConfig_v10_t;
 
-
 typedef struct {
   char* name;                      // Used mostly for logging.
   char* pciPath;                   // Path to the PCI device in /sys.
@@ -59,7 +58,8 @@ typedef struct {
   // should return successfully with sendComm == NULL with the expectation that
   // it will be called again until sendComm != NULL.
   // If *sendDevComm points to a valid object, then NCCL is requesting device offload for this connection
-  ncclResult_t (*connect)(int dev, ncclNetCommConfig_v10_t* config, void* handle, void** sendComm, ncclNetDeviceHandle_v10_t** sendDevComm);
+  ncclResult_t (*connect)(int dev, ncclNetCommConfig_v10_t* config, void* handle, void** sendComm,
+                          ncclNetDeviceHandle_v10_t** sendDevComm);
   // Finalize connection establishment after remote peer has called connect.
   // This call must not block for the connection to be established, and instead
   // should return successfully with recvComm == NULL with the expectation that
@@ -77,7 +77,8 @@ typedef struct {
   ncclResult_t (*isend)(void* sendComm, void* data, size_t size, int tag, void* mhandle, void* phandle, void** request);
   // Asynchronous recv from a peer.
   // May return request == NULL if the call cannot be performed (or would block)
-  ncclResult_t (*irecv)(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles, void** phandles, void** request);
+  ncclResult_t (*irecv)(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles, void** phandles,
+                        void** request);
   // Perform a flush/fence to make sure all data received with NCCL_PTR_CUDA is
   // visible to the GPU
   ncclResult_t (*iflush)(void* recvComm, int n, void** data, int* sizes, void** mhandles, void** request);
@@ -129,19 +130,19 @@ typedef struct {
   // Register/Deregister memory. Type is either NCCL_PTR_HOST or NCCL_PTR_CUDA.
   ncclResult_t (*regMr)(void* collComm, void* data, size_t size, int type, void** mhandle);
   /* DMA-BUF support */
-  ncclResult_t (*regMrDmaBuf)(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd, void** mhandle);
+  ncclResult_t (*regMrDmaBuf)(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd,
+                              void** mhandle);
   ncclResult_t (*deregMr)(void* collComm, void* mhandle);
   // Performs an asynchronous allreduce operation on the collective group.
   // May return request == NULL if the call cannot be performed (or would block).
-  ncclResult_t (*iallreduce)(void* collComm, void* sendData, void* recvData, size_t count,
-      ncclDataType_t dataType, ncclRedOp_t redOp, void* sendMhandle, void* recvMhandle, void** request);
+  ncclResult_t (*iallreduce)(void* collComm, void* sendData, void* recvData, size_t count, ncclDataType_t dataType,
+                             ncclRedOp_t redOp, void* sendMhandle, void* recvMhandle, void** request);
   ncclResult_t (*iallgather)(void* collComm, void* sendData, int nRecvParts, ncclNetSGE_v10_t* recvParts,
-                             size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
-                             void* sendMhandle, void** request);
+                             size_t bytesPerRank, size_t windowOffset, size_t windowBytes, void* sendMhandle,
+                             void** request);
   ncclResult_t (*ireducescatter)(void* collComm, int nSendParts, ncclNetSGE_v10_t* sendParts, void* recvData,
-                                 size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
-                                 ncclDataType_t dataType, ncclRedOp_t redOp,
-                                 void* recvMhandle, void** request);
+                                 size_t bytesPerRank, size_t windowOffset, size_t windowBytes, ncclDataType_t dataType,
+                                 ncclRedOp_t redOp, void* recvMhandle, void** request);
   // Perform a flush/fence to make sure all data received with NCCL_PTR_CUDA is
   // visible to the GPU
   ncclResult_t (*iflush)(void* collComm, void* data, int size, void* mhandle, void** request);

--- a/projects/rccl/src/include/plugin/net/net_v11.h
+++ b/projects/rccl/src/include/plugin/net/net_v11.h
@@ -45,13 +45,14 @@ typedef struct {
 
 #define NCCL_NET_ATTR_UNDEF -1
 
-#define NCCL_NET_ATTR_INIT { \
-  { NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF }, /* sendCommAttr */ \
-  { NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF }, /* recvCommAttr */ \
-  (uint32_t)NCCL_NET_ATTR_UNDEF, /* op */ \
-  (uint32_t)NCCL_NET_ATTR_UNDEF, /* algo */ \
-  (uint32_t)NCCL_NET_ATTR_UNDEF, /* proto */ \
-}
+#define NCCL_NET_ATTR_INIT \
+  { \
+    {NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF}, /* sendCommAttr */ \
+    {NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF}, /* recvCommAttr */ \
+    (uint32_t)NCCL_NET_ATTR_UNDEF, /* op */ \
+    (uint32_t)NCCL_NET_ATTR_UNDEF, /* algo */ \
+    (uint32_t)NCCL_NET_ATTR_UNDEF, /* proto */ \
+  }
 
 typedef struct {
   int32_t maxConcurrentPeers;
@@ -72,7 +73,8 @@ typedef struct {
   // Name of the network (mainly for logs)
   const char* name;
   // Initialize the network.
-  ncclResult_t (*init)(void** ctx, uint64_t commId, ncclNetCommConfig_v11_t* config, ncclDebugLogger_t logFunction, ncclProfilerCallback_t profFunction);
+  ncclResult_t (*init)(void** ctx, uint64_t commId, ncclNetCommConfig_v11_t* config, ncclDebugLogger_t logFunction,
+                       ncclProfilerCallback_t profFunction);
   // Return the number of adapters.
   ncclResult_t (*devices)(int* ndev);
   // Get various device properties.
@@ -104,7 +106,8 @@ typedef struct {
   ncclResult_t (*isend)(void* sendComm, void* data, size_t size, int tag, void* mhandle, void* phandle, void** request);
   // Asynchronous recv from a peer.
   // May return request == NULL if the call cannot be performed (or would block)
-  ncclResult_t (*irecv)(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles, void** phandles, void** request);
+  ncclResult_t (*irecv)(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles, void** phandles,
+                        void** request);
   // Perform a flush/fence to make sure all data received with NCCL_PTR_CUDA is
   // visible to the GPU
   ncclResult_t (*iflush)(void* recvComm, int n, void** data, int* sizes, void** mhandles, void** request);
@@ -160,19 +163,19 @@ typedef struct {
   // Register/Deregister memory. Type is either NCCL_PTR_HOST or NCCL_PTR_CUDA.
   ncclResult_t (*regMr)(void* collComm, void* data, size_t size, int type, void** mhandle);
   /* DMA-BUF support */
-  ncclResult_t (*regMrDmaBuf)(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd, void** mhandle);
+  ncclResult_t (*regMrDmaBuf)(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd,
+                              void** mhandle);
   ncclResult_t (*deregMr)(void* collComm, void* mhandle);
   // Performs an asynchronous allreduce operation on the collective group.
   // May return request == NULL if the call cannot be performed (or would block).
-  ncclResult_t (*iallreduce)(void* collComm, void* sendData, void* recvData, size_t count,
-      ncclDataType_t dataType, ncclRedOp_t redOp, void* sendMhandle, void* recvMhandle, void** request);
+  ncclResult_t (*iallreduce)(void* collComm, void* sendData, void* recvData, size_t count, ncclDataType_t dataType,
+                             ncclRedOp_t redOp, void* sendMhandle, void* recvMhandle, void** request);
   ncclResult_t (*iallgather)(void* collComm, void* sendData, int nRecvParts, ncclNetSGE_v11_t* recvParts,
-                             size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
-                             void* sendMhandle, void** request);
+                             size_t bytesPerRank, size_t windowOffset, size_t windowBytes, void* sendMhandle,
+                             void** request);
   ncclResult_t (*ireducescatter)(void* collComm, int nSendParts, ncclNetSGE_v11_t* sendParts, void* recvData,
-                                 size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
-                                 ncclDataType_t dataType, ncclRedOp_t redOp,
-                                 void* recvMhandle, void** request);
+                                 size_t bytesPerRank, size_t windowOffset, size_t windowBytes, ncclDataType_t dataType,
+                                 ncclRedOp_t redOp, void* recvMhandle, void** request);
   // Perform a flush/fence to make sure all data received with NCCL_PTR_CUDA is
   // visible to the GPU
   ncclResult_t (*iflush)(void* collComm, void* data, int size, void* mhandle, void** request);

--- a/projects/rccl/src/include/plugin/net/net_v12.h
+++ b/projects/rccl/src/include/plugin/net/net_v12.h
@@ -49,13 +49,14 @@ typedef struct {
 
 #define NCCL_NET_ID_UNDEF -1
 
-#define NCCL_NET_ATTR_INIT { \
-  { NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF }, /* sendCommAttr */ \
-  { NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF }, /* recvCommAttr */ \
-  (uint32_t)NCCL_NET_ATTR_UNDEF, /* op */ \
-  (uint32_t)NCCL_NET_ATTR_UNDEF, /* algo */ \
-  (uint32_t)NCCL_NET_ATTR_UNDEF, /* proto */ \
-}
+#define NCCL_NET_ATTR_INIT \
+  { \
+    {NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF}, /* sendCommAttr */ \
+    {NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF}, /* recvCommAttr */ \
+    (uint32_t)NCCL_NET_ATTR_UNDEF, /* op */ \
+    (uint32_t)NCCL_NET_ATTR_UNDEF, /* algo */ \
+    (uint32_t)NCCL_NET_ATTR_UNDEF, /* proto */ \
+  }
 
 typedef struct {
   int32_t maxConcurrentPeers;
@@ -76,7 +77,8 @@ typedef struct {
   // Name of the network (mainly for logs)
   const char* name;
   // Initialize the network.
-  ncclResult_t (*init)(void** ctx, uint64_t commId, ncclNetCommConfig_v12_t* config, ncclDebugLogger_t logFunction, ncclProfilerCallback_t profFunction);
+  ncclResult_t (*init)(void** ctx, uint64_t commId, ncclNetCommConfig_v12_t* config, ncclDebugLogger_t logFunction,
+                       ncclProfilerCallback_t profFunction);
   // Return the number of adapters.
   ncclResult_t (*devices)(int* ndev);
   // Get various device properties.
@@ -108,7 +110,8 @@ typedef struct {
   ncclResult_t (*isend)(void* sendComm, void* data, size_t size, int tag, void* mhandle, void* phandle, void** request);
   // Asynchronous recv from a peer.
   // May return request == NULL if the call cannot be performed (or would block)
-  ncclResult_t (*irecv)(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles, void** phandles, void** request);
+  ncclResult_t (*irecv)(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles, void** phandles,
+                        void** request);
   // Perform a flush/fence to make sure all data received with NCCL_PTR_CUDA is
   // visible to the GPU
   ncclResult_t (*iflush)(void* recvComm, int n, void** data, int* sizes, void** mhandles, void** request);
@@ -164,19 +167,19 @@ typedef struct {
   // Register/Deregister memory. Type is either NCCL_PTR_HOST or NCCL_PTR_CUDA.
   ncclResult_t (*regMr)(void* collComm, void* data, size_t size, int type, void** mhandle);
   /* DMA-BUF support */
-  ncclResult_t (*regMrDmaBuf)(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd, void** mhandle);
+  ncclResult_t (*regMrDmaBuf)(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd,
+                              void** mhandle);
   ncclResult_t (*deregMr)(void* collComm, void* mhandle);
   // Performs an asynchronous allreduce operation on the collective group.
   // May return request == NULL if the call cannot be performed (or would block).
-  ncclResult_t (*iallreduce)(void* collComm, void* sendData, void* recvData, size_t count,
-      ncclDataType_t dataType, ncclRedOp_t redOp, void* sendMhandle, void* recvMhandle, void** request);
+  ncclResult_t (*iallreduce)(void* collComm, void* sendData, void* recvData, size_t count, ncclDataType_t dataType,
+                             ncclRedOp_t redOp, void* sendMhandle, void* recvMhandle, void** request);
   ncclResult_t (*iallgather)(void* collComm, void* sendData, int nRecvParts, ncclNetSGE_v12_t* recvParts,
-                             size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
-                             void* sendMhandle, void** request);
+                             size_t bytesPerRank, size_t windowOffset, size_t windowBytes, void* sendMhandle,
+                             void** request);
   ncclResult_t (*ireducescatter)(void* collComm, int nSendParts, ncclNetSGE_v12_t* sendParts, void* recvData,
-                                 size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
-                                 ncclDataType_t dataType, ncclRedOp_t redOp,
-                                 void* recvMhandle, void** request);
+                                 size_t bytesPerRank, size_t windowOffset, size_t windowBytes, ncclDataType_t dataType,
+                                 ncclRedOp_t redOp, void* recvMhandle, void** request);
   // Perform a flush/fence to make sure all data received with NCCL_PTR_CUDA is
   // visible to the GPU
   ncclResult_t (*iflush)(void* collComm, void* data, int size, void* mhandle, void** request);

--- a/projects/rccl/src/include/plugin/net/net_v6.h
+++ b/projects/rccl/src/include/plugin/net/net_v6.h
@@ -94,12 +94,13 @@ typedef struct {
   // Register/Deregister memory. Type is either NCCL_PTR_HOST or NCCL_PTR_CUDA.
   ncclResult_t (*regMr)(void* collComm, void* data, int size, int type, void** mhandle);
   /* DMA-BUF support */
-  ncclResult_t (*regMrDmaBuf)(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd, void** mhandle);
+  ncclResult_t (*regMrDmaBuf)(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd,
+                              void** mhandle);
   ncclResult_t (*deregMr)(void* collComm, void* mhandle);
   // Performs an asynchronous allreduce operation on the collective group.
   // May return request == NULL if the call cannot be performed (or would block).
-  ncclResult_t (*iallreduce)(void* collComm, void* sendData, void* recvData, int count,
-      ncclDataType_t dataType, ncclRedOp_t redOp, void* sendMhandle, void* recvMhandle, void** request);
+  ncclResult_t (*iallreduce)(void* collComm, void* sendData, void* recvData, int count, ncclDataType_t dataType,
+                             ncclRedOp_t redOp, void* sendMhandle, void* recvMhandle, void** request);
   // Perform a flush/fence to make sure all data received with NCCL_PTR_CUDA is
   // visible to the GPU
   ncclResult_t (*iflush)(void* collComm, void* data, int size, void* mhandle, void** request);

--- a/projects/rccl/src/include/plugin/net/net_v7.h
+++ b/projects/rccl/src/include/plugin/net/net_v7.h
@@ -101,12 +101,13 @@ typedef struct {
   // Register/Deregister memory. Type is either NCCL_PTR_HOST or NCCL_PTR_CUDA.
   ncclResult_t (*regMr)(void* collComm, void* data, int size, int type, void** mhandle);
   /* DMA-BUF support */
-  ncclResult_t (*regMrDmaBuf)(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd, void** mhandle);
+  ncclResult_t (*regMrDmaBuf)(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd,
+                              void** mhandle);
   ncclResult_t (*deregMr)(void* collComm, void* mhandle);
   // Performs an asynchronous allreduce operation on the collective group.
   // May return request == NULL if the call cannot be performed (or would block).
-  ncclResult_t (*iallreduce)(void* collComm, void* sendData, void* recvData, int count,
-      ncclDataType_t dataType, ncclRedOp_t redOp, void* sendMhandle, void* recvMhandle, void** request);
+  ncclResult_t (*iallreduce)(void* collComm, void* sendData, void* recvData, int count, ncclDataType_t dataType,
+                             ncclRedOp_t redOp, void* sendMhandle, void* recvMhandle, void** request);
   // Perform a flush/fence to make sure all data received with NCCL_PTR_CUDA is
   // visible to the GPU
   ncclResult_t (*iflush)(void* collComm, void* data, int size, void* mhandle, void** request);

--- a/projects/rccl/src/include/plugin/net/net_v8.h
+++ b/projects/rccl/src/include/plugin/net/net_v8.h
@@ -108,19 +108,19 @@ typedef struct {
   // Register/Deregister memory. Type is either NCCL_PTR_HOST or NCCL_PTR_CUDA.
   ncclResult_t (*regMr)(void* collComm, void* data, size_t size, int type, void** mhandle);
   /* DMA-BUF support */
-  ncclResult_t (*regMrDmaBuf)(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd, void** mhandle);
+  ncclResult_t (*regMrDmaBuf)(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd,
+                              void** mhandle);
   ncclResult_t (*deregMr)(void* collComm, void* mhandle);
   // Performs an asynchronous allreduce operation on the collective group.
   // May return request == NULL if the call cannot be performed (or would block).
-  ncclResult_t (*iallreduce)(void* collComm, void* sendData, void* recvData, int count,
-      ncclDataType_t dataType, ncclRedOp_t redOp, void* sendMhandle, void* recvMhandle, void** request);
+  ncclResult_t (*iallreduce)(void* collComm, void* sendData, void* recvData, int count, ncclDataType_t dataType,
+                             ncclRedOp_t redOp, void* sendMhandle, void* recvMhandle, void** request);
   ncclResult_t (*iallgather)(void* collComm, void* sendData, int nRecvParts, ncclNetSGE_v8_t* recvParts,
-                             size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
-                             void* sendMhandle, void** request);
+                             size_t bytesPerRank, size_t windowOffset, size_t windowBytes, void* sendMhandle,
+                             void** request);
   ncclResult_t (*ireducescatter)(void* collComm, int nSendParts, ncclNetSGE_v8_t* sendParts, void* recvData,
-                                 size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
-                                 ncclDataType_t dataType, ncclRedOp_t redOp,
-                                 void* recvMhandle, void** request);
+                                 size_t bytesPerRank, size_t windowOffset, size_t windowBytes, ncclDataType_t dataType,
+                                 ncclRedOp_t redOp, void* recvMhandle, void** request);
   // Perform a flush/fence to make sure all data received with NCCL_PTR_CUDA is
   // visible to the GPU
   ncclResult_t (*iflush)(void* collComm, void* data, int size, void* mhandle, void** request);

--- a/projects/rccl/src/include/plugin/net/net_v9.h
+++ b/projects/rccl/src/include/plugin/net/net_v9.h
@@ -121,19 +121,19 @@ typedef struct {
   // Register/Deregister memory. Type is either NCCL_PTR_HOST or NCCL_PTR_CUDA.
   ncclResult_t (*regMr)(void* collComm, void* data, size_t size, int type, void** mhandle);
   /* DMA-BUF support */
-  ncclResult_t (*regMrDmaBuf)(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd, void** mhandle);
+  ncclResult_t (*regMrDmaBuf)(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd,
+                              void** mhandle);
   ncclResult_t (*deregMr)(void* collComm, void* mhandle);
   // Performs an asynchronous allreduce operation on the collective group.
   // May return request == NULL if the call cannot be performed (or would block).
-  ncclResult_t (*iallreduce)(void* collComm, void* sendData, void* recvData, size_t count,
-      ncclDataType_t dataType, ncclRedOp_t redOp, void* sendMhandle, void* recvMhandle, void** request);
+  ncclResult_t (*iallreduce)(void* collComm, void* sendData, void* recvData, size_t count, ncclDataType_t dataType,
+                             ncclRedOp_t redOp, void* sendMhandle, void* recvMhandle, void** request);
   ncclResult_t (*iallgather)(void* collComm, void* sendData, int nRecvParts, ncclNetSGE_v9_t* recvParts,
-                             size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
-                             void* sendMhandle, void** request);
+                             size_t bytesPerRank, size_t windowOffset, size_t windowBytes, void* sendMhandle,
+                             void** request);
   ncclResult_t (*ireducescatter)(void* collComm, int nSendParts, ncclNetSGE_v9_t* sendParts, void* recvData,
-                                 size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
-                                 ncclDataType_t dataType, ncclRedOp_t redOp,
-                                 void* recvMhandle, void** request);
+                                 size_t bytesPerRank, size_t windowOffset, size_t windowBytes, ncclDataType_t dataType,
+                                 ncclRedOp_t redOp, void* recvMhandle, void** request);
   // Perform a flush/fence to make sure all data received with NCCL_PTR_CUDA is
   // visible to the GPU
   ncclResult_t (*iflush)(void* collComm, void* data, int size, void* mhandle, void** request);

--- a/projects/rccl/src/include/plugin/profiler/profiler_v1.h
+++ b/projects/rccl/src/include/plugin/profiler/profiler_v1.h
@@ -97,7 +97,8 @@ typedef struct {
   //  - eHandle   : handle to event object created through startEvent
   //  - eStateArgs: optional argument used to capture event attribute updates associated with the state transition
   //  - eState    : event state transition
-  ncclResult_t (*recordEventState)(void* eHandle, ncclProfilerEventState_v1_t eState, ncclProfilerEventStateArgs_v1_t* eStateArgs);
+  ncclResult_t (*recordEventState)(void* eHandle, ncclProfilerEventState_v1_t eState,
+                                   ncclProfilerEventStateArgs_v1_t* eStateArgs);
 
   // finalize - finalize the profiler plugin
   // Input

--- a/projects/rccl/src/include/plugin/profiler/profiler_v2.h
+++ b/projects/rccl/src/include/plugin/profiler/profiler_v2.h
@@ -94,7 +94,8 @@ typedef struct {
   //  - eHandle   : handle to event object created through startEvent
   //  - eStateArgs: optional argument used to capture event attribute updates associated with the state transition
   //  - eState    : event state transition
-  ncclResult_t (*recordEventState)(void* eHandle, ncclProfilerEventState_v2_t eState, ncclProfilerEventStateArgs_v2_t* eStateArgs);
+  ncclResult_t (*recordEventState)(void* eHandle, ncclProfilerEventState_v2_t eState,
+                                   ncclProfilerEventStateArgs_v2_t* eStateArgs);
 
   // finalize - finalize the profiler plugin
   // Input

--- a/projects/rccl/src/include/plugin/profiler/profiler_v3.h
+++ b/projects/rccl/src/include/plugin/profiler/profiler_v3.h
@@ -102,7 +102,8 @@ typedef struct {
   //  - eHandle   : handle to event object created through startEvent
   //  - eStateArgs: optional argument used to capture event attribute updates associated with the state transition
   //  - eState    : event state transition
-  ncclResult_t (*recordEventState)(void* eHandle, ncclProfilerEventState_v3_t eState, ncclProfilerEventStateArgs_v3_t* eStateArgs);
+  ncclResult_t (*recordEventState)(void* eHandle, ncclProfilerEventState_v3_t eState,
+                                   ncclProfilerEventStateArgs_v3_t* eStateArgs);
 
   // finalize - finalize the profiler plugin
   // Input

--- a/projects/rccl/src/include/plugin/profiler/profiler_v4.h
+++ b/projects/rccl/src/include/plugin/profiler/profiler_v4.h
@@ -93,7 +93,8 @@ typedef struct {
   //  - logfn          : logger function
   // Output
   //  - eActivationMask: bitmask of active events set by the plugin
-  ncclResult_t (*init)(void** context, int* eActivationMask, const char* commName, uint64_t commHash, int nNodes, int nranks, int rank, ncclDebugLogger_t logfn);
+  ncclResult_t (*init)(void** context, int* eActivationMask, const char* commName, uint64_t commHash, int nNodes,
+                       int nranks, int rank, ncclDebugLogger_t logfn);
 
   // startEvent - initialize and start a new event for the supplied event descriptor inside the eventset
   // Input
@@ -113,7 +114,8 @@ typedef struct {
   //  - eHandle   : handle to event object created through startEvent
   //  - eStateArgs: optional argument used to capture event attribute updates associated with the state transition
   //  - eState    : event state transition
-  ncclResult_t (*recordEventState)(void* eHandle, ncclProfilerEventState_v4_t eState, ncclProfilerEventStateArgs_v4_t* eStateArgs);
+  ncclResult_t (*recordEventState)(void* eHandle, ncclProfilerEventState_v4_t eState,
+                                   ncclProfilerEventStateArgs_v4_t* eStateArgs);
 
   // finalize - finalize the profiler plugin
   // Input

--- a/projects/rccl/src/include/plugin/profiler/profiler_v5.h
+++ b/projects/rccl/src/include/plugin/profiler/profiler_v5.h
@@ -121,7 +121,8 @@ typedef struct {
   //  - logfn          : logger function
   // Output
   //  - eActivationMask: bitmask of active events set by the plugin
-  ncclResult_t (*init)(void** context, uint64_t commId, int* eActivationMask, const char* commName, int nNodes, int nranks, int rank, ncclDebugLogger_t logfn);
+  ncclResult_t (*init)(void** context, uint64_t commId, int* eActivationMask, const char* commName, int nNodes,
+                       int nranks, int rank, ncclDebugLogger_t logfn);
 
   // startEvent - initialize and start a new event for the supplied event descriptor inside the eventset
   // Input
@@ -141,7 +142,8 @@ typedef struct {
   //  - eHandle   : handle to event object created through startEvent
   //  - eStateArgs: optional argument used to capture event attribute updates associated with the state transition
   //  - eState    : event state transition
-  ncclResult_t (*recordEventState)(void* eHandle, ncclProfilerEventState_v5_t eState, ncclProfilerEventStateArgs_v5_t* eStateArgs);
+  ncclResult_t (*recordEventState)(void* eHandle, ncclProfilerEventState_v5_t eState,
+                                   ncclProfilerEventStateArgs_v5_t* eStateArgs);
 
   // finalize - finalize the profiler plugin
   // Input

--- a/projects/rccl/src/include/plugin/profiler/profiler_v6.h
+++ b/projects/rccl/src/include/plugin/profiler/profiler_v6.h
@@ -162,13 +162,15 @@ typedef union {
 typedef struct {
   const char* name;
 
-  ncclResult_t (*init)(void** context, uint64_t commId, int* eActivationMask, const char* commName, int nNodes, int nranks, int rank, ncclDebugLogger_t logfn);
+  ncclResult_t (*init)(void** context, uint64_t commId, int* eActivationMask, const char* commName, int nNodes,
+                       int nranks, int rank, ncclDebugLogger_t logfn);
 
   ncclResult_t (*startEvent)(void* context, void** eHandle, ncclProfilerEventDescr_v6_t* eDescr);
 
   ncclResult_t (*stopEvent)(void* eHandle);
 
-  ncclResult_t (*recordEventState)(void* eHandle, ncclProfilerEventState_v6_t eState, ncclProfilerEventStateArgs_v6_t* eStateArgs);
+  ncclResult_t (*recordEventState)(void* eHandle, ncclProfilerEventState_v6_t eState,
+                                   ncclProfilerEventStateArgs_v6_t* eStateArgs);
 
   ncclResult_t (*finalize)(void* context);
 } ncclProfiler_v6_t;

--- a/projects/rccl/src/include/plugin/tuner/tuner_v2.h
+++ b/projects/rccl/src/include/plugin/tuner/tuner_v2.h
@@ -21,7 +21,7 @@ typedef struct {
   //   - logFunction: a logFunction can be useful to integrate logging together with NCCL core.
   // Outputs:
   //   - context: tuner context object
-  ncclResult_t (*init)(size_t nRanks, size_t nNodes, ncclDebugLogger_t logFunction, void **context);
+  ncclResult_t (*init)(size_t nRanks, size_t nNodes, ncclDebugLogger_t logFunction, void** context);
 
   // Gets info (algo, protocol, number of ctas and threads) for a given collective.
   // Inputs:
@@ -42,9 +42,8 @@ typedef struct {
   // Also, the plugin is allowed to not set any output, or set only the
   // algorithm and protocol, but not only the algorithm or only the protocol.
   // Unset fields will be set automatically by NCCL.
-  ncclResult_t (*getCollInfo)(void* context, ncclFunc_t collType, size_t nBytes,
-                              int collNetSupport, int nvlsSupport, int numPipeOps,
-                              int* algorithm, int* protocol, int* nChannels);
+  ncclResult_t (*getCollInfo)(void* context, ncclFunc_t collType, size_t nBytes, int collNetSupport, int nvlsSupport,
+                              int numPipeOps, int* algorithm, int* protocol, int* nChannels);
 
   // Terminates the plugin and cleans up any resources that the plugin allocated.
   // context: tuner context object

--- a/projects/rccl/src/include/plugin/tuner/tuner_v3.h
+++ b/projects/rccl/src/include/plugin/tuner/tuner_v3.h
@@ -21,7 +21,7 @@ typedef struct {
   //   - logFunction: a logFunction can be useful to integrate logging together with NCCL core.
   // Outputs:
   //   - context: tuner context object
-  ncclResult_t (*init)(size_t nRanks, size_t nNodes, ncclDebugLogger_t logFunction, void **context);
+  ncclResult_t (*init)(size_t nRanks, size_t nNodes, ncclDebugLogger_t logFunction, void** context);
 
   // Gets info (algo, protocol, number of ctas and threads) for a given collective.
   // Inputs:
@@ -44,9 +44,8 @@ typedef struct {
   // Also, the plugin is allowed to not set any output, or set only the
   // algorithm and protocol, but not only the algorithm or only the protocol.
   // Unset fields will be set automatically by NCCL.
-  ncclResult_t (*getCollInfo)(void* context, ncclFunc_t collType, size_t nBytes,
-                              int numPipeOps, float** collCostTable, int numAlgo, int numProto,
-                              int* nChannels);
+  ncclResult_t (*getCollInfo)(void* context, ncclFunc_t collType, size_t nBytes, int numPipeOps, float** collCostTable,
+                              int numAlgo, int numProto, int* nChannels);
 
   // Terminates the plugin and cleans up any resources that the plugin allocated.
   // context: tuner context object

--- a/projects/rccl/src/include/plugin/tuner/tuner_v4.h
+++ b/projects/rccl/src/include/plugin/tuner/tuner_v4.h
@@ -21,7 +21,7 @@ typedef struct {
   //   - logFunction: a logFunction can be useful to integrate logging together with NCCL core.
   // Outputs:
   //   - context: tuner context object
-  ncclResult_t (*init)(size_t nRanks, size_t nNodes, ncclDebugLogger_t logFunction, void **context);
+  ncclResult_t (*init)(size_t nRanks, size_t nNodes, ncclDebugLogger_t logFunction, void** context);
 
   // Gets info (algo, protocol, number of ctas and threads) for a given collective.
   // Inputs:
@@ -45,9 +45,8 @@ typedef struct {
   // Also, the plugin is allowed to not set any output, or set only the
   // algorithm and protocol, but not only the algorithm or only the protocol.
   // Unset fields will be set automatically by NCCL.
-  ncclResult_t (*getCollInfo)(void* context, ncclFunc_t collType, size_t nBytes,
-                              int numPipeOps, float** collCostTable, int numAlgo, int numProto,
-                              int regBuff, int* nChannels);
+  ncclResult_t (*getCollInfo)(void* context, ncclFunc_t collType, size_t nBytes, int numPipeOps, float** collCostTable,
+                              int numAlgo, int numProto, int regBuff, int* nChannels);
 
   // Terminates the plugin and cleans up any resources that the plugin allocated.
   // context: tuner context object

--- a/projects/rccl/src/include/plugin/tuner/tuner_v5.h
+++ b/projects/rccl/src/include/plugin/tuner/tuner_v5.h
@@ -23,15 +23,15 @@ typedef struct {
 #define NCCL_NUM_TUNING_SCALES_V5 3
 
 typedef struct {
-  double baseLatencies [NCCL_NUM_ALGORITHMS_V5][NCCL_NUM_PROTOCOLS_V5];
-  double hwLatencies [NCCL_NUM_HW_LINKS_V5][NCCL_NUM_ALGORITHMS_V5][NCCL_NUM_PROTOCOLS_V5];
+  double baseLatencies[NCCL_NUM_ALGORITHMS_V5][NCCL_NUM_PROTOCOLS_V5];
+  double hwLatencies[NCCL_NUM_HW_LINKS_V5][NCCL_NUM_ALGORITHMS_V5][NCCL_NUM_PROTOCOLS_V5];
 
-  double llMaxBws [NCCL_NUM_COMPCAPS_V5][NCCL_NUM_TUNING_SCALES_V5];
-  double perChMaxRingLL128Bws [NCCL_NUM_COMPCAPS_V5][NCCL_NUM_TUNING_SCALES_V5];
-  double perChMaxTreeLL128Bws [NCCL_NUM_COMPCAPS_V5][NCCL_NUM_TUNING_SCALES_V5];
-  double perChMaxTreeBws [NCCL_NUM_COMPCAPS_V5][NCCL_NUM_TUNING_SCALES_V5];
-  double perChMaxNVLSTreeBws [NCCL_NUM_COMPCAPS_V5][NCCL_NUM_TUNING_SCALES_V5];
-  double bwRatio [2][NCCL_NUM_ALGORITHMS_V5][NCCL_NUM_PROTOCOLS_V5];
+  double llMaxBws[NCCL_NUM_COMPCAPS_V5][NCCL_NUM_TUNING_SCALES_V5];
+  double perChMaxRingLL128Bws[NCCL_NUM_COMPCAPS_V5][NCCL_NUM_TUNING_SCALES_V5];
+  double perChMaxTreeLL128Bws[NCCL_NUM_COMPCAPS_V5][NCCL_NUM_TUNING_SCALES_V5];
+  double perChMaxTreeBws[NCCL_NUM_COMPCAPS_V5][NCCL_NUM_TUNING_SCALES_V5];
+  double perChMaxNVLSTreeBws[NCCL_NUM_COMPCAPS_V5][NCCL_NUM_TUNING_SCALES_V5];
+  double bwRatio[2][NCCL_NUM_ALGORITHMS_V5][NCCL_NUM_PROTOCOLS_V5];
 } ncclTunerConstants_v5_t;
 
 // API to be implemented by external tuner
@@ -51,7 +51,7 @@ typedef struct {
   // Input/Output:
   //   - constants: tuner constants
   ncclResult_t (*init)(void** ctx, uint64_t commId, size_t nRanks, size_t nNodes, ncclDebugLogger_t logFunction,
-                      ncclNvlDomainInfo_v5_t* nvlDomainInfo, ncclTunerConstants_v5_t* constants);
+                       ncclNvlDomainInfo_v5_t* nvlDomainInfo, ncclTunerConstants_v5_t* constants);
 
   // Gets info (algo, protocol, number of ctas and threads) for a given collective.
   // Inputs:
@@ -75,9 +75,8 @@ typedef struct {
   // Also, the plugin is allowed to not set any output, or set only the
   // algorithm and protocol, but not only the algorithm or only the protocol.
   // Unset fields will be set automatically by NCCL.
-  ncclResult_t (*getCollInfo)(void* context, ncclFunc_t collType, size_t nBytes,
-                              int numPipeOps, float** collCostTable, int numAlgo, int numProto,
-                              int regBuff, int* nChannels);
+  ncclResult_t (*getCollInfo)(void* context, ncclFunc_t collType, size_t nBytes, int numPipeOps, float** collCostTable,
+                              int numAlgo, int numProto, int regBuff, int* nChannels);
 
   // Terminates the plugin and cleans up any resources that the plugin allocated.
   // context: tuner context object

--- a/projects/rccl/src/include/plugin/tuner/tuner_v6.h
+++ b/projects/rccl/src/include/plugin/tuner/tuner_v6.h
@@ -32,7 +32,7 @@ typedef struct {
   // Input/Output:
   //   - constants: tuner constants
   ncclResult_t (*init)(void** ctx, uint64_t commId, size_t nRanks, size_t nNodes, ncclDebugLogger_t logFunction,
-                      ncclNvlDomainInfo_v6_t* nvlDomainInfo, ncclTunerConstants_v6_t* constants);
+                       ncclNvlDomainInfo_v6_t* nvlDomainInfo, ncclTunerConstants_v6_t* constants);
 
   // Gets info (algo, protocol, number of ctas and threads) for a given collective.
   // Inputs:
@@ -56,9 +56,8 @@ typedef struct {
   // Also, the plugin is allowed to not set any output, or set only the
   // algorithm and protocol, but not only the algorithm or only the protocol.
   // Unset fields will be set automatically by NCCL.
-  ncclResult_t (*getCollInfo)(void* context, ncclFunc_t collType, size_t nBytes,
-                              int numPipeOps, float** collCostTable, int numAlgo, int numProto,
-                              int regBuff, int* nChannels);
+  ncclResult_t (*getCollInfo)(void* context, ncclFunc_t collType, size_t nBytes, int numPipeOps, float** collCostTable,
+                              int numAlgo, int numProto, int regBuff, int* nChannels);
 
   // Terminates the plugin and cleans up any resources that the plugin allocated.
   // context: tuner context object
@@ -77,8 +76,8 @@ typedef struct {
   //   - chunkSize: pointer to the chunk size computed by NCCL. The plugin can
   //                read and modify this value. NCCL will clamp the result to
   //                the maximum allowed chunk size based on buffer constraints.
-  ncclResult_t (*getChunkSize)(void* context, ncclFunc_t collType, size_t nBytes,
-                               int algo, int proto, int nChannels, size_t* chunkSize);
+  ncclResult_t (*getChunkSize)(void* context, ncclFunc_t collType, size_t nBytes, int algo, int proto, int nChannels,
+                               size_t* chunkSize);
 } ncclTuner_v6_t;
 
 #endif

--- a/projects/rccl/src/include/profiler.h
+++ b/projects/rccl/src/include/profiler.h
@@ -22,15 +22,15 @@ struct ncclProxyConnector;
 
 struct ncclProfilerProxy {
   bool initialized;
-  struct ncclDevProfiler* workStarted/*[MAXCHANNELS]*/;
-  struct ncclDevProfiler* workCompleted/*[MAXCHANNELS]*/;
+  struct ncclDevProfiler* workStarted /*[MAXCHANNELS]*/;
+  struct ncclDevProfiler* workCompleted /*[MAXCHANNELS]*/;
   uint64_t workCounter[MAXCHANNELS]; // host work counter
   struct ncclProxyConnector sendProxyConn[MAXCHANNELS];
   struct ncclProxyConnector recvProxyConn[MAXCHANNELS];
 };
 
 enum groupApiState {
-  ncclProfilerGroupApiStartStateReset   = 0,
+  ncclProfilerGroupApiStartStateReset = 0,
   ncclProfilerGroupApiStartStateStarted = 1,
   ncclProfilerGroupApiStartStateStopped = 2,
 };
@@ -40,10 +40,10 @@ typedef struct ncclProfilerApiState {
   int profilerGroupDepth;
   int eActivationMask;
   groupApiState state;
-  void *groupApiEventHandle;
+  void* groupApiEventHandle;
   // Tracks the latest API event handles for p2p/collectives
   void* p2pApiEventHandle;
-  void *collApiEventHandle;
+  void* collApiEventHandle;
 } ncclProfilerApiState_t;
 
 extern thread_local ncclProfilerApiState_t ncclProfilerApiState;
@@ -55,16 +55,16 @@ ncclResult_t ncclProfilerPluginInit(struct ncclComm* comm);
 ncclResult_t ncclProfilerPluginFinalize(struct ncclComm* comm);
 
 // Profiler Start/Stop/Record wrappers for ncclGroupStart and ncclGroupEnd API calls
-ncclResult_t ncclProfilerStartGroupApiEvent(struct ncclInfo *info, bool isGraphCaptured);
+ncclResult_t ncclProfilerStartGroupApiEvent(struct ncclInfo* info, bool isGraphCaptured);
 ncclResult_t ncclProfilerStopGroupApiEvent();
 ncclResult_t ncclProfilerRecordGroupApiEventState(ncclProfilerEventState_t eState);
 
-//Profiler Start/Stop wrappers for P2p API calls
-ncclResult_t ncclProfilerStartP2pApiEvent(struct ncclInfo *info, bool isGraphCaptured);
+// Profiler Start/Stop wrappers for P2p API calls
+ncclResult_t ncclProfilerStartP2pApiEvent(struct ncclInfo* info, bool isGraphCaptured);
 ncclResult_t ncclProfilerStopP2pApiEvent();
 
-//Profiler Start/Stop wrappers for Collective API calls
-ncclResult_t ncclProfilerStartCollApiEvent(struct ncclInfo *info, bool isGraphCaptured);
+// Profiler Start/Stop wrappers for Collective API calls
+ncclResult_t ncclProfilerStartCollApiEvent(struct ncclInfo* info, bool isGraphCaptured);
 ncclResult_t ncclProfilerStopCollApiEvent();
 
 // Kernel Launch Start/Stop Event Wrappers
@@ -98,8 +98,9 @@ ncclResult_t ncclProfilerStopKernelChEvent(struct ncclProxyArgs* args, int s, ui
 
 // Record Event Wrappers
 ncclResult_t ncclProfilerRecordProxyOpEventState(int sub, struct ncclProxyArgs* args, ncclProfilerEventState_t eState);
-ncclResult_t ncclProfilerRecordProxyStepEventState(int sub, struct ncclProxyArgs* args, int stepId, ncclProfilerEventState_t eState);
-ncclResult_t ncclProfilerRecordProxyCtrlEventState(void*eHandle, int appended, ncclProfilerEventState_t eState);
+ncclResult_t ncclProfilerRecordProxyStepEventState(int sub, struct ncclProxyArgs* args, int stepId,
+                                                   ncclProfilerEventState_t eState);
+ncclResult_t ncclProfilerRecordProxyCtrlEventState(void* eHandle, int appended, ncclProfilerEventState_t eState);
 
 // Profiler utility functions
 ncclResult_t ncclProfilerAddPidToProxyOp(struct ncclProxyOp* op);
@@ -128,9 +129,12 @@ struct ncclCeBatchOpsParams;
 // CE profiler event start/stop functions (simple wrappers that call plugin callbacks)
 ncclResult_t ncclProfilerStartCeCollEvent(struct ncclComm* comm, struct ncclCeCollArgs* args, cudaStream_t stream);
 ncclResult_t ncclProfilerStopCeCollEvent(struct ncclComm* comm, struct ncclCeCollArgs* args, cudaStream_t stream);
-ncclResult_t ncclProfilerStartCeSyncEvent(struct ncclComm* comm, struct ncclCeCollArgs* args, cudaStream_t stream, void** ceSyncHandle);
+ncclResult_t ncclProfilerStartCeSyncEvent(struct ncclComm* comm, struct ncclCeCollArgs* args, cudaStream_t stream,
+                                          void** ceSyncHandle);
 ncclResult_t ncclProfilerStopCeSyncEvent(struct ncclComm* comm, void* ceSyncHandle, cudaStream_t stream);
-ncclResult_t ncclProfilerStartCeBatchEvent(struct ncclComm* comm, struct ncclCeCollArgs* args, struct ncclCeBatchOpsParams* params, cudaStream_t stream, void** ceBatchHandle);
+ncclResult_t ncclProfilerStartCeBatchEvent(struct ncclComm* comm, struct ncclCeCollArgs* args,
+                                           struct ncclCeBatchOpsParams* params, cudaStream_t stream,
+                                           void** ceBatchHandle);
 ncclResult_t ncclProfilerStopCeBatchEvent(struct ncclComm* comm, void* ceBatchHandle, cudaStream_t stream);
 
 #endif

--- a/projects/rccl/src/include/proxy.h
+++ b/projects/rccl/src/include/proxy.h
@@ -57,14 +57,21 @@ typedef enum : uint8_t {
   ncclPatternProfiler,
 } ncclPattern_t;
 
-enum ncclProxyOpState { ncclProxyOpNone, ncclProxyOpReady, ncclProxyOpProgress };
-enum { proxyRecv=0, proxySend=1 };
+enum ncclProxyOpState {
+  ncclProxyOpNone,
+  ncclProxyOpReady,
+  ncclProxyOpProgress
+};
+enum {
+  proxyRecv = 0,
+  proxySend = 1
+};
 
 struct ncclProxyArgs;
 typedef ncclResult_t (*proxyProgressFunc_t)(struct ncclProxyState*, struct ncclProxyArgs*);
 
 #define NCCL_PROXY_MAX_SUBS MAXCHANNELS
-static_assert(2*NCCL_MAX_DEV_WORK_P2P_PER_BATCH <= MAXCHANNELS, "Not enough sub space for max work elements");
+static_assert(2 * NCCL_MAX_DEV_WORK_P2P_PER_BATCH <= MAXCHANNELS, "Not enough sub space for max work elements");
 
 union ncclProxyOpSpecifics {
   struct {
@@ -108,7 +115,7 @@ struct ncclProxyOp {
   uint8_t* sendbuff;
   uint8_t* recvbuff;
   int isOneRPN;
-  RingAlgorithm *ringAlgo;
+  RingAlgorithm* ringAlgo;
   int nextRank;
   int prevRank;
   union ncclProxyOpSpecifics specifics;
@@ -135,7 +142,7 @@ struct ncclProxyOp {
   void* profilerContext;
   uint64_t workCounter;
 
-  struct ncclProxyOp *enqNext;
+  struct ncclProxyOp* enqNext;
 
   // Used to track total real bytes of this op
   uint32_t totalBytes;
@@ -167,7 +174,7 @@ struct ncclProxySubArgs {
   ssize_t chunkSize;
   int peer;
   int isOneRPN;
-  RingAlgorithm *ringAlgo;
+  RingAlgorithm* ringAlgo;
   int groupSize; // Number of consecutive sub operations sharing the same recvComm
   uint64_t base;
   uint64_t posted;
@@ -246,10 +253,10 @@ struct ncclProxyArgs {
 // Make sure we have enough to store two full rounds of operations on all channels.
 // Otherwise we'd be unable to post half of them to free new elements. Each
 // p2p work contains a send and recv proxy op hence the 2x before it.
-#define MAX_OPS_PER_PEER (2*MAXCHANNELS*2*NCCL_MAX_DEV_WORK_P2P_PER_BATCH)
+#define MAX_OPS_PER_PEER (2 * MAXCHANNELS * 2 * NCCL_MAX_DEV_WORK_P2P_PER_BATCH)
 
 struct ncclProxyOpsPool {
-  struct ncclProxyOp ops[MAX_OPS_PER_PEER*NCCL_MAX_LOCAL_RANKS];
+  struct ncclProxyOp ops[MAX_OPS_PER_PEER * NCCL_MAX_LOCAL_RANKS];
   volatile int nextOps;
   volatile int nextOpsEnd;
   volatile int freeOps[NCCL_MAX_LOCAL_RANKS];
@@ -273,7 +280,7 @@ struct ncclProxySharedP2p {
   char* hostBuff;
   // CUDA IPC
   ncclIpcDesc ipcDesc;
-  int dmaBufFd;  // DMA-BUF fd for cuMem allocations
+  int dmaBufFd; // DMA-BUF fd for cuMem allocations
   struct ncclProxyArgs* proxyAppend[MAXCHANNELS]; // Separate send and recv
 };
 
@@ -310,11 +317,11 @@ struct ncclProxyProgressState {
 
 // Expected proxy response fifo
 struct ncclExpectedProxyResponse {
-  void*                             opId;
-  int                               respSize;
-  bool                              done;
-  void*                             respBuff;
-  ncclResult_t                      res;
+  void* opId;
+  int respSize;
+  bool done;
+  void* respBuff;
+  ncclResult_t res;
   struct ncclExpectedProxyResponse* next;
 };
 
@@ -349,7 +356,7 @@ struct ncclIpcHdr {
   int rank;
   int reqSize;
   int respSize;
-  void *opId;
+  void* opId;
   uint64_t data[16]; // 128-bytes
 };
 
@@ -371,7 +378,7 @@ struct ncclProxyState {
   struct ncclGinState* ginState;
   uint32_t* abortFlag;
   bool directMode;
-  struct ncclMemManager* memManager;  // Shared memory manager for proxy allocations
+  struct ncclMemManager* memManager; // Shared memory manager for proxy allocations
   // Service threads
   std::thread thread;
   std::thread threadUDS;
@@ -387,9 +394,10 @@ struct ncclProxyState {
   struct ncclSocket* peerSocks;
   struct ncclProxyOps* proxyOps;
   void** sharedDevMems;
-  int peerArraySize;  // Size of peerSocks/proxyOps/sharedDevMems arrays (nRanks for cross-clique, tpNLocalRanks otherwise)
+  int
+    peerArraySize; // Size of peerSocks/proxyOps/sharedDevMems arrays (nRanks for cross-clique, tpNLocalRanks otherwise)
   struct ncclIpcSocket peerIpcSock; // cuMEM API support (UDS)
-  uint64_t *peerAddressesUDS; // cuMem API support (UDS)
+  uint64_t* peerAddressesUDS; // cuMem API support (UDS)
 
   // Progress thread
   struct ncclProxyProgressState progressState;
@@ -417,12 +425,12 @@ struct ncclProxyState {
 };
 
 enum proxyConnectState {
-  connUninitialized     = 0,
-  connInitialized       = 1,
+  connUninitialized = 0,
+  connInitialized = 1,
   connSharedInitialized = 2,
-  connSetupDone         = 3,
-  connConnected         = 4,
-  numConnStates         = 5
+  connSetupDone = 3,
+  connConnected = 4,
+  numConnStates = 5
 };
 
 struct proxyMemHandle {
@@ -435,8 +443,8 @@ struct ncclProxyConnection {
   int tpLocalRank, sameProcess;
   struct ncclSocket* sock;
   struct ncclTransportComm* tcomm;
-  struct ncclProxyArgs *proxyAppend;
-  struct ncclProxyArgs **proxyAppendPtr;
+  struct ncclProxyArgs* proxyAppend;
+  struct ncclProxyArgs** proxyAppendPtr;
   void* transportResources;
   ncclNetDeviceHandle_t* netDeviceHandle;
   void* mhandles[NCCL_NUM_PROTOCOLS];
@@ -447,8 +455,8 @@ struct ncclProxyConnection {
 };
 
 #define NCCL_PROXY_CONN_POOL_SIZE_POW2 7
-#define NCCL_PROXY_CONN_POOL_SIZE      (1 << NCCL_PROXY_CONN_POOL_SIZE_POW2)
-#define NCCL_PROXY_CONN_POOL_MASK      (NCCL_PROXY_CONN_POOL_SIZE - 1)
+#define NCCL_PROXY_CONN_POOL_SIZE (1 << NCCL_PROXY_CONN_POOL_SIZE_POW2)
+#define NCCL_PROXY_CONN_POOL_MASK (NCCL_PROXY_CONN_POOL_SIZE - 1)
 struct ncclProxyConnectionPool {
   struct ncclProxyConnection** pools;
   int banks;
@@ -465,11 +473,13 @@ enum proxyMode {
   proxyTo = 2
 };
 
-ncclResult_t ncclProxySaveOp(struct ncclComm* comm, struct ncclProxyOp* proxyOp, bool *justInquire);
+ncclResult_t ncclProxySaveOp(struct ncclComm* comm, struct ncclProxyOp* proxyOp, bool* justInquire);
 ncclResult_t ncclProxyStart(struct ncclComm* comm);
-ncclResult_t ncclProxyInit(struct ncclComm* comm, struct ncclSocket* sock, union ncclSocketAddress* peerAddresses, uint64_t *peerAddressesUDS);
+ncclResult_t ncclProxyInit(struct ncclComm* comm, struct ncclSocket* sock, union ncclSocketAddress* peerAddresses,
+                           uint64_t* peerAddressesUDS);
 ncclResult_t ncclProxyCreate(struct ncclComm* comm);
-ncclResult_t ncclProxyConnect(struct ncclComm* comm, int transport, int send, int proxyRank, struct ncclProxyConnector* proxyConn);
+ncclResult_t ncclProxyConnect(struct ncclComm* comm, int transport, int send, int proxyRank,
+                              struct ncclProxyConnector* proxyConn);
 
 // NB: ncclProxyMsgTypeStr[] in proxy.cc needs to match
 enum ncclProxyMsgType {
@@ -490,16 +500,21 @@ enum ncclProxyMsgType {
 // This function is called by a client of the proxy that needs to invoke any of the non-progress proxyOp types
 // Call this function on the client, supplying a locally unique opId. Then, poll on the return value of
 // ncclPollProxyResponse(), supplying the same opId to confirm the operation has completed
-ncclResult_t ncclProxyCallAsync(struct ncclComm* comm, struct ncclProxyConnector* proxyConn, int type, void* reqBuff, int reqSize, int respSize, void* opId);
+ncclResult_t ncclProxyCallAsync(struct ncclComm* comm, struct ncclProxyConnector* proxyConn, int type, void* reqBuff,
+                                int reqSize, int respSize, void* opId);
 
 // This function will internally call ncclProxyCallAsync() and spin until ncclPollProxyResponse() confirms the result is received
-ncclResult_t ncclProxyCallBlocking(struct ncclComm* comm, struct ncclProxyConnector* proxyConn, int type, void* reqBuff, int reqSize, void* respBuff, int respSize);
-ncclResult_t ncclPollProxyResponse(struct ncclComm* comm, struct ncclProxyConnector* proxyConn, void* respBuff, void* opId);
+ncclResult_t ncclProxyCallBlocking(struct ncclComm* comm, struct ncclProxyConnector* proxyConn, int type, void* reqBuff,
+                                   int reqSize, void* respBuff, int respSize);
+ncclResult_t ncclPollProxyResponse(struct ncclComm* comm, struct ncclProxyConnector* proxyConn, void* respBuff,
+                                   void* opId);
 
 // UDS support
-ncclResult_t ncclProxyClientGetFdBlocking(struct ncclComm* comm, int rank, void *handle, int* convertedFd);
-ncclResult_t ncclProxyClientQueryFdBlocking(struct ncclComm* comm, struct ncclProxyConnector* proxyConn, int localFd, int* rmtFd);
-ncclResult_t ncclProxyClientBatchQueryFdBlocking(struct ncclComm* comm, struct ncclProxyConnector* proxyConn, int* localFds, int* rmtFds, int numSegments);
+ncclResult_t ncclProxyClientGetFdBlocking(struct ncclComm* comm, int rank, void* handle, int* convertedFd);
+ncclResult_t ncclProxyClientQueryFdBlocking(struct ncclComm* comm, struct ncclProxyConnector* proxyConn, int localFd,
+                                            int* rmtFd);
+ncclResult_t ncclProxyClientBatchQueryFdBlocking(struct ncclComm* comm, struct ncclProxyConnector* proxyConn,
+                                                 int* localFds, int* rmtFds, int numSegments);
 
 ncclResult_t ncclProxyStop(struct ncclComm* comm);
 ncclResult_t ncclProxyShmUnlink(struct ncclComm* comm);

--- a/projects/rccl/src/include/proxy_trace/proxy_trace.h
+++ b/projects/rccl/src/include/proxy_trace/proxy_trace.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
- 
+
 #pragma once
 
 #include <chrono>
@@ -58,7 +58,10 @@ enum class ProxyCounterTypes {
   UNINITIALIZED = 100
 };
 
-enum class ProxyOpType { SEND, RECV };
+enum class ProxyOpType {
+  SEND,
+  RECV
+};
 // ProxyTraceRecordKey and ProxyTraceExtraInfo is used to pass arguments to
 // proxy thread (see ncclProxyOp and ncclProxySubArgs in proxy.h)
 struct ProxyTraceRecordKey {
@@ -68,8 +71,7 @@ struct ProxyTraceRecordKey {
                          // collective/p2p (identified as commHash:opCount),
                          // assigned when creating ProxyTraceOp entry
   inline std::string str() const {
-    return "<" + std::to_string(commHash) + ":" + std::to_string(opCount) +
-           ":" + std::to_string(proxyOpId) + ">";
+    return "<" + std::to_string(commHash) + ":" + std::to_string(opCount) + ":" + std::to_string(proxyOpId) + ">";
   }
 };
 
@@ -80,8 +82,7 @@ struct ProxyTraceExtraInfo {
   uint32_t totalBytes{0};
   uint32_t chunkSize{0};
   inline std::string str() const {
-    return fmt::format("[fu,pr,pa,tb,ck]:{},{},{},{},{}", funcIdx, protocol,
-                       pattern, totalBytes, chunkSize);
+    return fmt::format("[fu,pr,pa,tb,ck]:{},{},{},{},{}", funcIdx, protocol, pattern, totalBytes, chunkSize);
   }
 };
 
@@ -95,17 +96,17 @@ struct ProxyTraceOp {
   int32_t myRank{-1};
   int32_t peerRank{-1};
   std::unordered_map<ProxyCounterTypes, int64_t> counters{
-      {ProxyCounterTypes::POSTED, 0},
-      {ProxyCounterTypes::KERNEL_COPY_READY, 0},
-      {ProxyCounterTypes::RTR_RECV, 0},
-      {ProxyCounterTypes::RTS_SEND, 0},
-      {ProxyCounterTypes::RECEIVED, 0},
-      {ProxyCounterTypes::TRANSMITTED, 0},
-      {ProxyCounterTypes::FLUSHED, 0},
-      {ProxyCounterTypes::DONE, 0},
-      {ProxyCounterTypes::RECV_TAIL, 0},
-      {ProxyCounterTypes::TAIL_OR_HEAD, 0},
-      {ProxyCounterTypes::FIFO_SZ_OR_HEAD_CACHE, -1},
+    {ProxyCounterTypes::POSTED, 0},
+    {ProxyCounterTypes::KERNEL_COPY_READY, 0},
+    {ProxyCounterTypes::RTR_RECV, 0},
+    {ProxyCounterTypes::RTS_SEND, 0},
+    {ProxyCounterTypes::RECEIVED, 0},
+    {ProxyCounterTypes::TRANSMITTED, 0},
+    {ProxyCounterTypes::FLUSHED, 0},
+    {ProxyCounterTypes::DONE, 0},
+    {ProxyCounterTypes::RECV_TAIL, 0},
+    {ProxyCounterTypes::TAIL_OR_HEAD, 0},
+    {ProxyCounterTypes::FIFO_SZ_OR_HEAD_CACHE, -1},
   };
   ProxyCounterTypes lastUpdatingCounter{ProxyCounterTypes::UNINITIALIZED};
   ProxyOpType opType{ProxyOpType::SEND};
@@ -113,54 +114,41 @@ struct ProxyTraceOp {
   std::chrono::time_point<std::chrono::high_resolution_clock> startTs{};
   std::chrono::time_point<std::chrono::high_resolution_clock> lastUpdateTs{};
   std::unordered_map<ProxyCounterTypes, std::chrono::time_point<std::chrono::high_resolution_clock>> timestamps{
-      {ProxyCounterTypes::POSTED, {}},
-      {ProxyCounterTypes::KERNEL_COPY_READY, {}},
+    {ProxyCounterTypes::POSTED, {}},
+    {ProxyCounterTypes::KERNEL_COPY_READY, {}},
   };
   void computeStatus();
   // str the entry to a string
   std::string str();
 };
 
-using ProxyActiveOpMap = std::unordered_map<
-    uint64_t /* commHash*/,
-    std::unordered_map<int64_t /* opCount*/,
+using ProxyActiveOpMap =
+  std::unordered_map<uint64_t /* commHash*/, std::unordered_map<int64_t /* opCount*/,
                        /* proxyOpId : op */
-                       std::unordered_map<int64_t, ProxyTraceOp>>>;
+                                                                std::unordered_map<int64_t, ProxyTraceOp>>>;
 
 using ProxyActiveOpIdTracker =
-    std::unordered_map<uint64_t /* commHash*/,
-                       std::unordered_map<int64_t /* opCount*/, int64_t>>;
+  std::unordered_map<uint64_t /* commHash*/, std::unordered_map<int64_t /* opCount*/, int64_t>>;
 
 class ProxyTrace {
- public:
-  ProxyTrace(int32_t rank) : myRank(rank) {}; 
-  
+public:
+  ProxyTrace(int32_t rank) : myRank(rank) {};
+
   ProxyTrace() = delete;
-  ProxyTrace(const ProxyTrace &) = delete;
-  ProxyTrace &operator=(const ProxyTrace &) = delete;
+  ProxyTrace(const ProxyTrace&) = delete;
+  ProxyTrace& operator=(const ProxyTrace&) = delete;
 
   //
   // Public APIs called by the proxy thread and ncclCommDump().
   // All these APIs lock the same shared mutex before executing.
   //
 
-  void updateProxyOpCounter(
-      const ProxyTraceRecordKey& traceKey,
-      ProxyCounterTypes counter,
-      int64_t val);
+  void updateProxyOpCounter(const ProxyTraceRecordKey& traceKey, ProxyCounterTypes counter, int64_t val);
 
-  void setProxyOpTimestamp(
-      const ProxyTraceRecordKey& traceKey,
-      ProxyCounterTypes counter);
+  void setProxyOpTimestamp(const ProxyTraceRecordKey& traceKey, ProxyCounterTypes counter);
 
-  void addNewProxyOp(
-      ProxyTraceRecordKey& key,
-      const ProxyTraceExtraInfo& extraInfo,
-      ProxyOpType opType,
-      int channelId,
-      int nSteps,
-      uint32_t nbytes,
-      int peerRank);
+  void addNewProxyOp(ProxyTraceRecordKey& key, const ProxyTraceExtraInfo& extraInfo, ProxyOpType opType, int channelId,
+                     int nSteps, uint32_t nbytes, int peerRank);
 
   // Dump all trace for a given communicator
   std::string dump(uint64_t commHash);
@@ -171,26 +159,23 @@ class ProxyTrace {
   //
   // Getters called by public APIs as well as unit tests.
   // These are not thread-safe unless called by the public APIs above.
-  // 
+  //
 
-  ProxyTraceOp *getProxyTraceOpPtr(const ProxyTraceRecordKey &traceKey);
+  ProxyTraceOp* getProxyTraceOpPtr(const ProxyTraceRecordKey& traceKey);
   float getMapSizeMB() const;
 
 private:
-  void checkOpCompleted(const ProxyTraceRecordKey &key);
+  void checkOpCompleted(const ProxyTraceRecordKey& key);
 
-  void addNewProxyTraceOpImpl(const ProxyTraceRecordKey &key,
-                              const ProxyTraceExtraInfo &extraInfo,
-                              ProxyOpType opType, int channelId, int nSteps,
-                              uint32_t nbytes, int peerRank);
+  void addNewProxyTraceOpImpl(const ProxyTraceRecordKey& key, const ProxyTraceExtraInfo& extraInfo, ProxyOpType opType,
+                              int channelId, int nSteps, uint32_t nbytes, int peerRank);
 
   // Get a unique proxyOpId for a given commHash:opCount
   // If the opCount is not found, create a new entry for it and return 0
   int64_t getOrCreateProxyOpId(uint64_t commHash, uint64_t opCount);
 
   // check if an active send/recv operation exists for a given commHash:opCount
-  bool checkActiveOpExist(uint64_t commHash, uint64_t opCount,
-                          uint32_t proxyOpId) const;
+  bool checkActiveOpExist(uint64_t commHash, uint64_t opCount, uint32_t proxyOpId) const;
 
   mutable std::mutex mutex_;
   int myRank{-1};

--- a/projects/rccl/src/include/rccl_common.h
+++ b/projects/rccl/src/include/rccl_common.h
@@ -74,25 +74,26 @@ typedef enum {
 #else
 #define RCCL_STATIC_EXPOSE_CHECK() \
   do { \
-    WARN("Attempting to use internal logic while required static functions are not exposed. Rebuild with RCCL_EXPOSE_STATIC enabled"); \
+    WARN("Attempting to use internal logic while required static functions are not exposed. Rebuild with " \
+         "RCCL_EXPOSE_STATIC enabled"); \
     return ncclInvalidUsage; \
   } while (0)
 #endif
 
 inline rcclTunableIndex_t rcclGetTunableIndex(ncclFunc_t const& func) {
   switch (func) {
-    case ncclFuncReduceScatter:
-      return RCCL_RS_TUNABLE;
-    case ncclFuncAllGather:
-      return RCCL_AG_TUNABLE;
-    case ncclFuncAllReduce:
-      return RCCL_AR_TUNABLE;
-    case ncclFuncReduce:
-      return RCCL_RE_TUNABLE;
-    case ncclFuncBroadcast:
-      return RCCL_BR_TUNABLE;
-    default:
-      return RCCL_UNSUPPORTED_TUNABLE; // Invalid or unsupported function
+  case ncclFuncReduceScatter:
+    return RCCL_RS_TUNABLE;
+  case ncclFuncAllGather:
+    return RCCL_AG_TUNABLE;
+  case ncclFuncAllReduce:
+    return RCCL_AR_TUNABLE;
+  case ncclFuncReduce:
+    return RCCL_RE_TUNABLE;
+  case ncclFuncBroadcast:
+    return RCCL_BR_TUNABLE;
+  default:
+    return RCCL_UNSUPPORTED_TUNABLE; // Invalid or unsupported function
   }
 }
 
@@ -101,33 +102,42 @@ inline size_t rcclGetSizePerRank(ncclFunc_t const& func, size_t const& nBytes, i
   // For AG, this is the send size per rank
   // For RS, this is the recv size per rank
   // For AR, this is the send/recv size per rank
-  return (func == ncclFuncReduceScatter || func == ncclFuncAllGather || func == ncclFuncBroadcast || func == ncclFuncReduce) ? nBytes / nRanks : nBytes;
+  return (func == ncclFuncReduceScatter || func == ncclFuncAllGather || func == ncclFuncBroadcast ||
+          func == ncclFuncReduce) ?
+           nBytes / nRanks :
+           nBytes;
 }
 ncclResult_t rcclOverrideChannels(struct ncclComm* comm, ncclFunc_t coll, size_t nBytes, int& nc);
 void rcclRestrictMaxChannels(struct ncclComm* comm, int& nc);
-ncclResult_t rcclGetAlgoProtoIndex(const char *envStr, const char* algoProtoString[], int nEntries, int& result);
-ncclResult_t rcclOverrideProtocol(const char* ncclProtoStr[], float table[][NCCL_NUM_PROTOCOLS], struct ncclTaskColl* info);
-ncclResult_t rcclOverrideAlgorithm(const char* ncclAlgoStr[], float table[][NCCL_NUM_PROTOCOLS], struct ncclTaskColl* info);
+ncclResult_t rcclGetAlgoProtoIndex(const char* envStr, const char* algoProtoString[], int nEntries, int& result);
+ncclResult_t rcclOverrideProtocol(const char* ncclProtoStr[], float table[][NCCL_NUM_PROTOCOLS],
+                                  struct ncclTaskColl* info);
+ncclResult_t rcclOverrideAlgorithm(const char* ncclAlgoStr[], float table[][NCCL_NUM_PROTOCOLS],
+                                   struct ncclTaskColl* info);
 void rcclUpdateCollectiveProtocol(struct ncclComm* comm, size_t const& nBytes, struct ncclTaskColl* info);
-void rcclUpdateThreadThreshold(struct ncclComm* comm, size_t const& nBytes, struct ncclTaskColl* info, int& threadThreshold);
+void rcclUpdateThreadThreshold(struct ncclComm* comm, size_t const& nBytes, struct ncclTaskColl* info,
+                               int& threadThreshold);
 void rcclSetPipelining(struct ncclComm* comm, size_t const& nBytes, struct ncclTaskColl* info);
 void rcclGetMaxNthreads(struct ncclComm* comm, int maxNthreads[]);
 void rcclOptThreadBlockSize(struct ncclComm* comm, struct ncclTaskColl* info, size_t nBytes, int& nThreads);
 void rcclSetDefaultBuffSizes(struct ncclComm* comm, int defaultBuffSizes[]);
-NCCL_API(ncclResult_t, rcclGetAlgoInfo, struct ncclComm* comm, ncclFunc_t coll, uint64_t count, ncclDataType_t dataType, int collNetSupport, int nvlsSupport, int numPipeOps, int* algo, int* protocol, int* maxChannels);
-NCCL_API(ncclResult_t, rcclSymKGetInfo, struct ncclComm* comm, ncclFunc_t coll, uint64_t count, ncclDataType_t dataType, ncclRedOp_t op, int* algo, int* protocol, int* maxChannels);
+NCCL_API(ncclResult_t, rcclGetAlgoInfo, struct ncclComm* comm, ncclFunc_t coll, uint64_t count, ncclDataType_t dataType,
+         int collNetSupport, int nvlsSupport, int numPipeOps, int* algo, int* protocol, int* maxChannels);
+NCCL_API(ncclResult_t, rcclSymKGetInfo, struct ncclComm* comm, ncclFunc_t coll, uint64_t count, ncclDataType_t dataType,
+         ncclRedOp_t op, int* algo, int* protocol, int* maxChannels);
 NCCL_API(ncclResult_t, rcclGetAlgoName, int algo, const char** algoName);
 NCCL_API(ncclResult_t, rcclGetProtocolName, int protocol, const char** algoName);
 bool rcclUseAllGatherDirect(struct ncclComm* comm, size_t& msgSize);
 bool rcclUseHierarchicalAllGather(struct ncclComm* comm, size_t msgSize);
 bool rcclUseReduceScatterDirect(struct ncclComm* comm, size_t& msgSize);
 bool rcclUseAlltoAllGda(struct ncclComm* comm);
-void rcclSetPxn(struct ncclComm* comm,  int& rcclPxnDisable);
-void rcclSetP2pNetChunkSize(struct ncclComm* comm,  int& rcclP2pNetChunkSize);
+void rcclSetPxn(struct ncclComm* comm, int& rcclPxnDisable);
+void rcclSetP2pNetChunkSize(struct ncclComm* comm, int& rcclP2pNetChunkSize);
 ncclResult_t rcclFuncMaxSendRecvCount(ncclFunc_t func, int nRanks, size_t count, size_t& maxCount);
 ncclResult_t commSetUnrollFactor(struct ncclComm* comm);
 ncclResult_t rcclCommSetP2pShiftSize(struct ncclComm* comm);
-bool validHsaScratchEnvSetting(const char*hsaScratchEnv, int hipRuntimeVersion, int firmwareVersion, const char* archName);
+bool validHsaScratchEnvSetting(const char* hsaScratchEnv, int hipRuntimeVersion, int firmwareVersion,
+                               const char* archName);
 
 // Direct ReduceScatter Limit
 RCCL_PARAM_DECLARE(DirectReduceScatterThreshold);

--- a/projects/rccl/src/include/rccl_float8.h
+++ b/projects/rccl/src/include/rccl_float8.h
@@ -30,21 +30,17 @@ typedef uint16_t fp8x2_storage_t;
 #if __cplusplus < 201103L || (!defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__))
 /*! \brief Struct to represent a 8 bit floating-point number. */
 
-typedef struct
-{
-    uint8_t data;
+typedef struct {
+  uint8_t data;
 } rccl_float8;
 
-typedef struct
-{
-    uint8_t data;
+typedef struct {
+  uint8_t data;
 } rccl_bfloat8;
 
 // __cplusplus < 201103L || (!defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__))
-#elif HIP_VERSION >= 60300000 && \
-      (!__HIP_DEVICE_COMPILE__ || \
-       defined(__gfx942__) || defined(__gfx950__) || \
-       defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx1250__))
+#elif HIP_VERSION >= 60300000 && (!__HIP_DEVICE_COMPILE__ || defined(__gfx942__) || defined(__gfx950__) || \
+                                  defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx1250__))
 
 #include <hip/hip_fp8.h>
 
@@ -63,137 +59,146 @@ typedef short shortx2_t __attribute__((ext_vector_type(2)));
 typedef short __attribute__((ext_vector_type(2))) __amd_shortx2_storage_t;
 typedef float float2_t __attribute__((ext_vector_type(2)));
 
-
-inline __device__  rccl_float8 hadd(rccl_float8 x, rccl_float8 y)
-{
-#if   __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
-    half2_t v1;
-    asm volatile("v_pk_add_f16 %0, %1, %2" : "=v"(v1) : "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_fp8(x.__x, 1.f, 0)), "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_fp8(y.__x, 1.f, 0)));
-    union {
-      shortx2_t i16_vec;
-      rccl_float8 fp8[4];
-    } u{0};
-    u.i16_vec = __builtin_amdgcn_cvt_scalef32_pk_fp8_f16(v1, v1, /* scale */ 1.f, 0);
-    return u.fp8[0];
+inline __device__ rccl_float8 hadd(rccl_float8 x, rccl_float8 y) {
+#if __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
+  half2_t v1;
+  asm volatile("v_pk_add_f16 %0, %1, %2"
+               : "=v"(v1)
+               : "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_fp8(x.__x, 1.f, 0)),
+                 "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_fp8(y.__x, 1.f, 0)));
+  union {
+    shortx2_t i16_vec;
+    rccl_float8 fp8[4];
+  } u{0};
+  u.i16_vec = __builtin_amdgcn_cvt_scalef32_pk_fp8_f16(v1, v1, /* scale */ 1.f, 0);
+  return u.fp8[0];
 #elif __HIP_DEVICE_COMPILE__ && defined(__gfx942__)
 
-    float2_t v;
-    uint32_t ival = 0;
-    asm volatile("v_pk_add_f32 %0, %1, %2" : "=v"(v) : "v"(__builtin_amdgcn_cvt_pk_f32_fp8(x.__x, 0)), "v"(__builtin_amdgcn_cvt_pk_f32_fp8(y.__x, 0)));
-    return __builtin_amdgcn_cvt_pk_fp8_f32(v[0], v[0], ival, false);
+  float2_t v;
+  uint32_t ival = 0;
+  asm volatile("v_pk_add_f32 %0, %1, %2"
+               : "=v"(v)
+               : "v"(__builtin_amdgcn_cvt_pk_f32_fp8(x.__x, 0)), "v"(__builtin_amdgcn_cvt_pk_f32_fp8(y.__x, 0)));
+  return __builtin_amdgcn_cvt_pk_fp8_f32(v[0], v[0], ival, false);
 #else
-    return rccl_float8(float(x) + float(y));
+  return rccl_float8(float(x) + float(y));
 #endif
 }
 
-inline __device__  rccl_bfloat8 hadd_b(rccl_bfloat8 x, rccl_bfloat8 y)
-{
-#if   __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
-    half2_t v1;
-    asm volatile("v_pk_add_f16 %0, %1, %2" : "=v"(v1) : "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_bf8(x.__x, 1.f, 0)), "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_bf8(y.__x, 1.f, 0)));
-    union {
-      shortx2_t i16_vec;
-      rccl_bfloat8 fp8[4];
-    } u1{0};
-    u1.i16_vec = __builtin_amdgcn_cvt_scalef32_pk_bf8_f16(v1, v1, /* scale */ 1.f, 0);
-    return u1.fp8[0];
+inline __device__ rccl_bfloat8 hadd_b(rccl_bfloat8 x, rccl_bfloat8 y) {
+#if __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
+  half2_t v1;
+  asm volatile("v_pk_add_f16 %0, %1, %2"
+               : "=v"(v1)
+               : "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_bf8(x.__x, 1.f, 0)),
+                 "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_bf8(y.__x, 1.f, 0)));
+  union {
+    shortx2_t i16_vec;
+    rccl_bfloat8 fp8[4];
+  } u1{0};
+  u1.i16_vec = __builtin_amdgcn_cvt_scalef32_pk_bf8_f16(v1, v1, /* scale */ 1.f, 0);
+  return u1.fp8[0];
 #elif __HIP_DEVICE_COMPILE__ && defined(__gfx942__)
 
-    float2_t v;
-    uint32_t ival       = 0;
-    asm volatile("v_pk_add_f32 %0, %1, %2" : "=v"(v) : "v"(__builtin_amdgcn_cvt_pk_f32_bf8(x.__x, 0)), "v"(__builtin_amdgcn_cvt_pk_f32_bf8(y.__x, 0)));
-    return __builtin_amdgcn_cvt_pk_bf8_f32(v[0], v[0], ival, false);
+  float2_t v;
+  uint32_t ival = 0;
+  asm volatile("v_pk_add_f32 %0, %1, %2"
+               : "=v"(v)
+               : "v"(__builtin_amdgcn_cvt_pk_f32_bf8(x.__x, 0)), "v"(__builtin_amdgcn_cvt_pk_f32_bf8(y.__x, 0)));
+  return __builtin_amdgcn_cvt_pk_bf8_f32(v[0], v[0], ival, false);
 #else
-    return rccl_bfloat8(float(x) + float(y));
+  return rccl_bfloat8(float(x) + float(y));
 #endif
 }
 
-inline __device__  fp8x2_storage_t hadd2(fp8x2_storage_t x, fp8x2_storage_t y)
-{
-#if   __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
-    half2_t v1;
-    asm volatile("v_pk_add_f16 %0, %1, %2" : "=v"(v1) : "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_fp8(x, 1.f, 0)), "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_fp8(y, 1.f, 0)));
-    union {
-      shortx2_t i16_vec;
-      fp8x2_storage_t fp8;
-    } u{0};
-    u.i16_vec = __builtin_amdgcn_cvt_scalef32_pk_fp8_f16(v1, v1, /* scale */ 1.f, 0);
-    return u.fp8;
+inline __device__ fp8x2_storage_t hadd2(fp8x2_storage_t x, fp8x2_storage_t y) {
+#if __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
+  half2_t v1;
+  asm volatile("v_pk_add_f16 %0, %1, %2"
+               : "=v"(v1)
+               : "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_fp8(x, 1.f, 0)),
+                 "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_fp8(y, 1.f, 0)));
+  union {
+    shortx2_t i16_vec;
+    fp8x2_storage_t fp8;
+  } u{0};
+  u.i16_vec = __builtin_amdgcn_cvt_scalef32_pk_fp8_f16(v1, v1, /* scale */ 1.f, 0);
+  return u.fp8;
 #elif __HIP_DEVICE_COMPILE__ && defined(__gfx942__)
-    float2_t v;
-    uint32_t ival = 0;
-    asm volatile("v_pk_add_f32 %0, %1, %2" : "=v"(v) : "v"(__builtin_amdgcn_cvt_pk_f32_fp8(x, 0)), "v"(__builtin_amdgcn_cvt_pk_f32_fp8(y, 0)));
-    return __builtin_amdgcn_cvt_pk_fp8_f32(v[0], v[1], ival, false);
+  float2_t v;
+  uint32_t ival = 0;
+  asm volatile("v_pk_add_f32 %0, %1, %2"
+               : "=v"(v)
+               : "v"(__builtin_amdgcn_cvt_pk_f32_fp8(x, 0)), "v"(__builtin_amdgcn_cvt_pk_f32_fp8(y, 0)));
+  return __builtin_amdgcn_cvt_pk_fp8_f32(v[0], v[1], ival, false);
 #else
-    union {
-      rccl_float8 fp8[2];
-      fp8x2_storage_t fp8x2;
-    } u, v, w;
-    u.fp8x2 = x;
-    v.fp8x2 = y;
-    w.fp8[0] = hadd(u.fp8[0], v.fp8[0]);
-    w.fp8[1] = hadd(u.fp8[1], v.fp8[1]);
-    return w.fp8x2;
+  union {
+    rccl_float8 fp8[2];
+    fp8x2_storage_t fp8x2;
+  } u, v, w;
+  u.fp8x2 = x;
+  v.fp8x2 = y;
+  w.fp8[0] = hadd(u.fp8[0], v.fp8[0]);
+  w.fp8[1] = hadd(u.fp8[1], v.fp8[1]);
+  return w.fp8x2;
 #endif
 }
 
-inline __device__  fp8x2_storage_t hadd2_b(fp8x2_storage_t x, fp8x2_storage_t y)
-{
-#if   __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
-    half2_t v1;
-    asm volatile("v_pk_add_f16 %0, %1, %2" : "=v"(v1) : "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_bf8(x, 1.f, 0)), "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_bf8(y, 1.f, 0)));
-    union {
-      shortx2_t i16_vec;
-      fp8x2_storage_t fp8;
-    } u{0};
-    u.i16_vec = __builtin_amdgcn_cvt_scalef32_pk_bf8_f16(v1, v1, /* scale */ 1.f, 0);
-    return u.fp8;
+inline __device__ fp8x2_storage_t hadd2_b(fp8x2_storage_t x, fp8x2_storage_t y) {
+#if __HIP_DEVICE_COMPILE__ && defined(__gfx950__)
+  half2_t v1;
+  asm volatile("v_pk_add_f16 %0, %1, %2"
+               : "=v"(v1)
+               : "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_bf8(x, 1.f, 0)),
+                 "v"(__builtin_amdgcn_cvt_scalef32_pk_f16_bf8(y, 1.f, 0)));
+  union {
+    shortx2_t i16_vec;
+    fp8x2_storage_t fp8;
+  } u{0};
+  u.i16_vec = __builtin_amdgcn_cvt_scalef32_pk_bf8_f16(v1, v1, /* scale */ 1.f, 0);
+  return u.fp8;
 #elif __HIP_DEVICE_COMPILE__ && defined(__gfx942__)
-    float2_t v;
-    uint32_t ival = 0;
-    asm volatile("v_pk_add_f32 %0, %1, %2" : "=v"(v) : "v"(__builtin_amdgcn_cvt_pk_f32_bf8(x, 0)), "v"(__builtin_amdgcn_cvt_pk_f32_bf8(y, 0)));
-    return __builtin_amdgcn_cvt_pk_bf8_f32(v[0], v[1], ival, false);
+  float2_t v;
+  uint32_t ival = 0;
+  asm volatile("v_pk_add_f32 %0, %1, %2"
+               : "=v"(v)
+               : "v"(__builtin_amdgcn_cvt_pk_f32_bf8(x, 0)), "v"(__builtin_amdgcn_cvt_pk_f32_bf8(y, 0)));
+  return __builtin_amdgcn_cvt_pk_bf8_f32(v[0], v[1], ival, false);
 #else
-    union {
-      rccl_bfloat8 bfp8[2];
-      fp8x2_storage_t bfp8x2;
-    } u, v, w;
-    u.bfp8x2 = x;
-    v.bfp8x2 = y;
-    w.bfp8[0] = hadd_b(u.bfp8[0], v.bfp8[0]);
-    w.bfp8[1] = hadd_b(u.bfp8[1], v.bfp8[1]);
-    return w.bfp8x2;
+  union {
+    rccl_bfloat8 bfp8[2];
+    fp8x2_storage_t bfp8x2;
+  } u, v, w;
+  u.bfp8x2 = x;
+  v.bfp8x2 = y;
+  w.bfp8[0] = hadd_b(u.bfp8[0], v.bfp8[0]);
+  w.bfp8[1] = hadd_b(u.bfp8[1], v.bfp8[1]);
+  return w.bfp8x2;
 #endif
 }
 
-inline std::ostream& operator<<(std::ostream& os, const rccl_float8& f8)
-{
-    return os << float(f8);
+inline std::ostream& operator<<(std::ostream& os, const rccl_float8& f8) {
+  return os << float(f8);
 }
 
-inline std::ostream& operator<<(std::ostream& os, const rccl_bfloat8& bf8)
-{
-    return os << float(bf8);
+inline std::ostream& operator<<(std::ostream& os, const rccl_bfloat8& bf8) {
+  return os << float(bf8);
 }
 
-inline __host__ __device__ float operator*(rccl_float8 a, rccl_float8 b)
-{
-    return float(a) * float(b);
+inline __host__ __device__ float operator*(rccl_float8 a, rccl_float8 b) {
+  return float(a) * float(b);
 }
 
-inline __host__ __device__ float operator*(rccl_bfloat8 a, rccl_bfloat8 b)
-{
-    return float(a) * float(b);
+inline __host__ __device__ float operator*(rccl_bfloat8 a, rccl_bfloat8 b) {
+  return float(a) * float(b);
 }
 
-inline __host__ __device__ float operator*(rccl_float8 a, float b)
-{
-    return float(a) * float(b);
+inline __host__ __device__ float operator*(rccl_float8 a, float b) {
+  return float(a) * float(b);
 }
 
-inline __host__ __device__ float operator*(rccl_bfloat8 a, float b)
-{
-    return float(a) * float(b);
+inline __host__ __device__ float operator*(rccl_bfloat8 a, float b) {
+  return float(a) * float(b);
 }
 
 // For older versions of ROCm that do not include hip_fp8.h,
@@ -207,85 +212,62 @@ inline __host__ __device__ float operator*(rccl_bfloat8 a, float b)
 // We are clipping in down conversion by default
 #define rccl_float8_downcast_clipping 1
 
-namespace rocblas_hip_f8_impl
-{
-    __host__ inline int clz(uint32_t x)
-    {
-        return __builtin_clz(x);
-    }
-    __device__ inline int clz(uint32_t x)
-    {
-        return __clz(x);
-    }
+namespace rocblas_hip_f8_impl {
+__host__ inline int clz(uint32_t x) {
+  return __builtin_clz(x);
+}
+__device__ inline int clz(uint32_t x) {
+  return __clz(x);
+}
 
-    template <int wm, int we, typename T, bool negative_zero_nan, bool clip>
-    HIP_HOST_DEVICE uint8_t cast_to_f8(T _x, bool stoch = false, uint32_t rng = 0)
-    {
-        constexpr bool is_half  = std::is_same<T, _Float16>::value;
-        constexpr bool is_float = std::is_same<T, float>::value;
-        static_assert(wm + we == 7, "wm+we==7");
-        static_assert(is_half || is_float, "Only half and float can be cast to f8");
+template <int wm, int we, typename T, bool negative_zero_nan, bool clip>
+HIP_HOST_DEVICE uint8_t cast_to_f8(T _x, bool stoch = false, uint32_t rng = 0) {
+  constexpr bool is_half = std::is_same<T, _Float16>::value;
+  constexpr bool is_float = std::is_same<T, float>::value;
+  static_assert(wm + we == 7, "wm+we==7");
+  static_assert(is_half || is_float, "Only half and float can be cast to f8");
 
-        const int mfmt = (sizeof(T) == 4) ? 23 : 10;
-        uint32_t  x;
-        if(sizeof(T) == 4)
-            x = reinterpret_cast<uint32_t&>(_x);
-        else
-            x = reinterpret_cast<uint16_t&>(_x);
+  const int mfmt = (sizeof(T) == 4) ? 23 : 10;
+  uint32_t x;
+  if (sizeof(T) == 4) x = reinterpret_cast<uint32_t&>(_x);
+  else x = reinterpret_cast<uint16_t&>(_x);
 
-        uint32_t head, mantissa;
-        int      exponent, bias;
-        uint32_t sign;
+  uint32_t head, mantissa;
+  int exponent, bias;
+  uint32_t sign;
 
-        if(sizeof(T) == 4)
-        {
-            head     = x & 0xFF800000;
-            mantissa = x & 0x7FFFFF;
-            exponent = (head >> 23) & 0xFF;
-            sign     = head >> 31;
-            bias     = 127;
-        }
-        else
-        {
-            head     = x & 0xFC00;
-            mantissa = x & 0x3FF;
-            exponent = (head >> 10) & 0x1F;
-            sign     = head >> 15;
-            bias     = 15;
-        }
+  if (sizeof(T) == 4) {
+    head = x & 0xFF800000;
+    mantissa = x & 0x7FFFFF;
+    exponent = (head >> 23) & 0xFF;
+    sign = head >> 31;
+    bias = 127;
+  } else {
+    head = x & 0xFC00;
+    mantissa = x & 0x3FF;
+    exponent = (head >> 10) & 0x1F;
+    sign = head >> 15;
+    bias = 15;
+  }
 
-        uint32_t signed_inf = (sign << 7) + (((1 << we) - 1) << wm);
+  uint32_t signed_inf = (sign << 7) + (((1 << we) - 1) << wm);
 
         // Deal with inf and NaNs
-        if(negative_zero_nan)
-        {
-            if(sizeof(T) == 4)
-            {
-                if((x & 0x7F800000) == 0x7F800000)
-                    return 0x80;
-            }
-            else
-            {
-                //if(__hisinf(x) || __hisnan(x))
-                if((x & 0x7C00) == 0x7C00)
-                    return 0x80;
-            }
-        }
-        else
-        {
-            if(sizeof(T) == 4)
-            {
-                if((x & 0x7F800000) == 0x7F800000)
-                    return signed_inf + (mantissa != 0 ? 1 : 0);
-            }
-            else
-            {
-                if((x & 0x7C00) == 0x7C00)
-                    return signed_inf + (mantissa != 0 ? 1 : 0);
-            }
-        }
-        if(x == 0)
-            return 0;
+  if (negative_zero_nan) {
+    if (sizeof(T) == 4) {
+      if ((x & 0x7F800000) == 0x7F800000) return 0x80;
+    } else {
+                // if(__hisinf(x) || __hisnan(x))
+      if ((x & 0x7C00) == 0x7C00) return 0x80;
+    }
+  } else {
+    if (sizeof(T) == 4) {
+      if ((x & 0x7F800000) == 0x7F800000) return signed_inf + (mantissa != 0 ? 1 : 0);
+    } else {
+      if ((x & 0x7C00) == 0x7C00) return signed_inf + (mantissa != 0 ? 1 : 0);
+    }
+  }
+  if (x == 0) return 0;
 
         // First need to check if it is normal or denorm as there is a difference of implict 1
         // Then need to adjust the exponent to align with the F8 exponent, in the meanwhile, shift
@@ -294,254 +276,206 @@ namespace rocblas_hip_f8_impl
         // exponent and mantissa again
 
         // For IEEE bias mode, the bias is 2^(k-1) -1 where k is the width of exponent bits
-        const int f8_bias                  = (1 << (we - 1)) - 1 + (negative_zero_nan ? 1 : 0);
-        const int f8_denormal_act_exponent = 1 - f8_bias; //actual exponent of f8 denormal
+  const int f8_bias = (1 << (we - 1)) - 1 + (negative_zero_nan ? 1 : 0);
+  const int f8_denormal_act_exponent = 1 - f8_bias; // actual exponent of f8 denormal
         // act_exponent is the actual exponent of fp32/fp16 (after subtracting bias)
         // f8_exponent is the converted f8 exponent with bias encoding
         // exponent_diff is the diff between fp32/fp16 exponent and f8 exponent,
         // the difference needs to be adjusted and mantissa shifted
-        int act_exponent, f8_exponent, exponent_diff;
+  int act_exponent, f8_exponent, exponent_diff;
 
-        if(exponent == 0)
-        { // fp32/fp16 is in denormal.
+  if (exponent == 0) { // fp32/fp16 is in denormal.
             /* fp32 denormal is below 2^-127 so it is usually not a concern here, we mostly concern fp16 here.
-   In this case, f8 is usually in denormal. But there could be exceptions.
-   fp16 denormal has exponent bias 15 while bf8 with NANOO has exponent bias 16.
-   It means that there are some numbers in fp16 denormal but they are bf8 (NANOO) normals - smallest bf8 (NANOO) normal is 2^-15.
-   fp16 numbers where exponent==0 (actual exponent -14) and highest bit of mantissa is 1 are bf8 (NANOO) normal.
-   In this case, the fp16 mantissa should be shift left by 1  */
-            act_exponent  = exponent - bias + 1;
-            exponent_diff = f8_denormal_act_exponent
-                            - act_exponent; // actual exponent is exponent-bias+1 as it is denormal
-        }
-        else
-        { // fp32/fp16 is normal with implicit 1
-            act_exponent = exponent - bias;
-            if(act_exponent <= f8_denormal_act_exponent)
-            {
+In this case, f8 is usually in denormal. But there could be exceptions.
+fp16 denormal has exponent bias 15 while bf8 with NANOO has exponent bias 16.
+It means that there are some numbers in fp16 denormal but they are bf8 (NANOO) normals - smallest bf8 (NANOO) normal is 2^-15.
+fp16 numbers where exponent==0 (actual exponent -14) and highest bit of mantissa is 1 are bf8 (NANOO) normal.
+In this case, the fp16 mantissa should be shift left by 1  */
+    act_exponent = exponent - bias + 1;
+    exponent_diff = f8_denormal_act_exponent - act_exponent; // actual exponent is exponent-bias+1 as it is denormal
+  } else { // fp32/fp16 is normal with implicit 1
+    act_exponent = exponent - bias;
+    if (act_exponent <= f8_denormal_act_exponent) {
                 /* This is the case where fp32/fp16 is normal but it is in f8 denormal range.
-       For example fp8 nanoo mode, denormal exponent is -7, but if the fp32/fp16
-       actual exponent is -7, it is actually larger due to the implict 1,
-       Therefore it needs to be adjust to -6 and mantissa shift right by 1.
-       So for fp32/fp16, exponent -8 is the cut point to convert to fp8 nanoo */
-                exponent_diff = f8_denormal_act_exponent - act_exponent;
-            }
-            else
-            { //both fp32/fp16 and f8 are in normal range
-                exponent_diff
-                    = 0; // exponent_diff=0 does not mean there is no difference for this case,
-                //act_exponent could be larger. Just that it does not need shift mantissa
-            }
-            mantissa += (1 << mfmt); //Add the implicit 1 into mantissa
-        }
+For example fp8 nanoo mode, denormal exponent is -7, but if the fp32/fp16
+actual exponent is -7, it is actually larger due to the implict 1,
+Therefore it needs to be adjust to -6 and mantissa shift right by 1.
+So for fp32/fp16, exponent -8 is the cut point to convert to fp8 nanoo */
+      exponent_diff = f8_denormal_act_exponent - act_exponent;
+    } else { // both fp32/fp16 and f8 are in normal range
+      exponent_diff = 0; // exponent_diff=0 does not mean there is no difference for this case,
+                // act_exponent could be larger. Just that it does not need shift mantissa
+    }
+    mantissa += (1 << mfmt); // Add the implicit 1 into mantissa
+  }
 
-        bool midpoint = (mantissa & ((1 << (mfmt - wm + exponent_diff)) - 1))
-                        == (1 << (mfmt - wm + exponent_diff - 1));
+  bool midpoint = (mantissa & ((1 << (mfmt - wm + exponent_diff)) - 1)) == (1 << (mfmt - wm + exponent_diff - 1));
         /* This part is a bit tricky. The judgment of whether it is a tie needs to be done before we shift right
-     as shift right could rip off some residual part and make something not midpoint look like midpoint.
-     For example, the fp16 number 0x1002 (0 00100 0000000010), it is larger than midpoint,
-     but after shift right by 4 bits, it would look like midpoint.
-  */
+as shift right could rip off some residual part and make something not midpoint look like midpoint.
+For example, the fp16 number 0x1002 (0 00100 0000000010), it is larger than midpoint,
+but after shift right by 4 bits, it would look like midpoint.
+*/
 
-        if(exponent_diff > 0)
-            mantissa >>= exponent_diff;
-        else if(exponent_diff == -1)
-            mantissa <<= -exponent_diff;
-        bool implicit_one = mantissa & (1 << mfmt);
-        //if there is no implict 1, it  means the f8 is denormal and need to adjust to denorm exponent
-        f8_exponent = (act_exponent + exponent_diff) /*actual f8 exponent*/ + f8_bias
-                      - (implicit_one ? 0 : 1);
+  if (exponent_diff > 0) mantissa >>= exponent_diff;
+  else if (exponent_diff == -1) mantissa <<= -exponent_diff;
+  bool implicit_one = mantissa & (1 << mfmt);
+        // if there is no implict 1, it  means the f8 is denormal and need to adjust to denorm exponent
+  f8_exponent = (act_exponent + exponent_diff) /*actual f8 exponent*/ + f8_bias - (implicit_one ? 0 : 1);
 
-        //Now we have the exponent and mantissa adjusted
-        uint32_t drop_mask = (1 << (mfmt - wm)) - 1;
-        bool     odd       = mantissa
-                   & (1 << (mfmt - wm)); // if the least significant bit that is not truncated is 1
-        mantissa
-            += (stoch ? rng : (midpoint ? (odd ? mantissa : mantissa - 1) : mantissa)) & drop_mask;
+        // Now we have the exponent and mantissa adjusted
+  uint32_t drop_mask = (1 << (mfmt - wm)) - 1;
+  bool odd = mantissa & (1 << (mfmt - wm)); // if the least significant bit that is not truncated is 1
+  mantissa += (stoch ? rng : (midpoint ? (odd ? mantissa : mantissa - 1) : mantissa)) & drop_mask;
 
-        //Now we deal with overflow
-        if(f8_exponent == 0)
-        {
-            if((1 << mfmt) & mantissa)
-            {
-                f8_exponent = 1; //denormal overflow to become normal, promote exponent
-            }
-        }
-        else
-        {
-            if((1 << (mfmt + 1)) & mantissa)
-            {
-                mantissa >>= 1;
-                f8_exponent++;
-            }
-        }
+        // Now we deal with overflow
+  if (f8_exponent == 0) {
+    if ((1 << mfmt) & mantissa) {
+      f8_exponent = 1; // denormal overflow to become normal, promote exponent
+    }
+  } else {
+    if ((1 << (mfmt + 1)) & mantissa) {
+      mantissa >>= 1;
+      f8_exponent++;
+    }
+  }
 
-        mantissa >>= (mfmt - wm);
+  mantissa >>= (mfmt - wm);
 
         // above range: quantize to maximum possible float of the same sign
-        const int max_exp = (1 << we) - (negative_zero_nan ? 1 : 2);
-        if(f8_exponent > max_exp)
-        {
-            if(clip)
-            {
-                mantissa    = (1 << wm) - 1;
-                f8_exponent = max_exp;
-            }
-            else
-            {
-                return signed_inf;
-            }
-        }
-
-        if(f8_exponent == 0 && mantissa == 0)
-            return negative_zero_nan ? 0 : (sign << 7);
-        mantissa &= (1 << wm) - 1;
-        return (sign << 7) | (f8_exponent << wm) | mantissa;
+  const int max_exp = (1 << we) - (negative_zero_nan ? 1 : 2);
+  if (f8_exponent > max_exp) {
+    if (clip) {
+      mantissa = (1 << wm) - 1;
+      f8_exponent = max_exp;
+    } else {
+      return signed_inf;
     }
+  }
 
-    template <int wm, int we, typename T, bool negative_zero_nan>
-    HIP_HOST_DEVICE T cast_from_f8(uint8_t x)
-    {
-        constexpr bool is_half  = std::is_same<T, _Float16>::value;
-        constexpr bool is_float = std::is_same<T, float>::value;
-        static_assert(is_half || is_float, "only half and float are supported");
+  if (f8_exponent == 0 && mantissa == 0) return negative_zero_nan ? 0 : (sign << 7);
+  mantissa &= (1 << wm) - 1;
+  return (sign << 7) | (f8_exponent << wm) | mantissa;
+}
 
-        constexpr int weo = is_half ? 5 : 8;
-        constexpr int wmo = is_half ? 10 : (is_float ? 23 : 7);
+template <int wm, int we, typename T, bool negative_zero_nan>
+HIP_HOST_DEVICE T cast_from_f8(uint8_t x) {
+  constexpr bool is_half = std::is_same<T, _Float16>::value;
+  constexpr bool is_float = std::is_same<T, float>::value;
+  static_assert(is_half || is_float, "only half and float are supported");
 
-        T fInf, fNegInf, fNaN, fNeg0;
-        if(is_half)
-        {
-            const uint16_t ihInf    = 0x7C00;
-            const uint16_t ihNegInf = 0xFC00;
-            const uint16_t ihNaN    = 0x7C01;
-            const uint16_t ihNeg0   = 0x8000;
-            fInf                    = reinterpret_cast<const _Float16&>(ihInf);
-            fNegInf                 = reinterpret_cast<const _Float16&>(ihNegInf);
-            fNaN                    = reinterpret_cast<const _Float16&>(ihNaN);
-            fNeg0                   = reinterpret_cast<const _Float16&>(ihNeg0);
-        }
-        else if(is_float)
-        {
-            const uint32_t ifInf    = 0x7F800000;
-            const uint32_t ifNegInf = 0xFF800000;
-            const uint32_t ifNaN    = 0x7F800001;
-            const uint32_t ifNeg0   = 0x80000000;
-            fInf                    = reinterpret_cast<const float&>(ifInf);
-            fNegInf                 = reinterpret_cast<const float&>(ifNegInf);
-            fNaN                    = reinterpret_cast<const float&>(ifNaN);
-            fNeg0                   = reinterpret_cast<const float&>(ifNeg0);
-        }
+  constexpr int weo = is_half ? 5 : 8;
+  constexpr int wmo = is_half ? 10 : (is_float ? 23 : 7);
 
-        if(x == 0)
-            return 0;
+  T fInf, fNegInf, fNaN, fNeg0;
+  if (is_half) {
+    const uint16_t ihInf = 0x7C00;
+    const uint16_t ihNegInf = 0xFC00;
+    const uint16_t ihNaN = 0x7C01;
+    const uint16_t ihNeg0 = 0x8000;
+    fInf = reinterpret_cast<const _Float16&>(ihInf);
+    fNegInf = reinterpret_cast<const _Float16&>(ihNegInf);
+    fNaN = reinterpret_cast<const _Float16&>(ihNaN);
+    fNeg0 = reinterpret_cast<const _Float16&>(ihNeg0);
+  } else if (is_float) {
+    const uint32_t ifInf = 0x7F800000;
+    const uint32_t ifNegInf = 0xFF800000;
+    const uint32_t ifNaN = 0x7F800001;
+    const uint32_t ifNeg0 = 0x80000000;
+    fInf = reinterpret_cast<const float&>(ifInf);
+    fNegInf = reinterpret_cast<const float&>(ifNegInf);
+    fNaN = reinterpret_cast<const float&>(ifNaN);
+    fNeg0 = reinterpret_cast<const float&>(ifNeg0);
+  }
 
-        uint32_t sign     = x >> 7;
-        uint32_t mantissa = x & ((1 << wm) - 1);
-        int      exponent = (x & 0x7F) >> wm;
-        if(negative_zero_nan)
-        {
-            if(x == 0x80)
-                return fNaN;
-        }
-        else
-        {
-            if(x == 0x80)
-                return fNeg0;
-            if(exponent == ((1 << we) - 1))
-                return (mantissa == 0) ? (sign ? fNegInf : fInf) : fNaN;
-        }
-        typename std::conditional<sizeof(T) == 2, uint16_t, uint32_t>::type retval;
-        if(we == 5 && is_half && !negative_zero_nan)
-        {
-            retval = x << 8;
-            return reinterpret_cast<const T&>(retval);
-        }
+  if (x == 0) return 0;
 
-        const int exp_low_cutoff
-            = (1 << (weo - 1)) - (1 << (we - 1)) + 1 - (negative_zero_nan ? 1 : 0);
+  uint32_t sign = x >> 7;
+  uint32_t mantissa = x & ((1 << wm) - 1);
+  int exponent = (x & 0x7F) >> wm;
+  if (negative_zero_nan) {
+    if (x == 0x80) return fNaN;
+  } else {
+    if (x == 0x80) return fNeg0;
+    if (exponent == ((1 << we) - 1)) return (mantissa == 0) ? (sign ? fNegInf : fInf) : fNaN;
+  }
+  typename std::conditional<sizeof(T) == 2, uint16_t, uint32_t>::type retval;
+  if (we == 5 && is_half && !negative_zero_nan) {
+    retval = x << 8;
+    return reinterpret_cast<const T&>(retval);
+  }
 
-        //subnormal input
-        if(exponent == 0)
-        {
-            //guaranteed mantissa!=0 since cases 0x0 and 0x80 are handled above
-            int sh = 1 + clz(mantissa) - (32 - wm);
-            mantissa <<= sh;
-            exponent += 1 - sh;
-            mantissa &= ((1 << wm) - 1);
-        }
-        exponent += exp_low_cutoff - 1;
-        mantissa <<= wmo - wm;
+  const int exp_low_cutoff = (1 << (weo - 1)) - (1 << (we - 1)) + 1 - (negative_zero_nan ? 1 : 0);
+
+        // subnormal input
+  if (exponent == 0) {
+            // guaranteed mantissa!=0 since cases 0x0 and 0x80 are handled above
+    int sh = 1 + clz(mantissa) - (32 - wm);
+    mantissa <<= sh;
+    exponent += 1 - sh;
+    mantissa &= ((1 << wm) - 1);
+  }
+  exponent += exp_low_cutoff - 1;
+  mantissa <<= wmo - wm;
 
         // subnormal output (occurs when T=half, we=5, negative_zero_nan=true)
-        if(exponent <= 0)
-        {
-            mantissa |= 1 << wmo;
-            mantissa >>= 1 - exponent;
-            exponent = 0;
-        }
+  if (exponent <= 0) {
+    mantissa |= 1 << wmo;
+    mantissa >>= 1 - exponent;
+    exponent = 0;
+  }
 
-        if(sizeof(T) == 2)
-            retval = (sign << 15) | (exponent << 10) | mantissa;
-        else
-            retval = (sign << 31) | (exponent << 23) | mantissa;
-        return reinterpret_cast<const T&>(retval);
-    }
+  if (sizeof(T) == 2) retval = (sign << 15) | (exponent << 10) | mantissa;
+  else retval = (sign << 31) | (exponent << 23) | mantissa;
+  return reinterpret_cast<const T&>(retval);
+}
 } // namespace rocblas_hip_f8_impl
 
 static __device__ bool rocblas_hip_f8_bias_mode_bit_device = true;
-static bool            rocblas_hip_f8_bias_mode_bit_host   = true;
+static bool rocblas_hip_f8_bias_mode_bit_host = true;
 
-struct rccl_float8
-{
-    uint8_t data;
-    enum class rocblas_hip_f8_rounding_mode
-    {
-        standard,
-        stochastic
-    };
+struct rccl_float8 {
+  uint8_t data;
+  enum class rocblas_hip_f8_rounding_mode {
+    standard,
+    stochastic
+  };
 
     // default constructor
-    HIP_HOST_DEVICE rccl_float8() = default;
+  HIP_HOST_DEVICE rccl_float8() = default;
 
-    constexpr inline HIP_HOST_DEVICE rccl_float8(const rccl_float8& a) : data(a.data) {}
+  constexpr inline HIP_HOST_DEVICE rccl_float8(const rccl_float8& a) : data(a.data) {}
 
 #if defined(__gfx942__) || defined(__gfx950__)
     // device specific optimized F8 down-conversion code
 
-    template <bool stochastic_rounding = false>
-    static HIP_DEVICE uint8_t cast_to_f8_from_f32(float v, uint32_t rng = 0)
-    {
-        uint8_t i8data;
-        union
-        {
-            float    fval;
-            uint32_t i32val;
-            uint8_t  i8val[4]; // NOTE: not endian independent
-        } val;
+  template <bool stochastic_rounding = false>
+  static HIP_DEVICE uint8_t cast_to_f8_from_f32(float v, uint32_t rng = 0) {
+    uint8_t i8data;
+    union {
+      float fval;
+      uint32_t i32val;
+      uint8_t i8val[4]; // NOTE: not endian independent
+    } val;
 
-        uint32_t ival = 0;
-        val.fval      = v;
+    uint32_t ival = 0;
+    val.fval = v;
 
 #ifdef rccl_float8_downcast_clipping
-        if((val.i32val & 0x7F800000) != 0x7F800000) /// propagate NAN/INF, no clipping
-            val.fval = __builtin_amdgcn_fmed3f(val.fval, 240.0, -240.0);
+    if ((val.i32val & 0x7F800000) != 0x7F800000) /// propagate NAN/INF, no clipping
+      val.fval = __builtin_amdgcn_fmed3f(val.fval, 240.0, -240.0);
 #endif
-        if(stochastic_rounding)
-        {
-            ival       = __builtin_amdgcn_cvt_sr_fp8_f32(val.fval, rng, ival, 0); // 0 pos
-            val.i32val = ival;
-            i8data     = val.i8val[0]; // little endian
-        }
-        else // RNE CVT
-        {
-            ival = __builtin_amdgcn_cvt_pk_fp8_f32(
-                val.fval, val.fval, ival, false); // false -> WORD0
-            val.i32val = ival;
-            i8data     = val.i8val[0];
-        }
-        return i8data;
+    if (stochastic_rounding) {
+      ival = __builtin_amdgcn_cvt_sr_fp8_f32(val.fval, rng, ival, 0); // 0 pos
+      val.i32val = ival;
+      i8data = val.i8val[0]; // little endian
+    } else // RNE CVT
+    {
+      ival = __builtin_amdgcn_cvt_pk_fp8_f32(val.fval, val.fval, ival, false); // false -> WORD0
+      val.i32val = ival;
+      i8data = val.i8val[0];
     }
+    return i8data;
+  }
 
 #endif // __gfx942__
 
@@ -549,168 +483,133 @@ struct rccl_float8
 #if defined(__gfx942__) || defined(__gfx950__)
 
     // NOTE: ON-DEVICE... always optimal bias
-    explicit HIP_DEVICE rccl_float8(float                        v,
-                                   rocblas_hip_f8_rounding_mode rm
-                                   = rocblas_hip_f8_rounding_mode::standard,
-                                   uint32_t rng = 0)
-    {
+  explicit HIP_DEVICE rccl_float8(float v, rocblas_hip_f8_rounding_mode rm = rocblas_hip_f8_rounding_mode::standard,
+                                  uint32_t rng = 0) {
         // runtime branch, use cast_to_f8_from_f32 if want to avoid it
-        if(rm == rocblas_hip_f8_rounding_mode::stochastic)
-            data = cast_to_f8_from_f32<true>(v, rng);
-        else
-            data = cast_to_f8_from_f32<false>(v);
-    }
+    if (rm == rocblas_hip_f8_rounding_mode::stochastic) data = cast_to_f8_from_f32<true>(v, rng);
+    else data = cast_to_f8_from_f32<false>(v);
+  }
 
     // Host only implementation using s/w simulation
-    explicit HIP_HOST
+  explicit HIP_HOST
 #else
     // both Host and DEVICE for non-gfx942 using s/w simulation
-    explicit HIP_HOST_DEVICE
+  explicit HIP_HOST_DEVICE
 #endif
-        rccl_float8(float                        v,
-                   rocblas_hip_f8_rounding_mode rm  = rocblas_hip_f8_rounding_mode::standard,
-                   uint32_t                     rng = 0)
-    {
+  rccl_float8(float v, rocblas_hip_f8_rounding_mode rm = rocblas_hip_f8_rounding_mode::standard, uint32_t rng = 0) {
 #ifdef rccl_float8_downcast_clipping
-        data = rocblas_hip_f8_impl::
-            cast_to_f8<3, 4, float, true /*negative_zero_nan*/, true /*clip*/>(
-                v, (rm == rocblas_hip_f8_rounding_mode::stochastic), rng);
+    data = rocblas_hip_f8_impl::cast_to_f8<3, 4, float, true /*negative_zero_nan*/, true /*clip*/>(
+      v, (rm == rocblas_hip_f8_rounding_mode::stochastic), rng);
 #else // rccl_float8_downcast_clipping
-        data = rocblas_hip_f8_impl::
-            cast_to_f8<3, 4, float, true /*negative_zero_nan*/, false /*clip*/>(
-                v, (rm == rocblas_hip_f8_rounding_mode::stochastic), rng);
+    data = rocblas_hip_f8_impl::cast_to_f8<3, 4, float, true /*negative_zero_nan*/, false /*clip*/>(
+      v, (rm == rocblas_hip_f8_rounding_mode::stochastic), rng);
 #endif // rccl_float8_downcast_clipping
-    }
+  }
 
     // Constructor from half
-    explicit HIP_HOST_DEVICE rccl_float8(_Float16                     v,
-                                        rocblas_hip_f8_rounding_mode rm
-                                        = rocblas_hip_f8_rounding_mode::standard,
-                                        uint32_t rng = 0)
-        : rccl_float8((float)v, rm, rng)
-    {
-    }
+  explicit HIP_HOST_DEVICE rccl_float8(
+    _Float16 v, rocblas_hip_f8_rounding_mode rm = rocblas_hip_f8_rounding_mode::standard, uint32_t rng = 0)
+    : rccl_float8((float)v, rm, rng) {}
     // constructor from int
-    explicit HIP_HOST_DEVICE rccl_float8(int                          v,
-                                        rocblas_hip_f8_rounding_mode rm
-                                        = rocblas_hip_f8_rounding_mode::standard,
-                                        uint32_t rng = 0)
-        : rccl_float8((float)v, rm, rng)
-    {
-    }
+  explicit HIP_HOST_DEVICE rccl_float8(int v, rocblas_hip_f8_rounding_mode rm = rocblas_hip_f8_rounding_mode::standard,
+                                       uint32_t rng = 0)
+    : rccl_float8((float)v, rm, rng) {}
     // constructor from double
-    explicit HIP_HOST_DEVICE rccl_float8(double                       v,
-                                        rocblas_hip_f8_rounding_mode rm
-                                        = rocblas_hip_f8_rounding_mode::standard,
-                                        uint32_t rng = 0)
-        : rccl_float8((float)v, rm, rng)
-    {
-    }
+  explicit HIP_HOST_DEVICE rccl_float8(
+    double v, rocblas_hip_f8_rounding_mode rm = rocblas_hip_f8_rounding_mode::standard, uint32_t rng = 0)
+    : rccl_float8((float)v, rm, rng) {}
 
     // convert to float
 #if defined(__gfx942__) || defined(__gfx950__)
     // upcast using device specific intrinsic
-    explicit inline HIP_DEVICE operator float() const
-    {
-        float    fval;
-        uint32_t i32val = static_cast<uint32_t>(data);
+  explicit inline HIP_DEVICE operator float() const {
+    float fval;
+    uint32_t i32val = static_cast<uint32_t>(data);
 
         // upcast
-        asm volatile("v_cvt_f32_fp8 %0, %1 src0_sel:BYTE_0" : "=v"(fval) : "v"(i32val));
+    asm volatile("v_cvt_f32_fp8 %0, %1 src0_sel:BYTE_0" : "=v"(fval) : "v"(i32val));
 
-        return fval;
-    }
+    return fval;
+  }
 
-    explicit inline HIP_HOST operator float() const
+  explicit inline HIP_HOST operator float() const
 #else // non gfx942
-    explicit inline HIP_HOST_DEVICE operator float() const
+  explicit inline HIP_HOST_DEVICE operator float() const
 #endif
-    {
-        return rocblas_hip_f8_impl::cast_from_f8<3, 4, float, true /*negative_zero_nan*/>(data);
-    }
+  {
+    return rocblas_hip_f8_impl::cast_from_f8<3, 4, float, true /*negative_zero_nan*/>(data);
+  }
 
     // convert to half
-    explicit inline HIP_HOST_DEVICE operator _Float16() const
-    {
-        return _Float16(float(*this)); // convert to float, then convert to f16
-    }
+  explicit inline HIP_HOST_DEVICE operator _Float16() const {
+    return _Float16(float(*this)); // convert to float, then convert to f16
+  }
 
     // check for zero
-    inline HIP_HOST_DEVICE bool is_zero() const
-    {
-        return data == 0x00;
-    }
+  inline HIP_HOST_DEVICE bool is_zero() const {
+    return data == 0x00;
+  }
 
     // check for nan
-    inline HIP_HOST_DEVICE bool is_nan() const
-    {
-        return data == 0x80;
-    }
+  inline HIP_HOST_DEVICE bool is_nan() const {
+    return data == 0x80;
+  }
 
     // check for inf
-    inline HIP_HOST_DEVICE bool is_inf() const
-    {
-        return data == 0x80;
-    }
+  inline HIP_HOST_DEVICE bool is_inf() const {
+    return data == 0x80;
+  }
 
     // assignment overloading only from the same F8 types
-    inline HIP_HOST_DEVICE rccl_float8& operator=(const rccl_float8& a)
-    {
-        data = a.data;
-        return *this;
-    }
+  inline HIP_HOST_DEVICE rccl_float8& operator=(const rccl_float8& a) {
+    data = a.data;
+    return *this;
+  }
 };
 
-struct rccl_bfloat8
-{
-    uint8_t data;
-    enum class rocblas_hip_f8_rounding_mode
-    {
-        standard,
-        stochastic
-    };
+struct rccl_bfloat8 {
+  uint8_t data;
+  enum class rocblas_hip_f8_rounding_mode {
+    standard,
+    stochastic
+  };
 
     // default constructor
-    HIP_HOST_DEVICE rccl_bfloat8() = default;
+  HIP_HOST_DEVICE rccl_bfloat8() = default;
 
-    constexpr inline HIP_HOST_DEVICE rccl_bfloat8(const rccl_bfloat8& a) : data(a.data) {}
+  constexpr inline HIP_HOST_DEVICE rccl_bfloat8(const rccl_bfloat8& a) : data(a.data) {}
 
 #if defined(__gfx942__) || defined(__gfx950__)
     // device specific optimized F8 down-conversion code
 
-    template <bool stochastic_rounding = false>
-    static HIP_DEVICE uint8_t cast_to_bf8_from_f32(float v, uint32_t rng = 0)
-    {
-        uint8_t i8data;
-        union
-        {
-            float    fval;
-            uint32_t i32val;
-            uint8_t  i8val[4]; // NOTE: not endian independent
-        } val;
+  template <bool stochastic_rounding = false>
+  static HIP_DEVICE uint8_t cast_to_bf8_from_f32(float v, uint32_t rng = 0) {
+    uint8_t i8data;
+    union {
+      float fval;
+      uint32_t i32val;
+      uint8_t i8val[4]; // NOTE: not endian independent
+    } val;
 
-        uint32_t ival = 0;
-        val.fval      = v;
+    uint32_t ival = 0;
+    val.fval = v;
 
 #ifdef rccl_float8_downcast_clipping
-        if((val.i32val & 0x7F800000) != 0x7F800000) // propagate NAN/INF, no clipping
-            val.fval = __builtin_amdgcn_fmed3f(val.fval, 57344.0, -57344.0);
+    if ((val.i32val & 0x7F800000) != 0x7F800000) // propagate NAN/INF, no clipping
+      val.fval = __builtin_amdgcn_fmed3f(val.fval, 57344.0, -57344.0);
 #endif
-        if(stochastic_rounding)
-        {
-            ival       = __builtin_amdgcn_cvt_sr_bf8_f32(val.fval, rng, ival, 0); // 0 pos
-            val.i32val = ival;
-            i8data     = val.i8val[0]; // little endian
-        }
-        else // RNE CVT
-        {
-            ival = __builtin_amdgcn_cvt_pk_bf8_f32(
-                val.fval, val.fval, ival, false); // false -> WORD0
-            val.i32val = ival;
-            i8data     = val.i8val[0];
-        }
-        return i8data;
+    if (stochastic_rounding) {
+      ival = __builtin_amdgcn_cvt_sr_bf8_f32(val.fval, rng, ival, 0); // 0 pos
+      val.i32val = ival;
+      i8data = val.i8val[0]; // little endian
+    } else // RNE CVT
+    {
+      ival = __builtin_amdgcn_cvt_pk_bf8_f32(val.fval, val.fval, ival, false); // false -> WORD0
+      val.i32val = ival;
+      i8data = val.i8val[0];
     }
+    return i8data;
+  }
 
 #endif // __gfx942__
 
@@ -718,441 +617,353 @@ struct rccl_bfloat8
 #if defined(__gfx942__) || defined(__gfx950__)
 
     // NOTE: ON-DEVICE... always optimal bias
-    explicit HIP_DEVICE rccl_bfloat8(float                        v,
-                                    rocblas_hip_f8_rounding_mode rm
-                                    = rocblas_hip_f8_rounding_mode::standard,
-                                    uint32_t rng = 0)
-    {
+  explicit HIP_DEVICE rccl_bfloat8(float v, rocblas_hip_f8_rounding_mode rm = rocblas_hip_f8_rounding_mode::standard,
+                                   uint32_t rng = 0) {
         // runtime branch, use cast_to_f8_from_f32 if want to avoid it
-        if(rm == rocblas_hip_f8_rounding_mode::stochastic)
-            data = cast_to_bf8_from_f32<true>(v, rng);
-        else
-            data = cast_to_bf8_from_f32<false>(v);
-    }
+    if (rm == rocblas_hip_f8_rounding_mode::stochastic) data = cast_to_bf8_from_f32<true>(v, rng);
+    else data = cast_to_bf8_from_f32<false>(v);
+  }
 
     // Host only implementation using s/w simulation
-    explicit HIP_HOST
+  explicit HIP_HOST
 #else
     // both Host and DEVICE for non-gfx942 using s/w simulation
-    explicit HIP_HOST_DEVICE
+  explicit HIP_HOST_DEVICE
 #endif
-        rccl_bfloat8(float                        v,
-                    rocblas_hip_f8_rounding_mode rm  = rocblas_hip_f8_rounding_mode::standard,
-                    uint32_t                     rng = 0)
-    {
+  rccl_bfloat8(float v, rocblas_hip_f8_rounding_mode rm = rocblas_hip_f8_rounding_mode::standard, uint32_t rng = 0) {
 #ifdef rccl_float8_downcast_clipping
-        data = rocblas_hip_f8_impl::
-            cast_to_f8<2, 5, float, true /*negative_zero_nan*/, true /*clip*/>(
-                v, (rm == rocblas_hip_f8_rounding_mode::stochastic), rng);
+    data = rocblas_hip_f8_impl::cast_to_f8<2, 5, float, true /*negative_zero_nan*/, true /*clip*/>(
+      v, (rm == rocblas_hip_f8_rounding_mode::stochastic), rng);
 #else
-        data = rocblas_hip_f8_impl::
-            cast_to_f8<2, 5, float, true /*negative_zero_nan*/, false /*clip*/>(
-                v, (rm == rocblas_hip_f8_rounding_mode::stochastic), rng);
+    data = rocblas_hip_f8_impl::cast_to_f8<2, 5, float, true /*negative_zero_nan*/, false /*clip*/>(
+      v, (rm == rocblas_hip_f8_rounding_mode::stochastic), rng);
 #endif // rccl_float8_downcast_clipping
-    }
+  }
 
     // Constructor from half
-    explicit HIP_HOST_DEVICE rccl_bfloat8(_Float16                     v,
-                                         rocblas_hip_f8_rounding_mode rm
-                                         = rocblas_hip_f8_rounding_mode::standard,
-                                         uint32_t rng = 0)
-        : rccl_bfloat8((float)v, rm, rng)
-    {
-    }
+  explicit HIP_HOST_DEVICE rccl_bfloat8(
+    _Float16 v, rocblas_hip_f8_rounding_mode rm = rocblas_hip_f8_rounding_mode::standard, uint32_t rng = 0)
+    : rccl_bfloat8((float)v, rm, rng) {}
     // constructor from int
-    explicit HIP_HOST_DEVICE rccl_bfloat8(int                          v,
-                                         rocblas_hip_f8_rounding_mode rm
-                                         = rocblas_hip_f8_rounding_mode::standard,
-                                         uint32_t rng = 0)
-        : rccl_bfloat8((float)v, rm, rng)
-    {
-    }
+  explicit HIP_HOST_DEVICE rccl_bfloat8(int v, rocblas_hip_f8_rounding_mode rm = rocblas_hip_f8_rounding_mode::standard,
+                                        uint32_t rng = 0)
+    : rccl_bfloat8((float)v, rm, rng) {}
     // constructor from double
-    explicit HIP_HOST_DEVICE rccl_bfloat8(double                       v,
-                                         rocblas_hip_f8_rounding_mode rm
-                                         = rocblas_hip_f8_rounding_mode::standard,
-                                         uint32_t rng = 0)
-        : rccl_bfloat8((float)v, rm, rng)
-    {
-    }
+  explicit HIP_HOST_DEVICE rccl_bfloat8(
+    double v, rocblas_hip_f8_rounding_mode rm = rocblas_hip_f8_rounding_mode::standard, uint32_t rng = 0)
+    : rccl_bfloat8((float)v, rm, rng) {}
 
     // convert to float
 #if defined(__gfx942__) || defined(__gfx950__)
     // upcast using device specific intrinsic
-    explicit inline HIP_DEVICE operator float() const
-    {
-        float    fval;
-        uint32_t i32val = static_cast<uint32_t>(data);
+  explicit inline HIP_DEVICE operator float() const {
+    float fval;
+    uint32_t i32val = static_cast<uint32_t>(data);
 
         // upcast
-        asm volatile("v_cvt_f32_bf8 %0, %1 src0_sel:BYTE_0" : "=v"(fval) : "v"(i32val));
+    asm volatile("v_cvt_f32_bf8 %0, %1 src0_sel:BYTE_0" : "=v"(fval) : "v"(i32val));
 
-        return fval;
-    }
+    return fval;
+  }
 
-    explicit inline HIP_HOST operator float() const
+  explicit inline HIP_HOST operator float() const
 #else // non gfx942
-    explicit inline HIP_HOST_DEVICE operator float() const
+  explicit inline HIP_HOST_DEVICE operator float() const
 #endif
-    {
-        return rocblas_hip_f8_impl::cast_from_f8<2, 5, float, true /*negative_zero_nan*/>(data);
-    }
+  {
+    return rocblas_hip_f8_impl::cast_from_f8<2, 5, float, true /*negative_zero_nan*/>(data);
+  }
 
     // convert to half
-    explicit inline HIP_HOST_DEVICE operator _Float16() const
-    {
-        return _Float16(float(*this)); // convert to float, then convert to f16
-    }
+  explicit inline HIP_HOST_DEVICE operator _Float16() const {
+    return _Float16(float(*this)); // convert to float, then convert to f16
+  }
 
     // check for zero
-    inline HIP_HOST_DEVICE bool is_zero() const
-    {
-        return data == 0x00;
-    }
+  inline HIP_HOST_DEVICE bool is_zero() const {
+    return data == 0x00;
+  }
 
     // check for nan
-    inline HIP_HOST_DEVICE bool is_nan() const
-    {
-        return data == 0x80;
-    }
+  inline HIP_HOST_DEVICE bool is_nan() const {
+    return data == 0x80;
+  }
 
     // check for inf
-    inline HIP_HOST_DEVICE bool is_inf() const
-    {
-        return data == 0x80;
-    }
+  inline HIP_HOST_DEVICE bool is_inf() const {
+    return data == 0x80;
+  }
 
     // assignment overloading only from the same F8 types
-    inline HIP_HOST_DEVICE rccl_bfloat8& operator=(const rccl_bfloat8& a)
-    {
-        data = a.data;
-        return *this;
-    }
+  inline HIP_HOST_DEVICE rccl_bfloat8& operator=(const rccl_bfloat8& a) {
+    data = a.data;
+    return *this;
+  }
 };
 
-namespace std
-{
-    inline rccl_float8 sin(rccl_float8 a)
-    {
-        return rccl_float8(sinf(float(a)));
-    }
-    inline rccl_float8 cos(rccl_float8 a)
-    {
-        return rccl_float8(cosf(float(a)));
-    }
-    inline rccl_bfloat8 sin(rccl_bfloat8 a)
-    {
-        return rccl_bfloat8(sinf(float(a)));
-    }
-    inline rccl_bfloat8 cos(rccl_bfloat8 a)
-    {
-        return rccl_bfloat8(cosf(float(a)));
-    }
-    HIP_HOST_DEVICE constexpr rccl_float8 real(const rccl_float8& a)
-    {
-        return a;
-    }
-    HIP_HOST_DEVICE constexpr rccl_bfloat8 real(const rccl_bfloat8& a)
-    {
-        return a;
-    }
+namespace std {
+inline rccl_float8 sin(rccl_float8 a) {
+  return rccl_float8(sinf(float(a)));
+}
+inline rccl_float8 cos(rccl_float8 a) {
+  return rccl_float8(cosf(float(a)));
+}
+inline rccl_bfloat8 sin(rccl_bfloat8 a) {
+  return rccl_bfloat8(sinf(float(a)));
+}
+inline rccl_bfloat8 cos(rccl_bfloat8 a) {
+  return rccl_bfloat8(cosf(float(a)));
+}
+HIP_HOST_DEVICE constexpr rccl_float8 real(const rccl_float8& a) {
+  return a;
+}
+HIP_HOST_DEVICE constexpr rccl_bfloat8 real(const rccl_bfloat8& a) {
+  return a;
+}
+} // namespace std
+
+inline __device__ rccl_float8 hadd(rccl_float8 x, rccl_float8 y) {
+  return rccl_float8(float(x) + float(y));
 }
 
-inline __device__  rccl_float8 hadd(rccl_float8 x, rccl_float8 y)
-{
-	return rccl_float8(float(x) + float(y));
+inline __device__ fp8x2_storage_t hadd2(fp8x2_storage_t x, fp8x2_storage_t y) {
+  union {
+    rccl_float8 fp8[2];
+    fp8x2_storage_t fp8x2;
+  } u, v, w;
+  u.fp8x2 = x;
+  v.fp8x2 = y;
+  w.fp8[0] = hadd(u.fp8[0], v.fp8[0]);
+  w.fp8[1] = hadd(u.fp8[1], v.fp8[1]);
+
+  return w.fp8x2;
 }
 
-inline __device__  fp8x2_storage_t hadd2(fp8x2_storage_t x, fp8x2_storage_t y)
-{
-    union {
-      rccl_float8 fp8[2];
-      fp8x2_storage_t fp8x2;
-    } u, v, w;
-    u.fp8x2 = x;
-    v.fp8x2 = y;
-    w.fp8[0] = hadd(u.fp8[0], v.fp8[0]);
-    w.fp8[1] = hadd(u.fp8[1], v.fp8[1]);
-
-	return w.fp8x2;
+inline __device__ rccl_bfloat8 hadd_b(rccl_bfloat8 x, rccl_bfloat8 y) {
+  return rccl_bfloat8(float(x) + float(y));
 }
 
-inline __device__  rccl_bfloat8 hadd_b(rccl_bfloat8 x, rccl_bfloat8 y)
-{
-    return rccl_bfloat8(float(x) + float(y));
-}
+inline __device__ fp8x2_storage_t hadd2_b(fp8x2_storage_t x, fp8x2_storage_t y) {
+  union {
+    rccl_bfloat8 fp8[2];
+    fp8x2_storage_t fp8x2;
+  } u, v, w;
+  u.fp8x2 = x;
+  v.fp8x2 = y;
+  w.fp8[0] = hadd_b(u.fp8[0], v.fp8[0]);
+  w.fp8[1] = hadd_b(u.fp8[1], v.fp8[1]);
 
-inline __device__  fp8x2_storage_t hadd2_b(fp8x2_storage_t x, fp8x2_storage_t y)                                            {
-    union {
-      rccl_bfloat8 fp8[2];
-      fp8x2_storage_t fp8x2;
-    } u, v, w;
-    u.fp8x2 = x;
-    v.fp8x2 = y;
-    w.fp8[0] = hadd_b(u.fp8[0], v.fp8[0]);
-    w.fp8[1] = hadd_b(u.fp8[1], v.fp8[1]);
-
-	return w.fp8x2;
+  return w.fp8x2;
 }
 
 // Special operator overloading
-inline std::ostream& operator<<(std::ostream& os, const rccl_float8& f8)
-{
-    return os << float(f8);
+inline std::ostream& operator<<(std::ostream& os, const rccl_float8& f8) {
+  return os << float(f8);
 }
 
-inline std::ostream& operator<<(std::ostream& os, const rccl_bfloat8& bf8)
-{
-    return os << float(bf8);
+inline std::ostream& operator<<(std::ostream& os, const rccl_bfloat8& bf8) {
+  return os << float(bf8);
 }
 
 // all + operator overloading with mixed types
 // mixed types, always converts to f32, does computation in f32, and returns float
-inline __host__ __device__ float operator+(const float fa, rccl_float8 b)
-{
-    return (fa + float(b));
+inline __host__ __device__ float operator+(const float fa, rccl_float8 b) {
+  return (fa + float(b));
 }
 
-inline __host__ __device__ float operator+(const float fa, rccl_bfloat8 b)
-{
-    return (fa + float(b));
+inline __host__ __device__ float operator+(const float fa, rccl_bfloat8 b) {
+  return (fa + float(b));
 }
 
-inline __host__ __device__ float operator+(rccl_float8 a, const float fb)
-{
-    return (float(a) + fb);
+inline __host__ __device__ float operator+(rccl_float8 a, const float fb) {
+  return (float(a) + fb);
 }
 
-inline __host__ __device__ float operator+(rccl_bfloat8 a, const float fb)
-{
-    return (float(a) + fb);
+inline __host__ __device__ float operator+(rccl_bfloat8 a, const float fb) {
+  return (float(a) + fb);
 }
 
-inline __host__ __device__ float operator+(rccl_float8 a, rccl_bfloat8 b)
-{
-    return (float(a) + float(b));
+inline __host__ __device__ float operator+(rccl_float8 a, rccl_bfloat8 b) {
+  return (float(a) + float(b));
 }
 
-inline __host__ __device__ float operator+(rccl_bfloat8 a, rccl_float8 b)
-{
-    return (float(a) + float(b));
+inline __host__ __device__ float operator+(rccl_bfloat8 a, rccl_float8 b) {
+  return (float(a) + float(b));
 }
 
-inline __host__ __device__ rccl_float8 operator+(rccl_float8 a, rccl_float8 b)
-{
-    return rccl_float8(float(a) + float(b));
+inline __host__ __device__ rccl_float8 operator+(rccl_float8 a, rccl_float8 b) {
+  return rccl_float8(float(a) + float(b));
 }
 
-inline __host__ __device__ rccl_bfloat8 operator+(rccl_bfloat8 a, rccl_bfloat8 b)
-{
-    return rccl_bfloat8(float(a) + float(b));
+inline __host__ __device__ rccl_bfloat8 operator+(rccl_bfloat8 a, rccl_bfloat8 b) {
+  return rccl_bfloat8(float(a) + float(b));
 }
 
-inline __host__ __device__ rccl_float8& operator+=(rccl_float8& a, rccl_float8 b)
-{
-    return a = rccl_float8(float(a) + float(b));
+inline __host__ __device__ rccl_float8& operator+=(rccl_float8& a, rccl_float8 b) {
+  return a = rccl_float8(float(a) + float(b));
 }
 
-inline __host__ __device__ rccl_bfloat8& operator+=(rccl_bfloat8& a, rccl_bfloat8 b)
-{
-    return a = rccl_bfloat8(float(a) + float(b));
+inline __host__ __device__ rccl_bfloat8& operator+=(rccl_bfloat8& a, rccl_bfloat8 b) {
+  return a = rccl_bfloat8(float(a) + float(b));
 }
 
 // overloading multiplication, always returns float,
-inline __host__ __device__ float operator*(rccl_float8 a, rccl_float8 b)
-{
-    return float(a) * float(b);
+inline __host__ __device__ float operator*(rccl_float8 a, rccl_float8 b) {
+  return float(a) * float(b);
 }
 
-inline __host__ __device__ float operator*(float a, rccl_float8 b)
-{
-    return (a * float(b));
+inline __host__ __device__ float operator*(float a, rccl_float8 b) {
+  return (a * float(b));
 }
 
-inline __host__ __device__ float operator*(rccl_float8 a, float b)
-{
-    return (float(a) * b);
+inline __host__ __device__ float operator*(rccl_float8 a, float b) {
+  return (float(a) * b);
 }
 
-inline __host__ __device__ float operator*(int32_t a, rccl_float8 b)
-{
-    return ((float)a * float(b));
+inline __host__ __device__ float operator*(int32_t a, rccl_float8 b) {
+  return ((float)a * float(b));
 }
 
-inline __host__ __device__ float operator*(double a, rccl_float8 b)
-{
-    return ((float)a * float(b));
+inline __host__ __device__ float operator*(double a, rccl_float8 b) {
+  return ((float)a * float(b));
 }
 
-inline __host__ __device__ float operator*(rccl_bfloat8 a, rccl_bfloat8 b)
-{
-    return float(a) * float(b);
+inline __host__ __device__ float operator*(rccl_bfloat8 a, rccl_bfloat8 b) {
+  return float(a) * float(b);
 }
 
-inline __host__ __device__ float operator*(float a, rccl_bfloat8 b)
-{
-    return (a * float(b));
+inline __host__ __device__ float operator*(float a, rccl_bfloat8 b) {
+  return (a * float(b));
 }
 
-inline __host__ __device__ float operator*(rccl_bfloat8 a, float b)
-{
-    return (float(a) * b);
+inline __host__ __device__ float operator*(rccl_bfloat8 a, float b) {
+  return (float(a) * b);
 }
 
-inline __host__ __device__ float operator*(int32_t a, rccl_bfloat8 b)
-{
-    return ((float)a * float(b));
+inline __host__ __device__ float operator*(int32_t a, rccl_bfloat8 b) {
+  return ((float)a * float(b));
 }
 
-inline __host__ __device__ float operator*(double a, rccl_bfloat8 b)
-{
-    return ((float)a * float(b));
+inline __host__ __device__ float operator*(double a, rccl_bfloat8 b) {
+  return ((float)a * float(b));
 }
 
 // overloading for mixed f8 and bf8 types
-inline __host__ __device__ float operator*(rccl_float8 a, rccl_bfloat8 b)
-{
-    return float(a) * float(b);
+inline __host__ __device__ float operator*(rccl_float8 a, rccl_bfloat8 b) {
+  return float(a) * float(b);
 }
 
-inline __host__ __device__ float operator*(rccl_bfloat8 a, rccl_float8 b)
-{
-    return float(a) * float(b);
+inline __host__ __device__ float operator*(rccl_bfloat8 a, rccl_float8 b) {
+  return float(a) * float(b);
 }
 
 // all - operator overloading with mixed types
 // mixed types, always converts to f32, does computation in f32, and returns float
-inline __host__ __device__ float operator-(const float fa, rccl_float8 b)
-{
-    return (fa - float(b));
+inline __host__ __device__ float operator-(const float fa, rccl_float8 b) {
+  return (fa - float(b));
 }
 
-inline __host__ __device__ float operator-(const float fa, rccl_bfloat8 b)
-{
-    return (fa - float(b));
+inline __host__ __device__ float operator-(const float fa, rccl_bfloat8 b) {
+  return (fa - float(b));
 }
 
-inline __host__ __device__ float operator-(rccl_float8 a, const float fb)
-{
-    return (float(a) - fb);
+inline __host__ __device__ float operator-(rccl_float8 a, const float fb) {
+  return (float(a) - fb);
 }
 
-inline __host__ __device__ float operator-(rccl_bfloat8 a, const float fb)
-{
-    return (float(a) - fb);
+inline __host__ __device__ float operator-(rccl_bfloat8 a, const float fb) {
+  return (float(a) - fb);
 }
 
-inline __host__ __device__ float operator-(rccl_float8 a, rccl_bfloat8 b)
-{
-    return (float(a) - float(b));
+inline __host__ __device__ float operator-(rccl_float8 a, rccl_bfloat8 b) {
+  return (float(a) - float(b));
 }
 
-inline __host__ __device__ float operator-(rccl_bfloat8 a, rccl_float8 b)
-{
-    return (float(a) - float(b));
+inline __host__ __device__ float operator-(rccl_bfloat8 a, rccl_float8 b) {
+  return (float(a) - float(b));
 }
 
-inline __host__ __device__ rccl_float8 operator-(rccl_float8 a, rccl_float8 b)
-{
-    return rccl_float8(float(a) - float(b));
+inline __host__ __device__ rccl_float8 operator-(rccl_float8 a, rccl_float8 b) {
+  return rccl_float8(float(a) - float(b));
 }
 
-inline __host__ __device__ rccl_bfloat8 operator-(rccl_bfloat8 a, rccl_bfloat8 b)
-{
-    return rccl_bfloat8(float(a) - float(b));
+inline __host__ __device__ rccl_bfloat8 operator-(rccl_bfloat8 a, rccl_bfloat8 b) {
+  return rccl_bfloat8(float(a) - float(b));
 }
 
-inline __host__ __device__ rccl_float8& operator-=(rccl_float8& a, rccl_float8 b)
-{
-    return a = rccl_float8(float(a) - float(b));
+inline __host__ __device__ rccl_float8& operator-=(rccl_float8& a, rccl_float8 b) {
+  return a = rccl_float8(float(a) - float(b));
 }
 
-inline __host__ __device__ rccl_bfloat8& operator-=(rccl_bfloat8& a, rccl_bfloat8 b)
-{
-    return a = rccl_bfloat8(float(a) - float(b));
+inline __host__ __device__ rccl_bfloat8& operator-=(rccl_bfloat8& a, rccl_bfloat8 b) {
+  return a = rccl_bfloat8(float(a) - float(b));
 }
 
 // overloading division, always returns float,
-inline __host__ __device__ float operator/(rccl_float8 a, rccl_float8 b)
-{
-    return float(a) / float(b);
+inline __host__ __device__ float operator/(rccl_float8 a, rccl_float8 b) {
+  return float(a) / float(b);
 }
 
-inline __host__ __device__ float operator/(float a, rccl_float8 b)
-{
-    return (a / float(b));
+inline __host__ __device__ float operator/(float a, rccl_float8 b) {
+  return (a / float(b));
 }
 
-inline __host__ __device__ float operator/(rccl_float8 a, float b)
-{
-    return (float(a) / b);
+inline __host__ __device__ float operator/(rccl_float8 a, float b) {
+  return (float(a) / b);
 }
 
-inline __host__ __device__ float operator/(int32_t a, rccl_float8 b)
-{
-    return ((float)a / float(b));
+inline __host__ __device__ float operator/(int32_t a, rccl_float8 b) {
+  return ((float)a / float(b));
 }
 
-inline __host__ __device__ float operator/(double a, rccl_float8 b)
-{
-    return ((float)a / float(b));
+inline __host__ __device__ float operator/(double a, rccl_float8 b) {
+  return ((float)a / float(b));
 }
 
-inline __host__ __device__ float operator/(rccl_bfloat8 a, rccl_bfloat8 b)
-{
-    return float(a) / float(b);
+inline __host__ __device__ float operator/(rccl_bfloat8 a, rccl_bfloat8 b) {
+  return float(a) / float(b);
 }
 
-inline __host__ __device__ float operator/(float a, rccl_bfloat8 b)
-{
-    return (a / float(b));
+inline __host__ __device__ float operator/(float a, rccl_bfloat8 b) {
+  return (a / float(b));
 }
 
-inline __host__ __device__ float operator/(rccl_bfloat8 a, float b)
-{
-    return (float(a) / b);
+inline __host__ __device__ float operator/(rccl_bfloat8 a, float b) {
+  return (float(a) / b);
 }
 
-inline __host__ __device__ float operator/(int32_t a, rccl_bfloat8 b)
-{
-    return ((float)a / float(b));
+inline __host__ __device__ float operator/(int32_t a, rccl_bfloat8 b) {
+  return ((float)a / float(b));
 }
 
-inline __host__ __device__ float operator/(double a, rccl_bfloat8 b)
-{
-    return ((float)a / float(b));
+inline __host__ __device__ float operator/(double a, rccl_bfloat8 b) {
+  return ((float)a / float(b));
 }
 
 // overloading for mixed f8 and bf8 types
-inline __host__ __device__ float operator/(rccl_float8 a, rccl_bfloat8 b)
-{
-    return float(a) / float(b);
+inline __host__ __device__ float operator/(rccl_float8 a, rccl_bfloat8 b) {
+  return float(a) / float(b);
 }
 
-inline __host__ __device__ float operator/(rccl_bfloat8 a, rccl_float8 b)
-{
-    return float(a) / float(b);
+inline __host__ __device__ float operator/(rccl_bfloat8 a, rccl_float8 b) {
+  return float(a) / float(b);
 }
 
 // overloading for compare
-inline __host__ __device__ bool operator==(rccl_float8 a, rccl_float8 b)
-{
-    return (a.data == b.data);
+inline __host__ __device__ bool operator==(rccl_float8 a, rccl_float8 b) {
+  return (a.data == b.data);
 }
 
-inline __host__ __device__ bool operator==(rccl_bfloat8 a, rccl_bfloat8 b)
-{
-    return (a.data == b.data);
+inline __host__ __device__ bool operator==(rccl_bfloat8 a, rccl_bfloat8 b) {
+  return (a.data == b.data);
 }
 
-inline __host__ __device__ bool operator!=(rccl_float8 a, rccl_float8 b)
-{
-    return (a.data != b.data);
+inline __host__ __device__ bool operator!=(rccl_float8 a, rccl_float8 b) {
+  return (a.data != b.data);
 }
 
-inline __host__ __device__ bool operator!=(rccl_bfloat8 a, rccl_bfloat8 b)
-{
-    return (a.data != b.data);
+inline __host__ __device__ bool operator!=(rccl_bfloat8 a, rccl_bfloat8 b) {
+  return (a.data != b.data);
 }
 
 // ================ Explicit downcasting to support different rounding (RNE, SR) ===============
@@ -1160,59 +971,44 @@ inline __host__ __device__ bool operator!=(rccl_bfloat8 a, rccl_bfloat8 b)
 // this explicit_downcast function to make any roudning behavior default
 // We have to explicitly call this function with SR flag
 
-template <typename T,
-          typename Ta,
-          bool stochastic_rounding,
+template <typename T, typename Ta, bool stochastic_rounding,
           typename std::enable_if<std::is_same<T, Ta>{}, int>::type = 0>
-inline __host__ __device__ T explicit_downcast(Ta a, uint32_t rng = 0)
-{
+inline __host__ __device__ T explicit_downcast(Ta a, uint32_t rng = 0) {
     // same type, no conversion
-    return a;
+  return a;
 }
 
 // Use h/w intrinsic and optimized version when __gfx942__
 template <
-    typename T,
-    typename Ta,
-    bool stochastic_rounding,
-    typename std::enable_if<(!(std::is_same<T, Ta>{})
-                             && (std::is_same<T, rccl_float8>{} || std::is_same<T, rccl_bfloat8>{})),
-                            int>::type
-    = 0>
-inline __host__ __device__ T explicit_downcast(Ta a, uint32_t rng)
-{
+  typename T, typename Ta, bool stochastic_rounding,
+  typename std::enable_if<
+    (!(std::is_same<T, Ta>{}) && (std::is_same<T, rccl_float8>{} || std::is_same<T, rccl_bfloat8>{})), int>::type = 0>
+inline __host__ __device__ T explicit_downcast(Ta a, uint32_t rng) {
 #if defined(__gfx942__) || defined(__gfx950__)
     // NOTE: we are directly calling cast_to_f8_from_f32 instead of constructor to optimize away one runtime branch
-    T val;
-    if(std::is_same<T, rccl_float8>::value)
-        val.data = rccl_float8::cast_to_f8_from_f32<stochastic_rounding>(float(a), rng);
-    else
-        val.data = rccl_bfloat8::cast_to_bf8_from_f32<stochastic_rounding>(float(a), rng);
-    return val;
+  T val;
+  if (std::is_same<T, rccl_float8>::value)
+    val.data = rccl_float8::cast_to_f8_from_f32<stochastic_rounding>(float(a), rng);
+  else val.data = rccl_bfloat8::cast_to_bf8_from_f32<stochastic_rounding>(float(a), rng);
+  return val;
 #else // non gfx942
-    return T(float(a),
-             stochastic_rounding ? T::rocblas_hip_f8_rounding_mode::stochastic
-                                 : T::rocblas_hip_f8_rounding_mode::standard,
-             rng);
+  return T(
+    float(a),
+    stochastic_rounding ? T::rocblas_hip_f8_rounding_mode::stochastic : T::rocblas_hip_f8_rounding_mode::standard, rng);
 #endif // __gfx942__
 }
 
 // NOTE NOTE: The above code is good if we don't consider HIP-GEMM code and only consider the quantization
 // However, if we need HIP-GEMM for fall-back, we would need explicit_cast handles Tacc=f32 to To=f16/bf16 conversion
 template <
-    typename T,
-    typename Ta,
-    bool stochastic_rounding,
-    typename std::enable_if<(!(std::is_same<T, Ta>{})
-                             && !(std::is_same<T, rccl_float8>{} || std::is_same<T, rccl_bfloat8>{})),
-                            int>::type
-    = 0>
-inline __host__ __device__ T explicit_downcast(Ta a, uint32_t rng)
-{
+  typename T, typename Ta, bool stochastic_rounding,
+  typename std::enable_if<
+    (!(std::is_same<T, Ta>{}) && !(std::is_same<T, rccl_float8>{} || std::is_same<T, rccl_bfloat8>{})), int>::type = 0>
+inline __host__ __device__ T explicit_downcast(Ta a, uint32_t rng) {
     // the return type is not a F8 types, no SR for those types
     // not sure if we have direct conversion, so converting to float first
     // no effect if the input type is float
-    return T(float(a));
+  return T(float(a));
 }
 
 // =================================================================================================

--- a/projects/rccl/src/include/recorder.h
+++ b/projects/rccl/src/include/recorder.h
@@ -8,8 +8,7 @@
 
 #include "info.h"
 
-namespace rccl
-{
+namespace rccl {
 // API opcode covered by rccl replayer
 typedef enum {
   rrBroadcast,
@@ -46,127 +45,99 @@ typedef enum {
   rrOtherCall
 } rcclCall_t;
 
-constexpr const char* rcclCallStr[]
-{
-  "Broadcast",
-  "Reduce",
-  "AllGather",
-  "ReduceScatter",
-  "AllReduce",
-  "AllReduceWithBias",
-  "Send",
-  "Recv",
-  "AllToAll",
-  "AllToAllv",
-  "Gather",
-  "Scatter",
-  "Bcast",
-  "GroupStart",
-  "GroupEnd",
-  "GroupSimulatedEnd",
-  "GetUniqueId",
-  "CommInitDev",
-  "CommInitRank",
-  "CommInitAll",
-  "CommInitRankConfig",
-  "CommSplit",
-  "CommFinalize",
-  "CommDestroy",
-  "CommAbort",
-  "CommRegister",
-  "CommDeregister",
-  "MemAlloc",
-  "MemFree",
-  "RedOpCreatePreMulSum",
-  "RedOpDestroy",
-  "OtherCall"
+constexpr const char* rcclCallStr[]{
+  "Broadcast",    "Reduce",       "AllGather",          "ReduceScatter",     "AllReduce",    "AllReduceWithBias",
+  "Send",         "Recv",         "AllToAll",           "AllToAllv",         "Gather",       "Scatter",
+  "Bcast",        "GroupStart",   "GroupEnd",           "GroupSimulatedEnd", "GetUniqueId",  "CommInitDev",
+  "CommInitRank", "CommInitAll",  "CommInitRankConfig", "CommSplit",         "CommFinalize", "CommDestroy",
+  "CommAbort",    "CommRegister", "CommDeregister",     "MemAlloc",          "MemFree",      "RedOpCreatePreMulSum",
+  "RedOpDestroy", "OtherCall"
 };
 
 struct rcclApiCall {
 // implicit data
-  int                   pid = -1;
-  int                   tid = -1;
-  int                   hipDev = -1;
-  int                   groupDepth = -1;
-  double                timestamp = -1;
-  unsigned long long    graphID = 0;
-  int                   graphCaptured = -1;
+  int pid = -1;
+  int tid = -1;
+  int hipDev = -1;
+  int groupDepth = -1;
+  double timestamp = -1;
+  unsigned long long graphID = 0;
+  int graphCaptured = -1;
 
 // explicit data from header
-  rcclCall_t            type;
-  uint64_t              opCount = 0;
-  const void*           sendbuff = NULL;
-  void*                 recvbuff = NULL;
-  const void*           acc = NULL;
-  void*                 sendPtrBase = NULL;
-  void*                 recvPtrBase = NULL;
-  size_t                sendPtrExtent = 0;
-  size_t                recvPtrExtent = 0;
-  size_t                count = 0;
-  ncclDataType_t        datatype;
-  ncclRedOp_t           op;
-  int                   root = -1;
-  int                   nRanks = -1;
-  ncclComm_t            comm = NULL;
-  hipStream_t           stream = NULL;
-  int                   nTasks = -1;
-  int                   globalRank = -1;
-  uint64_t              commId = 0;
+  rcclCall_t type;
+  uint64_t opCount = 0;
+  const void* sendbuff = NULL;
+  void* recvbuff = NULL;
+  const void* acc = NULL;
+  void* sendPtrBase = NULL;
+  void* recvPtrBase = NULL;
+  size_t sendPtrExtent = 0;
+  size_t recvPtrExtent = 0;
+  size_t count = 0;
+  ncclDataType_t datatype;
+  ncclRedOp_t op;
+  int root = -1;
+  int nRanks = -1;
+  ncclComm_t comm = NULL;
+  hipStream_t stream = NULL;
+  int nTasks = -1;
+  int globalRank = -1;
+  uint64_t commId = 0;
 
-  rcclApiCall(){}
+  rcclApiCall() {}
   rcclApiCall(rcclCall_t type, const ncclInfo& info);
   rcclApiCall(rcclCall_t type);
 };
 
 class Recorder {
- private:
-  std::ofstream         outputFile; // 1 per process
-  int                   output_json = 0; // 0 is to binary, 1 to json
-  std::string           filename;
-  int                   logLevel = -1;
+private:
+  std::ofstream outputFile; // 1 per process
+  int output_json = 0; // 0 is to binary, 1 to json
+  std::string filename;
+  int logLevel = -1;
 
-  //std::string           hostname;
-  int                   pid = -1;
-  [[maybe_unused]] int  numCall = 0; // reserved for future record format/debug
-  bool                  skipped = false; // number of sendrecv calls to skip for gather/scatter/a2a(v)
-  static __thread int   rcclReplayThreadIdx;
-  static int            depth; // for indentation purpose, will need thread safty later
+  // std::string           hostname;
+  int pid = -1;
+  [[maybe_unused]] int numCall = 0; // reserved for future record format/debug
+  bool skipped = false; // number of sendrecv calls to skip for gather/scatter/a2a(v)
+  static __thread int rcclReplayThreadIdx;
+  static int depth; // for indentation purpose, will need thread safty later
 
-  std::mutex            writemtx;
+  std::mutex writemtx;
   std::vector<rcclApiCall> calls;
 
-  void                  captureGpuContext(rcclApiCall& call) const;
-  void                  write(const rcclApiCall &call);
-  static void           recordLater(void* idx);
+  void captureGpuContext(rcclApiCall& call) const;
+  void write(const rcclApiCall& call);
+  static void recordLater(void* idx);
   Recorder();
   Recorder(const Recorder&) = delete;
   Recorder& operator=(const Recorder&) = delete;
   ~Recorder();
 
- public:
-  static Recorder&      instance();
-  void                  skip(bool b);
-  void                  record(const char* name); // non-replayable calls
-  ncclResult_t          record(rcclApiCall& call);
-  ncclResult_t          record(rcclCall_t type, const ncclInfo& info); // collective
-  ncclResult_t          record(rcclCall_t type, const void* sendbuff, void* recvbuff, size_t count, // sendrecv based
-                               ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream, int root = -1,
-                               const size_t sendcounts[] = NULL, const size_t sdispls[] = NULL, const size_t recvcounts[] = NULL,
-                               const size_t rdispls[] = NULL); // for alltoallv
-  ncclResult_t          record(rcclCall_t type, ncclRedOp_t op, ncclComm_t comm,
-                               ncclDataType_t datatype = ncclInt8, ncclScalarResidence_t residence = ncclScalarDevice,
-                               void* scalar = NULL); // redop
-  ncclResult_t          record(rcclCall_t type, int groupDepth); // group op
-  ncclResult_t          record(rcclCall_t type, int size, int rank, ncclUniqueId* commId,
-                               ncclComm_t comm = NULL, int device = 0); // init
-  void                  record(ncclComm_t* comms, int ndev, const int* devlist); // CommInitAll
-  ncclResult_t          record(rcclCall_t type, ncclComm_t comm); // comm destroy
-  void                  record(rcclCall_t type, int size, int rank, ncclUniqueId* commId, ncclConfig_t* config,
-                               ncclComm_t comm = NULL); // CommInitConfig OR split
-  ncclResult_t          record(rcclCall_t type, void* ptr, size_t size = 0); // mem alloc
-  ncclResult_t          record(rcclCall_t type, ncclComm_t comm, void* handle,
-                               void* userBuffer = NULL, size_t size = 0); // UBR
-  void                  record(int groupDepth, ncclSimInfo_t* siminfo); // SimulatedGroupEnd
+public:
+  static Recorder& instance();
+  void skip(bool b);
+  void record(const char* name); // non-replayable calls
+  ncclResult_t record(rcclApiCall& call);
+  ncclResult_t record(rcclCall_t type, const ncclInfo& info); // collective
+  ncclResult_t record(rcclCall_t type, const void* sendbuff, void* recvbuff, size_t count, // sendrecv based
+                      ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream, int root = -1,
+                      const size_t sendcounts[] = NULL, const size_t sdispls[] = NULL, const size_t recvcounts[] = NULL,
+                      const size_t rdispls[] = NULL); // for alltoallv
+  ncclResult_t record(rcclCall_t type, ncclRedOp_t op, ncclComm_t comm, ncclDataType_t datatype = ncclInt8,
+                      ncclScalarResidence_t residence = ncclScalarDevice,
+                      void* scalar = NULL); // redop
+  ncclResult_t record(rcclCall_t type, int groupDepth); // group op
+  ncclResult_t record(rcclCall_t type, int size, int rank, ncclUniqueId* commId, ncclComm_t comm = NULL,
+                      int device = 0); // init
+  void record(ncclComm_t* comms, int ndev, const int* devlist); // CommInitAll
+  ncclResult_t record(rcclCall_t type, ncclComm_t comm); // comm destroy
+  void record(rcclCall_t type, int size, int rank, ncclUniqueId* commId, ncclConfig_t* config,
+              ncclComm_t comm = NULL); // CommInitConfig OR split
+  ncclResult_t record(rcclCall_t type, void* ptr, size_t size = 0); // mem alloc
+  ncclResult_t record(rcclCall_t type, ncclComm_t comm, void* handle, void* userBuffer = NULL, size_t size = 0); // UBR
+  void record(int groupDepth, ncclSimInfo_t* siminfo); // SimulatedGroupEnd
 };
 
 void parseJsonEntry(const char* entry, std::vector<rcclApiCall>& calls);

--- a/projects/rccl/src/include/register.h
+++ b/projects/rccl/src/include/register.h
@@ -63,14 +63,14 @@ struct ncclReg {
 };
 
 struct ncclRegCache {
-  struct ncclReg **slots;
+  struct ncclReg** slots;
   int capacity, population;
   uintptr_t pageSize;
 };
 
 ncclResult_t ncclRegCleanup(struct ncclComm* comm);
 ncclResult_t ncclCommGraphRegister(const ncclComm_t comm, void* buff, size_t size, void** handle);
-ncclResult_t ncclCommGraphDeregister(const ncclComm_t comm, struct ncclReg *handle);
-ncclResult_t ncclRegLocalIsValid(struct ncclReg *reg, bool *isValid);
+ncclResult_t ncclCommGraphDeregister(const ncclComm_t comm, struct ncclReg* handle);
+ncclResult_t ncclRegLocalIsValid(struct ncclReg* reg, bool* isValid);
 
 #endif

--- a/projects/rccl/src/include/register_inline.h
+++ b/projects/rccl/src/include/register_inline.h
@@ -15,9 +15,9 @@
 static inline ncclResult_t ncclRegFind(struct ncclComm* comm, const void* data, size_t size, struct ncclReg** outReg) {
   struct ncclRegCache* cache = &comm->regCache;
   *outReg = NULL;
-  for (int slot=0; /*true*/; slot++) {
+  for (int slot = 0; /*true*/; slot++) {
     if (slot == cache->population) return ncclSuccess;
-    struct ncclReg *reg = cache->slots[slot];
+    struct ncclReg* reg = cache->slots[slot];
     if ((uintptr_t)data < reg->begAddr) return ncclSuccess;
     if ((uintptr_t)data + size <= reg->endAddr) {
       *outReg = reg;
@@ -25,6 +25,5 @@ static inline ncclResult_t ncclRegFind(struct ncclComm* comm, const void* data, 
     }
   }
 }
-
 
 #endif

--- a/projects/rccl/src/include/rma/rma.h
+++ b/projects/rccl/src/include/rma/rma.h
@@ -19,7 +19,7 @@ typedef enum {
   NCCL_SIGNAL = 1              // Default signal operation
 } ncclSignalMode_t;
 
-struct ncclRmaArgs{
+struct ncclRmaArgs {
   int ctx;
   ncclFunc_t func;
   int nRmaTasks;

--- a/projects/rccl/src/include/rma/rma_ce.h
+++ b/projects/rccl/src/include/rma/rma_ce.h
@@ -16,16 +16,16 @@ struct ncclComm;
 struct ncclRmaArgs;
 
 struct ncclRmaCeInitTask {
-  struct ncclRmaCeInitTask *next;
+  struct ncclRmaCeInitTask* next;
   struct ncclComm* comm;
 };
 
 struct ncclRmaCeCtx {
-  struct ncclComm *comm;
+  struct ncclComm* comm;
 
   // Per-rank sequence number for non-graph signal operations
   uint64_t* signalOpSeqs;
-  uint64_t *signalOpSeqsDev;
+  uint64_t* signalOpSeqsDev;
   // Host buffer to track the expected values of the non-graph signals
   uint64_t* signalsHost;
 
@@ -38,19 +38,18 @@ struct ncclRmaCeCtx {
   //   [2*nRanks+2 .. 3*nRanks+1]   graph per-rank ack flags
   // Total: (3*nRanks + 2) * sizeof(uint64_t)
   struct ncclDevrWindow* signalsWin;
-  uint64_t *signalsDev;       // non-graph per-rank signals
-  uint64_t *graphSignalsDev;  // graph per-rank signals
-  uint64_t *graphAckDev;      // graph per-rank ack flags
+  uint64_t* signalsDev;       // non-graph per-rank signals
+  uint64_t* graphSignalsDev;  // graph per-rank signals
+  uint64_t* graphAckDev;      // graph per-rank ack flags
   size_t signalOffset;        // byte offset of non-graph signals
   size_t graphSignalOffset;   // byte offset of graph signals
   size_t graphAckOffset;      // byte offset of graph ack flags
 
   // Device-resident constants for graph-safe D2D signal/ack writes
-  uint64_t *signalConstDev;
-  uint64_t *signalConstOneDev;
-  uint64_t *signalConstZeroDev;
+  uint64_t* signalConstDev;
+  uint64_t* signalConstOneDev;
+  uint64_t* signalConstZeroDev;
 };
-
 
 struct ncclRmaCeState {
   bool initialized;

--- a/projects/rccl/src/include/rma/rma_proxy.h
+++ b/projects/rccl/src/include/rma/rma_proxy.h
@@ -25,7 +25,7 @@ struct ncclComm;
 struct ncclRmaArgs;
 
 struct ncclRmaSignal_t {
-  void *signalMhandle;
+  void* signalMhandle;
   uint64_t offset;
   uint64_t val;
   uint32_t op;
@@ -45,9 +45,9 @@ typedef enum ncclRmaDescType_t {
 struct ncclRmaPutSignalDesc {
   // Network function descriptor
   uint64_t srcOff;
-  void *srcHandle;
+  void* srcHandle;
   uint64_t dstOff;
-  void *dstHandle;
+  void* dstHandle;
   size_t size;
   int targetRank;
   ncclRmaSignal_t signal;
@@ -65,7 +65,7 @@ struct ncclRmaWaitSignalDesc {
 };
 
 struct ncclRmaProxyDesc {
-  struct ncclRmaProxyDesc *next;
+  struct ncclRmaProxyDesc* next;
   ncclRmaDescType_t rmaDescType;
   ncclRmaDescState_t rmaDescState;
 
@@ -87,25 +87,24 @@ struct ncclRmaProxyDesc {
   // Graph capture fields
   struct ncclKernelPlan* persistPlan; // Back reference to persistent plan during clean up
   bool persistDescValid; // Persistent descriptor is valid
-
 };
 
 struct ncclRmaProxyCtx {
-  struct ncclComm *comm;
+  struct ncclComm* comm;
 
   // GIN context for the RMA proxy context
-  void *ginCollComm;
-  void *ginCtx;
-  ncclNetDeviceHandle_t *devHandle;
+  void* ginCollComm;
+  void* ginCtx;
+  ncclNetDeviceHandle_t* devHandle;
   ncclNetProperties_t props;
 
   //---------Non-graph descriptor queues and synchronization---------
 
   // Lock-free circular buffer for pending Descs
-  size_t queueSize;  // Power of 2 size for pending queue
-  struct ncclRmaProxyDesc** circularBuffers;  // Lock-free circular buffer per peer
-  uint32_t* pis;  // Producer Indices per peer
-  uint32_t* cis;  // Consumer Indices per peer
+  size_t queueSize; // Power of 2 size for pending queue
+  struct ncclRmaProxyDesc** circularBuffers; // Lock-free circular buffer per peer
+  uint32_t* pis; // Producer Indices per peer
+  uint32_t* cis; // Consumer Indices per peer
 
   // Per-rank inProgressQueues: Descs with issued network operations waiting for completion
   struct ncclIntruQueue<struct ncclRmaProxyDesc, &ncclRmaProxyDesc::next>* inProgressQueues;
@@ -127,9 +126,9 @@ struct ncclRmaProxyCtx {
   // - Offset [nRanks*8]: shared aggregate signal counter (8 bytes)
   // Total signal buffer size: (nRanks + 1) * 8 bytes
   CUmemGenericAllocationHandle signalsCumemhandle;
-  void *signalsMhandle;
-  void *signalsGinHandle;
-  uint64_t *signalsDev;
+  void* signalsMhandle;
+  void* signalsGinHandle;
+  uint64_t* signalsDev;
   uint64_t* signalsHost; // Host buffer to track the expected values of the signals
 
   //---------Graph descriptor queues and synchronization---------
@@ -138,22 +137,22 @@ struct ncclRmaProxyCtx {
   struct ncclIntruQueue<struct ncclRmaProxyDesc, &ncclRmaProxyDesc::next>* persistentQueues;
 
   // CPU-accessible signal is required as proxy needs to poll on the signal values
-  void *cpuAccessSignalsGdrHandle;
-  void *cpuAccessSignalsMhandle;
-  void *cpuAccessSignalsGinHandle;
-  uint64_t *cpuAccessSignals;
-  uint64_t *cpuAccessSignalsDev;
+  void* cpuAccessSignalsGdrHandle;
+  void* cpuAccessSignalsMhandle;
+  void* cpuAccessSignalsGinHandle;
+  uint64_t* cpuAccessSignals;
+  uint64_t* cpuAccessSignalsDev;
   uint64_t* cpuAccessSignalsHost; // Host buffer to track the expected values of the signals
 
   // Local flush buffer
   CUmemGenericAllocationHandle flushBufCumemhandle;
-  void *flushBufMhandle;
-  void *flushBufGinHandle;
-  uint64_t *flushBufDev;
+  void* flushBufMhandle;
+  void* flushBufGinHandle;
+  uint64_t* flushBufDev;
 };
 
 struct ncclRmaProxyState {
-  struct ncclComm *comm;
+  struct ncclComm* comm;
   ncclGin_t* ncclGin;
   void* ginInstance;
   bool connected;
@@ -169,8 +168,8 @@ struct ncclRmaProxyState {
   void** rmaProxyCtxs;
   ncclNetDeviceHandle_t** rmaProxyDevHandles;
 
-  int needsProxyProgress;  // Whether we need to progress GIN operations with the proxy
-  int ginProgress;         // GIN progress is enabled
+  int needsProxyProgress; // Whether we need to progress GIN operations with the proxy
+  int ginProgress; // GIN progress is enabled
   std::thread thread;
   std::mutex mutex;
   std::condition_variable cond;
@@ -187,8 +186,8 @@ ncclResult_t ncclRmaProxyConnectOnce(struct ncclComm* comm);
 ncclResult_t ncclRmaProxyFinalize(struct ncclComm* comm);
 
 // RMA Proxy context management
-ncclResult_t ncclRmaProxyCreateContext(struct ncclComm *comm, void *collComm, ncclNetProperties_t props,
-                                       void **outRmaProxyCtx, ncclNetDeviceHandle_t **outDevHandle);
+ncclResult_t ncclRmaProxyCreateContext(struct ncclComm* comm, void* collComm, ncclNetProperties_t props,
+                                       void** outRmaProxyCtx, ncclNetDeviceHandle_t** outDevHandle);
 ncclResult_t ncclRmaProxyDestroyContext(ncclGin_t* ginComm, void* rmaProxyCtx);
 ncclResult_t ncclRmaProxyProgress(ncclGin_t* ncclGin, void* rmaProxyCtx);
 

--- a/projects/rccl/src/include/rma/rma_proxy_mem.h
+++ b/projects/rccl/src/include/rma/rma_proxy_mem.h
@@ -21,14 +21,13 @@
 // argument for now. Defined here (file-local via static, matching gdrwrap.h's
 // convention) so both translation units can instantiate them.
 template <typename T>
-static ncclResult_t allocMemCPUAccessible(T **ptr, T **devPtr, size_t nelem, int /*host_flags*/,
-                                          void **gdrHandle, struct ncclMemManager* manager,
-                                          bool forceHost = false) {
+static ncclResult_t allocMemCPUAccessible(T** ptr, T** devPtr, size_t nelem, int /*host_flags*/, void** gdrHandle,
+                                          struct ncclMemManager* manager, bool forceHost = false) {
   if (ncclGdrCopy && !forceHost) {
     NCCLCHECK(ncclGdrCudaCalloc(ptr, devPtr, nelem, gdrHandle, manager));
   } else {
-    NCCLCHECK(ncclCuMemHostAlloc((void **)ptr, NULL, nelem * sizeof(T)));
-    memset((void *)*ptr, 0, nelem * sizeof(T));
+    NCCLCHECK(ncclCuMemHostAlloc((void**)ptr, NULL, nelem * sizeof(T)));
+    memset((void*)*ptr, 0, nelem * sizeof(T));
     *devPtr = *ptr;
     if (gdrHandle) *gdrHandle = NULL;
   }
@@ -36,7 +35,7 @@ static ncclResult_t allocMemCPUAccessible(T **ptr, T **devPtr, size_t nelem, int
 }
 
 template <typename T>
-static ncclResult_t freeMemCPUAccessible(T *ptr, void *gdrHandle, struct ncclMemManager* manager) {
+static ncclResult_t freeMemCPUAccessible(T* ptr, void* gdrHandle, struct ncclMemManager* manager) {
   if (gdrHandle != NULL) {
     NCCLCHECK(ncclGdrCudaFree(gdrHandle, manager));
   } else {

--- a/projects/rccl/src/include/rocm_smi_wrap.h
+++ b/projects/rccl/src/include/rocm_smi_wrap.h
@@ -33,6 +33,6 @@ ncclResult_t rocm_smi_init();
 ncclResult_t rocm_smi_getNumDevice(uint32_t* num_devs);
 ncclResult_t rocm_smi_getDevicePciBusIdString(uint32_t deviceIndex, char* pciBusId, size_t len);
 ncclResult_t rocm_smi_getDeviceIndexByPciBusId(const char* pciBusId, uint32_t* deviceIndex);
-ncclResult_t rocm_smi_getLinkInfo(int srcDev, int dstDev, RSMI_IO_LINK_TYPE* rsmi_type, int *hops, int *count);
+ncclResult_t rocm_smi_getLinkInfo(int srcDev, int dstDev, RSMI_IO_LINK_TYPE* rsmi_type, int* hops, int* count);
 
 #endif

--- a/projects/rccl/src/include/rocmwrap.h
+++ b/projects/rccl/src/include/rocmwrap.h
@@ -18,8 +18,7 @@
 
 // HIP: implemented in rma_proxy_launch.cc (hipStreamBatchMemOp + old-HIP fallback).
 // CUDA: implemented in cudawrap.cc (cuStreamBatchMemOp).
-ncclResult_t ncclCuStreamBatchMemOp(cudaStream_t stream, unsigned int numOps,
-                                    CUstreamBatchMemOpParams* batchParams);
+ncclResult_t ncclCuStreamBatchMemOp(cudaStream_t stream, unsigned int numOps, CUstreamBatchMemOpParams* batchParams);
 
 // Re-declare the DMA-BUF export entry as a weak reference. hsa_init,
 // hsa_system_get_info and hsa_status_string are required and resolve as hard
@@ -29,8 +28,8 @@ ncclResult_t ncclCuStreamBatchMemOp(cudaStream_t stream, unsigned int numOps,
 // undefined symbol), and pfn_hsa_amd_portable_export_dmabuf below stays the
 // runtime feature gate. This declaration must precede every use of the symbol
 // so all references (including the HSACHECK* macro call sites) are emitted weak.
-extern "C" hsa_status_t hsa_amd_portable_export_dmabuf(
-    const void* ptr, size_t size, int* dmabuf, uint64_t* offset) __attribute__((weak));
+extern "C" hsa_status_t hsa_amd_portable_export_dmabuf(const void* ptr, size_t size, int* dmabuf, uint64_t* offset)
+  __attribute__((weak));
 
 // hsa_init, hsa_system_get_info and hsa_status_string are called directly via the
 // hsa-runtime64 library that librccl links against. Only the DMA-BUF export entry
@@ -49,63 +48,69 @@ typedef hsa_status_t (*PFN_hsa_amd_portable_export_dmabuf)(const void* ptr, size
 // hsa_amd_portable_export_dmabuf stays gated by its function pointer and is not
 // referenced as a symbol in every consumer TU. hsa_status_string is a required
 // HSA entry point and is called directly.
-#define HSACHECK(cmd) do {				      \
-    hsa_status_t err = pfn_##cmd;				      \
-    if( err != HSA_STATUS_SUCCESS ) {				      \
-      const char *errStr;				      \
-      hsa_status_string(err, &errStr);	      \
+#define HSACHECK(cmd) \
+  do { \
+    hsa_status_t err = pfn_##cmd; \
+    if (err != HSA_STATUS_SUCCESS) { \
+      const char* errStr; \
+      hsa_status_string(err, &errStr); \
       WARN("HSA failure '%s' at %s:%d", errStr, __FILE__, __LINE__); \
-      return ncclUnhandledCudaError;			      \
-    }							      \
-} while(false)
+      return ncclUnhandledCudaError; \
+    } \
+  } while (false)
 
-#define HSACHECKGOTO(cmd, res, label) do {		      \
-    hsa_status_t err = pfn_##cmd;				      \
-    if( err != HSA_STATUS_SUCCESS ) {				      \
-      const char *errStr;				      \
-      hsa_status_string(err, &errStr);	      \
+#define HSACHECKGOTO(cmd, res, label) \
+  do { \
+    hsa_status_t err = pfn_##cmd; \
+    if (err != HSA_STATUS_SUCCESS) { \
+      const char* errStr; \
+      hsa_status_string(err, &errStr); \
       WARN("HSA failure '%s' at %s:%d", errStr, __FILE__, __LINE__); \
-      res = ncclUnhandledCudaError;			      \
-      goto label;					      \
-    }							      \
-} while(false)
+      res = ncclUnhandledCudaError; \
+      goto label; \
+    } \
+  } while (false)
 
 // Check CUDA PFN driver calls
-#define CUCHECK(cmd) do {				      \
-    hipError_t err = cmd;				      \
-    if( err != hipSuccess ) {				      \
-      WARN("HIP failure '%s' at %s:%d", hipGetErrorString(err), __FILE__, __LINE__);		      \
-      (void)hipGetLastError(); /* clear sticky HIP error state */   \
-      return ncclUnhandledCudaError;			      \
-    }							      \
-} while(false)
+#define CUCHECK(cmd) \
+  do { \
+    hipError_t err = cmd; \
+    if (err != hipSuccess) { \
+      WARN("HIP failure '%s' at %s:%d", hipGetErrorString(err), __FILE__, __LINE__); \
+      (void)hipGetLastError(); /* clear sticky HIP error state */ \
+      return ncclUnhandledCudaError; \
+    } \
+  } while (false)
 
-#define CUCHECKGOTO(cmd, res, label) do {		      \
-    hipError_t err = cmd;				      \
-    if( err != hipSuccess ) {				      \
-      WARN("HIP failure '%s' at %s:%d", hipGetErrorString(err), __FILE__, __LINE__);		      \
-      (void)hipGetLastError(); /* clear sticky HIP error state */   \
-      res = ncclUnhandledCudaError;			      \
-      goto label;					      \
-    }							      \
-} while(false)
+#define CUCHECKGOTO(cmd, res, label) \
+  do { \
+    hipError_t err = cmd; \
+    if (err != hipSuccess) { \
+      WARN("HIP failure '%s' at %s:%d", hipGetErrorString(err), __FILE__, __LINE__); \
+      (void)hipGetLastError(); /* clear sticky HIP error state */ \
+      res = ncclUnhandledCudaError; \
+      goto label; \
+    } \
+  } while (false)
 
 // Report failure but clear error and continue
-#define CUCHECKIGNORE(cmd) do {						\
-    hipError_t err = cmd;						\
-    if( err != hipSuccess ) {						\
-      INFO(NCCL_ALL,"%s:%d HIP failure '%s'", __FILE__, __LINE__, hipGetErrorString(err));	\
-    }									\
-} while(false)
+#define CUCHECKIGNORE(cmd) \
+  do { \
+    hipError_t err = cmd; \
+    if (err != hipSuccess) { \
+      INFO(NCCL_ALL, "%s:%d HIP failure '%s'", __FILE__, __LINE__, hipGetErrorString(err)); \
+    } \
+  } while (false)
 
-#define CUCHECKTHREAD(cmd, args) do {					\
-    hsa_status_t err = pfn_##cmd;						\
-    if (err != HSA_STATUS_SUCCESS) {						\
-      INFO(NCCL_INIT,"%s:%d -> %d [Async thread]", __FILE__, __LINE__, err); \
-      args->ret = ncclUnhandledCudaError;				\
-      return args;							\
-    }									\
-} while(0)
+#define CUCHECKTHREAD(cmd, args) \
+  do { \
+    hsa_status_t err = pfn_##cmd; \
+    if (err != HSA_STATUS_SUCCESS) { \
+      INFO(NCCL_INIT, "%s:%d -> %d [Async thread]", __FILE__, __LINE__, err); \
+      args->ret = ncclUnhandledCudaError; \
+      return args; \
+    } \
+  } while (0)
 
 #define DECLARE_ROCM_PFN_EXTERN(symbol) extern PFN_##symbol pfn_##symbol
 

--- a/projects/rccl/src/include/roctx.h
+++ b/projects/rccl/src/include/roctx.h
@@ -22,13 +22,13 @@
 
 /**
  * \brief Equivalent of nvtx types for roctx.
-*/
+ */
 enum roctxPayloadEntryType {
   /**
    * Only include the required/used types by rccl,
    * and needs to be updated in case of new type
    * tracing.
-  */
+   */
   ROCTX_PAYLOAD_ENTRY_TYPE_INT,
   ROCTX_PAYLOAD_ENTRY_TYPE_SIZE,
   ROCTX_PAYLOAD_ENTRY_TYPE_REDOP,
@@ -38,23 +38,23 @@ enum roctxPayloadEntryType {
 
 /**
  * \brief Stores the contents of the message that will be used by roctx.
-*/
+ */
 struct roctxPayloadSchemaEntryInfo {
   /**
    * Description of the data.
-  */
+   */
   const char* name;
 
   /**
    * Type of the data.
-  */
+   */
   roctxPayloadEntryType type;
 
   /**
    * Union of possible payload types.
-   * 
+   *
    * Should be in sync with roctxPayloadEntryType.
-  */
+   */
   union {
     int typeInt;
     size_t typeSize;
@@ -65,24 +65,24 @@ struct roctxPayloadSchemaEntryInfo {
 
 struct roctxPayloadInfo {
   /**
-   * Payload name. Usually the name of the function/API 
+   * Payload name. Usually the name of the function/API
    * being called from.
-  */
+   */
   const char* id;
 
   /**
    * Number of paylod entries
-  */
+   */
   size_t numEntries;
-  
+
   /**
    * Pointer to roctxPayloadSchemaEntryInfo elements in memory.
-  */
+   */
   roctxPayloadSchemaEntryInfo* payloadEntries = nullptr;
 
   /**
    * Message that will be used by roctx
-  */
+   */
   char* message = nullptr;
 };
 
@@ -94,51 +94,51 @@ extern const char* ncclDataTypeStr[ncclNumTypes];
 
 /**
  * \brief Maps nvtx types to roctx types.
-*/
+ */
 extern std::map<uint64_t, roctxPayloadEntryType> nvtxToRoctx;
 
 /**
  * \brief Allocate required memory for roctx
-*/
+ */
 void roctxAlloc(roctxPayloadInfo_t payloadInfo, const size_t numEntries);
 
 /**
  * \brief Free all the resources used by roctx
-*/
+ */
 void roctxFree(roctxPayloadInfo_t payloadInfo);
 
 /**
  * \brief Extracts payload schema entry info from nvtxPayloadSchemaEntry_t and,
  * nvtxPayloadData_t and stores in an array.
-*/
-void extractPayloadInfo(const nvtxPayloadSchemaEntry_t* schema, const nvtxPayloadData_t* data, const size_t numEntries, 
+ */
+void extractPayloadInfo(const nvtxPayloadSchemaEntry_t* schema, const nvtxPayloadData_t* data, const size_t numEntries,
                         const char* schemaName, roctxPayloadInfo_t payloadInfo);
 
 /**
  * \brief Stringify roctxPayloadInfo_t struct. Used as roctx message.
-*/
+ */
 void stringify(roctxPayloadInfo_t payloadInfo);
 
 /**
  * \brief Class to make roctx calls scoped.
-*/
+ */
 class roctx_scoped_range_in {
 public:
   /**
    * Construct a 'roctx_scoped_range_in' with specified NVTX params,
    * 'numEntries', and 'schemaName'
-  */
-  explicit roctx_scoped_range_in(const nvtxPayloadSchemaEntry_t* schema, const nvtxPayloadData_t* data, 
-                                const size_t numEntries, const char* schemaName) noexcept;
+   */
+  explicit roctx_scoped_range_in(const nvtxPayloadSchemaEntry_t* schema, const nvtxPayloadData_t* data,
+                                 const size_t numEntries, const char* schemaName) noexcept;
 
   /**
    * Construct a 'roctx_scoped_range_in' with the specified 'message'
-  */
+   */
   explicit roctx_scoped_range_in(const char* message) noexcept;
 
   /**
    * Default constructor 'roctx_scoped_range_in'
-  */
+   */
   roctx_scoped_range_in() noexcept;
 
   /**

--- a/projects/rccl/src/include/scheduler.h
+++ b/projects/rccl/src/include/scheduler.h
@@ -13,9 +13,14 @@
 #include "sym_kernels.h"
 #include "enqueue.h"
 
-ncclResult_t ncclMakeSymmetricTaskList(struct ncclComm* comm, struct ncclTaskColl* task, struct ncclIntruQueue<struct ncclTaskColl, &ncclTaskColl::next>* symTaskQueue, struct ncclTaskColl** remainTasksHead);
-ncclResult_t ncclSymmetricTaskScheduler(struct ncclComm* comm, struct ncclIntruQueue<struct ncclTaskColl, &ncclTaskColl::next>* symTaskQueue, struct ncclKernelPlan* plan);
+ncclResult_t ncclMakeSymmetricTaskList(struct ncclComm* comm, struct ncclTaskColl* task,
+                                       struct ncclIntruQueue<struct ncclTaskColl, &ncclTaskColl::next>* symTaskQueue,
+                                       struct ncclTaskColl** remainTasksHead);
+ncclResult_t ncclSymmetricTaskScheduler(struct ncclComm* comm,
+                                        struct ncclIntruQueue<struct ncclTaskColl, &ncclTaskColl::next>* symTaskQueue,
+                                        struct ncclKernelPlan* plan);
 
-ncclResult_t ncclScheduleBcastTasksToPlan(struct ncclComm* comm, struct ncclKernelPlan* plan, struct ncclKernelPlanBudget* budget);
+ncclResult_t ncclScheduleBcastTasksToPlan(struct ncclComm* comm, struct ncclKernelPlan* plan,
+                                          struct ncclKernelPlanBudget* budget);
 
 #endif // NCCL_SCHEDULER_H_

--- a/projects/rccl/src/include/shm.h
+++ b/projects/rccl/src/include/shm.h
@@ -21,13 +21,12 @@ struct shmCuIpc {
     CUmemFabricHandle handle;
     CUmemGenericAllocationHandle data;
   };
-  void *ptr;
+  void* ptr;
   size_t size;
 };
 
 struct shmIpcDesc {
-  union
-  {
+  union {
     struct shmLegacyIpc shmli;
     struct shmCuIpc shmci;
   };
@@ -36,8 +35,10 @@ struct shmIpcDesc {
 
 typedef struct shmIpcDesc ncclShmIpcDesc_t;
 
-ncclResult_t ncclShmAllocateShareableBuffer(size_t size, bool legacy, ncclShmIpcDesc_t *descOut, void **hptr, void **dptr);
-ncclResult_t ncclShmImportShareableBuffer(struct ncclComm *comm, int proxyRank, ncclShmIpcDesc_t *desc, void **hptr, void **dptr, ncclShmIpcDesc_t *descOut);
-ncclResult_t ncclShmIpcClose(ncclShmIpcDesc_t *desc);
+ncclResult_t ncclShmAllocateShareableBuffer(size_t size, bool legacy, ncclShmIpcDesc_t* descOut, void** hptr,
+                                            void** dptr);
+ncclResult_t ncclShmImportShareableBuffer(struct ncclComm* comm, int proxyRank, ncclShmIpcDesc_t* desc, void** hptr,
+                                          void** dptr, ncclShmIpcDesc_t* descOut);
+ncclResult_t ncclShmIpcClose(ncclShmIpcDesc_t* desc);
 
 #endif

--- a/projects/rccl/src/include/shmutils.h
+++ b/projects/rccl/src/include/shmutils.h
@@ -11,17 +11,19 @@
 #include "nccl.h"
 
 typedef void* ncclShmHandle_t;
-ncclResult_t ncclShmOpen(char* shmPath, size_t shmPathSize, size_t shmSize, void** shmPtr, void** devShmPtr, int refcount, ncclShmHandle_t* handle);
+ncclResult_t ncclShmOpen(char* shmPath, size_t shmPathSize, size_t shmSize, void** shmPtr, void** devShmPtr,
+                         int refcount, ncclShmHandle_t* handle);
 ncclResult_t ncclShmClose(ncclShmHandle_t handle);
 ncclResult_t ncclShmUnlink(ncclShmHandle_t handle);
 
 struct ncclShmemCollBuff {
-  size_t *cnt[2];
-  void *ptr[2];
+  size_t* cnt[2];
+  void* ptr[2];
   int round;
   size_t maxTypeSize;
 };
 
-ncclResult_t ncclShmemAllgather(struct ncclComm *comm, struct ncclShmemCollBuff *shmem, void *sendbuff, void *recvbuff, size_t typeSize);
+ncclResult_t ncclShmemAllgather(struct ncclComm* comm, struct ncclShmemCollBuff* shmem, void* sendbuff, void* recvbuff,
+                                size_t typeSize);
 
 #endif

--- a/projects/rccl/src/include/socket.h
+++ b/projects/rccl/src/include/socket.h
@@ -32,7 +32,7 @@
 #ifndef NI_MAXSERV
 #define NI_MAXSERV 32
 #endif
-#define SOCKET_NAME_MAXLEN (NI_MAXHOST+NI_MAXSERV)
+#define SOCKET_NAME_MAXLEN (NI_MAXHOST + NI_MAXSERV)
 #define NCCL_SOCKET_MAGIC 0x564ab9f2fc4b9d6cULL
 
 /* Placeholder; real definition needs sockaddr from system headers */
@@ -40,7 +40,7 @@ union ncclSocketAddress {
   char _storage[28];
 };
 #else
-#define SOCKET_NAME_MAXLEN (NI_MAXHOST+NI_MAXSERV)
+#define SOCKET_NAME_MAXLEN (NI_MAXHOST + NI_MAXSERV)
 #define NCCL_SOCKET_MAGIC 0x564ab9f2fc4b9d6cULL
 
 /* Common socket address storage structure for IPv4/IPv6 */
@@ -91,34 +91,36 @@ struct ncclSocket {
   int finalizeCounter; // Used to keep track of initial handshake for async sockets.
   char finalizeBuffer[sizeof(uint64_t)]; // Used to keep track of initial handshake for async sockets.
 #ifdef NCCL_OS_WINDOWS
-  int socketBlockingMode;  // 0 - blocking mode; 1 - non-blocking mode
+  int socketBlockingMode; // 0 - blocking mode; 1 - non-blocking mode
 #endif
 };
 
 struct ncclSocketOp {
-  int op;                  // NCCL_SOCKET_SEND or NCCL_SOCKET_RECV
+  int op; // NCCL_SOCKET_SEND or NCCL_SOCKET_RECV
   struct ncclSocket* sock; // Socket to operate on
-  void* ptr;               // Data pointer
-  int size;                // Size of data
-  int offset;              // Current progress offset
+  void* ptr; // Data pointer
+  int size; // Size of data
+  int offset; // Current progress offset
 };
 
-const char *ncclSocketToString(const union ncclSocketAddress *addr, char *buf, const int numericHostForm = 1);
+const char* ncclSocketToString(const union ncclSocketAddress* addr, char* buf, const int numericHostForm = 1);
 ncclResult_t ncclSocketGetAddrFromString(union ncclSocketAddress* ua, const char* ip_port_pair);
 ncclResult_t ncclFindInterfaceMatchSubnet(char* ifName, union ncclSocketAddress* localAddr,
                                           union ncclSocketAddress* remoteAddr, int ifNameMaxSize, int* found);
-ncclResult_t ncclFindInterfaces(char* ifNames, union ncclSocketAddress *ifAddrs, int ifNameMaxSize, int maxIfs,
+ncclResult_t ncclFindInterfaces(char* ifNames, union ncclSocketAddress* ifAddrs, int ifNameMaxSize, int maxIfs,
                                 int* nIfs);
 
 // Initialize a socket
-ncclResult_t ncclSocketInit(struct ncclSocket* sock, const union ncclSocketAddress* addr = NULL, uint64_t magic = NCCL_SOCKET_MAGIC, enum ncclSocketType type = ncclSocketTypeUnknown, volatile uint32_t* abortFlag = NULL, int asyncFlag = 0, int customRetry = 0);
+ncclResult_t ncclSocketInit(struct ncclSocket* sock, const union ncclSocketAddress* addr = NULL,
+                            uint64_t magic = NCCL_SOCKET_MAGIC, enum ncclSocketType type = ncclSocketTypeUnknown,
+                            volatile uint32_t* abortFlag = NULL, int asyncFlag = 0, int customRetry = 0);
 // Create a listening socket. sock->addr can be pre-filled with IP & port info. sock->fd is set after a successful call
 ncclResult_t ncclSocketListen(struct ncclSocket* sock);
 ncclResult_t ncclSocketGetAddr(struct ncclSocket* sock, union ncclSocketAddress* addr);
 // Connect to sock->addr. sock->socketDescriptor is set after a successful call.
 ncclResult_t ncclSocketConnect(struct ncclSocket* sock);
 // Return socket connection state.
-ncclResult_t ncclSocketReady(struct ncclSocket* sock, int *running);
+ncclResult_t ncclSocketReady(struct ncclSocket* sock, int* running);
 // Accept an incoming connection from listenSock->fd and keep the file descriptor in sock->fd, with the remote side IP/port in sock->addr.
 ncclResult_t ncclSocketAccept(struct ncclSocket* sock, struct ncclSocket* ulistenSock, bool retryOnBadMagic = true);
 ncclResult_t ncclSocketGetFd(struct ncclSocket* sock, int* fd);
@@ -132,10 +134,11 @@ ncclResult_t ncclSocketProgress(int op, struct ncclSocket* sock, void* ptr, int 
 ncclResult_t ncclSocketWait(int op, struct ncclSocket* sock, void* ptr, int size, int* offset);
 ncclResult_t ncclSocketSend(struct ncclSocket* sock, void* ptr, int size);
 ncclResult_t ncclSocketRecv(struct ncclSocket* sock, void* ptr, int size);
-ncclResult_t ncclSocketSendRecv(struct ncclSocket* sendSock, void* sendPtr, int sendSize, struct ncclSocket* recvSock, void* recvPtr, int recvSize);
+ncclResult_t ncclSocketSendRecv(struct ncclSocket* sendSock, void* sendPtr, int sendSize, struct ncclSocket* recvSock,
+                                void* recvPtr, int recvSize);
 ncclResult_t ncclSocketMultiOp(struct ncclSocketOp* ops, int numOps);
 ncclResult_t ncclSocketTryRecv(struct ncclSocket* sock, void* ptr, int size, int* closed, bool blocking);
 ncclResult_t ncclSocketShutdown(struct ncclSocket* sock, int how);
 ncclResult_t ncclSocketClose(struct ncclSocket* sock, bool wait = false);
-uint16_t ncclSocketToPort(union ncclSocketAddress *addr);
+uint16_t ncclSocketToPort(union ncclSocketAddress* addr);
 #endif

--- a/projects/rccl/src/include/strongstream.h
+++ b/projects/rccl/src/include/strongstream.h
@@ -38,29 +38,29 @@ struct ncclCudaGraph {
 
 inline struct ncclCudaGraph ncclCudaGraphNone(int graphUsageMode) {
   struct ncclCudaGraph tmp;
-  #if ROCM_VERSION >= 60100
-    tmp.origin = nullptr;
-    tmp.graph = nullptr;
-    tmp.graphId = ULLONG_MAX;
-    tmp.graphUsageMode = graphUsageMode;
-  #endif
+#if ROCM_VERSION >= 60100
+  tmp.origin = nullptr;
+  tmp.graph = nullptr;
+  tmp.graphId = ULLONG_MAX;
+  tmp.graphUsageMode = graphUsageMode;
+#endif
   return tmp;
 }
 
 inline bool ncclCudaGraphValid(struct ncclCudaGraph graph) {
-  #if ROCM_VERSION >= 60100
-    return graph.graphId != ULLONG_MAX;
-  #else
-    return false;
-  #endif
+#if ROCM_VERSION >= 60100
+  return graph.graphId != ULLONG_MAX;
+#else
+  return false;
+#endif
 }
 
 inline bool ncclCudaGraphSame(struct ncclCudaGraph a, struct ncclCudaGraph b) {
-  #if ROCM_VERSION >= 60100
-    return a.graphId == b.graphId;
-  #else
-    return true;
-  #endif
+#if ROCM_VERSION >= 60100
+  return a.graphId == b.graphId;
+#else
+  return true;
+#endif
 }
 
 ncclResult_t ncclCudaGetCapturingGraph(struct ncclCudaGraph* graph, cudaStream_t stream, int graphUsageMode);
@@ -88,23 +88,19 @@ ncclResult_t ncclStrongStreamDestruct(struct ncclStrongStream* ss);
 
 // Acquire the strong stream. Upon return `*workStream` will be usable to add work.
 // `concurrent` indicates if other threads may be using the strong stream.
-ncclResult_t ncclStrongStreamAcquire(
-  struct ncclCudaGraph graph, struct ncclStrongStream* ss, bool concurrent, cudaStream_t* workStream
-);
+ncclResult_t ncclStrongStreamAcquire(struct ncclCudaGraph graph, struct ncclStrongStream* ss, bool concurrent,
+                                     cudaStream_t* workStream);
 
 // Get the workStream for an already acquired strong stream.
 // `concurrent` indicates if other threads may be using the strong stream.
-ncclResult_t ncclStrongStreamAcquiredWorkStream(
-  struct ncclCudaGraph graph, struct ncclStrongStream* ss, bool concurrent, cudaStream_t* workStream
-);
+ncclResult_t ncclStrongStreamAcquiredWorkStream(struct ncclCudaGraph graph, struct ncclStrongStream* ss,
+                                                bool concurrent, cudaStream_t* workStream);
 
 // Release of the strong stream.
 // `concurrent` indicates if other threads may be using the strong stream.
 ncclResult_t ncclStrongStreamRelease(struct ncclCudaGraph graph, struct ncclStrongStream* ss, bool concurrent);
 
-ncclResult_t ncclStreamWaitStream(
-  cudaStream_t a, cudaStream_t b, cudaEvent_t scratchEvent
-);
+ncclResult_t ncclStreamWaitStream(cudaStream_t a, cudaStream_t b, cudaEvent_t scratchEvent);
 
 // Like cudaStreamWaitEvent except `e` must be strictly ahead of everything in `s`.
 ncclResult_t ncclStreamAdvanceToEvent(struct ncclCudaGraph g, cudaStream_t s, cudaEvent_t e);

--- a/projects/rccl/src/include/sym_kernels.h
+++ b/projects/rccl/src/include/sym_kernels.h
@@ -30,7 +30,7 @@ constexpr int ncclSymkMaxThreads = 256;
 constexpr int ncclSymkLLMaxEltSize = 8;
 
 constexpr __host__ __device__ int ncclSymkLLMaxSlots(int eltSize = ncclSymkLLMaxEltSize) {
-  return ncclSymkMaxThreads*ncclSymkLLMaxEltSize/eltSize;
+  return ncclSymkMaxThreads * ncclSymkLLMaxEltSize / eltSize;
 }
 
 enum ncclSymkKernelId {
@@ -83,7 +83,7 @@ struct ncclSymkChannelWorkRange {
 struct alignas(16) ncclSymkDevWork {
   uint64_t redOpArg; // must be collectively uniform
   size_t nElts;
-  struct ncclWindow_vidmem* inputWin, *outputWin;
+  struct ncclWindow_vidmem *inputWin, *outputWin;
   size_t inputOff, outputOff; // these = origUserOffset + cbdPartOffset
   int rootRank;
   uint64_t sChannelId:16, nChannels:16, padding:32;
@@ -98,13 +98,15 @@ struct alignas(16) ncclSymkDevWorkArgs {
   // ncclSymDevWork[nWorks];
   // aux functions
   __host__ static constexpr size_t calcArgsSize(int nChannels, int nWorks) {
-    return alignUp(sizeof(struct ncclSymkDevWorkArgs), 16) + alignUp(nChannels * sizeof(struct ncclSymkChannelWorkRange), 16) + nWorks * sizeof(struct ncclSymkDevWork);
+    return alignUp(sizeof(struct ncclSymkDevWorkArgs), 16) +
+           alignUp(nChannels * sizeof(struct ncclSymkChannelWorkRange), 16) + nWorks * sizeof(struct ncclSymkDevWork);
   }
   __host__ __device__ struct ncclSymkChannelWorkRange* getWorkRange() const {
     return (struct ncclSymkChannelWorkRange*)((uint8_t*)this + alignUp(sizeof(struct ncclSymkDevWorkArgs), 16));
   }
   __host__ __device__ struct ncclSymkDevWork* getWorks(int nChannels) const {
-    return (struct ncclSymkDevWork*)((uint8_t*)this->getWorkRange() + alignUp(nChannels * sizeof(struct ncclSymkChannelWorkRange), 16));
+    return (struct ncclSymkDevWork*)((uint8_t*)this->getWorkRange() +
+                                     alignUp(nChannels * sizeof(struct ncclSymkChannelWorkRange), 16));
   }
 };
 
@@ -125,9 +127,9 @@ typedef enum {
 ncclResult_t ncclSymkInitOnce(struct ncclComm* comm);
 ncclResult_t ncclSymkFinalize(struct ncclComm* comm);
 
-bool ncclSymkAvailable(struct ncclComm* comm, ncclFunc_t coll, int/*ncclDevRedOp_t*/ red,
-                       ncclDataType_t ty, size_t nElts);
-ncclResult_t ncclSymkPickKernel(struct ncclComm* comm, ncclFunc_t coll, int/*ncclDevRedOp_t*/ red, ncclDataType_t ty,
+bool ncclSymkAvailable(struct ncclComm* comm, ncclFunc_t coll, int /*ncclDevRedOp_t*/ red, ncclDataType_t ty,
+                       size_t nElts);
+ncclResult_t ncclSymkPickKernel(struct ncclComm* comm, ncclFunc_t coll, int /*ncclDevRedOp_t*/ red, ncclDataType_t ty,
                                 size_t nEltsTotal, size_t nEltsMax, int nWorks, ncclSymRegType_t winRegType,
                                 float* estTimeUs, ncclSymkKernelId* kernelId, int* nBlocks, int* nWarps, bool* forced);
 
@@ -138,13 +140,14 @@ extern int const ncclSymkKernelCount;
 extern void* ncclSymkKernelList[/*ncclSymkKernelCount*/];
 extern int ncclSymkKernelRequirements[/*ncclSymkKernelCount*/];
 extern int ncclSymkKernelMaxDynamicSmem[/*ncclSymkKernelCount*/]; // initialized by ncclInitKernelsForDevice()
-int ncclSymkGetKernelIndex(ncclSymkKernelId kernelId, int/*ncclDevRedOp_t*/ red, ncclDataType_t ty);
+int ncclSymkGetKernelIndex(ncclSymkKernelId kernelId, int /*ncclDevRedOp_t*/ red, ncclDataType_t ty);
 const char* ncclSymkKernelIdToString(int kernelId);
-ncclResult_t ncclGetSymRegType(struct ncclDevrWindow* sendWin, struct ncclDevrWindow* recvWin, ncclSymRegType_t* winRegType);
+ncclResult_t ncclGetSymRegType(struct ncclDevrWindow* sendWin, struct ncclDevrWindow* recvWin,
+                               ncclSymRegType_t* winRegType);
 bool rcclSymkKernelIdIsLL(int kernelId);
 
 int ncclSymkLLKernelMask();
 int ncclSymkDynamicSmemKernelMask();
 
-constexpr int ncclSymkAllGather_RailRing_ChunkSize = 1<<20;
+constexpr int ncclSymkAllGather_RailRing_ChunkSize = 1 << 20;
 #endif

--- a/projects/rccl/src/include/timer.h
+++ b/projects/rccl/src/include/timer.h
@@ -15,46 +15,56 @@ static void calibrate() {
   struct timeval tv;
   gettimeofday(&tv, NULL);
   uint64_t timeCycles = __rdtsc();
-  double time = - tv.tv_sec*1E6 - tv.tv_usec;
+  double time = -tv.tv_sec * 1E6 - tv.tv_usec;
   uint64_t total = 0ULL;
-  for (int i=0; i<10000; i++) total += __rdtsc();
+  for (int i = 0; i < 10000; i++) total += __rdtsc();
   gettimeofday(&tv, NULL);
   timeCycles = __rdtsc() - timeCycles;
-  time += tv.tv_sec*1E6 + tv.tv_usec;
-  freq = timeCycles/time;
+  time += tv.tv_sec * 1E6 + tv.tv_usec;
+  freq = timeCycles / time;
 }
 static inline double gettime() {
   if (freq == -1) calibrate();
-  return __rdtsc()/freq;
+  return __rdtsc() / freq;
 }
 static uint64_t counts[8];
 static double times[8];
 static double startTimes[8];
-#define TIME_START(index) do { \
-  counts[index]++; \
-  startTimes[index] = gettime(); \
-} while (0)
+#define TIME_START(index) \
+  do { \
+    counts[index]++; \
+    startTimes[index] = gettime(); \
+  } while (0)
 
-#define TIME_STOP(index) do { \
-  times[index] += gettime() - startTimes[index]; \
-} while (0)
+#define TIME_STOP(index) \
+  do { \
+    times[index] += gettime() - startTimes[index]; \
+  } while (0)
 
-#define TIME_CANCEL(index) do { \
-  counts[index]--; \
-} while (0)
+#define TIME_CANCEL(index) \
+  do { \
+    counts[index]--; \
+  } while (0)
 
-#define TIME_PRINT(name) do { \
-  printf("%s stats", name); \
-  for (int i=0; i<8; i++) { \
-    if (counts[i]) printf(" [%d] %g/%ld = %g", i, times[i], counts[i], times[i]/counts[i]); \
-    counts[i] = 0; \
-  } \
-  printf("\n"); \
-} while (0)
+#define TIME_PRINT(name) \
+  do { \
+    printf("%s stats", name); \
+    for (int i = 0; i < 8; i++) { \
+      if (counts[i]) printf(" [%d] %g/%ld = %g", i, times[i], counts[i], times[i] / counts[i]); \
+      counts[i] = 0; \
+    } \
+    printf("\n"); \
+  } while (0)
 #else
-#define TIME_START(index) do {} while(0)
-#define TIME_STOP(index) do {} while(0)
-#define TIME_CANCEL(index) do {} while(0)
+#define TIME_START(index) \
+  do { \
+  } while (0)
+#define TIME_STOP(index) \
+  do { \
+  } while (0)
+#define TIME_CANCEL(index) \
+  do { \
+  } while (0)
 #define TIME_PRINT(name)
 #endif
 #endif

--- a/projects/rccl/src/include/transport.h
+++ b/projects/rccl/src/include/transport.h
@@ -40,7 +40,8 @@ struct ncclComm;
 int64_t ncclParamMultiSegmentRegister();
 extern int64_t ncclParamNvlsEnable();
 
-#define CHANNEL_MASK_OFFSET(nranks, connIndex) (nranks * (connIndex == NCCL_CONN_IDX_P2P_NET ? NCCL_CONN_IDX_P2P_NET : 0))
+#define CHANNEL_MASK_OFFSET(nranks, connIndex) \
+  (nranks * (connIndex == NCCL_CONN_IDX_P2P_NET ? NCCL_CONN_IDX_P2P_NET : 0))
 
 #define CONNECT_SIZE 256
 #define NCCL_MAX_PAGE_SIZE (512L * 1024L * 1024L)
@@ -77,7 +78,7 @@ struct ncclNvlsSharedRes {
   int chunkSize;
   int treeMaxChunkSize;
   struct ncclShmemCollBuff nvlsShmem;
-  void *nvlsShmemHandle;
+  void* nvlsShmemHandle;
 };
 
 #endif /* CUDART_VERSION >= 12010 */
@@ -87,35 +88,45 @@ struct ncclCollNetSharedRes {
   int size;
   char* cudaBuff;
   char* hostBuff;
-  struct ncclProxyArgs* proxyAppend[2*NCCL_MAX_NETDEVS];
+  struct ncclProxyArgs* proxyAppend[2 * NCCL_MAX_NETDEVS];
   void* resources;
   int nChannels;
   size_t buffSize;
 };
 
 struct ncclTransportComm {
-  ncclResult_t (*setup)(struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo*, struct ncclPeerInfo*, struct ncclConnect*, struct ncclConnector*, int channelId, int connIndex);
+  ncclResult_t (*setup)(struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo*, struct ncclPeerInfo*,
+                        struct ncclConnect*, struct ncclConnector*, int channelId, int connIndex);
   ncclResult_t (*connect)(struct ncclComm* comm, struct ncclConnect*, int nranks, int rank, struct ncclConnector*);
   ncclResult_t (*free)(struct ncclComm* comm, struct ncclConnector*);
-  ncclResult_t (*proxySharedInit)(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, int nChannels);
-  ncclResult_t (*proxySetup)(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done);
-  ncclResult_t (*proxyConnect)(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done);
+  ncclResult_t (*proxySharedInit)(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState,
+                                  int nChannels);
+  ncclResult_t (*proxySetup)(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff,
+                             int reqSize, void* respBuff, int respSize, int* done);
+  ncclResult_t (*proxyConnect)(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff,
+                               int reqSize, void* respBuff, int respSize, int* done);
   ncclResult_t (*proxyFree)(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState);
   ncclResult_t (*proxyProgress)(struct ncclProxyState* proxyState, struct ncclProxyArgs*);
-  ncclResult_t (*proxyRegister)(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done);
-  ncclResult_t (*proxyDeregister)(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, int* done);
+  ncclResult_t (*proxyRegister)(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState,
+                                void* reqBuff, int reqSize, void* respBuff, int respSize, int* done);
+  ncclResult_t (*proxyDeregister)(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState,
+                                  void* reqBuff, int reqSize, int* done);
 };
 
 struct ncclTransport {
   const char name[8];
-  ncclResult_t (*canConnect)(int*, struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo*, struct ncclPeerInfo*);
+  ncclResult_t (*canConnect)(int*, struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo*,
+                             struct ncclPeerInfo*);
   struct ncclTransportComm send;
   struct ncclTransportComm recv;
 };
 
-ncclResult_t ncclTransportP2pConnect(struct ncclComm* comm, int channelId, int nrecv, int* peerRecv, int nsend, int* peerSend, int connIndex);
-ncclResult_t ncclTransportP2pSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, int connIndex, bool* needsProxy=NULL);
-ncclResult_t ncclTransportCheckP2pType(struct ncclComm* comm, bool* isAllDirectP2p, bool* directMode, bool* isAllCudaP2p);
+ncclResult_t ncclTransportP2pConnect(struct ncclComm* comm, int channelId, int nrecv, int* peerRecv, int nsend,
+                                     int* peerSend, int connIndex);
+ncclResult_t ncclTransportP2pSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, int connIndex,
+                                   bool* needsProxy = NULL);
+ncclResult_t ncclTransportCheckP2pType(struct ncclComm* comm, bool* isAllDirectP2p, bool* directMode,
+                                       bool* isAllCudaP2p);
 ncclResult_t ncclTransportIsAllDirectP2p(struct ncclComm* comm, int* isAllDirectP2p);
 bool ncclP2pUsesMemcpy();
 
@@ -124,17 +135,31 @@ ncclResult_t ncclNvlsTuning(struct ncclComm* comm);
 ncclResult_t ncclNvlsSetup(struct ncclComm* comm, struct ncclComm* parent);
 ncclResult_t ncclNvlsBufferSetup(struct ncclComm* comm);
 ncclResult_t ncclNvlsTreeConnect(struct ncclComm* comm);
-ncclResult_t ncclNvlsGraphRegisterBuffer(struct ncclComm *comm, const void *sendbuff, void *recvbuff, size_t sendbuffSize, size_t recvbuffSize, int *outRegBufUsed, void **outRegBufSend, void **outRegBufRecv, struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>* cleanupQueue, int* nCleanupQueueElts);
-ncclResult_t ncclNvlsLocalRegisterBuffer(struct ncclComm *comm, const void *sendbuff, void *recvbuff, size_t sendbuffSize, size_t recvbuffSize, int *outRegBufUsed, void **outRegBufSend, void **outRegBufRecv);
-ncclResult_t ncclNvlsDeregBuffer(struct ncclComm* comm, CUmemGenericAllocationHandle *mcHandler, CUdeviceptr ptr, int dev, size_t ucsize, size_t mcsize);
+ncclResult_t ncclNvlsGraphRegisterBuffer(
+  struct ncclComm* comm, const void* sendbuff, void* recvbuff, size_t sendbuffSize, size_t recvbuffSize,
+  int* outRegBufUsed, void** outRegBufSend, void** outRegBufRecv,
+  struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>* cleanupQueue, int* nCleanupQueueElts);
+ncclResult_t ncclNvlsLocalRegisterBuffer(struct ncclComm* comm, const void* sendbuff, void* recvbuff,
+                                         size_t sendbuffSize, size_t recvbuffSize, int* outRegBufUsed,
+                                         void** outRegBufSend, void** outRegBufRecv);
+ncclResult_t ncclNvlsDeregBuffer(struct ncclComm* comm, CUmemGenericAllocationHandle* mcHandler, CUdeviceptr ptr,
+                                 int dev, size_t ucsize, size_t mcsize);
 ncclResult_t ncclNvlsFree(struct ncclComm* comm);
 
-enum { collNetRecv=0, collNetSend=1 };
-bool ncclTransportCollNetSetup(struct ncclComm* comm, struct ncclTopoGraph* collNetGraph, struct ncclChannel* channel, int masterRank, int masterPeer, int collNetGraphChannelId, int type, ncclConnect* connect);
+enum {
+  collNetRecv = 0,
+  collNetSend = 1
+};
+bool ncclTransportCollNetSetup(struct ncclComm* comm, struct ncclTopoGraph* collNetGraph, struct ncclChannel* channel,
+                               int masterRank, int masterPeer, int collNetGraphChannelId, int type,
+                               ncclConnect* connect);
 ncclResult_t ncclTransportCollNetCheck(struct ncclComm* comm, int collNetSetupFail);
 ncclResult_t ncclTransportCollNetFree(struct ncclComm* comm);
-ncclResult_t ncclCollnetLocalRegisterBuffer(struct ncclComm* comm, const void* userbuff, size_t buffSize, int type, int* outRegBufUsed, void** outHandle);
-ncclResult_t ncclCollnetGraphRegisterBuffer(struct ncclComm* comm, const void* userbuff, size_t buffSize, int type, int* outRegBufFlag, void** outHandle, struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>* cleanupQueue, int* nCleanupQueueElts);
+ncclResult_t ncclCollnetLocalRegisterBuffer(struct ncclComm* comm, const void* userbuff, size_t buffSize, int type,
+                                            int* outRegBufUsed, void** outHandle);
+ncclResult_t ncclCollnetGraphRegisterBuffer(
+  struct ncclComm* comm, const void* userbuff, size_t buffSize, int type, int* outRegBufFlag, void** outHandle,
+  struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>* cleanupQueue, int* nCleanupQueueElts);
 ncclResult_t ncclCollnetDeregBuffer(struct ncclComm* comm, struct ncclProxyConnector* proxyconn, void* handle);
 
 ncclResult_t ncclTransportRingConnect(struct ncclComm* comm);
@@ -146,22 +171,40 @@ ncclResult_t ncclCollNetChainBufferSetup(ncclComm_t comm);
 ncclResult_t ncclCollNetDirectBufferSetup(ncclComm_t comm);
 
 ncclResult_t ncclNetDeregBuffer(struct ncclComm* comm, struct ncclProxyConnector* proxyConn, void* handle);
-ncclResult_t ncclNetLocalRegisterBuffer(ncclComm* comm, const void* userbuff, size_t buffSize, struct ncclConnector** peerConns, int nPeers, int* outRegBufFlag, void** outHandle);
-ncclResult_t ncclNetGraphRegisterBuffer(ncclComm* comm, const void* userbuff, size_t buffSize, struct ncclConnector** peerConns, int nPeers, int* outRegBufFlag, void** outHandle, struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>* cleanupQueue, int* nCleanupQueueElts);
+ncclResult_t ncclNetLocalRegisterBuffer(ncclComm* comm, const void* userbuff, size_t buffSize,
+                                        struct ncclConnector** peerConns, int nPeers, int* outRegBufFlag,
+                                        void** outHandle);
+ncclResult_t ncclNetGraphRegisterBuffer(
+  ncclComm* comm, const void* userbuff, size_t buffSize, struct ncclConnector** peerConns, int nPeers,
+  int* outRegBufFlag, void** outHandle,
+  struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>* cleanupQueue, int* nCleanupQueueElts);
 
-ncclResult_t ncclRegisterP2pIpcBuffer(struct ncclComm* comm, void* userbuff, size_t size, int peerRank, int* regFlag, void** regAddr, struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>* cleanupQueue);
-ncclResult_t ncclRegisterP2pNetBuffer(struct ncclComm* comm, void* userbuff, size_t size, struct ncclConnector* conn, int* regFlag, void** handle, struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>* cleanupQueue);
-ncclResult_t ncclRegisterCollBuffers(struct ncclComm* comm, struct ncclTaskColl* info, void* outRegBufSend[NCCL_MAX_LOCAL_RANKS], void* outRegBufRecv[NCCL_MAX_LOCAL_RANKS], struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>* cleanupQueue, bool* regNeedConnect);
-ncclResult_t ncclRegisterCollNvlsBuffers(struct ncclComm* comm, struct ncclTaskColl* info, void* outRegBufSend[NCCL_MAX_LOCAL_RANKS], void* outRegBufRecv[NCCL_MAX_LOCAL_RANKS], struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>* cleanupQueue, bool* regNeedConnect);
+ncclResult_t ncclRegisterP2pIpcBuffer(
+  struct ncclComm* comm, void* userbuff, size_t size, int peerRank, int* regFlag, void** regAddr,
+  struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>* cleanupQueue);
+ncclResult_t ncclRegisterP2pNetBuffer(
+  struct ncclComm* comm, void* userbuff, size_t size, struct ncclConnector* conn, int* regFlag, void** handle,
+  struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>* cleanupQueue);
+ncclResult_t ncclRegisterCollBuffers(
+  struct ncclComm* comm, struct ncclTaskColl* info, void* outRegBufSend[NCCL_MAX_LOCAL_RANKS],
+  void* outRegBufRecv[NCCL_MAX_LOCAL_RANKS],
+  struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>* cleanupQueue, bool* regNeedConnect);
+ncclResult_t ncclRegisterCollNvlsBuffers(
+  struct ncclComm* comm, struct ncclTaskColl* info, void* outRegBufSend[NCCL_MAX_LOCAL_RANKS],
+  void* outRegBufRecv[NCCL_MAX_LOCAL_RANKS],
+  struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>* cleanupQueue, bool* regNeedConnect);
 ncclResult_t ncclNvlsRegResourcesQuery(struct ncclComm* comm, struct ncclTaskColl* info, int* recChannels);
 
 #if CUDART_VERSION >= 12010
-ncclResult_t ncclNvlsGroupCreate(struct ncclComm *comm, CUmulticastObjectProp *prop, int rank, unsigned int nranks, CUmemGenericAllocationHandle *mcHandle, char *shareableHandle);
-ncclResult_t ncclNvlsGroupConnect(struct ncclComm *comm, char *shareableHandle, int rank, CUmemGenericAllocationHandle *mcHandle);
+ncclResult_t ncclNvlsGroupCreate(struct ncclComm* comm, CUmulticastObjectProp* prop, int rank, unsigned int nranks,
+                                 CUmemGenericAllocationHandle* mcHandle, char* shareableHandle);
+ncclResult_t ncclNvlsGroupConnect(struct ncclComm* comm, char* shareableHandle, int rank,
+                                  CUmemGenericAllocationHandle* mcHandle);
 #endif
 
 ncclResult_t ncclIpcSymmetricInit(struct ncclComm* comm);
-ncclResult_t ncclIpcMapSymmetric(struct ncclComm* comm, size_t offset, size_t size, CUmemGenericAllocationHandle memHandle, void** symPtr);
+ncclResult_t ncclIpcMapSymmetric(struct ncclComm* comm, size_t offset, size_t size,
+                                 CUmemGenericAllocationHandle memHandle, void** symPtr);
 ncclResult_t ncclIpcFreeSymmetric(struct ncclComm* comm, size_t size, void* symPtr);
 ncclResult_t ncclIpcSymmetricFinalize(struct ncclComm* comm);
 ncclResult_t ncclNvlsSymmetricInit(struct ncclComm* comm);

--- a/projects/rccl/src/include/trees.h
+++ b/projects/rccl/src/include/trees.h
@@ -11,6 +11,7 @@
 #include "nccl.h"
 
 ncclResult_t ncclGetBtree(int nranks, int rank, int* u0, int* d1, int* d0, int* parentChildType);
-ncclResult_t ncclGetDtree(int nranks, int rank, int* u0, int* d0_0, int* d0_1, int* parentChildType0, int* u1, int* d1_0, int* d1_1, int* parentChildType1);
+ncclResult_t ncclGetDtree(int nranks, int rank, int* u0, int* d0_0, int* d0_1, int* parentChildType0, int* u1,
+                          int* d1_0, int* d1_1, int* parentChildType1);
 
 #endif

--- a/projects/rccl/src/include/utils.h
+++ b/projects/rccl/src/include/utils.h
@@ -40,7 +40,7 @@ int ncclCudaCompCap();
 ncclResult_t int64ToBusId(int64_t id, char* busId);
 ncclResult_t busIdToInt64(const char* busId, int64_t* id);
 
-ncclResult_t getBusId(int cudaDev, int64_t *busId);
+ncclResult_t getBusId(int cudaDev, int64_t* busId);
 
 ncclResult_t getHostName(char* hostname, int maxlen, const char delim);
 uint64_t getHostHash();
@@ -61,9 +61,9 @@ static long log2i(long n) {
 }
 
 // Comparator function for qsort/bsearch to compare integers
-static int compareInts(const void *a, const void *b) {
-    int ia = *(const int*)a, ib = *(const int*)b;
-    return (ia > ib) - (ia < ib);
+static int compareInts(const void* a, const void* b) {
+  int ia = *(const int*)a, ib = *(const int*)b;
+  return (ia > ib) - (ia < ib);
 }
 
 inline uint64_t clockNano() {
@@ -112,12 +112,12 @@ static inline int gcd(int a, int b) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-template<typename Int>
+template <typename Int>
 inline void ncclAtomicRefCountIncrement(Int* refs) {
   COMPILER_ATOMIC_FETCH_ADD(refs, static_cast<Int>(1), std::memory_order_relaxed);
 }
 
-template<typename Int>
+template <typename Int>
 inline Int ncclAtomicRefCountDecrement(Int* refs) {
   return COMPILER_ATOMIC_SUB_FETCH(refs, static_cast<Int>(1), std::memory_order_acq_rel);
 }
@@ -139,9 +139,9 @@ void ncclMemoryStackDestruct(struct ncclMemoryStack* me);
 void ncclMemoryStackPush(struct ncclMemoryStack* me);
 void ncclMemoryStackPop(struct ncclMemoryStack* me);
 void* ncclMemoryStackAlloc(struct ncclMemoryStack* me, size_t size, size_t align);
-template<typename T>
-T* ncclMemoryStackAlloc(struct ncclMemoryStack* me, size_t n=1);
-template<typename Header, typename Element>
+template <typename T>
+T* ncclMemoryStackAlloc(struct ncclMemoryStack* me, size_t n = 1);
+template <typename Header, typename Element>
 inline Header* ncclMemoryStackAllocInlineArray(struct ncclMemoryStack* me, size_t nElt);
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -156,9 +156,9 @@ struct ncclMemoryPool;
 
 // Equivalent to zero-initialization
 void ncclMemoryPoolConstruct(struct ncclMemoryPool* me);
-template<typename T>
+template <typename T>
 T* ncclMemoryPoolAlloc(struct ncclMemoryPool* me, struct ncclMemoryStack* backing);
-template<typename T>
+template <typename T>
 void ncclMemoryPoolFree(struct ncclMemoryPool* me, T* obj);
 void ncclMemoryPoolTakeAll(struct ncclMemoryPool* me, struct ncclMemoryPool* from);
 
@@ -173,28 +173,27 @@ void ncclMemoryPoolTakeAll(struct ncclMemoryPool* me, struct ncclMemoryPool* fro
  *   ncclIntruQueue<Foo, &Foo::next1> list1;
  *   ncclIntruQueue<Foo, &Foo::next2> list2;
  */
-template<typename T, T *T::*next>
+template <typename T, T* T::* next>
 struct ncclIntruQueue;
 
-template<typename T, T *T::*next>
-void ncclIntruQueueConstruct(ncclIntruQueue<T,next> *me);
-template<typename T, T *T::*next>
-bool ncclIntruQueueEmpty(ncclIntruQueue<T,next> *me);
-template<typename T, T *T::*next>
-T* ncclIntruQueueHead(ncclIntruQueue<T,next> *me);
-template<typename T, T *T::*next>
-void ncclIntruQueueEnqueue(ncclIntruQueue<T,next> *me, T *x);
-template<typename T, T *T::*next>
-void ncclIntruQueueEnqueueFront(ncclIntruQueue<T,next> *me, T *x);
-template<typename T, T *T::*next>
-T* ncclIntruQueueDequeue(ncclIntruQueue<T,next> *me);
-template<typename T, T *T::*next>
-T* ncclIntruQueueTryDequeue(ncclIntruQueue<T,next> *me);
-template<typename T, T *T::*next>
-void ncclIntruQueueTransfer(ncclIntruQueue<T,next> *dst, ncclIntruQueue<T,next> *src);
-template<typename T, T *T::*next>
-inline T* ncclIntruQueueDelete(ncclIntruQueue<T,next> *me, T *x, bool (*cmp)(T*, T*));
-
+template <typename T, T* T::* next>
+void ncclIntruQueueConstruct(ncclIntruQueue<T, next>* me);
+template <typename T, T* T::* next>
+bool ncclIntruQueueEmpty(ncclIntruQueue<T, next>* me);
+template <typename T, T* T::* next>
+T* ncclIntruQueueHead(ncclIntruQueue<T, next>* me);
+template <typename T, T* T::* next>
+void ncclIntruQueueEnqueue(ncclIntruQueue<T, next>* me, T* x);
+template <typename T, T* T::* next>
+void ncclIntruQueueEnqueueFront(ncclIntruQueue<T, next>* me, T* x);
+template <typename T, T* T::* next>
+T* ncclIntruQueueDequeue(ncclIntruQueue<T, next>* me);
+template <typename T, T* T::* next>
+T* ncclIntruQueueTryDequeue(ncclIntruQueue<T, next>* me);
+template <typename T, T* T::* next>
+void ncclIntruQueueTransfer(ncclIntruQueue<T, next>* dst, ncclIntruQueue<T, next>* src);
+template <typename T, T* T::* next>
+inline T* ncclIntruQueueDelete(ncclIntruQueue<T, next>* me, T* x, bool (*cmp)(T*, T*));
 
 ////////////////////////////////////////////////////////////////////////////////
 /* ncclThreadSignal: Couples a std::mutex and std::condition_variable together. The "mutex"
@@ -210,25 +209,25 @@ extern thread_local struct ncclThreadSignal ncclThreadSignalLocalInstance;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-template<typename T, T *T::*next>
+template <typename T, T* T::* next>
 struct ncclIntruQueueMpsc;
 
-template<typename T, T *T::*next>
-void ncclIntruQueueMpscConstruct(struct ncclIntruQueueMpsc<T,next>* me);
-template<typename T, T *T::*next>
-bool ncclIntruQueueMpscEmpty(struct ncclIntruQueueMpsc<T,next>* me);
+template <typename T, T* T::* next>
+void ncclIntruQueueMpscConstruct(struct ncclIntruQueueMpsc<T, next>* me);
+template <typename T, T* T::* next>
+bool ncclIntruQueueMpscEmpty(struct ncclIntruQueueMpsc<T, next>* me);
 // Enqueue element. Returns true if queue is not abandoned. Even if queue is
 // abandoned the element enqueued, so the caller needs to make arrangements for
 // the queue to be tended.
-template<typename T, T *T::*next>
-bool ncclIntruQueueMpscEnqueue(struct ncclIntruQueueMpsc<T,next>* me, T* x);
+template <typename T, T* T::* next>
+bool ncclIntruQueueMpscEnqueue(struct ncclIntruQueueMpsc<T, next>* me, T* x);
 // Dequeue all elements at a glance. If there aren't any and `waitSome` is
 // true then this call will wait until it can return a non empty list.
-template<typename T, T *T::*next>
-T* ncclIntruQueueMpscDequeueAll(struct ncclIntruQueueMpsc<T,next>* me, bool waitSome);
+template <typename T, T* T::* next>
+T* ncclIntruQueueMpscDequeueAll(struct ncclIntruQueueMpsc<T, next>* me, bool waitSome);
 // Dequeue all elements and set queue to abandoned state.
-template<typename T, T *T::*next>
-T* ncclIntruQueueMpscAbandon(struct ncclIntruQueueMpsc<T,next>* me);
+template <typename T, T* T::* next>
+T* ncclIntruQueueMpscAbandon(struct ncclIntruQueueMpsc<T, next>* me);
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -266,7 +265,7 @@ inline void ncclMemoryStackConstruct(struct ncclMemoryStack* me) {
 }
 
 inline void* ncclMemoryStack::allocate(struct ncclMemoryStack* me, size_t size, size_t align) {
-  uintptr_t o = (me->topFrame.bumper + align-1) & ~(uintptr_t(align) - 1);
+  uintptr_t o = (me->topFrame.bumper + align - 1) & ~(uintptr_t(align) - 1);
   void* obj;
   if (COMPILER_EXPECT(o + size <= me->topFrame.end, true)) {
     me->topFrame.bumper = o + size;
@@ -278,25 +277,25 @@ inline void* ncclMemoryStack::allocate(struct ncclMemoryStack* me, size_t size, 
 }
 
 inline void* ncclMemoryStackAlloc(struct ncclMemoryStack* me, size_t size, size_t align) {
-  void *obj = ncclMemoryStack::allocate(me, size, align);
+  void* obj = ncclMemoryStack::allocate(me, size, align);
   memset(obj, 0, size);
   return obj;
 }
 
-template<typename T>
+template <typename T>
 inline T* ncclMemoryStackAlloc(struct ncclMemoryStack* me, size_t n) {
-  void *obj = ncclMemoryStack::allocate(me, n*sizeof(T), alignof(T));
-  memset(obj, 0, n*sizeof(T));
+  void* obj = ncclMemoryStack::allocate(me, n * sizeof(T), alignof(T));
+  memset(obj, 0, n * sizeof(T));
   return (T*)obj;
 }
 
-template<typename Header, typename Element>
+template <typename Header, typename Element>
 inline Header* ncclMemoryStackAllocInlineArray(struct ncclMemoryStack* me, size_t nElt) {
   size_t size = sizeof(Header);
-  size = (size + alignof(Element)-1) & -alignof(Element);
-  size += nElt*sizeof(Element);
+  size = (size + alignof(Element) - 1) & -alignof(Element);
+  size += nElt * sizeof(Element);
   size_t align = alignof(Header) < alignof(Element) ? alignof(Element) : alignof(Header);
-  void *obj = ncclMemoryStack::allocate(me, size, align);
+  void* obj = ncclMemoryStack::allocate(me, size, align);
   memset(obj, 0, size);
   return (Header*)obj;
 }
@@ -319,12 +318,11 @@ inline void ncclMemoryStackPop(struct ncclMemoryStack* me) {
   me->topFrame = *me->topFrame.below; // C++ struct assignment
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 
 struct ncclMemoryPool {
   struct Cell {
-    Cell *next;
+    Cell* next;
   };
   struct Cell* head;
   struct Cell* tail; // meaningful only when head != nullptr
@@ -334,7 +332,7 @@ inline void ncclMemoryPoolConstruct(struct ncclMemoryPool* me) {
   me->head = nullptr;
 }
 
-template<typename T>
+template <typename T>
 inline T* ncclMemoryPoolAlloc(struct ncclMemoryPool* me, struct ncclMemoryStack* backing) {
   using Cell = ncclMemoryPool::Cell;
   Cell* cell;
@@ -351,7 +349,7 @@ inline T* ncclMemoryPoolAlloc(struct ncclMemoryPool* me, struct ncclMemoryStack*
   return reinterpret_cast<T*>(cell);
 }
 
-template<typename T>
+template <typename T>
 inline void ncclMemoryPoolFree(struct ncclMemoryPool* me, T* obj) {
   using Cell = ncclMemoryPool::Cell;
   Cell* cell = reinterpret_cast<Cell*>(obj);
@@ -371,58 +369,58 @@ inline void ncclMemoryPoolTakeAll(struct ncclMemoryPool* me, struct ncclMemoryPo
 
 ////////////////////////////////////////////////////////////////////////////////
 
-template<typename T, T *T::*next>
+template <typename T, T* T::* next>
 struct ncclIntruQueue {
   T *head, *tail;
 };
 
-template<typename T, T *T::*next>
-inline void ncclIntruQueueConstruct(ncclIntruQueue<T,next> *me) {
+template <typename T, T* T::* next>
+inline void ncclIntruQueueConstruct(ncclIntruQueue<T, next>* me) {
   me->head = nullptr;
   me->tail = nullptr;
 }
 
-template<typename T, T *T::*next>
-inline bool ncclIntruQueueEmpty(ncclIntruQueue<T,next> *me) {
+template <typename T, T* T::* next>
+inline bool ncclIntruQueueEmpty(ncclIntruQueue<T, next>* me) {
   return me->head == nullptr;
 }
 
-template<typename T, T *T::*next>
-inline T* ncclIntruQueueHead(ncclIntruQueue<T,next> *me) {
+template <typename T, T* T::* next>
+inline T* ncclIntruQueueHead(ncclIntruQueue<T, next>* me) {
   return me->head;
 }
 
-template<typename T, T *T::*next>
-inline T* ncclIntruQueueTail(ncclIntruQueue<T,next> *me) {
+template <typename T, T* T::* next>
+inline T* ncclIntruQueueTail(ncclIntruQueue<T, next>* me) {
   return me->tail;
 }
 
-template<typename T, T *T::*next>
-inline void ncclIntruQueueEnqueue(ncclIntruQueue<T,next> *me, T *x) {
+template <typename T, T* T::* next>
+inline void ncclIntruQueueEnqueue(ncclIntruQueue<T, next>* me, T* x) {
   x->*next = nullptr;
   (me->head ? me->tail->*next : me->head) = x;
   me->tail = x;
 }
 
-template<typename T, T *T::*next>
-inline void ncclIntruQueueEnqueueFront(ncclIntruQueue<T,next> *me, T *x) {
+template <typename T, T* T::* next>
+inline void ncclIntruQueueEnqueueFront(ncclIntruQueue<T, next>* me, T* x) {
   if (me->head == nullptr) me->tail = x;
   x->*next = me->head;
   me->head = x;
 }
 
-template<typename T, T *T::*next>
-inline T* ncclIntruQueueDequeue(ncclIntruQueue<T,next> *me) {
-  T *ans = me->head;
+template <typename T, T* T::* next>
+inline T* ncclIntruQueueDequeue(ncclIntruQueue<T, next>* me) {
+  T* ans = me->head;
   me->head = ans->*next;
   if (me->head == nullptr) me->tail = nullptr;
   return ans;
 }
 
-template<typename T, T *T::*next>
-inline T* ncclIntruQueueDelete(ncclIntruQueue<T,next> *me, T *x, bool (*cmp)(T*, T*)) {
-  T *prev = nullptr;
-  T *cur = me->head;
+template <typename T, T* T::* next>
+inline T* ncclIntruQueueDelete(ncclIntruQueue<T, next>* me, T* x, bool (*cmp)(T*, T*)) {
+  T* prev = nullptr;
+  T* cur = me->head;
   bool found = false;
 
   while (cur) {
@@ -435,19 +433,16 @@ inline T* ncclIntruQueueDelete(ncclIntruQueue<T,next> *me, T *x, bool (*cmp)(T*,
   }
 
   if (found) {
-    if (prev == nullptr)
-      me->head = cur->*next;
-    else
-      prev->*next = cur->*next;
-    if (cur == me->tail)
-      me->tail = prev;
+    if (prev == nullptr) me->head = cur->*next;
+    else prev->*next = cur->*next;
+    if (cur == me->tail) me->tail = prev;
   }
   return cur;
 }
 
-template<typename T, T *T::*next>
-inline T* ncclIntruQueueTryDequeue(ncclIntruQueue<T,next> *me) {
-  T *ans = me->head;
+template <typename T, T* T::* next>
+inline T* ncclIntruQueueTryDequeue(ncclIntruQueue<T, next>* me) {
+  T* ans = me->head;
   if (ans != nullptr) {
     me->head = ans->*next;
     if (me->head == nullptr) me->tail = nullptr;
@@ -455,8 +450,8 @@ inline T* ncclIntruQueueTryDequeue(ncclIntruQueue<T,next> *me) {
   return ans;
 }
 
-template<typename T, T *T::*next>
-void ncclIntruQueueTransfer(ncclIntruQueue<T,next> *dst, ncclIntruQueue<T,next> *src) {
+template <typename T, T* T::* next>
+void ncclIntruQueueTransfer(ncclIntruQueue<T, next>* dst, ncclIntruQueue<T, next>* src) {
   (dst->tail ? dst->tail->next : dst->head) = src->head;
   if (src->tail) dst->tail = src->tail;
   src->head = nullptr;
@@ -465,27 +460,27 @@ void ncclIntruQueueTransfer(ncclIntruQueue<T,next> *dst, ncclIntruQueue<T,next> 
 
 ////////////////////////////////////////////////////////////////////////////////
 
-template<typename T, T *T::*next>
+template <typename T, T* T::* next>
 struct ncclIntruQueueMpsc {
   T* head;
   uintptr_t tail;
   struct ncclThreadSignal* waiting;
 };
 
-template<typename T, T *T::*next>
-void ncclIntruQueueMpscConstruct(struct ncclIntruQueueMpsc<T,next>* me) {
+template <typename T, T* T::* next>
+void ncclIntruQueueMpscConstruct(struct ncclIntruQueueMpsc<T, next>* me) {
   me->head = nullptr;
   me->tail = 0x0;
   me->waiting = nullptr;
 }
 
-template<typename T, T *T::*next>
-bool ncclIntruQueueMpscEmpty(struct ncclIntruQueueMpsc<T,next>* me) {
+template <typename T, T* T::* next>
+bool ncclIntruQueueMpscEmpty(struct ncclIntruQueueMpsc<T, next>* me) {
   return COMPILER_ATOMIC_LOAD(&me->tail, std::memory_order_relaxed) <= 0x2;
 }
 
-template<typename T, T *T::*next>
-bool ncclIntruQueueMpscEnqueue(ncclIntruQueueMpsc<T,next>* me, T* x) {
+template <typename T, T* T::* next>
+bool ncclIntruQueueMpscEnqueue(ncclIntruQueueMpsc<T, next>* me, T* x) {
   COMPILER_ATOMIC_STORE(&(x->*next), static_cast<T*>(nullptr), std::memory_order_relaxed);
   uintptr_t utail = COMPILER_ATOMIC_EXCHANGE(&me->tail, reinterpret_cast<uintptr_t>(x), std::memory_order_acq_rel);
   T* prev = reinterpret_cast<T*>(utail);
@@ -504,21 +499,22 @@ bool ncclIntruQueueMpscEnqueue(ncclIntruQueueMpsc<T,next>* me, T* x) {
   return utail != 0x2; // not abandoned
 }
 
-template<typename T, T *T::*next>
-T* ncclIntruQueueMpscDequeueAll(ncclIntruQueueMpsc<T,next>* me, bool waitSome) {
+template <typename T, T* T::* next>
+T* ncclIntruQueueMpscDequeueAll(ncclIntruQueueMpsc<T, next>* me, bool waitSome) {
   T* head = COMPILER_ATOMIC_LOAD(&me->head, std::memory_order_relaxed);
   if (head == nullptr) {
     if (!waitSome) return nullptr;
     uint64_t t0 = clockNano();
     bool sleeping = false;
     do {
-      if (clockNano()-t0 >= 10*1000) { // spin for first 10us
+      if (clockNano() - t0 >= 10 * 1000) { // spin for first 10us
         struct ncclThreadSignal* waitSignal = &ncclThreadSignalLocalInstance;
         std::unique_lock<std::mutex> lock(waitSignal->mutex);
         uintptr_t expected = sleeping ? 0x1 : 0x0;
         uintptr_t desired = 0x1;
         me->waiting = waitSignal; // release done by successful compare exchange
-        if (COMPILER_ATOMIC_COMPARE_EXCHANGE(&me->tail, &expected, desired, std::memory_order_release, std::memory_order_relaxed)) {
+        if (COMPILER_ATOMIC_COMPARE_EXCHANGE(&me->tail, &expected, desired, std::memory_order_release,
+                                             std::memory_order_relaxed)) {
           sleeping = true;
           waitSignal->cond.wait(lock);
         }
@@ -530,24 +526,28 @@ T* ncclIntruQueueMpscDequeueAll(ncclIntruQueueMpsc<T,next>* me, bool waitSome) {
   COMPILER_ATOMIC_STORE(&me->head, static_cast<T*>(nullptr), std::memory_order_relaxed);
   uintptr_t utail = COMPILER_ATOMIC_EXCHANGE(&me->tail, uintptr_t(0), std::memory_order_acq_rel);
   T* tail = utail <= 0x2 ? nullptr : reinterpret_cast<T*>(utail);
-  T *x = head;
+  T* x = head;
   while (x != tail) {
-    T *x1;
+    T* x1;
     int spins = 0;
     while (true) {
       x1 = COMPILER_ATOMIC_LOAD(&(x->*next), std::memory_order_relaxed);
       if (x1 != nullptr) break;
-      if (++spins == 1024) { spins = 1024-1; std::this_thread::yield(); }
+      if (++spins == 1024) {
+        spins = 1024 - 1;
+        std::this_thread::yield();
+      }
     }
     x = x1;
   }
   return head;
 }
 
-template<typename T, T *T::*next>
-T* ncclIntruQueueMpscAbandon(ncclIntruQueueMpsc<T,next>* me) {
+template <typename T, T* T::* next>
+T* ncclIntruQueueMpscAbandon(ncclIntruQueueMpsc<T, next>* me) {
   uintptr_t expected = 0x0;
-  if (COMPILER_ATOMIC_COMPARE_EXCHANGE(&me->tail, &expected, /*desired=*/uintptr_t(0x2), std::memory_order_relaxed, std::memory_order_relaxed)) {
+  if (COMPILER_ATOMIC_COMPARE_EXCHANGE(&me->tail, &expected, /*desired=*/uintptr_t(0x2), std::memory_order_relaxed,
+                                       std::memory_order_relaxed)) {
     return nullptr;
   } else {
     int spins = 0;
@@ -555,19 +555,25 @@ T* ncclIntruQueueMpscAbandon(ncclIntruQueueMpsc<T,next>* me) {
     while (true) {
       head = COMPILER_ATOMIC_LOAD(&me->head, std::memory_order_relaxed);
       if (head != nullptr) break;
-      if (++spins == 1024) { spins = 1024-1; std::this_thread::yield(); }
+      if (++spins == 1024) {
+        spins = 1024 - 1;
+        std::this_thread::yield();
+      }
     }
     COMPILER_ATOMIC_STORE(&me->head, static_cast<T*>(nullptr), std::memory_order_relaxed);
     uintptr_t utail = COMPILER_ATOMIC_EXCHANGE(&me->tail, uintptr_t(0x2), std::memory_order_acq_rel);
     T* tail = utail <= 0x2 ? nullptr : reinterpret_cast<T*>(utail);
-    T *x = head;
+    T* x = head;
     while (x != tail) {
-      T *x1;
+      T* x1;
       spins = 0;
       while (true) {
         x1 = COMPILER_ATOMIC_LOAD(&(x->*next), std::memory_order_relaxed);
         if (x1 != nullptr) break;
-        if (++spins == 1024) { spins = 1024-1; std::this_thread::yield(); }
+        if (++spins == 1024) {
+          spins = 1024 - 1;
+          std::this_thread::yield();
+        }
       }
       x = x1;
     }
@@ -575,7 +581,8 @@ T* ncclIntruQueueMpscAbandon(ncclIntruQueueMpsc<T,next>* me) {
   }
 }
 
-ncclResult_t ncclBitsToString(uint32_t bits, uint32_t mask, const char* (*toStr)(int), char *buf, size_t bufLen, const char *wildcard);
+ncclResult_t ncclBitsToString(uint32_t bits, uint32_t mask, const char* (*toStr)(int), char* buf, size_t bufLen,
+                              const char* wildcard);
 
 /**
  * @brief function to get page size of the system
@@ -583,7 +590,7 @@ ncclResult_t ncclBitsToString(uint32_t bits, uint32_t mask, const char* (*toStr)
 size_t get_sc_page_size(void);
 
 /**
- * @brief function to get system's page size aligned memory address and buffersize 
+ * @brief function to get system's page size aligned memory address and buffersize
  *
  * Given a pointer `ptr` to a buffer of size `bufsize`, this function computes:
  *   1. A new pointer `aligned_ptr` which points to the start of the page-aligned memory region that includes `ptr`.
@@ -597,7 +604,7 @@ size_t get_sc_page_size(void);
  * @param[out] aligned_ptr   Pointer to a variable that will be set to the aligned base address.
  * @param[out] aligned_size  Pointer to a variable that will be set to the aligned size.
  */
-void get_aligned_ptr_and_size(const void *ptr, const size_t bufsize, void **aligned_ptr, size_t *aligned_size);
+void get_aligned_ptr_and_size(const void* ptr, const size_t bufsize, void** aligned_ptr, size_t* aligned_size);
 
 ////////////////////////////////////////////////////////////////////////////////
 // Hash function for pointer types (shared by address map implementations)
@@ -614,16 +621,16 @@ struct ncclIntruAddressMap_untyped {
 };
 
 // Typed wrapper (uses composition for C compatibility)
-template<typename Obj, typename Key, Key Obj::*keyField, Obj* Obj::*nextField>
+template <typename Obj, typename Key, Key Obj::* keyField, Obj* Obj::* nextField>
 struct ncclIntruAddressMap {
   static_assert(sizeof(Key) <= sizeof(uintptr_t),
-    "ncclIntruAddressMap: Key type size must be <= sizeof(uintptr_t). "
-    "Keys larger than a pointer cannot be safely converted to uintptr_t.");
+                "ncclIntruAddressMap: Key type size must be <= sizeof(uintptr_t). "
+                "Keys larger than a pointer cannot be safely converted to uintptr_t.");
 
   ncclIntruAddressMap_untyped base;
 };
 
-template<typename Obj, typename Key, Key Obj::*keyField, Obj* Obj::*nextField>
+template <typename Obj, typename Key, Key Obj::* keyField, Obj* Obj::* nextField>
 static inline void ncclIntruAddressMapDestruct(struct ncclIntruAddressMap<Obj, Key, keyField, nextField>* map) {
   if (map->base.table != nullptr) {
     free(map->base.table);
@@ -633,58 +640,46 @@ static inline void ncclIntruAddressMapDestruct(struct ncclIntruAddressMap<Obj, K
   map->base.count = 0;
 }
 
-ncclResult_t ncclIntruAddressMapInsert_untyped(
-  struct ncclIntruAddressMap_untyped* map,
-  int keySize, int keyFieldOffset, int nextFieldOffset,
-  uintptr_t key, void* object);
+ncclResult_t ncclIntruAddressMapInsert_untyped(struct ncclIntruAddressMap_untyped* map, int keySize, int keyFieldOffset,
+                                               int nextFieldOffset, uintptr_t key, void* object);
 
-ncclResult_t ncclIntruAddressMapFind_untyped(
-  struct ncclIntruAddressMap_untyped* map,
-  int keySize, int keyFieldOffset, int nextFieldOffset,
-  uintptr_t key, void** object);
+ncclResult_t ncclIntruAddressMapFind_untyped(struct ncclIntruAddressMap_untyped* map, int keySize, int keyFieldOffset,
+                                             int nextFieldOffset, uintptr_t key, void** object);
 
-ncclResult_t ncclIntruAddressMapRemove_untyped(
-  struct ncclIntruAddressMap_untyped* map,
-  int keySize, int keyFieldOffset, int nextFieldOffset,
-  uintptr_t key);
+ncclResult_t ncclIntruAddressMapRemove_untyped(struct ncclIntruAddressMap_untyped* map, int keySize, int keyFieldOffset,
+                                               int nextFieldOffset, uintptr_t key);
 
-template<typename Obj, typename Key, Key Obj::*keyField, Obj* Obj::*nextField>
-static inline ncclResult_t ncclIntruAddressMapInsert(
-    struct ncclIntruAddressMap<Obj, Key, keyField, nextField>* map,
-    Key key, Obj* object) {
+template <typename Obj, typename Key, Key Obj::* keyField, Obj* Obj::* nextField>
+static inline ncclResult_t ncclIntruAddressMapInsert(struct ncclIntruAddressMap<Obj, Key, keyField, nextField>* map,
+                                                     Key key, Obj* object) {
   Obj dummy;
   int keyFieldOffset = (char*)&(dummy.*keyField) - (char*)&dummy;
   int nextFieldOffset = (char*)&(dummy.*nextField) - (char*)&dummy;
-  return ncclIntruAddressMapInsert_untyped(
-    &map->base, (int)sizeof(Key), keyFieldOffset, nextFieldOffset,
-    reinterpret_cast<uintptr_t>(key), object);
+  return ncclIntruAddressMapInsert_untyped(&map->base, (int)sizeof(Key), keyFieldOffset, nextFieldOffset,
+                                           reinterpret_cast<uintptr_t>(key), object);
 }
 
-template<typename Obj, typename Key, Key Obj::*keyField, Obj* Obj::*nextField>
-static inline ncclResult_t ncclIntruAddressMapFind(
-    struct ncclIntruAddressMap<Obj, Key, keyField, nextField>* map,
-    Key key, Obj** object) {
+template <typename Obj, typename Key, Key Obj::* keyField, Obj* Obj::* nextField>
+static inline ncclResult_t ncclIntruAddressMapFind(struct ncclIntruAddressMap<Obj, Key, keyField, nextField>* map,
+                                                   Key key, Obj** object) {
   Obj dummy;
   int keyFieldOffset = (char*)&(dummy.*keyField) - (char*)&dummy;
   int nextFieldOffset = (char*)&(dummy.*nextField) - (char*)&dummy;
   void* tmp;
-  ncclResult_t ret = ncclIntruAddressMapFind_untyped(
-    &map->base, (int)sizeof(Key), keyFieldOffset, nextFieldOffset,
-    reinterpret_cast<uintptr_t>(key), &tmp);
+  ncclResult_t ret = ncclIntruAddressMapFind_untyped(&map->base, (int)sizeof(Key), keyFieldOffset, nextFieldOffset,
+                                                     reinterpret_cast<uintptr_t>(key), &tmp);
   *object = (Obj*)tmp;
   return ret;
 }
 
-template<typename Obj, typename Key, Key Obj::*keyField, Obj* Obj::*nextField>
-static inline ncclResult_t ncclIntruAddressMapRemove(
-    struct ncclIntruAddressMap<Obj, Key, keyField, nextField>* map,
-    Key key) {
+template <typename Obj, typename Key, Key Obj::* keyField, Obj* Obj::* nextField>
+static inline ncclResult_t ncclIntruAddressMapRemove(struct ncclIntruAddressMap<Obj, Key, keyField, nextField>* map,
+                                                     Key key) {
   Obj dummy;
   int keyFieldOffset = (char*)&(dummy.*keyField) - (char*)&dummy;
   int nextFieldOffset = (char*)&(dummy.*nextField) - (char*)&dummy;
-  return ncclIntruAddressMapRemove_untyped(
-    &map->base, (int)sizeof(Key), keyFieldOffset, nextFieldOffset,
-    reinterpret_cast<uintptr_t>(key));
+  return ncclIntruAddressMapRemove_untyped(&map->base, (int)sizeof(Key), keyFieldOffset, nextFieldOffset,
+                                           reinterpret_cast<uintptr_t>(key));
 }
 
 inline ncclResult_t ncclThreadJoin(std::thread& thread) {

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -59,7 +59,7 @@
 #include "git_version.h"
 #include "rccl_vars.h"
 #include "hip_rocm_version_info.h"
-//#include <hsa/hsa_ext_amd.h>
+// #include <hsa/hsa_ext_amd.h>
 #ifdef USE_AMDSMI
 #include "amdsmi_wrap.h"
 #else
@@ -77,14 +77,14 @@
 #include "latency_profiler/CollTraceFunc.h"
 #include "dda_all_reduce_ipc.h"
 #include "ipc_init.h"
-#include  <cpuid.h>
+#include <cpuid.h>
 
 #ifndef STR2
-  #define STR2(v) #v
+#define STR2(v) #v
 #endif
 
 #ifndef STR
-  #define STR(v) STR2(v)
+#define STR(v) STR2(v)
 #endif
 
 #if CUDART_VERSION >= 9020 || defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
@@ -97,11 +97,14 @@
 
 using namespace rccl;
 
-const char* ncclFuncStr[NCCL_NUM_FUNCTIONS+4] = { "AllGather", "AllReduce", "AlltoAllPivot", "AlltoAllGda", "AlltoAllvGda", "Broadcast", "Reduce", "ReduceScatter", "SendRecv"};	//Increased numFunc by 1 for AlltollvGda
-const char* ncclAlgoStr[NCCL_NUM_ALGORITHMS] = { "Tree", "Ring", "CollNetDirect", "CollNetChain", "NVLS", "NVLSTree", "PAT" };
-const char* ncclProtoStr[NCCL_NUM_PROTOCOLS] = { "LL", "LL128", "Simple" };
-const char* ncclDevRedOpStr[ncclNumDevRedOps] = { "Sum", "Prod", "MinMax", "PreMulSum", "SumPostDiv" };
-const char *ncclTypeStr[ncclNumTypes] = {"_i8", "_u8", "_i32", "_u32", "_i64", "_u64", "_f16", "_f32", "_f64", "_b16"};
+const char* ncclFuncStr[NCCL_NUM_FUNCTIONS + 4] = {"AllGather",    "AllReduce", "AlltoAllPivot", "AlltoAllGda",
+                                                   "AlltoAllvGda", "Broadcast", "Reduce",        "ReduceScatter",
+                                                   "SendRecv"}; // Increased numFunc by 1 for AlltollvGda
+const char* ncclAlgoStr[NCCL_NUM_ALGORITHMS] = {"Tree",     "Ring", "CollNetDirect", "CollNetChain", "NVLS",
+                                                "NVLSTree", "PAT"};
+const char* ncclProtoStr[NCCL_NUM_PROTOCOLS] = {"LL", "LL128", "Simple"};
+const char* ncclDevRedOpStr[ncclNumDevRedOps] = {"Sum", "Prod", "MinMax", "PreMulSum", "SumPostDiv"};
+const char* ncclTypeStr[ncclNumTypes] = {"_i8", "_u8", "_i32", "_u32", "_i64", "_u64", "_f16", "_f32", "_f64", "_b16"};
 
 NCCL_PARAM(GroupCudaStream, "GROUP_CUDA_STREAM", NCCL_GROUP_CUDA_STREAM);
 
@@ -130,7 +133,7 @@ static bool ctaPolicyIsValid(int ctaPolicy) {
 }
 
 static int ctaPolicyEnv = NCCL_CONFIG_UNDEF_INT;
-static void getEnvCtaPolicyOnce(){
+static void getEnvCtaPolicyOnce() {
   const char* env = ncclGetEnv("NCCL_CTA_POLICY");
   if (env == NULL) return;
 
@@ -147,7 +150,8 @@ static void getEnvCtaPolicyOnce(){
       ctaPolicyEnv = NCCL_CTA_POLICY_ZERO;
       break;
     default:
-      INFO(NCCL_ENV, "Unknown CTA policy; the legacy usage of NCCL_CTA_POLICY only supports the value of 0 (DEFAULT), 1 (EFFICIENCY), or 2 (ZERO). Using DEFAULT instead.");
+      INFO(NCCL_ENV, "Unknown CTA policy; the legacy usage of NCCL_CTA_POLICY only supports the value of 0 (DEFAULT), "
+                     "1 (EFFICIENCY), or 2 (ZERO). Using DEFAULT instead.");
     };
   } else {
     // newer way allows the user to combine the modes
@@ -155,9 +159,9 @@ static void getEnvCtaPolicyOnce(){
     char* token = strtok(str, "|");
     while (token) {
       int tokenPolicy = NCCL_CONFIG_UNDEF_INT;
-      if (strcasecmp(token, "DEFAULT")==0) tokenPolicy = NCCL_CTA_POLICY_DEFAULT;
-      else if (strcasecmp(token, "EFFICIENCY")==0) tokenPolicy = NCCL_CTA_POLICY_EFFICIENCY;
-      else if (strcasecmp(token, "ZERO")==0) tokenPolicy = NCCL_CTA_POLICY_ZERO;
+      if (strcasecmp(token, "DEFAULT") == 0) tokenPolicy = NCCL_CTA_POLICY_DEFAULT;
+      else if (strcasecmp(token, "EFFICIENCY") == 0) tokenPolicy = NCCL_CTA_POLICY_EFFICIENCY;
+      else if (strcasecmp(token, "ZERO") == 0) tokenPolicy = NCCL_CTA_POLICY_ZERO;
       else INFO(NCCL_ENV, "Unknown CTA policy %s passed as environment variable. Ignoring.", token);
       if (tokenPolicy != NCCL_CONFIG_UNDEF_INT) {
         if (ctaPolicyEnv == NCCL_CONFIG_UNDEF_INT) ctaPolicyEnv = tokenPolicy;
@@ -187,9 +191,9 @@ std::unordered_map<ncclComm_t, rocshmem::rocshmem_team_t> ncclCommToRshmemTeam;
 RCCL_PARAM(Gfx9CheapFenceOff, "GFX9_CHEAP_FENCE_OFF", 1);
 
 /**
- * Used on gfx1151 (StrixHalo) to set the nChannels for ncclTopoPreset before determining number of nodes. 
+ * Used on gfx1151 (StrixHalo) to set the nChannels for ncclTopoPreset before determining number of nodes.
  */
-RCCL_PARAM( InitChannels, "INIT_CHANNELS", -1) ;
+RCCL_PARAM(InitChannels, "INIT_CHANNELS", -1);
 
 // GDRCOPY support: Off by default
 NCCL_PARAM(GdrCopyEnable, "GDRCOPY_ENABLE", 0);
@@ -232,24 +236,25 @@ ncclResult_t checkHsaEnvSetting() {
 
   INFO(NCCL_INIT, "Hipruntime version: %d, firmware version: %d", hipRuntimeVersion, firmwareVersion);
   if (!validHsaScratchEnvSetting(hsaScratchEnv, hipRuntimeVersion, firmwareVersion, devProp.gcnArchName)) {
-    WARN("HSA_NO_SCRATCH_RECLAIM=1 must be set to avoid performance degradation with the current HIP configuration. (Runtime version:%d, GPU Firmware version:%d)", hipRuntimeVersion, firmwareVersion);
+    WARN("HSA_NO_SCRATCH_RECLAIM=1 must be set to avoid performance degradation with the current HIP configuration. "
+         "(Runtime version:%d, GPU Firmware version:%d)",
+         hipRuntimeVersion, firmwareVersion);
   }
   return ncclSuccess;
 }
 
 // Fail the job if build flag HIP_HOST_UNCACHED_MEMORY is not set on mi350x
 ncclResult_t checkHostUncacheMemSetting(struct ncclComm* comm) {
-  #if defined(HIP_HOST_UNCACHED_MEMORY)
+#if defined(HIP_HOST_UNCACHED_MEMORY)
+  return ncclSuccess;
+#else
+  if (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950")) {
+    ERROR("Build flag HIP_HOST_UNCACHED_MEMORY must be set to avoid memory corruption on mi350x");
+    return ncclSystemError;
+  } else {
     return ncclSuccess;
-  #else
-    if( IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950") ){
-      ERROR("Build flag HIP_HOST_UNCACHED_MEMORY must be set to avoid memory corruption on mi350x");
-      return ncclSystemError;
-    }
-    else {
-      return ncclSuccess;
-    }
-  #endif
+  }
+#endif
 }
 
 static void initOnceFunc() {
@@ -269,44 +274,45 @@ exit:;
 static ncclResult_t ncclInit() {
     // Register atexit handler to detect process shutdown. This must happen
     // early so the handler runs BEFORE HIP runtime static destructors.
-    rcclRegisterShutdownHandler();
+  rcclRegisterShutdownHandler();
 
-    char strValue[2048];
-    NCCLCHECK(ncclTopoGetStrFromSys("/proc/sys/kernel", "numa_balancing", strValue));
-    if (strcmp(strValue, "1") == 0)
-      WARN("NUMA auto balancing enabled which can lead to variability in the RCCL performance! Disable by \"sudo sysctl kernel.numa_balancing=0\"");
-    NCCLCHECK(ncclTopoGetStrFromSys("/proc", "version", strValue));
-    char *verStr, *state;
-    verStr = strtok_r(strValue, " ", &state);
-    for (int i = 0; i < 2; i ++) {
-      verStr = strtok_r(NULL, " ", &state);
-      if (verStr == NULL) break;
-    }
-    INFO(NCCL_INIT, "Kernel version: %s", verStr);
-    if (strstr(verStr, "cray") == NULL) {
-      unsigned int eax, ebx, ecx, edx;
-      if (!__get_cpuid(1, &eax, &ebx, &ecx, &edx))
-        ecx = 0; // cpuid not supported
-      NCCLCHECK(ncclTopoGetStrFromSys("/sys/devices/virtual/dmi/id", "bios_version", strValue));
+  char strValue[2048];
+  NCCLCHECK(ncclTopoGetStrFromSys("/proc/sys/kernel", "numa_balancing", strValue));
+  if (strcmp(strValue, "1") == 0)
+    WARN("NUMA auto balancing enabled which can lead to variability in the RCCL performance! Disable by \"sudo sysctl "
+         "kernel.numa_balancing=0\"");
+  NCCLCHECK(ncclTopoGetStrFromSys("/proc", "version", strValue));
+  char *verStr, *state;
+  verStr = strtok_r(strValue, " ", &state);
+  for (int i = 0; i < 2; i++) {
+    verStr = strtok_r(NULL, " ", &state);
+    if (verStr == NULL) break;
+  }
+  INFO(NCCL_INIT, "Kernel version: %s", verStr);
+  if (strstr(verStr, "cray") == NULL) {
+    unsigned int eax, ebx, ecx, edx;
+    if (!__get_cpuid(1, &eax, &ebx, &ecx, &edx)) ecx = 0; // cpuid not supported
+    NCCLCHECK(ncclTopoGetStrFromSys("/sys/devices/virtual/dmi/id", "bios_version", strValue));
       // Check BIOS string and hypervisor presence on ecx bit 31
-      if (strncmp("Hyper-V UEFI Release", strValue, 20) != 0 && (ecx & (1u << 31)) == 0) {
-        FILE* file;
-        if ((file = fopen("/proc/cmdline", "r")) != NULL) {
-          if (feof(file) == 0 && ferror(file) == 0) {
-            int len = fread(strValue, 1, 2047, file);
-            strValue[len] = '\0';
-          }
-          fclose(file);
+    if (strncmp("Hyper-V UEFI Release", strValue, 20) != 0 && (ecx & (1u << 31)) == 0) {
+      FILE* file;
+      if ((file = fopen("/proc/cmdline", "r")) != NULL) {
+        if (feof(file) == 0 && ferror(file) == 0) {
+          int len = fread(strValue, 1, 2047, file);
+          strValue[len] = '\0';
         }
-        if (strstr(strValue, "iommu=pt") == NULL)
-          WARN("Missing \"iommu=pt\" from kernel command line which can lead to system instablity or hang!");
+        fclose(file);
       }
-#ifndef HIP_UNCACHED_MEMORY
-      char *env = getenv("HSA_FORCE_FINE_GRAIN_PCIE");
-      if (env == NULL || strcmp(env, "1") != 0)
-        WARN("Missing \"HSA_FORCE_FINE_GRAIN_PCIE=1\" from environment which can lead to low RCCL performance, system instablity or hang!");
-#endif
+      if (strstr(strValue, "iommu=pt") == NULL)
+        WARN("Missing \"iommu=pt\" from kernel command line which can lead to system instablity or hang!");
     }
+#ifndef HIP_UNCACHED_MEMORY
+    char* env = getenv("HSA_FORCE_FINE_GRAIN_PCIE");
+    if (env == NULL || strcmp(env, "1") != 0)
+      WARN("Missing \"HSA_FORCE_FINE_GRAIN_PCIE=1\" from environment which can lead to low RCCL performance, system "
+           "instablity or hang!");
+#endif
+  }
   std::call_once(initOnceFlag, initOnceFunc);
   return initResult;
 }
@@ -426,8 +432,7 @@ void ncclCommPushCudaGdrFree(struct ncclComm* comm, void* handle) {
 static ncclResult_t commFree(ncclComm_t comm) {
   int abort = 0;
   /* commFree() should not involve any sync among ranks. */
-  if (comm == NULL)
-    return ncclSuccess;
+  if (comm == NULL) return ncclSuccess;
 
   NCCLCHECK(ncclCeFinalize(comm));
 
@@ -491,10 +496,9 @@ static ncclResult_t commFree(ncclComm_t comm) {
   ncclProfilerProxyTraceDumpIfAny(comm->profilerContext);
 
   free(comm->peerInfo);
-  if (comm->topo)
-    ncclTopoFree(comm->topo);
+  if (comm->topo) ncclTopoFree(comm->topo);
   if (comm->nodeRanks) {
-    for (int n=0; n<comm->nNodes; n++) free(comm->nodeRanks[n].localRankToRank);
+    for (int n = 0; n < comm->nNodes; n++) free(comm->nodeRanks[n].localRankToRank);
     free(comm->nodeRanks);
   }
   free(comm->rankToNode);
@@ -504,14 +508,12 @@ static ncclResult_t commFree(ncclComm_t comm) {
 
   NCCLCHECK(ncclDdaIpcCommFini(comm));
 
-  if (comm->bootstrap)
-    NCCLCHECK(bootstrapClose(comm->bootstrap));
+  if (comm->bootstrap) NCCLCHECK(bootstrapClose(comm->bootstrap));
 
-  for (int channel=0; channel<MAXCHANNELS; channel++)
-    NCCLCHECK(freeChannel(comm->channels+channel, comm->nRanks, 1, comm->localRanks, comm));
+  for (int channel = 0; channel < MAXCHANNELS; channel++)
+    NCCLCHECK(freeChannel(comm->channels + channel, comm->nRanks, 1, comm->localRanks, comm));
 
-  if (comm->doneEvent != NULL)
-    CUDACHECK(hipEventDestroy(comm->doneEvent));
+  if (comm->doneEvent != NULL) CUDACHECK(hipEventDestroy(comm->doneEvent));
 
   // GIN may use proxy. We need to finalize it before destroying the proxy.
   NCCLCHECK(ncclGinHostFinalize(comm));
@@ -521,7 +523,7 @@ static ncclResult_t commFree(ncclComm_t comm) {
   if (comm->sharedRes) {
     sharedResRefCount = ncclAtomicRefCountDecrement(&comm->sharedRes->refCount);
     if (sharedResRefCount == 0) {
-      for (int c=0; c<MAXCHANNELS; c++) {
+      for (int c = 0; c < MAXCHANNELS; c++) {
         if (comm->sharedRes->peers[c]) free(comm->sharedRes->peers[c]);
         if (comm->sharedRes->devPeers[c]) ncclCudaFree(comm->sharedRes->devPeers[c], comm->memManager);
       }
@@ -570,7 +572,8 @@ static ncclResult_t commFree(ncclComm_t comm) {
 
   NCCLCHECK(ncclDestroySideStream(comm->cudaDev));
 
-  INFO(NCCL_DESTROY,"comm %p rank %d nranks %d cudaDev %d busId %lx - %s COMPLETE", comm, comm->rank, comm->nRanks, comm->cudaDev, comm->busId, abort ? "Abort" : "Destroy");
+  INFO(NCCL_DESTROY, "comm %p rank %d nranks %d cudaDev %d busId %lx - %s COMPLETE", comm, comm->rank, comm->nRanks,
+       comm->cudaDev, comm->busId, abort ? "Abort" : "Destroy");
 
   commPoison(comm); // poison comm before free to avoid comm reuse.
   NCCLCHECK(ncclProfilerPluginFinalize(comm));
@@ -592,7 +595,7 @@ NCCL_PARAM(AggChannelSize, "AGG_CHANNEL_SIZE", -2);
 NCCL_PARAM(DisableGraphHelper, "GRAPH_HELPER_DISABLE", 0);
 // GDRCOPY support: FIFO_ENABLE when enabled locates a workFifo in CUDA memory
 NCCL_PARAM(GdrCopyFifoEnable, "GDRCOPY_FIFO_ENABLE", 1);
-#define NCCL_WORK_FIFO_BYTES_DEFAULT (1<<22)
+#define NCCL_WORK_FIFO_BYTES_DEFAULT (1 << 22)
 NCCL_PARAM(WorkFifoBytes, "WORK_FIFO_BYTES", NCCL_WORK_FIFO_BYTES_DEFAULT);
 NCCL_PARAM(WorkArgsBytes, "WORK_ARGS_BYTES", INT64_MAX);
 enum ncclLaunchMode ncclParamLaunchMode;
@@ -608,7 +611,7 @@ static ncclResult_t dmaBufSupported(struct ncclComm* comm) {
   if (CUPFN(cuDeviceGet) == NULL || cudaDriverVersion < 11070) return ncclInternalError;
   CUCHECK(cuDeviceGet(&dev, comm->cudaDev));
   // Query device to see if DMA-BUF support is available
-  (void) CUPFN(cuDeviceGetAttribute(&flag, CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED, dev));
+  (void)CUPFN(cuDeviceGetAttribute(&flag, CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED, dev));
   if (flag == 0) return ncclInternalError;
   INFO(NCCL_INIT, "DMA-BUF is available on GPU device %d", comm->cudaDev);
   return ncclSuccess;
@@ -652,13 +655,13 @@ static ncclResult_t commAlloc(struct ncclComm* comm, struct ncclComm* parent, in
   ncclMemoryStackConstruct(&comm->memPermanent);
   ncclMemoryStackConstruct(&comm->memScoped);
   comm->destructorHead = nullptr;
-  
+
   comm->ddaIpcMemHandler = nullptr;
   comm->ddaIpcScratch = nullptr;
   comm->ddaIpcScratchBytes = 0;
   comm->ddaIpcPeerPtrsDev = nullptr;
   comm->ddaIpcBarrierState = nullptr;
-  
+
   comm->rank = rank;
   comm->nRanks = ndev;
   comm->pxnDisable = RCCL_VALUE_UNSET;
@@ -700,7 +703,8 @@ static ncclResult_t commAlloc(struct ncclComm* comm, struct ncclComm* parent, in
 
   if (parent && parent->shareResources) {
     if (parent->ncclNet != comm->ncclNet) {
-      WARN("Split shares resources, but parent comm netName %s is different from child comm netName %s", parent->ncclNet->name, comm->ncclNet->name);
+      WARN("Split shares resources, but parent comm netName %s is different from child comm netName %s",
+           parent->ncclNet->name, comm->ncclNet->name);
       return ncclInvalidUsage;
     }
   }
@@ -722,7 +726,7 @@ static ncclResult_t commAlloc(struct ncclComm* comm, struct ncclComm* parent, in
   }
 
   NCCLCHECK(getBusId(comm->cudaDev, &comm->busId));
-  char busId[]="0000:00:00.0";
+  char busId[] = "0000:00:00.0";
   NCCLCHECK(int64ToBusId(comm->busId, busId));
 
 #ifdef USE_AMDSMI
@@ -732,7 +736,8 @@ static ncclResult_t commAlloc(struct ncclComm* comm, struct ncclComm* parent, in
   NCCLCHECK(rocm_smi_init());
   NCCLCHECK(rocm_smi_getDeviceIndexByPciBusId(busId, (unsigned int*)&comm->nvmlDev));
 #endif
-  TRACE(NCCL_INIT,"comm %p rank %d nranks %d cudaDev %d busId %lx compCap %d", comm, rank, ndev, comm->cudaDev, comm->busId, comm->compCap);
+  TRACE(NCCL_INIT, "comm %p rank %d nranks %d cudaDev %d busId %lx compCap %d", comm, rank, ndev, comm->cudaDev,
+        comm->busId, comm->compCap);
 
   comm->checkMode = ncclParamCheckPointers() == 1 ? ncclCheckModeDebugLocal : ncclCheckModeDefault;
   comm->dmaBufSupport = (dmaBufSupported(comm) == ncclSuccess) ? true : false;
@@ -742,8 +747,7 @@ static ncclResult_t commAlloc(struct ncclComm* comm, struct ncclComm* parent, in
     // Share parent's memory manager
     comm->memManager = parent->memManager;
     ncclAtomicRefCountIncrement(&comm->memManager->refCount);
-    INFO(NCCL_INIT, "MemManager: Shared from parent, refCount=%d",
-         comm->memManager->refCount);
+    INFO(NCCL_INIT, "MemManager: Shared from parent, refCount=%d", comm->memManager->refCount);
   } else {
     // Create new memory manager
     NCCLCHECK(ncclMemManagerInit(comm));
@@ -768,19 +772,20 @@ static ncclResult_t commAlloc(struct ncclComm* comm, struct ncclComm* parent, in
   }
   comm->preconnectNext = reinterpret_cast<struct ncclComm*>(0x1);
 
-  static_assert(MAXCHANNELS <= sizeof(*comm->connectSend)*8, "comm->connectSend must have enough bits for all channels");
-  static_assert(MAXCHANNELS <= sizeof(*comm->connectRecv)*8, "comm->connectRecv must have enough bits for all channels");
-  NCCLCHECK(ncclCalloc(&comm->connectSend, comm->nRanks*NCCL_MAX_CONNS));
-  NCCLCHECK(ncclCalloc(&comm->connectRecv, comm->nRanks*NCCL_MAX_CONNS));
+  static_assert(MAXCHANNELS <= sizeof(*comm->connectSend) * 8,
+                "comm->connectSend must have enough bits for all channels");
+  static_assert(MAXCHANNELS <= sizeof(*comm->connectRecv) * 8,
+                "comm->connectRecv must have enough bits for all channels");
+  NCCLCHECK(ncclCalloc(&comm->connectSend, comm->nRanks * NCCL_MAX_CONNS));
+  NCCLCHECK(ncclCalloc(&comm->connectRecv, comm->nRanks * NCCL_MAX_CONNS));
 
   // Mark channels as non initialized.
-  for (int c=0; c < MAXCHANNELS; c++) comm->channels[c].id = -1;
+  for (int c = 0; c < MAXCHANNELS; c++) comm->channels[c].id = -1;
 
   CUDACHECK(hipDeviceGetAttribute(&comm->WarpSize, hipDeviceAttributeWarpSize, comm->cudaDev));
   if (comm->topParentRanks == NULL) {
     NCCLCHECK(ncclCalloc(&comm->topParentRanks, comm->nRanks));
-    for (int i = 0; i < comm->nRanks; ++i)
-      comm->topParentRanks[i] = i;
+    for (int i = 0; i < comm->nRanks; ++i) comm->topParentRanks[i] = i;
   }
 
   ncclIntruQueueMpscConstruct(&comm->callbackQueue);
@@ -811,18 +816,24 @@ static ncclResult_t devCommSetup(ncclComm_t comm) {
   ncclResult_t ret = ncclSuccess;
   int nRanks = comm->nRanks;
   struct ncclKernelCommAndChannels tmpCommAndChans;
-  struct ncclKernelCommAndChannels *devCommAndChans = NULL;
-  //struct ncclNvmlCCStatus ccStatus; //unused variable - compiler warning
+  struct ncclKernelCommAndChannels* devCommAndChans = NULL;
+  // struct ncclNvmlCCStatus ccStatus; //unused variable - compiler warning
   bool ccEnable = false;
   cudaStream_t deviceStream;
 
   memset(&tmpCommAndChans, '\0', sizeof(tmpCommAndChans));
-  NCCLCHECKGOTO(ncclStrongStreamAcquire(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->deviceStream, /*concurrent=*/false, &deviceStream), ret, fail);
+  NCCLCHECKGOTO(ncclStrongStreamAcquire(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->deviceStream,
+                                        /*concurrent=*/false, &deviceStream),
+                ret, fail);
   NCCLCHECKGOTO(ncclCudaCallocAsync(&devCommAndChans, 1, deviceStream, comm->memManager), ret, fail);
   ncclCommPushCudaFree(comm, devCommAndChans);
-  NCCLCHECKGOTO(ncclCudaCallocAsync(&tmpCommAndChans.comm.rankToLocalRank, comm->nRanks, deviceStream, comm->memManager), ret, fail);
+  NCCLCHECKGOTO(ncclCudaCallocAsync(&tmpCommAndChans.comm.rankToLocalRank, comm->nRanks, deviceStream,
+                                    comm->memManager),
+                ret, fail);
   ncclCommPushCudaFree(comm, tmpCommAndChans.comm.rankToLocalRank);
-  NCCLCHECKGOTO(ncclCudaMemcpyAsync(tmpCommAndChans.comm.rankToLocalRank, comm->rankToLocalRank, comm->nRanks, deviceStream), ret, fail);
+  NCCLCHECKGOTO(ncclCudaMemcpyAsync(tmpCommAndChans.comm.rankToLocalRank, comm->rankToLocalRank, comm->nRanks,
+                                    deviceStream),
+                ret, fail);
   comm->devComm = &devCommAndChans->comm;
   tmpCommAndChans.comm.rank = comm->rank;
   tmpCommAndChans.comm.nRanks = nRanks;
@@ -832,7 +843,7 @@ static ncclResult_t devCommSetup(ncclComm_t comm) {
   tmpCommAndChans.comm.isAllNvlink = comm->isAllNvlink;
   tmpCommAndChans.comm.p2pnChannelsPerPeer = comm->p2pnChannelsPerPeer;
   tmpCommAndChans.comm.gfx9CheapFenceOff = comm->gfx9CheapFenceOff;
-  for (int p=0; p < NCCL_NUM_PROTOCOLS; p++) {
+  for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) {
     tmpCommAndChans.comm.buffSizes[p] = comm->buffSizes[p];
   }
   tmpCommAndChans.comm.p2pChunkSize = comm->p2pChunkSize;
@@ -844,24 +855,25 @@ static ncclResult_t devCommSetup(ncclComm_t comm) {
 
 #if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
   memset(&ccStatus, 0, sizeof(ccStatus));
-  ccEnable = (ncclSuccess == ncclNvmlGetCCStatus(&ccStatus)) && (ccStatus.CCEnabled || ccStatus.multiGpuProtectedPCIE || ccStatus.multiGpuNVLE);
+  ccEnable = (ncclSuccess == ncclNvmlGetCCStatus(&ccStatus)) &&
+             (ccStatus.CCEnabled || ccStatus.multiGpuProtectedPCIE || ccStatus.multiGpuNVLE);
   if (ccEnable) {
     comm->workFifoBytes = 0;
   } else {
     comm->workFifoBytes = ncclParamWorkFifoBytes();
-    if (0 != (comm->workFifoBytes & (comm->workFifoBytes-1))) {
+    if (0 != (comm->workFifoBytes & (comm->workFifoBytes - 1))) {
       WARN("NCCL_WORK_FIFO_BYTES=%d is being ignored because it is not a power of 2.", comm->workFifoBytes);
       comm->workFifoBytes = NCCL_WORK_FIFO_BYTES_DEFAULT;
     }
-    comm->workFifoBytes = std::min(comm->workFifoBytes, 1u<<30);
+    comm->workFifoBytes = std::min(comm->workFifoBytes, 1u << 30);
   }
 #else
   comm->workFifoBytes = ncclParamWorkFifoBytes();
-  if (0 != (comm->workFifoBytes & (comm->workFifoBytes-1))) {
+  if (0 != (comm->workFifoBytes & (comm->workFifoBytes - 1))) {
     WARN("NCCL_WORK_FIFO_BYTES=%d is being ignored because it is not a power of 2.", comm->workFifoBytes);
     comm->workFifoBytes = NCCL_WORK_FIFO_BYTES_DEFAULT;
   }
-  comm->workFifoBytes = std::min(comm->workFifoBytes, 1u<<30);
+  comm->workFifoBytes = std::min(comm->workFifoBytes, 1u << 30);
 #endif
 
   if (comm->rank == 0) {
@@ -870,7 +882,9 @@ static ncclResult_t devCommSetup(ncclComm_t comm) {
 
   if (ncclGdrCopy != NULL && ncclParamGdrCopyFifoEnable() == 1) {
     // The workFifoBuf lives in GDR mapped CUDA memory.
-    NCCLCHECKGOTO(ncclGdrCudaCalloc(&comm->workFifoBuf, &comm->workFifoBufDev, comm->workFifoBytes, &comm->workFifoBufGdrHandle, comm->memManager), ret, fail);
+    NCCLCHECKGOTO(ncclGdrCudaCalloc(&comm->workFifoBuf, &comm->workFifoBufDev, comm->workFifoBytes,
+                                    &comm->workFifoBufGdrHandle, comm->memManager),
+                  ret, fail);
     ncclCommPushCudaGdrFree(comm, comm->workFifoBufGdrHandle);
   } else {
     // The workFifoBuf lives in cudaHost memory.
@@ -893,12 +907,16 @@ static ncclResult_t devCommSetup(ncclComm_t comm) {
   ncclCommPushCudaHostFree(comm, comm->profiler.workCompleted);
 
   if (comm->collNetDenseToUserRank != nullptr) {
-    NCCLCHECKGOTO(ncclCudaCallocAsync(&tmpCommAndChans.comm.collNetDenseToUserRank, nRanks, deviceStream, comm->memManager), ret, fail);
+    NCCLCHECKGOTO(ncclCudaCallocAsync(&tmpCommAndChans.comm.collNetDenseToUserRank, nRanks, deviceStream,
+                                      comm->memManager),
+                  ret, fail);
     ncclCommPushCudaFree(comm, tmpCommAndChans.comm.collNetDenseToUserRank);
-    NCCLCHECKGOTO(ncclCudaMemcpyAsync(tmpCommAndChans.comm.collNetDenseToUserRank, comm->collNetDenseToUserRank, nRanks, deviceStream), ret, fail);
+    NCCLCHECKGOTO(ncclCudaMemcpyAsync(tmpCommAndChans.comm.collNetDenseToUserRank, comm->collNetDenseToUserRank, nRanks,
+                                      deviceStream),
+                  ret, fail);
   }
 
-  for (int c=0; c < MAXCHANNELS; c++) {
+  for (int c = 0; c < MAXCHANNELS; c++) {
     tmpCommAndChans.channels[c].peers = comm->channels[c].devPeers;
     tmpCommAndChans.channels[c].ring = comm->channels[c].ring;
     tmpCommAndChans.channels[c].ring.userRanks = comm->channels[c].devRingUserRanks;
@@ -909,7 +927,9 @@ static ncclResult_t devCommSetup(ncclComm_t comm) {
     tmpCommAndChans.channels[c].nvls = comm->channels[c].nvls;
 
     if (comm->channels[c].ring.userRanks != nullptr) {
-      NCCLCHECKGOTO(ncclCudaMemcpyAsync(tmpCommAndChans.channels[c].ring.userRanks, comm->channels[c].ring.userRanks, nRanks, deviceStream), ret, fail);
+      NCCLCHECKGOTO(ncclCudaMemcpyAsync(tmpCommAndChans.channels[c].ring.userRanks, comm->channels[c].ring.userRanks,
+                                        nRanks, deviceStream),
+                    ret, fail);
     }
   }
 
@@ -919,7 +939,8 @@ static ncclResult_t devCommSetup(ncclComm_t comm) {
 
   NCCLCHECKGOTO(ncclCudaMemcpyAsync(devCommAndChans, &tmpCommAndChans, 1, deviceStream), ret, fail);
 exit:
-  NCCLCHECK(ncclStrongStreamRelease(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->deviceStream, /*concurrent=*/false));
+  NCCLCHECK(ncclStrongStreamRelease(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->deviceStream,
+                                    /*concurrent=*/false));
   NCCLCHECK(ncclStrongStreamSynchronize(&comm->sharedRes->deviceStream));
   return ret;
 fail:
@@ -929,7 +950,7 @@ fail:
 // Pre-process the string so that running "strings" on the lib can quickly reveal the version.
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
 #define VERSION_STRING "RCCL version : " STR(NCCL_MAJOR) "." STR(NCCL_MINOR) "." STR(NCCL_PATCH) NCCL_SUFFIX
-#define HIP_VERSION_STRING  "HIP version  : " HIP_BUILD_INFO
+#define HIP_VERSION_STRING "HIP version  : " HIP_BUILD_INFO
 #define ROCM_VERSION_STRING "ROCm version : " ROCM_BUILD_INFO
 #define VERSION_STRING_EXTENDED HIP_VERSION_STRING "\n" ROCM_VERSION_STRING
 #else
@@ -939,20 +960,18 @@ fail:
 static void showVersion() {
   // Retrieve Hostname info
   char hostBuf[HOST_NAME_MAX];
-  std::string hostInfo = (gethostname(hostBuf, sizeof(hostBuf)-1) == 0) ? hostBuf : "Unknown";
+  std::string hostInfo = (gethostname(hostBuf, sizeof(hostBuf) - 1) == 0) ? hostBuf : "Unknown";
 
   // Retrieve librccl path
   Dl_info pathInfo;
-  std::string libPathInfo =
-      dladdr((void*)ncclCommInitRank, &pathInfo) ? pathInfo.dli_fname : "Unknown";
+  std::string libPathInfo = dladdr((void*)ncclCommInitRank, &pathInfo) ? pathInfo.dli_fname : "Unknown";
 
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
   // Query the active HIP/ROCm runtime to report alongside the compile-time
   // versions when they differ.
   VersionInfo hipRt{};
   int hipRuntimeVer = 0;
-  if (hipRuntimeGetVersion(&hipRuntimeVer) == hipSuccess)
-    hipRt = decodeHipVer(hipRuntimeVer);
+  if (hipRuntimeGetVersion(&hipRuntimeVer) == hipSuccess) hipRt = decodeHipVer(hipRuntimeVer);
   const VersionInfo hipCt = {true, HIP_VERSION_MAJOR, HIP_VERSION_MINOR, HIP_VERSION_PATCH};
 
   VersionInfo rocmRt{}, rocmCt{};
@@ -964,21 +983,18 @@ static void showVersion() {
   rocmCt = VersionInfo{true, ROCM_VERSION_MAJOR, ROCM_VERSION_MINOR, ROCM_VERSION_PATCH};
 #endif
 
-  std::string extendedInfo = fmtExtVer(HIP_VERSION_STRING, hipRt, hipCt,
-                                       ROCM_VERSION_STRING, rocmRt, rocmCt);
+  std::string extendedInfo = fmtExtVer(HIP_VERSION_STRING, hipRt, hipCt, ROCM_VERSION_STRING, rocmRt, rocmCt);
 #else
   std::string extendedInfo = VERSION_STRING_EXTENDED;
 #endif
 
-  std::string versionInfo = fmt::format(
-    "{}-{}\n{}\n{:<12} : {}\n{:>12} : {}",
-    VERSION_STRING, rcclGitHash, extendedInfo,
-    "Hostname", hostInfo, "Librccl path", libPathInfo);
+  std::string versionInfo = fmt::format("{}-{}\n{}\n{:<12} : {}\n{:>12} : {}", VERSION_STRING, rcclGitHash,
+                                        extendedInfo, "Hostname", hostInfo, "Librccl path", libPathInfo);
 
   if (ncclDebugLevel == NCCL_LOG_VERSION || ncclDebugLevel == NCCL_LOG_WARN) {
     VERSION("%s", versionInfo.c_str());
   } else {
-    INFO(NCCL_ALL,"%s", versionInfo.c_str());
+    INFO(NCCL_ALL, "%s", versionInfo.c_str());
   }
 }
 
@@ -992,8 +1008,8 @@ static ncclResult_t fillInfo(struct ncclComm* comm, struct ncclPeerInfo* info, u
   info->cudaDev = comm->cudaDev;
   info->nvmlDev = comm->nvmlDev;
   info->version = NCCL_VERSION_CODE;
-  info->hostHash=getHostHash()+commHash;
-  info->pidHash=getPidHash()+commHash;
+  info->hostHash = getHostHash() + commHash;
+  info->pidHash = getPidHash() + commHash;
   info->cuMemSupport = ncclCuMemEnable();
   CUDACHECK(cudaGetDeviceProperties(&prop, comm->cudaDev));
   info->totalGlobalMem = ROUNDUP(prop.totalGlobalMem, (1ULL << 32));
@@ -1013,7 +1029,7 @@ static ncclResult_t fillInfo(struct ncclComm* comm, struct ncclPeerInfo* info, u
   info->busId = comm->busId;
 
   // detect if fine grained memory is available on this GPU
-  int *ptr;
+  int* ptr;
 #if defined(HIP_UNCACHED_MEMORY)
   if (hipExtMallocWithFlags((void**)&ptr, sizeof(int), hipDeviceMallocUncached) == hipSuccess) {
 #else
@@ -1022,12 +1038,9 @@ static ncclResult_t fillInfo(struct ncclComm* comm, struct ncclPeerInfo* info, u
     CUDACHECK(hipFree(ptr));
     info->hasFineGrain = true;
     // GPU supports GDR if DMABUF is supported
-    if (dmaBufSupported(comm) == ncclSuccess)
-      info->gdrSupport = 1;
-    else
-      NCCLCHECK(ncclGpuGdrSupport(comm, &info->gdrSupport));
-  }
-  else {
+    if (dmaBufSupported(comm) == ncclSuccess) info->gdrSupport = 1;
+    else NCCLCHECK(ncclGpuGdrSupport(comm, &info->gdrSupport));
+  } else {
     info->hasFineGrain = false;
     info->gdrSupport = 0;
   }
@@ -1045,7 +1058,7 @@ static ncclResult_t fillInfo(struct ncclComm* comm, struct ncclPeerInfo* info, u
     NCCLCHECK(int64ToBusId(info->busId, busId));
     NCCLCHECK(ncclNvmlDeviceGetHandleByPciBusId(busId, &nvmlDev));
     info->fabricInfo.state = NVML_GPU_FABRIC_STATE_NOT_SUPPORTED;
-    (void) ncclNvmlDeviceGetGpuFabricInfoV(nvmlDev, &info->fabricInfo);
+    (void)ncclNvmlDeviceGetGpuFabricInfoV(nvmlDev, &info->fabricInfo);
     if (info->fabricInfo.state != NVML_GPU_FABRIC_STATE_NOT_SUPPORTED) {
       unsigned long uuid0 = 0;
       unsigned long uuid1 = 0;
@@ -1058,46 +1071,39 @@ static ncclResult_t fillInfo(struct ncclComm* comm, struct ncclPeerInfo* info, u
       memcpy(&uuid0, info->fabricInfo.clusterUuid, sizeof(uuid0));
       memcpy(&uuid1, info->fabricInfo.clusterUuid + sizeof(uuid0), sizeof(uuid1));
       if (ncclParamMNNVLCliqueId() == -2) {
-        nvmlPlatformInfo_t platformInfo = { 0 };
+        nvmlPlatformInfo_t platformInfo = {0};
         NCCLCHECK(ncclNvmlDeviceGetPlatformInfo(nvmlDev, &platformInfo));
         INFO(NCCL_INIT, "MNNVL rack serial %s slot %d tray %d hostId %d peerType %d moduleId %d",
-             platformInfo.chassisSerialNumber, platformInfo.slotNumber, platformInfo.trayIndex,
-             platformInfo.hostId, platformInfo.peerType, platformInfo.moduleId);
+             platformInfo.chassisSerialNumber, platformInfo.slotNumber, platformInfo.trayIndex, platformInfo.hostId,
+             platformInfo.peerType, platformInfo.moduleId);
         // Use a hash of the Rack serial number to partition the NVLD clique
         info->fabricInfo.cliqueId = getHash(platformInfo.chassisSerialNumber, sizeof(platformInfo.chassisSerialNumber));
       } else if (ncclParamMNNVLCliqueId() != -1) info->fabricInfo.cliqueId = ncclParamMNNVLCliqueId();
-      INFO(NCCL_INIT, "MNNVL busId 0x%lx fabric UUID %lx.%lx cliqueId 0x%x state %d healthMask 0x%x",
-           info->busId,
-           uuid0, uuid1,
-           info->fabricInfo.cliqueId, info->fabricInfo.state, info->fabricInfo.healthMask);
+      INFO(NCCL_INIT, "MNNVL busId 0x%lx fabric UUID %lx.%lx cliqueId 0x%x state %d healthMask 0x%x", info->busId,
+           uuid0, uuid1, info->fabricInfo.cliqueId, info->fabricInfo.state, info->fabricInfo.healthMask);
     }
   }
 #else
-    char busId[NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE];
-    NCCLCHECK(int64ToBusId(info->busId, busId));
-    uint32_t deviceIndex = -1;
-    (void) amd_smi_getDeviceIndexByPciBusId(busId, &deviceIndex);
-    if(deviceIndex != -1) {
-      info->fabricInfo.fabricSupported = false;
-      (void) amd_smi_getFabricDeviceInfo(deviceIndex, &info->fabricInfo);
-      if (info->fabricInfo.fabricSupported) {
-        uint64_t uuid0 = 0;
-        uint64_t uuid1 = 0;
-        memcpy(&uuid0, info->fabricInfo.clusterUuid, sizeof(uuid0));
-        memcpy(&uuid1, info->fabricInfo.clusterUuid + sizeof(uuid0), sizeof(uuid1));
-        INFO(NCCL_INIT, "UALoE-enabled (aka MNNVL) device busId 0x%lx fabricType %d state %d acceleratorId %d bandwidth %u Mb/s latency %u ns UUID %lx.%lx ppodSize %u cliqueId %u clique size %u",
-             info->busId,
-             info->fabricInfo.fabricType,
-             info->fabricInfo.state,
-             info->fabricInfo.acceleratorId,
-             info->fabricInfo.bandwidth,
-             info->fabricInfo.latency,
-             uuid0, uuid1,
-             info->fabricInfo.ppodSize,
-             info->fabricInfo.cliqueId,
-             info->fabricInfo.vpodSize);
-      }
+  char busId[NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE];
+  NCCLCHECK(int64ToBusId(info->busId, busId));
+  uint32_t deviceIndex = -1;
+  (void)amd_smi_getDeviceIndexByPciBusId(busId, &deviceIndex);
+  if (deviceIndex != -1) {
+    info->fabricInfo.fabricSupported = false;
+    (void)amd_smi_getFabricDeviceInfo(deviceIndex, &info->fabricInfo);
+    if (info->fabricInfo.fabricSupported) {
+      uint64_t uuid0 = 0;
+      uint64_t uuid1 = 0;
+      memcpy(&uuid0, info->fabricInfo.clusterUuid, sizeof(uuid0));
+      memcpy(&uuid1, info->fabricInfo.clusterUuid + sizeof(uuid0), sizeof(uuid1));
+      INFO(NCCL_INIT,
+           "UALoE-enabled (aka MNNVL) device busId 0x%lx fabricType %d state %d acceleratorId %d bandwidth %u Mb/s "
+           "latency %u ns UUID %lx.%lx ppodSize %u cliqueId %u clique size %u",
+           info->busId, info->fabricInfo.fabricType, info->fabricInfo.state, info->fabricInfo.acceleratorId,
+           info->fabricInfo.bandwidth, info->fabricInfo.latency, uuid0, uuid1, info->fabricInfo.ppodSize,
+           info->fabricInfo.cliqueId, info->fabricInfo.vpodSize);
     }
+  }
 #endif
 
   // Peer capability flags (upstream v2.30 fillInfo additions) consumed by the
@@ -1105,7 +1111,8 @@ static ncclResult_t fillInfo(struct ncclComm* comm, struct ncclPeerInfo* info, u
   NCCLCHECK(ncclTopoCheckCrossNicSupport(&info->crossNicSupport));
 #if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
   int cuMemGdrSupport;
-  CUCHECK(cuDeviceGetAttribute(&cuMemGdrSupport, CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_WITH_CUDA_VMM_SUPPORTED, comm->cudaDev));
+  CUCHECK(cuDeviceGetAttribute(&cuMemGdrSupport, CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_WITH_CUDA_VMM_SUPPORTED,
+                               comm->cudaDev));
   info->cuMemGdrSupport = (cuMemGdrSupport == 1);
 #else
   // CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_WITH_CUDA_VMM_SUPPORTED has no ROCm
@@ -1125,22 +1132,23 @@ static ncclResult_t setupChannel(struct ncclComm* comm, int channelId, int rank,
 
   struct ncclRing* ring = &comm->channels[channelId].ring;
   // Find our ring-distance from rank zero and reorganize ranks to start with rank.
-  int ixZero=0, ixRank=0;
-  for (int i=0; i < nranks; i++) {
+  int ixZero = 0, ixRank = 0;
+  for (int i = 0; i < nranks; i++) {
     if (ringRanks[i] == 0) ixZero = i;
     if (ringRanks[i] == rank) ixRank = i;
   }
-  ring->index = (ixRank-ixZero + nranks)%nranks;
-  for (int i=0; i<nranks; i++) {
-    ring->userRanks[i] = ringRanks[(i+ixRank)%nranks];
+  ring->index = (ixRank - ixZero + nranks) % nranks;
+  for (int i = 0; i < nranks; i++) {
+    ring->userRanks[i] = ringRanks[(i + ixRank) % nranks];
     ring->rankToIndex[ring->userRanks[i]] = i;
   }
   return ncclSuccess;
 }
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
 #else
-#define DEFAULT_LL_BUFFSIZE (NCCL_LL_LINES_PER_THREAD*NCCL_LL_MAX_NTHREADS*NCCL_STEPS*sizeof(union ncclLLFifoLine))
-#define DEFAULT_LL128_BUFFSIZE (NCCL_LL128_ELEMS_PER_THREAD*NCCL_LL128_MAX_NTHREADS*NCCL_STEPS*sizeof(uint64_t))
+#define DEFAULT_LL_BUFFSIZE \
+  (NCCL_LL_LINES_PER_THREAD * NCCL_LL_MAX_NTHREADS * NCCL_STEPS * sizeof(union ncclLLFifoLine))
+#define DEFAULT_LL128_BUFFSIZE (NCCL_LL128_ELEMS_PER_THREAD * NCCL_LL128_MAX_NTHREADS * NCCL_STEPS * sizeof(uint64_t))
 #define DEFAULT_BUFFSIZE (1 << 22) /* 4MiB */
 #endif
 NCCL_PARAM(BuffSize, "BUFFSIZE", -2);
@@ -1152,26 +1160,26 @@ NCCL_PARAM(P2pPciChunkSize, "P2P_PCI_CHUNKSIZE", (1 << 17)); /* 128 kB */
 NCCL_PARAM(P2pNvlChunkSize, "P2P_NVL_CHUNKSIZE", (1 << 19)); /* 512 kB */
 
 static ncclResult_t computeBuffSizes(struct ncclComm* comm) {
-  int64_t envs[NCCL_NUM_PROTOCOLS] = { ncclParamLlBuffSize(), ncclParamLl128BuffSize(), ncclParamBuffSize() };
+  int64_t envs[NCCL_NUM_PROTOCOLS] = {ncclParamLlBuffSize(), ncclParamLl128BuffSize(), ncclParamBuffSize()};
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
   int defaults[NCCL_NUM_PROTOCOLS];
   rcclSetDefaultBuffSizes(comm, defaults);
 #else
-  int defaults[NCCL_NUM_PROTOCOLS] = { DEFAULT_LL_BUFFSIZE, DEFAULT_LL128_BUFFSIZE, DEFAULT_BUFFSIZE };
+  int defaults[NCCL_NUM_PROTOCOLS] = {DEFAULT_LL_BUFFSIZE, DEFAULT_LL128_BUFFSIZE, DEFAULT_BUFFSIZE};
 #endif
-  for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
+  for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) {
     comm->buffSizes[p] = envs[p] != -2 ? envs[p] : defaults[p];
   }
 
   if (comm->nNodes > 1) {
     rcclSetP2pNetChunkSize(comm, comm->p2pChunkSize);
-    comm->p2pChunkSize = (comm->p2pChunkSize > RCCL_VALUE_INVALID)? comm->p2pChunkSize :  ncclParamP2pNetChunkSize();
-  }
-  else if (comm->isAllNvlink) comm->p2pChunkSize = ncclParamP2pNvlChunkSize();
+    comm->p2pChunkSize = (comm->p2pChunkSize > RCCL_VALUE_INVALID) ? comm->p2pChunkSize : ncclParamP2pNetChunkSize();
+  } else if (comm->isAllNvlink) comm->p2pChunkSize = ncclParamP2pNvlChunkSize();
   else comm->p2pChunkSize = ncclParamP2pPciChunkSize();
 
   // Make sure P2P chunksize is not larger than coll chunksize.
-  if (comm->p2pChunkSize * NCCL_STEPS > comm->buffSizes[NCCL_PROTO_SIMPLE]) comm->p2pChunkSize = comm->buffSizes[NCCL_PROTO_SIMPLE]/NCCL_STEPS;
+  if (comm->p2pChunkSize * NCCL_STEPS > comm->buffSizes[NCCL_PROTO_SIMPLE])
+    comm->p2pChunkSize = comm->buffSizes[NCCL_PROTO_SIMPLE] / NCCL_STEPS;
 
   if (comm->sharedRes->owner != comm) {
     /* make sure split comm p2pChunkSize won't exceed shared p2pChunkSize. */
@@ -1213,8 +1221,8 @@ static ncclResult_t initNvlDomainInfo(struct ncclComm* comm) {
   comm->nvlDomainInfo.minRanksPerNvlDomain = comm->minLocalRanks;
   comm->nvlDomainInfo.maxRanksPerNvlDomain = comm->maxLocalRanks;
 
-  TRACE(NCCL_INIT, "NVLink domains: %d domains, min ranks per domain: %d, max ranks per domain: %d",
-        comm->nNodes, comm->nvlDomainInfo.minRanksPerNvlDomain, comm->nvlDomainInfo.maxRanksPerNvlDomain);
+  TRACE(NCCL_INIT, "NVLink domains: %d domains, min ranks per domain: %d, max ranks per domain: %d", comm->nNodes,
+        comm->nvlDomainInfo.minRanksPerNvlDomain, comm->nvlDomainInfo.maxRanksPerNvlDomain);
 
   return ncclSuccess;
 }
@@ -1227,7 +1235,10 @@ static bool uniformRanksPerHost(const struct ncclComm* comm, int nranks) {
     uint64_t h = comm->peerInfo[i].hostHash;
     bool lowestRankOnHost = true;
     for (int j = 0; j < i; j++) {
-      if (comm->peerInfo[j].hostHash == h) { lowestRankOnHost = false; break; }
+      if (comm->peerInfo[j].hostHash == h) {
+        lowestRankOnHost = false;
+        break;
+      }
     }
     if (!lowestRankOnHost) continue;
     int cnt = 0;
@@ -1264,7 +1275,8 @@ static ncclResult_t ncclP2pSchedule(struct ncclComm* comm) {
   int groupCount = 0;
   for (int n = 0; n < comm->nNodes; ++n) {
     if (0 != comm->nodeRanks[n].localRanks % groupSize) {
-      WARN("nLocals = %d should be a diviser of the number of ranks in node %d = %d", groupSize, n, comm->nodeRanks[n].localRanks);
+      WARN("nLocals = %d should be a diviser of the number of ranks in node %d = %d", groupSize, n,
+           comm->nodeRanks[n].localRanks);
       return ncclInternalError;
     }
     int nGroupsInNode = comm->nodeRanks[n].localRanks / groupSize;
@@ -1279,7 +1291,7 @@ static ncclResult_t ncclP2pSchedule(struct ncclComm* comm) {
     WARN("Group creation failed: %d vs %d", groupCount, nGroups);
     return ncclInternalError;
   }
-  INFO(NCCL_GRAPH,"%s: group size used is %d",__func__,groupSize);
+  INFO(NCCL_GRAPH, "%s: group size used is %d", __func__, groupSize);
 
   uint32_t groupRound = 0, groupDelta = 0;
   int round = 0;
@@ -1311,7 +1323,8 @@ static ncclResult_t ncclP2pSchedule(struct ncclComm* comm) {
   return ncclSuccess;
 }
 
-static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* parent, uint64_t timers[TIMERS_INIT_COUNT]) {
+static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* parent,
+                                       uint64_t timers[TIMERS_INIT_COUNT]) {
   // We use 2 AllGathers
   // 1. { peerInfo, comm, compCap}
   // 2. { nChannels, graphInfo, topoRanks }
@@ -1325,7 +1338,8 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   struct ncclTopoGraph* collNetChainGraph = &comm->graphs[NCCL_ALGO_COLLNET_CHAIN];
   struct ncclTopoGraph* collNetDirectGraph = &comm->graphs[NCCL_ALGO_COLLNET_DIRECT];
   struct ncclTopoGraph* nvlsGraph = &comm->graphs[NCCL_ALGO_NVLS];
-  struct ncclTopoGraph* graphs[NCCL_NUM_ALGORITHMS] = { treeGraph, ringGraph, collNetDirectGraph, collNetChainGraph, nvlsGraph, nvlsGraph, treeGraph };
+  struct ncclTopoGraph* graphs[NCCL_NUM_ALGORITHMS] = {treeGraph, ringGraph, collNetDirectGraph, collNetChainGraph,
+                                                       nvlsGraph, nvlsGraph, treeGraph};
 
   struct graphInfo {
     int pattern;
@@ -1359,14 +1373,14 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   };
 
   int nChannelsOrig;
-  struct allGatherInfo *allGather3Data = NULL;
+  struct allGatherInfo* allGather3Data = NULL;
   struct ncclTopoRanks** allTopoRanks = NULL;
   int *nodesFirstRank = NULL, *nodesTreePatterns = NULL;
-  int *rings = NULL;
+  int* rings = NULL;
   int* nvbPeers = NULL;
   struct ncclProxyConnector proxyConn;
   int* pxnPeers = NULL;
-  int *topParentLocalRanks = NULL;
+  int* topParentLocalRanks = NULL;
   int p2pLevel = -1;
   bool globalNicFused = false;
   bool globalGinSupport = comm->sharedRes->ginState.ginType != NCCL_GIN_TYPE_NONE;
@@ -1384,16 +1398,16 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
 
   timers[TIMER_INIT_ALLGATHER] = clockNano();
   // AllGather1 - begin
-  NCCLCHECKGOTO(ncclCalloc(&comm->peerInfo, nranks+1), ret, fail); // Extra rank to represent CollNet root
-  NCCLCHECKGOTO(fillInfo(comm, comm->peerInfo+rank, comm->commHash), ret, fail);
+  NCCLCHECKGOTO(ncclCalloc(&comm->peerInfo, nranks + 1), ret, fail); // Extra rank to represent CollNet root
+  NCCLCHECKGOTO(fillInfo(comm, comm->peerInfo + rank, comm->commHash), ret, fail);
   NCCLCHECKGOTO(bootstrapAllGather(comm->bootstrap, comm->peerInfo, sizeof(struct ncclPeerInfo)), ret, fail);
   COMPILER_ATOMIC_STORE(&comm->peerInfoValid, true, std::memory_order_release);
 
   comm->cuMemSupport = 1;
   for (int i = 0; i < nranks; i++) {
     if (comm->peerInfo[i].version != comm->peerInfo[rank].version) {
-      WARN("Mismatched NCCL version detected : rank %d version %d rank %d version %d",
-           i, comm->peerInfo[i].version, rank, comm->peerInfo[rank].version);
+      WARN("Mismatched NCCL version detected : rank %d version %d rank %d version %d", i, comm->peerInfo[i].version,
+           rank, comm->peerInfo[rank].version);
       ret = ncclInvalidUsage;
       goto fail;
     }
@@ -1437,7 +1451,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
       if (comm->nvlsRegSupport) {
         for (int j = i + 1; j < nranks; j++) {
           if (comm->peerInfo[i].hostHash == comm->peerInfo[j].hostHash &&
-            comm->peerInfo[i].pidHash == comm->peerInfo[j].pidHash) {
+              comm->peerInfo[i].pidHash == comm->peerInfo[j].pidHash) {
             comm->nvlsRegSupport = 0;
             break;
           }
@@ -1449,24 +1463,25 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
     if (comm->MNNVL) comm->nvlsRegSupport = 0;
     else if (ncclParamSingleProcMemRegEnable()) comm->nvlsRegSupport = 1;
 
-    TRACE(NCCL_INIT,"pidHash[%d] %lx intraProcRank %d intraProcRanks %d intraProcRank0 %d",
-        rank, comm->peerInfo[rank].pidHash, intraProcRank, intraProcRanks, intraProcRank0);
+    TRACE(NCCL_INIT, "pidHash[%d] %lx intraProcRank %d intraProcRanks %d intraProcRank0 %d", rank,
+          comm->peerInfo[rank].pidHash, intraProcRank, intraProcRanks, intraProcRank0);
     if (intraProcRank == -1 || intraProcRank0 == -1 || comm->peerInfo[intraProcRank0].comm == NULL) {
-      WARN("Failed to determine intra proc ranks rank %d hostHash %lx pidHash %lx intraProcRank %d intraProcRanks %d intraProcRank0 %d",
-          rank, comm->peerInfo[rank].hostHash, comm->peerInfo[rank].pidHash,
-          intraProcRank, intraProcRanks, intraProcRank0);
+      WARN("Failed to determine intra proc ranks rank %d hostHash %lx pidHash %lx intraProcRank %d intraProcRanks %d "
+           "intraProcRank0 %d",
+           rank, comm->peerInfo[rank].hostHash, comm->peerInfo[rank].pidHash, intraProcRank, intraProcRanks,
+           intraProcRank0);
       ret = ncclInternalError;
       goto fail;
     }
     struct ncclComm* comm0 = comm->peerInfo[intraProcRank0].comm;
-    assert(intraProcRank==0 ? comm==comm0 : true);
+    assert(intraProcRank == 0 ? comm == comm0 : true);
     comm->intraComm0 = comm0;
     comm->intraRank = intraProcRank;
     comm->intraRanks = intraProcRanks;
     comm->intraBarrierPhase = 0;
     comm->intraBarrierCounter = 0;
     comm->intraBarrierGate = 0;
-  } while(0);
+  } while (0);
 
   timers[TIMER_INIT_TOPO] = clockNano();
 
@@ -1479,7 +1494,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   // Topo detection / System graph creation
   NCCLCHECKGOTO(ncclTopoGetSystem(comm, &comm->topo), ret, fail);
   comm->topo->tuning = rcclGetTuningIndexForArch(comm->archName);
-  INFO(NCCL_INIT, "Tuning index set to: %d",  comm->topo->tuning);
+  INFO(NCCL_INIT, "Tuning index set to: %d", comm->topo->tuning);
   // save nRanks to ncclTopoSystem as indicator of multi-node
   comm->topo->nRanks = comm->nRanks;
   // init netGdrLevel
@@ -1548,11 +1563,9 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
           isNewHost = 0;
         }
       }
-      if (isNewHost)
-      {
+      if (isNewHost) {
         // Check if this is the same hostname associated with this rank
-        if (comm->peerInfo[r].hostHash == comm->peerInfo[rank].hostHash)
-          comm->topo->hostIdx = comm->topo->nHosts;
+        if (comm->peerInfo[r].hostHash == comm->peerInfo[rank].hostHash) comm->topo->hostIdx = comm->topo->nHosts;
         comm->topo->nHosts++;
       }
     }
@@ -1566,26 +1579,26 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   ringGraph->id = 0;
   ringGraph->pattern = NCCL_TOPO_PATTERN_RING;
   ringGraph->minChannels = 1;
-  ringGraph->maxChannels = MAXCHANNELS/2;
+  ringGraph->maxChannels = MAXCHANNELS / 2;
   NCCLCHECKGOTO(ncclTopoCompute(comm->topo, ringGraph), ret, fail);
   NCCLCHECKGOTO(ncclTopoPrintGraph(comm->topo, ringGraph), ret, fail);
 
-  if( IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx1151" ) ) {
+  if (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx1151")) {
     /**
      * GFX1151 (1 GPU/node): Uses Walecki + Greedy construction to generate 'nChannels'
      * edge-disjoint Hamiltonian rings. For N nodes, N/2 perfect rings are guaranteed;
      * additional channels are balanced via greedy heuristics to saturate Fat-Tree/Clos fabrics.
-     * Note: nNodes is only known AFTER bootstrapAllGather (Postset), but nChannels 
-     * is required during Preset. Therefore, nChannels cannot be auto-calculated 
+     * Note: nNodes is only known AFTER bootstrapAllGather (Postset), but nChannels
+     * is required during Preset. Therefore, nChannels cannot be auto-calculated
      * based on nNodes at this stage.
-     * Recommended: Set nChannels via environment variable (e.g., 6 channels for 
-     * optimal 4-node load balancing). Missing channel data is backfilled 
+     * Recommended: Set nChannels via environment variable (e.g., 6 channels for
+     * optimal 4-node load balancing). Missing channel data is backfilled
      * by repairMissingChannels() during Postset.
      * */
     int numChannels = rcclParamInitChannels() > 0 ? rcclParamInitChannels() : 6 /* 2 X (comm->nNodes - 1)  */;
-    ringGraph->nChannels = std::max(ringGraph->minChannels, std::min(ringGraph->maxChannels,(int32_t) numChannels));
+    ringGraph->nChannels = std::max(ringGraph->minChannels, std::min(ringGraph->maxChannels, (int32_t)numChannels));
   }
-  INFO(NCCL_INIT,"ringGraph->nChannels = %d ", ringGraph->nChannels);
+  INFO(NCCL_INIT, "ringGraph->nChannels = %d ", ringGraph->nChannels);
 
   memset(treeGraph, 0, sizeof(struct ncclTopoGraph));
   treeGraph->id = 1;
@@ -1636,8 +1649,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
       if (i == j) continue;
       int cudaDev2 = comm->peerInfo[j].cudaDev;
       int p2p;
-      if (hipDeviceCanAccessPeer(&p2p, cudaDev1, cudaDev2) != hipSuccess || !p2p)
-      {
+      if (hipDeviceCanAccessPeer(&p2p, cudaDev1, cudaDev2) != hipSuccess || !p2p) {
         hasPeerAccess = false;
         break;
       }
@@ -1652,13 +1664,14 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   comm->allocP2pNetLLBuffers = ncclParamAllocP2pNetLLBuffers() == 1;
 
   if (comm->rank == ncclParamGraphDumpFileRank()) {
-    struct ncclTopoGraph* dumpGraphs[5] = { ringGraph, treeGraph, collNetDirectGraph, collNetChainGraph, nvlsGraph };
+    struct ncclTopoGraph* dumpGraphs[5] = {ringGraph, treeGraph, collNetDirectGraph, collNetChainGraph, nvlsGraph};
     NCCLCHECKGOTO(ncclTopoDumpGraphs(comm->topo, 5, dumpGraphs), ret, fail);
   }
 
   // Cap maxP2pPeers to nRanks
   if (comm->config.maxP2pPeers != NCCL_CONFIG_UNDEF_INT && comm->config.maxP2pPeers > comm->nRanks) {
-    INFO(NCCL_INIT, "Max P2P Peers %d is too high, capping to communicator size %d", comm->config.maxP2pPeers, comm->nRanks);
+    INFO(NCCL_INIT, "Max P2P Peers %d is too high, capping to communicator size %d", comm->config.maxP2pPeers,
+         comm->nRanks);
     comm->config.maxP2pPeers = comm->nRanks;
   }
   // Compute nChannels per peer for p2p
@@ -1668,9 +1681,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
     if (rcclParamP2pNetDisable() == 0) {
       if (!(comm->topo->type & RCCL_TOPO_FORCE_INTRA)) comm->p2pNet = 1;
       INFO(NCCL_INIT, "RCCL enabled same node P2P over network");
-    }
-    else
-      INFO(NCCL_INIT, "RCCL force disabled same node P2P over network");
+    } else INFO(NCCL_INIT, "RCCL force disabled same node P2P over network");
   }
   // Because timers[[TIMER_INIT_ALLGATHER] already contains the timing of the first allgather,
   // we temporarily store the start time of the subsequent one in an as-of-yet unused CONNECT timer.
@@ -1681,34 +1692,33 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   NCCLCHECK(ncclTopoIdToIndex(comm->topo, GPU, NCCL_TOPO_ID(comm->topo->systemId, comm->busId), &idx));
   allGather3Data[rank].nc = 2;
   if (comm->topo->nodes[GPU].count == comm->topo->nRanks &&
-       IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx906") && allXgmi)
+      IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx906") && allXgmi)
     allGather3Data[rank].nc = 4;
   if (IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx908"))
-    allGather3Data[rank].nc = std::max(4/ringGraph->nChannels, 2);
-  if (comm->topo->nodes[GPU].count == comm->topo->nRanks &&
-       (comm->topo->type & RCCL_TOPO_CR8G))
+    allGather3Data[rank].nc = std::max(4 / ringGraph->nChannels, 2);
+  if (comm->topo->nodes[GPU].count == comm->topo->nRanks && (comm->topo->type & RCCL_TOPO_CR8G))
     allGather3Data[rank].nc = 4;
   if (comm->topo->nodes[GPU].count == comm->topo->nRanks &&
       IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx90a"))
     allGather3Data[rank].nc = 4;
   if (IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx90a"))
-    allGather3Data[rank].nc = std::max(allGather3Data[rank].nc, 4/ringGraph->nChannels);
-  if (ringGraph->nChannels > MAXCHANNELS/2)
-    allGather3Data[rank].nc = 1;
+    allGather3Data[rank].nc = std::max(allGather3Data[rank].nc, 4 / ringGraph->nChannels);
+  if (ringGraph->nChannels > MAXCHANNELS / 2) allGather3Data[rank].nc = 1;
   comm->gfx9CheapFenceOff = 1;
-  #ifdef HIP_UNCACHED_MEMORY
+#ifdef HIP_UNCACHED_MEMORY
   // cheap fence is only safe with cache bypassing load/store availability in kernel
   // only enabled on gfx942, gfx950 and gfx1250
-  if(!rcclParamGfx9CheapFenceOff()){
-    if(IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx942") ||
-      IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx950") ||
-      IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx1250"))
+  if (!rcclParamGfx9CheapFenceOff()) {
+    if (IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx942") ||
+        IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx950") ||
+        IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx1250"))
       comm->gfx9CheapFenceOff = 0;
   }
-  #endif
+#endif
   INFO(NCCL_INIT, "GFX9 cheap fence is %s", comm->gfx9CheapFenceOff ? "OFF" : "ON");
   // RCCL: Only use one slice per primitive on some single node gfx9xx systems, only currently enabled for AllReduce, ReduceScatter, and AllGather
-  if (IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx942") || IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx950")){
+  if (IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx942") ||
+      IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx950")) {
     comm->rcclUseOneSlice = nNodes == 1;
   }
   if (IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx942")) {
@@ -1729,15 +1739,16 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
     }
   }
 #ifdef ENABLE_WARP_SPEED
-  comm->topo->warpSpeedEnabled = (rcclParamWarpSpeedForceEnable() > 0 || ((!parent || comm->isGrow) && rcclCanUseWarpSpeedAuto(comm, nNodes)));
+  comm->topo->warpSpeedEnabled =
+    (rcclParamWarpSpeedForceEnable() > 0 || ((!parent || comm->isGrow) && rcclCanUseWarpSpeedAuto(comm, nNodes)));
 #endif
 
   // For single node communicators that do not uses the full xgmi links per gpu, i.e., nranks < 8
   // Inflate the nChannels a bit to achieve higher b/w.
   if (IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx950")) {
-    if (nranks == 2 && nNodes == 1){
+    if (nranks == 2 && nNodes == 1) {
       allGather3Data[rank].nc = 16;
-    } else if (nranks == 4 && nNodes == 1){
+    } else if (nranks == 4 && nNodes == 1) {
       allGather3Data[rank].nc = 8;
     } else {
       allGather3Data[rank].nc = 4;
@@ -1752,8 +1763,8 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   allGather3Data[rank].pivotA2AEnabled = comm->topo->pivotA2AEnabled && rcclParamPivotAlltoallEnable();
   // Default-enable LL128 on gfx1250 so NCCL_PROTO=LL128 is honored without
   // also requiring RCCL_LL128_FORCE_ENABLE=1.
-  comm->topo->ll128Enabled =  comm->topo->ll128Enabled || rcclParamLL128ForceEnable()
-    || IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx1250");
+  comm->topo->ll128Enabled = comm->topo->ll128Enabled || rcclParamLL128ForceEnable() ||
+                             IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx1250");
   allGather3Data[rank].ll128Enabled = comm->topo->ll128Enabled;
 
   if (comm->ncclNet && comm->ncclNet->devices) {
@@ -1765,7 +1776,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   INFO(NCCL_INIT, "Rank %d: %d Net devices", rank, localNetDeviceCount);
   INFO(NCCL_INIT, "Rank %d: %d CollNet devices", rank, localCollNetCount);
 
-  for (int a=0; a<NCCL_NUM_ALGORITHMS; a++) {
+  for (int a = 0; a < NCCL_NUM_ALGORITHMS; a++) {
     allGather3Data[rank].graphInfo[a].pattern = graphs[a]->pattern;
     allGather3Data[rank].graphInfo[a].nChannels = graphs[a]->nChannels;
     allGather3Data[rank].graphInfo[a].sameChannels = graphs[a]->sameChannels;
@@ -1779,7 +1790,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   allGather3Data[rank].cpuArch = comm->cpuArch;
   allGather3Data[rank].cpuVendor = comm->cpuVendor;
   allGather3Data[rank].romeTopoModelIdx = comm->topo->romeTopoModelIdx;
-  (void) getHostName(allGather3Data[rank].hostname, sizeof(allGather3Data[rank].hostname), '\0');
+  (void)getHostName(allGather3Data[rank].hostname, sizeof(allGather3Data[rank].hostname), '\0');
   allGather3Data[rank].p2pnChannelsPerPeer = comm->p2pnChannelsPerPeer;
   allGather3Data[rank].p2pMaxPeers = comm->p2pMaxPeers;
 
@@ -1791,7 +1802,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
 
   comm->nChannels = std::min(treeGraph->nChannels, ringGraph->nChannels);
 
-  //For a 1‑rank job there’s no topology constraint, so ncclTopoCompute drives the ring to its allowed maximum, which results 4 x MAXCHANNELS channels for single rank comms and causes issues.
+  // For a 1‑rank job there’s no topology constraint, so ncclTopoCompute drives the ring to its allowed maximum, which results 4 x MAXCHANNELS channels for single rank comms and causes issues.
   if (comm->nRanks == 1) {
     comm->nChannels = treeGraph->nChannels = ringGraph->nChannels = 8;
   }
@@ -1801,21 +1812,20 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
 
   if (uniformRanksPerHost(comm, nranks)) {
     NCCLCHECKGOTO(rcclCheckRomeTopoModelIdxConsensus(
-        nranks,
-        [&](int r) { return allGather3Data[r].romeTopoModelIdx; },
-        [&](int r) { return allGather3Data[r].hostname; },
-        [&](int r) { return comm->peerInfo[r].hostHash; }),
-      ret, fail);
+                    nranks, [&](int r) { return allGather3Data[r].romeTopoModelIdx; },
+                    [&](int r) { return allGather3Data[r].hostname; },
+                    [&](int r) { return comm->peerInfo[r].hostHash; }),
+                  ret, fail);
   }
 
   // Determine nNodes, firstRanks, ...
   NCCLCHECKGOTO(ncclCalloc(&nodesFirstRank, nranks), ret, fail);
   NCCLCHECKGOTO(ncclCalloc(&nodesTreePatterns, nranks), ret, fail);
   NCCLCHECKGOTO(ncclCalloc(&comm->rankToNode, comm->nRanks), ret, fail);
-  for (int r=0; r<nranks; r++) {
+  for (int r = 0; r < nranks; r++) {
     int node;
     int firstRank = allGather3Data[r].topoRanks.ringRecv[0];
-    for (node=0; node<comm->nNodes && nodesFirstRank[node] != firstRank; node++);
+    for (node = 0; node < comm->nNodes && nodesFirstRank[node] != firstRank; node++);
     if (node == comm->nNodes) {
       comm->nNodes++;
       nodesFirstRank[node] = firstRank;
@@ -1824,12 +1834,10 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
     }
     comm->rankToNode[r] = node;
 
-    if (comm->cpuArch != allGather3Data[r].cpuArch &&
-        comm->cpuArch != NCCL_TOPO_CPU_ARCH_MIXED) {
+    if (comm->cpuArch != allGather3Data[r].cpuArch && comm->cpuArch != NCCL_TOPO_CPU_ARCH_MIXED) {
       comm->cpuArch = NCCL_TOPO_CPU_ARCH_MIXED;
     }
-    if (comm->cpuVendor != allGather3Data[r].cpuVendor &&
-        comm->cpuVendor != NCCL_TOPO_CPU_VENDOR_MIXED) {
+    if (comm->cpuVendor != allGather3Data[r].cpuVendor && comm->cpuVendor != NCCL_TOPO_CPU_VENDOR_MIXED) {
       comm->cpuVendor = NCCL_TOPO_CPU_VENDOR_MIXED;
     }
     if (allGather3Data[r].nicFused) {
@@ -1845,22 +1853,27 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   }
   if (rank == 0) {
     INFO(NCCL_INIT, "Local Net device counts across ranks: min %d max %d", minLocalNetCount, maxLocalNetCount);
-    INFO(NCCL_INIT, "Local CollNet device counts across ranks: min %d max %d", minLocalCollNetCount, maxLocalCollNetCount);
+    INFO(NCCL_INIT, "Local CollNet device counts across ranks: min %d max %d", minLocalCollNetCount,
+         maxLocalCollNetCount);
 
     // Check Net device count mismatch
     if (minLocalNetCount != maxLocalNetCount) {
       // Log mismatched ranks first
-      for (int r=0; r<nranks; r++) {
+      for (int r = 0; r < nranks; r++) {
         if (allGather3Data[r].localNetDeviceCount < maxLocalNetCount) {
-          INFO(NCCL_INIT, "Rank %d has %d local Net devices (max %d).", r, allGather3Data[r].localNetDeviceCount, maxLocalNetCount);
+          INFO(NCCL_INIT, "Rank %d has %d local Net devices (max %d).", r, allGather3Data[r].localNetDeviceCount,
+               maxLocalNetCount);
         }
       }
       // Then warn or error based on env var
       if (ncclParamIgnoreNetMismatch()) {
-        INFO(NCCL_INIT, "Detected mixed local Net device counts across ranks (min %d, max %d). Ignoring due to NCCL_IGNORE_NET_MISMATCH.",
+        INFO(NCCL_INIT,
+             "Detected mixed local Net device counts across ranks (min %d, max %d). Ignoring due to "
+             "NCCL_IGNORE_NET_MISMATCH.",
              minLocalNetCount, maxLocalNetCount);
       } else {
-        WARN("Detected mixed local Net device counts across ranks (min %d, max %d). Set NCCL_IGNORE_NET_MISMATCH=1 to continue.",
+        WARN("Detected mixed local Net device counts across ranks (min %d, max %d). Set NCCL_IGNORE_NET_MISMATCH=1 to "
+             "continue.",
              minLocalNetCount, maxLocalNetCount);
         ret = ncclSystemError;
       }
@@ -1869,17 +1882,21 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
     // Check CollNet device count mismatch
     if (minLocalCollNetCount != maxLocalCollNetCount) {
       // Log mismatched ranks first
-      for (int r=0; r<nranks; r++) {
+      for (int r = 0; r < nranks; r++) {
         if (allGather3Data[r].localCollNetCount < maxLocalCollNetCount) {
-          INFO(NCCL_INIT, "Rank %d has %d local CollNet devices (max %d).", r, allGather3Data[r].localCollNetCount, maxLocalCollNetCount);
+          INFO(NCCL_INIT, "Rank %d has %d local CollNet devices (max %d).", r, allGather3Data[r].localCollNetCount,
+               maxLocalCollNetCount);
         }
       }
       // Then warn or error based on env var
       if (ncclParamIgnoreCollNetMismatch()) {
-        INFO(NCCL_INIT, "Detected mixed local CollNet device counts across ranks (min %d, max %d). Ignoring due to NCCL_IGNORE_COLLNET_MISMATCH.",
+        INFO(NCCL_INIT,
+             "Detected mixed local CollNet device counts across ranks (min %d, max %d). Ignoring due to "
+             "NCCL_IGNORE_COLLNET_MISMATCH.",
              minLocalCollNetCount, maxLocalCollNetCount);
       } else {
-        WARN("Detected mixed local CollNet device counts across ranks (min %d, max %d). Set NCCL_IGNORE_COLLNET_MISMATCH=1 to continue.",
+        WARN("Detected mixed local CollNet device counts across ranks (min %d, max %d). Set "
+             "NCCL_IGNORE_COLLNET_MISMATCH=1 to continue.",
              minLocalCollNetCount, maxLocalCollNetCount);
         ret = ncclSystemError;
       }
@@ -1891,7 +1908,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
 
   // Alert the user to the presence of mixed CPUs. In the past this has caused
   // locks in some collective routines. This may help debug issues in the future.
-  if (rank==0) {
+  if (rank == 0) {
     if (comm->cpuArch == NCCL_TOPO_CPU_ARCH_MIXED) {
       INFO(NCCL_GRAPH, "CPUs with mixed architecture were detected.");
     }
@@ -1899,25 +1916,25 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
       INFO(NCCL_GRAPH, "CPUs with mixed vendors were detected.");
     }
   }
-  
+
   // Now that we know nNodes, alloc nodeRanks and compute localRanks for each node
   NCCLCHECKGOTO(ncclCalloc(&comm->nodeRanks, comm->nNodes), ret, fail);
   NCCLCHECKGOTO(ncclCalloc(&comm->rankToLocalRank, comm->nRanks), ret, fail);
-  for (int r=0; r<comm->nRanks; r++) {
+  for (int r = 0; r < comm->nRanks; r++) {
     int node = comm->rankToNode[r];
     comm->rankToLocalRank[r] = comm->nodeRanks[node].localRanks;
     comm->nodeRanks[node].localRanks++;
   }
   comm->minLocalRanks = INT_MAX;
   // Allocate ranks arrays for each node
-  for (int n=0; n<comm->nNodes; n++) {
+  for (int n = 0; n < comm->nNodes; n++) {
     NCCLCHECKGOTO(ncclCalloc(&comm->nodeRanks[n].localRankToRank, comm->nodeRanks[n].localRanks), ret, fail);
     comm->maxLocalRanks = std::max(comm->maxLocalRanks, comm->nodeRanks[n].localRanks);
     comm->minLocalRanks = std::min(comm->minLocalRanks, comm->nodeRanks[n].localRanks);
     comm->nodeRanks[n].localRanks = 0;
   }
   // And fill the ranks arrays
-  for (int r=0; r<comm->nRanks; r++) {
+  for (int r = 0; r < comm->nRanks; r++) {
     int node = comm->rankToNode[r];
     comm->nodeRanks[node].localRankToRank[comm->nodeRanks[node].localRanks++] = r;
   }
@@ -1928,26 +1945,24 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
 
   NCCLCHECKGOTO(initNvlDomainInfo(comm), ret, fail);
 
-  TRACE(NCCL_INIT,"hostHash[%d] %lx localRank %d localRanks %d localRank0 %d",
-        rank, comm->peerInfo[rank].hostHash, comm->localRank, comm->localRanks, comm->localRankToRank[0]);
+  TRACE(NCCL_INIT, "hostHash[%d] %lx localRank %d localRanks %d localRank0 %d", rank, comm->peerInfo[rank].hostHash,
+        comm->localRank, comm->localRanks, comm->localRankToRank[0]);
   if (comm->localRank == -1 || comm->localRankToRank[0] == -1 || comm->localRanks == 0) {
     WARN("Failed to determine local ranks rank %d hostHash %lx pidHash %lx localRank %d localRanks %d localRank0 %d",
-         rank, comm->peerInfo[rank].hostHash, comm->peerInfo[rank].pidHash,
-         comm->localRank, comm->localRanks, comm->localRankToRank[0]);
+         rank, comm->peerInfo[rank].hostHash, comm->peerInfo[rank].pidHash, comm->localRank, comm->localRanks,
+         comm->localRankToRank[0]);
     ret = ncclInternalError;
     goto fail;
   }
 
-  INFO(NCCL_INIT, "comm %p rank %d nRanks %d nNodes %d localRanks %d localRank %d MNNVL %d",
-       comm, rank, comm->nRanks, comm->nNodes, comm->localRanks, comm->localRank, comm->MNNVL);
+  INFO(NCCL_INIT, "comm %p rank %d nRanks %d nNodes %d localRanks %d localRank %d MNNVL %d", comm, rank, comm->nRanks,
+       comm->nNodes, comm->localRanks, comm->localRank, comm->MNNVL);
 
   // Enable cross-clique P2P when MNNVL is active, parameter allows it, and there
   // are actually multiple cliques in the NVL domain (nvlDomainSize > clique size).
-  comm->p2pCrossClique = comm->MNNVL && ncclParamMNNVLCrossClique() &&
-                          comm->nvlDomainSize > comm->clique.size;
+  comm->p2pCrossClique = comm->MNNVL && ncclParamMNNVLCrossClique() && comm->nvlDomainSize > comm->clique.size;
   if (comm->p2pCrossClique) {
-    INFO(NCCL_INIT, "Cross-clique P2P enabled: nvlDomainSize=%d cliqueSize=%d",
-         comm->nvlDomainSize, comm->clique.size);
+    INFO(NCCL_INIT, "Cross-clique P2P enabled: nvlDomainSize=%d cliqueSize=%d", comm->nvlDomainSize, comm->clique.size);
   }
 
   nChannelsOrig = comm->nChannels;
@@ -1955,13 +1970,13 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   NCCLCHECKGOTO(ncclCalloc(&allTopoRanks, comm->nRanks), ret, fail);
   int nc;
   nc = allGather3Data[0].nc;
-  for (int i=0; i<nranks; i++) {
+  for (int i = 0; i < nranks; i++) {
     allTopoRanks[i] = &allGather3Data[i].topoRanks;
     nc = std::min(allGather3Data[i].nc, nc);
     // Make sure we align all ranks so that the tuning is consistent across ranks
     comm->topo->pivotA2AEnabled = comm->topo->pivotA2AEnabled && allGather3Data[i].pivotA2AEnabled;
     comm->topo->ll128Enabled = comm->topo->ll128Enabled && allGather3Data[i].ll128Enabled;
-    for (int a=0; a<NCCL_NUM_ALGORITHMS; a++) {
+    for (int a = 0; a < NCCL_NUM_ALGORITHMS; a++) {
       graphs[a]->nChannels = std::min(allGather3Data[i].graphInfo[a].nChannels, graphs[a]->nChannels);
       graphs[a]->sameChannels = std::min(allGather3Data[i].graphInfo[a].sameChannels, graphs[a]->sameChannels);
       graphs[a]->bwIntra = std::min(allGather3Data[i].graphInfo[a].bwIntra, graphs[a]->bwIntra);
@@ -1972,7 +1987,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
     }
     comm->maxTreePattern = std::max(comm->maxTreePattern, allGather3Data[i].graphInfo[NCCL_ALGO_TREE].pattern);
     comm->p2pnChannelsPerPeer = std::min(comm->p2pnChannelsPerPeer, allGather3Data[i].p2pnChannelsPerPeer);
-    comm->p2pMaxPeers = std::max(comm->p2pMaxPeers,allGather3Data[i].p2pMaxPeers);
+    comm->p2pMaxPeers = std::max(comm->p2pMaxPeers, allGather3Data[i].p2pMaxPeers);
     comm->minNetBw = std::min(comm->minNetBw, allGather3Data[i].minNetBw);
   }
   if (graphs[NCCL_ALGO_COLLNET_CHAIN]->nChannels == 0) comm->config.collnetEnable = 0;
@@ -1983,28 +1998,32 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   }
 
   comm->nChannels = treeGraph->nChannels = ringGraph->nChannels =
-    (comm->topo->nodes[GPU].count != comm->topo->nRanks && comm->topo->nodes[NET].count)
-    ? std::min(treeGraph->nChannels, ringGraph->nChannels) : ringGraph->nChannels;
+    (comm->topo->nodes[GPU].count != comm->topo->nRanks && comm->topo->nodes[NET].count) ?
+      std::min(treeGraph->nChannels, ringGraph->nChannels) :
+      ringGraph->nChannels;
   if (comm->nChannels < nChannelsOrig) {
     // We started duplicating channels during Preset(), so we need to move the
     // duplicated channels since we have removed some.
-    for (int i=0; i<comm->nChannels; i++) memcpy(comm->channels+comm->nChannels+i, comm->channels+nChannelsOrig+i, sizeof(struct ncclChannel));
+    for (int i = 0; i < comm->nChannels; i++)
+      memcpy(comm->channels + comm->nChannels + i, comm->channels + nChannelsOrig + i, sizeof(struct ncclChannel));
   }
 
   // Determine CollNet support after all-gather now that we know nNodes and each node localRanks
   if (comm->config.collnetEnable == 1) {
     int collNetNodeThreshold = ncclParamCollNetNodeThreshold();
     if (comm->nNodes < collNetNodeThreshold) {
-      INFO(NCCL_INIT, "Communicator has %d nodes which is less than CollNet node threshold %d, disabling CollNet", comm->nNodes, collNetNodeThreshold);
+      INFO(NCCL_INIT, "Communicator has %d nodes which is less than CollNet node threshold %d, disabling CollNet",
+           comm->nNodes, collNetNodeThreshold);
       comm->config.collnetEnable = 0;
     }
   }
   NCCLCHECK(ncclTopoPathAllNVLink(comm->topo, &comm->isAllNvlink));
   comm->isOneRPN = (comm->maxLocalRanks == 1);
 
-  NCCLCHECKGOTO(ncclCalloc(&rings, nranks*MAXCHANNELS), ret, fail);
+  NCCLCHECKGOTO(ncclCalloc(&rings, nranks * MAXCHANNELS), ret, fail);
 
-  NCCLCHECKGOTO(ncclTopoPostset(comm, nodesFirstRank, nodesTreePatterns, allTopoRanks, rings, graphs, parent, nc), ret, fail);
+  NCCLCHECKGOTO(ncclTopoPostset(comm, nodesFirstRank, nodesTreePatterns, allTopoRanks, rings, graphs, parent, nc), ret,
+                fail);
   if (comm->topo->treeDefined) NCCLCHECK(ncclTreeBasePostset(comm, treeGraph));
 
   // AllGather3 - end
@@ -2013,11 +2032,11 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   TRACE(NCCL_INIT, "rank %d nranks %d - BUILT %d TREES/RINGS", rank, nranks, comm->nChannels);
 
   char line[4096];
-  line[0]='\0';
-  for (int c=0; c<comm->nChannels; c++) {
+  line[0] = '\0';
+  for (int c = 0; c < comm->nChannels; c++) {
     struct ncclTree* tree = &comm->channels[c].tree;
-    snprintf(line+strlen(line), 2047-strlen(line), " [%d] %d/%d/%d->%d->%d",
-        c, tree->down[0], tree->down[1], tree->down[2], rank, tree->up);
+    snprintf(line + strlen(line), 2047 - strlen(line), " [%d] %d/%d/%d->%d->%d", c, tree->down[0], tree->down[1],
+             tree->down[2], rank, tree->up);
     INFO(NCCL_GRAPH, "Ring %d : %d -> %d -> %d comm %p nRanks %02d busId %lx", c, comm->channels[c].ring.prev,
          comm->rank, comm->channels[c].ring.next, comm, comm->nRanks, comm->busId);
   }
@@ -2050,7 +2069,8 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   // Profiler plugin context has to be initialized before proxy thread
   NCCLCHECK(ncclProfilerPluginInit(comm));
 
-  NCCLCHECKGOTO(ncclTransportCheckP2pType(comm, &comm->isAllDirectP2p, &comm->directMode, &comm->isAllCudaP2p), ret, fail);
+  NCCLCHECKGOTO(ncclTransportCheckP2pType(comm, &comm->isAllDirectP2p, &comm->directMode, &comm->isAllCudaP2p), ret,
+                fail);
   // Launch proxy service thread, after this, the proxy calls can be used.
   if (parent && parent->shareResources) {
     comm->proxyState = parent->sharedRes->proxyState;
@@ -2070,7 +2090,8 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   comm->planner.bcast_info.maxBcastPeer = INT_MIN;
 
   if (comm->config.numRmaCtx > 0) {
-    comm->planner.rmaTaskQueues = ncclMemoryStackAlloc<ncclIntruQueue<ncclTaskRma, &ncclTaskRma::next>>(&comm->memPermanent, comm->config.numRmaCtx);
+    comm->planner.rmaTaskQueues = ncclMemoryStackAlloc<ncclIntruQueue<ncclTaskRma, &ncclTaskRma::next>>(
+      &comm->memPermanent, comm->config.numRmaCtx);
     for (int i = 0; i < comm->config.numRmaCtx; i++) {
       ncclIntruQueueConstruct(&comm->planner.rmaTaskQueues[i]);
     }
@@ -2080,16 +2101,16 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
 
   comm->runtimeConn = comm->cuMemSupport && ncclParamRuntimeConnect();
   if (comm->runtimeConn) {
-    for (int c=0; c<comm->nChannels; c++) {
-      NCCLCHECKGOTO(setupChannel(comm, c, rank, nranks, rings+c*nranks), ret, fail);
+    for (int c = 0; c < comm->nChannels; c++) {
+      NCCLCHECKGOTO(setupChannel(comm, c, rank, nranks, rings + c * nranks), ret, fail);
     }
     // Attempt to setup NVLS
     NCCLCHECKGOTO(ncclNvlsSetup(comm, parent), ret, fail);
     // Check if we can setup CollNet
     if (comm->config.collnetEnable) ncclCollNetSetup(comm, parent, graphs);
   } else {
-    for (int c=0; c<comm->nChannels; c++) {
-      NCCLCHECKGOTO(setupChannel(comm, c, rank, nranks, rings+c*nranks), ret, fail);
+    for (int c = 0; c < comm->nChannels; c++) {
+      NCCLCHECKGOTO(setupChannel(comm, c, rank, nranks, rings + c * nranks), ret, fail);
     }
     NCCLCHECKGOTO(ncclTransportRingConnect(comm), ret, fail);
 
@@ -2097,9 +2118,11 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
     if (comm->graphs[NCCL_ALGO_RING].nIntraChannels && rcclParamP2pNetDisable() == 0) {
       comm->useIntraNet = 1;
       for (int c = 0; c < comm->nChannels; c++) {
-        struct ncclChannel* channel = comm->channels+c;
+        struct ncclChannel* channel = comm->channels + c;
         if (comm->nRanks == 1) continue;
-        NCCLCHECKGOTO(ncclTransportP2pConnect(comm, c, 1, &channel->ring.prev, 1, &channel->ring.next, NCCL_CONN_IDX_P2P_NET), ret, fail);
+        NCCLCHECKGOTO(ncclTransportP2pConnect(comm, c, 1, &channel->ring.prev, 1, &channel->ring.next,
+                                              NCCL_CONN_IDX_P2P_NET),
+                      ret, fail);
       }
       NCCLCHECKGOTO(ncclTransportP2pSetup(comm, &comm->graphs[NCCL_ALGO_RING], NCCL_CONN_IDX_P2P_NET), ret, fail);
     }
@@ -2122,22 +2145,26 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
     if (comm->config.collnetEnable) {
       ncclCollNetSetup(comm, parent, graphs);
       NCCLCHECKGOTO(ncclCollNetChainBufferSetup(comm), ret, fail);
-      if (comm->maxLocalRanks <= NCCL_MAX_DIRECT_ARITY+1) {
+      if (comm->maxLocalRanks <= NCCL_MAX_DIRECT_ARITY + 1) {
         NCCLCHECKGOTO(ncclCollNetDirectBufferSetup(comm), ret, fail);
       }
     }
 
     // Connect to local net proxy
     NCCLCHECKGOTO(ncclProxyConnect(comm, TRANSPORT_NET, 1, comm->rank, &proxyConn), ret, fail);
-    NCCLCHECKGOTO(ncclProxyCallBlocking(comm, &proxyConn, ncclProxyMsgSharedInit, &comm->p2pnChannels, sizeof(int), NULL, 0), ret, fail);
+    NCCLCHECKGOTO(ncclProxyCallBlocking(comm, &proxyConn, ncclProxyMsgSharedInit, &comm->p2pnChannels, sizeof(int),
+                                        NULL, 0),
+                  ret, fail);
 
     // Then to remote ones when using PXN
     if (ncclPxnDisable(comm) == 0) {
       int nranks;
       NCCLCHECKGOTO(ncclTopoGetPxnRanks(comm, &pxnPeers, &nranks), ret, fail);
-      for (int r=0; r<nranks; r++) {
+      for (int r = 0; r < nranks; r++) {
         NCCLCHECKGOTO(ncclProxyConnect(comm, TRANSPORT_NET, 1, pxnPeers[r], &proxyConn), ret, fail);
-        NCCLCHECKGOTO(ncclProxyCallBlocking(comm, &proxyConn, ncclProxyMsgSharedInit, &comm->p2pnChannels, sizeof(int), NULL, 0), ret, fail);
+        NCCLCHECKGOTO(ncclProxyCallBlocking(comm, &proxyConn, ncclProxyMsgSharedInit, &comm->p2pnChannels, sizeof(int),
+                                            NULL, 0),
+                      ret, fail);
       }
     }
 
@@ -2145,22 +2172,24 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
       // Connect p2p when using NVB path
       int nvbNpeers;
       NCCLCHECKGOTO(ncclTopoGetNvbGpus(comm->topo, comm->rank, &nvbNpeers, &nvbPeers), ret, fail);
-      for (int r=0; r<nvbNpeers; r++) {
+      for (int r = 0; r < nvbNpeers; r++) {
         int peer = nvbPeers[r];
-        int sendRound=0, recvRound=0;
+        int sendRound = 0, recvRound = 0;
         while (comm->p2pSchedule[sendRound].sendRank != peer) sendRound++;
         while (comm->p2pSchedule[recvRound].recvRank != peer) recvRound++;
         uint8_t sendBase = ncclP2pChannelBaseForRound(comm, sendRound);
         uint8_t recvBase = ncclP2pChannelBaseForRound(comm, recvRound);
-        for (int c=0; c<comm->p2pnChannelsPerPeer; c++) {
+        for (int c = 0; c < comm->p2pnChannelsPerPeer; c++) {
           int channelId;
-          channelId = ncclP2pChannelForPart(comm->p2pnChannels, sendBase, c, comm->p2pnChannelsPerPeer, comm->nNodes, comm->p2pChannelShiftSize);
+          channelId = ncclP2pChannelForPart(comm->p2pnChannels, sendBase, c, comm->p2pnChannelsPerPeer, comm->nNodes,
+                                            comm->p2pChannelShiftSize);
           if (comm->channels[channelId].peers[peer]->send[1].connected == 0) {
-            comm->connectSend[peer].masks[channelId/64] |= (1UL<<(channelId%64));
+            comm->connectSend[peer].masks[channelId / 64] |= (1UL << (channelId % 64));
           }
-          channelId = ncclP2pChannelForPart(comm->p2pnChannels, recvBase, c, comm->p2pnChannelsPerPeer, comm->nNodes, comm->p2pChannelShiftSize);
+          channelId = ncclP2pChannelForPart(comm->p2pnChannels, recvBase, c, comm->p2pnChannelsPerPeer, comm->nNodes,
+                                            comm->p2pChannelShiftSize);
           if (comm->channels[channelId].peers[peer]->recv[1].connected == 0) {
-            comm->connectRecv[peer].masks[channelId/64] |= (1UL<<(channelId%64));
+            comm->connectRecv[peer].masks[channelId / 64] |= (1UL << (channelId % 64));
           }
         }
       }
@@ -2175,11 +2204,16 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   NCCLCHECKGOTO(ncclTopoInitTunerConstants(comm), ret, fail);
   NCCLCHECKGOTO(ncclTunerPluginLoad(comm), ret, fail);
   if (comm->tuner) {
-    NCCLCHECK(comm->tuner->init(&comm->tunerContext, comm->commHash, comm->nRanks, comm->nNodes, ncclDebugLog, &comm->nvlDomainInfo, &comm->tunerConstants));
+    NCCLCHECK(comm->tuner->init(&comm->tunerContext, comm->commHash, comm->nRanks, comm->nNodes, ncclDebugLog,
+                                &comm->nvlDomainInfo, &comm->tunerConstants));
   }
   NCCLCHECKGOTO(ncclTopoTuneModel(comm, comm->minCompCap, comm->maxCompCap, graphs), ret, fail);
 
-  INFO(NCCL_INIT, "comm:%p, nRanks:%d, nNodes:%d, coll channels:%d collnet channels:%d, nvls channels:%d, p2p channels:%d, p2p channels per peer:%d, shiftSize:%d", comm, comm->nRanks, comm->nNodes, comm->nChannels, comm->nChannels, comm->nvlsChannels, comm->p2pnChannels, comm->p2pnChannelsPerPeer, comm->p2pChannelShiftSize);
+  INFO(NCCL_INIT,
+       "comm:%p, nRanks:%d, nNodes:%d, coll channels:%d collnet channels:%d, nvls channels:%d, p2p channels:%d, p2p "
+       "channels per peer:%d, shiftSize:%d",
+       comm, comm->nRanks, comm->nNodes, comm->nChannels, comm->nChannels, comm->nvlsChannels, comm->p2pnChannels,
+       comm->p2pnChannelsPerPeer, comm->p2pChannelShiftSize);
 
   if (comm->intraRank == 0) { // Load ncclParamLaunchMode
     const char* str = ncclGetEnv("NCCL_LAUNCH_MODE");
@@ -2192,8 +2226,9 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
     // In theory we could be racing with other communicators not associated with
     // this one if the user is connecting to multiple ncclUniqueId's concurrently.
     modeOld = COMPILER_ATOMIC_EXCHANGE(&ncclParamLaunchMode, mode, std::memory_order_relaxed);
-    if (modeOld == ncclLaunchModeInvalid && str && str[0]!='\0') {
-      INFO(NCCL_ENV, "NCCL_LAUNCH_MODE set by environment to %s", mode == ncclLaunchModeParallel ? "PARALLEL" : "GROUP");
+    if (modeOld == ncclLaunchModeInvalid && str && str[0] != '\0') {
+      INFO(NCCL_ENV, "NCCL_LAUNCH_MODE set by environment to %s",
+           mode == ncclLaunchModeParallel ? "PARALLEL" : "GROUP");
     }
   }
 
@@ -2202,16 +2237,20 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   if (globalGinSupport && !globalNicFused && globalCuMemGdrSupport) {
     comm->globalGinSupport = globalCrossNicSupport ? NCCL_GIN_CONNECTION_FULL : NCCL_GIN_CONNECTION_RAIL;
   }
-  comm->globalRmaProxySupport = globalRmaPluginSupport && globalCrossNicSupport && !globalNicFused && globalCuMemGdrSupport;
+  comm->globalRmaProxySupport =
+    globalRmaPluginSupport && globalCrossNicSupport && !globalNicFused && globalCuMemGdrSupport;
   isOneLsaTeams = ncclDevrIsOneLsaTeam(comm);
-  comm->symmetricSupport = comm->isAllCudaP2p && ncclParamWinEnable() && ncclCuMemEnable() && (comm->globalGinSupport != NCCL_GIN_CONNECTION_NONE || isOneLsaTeams);
+  comm->symmetricSupport = comm->isAllCudaP2p && ncclParamWinEnable() && ncclCuMemEnable() &&
+                           (comm->globalGinSupport != NCCL_GIN_CONNECTION_NONE || isOneLsaTeams);
   // hostRmaSupport must not require symmetricSupport: multi-node GIN proxy RMA
   // (globalRmaProxySupport) has no all-P2P symmetric window, and enqueue.cc has a
   // dedicated non-symmetric hostRma path for it.
   comm->hostRmaSupport = (isOneLsaTeams || comm->globalRmaProxySupport);
   if (!comm->symmetricSupport) {
-    INFO(NCCL_INIT, "Symmetric memory is not supported. cuMemEnable %d, "
-      "globalGinSupport %d, globalNicFused %d cuMemGdrSupport %d", ncclCuMemEnable(), comm->globalGinSupport, globalNicFused, globalCuMemGdrSupport);
+    INFO(NCCL_INIT,
+         "Symmetric memory is not supported. cuMemEnable %d, "
+         "globalGinSupport %d, globalNicFused %d cuMemGdrSupport %d",
+         ncclCuMemEnable(), comm->globalGinSupport, globalNicFused, globalCuMemGdrSupport);
   }
 
   comm->ceColl.baseUCSymReadyPtr = NULL;
@@ -2221,10 +2260,12 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   // launch NCCL kernels before all cuda mem allocation is complete. That could cause a deadlock.
   NCCLCHECKGOTO(devCommSetup(comm), ret, fail);
 
-  timers[TIMER_INIT_CONNECT] = clockNano() -  timers[TIMER_INIT_CONNECT];
+  timers[TIMER_INIT_CONNECT] = clockNano() - timers[TIMER_INIT_CONNECT];
 
   /* Local intra-node barrier */
-  NCCLCHECKGOTO(bootstrapIntraNodeBarrier(comm->bootstrap, comm->localRankToRank, comm->localRank, comm->localRanks, comm->localRankToRank[0]), ret, fail);
+  NCCLCHECKGOTO(bootstrapIntraNodeBarrier(comm->bootstrap, comm->localRankToRank, comm->localRank, comm->localRanks,
+                                          comm->localRankToRank[0]),
+                ret, fail);
 
   // We should have allocated all buffers, collective fifos, ... we can
   // restore the affinity.
@@ -2235,7 +2276,8 @@ exit:
   /* If split resource is shared, we are not able to unlink the proxy ops pool here since the child comm can
    * attach the proxy ops pool of parent at any time; otherwise, unlink it here to make sure the pool will be
    * properly cleaned up. */
-  if (comm->sharedRes->owner == comm && !comm->shareResources && ret == ncclSuccess && !ncclCuMemEnable()) ncclProxyShmUnlink(comm);
+  if (comm->sharedRes->owner == comm && !comm->shareResources && ret == ncclSuccess && !ncclCuMemEnable())
+    ncclProxyShmUnlink(comm);
   free(allTopoRanks);
   free(nodesTreePatterns);
   free(nodesFirstRank);
@@ -2305,11 +2347,12 @@ static void ncclCommFinalizeAsyncJobFree(void* _job) {
 NCCL_PARAM(CommSplitShareResources, "COMM_SPLIT_SHARE_RESOURCES", NCCL_CONFIG_UNDEF_INT);
 NCCL_PARAM(CommShrinkShareResources, "COMM_SHRINK_SHARE_RESOURCES", NCCL_CONFIG_UNDEF_INT);
 
-typedef struct{
+typedef struct {
   int key;
   int color;
 } commSplitInfo;
-static ncclResult_t commGetSplitInfo(struct ncclComm* comm, struct ncclComm* parent, int color, int key, int* nRanksRet, int* myRankRet, int* parentRanksRet) {
+static ncclResult_t commGetSplitInfo(struct ncclComm* comm, struct ncclComm* parent, int color, int key, int* nRanksRet,
+                                     int* myRankRet, int* parentRanksRet) {
   int nRanks = 0, myRank = 0;
   ncclResult_t ret = ncclSuccess;
 
@@ -2351,7 +2394,8 @@ fail:
   goto exit;
 }
 
-static ncclResult_t getParentRanks(int parentRanks, int parentRank, int* excludeRanksList, int excludeRanksCount, int* nRanksRet, int* myRankRet, int* parentRanksRet) {
+static ncclResult_t getParentRanks(int parentRanks, int parentRank, int* excludeRanksList, int excludeRanksCount,
+                                   int* nRanksRet, int* myRankRet, int* parentRanksRet) {
   int count = 0, j = 0;
   for (int i = 0; i < parentRanks; i++) {
     // we assume excludeRanksList is sorted
@@ -2383,16 +2427,16 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
   int cuCount;
   hipDeviceProp_t devProp;
 
-  #ifdef USE_INDIRECT_FUNCTION_CALL
+#ifdef USE_INDIRECT_FUNCTION_CALL
   int64_t stackSize;
-  #endif
+#endif
 
   timers[TIMER_INIT_TOTAL] = clockNano();
   CUDACHECKGOTO(cudaSetDevice(cudaDev), res, fail);
   CUDACHECKGOTO(cudaDeviceGetAttribute(&maxSharedMem, cudaDevAttrMaxSharedMemoryPerBlockOptin, cudaDev), res, fail);
   CUDACHECKGOTO(cudaDeviceGetAttribute(&archMajor, cudaDevAttrComputeCapabilityMajor, cudaDev), res, fail);
   CUDACHECKGOTO(cudaDeviceGetAttribute(&archMinor, cudaDevAttrComputeCapabilityMinor, cudaDev), res, fail);
-  cudaArch = 100*archMajor + 10*archMinor;
+  cudaArch = 100 * archMajor + 10 * archMinor;
 
   CUDACHECKGOTO(hipGetDeviceProperties(&devProp, cudaDev), res, fail);
   cuCount = devProp.multiProcessorCount;
@@ -2408,13 +2452,11 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
   // Set the maximum kernel stack size of all kernels to avoid
   // a CUDA memory reconfig on load (c.f. NVSHMEM issue)
 #ifdef USE_INDIRECT_FUNCTION_CALL
-  if (ncclParamSetStackSize() == 1 && !IsArchMatch(archName,"gfx942") && !IsArchMatch(archName,"gfx950")) {
+  if (ncclParamSetStackSize() == 1 && !IsArchMatch(archName, "gfx942") && !IsArchMatch(archName, "gfx950")) {
     stackSize = rcclParamStackSizeOverride() ? rcclParamStackSizeOverride() : maxLocalSizeBytes;
     if (stackSize == 0) {
-      if (IsArchMatch(archName,"gfx906"))
-        stackSize = 1024;
-      else
-        stackSize = 512;
+      if (IsArchMatch(archName, "gfx906")) stackSize = 1024;
+      else stackSize = 512;
     }
     INFO(NCCL_INIT, "Setting cudaLimitStackSize to %zi maxLocalSizeBytes %zi", stackSize, maxLocalSizeBytes);
     CUDACHECKIGNORE(cudaDeviceSetLimit(cudaLimitStackSize, stackSize));
@@ -2430,9 +2472,12 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
     // SPLIT/SHRINK: use bootstrapSplit
     NCCLCHECKGOTO(ncclCalloc(&parentRanks, job->parent->nRanks), res, fail);
     if (job->excludeRanksCount) {
-      NCCLCHECKGOTO(getParentRanks(job->parent->nRanks, job->parent->rank, job->excludeRanksList, job->excludeRanksCount, &job->nranks, &job->myrank, parentRanks), res, fail);
+      NCCLCHECKGOTO(getParentRanks(job->parent->nRanks, job->parent->rank, job->excludeRanksList,
+                                   job->excludeRanksCount, &job->nranks, &job->myrank, parentRanks),
+                    res, fail);
     } else {
-      NCCLCHECKGOTO(commGetSplitInfo(comm, job->parent, job->color, job->key, &job->nranks, &job->myrank, parentRanks), res, fail);
+      NCCLCHECKGOTO(commGetSplitInfo(comm, job->parent, job->color, job->key, &job->nranks, &job->myrank, parentRanks),
+                    res, fail);
       // Negative color does not create a new comm object. We needed to take part in the allgather, but we're done now.
       if (job->color == NCCL_SPLIT_NOCOLOR) {
         // archName was allocated but won't be assigned to comm, so free it here
@@ -2451,8 +2496,11 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
     NCCLCHECKGOTO(commAlloc(comm, job->parent, job->nranks, job->myrank), res, fail);
     timers[TIMER_INIT_ALLOC] = clockNano() - timers[TIMER_INIT_ALLOC];
     comm->isGrow = false;
-    INFO(NCCL_INIT, "%s comm %p rank %d nranks %d cudaDev %d nvmlDev %d busId %lx parent %p childCount %d color %d key %d- Init START", job->funcName,
-         comm, comm->rank, comm->nRanks, comm->cudaDev, comm->nvmlDev, comm->busId, job->parent, job->childCount, job->color, job->key);
+    INFO(NCCL_INIT,
+         "%s comm %p rank %d nranks %d cudaDev %d nvmlDev %d busId %lx parent %p childCount %d color %d key %d- Init "
+         "START",
+         job->funcName, comm, comm->rank, comm->nRanks, comm->cudaDev, comm->nvmlDev, comm->busId, job->parent,
+         job->childCount, job->color, job->key);
     timers[TIMER_INIT_BOOTSTRAP] = clockNano();
     NCCLCHECKGOTO(bootstrapSplit(comm->commHash, comm, job->parent, job->color, job->key, parentRanks), res, fail);
     timers[TIMER_INIT_BOOTSTRAP] = clockNano() - timers[TIMER_INIT_BOOTSTRAP];
@@ -2464,8 +2512,8 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
       struct ncclBootstrapHandle* growHandle = (struct ncclBootstrapHandle*)job->commId;
       uint64_t baseMagic = growHandle ? growHandle->magic : hashCombine(job->parent->magic, job->parent->childCount);
       comm->commHash = commIdHash = hashCombine(baseMagic, job->nranks);
-      INFO(NCCL_INIT, "Rank %d: Generated commHash 0x%lx from baseMagic 0x%lx and newNRanks %d",
-           job->myrank, comm->commHash, baseMagic, job->nranks);
+      INFO(NCCL_INIT, "Rank %d: Generated commHash 0x%lx from baseMagic 0x%lx and newNRanks %d", job->myrank,
+           comm->commHash, baseMagic, job->nranks);
     } else {
       // obtain a unique hash using the first commId
       comm->commHash = commIdHash = getHash(job->commId->internal, NCCL_UNIQUE_ID_BYTES);
@@ -2476,7 +2524,8 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
 
     comm->isGrow = job->isGrow;
     INFO(NCCL_INIT, "[Rank %d] %s comm %p rank %d nranks %d cudaDev %d nvmlDev %d busId %lx commId 0x%llx - Init START",
-         job->myrank, job->funcName, comm, comm->rank, comm->nRanks, comm->cudaDev, comm->nvmlDev, comm->busId, commIdHash);
+         job->myrank, job->funcName, comm, comm->rank, comm->nRanks, comm->cudaDev, comm->nvmlDev, comm->busId,
+         commIdHash);
     timers[TIMER_INIT_BOOTSTRAP] = clockNano();
     NCCLCHECKGOTO(bootstrapInit(job->nId, (struct ncclBootstrapHandle*)job->commId, comm, job->parent), res, fail);
     timers[TIMER_INIT_BOOTSTRAP] = clockNano() - timers[TIMER_INIT_BOOTSTRAP];
@@ -2490,7 +2539,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
 
   NCCLCHECKGOTO(initTransportsRank(comm, job->parent, timers), res, fail);
 
-    // Check if using host uncached mem correctly
+  // Check if using host uncached mem correctly
   NCCLCHECK(checkHostUncacheMemSetting(comm));
 
   // RCCL: determine and set unroll factor for comm
@@ -2498,13 +2547,13 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
 
 #ifdef ENABLE_ROCSHMEM
   if (!job->parent && rcclParamRocshmemEnabled()) {
-    INFO(NCCL_INIT,"Initializing rocSHMEM inside of RCCL");
+    INFO(NCCL_INIT, "Initializing rocSHMEM inside of RCCL");
     int ret;
     rocshmem::rocshmem_uniqueid_t rocshmemUniqueId;
     rocshmem::rocshmem_init_attr_t rocshmemAttr;
 
-    if(comm->rank == 0 ) {
-      ret = rocshmem::rocshmem_get_uniqueid (&rocshmemUniqueId);
+    if (comm->rank == 0) {
+      ret = rocshmem::rocshmem_get_uniqueid(&rocshmemUniqueId);
       if (ret != rocshmem::ROCSHMEM_SUCCESS) {
         ERROR("Error in rocshmem_get_uniqueid, Rocshmem cannot be initialized.");
         return ncclSystemError;
@@ -2512,7 +2561,8 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
     }
 
     NCCLCHECKGOTO(bootstrapBroadcast(comm->bootstrap, comm->rank, comm->nRanks, 0, &rocshmemUniqueId,
-			    sizeof(rocshmemUniqueId)), res, fail);
+                                     sizeof(rocshmemUniqueId)),
+                  res, fail);
     ret = rocshmem::rocshmem_set_attr_uniqueid_args(job->myrank, job->nranks, &rocshmemUniqueId, &rocshmemAttr);
     if (ret != rocshmem::ROCSHMEM_SUCCESS) {
       ERROR("Error in rocshmem_set_attr_uniqueid_args, Rocshmem cannot be initialized.");
@@ -2529,21 +2579,20 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
     size_t rocshmemHeapSize = 0;
 
     try {
-        if (inputStr != nullptr)
-    	    rocshmemHeapSize = std::stoull(inputStr);
+      if (inputStr != nullptr) rocshmemHeapSize = std::stoull(inputStr);
     } catch (const std::exception& e) {
-        std::cerr << "Error related to ROCSHMEM HEAP SIZE " << inputStr << ": " << e.what() << std::endl;
+      std::cerr << "Error related to ROCSHMEM HEAP SIZE " << inputStr << ": " << e.what() << std::endl;
     }
 
-    if (rocshmemHeapSize <= (size_t)(1073741824)) {	//default rocshmem heap size is 1GB
-	    rocshmemHeapSize = (size_t)(256*1024*1024);	//default size of symmetric allocation 256MB
+    if (rocshmemHeapSize <= (size_t)(1073741824)) { // default rocshmem heap size is 1GB
+      rocshmemHeapSize = (size_t)(256 * 1024 * 1024); // default size of symmetric allocation 256MB
     } else if (rocshmemHeapSize > (size_t)(2147483648)) {
-	    rocshmemHeapSize = (size_t)(1024*1024*1024); //increase symmetric allocation size for heap size > 2GB
+      rocshmemHeapSize = (size_t)(1024 * 1024 * 1024); // increase symmetric allocation size for heap size > 2GB
     }
-    
-    comm->sourceRshmem = (void *)rocshmem::rocshmem_malloc(rocshmemHeapSize);
-    comm->destRshmem = (void *)rocshmem::rocshmem_malloc(rocshmemHeapSize);
-    INFO(NCCL_INIT, "Symmetric memory allocated: size %zu", rocshmemHeapSize); 
+
+    comm->sourceRshmem = (void*)rocshmem::rocshmem_malloc(rocshmemHeapSize);
+    comm->destRshmem = (void*)rocshmem::rocshmem_malloc(rocshmemHeapSize);
+    INFO(NCCL_INIT, "Symmetric memory allocated: size %zu", rocshmemHeapSize);
 
     comm->enableRocshmem = rcclParamRocshmemEnabled();
     comm->rocshmemThreshold = rcclParamRocshmemThreshold();
@@ -2551,11 +2600,11 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
       comm->proxyState->rocshmemEnabled = true;
     comm->numSymBuf = NUM_SYM_BUF;
     comm->symId = 0;
-    comm->bufThreshold = rocshmemHeapSize/2;
-    //rocshmem::rocshmem_team_t team_reduce_world_dup;
+    comm->bufThreshold = rocshmemHeapSize / 2;
+    // rocshmem::rocshmem_team_t team_reduce_world_dup;
     comm->team_reduce_world_dup = rocshmem::ROCSHMEM_TEAM_INVALID;
     rocshmem::rocshmem_team_split_strided(rocshmem::ROCSHMEM_TEAM_WORLD, 0, 1, job->nranks, nullptr, 0,
-                               &(comm->team_reduce_world_dup));
+                                          &(comm->team_reduce_world_dup));
 
     ncclCommToRshmemTeam[comm] = comm->team_reduce_world_dup;
     CUDACHECK(hipDeviceSynchronize());
@@ -2563,13 +2612,13 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
 #endif
 
   // Allocate Temp Buffer for Direct Reduce Scatter
-  if (IsArchMatch(archName,"gfx950")) {
+  if (IsArchMatch(archName, "gfx950")) {
     NCCLCHECK(ncclCudaMalloc(&(comm->tempBuff), TEMP_BUFF_SIZE, comm->memManager));
   }
 
   NCCLCHECKGOTO(latency_profiler::collTraceInit(comm), res, fail);
   if (!job->parent && !job->isGrow && comm->nNodes == 1 && comm->nRanks == 8) {
-  	NCCLCHECKGOTO(ncclDdaIpcCommInit(comm), res, fail);
+    NCCLCHECKGOTO(ncclDdaIpcCommInit(comm), res, fail);
   }
   // update communicator state
   comm->initState = ncclSuccess;
@@ -2584,8 +2633,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
       const int lr = comm->maxLocalRanks;
       bool compactRanks = true;
       for (int r = 0; r < comm->nRanks; r++) {
-        if (comm->rankToNode[r] != r / lr ||
-            comm->rankToLocalRank[r] != r % lr) {
+        if (comm->rankToNode[r] != r / lr || comm->rankToLocalRank[r] != r % lr) {
           compactRanks = false;
           break;
         }
@@ -2602,11 +2650,12 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
         comm->forcePatEnable = !userDisabledPat && !rcclUseAinic();
         NCCLCHECKGOTO(ncclCommSplit(comm, local_rank, node_id, &comm->hierarchicalInterComm, NULL), res, fail);
         comm->forcePatEnable = false;
-        size_t tempBufSize = (comm->nNodes >= 16) ? HIERARCHICAL_AG_TEMP_BUFFER_SIZE : HIERARCHICAL_AG_TEMP_BUFFER_SIZE / 2;
+        size_t tempBufSize =
+          (comm->nNodes >= 16) ? HIERARCHICAL_AG_TEMP_BUFFER_SIZE : HIERARCHICAL_AG_TEMP_BUFFER_SIZE / 2;
         NCCLCHECKGOTO(ncclCudaMalloc(&(comm->hierarchicalAGTempBuffer), tempBufSize, comm->memManager), res, fail);
         comm->hierarchicalCommsInitialized = true;
         INFO(NCCL_INIT, "Hierarchical AllGather: intraComm (nRanks=%d) and interComm (nRanks=%d) Initialized",
-          comm->hierarchicalIntraComm->nRanks, comm->hierarchicalInterComm->nRanks);
+             comm->hierarchicalIntraComm->nRanks, comm->hierarchicalInterComm->nRanks);
       }
     }
   }
@@ -2620,26 +2669,30 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
     if (job->isGrow) {
       TRACE_CALL("ncclCommGrow(%p, %d, %p)", job->parent, comm->nRanks, comm);
     } else {
-      TRACE_CALL("ncclCommSplit(%p, %d, %d, %p, %d, %d)", job->parent, job->color, job->key, comm, comm->rank, comm->nRanks);
+      TRACE_CALL("ncclCommSplit(%p, %d, %d, %p, %d, %d)", job->parent, job->color, job->key, comm, comm->rank,
+                 comm->nRanks);
     }
-    INFO(NCCL_INIT, "%s comm %p rank %d nranks %d cudaDev %d nvmlDev %d busId %lx parent %p childCount %d color %d key %d - Init COMPLETE", job->funcName,
-         comm, comm->rank, comm->nRanks, comm->cudaDev, comm->nvmlDev, comm->busId, job->parent, job->childCount, job->color, job->key);
+    INFO(NCCL_INIT,
+         "%s comm %p rank %d nranks %d cudaDev %d nvmlDev %d busId %lx parent %p childCount %d color %d key %d - Init "
+         "COMPLETE",
+         job->funcName, comm, comm->rank, comm->nRanks, comm->cudaDev, comm->nvmlDev, comm->busId, job->parent,
+         job->childCount, job->color, job->key);
   } else {
     // the name for the replay tool is ncclCommInitRank for all the variations
     TRACE_CALL("ncclCommInitRank(%p, %d, 0x%llx, %d, %d)", comm, comm->nRanks, commIdHash, comm->rank, comm->cudaDev);
-    INFO(NCCL_INIT, "%s comm %p rank %d nranks %d cudaDev %d nvmlDev %d busId %lx commId 0x%llx - Init COMPLETE", job->funcName,
-         comm, comm->rank, comm->nRanks, comm->cudaDev, comm->nvmlDev, comm->busId, commIdHash);
+    INFO(NCCL_INIT, "%s comm %p rank %d nranks %d cudaDev %d nvmlDev %d busId %lx commId 0x%llx - Init COMPLETE",
+         job->funcName, comm, comm->rank, comm->nRanks, comm->cudaDev, comm->nvmlDev, comm->busId, commIdHash);
   }
   sum_timers = 0.0;
-  for (int it = 1; it < TIMERS_INIT_COUNT; ++it)
-    sum_timers += (timers[it] / 1e9);
+  for (int it = 1; it < TIMERS_INIT_COUNT; ++it) sum_timers += (timers[it] / 1e9);
   INFO(NCCL_INIT | NCCL_PROFILE,
-       "Init timings - %s: rank %d nranks %d total %.2f (kernels %.2f, alloc %.2f, bootstrap %.2f, allgathers %.2f, topo %.2f, graphs %.2f, "
+       "Init timings - %s: rank %d nranks %d total %.2f (kernels %.2f, alloc %.2f, bootstrap %.2f, allgathers %.2f, "
+       "topo %.2f, graphs %.2f, "
        "connections %.2f, rest %.2f)",
-       job->funcName, comm->rank, comm->nRanks,
-       timers[TIMER_INIT_TOTAL] / 1e9, timers[TIMER_INIT_KERNELS] / 1e9, timers[TIMER_INIT_ALLOC] / 1e9,
-       timers[TIMER_INIT_BOOTSTRAP] / 1e9, timers[TIMER_INIT_ALLGATHER] / 1e9, timers[TIMER_INIT_TOPO] / 1e9,
-       timers[TIMER_INIT_GRAPHS] / 1e9, timers[TIMER_INIT_CONNECT] / 1e9, timers[TIMER_INIT_TOTAL] / 1e9 - sum_timers);
+       job->funcName, comm->rank, comm->nRanks, timers[TIMER_INIT_TOTAL] / 1e9, timers[TIMER_INIT_KERNELS] / 1e9,
+       timers[TIMER_INIT_ALLOC] / 1e9, timers[TIMER_INIT_BOOTSTRAP] / 1e9, timers[TIMER_INIT_ALLGATHER] / 1e9,
+       timers[TIMER_INIT_TOPO] / 1e9, timers[TIMER_INIT_GRAPHS] / 1e9, timers[TIMER_INIT_CONNECT] / 1e9,
+       timers[TIMER_INIT_TOTAL] / 1e9 - sum_timers);
 exit:
   if (job->newcomm) {
     /* assign it to user pointer. */
@@ -2688,8 +2741,7 @@ static ncclResult_t envConfigOverride(ncclComm_t comm) {
 
   /* override configuration with env variable. */
   blockingEnv = ncclParamCommBlocking();
-  if (blockingEnv == 0 || blockingEnv == 1)
-    comm->config.blocking = blockingEnv;
+  if (blockingEnv == 0 || blockingEnv == 1) comm->config.blocking = blockingEnv;
 
   cgaClusterSizeEnv = ncclParamCGAClusterSize();
   if (0 <= cgaClusterSizeEnv && cgaClusterSizeEnv <= NCCL_MAX_CGA_CLUSTER_SIZE) {
@@ -2697,7 +2749,8 @@ static ncclResult_t envConfigOverride(ncclComm_t comm) {
       INFO(NCCL_ENV, "Comm config cgaClusterSize reset to NCCL_MAX_CGA_CLUSTER_SIZE=%d", cgaClusterSizeEnv);
     comm->config.cgaClusterSize = cgaClusterSizeEnv;
   } else if (cgaClusterSizeEnv > NCCL_MAX_CGA_CLUSTER_SIZE) {
-    INFO(NCCL_ENV, "NCCL_CGA_CLUSTER_SIZE value %d is too big. Limiting value to %d.", cgaClusterSizeEnv, NCCL_MAX_CGA_CLUSTER_SIZE);
+    INFO(NCCL_ENV, "NCCL_CGA_CLUSTER_SIZE value %d is too big. Limiting value to %d.", cgaClusterSizeEnv,
+         NCCL_MAX_CGA_CLUSTER_SIZE);
     comm->config.cgaClusterSize = NCCL_MAX_CGA_CLUSTER_SIZE;
   }
 
@@ -2727,10 +2780,12 @@ static ncclResult_t envConfigOverride(ncclComm_t comm) {
   nChannelsPerNetPeerEnv = ncclParamNChannelsPerNetPeer();
   if (nChannelsPerNetPeerEnv != NCCL_CONFIG_UNDEF_INT) {
     if (nChannelsPerNetPeerEnv <= 0)
-      INFO(NCCL_ENV, "NCCL_NCHANNELS_PER_NET_PEER %d is too low, leaving it set at %d", nChannelsPerNetPeerEnv, comm->config.nChannelsPerNetPeer);
+      INFO(NCCL_ENV, "NCCL_NCHANNELS_PER_NET_PEER %d is too low, leaving it set at %d", nChannelsPerNetPeerEnv,
+           comm->config.nChannelsPerNetPeer);
     else {
       if (comm->config.nChannelsPerNetPeer != NCCL_CONFIG_UNDEF_INT)
-        INFO(NCCL_ENV, "Comm config nChannelsPerNetPeer reset to NCCL_NCHANNELS_PER_NET_PEER=%d", nChannelsPerNetPeerEnv);
+        INFO(NCCL_ENV, "Comm config nChannelsPerNetPeer reset to NCCL_NCHANNELS_PER_NET_PEER=%d",
+             nChannelsPerNetPeerEnv);
       comm->config.nChannelsPerNetPeer = nChannelsPerNetPeerEnv;
     }
   }
@@ -2738,10 +2793,12 @@ static ncclResult_t envConfigOverride(ncclComm_t comm) {
   nvlinkUtilCentricSchedEnableEnv = ncclParamNvlinkUtilCentricSchedEnable();
   if (nvlinkUtilCentricSchedEnableEnv != NCCL_CONFIG_UNDEF_INT) {
     if (nvlinkUtilCentricSchedEnableEnv != 0 && nvlinkUtilCentricSchedEnableEnv != 1)
-      INFO(NCCL_ENV, "NCCL_NVLINK_UTIL_CENTRIC_SCHED_ENABLE %d is not valid, leaving it set at %d", nvlinkUtilCentricSchedEnableEnv, comm->config.nvlinkCentricSched);
+      INFO(NCCL_ENV, "NCCL_NVLINK_UTIL_CENTRIC_SCHED_ENABLE %d is not valid, leaving it set at %d",
+           nvlinkUtilCentricSchedEnableEnv, comm->config.nvlinkCentricSched);
     else {
       if (comm->config.nvlinkCentricSched != NCCL_CONFIG_UNDEF_INT)
-        INFO(NCCL_ENV, "Comm config nvlinkCentricSched reset to NCCL_NVLINK_UTIL_CENTRIC_SCHED_ENABLE=%d", nvlinkUtilCentricSchedEnableEnv);
+        INFO(NCCL_ENV, "Comm config nvlinkCentricSched reset to NCCL_NVLINK_UTIL_CENTRIC_SCHED_ENABLE=%d",
+             nvlinkUtilCentricSchedEnableEnv);
       comm->config.nvlinkCentricSched = nvlinkUtilCentricSchedEnableEnv;
     }
   }
@@ -2749,10 +2806,12 @@ static ncclResult_t envConfigOverride(ncclComm_t comm) {
   graphMixingSupportEnv = ncclParamGraphMixingSupport();
   if (graphMixingSupportEnv != NCCL_CONFIG_UNDEF_INT) {
     if (graphMixingSupportEnv != 0 && graphMixingSupportEnv != 1) {
-      INFO(NCCL_ENV, "NCCL_GRAPH_MIXING_SUPPORT %d is not valid, leaving it set at %d", graphMixingSupportEnv, comm->config.graphUsageMode);
+      INFO(NCCL_ENV, "NCCL_GRAPH_MIXING_SUPPORT %d is not valid, leaving it set at %d", graphMixingSupportEnv,
+           comm->config.graphUsageMode);
     } else {
       if (comm->config.graphUsageMode != NCCL_CONFIG_UNDEF_INT) {
-        INFO(NCCL_ENV, "Comm config graphUsageMode reset to %d by NCCL_GRAPH_MIXING_SUPPORT=%d", graphMixingSupportEnv == 1 ? 2 : 0, graphMixingSupportEnv);
+        INFO(NCCL_ENV, "Comm config graphUsageMode reset to %d by NCCL_GRAPH_MIXING_SUPPORT=%d",
+             graphMixingSupportEnv == 1 ? 2 : 0, graphMixingSupportEnv);
       }
       comm->config.graphUsageMode = graphMixingSupportEnv == 1 ? 2 : 0;
     }
@@ -2762,14 +2821,14 @@ static ncclResult_t envConfigOverride(ncclComm_t comm) {
   if (numRmaCtxEnv != NCCL_CONFIG_UNDEF_INT) {
     if (numRmaCtxEnv <= 0)
       INFO(NCCL_ENV, "NCCL_NUM_RMA_CTX %d is too low, leaving it set at %d", numRmaCtxEnv, comm->config.numRmaCtx);
-    else
-      comm->config.numRmaCtx = numRmaCtxEnv;
+    else comm->config.numRmaCtx = numRmaCtxEnv;
   }
 
   maxP2pPeersEnv = ncclParamMaxP2pPeers();
   if (maxP2pPeersEnv != NCCL_CONFIG_UNDEF_INT) {
     if (maxP2pPeersEnv <= 0)
-      INFO(NCCL_ENV, "NCCL_MAX_P2P_PEERS %d is too low, leaving it set at %d", maxP2pPeersEnv, comm->config.maxP2pPeers);
+      INFO(NCCL_ENV, "NCCL_MAX_P2P_PEERS %d is too low, leaving it set at %d", maxP2pPeersEnv,
+           comm->config.maxP2pPeers);
     else {
       if (comm->config.maxP2pPeers != NCCL_CONFIG_UNDEF_INT)
         INFO(NCCL_ENV, "Comm config maxP2pPeers reset to NCCL_MAX_P2P_PEERS=%d", maxP2pPeersEnv);
@@ -2779,10 +2838,8 @@ static ncclResult_t envConfigOverride(ncclComm_t comm) {
 
   envNetName = ncclGetEnv("NCCL_NET");
   if (envNetName) {
-    if (strcasecmp(envNetName, "ROCM-IB")==0)
-      tmpNetName = "IB-CAST";
-    else
-      tmpNetName = envNetName;
+    if (strcasecmp(envNetName, "ROCM-IB") == 0) tmpNetName = "IB-CAST";
+    else tmpNetName = envNetName;
   }
   if (tmpNetName != NULL) {
     if (comm->config.netName != NCCL_CONFIG_UNDEF_PTR)
@@ -2841,17 +2898,20 @@ static ncclResult_t envConfigOverride(ncclComm_t comm) {
 
   /* cap channels if needed */
   if (comm->config.minCTAs > MAXCHANNELS) {
-    INFO(NCCL_ENV, "minCTAs %d is larger than #channels upper limit %d, cap it to %d", comm->config.minCTAs, MAXCHANNELS, MAXCHANNELS);
+    INFO(NCCL_ENV, "minCTAs %d is larger than #channels upper limit %d, cap it to %d", comm->config.minCTAs,
+         MAXCHANNELS, MAXCHANNELS);
     comm->config.minCTAs = MAXCHANNELS;
   }
 
   if (comm->config.maxCTAs > MAXCHANNELS) {
-    INFO(NCCL_ENV, "maxCTAs %d is larger than #channels upper limit %d, cap it to %d", comm->config.maxCTAs, MAXCHANNELS, MAXCHANNELS);
+    INFO(NCCL_ENV, "maxCTAs %d is larger than #channels upper limit %d, cap it to %d", comm->config.maxCTAs,
+         MAXCHANNELS, MAXCHANNELS);
     comm->config.maxCTAs = MAXCHANNELS;
   }
 
   if (comm->config.minCTAs > comm->config.maxCTAs) {
-    INFO(NCCL_ENV, "minCTAs %d is larger than maxCTAs %d, set both to %d", comm->config.minCTAs, comm->config.maxCTAs, comm->config.maxCTAs);
+    INFO(NCCL_ENV, "minCTAs %d is larger than maxCTAs %d, set both to %d", comm->config.minCTAs, comm->config.maxCTAs,
+         comm->config.maxCTAs);
     comm->config.minCTAs = comm->config.maxCTAs;
   }
 
@@ -2871,14 +2931,16 @@ static ncclResult_t envConfigOverride(ncclComm_t comm) {
   }
 
   if (comm->config.nvlsCTAs != NCCL_CONFIG_UNDEF_INT && comm->config.nvlsCTAs <= 0) {
-    INFO(NCCL_ENV, "nvlsCTAs %d is not a valid value, NCCL will decide the default value automatically", comm->config.nvlsCTAs);
+    INFO(NCCL_ENV, "nvlsCTAs %d is not a valid value, NCCL will decide the default value automatically",
+         comm->config.nvlsCTAs);
     comm->config.nvlsCTAs = NCCL_CONFIG_UNDEF_INT;
   }
 
   // If POLICY_ZERO and POLICY_EFFICIENCY are set in CTAPolicy, unset POLICY_EFFICIENCY.
-  if ((comm->config.CTAPolicy & NCCL_CTA_POLICY_ZERO) &&
-      (comm->config.CTAPolicy & NCCL_CTA_POLICY_EFFICIENCY)) {
-    WARN("Both NCCL_CTA_POLICY_ZERO and NCCL_CTA_POLICY_EFFICIENCY are set in CTAPolicy (%d). Unsetting POLICY_EFFICIENCY.", comm->config.CTAPolicy);
+  if ((comm->config.CTAPolicy & NCCL_CTA_POLICY_ZERO) && (comm->config.CTAPolicy & NCCL_CTA_POLICY_EFFICIENCY)) {
+    WARN("Both NCCL_CTA_POLICY_ZERO and NCCL_CTA_POLICY_EFFICIENCY are set in CTAPolicy (%d). Unsetting "
+         "POLICY_EFFICIENCY.",
+         comm->config.CTAPolicy);
     comm->config.CTAPolicy &= ~NCCL_CTA_POLICY_EFFICIENCY;
   }
 
@@ -2906,12 +2968,12 @@ static ncclResult_t copyCommConfig(ncclComm_t childComm, ncclComm_t parnet) {
   return ncclSuccess;
 }
 
-static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t *config) {
+static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t* config) {
   ncclResult_t ret = ncclSuccess;
   /* config must not be NULL in this function */
   ncclConfig_t defaultConfig = NCCL_CONFIG_INITIALIZER;
   ncclConfig_t internalConfig = NCCL_CONFIG_INITIALIZER;
-  ncclConfig_t *internalConfigPtr;
+  ncclConfig_t* internalConfigPtr;
   size_t realSize;
 
   internalConfig.magic = 0;
@@ -2964,7 +3026,8 @@ static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t *config) {
   }
 
   /* check input config attributes, -1 means user-undefined and we should use default value from NCCL. */
-  if (internalConfigPtr->blocking != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->blocking != 0 && internalConfigPtr->blocking != 1) {
+  if (internalConfigPtr->blocking != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->blocking != 0 &&
+      internalConfigPtr->blocking != 1) {
     WARN("Invalid config blocking attribute value %d", internalConfigPtr->blocking);
     ret = ncclInvalidArgument;
     goto fail;
@@ -2976,23 +3039,24 @@ static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t *config) {
     goto fail;
   }
 
-  if ((internalConfigPtr->minCTAs != NCCL_CONFIG_UNDEF_INT &&
-    internalConfigPtr->minCTAs <= 0) ||
-    (internalConfigPtr->maxCTAs != NCCL_CONFIG_UNDEF_INT &&
-      internalConfigPtr->maxCTAs <= 0) ||
-    (internalConfigPtr->minCTAs > internalConfigPtr->maxCTAs)) {
-    WARN("Invalid config min/max channels attribute value %d/%d", internalConfigPtr->minCTAs, internalConfigPtr->maxCTAs);
+  if ((internalConfigPtr->minCTAs != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->minCTAs <= 0) ||
+      (internalConfigPtr->maxCTAs != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->maxCTAs <= 0) ||
+      (internalConfigPtr->minCTAs > internalConfigPtr->maxCTAs)) {
+    WARN("Invalid config min/max channels attribute value %d/%d", internalConfigPtr->minCTAs,
+         internalConfigPtr->maxCTAs);
     ret = ncclInvalidArgument;
     goto fail;
   }
 
-  if (internalConfigPtr->splitShare != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->splitShare != 0 && internalConfigPtr->splitShare != 1) {
+  if (internalConfigPtr->splitShare != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->splitShare != 0 &&
+      internalConfigPtr->splitShare != 1) {
     WARN("Invalid config splitShare attribute value %d", internalConfigPtr->splitShare);
     ret = ncclInvalidArgument;
     goto fail;
   }
 
-  if (internalConfigPtr->collnetEnable != NCCL_CONFIG_UNDEF_INT && (internalConfigPtr->collnetEnable < 0 || internalConfigPtr->collnetEnable > 1)) {
+  if (internalConfigPtr->collnetEnable != NCCL_CONFIG_UNDEF_INT &&
+      (internalConfigPtr->collnetEnable < 0 || internalConfigPtr->collnetEnable > 1)) {
     WARN("Invalid config collnetEnable attribute value %d", internalConfigPtr->collnetEnable);
     ret = ncclInvalidArgument;
     goto fail;
@@ -3006,7 +3070,8 @@ static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t *config) {
     }
   }
 
-  if (internalConfigPtr->shrinkShare != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->shrinkShare != 0 && internalConfigPtr->shrinkShare != 1) {
+  if (internalConfigPtr->shrinkShare != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->shrinkShare != 0 &&
+      internalConfigPtr->shrinkShare != 1) {
     WARN("Invalid config shrinkShare attribute value %d", internalConfigPtr->shrinkShare);
     ret = ncclInvalidArgument;
     goto fail;
@@ -3018,19 +3083,22 @@ static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t *config) {
     goto fail;
   }
 
-  if (internalConfigPtr->nChannelsPerNetPeer != NCCL_CONFIG_UNDEF_INT && (internalConfigPtr->nChannelsPerNetPeer <= 0 || internalConfigPtr->nChannelsPerNetPeer > MAXCHANNELS)) {
+  if (internalConfigPtr->nChannelsPerNetPeer != NCCL_CONFIG_UNDEF_INT &&
+      (internalConfigPtr->nChannelsPerNetPeer <= 0 || internalConfigPtr->nChannelsPerNetPeer > MAXCHANNELS)) {
     WARN("Invalid config nChannelsPerNetPeer attribute value %d", internalConfigPtr->nChannelsPerNetPeer);
     ret = ncclInvalidArgument;
     goto fail;
   }
 
-  if (internalConfigPtr->nvlinkCentricSched != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->nvlinkCentricSched != 0 && internalConfigPtr->nvlinkCentricSched != 1) {
+  if (internalConfigPtr->nvlinkCentricSched != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->nvlinkCentricSched != 0 &&
+      internalConfigPtr->nvlinkCentricSched != 1) {
     WARN("Invalid config nvlinkCentricSched attribute value %d", internalConfigPtr->nvlinkCentricSched);
     ret = ncclInvalidArgument;
     goto fail;
   }
 
-  if (internalConfigPtr->graphUsageMode != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->graphUsageMode != 0 && internalConfigPtr->graphUsageMode != 1 && internalConfigPtr->graphUsageMode != 2) {
+  if (internalConfigPtr->graphUsageMode != NCCL_CONFIG_UNDEF_INT && internalConfigPtr->graphUsageMode != 0 &&
+      internalConfigPtr->graphUsageMode != 1 && internalConfigPtr->graphUsageMode != 2) {
     WARN("Invalig config graphUsageMode attribute value %d", internalConfigPtr->graphUsageMode);
     ret = ncclInvalidArgument;
     goto fail;
@@ -3055,18 +3123,21 @@ static ncclResult_t parseCommConfig(ncclComm_t comm, ncclConfig_t *config) {
   NCCL_CONFIG_DEFAULT(internalConfigPtr, maxCTAs, NCCL_CONFIG_UNDEF_INT, MAXCHANNELS, "Max CTAs", "%d");
   NCCL_CONFIG_DEFAULT(internalConfigPtr, netName, NCCL_CONFIG_UNDEF_PTR, NULL, "Net name", "%s");
   NCCL_CONFIG_DEFAULT(internalConfigPtr, splitShare, NCCL_CONFIG_UNDEF_INT, 0, "Split share", "%d");
-  NCCL_CONFIG_DEFAULT(internalConfigPtr, trafficClass, NCCL_CONFIG_UNDEF_INT, NCCL_CONFIG_UNDEF_INT, "Traffic class", "%d");
+  NCCL_CONFIG_DEFAULT(internalConfigPtr, trafficClass, NCCL_CONFIG_UNDEF_INT, NCCL_CONFIG_UNDEF_INT, "Traffic class",
+                      "%d");
   NCCL_CONFIG_DEFAULT(internalConfigPtr, commName, NCCL_CONFIG_UNDEF_PTR, NULL, "Comm name", "%s");
   NCCL_CONFIG_DEFAULT(internalConfigPtr, collnetEnable, NCCL_CONFIG_UNDEF_INT, 0, "Collnet enable", "%d");
-  NCCL_CONFIG_DEFAULT(internalConfigPtr, CTAPolicy, NCCL_CONFIG_UNDEF_INT, NCCL_CTA_POLICY_DEFAULT, "CTA policy flags", "%d");
+  NCCL_CONFIG_DEFAULT(internalConfigPtr, CTAPolicy, NCCL_CONFIG_UNDEF_INT, NCCL_CTA_POLICY_DEFAULT, "CTA policy flags",
+                      "%d");
   NCCL_CONFIG_DEFAULT(internalConfigPtr, shrinkShare, NCCL_CONFIG_UNDEF_INT, 0, "shrinkShare", "%d");
   NCCL_CONFIG_DEFAULT(internalConfigPtr, nvlsCTAs, NCCL_CONFIG_UNDEF_INT, NCCL_CONFIG_UNDEF_INT, "nvlsCTAs", "%d");
-  NCCL_CONFIG_DEFAULT(internalConfigPtr, nChannelsPerNetPeer, NCCL_CONFIG_UNDEF_INT,
-                      NCCL_CONFIG_UNDEF_INT, "nChannelsPerNetPeer", "%d");
+  NCCL_CONFIG_DEFAULT(internalConfigPtr, nChannelsPerNetPeer, NCCL_CONFIG_UNDEF_INT, NCCL_CONFIG_UNDEF_INT,
+                      "nChannelsPerNetPeer", "%d");
   NCCL_CONFIG_DEFAULT(internalConfigPtr, nvlinkCentricSched, NCCL_CONFIG_UNDEF_INT, 0, "nvlinkCentricSched", "%d");
   NCCL_CONFIG_DEFAULT(internalConfigPtr, graphUsageMode, NCCL_CONFIG_UNDEF_INT, 0, "graphUsageMode", "%d");
   NCCL_CONFIG_DEFAULT(internalConfigPtr, numRmaCtx, NCCL_CONFIG_UNDEF_INT, 1, "numRmaCtx", "%d");
-  NCCL_CONFIG_DEFAULT(internalConfigPtr, maxP2pPeers, NCCL_CONFIG_UNDEF_INT, NCCL_CONFIG_UNDEF_INT, "maxP2pPeers", "%d");
+  NCCL_CONFIG_DEFAULT(internalConfigPtr, maxP2pPeers, NCCL_CONFIG_UNDEF_INT, NCCL_CONFIG_UNDEF_INT, "maxP2pPeers",
+                      "%d");
 
   /* assign config to communicator */
   comm->config.blocking = internalConfigPtr->blocking;
@@ -3100,7 +3171,8 @@ static void ncclCommInitJobFree(void* _job) {
   delete job;
 }
 
-static ncclResult_t ncclCommInitRankDev(ncclComm_t* newcomm, int nranks, int nId, ncclUniqueId* commId, int myrank, int cudaDev, ncclConfig_t *config, const char funcName[]) {
+static ncclResult_t ncclCommInitRankDev(ncclComm_t* newcomm, int nranks, int nId, ncclUniqueId* commId, int myrank,
+                                        int cudaDev, ncclConfig_t* config, const char funcName[]) {
   if (nId <= 0 || nId > nranks) {
     WARN("improper usage of ncclCommInitRank: nId = %d, nranks=%d", nId, nranks);
     return ncclInvalidArgument;
@@ -3164,7 +3236,8 @@ static ncclResult_t ncclCommInitRankDev(ncclComm_t* newcomm, int nranks, int nId
     NCCLCHECKGOTO(bootstrapCreateRoot((struct ncclBootstrapHandle*)&job->commId[0], true), res, fail);
   }
   launchedJob = true;
-  NCCLCHECKGOTO(ncclAsyncLaunch((struct ncclAsyncJob*)job, ncclCommInitRankFunc, NULL, ncclCommInitJobFree, comm), res, fail);
+  NCCLCHECKGOTO(ncclAsyncLaunch((struct ncclAsyncJob*)job, ncclCommInitRankFunc, NULL, ncclCommInitJobFree, comm), res,
+                fail);
 
 exit:
   // for loggin only, not ready for replaying
@@ -3198,7 +3271,7 @@ ncclResult_t ncclCommInitRank_impl(ncclComm_t* newcomm, int nranks, ncclUniqueId
   NCCLCHECK(ncclCommInitRankDev(newcomm, nranks, 1, &commId, myrank, cudaDev, &config, __func__));
 
   NVTX3_RANGE_ADD_PAYLOAD(CommInitRank, NcclNvtxParamsCommInitRankSchema,
-    NVTX3_PAYLOAD((*newcomm)->commHash, nranks, myrank, cudaDev));
+                          NVTX3_PAYLOAD((*newcomm)->commHash, nranks, myrank, cudaDev));
 
   return ncclSuccess;
 }
@@ -3208,7 +3281,7 @@ ncclResult_t ncclCommInitAll_impl(ncclComm_t* comms, int ndev, const int* devlis
   Recorder::instance().record(comms, ndev, devlist);
   ncclResult_t ret = ncclSuccess;
   int totalnDev;
-  int *gpuFlags = NULL;
+  int* gpuFlags = NULL;
   ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
   int oldDev = 0;
 
@@ -3251,16 +3324,15 @@ ncclResult_t ncclCommInitAll_impl(ncclComm_t* comms, int ndev, const int* devlis
   ncclUniqueId uniqueId;
   NCCLCHECKGOTO(ncclGetUniqueId(&uniqueId), ret, fail);
   NCCLCHECKGOTO(ncclGroupStartInternal(), ret, fail);
-  for (int i=0; i<ndev; i++) {
+  for (int i = 0; i < ndev; i++) {
     // Ignore return codes .. we need to call ncclGroupEnd to clean up anyway
     int dev = devlist ? devlist[i] : i;
     CUDACHECKGOTO(cudaSetDevice(dev), ret, fail);
-    ncclCommInitRankDev(comms+i, ndev,1, &uniqueId, i, dev, &config, __func__);
+    ncclCommInitRankDev(comms + i, ndev, 1, &uniqueId, i, dev, &config, __func__);
   }
   NCCLCHECKGOTO(ncclGroupEndInternal(), ret, fail);
 
-  NVTX3_RANGE_ADD_PAYLOAD(CommInitAll, NcclNvtxParamsCommInitAllSchema,
-    NVTX3_PAYLOAD(comms[0]->commHash, ndev));
+  NVTX3_RANGE_ADD_PAYLOAD(CommInitAll, NcclNvtxParamsCommInitAllSchema, NVTX3_PAYLOAD(comms[0]->commHash, ndev));
 
 exit:
   (void)cudaSetDevice(oldDev);
@@ -3280,13 +3352,15 @@ ncclResult_t ncclCommSetAsyncError(ncclComm_t comm, ncclResult_t nextState) {
   return ncclSuccess;
 }
 
-NCCL_API(ncclResult_t, ncclCommInitRankConfig, ncclComm_t* comm, int nranks, ncclUniqueId commId, int myrank, ncclConfig_t *config);
-ncclResult_t ncclCommInitRankConfig_impl(ncclComm_t *newcomm, int nranks, ncclUniqueId commId, int myrank, ncclConfig_t *config) {
+NCCL_API(ncclResult_t, ncclCommInitRankConfig, ncclComm_t* comm, int nranks, ncclUniqueId commId, int myrank,
+         ncclConfig_t* config);
+ncclResult_t ncclCommInitRankConfig_impl(ncclComm_t* newcomm, int nranks, ncclUniqueId commId, int myrank,
+                                         ncclConfig_t* config) {
   Recorder::instance().record(rrCommInitRankConfig, nranks, myrank, &commId, config);
   int cudaDev;
   ncclResult_t ret = ncclSuccess;
   ncclConfig_t internalConfig = NCCL_CONFIG_INITIALIZER;
-  ncclConfig_t *internalConfigPtr = NULL;
+  ncclConfig_t* internalConfigPtr = NULL;
 
   NCCLCHECK(ncclInitEnv());
   NVTX3_RANGE(NcclNvtxParamsCommInitRankConfig);
@@ -3296,73 +3370,74 @@ ncclResult_t ncclCommInitRankConfig_impl(ncclComm_t *newcomm, int nranks, ncclUn
   rocmLibraryInit();
   CUDACHECK(cudaGetDevice(&cudaDev));
 
-  if (config == NULL)
-    internalConfigPtr = &internalConfig;
-  else
-    internalConfigPtr = config;
-  NCCLCHECKGOTO(ncclCommInitRankDev(newcomm, nranks, 1, &commId, myrank, cudaDev, internalConfigPtr, __func__), ret, fail);
+  if (config == NULL) internalConfigPtr = &internalConfig;
+  else internalConfigPtr = config;
+  NCCLCHECKGOTO(ncclCommInitRankDev(newcomm, nranks, 1, &commId, myrank, cudaDev, internalConfigPtr, __func__), ret,
+                fail);
 
 exit:
   ncclGroupErrCheck(ret);
   NCCLCHECK(ncclGroupEndInternal());
   if (newcomm && *newcomm) {
     if (!(*newcomm)->config.blocking) {
-      (void) ncclCommGetAsyncError(*newcomm, &ret);
+      (void)ncclCommGetAsyncError(*newcomm, &ret);
     }
     NVTX3_RANGE_ADD_PAYLOAD(CommInitRankConfig, NcclNvtxParamsCommInitRankSchema,
-      NVTX3_PAYLOAD((*newcomm)->commHash, nranks, myrank, cudaDev));
+                            NVTX3_PAYLOAD((*newcomm)->commHash, nranks, myrank, cudaDev));
   }
   return ret;
 fail:
-  if (newcomm && *newcomm && !(*newcomm)->config.blocking) (void) ncclCommSetAsyncError(*newcomm, ret);
+  if (newcomm && *newcomm && !(*newcomm)->config.blocking) (void)ncclCommSetAsyncError(*newcomm, ret);
   goto exit;
 }
 
-NCCL_API(ncclResult_t, ncclCommInitRankScalable, ncclComm_t* newcomm, int nranks, int myrank, int nId, ncclUniqueId* commId, ncclConfig_t* config);
-ncclResult_t ncclCommInitRankScalable(ncclComm_t* newcomm, int nranks, int myrank, int nId, ncclUniqueId* commId, ncclConfig_t* config) {
+NCCL_API(ncclResult_t, ncclCommInitRankScalable, ncclComm_t* newcomm, int nranks, int myrank, int nId,
+         ncclUniqueId* commId, ncclConfig_t* config);
+ncclResult_t ncclCommInitRankScalable(ncclComm_t* newcomm, int nranks, int myrank, int nId, ncclUniqueId* commId,
+                                      ncclConfig_t* config) {
   NCCLCHECK(ncclInitEnv());
   NVTX3_RANGE(NcclNvtxParamsCommInitRankScalable);
 
   int cudaDev;
   ncclResult_t ret = ncclSuccess;
   ncclConfig_t internalConfig = NCCL_CONFIG_INITIALIZER;
-  ncclConfig_t *internalConfigPtr = NULL;
+  ncclConfig_t* internalConfigPtr = NULL;
   NCCLCHECK(ncclGroupStartInternal());
 
   rocmLibraryInit();
   CUDACHECK(cudaGetDevice(&cudaDev));
 
-  if (config == NULL)
-    internalConfigPtr = &internalConfig;
-  else
-    internalConfigPtr = config;
-  NCCLCHECKGOTO(ncclCommInitRankDev(newcomm, nranks, nId, commId, myrank, cudaDev, internalConfigPtr, __func__), ret, fail);
+  if (config == NULL) internalConfigPtr = &internalConfig;
+  else internalConfigPtr = config;
+  NCCLCHECKGOTO(ncclCommInitRankDev(newcomm, nranks, nId, commId, myrank, cudaDev, internalConfigPtr, __func__), ret,
+                fail);
 
 exit:
   ncclGroupErrCheck(ret);
   NCCLCHECK(ncclGroupEndInternal());
   if (newcomm && *newcomm) {
     if (!(*newcomm)->config.blocking) {
-      (void) ncclCommGetAsyncError(*newcomm, &ret);
+      (void)ncclCommGetAsyncError(*newcomm, &ret);
     }
     NVTX3_RANGE_ADD_PAYLOAD(CommInitRankScalable, NcclNvtxParamsCommInitRankSchema,
-      NVTX3_PAYLOAD((*newcomm)->commHash, nranks, myrank, cudaDev));
+                            NVTX3_PAYLOAD((*newcomm)->commHash, nranks, myrank, cudaDev));
   }
   return ret;
 fail:
-  if (newcomm && *newcomm && !(*newcomm)->config.blocking) (void) ncclCommSetAsyncError(*newcomm, ret);
+  if (newcomm && *newcomm && !(*newcomm)->config.blocking) (void)ncclCommSetAsyncError(*newcomm, ret);
   goto exit;
 }
 
 static ncclResult_t commDestroySync(struct ncclAsyncJob* job_) {
-  struct ncclCommFinalizeAsyncJob* job = (struct ncclCommFinalizeAsyncJob*) job_;
+  struct ncclCommFinalizeAsyncJob* job = (struct ncclCommFinalizeAsyncJob*)job_;
   ncclComm_t comm = job->comm;
   ncclResult_t ret = ncclSuccess;
 
   CUDACHECKGOTO(cudaSetDevice(comm->cudaDev), ret, fail);
 
   NCCLCHECKGOTO(latency_profiler::collTraceDestroy(comm), ret, fail);
-  TRACE(NCCL_DESTROY, "Destroying comm %p rank %d abortFlag %d asyncResult %d", comm, comm->rank, *comm->abortFlag, comm->asyncResult);
+  TRACE(NCCL_DESTROY, "Destroying comm %p rank %d abortFlag %d asyncResult %d", comm, comm->rank, *comm->abortFlag,
+        comm->asyncResult);
 
   if (comm->initState == ncclSuccess) {
     if ((ret = ncclStrongStreamSynchronize(&comm->sharedRes->hostStream)) != ncclSuccess) {
@@ -3413,7 +3488,7 @@ ncclResult_t ncclCommFinalize_impl(ncclComm_t comm) {
   NVTX3_RANGE(NcclNvtxParamsCommFinalize);
 
   ncclResult_t ret = ncclSuccess;
-  struct ncclCommFinalizeAsyncJob *job = NULL;
+  struct ncclCommFinalizeAsyncJob* job = NULL;
 
   NCCLCHECK(ncclGroupStartInternal());
   if (comm == NULL) goto exit;
@@ -3438,7 +3513,9 @@ ncclResult_t ncclCommFinalize_impl(ncclComm_t comm) {
   /* launch async thread to finalize comm. */
   NEW_NOTHROW_GOTO(job, ncclCommFinalizeAsyncJob, ret, fail);
   job->comm = comm;
-  NCCLCHECKGOTO(ncclAsyncLaunch((struct ncclAsyncJob*)job, commDestroySync, nullptr, ncclCommFinalizeAsyncJobFree, comm), ret, fail);
+  NCCLCHECKGOTO(ncclAsyncLaunch((struct ncclAsyncJob*)job, commDestroySync, nullptr, ncclCommFinalizeAsyncJobFree,
+                                comm),
+                ret, fail);
 
 exit:
   ncclGroupErrCheck(ret);
@@ -3447,17 +3524,16 @@ exit:
     if (!comm->config.blocking) {
       NCCLCHECK(ncclCommGetAsyncError(comm, &ret));
     }
-    NVTX3_RANGE_ADD_PAYLOAD(CommFinalize, NcclNvtxParamsCommFinalizeSchema,
-      NVTX3_PAYLOAD(comm->commHash));
+    NVTX3_RANGE_ADD_PAYLOAD(CommFinalize, NcclNvtxParamsCommFinalizeSchema, NVTX3_PAYLOAD(comm->commHash));
   }
   return ret;
 fail:
-  if (comm && !comm->config.blocking) (void) ncclCommSetAsyncError(comm, ret);
+  if (comm && !comm->config.blocking) (void)ncclCommSetAsyncError(comm, ret);
   goto exit;
 }
 
 static ncclResult_t commReclaim(struct ncclAsyncJob* job_) {
-  struct ncclCommFinalizeAsyncJob* job = (struct ncclCommFinalizeAsyncJob*) job_;
+  struct ncclCommFinalizeAsyncJob* job = (struct ncclCommFinalizeAsyncJob*)job_;
   ncclComm_t comm = job->comm;
   ncclResult_t ret = ncclSuccess;
 
@@ -3466,7 +3542,7 @@ static ncclResult_t commReclaim(struct ncclAsyncJob* job_) {
     int curRank; /* Debug info */
     int intraRanks = comm->intraRanks;
     ncclComm_t intracomm0 = comm->intraComm0;
-    int *finalizeRankCnt = &intracomm0->finalizeRankCnt;
+    int* finalizeRankCnt = &intracomm0->finalizeRankCnt;
 
     assert(intracomm0 != NULL && finalizeRankCnt != NULL);
     curRankCnt = COMPILER_ATOMIC_ADD_FETCH(finalizeRankCnt, 1, std::memory_order_acq_rel);
@@ -3485,7 +3561,7 @@ static ncclResult_t commReclaim(struct ncclAsyncJob* job_) {
           struct ncclCommFinalizeAsyncJob job;
           job.comm = curIntraComm;
           /* every comm aborts, commDestroySync should not be blocked. */
-          if ((ret = commDestroySync((struct ncclAsyncJob*) &job)) != ncclSuccess)
+          if ((ret = commDestroySync((struct ncclAsyncJob*)&job)) != ncclSuccess)
             WARN("commReclaim: comm %p (rank = %d) in commDestroySync, error %d", curIntraComm, curRank, ret);
         } else if (curIntraComm->revokedFlag) {
           /* commRevokeAsync already synced streams and stopped proxy;
@@ -3497,8 +3573,8 @@ static ncclResult_t commReclaim(struct ncclAsyncJob* job_) {
           while (!ncclIntruQueueEmpty(&curIntraComm->legacyRegCleanupQueue)) {
             struct ncclCommCallback* cb = ncclIntruQueueDequeue(&curIntraComm->legacyRegCleanupQueue);
             if (cb->fn(curIntraComm, cb) != ncclSuccess) {
-              WARN("commReclaim: legacy IPC cleanup callback failed comm %p (rank = %d) cb %p",
-                   curIntraComm, curRank, cb);
+              WARN("commReclaim: legacy IPC cleanup callback failed comm %p (rank = %d) cb %p", curIntraComm, curRank,
+                   cb);
             }
           }
         }
@@ -3539,26 +3615,25 @@ ncclResult_t ncclCommDestroy_impl(ncclComm_t comm) {
 #ifdef ENABLE_ROCSHMEM
   if (comm->enableRocshmem) {
     rocshmem::rocshmem_free(comm->sourceRshmem);
-    rocshmem::rocshmem_free(comm->destRshmem);	 
-    //TODO: subcomm check
-    rocshmem::rocshmem_team_t  team;
+    rocshmem::rocshmem_free(comm->destRshmem);
+    // TODO: subcomm check
+    rocshmem::rocshmem_team_t team;
     if (!ncclCommToRshmemTeam.empty()) {
-        team = ncclCommToRshmemTeam[comm];
-        rocshmem::rocshmem_team_destroy(team);
-        ncclCommToRshmemTeam.erase(comm);
+      team = ncclCommToRshmemTeam[comm];
+      rocshmem::rocshmem_team_destroy(team);
+      ncclCommToRshmemTeam.erase(comm);
     }
     if (ncclCommToRshmemTeam.empty()) {
-        rocshmem::rocshmem_finalize();
+      rocshmem::rocshmem_finalize();
     }
   }
 #endif
 
   int rank = comm->rank, nranks = comm->nRanks, cudaDev = comm->cudaDev;
-  struct ncclCommFinalizeAsyncJob *job = NULL;
+  struct ncclCommFinalizeAsyncJob* job = NULL;
   ncclResult_t res = ncclSuccess;
 
-  NVTX3_FUNC_WITH_PARAMS(CommDestroy, NcclNvtxParamsCommInitRank,
-    NVTX3_PAYLOAD(comm->commHash, nranks, rank, cudaDev));
+  NVTX3_FUNC_WITH_PARAMS(CommDestroy, NcclNvtxParamsCommInitRank, NVTX3_PAYLOAD(comm->commHash, nranks, rank, cudaDev));
 
   TRACE(NCCL_DESTROY, "comm %p rank %d nRanks %d cudaDev %d busId %lx", comm, rank, nranks, cudaDev, comm->busId);
   NCCLCHECK(ncclGroupStartInternal());
@@ -3573,7 +3648,8 @@ ncclResult_t ncclCommDestroy_impl(ncclComm_t comm) {
   NCCLCHECK(ncclCommEnsureReady(comm));
   NEW_NOTHROW_GOTO(job, ncclCommFinalizeAsyncJob, res, fail);
   job->comm = comm;
-  NCCLCHECKGOTO(ncclAsyncLaunch((struct ncclAsyncJob*)job, commReclaim, nullptr, ncclCommFinalizeAsyncJobFree, comm), res, fail);
+  NCCLCHECKGOTO(ncclAsyncLaunch((struct ncclAsyncJob*)job, commReclaim, nullptr, ncclCommFinalizeAsyncJobFree, comm),
+                res, fail);
 
 exit:
   ncclGroupErrCheck(res);
@@ -3596,21 +3672,21 @@ static ncclResult_t setCommAbortFlags(ncclComm_t comm, int value) {
 }
 
 static ncclResult_t commRevokeAsync(struct ncclAsyncJob* job_) {
-  struct ncclCommRevokeAsyncJob* job = (struct ncclCommRevokeAsyncJob*) job_;
+  struct ncclCommRevokeAsyncJob* job = (struct ncclCommRevokeAsyncJob*)job_;
   ncclComm_t comm = job->comm;
   ncclResult_t res = ncclSuccess;
 
   NCCLCHECKGOTO(PtrCheck(comm, "CommRevokeAsync", "comm"), res, exit);
-  INFO(NCCL_DESTROY, "CommRevokeAsync START comm %p rank %d nRanks %d nNodes %d localRank %d cudaDev %d",
-      comm, comm->rank, comm->nRanks, comm->nNodes, comm->localRank, comm->cudaDev);
+  INFO(NCCL_DESTROY, "CommRevokeAsync START comm %p rank %d nRanks %d nNodes %d localRank %d cudaDev %d", comm,
+       comm->rank, comm->nRanks, comm->nNodes, comm->localRank, comm->cudaDev);
 
-  NCCLCHECKGOTO(ncclStrongStreamSynchronize(&comm->sharedRes->hostStream),   res, exit);
+  NCCLCHECKGOTO(ncclStrongStreamSynchronize(&comm->sharedRes->hostStream), res, exit);
   NCCLCHECKGOTO(ncclStrongStreamSynchronize(&comm->sharedRes->deviceStream), res, exit);
 
-  NCCLCHECKGOTO(ncclCommPollEventCallbacks(comm, /*waitSome=*/true),  res, exit);
-  NCCLCHECKGOTO(ncclCommPollCallbacks(comm,      /*waitSome=*/false), res, exit);
+  NCCLCHECKGOTO(ncclCommPollEventCallbacks(comm, /*waitSome=*/true), res, exit);
+  NCCLCHECKGOTO(ncclCommPollCallbacks(comm, /*waitSome=*/false), res, exit);
 
-  (void) ncclProxyStop(comm);
+  (void)ncclProxyStop(comm);
   if (comm->proxyState && comm->proxyRefCountOld == 0) {
     if (comm->proxyState->thread.joinable()) {
       comm->proxyState->thread.join();
@@ -3623,7 +3699,7 @@ static ncclResult_t commRevokeAsync(struct ncclAsyncJob* job_) {
   NCCLCHECKGOTO(setCommAbortFlags(comm, 0), res, exit);
 
 exit:
-  (void) ncclCommSetAsyncError(comm, res);
+  (void)ncclCommSetAsyncError(comm, res);
   INFO(NCCL_DESTROY, "CommRevokeAsync END comm %p result %d", comm, res);
   return res;
 }
@@ -3661,8 +3737,8 @@ ncclResult_t ncclCommRevoke_impl(ncclComm_t comm, int revokeFlags) {
   (void)ncclCommEnsureReady(comm);
   comm->finalizeCalled = true;
 
-  INFO(NCCL_DESTROY, "comm %p rank %d nRanks %d cudaDev %d busId %lx - Revoke START",
-       comm, comm->rank, comm->nRanks, comm->cudaDev, comm->busId);
+  INFO(NCCL_DESTROY, "comm %p rank %d nRanks %d cudaDev %d busId %lx - Revoke START", comm, comm->rank, comm->nRanks,
+       comm->cudaDev, comm->busId);
 
   NCCLCHECKGOTO(ncclCalloc(&job, 1), ret, fail);
   job->comm = comm;
@@ -3674,11 +3750,11 @@ exit:
   if (comm && !comm->config.blocking) {
     NCCLCHECK(ncclCommGetAsyncError(comm, &ret));
   }
-  INFO(NCCL_DESTROY, "comm %p rank %d nRanks %d cudaDev %d busId %lx - Revoke COMPLETE, result %d",
-       comm, comm->rank, comm->nRanks, comm->cudaDev, comm->busId, ret);
+  INFO(NCCL_DESTROY, "comm %p rank %d nRanks %d cudaDev %d busId %lx - Revoke COMPLETE, result %d", comm, comm->rank,
+       comm->nRanks, comm->cudaDev, comm->busId, ret);
   return ret;
 fail:
-  if (comm && !comm->config.blocking) (void) ncclCommSetAsyncError(comm, ret);
+  if (comm && !comm->config.blocking) (void)ncclCommSetAsyncError(comm, ret);
   goto exit;
 }
 
@@ -3691,12 +3767,12 @@ ncclResult_t ncclCommAbort_impl(ncclComm_t comm) {
     return ncclSuccess;
   }
 
-  INFO(NCCL_DESTROY, "comm %p rank %d nRanks %d cudaDev %d busId %lx - Abort START",
-      comm, comm->rank, comm->nRanks, comm->cudaDev, comm->busId);
+  INFO(NCCL_DESTROY, "comm %p rank %d nRanks %d cudaDev %d busId %lx - Abort START", comm, comm->rank, comm->nRanks,
+       comm->cudaDev, comm->busId);
 
   NCCLCHECK(ncclGroupStartInternal());
   // Ask anything that might still be running on the device to quit
-  NCCLCHECK(setCommAbortFlags(comm,1));
+  NCCLCHECK(setCommAbortFlags(comm, 1));
   comm->destroyFlag = 1;
   /* init thread must be joined before we destroy the comm,
    * and we should ignore the init error here. */
@@ -3704,17 +3780,18 @@ ncclResult_t ncclCommAbort_impl(ncclComm_t comm) {
 
   // once the comm is ready, we can access ranks etc
   int rank = comm->rank, nranks = comm->nRanks, cudaDev = comm->cudaDev;
-  struct ncclCommFinalizeAsyncJob *job = NULL;
+  struct ncclCommFinalizeAsyncJob* job = NULL;
   ncclResult_t res = ncclSuccess;
 
   NVTX3_RANGE_ADD_PAYLOAD(CommAbort, NcclNvtxParamsCommInitRankSchema,
-    NVTX3_PAYLOAD(comm->commHash, nranks, rank, cudaDev));
+                          NVTX3_PAYLOAD(comm->commHash, nranks, rank, cudaDev));
 
   TRACE(NCCL_INIT, "comm %p rank %d nRanks %d cudaDev %d busId %lx", comm, rank, nranks, cudaDev, comm->busId);
 
   NEW_NOTHROW_GOTO(job, ncclCommFinalizeAsyncJob, res, fail);
   job->comm = comm;
-  NCCLCHECKGOTO(ncclAsyncLaunch((struct ncclAsyncJob*)job, commReclaim, nullptr, ncclCommFinalizeAsyncJobFree, comm), res, fail);
+  NCCLCHECKGOTO(ncclAsyncLaunch((struct ncclAsyncJob*)job, commReclaim, nullptr, ncclCommFinalizeAsyncJobFree, comm),
+                res, fail);
 
 exit:
   ncclGroupErrCheck(res);
@@ -3731,9 +3808,10 @@ static void childCommCleanupJob(void* job) {
 }
 
 // initializing a child communicator (for both split and shrink)
-static ncclResult_t ncclCommInitChildComm(ncclComm_t comm, ncclComm_t* newcomm, bool isShrink, int flags, int color, int key, int* excludeRanksList, int excludeRanksCount,
-                                          ncclConfig_t* config, const char* caller) {
-  struct ncclCommInitRankAsyncJob *job = NULL;
+static ncclResult_t ncclCommInitChildComm(ncclComm_t comm, ncclComm_t* newcomm, bool isShrink, int flags, int color,
+                                          int key, int* excludeRanksList, int excludeRanksCount, ncclConfig_t* config,
+                                          const char* caller) {
+  struct ncclCommInitRankAsyncJob* job = NULL;
   struct ncclComm* childComm = NCCL_COMM_NULL;
   ncclResult_t res = ncclSuccess;
 
@@ -3747,7 +3825,10 @@ static ncclResult_t ncclCommInitChildComm(ncclComm_t comm, ncclComm_t* newcomm, 
     // excludeRanksList may not be sorted, need to sort it
     qsort(excludeRanksList, excludeRanksCount, sizeof(int), compareInts);
     // ranks in excludeRanksList should not call into this function
-    NCCLCHECKGOTO(bsearch(&comm->rank, excludeRanksList, excludeRanksCount, sizeof(int), compareInts) ? ncclInvalidArgument : ncclSuccess, res, exit);
+    NCCLCHECKGOTO(bsearch(&comm->rank, excludeRanksList, excludeRanksCount, sizeof(int), compareInts) ?
+                    ncclInvalidArgument :
+                    ncclSuccess,
+                  res, exit);
   }
   NCCLCHECKGOTO(ncclCommEnsureReady(comm), res, exit);
   CUDACHECKGOTO(cudaSetDevice(comm->cudaDev), res, exit);
@@ -3762,7 +3843,8 @@ static ncclResult_t ncclCommInitChildComm(ncclComm_t comm, ncclComm_t* newcomm, 
 
     // Set the shareResource field, this is used throughout the init and must be reset every time.
     // If we shrink, we only reuse resources if we shrink in the default mode
-    comm->shareResources = isShrink ? (!(flags & NCCL_SHRINK_ABORT) && comm->config.shrinkShare) : comm->config.splitShare;
+    comm->shareResources =
+      isShrink ? (!(flags & NCCL_SHRINK_ABORT) && comm->config.shrinkShare) : comm->config.splitShare;
     if (__atomic_load_n(&comm->revokedFlag, __ATOMIC_ACQUIRE)) {
       comm->shareResources = false;
     }
@@ -3809,7 +3891,9 @@ static ncclResult_t ncclCommInitChildComm(ncclComm_t comm, ncclComm_t* newcomm, 
   }
   job->cudaDev = comm->cudaDev;
   snprintf(job->funcName, NCCL_COMMINIT_FUNCNAME_LEN, "%s", caller);
-  NCCLCHECKGOTO(ncclAsyncLaunch((struct ncclAsyncJob*)job, ncclCommInitRankFunc, /*undo=*/NULL, /*destructor=*/childCommCleanupJob, comm), res, fail);
+  NCCLCHECKGOTO(ncclAsyncLaunch((struct ncclAsyncJob*)job, ncclCommInitRankFunc, /*undo=*/NULL,
+                                /*destructor=*/childCommCleanupJob, comm),
+                res, fail);
 
 exit:
   // for loggin only, not ready for replaying
@@ -3831,8 +3915,10 @@ fail:
   goto exit;
 }
 
-NCCL_API(ncclResult_t, ncclCommShrink, ncclComm_t comm, int* excludeRanksList, int excludeRanksCount, ncclComm_t* newcomm, ncclConfig_t* config, int shrinkFlags);
-ncclResult_t  ncclCommShrink_impl(ncclComm_t comm, int* excludeRanksList, int excludeRanksCount, ncclComm_t *newcomm, ncclConfig_t* config, int shrinkFlags) {
+NCCL_API(ncclResult_t, ncclCommShrink, ncclComm_t comm, int* excludeRanksList, int excludeRanksCount,
+         ncclComm_t* newcomm, ncclConfig_t* config, int shrinkFlags);
+ncclResult_t ncclCommShrink_impl(ncclComm_t comm, int* excludeRanksList, int excludeRanksCount, ncclComm_t* newcomm,
+                                 ncclConfig_t* config, int shrinkFlags) {
   NVTX3_RANGE(NcclNvtxParamsCommShrink)
   ncclResult_t res = ncclSuccess;
   NCCLCHECK(ncclGroupStartInternal());
@@ -3842,13 +3928,17 @@ ncclResult_t  ncclCommShrink_impl(ncclComm_t comm, int* excludeRanksList, int ex
     NCCLCHECKGOTO(ncclStrongStreamSynchronize(&comm->sharedRes->deviceStream), res, exit);
     NCCLCHECKGOTO(setCommAbortFlags(comm, 0), res, exit);
   }
-  NCCLCHECKGOTO(ncclCommInitChildComm(comm, newcomm, /*isShrink=*/true, shrinkFlags, /*color=*/0, /*key=*/comm->rank, excludeRanksList, excludeRanksCount, config, __func__), res, exit);
+  NCCLCHECKGOTO(ncclCommInitChildComm(comm, newcomm, /*isShrink=*/true, shrinkFlags, /*color=*/0, /*key=*/comm->rank,
+                                      excludeRanksList, excludeRanksCount, config, __func__),
+                res, exit);
 
 exit:
   (void)ncclGroupErrCheck(res);
   NCCLCHECK(ncclGroupEndInternal());
 
-  if (newcomm && *newcomm) NVTX3_RANGE_ADD_PAYLOAD(CommShrink, NcclNvtxParamsCommShrinkSchema, NVTX3_PAYLOAD(comm->commHash, comm->nRanks, comm->rank, comm->cudaDev, excludeRanksCount));
+  if (newcomm && *newcomm)
+    NVTX3_RANGE_ADD_PAYLOAD(CommShrink, NcclNvtxParamsCommShrinkSchema,
+                            NVTX3_PAYLOAD(comm->commHash, comm->nRanks, comm->rank, comm->cudaDev, excludeRanksCount));
 
   return res;
 }
@@ -3870,8 +3960,10 @@ ncclResult_t ncclCommGetUniqueId_impl(ncclComm_t comm, ncclUniqueId* uniqueId) {
   return ncclSuccess;
 }
 
-NCCL_API(ncclResult_t, ncclCommGrow, ncclComm_t comm, int nRanks, const ncclUniqueId* uniqueId, int rank, ncclComm_t* newcomm, ncclConfig_t* config);
-ncclResult_t ncclCommGrow_impl(ncclComm_t comm, int nRanks, const ncclUniqueId* uniqueId, int rank, ncclComm_t* newcomm, ncclConfig_t* config) {
+NCCL_API(ncclResult_t, ncclCommGrow, ncclComm_t comm, int nRanks, const ncclUniqueId* uniqueId, int rank,
+         ncclComm_t* newcomm, ncclConfig_t* config);
+ncclResult_t ncclCommGrow_impl(ncclComm_t comm, int nRanks, const ncclUniqueId* uniqueId, int rank, ncclComm_t* newcomm,
+                               ncclConfig_t* config) {
   NVTX3_RANGE(NcclNvtxParamsCommGrow)
 
   if (newcomm == NULL) return ncclInvalidArgument;
@@ -3886,11 +3978,11 @@ ncclResult_t ncclCommGrow_impl(ncclComm_t comm, int nRanks, const ncclUniqueId* 
 
   ncclResult_t res = ncclSuccess;
   bool isExistingRank = (comm != NULL);
-  struct ncclCommInitRankAsyncJob *job = NULL;
+  struct ncclCommInitRankAsyncJob* job = NULL;
   ncclComm_t newComm = NULL;
   struct ncclBootstrapHandle recvHandle;
 
-  *newcomm = NULL;  // Initialize output parameter early in case of early errors
+  *newcomm = NULL; // Initialize output parameter early in case of early errors
 
   NCCLCHECK(ncclGroupStartInternal());
 
@@ -3911,8 +4003,8 @@ ncclResult_t ncclCommGrow_impl(ncclComm_t comm, int nRanks, const ncclUniqueId* 
       NCCLCHECKGOTO(bcastGrowHandle(&recvHandle, comm, /*isRoot=*/false), res, exit);
       // verify the magic is the same as the one computed by the root
       if (recvHandle.magic != hashCombine(comm->magic, comm->childCount)) {
-        WARN("ncclCommGrow: magic mismatch computed by the root, got %lx expected %lx",
-          recvHandle.magic, hashCombine(comm->magic, comm->childCount));
+        WARN("ncclCommGrow: magic mismatch computed by the root, got %lx expected %lx", recvHandle.magic,
+             hashCombine(comm->magic, comm->childCount));
         res = ncclInvalidArgument;
         goto exit;
       }
@@ -3937,14 +4029,14 @@ ncclResult_t ncclCommGrow_impl(ncclComm_t comm, int nRanks, const ncclUniqueId* 
     }
 
     // Initialize NCCL and CUDA for new ranks (same sequence as ncclCommInitRank)
-    NCCLCHECKGOTO(ncclInitEnv(), res, exit);  // Environment plugins
+    NCCLCHECKGOTO(ncclInitEnv(), res, exit); // Environment plugins
     // [RCCL] HIP doesn't use CUDA driver API loader; skip ncclCudaLibraryInit()
-    NCCLCHECKGOTO(ncclInit(), res, exit);      // Bootstrap network, CPU stack, GDR
+    NCCLCHECKGOTO(ncclInit(), res, exit); // Bootstrap network, CPU stack, GDR
     if (ncclDebugLevel > NCCL_LOG_WARN || (ncclDebugLevel != NCCL_LOG_NONE && rank == 0)) {
       static std::once_flag once;
-      std::call_once(once, showVersion);       // Version display
+      std::call_once(once, showVersion); // Version display
     }
-    CUDACHECKGOTO(cudaFree(NULL), res, exit);  // CUDA runtime initialization
+    CUDACHECKGOTO(cudaFree(NULL), res, exit); // CUDA runtime initialization
   }
 
   INFO(NCCL_INIT, "ncclCommGrow: %s rank creating new communicator with %d total ranks",
@@ -3981,7 +4073,7 @@ ncclResult_t ncclCommGrow_impl(ncclComm_t comm, int nRanks, const ncclUniqueId* 
     // Existing rank: new comm, parent is old comm
     job->parent = comm;
     job->cudaDev = comm->cudaDev;
-    job->myrank = comm->rank;  // Keep same rank in expanded comm
+    job->myrank = comm->rank; // Keep same rank in expanded comm
   } else {
     // New rank: new comm, no parent
     int device;
@@ -4000,13 +4092,15 @@ ncclResult_t ncclCommGrow_impl(ncclComm_t comm, int nRanks, const ncclUniqueId* 
   job->isGrow = 1;
   job->color = 0;
   job->key = job->myrank;
-  NCCLCHECKGOTO(ncclAsyncLaunch((struct ncclAsyncJob*)job, ncclCommInitRankFunc, NULL, childCommCleanupJob, newComm), res, fail);
+  NCCLCHECKGOTO(ncclAsyncLaunch((struct ncclAsyncJob*)job, ncclCommInitRankFunc, NULL, childCommCleanupJob, newComm),
+                res, fail);
 
 exit:
   if (*newcomm) {
     uint64_t parentHash = isExistingRank ? comm->commHash : 0;
     NVTX3_RANGE_ADD_PAYLOAD(CommGrow, NcclNvtxParamsCommGrowSchema,
-      NVTX3_PAYLOAD((*newcomm)->commHash, parentHash, nRanks, (*newcomm)->rank, (*newcomm)->cudaDev));
+                            NVTX3_PAYLOAD((*newcomm)->commHash, parentHash, nRanks, (*newcomm)->rank,
+                                          (*newcomm)->cudaDev));
   }
   (void)ncclGroupErrCheck(res);
   NCCLCHECK(ncclGroupEndInternal());
@@ -4034,20 +4128,24 @@ fail:
   goto exit;
 }
 
-NCCL_API(ncclResult_t, ncclCommSplit, ncclComm_t comm, int color, int key, ncclComm_t *newcomm, ncclConfig_t *config);
-ncclResult_t ncclCommSplit_impl(ncclComm_t comm, int color, int key, ncclComm_t *newcomm, ncclConfig_t *config) {
+NCCL_API(ncclResult_t, ncclCommSplit, ncclComm_t comm, int color, int key, ncclComm_t* newcomm, ncclConfig_t* config);
+ncclResult_t ncclCommSplit_impl(ncclComm_t comm, int color, int key, ncclComm_t* newcomm, ncclConfig_t* config) {
   NVTX3_RANGE(NcclNvtxParamsCommSplit)
 
   ncclResult_t res = ncclSuccess;
   NCCLCHECK(ncclGroupStartInternal());
-  NCCLCHECKGOTO(ncclCommInitChildComm(comm, newcomm, /*isShrink=*/false, /*shrink mode=*/NCCL_SHRINK_DEFAULT, color, key, NULL, 0, config, __func__), res, exit);
+  NCCLCHECKGOTO(ncclCommInitChildComm(comm, newcomm, /*isShrink=*/false, /*shrink mode=*/NCCL_SHRINK_DEFAULT, color,
+                                      key, NULL, 0, config, __func__),
+                res, exit);
 
 exit:
   (void)ncclGroupErrCheck(res);
   NCCLCHECK(ncclGroupEndInternal());
 
   if (newcomm && *newcomm)
-    NVTX3_RANGE_ADD_PAYLOAD(CommSplit, NcclNvtxParamsCommSplitSchema, NVTX3_PAYLOAD((*newcomm)->commHash, comm->commHash, comm->nRanks, comm->rank, comm->cudaDev, color, key));
+    NVTX3_RANGE_ADD_PAYLOAD(CommSplit, NcclNvtxParamsCommSplitSchema,
+                            NVTX3_PAYLOAD((*newcomm)->commHash, comm->commHash, comm->nRanks, comm->rank, comm->cudaDev,
+                                          color, key));
 
   return res;
 }
@@ -4056,16 +4154,26 @@ NCCL_API(const char*, ncclGetErrorString, ncclResult_t code);
 const char* ncclGetErrorString_impl(ncclResult_t code) {
   Recorder::instance().record("GetErrorString");
   switch (code) {
-    case ncclSuccess                : return "no error";
-    case ncclUnhandledCudaError     : return "unhandled cuda error (run with NCCL_DEBUG=INFO for details)";
-    case ncclSystemError            : return "unhandled system error (run with NCCL_DEBUG=INFO for details)";
-    case ncclInternalError          : return "internal error - please report this issue to the NCCL developers";
-    case ncclInvalidArgument        : return "invalid argument (run with NCCL_DEBUG=WARN for details)";
-    case ncclInvalidUsage           : return "invalid usage (run with NCCL_DEBUG=WARN for details)";
-    case ncclRemoteError            : return "remote process exited or there was a network error";
-    case ncclInProgress             : return "NCCL operation in progress";
-    case ncclTimeout                : return "timeout";
-    default                         : return "unknown result code";
+  case ncclSuccess:
+    return "no error";
+  case ncclUnhandledCudaError:
+    return "unhandled cuda error (run with NCCL_DEBUG=INFO for details)";
+  case ncclSystemError:
+    return "unhandled system error (run with NCCL_DEBUG=INFO for details)";
+  case ncclInternalError:
+    return "internal error - please report this issue to the NCCL developers";
+  case ncclInvalidArgument:
+    return "invalid argument (run with NCCL_DEBUG=WARN for details)";
+  case ncclInvalidUsage:
+    return "invalid usage (run with NCCL_DEBUG=WARN for details)";
+  case ncclRemoteError:
+    return "remote process exited or there was a network error";
+  case ncclInProgress:
+    return "NCCL operation in progress";
+  case ncclTimeout:
+    return "timeout";
+  default:
+    return "unknown result code";
   }
 }
 
@@ -4078,20 +4186,22 @@ const char* ncclGetLastError_impl(ncclComm_t comm) {
   return ncclLastError;
 }
 
-NCCL_API(ncclResult_t, ncclCommGetAsyncError, ncclComm_t comm, ncclResult_t *asyncError);
-ncclResult_t ncclCommGetAsyncError_impl(ncclComm_t comm, ncclResult_t *asyncError) {
+NCCL_API(ncclResult_t, ncclCommGetAsyncError, ncclComm_t comm, ncclResult_t* asyncError);
+ncclResult_t ncclCommGetAsyncError_impl(ncclComm_t comm, ncclResult_t* asyncError) {
   Recorder::instance().record("GetAsyncError");
   NCCLCHECK(CommCheck(comm, "ncclGetAsyncError", "comm"));
   NCCLCHECK(PtrCheck(asyncError, "ncclGetAsyncError", "asyncError"));
 
   *asyncError = COMPILER_ATOMIC_LOAD(&comm->asyncResult, std::memory_order_acquire);
-  if (*asyncError == ncclSuccess && comm->proxyState) *asyncError = COMPILER_ATOMIC_LOAD(&comm->proxyState->asyncResult, std::memory_order_acquire);
+  if (*asyncError == ncclSuccess && comm->proxyState)
+    *asyncError = COMPILER_ATOMIC_LOAD(&comm->proxyState->asyncResult, std::memory_order_acquire);
 
   /* Check gin status */
   if (*asyncError == ncclSuccess && comm->sharedRes && comm->sharedRes->ginState.connected) {
     struct ncclGinState* ginState = &comm->sharedRes->ginState;
     // Gin progress thread status
-    if (ginState->needsProxyProgress) *asyncError = COMPILER_ATOMIC_LOAD(&comm->sharedRes->ginState.asyncResult, std::memory_order_acquire);
+    if (ginState->needsProxyProgress)
+      *asyncError = COMPILER_ATOMIC_LOAD(&comm->sharedRes->ginState.asyncResult, std::memory_order_acquire);
     // Gin side errors, also works when we have no GIN progress thread.
     if (*asyncError == ncclSuccess) {
       bool ginError;
@@ -4153,4 +4263,3 @@ ncclResult_t ncclCommUserRank_impl(const ncclComm_t comm, int* rank) {
   *rank = comm->rank;
   return ncclSuccess;
 }
-

--- a/projects/rccl/src/init_nvtx.cc
+++ b/projects/rccl/src/init_nvtx.cc
@@ -10,11 +10,7 @@
 #include "param.h"
 
 static constexpr const nvtxPayloadEnum_t NvtxEnumRedSchema[] = {
-  {"Sum", ncclSum, 0},
-  {"Product", ncclProd, 0},
-  {"Max", ncclMax, 0},
-  {"Min", ncclMin, 0},
-  {"Avg", ncclAvg, 0}
+  {"Sum", ncclSum, 0}, {"Product", ncclProd, 0}, {"Max", ncclMax, 0}, {"Min", ncclMin, 0}, {"Avg", ncclAvg, 0}
 };
 
 NCCL_PARAM(NvtxDisable, "NVTX_DISABLE", 0);
@@ -27,16 +23,14 @@ void initNvtxRegisteredEnums() {
     return;
   }
 
-  constexpr const nvtxPayloadEnumAttr_t eAttr {
-    NVTX_PAYLOAD_ENUM_ATTR_ENTRIES | NVTX_PAYLOAD_ENUM_ATTR_NUM_ENTRIES |
-      NVTX_PAYLOAD_ENUM_ATTR_SIZE | NVTX_PAYLOAD_ENUM_ATTR_SCHEMA_ID,
-    NULL,
-    NvtxEnumRedSchema,
-    std::extent<decltype(NvtxEnumRedSchema)>::value,
-    sizeof(ncclRedOp_t),
-    NVTX_PAYLOAD_ENTRY_NCCL_REDOP,
-    nullptr
-  };
+  constexpr const nvtxPayloadEnumAttr_t eAttr{NVTX_PAYLOAD_ENUM_ATTR_ENTRIES | NVTX_PAYLOAD_ENUM_ATTR_NUM_ENTRIES |
+                                                NVTX_PAYLOAD_ENUM_ATTR_SIZE | NVTX_PAYLOAD_ENUM_ATTR_SCHEMA_ID,
+                                              NULL,
+                                              NvtxEnumRedSchema,
+                                              std::extent<decltype(NvtxEnumRedSchema)>::value,
+                                              sizeof(ncclRedOp_t),
+                                              NVTX_PAYLOAD_ENTRY_NCCL_REDOP,
+                                              nullptr};
 
   nvtxPayloadEnumRegister(nvtx3::domain::get<nccl_domain>(), &eAttr);
 #endif

--- a/projects/rccl/src/ipc_gpu_barrier.cu
+++ b/projects/rccl/src/ipc_gpu_barrier.cu
@@ -19,47 +19,35 @@
 namespace meta::comms {
 
 __host__ DeviceMailbox::DeviceMailbox(int nRanks, int nBlocks, void* flagsBuf)
-    : nBlocks_(nBlocks), flags_(static_cast<FlagType*>(flagsBuf)) {
+  : nBlocks_(nBlocks), flags_(static_cast<FlagType*>(flagsBuf)) {
   assert(nRanks == NRANKS);
 }
 
-/* static */ __host__ std::pair<std::unique_ptr<DeviceBuffer>, DeviceMailbox>
-DeviceMailbox::mallocAndInit(int nRanks, int nBlocks) {
+/* static */ __host__ std::pair<std::unique_ptr<DeviceBuffer>, DeviceMailbox> DeviceMailbox::mallocAndInit(
+  int nRanks, int nBlocks) {
   assert(nRanks == NRANKS);
-  auto flagBuf =
-      std::make_unique<DeviceBuffer>(nRanks * nBlocks * sizeof(FlagType));
+  auto flagBuf = std::make_unique<DeviceBuffer>(nRanks * nBlocks * sizeof(FlagType));
   if (flagBuf == nullptr) {
     ERROR("DeviceMailbox::mallocAndInit: allocation failed");
     return {nullptr, DeviceMailbox{}};
   }
-  cudaError_t err = cudaMemset(
-      flagBuf->get(), 0, nRanks * nBlocks * sizeof(FlagType));
+  cudaError_t err = cudaMemset(flagBuf->get(), 0, nRanks * nBlocks * sizeof(FlagType));
   if (err != cudaSuccess) {
-    WARN("DeviceMailbox::mallocAndInit: cudaMemset failed (%s)",
-         cudaGetErrorString(err));
+    WARN("DeviceMailbox::mallocAndInit: cudaMemset failed (%s)", cudaGetErrorString(err));
     return {nullptr, DeviceMailbox{}};
   }
-  DeviceMailbox mailbox{
-      nRanks, nBlocks, static_cast<FlagType*>(flagBuf->get())};
+  DeviceMailbox mailbox{nRanks, nBlocks, static_cast<FlagType*>(flagBuf->get())};
   return {std::move(flagBuf), mailbox};
 }
 
-__host__ IpcGpuBarrier::IpcGpuBarrier(
-    int nRanks,
-    int nBlocks,
-    int selfRank,
-    const std::array<DeviceMailbox, NRANKS>& allMailboxes)
-    : nBlocks_(nBlocks), selfRank_(selfRank), allMailboxes_(allMailboxes) {
+__host__ IpcGpuBarrier::IpcGpuBarrier(int nRanks, int nBlocks, int selfRank,
+                                      const std::array<DeviceMailbox, NRANKS>& allMailboxes)
+  : nBlocks_(nBlocks), selfRank_(selfRank), allMailboxes_(allMailboxes) {
   assert(nRanks == NRANKS);
 }
 
-/* static */ __host__
-    std::pair<std::unique_ptr<IpcGpuBarrierResources>, IpcGpuBarrier>
-    IpcGpuBarrier::mallocAndInit(
-        int nRanks,
-        int nBlocks,
-        int selfRank,
-        void* bootstrap) {
+/* static */ __host__ std::pair<std::unique_ptr<IpcGpuBarrierResources>, IpcGpuBarrier> IpcGpuBarrier::mallocAndInit(
+  int nRanks, int nBlocks, int selfRank, void* bootstrap) {
   assert(nRanks == NRANKS);
   auto selfAlloc = DeviceMailbox::mallocAndInit(nRanks, nBlocks);
   auto& selfMboxBuf = selfAlloc.first;
@@ -68,9 +56,8 @@ __host__ IpcGpuBarrier::IpcGpuBarrier(
     return {nullptr, IpcGpuBarrier{}};
   }
 
-  auto memHandler =
-      std::make_unique<ncclIpcMemHandler>(bootstrap, selfRank, nRanks);
-  
+  auto memHandler = std::make_unique<ncclIpcMemHandler>(bootstrap, selfRank, nRanks);
+
   ncclResult_t result = memHandler->addSelfDeviceMemPtr(selfMboxBuf->get());
   if (result != ncclSuccess && result != ncclInProgress) {
     if (ncclDebugNoWarn == 0) {
@@ -93,7 +80,7 @@ __host__ IpcGpuBarrier::IpcGpuBarrier(
     } else {
       void* peerPtr = nullptr;
       result = memHandler->getPeerDeviceMemPtr(i, &peerPtr);
-      
+
       if (result != ncclSuccess && result != ncclInProgress) {
         if (ncclDebugNoWarn == 0) {
           INFO(NCCL_ALL, "%s:%d -> %d", __FILE__, __LINE__, result);
@@ -110,7 +97,6 @@ __host__ IpcGpuBarrier::IpcGpuBarrier(
   resources->ipcMemHandler = std::move(memHandler);
   resources->selfMailboxBuf = std::move(selfMboxBuf);
   return {std::move(resources), barrier};
-
 }
 
 } // namespace meta::comms

--- a/projects/rccl/src/ipc_init.cu
+++ b/projects/rccl/src/ipc_init.cu
@@ -19,16 +19,14 @@ using nccl_dda_ipc_detail::DdaIpcBarrierState;
 using nccl_dda_ipc_detail::ddaMaxNBlocksForScratch;
 using nccl_dda_ipc_detail::kDdaNranks;
 
-
-#define HIP_CALL(cmd)                                                                   \
-    do {                                                                                \
-        hipError_t error = (cmd);                                                       \
-        if (error != hipSuccess)                                                        \
-        {                                                                               \
-            std::cerr << "Encountered HIP error (" << hipGetErrorString(error)          \
-                      << ") at line " << __LINE__ << " in file " << __FILE__ << "\n";   \
-        }                                                                               \
-    } while (0)
+#define HIP_CALL(cmd) \
+  do { \
+    hipError_t error = (cmd); \
+    if (error != hipSuccess) { \
+      std::cerr << "Encountered HIP error (" << hipGetErrorString(error) << ") at line " << __LINE__ << " in file " \
+                << __FILE__ << "\n"; \
+    } \
+  } while (0)
 
 ncclResult_t ncclDdaIpcCommInit(ncclComm* comm) {
   if (comm == nullptr) {
@@ -46,12 +44,9 @@ ncclResult_t ncclDdaIpcCommInit(ncclComm* comm) {
   //   uncached-memory IPC export fails (hipIpcGetMemHandle -> hipErrorInvalidValue),
   //   which aborts comm init entirely. Gate init to match dispatch.
   const bool ddaArchSupported =
-      comm->archName != nullptr &&
-      (IsArchMatch(comm->archName, "gfx942") ||
-       IsArchMatch(comm->archName, "gfx950"));
-  if (comm->nRanks != kDdaNranks || comm->nNodes != 1 ||
-      comm->bootstrap == nullptr || comm->directMode || comm->MNNVL ||
-      !ddaArchSupported) {
+    comm->archName != nullptr && (IsArchMatch(comm->archName, "gfx942") || IsArchMatch(comm->archName, "gfx950"));
+  if (comm->nRanks != kDdaNranks || comm->nNodes != 1 || comm->bootstrap == nullptr || comm->directMode ||
+      comm->MNNVL || !ddaArchSupported) {
     return ncclSuccess;
   }
 
@@ -67,8 +62,7 @@ ncclResult_t ncclDdaIpcCommInit(ncclComm* comm) {
   HIP_CALL(hipExtMallocWithFlags((void**)&scratch, bytes, hipDeviceMallocFinegrained));
 #endif
 
-  auto* handler = new (std::nothrow) ncclIpcMemHandler(
-      comm->bootstrap, comm->rank, comm->nRanks);
+  auto* handler = new (std::nothrow) ncclIpcMemHandler(comm->bootstrap, comm->rank, comm->nRanks);
   if (handler == nullptr) {
     CUDACHECKIGNORE(cudaFree(scratch));
     WARN("ncclDdaIpcCommInit: OOM allocating ncclIpcMemHandler");
@@ -95,9 +89,7 @@ ncclResult_t ncclDdaIpcCommInit(ncclComm* comm) {
   if (ce != cudaSuccess) {
     delete handler;
     CUDACHECKIGNORE(cudaFree(scratch));
-    WARN(
-        "ncclDdaIpcCommInit: cudaMalloc(peer table) failed (%s)",
-        cudaGetErrorString(ce));
+    WARN("ncclDdaIpcCommInit: cudaMalloc(peer table) failed (%s)", cudaGetErrorString(ce));
     return ncclSuccess;
   }
 
@@ -115,24 +107,17 @@ ncclResult_t ncclDdaIpcCommInit(ncclComm* comm) {
     h_ptrs[i] = p;
   }
 
-  ce = cudaMemcpy(
-      peerDev,
-      h_ptrs,
-      kDdaNranks * sizeof(void*),
-      cudaMemcpyHostToDevice);
+  ce = cudaMemcpy(peerDev, h_ptrs, kDdaNranks * sizeof(void*), cudaMemcpyHostToDevice);
   if (ce != cudaSuccess) {
     CUDACHECKIGNORE(cudaFree(peerDev));
     delete handler;
     CUDACHECKIGNORE(cudaFree(scratch));
-    WARN(
-        "ncclDdaIpcCommInit: cudaMemcpy(peer table) failed (%s)",
-        cudaGetErrorString(ce));
+    WARN("ncclDdaIpcCommInit: cudaMemcpy(peer table) failed (%s)", cudaGetErrorString(ce));
     return ncclSuccess;
   }
 
   const int nBlocksMax = ddaMaxNBlocksForScratch();
-  auto barrierPair = meta::comms::IpcGpuBarrier::mallocAndInit(
-      kDdaNranks, nBlocksMax, comm->rank, comm->bootstrap);
+  auto barrierPair = meta::comms::IpcGpuBarrier::mallocAndInit(kDdaNranks, nBlocksMax, comm->rank, comm->bootstrap);
   if (!barrierPair.first) {
     CUDACHECKIGNORE(cudaFree(peerDev));
     delete handler;
@@ -158,11 +143,8 @@ ncclResult_t ncclDdaIpcCommInit(ncclComm* comm) {
   comm->ddaIpcScratchBytes = bytes;
   comm->ddaIpcPeerPtrsDev = peerDev;
   comm->ddaIpcBarrierState = barrierState;
-  INFO(
-      NCCL_INIT,
-      "ncclDdaIpcCommInit: scratch %zu bytes, IpcGpuBarrier nBlocks=%d, peer IPC table on device",
-      bytes,
-      nBlocksMax);
+  INFO(NCCL_INIT, "ncclDdaIpcCommInit: scratch %zu bytes, IpcGpuBarrier nBlocks=%d, peer IPC table on device", bytes,
+       nBlocksMax);
   return ncclSuccess;
 }
 

--- a/projects/rccl/src/ipc_mem_handler.cc
+++ b/projects/rccl/src/ipc_mem_handler.cc
@@ -14,11 +14,8 @@
 #include <cuda_runtime.h>
 
 ncclIpcMemHandler::ncclIpcMemHandler(void* bootstrap, int rank, int nranks)
-    : bootstrap_(bootstrap),
-      rank_(rank),
-      nranks_(nranks),
-      memPtrs_(static_cast<size_t>(nranks), nullptr),
-      exchanged_(false) {}
+  : bootstrap_(bootstrap), rank_(rank), nranks_(nranks), memPtrs_(static_cast<size_t>(nranks), nullptr),
+    exchanged_(false) {}
 
 ncclIpcMemHandler::~ncclIpcMemHandler() {
   if (!exchanged_) {
@@ -56,10 +53,7 @@ ncclResult_t ncclIpcMemHandler::exchangeMemPtrs() {
     if (i == rank_) {
       continue;
     }
-    CUDACHECK(cudaIpcOpenMemHandle(
-        &memPtrs_[static_cast<size_t>(i)],
-        ipcHandles[i],
-        cudaIpcMemLazyEnablePeerAccess));
+    CUDACHECK(cudaIpcOpenMemHandle(&memPtrs_[static_cast<size_t>(i)], ipcHandles[i], cudaIpcMemLazyEnablePeerAccess));
   }
   exchanged_ = true;
   return ncclSuccess;

--- a/projects/rccl/src/mem_manager.cc
+++ b/projects/rccl/src/mem_manager.cc
@@ -96,10 +96,8 @@ ncclResult_t ncclMemManagerDestroy(struct ncclComm* comm) {
     }
 
     // Close shareable FD if valid (defensive cleanup for POSIX FD handle type)
-    if (!entry->isImportedFromPeer &&
-        entry->desc.local.shareableHandleValid &&
-        entry->handleType == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR &&
-        entry->desc.local.shareableHandle.fd >= 0) {
+    if (!entry->isImportedFromPeer && entry->desc.local.shareableHandleValid &&
+        entry->handleType == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR && entry->desc.local.shareableHandle.fd >= 0) {
       close(entry->desc.local.shareableHandle.fd);
       entry->desc.local.shareableHandle.fd = -1;
       entry->desc.local.shareableHandleValid = false;
@@ -135,18 +133,10 @@ ncclResult_t ncclMemManagerDestroy(struct ncclComm* comm) {
 }
 
 // Internal helper to create and track memory entry
-static ncclResult_t ncclMemTrackInternal(
-  struct ncclMemManager* manager,
-  void* ptr,
-  size_t size,
-  CUmemGenericAllocationHandle handle,
-  CUmemAllocationHandleType handleType,
-  ncclMemType_t memType,
-  bool isImportedFromPeer,
-  int ownerRank,
-  int ownerDev,
-  void* ownerPtr
-) {
+static ncclResult_t ncclMemTrackInternal(struct ncclMemManager* manager, void* ptr, size_t size,
+                                         CUmemGenericAllocationHandle handle, CUmemAllocationHandleType handleType,
+                                         ncclMemType_t memType, bool isImportedFromPeer, int ownerRank, int ownerDev,
+                                         void* ownerPtr) {
   if (ncclParamMemManagerDisable()) return ncclSuccess;
   if (manager == nullptr || ptr == nullptr) return ncclInternalError;
   if (!COMPILER_ATOMIC_LOAD(&manager->initialized, std::memory_order_acquire)) {
@@ -158,12 +148,10 @@ static ncclResult_t ncclMemTrackInternal(
   if (memType == ncclMemPersist) {
     if (isImportedFromPeer) {
       (void)COMPILER_ATOMIC_ADD_FETCH(&manager->totalPersistImported, size, std::memory_order_relaxed);
-      TRACE(NCCL_ALLOC, "MemManager: Track Persistent Import ptr=%p size=%zu from rank=%d",
-            ptr, size, ownerRank);
+      TRACE(NCCL_ALLOC, "MemManager: Track Persistent Import ptr=%p size=%zu from rank=%d", ptr, size, ownerRank);
     } else {
       (void)COMPILER_ATOMIC_ADD_FETCH(&manager->totalPersist, size, std::memory_order_relaxed);
-      TRACE(NCCL_ALLOC, "MemManager: Track Persistent ptr=%p size=%zu dev=%d",
-            ptr, size, manager->commCudaDev);
+      TRACE(NCCL_ALLOC, "MemManager: Track Persistent ptr=%p size=%zu dev=%d", ptr, size, manager->commCudaDev);
     }
     return ncclSuccess;
   }
@@ -217,48 +205,32 @@ static ncclResult_t ncclMemTrackInternal(
     } else if (memType == ncclMemOffload) {
       (void)COMPILER_ATOMIC_ADD_FETCH(&manager->totalOffloadImported, size, std::memory_order_relaxed);
     }
-    TRACE(NCCL_ALLOC, "MemManager: Track imported ptr=%p size=%zu type=%d from rank=%d entries=%d",
-          ptr, size, memType, ownerRank, manager->numEntries);
+    TRACE(NCCL_ALLOC, "MemManager: Track imported ptr=%p size=%zu type=%d from rank=%d entries=%d", ptr, size, memType,
+          ownerRank, manager->numEntries);
   } else {
     if (memType == ncclMemScratch) {
       (void)COMPILER_ATOMIC_ADD_FETCH(&manager->totalScratch, size, std::memory_order_relaxed);
     } else if (memType == ncclMemOffload) {
       (void)COMPILER_ATOMIC_ADD_FETCH(&manager->totalOffload, size, std::memory_order_relaxed);
     }
-    TRACE(NCCL_ALLOC, "MemManager: Track ptr=%p size=%zu type=%d dev=%d entries=%d",
-          ptr, size, memType, manager->commCudaDev, manager->numEntries);
+    TRACE(NCCL_ALLOC, "MemManager: Track ptr=%p size=%zu type=%d dev=%d entries=%d", ptr, size, memType,
+          manager->commCudaDev, manager->numEntries);
   }
 
   return ncclSuccess;
 }
 
 // Track a new allocation
-ncclResult_t ncclMemTrack(
-  struct ncclMemManager* manager,
-  void* ptr,
-  size_t size,
-  CUmemGenericAllocationHandle handle,
-  CUmemAllocationHandleType handleType,
-  ncclMemType_t memType
-) {
-  return ncclMemTrackInternal(manager, ptr, size, handle, handleType, memType,
-                              false, -1, -1, nullptr);
+ncclResult_t ncclMemTrack(struct ncclMemManager* manager, void* ptr, size_t size, CUmemGenericAllocationHandle handle,
+                          CUmemAllocationHandleType handleType, ncclMemType_t memType) {
+  return ncclMemTrackInternal(manager, ptr, size, handle, handleType, memType, false, -1, -1, nullptr);
 }
 
 // Track imported allocation from peer
-ncclResult_t ncclMemTrackImportFromPeer(
-  struct ncclMemManager* manager,
-  void* ptr,
-  size_t size,
-  CUmemGenericAllocationHandle handle,
-  CUmemAllocationHandleType handleType,
-  ncclMemType_t memType,
-  int ownerRank,
-  int ownerDev,
-  void* ownerPtr
-) {
-  return ncclMemTrackInternal(manager, ptr, size, handle, handleType, memType,
-                              true, ownerRank, ownerDev, ownerPtr);
+ncclResult_t ncclMemTrackImportFromPeer(struct ncclMemManager* manager, void* ptr, size_t size,
+                                        CUmemGenericAllocationHandle handle, CUmemAllocationHandleType handleType,
+                                        ncclMemType_t memType, int ownerRank, int ownerDev, void* ownerPtr) {
+  return ncclMemTrackInternal(manager, ptr, size, handle, handleType, memType, true, ownerRank, ownerDev, ownerPtr);
 }
 
 // Untrack allocation
@@ -301,8 +273,7 @@ ncclResult_t ncclMemUntrack(struct ncclMemManager* manager, void* ptr, size_t si
         }
 
         // Close shareable FD if valid (defensive cleanup for POSIX FD handle type)
-        if (!entry->isImportedFromPeer &&
-            entry->desc.local.shareableHandleValid &&
+        if (!entry->isImportedFromPeer && entry->desc.local.shareableHandleValid &&
             entry->handleType == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR &&
             entry->desc.local.shareableHandle.fd >= 0) {
           close(entry->desc.local.shareableHandle.fd);
@@ -351,8 +322,7 @@ ncclResult_t ncclMemUntrack(struct ncclMemManager* manager, void* ptr, size_t si
       }
     }
 
-    TRACE(NCCL_ALLOC, "MemManager: Untrack ptr=%p size=%zu entries=%d",
-          ptr, entrySize, numEntries);
+    TRACE(NCCL_ALLOC, "MemManager: Untrack ptr=%p size=%zu entries=%d", ptr, entrySize, numEntries);
     (void)numEntries; // suppress unused-variable warning when TRACE expands to no-op in Release
   } else {
     // Entry not found in linked list - must be persistent memory
@@ -384,7 +354,8 @@ ncclResult_t ncclDynMemMarkExportToPeer(struct ncclMemManager* manager, void* pt
 
   if (entry == nullptr) {
     WARN("MemManager: Cannot mark export for ptr=%p - not found in tracked entries. "
-         "Only dynamic memory (scratch/offload) needs export tracking for suspend/resume.", ptr);
+         "Only dynamic memory (scratch/offload) needs export tracking for suspend/resume.",
+         ptr);
     return ncclInternalError;
   }
 
@@ -404,10 +375,9 @@ ncclResult_t ncclDynMemMarkExportToPeer(struct ncclMemManager* manager, void* pt
 
   if (entry->desc.local.numExportedPeers >= entry->desc.local.exportedPeersCapacity) {
     int newCapacity = entry->desc.local.exportedPeersCapacity == 0 ? NCCL_MEM_EXPORT_PEERS_INIT :
-                      entry->desc.local.exportedPeersCapacity * 2;
-    ncclResult_t ret = ncclRealloc(&entry->desc.local.exportedPeerRanks,
-                                   entry->desc.local.exportedPeersCapacity,
-                                   newCapacity);
+                                                                     entry->desc.local.exportedPeersCapacity * 2;
+    ncclResult_t ret =
+      ncclRealloc(&entry->desc.local.exportedPeerRanks, entry->desc.local.exportedPeersCapacity, newCapacity);
     if (ret != ncclSuccess) {
       WARN("MemManager: Failed to grow exportedPeerRanks array for ptr=%p", ptr);
       return ret;
@@ -418,8 +388,8 @@ ncclResult_t ncclDynMemMarkExportToPeer(struct ncclMemManager* manager, void* pt
   // Add peer to export list
   entry->desc.local.exportedPeerRanks[entry->desc.local.numExportedPeers++] = peerRank;
 
-  TRACE(NCCL_ALLOC, "MemManager: ExportToPeer ptr=%p peerRank=%d numExportedPeers=%d",
-        ptr, peerRank, entry->desc.local.numExportedPeers);
+  TRACE(NCCL_ALLOC, "MemManager: ExportToPeer ptr=%p peerRank=%d numExportedPeers=%d", ptr, peerRank,
+        entry->desc.local.numExportedPeers);
   return ncclSuccess;
 }
 
@@ -463,13 +433,14 @@ ncclResult_t ncclCommMemSuspend(struct ncclComm* comm) {
   entry = manager->entries;
   while (entry != nullptr) {
     if (entry->isImportedFromPeer && entry->state == ncclDynMemStateActive) {
-      TRACE(NCCL_ALLOC, "MemManager: Unmapping peer-imported buffer ptr=%p from rank %d",
-            entry->ptr, entry->desc.imported.ownerRank);
+      TRACE(NCCL_ALLOC, "MemManager: Unmapping peer-imported buffer ptr=%p from rank %d", entry->ptr,
+            entry->desc.imported.ownerRank);
 
       // Unmap our local mapping of the peer's memory
       hipError_t unmapErr = cuMemUnmap((CUdeviceptr)entry->ptr, entry->size);
       if (unmapErr != hipSuccess) {
-        WARN("MemManager: cuMemUnmap failed during Suspend for peer-imported ptr=%p size=%zu from rank=%d: '%s' (entry kept Active, handle preserved)",
+        WARN("MemManager: cuMemUnmap failed during Suspend for peer-imported ptr=%p size=%zu from rank=%d: '%s' (entry "
+             "kept Active, handle preserved)",
              entry->ptr, entry->size, entry->desc.imported.ownerRank, hipGetErrorString(unmapErr));
         if (ret == ncclSuccess) ret = ncclUnhandledCudaError;
         entry = entry->next;
@@ -481,7 +452,8 @@ ncclResult_t ncclCommMemSuspend(struct ncclComm* comm) {
       if (entry->handle != 0) {
         hipError_t relErr = cuMemRelease(entry->handle);
         if (relErr != hipSuccess) {
-          WARN("MemManager: cuMemRelease failed during Suspend for peer-imported ptr=%p handle=%llu: '%s' (handle ref leaked in driver, marking Released)",
+          WARN("MemManager: cuMemRelease failed during Suspend for peer-imported ptr=%p handle=%llu: '%s' (handle ref "
+               "leaked in driver, marking Released)",
                entry->ptr, (unsigned long long)entry->handle, hipGetErrorString(relErr));
           if (ret == ncclSuccess) ret = ncclUnhandledCudaError;
         }
@@ -536,8 +508,7 @@ ncclResult_t ncclCommMemSuspend(struct ncclComm* comm) {
     }
 
     // Close the shareable FD if valid (for POSIX handles)
-    if (entry->desc.local.shareableHandleValid &&
-        entry->handleType == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR &&
+    if (entry->desc.local.shareableHandleValid && entry->handleType == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR &&
         entry->desc.local.shareableHandle.fd >= 0) {
       close(entry->desc.local.shareableHandle.fd);
       entry->desc.local.shareableHandle.fd = -1;
@@ -551,7 +522,8 @@ ncclResult_t ncclCommMemSuspend(struct ncclComm* comm) {
     // of a live mapping); cpuBackup will be freed by Destroy.
     hipError_t unmapErr = cuMemUnmap((CUdeviceptr)entry->ptr, entry->size);
     if (unmapErr != hipSuccess) {
-      WARN("MemManager: cuMemUnmap failed during Suspend for local ptr=%p size=%zu type=%d: '%s' (entry kept Active, handle preserved)",
+      WARN("MemManager: cuMemUnmap failed during Suspend for local ptr=%p size=%zu type=%d: '%s' (entry kept Active, "
+           "handle preserved)",
            entry->ptr, entry->size, entry->memType, hipGetErrorString(unmapErr));
       if (ret == ncclSuccess) ret = ncclUnhandledCudaError;
       entry = entry->next;
@@ -561,7 +533,8 @@ ncclResult_t ncclCommMemSuspend(struct ncclComm* comm) {
     // Release physical memory handle
     hipError_t relErr = cuMemRelease(entry->handle);
     if (relErr != hipSuccess) {
-      WARN("MemManager: cuMemRelease failed during Suspend for local ptr=%p handle=%llu: '%s' (handle ref leaked in driver, marking Released)",
+      WARN("MemManager: cuMemRelease failed during Suspend for local ptr=%p handle=%llu: '%s' (handle ref leaked in "
+           "driver, marking Released)",
            entry->ptr, (unsigned long long)entry->handle, hipGetErrorString(relErr));
       if (ret == ncclSuccess) ret = ncclUnhandledCudaError;
     }
@@ -578,10 +551,14 @@ ncclResult_t ncclCommMemSuspend(struct ncclComm* comm) {
   // (Active entries that failed will be revisited) or fall through to Destroy.
   if (ret == ncclSuccess) {
     __atomic_store_n(&manager->released, 1, __ATOMIC_RELEASE);
-    INFO(NCCL_ALLOC, "MemManager: rank %d suspended %d local + %d peer entries (scratch=%zu, offload=%zu, peerImport=%zu, cpuBackup=%zu)",
-         comm->rank, releasedCount, peerImportCount, releasedScratch, releasedOffload, releasedPeerImport, manager->cpuBackupUsage);
+    INFO(NCCL_ALLOC,
+         "MemManager: rank %d suspended %d local + %d peer entries (scratch=%zu, offload=%zu, peerImport=%zu, "
+         "cpuBackup=%zu)",
+         comm->rank, releasedCount, peerImportCount, releasedScratch, releasedOffload, releasedPeerImport,
+         manager->cpuBackupUsage);
   } else {
-    WARN("MemManager: rank %d Suspend completed with errors (released %d local + %d peer entries before first failure); manager left in unsuspended state, retry Suspend or call Destroy",
+    WARN("MemManager: rank %d Suspend completed with errors (released %d local + %d peer entries before first "
+         "failure); manager left in unsuspended state, retry Suspend or call Destroy",
          comm->rank, releasedCount, peerImportCount);
   }
 
@@ -674,15 +651,16 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
       int peerRank = entry->desc.local.exportedPeerRanks[i];
       if (peerRank >= 0 && peerRank < comm->nRanks) {
         // Only set access for peers on the same node and same process
-        if (comm->peerInfo[peerRank].pidHash == comm->peerInfo[comm->rank].pidHash && comm->peerInfo[peerRank].hostHash == comm->peerInfo[comm->rank].hostHash){
+        if (comm->peerInfo[peerRank].pidHash == comm->peerInfo[comm->rank].pidHash &&
+            comm->peerInfo[peerRank].hostHash == comm->peerInfo[comm->rank].hostHash) {
           int peerDev = comm->peerInfo[peerRank].cudaDev;
           CUmemAccessDesc peerAccessDesc = {};
           peerAccessDesc.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
           peerAccessDesc.location.id = peerDev;
           peerAccessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
           CUCHECKIGNORE(cuMemSetAccess((CUdeviceptr)entry->ptr, entry->size, &peerAccessDesc, 1));
-          TRACE(NCCL_ALLOC, "MemManager: Restored peer access for ptr=%p to rank %d dev %d",
-                entry->ptr, peerRank, peerDev);
+          TRACE(NCCL_ALLOC, "MemManager: Restored peer access for ptr=%p to rank %d dev %d", entry->ptr, peerRank,
+                peerDev);
         }
       }
     }
@@ -706,8 +684,8 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
 
     entry->desc.local.shareableHandleValid = false;
     if (entry->handleType == CU_MEM_HANDLE_TYPE_FABRIC) {
-      CUresult exportRet = CUPFN(cuMemExportToShareableHandle(&entry->desc.local.shareableHandle.fabricHandle, newHandle,
-                                                               CU_MEM_HANDLE_TYPE_FABRIC, 0));
+      CUresult exportRet = CUPFN(cuMemExportToShareableHandle(&entry->desc.local.shareableHandle.fabricHandle,
+                                                              newHandle, CU_MEM_HANDLE_TYPE_FABRIC, 0));
       if (exportRet != CUDA_SUCCESS) {
         WARN("MemManager: cuMemExportToShareableHandle (FABRIC) failed for ptr=%p", entry->ptr);
         CUCHECKIGNORE(cuMemUnmap((CUdeviceptr)entry->ptr, entry->size));
@@ -723,16 +701,16 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
     restoredLocalCount++;
     restoredLocalBytes += entry->size;
 
-    TRACE(NCCL_ALLOC, "MemManager: Resumed local buffer ptr=%p size=%zu numExportedPeers=%d",
-          entry->ptr, entry->size, entry->desc.local.numExportedPeers);
+    TRACE(NCCL_ALLOC, "MemManager: Resumed local buffer ptr=%p size=%zu numExportedPeers=%d", entry->ptr, entry->size,
+          entry->desc.local.numExportedPeers);
 
     entry = entry->next;
   }
 
   // Step 2: Barrier to ensure all ranks have resumed their local memory
   if (comm->bootstrap != nullptr) {
-    INFO(NCCL_ALLOC, "MemManager: rank %d resumed %d local entries, waiting at barrier",
-         comm->rank, restoredLocalCount);
+    INFO(NCCL_ALLOC, "MemManager: rank %d resumed %d local entries, waiting at barrier", comm->rank,
+         restoredLocalCount);
     ret = bootstrapBarrier(comm->bootstrap, comm->rank, comm->nRanks, 0xBEEF);
     if (ret != ncclSuccess) {
       WARN("MemManager: Barrier failed during resume");
@@ -802,7 +780,8 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
       int idx = 0;
       entry = manager->entries;
       while (entry != nullptr && idx < localBroadcastCount) {
-        if (!entry->isImportedFromPeer && entry->desc.local.numExportedPeers > 0 && entry->state == ncclDynMemStateActive) {
+        if (!entry->isImportedFromPeer && entry->desc.local.numExportedPeers > 0 &&
+            entry->state == ncclDynMemStateActive) {
           localInfos[idx].ptr = entry->ptr;
           localInfos[idx].ownerRank = comm->rank;
           localInfos[idx].ownerDev = entry->cudaDev;
@@ -812,7 +791,8 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
           if (entry->handleType == CU_MEM_HANDLE_TYPE_FABRIC) {
             // For FABRIC: copy the exported fabric handle (can be shared directly)
             if (entry->desc.local.shareableHandleValid) {
-              memcpy(&localInfos[idx].fabricHandle, &entry->desc.local.shareableHandle.fabricHandle, sizeof(hipMemFabricHandle_compat_t));
+              memcpy(&localInfos[idx].fabricHandle, &entry->desc.local.shareableHandle.fabricHandle,
+                     sizeof(hipMemFabricHandle_compat_t));
             } else {
               WARN("MemManager: FABRIC handle not valid for entry ptr=%p", entry->ptr);
             }
@@ -837,15 +817,13 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
 
       // Copy local data to correct position
       if (localBroadcastCount > 0) {
-        memcpy(allInfos + offsets[comm->rank], localInfos,
-               localBroadcastCount * sizeof(ncclDynMemP2pHandleInfo));
+        memcpy(allInfos + offsets[comm->rank], localInfos, localBroadcastCount * sizeof(ncclDynMemP2pHandleInfo));
       }
 
       // Exchange using Send/Recv (send first, then receive to avoid deadlock)
       for (int r = 0; r < comm->nRanks; r++) {
         if (r != comm->rank && localBroadcastCount > 0) {
-          ret = bootstrapSend(comm->bootstrap, r, 0xFEED,
-                              localInfos,
+          ret = bootstrapSend(comm->bootstrap, r, 0xFEED, localInfos,
                               localBroadcastCount * sizeof(ncclDynMemP2pHandleInfo));
           if (ret != ncclSuccess) {
             WARN("MemManager: Send to rank %d failed - handle exchange incomplete", r);
@@ -860,8 +838,7 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
 
       for (int r = 0; r < comm->nRanks; r++) {
         if (r != comm->rank && allCounts[r] > 0) {
-          ret = bootstrapRecv(comm->bootstrap, r, 0xFEED,
-                              allInfos + offsets[r],
+          ret = bootstrapRecv(comm->bootstrap, r, 0xFEED, allInfos + offsets[r],
                               allCounts[r] * sizeof(ncclDynMemP2pHandleInfo));
           if (ret != ncclSuccess) {
             WARN("MemManager: Recv from rank %d failed - handle exchange incomplete", r);
@@ -891,8 +868,7 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
       if (allInfos != nullptr) {
         for (int i = 0; i < totalInfoCount; i++) {
           if (allInfos[i].ownerRank == entry->desc.imported.ownerRank &&
-              allInfos[i].ptr == entry->desc.imported.ownerPtr &&
-              allInfos[i].size == entry->size) {
+              allInfos[i].ptr == entry->desc.imported.ownerPtr && allInfos[i].size == entry->size) {
             matchedInfo = &allInfos[i];
             break;
           }
@@ -900,16 +876,16 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
       }
 
       if (matchedInfo == nullptr) {
-        WARN("MemManager: Could not find matching handle info for ptr=%p from rank %d",
-             entry->ptr, entry->desc.imported.ownerRank);
+        WARN("MemManager: Could not find matching handle info for ptr=%p from rank %d", entry->ptr,
+             entry->desc.imported.ownerRank);
         // RCCL: surface partial-failure so released stays 1 below
         if (ret == ncclSuccess) ret = ncclSystemError;
         entry = entry->next;
         continue;
       }
 
-      TRACE(NCCL_ALLOC, "MemManager: Re-importing peer buffer ptr=%p from rank %d (owner ptr=%p)",
-            entry->ptr, entry->desc.imported.ownerRank, matchedInfo->ptr);
+      TRACE(NCCL_ALLOC, "MemManager: Re-importing peer buffer ptr=%p from rank %d (owner ptr=%p)", entry->ptr,
+            entry->desc.imported.ownerRank, matchedInfo->ptr);
 
       CUmemGenericAllocationHandle newHandle;
       CUresult curet;
@@ -933,11 +909,9 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
         // a prior partial-failure ret set earlier in the loop
         // The handleData contains the cuMem handle - request FD conversion
         ncclResult_t fdRet =
-          ncclProxyClientGetFdBlocking(comm, entry->desc.imported.ownerRank,
-                                       &matchedInfo->handleData, &fd);
+          ncclProxyClientGetFdBlocking(comm, entry->desc.imported.ownerRank, &matchedInfo->handleData, &fd);
         if (fdRet != ncclSuccess || fd < 0) {
-          WARN("MemManager: Failed to get FD from rank %d for ptr=%p",
-               entry->desc.imported.ownerRank, entry->ptr);
+          WARN("MemManager: Failed to get FD from rank %d for ptr=%p", entry->desc.imported.ownerRank, entry->ptr);
           if (ret == ncclSuccess) {
             ret = (fdRet != ncclSuccess) ? fdRet : ncclSystemError;
           }
@@ -946,12 +920,12 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
         }
 
         curet = CUPFN(cuMemImportFromShareableHandle(&newHandle, (void*)(uintptr_t)fd,
-                                                CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR));
+                                                     CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR));
         close(fd);
       } else if (matchedInfo->handleType == CU_MEM_HANDLE_TYPE_FABRIC) {
         // For FABRIC: Import directly using the fabric handle
-        curet = CUPFN(cuMemImportFromShareableHandle(&newHandle, &matchedInfo->fabricHandle,
-                                                CU_MEM_HANDLE_TYPE_FABRIC));
+        curet =
+          CUPFN(cuMemImportFromShareableHandle(&newHandle, &matchedInfo->fabricHandle, CU_MEM_HANDLE_TYPE_FABRIC));
       } else {
         WARN("MemManager: Unknown handle type %d for peer import", matchedInfo->handleType);
         if (ret == ncclSuccess) ret = ncclInvalidUsage;
@@ -960,8 +934,7 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
       }
 
       if (curet != CUDA_SUCCESS) {
-        WARN("MemManager: cuMemImportFromShareableHandle failed for ptr=%p (curet=%d)",
-             entry->ptr, curet);
+        WARN("MemManager: cuMemImportFromShareableHandle failed for ptr=%p (curet=%d)", entry->ptr, curet);
         if (ret == ncclSuccess) ret = ncclUnhandledCudaError;
         entry = entry->next;
         continue;
@@ -983,15 +956,15 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
       restoredPeerCount++;
       restoredPeerBytes += entry->size;
 
-      TRACE(NCCL_ALLOC, "MemManager: Successfully re-imported peer buffer ptr=%p from rank %d",
-            entry->ptr, entry->desc.imported.ownerRank);
+      TRACE(NCCL_ALLOC, "MemManager: Successfully re-imported peer buffer ptr=%p from rank %d", entry->ptr,
+            entry->desc.imported.ownerRank);
     }
     entry = entry->next;
   }
 
   // RCCL: only flip released back to 0 when every entry was restored. Each
   // failing peer-import branch above leaves the entry in ncclDynMemStateReleased
-  if(ret == ncclSuccess) {
+  if (ret == ncclSuccess) {
     __atomic_store_n(&manager->released, 0, __ATOMIC_RELEASE);
   } else {
     WARN("MemManager: rank %d Resume completed with errors "
@@ -1003,10 +976,9 @@ ncclResult_t ncclCommMemResume(struct ncclComm* comm) {
 
   // Final barrier to ensure all ranks have completed peer import setup
   if (comm->bootstrap != nullptr) {
-    INFO(NCCL_ALLOC, "MemManager: rank %d resumed %d local + %d peer entries (%zu + %zu bytes)",
-         comm->rank, restoredLocalCount, restoredPeerCount, restoredLocalBytes, restoredPeerBytes);
-    ncclResult_t barrierRet = bootstrapBarrier(comm->bootstrap, comm->rank, 
-                                               comm->nRanks, 0xCAFE);
+    INFO(NCCL_ALLOC, "MemManager: rank %d resumed %d local + %d peer entries (%zu + %zu bytes)", comm->rank,
+         restoredLocalCount, restoredPeerCount, restoredLocalBytes, restoredPeerBytes);
+    ncclResult_t barrierRet = bootstrapBarrier(comm->bootstrap, comm->rank, comm->nRanks, 0xCAFE);
     if (barrierRet != ncclSuccess) {
       if (ret == ncclSuccess) ret = barrierRet;
       // Cleanup
@@ -1066,15 +1038,13 @@ ncclResult_t ncclCommSuspend_impl(ncclComm_t comm, int flags) {
       goto fail;
     }
     if (comm->memManager && comm->memManager->refCount > 1) {
-      WARN("Memory suspend not supported with split_share communicators (refCount=%d)",
-           comm->memManager->refCount);
+      WARN("Memory suspend not supported with split_share communicators (refCount=%d)", comm->memManager->refCount);
       ret = ncclInvalidUsage;
       goto fail;
     }
     // RCCL: reject double-Suspend. Queue-aware: pending Resume in
     // resumeTaskQueue will flip released=0 during drain, so accept it.
-    if (comm->memManager &&
-        __atomic_load_n(&comm->memManager->released, __ATOMIC_ACQUIRE) &&
+    if (comm->memManager && __atomic_load_n(&comm->memManager->released, __ATOMIC_ACQUIRE) &&
         ncclIntruQueueEmpty(&comm->resumeTaskQueue)) {
       WARN("ncclCommSuspend: rank %d already suspended", comm->rank);
       ret = ncclInvalidUsage;
@@ -1091,7 +1061,9 @@ ncclResult_t ncclCommSuspend_impl(ncclComm_t comm, int flags) {
 exit:
   ncclGroupErrCheck(ret);
   NCCLCHECK(ncclGroupEndInternal());
-  if (comm && !comm->config.blocking) { NCCLCHECK(ncclCommGetAsyncError(comm, &ret)); }
+  if (comm && !comm->config.blocking) {
+    NCCLCHECK(ncclCommGetAsyncError(comm, &ret));
+  }
   CUDACHECK(cudaSetDevice(saveDev));
   return ret;
 fail:
@@ -1116,15 +1088,13 @@ ncclResult_t ncclCommResume_impl(ncclComm_t comm) {
     goto fail;
   }
   if (comm->memManager && comm->memManager->refCount > 1) {
-    WARN("Memory resume not supported with split_share communicators (refCount=%d)",
-         comm->memManager->refCount);
+    WARN("Memory resume not supported with split_share communicators (refCount=%d)", comm->memManager->refCount);
     ret = ncclInvalidUsage;
     goto fail;
   }
   // RCCL: reject Resume on active comm. Queue-aware: pending Suspend in
   // suspendTaskQueue will flip released=1 during drain, so accept it.
-  if (comm->memManager &&
-      !__atomic_load_n(&comm->memManager->released, __ATOMIC_ACQUIRE) &&
+  if (comm->memManager && !__atomic_load_n(&comm->memManager->released, __ATOMIC_ACQUIRE) &&
       ncclIntruQueueEmpty(&comm->suspendTaskQueue)) {
     WARN("ncclCommResume: rank %d not suspended", comm->rank);
     ret = ncclInvalidUsage;
@@ -1140,7 +1110,9 @@ ncclResult_t ncclCommResume_impl(ncclComm_t comm) {
 exit:
   ncclGroupErrCheck(ret);
   NCCLCHECK(ncclGroupEndInternal());
-  if (comm && !comm->config.blocking) { NCCLCHECK(ncclCommGetAsyncError(comm, &ret)); }
+  if (comm && !comm->config.blocking) {
+    NCCLCHECK(ncclCommGetAsyncError(comm, &ret));
+  }
   CUDACHECK(cudaSetDevice(saveDev));
   return ret;
 fail:
@@ -1166,23 +1138,23 @@ ncclResult_t ncclCommMemStats_impl(ncclComm_t comm, ncclCommMemStat_t stat, uint
 
   ncclMemManager* manager = comm->memManager;
   switch (stat) {
-    case ncclStatGpuMemTotal:
-      *value = COMPILER_ATOMIC_LOAD(&manager->totalPersist, std::memory_order_relaxed) +
-               COMPILER_ATOMIC_LOAD(&manager->totalScratch, std::memory_order_relaxed) +
-               COMPILER_ATOMIC_LOAD(&manager->totalOffload, std::memory_order_relaxed);
-      return ncclSuccess;
-    case ncclStatGpuMemPersist:
-      *value = COMPILER_ATOMIC_LOAD(&manager->totalPersist, std::memory_order_relaxed);
-      return ncclSuccess;
-    case ncclStatGpuMemSuspend:
-      *value = COMPILER_ATOMIC_LOAD(&manager->totalScratch, std::memory_order_relaxed) +
-               COMPILER_ATOMIC_LOAD(&manager->totalOffload, std::memory_order_relaxed);
-      return ncclSuccess;
-    case ncclStatGpuMemSuspended:
+  case ncclStatGpuMemTotal:
+    *value = COMPILER_ATOMIC_LOAD(&manager->totalPersist, std::memory_order_relaxed) +
+             COMPILER_ATOMIC_LOAD(&manager->totalScratch, std::memory_order_relaxed) +
+             COMPILER_ATOMIC_LOAD(&manager->totalOffload, std::memory_order_relaxed);
+    return ncclSuccess;
+  case ncclStatGpuMemPersist:
+    *value = COMPILER_ATOMIC_LOAD(&manager->totalPersist, std::memory_order_relaxed);
+    return ncclSuccess;
+  case ncclStatGpuMemSuspend:
+    *value = COMPILER_ATOMIC_LOAD(&manager->totalScratch, std::memory_order_relaxed) +
+             COMPILER_ATOMIC_LOAD(&manager->totalOffload, std::memory_order_relaxed);
+    return ncclSuccess;
+  case ncclStatGpuMemSuspended:
       // Boolean: 0=active, 1=suspended
-      *value = __atomic_load_n(&manager->released, __ATOMIC_ACQUIRE) ? 1 : 0;
-      return ncclSuccess;
-    default:
-      return ncclInvalidArgument;
+    *value = __atomic_load_n(&manager->released, __ATOMIC_ACQUIRE) ? 1 : 0;
+    return ncclSuccess;
+  default:
+    return ncclInvalidArgument;
   }
 }

--- a/projects/rccl/src/misc/alt_rsmi.cc
+++ b/projects/rccl/src/misc/alt_rsmi.cc
@@ -25,28 +25,28 @@
 #include "alt_rsmi.h"
 #include "debug.h"
 
-static int ARSMI_readDeviceProperties(uint32_t node_id, std::map<std::string, uint64_t> &retVec);
-static int ARSMI_readLinkProperties(uint32_t node_id, uint32_t target_id, std::map<std::string, uint64_t> &retVec);
-static int read_node_properties(uint32_t node, std::string property_name, uint64_t *val,
-                                std::map<std::string, uint64_t> &properties);
-static int read_link_properties(uint32_t node, uint32_t target, std::string property_name, uint64_t *val,
-                                std::map<std::string, uint64_t> &properties);
+static int ARSMI_readDeviceProperties(uint32_t node_id, std::map<std::string, uint64_t>& retVec);
+static int ARSMI_readLinkProperties(uint32_t node_id, uint32_t target_id, std::map<std::string, uint64_t>& retVec);
+static int read_node_properties(uint32_t node, std::string property_name, uint64_t* val,
+                                std::map<std::string, uint64_t>& properties);
+static int read_link_properties(uint32_t node, uint32_t target, std::string property_name, uint64_t* val,
+                                std::map<std::string, uint64_t>& properties);
 static int getNodeIndex(uint32_t node_id);
-static int getGpuId(uint32_t node, uint64_t *gpu_id);
+static int getGpuId(uint32_t node, uint64_t* gpu_id);
 static int countIoLinks(uint32_t dev_id);
 
 struct ARSMI_systemNode {
-    uint32_t s_node_id = 0;
-    uint64_t s_gpu_id = 0;
-    uint64_t s_unique_id = 0;
-    uint64_t s_location_id = 0;
-    uint64_t s_bdf = 0;
-    uint64_t s_domain = 0;
-    uint8_t  s_bus = 0;
-    uint8_t  s_device = 0;
-    uint8_t  s_function = 0;
-    uint8_t  s_partition_id = 0;
-    std::string s_card;
+  uint32_t s_node_id = 0;
+  uint64_t s_gpu_id = 0;
+  uint64_t s_unique_id = 0;
+  uint64_t s_location_id = 0;
+  uint64_t s_bdf = 0;
+  uint64_t s_domain = 0;
+  uint8_t s_bus = 0;
+  uint8_t s_device = 0;
+  uint8_t s_function = 0;
+  uint8_t s_partition_id = 0;
+  std::string s_card;
 };
 
 // Internal implementation details
@@ -55,14 +55,14 @@ struct ARSMI_systemNode {
 // When compiled into the production library (ARSMI_TEST_BUILD not defined), these are static.
 #ifdef ARSMI_TEST_BUILD
   // Test build: external linkage for cross-TU access
-  #define ARSMI_LOCAL thread_local
+#define ARSMI_LOCAL thread_local
 #else
   // Production build: static/internal linkage
-  #define ARSMI_LOCAL static thread_local
+#define ARSMI_LOCAL static thread_local
 #endif
 
-ARSMI_LOCAL const char *kKFDNodesPathRoot = "/sys/class/kfd/kfd/topology/nodes";
-ARSMI_LOCAL const char *kDrmClassRoot = "/sys/class/drm";
+ARSMI_LOCAL const char* kKFDNodesPathRoot = "/sys/class/kfd/kfd/topology/nodes";
+ARSMI_LOCAL const char* kDrmClassRoot = "/sys/class/drm";
 static const uint32_t kAmdGpuId = 0x1002;
 
 // Vector containing data about each node, ordered by bdf ID
@@ -72,329 +72,308 @@ ARSMI_LOCAL std::vector<ARSMI_systemNode> ARSMI_orderedNodes;
 ARSMI_LOCAL std::vector<std::vector<ARSMI_linkInfo>> ARSMI_orderedLinks;
 
 // Number of devices recognized
-ARSMI_LOCAL int ARSMI_num_devices=-1;
+ARSMI_LOCAL int ARSMI_num_devices = -1;
 
 // Public API functions
-int ARSMI_init(void)
-{
-    std::string err_msg;
-    std::multimap<uint64_t, ARSMI_systemNode> ARSMI_allSystemNodes;
+int ARSMI_init(void) {
+  std::string err_msg;
+  std::multimap<uint64_t, ARSMI_systemNode> ARSMI_allSystemNodes;
 
-    if (ARSMI_num_devices > 0) {
+  if (ARSMI_num_devices > 0) {
         // has already been initialized
-        return 0;
+    return 0;
+  }
+
+  auto node_dir = opendir(kKFDNodesPathRoot);
+  if (node_dir == nullptr) {
+    WARN("Failed to open topo/nodes directory ");
+    return 1;
+  }
+  auto dentry = readdir(node_dir);
+
+  while (dentry != nullptr) {
+    uint64_t gpu_id = 0, unique_id = 0, location_id = 0, domain = 0;
+    uint64_t vendor_id = 0;
+    if ((strcmp(dentry->d_name, ".") == 0) || (strcmp(dentry->d_name, "..") == 0)) {
+      dentry = readdir(node_dir);
+      continue;
     }
 
-    auto node_dir = opendir(kKFDNodesPathRoot);
-    if (node_dir == nullptr) {
-        WARN("Failed to open topo/nodes directory ");
-        return 1;
-    }
-    auto dentry = readdir(node_dir);
+    uint32_t node_id = std::stoi(dentry->d_name);
 
-    while (dentry != nullptr) {
-        uint64_t gpu_id = 0, unique_id = 0, location_id = 0, domain = 0;
-        uint64_t vendor_id = 0;
-        if ((strcmp(dentry->d_name, ".") == 0) ||
-            (strcmp(dentry->d_name, "..") == 0)) {
-            dentry = readdir(node_dir);
-            continue;
-        }
+    std::map<std::string, uint64_t> properties;
+    ARSMI_readDeviceProperties(node_id, properties);
 
-        uint32_t node_id = std::stoi(dentry->d_name);
+    int ret_gpu_id = getGpuId(node_id, &gpu_id);
 
-        std::map<std::string, uint64_t> properties;
-        ARSMI_readDeviceProperties(node_id, properties);
-
-        int ret_gpu_id = getGpuId(node_id, &gpu_id);
-
-        int ret_unique_id = read_node_properties(node_id, "unique_id", &unique_id, properties);
-        int ret_loc_id = read_node_properties(node_id, "location_id", &location_id, properties);
-        int ret_domain = read_node_properties(node_id, "domain", &domain, properties);
-        int ret_vendor = read_node_properties(node_id, "vendor_id", &vendor_id, properties);
-        if (ret_gpu_id == 0 &&  !(ret_unique_id != 0 || ret_loc_id != 0 || ret_domain != 0 || ret_vendor != 0) &&
-            (gpu_id != 0) && (vendor_id == kAmdGpuId)) {
+    int ret_unique_id = read_node_properties(node_id, "unique_id", &unique_id, properties);
+    int ret_loc_id = read_node_properties(node_id, "location_id", &location_id, properties);
+    int ret_domain = read_node_properties(node_id, "domain", &domain, properties);
+    int ret_vendor = read_node_properties(node_id, "vendor_id", &vendor_id, properties);
+    if (ret_gpu_id == 0 && !(ret_unique_id != 0 || ret_loc_id != 0 || ret_domain != 0 || ret_vendor != 0) &&
+        (gpu_id != 0) && (vendor_id == kAmdGpuId)) {
             // Do not try to build a node if one of these fields
             // do not exist in KFD (0 as values okay)
-            ARSMI_systemNode myNode;
-            myNode.s_node_id = node_id;
-            myNode.s_gpu_id = gpu_id;
-            myNode.s_unique_id = unique_id;
-            myNode.s_location_id = location_id;
-            myNode.s_domain = domain & 0xFFFFFFFF;
-            myNode.s_bdf = (myNode.s_domain << 32) | (myNode.s_location_id);
-            myNode.s_location_id = myNode.s_bdf;
-            myNode.s_bdf |= ((domain & 0xFFFFFFFF) << 32);
-            myNode.s_location_id = myNode.s_bdf;
-            myNode.s_domain = myNode.s_location_id >> 32;
-            myNode.s_bus = ((myNode.s_location_id >> 8) & 0xFF);
-            myNode.s_device = ((myNode.s_location_id >> 3) & 0x1F);
-            myNode.s_function = myNode.s_location_id & 0x7;
-            myNode.s_partition_id = ((myNode.s_location_id >> 28) & 0xF);
+      ARSMI_systemNode myNode;
+      myNode.s_node_id = node_id;
+      myNode.s_gpu_id = gpu_id;
+      myNode.s_unique_id = unique_id;
+      myNode.s_location_id = location_id;
+      myNode.s_domain = domain & 0xFFFFFFFF;
+      myNode.s_bdf = (myNode.s_domain << 32) | (myNode.s_location_id);
+      myNode.s_location_id = myNode.s_bdf;
+      myNode.s_bdf |= ((domain & 0xFFFFFFFF) << 32);
+      myNode.s_location_id = myNode.s_bdf;
+      myNode.s_domain = myNode.s_location_id >> 32;
+      myNode.s_bus = ((myNode.s_location_id >> 8) & 0xFF);
+      myNode.s_device = ((myNode.s_location_id >> 3) & 0x1F);
+      myNode.s_function = myNode.s_location_id & 0x7;
+      myNode.s_partition_id = ((myNode.s_location_id >> 28) & 0xF);
 
-            ARSMI_allSystemNodes.emplace(unique_id, myNode);
-        }
-
-        dentry = readdir(node_dir);
+      ARSMI_allSystemNodes.emplace(unique_id, myNode);
     }
 
-    ARSMI_num_devices = ARSMI_allSystemNodes.size();
+    dentry = readdir(node_dir);
+  }
 
-    for (auto i : ARSMI_allSystemNodes) {
-        std::ostringstream ss;
-        ss << "[node_id = " << std::to_string(i.second.s_node_id)
-           << "; gpu_id = " << std::to_string(i.second.s_gpu_id)
-           << "; unique_id = " << std::to_string(i.second.s_unique_id)
-           << "; location_id = " << std::to_string(i.second.s_location_id)
-           << "; bdf = " << std::to_string(i.second.s_bdf)
-           << "; domain = " << std::to_string(i.second.s_domain)
-           << "; partition = " << std::to_string(i.second.s_partition_id)
-           << "], ";
-        std::string tempstr = ss.str();
-        INFO(NCCL_INIT, "%s", tempstr.c_str());
-    }
+  ARSMI_num_devices = ARSMI_allSystemNodes.size();
 
-    if (closedir(node_dir)) {
-        WARN("Failed to close topology/node root directory");
-        return 1;
-    }
+  for (auto i : ARSMI_allSystemNodes) {
+    std::ostringstream ss;
+    ss << "[node_id = " << std::to_string(i.second.s_node_id) << "; gpu_id = " << std::to_string(i.second.s_gpu_id)
+       << "; unique_id = " << std::to_string(i.second.s_unique_id)
+       << "; location_id = " << std::to_string(i.second.s_location_id) << "; bdf = " << std::to_string(i.second.s_bdf)
+       << "; domain = " << std::to_string(i.second.s_domain)
+       << "; partition = " << std::to_string(i.second.s_partition_id) << "], ";
+    std::string tempstr = ss.str();
+    INFO(NCCL_INIT, "%s", tempstr.c_str());
+  }
+
+  if (closedir(node_dir)) {
+    WARN("Failed to close topology/node root directory");
+    return 1;
+  }
 
     // Sort devices found. For this we need to group all devices
     // having the same unique_id, sort all devices with the same
     // unique_id by there bdf value. In addition, the groups
     // of devices with the same unique_id are sorted by
     // lowest bdf value among each others.
-    std::vector<uint64_t> already_seen;
-    std::vector<std::vector<ARSMI_systemNode>> sort_vecs;
-    int elem=0;
-    for (auto i : ARSMI_allSystemNodes) {
-        auto device_uuid = i.second.s_unique_id;
+  std::vector<uint64_t> already_seen;
+  std::vector<std::vector<ARSMI_systemNode>> sort_vecs;
+  int elem = 0;
+  for (auto i : ARSMI_allSystemNodes) {
+    auto device_uuid = i.second.s_unique_id;
 
-        if ( std::find(already_seen.begin(), already_seen.end(), device_uuid) == already_seen.end()) {
-            auto range = ARSMI_allSystemNodes.equal_range(device_uuid);
+    if (std::find(already_seen.begin(), already_seen.end(), device_uuid) == already_seen.end()) {
+      auto range = ARSMI_allSystemNodes.equal_range(device_uuid);
 
-            sort_vecs.resize(sort_vecs.size()+1);
-            for (auto j = range.first; j != range.second ; j++) {
-                sort_vecs[elem].push_back(j->second);
-            }
-            already_seen.push_back(device_uuid);
-            elem++;
-        }
+      sort_vecs.resize(sort_vecs.size() + 1);
+      for (auto j = range.first; j != range.second; j++) {
+        sort_vecs[elem].push_back(j->second);
+      }
+      already_seen.push_back(device_uuid);
+      elem++;
     }
+  }
 
-    //Sort each subvector
-    for (auto i = 0; i < sort_vecs.size(); i++) {
-        std::sort(sort_vecs[i].begin(), sort_vecs[i].end(), []
-                  (const ARSMI_systemNode &p1, const ARSMI_systemNode &p2) {
-                      return p1.s_bdf < p2.s_bdf;
-                  });
-    }
+    // Sort each subvector
+  for (auto i = 0; i < sort_vecs.size(); i++) {
+    std::sort(sort_vecs[i].begin(), sort_vecs[i].end(),
+              [](const ARSMI_systemNode& p1, const ARSMI_systemNode& p2) { return p1.s_bdf < p2.s_bdf; });
+  }
 
     // Copy the first element for every uuid into the first_elem vector
-    std::vector<uint64_t> first_elem;
-    for (auto i=0; i < sort_vecs.size(); i++) {
-        first_elem.push_back(sort_vecs[i][0].s_bdf);
-    }
-    std::sort (first_elem.begin(), first_elem.end(), []
-               (const uint64_t &p1, const uint64_t &p2) {
-                   return p1 < p2;
-               });
+  std::vector<uint64_t> first_elem;
+  for (auto i = 0; i < sort_vecs.size(); i++) {
+    first_elem.push_back(sort_vecs[i][0].s_bdf);
+  }
+  std::sort(first_elem.begin(), first_elem.end(), [](const uint64_t& p1, const uint64_t& p2) { return p1 < p2; });
 
     // Copy all elements of the sort_vecs subarrays into
     // ordered_nodes, with the sorted first_elem vector indicating
     // the order of each block.
-    for (auto i=0; i < first_elem.size(); i++) {
+  for (auto i = 0; i < first_elem.size(); i++) {
         // Find the first_elem[i] in sort_vecs in
-        for (auto j = 0; j < sort_vecs.size(); j++ ) {
-            if (first_elem[i] == sort_vecs[j][0].s_bdf) {
-                for (auto k=0; k<sort_vecs[j].size(); k++) {
-                    ARSMI_orderedNodes.push_back(sort_vecs[j][k]);
-                }
-                break;
-            }
+    for (auto j = 0; j < sort_vecs.size(); j++) {
+      if (first_elem[i] == sort_vecs[j][0].s_bdf) {
+        for (auto k = 0; k < sort_vecs[j].size(); k++) {
+          ARSMI_orderedNodes.push_back(sort_vecs[j][k]);
         }
+        break;
+      }
     }
+  }
 
     // Part 2: generate Link Matrix
-    ARSMI_orderedLinks.resize(ARSMI_num_devices);
-    for (int i=0; i<ARSMI_num_devices; i++) {
-        ARSMI_orderedLinks[i].resize(ARSMI_num_devices);
-        for (int j = 0; j < ARSMI_num_devices; j++) {
-            ARSMI_orderedLinks[i][j].src_node = std::numeric_limits<unsigned>::max();
-            ARSMI_orderedLinks[i][j].dst_node = std::numeric_limits<unsigned>::max();
-        }
+  ARSMI_orderedLinks.resize(ARSMI_num_devices);
+  for (int i = 0; i < ARSMI_num_devices; i++) {
+    ARSMI_orderedLinks[i].resize(ARSMI_num_devices);
+    for (int j = 0; j < ARSMI_num_devices; j++) {
+      ARSMI_orderedLinks[i][j].src_node = std::numeric_limits<unsigned>::max();
+      ARSMI_orderedLinks[i][j].dst_node = std::numeric_limits<unsigned>::max();
     }
+  }
 
-    for (int src_idx = 0; src_idx < ARSMI_num_devices; src_idx++) {
-        struct ARSMI_systemNode node = ARSMI_orderedNodes[src_idx];
-        uint32_t src_id = node.s_node_id, nlinks = countIoLinks(src_id);
-        for (int i = 0; i < nlinks; i++) {
-            ARSMI_linkInfo info;
-            std::map<std::string, uint64_t> properties;
-            int ret = ARSMI_readLinkProperties(src_id, i, properties);
-            if (ret != 0){
-                continue;
-            }
+  for (int src_idx = 0; src_idx < ARSMI_num_devices; src_idx++) {
+    struct ARSMI_systemNode node = ARSMI_orderedNodes[src_idx];
+    uint32_t src_id = node.s_node_id, nlinks = countIoLinks(src_id);
+    for (int i = 0; i < nlinks; i++) {
+      ARSMI_linkInfo info;
+      std::map<std::string, uint64_t> properties;
+      int ret = ARSMI_readLinkProperties(src_id, i, properties);
+      if (ret != 0) {
+        continue;
+      }
 
-            uint64_t type;
-            uint64_t weight;
-            uint64_t min_bandwidth;
-            uint64_t max_bandwidth;
-            uint64_t dst_id;
+      uint64_t type;
+      uint64_t weight;
+      uint64_t min_bandwidth;
+      uint64_t max_bandwidth;
+      uint64_t dst_id;
 
-            int ret_target = read_link_properties(src_id, i, "node_to", &dst_id, properties);
-            if (ret_target != 0) {
-                continue;
-            }
-            int dst_idx = getNodeIndex(dst_id);
-            if (dst_idx == -1) {
+      int ret_target = read_link_properties(src_id, i, "node_to", &dst_id, properties);
+      if (ret_target != 0) {
+        continue;
+      }
+      int dst_idx = getNodeIndex(dst_id);
+      if (dst_idx == -1) {
                 // Not all GPUs might be directly connected to all other GPUs.
                 // Will set default values in the topo_get_link_info function.
-                continue;
-            }
-            info.src_node = src_id;
-            info.dst_node = dst_id;
+        continue;
+      }
+      info.src_node = src_id;
+      info.dst_node = dst_id;
 
-            int ret_weight = read_link_properties(src_id, i, "weight", &weight, properties);
-            if (ret_weight != 0) {
-                WARN("Error reading link properties files");
-                return 1;
-            }
-            info.weight = weight;
+      int ret_weight = read_link_properties(src_id, i, "weight", &weight, properties);
+      if (ret_weight != 0) {
+        WARN("Error reading link properties files");
+        return 1;
+      }
+      info.weight = weight;
 
-            int ret_type = read_link_properties(src_id, i, "type", &type, properties);
-            if (ret_type != 0) {
-                WARN("Error reading link properties files");
-                return 1;
-            }
-            if (type == 11){
-                info.type = ARSMI_IOLINK_TYPE_XGMI;
-                info.hops = 1;
-            }
-            else if (type == 2) {
-                info.type = ARSMI_IOLINK_TYPE_PCIEXPRESS;
+      int ret_type = read_link_properties(src_id, i, "type", &type, properties);
+      if (ret_type != 0) {
+        WARN("Error reading link properties files");
+        return 1;
+      }
+      if (type == 11) {
+        info.type = ARSMI_IOLINK_TYPE_XGMI;
+        info.hops = 1;
+      } else if (type == 2) {
+        info.type = ARSMI_IOLINK_TYPE_PCIEXPRESS;
                 // hard coding for now to 2
-                info.hops = 2;
-            }
-            else {
-                info.type = ARSMI_IOLINK_TYPE_UNDEFINED;
-                info.hops = 0;
-            }
+        info.hops = 2;
+      } else {
+        info.type = ARSMI_IOLINK_TYPE_UNDEFINED;
+        info.hops = 0;
+      }
 
-            int ret_min_bw = read_link_properties(src_id, i, "min_bandwidth", &min_bandwidth, properties);
-            if (ret_min_bw != 0) {
-                WARN("Error reading link properties files");
-                return 1;
-            }
-            info.min_bandwidth = min_bandwidth;
+      int ret_min_bw = read_link_properties(src_id, i, "min_bandwidth", &min_bandwidth, properties);
+      if (ret_min_bw != 0) {
+        WARN("Error reading link properties files");
+        return 1;
+      }
+      info.min_bandwidth = min_bandwidth;
 
-            int ret_max_bw = read_link_properties(src_id, i, "max_bandwidth", &max_bandwidth, properties);
-            if (ret_max_bw != 0) {
-                return 1;
-            }
-            info.max_bandwidth = max_bandwidth;
+      int ret_max_bw = read_link_properties(src_id, i, "max_bandwidth", &max_bandwidth, properties);
+      if (ret_max_bw != 0) {
+        return 1;
+      }
+      info.max_bandwidth = max_bandwidth;
 
-            ARSMI_orderedLinks[src_idx][dst_idx] = info;
-        }
+      ARSMI_orderedLinks[src_idx][dst_idx] = info;
     }
+  }
 
-    return 0;
+  return 0;
 }
 
+int ARSMI_get_num_devices(uint32_t* num_devices) {
+  int res = 0;
 
-int ARSMI_get_num_devices (uint32_t *num_devices)
-{
-    int res = 0;
+  if (ARSMI_num_devices < 0) {
+    res = ARSMI_init();
+  }
 
-    if (ARSMI_num_devices < 0) {
-        res = ARSMI_init();
-    }
-
-    *num_devices = ARSMI_num_devices;
-    return res;
+  *num_devices = ARSMI_num_devices;
+  return res;
 }
 
-int ARSMI_dev_pci_id_get(uint32_t dv_ind, uint64_t *bdfid)
-{
-    if (bdfid == nullptr) {
-        return EINVAL;
+int ARSMI_dev_pci_id_get(uint32_t dv_ind, uint64_t* bdfid) {
+  if (bdfid == nullptr) {
+    return EINVAL;
+  }
+
+  if (ARSMI_num_devices < 0) {
+    int res = ARSMI_init();
+    if (res != 0) {
+      return res;
     }
+  }
 
-    if (ARSMI_num_devices < 0) {
-        int res = ARSMI_init();
-        if (res != 0) {
-            return res;
-        }
-    }
+  *bdfid = ARSMI_orderedNodes[dv_ind].s_bdf;
 
-    *bdfid = ARSMI_orderedNodes[dv_ind].s_bdf;
-
-    return 0;
+  return 0;
 }
 
+int ARSMI_topo_get_link_info(uint32_t dv_ind_src, uint32_t dv_ind_dst, ARSMI_linkInfo* info) {
+  if (info == nullptr) {
+    return EINVAL;
+  }
 
-int ARSMI_topo_get_link_info(uint32_t dv_ind_src, uint32_t dv_ind_dst,
-                             ARSMI_linkInfo *info)
-{
-    if (info == nullptr) {
-        return EINVAL;
+  if (ARSMI_num_devices < 0) {
+    int res = ARSMI_init();
+    if (res != 0) {
+      return res;
     }
+  }
 
-    if (ARSMI_num_devices < 0) {
-        int res = ARSMI_init();
-        if (res != 0) {
-            return res;
-        }
-    }
+  if (dv_ind_src < 0 || dv_ind_src > ARSMI_num_devices) {
+    return EINVAL;
+  }
+  if (dv_ind_dst < 0 || dv_ind_dst > ARSMI_num_devices) {
+    return EINVAL;
+  }
 
-    if (dv_ind_src < 0 || dv_ind_src > ARSMI_num_devices) {
-        return EINVAL;
-    }
-    if (dv_ind_dst < 0 || dv_ind_dst > ARSMI_num_devices) {
-        return EINVAL;
-    }
+  uint32_t src_id = ARSMI_orderedNodes[dv_ind_src].s_node_id;
+  uint32_t dst_id = ARSMI_orderedNodes[dv_ind_dst].s_node_id;
 
-    uint32_t src_id = ARSMI_orderedNodes[dv_ind_src].s_node_id;
-    uint32_t dst_id = ARSMI_orderedNodes[dv_ind_dst].s_node_id;
-
-    ARSMI_linkInfo tinfo = ARSMI_orderedLinks[dv_ind_src][dv_ind_dst];
-    if (tinfo.src_node != src_id || tinfo.dst_node != dst_id) {
+  ARSMI_linkInfo tinfo = ARSMI_orderedLinks[dv_ind_src][dv_ind_dst];
+  if (tinfo.src_node != src_id || tinfo.dst_node != dst_id) {
         // Setting  default values.
-        tinfo.hops = 2;
-        tinfo.type = ARSMI_IOLINK_TYPE_PCIEXPRESS;
-        tinfo.weight = 40;
-        tinfo.min_bandwidth = 0;
-        tinfo.max_bandwidth = 0;
-    }
-    *info = tinfo;
+    tinfo.hops = 2;
+    tinfo.type = ARSMI_IOLINK_TYPE_PCIEXPRESS;
+    tinfo.weight = 40;
+    tinfo.min_bandwidth = 0;
+    tinfo.max_bandwidth = 0;
+  }
+  *info = tinfo;
 
-    return 0;
+  return 0;
 }
 
-int ARSMI_get_fw_version(uint32_t /*dv_ind*/, uint64_t *fw_version)
-{
-    if (fw_version == nullptr) return EINVAL;
+int ARSMI_get_fw_version(uint32_t /*dv_ind*/, uint64_t* fw_version) {
+  if (fw_version == nullptr) return EINVAL;
     // We assume that all GPUs on the system run the same firmware image.
     // dv_ind is accepted for API consistency with the amdsmi path but is not
     // used: MEC firmware is a system-wide property loaded once by the driver.
     // Search all DRM cards for a readable sysfs entry rather than mapping
     // dv_ind to a specific card — card0 is not guaranteed to expose it.
-    constexpr uint32_t maxCards = 128;
-    *fw_version = 0;
-    for (uint32_t card = 0; card < maxCards; card++) {
-        char path[256];
-        snprintf(path, sizeof(path),
-                 "%s/card%u/device/fw_version/mec_fw_version", kDrmClassRoot, card);
-        FILE *fp = fopen(path, "r");
-        if (fp != nullptr) {
-            char line[64];
-            if (fgets(line, sizeof(line), fp) != nullptr)
-                *fw_version = strtoull(line, nullptr, 16);
-            fclose(fp);
-            return 0;
-        }
+  constexpr uint32_t maxCards = 128;
+  *fw_version = 0;
+  for (uint32_t card = 0; card < maxCards; card++) {
+    char path[256];
+    snprintf(path, sizeof(path), "%s/card%u/device/fw_version/mec_fw_version", kDrmClassRoot, card);
+    FILE* fp = fopen(path, "r");
+    if (fp != nullptr) {
+      char line[64];
+      if (fgets(line, sizeof(line), fp) != nullptr) *fw_version = strtoull(line, nullptr, 16);
+      fclose(fp);
+      return 0;
     }
-    return 0;  // not found is not an error; caller receives 0
+  }
+  return 0;  // not found is not an error; caller receives 0
 }
 
 // ---------------------------------------------------------------------------
@@ -403,494 +382,461 @@ int ARSMI_get_fw_version(uint32_t /*dv_ind*/, uint64_t *fw_version)
 
 // Find the DRM card number whose PCI slot name matches the given BDF.
 // Returns the card number on success, -1 if not found.
-static int findCardForBdf(uint32_t domain, uint8_t bus, uint8_t device, uint8_t function)
-{
-    for (uint32_t card = 0; card < 128; card++) {
-        char path[256];
-        snprintf(path, sizeof(path), "%s/card%u/device/uevent", kDrmClassRoot, card);
-        FILE *fp = fopen(path, "r");
-        if (fp == nullptr) continue;
+static int findCardForBdf(uint32_t domain, uint8_t bus, uint8_t device, uint8_t function) {
+  for (uint32_t card = 0; card < 128; card++) {
+    char path[256];
+    snprintf(path, sizeof(path), "%s/card%u/device/uevent", kDrmClassRoot, card);
+    FILE* fp = fopen(path, "r");
+    if (fp == nullptr) continue;
 
-        char line[256];
-        bool found = false;
-        while (fgets(line, sizeof(line), fp)) {
-            unsigned d, b, dev, fn;
-            if (sscanf(line, "PCI_SLOT_NAME=%x:%x:%x.%x", &d, &b, &dev, &fn) == 4) {
-                found = (d == domain && (uint8_t)b == bus &&
-                         (uint8_t)dev == device && (uint8_t)fn == function);
-                break;
-            }
-        }
-        fclose(fp);
-        if (found) return (int)card;
+    char line[256];
+    bool found = false;
+    while (fgets(line, sizeof(line), fp)) {
+      unsigned d, b, dev, fn;
+      if (sscanf(line, "PCI_SLOT_NAME=%x:%x:%x.%x", &d, &b, &dev, &fn) == 4) {
+        found = (d == domain && (uint8_t)b == bus && (uint8_t)dev == device && (uint8_t)fn == function);
+        break;
+      }
     }
-    return -1;
+    fclose(fp);
+    if (found) return (int)card;
+  }
+  return -1;
 }
 
 // Read a sysfs attribute as a NUL-terminated, newline-stripped string.
 // Returns 0 on success, -1 if the file cannot be opened or is empty.
-static int readUalinkStr(const char *dir, const char *attr, char *buf, size_t len)
-{
-    char path[512];
-    snprintf(path, sizeof(path), "%s/%s", dir, attr);
-    FILE *fp = fopen(path, "r");
-    if (fp == nullptr) return -1;
-    size_t n = fread(buf, 1, len - 1, fp);
-    fclose(fp);
-    if (n == 0) return -1;
-    buf[n] = '\0';
-    while (n > 0 && (buf[n-1] == '\n' || buf[n-1] == '\r' || buf[n-1] == ' '))
-        buf[--n] = '\0';
-    return 0;
+static int readUalinkStr(const char* dir, const char* attr, char* buf, size_t len) {
+  char path[512];
+  snprintf(path, sizeof(path), "%s/%s", dir, attr);
+  FILE* fp = fopen(path, "r");
+  if (fp == nullptr) return -1;
+  size_t n = fread(buf, 1, len - 1, fp);
+  fclose(fp);
+  if (n == 0) return -1;
+  buf[n] = '\0';
+  while (n > 0 && (buf[n - 1] == '\n' || buf[n - 1] == '\r' || buf[n - 1] == ' ')) buf[--n] = '\0';
+  return 0;
 }
 
 // Read a sysfs attribute as a uint32_t (decimal). Returns def on failure.
-static uint32_t readUalinkU32(const char *dir, const char *attr, uint32_t def)
-{
-    char buf[64];
-    if (readUalinkStr(dir, attr, buf, sizeof(buf)) != 0) return def;
-    return (uint32_t)strtoul(buf, nullptr, 10);
+static uint32_t readUalinkU32(const char* dir, const char* attr, uint32_t def) {
+  char buf[64];
+  if (readUalinkStr(dir, attr, buf, sizeof(buf)) != 0) return def;
+  return (uint32_t)strtoul(buf, nullptr, 10);
 }
 
-int ARSMI_get_fabric_info(uint32_t dv_ind, struct ARSMI_fabricInfo *info)
-{
-    if (info == nullptr) return EINVAL;
-    memset(info, 0, sizeof(*info));
-    info->fabric_type = ARSMI_FABRIC_TYPE_UNKNOWN;
-    info->accel_state = ARSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNKNOWN;
-    info->addr_mode = ARSMI_FABRIC_NPA_ADDRESS_MODE_UNKNOWN;
+int ARSMI_get_fabric_info(uint32_t dv_ind, struct ARSMI_fabricInfo* info) {
+  if (info == nullptr) return EINVAL;
+  memset(info, 0, sizeof(*info));
+  info->fabric_type = ARSMI_FABRIC_TYPE_UNKNOWN;
+  info->accel_state = ARSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNKNOWN;
+  info->addr_mode = ARSMI_FABRIC_NPA_ADDRESS_MODE_UNKNOWN;
 
-    if (ARSMI_num_devices < 0) {
-        int res = ARSMI_init();
-        if (res != 0) return res;
-    }
-    if ((int)dv_ind >= ARSMI_num_devices) return EINVAL;
+  if (ARSMI_num_devices < 0) {
+    int res = ARSMI_init();
+    if (res != 0) return res;
+  }
+  if ((int)dv_ind >= ARSMI_num_devices) return EINVAL;
 
-    const ARSMI_systemNode &node = ARSMI_orderedNodes[dv_ind];
-    int card = findCardForBdf((uint32_t)node.s_domain, node.s_bus,
-                               node.s_device, node.s_function);
-    if (card < 0) return ENODEV;
+  const ARSMI_systemNode& node = ARSMI_orderedNodes[dv_ind];
+  int card = findCardForBdf((uint32_t)node.s_domain, node.s_bus, node.s_device, node.s_function);
+  if (card < 0) return ENODEV;
 
-    char dir[256];
-    snprintf(dir, sizeof(dir), "%s/card%d/device/ualink", kDrmClassRoot, card);
+  char dir[256];
+  snprintf(dir, sizeof(dir), "%s/card%d/device/ualink", kDrmClassRoot, card);
 
-    struct stat st;
-    if (stat(dir, &st) != 0 || !S_ISDIR(st.st_mode)) return ENODEV;
+  struct stat st;
+  if (stat(dir, &st) != 0 || !S_ISDIR(st.st_mode)) return ENODEV;
 
-    char buf[256];
+  char buf[256];
 
     // link_type: "UALoE" | "UALLink"
-    if (readUalinkStr(dir, "link_type", buf, sizeof(buf)) == 0) {
-        if      (strcmp(buf, "UALoE")   == 0) info->fabric_type = ARSMI_FABRIC_TYPE_UALOE;
-        else if (strcmp(buf, "UALLink") == 0) info->fabric_type = ARSMI_FABRIC_TYPE_UALLINK;
-        else                                  info->fabric_type = ARSMI_FABRIC_TYPE_UNKNOWN;
-    }
+  if (readUalinkStr(dir, "link_type", buf, sizeof(buf)) == 0) {
+    if (strcmp(buf, "UALoE") == 0) info->fabric_type = ARSMI_FABRIC_TYPE_UALOE;
+    else if (strcmp(buf, "UALLink") == 0) info->fabric_type = ARSMI_FABRIC_TYPE_UALLINK;
+    else info->fabric_type = ARSMI_FABRIC_TYPE_UNKNOWN;
+  }
 
     // accel_state: "unconfigured" | "configured" | "ready" | "active" | "error"
-    if (readUalinkStr(dir, "accel_state", buf, sizeof(buf)) == 0) {
-        if      (strcmp(buf, "active")       == 0) info->accel_state = ARSMI_FABRIC_ACCELERATOR_VPOD_STATE_ACTIVE;
-        else if (strcmp(buf, "ready")        == 0) info->accel_state = ARSMI_FABRIC_ACCELERATOR_VPOD_STATE_READY;
-        else if (strcmp(buf, "configured")   == 0) info->accel_state = ARSMI_FABRIC_ACCELERATOR_VPOD_STATE_CONFIGURED;
-        else if (strcmp(buf, "unconfigured") == 0) info->accel_state = ARSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNCONFIGURED;
-        else if (strcmp(buf, "error")        == 0) info->accel_state = ARSMI_FABRIC_ACCELERATOR_VPOD_STATE_ERROR;
-        else                                       info->accel_state = ARSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNKNOWN;
-    }
+  if (readUalinkStr(dir, "accel_state", buf, sizeof(buf)) == 0) {
+    if (strcmp(buf, "active") == 0) info->accel_state = ARSMI_FABRIC_ACCELERATOR_VPOD_STATE_ACTIVE;
+    else if (strcmp(buf, "ready") == 0) info->accel_state = ARSMI_FABRIC_ACCELERATOR_VPOD_STATE_READY;
+    else if (strcmp(buf, "configured") == 0) info->accel_state = ARSMI_FABRIC_ACCELERATOR_VPOD_STATE_CONFIGURED;
+    else if (strcmp(buf, "unconfigured") == 0) info->accel_state = ARSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNCONFIGURED;
+    else if (strcmp(buf, "error") == 0) info->accel_state = ARSMI_FABRIC_ACCELERATOR_VPOD_STATE_ERROR;
+    else info->accel_state = ARSMI_FABRIC_ACCELERATOR_VPOD_STATE_UNKNOWN;
+  }
 
-    info->supported = (info->fabric_type == ARSMI_FABRIC_TYPE_UALOE ||
-                       info->fabric_type == ARSMI_FABRIC_TYPE_UALLINK) &&
-                      (info->accel_state == ARSMI_FABRIC_ACCELERATOR_VPOD_STATE_ACTIVE ||
-                       info->accel_state == ARSMI_FABRIC_ACCELERATOR_VPOD_STATE_READY);
+  info->supported = (info->fabric_type == ARSMI_FABRIC_TYPE_UALOE || info->fabric_type == ARSMI_FABRIC_TYPE_UALLINK) &&
+                    (info->accel_state == ARSMI_FABRIC_ACCELERATOR_VPOD_STATE_ACTIVE ||
+                     info->accel_state == ARSMI_FABRIC_ACCELERATOR_VPOD_STATE_READY);
 
-    info->accel_id  = readUalinkU32(dir, "accel_id",  0);
-    info->ppod_size = readUalinkU32(dir, "ppod_size", 0);
-    info->bandwidth = readUalinkU32(dir, "bandwidth", 0);
-    info->latency   = readUalinkU32(dir, "latency",   0);
-    info->vpod_id   = readUalinkU32(dir, "vpod_id",   0);
-    info->vpod_size = readUalinkU32(dir, "vpod_size", 0);
+  info->accel_id = readUalinkU32(dir, "accel_id", 0);
+  info->ppod_size = readUalinkU32(dir, "ppod_size", 0);
+  info->bandwidth = readUalinkU32(dir, "bandwidth", 0);
+  info->latency = readUalinkU32(dir, "latency", 0);
+  info->vpod_id = readUalinkU32(dir, "vpod_id", 0);
+  info->vpod_size = readUalinkU32(dir, "vpod_size", 0);
 
     // addr_mode: "source-aliasing" | "source-identification"
-    info->addr_mode = ARSMI_FABRIC_NPA_ADDRESS_MODE_UNKNOWN;
-    if (readUalinkStr(dir, "addr_mode", buf, sizeof(buf)) == 0) {
-        if (strcmp(buf, "source-identification") == 0) {
-            info->addr_mode = ARSMI_FABRIC_NPA_ADDRESS_MODE_SOURCE_IDENTIFICATION;
-        } else if (strcmp(buf, "source-aliasing") == 0) {
-            info->addr_mode = ARSMI_FABRIC_NPA_ADDRESS_MODE_SOURCE_ALIASING;
-        }
+  info->addr_mode = ARSMI_FABRIC_NPA_ADDRESS_MODE_UNKNOWN;
+  if (readUalinkStr(dir, "addr_mode", buf, sizeof(buf)) == 0) {
+    if (strcmp(buf, "source-identification") == 0) {
+      info->addr_mode = ARSMI_FABRIC_NPA_ADDRESS_MODE_SOURCE_IDENTIFICATION;
+    } else if (strcmp(buf, "source-aliasing") == 0) {
+      info->addr_mode = ARSMI_FABRIC_NPA_ADDRESS_MODE_SOURCE_ALIASING;
     }
+  }
 
     // ppod_id: UUID string "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" → 16 bytes
-    memset(info->ppod_id, 0, sizeof(info->ppod_id));
-    if (readUalinkStr(dir, "ppod_id", buf, sizeof(buf)) == 0) {
-        int parsed = sscanf(buf,
-                            "%02hhx%02hhx%02hhx%02hhx-"
-                            "%02hhx%02hhx-"
-                            "%02hhx%02hhx-"
-                            "%02hhx%02hhx-"
-                            "%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx",
-                            &info->ppod_id[0],  &info->ppod_id[1],
-                            &info->ppod_id[2],  &info->ppod_id[3],
-                            &info->ppod_id[4],  &info->ppod_id[5],
-                            &info->ppod_id[6],  &info->ppod_id[7],
-                            &info->ppod_id[8],  &info->ppod_id[9],
-                            &info->ppod_id[10], &info->ppod_id[11],
-                            &info->ppod_id[12], &info->ppod_id[13],
-                            &info->ppod_id[14], &info->ppod_id[15]);
-        if (parsed != 16) {
-            memset(info->ppod_id, 0, sizeof(info->ppod_id));
-        }
+  memset(info->ppod_id, 0, sizeof(info->ppod_id));
+  if (readUalinkStr(dir, "ppod_id", buf, sizeof(buf)) == 0) {
+    int parsed = sscanf(buf,
+                        "%02hhx%02hhx%02hhx%02hhx-"
+                        "%02hhx%02hhx-"
+                        "%02hhx%02hhx-"
+                        "%02hhx%02hhx-"
+                        "%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx",
+                        &info->ppod_id[0], &info->ppod_id[1], &info->ppod_id[2], &info->ppod_id[3], &info->ppod_id[4],
+                        &info->ppod_id[5], &info->ppod_id[6], &info->ppod_id[7], &info->ppod_id[8], &info->ppod_id[9],
+                        &info->ppod_id[10], &info->ppod_id[11], &info->ppod_id[12], &info->ppod_id[13],
+                        &info->ppod_id[14], &info->ppod_id[15]);
+    if (parsed != 16) {
+      memset(info->ppod_id, 0, sizeof(info->ppod_id));
     }
+  }
 
-    return 0;
+  return 0;
 }
 
-const char* ARSMI_fabric_telem_id_to_string(uint64_t /*telem_id*/)
-{
-    return "UNKNOWN";
+const char* ARSMI_fabric_telem_id_to_string(uint64_t /*telem_id*/) {
+  return "UNKNOWN";
 }
 
 // Internal functions
-static int getNodeIndex(uint32_t node_id)
-{
-    int res = -1;
-    assert (ARSMI_num_devices > 0);
+static int getNodeIndex(uint32_t node_id) {
+  int res = -1;
+  assert(ARSMI_num_devices > 0);
 
-    for (int i = 0; i < ARSMI_num_devices; i++) {
-        if (ARSMI_orderedNodes[i].s_node_id == node_id) {
-            res = i;
-            break;
-        }
+  for (int i = 0; i < ARSMI_num_devices; i++) {
+    if (ARSMI_orderedNodes[i].s_node_id == node_id) {
+      res = i;
+      break;
     }
+  }
 
-    return res;
+  return res;
 }
 
-static std::string DevicePath(uint32_t dev_id)
-{
-    std::string node_path = kKFDNodesPathRoot;
-    node_path += '/';
-    node_path += std::to_string(dev_id);
+static std::string DevicePath(uint32_t dev_id) {
+  std::string node_path = kKFDNodesPathRoot;
+  node_path += '/';
+  node_path += std::to_string(dev_id);
 
-    return node_path;
+  return node_path;
 }
 
-static int isRegularFile(std::string fname, bool *is_reg)
-{
-    struct stat file_stat;
-    int ret;
+static int isRegularFile(std::string fname, bool* is_reg) {
+  struct stat file_stat;
+  int ret;
 
-    ret = stat(fname.c_str(), &file_stat);
-    if (ret) {
-        return errno;
-    }
+  ret = stat(fname.c_str(), &file_stat);
+  if (ret) {
+    return errno;
+  }
 
-    if (is_reg != nullptr) {
-        *is_reg = S_ISREG(file_stat.st_mode);
-    }
+  if (is_reg != nullptr) {
+    *is_reg = S_ISREG(file_stat.st_mode);
+  }
 
-    return 0;
+  return 0;
 }
 
-static bool isNumber(const std::string &s)
-{
-    return !s.empty() && std::all_of(s.begin(), s.end(), ::isdigit);
+static bool isNumber(const std::string& s) {
+  return !s.empty() && std::all_of(s.begin(), s.end(), ::isdigit);
 }
 
-static int openNodeFile(uint32_t dev_id, std::string node_file,
-                        std::ifstream *fs)
-{
-    std::string line;
-    std::string f_path;
-    bool reg_file;
+static int openNodeFile(uint32_t dev_id, std::string node_file, std::ifstream* fs) {
+  std::string line;
+  std::string f_path;
+  bool reg_file;
 
-    assert(fs != nullptr);
+  assert(fs != nullptr);
 
-    f_path = DevicePath(dev_id);
-    f_path += "/";
-    f_path += node_file;
+  f_path = DevicePath(dev_id);
+  f_path += "/";
+  f_path += node_file;
 
-    int ret = isRegularFile(f_path, &reg_file);
-    if (ret != 0) {
-        return ret;
-    }
-    if (!reg_file) {
-        return ENOENT;
-    }
+  int ret = isRegularFile(f_path, &reg_file);
+  if (ret != 0) {
+    return ret;
+  }
+  if (!reg_file) {
+    return ENOENT;
+  }
 
-    fs->open(f_path);
-    if (!fs->is_open()) {
-        return errno;
-    }
+  fs->open(f_path);
+  if (!fs->is_open()) {
+    return errno;
+  }
 
-    return 0;
+  return 0;
 }
 
-static int countIoLinks(uint32_t dev_id)
-{
-    std::string f_path;
-    int file_count = 0;
+static int countIoLinks(uint32_t dev_id) {
+  std::string f_path;
+  int file_count = 0;
 
-    f_path = DevicePath(dev_id);
-    f_path += "/io_links/";
+  f_path = DevicePath(dev_id);
+  f_path += "/io_links/";
 
-    auto node_dir = opendir(f_path.c_str());
-    auto dentry = readdir(node_dir);
-    while (dentry != NULL) {
-        if (dentry->d_type == DT_DIR && strcmp(dentry->d_name, ".") != 0
-            && strcmp(dentry->d_name, "..") != 0) {
-            file_count++;
-        }
-        dentry = readdir(node_dir);
+  auto node_dir = opendir(f_path.c_str());
+  auto dentry = readdir(node_dir);
+  while (dentry != NULL) {
+    if (dentry->d_type == DT_DIR && strcmp(dentry->d_name, ".") != 0 && strcmp(dentry->d_name, "..") != 0) {
+      file_count++;
     }
-    closedir(node_dir);
-    return file_count;
+    dentry = readdir(node_dir);
+  }
+  closedir(node_dir);
+  return file_count;
 }
 
-static int openLinkFile(uint32_t dev_id, uint32_t target_id,
-                        std::string node_file, std::ifstream *fs)
-{
-    std::string line;
-    std::string f_path;
-    bool reg_file;
+static int openLinkFile(uint32_t dev_id, uint32_t target_id, std::string node_file, std::ifstream* fs) {
+  std::string line;
+  std::string f_path;
+  bool reg_file;
 
-    assert(fs != nullptr);
+  assert(fs != nullptr);
 
-    f_path = DevicePath(dev_id);
-    f_path += "/io_links/";
-    f_path +=std::to_string(target_id);
-    f_path += "/";
-    f_path += node_file;
+  f_path = DevicePath(dev_id);
+  f_path += "/io_links/";
+  f_path += std::to_string(target_id);
+  f_path += "/";
+  f_path += node_file;
 
-    int ret = isRegularFile(f_path, &reg_file);
-    if (ret != 0) {
-        return ret;
-    }
-    if (!reg_file) {
-        return ENOENT;
-    }
+  int ret = isRegularFile(f_path, &reg_file);
+  if (ret != 0) {
+    return ret;
+  }
+  if (!reg_file) {
+    return ENOENT;
+  }
 
-    fs->open(f_path);
-    if (!fs->is_open()) {
-        return errno;
-    }
+  fs->open(f_path);
+  if (!fs->is_open()) {
+    return errno;
+  }
 
-    return 0;
+  return 0;
 }
 
+static int readGpuId(uint32_t node_id, uint64_t* gpu_id) {
+  std::string line;
+  std::ifstream fs;
 
-static int readGpuId(uint32_t node_id, uint64_t *gpu_id)
-{
-    std::string line;
-    std::ifstream fs;
-
-    assert(gpu_id != nullptr);
-    int ret = openNodeFile(node_id, "gpu_id", &fs);
-    if (ret) {
-        fs.close();
-        return ret;
-    }
-
-    std::stringstream ss;
-    ss << fs.rdbuf();
-    fs.close();
-
-    std::string gpu_id_str = ss.str();
-    gpu_id_str.erase(std::remove(gpu_id_str.begin(), gpu_id_str.end(), '\n'),
-                     gpu_id_str.end());
-    if (!isNumber(gpu_id_str)) {
-        return ENXIO;
-    }
-
-    *gpu_id = static_cast<uint64_t>(std::stoi(gpu_id_str));
-    return 0;
-}
-
-static bool isNodeSupported(uint32_t node_indx)
-{
-    std::ifstream fs;
-    bool ret = true;
-
-    int err = openNodeFile(node_indx, "properties", &fs);
-    if (err == ENOENT) {
-        return false;
-    }
-    if (fs.peek() == std::ifstream::traits_type::eof()) {
-        ret = false;
-    }
-
+  assert(gpu_id != nullptr);
+  int ret = openNodeFile(node_id, "gpu_id", &fs);
+  if (ret) {
     fs.close();
     return ret;
+  }
+
+  std::stringstream ss;
+  ss << fs.rdbuf();
+  fs.close();
+
+  std::string gpu_id_str = ss.str();
+  gpu_id_str.erase(std::remove(gpu_id_str.begin(), gpu_id_str.end(), '\n'), gpu_id_str.end());
+  if (!isNumber(gpu_id_str)) {
+    return ENXIO;
+  }
+
+  *gpu_id = static_cast<uint64_t>(std::stoi(gpu_id_str));
+  return 0;
 }
 
-static int getPropertyValue(std::string property, uint64_t *value, std::map<std::string, uint64_t> &properties)
-{
-    if (value == nullptr) {
-        return EINVAL;
-    }
-    if (properties.empty()) {
-        return EINVAL;
-    }
+static bool isNodeSupported(uint32_t node_indx) {
+  std::ifstream fs;
+  bool ret = true;
 
-    if (properties.find(property) == properties.end()) {
-        return EINVAL;
-    }
+  int err = openNodeFile(node_indx, "properties", &fs);
+  if (err == ENOENT) {
+    return false;
+  }
+  if (fs.peek() == std::ifstream::traits_type::eof()) {
+    ret = false;
+  }
 
-    *value = properties[property];
-    return 0;
+  fs.close();
+  return ret;
 }
 
-static int ARSMI_readDeviceProperties(uint32_t node_id, std::map<std::string, uint64_t> &properties)
-{
-    std::string line;
-    std::ifstream fs;
-    std::vector<std::string> tVec;
+static int getPropertyValue(std::string property, uint64_t* value, std::map<std::string, uint64_t>& properties) {
+  if (value == nullptr) {
+    return EINVAL;
+  }
+  if (properties.empty()) {
+    return EINVAL;
+  }
 
-    int ret = openNodeFile(node_id, "properties", &fs);
-    if (ret) {
-        return ret;
-    }
+  if (properties.find(property) == properties.end()) {
+    return EINVAL;
+  }
 
-    while (std::getline(fs, line)) {
-        tVec.push_back(line);
-    }
+  *value = properties[property];
+  return 0;
+}
 
-    if (tVec.empty()) {
-        fs.close();
-        return ENOENT;
-    }
+static int ARSMI_readDeviceProperties(uint32_t node_id, std::map<std::string, uint64_t>& properties) {
+  std::string line;
+  std::ifstream fs;
+  std::vector<std::string> tVec;
+
+  int ret = openNodeFile(node_id, "properties", &fs);
+  if (ret) {
+    return ret;
+  }
+
+  while (std::getline(fs, line)) {
+    tVec.push_back(line);
+  }
+
+  if (tVec.empty()) {
+    fs.close();
+    return ENOENT;
+  }
 
     // Remove any *trailing* empty (whitespace) lines
-    while (tVec.back().find_first_not_of(" \t\n\v\f\r") == std::string::npos) {
-        tVec.pop_back();
-    }
+  while (tVec.back().find_first_not_of(" \t\n\v\f\r") == std::string::npos) {
+    tVec.pop_back();
+  }
 
-    fs.close();
+  fs.close();
 
-    std::string key_str;
-    std::string val_str;
-    uint64_t val_int;  // Assume all properties are unsigned integers for now
-    std::istringstream fs2;
+  std::string key_str;
+  std::string val_str;
+  uint64_t val_int;  // Assume all properties are unsigned integers for now
+  std::istringstream fs2;
 
-    for (const auto & i : tVec) {
-        fs2.str(i);
-        fs2 >> key_str;
-        fs2 >> val_str;
+  for (const auto& i : tVec) {
+    fs2.str(i);
+    fs2 >> key_str;
+    fs2 >> val_str;
 
-        val_int = std::stoull(val_str);
-        properties[key_str] = val_int;
+    val_int = std::stoull(val_str);
+    properties[key_str] = val_int;
 
-        fs2.str("");
-        fs2.clear();
-    }
+    fs2.str("");
+    fs2.clear();
+  }
 
-    return 0;
+  return 0;
 }
 
 static int ARSMI_readLinkProperties(uint32_t node_id, uint32_t target_node_id,
-                                    std::map<std::string, uint64_t> &properties)
-{
-    std::string line;
-    std::ifstream fs;
-    std::vector<std::string> tVec;
+                                    std::map<std::string, uint64_t>& properties) {
+  std::string line;
+  std::ifstream fs;
+  std::vector<std::string> tVec;
 
-    int ret = openLinkFile(node_id, target_node_id, "properties", &fs);
-    if (ret) {
-        return ret;
-    }
+  int ret = openLinkFile(node_id, target_node_id, "properties", &fs);
+  if (ret) {
+    return ret;
+  }
 
-    while (std::getline(fs, line)) {
-        tVec.push_back(line);
-    }
+  while (std::getline(fs, line)) {
+    tVec.push_back(line);
+  }
 
-    if (tVec.empty()) {
-        fs.close();
-        return ENOENT;
-    }
+  if (tVec.empty()) {
+    fs.close();
+    return ENOENT;
+  }
 
     // Remove any *trailing* empty (whitespace) lines
-    while (tVec.back().find_first_not_of(" \t\n\v\f\r") == std::string::npos) {
-        tVec.pop_back();
-    }
+  while (tVec.back().find_first_not_of(" \t\n\v\f\r") == std::string::npos) {
+    tVec.pop_back();
+  }
 
-    fs.close();
+  fs.close();
 
-    std::string key_str;
-    std::string val_str;
-    uint64_t val_int;  // Assume all properties are unsigned integers for now
-    std::istringstream fs2;
+  std::string key_str;
+  std::string val_str;
+  uint64_t val_int;  // Assume all properties are unsigned integers for now
+  std::istringstream fs2;
 
-    for (const auto & i : tVec) {
-        fs2.str(i);
-        fs2 >> key_str;
-        fs2 >> val_str;
+  for (const auto& i : tVec) {
+    fs2.str(i);
+    fs2 >> key_str;
+    fs2 >> val_str;
 
-        val_int = std::stoull(val_str);
-        properties[key_str] = val_int;
+    val_int = std::stoull(val_str);
+    properties[key_str] = val_int;
 
-        fs2.str("");
-        fs2.clear();
-    }
+    fs2.str("");
+    fs2.clear();
+  }
 
-    return 0;
+  return 0;
 }
 
 // /sys/class/kfd/kfd/topology/nodes/*/properties
-static int read_node_properties(uint32_t node, std::string property_name,
-                                uint64_t *val, std::map<std::string, uint64_t> &properties)
-{
-    int retVal = EINVAL;
+static int read_node_properties(uint32_t node, std::string property_name, uint64_t* val,
+                                std::map<std::string, uint64_t>& properties) {
+  int retVal = EINVAL;
 
-    if (property_name.empty() || val == nullptr) {
-        WARN("Could not read node # %u property %s", node, property_name.c_str());
-        return retVal;
-    }
-
-    if (isNodeSupported(node)) {
-        retVal = getPropertyValue(property_name, val, properties);
-    } else {
-        retVal = 1;
-        WARN("Could not read node # %u",node);
-    }
-
+  if (property_name.empty() || val == nullptr) {
+    WARN("Could not read node # %u property %s", node, property_name.c_str());
     return retVal;
+  }
+
+  if (isNodeSupported(node)) {
+    retVal = getPropertyValue(property_name, val, properties);
+  } else {
+    retVal = 1;
+    WARN("Could not read node # %u", node);
+  }
+
+  return retVal;
 }
 
 // /sys/class/kfd/kfd/topology/nodes/*/io_links/*/properties
-static int read_link_properties(uint32_t node, uint32_t target, std::string property_name,
-                                uint64_t *val, std::map<std::string, uint64_t> &properties)
-{
-    int retVal = EINVAL;
+static int read_link_properties(uint32_t node, uint32_t target, std::string property_name, uint64_t* val,
+                                std::map<std::string, uint64_t>& properties) {
+  int retVal = EINVAL;
 
-    if (property_name.empty() || val == nullptr) {
-        WARN("Could not read node # %u", node);
-        return retVal;
-    }
-
-    if (isNodeSupported(node)) {
-        retVal = getPropertyValue(property_name, val, properties);
-    } else {
-        retVal = 1;
-        WARN("Could not read node # %u", node);
-    }
-
+  if (property_name.empty() || val == nullptr) {
+    WARN("Could not read node # %u", node);
     return retVal;
+  }
+
+  if (isNodeSupported(node)) {
+    retVal = getPropertyValue(property_name, val, properties);
+  } else {
+    retVal = 1;
+    WARN("Could not read node # %u", node);
+  }
+
+  return retVal;
 }
 
 // /sys/class/kfd/kfd/topology/nodes/*/gpu_id
-int getGpuId(uint32_t node, uint64_t *gpu_id)
-{
-    int retVal = EINVAL;
+int getGpuId(uint32_t node, uint64_t* gpu_id) {
+  int retVal = EINVAL;
 
-    if (gpu_id == nullptr) {
-        WARN("Could not determine GPU id of node # %u", node);
-        return retVal;
-    }
+  if (gpu_id == nullptr) {
+    WARN("Could not determine GPU id of node # %u", node);
+    return retVal;
+  }
 
-    if (isNodeSupported(node)) {
-        retVal = readGpuId(node, gpu_id);
-    } else {
-        retVal = 1;
-        WARN("Could not read node # %u", node);
-    }
+  if (isNodeSupported(node)) {
+    retVal = readGpuId(node, gpu_id);
+  } else {
+    retVal = 1;
+    WARN("Could not read node # %u", node);
+  }
 
   return retVal;
 }

--- a/projects/rccl/src/misc/amdsmi_wrap.cc
+++ b/projects/rccl/src/misc/amdsmi_wrap.cc
@@ -13,40 +13,43 @@
 
 static int is_wsl2 = -1;
 
-#define AMDSMICHECK(cmd) do {                \
-  amdsmi_status_t ret = cmd;                 \
-  if( ret != AMDSMI_STATUS_SUCCESS ) {       \
-    const char *err;                         \
-    pfn_amdsmi_status_code_to_string(ret, &err);         \
-    ERROR("AMD SMI failure: %s at line: %d in file: %s", err, __LINE__, __FILE__);    \
-    return ncclInternalError;                \
-  }                                          \
-} while(false)
+#define AMDSMICHECK(cmd) \
+  do { \
+    amdsmi_status_t ret = cmd; \
+    if (ret != AMDSMI_STATUS_SUCCESS) { \
+      const char* err; \
+      pfn_amdsmi_status_code_to_string(ret, &err); \
+      ERROR("AMD SMI failure: %s at line: %d in file: %s", err, __LINE__, __FILE__); \
+      return ncclInternalError; \
+    } \
+  } while (false)
 
-#define ARSMICHECK(cmd) do {         \
-  int ret = cmd;                     \
-  if( ret != 0 ) {                   \
-    ERROR("ARSMI failure: %d", ret); \
-    return ncclInternalError;        \
-  }                                  \
-} while(false)
+#define ARSMICHECK(cmd) \
+  do { \
+    int ret = cmd; \
+    if (ret != 0) { \
+      ERROR("ARSMI failure: %d", ret); \
+      return ncclInternalError; \
+    } \
+  } while (false)
 
-#define AMDSMITRY(name, ...) do { \
-  if (!AMDSMI_DIRECT && pfn_##name == nullptr) \
-    return ncclInternalError; /* missing symbol is not a warned error */ \
-  amdsmi_status_t ret = pfn_##name(__VA_ARGS__); \
-  if( ret != AMDSMI_STATUS_SUCCESS ) {       \
-    const char *err;                         \
-    pfn_amdsmi_status_code_to_string(ret, &err); \
-    ERROR("AMD SMI failure: %s at line: %d in file: %s", err, __LINE__, __FILE__);    \
-    return ncclInternalError;                \
-  }                                          \
-} while(0)
+#define AMDSMITRY(name, ...) \
+  do { \
+    if (!AMDSMI_DIRECT && pfn_##name == nullptr) return ncclInternalError; /* missing symbol is not a warned error */ \
+    amdsmi_status_t ret = pfn_##name(__VA_ARGS__); \
+    if (ret != AMDSMI_STATUS_SUCCESS) { \
+      const char* err; \
+      pfn_amdsmi_status_code_to_string(ret, &err); \
+      ERROR("AMD SMI failure: %s at line: %d in file: %s", err, __LINE__, __FILE__); \
+      return ncclInternalError; \
+    } \
+  } while (0)
 
-RCCL_PARAM(UseAmdSmiLib, "USE_AMD_SMI_LIB", 0); // Opt-in environment variable for enabling using amd_smi_lib instead of internal code
+RCCL_PARAM(UseAmdSmiLib, "USE_AMD_SMI_LIB",
+           0); // Opt-in environment variable for enabling using amd_smi_lib instead of internal code
 
 #include <dlfcn.h>
-#define RCCL_AMDSMI_FN(name, rettype, arglist) rettype(*pfn_##name)arglist = nullptr;
+#define RCCL_AMDSMI_FN(name, rettype, arglist) rettype(*pfn_##name) arglist = nullptr;
 
 // dlopen the versioned SONAME (in every runtime tree), not the unversioned dev
 // symlink (devel packages and /opt/rocm installs only). The major comes from
@@ -60,35 +63,51 @@ RCCL_PARAM(UseAmdSmiLib, "USE_AMD_SMI_LIB", 0); // Opt-in environment variable f
 #define RCCL_AMDSMI_LIBNAME "libamd_smi.so"
 #endif
 
-
 namespace {
   // Core AMD SMI functions
-  RCCL_AMDSMI_FN(amdsmi_init, amdsmi_status_t, (uint64_t init_flags))
-  RCCL_AMDSMI_FN(amdsmi_shut_down, amdsmi_status_t, ())
-  RCCL_AMDSMI_FN(amdsmi_status_code_to_string, amdsmi_status_t, (amdsmi_status_t status, const char **status_string))
-  RCCL_AMDSMI_FN(amdsmi_get_lib_version, amdsmi_status_t, (amdsmi_version_t *version))
+RCCL_AMDSMI_FN(amdsmi_init, amdsmi_status_t, (uint64_t init_flags))
+RCCL_AMDSMI_FN(amdsmi_shut_down, amdsmi_status_t, ())
+RCCL_AMDSMI_FN(amdsmi_status_code_to_string, amdsmi_status_t, (amdsmi_status_t status, const char** status_string))
+RCCL_AMDSMI_FN(amdsmi_get_lib_version, amdsmi_status_t, (amdsmi_version_t * version))
   // Socket and processor handle functions
-  RCCL_AMDSMI_FN(amdsmi_get_socket_handles, amdsmi_status_t, (uint32_t *socket_count, amdsmi_socket_handle* socket_handles))
-  RCCL_AMDSMI_FN(amdsmi_get_processor_handles, amdsmi_status_t, (amdsmi_socket_handle socket_handle, uint32_t *processor_count, amdsmi_processor_handle* processor_handles))
-  RCCL_AMDSMI_FN(amdsmi_get_processor_type, amdsmi_status_t, (amdsmi_processor_handle processor_handle, processor_type_t* processor_type))
-  RCCL_AMDSMI_FN(amdsmi_get_processor_handle_from_bdf, amdsmi_status_t, (amdsmi_bdf_t bdf, amdsmi_processor_handle* processor_handle))
+RCCL_AMDSMI_FN(amdsmi_get_socket_handles, amdsmi_status_t,
+               (uint32_t* socket_count, amdsmi_socket_handle* socket_handles))
+RCCL_AMDSMI_FN(amdsmi_get_processor_handles, amdsmi_status_t,
+               (amdsmi_socket_handle socket_handle, uint32_t* processor_count,
+                amdsmi_processor_handle* processor_handles))
+RCCL_AMDSMI_FN(amdsmi_get_processor_type, amdsmi_status_t,
+               (amdsmi_processor_handle processor_handle, processor_type_t* processor_type))
+RCCL_AMDSMI_FN(amdsmi_get_processor_handle_from_bdf, amdsmi_status_t,
+               (amdsmi_bdf_t bdf, amdsmi_processor_handle* processor_handle))
   // GPU enumeration and BDF functions
-  RCCL_AMDSMI_FN(amdsmi_get_gpu_enumeration_info, amdsmi_status_t, (amdsmi_processor_handle processor_handle, amdsmi_enumeration_info_t *info))
-  RCCL_AMDSMI_FN(amdsmi_get_gpu_bdf_id, amdsmi_status_t, (amdsmi_processor_handle processor_handle, uint64_t *bdfid))
+RCCL_AMDSMI_FN(amdsmi_get_gpu_enumeration_info, amdsmi_status_t,
+               (amdsmi_processor_handle processor_handle, amdsmi_enumeration_info_t* info))
+RCCL_AMDSMI_FN(amdsmi_get_gpu_bdf_id, amdsmi_status_t, (amdsmi_processor_handle processor_handle, uint64_t* bdfid))
   // Topology functions
-  RCCL_AMDSMI_FN(amdsmi_topo_get_link_type, amdsmi_status_t, (amdsmi_processor_handle processor_handle_src, amdsmi_processor_handle processor_handle_dst, uint64_t *hops, amdsmi_link_type_t *type))
-  RCCL_AMDSMI_FN(amdsmi_topo_get_link_weight, amdsmi_status_t, (amdsmi_processor_handle processor_handle_src, amdsmi_processor_handle processor_handle_dst, uint64_t *weight))
-  RCCL_AMDSMI_FN(amdsmi_get_minmax_bandwidth_between_processors, amdsmi_status_t, (amdsmi_processor_handle processor_handle_src, amdsmi_processor_handle processor_handle_dst, uint64_t *min_bandwidth, uint64_t *max_bandwidth))
+RCCL_AMDSMI_FN(amdsmi_topo_get_link_type, amdsmi_status_t,
+               (amdsmi_processor_handle processor_handle_src, amdsmi_processor_handle processor_handle_dst,
+                uint64_t* hops, amdsmi_link_type_t* type))
+RCCL_AMDSMI_FN(amdsmi_topo_get_link_weight, amdsmi_status_t,
+               (amdsmi_processor_handle processor_handle_src, amdsmi_processor_handle processor_handle_dst,
+                uint64_t* weight))
+RCCL_AMDSMI_FN(amdsmi_get_minmax_bandwidth_between_processors, amdsmi_status_t,
+               (amdsmi_processor_handle processor_handle_src, amdsmi_processor_handle processor_handle_dst,
+                uint64_t* min_bandwidth, uint64_t* max_bandwidth))
   // UALoE Fabric support
-  RCCL_AMDSMI_FN(amdsmi_get_gpu_fabric_info, amdsmi_status_t, (amdsmi_processor_handle processor_handle, amdsmi_fabric_info_t* info))
+RCCL_AMDSMI_FN(amdsmi_get_gpu_fabric_info, amdsmi_status_t,
+               (amdsmi_processor_handle processor_handle, amdsmi_fabric_info_t* info))
   // UALoE Fabric Telemetry support
-  RCCL_AMDSMI_FN(amdsmi_alloc_fabric_telemetry, amdsmi_status_t, (amdsmi_processor_handle processor_handle, uint32_t category_mask, amdsmi_fabric_telemetry_t **telemetry))
-  RCCL_AMDSMI_FN(amdsmi_get_fabric_telemetry_data, amdsmi_status_t, (amdsmi_processor_handle processor_handle, amdsmi_fabric_telemetry_t *telemetry))
-  RCCL_AMDSMI_FN(amdsmi_free_fabric_telemetry, amdsmi_status_t, (amdsmi_processor_handle processor_handle, amdsmi_fabric_telemetry_t *telemetry))
-  RCCL_AMDSMI_FN(amdsmi_fabric_telem_id_to_string, const char*, (uint64_t telem_id))
+RCCL_AMDSMI_FN(amdsmi_alloc_fabric_telemetry, amdsmi_status_t,
+               (amdsmi_processor_handle processor_handle, uint32_t category_mask,
+                amdsmi_fabric_telemetry_t** telemetry))
+RCCL_AMDSMI_FN(amdsmi_get_fabric_telemetry_data, amdsmi_status_t,
+               (amdsmi_processor_handle processor_handle, amdsmi_fabric_telemetry_t* telemetry))
+RCCL_AMDSMI_FN(amdsmi_free_fabric_telemetry, amdsmi_status_t,
+               (amdsmi_processor_handle processor_handle, amdsmi_fabric_telemetry_t* telemetry))
+RCCL_AMDSMI_FN(amdsmi_fabric_telem_id_to_string, const char*, (uint64_t telem_id))
   // Firmware info
-  RCCL_AMDSMI_FN(amdsmi_get_fw_info, amdsmi_status_t, (amdsmi_processor_handle processor_handle, amdsmi_fw_info_t *info))
-}
+RCCL_AMDSMI_FN(amdsmi_get_fw_info, amdsmi_status_t, (amdsmi_processor_handle processor_handle, amdsmi_fw_info_t* info))
+} // namespace
 
 /*************************************************************************
  * UALoE Fabric Support - Global State
@@ -100,13 +119,13 @@ int amdsmiFabricDeviceCount = 0;
 struct amdsmiFabricDeviceInfo amdsmiFabricDevices[amdsmiFabricMaxDevices];
 
 namespace {
-  std::mutex fabricLock;  // Thread safety for fabric operations
-  bool fabricInitialized = false;
-  thread_local bool threadFabricInitialized = false;
-  ncclResult_t fabricInitResult = ncclSuccess;
-  ncclResult_t amdSmiInitResult = ncclSuccess;
-  std::atomic<bool> amdSmiInitCalled{false};  // Track if amd_smi_init has been called
-}
+std::mutex fabricLock;  // Thread safety for fabric operations
+bool fabricInitialized = false;
+thread_local bool threadFabricInitialized = false;
+ncclResult_t fabricInitResult = ncclSuccess;
+ncclResult_t amdSmiInitResult = ncclSuccess;
+std::atomic<bool> amdSmiInitCalled{false};  // Track if amd_smi_init has been called
+} // namespace
 
 /*************************************************************************
  * Helper: Get processor handle for a device index
@@ -166,14 +185,17 @@ ncclResult_t amd_smi_init() {
     if (pfn_amdsmi_init == nullptr) {
       // RCCL_AMDSMI_LIBNAME resolves to the versioned SONAME when built against
       // the amdsmi headers, otherwise the unversioned name (see above).
-      static void *libhandle = dlopen(RCCL_AMDSMI_LIBNAME, RTLD_NOW);
+      static void* libhandle = dlopen(RCCL_AMDSMI_LIBNAME, RTLD_NOW);
       if (libhandle == nullptr) {
         WARN("Failed to open %s: %s", RCCL_AMDSMI_LIBNAME, dlerror());
         amdSmiInitResult = ncclInternalError;
         return ncclInternalError;
       }
 
-      struct Symbol { void **ppfn; char const *name; };
+      struct Symbol {
+        void** ppfn;
+        char const* name;
+      };
       std::initializer_list<Symbol> symbols = {
         {(void**)&pfn_amdsmi_init, "amdsmi_init"},
         {(void**)&pfn_amdsmi_shut_down, "amdsmi_shut_down"},
@@ -197,7 +219,7 @@ ncclResult_t amd_smi_init() {
         {(void**)&pfn_amdsmi_free_fabric_telemetry, "amdsmi_free_fabric_telemetry"},
         {(void**)&pfn_amdsmi_get_fw_info, "amdsmi_get_fw_info"},
       };
-      for(Symbol sym: symbols) {
+      for (Symbol sym : symbols) {
         *sym.ppfn = dlsym(libhandle, sym.name);
       }
     }
@@ -211,7 +233,8 @@ ncclResult_t amd_smi_init() {
     INFO(NCCL_INIT, "amdsmi_lib: version %d.%d.%d.%s", version.major, version.minor, version.release, version.build);
   } else {
 #ifdef HIP_FABRIC_API
-    WARN("RCCL_USE_AMD_SMI_LIB not set, but HIP_FABRIC_API is defined. Fabric support is only available through AMD SMI. Rerun with RCCL_USE_AMD_SMI_LIB=1 to enable AMD SMI and UALoE fabric support.");
+    WARN("RCCL_USE_AMD_SMI_LIB not set, but HIP_FABRIC_API is defined. Fabric support is only available through AMD "
+         "SMI. Rerun with RCCL_USE_AMD_SMI_LIB=1 to enable AMD SMI and UALoE fabric support.");
 #endif
     // initialize alternate rsmi
     ARSMICHECK(ARSMI_init());
@@ -233,8 +256,7 @@ ncclResult_t amd_smi_shutdown() {
 }
 
 ncclResult_t amd_smi_getNumDevice(uint32_t* num_devs) {
-  if (__atomic_load_n(&is_wsl2, __ATOMIC_ACQUIRE))
-    CUDACHECK(cudaGetDeviceCount((int *)num_devs));
+  if (__atomic_load_n(&is_wsl2, __ATOMIC_ACQUIRE)) CUDACHECK(cudaGetDeviceCount((int*)num_devs));
   else {
     if (rcclParamUseAmdSmiLib()) {
       // rsmi_num_monitor_devices is deprecated
@@ -301,10 +323,10 @@ ncclResult_t amd_smi_getDevicePciBusIdString(uint32_t deviceIndex, char* busId, 
           processor_type_t type;
 
           AMDSMITRY(amdsmi_get_processor_type, proc, &type);
-          if(type == AMDSMI_PROCESSOR_TYPE_AMD_GPU) {
+          if (type == AMDSMI_PROCESSOR_TYPE_AMD_GPU) {
             amdsmi_enumeration_info_t info;
             AMDSMITRY(amdsmi_get_gpu_enumeration_info, proc, &info);
-            if(info.hip_id == deviceIndex) {
+            if (info.hip_id == deviceIndex) {
               AMDSMITRY(amdsmi_get_gpu_bdf_id, proc, &id);
               found = true;
               break;
@@ -327,10 +349,9 @@ ncclResult_t amd_smi_getDevicePciBusIdString(uint32_t deviceIndex, char* busId, 
   return ncclSuccess;
 }
 
-
 ncclResult_t amd_smi_getDeviceIndexByPciBusId(const char* pciBusId, uint32_t* deviceIndex) {
   if (__atomic_load_n(&is_wsl2, __ATOMIC_ACQUIRE)) {
-    CUDACHECK(hipDeviceGetByPCIBusId((int *)deviceIndex, pciBusId));
+    CUDACHECK(hipDeviceGetByPCIBusId((int*)deviceIndex, pciBusId));
     return ncclSuccess;
   } else {
     int64_t busid;
@@ -370,7 +391,7 @@ ncclResult_t amd_smi_getDeviceIndexByPciBusId(const char* pciBusId, uint32_t* de
 
       processor_type_t type;
       AMDSMITRY(amdsmi_get_processor_type, processor_handle, &type);
-      if(type == AMDSMI_PROCESSOR_TYPE_AMD_GPU) {
+      if (type == AMDSMI_PROCESSOR_TYPE_AMD_GPU) {
         amdsmi_enumeration_info_t info;
         AMDSMITRY(amdsmi_get_gpu_enumeration_info, processor_handle, &info);
         *deviceIndex = info.hip_id;
@@ -380,19 +401,18 @@ ncclResult_t amd_smi_getDeviceIndexByPciBusId(const char* pciBusId, uint32_t* de
       ERROR("amdsmi_lib: %s device index not found", pciBusId);
     } else {
       uint32_t i, num_devs = 0;
-      busid = ((busid&0xffff00000L)<<12)+((busid&0xff000L)>>4)+((busid&0xff0L)>>1)+(busid&0x7L);
+      busid = ((busid & 0xffff00000L) << 12) + ((busid & 0xff000L) >> 4) + ((busid & 0xff0L) >> 1) + (busid & 0x7L);
 
       ARSMICHECK(ARSMI_get_num_devices(&num_devs));
       for (i = 0; i < num_devs; i++) {
         uint64_t bdfid;
         ARSMICHECK(ARSMI_dev_pci_id_get(i, &bdfid));
-        if ((int64_t) bdfid == busid) break;
+        if ((int64_t)bdfid == busid) break;
       }
       if (i < num_devs) {
         *deviceIndex = i;
         return ncclSuccess;
-      }
-      else {
+      } else {
         WARN("ARSMI_lib: %s device index not found", pciBusId);
       }
     }
@@ -400,14 +420,14 @@ ncclResult_t amd_smi_getDeviceIndexByPciBusId(const char* pciBusId, uint32_t* de
   }
 }
 
-ncclResult_t amd_smi_getLinkInfo(int srcIndex, int dstIndex, amdsmi_link_type_t* type, int *hops, int *count) {
+ncclResult_t amd_smi_getLinkInfo(int srcIndex, int dstIndex, amdsmi_link_type_t* type, int* hops, int* count) {
   if (__atomic_load_n(&is_wsl2, __ATOMIC_ACQUIRE)) {
     *type = AMDSMI_LINK_TYPE_PCIE;
     *hops = 1;
     *count = 1;
   } else {
     amdsmi_link_type_t amdsmi_type;
-    uint64_t amdsmi_hops, amdsmi_weight ;
+    uint64_t amdsmi_hops, amdsmi_weight;
     *count = 1;
     *hops = 2;
     // rsmi_minmax_bandwidth_get is replaced by amdsmi_get_minmax_bandwidth_between_processors
@@ -439,14 +459,14 @@ ncclResult_t amd_smi_getLinkInfo(int srcIndex, int dstIndex, amdsmi_link_type_t*
         for (auto& proc : processor_handles) {
           processor_type_t proc_type;
           AMDSMITRY(amdsmi_get_processor_type, proc, &proc_type);
-          if(proc_type == AMDSMI_PROCESSOR_TYPE_AMD_GPU) {
+          if (proc_type == AMDSMI_PROCESSOR_TYPE_AMD_GPU) {
             amdsmi_enumeration_info_t info;
             AMDSMITRY(amdsmi_get_gpu_enumeration_info, proc, &info);
-            if((int) info.hip_id == srcIndex) {
+            if ((int)info.hip_id == srcIndex) {
               src_processor_handle = proc;
               found_src = true;
             }
-            if((int) info.hip_id == dstIndex) {
+            if ((int)info.hip_id == dstIndex) {
               dst_processor_handle = proc;
               found_dst = true;
             }
@@ -462,8 +482,9 @@ ncclResult_t amd_smi_getLinkInfo(int srcIndex, int dstIndex, amdsmi_link_type_t*
       // amd-smi reports weight=0 for XGMI ??
       if (amdsmi_type == AMDSMI_LINK_TYPE_XGMI) {
         uint64_t min_bw = 0, max_bw = 0;
-        AMDSMITRY(amdsmi_get_minmax_bandwidth_between_processors, src_processor_handle, dst_processor_handle, &min_bw, &max_bw);
-        if (max_bw && min_bw) *count = max_bw/min_bw;
+        AMDSMITRY(amdsmi_get_minmax_bandwidth_between_processors, src_processor_handle, dst_processor_handle, &min_bw,
+                  &max_bw);
+        if (max_bw && min_bw) *count = max_bw / min_bw;
       }
 
       *type = amdsmi_type;
@@ -476,15 +497,19 @@ ncclResult_t amd_smi_getLinkInfo(int srcIndex, int dstIndex, amdsmi_link_type_t*
       //   ARSMI: UNDEFINED=0, PCIEXPRESS=1, XGMI=2
       //   amdsmi: INTERNAL=0, XGMI=1, PCIE=2, NOT_APPLICABLE=3, UNKNOWN=4
       switch (tinfo.type) {
-        case ARSMI_IOLINK_TYPE_PCIEXPRESS: *type = AMDSMI_LINK_TYPE_PCIE; break;
-        case ARSMI_IOLINK_TYPE_XGMI:       *type = AMDSMI_LINK_TYPE_XGMI; break;
-        default:                           *type = AMDSMI_LINK_TYPE_UNKNOWN; break;
+      case ARSMI_IOLINK_TYPE_PCIEXPRESS:
+        *type = AMDSMI_LINK_TYPE_PCIE;
+        break;
+      case ARSMI_IOLINK_TYPE_XGMI:
+        *type = AMDSMI_LINK_TYPE_XGMI;
+        break;
+      default:
+        *type = AMDSMI_LINK_TYPE_UNKNOWN;
+        break;
       }
-      if (*type == AMDSMI_LINK_TYPE_XGMI && (tinfo.weight == 15 ||
-        tinfo.weight == 41 || tinfo.weight == 13)) {
+      if (*type == AMDSMI_LINK_TYPE_XGMI && (tinfo.weight == 15 || tinfo.weight == 41 || tinfo.weight == 13)) {
         *hops = 1;
-        if (tinfo.max_bandwidth && tinfo.min_bandwidth)
-          *count = tinfo.max_bandwidth/tinfo.min_bandwidth;
+        if (tinfo.max_bandwidth && tinfo.min_bandwidth) *count = tinfo.max_bandwidth / tinfo.min_bandwidth;
       }
     }
   }
@@ -495,7 +520,7 @@ ncclResult_t amd_smi_getLinkInfo(int srcIndex, int dstIndex, amdsmi_link_type_t*
 ncclResult_t amd_smi_getFirmwareVersion(uint32_t deviceIndex, uint64_t* fwVersion) {
   if (__atomic_load_n(&is_wsl2, __ATOMIC_ACQUIRE)) {
     *fwVersion = 0;
-    return ncclSuccess;  // Firmware query not supported on WSL2
+    return ncclSuccess; // Firmware query not supported on WSL2
   }
 
   if (rcclParamUseAmdSmiLib()) {
@@ -528,7 +553,6 @@ ncclResult_t amd_smi_getFirmwareVersion(uint32_t deviceIndex, uint64_t* fwVersio
  * These functions provide access to AMD's UALoE fabric for scale-up
  * networking, similar to how nvmlwrap.cc provides MNNVL support for NVIDIA.
  ************************************************************************/
-
 
 ncclResult_t amd_smi_ensureFabricInitialized() {
   // Optimization to avoid repeatedly grabbing the lock when we only want to
@@ -581,19 +605,21 @@ ncclResult_t amd_smi_ensureFabricInitialized() {
         continue;
       }
       devInfo->fabricSupported = (bool)arsmiInfo.supported;
-      devInfo->fabricType      = (amdsmi_fabric_type_t)arsmiInfo.fabric_type;
-      devInfo->state           = (amdsmi_fabric_accelerator_vpod_state_t)arsmiInfo.accel_state;
-      devInfo->acceleratorId   = arsmiInfo.accel_id;
-      devInfo->bandwidth       = arsmiInfo.bandwidth;
-      devInfo->latency         = arsmiInfo.latency;
+      devInfo->fabricType = (amdsmi_fabric_type_t)arsmiInfo.fabric_type;
+      devInfo->state = (amdsmi_fabric_accelerator_vpod_state_t)arsmiInfo.accel_state;
+      devInfo->acceleratorId = arsmiInfo.accel_id;
+      devInfo->bandwidth = arsmiInfo.bandwidth;
+      devInfo->latency = arsmiInfo.latency;
       memcpy(devInfo->clusterUuid, arsmiInfo.ppod_id, sizeof(devInfo->clusterUuid));
-      devInfo->ppodSize        = arsmiInfo.ppod_size;
-      devInfo->cliqueId        = arsmiInfo.vpod_id;
-      devInfo->vpodSize        = arsmiInfo.vpod_size;
+      devInfo->ppodSize = arsmiInfo.ppod_size;
+      devInfo->cliqueId = arsmiInfo.vpod_id;
+      devInfo->vpodSize = arsmiInfo.vpod_size;
     } else {
       amdsmi_processor_handle procHandle;
       if (getProcessorHandle(d, &procHandle) != ncclSuccess || !amd_smi_FabricFunctionsLoaded()) {
-        WARN("AMD SMI fabric: unable to get processor handle or fabric functions not loaded for device %u, skipping fabric detection", d);
+        WARN("AMD SMI fabric: unable to get processor handle or fabric functions not loaded for device %u, skipping "
+             "fabric detection",
+             d);
         devInfo->fabricSupported = false;
         continue;
       }
@@ -611,29 +637,29 @@ ncclResult_t amd_smi_ensureFabricInitialized() {
         continue;
       }
       const amdsmi_fabric_info_v1_t* v1 = &fabricInfo.fabric_info.fabric_version.v1;
-      devInfo->fabricSupported = ((v1->fabric_type == AMDSMI_FABRIC_TYPE_UALOE ||
-                                   v1->fabric_type == AMDSMI_FABRIC_TYPE_UALLINK) &&
-                                  (v1->accel_state == AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_ACTIVE ||
-                                   v1->accel_state == AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_READY));
-      devInfo->fabricType    = v1->fabric_type;
-      devInfo->state         = v1->accel_state;
+      devInfo->fabricSupported =
+        ((v1->fabric_type == AMDSMI_FABRIC_TYPE_UALOE || v1->fabric_type == AMDSMI_FABRIC_TYPE_UALLINK) &&
+         (v1->accel_state == AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_ACTIVE ||
+          v1->accel_state == AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_READY));
+      devInfo->fabricType = v1->fabric_type;
+      devInfo->state = v1->accel_state;
       devInfo->acceleratorId = v1->accelerator_id;
-      devInfo->bandwidth     = v1->bandwidth;
-      devInfo->latency       = v1->latency;
+      devInfo->bandwidth = v1->bandwidth;
+      devInfo->latency = v1->latency;
       memcpy(devInfo->clusterUuid, v1->ppod_id, sizeof(v1->ppod_id));
-      devInfo->ppodSize      = v1->ppod_size;
-      devInfo->cliqueId      = v1->vpod_id;
-      devInfo->vpodSize      = v1->vpod_size;
+      devInfo->ppodSize = v1->ppod_size;
+      devInfo->cliqueId = v1->vpod_id;
+      devInfo->vpodSize = v1->vpod_size;
     }
 
     if (devInfo->fabricSupported) {
       uint64_t uuidHigh, uuidLow;
       memcpy(&uuidHigh, devInfo->clusterUuid, sizeof(uint64_t));
-      memcpy(&uuidLow,  devInfo->clusterUuid + sizeof(uint64_t), sizeof(uint64_t));
+      memcpy(&uuidLow, devInfo->clusterUuid + sizeof(uint64_t), sizeof(uint64_t));
       const char* typeStr = (devInfo->fabricType == AMDSMI_FABRIC_TYPE_UALLINK) ? "UALLink" : "UALoE";
-      INFO(NCCL_INIT, "GPU %d: %s fabric detected%s - accelId=%u bw=%uMb/s lat=%uns vpod=%u/%u uuid=%lx.%lx ppod_size=%u",
-           d, typeStr, useSysfs ? " (sysfs)" : "",
-           devInfo->acceleratorId, devInfo->bandwidth, devInfo->latency,
+      INFO(NCCL_INIT,
+           "GPU %d: %s fabric detected%s - accelId=%u bw=%uMb/s lat=%uns vpod=%u/%u uuid=%lx.%lx ppod_size=%u", d,
+           typeStr, useSysfs ? " (sysfs)" : "", devInfo->acceleratorId, devInfo->bandwidth, devInfo->latency,
            devInfo->cliqueId, devInfo->vpodSize, uuidHigh, uuidLow, devInfo->ppodSize);
     }
   }
@@ -677,14 +703,13 @@ ncclResult_t amd_smi_getFabricBandwidth(uint32_t deviceIndex, uint32_t* bandwidt
   if (devInfo->fabricSupported) {
     *bandwidthMbps = devInfo->bandwidth;
   } else {
-    *bandwidthMbps = 0;  // Indicate fallback to arch-based defaults
+    *bandwidthMbps = 0; // Indicate fallback to arch-based defaults
   }
 
   return ncclSuccess;
 }
 
-ncclResult_t amd_smi_allocFabricTelemetry(uint32_t deviceIndex,
-                                          uint32_t categoryMask,
+ncclResult_t amd_smi_allocFabricTelemetry(uint32_t deviceIndex, uint32_t categoryMask,
                                           amdsmi_fabric_telemetry_t** telemetry) {
   if (!rcclParamUseAmdSmiLib()) {
     return ncclSystemError;
@@ -698,8 +723,7 @@ ncclResult_t amd_smi_allocFabricTelemetry(uint32_t deviceIndex,
   return ncclSuccess;
 }
 
-ncclResult_t amd_smi_getFabricTelemetryData(uint32_t deviceIndex,
-                                            amdsmi_fabric_telemetry_t* telemetry) {
+ncclResult_t amd_smi_getFabricTelemetryData(uint32_t deviceIndex, amdsmi_fabric_telemetry_t* telemetry) {
   if (!rcclParamUseAmdSmiLib() || telemetry == nullptr) {
     return ncclSystemError;
   }
@@ -711,8 +735,7 @@ ncclResult_t amd_smi_getFabricTelemetryData(uint32_t deviceIndex,
   return ncclSuccess;
 }
 
-ncclResult_t amd_smi_freeFabricTelemetry(uint32_t deviceIndex,
-                                         amdsmi_fabric_telemetry_t* telemetry) {
+ncclResult_t amd_smi_freeFabricTelemetry(uint32_t deviceIndex, amdsmi_fabric_telemetry_t* telemetry) {
   if (!rcclParamUseAmdSmiLib() || telemetry == nullptr) {
     return ncclSystemError;
   }

--- a/projects/rccl/src/misc/api_trace.cc
+++ b/projects/rccl/src/misc/api_trace.cc
@@ -1,4 +1,3 @@
-
 #include "api_trace.h"
 #include "core.h"
 #include "nccl.h"
@@ -12,187 +11,127 @@
 #include <vector>
 
 #if defined(RCCL_ROCPROFILER_REGISTER) && RCCL_ROCPROFILER_REGISTER > 0
-#    include <rocprofiler-register/rocprofiler-register.h>
+#include <rocprofiler-register/rocprofiler-register.h>
 
-#    define ROCP_REG_VERSION                                                             \
-        ROCPROFILER_REGISTER_COMPUTE_VERSION_3(NCCL_MAJOR, NCCL_MINOR, NCCL_PATCH)
+#define ROCP_REG_VERSION ROCPROFILER_REGISTER_COMPUTE_VERSION_3(NCCL_MAJOR, NCCL_MINOR, NCCL_PATCH)
 
 ROCPROFILER_REGISTER_DEFINE_IMPORT(rccl, ROCP_REG_VERSION)
 #endif
 
-ncclResult_t
-ncclAllGather_impl(const void* sendbuff, void* recvbuff, size_t sendcount,
-                   ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream);
+ncclResult_t ncclAllGather_impl(const void* sendbuff, void* recvbuff, size_t sendcount, ncclDataType_t datatype,
+                                ncclComm_t comm, cudaStream_t stream);
 
-ncclResult_t
-ncclAllReduce_impl(const void* sendbuff, void* recvbuff, size_t count,
-                   ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm,
-                   cudaStream_t stream);
+ncclResult_t ncclAllReduce_impl(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
+                                ncclRedOp_t op, ncclComm* comm, cudaStream_t stream);
 
-ncclResult_t
-ncclAlltoAll_impl(const void* sendbuff, void* recvbuff, size_t count,
-                  ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream);
+ncclResult_t ncclAlltoAll_impl(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
+                               ncclComm_t comm, hipStream_t stream);
 
-ncclResult_t
-ncclAlltoAllv_impl(const void* sendbuff, const size_t sendcounts[],
-                   const size_t sdispls[], void* recvbuff, const size_t recvcounts[],
-                   const size_t rdispls[], ncclDataType_t datatype, ncclComm_t comm,
-                   hipStream_t stream);
+ncclResult_t ncclAlltoAllv_impl(const void* sendbuff, const size_t sendcounts[], const size_t sdispls[], void* recvbuff,
+                                const size_t recvcounts[], const size_t rdispls[], ncclDataType_t datatype,
+                                ncclComm_t comm, hipStream_t stream);
 
-ncclResult_t
-ncclBroadcast_impl(const void* sendbuff, void* recvbuff, size_t count,
-                   ncclDataType_t datatype, int root, ncclComm_t comm,
-                   cudaStream_t stream);
+ncclResult_t ncclBroadcast_impl(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, int root,
+                                ncclComm_t comm, cudaStream_t stream);
 
-ncclResult_t
-ncclGather_impl(const void* sendbuff, void* recvbuff, size_t sendcount,
-                ncclDataType_t datatype, int root, ncclComm_t comm, hipStream_t stream);
+ncclResult_t ncclGather_impl(const void* sendbuff, void* recvbuff, size_t sendcount, ncclDataType_t datatype, int root,
+                             ncclComm_t comm, hipStream_t stream);
 
-ncclResult_t
-ncclReduce_impl(const void* sendbuff, void* recvbuff, size_t count,
-                ncclDataType_t datatype, ncclRedOp_t op, int root, ncclComm_t comm,
-                cudaStream_t stream);
+ncclResult_t ncclReduce_impl(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
+                             ncclRedOp_t op, int root, ncclComm_t comm, cudaStream_t stream);
 
-ncclResult_t
-ncclReduceScatter_impl(const void* sendbuff, void* recvbuff, size_t recvcount,
-                       ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm,
-                       cudaStream_t stream);
+ncclResult_t ncclReduceScatter_impl(const void* sendbuff, void* recvbuff, size_t recvcount, ncclDataType_t datatype,
+                                    ncclRedOp_t op, ncclComm* comm, cudaStream_t stream);
 
-ncclResult_t
-ncclScatter_impl(const void* sendbuff, void* recvbuff, size_t recvcount,
-                 ncclDataType_t datatype, int root, ncclComm_t comm, hipStream_t stream);
+ncclResult_t ncclScatter_impl(const void* sendbuff, void* recvbuff, size_t recvcount, ncclDataType_t datatype, int root,
+                              ncclComm_t comm, hipStream_t stream);
 
-ncclResult_t
-ncclSend_impl(const void* sendbuff, size_t count, ncclDataType_t datatype, int peer,
-              ncclComm_t comm, cudaStream_t stream);
+ncclResult_t ncclSend_impl(const void* sendbuff, size_t count, ncclDataType_t datatype, int peer, ncclComm_t comm,
+                           cudaStream_t stream);
 
-ncclResult_t
-ncclRecv_impl(void* recvbuff, size_t count, ncclDataType_t datatype, int peer,
-              ncclComm_t comm, cudaStream_t stream);
+ncclResult_t ncclRecv_impl(void* recvbuff, size_t count, ncclDataType_t datatype, int peer, ncclComm_t comm,
+                           cudaStream_t stream);
 
-ncclResult_t
-ncclPutSignal_impl(const void* localbuff, size_t count, ncclDataType_t datatype,
-                   int peer, ncclWindow_t peerWin, size_t peerWinOffset,
-                   int sigIdx, int ctx, unsigned int flags,
-                   ncclComm_t comm, cudaStream_t stream);
+ncclResult_t ncclPutSignal_impl(const void* localbuff, size_t count, ncclDataType_t datatype, int peer,
+                                ncclWindow_t peerWin, size_t peerWinOffset, int sigIdx, int ctx, unsigned int flags,
+                                ncclComm_t comm, cudaStream_t stream);
 
-ncclResult_t
-ncclSignal_impl(int peer, int sigIdx, int ctx, unsigned int flags,
-                ncclComm_t comm, cudaStream_t stream);
+ncclResult_t ncclSignal_impl(int peer, int sigIdx, int ctx, unsigned int flags, ncclComm_t comm, cudaStream_t stream);
 
-ncclResult_t
-ncclWaitSignal_impl(int nDesc, ncclWaitSignalDesc_t* signalDescs,
-                    ncclComm_t comm, cudaStream_t stream);
+ncclResult_t ncclWaitSignal_impl(int nDesc, ncclWaitSignalDesc_t* signalDescs, ncclComm_t comm, cudaStream_t stream);
 
-ncclResult_t
-ncclRedOpCreatePreMulSum_impl(ncclRedOp_t* op, void* scalar, ncclDataType_t datatype,
-                              ncclScalarResidence_t residence, ncclComm_t comm);
+ncclResult_t ncclRedOpCreatePreMulSum_impl(ncclRedOp_t* op, void* scalar, ncclDataType_t datatype,
+                                           ncclScalarResidence_t residence, ncclComm_t comm);
 
-ncclResult_t
-ncclRedOpDestroy_impl(ncclRedOp_t op, ncclComm_t comm);
+ncclResult_t ncclRedOpDestroy_impl(ncclRedOp_t op, ncclComm_t comm);
 
-ncclResult_t
-ncclGroupStart_impl();
+ncclResult_t ncclGroupStart_impl();
 
-ncclResult_t
-ncclGroupEnd_impl();
+ncclResult_t ncclGroupEnd_impl();
 
-ncclResult_t
-ncclGetVersion_impl(int* version);
+ncclResult_t ncclGetVersion_impl(int* version);
 
-ncclResult_t
-ncclGetUniqueId_impl(ncclUniqueId* out);
+ncclResult_t ncclGetUniqueId_impl(ncclUniqueId* out);
 
-ncclResult_t
-ncclCommInitRank_impl(ncclComm_t* newcomm, int nranks, ncclUniqueId commId, int myrank);
+ncclResult_t ncclCommInitRank_impl(ncclComm_t* newcomm, int nranks, ncclUniqueId commId, int myrank);
 
-ncclResult_t
-ncclCommInitAll_impl(ncclComm_t* comms, int ndev, const int* devlist);
+ncclResult_t ncclCommInitAll_impl(ncclComm_t* comms, int ndev, const int* devlist);
 
-ncclResult_t
-ncclCommInitRankConfig_impl(ncclComm_t* comm, int nranks, ncclUniqueId commId, int myrank,
-                            ncclConfig_t* config);
+ncclResult_t ncclCommInitRankConfig_impl(ncclComm_t* comm, int nranks, ncclUniqueId commId, int myrank,
+                                         ncclConfig_t* config);
 
-ncclResult_t
-ncclCommFinalize_impl(ncclComm_t comm);
+ncclResult_t ncclCommFinalize_impl(ncclComm_t comm);
 
-ncclResult_t
-ncclCommDestroy_impl(ncclComm_t comm);
+ncclResult_t ncclCommDestroy_impl(ncclComm_t comm);
 
-ncclResult_t
-ncclCommAbort_impl(ncclComm_t comm);
+ncclResult_t ncclCommAbort_impl(ncclComm_t comm);
 
-ncclResult_t
-ncclCommRevoke_impl(ncclComm_t comm, int revokeFlags);
+ncclResult_t ncclCommRevoke_impl(ncclComm_t comm, int revokeFlags);
 
-ncclResult_t
-ncclCommShrink_impl(ncclComm_t comm, int* excludeRanksList, int excludeRanksCount, ncclComm_t *newcomm,
-                    ncclConfig_t* config, int shrinkFlags);
+ncclResult_t ncclCommShrink_impl(ncclComm_t comm, int* excludeRanksList, int excludeRanksCount, ncclComm_t* newcomm,
+                                 ncclConfig_t* config, int shrinkFlags);
 
-ncclResult_t
-ncclCommSplit_impl(ncclComm_t comm, int color, int key, ncclComm_t* newcomm,
-                   ncclConfig_t* config);
+ncclResult_t ncclCommSplit_impl(ncclComm_t comm, int color, int key, ncclComm_t* newcomm, ncclConfig_t* config);
 
-const char*
-ncclGetErrorString_impl(ncclResult_t code);
+const char* ncclGetErrorString_impl(ncclResult_t code);
 
-const char*
-ncclGetLastError_impl(const ncclComm_t comm);
+const char* ncclGetLastError_impl(const ncclComm_t comm);
 
-ncclResult_t
-ncclCommGetAsyncError_impl(ncclComm_t comm, ncclResult_t* asyncError);
+ncclResult_t ncclCommGetAsyncError_impl(ncclComm_t comm, ncclResult_t* asyncError);
 
-ncclResult_t
-ncclCommCount_impl(const ncclComm_t comm, int* count);
+ncclResult_t ncclCommCount_impl(const ncclComm_t comm, int* count);
 
-ncclResult_t
-ncclCommCuDevice_impl(const ncclComm_t comm, int* devid);
+ncclResult_t ncclCommCuDevice_impl(const ncclComm_t comm, int* devid);
 
-ncclResult_t
-ncclCommUserRank_impl(const ncclComm_t comm, int* rank);
+ncclResult_t ncclCommUserRank_impl(const ncclComm_t comm, int* rank);
 
-ncclResult_t
-ncclMemAlloc_impl(void** ptr, size_t size);
+ncclResult_t ncclMemAlloc_impl(void** ptr, size_t size);
 
-ncclResult_t
-ncclMemFree_impl(void* ptr);
+ncclResult_t ncclMemFree_impl(void* ptr);
 
-ncclResult_t
-ncclCommRegister_impl(const ncclComm_t comm, void* buff, size_t size, void** handle);
+ncclResult_t ncclCommRegister_impl(const ncclComm_t comm, void* buff, size_t size, void** handle);
 
-ncclResult_t
-ncclCommDeregister_impl(const ncclComm_t comm, void* handle);
+ncclResult_t ncclCommDeregister_impl(const ncclComm_t comm, void* handle);
 
-ncclResult_t
-ncclCommWindowRegister_impl(ncclComm_t comm, void* buff, size_t size, ncclWindow_t* win, int winFlags);
+ncclResult_t ncclCommWindowRegister_impl(ncclComm_t comm, void* buff, size_t size, ncclWindow_t* win, int winFlags);
 
-ncclResult_t
-ncclCommWindowDeregister_impl(ncclComm_t comm, ncclWindow_t win);
+ncclResult_t ncclCommWindowDeregister_impl(ncclComm_t comm, ncclWindow_t win);
 
-ncclResult_t
-ncclCommSuspend_impl(ncclComm_t comm, int flags);
+ncclResult_t ncclCommSuspend_impl(ncclComm_t comm, int flags);
 
-ncclResult_t
-ncclCommResume_impl(ncclComm_t comm);
+ncclResult_t ncclCommResume_impl(ncclComm_t comm);
 
-ncclResult_t
-ncclCommMemStats_impl(ncclComm_t comm, ncclCommMemStat_t stat, uint64_t* value);
+ncclResult_t ncclCommMemStats_impl(ncclComm_t comm, ncclCommMemStat_t stat, uint64_t* value);
 
-ncclResult_t
-ncclCommGetUniqueId_impl(ncclComm_t comm, ncclUniqueId* uniqueId);
+ncclResult_t ncclCommGetUniqueId_impl(ncclComm_t comm, ncclUniqueId* uniqueId);
 
-ncclResult_t
-ncclCommGrow_impl(ncclComm_t comm, int nRanks, const ncclUniqueId* uniqueId,
-                  int rank, ncclComm_t* newcomm, ncclConfig_t* config);
+ncclResult_t ncclCommGrow_impl(ncclComm_t comm, int nRanks, const ncclUniqueId* uniqueId, int rank, ncclComm_t* newcomm,
+                               ncclConfig_t* config);
 
-ncclResult_t
-ncclAllReduceWithBias_impl(const void* sendbuff, void* recvbuff, size_t count,
-                   ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm,
-                   cudaStream_t stream, const void* acc);
+ncclResult_t ncclAllReduceWithBias_impl(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
+                                        ncclRedOp_t op, ncclComm* comm, cudaStream_t stream, const void* acc);
 
-ncclResult_t
-mscclLoadAlgo_impl(const char* mscclAlgoFilePath, mscclAlgoHandle_t* mscclAlgoHandle, int rank)
-{
+ncclResult_t mscclLoadAlgo_impl(const char* mscclAlgoFilePath, mscclAlgoHandle_t* mscclAlgoHandle, int rank) {
   (void)mscclAlgoFilePath;
   (void)mscclAlgoHandle;
   (void)rank;
@@ -201,12 +140,10 @@ mscclLoadAlgo_impl(const char* mscclAlgoFilePath, mscclAlgoHandle_t* mscclAlgoHa
   return ncclSuccess;
 }
 
-ncclResult_t
-mscclRunAlgo_impl(const void* sendBuff, const size_t sendCounts[], const size_t sDisPls[],
-                  void* recvBuff, const size_t recvCounts[], const size_t rDisPls[],
-                  size_t count, ncclDataType_t dataType, int root, int peer, ncclRedOp_t op,
-                  mscclAlgoHandle_t mscclAlgoHandle, ncclComm_t comm, hipStream_t stream)
-{
+ncclResult_t mscclRunAlgo_impl(const void* sendBuff, const size_t sendCounts[], const size_t sDisPls[], void* recvBuff,
+                               const size_t recvCounts[], const size_t rDisPls[], size_t count, ncclDataType_t dataType,
+                               int root, int peer, ncclRedOp_t op, mscclAlgoHandle_t mscclAlgoHandle, ncclComm_t comm,
+                               hipStream_t stream) {
   (void)sendBuff;
   (void)sendCounts;
   (void)sDisPls;
@@ -222,41 +159,31 @@ mscclRunAlgo_impl(const void* sendBuff, const size_t sendCounts[], const size_t 
   (void)comm;
   (void)stream;
   rccl::Recorder::instance().record("mscclRunAlgo");
-  NVTX3_FUNC_WITH_PARAMS(MSCCL, NcclNvtxParamsMSCCL,
-    NVTX3_PAYLOAD(0, count * ncclTypeSize(dataType), op, dataType));
+  NVTX3_FUNC_WITH_PARAMS(MSCCL, NcclNvtxParamsMSCCL, NVTX3_PAYLOAD(0, count * ncclTypeSize(dataType), op, dataType));
   WARN("MSCCL support has been removed from RCCL; mscclRunAlgo has no effect.");
   return ncclSuccess;
 }
 
-ncclResult_t
-mscclUnloadAlgo_impl(mscclAlgoHandle_t mscclAlgoHandle)
-{
+ncclResult_t mscclUnloadAlgo_impl(mscclAlgoHandle_t mscclAlgoHandle) {
   (void)mscclAlgoHandle;
   rccl::Recorder::instance().record("mscclUnloadAlgo");
   WARN("MSCCL support has been removed from RCCL; mscclUnloadAlgo has no effect.");
   return ncclSuccess;
 }
 
-namespace rccl
-{
-namespace
-{
+namespace rccl {
+namespace {
 
-constexpr size_t
-compute_table_offset(size_t n)
-{
-    return (sizeof(uint64_t) + (n * sizeof(void*)));
+constexpr size_t compute_table_offset(size_t n) {
+  return (sizeof(uint64_t) + (n * sizeof(void*)));
 }
 
-constexpr size_t
-compute_table_size(size_t nmembers)
-{
-    return (sizeof(uint64_t) + (nmembers * sizeof(void*)));
+constexpr size_t compute_table_size(size_t nmembers) {
+  return (sizeof(uint64_t) + (nmembers * sizeof(void*)));
 }
 
-#define RCCL_ASSERT_OFFSET(TABLE, MEMBER, IDX)                                           \
-    static_assert(offsetof(TABLE, MEMBER) == compute_table_offset(IDX),                  \
-                  "Do not re-arrange the table members")
+#define RCCL_ASSERT_OFFSET(TABLE, MEMBER, IDX) \
+  static_assert(offsetof(TABLE, MEMBER) == compute_table_offset(IDX), "Do not re-arrange the table members")
 
 // DO NOT REORDER, ADD NEW ITEMS TO BOTTOM
 RCCL_ASSERT_OFFSET(rcclApiFuncTable, ncclAllGather_fn, 0);
@@ -321,159 +248,145 @@ static_assert(sizeof(rcclApiFuncTable) == compute_table_size(52),
 
 std::array<unsigned char, sizeof(rcclApiFuncTable)> m_buffer = {};
 
-rcclApiFuncTable*
-RcclGetFunctionTable_impl()
-{
-    static auto* tbl =
-        new(m_buffer.data()) rcclApiFuncTable{ sizeof(rcclApiFuncTable),
-                                               &ncclAllGather_impl,
-                                               &ncclAllReduce_impl,
-                                               nullptr,
-                                               nullptr,
-                                               &ncclBroadcast_impl,
-                                               &ncclGather_impl,
-                                               &ncclReduce_impl,
-                                               &ncclReduceScatter_impl,
-                                               &ncclScatter_impl,
-                                               &ncclSend_impl,
-                                               &ncclRecv_impl,
-                                               &ncclRedOpCreatePreMulSum_impl,
-                                               &ncclRedOpDestroy_impl,
-                                               &ncclGroupStart_impl,
-                                               &ncclGroupEnd_impl,
-                                               &ncclGetVersion_impl,
-                                               &ncclGetUniqueId_impl,
-                                               &ncclCommInitRank_impl,
-                                               &ncclCommInitAll_impl,
-                                               &ncclCommInitRankConfig_impl,
-                                               &ncclCommFinalize_impl,
-                                               &ncclCommDestroy_impl,
-                                               &ncclCommAbort_impl,
-                                               &ncclCommSplit_impl,
-                                               &ncclGetErrorString_impl,
-                                               &ncclGetLastError_impl,
-                                               &ncclCommGetAsyncError_impl,
-                                               &ncclCommCount_impl,
-                                               &ncclCommCuDevice_impl,
-                                               &ncclCommUserRank_impl,
-                                               &ncclMemAlloc_impl,
-                                               &ncclMemFree_impl,
-                                               &mscclLoadAlgo_impl,
-                                               &mscclRunAlgo_impl,
-                                               &mscclUnloadAlgo_impl,
-                                               &ncclCommRegister_impl,
-                                               &ncclCommDeregister_impl,
-                                               &ncclAllReduceWithBias_impl,
-                                               &ncclCommShrink_impl,
-                                               &ncclCommWindowRegister_impl,
-                                               &ncclCommWindowDeregister_impl,
-                                               &ncclAlltoAll_impl,
-                                               &ncclAlltoAllv_impl,
-                                               &ncclCommRevoke_impl,
-                                               &ncclCommSuspend_impl,
-                                               &ncclCommResume_impl,
-                                               &ncclCommMemStats_impl,
-                                               &ncclPutSignal_impl,
-                                               &ncclSignal_impl,
-                                               &ncclWaitSignal_impl,
-                                               &ncclCommGetUniqueId_impl,
-                                               &ncclCommGrow_impl
+rcclApiFuncTable* RcclGetFunctionTable_impl() {
+  static auto* tbl = new (m_buffer.data()) rcclApiFuncTable{
+    sizeof(rcclApiFuncTable),
+    &ncclAllGather_impl,
+    &ncclAllReduce_impl,
+    nullptr,
+    nullptr,
+    &ncclBroadcast_impl,
+    &ncclGather_impl,
+    &ncclReduce_impl,
+    &ncclReduceScatter_impl,
+    &ncclScatter_impl,
+    &ncclSend_impl,
+    &ncclRecv_impl,
+    &ncclRedOpCreatePreMulSum_impl,
+    &ncclRedOpDestroy_impl,
+    &ncclGroupStart_impl,
+    &ncclGroupEnd_impl,
+    &ncclGetVersion_impl,
+    &ncclGetUniqueId_impl,
+    &ncclCommInitRank_impl,
+    &ncclCommInitAll_impl,
+    &ncclCommInitRankConfig_impl,
+    &ncclCommFinalize_impl,
+    &ncclCommDestroy_impl,
+    &ncclCommAbort_impl,
+    &ncclCommSplit_impl,
+    &ncclGetErrorString_impl,
+    &ncclGetLastError_impl,
+    &ncclCommGetAsyncError_impl,
+    &ncclCommCount_impl,
+    &ncclCommCuDevice_impl,
+    &ncclCommUserRank_impl,
+    &ncclMemAlloc_impl,
+    &ncclMemFree_impl,
+    &mscclLoadAlgo_impl,
+    &mscclRunAlgo_impl,
+    &mscclUnloadAlgo_impl,
+    &ncclCommRegister_impl,
+    &ncclCommDeregister_impl,
+    &ncclAllReduceWithBias_impl,
+    &ncclCommShrink_impl,
+    &ncclCommWindowRegister_impl,
+    &ncclCommWindowDeregister_impl,
+    &ncclAlltoAll_impl,
+    &ncclAlltoAllv_impl,
+    &ncclCommRevoke_impl,
+    &ncclCommSuspend_impl,
+    &ncclCommResume_impl,
+    &ncclCommMemStats_impl,
+    &ncclPutSignal_impl,
+    &ncclSignal_impl,
+    &ncclWaitSignal_impl,
+    &ncclCommGetUniqueId_impl,
+    &ncclCommGrow_impl
                                                // DO NOT REORDER, ADD NEW ITEMS HERE
-                                             };
+  };
 
 #if defined(RCCL_ROCPROFILER_REGISTER) && RCCL_ROCPROFILER_REGISTER > 0
-    std::array<void*, 1>                       table_array{ tbl };
-    rocprofiler_register_library_indentifier_t lib_id =
-        rocprofiler_register_library_indentifier_t{};
-    rocprofiler_register_error_code_t rocp_reg_status =
-        rocprofiler_register_library_api_table(
-            "rccl", &ROCPROFILER_REGISTER_IMPORT_FUNC(rccl), ROCP_REG_VERSION,
-            table_array.data(), table_array.size(), &lib_id);
+  std::array<void*, 1> table_array{tbl};
+  rocprofiler_register_library_indentifier_t lib_id = rocprofiler_register_library_indentifier_t{};
+  rocprofiler_register_error_code_t rocp_reg_status = rocprofiler_register_library_api_table(
+    "rccl", &ROCPROFILER_REGISTER_IMPORT_FUNC(rccl), ROCP_REG_VERSION, table_array.data(), table_array.size(), &lib_id);
 
-    INFO(NCCL_COLL,
-         "[rocprofiler-sdk-rccl][ = %d ] rocprofiler-register returned code = %d : %s",
+  INFO(NCCL_COLL, "[rocprofiler-sdk-rccl][ = %d ] rocprofiler-register returned code = %d : %s", getpid(),
+       rocp_reg_status, rocprofiler_register_error_string(rocp_reg_status));
+
+  if (rocp_reg_status != ROCP_REG_SUCCESS && rocp_reg_status != ROCP_REG_NO_TOOLS)
+    WARN("[rocprofiler-sdk-rccl][%d] rocprofiler-register failed with error code %d "
+         ": %s",
          getpid(), rocp_reg_status, rocprofiler_register_error_string(rocp_reg_status));
-
-    if(rocp_reg_status != ROCP_REG_SUCCESS && rocp_reg_status != ROCP_REG_NO_TOOLS)
-        WARN("[rocprofiler-sdk-rccl][%d] rocprofiler-register failed with error code %d "
-             ": %s",
-             getpid(), rocp_reg_status,
-             rocprofiler_register_error_string(rocp_reg_status));
 #endif
 
-    return tbl;
+  return tbl;
 }
 }  // end of namespace
 
-const rcclApiFuncTable*
-RcclGetFunctionTable()
-{
-    static const auto* tbl = RcclGetFunctionTable_impl();
-    return tbl;
+const rcclApiFuncTable* RcclGetFunctionTable() {
+  static const auto* tbl = RcclGetFunctionTable_impl();
+  return tbl;
 }
 }  // end of namespace rccl
 
-NCCL_API(ncclResult_t, ncclAllGather, const void* sendbuff, void* recvbuff,
-         size_t sendcount, ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream);
+NCCL_API(ncclResult_t, ncclAllGather, const void* sendbuff, void* recvbuff, size_t sendcount, ncclDataType_t datatype,
+         ncclComm_t comm, cudaStream_t stream);
 
-NCCL_API(ncclResult_t, ncclAllReduce, const void* sendbuff, void* recvbuff, size_t count,
-         ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm, hipStream_t stream);
+NCCL_API(ncclResult_t, ncclAllReduce, const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
+         ncclRedOp_t op, ncclComm* comm, hipStream_t stream);
 
 NCCL_API(ncclResult_t, ncclAllReduceWithBias, const void* sendbuff, void* recvbuff, size_t count,
          ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm, hipStream_t stream, const void* acc);
 
-NCCL_API(ncclResult_t, ncclAlltoAll, const void* sendbuff, void* recvbuff, size_t count,
-         ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream);
-
-NCCL_API(ncclResult_t, ncclAllToAll, const void* sendbuff, void* recvbuff, size_t count,
-        ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream);
-
-NCCL_API(ncclResult_t, ncclAlltoAllv, const void* sendbuff, const size_t sendcounts[],
-         const size_t sdispls[], void* recvbuff, const size_t recvcounts[],
-         const size_t rdispls[], ncclDataType_t datatype, ncclComm_t comm,
-         hipStream_t stream);
-
-NCCL_API(ncclResult_t, ncclAllToAllv, const void* sendbuff, const size_t sendcounts[],
-        const size_t sdispls[], void* recvbuff, const size_t recvcounts[],
-        const size_t rdispls[], ncclDataType_t datatype, ncclComm_t comm,
-        hipStream_t stream);
-
-NCCL_API(ncclResult_t, ncclBroadcast, const void* sendbuff, void* recvbuff, size_t count,
-         ncclDataType_t datatype, int root, ncclComm_t comm, hipStream_t stream);
-
-NCCL_API(ncclResult_t, ncclGather, const void* sendbuff, void* recvbuff, size_t sendcount,
-         ncclDataType_t datatype, int root, ncclComm_t comm, hipStream_t stream);
-
-NCCL_API(ncclResult_t, ncclReduce, const void* sendbuff, void* recvbuff, size_t count,
-         ncclDataType_t datatype, ncclRedOp_t op, int root, ncclComm_t comm,
-         hipStream_t stream);
-
-NCCL_API(ncclResult_t, ncclReduceScatter, const void* sendbuff, void* recvbuff,
-         size_t recvcount, ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm,
-         hipStream_t stream);
-
-NCCL_API(ncclResult_t, ncclScatter, const void* sendbuff, void* recvbuff,
-         size_t recvcount, ncclDataType_t datatype, int root, ncclComm_t comm,
-         hipStream_t stream);
-
-NCCL_API(ncclResult_t, ncclSend, const void* sendbuff, size_t count,
-         ncclDataType_t datatype, int peer, ncclComm_t comm, hipStream_t stream);
-
-NCCL_API(ncclResult_t, ncclRecv, void* recvbuff, size_t count, ncclDataType_t datatype,
-         int peer, ncclComm_t comm, hipStream_t stream);
-
-NCCL_API(ncclResult_t, ncclPutSignal, const void* localbuff, size_t count,
-         ncclDataType_t datatype, int peer, ncclWindow_t peerWin, size_t peerWinOffset,
-         int sigIdx, int ctx, unsigned int flags, ncclComm_t comm, hipStream_t stream);
-
-NCCL_API(ncclResult_t, ncclSignal, int peer, int sigIdx, int ctx, unsigned int flags,
+NCCL_API(ncclResult_t, ncclAlltoAll, const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
          ncclComm_t comm, hipStream_t stream);
 
-NCCL_API(ncclResult_t, ncclWaitSignal, int nDesc, ncclWaitSignalDesc_t* signalDescs,
+NCCL_API(ncclResult_t, ncclAllToAll, const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
          ncclComm_t comm, hipStream_t stream);
 
-NCCL_API(ncclResult_t, ncclRedOpCreatePreMulSum, ncclRedOp_t* op, void* scalar,
-         ncclDataType_t datatype, ncclScalarResidence_t residence, ncclComm_t comm);
+NCCL_API(ncclResult_t, ncclAlltoAllv, const void* sendbuff, const size_t sendcounts[], const size_t sdispls[],
+         void* recvbuff, const size_t recvcounts[], const size_t rdispls[], ncclDataType_t datatype, ncclComm_t comm,
+         hipStream_t stream);
+
+NCCL_API(ncclResult_t, ncclAllToAllv, const void* sendbuff, const size_t sendcounts[], const size_t sdispls[],
+         void* recvbuff, const size_t recvcounts[], const size_t rdispls[], ncclDataType_t datatype, ncclComm_t comm,
+         hipStream_t stream);
+
+NCCL_API(ncclResult_t, ncclBroadcast, const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
+         int root, ncclComm_t comm, hipStream_t stream);
+
+NCCL_API(ncclResult_t, ncclGather, const void* sendbuff, void* recvbuff, size_t sendcount, ncclDataType_t datatype,
+         int root, ncclComm_t comm, hipStream_t stream);
+
+NCCL_API(ncclResult_t, ncclReduce, const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
+         ncclRedOp_t op, int root, ncclComm_t comm, hipStream_t stream);
+
+NCCL_API(ncclResult_t, ncclReduceScatter, const void* sendbuff, void* recvbuff, size_t recvcount,
+         ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm, hipStream_t stream);
+
+NCCL_API(ncclResult_t, ncclScatter, const void* sendbuff, void* recvbuff, size_t recvcount, ncclDataType_t datatype,
+         int root, ncclComm_t comm, hipStream_t stream);
+
+NCCL_API(ncclResult_t, ncclSend, const void* sendbuff, size_t count, ncclDataType_t datatype, int peer, ncclComm_t comm,
+         hipStream_t stream);
+
+NCCL_API(ncclResult_t, ncclRecv, void* recvbuff, size_t count, ncclDataType_t datatype, int peer, ncclComm_t comm,
+         hipStream_t stream);
+
+NCCL_API(ncclResult_t, ncclPutSignal, const void* localbuff, size_t count, ncclDataType_t datatype, int peer,
+         ncclWindow_t peerWin, size_t peerWinOffset, int sigIdx, int ctx, unsigned int flags, ncclComm_t comm,
+         hipStream_t stream);
+
+NCCL_API(ncclResult_t, ncclSignal, int peer, int sigIdx, int ctx, unsigned int flags, ncclComm_t comm,
+         hipStream_t stream);
+
+NCCL_API(ncclResult_t, ncclWaitSignal, int nDesc, ncclWaitSignalDesc_t* signalDescs, ncclComm_t comm,
+         hipStream_t stream);
+
+NCCL_API(ncclResult_t, ncclRedOpCreatePreMulSum, ncclRedOp_t* op, void* scalar, ncclDataType_t datatype,
+         ncclScalarResidence_t residence, ncclComm_t comm);
 
 NCCL_API(ncclResult_t, ncclRedOpDestroy, ncclRedOp_t op, ncclComm_t comm);
 
@@ -485,13 +398,12 @@ NCCL_API(ncclResult_t, ncclGetVersion, int* version);
 
 NCCL_API(ncclResult_t, ncclGetUniqueId, ncclUniqueId* out);
 
-NCCL_API(ncclResult_t, ncclCommInitRank, ncclComm_t* newcomm, int nranks,
-         ncclUniqueId commId, int myrank);
+NCCL_API(ncclResult_t, ncclCommInitRank, ncclComm_t* newcomm, int nranks, ncclUniqueId commId, int myrank);
 
 NCCL_API(ncclResult_t, ncclCommInitAll, ncclComm_t* comms, int ndev, const int* devlist);
 
-NCCL_API(ncclResult_t, ncclCommInitRankConfig, ncclComm_t* comm, int nranks,
-         ncclUniqueId commId, int myrank, ncclConfig_t* config);
+NCCL_API(ncclResult_t, ncclCommInitRankConfig, ncclComm_t* comm, int nranks, ncclUniqueId commId, int myrank,
+         ncclConfig_t* config);
 
 NCCL_API(ncclResult_t, ncclCommFinalize, ncclComm_t comm);
 
@@ -504,8 +416,7 @@ NCCL_API(ncclResult_t, ncclCommRevoke, ncclComm_t comm, int revokeFlags);
 NCCL_API(ncclResult_t, ncclCommShrink, ncclComm_t comm, int* excludeRanksList, int excludeRanksCount,
          ncclComm_t* newcomm, ncclConfig_t* config, int shrinkFlags);
 
-NCCL_API(ncclResult_t, ncclCommSplit, ncclComm_t comm, int color, int key,
-         ncclComm_t* newcomm, ncclConfig_t* config);
+NCCL_API(ncclResult_t, ncclCommSplit, ncclComm_t comm, int color, int key, ncclComm_t* newcomm, ncclConfig_t* config);
 
 NCCL_API(const char*, ncclGetErrorString, ncclResult_t code);
 
@@ -523,24 +434,20 @@ NCCL_API(ncclResult_t, ncclMemAlloc, void** ptr, size_t size);
 
 NCCL_API(ncclResult_t, ncclMemFree, void* ptr);
 
-NCCL_API(ncclResult_t, mscclLoadAlgo, const char* mscclAlgoFilePath,
-         mscclAlgoHandle_t* mscclAlgoHandle, int rank);
+NCCL_API(ncclResult_t, mscclLoadAlgo, const char* mscclAlgoFilePath, mscclAlgoHandle_t* mscclAlgoHandle, int rank);
 
-NCCL_API(ncclResult_t, mscclRunAlgo, const void* sendBuff, const size_t sendCounts[],
-         const size_t sDisPls[], void* recvBuff, const size_t recvCounts[],
-         const size_t rDisPls[], size_t count, ncclDataType_t dataType, int root,
-         int peer, ncclRedOp_t op, mscclAlgoHandle_t mscclAlgoHandle, ncclComm_t comm,
-         hipStream_t stream);
+NCCL_API(ncclResult_t, mscclRunAlgo, const void* sendBuff, const size_t sendCounts[], const size_t sDisPls[],
+         void* recvBuff, const size_t recvCounts[], const size_t rDisPls[], size_t count, ncclDataType_t dataType,
+         int root, int peer, ncclRedOp_t op, mscclAlgoHandle_t mscclAlgoHandle, ncclComm_t comm, hipStream_t stream);
 
 NCCL_API(ncclResult_t, mscclUnloadAlgo, mscclAlgoHandle_t mscclAlgoHandle);
 
-NCCL_API(ncclResult_t, ncclCommRegister, const ncclComm_t comm, void* buff, size_t size,
-         void** handle);
+NCCL_API(ncclResult_t, ncclCommRegister, const ncclComm_t comm, void* buff, size_t size, void** handle);
 
 NCCL_API(ncclResult_t, ncclCommDeregister, const ncclComm_t comm, void* handle);
 
-NCCL_API(ncclResult_t, ncclCommWindowRegister, ncclComm_t comm, void* buff, size_t size, 
-         ncclWindow_t* win, int winFlags);
+NCCL_API(ncclResult_t, ncclCommWindowRegister, ncclComm_t comm, void* buff, size_t size, ncclWindow_t* win,
+         int winFlags);
 
 NCCL_API(ncclResult_t, ncclCommWindowDeregister, ncclComm_t comm, ncclWindow_t win);
 
@@ -548,382 +455,252 @@ NCCL_API(ncclResult_t, ncclCommSuspend, ncclComm_t comm, int flags);
 
 NCCL_API(ncclResult_t, ncclCommResume, ncclComm_t comm);
 
-NCCL_API(ncclResult_t, ncclCommMemStats, ncclComm_t comm, ncclCommMemStat_t stat,
-         uint64_t* value);
+NCCL_API(ncclResult_t, ncclCommMemStats, ncclComm_t comm, ncclCommMemStat_t stat, uint64_t* value);
 
 NCCL_API(ncclResult_t, ncclCommGetUniqueId, ncclComm_t comm, ncclUniqueId* uniqueId);
 
-NCCL_API(ncclResult_t, ncclCommGrow, ncclComm_t comm, int nRanks,
-         const ncclUniqueId* uniqueId, int rank, ncclComm_t* newcomm,
-         ncclConfig_t* config);
+NCCL_API(ncclResult_t, ncclCommGrow, ncclComm_t comm, int nRanks, const ncclUniqueId* uniqueId, int rank,
+         ncclComm_t* newcomm, ncclConfig_t* config);
 
-ncclResult_t
-ncclAllGather(const void* sendbuff, void* recvbuff, size_t sendcount,
-              ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclAllGather_fn(sendbuff, recvbuff, sendcount,
-                                                            datatype, comm, stream);
+ncclResult_t ncclAllGather(const void* sendbuff, void* recvbuff, size_t sendcount, ncclDataType_t datatype,
+                           ncclComm_t comm, cudaStream_t stream) {
+  return ::rccl::RcclGetFunctionTable()->ncclAllGather_fn(sendbuff, recvbuff, sendcount, datatype, comm, stream);
 }
 
-ncclResult_t
-ncclAllReduce(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
-              ncclRedOp_t op, ncclComm* comm, cudaStream_t stream)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclAllReduce_fn(sendbuff, recvbuff, count,
-                                                            datatype, op, comm, stream);
+ncclResult_t ncclAllReduce(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, ncclRedOp_t op,
+                           ncclComm* comm, cudaStream_t stream) {
+  return ::rccl::RcclGetFunctionTable()->ncclAllReduce_fn(sendbuff, recvbuff, count, datatype, op, comm, stream);
 }
 
-ncclResult_t
-ncclAllReduceWithBias(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
-              ncclRedOp_t op, ncclComm* comm, cudaStream_t stream, const void* acc)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclAllReduceWithBias_fn(sendbuff, recvbuff, count,
-                                                            datatype, op, comm, stream, acc);
+ncclResult_t ncclAllReduceWithBias(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
+                                   ncclRedOp_t op, ncclComm* comm, cudaStream_t stream, const void* acc) {
+  return ::rccl::RcclGetFunctionTable()->ncclAllReduceWithBias_fn(sendbuff, recvbuff, count, datatype, op, comm, stream,
+                                                                  acc);
 }
 
-ncclResult_t
-ncclAlltoAll(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
-             ncclComm_t comm, hipStream_t stream)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclAlltoAll_fn(sendbuff, recvbuff, count,
-                                                           datatype, comm, stream);
+ncclResult_t ncclAlltoAll(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, ncclComm_t comm,
+                          hipStream_t stream) {
+  return ::rccl::RcclGetFunctionTable()->ncclAlltoAll_fn(sendbuff, recvbuff, count, datatype, comm, stream);
 }
 
-ncclResult_t
-ncclAllToAll(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
-             ncclComm_t comm, hipStream_t stream)
-{
-    WARN("Please note that ncclAllToAll is deprecated, please use ncclAlltoAll instead");
-    return ::rccl::RcclGetFunctionTable()->ncclAlltoAll_fn(sendbuff, recvbuff, count,
-                                                           datatype, comm, stream);
+ncclResult_t ncclAllToAll(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, ncclComm_t comm,
+                          hipStream_t stream) {
+  WARN("Please note that ncclAllToAll is deprecated, please use ncclAlltoAll instead");
+  return ::rccl::RcclGetFunctionTable()->ncclAlltoAll_fn(sendbuff, recvbuff, count, datatype, comm, stream);
 }
 
-ncclResult_t
-ncclAlltoAllv(const void* sendbuff, const size_t sendcounts[], const size_t sdispls[],
-              void* recvbuff, const size_t recvcounts[], const size_t rdispls[],
-              ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclAlltoAllv_fn(sendbuff, sendcounts, sdispls,
-                                                            recvbuff, recvcounts, rdispls,
-                                                            datatype, comm, stream);
+ncclResult_t ncclAlltoAllv(const void* sendbuff, const size_t sendcounts[], const size_t sdispls[], void* recvbuff,
+                           const size_t recvcounts[], const size_t rdispls[], ncclDataType_t datatype, ncclComm_t comm,
+                           hipStream_t stream) {
+  return ::rccl::RcclGetFunctionTable()->ncclAlltoAllv_fn(sendbuff, sendcounts, sdispls, recvbuff, recvcounts, rdispls,
+                                                          datatype, comm, stream);
 }
 
-ncclResult_t
-ncclAllToAllv(const void* sendbuff, const size_t sendcounts[], const size_t sdispls[],
-              void* recvbuff, const size_t recvcounts[], const size_t rdispls[],
-              ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream)
-{
-    WARN("Please note that ncclAllToAllv is deprecated, please use ncclAlltoAllv instead");
-    return ::rccl::RcclGetFunctionTable()->ncclAlltoAllv_fn(sendbuff, sendcounts, sdispls,
-                                                            recvbuff, recvcounts, rdispls,
-                                                            datatype, comm, stream);
+ncclResult_t ncclAllToAllv(const void* sendbuff, const size_t sendcounts[], const size_t sdispls[], void* recvbuff,
+                           const size_t recvcounts[], const size_t rdispls[], ncclDataType_t datatype, ncclComm_t comm,
+                           hipStream_t stream) {
+  WARN("Please note that ncclAllToAllv is deprecated, please use ncclAlltoAllv instead");
+  return ::rccl::RcclGetFunctionTable()->ncclAlltoAllv_fn(sendbuff, sendcounts, sdispls, recvbuff, recvcounts, rdispls,
+                                                          datatype, comm, stream);
 }
 
-ncclResult_t
-ncclBroadcast(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
-              int root, ncclComm_t comm, cudaStream_t stream)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclBroadcast_fn(sendbuff, recvbuff, count,
-                                                            datatype, root, comm, stream);
+ncclResult_t ncclBroadcast(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, int root,
+                           ncclComm_t comm, cudaStream_t stream) {
+  return ::rccl::RcclGetFunctionTable()->ncclBroadcast_fn(sendbuff, recvbuff, count, datatype, root, comm, stream);
 }
 
-ncclResult_t
-ncclGather(const void* sendbuff, void* recvbuff, size_t sendcount,
-           ncclDataType_t datatype, int root, ncclComm_t comm, hipStream_t stream)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclGather_fn(sendbuff, recvbuff, sendcount,
-                                                         datatype, root, comm, stream);
+ncclResult_t ncclGather(const void* sendbuff, void* recvbuff, size_t sendcount, ncclDataType_t datatype, int root,
+                        ncclComm_t comm, hipStream_t stream) {
+  return ::rccl::RcclGetFunctionTable()->ncclGather_fn(sendbuff, recvbuff, sendcount, datatype, root, comm, stream);
 }
 
-ncclResult_t
-ncclReduce(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype,
-           ncclRedOp_t op, int root, ncclComm_t comm, cudaStream_t stream)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclReduce_fn(
-        sendbuff, recvbuff, count, datatype, op, root, comm, stream);
+ncclResult_t ncclReduce(const void* sendbuff, void* recvbuff, size_t count, ncclDataType_t datatype, ncclRedOp_t op,
+                        int root, ncclComm_t comm, cudaStream_t stream) {
+  return ::rccl::RcclGetFunctionTable()->ncclReduce_fn(sendbuff, recvbuff, count, datatype, op, root, comm, stream);
 }
 
-ncclResult_t
-ncclReduceScatter(const void* sendbuff, void* recvbuff, size_t recvcount,
-                  ncclDataType_t datatype, ncclRedOp_t op, ncclComm* comm,
-                  cudaStream_t stream)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclReduceScatter_fn(
-        sendbuff, recvbuff, recvcount, datatype, op, comm, stream);
+ncclResult_t ncclReduceScatter(const void* sendbuff, void* recvbuff, size_t recvcount, ncclDataType_t datatype,
+                               ncclRedOp_t op, ncclComm* comm, cudaStream_t stream) {
+  return ::rccl::RcclGetFunctionTable()->ncclReduceScatter_fn(sendbuff, recvbuff, recvcount, datatype, op, comm,
+                                                              stream);
 }
 
-ncclResult_t
-ncclScatter(const void* sendbuff, void* recvbuff, size_t recvcount,
-            ncclDataType_t datatype, int root, ncclComm_t comm, hipStream_t stream)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclScatter_fn(sendbuff, recvbuff, recvcount,
-                                                          datatype, root, comm, stream);
+ncclResult_t ncclScatter(const void* sendbuff, void* recvbuff, size_t recvcount, ncclDataType_t datatype, int root,
+                         ncclComm_t comm, hipStream_t stream) {
+  return ::rccl::RcclGetFunctionTable()->ncclScatter_fn(sendbuff, recvbuff, recvcount, datatype, root, comm, stream);
 }
 
-ncclResult_t
-ncclSend(const void* sendbuff, size_t count, ncclDataType_t datatype, int peer,
-         ncclComm_t comm, cudaStream_t stream)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclSend_fn(sendbuff, count, datatype, peer,
-                                                       comm, stream);
+ncclResult_t ncclSend(const void* sendbuff, size_t count, ncclDataType_t datatype, int peer, ncclComm_t comm,
+                      cudaStream_t stream) {
+  return ::rccl::RcclGetFunctionTable()->ncclSend_fn(sendbuff, count, datatype, peer, comm, stream);
 }
 
-ncclResult_t
-ncclRecv(void* recvbuff, size_t count, ncclDataType_t datatype, int peer, ncclComm_t comm,
-         cudaStream_t stream)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclRecv_fn(recvbuff, count, datatype, peer,
-                                                       comm, stream);
+ncclResult_t ncclRecv(void* recvbuff, size_t count, ncclDataType_t datatype, int peer, ncclComm_t comm,
+                      cudaStream_t stream) {
+  return ::rccl::RcclGetFunctionTable()->ncclRecv_fn(recvbuff, count, datatype, peer, comm, stream);
 }
 
-ncclResult_t
-ncclRedOpCreatePreMulSum(ncclRedOp_t* op, void* scalar, ncclDataType_t datatype,
-                         ncclScalarResidence_t residence, ncclComm_t comm)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclRedOpCreatePreMulSum_fn(
-        op, scalar, datatype, residence, comm);
+ncclResult_t ncclRedOpCreatePreMulSum(ncclRedOp_t* op, void* scalar, ncclDataType_t datatype,
+                                      ncclScalarResidence_t residence, ncclComm_t comm) {
+  return ::rccl::RcclGetFunctionTable()->ncclRedOpCreatePreMulSum_fn(op, scalar, datatype, residence, comm);
 }
 
-ncclResult_t
-ncclRedOpDestroy(ncclRedOp_t op, ncclComm_t comm)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclRedOpDestroy_fn(op, comm);
+ncclResult_t ncclRedOpDestroy(ncclRedOp_t op, ncclComm_t comm) {
+  return ::rccl::RcclGetFunctionTable()->ncclRedOpDestroy_fn(op, comm);
 }
 
-ncclResult_t
-ncclGroupStart()
-{
-    return ::rccl::RcclGetFunctionTable()->ncclGroupStart_fn();
+ncclResult_t ncclGroupStart() {
+  return ::rccl::RcclGetFunctionTable()->ncclGroupStart_fn();
 }
 
-ncclResult_t
-ncclGroupEnd()
-{
-    return ::rccl::RcclGetFunctionTable()->ncclGroupEnd_fn();
+ncclResult_t ncclGroupEnd() {
+  return ::rccl::RcclGetFunctionTable()->ncclGroupEnd_fn();
 }
 
-ncclResult_t
-ncclGetVersion(int* version)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclGetVersion_fn(version);
+ncclResult_t ncclGetVersion(int* version) {
+  return ::rccl::RcclGetFunctionTable()->ncclGetVersion_fn(version);
 }
 
-ncclResult_t
-ncclGetUniqueId(ncclUniqueId* out)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclGetUniqueId_fn(out);
+ncclResult_t ncclGetUniqueId(ncclUniqueId* out) {
+  return ::rccl::RcclGetFunctionTable()->ncclGetUniqueId_fn(out);
 }
 
-ncclResult_t
-ncclCommInitRank(ncclComm_t* newcomm, int nranks, ncclUniqueId commId, int myrank)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclCommInitRank_fn(newcomm, nranks, commId,
-                                                               myrank);
+ncclResult_t ncclCommInitRank(ncclComm_t* newcomm, int nranks, ncclUniqueId commId, int myrank) {
+  return ::rccl::RcclGetFunctionTable()->ncclCommInitRank_fn(newcomm, nranks, commId, myrank);
 }
 
-ncclResult_t
-ncclCommInitAll(ncclComm_t* comms, int ndev, const int* devlist)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclCommInitAll_fn(comms, ndev, devlist);
+ncclResult_t ncclCommInitAll(ncclComm_t* comms, int ndev, const int* devlist) {
+  return ::rccl::RcclGetFunctionTable()->ncclCommInitAll_fn(comms, ndev, devlist);
 }
 
-ncclResult_t
-ncclCommInitRankConfig(ncclComm_t* comm, int nranks, ncclUniqueId commId, int myrank,
-                       ncclConfig_t* config)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclCommInitRankConfig_fn(comm, nranks, commId,
-                                                                     myrank, config);
+ncclResult_t ncclCommInitRankConfig(ncclComm_t* comm, int nranks, ncclUniqueId commId, int myrank,
+                                    ncclConfig_t* config) {
+  return ::rccl::RcclGetFunctionTable()->ncclCommInitRankConfig_fn(comm, nranks, commId, myrank, config);
 }
 
-ncclResult_t
-ncclCommFinalize(ncclComm_t comm)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclCommFinalize_fn(comm);
+ncclResult_t ncclCommFinalize(ncclComm_t comm) {
+  return ::rccl::RcclGetFunctionTable()->ncclCommFinalize_fn(comm);
 }
 
-ncclResult_t
-ncclCommDestroy(ncclComm_t comm)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclCommDestroy_fn(comm);
+ncclResult_t ncclCommDestroy(ncclComm_t comm) {
+  return ::rccl::RcclGetFunctionTable()->ncclCommDestroy_fn(comm);
 }
 
-ncclResult_t
-ncclCommAbort(ncclComm_t comm)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclCommAbort_fn(comm);
+ncclResult_t ncclCommAbort(ncclComm_t comm) {
+  return ::rccl::RcclGetFunctionTable()->ncclCommAbort_fn(comm);
 }
 
-ncclResult_t
-ncclCommRevoke(ncclComm_t comm, int revokeFlags)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclCommRevoke_fn(comm, revokeFlags);
+ncclResult_t ncclCommRevoke(ncclComm_t comm, int revokeFlags) {
+  return ::rccl::RcclGetFunctionTable()->ncclCommRevoke_fn(comm, revokeFlags);
 }
 
-ncclResult_t
-ncclCommShrink(ncclComm_t comm, int* excludeRanksList, int excludeRanksCount, ncclComm_t* newcomm,
-               ncclConfig_t* config, int shrinkFlags)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclCommShrink_fn(comm, excludeRanksList, excludeRanksCount, 
-                                                             newcomm, config, shrinkFlags);
+ncclResult_t ncclCommShrink(ncclComm_t comm, int* excludeRanksList, int excludeRanksCount, ncclComm_t* newcomm,
+                            ncclConfig_t* config, int shrinkFlags) {
+  return ::rccl::RcclGetFunctionTable()->ncclCommShrink_fn(comm, excludeRanksList, excludeRanksCount, newcomm, config,
+                                                           shrinkFlags);
 }
 
-ncclResult_t
-ncclCommSplit(ncclComm_t comm, int color, int key, ncclComm_t* newcomm,
-              ncclConfig_t* config)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclCommSplit_fn(comm, color, key, newcomm,
-                                                            config);
+ncclResult_t ncclCommSplit(ncclComm_t comm, int color, int key, ncclComm_t* newcomm, ncclConfig_t* config) {
+  return ::rccl::RcclGetFunctionTable()->ncclCommSplit_fn(comm, color, key, newcomm, config);
 }
 
-const char*
-ncclGetErrorString(ncclResult_t code)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclGetErrorString_fn(code);
+const char* ncclGetErrorString(ncclResult_t code) {
+  return ::rccl::RcclGetFunctionTable()->ncclGetErrorString_fn(code);
 }
 
-const char*
-ncclGetLastError(const ncclComm_t comm)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclGetLastError_fn(comm);
+const char* ncclGetLastError(const ncclComm_t comm) {
+  return ::rccl::RcclGetFunctionTable()->ncclGetLastError_fn(comm);
 }
 
-ncclResult_t
-ncclCommGetAsyncError(ncclComm_t comm, ncclResult_t* asyncError)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclCommGetAsyncError_fn(comm, asyncError);
+ncclResult_t ncclCommGetAsyncError(ncclComm_t comm, ncclResult_t* asyncError) {
+  return ::rccl::RcclGetFunctionTable()->ncclCommGetAsyncError_fn(comm, asyncError);
 }
 
-ncclResult_t
-ncclCommCount(const ncclComm_t comm, int* count)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclCommCount_fn(comm, count);
+ncclResult_t ncclCommCount(const ncclComm_t comm, int* count) {
+  return ::rccl::RcclGetFunctionTable()->ncclCommCount_fn(comm, count);
 }
 
-ncclResult_t
-ncclCommCuDevice(const ncclComm_t comm, int* devid)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclCommCuDevice_fn(comm, devid);
+ncclResult_t ncclCommCuDevice(const ncclComm_t comm, int* devid) {
+  return ::rccl::RcclGetFunctionTable()->ncclCommCuDevice_fn(comm, devid);
 }
 
-ncclResult_t
-ncclCommUserRank(const ncclComm_t comm, int* rank)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclCommUserRank_fn(comm, rank);
+ncclResult_t ncclCommUserRank(const ncclComm_t comm, int* rank) {
+  return ::rccl::RcclGetFunctionTable()->ncclCommUserRank_fn(comm, rank);
 }
 
-ncclResult_t
-ncclMemAlloc(void** ptr, size_t size)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclMemAlloc_fn(ptr, size);
+ncclResult_t ncclMemAlloc(void** ptr, size_t size) {
+  return ::rccl::RcclGetFunctionTable()->ncclMemAlloc_fn(ptr, size);
 }
 
-ncclResult_t
-ncclMemFree(void* ptr)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclMemFree_fn(ptr);
+ncclResult_t ncclMemFree(void* ptr) {
+  return ::rccl::RcclGetFunctionTable()->ncclMemFree_fn(ptr);
 }
 
-ncclResult_t
-mscclLoadAlgo(const char* mscclAlgoFilePath, mscclAlgoHandle_t* mscclAlgoHandle, int rank)
-{
-    return ::rccl::RcclGetFunctionTable()->mscclLoadAlgo_fn(mscclAlgoFilePath,
-                                                            mscclAlgoHandle, rank);
+ncclResult_t mscclLoadAlgo(const char* mscclAlgoFilePath, mscclAlgoHandle_t* mscclAlgoHandle, int rank) {
+  return ::rccl::RcclGetFunctionTable()->mscclLoadAlgo_fn(mscclAlgoFilePath, mscclAlgoHandle, rank);
 }
 
-ncclResult_t
-mscclRunAlgo(const void* sendBuff, const size_t sendCounts[], const size_t sDisPls[],
-             void* recvBuff, const size_t recvCounts[], const size_t rDisPls[],
-             size_t count, ncclDataType_t dataType, int root, int peer, ncclRedOp_t op,
-             mscclAlgoHandle_t mscclAlgoHandle, ncclComm_t comm, hipStream_t stream)
-{
-    return ::rccl::RcclGetFunctionTable()->mscclRunAlgo_fn(
-        sendBuff, sendCounts, sDisPls, recvBuff, recvCounts, rDisPls, count, dataType,
-        root, peer, op, mscclAlgoHandle, comm, stream);
+ncclResult_t mscclRunAlgo(const void* sendBuff, const size_t sendCounts[], const size_t sDisPls[], void* recvBuff,
+                          const size_t recvCounts[], const size_t rDisPls[], size_t count, ncclDataType_t dataType,
+                          int root, int peer, ncclRedOp_t op, mscclAlgoHandle_t mscclAlgoHandle, ncclComm_t comm,
+                          hipStream_t stream) {
+  return ::rccl::RcclGetFunctionTable()->mscclRunAlgo_fn(sendBuff, sendCounts, sDisPls, recvBuff, recvCounts, rDisPls,
+                                                         count, dataType, root, peer, op, mscclAlgoHandle, comm,
+                                                         stream);
 }
 
-ncclResult_t
-mscclUnloadAlgo(mscclAlgoHandle_t mscclAlgoHandle)
-{
-    return ::rccl::RcclGetFunctionTable()->mscclUnloadAlgo_fn(mscclAlgoHandle);
+ncclResult_t mscclUnloadAlgo(mscclAlgoHandle_t mscclAlgoHandle) {
+  return ::rccl::RcclGetFunctionTable()->mscclUnloadAlgo_fn(mscclAlgoHandle);
 }
 
-ncclResult_t
-ncclCommRegister(const ncclComm_t comm, void* buff, size_t size, void** handle)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclCommRegister_fn(comm, buff, size, handle);
+ncclResult_t ncclCommRegister(const ncclComm_t comm, void* buff, size_t size, void** handle) {
+  return ::rccl::RcclGetFunctionTable()->ncclCommRegister_fn(comm, buff, size, handle);
 }
 
-ncclResult_t
-ncclCommDeregister(const ncclComm_t comm, void* handle)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclCommDeregister_fn(comm, handle);
+ncclResult_t ncclCommDeregister(const ncclComm_t comm, void* handle) {
+  return ::rccl::RcclGetFunctionTable()->ncclCommDeregister_fn(comm, handle);
 }
 
-ncclResult_t
-ncclCommWindowRegister(ncclComm_t comm, void* buff, size_t size, ncclWindow_t* win, int winFlags)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclCommWindowRegister_fn(comm, buff, size, win, winFlags);
+ncclResult_t ncclCommWindowRegister(ncclComm_t comm, void* buff, size_t size, ncclWindow_t* win, int winFlags) {
+  return ::rccl::RcclGetFunctionTable()->ncclCommWindowRegister_fn(comm, buff, size, win, winFlags);
 }
 
-ncclResult_t
-ncclCommWindowDeregister(ncclComm_t comm, ncclWindow_t win)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclCommWindowDeregister_fn(comm, win);
+ncclResult_t ncclCommWindowDeregister(ncclComm_t comm, ncclWindow_t win) {
+  return ::rccl::RcclGetFunctionTable()->ncclCommWindowDeregister_fn(comm, win);
 }
 
-ncclResult_t
-ncclCommSuspend(ncclComm_t comm, int flags)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclCommSuspend_fn(comm, flags);
+ncclResult_t ncclCommSuspend(ncclComm_t comm, int flags) {
+  return ::rccl::RcclGetFunctionTable()->ncclCommSuspend_fn(comm, flags);
 }
 
-ncclResult_t
-ncclCommResume(ncclComm_t comm)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclCommResume_fn(comm);
+ncclResult_t ncclCommResume(ncclComm_t comm) {
+  return ::rccl::RcclGetFunctionTable()->ncclCommResume_fn(comm);
 }
 
-ncclResult_t
-ncclCommMemStats(ncclComm_t comm, ncclCommMemStat_t stat, uint64_t* value)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclCommMemStats_fn(comm, stat, value);
+ncclResult_t ncclCommMemStats(ncclComm_t comm, ncclCommMemStat_t stat, uint64_t* value) {
+  return ::rccl::RcclGetFunctionTable()->ncclCommMemStats_fn(comm, stat, value);
 }
 
-ncclResult_t
-ncclPutSignal(const void* localbuff, size_t count, ncclDataType_t datatype,
-              int peer, ncclWindow_t peerWin, size_t peerWinOffset,
-              int sigIdx, int ctx, unsigned int flags,
-              ncclComm_t comm, cudaStream_t stream)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclPutSignal_fn(localbuff, count, datatype,
-                                                            peer, peerWin, peerWinOffset,
-                                                            sigIdx, ctx, flags, comm, stream);
+ncclResult_t ncclPutSignal(const void* localbuff, size_t count, ncclDataType_t datatype, int peer, ncclWindow_t peerWin,
+                           size_t peerWinOffset, int sigIdx, int ctx, unsigned int flags, ncclComm_t comm,
+                           cudaStream_t stream) {
+  return ::rccl::RcclGetFunctionTable()->ncclPutSignal_fn(localbuff, count, datatype, peer, peerWin, peerWinOffset,
+                                                          sigIdx, ctx, flags, comm, stream);
 }
 
-ncclResult_t
-ncclSignal(int peer, int sigIdx, int ctx, unsigned int flags,
-           ncclComm_t comm, cudaStream_t stream)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclSignal_fn(peer, sigIdx, ctx, flags, comm, stream);
+ncclResult_t ncclSignal(int peer, int sigIdx, int ctx, unsigned int flags, ncclComm_t comm, cudaStream_t stream) {
+  return ::rccl::RcclGetFunctionTable()->ncclSignal_fn(peer, sigIdx, ctx, flags, comm, stream);
 }
 
-ncclResult_t
-ncclWaitSignal(int nDesc, ncclWaitSignalDesc_t* signalDescs,
-               ncclComm_t comm, cudaStream_t stream)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclWaitSignal_fn(nDesc, signalDescs, comm, stream);
+ncclResult_t ncclWaitSignal(int nDesc, ncclWaitSignalDesc_t* signalDescs, ncclComm_t comm, cudaStream_t stream) {
+  return ::rccl::RcclGetFunctionTable()->ncclWaitSignal_fn(nDesc, signalDescs, comm, stream);
 }
 
-ncclResult_t
-ncclCommGetUniqueId(ncclComm_t comm, ncclUniqueId* uniqueId)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclCommGetUniqueId_fn(comm, uniqueId);
+ncclResult_t ncclCommGetUniqueId(ncclComm_t comm, ncclUniqueId* uniqueId) {
+  return ::rccl::RcclGetFunctionTable()->ncclCommGetUniqueId_fn(comm, uniqueId);
 }
 
-ncclResult_t
-ncclCommGrow(ncclComm_t comm, int nRanks, const ncclUniqueId* uniqueId, int rank,
-             ncclComm_t* newcomm, ncclConfig_t* config)
-{
-    return ::rccl::RcclGetFunctionTable()->ncclCommGrow_fn(comm, nRanks, uniqueId, rank,
-                                                           newcomm, config);
+ncclResult_t ncclCommGrow(ncclComm_t comm, int nRanks, const ncclUniqueId* uniqueId, int rank, ncclComm_t* newcomm,
+                          ncclConfig_t* config) {
+  return ::rccl::RcclGetFunctionTable()->ncclCommGrow_fn(comm, nRanks, uniqueId, rank, newcomm, config);
 }

--- a/projects/rccl/src/misc/archinfo.cc
+++ b/projects/rccl/src/misc/archinfo.cc
@@ -28,7 +28,7 @@ THE SOFTWARE.
 void GcnArchNameFormat(char* gcnArchName, char* out) {
   // this function parses the char array from the device properties into something easier to handle.
   // as the gcnArchName attribute looks something like: "gfx900:xnack+:blah-:etc-"
-  char *gcnArchNameToken = strtok(gcnArchName, ":");
+  char* gcnArchNameToken = strtok(gcnArchName, ":");
   strcpy(out, gcnArchNameToken);
 }
 
@@ -36,20 +36,13 @@ void convertGcnArchToGcnArchName(const char* gcnArch, const char** gcnArchName) 
   // gcnArch is deprecated and we should instead use gcnArchName; however, some data files still have
   // the older gcnArch value.  There's only a handful of architectures that were coded prior to deprecation,
   // so we handle those cases here.
-  if (strcmp(gcnArch, "906") == 0)
-    *gcnArchName = "gfx906";
-  else if (strcmp(gcnArch, "908") == 0)
-    *gcnArchName = "gfx908";
-  else if (strcmp(gcnArch, "910") == 0)
-    *gcnArchName = "gfx90a";
-  else if (strcmp(gcnArch, "942") == 0)
-    *gcnArchName = "gfx942";
-  else if (strcmp(gcnArch, "950") == 0)
-    *gcnArchName = "gfx950";
-  else if (strcmp(gcnArch, "1250") == 0)
-    *gcnArchName = "gfx1250";
-  else
-    *gcnArchName = gcnArch;
+  if (strcmp(gcnArch, "906") == 0) *gcnArchName = "gfx906";
+  else if (strcmp(gcnArch, "908") == 0) *gcnArchName = "gfx908";
+  else if (strcmp(gcnArch, "910") == 0) *gcnArchName = "gfx90a";
+  else if (strcmp(gcnArch, "942") == 0) *gcnArchName = "gfx942";
+  else if (strcmp(gcnArch, "950") == 0) *gcnArchName = "gfx950";
+  else if (strcmp(gcnArch, "1250") == 0) *gcnArchName = "gfx1250";
+  else *gcnArchName = gcnArch;
 }
 
 int GetGcnArchName(int deviceId, char* out) {
@@ -63,14 +56,10 @@ int GetGcnArchName(int deviceId, char* out) {
 double GetDeviceWallClockRateInKhz(int deviceId) {
   char gcn[256];
   GetGcnArchName(deviceId, gcn);
-  if (strncmp("gfx942", gcn, 6) == 0)
-    return 1.0E5;
-  else if(strncmp("gfx950", gcn, 6) == 0)
-    return 1.0E5;
-  else if(strncmp("gfx1250", gcn, 7) == 0)
-    return 1.0E5;
-  else
-    return 2.5E4;
+  if (strncmp("gfx942", gcn, 6) == 0) return 1.0E5;
+  else if (strncmp("gfx950", gcn, 6) == 0) return 1.0E5;
+  else if (strncmp("gfx1250", gcn, 7) == 0) return 1.0E5;
+  else return 2.5E4;
 }
 
 bool IsArchMatch(char const* arch, char const* target) {

--- a/projects/rccl/src/misc/argcheck.cc
+++ b/projects/rccl/src/misc/argcheck.cc
@@ -52,8 +52,8 @@ static ncclResult_t registrationCheck(struct ncclInfo* info) {
   };
 
   ncclResult_t ret = ncclSuccess;
-  struct ncclComm *comm = info->comm;
-  struct symBufInfo *bufInfo = nullptr; // send and recv buffers
+  struct ncclComm* comm = info->comm;
+  struct symBufInfo* bufInfo = nullptr; // send and recv buffers
   struct ncclDevrWindow* sendWin = nullptr;
   struct ncclDevrWindow* recvWin = nullptr;
   struct symBufInfo cmpBufInfo[2] = {};
@@ -76,14 +76,20 @@ static ncclResult_t registrationCheck(struct ncclInfo* info) {
     bufInfo[myInfoIdx].isSymRegistered = true;
     bufInfo[myInfoIdx].bigOffset = sendWin->bigOffset;
     bufInfo[myInfoIdx].userOffset = (uintptr_t)info->sendbuff - (uintptr_t)sendWin->userPtr;
-    INFO(NCCL_COLL, "SymCheck: coll %s size %ld rank %d bigOffset %lx userOffset %lx info->sendbuff %p sendWin->userPtr %p", info->opName, size, comm->rank, bufInfo[myInfoIdx].bigOffset, bufInfo[myInfoIdx].userOffset, info->sendbuff, sendWin->userPtr);
+    INFO(NCCL_COLL,
+         "SymCheck: coll %s size %ld rank %d bigOffset %lx userOffset %lx info->sendbuff %p sendWin->userPtr %p",
+         info->opName, size, comm->rank, bufInfo[myInfoIdx].bigOffset, bufInfo[myInfoIdx].userOffset, info->sendbuff,
+         sendWin->userPtr);
   }
 
   if (recvWin && (recvWin->winFlags & NCCL_WIN_COLL_SYMMETRIC)) {
     bufInfo[myInfoIdx + 1].isSymRegistered = true;
     bufInfo[myInfoIdx + 1].bigOffset = recvWin->bigOffset;
     bufInfo[myInfoIdx + 1].userOffset = (uintptr_t)info->recvbuff - (uintptr_t)recvWin->userPtr;
-    INFO(NCCL_COLL, "SymCheck: coll %s size %ld rank %d bigOffset %lx userOffset %lx info->recvbuff %p recvWin->userPtr %p", info->opName, size, comm->rank, bufInfo[myInfoIdx + 1].bigOffset, bufInfo[myInfoIdx + 1].userOffset, info->recvbuff, recvWin->userPtr);
+    INFO(NCCL_COLL,
+         "SymCheck: coll %s size %ld rank %d bigOffset %lx userOffset %lx info->recvbuff %p recvWin->userPtr %p",
+         info->opName, size, comm->rank, bufInfo[myInfoIdx + 1].bigOffset, bufInfo[myInfoIdx + 1].userOffset,
+         info->recvbuff, recvWin->userPtr);
   }
 
   NCCLCHECKGOTO(bootstrapAllGather(comm->bootstrap, bufInfo, sizeof(struct symBufInfo) * 2), ret, fail);
@@ -92,42 +98,77 @@ static ncclResult_t registrationCheck(struct ncclInfo* info) {
   cmpBufInfo[1] = bufInfo[1];
   for (int r = 1; r < comm->nRanks; r++) {
     int infoIdx = r * 2;
-    if (cmpBufInfo[0].isSymRegistered != bufInfo[infoIdx].isSymRegistered || cmpBufInfo[1].isSymRegistered != bufInfo[infoIdx + 1].isSymRegistered) {
-      if (comm->rank == 0) WARN("Coll %s size %ld symmetric registration check failed on rank %d: sendReg %d recvReg %d mismatch with rank 0 sendReg %d recvReg %d", info->opName, size, r, bufInfo[infoIdx].isSymRegistered, bufInfo[infoIdx + 1].isSymRegistered, cmpBufInfo[0].isSymRegistered, cmpBufInfo[1].isSymRegistered);
+    if (cmpBufInfo[0].isSymRegistered != bufInfo[infoIdx].isSymRegistered ||
+        cmpBufInfo[1].isSymRegistered != bufInfo[infoIdx + 1].isSymRegistered) {
+      if (comm->rank == 0)
+        WARN("Coll %s size %ld symmetric registration check failed on rank %d: sendReg %d recvReg %d mismatch with "
+             "rank 0 sendReg %d recvReg %d",
+             info->opName, size, r, bufInfo[infoIdx].isSymRegistered, bufInfo[infoIdx + 1].isSymRegistered,
+             cmpBufInfo[0].isSymRegistered, cmpBufInfo[1].isSymRegistered);
       ret = ncclInvalidArgument;
       goto fail;
     }
 
-    if (cmpBufInfo[0].bigOffset != bufInfo[infoIdx].bigOffset) { sendWinMismatch = true; sendWinMismatchRank = r; }
-    if (cmpBufInfo[1].bigOffset != bufInfo[infoIdx + 1].bigOffset) { recvWinMismatch = true; recvWinMismatchRank = r; }
-    if (cmpBufInfo[0].userOffset != bufInfo[infoIdx].userOffset) { sendUserMismatch = true; sendUserMismatchRank = r; }
-    if (cmpBufInfo[1].userOffset != bufInfo[infoIdx + 1].userOffset) { recvUserMismatch = true; recvUserMismatchRank = r; }
+    if (cmpBufInfo[0].bigOffset != bufInfo[infoIdx].bigOffset) {
+      sendWinMismatch = true;
+      sendWinMismatchRank = r;
+    }
+    if (cmpBufInfo[1].bigOffset != bufInfo[infoIdx + 1].bigOffset) {
+      recvWinMismatch = true;
+      recvWinMismatchRank = r;
+    }
+    if (cmpBufInfo[0].userOffset != bufInfo[infoIdx].userOffset) {
+      sendUserMismatch = true;
+      sendUserMismatchRank = r;
+    }
+    if (cmpBufInfo[1].userOffset != bufInfo[infoIdx + 1].userOffset) {
+      recvUserMismatch = true;
+      recvUserMismatchRank = r;
+    }
   }
 
-  if (info->coll == ncclFuncAllReduce || info->coll == ncclFuncReduceScatter || info->coll == ncclFuncAlltoAll || info->coll == ncclFuncGather) {
+  if (info->coll == ncclFuncAllReduce || info->coll == ncclFuncReduceScatter || info->coll == ncclFuncAlltoAll ||
+      info->coll == ncclFuncGather) {
     if (cmpBufInfo[0].isSymRegistered) {
       if (sendWinMismatch) {
-        if (comm->rank == 0) WARN("Coll %s size %ld symmetric registration check failed on rank %d: send buffer window (0x%lx) mismatch with rank 0 (0x%lx)", info->opName, size, sendWinMismatchRank, bufInfo[sendWinMismatchRank * 2].bigOffset, cmpBufInfo[0].bigOffset);
+        if (comm->rank == 0)
+          WARN("Coll %s size %ld symmetric registration check failed on rank %d: send buffer window (0x%lx) mismatch "
+               "with rank 0 (0x%lx)",
+               info->opName, size, sendWinMismatchRank, bufInfo[sendWinMismatchRank * 2].bigOffset,
+               cmpBufInfo[0].bigOffset);
         ret = ncclInvalidArgument;
         goto fail;
       }
       if (sendUserMismatch) {
-        if (comm->rank == 0) WARN("Coll %s size %ld symmetric registration check failed on rank %d: send buffer user offset (0x%lx) mismatch with rank 0 (0x%lx)", info->opName, size, sendUserMismatchRank, bufInfo[sendUserMismatchRank * 2].userOffset, cmpBufInfo[0].userOffset);
+        if (comm->rank == 0)
+          WARN("Coll %s size %ld symmetric registration check failed on rank %d: send buffer user offset (0x%lx) "
+               "mismatch with rank 0 (0x%lx)",
+               info->opName, size, sendUserMismatchRank, bufInfo[sendUserMismatchRank * 2].userOffset,
+               cmpBufInfo[0].userOffset);
         ret = ncclInvalidArgument;
         goto fail;
       }
     }
   }
 
-  if (info->coll == ncclFuncAllGather || info->coll == ncclFuncAllReduce || info->coll == ncclFuncAlltoAll || info->coll == ncclFuncScatter) {
+  if (info->coll == ncclFuncAllGather || info->coll == ncclFuncAllReduce || info->coll == ncclFuncAlltoAll ||
+      info->coll == ncclFuncScatter) {
     if (cmpBufInfo[1].isSymRegistered) {
       if (recvWinMismatch) {
-        if (comm->rank == 0) WARN("Coll %s size %ld symmetric registration check failed on rank %d: recv buffer window (0x%lx) mismatch with rank 0 (0x%lx)", info->opName, size, recvWinMismatchRank, bufInfo[recvWinMismatchRank * 2 + 1].bigOffset, cmpBufInfo[1].bigOffset);
+        if (comm->rank == 0)
+          WARN("Coll %s size %ld symmetric registration check failed on rank %d: recv buffer window (0x%lx) mismatch "
+               "with rank 0 (0x%lx)",
+               info->opName, size, recvWinMismatchRank, bufInfo[recvWinMismatchRank * 2 + 1].bigOffset,
+               cmpBufInfo[1].bigOffset);
         ret = ncclInvalidArgument;
         goto fail;
       }
       if (recvUserMismatch) {
-        if (comm->rank == 0) WARN("Coll %s size %ld symmetric registration check failed on rank %d: recv buffer user offset (0x%lx) mismatch with rank 0 (0x%lx)", info->opName, size, recvUserMismatchRank, bufInfo[recvUserMismatchRank * 2 + 1].userOffset, cmpBufInfo[1].userOffset);
+        if (comm->rank == 0)
+          WARN("Coll %s size %ld symmetric registration check failed on rank %d: recv buffer user offset (0x%lx) "
+               "mismatch with rank 0 (0x%lx)",
+               info->opName, size, recvUserMismatchRank, bufInfo[recvUserMismatchRank * 2 + 1].userOffset,
+               cmpBufInfo[1].userOffset);
         ret = ncclInvalidArgument;
         goto fail;
       }
@@ -143,7 +184,8 @@ fail:
 
 ncclResult_t ncclArgsGlobalCheck(struct ncclArgsInfo* argsInfo) {
   struct ncclInfo* info = &argsInfo->info;
-  if (info->coll != ncclFuncSend && info->coll != ncclFuncRecv && info->coll != ncclFuncPutSignal && info->coll != ncclFuncSignal && info->coll != ncclFuncWaitSignal) { // exclude one-sided and sendrecv operations
+  if (info->coll != ncclFuncSend && info->coll != ncclFuncRecv && info->coll != ncclFuncPutSignal &&
+      info->coll != ncclFuncSignal && info->coll != ncclFuncWaitSignal) { // exclude one-sided and sendrecv operations
     // Check registration globally
     NCCLCHECK(registrationCheck(info));
   }
@@ -178,8 +220,7 @@ ncclResult_t ArgsCheck(struct ncclInfo* info) {
 
   if (info->comm->checkMode != ncclCheckModeDefault) {
     if ((info->coll == ncclFuncSend || info->coll == ncclFuncRecv)) {
-      if (info->count >0)
-        NCCLCHECK(CudaPtrCheck(info->recvbuff, info->comm, "buff", info->opName));
+      if (info->count > 0) NCCLCHECK(CudaPtrCheck(info->recvbuff, info->comm, "buff", info->opName));
     } else if (info->coll == ncclFuncPutSignal || info->coll == ncclFuncSignal || info->coll == ncclFuncWaitSignal) {
       // One-sided RMA ops specify the remote destination via peerWin, not sendbuff/recvbuff,
       // so the standard CUDA pointer checks do not apply here.

--- a/projects/rccl/src/misc/coverage_flush.cc
+++ b/projects/rccl/src/misc/coverage_flush.cc
@@ -16,8 +16,6 @@
 
 extern "C" int __llvm_profile_write_file(void);
 
-extern "C" __attribute__((visibility("default")))
-int rcclCoverageWriteFile(void)
-{
-    return __llvm_profile_write_file();
+extern "C" __attribute__((visibility("default"))) int rcclCoverageWriteFile(void) {
+  return __llvm_profile_write_file();
 }

--- a/projects/rccl/src/misc/cudawrap.cc
+++ b/projects/rccl/src/misc/cudawrap.cc
@@ -22,7 +22,7 @@ static int ncclCuMemSupported = 0;
 
 // Determine whether CUMEM & VMM RDMA is supported on this platform
 int ncclIsCuMemSupported() {
-#if CUDART_VERSION < 11030 || defined (NCCL_OS_WINDOWS)
+#if CUDART_VERSION < 11030 || defined(NCCL_OS_WINDOWS)
   return 0;
 #else
   CUdevice currentDev;
@@ -36,7 +36,8 @@ int ncclIsCuMemSupported() {
   if (CUPFN(cuMemCreate) == NULL) return 0;
   CUCHECKGOTO(cuDeviceGet(&currentDev, cudaDev), ret, error);
   // Query device to see if CUMEM VMM support is available
-  CUCHECKGOTO(cuDeviceGetAttribute(&flag, CU_DEVICE_ATTRIBUTE_VIRTUAL_MEMORY_MANAGEMENT_SUPPORTED, currentDev), ret, error);
+  CUCHECKGOTO(cuDeviceGetAttribute(&flag, CU_DEVICE_ATTRIBUTE_VIRTUAL_MEMORY_MANAGEMENT_SUPPORTED, currentDev), ret,
+              error);
   if (!flag) return 0;
 error:
   return (ret == ncclSuccess);
@@ -46,13 +47,12 @@ error:
 int ncclCuMemEnable() {
   // NCCL_CUMEM_ENABLE=-2 means auto-detect CUMEM support
   int param = ncclParamCuMemEnable();
-  return  param >= 0 ? param : (param == -2 && ncclCuMemSupported);
+  return param >= 0 ? param : (param == -2 && ncclCuMemSupported);
 }
 
 static int ncclCumemHostEnable = -1;
 int ncclCuMemHostEnable() {
-  if (ncclCumemHostEnable != -1)
-    return ncclCumemHostEnable;
+  if (ncclCumemHostEnable != -1) return ncclCumemHostEnable;
 #if CUDART_VERSION < 12020
   ncclCumemHostEnable = 0;
   return ncclCumemHostEnable;
@@ -63,13 +63,10 @@ int ncclCuMemHostEnable() {
   CUDACHECKGOTO(cudaDriverGetVersion(&cudaDriverVersion), ret, error);
   if (cudaDriverVersion < 12020) {
     ncclCumemHostEnable = 0;
-  }
-  else {
+  } else {
     paramValue = ncclParamCuMemHostEnable();
-    if (paramValue != -1)
-      ncclCumemHostEnable = paramValue;
-    else
-      ncclCumemHostEnable = (cudaDriverVersion >= 12060) ? 1 : 0;
+    if (paramValue != -1) ncclCumemHostEnable = paramValue;
+    else ncclCumemHostEnable = (cudaDriverVersion >= 12060) ? 1 : 0;
     if (ncclCumemHostEnable) {
       // Verify that host allocations actually work.  Docker in particular is known to disable "get_mempolicy",
       // causing such allocations to fail (this can be fixed by invoking Docker with "--cap-add SYS_NICE").
@@ -93,8 +90,8 @@ int ncclCuMemHostEnable() {
       ALIGN_SIZE(size, granularity);
       if (CUPFN(cuMemCreate(&handle, size, &prop, 0)) != CUDA_SUCCESS) {
         INFO(NCCL_INIT, "cuMem host allocations do not appear to be working; falling back to a /dev/shm/ based "
-             "implementation. This could be due to the container runtime disabling NUMA support. "
-             "To disable this warning, set NCCL_CUMEM_HOST_ENABLE=0");
+                        "implementation. This could be due to the container runtime disabling NUMA support. "
+                        "To disable this warning, set NCCL_CUMEM_HOST_ENABLE=0");
         ncclCumemHostEnable = 0;
       } else {
         CUCHECK(cuMemRelease(handle));
@@ -107,7 +104,7 @@ error:
 #endif
 }
 
-#define DECLARE_CUDA_PFN(symbol,version) PFN_##symbol##_v##version pfn_##symbol = nullptr
+#define DECLARE_CUDA_PFN(symbol, version) PFN_##symbol##_v##version pfn_##symbol = nullptr
 
 #if CUDART_VERSION >= 11030
 /* CUDA Driver functions loaded with cuGetProcAddress for versioning */
@@ -171,38 +168,47 @@ bool ncclCudaLaunchBlocking = false;
 #if CUDART_VERSION >= 11030
 
 #if CUDART_VERSION >= 13000
-#define LOAD_SYM(symbol, version, ignore) do {                           \
+#define LOAD_SYM(symbol, version, ignore) \
+  do { \
     cudaDriverEntryPointQueryResult driverStatus = cudaDriverEntryPointSymbolNotFound; \
-    res = CUDACLEARERROR(cudaGetDriverEntryPointByVersion(#symbol, (void **) (&pfn_##symbol), version, cudaEnableDefault, &driverStatus)); \
+    res = CUDACLEARERROR(cudaGetDriverEntryPointByVersion(#symbol, (void**)(&pfn_##symbol), version, \
+                                                          cudaEnableDefault, &driverStatus)); \
     if (res != cudaSuccess || driverStatus != cudaDriverEntryPointSuccess) { \
-      if (!ignore) {                                                    \
+      if (!ignore) { \
         WARN("Retrieve %s version %d failed with %d status %d", #symbol, version, res, driverStatus); \
-        return ncclSystemError; }                                       \
-    } } while(0)
+        return ncclSystemError; \
+      } \
+    } \
+  } while (0)
 #elif CUDART_VERSION >= 12000
-#define LOAD_SYM(symbol, version, ignore) do {                           \
+#define LOAD_SYM(symbol, version, ignore) \
+  do { \
     cudaDriverEntryPointQueryResult driverStatus = cudaDriverEntryPointSymbolNotFound; \
-    res = CUDACLEARERROR(cudaGetDriverEntryPoint(#symbol, (void **) (&pfn_##symbol), cudaEnableDefault, &driverStatus)); \
+    res = CUDACLEARERROR(cudaGetDriverEntryPoint(#symbol, (void**)(&pfn_##symbol), cudaEnableDefault, &driverStatus)); \
     if (res != cudaSuccess || driverStatus != cudaDriverEntryPointSuccess) { \
-      if (!ignore) {                                                    \
+      if (!ignore) { \
         WARN("Retrieve %s failed with %d status %d", #symbol, res, driverStatus); \
-        return ncclSystemError; }                                       \
-    } } while(0)
+        return ncclSystemError; \
+      } \
+    } \
+  } while (0)
 #else
-#define LOAD_SYM(symbol, version, ignore) do {                           \
-    res = CUDACLEARERROR(cudaGetDriverEntryPoint(#symbol, (void **) (&pfn_##symbol), cudaEnableDefault)); \
+#define LOAD_SYM(symbol, version, ignore) \
+  do { \
+    res = CUDACLEARERROR(cudaGetDriverEntryPoint(#symbol, (void**)(&pfn_##symbol), cudaEnableDefault)); \
     if (res != cudaSuccess) { \
-      if (!ignore) {                                                    \
-        WARN("Retrieve %s failed with %d", #symbol, res);               \
-        return ncclSystemError; }                                       \
-    } } while(0)
+      if (!ignore) { \
+        WARN("Retrieve %s failed with %d", #symbol, res); \
+        return ncclSystemError; \
+      } \
+    } \
+  } while (0)
 #endif
 
 /*
   Load the CUDA symbols
  */
 static ncclResult_t cudaPfnFuncLoader(void) {
-
   cudaError_t res;
 
   LOAD_SYM(cuGetErrorString, 6000, 0);
@@ -262,7 +268,7 @@ static ncclResult_t initResult;
 static void initOnceFunc() {
   do {
     const char* val = ncclGetEnv("CUDA_LAUNCH_BLOCKING");
-    ncclCudaLaunchBlocking = val!=nullptr && val[0]!=0 && !(val[0]=='0' && val[1]==0);
+    ncclCudaLaunchBlocking = val != nullptr && val[0] != 0 && !(val[0] == '0' && val[1] == 0);
   } while (0);
 
   ncclResult_t ret = ncclSuccess;
@@ -279,12 +285,12 @@ static void initOnceFunc() {
     goto error;
   }
 
-  #if CUDART_VERSION >= 11030
+#if CUDART_VERSION >= 11030
   if (cudaPfnFuncLoader()) {
     WARN("CUDA some PFN functions not found in the library");
     goto error;
   }
-  #endif
+#endif
 
   // Determine whether we support the cuMem APIs or not
   ncclCuMemSupported = ncclIsCuMemSupported();

--- a/projects/rccl/src/misc/gdrwrap.cc
+++ b/projects/rccl/src/misc/gdrwrap.cc
@@ -15,17 +15,17 @@
 /* Function pointers assigned from dynamic library (os layer) */
 static gdr_t (*gdr_internal_open)(void);
 static int (*gdr_internal_close)(gdr_t g);
-static int (*gdr_internal_pin_buffer)(gdr_t g, unsigned long addr, size_t size, uint64_t p2p_token, uint32_t va_space, gdr_mh_t *handle);
-static int (*gdr_internal_pin_buffer_v2)(gdr_t g, unsigned long addr, size_t size, uint32_t flags, gdr_mh_t *handle);
+static int (*gdr_internal_pin_buffer)(gdr_t g, unsigned long addr, size_t size, uint64_t p2p_token, uint32_t va_space,
+                                      gdr_mh_t* handle);
+static int (*gdr_internal_pin_buffer_v2)(gdr_t g, unsigned long addr, size_t size, uint32_t flags, gdr_mh_t* handle);
 static int (*gdr_internal_unpin_buffer)(gdr_t g, gdr_mh_t handle);
-static int (*gdr_internal_get_info)(gdr_t g, gdr_mh_t handle, gdr_info_t *info);
-static int (*gdr_internal_map)(gdr_t g, gdr_mh_t handle, void **va, size_t size);
-static int (*gdr_internal_unmap)(gdr_t g, gdr_mh_t handle, void *va, size_t size);
-static void (*gdr_internal_runtime_get_version)(int *major, int *minor);
-static void (*gdr_internal_driver_get_version)(gdr_t g, int *major, int *minor);
-static int (*gdr_internal_copy_to_mapping)(gdr_mh_t handle, void *map_d_ptr, const void *h_ptr, size_t size);
-static int (*gdr_internal_copy_from_mapping)(gdr_mh_t handle, void *h_ptr, const void *map_d_ptr, size_t size);
-
+static int (*gdr_internal_get_info)(gdr_t g, gdr_mh_t handle, gdr_info_t* info);
+static int (*gdr_internal_map)(gdr_t g, gdr_mh_t handle, void** va, size_t size);
+static int (*gdr_internal_unmap)(gdr_t g, gdr_mh_t handle, void* va, size_t size);
+static void (*gdr_internal_runtime_get_version)(int* major, int* minor);
+static void (*gdr_internal_driver_get_version)(gdr_t g, int* major, int* minor);
+static int (*gdr_internal_copy_to_mapping)(gdr_mh_t handle, void* map_d_ptr, const void* h_ptr, size_t size);
+static int (*gdr_internal_copy_from_mapping)(gdr_mh_t handle, void* h_ptr, const void* map_d_ptr, size_t size);
 
 // Used to make the GDR library calls thread safe
 std::mutex& getGdrMutex() {
@@ -39,23 +39,25 @@ std::mutex& getGdrMutex() {
 #define GDRAPI_LIBNAME "libgdrapi.so"
 #endif
 
-#define LOAD_SYM(handle, symbol, funcptr) do {         \
-    cast = (void**)&funcptr;                             \
-    tmp = ncclOsDlsym(handle, symbol);                   \
-    if (tmp == NULL) {                                   \
+#define LOAD_SYM(handle, symbol, funcptr) \
+  do { \
+    cast = (void**)&funcptr; \
+    tmp = ncclOsDlsym(handle, symbol); \
+    if (tmp == NULL) { \
       WARN("ncclOsDlsym failed on %s - %s", symbol, ncclOsDlerror()); \
-      goto teardown;                                     \
-    }                                                    \
-    *cast = tmp;                                         \
+      goto teardown; \
+    } \
+    *cast = tmp; \
   } while (0)
 
-#define LOAD_SYM_OPTIONAL(handle, symbol, funcptr) do {\
-    cast = (void**)&funcptr;                             \
-    tmp = ncclOsDlsym(handle, symbol);                   \
-    if (tmp == NULL) {                                   \
-      INFO(NCCL_INIT,"ncclOsDlsym failed on %s, ignoring", symbol); \
-    }                                                    \
-    *cast = tmp;                                         \
+#define LOAD_SYM_OPTIONAL(handle, symbol, funcptr) \
+  do { \
+    cast = (void**)&funcptr; \
+    tmp = ncclOsDlsym(handle, symbol); \
+    if (tmp == NULL) { \
+      INFO(NCCL_INIT, "ncclOsDlsym failed on %s, ignoring", symbol); \
+    } \
+    *cast = tmp; \
   } while (0)
 
 static std::once_flag initOnceFlag;
@@ -108,7 +110,6 @@ teardown:
   return;
 }
 
-
 ncclResult_t wrap_gdr_symbols(void) {
   std::call_once(initOnceFlag, initOnceFunc);
   return initResult;
@@ -135,7 +136,8 @@ ncclResult_t wrap_gdr_close(gdr_t g) {
   return ncclSuccess;
 }
 
-ncclResult_t wrap_gdr_pin_buffer(gdr_t g, unsigned long addr, size_t size, uint64_t p2p_token, uint32_t va_space, gdr_mh_t *handle) {
+ncclResult_t wrap_gdr_pin_buffer(gdr_t g, unsigned long addr, size_t size, uint64_t p2p_token, uint32_t va_space,
+                                 gdr_mh_t* handle) {
   if (gdr_internal_pin_buffer == NULL) {
     WARN("GDRCOPY lib wrapper not initialized.");
     return ncclInternalError;
@@ -162,7 +164,7 @@ bool ncclGdrPinV2Available(void) {
   return available;
 }
 
-ncclResult_t wrap_gdr_pin_buffer_v2(gdr_t g, unsigned long addr, size_t size, uint32_t flags, gdr_mh_t *handle) {
+ncclResult_t wrap_gdr_pin_buffer_v2(gdr_t g, unsigned long addr, size_t size, uint32_t flags, gdr_mh_t* handle) {
   if (!ncclGdrPinV2Available()) {
     WARN("gdr_pin_buffer_v2 not available; GDRCopy >= 2.5 required");
     return ncclInternalError;
@@ -190,7 +192,7 @@ ncclResult_t wrap_gdr_unpin_buffer(gdr_t g, gdr_mh_t handle) {
   return ncclSuccess;
 }
 
-ncclResult_t wrap_gdr_get_info(gdr_t g, gdr_mh_t handle, gdr_info_t *info) {
+ncclResult_t wrap_gdr_get_info(gdr_t g, gdr_mh_t handle, gdr_info_t* info) {
   if (gdr_internal_get_info == NULL) {
     WARN("GDRCOPY lib wrapper not initialized.");
     return ncclInternalError;
@@ -204,7 +206,7 @@ ncclResult_t wrap_gdr_get_info(gdr_t g, gdr_mh_t handle, gdr_info_t *info) {
   return ncclSuccess;
 }
 
-ncclResult_t wrap_gdr_map(gdr_t g, gdr_mh_t handle, void **va, size_t size) {
+ncclResult_t wrap_gdr_map(gdr_t g, gdr_mh_t handle, void** va, size_t size) {
   if (gdr_internal_map == NULL) {
     WARN("GDRCOPY lib wrapper not initialized.");
     return ncclInternalError;
@@ -218,7 +220,7 @@ ncclResult_t wrap_gdr_map(gdr_t g, gdr_mh_t handle, void **va, size_t size) {
   return ncclSuccess;
 }
 
-ncclResult_t wrap_gdr_unmap(gdr_t g, gdr_mh_t handle, void *va, size_t size) {
+ncclResult_t wrap_gdr_unmap(gdr_t g, gdr_mh_t handle, void* va, size_t size) {
   if (gdr_internal_unmap == NULL) {
     WARN("GDRCOPY lib wrapper not initialized.");
     return ncclInternalError;
@@ -232,7 +234,7 @@ ncclResult_t wrap_gdr_unmap(gdr_t g, gdr_mh_t handle, void *va, size_t size) {
   return ncclSuccess;
 }
 
-ncclResult_t wrap_gdr_runtime_get_version(int *major, int *minor) {
+ncclResult_t wrap_gdr_runtime_get_version(int* major, int* minor) {
   if (gdr_internal_runtime_get_version == NULL) {
     WARN("GDRCOPY lib wrapper not initialized.");
     return ncclInternalError;
@@ -241,7 +243,7 @@ ncclResult_t wrap_gdr_runtime_get_version(int *major, int *minor) {
   return ncclSuccess;
 }
 
-ncclResult_t wrap_gdr_driver_get_version(gdr_t g, int *major, int *minor) {
+ncclResult_t wrap_gdr_driver_get_version(gdr_t g, int* major, int* minor) {
   if (gdr_internal_driver_get_version == NULL) {
     WARN("GDRCOPY lib wrapper not initialized.");
     return ncclInternalError;
@@ -250,7 +252,7 @@ ncclResult_t wrap_gdr_driver_get_version(gdr_t g, int *major, int *minor) {
   return ncclSuccess;
 }
 
-ncclResult_t wrap_gdr_copy_to_mapping(gdr_mh_t handle, void *map_d_ptr, const void *h_ptr, size_t size) {
+ncclResult_t wrap_gdr_copy_to_mapping(gdr_mh_t handle, void* map_d_ptr, const void* h_ptr, size_t size) {
   if (gdr_internal_copy_to_mapping == NULL) {
     WARN("GDRCOPY lib wrapper not initialized.");
     return ncclInternalError;
@@ -258,13 +260,14 @@ ncclResult_t wrap_gdr_copy_to_mapping(gdr_mh_t handle, void *map_d_ptr, const vo
   int ret;
   GDRLOCKCALL(gdr_internal_copy_to_mapping(handle, map_d_ptr, h_ptr, size), ret);
   if (ret != 0) {
-    WARN("gdr_copy_to_mapping(handle %lx, map_d_ptr %p, h_ptr %p, size %zu) failed: %d", handle.h, map_d_ptr, h_ptr, size, ret);
+    WARN("gdr_copy_to_mapping(handle %lx, map_d_ptr %p, h_ptr %p, size %zu) failed: %d", handle.h, map_d_ptr, h_ptr,
+         size, ret);
     return ncclSystemError;
   }
   return ncclSuccess;
 }
 
-ncclResult_t wrap_gdr_copy_from_mapping(gdr_mh_t handle, void *h_ptr, const void *map_d_ptr, size_t size) {
+ncclResult_t wrap_gdr_copy_from_mapping(gdr_mh_t handle, void* h_ptr, const void* map_d_ptr, size_t size) {
   if (gdr_internal_copy_from_mapping == NULL) {
     WARN("GDRCOPY lib wrapper not initialized.");
     return ncclInternalError;
@@ -272,7 +275,8 @@ ncclResult_t wrap_gdr_copy_from_mapping(gdr_mh_t handle, void *h_ptr, const void
   int ret;
   GDRLOCKCALL(gdr_internal_copy_from_mapping(handle, h_ptr, map_d_ptr, size), ret);
   if (ret != 0) {
-    WARN("gdr_copy_from_mapping(handle %lx, h_ptr %p, map_d_ptr %p, size %zu) failed: %d", handle.h, h_ptr, map_d_ptr, size, ret);
+    WARN("gdr_copy_from_mapping(handle %lx, h_ptr %p, map_d_ptr %p, size %zu) failed: %d", handle.h, h_ptr, map_d_ptr,
+         size, ret);
     return ncclSystemError;
   }
   return ncclSuccess;

--- a/projects/rccl/src/misc/git_version.cc
+++ b/projects/rccl/src/misc/git_version.cc
@@ -9,6 +9,6 @@
 
 // Pre-process the string so that running "strings" on the lib can quickly reveal the version.
 #define NCCL_GIT_VERSION_STRING "NCCL git version " NCCL_GIT_BRANCH " " NCCL_GIT_COMMIT_HASH
-const char * ncclGetGitVersion(void) {
+const char* ncclGetGitVersion(void) {
   return NCCL_GIT_VERSION_STRING;
 }

--- a/projects/rccl/src/misc/ibvsymbols.cc
+++ b/projects/rccl/src/misc/ibvsymbols.cc
@@ -13,23 +13,16 @@
 #ifdef NCCL_BUILD_RDMA_CORE
 /* RDMA-core linking mode. Symbols are pointers to linked IB Verbs */
 
-#define ASSIGN_SYM(container, symbol, name) container->name= &symbol;
+#define ASSIGN_SYM(container, symbol, name) container->name = &symbol;
 
 // Passthrough function for ibv_reg_mr macro in verbs.h
-struct ibv_mr* ibv_internal_reg_mr(
-      struct ibv_pd* pd,
-      void* addr,
-      size_t length,
-      int access) {
-    return ibv_reg_mr(pd, addr, length, access);
-  }
+struct ibv_mr* ibv_internal_reg_mr(struct ibv_pd* pd, void* addr, size_t length, int access) {
+  return ibv_reg_mr(pd, addr, length, access);
+}
 
 // Passthrough function for ibv_internal_query_port macro in verbs.h
-int ibv_internal_query_port(
-      struct ibv_context* context,
-      uint8_t port_num,
-      struct ibv_port_attr* port_attr) {
-    return ibv_query_port(context, port_num, port_attr);
+int ibv_internal_query_port(struct ibv_context* context, uint8_t port_num, struct ibv_port_attr* port_attr) {
+  return ibv_query_port(context, port_num, port_attr);
 }
 
 ncclResult_t buildIbvSymbols(struct ncclIbvSymbols* ibvSymbols) {
@@ -82,8 +75,8 @@ ncclResult_t buildIbvSymbols(struct ncclIbvSymbols* ibvSymbols) {
   void* tmp;
   void** cast;
   const char* envIbVerbsLib = ncclGetEnv("NCCL_IBVERBS_LIB");
-  const char* ibVerbsLib[NCCL_IBVERBS_LIBS] = { envIbVerbsLib, "libibverbs.so", "libibverbs.so.1" };
-  if (envIbVerbsLib) INFO(NCCL_ENV|NCCL_INIT, "NCCL_IBVERBS_LIB set by environment to %s", envIbVerbsLib);
+  const char* ibVerbsLib[NCCL_IBVERBS_LIBS] = {envIbVerbsLib, "libibverbs.so", "libibverbs.so.1"};
+  if (envIbVerbsLib) INFO(NCCL_ENV | NCCL_INIT, "NCCL_IBVERBS_LIB set by environment to %s", envIbVerbsLib);
 
   for (int i = 0; i < NCCL_IBVERBS_LIBS; i++) {
     if (ibVerbsLib[i] == nullptr) continue;
@@ -93,20 +86,22 @@ ncclResult_t buildIbvSymbols(struct ncclIbvSymbols* ibvSymbols) {
   }
   if (ibvhandle == nullptr) goto teardown;
 
-#define LOAD_SYM(handle, symbol, funcptr) do {           \
-    cast = (void**)&funcptr;                             \
-    tmp = dlvsym(handle, symbol, IBVERBS_VERSION);       \
-    if (tmp == NULL) {                                   \
-      WARN("dlvsym failed on %s - %s version %s", symbol, dlerror(), IBVERBS_VERSION);  \
-      goto teardown;                                     \
-    }                                                    \
-    *cast = tmp;                                         \
+#define LOAD_SYM(handle, symbol, funcptr) \
+  do { \
+    cast = (void**)&funcptr; \
+    tmp = dlvsym(handle, symbol, IBVERBS_VERSION); \
+    if (tmp == NULL) { \
+      WARN("dlvsym failed on %s - %s version %s", symbol, dlerror(), IBVERBS_VERSION); \
+      goto teardown; \
+    } \
+    *cast = tmp; \
   } while (0)
 
 // Attempt to load a specific symbol version - fail silently
-#define LOAD_SYM_VERSION(handle, symbol, funcptr, version) do {  \
-    cast = (void**)&funcptr;                                     \
-    *cast = dlvsym(handle, symbol, version);                     \
+#define LOAD_SYM_VERSION(handle, symbol, funcptr, version) \
+  do { \
+    cast = (void**)&funcptr; \
+    *cast = dlvsym(handle, symbol, version); \
   } while (0)
 
   LOAD_SYM(ibvhandle, "ibv_get_device_list", ibvSymbols->ibv_internal_get_device_list);
@@ -137,7 +132,7 @@ ncclResult_t buildIbvSymbols(struct ncclIbvSymbols* ibvSymbols) {
   LOAD_SYM(ibvhandle, "ibv_event_type_str", ibvSymbols->ibv_internal_event_type_str);
 
   LOAD_SYM_VERSION(ibvhandle, "ibv_query_ece", ibvSymbols->ibv_internal_query_ece, "IBVERBS_1.10");
-  LOAD_SYM_VERSION(ibvhandle, "ibv_set_ece",   ibvSymbols->ibv_internal_set_ece, "IBVERBS_1.10");
+  LOAD_SYM_VERSION(ibvhandle, "ibv_set_ece", ibvSymbols->ibv_internal_set_ece, "IBVERBS_1.10");
 
   return ncclSuccess;
 

--- a/projects/rccl/src/misc/ibvwrap.cc
+++ b/projects/rccl/src/misc/ibvwrap.cc
@@ -53,16 +53,15 @@ static std::unordered_map<struct ibv_context*, ncclIbQpTracker> ncclIbQpMap;
 #endif
 
 ncclResult_t wrap_ibv_symbols(void) {
-  std::call_once(initOnceFlag,
-               [](){ initResult = buildIbvSymbols(&ibvSymbols); });
+  std::call_once(initOnceFlag, []() { initResult = buildIbvSymbols(&ibvSymbols); });
   return initResult;
 }
 
 /* CHECK_NOT_NULL: helper macro to check for NULL symbol */
 #define CHECK_NOT_NULL(container, internal_name) \
   if (container.internal_name == NULL) { \
-     WARN("lib wrapper not initialized."); \
-     return ncclInternalError; \
+    WARN("lib wrapper not initialized."); \
+    return ncclInternalError; \
   }
 
 #define IBV_PTR_CHECK_ERRNO(container, internal_name, call, retval, error_retval, name) \
@@ -129,26 +128,26 @@ NCCL_PARAM(IbMQpRetryAll, "IB_MQP_RETRY_ALL", 0);
 NCCL_PARAM(IbMQpRetryCnt, "IB_MQP_RETRY_CNT", 34);
 NCCL_PARAM(IbMQpRetryTimeout, "IB_MQP_RETRY_SLEEP_MSEC", 100); // in milliseconds
 
-#define IBV_ERR_EQ(e, code)        (e == code || e == (-code))
-#define IBV_MQP_RETRY_ERRNO(e)     (IBV_ERR_EQ(e, ETIMEDOUT))
+#define IBV_ERR_EQ(e, code) (e == code || e == (-code))
+#define IBV_MQP_RETRY_ERRNO(e) (IBV_ERR_EQ(e, ETIMEDOUT))
 #define IBV_MQP_RETRY_ERRNO_ALL(e) (ncclParamIbMQpRetryAll() ? (e != 0) : IBV_MQP_RETRY_ERRNO(e))
 
 ncclResult_t wrap_ibv_fork_init() {
   IBV_INT_CHECK(ibvSymbols, ibv_internal_fork_init, ibv_internal_fork_init(), -1, "ibv_fork_init");
 }
 
-ncclResult_t wrap_ibv_get_device_list(struct ibv_device ***ret, int *num_devices) {
+ncclResult_t wrap_ibv_get_device_list(struct ibv_device*** ret, int* num_devices) {
   *ret = ibvSymbols.ibv_internal_get_device_list(num_devices);
   if (*ret == NULL) *num_devices = 0;
   return ncclSuccess;
 }
 
-ncclResult_t wrap_ibv_free_device_list(struct ibv_device **list) {
+ncclResult_t wrap_ibv_free_device_list(struct ibv_device** list) {
   if (list == NULL) return ncclSuccess;
   IBV_PASSTHRU(ibvSymbols, ibv_internal_free_device_list, ibv_internal_free_device_list(list));
 }
 
-const char *wrap_ibv_get_device_name(struct ibv_device *device) {
+const char* wrap_ibv_get_device_name(struct ibv_device* device) {
   if (ibvSymbols.ibv_internal_get_device_name == NULL) {
     WARN("lib wrapper not initialized.");
     exit(-1);
@@ -156,7 +155,8 @@ const char *wrap_ibv_get_device_name(struct ibv_device *device) {
   return ibvSymbols.ibv_internal_get_device_name(device);
 }
 
-ncclResult_t wrap_ibv_open_device(struct ibv_context **ret, struct ibv_device *device) { /*returns ncclResult_t (ncclSuccess on success)*/
+ncclResult_t wrap_ibv_open_device(struct ibv_context** ret,
+                                  struct ibv_device* device) { /*returns ncclResult_t (ncclSuccess on success)*/
 #ifdef ENABLE_FAULT_INJECTION
   // Expand IBV_PTR_CHECK inline to install fault shims before returning.
   CHECK_NOT_NULL(ibvSymbols, ibv_internal_open_device);
@@ -177,7 +177,7 @@ ncclResult_t wrap_ibv_open_device(struct ibv_context **ret, struct ibv_device *d
 #endif
 }
 
-ncclResult_t wrap_ibv_close_device(struct ibv_context *context) { /*returns ncclResult_t (ncclSuccess on success)*/
+ncclResult_t wrap_ibv_close_device(struct ibv_context* context) { /*returns ncclResult_t (ncclSuccess on success)*/
 #ifdef ENABLE_FAULT_INJECTION
   // Restore original ops before closing so the real close sees a clean context.
   if (context) NCCLCHECK(ncclIbOpsFaultRemove(context));
@@ -185,54 +185,67 @@ ncclResult_t wrap_ibv_close_device(struct ibv_context *context) { /*returns nccl
   IBV_INT_CHECK(ibvSymbols, ibv_internal_close_device, ibv_internal_close_device(context), -1, "ibv_close_device");
 }
 
-ncclResult_t wrap_ibv_get_async_event(struct ibv_context *context, struct ibv_async_event *event) { /*returns 0 on success, and -1 on error*/
-  IBV_INT_CHECK(ibvSymbols, ibv_internal_get_async_event, ibv_internal_get_async_event(context, event), -1, "ibv_get_async_event");
+ncclResult_t wrap_ibv_get_async_event(struct ibv_context* context,
+                                      struct ibv_async_event* event) { /*returns 0 on success, and -1 on error*/
+  IBV_INT_CHECK(ibvSymbols, ibv_internal_get_async_event, ibv_internal_get_async_event(context, event), -1,
+                "ibv_get_async_event");
 }
 
-ncclResult_t wrap_ibv_ack_async_event(struct ibv_async_event *event) {
+ncclResult_t wrap_ibv_ack_async_event(struct ibv_async_event* event) {
   IBV_PASSTHRU(ibvSymbols, ibv_internal_ack_async_event, ibv_internal_ack_async_event(event));
 }
 
-ncclResult_t wrap_ibv_query_device(struct ibv_context *context, struct ibv_device_attr *device_attr) { /*returns 0 on success, or the value of errno on failure (which indicates the failure reason)*/
-  IBV_INT_CHECK_RET_ERRNO(ibvSymbols, ibv_internal_query_device, ibv_internal_query_device(context, device_attr), 0, "ibv_query_device");
+ncclResult_t wrap_ibv_query_device(
+  struct ibv_context* context,
+  struct ibv_device_attr*
+    device_attr) { /*returns 0 on success, or the value of errno on failure (which indicates the failure reason)*/
+  IBV_INT_CHECK_RET_ERRNO(ibvSymbols, ibv_internal_query_device, ibv_internal_query_device(context, device_attr), 0,
+                          "ibv_query_device");
 }
 
-ncclResult_t wrap_ibv_query_port(struct ibv_context *context, uint8_t port_num, struct ibv_port_attr *port_attr) {
+ncclResult_t wrap_ibv_query_port(struct ibv_context* context, uint8_t port_num, struct ibv_port_attr* port_attr) {
 #ifndef NCCL_BUILD_RDMA_CORE
   // First try and query the extended port attributes (e.g. active_speed_ex)
   if (ibv_query_port_ex(context, port_num, port_attr) != 0) {
     // Fall back to the original attribute API call, but zero all members first
     memset(port_attr, 0, sizeof(*port_attr));
-    IBV_INT_CHECK_RET_ERRNO(ibvSymbols, ibv_internal_query_port, ibv_internal_query_port(context, port_num, port_attr), 0, "ibv_query_port");
+    IBV_INT_CHECK_RET_ERRNO(ibvSymbols, ibv_internal_query_port, ibv_internal_query_port(context, port_num, port_attr),
+                            0, "ibv_query_port");
   }
 #else
   // When using system rdma-core, use the regular ibv_query_port
-  IBV_INT_CHECK_RET_ERRNO(ibvSymbols, ibv_internal_query_port, ibv_internal_query_port(context, port_num, port_attr), 0, "ibv_query_port");
+  IBV_INT_CHECK_RET_ERRNO(ibvSymbols, ibv_internal_query_port, ibv_internal_query_port(context, port_num, port_attr), 0,
+                          "ibv_query_port");
 #endif
   return ncclSuccess;
 }
 
-ncclResult_t wrap_ibv_query_gid(struct ibv_context *context, uint8_t port_num, int index, union ibv_gid *gid) {
-  IBV_INT_CHECK_RET_ERRNO(ibvSymbols, ibv_internal_query_gid, ibv_internal_query_gid(context, port_num, index, gid), 0, "ibv_query_gid");
+ncclResult_t wrap_ibv_query_gid(struct ibv_context* context, uint8_t port_num, int index, union ibv_gid* gid) {
+  IBV_INT_CHECK_RET_ERRNO(ibvSymbols, ibv_internal_query_gid, ibv_internal_query_gid(context, port_num, index, gid), 0,
+                          "ibv_query_gid");
 }
 
-ncclResult_t wrap_ibv_query_qp(struct ibv_qp *qp, struct ibv_qp_attr *attr, int attr_mask, struct ibv_qp_init_attr *init_attr) {
-  IBV_INT_CHECK_RET_ERRNO(ibvSymbols, ibv_internal_query_qp, ibv_internal_query_qp(qp, attr, attr_mask, init_attr), 0, "ibv_query_qp");
+ncclResult_t wrap_ibv_query_qp(struct ibv_qp* qp, struct ibv_qp_attr* attr, int attr_mask,
+                               struct ibv_qp_init_attr* init_attr) {
+  IBV_INT_CHECK_RET_ERRNO(ibvSymbols, ibv_internal_query_qp, ibv_internal_query_qp(qp, attr, attr_mask, init_attr), 0,
+                          "ibv_query_qp");
 }
 
-ncclResult_t wrap_ibv_alloc_pd(struct ibv_pd **ret, struct ibv_context *context) {
+ncclResult_t wrap_ibv_alloc_pd(struct ibv_pd** ret, struct ibv_context* context) {
   IBV_PTR_CHECK_ERRNO(ibvSymbols, ibv_internal_alloc_pd, ibv_internal_alloc_pd(context), *ret, NULL, "ibv_alloc_pd");
 }
 
-ncclResult_t wrap_ibv_dealloc_pd(struct ibv_pd *pd) { /*returns 0 on success, or the value of errno on failure (which indicates the failure reason)*/
+ncclResult_t wrap_ibv_dealloc_pd(
+  struct ibv_pd* pd) { /*returns 0 on success, or the value of errno on failure (which indicates the failure reason)*/
   IBV_INT_CHECK_RET_ERRNO(ibvSymbols, ibv_internal_dealloc_pd, ibv_internal_dealloc_pd(pd), 0, "ibv_dealloc_pd");
 }
 
-ncclResult_t wrap_ibv_reg_mr(struct ibv_mr **ret, struct ibv_pd *pd, void *addr, size_t length, int access) {
-  IBV_PTR_CHECK_ERRNO(ibvSymbols, ibv_internal_reg_mr, ibv_internal_reg_mr(pd, addr, length, access), *ret, NULL, "ibv_reg_mr");
+ncclResult_t wrap_ibv_reg_mr(struct ibv_mr** ret, struct ibv_pd* pd, void* addr, size_t length, int access) {
+  IBV_PTR_CHECK_ERRNO(ibvSymbols, ibv_internal_reg_mr, ibv_internal_reg_mr(pd, addr, length, access), *ret, NULL,
+                      "ibv_reg_mr");
 }
 
-struct ibv_mr * wrap_direct_ibv_reg_mr(struct ibv_pd *pd, void *addr, size_t length, int access) {
+struct ibv_mr* wrap_direct_ibv_reg_mr(struct ibv_pd* pd, void* addr, size_t length, int access) {
   if (ibvSymbols.ibv_internal_reg_mr == NULL) {
     WARN("lib wrapper not initialized.");
     return NULL;
@@ -240,20 +253,28 @@ struct ibv_mr * wrap_direct_ibv_reg_mr(struct ibv_pd *pd, void *addr, size_t len
   return ibvSymbols.ibv_internal_reg_mr(pd, addr, length, access);
 }
 
-ncclResult_t wrap_ibv_reg_mr_iova2(struct ibv_mr **ret, struct ibv_pd *pd, void *addr, size_t length, uint64_t iova, int access) {
+ncclResult_t wrap_ibv_reg_mr_iova2(struct ibv_mr** ret, struct ibv_pd* pd, void* addr, size_t length, uint64_t iova,
+                                   int access) {
   if (ibvSymbols.ibv_internal_reg_mr_iova2 == NULL) {
     return ncclInternalError;
   }
-  if (ret == NULL) { return ncclSuccess; } // Assume dummy call
-  IBV_PTR_CHECK_ERRNO(ibvSymbols, ibv_internal_reg_mr_iova2, ibv_internal_reg_mr_iova2(pd, addr, length, iova, access), *ret, NULL, "ibv_reg_mr_iova2");
+  if (ret == NULL) {
+    return ncclSuccess;
+  } // Assume dummy call
+  IBV_PTR_CHECK_ERRNO(ibvSymbols, ibv_internal_reg_mr_iova2, ibv_internal_reg_mr_iova2(pd, addr, length, iova, access),
+                      *ret, NULL, "ibv_reg_mr_iova2");
 }
 
 /* DMA-BUF support */
-ncclResult_t wrap_ibv_reg_dmabuf_mr(struct ibv_mr **ret, struct ibv_pd *pd, uint64_t offset, size_t length, uint64_t iova, int fd, int access) {
-  IBV_PTR_CHECK_ERRNO(ibvSymbols, ibv_internal_reg_dmabuf_mr, ibv_internal_reg_dmabuf_mr(pd, offset, length, iova, fd, access), *ret, NULL, "ibv_reg_dmabuf_mr");
+ncclResult_t wrap_ibv_reg_dmabuf_mr(struct ibv_mr** ret, struct ibv_pd* pd, uint64_t offset, size_t length,
+                                    uint64_t iova, int fd, int access) {
+  IBV_PTR_CHECK_ERRNO(ibvSymbols, ibv_internal_reg_dmabuf_mr,
+                      ibv_internal_reg_dmabuf_mr(pd, offset, length, iova, fd, access), *ret, NULL,
+                      "ibv_reg_dmabuf_mr");
 }
 
-struct ibv_mr * wrap_direct_ibv_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset, size_t length, uint64_t iova, int fd, int access) {
+struct ibv_mr* wrap_direct_ibv_reg_dmabuf_mr(struct ibv_pd* pd, uint64_t offset, size_t length, uint64_t iova, int fd,
+                                             int access) {
   if (ibvSymbols.ibv_internal_reg_dmabuf_mr == NULL) {
     errno = EOPNOTSUPP; // ncclIbDmaBufSupport() requires this errno being set
     return NULL;
@@ -261,19 +282,23 @@ struct ibv_mr * wrap_direct_ibv_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset
   return ibvSymbols.ibv_internal_reg_dmabuf_mr(pd, offset, length, iova, fd, access);
 }
 
-ncclResult_t wrap_ibv_dereg_mr(struct ibv_mr *mr) { /*returns 0 on success, or the value of errno on failure (which indicates the failure reason)*/
+ncclResult_t wrap_ibv_dereg_mr(
+  struct ibv_mr* mr) { /*returns 0 on success, or the value of errno on failure (which indicates the failure reason)*/
   IBV_INT_CHECK_RET_ERRNO(ibvSymbols, ibv_internal_dereg_mr, ibv_internal_dereg_mr(mr), 0, "ibv_dereg_mr");
 }
 
-ncclResult_t wrap_ibv_create_cq(struct ibv_cq **ret, struct ibv_context *context, int cqe, void *cq_context, struct ibv_comp_channel *channel, int comp_vector) {
-  IBV_PTR_CHECK_ERRNO(ibvSymbols, ibv_internal_create_cq, ibv_internal_create_cq(context, cqe, cq_context, channel, comp_vector), *ret, NULL, "ibv_create_cq");
+ncclResult_t wrap_ibv_create_cq(struct ibv_cq** ret, struct ibv_context* context, int cqe, void* cq_context,
+                                struct ibv_comp_channel* channel, int comp_vector) {
+  IBV_PTR_CHECK_ERRNO(ibvSymbols, ibv_internal_create_cq,
+                      ibv_internal_create_cq(context, cqe, cq_context, channel, comp_vector), *ret, NULL,
+                      "ibv_create_cq");
 }
 
-ncclResult_t wrap_ibv_destroy_cq(struct ibv_cq *cq) {
+ncclResult_t wrap_ibv_destroy_cq(struct ibv_cq* cq) {
   IBV_INT_CHECK_RET_ERRNO(ibvSymbols, ibv_internal_destroy_cq, ibv_internal_destroy_cq(cq), 0, "ibv_destroy_cq");
 }
 
-ncclResult_t wrap_ibv_destroy_qp(struct ibv_qp *qp) {
+ncclResult_t wrap_ibv_destroy_qp(struct ibv_qp* qp) {
 #ifdef ENABLE_QP_TRACKING
   struct ibv_context* ctx = qp->context;
   const char* devName = wrap_ibv_get_device_name(ctx->device);
@@ -289,14 +314,14 @@ ncclResult_t wrap_ibv_destroy_qp(struct ibv_qp *qp) {
     std::lock_guard<std::mutex> lock(ncclIbQpMapMutex);
     auto& t = ncclIbQpMap[ctx];
     t.trackDestroy();
-    TRACE(NCCL_NET, "NET/IB: QP destroyed on %s ctx=%p total=%d active=%d peak=%d",
-         devName, ctx, t.total, t.active, t.peak);
+    TRACE(NCCL_NET, "NET/IB: QP destroyed on %s ctx=%p total=%d active=%d peak=%d", devName, ctx, t.total, t.active,
+          t.peak);
   }
 #endif
   return ncclSuccess;
 }
 
-ncclResult_t wrap_ibv_create_qp(struct ibv_qp **ret, struct ibv_pd *pd, struct ibv_qp_init_attr *qp_init_attr) {
+ncclResult_t wrap_ibv_create_qp(struct ibv_qp** ret, struct ibv_pd* pd, struct ibv_qp_init_attr* qp_init_attr) {
   CHECK_NOT_NULL(ibvSymbols, ibv_internal_create_qp);
   *ret = ibvSymbols.ibv_internal_create_qp(pd, qp_init_attr);
   if (*ret == NULL) {
@@ -310,8 +335,8 @@ ncclResult_t wrap_ibv_create_qp(struct ibv_qp **ret, struct ibv_pd *pd, struct i
     std::lock_guard<std::mutex> lock(ncclIbQpMapMutex);
     auto& t = ncclIbQpMap[ctx];
     t.trackCreate();
-    TRACE(NCCL_NET, "NET/IB: QP created on %s ctx=%p total=%d active=%d peak=%d",
-         devName, ctx, t.total, t.active, t.peak);
+    TRACE(NCCL_NET, "NET/IB: QP created on %s ctx=%p total=%d active=%d peak=%d", devName, ctx, t.total, t.active,
+          t.peak);
   }
 #endif
   return ncclSuccess;
@@ -319,21 +344,40 @@ ncclResult_t wrap_ibv_create_qp(struct ibv_qp **ret, struct ibv_pd *pd, struct i
 
 static void ibvQpStateName(enum ibv_qp_state state, char* msg, const size_t len) {
   switch (state) {
-  case (IBV_QPS_RESET): snprintf(msg, len, "RESET"); break;
-  case (IBV_QPS_INIT): snprintf(msg, len, "INIT"); break;
-  case (IBV_QPS_RTR): snprintf(msg, len, "RTR"); break;
-  case (IBV_QPS_RTS): snprintf(msg, len, "RTS"); break;
-  case (IBV_QPS_SQD): snprintf(msg, len, "SQD"); break;
-  case (IBV_QPS_SQE): snprintf(msg, len, "SQE"); break;
-  case (IBV_QPS_ERR): snprintf(msg, len, "ERR"); break;
-  case (IBV_QPS_UNKNOWN): snprintf(msg, len, "UNKNOWN"); break;
-  default: snprintf(msg, len, "NOT RECOGNIZED (%d)", state); break;
+  case (IBV_QPS_RESET):
+    snprintf(msg, len, "RESET");
+    break;
+  case (IBV_QPS_INIT):
+    snprintf(msg, len, "INIT");
+    break;
+  case (IBV_QPS_RTR):
+    snprintf(msg, len, "RTR");
+    break;
+  case (IBV_QPS_RTS):
+    snprintf(msg, len, "RTS");
+    break;
+  case (IBV_QPS_SQD):
+    snprintf(msg, len, "SQD");
+    break;
+  case (IBV_QPS_SQE):
+    snprintf(msg, len, "SQE");
+    break;
+  case (IBV_QPS_ERR):
+    snprintf(msg, len, "ERR");
+    break;
+  case (IBV_QPS_UNKNOWN):
+    snprintf(msg, len, "UNKNOWN");
+    break;
+  default:
+    snprintf(msg, len, "NOT RECOGNIZED (%d)", state);
+    break;
   }
 }
 
 #define QP_ATTR(attr, userAttr, userFlag, mask) ((userFlag & mask) ? (userAttr) : (attr))
 
-static void ibvModifyQpLog(struct ibv_qp* qp, enum ibv_qp_state qpState, struct ibv_qp_attr* userAttr, int userFlag, char* msg, size_t msgLen) {
+static void ibvModifyQpLog(struct ibv_qp* qp, enum ibv_qp_state qpState, struct ibv_qp_attr* userAttr, int userFlag,
+                           char* msg, size_t msgLen) {
   ncclResult_t res;
   int portNum = -1, gidIndex = -1;
   char localGidName[INET6_ADDRSTRLEN], remoteGidName[INET6_ADDRSTRLEN];
@@ -343,26 +387,27 @@ static void ibvModifyQpLog(struct ibv_qp* qp, enum ibv_qp_state qpState, struct 
   ibvQpStateName(qp->state, currState, sizeof(currState));
   ibvQpStateName(qpState, nextState, sizeof(nextState));
   char devName[IBV_SYSFS_NAME_MAX] = "";
-  snprintf(devName, sizeof(devName), "%s", (qp->pd->context) ? wrap_ibv_get_device_name(qp->pd->context->device) : "N/A");
+  snprintf(devName, sizeof(devName), "%s",
+           (qp->pd->context) ? wrap_ibv_get_device_name(qp->pd->context->device) : "N/A");
 
   struct ibv_qp_attr attr;
   struct ibv_qp_init_attr init_attr;
   int attr_mask = IBV_QP_PORT | IBV_QP_AV;
   res = wrap_ibv_query_qp(qp, &attr, attr_mask, &init_attr);
-  struct ibv_qp_attr *qpAttr = (res == ncclSuccess) ? &attr : NULL;
+  struct ibv_qp_attr* qpAttr = (res == ncclSuccess) ? &attr : NULL;
 
   // port info, portAttr can be NULL if not given by the user and query_qp failed
-  struct ibv_qp_attr *portAttr = QP_ATTR(qpAttr, userAttr, userFlag, IBV_QP_PORT);
+  struct ibv_qp_attr* portAttr = QP_ATTR(qpAttr, userAttr, userFlag, IBV_QP_PORT);
   portNum = portAttr ? portAttr->port_num : -1;
 
   // address info, avAttr can be NULL if not given by the user and query_qp failed
-  struct ibv_qp_attr *avAttr = QP_ATTR(qpAttr, userAttr, userFlag, IBV_QP_AV);
+  struct ibv_qp_attr* avAttr = QP_ATTR(qpAttr, userAttr, userFlag, IBV_QP_AV);
   if (avAttr && avAttr->ah_attr.is_global) {
-    union ibv_gid *remoteGid = &avAttr->ah_attr.grh.dgid;
+    union ibv_gid* remoteGid = &avAttr->ah_attr.grh.dgid;
     remoteGidRes = ibvGetGidStr(remoteGid, remoteGidName, sizeof(remoteGidName));
     // we need pd->context to retrieve local GID, skip if not there
     if (!qp->pd->context) goto print;
-    gidIndex =  avAttr->ah_attr.grh.sgid_index;
+    gidIndex = avAttr->ah_attr.grh.sgid_index;
     union ibv_gid localGid;
     NCCLCHECKGOTO(wrap_ibv_query_gid(qp->pd->context, portNum, gidIndex, &localGid), res, print);
     localGidRes = ibvGetGidStr(&localGid, localGidName, sizeof(localGidName));
@@ -370,7 +415,8 @@ static void ibvModifyQpLog(struct ibv_qp* qp, enum ibv_qp_state qpState, struct 
 
 print:
   snprintf(msg, msgLen, "on dev %s:%d, curr state %s, next state %s, local GID index %d, local GID %s, remote GID %s",
-           devName, portNum, currState, nextState, gidIndex, localGidRes ? localGidName : "N/A", remoteGidRes ? remoteGidName : "N/A");
+           devName, portNum, currState, nextState, gidIndex, localGidRes ? localGidName : "N/A",
+           remoteGidRes ? remoteGidName : "N/A");
   return;
 }
 
@@ -384,7 +430,8 @@ ncclResult_t wrap_ibv_modify_qp(struct ibv_qp* qp, struct ibv_qp_attr* attr, int
     if (attempts > 0) {
       unsigned int sleepTime = timeOut * attempts;
       ibvModifyQpLog(qp, attr->qp_state, attr, attr_mask, qpMsg, sizeof(qpMsg));
-      INFO(NCCL_NET, "Call to ibv_modify_qp failed with %d %s, %s, retrying %d/%d after %u msec of sleep", ret, strerror(ret), qpMsg, attempts, maxCnt, sleepTime);
+      INFO(NCCL_NET, "Call to ibv_modify_qp failed with %d %s, %s, retrying %d/%d after %u msec of sleep", ret,
+           strerror(ret), qpMsg, attempts, maxCnt, sleepTime);
       // sleep before retrying
       std::this_thread::sleep_for(std::chrono::milliseconds(sleepTime));
     }
@@ -399,72 +446,118 @@ ncclResult_t wrap_ibv_modify_qp(struct ibv_qp* qp, struct ibv_qp_attr* attr, int
   return ncclSuccess;
 }
 
-ncclResult_t wrap_ibv_query_ece(struct ibv_qp *qp, struct ibv_ece *ece, int* supported) { /*returns 0 on success, or the value of errno on failure (which indicates the failure reason)*/
-  IBV_INT_CHECK_RET_ERRNO_OPTIONAL(ibvSymbols, ibv_internal_query_ece, ibv_internal_query_ece(qp, ece), 0, "ibv_query_ece", supported);
+ncclResult_t wrap_ibv_query_ece(
+  struct ibv_qp* qp, struct ibv_ece* ece,
+  int* supported) { /*returns 0 on success, or the value of errno on failure (which indicates the failure reason)*/
+  IBV_INT_CHECK_RET_ERRNO_OPTIONAL(ibvSymbols, ibv_internal_query_ece, ibv_internal_query_ece(qp, ece), 0,
+                                   "ibv_query_ece", supported);
 }
 
-ncclResult_t wrap_ibv_set_ece(struct ibv_qp *qp, struct ibv_ece *ece, int* supported) { /*returns 0 on success, or the value of errno on failure (which indicates the failure reason)*/
-  IBV_INT_CHECK_RET_ERRNO_OPTIONAL(ibvSymbols, ibv_internal_set_ece, ibv_internal_set_ece(qp, ece), 0, "ibv_set_ece", supported);
+ncclResult_t wrap_ibv_set_ece(
+  struct ibv_qp* qp, struct ibv_ece* ece,
+  int* supported) { /*returns 0 on success, or the value of errno on failure (which indicates the failure reason)*/
+  IBV_INT_CHECK_RET_ERRNO_OPTIONAL(ibvSymbols, ibv_internal_set_ece, ibv_internal_set_ece(qp, ece), 0, "ibv_set_ece",
+                                   supported);
 }
 
-ncclResult_t wrap_ibv_event_type_str(char **ret, enum ibv_event_type event) {
-  *ret = (char *) ibvSymbols.ibv_internal_event_type_str(event);
+ncclResult_t wrap_ibv_event_type_str(char** ret, enum ibv_event_type event) {
+  *ret = (char*)ibvSymbols.ibv_internal_event_type_str(event);
   return ncclSuccess;
 }
 
 // Helper function to convert IB work completion status to string
 const char* ibvWcStatusStr(enum ibv_wc_status status) {
   switch (status) {
-    case IBV_WC_SUCCESS:            return "IBV_WC_SUCCESS";
-    case IBV_WC_LOC_LEN_ERR:        return "IBV_WC_LOC_LEN_ERR";
-    case IBV_WC_LOC_QP_OP_ERR:      return "IBV_WC_LOC_QP_OP_ERR";
-    case IBV_WC_LOC_EEC_OP_ERR:     return "IBV_WC_LOC_EEC_OP_ERR";
-    case IBV_WC_LOC_PROT_ERR:       return "IBV_WC_LOC_PROT_ERR";
-    case IBV_WC_WR_FLUSH_ERR:       return "IBV_WC_WR_FLUSH_ERR";
-    case IBV_WC_MW_BIND_ERR:        return "IBV_WC_MW_BIND_ERR";
-    case IBV_WC_BAD_RESP_ERR:       return "IBV_WC_BAD_RESP_ERR";
-    case IBV_WC_LOC_ACCESS_ERR:     return "IBV_WC_LOC_ACCESS_ERR";
-    case IBV_WC_REM_INV_REQ_ERR:    return "IBV_WC_REM_INV_REQ_ERR";
-    case IBV_WC_REM_ACCESS_ERR:     return "IBV_WC_REM_ACCESS_ERR";
-    case IBV_WC_REM_OP_ERR:         return "IBV_WC_REM_OP_ERR";
-    case IBV_WC_RETRY_EXC_ERR:      return "IBV_WC_RETRY_EXC_ERR";
-    case IBV_WC_RNR_RETRY_EXC_ERR:  return "IBV_WC_RNR_RETRY_EXC_ERR";
-    case IBV_WC_LOC_RDD_VIOL_ERR:   return "IBV_WC_LOC_RDD_VIOL_ERR";
-    case IBV_WC_REM_INV_RD_REQ_ERR: return "IBV_WC_REM_INV_RD_REQ_ERR";
-    case IBV_WC_REM_ABORT_ERR:      return "IBV_WC_REM_ABORT_ERR";
-    case IBV_WC_INV_EECN_ERR:       return "IBV_WC_INV_EECN_ERR";
-    case IBV_WC_INV_EEC_STATE_ERR:  return "IBV_WC_INV_EEC_STATE_ERR";
-    case IBV_WC_FATAL_ERR:          return "IBV_WC_FATAL_ERR";
-    case IBV_WC_RESP_TIMEOUT_ERR:   return "IBV_WC_RESP_TIMEOUT_ERR";
-    case IBV_WC_GENERAL_ERR:        return "IBV_WC_GENERAL_ERR";
-    default:                        return "UNKNOWN_STATUS";
+  case IBV_WC_SUCCESS:
+    return "IBV_WC_SUCCESS";
+  case IBV_WC_LOC_LEN_ERR:
+    return "IBV_WC_LOC_LEN_ERR";
+  case IBV_WC_LOC_QP_OP_ERR:
+    return "IBV_WC_LOC_QP_OP_ERR";
+  case IBV_WC_LOC_EEC_OP_ERR:
+    return "IBV_WC_LOC_EEC_OP_ERR";
+  case IBV_WC_LOC_PROT_ERR:
+    return "IBV_WC_LOC_PROT_ERR";
+  case IBV_WC_WR_FLUSH_ERR:
+    return "IBV_WC_WR_FLUSH_ERR";
+  case IBV_WC_MW_BIND_ERR:
+    return "IBV_WC_MW_BIND_ERR";
+  case IBV_WC_BAD_RESP_ERR:
+    return "IBV_WC_BAD_RESP_ERR";
+  case IBV_WC_LOC_ACCESS_ERR:
+    return "IBV_WC_LOC_ACCESS_ERR";
+  case IBV_WC_REM_INV_REQ_ERR:
+    return "IBV_WC_REM_INV_REQ_ERR";
+  case IBV_WC_REM_ACCESS_ERR:
+    return "IBV_WC_REM_ACCESS_ERR";
+  case IBV_WC_REM_OP_ERR:
+    return "IBV_WC_REM_OP_ERR";
+  case IBV_WC_RETRY_EXC_ERR:
+    return "IBV_WC_RETRY_EXC_ERR";
+  case IBV_WC_RNR_RETRY_EXC_ERR:
+    return "IBV_WC_RNR_RETRY_EXC_ERR";
+  case IBV_WC_LOC_RDD_VIOL_ERR:
+    return "IBV_WC_LOC_RDD_VIOL_ERR";
+  case IBV_WC_REM_INV_RD_REQ_ERR:
+    return "IBV_WC_REM_INV_RD_REQ_ERR";
+  case IBV_WC_REM_ABORT_ERR:
+    return "IBV_WC_REM_ABORT_ERR";
+  case IBV_WC_INV_EECN_ERR:
+    return "IBV_WC_INV_EECN_ERR";
+  case IBV_WC_INV_EEC_STATE_ERR:
+    return "IBV_WC_INV_EEC_STATE_ERR";
+  case IBV_WC_FATAL_ERR:
+    return "IBV_WC_FATAL_ERR";
+  case IBV_WC_RESP_TIMEOUT_ERR:
+    return "IBV_WC_RESP_TIMEOUT_ERR";
+  case IBV_WC_GENERAL_ERR:
+    return "IBV_WC_GENERAL_ERR";
+  default:
+    return "UNKNOWN_STATUS";
   }
 }
 
 // Helper function to convert IB work completion opcode to string
 const char* ibvWcOpcodeStr(enum ibv_wc_opcode opcode) {
   switch (opcode) {
-    case IBV_WC_SEND:               return "IBV_WC_SEND";
-    case IBV_WC_RDMA_WRITE:         return "IBV_WC_RDMA_WRITE";
-    case IBV_WC_RDMA_READ:          return "IBV_WC_RDMA_READ";
-    case IBV_WC_COMP_SWAP:          return "IBV_WC_COMP_SWAP";
-    case IBV_WC_FETCH_ADD:          return "IBV_WC_FETCH_ADD";
-    case IBV_WC_BIND_MW:            return "IBV_WC_BIND_MW";
-    case IBV_WC_RECV:               return "IBV_WC_RECV";
-    case IBV_WC_RECV_RDMA_WITH_IMM: return "IBV_WC_RECV_RDMA_WITH_IMM";
-    default:                        return "UNKNOWN_OPCODE";
+  case IBV_WC_SEND:
+    return "IBV_WC_SEND";
+  case IBV_WC_RDMA_WRITE:
+    return "IBV_WC_RDMA_WRITE";
+  case IBV_WC_RDMA_READ:
+    return "IBV_WC_RDMA_READ";
+  case IBV_WC_COMP_SWAP:
+    return "IBV_WC_COMP_SWAP";
+  case IBV_WC_FETCH_ADD:
+    return "IBV_WC_FETCH_ADD";
+  case IBV_WC_BIND_MW:
+    return "IBV_WC_BIND_MW";
+  case IBV_WC_RECV:
+    return "IBV_WC_RECV";
+  case IBV_WC_RECV_RDMA_WITH_IMM:
+    return "IBV_WC_RECV_RDMA_WITH_IMM";
+  default:
+    return "UNKNOWN_OPCODE";
   }
 }
 
 const char* ibvWrOpcodeStr(enum ibv_wr_opcode opcode) {
   switch (opcode) {
-    case IBV_WR_RDMA_WRITE:          return "IBV_WR_RDMA_WRITE";
-    case IBV_WR_RDMA_WRITE_WITH_IMM: return "IBV_WR_RDMA_WRITE_WITH_IMM";
-    case IBV_WR_SEND:                return "IBV_WR_SEND";
-    case IBV_WR_SEND_WITH_IMM:       return "IBV_WR_SEND_WITH_IMM";
-    case IBV_WR_RDMA_READ:           return "IBV_WR_RDMA_READ";
-    case IBV_WR_ATOMIC_CMP_AND_SWP:  return "IBV_WR_ATOMIC_CMP_AND_SWP";
-    case IBV_WR_ATOMIC_FETCH_AND_ADD: return "IBV_WR_ATOMIC_FETCH_AND_ADD";
-    default:                          return "UNKNOWN_OPCODE";
+  case IBV_WR_RDMA_WRITE:
+    return "IBV_WR_RDMA_WRITE";
+  case IBV_WR_RDMA_WRITE_WITH_IMM:
+    return "IBV_WR_RDMA_WRITE_WITH_IMM";
+  case IBV_WR_SEND:
+    return "IBV_WR_SEND";
+  case IBV_WR_SEND_WITH_IMM:
+    return "IBV_WR_SEND_WITH_IMM";
+  case IBV_WR_RDMA_READ:
+    return "IBV_WR_RDMA_READ";
+  case IBV_WR_ATOMIC_CMP_AND_SWP:
+    return "IBV_WR_ATOMIC_CMP_AND_SWP";
+  case IBV_WR_ATOMIC_FETCH_AND_ADD:
+    return "IBV_WR_ATOMIC_FETCH_AND_ADD";
+  default:
+    return "UNKNOWN_OPCODE";
   }
 }

--- a/projects/rccl/src/misc/ionicdvsymbols.cc
+++ b/projects/rccl/src/misc/ionicdvsymbols.cc
@@ -24,25 +24,27 @@ ncclResult_t buildIonicdvSymbols(struct ncclIonicdvSymbols* ionicdvSymbols) {
     }
   }
 
-#define LOAD_SYM(handle, symbol, funcptr) do {           \
-    cast = (void**)&funcptr;                             \
-    tmp = dlvsym(handle, symbol, IONIC_VERSION);       \
-    if (tmp == NULL) {                                   \
-      WARN("dlvsym failed on %s - %s version %s", symbol, dlerror(), IONIC_VERSION);  \
-      goto teardown;                                     \
-    } else {                                             \
-      WARN("dlvsym loaded successfully for %s - version %s", symbol, IONIC_VERSION);  \
-    }                                                    \
-    *cast = tmp;                                         \
+#define LOAD_SYM(handle, symbol, funcptr) \
+  do { \
+    cast = (void**)&funcptr; \
+    tmp = dlvsym(handle, symbol, IONIC_VERSION); \
+    if (tmp == NULL) { \
+      WARN("dlvsym failed on %s - %s version %s", symbol, dlerror(), IONIC_VERSION); \
+      goto teardown; \
+    } else { \
+      WARN("dlvsym loaded successfully for %s - version %s", symbol, IONIC_VERSION); \
+    } \
+    *cast = tmp; \
   } while (0)
 
 // Attempt to load a specific symbol version - fail silently
-#define LOAD_SYM_VERSION(handle, symbol, funcptr, version) do {  \
-    cast = (void**)&funcptr;                                     \
-    *cast = dlvsym(handle, symbol, version);                     \
-    if (*cast == NULL) {                                         \
-      INFO(NCCL_NET, "dlvsym failed on %s - %s version %s", symbol, dlerror(), version);  \
-    }                                                            \
+#define LOAD_SYM_VERSION(handle, symbol, funcptr, version) \
+  do { \
+    cast = (void**)&funcptr; \
+    *cast = dlvsym(handle, symbol, version); \
+    if (*cast == NULL) { \
+      INFO(NCCL_NET, "dlvsym failed on %s - %s version %s", symbol, dlerror(), version); \
+    } \
   } while (0)
 
   LOAD_SYM(ionicdvhandle, "ionic_dv_qp_set_gda", ionicdvSymbols->ionicdv_internal_qp_set_gda);

--- a/projects/rccl/src/misc/ionicdvwrap.cc
+++ b/projects/rccl/src/misc/ionicdvwrap.cc
@@ -15,8 +15,7 @@ extern bool rcclUseAinic();
 ncclResult_t wrap_ionicdv_symbols(void) {
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
   if (rcclUseAinic()) {
-    pthread_once(&initOnceControl,
-                 [](){ initResult = buildIonicdvSymbols(&ionicdvSymbols); });
+    pthread_once(&initOnceControl, []() { initResult = buildIonicdvSymbols(&ionicdvSymbols); });
     return initResult;
   }
 #endif
@@ -27,8 +26,8 @@ ncclResult_t wrap_ionicdv_symbols(void) {
 /* CHECK_NOT_NULL: helper macro to check for NULL symbol */
 #define CHECK_NOT_NULL(container, internal_name) \
   if (container.internal_name == NULL) { \
-     WARN("lib wrapper not initialized."); \
-     return ncclInternalError; \
+    WARN("lib wrapper not initialized."); \
+    return ncclInternalError; \
   }
 
 #define IONICDV_INT_CHECK_RET_ERRNO(container, internal_name, call, success_retval, name) \
@@ -42,18 +41,20 @@ ncclResult_t wrap_ionicdv_symbols(void) {
   } \
   return ncclSuccess;
 
-ncclResult_t wrap_ionicdv_qp_set_gda(struct ibv_qp *qp, bool enable_send, bool enable_recv) {
+ncclResult_t wrap_ionicdv_qp_set_gda(struct ibv_qp* qp, bool enable_send, bool enable_recv) {
   if (ionicdvSymbols.ionicdv_internal_qp_set_gda == NULL) {
     errno = EOPNOTSUPP;
     return ncclSystemError;
   }
-  IONICDV_INT_CHECK_RET_ERRNO(ionicdvSymbols, ionicdv_internal_qp_set_gda, ionicdv_internal_qp_set_gda(qp, enable_send, enable_recv), 0, "ionic_dv_qp_set_gda");
+  IONICDV_INT_CHECK_RET_ERRNO(ionicdvSymbols, ionicdv_internal_qp_set_gda,
+                              ionicdv_internal_qp_set_gda(qp, enable_send, enable_recv), 0, "ionic_dv_qp_set_gda");
 }
 
-ncclResult_t wrap_ionicdv_pd_set_udma_mask(struct ibv_pd *ibpd, uint8_t udma_mask) {
+ncclResult_t wrap_ionicdv_pd_set_udma_mask(struct ibv_pd* ibpd, uint8_t udma_mask) {
   if (ionicdvSymbols.ionicdv_internal_pd_set_udma_mask == NULL) {
     errno = EOPNOTSUPP;
     return ncclSystemError;
   }
-  IONICDV_INT_CHECK_RET_ERRNO(ionicdvSymbols, ionicdv_internal_pd_set_udma_mask, ionicdv_internal_pd_set_udma_mask(ibpd, udma_mask), 0, "ionic_dv_pd_set_udma_mask");
+  IONICDV_INT_CHECK_RET_ERRNO(ionicdvSymbols, ionicdv_internal_pd_set_udma_mask,
+                              ionicdv_internal_pd_set_udma_mask(ibpd, udma_mask), 0, "ionic_dv_pd_set_udma_mask");
 }

--- a/projects/rccl/src/misc/latency_profiler/CollTrace.cc
+++ b/projects/rccl/src/misc/latency_profiler/CollTrace.cc
@@ -27,23 +27,14 @@ CudaEventPtr getCudaEventPtr() {
 }
 } // namespace
 
-CollTrace::CollTrace(ncclComm* comm)
-    : comm_(comm),
-      commHash_(std::to_string(comm->commHash)),
-      rank_(comm->rank) {
-  profilingWorkerThread_ =
-      std::thread{[this]() { return collTraceThreadFn(comm_->cudaDev); }};
+CollTrace::CollTrace(ncclComm* comm) : comm_(comm), commHash_(std::to_string(comm->commHash)), rank_(comm->rank) {
+  profilingWorkerThread_ = std::thread{[this]() { return collTraceThreadFn(comm_->cudaDev); }};
 }
 
 CollTrace::~CollTrace() {
   try {
-    INFO(
-        NCCL_INIT,
-        "COLLTRACE: commHash %s rank %d - Destroy START",
-        commHash_.c_str(),
-        rank_);
-    eventQueue_.push(std::unique_ptr<CollTraceEvent>(
-        new CollTraceEvent(CollTraceEvent::EventType::TERMINATE)));
+    INFO(NCCL_INIT, "COLLTRACE: commHash %s rank %d - Destroy START", commHash_.c_str(), rank_);
+    eventQueue_.push(std::unique_ptr<CollTraceEvent>(new CollTraceEvent(CollTraceEvent::EventType::TERMINATE)));
     if (profilingWorkerThread_.joinable()) {
       profilingWorkerThread_.join();
     }
@@ -52,17 +43,9 @@ CollTrace::~CollTrace() {
       reportIfNeeded(false);
     }
 
-    INFO(
-        NCCL_INIT,
-        "COLLTRACE: commHash %s rank %d - Destroy COMPLETE",
-        commHash_.c_str(),
-        rank_);
+    INFO(NCCL_INIT, "COLLTRACE: commHash %s rank %d - Destroy COMPLETE", commHash_.c_str(), rank_);
   } catch (const std::exception& e) {
-    WARN(
-        "COLLTRACE: commHash %s rank %d - Destroy FAILED: %s",
-        commHash_.c_str(),
-        rank_,
-        e.what());
+    WARN("COLLTRACE: commHash %s rank %d - Destroy FAILED: %s", commHash_.c_str(), rank_, e.what());
   }
 }
 
@@ -76,11 +59,7 @@ void* CollTrace::collTraceThreadFn(int cudaDev) {
 
   lastReportTime_ = std::chrono::steady_clock::now();
 
-  INFO(
-      NCCL_INIT,
-      "COLLTRACE: commHash %s rank %d - worker thread STARTED",
-      commHash_.c_str(),
-      rank_);
+  INFO(NCCL_INIT, "COLLTRACE: commHash %s rank %d - worker thread STARTED", commHash_.c_str(), rank_);
   while (true) {
     curEvent_ = eventQueue_.waitPop();
     if (curEvent_->eventType == CollTraceEvent::EventType::TERMINATE) {
@@ -91,13 +70,11 @@ void* CollTrace::collTraceThreadFn(int cudaDev) {
     float latency = -1;
 
     if (ncclRes == ncclSuccess) {
-      auto latencyMaybe =
-          curEvent_->stop->getElapsedTimeSinceEvent(curEvent_->start.get());
+      auto latencyMaybe = curEvent_->stop->getElapsedTimeSinceEvent(curEvent_->start.get());
       // latencyMaybe could be nullopt when cudaEventElapsedTime failed
       // this could happen when events are not recorded or stream is not valid
       if (latencyMaybe == nullptr) {
-        WARN(
-            "CollTrace: getElapsedTimeSinceEvent failed, aborting worker thread");
+        WARN("CollTrace: getElapsedTimeSinceEvent failed, aborting worker thread");
         return nullptr;
       }
       latency = *latencyMaybe;
@@ -107,11 +84,7 @@ void* CollTrace::collTraceThreadFn(int cudaDev) {
     curEvent_.reset();
   }
 
-  INFO(
-      NCCL_INIT,
-      "COLLTRACE: commHash %s rank %d - worker thread TERMINATE",
-      commHash_.c_str(),
-      rank_);
+  INFO(NCCL_INIT, "COLLTRACE: commHash %s rank %d - worker thread TERMINATE", commHash_.c_str(), rank_);
   return nullptr;
 }
 
@@ -120,8 +93,7 @@ void CollTrace::enqueueEvent(std::unique_ptr<CollTraceEvent> event) {
   eventQueue_.push(std::move(event));
 }
 
-std::unique_ptr<CollTraceEvent> CollTrace::createEvent(
-    CollTraceEvent::EventType type) {
+std::unique_ptr<CollTraceEvent> CollTrace::createEvent(CollTraceEvent::EventType type) {
   auto eventInfo = std::make_unique<CollTraceEvent>(type);
   eventInfo->start = std::make_unique<CudaWaitEvent>(getCudaEventPtr());
   eventInfo->stop = std::make_unique<CudaWaitEvent>(getCudaEventPtr());
@@ -140,22 +112,15 @@ bool shouldAggregateRingBuffer(int collId) {
 
 void CollTrace::reportIfNeeded(bool checkInterval = true) {
   auto now = std::chrono::steady_clock::now();
-  auto secs_passed =
-      std::chrono::duration_cast<std::chrono::seconds>(now - lastReportTime_)
-          .count();
+  auto secs_passed = std::chrono::duration_cast<std::chrono::seconds>(now - lastReportTime_).count();
   if (checkInterval) {
-    if (secs_passed < ncclParamColltraceDumpIntervalSec() &&
-        stats_.size() < ncclParamColltraceMaxDumpSize()) {
+    if (secs_passed < ncclParamColltraceDumpIntervalSec() && stats_.size() < ncclParamColltraceMaxDumpSize()) {
       return;
     }
   }
 
-  INFO(
-      NCCL_COLL,
-      "CollTrace: %ld seconds passed since last report, stats size = %zu, checkInterval = %d",
-      secs_passed,
-      stats_.size(),
-      checkInterval);
+  INFO(NCCL_COLL, "CollTrace: %ld seconds passed since last report, stats size = %zu, checkInterval = %d", secs_passed,
+       stats_.size(), checkInterval);
 
 // reportToScuba is a placeholder for oss environment.
 // meta production reports to scuba instead of file, which enables
@@ -189,17 +154,11 @@ void CollTrace::recordCurCollResult(int rank, float latency) {
       latencyAllGather[i] = pastColls_[i - start]->latencyMs;
     }
     auto before = std::chrono::high_resolution_clock::now();
-    auto ncclResult = bootstrapIntraNodeAllGather(
-        comm_->bootstrap,
-        comm_->localRankToRank,
-        comm_->localRank,
-        comm_->localRanks,
-        latencyAllGather.data(),
-        NCCL_COLLTRACE_RECORD_MAX * sizeof(float));
+    auto ncclResult =
+      bootstrapIntraNodeAllGather(comm_->bootstrap, comm_->localRankToRank, comm_->localRank, comm_->localRanks,
+                                  latencyAllGather.data(), NCCL_COLLTRACE_RECORD_MAX * sizeof(float));
     auto after = std::chrono::high_resolution_clock::now();
-    auto interval_us =
-        std::chrono::duration_cast<std::chrono::microseconds>(after - before)
-            .count();
+    auto interval_us = std::chrono::duration_cast<std::chrono::microseconds>(after - before).count();
     if (ncclResult != ncclSuccess) {
       WARN("CollTrace: All gather exchange latency data failed");
       return;
@@ -208,11 +167,7 @@ void CollTrace::recordCurCollResult(int rank, float latency) {
     if (rank == 0) {
       INFO(NCCL_COLL, "latency metrics all gather takes %ld us", interval_us);
       try {
-        auto stats = aggregateResults(
-            pastColls_,
-            latencyAllGather,
-            RANKS_PER_HOST,
-            NCCL_COLLTRACE_RECORD_MAX);
+        auto stats = aggregateResults(pastColls_, latencyAllGather, RANKS_PER_HOST, NCCL_COLLTRACE_RECORD_MAX);
         stats_.push_back(stats);
         if (stats_.size() > ncclParamColltraceMaxDumpSize()) {
           stats_.pop_front();

--- a/projects/rccl/src/misc/latency_profiler/CollTraceEvent.cc
+++ b/projects/rccl/src/misc/latency_profiler/CollTraceEvent.cc
@@ -20,18 +20,15 @@ ncclResult_t CudaWaitEvent::waitEventFinish() {
     if (res != cudaErrorNotReady) {
       CUDACHECK(res);
     }
-    std::this_thread::sleep_for(
-        std::chrono::milliseconds(ncclParamColltraceCheckIntervalMs()));
+    std::this_thread::sleep_for(std::chrono::milliseconds(ncclParamColltraceCheckIntervalMs()));
     res = cudaEventQuery(event_.get());
   }
   return ncclSuccess;
 }
 
-std::shared_ptr<float> CudaWaitEvent::getElapsedTimeSinceEvent(
-    CudaWaitEvent* start) {
+std::shared_ptr<float> CudaWaitEvent::getElapsedTimeSinceEvent(CudaWaitEvent* start) {
   float elapsedTime;
-  auto res =
-      cudaEventElapsedTime(&elapsedTime, start->event_.get(), event_.get());
+  auto res = cudaEventElapsedTime(&elapsedTime, start->event_.get(), event_.get());
   if (res != cudaSuccess) {
     WARN("get elapsed time failed error: %s", cudaGetErrorString(res));
     return nullptr;

--- a/projects/rccl/src/misc/latency_profiler/CollTraceFunc.cc
+++ b/projects/rccl/src/misc/latency_profiler/CollTraceFunc.cc
@@ -12,10 +12,7 @@ namespace {
 bool enableCollTrace() {
   const char* colltraceEnable = ncclGetEnv("RCCL_LATENCY_PROFILER");
   if (colltraceEnable != NULL) {
-    INFO(
-        NCCL_INIT,
-        "RCCL_LATENCY_PROFILER set by environment to %s.",
-        colltraceEnable);
+    INFO(NCCL_INIT, "RCCL_LATENCY_PROFILER set by environment to %s.", colltraceEnable);
     if (strcmp(colltraceEnable, "1") == 0) {
       return true;
     }
@@ -42,22 +39,15 @@ ncclResult_t collTraceDestroy(ncclComm* comm) {
   return ncclSuccess;
 }
 
-ncclResult_t collTraceRecordStartEvent(
-    ncclComm* comm,
-    cudaStream_t launchStream,
-    CollTraceEvent* event) {
+ncclResult_t collTraceRecordStartEvent(ncclComm* comm, cudaStream_t launchStream, CollTraceEvent* event) {
   if (comm->ctrace && event) {
-    CUDACHECK(
-        cudaEventRecord(event->start.get()->getCudaEvent(), launchStream));
+    CUDACHECK(cudaEventRecord(event->start.get()->getCudaEvent(), launchStream));
   }
   return ncclSuccess;
 }
 
-ncclResult_t collTraceRecordEndEvent(
-    ncclComm* comm,
-    ncclKernelPlan* plan,
-    cudaStream_t launchStream,
-    std::unique_ptr<CollTraceEvent> event) {
+ncclResult_t collTraceRecordEndEvent(ncclComm* comm, ncclKernelPlan* plan, cudaStream_t launchStream,
+                                     std::unique_ptr<CollTraceEvent> event) {
   if (comm->ctrace && event) {
     CUDACHECK(cudaEventRecord(event->stop.get()->getCudaEvent(), launchStream));
     comm->ctrace->enqueueEvent(std::move(event));
@@ -67,15 +57,13 @@ ncclResult_t collTraceRecordEndEvent(
 
 CollTraceInfo parseCollInfoFromCollTask(const ncclTaskColl& collTask) {
   return CollTraceInfo{
-      .opName = std::string{ncclFuncToString(collTask.func)},
-      .dataType = std::string{ncclDatatypeToString(collTask.datatype)},
-      .count = (int64_t)collTask.count,
+    .opName = std::string{ncclFuncToString(collTask.func)},
+    .dataType = std::string{ncclDatatypeToString(collTask.datatype)},
+    .count = (int64_t)collTask.count,
   };
 }
 
-std::shared_ptr<CollTraceInfo> parseCollInfoFromNcclKernelPlan(
-    ncclKernelPlan& plan,
-    cudaStream_t stream) {
+std::shared_ptr<CollTraceInfo> parseCollInfoFromNcclKernelPlan(ncclKernelPlan& plan, cudaStream_t stream) {
   if (plan.comm == nullptr || plan.comm->ctrace == nullptr) {
     return nullptr;
   }
@@ -89,10 +77,8 @@ std::shared_ptr<CollTraceInfo> parseCollInfoFromNcclKernelPlan(
   return std::make_shared<CollTraceInfo>(collInfo);
 }
 
-std::unique_ptr<CollTraceEvent> collTraceAquireEventCommon(
-    ncclComm* comm,
-    CollTraceEvent::EventType type,
-    cudaStream_t stream) {
+std::unique_ptr<CollTraceEvent> collTraceAquireEventCommon(ncclComm* comm, CollTraceEvent::EventType type,
+                                                           cudaStream_t stream) {
   if (!comm->ctrace) {
     return nullptr;
   }
@@ -104,9 +90,7 @@ std::unique_ptr<CollTraceEvent> collTraceAquireEventCommon(
   }
   if (graph.graph != nullptr) {
     // We are in a cuda graph, this is currently unsupported
-    WARN(
-        "COLLTRACE: does not support cuda graph. Collectives from comm %lx will be skipped",
-        comm->commHash);
+    WARN("COLLTRACE: does not support cuda graph. Collectives from comm %lx will be skipped", comm->commHash);
     return nullptr;
   }
   auto event = comm->ctrace->createEvent(type);
@@ -117,9 +101,7 @@ std::unique_ptr<CollTraceEvent> collTraceAquireEventCommon(
   return event;
 }
 
-std::unique_ptr<CollTraceEvent> collTraceAquireEventBaseline(
-    ncclKernelPlan* plan,
-    cudaStream_t stream) {
+std::unique_ptr<CollTraceEvent> collTraceAquireEventBaseline(ncclKernelPlan* plan, cudaStream_t stream) {
   auto collPtr = parseCollInfoFromNcclKernelPlan(*plan, stream);
   if (collPtr == nullptr) {
     return nullptr;
@@ -129,8 +111,7 @@ std::unique_ptr<CollTraceEvent> collTraceAquireEventBaseline(
     return nullptr;
   }
 
-  auto event =
-      collTraceAquireEventCommon(comm, CollTraceEvent::EventType::COMM, stream);
+  auto event = collTraceAquireEventCommon(comm, CollTraceEvent::EventType::COMM, stream);
   if (event == nullptr) {
     WARN("COLLTRACE: failed to aquire event");
     return nullptr;

--- a/projects/rccl/src/misc/latency_profiler/CollTraceUtils.cc
+++ b/projects/rccl/src/misc/latency_profiler/CollTraceUtils.cc
@@ -11,8 +11,7 @@
 namespace latency_profiler {
 
 float getSizeMb(const std::string& dataType, int count) {
-  if (dataType == "ncclInt8" || dataType == "ncclFp8E4M3" ||
-      dataType == "ncclFp8E5M2") {
+  if (dataType == "ncclInt8" || dataType == "ncclFp8E4M3" || dataType == "ncclFp8E5M2") {
     return count / 1024.0 / 1024.0;
   }
 
@@ -20,66 +19,54 @@ float getSizeMb(const std::string& dataType, int count) {
     return 2 * count / 1024.0 / 1024.0;
   }
 
-  if (dataType == "ncclInt32" || dataType == "ncclUint32" ||
-      dataType == "ncclFloat32") {
+  if (dataType == "ncclInt32" || dataType == "ncclUint32" || dataType == "ncclFloat32") {
     return 4 * count / 1024.0 / 1024.0;
   }
 
-  if (dataType == "ncclInt64" || dataType == "ncclUint64" ||
-      dataType == "ncclFloat64") {
+  if (dataType == "ncclInt64" || dataType == "ncclUint64" || dataType == "ncclFloat64") {
     return 8 * count / 1024.0 / 1024.0;
   }
 
   throw std::runtime_error("CollTrace: unsupported data type " + dataType);
 }
 
-void reportToFile(
-    const std::deque<std::vector<CollStats>>& stats,
-    const std::string& commHash) {
+void reportToFile(const std::deque<std::vector<CollStats>>& stats, const std::string& commHash) {
   for (const auto& oneDumpStats : stats) {
     for (const auto& elem : oneDumpStats) {
       auto size_mb = getSizeMb(elem.dataType, elem.count);
-      INFO(NCCL_COLL, "coll_id %d, percent %d, min_latency_us %f, max_latency_us %f, op_name %s, data_type %s, count %ld, message_size_MB %f, comm_hash %s", elem.collId, elem.percent, elem.minLatencyUs, elem.maxLatencyUs, elem.opName.c_str(), elem.dataType.c_str(), elem.count, size_mb, commHash.c_str());
+      INFO(NCCL_COLL,
+           "coll_id %d, percent %d, min_latency_us %f, max_latency_us %f, op_name %s, data_type %s, count %ld, "
+           "message_size_MB %f, comm_hash %s",
+           elem.collId, elem.percent, elem.minLatencyUs, elem.maxLatencyUs, elem.opName.c_str(), elem.dataType.c_str(),
+           elem.count, size_mb, commHash.c_str());
     }
   }
 }
 
-std::vector<CollStats> aggregateResults(
-    const std::deque<std::unique_ptr<CollTraceInfo>>& info,
-    const std::vector<float>& latencyAllGather,
-    int RANKS_PER_HOST,
-    int NCCL_COLLTRACE_RECORD_MAX) {
+std::vector<CollStats> aggregateResults(const std::deque<std::unique_ptr<CollTraceInfo>>& info,
+                                        const std::vector<float>& latencyAllGather, int RANKS_PER_HOST,
+                                        int NCCL_COLLTRACE_RECORD_MAX) {
   std::vector<std::pair<float, float>> latencyMetrics;
   for (auto rank = 0; rank < RANKS_PER_HOST; rank++) {
     for (auto i = 0; i < NCCL_COLLTRACE_RECORD_MAX; i++) {
       auto val = latencyAllGather.at(rank * NCCL_COLLTRACE_RECORD_MAX + i);
       if (val == 0) {
-        throw std::runtime_error(
-            "CollTrace: latency value cannot be zero, CPU all gather failed");
+        throw std::runtime_error("CollTrace: latency value cannot be zero, CPU all gather failed");
       }
       if (rank == 0) {
         latencyMetrics.emplace_back(val, val);
       } else {
-        latencyMetrics.at(i).first =
-            std::min<float>(latencyMetrics.at(i).first, val);
-        latencyMetrics.at(i).second =
-            std::max<float>(latencyMetrics.at(i).second, val);
+        latencyMetrics.at(i).first = std::min<float>(latencyMetrics.at(i).first, val);
+        latencyMetrics.at(i).second = std::max<float>(latencyMetrics.at(i).second, val);
       }
     }
   }
   std::vector<CollStats> results;
   for (int i = 0; i < info.size(); i++) {
-    int percent = 100 *
-        (latencyMetrics.at(i).second - latencyMetrics.at(i).first) /
-        latencyMetrics.at(i).first;
-    results.emplace_back(CollStats(
-        (int)info[i]->collId,
-        percent,
-        latencyMetrics.at(i).first * 1000,
-        latencyMetrics.at(i).second * 1000,
-        info[i]->opName,
-        info[i]->dataType,
-        info[i]->count));
+    int percent = 100 * (latencyMetrics.at(i).second - latencyMetrics.at(i).first) / latencyMetrics.at(i).first;
+    results.emplace_back(CollStats((int)info[i]->collId, percent, latencyMetrics.at(i).first * 1000,
+                                   latencyMetrics.at(i).second * 1000, info[i]->opName, info[i]->dataType,
+                                   info[i]->count));
   }
   return results;
 }

--- a/projects/rccl/src/misc/mlx5dvsymbols.cc
+++ b/projects/rccl/src/misc/mlx5dvsymbols.cc
@@ -13,7 +13,7 @@
 #ifdef NCCL_BUILD_MLX5DV
 /* Mlx5dv linking mode. Symbols are pointers to linked MLX5 Direct Verbs */
 
-#define ASSIGN_SYM(container, symbol, name) container->name= &symbol;
+#define ASSIGN_SYM(container, symbol, name) container->name = &symbol;
 
 ncclResult_t buildMlx5dvSymbols(struct ncclMlx5dvSymbols* mlx5dvSymbols) {
   ASSIGN_SYM(mlx5dvSymbols, mlx5dv_is_supported, mlx5dv_internal_is_supported);
@@ -38,37 +38,40 @@ ncclResult_t buildMlx5dvSymbols(struct ncclMlx5dvSymbols* mlx5dvSymbols) {
   void* tmp;
   void** cast;
 
-  mlx5dvhandle=dlopen("libmlx5.so", RTLD_NOW);
+  mlx5dvhandle = dlopen("libmlx5.so", RTLD_NOW);
   if (!mlx5dvhandle) {
-    mlx5dvhandle=dlopen("libmlx5.so.1", RTLD_NOW);
+    mlx5dvhandle = dlopen("libmlx5.so.1", RTLD_NOW);
     if (!mlx5dvhandle) {
       INFO(NCCL_INIT, "Failed to open libmlx5.so[.1]");
       goto teardown;
     }
   }
 
-#define LOAD_SYM(handle, symbol, funcptr) do {           \
-    cast = (void**)&funcptr;                             \
-    tmp = dlvsym(handle, symbol, MLX5DV_VERSION);       \
-    if (tmp == NULL) {                                   \
-      WARN("dlvsym failed on %s - %s version %s", symbol, dlerror(), MLX5DV_VERSION);  \
-      goto teardown;                                     \
-    }                                                    \
-    *cast = tmp;                                         \
+#define LOAD_SYM(handle, symbol, funcptr) \
+  do { \
+    cast = (void**)&funcptr; \
+    tmp = dlvsym(handle, symbol, MLX5DV_VERSION); \
+    if (tmp == NULL) { \
+      WARN("dlvsym failed on %s - %s version %s", symbol, dlerror(), MLX5DV_VERSION); \
+      goto teardown; \
+    } \
+    *cast = tmp; \
   } while (0)
 
 // Attempt to load a specific symbol version - fail silently
-#define LOAD_SYM_VERSION(handle, symbol, funcptr, version) do {  \
-    cast = (void**)&funcptr;                                     \
-    *cast = dlvsym(handle, symbol, version);                     \
-    if (*cast == NULL) {                                         \
-      INFO(NCCL_NET, "dlvsym failed on %s - %s version %s", symbol, dlerror(), version);  \
-    }                                                            \
+#define LOAD_SYM_VERSION(handle, symbol, funcptr, version) \
+  do { \
+    cast = (void**)&funcptr; \
+    *cast = dlvsym(handle, symbol, version); \
+    if (*cast == NULL) { \
+      INFO(NCCL_NET, "dlvsym failed on %s - %s version %s", symbol, dlerror(), version); \
+    } \
   } while (0)
 
   LOAD_SYM(mlx5dvhandle, "mlx5dv_is_supported", mlx5dvSymbols->mlx5dv_internal_is_supported);
   // Cherry-pick the mlx5dv_get_data_direct_sysfs_path API from MLX5 1.25
-  LOAD_SYM_VERSION(mlx5dvhandle, "mlx5dv_get_data_direct_sysfs_path", mlx5dvSymbols->mlx5dv_internal_get_data_direct_sysfs_path, "MLX5_1.25");
+  LOAD_SYM_VERSION(mlx5dvhandle, "mlx5dv_get_data_direct_sysfs_path",
+                   mlx5dvSymbols->mlx5dv_internal_get_data_direct_sysfs_path, "MLX5_1.25");
   // Cherry-pick the ibv_reg_dmabuf_mr API from MLX5 1.25
   LOAD_SYM_VERSION(mlx5dvhandle, "mlx5dv_reg_dmabuf_mr", mlx5dvSymbols->mlx5dv_internal_reg_dmabuf_mr, "MLX5_1.25");
   // mlx5dv_query_device is versioned at MLX5_1.0

--- a/projects/rccl/src/misc/mlx5dvwrap.cc
+++ b/projects/rccl/src/misc/mlx5dvwrap.cc
@@ -22,16 +22,15 @@ static ncclResult_t initResult;
 struct ncclMlx5dvSymbols mlx5dvSymbols;
 
 ncclResult_t wrap_mlx5dv_symbols(void) {
-  std::call_once(initOnceFlag,
-               [](){ initResult = buildMlx5dvSymbols(&mlx5dvSymbols); });
+  std::call_once(initOnceFlag, []() { initResult = buildMlx5dvSymbols(&mlx5dvSymbols); });
   return initResult;
 }
 
 /* CHECK_NOT_NULL: helper macro to check for NULL symbol */
 #define CHECK_NOT_NULL(container, internal_name) \
   if (container.internal_name == NULL) { \
-     WARN("NET/MLX5: lib wrapper not initialized."); \
-     return ncclInternalError; \
+    WARN("NET/MLX5: lib wrapper not initialized."); \
+    return ncclInternalError; \
   }
 
 #define MLX5DV_PTR_CHECK_ERRNO(container, internal_name, call, retval, error_retval, name) \
@@ -52,7 +51,7 @@ ncclResult_t wrap_mlx5dv_symbols(void) {
   } \
   return ncclSuccess;
 
-bool wrap_mlx5dv_is_supported(struct ibv_device *device) {
+bool wrap_mlx5dv_is_supported(struct ibv_device* device) {
   if (mlx5dvSymbols.mlx5dv_internal_is_supported == NULL) {
     return 0;
   }
@@ -65,16 +64,21 @@ ncclResult_t wrap_mlx5dv_get_data_direct_sysfs_path(struct ibv_context* context,
   if (ret == 0) return ncclSuccess;
   /* ENODEV can happen if the devices is not data-direct but mlx5 is used. It's not an error*/
   if (ret == ENODEV) return ncclInvalidArgument;
-  INFO(NCCL_NET, "NET/MLX5: Call to mlx5dv_internal_get_data_direct_sysfs_path failed with error %s errno %d", strerror(ret), ret);
+  INFO(NCCL_NET, "NET/MLX5: Call to mlx5dv_internal_get_data_direct_sysfs_path failed with error %s errno %d",
+       strerror(ret), ret);
   return ncclSystemError;
 }
 
 /* DMA-BUF support */
-ncclResult_t wrap_mlx5dv_reg_dmabuf_mr(struct ibv_mr **ret, struct ibv_pd *pd, uint64_t offset, size_t length, uint64_t iova, int fd, int access, int mlx5_access) {
-  MLX5DV_PTR_CHECK_ERRNO(mlx5dvSymbols, mlx5dv_internal_reg_dmabuf_mr, mlx5dv_internal_reg_dmabuf_mr(pd, offset, length, iova, fd, access, mlx5_access), *ret, NULL, "mlx5dv_reg_dmabuf_mr");
+ncclResult_t wrap_mlx5dv_reg_dmabuf_mr(struct ibv_mr** ret, struct ibv_pd* pd, uint64_t offset, size_t length,
+                                       uint64_t iova, int fd, int access, int mlx5_access) {
+  MLX5DV_PTR_CHECK_ERRNO(mlx5dvSymbols, mlx5dv_internal_reg_dmabuf_mr,
+                         mlx5dv_internal_reg_dmabuf_mr(pd, offset, length, iova, fd, access, mlx5_access), *ret, NULL,
+                         "mlx5dv_reg_dmabuf_mr");
 }
 
-struct ibv_mr * wrap_direct_mlx5dv_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset, size_t length, uint64_t iova, int fd, int access, int mlx5_access) {
+struct ibv_mr* wrap_direct_mlx5dv_reg_dmabuf_mr(struct ibv_pd* pd, uint64_t offset, size_t length, uint64_t iova,
+                                                int fd, int access, int mlx5_access) {
   if (mlx5dvSymbols.mlx5dv_internal_reg_dmabuf_mr == NULL) {
     errno = EOPNOTSUPP; // ncclIbDmaBufSupport() requires this errno being set
     return NULL;
@@ -82,11 +86,13 @@ struct ibv_mr * wrap_direct_mlx5dv_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t off
   return mlx5dvSymbols.mlx5dv_internal_reg_dmabuf_mr(pd, offset, length, iova, fd, access, mlx5_access);
 }
 
-ncclResult_t wrap_mlx5dv_query_device(struct ibv_context *ctx_in, struct mlx5dv_context *attrs_out) {
-  MLX5DV_INT_CHECK_RET_ERRNO(mlx5dvSymbols, mlx5dv_internal_query_device, mlx5dv_internal_query_device(ctx_in, attrs_out), 0, "mlx5dv_query_device");
+ncclResult_t wrap_mlx5dv_query_device(struct ibv_context* ctx_in, struct mlx5dv_context* attrs_out) {
+  MLX5DV_INT_CHECK_RET_ERRNO(mlx5dvSymbols, mlx5dv_internal_query_device,
+                             mlx5dv_internal_query_device(ctx_in, attrs_out), 0, "mlx5dv_query_device");
 }
 
-struct ibv_qp *wrap_mlx5dv_create_qp(struct ibv_context *context, struct ibv_qp_init_attr_ex *qp_attr, struct mlx5dv_qp_init_attr *mlx5_qp_attr) {
+struct ibv_qp* wrap_mlx5dv_create_qp(struct ibv_context* context, struct ibv_qp_init_attr_ex* qp_attr,
+                                     struct mlx5dv_qp_init_attr* mlx5_qp_attr) {
   if (mlx5dvSymbols.mlx5dv_internal_create_qp == NULL) {
     return 0;
   }

--- a/projects/rccl/src/misc/nvmlwrap.cc
+++ b/projects/rccl/src/misc/nvmlwrap.cc
@@ -19,44 +19,49 @@ ncclNvmlDeviceInfo ncclNvmlDevices[ncclNvmlMaxDevices];
 ncclNvmlDevicePairInfo ncclNvmlDevicePairs[ncclNvmlMaxDevices][ncclNvmlMaxDevices];
 
 #if NCCL_NVML_DIRECT
-  #define NCCL_NVML_FN(name, rettype, arglist) constexpr rettype(*pfn_##name)arglist = name;
+#define NCCL_NVML_FN(name, rettype, arglist) constexpr rettype(*pfn_##name) arglist = name;
 #else
-  #define NCCL_NVML_FN(name, rettype, arglist) rettype(*pfn_##name)arglist = nullptr;
+#define NCCL_NVML_FN(name, rettype, arglist) rettype(*pfn_##name) arglist = nullptr;
 #endif
 
 namespace {
-  NCCL_NVML_FN(nvmlInit, nvmlReturn_t, ())
-  NCCL_NVML_FN(nvmlInit_v2, nvmlReturn_t, ())
-  NCCL_NVML_FN(nvmlShutdown, nvmlReturn_t, ())
-  NCCL_NVML_FN(nvmlDeviceGetCount, nvmlReturn_t, (unsigned int*))
-  NCCL_NVML_FN(nvmlDeviceGetCount_v2, nvmlReturn_t, (unsigned int*))
-  NCCL_NVML_FN(nvmlDeviceGetHandleByPciBusId, nvmlReturn_t, (const char* pciBusId, nvmlDevice_t* device))
-  NCCL_NVML_FN(nvmlDeviceGetHandleByIndex, nvmlReturn_t, (unsigned int index, nvmlDevice_t *device))
-  NCCL_NVML_FN(nvmlDeviceGetIndex, nvmlReturn_t, (nvmlDevice_t device, unsigned* index))
-  NCCL_NVML_FN(nvmlErrorString, char const*, (nvmlReturn_t r))
-  NCCL_NVML_FN(nvmlDeviceGetNvLinkState, nvmlReturn_t, (nvmlDevice_t device, unsigned int link, nvmlEnableState_t *isActive))
-  NCCL_NVML_FN(nvmlDeviceGetNvLinkRemotePciInfo, nvmlReturn_t, (nvmlDevice_t device, unsigned int link, nvmlPciInfo_t *pci))
-  NCCL_NVML_FN(nvmlDeviceGetNvLinkCapability, nvmlReturn_t, (nvmlDevice_t device, unsigned int link, nvmlNvLinkCapability_t capability, unsigned int *capResult))
-  NCCL_NVML_FN(nvmlDeviceGetCudaComputeCapability, nvmlReturn_t, (nvmlDevice_t device, int* major, int* minor))
-  NCCL_NVML_FN(nvmlDeviceGetP2PStatus, nvmlReturn_t, (nvmlDevice_t device1, nvmlDevice_t device2, nvmlGpuP2PCapsIndex_t p2pIndex, nvmlGpuP2PStatus_t* p2pStatus))
-  NCCL_NVML_FN(nvmlDeviceGetFieldValues, nvmlReturn_t, (nvmlDevice_t device, int valuesCount, nvmlFieldValue_t *values))
+NCCL_NVML_FN(nvmlInit, nvmlReturn_t, ())
+NCCL_NVML_FN(nvmlInit_v2, nvmlReturn_t, ())
+NCCL_NVML_FN(nvmlShutdown, nvmlReturn_t, ())
+NCCL_NVML_FN(nvmlDeviceGetCount, nvmlReturn_t, (unsigned int*))
+NCCL_NVML_FN(nvmlDeviceGetCount_v2, nvmlReturn_t, (unsigned int*))
+NCCL_NVML_FN(nvmlDeviceGetHandleByPciBusId, nvmlReturn_t, (const char* pciBusId, nvmlDevice_t* device))
+NCCL_NVML_FN(nvmlDeviceGetHandleByIndex, nvmlReturn_t, (unsigned int index, nvmlDevice_t* device))
+NCCL_NVML_FN(nvmlDeviceGetIndex, nvmlReturn_t, (nvmlDevice_t device, unsigned* index))
+NCCL_NVML_FN(nvmlErrorString, char const*, (nvmlReturn_t r))
+NCCL_NVML_FN(nvmlDeviceGetNvLinkState, nvmlReturn_t,
+             (nvmlDevice_t device, unsigned int link, nvmlEnableState_t* isActive))
+NCCL_NVML_FN(nvmlDeviceGetNvLinkRemotePciInfo, nvmlReturn_t,
+             (nvmlDevice_t device, unsigned int link, nvmlPciInfo_t* pci))
+NCCL_NVML_FN(nvmlDeviceGetNvLinkCapability, nvmlReturn_t,
+             (nvmlDevice_t device, unsigned int link, nvmlNvLinkCapability_t capability, unsigned int* capResult))
+NCCL_NVML_FN(nvmlDeviceGetCudaComputeCapability, nvmlReturn_t, (nvmlDevice_t device, int* major, int* minor))
+NCCL_NVML_FN(nvmlDeviceGetP2PStatus, nvmlReturn_t,
+             (nvmlDevice_t device1, nvmlDevice_t device2, nvmlGpuP2PCapsIndex_t p2pIndex,
+              nvmlGpuP2PStatus_t* p2pStatus))
+NCCL_NVML_FN(nvmlDeviceGetFieldValues, nvmlReturn_t, (nvmlDevice_t device, int valuesCount, nvmlFieldValue_t* values))
   // MNNVL support
-  NCCL_NVML_FN(nvmlDeviceGetGpuFabricInfoV, nvmlReturn_t, (nvmlDevice_t device, nvmlGpuFabricInfoV_t *gpuFabricInfo))
-  NCCL_NVML_FN(nvmlDeviceGetPlatformInfo, nvmlReturn_t, (nvmlDevice_t device, nvmlPlatformInfo_t *platfromInfo))
+NCCL_NVML_FN(nvmlDeviceGetGpuFabricInfoV, nvmlReturn_t, (nvmlDevice_t device, nvmlGpuFabricInfoV_t* gpuFabricInfo))
+NCCL_NVML_FN(nvmlDeviceGetPlatformInfo, nvmlReturn_t, (nvmlDevice_t device, nvmlPlatformInfo_t* platfromInfo))
   // CC support
-  NCCL_NVML_FN(nvmlSystemGetConfComputeState, nvmlReturn_t, (nvmlConfComputeSystemState_t *state));
-  NCCL_NVML_FN(nvmlSystemGetConfComputeSettings, nvmlReturn_t, (nvmlSystemConfComputeSettings_t *setting));
+NCCL_NVML_FN(nvmlSystemGetConfComputeState, nvmlReturn_t, (nvmlConfComputeSystemState_t* state));
+NCCL_NVML_FN(nvmlSystemGetConfComputeSettings, nvmlReturn_t, (nvmlSystemConfComputeSettings_t* setting));
 
-  std::mutex lock; // NVML has had some thread safety bugs
-  bool initialized = false;
-  thread_local bool threadInitialized = false;
-  ncclResult_t initResult;
+std::mutex lock; // NVML has had some thread safety bugs
+bool initialized = false;
+thread_local bool threadInitialized = false;
+ncclResult_t initResult;
 
-  union nvmlCCInfoInternal {
-    nvmlConfComputeSystemState_t settingV12020;
-    nvmlSystemConfComputeSettings_t settingV12040;
-  };
-}
+union nvmlCCInfoInternal {
+  nvmlConfComputeSystemState_t settingV12020;
+  nvmlSystemConfComputeSettings_t settingV12040;
+};
+} // namespace
 
 ncclResult_t ncclNvmlEnsureInitialized() {
   // Optimization to avoid repeatedly grabbing the lock when we only want to
@@ -69,7 +74,7 @@ ncclResult_t ncclNvmlEnsureInitialized() {
   if (initialized) return initResult;
   initialized = true;
 
-  #if !NCCL_NVML_DIRECT
+#if !NCCL_NVML_DIRECT
   if (pfn_nvmlInit == nullptr) {
     ncclOsLibraryHandle libhandle;
     ncclResult_t openRes = ncclOsNvmlOpen(&libhandle);
@@ -78,7 +83,10 @@ ncclResult_t ncclNvmlEnsureInitialized() {
       return initResult;
     }
 
-    struct Symbol { void **ppfn; char const *name; };
+    struct Symbol {
+      void** ppfn;
+      char const* name;
+    };
     std::initializer_list<Symbol> symbols = {
       {(void**)&pfn_nvmlInit, "nvmlInit"},
       {(void**)&pfn_nvmlInit_v2, "nvmlInit_v2"},
@@ -111,13 +119,15 @@ ncclResult_t ncclNvmlEnsureInitialized() {
     // the process terminates, so that we can use its code.
     // coverity[leaked_storage]
   }
-  #endif
+#endif
 
-  #if NCCL_NVML_DIRECT
-    bool have_v2 = true;
-  #else
-    bool have_v2 = pfn_nvmlInit_v2 != nullptr; // if this compare is done in the NCCL_NVML_DIRECT=1 case then GCC warns about it never being null
-  #endif
+#if NCCL_NVML_DIRECT
+  bool have_v2 = true;
+#else
+  bool have_v2 =
+    pfn_nvmlInit_v2 !=
+    nullptr; // if this compare is done in the NCCL_NVML_DIRECT=1 case then GCC warns about it never being null
+#endif
   nvmlReturn_t res1 = (have_v2 ? pfn_nvmlInit_v2 : pfn_nvmlInit)();
   if (res1 != NVML_SUCCESS) {
     WARN("nvmlInit%s() failed: %s", have_v2 ? "_v2" : "", pfn_nvmlErrorString(res1));
@@ -128,19 +138,20 @@ ncclResult_t ncclNvmlEnsureInitialized() {
   unsigned int ndev;
   res1 = (have_v2 ? pfn_nvmlDeviceGetCount_v2 : pfn_nvmlDeviceGetCount)(&ndev);
   if (res1 != NVML_SUCCESS) {
-    WARN("nvmlDeviceGetCount%s() failed: %s", have_v2 ? "_v2" :"", pfn_nvmlErrorString(res1));
+    WARN("nvmlDeviceGetCount%s() failed: %s", have_v2 ? "_v2" : "", pfn_nvmlErrorString(res1));
     initResult = ncclSystemError;
     return initResult;
   }
 
   ncclNvmlDeviceCount = int(ndev);
   if (ncclNvmlMaxDevices < ncclNvmlDeviceCount) {
-    WARN("nvmlDeviceGetCount() reported more devices (%d) than the internal maximum (ncclNvmlMaxDevices=%d)", ncclNvmlDeviceCount, ncclNvmlMaxDevices);
+    WARN("nvmlDeviceGetCount() reported more devices (%d) than the internal maximum (ncclNvmlMaxDevices=%d)",
+         ncclNvmlDeviceCount, ncclNvmlMaxDevices);
     initResult = ncclInternalError;
     return initResult;
   }
 
-  for(int a=0; a < ncclNvmlDeviceCount; a++) {
+  for (int a = 0; a < ncclNvmlDeviceCount; a++) {
     res1 = pfn_nvmlDeviceGetHandleByIndex(a, &ncclNvmlDevices[a].handle);
     if (res1 != NVML_SUCCESS) {
       WARN("nvmlDeviceGetHandleByIndex(%d) failed: %s", int(a), pfn_nvmlErrorString(res1));
@@ -148,7 +159,8 @@ ncclResult_t ncclNvmlEnsureInitialized() {
       return initResult;
     }
 
-    res1 = pfn_nvmlDeviceGetCudaComputeCapability(ncclNvmlDevices[a].handle, &ncclNvmlDevices[a].computeCapabilityMajor, &ncclNvmlDevices[a].computeCapabilityMinor);
+    res1 = pfn_nvmlDeviceGetCudaComputeCapability(ncclNvmlDevices[a].handle, &ncclNvmlDevices[a].computeCapabilityMajor,
+                                                  &ncclNvmlDevices[a].computeCapabilityMinor);
     if (res1 != NVML_SUCCESS) {
       WARN("nvmlDeviceGetCudaComputeCapability(%d) failed: %s", int(a), pfn_nvmlErrorString(res1));
       initResult = ncclSystemError;
@@ -156,8 +168,8 @@ ncclResult_t ncclNvmlEnsureInitialized() {
     }
   }
 
-  for(int a=0; a < ncclNvmlDeviceCount; a++) {
-    for(int b=0; b < ncclNvmlDeviceCount; b++) {
+  for (int a = 0; a < ncclNvmlDeviceCount; a++) {
+    for (int b = 0; b < ncclNvmlDeviceCount; b++) {
       nvmlDevice_t da = ncclNvmlDevices[a].handle;
       nvmlDevice_t db = ncclNvmlDevices[b].handle;
 
@@ -181,24 +193,26 @@ ncclResult_t ncclNvmlEnsureInitialized() {
   return initResult;
 }
 
-#define NVMLCHECK(name, ...) do { \
-  nvmlReturn_t e44241808 = pfn_##name(__VA_ARGS__); \
-  if (e44241808 != NVML_SUCCESS) { \
-    WARN(#name "() failed: %s", pfn_nvmlErrorString(e44241808)); \
-    return ncclSystemError; \
-  } \
-} while(0)
+#define NVMLCHECK(name, ...) \
+  do { \
+    nvmlReturn_t e44241808 = pfn_##name(__VA_ARGS__); \
+    if (e44241808 != NVML_SUCCESS) { \
+      WARN(#name "() failed: %s", pfn_nvmlErrorString(e44241808)); \
+      return ncclSystemError; \
+    } \
+  } while (0)
 
-#define NVMLTRY(name, ...) do { \
-  if (!NCCL_NVML_DIRECT && pfn_##name == nullptr) \
-    return ncclInternalError; /* missing symbol is not a warned error */ \
-  nvmlReturn_t e44241808 = pfn_##name(__VA_ARGS__); \
-  if (e44241808 != NVML_SUCCESS) { \
-    if (e44241808 != NVML_ERROR_NOT_SUPPORTED) \
-      INFO(NCCL_INIT, #name "() failed: %s", pfn_nvmlErrorString(e44241808)); \
-    return ncclSystemError; \
-  } \
-} while(0)
+#define NVMLTRY(name, ...) \
+  do { \
+    if (!NCCL_NVML_DIRECT && pfn_##name == nullptr) \
+      return ncclInternalError; /* missing symbol is not a warned error */ \
+    nvmlReturn_t e44241808 = pfn_##name(__VA_ARGS__); \
+    if (e44241808 != NVML_SUCCESS) { \
+      if (e44241808 != NVML_ERROR_NOT_SUPPORTED) \
+        INFO(NCCL_INIT, #name "() failed: %s", pfn_nvmlErrorString(e44241808)); \
+      return ncclSystemError; \
+    } \
+  } while (0)
 
 ncclResult_t ncclNvmlDeviceGetHandleByPciBusId(const char* pciBusId, nvmlDevice_t* device) {
   NCCLCHECK(ncclNvmlEnsureInitialized());
@@ -207,7 +221,7 @@ ncclResult_t ncclNvmlDeviceGetHandleByPciBusId(const char* pciBusId, nvmlDevice_
   return ncclSuccess;
 }
 
-ncclResult_t ncclNvmlDeviceGetHandleByIndex(unsigned int index, nvmlDevice_t *device) {
+ncclResult_t ncclNvmlDeviceGetHandleByIndex(unsigned int index, nvmlDevice_t* device) {
   NCCLCHECK(ncclNvmlEnsureInitialized());
   *device = ncclNvmlDevices[index].handle;
   return ncclSuccess;
@@ -215,7 +229,7 @@ ncclResult_t ncclNvmlDeviceGetHandleByIndex(unsigned int index, nvmlDevice_t *de
 
 ncclResult_t ncclNvmlDeviceGetIndex(nvmlDevice_t device, unsigned* index) {
   NCCLCHECK(ncclNvmlEnsureInitialized());
-  for (int d=0; d < ncclNvmlDeviceCount; d++) {
+  for (int d = 0; d < ncclNvmlDeviceCount; d++) {
     if (ncclNvmlDevices[d].handle == device) {
       *index = d;
       return ncclSuccess;
@@ -224,24 +238,22 @@ ncclResult_t ncclNvmlDeviceGetIndex(nvmlDevice_t device, unsigned* index) {
   return ncclInvalidArgument;
 }
 
-ncclResult_t ncclNvmlDeviceGetNvLinkState(nvmlDevice_t device, unsigned int link, nvmlEnableState_t *isActive) {
+ncclResult_t ncclNvmlDeviceGetNvLinkState(nvmlDevice_t device, unsigned int link, nvmlEnableState_t* isActive) {
   NCCLCHECK(ncclNvmlEnsureInitialized());
   std::lock_guard<std::mutex> locked(lock);
   NVMLTRY(nvmlDeviceGetNvLinkState, device, link, isActive);
   return ncclSuccess;
 }
 
-ncclResult_t ncclNvmlDeviceGetNvLinkRemotePciInfo(nvmlDevice_t device, unsigned int link, nvmlPciInfo_t *pci) {
+ncclResult_t ncclNvmlDeviceGetNvLinkRemotePciInfo(nvmlDevice_t device, unsigned int link, nvmlPciInfo_t* pci) {
   NCCLCHECK(ncclNvmlEnsureInitialized());
   std::lock_guard<std::mutex> locked(lock);
   NVMLTRY(nvmlDeviceGetNvLinkRemotePciInfo, device, link, pci);
   return ncclSuccess;
 }
 
-ncclResult_t ncclNvmlDeviceGetNvLinkCapability(
-    nvmlDevice_t device, unsigned int link, nvmlNvLinkCapability_t capability,
-    unsigned int *capResult
-  ) {
+ncclResult_t ncclNvmlDeviceGetNvLinkCapability(nvmlDevice_t device, unsigned int link,
+                                               nvmlNvLinkCapability_t capability, unsigned int* capResult) {
   NCCLCHECK(ncclNvmlEnsureInitialized());
   std::lock_guard<std::mutex> locked(lock);
   NVMLTRY(nvmlDeviceGetNvLinkCapability, device, link, capability, capResult);
@@ -251,8 +263,8 @@ ncclResult_t ncclNvmlDeviceGetNvLinkCapability(
 ncclResult_t ncclNvmlDeviceGetCudaComputeCapability(nvmlDevice_t device, int* major, int* minor) {
   NCCLCHECK(ncclNvmlEnsureInitialized());
 
-  for(int d=0; d < ncclNvmlDeviceCount; d++) {
-    if(device == ncclNvmlDevices[d].handle) {
+  for (int d = 0; d < ncclNvmlDeviceCount; d++) {
+    if (device == ncclNvmlDevices[d].handle) {
       *major = ncclNvmlDevices[d].computeCapabilityMajor;
       *minor = ncclNvmlDevices[d].computeCapabilityMinor;
       return ncclSuccess;
@@ -261,32 +273,27 @@ ncclResult_t ncclNvmlDeviceGetCudaComputeCapability(nvmlDevice_t device, int* ma
   return ncclInvalidArgument;
 }
 
-ncclResult_t ncclNvmlDeviceGetP2PStatus(
-    nvmlDevice_t device1, nvmlDevice_t device2, nvmlGpuP2PCapsIndex_t p2pIndex,
-    nvmlGpuP2PStatus_t* p2pStatus
-  ) {
+ncclResult_t ncclNvmlDeviceGetP2PStatus(nvmlDevice_t device1, nvmlDevice_t device2, nvmlGpuP2PCapsIndex_t p2pIndex,
+                                        nvmlGpuP2PStatus_t* p2pStatus) {
   NCCLCHECK(ncclNvmlEnsureInitialized());
 
   if (p2pIndex == NVML_P2P_CAPS_INDEX_READ || p2pIndex == NVML_P2P_CAPS_INDEX_WRITE) {
     int a = -1, b = -1;
-    for(int d=0; d < ncclNvmlDeviceCount; d++) {
-      if(device1 == ncclNvmlDevices[d].handle) a = d;
-      if(device2 == ncclNvmlDevices[d].handle) b = d;
+    for (int d = 0; d < ncclNvmlDeviceCount; d++) {
+      if (device1 == ncclNvmlDevices[d].handle) a = d;
+      if (device2 == ncclNvmlDevices[d].handle) b = d;
     }
     if (a == -1 || b == -1) return ncclInvalidArgument;
-    if (p2pIndex == NVML_P2P_CAPS_INDEX_READ)
-      *p2pStatus = ncclNvmlDevicePairs[a][b].p2pStatusRead;
-    else
-      *p2pStatus = ncclNvmlDevicePairs[a][b].p2pStatusWrite;
-  }
-  else {
+    if (p2pIndex == NVML_P2P_CAPS_INDEX_READ) *p2pStatus = ncclNvmlDevicePairs[a][b].p2pStatusRead;
+    else *p2pStatus = ncclNvmlDevicePairs[a][b].p2pStatusWrite;
+  } else {
     std::lock_guard<std::mutex> locked(lock);
     NVMLCHECK(nvmlDeviceGetP2PStatus, device1, device2, p2pIndex, p2pStatus);
   }
   return ncclSuccess;
 }
 
-ncclResult_t ncclNvmlDeviceGetFieldValues(nvmlDevice_t device, int valuesCount, nvmlFieldValue_t *values) {
+ncclResult_t ncclNvmlDeviceGetFieldValues(nvmlDevice_t device, int valuesCount, nvmlFieldValue_t* values) {
   NCCLCHECK(ncclNvmlEnsureInitialized());
   std::lock_guard<std::mutex> locked(lock);
   NVMLTRY(nvmlDeviceGetFieldValues, device, valuesCount, values);
@@ -294,7 +301,7 @@ ncclResult_t ncclNvmlDeviceGetFieldValues(nvmlDevice_t device, int valuesCount, 
 }
 
 // MNNVL support
-ncclResult_t ncclNvmlDeviceGetGpuFabricInfoV(nvmlDevice_t device, nvmlGpuFabricInfoV_t *gpuFabricInfo) {
+ncclResult_t ncclNvmlDeviceGetGpuFabricInfoV(nvmlDevice_t device, nvmlGpuFabricInfoV_t* gpuFabricInfo) {
   NCCLCHECK(ncclNvmlEnsureInitialized());
   std::lock_guard<std::mutex> locked(lock);
   gpuFabricInfo->version = nvmlGpuFabricInfo_v2;
@@ -302,7 +309,7 @@ ncclResult_t ncclNvmlDeviceGetGpuFabricInfoV(nvmlDevice_t device, nvmlGpuFabricI
   return ncclSuccess;
 }
 
-ncclResult_t ncclNvmlDeviceGetPlatformInfo(nvmlDevice_t device, nvmlPlatformInfo_t *platformInfo) {
+ncclResult_t ncclNvmlDeviceGetPlatformInfo(nvmlDevice_t device, nvmlPlatformInfo_t* platformInfo) {
   NCCLCHECK(ncclNvmlEnsureInitialized());
   std::lock_guard<std::mutex> locked(lock);
   platformInfo->version = nvmlPlatformInfo_v2;
@@ -310,33 +317,25 @@ ncclResult_t ncclNvmlDeviceGetPlatformInfo(nvmlDevice_t device, nvmlPlatformInfo
   return ncclSuccess;
 }
 
-
-ncclResult_t ncclNvmlGetCCStatus(struct ncclNvmlCCStatus *status) {
+ncclResult_t ncclNvmlGetCCStatus(struct ncclNvmlCCStatus* status) {
   NCCLCHECK(ncclNvmlEnsureInitialized());
   std::lock_guard<std::mutex> locked(lock);
   nvmlCCInfoInternal ccInfo;
   if (pfn_nvmlSystemGetConfComputeSettings != NULL) {
     ccInfo.settingV12040.version = nvmlSystemConfComputeSettings_v1;
     NVMLTRY(nvmlSystemGetConfComputeSettings, &ccInfo.settingV12040);
-    if (ccInfo.settingV12040.ccFeature == NVML_CC_SYSTEM_FEATURE_ENABLED)
-      status->CCEnabled = true;
-    else
-      status->CCEnabled = false;
+    if (ccInfo.settingV12040.ccFeature == NVML_CC_SYSTEM_FEATURE_ENABLED) status->CCEnabled = true;
+    else status->CCEnabled = false;
 
     if (ccInfo.settingV12040.multiGpuMode == NVML_CC_SYSTEM_MULTIGPU_PROTECTED_PCIE)
       status->multiGpuProtectedPCIE = true;
-    else
-      status->multiGpuProtectedPCIE = false;
-    if (ccInfo.settingV12040.multiGpuMode == NVML_CC_SYSTEM_MULTIGPU_NVLE)
-      status->multiGpuNVLE = true;
-    else
-      status->multiGpuNVLE = false;
+    else status->multiGpuProtectedPCIE = false;
+    if (ccInfo.settingV12040.multiGpuMode == NVML_CC_SYSTEM_MULTIGPU_NVLE) status->multiGpuNVLE = true;
+    else status->multiGpuNVLE = false;
   } else if (pfn_nvmlSystemGetConfComputeState != NULL) {
     NVMLTRY(nvmlSystemGetConfComputeState, &ccInfo.settingV12020);
-    if (ccInfo.settingV12020.ccFeature == NVML_CC_SYSTEM_FEATURE_ENABLED)
-      status->CCEnabled = true;
-    else
-      status->CCEnabled = false;
+    if (ccInfo.settingV12020.ccFeature == NVML_CC_SYSTEM_FEATURE_ENABLED) status->CCEnabled = true;
+    else status->CCEnabled = false;
     status->multiGpuProtectedPCIE = false;
     status->multiGpuNVLE = false;
   } else {

--- a/projects/rccl/src/misc/nvmlwrap_stub.cc
+++ b/projects/rccl/src/misc/nvmlwrap_stub.cc
@@ -24,7 +24,7 @@ ncclResult_t ncclNvmlDeviceGetHandleByPciBusId(const char* pciBusId, nvmlDevice_
 }
 
 ncclResult_t ncclNvmlDeviceGetIndex(nvmlDevice_t device, unsigned* index) {
-  *index  = 0;
+  *index = 0;
   return ncclSuccess;
 }
 
@@ -37,16 +37,16 @@ ncclResult_t ncclNvmlDeviceGetMinorNumber(nvmlDevice_t device, unsigned int* min
   return ncclSuccess;
 }
 
-ncclResult_t ncclNvmlDeviceGetNvLinkState(nvmlDevice_t device, unsigned int link, nvmlEnableState_t *isActive) {
+ncclResult_t ncclNvmlDeviceGetNvLinkState(nvmlDevice_t device, unsigned int link, nvmlEnableState_t* isActive) {
   return ncclSystemError;
 }
 
-ncclResult_t ncclNvmlDeviceGetNvLinkRemotePciInfo(nvmlDevice_t device, unsigned int link, nvmlPciInfo_t *pci) {
+ncclResult_t ncclNvmlDeviceGetNvLinkRemotePciInfo(nvmlDevice_t device, unsigned int link, nvmlPciInfo_t* pci) {
   return ncclSystemError;
 }
 
 ncclResult_t ncclNvmlDeviceGetNvLinkCapability(nvmlDevice_t device, unsigned int link,
-    nvmlNvLinkCapability_t capability, unsigned int *capResult) {
+                                               nvmlNvLinkCapability_t capability, unsigned int* capResult) {
   return ncclSystemError;
 }
 

--- a/projects/rccl/src/misc/param.cc
+++ b/projects/rccl/src/misc/param.cc
@@ -25,7 +25,7 @@ const char* userHomeDir() {
 }
 
 void setEnvFile(const char* fileName) {
-  FILE * file = fopen(fileName, "r");
+  FILE* file = fopen(fileName, "r");
   if (file == NULL) return;
 
   char line[4096];
@@ -33,16 +33,16 @@ void setEnvFile(const char* fileName) {
   char envValue[1024];
   while (fgets(line, (int)sizeof(line), file) != NULL) {
     size_t len = strlen(line);
-    if (len > 0 && line[len-1] == '\n') line[--len] = '\0';
-    if (len > 0 && line[len-1] == '\r') line[--len] = '\0';
+    if (len > 0 && line[len - 1] == '\n') line[--len] = '\0';
+    if (len > 0 && line[len - 1] == '\r') line[--len] = '\0';
     if (line[0] == '#') continue;
     int s = 0;
     while (line[s] != '\0' && line[s] != '=') s++;
     if (line[s] == '\0') continue;
-    strncpy(envVar, line, std::min(1023,s));
-    envVar[std::min(1023,s)] = '\0';
+    strncpy(envVar, line, std::min(1023, s));
+    envVar[std::min(1023, s)] = '\0';
     s++;
-    strncpy(envValue, line+s, 1023);
+    strncpy(envValue, line + s, 1023);
     envValue[1023] = '\0';
     ncclOsSetEnv(envVar, envValue);
   }
@@ -82,7 +82,8 @@ int64_t ncclLoadParam(char const* env, int64_t deftVal, int64_t uninitialized, i
   // noCache is only load/stored within the mutex, no need for atomic
   if (*noCache == /*uninitialized*/ -1) ncclGetCachePolicy(env, noCache);
 
-  if (COMPILER_ATOMIC_LOAD(cache, std::memory_order_relaxed) != uninitialized) return COMPILER_ATOMIC_LOAD(cache, std::memory_order_relaxed);
+  if (COMPILER_ATOMIC_LOAD(cache, std::memory_order_relaxed) != uninitialized)
+    return COMPILER_ATOMIC_LOAD(cache, std::memory_order_relaxed);
 
   // Read the environment variable
   const char* str = ncclGetEnv(env);

--- a/projects/rccl/src/misc/proxy_trace/proxy_trace.cc
+++ b/projects/rccl/src/misc/proxy_trace/proxy_trace.cc
@@ -14,50 +14,41 @@
 #include <map>
 
 constexpr int32_t kFinishedProxyOpItems = 32;
-static std::unordered_map<facebook_rccl::ProxyOpStepStatus, std::string>
-    proxyStepStatusStrMap = {
-        {facebook_rccl::ProxyOpStepStatus::INIT, "INIT"},
-        {facebook_rccl::ProxyOpStepStatus::POSTING, "POSTING"},
-        {facebook_rccl::ProxyOpStepStatus::SENDING, "SENDING"},
-        {facebook_rccl::ProxyOpStepStatus::RECEIVING, "RECEIVING"},
-        {facebook_rccl::ProxyOpStepStatus::WAITING_GPU, "WAITING_GPU"},
-        {facebook_rccl::ProxyOpStepStatus::FLUSHING, "FLUSHING"},
-        {facebook_rccl::ProxyOpStepStatus::DONE, "DONE"},
-        {facebook_rccl::ProxyOpStepStatus::UNINITIALIZED, "ILLEGAL"},
+static std::unordered_map<facebook_rccl::ProxyOpStepStatus, std::string> proxyStepStatusStrMap = {
+  {facebook_rccl::ProxyOpStepStatus::INIT, "INIT"},
+  {facebook_rccl::ProxyOpStepStatus::POSTING, "POSTING"},
+  {facebook_rccl::ProxyOpStepStatus::SENDING, "SENDING"},
+  {facebook_rccl::ProxyOpStepStatus::RECEIVING, "RECEIVING"},
+  {facebook_rccl::ProxyOpStepStatus::WAITING_GPU, "WAITING_GPU"},
+  {facebook_rccl::ProxyOpStepStatus::FLUSHING, "FLUSHING"},
+  {facebook_rccl::ProxyOpStepStatus::DONE, "DONE"},
+  {facebook_rccl::ProxyOpStepStatus::UNINITIALIZED, "ILLEGAL"},
 };
 
-bool facebook_rccl::ProxyTrace::checkActiveOpExist(uint64_t commHash,
-                                                   uint64_t opCount,
-                                                   uint32_t proxyOpId) const {
+bool facebook_rccl::ProxyTrace::checkActiveOpExist(uint64_t commHash, uint64_t opCount, uint32_t proxyOpId) const {
   return (activeOps.find(commHash) != activeOps.end() &&
-          activeOps.at(commHash).find(opCount) !=
-              activeOps.at(commHash).end() &&
-          activeOps.at(commHash).at(opCount).find(proxyOpId) !=
-              activeOps.at(commHash).at(opCount).end());
+          activeOps.at(commHash).find(opCount) != activeOps.at(commHash).end() &&
+          activeOps.at(commHash).at(opCount).find(proxyOpId) != activeOps.at(commHash).at(opCount).end());
 }
 
 // Get a unique proxyOpId for a given commHash:opCount
 // If the opCount is not found, create a new entry for it and return 0
-int64_t facebook_rccl::ProxyTrace::getOrCreateProxyOpId(uint64_t commHash,
-                                                        uint64_t opCount) {
+int64_t facebook_rccl::ProxyTrace::getOrCreateProxyOpId(uint64_t commHash, uint64_t opCount) {
   return activeOpIdTracker[commHash][opCount];
 }
 
-facebook_rccl::ProxyTraceOp *
-facebook_rccl::ProxyTrace::getProxyTraceOpPtr(const ProxyTraceRecordKey &key) {
+facebook_rccl::ProxyTraceOp* facebook_rccl::ProxyTrace::getProxyTraceOpPtr(const ProxyTraceRecordKey& key) {
   if (checkActiveOpExist(key.commHash, key.opCount, key.proxyOpId)) {
     return &(activeOps.at(key.commHash).at(key.opCount).at(key.proxyOpId));
   }
   return nullptr;
 }
 
-void facebook_rccl::ProxyTrace::checkOpCompleted(
-    const ProxyTraceRecordKey &key) {
+void facebook_rccl::ProxyTrace::checkOpCompleted(const ProxyTraceRecordKey& key) {
   if (checkActiveOpExist(key.commHash, key.opCount, key.proxyOpId)) {
-    auto &traceOp = activeOps[key.commHash][key.opCount][key.proxyOpId];
+    auto& traceOp = activeOps[key.commHash][key.opCount][key.proxyOpId];
     // Remove finished proxyOp or colls to avoid memory leak
-    if (traceOp.counters[facebook_rccl::ProxyCounterTypes::DONE] ==
-        traceOp.nSteps) {
+    if (traceOp.counters[facebook_rccl::ProxyCounterTypes::DONE] == traceOp.nSteps) {
       traceOp.status = ProxyOpStepStatus::DONE;
       if (finishedOps.size() >= kFinishedProxyOpItems) {
         finishedOps.pop_front();
@@ -74,12 +65,10 @@ void facebook_rccl::ProxyTrace::checkOpCompleted(
   }
 }
 
-void facebook_rccl::ProxyTrace::addNewProxyTraceOpImpl(
-    const ProxyTraceRecordKey &key, const ProxyTraceExtraInfo &extraInfo,
-    ProxyOpType opType, int channelId, int nSteps, uint32_t nbytes,
-    int peerRank) {
-  if (nSteps > 0 &&
-      !checkActiveOpExist(key.commHash, key.opCount, key.proxyOpId)) {
+void facebook_rccl::ProxyTrace::addNewProxyTraceOpImpl(const ProxyTraceRecordKey& key,
+                                                       const ProxyTraceExtraInfo& extraInfo, ProxyOpType opType,
+                                                       int channelId, int nSteps, uint32_t nbytes, int peerRank) {
+  if (nSteps > 0 && !checkActiveOpExist(key.commHash, key.opCount, key.proxyOpId)) {
     auto traceOp = facebook_rccl::ProxyTraceOp();
     traceOp.opType = opType;
     traceOp.traceKey = key;
@@ -92,8 +81,7 @@ void facebook_rccl::ProxyTrace::addNewProxyTraceOpImpl(
     traceOp.startTs = std::chrono::high_resolution_clock::now();
     traceOp.status = ProxyOpStepStatus::INIT;
     activeOpIdTracker[key.commHash][key.opCount]++;
-    activeOps[key.commHash][key.opCount].emplace(key.proxyOpId,
-                                                 std::move(traceOp));
+    activeOps[key.commHash][key.opCount].emplace(key.proxyOpId, std::move(traceOp));
   } else if (nSteps == 0) {
     INFO(NCCL_PROXY, "nSteps is 0, ignored %s", key.str().c_str());
   }
@@ -106,27 +94,17 @@ void facebook_rccl::ProxyTraceOp::computeStatus() {
   int transmitted = counters[facebook_rccl::ProxyCounterTypes::TRANSMITTED];
   int done = counters[facebook_rccl::ProxyCounterTypes::DONE];
   if (opType == ProxyOpType::RECV) {
-    if (posted < nSteps && posted < done + NCCL_STEPS)
-      newStatus = ProxyOpStepStatus::POSTING; // Init
-    else if (received < posted)
-      newStatus = ProxyOpStepStatus::RECEIVING; // Receiving
-    else if (received < transmitted)
-      newStatus = ProxyOpStepStatus::RECEIVING; // Receiving
-    else if (transmitted < received)
-      newStatus = ProxyOpStepStatus::FLUSHING; // Flushing
-    else if (done < transmitted)
-      newStatus = ProxyOpStepStatus::WAITING_GPU; // Waiting on GPU
-    else
-      newStatus = ProxyOpStepStatus::DONE; // Done
+    if (posted < nSteps && posted < done + NCCL_STEPS) newStatus = ProxyOpStepStatus::POSTING; // Init
+    else if (received < posted) newStatus = ProxyOpStepStatus::RECEIVING; // Receiving
+    else if (received < transmitted) newStatus = ProxyOpStepStatus::RECEIVING; // Receiving
+    else if (transmitted < received) newStatus = ProxyOpStepStatus::FLUSHING; // Flushing
+    else if (done < transmitted) newStatus = ProxyOpStepStatus::WAITING_GPU; // Waiting on GPU
+    else newStatus = ProxyOpStepStatus::DONE; // Done
   } else {
-    if (posted < nSteps && posted < done + NCCL_STEPS)
-      newStatus = ProxyOpStepStatus::POSTING; // Init
-    else if (transmitted < posted)
-      newStatus = ProxyOpStepStatus::WAITING_GPU; // Waiting on GPU
-    else if (done < transmitted)
-      newStatus = ProxyOpStepStatus::SENDING; // Sending
-    else
-      newStatus = ProxyOpStepStatus::DONE; // Done
+    if (posted < nSteps && posted < done + NCCL_STEPS) newStatus = ProxyOpStepStatus::POSTING; // Init
+    else if (transmitted < posted) newStatus = ProxyOpStepStatus::WAITING_GPU; // Waiting on GPU
+    else if (done < transmitted) newStatus = ProxyOpStepStatus::SENDING; // Sending
+    else newStatus = ProxyOpStepStatus::DONE; // Done
   }
   this->status = newStatus;
 }
@@ -135,16 +113,15 @@ std::string facebook_rccl::ProxyTrace::dump(uint64_t commHash) {
   std::lock_guard<std::mutex> lock(mutex_);
   std::string result = fmt::format("commDump for commHash:{}\n", commHash);
   std::map<std::string, std::string> sortedDumpStrMap;
-  for (auto &opCountMap : activeOps.at(commHash)) {
-    for (auto &proxyOpMap : opCountMap.second) {
-      ProxyTraceRecordKey traceKey = {commHash, opCountMap.first,
-                                      proxyOpMap.first};
+  for (auto& opCountMap : activeOps.at(commHash)) {
+    for (auto& proxyOpMap : opCountMap.second) {
+      ProxyTraceRecordKey traceKey = {commHash, opCountMap.first, proxyOpMap.first};
       proxyOpMap.second.computeStatus();
       sortedDumpStrMap[traceKey.str()] = proxyOpMap.second.str();
     }
   }
-  for (const auto &pair : sortedDumpStrMap) {
-    result += pair.second; //proxyOpStr
+  for (const auto& pair : sortedDumpStrMap) {
+    result += pair.second; // proxyOpStr
   }
   return result;
 }
@@ -156,9 +133,9 @@ std::string facebook_rccl::ProxyTrace::dump() {
 
   // maps serialized key to serliazed proxyOp; sorted by key
   std::map<std::string, std::string> sortedDumpStrMap;
-  for (auto &commHash_opCountMap : activeOps) {
-    for (auto &opCount_proxyOpMap : commHash_opCountMap.second /*opCountMap*/) {
-      for (auto &opId_opEntry : opCount_proxyOpMap.second/*proxyOpMap*/) {
+  for (auto& commHash_opCountMap : activeOps) {
+    for (auto& opCount_proxyOpMap : commHash_opCountMap.second /*opCountMap*/) {
+      for (auto& opId_opEntry : opCount_proxyOpMap.second /*proxyOpMap*/) {
         ProxyTraceRecordKey traceKey = {commHash_opCountMap.first, opCount_proxyOpMap.first, opId_opEntry.first};
         opId_opEntry.second.computeStatus();
         sortedDumpStrMap[traceKey.str()] = opId_opEntry.second.str();
@@ -167,10 +144,10 @@ std::string facebook_rccl::ProxyTrace::dump() {
   }
 
   // add the recent finished ops as well
-  for (const auto &keyStr_proxyOpStr : finishedOps) {
+  for (const auto& keyStr_proxyOpStr : finishedOps) {
     sortedDumpStrMap[keyStr_proxyOpStr.first] = keyStr_proxyOpStr.second;
   }
-  for (const auto &keyStr_proxyOpStr : sortedDumpStrMap) {
+  for (const auto& keyStr_proxyOpStr : sortedDumpStrMap) {
     result += keyStr_proxyOpStr.second;
   }
   return result;
@@ -178,55 +155,44 @@ std::string facebook_rccl::ProxyTrace::dump() {
 
 std::string facebook_rccl::ProxyTraceOp::str() {
   computeStatus();
-  std::string ret = fmt::format(
-      "createT:{}, lastT:{}, postT:{}, sendT:{}, cntNm:{}, {}, {}, {}->{}({}), "
-      "chan:{}, status:{}, ns:{}, nb:{}, po:{}, ke:{}, tail/h:{}, recvT:{}, "
-      "connSz/h:{}, trans:{}, flushed:{}, recvd:{}, done:{}\n",
-      std::chrono::duration_cast<std::chrono::milliseconds>(
-          startTs.time_since_epoch())
-          .count(),
-      std::chrono::duration_cast<std::chrono::milliseconds>(
-          lastUpdateTs.time_since_epoch())
-          .count(),
-      std::chrono::duration_cast<std::chrono::milliseconds>(
-          timestamps[facebook_rccl::ProxyCounterTypes::POSTED].time_since_epoch())
-          .count(),
-      std::chrono::duration_cast<std::chrono::milliseconds>(
-          timestamps[facebook_rccl::ProxyCounterTypes::KERNEL_COPY_READY].time_since_epoch())
-          .count(),  
-      static_cast<int>(lastUpdatingCounter), traceKey.str(), extraInfo.str(),
-      myRank, peerRank, opType == ProxyOpType::SEND ? "S" : "R", channelId,
-      proxyStepStatusStrMap[status], nSteps, nbytes,
-      counters[ProxyCounterTypes::POSTED],
-      counters[ProxyCounterTypes::KERNEL_COPY_READY],
-      counters[ProxyCounterTypes::TAIL_OR_HEAD],
-      counters[ProxyCounterTypes::RECV_TAIL],
-      counters[ProxyCounterTypes::FIFO_SZ_OR_HEAD_CACHE],
-      counters[ProxyCounterTypes::TRANSMITTED],
-      counters[ProxyCounterTypes::FLUSHED],
-      counters[ProxyCounterTypes::RECEIVED], counters[ProxyCounterTypes::DONE]);
+  std::string ret =
+    fmt::format("createT:{}, lastT:{}, postT:{}, sendT:{}, cntNm:{}, {}, {}, {}->{}({}), "
+                "chan:{}, status:{}, ns:{}, nb:{}, po:{}, ke:{}, tail/h:{}, recvT:{}, "
+                "connSz/h:{}, trans:{}, flushed:{}, recvd:{}, done:{}\n",
+                std::chrono::duration_cast<std::chrono::milliseconds>(startTs.time_since_epoch()).count(),
+                std::chrono::duration_cast<std::chrono::milliseconds>(lastUpdateTs.time_since_epoch()).count(),
+                std::chrono::duration_cast<std::chrono::milliseconds>(
+                  timestamps[facebook_rccl::ProxyCounterTypes::POSTED].time_since_epoch())
+                  .count(),
+                std::chrono::duration_cast<std::chrono::milliseconds>(
+                  timestamps[facebook_rccl::ProxyCounterTypes::KERNEL_COPY_READY].time_since_epoch())
+                  .count(),
+                static_cast<int>(lastUpdatingCounter), traceKey.str(), extraInfo.str(), myRank, peerRank,
+                opType == ProxyOpType::SEND ? "S" : "R", channelId, proxyStepStatusStrMap[status], nSteps, nbytes,
+                counters[ProxyCounterTypes::POSTED], counters[ProxyCounterTypes::KERNEL_COPY_READY],
+                counters[ProxyCounterTypes::TAIL_OR_HEAD], counters[ProxyCounterTypes::RECV_TAIL],
+                counters[ProxyCounterTypes::FIFO_SZ_OR_HEAD_CACHE], counters[ProxyCounterTypes::TRANSMITTED],
+                counters[ProxyCounterTypes::FLUSHED], counters[ProxyCounterTypes::RECEIVED],
+                counters[ProxyCounterTypes::DONE]);
   return ret;
 }
 
 float facebook_rccl::ProxyTrace::getMapSizeMB() const {
   float size = 0;
-  for (const auto &commHash_opCountMap : activeOps) {
-    for (const auto &opCount_proxyOpMap : commHash_opCountMap.second) {
+  for (const auto& commHash_opCountMap : activeOps) {
+    for (const auto& opCount_proxyOpMap : commHash_opCountMap.second) {
       size += opCount_proxyOpMap.second.size() *
-              (sizeof(ProxyTraceOp) +
-               sizeof(std::unique_ptr<facebook_rccl::ProxyTraceOp>));
+              (sizeof(ProxyTraceOp) + sizeof(std::unique_ptr<facebook_rccl::ProxyTraceOp>));
     }
   }
-  for (const auto &keyStr_proxyOpStr : finishedOps) {
+  for (const auto& keyStr_proxyOpStr : finishedOps) {
     size += keyStr_proxyOpStr.first.size() + keyStr_proxyOpStr.second.size();
   }
   return size / 1024.0 / 1024.0;
 }
 
-void facebook_rccl::ProxyTrace::updateProxyOpCounter(
-    const ProxyTraceRecordKey& traceKey,
-    ProxyCounterTypes counter,
-    int64_t val) {
+void facebook_rccl::ProxyTrace::updateProxyOpCounter(const ProxyTraceRecordKey& traceKey, ProxyCounterTypes counter,
+                                                     int64_t val) {
   std::lock_guard<std::mutex> lock(mutex_);
   auto traceOpPtr = getProxyTraceOpPtr(traceKey);
   if (traceOpPtr) {
@@ -237,9 +203,7 @@ void facebook_rccl::ProxyTrace::updateProxyOpCounter(
   }
 }
 
-void facebook_rccl::ProxyTrace::setProxyOpTimestamp(
-    const ProxyTraceRecordKey& traceKey,
-    ProxyCounterTypes counter) {
+void facebook_rccl::ProxyTrace::setProxyOpTimestamp(const ProxyTraceRecordKey& traceKey, ProxyCounterTypes counter) {
   std::lock_guard<std::mutex> lock(mutex_);
   auto traceOpPtr = getProxyTraceOpPtr(traceKey);
   if (!traceOpPtr || traceOpPtr->timestamps.find(counter) == traceOpPtr->timestamps.end()) {
@@ -249,17 +213,11 @@ void facebook_rccl::ProxyTrace::setProxyOpTimestamp(
   traceOpPtr->timestamps[counter] = std::chrono::high_resolution_clock::now();
 }
 
-void facebook_rccl::ProxyTrace::addNewProxyOp(
-    ProxyTraceRecordKey& key,
-    const ProxyTraceExtraInfo& extraInfo,
-    ProxyOpType opType,
-    int channelId,
-    int nSteps,
-    uint32_t nbytes,
-    int peerRank) {
+void facebook_rccl::ProxyTrace::addNewProxyOp(ProxyTraceRecordKey& key, const ProxyTraceExtraInfo& extraInfo,
+                                              ProxyOpType opType, int channelId, int nSteps, uint32_t nbytes,
+                                              int peerRank) {
   std::lock_guard<std::mutex> lock(mutex_);
   auto opId = getOrCreateProxyOpId(key.commHash, key.opCount);
   key.proxyOpId = opId;
-  addNewProxyTraceOpImpl(
-      key, extraInfo, opType, channelId, nSteps, nbytes, peerRank);
+  addNewProxyTraceOpImpl(key, extraInfo, opType, channelId, nSteps, nbytes, peerRank);
 }

--- a/projects/rccl/src/misc/recorder.cc
+++ b/projects/rccl/src/misc/recorder.cc
@@ -8,22 +8,26 @@
 #include <iomanip>
 #include <sys/syscall.h>
 #include "debug.h"
- 
+
 using namespace std::chrono;
 
-namespace rccl
-{
+namespace rccl {
 __thread int Recorder::rcclReplayThreadIdx = -1;
 int Recorder::depth = 0;
 
 static char buffer[4096];
 static rcclCall_t lastcall = rrGroupStart; // for trailing comma, need modify for multithread case for Bcast
-void indent(int depth, std::ofstream& o) {for (int i = 0; i < depth; i++) o << " ";}
-void newLine(std::ofstream& o) {if (lastcall != rrGroupStart) o << ","; o << std::endl;}
-static uint64_t hashUniqueId(ncclUniqueId const &id) {
-  char const *bytes = (char const*)&id;
+void indent(int depth, std::ofstream& o) {
+  for (int i = 0; i < depth; i++) o << " ";
+}
+void newLine(std::ofstream& o) {
+  if (lastcall != rrGroupStart) o << ",";
+  o << std::endl;
+}
+static uint64_t hashUniqueId(ncclUniqueId const& id) {
+  char const* bytes = (char const*)&id;
   uint64_t h = 0xdeadbeef;
-  for(int i=0; i < (int)sizeof(ncclUniqueId); i++) {
+  for (int i = 0; i < (int)sizeof(ncclUniqueId); i++) {
     h ^= h >> 32;
     h *= 0x8db3db47fa2994ad;
     h += bytes[i];
@@ -31,35 +35,29 @@ static uint64_t hashUniqueId(ncclUniqueId const &id) {
   return h;
 }
 
-rcclApiCall::rcclApiCall(rcclCall_t type, const ncclInfo& info)://name(rcclCallStr[call.type]), // opName
-                                                                type(type),
-                                                                opCount(info.comm->opCount),
-                                                                sendbuff(info.sendbuff),
-                                                                recvbuff(info.recvbuff),
-                                                                acc(info.acc),
-                                                                count(info.count),
-                                                                datatype(info.datatype),
-                                                                op(info.op),
-                                                                root(info.root),
-                                                                nRanks(info.comm->nRanks),
-                                                                comm(info.comm),
-                                                                stream(info.stream),
-                                                                nTasks(info.comm->planner.nTasksP2p + info.comm->planner.nTasksColl),
-                                                                globalRank(info.comm->localRankToRank[info.comm->localRank])
-{
-  (void)hipMemGetAddressRange(&recvPtrBase, &recvPtrExtent, const_cast<void*>(info.recvbuff)); // should always exist for collectives
+rcclApiCall::rcclApiCall(rcclCall_t type, const ncclInfo& info)
+  :// name(rcclCallStr[call.type]), // opName
+    type(type), opCount(info.comm->opCount), sendbuff(info.sendbuff), recvbuff(info.recvbuff), acc(info.acc),
+    count(info.count), datatype(info.datatype), op(info.op), root(info.root), nRanks(info.comm->nRanks),
+    comm(info.comm), stream(info.stream), nTasks(info.comm->planner.nTasksP2p + info.comm->planner.nTasksColl),
+    globalRank(info.comm->localRankToRank[info.comm->localRank]) {
+  (void)hipMemGetAddressRange(&recvPtrBase, &recvPtrExtent,
+                              const_cast<void*>(info.recvbuff)); // should always exist for collectives
   if (info.sendbuff) // ncclSend/Recv
   {
     (void)hipMemGetAddressRange(&sendPtrBase, &sendPtrExtent, const_cast<void*>(info.sendbuff));
   }
 }
 
-rcclApiCall::rcclApiCall(rcclCall_t type) : type(type){}
+rcclApiCall::rcclApiCall(rcclCall_t type) : type(type) {}
 
 std::string siminfo_fmt = "[size : %zu, magic : %u, version : %u, estimated time : %f, timestamp : %f]";
-std::string config_fmt = ", ncclConfig : [size : %zu, magic : %u, version : %u, blocking : %d, cgaClusterSize : %d, minCTA : %d, maxCTA : %d, netname : %s, splitshare : %d]";
-std::string ctxt_fmt = "time : %lf, thread : %d, device : %d, captured : %d, graphID : %llu ]]"; // implicit context info
-std::string ubr_fmt = "%s : [comm : %p, buff : [addr : %p, base : %p, size : %zu], returned handle : %p, count : %zu, context : [";
+std::string config_fmt = ", ncclConfig : [size : %zu, magic : %u, version : %u, blocking : %d, cgaClusterSize : %d, "
+                         "minCTA : %d, maxCTA : %d, netname : %s, splitshare : %d]";
+std::string ctxt_fmt =
+  "time : %lf, thread : %d, device : %d, captured : %d, graphID : %llu ]]"; // implicit context info
+std::string ubr_fmt =
+  "%s : [comm : %p, buff : [addr : %p, base : %p, size : %zu], returned handle : %p, count : %zu, context : [";
 std::string getId_fmt = "%s : [uniqueID : %llu, context : [";
 std::string ubDereg_fmt = "%s : [comm : %p, handle : %p, context : [";
 std::string rank_fmt = "%s : [size : %d, uniqueID : %llu, rank : %d, context : [";
@@ -71,14 +69,14 @@ std::string alloc_fmt = "%s : [returned ptr : %p, size : %zu, context : [";
 std::string free_fmt = "%s : [ptr : %p, context : [";
 std::string redop_fmt = "%s : [scalar : %p, datatype : %d, op : %d, residence : %d, comm : %p, context : [";
 std::string redopdestroy_fmt = "%s : [op : %d, comm : %p, context : [";
-std::string coll_fmt = "%s : [opCount : %lx, sendbuff : [addr : %p, base : %p, size : %zu], recvbuff : [addr : %p, base : %p, size : %zu], acc : %p, count : %zu, datatype : %d, op : %d, root : %d, comm : %p, nranks : %d, stream : %p, task : %d, globalrank : %d, context : [";
+std::string coll_fmt = "%s : [opCount : %lx, sendbuff : [addr : %p, base : %p, size : %zu], recvbuff : [addr : %p, "
+                       "base : %p, size : %zu], acc : %p, count : %zu, datatype : %d, op : %d, root : %d, comm : %p, "
+                       "nranks : %d, stream : %p, task : %d, globalrank : %d, context : [";
 
-Recorder::Recorder()
-{
+Recorder::Recorder() {
   filename = getenv("RCCL_REPLAY_FILE") ? getenv("RCCL_REPLAY_FILE") : "";
 
-  if (!filename.size())
-  {
+  if (!filename.size()) {
     return;
   }
 
@@ -91,12 +89,10 @@ Recorder::Recorder()
   size_t dot;
   std::string output_name, output_extension;
 
-  if ((dot = std::string(filename).find(".")) != std::string::npos)
-  {
+  if ((dot = std::string(filename).find(".")) != std::string::npos) {
     output_name = std::string(filename).substr(0, dot);
     output_extension = std::string(filename).substr(dot);
-    if (output_extension.compare(".json") == 0)
-    {
+    if (output_extension.compare(".json") == 0) {
       output_json = 1;
     }
   } else {
@@ -105,34 +101,28 @@ Recorder::Recorder()
 
   outputFile.open(output_name + "." + std::to_string(pid) + "." + std::string(hostname) + output_extension,
                   output_json ? std::ofstream::out : std::ofstream::binary);
-  if (output_json)
-  {
+  if (output_json) {
     outputFile << "{" << std::endl;
     indent(2, outputFile);
     outputFile << "version : 1,";
   }
 }
 
-Recorder& Recorder::instance()
-{
+Recorder& Recorder::instance() {
   static Recorder _instance;
   return _instance;
 }
 
-void Recorder::skip(bool b)
-{
-  if (filename.size())
-  {
+void Recorder::skip(bool b) {
+  if (filename.size()) {
     skipped = b;
   }
 }
 
-void Recorder::captureGpuContext(rcclApiCall& call) const
-{
+void Recorder::captureGpuContext(rcclApiCall& call) const {
   call.timestamp = duration_cast<duration<double>>(high_resolution_clock::now().time_since_epoch()).count() * 1000;
 
-  if (rcclReplayThreadIdx == -1)
-  {
+  if (rcclReplayThreadIdx == -1) {
     rcclReplayThreadIdx = syscall(SYS_gettid);
   }
 
@@ -147,32 +137,27 @@ void Recorder::captureGpuContext(rcclApiCall& call) const
 
 // for single process use only, for now
 // TODO: potentially need async logging for performance
-void Recorder::write(const rcclApiCall &call)
-{
-  if (!filename.size())
-  {
-    return ;
+void Recorder::write(const rcclApiCall& call) {
+  if (!filename.size()) {
+    return;
   }
 
   std::unique_lock<std::mutex> lock(writemtx);
 
-  if (lastcall == rrBcast && call.type == rrBroadcast)
-  {
+  if (lastcall == rrBcast && call.type == rrBroadcast) {
     return;
   }
 
   int len = -1;
 
-  if (output_json)
-  {
-    if (call.type == rrGroupEnd || call.type == rrGroupSimulatedEnd)
-    {
+  if (output_json) {
+    if (call.type == rrGroupEnd || call.type == rrGroupSimulatedEnd) {
       depth--;
       outputFile << std::endl;
       indent(2 + 2 * depth, outputFile);
       outputFile << "}";
       lastcall = call.type;
-      return ;
+      return;
     }
 
     newLine(outputFile);
@@ -180,127 +165,122 @@ void Recorder::write(const rcclApiCall &call)
     lastcall = call.type;
     switch (call.type) {
     case rrGroupStart:
-    {
-      outputFile << "{";
-      depth++;
-      return ;
-    }
+      {
+        outputFile << "{";
+        depth++;
+        return;
+      }
     case rrCommRegister:
-    {
-      len = snprintf(buffer, 4096, ubr_fmt.c_str(),
-                     rcclCallStr[call.type], call.comm, call.sendbuff, call.sendPtrBase, call.sendPtrExtent, call.recvbuff, call.count);
-      break;
-    }
+      {
+        len = snprintf(buffer, 4096, ubr_fmt.c_str(), rcclCallStr[call.type], call.comm, call.sendbuff,
+                       call.sendPtrBase, call.sendPtrExtent, call.recvbuff, call.count);
+        break;
+      }
     case rrCommDeregister:
-    {
-      len = snprintf(buffer, 4096, ubDereg_fmt.c_str(),
-                     rcclCallStr[call.type], call.comm, call.recvbuff);
-      break;
-    }
+      {
+        len = snprintf(buffer, 4096, ubDereg_fmt.c_str(), rcclCallStr[call.type], call.comm, call.recvbuff);
+        break;
+      }
     case rrGetUniqueId:
-    {
-      len = snprintf(buffer, 4096, getId_fmt.c_str(), rcclCallStr[call.type], call.commId);
-      break;
-    }
+      {
+        len = snprintf(buffer, 4096, getId_fmt.c_str(), rcclCallStr[call.type], call.commId);
+        break;
+      }
     case rrCommInitDev:
-    {
-      len = snprintf(buffer, 4096, init_fmt.c_str(), rcclCallStr[call.type], call.comm, call.nRanks, call.commId, call.globalRank, call.root);
-      break;
-    }
+      {
+        len = snprintf(buffer, 4096, init_fmt.c_str(), rcclCallStr[call.type], call.comm, call.nRanks, call.commId,
+                       call.globalRank, call.root);
+        break;
+      }
     case rrCommInitRank:
     case rrCommInitRankConfig:
-    {
-      len = snprintf(buffer, 4096, rank_fmt.c_str(), rcclCallStr[call.type], call.nRanks, call.commId, call.globalRank);
-      break; // detail to be provided by init dev or config info
-    }
+      {
+        len =
+          snprintf(buffer, 4096, rank_fmt.c_str(), rcclCallStr[call.type], call.nRanks, call.commId, call.globalRank);
+        break; // detail to be provided by init dev or config info
+      }
     case rrCommInitAll:
-    {
-      len = snprintf(buffer, 4096, all_fmt.c_str(), rcclCallStr[call.type], call.root);
-      break;
-    }
+      {
+        len = snprintf(buffer, 4096, all_fmt.c_str(), rcclCallStr[call.type], call.root);
+        break;
+      }
     case rrCommFinalize:
     case rrCommDestroy:
     case rrCommAbort:
-    {
-      len = snprintf(buffer, 4096, destroy_fmt.c_str(), rcclCallStr[call.type], call.comm);
-      break;
-    }
+      {
+        len = snprintf(buffer, 4096, destroy_fmt.c_str(), rcclCallStr[call.type], call.comm);
+        break;
+      }
     case rrCommSplit:
-    {
-      len = snprintf(buffer, 4096, split_fmt.c_str(),
-                     rcclCallStr[call.type], (void*)(call.commId), call.comm, call.nRanks, call.globalRank, call.comm);
-      break;
-    }
+      {
+        len = snprintf(buffer, 4096, split_fmt.c_str(), rcclCallStr[call.type], (void*)(call.commId), call.comm,
+                       call.nRanks, call.globalRank, call.comm);
+        break;
+      }
     case rrMemAlloc:
-    {
-      len = snprintf(buffer, 4096, alloc_fmt.c_str(),
-                     rcclCallStr[call.type], call.recvbuff, call.count);
-      break;
-    }
+      {
+        len = snprintf(buffer, 4096, alloc_fmt.c_str(), rcclCallStr[call.type], call.recvbuff, call.count);
+        break;
+      }
     case rrMemFree:
-    {
-      len = snprintf(buffer, 4096, free_fmt.c_str(),
-                     rcclCallStr[call.type], call.recvbuff);
-      break;
-    }
+      {
+        len = snprintf(buffer, 4096, free_fmt.c_str(), rcclCallStr[call.type], call.recvbuff);
+        break;
+      }
     case rrRedOpCreatePreMulSum:
-    {
-      len = snprintf(buffer, 4096, redop_fmt.c_str(),
-                     rcclCallStr[call.type], call.sendbuff, call.datatype, call.op, call.root, call.comm);
-      break;
-    }
+      {
+        len = snprintf(buffer, 4096, redop_fmt.c_str(), rcclCallStr[call.type], call.sendbuff, call.datatype, call.op,
+                       call.root, call.comm);
+        break;
+      }
     case rrRedOpDestroy:
-    {
-      len = snprintf(buffer, 4096, redopdestroy_fmt.c_str(),
-                     rcclCallStr[call.type], call.op, call.comm);
-      break;
-    }
+      {
+        len = snprintf(buffer, 4096, redopdestroy_fmt.c_str(), rcclCallStr[call.type], call.op, call.comm);
+        break;
+      }
     default: // collectives
-      len = snprintf(buffer, 4096, coll_fmt.c_str(),
-                     rcclCallStr[call.type], call.opCount, call.sendbuff, call.sendPtrBase, call.sendPtrExtent,
-                     call.recvbuff, call.recvPtrBase, call.recvPtrExtent, call.acc, call.count, call.datatype,
-                     call.op, call.root, call.comm, call.nRanks, call.stream, call.nTasks, call.globalRank);
-
+      len =
+        snprintf(buffer, 4096, coll_fmt.c_str(), rcclCallStr[call.type], call.opCount, call.sendbuff, call.sendPtrBase,
+                 call.sendPtrExtent, call.recvbuff, call.recvPtrBase, call.recvPtrExtent, call.acc, call.count,
+                 call.datatype, call.op, call.root, call.comm, call.nRanks, call.stream, call.nTasks, call.globalRank);
     }
     outputFile.write(buffer, len);
-    len = snprintf(buffer, 4096, ctxt_fmt.c_str(), call.timestamp, call.tid, call.hipDev, call.graphCaptured, call.graphID);
+    len =
+      snprintf(buffer, 4096, ctxt_fmt.c_str(), call.timestamp, call.tid, call.hipDev, call.graphCaptured, call.graphID);
     outputFile.write(buffer, len);
   } else {
     outputFile.write((char*)&call, sizeof(rcclApiCall));
   }
   outputFile.flush();
-  return ;
+  return;
 }
 
 // wrapper function for graph launch callback
-void Recorder::recordLater(void* idx)
-{
+void Recorder::recordLater(void* idx) {
   Recorder& recorder = Recorder::instance();
-  size_t callidx = (size_t) idx;
+  size_t callidx = (size_t)idx;
   rcclApiCall call = recorder.calls[callidx];
   recorder.record(call);
 }
 
-void Recorder::record(const char* name)
-{
-  if (!filename.size() || logLevel <= 1)
-  {
+void Recorder::record(const char* name) {
+  if (!filename.size() || logLevel <= 1) {
     return;
   }
   double ts = duration_cast<duration<double>>(high_resolution_clock::now().time_since_epoch()).count() * 1000;
   if (output_json) // will not record for binary replay export
   {
     std::unique_lock<std::mutex> lock(writemtx);
-    newLine(outputFile); lastcall = rrOtherCall;
+    newLine(outputFile);
+    lastcall = rrOtherCall;
     indent(2 + 2 * depth, outputFile);
     outputFile << name << " : [time : " << std::fixed << std::setprecision(6) << ts << "]";
   }
-  //numCall++;
+  // numCall++;
   outputFile.flush();
 }
 
-ncclResult_t Recorder::record(rcclApiCall& call)
-{
+ncclResult_t Recorder::record(rcclApiCall& call) {
   ncclResult_t ret = ncclSuccess;
   captureGpuContext(call);
 
@@ -328,10 +308,11 @@ ncclResult_t Recorder::record(rcclApiCall& call)
   // collectives, which may be registered with graph
   case rrAllToAll: // should work with rest of the coll with nested sendrecv
   default: // collective other than a2a/a2av
-  #if ROCM_VERSION >= 60100
+#if ROCM_VERSION >= 60100
     hipStreamCaptureStatus status;
     hipGraph_t graphCaptured;
-    CUDACHECK(hipStreamGetCaptureInfo_v2(call.stream, &status, &(call.graphID), &graphCaptured)); // shouldnt we need dependency?
+    CUDACHECK(hipStreamGetCaptureInfo_v2(call.stream, &status, &(call.graphID),
+                                         &graphCaptured)); // shouldnt we need dependency?
 
     if (status == hipStreamCaptureStatusActive) // when graph launched this should be disabled
     {
@@ -340,22 +321,20 @@ ncclResult_t Recorder::record(rcclApiCall& call)
       hipGraphNode_t logNode;
       hipHostNodeParams p;
       p.fn = &(Recorder::recordLater);
-      p.userData = (void*) (calls.size() - 1);
+      p.userData = (void*)(calls.size() - 1);
       CUDACHECK(hipGraphAddHostNode(&logNode, graphCaptured, nullptr, 0, &p));
     } else {
       call.graphCaptured = 0;
     }
-  #endif
+#endif
   }
 
   write(call); // write immediatelly
   return ret;
 }
 
-ncclResult_t Recorder::record(rcclCall_t type, const ncclInfo& info)
-{
-  if (!filename.size() || skipped)
-  {
+ncclResult_t Recorder::record(rcclCall_t type, const ncclInfo& info) {
+  if (!filename.size() || skipped) {
     return ncclSuccess;
   }
 
@@ -363,28 +342,25 @@ ncclResult_t Recorder::record(rcclCall_t type, const ncclInfo& info)
   return record(call);
 }
 
-ncclResult_t Recorder::record(rcclCall_t type, const void* sendbuff, void* recvbuff,
-                              size_t count, ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream, int root,
-                              const size_t sendcounts[], const size_t sdispls[], const size_t recvcounts[], const size_t rdispls[])
-{
-  if (!filename.size())
-  {
+ncclResult_t Recorder::record(rcclCall_t type, const void* sendbuff, void* recvbuff, size_t count,
+                              ncclDataType_t datatype, ncclComm_t comm, hipStream_t stream, int root,
+                              const size_t sendcounts[], const size_t sdispls[], const size_t recvcounts[],
+                              const size_t rdispls[]) {
+  if (!filename.size()) {
     return ncclSuccess;
   }
 
-  rcclApiCall call(type, {.sendbuff = sendbuff, .recvbuff = recvbuff, .count = count,
-                          .datatype = datatype, .comm = comm, .stream = stream});
-  if (root != -1)
-  {
+  rcclApiCall call(
+    type,
+    {.sendbuff = sendbuff, .recvbuff = recvbuff, .count = count, .datatype = datatype, .comm = comm, .stream = stream});
+  if (root != -1) {
     call.root = root;
   }
 
   ncclResult_t ret = record(call);
-  if (type == rrAllToAllv)
-  {
+  if (type == rrAllToAllv) {
     int size = call.nRanks - 1;
-    if (output_json)
-    {
+    if (output_json) {
       outputFile << ", sendcounts : [";
       for (int i = 0; i < size; i++) outputFile << sendcounts[i] << ", ";
       outputFile << sendcounts[size] << "], sdispls : [";
@@ -405,29 +381,25 @@ ncclResult_t Recorder::record(rcclCall_t type, const void* sendbuff, void* recvb
   return ret;
 }
 
-ncclResult_t Recorder::record(rcclCall_t type, ncclRedOp_t op, ncclComm_t comm, ncclDataType_t datatype, ncclScalarResidence_t residence, void* scalar)
-{
-  if (!filename.size())
-  {
+ncclResult_t Recorder::record(rcclCall_t type, ncclRedOp_t op, ncclComm_t comm, ncclDataType_t datatype,
+                              ncclScalarResidence_t residence, void* scalar) {
+  if (!filename.size()) {
     return ncclSuccess;
   }
 
   rcclApiCall call(type, {.op = op, .comm = comm});
-  if (type == rrRedOpCreatePreMulSum)
-  {
+  if (type == rrRedOpCreatePreMulSum) {
     call.sendbuff = scalar;
     call.datatype = datatype;
     call.root = residence;
     call.sendbuff = scalar;
   }
   return record(call);
-  //TODO: printout scalar
+  // TODO: printout scalar
 }
 
-ncclResult_t Recorder::record(rcclCall_t type, int groupDepth)
-{
-  if (!filename.size() || skipped)
-  {
+ncclResult_t Recorder::record(rcclCall_t type, int groupDepth) {
+  if (!filename.size() || skipped) {
     return ncclSuccess;
   }
   rcclApiCall gc(type);
@@ -435,17 +407,14 @@ ncclResult_t Recorder::record(rcclCall_t type, int groupDepth)
   return record(gc);
 }
 
-ncclResult_t Recorder::record(rcclCall_t type, int size, int rank, ncclUniqueId* commId, ncclComm_t comm, int device)
-{
-  if (!filename.size())
-  {
+ncclResult_t Recorder::record(rcclCall_t type, int size, int rank, ncclUniqueId* commId, ncclComm_t comm, int device) {
+  if (!filename.size()) {
     return ncclSuccess;
   }
 
   rcclApiCall initCall(type);
 
-  if (type == rrCommSplit)
-  {
+  if (type == rrCommSplit) {
     initCall.comm = comm;
     initCall.commId = (uint64_t)commId;
   } else {
@@ -454,8 +423,7 @@ ncclResult_t Recorder::record(rcclCall_t type, int size, int rank, ncclUniqueId*
 
   initCall.nRanks = size;
   initCall.globalRank = rank;
-  if (type == rrCommInitDev)
-  {
+  if (type == rrCommInitDev) {
     initCall.root = device;
     initCall.comm = comm;
   }
@@ -464,10 +432,8 @@ ncclResult_t Recorder::record(rcclCall_t type, int size, int rank, ncclUniqueId*
 }
 
 // comm destroy
-ncclResult_t Recorder::record(rcclCall_t type, ncclComm_t comm)
-{
-  if (!filename.size())
-  {
+ncclResult_t Recorder::record(rcclCall_t type, ncclComm_t comm) {
+  if (!filename.size()) {
     return ncclSuccess;
   }
 
@@ -476,17 +442,14 @@ ncclResult_t Recorder::record(rcclCall_t type, ncclComm_t comm)
   return record(call);
 }
 
-ncclResult_t Recorder::record(rcclCall_t type, ncclComm_t comm, void* handle, void* userBuffer, size_t size)
-{
-  if (!filename.size())
-  {
+ncclResult_t Recorder::record(rcclCall_t type, ncclComm_t comm, void* handle, void* userBuffer, size_t size) {
+  if (!filename.size()) {
     return ncclSuccess;
   }
   rcclApiCall call(type);
   call.comm = comm;
   call.recvbuff = handle;
-  if (type == rrCommRegister)
-  {
+  if (type == rrCommRegister) {
     CUDACHECK(hipMemGetAddressRange(&call.sendPtrBase, &call.sendPtrExtent, userBuffer));
     call.sendbuff = userBuffer;
     call.count = size;
@@ -494,58 +457,48 @@ ncclResult_t Recorder::record(rcclCall_t type, ncclComm_t comm, void* handle, vo
   return record(call);
 }
 
-ncclResult_t Recorder::record(rcclCall_t type, void* ptr, size_t size)
-{
-  if (!filename.size())
-  {
+ncclResult_t Recorder::record(rcclCall_t type, void* ptr, size_t size) {
+  if (!filename.size()) {
     return ncclSuccess;
   }
   rcclApiCall call(type);
   call.recvbuff = ptr;
-  if (type == rrMemAlloc)
-  {
+  if (type == rrMemAlloc) {
     call.count = size;
   }
   return record(call);
 }
 
-void Recorder::record(int groupDepth, ncclSimInfo_t *siminfo)
-{
-  if (!filename.size())
-  {
+void Recorder::record(int groupDepth, ncclSimInfo_t* siminfo) {
+  if (!filename.size()) {
     return;
   }
   rcclApiCall call(rrGroupSimulatedEnd);
   record(call);
 
-  if (output_json && siminfo)
-  {
-    int len = snprintf(buffer, 4096, siminfo_fmt.c_str(),
-                       siminfo->size, siminfo->magic, siminfo->version, siminfo->estimatedTime, call.timestamp);
+  if (output_json && siminfo) {
+    int len = snprintf(buffer, 4096, siminfo_fmt.c_str(), siminfo->size, siminfo->magic, siminfo->version,
+                       siminfo->estimatedTime, call.timestamp);
     outputFile.write(buffer, len);
   } // no tid for groupCall
   // TODO: else flush siminfo in binary
   outputFile.flush();
 }
 
-void Recorder::record(rcclCall_t type, int size, int rank, ncclUniqueId* commId, ncclConfig_t* config, ncclComm_t comm)
-{
-  if (!filename.size())
-  {
-    return ;
+void Recorder::record(rcclCall_t type, int size, int rank, ncclUniqueId* commId, ncclConfig_t* config,
+                      ncclComm_t comm) {
+  if (!filename.size()) {
+    return;
   }
 
-  if (type == rrCommInitRankConfig)
-  {
+  if (type == rrCommInitRankConfig) {
     record(type, size, rank, commId);
-  }
-  else //rrCommSplit
+  } else // rrCommSplit
   {
-    record(type, size /*color*/, rank/*key*/, commId, comm);
+    record(type, size /*color*/, rank /*key*/, commId, comm);
   }
 
-  if (output_json && config)
-  {
+  if (output_json && config) {
     int len = snprintf(buffer, 4096, config_fmt.c_str(), config->size, config->magic, config->version, config->blocking,
                        config->cgaClusterSize, config->minCTAs, config->maxCTAs, config->netName, config->splitShare);
     outputFile.write(buffer, len);
@@ -554,11 +507,9 @@ void Recorder::record(rcclCall_t type, int size, int rank, ncclUniqueId* commId,
   // TODO: else flush ncclConfig in binary
 }
 
-void Recorder::record(ncclComm_t* comms, int ndev, const int* devlist)
-{
-  if (!filename.size())
-  {
-    return ;
+void Recorder::record(ncclComm_t* comms, int ndev, const int* devlist) {
+  if (!filename.size()) {
+    return;
   }
 
   rcclApiCall call(rrCommInitAll);
@@ -566,13 +517,10 @@ void Recorder::record(ncclComm_t* comms, int ndev, const int* devlist)
   call.sendbuff = devlist;
   record(call);
 
-  if (devlist)
-  {
-    if (output_json)
-    {
+  if (devlist) {
+    if (output_json) {
       outputFile << ", devlist : [";
-      for (int i = 0; i < call.root - 1; i++)
-        outputFile << devlist[i] << ", ";
+      for (int i = 0; i < call.root - 1; i++) outputFile << devlist[i] << ", ";
       outputFile << devlist[call.root - 1] << "]";
     } else {
       outputFile.write((char*)devlist, sizeof(int) * ndev);
@@ -581,22 +529,17 @@ void Recorder::record(ncclComm_t* comms, int ndev, const int* devlist)
   }
 }
 
-Recorder::~Recorder()
-{
-  if (outputFile.is_open())
-  {
+Recorder::~Recorder() {
+  if (outputFile.is_open()) {
     if (output_json) outputFile << std::endl << "}" << std::endl;
     outputFile.close();
     calls.clear();
   }
 }
 
-static rcclCall_t getFuncType(std::string func)
-{
-  for (int i = 0; i < sizeof(rcclCallStr) / sizeof(char*); i++)
-  {
-    if (func == std::string(rcclCallStr[i]))
-    {
+static rcclCall_t getFuncType(std::string func) {
+  for (int i = 0; i < sizeof(rcclCallStr) / sizeof(char*); i++) {
+    if (func == std::string(rcclCallStr[i])) {
       return (rcclCall_t)i;
     }
   }
@@ -604,8 +547,7 @@ static rcclCall_t getFuncType(std::string func)
   exit(1);
 }
 
-void parseJsonEntry(const char* entry, std::vector<rcclApiCall>& calls)
-{
+void parseJsonEntry(const char* entry, std::vector<rcclApiCall>& calls) {
   // TODO: parse comma too
   rcclApiCall call;
   std::string str(entry);
@@ -625,92 +567,89 @@ void parseJsonEntry(const char* entry, std::vector<rcclApiCall>& calls)
     return;
   }
 
-  rcclCall_t type = getFuncType(str.substr(begin, end-begin));
+  rcclCall_t type = getFuncType(str.substr(begin, end - begin));
   call.type = type;
-  switch(type) {
+  switch (type) {
   case rrCommRegister:
-  {
-    assert(sscanf(str.c_str() + end + 3, (ubr_fmt.substr(5) + ctxt_fmt).c_str(),
-                  &call.comm, &call.sendbuff, &call.sendPtrBase, &call.sendPtrExtent, &call.recvbuff, &call.count) == 6);
-    break;
-  }
+    {
+      assert(sscanf(str.c_str() + end + 3, (ubr_fmt.substr(5) + ctxt_fmt).c_str(), &call.comm, &call.sendbuff,
+                    &call.sendPtrBase, &call.sendPtrExtent, &call.recvbuff, &call.count) == 6);
+      break;
+    }
   case rrCommDeregister:
-  {
-    assert(sscanf(str.c_str() + end + 3, (ubDereg_fmt.substr(5) + ctxt_fmt).c_str(),
-                  &call.comm, &call.recvbuff) == 2);
-    break;
-  }
+    {
+      assert(sscanf(str.c_str() + end + 3, (ubDereg_fmt.substr(5) + ctxt_fmt).c_str(), &call.comm, &call.recvbuff) ==
+             2);
+      break;
+    }
   case rrGetUniqueId:
-  {
-    assert(sscanf(str.c_str() + end + 3, (getId_fmt.substr(5) + ctxt_fmt).c_str(), &call.commId) == 1);
-    break;
-  }
+    {
+      assert(sscanf(str.c_str() + end + 3, (getId_fmt.substr(5) + ctxt_fmt).c_str(), &call.commId) == 1);
+      break;
+    }
   case rrCommInitDev:
-  {
-    assert(sscanf(str.c_str() + end + 3, (init_fmt.substr(5) + ctxt_fmt).c_str(),
-                  &call.comm, &call.nRanks, &call.commId, &call.globalRank, &call.root) == 5);
-    break;
-  }
+    {
+      assert(sscanf(str.c_str() + end + 3, (init_fmt.substr(5) + ctxt_fmt).c_str(), &call.comm, &call.nRanks,
+                    &call.commId, &call.globalRank, &call.root) == 5);
+      break;
+    }
   case rrCommInitRank:
   case rrCommInitRankConfig:
-  {
-    assert(sscanf(str.c_str() + end + 3, (rank_fmt.substr(5) + ctxt_fmt).c_str(),
-           &call.nRanks, &call.commId, &call.globalRank) == 3);
-    break;
-  }
+    {
+      assert(sscanf(str.c_str() + end + 3, (rank_fmt.substr(5) + ctxt_fmt).c_str(), &call.nRanks, &call.commId,
+                    &call.globalRank) == 3);
+      break;
+    }
   case rrCommInitAll:
-  {
-    assert(sscanf(str.c_str() + end + 3, (all_fmt.substr(5) + ctxt_fmt).c_str(), &call.root) == 1);
-    break;
-  }
+    {
+      assert(sscanf(str.c_str() + end + 3, (all_fmt.substr(5) + ctxt_fmt).c_str(), &call.root) == 1);
+      break;
+    }
   case rrCommFinalize:
   case rrCommDestroy:
   case rrCommAbort:
-  {
-    assert(sscanf(str.c_str() + end + 3, (destroy_fmt.substr(5) + ctxt_fmt).c_str(), &call.comm) == 1);
-    break;
-  }
+    {
+      assert(sscanf(str.c_str() + end + 3, (destroy_fmt.substr(5) + ctxt_fmt).c_str(), &call.comm) == 1);
+      break;
+    }
   case rrCommSplit:
-  {
-    assert(sscanf(str.c_str() + end + 3, (split_fmt.substr(5) + ctxt_fmt).c_str(),
-           &call.commId, &call.comm, &call.nRanks, &call.globalRank, &call.comm) == 5);
-    break;
-  }
+    {
+      assert(sscanf(str.c_str() + end + 3, (split_fmt.substr(5) + ctxt_fmt).c_str(), &call.commId, &call.comm,
+                    &call.nRanks, &call.globalRank, &call.comm) == 5);
+      break;
+    }
   case rrMemAlloc:
-  {
-    assert(sscanf(str.c_str() + end + 3, (alloc_fmt.substr(5) + ctxt_fmt).c_str(),
-           &call.recvbuff, &call.count) == 2);
-    break;
-  }
+    {
+      assert(sscanf(str.c_str() + end + 3, (alloc_fmt.substr(5) + ctxt_fmt).c_str(), &call.recvbuff, &call.count) == 2);
+      break;
+    }
   case rrMemFree:
-  {
-    assert(sscanf(str.c_str() + end + 3, (free_fmt.substr(5) + ctxt_fmt).c_str(), &call.recvbuff) == 1);
-    break;
-  }
+    {
+      assert(sscanf(str.c_str() + end + 3, (free_fmt.substr(5) + ctxt_fmt).c_str(), &call.recvbuff) == 1);
+      break;
+    }
   case rrRedOpCreatePreMulSum:
-  {
-    assert(sscanf(str.c_str() + end + 3, (redop_fmt.substr(5) + ctxt_fmt).c_str(),
-           &call.sendbuff, &call.datatype, &call.op, &call.root, &call.comm) == 5);
-    break;
-  }
+    {
+      assert(sscanf(str.c_str() + end + 3, (redop_fmt.substr(5) + ctxt_fmt).c_str(), &call.sendbuff, &call.datatype,
+                    &call.op, &call.root, &call.comm) == 5);
+      break;
+    }
   case rrRedOpDestroy:
-  {
-    assert(sscanf(str.c_str() + end + 3, (redopdestroy_fmt.substr(5) + ctxt_fmt).c_str(),
-           &call.op, &call.comm) == 2);
-    break;
-  }
+    {
+      assert(sscanf(str.c_str() + end + 3, (redopdestroy_fmt.substr(5) + ctxt_fmt).c_str(), &call.op, &call.comm) == 2);
+      break;
+    }
   default:
-    assert(sscanf(str.c_str() + end + 3, (coll_fmt.substr(5) + ctxt_fmt).c_str(),
-                  &call.opCount, &call.sendbuff, &call.sendPtrBase, &call.sendPtrExtent, &call.recvbuff, &call.recvPtrBase, &call.recvPtrExtent,
-                  &call.acc, &call.count, &call.datatype, &call.op, &call.root,
-                  &call.comm, &call.nRanks, &call.stream, &call.nTasks, &call.globalRank, &call.timestamp, &call.tid,
-                  &call.hipDev, &call.graphCaptured, &call.graphID) == 22);
+    assert(sscanf(str.c_str() + end + 3, (coll_fmt.substr(5) + ctxt_fmt).c_str(), &call.opCount, &call.sendbuff,
+                  &call.sendPtrBase, &call.sendPtrExtent, &call.recvbuff, &call.recvPtrBase, &call.recvPtrExtent,
+                  &call.acc, &call.count, &call.datatype, &call.op, &call.root, &call.comm, &call.nRanks, &call.stream,
+                  &call.nTasks, &call.globalRank, &call.timestamp, &call.tid, &call.hipDev, &call.graphCaptured,
+                  &call.graphID) == 22);
   }
   calls.push_back(call);
 }
 
-void parseBinLog()
-{
+void parseBinLog() {
   // TODO: need to handle trailing data such as simInfo, devList, a2av data, etc.
 }
-};
+}; // namespace rccl

--- a/projects/rccl/src/misc/rocm_smi_wrap.cc
+++ b/projects/rccl/src/misc/rocm_smi_wrap.cc
@@ -26,25 +26,28 @@ THE SOFTWARE.
 
 static int is_wsl2 = -1;
 
-#define ROCMSMICHECK(cmd) do {               \
-  rsmi_status_t ret = cmd;                   \
-  if( ret != RSMI_STATUS_SUCCESS ) {         \
-    const char *err;                         \
-    rsmi_status_string(ret, &err);           \
-    WARN("ROCm SMI init failure %s", err);   \
-    return ncclInternalError;                \
-  }                                          \
-} while(false)
+#define ROCMSMICHECK(cmd) \
+  do { \
+    rsmi_status_t ret = cmd; \
+    if (ret != RSMI_STATUS_SUCCESS) { \
+      const char* err; \
+      rsmi_status_string(ret, &err); \
+      WARN("ROCm SMI init failure %s", err); \
+      return ncclInternalError; \
+    } \
+  } while (false)
 
-#define ARSMICHECK(cmd) do {         \
-  int ret = cmd;                     \
-  if( ret != 0 ) {		     \
-    WARN("ARSMI failure %d", ret);   \
-    return ncclInternalError;        \
-  }                                  \
-} while(false)
+#define ARSMICHECK(cmd) \
+  do { \
+    int ret = cmd; \
+    if (ret != 0) { \
+      WARN("ARSMI failure %d", ret); \
+      return ncclInternalError; \
+    } \
+  } while (false)
 
-RCCL_PARAM(UseRocmSmiLib, "USE_ROCM_SMI_LIB", 0); // Opt-in environment variable for enabling using rocm_smi_lib instead of internal code
+RCCL_PARAM(UseRocmSmiLib, "USE_ROCM_SMI_LIB",
+           0); // Opt-in environment variable for enabling using rocm_smi_lib instead of internal code
 
 ncclResult_t rocm_smi_init() {
   if (__atomic_load_n(&is_wsl2, __ATOMIC_ACQUIRE) == -1)
@@ -71,14 +74,12 @@ ncclResult_t rocm_smi_init() {
 }
 
 ncclResult_t rocm_smi_getNumDevice(uint32_t* num_devs) {
-  if (__atomic_load_n(&is_wsl2, __ATOMIC_ACQUIRE))
-    CUDACHECK(cudaGetDeviceCount((int *)num_devs));
-  else
-    if (rcclParamUseRocmSmiLib()) {
-      ROCMSMICHECK(rsmi_num_monitor_devices(num_devs));
-    } else {
-      ARSMICHECK(ARSMI_get_num_devices(num_devs));
-    }
+  if (__atomic_load_n(&is_wsl2, __ATOMIC_ACQUIRE)) CUDACHECK(cudaGetDeviceCount((int*)num_devs));
+  else if (rcclParamUseRocmSmiLib()) {
+    ROCMSMICHECK(rsmi_num_monitor_devices(num_devs));
+  } else {
+    ARSMICHECK(ARSMI_get_num_devices(num_devs));
+  }
 
   return ncclSuccess;
 }
@@ -107,10 +108,9 @@ ncclResult_t rocm_smi_getDevicePciBusIdString(uint32_t deviceIndex, char* busId,
   return ncclSuccess;
 }
 
-
 ncclResult_t rocm_smi_getDeviceIndexByPciBusId(const char* pciBusId, uint32_t* deviceIndex) {
   if (__atomic_load_n(&is_wsl2, __ATOMIC_ACQUIRE)) {
-    CUDACHECK(hipDeviceGetByPCIBusId((int *)deviceIndex, pciBusId));
+    CUDACHECK(hipDeviceGetByPCIBusId((int*)deviceIndex, pciBusId));
     return ncclSuccess;
   } else {
     uint32_t i, num_devs = 0;
@@ -126,7 +126,7 @@ ncclResult_t rocm_smi_getDeviceIndexByPciBusId(const char* pciBusId, uint32_t* d
      *  | Device   | [ 7: 3] |
      *  | Function | [ 2: 0] |
      **/
-    busid = ((busid&0xffff00000L)<<12)+((busid&0xff000L)>>4)+((busid&0xff0L)>>1)+(busid&0x7L);
+    busid = ((busid & 0xffff00000L) << 12) + ((busid & 0xff000L) >> 4) + ((busid & 0xff0L) >> 1) + (busid & 0x7L);
 
     if (rcclParamUseRocmSmiLib()) {
       ROCMSMICHECK(rsmi_num_monitor_devices(&num_devs));
@@ -136,9 +136,9 @@ ncclResult_t rocm_smi_getDeviceIndexByPciBusId(const char* pciBusId, uint32_t* d
     for (i = 0; i < num_devs; i++) {
       uint64_t bdfid;
       if (rcclParamUseRocmSmiLib()) {
-	ROCMSMICHECK(rsmi_dev_pci_id_get(i, &bdfid));
+        ROCMSMICHECK(rsmi_dev_pci_id_get(i, &bdfid));
       } else {
-	ARSMICHECK(ARSMI_dev_pci_id_get(i, &bdfid));
+        ARSMICHECK(ARSMI_dev_pci_id_get(i, &bdfid));
       }
 
       if (bdfid == busid) break;
@@ -147,19 +147,18 @@ ncclResult_t rocm_smi_getDeviceIndexByPciBusId(const char* pciBusId, uint32_t* d
     if (i < num_devs) {
       *deviceIndex = i;
       return ncclSuccess;
-    }
-    else {
+    } else {
       if (rcclParamUseRocmSmiLib()) {
-	WARN("rocm_smi_lib: %s device index not found", pciBusId);
+        WARN("rocm_smi_lib: %s device index not found", pciBusId);
       } else {
-	WARN("ARSMI_lib: %s device index not found", pciBusId);
+        WARN("ARSMI_lib: %s device index not found", pciBusId);
       }
       return ncclInternalError;
     }
   }
 }
 
-ncclResult_t rocm_smi_getLinkInfo(int srcIndex, int dstIndex, RSMI_IO_LINK_TYPE* rsmi_type, int *hops, int *count) {
+ncclResult_t rocm_smi_getLinkInfo(int srcIndex, int dstIndex, RSMI_IO_LINK_TYPE* rsmi_type, int* hops, int* count) {
   if (__atomic_load_n(&is_wsl2, __ATOMIC_ACQUIRE)) {
     *rsmi_type = RSMI_IOLINK_TYPE_PCIEXPRESS;
     *hops = 1;
@@ -172,29 +171,24 @@ ncclResult_t rocm_smi_getLinkInfo(int srcIndex, int dstIndex, RSMI_IO_LINK_TYPE*
     if (rcclParamUseRocmSmiLib()) {
       ROCMSMICHECK(rsmi_topo_get_link_type(srcIndex, dstIndex, &rsmi_hops, rsmi_type));
       ROCMSMICHECK(rsmi_topo_get_link_weight(srcIndex, dstIndex, &rsmi_weight));
-      if (*rsmi_type == RSMI_IOLINK_TYPE_XGMI && (rsmi_weight == 15 ||
-        rsmi_weight == 41 || rsmi_weight == 13)) {
-  *hops = 1;
+      if (*rsmi_type == RSMI_IOLINK_TYPE_XGMI && (rsmi_weight == 15 || rsmi_weight == 41 || rsmi_weight == 13)) {
+        *hops = 1;
 #if defined HAVE_ROCM_SMI64CONFIG && rocm_smi_VERSION_MAJOR >= 5
-  uint64_t min_bw = 0, max_bw = 0;
-  rsmi_version_t version;
-  ROCMSMICHECK(rsmi_version_get(&version));
-  if (version.major >= 5)
-    ROCMSMICHECK(rsmi_minmax_bandwidth_get(srcIndex, dstIndex, &min_bw, &max_bw));
-  if (max_bw && min_bw)
-    *count = max_bw/min_bw;
+        uint64_t min_bw = 0, max_bw = 0;
+        rsmi_version_t version;
+        ROCMSMICHECK(rsmi_version_get(&version));
+        if (version.major >= 5) ROCMSMICHECK(rsmi_minmax_bandwidth_get(srcIndex, dstIndex, &min_bw, &max_bw));
+        if (max_bw && min_bw) *count = max_bw / min_bw;
 #endif
       }
     } else {
       ARSMI_linkInfo tinfo;
       ARSMICHECK(ARSMI_topo_get_link_info(srcIndex, dstIndex, &tinfo));
 
-      *rsmi_type  = (RSMI_IO_LINK_TYPE) tinfo.type;
-      if (*rsmi_type == RSMI_IOLINK_TYPE_XGMI && (tinfo.weight == 15 ||
-        tinfo.weight == 41 || tinfo.weight == 13)) {
-	*hops = 1;
-	if (tinfo.max_bandwidth && tinfo.min_bandwidth)
-	  *count = tinfo.max_bandwidth/tinfo.min_bandwidth;
+      *rsmi_type = (RSMI_IO_LINK_TYPE)tinfo.type;
+      if (*rsmi_type == RSMI_IOLINK_TYPE_XGMI && (tinfo.weight == 15 || tinfo.weight == 41 || tinfo.weight == 13)) {
+        *hops = 1;
+        if (tinfo.max_bandwidth && tinfo.min_bandwidth) *count = tinfo.max_bandwidth / tinfo.min_bandwidth;
       }
     }
   }

--- a/projects/rccl/src/misc/rocmwrap.cc
+++ b/projects/rccl/src/misc/rocmwrap.cc
@@ -42,14 +42,13 @@ CUmemAllocationHandleType ncclCuMemHandleType = CU_MEM_HANDLE_TYPE_POSIX_FILE_DE
 static int ncclCuMemSupported = 0;
 
 // cuMem VMM API availability by HIP/driver version.
-#define NCCL_CUMEM_NATIVE_MIN_VERSION   71260540
+#define NCCL_CUMEM_NATIVE_MIN_VERSION 71260540
 #define NCCL_CUMEM_BACKPORT_MIN_VERSION 70051831
 #define NCCL_CUMEM_BACKPORT_MAX_VERSION 70060000
 
-#define NCCL_CUMEM_VERSION_SUPPORTED(version)                  \
-  ((version) >= NCCL_CUMEM_NATIVE_MIN_VERSION ||               \
-   ((version) >= NCCL_CUMEM_BACKPORT_MIN_VERSION &&            \
-    (version) < NCCL_CUMEM_BACKPORT_MAX_VERSION))
+#define NCCL_CUMEM_VERSION_SUPPORTED(version) \
+  ((version) >= NCCL_CUMEM_NATIVE_MIN_VERSION || \
+   ((version) >= NCCL_CUMEM_BACKPORT_MIN_VERSION && (version) < NCCL_CUMEM_BACKPORT_MAX_VERSION))
 
 #define KERNEL_VERSION_CODE(major, minor) ((major << 16) | (minor << 8))
 
@@ -90,7 +89,8 @@ int ncclIsCuMemSupported() {
   if (CUPFN(cuMemCreate) == NULL) supported = 0;
   CUCHECKGOTO(cuDeviceGet(&currentDev, cudaDev), ret, error);
   // Query device to see if CUMEM VMM support is available
-  CUCHECKGOTO(cuDeviceGetAttribute(&flag, CU_DEVICE_ATTRIBUTE_VIRTUAL_MEMORY_MANAGEMENT_SUPPORTED, currentDev), ret, error);
+  CUCHECKGOTO(cuDeviceGetAttribute(&flag, CU_DEVICE_ATTRIBUTE_VIRTUAL_MEMORY_MANAGEMENT_SUPPORTED, currentDev), ret,
+              error);
   if (!flag) {
     WARN("cuMem support requires VMM RDMA support");
     supported = 0;
@@ -107,15 +107,16 @@ int ncclCuMemEnable() {
   return param >= 0 ? param : (param == -2 && ncclCuMemSupported);
 #else
   if (ncclParamCuMemEnable() > 0)
-    WARN("NCCL_CUMEM_ENABLE=1 is set but cuMem VMM APIs are unavailable in this build (HIP_VERSION=%d); disabling cuMem", HIP_VERSION);
+    WARN(
+      "NCCL_CUMEM_ENABLE=1 is set but cuMem VMM APIs are unavailable in this build (HIP_VERSION=%d); disabling cuMem",
+      HIP_VERSION);
   return 0;
 #endif
 }
 
 static int ncclCumemHostEnable = -1;
 int ncclCuMemHostEnable() {
-  if (ncclCumemHostEnable != -1)
-    return ncclCumemHostEnable;
+  if (ncclCumemHostEnable != -1) return ncclCumemHostEnable;
 #if HIP_VERSION < 71260540
   ncclCumemHostEnable = 0;
   return ncclCumemHostEnable;
@@ -126,13 +127,10 @@ int ncclCuMemHostEnable() {
   CUDACHECKGOTO(cudaDriverGetVersion(&cudaDriverVersion), ret, error);
   if (cudaDriverVersion < 71260540) {
     ncclCumemHostEnable = 0;
-  }
-  else {
+  } else {
     paramValue = ncclParamCuMemHostEnable();
-    if (paramValue != -1)
-      ncclCumemHostEnable = paramValue;
-    else
-      ncclCumemHostEnable = (cudaDriverVersion >= 71260540) ? 1 : 0;
+    if (paramValue != -1) ncclCumemHostEnable = paramValue;
+    else ncclCumemHostEnable = (cudaDriverVersion >= 71260540) ? 1 : 0;
     if (ncclCumemHostEnable) {
       // Verify that host allocations actually work.  Docker in particular is known to disable "get_mempolicy",
       // causing such allocations to fail (this can be fixed by invoking Docker with "--cap-add SYS_NICE").
@@ -158,8 +156,8 @@ int ncclCuMemHostEnable() {
       ALIGN_SIZE(size, granularity);
       if (CUPFN(cuMemCreate(&handle, size, &prop, 0)) != CUDA_SUCCESS) {
         INFO(NCCL_INIT, "cuMem host allocations do not appear to be working; falling back to a /dev/shm/ based "
-             "implementation. This could be due to the container runtime disabling NUMA support. "
-             "To disable this warning, set NCCL_CUMEM_HOST_ENABLE=0");
+                        "implementation. This could be due to the container runtime disabling NUMA support. "
+                        "To disable this warning, set NCCL_CUMEM_HOST_ENABLE=0");
         ncclCumemHostEnable = 0;
       } else {
         CUCHECK(cuMemRelease(handle));
@@ -175,7 +173,7 @@ error:
 static void initOnceFunc() {
   do {
     char* val = getenv("CUDA_LAUNCH_BLOCKING");
-    ncclCudaLaunchBlocking = val!=nullptr && val[0]!=0 && !(val[0]=='0' && val[1]==0);
+    ncclCudaLaunchBlocking = val != nullptr && val[0] != 0 && !(val[0] == '0' && val[1] == 0);
   } while (0);
 
   bool dmaBufSupport = false;
@@ -200,55 +198,48 @@ static void initOnceFunc() {
 
   INFO(NCCL_INIT, "ROCr version %d.%d", version_major, version_minor);
 
-  //if (hsaDriverVersion < ROCR_DRIVER_MIN_VERSION) {
+  // if (hsaDriverVersion < ROCR_DRIVER_MIN_VERSION) {
     // WARN("ROCr Driver version found is %d. Minimum requirement is %d", hsaDriverVersion, ROCR_DRIVER_MIN_VERSION);
     // Silently ignore version check mismatch for backwards compatibility
-    //goto error;
+    // goto error;
   //}
 
   // Determine whether we support the cuMem APIs or not
   ncclCuMemSupported = ncclIsCuMemSupported();
 
   /* DMA-BUF support */
-  //ROCm support
-  if(rcclParamForceEnableDMABUF())
-  {
-      dmaBufSupport = 1;
-      WARN("DMA_BUF Support is force enabled, so explicitly setting RCCL_FORCE_ENABLE_DMABUF=1");
-  }
-  else if (ncclCuMemEnable() && ncclParamDmaBufEnable() == 0)
-  {
+  // ROCm support
+  if (rcclParamForceEnableDMABUF()) {
+    dmaBufSupport = 1;
+    WARN("DMA_BUF Support is force enabled, so explicitly setting RCCL_FORCE_ENABLE_DMABUF=1");
+  } else if (ncclCuMemEnable() && ncclParamDmaBufEnable() == 0) {
     dmaBufSupport = 1;
     WARN("NCCL_CUMEM_ENABLE is set but NCCL_DMABUF_ENABLE is not. Forcefully enabling DMA-BUF for hipMem.");
-  }
-  else if (ncclParamDmaBufEnable() == 0)
-  {
+  } else if (ncclParamDmaBufEnable() == 0) {
     INFO(NCCL_INIT, "Dmabuf feature disabled without NCCL_DMABUF_ENABLE=1");
     goto error;
   }
 
   // ROCr checks
-  res = hsa_system_get_info((hsa_system_info_t) 0x204, &dmaBufSupport);
-  if (res != HSA_STATUS_SUCCESS || !dmaBufSupport){
+  res = hsa_system_get_info((hsa_system_info_t)0x204, &dmaBufSupport);
+  if (res != HSA_STATUS_SUCCESS || !dmaBufSupport) {
     INFO(NCCL_INIT, "Current version of ROCm does not support dmabuf feature.");
     goto error;
-  }
-  else if (hsa_amd_portable_export_dmabuf == nullptr) {
+  } else if (hsa_amd_portable_export_dmabuf == nullptr) {
     // The capability query advertised DMA-BUF, but the weakly-linked entry point
     // did not resolve (ROCr runtime too old to export it). Disable the feature
     // cleanly rather than leaving an inconsistent gate.
     INFO(NCCL_INIT, "ROCr runtime does not export hsa_amd_portable_export_dmabuf; disabling DMA-BUF.");
     goto error;
-  }
-  else {
+  } else {
     // Arm the DMA-BUF feature gate with the resolved HSA symbol.
     pfn_hsa_amd_portable_export_dmabuf = hsa_amd_portable_export_dmabuf;
   }
 
-  //check OS kernel support
-  if(!rcclParamForceEnableDMABUF()) {
+  // check OS kernel support
+  if (!rcclParamForceEnableDMABUF()) {
     struct utsname utsname;
-    FILE *fp = NULL;
+    FILE* fp = NULL;
     char kernel_opt1[28] = "CONFIG_DMABUF_MOVE_NOTIFY=y";
     char kernel_opt2[20] = "CONFIG_PCI_P2PDMA=y";
     char kernel_conf_file[128];
@@ -256,9 +247,9 @@ static void initOnceFunc() {
     int found_opt1 = 0;
     int found_opt2 = 0;
 
-    //check for kernel name exists
-    if (uname(&utsname) == -1) INFO(NCCL_INIT,"Could not get kernel name");
-    //format and store the kernel conf file location
+    // check for kernel name exists
+    if (uname(&utsname) == -1) INFO(NCCL_INIT, "Could not get kernel name");
+    // format and store the kernel conf file location
     const char* possiblePaths[] = {
       "/proc/config.gz",
       "/boot/config-%s",
@@ -287,8 +278,7 @@ static void initOnceFunc() {
         // popen() succeeds even when the file is missing, producing an empty
         // stream that falsely triggers the "not found" error path.
         if (!has_zcat || access("/proc/config.gz", R_OK) != 0) {
-          INFO(NCCL_INIT, "Skipping %s (zcat %s, file %s)", kernel_conf_file,
-               has_zcat ? "available" : "unavailable",
+          INFO(NCCL_INIT, "Skipping %s (zcat %s, file %s)", kernel_conf_file, has_zcat ? "available" : "unavailable",
                access("/proc/config.gz", R_OK) == 0 ? "exists" : "not found");
           continue;
         }
@@ -297,16 +287,16 @@ static void initOnceFunc() {
         fp = fopen(kernel_conf_file, "r");
       }
 
-      if (fp != NULL){
-        //look for kernel_opt1 and kernel_opt2 in the conf file and check
+      if (fp != NULL) {
+        // look for kernel_opt1 and kernel_opt2 in the conf file and check
         while (fgets(buf, sizeof(buf), fp) != NULL) {
           if (strstr(buf, kernel_opt1) != NULL) {
             found_opt1 = 1;
-            INFO(NCCL_INIT,"%s in %s", kernel_opt1, kernel_conf_file);
+            INFO(NCCL_INIT, "%s in %s", kernel_opt1, kernel_conf_file);
           }
           if (strstr(buf, kernel_opt2) != NULL) {
             found_opt2 = 1;
-            INFO(NCCL_INIT,"%s in %s", kernel_opt2, kernel_conf_file);
+            INFO(NCCL_INIT, "%s in %s", kernel_opt2, kernel_conf_file);
           }
         }
 
@@ -320,26 +310,25 @@ static void initOnceFunc() {
         // Check if both options were found
         if (!found_opt1 || !found_opt2) {
           dmaBufSupport = 0;
-          INFO(NCCL_INIT, "CONFIG_DMABUF_MOVE_NOTIFY and CONFIG_PCI_P2PDMA should be set for DMA_BUF in %s", kernel_conf_file);
+          INFO(NCCL_INIT, "CONFIG_DMABUF_MOVE_NOTIFY and CONFIG_PCI_P2PDMA should be set for DMA_BUF in %s",
+               kernel_conf_file);
           INFO(NCCL_INIT, "DMA_BUF_SUPPORT Failed due to OS kernel support");
         }
 
-        if(dmaBufSupport) INFO(NCCL_INIT, "DMA_BUF Support Enabled");
+        if (dmaBufSupport) INFO(NCCL_INIT, "DMA_BUF Support Enabled");
         else goto error;
         break;
       }
     }
-    if(fp == NULL) {
+    if (fp == NULL) {
       // Fallback: check /proc/kallsyms for DMA-BUF and P2PDMA kernel symbols.
       // Works inside Docker containers where /boot/config-* is unavailable.
       INFO(NCCL_INIT, "Could not open kernel conf file, trying /proc/kallsyms fallback");
-      FILE *kallsyms = fopen("/proc/kallsyms", "r");
+      FILE* kallsyms = fopen("/proc/kallsyms", "r");
       if (kallsyms) {
         while (fgets(buf, sizeof(buf), kallsyms) != NULL) {
-          if (!found_opt1 && strstr(buf, "dma_buf_move_notify") != NULL)
-            found_opt1 = 1;
-          if (!found_opt2 && strstr(buf, "pci_p2pdma") != NULL)
-            found_opt2 = 1;
+          if (!found_opt1 && strstr(buf, "dma_buf_move_notify") != NULL) found_opt1 = 1;
+          if (!found_opt2 && strstr(buf, "pci_p2pdma") != NULL) found_opt2 = 1;
           if (found_opt1 && found_opt2) break;
         }
         fclose(kallsyms);

--- a/projects/rccl/src/misc/roctx.cc
+++ b/projects/rccl/src/misc/roctx.cc
@@ -8,15 +8,18 @@
 #include "param.h"
 #include "debug.h"
 
-std::map<uint64_t, roctxPayloadEntryType> nvtxToRoctx {
-  {NVTX_PAYLOAD_ENTRY_TYPE_INT, ROCTX_PAYLOAD_ENTRY_TYPE_INT},
-  {NVTX_PAYLOAD_ENTRY_TYPE_SIZE, ROCTX_PAYLOAD_ENTRY_TYPE_SIZE},
-  {NVTX_PAYLOAD_ENTRY_TYPE_REDOP, ROCTX_PAYLOAD_ENTRY_TYPE_REDOP},
-  {NVTX_PAYLOAD_ENTRY_TYPE_DATATYPE, ROCTX_PAYLOAD_ENTRY_TYPE_DATATYPE}};
+std::map<uint64_t, roctxPayloadEntryType> nvtxToRoctx{{NVTX_PAYLOAD_ENTRY_TYPE_INT, ROCTX_PAYLOAD_ENTRY_TYPE_INT},
+                                                      {NVTX_PAYLOAD_ENTRY_TYPE_SIZE, ROCTX_PAYLOAD_ENTRY_TYPE_SIZE},
+                                                      {NVTX_PAYLOAD_ENTRY_TYPE_REDOP, ROCTX_PAYLOAD_ENTRY_TYPE_REDOP},
+                                                      {NVTX_PAYLOAD_ENTRY_TYPE_DATATYPE,
+                                                       ROCTX_PAYLOAD_ENTRY_TYPE_DATATYPE}};
 
-const char* roctxEntryTypeStr[ROCTX_PAYLOAD_NUM_ENTRY_TYPES] = {"ROCTX_PAYLOAD_ENTRY_TYPE_INT", "ROCTX_PAYLOAD_ENTRY_TYPE_SIZE", "ROCTX_PAYLOAD_ENTRY_TYPE_REDOP"};
-const char* ncclRedOpStr[ncclNumDevRedOps]                   = {"Sum", "Prod", "MinMax", "PreMulSum", "SumPostDiv"};
-const char* ncclDataTypeStr[ncclNumTypes]                    = {"i8", "u8", "i32", "u32", "i64", "u64", "f16", "f32", "f64", "b16", "f8", "b8"};
+const char* roctxEntryTypeStr[ROCTX_PAYLOAD_NUM_ENTRY_TYPES] = {
+  "ROCTX_PAYLOAD_ENTRY_TYPE_INT", "ROCTX_PAYLOAD_ENTRY_TYPE_SIZE", "ROCTX_PAYLOAD_ENTRY_TYPE_REDOP"
+};
+const char* ncclRedOpStr[ncclNumDevRedOps] = {"Sum", "Prod", "MinMax", "PreMulSum", "SumPostDiv"};
+const char* ncclDataTypeStr[ncclNumTypes] = {"i8",  "u8",  "i32", "u32", "i64", "u64",
+                                             "f16", "f32", "f64", "b16", "f8",  "b8"};
 
 void roctxAlloc(roctxPayloadInfo_t payloadInfo, const size_t numEntries) {
   // Allocate enough memory for numEntries in payloadEntries
@@ -43,7 +46,6 @@ void roctxFree(roctxPayloadInfo_t payloadInfo) {
 
 void extractPayloadInfo(const nvtxPayloadSchemaEntry_t* schema, const nvtxPayloadData_t* data, const size_t numEntries,
                         const char* schemaName, roctxPayloadInfo_t payloadInfo) {
-
   if (payloadInfo->payloadEntries == nullptr) return;
 
   payloadInfo->id = schemaName;
@@ -61,11 +63,20 @@ void extractPayloadInfo(const nvtxPayloadSchemaEntry_t* schema, const nvtxPayloa
 
     // Populate payload union based on the roctx type
     switch (payloadInfo->payloadEntries[i].type) {
-      case ROCTX_PAYLOAD_ENTRY_TYPE_INT:      payloadInfo->payloadEntries[i].payload.typeInt = *reinterpret_cast<const int*>(entryData);                 break;
-      case ROCTX_PAYLOAD_ENTRY_TYPE_SIZE:     payloadInfo->payloadEntries[i].payload.typeSize = *reinterpret_cast<const size_t*>(entryData);             break;
-      case ROCTX_PAYLOAD_ENTRY_TYPE_REDOP:    payloadInfo->payloadEntries[i].payload.typeRedOp = *reinterpret_cast<const ncclDevRedOp_t*>(entryData);    break;
-      case ROCTX_PAYLOAD_ENTRY_TYPE_DATATYPE: payloadInfo->payloadEntries[i].payload.typeDataType = *reinterpret_cast<const ncclDataType_t*>(entryData); break;
-      default:                                                                                                                                           break;
+    case ROCTX_PAYLOAD_ENTRY_TYPE_INT:
+      payloadInfo->payloadEntries[i].payload.typeInt = *reinterpret_cast<const int*>(entryData);
+      break;
+    case ROCTX_PAYLOAD_ENTRY_TYPE_SIZE:
+      payloadInfo->payloadEntries[i].payload.typeSize = *reinterpret_cast<const size_t*>(entryData);
+      break;
+    case ROCTX_PAYLOAD_ENTRY_TYPE_REDOP:
+      payloadInfo->payloadEntries[i].payload.typeRedOp = *reinterpret_cast<const ncclDevRedOp_t*>(entryData);
+      break;
+    case ROCTX_PAYLOAD_ENTRY_TYPE_DATATYPE:
+      payloadInfo->payloadEntries[i].payload.typeDataType = *reinterpret_cast<const ncclDataType_t*>(entryData);
+      break;
+    default:
+      break;
     }
   }
 
@@ -78,34 +89,34 @@ void stringify(roctxPayloadInfo_t payloadInfo) {
 
   int offset = snprintf(payloadInfo->message, MAX_MESSAGE_LENGTH, "{%s: ", payloadInfo->id);
 
-  for (size_t i = 0; i < payloadInfo->numEntries; ++i)
-  {
+  for (size_t i = 0; i < payloadInfo->numEntries; ++i) {
     roctxPayloadSchemaEntryInfo entry = payloadInfo->payloadEntries[i];
 
     offset += snprintf(payloadInfo->message + offset, MAX_MESSAGE_LENGTH - offset, "%s: ", entry.name);
 
-    switch (entry.type)
-    {
-      case ROCTX_PAYLOAD_ENTRY_TYPE_INT:
-        offset += snprintf(payloadInfo->message + offset, MAX_MESSAGE_LENGTH - offset, "%d", entry.payload.typeInt); 
-        break;
-      case ROCTX_PAYLOAD_ENTRY_TYPE_SIZE:
-        offset += snprintf(payloadInfo->message + offset, MAX_MESSAGE_LENGTH - offset, "%zu", entry.payload.typeSize); 
-        break;
-      case ROCTX_PAYLOAD_ENTRY_TYPE_REDOP:
-        offset += snprintf(payloadInfo->message + offset, MAX_MESSAGE_LENGTH - offset, "%s", 
-                          entry.payload.typeRedOp < ncclNumDevRedOps ? ncclRedOpStr[entry.payload.typeRedOp] : "unknown"); 
-        break;
-      case ROCTX_PAYLOAD_ENTRY_TYPE_DATATYPE:
-        offset += snprintf(payloadInfo->message + offset, MAX_MESSAGE_LENGTH - offset, "%s",
-                          entry.payload.typeDataType < ncclNumTypes ? ncclDataTypeStr[entry.payload.typeDataType] : "unknown");
-        break;
-      default:
-        offset += snprintf(payloadInfo->message + offset, MAX_MESSAGE_LENGTH - offset, "unknown roctx payload type"); 
-        break;
+    switch (entry.type) {
+    case ROCTX_PAYLOAD_ENTRY_TYPE_INT:
+      offset += snprintf(payloadInfo->message + offset, MAX_MESSAGE_LENGTH - offset, "%d", entry.payload.typeInt);
+      break;
+    case ROCTX_PAYLOAD_ENTRY_TYPE_SIZE:
+      offset += snprintf(payloadInfo->message + offset, MAX_MESSAGE_LENGTH - offset, "%zu", entry.payload.typeSize);
+      break;
+    case ROCTX_PAYLOAD_ENTRY_TYPE_REDOP:
+      offset +=
+        snprintf(payloadInfo->message + offset, MAX_MESSAGE_LENGTH - offset, "%s",
+                 entry.payload.typeRedOp < ncclNumDevRedOps ? ncclRedOpStr[entry.payload.typeRedOp] : "unknown");
+      break;
+    case ROCTX_PAYLOAD_ENTRY_TYPE_DATATYPE:
+      offset +=
+        snprintf(payloadInfo->message + offset, MAX_MESSAGE_LENGTH - offset, "%s",
+                 entry.payload.typeDataType < ncclNumTypes ? ncclDataTypeStr[entry.payload.typeDataType] : "unknown");
+      break;
+    default:
+      offset += snprintf(payloadInfo->message + offset, MAX_MESSAGE_LENGTH - offset, "unknown roctx payload type");
+      break;
     }
 
-    if (i != payloadInfo->numEntries - 1) 
+    if (i != payloadInfo->numEntries - 1)
       offset += snprintf(payloadInfo->message + offset, MAX_MESSAGE_LENGTH - offset, ", ");
   }
 
@@ -114,8 +125,8 @@ void stringify(roctxPayloadInfo_t payloadInfo) {
 
 RCCL_PARAM(LogRoctx, "LOG_ROCTX", 0);
 
-roctx_scoped_range_in::roctx_scoped_range_in(const nvtxPayloadSchemaEntry_t* schema, const nvtxPayloadData_t* data, 
-                                const size_t numEntries, const char* schemaName) noexcept {
+roctx_scoped_range_in::roctx_scoped_range_in(const nvtxPayloadSchemaEntry_t* schema, const nvtxPayloadData_t* data,
+                                             const size_t numEntries, const char* schemaName) noexcept {
   if (rcclParamLogRoctx()) {
     roctxAlloc(&payloadInfo, numEntries);
     extractPayloadInfo(schema, data, numEntries, schemaName, &payloadInfo);
@@ -137,7 +148,7 @@ roctx_scoped_range_in::roctx_scoped_range_in(const char* message) noexcept {
   }
 }
 
-roctx_scoped_range_in::roctx_scoped_range_in() noexcept : roctx_scoped_range_in{""} {/*no impl*/}
+roctx_scoped_range_in::roctx_scoped_range_in() noexcept : roctx_scoped_range_in{""} { /*no impl*/ }
 
 roctx_scoped_range_in::~roctx_scoped_range_in() noexcept {
   if (rcclParamLogRoctx()) {

--- a/projects/rccl/src/misc/shmutils.cc
+++ b/projects/rccl/src/misc/shmutils.cc
@@ -12,12 +12,10 @@
 #include <stdlib.h>
 #include "compiler.h"
 
-ncclResult_t ncclShmOpen(char* shmPath, size_t shmPathSize, size_t shmSize,
-  void** shmPtr, void** devShmPtr, int refcount,
-  ncclShmHandle_t* handle) {
+ncclResult_t ncclShmOpen(char* shmPath, size_t shmPathSize, size_t shmSize, void** shmPtr, void** devShmPtr,
+                         int refcount, ncclShmHandle_t* handle) {
   struct ncclShmHandleInternal* internalHandle = NULL;
-  ncclResult_t ret = ncclOsShmOpen(shmPath, shmPathSize, shmSize, shmPtr, devShmPtr,
-              refcount, &internalHandle);
+  ncclResult_t ret = ncclOsShmOpen(shmPath, shmPathSize, shmSize, shmPtr, devShmPtr, refcount, &internalHandle);
   *handle = (ncclShmHandle_t)internalHandle;
   return ret;
 }
@@ -30,7 +28,8 @@ ncclResult_t ncclShmUnlink(ncclShmHandle_t handle) {
   return ncclOsShmUnlink((struct ncclShmHandleInternal*)handle);
 }
 
-ncclResult_t ncclShmemAllgather(struct ncclComm *comm, struct ncclShmemCollBuff *shmem, void *sendbuff, void *recvbuff, size_t typeSize) {
+ncclResult_t ncclShmemAllgather(struct ncclComm* comm, struct ncclShmemCollBuff* shmem, void* sendbuff, void* recvbuff,
+                                size_t typeSize) {
   ncclResult_t ret = ncclSuccess;
   int nextRound = shmem->round + 1;
   int curIndex = shmem->round % 2;
@@ -45,12 +44,14 @@ ncclResult_t ncclShmemAllgather(struct ncclComm *comm, struct ncclShmemCollBuff 
 
   memcpy((char*)shmem->ptr[curIndex] + comm->localRank * maxTypeSize, sendbuff, typeSize);
   /* reset the previous round and notify I arrive this round */
-  COMPILER_ATOMIC_STORE((int*)((char*)shmem->cnt[curIndex] + CACHE_LINE_SIZE * comm->localRank), nextRound, std::memory_order_release);
+  COMPILER_ATOMIC_STORE((int*)((char*)shmem->cnt[curIndex] + CACHE_LINE_SIZE * comm->localRank), nextRound,
+                        std::memory_order_release);
 
   do {
     done = true;
     for (int i = index; i < comm->localRanks; ++i) {
-      if (i != comm->localRank && COMPILER_ATOMIC_LOAD((int*)((char*)shmem->cnt[curIndex] + CACHE_LINE_SIZE * i), std::memory_order_acquire) < nextRound) {
+      if (i != comm->localRank && COMPILER_ATOMIC_LOAD((int*)((char*)shmem->cnt[curIndex] + CACHE_LINE_SIZE * i),
+                                                       std::memory_order_acquire) < nextRound) {
         done = false;
         index = i;
         break;

--- a/projects/rccl/src/misc/signals.cc
+++ b/projects/rccl/src/misc/signals.cc
@@ -16,69 +16,59 @@
 #include "debug.h"
 #include <vector>
 
-void sig_handler(int signum)
-{
+void sig_handler(int signum) {
   printf("\n[Process: %d] Inside handler function signal: %s (%d)\n", getpid(), strsignal(signum), signum);
 
 #ifdef HAVE_BFD
-  void *addresses[BACKTRACE_MAX];
+  void* addresses[BACKTRACE_MAX];
   int num_addresses = backtrace(addresses, BACKTRACE_MAX);
   struct backtrace_file file;
   backtrace_line line;
   backtrace_h bckt;
   bckt.size = 0;
 
-  for (int i = 0; i < num_addresses; ++i)
-  {
+  for (int i = 0; i < num_addresses; ++i) {
     file.dl.address = (unsigned long)addresses[i];
-    if (dl_lookup_address(&file.dl) && load_file(&file))
-    {
-      bckt.size += get_line_info(&file, 1,
-                                 bckt.lines + bckt.size,
-                                 BACKTRACE_MAX - bckt.size);
+    if (dl_lookup_address(&file.dl) && load_file(&file)) {
+      bckt.size += get_line_info(&file, 1, bckt.lines + bckt.size, BACKTRACE_MAX - bckt.size);
       unload_file(&file);
     }
   }
 
-  for (int i=0; i<BACKTRACE_MAX; i++ )
-  {
+  for (int i = 0; i < BACKTRACE_MAX; i++) {
     if ((char*)bckt.lines[i].address == NULL) break;
-    printf("%p %s : %s line %u\n", (char*)bckt.lines[i].address,
-           bckt.lines[i].file, bckt.lines[i].function, bckt.lines[i].lineno);
+    printf("%p %s : %s line %u\n", (char*)bckt.lines[i].address, bckt.lines[i].file, bckt.lines[i].function,
+           bckt.lines[i].lineno);
   }
 #else
 #define BT_BUF_SIZE 1024
-  void *buffer[BT_BUF_SIZE];
-  char **strings;
+  void* buffer[BT_BUF_SIZE];
+  char** strings;
 
   int nptrs = backtrace(buffer, BT_BUF_SIZE);
   strings = backtrace_symbols(buffer, nptrs);
-  for (int j = 0; j < nptrs; j++)
-    printf("%s\n", strings[j]);
-  free (strings);
+  for (int j = 0; j < nptrs; j++) printf("%s\n", strings[j]);
+  free(strings);
 #endif
 
   if (signum == SIGUSR2) {
     return;
   }
 
-  exit (-1);
+  exit(-1);
 }
 
-RCCL_PARAM(EnableSignalHandler, "ENABLE_SIGNALHANDLER", 0); // Opt-in environment variable for enabling custom signal handler
+RCCL_PARAM(EnableSignalHandler, "ENABLE_SIGNALHANDLER",
+           0); // Opt-in environment variable for enabling custom signal handler
 
-void RegisterSignalHandlers()
-{
-  if (rcclParamEnableSignalHandler())
-  {
+void RegisterSignalHandlers() {
+  if (rcclParamEnableSignalHandler()) {
     INFO(NCCL_INIT, "Enabling custom signal handler");
 
     std::vector<int> signalsToCatch = {SIGILL, SIGBUS, SIGFPE, SIGSEGV, SIGUSR2};
 
-    for (auto signum : signalsToCatch)
-    {
-      if (signal(signum, sig_handler) == SIG_ERR)
-      {
+    for (auto signum : signalsToCatch) {
+      if (signal(signum, sig_handler) == SIG_ERR) {
         INFO(NCCL_INIT, "Unable to register signal handler for %s\n", strsignal(signum));
       }
     }

--- a/projects/rccl/src/misc/socket.cc
+++ b/projects/rccl/src/misc/socket.cc
@@ -29,7 +29,8 @@ NCCL_PARAM(SocketMaxSendBuff, "SOCKET_SNDBUF", -1);
 RCCL_PARAM(SocketReuseAddr, "SOCKET_REUSEADDR", 0);
 RCCL_PARAM(SocketLinger, "SOCKET_LINGER", -1);
 
-static ncclResult_t socketProgress(int op, struct ncclSocket* sock, void* ptr, int size, int* offset, int* pclosed = NULL) {
+static ncclResult_t socketProgress(int op, struct ncclSocket* sock, void* ptr, int size, int* offset,
+                                   int* pclosed = NULL) {
   int closed;
   NCCLCHECK(ncclOsSocketProgressOpt(op, sock, ptr, size, offset, 0 /*block*/, &closed));
   if (closed) {
@@ -37,9 +38,9 @@ static ncclResult_t socketProgress(int op, struct ncclSocket* sock, void* ptr, i
       *pclosed = closed;
       return ncclSuccess;
     } else {
-      char line[SOCKET_NAME_MAXLEN+1];
+      char line[SOCKET_NAME_MAXLEN + 1];
       WARN("socketProgress: Connection closed by remote peer %s",
-           ncclSocketToString(&sock->addr, line, /*numericHostForm*/0));
+           ncclSocketToString(&sock->addr, line, /*numericHostForm*/ 0));
       return ncclRemoteError;
     }
   }
@@ -58,7 +59,7 @@ static ncclResult_t socketWait(int op, struct ncclSocket* sock, void* ptr, int s
   return ncclSuccess;
 }
 
-uint16_t ncclSocketToPort(union ncclSocketAddress *addr) {
+uint16_t ncclSocketToPort(union ncclSocketAddress* addr) {
   return ntohs(addr->sa.sa_family == AF_INET ? addr->sin.sin_port : addr->sin6.sin6_port);
 }
 
@@ -89,7 +90,6 @@ ncclResult_t ncclSocketSetFd(ncclSocketDescriptor socketDescriptor, struct ncclS
   sock->socketDescriptor = socketDescriptor;
   return ncclSuccess;
 }
-
 
 ncclResult_t ncclSocketListen(struct ncclSocket* sock) {
   if (sock == NULL) {
@@ -125,8 +125,8 @@ ncclResult_t ncclSocketListen(struct ncclSocket* sock) {
   SYSCHECK(getsockname(sock->socketDescriptor, &sock->addr.sa, &size), "getsockname");
 
 #ifdef ENABLE_TRACE
-  char line[SOCKET_NAME_MAXLEN+1];
-  TRACE(NCCL_INIT|NCCL_NET,"Listening on socket %s", ncclSocketToString(&sock->addr, line));
+  char line[SOCKET_NAME_MAXLEN + 1];
+  TRACE(NCCL_INIT | NCCL_NET, "Listening on socket %s", ncclSocketToString(&sock->addr, line));
 #endif
 
   SYSCHECK(listen(sock->socketDescriptor, 16384), "listen");
@@ -141,8 +141,8 @@ ncclResult_t ncclSocketListen(struct ncclSocket* sock) {
  *
  * Output: "IPv4/IPv6 address<port>"
  */
-const char *ncclSocketToString(const union ncclSocketAddress *addr, char *buf, const int numericHostForm /*= 1*/) {
-  const struct sockaddr *saddr = &addr->sa;
+const char* ncclSocketToString(const union ncclSocketAddress* addr, char* buf, const int numericHostForm /*= 1*/) {
+  const struct sockaddr* saddr = &addr->sa;
   char host[NI_MAXHOST], service[NI_MAXSERV];
   int flag = NI_NUMERICSERV | (numericHostForm ? NI_NUMERICHOST : 0);
   if (buf == NULL || addr == NULL) goto fail;
@@ -154,8 +154,7 @@ const char *ncclSocketToString(const union ncclSocketAddress *addr, char *buf, c
   sprintf(buf, "%s<%s>", host, service);
   return buf;
 fail:
-  if (buf)
-    buf[0] = '\0';
+  if (buf) buf[0] = '\0';
   return buf;
 }
 
@@ -163,20 +162,17 @@ fail:
 int ncclEnvSocketFamily(void) {
   int family = -1; // Family selection is not forced, will use first one found
   const char* env = ncclGetEnv("NCCL_SOCKET_FAMILY");
-  if (env == NULL)
-    return family;
+  if (env == NULL) return family;
 
   INFO(NCCL_ENV, "NCCL_SOCKET_FAMILY set by environment to %s", env);
 
-  if (strcmp(env, "AF_INET") == 0)
-    family = AF_INET;  // IPv4
-  else if (strcmp(env, "AF_INET6") == 0)
-    family = AF_INET6; // IPv6
+  if (strcmp(env, "AF_INET") == 0) family = AF_INET;  // IPv4
+  else if (strcmp(env, "AF_INET6") == 0) family = AF_INET6; // IPv6
   return family;
 }
 
-ncclResult_t ncclFindInterfaces(char* ifNames, union ncclSocketAddress *ifAddrs, int ifNameMaxSize, int maxIfs,
-  int* nIfs) {
+ncclResult_t ncclFindInterfaces(char* ifNames, union ncclSocketAddress* ifAddrs, int ifNameMaxSize, int maxIfs,
+                                int* nIfs) {
   static int shownIfName = 0;
   // Allow user to force the INET socket family selection
   int sock_family = ncclEnvSocketFamily();
@@ -204,11 +200,14 @@ ncclResult_t ncclFindInterfaces(char* ifNames, union ncclSocketAddress *ifAddrs,
       }
     }
     // Then look for anything else (but not docker,lo, or virtual)
-    if (*nIfs == 0) NCCLCHECK(ncclOsFindInterfaces("^docker,lo,virbr", ifNames, ifAddrs, sock_family, ifNameMaxSize, maxIfs, nIfs));
+    if (*nIfs == 0)
+      NCCLCHECK(ncclOsFindInterfaces("^docker,lo,virbr", ifNames, ifAddrs, sock_family, ifNameMaxSize, maxIfs, nIfs));
     // Finally look for docker, then lo.
-    if (*nIfs == 0) NCCLCHECK(ncclOsFindInterfaces("docker", ifNames, ifAddrs, sock_family, ifNameMaxSize, maxIfs, nIfs));
+    if (*nIfs == 0)
+      NCCLCHECK(ncclOsFindInterfaces("docker", ifNames, ifAddrs, sock_family, ifNameMaxSize, maxIfs, nIfs));
     if (*nIfs == 0) NCCLCHECK(ncclOsFindInterfaces("lo", ifNames, ifAddrs, sock_family, ifNameMaxSize, maxIfs, nIfs));
-    if (*nIfs == 0) NCCLCHECK(ncclOsFindInterfaces("virbr", ifNames, ifAddrs, sock_family, ifNameMaxSize, maxIfs, nIfs));
+    if (*nIfs == 0)
+      NCCLCHECK(ncclOsFindInterfaces("virbr", ifNames, ifAddrs, sock_family, ifNameMaxSize, maxIfs, nIfs));
   }
   return ncclSuccess;
 }
@@ -235,7 +234,7 @@ ncclResult_t ncclSocketGetAddrFromString(union ncclSocketAddress* ua, const char
     hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;
 
-    if ( (rv = getaddrinfo(ni.prefix, NULL, &hints, &p)) != 0) {
+    if ((rv = getaddrinfo(ni.prefix, NULL, &hints, &p)) != 0) {
       WARN("Net : error encountered when getting address info : %s", gai_strerror(rv));
       return ncclInvalidArgument;
     }
@@ -245,7 +244,7 @@ ncclResult_t ncclSocketGetAddrFromString(union ncclSocketAddress* ua, const char
       struct sockaddr_in& sin = ua->sin;
       memcpy(&sin, p->ai_addr, sizeof(struct sockaddr_in));
       sin.sin_family = AF_INET;                        // IPv4
-      //inet_pton(AF_INET, ni.prefix, &(sin.sin_addr));  // IP address
+      // inet_pton(AF_INET, ni.prefix, &(sin.sin_addr));  // IP address
       sin.sin_port = htons(ni.port);                   // port
     } else if (p->ai_family == AF_INET6) {
       struct sockaddr_in6& sin6 = ua->sin6;
@@ -278,17 +277,17 @@ ncclResult_t ncclSocketGetAddrFromString(union ncclSocketAddress* ua, const char
     memset(ip_str, '\0', sizeof(ip_str));
     memset(port_str, '\0', sizeof(port_str));
     memset(if_name, '\0', sizeof(if_name));
-    strncpy(ip_str, ip_port_pair+1, global_scope ? i-1 : j-1);
-    strncpy(port_str, ip_port_pair+i+2, len-i-1);
+    strncpy(ip_str, ip_port_pair + 1, global_scope ? i - 1 : j - 1);
+    strncpy(port_str, ip_port_pair + i + 2, len - i - 1);
     int port = atoi(port_str);
-    if (!global_scope) strncpy(if_name, ip_port_pair+j+1, i-j-1); // If not global scope, we need the intf name
+    if (!global_scope) strncpy(if_name, ip_port_pair + j + 1, i - j - 1); // If not global scope, we need the intf name
 
     struct sockaddr_in6& sin6 = ua->sin6;
-    sin6.sin6_family = AF_INET6;                       // IPv6
-    inet_pton(AF_INET6, ip_str, &(sin6.sin6_addr));    // IP address
-    sin6.sin6_port = htons(port);                      // port
-    sin6.sin6_flowinfo = 0;                            // needed by IPv6, but possibly obsolete
-    sin6.sin6_scope_id = global_scope ? 0 : if_nametoindex(if_name);  // 0 if global scope; intf index if link scope
+    sin6.sin6_family = AF_INET6; // IPv6
+    inet_pton(AF_INET6, ip_str, &(sin6.sin6_addr)); // IP address
+    sin6.sin6_port = htons(port); // port
+    sin6.sin6_flowinfo = 0; // needed by IPv6, but possibly obsolete
+    sin6.sin6_scope_id = global_scope ? 0 : if_nametoindex(if_name); // 0 if global scope; intf index if link scope
   }
   return ncclSuccess;
 }
@@ -307,7 +306,7 @@ static ncclResult_t socketFinalizeAccept(struct ncclSocket* sock) {
   uint64_t magic;
   enum ncclSocketType type;
   int received;
-  char line[SOCKET_NAME_MAXLEN+1];
+  char line[SOCKET_NAME_MAXLEN + 1];
   // once accepted, linux sockets do NOT inherit file status flags such as O_NONBLOCK (BSD ones do)
   NCCLCHECK(ncclOsSocketSetFlags(sock));
 
@@ -349,7 +348,7 @@ static ncclResult_t socketFinalizeAccept(struct ncclSocket* sock) {
   }
   if (type != sock->type) {
     WARN("socketFinalizeAccept from %s: wrong type %d != %d", ncclSocketToString(&sock->addr, line), type, sock->type);
-    (void) ncclSocketClose(sock);
+    (void)ncclSocketClose(sock);
     sock->state = ncclSocketStateError;
     return ncclInternalError;
   } else {
@@ -415,7 +414,7 @@ static ncclResult_t socketProgressState(struct ncclSocket* sock) {
   return ncclSuccess;
 }
 
-ncclResult_t ncclSocketReady(struct ncclSocket* sock, int *running) {
+ncclResult_t ncclSocketReady(struct ncclSocket* sock, int* running) {
   if (sock == NULL) {
     *running = 0;
     return ncclSuccess;
@@ -434,7 +433,7 @@ ncclResult_t ncclSocketReady(struct ncclSocket* sock, int *running) {
 
 ncclResult_t ncclSocketConnect(struct ncclSocket* sock) {
 #ifdef ENABLE_TRACE
-  char line[SOCKET_NAME_MAXLEN+1];
+  char line[SOCKET_NAME_MAXLEN + 1];
 #endif
   if (sock == NULL) {
     WARN("ncclSocketConnect: pass NULL socket");
@@ -450,31 +449,30 @@ ncclResult_t ncclSocketConnect(struct ncclSocket* sock) {
     if (sock->state == ncclSocketStateError) return ncclRemoteError;
     return ncclInternalError;
   }
-  TRACE(NCCL_INIT|NCCL_NET,"Connecting to socket %s", ncclSocketToString(&sock->addr, line));
+  TRACE(NCCL_INIT | NCCL_NET, "Connecting to socket %s", ncclSocketToString(&sock->addr, line));
 
   sock->state = ncclSocketStateConnecting;
   sock->finalizeCounter = 0;
   do {
     NCCLCHECK(socketProgressState(sock));
   } while (sock->asyncFlag == 0 &&
-      (sock->abortFlag == NULL || COMPILER_ATOMIC_LOAD(sock->abortFlag, std::memory_order_acquire) == 0) &&
-      (sock->state == ncclSocketStateConnecting ||
-       sock->state == ncclSocketStateConnectPolling ||
-       sock->state == ncclSocketStateConnected));
+           (sock->abortFlag == NULL || COMPILER_ATOMIC_LOAD(sock->abortFlag, std::memory_order_acquire) == 0) &&
+           (sock->state == ncclSocketStateConnecting || sock->state == ncclSocketStateConnectPolling ||
+            sock->state == ncclSocketStateConnected));
 
   if (sock->abortFlag && COMPILER_ATOMIC_LOAD(sock->abortFlag, std::memory_order_acquire)) return ncclInternalError;
 
   switch (sock->state) {
-    case ncclSocketStateConnecting:
-    case ncclSocketStateConnectPolling:
-    case ncclSocketStateConnected:
-    case ncclSocketStateReady:
-      return ncclSuccess;
-    case ncclSocketStateError:
-      return ncclSystemError;
-    default:
-      WARN("ncclSocketConnect: wrong socket state %d", sock->state);
-      return ncclInternalError;
+  case ncclSocketStateConnecting:
+  case ncclSocketStateConnectPolling:
+  case ncclSocketStateConnected:
+  case ncclSocketStateReady:
+    return ncclSuccess;
+  case ncclSocketStateError:
+    return ncclSystemError;
+  default:
+    WARN("ncclSocketConnect: wrong socket state %d", sock->state);
+    return ncclInternalError;
   }
 }
 
@@ -488,10 +486,8 @@ ncclResult_t ncclSocketAccept(struct ncclSocket* sock, struct ncclSocket* listen
   }
   if (listenSock->state != ncclSocketStateReady) {
     WARN("ncclSocketAccept: wrong socket state %d", listenSock->state);
-    if (listenSock->state == ncclSocketStateError)
-      ret = ncclSystemError;
-    else
-      ret = ncclInternalError;
+    if (listenSock->state == ncclSocketStateError) ret = ncclSystemError;
+    else ret = ncclInternalError;
     goto exit;
   }
 
@@ -508,33 +504,33 @@ ncclResult_t ncclSocketAccept(struct ncclSocket* sock, struct ncclSocket* listen
       sock->state = ncclSocketStateAccepting;
     }
   } while (sock->asyncFlag == 0 &&
-      (sock->abortFlag == NULL || COMPILER_ATOMIC_LOAD(sock->abortFlag, std::memory_order_acquire) == 0) &&
-      (sock->state == ncclSocketStateAccepting ||
-       sock->state == ncclSocketStateAccepted));
+           (sock->abortFlag == NULL || COMPILER_ATOMIC_LOAD(sock->abortFlag, std::memory_order_acquire) == 0) &&
+           (sock->state == ncclSocketStateAccepting || sock->state == ncclSocketStateAccepted));
 
   if (sock->abortFlag && COMPILER_ATOMIC_LOAD(sock->abortFlag, std::memory_order_acquire)) return ncclInternalError;
 
   switch (sock->state) {
-    case ncclSocketStateAccepting:
-    case ncclSocketStateAccepted:
-    case ncclSocketStateReady:
-    case ncclSocketStateBadMagic:
-      ret = ncclSuccess;
-      break;
-    case ncclSocketStateError:
-      ret = ncclSystemError;
-      break;
-    default:
-      WARN("ncclSocketAccept: wrong socket state %d", sock->state);
-      ret = ncclInternalError;
-      break;
+  case ncclSocketStateAccepting:
+  case ncclSocketStateAccepted:
+  case ncclSocketStateReady:
+  case ncclSocketStateBadMagic:
+    ret = ncclSuccess;
+    break;
+  case ncclSocketStateError:
+    ret = ncclSystemError;
+    break;
+  default:
+    WARN("ncclSocketAccept: wrong socket state %d", sock->state);
+    ret = ncclInternalError;
+    break;
   }
 
 exit:
   return ret;
 }
 
-ncclResult_t ncclSocketInit(struct ncclSocket* sock, const union ncclSocketAddress* addr, uint64_t magic, enum ncclSocketType type, volatile uint32_t* abortFlag, int asyncFlag, int customRetry) {
+ncclResult_t ncclSocketInit(struct ncclSocket* sock, const union ncclSocketAddress* addr, uint64_t magic,
+                            enum ncclSocketType type, volatile uint32_t* abortFlag, int asyncFlag, int customRetry) {
   ncclResult_t ret = ncclSuccess;
 
   if (sock == NULL) goto exit;
@@ -557,9 +553,9 @@ ncclResult_t ncclSocketInit(struct ncclSocket* sock, const union ncclSocketAddre
     memcpy(&sock->addr, addr, sizeof(union ncclSocketAddress));
     family = sock->addr.sa.sa_family;
     if (family != AF_INET && family != AF_INET6) {
-      char line[SOCKET_NAME_MAXLEN+1];
+      char line[SOCKET_NAME_MAXLEN + 1];
       WARN("ncclSocketInit: connecting to address %s with family %d is neither AF_INET(%d) nor AF_INET6(%d)",
-          ncclSocketToString(&sock->addr, line), family, AF_INET, AF_INET6);
+           ncclSocketToString(&sock->addr, line), family, AF_INET, AF_INET6);
       ret = ncclInternalError;
       goto exit;
     }
@@ -570,12 +566,14 @@ ncclResult_t ncclSocketInit(struct ncclSocket* sock, const union ncclSocketAddre
     // [RCCL] Runtime socket options
     if (rcclParamSocketReuseAddr()) {
       int opt = 1;
-      SYSCHECKGOTO(setsockopt(sock->socketDescriptor, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)), "setsockopt", ret, fail);
+      SYSCHECKGOTO(setsockopt(sock->socketDescriptor, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)), "setsockopt", ret,
+                   fail);
     }
     int lingerParam = (int)rcclParamSocketLinger();
     if (lingerParam > -1) {
-      linger linger_opt = { 1, lingerParam };
-      SYSCHECKGOTO(setsockopt(sock->socketDescriptor, SOL_SOCKET, SO_LINGER, &linger_opt, sizeof(linger_opt)), "setsockopt", ret, fail);
+      linger linger_opt = {1, lingerParam};
+      SYSCHECKGOTO(setsockopt(sock->socketDescriptor, SOL_SOCKET, SO_LINGER, &linger_opt, sizeof(linger_opt)),
+                   "setsockopt", ret, fail);
     }
   } else {
     memset(&sock->addr, 0, sizeof(union ncclSocketAddress));
@@ -583,7 +581,7 @@ ncclResult_t ncclSocketInit(struct ncclSocket* sock, const union ncclSocketAddre
 exit:
   return ret;
 fail:
-  (void) ncclSocketClose(sock);
+  (void)ncclSocketClose(sock);
   goto exit;
 }
 
@@ -633,7 +631,8 @@ ncclResult_t ncclSocketRecv(struct ncclSocket* sock, void* ptr, int size) {
   return ncclSuccess;
 }
 
-ncclResult_t ncclSocketSendRecv(struct ncclSocket* sendSock, void* sendPtr, int sendSize, struct ncclSocket* recvSock, void* recvPtr, int recvSize) {
+ncclResult_t ncclSocketSendRecv(struct ncclSocket* sendSock, void* sendPtr, int sendSize, struct ncclSocket* recvSock,
+                                void* recvPtr, int recvSize) {
   int sendOffset = 0, recvOffset = 0;
   if (sendSock == NULL || recvSock == NULL) {
     WARN("ncclSocketSendRecv: invalid socket %p/%p", sendSock, recvSock);
@@ -690,7 +689,6 @@ ncclResult_t ncclSocketMultiOp(struct ncclSocketOp* ops, int numOps) {
   return ncclSuccess;
 }
 
-
 // Receive or detect connection closed
 ncclResult_t ncclSocketTryRecv(struct ncclSocket* sock, void* ptr, int size, int* closed, bool blocking) {
   int offset = 0;
@@ -715,7 +713,7 @@ ncclResult_t ncclSocketTryRecv(struct ncclSocket* sock, void* ptr, int size, int
         NCCLCHECK(ncclOsSocketProgressOpt(NCCL_SOCKET_RECV, sock, ptr, size, &offset, 0, closed));
         if (*closed) return ncclSuccess;
       }
-    // No bytes were received, return ncclInProgress
+      // No bytes were received, return ncclInProgress
     } else {
       return ncclInProgress;
     }

--- a/projects/rccl/src/misc/strongstream.cc
+++ b/projects/rccl/src/misc/strongstream.cc
@@ -73,9 +73,7 @@ void ncclCudaContextDrop(struct ncclCudaContext* cxt) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-ncclResult_t ncclCudaGetCapturingGraph(
-    struct ncclCudaGraph* graph, cudaStream_t stream, int graphUsageMode
-  ) {
+ncclResult_t ncclCudaGetCapturingGraph(struct ncclCudaGraph* graph, cudaStream_t stream, int graphUsageMode) {
 #if ROCM_VERSION >= 60100
   hipStreamCaptureStatus status;
   CUDACHECK(hipStreamGetCaptureInfo_v2(stream, &status, &graph->graphId, &graph->graph, nullptr, nullptr));
@@ -93,43 +91,41 @@ ncclResult_t ncclCudaGetCapturingGraph(
 }
 
 ncclResult_t ncclCudaGraphAddDestructor(struct ncclCudaGraph graph, cudaHostFn_t fn, void* arg) {
-  #if ROCM_VERSION >= 60100
-    cudaUserObject_t object;
-    CUDACHECK(cudaUserObjectCreate(
-      &object, arg, fn, /*initialRefcount=*/1, cudaUserObjectNoDestructorSync
-    ));
+#if ROCM_VERSION >= 60100
+  cudaUserObject_t object;
+  CUDACHECK(cudaUserObjectCreate(&object, arg, fn, /*initialRefcount=*/1, cudaUserObjectNoDestructorSync));
     // Hand over ownership to CUDA Graph
-    CUDACHECK(cudaGraphRetainUserObject(graph.graph, object, 1, cudaGraphUserObjectMove));
-    return ncclSuccess;
-  #else
-    return ncclInvalidUsage;
-  #endif
+  CUDACHECK(cudaGraphRetainUserObject(graph.graph, object, 1, cudaGraphUserObjectMove));
+  return ncclSuccess;
+#else
+  return ncclInvalidUsage;
+#endif
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 ncclResult_t ncclStrongStreamConstruct(struct ncclStrongStream* ss) {
   CUDACHECK(cudaStreamCreateWithFlags(&ss->liveStream, cudaStreamNonBlocking));
-  #if ROCM_VERSION >= 60100
-    ss->everCaptured = false;
-    ss->captureHead = nullptr;
-    CUDACHECK(cudaEventCreateWithFlags(&ss->serialEvent, cudaEventDisableTiming));
-  #endif
+#if ROCM_VERSION >= 60100
+  ss->everCaptured = false;
+  ss->captureHead = nullptr;
+  CUDACHECK(cudaEventCreateWithFlags(&ss->serialEvent, cudaEventDisableTiming));
+#endif
   return ncclSuccess;
 }
 
 ncclResult_t ncclStrongStreamDestruct(struct ncclStrongStream* ss) {
   CUDACHECK(cudaStreamDestroy(ss->liveStream));
-  #if ROCM_VERSION >= 60100
-    struct ncclStrongStreamCapture* cap = ss->captureHead;
-    while (cap) {
-      struct ncclStrongStreamCapture* next = cap->next;
-      CUDACHECK(cudaStreamDestroy(cap->captureStream));
-      free(cap);
-      cap = next;
-    }
-    CUDACHECK(cudaEventDestroy(ss->serialEvent));
-  #endif
+#if ROCM_VERSION >= 60100
+  struct ncclStrongStreamCapture* cap = ss->captureHead;
+  while (cap) {
+    struct ncclStrongStreamCapture* next = cap->next;
+    CUDACHECK(cudaStreamDestroy(cap->captureStream));
+    free(cap);
+    cap = next;
+  }
+  CUDACHECK(cudaEventDestroy(ss->serialEvent));
+#endif
   return ncclSuccess;
 }
 
@@ -137,200 +133,195 @@ NCCL_PARAM(LaunchRaceFatal, "LAUNCH_RACE_FATAL", 1);
 constexpr char const* launchRaceFatalMsg = "Fatal: host threads racing to launch NCCL on same device.";
 
 static thread_local char threadIdMarker;
-static void* localThreadId() { return &threadIdMarker; }
+static void* localThreadId() {
+  return &threadIdMarker;
+}
 
-ncclResult_t ncclStrongStreamAcquire(
-   struct ncclCudaGraph graph, struct ncclStrongStream* ss, bool concurrent,
-   cudaStream_t* workStream
-  ) {
-  #if ROCM_VERSION >= 60100
-    bool mixing = graph.graphUsageMode == 2;
-    if (graph.graphId == ULLONG_MAX) {
-      *workStream = ss->liveStream;
-      ss->liveAcquiredBy = localThreadId();
-      if (mixing && COMPILER_ATOMIC_LOAD(&ss->everCaptured, std::memory_order_relaxed)) {
-        CUDACHECK(cudaStreamWaitEvent(ss->liveStream, ss->serialEvent, 0));
-      }
-    } else {
-      bool firstCapture = !ss->everCaptured;
-      COMPILER_ATOMIC_STORE(&ss->everCaptured, true, std::memory_order_relaxed);
+ncclResult_t ncclStrongStreamAcquire(struct ncclCudaGraph graph, struct ncclStrongStream* ss, bool concurrent,
+                                     cudaStream_t* workStream) {
+#if ROCM_VERSION >= 60100
+  bool mixing = graph.graphUsageMode == 2;
+  if (graph.graphId == ULLONG_MAX) {
+    *workStream = ss->liveStream;
+    ss->liveAcquiredBy = localThreadId();
+    if (mixing && COMPILER_ATOMIC_LOAD(&ss->everCaptured, std::memory_order_relaxed)) {
+      CUDACHECK(cudaStreamWaitEvent(ss->liveStream, ss->serialEvent, 0));
+    }
+  } else {
+    bool firstCapture = !ss->everCaptured;
+    COMPILER_ATOMIC_STORE(&ss->everCaptured, true, std::memory_order_relaxed);
 
-      ncclResult_t ret = ncclSuccess;
-      std::unique_lock<std::mutex> lock(ss->mutex, std::defer_lock);
-      if (concurrent) lock.lock();
+    ncclResult_t ret = ncclSuccess;
+    std::unique_lock<std::mutex> lock(ss->mutex, std::defer_lock);
+    if (concurrent) lock.lock();
 
       // Look for capture in our list of active captures.
-      struct ncclStrongStreamCapture** pcap = &ss->captureHead;
-      struct ncclStrongStreamCapture* cap;
-      struct ncclStrongStreamCapture* spare = nullptr;
-      while (*pcap != nullptr) {
-        cap = *pcap;
-        if (cap->graphId == graph.graphId) { // Capture node already exists.
-          *workStream = cap->captureStream;
-          cap->acquiredBy = localThreadId();
-          return ncclSuccess;
-        } else {
-          cudaStreamCaptureStatus status;
-          CUDACHECKGOTO(cudaStreamIsCapturing(cap->captureStream, &status), ret, do_unlock);
-          if (status == cudaStreamCaptureStatusActive) {
-            pcap = &cap->next; // Active capture doesn't match, on to next.
-          } else { // Capture no longer active
-            *pcap = cap->next; // Remove from current list
-            if (spare == nullptr) { // Keep one spare to reuse below.
-              spare = cap;
-            } else {
-              CUDACHECKIGNORE(cudaStreamDestroy(cap->captureStream));
-              free(cap);
-            }
+    struct ncclStrongStreamCapture** pcap = &ss->captureHead;
+    struct ncclStrongStreamCapture* cap;
+    struct ncclStrongStreamCapture* spare = nullptr;
+    while (*pcap != nullptr) {
+      cap = *pcap;
+      if (cap->graphId == graph.graphId) { // Capture node already exists.
+        *workStream = cap->captureStream;
+        cap->acquiredBy = localThreadId();
+        return ncclSuccess;
+      } else {
+        cudaStreamCaptureStatus status;
+        CUDACHECKGOTO(cudaStreamIsCapturing(cap->captureStream, &status), ret, do_unlock);
+        if (status == cudaStreamCaptureStatusActive) {
+          pcap = &cap->next; // Active capture doesn't match, on to next.
+        } else { // Capture no longer active
+          *pcap = cap->next; // Remove from current list
+          if (spare == nullptr) { // Keep one spare to reuse below.
+            spare = cap;
+          } else {
+            CUDACHECKIGNORE(cudaStreamDestroy(cap->captureStream));
+            free(cap);
           }
         }
       }
+    }
       // No matching capture, need a new entry.
-      cap = spare;
+    cap = spare;
+    if (cap == nullptr) {
+      cap = (struct ncclStrongStreamCapture*)calloc(1, sizeof(struct ncclStrongStreamCapture));
       if (cap == nullptr) {
-        cap = (struct ncclStrongStreamCapture*)calloc(1, sizeof(struct ncclStrongStreamCapture));
-        if (cap == nullptr) {
-          ret = ncclSystemError;
-          goto do_unlock;
-        }
-        CUDACHECKGOTO(cudaStreamCreateWithFlags(&cap->captureStream, cudaStreamNonBlocking), ret, do_unlock);
+        ret = ncclSystemError;
+        goto do_unlock;
       }
-      cap->graphId = graph.graphId;
-      cap->acquiredBy = localThreadId();
+      CUDACHECKGOTO(cudaStreamCreateWithFlags(&cap->captureStream, cudaStreamNonBlocking), ret, do_unlock);
+    }
+    cap->graphId = graph.graphId;
+    cap->acquiredBy = localThreadId();
       // Push to capturing list.
-      cap->next = ss->captureHead;
-      ss->captureHead = cap;
+    cap->next = ss->captureHead;
+    ss->captureHead = cap;
 
-    do_unlock:
-      if (concurrent) lock.unlock();
-      if (ret != ncclSuccess) return ret;
+  do_unlock:
+    if (concurrent) lock.unlock();
+    if (ret != ncclSuccess) return ret;
 
-      *workStream = cap->captureStream;
+    *workStream = cap->captureStream;
 
       // Bring captureStream into the graph but without any dependencies.
-      cudaEvent_t scratch;
-      CUDACHECK(cudaEventCreateWithFlags(&scratch, cudaEventDisableTiming));
-      CUDACHECK(cudaEventRecord(scratch, graph.origin));
-      CUDACHECK(cudaStreamWaitEvent(cap->captureStream, scratch, 0));
-      CUDACHECK(cudaEventDestroy(scratch));
-      #if CUDART_VERSION >= 13000
-      CUDACHECK(cudaStreamUpdateCaptureDependencies_v2(cap->captureStream, nullptr, nullptr, 0, cudaStreamSetCaptureDependencies));
-      #else
-      CUDACHECK(cudaStreamUpdateCaptureDependencies(cap->captureStream, nullptr, 0, cudaStreamSetCaptureDependencies));
-      #endif
+    cudaEvent_t scratch;
+    CUDACHECK(cudaEventCreateWithFlags(&scratch, cudaEventDisableTiming));
+    CUDACHECK(cudaEventRecord(scratch, graph.origin));
+    CUDACHECK(cudaStreamWaitEvent(cap->captureStream, scratch, 0));
+    CUDACHECK(cudaEventDestroy(scratch));
+#if CUDART_VERSION >= 13000
+    CUDACHECK(cudaStreamUpdateCaptureDependencies_v2(cap->captureStream, nullptr, nullptr, 0,
+                                                     cudaStreamSetCaptureDependencies));
+#else
+    CUDACHECK(cudaStreamUpdateCaptureDependencies(cap->captureStream, nullptr, 0, cudaStreamSetCaptureDependencies));
+#endif
 
-      if (mixing && firstCapture) {
-        CUDACHECK(cudaEventRecord(ss->serialEvent, ss->liveStream));
-      }
-      if (mixing) {
-        // First dependency is to wait on serialEvent
-        CUDACHECK(cudaStreamWaitEvent(cap->captureStream, ss->serialEvent, 0));
-      }
+    if (mixing && firstCapture) {
+      CUDACHECK(cudaEventRecord(ss->serialEvent, ss->liveStream));
     }
-  #endif
+    if (mixing) {
+        // First dependency is to wait on serialEvent
+      CUDACHECK(cudaStreamWaitEvent(cap->captureStream, ss->serialEvent, 0));
+    }
+  }
+#endif
   return ncclSuccess;
 }
 
-ncclResult_t ncclStrongStreamAcquiredWorkStream(
-    struct ncclCudaGraph graph, struct ncclStrongStream* ss, bool concurrent,
-    cudaStream_t* workStream
-  ) {
-  #if ROCM_VERSION >= 60100
+ncclResult_t ncclStrongStreamAcquiredWorkStream(struct ncclCudaGraph graph, struct ncclStrongStream* ss,
+                                                bool concurrent, cudaStream_t* workStream) {
+#if ROCM_VERSION >= 60100
+  if (graph.graphId == ULLONG_MAX) {
+    *workStream = ss->liveStream;
+  } else {
+    std::unique_lock<std::mutex> lock(ss->mutex, std::defer_lock);
+    if (concurrent) lock.lock();
+    struct ncclStrongStreamCapture* cap = ss->captureHead;
+    while (cap->graphId != graph.graphId) cap = cap->next;
+    *workStream = cap->captureStream;
+  }
+#else
+  *workStream = ss->liveStream
+#endif
+  return ncclSuccess;
+}
+
+ncclResult_t ncclStrongStreamRelease(struct ncclCudaGraph graph, struct ncclStrongStream* ss, bool concurrent) {
+#if ROCM_VERSION >= 60100
+  bool mixing = graph.graphUsageMode == 2;
+  if (mixing) {
     if (graph.graphId == ULLONG_MAX) {
-      *workStream = ss->liveStream;
+      if (COMPILER_ATOMIC_LOAD(&ss->everCaptured, std::memory_order_relaxed)) {
+        CUDACHECK(cudaEventRecord(ss->serialEvent, ss->liveStream));
+      }
+      if (ss->liveAcquiredBy != localThreadId() && ncclParamLaunchRaceFatal()) {
+        ERROR("%s", launchRaceFatalMsg);
+        return ncclInvalidUsage;
+      }
     } else {
       std::unique_lock<std::mutex> lock(ss->mutex, std::defer_lock);
       if (concurrent) lock.lock();
       struct ncclStrongStreamCapture* cap = ss->captureHead;
       while (cap->graphId != graph.graphId) cap = cap->next;
-      *workStream = cap->captureStream;
-    }
-  #else
-    *workStream = ss->liveStream
-  #endif
-  return ncclSuccess;
-}
-
-ncclResult_t ncclStrongStreamRelease(
-    struct ncclCudaGraph graph, struct ncclStrongStream* ss, bool concurrent
-  ) {
-  #if ROCM_VERSION >= 60100
-    bool mixing = graph.graphUsageMode == 2;
-    if (mixing) {
-      if (graph.graphId == ULLONG_MAX) {
-        if (COMPILER_ATOMIC_LOAD(&ss->everCaptured, std::memory_order_relaxed)) {
-          CUDACHECK(cudaEventRecord(ss->serialEvent, ss->liveStream));
-        }
-        if (ss->liveAcquiredBy != localThreadId() && ncclParamLaunchRaceFatal()) {
-          ERROR("%s", launchRaceFatalMsg);
-          return ncclInvalidUsage;
-        }
-      } else {
-        std::unique_lock<std::mutex> lock(ss->mutex, std::defer_lock);
-        if (concurrent) lock.lock();
-        struct ncclStrongStreamCapture* cap = ss->captureHead;
-        while (cap->graphId != graph.graphId) cap = cap->next;
-        if (concurrent) lock.unlock();
+      if (concurrent) lock.unlock();
 
         // Add event record node with dependencies added further down.
-        cudaGraphNode_t recordNode;
-        CUDACHECK(cudaGraphAddEventRecordNode(&recordNode, graph.graph, nullptr, 0, ss->serialEvent));
+      cudaGraphNode_t recordNode;
+      CUDACHECK(cudaGraphAddEventRecordNode(&recordNode, graph.graph, nullptr, 0, ss->serialEvent));
 
         // Get current nodes from work stream so we can add them as dependencies.
-        cudaStreamCaptureStatus status;
-        cudaGraphNode_t const* nodes;
-        size_t count = 0;
-        #if CUDART_VERSION >= 13000
-        cudaError_t res = hipStreamGetCaptureInfo_v3(cap->captureStream, &status, nullptr, nullptr, &nodes, nullptr, &count);
-        #else
-        cudaError_t res = hipStreamGetCaptureInfo_v2(cap->captureStream, &status, nullptr, nullptr, &nodes, &count);
-        #endif
+      cudaStreamCaptureStatus status;
+      cudaGraphNode_t const* nodes;
+      size_t count = 0;
+#if CUDART_VERSION >= 13000
+      cudaError_t res =
+        hipStreamGetCaptureInfo_v3(cap->captureStream, &status, nullptr, nullptr, &nodes, nullptr, &count);
+#else
+      cudaError_t res = hipStreamGetCaptureInfo_v2(cap->captureStream, &status, nullptr, nullptr, &nodes, &count);
+#endif
 
-        #if CUDART_VERSION >= 12030
-        if (res == cudaErrorLossyQuery) { // CUDA is telling us the dependencies have edge annotations.
-          cudaGraphEdgeData const* edges;
-          CUDACHECK(cudaStreamGetCaptureInfo_v3(cap->captureStream, &status, nullptr, nullptr, &nodes, &edges, &count));
-          for (int i=0; i < (int)count; i++) {
-            CUDACHECK(cudaGraphAddDependencies_v2(graph.graph, &nodes[i], &recordNode, &edges[i], 1));
-          }
-        }
-        #else
-        if (false) {}
-        #endif
-        else {
-          CUDACHECK(res /* = cudaStreamGetCaptureInfo_v2(...)*/);
-          for (int i=0; i < (int)count; i++) {
-          #if CUDART_VERSION >= 13000
-            CUDACHECK(cudaGraphAddDependencies_v2(graph.graph, &nodes[i], &recordNode, nullptr, 1));
-          #else
-            CUDACHECK(cudaGraphAddDependencies(graph.graph, &nodes[i], &recordNode, 1));
-          #endif
-          }
-        }
-
-	// Make every future operation captured on cap->captureStream depend on 'recordNode'.
-        #if CUDART_VERSION >= 13000
-        CUDACHECK(cudaStreamUpdateCaptureDependencies_v2(
-                    cap->captureStream,
-                    &recordNode,          /* dependencies                */
-                    /*edges =*/ nullptr,  /* no edge annotations         */
-                    1,                    /* count                       */
-                    cudaStreamSetCaptureDependencies));
-        #else
-        CUDACHECK(cudaStreamUpdateCaptureDependencies(
-                    cap->captureStream,
-                    &recordNode,
-                    1,
-                    cudaStreamSetCaptureDependencies));
-        #endif
-
-        if (cap->acquiredBy != localThreadId() && ncclParamLaunchRaceFatal()) {
-          ERROR("%s", launchRaceFatalMsg);
-          return ncclInvalidUsage;
+#if CUDART_VERSION >= 12030
+      if (res == cudaErrorLossyQuery) { // CUDA is telling us the dependencies have edge annotations.
+        cudaGraphEdgeData const* edges;
+        CUDACHECK(cudaStreamGetCaptureInfo_v3(cap->captureStream, &status, nullptr, nullptr, &nodes, &edges, &count));
+        for (int i = 0; i < (int)count; i++) {
+          CUDACHECK(cudaGraphAddDependencies_v2(graph.graph, &nodes[i], &recordNode, &edges[i], 1));
         }
       }
+#else
+      if (false) {
+      }
+#endif
+      else {
+        CUDACHECK(res /* = cudaStreamGetCaptureInfo_v2(...)*/);
+        for (int i = 0; i < (int)count; i++) {
+#if CUDART_VERSION >= 13000
+          CUDACHECK(cudaGraphAddDependencies_v2(graph.graph, &nodes[i], &recordNode, nullptr, 1));
+#else
+          CUDACHECK(cudaGraphAddDependencies(graph.graph, &nodes[i], &recordNode, 1));
+#endif
+        }
+      }
+
+        // Make every future operation captured on cap->captureStream depend on 'recordNode'.
+#if CUDART_VERSION >= 13000
+      CUDACHECK(cudaStreamUpdateCaptureDependencies_v2(cap->captureStream,
+                                                       &recordNode,          /* dependencies                */
+                                                       /*edges =*/nullptr,  /* no edge annotations         */
+                                                       1,                    /* count                       */
+                                                       cudaStreamSetCaptureDependencies));
+#else
+      CUDACHECK(cudaStreamUpdateCaptureDependencies(cap->captureStream, &recordNode, 1,
+                                                    cudaStreamSetCaptureDependencies));
+#endif
+
+      if (cap->acquiredBy != localThreadId() && ncclParamLaunchRaceFatal()) {
+        ERROR("%s", launchRaceFatalMsg);
+        return ncclInvalidUsage;
+      }
     }
-  #endif
+  }
+#endif
   return ncclSuccess;
 }
 
@@ -351,28 +342,32 @@ ncclResult_t ncclStreamAdvanceToEvent(struct ncclCudaGraph g, cudaStream_t s, cu
     cudaStreamCaptureStatus status;
     cudaGraphNode_t const* nodes;
     size_t count = 0;
-    #if CUDART_VERSION >= 13000
+#if CUDART_VERSION >= 13000
     cudaError_t res = hipStreamGetCaptureInfo_v3(tmp, &status, nullptr, nullptr, &nodes, nullptr, &count);
-    #else
+#else
     cudaError_t res = hipStreamGetCaptureInfo_v2(tmp, &status, nullptr, nullptr, &nodes, &count);
-    #endif
+#endif
 
-    #if CUDART_VERSION >= 12030
+#if CUDART_VERSION >= 12030
     if (res == cudaErrorLossyQuery) { // CUDA is telling us the dependencies have edge annotations.
       cudaGraphEdgeData const* edges;
       CUDACHECK(cudaStreamGetCaptureInfo_v3(tmp, &status, nullptr, nullptr, &nodes, &edges, &count));
-      CUDACHECK(cudaStreamUpdateCaptureDependencies_v2(s, (cudaGraphNode_t*)nodes, edges, count, cudaStreamSetCaptureDependencies));
+      CUDACHECK(cudaStreamUpdateCaptureDependencies_v2(s, (cudaGraphNode_t*)nodes, edges, count,
+                                                       cudaStreamSetCaptureDependencies));
     }
-    #else
-    if (false) {}
-    #endif
+#else
+    if (false) {
+    }
+#endif
     else {
       CUDACHECK(res /* = cudaStreamGetCaptureInfo_v2(...)*/);
-    #if CUDART_VERSION >= 13000
-      CUDACHECK(cudaStreamUpdateCaptureDependencies_v2(s, (cudaGraphNode_t*)nodes, nullptr, count, cudaStreamSetCaptureDependencies));
-    #else
-      CUDACHECK(cudaStreamUpdateCaptureDependencies(s, (cudaGraphNode_t*)nodes, count, cudaStreamSetCaptureDependencies));
-    #endif
+#if CUDART_VERSION >= 13000
+      CUDACHECK(cudaStreamUpdateCaptureDependencies_v2(s, (cudaGraphNode_t*)nodes, nullptr, count,
+                                                       cudaStreamSetCaptureDependencies));
+#else
+      CUDACHECK(cudaStreamUpdateCaptureDependencies(s, (cudaGraphNode_t*)nodes, count,
+                                                    cudaStreamSetCaptureDependencies));
+#endif
     }
 
     CUDACHECK(cudaStreamDestroy(tmp));
@@ -381,9 +376,9 @@ ncclResult_t ncclStreamAdvanceToEvent(struct ncclCudaGraph g, cudaStream_t s, cu
 }
 
 ncclResult_t ncclStrongStreamSynchronize(struct ncclStrongStream* ss) {
-  #if ROCM_VERSION >= 60100
-    CUDACHECK(cudaStreamWaitEvent(ss->liveStream, ss->serialEvent, 0));
-  #endif
+#if ROCM_VERSION >= 60100
+  CUDACHECK(cudaStreamWaitEvent(ss->liveStream, ss->serialEvent, 0));
+#endif
   CUDACHECK(cudaStreamSynchronize(ss->liveStream));
   return ncclSuccess;
 }

--- a/projects/rccl/src/misc/utils.cc
+++ b/projects/rccl/src/misc/utils.cc
@@ -22,12 +22,11 @@ int ncclCudaCompCap() {
   int ccMajor, ccMinor;
   if (!CUDASUCCESS(cudaDeviceGetAttribute(&ccMajor, cudaDevAttrComputeCapabilityMajor, cudaDev))) return 0;
   if (!CUDASUCCESS(cudaDeviceGetAttribute(&ccMinor, cudaDevAttrComputeCapabilityMinor, cudaDev))) return 0;
-  return ccMajor*10+ccMinor;
+  return ccMajor * 10 + ccMinor;
 }
 
 ncclResult_t int64ToBusId(int64_t id, char* busId) {
-  sprintf(busId, "%04lx:%02lx:%02lx.%01lx",
-          (unsigned long)((id) >> 20), (unsigned long)((id & 0xff000) >> 12),
+  sprintf(busId, "%04lx:%02lx:%02lx.%01lx", (unsigned long)((id) >> 20), (unsigned long)((id & 0xff000) >> 12),
           (unsigned long)((id & 0xff0) >> 4), (unsigned long)(id & 0xf));
   return ncclSuccess;
 }
@@ -38,9 +37,7 @@ ncclResult_t busIdToInt64(const char* busId, int64_t* id) {
   for (int i = 0; hexOffset < sizeof(hexStr) - 1; i++) {
     char c = busId[i];
     if (c == '.' || c == ':') continue;
-    if ((c >= '0' && c <= '9') ||
-        (c >= 'A' && c <= 'F') ||
-        (c >= 'a' && c <= 'f')) {
+    if ((c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f')) {
       hexStr[hexOffset++] = busId[i];
     } else break;
   }
@@ -51,7 +48,7 @@ ncclResult_t busIdToInt64(const char* busId, int64_t* id) {
 
 // Get an int64 from a PCI path. For example, sys/class/pci0000:00/0000:00:02.0/0000:02:00.0/ will return 0x000002000.
 ncclResult_t pciPathToInt64(char* path, int64_t* id) {
-  char* str = path+strlen(path)-1;
+  char* str = path + strlen(path) - 1;
   // Remove trailing "/"
   if (*str == '/') str--;
   // Find next /
@@ -62,7 +59,7 @@ ncclResult_t pciPathToInt64(char* path, int64_t* id) {
 }
 
 // Convert a logical cudaDev index to the NVML device minor number
-ncclResult_t getBusId(int cudaDev, int64_t *busId) {
+ncclResult_t getBusId(int cudaDev, int64_t* busId) {
   // On most systems, the PCI bus ID comes back as in the 0000:00:00.0
   // format. Still need to allocate proper space in case PCI domain goes
   // higher.
@@ -78,7 +75,7 @@ ncclResult_t getHostName(char* hostname, int maxlen, const char delim) {
     return ncclSystemError;
   }
   int i = 0;
-  while ((hostname[i] != delim) && (hostname[i] != '\0') && (i < maxlen-1)) i++;
+  while ((hostname[i] != delim) && (hostname[i] != '\0') && (i < maxlen - 1)) i++;
   hostname[i] = '\0';
   return ncclSuccess;
 }
@@ -101,22 +98,13 @@ static uint64_t hostHashValue = 0;
 /* Get Windows MachineGuid - similar to boot_id on Linux */
 static bool getWindowsMachineGuid(char* guid, size_t len) {
   HKEY hKey;
-  LONG result = RegOpenKeyExA(HKEY_LOCAL_MACHINE,
-                               "SOFTWARE\\Microsoft\\Cryptography",
-                               0,
-                               KEY_READ,
-                               &hKey);
+  LONG result = RegOpenKeyExA(HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Cryptography", 0, KEY_READ, &hKey);
   if (result != ERROR_SUCCESS) {
     return false;
   }
   DWORD dataSize = (DWORD)len;
   DWORD dataType;
-  result = RegQueryValueExA(hKey,
-                            "MachineGuid",
-                            NULL,
-                            &dataType,
-                            (LPBYTE)guid,
-                            &dataSize);
+  result = RegQueryValueExA(hKey, "MachineGuid", NULL, &dataType, (LPBYTE)guid, &dataSize);
   RegCloseKey(hKey);
   if (result != ERROR_SUCCESS || dataType != REG_SZ) {
     return false;
@@ -127,23 +115,23 @@ static bool getWindowsMachineGuid(char* guid, size_t len) {
 
 static void getHostHashOnce() {
   char hostHash[1024];
-  const char *hostId;
+  const char* hostId;
 
   // Fall back is the full hostname if something fails
-  (void) getHostName(hostHash, sizeof(hostHash), '\0');
+  (void)getHostName(hostHash, sizeof(hostHash), '\0');
   int offset = strlen(hostHash);
 
   if ((hostId = ncclGetEnv("NCCL_HOSTID")) != NULL) {
     INFO(NCCL_ENV, "NCCL_HOSTID set by environment to %s", hostId);
-    strncpy(hostHash, hostId, sizeof(hostHash)-1);
-    hostHash[sizeof(hostHash)-1] = '\0';
+    strncpy(hostHash, hostId, sizeof(hostHash) - 1);
+    hostHash[sizeof(hostHash) - 1] = '\0';
   } else {
 #if defined(NCCL_OS_LINUX)
-    FILE *file = fopen(HOSTID_FILE, "r");
+    FILE* file = fopen(HOSTID_FILE, "r");
     if (file != NULL) {
-      char *p;
+      char* p;
       if (fscanf(file, "%ms", &p) == 1) {
-        strncpy(hostHash+offset, p, sizeof(hostHash)-offset-1);
+        strncpy(hostHash + offset, p, sizeof(hostHash) - offset - 1);
         free(p);
       }
       fclose(file);
@@ -151,15 +139,15 @@ static void getHostHashOnce() {
 #elif defined(NCCL_OS_WINDOWS)
     char machineGuid[256];
     if (getWindowsMachineGuid(machineGuid, sizeof(machineGuid))) {
-      strncpy(hostHash+offset, machineGuid, sizeof(hostHash)-offset-1);
+      strncpy(hostHash + offset, machineGuid, sizeof(hostHash) - offset - 1);
     }
 #endif
   }
 
   // Make sure the string is terminated
-  hostHash[sizeof(hostHash)-1]='\0';
+  hostHash[sizeof(hostHash) - 1] = '\0';
 
-  TRACE(NCCL_INIT,"unique hostname '%s'", hostHash);
+  TRACE(NCCL_INIT, "unique hostname '%s'", hostHash);
 
   hostHashValue = getHash(hostHash, strlen(hostHash));
 }
@@ -184,15 +172,15 @@ uint64_t hashCombine(uint64_t baseHash, uint64_t value) {
 uint64_t getPidHash(void) {
   char pname[1024];
   // Start off with our pid ($$)
-  sprintf(pname, "%ld", (long) ncclOsGetPid());
+  sprintf(pname, "%ld", (long)ncclOsGetPid());
   int plen = strlen(pname);
 #if defined(NCCL_OS_LINUX)
-  int len = readlink("/proc/self/ns/pid", pname+plen, sizeof(pname)-1-plen);
+  int len = readlink("/proc/self/ns/pid", pname + plen, sizeof(pname) - 1 - plen);
   if (len < 0) len = 0;
   plen += len;
 #endif
-  pname[plen]='\0';
-  TRACE(NCCL_INIT,"unique PID '%s'", pname);
+  pname[plen] = '\0';
+  TRACE(NCCL_INIT, "unique PID '%s'", pname);
 
   return getHash(pname, strlen(pname));
 }
@@ -210,15 +198,17 @@ int parseStringList(const char* string, struct netIf* ifList, int maxList) {
     if (c == ':') {
       if (ifC > 0) {
         ifList[ifNum].prefix[ifC] = '\0';
-        ifList[ifNum].port = atoi(ptr+1);
-        ifNum++; ifC = 0;
+        ifList[ifNum].port = atoi(ptr + 1);
+        ifNum++;
+        ifC = 0;
       }
       while (c != ',' && c != '\0') c = *(++ptr);
     } else if (c == ',' || c == '\0') {
       if (ifC > 0) {
         ifList[ifNum].prefix[ifC] = '\0';
         ifList[ifNum].port = -1;
-        ifNum++; ifC = 0;
+        ifNum++;
+        ifC = 0;
       }
     } else {
       ifList[ifNum].prefix[ifC] = c;
@@ -242,14 +232,12 @@ static bool matchPort(const int port1, const int port2) {
   return false;
 }
 
-
 bool matchIfList(const char* string, int port, struct netIf* ifList, int listSize, bool matchExact) {
   // Make an exception for the case where no user list is defined
   if (listSize == 0) return true;
 
-  for (int i=0; i<listSize; i++) {
-    if (matchIf(string, ifList[i].prefix, matchExact)
-        && matchPort(port, ifList[i].port)) {
+  for (int i = 0; i < listSize; i++) {
+    if (matchIf(string, ifList[i].prefix, matchExact) && matchPort(port, ifList[i].port)) {
       return true;
     }
   }
@@ -266,14 +254,13 @@ void* ncclMemoryStack::allocateSpilled(struct ncclMemoryStack* me, size_t size, 
 
   // If we have lots of space left in hunk but that wasn't enough then we'll
   // allocate the object unhunked.
-  if (me->topFrame.end - me->topFrame.bumper >= 8<<10)
-    goto unhunked;
+  if (me->topFrame.end - me->topFrame.bumper >= 8 << 10) goto unhunked;
 
   // If we have another hunk (which must be empty) waiting above this one and
   // the object fits then use that.
   if (top && top->above) {
     struct Hunk* top1 = top->above;
-    uintptr_t uobj = (reinterpret_cast<uintptr_t>(top1) + sizeof(struct Hunk) + align-1) & -uintptr_t(align);
+    uintptr_t uobj = (reinterpret_cast<uintptr_t>(top1) + sizeof(struct Hunk) + align - 1) & -uintptr_t(align);
     if (uobj + size <= reinterpret_cast<uintptr_t>(top1) + top1->size) {
       me->topFrame.hunk = top1;
       me->topFrame.bumper = uobj + size;
@@ -284,19 +271,18 @@ void* ncclMemoryStack::allocateSpilled(struct ncclMemoryStack* me, size_t size, 
 
   { // If the next hunk we're going to allocate wouldn't be big enough but the
     // Unhunk proxy fits in the current hunk then go allocate as unhunked.
-    size_t nextSize = (top ? top->size : 0) + (64<<10);
+    size_t nextSize = (top ? top->size : 0) + (64 << 10);
     constexpr size_t maxAlign = 64;
     if (nextSize < sizeof(struct Hunk) + maxAlign + size) {
-      uintptr_t uproxy = (me->topFrame.bumper + alignof(Unhunk)-1) & -uintptr_t(alignof(Unhunk));
-      if (uproxy + sizeof(struct Unhunk) <= me->topFrame.end)
-        goto unhunked;
+      uintptr_t uproxy = (me->topFrame.bumper + alignof(Unhunk) - 1) & -uintptr_t(alignof(Unhunk));
+      if (uproxy + sizeof(struct Unhunk) <= me->topFrame.end) goto unhunked;
     }
 
     // At this point we must need another hunk, either to fit the object
     // itself or its Unhunk proxy.
     mallocSize = nextSize;
     INFO(NCCL_ALLOC, "%s:%d memory stack hunk malloc(%llu)", __FILE__, __LINE__, (unsigned long long)mallocSize);
-    struct Hunk *top1 = (struct Hunk*)malloc(mallocSize);
+    struct Hunk* top1 = (struct Hunk*)malloc(mallocSize);
     if (top1 == nullptr) goto malloc_exhausted;
     top1->size = nextSize;
     top1->above = nullptr;
@@ -308,7 +294,7 @@ void* ncclMemoryStack::allocateSpilled(struct ncclMemoryStack* me, size_t size, 
   }
 
   { // Try to fit object in the new top hunk.
-    uintptr_t uobj = (me->topFrame.bumper + align-1) & -uintptr_t(align);
+    uintptr_t uobj = (me->topFrame.bumper + align - 1) & -uintptr_t(align);
     if (uobj + size <= me->topFrame.end) {
       me->topFrame.bumper = uobj + size;
       return reinterpret_cast<void*>(uobj);
@@ -318,7 +304,7 @@ void* ncclMemoryStack::allocateSpilled(struct ncclMemoryStack* me, size_t size, 
 unhunked:
   { // We need to allocate the object out-of-band and put an Unhunk proxy in-band
     // to keep track of it.
-    uintptr_t uproxy = (me->topFrame.bumper + alignof(Unhunk)-1) & -uintptr_t(alignof(Unhunk));
+    uintptr_t uproxy = (me->topFrame.bumper + alignof(Unhunk) - 1) & -uintptr_t(alignof(Unhunk));
     Unhunk* proxy = reinterpret_cast<Unhunk*>(uproxy);
     me->topFrame.bumper = uproxy + sizeof(Unhunk);
     proxy->next = me->topFrame.unhunks;
@@ -331,7 +317,8 @@ unhunked:
   }
 
 malloc_exhausted:
-  WARN("%s:%d Unrecoverable error detected: malloc(size=%llu) returned null.", __FILE__, __LINE__, (unsigned long long)mallocSize);
+  WARN("%s:%d Unrecoverable error detected: malloc(size=%llu) returned null.", __FILE__, __LINE__,
+       (unsigned long long)mallocSize);
   abort();
 }
 
@@ -349,16 +336,16 @@ void ncclMemoryStackDestruct(struct ncclMemoryStack* me) {
   // Free hunks
   struct ncclMemoryStack::Hunk* h = me->stub.above;
   while (h != nullptr) {
-    struct ncclMemoryStack::Hunk *h1 = h->above;
+    struct ncclMemoryStack::Hunk* h1 = h->above;
     free(h);
     h = h1;
   }
 }
 
 /* return concatenated string representing each set bit */
-ncclResult_t ncclBitsToString(uint32_t bits, uint32_t mask, const char* (*toStr)(int), char *buf, size_t bufLen, const char *wildcard) {
-  if (!buf || !bufLen)
-    return ncclInvalidArgument;
+ncclResult_t ncclBitsToString(uint32_t bits, uint32_t mask, const char* (*toStr)(int), char* buf, size_t bufLen,
+                              const char* wildcard) {
+  if (!buf || !bufLen) return ncclInvalidArgument;
 
   bits &= mask;
 
@@ -382,21 +369,21 @@ ncclResult_t ncclBitsToString(uint32_t bits, uint32_t mask, const char* (*toStr)
 
 size_t get_sc_page_size() {
   static size_t cached_page_size = 0;
-  size_t ps = __atomic_load_n(&cached_page_size,__ATOMIC_RELAXED);
+  size_t ps = __atomic_load_n(&cached_page_size, __ATOMIC_RELAXED);
   if (ps == 0) {
-      ps = (size_t)sysconf(_SC_PAGESIZE);
-      __atomic_store_n(&cached_page_size, ps,__ATOMIC_RELAXED);
+    ps = (size_t)sysconf(_SC_PAGESIZE);
+    __atomic_store_n(&cached_page_size, ps, __ATOMIC_RELAXED);
   }
   return ps;
 }
 
-void get_aligned_ptr_and_size(const void *ptr, const size_t bufsize, void **aligned_ptr, size_t *aligned_size) {
+void get_aligned_ptr_and_size(const void* ptr, const size_t bufsize, void** aligned_ptr, size_t* aligned_size) {
   if (!aligned_ptr || !aligned_size) return;
   const size_t page_size = get_sc_page_size();
   uintptr_t aligned_ptr_local = (uintptr_t)ptr & ~(page_size - 1);
   size_t local_offset = (size_t)((uintptr_t)ptr - aligned_ptr_local);
   *aligned_size = (bufsize + local_offset + page_size - 1) & ~(page_size - 1);
-  *aligned_ptr = (void *)aligned_ptr_local;
+  *aligned_ptr = (void*)aligned_ptr_local;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -404,9 +391,9 @@ void get_aligned_ptr_and_size(const void *ptr, const size_t bufsize, void **alig
 // Uses shadowpool's algorithm
 uint64_t ncclHashPointer(int hbits, void* key) {
   uintptr_t h = reinterpret_cast<uintptr_t>(key);
-  h ^= h>>32;
+  h ^= h >> 32;
   h *= 0x9e3779b97f4a7c13;
-  return (uint64_t)h >> (64-hbits);
+  return (uint64_t)h >> (64 - hbits);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -431,10 +418,8 @@ static inline void writeNextPtr(void* object, int nextFieldOffset, void* value) 
   memcpy(nextPtr, &value, sizeof(void*));
 }
 
-ncclResult_t ncclIntruAddressMapInsert_untyped(
-    struct ncclIntruAddressMap_untyped* map,
-    int keySize, int keyFieldOffset, int nextFieldOffset,
-    uintptr_t key, void* object) {
+ncclResult_t ncclIntruAddressMapInsert_untyped(struct ncclIntruAddressMap_untyped* map, int keySize, int keyFieldOffset,
+                                               int nextFieldOffset, uintptr_t key, void* object) {
   if (map == nullptr) {
     WARN("Intrusive address map pointer is NULL");
     return ncclInvalidUsage;
@@ -450,21 +435,21 @@ ncclResult_t ncclIntruAddressMapInsert_untyped(
 
   if (map->hbits == 0) {
     map->hbits = 4;
-    map->table = (void**)calloc((size_t)1<<map->hbits, sizeof(void*));
+    map->table = (void**)calloc((size_t)1 << map->hbits, sizeof(void*));
     if (map->table == nullptr) {
       map->hbits = 0; // Reset on failure
-      WARN("Intrusive address map initialization failed: calloc(%zu entries) returned null", (size_t)1<<map->hbits);
+      WARN("Intrusive address map initialization failed: calloc(%zu entries) returned null", (size_t)1 << map->hbits);
       return ncclSystemError;
     }
   }
 
   int hbits = map->hbits;
 
-  if (map->count+1 > 2<<hbits) {
+  if (map->count + 1 > 2 << hbits) {
     int oldHbits = hbits;
-    int oldSize = 1<<oldHbits;
+    int oldSize = 1 << oldHbits;
     int newHbits = hbits + 1;
-    int newSize = 1<<newHbits;
+    int newSize = 1 << newHbits;
 
     void** newTable = (void**)malloc(newSize * sizeof(void*));
     if (newTable == nullptr) {
@@ -498,7 +483,8 @@ ncclResult_t ncclIntruAddressMapInsert_untyped(
   void* currentNext = readNextPtr(object, nextFieldOffset);
 
   if (currentNext != nullptr) {
-    INFO(NCCL_INIT, "Intrusive map: inserting object %p with non-NULL next pointer %p (key=0x%lx). "
+    INFO(NCCL_INIT,
+         "Intrusive map: inserting object %p with non-NULL next pointer %p (key=0x%lx). "
          "Object may already be in another list or this is intentional reuse.",
          object, currentNext, (unsigned long)key);
   }
@@ -510,10 +496,8 @@ ncclResult_t ncclIntruAddressMapInsert_untyped(
   return ncclSuccess;
 }
 
-ncclResult_t ncclIntruAddressMapFind_untyped(
-    struct ncclIntruAddressMap_untyped* map,
-    int keySize, int keyFieldOffset, int nextFieldOffset,
-    uintptr_t key, void** object) {
+ncclResult_t ncclIntruAddressMapFind_untyped(struct ncclIntruAddressMap_untyped* map, int keySize, int keyFieldOffset,
+                                             int nextFieldOffset, uintptr_t key, void** object) {
   if (map == nullptr) {
     WARN("Intrusive address map pointer is NULL");
     return ncclInvalidUsage;
@@ -548,10 +532,8 @@ ncclResult_t ncclIntruAddressMapFind_untyped(
   return ncclSuccess;
 }
 
-ncclResult_t ncclIntruAddressMapRemove_untyped(
-    struct ncclIntruAddressMap_untyped* map,
-    int keySize, int keyFieldOffset, int nextFieldOffset,
-    uintptr_t key) {
+ncclResult_t ncclIntruAddressMapRemove_untyped(struct ncclIntruAddressMap_untyped* map, int keySize, int keyFieldOffset,
+                                               int nextFieldOffset, uintptr_t key) {
   if (map == nullptr) {
     WARN("Intrusive address map pointer is NULL");
     return ncclInvalidUsage;

--- a/projects/rccl/src/mnnvl.cc
+++ b/projects/rccl/src/mnnvl.cc
@@ -22,7 +22,7 @@ ncclResult_t ncclMnnvlCheck(struct ncclComm* comm) {
   CUDACHECK(cudaGetDevice(&cudaDev));
   CUDACHECK(cuDeviceGet(&currentDev, cudaDev));
   // Ignore error if CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED is not supported
-  (void) cuDeviceGetAttribute(&flag, CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED, currentDev);
+  (void)cuDeviceGetAttribute(&flag, CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED, currentDev);
   if (!flag) return ncclSuccess;
 
 #if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
@@ -37,8 +37,8 @@ ncclResult_t ncclMnnvlCheck(struct ncclComm* comm) {
   for (int i = 0; i < comm->nRanks; i++) {
     if ((comm->peerInfo[i].fabricInfo.state != AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_ACTIVE) &&
         (comm->peerInfo[i].fabricInfo.state != AMDSMI_FABRIC_ACCELERATOR_VPOD_STATE_READY)) {
-      INFO(NCCL_INIT, "MNNVL disabled: peer %d fabric state %d is not ACTIVE or READY; falling back to RDMA",
-           i, comm->peerInfo[i].fabricInfo.state);
+      INFO(NCCL_INIT, "MNNVL disabled: peer %d fabric state %d is not ACTIVE or READY; falling back to RDMA", i,
+           comm->peerInfo[i].fabricInfo.state);
       return ncclSuccess;
     }
   }
@@ -76,16 +76,18 @@ ncclResult_t ncclMnnvlCheck(struct ncclComm* comm) {
 #ifdef HIP_FABRIC_API
   // Check that FABRIC handles can be exported & imported by IMEX
   {
-    void *ptr = NULL;
+    void* ptr = NULL;
     CUmemGenericAllocationHandle handle;
     ncclCuDesc cuDesc;
     CUresult err;
 
     // Allocate FABRIC handle compatible memory
-    ncclResult_t ret = ncclCuMemAlloc(&ptr, &handle, CU_MEM_HANDLE_TYPE_FABRIC, CUDA_IPC_MIN, comm->memManager, ncclMemOffload);
+    ncclResult_t ret =
+      ncclCuMemAlloc(&ptr, &handle, CU_MEM_HANDLE_TYPE_FABRIC, CUDA_IPC_MIN, comm->memManager, ncclMemOffload);
     if (ret != ncclSuccess) {
       // Return an error if this is a MNNVL capable system but FABRIC handles are not supported
-      WARN("MNNVL (cliqueSize %d) is available but not working on this system. Check afmctl. Set NCCL_MNNVL_ENABLE=0 to ignore this issue.",
+      WARN("MNNVL (cliqueSize %d) is available but not working on this system. Check afmctl. Set NCCL_MNNVL_ENABLE=0 "
+           "to ignore this issue.",
            comm->clique.size);
       return ncclSystemError;
     }
@@ -98,12 +100,14 @@ ncclResult_t ncclMnnvlCheck(struct ncclComm* comm) {
     // implicitly when the first actual P2P transfer succeeds after MNNVL is enabled.
     // The ImportFromShareableHandle check above is preserved to document what was tried and why
     // it was removed, so future maintainers don't re-add it expecting it to work.
-      const char *errStr;
-      (void) cuGetErrorString(err, &errStr);
+      const char* errStr;
+      (void)cuGetErrorString(err, &errStr);
       NCCLCHECK(ncclCuMemFree(ptr, comm->memManager));
       // Return an error if this is a MNNVL capable system but it's not working
-      WARN("MNNVL rank%d (cliqueSize %d) is available but not working on this system: cuMemExportToShareableHandle/cuMemImportFromShareableHandle failed: %s. Check afmctl. Set NCCL_MNNVL_ENABLE=0 to ignore this issue.",
-          comm->rank, comm->clique.size, errStr);
+      WARN("MNNVL rank%d (cliqueSize %d) is available but not working on this system: "
+           "cuMemExportToShareableHandle/cuMemImportFromShareableHandle failed: %s. Check afmctl. Set "
+           "NCCL_MNNVL_ENABLE=0 to ignore this issue.",
+           comm->rank, comm->clique.size, errStr);
       return ncclSystemError;
     }
     NCCLCHECK(ncclCuMemFree(ptr, comm->memManager));
@@ -111,8 +115,8 @@ ncclResult_t ncclMnnvlCheck(struct ncclComm* comm) {
     // Force the CUMEM handle type to be FABRIC for MNNVL
     ncclCuMemHandleType = CU_MEM_HANDLE_TYPE_FABRIC;
     comm->MNNVL = 1;
-    INFO(NCCL_INIT, "MNNVL %d cliqueId %x cliqueSize %d cliqueRank %d nvlDomainSize %d",
-        comm->MNNVL, comm->clique.id, comm->clique.size, comm->cliqueRank, comm->nvlDomainSize);
+    INFO(NCCL_INIT, "MNNVL %d cliqueId %x cliqueSize %d cliqueRank %d nvlDomainSize %d", comm->MNNVL, comm->clique.id,
+         comm->clique.size, comm->cliqueRank, comm->nvlDomainSize);
   }
 #endif
   return ncclSuccess;

--- a/projects/rccl/src/nccl_device/core.cc
+++ b/projects/rccl/src/nccl_device/core.cc
@@ -38,15 +38,15 @@ ncclTeam_t ncclTeamRail(ncclComm_t comm) {
   if (ncclSuccess != ncclDevrInitOnce(comm)) return ncclTeam_t{};
 
   ncclTeam_t ans;
-  ans.nRanks = comm->nRanks/comm->devrState.lsaSize;
-  ans.rank = comm->rank/comm->devrState.lsaSize;
+  ans.nRanks = comm->nRanks / comm->devrState.lsaSize;
+  ans.rank = comm->rank / comm->devrState.lsaSize;
   ans.stride = comm->devrState.lsaSize;
   return ans;
 }
 
 NCCL_API(int, ncclTeamRankToWorld, ncclComm_t comm, ncclTeam_t team, int rank);
 int ncclTeamRankToWorld(ncclComm_t comm, ncclTeam_t team, int rank) {
-  return comm->rank + (rank - team.rank)*team.stride;
+  return comm->rank + (rank - team.rank) * team.stride;
 }
 
 NCCL_API(int, ncclTeamRankToLsa, ncclComm_t comm, ncclTeam_t team, int rank);
@@ -54,5 +54,5 @@ int ncclTeamRankToLsa(ncclComm_t comm, ncclTeam_t team, int rank) {
   // Ignoring errors as above.
   if (ncclSuccess != ncclDevrInitOnce(comm)) return -1;
 
-  return comm->devrState.lsaSelf + (rank - team.rank)*team.stride;
+  return comm->devrState.lsaSelf + (rank - team.rank) * team.stride;
 }

--- a/projects/rccl/src/nccl_device/gin_barrier.cc
+++ b/projects/rccl/src/nccl_device/gin_barrier.cc
@@ -8,11 +8,10 @@
 #include "core.h"
 #include "nccl_device/impl/gin_barrier__funcs.h"
 
-NCCL_API(ncclResult_t, ncclGinBarrierCreateRequirement, ncclComm_t comm, ncclTeam_t team, int nBarriers, ncclGinBarrierHandle_t* outHandle, ncclDevResourceRequirements_t* outReq);
-ncclResult_t ncclGinBarrierCreateRequirement(
-    ncclComm_t comm, ncclTeam_t team, int nBarriers,
-    ncclGinBarrierHandle_t* outHandle, ncclDevResourceRequirements_t* outReq
-  ) {
+NCCL_API(ncclResult_t, ncclGinBarrierCreateRequirement, ncclComm_t comm, ncclTeam_t team, int nBarriers,
+         ncclGinBarrierHandle_t* outHandle, ncclDevResourceRequirements_t* outReq);
+ncclResult_t ncclGinBarrierCreateRequirement(ncclComm_t comm, ncclTeam_t team, int nBarriers,
+                                             ncclGinBarrierHandle_t* outHandle, ncclDevResourceRequirements_t* outReq) {
   memset(outReq, 0, sizeof(*outReq));
   outReq->ginSignalCount = nBarriers * team.nRanks;
   outReq->outGinSignalStart = &outHandle->signal0;

--- a/projects/rccl/src/nccl_device/gin_scratch.cc
+++ b/projects/rccl/src/nccl_device/gin_scratch.cc
@@ -8,19 +8,15 @@
 #include "core.h"
 #include "../device/symmetric/gin_scratch__funcs.h"
 
-NCCL_API(ncclResult_t, ncclGinOutboxCreateRequirement,
-  int nBlocks, int size_log2,
-  ncclGinOutboxHandle* outHandle, ncclDevResourceRequirements* outReq
-);
+NCCL_API(ncclResult_t, ncclGinOutboxCreateRequirement, int nBlocks, int size_log2, ncclGinOutboxHandle* outHandle,
+         ncclDevResourceRequirements* outReq);
 
-ncclResult_t ncclGinOutboxCreateRequirement(
-    int nBlocks, int size_log2,
-    ncclGinOutboxHandle* outHandle, ncclDevResourceRequirements* outReq
-  ) {
+ncclResult_t ncclGinOutboxCreateRequirement(int nBlocks, int size_log2, ncclGinOutboxHandle* outHandle,
+                                            ncclDevResourceRequirements* outReq) {
   memset(outReq, 0, sizeof(*outReq));
   size_log2 = std::max<int>(size_log2, /*log2(128)=*/7);
   outHandle->size_log2 = size_log2;
-  outReq->bufferSize = nBlocks*(sizeof(ncclGinOutboxState) + alignUp(1<<size_log2, alignof(ncclGinOutboxState)));
+  outReq->bufferSize = nBlocks * (sizeof(ncclGinOutboxState) + alignUp(1 << size_log2, alignof(ncclGinOutboxState)));
   outReq->bufferAlign = 128;
   outReq->outBufferHandle = &outHandle->bufHandle;
   outReq->ginCounterCount = nBlocks << ncclGinScratchMaxBufs_log2;
@@ -28,23 +24,20 @@ ncclResult_t ncclGinOutboxCreateRequirement(
   return ncclSuccess;
 }
 
-NCCL_API(ncclResult_t, ncclGinInboxA2ACreateRequirement,
-  ncclTeam peers, int nBlocks, int size_log2,
-  ncclGinInboxA2AHandle* outHandle, ncclDevResourceRequirements* outReq
-);
+NCCL_API(ncclResult_t, ncclGinInboxA2ACreateRequirement, ncclTeam peers, int nBlocks, int size_log2,
+         ncclGinInboxA2AHandle* outHandle, ncclDevResourceRequirements* outReq);
 
-ncclResult_t ncclGinInboxA2ACreateRequirement(
-    ncclTeam peers, int nBlocks, int size_log2,
-    ncclGinInboxA2AHandle* outHandle, ncclDevResourceRequirements* outReq
-  ) {
+ncclResult_t ncclGinInboxA2ACreateRequirement(ncclTeam peers, int nBlocks, int size_log2,
+                                              ncclGinInboxA2AHandle* outHandle, ncclDevResourceRequirements* outReq) {
   int nPeers = peers.nRanks - 1;
   memset(outReq, 0, sizeof(*outReq));
   outHandle->size_log2 = size_log2;
   outHandle->nPeers_rcp32 = idivRcp32(nPeers);
-  outReq->bufferSize = nBlocks*(sizeof(ncclGinInboxA2AState) + alignUp(1<<size_log2, alignof(ncclGinInboxA2AState)));
+  outReq->bufferSize =
+    nBlocks * (sizeof(ncclGinInboxA2AState) + alignUp(1 << size_log2, alignof(ncclGinInboxA2AState)));
   outReq->bufferAlign = 128;
   outReq->outBufferHandle = &outHandle->bufHandle;
-  outReq->ginSignalCount = nBlocks*4*(nPeers + (1<<ncclGinScratchMaxBufs_log2));
+  outReq->ginSignalCount = nBlocks * 4 * (nPeers + (1 << ncclGinScratchMaxBufs_log2));
   outReq->outGinSignalStart = &outHandle->signals;
   return ncclSuccess;
 }

--- a/projects/rccl/src/nccl_device/ll_a2a.cc
+++ b/projects/rccl/src/nccl_device/ll_a2a.cc
@@ -10,17 +10,16 @@
 
 NCCL_API(int, ncclLLA2ACalcSlots, int maxElts, int maxEltSize);
 int ncclLLA2ACalcSlots(int maxElts, int maxEltSize) {
-  return maxElts*divUp(maxEltSize, 8);
+  return maxElts * divUp(maxEltSize, 8);
 }
 
-NCCL_API(ncclResult_t, ncclLLA2ACreateRequirement, int nBlocks, int nSlots, ncclLLA2AHandle_t* outHandle, ncclDevResourceRequirements_t* outReq);
-ncclResult_t ncclLLA2ACreateRequirement(
-    int nBlocks, int nSlots, ncclLLA2AHandle_t* outHandle,
-    ncclDevResourceRequirements_t* outReq
-  ) {
+NCCL_API(ncclResult_t, ncclLLA2ACreateRequirement, int nBlocks, int nSlots, ncclLLA2AHandle_t* outHandle,
+         ncclDevResourceRequirements_t* outReq);
+ncclResult_t ncclLLA2ACreateRequirement(int nBlocks, int nSlots, ncclLLA2AHandle_t* outHandle,
+                                        ncclDevResourceRequirements_t* outReq) {
   outHandle->nSlots = nSlots;
   memset(outReq, 0, sizeof(*outReq));
-  outReq->bufferSize = nBlocks*(1 + 2*nSlots)*16;
+  outReq->bufferSize = nBlocks * (1 + 2 * nSlots) * 16;
   outReq->bufferAlign = 16;
   outReq->outBufferHandle = &outHandle->bufHandle;
   return ncclSuccess;

--- a/projects/rccl/src/nccl_device/lsa_barrier.cc
+++ b/projects/rccl/src/nccl_device/lsa_barrier.cc
@@ -8,14 +8,13 @@
 #include "core.h"
 #include "nccl_device/impl/lsa_barrier__funcs.h"
 
-NCCL_API(ncclResult_t, ncclLsaBarrierCreateRequirement, ncclTeam_t team, int nBarriers, ncclLsaBarrierHandle_t* outHandle, ncclDevResourceRequirements_t* outReq);
-ncclResult_t ncclLsaBarrierCreateRequirement(
-    ncclTeam_t team, int nBarriers, ncclLsaBarrierHandle_t* outHandle,
-    ncclDevResourceRequirements_t* outReq
-  ) {
+NCCL_API(ncclResult_t, ncclLsaBarrierCreateRequirement, ncclTeam_t team, int nBarriers,
+         ncclLsaBarrierHandle_t* outHandle, ncclDevResourceRequirements_t* outReq);
+ncclResult_t ncclLsaBarrierCreateRequirement(ncclTeam_t team, int nBarriers, ncclLsaBarrierHandle_t* outHandle,
+                                             ncclDevResourceRequirements_t* outReq) {
   memset(outReq, 0, sizeof(*outReq));
   outHandle->nBarriers = nBarriers;
-  outReq->bufferSize = (3*nBarriers + nBarriers*team.nRanks)*sizeof(uint32_t);
+  outReq->bufferSize = (3 * nBarriers + nBarriers * team.nRanks) * sizeof(uint32_t);
   outReq->bufferAlign = alignof(uint32_t);
   outReq->outBufferHandle = &outHandle->bufHandle;
   return ncclSuccess;

--- a/projects/rccl/src/os/linux.cc
+++ b/projects/rccl/src/os/linux.cc
@@ -89,11 +89,11 @@ size_t ncclOsGetPageSize() {
 }
 
 void* ncclOsAlignedAlloc(size_t alignment, size_t size) {
-    return aligned_alloc(alignment, size);
+  return aligned_alloc(alignment, size);
 }
 
 void ncclOsAlignedFree(void* ptr) {
-    free(ptr);
+  free(ptr);
 }
 
 void ncclOsSetEnv(const char* name, const char* value) {
@@ -105,7 +105,7 @@ char* ncclOsRealpath(const char* path, char* resolved_path) {
 }
 
 // The default Linux stack size (8MB) is safe.
-#define SAFE_STACK_SIZE (8192*1024)
+#define SAFE_STACK_SIZE (8192 * 1024)
 
 static ncclResult_t setCpuStackSize() {
   // Query the stack size used for newly launched threads.
@@ -122,12 +122,10 @@ static ncclResult_t setCpuStackSize() {
     struct rlimit stackLimit;
     char buf[30];
     SYSCHECK(getrlimit(RLIMIT_STACK, &stackLimit), "getrlimit");
-    if (stackLimit.rlim_cur == RLIM_INFINITY)
-      strcpy(buf, "unlimited");
-    else
-      snprintf(buf, sizeof(buf), "%ldKB", stackLimit.rlim_cur / 1024);
-    INFO(NCCL_INIT | NCCL_ENV, "Stack size limit (%s) is unsafe; will use %dKB for newly launched threads",
-         buf, SAFE_STACK_SIZE / 1024);
+    if (stackLimit.rlim_cur == RLIM_INFINITY) strcpy(buf, "unlimited");
+    else snprintf(buf, sizeof(buf), "%ldKB", stackLimit.rlim_cur / 1024);
+    INFO(NCCL_INIT | NCCL_ENV, "Stack size limit (%s) is unsafe; will use %dKB for newly launched threads", buf,
+         SAFE_STACK_SIZE / 1024);
 
     // Change the default pthread stack size (via a nonportable API as the feature is not available in std::thread)
     PTHREADCHECK(pthread_attr_setstacksize(&attr, SAFE_STACK_SIZE), "pthread_attr_setstacksize");
@@ -171,7 +169,7 @@ void ncclOsPollSocket(int socketDescriptor, int op) {
   memset(&pfd, 0, sizeof(struct pollfd));
   pfd.fd = socketDescriptor;
   pfd.events = (op == NCCL_SOCKET_RECV) ? POLLIN : POLLOUT;
-  (void) poll(&pfd, 1, ncclParamPollTimeOut());
+  (void)poll(&pfd, 1, ncclParamPollTimeOut());
 }
 
 extern long int ncclParamRetryCnt();
@@ -181,16 +179,16 @@ ncclResult_t ncclOsSocketTryAccept(struct ncclSocket* sock) {
   sock->socketDescriptor = accept(sock->acceptSocketDescriptor, (struct sockaddr*)&sock->addr, &socklen);
   if (ncclOsSocketIsValid(sock)) {
     sock->state = ncclSocketStateAccepted;
-  } else if (errno == ENETDOWN || errno == EPROTO || errno == ENOPROTOOPT || errno == EHOSTDOWN ||
-             errno == ENONET || errno == EHOSTUNREACH || errno == EOPNOTSUPP || errno == ENETUNREACH ||
-             errno == EINTR) {
+  } else if (errno == ENETDOWN || errno == EPROTO || errno == ENOPROTOOPT || errno == EHOSTDOWN || errno == ENONET ||
+             errno == EHOSTUNREACH || errno == EOPNOTSUPP || errno == ENETUNREACH || errno == EINTR) {
     /* per accept's man page, for linux sockets, the following errors might be already pending errors
      * and should be considered as EAGAIN. To avoid infinite loop in case of errors, we use the retry count*/
     if (++sock->errorRetries == ncclParamRetryCnt()) {
-      WARN("ncclOsSocketTryAccept: exceeded error retry count after %d attempts, %s", sock->errorRetries, strerror(errno));
+      WARN("ncclOsSocketTryAccept: exceeded error retry count after %d attempts, %s", sock->errorRetries,
+           strerror(errno));
       return ncclSystemError;
     }
-    INFO(NCCL_NET|NCCL_INIT, "Call to accept returned %s, retrying", strerror(errno));
+    INFO(NCCL_NET | NCCL_INIT, "Call to accept returned %s, retrying", strerror(errno));
   } else if (errno != EINTR && errno != EAGAIN && errno != EWOULDBLOCK) {
     WARN("ncclOsSocketTryAccept: Accept failed: %s", strerror(errno));
     return ncclSystemError;
@@ -216,12 +214,17 @@ ncclResult_t ncclOsSocketSetFlags(struct ncclSocket* sock) {
     SYSCHECKGOTO(flags = fcntl(sock->socketDescriptor, F_GETFL), "fcntl", ret, fail);
     SYSCHECKGOTO(fcntl(sock->socketDescriptor, F_SETFL, flags | O_NONBLOCK), "fcntl", ret, fail);
   }
-  SYSCHECKGOTO(setsockopt(sock->socketDescriptor, IPPROTO_TCP, TCP_NODELAY, (char*)&one, sizeof(int)), "setsockopt TCP NODELAY", ret, fail);
+  SYSCHECKGOTO(setsockopt(sock->socketDescriptor, IPPROTO_TCP, TCP_NODELAY, (char*)&one, sizeof(int)),
+               "setsockopt TCP NODELAY", ret, fail);
   // setsockopt should not fail even if the sizes are too large, do not change the default if unset by the user (=-1)
   rcvBuf = ncclParamSocketMaxRecvBuff();
   sndBuf = ncclParamSocketMaxSendBuff();
-  if (sndBuf > 0) SYSCHECKGOTO(setsockopt(sock->socketDescriptor, SOL_SOCKET, SO_SNDBUF, (char*)&sndBuf, sizeof(int)), "setsockopt SO_SNDBUF", ret, fail);
-  if (rcvBuf > 0) SYSCHECKGOTO(setsockopt(sock->socketDescriptor, SOL_SOCKET, SO_RCVBUF, (char*)&rcvBuf, sizeof(int)), "setsockopt SO_RCVBUF", ret, fail);
+  if (sndBuf > 0)
+    SYSCHECKGOTO(setsockopt(sock->socketDescriptor, SOL_SOCKET, SO_SNDBUF, (char*)&sndBuf, sizeof(int)),
+                 "setsockopt SO_SNDBUF", ret, fail);
+  if (rcvBuf > 0)
+    SYSCHECKGOTO(setsockopt(sock->socketDescriptor, SOL_SOCKET, SO_RCVBUF, (char*)&rcvBuf, sizeof(int)),
+                 "setsockopt SO_RCVBUF", ret, fail);
 exit:
   return ret;
 fail:
@@ -229,8 +232,8 @@ fail:
 }
 
 void ncclOsSocketResetAccept(struct ncclSocket* sock) {
-  char line[SOCKET_NAME_MAXLEN+1];
-  INFO(NCCL_NET|NCCL_INIT, "socketFinalizeAccept: didn't receive a valid magic from %s",
+  char line[SOCKET_NAME_MAXLEN + 1];
+  INFO(NCCL_NET | NCCL_INIT, "socketFinalizeAccept: didn't receive a valid magic from %s",
        ncclSocketToString(&sock->addr, line));
   // Ignore spurious connection and accept again
   (void)close(sock->socketDescriptor);
@@ -262,7 +265,7 @@ cleanup:
 }
 
 static ncclResult_t socketConnectCheck(struct ncclSocket* sock, int errCode, const char funcName[]) {
-  char line[SOCKET_NAME_MAXLEN+1];
+  char line[SOCKET_NAME_MAXLEN + 1];
   if (errCode == 0) {
     sock->state = ncclSocketStateConnected;
   } else if (errCode == EINPROGRESS) {
@@ -272,14 +275,14 @@ static ncclResult_t socketConnectCheck(struct ncclSocket* sock, int errCode, con
     if (sock->customRetry == 0) {
       if (sock->errorRetries++ == ncclParamRetryCnt()) {
         sock->state = ncclSocketStateError;
-        WARN("%s: connect to %s returned %s, exceeded error retry count after %d attempts",
-             funcName, ncclSocketToString(&sock->addr, line), strerror(errCode), sock->errorRetries);
+        WARN("%s: connect to %s returned %s, exceeded error retry count after %d attempts", funcName,
+             ncclSocketToString(&sock->addr, line), strerror(errCode), sock->errorRetries);
         return ncclRemoteError;
       }
       unsigned int sleepTime = sock->errorRetries * ncclParamRetryTimeOut();
-      INFO(NCCL_NET|NCCL_INIT, "%s: connect to %s returned %s, retrying (%d/%ld) after sleep for %u msec",
-           funcName, ncclSocketToString(&sock->addr, line), strerror(errCode),
-           sock->errorRetries, ncclParamRetryCnt(), sleepTime);
+      INFO(NCCL_NET | NCCL_INIT, "%s: connect to %s returned %s, retrying (%d/%ld) after sleep for %u msec", funcName,
+           ncclSocketToString(&sock->addr, line), strerror(errCode), sock->errorRetries, ncclParamRetryCnt(),
+           sleepTime);
       std::this_thread::sleep_for(std::chrono::milliseconds(sleepTime));
     }
     NCCLCHECK(ncclOsSocketResetFd(sock)); /* in case of failure in connect, socket state is unspecified */
@@ -302,7 +305,7 @@ ncclResult_t ncclOsSocketPollConnect(struct ncclSocket* sock) {
   struct pollfd pfd;
   int timeout = 1, ret;
   socklen_t rlen = sizeof(int);
-  char line[SOCKET_NAME_MAXLEN+1];
+  char line[SOCKET_NAME_MAXLEN + 1];
 
   memset(&pfd, 0, sizeof(struct pollfd));
   pfd.fd = sock->socketDescriptor;
@@ -321,15 +324,19 @@ ncclResult_t ncclOsSocketPollConnect(struct ncclSocket* sock) {
   return socketConnectCheck(sock, ret, __func__);
 }
 
-ncclResult_t ncclOsSocketProgressOpt(int op, struct ncclSocket* sock, void* ptr, int size, int* offset, int block, int* closed) {
+ncclResult_t ncclOsSocketProgressOpt(int op, struct ncclSocket* sock, void* ptr, int size, int* offset, int block,
+                                     int* closed) {
   int bytes = 0;
   *closed = 0;
   char* data = (char*)ptr;
-  char line[SOCKET_NAME_MAXLEN+1];
+  char line[SOCKET_NAME_MAXLEN + 1];
   if (sock->asyncFlag || sock->abortFlag) block = 0;
   do {
-    if (op == NCCL_SOCKET_RECV) bytes = recv(sock->socketDescriptor, data+(*offset), size-(*offset), block ? 0 : MSG_DONTWAIT);
-    if (op == NCCL_SOCKET_SEND) bytes = send(sock->socketDescriptor, data+(*offset), size-(*offset), block ? MSG_NOSIGNAL : MSG_DONTWAIT | MSG_NOSIGNAL);
+    if (op == NCCL_SOCKET_RECV)
+      bytes = recv(sock->socketDescriptor, data + (*offset), size - (*offset), block ? 0 : MSG_DONTWAIT);
+    if (op == NCCL_SOCKET_SEND)
+      bytes = send(sock->socketDescriptor, data + (*offset), size - (*offset),
+                   block ? MSG_NOSIGNAL : MSG_DONTWAIT | MSG_NOSIGNAL);
     if (op == NCCL_SOCKET_RECV && bytes == 0) {
       *closed = 1;
       return ncclSuccess;
@@ -341,14 +348,15 @@ ncclResult_t ncclOsSocketProgressOpt(int op, struct ncclSocket* sock, void* ptr,
       }
       if (errno != EINTR && errno != EWOULDBLOCK && errno != EAGAIN) {
         WARN("ncclOsSocketProgressOpt: Call to %s %s failed : %s", (op == NCCL_SOCKET_RECV ? "recv from" : "send to"),
-              ncclSocketToString(&sock->addr, line), strerror(errno));
+             ncclSocketToString(&sock->addr, line), strerror(errno));
         return ncclRemoteError;
       } else {
         bytes = 0;
       }
     }
     (*offset) += bytes;
-    if (sock->abortFlag && std::atomic_load_explicit((std::atomic<uint32_t>*)sock->abortFlag, std::memory_order_acquire)) {
+    if (sock->abortFlag &&
+        std::atomic_load_explicit((std::atomic<uint32_t>*)sock->abortFlag, std::memory_order_acquire)) {
       INFO(NCCL_NET, "ncclOsSocketProgressOpt: abort called");
       return ncclInternalError;
     }
@@ -356,10 +364,10 @@ ncclResult_t ncclOsSocketProgressOpt(int op, struct ncclSocket* sock, void* ptr,
   return ncclSuccess;
 }
 
-ncclResult_t ncclOsFindInterfaces(const char* prefixList, char* names, union ncclSocketAddress *addrs, int sock_family,
-  int maxIfNameSize, int maxIfs, int* found) {
+ncclResult_t ncclOsFindInterfaces(const char* prefixList, char* names, union ncclSocketAddress* addrs, int sock_family,
+                                  int maxIfNameSize, int maxIfs, int* found) {
 #ifdef ENABLE_TRACE
-  char line[SOCKET_NAME_MAXLEN+1];
+  char line[SOCKET_NAME_MAXLEN + 1];
 #endif
   struct netIf userIfs[MAX_IFS];
   bool searchNot = prefixList && prefixList[0] == '^';
@@ -376,17 +384,16 @@ ncclResult_t ncclOsFindInterfaces(const char* prefixList, char* names, union ncc
 
     /* We only support IPv4 & IPv6 */
     int family = interface->ifa_addr->sa_family;
-    if (family != AF_INET && family != AF_INET6)
-      continue;
+    if (family != AF_INET && family != AF_INET6) continue;
 
     /* Only consider running interfaces, i.e. UP and physically attached. */
     if (!(interface->ifa_flags & IFF_RUNNING)) continue;
 
-    TRACE(NCCL_INIT|NCCL_NET,"Found interface %s:%s", interface->ifa_name, ncclSocketToString((union ncclSocketAddress *) interface->ifa_addr, line));
+    TRACE(NCCL_INIT | NCCL_NET, "Found interface %s:%s", interface->ifa_name,
+          ncclSocketToString((union ncclSocketAddress*)interface->ifa_addr, line));
 
     /* Allow the caller to force the socket family type */
-    if (sock_family != -1 && family != sock_family)
-      continue;
+    if (sock_family != -1 && family != sock_family) continue;
 
     /* We also need to skip IPv6 loopback interfaces */
     if (family == AF_INET6) {
@@ -403,12 +410,15 @@ ncclResult_t ncclOsFindInterfaces(const char* prefixList, char* names, union ncc
     // getifaddrs() normal order appears to be; IPv4, IPv6 Global, IPv6 Link
     bool duplicate = false;
     for (int i = 0; i < *found; i++) {
-      if (strcmp(interface->ifa_name, names+i*maxIfNameSize) == 0) { duplicate = true; break; }
+      if (strcmp(interface->ifa_name, names + i * maxIfNameSize) == 0) {
+        duplicate = true;
+        break;
+      }
     }
 
     if (!duplicate) {
       // Store the interface name
-      strncpy(names + (*found)*maxIfNameSize, interface->ifa_name, maxIfNameSize);
+      strncpy(names + (*found) * maxIfNameSize, interface->ifa_name, maxIfNameSize);
       // Store the IP address
       int salen = (family == AF_INET) ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6);
       memset(addrs + *found, '\0', sizeof(*addrs));
@@ -443,8 +453,8 @@ static bool matchSubnet(struct ifaddrs local_if, union ncclSocketAddress* remote
     struct in6_addr& mask_in6 = mask->sin6_addr;
     struct in6_addr& remote_in6 = remote_addr.sin6_addr;
     bool same = true;
-    int len = 16;  //IPv6 address is 16 unsigned char
-    for (int c = 0; c < len; c++) {  //Network byte order is big-endian
+    int len = 16;  // IPv6 address is 16 unsigned char
+    for (int c = 0; c < len; c++) {  // Network byte order is big-endian
       char c1 = local_in6.s6_addr[c] & mask_in6.s6_addr[c];
       char c2 = remote_in6.s6_addr[c] & mask_in6.s6_addr[c];
       if (c1 ^ c2) {
@@ -466,8 +476,8 @@ static bool matchSubnet(struct ifaddrs local_if, union ncclSocketAddress* remote
 ncclResult_t ncclFindInterfaceMatchSubnet(char* ifName, union ncclSocketAddress* localAddr,
                                           union ncclSocketAddress* remoteAddr, int ifNameMaxSize, int* found) {
 #ifdef ENABLE_TRACE
-  char line[SOCKET_NAME_MAXLEN+1];
-  char line_a[SOCKET_NAME_MAXLEN+1];
+  char line[SOCKET_NAME_MAXLEN + 1];
+  char line_a[SOCKET_NAME_MAXLEN + 1];
 #endif
   *found = 0;
   struct ifaddrs *interfaces, *interface;
@@ -477,8 +487,7 @@ ncclResult_t ncclFindInterfaceMatchSubnet(char* ifName, union ncclSocketAddress*
 
     /* We only support IPv4 & IPv6 */
     int family = interface->ifa_addr->sa_family;
-    if (family != AF_INET && family != AF_INET6)
-      continue;
+    if (family != AF_INET && family != AF_INET6) continue;
 
     // check against user specified interfaces
     if (!matchSubnet(*interface, remoteAddr)) {
@@ -492,7 +501,7 @@ ncclResult_t ncclFindInterfaceMatchSubnet(char* ifName, union ncclSocketAddress*
     // Store the interface name
     strncpy(ifName, interface->ifa_name, ifNameMaxSize);
 
-    TRACE(NCCL_INIT|NCCL_NET,"NET : Found interface %s:%s in the same subnet as remote address %s",
+    TRACE(NCCL_INIT | NCCL_NET, "NET : Found interface %s:%s in the same subnet as remote address %s",
           interface->ifa_name, ncclSocketToString(localAddr, line), ncclSocketToString(remoteAddr, line_a));
     *found = 1;
   }
@@ -525,7 +534,7 @@ ncclResult_t ncclSocketClose(struct ncclSocket* sock, bool wait) {
   return ncclSuccess;
 }
 
-void ncclOsSetMutexCondShared(std::mutex &mutex, std::condition_variable &cond) {
+void ncclOsSetMutexCondShared(std::mutex& mutex, std::condition_variable& cond) {
   pthread_mutexattr_t mutexAttr;
   pthread_mutexattr_init(&mutexAttr);
   pthread_mutexattr_setpshared(&mutexAttr, PTHREAD_PROCESS_SHARED);
@@ -598,7 +607,6 @@ ncclResult_t ncclOsNvmlOpen(ncclOsLibraryHandle* handle) {
   return ncclSuccess;
 }
 
-
 // Shared memory implementation for Linux
 #include "comm.h"
 #include <sys/stat.h>
@@ -608,9 +616,8 @@ ncclResult_t ncclOsNvmlOpen(ncclOsLibraryHandle* handle) {
 #include <string.h>
 #include <stdlib.h>
 
-void ncclOsShmHandleInit(ncclShmDescriptor shmDesc, char* shmPath, size_t shmSize, size_t realShmSize,
-                         char* hptr, void* dptr, bool create,
-                         struct ncclShmHandleInternal* handle) {
+void ncclOsShmHandleInit(ncclShmDescriptor shmDesc, char* shmPath, size_t shmSize, size_t realShmSize, char* hptr,
+                         void* dptr, bool create, struct ncclShmHandleInternal* handle) {
   handle->shmDesc = shmDesc;
   handle->shmPtr = hptr;
   handle->devShmPtr = dptr;
@@ -627,9 +634,8 @@ void ncclOsShmHandleInit(ncclShmDescriptor shmDesc, char* shmPath, size_t shmSiz
   }
 }
 
-ncclResult_t ncclOsShmOpen(char* shmPath, size_t shmPathSize, size_t shmSize,
-                           void** shmPtr, void** devShmPtr, int refcount,
-                           struct ncclShmHandleInternal** handle) {
+ncclResult_t ncclOsShmOpen(char* shmPath, size_t shmPathSize, size_t shmSize, void** shmPtr, void** devShmPtr,
+                           int refcount, struct ncclShmHandleInternal** handle) {
   int fd = -1;
   char* hptr = NULL;
   void* dptr = NULL;
@@ -641,7 +647,8 @@ ncclResult_t ncclOsShmOpen(char* shmPath, size_t shmPathSize, size_t shmSize,
 
   *handle = NULL;
   *shmPtr = NULL;
-  EQCHECKGOTO(tmphandle = (struct ncclShmHandleInternal*)calloc(1, sizeof(struct ncclShmHandleInternal)), NULL, ret, fail);
+  EQCHECKGOTO(tmphandle = (struct ncclShmHandleInternal*)calloc(1, sizeof(struct ncclShmHandleInternal)), NULL, ret,
+              fail);
 
   if (create) {
     if (shmPath[0] == '\0') {
@@ -664,7 +671,8 @@ ncclResult_t ncclOsShmOpen(char* shmPath, size_t shmPathSize, size_t shmSize,
   retry_fallocate:
     if (fallocate(fd, 0, 0, realShmSize) != 0) {
       if (errno == EINTR) {
-        INFO(NCCL_ALL, "fallocate: Failed to extend %s to %ld bytes, error: %s (%d) - retrying", shmPath, realShmSize, strerror(errno), errno);
+        INFO(NCCL_ALL, "fallocate: Failed to extend %s to %ld bytes, error: %s (%d) - retrying", shmPath, realShmSize,
+             strerror(errno), errno);
         goto retry_fallocate;
       }
       WARN("Error: failed to extend %s to %ld bytes, error: %s (%d)", shmPath, realShmSize, strerror(errno), errno);
@@ -696,13 +704,18 @@ ncclResult_t ncclOsShmOpen(char* shmPath, size_t shmPathSize, size_t shmSize,
   }
 
   if (devShmPtr) {
-    INFO(NCCL_ALLOC, "SHM legacy: sharing buffer with GPU via cudaHostRegister + cudaHostGetDevicePointer (host %p size %ld)", (void*)hptr, (long)realShmSize);
+    INFO(NCCL_ALLOC,
+         "SHM legacy: sharing buffer with GPU via cudaHostRegister + cudaHostGetDevicePointer (host %p size %ld)",
+         (void*)hptr, (long)realShmSize);
     cudaStreamCaptureMode mode = cudaStreamCaptureModeRelaxed;
     CUDACHECKGOTO(cudaThreadExchangeStreamCaptureMode(&mode), ret, fail);
 #if defined(HIP_HOST_UNCACHED_MEMORY)
-    CUDACHECKGOTO(cudaHostRegister((void*)hptr, realShmSize, cudaHostRegisterPortable | cudaHostRegisterMapped | hipExtHostRegisterUncached), ret, fail);
+    CUDACHECKGOTO(cudaHostRegister((void*)hptr, realShmSize,
+                                   cudaHostRegisterPortable | cudaHostRegisterMapped | hipExtHostRegisterUncached),
+                  ret, fail);
 #else
-    CUDACHECKGOTO(cudaHostRegister((void*)hptr, realShmSize, cudaHostRegisterPortable | cudaHostRegisterMapped), ret, fail);
+    CUDACHECKGOTO(cudaHostRegister((void*)hptr, realShmSize, cudaHostRegisterPortable | cudaHostRegisterMapped), ret,
+                  fail);
 #endif
     CUDACHECKGOTO(cudaHostGetDevicePointer(&dptr, (void*)hptr, 0), ret, fail);
     CUDACHECKGOTO(cudaThreadExchangeStreamCaptureMode(&mode), ret, fail);
@@ -744,7 +757,8 @@ ncclResult_t ncclOsShmClose(struct ncclShmHandleInternal* handle) {
     if (handle->shmPtr) {
       if (handle->devShmPtr) CUDACHECK(cudaHostUnregister(handle->shmPtr));
       if (munmap(handle->shmPtr, handle->realShmSize) != 0) {
-        WARN("munmap of shared memory %p size %ld failed, error: %s (%d)", handle->shmPtr, handle->realShmSize, strerror(errno), errno);
+        WARN("munmap of shared memory %p size %ld failed, error: %s (%d)", handle->shmPtr, handle->realShmSize,
+             strerror(errno), errno);
         ret = ncclSystemError;
       }
     }

--- a/projects/rccl/src/os/linux_ipcsocket.cc
+++ b/projects/rccl/src/os/linux_ipcsocket.cc
@@ -25,7 +25,7 @@ NCCL_PARAM(IpcUseAbstractSocket, "IPC_USE_ABSTRACT_SOCKET", 1);
 /*
  * Create a Unix Domain Socket
  */
-ncclResult_t ncclIpcSocketInit(ncclIpcSocket *handle, int rank, uint64_t hash, volatile uint32_t* abortFlag) {
+ncclResult_t ncclIpcSocketInit(ncclIpcSocket* handle, int rank, uint64_t hash, volatile uint32_t* abortFlag) {
   int fd = NCCL_INVALID_SOCKET;
   struct sockaddr_un cliaddr;
   char temp[NCCL_IPC_SOCKNAME_LEN] = "";
@@ -55,16 +55,16 @@ ncclResult_t ncclIpcSocketInit(ncclIpcSocket *handle, int rank, uint64_t hash, v
   int useAbstractSocket = ncclParamIpcUseAbstractSocket();
   if (!useAbstractSocket) {
     // For regular Unix domain sockets, unlink any existing socket file
-    (void) unlink(temp);
+    (void)unlink(temp);
   }
 
-  TRACE(NCCL_INIT|NCCL_P2P, "UDS: Creating socket %s%s", temp, useAbstractSocket ? " (abstract)" : "");
+  TRACE(NCCL_INIT | NCCL_P2P, "UDS: Creating socket %s%s", temp, useAbstractSocket ? " (abstract)" : "");
 
   strcpy(cliaddr.sun_path, temp);
   if (useAbstractSocket) {
     cliaddr.sun_path[0] = '\0'; // Linux abstract socket trick
   }
-  if (bind(fd, (struct sockaddr *)&cliaddr, sizeof(cliaddr)) < 0) {
+  if (bind(fd, (struct sockaddr*)&cliaddr, sizeof(cliaddr)) < 0) {
     WARN("UDS: Binding to socket %s failed : %s (%d)", temp, strerror(errno), errno);
     close(fd);
     return ncclSystemError;
@@ -93,7 +93,7 @@ ncclResult_t ncclIpcSocketGetFd(struct ncclIpcSocket* handle, int* fd) {
   return ncclSuccess;
 }
 
-ncclResult_t ncclIpcSocketClose(ncclIpcSocket *handle) {
+ncclResult_t ncclIpcSocketClose(ncclIpcSocket* handle) {
   if (handle == NULL) {
     return ncclInternalError;
   }
@@ -102,14 +102,14 @@ ncclResult_t ncclIpcSocketClose(ncclIpcSocket *handle) {
   }
   int useAbstractSocket = ncclParamIpcUseAbstractSocket();
   if (!useAbstractSocket) {
-    (void) unlink(handle->socketName);
+    (void)unlink(handle->socketName);
   }
   close(handle->fd);
 
   return ncclSuccess;
 }
 
-ncclResult_t ncclIpcSocketRecvMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, int *recvFd) {
+ncclResult_t ncclIpcSocketRecvMsg(ncclIpcSocket* handle, void* hdr, int hdrLen, int* recvFd) {
   struct msghdr msg = {0, 0, 0, 0, 0, 0, 0};
   struct iovec iov[1];
 
@@ -119,7 +119,7 @@ ncclResult_t ncclIpcSocketRecvMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, 
     char control[CMSG_SPACE(sizeof(int))];
   } control_un;
 
-  struct cmsghdr *cmptr;
+  struct cmsghdr* cmptr;
   char dummy_buffer[1];
   int ret;
 
@@ -127,7 +127,7 @@ ncclResult_t ncclIpcSocketRecvMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, 
   msg.msg_controllen = sizeof(control_un.control);
 
   if (hdr == NULL) {
-    iov[0].iov_base = (void *)dummy_buffer;
+    iov[0].iov_base = (void*)dummy_buffer;
     iov[0].iov_len = sizeof(dummy_buffer);
   } else {
     iov[0].iov_base = hdr;
@@ -142,14 +142,15 @@ ncclResult_t ncclIpcSocketRecvMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, 
       WARN("UDS: Receiving data over socket failed : %d", errno);
       return ncclSystemError;
     }
-    if (handle->abortFlag && COMPILER_ATOMIC_LOAD(handle->abortFlag, std::memory_order_acquire)) return ncclInternalError;
+    if (handle->abortFlag && COMPILER_ATOMIC_LOAD(handle->abortFlag, std::memory_order_acquire))
+      return ncclInternalError;
   }
 
   if (recvFd != NULL) {
     if (((cmptr = CMSG_FIRSTHDR(&msg)) != NULL) && (cmptr->cmsg_len == CMSG_LEN(sizeof(int)))) {
       if ((cmptr->cmsg_level != SOL_SOCKET) || (cmptr->cmsg_type != SCM_RIGHTS)) {
         WARN("UDS: Receiving data over socket failed");
-      return ncclSystemError;
+        return ncclSystemError;
       }
 
       memmove(recvFd, CMSG_DATA(cmptr), sizeof(*recvFd));
@@ -157,17 +158,18 @@ ncclResult_t ncclIpcSocketRecvMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, 
       WARN("UDS: Receiving data over socket %s failed", handle->socketName);
       return ncclSystemError;
     }
-    TRACE(NCCL_INIT|NCCL_P2P, "UDS: Got recvFd %d from socket %s", *recvFd, handle->socketName);
+    TRACE(NCCL_INIT | NCCL_P2P, "UDS: Got recvFd %d from socket %s", *recvFd, handle->socketName);
   }
 
   return ncclSuccess;
 }
 
-ncclResult_t ncclIpcSocketRecvFd(ncclIpcSocket *handle, int *recvFd) {
+ncclResult_t ncclIpcSocketRecvFd(ncclIpcSocket* handle, int* recvFd) {
   return ncclIpcSocketRecvMsg(handle, NULL, 0, recvFd);
 }
 
-ncclResult_t ncclIpcSocketSendMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, const int sendFd, int rank, uint64_t hash) {
+ncclResult_t ncclIpcSocketSendMsg(ncclIpcSocket* handle, void* hdr, int hdrLen, const int sendFd, int rank,
+                                  uint64_t hash) {
   struct msghdr msg = {0, 0, 0, 0, 0, 0, 0};
   struct iovec iov[1];
   char temp[NCCL_IPC_SOCKNAME_LEN];
@@ -177,7 +179,7 @@ ncclResult_t ncclIpcSocketSendMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, 
     char control[CMSG_SPACE(sizeof(int))];
   } control_un;
 
-  struct cmsghdr *cmptr;
+  struct cmsghdr* cmptr;
   char dummy_buffer[1] = {'\0'};
   struct sockaddr_un cliaddr;
 
@@ -211,11 +213,11 @@ ncclResult_t ncclIpcSocketSendMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, 
     memmove(CMSG_DATA(cmptr), &sendFd, sizeof(sendFd));
   }
 
-  msg.msg_name = (void *)&cliaddr;
+  msg.msg_name = (void*)&cliaddr;
   msg.msg_namelen = sizeof(struct sockaddr_un);
 
   if (hdr == NULL) {
-    iov[0].iov_base = (void *)dummy_buffer;
+    iov[0].iov_base = (void*)dummy_buffer;
     iov[0].iov_len = sizeof(dummy_buffer);
   } else {
     iov[0].iov_base = hdr;
@@ -231,12 +233,13 @@ ncclResult_t ncclIpcSocketSendMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, 
       WARN("UDS: Sending data over socket %s failed : %s (%d)", temp, strerror(errno), errno);
       return ncclSystemError;
     }
-    if (handle->abortFlag && COMPILER_ATOMIC_LOAD(handle->abortFlag, std::memory_order_acquire)) return ncclInternalError;
+    if (handle->abortFlag && COMPILER_ATOMIC_LOAD(handle->abortFlag, std::memory_order_acquire))
+      return ncclInternalError;
   }
 
   return ncclSuccess;
 }
 
-ncclResult_t ncclIpcSocketSendFd(ncclIpcSocket *handle, const int sendFd, int rank, uint64_t hash) {
+ncclResult_t ncclIpcSocketSendFd(ncclIpcSocket* handle, const int sendFd, int rank, uint64_t hash) {
   return ncclIpcSocketSendMsg(handle, NULL, 0, sendFd, rank, hash);
 }

--- a/projects/rccl/src/os/windows.cc
+++ b/projects/rccl/src/os/windows.cc
@@ -49,9 +49,8 @@ static thread_local char ncclDlErrorBuf[256] = {0};
 static void saveDlError() {
   DWORD err = GetLastError();
   if (err != 0) {
-    DWORD len = FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-                               NULL, err, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-                               ncclDlErrorBuf, sizeof(ncclDlErrorBuf), NULL);
+    DWORD len = FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, err,
+                               MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), ncclDlErrorBuf, sizeof(ncclDlErrorBuf), NULL);
     if (len == 0) {
       snprintf(ncclDlErrorBuf, sizeof(ncclDlErrorBuf), "GetLastError=%lu", err);
     }
@@ -110,11 +109,11 @@ size_t ncclOsGetPageSize() {
 }
 
 void* ncclOsAlignedAlloc(size_t alignment, size_t size) {
-    return _aligned_malloc(size, alignment);
+  return _aligned_malloc(size, alignment);
 }
 
 void ncclOsAlignedFree(void* ptr) {
-    _aligned_free(ptr);
+  _aligned_free(ptr);
 }
 
 void ncclOsSetEnv(const char* name, const char* value) {
@@ -139,13 +138,13 @@ ncclResult_t ncclOsInitialize() {
     WARN("WSAStartup failed with error: %d", result);
     return ncclSystemError;
   }
-  INFO(NCCL_INIT|NCCL_NET, "WSAStartup succeeded, Winsock version %d.%d",
-       LOBYTE(wsaData.wVersion), HIBYTE(wsaData.wVersion));
+  INFO(NCCL_INIT | NCCL_NET, "WSAStartup succeeded, Winsock version %d.%d", LOBYTE(wsaData.wVersion),
+       HIBYTE(wsaData.wVersion));
   return ncclSuccess;
 }
 
 ncclResult_t ncclOsSetFilesLimit() {
-    return ncclSuccess;
+  return ncclSuccess;
 }
 
 bool ncclOsSocketDescriptorIsValid(ncclSocketDescriptor sockDescriptor) {
@@ -169,9 +168,8 @@ void ncclOsPollSocket(SOCKET sock, int op) {
 
 static const char* getWSAErrorMessage(int error) {
   static char errorMsg[256];
-  FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-                 NULL, error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-                 errorMsg, sizeof(errorMsg), NULL);
+  FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, error,
+                 MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), errorMsg, sizeof(errorMsg), NULL);
   return errorMsg;
 }
 
@@ -187,10 +185,11 @@ ncclResult_t ncclOsSocketTryAccept(struct ncclSocket* sock) {
     if (wsaError == WSAEINPROGRESS) {
       // Connection in progress, retry with backoff
       if (++sock->errorRetries == ncclParamRetryCnt()) {
-        WARN("ncclOsSocketTryAccept: exceeded error retry count after %d attempts, %s", sock->errorRetries, getWSAErrorMessage(wsaError));
+        WARN("ncclOsSocketTryAccept: exceeded error retry count after %d attempts, %s", sock->errorRetries,
+             getWSAErrorMessage(wsaError));
         return ncclSystemError;
       }
-      INFO(NCCL_NET|NCCL_INIT, "Call to accept returned %s, retrying", getWSAErrorMessage(wsaError));
+      INFO(NCCL_NET | NCCL_INIT, "Call to accept returned %s, retrying", getWSAErrorMessage(wsaError));
     } else if (wsaError != WSAEINTR && wsaError != WSAEWOULDBLOCK) {
       // WSAEWOULDBLOCK (10035) is expected for non-blocking accept - means no pending connection yet
       // WSAEINTR means interrupted, both are normal and we just return success to try again later
@@ -224,12 +223,17 @@ ncclResult_t ncclOsSocketSetFlags(struct ncclSocket* sock) {
     }
     sock->socketBlockingMode = 0;
   }
-  SYSCHECKGOTO(setsockopt(sock->socketDescriptor, IPPROTO_TCP, TCP_NODELAY, (char*)&one, sizeof(int)), "setsockopt TCP NODELAY", ret, fail);
+  SYSCHECKGOTO(setsockopt(sock->socketDescriptor, IPPROTO_TCP, TCP_NODELAY, (char*)&one, sizeof(int)),
+               "setsockopt TCP NODELAY", ret, fail);
   // setsockopt should not fail even if the sizes are too large, do not change the default if unset by the user (=-1)
   rcvBuf = ncclParamSocketMaxRecvBuff();
   sndBuf = ncclParamSocketMaxSendBuff();
-  if (sndBuf > 0) SYSCHECKGOTO(setsockopt(sock->socketDescriptor, SOL_SOCKET, SO_SNDBUF, (char*)&sndBuf, sizeof(int)), "setsockopt SO_SNDBUF", ret, fail);
-  if (rcvBuf > 0) SYSCHECKGOTO(setsockopt(sock->socketDescriptor, SOL_SOCKET, SO_RCVBUF, (char*)&rcvBuf, sizeof(int)), "setsockopt SO_RCVBUF", ret, fail);
+  if (sndBuf > 0)
+    SYSCHECKGOTO(setsockopt(sock->socketDescriptor, SOL_SOCKET, SO_SNDBUF, (char*)&sndBuf, sizeof(int)),
+                 "setsockopt SO_SNDBUF", ret, fail);
+  if (rcvBuf > 0)
+    SYSCHECKGOTO(setsockopt(sock->socketDescriptor, SOL_SOCKET, SO_RCVBUF, (char*)&rcvBuf, sizeof(int)),
+                 "setsockopt SO_RCVBUF", ret, fail);
 exit:
   return ret;
 fail:
@@ -237,8 +241,8 @@ fail:
 }
 
 void ncclOsSocketResetAccept(struct ncclSocket* sock) {
-  char line[SOCKET_NAME_MAXLEN+1];
-  INFO(NCCL_NET|NCCL_INIT, "socketFinalizeAccept: didn't receive a valid magic from %s",
+  char line[SOCKET_NAME_MAXLEN + 1];
+  INFO(NCCL_NET | NCCL_INIT, "socketFinalizeAccept: didn't receive a valid magic from %s",
        ncclSocketToString(&sock->addr, line));
   // Ignore spurious connection and accept again
   (void)closesocket(sock->socketDescriptor);
@@ -253,10 +257,10 @@ ncclResult_t ncclOsSocketResetFd(struct ncclSocket* sock) {
 
   newSocket = socket(sock->addr.sa.sa_family, SOCK_STREAM, 0);
   if (newSocket == INVALID_SOCKET) {
-      int wsaError = WSAGetLastError();
-      WARN("ncclOsSocketResetFd: socket() failed with error %d: %s", wsaError, getWSAErrorMessage(wsaError));
-      ret = ncclSystemError;
-      goto cleanup;
+    int wsaError = WSAGetLastError();
+    WARN("ncclOsSocketResetFd: socket() failed with error %d: %s", wsaError, getWSAErrorMessage(wsaError));
+    ret = ncclSystemError;
+    goto cleanup;
   }
 
   // if socket is valid, close it and replace with new socket
@@ -276,26 +280,26 @@ cleanup:
 }
 
 static ncclResult_t socketConnectCheck(struct ncclSocket* sock, int errCode, const char funcName[]) {
-  char line[SOCKET_NAME_MAXLEN+1];
+  char line[SOCKET_NAME_MAXLEN + 1];
   if (errCode == 0) {
     sock->state = ncclSocketStateConnected;
   } else if (errCode == WSAEINPROGRESS || errCode == WSAEWOULDBLOCK) {
     // WSAEWOULDBLOCK (10035) on Windows for non-blocking connect() is equivalent to
     // EINPROGRESS on Linux - it means connection is in progress, poll for completion
     sock->state = ncclSocketStateConnectPolling;
-  } else if (errCode == WSAEINTR || errCode == WSAEAGAIN ||
-             errCode == WSAETIMEDOUT || errCode == WSAEHOSTUNREACH || errCode == WSAECONNREFUSED) {
+  } else if (errCode == WSAEINTR || errCode == WSAEAGAIN || errCode == WSAETIMEDOUT || errCode == WSAEHOSTUNREACH ||
+             errCode == WSAECONNREFUSED) {
     if (sock->customRetry == 0) {
       if (sock->errorRetries++ == ncclParamRetryCnt()) {
         sock->state = ncclSocketStateError;
-        WARN("%s: connect to %s returned %s, exceeded error retry count after %d attempts",
-             funcName, ncclSocketToString(&sock->addr, line), getWSAErrorMessage(errCode), sock->errorRetries);
+        WARN("%s: connect to %s returned %s, exceeded error retry count after %d attempts", funcName,
+             ncclSocketToString(&sock->addr, line), getWSAErrorMessage(errCode), sock->errorRetries);
         return ncclRemoteError;
       }
       unsigned int sleepTime = sock->errorRetries * ncclParamRetryTimeOut();
-      INFO(NCCL_NET|NCCL_INIT, "%s: connect to %s returned %s, retrying (%d/%ld) after sleep for %u msec",
-           funcName, ncclSocketToString(&sock->addr, line), getWSAErrorMessage(errCode),
-           sock->errorRetries, ncclParamRetryCnt(), sleepTime);
+      INFO(NCCL_NET | NCCL_INIT, "%s: connect to %s returned %s, retrying (%d/%ld) after sleep for %u msec", funcName,
+           ncclSocketToString(&sock->addr, line), getWSAErrorMessage(errCode), sock->errorRetries, ncclParamRetryCnt(),
+           sleepTime);
       std::this_thread::sleep_for(std::chrono::milliseconds(sleepTime));
     }
     NCCLCHECK(ncclOsSocketResetFd(sock)); /* in case of failure in connect, socket state is unspecified */
@@ -318,7 +322,7 @@ ncclResult_t ncclOsSocketPollConnect(struct ncclSocket* sock) {
   WSAPOLLFD pfd;
   int timeout = 1, ret;
   int optlen = sizeof(int);  /* Windows getsockopt expects int* for optlen */
-  char line[SOCKET_NAME_MAXLEN+1];
+  char line[SOCKET_NAME_MAXLEN + 1];
 
   memset(&pfd, 0, sizeof(WSAPOLLFD));
   pfd.fd = sock->socketDescriptor;
@@ -329,7 +333,8 @@ ncclResult_t ncclOsSocketPollConnect(struct ncclSocket* sock) {
     return ncclSuccess;
   } else if (ret < 0) {
     int wsaError = WSAGetLastError();
-    WARN("ncclOsSocketPollConnect to %s failed with error %s", ncclSocketToString(&sock->addr, line), getWSAErrorMessage(wsaError));
+    WARN("ncclOsSocketPollConnect to %s failed with error %s", ncclSocketToString(&sock->addr, line),
+         getWSAErrorMessage(wsaError));
     return ncclSystemError;
   }
 
@@ -338,11 +343,12 @@ ncclResult_t ncclOsSocketPollConnect(struct ncclSocket* sock) {
   return socketConnectCheck(sock, ret, __func__);
 }
 
-ncclResult_t ncclOsSocketProgressOpt(int op, struct ncclSocket* sock, void* ptr, int size, int* offset, int block, int* closed) {
+ncclResult_t ncclOsSocketProgressOpt(int op, struct ncclSocket* sock, void* ptr, int size, int* offset, int block,
+                                     int* closed) {
   int bytes = 0;
   *closed = 0;
   char* data = (char*)ptr;
-  char line[SOCKET_NAME_MAXLEN+1];
+  char line[SOCKET_NAME_MAXLEN + 1];
   if (sock->asyncFlag || sock->abortFlag) block = 0;
   if (block != sock->socketBlockingMode) {
     u_long mode = !block;
@@ -354,8 +360,8 @@ ncclResult_t ncclOsSocketProgressOpt(int op, struct ncclSocket* sock, void* ptr,
     sock->socketBlockingMode = block;
   }
   do {
-    if (op == NCCL_SOCKET_RECV) bytes = recv(sock->socketDescriptor, data+(*offset), size-(*offset), 0);
-    if (op == NCCL_SOCKET_SEND) bytes = send(sock->socketDescriptor, data+(*offset), size-(*offset), 0);
+    if (op == NCCL_SOCKET_RECV) bytes = recv(sock->socketDescriptor, data + (*offset), size - (*offset), 0);
+    if (op == NCCL_SOCKET_SEND) bytes = send(sock->socketDescriptor, data + (*offset), size - (*offset), 0);
     if (op == NCCL_SOCKET_RECV && bytes == 0) {
       *closed = 1;
       return ncclSuccess;
@@ -370,15 +376,17 @@ ncclResult_t ncclOsSocketProgressOpt(int op, struct ncclSocket* sock, void* ptr,
       // WSAEINPROGRESS (10036) means operation is in progress
       // WSAEINTR means interrupted by signal
       if (wsaError != WSAEWOULDBLOCK && wsaError != WSAEINPROGRESS && wsaError != WSAEINTR) {
-        WARN("ncclOsSocketProgressOpt: Call to %s %s failed : %d (%s)", (op == NCCL_SOCKET_RECV ? "recv from" : "send to"),
-              ncclSocketToString(&sock->addr, line), wsaError, getWSAErrorMessage(wsaError));
+        WARN("ncclOsSocketProgressOpt: Call to %s %s failed : %d (%s)",
+             (op == NCCL_SOCKET_RECV ? "recv from" : "send to"), ncclSocketToString(&sock->addr, line), wsaError,
+             getWSAErrorMessage(wsaError));
         return ncclRemoteError;
       } else {
         bytes = 0;
       }
     }
     (*offset) += bytes;
-    if (sock->abortFlag && std::atomic_load_explicit((std::atomic<uint32_t>*)sock->abortFlag, std::memory_order_acquire)) {
+    if (sock->abortFlag &&
+        std::atomic_load_explicit((std::atomic<uint32_t>*)sock->abortFlag, std::memory_order_acquire)) {
       INFO(NCCL_NET, "ncclOsSocketProgressOpt: abort called");
       return ncclInternalError;
     }
@@ -386,10 +394,10 @@ ncclResult_t ncclOsSocketProgressOpt(int op, struct ncclSocket* sock, void* ptr,
   return ncclSuccess;
 }
 
-ncclResult_t ncclOsFindInterfaces(const char* prefixList, char* names, union ncclSocketAddress *addrs, int sock_family,
-  int maxIfNameSize, int maxIfs, int* found) {
+ncclResult_t ncclOsFindInterfaces(const char* prefixList, char* names, union ncclSocketAddress* addrs, int sock_family,
+                                  int maxIfNameSize, int maxIfs, int* found) {
 #ifdef ENABLE_TRACE
-  char line[SOCKET_NAME_MAXLEN+1];
+  char line[SOCKET_NAME_MAXLEN + 1];
 #endif
   struct netIf userIfs[MAX_IFS];
   bool searchNot = prefixList && prefixList[0] == '^';
@@ -432,9 +440,8 @@ ncclResult_t ncclOsFindInterfaces(const char* prefixList, char* names, union ncc
     if (adapter->IfType == IF_TYPE_SOFTWARE_LOOPBACK) continue;
 
     // Iterate through unicast addresses for this adapter
-    for (IP_ADAPTER_UNICAST_ADDRESS* unicast = adapter->FirstUnicastAddress;
-         unicast && *found < maxIfs; unicast = unicast->Next) {
-
+    for (IP_ADAPTER_UNICAST_ADDRESS* unicast = adapter->FirstUnicastAddress; unicast && *found < maxIfs;
+         unicast = unicast->Next) {
       if (unicast->Address.lpSockaddr == NULL) continue;
 
       // Get address family
@@ -454,7 +461,8 @@ ncclResult_t ncclOsFindInterfaces(const char* prefixList, char* names, union ncc
       char adapterName[MAX_IF_NAME_SIZE];
       WideCharToMultiByte(CP_UTF8, 0, adapter->FriendlyName, -1, adapterName, MAX_IF_NAME_SIZE, NULL, NULL);
 
-      TRACE(NCCL_INIT|NCCL_NET,"Found interface %s:%s", adapterName, ncclSocketToString((union ncclSocketAddress *) unicast->Address.lpSockaddr, line));
+      TRACE(NCCL_INIT | NCCL_NET, "Found interface %s:%s", adapterName,
+            ncclSocketToString((union ncclSocketAddress*)unicast->Address.lpSockaddr, line));
 
       // Check against user specified interfaces
       if (!(matchIfList(adapterName, -1, userIfs, nUserIfs, searchExact) ^ searchNot)) {
@@ -464,7 +472,7 @@ ncclResult_t ncclOsFindInterfaces(const char* prefixList, char* names, union ncc
       // Check that this interface has not already been saved
       bool duplicate = false;
       for (int i = 0; i < *found; i++) {
-        if (strcmp(adapterName, names+i*maxIfNameSize) == 0) {
+        if (strcmp(adapterName, names + i * maxIfNameSize) == 0) {
           duplicate = true;
           break;
         }
@@ -472,7 +480,7 @@ ncclResult_t ncclOsFindInterfaces(const char* prefixList, char* names, union ncc
 
       if (!duplicate) {
         // Store the interface name
-        strncpy(names + (*found)*maxIfNameSize, adapterName, maxIfNameSize);
+        strncpy(names + (*found) * maxIfNameSize, adapterName, maxIfNameSize);
         // Store the IP address
         int salen = (family == AF_INET) ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6);
         memset(addrs + *found, '\0', sizeof(*addrs));
@@ -557,8 +565,8 @@ static bool matchSubnet(IP_ADAPTER_UNICAST_ADDRESS* local_addr, union ncclSocket
 ncclResult_t ncclFindInterfaceMatchSubnet(char* ifName, union ncclSocketAddress* localAddr,
                                           union ncclSocketAddress* remoteAddr, int ifNameMaxSize, int* found) {
 #ifdef ENABLE_TRACE
-  char line[SOCKET_NAME_MAXLEN+1];
-  char line_a[SOCKET_NAME_MAXLEN+1];
+  char line[SOCKET_NAME_MAXLEN + 1];
+  char line_a[SOCKET_NAME_MAXLEN + 1];
 #endif
   ncclResult_t ret = ncclSuccess;
   *found = 0;
@@ -596,9 +604,8 @@ ncclResult_t ncclFindInterfaceMatchSubnet(char* ifName, union ncclSocketAddress*
     if (adapter->IfType == IF_TYPE_SOFTWARE_LOOPBACK) continue;
 
     // Iterate through unicast addresses for this adapter
-    for (IP_ADAPTER_UNICAST_ADDRESS* unicast = adapter->FirstUnicastAddress;
-         unicast && !*found; unicast = unicast->Next) {
-
+    for (IP_ADAPTER_UNICAST_ADDRESS* unicast = adapter->FirstUnicastAddress; unicast && !*found;
+         unicast = unicast->Next) {
       if (unicast->Address.lpSockaddr == NULL) continue;
 
       // Get address family
@@ -623,8 +630,8 @@ ncclResult_t ncclFindInterfaceMatchSubnet(char* ifName, union ncclSocketAddress*
       // Convert adapter name to char* for storage
       WideCharToMultiByte(CP_UTF8, 0, adapter->FriendlyName, -1, ifName, ifNameMaxSize, NULL, NULL);
 
-      TRACE(NCCL_INIT|NCCL_NET,"NET : Found interface %s:%s in the same subnet as remote address %s",
-            ifName, ncclSocketToString(localAddr, line), ncclSocketToString(remoteAddr, line_a));
+      TRACE(NCCL_INIT | NCCL_NET, "NET : Found interface %s:%s in the same subnet as remote address %s", ifName,
+            ncclSocketToString(localAddr, line), ncclSocketToString(remoteAddr, line_a));
       *found = 1;
     }
   }
@@ -657,7 +664,7 @@ ncclResult_t ncclSocketClose(struct ncclSocket* sock, bool wait) {
   return ncclSuccess;
 }
 
-void ncclOsSetMutexCondShared(std::mutex &mutex, std::condition_variable &cond) {
+void ncclOsSetMutexCondShared(std::mutex& mutex, std::condition_variable& cond) {
   // Not implemented on Windows
 }
 
@@ -709,11 +716,9 @@ ncclResult_t ncclOsNvmlOpen(ncclOsLibraryHandle* handle) {
   *handle = nullptr;
 
   // On Windows, try multiple possible locations for nvml.dll
-  const char* nvmlPaths[] = {
-    "nvml.dll",  // System PATH or current directory
-    "C:\\Windows\\System32\\nvml.dll",  // Common system location
-    nullptr
-  };
+  const char* nvmlPaths[] = {"nvml.dll",  // System PATH or current directory
+                             "C:\\Windows\\System32\\nvml.dll",  // Common system location
+                             nullptr};
 
   for (int i = 0; nvmlPaths[i] != nullptr && *handle == nullptr; i++) {
     *handle = ncclOsDlopen(nvmlPaths[i]);
@@ -730,7 +735,6 @@ ncclResult_t ncclOsNvmlOpen(ncclOsLibraryHandle* handle) {
 
   return ncclSuccess;
 }
-
 
 char* ncclOsRealpath(const char* path, char* resolved_path) {
   if (path == NULL) {
@@ -767,9 +771,8 @@ char* ncclOsRealpath(const char* path, char* resolved_path) {
 #include <string.h>
 #include <stdlib.h>
 
-void ncclOsShmHandleInit(ncclShmDescriptor shmDesc, char* shmPath, size_t shmSize, size_t realShmSize,
-                         char* hptr, void* dptr, bool create,
-                         struct ncclShmHandleInternal* handle) {
+void ncclOsShmHandleInit(ncclShmDescriptor shmDesc, char* shmPath, size_t shmSize, size_t realShmSize, char* hptr,
+                         void* dptr, bool create, struct ncclShmHandleInternal* handle) {
   handle->shmDesc = shmDesc;
   handle->shmPtr = hptr;
   handle->devShmPtr = dptr;
@@ -786,9 +789,8 @@ void ncclOsShmHandleInit(ncclShmDescriptor shmDesc, char* shmPath, size_t shmSiz
   }
 }
 
-ncclResult_t ncclOsShmOpen(char* shmPath, size_t shmPathSize, size_t shmSize,
-                           void** shmPtr, void** devShmPtr, int refcount,
-                           struct ncclShmHandleInternal** handle) {
+ncclResult_t ncclOsShmOpen(char* shmPath, size_t shmPathSize, size_t shmSize, void** shmPtr, void** devShmPtr,
+                           int refcount, struct ncclShmHandleInternal** handle) {
   HANDLE hMapFile = NULL;
   char* hptr = NULL;
   void* dptr = NULL;
@@ -800,25 +802,24 @@ ncclResult_t ncclOsShmOpen(char* shmPath, size_t shmPathSize, size_t shmSize,
 
   *handle = NULL;
   *shmPtr = NULL;
-  EQCHECKGOTO(tmphandle = (struct ncclShmHandleInternal*)calloc(1, sizeof(struct ncclShmHandleInternal)), NULL, ret, fail);
+  EQCHECKGOTO(tmphandle = (struct ncclShmHandleInternal*)calloc(1, sizeof(struct ncclShmHandleInternal)), NULL, ret,
+              fail);
 
   if (create) {
     if (shmPath[0] == '\0') {
       // Generate unique shared memory name using process ID and timestamp
       uint64_t timestamp = clockNano();
-      snprintf(shmPath, shmPathSize, "Local\\nccl-shm-%llu-%llu",
-               (unsigned long long)GetCurrentProcessId(),
+      snprintf(shmPath, shmPathSize, "Local\\nccl-shm-%llu-%llu", (unsigned long long)GetCurrentProcessId(),
                (unsigned long long)timestamp);
     }
 
     // Create file mapping object
-    hMapFile = CreateFileMappingA(
-      INVALID_HANDLE_VALUE,    // use paging file
-      NULL,                    // default security
-      PAGE_READWRITE,          // read/write access
-      (DWORD)((realShmSize >> 32) & 0xFFFFFFFF),  // high-order DWORD of size
-      (DWORD)(realShmSize & 0xFFFFFFFF),          // low-order DWORD of size
-      shmPath);                // name of mapping object
+    hMapFile = CreateFileMappingA(INVALID_HANDLE_VALUE,    // use paging file
+                                  NULL,                    // default security
+                                  PAGE_READWRITE,          // read/write access
+                                  (DWORD)((realShmSize >> 32) & 0xFFFFFFFF),  // high-order DWORD of size
+                                  (DWORD)(realShmSize & 0xFFFFFFFF),          // low-order DWORD of size
+                                  shmPath);                // name of mapping object
 
     if (hMapFile == NULL) {
       WARN("Error: failed to create shared memory mapping %s, error code: %lu", shmPath, GetLastError());
@@ -829,10 +830,9 @@ ncclResult_t ncclOsShmOpen(char* shmPath, size_t shmPathSize, size_t shmSize,
     INFO(NCCL_ALLOC, "Created shared memory mapping %s with %ld bytes", shmPath, realShmSize);
   } else {
     // Open existing file mapping object
-    hMapFile = OpenFileMappingA(
-      FILE_MAP_ALL_ACCESS,   // read/write access
-      FALSE,                 // do not inherit the name
-      shmPath);              // name of mapping object
+    hMapFile = OpenFileMappingA(FILE_MAP_ALL_ACCESS,   // read/write access
+                                FALSE,                 // do not inherit the name
+                                shmPath);              // name of mapping object
 
     if (hMapFile == NULL) {
       WARN("Error: failed to open shared memory mapping %s, error code: %lu", shmPath, GetLastError());
@@ -842,12 +842,11 @@ ncclResult_t ncclOsShmOpen(char* shmPath, size_t shmPathSize, size_t shmSize,
   }
 
   // Map view of the file mapping into address space
-  hptr = (char*)MapViewOfFile(
-    hMapFile,            // handle to map object
-    FILE_MAP_ALL_ACCESS, // read/write permission
-    0,                   // high-order DWORD of offset
-    0,                   // low-order DWORD of offset
-    realShmSize);        // number of bytes to map
+  hptr = (char*)MapViewOfFile(hMapFile,            // handle to map object
+                              FILE_MAP_ALL_ACCESS, // read/write permission
+                              0,                   // high-order DWORD of offset
+                              0,                   // low-order DWORD of offset
+                              realShmSize);        // number of bytes to map
 
   if (hptr == NULL) {
     WARN("Error: Could not map view of file %s size %zu, error code: %lu", shmPath, realShmSize, GetLastError());
@@ -865,19 +864,22 @@ ncclResult_t ncclOsShmOpen(char* shmPath, size_t shmPathSize, size_t shmSize,
   }
 
   if (devShmPtr) {
-    INFO(NCCL_ALLOC, "SHM legacy: sharing buffer with GPU via cudaHostRegister + cudaHostGetDevicePointer (host %p size %ld)", (void*)hptr, (long)realShmSize);
+    INFO(NCCL_ALLOC,
+         "SHM legacy: sharing buffer with GPU via cudaHostRegister + cudaHostGetDevicePointer (host %p size %ld)",
+         (void*)hptr, (long)realShmSize);
     cudaStreamCaptureMode mode = cudaStreamCaptureModeRelaxed;
     cudaError_t regRes = cudaThreadExchangeStreamCaptureMode(&mode);
     if (regRes == cudaSuccess)
       regRes = cudaHostRegister((void*)hptr, realShmSize, cudaHostRegisterPortable | cudaHostRegisterMapped);
-    if (regRes == cudaSuccess)
-      regRes = cudaHostGetDevicePointer(&dptr, (void*)hptr, 0);
-    if (regRes == cudaSuccess)
-      regRes = cudaThreadExchangeStreamCaptureMode(&mode);
+    if (regRes == cudaSuccess) regRes = cudaHostGetDevicePointer(&dptr, (void*)hptr, 0);
+    if (regRes == cudaSuccess) regRes = cudaThreadExchangeStreamCaptureMode(&mode);
     /* cudaHostRegister on MapViewOfFile memory often fails (driver limitation).
      * Do not fail the open; leave dptr unset so transport can use staging path. */
     if (regRes != cudaSuccess) {
-      INFO(NCCL_ALLOC, "SHM legacy: cudaHostRegister/cudaHostGetDevicePointer failed: %s; segment will be used unpinned (staging path)", cudaGetErrorString(regRes));
+      INFO(NCCL_ALLOC,
+           "SHM legacy: cudaHostRegister/cudaHostGetDevicePointer failed: %s; segment will be used unpinned (staging "
+           "path)",
+           cudaGetErrorString(regRes));
       dptr = NULL;
     }
   }
@@ -889,8 +891,7 @@ exit:
   *handle = tmphandle;
   return ret;
 fail:
-  WARN("Error while %s shared memory segment %s (size %ld)", create ? "creating" : "attaching to",
-       shmPath, shmSize);
+  WARN("Error while %s shared memory segment %s (size %ld)", create ? "creating" : "attaching to", shmPath, shmSize);
   if (tmphandle) {
     ncclOsShmHandleInit(hMapFile, shmPath, shmSize, realShmSize, hptr, dptr, create, tmphandle);
     (void)ncclOsShmClose(tmphandle);
@@ -907,16 +908,16 @@ ncclResult_t ncclOsShmClose(struct ncclShmHandleInternal* handle) {
     if (handle->shmPtr) {
       // if (handle->devShmPtr) CUDACHECK(cudaHostUnregister(handle->shmPtr));
       if (!UnmapViewOfFile(handle->shmPtr)) {
-        WARN("UnmapViewOfFile of shared memory %p size %ld failed, error code: %lu",
-             handle->shmPtr, handle->realShmSize, GetLastError());
+        WARN("UnmapViewOfFile of shared memory %p size %ld failed, error code: %lu", handle->shmPtr,
+             handle->realShmSize, GetLastError());
         ret = ncclSystemError;
       }
     }
 
     if (handle->shmDesc != NULL) {
       if (!CloseHandle(handle->shmDesc)) {
-        WARN("CloseHandle for shared memory %s failed, error code: %lu",
-             handle->shmPath ? handle->shmPath : "(null)", GetLastError());
+        WARN("CloseHandle for shared memory %s failed, error code: %lu", handle->shmPath ? handle->shmPath : "(null)",
+             GetLastError());
         ret = ncclSystemError;
       }
       free(handle->shmPath);

--- a/projects/rccl/src/os/windows_ipcsocket.cc
+++ b/projects/rccl/src/os/windows_ipcsocket.cc
@@ -30,7 +30,7 @@ struct ncclIpcMsg {
   char hdrData[PIPE_BUFFER_SIZE - sizeof(int) - sizeof(HANDLE) * 2];
 };
 
-ncclResult_t ncclIpcSocketInit(ncclIpcSocket *handle, int rank, uint64_t hash, volatile uint32_t* abortFlag) {
+ncclResult_t ncclIpcSocketInit(ncclIpcSocket* handle, int rank, uint64_t hash, volatile uint32_t* abortFlag) {
   if (handle == NULL) {
     return ncclInternalError;
   }
@@ -47,20 +47,19 @@ ncclResult_t ncclIpcSocketInit(ncclIpcSocket *handle, int rank, uint64_t hash, v
     return ncclInternalError;
   }
 
-  TRACE(NCCL_INIT|NCCL_P2P, "IPC: Creating named pipe %s", pipeName);
+  TRACE(NCCL_INIT | NCCL_P2P, "IPC: Creating named pipe %s", pipeName);
 
   // Create named pipe for receiving
-  HANDLE hPipe = CreateNamedPipeA(
-    pipeName,
-    PIPE_ACCESS_DUPLEX,       // Read/write access
-    PIPE_TYPE_MESSAGE |       // Message type pipe
-    PIPE_READMODE_MESSAGE |   // Message-read mode
-    PIPE_WAIT,                // Blocking mode
-    PIPE_UNLIMITED_INSTANCES, // Max instances
-    PIPE_BUFFER_SIZE,         // Output buffer size
-    PIPE_BUFFER_SIZE,         // Input buffer size
-    PIPE_TIMEOUT_MS,          // Client timeout
-    NULL                      // Default security
+  HANDLE hPipe = CreateNamedPipeA(pipeName,
+                                  PIPE_ACCESS_DUPLEX,       // Read/write access
+                                  PIPE_TYPE_MESSAGE |       // Message type pipe
+                                    PIPE_READMODE_MESSAGE |   // Message-read mode
+                                    PIPE_WAIT,                // Blocking mode
+                                  PIPE_UNLIMITED_INSTANCES, // Max instances
+                                  PIPE_BUFFER_SIZE,         // Output buffer size
+                                  PIPE_BUFFER_SIZE,         // Input buffer size
+                                  PIPE_TIMEOUT_MS,          // Client timeout
+                                  NULL                      // Default security
   );
 
   if (hPipe == INVALID_HANDLE_VALUE) {
@@ -73,7 +72,7 @@ ncclResult_t ncclIpcSocketInit(ncclIpcSocket *handle, int rank, uint64_t hash, v
   strncpy(handle->socketName, pipeName, NCCL_IPC_SOCKNAME_LEN);
   handle->socketName[NCCL_IPC_SOCKNAME_LEN - 1] = '\0';
 
-  TRACE(NCCL_INIT|NCCL_P2P, "IPC: Named pipe created successfully: %s (handle: %p)", pipeName, hPipe);
+  TRACE(NCCL_INIT | NCCL_P2P, "IPC: Named pipe created successfully: %s (handle: %p)", pipeName, hPipe);
   return ncclSuccess;
 }
 
@@ -86,7 +85,7 @@ ncclResult_t ncclIpcSocketGetFd(struct ncclIpcSocket* handle, int* fd) {
   return ncclSuccess;
 }
 
-ncclResult_t ncclIpcSocketClose(ncclIpcSocket *handle) {
+ncclResult_t ncclIpcSocketClose(ncclIpcSocket* handle) {
   if (handle == NULL) {
     return ncclInternalError;
   }
@@ -99,7 +98,7 @@ ncclResult_t ncclIpcSocketClose(ncclIpcSocket *handle) {
   return ncclSuccess;
 }
 
-ncclResult_t ncclIpcSocketRecvMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, int *recvFd) {
+ncclResult_t ncclIpcSocketRecvMsg(ncclIpcSocket* handle, void* hdr, int hdrLen, int* recvFd) {
   if (handle == NULL || handle->fd == NCCL_INVALID_SOCKET) {
     WARN("IPC: Invalid socket handle");
     return ncclInvalidArgument;
@@ -110,7 +109,7 @@ ncclResult_t ncclIpcSocketRecvMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, 
   DWORD bytesRead = 0;
   BOOL success = FALSE;
 
-  TRACE(NCCL_INIT|NCCL_P2P, "IPC: Waiting for connection on pipe %s", handle->socketName);
+  TRACE(NCCL_INIT | NCCL_P2P, "IPC: Waiting for connection on pipe %s", handle->socketName);
 
   // Wait for client to connect
   BOOL connected = ConnectNamedPipe(hPipe, NULL);
@@ -119,7 +118,7 @@ ncclResult_t ncclIpcSocketRecvMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, 
     return ncclSystemError;
   }
 
-  TRACE(NCCL_INIT|NCCL_P2P, "IPC: Client connected, reading message");
+  TRACE(NCCL_INIT | NCCL_P2P, "IPC: Client connected, reading message");
 
   // Read message with retry logic for abort flag
   while (TRUE) {
@@ -143,7 +142,7 @@ ncclResult_t ncclIpcSocketRecvMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, 
     return ncclSystemError;
   }
 
-  TRACE(NCCL_INIT|NCCL_P2P, "IPC: Read %d bytes from pipe", bytesRead);
+  TRACE(NCCL_INIT | NCCL_P2P, "IPC: Read %d bytes from pipe", bytesRead);
 
   // Copy header data if requested
   if (hdr != NULL && msg.hdrLen > 0) {
@@ -153,14 +152,13 @@ ncclResult_t ncclIpcSocketRecvMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, 
   // Duplicate handle if requested
   if (recvFd != NULL && msg.handleToDup != NULL) {
     HANDLE duplicatedHandle;
-    BOOL dupSuccess = DuplicateHandle(
-      msg.sourceProcess,      // Source process
-      msg.handleToDup,        // Source handle
-      GetCurrentProcess(),    // Target process
-      &duplicatedHandle,      // Target handle
-      0,                      // Desired access (same as source)
-      FALSE,                  // Not inheritable
-      DUPLICATE_SAME_ACCESS   // Same access as source
+    BOOL dupSuccess = DuplicateHandle(msg.sourceProcess,      // Source process
+                                      msg.handleToDup,        // Source handle
+                                      GetCurrentProcess(),    // Target process
+                                      &duplicatedHandle,      // Target handle
+                                      0,                      // Desired access (same as source)
+                                      FALSE,                  // Not inheritable
+                                      DUPLICATE_SAME_ACCESS   // Same access as source
     );
 
     if (!dupSuccess) {
@@ -169,17 +167,18 @@ ncclResult_t ncclIpcSocketRecvMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, 
     }
 
     *recvFd = (int)duplicatedHandle;
-    TRACE(NCCL_INIT|NCCL_P2P, "IPC: Duplicated handle %p -> %p", msg.handleToDup, duplicatedHandle);
+    TRACE(NCCL_INIT | NCCL_P2P, "IPC: Duplicated handle %p -> %p", msg.handleToDup, duplicatedHandle);
   }
 
   return ncclSuccess;
 }
 
-ncclResult_t ncclIpcSocketRecvFd(ncclIpcSocket *handle, int *fd) {
+ncclResult_t ncclIpcSocketRecvFd(ncclIpcSocket* handle, int* fd) {
   return ncclIpcSocketRecvMsg(handle, NULL, 0, fd);
 }
 
-ncclResult_t ncclIpcSocketSendMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, const int sendFd, int rank, uint64_t hash) {
+ncclResult_t ncclIpcSocketSendMsg(ncclIpcSocket* handle, void* hdr, int hdrLen, const int sendFd, int rank,
+                                  uint64_t hash) {
   // Construct target pipe name
   char pipeName[NCCL_IPC_SOCKNAME_LEN];
   int len = snprintf(pipeName, NCCL_IPC_SOCKNAME_LEN, NCCL_IPC_PIPENAME_STR, rank, hash);
@@ -188,20 +187,18 @@ ncclResult_t ncclIpcSocketSendMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, 
     return ncclInternalError;
   }
 
-  TRACE(NCCL_INIT|NCCL_P2P, "IPC: Connecting to pipe %s", pipeName);
+  TRACE(NCCL_INIT | NCCL_P2P, "IPC: Connecting to pipe %s", pipeName);
 
   // Connect to the named pipe with retry logic (retries indefinitely until success or abort)
   HANDLE hPipe = INVALID_HANDLE_VALUE;
 
   while (TRUE) {
-    hPipe = CreateFileA(
-      pipeName,
-      GENERIC_READ | GENERIC_WRITE,
-      0,              // No sharing
-      NULL,           // Default security
-      OPEN_EXISTING,  // Opens existing pipe
-      0,              // Default attributes
-      NULL            // No template
+    hPipe = CreateFileA(pipeName, GENERIC_READ | GENERIC_WRITE,
+                        0,              // No sharing
+                        NULL,           // Default security
+                        OPEN_EXISTING,  // Opens existing pipe
+                        0,              // Default attributes
+                        NULL            // No template
     );
 
     if (hPipe != INVALID_HANDLE_VALUE) {
@@ -221,7 +218,7 @@ ncclResult_t ncclIpcSocketSendMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, 
     }
   }
 
-  TRACE(NCCL_INIT|NCCL_P2P, "IPC: Connected to pipe %s", pipeName);
+  TRACE(NCCL_INIT | NCCL_P2P, "IPC: Connected to pipe %s", pipeName);
 
   // Set pipe to message mode
   DWORD mode = PIPE_READMODE_MESSAGE;
@@ -243,7 +240,7 @@ ncclResult_t ncclIpcSocketSendMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, 
     memcpy(msg.hdrData, hdr, copyLen);
   }
 
-  TRACE(NCCL_INIT|NCCL_P2P, "IPC: Sending message (hdrLen=%d, handle=%p)", hdrLen, msg.handleToDup);
+  TRACE(NCCL_INIT | NCCL_P2P, "IPC: Sending message (hdrLen=%d, handle=%p)", hdrLen, msg.handleToDup);
 
   // Send message
   DWORD bytesWritten = 0;
@@ -258,12 +255,12 @@ ncclResult_t ncclIpcSocketSendMsg(ncclIpcSocket *handle, void *hdr, int hdrLen, 
   // Flush to ensure message is sent
   FlushFileBuffers(hPipe);
 
-  TRACE(NCCL_INIT|NCCL_P2P, "IPC: Message sent successfully (%d bytes)", bytesWritten);
+  TRACE(NCCL_INIT | NCCL_P2P, "IPC: Message sent successfully (%d bytes)", bytesWritten);
 
   CloseHandle(hPipe);
   return ncclSuccess;
 }
 
-ncclResult_t ncclIpcSocketSendFd(ncclIpcSocket *handle, const int sendFd, int rank, uint64_t hash) {
+ncclResult_t ncclIpcSocketSendFd(ncclIpcSocket* handle, const int sendFd, int rank, uint64_t hash) {
   return ncclIpcSocketSendMsg(handle, NULL, 0, sendFd, rank, hash);
 }

--- a/projects/rccl/src/os/windows_stubs.cc
+++ b/projects/rccl/src/os/windows_stubs.cc
@@ -60,8 +60,7 @@ ncclResult_t ncclNetInitFromParent(struct ncclComm* comm, struct ncclComm* paren
 }
 
 ncclResult_t ncclNetFinalize(struct ncclComm* comm) {
-  if (comm->ncclNet && comm->netContext)
-    NCCLCHECK(comm->ncclNet->finalize(comm->netContext));
+  if (comm->ncclNet && comm->netContext) NCCLCHECK(comm->ncclNet->finalize(comm->netContext));
   return ncclSuccess;
 }
 
@@ -126,7 +125,7 @@ ncclResult_t getGlobalGinType(struct ncclComm* comm, ncclGinType_t* ginType) {
 
 /* GIN requirement/create stubs (implemented in gin_barrier.cc and gin_scratch.cc on Linux only) */
 ncclResult_t ncclGinBarrierCreateRequirement(ncclComm_t comm, ncclTeam_t team, int nBarriers,
-                                            ncclGinBarrierHandle_t* outHandle, ncclDevResourceRequirements_t* outReq) {
+                                             ncclGinBarrierHandle_t* outHandle, ncclDevResourceRequirements_t* outReq) {
   (void)comm;
   (void)team;
   (void)nBarriers;
@@ -135,8 +134,8 @@ ncclResult_t ncclGinBarrierCreateRequirement(ncclComm_t comm, ncclTeam_t team, i
   return ncclSuccess;
 }
 
-ncclResult_t ncclGinOutboxCreateRequirement(int nBlocks, int size_log2,
-                                            ncclGinOutboxHandle* outHandle, ncclDevResourceRequirements_t* outReq) {
+ncclResult_t ncclGinOutboxCreateRequirement(int nBlocks, int size_log2, ncclGinOutboxHandle* outHandle,
+                                            ncclDevResourceRequirements_t* outReq) {
   (void)nBlocks;
   (void)size_log2;
   (void)outHandle;
@@ -165,7 +164,8 @@ ncclResult_t ncclGinConnectOnce(struct ncclComm* comm) {
   return ncclSuccess;
 }
 
-ncclResult_t ncclGinDevCommSetup(struct ncclComm* comm, struct ncclDevCommRequirements const* reqs, struct ncclDevComm* devComm) {
+ncclResult_t ncclGinDevCommSetup(struct ncclComm* comm, struct ncclDevCommRequirements const* reqs,
+                                 struct ncclDevComm* devComm) {
   (void)comm;
   (void)reqs;
   (void)devComm;
@@ -180,8 +180,8 @@ ncclResult_t ncclGinDevCommFree(struct ncclComm* comm, struct ncclDevComm const*
 
 ncclResult_t ncclGinRegister(struct ncclComm* comm, void* address, size_t size,
                              void* ginHostWins[NCCL_GIN_MAX_CONNECTIONS],
-                             ncclGinWindow_t ginDevWins[NCCL_GIN_MAX_CONNECTIONS], int winFlags,
-                             bool multiSegment, int memType) {
+                             ncclGinWindow_t ginDevWins[NCCL_GIN_MAX_CONNECTIONS], int winFlags, bool multiSegment,
+                             int memType) {
   (void)comm;
   (void)address;
   (void)size;
@@ -240,9 +240,8 @@ int64_t ncclParamGinEnable(void) {
 /* --------------------------------------------------------------------------
  * Profiler plugin stubs and globals
  * -------------------------------------------------------------------------- */
-thread_local ncclProfilerApiState_t ncclProfilerApiState = {
-  0, 0, ncclProfilerGroupApiStartStateReset, nullptr, nullptr, nullptr
-};
+thread_local ncclProfilerApiState_t ncclProfilerApiState = {0,       0,       ncclProfilerGroupApiStartStateReset,
+                                                            nullptr, nullptr, nullptr};
 
 int ncclProfilerEventMask = 0;
 
@@ -396,7 +395,8 @@ ncclResult_t ncclProfilerRecordProxyOpEventState(int sub, struct ncclProxyArgs* 
   return ncclSuccess;
 }
 
-ncclResult_t ncclProfilerRecordProxyStepEventState(int sub, struct ncclProxyArgs* args, int stepId, ncclProfilerEventState_t eState) {
+ncclResult_t ncclProfilerRecordProxyStepEventState(int sub, struct ncclProxyArgs* args, int stepId,
+                                                   ncclProfilerEventState_t eState) {
   (void)sub;
   (void)args;
   (void)stepId;
@@ -432,7 +432,8 @@ ncclResult_t ncclProfilerStopCeCollEvent(struct ncclComm* comm, struct ncclCeCol
   return ncclSuccess;
 }
 
-ncclResult_t ncclProfilerStartCeSyncEvent(struct ncclComm* comm, struct ncclCeCollArgs* args, cudaStream_t stream, void** ceSyncHandle) {
+ncclResult_t ncclProfilerStartCeSyncEvent(struct ncclComm* comm, struct ncclCeCollArgs* args, cudaStream_t stream,
+                                          void** ceSyncHandle) {
   (void)comm;
   (void)args;
   (void)stream;
@@ -447,7 +448,9 @@ ncclResult_t ncclProfilerStopCeSyncEvent(struct ncclComm* comm, void* ceSyncHand
   return ncclSuccess;
 }
 
-ncclResult_t ncclProfilerStartCeBatchEvent(struct ncclComm* comm, struct ncclCeCollArgs* args, struct ncclCeBatchOpsParams* params, cudaStream_t stream, void** ceBatchHandle) {
+ncclResult_t ncclProfilerStartCeBatchEvent(struct ncclComm* comm, struct ncclCeCollArgs* args,
+                                           struct ncclCeBatchOpsParams* params, cudaStream_t stream,
+                                           void** ceBatchHandle) {
   (void)comm;
   (void)args;
   (void)params;

--- a/projects/rccl/src/param/c_api.cc
+++ b/projects/rccl/src/param/c_api.cc
@@ -37,8 +37,10 @@ static inline void ncclParamCheckFlag(uint64_t flags, const char* key) {
   if (flags & NCCL_PARAM_FLAG_UNUSED) {
     INFO(NCCL_ENV, "Warning: ENV %s is unused. Setting it has no effect.", key);
   } else if (flags & NCCL_PARAM_FLAG_DEPRECATED) {
-    INFO(NCCL_ENV, "Warning: ENV %s is deprecated. "
-         "It may be removed or become unused in future versions.", key);
+    INFO(NCCL_ENV,
+         "Warning: ENV %s is deprecated. "
+         "It may be removed or become unused in future versions.",
+         key);
   }
 
   if (!(flags & NCCL_PARAM_FLAG_PUBLISHED)) {
@@ -67,25 +69,24 @@ ncclResult_t ncclParamBind(ncclParamHandle_t** out, const char* key) {
 // Typed Getters — dispatch via typeId + getRawData()
 // ============================================================================
 
-#define NCCL_PARAM_DEFINE_TYPED_GETTER(suffix, ctype, tid)                    \
-  NCCL_API(ncclResult_t, ncclParamGet##suffix,                               \
-           ncclParamHandle_t* h, ctype* out);                                 \
-  ncclResult_t ncclParamGet##suffix(ncclParamHandle_t* h, ctype* out) {      \
-    if (!h || !out) return ncclInvalidArgument;                               \
-    auto* e = unwrap(h);                                                      \
-    if (e->info.typeId != (tid)) {                                            \
-      INFO(NCCL_ENV, "PARAM: type mismatch for key \"%s\"", e->info.key);    \
-      return ncclInvalidArgument;                                             \
-    }                                                                         \
-    int len = 0;                                                              \
-    return e->param->getRawData(out, sizeof(*out), &len);                     \
+#define NCCL_PARAM_DEFINE_TYPED_GETTER(suffix, ctype, tid) \
+  NCCL_API(ncclResult_t, ncclParamGet##suffix, ncclParamHandle_t* h, ctype* out); \
+  ncclResult_t ncclParamGet##suffix(ncclParamHandle_t* h, ctype* out) { \
+    if (!h || !out) return ncclInvalidArgument; \
+    auto* e = unwrap(h); \
+    if (e->info.typeId != (tid)) { \
+      INFO(NCCL_ENV, "PARAM: type mismatch for key \"%s\"", e->info.key); \
+      return ncclInvalidArgument; \
+    } \
+    int len = 0; \
+    return e->param->getRawData(out, sizeof(*out), &len); \
   }
 
-NCCL_PARAM_DEFINE_TYPED_GETTER(I8,  int8_t,   NCCL_PARAM_TYPE_I8)
-NCCL_PARAM_DEFINE_TYPED_GETTER(I16, int16_t,  NCCL_PARAM_TYPE_I16)
-NCCL_PARAM_DEFINE_TYPED_GETTER(I32, int32_t,  NCCL_PARAM_TYPE_I32)
-NCCL_PARAM_DEFINE_TYPED_GETTER(I64, int64_t,  NCCL_PARAM_TYPE_I64)
-NCCL_PARAM_DEFINE_TYPED_GETTER(U8,  uint8_t,  NCCL_PARAM_TYPE_U8)
+NCCL_PARAM_DEFINE_TYPED_GETTER(I8, int8_t, NCCL_PARAM_TYPE_I8)
+NCCL_PARAM_DEFINE_TYPED_GETTER(I16, int16_t, NCCL_PARAM_TYPE_I16)
+NCCL_PARAM_DEFINE_TYPED_GETTER(I32, int32_t, NCCL_PARAM_TYPE_I32)
+NCCL_PARAM_DEFINE_TYPED_GETTER(I64, int64_t, NCCL_PARAM_TYPE_I64)
+NCCL_PARAM_DEFINE_TYPED_GETTER(U8, uint8_t, NCCL_PARAM_TYPE_U8)
 NCCL_PARAM_DEFINE_TYPED_GETTER(U16, uint16_t, NCCL_PARAM_TYPE_U16)
 NCCL_PARAM_DEFINE_TYPED_GETTER(U32, uint32_t, NCCL_PARAM_TYPE_U32)
 NCCL_PARAM_DEFINE_TYPED_GETTER(U64, uint64_t, NCCL_PARAM_TYPE_U64)
@@ -176,7 +177,7 @@ ncclResult_t ncclParamGetParameter(const char* key, const char** value, int* val
 }
 
 NCCL_API(void, ncclParamDumpAll);
-void ncclParamDumpAll(){
+void ncclParamDumpAll() {
   bool showAll = ncclParamDumpAllFlag();
   printf("=== ncclParam Registry Dump ===\n");
   std::lock_guard<std::mutex> regLock(ncclParamRegistry::mutex());

--- a/projects/rccl/src/param/param.cc
+++ b/projects/rccl/src/param/param.cc
@@ -13,13 +13,11 @@
 
 #include <unordered_set>
 
-DEFINE_NCCL_PARAM(ncclParamDumpAllFlag, bool, NCCL_PARAM_DUMP_ALL, false,
-                  NCCL_PARAM_FLAG_NONE, NCCL_PARAM_DEFAULT,
+DEFINE_NCCL_PARAM(ncclParamDumpAllFlag, bool, NCCL_PARAM_DUMP_ALL, false, NCCL_PARAM_FLAG_NONE, NCCL_PARAM_DEFAULT,
                   "Print all parameters including private ones");
 
 using ncclStringSet = std::unordered_set<std::string>;
-DEFINE_NCCL_PARAM(ncclParamNoCacheStr, const char *, NCCL_NO_CACHE, nullptr,
-                  NCCL_PARAM_FLAG_CACHED, NCCL_PARAM_DEFAULT,
+DEFINE_NCCL_PARAM(ncclParamNoCacheStr, const char*, NCCL_NO_CACHE, nullptr, NCCL_PARAM_FLAG_CACHED, NCCL_PARAM_DEFAULT,
                   "Comma-separated list of param keys to disable caching (or ALL)");
 
 extern "C" NCCL_PARAM_COMPILER_EXPORT_SYMBOL bool ncclParamIsCacheDisabled(const char* key) {
@@ -50,4 +48,3 @@ extern "C" NCCL_PARAM_COMPILER_EXPORT_SYMBOL const char* ncclParamEnvPluginGet(c
   ncclInitEnv();
   return ncclEnvPluginGetEnv(key);
 }
-

--- a/projects/rccl/src/param/param_registry.cc
+++ b/projects/rccl/src/param/param_registry.cc
@@ -13,8 +13,7 @@ extern "C" NCCL_PARAM_COMPILER_EXPORT_SYMBOL void* ncclParamRegistryInstance() {
   return &state;
 }
 
-ncclResult_t ncclParamRegistry::add(std::string key, ncclParamInfo_t info,
-                                    ncclParamInterface* param) {
+ncclResult_t ncclParamRegistry::add(std::string key, ncclParamInfo_t info, ncclParamInterface* param) {
   auto& reg = state();
   std::lock_guard<std::mutex> lock(reg.mtx);
   if (reg.map.find(key) != reg.map.end()) {

--- a/projects/rccl/src/plugin/env.cc
+++ b/projects/rccl/src/plugin/env.cc
@@ -25,12 +25,12 @@ extern ncclEnv_v1_t ncclIntEnv_v1;
 #define EXT_ENV_PLUGIN 0
 #define INT_ENV_PLUGIN 1
 #define NUM_ENV_PLUGIN 2
-static ncclEnv_t *ncclEnvPlugins[NUM_ENV_PLUGIN] = { nullptr, &ncclIntEnv_v1 };
+static ncclEnv_t* ncclEnvPlugins[NUM_ENV_PLUGIN] = {nullptr, &ncclIntEnv_v1};
 
 enum {
-  envPluginLoadFailed  = -1,
-  envPluginLoadReady   =  0,
-  envPluginLoadSuccess =  1,
+  envPluginLoadFailed = -1,
+  envPluginLoadReady = 0,
+  envPluginLoadSuccess = 1,
 };
 static int envPluginStatus = envPluginLoadReady;
 
@@ -89,7 +89,8 @@ static bool initialized;
 ncclResult_t ncclEnvPluginInit(void) {
   initEnv();
   NCCLCHECK(ncclEnvPluginLoad());
-  ncclEnvPlugin = (envPluginLoadSuccess == envPluginStatus) ? ncclEnvPlugins[EXT_ENV_PLUGIN] : ncclEnvPlugins[INT_ENV_PLUGIN];
+  ncclEnvPlugin =
+    (envPluginLoadSuccess == envPluginStatus) ? ncclEnvPlugins[EXT_ENV_PLUGIN] : ncclEnvPlugins[INT_ENV_PLUGIN];
   NCCLCHECK(ncclEnvPlugin->init(NCCL_MAJOR, NCCL_MINOR, NCCL_PATCH, NCCL_SUFFIX));
   atexit(ncclEnvPluginFinalize);
   COMPILER_ATOMIC_STORE(&initialized, true, std::memory_order_release);

--- a/projects/rccl/src/plugin/env/env_v1.cc
+++ b/projects/rccl/src/plugin/env/env_v1.cc
@@ -15,7 +15,7 @@ static ncclEnv_v1_t* ncclEnv_v1;
 ncclEnv_t* getNcclEnv_v1(void* lib) {
   ncclEnv_v1 = (ncclEnv_v1_t*)ncclOsDlsym(lib, "ncclEnvPlugin_v1");
   if (ncclEnv_v1) {
-    INFO(NCCL_INIT|NCCL_ENV, "ENV/Plugin: Using %s (v1)", ncclEnv_v1->name);
+    INFO(NCCL_INIT | NCCL_ENV, "ENV/Plugin: Using %s (v1)", ncclEnv_v1->name);
     return ncclEnv_v1;
   }
   return nullptr;

--- a/projects/rccl/src/plugin/gin.cc
+++ b/projects/rccl/src/plugin/gin.cc
@@ -14,7 +14,7 @@
 #include <string.h>
 #include <errno.h>
 #include <mutex>
-//Temporary stubs
+// Temporary stubs
 
 typedef ncclGin_t* getNcclGin_t(void* ginPluginLib);
 
@@ -34,11 +34,11 @@ extern ncclGin_t* getNcclGin_v12_internal(ncclGin_v12_t* ncclGin_v12);
 #define NCCL_GIN_NUM_INTERNAL_PLUGINS 1
 
 typedef enum ncclGinPluginState {
-  ncclGinPluginStateDisabled        = -2,       // Plugin library failed to initialize
-  ncclGinPluginStateLoadFailed      = -1,       // Plugin library failed to load
-  ncclGinPluginStateLoadReady       = 0,        // Plugin library is ready to be loaded
-  ncclGinPluginStateInitReady       = 1,        // Plugin library is loaded and ready to be initialized
-  ncclGinPluginStateEnabled         = 2,        // Plugin library is loaded and initialized
+  ncclGinPluginStateDisabled = -2,       // Plugin library failed to initialize
+  ncclGinPluginStateLoadFailed = -1,       // Plugin library failed to load
+  ncclGinPluginStateLoadReady = 0,        // Plugin library is ready to be loaded
+  ncclGinPluginStateInitReady = 1,        // Plugin library is loaded and ready to be initialized
+  ncclGinPluginStateEnabled = 2,        // Plugin library is loaded and initialized
 } ncclGinPluginState_t;
 
 #define MAX_STR_LEN 255
@@ -55,13 +55,13 @@ typedef struct ginPluginLib {
 } ginPluginLib_t;
 
 static int pluginCount = 0;
-static ginPluginLib_t ginPluginLibs[NCCL_GIN_MAX_PLUGINS] = { 0 };
+static ginPluginLib_t ginPluginLibs[NCCL_GIN_MAX_PLUGINS] = {0};
 static std::mutex ginPluginMutex;
 static std::once_flag initPluginLibsOnceFlag;
 
 static ncclResult_t ncclGinPluginUnload(ginPluginLib_t* pluginLib) {
   if (pluginLib->dlHandle && pluginLib->ncclGinPluginRefCount == 0) {
-    INFO(NCCL_DESTROY|NCCL_NET, "Unloading plugin %s", pluginLib->name);
+    INFO(NCCL_DESTROY | NCCL_NET, "Unloading plugin %s", pluginLib->name);
     NCCLCHECK(ncclClosePluginLib(pluginLib->dlHandle, ncclPluginTypeGin));
 
     // Reset fields but preserve name, to be reused when reloading
@@ -91,12 +91,10 @@ static ncclResult_t ncclGinPluginLoad(ginPluginLib_t* pluginLib) {
     if (pluginLib->ncclGin) break;
   }
 
-  if (pluginLib->ncclGin == nullptr)
-    pluginLib->ncclGinPluginState = ncclGinPluginStateLoadFailed;
-  else
-    pluginLib->ncclGinPluginState = ncclGinPluginStateInitReady;
+  if (pluginLib->ncclGin == nullptr) pluginLib->ncclGinPluginState = ncclGinPluginStateLoadFailed;
+  else pluginLib->ncclGinPluginState = ncclGinPluginStateInitReady;
 
-  INFO(NCCL_INIT|NCCL_NET, "Successfully loaded external gin plugin %s",
+  INFO(NCCL_INIT | NCCL_NET, "Successfully loaded external gin plugin %s",
        (ncclPluginLibPaths[ncclPluginTypeGin] ? ncclPluginLibPaths[ncclPluginTypeGin] : pluginLib->name));
 exit:
   return ncclSuccess;
@@ -120,8 +118,7 @@ static ncclResult_t ncclGinPluginInit(struct ncclComm* comm, ginPluginLib_t* plu
   if (pluginLib->ncclGinPluginState == ncclGinPluginStateInitReady && pluginLib->ncclGin) {
     if (pluginLib->ncclGin->devices(&ndev) != ncclSuccess || ndev <= 0) {
       pluginLib->ncclGinPluginState = ncclGinPluginStateDisabled;
-      }
-    else {
+    } else {
       pluginLib->ginPhysDevs = ndev;
       pluginLib->ncclGinPluginState = ncclGinPluginStateEnabled;
     }
@@ -136,8 +133,7 @@ static ncclResult_t ncclGinPluginInit(struct ncclComm* comm, ginPluginLib_t* plu
   if (pluginLib->ncclRmaPluginState == ncclGinPluginStateInitReady && pluginLib->ncclRma) {
     if (pluginLib->ncclRma->devices(&ndev) != ncclSuccess || ndev <= 0) {
       pluginLib->ncclRmaPluginState = ncclGinPluginStateDisabled;
-    }
-    else {
+    } else {
       pluginLib->ncclRmaPluginState = ncclGinPluginStateEnabled;
     }
   }
@@ -148,14 +144,14 @@ static ncclResult_t ncclGinPluginAssignToComm(struct ncclComm* comm, int pluginI
   *isAssigned = false;
 
   if (ginPluginLibs[pluginIndex].ncclGinPluginState >= ncclGinPluginStateEnabled) {
-    INFO(NCCL_INIT|NCCL_NET, "Assigned GIN plugin %s to comm", ginPluginLibs[pluginIndex].ncclGin->name);
+    INFO(NCCL_INIT | NCCL_NET, "Assigned GIN plugin %s to comm", ginPluginLibs[pluginIndex].ncclGin->name);
     comm->sharedRes->ginState.ncclGin = ginPluginLibs[pluginIndex].ncclGin;
     comm->sharedRes->ginState.ginVersion = ginPluginLibs[pluginIndex].ncclGinVersion;
     comm->ginPluginIndex = pluginIndex;
     NCCLCHECK(setLocalGinType(comm));
   }
   if (ginPluginLibs[pluginIndex].ncclRmaPluginState >= ncclGinPluginStateEnabled) {
-    INFO(NCCL_INIT|NCCL_NET, "Assigned RMA plugin %s to comm", ginPluginLibs[pluginIndex].ncclRma->name);
+    INFO(NCCL_INIT | NCCL_NET, "Assigned RMA plugin %s to comm", ginPluginLibs[pluginIndex].ncclRma->name);
     comm->rmaState.rmaProxyState.ncclGin = ginPluginLibs[pluginIndex].ncclRma;
   }
   ginPluginLibs[pluginIndex].ncclGinPluginRefCount++;
@@ -166,16 +162,17 @@ static ncclResult_t ncclGinPluginAssignToComm(struct ncclComm* comm, int pluginI
 static ncclResult_t ncclGinPluginDisableOtherExternal(int pluginIndex) {
   // Only if an external plugin is enabled, disable other external plugins
   if (pluginIndex >= (pluginCount - NCCL_GIN_NUM_INTERNAL_PLUGINS)) return ncclSuccess;
-  char names[MAX_STR_LEN*(NCCL_GIN_MAX_PLUGINS - NCCL_GIN_NUM_INTERNAL_PLUGINS)] = { 0 };
+  char names[MAX_STR_LEN * (NCCL_GIN_MAX_PLUGINS - NCCL_GIN_NUM_INTERNAL_PLUGINS)] = {0};
   for (int i = 0; i < (pluginCount - NCCL_GIN_NUM_INTERNAL_PLUGINS); i++) {
     if (i != pluginIndex) {
       // Append all disabled plugin names to a string
-      snprintf(names+strlen(names), sizeof(names)-strlen(names), (strlen(names) == 0) ? "%s" : ", %s", ginPluginLibs[i].name);
+      snprintf(names + strlen(names), sizeof(names) - strlen(names), (strlen(names) == 0) ? "%s" : ", %s",
+               ginPluginLibs[i].name);
       ginPluginLibs[i].ncclGinPluginState = ncclGinPluginStateDisabled;
     }
   }
-  if(strlen(names) > 0) {
-    INFO(NCCL_INIT|NCCL_NET, "Disabling external plugins: %s", names);
+  if (strlen(names) > 0) {
+    INFO(NCCL_INIT | NCCL_NET, "Disabling external plugins: %s", names);
   }
   return ncclSuccess;
 }
@@ -191,26 +188,28 @@ static void initPluginLibsOnceFunc() {
   memset(ginPluginLibs, 0, NCCL_GIN_MAX_PLUGINS * sizeof(ginPluginLib_t));
   envGinPlugin = ncclGetEnv("NCCL_GIN_PLUGIN");
   if (envGinPlugin) {
-    INFO(NCCL_ENV|NCCL_NET, "NCCL_GIN_PLUGIN set by environment to %s", envGinPlugin);
-    if (strcasecmp(envGinPlugin, "none") == 0)
-      envGinPlugin = "";
+    INFO(NCCL_ENV | NCCL_NET, "NCCL_GIN_PLUGIN set by environment to %s", envGinPlugin);
+    if (strcasecmp(envGinPlugin, "none") == 0) envGinPlugin = "";
     envGinPluginList = strdup(envGinPlugin);
     // Iterate over list until the list is empty
     ginPluginName = strtok_r(envGinPluginList, ",", &savePtr);
-    while(ginPluginName) {
+    while (ginPluginName) {
       // So, we can have at most( NCCL_GIN_MAX_PLUGINS - (NCCL_GIN_NUM_INTERNAL_PLUGINS)) in the NCCL_GIN_PLUGIN list
       if (pluginCounter >= (NCCL_GIN_MAX_PLUGINS - (NCCL_GIN_NUM_INTERNAL_PLUGINS))) {
-        INFO(NCCL_NET|NCCL_ENV,"NCCL_GIN_PLUGIN list contains more than %d plugins, ignoring the rest", (NCCL_GIN_MAX_PLUGINS - (NCCL_GIN_NUM_INTERNAL_PLUGINS + 1)));
+        INFO(NCCL_NET | NCCL_ENV, "NCCL_GIN_PLUGIN list contains more than %d plugins, ignoring the rest",
+             (NCCL_GIN_MAX_PLUGINS - (NCCL_GIN_NUM_INTERNAL_PLUGINS + 1)));
         break;
       }
       // need to leave space for the name + "\n"
-      if ((strlen(ginPluginName)+1) <= MAX_STR_LEN) {
+      if ((strlen(ginPluginName) + 1) <= MAX_STR_LEN) {
         ginPluginLibs[pluginCounter].ncclGinPluginState = ncclGinPluginStateLoadReady;
         ginPluginLibs[pluginCounter].ncclGinPluginRefCount = ncclParamGinPluginRefCount();
         strcpy(ginPluginLibs[pluginCounter].name, ginPluginName);
         pluginCounter++;
       } else {
-        INFO(NCCL_NET|NCCL_ENV,"NCCL_GIN_PLUGIN list contains a plugin name %s longer than %d characters, ignoring it.", ginPluginName, MAX_STR_LEN);
+        INFO(NCCL_NET | NCCL_ENV,
+             "NCCL_GIN_PLUGIN list contains a plugin name %s longer than %d characters, ignoring it.", ginPluginName,
+             MAX_STR_LEN);
       }
       ginPluginName = strtok_r(nullptr, ",", &savePtr);
     }
@@ -251,13 +250,14 @@ static void initPluginLibsOnceFunc() {
 
   pluginCounter++;
 
-
   pluginCount = pluginCounter;
 }
 
 static ncclResult_t ncclGinPluginFinalize(struct ncclComm* comm, int pluginIndex) {
-  if (ginPluginLibs[pluginIndex].ncclRma && ginPluginLibs[pluginIndex].ncclRmaPluginState == ncclGinPluginStateEnabled) NCCLCHECK(ginPluginLibs[pluginIndex].ncclRma->finalize(comm->rmaGinContext));
-  if (ginPluginLibs[pluginIndex].ncclGin && ginPluginLibs[pluginIndex].ncclGinPluginState == ncclGinPluginStateEnabled) NCCLCHECK(ginPluginLibs[pluginIndex].ncclGin->finalize(comm->ginContext));
+  if (ginPluginLibs[pluginIndex].ncclRma && ginPluginLibs[pluginIndex].ncclRmaPluginState == ncclGinPluginStateEnabled)
+    NCCLCHECK(ginPluginLibs[pluginIndex].ncclRma->finalize(comm->rmaGinContext));
+  if (ginPluginLibs[pluginIndex].ncclGin && ginPluginLibs[pluginIndex].ncclGinPluginState == ncclGinPluginStateEnabled)
+    NCCLCHECK(ginPluginLibs[pluginIndex].ncclGin->finalize(comm->ginContext));
   ginPluginLibs[pluginIndex].ncclGinPluginRefCount--;
   if (pluginIndex < (pluginCount - NCCL_GIN_NUM_INTERNAL_PLUGINS)) {
     NCCLCHECK(ncclGinPluginUnload(&ginPluginLibs[pluginIndex]));
@@ -270,7 +270,8 @@ ncclResult_t ncclGinInit(struct ncclComm* comm) {
   std::call_once(initPluginLibsOnceFlag, initPluginLibsOnceFunc);
   std::lock_guard<std::mutex> lock(ginPluginMutex);
   for (int pluginIndex = 0; pluginIndex < pluginCount; pluginIndex++) {
-    if (pluginIndex < (pluginCount - NCCL_GIN_NUM_INTERNAL_PLUGINS) && ginPluginLibs[pluginIndex].ncclGinPluginState == ncclGinPluginStateLoadReady) {
+    if (pluginIndex < (pluginCount - NCCL_GIN_NUM_INTERNAL_PLUGINS) &&
+        ginPluginLibs[pluginIndex].ncclGinPluginState == ncclGinPluginStateLoadReady) {
       NCCLCHECK(ncclGinPluginLoad(&ginPluginLibs[pluginIndex]));
     }
     if (ginPluginLibs[pluginIndex].ncclGinPluginState >= ncclGinPluginStateInitReady) {
@@ -290,7 +291,7 @@ ncclResult_t ncclGinInit(struct ncclComm* comm) {
       }
     }
   }
-  if (!ncclGinPluginInitialized) INFO(NCCL_INIT|NCCL_NET, "Failed to initialize any GIN plugin");
+  if (!ncclGinPluginInitialized) INFO(NCCL_INIT | NCCL_NET, "Failed to initialize any GIN plugin");
   return ncclSuccess;
 }
 
@@ -310,7 +311,8 @@ ncclResult_t ncclGinFinalize(struct ncclComm* comm) {
 
 ncclResult_t ncclGinGetDevCount(int ginPluginIndex, int* nPhysDevs, int* nVirtDevs) {
   if (ginPluginLibs[ginPluginIndex].ncclGinPluginState != ncclGinPluginStateEnabled ||
-     ginPluginLibs[ginPluginIndex].ginPhysDevs == 0) goto fail;
+      ginPluginLibs[ginPluginIndex].ginPhysDevs == 0)
+    goto fail;
   // lock not needed as it's called within a lock already in ncclTopoGetSystem
   *nPhysDevs = ginPluginLibs[ginPluginIndex].ginPhysDevs;
   return ncclSuccess;

--- a/projects/rccl/src/plugin/gin/gin_v11.cc
+++ b/projects/rccl/src/plugin/gin/gin_v11.cc
@@ -13,8 +13,8 @@
 static ncclGin_v11_t* ncclGin_v11;
 static ncclGin_t ncclGin;
 
-static ncclResult_t ncclGin_createContext(void* collComm, ncclGinConfig_t* config,
-    void** ginCtx, ncclNetDeviceHandle_t** devHandle) {
+static ncclResult_t ncclGin_createContext(void* collComm, ncclGinConfig_t* config, void** ginCtx,
+                                          ncclNetDeviceHandle_t** devHandle) {
   if (config->nContexts > 1) {
     WARN("GIN plugin v11 does not support multiple contexts");
     return ncclInvalidUsage;
@@ -36,7 +36,7 @@ static ncclResult_t ncclGin_destroyContext(void* ginCtx) {
 }
 
 static ncclResult_t ncclGin_iput(void* ginCtx, int context, uint64_t srcOff, void* srcMhandle, size_t size,
-    uint64_t dstOff, void* dstMhandle, uint32_t rank, void** request) {
+                                 uint64_t dstOff, void* dstMhandle, uint32_t rank, void** request) {
   if (context != 0) {
     WARN("GIN plugin v11 does not support multiple contexts");
     return ncclInvalidUsage;
@@ -51,14 +51,15 @@ static ncclResult_t ncclGin_iflush(void* ginCtx, int context, void* mhandle, uin
   return ncclSuccess;
 }
 
-static ncclResult_t ncclGin_iputSignal(void* ginCtx, int context, uint64_t srcOff, void* srcMhandle,
-    size_t size, uint64_t dstOff, void* dstMhandle, uint32_t rank, uint64_t signalOff, void *signalMhandle,
-    uint64_t signalValue, uint32_t signalOp, void** request) {
+static ncclResult_t ncclGin_iputSignal(void* ginCtx, int context, uint64_t srcOff, void* srcMhandle, size_t size,
+                                       uint64_t dstOff, void* dstMhandle, uint32_t rank, uint64_t signalOff,
+                                       void* signalMhandle, uint64_t signalValue, uint32_t signalOp, void** request) {
   if (context != 0) {
     WARN("GIN plugin v11 does not support multiple connections");
     return ncclInvalidUsage;
   }
-  return ncclGin_v11->iputSignal(ginCtx, srcOff, srcMhandle, size, dstOff, dstMhandle, rank, signalOff, signalMhandle, signalValue, signalOp, request);
+  return ncclGin_v11->iputSignal(ginCtx, srcOff, srcMhandle, size, dstOff, dstMhandle, rank, signalOff, signalMhandle,
+                                 signalValue, signalOp, request);
 }
 
 static ncclResult_t ncclGin_getProperties(int dev, ncclNetProperties_t* props) {
@@ -78,8 +79,7 @@ static ncclResult_t ncclGin_getProperties(int dev, ncclNetProperties_t* props) {
   props->netDeviceType = props_v11.netDeviceType;
   props->netDeviceVersion = props_v11.netDeviceVersion;
   props->vProps.ndevs = props_v11.vProps.ndevs;
-  for (int i = 0; i < props_v11.vProps.ndevs; i++)
-    props->vProps.devs[i] = props_v11.vProps.devs[i];
+  for (int i = 0; i < props_v11.vProps.ndevs; i++) props->vProps.devs[i] = props_v11.vProps.devs[i];
   props->maxP2pBytes = props_v11.maxP2pBytes;
   props->maxCollBytes = props_v11.maxCollBytes;
   props->maxMultiRequestSize = props_v11.maxMultiRequestSize;
@@ -95,7 +95,7 @@ static ncclResult_t ncclGin_getProperties(int dev, ncclNetProperties_t* props) {
 ncclGin_t* getNcclGin_v11(void* lib) {
   ncclGin_v11 = (ncclGin_v11_t*)ncclOsDlsym(lib, "ncclGinPlugin_v11");
   if (ncclGin_v11) {
-    INFO(NCCL_INIT|NCCL_NET, "NET/Plugin: Loaded gin plugin %s (v11)", ncclGin_v11->name);
+    INFO(NCCL_INIT | NCCL_NET, "NET/Plugin: Loaded gin plugin %s (v11)", ncclGin_v11->name);
     ncclGin.name = ncclGin_v11->name;
     ncclGin.init = ncclGin_v11->init;
     ncclGin.devices = ncclGin_v11->devices;

--- a/projects/rccl/src/plugin/gin/gin_v12.cc
+++ b/projects/rccl/src/plugin/gin/gin_v12.cc
@@ -12,13 +12,13 @@
 static ncclGin_v12_t* ncclGin_v12;
 static ncclGin_t ncclGin;
 
-static ncclResult_t ncclGin_connect(void* ctx, void* handles[], int nranks, int rank,
-  void* listenComm, void** collComm) {
+static ncclResult_t ncclGin_connect(void* ctx, void* handles[], int nranks, int rank, void* listenComm,
+                                    void** collComm) {
   return ncclGin_v12->connect(ctx, handles, nranks, rank, 1, 0, listenComm, collComm);
 }
 
-static ncclResult_t ncclGin_createContext(void* collComm, ncclGinConfig_t* config,
-    void** ginCtx, ncclNetDeviceHandle_t** devHandle) {
+static ncclResult_t ncclGin_createContext(void* collComm, ncclGinConfig_t* config, void** ginCtx,
+                                          ncclNetDeviceHandle_t** devHandle) {
   if (ncclGin_v12->createContext == NULL) {
     if (config->nContexts > 1) {
       WARN("GIN plugin v12 does not support multiple contexts");
@@ -27,7 +27,8 @@ static ncclResult_t ncclGin_createContext(void* collComm, ncclGinConfig_t* confi
     *ginCtx = collComm;
     return ncclSuccess;
   } else {
-    NCCLCHECK(ncclGin_v12->createContext(collComm, config->nSignals, config->nCounters, config->nContexts, ginCtx, devHandle));
+    NCCLCHECK(ncclGin_v12->createContext(collComm, config->nSignals, config->nCounters, config->nContexts, ginCtx,
+                                         devHandle));
   }
   return ncclSuccess;
 }
@@ -47,7 +48,7 @@ static ncclResult_t ncclGin_iflush(void* ginCtx, int context, void* mhandle, uin
 }
 
 static ncclResult_t ncclGin_iput(void* ginCtx, int context, uint64_t srcOff, void* srcMhandle, size_t size,
-    uint64_t dstOff, void* dstMhandle, uint32_t rank, void** request) {
+                                 uint64_t dstOff, void* dstMhandle, uint32_t rank, void** request) {
   if (context != 0) {
     WARN("GIN plugin v12 does not support multiple contexts");
     return ncclInvalidUsage;
@@ -55,14 +56,15 @@ static ncclResult_t ncclGin_iput(void* ginCtx, int context, uint64_t srcOff, voi
   return ncclGin_v12->iput(ginCtx, srcOff, srcMhandle, size, dstOff, dstMhandle, rank, 0, request);
 }
 
-static ncclResult_t ncclGin_iputSignal(void* ginCtx, int context, uint64_t srcOff, void* srcMhandle,
-    size_t size, uint64_t dstOff, void* dstMhandle, uint32_t rank, uint64_t signalOff, void *signalMhandle,
-    uint64_t signalValue, uint32_t signalOp, void** request) {
+static ncclResult_t ncclGin_iputSignal(void* ginCtx, int context, uint64_t srcOff, void* srcMhandle, size_t size,
+                                       uint64_t dstOff, void* dstMhandle, uint32_t rank, uint64_t signalOff,
+                                       void* signalMhandle, uint64_t signalValue, uint32_t signalOp, void** request) {
   if (context != 0) {
     WARN("GIN plugin v12 does not support multiple connections");
     return ncclInvalidUsage;
   }
-  return ncclGin_v12->iputSignal(ginCtx, srcOff, srcMhandle, size, dstOff, dstMhandle, rank, signalOff, signalMhandle, signalValue, signalOp, 0, request);
+  return ncclGin_v12->iputSignal(ginCtx, srcOff, srcMhandle, size, dstOff, dstMhandle, rank, signalOff, signalMhandle,
+                                 signalValue, signalOp, 0, request);
 }
 
 static ncclResult_t ncclGin_getProperties(int dev, ncclNetProperties_t* props) {
@@ -82,8 +84,7 @@ static ncclResult_t ncclGin_getProperties(int dev, ncclNetProperties_t* props) {
   props->netDeviceType = props_v11.netDeviceType;
   props->netDeviceVersion = props_v11.netDeviceVersion;
   props->vProps.ndevs = props_v11.vProps.ndevs;
-  for (int i = 0; i < props_v11.vProps.ndevs; i++)
-    props->vProps.devs[i] = props_v11.vProps.devs[i];
+  for (int i = 0; i < props_v11.vProps.ndevs; i++) props->vProps.devs[i] = props_v11.vProps.devs[i];
   props->maxP2pBytes = props_v11.maxP2pBytes;
   props->maxCollBytes = props_v11.maxCollBytes;
   props->maxMultiRequestSize = props_v11.maxMultiRequestSize;
@@ -98,7 +99,7 @@ static ncclResult_t ncclGin_getProperties(int dev, ncclNetProperties_t* props) {
 ncclGin_t* getNcclGin_v12(void* lib) {
   ncclGin_v12 = (ncclGin_v12_t*)ncclOsDlsym(lib, "ncclGinPlugin_v12");
   if (ncclGin_v12) {
-    INFO(NCCL_INIT|NCCL_NET, "NET/Plugin: Loaded gin plugin %s (v12)", ncclGin_v12->name);
+    INFO(NCCL_INIT | NCCL_NET, "NET/Plugin: Loaded gin plugin %s (v12)", ncclGin_v12->name);
     ncclGin.name = ncclGin_v12->name;
     ncclGin.init = ncclGin_v12->init;
     ncclGin.devices = ncclGin_v12->devices;
@@ -125,15 +126,15 @@ ncclGin_t* getNcclGin_v12(void* lib) {
   return nullptr;
 }
 
-
 ncclGin_t* getNcclGin_v12_internal(ncclGin_v12_t* ncclGin_v12_ext) {
   if (ncclGin_v12 != NULL) {
-    INFO(NCCL_INIT|NCCL_NET, "NET/Plugin: cannot load built-in v12 gin iface. preoccupied with %s (v12)", ncclGin_v12->name); 
+    INFO(NCCL_INIT | NCCL_NET, "NET/Plugin: cannot load built-in v12 gin iface. preoccupied with %s (v12)",
+         ncclGin_v12->name);
     return nullptr;
   }
   ncclGin_v12 = ncclGin_v12_ext;
 
-  INFO(NCCL_INIT|NCCL_NET, "NET/Plugin: Loaded gin plugin %s (v12)", ncclGin_v12->name);
+  INFO(NCCL_INIT | NCCL_NET, "NET/Plugin: Loaded gin plugin %s (v12)", ncclGin_v12->name);
   ncclGin.name = ncclGin_v12->name;
   ncclGin.init = ncclGin_v12->init;
   ncclGin.devices = ncclGin_v12->devices;

--- a/projects/rccl/src/plugin/gin/gin_v13.cc
+++ b/projects/rccl/src/plugin/gin/gin_v13.cc
@@ -14,7 +14,7 @@ static ncclGin_v13_t* ncclGin_v13;
 ncclGin_t* getNcclGin_v13(void* lib) {
   ncclGin_v13 = (ncclGin_v13_t*)ncclOsDlsym(lib, "ncclGinPlugin_v13");
   if (ncclGin_v13) {
-    INFO(NCCL_INIT|NCCL_NET, "NET/Plugin: Loaded gin plugin %s (v13)", ncclGin_v13->name);
+    INFO(NCCL_INIT | NCCL_NET, "NET/Plugin: Loaded gin plugin %s (v13)", ncclGin_v13->name);
     return ncclGin_v13;
   }
   return nullptr;
@@ -25,7 +25,7 @@ static ncclGin_v13_t* ncclRma_v13;
 ncclGin_t* getNcclRma_v13(void* lib) {
   ncclRma_v13 = (ncclGin_v13_t*)dlsym(lib, "ncclRmaPlugin_v13");
   if (ncclRma_v13) {
-    INFO(NCCL_INIT|NCCL_NET, "NET/Plugin: Loaded rma plugin %s (v13)", ncclRma_v13->name);
+    INFO(NCCL_INIT | NCCL_NET, "NET/Plugin: Loaded rma plugin %s (v13)", ncclRma_v13->name);
     return ncclRma_v13;
   }
   return nullptr;

--- a/projects/rccl/src/plugin/net.cc
+++ b/projects/rccl/src/plugin/net.cc
@@ -14,9 +14,9 @@
 #include <string.h>
 #include <errno.h>
 #include <mutex>
-//#include <sys/types.h>
-//#include <sys/stat.h>
-//#include <unistd.h>
+// #include <sys/types.h>
+// #include <sys/stat.h>
+// #include <unistd.h>
 
 typedef ncclNet_t* getNcclNet_t(void* netPluginLib);
 typedef ncclCollNet_t* getNcclCollNet_t(void* netPluginLib);
@@ -41,17 +41,20 @@ extern getNcclCollNet_t getNcclCollNet_v12;
 NCCL_PARAM(NetPluginRefCount, "NET_PLUGIN_REF_COUNT", 0);
 #define NCCL_NET_VERSION_COUNT 7
 int ncclNetVersion[NCCL_NET_VERSION_COUNT] = {12, 11, 10, 9, 8, 7, 6};
-getNcclNet_t* getNcclNet[NCCL_NET_VERSION_COUNT] = {getNcclNet_v12, getNcclNet_v11, getNcclNet_v10, getNcclNet_v9, getNcclNet_v8, getNcclNet_v7, getNcclNet_v6};
-getNcclCollNet_t* getNcclCollNet[NCCL_NET_VERSION_COUNT] = {getNcclCollNet_v12, getNcclCollNet_v11, getNcclCollNet_v10, getNcclCollNet_v9, getNcclCollNet_v8, getNcclCollNet_v7, getNcclCollNet_v6};
+getNcclNet_t* getNcclNet[NCCL_NET_VERSION_COUNT] = {getNcclNet_v12, getNcclNet_v11, getNcclNet_v10, getNcclNet_v9,
+                                                    getNcclNet_v8,  getNcclNet_v7,  getNcclNet_v6};
+getNcclCollNet_t* getNcclCollNet[NCCL_NET_VERSION_COUNT] = {getNcclCollNet_v12, getNcclCollNet_v11, getNcclCollNet_v10,
+                                                            getNcclCollNet_v9,  getNcclCollNet_v8,  getNcclCollNet_v7,
+                                                            getNcclCollNet_v6};
 
 #define NCCL_NET_NUM_INTERNAL_PLUGINS 2
 
 typedef enum ncclNetPluginState {
-  ncclNetPluginStateDisabled        = -2,       // Plugin library failed to initialize
-  ncclNetPluginStateLoadFailed      = -1,       // Plugin library failed to load
-  ncclNetPluginStateLoadReady       = 0,        // Plugin library is ready to be loaded
-  ncclNetPluginStateInitReady       = 1,        // Plugin library is loaded and ready to be initialized
-  ncclNetPluginStateEnabled         = 2,        // Plugin library is loaded and initialized
+  ncclNetPluginStateDisabled = -2,       // Plugin library failed to initialize
+  ncclNetPluginStateLoadFailed = -1,       // Plugin library failed to load
+  ncclNetPluginStateLoadReady = 0,        // Plugin library is ready to be loaded
+  ncclNetPluginStateInitReady = 1,        // Plugin library is loaded and ready to be initialized
+  ncclNetPluginStateEnabled = 2,        // Plugin library is loaded and initialized
 } ncclNetPluginState_t;
 
 #define MAX_STR_LEN 255
@@ -78,7 +81,7 @@ static std::once_flag initPluginLibsOnceFlag;
 
 static ncclResult_t ncclNetPluginUnload(netPluginLib_t* pluginLib) {
   if ((pluginLib->dlHandle) && ((pluginLib->ncclNetPluginRefCount) == 0)) {
-    INFO(NCCL_DESTROY|NCCL_NET, "Unloading plugin %s", pluginLib->name);
+    INFO(NCCL_DESTROY | NCCL_NET, "Unloading plugin %s", pluginLib->name);
     NCCLCHECK(ncclClosePluginLib(pluginLib->dlHandle, ncclPluginTypeNet));
 
     // Reset fields but preserve name, to be reused when reloading
@@ -108,7 +111,7 @@ static ncclResult_t ncclNetPluginLoad(netPluginLib_t* pluginLib) {
 
   // if we fail to find a net, exit
   if (pluginLib->ncclNet == nullptr) {
-    INFO(NCCL_INIT|NCCL_NET, "External network plugin %s is unsupported",
+    INFO(NCCL_INIT | NCCL_NET, "External network plugin %s is unsupported",
          (ncclPluginLibPaths[ncclPluginTypeNet] ? ncclPluginLibPaths[ncclPluginTypeNet] : pluginLib->name));
     goto fail;
   }
@@ -121,12 +124,10 @@ static ncclResult_t ncclNetPluginLoad(netPluginLib_t* pluginLib) {
     if (pluginLib->ncclCollNet) break;
   }
 
-  if (pluginLib->ncclCollNet == nullptr)
-    pluginLib->ncclCollNetPluginState = ncclNetPluginStateLoadFailed;
-  else
-    pluginLib->ncclCollNetPluginState = ncclNetPluginStateInitReady;
+  if (pluginLib->ncclCollNet == nullptr) pluginLib->ncclCollNetPluginState = ncclNetPluginStateLoadFailed;
+  else pluginLib->ncclCollNetPluginState = ncclNetPluginStateInitReady;
 
-  INFO(NCCL_INIT|NCCL_NET, "Successfully loaded external network plugin %s",
+  INFO(NCCL_INIT | NCCL_NET, "Successfully loaded external network plugin %s",
        (ncclPluginLibPaths[ncclPluginTypeNet] ? ncclPluginLibPaths[ncclPluginTypeNet] : pluginLib->name));
 exit:
   return ncclSuccess;
@@ -148,18 +149,18 @@ ncclResult_t ncclNetCheckDeviceVersion(struct ncclComm* comm, ncclNet_t* net, in
   if (type) switch (type) {
     case NCCL_NET_DEVICE_UNPACK:
       if (props.netDeviceVersion == NCCL_NET_DEVICE_UNPACK_VERSION) {
-        INFO(NCCL_INIT, "Using NCCL_NET_DEVICE_UNPACK net plugin version %d",
-          props.netDeviceVersion);
+        INFO(NCCL_INIT, "Using NCCL_NET_DEVICE_UNPACK net plugin version %d", props.netDeviceVersion);
         return ncclSuccess;
       } else {
-        WARN("NCCL_DEVICE_UNPACK plugin has incompatible version %d, this NCCL build is compatible with %d, not using it",
+        WARN(
+          "NCCL_DEVICE_UNPACK plugin has incompatible version %d, this NCCL build is compatible with %d, not using it",
           props.netDeviceVersion, NCCL_NET_DEVICE_UNPACK_VERSION);
         return ncclInternalError;
       }
     default:
       WARN("Unknown device code index %d", type);
       return ncclInternalError;
-  }
+    }
 
   return ncclSuccess;
 }
@@ -170,8 +171,11 @@ static ncclResult_t ncclNetPluginInit(struct ncclComm* comm, netPluginLib_t* plu
   // Init must be called for each new comm to set the right context
   if (pluginLib->ncclNetPluginState >= ncclNetPluginStateInitReady && pluginLib->ncclNet) {
     ncclNetCommConfig_t commConfig = {};
-    commConfig.trafficClass = comm->config.trafficClass == NCCL_CONFIG_UNDEF_INT ? NCCL_NET_TRAFFIC_CLASS_UNDEF : comm->config.trafficClass;
-    if (pluginLib->ncclNet->init(&comm->netContext, comm->commHash, &commConfig, ncclDebugLog, ncclProfilerCallback) != ncclSuccess) goto fail;
+    commConfig.trafficClass =
+      comm->config.trafficClass == NCCL_CONFIG_UNDEF_INT ? NCCL_NET_TRAFFIC_CLASS_UNDEF : comm->config.trafficClass;
+    if (pluginLib->ncclNet->init(&comm->netContext, comm->commHash, &commConfig, ncclDebugLog, ncclProfilerCallback) !=
+        ncclSuccess)
+      goto fail;
     initCompleted = true;
   }
   // Detection of the devices is only done when the plugin is being initialized the first time
@@ -181,15 +185,17 @@ static ncclResult_t ncclNetPluginInit(struct ncclComm* comm, netPluginLib_t* plu
     pluginLib->netVirtDevs = NCCL_UNDEF_DEV_COUNT;
   }
   pluginLib->ncclNetPluginState = ncclNetPluginStateEnabled;
-  INFO(NCCL_INIT|NCCL_NET, "Initialized NET plugin %s", pluginLib->ncclNet->name);
+  INFO(NCCL_INIT | NCCL_NET, "Initialized NET plugin %s", pluginLib->ncclNet->name);
 
   // Init must be called for each new comm to set the right context
   if (pluginLib->ncclCollNetPluginState >= ncclNetPluginStateInitReady && pluginLib->ncclCollNet) {
-    if (pluginLib->ncclCollNet->init(&comm->collNetContext, comm->commHash, ncclDebugLog) != ncclSuccess) pluginLib->ncclCollNetPluginState = ncclNetPluginStateDisabled;
+    if (pluginLib->ncclCollNet->init(&comm->collNetContext, comm->commHash, ncclDebugLog) != ncclSuccess)
+      pluginLib->ncclCollNetPluginState = ncclNetPluginStateDisabled;
   }
   // Detection of the devices is only done when the plugin is being initialized the first time
   if (pluginLib->ncclCollNetPluginState == ncclNetPluginStateInitReady && pluginLib->ncclCollNet) {
-    if (pluginLib->ncclCollNet->devices(&ndev) != ncclSuccess || ndev <= 0) pluginLib->ncclCollNetPluginState = ncclNetPluginStateDisabled;
+    if (pluginLib->ncclCollNet->devices(&ndev) != ncclSuccess || ndev <= 0)
+      pluginLib->ncclCollNetPluginState = ncclNetPluginStateDisabled;
     else {
       pluginLib->collNetPhysDevs = ndev;
       pluginLib->collNetVirtDevs = NCCL_UNDEF_DEV_COUNT;
@@ -200,7 +206,7 @@ static ncclResult_t ncclNetPluginInit(struct ncclComm* comm, netPluginLib_t* plu
 exit:
   return ncclSuccess;
 fail:
-  INFO(NCCL_INIT|NCCL_NET, "Failed to initialize NET plugin %s", pluginLib->ncclNet->name);
+  INFO(NCCL_INIT | NCCL_NET, "Failed to initialize NET plugin %s", pluginLib->ncclNet->name);
   if (initCompleted) pluginLib->ncclNet->finalize(comm->netContext);
   pluginLib->netPhysDevs = pluginLib->netVirtDevs = NCCL_UNDEF_DEV_COUNT;
   pluginLib->collNetPhysDevs = pluginLib->collNetVirtDevs = NCCL_UNDEF_DEV_COUNT;
@@ -220,7 +226,7 @@ static ncclResult_t ncclNetPluginAssignToComm(struct ncclComm* comm, int pluginI
     comm->netPluginIndex = pluginIndex;
     netPluginLibs[pluginIndex].ncclNetPluginRefCount++;
     *isAssigned = true;
-    INFO(NCCL_INIT|NCCL_NET, "Assigned NET plugin %s to comm", netPluginLibs[pluginIndex].ncclNet->name);
+    INFO(NCCL_INIT | NCCL_NET, "Assigned NET plugin %s to comm", netPluginLibs[pluginIndex].ncclNet->name);
     if (netPluginLibs[pluginIndex].ncclCollNetPluginState >= ncclNetPluginStateEnabled) {
       comm->ncclCollNet = netPluginLibs[pluginIndex].ncclCollNet;
     }
@@ -231,16 +237,17 @@ static ncclResult_t ncclNetPluginAssignToComm(struct ncclComm* comm, int pluginI
 static ncclResult_t ncclNetPluginDisableOtherExternal(int pluginIndex) {
   // Only if an external plugin is enabled, disable other external plugins
   if (pluginIndex >= (pluginCount - NCCL_NET_NUM_INTERNAL_PLUGINS)) return ncclSuccess;
-  char names[MAX_STR_LEN*(NCCL_NET_MAX_PLUGINS - NCCL_NET_NUM_INTERNAL_PLUGINS)] = { 0 };
+  char names[MAX_STR_LEN * (NCCL_NET_MAX_PLUGINS - NCCL_NET_NUM_INTERNAL_PLUGINS)] = {0};
   for (int i = 0; i < (pluginCount - NCCL_NET_NUM_INTERNAL_PLUGINS); i++) {
     if (i != pluginIndex) {
       // Append all disabled plugin names to a string
-      snprintf(names+strlen(names), sizeof(names)-strlen(names), (strlen(names) == 0) ? "%s" : ", %s", netPluginLibs[i].name);
+      snprintf(names + strlen(names), sizeof(names) - strlen(names), (strlen(names) == 0) ? "%s" : ", %s",
+               netPluginLibs[i].name);
       netPluginLibs[i].ncclNetPluginState = ncclNetPluginStateDisabled;
     }
   }
-  if(strlen(names) > 0) {
-    INFO(NCCL_INIT|NCCL_NET, "Disabling external plugins: %s", names);
+  if (strlen(names) > 0) {
+    INFO(NCCL_INIT | NCCL_NET, "Disabling external plugins: %s", names);
   }
   return ncclSuccess;
 }
@@ -256,27 +263,29 @@ static void initPluginLibsOnceFunc() {
   memset(netPluginLibs, 0, NCCL_NET_MAX_PLUGINS * sizeof(netPluginLib_t));
   envNetPlugin = ncclGetEnv("NCCL_NET_PLUGIN");
   if (envNetPlugin) {
-    INFO(NCCL_ENV|NCCL_NET, "NCCL_NET_PLUGIN set by environment to %s", envNetPlugin);
-    if (strcasecmp(envNetPlugin, "none") == 0)
-      envNetPlugin = "";
+    INFO(NCCL_ENV | NCCL_NET, "NCCL_NET_PLUGIN set by environment to %s", envNetPlugin);
+    if (strcasecmp(envNetPlugin, "none") == 0) envNetPlugin = "";
     envNetPluginList = strdup(envNetPlugin);
     // Iterate over list until the list is empty
     netPluginName = strtok_r(envNetPluginList, ",", &savePtr);
-    while(netPluginName) {
+    while (netPluginName) {
       // We have 2 internal plugins (ib and socket)
       // So, we can have at most( NCCL_NET_MAX_PLUGINS - (NCCL_NET_NUM_INTERNAL_PLUGINS)) in the NCCL_NET_PLUGIN list
       if (pluginCounter >= (NCCL_NET_MAX_PLUGINS - (NCCL_NET_NUM_INTERNAL_PLUGINS))) {
-        INFO(NCCL_NET|NCCL_ENV,"NCCL_NET_PLUGIN list contains more than %d plugins, ignoring the rest", (NCCL_NET_MAX_PLUGINS - (NCCL_NET_NUM_INTERNAL_PLUGINS + 1)));
+        INFO(NCCL_NET | NCCL_ENV, "NCCL_NET_PLUGIN list contains more than %d plugins, ignoring the rest",
+             (NCCL_NET_MAX_PLUGINS - (NCCL_NET_NUM_INTERNAL_PLUGINS + 1)));
         break;
       }
       // need to leave space for the name + "\n"
-      if((strlen(netPluginName)+1) <= MAX_STR_LEN) {
+      if ((strlen(netPluginName) + 1) <= MAX_STR_LEN) {
         netPluginLibs[pluginCounter].ncclNetPluginState = ncclNetPluginStateLoadReady;
         netPluginLibs[pluginCounter].ncclNetPluginRefCount = ncclParamNetPluginRefCount();
         strcpy(netPluginLibs[pluginCounter].name, netPluginName);
         pluginCounter++;
       } else {
-        INFO(NCCL_NET|NCCL_ENV,"NCCL_NET_PLUGIN list contains a plugin name %s longer than %d characters, ignoring it.", netPluginName, MAX_STR_LEN);
+        INFO(NCCL_NET | NCCL_ENV,
+             "NCCL_NET_PLUGIN list contains a plugin name %s longer than %d characters, ignoring it.", netPluginName,
+             MAX_STR_LEN);
       }
       netPluginName = strtok_r(nullptr, ",", &savePtr);
     }
@@ -293,7 +302,7 @@ static void initPluginLibsOnceFunc() {
   {
     const char* envNet = ncclGetEnv("NCCL_NET");
     if (envNet && (strcasecmp(envNet, "ROCM-IB") == 0)) {
-       envNet = "IB-CAST";
+      envNet = "IB-CAST";
     }
     if ((envNet && strcasecmp(envNet, "IB-CAST") == 0 && !(envNetPlugin)) ||
         (!envNet && rcclUseAinic() && !(envNetPlugin))) {
@@ -315,7 +324,9 @@ static void initPluginLibsOnceFunc() {
 
 static ncclResult_t ncclNetPluginFinalize(struct ncclComm* comm, int pluginIndex) {
   NCCLCHECK(netPluginLibs[pluginIndex].ncclNet->finalize(comm->netContext));
-  if (netPluginLibs[pluginIndex].ncclCollNet && netPluginLibs[pluginIndex].ncclCollNetPluginState == ncclNetPluginStateEnabled) NCCLCHECK(netPluginLibs[pluginIndex].ncclCollNet->finalize(comm->collNetContext));
+  if (netPluginLibs[pluginIndex].ncclCollNet &&
+      netPluginLibs[pluginIndex].ncclCollNetPluginState == ncclNetPluginStateEnabled)
+    NCCLCHECK(netPluginLibs[pluginIndex].ncclCollNet->finalize(comm->collNetContext));
   netPluginLibs[pluginIndex].ncclNetPluginRefCount--;
   if (pluginIndex < (pluginCount - NCCL_NET_NUM_INTERNAL_PLUGINS)) {
     NCCLCHECK(ncclNetPluginUnload(&netPluginLibs[pluginIndex]));
@@ -328,11 +339,12 @@ ncclResult_t ncclNetInit(struct ncclComm* comm) {
   std::call_once(initPluginLibsOnceFlag, initPluginLibsOnceFunc);
   std::lock_guard<std::mutex> lock(netPluginMutex);
   for (int pluginIndex = 0; pluginIndex < pluginCount; pluginIndex++) {
-    if ((pluginIndex < (pluginCount - NCCL_NET_NUM_INTERNAL_PLUGINS)) && (netPluginLibs[pluginIndex].ncclNetPluginState == ncclNetPluginStateLoadReady)) {
+    if ((pluginIndex < (pluginCount - NCCL_NET_NUM_INTERNAL_PLUGINS)) &&
+        (netPluginLibs[pluginIndex].ncclNetPluginState == ncclNetPluginStateLoadReady)) {
       NCCLCHECK(ncclNetPluginLoad(&netPluginLibs[pluginIndex]));
     }
-    if ((netPluginLibs[pluginIndex].ncclNetPluginState >= ncclNetPluginStateInitReady)
-        && (!comm->config.netName || (strcasecmp(comm->config.netName, netPluginLibs[pluginIndex].ncclNet->name) == 0))) {
+    if ((netPluginLibs[pluginIndex].ncclNetPluginState >= ncclNetPluginStateInitReady) &&
+        (!comm->config.netName || (strcasecmp(comm->config.netName, netPluginLibs[pluginIndex].ncclNet->name) == 0))) {
       // plugin init must be done by all comms to setup the context, therefore we use ">="
       NCCLCHECK(ncclNetPluginInit(comm, &netPluginLibs[pluginIndex]));
       if (netPluginLibs[pluginIndex].ncclNetPluginState == ncclNetPluginStateEnabled) {
@@ -343,8 +355,7 @@ ncclResult_t ncclNetInit(struct ncclComm* comm) {
           ncclNetPluginDisableOtherExternal(pluginIndex);
           ncclNetPluginInitialized = true;
           break;
-        }
-        else {
+        } else {
           ncclNetPluginFinalize(comm, pluginIndex);
         }
       }
@@ -367,7 +378,8 @@ ncclResult_t ncclNetInitFromParent(struct ncclComm* comm, struct ncclComm* paren
     ret = ncclInvalidUsage;
   }
   if (comm->config.trafficClass != NCCL_CONFIG_UNDEF_INT && comm->config.trafficClass != parent->config.trafficClass) {
-    INFO(NCCL_INIT, "Comm config trafficClass (%d) does not match the parent (%d)", comm->config.trafficClass, parent->config.trafficClass);
+    INFO(NCCL_INIT, "Comm config trafficClass (%d) does not match the parent (%d)", comm->config.trafficClass,
+         parent->config.trafficClass);
   }
   return ret;
 }
@@ -381,7 +393,8 @@ ncclResult_t ncclNetFinalize(struct ncclComm* comm) {
 
 ncclResult_t ncclNetGetDevCount(int netPluginIndex, int* nPhysDevs, int* nVirtDevs) {
   if (netPluginLibs[netPluginIndex].ncclNetPluginState != ncclNetPluginStateEnabled ||
-     netPluginLibs[netPluginIndex].netPhysDevs == NCCL_UNDEF_DEV_COUNT) goto fail;
+      netPluginLibs[netPluginIndex].netPhysDevs == NCCL_UNDEF_DEV_COUNT)
+    goto fail;
   // lock not needed as it's called within a lock already in ncclTopoGetSystem
   *nPhysDevs = netPluginLibs[netPluginIndex].netPhysDevs;
   *nVirtDevs = netPluginLibs[netPluginIndex].netVirtDevs;
@@ -393,7 +406,8 @@ fail:
 
 ncclResult_t ncclCollNetGetDevCount(int netPluginIndex, int* nPhysDevs, int* nVirtDevs) {
   if (netPluginLibs[netPluginIndex].ncclCollNetPluginState != ncclNetPluginStateEnabled ||
-     netPluginLibs[netPluginIndex].collNetPhysDevs == NCCL_UNDEF_DEV_COUNT) goto fail;
+      netPluginLibs[netPluginIndex].collNetPhysDevs == NCCL_UNDEF_DEV_COUNT)
+    goto fail;
   // lock not needed as it's called within a lock already in ncclTopoGetSystem
   *nPhysDevs = netPluginLibs[netPluginIndex].collNetPhysDevs;
   *nVirtDevs = netPluginLibs[netPluginIndex].collNetVirtDevs;
@@ -409,7 +423,7 @@ ncclResult_t ncclNetSetVirtDevCount(int netPluginIndex, int nVirtDevs) {
   netPluginLibs[netPluginIndex].netVirtDevs = nVirtDevs;
   return ncclSuccess;
 fail:
-  WARN("%s: failed to set the number of devices for netPlugin[%d] to %d", __func__, netPluginIndex,nVirtDevs);
+  WARN("%s: failed to set the number of devices for netPlugin[%d] to %d", __func__, netPluginIndex, nVirtDevs);
   return ncclInternalError;
 }
 
@@ -419,12 +433,12 @@ ncclResult_t ncclCollNetSetVirtDevCount(int netPluginIndex, int nVirtDevs) {
   netPluginLibs[netPluginIndex].collNetVirtDevs = nVirtDevs;
   return ncclSuccess;
 fail:
-  WARN("%s: failed to set the number of devices for netPlugin[%d] to %d", __func__, netPluginIndex,nVirtDevs);
+  WARN("%s: failed to set the number of devices for netPlugin[%d] to %d", __func__, netPluginIndex, nVirtDevs);
   return ncclInternalError;
 }
 
 ncclResult_t ncclGpuGdrSupport(struct ncclComm* comm, int* gdrSupport) {
-  constexpr int GPU_BUF_SIZE = 2*1024*1024;
+  constexpr int GPU_BUF_SIZE = 2 * 1024 * 1024;
 #if CUDART_VERSION >= 11030
   // In CUDA 11.3 and later we can now query the cudaDevAttrGPUDirectRDMASupported attribute
   int driverVersion;
@@ -437,14 +451,13 @@ ncclResult_t ncclGpuGdrSupport(struct ncclComm* comm, int* gdrSupport) {
     return ncclSuccess;
   }
 #endif
-  static int gdrSupportMatrix[32] = {
-	  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-	  -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 };
+  static int gdrSupportMatrix[32] = {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                                     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
   if (gdrSupportMatrix[comm->cudaDev] == -1) {
     int netDevs;
     NCCLCHECK(comm->ncclNet->devices(&netDevs));
     gdrSupportMatrix[comm->cudaDev] = 0;
-    for (int dev=0; dev<netDevs; dev++) {
+    for (int dev = 0; dev < netDevs; dev++) {
       // Find a net device which is GDR-capable
       ncclNetProperties_t props;
       NCCLCHECK(comm->ncclNet->getProperties(dev, &props));
@@ -454,48 +467,45 @@ ncclResult_t ncclGpuGdrSupport(struct ncclComm* comm, int* gdrSupport) {
       break;
 #endif
 
-    // Allocate memory on the GPU and try to register it on the NIC.
-    void *lComm = NULL, *sComm = NULL, *rComm = NULL;
-    ncclNetHandle_t handle;
-    char* gpuPtr = NULL;
-    void* mHandle = NULL;
-    ncclResult_t ret;
-    NCCLCHECKGOTONOWARN(comm->ncclNet->listen(comm->netContext, dev, &handle, &lComm), ret, cleanup1, NCCL_NET);
+      // Allocate memory on the GPU and try to register it on the NIC.
+      void *lComm = NULL, *sComm = NULL, *rComm = NULL;
+      ncclNetHandle_t handle;
+      char* gpuPtr = NULL;
+      void* mHandle = NULL;
+      ncclResult_t ret;
+      NCCLCHECKGOTONOWARN(comm->ncclNet->listen(comm->netContext, dev, &handle, &lComm), ret, cleanup1, NCCL_NET);
 
-    bool connected;
-    connected = false;
-    while (!connected) {
+      bool connected;
+      connected = false;
+      while (!connected) {
+        // If we're aborting now, skip to cleanup
+        if (COMPILER_ATOMIC_LOAD(comm->abortFlag, std::memory_order_acquire)) {
+          goto cleanup2;
+        }
 
-      // If we're aborting now, skip to cleanup
-      if (COMPILER_ATOMIC_LOAD(comm->abortFlag, std::memory_order_acquire)) {
-        goto cleanup2;
+        if (sComm == NULL)
+          NCCLCHECKGOTONOWARN(comm->ncclNet->connect(comm->netContext, dev, &handle, &sComm, NULL), ret, cleanup2,
+                              NCCL_NET);
+
+        if (rComm == NULL) NCCLCHECKGOTONOWARN(comm->ncclNet->accept(lComm, &rComm, NULL), ret, cleanup2, NCCL_NET);
+
+        connected = (rComm != NULL) && (sComm != NULL);
       }
 
-      if (sComm == NULL)
-        NCCLCHECKGOTONOWARN(comm->ncclNet->connect(comm->netContext, dev, &handle, &sComm, NULL), ret, cleanup2, NCCL_NET);
-
-      if (rComm == NULL)
-        NCCLCHECKGOTONOWARN(comm->ncclNet->accept(lComm, &rComm, NULL), ret, cleanup2, NCCL_NET);
-
-      connected = (rComm != NULL) && (sComm != NULL);
-    }
-
-    NCCLCHECKGOTONOWARN(ncclCudaMalloc(&gpuPtr, GPU_BUF_SIZE, comm->memManager), ret, cleanup2, NCCL_NET);
-    NOWARN(ret = comm->ncclNet->regMr(sComm, gpuPtr, GPU_BUF_SIZE, NCCL_PTR_CUDA, &mHandle), NCCL_NET);
-    if (ret == ncclSuccess) {
-      NCCLCHECKNOWARN(comm->ncclNet->deregMr(sComm, mHandle), NCCL_NET);
-      NCCLCHECKNOWARN(comm->ncclNet->regMr(rComm, gpuPtr, GPU_BUF_SIZE, NCCL_PTR_CUDA, &mHandle), NCCL_NET);
-      NCCLCHECKNOWARN(comm->ncclNet->deregMr(rComm, mHandle), NCCL_NET);
-      gdrSupportMatrix[comm->cudaDev] = 1;
-    }
-    NCCLCHECK(ncclCudaFree(gpuPtr, comm->memManager));
-cleanup2:
-    if (rComm != NULL)
-      NCCLCHECK(comm->ncclNet->closeRecv(rComm));
-    if (sComm != NULL)
-      NCCLCHECK(comm->ncclNet->closeSend(sComm));
-    NCCLCHECK(comm->ncclNet->closeListen(lComm));
-cleanup1:
+      NCCLCHECKGOTONOWARN(ncclCudaMalloc(&gpuPtr, GPU_BUF_SIZE, comm->memManager), ret, cleanup2, NCCL_NET);
+      NOWARN(ret = comm->ncclNet->regMr(sComm, gpuPtr, GPU_BUF_SIZE, NCCL_PTR_CUDA, &mHandle), NCCL_NET);
+      if (ret == ncclSuccess) {
+        NCCLCHECKNOWARN(comm->ncclNet->deregMr(sComm, mHandle), NCCL_NET);
+        NCCLCHECKNOWARN(comm->ncclNet->regMr(rComm, gpuPtr, GPU_BUF_SIZE, NCCL_PTR_CUDA, &mHandle), NCCL_NET);
+        NCCLCHECKNOWARN(comm->ncclNet->deregMr(rComm, mHandle), NCCL_NET);
+        gdrSupportMatrix[comm->cudaDev] = 1;
+      }
+      NCCLCHECK(ncclCudaFree(gpuPtr, comm->memManager));
+    cleanup2:
+      if (rComm != NULL) NCCLCHECK(comm->ncclNet->closeRecv(rComm));
+      if (sComm != NULL) NCCLCHECK(comm->ncclNet->closeSend(sComm));
+      NCCLCHECK(comm->ncclNet->closeListen(lComm));
+    cleanup1:
       break;
     }
   }

--- a/projects/rccl/src/plugin/net/net_v10.cc
+++ b/projects/rccl/src/plugin/net/net_v10.cc
@@ -49,18 +49,18 @@ static ncclResult_t ncclNet_getProperties(int dev, ncclNetProperties_t* props) {
   return ncclSuccess;
 }
 
-static ncclResult_t ncclNet_listen(void* ctx __attribute__((unused)),
-    int dev, void* handle, void** listenComm) {
+static ncclResult_t ncclNet_listen(void* ctx __attribute__((unused)), int dev, void* handle, void** listenComm) {
   return ncclNet_v10->listen(dev, handle, listenComm);
 }
 
-static ncclResult_t ncclNet_connect(void* ctx, int dev, void* handle, void** sendComm, ncclNetDeviceHandle_t** sendDevComm) {
-  return ncclNet_v10->connect(dev, (ncclNetCommConfig_v10_t *)ctx, handle, sendComm, sendDevComm);
+static ncclResult_t ncclNet_connect(void* ctx, int dev, void* handle, void** sendComm,
+                                    ncclNetDeviceHandle_t** sendDevComm) {
+  return ncclNet_v10->connect(dev, (ncclNetCommConfig_v10_t*)ctx, handle, sendComm, sendDevComm);
 }
 
 static ncclResult_t ncclNet_makeVDevice(int* d, ncclNetVDeviceProps_t* props) {
   // Safe cast: devs[] is at the end of the struct and NCCL limits ndevs to NCCL_NET_MAX_DEVS_PER_NIC_V11 for v10 plugins.
-  return ncclNet_v10->makeVDevice(d, (ncclNetVDeviceProps_v10_t *)props);
+  return ncclNet_v10->makeVDevice(d, (ncclNetVDeviceProps_v10_t*)props);
 }
 
 static ncclResult_t ncclNet_finalize(void* ctx) {
@@ -69,8 +69,8 @@ static ncclResult_t ncclNet_finalize(void* ctx) {
   return ncclSuccess;
 }
 
-static ncclResult_t ncclNet_init(void** ctx, uint64_t commId __attribute__((unused)),
-    ncclNetCommConfig_t* config, ncclDebugLogger_t logfn, ncclProfilerCallback_t proffn) {
+static ncclResult_t ncclNet_init(void** ctx, uint64_t commId __attribute__((unused)), ncclNetCommConfig_t* config,
+                                 ncclDebugLogger_t logfn, ncclProfilerCallback_t proffn) {
   // since ncclNet_v11, the ncclNetCommConfig_t has been moved from connect to init. Since the config is per comm,
   // this allows the config to be passed only once, instead of multiple times (once per connect). To preserve the
   // ncclNet_v10 behavior, in the compat layer, we store the config in the context pointer and pass it to the connect
@@ -120,7 +120,7 @@ ncclNet_t* getNcclNet_v10(void* lib) {
   if (ncclNet_v10) {
     ncclNet.name = ncclNet_v10->name;
     ncclNet.init = ncclNet_init;
-    INFO(NCCL_INIT|NCCL_NET, "NET/Plugin: Loaded net plugin %s (v10)", ncclNet_v10->name);
+    INFO(NCCL_INIT | NCCL_NET, "NET/Plugin: Loaded net plugin %s (v10)", ncclNet_v10->name);
     return &ncclNet;
   }
   return nullptr;
@@ -152,29 +152,28 @@ static ncclResult_t ncclCollNet_getProperties(int dev, ncclNetProperties_t* prop
   return ncclSuccess;
 }
 
-static ncclResult_t ncclCollNet_listen(void* ctx __attribute__((unused)),
-    int dev, void* handle , void** listenComm) {
+static ncclResult_t ncclCollNet_listen(void* ctx __attribute__((unused)), int dev, void* handle, void** listenComm) {
   return ncclCollNet_v10->listen(dev, handle, listenComm);
 }
 
 static ncclResult_t ncclCollNet_iallgather(void* collComm, void* sendData, int nRecvParts, ncclNetSGE_t* recvParts,
-                             size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
-                             void* sendMhandle, void** request) {
+                                           size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
+                                           void* sendMhandle, void** request) {
   return ncclCollNet_v10->iallgather(collComm, sendData, nRecvParts, (ncclNetSGE_v10_t*)recvParts, bytesPerRank,
-                             windowOffset, windowBytes, sendMhandle, request);
+                                     windowOffset, windowBytes, sendMhandle, request);
 }
 
 static ncclResult_t ncclCollNet_ireducescatter(void* collComm, int nSendParts, ncclNetSGE_t* sendParts, void* recvData,
-                                 size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
-                                 ncclDataType_t dataType, ncclRedOp_t redOp,
-                                 void* recvMhandle, void** request) {
+                                               size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
+                                               ncclDataType_t dataType, ncclRedOp_t redOp, void* recvMhandle,
+                                               void** request) {
   return ncclCollNet_v10->ireducescatter(collComm, nSendParts, (ncclNetSGE_v10_t*)sendParts, recvData, bytesPerRank,
-                                 windowOffset, windowBytes, dataType, redOp, recvMhandle, request);
+                                         windowOffset, windowBytes, dataType, redOp, recvMhandle, request);
 }
 
 static ncclResult_t ncclCollNet_makeVDevice(int* d, ncclNetVDeviceProps_t* props) {
   // Safe cast: devs[] is at the end of the struct and NCCL limits ndevs to NCCL_NET_MAX_DEVS_PER_NIC_V11 for v10 plugins.
-  return ncclCollNet_v10->makeVDevice(d, (ncclNetVDeviceProps_v10_t *)props);
+  return ncclCollNet_v10->makeVDevice(d, (ncclNetVDeviceProps_v10_t*)props);
 }
 
 static ncclResult_t ncclCollNet_finalize(void* ctx __attribute__((unused))) {
@@ -182,9 +181,8 @@ static ncclResult_t ncclCollNet_finalize(void* ctx __attribute__((unused))) {
   return ncclSuccess;
 }
 
-static ncclResult_t ncclCollNet_init(void** ctx __attribute__((unused)),
-    uint64_t commId __attribute__((unused)),
-    ncclDebugLogger_t logfn) {
+static ncclResult_t ncclCollNet_init(void** ctx __attribute__((unused)), uint64_t commId __attribute__((unused)),
+                                     ncclDebugLogger_t logfn) {
   // before ncclCollNet_v11 the collnet plugin was initialized only once. With ncclCollNet_v11 this is no longer the case.
   // The compat layer preserves the ncclCollNet_v10 behavior using a refCount to track the number of times the plugin
   // is initialized, and avoid initializing it multiple times.
@@ -217,7 +215,7 @@ ncclCollNet_t* getNcclCollNet_v10(void* lib) {
   if (ncclCollNet_v10) {
     ncclCollNet.name = ncclCollNet_v10->name;
     ncclCollNet.init = ncclCollNet_init;
-    INFO(NCCL_INIT|NCCL_NET, "NET/Plugin: Loaded collnet plugin %s (v10)", ncclCollNet_v10->name);
+    INFO(NCCL_INIT | NCCL_NET, "NET/Plugin: Loaded collnet plugin %s (v10)", ncclCollNet_v10->name);
     return &ncclCollNet;
   }
   return nullptr;

--- a/projects/rccl/src/plugin/net/net_v11.cc
+++ b/projects/rccl/src/plugin/net/net_v11.cc
@@ -31,8 +31,7 @@ static ncclResult_t ncclNet_getProperties(int dev, ncclNetProperties_t* props) {
   props->netDeviceType = props_v11.netDeviceType;
   props->netDeviceVersion = props_v11.netDeviceVersion;
   props->vProps.ndevs = props_v11.vProps.ndevs;
-  for (int i = 0; i < props_v11.vProps.ndevs; i++)
-    props->vProps.devs[i] = props_v11.vProps.devs[i];
+  for (int i = 0; i < props_v11.vProps.ndevs; i++) props->vProps.devs[i] = props_v11.vProps.devs[i];
   props->maxP2pBytes = props_v11.maxP2pBytes;
   props->maxCollBytes = props_v11.maxCollBytes;
   props->maxMultiRequestSize = props_v11.maxMultiRequestSize;
@@ -51,7 +50,8 @@ static ncclResult_t ncclNet_setNetAttr(void* ctx, ncclNetAttr_t* netAttr) {
   return ncclNet_v11->setNetAttr(ctx, (ncclNetAttr_v11_t*)netAttr);
 }
 
-static ncclResult_t ncclNet_init(void** ctx, uint64_t commId, ncclNetCommConfig_t* config, ncclDebugLogger_t logFunction, ncclProfilerCallback_t profFunction) {
+static ncclResult_t ncclNet_init(void** ctx, uint64_t commId, ncclNetCommConfig_t* config,
+                                 ncclDebugLogger_t logFunction, ncclProfilerCallback_t profFunction) {
   // Safe cast: ncclNetCommConfig_v11_t and ncclNetCommConfig_v12_t are binary identical.
   NCCLCHECK(ncclNet_v11->init(ctx, commId, (ncclNetCommConfig_v11_t*)config, logFunction, profFunction));
   ncclNet.devices = ncclNet_v11->devices;
@@ -82,7 +82,7 @@ ncclNet_t* getNcclNet_v11(void* lib) {
   if (ncclNet_v11) {
     ncclNet.name = ncclNet_v11->name;
     ncclNet.init = ncclNet_init;
-    INFO(NCCL_INIT|NCCL_NET, "NET/Plugin: Loaded net plugin %s (v11)", ncclNet_v11->name);
+    INFO(NCCL_INIT | NCCL_NET, "NET/Plugin: Loaded net plugin %s (v11)", ncclNet_v11->name);
     return &ncclNet;
   }
   return nullptr;
@@ -105,8 +105,7 @@ static ncclResult_t ncclCollNet_getProperties(int dev, ncclNetProperties_t* prop
   props->netDeviceType = props_v11.netDeviceType;
   props->netDeviceVersion = props_v11.netDeviceVersion;
   props->vProps.ndevs = props_v11.vProps.ndevs;
-  for (int i = 0; i < props_v11.vProps.ndevs; i++)
-    props->vProps.devs[i] = props_v11.vProps.devs[i];
+  for (int i = 0; i < props_v11.vProps.ndevs; i++) props->vProps.devs[i] = props_v11.vProps.devs[i];
   props->maxP2pBytes = props_v11.maxP2pBytes;
   props->maxCollBytes = props_v11.maxCollBytes;
   props->maxMultiRequestSize = props_v11.maxMultiRequestSize;
@@ -117,18 +116,17 @@ static ncclResult_t ncclCollNet_iallgather(void* collComm, void* sendData, int n
                                            size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
                                            void* sendMhandle, void** request) {
   // Safe cast: ncclNetSGE_v11_t and ncclNetSGE_v12_t are binary identical.
-  return ncclCollNet_v11->iallgather(collComm, sendData, nRecvParts, (ncclNetSGE_v11_t*)recvParts,
-                                     bytesPerRank, windowOffset, windowBytes, sendMhandle, request);
+  return ncclCollNet_v11->iallgather(collComm, sendData, nRecvParts, (ncclNetSGE_v11_t*)recvParts, bytesPerRank,
+                                     windowOffset, windowBytes, sendMhandle, request);
 }
 
 static ncclResult_t ncclCollNet_ireducescatter(void* collComm, int nSendParts, ncclNetSGE_t* sendParts, void* recvData,
                                                size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
-                                               ncclDataType_t dataType, ncclRedOp_t redOp,
-                                               void* recvMhandle, void** request) {
+                                               ncclDataType_t dataType, ncclRedOp_t redOp, void* recvMhandle,
+                                               void** request) {
   // Safe cast: ncclNetSGE_v11_t and ncclNetSGE_v12_t are binary identical.
-  return ncclCollNet_v11->ireducescatter(collComm, nSendParts, (ncclNetSGE_v11_t*)sendParts, recvData,
-                                         bytesPerRank, windowOffset, windowBytes, dataType, redOp,
-                                         recvMhandle, request);
+  return ncclCollNet_v11->ireducescatter(collComm, nSendParts, (ncclNetSGE_v11_t*)sendParts, recvData, bytesPerRank,
+                                         windowOffset, windowBytes, dataType, redOp, recvMhandle, request);
 }
 
 static ncclResult_t ncclCollNet_makeVDevice(int* d, ncclNetVDeviceProps_t* props) {
@@ -163,7 +161,7 @@ ncclCollNet_t* getNcclCollNet_v11(void* lib) {
   if (ncclCollNet_v11) {
     ncclCollNet.name = ncclCollNet_v11->name;
     ncclCollNet.init = ncclCollNet_init;
-    INFO(NCCL_INIT|NCCL_NET, "NET/Plugin: Loaded collnet plugin %s (v11)", ncclCollNet_v11->name);
+    INFO(NCCL_INIT | NCCL_NET, "NET/Plugin: Loaded collnet plugin %s (v11)", ncclCollNet_v11->name);
     return &ncclCollNet;
   }
   return nullptr;

--- a/projects/rccl/src/plugin/net/net_v12.cc
+++ b/projects/rccl/src/plugin/net/net_v12.cc
@@ -15,7 +15,7 @@ static ncclCollNet_v12_t* ncclCollNet_v12;
 ncclNet_t* getNcclNet_v12(void* lib) {
   ncclNet_v12 = (ncclNet_v12_t*)dlsym(lib, "ncclNetPlugin_v12");
   if (ncclNet_v12) {
-    INFO(NCCL_INIT|NCCL_NET, "NET/Plugin: Loaded net plugin %s (v12)", ncclNet_v12->name);
+    INFO(NCCL_INIT | NCCL_NET, "NET/Plugin: Loaded net plugin %s (v12)", ncclNet_v12->name);
     return (ncclNet_t*)ncclNet_v12;
   }
   return nullptr;
@@ -24,7 +24,7 @@ ncclNet_t* getNcclNet_v12(void* lib) {
 ncclCollNet_t* getNcclCollNet_v12(void* lib) {
   ncclCollNet_v12 = (ncclCollNet_v12_t*)dlsym(lib, "ncclCollNetPlugin_v12");
   if (ncclCollNet_v12) {
-    INFO(NCCL_INIT|NCCL_NET, "NET/Plugin: Loaded collnet plugin %s (v12)", ncclCollNet_v12->name);
+    INFO(NCCL_INIT | NCCL_NET, "NET/Plugin: Loaded collnet plugin %s (v12)", ncclCollNet_v12->name);
     return (ncclCollNet_t*)ncclCollNet_v12;
   }
   return nullptr;

--- a/projects/rccl/src/plugin/net/net_v6.cc
+++ b/projects/rccl/src/plugin/net/net_v6.cc
@@ -49,18 +49,16 @@ static ncclResult_t ncclNet_getProperties(int dev, ncclNetProperties_t* props) {
 }
 
 static ncclResult_t ncclNet_regMr(void* comm, void* data, size_t size, int type, void** mhandle) {
-  if (size >= 1ULL<<31) return ncclInternalError;
-  return ncclNet_v6->regMr(comm, data, (int) size, type, mhandle);
+  if (size >= 1ULL << 31) return ncclInternalError;
+  return ncclNet_v6->regMr(comm, data, (int)size, type, mhandle);
 }
 
-static ncclResult_t ncclNet_listen(void* ctx __attribute__((unused)),
-    int d, void* handle, void** listenComm) {
+static ncclResult_t ncclNet_listen(void* ctx __attribute__((unused)), int d, void* handle, void** listenComm) {
   return ncclNet_v6->listen(d, handle, listenComm);
 }
 
-static ncclResult_t ncclNet_connect(void* ctx __attribute__((unused)),
-    int dev,
-    void* handle, void** sendComm, ncclNetDeviceHandle_t** /*sendDevComm*/) {
+static ncclResult_t ncclNet_connect(void* ctx __attribute__((unused)), int dev, void* handle, void** sendComm,
+                                    ncclNetDeviceHandle_t** /*sendDevComm*/) {
   return ncclNet_v6->connect(dev, handle, sendComm);
 }
 
@@ -69,8 +67,7 @@ static ncclResult_t ncclNet_accept(void* listenComm, void** recvComm, ncclNetDev
 }
 
 static ncclResult_t ncclNet_isend(void* sendComm, void* data, size_t size, int tag, void* mhandle,
-    void* pHandle __attribute__((unused)),
-    void** request) {
+                                  void* pHandle __attribute__((unused)), void** request) {
   int sizeInt;
   if (size > MAX_NET_SIZE) return ncclInternalError;
   sizeInt = (int)size;
@@ -79,14 +76,13 @@ static ncclResult_t ncclNet_isend(void* sendComm, void* data, size_t size, int t
 }
 
 static ncclResult_t ncclNet_irecv(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles,
-    void** pHandles __attribute__((unused)),
-    void** request) {
+                                  void** pHandles __attribute__((unused)), void** request) {
   int sizesInt[NCCL_PROXY_MAX_SUBS];
-  //reset to nullptr if optional receive completion is set
-  if (*request == (void *)NCCL_NET_OPTIONAL_RECV_COMPLETION) *request = nullptr;
-  for (int i=0; i<n; i++) {
+  // reset to nullptr if optional receive completion is set
+  if (*request == (void*)NCCL_NET_OPTIONAL_RECV_COMPLETION) *request = nullptr;
+  for (int i = 0; i < n; i++) {
     if (sizes[i] > MAX_NET_SIZE) return ncclInternalError;
-    sizesInt[i] = (int) sizes[i];
+    sizesInt[i] = (int)sizes[i];
   }
   ncclResult_t ans = ncclNet_v6->irecv(recvComm, n, data, sizesInt, tags, mhandles, request);
   return ans;
@@ -112,7 +108,7 @@ static ncclResult_t ncclCollNet_getProperties(int dev, ncclNetProperties_t* prop
   props->maxComms = p6.maxComms;
   props->maxRecvs = p6.maxRecvs;
   props->latency = p6.latency;
-  props->netDeviceType    = NCCL_NET_DEVICE_HOST;
+  props->netDeviceType = NCCL_NET_DEVICE_HOST;
   props->netDeviceVersion = NCCL_NET_DEVICE_INVALID_VERSION;
   props->vProps.ndevs = 1;
   props->vProps.devs[0] = dev;
@@ -122,23 +118,23 @@ static ncclResult_t ncclCollNet_getProperties(int dev, ncclNetProperties_t* prop
   return ncclSuccess;
 }
 
-static ncclResult_t ncclCollNet_listen(void* ctx __attribute__((unused)),
-    int d, void* handle, void** listenComm) {
+static ncclResult_t ncclCollNet_listen(void* ctx __attribute__((unused)), int d, void* handle, void** listenComm) {
   return ncclCollNet_v6->listen(d, handle, listenComm);
 }
 
 static ncclResult_t ncclCollNet_regMr(void* comm, void* data, size_t size, int type, void** mhandle) {
-  if (size >= 1ULL<<31) return ncclInternalError;
-  return ncclCollNet_v6->regMr(comm, data, (int) size, type, mhandle);
+  if (size >= 1ULL << 31) return ncclInternalError;
+  return ncclCollNet_v6->regMr(comm, data, (int)size, type, mhandle);
 }
 
 static ncclResult_t ncclCollNet_iallreduce(void* collComm, void* sendData, void* recvData, size_t count,
-     ncclDataType_t dataType, ncclRedOp_t redOp, void* sendMhandle, void* recvMhandle, void** request) {
+                                           ncclDataType_t dataType, ncclRedOp_t redOp, void* sendMhandle,
+                                           void* recvMhandle, void** request) {
   int countInt;
   if (count > MAX_NET_SIZE) return ncclInternalError;
   countInt = (int)count;
-  ncclResult_t ans = ncclCollNet_v6->iallreduce(collComm, sendData, recvData, countInt, dataType, redOp,
-                 sendMhandle, recvMhandle, request);
+  ncclResult_t ans = ncclCollNet_v6->iallreduce(collComm, sendData, recvData, countInt, dataType, redOp, sendMhandle,
+                                                recvMhandle, request);
   return ans;
 }
 
@@ -147,11 +143,9 @@ static ncclResult_t ncclCollNet_finalize(void* ctx __attribute__((unused))) {
   return ncclSuccess;
 }
 
-static ncclResult_t ncclNet_init(void** ctx __attribute__((unused)),
-    uint64_t commId __attribute__((unused)),
-    ncclNetCommConfig_t* config __attribute__((unused)),
-    ncclDebugLogger_t logfn,
-    ncclProfilerCallback_t proffn __attribute__((unused))) {
+static ncclResult_t ncclNet_init(void** ctx __attribute__((unused)), uint64_t commId __attribute__((unused)),
+                                 ncclNetCommConfig_t* config __attribute__((unused)), ncclDebugLogger_t logfn,
+                                 ncclProfilerCallback_t proffn __attribute__((unused))) {
   // before ncclNet_v11 the net plugin was initialized only once. With ncclNet_v11 this is no longer the case.
   // The compat layer preserves the ncclNet_v6 behavior using a refCount to track the number of times the plugin
   // is initialized, and avoid initializing it multiple times.
@@ -161,7 +155,7 @@ static ncclResult_t ncclNet_init(void** ctx __attribute__((unused)),
   ncclNet.getProperties = ncclNet_getProperties;
   ncclNet.listen = ncclNet_listen;
   ncclNet.connect = ncclNet_connect;
-  ncclNet.accept =  ncclNet_accept;
+  ncclNet.accept = ncclNet_accept;
   ncclNet.regMr = ncclNet_regMr;
   ncclNet.regMrDmaBuf = ncclNet_v6->regMrDmaBuf;
   ncclNet.deregMr = ncclNet_v6->deregMr;
@@ -174,7 +168,7 @@ static ncclResult_t ncclNet_init(void** ctx __attribute__((unused)),
   ncclNet.closeListen = ncclNet_v6->closeListen;
   ncclNet.getDeviceMr = NULL;
   ncclNet.irecvConsumed = NULL;
-  ncclNet.makeVDevice  = NULL;
+  ncclNet.makeVDevice = NULL;
   ncclNet.finalize = ncclNet_finalize;
   ncclNet.setNetAttr = nullptr;
 exit:
@@ -187,15 +181,14 @@ ncclNet_t* getNcclNet_v6(void* lib) {
   if (ncclNet_v6) {
     ncclNet.name = ncclNet_v6->name;
     ncclNet.init = ncclNet_init;
-    INFO(NCCL_INIT|NCCL_NET, "NET/Plugin: Loaded net plugin %s (v6)", ncclNet_v6->name);
+    INFO(NCCL_INIT | NCCL_NET, "NET/Plugin: Loaded net plugin %s (v6)", ncclNet_v6->name);
     return &ncclNet;
   }
   return nullptr;
 }
 
-static ncclResult_t ncclCollNet_init(void** ctx __attribute__((unused)),
-    uint64_t commId __attribute__((unused)),
-    ncclDebugLogger_t logfn) {
+static ncclResult_t ncclCollNet_init(void** ctx __attribute__((unused)), uint64_t commId __attribute__((unused)),
+                                     ncclDebugLogger_t logfn) {
   // before ncclCollNet_v11 the collnet plugin was initialized only once. With ncclCollNet_v11 this is no longer the case.
   // The compat layer preserves the ncclCollNet_v6 behavior using a refCount to track the number of times the plugin
   // is initialized, and avoid initializing it multiple times.
@@ -216,7 +209,7 @@ static ncclResult_t ncclCollNet_init(void** ctx __attribute__((unused)),
   ncclCollNet.test = ncclCollNet_v6->test;
   ncclCollNet.closeColl = ncclCollNet_v6->closeColl;
   ncclCollNet.closeListen = ncclCollNet_v6->closeListen;
-  ncclCollNet.makeVDevice  = NULL;
+  ncclCollNet.makeVDevice = NULL;
   ncclCollNet.finalize = ncclCollNet_finalize;
 exit:
   refCount[COLLNET_INDEX]++;
@@ -228,7 +221,7 @@ ncclCollNet_t* getNcclCollNet_v6(void* lib) {
   if (ncclCollNet_v6) {
     ncclCollNet.name = ncclCollNet_v6->name;
     ncclCollNet.init = ncclCollNet_init;
-    INFO(NCCL_INIT|NCCL_NET, "NET/Plugin: Loaded collnet plugin %s (v6)", ncclCollNet_v6->name);
+    INFO(NCCL_INIT | NCCL_NET, "NET/Plugin: Loaded collnet plugin %s (v6)", ncclCollNet_v6->name);
     return &ncclCollNet;
   }
   return nullptr;

--- a/projects/rccl/src/plugin/net/net_v7.cc
+++ b/projects/rccl/src/plugin/net/net_v7.cc
@@ -48,25 +48,22 @@ static ncclResult_t ncclNet_getProperties(int dev, ncclNetProperties_t* props) {
   return ncclSuccess;
 }
 
-static ncclResult_t ncclNet_listen(void* ctx __attribute__((unused)),
-    int dev, void* handle, void** listenComm) {
+static ncclResult_t ncclNet_listen(void* ctx __attribute__((unused)), int dev, void* handle, void** listenComm) {
   return ncclNet_v7->listen(dev, handle, listenComm);
 }
 
-static ncclResult_t ncclNet_connect(void* ctx __attribute__((unused)),
-    int dev,
-    void* handle, void** sendComm, ncclNetDeviceHandle_t** sendDevComm) {
+static ncclResult_t ncclNet_connect(void* ctx __attribute__((unused)), int dev, void* handle, void** sendComm,
+                                    ncclNetDeviceHandle_t** sendDevComm) {
   return ncclNet_v7->connect(dev, handle, sendComm, sendDevComm);
 }
 
 static ncclResult_t ncclNet_regMr(void* comm, void* data, size_t size, int type, void** mhandle) {
-  if (size >= 1ULL<<31) return ncclInternalError;
-  return ncclNet_v7->regMr(comm, data, (int) size, type, mhandle);
+  if (size >= 1ULL << 31) return ncclInternalError;
+  return ncclNet_v7->regMr(comm, data, (int)size, type, mhandle);
 }
 
 static ncclResult_t ncclNet_isend(void* sendComm, void* data, size_t size, int tag, void* mhandle,
-    void* pHandle __attribute__((unused)),
-    void** request) {
+                                  void* pHandle __attribute__((unused)), void** request) {
   int sizeInt;
   if (size > MAX_NET_SIZE) return ncclInternalError;
   sizeInt = (int)size;
@@ -75,14 +72,13 @@ static ncclResult_t ncclNet_isend(void* sendComm, void* data, size_t size, int t
 }
 
 static ncclResult_t ncclNet_irecv(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles,
-    void** pHandles __attribute__((unused)),
-    void** request) {
+                                  void** pHandles __attribute__((unused)), void** request) {
   int sizesInt[NCCL_PROXY_MAX_SUBS];
-  //reset to nullptr if optional receive completion is set
-  if (*request == (void *)NCCL_NET_OPTIONAL_RECV_COMPLETION) *request = nullptr;
-  for (int i=0; i<n; i++) {
+  // reset to nullptr if optional receive completion is set
+  if (*request == (void*)NCCL_NET_OPTIONAL_RECV_COMPLETION) *request = nullptr;
+  for (int i = 0; i < n; i++) {
     if (sizes[i] > MAX_NET_SIZE) return ncclInternalError;
-    sizesInt[i] = (int) sizes[i];
+    sizesInt[i] = (int)sizes[i];
   }
   ncclResult_t ans = ncclNet_v7->irecv(recvComm, n, data, sizesInt, tags, mhandles, request);
   return ans;
@@ -108,7 +104,7 @@ static ncclResult_t ncclCollNet_getProperties(int dev, ncclNetProperties_t* prop
   props->maxComms = p7.maxComms;
   props->maxRecvs = p7.maxRecvs;
   props->latency = p7.latency;
-  props->netDeviceType    = NCCL_NET_DEVICE_HOST;
+  props->netDeviceType = NCCL_NET_DEVICE_HOST;
   props->netDeviceVersion = NCCL_NET_DEVICE_INVALID_VERSION;
   props->vProps.ndevs = 1;
   props->vProps.devs[0] = dev;
@@ -118,23 +114,23 @@ static ncclResult_t ncclCollNet_getProperties(int dev, ncclNetProperties_t* prop
   return ncclSuccess;
 }
 
-static ncclResult_t ncclCollNet_listen(void* ctx __attribute__((unused)),
-    int d, void* handle, void** listenComm) {
+static ncclResult_t ncclCollNet_listen(void* ctx __attribute__((unused)), int d, void* handle, void** listenComm) {
   return ncclCollNet_v7->listen(d, handle, listenComm);
 }
 
 static ncclResult_t ncclCollNet_regMr(void* comm, void* data, size_t size, int type, void** mhandle) {
-  if (size >= 1ULL<<31) return ncclInternalError;
-  return ncclCollNet_v7->regMr(comm, data, (int) size, type, mhandle);
+  if (size >= 1ULL << 31) return ncclInternalError;
+  return ncclCollNet_v7->regMr(comm, data, (int)size, type, mhandle);
 }
 
 static ncclResult_t ncclCollNet_iallreduce(void* collComm, void* sendData, void* recvData, size_t count,
-      ncclDataType_t dataType, ncclRedOp_t redOp, void* sendMhandle, void* recvMhandle, void** request) {
+                                           ncclDataType_t dataType, ncclRedOp_t redOp, void* sendMhandle,
+                                           void* recvMhandle, void** request) {
   int countInt;
   if (count > MAX_NET_SIZE) return ncclInternalError;
   countInt = (int)count;
-  ncclResult_t ans = ncclCollNet_v7->iallreduce(collComm, sendData, recvData, countInt, dataType, redOp,
-                 sendMhandle, recvMhandle, request);
+  ncclResult_t ans = ncclCollNet_v7->iallreduce(collComm, sendData, recvData, countInt, dataType, redOp, sendMhandle,
+                                                recvMhandle, request);
   return ans;
 }
 
@@ -143,11 +139,9 @@ static ncclResult_t ncclCollNet_finalize(void* ctx __attribute__((unused))) {
   return ncclSuccess;
 }
 
-static ncclResult_t ncclNet_init(void** ctx __attribute__((unused)),
-    uint64_t commId __attribute__((unused)),
-    ncclNetCommConfig_t* config __attribute__((unused)),
-    ncclDebugLogger_t logfn,
-    ncclProfilerCallback_t proffn __attribute__((unused))) {
+static ncclResult_t ncclNet_init(void** ctx __attribute__((unused)), uint64_t commId __attribute__((unused)),
+                                 ncclNetCommConfig_t* config __attribute__((unused)), ncclDebugLogger_t logfn,
+                                 ncclProfilerCallback_t proffn __attribute__((unused))) {
   // before ncclNet_v11 the net plugin was initialized only once. With ncclNet_v11 this is no longer the case.
   // The compat layer preserves the ncclNet_v7 behavior using a refCount to track the number of times the plugin
   // is initialized, and avoid initializing it multiple times.
@@ -157,7 +151,7 @@ static ncclResult_t ncclNet_init(void** ctx __attribute__((unused)),
   ncclNet.getProperties = ncclNet_getProperties; // ncclNet_v5->getProperties;
   ncclNet.listen = ncclNet_listen;
   ncclNet.connect = ncclNet_connect;
-  ncclNet.accept =  ncclNet_v7->accept;
+  ncclNet.accept = ncclNet_v7->accept;
   ncclNet.regMr = ncclNet_regMr;
   ncclNet.regMrDmaBuf = ncclNet_v7->regMrDmaBuf;
   ncclNet.deregMr = ncclNet_v7->deregMr;
@@ -170,7 +164,7 @@ static ncclResult_t ncclNet_init(void** ctx __attribute__((unused)),
   ncclNet.closeListen = ncclNet_v7->closeListen;
   ncclNet.getDeviceMr = ncclNet_v7->getDeviceMr;
   ncclNet.irecvConsumed = ncclNet_v7->irecvConsumed;
-  ncclNet.makeVDevice  = NULL;
+  ncclNet.makeVDevice = NULL;
   ncclNet.finalize = ncclNet_finalize;
   ncclNet.setNetAttr = nullptr;
 exit:
@@ -183,15 +177,14 @@ ncclNet_t* getNcclNet_v7(void* lib) {
   if (ncclNet_v7) {
     ncclNet.name = ncclNet_v7->name;
     ncclNet.init = ncclNet_init;
-    INFO(NCCL_INIT|NCCL_NET, "NET/Plugin: Loaded net plugin %s (v7)", ncclNet_v7->name);
+    INFO(NCCL_INIT | NCCL_NET, "NET/Plugin: Loaded net plugin %s (v7)", ncclNet_v7->name);
     return &ncclNet;
   }
   return nullptr;
 }
 
-static ncclResult_t ncclCollNet_init(void** ctx __attribute__((unused)),
-    uint64_t commId __attribute__((unused)),
-    ncclDebugLogger_t logfn) {
+static ncclResult_t ncclCollNet_init(void** ctx __attribute__((unused)), uint64_t commId __attribute__((unused)),
+                                     ncclDebugLogger_t logfn) {
   // before ncclCollNet_v11 the collnet plugin was initialized only once. With ncclCollNet_v11 this is no longer the case.
   // The compat layer preserves the ncclCollNet_v7 behavior using a refCount to track the number of times the plugin
   // is initialized, and avoid initializing it multiple times.
@@ -223,7 +216,7 @@ ncclCollNet_t* getNcclCollNet_v7(void* lib) {
   if (ncclCollNet_v7) {
     ncclCollNet.name = ncclCollNet_v7->name;
     ncclCollNet.init = ncclCollNet_init;
-    INFO(NCCL_INIT|NCCL_NET, "NET/Plugin: Loaded collnet plugin %s (v7)", ncclCollNet_v7->name);
+    INFO(NCCL_INIT | NCCL_NET, "NET/Plugin: Loaded collnet plugin %s (v7)", ncclCollNet_v7->name);
     return &ncclCollNet;
   }
   return nullptr;

--- a/projects/rccl/src/plugin/net/net_v8.cc
+++ b/projects/rccl/src/plugin/net/net_v8.cc
@@ -48,20 +48,17 @@ static ncclResult_t ncclNet_getProperties(int dev, ncclNetProperties_t* props) {
   return ncclSuccess;
 }
 
-static ncclResult_t ncclNet_listen(void* ctx __attribute__((unused)),
-    int dev, void* handle, void** listenComm) {
+static ncclResult_t ncclNet_listen(void* ctx __attribute__((unused)), int dev, void* handle, void** listenComm) {
   return ncclNet_v8->listen(dev, handle, listenComm);
 }
 
-static ncclResult_t ncclNet_connect(void* ctx __attribute__((unused)),
-    int dev,
-    void* handle, void** sendComm, ncclNetDeviceHandle_t** sendDevComm) {
+static ncclResult_t ncclNet_connect(void* ctx __attribute__((unused)), int dev, void* handle, void** sendComm,
+                                    ncclNetDeviceHandle_t** sendDevComm) {
   return ncclNet_v8->connect(dev, handle, sendComm, sendDevComm);
 }
 
 static ncclResult_t ncclNet_isend(void* sendComm, void* data, size_t size, int tag, void* mhandle,
-    void* pHandle __attribute__((unused)),
-    void** request) {
+                                  void* pHandle __attribute__((unused)), void** request) {
   int sizeInt;
   if (size > MAX_NET_SIZE) return ncclInternalError;
   sizeInt = (int)size;
@@ -70,14 +67,13 @@ static ncclResult_t ncclNet_isend(void* sendComm, void* data, size_t size, int t
 }
 
 static ncclResult_t ncclNet_irecv(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles,
-    void** pHandles __attribute__((unused)),
-    void** request) {
+                                  void** pHandles __attribute__((unused)), void** request) {
   int sizesInt[NCCL_PROXY_MAX_SUBS];
-  //reset to nullptr if optional receive completion is set
-  if (*request == (void *)NCCL_NET_OPTIONAL_RECV_COMPLETION) *request = nullptr;
-  for (int i=0; i<n; i++) {
+  // reset to nullptr if optional receive completion is set
+  if (*request == (void*)NCCL_NET_OPTIONAL_RECV_COMPLETION) *request = nullptr;
+  for (int i = 0; i < n; i++) {
     if (sizes[i] > MAX_NET_SIZE) return ncclInternalError;
-    sizesInt[i] = (int) sizes[i];
+    sizesInt[i] = (int)sizes[i];
   }
   ncclResult_t ans = ncclNet_v8->irecv(recvComm, n, data, sizesInt, tags, mhandles, request);
   return ans;
@@ -103,7 +99,7 @@ static ncclResult_t ncclCollNet_getProperties(int dev, ncclNetProperties_t* prop
   props->maxComms = p8.maxComms;
   props->maxRecvs = p8.maxRecvs;
   props->latency = p8.latency;
-  props->netDeviceType    = NCCL_NET_DEVICE_HOST;
+  props->netDeviceType = NCCL_NET_DEVICE_HOST;
   props->netDeviceVersion = NCCL_NET_DEVICE_INVALID_VERSION;
   props->vProps.ndevs = 1;
   props->vProps.devs[0] = dev;
@@ -113,50 +109,47 @@ static ncclResult_t ncclCollNet_getProperties(int dev, ncclNetProperties_t* prop
   return ncclSuccess;
 }
 
-static ncclResult_t ncclCollNet_listen(void* ctx __attribute__((unused)),
-    int dev, void* handle, void** listenComm) {
+static ncclResult_t ncclCollNet_listen(void* ctx __attribute__((unused)), int dev, void* handle, void** listenComm) {
   return ncclCollNet_v8->listen(dev, handle, listenComm);
 }
 
 static ncclResult_t ncclCollNet_iallreduce(void* collComm, void* sendData, void* recvData, size_t count,
-      ncclDataType_t dataType, ncclRedOp_t redOp, void* sendMhandle, void* recvMhandle, void** request) {
+                                           ncclDataType_t dataType, ncclRedOp_t redOp, void* sendMhandle,
+                                           void* recvMhandle, void** request) {
   int countInt;
   if (count > MAX_NET_SIZE) return ncclInternalError;
   countInt = (int)count;
-  ncclResult_t ans = ncclCollNet_v8->iallreduce(collComm, sendData, recvData, countInt, dataType, redOp,
-                 sendMhandle, recvMhandle, request);
+  ncclResult_t ans = ncclCollNet_v8->iallreduce(collComm, sendData, recvData, countInt, dataType, redOp, sendMhandle,
+                                                recvMhandle, request);
   return ans;
 }
 
-static ncclResult_t ncclCollNet_iallgather (void* collComm, void* sendData, int nRecvParts, ncclNetSGE_t* recvParts,
-                           size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
-                           void* sendMhandle, void** request) {
+static ncclResult_t ncclCollNet_iallgather(void* collComm, void* sendData, int nRecvParts, ncclNetSGE_t* recvParts,
+                                           size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
+                                           void* sendMhandle, void** request) {
   ncclNetSGE_v8_t recvPartsInt;
   if (nRecvParts > 1) return ncclInternalError;
   if (recvParts->size > MAX_COLLNET_SIZE) return ncclInternalError;
   recvPartsInt.mhandle = recvParts->mhandle;
   recvPartsInt.address = recvParts->address;
   recvPartsInt.size = (int)recvParts->size;
-  ncclResult_t ans = ncclCollNet_v8->iallgather(collComm, sendData, nRecvParts, &recvPartsInt,
-                  bytesPerRank, windowOffset, windowBytes,
-                  sendMhandle, request);
+  ncclResult_t ans = ncclCollNet_v8->iallgather(collComm, sendData, nRecvParts, &recvPartsInt, bytesPerRank,
+                                                windowOffset, windowBytes, sendMhandle, request);
   return ans;
 }
 
 static ncclResult_t ncclCollNet_ireducescatter(void* collComm, int nSendParts, ncclNetSGE_t* sendParts, void* recvData,
-                               size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
-                               ncclDataType_t dataType, ncclRedOp_t redOp,
-                               void* recvMhandle, void** request) {
+                                               size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
+                                               ncclDataType_t dataType, ncclRedOp_t redOp, void* recvMhandle,
+                                               void** request) {
   ncclNetSGE_v8_t sendPartsInt;
   if (nSendParts > 1) return ncclInternalError;
   if (sendParts->size > MAX_COLLNET_SIZE) return ncclInternalError;
   sendPartsInt.mhandle = sendParts->mhandle;
   sendPartsInt.address = sendParts->address;
   sendPartsInt.size = (int)sendParts->size;
-  ncclResult_t ans = ncclCollNet_v8->ireducescatter(collComm, nSendParts, &sendPartsInt,
-                  recvData, bytesPerRank, windowOffset, windowBytes,
-                  dataType, redOp,
-                  recvMhandle, request);
+  ncclResult_t ans = ncclCollNet_v8->ireducescatter(collComm, nSendParts, &sendPartsInt, recvData, bytesPerRank,
+                                                    windowOffset, windowBytes, dataType, redOp, recvMhandle, request);
   return ans;
 }
 
@@ -165,10 +158,9 @@ static ncclResult_t ncclCollNet_finalize(void* ctx __attribute__((unused))) {
   return ncclSuccess;
 }
 
-static ncclResult_t ncclNet_init(void** ctx __attribute__((unused)),
-    uint64_t commId __attribute__((unused)),
-    ncclNetCommConfig_t* config __attribute__((unused)),
-    ncclDebugLogger_t logfn, ncclProfilerCallback_t proffn) {
+static ncclResult_t ncclNet_init(void** ctx __attribute__((unused)), uint64_t commId __attribute__((unused)),
+                                 ncclNetCommConfig_t* config __attribute__((unused)), ncclDebugLogger_t logfn,
+                                 ncclProfilerCallback_t proffn) {
   // before ncclNet_v11 the net plugin was initialized only once. With ncclNet_v11 this is no longer the case.
   // The compat layer preserves the ncclNet_v8 behavior using a refCount to track the number of times the plugin
   // is initialized, and avoid initializing it multiple times.
@@ -178,7 +170,7 @@ static ncclResult_t ncclNet_init(void** ctx __attribute__((unused)),
   ncclNet.getProperties = ncclNet_getProperties;
   ncclNet.listen = ncclNet_listen;
   ncclNet.connect = ncclNet_connect;
-  ncclNet.accept =  ncclNet_v8->accept;
+  ncclNet.accept = ncclNet_v8->accept;
   ncclNet.regMr = ncclNet_v8->regMr;
   ncclNet.regMrDmaBuf = ncclNet_v8->regMrDmaBuf;
   ncclNet.deregMr = ncclNet_v8->deregMr;
@@ -191,7 +183,7 @@ static ncclResult_t ncclNet_init(void** ctx __attribute__((unused)),
   ncclNet.closeListen = ncclNet_v8->closeListen;
   ncclNet.getDeviceMr = ncclNet_v8->getDeviceMr;
   ncclNet.irecvConsumed = ncclNet_v8->irecvConsumed;
-  ncclNet.makeVDevice   = NULL;
+  ncclNet.makeVDevice = NULL;
   ncclNet.finalize = ncclNet_finalize;
   ncclNet.setNetAttr = nullptr;
 exit:
@@ -204,15 +196,14 @@ ncclNet_t* getNcclNet_v8(void* lib) {
   if (ncclNet_v8) {
     ncclNet.name = ncclNet_v8->name;
     ncclNet.init = ncclNet_init;
-    INFO(NCCL_INIT|NCCL_NET, "NET/Plugin: Loaded net plugin %s (v8)", ncclNet_v8->name);
+    INFO(NCCL_INIT | NCCL_NET, "NET/Plugin: Loaded net plugin %s (v8)", ncclNet_v8->name);
     return &ncclNet;
   }
   return nullptr;
 }
 
-static ncclResult_t ncclCollNet_init(void** ctx __attribute__((unused)),
-    uint64_t commId __attribute__((unused)),
-    ncclDebugLogger_t logfn) {
+static ncclResult_t ncclCollNet_init(void** ctx __attribute__((unused)), uint64_t commId __attribute__((unused)),
+                                     ncclDebugLogger_t logfn) {
   // before ncclCollNet_v11 the collnet plugin was initialized only once. With ncclCollNet_v11 this is no longer the case.
   // The compat layer preserves the ncclCollNet_v8 behavior using a refCount to track the number of times the plugin
   // is initialized, and avoid initializing it multiple times.
@@ -245,7 +236,7 @@ ncclCollNet_t* getNcclCollNet_v8(void* lib) {
   if (ncclCollNet_v8) {
     ncclCollNet.name = ncclCollNet_v8->name;
     ncclCollNet.init = ncclCollNet_init;
-    INFO(NCCL_INIT|NCCL_NET, "NET/Plugin: Loaded collnet plugin %s (v8)", ncclCollNet_v8->name);
+    INFO(NCCL_INIT | NCCL_NET, "NET/Plugin: Loaded collnet plugin %s (v8)", ncclCollNet_v8->name);
     return &ncclCollNet;
   }
   return nullptr;

--- a/projects/rccl/src/plugin/net/net_v9.cc
+++ b/projects/rccl/src/plugin/net/net_v9.cc
@@ -50,25 +50,21 @@ static ncclResult_t ncclNet_getProperties(int dev, ncclNetProperties_t* props) {
 }
 
 static ncclResult_t ncclNet_isend(void* sendComm, void* data, size_t size, int tag, void* mhandle,
-    void* pHandle __attribute__((unused)),
-    void** request) {
+                                  void* pHandle __attribute__((unused)), void** request) {
   return ncclNet_v9->isend(sendComm, data, size, tag, mhandle, request);
 }
 
 static ncclResult_t ncclNet_irecv(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles,
-    void** pHandles __attribute__((unused)),
-    void** request) {
+                                  void** pHandles __attribute__((unused)), void** request) {
   return ncclNet_v9->irecv(recvComm, n, data, sizes, tags, mhandles, request);
 }
 
-static ncclResult_t ncclNet_listen(void* ctx __attribute__((unused)),
-    int dev, void* handle, void** listenComm) {
+static ncclResult_t ncclNet_listen(void* ctx __attribute__((unused)), int dev, void* handle, void** listenComm) {
   return ncclNet_v9->listen(dev, handle, listenComm);
 }
 
-static ncclResult_t ncclNet_connect(void* ctx __attribute__((unused)),
-    int dev,
-    void* handle, void** sendComm, ncclNetDeviceHandle_t** sendDevComm) {
+static ncclResult_t ncclNet_connect(void* ctx __attribute__((unused)), int dev, void* handle, void** sendComm,
+                                    ncclNetDeviceHandle_t** sendDevComm) {
   return ncclNet_v9->connect(dev, handle, sendComm, sendDevComm);
 }
 
@@ -108,29 +104,28 @@ static ncclResult_t ncclCollNet_getProperties(int dev, ncclNetProperties_t* prop
   return ncclSuccess;
 }
 
-static ncclResult_t ncclCollNet_listen(void* ctx __attribute__((unused)),
-    int d, void* handle, void** listenComm) {
+static ncclResult_t ncclCollNet_listen(void* ctx __attribute__((unused)), int d, void* handle, void** listenComm) {
   return ncclCollNet_v9->listen(d, handle, listenComm);
 }
 
 static ncclResult_t ncclCollNet_iallgather(void* collComm, void* sendData, int nRecvParts, ncclNetSGE_t* recvParts,
-                             size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
-                             void* sendMhandle, void** request) {
+                                           size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
+                                           void* sendMhandle, void** request) {
   return ncclCollNet_v9->iallgather(collComm, sendData, nRecvParts, (ncclNetSGE_v9_t*)recvParts, bytesPerRank,
-                             windowOffset, windowBytes, sendMhandle, request);
+                                    windowOffset, windowBytes, sendMhandle, request);
 }
 
 static ncclResult_t ncclCollNet_ireducescatter(void* collComm, int nSendParts, ncclNetSGE_t* sendParts, void* recvData,
-                                 size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
-                                 ncclDataType_t dataType, ncclRedOp_t redOp,
-                                 void* recvMhandle, void** request) {
+                                               size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
+                                               ncclDataType_t dataType, ncclRedOp_t redOp, void* recvMhandle,
+                                               void** request) {
   return ncclCollNet_v9->ireducescatter(collComm, nSendParts, (ncclNetSGE_v9_t*)sendParts, recvData, bytesPerRank,
-                                 windowOffset, windowBytes, dataType, redOp, recvMhandle, request);
+                                        windowOffset, windowBytes, dataType, redOp, recvMhandle, request);
 }
 
 static ncclResult_t ncclCollNet_makeVDevice(int* d, ncclNetVDeviceProps_t* props) {
   // Safe cast: devs[] is at the end of the struct and NCCL limits ndevs to NCCL_NET_MAX_DEVS_PER_NIC_V11 for v9 plugins.
-  return ncclCollNet_v9->makeVDevice(d, (ncclNetVDeviceProps_v9_t *)props);
+  return ncclCollNet_v9->makeVDevice(d, (ncclNetVDeviceProps_v9_t*)props);
 }
 
 static ncclResult_t ncclCollNet_finalize(void* ctx __attribute__((unused))) {
@@ -138,10 +133,9 @@ static ncclResult_t ncclCollNet_finalize(void* ctx __attribute__((unused))) {
   return ncclSuccess;
 }
 
-static ncclResult_t ncclNet_init(void** ctx __attribute__((unused)),
-    uint64_t commId __attribute__((unused)),
-    ncclNetCommConfig_t* config __attribute__((unused)),
-    ncclDebugLogger_t logfn, ncclProfilerCallback_t proffn) {
+static ncclResult_t ncclNet_init(void** ctx __attribute__((unused)), uint64_t commId __attribute__((unused)),
+                                 ncclNetCommConfig_t* config __attribute__((unused)), ncclDebugLogger_t logfn,
+                                 ncclProfilerCallback_t proffn) {
   // before ncclNet_v11 the net plugin was initialized only once. With ncclNet_v11 this is no longer the case.
   // The compat layer preserves the ncclNet_v9 behavior using a refCount to track the number of times the plugin
   // is initialized, and avoid initializing it multiple times.
@@ -177,15 +171,14 @@ ncclNet_t* getNcclNet_v9(void* lib) {
   if (ncclNet_v9) {
     ncclNet.name = ncclNet_v9->name;
     ncclNet.init = ncclNet_init;
-    INFO(NCCL_INIT|NCCL_NET, "NET/Plugin: Loaded net plugin %s (v9)", ncclNet_v9->name);
+    INFO(NCCL_INIT | NCCL_NET, "NET/Plugin: Loaded net plugin %s (v9)", ncclNet_v9->name);
     return &ncclNet;
   }
   return nullptr;
 }
 
-static ncclResult_t ncclCollNet_init(void** ctx __attribute__((unused)),
-    uint64_t commId __attribute__((unused)),
-    ncclDebugLogger_t logfn) {
+static ncclResult_t ncclCollNet_init(void** ctx __attribute__((unused)), uint64_t commId __attribute__((unused)),
+                                     ncclDebugLogger_t logfn) {
   // before ncclCollNet_v11 the collnet plugin was initialized only once. With ncclCollNet_v11 this is no longer the case.
   // The compat layer preserves the ncclCollNet_v9 behavior using a refCount to track the number of times the plugin
   // is initialized, and avoid initializing it multiple times.
@@ -218,7 +211,7 @@ ncclCollNet_t* getNcclCollNet_v9(void* lib) {
   if (ncclCollNet_v9) {
     ncclCollNet.name = ncclCollNet_v9->name;
     ncclCollNet.init = ncclCollNet_init;
-    INFO(NCCL_INIT|NCCL_NET, "NET/Plugin: Loaded collnet plugin %s (v9)", ncclCollNet_v9->name);
+    INFO(NCCL_INIT | NCCL_NET, "NET/Plugin: Loaded collnet plugin %s (v9)", ncclCollNet_v9->name);
     return &ncclCollNet;
   }
   return nullptr;

--- a/projects/rccl/src/plugin/plugin_open.cc
+++ b/projects/rccl/src/plugin/plugin_open.cc
@@ -18,11 +18,13 @@
 #define NUM_LIBS 5
 static char* libNames[NUM_LIBS];
 char* ncclPluginLibPaths[NUM_LIBS];
-static void *libHandles[NUM_LIBS];
-static const char *pluginNames[NUM_LIBS] = { "NET", "GIN", "TUNER", "PROFILER", "ENV" };
-static const char *pluginPrefix[NUM_LIBS] = { "librccl-net", "libnccl-gin", "libnccl-tuner", "libnccl-profiler", "libnccl-env" };
-static const char *pluginFallback[NUM_LIBS] = { "", "", "", "", "" };
-static unsigned long subsys[NUM_LIBS] = { NCCL_INIT|NCCL_NET, NCCL_INIT|NCCL_NET, NCCL_INIT|NCCL_TUNING, NCCL_INIT, NCCL_INIT|NCCL_ENV };
+static void* libHandles[NUM_LIBS];
+static const char* pluginNames[NUM_LIBS] = {"NET", "GIN", "TUNER", "PROFILER", "ENV"};
+static const char* pluginPrefix[NUM_LIBS] = {"librccl-net", "libnccl-gin", "libnccl-tuner", "libnccl-profiler",
+                                             "libnccl-env"};
+static const char* pluginFallback[NUM_LIBS] = {"", "", "", "", ""};
+static unsigned long subsys[NUM_LIBS] = {NCCL_INIT | NCCL_NET, NCCL_INIT | NCCL_NET, NCCL_INIT | NCCL_TUNING, NCCL_INIT,
+                                         NCCL_INIT | NCCL_ENV};
 
 static void* tryOpenLib(char* name, int* err, char* errStr) {
   *err = 0;
@@ -34,7 +36,7 @@ static void* tryOpenLib(char* name, int* err, char* errStr) {
     name = nullptr;
   }
 
-  void *handle = ncclOsDlopen(name);
+  void* handle = ncclOsDlopen(name);
   if (nullptr == handle) {
     const char* dlErr = ncclOsDlerror();
     if (dlErr) {
@@ -52,7 +54,7 @@ static void* tryOpenLib(char* name, int* err, char* errStr) {
   return handle;
 }
 
-static void appendNameToList(char* nameList, int *leftChars, char* name) {
+static void appendNameToList(char* nameList, int* leftChars, char* name) {
   snprintf(nameList + PATH_MAX - *leftChars, *leftChars, " %s", name);
   *leftChars -= strlen(name) + 1;
 }
@@ -60,26 +62,23 @@ static void appendNameToList(char* nameList, int *leftChars, char* name) {
 #if defined(NCCL_OS_LINUX)
 static char* getLibPath(void* handle) {
   struct link_map* lm;
-  if (dlinfo(handle, RTLD_DI_LINKMAP, &lm) != 0)
-    return nullptr;
-  else
-    return strdup(lm->l_name);
+  if (dlinfo(handle, RTLD_DI_LINKMAP, &lm) != 0) return nullptr;
+  else return strdup(lm->l_name);
 }
 #elif defined(NCCL_OS_WINDOWS)
 static char* getLibPath(void* handle) {
   char path[PATH_MAX];
   DWORD len = GetModuleFileNameA((HMODULE)handle, path, PATH_MAX);
-  if (len == 0 || len >= PATH_MAX)
-    return nullptr;
+  if (len == 0 || len >= PATH_MAX) return nullptr;
   return strdup(path);
 }
 #endif
 
 static void* openPluginLib(enum ncclPluginType type, const char* libName) {
   int openErr, len = PATH_MAX;
-  char libName_[MAX_STR_LEN] = { 0 };
-  char openErrStr[MAX_STR_LEN + 1] = { 0 };
-  char eNoEntNameList[PATH_MAX] = { 0 };
+  char libName_[MAX_STR_LEN] = {0};
+  char openErrStr[MAX_STR_LEN + 1] = {0};
+  char eNoEntNameList[PATH_MAX] = {0};
 
   if (libName && strlen(libName)) {
     snprintf(libName_, MAX_STR_LEN, "%s", libName);

--- a/projects/rccl/src/plugin/profiler.cc
+++ b/projects/rccl/src/plugin/profiler.cc
@@ -62,8 +62,7 @@ static ncclResult_t ncclProfilerProxyTraceSiblingPath(char* out, size_t outSz) {
 #if defined(__linux__)
   Dl_info info;
   memset(&info, 0, sizeof(info));
-  if (dladdr((void*)&ncclProfilerPluginLoad, &info) == 0 || info.dli_fname == nullptr)
-    return ncclInvalidUsage;
+  if (dladdr((void*)&ncclProfilerPluginLoad, &info) == 0 || info.dli_fname == nullptr) return ncclInvalidUsage;
   char dirbuf[PATH_MAX];
   snprintf(dirbuf, sizeof(dirbuf), "%s", info.dli_fname);
   char* dir = dirname(dirbuf);
@@ -90,8 +89,7 @@ static ncclResult_t ncclProfilerPluginLoad(void) {
 
   if ((profilerName = ncclGetEnv("NCCL_PROFILER_PLUGIN")) != nullptr) {
     INFO(NCCL_ENV, "NCCL_PROFILER_PLUGIN set by environment to %s", profilerName);
-    if (strcasecmp(profilerName, "none") == 0)
-      goto fail;
+    if (strcasecmp(profilerName, "none") == 0) goto fail;
   }
   profilerPluginLib = ncclOpenProfilerPluginLib(profilerName);
   if (profilerPluginLib == nullptr && rcclParamEnableProxyTrace()) {
@@ -200,42 +198,70 @@ static double proxyStepStartTs[2], proxyStepStopTs[2];
 static double proxyCtrlStartTs[2], proxyCtrlStopTs[2];
 static double proxyOpRecordTs[2], proxyStepRecordTs[2], proxyCtrlRecordTs[2];
 
-#define TIME_START_EVENT(event) do {            \
-    (event ## Count)++;                         \
-    (event ## Ts)[0] = gettime();               \
-  } while(0)
+#define TIME_START_EVENT(event) \
+  do { \
+    (event##Count)++; \
+    (event##Ts)[0] = gettime(); \
+  } while (0)
 
-#define TIME_STOP_EVENT(event) do {             \
-    double val = gettime() - (event ## Ts)[0];  \
-    (event ## Ts)[1] += val;                    \
-  } while(0)
+#define TIME_STOP_EVENT(event) \
+  do { \
+    double val = gettime() - (event##Ts)[0]; \
+    (event##Ts)[1] += val; \
+  } while (0)
 
-#define TIME_PRINT_EVENTS(name) do {                                    \
-    printf("%s ", name);                                                \
-    if (elapsedCount)         printf("[elapsed] %g/%ld = %g ", elapsedTs[1], elapsedCount, elapsedTs[1]/elapsedCount); \
-    if (initCount)            printf("[init] %g/%ld = %g ", initTs[1], initCount, initTs[1]/initCount); \
-    if (finalizeCount)        printf("[finalize] %g/%ld = %g ", finalizeTs[1], finalizeCount, finalizeTs[1]/finalizeCount); \
-    if (groupStartCount)      printf("[groupStart] %g/%ld = %g ", groupStartTs[1], groupStartCount, groupStartTs[1]/groupStartCount); \
-    if (groupStopCount)       printf("[groupStop] %g/%ld = %g ", groupStopTs[1], groupStopCount, groupStopTs[1]/groupStopCount); \
-    if (taskStartCount)       printf("[taskStart] %g/%ld = %g ", taskStartTs[1], taskStartCount, taskStartTs[1]/taskStartCount); \
-    if (taskStopCount)        printf("[taskStop] %g/%ld = %g ", taskStopTs[1], taskStopCount, taskStopTs[1]/taskStopCount); \
-    if (proxyOpStartCount)    printf("[proxyOpStart] %g/%ld = %g ", proxyOpStartTs[1], proxyOpStartCount, proxyOpStartTs[1]/proxyOpStartCount); \
-    if (proxyOpStopCount)     printf("[proxyOpStop] %g/%ld = %g ", proxyOpStopTs[1], proxyOpStopCount, proxyOpStopTs[1]/proxyOpStopCount); \
-    if (proxyStepStartCount)  printf("[proxyStepStart] %g/%ld = %g ", proxyStepStartTs[1], proxyStepStartCount, proxyStepStartTs[1]/proxyStepStartCount); \
-    if (proxyStepStopCount)   printf("[proxyStepStop] %g/%ld = %g ", proxyStepStopTs[1], proxyStepStopCount, proxyStepStopTs[1]/proxyStepStopCount); \
-    if (proxyCtrlStartCount)  printf("[proxyCtrlStart] %g/%ld = %g ", proxyCtrlStartTs[1], proxyCtrlStartCount, proxyCtrlStartTs[1]/proxyCtrlStartCount); \
-    if (proxyCtrlStopCount)   printf("[proxyCtrlStop] %g/%ld = %g ", proxyCtrlStopTs[1], proxyCtrlStopCount, proxyCtrlStopTs[1]/proxyCtrlStopCount); \
-    if (proxyOpRecordCount)   printf("[proxyOpRecord] %g/%ld = %g ", proxyOpRecordTs[1], proxyOpRecordCount, proxyOpRecordTs[1]/proxyOpRecordCount); \
-    if (proxyStepRecordCount) printf("[proxyStepRecord] %g/%ld = %g ", proxyStepRecordTs[1], proxyStepRecordCount, proxyStepRecordTs[1]/proxyStepRecordCount); \
-    if (proxyCtrlRecordCount) printf("[proxyCtrlRecord] %g/%ld = %g", proxyCtrlRecordTs[1], proxyCtrlRecordCount, proxyCtrlRecordTs[1]/proxyCtrlRecordCount); \
-    printf("\n");                                                       \
-  } while(0)
+#define TIME_PRINT_EVENTS(name) \
+  do { \
+    printf("%s ", name); \
+    if (elapsedCount) printf("[elapsed] %g/%ld = %g ", elapsedTs[1], elapsedCount, elapsedTs[1] / elapsedCount); \
+    if (initCount) printf("[init] %g/%ld = %g ", initTs[1], initCount, initTs[1] / initCount); \
+    if (finalizeCount) printf("[finalize] %g/%ld = %g ", finalizeTs[1], finalizeCount, finalizeTs[1] / finalizeCount); \
+    if (groupStartCount) \
+      printf("[groupStart] %g/%ld = %g ", groupStartTs[1], groupStartCount, groupStartTs[1] / groupStartCount); \
+    if (groupStopCount) \
+      printf("[groupStop] %g/%ld = %g ", groupStopTs[1], groupStopCount, groupStopTs[1] / groupStopCount); \
+    if (taskStartCount) \
+      printf("[taskStart] %g/%ld = %g ", taskStartTs[1], taskStartCount, taskStartTs[1] / taskStartCount); \
+    if (taskStopCount) printf("[taskStop] %g/%ld = %g ", taskStopTs[1], taskStopCount, taskStopTs[1] / taskStopCount); \
+    if (proxyOpStartCount) \
+      printf("[proxyOpStart] %g/%ld = %g ", proxyOpStartTs[1], proxyOpStartCount, \
+             proxyOpStartTs[1] / proxyOpStartCount); \
+    if (proxyOpStopCount) \
+      printf("[proxyOpStop] %g/%ld = %g ", proxyOpStopTs[1], proxyOpStopCount, proxyOpStopTs[1] / proxyOpStopCount); \
+    if (proxyStepStartCount) \
+      printf("[proxyStepStart] %g/%ld = %g ", proxyStepStartTs[1], proxyStepStartCount, \
+             proxyStepStartTs[1] / proxyStepStartCount); \
+    if (proxyStepStopCount) \
+      printf("[proxyStepStop] %g/%ld = %g ", proxyStepStopTs[1], proxyStepStopCount, \
+             proxyStepStopTs[1] / proxyStepStopCount); \
+    if (proxyCtrlStartCount) \
+      printf("[proxyCtrlStart] %g/%ld = %g ", proxyCtrlStartTs[1], proxyCtrlStartCount, \
+             proxyCtrlStartTs[1] / proxyCtrlStartCount); \
+    if (proxyCtrlStopCount) \
+      printf("[proxyCtrlStop] %g/%ld = %g ", proxyCtrlStopTs[1], proxyCtrlStopCount, \
+             proxyCtrlStopTs[1] / proxyCtrlStopCount); \
+    if (proxyOpRecordCount) \
+      printf("[proxyOpRecord] %g/%ld = %g ", proxyOpRecordTs[1], proxyOpRecordCount, \
+             proxyOpRecordTs[1] / proxyOpRecordCount); \
+    if (proxyStepRecordCount) \
+      printf("[proxyStepRecord] %g/%ld = %g ", proxyStepRecordTs[1], proxyStepRecordCount, \
+             proxyStepRecordTs[1] / proxyStepRecordCount); \
+    if (proxyCtrlRecordCount) \
+      printf("[proxyCtrlRecord] %g/%ld = %g", proxyCtrlRecordTs[1], proxyCtrlRecordCount, \
+             proxyCtrlRecordTs[1] / proxyCtrlRecordCount); \
+    printf("\n"); \
+  } while (0)
 #else
-#define TIME_START_EVENT(event) do {} while(0)
-#define TIME_STOP_EVENT(event)  do {} while(0)
-#define TIME_PRINT_EVENTS(name) do {} while(0)
+#define TIME_START_EVENT(event) \
+  do { \
+  } while (0)
+#define TIME_STOP_EVENT(event) \
+  do { \
+  } while (0)
+#define TIME_PRINT_EVENTS(name) \
+  do { \
+  } while (0)
 #endif
-
 
 int ncclProfilerEventMask;       // Set by profiler
 
@@ -245,22 +271,22 @@ static void printProfilerEventMask(int mask) {
 
   char enabled[512] = {0};
   int pos = 0;
-  if (mask & ncclProfileGroup)        pos += sprintf(enabled + pos, "Group ");
-  if (mask & ncclProfileColl)         pos += sprintf(enabled + pos, "Coll ");
-  if (mask & ncclProfileP2p)          pos += sprintf(enabled + pos, "P2p ");
-  if (mask & ncclProfileProxyOp)      pos += sprintf(enabled + pos, "ProxyOp ");
-  if (mask & ncclProfileProxyStep)    pos += sprintf(enabled + pos, "ProxyStep ");
-  if (mask & ncclProfileProxyCtrl)    pos += sprintf(enabled + pos, "ProxyCtrl ");
-  if (mask & ncclProfileKernelCh)     pos += sprintf(enabled + pos, "KernelCh ");
-  if (mask & ncclProfileNetPlugin)    pos += sprintf(enabled + pos, "NetPlugin ");
-  if (mask & ncclProfileGroupApi)     pos += sprintf(enabled + pos, "GroupApi ");
-  if (mask & ncclProfileCollApi)      pos += sprintf(enabled + pos, "CollApi ");
-  if (mask & ncclProfileP2pApi)       pos += sprintf(enabled + pos, "P2pApi ");
+  if (mask & ncclProfileGroup) pos += sprintf(enabled + pos, "Group ");
+  if (mask & ncclProfileColl) pos += sprintf(enabled + pos, "Coll ");
+  if (mask & ncclProfileP2p) pos += sprintf(enabled + pos, "P2p ");
+  if (mask & ncclProfileProxyOp) pos += sprintf(enabled + pos, "ProxyOp ");
+  if (mask & ncclProfileProxyStep) pos += sprintf(enabled + pos, "ProxyStep ");
+  if (mask & ncclProfileProxyCtrl) pos += sprintf(enabled + pos, "ProxyCtrl ");
+  if (mask & ncclProfileKernelCh) pos += sprintf(enabled + pos, "KernelCh ");
+  if (mask & ncclProfileNetPlugin) pos += sprintf(enabled + pos, "NetPlugin ");
+  if (mask & ncclProfileGroupApi) pos += sprintf(enabled + pos, "GroupApi ");
+  if (mask & ncclProfileCollApi) pos += sprintf(enabled + pos, "CollApi ");
+  if (mask & ncclProfileP2pApi) pos += sprintf(enabled + pos, "P2pApi ");
   if (mask & ncclProfileKernelLaunch) pos += sprintf(enabled + pos, "KernelLaunch ");
-  if (mask & ncclProfileCeColl)       pos += sprintf(enabled + pos, "CeColl ");
-  if (mask & ncclProfileCeSync)       pos += sprintf(enabled + pos, "CeSync ");
-  if (mask & ncclProfileCeBatch)      pos += sprintf(enabled + pos, "CeBatch ");
-  if (mask & ncclProfileProxyDiag)    pos += sprintf(enabled + pos, "ProxyDiag ");
+  if (mask & ncclProfileCeColl) pos += sprintf(enabled + pos, "CeColl ");
+  if (mask & ncclProfileCeSync) pos += sprintf(enabled + pos, "CeSync ");
+  if (mask & ncclProfileCeBatch) pos += sprintf(enabled + pos, "CeBatch ");
+  if (mask & ncclProfileProxyDiag) pos += sprintf(enabled + pos, "ProxyDiag ");
   INFO(NCCL_INIT, "Profiler event mask: 0x%x (%d) - Enabled: %s", mask, mask, enabled);
 }
 
@@ -269,7 +295,8 @@ ncclResult_t ncclProfilerPluginInit(struct ncclComm* comm) {
   TIME_START_EVENT(init);
   ncclProfilerPluginLoad();
   if (COMPILER_EXPECT(ncclProfiler != NULL, 0)) {
-    int err = ncclProfiler->init(&comm->profilerContext, comm->commHash, &ncclProfilerEventMask, comm->config.commName, comm->nNodes, comm->nRanks, comm->rank, ncclDebugLog);
+    int err = ncclProfiler->init(&comm->profilerContext, comm->commHash, &ncclProfilerEventMask, comm->config.commName,
+                                 comm->nNodes, comm->nRanks, comm->rank, ncclDebugLog);
     if (err) {
       ncclProfilerPluginUnload();
       INFO(NCCL_INIT, "Profiler init failed with error '%d': %s. Continue without profiler.", err, strerror(errno));
@@ -294,12 +321,15 @@ ncclResult_t ncclProfilerPluginFinalize(struct ncclComm* comm) {
 }
 
 ncclResult_t ncclProfilerStartGroupApiEvent(struct ncclInfo* info, bool isGraphCaptured) {
-  ncclProfilerEventDescr_t eDescr = { 0 };
+  ncclProfilerEventDescr_t eDescr = {0};
   eDescr.type = ncclProfileGroupApi;
   eDescr.groupApi.graphCaptured = isGraphCaptured;
 
   ncclProfilerApiState.eActivationMask = COMPILER_ATOMIC_LOAD(&ncclProfilerEventMask, std::memory_order_relaxed);
-  int groupApiMask = ncclProfileGroupApi | ncclProfileP2pApi | ncclProfileCollApi | ncclProfileKernelLaunch | ncclProfileGroup | ncclProfileColl | ncclProfileP2p | ncclProfileProxyOp | ncclProfileProxyStep | ncclProfileKernelCh | ncclProfileNetPlugin | ncclProfileCeColl | ncclProfileCeSync | ncclProfileCeBatch;
+  int groupApiMask = ncclProfileGroupApi | ncclProfileP2pApi | ncclProfileCollApi | ncclProfileKernelLaunch |
+                     ncclProfileGroup | ncclProfileColl | ncclProfileP2p | ncclProfileProxyOp | ncclProfileProxyStep |
+                     ncclProfileKernelCh | ncclProfileNetPlugin | ncclProfileCeColl | ncclProfileCeSync |
+                     ncclProfileCeBatch;
 
   // Only count outermost groups when emitting group API events
   if (COMPILER_EXPECT(ncclProfiler != NULL, 0) && (ncclProfilerApiState.eActivationMask & groupApiMask)) {
@@ -328,7 +358,8 @@ ncclResult_t ncclProfilerRecordGroupApiEventState(ncclProfilerEventState_t eStat
   if (eState == ncclProfilerGroupStartApiStop && ncclProfilerApiState.state == ncclProfilerGroupApiStartStateStarted) {
     ncclProfilerApiState.state = ncclProfilerGroupApiStartStateStopped;
     shouldRecord = true;
-  } else if (eState == ncclProfilerGroupEndApiStart && ncclProfilerApiState.state == ncclProfilerGroupApiStartStateStopped) {
+  } else if (eState == ncclProfilerGroupEndApiStart &&
+             ncclProfilerApiState.state == ncclProfilerGroupApiStartStateStopped) {
     ncclProfilerApiState.state = ncclProfilerGroupApiStartStateReset;
     shouldRecord = true;
   }
@@ -339,21 +370,25 @@ ncclResult_t ncclProfilerRecordGroupApiEventState(ncclProfilerEventState_t eStat
   return ncclSuccess;
 }
 
-ncclResult_t ncclProfilerStartP2pApiEvent(struct ncclInfo *info, bool isGraphCaptured) {
-  ncclProfilerEventDescr_t eDescr = { 0 };
+ncclResult_t ncclProfilerStartP2pApiEvent(struct ncclInfo* info, bool isGraphCaptured) {
+  ncclProfilerEventDescr_t eDescr = {0};
   eDescr.type = ncclProfileP2pApi;
   eDescr.parentObj = ncclProfilerApiState.groupApiEventHandle;
   eDescr.p2pApi.func = ncclFuncToString(info->coll);
   eDescr.p2pApi.count = info->count;
   eDescr.p2pApi.datatype = ncclDatatypeToString(info->datatype);
-  eDescr.p2pApi.stream = (void *) info->stream;
+  eDescr.p2pApi.stream = (void*)info->stream;
   eDescr.p2pApi.graphCaptured = isGraphCaptured;
-  int p2pApiMask = ncclProfileP2pApi | ncclProfileP2p | ncclProfileProxyOp | ncclProfileProxyStep | ncclProfileKernelCh | ncclProfileNetPlugin;
+  int p2pApiMask = ncclProfileP2pApi | ncclProfileP2p | ncclProfileProxyOp | ncclProfileProxyStep |
+                   ncclProfileKernelCh | ncclProfileNetPlugin;
   if (COMPILER_EXPECT(ncclProfiler != NULL, 0) && (ncclProfilerApiState.eActivationMask & p2pApiMask)) {
     ncclProfiler->startEvent(info->comm->profilerContext, &ncclProfilerApiState.p2pApiEventHandle, &eDescr);
   }
   if (isGraphCaptured && info->comm->config.graphUsageMode == 0) {
-    INFO(NCCL_P2P | NCCL_ENV, "Comm config graphUsageMode is set to %d but the user is capturing graphs on the stream. Violating graphUsageMode semantics can lead to hangs!", info->comm->config.graphUsageMode);
+    INFO(NCCL_P2P | NCCL_ENV,
+         "Comm config graphUsageMode is set to %d but the user is capturing graphs on the stream. Violating "
+         "graphUsageMode semantics can lead to hangs!",
+         info->comm->config.graphUsageMode);
   }
   return ncclSuccess;
 }
@@ -366,22 +401,27 @@ ncclResult_t ncclProfilerStopP2pApiEvent() {
   return ncclSuccess;
 }
 
-ncclResult_t ncclProfilerStartCollApiEvent(struct ncclInfo *info, bool isGraphCaptured) {
-  ncclProfilerEventDescr_t eDescr = { 0 };
+ncclResult_t ncclProfilerStartCollApiEvent(struct ncclInfo* info, bool isGraphCaptured) {
+  ncclProfilerEventDescr_t eDescr = {0};
   eDescr.type = ncclProfileCollApi;
   eDescr.parentObj = ncclProfilerApiState.groupApiEventHandle;
   eDescr.collApi.func = ncclFuncToString(info->coll);
   eDescr.collApi.count = info->count;
   eDescr.collApi.datatype = ncclDatatypeToString(info->datatype);
-  eDescr.collApi.stream = (void *) info->stream;
+  eDescr.collApi.stream = (void*)info->stream;
   eDescr.collApi.root = info->root;
   eDescr.collApi.graphCaptured = isGraphCaptured;
-  int collApiMask = ncclProfileCollApi | ncclProfileColl | ncclProfileProxyOp | ncclProfileProxyStep | ncclProfileKernelCh | ncclProfileNetPlugin | ncclProfileCeColl | ncclProfileCeSync | ncclProfileCeBatch;
+  int collApiMask = ncclProfileCollApi | ncclProfileColl | ncclProfileProxyOp | ncclProfileProxyStep |
+                    ncclProfileKernelCh | ncclProfileNetPlugin | ncclProfileCeColl | ncclProfileCeSync |
+                    ncclProfileCeBatch;
   if (COMPILER_EXPECT(ncclProfiler != NULL, 0) && (ncclProfilerApiState.eActivationMask & collApiMask)) {
     ncclProfiler->startEvent(info->comm->profilerContext, &ncclProfilerApiState.collApiEventHandle, &eDescr);
   }
   if (isGraphCaptured && info->comm->config.graphUsageMode == 0) {
-    INFO(NCCL_COLL | NCCL_ENV, "Comm config graphUsageMode is set to %d but the user is capturing graphs on the stream. Violating graphUsageMode semantics can lead to hangs!", info->comm->config.graphUsageMode);
+    INFO(NCCL_COLL | NCCL_ENV,
+         "Comm config graphUsageMode is set to %d but the user is capturing graphs on the stream. Violating "
+         "graphUsageMode semantics can lead to hangs!",
+         info->comm->config.graphUsageMode);
   }
   return ncclSuccess;
 }
@@ -394,7 +434,7 @@ ncclResult_t ncclProfilerStopCollApiEvent() {
 }
 
 ncclResult_t ncclProfilerStartKernelLaunchEvent(struct ncclKernelPlan* plan, cudaStream_t stream) {
-  ncclProfilerEventDescr_t eDescr = { 0 };
+  ncclProfilerEventDescr_t eDescr = {0};
   if (COMPILER_EXPECT(ncclProfiler != NULL, 0)) {
     void* groupApiEventHandle = NULL;
     // Check if any collective in the plan has a set event activation mask
@@ -423,7 +463,7 @@ ncclResult_t ncclProfilerStartKernelLaunchEvent(struct ncclKernelPlan* plan, cud
     if (eActivationMask_ & ncclProfileKernelLaunch) {
       eDescr.type = ncclProfileKernelLaunch;
       eDescr.parentObj = groupApiEventHandle;
-      eDescr.kernelLaunch.stream = (void *) stream;
+      eDescr.kernelLaunch.stream = (void*)stream;
       ncclProfiler->startEvent(plan->comm->profilerContext, &plan->kernelLaunchEventHandle, &eDescr);
     }
   }
@@ -461,8 +501,9 @@ ncclResult_t ncclProfilerStartGroupEvent(struct ncclKernelPlan* plan) {
     }
 
   startGroup:
-    if (eActivationMask_ & (ncclProfileGroup | ncclProfileColl | ncclProfileP2p | ncclProfileProxyOp | ncclProfileProxyStep | ncclProfileKernelCh | ncclProfileNetPlugin)) {
-      ncclProfilerEventDescr_t eDescr = { 0 };
+    if (eActivationMask_ & (ncclProfileGroup | ncclProfileColl | ncclProfileP2p | ncclProfileProxyOp |
+                            ncclProfileProxyStep | ncclProfileKernelCh | ncclProfileNetPlugin)) {
+      ncclProfilerEventDescr_t eDescr = {0};
       eDescr.type = ncclProfileGroup;
       ncclProfiler->startEvent(plan->comm->profilerContext, &plan->groupEventHandle, &eDescr);
     }
@@ -485,9 +526,10 @@ ncclResult_t ncclProfilerStartTaskEvents(struct ncclKernelPlan* plan) {
   struct ncclTaskColl* ct = ncclIntruQueueHead(&plan->collTaskQueue);
   while (ct) {
     if (COMPILER_EXPECT(ncclProfiler != NULL, 0)) {
-      int enable = ct->eActivationMask & (ncclProfileColl | ncclProfileProxyOp | ncclProfileProxyStep | ncclProfileKernelCh | ncclProfileNetPlugin);
+      int enable = ct->eActivationMask & (ncclProfileColl | ncclProfileProxyOp | ncclProfileProxyStep |
+                                          ncclProfileKernelCh | ncclProfileNetPlugin);
       if (enable) {
-        ncclProfilerEventDescr_t eDescr = { 0 };
+        ncclProfilerEventDescr_t eDescr = {0};
         eDescr.type = ncclProfileColl;
         eDescr.coll.parentGroup = plan->groupEventHandle;
         eDescr.parentObj = ct->collApiEventHandle;
@@ -512,17 +554,19 @@ ncclResult_t ncclProfilerStartTaskEvents(struct ncclKernelPlan* plan) {
     // reports from RAS.  Instead, we choose not to include graph-captured collectives in our counts.  An exception is
     // made if ncclProfileKernelCh profiler events are active, as they result in proxy events always being added, which
     // gives the consistency.
-    if (!plan->persistent || (COMPILER_EXPECT(ncclProfiler != NULL, 0) && (plan->groupEventHandle || ct->collApiEventHandle) &&
-                              (ct->eActivationMask & ncclProfileKernelCh)))
+    if (!plan->persistent ||
+        (COMPILER_EXPECT(ncclProfiler != NULL, 0) && (plan->groupEventHandle || ct->collApiEventHandle) &&
+         (ct->eActivationMask & ncclProfileKernelCh)))
       COMPILER_ATOMIC_FETCH_ADD(&plan->comm->seqNumber[ct->func], 1ULL, std::memory_order_relaxed);
     ct = ct->next;
   }
   if (COMPILER_EXPECT(ncclProfiler != NULL, 0)) {
     struct ncclTaskP2p* pt = ncclIntruQueueHead(&plan->p2pTaskQueue);
     while (pt) {
-      int enable = pt->eActivationMask & (ncclProfileP2p | ncclProfileProxyOp | ncclProfileProxyStep | ncclProfileKernelCh | ncclProfileNetPlugin);
+      int enable = pt->eActivationMask & (ncclProfileP2p | ncclProfileProxyOp | ncclProfileProxyStep |
+                                          ncclProfileKernelCh | ncclProfileNetPlugin);
       if (enable) {
-        ncclProfilerEventDescr_t eDescr = { 0 };
+        ncclProfilerEventDescr_t eDescr = {0};
         eDescr.type = ncclProfileP2p;
         eDescr.p2p.parentGroup = plan->groupEventHandle;
         eDescr.parentObj = pt->p2pApiEventHandle;
@@ -569,8 +613,9 @@ ncclResult_t ncclProfilerStartProxyOpEvent(int s, struct ncclProxyArgs* args) {
   TIME_START_EVENT(proxyOpStart);
   struct ncclProxySubArgs* sub = &args->subs[s];
   if (COMPILER_EXPECT(ncclProfiler != NULL, 0)) {
-    if (sub->eActivationMask & (ncclProfileProxyOp | ncclProfileProxyStep | ncclProfileNetPlugin | ncclProfileProxyDiag)) {
-      ncclProfilerEventDescr_t eDescr = { 0 };
+    if (sub->eActivationMask &
+        (ncclProfileProxyOp | ncclProfileProxyStep | ncclProfileNetPlugin | ncclProfileProxyDiag)) {
+      ncclProfilerEventDescr_t eDescr = {0};
       eDescr.type = ncclProfileProxyOp;
       eDescr.parentObj = sub->taskEventHandle;
       eDescr.rank = sub->rank;
@@ -623,15 +668,15 @@ ncclResult_t ncclProfilerStartSendProxyStepEvent(int s, struct ncclProxyArgs* ar
   int step_ = DIVUP(stepId, args->sliceSteps);
   if (COMPILER_EXPECT(ncclProfiler != NULL, 0)) {
     if (sub->eActivationMask & (ncclProfileProxyStep | ncclProfileNetPlugin | ncclProfileProxyDiag)) {
-      ncclProfilerEventDescr_t eDescr = { 0 };
+      ncclProfilerEventDescr_t eDescr = {0};
       eDescr.type = ncclProfileProxyStep;
       eDescr.parentObj = sub->opEventHandle;
       eDescr.rank = sub->rank;
       eDescr.proxyStep.step = step_;
-      ncclProfiler->startEvent(sub->profilerContext, &sub->pHandles[step_%NCCL_STEPS].stepEventHandle, &eDescr);
+      ncclProfiler->startEvent(sub->profilerContext, &sub->pHandles[step_ % NCCL_STEPS].stepEventHandle, &eDescr);
     }
   }
-  sub->pHandles[step_%NCCL_STEPS].subArgPtr = sub;
+  sub->pHandles[step_ % NCCL_STEPS].subArgPtr = sub;
   TIME_STOP_EVENT(proxyStepStart);
   return ncclSuccess;
 }
@@ -642,15 +687,15 @@ ncclResult_t ncclProfilerStartRecvProxyStepEvent(int s, struct ncclProxyArgs* ar
   int step_ = DIVUP(stepId, args->sliceSteps);
   if (COMPILER_EXPECT(ncclProfiler != NULL, 0)) {
     if (sub->eActivationMask & (ncclProfileProxyStep | ncclProfileNetPlugin | ncclProfileProxyDiag)) {
-      ncclProfilerEventDescr_t eDescr = { 0 };
+      ncclProfilerEventDescr_t eDescr = {0};
       eDescr.type = ncclProfileProxyStep;
       eDescr.parentObj = sub->opEventHandle;
       eDescr.rank = sub->rank;
       eDescr.proxyStep.step = step_;
-      ncclProfiler->startEvent(sub->profilerContext, &sub->pHandles[step_%NCCL_STEPS].stepEventHandle, &eDescr);
+      ncclProfiler->startEvent(sub->profilerContext, &sub->pHandles[step_ % NCCL_STEPS].stepEventHandle, &eDescr);
     }
   }
-  sub->pHandles[step_%NCCL_STEPS].subArgPtr = sub;
+  sub->pHandles[step_ % NCCL_STEPS].subArgPtr = sub;
   TIME_STOP_EVENT(proxyStepStart);
   return ncclSuccess;
 }
@@ -660,9 +705,9 @@ ncclResult_t ncclProfilerStopProxyStepEvent(int s, struct ncclProxyArgs* args, i
   struct ncclProxySubArgs* sub = &args->subs[s];
   if (COMPILER_EXPECT(ncclProfiler != NULL, 0)) {
     int step_ = DIVUP(stepId, args->sliceSteps);
-    if (sub->pHandles[step_%NCCL_STEPS].stepEventHandle) {
-      ncclProfiler->stopEvent(sub->pHandles[step_%NCCL_STEPS].stepEventHandle);
-      sub->pHandles[step_%NCCL_STEPS].stepEventHandle = NULL;
+    if (sub->pHandles[step_ % NCCL_STEPS].stepEventHandle) {
+      ncclProfiler->stopEvent(sub->pHandles[step_ % NCCL_STEPS].stepEventHandle);
+      sub->pHandles[step_ % NCCL_STEPS].stepEventHandle = NULL;
     }
   }
   TIME_STOP_EVENT(proxyStepStop);
@@ -675,7 +720,7 @@ ncclResult_t ncclProfilerStartProxyCtrlEvent(void* profilerContext, void** eHand
     // for proxy control events we allow profiling mode to change on a per event basis
     int eActivationMaskProxy = COMPILER_ATOMIC_LOAD(&ncclProfilerEventMask, std::memory_order_relaxed);
     if (eActivationMaskProxy & ncclProfileProxyCtrl) {
-      ncclProfilerEventDescr_t eDescr = { 0 };
+      ncclProfilerEventDescr_t eDescr = {0};
       eDescr.type = ncclProfileProxyCtrl;
       ncclProfiler->startEvent(profilerContext, eHandle, &eDescr);
       TIME_STOP_EVENT(proxyCtrlStart);
@@ -700,7 +745,7 @@ ncclResult_t ncclProfilerStartKernelChEvent(struct ncclProxyArgs* args, int s, u
   if (COMPILER_EXPECT(ncclProfiler != NULL, 0)) {
     struct ncclProxySubArgs* sub = &args->subs[s];
     if (sub->eActivationMask & ncclProfileKernelCh) {
-      ncclProfilerEventDescr_t eDescr = { };
+      ncclProfilerEventDescr_t eDescr = {};
       eDescr.type = ncclProfileKernelCh;
       eDescr.parentObj = sub->taskEventHandle;
       eDescr.kernelCh.channelId = sub->channelId;
@@ -715,7 +760,7 @@ ncclResult_t ncclProfilerStopKernelChEvent(struct ncclProxyArgs* args, int s, ui
   if (COMPILER_EXPECT(ncclProfiler != NULL, 0)) {
     struct ncclProxySubArgs* sub = &args->subs[s];
     if (sub->kernelEventHandle) {
-      ncclProfilerEventStateArgs_t a = { };
+      ncclProfilerEventStateArgs_t a = {};
       a.kernelCh.pTimer = stop;
       ncclProfiler->recordEventState(sub->kernelEventHandle, ncclProfilerKernelChStop, &a);
       ncclProfiler->stopEvent(sub->kernelEventHandle);
@@ -728,22 +773,23 @@ ncclResult_t ncclProfilerRecordProxyOpEventState(int s, struct ncclProxyArgs* ar
   TIME_START_EVENT(proxyOpRecord);
   struct ncclProxySubArgs* sub = &args->subs[s];
   if (COMPILER_EXPECT(ncclProfiler != NULL, 0) && sub->opEventHandle) {
-    ncclProfilerEventStateArgs_t a = { };
+    ncclProfilerEventStateArgs_t a = {};
     ncclProfiler->recordEventState(sub->opEventHandle, eState, &a);
   }
   TIME_STOP_EVENT(proxyOpRecord);
   return ncclSuccess;
 }
 
-ncclResult_t ncclProfilerRecordProxyStepEventState(int s, struct ncclProxyArgs* args, int stepId, ncclProfilerEventState_t eState) {
+ncclResult_t ncclProfilerRecordProxyStepEventState(int s, struct ncclProxyArgs* args, int stepId,
+                                                   ncclProfilerEventState_t eState) {
   TIME_START_EVENT(proxyStepRecord);
   struct ncclProxySubArgs* sub = &args->subs[s];
   if (COMPILER_EXPECT(ncclProfiler != NULL, 0) && sub->opEventHandle) {
     int step_ = DIVUP(stepId, args->sliceSteps);
-    if (sub->pHandles[step_%NCCL_STEPS].stepEventHandle) {
-      ncclProfilerEventStateArgs_t a = { };
+    if (sub->pHandles[step_ % NCCL_STEPS].stepEventHandle) {
+      ncclProfilerEventStateArgs_t a = {};
       a.proxyStep.transSize = sub->transSize;
-      ncclProfiler->recordEventState(sub->pHandles[step_%NCCL_STEPS].stepEventHandle, eState, &a);
+      ncclProfiler->recordEventState(sub->pHandles[step_ % NCCL_STEPS].stepEventHandle, eState, &a);
     }
   }
   TIME_STOP_EVENT(proxyStepRecord);
@@ -752,8 +798,9 @@ ncclResult_t ncclProfilerRecordProxyStepEventState(int s, struct ncclProxyArgs* 
 
 ncclResult_t ncclProfilerRecordProxyCtrlEventState(void* eHandle, int appended, ncclProfilerEventState_t eState) {
   TIME_START_EVENT(proxyCtrlRecord);
-  if (COMPILER_EXPECT(ncclProfiler != NULL, 0) && eHandle && COMPILER_ATOMIC_LOAD(&ncclProfilerEventMask, std::memory_order_relaxed) & ncclProfileProxyCtrl) {
-    ncclProfilerEventStateArgs_t args = { };
+  if (COMPILER_EXPECT(ncclProfiler != NULL, 0) && eHandle &&
+      COMPILER_ATOMIC_LOAD(&ncclProfilerEventMask, std::memory_order_relaxed) & ncclProfileProxyCtrl) {
+    ncclProfilerEventStateArgs_t args = {};
     args.proxyCtrl.appendedProxyOps = appended;
     ncclProfiler->recordEventState(eHandle, eState, &args);
   }
@@ -772,7 +819,7 @@ ncclResult_t ncclProfilerRecordProxyDiagState(int s, struct ncclProxyArgs* args,
   if (!COMPILER_EXPECT(ncclProfiler != NULL, 0)) return ncclSuccess;
   if (!(sub->eActivationMask & ncclProfileProxyDiag)) return ncclSuccess;
   if (!sub->opEventHandle) return ncclSuccess;
-  ncclProfilerEventStateArgs_t a = { };
+  ncclProfilerEventStateArgs_t a = {};
   a.proxyDiag.counterKind = counterKind;
   a.proxyDiag.value = value;
   a.proxyDiag.value2 = value2;
@@ -799,10 +846,14 @@ static ncclResult_t proxyProfilerConnect(struct ncclComm* comm, struct ncclProxy
   std::lock_guard<std::mutex> lock(proxyProfilerConnectMutex);
   if (comm->profiler.initialized) goto exit;
   for (int c = 0; c < MAXCHANNELS; c++) {
-    NCCLCHECKGOTO(ncclProxyConnect(comm, TRANSPORT_PROFILER, 0, comm->rank, &comm->profiler.sendProxyConn[c]), ret, exit);
-    NCCLCHECKGOTO(ncclProxyCallBlocking(comm, &comm->profiler.sendProxyConn[c], ncclProxyMsgConnect, NULL, 0, NULL, 0), ret, exit);
-    NCCLCHECKGOTO(ncclProxyConnect(comm, TRANSPORT_PROFILER, 0, comm->rank, &comm->profiler.recvProxyConn[c]), ret, exit);
-    NCCLCHECKGOTO(ncclProxyCallBlocking(comm, &comm->profiler.recvProxyConn[c], ncclProxyMsgConnect, NULL, 0, NULL, 0), ret, exit);
+    NCCLCHECKGOTO(ncclProxyConnect(comm, TRANSPORT_PROFILER, 0, comm->rank, &comm->profiler.sendProxyConn[c]), ret,
+                  exit);
+    NCCLCHECKGOTO(ncclProxyCallBlocking(comm, &comm->profiler.sendProxyConn[c], ncclProxyMsgConnect, NULL, 0, NULL, 0),
+                  ret, exit);
+    NCCLCHECKGOTO(ncclProxyConnect(comm, TRANSPORT_PROFILER, 0, comm->rank, &comm->profiler.recvProxyConn[c]), ret,
+                  exit);
+    NCCLCHECKGOTO(ncclProxyCallBlocking(comm, &comm->profiler.recvProxyConn[c], ncclProxyMsgConnect, NULL, 0, NULL, 0),
+                  ret, exit);
   }
   comm->profiler.initialized = true;
 exit:
@@ -825,7 +876,7 @@ ncclResult_t ncclProfilerCallback(void** eHandle, int type, void* pHandle, int64
       struct ncclProxyEventHandle* p = (struct ncclProxyEventHandle*)pHandle;
       struct ncclProxySubArgs* sub = p->subArgPtr;
       if (sub->eActivationMask & ncclProfileNetPlugin) {
-        ncclProfilerEventDescr_t eDescr = { 0 };
+        ncclProfilerEventDescr_t eDescr = {0};
         eDescr.type = ncclProfileNetPlugin;
         eDescr.parentObj = p->stepEventHandle;
         eDescr.rank = sub->rank;
@@ -836,11 +887,11 @@ ncclResult_t ncclProfilerCallback(void** eHandle, int type, void* pHandle, int64
     } else if (type == ncclProfilerNetEventStop) { // stop
       ncclProfiler->stopEvent(*eHandle);
     } else if (type == ncclProfilerNetEventUpdate) { // update
-      ncclProfilerEventStateArgs_t args = { };
+      ncclProfilerEventStateArgs_t args = {};
       args.netPlugin.data = extData;
       ncclProfiler->recordEventState(*eHandle, ncclProfilerNetPluginUpdate, &args);
     } else { // update and stop
-      ncclProfilerEventStateArgs_t args = { };
+      ncclProfilerEventStateArgs_t args = {};
       args.netPlugin.data = extData;
       ncclProfiler->recordEventState(*eHandle, ncclProfilerNetPluginUpdate, &args);
       ncclProfiler->stopEvent(*eHandle);
@@ -861,7 +912,7 @@ ncclResult_t ncclProfilerStartCeCollEvent(struct ncclComm* comm, struct ncclCeCo
     // Check if CE Coll events are enabled (or child events CeSync/CeBatch which need CeColl)
     int ceCollMask = ncclProfileCeColl | ncclProfileCeSync | ncclProfileCeBatch;
     if (__atomic_load_n(&ncclProfilerEventMask, __ATOMIC_RELAXED) & ceCollMask) {
-      ncclProfilerEventDescr_t eDescr = { 0 };
+      ncclProfilerEventDescr_t eDescr = {0};
       eDescr.type = ncclProfileCeColl;
       eDescr.parentObj = args->collApiEventHandle;
       eDescr.rank = comm->rank;
@@ -902,12 +953,13 @@ ncclResult_t ncclProfilerStopCeCollEvent(struct ncclComm* comm, struct ncclCeCol
 /*
  * CE Sync start event - calls plugin startEvent callback
  */
-ncclResult_t ncclProfilerStartCeSyncEvent(struct ncclComm* comm, struct ncclCeCollArgs* args,
-                                          cudaStream_t stream, void** ceSyncHandle) {
+ncclResult_t ncclProfilerStartCeSyncEvent(struct ncclComm* comm, struct ncclCeCollArgs* args, cudaStream_t stream,
+                                          void** ceSyncHandle) {
   if (COMPILER_EXPECT(ncclProfiler != NULL, 0)) {
-    if (args && args->ceCollProfHandle && (__atomic_load_n(&ncclProfilerEventMask, __ATOMIC_RELAXED) & ncclProfileCeSync)) {
+    if (args && args->ceCollProfHandle &&
+        (__atomic_load_n(&ncclProfilerEventMask, __ATOMIC_RELAXED) & ncclProfileCeSync)) {
       // CeSync only needs to check if it's enabled; parent CeColl is implicitly started via ceCollMask
-      ncclProfilerEventDescr_t eDescr = { 0 };
+      ncclProfilerEventDescr_t eDescr = {0};
       eDescr.type = ncclProfileCeSync;
       eDescr.parentObj = args->ceCollProfHandle;
       eDescr.rank = comm->rank;
@@ -924,8 +976,7 @@ ncclResult_t ncclProfilerStartCeSyncEvent(struct ncclComm* comm, struct ncclCeCo
 /*
  * CE Sync stop event - calls plugin stopEvent callback
  */
-ncclResult_t ncclProfilerStopCeSyncEvent(struct ncclComm* comm, void* ceSyncHandle,
-                                         cudaStream_t stream) {
+ncclResult_t ncclProfilerStopCeSyncEvent(struct ncclComm* comm, void* ceSyncHandle, cudaStream_t stream) {
   if (COMPILER_EXPECT(ncclProfiler != NULL, 0) && ceSyncHandle) {
     ncclProfiler->stopEvent(ceSyncHandle);
   }
@@ -935,16 +986,14 @@ ncclResult_t ncclProfilerStopCeSyncEvent(struct ncclComm* comm, void* ceSyncHand
 /*
  * CE Batch start event - calls plugin startEvent callback
  */
-ncclResult_t ncclProfilerStartCeBatchEvent(struct ncclComm* comm,
-                                           struct ncclCeCollArgs* args,
-                                           struct ncclCeBatchOpsParams* params,
-                                           cudaStream_t stream,
+ncclResult_t ncclProfilerStartCeBatchEvent(struct ncclComm* comm, struct ncclCeCollArgs* args,
+                                           struct ncclCeBatchOpsParams* params, cudaStream_t stream,
                                            void** ceBatchHandle) {
   if (COMPILER_EXPECT(ncclProfiler != NULL, 0)) {
     if (args && args->ceCollProfHandle) {
       // CeBatch only needs to check if it's enabled; parent CeColl is implicitly started via ceCollMask
       if (__atomic_load_n(&ncclProfilerEventMask, __ATOMIC_RELAXED) & ncclProfileCeBatch) {
-        ncclProfilerEventDescr_t eDescr = { 0 };
+        ncclProfilerEventDescr_t eDescr = {0};
         eDescr.type = ncclProfileCeBatch;
         eDescr.parentObj = args->ceCollProfHandle;
         eDescr.rank = comm->rank;
@@ -974,4 +1023,3 @@ ncclResult_t ncclProfilerStopCeBatchEvent(struct ncclComm* comm, void* ceBatchHa
   }
   return ncclSuccess;
 }
-

--- a/projects/rccl/src/plugin/profiler/profiler_v1.cc
+++ b/projects/rccl/src/plugin/profiler/profiler_v1.cc
@@ -56,13 +56,15 @@ static uint8_t ncclStringToDatatype(const char* dt) {
 
 static ncclResult_t ncclProfiler_startEvent(void* context, void** eHandle, ncclProfilerEventDescr_t* eDescr) {
   *eHandle = NULL;
-  ncclProfilerEventDescr_v1_t eDescr_v1 = { 0 };
+  ncclProfilerEventDescr_v1_t eDescr_v1 = {0};
   eDescr_v1.type = eDescr->type;
   eDescr_v1.parentObj = eDescr->parentObj;
   eDescr_v1.rank = eDescr->rank;
-  switch(eDescr->type) {
-    case ncclProfileGroup: break;
-    case ncclProfileColl: {
+  switch (eDescr->type) {
+  case ncclProfileGroup:
+    break;
+  case ncclProfileColl:
+    {
       eDescr_v1.coll.name = nullptr; // removed in v4
       eDescr_v1.coll.commHash = 0; // removed in v4
       eDescr_v1.parentObj = eDescr->coll.parentGroup; // Hierarchy changed in v5
@@ -79,8 +81,10 @@ static ncclResult_t ncclProfiler_startEvent(void* context, void** eHandle, ncclP
       eDescr_v1.coll.nWarps = eDescr->coll.nWarps;
       eDescr_v1.coll.algo = ncclStringToAlgo(eDescr->coll.algo);
       eDescr_v1.coll.proto = ncclStringToProto(eDescr->coll.proto);
-    } break;
-    case ncclProfileP2p: {
+    }
+    break;
+  case ncclProfileP2p:
+    {
       eDescr_v1.p2p.name = nullptr; // removed in v4
       eDescr_v1.p2p.commHash = 0; // removed in v4
       eDescr_v1.parentObj = eDescr->p2p.parentGroup; // Hierarchy changed in v5
@@ -89,55 +93,60 @@ static ncclResult_t ncclProfiler_startEvent(void* context, void** eHandle, ncclP
       eDescr_v1.p2p.count = eDescr->p2p.count;
       eDescr_v1.p2p.datatype = ncclStringToDatatype(eDescr->p2p.datatype);
       eDescr_v1.p2p.peer = eDescr->p2p.peer;
-    } break;
-    case ncclProfileProxyOp: {
+    }
+    break;
+  case ncclProfileProxyOp:
+    {
       eDescr_v1.proxyOp.pid = eDescr->proxyOp.pid;
       eDescr_v1.proxyOp.channelId = eDescr->proxyOp.channelId;
       eDescr_v1.proxyOp.peer = eDescr->proxyOp.peer;
       eDescr_v1.proxyOp.nSteps = eDescr->proxyOp.nSteps;
       eDescr_v1.proxyOp.chunkSize = eDescr->proxyOp.chunkSize;
       eDescr_v1.proxyOp.isSend = eDescr->proxyOp.isSend;
-    } break;
-    case ncclProfileProxyStep: {
+    }
+    break;
+  case ncclProfileProxyStep:
+    {
       eDescr_v1.proxyStep.step = eDescr->proxyStep.step;
-    } break;
-    case ncclProfileProxyCtrl: break;
-    default: return ncclSuccess;
+    }
+    break;
+  case ncclProfileProxyCtrl:
+    break;
+  default:
+    return ncclSuccess;
   }
   return ncclProfiler_v1->startEvent(context, eHandle, &eDescr_v1);
 }
 
-static ncclResult_t ncclProfiler_recordEventState(void* eHandle, ncclProfilerEventState_t eState, ncclProfilerEventStateArgs_t* eStateArgs) {
-  ncclProfilerEventStateArgs_v1_t args = { };
+static ncclResult_t ncclProfiler_recordEventState(void* eHandle, ncclProfilerEventState_t eState,
+                                                  ncclProfilerEventStateArgs_t* eStateArgs) {
+  ncclProfilerEventStateArgs_v1_t args = {};
   switch (eState) {
-    case ncclProfilerProxyCtrlIdle:
-    case ncclProfilerProxyCtrlActive:
-    case ncclProfilerProxyCtrlSleep:
-    case ncclProfilerProxyCtrlWakeup:
-    case ncclProfilerProxyCtrlAppend:
-    case ncclProfilerProxyCtrlAppendEnd:
-      args.proxyCtrl.appendedProxyOps = eStateArgs->proxyCtrl.appendedProxyOps;
-      break;
-    case ncclProfilerProxyStepSendGPUWait:
-    case ncclProfilerProxyStepSendWait:
-    case ncclProfilerProxyStepRecvWait:
-    case ncclProfilerProxyStepRecvFlushWait:
-    case ncclProfilerProxyStepRecvGPUWait:
-      break;
-    default: return ncclSuccess;
+  case ncclProfilerProxyCtrlIdle:
+  case ncclProfilerProxyCtrlActive:
+  case ncclProfilerProxyCtrlSleep:
+  case ncclProfilerProxyCtrlWakeup:
+  case ncclProfilerProxyCtrlAppend:
+  case ncclProfilerProxyCtrlAppendEnd:
+    args.proxyCtrl.appendedProxyOps = eStateArgs->proxyCtrl.appendedProxyOps;
+    break;
+  case ncclProfilerProxyStepSendGPUWait:
+  case ncclProfilerProxyStepSendWait:
+  case ncclProfilerProxyStepRecvWait:
+  case ncclProfilerProxyStepRecvFlushWait:
+  case ncclProfilerProxyStepRecvGPUWait:
+    break;
+  default:
+    return ncclSuccess;
   }
   return ncclProfiler_v1->recordEventState(eHandle, eState, &args);
 }
 
-static ncclResult_t ncclProfiler_init(void** context,
-    uint64_t commId __attribute__((unused)),
-    int* eActivationMask __attribute__((unused)),
-    const char* commName __attribute__((unused)),
-    int nNodes __attribute__((unused)),
-    int nranks __attribute__((unused)),
-    int rank __attribute__((unused)),
-    ncclDebugLogger_t logfn __attribute__((unused))
-  ) {
+static ncclResult_t ncclProfiler_init(void** context, uint64_t commId __attribute__((unused)),
+                                      int* eActivationMask __attribute__((unused)),
+                                      const char* commName __attribute__((unused)), int nNodes __attribute__((unused)),
+                                      int nranks __attribute__((unused)), int rank __attribute__((unused)),
+                                      ncclDebugLogger_t logfn __attribute__((unused))) {
   NCCLCHECK(ncclProfiler_v1->init(context, eActivationMask));
   ncclProfiler.startEvent = ncclProfiler_startEvent;
   ncclProfiler.stopEvent = ncclProfiler_v1->stopEvent;

--- a/projects/rccl/src/plugin/profiler/profiler_v2.cc
+++ b/projects/rccl/src/plugin/profiler/profiler_v2.cc
@@ -15,13 +15,15 @@ static ncclProfiler_v2_t* ncclProfiler_v2;
 
 static ncclResult_t ncclProfiler_startEvent(void* context, void** eHandle, ncclProfilerEventDescr_t* eDescr) {
   *eHandle = nullptr;
-  ncclProfilerEventDescr_v2_t eDescr_v2 = { };
+  ncclProfilerEventDescr_v2_t eDescr_v2 = {};
   eDescr_v2.type = eDescr->type;
   eDescr_v2.parentObj = eDescr->parentObj;
   eDescr_v2.rank = eDescr->rank;
-  switch(eDescr->type) {
-    case ncclProfileGroup: break;
-    case ncclProfileColl: {
+  switch (eDescr->type) {
+  case ncclProfileGroup:
+    break;
+  case ncclProfileColl:
+    {
       eDescr_v2.parentObj = eDescr->coll.parentGroup; // Hierarchy changed in v5
       eDescr_v2.coll.name = nullptr; // removed in v4
       eDescr_v2.coll.commHash = 0; // removed in v4
@@ -37,8 +39,10 @@ static ncclResult_t ncclProfiler_startEvent(void* context, void** eHandle, ncclP
       eDescr_v2.coll.nWarps = eDescr->coll.nWarps;
       eDescr_v2.coll.algo = eDescr->coll.algo;
       eDescr_v2.coll.proto = eDescr->coll.proto;
-    } break;
-    case ncclProfileP2p: {
+    }
+    break;
+  case ncclProfileP2p:
+    {
       eDescr_v2.p2p.name = nullptr; // removed in v4
       eDescr_v2.p2p.commHash = 0; // removed in v4
       eDescr_v2.parentObj = eDescr->p2p.parentGroup; // Hierarchy changed in v5
@@ -47,55 +51,60 @@ static ncclResult_t ncclProfiler_startEvent(void* context, void** eHandle, ncclP
       eDescr_v2.p2p.count = eDescr->p2p.count;
       eDescr_v2.p2p.datatype = eDescr->p2p.datatype;
       eDescr_v2.p2p.peer = eDescr->p2p.peer;
-    } break;
-    case ncclProfileProxyOp: {
+    }
+    break;
+  case ncclProfileProxyOp:
+    {
       eDescr_v2.proxyOp.pid = eDescr->proxyOp.pid;
       eDescr_v2.proxyOp.channelId = eDescr->proxyOp.channelId;
       eDescr_v2.proxyOp.peer = eDescr->proxyOp.peer;
       eDescr_v2.proxyOp.nSteps = eDescr->proxyOp.nSteps;
       eDescr_v2.proxyOp.chunkSize = eDescr->proxyOp.chunkSize;
       eDescr_v2.proxyOp.isSend = eDescr->proxyOp.isSend;
-    } break;
-    case ncclProfileProxyStep: {
+    }
+    break;
+  case ncclProfileProxyStep:
+    {
       eDescr_v2.proxyStep.step = eDescr->proxyStep.step;
-    } break;
-    case ncclProfileProxyCtrl: break;
-    default: return ncclSuccess;
+    }
+    break;
+  case ncclProfileProxyCtrl:
+    break;
+  default:
+    return ncclSuccess;
   }
   return ncclProfiler_v2->startEvent(context, eHandle, &eDescr_v2);
 }
 
-static ncclResult_t ncclProfiler_recordEventState(void* eHandle, ncclProfilerEventState_t eState, ncclProfilerEventStateArgs_t* eStateArgs) {
-  ncclProfilerEventStateArgs_v2_t args = { };
+static ncclResult_t ncclProfiler_recordEventState(void* eHandle, ncclProfilerEventState_t eState,
+                                                  ncclProfilerEventStateArgs_t* eStateArgs) {
+  ncclProfilerEventStateArgs_v2_t args = {};
   switch (eState) {
-    case ncclProfilerProxyCtrlIdle:
-    case ncclProfilerProxyCtrlActive:
-    case ncclProfilerProxyCtrlSleep:
-    case ncclProfilerProxyCtrlWakeup:
-    case ncclProfilerProxyCtrlAppend:
-    case ncclProfilerProxyCtrlAppendEnd:
-      args.proxyCtrl.appendedProxyOps = eStateArgs->proxyCtrl.appendedProxyOps;
-      break;
-    case ncclProfilerProxyStepSendGPUWait:
-    case ncclProfilerProxyStepSendWait:
-    case ncclProfilerProxyStepRecvWait:
-    case ncclProfilerProxyStepRecvFlushWait:
-    case ncclProfilerProxyStepRecvGPUWait:
-      break;
-    default: return ncclSuccess;
+  case ncclProfilerProxyCtrlIdle:
+  case ncclProfilerProxyCtrlActive:
+  case ncclProfilerProxyCtrlSleep:
+  case ncclProfilerProxyCtrlWakeup:
+  case ncclProfilerProxyCtrlAppend:
+  case ncclProfilerProxyCtrlAppendEnd:
+    args.proxyCtrl.appendedProxyOps = eStateArgs->proxyCtrl.appendedProxyOps;
+    break;
+  case ncclProfilerProxyStepSendGPUWait:
+  case ncclProfilerProxyStepSendWait:
+  case ncclProfilerProxyStepRecvWait:
+  case ncclProfilerProxyStepRecvFlushWait:
+  case ncclProfilerProxyStepRecvGPUWait:
+    break;
+  default:
+    return ncclSuccess;
   }
   return ncclProfiler_v2->recordEventState(eHandle, eState, &args);
 }
 
-static ncclResult_t ncclProfiler_init(void** context,
-    uint64_t commId __attribute__((unused)),
-    int* eActivationMask __attribute__((unused)),
-    const char* commName __attribute__((unused)),
-    int nNodes __attribute__((unused)),
-    int nranks __attribute__((unused)),
-    int rank __attribute__((unused)),
-    ncclDebugLogger_t logfn __attribute__((unused))
-  ) {
+static ncclResult_t ncclProfiler_init(void** context, uint64_t commId __attribute__((unused)),
+                                      int* eActivationMask __attribute__((unused)),
+                                      const char* commName __attribute__((unused)), int nNodes __attribute__((unused)),
+                                      int nranks __attribute__((unused)), int rank __attribute__((unused)),
+                                      ncclDebugLogger_t logfn __attribute__((unused))) {
   NCCLCHECK(ncclProfiler_v2->init(context, eActivationMask));
   ncclProfiler.startEvent = ncclProfiler_startEvent;
   ncclProfiler.stopEvent = ncclProfiler_v2->stopEvent;

--- a/projects/rccl/src/plugin/profiler/profiler_v3.cc
+++ b/projects/rccl/src/plugin/profiler/profiler_v3.cc
@@ -15,13 +15,15 @@ static ncclProfiler_v3_t* ncclProfiler_v3;
 
 static ncclResult_t ncclProfiler_startEvent(void* context, void** eHandle, ncclProfilerEventDescr_t* eDescr) {
   *eHandle = nullptr;
-  ncclProfilerEventDescr_v3_t eDescr_v3 = { };
+  ncclProfilerEventDescr_v3_t eDescr_v3 = {};
   eDescr_v3.type = eDescr->type;
   eDescr_v3.parentObj = eDescr->parentObj;
   eDescr_v3.rank = eDescr->rank;
-  switch(eDescr->type) {
-    case ncclProfileGroup: break;
-    case ncclProfileColl: {
+  switch (eDescr->type) {
+  case ncclProfileGroup:
+    break;
+  case ncclProfileColl:
+    {
       eDescr_v3.coll.name = nullptr; // removed in v4
       eDescr_v3.coll.commHash = 0; // removed in v4
       eDescr_v3.parentObj = eDescr->coll.parentGroup; // Hierarchy changed in v5
@@ -36,8 +38,10 @@ static ncclResult_t ncclProfiler_startEvent(void* context, void** eHandle, ncclP
       eDescr_v3.coll.nWarps = eDescr->coll.nWarps;
       eDescr_v3.coll.algo = eDescr->coll.algo;
       eDescr_v3.coll.proto = eDescr->coll.proto;
-    } break;
-    case ncclProfileP2p: {
+    }
+    break;
+  case ncclProfileP2p:
+    {
       eDescr_v3.p2p.name = nullptr; // removed in v4
       eDescr_v3.p2p.commHash = 0; // removed in v4
       eDescr_v3.parentObj = eDescr->p2p.parentGroup; // Hierarchy changed in v5
@@ -46,62 +50,71 @@ static ncclResult_t ncclProfiler_startEvent(void* context, void** eHandle, ncclP
       eDescr_v3.p2p.count = eDescr->p2p.count;
       eDescr_v3.p2p.datatype = eDescr->p2p.datatype;
       eDescr_v3.p2p.peer = eDescr->p2p.peer;
-    } break;
-    case ncclProfileProxyOp: {
+    }
+    break;
+  case ncclProfileProxyOp:
+    {
       eDescr_v3.proxyOp.pid = eDescr->proxyOp.pid;
       eDescr_v3.proxyOp.channelId = eDescr->proxyOp.channelId;
       eDescr_v3.proxyOp.peer = eDescr->proxyOp.peer;
       eDescr_v3.proxyOp.nSteps = eDescr->proxyOp.nSteps;
       eDescr_v3.proxyOp.chunkSize = eDescr->proxyOp.chunkSize;
       eDescr_v3.proxyOp.isSend = eDescr->proxyOp.isSend;
-    } break;
-    case ncclProfileProxyStep: {
+    }
+    break;
+  case ncclProfileProxyStep:
+    {
       eDescr_v3.proxyStep.step = eDescr->proxyStep.step;
-    } break;
-    case ncclProfileProxyCtrl: break;
-    case ncclProfileKernelCh: {
+    }
+    break;
+  case ncclProfileProxyCtrl:
+    break;
+  case ncclProfileKernelCh:
+    {
       eDescr_v3.kernelCh.channelId = eDescr->kernelCh.channelId;
-    } break;
-    case ncclProfileNetPlugin: {
+    }
+    break;
+  case ncclProfileNetPlugin:
+    {
       eDescr_v3.netPlugin.id = eDescr->netPlugin.id;
       eDescr_v3.netPlugin.data = eDescr->netPlugin.data;
-    } break;
-    default: return ncclSuccess;
+    }
+    break;
+  default:
+    return ncclSuccess;
   }
   return ncclProfiler_v3->startEvent(context, eHandle, &eDescr_v3);
 }
 
-static ncclResult_t ncclProfiler_recordEventState(void* eHandle, ncclProfilerEventState_t eState, ncclProfilerEventStateArgs_t* eStateArgs) {
-  ncclProfilerEventStateArgs_v3_t args = { };
+static ncclResult_t ncclProfiler_recordEventState(void* eHandle, ncclProfilerEventState_t eState,
+                                                  ncclProfilerEventStateArgs_t* eStateArgs) {
+  ncclProfilerEventStateArgs_v3_t args = {};
   switch (eState) {
-    case ncclProfilerProxyCtrlIdle:
-    case ncclProfilerProxyCtrlActive:
-    case ncclProfilerProxyCtrlSleep:
-    case ncclProfilerProxyCtrlWakeup:
-    case ncclProfilerProxyCtrlAppend:
-    case ncclProfilerProxyCtrlAppendEnd:
-      args.proxyCtrl.appendedProxyOps = eStateArgs->proxyCtrl.appendedProxyOps;
-      break;
-    case ncclProfilerProxyStepSendGPUWait:
-    case ncclProfilerProxyStepSendWait:
-    case ncclProfilerProxyStepRecvWait:
-    case ncclProfilerProxyStepRecvFlushWait:
-    case ncclProfilerProxyStepRecvGPUWait:
-      break;
-    default: return ncclSuccess;
+  case ncclProfilerProxyCtrlIdle:
+  case ncclProfilerProxyCtrlActive:
+  case ncclProfilerProxyCtrlSleep:
+  case ncclProfilerProxyCtrlWakeup:
+  case ncclProfilerProxyCtrlAppend:
+  case ncclProfilerProxyCtrlAppendEnd:
+    args.proxyCtrl.appendedProxyOps = eStateArgs->proxyCtrl.appendedProxyOps;
+    break;
+  case ncclProfilerProxyStepSendGPUWait:
+  case ncclProfilerProxyStepSendWait:
+  case ncclProfilerProxyStepRecvWait:
+  case ncclProfilerProxyStepRecvFlushWait:
+  case ncclProfilerProxyStepRecvGPUWait:
+    break;
+  default:
+    return ncclSuccess;
   }
   return ncclProfiler_v3->recordEventState(eHandle, eState, &args);
 }
 
-static ncclResult_t ncclProfiler_init(void** context,
-    uint64_t commId __attribute__((unused)),
-    int* eActivationMask __attribute__((unused)),
-    const char* commName __attribute__((unused)),
-    int nNodes __attribute__((unused)),
-    int nranks __attribute__((unused)),
-    int rank __attribute__((unused)),
-    ncclDebugLogger_t logfn __attribute__((unused))
-  ) {
+static ncclResult_t ncclProfiler_init(void** context, uint64_t commId __attribute__((unused)),
+                                      int* eActivationMask __attribute__((unused)),
+                                      const char* commName __attribute__((unused)), int nNodes __attribute__((unused)),
+                                      int nranks __attribute__((unused)), int rank __attribute__((unused)),
+                                      ncclDebugLogger_t logfn __attribute__((unused))) {
   NCCLCHECK(ncclProfiler_v3->init(context, eActivationMask));
   ncclProfiler.startEvent = ncclProfiler_startEvent;
   ncclProfiler.stopEvent = ncclProfiler_v3->stopEvent;

--- a/projects/rccl/src/plugin/profiler/profiler_v4.cc
+++ b/projects/rccl/src/plugin/profiler/profiler_v4.cc
@@ -18,9 +18,11 @@ static ncclResult_t ncclProfiler_startEvent(void* ctx, void** eHandle, ncclProfi
   eDescr_v4.type = eDescr->type;
   eDescr_v4.parentObj = eDescr->parentObj;
   eDescr_v4.rank = eDescr->rank;
-  switch(eDescr->type) {
-    case ncclProfileGroup: break;
-    case ncclProfileColl: {
+  switch (eDescr->type) {
+  case ncclProfileGroup:
+    break;
+  case ncclProfileColl:
+    {
       eDescr_v4.coll.seqNumber = eDescr->coll.seqNumber;
       eDescr_v4.coll.func = eDescr->coll.func;
       eDescr_v4.coll.sendBuff = eDescr->coll.sendBuff;
@@ -33,73 +35,89 @@ static ncclResult_t ncclProfiler_startEvent(void* ctx, void** eHandle, ncclProfi
       eDescr_v4.coll.algo = eDescr->coll.algo;
       eDescr_v4.coll.proto = eDescr->coll.proto;
       eDescr_v4.parentObj = eDescr->coll.parentGroup;
-    } break;
-    case ncclProfileP2p: {
+    }
+    break;
+  case ncclProfileP2p:
+    {
       eDescr_v4.p2p.func = eDescr->p2p.func;
       eDescr_v4.p2p.buff = eDescr->p2p.buff;
       eDescr_v4.p2p.count = eDescr->p2p.count;
       eDescr_v4.p2p.datatype = eDescr->p2p.datatype;
       eDescr_v4.p2p.peer = eDescr->p2p.peer;
       eDescr_v4.parentObj = eDescr->p2p.parentGroup;
-    } break;
-    case ncclProfileProxyOp: {
+    }
+    break;
+  case ncclProfileProxyOp:
+    {
       eDescr_v4.proxyOp.pid = eDescr->proxyOp.pid;
       eDescr_v4.proxyOp.channelId = eDescr->proxyOp.channelId;
       eDescr_v4.proxyOp.peer = eDescr->proxyOp.peer;
       eDescr_v4.proxyOp.nSteps = eDescr->proxyOp.nSteps;
       eDescr_v4.proxyOp.chunkSize = eDescr->proxyOp.chunkSize;
       eDescr_v4.proxyOp.isSend = eDescr->proxyOp.isSend;
-    } break;
-    case ncclProfileProxyStep: {
+    }
+    break;
+  case ncclProfileProxyStep:
+    {
       eDescr_v4.proxyStep.step = eDescr->proxyStep.step;
-    } break;
-    case ncclProfileProxyCtrl: break;
-    case ncclProfileKernelCh: {
+    }
+    break;
+  case ncclProfileProxyCtrl:
+    break;
+  case ncclProfileKernelCh:
+    {
       eDescr_v4.kernelCh.channelId = eDescr->kernelCh.channelId;
       eDescr_v4.kernelCh.pTimer = eDescr->kernelCh.pTimer;
-    } break;
-    case ncclProfileNetPlugin: {
+    }
+    break;
+  case ncclProfileNetPlugin:
+    {
       eDescr_v4.netPlugin.id = eDescr->netPlugin.id;
       eDescr_v4.netPlugin.data = eDescr->netPlugin.data;
-    } break;
-    default: return ncclSuccess;
+    }
+    break;
+  default:
+    return ncclSuccess;
   }
   return ncclProfiler_v4->startEvent(ctx, eHandle, &eDescr_v4);
 }
 
-static ncclResult_t ncclProfiler_recordEventState(void* eHandle, ncclProfilerEventState_t eState, ncclProfilerEventStateArgs_t* eStateArgs) {
+static ncclResult_t ncclProfiler_recordEventState(void* eHandle, ncclProfilerEventState_t eState,
+                                                  ncclProfilerEventStateArgs_t* eStateArgs) {
   ncclProfilerEventStateArgs_v4_t eStateArgs_v4;
-  switch(eState) {
-    case ncclProfilerProxyOpInProgress_v4:
-      break;
-    case ncclProfilerProxyStepSendGPUWait:
-    case ncclProfilerProxyStepSendPeerWait_v4:
-    case ncclProfilerProxyStepSendWait:
-    case ncclProfilerProxyStepRecvWait:
-    case ncclProfilerProxyStepRecvFlushWait:
-    case ncclProfilerProxyStepRecvGPUWait:
-      eStateArgs_v4.proxyStep.transSize = eStateArgs->proxyStep.transSize;
-      break;
-    case ncclProfilerNetPluginUpdate:
-      eStateArgs_v4.netPlugin.data = eStateArgs->netPlugin.data;
-      break;
-    case ncclProfilerKernelChStop:
-      eStateArgs_v4.kernelCh.pTimer = eStateArgs->kernelCh.pTimer;
-      break;
-    case ncclProfilerProxyCtrlIdle:
-    case ncclProfilerProxyCtrlActive:
-    case ncclProfilerProxyCtrlSleep:
-    case ncclProfilerProxyCtrlWakeup:
-    case ncclProfilerProxyCtrlAppend:
-    case ncclProfilerProxyCtrlAppendEnd:
-      eStateArgs_v4.proxyCtrl.appendedProxyOps = eStateArgs->proxyCtrl.appendedProxyOps;
-      break;
-    default: return ncclSuccess;
+  switch (eState) {
+  case ncclProfilerProxyOpInProgress_v4:
+    break;
+  case ncclProfilerProxyStepSendGPUWait:
+  case ncclProfilerProxyStepSendPeerWait_v4:
+  case ncclProfilerProxyStepSendWait:
+  case ncclProfilerProxyStepRecvWait:
+  case ncclProfilerProxyStepRecvFlushWait:
+  case ncclProfilerProxyStepRecvGPUWait:
+    eStateArgs_v4.proxyStep.transSize = eStateArgs->proxyStep.transSize;
+    break;
+  case ncclProfilerNetPluginUpdate:
+    eStateArgs_v4.netPlugin.data = eStateArgs->netPlugin.data;
+    break;
+  case ncclProfilerKernelChStop:
+    eStateArgs_v4.kernelCh.pTimer = eStateArgs->kernelCh.pTimer;
+    break;
+  case ncclProfilerProxyCtrlIdle:
+  case ncclProfilerProxyCtrlActive:
+  case ncclProfilerProxyCtrlSleep:
+  case ncclProfilerProxyCtrlWakeup:
+  case ncclProfilerProxyCtrlAppend:
+  case ncclProfilerProxyCtrlAppendEnd:
+    eStateArgs_v4.proxyCtrl.appendedProxyOps = eStateArgs->proxyCtrl.appendedProxyOps;
+    break;
+  default:
+    return ncclSuccess;
   }
   return ncclProfiler_v4->recordEventState(eHandle, (ncclProfilerEventState_v4_t)eState, &eStateArgs_v4);
 }
 
-static ncclResult_t ncclProfiler_init(void** ctx, uint64_t commId, int* eActivationMask, const char* commName, int nNodes, int nRanks, int rank, ncclDebugLogger_t logfn) {
+static ncclResult_t ncclProfiler_init(void** ctx, uint64_t commId, int* eActivationMask, const char* commName,
+                                      int nNodes, int nRanks, int rank, ncclDebugLogger_t logfn) {
   NCCLCHECK(ncclProfiler_v4->init(ctx, eActivationMask, commName, commId, nNodes, nRanks, rank, logfn));
   ncclProfiler.startEvent = ncclProfiler_startEvent;
   ncclProfiler.recordEventState = ncclProfiler_recordEventState;

--- a/projects/rccl/src/plugin/profiler/profiler_v5.cc
+++ b/projects/rccl/src/plugin/profiler/profiler_v5.cc
@@ -19,73 +19,95 @@ static ncclResult_t ncclProfiler_startEvent(void* ctx, void** eHandle, ncclProfi
   eDescr_v5.parentObj = eDescr->parentObj;
   eDescr_v5.rank = eDescr->rank;
 
-  switch(eDescr->type) {
-  case ncclProfileGroup: break;
-  case ncclProfileGroupApi: {
-    eDescr_v5.groupApi.graphCaptured = eDescr->groupApi.graphCaptured;
-    eDescr_v5.groupApi.groupDepth = eDescr->groupApi.groupDepth;
-  } break;
-  case ncclProfileCollApi: {
-    eDescr_v5.collApi.func = eDescr->collApi.func;
-    eDescr_v5.collApi.count = eDescr->collApi.count;
-    eDescr_v5.collApi.datatype = eDescr->collApi.datatype;
-    eDescr_v5.collApi.root = eDescr->collApi.root;
-    eDescr_v5.collApi.stream = eDescr->collApi.stream;
-    eDescr_v5.collApi.graphCaptured = eDescr->collApi.graphCaptured;
-  } break;
-  case ncclProfileP2pApi: {
-    eDescr_v5.p2pApi.func = eDescr->p2pApi.func;
-    eDescr_v5.p2pApi.count = eDescr->p2pApi.count;
-    eDescr_v5.p2pApi.datatype = eDescr->p2pApi.datatype;
-    eDescr_v5.p2pApi.stream = eDescr->p2pApi.stream;
-    eDescr_v5.p2pApi.graphCaptured = eDescr->p2pApi.graphCaptured;
-  } break;
-  case ncclProfileKernelLaunch: {
-    eDescr_v5.kernelLaunch.stream = eDescr->kernelLaunch.stream;
-  } break;
-  case ncclProfileColl: {
-    eDescr_v5.coll.seqNumber = eDescr->coll.seqNumber;
-    eDescr_v5.coll.func = eDescr->coll.func;
-    eDescr_v5.coll.sendBuff = eDescr->coll.sendBuff;
-    eDescr_v5.coll.recvBuff = eDescr->coll.recvBuff;
-    eDescr_v5.coll.count = eDescr->coll.count;
-    eDescr_v5.coll.root = eDescr->coll.root;
-    eDescr_v5.coll.datatype = eDescr->coll.datatype;
-    eDescr_v5.coll.nChannels = eDescr->coll.nChannels;
-    eDescr_v5.coll.nWarps = eDescr->coll.nWarps;
-    eDescr_v5.coll.algo = eDescr->coll.algo;
-    eDescr_v5.coll.proto = eDescr->coll.proto;
-    eDescr_v5.coll.parentGroup = eDescr->coll.parentGroup;
-  } break;
-  case ncclProfileP2p: {
-    eDescr_v5.p2p.func = eDescr->p2p.func;
-    eDescr_v5.p2p.buff = eDescr->p2p.buff;
-    eDescr_v5.p2p.datatype = eDescr->p2p.datatype;
-    eDescr_v5.p2p.count = eDescr->p2p.count;
-    eDescr_v5.p2p.peer = eDescr->p2p.peer;
-    eDescr_v5.p2p.nChannels = eDescr->p2p.nChannels;
-    eDescr_v5.p2p.parentGroup = eDescr->p2p.parentGroup;
-  } break;
-  case ncclProfileProxyOp: {
-    eDescr_v5.proxyOp.pid = eDescr->proxyOp.pid;
-    eDescr_v5.proxyOp.channelId = eDescr->proxyOp.channelId;
-    eDescr_v5.proxyOp.peer = eDescr->proxyOp.peer;
-    eDescr_v5.proxyOp.nSteps = eDescr->proxyOp.nSteps;
-    eDescr_v5.proxyOp.chunkSize = eDescr->proxyOp.chunkSize;
-    eDescr_v5.proxyOp.isSend = eDescr->proxyOp.isSend;
-  } break;
-  case ncclProfileProxyStep: {
-    eDescr_v5.proxyStep.step = eDescr->proxyStep.step;
-  } break;
-  case ncclProfileProxyCtrl: break;
-  case ncclProfileKernelCh: {
-    eDescr_v5.kernelCh.channelId = eDescr->kernelCh.channelId;
-    eDescr_v5.kernelCh.pTimer = eDescr->kernelCh.pTimer;
-  } break;
-  case ncclProfileNetPlugin: {
-    eDescr_v5.netPlugin.id = eDescr->netPlugin.id;
-    eDescr_v5.netPlugin.data = eDescr->netPlugin.data;
-  } break;
+  switch (eDescr->type) {
+  case ncclProfileGroup:
+    break;
+  case ncclProfileGroupApi:
+    {
+      eDescr_v5.groupApi.graphCaptured = eDescr->groupApi.graphCaptured;
+      eDescr_v5.groupApi.groupDepth = eDescr->groupApi.groupDepth;
+    }
+    break;
+  case ncclProfileCollApi:
+    {
+      eDescr_v5.collApi.func = eDescr->collApi.func;
+      eDescr_v5.collApi.count = eDescr->collApi.count;
+      eDescr_v5.collApi.datatype = eDescr->collApi.datatype;
+      eDescr_v5.collApi.root = eDescr->collApi.root;
+      eDescr_v5.collApi.stream = eDescr->collApi.stream;
+      eDescr_v5.collApi.graphCaptured = eDescr->collApi.graphCaptured;
+    }
+    break;
+  case ncclProfileP2pApi:
+    {
+      eDescr_v5.p2pApi.func = eDescr->p2pApi.func;
+      eDescr_v5.p2pApi.count = eDescr->p2pApi.count;
+      eDescr_v5.p2pApi.datatype = eDescr->p2pApi.datatype;
+      eDescr_v5.p2pApi.stream = eDescr->p2pApi.stream;
+      eDescr_v5.p2pApi.graphCaptured = eDescr->p2pApi.graphCaptured;
+    }
+    break;
+  case ncclProfileKernelLaunch:
+    {
+      eDescr_v5.kernelLaunch.stream = eDescr->kernelLaunch.stream;
+    }
+    break;
+  case ncclProfileColl:
+    {
+      eDescr_v5.coll.seqNumber = eDescr->coll.seqNumber;
+      eDescr_v5.coll.func = eDescr->coll.func;
+      eDescr_v5.coll.sendBuff = eDescr->coll.sendBuff;
+      eDescr_v5.coll.recvBuff = eDescr->coll.recvBuff;
+      eDescr_v5.coll.count = eDescr->coll.count;
+      eDescr_v5.coll.root = eDescr->coll.root;
+      eDescr_v5.coll.datatype = eDescr->coll.datatype;
+      eDescr_v5.coll.nChannels = eDescr->coll.nChannels;
+      eDescr_v5.coll.nWarps = eDescr->coll.nWarps;
+      eDescr_v5.coll.algo = eDescr->coll.algo;
+      eDescr_v5.coll.proto = eDescr->coll.proto;
+      eDescr_v5.coll.parentGroup = eDescr->coll.parentGroup;
+    }
+    break;
+  case ncclProfileP2p:
+    {
+      eDescr_v5.p2p.func = eDescr->p2p.func;
+      eDescr_v5.p2p.buff = eDescr->p2p.buff;
+      eDescr_v5.p2p.datatype = eDescr->p2p.datatype;
+      eDescr_v5.p2p.count = eDescr->p2p.count;
+      eDescr_v5.p2p.peer = eDescr->p2p.peer;
+      eDescr_v5.p2p.nChannels = eDescr->p2p.nChannels;
+      eDescr_v5.p2p.parentGroup = eDescr->p2p.parentGroup;
+    }
+    break;
+  case ncclProfileProxyOp:
+    {
+      eDescr_v5.proxyOp.pid = eDescr->proxyOp.pid;
+      eDescr_v5.proxyOp.channelId = eDescr->proxyOp.channelId;
+      eDescr_v5.proxyOp.peer = eDescr->proxyOp.peer;
+      eDescr_v5.proxyOp.nSteps = eDescr->proxyOp.nSteps;
+      eDescr_v5.proxyOp.chunkSize = eDescr->proxyOp.chunkSize;
+      eDescr_v5.proxyOp.isSend = eDescr->proxyOp.isSend;
+    }
+    break;
+  case ncclProfileProxyStep:
+    {
+      eDescr_v5.proxyStep.step = eDescr->proxyStep.step;
+    }
+    break;
+  case ncclProfileProxyCtrl:
+    break;
+  case ncclProfileKernelCh:
+    {
+      eDescr_v5.kernelCh.channelId = eDescr->kernelCh.channelId;
+      eDescr_v5.kernelCh.pTimer = eDescr->kernelCh.pTimer;
+    }
+    break;
+  case ncclProfileNetPlugin:
+    {
+      eDescr_v5.netPlugin.id = eDescr->netPlugin.id;
+      eDescr_v5.netPlugin.data = eDescr->netPlugin.data;
+    }
+    break;
   /* v6 / RCCL-only descriptor arms: not representable in narrow v5 */
   case ncclProfileCeColl:
   case ncclProfileCeSync:
@@ -99,8 +121,9 @@ static ncclResult_t ncclProfiler_startEvent(void* ctx, void** eHandle, ncclProfi
   return ncclProfiler_v5->startEvent(ctx, eHandle, &eDescr_v5);
 }
 
-static ncclResult_t ncclProfiler_recordEventState(void* eHandle, ncclProfilerEventState_t eState, ncclProfilerEventStateArgs_t* eStateArgs) {
-  switch(eState) {
+static ncclResult_t ncclProfiler_recordEventState(void* eHandle, ncclProfilerEventState_t eState,
+                                                  ncclProfilerEventStateArgs_t* eStateArgs) {
+  switch (eState) {
   case ncclProfilerCeCollStart:
   case ncclProfilerCeCollComplete:
   case ncclProfilerCeSyncStart:
@@ -115,7 +138,7 @@ static ncclResult_t ncclProfiler_recordEventState(void* eHandle, ncclProfilerEve
   if (!eStateArgs) return ncclSuccess;
 
   ncclProfilerEventStateArgs_v5_t eStateArgs_v5;
-  switch(eState) {
+  switch (eState) {
   case ncclProfilerProxyStepSendGPUWait:
   case ncclProfilerProxyStepSendPeerWait_v4:
   case ncclProfilerProxyStepSendWait:
@@ -149,7 +172,8 @@ static ncclResult_t ncclProfiler_recordEventState(void* eHandle, ncclProfilerEve
   return ncclProfiler_v5->recordEventState(eHandle, (ncclProfilerEventState_v5_t)eState, &eStateArgs_v5);
 }
 
-static ncclResult_t ncclProfiler_init(void** ctx, uint64_t commId, int* eActivationMask, const char* commName, int nNodes, int nRanks, int rank, ncclDebugLogger_t logfn) {
+static ncclResult_t ncclProfiler_init(void** ctx, uint64_t commId, int* eActivationMask, const char* commName,
+                                      int nNodes, int nRanks, int rank, ncclDebugLogger_t logfn) {
   NCCLCHECK(ncclProfiler_v5->init(ctx, commId, eActivationMask, commName, nNodes, nRanks, rank, logfn));
 
   if (eActivationMask) {

--- a/projects/rccl/src/plugin/tuner.cc
+++ b/projects/rccl/src/plugin/tuner.cc
@@ -31,9 +31,9 @@ static ncclTuner_t* tunerSymbol = nullptr;
 static bool usingBuiltinCsvTuner = false;
 
 enum {
-  tunerPluginLoadFailed  = -1,
-  tunerPluginLoadReady   =  0,
-  tunerPluginLoadSuccess =  1,
+  tunerPluginLoadFailed = -1,
+  tunerPluginLoadReady = 0,
+  tunerPluginLoadSuccess = 1,
 };
 
 #define MAX_PLUGIN_LOAD 4
@@ -61,9 +61,8 @@ ncclResult_t ncclTunerPluginLoad(struct ncclComm* comm) {
   }
 
   if ((tunerName = ncclGetEnv("NCCL_TUNER_PLUGIN")) != nullptr) {
-    INFO(NCCL_ENV|NCCL_TUNING, "NCCL_TUNER_PLUGIN set by environment to %s", tunerName);
-    if (strcasecmp(tunerName, "none") == 0)
-      goto fail;
+    INFO(NCCL_ENV | NCCL_TUNING, "NCCL_TUNER_PLUGIN set by environment to %s", tunerName);
+    if (strcasecmp(tunerName, "none") == 0) goto fail;
   }
   tunerPluginLib = ncclOpenTunerPluginLib(tunerName);
   if (nullptr == tunerPluginLib) {
@@ -79,7 +78,7 @@ ncclResult_t ncclTunerPluginLoad(struct ncclComm* comm) {
       // Check if CSV config file exists
       const char* csvConfigPath = rcclCsvTunerFindConfig(gpuArch);
       if (csvConfigPath != nullptr) {
-        INFO(NCCL_INIT|NCCL_TUNING, "Using built-in CSV tuner, config: %s", csvConfigPath);
+        INFO(NCCL_INIT | NCCL_TUNING, "Using built-in CSV tuner, config: %s", csvConfigPath);
         tunerSymbol = &rcclCsvTuner;
         usingBuiltinCsvTuner = true;
         comm->tuner = tunerSymbol;
@@ -110,10 +109,10 @@ ncclResult_t ncclTunerPluginLoad(struct ncclComm* comm) {
     tunerSymbol = getNcclTuner_v2(tunerPluginLib);
   }
   if (tunerSymbol == NULL) {
-    if (tunerName) INFO(NCCL_INIT|NCCL_TUNING, "External tuner plugin %s is unsupported", tunerName);
+    if (tunerName) INFO(NCCL_INIT | NCCL_TUNING, "External tuner plugin %s is unsupported", tunerName);
     goto fail;
   }
-  if (tunerName) INFO(NCCL_INIT|NCCL_TUNING, "Successfully loaded external tuner plugin %s", tunerName);
+  if (tunerName) INFO(NCCL_INIT | NCCL_TUNING, "Successfully loaded external tuner plugin %s", tunerName);
 
   usingBuiltinCsvTuner = false;
   comm->tuner = tunerSymbol;
@@ -133,7 +132,7 @@ fail:
 ncclResult_t ncclTunerPluginUnload(struct ncclComm* comm) {
   std::lock_guard<std::mutex> lock(tunerPluginMutex);
   if (comm->tunerPluginLoaded && 0 == (--tunerPluginRefCount)) {
-    INFO(NCCL_DESTROY|NCCL_TUNING, "TUNER/Plugin: Closing tuner: '%s'", tunerSymbol->name);
+    INFO(NCCL_DESTROY | NCCL_TUNING, "TUNER/Plugin: Closing tuner: '%s'", tunerSymbol->name);
     // Only close plugin lib if we're not using the built-in CSV tuner
     if (!usingBuiltinCsvTuner && tunerPluginLib) {
       NCCLCHECK(ncclClosePluginLib(tunerPluginLib, ncclPluginTypeTuner));

--- a/projects/rccl/src/plugin/tuner/csv_tuner.cc
+++ b/projects/rccl/src/plugin/tuner/csv_tuner.cc
@@ -42,22 +42,22 @@
 
 // CSV field indices for configuration parsing
 // Format: colltype,minbytes,maxbytes,algorithm,protocol,channels,nNodes,nRanks,numPipeOps,regBuff
-#define CONFIG_FIELD_COLLTYPE     0
-#define CONFIG_FIELD_MINBYTES     1
-#define CONFIG_FIELD_MAXBYTES     2
-#define CONFIG_FIELD_ALGORITHM    3
-#define CONFIG_FIELD_PROTOCOL     4
-#define CONFIG_FIELD_CHANNELS     5
-#define CONFIG_FIELD_NNODES       6
-#define CONFIG_FIELD_NRANKS       7
-#define CONFIG_FIELD_PIPEOPS      8  // Optional field
-#define CONFIG_FIELD_REGBUFF      9  // Optional field
+#define CONFIG_FIELD_COLLTYPE 0
+#define CONFIG_FIELD_MINBYTES 1
+#define CONFIG_FIELD_MAXBYTES 2
+#define CONFIG_FIELD_ALGORITHM 3
+#define CONFIG_FIELD_PROTOCOL 4
+#define CONFIG_FIELD_CHANNELS 5
+#define CONFIG_FIELD_NNODES 6
+#define CONFIG_FIELD_NRANKS 7
+#define CONFIG_FIELD_PIPEOPS 8  // Optional field
+#define CONFIG_FIELD_REGBUFF 9  // Optional field
 
 // Field count constants
-#define CONFIG_FIELDS_REQUIRED    8   // Minimum required fields (up to nRanks)
+#define CONFIG_FIELDS_REQUIRED 8   // Minimum required fields (up to nRanks)
 #define CONFIG_FIELDS_WITH_PIPEOPS 9  // Fields including numPipeOps
 #define CONFIG_FIELDS_WITH_REGBUFF 10 // Fields including both numPipeOps and regBuff
-#define CONFIG_FIELDS_MAX         10  // Maximum number of fields supported
+#define CONFIG_FIELDS_MAX 10  // Maximum number of fields supported
 
 // Global state for CSV config file path discovery
 static std::mutex csvTunerMutex;
@@ -105,12 +105,18 @@ static ncclFunc_t parseCollType(const char* str, bool* valid) {
 // Convert collective type to string (for logging)
 static const char* collTypeToString(ncclFunc_t collType) {
   switch (collType) {
-    case ncclFuncBroadcast: return "broadcast";
-    case ncclFuncReduce: return "reduce";
-    case ncclFuncAllGather: return "allgather";
-    case ncclFuncReduceScatter: return "reducescatter";
-    case ncclFuncAllReduce: return "allreduce";
-    default: return "unknown";
+  case ncclFuncBroadcast:
+    return "broadcast";
+  case ncclFuncReduce:
+    return "reduce";
+  case ncclFuncAllGather:
+    return "allgather";
+  case ncclFuncReduceScatter:
+    return "reducescatter";
+  case ncclFuncAllReduce:
+    return "allreduce";
+  default:
+    return "unknown";
   }
 }
 
@@ -131,14 +137,22 @@ static int parseAlgorithm(const char* str, bool* valid) {
 // Convert algorithm to string (for logging)
 static const char* algorithmToString(int algorithm) {
   switch (algorithm) {
-    case NCCL_ALGO_TREE: return "tree";
-    case NCCL_ALGO_RING: return "ring";
-    case NCCL_ALGO_COLLNET_DIRECT: return "collnet_direct";
-    case NCCL_ALGO_COLLNET_CHAIN: return "collnet_chain";
-    case NCCL_ALGO_NVLS: return "nvls";
-    case NCCL_ALGO_NVLS_TREE: return "nvls_tree";
-    case NCCL_ALGO_PAT: return "pat";
-    default: return "unknown";
+  case NCCL_ALGO_TREE:
+    return "tree";
+  case NCCL_ALGO_RING:
+    return "ring";
+  case NCCL_ALGO_COLLNET_DIRECT:
+    return "collnet_direct";
+  case NCCL_ALGO_COLLNET_CHAIN:
+    return "collnet_chain";
+  case NCCL_ALGO_NVLS:
+    return "nvls";
+  case NCCL_ALGO_NVLS_TREE:
+    return "nvls_tree";
+  case NCCL_ALGO_PAT:
+    return "pat";
+  default:
+    return "unknown";
   }
 }
 
@@ -155,10 +169,14 @@ static int parseProtocol(const char* str, bool* valid) {
 // Convert protocol to string (for logging)
 static const char* protocolToString(int protocol) {
   switch (protocol) {
-    case NCCL_PROTO_LL: return "ll";
-    case NCCL_PROTO_LL128: return "ll128";
-    case NCCL_PROTO_SIMPLE: return "simple";
-    default: return "unknown";
+  case NCCL_PROTO_LL:
+    return "ll";
+  case NCCL_PROTO_LL128:
+    return "ll128";
+  case NCCL_PROTO_SIMPLE:
+    return "simple";
+  default:
+    return "unknown";
   }
 }
 
@@ -196,8 +214,8 @@ static ncclResult_t loadConfig(CsvTunerContext* ctx, const char* filename) {
   FILE* file = fopen(filename, "r");
   if (!file) {
     if (ctx->logFunction) {
-      ctx->logFunction(NCCL_LOG_INFO, NCCL_TUNING, __FILE__, __LINE__,
-                       "TUNER/CsvTuner: Config file %s not found", filename);
+      ctx->logFunction(NCCL_LOG_INFO, NCCL_TUNING, __FILE__, __LINE__, "TUNER/CsvTuner: Config file %s not found",
+                       filename);
     }
     return ncclSuccess; // Not finding config file is not an error
   }
@@ -280,8 +298,7 @@ static ncclResult_t loadConfig(CsvTunerContext* ctx, const char* filename) {
       if (*token == '\0') {
         if (ctx->logFunction) {
           ctx->logFunction(NCCL_LOG_WARN, NCCL_TUNING, __FILE__, __LINE__,
-                           "TUNER/CsvTuner: Skipping malformed line %d with empty field: %s",
-                           lineNum, line);
+                           "TUNER/CsvTuner: Skipping malformed line %d with empty field: %s", lineNum, line);
         }
         lineValid = false;
         break;
@@ -309,12 +326,9 @@ static ncclResult_t loadConfig(CsvTunerContext* ctx, const char* filename) {
       if (!collTypeValid || !algoValid || !protoValid) {
         if (ctx->logFunction) {
           ctx->logFunction(NCCL_LOG_WARN, NCCL_TUNING, __FILE__, __LINE__,
-                           "TUNER/CsvTuner: Skipping line %d with unknown %s%s%s value: %s",
-                           lineNum,
-                           !collTypeValid ? "colltype " : "",
-                           !algoValid ? "algorithm " : "",
-                           !protoValid ? "protocol" : "",
-                           line);
+                           "TUNER/CsvTuner: Skipping line %d with unknown %s%s%s value: %s", lineNum,
+                           !collTypeValid ? "colltype " : "", !algoValid ? "algorithm " : "",
+                           !protoValid ? "protocol" : "", line);
         }
         continue;
       }
@@ -339,8 +353,8 @@ static ncclResult_t loadConfig(CsvTunerContext* ctx, const char* filename) {
         ctx->logFunction(NCCL_LOG_INFO, NCCL_TUNING, __FILE__, __LINE__,
                          "TUNER/CsvTuner: Loaded config: %s [%zu-%zu] %s/%s channels=%d nodes=%d ranks=%d",
                          collTypeToString(config->collType), config->minBytes, config->maxBytes,
-                         algorithmToString(config->algorithm), protocolToString(config->protocol),
-                         config->nChannels, config->nNodes, config->nRanks);
+                         algorithmToString(config->algorithm), protocolToString(config->protocol), config->nChannels,
+                         config->nNodes, config->nRanks);
       }
     }
   }
@@ -390,8 +404,8 @@ static bool findTunerFileInDir(const char* dirPath, char* outPath, size_t outPat
 // Get the directory containing librccl.so using dladdr1 (same pattern as MSCCL)
 static bool getLibraryDirectory(std::string& libDir) {
   Dl_info dl_info;
-  struct link_map *link_map_ptr = nullptr;
-  if (!dladdr1((void *)&rcclCsvTuner, &dl_info, (void **)&link_map_ptr, RTLD_DL_LINKMAP)) {
+  struct link_map* link_map_ptr = nullptr;
+  if (!dladdr1((void*)&rcclCsvTuner, &dl_info, (void**)&link_map_ptr, RTLD_DL_LINKMAP)) {
     return false;
   }
   std::string selfLibPath = link_map_ptr->l_name;
@@ -426,14 +440,12 @@ const char* rcclCsvTunerFindConfig(const char* gpuArch) {
   if (getLibraryDirectory(libDir)) {
     std::string tunerDir = libDir + "/tuner";
     if (gpuArch && gpuArch[0]) {
-      snprintf(csvTunerConfigPath, sizeof(csvTunerConfigPath),
-               "%s/rccl_tuner_%s.csv", tunerDir.c_str(), gpuArch);
+      snprintf(csvTunerConfigPath, sizeof(csvTunerConfigPath), "%s/rccl_tuner_%s.csv", tunerDir.c_str(), gpuArch);
       if (fileExists(csvTunerConfigPath)) {
         return csvTunerConfigPath;
       }
     }
-    snprintf(csvTunerConfigPath, sizeof(csvTunerConfigPath),
-             "%s/rccl_tuner.csv", tunerDir.c_str());
+    snprintf(csvTunerConfigPath, sizeof(csvTunerConfigPath), "%s/rccl_tuner.csv", tunerDir.c_str());
     if (fileExists(csvTunerConfigPath)) {
       return csvTunerConfigPath;
     }
@@ -447,14 +459,12 @@ const char* rcclCsvTunerFindConfig(const char* gpuArch) {
     // 3. Check relative share path: <libdir>/../share/rccl/tuner/ (for installed RCCL)
     std::string tunerShareDir = libDir + "/../share/rccl/tuner";
     if (gpuArch && gpuArch[0]) {
-      snprintf(csvTunerConfigPath, sizeof(csvTunerConfigPath),
-               "%s/rccl_tuner_%s.csv", tunerShareDir.c_str(), gpuArch);
+      snprintf(csvTunerConfigPath, sizeof(csvTunerConfigPath), "%s/rccl_tuner_%s.csv", tunerShareDir.c_str(), gpuArch);
       if (fileExists(csvTunerConfigPath)) {
         return csvTunerConfigPath;
       }
     }
-    snprintf(csvTunerConfigPath, sizeof(csvTunerConfigPath),
-             "%s/rccl_tuner.csv", tunerShareDir.c_str());
+    snprintf(csvTunerConfigPath, sizeof(csvTunerConfigPath), "%s/rccl_tuner.csv", tunerShareDir.c_str());
     if (fileExists(csvTunerConfigPath)) {
       return csvTunerConfigPath;
     }
@@ -474,16 +484,15 @@ const char* rcclCsvTunerFindConfig(const char* gpuArch) {
 
   // 4. Check GPU arch-specific config: ${ROCM_PATH}/share/rccl/tuner/rccl_tuner_<arch>.csv
   if (gpuArch && gpuArch[0]) {
-    snprintf(csvTunerConfigPath, sizeof(csvTunerConfigPath),
-             "%s/share/rccl/tuner/rccl_tuner_%s.csv", rocmPath, gpuArch);
+    snprintf(csvTunerConfigPath, sizeof(csvTunerConfigPath), "%s/share/rccl/tuner/rccl_tuner_%s.csv", rocmPath,
+             gpuArch);
     if (fileExists(csvTunerConfigPath)) {
       return csvTunerConfigPath;
     }
   }
 
   // 5. Check generic config: ${ROCM_PATH}/share/rccl/tuner/rccl_tuner.csv
-  snprintf(csvTunerConfigPath, sizeof(csvTunerConfigPath),
-           "%s/share/rccl/tuner/rccl_tuner.csv", rocmPath);
+  snprintf(csvTunerConfigPath, sizeof(csvTunerConfigPath), "%s/share/rccl/tuner/rccl_tuner.csv", rocmPath);
   if (fileExists(csvTunerConfigPath)) {
     return csvTunerConfigPath;
   }
@@ -511,8 +520,8 @@ void rcclCsvTunerResetConfigPath() {
 
 // Tuner init function
 static ncclResult_t csvTunerInit(void** context, uint64_t commId, size_t nRanks, size_t nNodes,
-                                  ncclDebugLogger_t logFunction, ncclNvlDomainInfo_t* nvlDomainInfo,
-                                  ncclTunerConstants_t* constants) {
+                                 ncclDebugLogger_t logFunction, ncclNvlDomainInfo_t* nvlDomainInfo,
+                                 ncclTunerConstants_t* constants) {
   CsvTunerContext* ctx = (CsvTunerContext*)malloc(sizeof(CsvTunerContext));
   if (!ctx) return ncclSystemError;
 
@@ -530,8 +539,7 @@ static ncclResult_t csvTunerInit(void** context, uint64_t commId, size_t nRanks,
 
   if (logFunction) {
     logFunction(NCCL_LOG_INFO, NCCL_TUNING, __FILE__, __LINE__,
-                "TUNER/CsvTuner: Initializing built-in CSV tuner for %zu nodes, %zu ranks",
-                nNodes, nRanks);
+                "TUNER/CsvTuner: Initializing built-in CSV tuner for %zu nodes, %zu ranks", nNodes, nRanks);
   }
 
   // Use the config path that was discovered earlier
@@ -565,9 +573,8 @@ static ncclResult_t csvTunerInit(void** context, uint64_t commId, size_t nRanks,
 }
 
 // Tuner getCollInfo function
-static ncclResult_t csvTunerGetCollInfo(void* context, ncclFunc_t collType, size_t nBytes,
-                                         int numPipeOps, float** collCostTable, int numAlgo, int numProto,
-                                         int regBuff, int* nChannels) {
+static ncclResult_t csvTunerGetCollInfo(void* context, ncclFunc_t collType, size_t nBytes, int numPipeOps,
+                                        float** collCostTable, int numAlgo, int numProto, int regBuff, int* nChannels) {
   CsvTunerContext* ctx = (CsvTunerContext*)context;
   if (!ctx) return ncclInternalError;
 
@@ -588,14 +595,11 @@ static ncclResult_t csvTunerGetCollInfo(void* context, ncclFunc_t collType, size
     CsvTuningConfig* config = &ctx->configs[i];
 
     // Check if this config matches the current collective, size range, topology, pipeline ops, and regBuff
-    if (config->collType == collType &&
-        nBytes >= config->minBytes &&
-        nBytes <= config->maxBytes &&
+    if (config->collType == collType && nBytes >= config->minBytes && nBytes <= config->maxBytes &&
         (config->nNodes == -1 || config->nNodes == (int)ctx->nNodes) &&
         (config->nRanks == -1 || config->nRanks == (int)ctx->nRanks) &&
         (config->numPipeOps == -1 || config->numPipeOps == numPipeOps) &&
         (config->regBuff == -1 || config->regBuff == regBuff)) {
-
       // Check bounds
       if (config->algorithm < numAlgo && config->protocol < numProto) {
         if (table[config->algorithm][config->protocol] != NCCL_ALGO_PROTO_IGNORE) {
@@ -607,17 +611,16 @@ static ncclResult_t csvTunerGetCollInfo(void* context, ncclFunc_t collType, size
           } else if (config->nChannels != -1) {
             if (ctx->logFunction) {
               ctx->logFunction(NCCL_LOG_WARN, NCCL_TUNING, __FILE__, __LINE__,
-                               "TUNER/CsvTuner: Ignoring invalid channel count %d for %s, bytes=%zu",
-                               config->nChannels, collTypeToString(config->collType), nBytes);
+                               "TUNER/CsvTuner: Ignoring invalid channel count %d for %s, bytes=%zu", config->nChannels,
+                               collTypeToString(config->collType), nBytes);
             }
           }
 
           if (ctx->logFunction) {
             ctx->logFunction(NCCL_LOG_INFO, NCCL_TUNING, __FILE__, __LINE__,
                              "TUNER/CsvTuner: Applied config for %s, bytes=%zu: algo=%s, proto=%s, channels=%d",
-                             collTypeToString(config->collType), nBytes,
-                             algorithmToString(config->algorithm), protocolToString(config->protocol),
-                             config->nChannels);
+                             collTypeToString(config->collType), nBytes, algorithmToString(config->algorithm),
+                             protocolToString(config->protocol), config->nChannels);
           }
           return ncclSuccess;
         }
@@ -628,8 +631,7 @@ static ncclResult_t csvTunerGetCollInfo(void* context, ncclFunc_t collType, size
   // No matching config found
   if (ctx->logFunction) {
     ctx->logFunction(NCCL_LOG_TRACE, NCCL_TUNING, __FILE__, __LINE__,
-                     "TUNER/CsvTuner: No matching config for %s, bytes=%zu",
-                     collTypeToString(collType), nBytes);
+                     "TUNER/CsvTuner: No matching config for %s, bytes=%zu", collTypeToString(collType), nBytes);
   }
 
   return ncclSuccess;
@@ -647,10 +649,6 @@ static ncclResult_t csvTunerFinalize(void* context) {
   return ncclSuccess;
 }
 
-
 ncclTuner_t rcclCsvTuner = {
-  .name = "RcclCsvTuner",
-  .init = csvTunerInit,
-  .getCollInfo = csvTunerGetCollInfo,
-  .finalize = csvTunerFinalize
+  .name = "RcclCsvTuner", .init = csvTunerInit, .getCollInfo = csvTunerGetCollInfo, .finalize = csvTunerFinalize
 };

--- a/projects/rccl/src/plugin/tuner/tuner_v2.cc
+++ b/projects/rccl/src/plugin/tuner/tuner_v2.cc
@@ -25,7 +25,10 @@ static int hasNvlsSupport(float** collCostTable) {
   //
   // nvlsSupport = 1 if either NVLS or NVLS_TREE entries in the cost table are not -1
   float (*table)[NCCL_NUM_PROTOCOLS] = (float (*)[NCCL_NUM_PROTOCOLS])collCostTable;
-  return (table[NCCL_ALGO_NVLS][NCCL_PROTO_SIMPLE] != NCCL_ALGO_PROTO_IGNORE || table[NCCL_ALGO_NVLS_TREE][NCCL_PROTO_SIMPLE] != NCCL_ALGO_PROTO_IGNORE) ? 1 : 0;
+  return (table[NCCL_ALGO_NVLS][NCCL_PROTO_SIMPLE] != NCCL_ALGO_PROTO_IGNORE ||
+          table[NCCL_ALGO_NVLS_TREE][NCCL_PROTO_SIMPLE] != NCCL_ALGO_PROTO_IGNORE) ?
+           1 :
+           0;
 }
 
 static int hasCollNetSupport(float** collCostTable) {
@@ -33,12 +36,16 @@ static int hasCollNetSupport(float** collCostTable) {
   return (table[NCCL_ALGO_COLLNET_CHAIN][NCCL_PROTO_SIMPLE] == NCCL_ALGO_PROTO_IGNORE) ? 0 : 1;
 }
 
-static ncclResult_t ncclTuner_getCollInfo(void* context, ncclFunc_t collType, size_t nBytes, int numPipeOps, float** collCostTable, int numAlgo __attribute__((unused)), int numProto __attribute__((unused)), int regBuff __attribute__((unused)), int* nChannels) {
+static ncclResult_t ncclTuner_getCollInfo(void* context, ncclFunc_t collType, size_t nBytes, int numPipeOps,
+                                          float** collCostTable, int numAlgo __attribute__((unused)),
+                                          int numProto __attribute__((unused)), int regBuff __attribute__((unused)),
+                                          int* nChannels) {
   int algorithm = NCCL_ALGO_UNDEF;
   int protocol = NCCL_PROTO_UNDEF;
   int nvlsSupport = hasNvlsSupport(collCostTable);
   int collNetSupport = hasCollNetSupport(collCostTable);
-  NCCLCHECK(ncclTuner_v2->getCollInfo(context, collType, nBytes, collNetSupport, nvlsSupport, numPipeOps, &algorithm, &protocol, nChannels));
+  NCCLCHECK(ncclTuner_v2->getCollInfo(context, collType, nBytes, collNetSupport, nvlsSupport, numPipeOps, &algorithm,
+                                      &protocol, nChannels));
   // set time to 0 below to make sure this algorithm/protocol is selected later on
   if (algorithm >= 0 && algorithm < NCCL_NUM_ALGORITHMS && protocol >= 0 && protocol < NCCL_NUM_PROTOCOLS) {
     float (*table)[NCCL_NUM_PROTOCOLS] = (float (*)[NCCL_NUM_PROTOCOLS])collCostTable;
@@ -65,7 +72,7 @@ ncclTuner_t* getNcclTuner_v2(void* lib) {
   if (ncclTuner_v2) {
     ncclTuner.name = ncclTuner_v2->name;
     ncclTuner.init = ncclTuner_init;
-    INFO(NCCL_INIT|NCCL_TUNING, "TUNER/Plugin: Using %s (v2)", ncclTuner_v2->name);
+    INFO(NCCL_INIT | NCCL_TUNING, "TUNER/Plugin: Using %s (v2)", ncclTuner_v2->name);
     return &ncclTuner;
   }
   return NULL;

--- a/projects/rccl/src/plugin/tuner/tuner_v3.cc
+++ b/projects/rccl/src/plugin/tuner/tuner_v3.cc
@@ -14,8 +14,11 @@
 static ncclTuner_v3_t* ncclTuner_v3;
 static ncclTuner_t ncclTuner;
 
-static ncclResult_t ncclTuner_getCollInfo(void* context, ncclFunc_t collType, size_t nBytes, int numPipeOps, float** collCostTable, int numAlgo, int numProto, int regBuff __attribute__((unused)), int* nChannels) {
-  NCCLCHECK(ncclTuner_v3->getCollInfo(context, collType, nBytes, numPipeOps, collCostTable, numAlgo, numProto,  nChannels));
+static ncclResult_t ncclTuner_getCollInfo(void* context, ncclFunc_t collType, size_t nBytes, int numPipeOps,
+                                          float** collCostTable, int numAlgo, int numProto,
+                                          int regBuff __attribute__((unused)), int* nChannels) {
+  NCCLCHECK(ncclTuner_v3->getCollInfo(context, collType, nBytes, numPipeOps, collCostTable, numAlgo, numProto,
+                                      nChannels));
   return ncclSuccess;
 }
 
@@ -23,8 +26,9 @@ static ncclResult_t ncclTuner_finalize(void* ctx) {
   return ncclTuner_v3->destroy(ctx);
 }
 
-static ncclResult_t ncclTuner_init(void** context, uint64_t commId, size_t nRanks, size_t nNodes, ncclDebugLogger_t logfn,
-                                   ncclNvlDomainInfo_v5_t* nvlDomainInfo, ncclTunerConstants_t* /*constants*/) {
+static ncclResult_t ncclTuner_init(void** context, uint64_t commId, size_t nRanks, size_t nNodes,
+                                   ncclDebugLogger_t logfn, ncclNvlDomainInfo_v5_t* nvlDomainInfo,
+                                   ncclTunerConstants_t* /*constants*/) {
   NCCLCHECK(ncclTuner_v3->init(nRanks, nNodes, logfn, context));
   ncclTuner.getCollInfo = ncclTuner_getCollInfo;
   ncclTuner.getChunkSize = NULL;
@@ -37,7 +41,7 @@ ncclTuner_t* getNcclTuner_v3(void* lib) {
   if (ncclTuner_v3) {
     ncclTuner.name = ncclTuner_v3->name;
     ncclTuner.init = ncclTuner_init;
-    INFO(NCCL_INIT|NCCL_TUNING, "TUNER/Plugin: Using %s (v3)", ncclTuner_v3->name);
+    INFO(NCCL_INIT | NCCL_TUNING, "TUNER/Plugin: Using %s (v3)", ncclTuner_v3->name);
     return &ncclTuner;
   }
   return NULL;

--- a/projects/rccl/src/plugin/tuner/tuner_v4.cc
+++ b/projects/rccl/src/plugin/tuner/tuner_v4.cc
@@ -18,8 +18,9 @@ static ncclResult_t ncclTuner_finalize(void* ctx) {
   return ncclTuner_v4->destroy(ctx);
 }
 
-static ncclResult_t ncclTuner_init(void** context, uint64_t commId, size_t nRanks, size_t nNodes, ncclDebugLogger_t logfn,
-                                   ncclNvlDomainInfo_v5_t* nvlDomainInfo, ncclTunerConstants_t* /*constants*/) {
+static ncclResult_t ncclTuner_init(void** context, uint64_t commId, size_t nRanks, size_t nNodes,
+                                   ncclDebugLogger_t logfn, ncclNvlDomainInfo_v5_t* nvlDomainInfo,
+                                   ncclTunerConstants_t* /*constants*/) {
   NCCLCHECK(ncclTuner_v4->init(nRanks, nNodes, logfn, context));
   ncclTuner.getCollInfo = ncclTuner_v4->getCollInfo;
   ncclTuner.getChunkSize = NULL;
@@ -33,7 +34,7 @@ ncclTuner_t* getNcclTuner_v4(void* lib) {
     ncclTuner.name = ncclTuner_v4->name;
     ncclTuner.init = ncclTuner_init;
 
-    INFO(NCCL_INIT|NCCL_TUNING, "TUNER/Plugin: Using %s (v4)", ncclTuner_v4->name);
+    INFO(NCCL_INIT | NCCL_TUNING, "TUNER/Plugin: Using %s (v4)", ncclTuner_v4->name);
     return &ncclTuner;
   }
   return NULL;

--- a/projects/rccl/src/plugin/tuner/tuner_v5.cc
+++ b/projects/rccl/src/plugin/tuner/tuner_v5.cc
@@ -14,8 +14,11 @@
 static ncclTuner_v5_t* ncclTuner_v5;
 static ncclTuner_t ncclTuner;
 
-static ncclResult_t ncclTuner_getCollInfo(void* context, ncclFunc_t collType, size_t nBytes, int numPipeOps, float** collCostTable, int numAlgo, int numProto, int regBuff, int* nChannels) {
-  NCCLCHECK(ncclTuner_v5->getCollInfo(context, collType, nBytes, numPipeOps, collCostTable, numAlgo, numProto, regBuff, nChannels));
+static ncclResult_t ncclTuner_getCollInfo(void* context, ncclFunc_t collType, size_t nBytes, int numPipeOps,
+                                          float** collCostTable, int numAlgo, int numProto, int regBuff,
+                                          int* nChannels) {
+  NCCLCHECK(ncclTuner_v5->getCollInfo(context, collType, nBytes, numPipeOps, collCostTable, numAlgo, numProto, regBuff,
+                                      nChannels));
   return ncclSuccess;
 }
 
@@ -23,8 +26,9 @@ static ncclResult_t ncclTuner_finalize(void* ctx) {
   return ncclTuner_v5->finalize(ctx);
 }
 
-static ncclResult_t ncclTuner_init(void** context, uint64_t commId, size_t nRanks, size_t nNodes, ncclDebugLogger_t logfn,
-                                   ncclNvlDomainInfo_v5_t* nvlDomainInfo, ncclTunerConstants_t* constants) {
+static ncclResult_t ncclTuner_init(void** context, uint64_t commId, size_t nRanks, size_t nNodes,
+                                   ncclDebugLogger_t logfn, ncclNvlDomainInfo_v5_t* nvlDomainInfo,
+                                   ncclTunerConstants_t* constants) {
   NCCLCHECK(ncclTuner_v5->init(context, commId, nRanks, nNodes, logfn, nvlDomainInfo, constants));
   ncclTuner.getCollInfo = ncclTuner_getCollInfo;
   ncclTuner.finalize = ncclTuner_finalize;
@@ -37,7 +41,7 @@ ncclTuner_t* getNcclTuner_v5(void* lib) {
   if (ncclTuner_v5) {
     ncclTuner.name = ncclTuner_v5->name;
     ncclTuner.init = ncclTuner_init;
-    INFO(NCCL_INIT|NCCL_TUNING, "TUNER/Plugin: Using %s (v5)", ncclTuner_v5->name);
+    INFO(NCCL_INIT | NCCL_TUNING, "TUNER/Plugin: Using %s (v5)", ncclTuner_v5->name);
     return &ncclTuner;
   }
   return NULL;

--- a/projects/rccl/src/plugin/tuner/tuner_v6.cc
+++ b/projects/rccl/src/plugin/tuner/tuner_v6.cc
@@ -14,7 +14,7 @@ static ncclTuner_v6_t* ncclTuner_v6;
 ncclTuner_t* getNcclTuner_v6(void* lib) {
   ncclTuner_v6 = (ncclTuner_v6_t*)dlsym(lib, "ncclTunerPlugin_v6");
   if (ncclTuner_v6) {
-    INFO(NCCL_INIT|NCCL_TUNING, "TUNER/Plugin: Using %s (v6)", ncclTuner_v6->name);
+    INFO(NCCL_INIT | NCCL_TUNING, "TUNER/Plugin: Using %s (v6)", ncclTuner_v6->name);
     return ncclTuner_v6;
   }
   return NULL;

--- a/projects/rccl/src/proxy.cc
+++ b/projects/rccl/src/proxy.cc
@@ -27,7 +27,7 @@
 #include <cinttypes>
 #include <thread>
 
-#define NCCL_MAX_PROXY_CONNECTIONS (NCCL_MAX_LOCAL_RANKS+1)
+#define NCCL_MAX_PROXY_CONNECTIONS (NCCL_MAX_LOCAL_RANKS + 1)
 
 void* ncclProxyServiceUDS(void* _args);
 
@@ -36,18 +36,18 @@ static bool NeedProxy(int type, int pattern, int root, struct ncclRing* ring, in
 
   /* In chains, one rank does not need a proxy. Let's figure out which one it is */
   /* Which index in the reorganized rings should we compare root against */
-  const int myrank = 0, nextrank = 1, prevrank = nranks-1;
+  const int myrank = 0, nextrank = 1, prevrank = nranks - 1;
   int index = pattern == ncclPatternPipelineFrom ?
       /*                            no recv /  no send    if root = */
-      /* bcast  */ (type == proxyRecv ?   myrank : nextrank ):
-      /* reduce */ (type == proxyRecv ? prevrank :   myrank );
+                /* bcast  */ (type == proxyRecv ? myrank : nextrank) :
+                /* reduce */ (type == proxyRecv ? prevrank : myrank);
   int rank = ring->userRanks[index];
   return (root != rank);
 }
 
 #define PROXYARGS_ALLOCATE_SIZE NCCL_MAX_OPS
 struct ncclProxyPool {
-  struct ncclProxyPool *next;
+  struct ncclProxyPool* next;
   struct ncclProxyArgs elems[PROXYARGS_ALLOCATE_SIZE];
 };
 
@@ -63,7 +63,8 @@ static void expectedProxyResponseFree(struct ncclProxyState* state) {
   }
 }
 
-static ncclResult_t expectedProxyResponseStore(struct ncclProxyState* state, void* opId, void* respBuff, int respSize, ncclResult_t res) {
+static ncclResult_t expectedProxyResponseStore(struct ncclProxyState* state, void* opId, void* respBuff, int respSize,
+                                               ncclResult_t res) {
   struct ncclExpectedProxyResponse* elem = state->expectedResponses;
   while (elem) {
     if (elem->opId == opId) {
@@ -82,7 +83,7 @@ static ncclResult_t expectedProxyResponseStore(struct ncclProxyState* state, voi
         free(respBuff);
       }
       elem->done = true;
-      elem->res  = res;
+      elem->res = res;
       return ncclSuccess;
     }
     elem = elem->next;
@@ -104,8 +105,8 @@ static ncclResult_t expectedProxyResponseEnqueue(struct ncclProxyState* state, v
     return ncclSystemError;
   }
   ex->respSize = respSize;
-  ex->res      = ncclInternalError;
-  ex->done     = false;
+  ex->res = ncclInternalError;
+  ex->done = false;
 
   // Enqueue
   struct ncclExpectedProxyResponse* list = state->expectedResponses;
@@ -216,8 +217,8 @@ static ncclResult_t allocateArgs(struct ncclProxyProgressState* state, struct nc
 
     struct ncclProxyArgs* newElems = newPool->elems;
     // Chain newly allocated elements
-    for (int i=0; i<PROXYARGS_ALLOCATE_SIZE; i++) {
-      if (i+1 < PROXYARGS_ALLOCATE_SIZE) newElems[i].next = newElems+i+1;
+    for (int i = 0; i < PROXYARGS_ALLOCATE_SIZE; i++) {
+      if (i + 1 < PROXYARGS_ALLOCATE_SIZE) newElems[i].next = newElems + i + 1;
     }
     // Add them all to the pool list
     state->pool = newElems;
@@ -232,21 +233,21 @@ static ncclResult_t allocateArgs(struct ncclProxyProgressState* state, struct nc
   return ncclSuccess;
 }
 
-//#define DEBUG_PROXY 1
+// #define DEBUG_PROXY 1
 #ifdef DEBUG_PROXY
 #define DEBUG_PROXY_PRINT printf
 #else
 #define DEBUG_PROXY_PRINT(...)
 #endif
 
-#define OP_INDEX(op) ((op) ? (op)-state->pools->elems : -1)
+#define OP_INDEX(op) ((op) ? (op) - state->pools->elems : -1)
 #define OP_SEEN 0x100000
 
 ncclResult_t getOpIndex(struct ncclProxyArgs* op, struct ncclProxyProgressState* state, int* poolIndex, int* opIndex) {
   struct ncclProxyPool* pool = state->pools;
   int p = 0;
   while (pool) {
-    uint64_t o = op-pool->elems;
+    uint64_t o = op - pool->elems;
     if (o < PROXYARGS_ALLOCATE_SIZE) {
       *opIndex = o;
       *poolIndex = p;
@@ -263,10 +264,10 @@ ncclResult_t printProxyOp(struct ncclProxyArgs* op, int poolIndex, int opIndex) 
   int peer = op->send ? op->nextRank : op->prevRank;
   bool isColl = (op->pattern != ncclPatternRecv) && (op->pattern != ncclPatternSend);
 
-  fprintf(stderr, "%p [%d-%d|%ld| %s",op, poolIndex, opIndex, op->opCount, isColl ? "Coll->" : "");
+  fprintf(stderr, "%p [%d-%d|%ld| %s", op, poolIndex, opIndex, op->opCount, isColl ? "Coll->" : "");
   fprintf(stderr, "%s", op->send ? "Send" : "Recv");
-  for (int s=0; s<op->nsubs; s++) {
-    struct ncclProxySubArgs* sub = op->subs+s;
+  for (int s = 0; s < op->nsubs; s++) {
+    struct ncclProxySubArgs* sub = op->subs + s;
     if (op->state == ncclProxyOpProgress) {
       char status = ' ';
       if (op->pattern == ncclPatternRecv) { // ncclRecv
@@ -276,20 +277,21 @@ ncclResult_t printProxyOp(struct ncclProxyArgs* op, int poolIndex, int opIndex) 
         else if (sub->transmitted < sub->received) status = 'F'; // Flushing
         else if (sub->done < sub->transmitted) status = 'G'; // Waiting on GPU
         else status = 'D'; // Done
-      } else if (op->pattern == ncclPatternSend) { //ncclSend
+      } else if (op->pattern == ncclPatternSend) { // ncclSend
         if (sub->posted < sub->nsteps && sub->posted < sub->done + NCCL_STEPS) status = 'I'; // Init
         else if (sub->transmitted < sub->posted) status = 'G'; // Waiting on GPU
         else if (sub->done < sub->transmitted) status = 'S'; // Sending
         else status = 'D'; // Done
       } else {
-	// Send or recv within a collective. Dump raw state data.
-	fprintf(stderr, " nb:%zd ns:%d p:%lu t:%lu r:%lu, d:%lu ",sub->nbytes,sub->nsteps, sub->posted, sub->transmitted, sub->received, sub->done);
+        // Send or recv within a collective. Dump raw state data.
+        fprintf(stderr, " nb:%zd ns:%d p:%lu t:%lu r:%lu, d:%lu ", sub->nbytes, sub->nsteps, sub->posted,
+                sub->transmitted, sub->received, sub->done);
       }
       fprintf(stderr, "%c peer:%d chan:%d ", status, peer, sub->channelId);
     } else {
-        if (op->state == ncclProxyOpNone) fprintf(stderr, "\t[]");
-        else if (op->state == ncclProxyOpReady) fprintf(stderr, "\t[R]");
-        else fprintf(stderr, "\t[UNDEFINED]");
+      if (op->state == ncclProxyOpNone) fprintf(stderr, "\t[]");
+      else if (op->state == ncclProxyOpReady) fprintf(stderr, "\t[R]");
+      else fprintf(stderr, "\t[UNDEFINED]");
       fprintf(stderr, " peer:%d channel:%d", peer, sub->channelId);
     }
   }
@@ -330,7 +332,7 @@ ncclResult_t dumpProxyState(struct ncclProxyProgressState* state) {
   }
   fprintf(stderr, "[%d]\n\n", list_len);
 
-# if 0
+#if 0
   printf("FREE OPS\n");
   op = state->pool;
   while (op) {
@@ -360,7 +362,7 @@ ncclResult_t dumpProxyState(struct ncclProxyProgressState* state) {
   poolIndex = 0;
   while (pool) {
     struct ncclProxyArgs* elem = pool->elems;
-    for (int e=0; e<PROXYARGS_ALLOCATE_SIZE; e++, elem++) {
+    for (int e = 0; e < PROXYARGS_ALLOCATE_SIZE; e++, elem++) {
       if ((elem->state & OP_SEEN) == 0) {
         fprintf(stderr, "Elem %d-%d is not in any list:\n", poolIndex, e);
         NCCLCHECK(printProxyOp(elem, poolIndex, e));
@@ -375,12 +377,12 @@ ncclResult_t dumpProxyState(struct ncclProxyProgressState* state) {
 }
 
 static ncclResult_t ncclProxyOpToArgs(struct ncclProxyOp* op, struct ncclProxyArgs* args, int subIndex) {
-  struct ncclProxySubArgs* sub = args->subs+subIndex;
+  struct ncclProxySubArgs* sub = args->subs + subIndex;
   if (subIndex >= NCCL_PROXY_MAX_SUBS) {
     WARN("Proxy append out of bounds");
     return ncclInternalError;
   }
-  //memset(sub, 0, sizeof(struct ncclProxySubArgs));
+  // memset(sub, 0, sizeof(struct ncclProxySubArgs));
   sub->connection = op->connection;
   sub->channelId = op->channelId;
   sub->nsteps = op->nsteps;
@@ -403,7 +405,7 @@ static ncclResult_t ncclProxyOpToArgs(struct ncclProxyOp* op, struct ncclProxyAr
   sub->profilerContext = op->profilerContext;
   sub->ringAlgo = op->ringAlgo;
   sub->workCounter = op->workCounter;
-  args->nsubs = subIndex+1;
+  args->nsubs = subIndex + 1;
   if (ncclProfilerProxyDiagEnabled()) {
     sub->commHash = op->commHash;
     sub->profExtras.funcIdx = op->coll;
@@ -418,11 +420,8 @@ static ncclResult_t ncclProxyOpToArgs(struct ncclProxyOp* op, struct ncclProxyAr
   if (subIndex) {
     args->nChannels = std::min(args->nChannels, op->nChannels);
     args->nPeers = std::min(args->nPeers, op->nPeers);
-    if ((args->sliceSteps != op->sliceSteps) ||
-        (args->chunkSteps != op->chunkSteps) ||
-        (args->protocol != op->protocol) ||
-        (args->dtype != op->dtype) ||
-        (args->redOp != op->redOp) ||
+    if ((args->sliceSteps != op->sliceSteps) || (args->chunkSteps != op->chunkSteps) ||
+        (args->protocol != op->protocol) || (args->dtype != op->dtype) || (args->redOp != op->redOp) ||
         (args->coll != op->coll)) {
       WARN("Proxy append mismatch");
       return ncclInternalError;
@@ -433,7 +432,7 @@ static ncclResult_t ncclProxyOpToArgs(struct ncclProxyOp* op, struct ncclProxyAr
     }
     goto exit;
   }
-  //memset(&args->progress, 0, sizeof(struct ncclProxyArgs)-offsetof(struct ncclProxyArgs, progress));
+  // memset(&args->progress, 0, sizeof(struct ncclProxyArgs)-offsetof(struct ncclProxyArgs, progress));
   args->done = 0;
   args->opCount = op->opCount;
   args->sliceSteps = op->sliceSteps;
@@ -469,13 +468,15 @@ static ncclResult_t ProxyAppend(struct ncclProxyProgressState* state, struct ncc
   if (args) {
     if (shared && args->opCount == op->opCount) {
       NCCLCHECK(ncclProxyOpToArgs(op, args, args->nsubs));
-      DEBUG_PROXY_PRINT("Insert (%d/%5ld/%5ld) as group with %5ld\n", shared, args->opCount, op->opCount, OP_INDEX(args));
+      DEBUG_PROXY_PRINT("Insert (%d/%5ld/%5ld) as group with %5ld\n", shared, args->opCount, op->opCount,
+                        OP_INDEX(args));
     } else {
       struct ncclProxyArgs* prevArgs = args;
       NCCLCHECK(allocateArgs(state, &args));
       NCCLCHECK(ncclProxyOpToArgs(op, args, 0));
       prevArgs->nextPeer = args;
-      DEBUG_PROXY_PRINT("Insert  %5ld (%d/%5ld/%5ld) as nextPeer of %5ld\n", OP_INDEX(args), shared, prevArgs->opCount, args->opCount, OP_INDEX(prevArgs));
+      DEBUG_PROXY_PRINT("Insert  %5ld (%d/%5ld/%5ld) as nextPeer of %5ld\n", OP_INDEX(args), shared, prevArgs->opCount,
+                        args->opCount, OP_INDEX(prevArgs));
       *(args->proxyAppendPtr) = args;
     }
   } else {
@@ -510,7 +511,8 @@ ncclResult_t ncclProxyPost(struct ncclProxyOpsPool* pool, int nextOps, int nextO
   return ncclSuccess;
 }
 
-static ncclResult_t ncclLocalOpAppend(struct ncclComm* comm, struct ncclProxyConnector* proxyConn, struct ncclProxyOp* proxyOp) {
+static ncclResult_t ncclLocalOpAppend(struct ncclComm* comm, struct ncclProxyConnector* proxyConn,
+                                      struct ncclProxyOp* proxyOp) {
   int tpLocalRank = comm->topParentLocalRanks[comm->localRank];
   struct ncclProxyOps* proxyOps = comm->proxyState->proxyOps;
   if (proxyOps == NULL) return ncclInternalError;
@@ -521,7 +523,7 @@ static ncclResult_t ncclLocalOpAppend(struct ncclComm* comm, struct ncclProxyCon
   int opIndex = proxyOps->freeOp;
   struct ncclProxyOp* op;
   if (opIndex != -1) {
-    op = pool->ops+opIndex;
+    op = pool->ops + opIndex;
     proxyOps->freeOp = op->next;
   } else {
     // Read the freeOps value and wait for a value different than -1. Once not -1, read the value with acquire and reset -1
@@ -531,10 +533,10 @@ static ncclResult_t ncclLocalOpAppend(struct ncclComm* comm, struct ncclProxyCon
       if (freeOp == -1) std::this_thread::yield();
     }
     opIndex = freeOp;
-    op = pool->ops+opIndex;
+    op = pool->ops + opIndex;
     proxyOps->freeOp = op->next;
   }
-  if (op->next != -1) COMPILER_PREFETCH(pool->ops+op->next); // Prefetch next free op
+  if (op->next != -1) COMPILER_PREFETCH(pool->ops + op->next); // Prefetch next free op
   memcpy(op, proxyOp, sizeof(struct ncclProxyOp));
   if (proxyOp->ringAlgo) proxyOp->ringAlgo->incRefCount();
   op->next = -1;
@@ -553,7 +555,7 @@ static ncclResult_t ncclLocalOpAppend(struct ncclComm* comm, struct ncclProxyCon
     int lastOp = -1;
     int toSend = 0;
     int ops = 0;
-    for (int op= proxyOps->nextOps; op != proxyOps->nextOpsEnd; op=pool->ops[op].next) {
+    for (int op = proxyOps->nextOps; op != proxyOps->nextOpsEnd; op = pool->ops[op].next) {
       ops++;
       if (pool->ops[op].opCount != lastOpCount) {
         lastOp = op;
@@ -561,7 +563,8 @@ static ncclResult_t ncclLocalOpAppend(struct ncclComm* comm, struct ncclProxyCon
       }
     }
     if (lastOp == -1) {
-      WARN("Unable to post incomplete proxy op chain %d..%d (opCount %ld)", proxyOps->nextOps, proxyOps->nextOpsEnd, lastOpCount);
+      WARN("Unable to post incomplete proxy op chain %d..%d (opCount %ld)", proxyOps->nextOps, proxyOps->nextOpsEnd,
+           lastOpCount);
       return ncclInternalError;
     }
     // Cut chain at lastOp
@@ -576,17 +579,19 @@ static ncclResult_t ncclLocalOpAppend(struct ncclComm* comm, struct ncclProxyCon
 }
 
 static void incWorkCounter(struct ncclComm* comm, struct ncclProxyOp* op) {
-  op->workCounter = (op->incWorkCounter) ? ++comm->profiler.workCounter[op->channelId] : comm->profiler.workCounter[op->channelId];
+  op->workCounter =
+    (op->incWorkCounter) ? ++comm->profiler.workCounter[op->channelId] : comm->profiler.workCounter[op->channelId];
 }
 
 static ncclResult_t SaveProxyProfiler(struct ncclComm* comm, struct ncclProxyOp* op, bool* justInquire) {
-  struct ncclProxyConnector* proxyConn = (op->coll == ncclFuncRecv) ? &comm->profiler.recvProxyConn[op->channelId] : &comm->profiler.sendProxyConn[op->channelId];
+  struct ncclProxyConnector* proxyConn = (op->coll == ncclFuncRecv) ? &comm->profiler.recvProxyConn[op->channelId] :
+                                                                      &comm->profiler.sendProxyConn[op->channelId];
   if (justInquire) {
     *justInquire = true;
     if (!comm->planner.persistent) incWorkCounter(comm, op);
   } else {
-    op->sendbuff = (uint8_t *)comm->profiler.workStarted;
-    op->recvbuff = (uint8_t *)comm->profiler.workCompleted;
+    op->sendbuff = (uint8_t*)comm->profiler.workStarted;
+    op->recvbuff = (uint8_t*)comm->profiler.workCompleted;
     // Ensure that in graph capturing the proxy workCounter is incremented to keep up with kernel workCounter
     if (comm->planner.persistent) incWorkCounter(comm, op);
     NCCLCHECK(ncclLocalOpAppend(comm, proxyConn, op));
@@ -594,14 +599,15 @@ static ncclResult_t SaveProxyProfiler(struct ncclComm* comm, struct ncclProxyOp*
   return ncclSuccess;
 }
 
-static ncclResult_t SaveProxy(struct ncclComm* comm, struct ncclChannel* channel, int type, int peer, struct ncclProxyOp* op, int connIndex, bool* justInquire) {
+static ncclResult_t SaveProxy(struct ncclComm* comm, struct ncclChannel* channel, int type, int peer,
+                              struct ncclProxyOp* op, int connIndex, bool* justInquire) {
   if (peer < 0) return ncclSuccess;
 
   struct ncclChannelPeer* peerComm = channel->peers[peer];
-  struct ncclConnector* connector = type == proxyRecv ? peerComm->recv+connIndex : peerComm->send+connIndex;
+  struct ncclConnector* connector = type == proxyRecv ? peerComm->recv + connIndex : peerComm->send + connIndex;
   if (connector->transportComm == NULL) {
-    WARN("Rank %d has no transport for %s peer %d on channel %d/%d", comm->rank,
-        type == proxyRecv ? "recv" : "send", peer, channel->id, connIndex);
+    WARN("Rank %d has no transport for %s peer %d on channel %d/%d", comm->rank, type == proxyRecv ? "recv" : "send",
+         peer, channel->id, connIndex);
     return ncclInternalError;
   }
   if (connector->proxyConn.proxyProgress == NULL) return ncclSuccess;
@@ -625,7 +631,8 @@ ncclResult_t ncclProxySaveOp(struct ncclComm* comm, struct ncclProxyOp* op, bool
   case ncclPatternRing:
   case ncclPatternRingTwice:
   case ncclPatternPipelineFrom:
-  case ncclPatternPipelineTo: {
+  case ncclPatternPipelineTo:
+    {
       struct ncclRing* ring = &channel->ring;
       if (NeedProxy(proxyRecv, op->pattern, op->root, ring, comm->nRanks)) {
         op->prevRank = ring->prev;
@@ -637,49 +644,61 @@ ncclResult_t ncclProxySaveOp(struct ncclComm* comm, struct ncclProxyOp* op, bool
         op->nextRank = ring->next;
         NCCLCHECK(SaveProxy(comm, channel, proxySend, ring->next, op, op->connIndex, justInquire));
       }
-    } break;
+    }
+    break;
   case ncclPatternTreeUp:
   case ncclPatternTreeDown:
-  case ncclPatternTreeUpDown: {
+  case ncclPatternTreeUpDown:
+    {
       if (op->pattern != ncclPatternTreeDown) { // Tree up
         struct ncclTree* tree = &channel->tree;
-        for (int i=0; i<NCCL_MAX_TREE_ARITY; i++) {
+        for (int i = 0; i < NCCL_MAX_TREE_ARITY; i++) {
           NCCLCHECK(SaveProxy(comm, channel, proxyRecv, tree->down[i], op, 0, justInquire));
         }
         NCCLCHECK(SaveProxy(comm, channel, proxySend, tree->up, op, 0, justInquire));
       }
       if (op->pattern != ncclPatternTreeUp) { // Tree down
         struct ncclTree* tree = &channel->tree;
-        for (int i=0; i< NCCL_MAX_TREE_ARITY; i++) {
+        for (int i = 0; i < NCCL_MAX_TREE_ARITY; i++) {
           NCCLCHECK(SaveProxy(comm, channel, proxySend, tree->down[i], op, 0, justInquire));
         }
         NCCLCHECK(SaveProxy(comm, channel, proxyRecv, tree->up, op, 0, justInquire));
       }
-    } break;
-  case ncclPatternCollnetChain: {
+    }
+    break;
+  case ncclPatternCollnetChain:
+    {
       NCCLCHECK(SaveProxy(comm, channel, proxySend, channel->collnetChain.up, op, 1, justInquire));
       NCCLCHECK(SaveProxy(comm, channel, proxyRecv, channel->collnetChain.up, op, 0, justInquire));
-    } break;
-  case ncclPatternCollnetDirect: {
+    }
+    break;
+  case ncclPatternCollnetDirect:
+    {
       NCCLCHECK(SaveProxy(comm, channel, proxySend, channel->collnetDirect.out, op, 1, justInquire));
       NCCLCHECK(SaveProxy(comm, channel, proxyRecv, channel->collnetDirect.out, op, 0, justInquire));
-    } break;
-  case ncclPatternNvls: {
+    }
+    break;
+  case ncclPatternNvls:
+    {
       NCCLCHECK(SaveProxy(comm, channel, proxySend, channel->nvls.out, op, 1, justInquire));
       NCCLCHECK(SaveProxy(comm, channel, proxyRecv, channel->nvls.out, op, 0, justInquire));
-    } break;
-  case ncclPatternNvlsTree: {
+    }
+    break;
+  case ncclPatternNvlsTree:
+    {
       NCCLCHECK(SaveProxy(comm, channel, proxyRecv, channel->nvls.treeDown[1], op, 0, justInquire));
       NCCLCHECK(SaveProxy(comm, channel, proxyRecv, channel->nvls.treeDown[2], op, 0, justInquire));
       NCCLCHECK(SaveProxy(comm, channel, proxySend, channel->nvls.treeUp, op, 0, justInquire));
       NCCLCHECK(SaveProxy(comm, channel, proxySend, channel->nvls.treeDown[1], op, 0, justInquire));
       NCCLCHECK(SaveProxy(comm, channel, proxySend, channel->nvls.treeDown[2], op, 0, justInquire));
       NCCLCHECK(SaveProxy(comm, channel, proxyRecv, channel->nvls.treeUp, op, 0, justInquire));
-    } break;
-  case ncclPatternPatUp: {
+    }
+    break;
+  case ncclPatternPatUp:
+    {
       // Run full algorithm to count the number of steps for each peer.
       ncclResult_t result = ncclSuccess;
-      const ssize_t size = op->nbytes/comm->nRanks;
+      const ssize_t size = op->nbytes / comm->nRanks;
       const int rank = comm->rank, nranks = comm->nRanks;
       int *nstepsSend = NULL, *nstepsRecv = NULL;
       PatRSAlgorithm<char> algo(op->chunkSize, NCCL_STEPS, 16, 0, size, size, op->chunkSize, rank, nranks);
@@ -693,14 +712,14 @@ ncclResult_t ncclProxySaveOp(struct ncclComm* comm, struct ncclProxyOp* op, bool
         if (ps.recvDim != -1 && ps.postRecv) nstepsRecv[ps.recvDim]++;
         if (ps.sendDim != -1 && ps.postSend) nstepsSend[ps.sendDim]++;
       } while (ps.last != 2);
-      for (int i=0; i<log2Up(nranks); i++) {
+      for (int i = 0; i < log2Up(nranks); i++) {
         if (nstepsSend[i]) {
-          int sendPeer = (rank + (1<<i)) % nranks;
+          int sendPeer = (rank + (1 << i)) % nranks;
           op->nsteps = nstepsSend[i];
           NCCLCHECKGOTO(SaveProxy(comm, channel, proxySend, sendPeer, op, 0, justInquire), result, exit_pat_up);
         }
         if (nstepsRecv[i]) {
-          int recvPeer = (rank - (1<<i) + nranks) % nranks;
+          int recvPeer = (rank - (1 << i) + nranks) % nranks;
           op->nsteps = nstepsRecv[i];
           NCCLCHECKGOTO(SaveProxy(comm, channel, proxyRecv, recvPeer, op, 0, justInquire), result, exit_pat_up);
         }
@@ -709,11 +728,13 @@ ncclResult_t ncclProxySaveOp(struct ncclComm* comm, struct ncclProxyOp* op, bool
       free(nstepsSend);
       free(nstepsRecv);
       NCCLCHECK(result);
-    } break;
-  case ncclPatternPatDown: {
+    }
+    break;
+  case ncclPatternPatDown:
+    {
       // Run full algorithm to count the number of steps for each peer.
       ncclResult_t result = ncclSuccess;
-      const ssize_t size = op->nbytes/comm->nRanks;
+      const ssize_t size = op->nbytes / comm->nRanks;
       const int rank = comm->rank, nranks = comm->nRanks;
       int *nstepsSend = NULL, *nstepsRecv = NULL;
       PatAGAlgorithm<char> algo(op->chunkSize, NCCL_STEPS, 16, 0, size, size, op->chunkSize, rank, nranks);
@@ -727,14 +748,14 @@ ncclResult_t ncclProxySaveOp(struct ncclComm* comm, struct ncclProxyOp* op, bool
         if (ps.recvDim != -1 && ps.postRecv) nstepsRecv[ps.recvDim]++;
         if (ps.sendDim != -1 && ps.postSend) nstepsSend[ps.sendDim]++;
       } while (ps.last != 2);
-      for (int i=0; i<log2Up(nranks); i++) {
+      for (int i = 0; i < log2Up(nranks); i++) {
         if (nstepsSend[i]) {
-          int sendPeer = (rank - (1<<i) + nranks) % nranks;
+          int sendPeer = (rank - (1 << i) + nranks) % nranks;
           op->nsteps = nstepsSend[i];
           NCCLCHECKGOTO(SaveProxy(comm, channel, proxySend, sendPeer, op, 0, justInquire), result, exit_pat_down);
         }
         if (nstepsRecv[i]) {
-          int recvPeer = (rank + (1<<i)) % nranks;
+          int recvPeer = (rank + (1 << i)) % nranks;
           op->nsteps = nstepsRecv[i];
           NCCLCHECKGOTO(SaveProxy(comm, channel, proxyRecv, recvPeer, op, 0, justInquire), result, exit_pat_down);
         }
@@ -743,21 +764,28 @@ ncclResult_t ncclProxySaveOp(struct ncclComm* comm, struct ncclProxyOp* op, bool
       free(nstepsSend);
       free(nstepsRecv);
       NCCLCHECK(result);
-    } break;
+    }
+    break;
   case ncclPatternSend:
-  case ncclPatternRecv: {
+  case ncclPatternRecv:
+    {
       if (op->root == comm->rank) return ncclSuccess;
-      NCCLCHECK(SaveProxy(comm, channel, op->pattern == ncclPatternSend ? proxySend : proxyRecv, op->root, op, op->connIndex, justInquire));
-    } break;
-  case ncclPatternProfiler: {
+      NCCLCHECK(SaveProxy(comm, channel, op->pattern == ncclPatternSend ? proxySend : proxyRecv, op->root, op,
+                          op->connIndex, justInquire));
+    }
+    break;
+  case ncclPatternProfiler:
+    {
       if (ncclProfilerNeedsProxy(comm, op)) NCCLCHECK(SaveProxyProfiler(comm, op, justInquire));
       else incWorkCounter(comm, op);
-    } break;
+    }
+    break;
   }
   return ncclSuccess;
 }
 
-static ncclResult_t removeOp(struct ncclProxyProgressState* state, struct ncclProxyArgs** opPtr, struct ncclProxyArgs** prevOpPtr) {
+static ncclResult_t removeOp(struct ncclProxyProgressState* state, struct ncclProxyArgs** opPtr,
+                             struct ncclProxyArgs** prevOpPtr) {
   struct ncclProxyArgs* freeOp = *opPtr;
   struct ncclProxyArgs* next = freeOp->next;
   DEBUG_PROXY_PRINT("Remove %ld -> %ld -> %ld\n", OP_INDEX(*prevOpPtr), OP_INDEX(freeOp), OP_INDEX(next));
@@ -790,19 +818,27 @@ static ncclResult_t removeOp(struct ncclProxyProgressState* state, struct ncclPr
   return ncclSuccess;
 }
 
-static ncclResult_t progressOps(struct ncclProxyState* proxyState, struct ncclProxyProgressState* state, struct ncclProxyArgs* opStart, int* idle) {
+static ncclResult_t progressOps(struct ncclProxyState* proxyState, struct ncclProxyProgressState* state,
+                                struct ncclProxyArgs* opStart, int* idle) {
   struct ncclProxyArgs* prevOp = NULL;
   struct ncclProxyArgs* op = opStart;
   ncclResult_t status = ncclSuccess;
   while (op) {
     op->retry_total++;
     if (op->state == ncclProxyOpNone) return ncclInternalError;
-    TIME_START(0); TIME_START(1);
+    TIME_START(0);
+    TIME_START(1);
     ncclResult_t ret = op->progress(proxyState, op);
-    if (op->idle) { TIME_STOP(1); TIME_CANCEL(0); } else { TIME_CANCEL(1); TIME_STOP(0); }
+    if (op->idle) {
+      TIME_STOP(1);
+      TIME_CANCEL(0);
+    } else {
+      TIME_CANCEL(1);
+      TIME_STOP(0);
+    }
     *idle &= op->idle;
     if (op->state == ncclProxyOpNone || ret != ncclSuccess) {
-      //track first error that occured
+      // track first error that occured
       if (ret != ncclSuccess && status == ncclSuccess) status = ret;
       TIME_START(2);
       NCCLCHECK(removeOp(state, &op, &prevOp));
@@ -872,14 +908,14 @@ process_nextops:
   int lastPeer = -1;
   int count = 0;
   for (int opIndex = state->nextOps; opIndex != -1;) {
-    struct ncclProxyOp* peerOp = pool->ops+opIndex;
+    struct ncclProxyOp* peerOp = pool->ops + opIndex;
     int peer = opIndex / MAX_OPS_PER_PEER;
     if ((lastOpCount && peerOp->opCount != lastOpCount) || ((lastPeer != -1) && peer != lastPeer)) count++;
-    if (count == ncclParamProxyAppendBatchSize()+1) break;
+    if (count == ncclParamProxyAppendBatchSize() + 1) break;
     lastOpCount = peerOp->opCount;
     lastPeer = peer;
     if (peerOp->connection == NULL) return ncclInternalError;
-    if (peerOp->next != -1) COMPILER_PREFETCH(pool->ops+peerOp->next);
+    if (peerOp->next != -1) COMPILER_PREFETCH(pool->ops + peerOp->next);
     NCCLCHECK(ProxyAppend(state, peerOp));
     (*added)++;
     int lastOpIndex = opIndex;
@@ -905,7 +941,9 @@ process_nextops:
       // freeOp[i], hence ensuring that freeOpEnd[i] is also initialized.
       // coverity[uninit_use:FALSE]
       pool->ops[freeOpEnd[i]].next = oldFree;
-    } while (!COMPILER_ATOMIC_COMPARE_EXCHANGE(&pool->freeOps[i], &oldFree, newFree, /*success=*/std::memory_order_release, /*failure=*/std::memory_order_acquire));
+    } while (!COMPILER_ATOMIC_COMPARE_EXCHANGE(&pool->freeOps[i], &oldFree, newFree,
+                                               /*success=*/std::memory_order_release,
+                                               /*failure=*/std::memory_order_acquire));
   }
   ncclProfilerRecordProxyCtrlEventState(eHandle, *added, ncclProfilerProxyCtrlAppendEnd);
   ncclProfilerStopProxyCtrlEvent(eHandle);
@@ -935,9 +973,11 @@ static ncclResult_t setProxyThreadContext(struct ncclProxyState* proxyState, con
       proxyState->cudaCtx = NULL;
       return;
     }
-    int cudaError = CUPFN(cuCtxCreate(&proxyState->cudaCtx, NULL, 0, CU_CTX_SCHED_SPIN | CU_CTX_MAP_HOST, proxyState->cudaDev));
+    int cudaError =
+      CUPFN(cuCtxCreate(&proxyState->cudaCtx, NULL, 0, CU_CTX_SCHED_SPIN | CU_CTX_MAP_HOST, proxyState->cudaDev));
     if (cudaError != CUDA_SUCCESS) {
-      INFO(NCCL_INIT, "[%s] Failed to create CUDA context on device %d with error %d, disabling cuda context.", prefix, proxyState->cudaDev, cudaError);
+      INFO(NCCL_INIT, "[%s] Failed to create CUDA context on device %d with error %d, disabling cuda context.", prefix,
+           proxyState->cudaDev, cudaError);
       proxyState->cudaCtx = NULL;
     }
   });
@@ -948,7 +988,8 @@ static ncclResult_t setProxyThreadContext(struct ncclProxyState* proxyState, con
   // creating thread, but all three proxy threads call here so keep them symmetric.
   int cudaError = CUPFN(cuCtxSetCurrent(proxyState->cudaCtx));
   if (cudaError != CUDA_SUCCESS) {
-    INFO(NCCL_INIT, "[%s] Failed to set CUDA context on device %d with error %d.", prefix, proxyState->cudaDev, cudaError);
+    INFO(NCCL_INIT, "[%s] Failed to set CUDA context on device %d with error %d.", prefix, proxyState->cudaDev,
+         cudaError);
     return ncclInvalidUsage;
   }
 
@@ -986,7 +1027,7 @@ fail:
   return;
 }
 
-void* ncclProxyProgress(void *proxyState_) {
+void* ncclProxyProgress(void* proxyState_) {
   struct ncclProxyState* proxyState = (struct ncclProxyState*)proxyState_;
   // This thread is created by proxyService, therefore setting the affinity is not needed.
   INFO(NCCL_INIT, "[Proxy Progress] Device %d CPU core %d", proxyState->cudaDev, ncclOsGetCpu());
@@ -1017,7 +1058,7 @@ void* ncclProxyProgress(void *proxyState_) {
     ncclResult_t ret = progressOps(proxyState, state, state->active, &idle);
     if (ret != ncclSuccess) {
       COMPILER_ATOMIC_STORE(&proxyState->asyncResult, ret, std::memory_order_release);
-      INFO(NCCL_ALL,"%s:%d -> %d [Progress Thread]", __FILE__, __LINE__, ret);
+      INFO(NCCL_ALL, "%s:%d -> %d [Progress Thread]", __FILE__, __LINE__, ret);
       break;
     }
     if ((lastIdle == 0 && idle == 1) || (lastIdle == 1 && idle == 0)) {
@@ -1032,17 +1073,22 @@ void* ncclProxyProgress(void *proxyState_) {
       proxyOpAppendCounter = 0;
       TIME_START(3);
       ret = ncclProxyGetPostedOps(proxyState, &added);
-      if (added) { TIME_STOP(3); } else { TIME_CANCEL(3); }
+      if (added) {
+        TIME_STOP(3);
+      } else {
+        TIME_CANCEL(3);
+      }
       if (ret != ncclSuccess) {
         COMPILER_ATOMIC_STORE(&proxyState->asyncResult, ret, std::memory_order_release);
-        INFO(NCCL_ALL,"%s:%d -> %d [Progress Thread]", __FILE__, __LINE__, ret);
+        INFO(NCCL_ALL, "%s:%d -> %d [Progress Thread]", __FILE__, __LINE__, ret);
       }
       if (added == 0) {
         std::this_thread::yield(); // No request progressed. Let others run.
       }
     }
     lastIdle = idle;
-  } while ((state->stop == 0 || (state->stop == 1 && state->active)) && COMPILER_ATOMIC_LOAD(proxyState->abortFlag, std::memory_order_acquire) == 0);
+  } while ((state->stop == 0 || (state->stop == 1 && state->active)) &&
+           COMPILER_ATOMIC_LOAD(proxyState->abortFlag, std::memory_order_acquire) == 0);
   return NULL;
 }
 
@@ -1092,7 +1138,7 @@ ncclResult_t ncclProxyProgressDestroy(struct ncclProxyState* proxyState) {
 
   // Free off any memory allocated for the proxy arg pools
   while (state->pools != NULL) {
-    struct ncclProxyPool *next = state->pools->next;
+    struct ncclProxyPool* next = state->pools->next;
     free(state->pools);
     state->pools = next;
   }
@@ -1103,24 +1149,24 @@ ncclResult_t ncclProxyProgressDestroy(struct ncclProxyState* proxyState) {
 
 ncclResult_t ncclProxyNewConnection(struct ncclProxyConnectionPool* pool, int* id) {
   if (pool->offset == NCCL_PROXY_CONN_POOL_SIZE) {
-    NCCLCHECK(ncclRealloc(&pool->pools, pool->banks, pool->banks+1));
-    NCCLCHECK(ncclCalloc(pool->pools+pool->banks, NCCL_PROXY_CONN_POOL_SIZE));
+    NCCLCHECK(ncclRealloc(&pool->pools, pool->banks, pool->banks + 1));
+    NCCLCHECK(ncclCalloc(pool->pools + pool->banks, NCCL_PROXY_CONN_POOL_SIZE));
     pool->banks++;
     pool->offset = 0;
   }
-  *id = ((pool->banks-1) << NCCL_PROXY_CONN_POOL_SIZE_POW2) + pool->offset;
+  *id = ((pool->banks - 1) << NCCL_PROXY_CONN_POOL_SIZE_POW2) + pool->offset;
   pool->offset++;
   return ncclSuccess;
 }
 
 ncclResult_t ncclProxyGetConnection(struct ncclProxyConnectionPool* pool, int id, struct ncclProxyConnection** conn) {
   if (id < 0) return ncclInvalidArgument;
-  int bank = id>>NCCL_PROXY_CONN_POOL_SIZE_POW2;
-  int offset = id&NCCL_PROXY_CONN_POOL_MASK;
+  int bank = id >> NCCL_PROXY_CONN_POOL_SIZE_POW2;
+  int offset = id & NCCL_PROXY_CONN_POOL_MASK;
   if ((pool->pools == NULL) || (bank >= pool->banks) || (pool->pools[bank] == NULL)) return ncclInvalidArgument;
   // Last bank's high-water mark is pool->offset; reject IDs past it so callers can't index uninitialized slots.
   if (bank == pool->banks - 1 && offset >= pool->offset) return ncclInvalidArgument;
-  *conn = pool->pools[bank]+offset;
+  *conn = pool->pools[bank] + offset;
   return ncclSuccess;
 }
 
@@ -1138,10 +1184,10 @@ static ncclResult_t proxyFree(struct ncclProxyConnection* connection, struct ncc
 }
 
 static ncclResult_t ncclProxyFreeConnections(struct ncclProxyConnectionPool* pool, struct ncclProxyState* proxyState) {
-  for (int b=0; b<pool->banks; b++) {
-    int max = b == pool->banks-1 ? pool->offset : NCCL_PROXY_CONN_POOL_SIZE;
-    for (int i=0; i<max; i++) {
-      ncclProxyConnection *connection = pool->pools[b]+i;
+  for (int b = 0; b < pool->banks; b++) {
+    int max = b == pool->banks - 1 ? pool->offset : NCCL_PROXY_CONN_POOL_SIZE;
+    for (int i = 0; i < max; i++) {
+      ncclProxyConnection* connection = pool->pools[b] + i;
       if (connection->state != connUninitialized) {
         NCCLCHECK(proxyFree(connection, proxyState));
       }
@@ -1168,14 +1214,17 @@ struct ncclProxyInitResp {
   char devShmPath[6]; // "XXXXXX" - May or may not be set
 };
 
-ncclResult_t ncclProxyConnect(struct ncclComm* comm, int transport, int send, int proxyRank, struct ncclProxyConnector* proxyConn) {
+ncclResult_t ncclProxyConnect(struct ncclComm* comm, int transport, int send, int proxyRank,
+                              struct ncclProxyConnector* proxyConn) {
   struct ncclSocket* sock;
   int ready;
   struct ncclProxyState* sharedProxyState = comm->proxyState;
   int tpProxyRank = comm->topParentRanks[proxyRank];
 
   proxyConn->sameProcess = ((comm->peerInfo[proxyRank].hostHash == comm->peerInfo[comm->rank].hostHash) &&
-                            (comm->peerInfo[proxyRank].pidHash == comm->peerInfo[comm->rank].pidHash)) ? 1 : 0;
+                            (comm->peerInfo[proxyRank].pidHash == comm->peerInfo[comm->rank].pidHash)) ?
+                             1 :
+                             0;
   // Keep one connection per local rank
   proxyConn->connection = NULL;
   proxyConn->connId = -1;
@@ -1197,7 +1246,8 @@ ncclResult_t ncclProxyConnect(struct ncclComm* comm, int transport, int send, in
   sock = sharedProxyState->peerSocks + peerIndex;
   NCCLCHECK(ncclSocketReady(sock, &ready));
   if (!ready) {
-    NCCLCHECK(ncclSocketInit(sock, sharedProxyState->peerAddresses+proxyConn->tpRank, comm->sharedRes->magic, ncclSocketTypeProxy, comm->abortFlag));
+    NCCLCHECK(ncclSocketInit(sock, sharedProxyState->peerAddresses + proxyConn->tpRank, comm->sharedRes->magic,
+                             ncclSocketTypeProxy, comm->abortFlag));
     NCCLCHECK(ncclSocketConnect(sock));
   }
 
@@ -1218,7 +1268,6 @@ ncclResult_t ncclProxyConnect(struct ncclComm* comm, int transport, int send, in
   // If we need proxy progress, map progress ops
   struct ncclTransportComm* tcomm = send ? &ncclTransports[transport]->send : &ncclTransports[transport]->recv;
   if (tcomm->proxyProgress) {
-
 #if defined(NCCL_OS_LINUX)
     char poolPath[sizeof("/dev/shm/nccl-XXXXXX")];
     snprintf(poolPath, sizeof(poolPath), "/dev/shm/nccl-%.6s", resp.devShmPath);
@@ -1228,20 +1277,24 @@ ncclResult_t ncclProxyConnect(struct ncclComm* comm, int transport, int send, in
 #endif
     struct ncclProxyOps* proxyOps = sharedProxyState->proxyOps + proxyConn->tpLocalRank;
     if (proxyOps->pool == NULL) {
-      NCCLCHECK(ncclShmOpen(poolPath, sizeof(poolPath), sizeof(struct ncclProxyOpsPool), (void**)(&proxyOps->pool), NULL, -1, &proxyOps->handle));
+      NCCLCHECK(ncclShmOpen(poolPath, sizeof(poolPath), sizeof(struct ncclProxyOpsPool), (void**)(&proxyOps->pool),
+                            NULL, -1, &proxyOps->handle));
       proxyOps->nextOps = proxyOps->nextOpsEnd = proxyOps->freeOp = -1;
     }
   }
   proxyConn->initialized = true;
-  INFO(NCCL_NET|NCCL_PROXY, "Connected to proxy localRank %d -> connection %p (connId %d)", proxyConn->tpLocalRank, proxyConn->connection, proxyConn->connId);
+  INFO(NCCL_NET | NCCL_PROXY, "Connected to proxy localRank %d -> connection %p (connId %d)", proxyConn->tpLocalRank,
+       proxyConn->connection, proxyConn->connId);
   return ncclSuccess;
 }
 
 // UDS support
-ncclResult_t ncclProxyCallBlockingUDS(struct ncclComm* comm, struct ncclProxyConnector* proxyConn, int type, void* reqBuff, int reqSize, void* respBuff, int respSize, int* reqFd, int *respFd) {
+ncclResult_t ncclProxyCallBlockingUDS(struct ncclComm* comm, struct ncclProxyConnector* proxyConn, int type,
+                                      void* reqBuff, int reqSize, void* respBuff, int respSize, int* reqFd,
+                                      int* respFd) {
   ncclResult_t res = ncclSuccess;
-  struct ncclIpcSocket ipcSock = { 0 };
-  void *opId;
+  struct ncclIpcSocket ipcSock = {0};
+  void* opId;
   NCCLCHECK(getRandomData(&opId, sizeof(opId)));
   int reqFdtmp = -1;
 
@@ -1249,8 +1302,8 @@ ncclResult_t ncclProxyCallBlockingUDS(struct ncclComm* comm, struct ncclProxyCon
   struct ncclProxyState* sharedProxyState = comm->proxyState;
   uint64_t pidHash = sharedProxyState->peerAddressesUDS[proxyConn->tpRank];
 
-  INFO(NCCL_PROXY, "ProxyCall UDS comm %p rank %d tpRank %d(%lx) reqSize %d respSize %d respFd %p opId %p",
-       comm, rank, proxyConn->tpRank, pidHash, reqSize, respSize, respFd, opId);
+  INFO(NCCL_PROXY, "ProxyCall UDS comm %p rank %d tpRank %d(%lx) reqSize %d respSize %d respFd %p opId %p", comm, rank,
+       proxyConn->tpRank, pidHash, reqSize, respSize, respFd, opId);
 
   // cuMem: Create a UDS socket to receive the response
   NCCLCHECK(ncclIpcSocketInit(&ipcSock, rank, (uint64_t)opId, comm->abortFlag));
@@ -1276,8 +1329,8 @@ ncclResult_t ncclProxyCallBlockingUDS(struct ncclComm* comm, struct ncclProxyCon
   NCCLCHECKGOTO(ncclIpcSocketRecvMsg(&ipcSock, respBuff, respSize, respFd), res, error);
   NCCLCHECKGOTO(ncclIpcSocketClose(&ipcSock), res, error);
 
-  INFO(NCCL_PROXY, "ProxyCall UDS comm %p rank %d tpRank %d(%lx) reqSize %d respSize %d respFd %d opId %p - DONE",
-       comm, rank, proxyConn->tpRank, pidHash, reqSize, respSize, (respFd ? *respFd : -1), opId);
+  INFO(NCCL_PROXY, "ProxyCall UDS comm %p rank %d tpRank %d(%lx) reqSize %d respSize %d respFd %d opId %p - DONE", comm,
+       rank, proxyConn->tpRank, pidHash, reqSize, respSize, (respFd ? *respFd : -1), opId);
 
   return res;
 
@@ -1289,7 +1342,7 @@ error:
 
 // cuMem API support
 // The request/response is sent out-of-band using ncclIpcSocket for this specific command
-ncclResult_t ncclProxyClientGetFdBlocking(struct ncclComm* comm, int proxyRank, void *handle, int* convertedFd) {
+ncclResult_t ncclProxyClientGetFdBlocking(struct ncclComm* comm, int proxyRank, void* handle, int* convertedFd) {
   ncclResult_t ret = ncclSuccess;
   // Request the allocation of a UDS fd for the handle
   if (comm->gproxyConn[proxyRank].initialized == false) {
@@ -1298,28 +1351,38 @@ ncclResult_t ncclProxyClientGetFdBlocking(struct ncclComm* comm, int proxyRank, 
 #if (defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)) && HIP_VERSION < 71260540
   {
     uint64_t hipHandleVal = (uint64_t)(uintptr_t)(*(hipMemGenericAllocationHandle_t*)handle);
-    NCCLCHECKGOTO(ncclProxyCallBlockingUDS(comm, &comm->gproxyConn[proxyRank], ncclProxyMsgGetFd, (void*)&hipHandleVal, sizeof(hipHandleVal), NULL, 0, NULL, convertedFd), ret, error);
+    NCCLCHECKGOTO(ncclProxyCallBlockingUDS(comm, &comm->gproxyConn[proxyRank], ncclProxyMsgGetFd, (void*)&hipHandleVal,
+                                           sizeof(hipHandleVal), NULL, 0, NULL, convertedFd),
+                  ret, error);
   }
 #else
-  NCCLCHECKGOTO(ncclProxyCallBlockingUDS(comm, &comm->gproxyConn[proxyRank], ncclProxyMsgGetFd, handle, sizeof(CUmemGenericAllocationHandle), NULL, 0, NULL, convertedFd), ret, error);
+  NCCLCHECKGOTO(ncclProxyCallBlockingUDS(comm, &comm->gproxyConn[proxyRank], ncclProxyMsgGetFd, handle,
+                                         sizeof(CUmemGenericAllocationHandle), NULL, 0, NULL, convertedFd),
+                ret, error);
 #endif
 
   // We have now received the converted fd over UDS
-  INFO(NCCL_PROXY, "UDS: ClientGetFd handle 0x%lx tpRank %d returned fd %d sameProcess %d", *(uint64_t*)handle, comm->topParentRanks[proxyRank], *convertedFd, comm->gproxyConn[proxyRank].sameProcess);
+  INFO(NCCL_PROXY, "UDS: ClientGetFd handle 0x%lx tpRank %d returned fd %d sameProcess %d", *(uint64_t*)handle,
+       comm->topParentRanks[proxyRank], *convertedFd, comm->gproxyConn[proxyRank].sameProcess);
 
   return ret;
 
 error:
-  WARN("ncclProxyClientGetFd call to tpRank %d handle 0x%lx failed : %d", comm->topParentRanks[proxyRank], *(uint64_t*)handle, ret);
+  WARN("ncclProxyClientGetFd call to tpRank %d handle 0x%lx failed : %d", comm->topParentRanks[proxyRank],
+       *(uint64_t*)handle, ret);
   return ret;
 }
 
-ncclResult_t ncclProxyClientBatchQueryFdBlocking(struct ncclComm* comm, struct ncclProxyConnector* proxyConn, int* localFds, int* rmtFds, int numSegments) {
+ncclResult_t ncclProxyClientBatchQueryFdBlocking(struct ncclComm* comm, struct ncclProxyConnector* proxyConn,
+                                                 int* localFds, int* rmtFds, int numSegments) {
   ncclResult_t ret = ncclSuccess;
   for (int segment = 0; segment < numSegments; segment++) {
-    NCCLCHECKGOTO(ncclProxyCallBlockingUDS(comm, proxyConn, ncclProxyMsgQueryFd, NULL, 0, (void*) &rmtFds[segment], sizeof(int), &localFds[segment], NULL), ret, fail);
+    NCCLCHECKGOTO(ncclProxyCallBlockingUDS(comm, proxyConn, ncclProxyMsgQueryFd, NULL, 0, (void*)&rmtFds[segment],
+                                           sizeof(int), &localFds[segment], NULL),
+                  ret, fail);
     // We have now received the converted fd for a segment over UDS
-    INFO(NCCL_PROXY, "UDS: ClientQueryFdBatch localFd %d tpRank %d remote fd %d sameProcess %d segment %d", localFds[segment], proxyConn->tpRank, rmtFds[segment], proxyConn->sameProcess, segment);
+    INFO(NCCL_PROXY, "UDS: ClientQueryFdBatch localFd %d tpRank %d remote fd %d sameProcess %d segment %d",
+         localFds[segment], proxyConn->tpRank, rmtFds[segment], proxyConn->sameProcess, segment);
   }
 exit:
   return ret;
@@ -1327,20 +1390,26 @@ fail:
   goto exit;
 }
 
-ncclResult_t ncclProxyClientQueryFdBlocking(struct ncclComm* comm, struct ncclProxyConnector* proxyConn, int localFd, int* rmtFd) {
+ncclResult_t ncclProxyClientQueryFdBlocking(struct ncclComm* comm, struct ncclProxyConnector* proxyConn, int localFd,
+                                            int* rmtFd) {
   ncclResult_t ret = ncclSuccess;
-  NCCLCHECKGOTO(ncclProxyCallBlockingUDS(comm, proxyConn, ncclProxyMsgQueryFd, NULL, 0, (void*)rmtFd, sizeof(int), &localFd, NULL), ret, fail);
+  NCCLCHECKGOTO(ncclProxyCallBlockingUDS(comm, proxyConn, ncclProxyMsgQueryFd, NULL, 0, (void*)rmtFd, sizeof(int),
+                                         &localFd, NULL),
+                ret, fail);
 exit:
   // We have now received the converted fd over UDS
-  INFO(NCCL_PROXY, "UDS: ClientQueryFd localFd %d tpRank %d remote fd %d sameProcess %d", localFd, proxyConn->tpRank, *rmtFd, proxyConn->sameProcess);
+  INFO(NCCL_PROXY, "UDS: ClientQueryFd localFd %d tpRank %d remote fd %d sameProcess %d", localFd, proxyConn->tpRank,
+       *rmtFd, proxyConn->sameProcess);
   return ret;
 fail:
   WARN("ncclProxyClientQueryFdBlocking call to tpRank %d localFd %d failed : %d", proxyConn->tpRank, localFd, ret);
   goto exit;
 }
 
-const char* ncclProxyMsgTypeStr[] = { "Unknown", "Init", "SharedInit", "Setup", "Connect", "Start", "Close", "Abort", "Stop", "GetFd", "QueryFd", "Register", "Deregister" };
-ncclResult_t ncclProxyCallAsync(struct ncclComm* comm, struct ncclProxyConnector* proxyConn, int type, void* reqBuff, int reqSize, int respSize, void* opId) {
+const char* ncclProxyMsgTypeStr[] = {"Unknown", "Init", "SharedInit", "Setup",   "Connect",  "Start",     "Close",
+                                     "Abort",   "Stop", "GetFd",      "QueryFd", "Register", "Deregister"};
+ncclResult_t ncclProxyCallAsync(struct ncclComm* comm, struct ncclProxyConnector* proxyConn, int type, void* reqBuff,
+                                int reqSize, int respSize, void* opId) {
   struct ncclSocket* sock;
   ncclResult_t ret = ncclSuccess;
   struct ncclProxyState* sharedProxyState = comm->proxyState;
@@ -1368,7 +1437,8 @@ error:
   return ret;
 }
 
-ncclResult_t ncclPollProxyResponse(struct ncclComm* comm, struct ncclProxyConnector* proxyConn, void* respBuff, void* opId) {
+ncclResult_t ncclPollProxyResponse(struct ncclComm* comm, struct ncclProxyConnector* proxyConn, void* respBuff,
+                                   void* opId) {
   struct ncclProxyState* sharedProxyState = comm->proxyState;
   // Receive the connection pointer from the Proxy
   if (COMPILER_ATOMIC_LOAD(comm->abortFlag, std::memory_order_acquire)) {
@@ -1392,10 +1462,9 @@ ncclResult_t ncclPollProxyResponse(struct ncclComm* comm, struct ncclProxyConnec
 
     if (offset == 0) {
       return ncclInProgress;
-    // If we've returned a partial response, block to receive the rest of it
+      // If we've returned a partial response, block to receive the rest of it
     } else if (offset < sizeof(resp)) {
-      while (offset < sizeof(resp))
-        NCCLCHECK(ncclSocketProgress(NCCL_SOCKET_RECV, sock, &resp, sizeof(resp), &offset));
+      while (offset < sizeof(resp)) NCCLCHECK(ncclSocketProgress(NCCL_SOCKET_RECV, sock, &resp, sizeof(resp), &offset));
     }
 
     INFO(NCCL_PROXY, "ncclPollProxyResponse Received new opId=%p", resp.opId);
@@ -1430,7 +1499,8 @@ ncclResult_t ncclPollProxyResponse(struct ncclComm* comm, struct ncclProxyConnec
   return res;
 }
 
-ncclResult_t ncclProxyCallBlocking(struct ncclComm* comm, struct ncclProxyConnector* proxyConn, int type, void* reqBuff, int reqSize, void* respBuff, int respSize) {
+ncclResult_t ncclProxyCallBlocking(struct ncclComm* comm, struct ncclProxyConnector* proxyConn, int type, void* reqBuff,
+                                   int reqSize, void* respBuff, int respSize) {
   // Alloc some memory to act as a handle
   ncclResult_t res = ncclSuccess;
   void* opId = malloc(1);
@@ -1465,14 +1535,16 @@ static ncclResult_t proxyProgressInit(struct ncclProxyState* proxyState) {
     char shmPath[64];
     snprintf(shmPath, sizeof(shmPath), "Local\\nccl-shm-%d", GetCurrentProcessId());
 #endif
-    NCCLCHECK(ncclShmOpen(shmPath, sizeof(shmPath), size, (void**)&pool, NULL, proxyState->tpLocalnRanks, &state->handle));
+    NCCLCHECK(ncclShmOpen(shmPath, sizeof(shmPath), size, (void**)&pool, NULL, proxyState->tpLocalnRanks,
+                          &state->handle));
     // Init pool
     pool->nextOps = -1;
 
     for (int r = 0; r < proxyState->tpLocalnRanks; r++) {
-      pool->freeOps[r] = r*MAX_OPS_PER_PEER;
-      for (int i=0; i<MAX_OPS_PER_PEER-1; i++) pool->ops[r*MAX_OPS_PER_PEER+i].next = r*MAX_OPS_PER_PEER+i+1;
-      pool->ops[(r+1)*MAX_OPS_PER_PEER-1].next = -1;
+      pool->freeOps[r] = r * MAX_OPS_PER_PEER;
+      for (int i = 0; i < MAX_OPS_PER_PEER - 1; i++)
+        pool->ops[r * MAX_OPS_PER_PEER + i].next = r * MAX_OPS_PER_PEER + i + 1;
+      pool->ops[(r + 1) * MAX_OPS_PER_PEER - 1].next = -1;
     }
 
     ncclOsSetMutexCondShared(pool->mutex, pool->cond);
@@ -1480,7 +1552,7 @@ static ncclResult_t proxyProgressInit(struct ncclProxyState* proxyState) {
     state->opsPool = pool;
 
 #if defined(NCCL_OS_LINUX)
-    memcpy(state->opsPoolShmSuffix, shmPath+sizeof("/dev/shm/nccl-")-1, sizeof("XXXXXX")-1);
+    memcpy(state->opsPoolShmSuffix, shmPath + sizeof("/dev/shm/nccl-") - 1, sizeof("XXXXXX") - 1);
 #elif defined(NCCL_OS_WINDOWS)
     const char* shmPrefix = "Local\\nccl-shm-";
     size_t prefixLen = strlen(shmPrefix);
@@ -1512,7 +1584,9 @@ ncclResult_t ncclProxyShmUnlink(struct ncclComm* comm) {
   return ncclSuccess;
 }
 
-static ncclResult_t proxyConnInit(struct ncclProxyLocalPeer* peer, struct ncclProxyConnectionPool* connectionPool, struct ncclProxyState* proxyState, ncclProxyInitReq* req, ncclProxyInitResp* resp, struct ncclProxyConnection** connection) {
+static ncclResult_t proxyConnInit(struct ncclProxyLocalPeer* peer, struct ncclProxyConnectionPool* connectionPool,
+                                  struct ncclProxyState* proxyState, ncclProxyInitReq* req, ncclProxyInitResp* resp,
+                                  struct ncclProxyConnection** connection) {
   int id;
 
   if ((unsigned)req->tpLocalRank >= (unsigned)proxyState->tpLocalnRanks) {
@@ -1534,25 +1608,27 @@ static ncclResult_t proxyConnInit(struct ncclProxyLocalPeer* peer, struct ncclPr
   resp->connection = *connection;
   resp->connId = id;
 
-  (*connection)->tcomm = (*connection)->send ? &ncclTransports[(*connection)->transport]->send : &ncclTransports[(*connection)->transport]->recv;
+  (*connection)->tcomm = (*connection)->send ? &ncclTransports[(*connection)->transport]->send :
+                                               &ncclTransports[(*connection)->transport]->recv;
   // If we need proxy progress, let's allocate ops and start the thread
   if ((*connection)->tcomm->proxyProgress) {
     NCCLCHECK(proxyProgressInit(proxyState));
     struct ncclProxyProgressState* state = &proxyState->progressState;
     memcpy(resp->devShmPath, state->opsPoolShmSuffix, sizeof(resp->devShmPath));
   }
-  INFO(NCCL_PROXY, "New proxy %s connection %d from local rank %d, transport %d", (*connection)->send ? "send":"recv", id, (*connection)->tpLocalRank, (*connection)->transport);
+  INFO(NCCL_PROXY, "New proxy %s connection %d from local rank %d, transport %d", (*connection)->send ? "send" : "recv",
+       id, (*connection)->tpLocalRank, (*connection)->transport);
   COMPILER_ATOMIC_STORE(&(*connection)->state, connInitialized, std::memory_order_release);
   return ncclSuccess;
 }
 
-static ncclResult_t proxyQueryFd(struct ncclProxyState* proxyState, int rank, void *opId, int rmtFd) {
+static ncclResult_t proxyQueryFd(struct ncclProxyState* proxyState, int rank, void* opId, int rmtFd) {
 #if ROCM_VERSION >= 70000
-  struct ncclIpcSocket ipcSock = { 0 };
-  uint64_t hash = (uint64_t) opId;
+  struct ncclIpcSocket ipcSock = {0};
+  uint64_t hash = (uint64_t)opId;
   ncclResult_t ret = ncclSuccess;
 
-  NCCLCHECKGOTO(ncclIpcSocketInit(&ipcSock, proxyState->tpRank, hash^1, proxyState->abortFlag), ret, exit);
+  NCCLCHECKGOTO(ncclIpcSocketInit(&ipcSock, proxyState->tpRank, hash ^ 1, proxyState->abortFlag), ret, exit);
   NCCLCHECKGOTO(ncclIpcSocketSendMsg(&ipcSock, &rmtFd, sizeof(int), -1, rank, hash), ret, exit);
 exit:
   NCCLCHECK(ncclIpcSocketClose(&ipcSock));
@@ -1563,18 +1639,18 @@ exit:
 }
 
 // cuMem API support
-static ncclResult_t proxyGetFd(struct ncclProxyState* proxyState, int rank, void *opId,
+static ncclResult_t proxyGetFd(struct ncclProxyState* proxyState, int rank, void* opId,
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-  hipMemGenericAllocationHandle_t handle
+                               hipMemGenericAllocationHandle_t handle
 #else
-   uint64_t handle
+                               uint64_t handle
 #endif
 ) {
 #if ROCM_VERSION >= 70000
   // cuMem API support
   ncclResult_t ret = ncclSuccess;
-  struct ncclIpcSocket ipcSock = { 0 };
-  uint64_t hash = (uint64_t) opId;
+  struct ncclIpcSocket ipcSock = {0};
+  uint64_t hash = (uint64_t)opId;
   INFO(NCCL_PROXY, "UDS proxyGetFd received handle 0x%" PRIxPTR " peer %d opId %lx", (uintptr_t)handle, rank, hash);
 
   CUmemAllocationHandleType type = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
@@ -1582,7 +1658,7 @@ static ncclResult_t proxyGetFd(struct ncclProxyState* proxyState, int rank, void
 
   CUCHECK(cuMemExportToShareableHandle(&fd, handle, type, 0));
   // Send back the converted fd using UDS
-  NCCLCHECKGOTO(ncclIpcSocketInit(&ipcSock, proxyState->tpRank, hash^1, proxyState->abortFlag), ret, error);
+  NCCLCHECKGOTO(ncclIpcSocketInit(&ipcSock, proxyState->tpRank, hash ^ 1, proxyState->abortFlag), ret, error);
   NCCLCHECKGOTO(ncclIpcSocketSendFd(&ipcSock, fd, rank, hash), ret, error);
 error:
   NCCLCHECK(ncclIpcSocketClose(&ipcSock));
@@ -1594,39 +1670,53 @@ error:
 #endif
 }
 
-static ncclResult_t proxyProgressAsync(struct ncclProxyAsyncOp* op, struct ncclProxyState* proxyState, int* asyncOpCount, struct ncclProxyLocalPeer* peer, struct ncclProxyConnectionPool* connectionPool) {
+static ncclResult_t proxyProgressAsync(struct ncclProxyAsyncOp* op, struct ncclProxyState* proxyState,
+                                       int* asyncOpCount, struct ncclProxyLocalPeer* peer,
+                                       struct ncclProxyConnectionPool* connectionPool) {
   int done = 1;
   ncclResult_t res = ncclInternalError;
   if (op->type == ncclProxyMsgSetup) {
     TRACE(NCCL_PROXY, "proxyProgressAsync::proxySetup() opId=%p", op->opId);
-    res = op->connection->tcomm->proxySetup(op->connection, proxyState, op->reqBuff, op->reqSize, op->respBuff, op->respSize, &done);
+    res = op->connection->tcomm->proxySetup(op->connection, proxyState, op->reqBuff, op->reqSize, op->respBuff,
+                                            op->respSize, &done);
   } else if (op->type == ncclProxyMsgConnect) {
     TRACE(NCCL_PROXY, "proxyProgressAsync::proxyConnect() opId=%p op.reqBuff=%p", op->opId, op->reqBuff);
-    res = op->connection->tcomm->proxyConnect(op->connection, proxyState, op->reqBuff, op->reqSize, op->respBuff, op->respSize, &done);
+    res = op->connection->tcomm->proxyConnect(op->connection, proxyState, op->reqBuff, op->reqSize, op->respBuff,
+                                              op->respSize, &done);
   } else if (op->type == ncclProxyMsgSharedInit) {
-    int nChannels = *((int*) op->reqBuff);
+    int nChannels = *((int*)op->reqBuff);
 
-    TRACE(NCCL_PROXY, "proxyProgressAsync::ncclProxyMsgSharedInit opId=%p op.reqBuff=%p nChannels=%d", op->opId, op->reqBuff, nChannels);
-    if (op->connection->tcomm->proxySharedInit) res = op->connection->tcomm->proxySharedInit(op->connection, proxyState, nChannels);
-    COMPILER_ATOMIC_STORE(&op->connection->state, static_cast<proxyConnectState>(connSharedInitialized), std::memory_order_release);
-  }
-  else if (op->type == ncclProxyMsgInit) {
+    TRACE(NCCL_PROXY, "proxyProgressAsync::ncclProxyMsgSharedInit opId=%p op.reqBuff=%p nChannels=%d", op->opId,
+          op->reqBuff, nChannels);
+    if (op->connection->tcomm->proxySharedInit)
+      res = op->connection->tcomm->proxySharedInit(op->connection, proxyState, nChannels);
+    COMPILER_ATOMIC_STORE(&op->connection->state, static_cast<proxyConnectState>(connSharedInitialized),
+                          std::memory_order_release);
+  } else if (op->type == ncclProxyMsgInit) {
     TRACE(NCCL_PROXY, "proxyProgressAsync::ncclProxyMsgInit opId=%p op.reqBuff=%p", op->opId, op->reqBuff);
-    res = proxyConnInit(peer, connectionPool, proxyState, (ncclProxyInitReq*) op->reqBuff, (ncclProxyInitResp*) op->respBuff, &op->connection);
+    res = proxyConnInit(peer, connectionPool, proxyState, (ncclProxyInitReq*)op->reqBuff,
+                        (ncclProxyInitResp*)op->respBuff, &op->connection);
   } else if (op->type == ncclProxyMsgRegister) {
-    TRACE(NCCL_PROXY, "proxyProgressAsync::ncclProxyMsgRegister opId=%p op.reqBuff=%p, op->reqSize=%d, op->respSize=%d", op->opId, op->reqBuff, op->reqSize, op->respSize);
-    res = op->connection->tcomm->proxyRegister(op->connection, proxyState, op->reqBuff, op->reqSize, op->respBuff, op->respSize, &done);
+    TRACE(NCCL_PROXY, "proxyProgressAsync::ncclProxyMsgRegister opId=%p op.reqBuff=%p, op->reqSize=%d, op->respSize=%d",
+          op->opId, op->reqBuff, op->reqSize, op->respSize);
+    res = op->connection->tcomm->proxyRegister(op->connection, proxyState, op->reqBuff, op->reqSize, op->respBuff,
+                                               op->respSize, &done);
   } else if (op->type == ncclProxyMsgDeregister) {
-    TRACE(NCCL_PROXY, "proxyProgressAsync::ncclProxyMsgDeregister opId=%p op.reqBuff=%p, op->reqSize=%d, op->respSize=%d", op->opId, op->reqBuff, op->reqSize, op->respSize);
+    TRACE(NCCL_PROXY,
+          "proxyProgressAsync::ncclProxyMsgDeregister opId=%p op.reqBuff=%p, op->reqSize=%d, op->respSize=%d", op->opId,
+          op->reqBuff, op->reqSize, op->respSize);
     res = op->connection->tcomm->proxyDeregister(op->connection, proxyState, op->reqBuff, op->reqSize, &done);
   } else return ncclInternalError;
 
   if (done) {
-    INFO(NCCL_PROXY, "proxyProgressAsync opId=%p op.type=%d op.reqBuff=%p op.respSize=%d done", op->opId, op->type, op->reqBuff, op->respSize);
+    INFO(NCCL_PROXY, "proxyProgressAsync opId=%p op.type=%d op.reqBuff=%p op.respSize=%d done", op->opId, op->type,
+         op->reqBuff, op->respSize);
     if (op->type == ncclProxyMsgSetup)
-      COMPILER_ATOMIC_STORE(&op->connection->state, static_cast<proxyConnectState>(connSetupDone), std::memory_order_release);
+      COMPILER_ATOMIC_STORE(&op->connection->state, static_cast<proxyConnectState>(connSetupDone),
+                            std::memory_order_release);
     else if (op->type == ncclProxyMsgConnect)
-      COMPILER_ATOMIC_STORE(&op->connection->state, static_cast<proxyConnectState>(connConnected), std::memory_order_release);
+      COMPILER_ATOMIC_STORE(&op->connection->state, static_cast<proxyConnectState>(connConnected),
+                            std::memory_order_release);
     /* if setup or connect is done, we should not return any error at this point since
      * ncclSocketSend might already send the respBuff to the requester. If we still choose
      * to abort and close the connection, it can cause segfault if the requester is using
@@ -1653,7 +1743,9 @@ static ncclResult_t proxyProgressAsync(struct ncclProxyAsyncOp* op, struct ncclP
   return ncclInProgress;
 }
 
-static ncclResult_t proxyServiceInitOp(int type, struct ncclProxyLocalPeer* peer, struct ncclProxyConnectionPool* connectionPool, struct ncclProxyState* proxyState, int* asyncOpCount) {
+static ncclResult_t proxyServiceInitOp(int type, struct ncclProxyLocalPeer* peer,
+                                       struct ncclProxyConnectionPool* connectionPool,
+                                       struct ncclProxyState* proxyState, int* asyncOpCount) {
   ncclResult_t ret = ncclSuccess;
   struct ncclSocket* sock = &peer->sock;
   struct ncclProxyAsyncOp* asyncOp;
@@ -1702,16 +1794,16 @@ fail:
 
 static bool proxyMatchOpType(int type) {
   switch (type) {
-    case ncclProxyMsgInit:
-    case ncclProxyMsgSharedInit:
-    case ncclProxyMsgSetup:
-    case ncclProxyMsgConnect:
-    case ncclProxyMsgGetFd:
-    case ncclProxyMsgRegister:
-    case ncclProxyMsgDeregister:
-      return true;
-    default:
-      return false;
+  case ncclProxyMsgInit:
+  case ncclProxyMsgSharedInit:
+  case ncclProxyMsgSetup:
+  case ncclProxyMsgConnect:
+  case ncclProxyMsgGetFd:
+  case ncclProxyMsgRegister:
+  case ncclProxyMsgDeregister:
+    return true;
+  default:
+    return false;
   }
 }
 
@@ -1722,7 +1814,7 @@ enum {
 };
 
 void* ncclProxyService(void* _args) {
-  struct ncclProxyState* proxyState =  (struct ncclProxyState*) _args;
+  struct ncclProxyState* proxyState = (struct ncclProxyState*)_args;
   // set the thread affinity before setting the cuda context
   std::call_once(proxyCpusetOnceFlag, proxyCpusetOnceFunc);
   if (ncclOsCpuCount(proxyCpuset)) ncclOsSetAffinity(proxyCpuset);
@@ -1753,7 +1845,7 @@ void* ncclProxyService(void* _args) {
   NCCLCHECKGOTO(ncclCalloc(&peers, maxProxyConnections), ret, fail);
   for (int s = 0; s < maxProxyConnections; s++) {
     pollfds[s].fd = NCCL_INVALID_SOCKET;
-    pollfds[s].events = POLLHUP|POLLIN;
+    pollfds[s].events = POLLHUP | POLLIN;
   }
   NCCLCHECKGOTO(ncclSocketGetFd(proxyState->listenSock, &pollfds[maxProxyConnections].fd), ret, fail);
 
@@ -1761,7 +1853,7 @@ void* ncclProxyService(void* _args) {
   pollfds[maxProxyConnections].revents = 0;
 
   // Initialize peer sockets starting at index 1
-  for (int s=0; s<maxProxyConnections; s++) {
+  for (int s = 0; s < maxProxyConnections; s++) {
     pollfds[s].fd = NCCL_INVALID_SOCKET;
     pollfds[s].events = NCCL_POLLIN;
     pollfds[s].revents = 0;
@@ -1769,7 +1861,7 @@ void* ncclProxyService(void* _args) {
 
   // RCCL: log the proxy listening socket address (diagnostic).
   {
-    char line[SOCKET_NAME_MAXLEN+1];
+    char line[SOCKET_NAME_MAXLEN + 1];
     INFO(NCCL_INIT, "proxy listening socket at %s", ncclSocketToString(&proxyState->listenSock->addr, line));
   }
 
@@ -1811,10 +1903,10 @@ void* ncclProxyService(void* _args) {
         WARN("[Proxy service] Too many connections (%d max)", maxProxyConnections);
         goto fail;
       }
-      if (maxnpeers < s+1) maxnpeers = s+1;
+      if (maxnpeers < s + 1) maxnpeers = s + 1;
       NCCLCHECKGOTO(ncclSocketInit(&peers[s].sock), ret, fail);
       // RCCL: retryOnBadMagic=false so a stray/bad-magic connection can't hang the single-threaded proxy poll loop.
-      if (ncclSocketAccept(&peers[s].sock, proxyState->listenSock, /*retryOnBadMagic*/false) != ncclSuccess) {
+      if (ncclSocketAccept(&peers[s].sock, proxyState->listenSock, /*retryOnBadMagic*/ false) != ncclSuccess) {
         INFO(NCCL_PROXY, "[Service thread] Accept failed %s", strerror(errno));
       } else {
         NCCLCHECKGOTO(ncclSocketGetFd(&peers[s].sock, &pollfds[s].fd), ret, fail);
@@ -1829,8 +1921,8 @@ void* ncclProxyService(void* _args) {
         }
       }
     }
-    for (int s=0; s<maxnpeers; s++) {
-      struct ncclProxyLocalPeer* peer = peers+s;
+    for (int s = 0; s < maxnpeers; s++) {
+      struct ncclProxyLocalPeer* peer = peers + s;
       struct ncclSocket* sock = &peer->sock;
       int closeConn = 0;
       int type = 0;
@@ -1838,7 +1930,9 @@ void* ncclProxyService(void* _args) {
       if (pollfds[s].fd == NCCL_INVALID_SOCKET) continue;
 
       // Progress all ops for this ncclProxyLocalPeer
-      if (stop == PROXY_ABORT && ncclCuMemEnable() && ncclCuMemHostEnable() && !proxyState->directMode && COMPILER_ATOMIC_LOAD(&proxyState->stop, std::memory_order_acquire)) closeConn = 1;
+      if (stop == PROXY_ABORT && ncclCuMemEnable() && ncclCuMemHostEnable() && !proxyState->directMode &&
+          COMPILER_ATOMIC_LOAD(&proxyState->stop, std::memory_order_acquire))
+        closeConn = 1;
       ncclProxyAsyncOp* op = peer->asyncOps;
       while (op != nullptr) {
         ncclProxyAsyncOp* opnext = op->next; /* in case op is freed in proxyProgressAsync */
@@ -1852,7 +1946,8 @@ void* ncclProxyService(void* _args) {
         } else {
           // Res is a bad result
           closeConn = 1;
-          WARN("[Service thread] Error encountered progressing operation=%s, res=%d, closing connection", ncclProxyMsgTypeStr[type], res);
+          WARN("[Service thread] Error encountered progressing operation=%s, res=%d, closing connection",
+               ncclProxyMsgTypeStr[type], res);
           break;
         }
       }
@@ -1864,10 +1959,12 @@ void* ncclProxyService(void* _args) {
         res = ncclSocketTryRecv(sock, &type, sizeof(int), &closed, false /*blocking*/);
         if (res != ncclSuccess && res != ncclInProgress) {
           if (!COMPILER_ATOMIC_LOAD(proxyState->abortFlag, std::memory_order_relaxed))
-            WARN("[Service thread] Could not receive type from localRank %d, res=%u, closed=%d", peer->tpLocalRank, res, closed);
+            WARN("[Service thread] Could not receive type from localRank %d, res=%u, closed=%d", peer->tpLocalRank, res,
+                 closed);
           closeConn = 1;
         } else if (closed) {
-          INFO(NCCL_DESTROY|NCCL_NET|NCCL_PROXY, "[Service thread] Connection closed by localRank %d", peer->tpLocalRank);
+          INFO(NCCL_DESTROY | NCCL_NET | NCCL_PROXY, "[Service thread] Connection closed by localRank %d",
+               peer->tpLocalRank);
           closeConn = 1;
         } else if (res == ncclSuccess) { // We received something from the sock
           if (type == ncclProxyMsgStop) {
@@ -1876,7 +1973,7 @@ void* ncclProxyService(void* _args) {
           } else if (type == ncclProxyMsgClose) {
             closeConn = 1;
           } else if (proxyMatchOpType(type)) {
-            res = proxyServiceInitOp(type, peers+s, &connectionPool, proxyState, &asyncOpCount);
+            res = proxyServiceInitOp(type, peers + s, &connectionPool, proxyState, &asyncOpCount);
           } else {
             WARN("[Service thread] Unknown command %d from localRank %d", type, peer->tpLocalRank);
             closeConn = 1;
@@ -1885,13 +1982,14 @@ void* ncclProxyService(void* _args) {
           INFO(NCCL_PROXY, "Received and initiated operation=%s res=%d", ncclProxyMsgTypeStr[type], res);
         }
 
-      // Check for socket error conditions
+        // Check for socket error conditions
       } else if (pollfds[s].revents & NCCL_POLLERR) {
         closeConn = 1;
       }
       if (res != ncclSuccess && res != ncclInProgress) {
         if (!COMPILER_ATOMIC_LOAD(proxyState->abortFlag, std::memory_order_relaxed))
-          WARN("[Proxy Service %d] Failed to execute operation %s from rank %d, retcode %d", proxyState->tpRank, ncclProxyMsgTypeStr[type], peer->tpRank, res);
+          WARN("[Proxy Service %d] Failed to execute operation %s from rank %d, retcode %d", proxyState->tpRank,
+               ncclProxyMsgTypeStr[type], peer->tpRank, res);
         closeConn = 1;
       }
 
@@ -1903,7 +2001,7 @@ void* ncclProxyService(void* _args) {
           asyncOpCount--;
         }
         pollfds[s].fd = NCCL_INVALID_SOCKET;
-        pollfds[s].events = 0;  // Clear events for invalid socket descriptors on Windows
+        pollfds[s].events = 0; // Clear events for invalid socket descriptors on Windows
         npeers--;
       }
 
@@ -1922,7 +2020,7 @@ void* ncclProxyService(void* _args) {
   if (ncclProxyProgressDestroy(proxyState) != ncclSuccess) {
     WARN("[Proxy Service] proxyDestroy failed");
   }
-  for (int s=0; s<maxnpeers; s++) {
+  for (int s = 0; s < maxnpeers; s++) {
     (void)ncclSocketClose(&peers[s].sock);
   }
   ncclProxyFreeConnections(&connectionPool, proxyState);
@@ -1934,7 +2032,6 @@ fail:
   free(peers);
   return NULL;
 }
-
 
 // Process a request on the UDS socket
 static ncclResult_t proxyUDSRecvReq(struct ncclProxyState* proxyState, int reqFd) {
@@ -1951,7 +2048,8 @@ static ncclResult_t proxyUDSRecvReq(struct ncclProxyState* proxyState, int reqFd
 #else
     uint64_t handle = *(uint64_t*)hdr.data;
 #endif
-    INFO(NCCL_PROXY, "proxyUDSRecvReq::ncclProxyMsgGetFd rank %d opId %p handle=0x%" PRIxPTR, hdr.rank, hdr.opId, reinterpret_cast<uintptr_t>(handle));
+    INFO(NCCL_PROXY, "proxyUDSRecvReq::ncclProxyMsgGetFd rank %d opId %p handle=0x%" PRIxPTR, hdr.rank, hdr.opId,
+         reinterpret_cast<uintptr_t>(handle));
     close(rmtFd);
     return proxyGetFd(proxyState, hdr.rank, hdr.opId, handle);
   } else if (hdr.type == ncclProxyMsgQueryFd) {
@@ -1967,7 +2065,7 @@ static ncclResult_t proxyUDSRecvReq(struct ncclProxyState* proxyState, int reqFd
 
 // UDS fd handle support
 void* ncclProxyServiceUDS(void* _args) {
-  struct ncclProxyState* proxyState =  (struct ncclProxyState*) _args;
+  struct ncclProxyState* proxyState = (struct ncclProxyState*)_args;
   struct pollfd pollfds[1];
 
   // set the thread affinity before setting the cuda context
@@ -1989,7 +2087,7 @@ void* ncclProxyServiceUDS(void* _args) {
     }
     pollfds[0].fd = (decltype(pollfds[0].fd))ipcFd;
   }
-  pollfds[0].events = POLLIN|POLLHUP;
+  pollfds[0].events = POLLIN | POLLHUP;
 
   while (1) {
     /* never let proxy service thread blocks in poll, or it cannot receive abortFlag. */
@@ -2018,7 +2116,9 @@ void* ncclProxyServiceUDS(void* _args) {
 #endif
 
     // Check for stop/abort
-    if (COMPILER_ATOMIC_LOAD(&proxyState->stop, std::memory_order_acquire) || COMPILER_ATOMIC_LOAD(proxyState->abortFlag, std::memory_order_acquire)) break;
+    if (COMPILER_ATOMIC_LOAD(&proxyState->stop, std::memory_order_acquire) ||
+        COMPILER_ATOMIC_LOAD(proxyState->abortFlag, std::memory_order_acquire))
+      break;
 
     if (pollfds[0].revents) {
       // A request was seen on the UDS fd
@@ -2031,7 +2131,8 @@ void* ncclProxyServiceUDS(void* _args) {
   return NULL;
 }
 
-ncclResult_t ncclProxyInit(struct ncclComm* comm, struct ncclSocket* sock, union ncclSocketAddress* peerAddresses, uint64_t *peerAddressesUDS) {
+ncclResult_t ncclProxyInit(struct ncclComm* comm, struct ncclSocket* sock, union ncclSocketAddress* peerAddresses,
+                           uint64_t* peerAddressesUDS) {
   assert(comm->sharedRes->proxyState == nullptr);
   comm->sharedRes->proxyState = new ncclProxyState{};
   comm->proxyState = comm->sharedRes->proxyState;
@@ -2056,7 +2157,7 @@ ncclResult_t ncclProxyCreate(struct ncclComm* comm) {
   if (proxyState->refCount == 1) {
     /* we have to make sure all following fields in comm have been initialized. */
     proxyState->comm = comm;
-    proxyState->memManager = comm->memManager;  // Set shared memory manager for proxy allocations
+    proxyState->memManager = comm->memManager; // Set shared memory manager for proxy allocations
     proxyState->tpRank = comm->rank;
     proxyState->tpnRanks = comm->nRanks;
     proxyState->tpLocalnRanks = comm->localRanks;
@@ -2075,7 +2176,7 @@ ncclResult_t ncclProxyCreate(struct ncclComm* comm) {
     proxyState->profilerContext = comm->profilerContext;
     proxyState->directMode = comm->directMode;
     memcpy(proxyState->buffSizes, comm->buffSizes, sizeof(comm->buffSizes));
-    // [RCCL] Host side mirrors of device side NCCL_LL128_LINEELEMS & NCCL_LL128_DATAELEMS 
+    // [RCCL] Host side mirrors of device side NCCL_LL128_LINEELEMS & NCCL_LL128_DATAELEMS
     proxyState->ll128LineElems = comm->ll128LineElems;
     proxyState->ll128DataElems = comm->ll128DataElems;
 
@@ -2099,7 +2200,8 @@ ncclResult_t ncclProxyStop(struct ncclComm* comm) {
         // We need to send a ncclProxyMsgStop message to our own proxy
         struct ncclSocket sock;
         int type = ncclProxyMsgStop;
-        NCCLCHECK(ncclSocketInit(&sock, sharedProxyState->peerAddresses + comm->topParentRanks[comm->rank], comm->sharedRes->magic, ncclSocketTypeProxy, comm->abortFlag));
+        NCCLCHECK(ncclSocketInit(&sock, sharedProxyState->peerAddresses + comm->topParentRanks[comm->rank],
+                                 comm->sharedRes->magic, ncclSocketTypeProxy, comm->abortFlag));
         if (ncclSocketConnect(&sock) == ncclSuccess) {
           (void)ncclSocketSend(&sock, &type, sizeof(int));
         }

--- a/projects/rccl/src/ras/client.cc
+++ b/projects/rccl/src/ras/client.cc
@@ -45,51 +45,53 @@ static void printUsage(const char* argv0) {
           "                      combinations like lifecycle,trace (lifecycle by default)\n"
           "  -p, --port=PORT     TCP port of the RAS client socket of the NCCL job\n"
           "                      (" STR(NCCL_RAS_CLIENT_PORT) " by default)\n"
-          "  -t, --timeout=SECS  Maximum time for the local NCCL process to wait for\n"
-          "                      responses from other NCCL processes\n"
-          "                      (" STR(RAS_COLLECTIVE_LEG_TIMEOUT_SEC) " secs by default; 0 disables the timeout)\n"
-          "  -v, --verbose       Increase the verbosity level of the RAS output\n"
-          "      --help          Print this help and exit\n"
-          "      --version       Print the version number and exit\n", argv0);
+                                  "  -t, --timeout=SECS  Maximum time for the local NCCL process to wait for\n"
+                                  "                      responses from other NCCL processes\n"
+                                  "                      (" STR(RAS_COLLECTIVE_LEG_TIMEOUT_SEC) " secs by default; 0 disables the timeout)\n"
+                                                                    "  -v, --verbose       Increase the verbosity "
+                                                                    "level of the RAS output\n"
+                                                                    "      --help          Print this help and exit\n"
+                                                                    "      --version       Print the version number "
+                                                                    "and exit\n",
+                                    argv0);
 }
 
 static void parseArgs(int argc, char** argv) {
   int c;
   int optIdx = 0;
-  struct option longOpts[] = {
-    {"format",  required_argument, NULL, 'f'},
-    {"help",    no_argument,       NULL, 'e'},
-    {"host",    required_argument, NULL, 'h'},
-    {"monitor", optional_argument, NULL, 'm'},
-    {"port",    required_argument, NULL, 'p'},
-    {"timeout", required_argument, NULL, 't'},
-    {"verbose", no_argument,       NULL, 'v'},
-    {"version", no_argument,       NULL, 'r'},
-    {0}
-  };
+  struct option longOpts[] = {{"format", required_argument, NULL, 'f'},
+                              {"help", no_argument, NULL, 'e'},
+                              {"host", required_argument, NULL, 'h'},
+                              {"monitor", optional_argument, NULL, 'm'},
+                              {"port", required_argument, NULL, 'p'},
+                              {"timeout", required_argument, NULL, 't'},
+                              {"verbose", no_argument, NULL, 'v'},
+                              {"version", no_argument, NULL, 'r'},
+                              {0}};
 
   while ((c = getopt_long(argc, argv, "f:h:m::p:t:v", longOpts, &optIdx)) != -1) {
     switch (c) {
-      case 'f':
-        format = optarg;
-        if (strcasecmp(format, "text") != 0 && strcasecmp(format, "json") != 0) {
-          fprintf(stderr, "Invalid format: %s (must be text or json)\n", format);
-          exit(1);
-        }
-        break;
-      case 'h':
-        hostName = optarg;
-        break;
-      case 'm':
-        monitorMode = true;
-        if (optarg) {
-          events = optarg;
-        }
-        break;
-      case 'p':
-        port = optarg;
-        break;
-      case 't': {
+    case 'f':
+      format = optarg;
+      if (strcasecmp(format, "text") != 0 && strcasecmp(format, "json") != 0) {
+        fprintf(stderr, "Invalid format: %s (must be text or json)\n", format);
+        exit(1);
+      }
+      break;
+    case 'h':
+      hostName = optarg;
+      break;
+    case 'm':
+      monitorMode = true;
+      if (optarg) {
+        events = optarg;
+      }
+      break;
+    case 'p':
+      port = optarg;
+      break;
+    case 't':
+      {
         char* endPtr = nullptr;
         timeout = strtol(optarg, &endPtr, 10);
         if (timeout < 0 || !endPtr || *endPtr != '\0') {
@@ -98,19 +100,19 @@ static void parseArgs(int argc, char** argv) {
         }
         break;
       }
-      case 'v':
-        verbose = true;
-        break;
-      case 'e':
-        printUsage(argv[0]);
-        exit(0);
-      case 'r':
-        fprintf(stderr, "RCCL RAS client version " STR(NCCL_MAJOR) "." STR(NCCL_MINOR) "."
-                STR(NCCL_PATCH) NCCL_SUFFIX "\n");
-        exit(0);
-      default:
-        printUsage(argv[0]);
-        exit(1);
+    case 'v':
+      verbose = true;
+      break;
+    case 'e':
+      printUsage(argv[0]);
+      exit(0);
+    case 'r':
+      fprintf(stderr,
+              "RCCL RAS client version " STR(NCCL_MAJOR) "." STR(NCCL_MINOR) "." STR(NCCL_PATCH) NCCL_SUFFIX "\n");
+      exit(0);
+    default:
+      printUsage(argv[0]);
+      exit(1);
     }
   }
 }
@@ -119,10 +121,9 @@ static ssize_t socketWrite(int fd, const void* buf, size_t count) {
   size_t done = 0;
   do {
     ssize_t ret;
-    ret = write(fd, ((const char*)buf)+done, count-done);
+    ret = write(fd, ((const char*)buf) + done, count - done);
     if (ret == -1) {
-      if (errno != EINTR)
-        return -1;
+      if (errno != EINTR) return -1;
       continue;
     }
     done += ret;
@@ -139,16 +140,14 @@ static ssize_t rasRead(int fd, void* buf, size_t count, bool untilNewline = true
   size_t done = 0;
   do {
     ssize_t ret;
-    ret = read(fd, bufChar+done, count-1-done);
+    ret = read(fd, bufChar + done, count - 1 - done);
     if (ret == -1) {
-      if (errno != EINTR)
-        return -1;
+      if (errno != EINTR) return -1;
       continue;
     }
-    if (ret == 0)
-      break; // EOF
+    if (ret == 0) break; // EOF
     done += ret;
-  } while (untilNewline && (done == 0 || bufChar[done-1] != '\n'));
+  } while (untilNewline && (done == 0 || bufChar[done - 1] != '\n'));
   bufChar[done] = '\0';
 
   return done;
@@ -191,8 +190,7 @@ retry:
         // Non-fatal; fall through.
       }
     }
-    if (connect(sock, ai->ai_addr, ai->ai_addrlen) == 0)
-      break;
+    if (connect(sock, ai->ai_addr, ai->ai_addrlen) == 0) break;
     err = errno;
     if (getnameinfo(ai->ai_addr, ai->ai_addrlen, hostBuf, sizeof(hostBuf), portBuf, sizeof(portBuf),
                     NI_NUMERICHOST | NI_NUMERICSERV) != 0) {
@@ -207,12 +205,14 @@ retry:
   addrInfo = nullptr;
 
   if (sock == -1) {
-    fprintf(stderr, "Failed to connect to the NCCL RAS service!\n"
+    fprintf(stderr,
+            "Failed to connect to the NCCL RAS service!\n"
             "Please make sure that the NCCL job has the RAS service enabled and that\n"
             "%s.\n",
-            (strcmp(hostName, "localhost") || strcmp(port, STR(NCCL_RAS_CLIENT_PORT)) ?
-            "the host/port arguments are correct and match NCCL_RAS_ADDR" :
-            "the RAS client was started on a node where the NCCL job is running"));
+            (strcmp(hostName, "localhost") ||
+             strcmp(port, STR(NCCL_RAS_CLIENT_PORT)) ?
+                    "the host/port arguments are correct and match NCCL_RAS_ADDR" :
+                    "the RAS client was started on a node where the NCCL job is running"));
     goto fail;
   }
 
@@ -241,9 +241,11 @@ retry:
     fprintf(stderr, "Unexpected response from NCCL: %s\n", msgBuf);
     goto fail;
   }
-  if (strtol(msgBuf+strlen("SERVER PROTOCOL "), nullptr, 10) != NCCL_RAS_CLIENT_PROTOCOL) {
-    fprintf(stderr, "NCCL RAS protocol version mismatch (NCCL: %s; RAS client: %d)!\n"
-            "Will try to continue in spite of that...\n", msgBuf+strlen("SERVER PROTOCOL "), NCCL_RAS_CLIENT_PROTOCOL);
+  if (strtol(msgBuf + strlen("SERVER PROTOCOL "), nullptr, 10) != NCCL_RAS_CLIENT_PROTOCOL) {
+    fprintf(stderr,
+            "NCCL RAS protocol version mismatch (NCCL: %s; RAS client: %d)!\n"
+            "Will try to continue in spite of that...\n",
+            msgBuf + strlen("SERVER PROTOCOL "), NCCL_RAS_CLIENT_PROTOCOL);
   }
 
   if (timeout >= 0) {
@@ -275,9 +277,9 @@ retry:
   if (timeout) {
     // Increase the socket timeout to accommodate NCCL timeout.
     tv.tv_sec += (timeout > 0 ? timeout : RAS_COLLECTIVE_LEG_TIMEOUT_SEC) + RAS_COLLECTIVE_EXTRA_TIMEOUT_SEC;
-#if defined (NCCL_OS_LINUX)
+#if defined(NCCL_OS_LINUX)
     if (setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof tv) != 0) {
-#elif defined (NCCL_OS_WINDOWS)
+#elif defined(NCCL_OS_WINDOWS)
     DWORD timeout_ms = tv.tv_sec * 1000 + tv.tv_usec / 1000;
     if (setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const char*)&timeout_ms, sizeof(timeout_ms)) != 0) {
 #endif
@@ -288,10 +290,8 @@ retry:
 
   return 0;
 fail:
-  if (addrInfo)
-    freeaddrinfo(addrInfo);
-  if (sock != -1)
-    (void)close(sock);
+  if (addrInfo) freeaddrinfo(addrInfo);
+  if (sock != -1) (void)close(sock);
   return 1;
 timeout:
   fprintf(stderr, "Connection timed out; retrying...\n");
@@ -307,19 +307,15 @@ static int setOutputFormat() {
   if (format) {
     snprintf(msgBuf, sizeof(msgBuf), "SET FORMAT %s\n", format);
     if (socketWrite(sock, msgBuf, strlen(msgBuf)) != strlen(msgBuf)) {
-      if (errno == EAGAIN || errno == EWOULDBLOCK)
-        fprintf(stderr, "Connection timed out\n");
-      else
-        perror("write to socket");
+      if (errno == EAGAIN || errno == EWOULDBLOCK) fprintf(stderr, "Connection timed out\n");
+      else perror("write to socket");
       return 1;
     }
     // Read response.
     bytes = rasRead(sock, msgBuf, sizeof(msgBuf));
     if (bytes < 0) {
-      if (errno == EAGAIN || errno == EWOULDBLOCK)
-        fprintf(stderr, "Connection timed out\n");
-      else
-        perror("read socket");
+      if (errno == EAGAIN || errno == EWOULDBLOCK) fprintf(stderr, "Connection timed out\n");
+      else perror("read socket");
       return 1;
     }
     if (bytes == 0) {
@@ -341,19 +337,15 @@ static int getNCCLStatus() {
   // Send the status command.
   snprintf(msgBuf, sizeof(msgBuf), "%sSTATUS\n", (verbose ? "VERBOSE " : ""));
   if (socketWrite(sock, msgBuf, strlen(msgBuf)) != strlen(msgBuf)) {
-    if (errno == EAGAIN || errno == EWOULDBLOCK)
-      fprintf(stderr, "Connection timed out\n");
-    else
-      perror("write to socket");
+    if (errno == EAGAIN || errno == EWOULDBLOCK) fprintf(stderr, "Connection timed out\n");
+    else perror("write to socket");
     return 1;
   }
   for (;;) {
-    bytes = rasRead(sock, msgBuf, sizeof(msgBuf), /*untileNewLine*/false);
+    bytes = rasRead(sock, msgBuf, sizeof(msgBuf), /*untileNewLine*/ false);
     if (bytes < 0) {
-      if (errno == EAGAIN || errno == EWOULDBLOCK)
-        fprintf(stderr, "Connection timed out\n");
-      else
-        perror("read socket");
+      if (errno == EAGAIN || errno == EWOULDBLOCK) fprintf(stderr, "Connection timed out\n");
+      else perror("read socket");
       return 1;
     }
     if (bytes == 0) // EOF
@@ -382,20 +374,16 @@ static int monitorNCCLEvents() {
     snprintf(msgBuf, sizeof(msgBuf), "MONITOR\n");
   }
   if (socketWrite(sock, msgBuf, strlen(msgBuf)) != strlen(msgBuf)) {
-    if (errno == EAGAIN || errno == EWOULDBLOCK)
-      fprintf(stderr, "Connection timed out\n");
-    else
-      perror("Failed to send monitor command");
+    if (errno == EAGAIN || errno == EWOULDBLOCK) fprintf(stderr, "Connection timed out\n");
+    else perror("Failed to send monitor command");
     return 1;
   }
 
   // Wait for initial response confirming monitor mode is activated.
   bytes = rasRead(sock, msgBuf, sizeof(msgBuf));
   if (bytes < 0) {
-    if (errno == EAGAIN || errno == EWOULDBLOCK)
-      fprintf(stderr, "Connection timed out\n");
-    else
-      perror("read socket");
+    if (errno == EAGAIN || errno == EWOULDBLOCK) fprintf(stderr, "Connection timed out\n");
+    else perror("read socket");
     return 1;
   }
   if (bytes == 0) {
@@ -465,8 +453,7 @@ static int monitorNCCLEvents() {
 int main(int argc, char** argv) {
   parseArgs(argc, argv);
 
-  if (connectToNCCL())
-    return 1;
+  if (connectToNCCL()) return 1;
 
   // Set the output format.
   if (setOutputFormat() != 0) {

--- a/projects/rccl/src/ras/client_support.cc
+++ b/projects/rccl/src/ras/client_support.cc
@@ -105,14 +105,13 @@ static int rasOutBufferSize = 0;
 
 // We use them all over the place; no point in wasting the stack...
 static char lineBuf[1024]; // Temporary buffer used for printing at most 10 (RAS_CLIENT_DETAIL_THRESHOLD) rank numbers
-                           // or for printing the local GPU devices, which can't be more than 64
-                           // small numbers (times two if the NVML mask is different than the CUDA mask).
-                           // Still, 1024 should normally be plenty (verbose output may make things more difficult,
-                           // but we do check for overflows, so it will just be trimmed).
+// or for printing the local GPU devices, which can't be more than 64
+// small numbers (times two if the NVML mask is different than the CUDA mask).
+// Still, 1024 should normally be plenty (verbose output may make things more difficult,
+// but we do check for overflows, so it will just be trimmed).
 
 // CUDA version information - shared across functions.
 static int cudaDriverVersion = -1, cudaRuntimeVersion = -1;
-
 
 static ncclResult_t getNewClientEntry(struct rasClient** pClient);
 static void rasClientEnqueueMsg(struct rasClient* client, char* msg, size_t msgLen);
@@ -122,10 +121,10 @@ static ncclResult_t rasClientRun(struct rasClient* client);
 static ncclResult_t rasClientRunInit(struct rasClient* client);
 static ncclResult_t rasClientRunConns(struct rasClient* client);
 static ncclResult_t rasClientRunComms(struct rasClient* client);
-static void rasClientBreakDownErrors(struct rasClient* client, struct rasCollComms::comm* comm,
-                                     const int* peerIdxConv, int ncclErrors[ncclNumResults], bool isAsync = false);
+static void rasClientBreakDownErrors(struct rasClient* client, struct rasCollComms::comm* comm, const int* peerIdxConv,
+                                     int ncclErrors[ncclNumResults], bool isAsync = false);
 
-static void rasOutAppend(const char* format, ...) __attribute__ ((format(printf, 1, 2)));
+static void rasOutAppend(const char* format, ...) __attribute__((format(printf, 1, 2)));
 static void rasOutExtract(char* buffer);
 static int rasOutLength();
 static void rasOutReset();
@@ -142,21 +141,20 @@ static const char* ncclErrorToString(ncclResult_t err);
 static bool rasCountIsOutlier(int count, bool verbose, int totalCount = -1);
 
 // CUDA version information - shared across functions.
-static void rasDumpCommsToJSON(struct rasClient* client, struct rasCollComms* commsData,
-                               struct rasCollective* coll, const int* peerIdxConv);
-static void jsonWriteHeader(const char* ncclVersion, int cudaRuntime, int cudaDriver,
-                            const char* timestamp, int commsCount);
-static void jsonStartCommunicator(unsigned long commHash, unsigned long hostHash, unsigned long pidHash,
-                                  int commSize, int ranksCount, int missingCount, bool firstComm);
-static void jsonWriteRankData(int rank, const char* host, int pid, int cudaDev, int nvmlDev,
-                              int initState, int asyncError, bool finalizeCalled, bool destroyFlag,
-                              bool abortFlag, const unsigned long* collCounts, bool firstRank);
+static void rasDumpCommsToJSON(struct rasClient* client, struct rasCollComms* commsData, struct rasCollective* coll,
+                               const int* peerIdxConv);
+static void jsonWriteHeader(const char* ncclVersion, int cudaRuntime, int cudaDriver, const char* timestamp,
+                            int commsCount);
+static void jsonStartCommunicator(unsigned long commHash, unsigned long hostHash, unsigned long pidHash, int commSize,
+                                  int ranksCount, int missingCount, bool firstComm);
+static void jsonWriteRankData(int rank, const char* host, int pid, int cudaDev, int nvmlDev, int initState,
+                              int asyncError, bool finalizeCalled, bool destroyFlag, bool abortFlag,
+                              const unsigned long* collCounts, bool firstRank);
 static void jsonStartMissingRanks();
-static void jsonWriteMissingRank(int rank, const char* host, int pid, int cudaDev, int nvmlDev,
-                                 bool unresponsive, bool dead, bool firstMissing);
+static void jsonWriteMissingRank(int rank, const char* host, int pid, int cudaDev, int nvmlDev, bool unresponsive,
+                                 bool dead, bool firstMissing);
 static void jsonEndCommunicator();
 static void jsonWriteFooter(double collectionTime, int timeoutsCount);
-
 
 ///////////////////////////////////
 // General rasClients functions. //
@@ -168,24 +166,24 @@ ncclResult_t rasClientInitSocket() {
   const char* clientAddr = "localhost:" STR(NCCL_RAS_CLIENT_PORT);
   union ncclSocketAddress addr;
   const int opt = 1;
-  if (const char* env = ncclGetEnv("NCCL_RAS_ADDR"))
-    clientAddr = env;
+  if (const char* env = ncclGetEnv("NCCL_RAS_ADDR")) clientAddr = env;
   NCCLCHECKGOTO(ncclSocketGetAddrFromString(&addr, clientAddr), ret, fail);
   SYSCHECKGOTO(rasClientListeningSocket = socket(addr.sa.sa_family, SOCK_STREAM, 0), "socket", ret, fail);
-  SYSCHECKGOTO(setsockopt(rasClientListeningSocket, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)),
-               "setsockopt", ret, fail);
+  SYSCHECKGOTO(setsockopt(rasClientListeningSocket, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)), "setsockopt", ret,
+               fail);
 #if defined(SO_REUSEPORT)
-  SYSCHECKGOTO(setsockopt(rasClientListeningSocket, SOL_SOCKET, SO_REUSEPORT, &opt, sizeof(opt)),
-               "setsockopt", ret, fail);
+  SYSCHECKGOTO(setsockopt(rasClientListeningSocket, SOL_SOCKET, SO_REUSEPORT, &opt, sizeof(opt)), "setsockopt", ret,
+               fail);
 #endif
-  SYSCHECKGOTO(bind(rasClientListeningSocket, &addr.sa, (addr.sa.sa_family == AF_INET ? sizeof(struct sockaddr_in) :
-                                                          sizeof(struct sockaddr_in6))), "bind", ret, fail);
+  SYSCHECKGOTO(bind(rasClientListeningSocket, &addr.sa,
+                    (addr.sa.sa_family == AF_INET ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6))),
+               "bind", ret, fail);
   SYSCHECKGOTO(listen(rasClientListeningSocket, 16384), "listen", ret, fail);
-  INFO(NCCL_INIT|NCCL_RAS, "RAS client listening socket at %s", ncclSocketToString(&addr, rasLine));
+  INFO(NCCL_INIT | NCCL_RAS, "RAS client listening socket at %s", ncclSocketToString(&addr, rasLine));
 exit:
   return ret;
 fail:
-  INFO(NCCL_INIT|NCCL_RAS, "RAS failed to establish a client listening socket at %s", clientAddr);
+  INFO(NCCL_INIT | NCCL_RAS, "RAS failed to establish a client listening socket at %s", clientAddr);
   if (rasClientListeningSocket != -1) {
     (void)close(rasClientListeningSocket);
     rasClientListeningSocket = -1;
@@ -215,8 +213,7 @@ ncclResult_t rasClientAcceptNewSocket() {
 exit:
   return ret;
 fail:
-  if (client && client->sock != -1)
-    (void)close(client->sock);
+  if (client && client->sock != -1) (void)close(client->sock);
   goto exit;
 }
 
@@ -228,7 +225,7 @@ static ncclResult_t getNewClientEntry(struct rasClient** pClient) {
 
   client->sock = client->pfd = -1;
   ncclIntruQueueConstruct(&client->sendQ);
-  client->timeout =  RAS_COLLECTIVE_LEG_TIMEOUT;
+  client->timeout = RAS_COLLECTIVE_LEG_TIMEOUT;
   client->outputFormat = RAS_OUTPUT_TEXT;
   client->monitorMask = 0; // Not in monitor mode.
 
@@ -279,17 +276,12 @@ static void rasClientTerminate(struct rasClient* client) {
     free(meta);
   }
 
-  if (client == rasClientsHead)
-    rasClientsHead = rasClientsHead->next;
-  if (client == rasClientsTail)
-    rasClientsTail = rasClientsTail->prev;
-  if (client->prev)
-    client->prev->next = client->next;
-  if (client->next)
-    client->next->prev = client->prev;
+  if (client == rasClientsHead) rasClientsHead = rasClientsHead->next;
+  if (client == rasClientsTail) rasClientsTail = rasClientsTail->prev;
+  if (client->prev) client->prev->next = client->next;
+  if (client->next) client->next->prev = client->prev;
   free(client);
 }
-
 
 //////////////////////////////////////////////////////////////////////
 // Functions related to the asynchronous operations of RAS clients. //
@@ -301,8 +293,7 @@ ncclResult_t rasClientResume(struct rasCollective* coll) {
   struct rasClient* client;
 
   for (client = rasClientsHead; client; client = client->next)
-    if (client->coll == coll)
-      break;
+    if (client->coll == coll) break;
   if (client == nullptr) {
     INFO(NCCL_RAS, "RAS failed to find a matching client!");
     rasCollFree(coll);
@@ -324,16 +315,14 @@ void rasClientEventLoop(struct rasClient* client, int pollIdx) {
     if (rasPfds[pollIdx].revents & POLLIN) {
       if (client->recvOffset < sizeof(client->recvBuffer)) {
         ssize_t nRecv;
-        nRecv = recv(client->sock, client->recvBuffer+client->recvOffset,
+        nRecv = recv(client->sock, client->recvBuffer + client->recvOffset,
                      sizeof(client->recvBuffer) - client->recvOffset, MSG_DONTWAIT);
         if (nRecv == 0) {
           closed = true;
         } else if (nRecv == -1) {
           if (errno != EINTR && errno != EWOULDBLOCK && errno != EAGAIN) {
-            if (errno == ECONNRESET)
-              INFO(NCCL_RAS, "RAS socket closed by the client on receive; terminating it");
-            else
-              INFO(NCCL_RAS, "RAS unexpected error from recv; terminating the client socket");
+            if (errno == ECONNRESET) INFO(NCCL_RAS, "RAS socket closed by the client on receive; terminating it");
+            else INFO(NCCL_RAS, "RAS unexpected error from recv; terminating the client socket");
             closed = true;
           }
         } else { // nRecv > 0
@@ -348,7 +337,7 @@ void rasClientEventLoop(struct rasClient* client, int pollIdx) {
       return;
     }
     cmd = client->recvBuffer;
-    while ((cmdEnd = (char*)memchr(cmd, '\n', client->recvOffset - (cmd-client->recvBuffer))) != nullptr) {
+    while ((cmdEnd = (char*)memchr(cmd, '\n', client->recvOffset - (cmd - client->recvBuffer))) != nullptr) {
       char* msg;
       int msgLen;
       *cmdEnd = '\0'; // Replaces '\n'.
@@ -368,9 +357,9 @@ void rasClientEventLoop(struct rasClient* client, int pollIdx) {
         rasClientEnqueueMsg(client, msg, msgLen);
       } else if (strncasecmp(cmd, "timeout ", strlen("timeout ")) == 0) {
         char* endPtr = nullptr;
-        int timeout = strtol(cmd+strlen("timeout "), &endPtr, 10);
+        int timeout = strtol(cmd + strlen("timeout "), &endPtr, 10);
         if (timeout < 0 || !endPtr || *endPtr != '\0') {
-          snprintf(rasLine, sizeof(rasLine), "ERROR: Invalid timeout value %s\n", cmd+strlen("timeout "));
+          snprintf(rasLine, sizeof(rasLine), "ERROR: Invalid timeout value %s\n", cmd + strlen("timeout "));
         } else {
           client->timeout = timeout * CLOCK_UNITS_PER_SEC;
           strcpy(rasLine, "OK\n");
@@ -461,7 +450,7 @@ void rasClientEventLoop(struct rasClient* client, int pollIdx) {
         rasClientEnqueueMsg(client, msg, msgLen);
       }
 
-      cmd = cmdEnd+1;
+      cmd = cmdEnd + 1;
     } // while newline found
 
     if (cmd == client->recvBuffer) {
@@ -474,8 +463,8 @@ void rasClientEventLoop(struct rasClient* client, int pollIdx) {
       // Otherwise it's an incomplete command; we need to wait for the rest of it.
     } else { // cmd > client->recvBuffer
       // Shift whatever remains (if anything) to the beginning of the buffer.
-      memmove(client->recvBuffer, cmd, client->recvOffset - (cmd-client->recvBuffer));
-      client->recvOffset -= cmd-client->recvBuffer;
+      memmove(client->recvBuffer, cmd, client->recvOffset - (cmd - client->recvBuffer));
+      client->recvOffset -= cmd - client->recvBuffer;
     }
   } // if (client->status == RAS_CLIENT_CONNECTED)
 
@@ -483,22 +472,19 @@ void rasClientEventLoop(struct rasClient* client, int pollIdx) {
     struct rasMsgMeta* meta;
     while ((meta = ncclIntruQueueHead(&client->sendQ)) != nullptr) {
       ssize_t nSend;
-      nSend = send(client->sock, ((char*)&meta->msg)+meta->offset, meta->length-meta->offset,
+      nSend = send(client->sock, ((char*)&meta->msg) + meta->offset, meta->length - meta->offset,
                    MSG_DONTWAIT | MSG_NOSIGNAL);
       if (nSend < 1) {
         if (nSend == -1 && errno != EINTR && errno != EWOULDBLOCK && errno != EAGAIN) {
-          if (errno == EPIPE)
-            INFO(NCCL_RAS, "RAS socket closed by the client on send; terminating it");
-          else
-            INFO(NCCL_RAS, "RAS unexpected error from send; terminating the client socket");
+          if (errno == EPIPE) INFO(NCCL_RAS, "RAS socket closed by the client on send; terminating it");
+          else INFO(NCCL_RAS, "RAS unexpected error from send; terminating the client socket");
           closed = true;
         }
         break;
       }
 
       meta->offset += nSend;
-      if (meta->offset < meta->length)
-        break;
+      if (meta->offset < meta->length) break;
 
       ncclIntruQueueDequeue(&client->sendQ);
       free(meta);
@@ -511,12 +497,10 @@ void rasClientEventLoop(struct rasClient* client, int pollIdx) {
 
     if (!meta) {
       rasPfds[client->pfd].events &= ~POLLOUT; // Nothing more to send for now.
-      if (client->status == RAS_CLIENT_FINISHED)
-        rasClientTerminate(client);
+      if (client->status == RAS_CLIENT_FINISHED) rasClientTerminate(client);
     }
   } // if (rasPfds[pollIdx].revents & POLLOUT)
 }
-
 
 //////////////////////////////////////////////////////////
 // Functions driving data gathering for the RAS client. //
@@ -530,10 +514,10 @@ static ncclResult_t rasClientRun(struct rasClient* client) {
   ncclResult_t ret = ncclSuccess;
 
   switch (client->status) {
-    case RAS_CLIENT_INIT:
-      NCCLCHECKGOTO(rasClientRunInit(client), ret, exit);
+  case RAS_CLIENT_INIT:
+    NCCLCHECKGOTO(rasClientRunInit(client), ret, exit);
 #if 0 // Commented out for now to focus the summary status report on the information most relevant to the users.
-      // To be revisited with future extensions to RAS.
+    // To be revisited with future extensions to RAS.
       client->status = RAS_CLIENT_CONNS;
       if (ret == ncclInProgress) {
         ret = ncclSuccess;
@@ -542,19 +526,19 @@ static ncclResult_t rasClientRun(struct rasClient* client) {
     case RAS_CLIENT_CONNS:
       NCCLCHECKGOTO(rasClientRunConns(client), ret, exit);
 #endif
-      client->status = RAS_CLIENT_COMMS;
-      if (ret == ncclInProgress) {
-        ret = ncclSuccess;
-        break;
-      }
-    case RAS_CLIENT_COMMS:
-      NCCLCHECKGOTO(rasClientRunComms(client), ret, exit);
-      client->status = RAS_CLIENT_FINISHED;
+    client->status = RAS_CLIENT_COMMS;
+    if (ret == ncclInProgress) {
+      ret = ncclSuccess;
       break;
-    default:
-      WARN("Invalid client status %d", client->status);
-      ret = ncclInternalError;
-      goto exit;
+    }
+  case RAS_CLIENT_COMMS:
+    NCCLCHECKGOTO(rasClientRunComms(client), ret, exit);
+    client->status = RAS_CLIENT_FINISHED;
+    break;
+  default:
+    WARN("Invalid client status %d", client->status);
+    ret = ncclInternalError;
+    goto exit;
   }
 exit:
   return ret;
@@ -578,18 +562,15 @@ static ncclResult_t rasClientRunInit(struct rasClient* client) {
   rasOutReset();
 
   // Get HIP version info once for all output formats.
-  if (cudaRuntimeVersion == -1)
-    CUDACHECKIGNORE(hipRuntimeGetVersion(&cudaRuntimeVersion));
-  if (cudaDriverVersion == -1)
-    CUDACHECKIGNORE(hipDriverGetVersion(&cudaDriverVersion));
+  if (cudaRuntimeVersion == -1) CUDACHECKIGNORE(hipRuntimeGetVersion(&cudaRuntimeVersion));
+  if (cudaDriverVersion == -1) CUDACHECKIGNORE(hipDriverGetVersion(&cudaDriverVersion));
 
   // For structured formats (JSON), skip the initial text output.
   // It will be included in the structured output later.
   if (client->outputFormat == RAS_OUTPUT_TEXT) {
     rasOutAppend("RCCL version " STR(NCCL_MAJOR) "." STR(NCCL_MINOR) "." STR(NCCL_PATCH) NCCL_SUFFIX
                  " compiled with ROCm " STR(ROCM_BUILD_INFO) "\n");
-    rasOutAppend("HIP runtime version %d, amdgpu driver version %d\n\n",
-                 cudaRuntimeVersion, cudaDriverVersion);
+    rasOutAppend("HIP runtime version %d, amdgpu driver version %d\n\n", cudaRuntimeVersion, cudaDriverVersion);
     msgLen = rasOutLength();
     NCCLCHECKGOTO(rasClientAllocMsg(&msg, msgLen), ret, fail);
     rasOutExtract(msg);
@@ -613,27 +594,21 @@ static ncclResult_t rasClientRunInit(struct rasClient* client) {
       nPeers = 1;
       firstNGpusGlobal = firstNGpusNode = nGpus;
     } else { // peerIdx > 0
-      if (nGpus != firstNGpusGlobal)
-        consistentNGpusGlobal = false;
-      if (!ncclSocketsSameNode(&rasPeers[peerIdx].addr, &rasPeers[peerIdx-1].addr)) {
+      if (nGpus != firstNGpusGlobal) consistentNGpusGlobal = false;
+      if (!ncclSocketsSameNode(&rasPeers[peerIdx].addr, &rasPeers[peerIdx - 1].addr)) {
         totalNodes++;
-        if (firstNPeersGlobal == 0)
-          firstNPeersGlobal = nPeers;
-        else if (nPeers != firstNPeersGlobal)
-          consistentNPeersGlobal = false;
+        if (firstNPeersGlobal == 0) firstNPeersGlobal = nPeers;
+        else if (nPeers != firstNPeersGlobal) consistentNPeersGlobal = false;
         nPeers = 1;
         firstNGpusNode = nGpus;
       } else { // Same node.
-        if (nGpus != firstNGpusNode)
-          consistentNGpusNode = false;
+        if (nGpus != firstNGpusNode) consistentNGpusNode = false;
         nPeers++;
       } // Same node
     } // peerIdx > 0
-    if (peerIdx == nRasPeers-1) {
-      if (firstNPeersGlobal == 0)
-        firstNPeersGlobal = nPeers;
-      else if (nPeers != firstNPeersGlobal)
-        consistentNPeersGlobal = false;
+    if (peerIdx == nRasPeers - 1) {
+      if (firstNPeersGlobal == 0) firstNPeersGlobal = nPeers;
+      else if (nPeers != firstNPeersGlobal) consistentNPeersGlobal = false;
     }
   } // for (peerIdx)
 
@@ -650,160 +625,163 @@ static ncclResult_t rasClientRunInit(struct rasClient* client) {
     if (consistentNGpusNode && consistentNGpusGlobal && consistentNPeersGlobal) {
       rasOutAppend("  Nodes  Processes         GPUs  Processes     GPUs\n"
                    "(total)   per node  per process    (total)  (total)\n"
-                   "%7d"  "  %9d"    "  %11d"     "  %9d"    "  %7d\n",
+                   "%7d"
+                   "  %9d"
+                   "  %11d"
+                   "  %9d"
+                   "  %7d\n",
                    totalNodes, firstNPeersGlobal, firstNGpusGlobal, nRasPeers, totalGpus);
     } else {
-    // Gather the stats on the number of processes per node.  However, that number is not a property of a peer,
-    // but of a group of peers, so calculating it is more involved.  We store the value in a temporary auxRasPeers
-    // array.
-    NCCLCHECKGOTO(ncclCalloc(&auxRasPeers, nRasPeers), ret, fail);
+      // Gather the stats on the number of processes per node.  However, that number is not a property of a peer,
+      // but of a group of peers, so calculating it is more involved.  We store the value in a temporary auxRasPeers
+      // array.
+      NCCLCHECKGOTO(ncclCalloc(&auxRasPeers, nRasPeers), ret, fail);
 
-    firstIdx = 0;
-    nPeers = 0;
-    for (int peerIdx = 0; peerIdx < nRasPeers; peerIdx++) {
-      auxRasPeers[peerIdx].peer = rasPeers+peerIdx;
-      if (peerIdx == 0) {
-        nPeers = 1;
-        firstIdx = 0;
-      } else { // peerIdx > 0
-        if (!ncclSocketsSameNode(&auxRasPeers[peerIdx].peer->addr, &auxRasPeers[peerIdx-1].peer->addr)) {
+      firstIdx = 0;
+      nPeers = 0;
+      for (int peerIdx = 0; peerIdx < nRasPeers; peerIdx++) {
+        auxRasPeers[peerIdx].peer = rasPeers + peerIdx;
+        if (peerIdx == 0) {
+          nPeers = 1;
+          firstIdx = 0;
+        } else { // peerIdx > 0
+          if (!ncclSocketsSameNode(&auxRasPeers[peerIdx].peer->addr, &auxRasPeers[peerIdx - 1].peer->addr)) {
+            TRACE(NCCL_RAS, "RAS: node %s: nPeers %d",
+                  ncclSocketToHost(&auxRasPeers[peerIdx].peer->addr, rasLine, sizeof(rasLine)), nPeers);
+            for (int i = firstIdx; i < peerIdx; i++) {
+              // Go back and update the number of processes of all the elements of that node.
+              auxRasPeers[i].value = nPeers;
+            }
+            nPeers = 1;
+            firstIdx = peerIdx;
+          } else {
+            nPeers++;
+          }
+        } // peerIdx > 0
+        if (peerIdx == nRasPeers - 1) {
+          // Last iteration of the loop.
           TRACE(NCCL_RAS, "RAS: node %s: nPeers %d",
                 ncclSocketToHost(&auxRasPeers[peerIdx].peer->addr, rasLine, sizeof(rasLine)), nPeers);
-          for (int i = firstIdx; i < peerIdx; i++) {
-            // Go back and update the number of processes of all the elements of that node.
+          for (int i = firstIdx; i < nRasPeers; i++) {
             auxRasPeers[i].value = nPeers;
           }
-          nPeers = 1;
-          firstIdx = peerIdx;
-        } else {
-          nPeers++;
         }
-      } // peerIdx > 0
-      if (peerIdx == nRasPeers-1) {
-        // Last iteration of the loop.
-        TRACE(NCCL_RAS, "RAS: node %s: nPeers %d",
-              ncclSocketToHost(&auxRasPeers[peerIdx].peer->addr, rasLine, sizeof(rasLine)), nPeers);
-        for (int i = firstIdx; i < nRasPeers; i++) {
-          auxRasPeers[i].value = nPeers;
-        }
-      }
-    } // for (peerIdx)
+      } // for (peerIdx)
 
-    // Re-sort it now using the number of processes on the node (value) as the primary key, host IP as the
-    // secondary, and process id as the tertiary.
-    qsort(auxRasPeers, nRasPeers, sizeof(*auxRasPeers), rasAuxPeersValueCompare);
-
-    // Calculate the distribution of different numbers of peers per node.
-    nValCounts = 0;
-    for (int peerIdx = 0; peerIdx < nRasPeers;) {
-      if (peerIdx == 0 || auxRasPeers[peerIdx].value != auxRasPeers[peerIdx-1].value) {
-        valCounts[nValCounts].value = auxRasPeers[peerIdx].value;
-        valCounts[nValCounts].count = 1;
-        valCounts[nValCounts].firstIdx = peerIdx;
-        nValCounts++;
-      } else {
-        valCounts[nValCounts-1].count++;
-      }
-      // Advance peerIdx to the next node.
-      peerIdx += auxRasPeers[peerIdx].value;
-    } // for (peerIdx)
-    // valCounts is currently sorted by value (the number of peers per node).  Sort it by the count (most frequent
-    // number of peers first).
-    qsort(valCounts, nValCounts, sizeof(*valCounts), rasValCountsCompareRev);
-
-    // Print it out, the most frequent peer counts first.
-    if (consistentNGpusNode && consistentNGpusGlobal) {
-      // consistentNPeersGlobal must be false
-      rasOutAppend("  Nodes  Processes         GPUs\n"
-                   "          per node  per process\n");
-      for (int i = 0; i < nValCounts; i++) {
-        struct rasValCount* vc = valCounts+i;
-        rasOutAppend("%7d  %9ld  %11d\n",
-                     vc->count, vc->value, firstNGpusGlobal);
-      }
-    } else { // !consistentNGpusNode || !consistentNGpusGlobal
-      rasOutAppend("  Nodes  Processes\n"
-                   "          per node\n");
-      for (int i = 0; i < nValCounts; i++) {
-        struct rasValCount* vc = valCounts+i;
-        rasOutAppend("%7d  %9ld\n",
-                     vc->count, vc->value);
-      }
-
-      // We calculate and print the GPUs/process separately.  This is required for !consistentNGpusNode and
-      // it also makes our life easier above for !consistentNGpusGlobal (which could require a larger valCounts).
-
-      // Sort peers by the GPU count, to simplify data extraction.  Not sure how fast COMPILER_POPCOUNT64 is so we
-      // may just as well cache it...
-      for (int peerIdx = 0; peerIdx < nRasPeers; peerIdx++) {
-        auxRasPeers[peerIdx].value = COMPILER_POPCOUNT64(auxRasPeers[peerIdx].peer->cudaDevs);
-        TRACE(NCCL_RAS, "RAS: node %s pid %d: nGpus %d",
-              ncclSocketToHost(&auxRasPeers[peerIdx].peer->addr, rasLine, sizeof(rasLine)),
-              auxRasPeers[peerIdx].peer->pid, auxRasPeers[peerIdx].value);
-      }
-      // GPU count is the primary key, host IP is the secondary, and process id is the tertiary.
+      // Re-sort it now using the number of processes on the node (value) as the primary key, host IP as the
+      // secondary, and process id as the tertiary.
       qsort(auxRasPeers, nRasPeers, sizeof(*auxRasPeers), rasAuxPeersValueCompare);
 
-      // Calculate the distribution of different numbers of GPUs per peer.
+      // Calculate the distribution of different numbers of peers per node.
       nValCounts = 0;
-      for (int peerIdx = 0; peerIdx < nRasPeers; peerIdx++) {
-        if (peerIdx == 0 || auxRasPeers[peerIdx].value != auxRasPeers[peerIdx-1].value) {
+      for (int peerIdx = 0; peerIdx < nRasPeers;) {
+        if (peerIdx == 0 || auxRasPeers[peerIdx].value != auxRasPeers[peerIdx - 1].value) {
           valCounts[nValCounts].value = auxRasPeers[peerIdx].value;
           valCounts[nValCounts].count = 1;
           valCounts[nValCounts].firstIdx = peerIdx;
           nValCounts++;
         } else {
-          valCounts[nValCounts-1].count++;
+          valCounts[nValCounts - 1].count++;
         }
+        // Advance peerIdx to the next node.
+        peerIdx += auxRasPeers[peerIdx].value;
       } // for (peerIdx)
-      // valCounts is currently sorted by value (number of GPUs per peer).  Sort it by the count (most frequent
-      // GPU counts first).
+      // valCounts is currently sorted by value (the number of peers per node).  Sort it by the count (most frequent
+      // number of peers first).
       qsort(valCounts, nValCounts, sizeof(*valCounts), rasValCountsCompareRev);
 
-      // Print it out, the most frequent GPU counts first.
-      rasOutAppend("\n"
-                   "         Processes         GPUs\n"
-                   "                    per process\n");
-      for (int i = 0; i < nValCounts; i++) {
-        struct rasValCount* vc = valCounts+i;
-        rasOutAppend("         %9d  %11ld\n",
-                     vc->count, vc->value);
-      }
-    } // !consistentNGpusNode || !consistentNGpusGlobal
-    rasOutAppend("\n"
-                 "  Nodes  Processes         GPUs\n"
-                 "(total)    (total)      (total)\n"
-                 "%7d"  "  %9d"    "  %11d\n",
-                 totalNodes, nRasPeers, totalGpus);
+      // Print it out, the most frequent peer counts first.
+      if (consistentNGpusNode && consistentNGpusGlobal) {
+        // consistentNPeersGlobal must be false
+        rasOutAppend("  Nodes  Processes         GPUs\n"
+                     "          per node  per process\n");
+        for (int i = 0; i < nValCounts; i++) {
+          struct rasValCount* vc = valCounts + i;
+          rasOutAppend("%7d  %9ld  %11d\n", vc->count, vc->value, firstNGpusGlobal);
+        }
+      } else { // !consistentNGpusNode || !consistentNGpusGlobal
+        rasOutAppend("  Nodes  Processes\n"
+                     "          per node\n");
+        for (int i = 0; i < nValCounts; i++) {
+          struct rasValCount* vc = valCounts + i;
+          rasOutAppend("%7d  %9ld\n", vc->count, vc->value);
+        }
 
-    if (consistentNGpusNode && consistentNGpusGlobal) {
-      // In this simpler case, also print the node outliers.
-      for (int i = 1; i < nValCounts; i++) {
-        struct rasValCount* vc = valCounts+i;
-        // We assume that the most frequent group is correct; for the remaining ones, we try to provide more info,
-        // provided that they meet our definition of an outlier.
-        if (rasCountIsOutlier(vc->count, client->verbose, totalNodes)) {
-          rasOutAppend("\nThe outlier node%s:\n", (vc->count > 1 ? "s" : ""));
-          // auxRasPeers is sorted by the node IP address (not port!) as the secondary key and the pid as
-          // the tertiary, which comes in handy when printing...
-          for (int peerIdx = vc->firstIdx; peerIdx < vc->count*vc->value + vc->firstIdx; peerIdx += vc->value) {
-            lineBuf[0] = '\0';
-            for (int j = 0; j < vc->value; j++) {
-              snprintf(lineBuf+strlen(lineBuf), sizeof(lineBuf)-strlen(lineBuf), "%s%d",
-                       (j > 0 ? "," : ""), auxRasPeers[j].peer->pid);
-            }
-            rasOutAppend("  Node %s running process%s %s\n",
-                         ncclSocketToHost(&auxRasPeers[peerIdx].peer->addr, rasLine, sizeof(rasLine)),
-                         (vc->value > 1 ? "es" : ""), lineBuf);
-          } // for (peerIdx)
-        } // if (rasCountIsOutlier(vc->count))
-      } // for (i)
+        // We calculate and print the GPUs/process separately.  This is required for !consistentNGpusNode and
+        // it also makes our life easier above for !consistentNGpusGlobal (which could require a larger valCounts).
+
+        // Sort peers by the GPU count, to simplify data extraction.  Not sure how fast COMPILER_POPCOUNT64 is so we
+        // may just as well cache it...
+        for (int peerIdx = 0; peerIdx < nRasPeers; peerIdx++) {
+          auxRasPeers[peerIdx].value = COMPILER_POPCOUNT64(auxRasPeers[peerIdx].peer->cudaDevs);
+          TRACE(NCCL_RAS, "RAS: node %s pid %d: nGpus %d",
+                ncclSocketToHost(&auxRasPeers[peerIdx].peer->addr, rasLine, sizeof(rasLine)),
+                auxRasPeers[peerIdx].peer->pid, auxRasPeers[peerIdx].value);
+        }
+        // GPU count is the primary key, host IP is the secondary, and process id is the tertiary.
+        qsort(auxRasPeers, nRasPeers, sizeof(*auxRasPeers), rasAuxPeersValueCompare);
+
+        // Calculate the distribution of different numbers of GPUs per peer.
+        nValCounts = 0;
+        for (int peerIdx = 0; peerIdx < nRasPeers; peerIdx++) {
+          if (peerIdx == 0 || auxRasPeers[peerIdx].value != auxRasPeers[peerIdx - 1].value) {
+            valCounts[nValCounts].value = auxRasPeers[peerIdx].value;
+            valCounts[nValCounts].count = 1;
+            valCounts[nValCounts].firstIdx = peerIdx;
+            nValCounts++;
+          } else {
+            valCounts[nValCounts - 1].count++;
+          }
+        } // for (peerIdx)
+        // valCounts is currently sorted by value (number of GPUs per peer).  Sort it by the count (most frequent
+        // GPU counts first).
+        qsort(valCounts, nValCounts, sizeof(*valCounts), rasValCountsCompareRev);
+
+        // Print it out, the most frequent GPU counts first.
+        rasOutAppend("\n"
+                     "         Processes         GPUs\n"
+                     "                    per process\n");
+        for (int i = 0; i < nValCounts; i++) {
+          struct rasValCount* vc = valCounts + i;
+          rasOutAppend("         %9d  %11ld\n", vc->count, vc->value);
+        }
+      } // !consistentNGpusNode || !consistentNGpusGlobal
+      rasOutAppend("\n"
+                   "  Nodes  Processes         GPUs\n"
+                   "(total)    (total)      (total)\n"
+                   "%7d"
+                   "  %9d"
+                   "  %11d\n",
+                   totalNodes, nRasPeers, totalGpus);
+
+      if (consistentNGpusNode && consistentNGpusGlobal) {
+        // In this simpler case, also print the node outliers.
+        for (int i = 1; i < nValCounts; i++) {
+          struct rasValCount* vc = valCounts + i;
+          // We assume that the most frequent group is correct; for the remaining ones, we try to provide more info,
+          // provided that they meet our definition of an outlier.
+          if (rasCountIsOutlier(vc->count, client->verbose, totalNodes)) {
+            rasOutAppend("\nThe outlier node%s:\n", (vc->count > 1 ? "s" : ""));
+            // auxRasPeers is sorted by the node IP address (not port!) as the secondary key and the pid as
+            // the tertiary, which comes in handy when printing...
+            for (int peerIdx = vc->firstIdx; peerIdx < vc->count * vc->value + vc->firstIdx; peerIdx += vc->value) {
+              lineBuf[0] = '\0';
+              for (int j = 0; j < vc->value; j++) {
+                snprintf(lineBuf + strlen(lineBuf), sizeof(lineBuf) - strlen(lineBuf), "%s%d", (j > 0 ? "," : ""),
+                         auxRasPeers[j].peer->pid);
+              }
+              rasOutAppend("  Node %s running process%s %s\n",
+                           ncclSocketToHost(&auxRasPeers[peerIdx].peer->addr, rasLine, sizeof(rasLine)),
+                           (vc->value > 1 ? "es" : ""), lineBuf);
+            } // for (peerIdx)
+          } // if (rasCountIsOutlier(vc->count))
+        } // for (i)
       } // !consistentNPeersGlobal
     } // !consistentNGpusNode || !consistentNGpusGlobal || !consistentNPeersGlobal
   } // TEXT format only
 
 #if 0 // Commented out for now to focus the summary status report on the information most relevant to the users.
-      // To be revisited with future extensions to RAS.
+  // To be revisited with future extensions to RAS.
   rasOutAppend("\nGathering data about the RAS network (timeout %lds)...", client->timeout / CLOCK_UNITS_PER_SEC);
   msgLen = rasOutLength();
   NCCLCHECKGOTO(rasClientAllocMsg(&msg, msgLen), ret, fail);
@@ -837,8 +815,7 @@ static ncclResult_t rasClientRunInit(struct rasClient* client) {
     collReq.timeout = client->timeout;
     collReq.type = RAS_COLL_COMMS;
     NCCLCHECKGOTO(rasNetSendCollReq(&collReq, &allDone, &client->coll), ret, fail);
-    if (!allDone)
-      ret = ncclInProgress;
+    if (!allDone) ret = ncclInProgress;
   }
   TRACE(NCCL_RAS, "RAS: rasClientRunInit: scheduling RAS_COLL_COMMS and finishing");
 exit:
@@ -849,7 +826,7 @@ fail:
 }
 
 #if 0 // Commented out for now to focus the summary status report on the information most relevant to the users.
-      // To be revisited with future extensions to RAS.
+// To be revisited with future extensions to RAS.
 // Processes the response from the RAS_COLL_CONNS collective operation and sends the data to the client (for now
 // primarily the list of missing processes).  Initiates the RAS_COLL_COMMS collective operation.
 static ncclResult_t rasClientRunConns(struct rasClient* client) {
@@ -997,8 +974,8 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
   int vcIdx;
   int nPeersMissing;
   uint64_t* peerNvmlDevs = nullptr;
-  const char*const statusStr[] = { "NOCOMM", "INIT", "RUNNING", "FINALIZE", "ABORT" };
-  const char*const errorStr[] = {
+  const char* const statusStr[] = {"NOCOMM", "INIT", "RUNNING", "FINALIZE", "ABORT"};
+  const char* const errorStr[] = {
     // Listing them all like this, while a bit of a hassle, is less effort than formatting in a temporary buffer.
     "OK",
     "MISMATCH",
@@ -1011,8 +988,8 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
   };
 
   TRACE(NCCL_RAS, "RAS: rasClientRunComms: starting");
-  TRACE(NCCL_RAS, "RAS: coll nLegTimeouts %d, nPeers %d, nData %d; commsData nComms %d",
-        coll->nLegTimeouts, coll->nPeers, coll->nData, commsData->nComms);
+  TRACE(NCCL_RAS, "RAS: coll nLegTimeouts %d, nPeers %d, nData %d; commsData nComms %d", coll->nLegTimeouts,
+        coll->nPeers, coll->nData, commsData->nComms);
 
   if (coll == nullptr || coll->nFwdSent != coll->nFwdRecv) {
     INFO(NCCL_RAS, "RAS invalid collective operation status; client status %d -- internal error?", client->status);
@@ -1035,10 +1012,9 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
   maxCommSize = 0;
   comm = commsData->comms;
   for (int commIdx = 0; commIdx < commsData->nComms; commIdx++) {
-    if (maxCommSize < comm->commNRanks)
-      maxCommSize = comm->commNRanks;
+    if (maxCommSize < comm->commNRanks) maxCommSize = comm->commNRanks;
     auxComms[commIdx].comm = comm;
-    comm = (struct rasCollComms::comm*)(((char*)(comm+1)) + comm->nRanks * sizeof(*comm->ranks) +
+    comm = (struct rasCollComms::comm*)(((char*)(comm + 1)) + comm->nRanks * sizeof(*comm->ranks) +
                                         comm->nMissingRanks * sizeof(struct rasCollCommsMissingRank));
   }
   NCCLCHECKGOTO(ncclCalloc(&auxCommRanks, maxCommSize), ret, fail);
@@ -1047,7 +1023,7 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
   // For convenience, create a translation table from rasCollective's peerIdx to rasPeers peerIdx.
   NCCLCHECKGOTO(ncclCalloc(&peerIdxConv, coll->nPeers), ret, fail);
   for (int peerIdx = 0; peerIdx < coll->nPeers; peerIdx++) {
-    peerIdxConv[peerIdx] = rasPeerFind(coll->peers+peerIdx);
+    peerIdxConv[peerIdx] = rasPeerFind(coll->peers + peerIdx);
     TRACE(NCCL_RAS, "RAS: coll peers[%d] -> rasPeers[%d]", peerIdx, peerIdxConv[peerIdx]);
   }
   // Sort coll->peers to match the ordering of rasPeers -- we may need it later...
@@ -1066,16 +1042,16 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
   }
 
   // Default TEXT format continues below.
-  rasOutAppend(" (%.3fs)\n=============\n\n", (clockNano()-coll->startTime)/1e9);
+  rasOutAppend(" (%.3fs)\n=============\n\n", (clockNano() - coll->startTime) / 1e9);
 
   // Fill in the remaining fields of auxComm's.
   for (int commIdx = 0; commIdx < commsData->nComms; commIdx++) {
-    struct rasAuxComm* auxComm = auxComms+commIdx;
+    struct rasAuxComm* auxComm = auxComms + commIdx;
     int nRanks = 0;
     comm = auxComm->comm;
     TRACE(NCCL_RAS, "RAS: coll comms[%d]: commId (0x%lx, 0x%lx, 0x%lx), commNRanks %d, nRanks %d, nMissingRanks %d",
-          commIdx, comm->commId.commHash, comm->commId.hostHash, comm->commId.pidHash,
-          comm->commNRanks, comm->nRanks, comm->nMissingRanks);
+          commIdx, comm->commId.commHash, comm->commId.hostHash, comm->commId.pidHash, comm->commNRanks, comm->nRanks,
+          comm->nMissingRanks);
 
     if (comm->nMissingRanks > 0) {
       // There are two possibilities here.  Either we are missing the data on some ranks because the processes are
@@ -1089,7 +1065,7 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
         // We failed to receive data from some processes but we don't know if that's why we don't have the info about
         // some ranks of this communicator.  We need to check all the missing ranks one-by-one as different ranks may
         // have different reason.
-        struct rasCollCommsMissingRank* missingRanks = (struct rasCollCommsMissingRank*)(comm->ranks+comm->nRanks);
+        struct rasCollCommsMissingRank* missingRanks = (struct rasCollCommsMissingRank*)(comm->ranks + comm->nRanks);
 
         for (int rankIdx = 0; rankIdx < comm->nMissingRanks; rankIdx++) {
           struct rasCollCommsMissingRank* missingRank = missingRanks + rankIdx;
@@ -1104,8 +1080,8 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
             auxComm->errors |= RAS_ACE_INCOMPLETE;
             auxComm->nIncompleteRanks++;
           }
-          TRACE(NCCL_RAS, "RAS: comm missingRank[%d] commRank %d, addr %td (-> %d), cudaDev %d, nvmlDev %d",
-                rankIdx, missingRank->commRank, (found ? ((union ncclSocketAddress*)found) - coll->peers: -1),
+          TRACE(NCCL_RAS, "RAS: comm missingRank[%d] commRank %d, addr %td (-> %d), cudaDev %d, nvmlDev %d", rankIdx,
+                missingRank->commRank, (found ? ((union ncclSocketAddress*)found) - coll->peers : -1),
                 rasPeerFind(&missingRank->addr), missingRank->cudaDev, missingRank->nvmlDev);
         } // for (rankIdx)
       } // nPeersMissing > 0 || nRasDeadPeers > 0
@@ -1114,16 +1090,17 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
     // Initialize auxCommRanks from comm->rank, converting peerIdx to rasPeers, then sort by it -- that way we will
     // have the ranks sorted by node and process, which makes counting easy.
     for (int rankIdx = 0; rankIdx < comm->nRanks; rankIdx++) {
-      struct rasCollComms::comm::rank* rank = comm->ranks+rankIdx;
+      struct rasCollComms::comm::rank* rank = comm->ranks + rankIdx;
       auxCommRanks[rankIdx].rank = rank;
       auxCommRanks[rankIdx].value = peerIdxConv[rank->peerIdx];
-      TRACE(NCCL_RAS, "RAS: comm rank[%d] commRank %d, peerIdx %d (-> %d), cudaDev %d, nvmlDev %d",
-            rankIdx, rank->commRank, rank->peerIdx, peerIdxConv[rank->peerIdx], rank->cudaDev, rank->nvmlDev);
-      TRACE(NCCL_RAS, "RAS: comm rank[%d] collOpCounts (%ld, %ld, %ld, %ld, %ld)",
-            rankIdx, rank->collOpCounts[0], rank->collOpCounts[1], rank->collOpCounts[2], rank->collOpCounts[3],
-            rank->collOpCounts[4]);
-      TRACE(NCCL_RAS, "RAS: comm rank[%d] status initState %d, asyncError %d, finalizeCalled %d, destroyFlag %d, "
-            "abortFlag %d", rankIdx, rank->status.initState, rank->status.asyncError, rank->status.finalizeCalled,
+      TRACE(NCCL_RAS, "RAS: comm rank[%d] commRank %d, peerIdx %d (-> %d), cudaDev %d, nvmlDev %d", rankIdx,
+            rank->commRank, rank->peerIdx, peerIdxConv[rank->peerIdx], rank->cudaDev, rank->nvmlDev);
+      TRACE(NCCL_RAS, "RAS: comm rank[%d] collOpCounts (%ld, %ld, %ld, %ld, %ld)", rankIdx, rank->collOpCounts[0],
+            rank->collOpCounts[1], rank->collOpCounts[2], rank->collOpCounts[3], rank->collOpCounts[4]);
+      TRACE(NCCL_RAS,
+            "RAS: comm rank[%d] status initState %d, asyncError %d, finalizeCalled %d, destroyFlag %d, "
+            "abortFlag %d",
+            rankIdx, rank->status.initState, rank->status.asyncError, rank->status.finalizeCalled,
             rank->status.destroyFlag, rank->status.abortFlag); /**/
     }
     // This also sorts by the commRank, which we don't care about here, but it won't hurt.
@@ -1131,7 +1108,7 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
 
     // Count the peers and nodes, get the status/error indicators.
     for (int rankIdx = 0; rankIdx < comm->nRanks; rankIdx++) {
-      struct rasAuxCommRank* auxRank = auxCommRanks+rankIdx;
+      struct rasAuxCommRank* auxRank = auxCommRanks + rankIdx;
       if (rankIdx == 0) {
         auxComm->nPeers = auxComm->nNodes = 1;
         auxComm->ranksPerNodeMin = NCCL_MAX_LOCAL_RANKS;
@@ -1143,34 +1120,27 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
           auxComm->nPeers++;
           if (!ncclSocketsSameNode(&rasPeers[auxRank->value].addr, &rasPeers[auxRank[-1].value].addr)) {
             auxComm->nNodes++;
-            if (auxComm->ranksPerNodeMin > nRanks)
-              auxComm->ranksPerNodeMin = nRanks;
-            if (auxComm->ranksPerNodeMax < nRanks)
-              auxComm->ranksPerNodeMax = nRanks;
+            if (auxComm->ranksPerNodeMin > nRanks) auxComm->ranksPerNodeMin = nRanks;
+            if (auxComm->ranksPerNodeMax < nRanks) auxComm->ranksPerNodeMax = nRanks;
             nRanks = 0;
           }
         } // if (auxRank->value != auxRank[-1].value)
         nRanks++;
       } // rankIdx > 0
-      if (rankIdx == comm->nRanks-1) {
+      if (rankIdx == comm->nRanks - 1) {
         // Last iteration of the loop.
-        if (auxComm->ranksPerNodeMin > nRanks)
-          auxComm->ranksPerNodeMin = nRanks;
-        if (auxComm->ranksPerNodeMax < nRanks)
-          auxComm->ranksPerNodeMax = nRanks;
+        if (auxComm->ranksPerNodeMin > nRanks) auxComm->ranksPerNodeMin = nRanks;
+        if (auxComm->ranksPerNodeMax < nRanks) auxComm->ranksPerNodeMax = nRanks;
       }
 
-      if (auxRank->rank->status.abortFlag)
-        auxComm->status |= RAS_ACS_ABORT;
+      if (auxRank->rank->status.abortFlag) auxComm->status |= RAS_ACS_ABORT;
       else if (auxRank->rank->status.finalizeCalled || auxRank->rank->status.destroyFlag) {
         // destroyFlag is set by ncclCommDestroy and ncclCommAbort.  finalizeCalled appears to be set by
         // ncclCommFinalize only.  According to the docs, ncclCommDestroy *can* be called without calling
         // ncclCommFinalize first.  The code structure here ensures that we attribute destroyFlag properly
         // as a finalize state indicator (and ignore it in case of ncclCommAbort).
         auxComm->status |= RAS_ACS_FINALIZE;
-      }
-      else if (auxRank->rank->status.initState == ncclSuccess)
-        auxComm->status |= RAS_ACS_RUNNING;
+      } else if (auxRank->rank->status.initState == ncclSuccess) auxComm->status |= RAS_ACS_RUNNING;
       else // auxRank->rank->initState != ncclSuccess
         auxComm->status |= RAS_ACS_INIT;
 
@@ -1188,32 +1158,30 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
       // We've got a status mismatch between ranks.
       auxComm->errors |= RAS_ACE_MISMATCH;
     }
-    TRACE(NCCL_RAS, "RAS: auxComm nPeers %d, nNodes %d, nIncompleteRanks %d",
-          auxComm->nPeers, auxComm->nNodes, auxComm->nIncompleteRanks);
+    TRACE(NCCL_RAS, "RAS: auxComm nPeers %d, nNodes %d, nIncompleteRanks %d", auxComm->nPeers, auxComm->nNodes,
+          auxComm->nIncompleteRanks);
     TRACE(NCCL_RAS, "RAS: auxComm ranksPerNodeMin %d, ranksPerNodeMax %d, status 0x%x, errors 0x%x",
           auxComm->ranksPerNodeMin, auxComm->ranksPerNodeMax, auxComm->status, auxComm->errors);
   } // for (commIdx)
   // Sort it by size/nNodes/status/errors/missing ranks.
-  if (auxComms)
-    qsort(auxComms, commsData->nComms, sizeof(*auxComms), &rasAuxCommsCompareRev);
+  if (auxComms) qsort(auxComms, commsData->nComms, sizeof(*auxComms), &rasAuxCommsCompareRev);
 
   // Calculate the distribution of different communicator sizes.
   NCCLCHECKGOTO(ncclCalloc(&valCounts, commsData->nComms), ret, fail);
   nValCounts = 0;
   for (int commIdx = 0; commIdx < commsData->nComms; commIdx++) {
-    if (commIdx == 0 ||
-        auxComms[commIdx].comm->commNRanks != auxComms[commIdx-1].comm->commNRanks ||
-        auxComms[commIdx].nNodes != auxComms[commIdx-1].nNodes ||
+    if (commIdx == 0 || auxComms[commIdx].comm->commNRanks != auxComms[commIdx - 1].comm->commNRanks ||
+        auxComms[commIdx].nNodes != auxComms[commIdx - 1].nNodes ||
         // COMPILER_CLZ returns the number of leading 0-bits, which is a proxy for the index of the highest 1-bit.
-        COMPILER_CLZ(auxComms[commIdx].status) != COMPILER_CLZ(auxComms[commIdx-1].status) ||
-        auxComms[commIdx].errors != auxComms[commIdx-1].errors) {
+        COMPILER_CLZ(auxComms[commIdx].status) != COMPILER_CLZ(auxComms[commIdx - 1].status) ||
+        auxComms[commIdx].errors != auxComms[commIdx - 1].errors) {
       valCounts[nValCounts].value = 0; // We have many distinguishing values but only one field to store them.
-                                       // It doesn't really matter, given that we can extract them via firstIdx.
+      // It doesn't really matter, given that we can extract them via firstIdx.
       valCounts[nValCounts].count = 1;
       valCounts[nValCounts].firstIdx = commIdx;
       nValCounts++;
     } else {
-      valCounts[nValCounts-1].count++;
+      valCounts[nValCounts - 1].count++;
     }
   }
 
@@ -1231,8 +1199,8 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
 
   // Print it out, the largest communicators first.
   for (int vcIdx = 0; vcIdx < nValCounts; vcIdx++) {
-    struct rasValCount* vc = valCounts+vcIdx;
-    struct rasAuxComm* auxComm = auxComms+vc->firstIdx;
+    struct rasValCount* vc = valCounts + vcIdx;
+    struct rasAuxComm* auxComm = auxComms + vc->firstIdx;
     int ranksPerNodeMin, ranksPerNodeMax;
     int ranksTotal;
 
@@ -1243,27 +1211,22 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
     // Calculate the group's min/max.
     // Also calculate the number of unique ranks in the group.
     for (int commIdx = 0; commIdx < vc->count; commIdx++) {
-      if (ranksPerNodeMin > auxComm[commIdx].ranksPerNodeMin)
-        ranksPerNodeMin = auxComm[commIdx].ranksPerNodeMin;
-      if (ranksPerNodeMax < auxComm[commIdx].ranksPerNodeMax)
-        ranksPerNodeMax = auxComm[commIdx].ranksPerNodeMax;
+      if (ranksPerNodeMin > auxComm[commIdx].ranksPerNodeMin) ranksPerNodeMin = auxComm[commIdx].ranksPerNodeMin;
+      if (ranksPerNodeMax < auxComm[commIdx].ranksPerNodeMax) ranksPerNodeMax = auxComm[commIdx].ranksPerNodeMax;
       for (int rankIdx = 0; rankIdx < auxComm[commIdx].comm->nRanks; rankIdx++) {
-        struct rasCollComms::comm::rank* rank = auxComm[commIdx].comm->ranks+rankIdx;
+        struct rasCollComms::comm::rank* rank = auxComm[commIdx].comm->ranks + rankIdx;
         peerNvmlDevs[rank->peerIdx] |= (1ULL << rank->nvmlDev);
       }
     }
     ranksTotal = 0;
-    for (int peerIdx = 0; peerIdx < coll->nPeers; peerIdx++)
-      ranksTotal += COMPILER_POPCOUNT64(peerNvmlDevs[peerIdx]);
-    if (ranksPerNodeMin == ranksPerNodeMax)
-      snprintf(rasLine, sizeof(rasLine), "%d", ranksPerNodeMin);
-    else
-      snprintf(rasLine, sizeof(rasLine), "%d-%d", ranksPerNodeMin, ranksPerNodeMax);
-    rasOutAppend("%5d  %8d  %8d  %8s  %8d  %8d  %8s  %6s\n",
-                 vcIdx, vc->count, auxComm->nNodes, rasLine, auxComm->comm->commNRanks, ranksTotal,
+    for (int peerIdx = 0; peerIdx < coll->nPeers; peerIdx++) ranksTotal += COMPILER_POPCOUNT64(peerNvmlDevs[peerIdx]);
+    if (ranksPerNodeMin == ranksPerNodeMax) snprintf(rasLine, sizeof(rasLine), "%d", ranksPerNodeMin);
+    else snprintf(rasLine, sizeof(rasLine), "%d-%d", ranksPerNodeMin, ranksPerNodeMax);
+    rasOutAppend("%5d  %8d  %8d  %8s  %8d  %8d  %8s  %6s\n", vcIdx, vc->count, auxComm->nNodes, rasLine,
+                 auxComm->comm->commNRanks, ranksTotal,
                  // COMPILER_CLZ returns the number of leading 0-bits.  This makes it possible to translate the
                  // status (which is a bitmask) into an array index.
-                 statusStr[(sizeof(unsigned int)*8-1)-COMPILER_CLZ(auxComm->status)], errorStr[auxComm->errors]);
+                 statusStr[(sizeof(unsigned int) * 8 - 1) - COMPILER_CLZ(auxComm->status)], errorStr[auxComm->errors]);
   }
   msgLen = rasOutLength();
   NCCLCHECKGOTO(rasClientAllocMsg(&msg, msgLen), ret, fail);
@@ -1276,7 +1239,8 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
 
   if (nPeersMissing > 0) {
     rasOutAppend("INCOMPLETE\n"
-                 "  Missing communicator data from %d job process%s\n", nPeersMissing, (nPeersMissing > 1 ? "es" : ""));
+                 "  Missing communicator data from %d job process%s\n",
+                 nPeersMissing, (nPeersMissing > 1 ? "es" : ""));
     if (rasCountIsOutlier(nPeersMissing, client->verbose)) {
       // Extract a list of missing peers.  We don't want to print it right away because it would be sorted
       // by address (including port, which isn't meaningful to end users).
@@ -1290,9 +1254,8 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
       for (int rasPeerIdx = 0, collPeerIdx = 0; rasPeerIdx < nRasPeers || collPeerIdx < coll->nPeers;) {
         int cmp;
         if (rasPeerIdx < nRasPeers && collPeerIdx < coll->nPeers)
-          cmp = ncclSocketsCompare(&rasPeers[rasPeerIdx].addr, coll->peers+collPeerIdx);
-        else
-          cmp = (rasPeerIdx < nRasPeers ? -1 : 1);
+          cmp = ncclSocketsCompare(&rasPeers[rasPeerIdx].addr, coll->peers + collPeerIdx);
+        else cmp = (rasPeerIdx < nRasPeers ? -1 : 1);
 
         if (cmp == 0) {
           rasPeerIdx++;
@@ -1303,20 +1266,21 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
           bool dead;
           if (!(dead = rasPeerIsDead(&rasPeers[rasPeerIdx].addr))) {
             if (nPeersBuf < nPeersMissing) {
-              auxPeersBuf[nPeersBuf++].peer = rasPeers+rasPeerIdx;
+              auxPeersBuf[nPeersBuf++].peer = rasPeers + rasPeerIdx;
             } else {
-              INFO(NCCL_RAS, "RAS overflow of auxPeersBuf: nPeersBuf %d, rasPeerIdx %d (%s), collPeerIdx %d -- "
+              INFO(NCCL_RAS,
+                   "RAS overflow of auxPeersBuf: nPeersBuf %d, rasPeerIdx %d (%s), collPeerIdx %d -- "
                    "internal error?",
                    nPeersBuf, rasPeerIdx, ncclSocketToString(&rasPeers[rasPeerIdx].addr, rasLine), collPeerIdx);
             }
           }
-          TRACE(NCCL_RAS, "RAS rasPeerIdx %d (%s) is missing from coll->peers; dead %d",
-                rasPeerIdx, ncclSocketToString(&rasPeers[rasPeerIdx].addr, rasLine), dead);
+          TRACE(NCCL_RAS, "RAS rasPeerIdx %d (%s) is missing from coll->peers; dead %d", rasPeerIdx,
+                ncclSocketToString(&rasPeers[rasPeerIdx].addr, rasLine), dead);
           rasPeerIdx++;
         } else { // cmp > 0
           // Process not found in rasPeers -- shouldn't happen, unless during a race?
-          INFO(NCCL_RAS, "RAS failed to find coll->peer[%d] (%s) in rasPeers -- internal error?",
-               collPeerIdx, ncclSocketToString(coll->peers+collPeerIdx, rasLine));
+          INFO(NCCL_RAS, "RAS failed to find coll->peer[%d] (%s) in rasPeers -- internal error?", collPeerIdx,
+               ncclSocketToString(coll->peers + collPeerIdx, rasLine));
           collPeerIdx++;
         } // cmp > 0
       } // for (rasPeerIdx, collPeerIdx)
@@ -1325,16 +1289,15 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
       // all auxPeersBuf elements here, so it will do.
       qsort(auxPeersBuf, nPeersBuf, sizeof(*auxPeersBuf), rasAuxPeersValueCompare);
       for (int peerIdx = 0; peerIdx < nPeersBuf; peerIdx++) {
-        struct rasAuxPeerInfo* auxPeer = auxPeersBuf+peerIdx;
+        struct rasAuxPeerInfo* auxPeer = auxPeersBuf + peerIdx;
         rasOutAppend("  Process %d on node %s managing GPU%s %s\n", auxPeer->peer->pid,
                      ncclSocketToHost(&auxPeer->peer->addr, rasLine, sizeof(rasLine)),
                      (COMPILER_POPCOUNT64(auxPeer->peer->cudaDevs) > 1 ? "s" : ""),
-                     rasGpuDevsToString(auxPeer->peer->cudaDevs, auxPeer->peer->nvmlDevs, lineBuf,
-                                        sizeof(lineBuf)));
+                     rasGpuDevsToString(auxPeer->peer->cudaDevs, auxPeer->peer->nvmlDevs, lineBuf, sizeof(lineBuf)));
       }
       if (nPeersBuf != nPeersMissing)
-        rasOutAppend("  [could not find information on %d process%s]\n",
-                     nPeersMissing-nPeersBuf, (nPeersMissing-nPeersBuf > 1 ? "es" : ""));
+        rasOutAppend("  [could not find information on %d process%s]\n", nPeersMissing - nPeersBuf,
+                     (nPeersMissing - nPeersBuf > 1 ? "es" : ""));
       free(auxPeersBuf);
     } // if (rasCountIsOutlier(nPeersMissing))
     rasOutAppend("\n");
@@ -1342,32 +1305,30 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
 
   if (nRasDeadPeers > 0) {
     rasOutAppend("DEAD\n"
-                 "  %d job process%s considered dead (unreachable via the RAS network)\n", nRasDeadPeers,
-                 (nRasDeadPeers > 1 ? "es are" : " is"));
+                 "  %d job process%s considered dead (unreachable via the RAS network)\n",
+                 nRasDeadPeers, (nRasDeadPeers > 1 ? "es are" : " is"));
     if (rasCountIsOutlier(nRasDeadPeers, client->verbose)) {
       // rasDeadPeers contains only addresses, whereas we want a complete rasPeerInfo, and sorted differently.
       struct rasAuxPeerInfo* auxPeersBuf = nullptr;
       int nPeersBuf = 0;
       NCCLCHECKGOTO(ncclCalloc(&auxPeersBuf, nRasDeadPeers), ret, fail);
       for (int i = 0; i < nRasDeadPeers; i++) {
-        int peerIdx = rasPeerFind(rasDeadPeers+i);
-        if (peerIdx != -1)
-          auxPeersBuf[nPeersBuf++].peer = rasPeers+peerIdx;
+        int peerIdx = rasPeerFind(rasDeadPeers + i);
+        if (peerIdx != -1) auxPeersBuf[nPeersBuf++].peer = rasPeers + peerIdx;
       }
       // Sort the output by host and pid, not host and port.  rasAuxPeersValueCompare uses value as the primary key,
       // which is 0 for all auxPeersBuf elements here, so it will do.
       qsort(auxPeersBuf, nPeersBuf, sizeof(*auxPeersBuf), rasAuxPeersValueCompare);
       for (int peerIdx = 0; peerIdx < nPeersBuf; peerIdx++) {
-        struct rasAuxPeerInfo* auxPeer = auxPeersBuf+peerIdx;
+        struct rasAuxPeerInfo* auxPeer = auxPeersBuf + peerIdx;
         rasOutAppend("  Process %d on node %s managing GPU%s %s\n", auxPeer->peer->pid,
                      ncclSocketToHost(&auxPeer->peer->addr, rasLine, sizeof(rasLine)),
                      (COMPILER_POPCOUNT64(auxPeer->peer->cudaDevs) > 1 ? "s" : ""),
-                     rasGpuDevsToString(auxPeer->peer->cudaDevs, auxPeer->peer->nvmlDevs, lineBuf,
-                                        sizeof(lineBuf)));
+                     rasGpuDevsToString(auxPeer->peer->cudaDevs, auxPeer->peer->nvmlDevs, lineBuf, sizeof(lineBuf)));
       }
       if (nPeersBuf != nRasDeadPeers)
-        rasOutAppend("  [could not find information on %d process%s]\n",
-                     nRasDeadPeers-nPeersBuf, (nRasDeadPeers-nPeersBuf > 1 ? "es" : ""));
+        rasOutAppend("  [could not find information on %d process%s]\n", nRasDeadPeers - nPeersBuf,
+                     (nRasDeadPeers - nPeersBuf > 1 ? "es" : ""));
       free(auxPeersBuf);
     } // if (rasCountIsOutlier(nRasDeadPeers)
     rasOutAppend("\n");
@@ -1376,17 +1337,18 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
   // Continue printing the largest communicators first, as in the summary table.
   for (vcIdx = 0; vcIdx < nValCounts; vcIdx++) {
     struct rasValCount* vc;
-    vc = valCounts+vcIdx;
+    vc = valCounts + vcIdx;
     for (int commIdx = vc->firstIdx; commIdx < vc->count + vc->firstIdx; commIdx++) {
-      struct rasAuxComm* auxComm = auxComms+commIdx;
+      struct rasAuxComm* auxComm = auxComms + commIdx;
       comm = auxComm->comm;
 
       if (auxComm->errors & RAS_ACE_INCOMPLETE) {
         rasOutAppend("#%d-%d (%016lx) INCOMPLETE\n"
-                     "  Missing communicator data from %d rank%s\n", vcIdx, commIdx - vc->firstIdx,
-                     comm->commId.commHash, auxComm->nIncompleteRanks, (auxComm->nIncompleteRanks > 1 ? "s" : ""));
+                     "  Missing communicator data from %d rank%s\n",
+                     vcIdx, commIdx - vc->firstIdx, comm->commId.commHash, auxComm->nIncompleteRanks,
+                     (auxComm->nIncompleteRanks > 1 ? "s" : ""));
         if (rasCountIsOutlier(auxComm->nIncompleteRanks, client->verbose)) {
-          struct rasCollCommsMissingRank* missingRanks = (struct rasCollCommsMissingRank*)(comm->ranks+comm->nRanks);
+          struct rasCollCommsMissingRank* missingRanks = (struct rasCollCommsMissingRank*)(comm->ranks + comm->nRanks);
           for (int rankIdx = 0; rankIdx < comm->nMissingRanks; rankIdx++) {
             struct rasCollCommsMissingRank* missingRank = missingRanks + rankIdx;
             // Filter out ranks that provided a response but not for this communicator.
@@ -1394,11 +1356,9 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
                 nullptr) {
               int peerIdx = rasPeerFind(&missingRank->addr);
               if (peerIdx != -1) {
-                rasOutAppend("  Rank %d -- GPU %s managed by process %d on node %s\n",
-                             missingRank->commRank,
+                rasOutAppend("  Rank %d -- GPU %s managed by process %d on node %s\n", missingRank->commRank,
                              rasGpuToString(missingRank->cudaDev, missingRank->nvmlDev, lineBuf, sizeof(lineBuf)),
-                             rasPeers[peerIdx].pid,
-                             ncclSocketToHost(&missingRank->addr, rasLine, sizeof(rasLine)));
+                             rasPeers[peerIdx].pid, ncclSocketToHost(&missingRank->addr, rasLine, sizeof(rasLine)));
               } else {
                 rasOutAppend("  Rank %d -- [process information not found]\n", missingRank->commRank);
               }
@@ -1414,23 +1374,21 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
         rasOutAppend("#%d-%d (%016lx) ERROR\n", vcIdx, commIdx - vc->firstIdx, comm->commId.commHash);
 
         memset(ncclErrors, '\0', sizeof(ncclErrors));
-        for (int rankIdx = 0; rankIdx < comm->nRanks; rankIdx++)
-          ncclErrors[comm->ranks[rankIdx].status.initState]++;
+        for (int rankIdx = 0; rankIdx < comm->nRanks; rankIdx++) ncclErrors[comm->ranks[rankIdx].status.initState]++;
         nErrors = comm->nRanks - (ncclErrors[ncclSuccess] + ncclErrors[ncclInProgress]);
         if (nErrors > 0) {
-          rasOutAppend("  Initialization error%s on %d rank%s\n",
-                       (nErrors > 1 ? "s" : ""), nErrors, (nErrors > 1 ? "s" : ""));
+          rasOutAppend("  Initialization error%s on %d rank%s\n", (nErrors > 1 ? "s" : ""), nErrors,
+                       (nErrors > 1 ? "s" : ""));
           rasClientBreakDownErrors(client, comm, peerIdxConv, ncclErrors);
         }
 
         memset(ncclErrors, '\0', sizeof(ncclErrors));
-        for (int rankIdx = 0; rankIdx < comm->nRanks; rankIdx++)
-          ncclErrors[comm->ranks[rankIdx].status.asyncError]++;
+        for (int rankIdx = 0; rankIdx < comm->nRanks; rankIdx++) ncclErrors[comm->ranks[rankIdx].status.asyncError]++;
         nErrors = comm->nRanks - (ncclErrors[ncclSuccess] + ncclErrors[ncclInProgress]);
         if (nErrors > 0) {
-          rasOutAppend("  Asynchronous error%s on %d rank%s\n",
-                       (nErrors > 1 ? "s" : ""), nErrors, (nErrors > 1 ? "s" : ""));
-          rasClientBreakDownErrors(client, comm, peerIdxConv, ncclErrors, /*isAsync*/true);
+          rasOutAppend("  Asynchronous error%s on %d rank%s\n", (nErrors > 1 ? "s" : ""), nErrors,
+                       (nErrors > 1 ? "s" : ""));
+          rasClientBreakDownErrors(client, comm, peerIdxConv, ncclErrors, /*isAsync*/ true);
         }
         rasOutAppend("\n");
       } // if (auxComm->errors & RAS_ACE_ERROR)
@@ -1453,9 +1411,9 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
 
   // Continue printing the largest communicators first, as in the summary table.
   for (int vcIdx = 0; vcIdx < nValCounts; vcIdx++) {
-    struct rasValCount* vc = valCounts+vcIdx;
+    struct rasValCount* vc = valCounts + vcIdx;
     for (int commIdx = vc->firstIdx; commIdx < vc->count + vc->firstIdx; commIdx++) {
-      struct rasAuxComm* auxComm = auxComms+commIdx;
+      struct rasAuxComm* auxComm = auxComms + commIdx;
       comm = auxComm->comm;
 
       if (auxComm->errors & RAS_ACE_MISMATCH) {
@@ -1474,34 +1432,30 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
           // We need to sort the ranks by status.  However, status is normally calculated from other fields.
           // We will store it in the auxCommRanks' value.
           for (int rankIdx = 0; rankIdx < comm->nRanks; rankIdx++) {
-            struct rasCollComms::comm::rank* rank = comm->ranks+rankIdx;
-            struct rasAuxCommRank* auxRank = auxCommRanks+rankIdx;
+            struct rasCollComms::comm::rank* rank = comm->ranks + rankIdx;
+            struct rasAuxCommRank* auxRank = auxCommRanks + rankIdx;
             auxRank->rank = rank;
 
-            if (rank->status.abortFlag)
-              auxRank->value = RAS_ACS_ABORT;
-            else if (rank->status.finalizeCalled || rank->status.destroyFlag)
-              auxRank->value = RAS_ACS_FINALIZE;
-            else if (rank->status.initState == ncclSuccess)
-              auxRank->value = RAS_ACS_RUNNING;
-            else
-              auxRank->value = RAS_ACS_INIT;
+            if (rank->status.abortFlag) auxRank->value = RAS_ACS_ABORT;
+            else if (rank->status.finalizeCalled || rank->status.destroyFlag) auxRank->value = RAS_ACS_FINALIZE;
+            else if (rank->status.initState == ncclSuccess) auxRank->value = RAS_ACS_RUNNING;
+            else auxRank->value = RAS_ACS_INIT;
           }
           qsort(auxCommRanks, comm->nRanks, sizeof(*auxCommRanks), rasAuxCommRanksValueCompare);
           // Calculate the frequency of different status values.
           int nCollOpCounts = 0;
           for (int rankIdx = 0; rankIdx < comm->nRanks; rankIdx++) {
-            if (rankIdx == 0 || auxCommRanks[rankIdx].value != auxCommRanks[rankIdx-1].value) {
+            if (rankIdx == 0 || auxCommRanks[rankIdx].value != auxCommRanks[rankIdx - 1].value) {
               // COMPILER_CLZ returns the number of leading 0-bits.  This makes it possible to translate the
               // status (which is a bitmask) into an array index.  The argument is an unsigned int (there is no
               // 64-bit version seemingly, but we don't actually need one here).
               collOpCounts[nCollOpCounts].value =
-                (sizeof(unsigned int)*8-1) - COMPILER_CLZ((unsigned int)auxCommRanks[rankIdx].value);
+                (sizeof(unsigned int) * 8 - 1) - COMPILER_CLZ((unsigned int)auxCommRanks[rankIdx].value);
               collOpCounts[nCollOpCounts].count = 1;
               collOpCounts[nCollOpCounts].firstIdx = rankIdx;
               nCollOpCounts++;
             } else {
-              collOpCounts[nCollOpCounts-1].count++;
+              collOpCounts[nCollOpCounts - 1].count++;
             }
           }
           if (comm->nMissingRanks - auxComm->nIncompleteRanks > 0) {
@@ -1515,13 +1469,12 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
           qsort(collOpCounts, nCollOpCounts, sizeof(*collOpCounts), rasValCountsCompareRev);
 
           for (int coc = 0; coc < nCollOpCounts; coc++) {
-            struct rasValCount* vcc = collOpCounts+coc;
-            if (vcc->count > 1)
-              rasOutAppend("  %d ranks have status %s\n", vcc->count, statusStr[vcc->value]);
+            struct rasValCount* vcc = collOpCounts + coc;
+            if (vcc->count > 1) rasOutAppend("  %d ranks have status %s\n", vcc->count, statusStr[vcc->value]);
             if (rasCountIsOutlier(vcc->count, client->verbose, comm->commNRanks)) {
               if (vcc->firstIdx != -1) {
                 // auxCommRanks is sorted by commRank as the secondary key, which comes in handy when printing...
-                for (int rankIdx = vcc->firstIdx; rankIdx < vcc->count+vcc->firstIdx; rankIdx++) {
+                for (int rankIdx = vcc->firstIdx; rankIdx < vcc->count + vcc->firstIdx; rankIdx++) {
                   int peerIdx = peerIdxConv[auxCommRanks[rankIdx].rank->peerIdx];
                   if (peerIdx != -1) {
                     if (vcc->count > 1)
@@ -1547,8 +1500,8 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
                 } // for (rankIdx)
               } else {
                 // NOCOMM ranks are in a different array.
-                struct rasCollCommsMissingRank* missingRanks = (struct rasCollCommsMissingRank*)(comm->ranks +
-                                                                                                 comm->nRanks);
+                struct rasCollCommsMissingRank* missingRanks =
+                  (struct rasCollCommsMissingRank*)(comm->ranks + comm->nRanks);
                 for (int rankIdx = 0; rankIdx < comm->nMissingRanks; rankIdx++) {
                   struct rasCollCommsMissingRank* missingRank = missingRanks + rankIdx;
                   // Filter out ranks that did not respond at all.
@@ -1557,17 +1510,16 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
                     int peerIdx = rasPeerFind(&missingRank->addr);
                     if (peerIdx != -1) {
                       if (vcc->count > 1) {
-                        rasOutAppend("  Rank %d -- GPU %s managed by process %d on node %s\n",
-                                     missingRank->commRank, rasGpuToString(missingRank->cudaDev, missingRank->nvmlDev,
-                                                                           lineBuf, sizeof(lineBuf)),
-                                     rasPeers[peerIdx].pid,
-                                     ncclSocketToHost(&missingRank->addr, rasLine, sizeof(rasLine)));
+                        rasOutAppend(
+                          "  Rank %d -- GPU %s managed by process %d on node %s\n", missingRank->commRank,
+                          rasGpuToString(missingRank->cudaDev, missingRank->nvmlDev, lineBuf, sizeof(lineBuf)),
+                          rasPeers[peerIdx].pid, ncclSocketToHost(&missingRank->addr, rasLine, sizeof(rasLine)));
                       } else {
-                        rasOutAppend("  Rank %d has status %s -- GPU %s managed by process %d on node %s\n",
-                                     missingRank->commRank, statusStr[vcc->value],
-                                     rasGpuToString(missingRank->cudaDev, missingRank->nvmlDev,
-                                                    lineBuf, sizeof(lineBuf)), rasPeers[peerIdx].pid,
-                                     ncclSocketToHost(&missingRank->addr, rasLine, sizeof(rasLine)));
+                        rasOutAppend(
+                          "  Rank %d has status %s -- GPU %s managed by process %d on node %s\n", missingRank->commRank,
+                          statusStr[vcc->value],
+                          rasGpuToString(missingRank->cudaDev, missingRank->nvmlDev, lineBuf, sizeof(lineBuf)),
+                          rasPeers[peerIdx].pid, ncclSocketToHost(&missingRank->addr, rasLine, sizeof(rasLine)));
                       }
                     } else { // peerIdx == -1
                       if (vcc->count > 1) {
@@ -1599,8 +1551,8 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
 
             // Sort the ranks by collOpCounts[collIdx] and commRank for easy counting.
             for (int rankIdx = 0; rankIdx < comm->nRanks; rankIdx++) {
-              struct rasCollComms::comm::rank* rank = comm->ranks+rankIdx;
-              struct rasAuxCommRank* auxRank = auxCommRanks+rankIdx;
+              struct rasCollComms::comm::rank* rank = comm->ranks + rankIdx;
+              struct rasAuxCommRank* auxRank = auxCommRanks + rankIdx;
               auxRank->rank = rank;
               auxRank->value = rank->collOpCounts[collIdx];
             }
@@ -1608,29 +1560,28 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
             // Calculate the frequency of different collOpCounts[collIdx] values.
             int nCollOpCounts = 0;
             for (int rankIdx = 0; rankIdx < comm->nRanks; rankIdx++) {
-              if (rankIdx == 0 || auxCommRanks[rankIdx].value != auxCommRanks[rankIdx-1].value) {
+              if (rankIdx == 0 || auxCommRanks[rankIdx].value != auxCommRanks[rankIdx - 1].value) {
                 collOpCounts[nCollOpCounts].value = auxCommRanks[rankIdx].value;
                 collOpCounts[nCollOpCounts].count = 1;
                 collOpCounts[nCollOpCounts].firstIdx = rankIdx;
                 nCollOpCounts++;
               } else {
-                collOpCounts[nCollOpCounts-1].count++;
+                collOpCounts[nCollOpCounts - 1].count++;
               }
             }
             // Sort by that frequency (most frequent first).
             qsort(collOpCounts, nCollOpCounts, sizeof(*collOpCounts), rasValCountsCompareRev);
 
             for (int coc = 0; coc < nCollOpCounts; coc++) {
-              struct rasValCount* vcc = collOpCounts+coc;
+              struct rasValCount* vcc = collOpCounts + coc;
               if (vcc->count > 1) {
                 if (vcc->value > 0)
                   rasOutAppend("  %d ranks have launched up to operation %ld\n", vcc->count, vcc->value);
-                else
-                  rasOutAppend("  %d ranks have not launched any operations\n", vcc->count);
+                else rasOutAppend("  %d ranks have not launched any operations\n", vcc->count);
               }
               if (rasCountIsOutlier(vcc->count, client->verbose, comm->commNRanks)) {
                 // auxCommRanks is sorted by commRank as the secondary key, which comes in handy when printing...
-                for (int rankIdx = vcc->firstIdx; rankIdx < vcc->count+vcc->firstIdx; rankIdx++) {
+                for (int rankIdx = vcc->firstIdx; rankIdx < vcc->count + vcc->firstIdx; rankIdx++) {
                   int peerIdx = peerIdxConv[auxCommRanks[rankIdx].rank->peerIdx];
                   if (peerIdx != -1) {
                     if (vcc->count > 1) {
@@ -1642,13 +1593,15 @@ static ncclResult_t rasClientRunComms(struct rasClient* client) {
                     } else {
                       if (vcc->value > 0) {
                         rasOutAppend("  Rank %d has launched up to operation %ld -- GPU %s managed by process %d "
-                                     "on node %s\n", auxCommRanks[rankIdx].rank->commRank, vcc->value,
+                                     "on node %s\n",
+                                     auxCommRanks[rankIdx].rank->commRank, vcc->value,
                                      rasCommRankGpuToString(auxCommRanks[rankIdx].rank, lineBuf, sizeof(lineBuf)),
                                      rasPeers[peerIdx].pid,
                                      ncclSocketToHost(&rasPeers[peerIdx].addr, rasLine, sizeof(rasLine)));
                       } else {
                         rasOutAppend("  Rank %d has not launched any operations -- GPU %s managed by process %d "
-                                     "on node %s\n", auxCommRanks[rankIdx].rank->commRank,
+                                     "on node %s\n",
+                                     auxCommRanks[rankIdx].rank->commRank,
                                      rasCommRankGpuToString(auxCommRanks[rankIdx].rank, lineBuf, sizeof(lineBuf)),
                                      rasPeers[peerIdx].pid,
                                      ncclSocketToHost(&rasPeers[peerIdx].addr, rasLine, sizeof(rasLine)));
@@ -1698,8 +1651,8 @@ fail:
 }
 
 // Generates detailed info about encountered errors, be it initialization ones or asynchronous ones.
-static void rasClientBreakDownErrors(struct rasClient* client, struct rasCollComms::comm* comm,
-                                     const int* peerIdxConv, int ncclErrors[ncclNumResults], bool isAsync) {
+static void rasClientBreakDownErrors(struct rasClient* client, struct rasCollComms::comm* comm, const int* peerIdxConv,
+                                     int ncclErrors[ncclNumResults], bool isAsync) {
   // Because the number of possible error kinds is finite and small, we don't bother in this case with allocating
   // temporary data structures, counting the errors, sorting arrays, etc.  Instead, in each iteration we pick the most
   // numerous error kind, we iterate through the ranks in search for this error, and immediately add it to the output.
@@ -1712,33 +1665,28 @@ static void rasClientBreakDownErrors(struct rasClient* client, struct rasCollCom
         maxCountIdx = (ncclResult_t)i;
       }
     } // for (i)
-    if (maxCountIdx == ncclSuccess)
-      break;
-    if (maxCount > 1)
-      rasOutAppend("  %d ranks reported %s\n", maxCount, ncclErrorToString(maxCountIdx));
+    if (maxCountIdx == ncclSuccess) break;
+    if (maxCount > 1) rasOutAppend("  %d ranks reported %s\n", maxCount, ncclErrorToString(maxCountIdx));
     if (rasCountIsOutlier(maxCount, client->verbose)) {
       for (int rankIdx = 0; rankIdx < comm->nRanks; rankIdx++) {
         if ((isAsync ? comm->ranks[rankIdx].status.asyncError : comm->ranks[rankIdx].status.initState) == maxCountIdx) {
           int peerIdx = peerIdxConv[comm->ranks[rankIdx].peerIdx];
           if (peerIdx != -1) {
             if (maxCount > 1)
-              rasOutAppend("  Rank %d -- GPU %s managed by process %d on node %s\n",
-                           comm->ranks[rankIdx].commRank,
-                           rasCommRankGpuToString(comm->ranks+rankIdx, lineBuf, sizeof(lineBuf)),
-                           rasPeers[peerIdx].pid,
-                           ncclSocketToHost(&rasPeers[peerIdx].addr, rasLine, sizeof(rasLine)));
+              rasOutAppend("  Rank %d -- GPU %s managed by process %d on node %s\n", comm->ranks[rankIdx].commRank,
+                           rasCommRankGpuToString(comm->ranks + rankIdx, lineBuf, sizeof(lineBuf)),
+                           rasPeers[peerIdx].pid, ncclSocketToHost(&rasPeers[peerIdx].addr, rasLine, sizeof(rasLine)));
             else
               rasOutAppend("  Rank %d reported %s -- GPU %s managed by process %d on node %s\n",
                            comm->ranks[rankIdx].commRank, ncclErrorToString(maxCountIdx),
-                           rasCommRankGpuToString(comm->ranks+rankIdx, lineBuf, sizeof(lineBuf)),
-                           rasPeers[peerIdx].pid,
-                           ncclSocketToHost(&rasPeers[peerIdx].addr, rasLine, sizeof(rasLine)));
+                           rasCommRankGpuToString(comm->ranks + rankIdx, lineBuf, sizeof(lineBuf)),
+                           rasPeers[peerIdx].pid, ncclSocketToHost(&rasPeers[peerIdx].addr, rasLine, sizeof(rasLine)));
           } else { // peerIdx == -1
             if (maxCount > 1)
               rasOutAppend("  Rank %d -- [process information not found]\n", comm->ranks[rankIdx].commRank);
             else
-              rasOutAppend("  Rank %d reported %s -- [process information not found]\n",
-                           comm->ranks[rankIdx].commRank, ncclErrorToString(maxCountIdx));
+              rasOutAppend("  Rank %d reported %s -- [process information not found]\n", comm->ranks[rankIdx].commRank,
+                           ncclErrorToString(maxCountIdx));
           } // peerIdx == -1
         } // if rank's error matches
       } // for (rankIdx)
@@ -1746,7 +1694,6 @@ static void rasClientBreakDownErrors(struct rasClient* client, struct rasCollCom
     ncclErrors[maxCountIdx] = 0;
   } // for (;;)
 }
-
 
 //////////////////////////////////////////////////////////////////////
 // Functions related to the handling of the internal output buffer. //
@@ -1759,20 +1706,20 @@ static void rasOutAppend(const char* format, ...) {
   va_list vargs;
   int needed;
   va_start(vargs, format);
-  needed = vsnprintf(rasOutBuffer+nRasOutBuffer, rasOutBufferSize-nRasOutBuffer, format, vargs);
+  needed = vsnprintf(rasOutBuffer + nRasOutBuffer, rasOutBufferSize - nRasOutBuffer, format, vargs);
   va_end(vargs);
 
   if (needed < 0) // Output error (whatever that might be...)
     return;
 
   // The +1 below accounts for the terminating '\0'.
-  if (needed + 1 > rasOutBufferSize-nRasOutBuffer) {
-    int newBufferSize = ROUNDUP(nRasOutBuffer+needed+1, RAS_OUT_INCREMENT);
+  if (needed + 1 > rasOutBufferSize - nRasOutBuffer) {
+    int newBufferSize = ROUNDUP(nRasOutBuffer + needed + 1, RAS_OUT_INCREMENT);
     NCCLCHECKGOTO(ncclRealloc(&rasOutBuffer, rasOutBufferSize, newBufferSize), ret, exit);
     rasOutBufferSize = newBufferSize;
 
     va_start(vargs, format);
-    needed = vsnprintf(rasOutBuffer+nRasOutBuffer, rasOutBufferSize-nRasOutBuffer, format, vargs);
+    needed = vsnprintf(rasOutBuffer + nRasOutBuffer, rasOutBufferSize - nRasOutBuffer, format, vargs);
     va_end(vargs);
 
     if (needed < 0) // Output error (whatever that might be...)
@@ -1782,8 +1729,7 @@ static void rasOutAppend(const char* format, ...) {
   nRasOutBuffer += needed;
   if (nRasOutBuffer >= rasOutBufferSize)
     nRasOutBuffer = rasOutBufferSize - 1; // Should never happen, but just to be extra sure...
-exit:
-  ;
+exit:;
 }
 
 // Copies the output data from an internal buffer to a user-supplied one, including the terminating '\0'.
@@ -1809,10 +1755,8 @@ static void rasOutReset() {
     NCCLCHECKGOTO(ncclCalloc(&rasOutBuffer, RAS_OUT_INCREMENT), ret, exit);
     rasOutBufferSize = RAS_OUT_INCREMENT;
   }
-exit:
-  ;
+exit:;
 }
-
 
 ///////////////////////////////////////////////////////////////////
 // Various sorting callbacks used when grouping/formatting data. //
@@ -1844,8 +1788,7 @@ static int ncclSocketsHostCompare(const void* p1, const void* p2) {
   // AF_INET (2) is less than AF_INET6 (10).
   int family = a1->sa.sa_family;
   if (family != a2->sa.sa_family) {
-    if (family > 0 && a2->sa.sa_family > 0)
-      return (family < a2->sa.sa_family ? -1 : 1);
+    if (family > 0 && a2->sa.sa_family > 0) return (family < a2->sa.sa_family ? -1 : 1);
     else // Put empty addresses at the end (not that it matters...).
       return (family > 0 ? -1 : 1);
   }
@@ -1853,13 +1796,11 @@ static int ncclSocketsHostCompare(const void* p1, const void* p2) {
   int cmp;
   if (family == AF_INET) {
     cmp = memcmp(&a1->sin.sin_addr, &a2->sin.sin_addr, sizeof(a1->sin.sin_addr));
-  }
-  else if (family == AF_INET6) {
+  } else if (family == AF_INET6) {
     cmp = memcmp(&a1->sin6.sin6_addr, &a2->sin6.sin6_addr, sizeof(a1->sin6.sin6_addr));
   } else {
     // The only remaining valid case are empty addresses.
-    if (family != 0)
-      INFO(NCCL_RAS, "RAS invalid address family %d -- internal error?", family);
+    if (family != 0) INFO(NCCL_RAS, "RAS invalid address family %d -- internal error?", family);
     cmp = 0; // Two empty addresses are equal...
   }
 
@@ -1872,7 +1813,7 @@ static int rasValCountsCompareRev(const void* p1, const void* p2) {
   const struct rasValCount* r2 = (const struct rasValCount*)p2;
 
   if (r1->count == r2->count) {
-    return (r1->value > r2->value ? -1 : (r1->value < r2->value ? 1: 0));
+    return (r1->value > r2->value ? -1 : (r1->value < r2->value ? 1 : 0));
   } else {
     return (r1->count > r2->count ? -1 : 1);
   }
@@ -1930,14 +1871,13 @@ static int rasAuxCommRanksValueCompare(const void* p1, const void* p2) {
   }
 }
 
-
 //////////////////////////////////////////////////////////
 // JSON utility functions for structured output format. //
 //////////////////////////////////////////////////////////
 
 // Writes the JSON document header with metadata and opens the communicators array.
-static void jsonWriteHeader(const char* ncclVersion, int cudaRuntime, int cudaDriver,
-                            const char* timestamp, int commsCount) {
+static void jsonWriteHeader(const char* ncclVersion, int cudaRuntime, int cudaDriver, const char* timestamp,
+                            int commsCount) {
   rasOutAppend("{\n");
   rasOutAppend("  \"nccl_version\": \"%s\",\n", ncclVersion);
   rasOutAppend("  \"cuda_runtime_version\": %d,\n", cudaRuntime);
@@ -1948,8 +1888,8 @@ static void jsonWriteHeader(const char* ncclVersion, int cudaRuntime, int cudaDr
 }
 
 // Starts a new communicator entry in the JSON output.
-static void jsonStartCommunicator(unsigned long commHash, unsigned long hostHash, unsigned long pidHash,
-                                  int commSize, int ranksCount, int missingCount, bool firstComm) {
+static void jsonStartCommunicator(unsigned long commHash, unsigned long hostHash, unsigned long pidHash, int commSize,
+                                  int ranksCount, int missingCount, bool firstComm) {
   if (!firstComm) rasOutAppend(",\n");
   rasOutAppend("    {\n");
   rasOutAppend("      \"hash\": \"0x%lx\",\n", commHash);
@@ -1961,9 +1901,9 @@ static void jsonStartCommunicator(unsigned long commHash, unsigned long hostHash
 }
 
 // Writes detailed rank information including status and collective operation counts.
-static void jsonWriteRankData(int rank, const char* host, int pid, int cudaDev, int nvmlDev,
-                              int initState, int asyncError, bool finalizeCalled, bool destroyFlag,
-                              bool abortFlag, const unsigned long* collCounts, bool firstRank) {
+static void jsonWriteRankData(int rank, const char* host, int pid, int cudaDev, int nvmlDev, int initState,
+                              int asyncError, bool finalizeCalled, bool destroyFlag, bool abortFlag,
+                              const unsigned long* collCounts, bool firstRank) {
   if (!firstRank) rasOutAppend(",\n");
   rasOutAppend("        {\n");
   rasOutAppend("          \"rank\": %d,\n", rank);
@@ -2001,8 +1941,8 @@ static void jsonStartMissingRanks() {
 }
 
 // Writes basic information for a missing rank.
-static void jsonWriteMissingRank(int rank, const char* host, int pid, int cudaDev, int nvmlDev,
-                                 bool unresponsive, bool dead, bool firstMissing) {
+static void jsonWriteMissingRank(int rank, const char* host, int pid, int cudaDev, int nvmlDev, bool unresponsive,
+                                 bool dead, bool firstMissing) {
   if (!firstMissing) rasOutAppend(",\n");
   rasOutAppend("        {\n");
   rasOutAppend("          \"rank\": %d,\n", rank);
@@ -2035,7 +1975,6 @@ static void jsonWriteFooter(double collectionTime, int timeoutsCount) {
   rasOutAppend("}\n");
 }
 
-
 ////////////////////////////////////////////////////////////
 // String formatting functions for various types of data. //
 ////////////////////////////////////////////////////////////
@@ -2044,20 +1983,20 @@ static void jsonWriteFooter(double collectionTime, int timeoutsCount) {
 const char* rasGpuDevsToString(uint64_t cudaDevs, uint64_t nvmlDevs, char* buf, size_t size) {
   bool first = true;
   buf[0] = '\0';
-  for (int i = 0; i < sizeof(cudaDevs)*8; i++)
+  for (int i = 0; i < sizeof(cudaDevs) * 8; i++)
     if (cudaDevs & (1ULL << i)) {
-      snprintf(buf+strlen(buf), size-strlen(buf), "%s%d", (first ? "" : ","), i);
+      snprintf(buf + strlen(buf), size - strlen(buf), "%s%d", (first ? "" : ","), i);
       first = false;
     }
   if (cudaDevs != nvmlDevs) {
-    snprintf(buf+strlen(buf), size-strlen(buf), " (NVML ");
+    snprintf(buf + strlen(buf), size - strlen(buf), " (NVML ");
     first = true;
-    for (int i = 0; i < sizeof(nvmlDevs)*8; i++)
+    for (int i = 0; i < sizeof(nvmlDevs) * 8; i++)
       if (nvmlDevs & (1ULL << i)) {
-        snprintf(buf+strlen(buf), size-strlen(buf), "%s%d", (first ? "" : ","), i);
+        snprintf(buf + strlen(buf), size - strlen(buf), "%s%d", (first ? "" : ","), i);
         first = false;
       }
-    snprintf(buf+strlen(buf), size-strlen(buf), ")");
+    snprintf(buf + strlen(buf), size - strlen(buf), ")");
   }
   return buf;
 }
@@ -2067,7 +2006,7 @@ const char* rasGpuDevsToString(uint64_t cudaDevs, uint64_t nvmlDevs, char* buf, 
 static const char* rasGpuToString(int cudaDev, int nvmlDev, char* buf, size_t size) {
   snprintf(buf, size, "%d", cudaDev);
   if (cudaDev != nvmlDev) {
-    snprintf(buf+strlen(buf), size-strlen(buf), " (NVML %d)", nvmlDev);
+    snprintf(buf + strlen(buf), size - strlen(buf), " (NVML %d)", nvmlDev);
   }
   return buf;
 }
@@ -2081,14 +2020,22 @@ static const char* rasCommRankGpuToString(const struct rasCollComms::comm::rank*
 // Converts a NCCL error result to a string.
 static const char* ncclErrorToString(ncclResult_t err) {
   switch (err) {
-    case ncclUnhandledCudaError     : return "Unhandled CUDA error";
-    case ncclSystemError            : return "System error";
-    case ncclInternalError          : return "Internal error";
-    case ncclInvalidArgument        : return "Invalid argument";
-    case ncclInvalidUsage           : return "Invalid usage";
-    case ncclRemoteError            : return "Remote process error";
-    case ncclInProgress             : return "NCCL operation in progress";
-    default                         : return "Unexpected error";
+  case ncclUnhandledCudaError:
+    return "Unhandled CUDA error";
+  case ncclSystemError:
+    return "System error";
+  case ncclInternalError:
+    return "Internal error";
+  case ncclInvalidArgument:
+    return "Invalid argument";
+  case ncclInvalidUsage:
+    return "Invalid usage";
+  case ncclRemoteError:
+    return "Remote process error";
+  case ncclInProgress:
+    return "NCCL operation in progress";
+  default:
+    return "Unexpected error";
   }
 }
 
@@ -2096,18 +2043,17 @@ static const char* ncclErrorToString(ncclResult_t err) {
 const char* ncclSocketToHost(const union ncclSocketAddress* addr, char* buf, size_t size) {
   if (addr->sa.sa_family > 0)
     return inet_ntop(addr->sa.sa_family,
-                     (addr->sa.sa_family == AF_INET ? (void*)&addr->sin.sin_addr : (void*)&addr->sin6.sin6_addr),
-                     buf, size);
+                     (addr->sa.sa_family == AF_INET ? (void*)&addr->sin.sin_addr : (void*)&addr->sin6.sin6_addr), buf,
+                     size);
   else {
-    if (size > 0)
-      buf[0] = '\0';
+    if (size > 0) buf[0] = '\0';
     return buf;
   }
 }
 
 // Dump communicator data to JSON format - build JSON in output buffer.
-static void rasDumpCommsToJSON(struct rasClient* client, struct rasCollComms* commsData,
-                               struct rasCollective* coll, const int* peerIdxConv) {
+static void rasDumpCommsToJSON(struct rasClient* client, struct rasCollComms* commsData, struct rasCollective* coll,
+                               const int* peerIdxConv) {
   char hostBuf[256], timeBuf[64];
 
   time_t timestampSec = time(NULL);
@@ -2116,15 +2062,15 @@ static void rasDumpCommsToJSON(struct rasClient* client, struct rasCollComms* co
   strftime(timeBuf, sizeof(timeBuf), "%F %T", tmInfo);
 
   // Write JSON header with metadata.
-  jsonWriteHeader(STR(NCCL_MAJOR) "." STR(NCCL_MINOR) "." STR(NCCL_PATCH) NCCL_SUFFIX,
-                  cudaRuntimeVersion, cudaDriverVersion, timeBuf, commsData->nComms);
+  jsonWriteHeader(STR(NCCL_MAJOR) "." STR(NCCL_MINOR) "." STR(NCCL_PATCH) NCCL_SUFFIX, cudaRuntimeVersion,
+                                                              cudaDriverVersion, timeBuf, commsData->nComms);
 
   struct rasCollComms::comm* comm = commsData->comms;
 
   // Iterate through communicators.
   for (int commIdx = 0; commIdx < commsData->nComms; commIdx++) {
-    jsonStartCommunicator(comm->commId.commHash, comm->commId.hostHash, comm->commId.pidHash,
-                          comm->commNRanks, comm->nRanks, comm->nMissingRanks, (commIdx == 0));
+    jsonStartCommunicator(comm->commId.commHash, comm->commId.hostHash, comm->commId.pidHash, comm->commNRanks,
+                          comm->nRanks, comm->nMissingRanks, (commIdx == 0));
 
     // Add each rank.
     for (int rankIdx = 0; rankIdx < comm->nRanks; rankIdx++) {
@@ -2139,10 +2085,9 @@ static void rasDumpCommsToJSON(struct rasClient* client, struct rasCollComms* co
         pid = rasPeers[rasPeerIdx].pid;
       }
 
-      jsonWriteRankData(rank->commRank, host, pid, rank->cudaDev, rank->nvmlDev,
-                        rank->status.initState, rank->status.asyncError,
-                        rank->status.finalizeCalled, rank->status.destroyFlag, rank->status.abortFlag,
-                        rank->collOpCounts, (rankIdx == 0));
+      jsonWriteRankData(rank->commRank, host, pid, rank->cudaDev, rank->nvmlDev, rank->status.initState,
+                        rank->status.asyncError, rank->status.finalizeCalled, rank->status.destroyFlag,
+                        rank->status.abortFlag, rank->collOpCounts, (rankIdx == 0));
     }
 
     // Start missing ranks section.
@@ -2157,33 +2102,32 @@ static void rasDumpCommsToJSON(struct rasClient* client, struct rasCollComms* co
       int rasPeerIdx = rasPeerFind(&missingRank->addr);
       const char* host = "unknown";
       int pid = -1;
-      bool unresponsive = (bsearch(&missingRank->addr, coll->peers, coll->nPeers, sizeof(*coll->peers),
-                                   ncclSocketsCompare) == nullptr);
+      bool unresponsive =
+        (bsearch(&missingRank->addr, coll->peers, coll->nPeers, sizeof(*coll->peers), ncclSocketsCompare) == nullptr);
       bool dead = rasPeerIsDead(&missingRank->addr);
       if (rasPeerIdx >= 0) {
         host = ncclSocketToHost(&rasPeers[rasPeerIdx].addr, hostBuf, sizeof(hostBuf));
         pid = rasPeers[rasPeerIdx].pid;
       }
 
-      jsonWriteMissingRank(missingRank->commRank, host, pid, missingRank->cudaDev, missingRank->nvmlDev,
-                           unresponsive, dead, (missingIdx == 0));
+      jsonWriteMissingRank(missingRank->commRank, host, pid, missingRank->cudaDev, missingRank->nvmlDev, unresponsive,
+                           dead, (missingIdx == 0));
     }
 
     jsonEndCommunicator();
 
     // Move to the next communicator.
-    comm = (struct rasCollComms::comm*)(((char*)(comm+1)) + comm->nRanks * sizeof(*comm->ranks) +
+    comm = (struct rasCollComms::comm*)(((char*)(comm + 1)) + comm->nRanks * sizeof(*comm->ranks) +
                                         comm->nMissingRanks * sizeof(struct rasCollCommsMissingRank));
   }
 
   // Write JSON footer with RAS metadata.
-  jsonWriteFooter((clockNano()-coll->startTime)/1e9, coll->nLegTimeouts);
+  jsonWriteFooter((clockNano() - coll->startTime) / 1e9, coll->nLegTimeouts);
 }
 
 // Determines if the given count constitutes an outlier.
 static bool rasCountIsOutlier(int count, bool verbose, int totalCount) {
-  if (count == 1)
-    return true; // A single rank is always considered an outlier...
+  if (count == 1) return true; // A single rank is always considered an outlier...
   if (verbose) {
     return (totalCount != -1 ? count < totalCount * RAS_CLIENT_VERBOSE_OUTLIER_FRACTION : true);
   } else {
@@ -2217,14 +2161,14 @@ void rasClientsNotifyEvent(rasEventGroup group, const struct rasEventNotificatio
           }
         }
         if (peer) {
-          char hostBuf[SOCKET_NAME_MAXLEN+1];
+          char hostBuf[SOCKET_NAME_MAXLEN + 1];
           char cudaDevs[256], nvmlDevs[256];
           ncclSocketToHost(&peer->addr, hostBuf, sizeof(hostBuf));
           // Build cuda_devs array.
           int offset = 0;
           snprintf(cudaDevs + offset, sizeof(cudaDevs) - offset, "[");
           offset = strlen(cudaDevs);
-          for (int i = 0; i < sizeof(peer->cudaDevs)*8; i++) {
+          for (int i = 0; i < sizeof(peer->cudaDevs) * 8; i++) {
             if (peer->cudaDevs & (1ULL << i)) {
               snprintf(cudaDevs + offset, sizeof(cudaDevs) - offset, "%s%d", (offset > 1 ? "," : ""), i);
               offset = strlen(cudaDevs);
@@ -2235,7 +2179,7 @@ void rasClientsNotifyEvent(rasEventGroup group, const struct rasEventNotificatio
           offset = 0;
           snprintf(nvmlDevs + offset, sizeof(nvmlDevs) - offset, "[");
           offset = strlen(nvmlDevs);
-          for (int i = 0; i < sizeof(peer->nvmlDevs)*8; i++) {
+          for (int i = 0; i < sizeof(peer->nvmlDevs) * 8; i++) {
             if (peer->nvmlDevs & (1ULL << i)) {
               snprintf(nvmlDevs + offset, sizeof(nvmlDevs) - offset, "%s%d", (offset > 1 ? "," : ""), i);
               offset = strlen(nvmlDevs);
@@ -2258,7 +2202,7 @@ void rasClientsNotifyEvent(rasEventGroup group, const struct rasEventNotificatio
                    timeStr, groupStr, event->eventType, hostBuf, peer->pid, cudaDevs, nvmlDevs, event->details);
         } else if (event->peerAddr) {
           // Peer not found, just use address.
-          char addrStr[SOCKET_NAME_MAXLEN+1];
+          char addrStr[SOCKET_NAME_MAXLEN + 1];
           ncclSocketToString(event->peerAddr, addrStr, sizeof(addrStr));
           snprintf(formattedNotification, sizeof(formattedNotification),
                    "{\n"
@@ -2289,11 +2233,11 @@ void rasClientsNotifyEvent(rasEventGroup group, const struct rasEventNotificatio
           rasPeerToString(event->peerAddr, peerStr, sizeof(peerStr));
         }
         if (strlen(peerStr) > 0) {
-          snprintf(formattedNotification, sizeof(formattedNotification),
-                   "[%s] %s: %s %s\n", timeStr, event->eventType, peerStr, event->details);
+          snprintf(formattedNotification, sizeof(formattedNotification), "[%s] %s: %s %s\n", timeStr, event->eventType,
+                   peerStr, event->details);
         } else {
-          snprintf(formattedNotification, sizeof(formattedNotification),
-                   "[%s] %s: %s\n", timeStr, event->eventType, event->details);
+          snprintf(formattedNotification, sizeof(formattedNotification), "[%s] %s: %s\n", timeStr, event->eventType,
+                   event->details);
         }
       }
 

--- a/projects/rccl/src/ras/collectives.cc
+++ b/projects/rccl/src/ras/collectives.cc
@@ -43,9 +43,8 @@ static ncclResult_t rasLinkSendCollReq(struct rasLink* link, struct rasCollectiv
                                        const struct rasCollRequest* req, size_t reqLen, struct rasConnection* fromConn);
 static ncclResult_t rasConnSendCollReq(struct rasConnection* conn, const struct rasCollRequest* req, size_t reqLen);
 static ncclResult_t rasCollReadyResp(struct rasCollective* coll);
-static ncclResult_t rasConnSendCollResp(struct rasConnection* conn,
-                                        const union ncclSocketAddress* rootAddr, uint64_t rootId,
-                                        const union ncclSocketAddress* peers, int nPeers,
+static ncclResult_t rasConnSendCollResp(struct rasConnection* conn, const union ncclSocketAddress* rootAddr,
+                                        uint64_t rootId, const union ncclSocketAddress* peers, int nPeers,
                                         const char* data, int nData, int nLegTimeouts);
 
 static ncclResult_t rasCollConnsInit(struct rasCollRequest** pReq, size_t* pReqLen, char** pData, int* pNData);
@@ -59,7 +58,6 @@ static int peersHashesCompare(const void* p1, const void* p2);
 static int peersHashesSearch(const void* k, const void* e);
 static int rasCommIdCompare(const void* p1, const void* p2);
 static int rasCollCommsMissingRankSearch(const void* k, const void* e);
-
 
 ///////////////////////////////////////////////////////////////////////////////////////
 // Functions related to the initialization of collectives and the message exchanges. //
@@ -76,8 +74,7 @@ static ncclResult_t getNewCollEntry(struct rasCollective** pColl) {
   coll->fromConn = nullptr;
   // We are unlikely to use the whole array, but at least we won't need to realloc.
   nRasConns = 0;
-  for (struct rasConnection* conn = rasConnsHead; conn; conn = conn->next)
-    nRasConns++;
+  for (struct rasConnection* conn = rasConnsHead; conn; conn = conn->next) nRasConns++;
   NCCLCHECK(ncclCalloc(&coll->fwdConns, nRasConns));
 
   if (rasCollectivesHead) {
@@ -107,16 +104,15 @@ void rasCollReqInit(struct rasCollRequest* req) {
 // in scenarios such as a total of two peers.
 // pColl provides on return a pointer to the allocated rasCollective structure to track this collective (unless
 // it's a broadcast, which require no such tracking).
-ncclResult_t rasNetSendCollReq(const struct rasCollRequest* req, bool* pAllDone,
-                               struct rasCollective** pColl, struct rasConnection* fromConn) {
+ncclResult_t rasNetSendCollReq(const struct rasCollRequest* req, bool* pAllDone, struct rasCollective** pColl,
+                               struct rasConnection* fromConn) {
   struct rasCollective* coll = nullptr;
   struct rasCollRequest* reqMod = (struct rasCollRequest*)req;
   size_t reqLen = 0;
   if (req->type >= RAS_COLL_CONNS) {
     // Keep track of this collective operation so that we can handle the responses appropriately.
     NCCLCHECK(getNewCollEntry(&coll));
-    if (pColl)
-      *pColl = coll;
+    if (pColl) *pColl = coll;
     memcpy(&coll->rootAddr, &req->rootAddr, sizeof(coll->rootAddr));
     coll->rootId = req->rootId;
     coll->type = req->type;
@@ -128,13 +124,11 @@ ncclResult_t rasNetSendCollReq(const struct rasCollRequest* req, bool* pAllDone,
     }
 
     // Collective-specific initialization of accumulated data (using local data for now).
-    if (req->type == RAS_COLL_CONNS)
-      (void)rasCollConnsInit(&reqMod, &reqLen, &coll->data, &coll->nData);
-    else if (req->type == RAS_COLL_COMMS)
-      (void)rasCollCommsInit(&reqMod, &reqLen, &coll->data, &coll->nData);
+    if (req->type == RAS_COLL_CONNS) (void)rasCollConnsInit(&reqMod, &reqLen, &coll->data, &coll->nData);
+    else if (req->type == RAS_COLL_COMMS) (void)rasCollCommsInit(&reqMod, &reqLen, &coll->data, &coll->nData);
   } else { // req->type < RAS_COLL_CONNS
     // Add the info to the collective message history.
-    nRasCollHistory = std::min(nRasCollHistory+1, COLL_HISTORY_SIZE);
+    nRasCollHistory = std::min(nRasCollHistory + 1, COLL_HISTORY_SIZE);
     memcpy(&rasCollHistory[rasCollHistNextIdx].rootAddr, &req->rootAddr,
            sizeof(rasCollHistory[rasCollHistNextIdx].rootAddr));
     rasCollHistory[rasCollHistNextIdx].rootId = req->rootId;
@@ -144,22 +138,18 @@ ncclResult_t rasNetSendCollReq(const struct rasCollRequest* req, bool* pAllDone,
     if (req->type == RAS_BC_DEADPEER) {
       bool done = false;
       rasMsgHandleBCDeadPeer(&reqMod, &reqLen, &done);
-      if (done)
-        goto exit;
+      if (done) goto exit;
     }
   } // req->type < RAS_COLL_CONNS
 
-  for (struct rasConnection* conn = rasConnsHead; conn; conn = conn->next)
-    conn->linkFlag = false;
+  for (struct rasConnection* conn = rasConnsHead; conn; conn = conn->next) conn->linkFlag = false;
 
   (void)rasLinkSendCollReq(&rasNextLink, coll, reqMod, reqLen, fromConn);
   (void)rasLinkSendCollReq(&rasPrevLink, coll, reqMod, reqLen, fromConn);
 
-  if (coll && pAllDone)
-    *pAllDone = (coll->nFwdSent == coll->nFwdRecv);
+  if (coll && pAllDone) *pAllDone = (coll->nFwdSent == coll->nFwdRecv);
 exit:
-  if (reqMod != req)
-    free(reqMod);
+  if (reqMod != req) free(reqMod);
   return ncclSuccess;
 }
 
@@ -203,11 +193,11 @@ static ncclResult_t rasConnSendCollReq(struct rasConnection* conn, const struct 
 ncclResult_t rasMsgHandleCollReq(struct rasMsg* msg, struct rasSocket* sock) {
   bool allDone = false;
   struct rasCollective* coll = nullptr;
-  char line[SOCKET_NAME_MAXLEN+1];
+  char line[SOCKET_NAME_MAXLEN + 1];
 
   INFO(NCCL_RAS, "RAS handling collReq from %s (root %s:%" PRIu64 ", timeout %" PRId64 ", type %d)",
        ncclSocketToString(&sock->sock.addr, rasLine), ncclSocketToString(&msg->collReq.rootAddr, line),
-       msg->collReq.rootId, (int64_t)(msg->collReq.timeout/CLOCK_UNITS_PER_SEC), msg->collReq.type);
+       msg->collReq.rootId, (int64_t)(msg->collReq.timeout / CLOCK_UNITS_PER_SEC), msg->collReq.type);
   if (sock->conn == nullptr) {
     INFO(NCCL_RAS, "RAS socket lacks a connection: status %d -- internal error?", sock->status);
     return ncclInternalError;
@@ -224,7 +214,8 @@ ncclResult_t rasMsgHandleCollReq(struct rasMsg* msg, struct rasSocket* sock) {
         // Send an empty response so that the sender can account for it.  The non-empty response has already been
         // sent through the connection that we received the request through first.
         NCCLCHECK(rasConnSendCollResp(sock->conn, &msg->collReq.rootAddr, msg->collReq.rootId,
-                                      /*peers*/nullptr, /*nPeers*/0, /*data*/nullptr, /*nData*/0, /*nLegTimeouts*/0));
+                                      /*peers*/ nullptr, /*nPeers*/ 0, /*data*/ nullptr, /*nData*/ 0,
+                                      /*nLegTimeouts*/ 0));
       }
       goto exit;
     }
@@ -240,12 +231,13 @@ ncclResult_t rasMsgHandleCollReq(struct rasMsg* msg, struct rasSocket* sock) {
           // Send an empty response so that the sender can account for it.  The non-empty response will be
           // sent through the connection that we received the request through first.
           NCCLCHECK(rasConnSendCollResp(sock->conn, &msg->collReq.rootAddr, msg->collReq.rootId,
-                                        /*peers*/nullptr, /*nPeers*/0, /*data*/nullptr, /*nData*/0, /*nLegTimeouts*/0));
+                                        /*peers*/ nullptr, /*nPeers*/ 0, /*data*/ nullptr, /*nData*/ 0,
+                                        /*nLegTimeouts*/ 0));
           goto exit;
         } else {
           // Should never happen.
-          INFO(NCCL_RAS, "RAS collective type mismatch: request %d, ongoing %d -- internal error?",
-               msg->collReq.type, coll->type);
+          INFO(NCCL_RAS, "RAS collective type mismatch: request %d, ongoing %d -- internal error?", msg->collReq.type,
+               coll->type);
         }
       } // if match
     } // for (coll)
@@ -275,11 +267,11 @@ exit:
 static ncclResult_t rasCollReadyResp(struct rasCollective* coll) {
   if (coll->fromConn) {
     // For remotely-initiated collectives, send the response back.
-    NCCLCHECK(rasConnSendCollResp(coll->fromConn, &coll->rootAddr, coll->rootId,
-                                  coll->peers, coll->nPeers, coll->data, coll->nData, coll->nLegTimeouts));
+    NCCLCHECK(rasConnSendCollResp(coll->fromConn, &coll->rootAddr, coll->rootId, coll->peers, coll->nPeers, coll->data,
+                                  coll->nData, coll->nLegTimeouts));
 
     // Add the identifying info to the collective message history.
-    nRasCollHistory = std::min(nRasCollHistory+1, COLL_HISTORY_SIZE);
+    nRasCollHistory = std::min(nRasCollHistory + 1, COLL_HISTORY_SIZE);
     memcpy(&rasCollHistory[rasCollHistNextIdx].rootAddr, &coll->rootAddr,
            sizeof(rasCollHistory[rasCollHistNextIdx].rootAddr));
     rasCollHistory[rasCollHistNextIdx].rootId = coll->rootId;
@@ -295,12 +287,11 @@ static ncclResult_t rasCollReadyResp(struct rasCollective* coll) {
 
 // Sends a collective response via the connection we originally received the request from.  The message should be
 // a cumulative response from this process and all the processes that we forwarded the request to.
-static ncclResult_t rasConnSendCollResp(struct rasConnection* conn,
-                                        const union ncclSocketAddress* rootAddr, uint64_t rootId,
-                                        const union ncclSocketAddress* peers, int nPeers,
+static ncclResult_t rasConnSendCollResp(struct rasConnection* conn, const union ncclSocketAddress* rootAddr,
+                                        uint64_t rootId, const union ncclSocketAddress* peers, int nPeers,
                                         const char* data, int nData, int nLegTimeouts) {
   struct rasMsg* msg = nullptr;
-  int msgLen = rasMsgLength(RAS_MSG_COLLRESP) + nPeers*sizeof(*peers);
+  int msgLen = rasMsgLength(RAS_MSG_COLLRESP) + nPeers * sizeof(*peers);
   int dataOffset = 0;
 
   if (nData > 0) {
@@ -316,10 +307,8 @@ static ncclResult_t rasConnSendCollResp(struct rasConnection* conn,
   msg->collResp.nLegTimeouts = nLegTimeouts;
   msg->collResp.nPeers = nPeers;
   msg->collResp.nData = nData;
-  if (nPeers)
-    memcpy(msg->collResp.peers, peers, nPeers*sizeof(*msg->collResp.peers));
-  if (nData)
-    memcpy(((char*)msg)+dataOffset, data, nData);
+  if (nPeers) memcpy(msg->collResp.peers, peers, nPeers * sizeof(*msg->collResp.peers));
+  if (nData) memcpy(((char*)msg) + dataOffset, data, nData);
 
   rasConnEnqueueMsg(conn, msg, msgLen);
 
@@ -331,7 +320,7 @@ static ncclResult_t rasConnSendCollResp(struct rasConnection* conn,
 // accumulated response back.
 ncclResult_t rasMsgHandleCollResp(struct rasMsg* msg, struct rasSocket* sock) {
   struct rasCollective* coll;
-  char line[SOCKET_NAME_MAXLEN+1];
+  char line[SOCKET_NAME_MAXLEN + 1];
 
   INFO(NCCL_RAS, "RAS handling collResp from %s (root %s:%" PRIu64 ", nPeers %d, nData %d, nLegTimeouts %d)",
        ncclSocketToString(&sock->sock.addr, rasLine), ncclSocketToString(&msg->collResp.rootAddr, line),
@@ -363,21 +352,18 @@ ncclResult_t rasMsgHandleCollResp(struct rasMsg* msg, struct rasSocket* sock) {
   coll->nFwdRecv++;
   if (msg->collResp.nData > 0) {
     // Collective-specific merging of the response into locally accumulated data.
-    if (coll->type == RAS_COLL_CONNS)
-      NCCLCHECK(rasCollConnsMerge(coll, msg));
-    else if (coll->type == RAS_COLL_COMMS)
-      NCCLCHECK(rasCollCommsMerge(coll, msg));
+    if (coll->type == RAS_COLL_CONNS) NCCLCHECK(rasCollConnsMerge(coll, msg));
+    else if (coll->type == RAS_COLL_COMMS) NCCLCHECK(rasCollCommsMerge(coll, msg));
   }
   // We merge the peers after merging the data, so that the data merge function can rely on peers being unchanged.
   if (msg->collResp.nPeers > 0) {
     NCCLCHECK(ncclRealloc(&coll->peers, coll->nPeers, coll->nPeers + msg->collResp.nPeers));
-    memcpy(coll->peers+coll->nPeers, msg->collResp.peers, msg->collResp.nPeers * sizeof(*coll->peers));
+    memcpy(coll->peers + coll->nPeers, msg->collResp.peers, msg->collResp.nPeers * sizeof(*coll->peers));
     coll->nPeers += msg->collResp.nPeers;
   }
 
   // If we received all the data we were waiting for, send our response back.
-  if (coll->nFwdSent == coll->nFwdRecv)
-    NCCLCHECK(rasCollReadyResp(coll));
+  if (coll->nFwdSent == coll->nFwdRecv) NCCLCHECK(rasCollReadyResp(coll));
 exit:
   return ncclSuccess;
 }
@@ -387,11 +373,10 @@ exit:
 void rasCollsPurgeConn(struct rasConnection* conn) {
   for (struct rasCollective* coll = rasCollectivesHead; coll;) {
     struct rasCollective* collNext = coll->next;
-    char line[SOCKET_NAME_MAXLEN+1];
+    char line[SOCKET_NAME_MAXLEN + 1];
     if (coll->fromConn == conn) {
       INFO(NCCL_RAS, "RAS purging collective %s:%" PRIu64 " because it comes from %s",
-           ncclSocketToString(&coll->rootAddr, line), coll->rootId,
-           ncclSocketToString(&conn->addr, rasLine));
+           ncclSocketToString(&coll->rootAddr, line), coll->rootId, ncclSocketToString(&conn->addr, rasLine));
       rasCollFree(coll);
     } else {
       for (int i = 0; i < coll->nFwdSent; i++) {
@@ -399,12 +384,12 @@ void rasCollsPurgeConn(struct rasConnection* conn) {
           coll->fwdConns[i] = nullptr;
           coll->nFwdRecv++;
           coll->nLegTimeouts++;
-          INFO(NCCL_RAS, "RAS not waiting for response from %s to collective %s:%" PRIu64 " "
+          INFO(NCCL_RAS,
+               "RAS not waiting for response from %s to collective %s:%" PRIu64 " "
                "(nFwdSent %d, nFwdRecv %d, nLegTimeouts %d)",
                ncclSocketToString(&conn->addr, rasLine), ncclSocketToString(&coll->rootAddr, line), coll->rootId,
                coll->nFwdSent, coll->nFwdRecv, coll->nLegTimeouts);
-          if (coll->nFwdSent == coll->nFwdRecv)
-            (void)rasCollReadyResp(coll);
+          if (coll->nFwdSent == coll->nFwdRecv) (void)rasCollReadyResp(coll);
           break;
         }
       } // for (i)
@@ -415,21 +400,16 @@ void rasCollsPurgeConn(struct rasConnection* conn) {
 
 // Frees a rasCollective entry and any memory associated with it.
 void rasCollFree(struct rasCollective* coll) {
-  if (coll == nullptr)
-    return;
+  if (coll == nullptr) return;
 
   free(coll->fwdConns);
   free(coll->peers);
   free(coll->data);
 
-  if (coll == rasCollectivesHead)
-    rasCollectivesHead = rasCollectivesHead->next;
-  if (coll == rasCollectivesTail)
-    rasCollectivesTail = rasCollectivesTail->prev;
-  if (coll->prev)
-    coll->prev->next = coll->next;
-  if (coll->next)
-    coll->next->prev = coll->prev;
+  if (coll == rasCollectivesHead) rasCollectivesHead = rasCollectivesHead->next;
+  if (coll == rasCollectivesTail) rasCollectivesTail = rasCollectivesTail->prev;
+  if (coll->prev) coll->prev->next = coll->next;
+  if (coll->next) coll->next->prev = coll->prev;
   free(coll);
 }
 
@@ -459,19 +439,19 @@ void rasCollsHandleTimeouts(int64_t now, int64_t* nextWakeup) {
         for (int i = 0; i < coll->nFwdSent; i++) {
           if (coll->fwdConns[i]) {
             struct rasConnection* conn = coll->fwdConns[i];
-            char line[SOCKET_NAME_MAXLEN+1];
+            char line[SOCKET_NAME_MAXLEN + 1];
             if (!conn->experiencingDelays && conn->sock) {
               // Ensure that the connection is fully established and operational, and that the socket hasn't been
               // re-created during the handling of the collective (which would suggest that the request may have been
               // lost).
-              if (conn->sock->status == RAS_SOCK_READY && conn->sock->createTime < coll->startTime)
-                continue;
+              if (conn->sock->status == RAS_SOCK_READY && conn->sock->createTime < coll->startTime) continue;
             }
             // In all other cases we declare a timeout so that we can (hopefully) recover.
-            INFO(NCCL_RAS, "RAS not waiting for response from %s to collective %s:%" PRIu64 " "
+            INFO(NCCL_RAS,
+                 "RAS not waiting for response from %s to collective %s:%" PRIu64 " "
                  "(nFwdSent %d, nFwdRecv %d, nLegTimeouts %d)",
-                 ncclSocketToString(&conn->addr, rasLine), ncclSocketToString(&coll->rootAddr, line),
-                 coll->rootId, coll->nFwdSent, coll->nFwdRecv, coll->nLegTimeouts);
+                 ncclSocketToString(&conn->addr, rasLine), ncclSocketToString(&coll->rootAddr, line), coll->rootId,
+                 coll->nFwdSent, coll->nFwdRecv, coll->nLegTimeouts);
             coll->fwdConns[i] = nullptr;
             coll->nFwdRecv++;
             coll->nLegTimeouts++;
@@ -486,25 +466,26 @@ void rasCollsHandleTimeouts(int64_t now, int64_t* nextWakeup) {
           if (now - coll->startTime > coll->timeout + RAS_COLLECTIVE_EXTRA_TIMEOUT) {
             // We've exceeded even the longer timeout, which is unexpected.  Try to return whatever we have (though
             // the originator of the collective, if it's not us, may have timed out already anyway).
-            INFO(NCCL_RAS, "RAS collective %s:%" PRIu64 " timeout error (%" PRId64 "s) -- giving up on %d missing responses",
+            INFO(NCCL_RAS,
+                 "RAS collective %s:%" PRIu64 " timeout error (%" PRId64 "s) -- giving up on %d missing responses",
                  ncclSocketToString(&coll->rootAddr, rasLine), coll->rootId,
                  (int64_t)((now - coll->startTime) / CLOCK_UNITS_PER_SEC), coll->nFwdSent - coll->nFwdRecv);
             coll->nLegTimeouts += coll->nFwdSent - coll->nFwdRecv;
             coll->nFwdRecv = coll->nFwdSent;
             (void)rasCollReadyResp(coll);
           } else {
-            *nextWakeup = std::min(*nextWakeup, static_cast<int64_t>(coll->startTime+coll->timeout+RAS_COLLECTIVE_EXTRA_TIMEOUT));
+            *nextWakeup = std::min(*nextWakeup, static_cast<int64_t>(coll->startTime + coll->timeout +
+                                                                     RAS_COLLECTIVE_EXTRA_TIMEOUT));
           }
         } // conn->nFwdRecv < conn->nFwdSent
       } else {
-        *nextWakeup = std::min(*nextWakeup, static_cast<int64_t>(coll->startTime+coll->timeout));
+        *nextWakeup = std::min(*nextWakeup, static_cast<int64_t>(coll->startTime + coll->timeout));
       }
     } // if (coll->timeout > 0)
 
     coll = collNext;
   } // for (coll)
 }
-
 
 /////////////////////////////////////////////////////////////////////////
 // Functions related to the handling of the RAS_COLL_CONNS collective. //
@@ -524,19 +505,16 @@ static ncclResult_t rasCollConnsInit(struct rasCollRequest** pReq, size_t* pReqL
   // will need.
   for (struct rasConnection* conn = rasConnsHead; conn; conn = conn->next) {
     if (conn->travelTimeCount > 0) {
-      if (connsData.travelTimeMin > conn->travelTimeMin)
-        connsData.travelTimeMin = conn->travelTimeMin;
-      if (connsData.travelTimeMax < conn->travelTimeMax)
-        connsData.travelTimeMax = conn->travelTimeMax;
+      if (connsData.travelTimeMin > conn->travelTimeMin) connsData.travelTimeMin = conn->travelTimeMin;
+      if (connsData.travelTimeMax < conn->travelTimeMax) connsData.travelTimeMax = conn->travelTimeMax;
       connsData.travelTimeSum += conn->travelTimeSum;
       connsData.travelTimeCount += conn->travelTimeCount;
       connsData.nConns++;
-      if (conn->travelTimeMin < 0)
-        connsData.nNegativeMins++;
+      if (conn->travelTimeMin < 0) connsData.nNegativeMins++;
     }
   }
 
-  *pNData = sizeof(connsData) + connsData.nNegativeMins*sizeof(*connsData.negativeMins);
+  *pNData = sizeof(connsData) + connsData.nNegativeMins * sizeof(*connsData.negativeMins);
   NCCLCHECK(ncclCalloc(pData, *pNData));
   pConnsData = (struct rasCollConns*)*pData;
   memcpy(pConnsData, &connsData, sizeof(*pConnsData));
@@ -544,7 +522,7 @@ static ncclResult_t rasCollConnsInit(struct rasCollRequest** pReq, size_t* pReqL
     int negMinsIdx = 0;
     for (struct rasConnection* conn = rasConnsHead; conn; conn = conn->next) {
       if (conn->travelTimeMin < 0) {
-        struct rasCollConns::negativeMin* negativeMin = pConnsData->negativeMins+negMinsIdx;
+        struct rasCollConns::negativeMin* negativeMin = pConnsData->negativeMins + negMinsIdx;
         if (negMinsIdx >= connsData.nNegativeMins) {
           // Should never happen;
           INFO(NCCL_RAS, "RAS overflow of negativeMins: connsData.nNegativeMins %d, negMinsIdx %d -- internal error?",
@@ -566,36 +544,32 @@ static ncclResult_t rasCollConnsInit(struct rasCollRequest** pReq, size_t* pReqL
 static ncclResult_t rasCollConnsMerge(struct rasCollective* coll, struct rasMsg* msg) {
   struct rasCollConns* collData;
   struct rasCollConns* msgData;
-  int dataOffset = rasMsgLength(RAS_MSG_COLLRESP) + msg->collResp.nPeers*sizeof(*msg->collResp.peers);
+  int dataOffset = rasMsgLength(RAS_MSG_COLLRESP) + msg->collResp.nPeers * sizeof(*msg->collResp.peers);
   ALIGN_SIZE(dataOffset, alignof(int64_t));
 
   msgData = (struct rasCollConns*)(((char*)msg) + dataOffset);
   collData = (struct rasCollConns*)coll->data;
 
   // Merge the stats.
-  if (collData->travelTimeMin > msgData->travelTimeMin)
-    collData->travelTimeMin = msgData->travelTimeMin;
-  if (collData->travelTimeMax < msgData->travelTimeMax)
-    collData->travelTimeMax = msgData->travelTimeMax;
+  if (collData->travelTimeMin > msgData->travelTimeMin) collData->travelTimeMin = msgData->travelTimeMin;
+  if (collData->travelTimeMax < msgData->travelTimeMax) collData->travelTimeMax = msgData->travelTimeMax;
   collData->travelTimeSum += msgData->travelTimeSum;
   collData->travelTimeCount += msgData->travelTimeCount;
   collData->nConns += msgData->nConns;
 
   // Append the info about negative minimums.
   if (msgData->nNegativeMins > 0) {
-    int nData = sizeof(*collData) +
-      (collData->nNegativeMins+msgData->nNegativeMins) * sizeof(*collData->negativeMins);
+    int nData =
+      sizeof(*collData) + (collData->nNegativeMins + msgData->nNegativeMins) * sizeof(*collData->negativeMins);
     NCCLCHECK(ncclRealloc(&coll->data, coll->nData, nData));
     collData = (struct rasCollConns*)coll->data;
-    memcpy(coll->data+coll->nData, msgData->negativeMins,
-           msgData->nNegativeMins * sizeof(*collData->negativeMins));
+    memcpy(coll->data + coll->nData, msgData->negativeMins, msgData->nNegativeMins * sizeof(*collData->negativeMins));
     coll->nData = nData;
     collData->nNegativeMins += msgData->nNegativeMins;
   }
 
   return ncclSuccess;
 }
-
 
 /////////////////////////////////////////////////////////////////////////
 // Functions related to the handling of the RAS_COLL_COMMS collective. //
@@ -622,7 +596,7 @@ static ncclResult_t rasCollCommsInit(struct rasCollRequest** pReq, size_t* pReqL
   int firstNewSkipMissingIdx = -1;
 
   *pReqLen = rasCollDataLength(RAS_COLL_COMMS) +
-    (*pReq)->comms.nSkipMissingRanksComms * sizeof(*(*pReq)->comms.skipMissingRanksComms);
+             (*pReq)->comms.nSkipMissingRanksComms * sizeof(*(*pReq)->comms.skipMissingRanksComms);
   *pData = nullptr;
 
   // Start by counting the communicators so that we know how much space to allocate.
@@ -641,7 +615,7 @@ static ncclResult_t rasCollCommsInit(struct rasCollRequest** pReq, size_t* pReqL
     }
     // A process may manage multiple GPUs and thus have multiple communicators with the same commHash.
     // Comparing just the commHash is OK though within communicators that are part of the same process.
-    if (commIdx == 0 || ncclComms[commIdx]->commHash != ncclComms[commIdx-1]->commHash) {
+    if (commIdx == 0 || ncclComms[commIdx]->commHash != ncclComms[commIdx - 1]->commHash) {
       skipMissing = rasCollCommsSkipMissing(*pReq, ncclComms[commIdx]);
       if (!skipMissing) {
         // Add this communicator to the request so that the processes we forward the request to know not to fill in
@@ -649,7 +623,7 @@ static ncclResult_t rasCollCommsInit(struct rasCollRequest** pReq, size_t* pReqL
         struct rasCommId* skipComm;
         if (req == nullptr) {
           // We pessimistically allocate space for all the remaining communicators so that we don't need to reallocate.
-          int newSize = *pReqLen + (nNcclComms-commIdx) * sizeof(*req->comms.skipMissingRanksComms);
+          int newSize = *pReqLen + (nNcclComms - commIdx) * sizeof(*req->comms.skipMissingRanksComms);
           NCCLCHECKGOTO(ncclCalloc((char**)&req, newSize), ret, fail);
           memcpy(req, *pReq, *pReqLen);
           *pReq = req;
@@ -665,8 +639,7 @@ static ncclResult_t rasCollCommsInit(struct rasCollRequest** pReq, size_t* pReqL
       nComms++;
     } // if encountered a new communicator
     nRanks++;
-    if (!skipMissing)
-      nMissingRanks--;
+    if (!skipMissing) nMissingRanks--;
   } // for (commIdx)
 
   // rasCollComms has nested variable-length arrays, which makes the size calculation and subsequent
@@ -674,7 +647,7 @@ static ncclResult_t rasCollCommsInit(struct rasCollRequest** pReq, size_t* pReqL
   // This is extra complicated because of the "hidden" array of struct rasCollCommsMissingRank following the
   // ranks array for each communicator.
   *pNData = sizeof(*commsData) + nComms * sizeof(*commsData->comms) + nRanks * sizeof(*commsData->comms[0].ranks) +
-    nMissingRanks * sizeof(struct rasCollCommsMissingRank);
+            nMissingRanks * sizeof(struct rasCollCommsMissingRank);
   NCCLCHECKGOTO(ncclCalloc(pData, *pNData), ret, fail);
   commsData = (struct rasCollComms*)*pData;
   commsData->nComms = nComms;
@@ -684,13 +657,12 @@ static ncclResult_t rasCollCommsInit(struct rasCollRequest** pReq, size_t* pReqL
   // collCommIdx counts rasCollComms::comm (comm); commIdx indexes ncclComms.
   for (int collCommIdx = 0, commIdx = 0; collCommIdx < nComms; collCommIdx++) {
     struct ncclComm* ncclComm = ncclComms[commIdx];
-    if (!COMPILER_ATOMIC_LOAD(&ncclComm->peerInfoValid, std::memory_order_acquire))
-      continue;
+    if (!COMPILER_ATOMIC_LOAD(&ncclComm->peerInfoValid, std::memory_order_acquire)) continue;
 
-    if ((char*)(comm+1) - (char*)commsData > *pNData) {
+    if ((char*)(comm + 1) - (char*)commsData > *pNData) {
       // Should never happen.
       INFO(NCCL_RAS, "RAS overflow of commsData: collCommIdx %d, nComms %d, pNData %d, needs %td -- internal error?",
-           collCommIdx, nComms, *pNData, (char*)(comm+1) - (char*)commsData);
+           collCommIdx, nComms, *pNData, (char*)(comm + 1) - (char*)commsData);
       break;
     }
 
@@ -704,13 +676,14 @@ static ncclResult_t rasCollCommsInit(struct rasCollRequest** pReq, size_t* pReqL
     for (; commIdx < nNcclComms && ncclComms[commIdx] && ncclComms[commIdx]->commHash == comm->commId.commHash;
          commIdx++) {
       ncclComm = ncclComms[commIdx];
-      struct rasCollComms::comm::rank* rank = comm->ranks+comm->nRanks;
+      struct rasCollComms::comm::rank* rank = comm->ranks + comm->nRanks;
 
-      if ((char*)(rank+1) - (char*)commsData > *pNData) {
+      if ((char*)(rank + 1) - (char*)commsData > *pNData) {
         // Should never happen.
-        INFO(NCCL_RAS, "RAS overflow of commsData: collCommIdx %d, nComms %d, rank %d, commIdx %d, pNData %d, "
+        INFO(NCCL_RAS,
+             "RAS overflow of commsData: collCommIdx %d, nComms %d, rank %d, commIdx %d, pNData %d, "
              "needs %td -- internal error?",
-             collCommIdx, nComms, comm->nRanks, commIdx, *pNData, (char*)(rank+1) - (char*)commsData);
+             collCommIdx, nComms, comm->nRanks, commIdx, *pNData, (char*)(rank + 1) - (char*)commsData);
         break;
       }
 
@@ -732,16 +705,15 @@ static ncclResult_t rasCollCommsInit(struct rasCollRequest** pReq, size_t* pReqL
     } // for (commIdx)
 
     if (COMPILER_ATOMIC_LOAD(&ncclComm->peerInfoValid, std::memory_order_acquire) && firstNewSkipMissingIdx != -1 &&
-        memcmp(req->comms.skipMissingRanksComms+firstNewSkipMissingIdx, &comm->commId, sizeof(comm->commId)) == 0) {
+        memcmp(req->comms.skipMissingRanksComms + firstNewSkipMissingIdx, &comm->commId, sizeof(comm->commId)) == 0) {
       // Fill in the missingRanks array that follows the comm->ranks.
-      struct rasCollCommsMissingRank* missingRanks = (struct rasCollCommsMissingRank*)(comm->ranks+comm->nRanks);
+      struct rasCollCommsMissingRank* missingRanks = (struct rasCollCommsMissingRank*)(comm->ranks + comm->nRanks);
 
       if (peersReSorted == nullptr) {
         // Create a lookup table to rasPeers that is sorted by hostHash and pidHash, to reduce the complexity of the
         // lookups in the missingRankIdx loop below.
         NCCLCHECKGOTO(ncclCalloc(&peersReSorted, nRasPeers), ret, fail);
-        for (int peerIdx = 0; peerIdx < nRasPeers; peerIdx++)
-          peersReSorted[peerIdx] = rasPeers+peerIdx;
+        for (int peerIdx = 0; peerIdx < nRasPeers; peerIdx++) peersReSorted[peerIdx] = rasPeers + peerIdx;
         qsort(peersReSorted, nRasPeers, sizeof(*peersReSorted), peersHashesCompare);
       }
 
@@ -752,42 +724,40 @@ static ncclResult_t rasCollCommsInit(struct rasCollRequest** pReq, size_t* pReqL
         struct rasPeerInfo** peer;
         uint64_t key[2];
 
-        if ((char*)(missingRank+1) - (char*)commsData > *pNData) {
+        if ((char*)(missingRank + 1) - (char*)commsData > *pNData) {
           // Should never happen.
-          INFO(NCCL_RAS, "RAS overflow of commsData: collCommIdx %d, nComms %d, nRanks %d, missingRankIdx %d, "
+          INFO(NCCL_RAS,
+               "RAS overflow of commsData: collCommIdx %d, nComms %d, nRanks %d, missingRankIdx %d, "
                "nMissingRanks %d, pNData %d, needs %td -- internal error?",
                collCommIdx, nComms, comm->nRanks, missingRankIdx, comm->nMissingRanks, *pNData,
-               (char*)(missingRank+1) - (char*)commsData);
+               (char*)(missingRank + 1) - (char*)commsData);
           break;
         }
 
         // Look for the next "hole" in the ranks array.
-        while (rankIdx < comm->nRanks && comm->ranks[rankIdx].commRank == rankIdx+missingRankIdx)
-          rankIdx++;
+        while (rankIdx < comm->nRanks && comm->ranks[rankIdx].commRank == rankIdx + missingRankIdx) rankIdx++;
 
         missingRank->commRank = rankIdx + missingRankIdx;
         info = ncclComm->peerInfo + missingRank->commRank;
         key[0] = info->hostHash - ncclComm->commHash;
         key[1] = info->pidHash - ncclComm->commHash;
         peer = (struct rasPeerInfo**)bsearch(key, peersReSorted, nRasPeers, sizeof(*peersReSorted), peersHashesSearch);
-        if (peer)
-          memcpy(&missingRank->addr, &(*peer)->addr, sizeof(missingRank->addr));
+        if (peer) memcpy(&missingRank->addr, &(*peer)->addr, sizeof(missingRank->addr));
         missingRank->cudaDev = info->cudaDev;
         missingRank->nvmlDev = info->nvmlDev;
       } // for (missingRankIdx)
 
-      if (++firstNewSkipMissingIdx == req->comms.nSkipMissingRanksComms)
-        firstNewSkipMissingIdx = -1;
+      if (++firstNewSkipMissingIdx == req->comms.nSkipMissingRanksComms) firstNewSkipMissingIdx = -1;
     } // if need to fill in the missingRanks
 
-    comm = (struct rasCollComms::comm*)((char*)(comm+1) + comm->nRanks * sizeof(*comm->ranks) +
+    comm = (struct rasCollComms::comm*)((char*)(comm + 1) + comm->nRanks * sizeof(*comm->ranks) +
                                         comm->nMissingRanks * sizeof(struct rasCollCommsMissingRank));
   } // for (collCommIdx)
 
   if (req) {
     // Finish updating the request.
-    *pReqLen = rasCollDataLength(RAS_COLL_COMMS) +
-      req->comms.nSkipMissingRanksComms * sizeof(*req->comms.skipMissingRanksComms);
+    *pReqLen =
+      rasCollDataLength(RAS_COLL_COMMS) + req->comms.nSkipMissingRanksComms * sizeof(*req->comms.skipMissingRanksComms);
     qsort(req->comms.skipMissingRanksComms, req->comms.nSkipMissingRanksComms,
           sizeof(*req->comms.skipMissingRanksComms), rasCommIdCompare);
   }
@@ -809,7 +779,7 @@ static ncclResult_t rasCollCommsMerge(struct rasCollective* coll, struct rasMsg*
   struct rasCollComms* collData; // Data previously stored (locally) by our process.
   struct rasCollComms* msgData; // Data just received from another process.
   union ncclSocketAddress emptyAddr;
-  int dataOffset = rasMsgLength(RAS_MSG_COLLRESP) + msg->collResp.nPeers*sizeof(*msg->collResp.peers);
+  int dataOffset = rasMsgLength(RAS_MSG_COLLRESP) + msg->collResp.nPeers * sizeof(*msg->collResp.peers);
   ALIGN_SIZE(dataOffset, alignof(int64_t));
   memset(&emptyAddr, '\0', sizeof(emptyAddr));
 
@@ -829,43 +799,47 @@ static ncclResult_t rasCollCommsMerge(struct rasCollective* coll, struct rasMsg*
     for (int collIdx = 0, msgIdx = 0; collIdx < collData->nComms || msgIdx < msgData->nComms; newData->nComms++) {
       int cmp;
 
-      if ((char*)(newComm+1) - (char*)newData > nNewData) {
+      if ((char*)(newComm + 1) - (char*)newData > nNewData) {
         // Should never happen.
-        INFO(NCCL_RAS, "RAS overflow of newData: newIdx %d, collIdx %d, msgIdx %d, nNewData %d, "
+        INFO(NCCL_RAS,
+             "RAS overflow of newData: newIdx %d, collIdx %d, msgIdx %d, nNewData %d, "
              "needs %td -- internal error?",
-             newData->nComms, collIdx, msgIdx, nNewData, (char*)(newComm+1) - (char*)newData);
+             newData->nComms, collIdx, msgIdx, nNewData, (char*)(newComm + 1) - (char*)newData);
         break;
       }
-      if (collIdx < collData->nComms &&
-          (char*)(collComm+1) + collComm->nRanks * sizeof(*collComm->ranks) +
-          collComm->nMissingRanks * sizeof(struct rasCollCommsMissingRank) - (char*)collData > coll->nData) {
+      if (collIdx < collData->nComms && (char*)(collComm + 1) + collComm->nRanks * sizeof(*collComm->ranks) +
+                                            collComm->nMissingRanks * sizeof(struct rasCollCommsMissingRank) -
+                                            (char*)collData >
+                                          coll->nData) {
         // Should never happen.
         INFO(NCCL_RAS, "RAS overflow of collData: collIdx %d, nComms %d, nData %d, needs %td -- internal error?",
              collIdx, collData->nComms, coll->nData,
-             (char*)(collComm+1) + collComm->nRanks * sizeof(*collComm->ranks) +
-             collComm->nMissingRanks * sizeof(struct rasCollCommsMissingRank) - (char*)collData);
+             (char*)(collComm + 1) + collComm->nRanks * sizeof(*collComm->ranks) +
+               collComm->nMissingRanks * sizeof(struct rasCollCommsMissingRank) - (char*)collData);
         break;
       }
-      if (msgIdx < msgData->nComms &&
-          (char*)(msgComm+1) + msgComm->nRanks * sizeof(*msgComm->ranks) +
-          msgComm->nMissingRanks * sizeof(struct rasCollCommsMissingRank) - (char*)msgData > msg->collResp.nData) {
+      if (msgIdx < msgData->nComms && (char*)(msgComm + 1) + msgComm->nRanks * sizeof(*msgComm->ranks) +
+                                          msgComm->nMissingRanks * sizeof(struct rasCollCommsMissingRank) -
+                                          (char*)msgData >
+                                        msg->collResp.nData) {
         // Should never happen.
-        INFO(NCCL_RAS, "RAS overflow of msgData: msgIdx %d, nComms %d, nData %d, needs %td -- internal error?",
-             msgIdx, msgData->nComms, msg->collResp.nData,
-             (char*)(msgComm+1) + msgComm->nRanks * sizeof(*msgComm->ranks) +
-             msgComm->nMissingRanks * sizeof(struct rasCollCommsMissingRank) - (char*)msgData);
+        INFO(NCCL_RAS, "RAS overflow of msgData: msgIdx %d, nComms %d, nData %d, needs %td -- internal error?", msgIdx,
+             msgData->nComms, msg->collResp.nData,
+             (char*)(msgComm + 1) + msgComm->nRanks * sizeof(*msgComm->ranks) +
+               msgComm->nMissingRanks * sizeof(struct rasCollCommsMissingRank) - (char*)msgData);
         break;
       }
 
       if (collIdx < collData->nComms && msgIdx < msgData->nComms)
         cmp = rasCommIdCompare(&collComm->commId, &msgComm->commId);
-      else
-        cmp = (collIdx < collData->nComms ? -1 : 1);
+      else cmp = (collIdx < collData->nComms ? -1 : 1);
 
       if (cmp == 0 && collComm->commNRanks != msgComm->commNRanks) {
-        INFO(NCCL_RAS, "RAS encountered inconsistent communicator data: size %d != %d -- "
-             "possible hash collision (0x%lx, 0x%lx, 0x%lx)", collComm->commNRanks, msgComm->commNRanks,
-             collComm->commId.commHash, collComm->commId.hostHash, collComm->commId.pidHash);
+        INFO(NCCL_RAS,
+             "RAS encountered inconsistent communicator data: size %d != %d -- "
+             "possible hash collision (0x%lx, 0x%lx, 0x%lx)",
+             collComm->commNRanks, msgComm->commNRanks, collComm->commId.commHash, collComm->commId.hostHash,
+             collComm->commId.pidHash);
         cmp = (collComm->commNRanks < msgComm->commNRanks ? -1 : 1);
         // We try to preserve them both separately...
       }
@@ -877,8 +851,9 @@ static ncclResult_t rasCollCommsMerge(struct rasCollective* coll, struct rasMsg*
         if (collComm->nRanks + msgComm->nRanks > collComm->commNRanks) {
           INFO(NCCL_RAS,
                "RAS encountered more ranks (%d) than the communicator size (%d) -- possible hash collision "
-               "(0x%lx, 0x%lx, 0x%lx)", collComm->nRanks + msgComm->nRanks, newComm->commNRanks,
-               collComm->commId.commHash, collComm->commId.hostHash, collComm->commId.pidHash);
+               "(0x%lx, 0x%lx, 0x%lx)",
+               collComm->nRanks + msgComm->nRanks, newComm->commNRanks, collComm->commId.commHash,
+               collComm->commId.hostHash, collComm->commId.pidHash);
           newComm->nRanks = newComm->commNRanks;
           // We'll skip the extras in the loop below.
         } else {
@@ -886,34 +861,38 @@ static ncclResult_t rasCollCommsMerge(struct rasCollective* coll, struct rasMsg*
         }
         // Merge the ranks.
         for (int newRankIdx = 0, collRankIdx = 0, msgRankIdx = 0;
-             collRankIdx < collComm->nRanks || msgRankIdx < msgComm->nRanks;
-             newRankIdx++) {
+             collRankIdx < collComm->nRanks || msgRankIdx < msgComm->nRanks; newRankIdx++) {
           int cmpRank;
-          if (newRankIdx == newComm->commNRanks)
-            break; // Short of failing, the best we can do is skip...
+          if (newRankIdx == newComm->commNRanks) break; // Short of failing, the best we can do is skip...
           if (collRankIdx < collComm->nRanks && msgRankIdx < msgComm->nRanks) {
-            cmpRank = (collComm->ranks[collRankIdx].commRank < msgComm->ranks[msgRankIdx].commRank ? -1 :
-                       (collComm->ranks[collRankIdx].commRank > msgComm->ranks[msgRankIdx].commRank ? 1 : 0));
+            cmpRank = (collComm->ranks[collRankIdx].commRank < msgComm->ranks[msgRankIdx].commRank ?
+                         -1 :
+                         (collComm->ranks[collRankIdx].commRank > msgComm->ranks[msgRankIdx].commRank ? 1 : 0));
           } else {
             cmpRank = (collRankIdx < collComm->nRanks ? -1 : 1);
           }
 
           // There shouldn't be any overlaps in ranks between different sources.
           if (cmpRank == 0) {
-            INFO(NCCL_RAS, "RAS encountered duplicate data for rank %d -- possible hash collision "
-                 "(0x%lx, 0x%lx, 0x%lx)", collComm->ranks[collRankIdx].commRank,
-                 newComm->commId.commHash, newComm->commId.hostHash, newComm->commId.pidHash);
+            INFO(NCCL_RAS,
+                 "RAS encountered duplicate data for rank %d -- possible hash collision "
+                 "(0x%lx, 0x%lx, 0x%lx)",
+                 collComm->ranks[collRankIdx].commRank, newComm->commId.commHash, newComm->commId.hostHash,
+                 newComm->commId.pidHash);
             msgRankIdx++; // Short of failing, the best we can do is skip...
           }
-          if ((char*)(newComm->ranks+newRankIdx+1) - (char*)newData <= nNewData) {
-            memcpy(newComm->ranks+newRankIdx, (cmpRank <= 0 ? collComm->ranks+collRankIdx++ :
-                                               msgComm->ranks+msgRankIdx++), sizeof(*newComm->ranks));
+          if ((char*)(newComm->ranks + newRankIdx + 1) - (char*)newData <= nNewData) {
+            memcpy(newComm->ranks + newRankIdx,
+                   (cmpRank <= 0 ? collComm->ranks + collRankIdx++ : msgComm->ranks + msgRankIdx++),
+                   sizeof(*newComm->ranks));
           } else {
             // Should never happen.
-            INFO(NCCL_RAS, "RAS overflow of newData: newIdx %d, collIdx %d, msgIdx %d, newRankIdx %d, collRankIdx %d, "
+            INFO(NCCL_RAS,
+                 "RAS overflow of newData: newIdx %d, collIdx %d, msgIdx %d, newRankIdx %d, collRankIdx %d, "
                  "msgRankIdx %d, newNRanks %d, collNranks %d, msgNranks %d, nNewData %d, needs %td -- internal error?",
                  newData->nComms, collIdx, msgIdx, newRankIdx, collRankIdx, msgRankIdx, newComm->nRanks,
-                 collComm->nRanks, msgComm->nRanks, nNewData, (char*)(newComm->ranks+newRankIdx+1) - (char*)newData);
+                 collComm->nRanks, msgComm->nRanks, nNewData,
+                 (char*)(newComm->ranks + newRankIdx + 1) - (char*)newData);
             break;
           }
           if (cmpRank > 0) {
@@ -923,11 +902,9 @@ static ncclResult_t rasCollCommsMerge(struct rasCollective* coll, struct rasMsg*
             if (collComm->nMissingRanks > 0) {
               // Remove the corresponding entry from missingRanks.
               struct rasCollCommsMissingRank* missingRank;
-              missingRank = (struct rasCollCommsMissingRank*)bsearch(&newComm->ranks[newRankIdx].commRank,
-                                                                     collComm->ranks+collComm->nRanks,
-                                                                     collComm->nMissingRanks,
-                                                                     sizeof(struct rasCollCommsMissingRank),
-                                                                     rasCollCommsMissingRankSearch);
+              missingRank = (struct rasCollCommsMissingRank*)bsearch(
+                &newComm->ranks[newRankIdx].commRank, collComm->ranks + collComm->nRanks, collComm->nMissingRanks,
+                sizeof(struct rasCollCommsMissingRank), rasCollCommsMissingRankSearch);
               if (missingRank) {
                 // Mark the entry as no longer needed.
                 memset(&missingRank->addr, '\0', sizeof(missingRank->addr));
@@ -943,19 +920,20 @@ static ncclResult_t rasCollCommsMerge(struct rasCollective* coll, struct rasMsg*
           struct rasCollCommsMissingRank* newMissingRanks;
           int newRankIdx;
 
-          collMissingRanks = (struct rasCollCommsMissingRank*)(collComm->ranks+collComm->nRanks);
-          newMissingRanks = (struct rasCollCommsMissingRank*)(newComm->ranks+newComm->nRanks);
+          collMissingRanks = (struct rasCollCommsMissingRank*)(collComm->ranks + collComm->nRanks);
+          newMissingRanks = (struct rasCollCommsMissingRank*)(newComm->ranks + newComm->nRanks);
           newRankIdx = 0;
           for (int collRankIdx = 0; collRankIdx < collComm->nMissingRanks; collRankIdx++) {
             if (memcmp(&collMissingRanks[collRankIdx].addr, &emptyAddr, sizeof(emptyAddr))) {
-              if ((char*)(newMissingRanks + newRankIdx+1) - (char*)newData <= nNewData) {
+              if ((char*)(newMissingRanks + newRankIdx + 1) - (char*)newData <= nNewData) {
                 memcpy(newMissingRanks + newRankIdx++, collMissingRanks + collRankIdx, sizeof(*newMissingRanks));
               } else {
                 // Should never happen.
-                INFO(NCCL_RAS, "RAS overflow of newData: newIdx %d, collIdx %d, msgIdx %d, newRankIdx %d, "
+                INFO(NCCL_RAS,
+                     "RAS overflow of newData: newIdx %d, collIdx %d, msgIdx %d, newRankIdx %d, "
                      "collRankIdx %d, collNMissingRanks %d, nNewData %d, needs %td -- internal error?",
-                     newData->nComms, collIdx, msgIdx, newRankIdx, collRankIdx, collComm->nMissingRanks,
-                     nNewData, (char*)(newMissingRanks + newRankIdx+1) - (char*)newData);
+                     newData->nComms, collIdx, msgIdx, newRankIdx, collRankIdx, collComm->nMissingRanks, nNewData,
+                     (char*)(newMissingRanks + newRankIdx + 1) - (char*)newData);
                 break;
               }
             }
@@ -963,28 +941,30 @@ static ncclResult_t rasCollCommsMerge(struct rasCollective* coll, struct rasMsg*
           newComm->nMissingRanks = newRankIdx;
           if (newComm->nRanks + newComm->nMissingRanks != newComm->commNRanks) {
             // Should never happen.
-            INFO(NCCL_RAS, "RAS collective comms merge mismatch for newIdx %d: nRanks %d, nMissingRanks %d, "
+            INFO(NCCL_RAS,
+                 "RAS collective comms merge mismatch for newIdx %d: nRanks %d, nMissingRanks %d, "
                  "commNRanks %d -- internal error?",
                  newData->nComms, newComm->nRanks, newComm->nMissingRanks, newComm->commNRanks);
           }
         }
-        newComm = (struct rasCollComms::comm*)(((char*)(newComm+1)) + newComm->nRanks * sizeof(*newComm->ranks) +
+        newComm = (struct rasCollComms::comm*)(((char*)(newComm + 1)) + newComm->nRanks * sizeof(*newComm->ranks) +
                                                newComm->nMissingRanks * sizeof(struct rasCollCommsMissingRank));
-        collComm = (struct rasCollComms::comm*)(((char*)(collComm+1)) + collComm->nRanks * sizeof(*collComm->ranks) +
+        collComm = (struct rasCollComms::comm*)(((char*)(collComm + 1)) + collComm->nRanks * sizeof(*collComm->ranks) +
                                                 collComm->nMissingRanks * sizeof(struct rasCollCommsMissingRank));
         collIdx++;
-        msgComm = (struct rasCollComms::comm*)(((char*)(msgComm+1)) + msgComm->nRanks * sizeof(*msgComm->ranks) +
+        msgComm = (struct rasCollComms::comm*)(((char*)(msgComm + 1)) + msgComm->nRanks * sizeof(*msgComm->ranks) +
                                                msgComm->nMissingRanks * sizeof(struct rasCollCommsMissingRank));
         msgIdx++;
       } else if (cmp < 0) {
         // Copy from collComm.
         int commSize = sizeof(*collComm) + collComm->nRanks * sizeof(*collComm->ranks) +
-          collComm->nMissingRanks * sizeof(struct rasCollCommsMissingRank);
+                       collComm->nMissingRanks * sizeof(struct rasCollCommsMissingRank);
         if ((char*)newComm + commSize - (char*)newData <= nNewData) {
           memcpy(newComm, collComm, commSize);
         } else {
           // Should never happen.
-          INFO(NCCL_RAS, "RAS overflow of newData: newIdx %d, collIdx %d, msgIdx %d, nNewData %d, "
+          INFO(NCCL_RAS,
+               "RAS overflow of newData: newIdx %d, collIdx %d, msgIdx %d, nNewData %d, "
                "needs %td -- internal error?",
                newData->nComms, collIdx, msgIdx, nNewData, (char*)newComm + commSize - (char*)newData);
           break;
@@ -995,12 +975,13 @@ static ncclResult_t rasCollCommsMerge(struct rasCollective* coll, struct rasMsg*
       } else { // cmp > 0
         // Copy from msgComm.
         int commSize = sizeof(*msgComm) + msgComm->nRanks * sizeof(*msgComm->ranks) +
-          msgComm->nMissingRanks * sizeof(struct rasCollCommsMissingRank);
+                       msgComm->nMissingRanks * sizeof(struct rasCollCommsMissingRank);
         if ((char*)newComm + commSize - (char*)newData <= nNewData) {
           memcpy(newComm, msgComm, commSize);
         } else {
           // Should never happen.
-          INFO(NCCL_RAS, "RAS overflow of newData: newIdx %d, collIdx %d, msgIdx %d, nNewData %d, "
+          INFO(NCCL_RAS,
+               "RAS overflow of newData: newIdx %d, collIdx %d, msgIdx %d, nNewData %d, "
                "needs %td -- internal error?",
                newData->nComms, collIdx, msgIdx, nNewData, (char*)newComm + commSize - (char*)newData);
           break;
@@ -1040,8 +1021,7 @@ static int ncclCommsCompare(const void* p1, const void* p2) {
   const ncclComm* comm2 = *(const ncclComm**)p2;
 
   // Put nullptr's at the end.
-  if (comm1 == nullptr || comm2 == nullptr)
-    return (comm1 != nullptr ? -1 : (comm2 != nullptr ? 1 : 0));
+  if (comm1 == nullptr || comm2 == nullptr) return (comm1 != nullptr ? -1 : (comm2 != nullptr ? 1 : 0));
 
   if (comm1->commHash == comm2->commHash) {
     return (comm1->rank < comm2->rank ? -1 : (comm1->rank > comm2->rank ? 1 : 0));

--- a/projects/rccl/src/ras/peers.cc
+++ b/projects/rccl/src/ras/peers.cc
@@ -13,7 +13,6 @@
 #include "ras_internal.h"
 #include "compiler.h"
 
-
 // All the known peer NCCL processes. The array is sorted by addr to ensure locality (within a node and hopefully
 // also within a DC).  The array may grow over time and it *includes* dead peers.
 struct rasPeerInfo* rasPeers;
@@ -35,8 +34,8 @@ static int rasDeadPeersSize;
 // Hash of the rasDeadPeers array, for figuring out when to sync with a remote peer.
 uint64_t rasDeadPeersHash;
 
-static ncclResult_t rasRanksConvertToPeers(struct rasRankInit* ranks, int nranks,
-                                           struct rasPeerInfo** rankPeers, int *nRankPeers, int* newNRasPeers);
+static ncclResult_t rasRanksConvertToPeers(struct rasRankInit* ranks, int nranks, struct rasPeerInfo** rankPeers,
+                                           int* nRankPeers, int* newNRasPeers);
 static ncclResult_t rasPeersUpdate(struct rasPeerInfo* rankPeers, int* nRankPeers, int newNRasPeers = -1);
 
 static ncclResult_t rasNetUpdatePeers(const struct rasPeerInfo* newPeers, int nNewPeers, bool updateDeadPeers,
@@ -63,7 +62,6 @@ static void rasDeadPeersDump();
 static char* rasPeerDump(const struct rasPeerInfo* peer, char* result, size_t nres);
 static void rasNewPeerNotify(const struct rasPeerInfo* peer);
 
-
 /////////////////////////////////////////////////////////////////////////////
 // Functions related to the handling of local RAS_ADD_RANKS notifications. //
 /////////////////////////////////////////////////////////////////////////////
@@ -84,18 +82,16 @@ ncclResult_t rasLocalHandleAddRanks(struct rasRankInit* ranks, int nranks) {
   // Update local rasPeers.
   NCCLCHECKGOTO(rasPeersUpdate(rankPeers, &nRankPeers, newNRasPeers), ret, fail);
 
-  INFO(NCCL_RAS, "RAS finished local processing of addRanks request (new nRasPeers %d, nRankPeers %d)",
-       nRasPeers, nRankPeers);
+  INFO(NCCL_RAS, "RAS finished local processing of addRanks request (new nRasPeers %d, nRankPeers %d)", nRasPeers,
+       nRankPeers);
   // Print peers only if something changed and we're the "root".
-  if (nRankPeers > 0 && memcmp(&ranks[0].addr, &rasNetListeningSocket.addr, sizeof(ranks[0].addr)) == 0)
-    rasPeersDump();
+  if (nRankPeers > 0 && memcmp(&ranks[0].addr, &rasNetListeningSocket.addr, sizeof(ranks[0].addr)) == 0) rasPeersDump();
 
   // Propagate the changes through our RAS network links.
-  NCCLCHECKGOTO(rasNetUpdatePeers(rankPeers, nRankPeers, /*updateDeadPeers*/false, ranks, nranks), ret, fail);
+  NCCLCHECKGOTO(rasNetUpdatePeers(rankPeers, nRankPeers, /*updateDeadPeers*/ false, ranks, nranks), ret, fail);
 
 exit:
-  if (rankPeers)
-    free(rankPeers);
+  if (rankPeers) free(rankPeers);
   free(ranks);
   return ret;
 fail:
@@ -105,8 +101,8 @@ fail:
 // Converts the rasRankInit structure into rasPeerInfo.  This skips empty elements (in case of errors), orders
 // elements by the address/cudaDev, and merges elements with duplicate addresses (in case of multiple CUDA devices per
 // process).  In the process we also calculate how large the merged rasPeers array will need to be.
-static ncclResult_t rasRanksConvertToPeers(struct rasRankInit* ranks, int nranks,
-                                           struct rasPeerInfo** rankPeers, int *nRankPeers, int* newNRasPeers) {
+static ncclResult_t rasRanksConvertToPeers(struct rasRankInit* ranks, int nranks, struct rasPeerInfo** rankPeers,
+                                           int* nRankPeers, int* newNRasPeers) {
   ncclResult_t ret = ncclSuccess;
   int peerIdx, rankPeerIdx;
 
@@ -125,8 +121,8 @@ static ncclResult_t rasRanksConvertToPeers(struct rasRankInit* ranks, int nranks
   peerIdx = rankPeerIdx = 0;
   *newNRasPeers = nRasPeers;
   for (int rankIdx = 0; rankIdx < nranks; rankIdx++) {
-    const struct rasRankInit* rank = ranks+rankIdx;
-    struct rasPeerInfo* rankPeer = *rankPeers+rankPeerIdx;
+    const struct rasRankInit* rank = ranks + rankIdx;
+    struct rasPeerInfo* rankPeer = *rankPeers + rankPeerIdx;
 
     if (memcmp(&emptyAddr, &rank->addr, sizeof(emptyAddr)) == 0) {
       // Skip empty rank entries.
@@ -157,12 +153,11 @@ static ncclResult_t rasRanksConvertToPeers(struct rasRankInit* ranks, int nranks
 
     // Also check if there is already an entry with that address in the global rasPeers so that the caller can know how
     // many more entries will be needed.
-    const struct rasPeerInfo* rasPeer = rasPeers+peerIdx;
+    const struct rasPeerInfo* rasPeer = rasPeers + peerIdx;
     int cmp = 0;
     while (peerIdx < nRasPeers) {
       cmp = ncclSocketsCompare(&rank->addr, &rasPeer->addr);
-      if (cmp <= 0)
-        break;
+      if (cmp <= 0) break;
       peerIdx++;
       rasPeer++;
     }
@@ -207,8 +202,8 @@ static ncclResult_t rasPeersUpdate(struct rasPeerInfo* rankPeers, int* nRankPeer
     // First calculate the new size of rasPeers.
     newNRasPeers = nRasPeers;
     for (rankPeerIdx = peerIdx = 0; rankPeerIdx < *nRankPeers; rankPeerIdx++) {
-      struct rasPeerInfo* rankPeer = rankPeers+rankPeerIdx;
-      struct rasPeerInfo* rasPeer = rasPeers+peerIdx;
+      struct rasPeerInfo* rankPeer = rankPeers + rankPeerIdx;
+      struct rasPeerInfo* rasPeer = rasPeers + peerIdx;
       int cmp = 1;
 
       while (peerIdx < nRasPeers) {
@@ -223,8 +218,7 @@ static ncclResult_t rasPeersUpdate(struct rasPeerInfo* rankPeers, int* nRankPeer
         peerIdx++;
         rasPeer++;
 
-        if (cmp == 0)
-          break;
+        if (cmp == 0) break;
       }
       if (cmp > 0) // No more rasPeer entries -- rankPeer will go at the end.
         newNRasPeers++;
@@ -245,9 +239,9 @@ static ncclResult_t rasPeersUpdate(struct rasPeerInfo* rankPeers, int* nRankPeer
   newMyPeerIdx = -1;
   int newPeerIdx;
   for (newPeerIdx = rankPeerIdx = peerIdx = 0; rankPeerIdx < *nRankPeers || peerIdx < nRasPeers; newPeerIdx++) {
-    struct rasPeerInfo* rankPeer = rankPeers+rankPeerIdx;
-    struct rasPeerInfo* rasPeer = rasPeers+peerIdx;
-    struct rasPeerInfo* newRasPeer = newRasPeers+newPeerIdx;
+    struct rasPeerInfo* rankPeer = rankPeers + rankPeerIdx;
+    struct rasPeerInfo* rasPeer = rasPeers + peerIdx;
+    struct rasPeerInfo* newRasPeer = newRasPeers + newPeerIdx;
 
     if (rankPeerIdx < *nRankPeers) {
       if (peerIdx < nRasPeers) {
@@ -260,15 +254,18 @@ static ncclResult_t rasPeersUpdate(struct rasPeerInfo* rankPeers, int* nRankPeer
               memcpy(newRasPeer, rankPeer, sizeof(*newRasPeer));
               rasNewPeerNotify(rankPeer);
             } else {
-              INFO(NCCL_RAS, "RAS new peer %s but there's no room for it: newPeerIdx %d, newNRasPeers %d, "
+              INFO(NCCL_RAS,
+                   "RAS new peer %s but there's no room for it: newPeerIdx %d, newNRasPeers %d, "
                    "nRasPeers %d -- internal error?",
                    ncclSocketToString(&rankPeer->addr, rasLine), newPeerIdx, newNRasPeers, nRasPeers);
               break;
             }
           } else {
             // Should never happen -- newNRasPeers should include room for it.
-            INFO(NCCL_RAS, "RAS new peer %s but there's no room for it: newNRasPeers %d, nRasPeers %d -- "
-                 "internal error?", ncclSocketToString(&rankPeer->addr, rasLine), newNRasPeers, nRasPeers);
+            INFO(NCCL_RAS,
+                 "RAS new peer %s but there's no room for it: newNRasPeers %d, nRasPeers %d -- "
+                 "internal error?",
+                 ncclSocketToString(&rankPeer->addr, rasLine), newNRasPeers, nRasPeers);
           }
           rankPeerIdx++;
         } else { // cmp >= 0
@@ -277,7 +274,8 @@ static ncclResult_t rasPeersUpdate(struct rasPeerInfo* rankPeers, int* nRankPeer
             if (newPeerIdx < newNRasPeers) {
               memcpy(newRasPeer, rasPeer, sizeof(*newRasPeer));
             } else {
-              INFO(NCCL_RAS, "RAS old peer %s but there's no room for it: newPeerIdx %d, newNRasPeers %d, "
+              INFO(NCCL_RAS,
+                   "RAS old peer %s but there's no room for it: newPeerIdx %d, newNRasPeers %d, "
                    "nRasPeers %d -- internal error?",
                    ncclSocketToString(&rasPeer->addr, rasLine), newPeerIdx, newNRasPeers, nRasPeers);
               break;
@@ -285,7 +283,8 @@ static ncclResult_t rasPeersUpdate(struct rasPeerInfo* rankPeers, int* nRankPeer
           } else { // in-place
             if (newPeerIdx != peerIdx) {
               // Should never happen -- both indexes should advance at the same pace.
-              INFO(NCCL_RAS, "RAS old peer %s in-place mismatch: newPeerIdx %d, peerIdx %d, newNRasPeers %d, "
+              INFO(NCCL_RAS,
+                   "RAS old peer %s in-place mismatch: newPeerIdx %d, peerIdx %d, newNRasPeers %d, "
                    "nRasPeers %d -- internal error?",
                    ncclSocketToString(&rasPeer->addr, rasLine), newPeerIdx, peerIdx, newNRasPeers, nRasPeers);
             }
@@ -305,8 +304,7 @@ static ncclResult_t rasPeersUpdate(struct rasPeerInfo* rankPeers, int* nRankPeer
             rankPeerIdx++;
           }
           // Given that we might've added new entries, we need to update myPeerIdx as well.
-          if (myPeerIdx == peerIdx)
-            newMyPeerIdx = newPeerIdx;
+          if (myPeerIdx == peerIdx) newMyPeerIdx = newPeerIdx;
           peerIdx++;
         } // cmp >= 0
       } else { // peerIdx == nRasPeers
@@ -315,7 +313,8 @@ static ncclResult_t rasPeersUpdate(struct rasPeerInfo* rankPeers, int* nRankPeer
           memcpy(newRasPeer, rankPeer, sizeof(*newRasPeer));
           rasNewPeerNotify(rankPeer);
         } else {
-          INFO(NCCL_RAS, "RAS new peer %s but there's no room for it: newPeerIdx %d, newNRasPeers %d, "
+          INFO(NCCL_RAS,
+               "RAS new peer %s but there's no room for it: newPeerIdx %d, newNRasPeers %d, "
                "nRasPeers %d -- internal error?",
                ncclSocketToString(&rankPeer->addr, rasLine), newPeerIdx, newNRasPeers, nRasPeers);
           break;
@@ -332,34 +331,35 @@ static ncclResult_t rasPeersUpdate(struct rasPeerInfo* rankPeers, int* nRankPeer
         if (newPeerIdx < newNRasPeers) {
           memcpy(newRasPeer, rasPeer, sizeof(*newRasPeer));
         } else {
-          INFO(NCCL_RAS, "RAS old peer %s but there's no room for it: newPeerIdx %d, newNRasPeers %d, "
+          INFO(NCCL_RAS,
+               "RAS old peer %s but there's no room for it: newPeerIdx %d, newNRasPeers %d, "
                "nRasPeers %d -- internal error?",
                ncclSocketToString(&rasPeer->addr, rasLine), newPeerIdx, newNRasPeers, nRasPeers);
           break;
         }
-      }
-      else { // in-place at the end.
+      } else { // in-place at the end.
         if (newPeerIdx != peerIdx) {
           // Should never happen -- both indexes should advance at the same pace.
-          INFO(NCCL_RAS, "RAS old peer %s in-place mismatch: newPeerIdx %d, peerIdx %d, newNRasPeers %d, "
+          INFO(NCCL_RAS,
+               "RAS old peer %s in-place mismatch: newPeerIdx %d, peerIdx %d, newNRasPeers %d, "
                "nRasPeers %d -- internal error?",
                ncclSocketToString(&rasPeer->addr, rasLine), newPeerIdx, peerIdx, newNRasPeers, nRasPeers);
         }
       }
-      if (myPeerIdx == peerIdx)
-        newMyPeerIdx = newPeerIdx;
+      if (myPeerIdx == peerIdx) newMyPeerIdx = newPeerIdx;
       peerIdx++;
     } // rankPeerIdx == *nRankPeers
   } // for (newPeerIdx)
   if (newPeerIdx != newNRasPeers) {
     // Should never happen, unless an internal error got triggered above?
-    INFO(NCCL_RAS, "RAS post-merge discrepancy: newPeerIdx %d, newNRasPeers %d, nRasPeers %d, nRankPeers %d -- "
-         "internal error?", newPeerIdx, newNRasPeers, nRasPeers, *nRankPeers);
+    INFO(NCCL_RAS,
+         "RAS post-merge discrepancy: newPeerIdx %d, newNRasPeers %d, nRasPeers %d, nRankPeers %d -- "
+         "internal error?",
+         newPeerIdx, newNRasPeers, nRasPeers, *nRankPeers);
   }
 
   if (newRasPeers != rasPeers) {
-    if (rasPeers)
-      free(rasPeers);
+    if (rasPeers) free(rasPeers);
     rasPeers = newRasPeers;
     nRasPeers = newNRasPeers;
     if (newMyPeerIdx == -1) {
@@ -372,20 +372,20 @@ static ncclResult_t rasPeersUpdate(struct rasPeerInfo* rankPeers, int* nRankPeer
   } else {
     if (newMyPeerIdx != myPeerIdx) {
       // Should never happen, but if it does, then we are in deep trouble...  Update via the regular binary search.
-      INFO(NCCL_RAS, "RAS post-merge discrepancy: myPeerIdx %d, newMyPeerIdx %d -- internal error?",
-           myPeerIdx, newMyPeerIdx);
+      INFO(NCCL_RAS, "RAS post-merge discrepancy: myPeerIdx %d, newMyPeerIdx %d -- internal error?", myPeerIdx,
+           newMyPeerIdx);
       myPeerIdx = rasPeerFind(&rasNetListeningSocket.addr);
       INFO(NCCL_RAS, "RAS post-merge discrepancy: found value %d", myPeerIdx);
     }
   }
-  rasPeersHash = getHash((const char*)rasPeers, nRasPeers*sizeof(*rasPeers));
+  rasPeersHash = getHash((const char*)rasPeers, nRasPeers * sizeof(*rasPeers));
 
   // Purge from rankPeers all entries that didn't actually contribute any new GPUs.
   for (rankPeerIdx = rankPeerIdxDst = 0; rankPeerIdx < *nRankPeers; rankPeerIdx++) {
-    struct rasPeerInfo* rankPeer = rankPeers+rankPeerIdx;
+    struct rasPeerInfo* rankPeer = rankPeers + rankPeerIdx;
     if (rankPeer->cudaDevs != 0) {
       if (rankPeerIdxDst != rankPeerIdx) {
-        memcpy(rankPeers+rankPeerIdxDst, rankPeer, sizeof(*rankPeers));
+        memcpy(rankPeers + rankPeerIdxDst, rankPeer, sizeof(*rankPeers));
       }
       rankPeerIdxDst++;
     }
@@ -401,11 +401,10 @@ fail:
 // Searches through rasPeers given the peer address.  Returns the index of the found entry in the rasPeers
 // array or -1 if not found.
 int rasPeerFind(const union ncclSocketAddress* addr) {
-  struct rasPeerInfo* peer = (struct rasPeerInfo*)bsearch(addr, rasPeers, nRasPeers, sizeof(*rasPeers),
-                                                          rasAddrPeerInfoCompare);
-  return (peer ? peer-rasPeers : -1);
+  struct rasPeerInfo* peer =
+    (struct rasPeerInfo*)bsearch(addr, rasPeers, nRasPeers, sizeof(*rasPeers), rasAddrPeerInfoCompare);
+  return (peer ? peer - rasPeers : -1);
 }
-
 
 /////////////////////////////////////////////////////////////////////////////////
 // Functions related to the propagation of peers updates over the RAS network. //
@@ -424,8 +423,7 @@ static ncclResult_t rasNetUpdatePeers(const struct rasPeerInfo* newPeers, int nN
   ncclResult_t ret = ncclSuccess;
 
   // Do we actually have anything to do?
-  if (nNewPeers == 0 && !updateDeadPeers)
-    goto exit;
+  if (nNewPeers == 0 && !updateDeadPeers) goto exit;
 
   // Start by propagating the update through the RAS network links.  We consider any errors during this process
   // to be non-fatal (we can re-sync later around a keep-alive exchange).
@@ -468,10 +466,9 @@ static ncclResult_t rasConnPropagateUpdate(struct rasConnection* conn, const str
     // communicator.
     int connRank = -1;
     if (ranks && !updateDeadPeers) {
-      struct rasRankInit* rank = (struct rasRankInit*)bsearch(&conn->addr, ranks, nranks, sizeof(*ranks),
-                                                              rasAddrRankInitCompare);
-      if (rank)
-        connRank = rank-ranks;
+      struct rasRankInit* rank =
+        (struct rasRankInit*)bsearch(&conn->addr, ranks, nranks, sizeof(*ranks), rasAddrRankInitCompare);
+      if (rank) connRank = rank - ranks;
     }
     if (connRank < 0) {
       // It did not participate or we don't know -- we should send an update to that peer then.
@@ -501,14 +498,13 @@ ncclResult_t rasConnSendPeersUpdate(struct rasConnection* conn, const struct ras
     nDeadPeers = nRasDeadPeers;
   }
 
-  if (nPeers == 0 && nDeadPeers == 0)
-    goto exit;
+  if (nPeers == 0 && nDeadPeers == 0) goto exit;
 
-  msgLen = rasMsgLength(RAS_MSG_PEERSUPDATE) + nPeers*sizeof(*peers);
+  msgLen = rasMsgLength(RAS_MSG_PEERSUPDATE) + nPeers * sizeof(*peers);
   if (nDeadPeers > 0) {
     ALIGN_SIZE(msgLen, alignof(union ncclSocketAddress));
     deadPeersOffset = msgLen;
-    msgLen += nDeadPeers*sizeof(*rasDeadPeers);
+    msgLen += nDeadPeers * sizeof(*rasDeadPeers);
   }
 
   NCCLCHECK(rasMsgAlloc(&msg, msgLen));
@@ -518,16 +514,13 @@ ncclResult_t rasConnSendPeersUpdate(struct rasConnection* conn, const struct ras
   msg->peersUpdate.deadPeersHash = rasDeadPeersHash;
   msg->peersUpdate.nDeadPeers = nDeadPeers;
   memcpy(msg->peersUpdate.peers, peers, nPeers * sizeof(msg->peersUpdate.peers[0]));
-  if (nDeadPeers > 0)
-    memcpy(((char*)msg)+deadPeersOffset, rasDeadPeers, nDeadPeers * sizeof(*rasDeadPeers));
+  if (nDeadPeers > 0) memcpy(((char*)msg) + deadPeersOffset, rasDeadPeers, nDeadPeers * sizeof(*rasDeadPeers));
 
-  if (nPeers > 0)
-    conn->lastSentPeersHash = rasPeersHash;
-  if (nDeadPeers > 0)
-    conn->lastSentDeadPeersHash = rasDeadPeersHash;
+  if (nPeers > 0) conn->lastSentPeersHash = rasPeersHash;
+  if (nDeadPeers > 0) conn->lastSentDeadPeersHash = rasDeadPeersHash;
 
-  INFO(NCCL_RAS, "RAS sending a peersUpdate to %s (nPeers %d, nDeadPeers %d)",
-       ncclSocketToString(&conn->addr, rasLine), nPeers, nDeadPeers);
+  INFO(NCCL_RAS, "RAS sending a peersUpdate to %s (nPeers %d, nDeadPeers %d)", ncclSocketToString(&conn->addr, rasLine),
+       nPeers, nDeadPeers);
 
   rasConnEnqueueMsg(conn, msg, msgLen);
 exit:
@@ -549,8 +542,8 @@ ncclResult_t rasMsgHandlePeersUpdate(struct rasMsg* msg, struct rasSocket* sock)
   INFO(NCCL_RAS, "RAS handling peersUpdate from %s (peersHash 0x%lx, deadPeersHash 0x%lx, nPeers %d, nDeadPeers %d)",
        ncclSocketToString(&sock->sock.addr, rasLine), msg->peersUpdate.peersHash, msg->peersUpdate.deadPeersHash,
        msg->peersUpdate.nPeers, msg->peersUpdate.nDeadPeers);
-  INFO(NCCL_RAS, "RAS my old rasPeersHash 0x%lx, rasDeadPeersHash 0x%lx, nRasPeers %d, nRasDeadPeers %d",
-       rasPeersHash, rasDeadPeersHash, nRasPeers, nRasDeadPeers);
+  INFO(NCCL_RAS, "RAS my old rasPeersHash 0x%lx, rasDeadPeersHash 0x%lx, nRasPeers %d, nRasDeadPeers %d", rasPeersHash,
+       rasDeadPeersHash, nRasPeers, nRasDeadPeers);
   if (sock->conn == nullptr) {
     INFO(NCCL_RAS, "RAS socket lacks a connection: status %d -- internal error?", sock->status);
     return ncclInternalError;
@@ -565,12 +558,12 @@ ncclResult_t rasMsgHandlePeersUpdate(struct rasMsg* msg, struct rasSocket* sock)
   // nPeers and nDeadPeers are used primarily for message length calculations, so they have to assume the worst-case
   // scenario (e.g., no overlap in case of nDeadPeers).
   nPeers = (msg->peersUpdate.peersHash != rasPeersHash ? nRasPeers : 0);
-  nDeadPeers = (msg->peersUpdate.deadPeersHash != rasDeadPeersHash ? nRasDeadPeers+msg->peersUpdate.nDeadPeers : 0);
+  nDeadPeers = (msg->peersUpdate.deadPeersHash != rasDeadPeersHash ? nRasDeadPeers + msg->peersUpdate.nDeadPeers : 0);
   if (nPeers > 0 || nDeadPeers > 0) {
-    newMsgLen = rasMsgLength(RAS_MSG_PEERSUPDATE) + nPeers*sizeof(*rasPeers);
+    newMsgLen = rasMsgLength(RAS_MSG_PEERSUPDATE) + nPeers * sizeof(*rasPeers);
     if (nDeadPeers > 0) {
       ALIGN_SIZE(newMsgLen, alignof(union ncclSocketAddress));
-      newMsgLen += nDeadPeers*sizeof(*rasDeadPeers);
+      newMsgLen += nDeadPeers * sizeof(*rasDeadPeers);
     }
     NCCLCHECKGOTO(rasMsgAlloc(&newMsg, newMsgLen), ret, fail);
     newMsg->type = RAS_MSG_PEERSUPDATE;
@@ -585,29 +578,26 @@ ncclResult_t rasMsgHandlePeersUpdate(struct rasMsg* msg, struct rasSocket* sock)
       ALIGN_SIZE(deadPeersOffset, alignof(union ncclSocketAddress));
     }
 
-    if (nPeers > 0)
-      NCCLCHECKGOTO(rasPeersUpdate(msg->peersUpdate.peers, &msg->peersUpdate.nPeers), ret, fail);
-    else
-      msg->peersUpdate.nPeers = 0;
+    if (nPeers > 0) NCCLCHECKGOTO(rasPeersUpdate(msg->peersUpdate.peers, &msg->peersUpdate.nPeers), ret, fail);
+    else msg->peersUpdate.nPeers = 0;
     if (nDeadPeers > 0)
-      NCCLCHECKGOTO(rasDeadPeersUpdate((union ncclSocketAddress*)(((char*)msg)+deadPeersOffset),
-                                       &msg->peersUpdate.nDeadPeers), ret, fail);
-    else
-      msg->peersUpdate.nDeadPeers = 0;
+      NCCLCHECKGOTO(rasDeadPeersUpdate((union ncclSocketAddress*)(((char*)msg) + deadPeersOffset),
+                                       &msg->peersUpdate.nDeadPeers),
+                    ret, fail);
+    else msg->peersUpdate.nDeadPeers = 0;
 
-    INFO(NCCL_RAS, "RAS finished local processing of peersUpdate "
+    INFO(NCCL_RAS,
+         "RAS finished local processing of peersUpdate "
          "(new nRasPeers %d, nRasDeadPeers %d, nPeers %d, nDeadPeers %d)",
          nRasPeers, nRasDeadPeers, msg->peersUpdate.nPeers, msg->peersUpdate.nDeadPeers);
 
-    if (msg->peersUpdate.nPeers > 0)
-      rasPeersDump();
-    if (msg->peersUpdate.nDeadPeers > 0)
-      rasDeadPeersDump();
+    if (msg->peersUpdate.nPeers > 0) rasPeersDump();
+    if (msg->peersUpdate.nDeadPeers > 0) rasDeadPeersDump();
 
     // If post-merge the hashes are still different, send our (dead) peers back.
     updatePeers = (sock->conn->lastSentPeersHash != rasPeersHash && sock->conn->lastRecvPeersHash != rasPeersHash);
-    updateDeadPeers = (sock->conn->lastSentDeadPeersHash != rasDeadPeersHash &&
-                       sock->conn->lastRecvDeadPeersHash != rasDeadPeersHash);
+    updateDeadPeers =
+      (sock->conn->lastSentDeadPeersHash != rasDeadPeersHash && sock->conn->lastRecvDeadPeersHash != rasDeadPeersHash);
     if (updatePeers || updateDeadPeers) {
       newMsg->peersUpdate.peersHash = rasPeersHash;
       newMsg->peersUpdate.deadPeersHash = rasDeadPeersHash;
@@ -629,23 +619,23 @@ ncclResult_t rasMsgHandlePeersUpdate(struct rasMsg* msg, struct rasSocket* sock)
         if (nRasDeadPeers == 0) {
           // Should never happen.
           INFO(NCCL_RAS, "RAS peersUpdate discrepancy: updateDeadPeers is true but nRasDeadPeers is 0 -- "
-               "internal error?");
+                         "internal error?");
         }
         sock->conn->lastSentDeadPeersHash = rasDeadPeersHash;
 
         ALIGN_SIZE(newMsgLen, alignof(union ncclSocketAddress));
         deadPeersOffset = newMsgLen;
-        newMsgLen += nRasDeadPeers*sizeof(*rasDeadPeers);
+        newMsgLen += nRasDeadPeers * sizeof(*rasDeadPeers);
 
-        memcpy(((char*)newMsg)+deadPeersOffset, rasDeadPeers, nDeadPeers * sizeof(*rasDeadPeers));
+        memcpy(((char*)newMsg) + deadPeersOffset, rasDeadPeers, nDeadPeers * sizeof(*rasDeadPeers));
         sock->conn->lastSentDeadPeersHash = rasDeadPeersHash;
         newMsg->peersUpdate.nDeadPeers = nRasDeadPeers;
       } else {
         newMsg->peersUpdate.nDeadPeers = 0;
       }
 
-      INFO(NCCL_RAS, "RAS sending back a peersUpdate (nPeers %d, nDeadPeers %d)",
-           newMsg->peersUpdate.nPeers, newMsg->peersUpdate.nDeadPeers);
+      INFO(NCCL_RAS, "RAS sending back a peersUpdate (nPeers %d, nDeadPeers %d)", newMsg->peersUpdate.nPeers,
+           newMsg->peersUpdate.nDeadPeers);
 
       rasConnEnqueueMsg(sock->conn, newMsg, newMsgLen);
       newMsg = nullptr;
@@ -653,7 +643,8 @@ ncclResult_t rasMsgHandlePeersUpdate(struct rasMsg* msg, struct rasSocket* sock)
 
     // Propagate the changes through our RAS network links.
     NCCLCHECKGOTO(rasNetUpdatePeers(msg->peersUpdate.peers, msg->peersUpdate.nPeers, updateDeadPeers, nullptr, 0,
-                                    sock->conn), ret, fail);
+                                    sock->conn),
+                  ret, fail);
   }
 
 exit:
@@ -662,7 +653,6 @@ exit:
 fail:
   goto exit;
 }
-
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // Functions related to the (re-)configuration of RAS connections after a peers update. //
@@ -695,7 +685,7 @@ static ncclResult_t rasLinkReinitConns(struct rasLink* link) {
 
   // Fill in the entry for the primary connection.
   linkConn = link->conns;
-  linkConn->peerIdx = newPeerIdx = rasLinkCalculatePeer(link, myPeerIdx, /*isFallback*/false);
+  linkConn->peerIdx = newPeerIdx = rasLinkCalculatePeer(link, myPeerIdx, /*isFallback*/ false);
   linkConn->conn = (newPeerIdx != -1 ? rasConnFind(&rasPeers[newPeerIdx].addr) : nullptr);
   linkConn->external = false;
 
@@ -703,25 +693,24 @@ static ncclResult_t rasLinkReinitConns(struct rasLink* link) {
     if (linkConn->peerIdx != -1) {
       // We try to initiate primary connections from the side with a lower address (and thus an earlier peer index)
       // to avoid races and the creation of duplicate connections.
-      INFO(NCCL_RAS, "RAS link %d: %s primary connection with %s",
-           link->direction, (myPeerIdx < linkConn->peerIdx ? "opening new" : "calculated deferred"),
+      INFO(NCCL_RAS, "RAS link %d: %s primary connection with %s", link->direction,
+           (myPeerIdx < linkConn->peerIdx ? "opening new" : "calculated deferred"),
            ncclSocketToString(&rasPeers[linkConn->peerIdx].addr, rasLine));
       if (myPeerIdx < linkConn->peerIdx) {
         NCCLCHECK(rasConnCreate(&rasPeers[linkConn->peerIdx].addr, &linkConn->conn));
-      }
-      else { // If we didn't initiate the connection, start the timeout.
+      } else { // If we didn't initiate the connection, start the timeout.
         link->lastUpdatePeersTime = clockNano();
       }
     } // if (linkConn->peerIdx != -1)
   } else { // linkConn->conn
-    INFO(NCCL_RAS, "RAS link %d: calculated existing primary connection with %s",
-         link->direction, ncclSocketToString(&rasPeers[linkConn->peerIdx].addr, rasLine));
+    INFO(NCCL_RAS, "RAS link %d: calculated existing primary connection with %s", link->direction,
+         ncclSocketToString(&rasPeers[linkConn->peerIdx].addr, rasLine));
   } // linkConn->conn
 
   if (linkConn->conn && linkConn->conn->experiencingDelays) {
     INFO(NCCL_RAS, "RAS connection experiencingDelays %d, startRetryTime %.2fs, socket status %d",
-         linkConn->conn->experiencingDelays, (clockNano()-linkConn->conn->startRetryTime)/1e9,
-         (linkConn->conn->sock ? linkConn->conn->sock->status : - 1));
+         linkConn->conn->experiencingDelays, (clockNano() - linkConn->conn->startRetryTime) / 1e9,
+         (linkConn->conn->sock ? linkConn->conn->sock->status : -1));
     NCCLCHECK(rasLinkAddFallback(link, linkConn->conn));
   }
 
@@ -763,26 +752,20 @@ int rasLinkCalculatePeer(const struct rasLink* link, int peerIdx, bool isFallbac
 
         tryConn = nullptr;
         tryPeerIdx = (tryPeerIdx + link->direction + nRasPeers) % nRasPeers;
-        if (tryPeerIdx == myPeerIdx)
-          break;
+        if (tryPeerIdx == myPeerIdx) break;
       }
 
-      if (tryConn == nullptr)
-        newPeerIdx = tryPeerIdx;
-      if (tryPeerIdx == myPeerIdx)
-        break;
+      if (tryConn == nullptr) newPeerIdx = tryPeerIdx;
+      if (tryPeerIdx == myPeerIdx) break;
     } // if (isFallback && !ncclSocketsSameNode(&rasPeers[peerIdx].addr, &rasNetListeningSocket.addr))
 
     if (rasPeerIsDead(&rasPeers[newPeerIdx].addr)) {
       newPeerIdx = (newPeerIdx + nRasPeers + link->direction) % nRasPeers;
-    }
-    else
-      break;
+    } else break;
   } while (newPeerIdx != myPeerIdx);
 
   return (newPeerIdx != myPeerIdx ? newPeerIdx : -1);
 }
-
 
 //////////////////////////////////////////////////////
 // Functions related to the handling of dead peers. //
@@ -798,16 +781,13 @@ ncclResult_t rasPeerDeclareDead(const union ncclSocketAddress* addr) {
     memcpy(deadAddr, addr, sizeof(*deadAddr));
     qsort(rasDeadPeers, nRasDeadPeers, sizeof(*rasDeadPeers), &ncclSocketsCompare);
 
-    rasDeadPeersHash = getHash((const char*)rasDeadPeers, nRasDeadPeers*sizeof(*rasDeadPeers));
+    rasDeadPeersHash = getHash((const char*)rasDeadPeers, nRasDeadPeers * sizeof(*rasDeadPeers));
 
-    INFO(NCCL_RAS, "RAS declaring peer %s as DEAD; rasDeadPeersHash 0x%lx",
-         ncclSocketToString(addr, rasLine), rasDeadPeersHash);
+    INFO(NCCL_RAS, "RAS declaring peer %s as DEAD; rasDeadPeersHash 0x%lx", ncclSocketToString(addr, rasLine),
+         rasDeadPeersHash);
 
     struct rasEventNotification event = {
-      .eventType = "PEER_DEAD",
-      .details = "",
-      .peerInfo = nullptr,
-      .peerAddr = addr
+      .eventType = "PEER_DEAD", .details = "", .peerInfo = nullptr, .peerAddr = addr
     };
     rasClientsNotifyEvent(RAS_EVENT_LIFECYCLE, &event);
   }
@@ -816,13 +796,12 @@ ncclResult_t rasPeerDeclareDead(const union ncclSocketAddress* addr) {
 
 // Formats a peer description from a rasPeerInfo struct (format: "Process <pid> on node <host> managing GPU[s] <gpus>").
 const char* rasPeerInfoToString(const struct rasPeerInfo* peer, char* buf, size_t size) {
-  char hostBuf[SOCKET_NAME_MAXLEN+1];
+  char hostBuf[SOCKET_NAME_MAXLEN + 1];
   char gpuBuf[1024];
 
   ncclSocketToHost(&peer->addr, hostBuf, sizeof(hostBuf));
 
-  snprintf(buf, size, "Process %d on node %s managing GPU%s %s",
-           peer->pid, hostBuf,
+  snprintf(buf, size, "Process %d on node %s managing GPU%s %s", peer->pid, hostBuf,
            (COMPILER_POPCOUNT64(peer->cudaDevs) > 1 ? "s" : ""),
            rasGpuDevsToString(peer->cudaDevs, peer->nvmlDevs, gpuBuf, sizeof(gpuBuf)));
   return buf;
@@ -830,12 +809,7 @@ const char* rasPeerInfoToString(const struct rasPeerInfo* peer, char* buf, size_
 
 // Notifies monitoring clients about a new peer joining the job.
 static void rasNewPeerNotify(const struct rasPeerInfo* peer) {
-  struct rasEventNotification event = {
-    .eventType = "PEER_NEW",
-    .details = "",
-    .peerInfo = peer,
-    .peerAddr = nullptr
-  };
+  struct rasEventNotification event = {.eventType = "PEER_NEW", .details = "", .peerInfo = peer, .peerAddr = nullptr};
   rasClientsNotifyEvent(RAS_EVENT_LIFECYCLE, &event);
 }
 
@@ -847,8 +821,7 @@ static ncclResult_t rasDeadPeersUpdate(union ncclSocketAddress* updatePeers, int
   static union ncclSocketAddress* newPeers = nullptr;
   static union ncclSocketAddress* oldPeers;
 
-  if (*nUpdatePeers == 0)
-    return ncclSuccess;
+  if (*nUpdatePeers == 0) return ncclSuccess;
 
   // Pessimistically estimate the new size of rasDeadPeers.
   int nNewPeers = nRasDeadPeers + *nUpdatePeers;
@@ -860,8 +833,8 @@ static ncclResult_t rasDeadPeersUpdate(union ncclSocketAddress* updatePeers, int
   } else {
     // We don't need to allocate a new array in this case.  We just shift the existing content to the end of the
     // array to make room in the front for merging.
-    oldPeers = rasDeadPeers+(rasDeadPeersSize-nRasDeadPeers);
-    memmove(oldPeers, rasDeadPeers, nRasDeadPeers*sizeof(*rasDeadPeers));
+    oldPeers = rasDeadPeers + (rasDeadPeersSize - nRasDeadPeers);
+    memmove(oldPeers, rasDeadPeers, nRasDeadPeers * sizeof(*rasDeadPeers));
     newPeers = rasDeadPeers;
   }
 
@@ -870,26 +843,22 @@ static ncclResult_t rasDeadPeersUpdate(union ncclSocketAddress* updatePeers, int
   for (oldPeersIdx = updatePeersIdx = newPeersIdx = 0; oldPeersIdx < nRasDeadPeers || updatePeersIdx < *nUpdatePeers;) {
     int cmp;
     if (oldPeersIdx < nRasDeadPeers && updatePeersIdx < *nUpdatePeers) {
-      cmp = ncclSocketsCompare(oldPeers+oldPeersIdx, updatePeers+updatePeersIdx);
+      cmp = ncclSocketsCompare(oldPeers + oldPeersIdx, updatePeers + updatePeersIdx);
     } else {
       cmp = (oldPeersIdx < nRasDeadPeers ? -1 : 1);
     }
 
-    memmove(newPeers+newPeersIdx++, (cmp <= 0 ? oldPeers+oldPeersIdx : updatePeers+updatePeersIdx), sizeof(*newPeers));
-    if (cmp <= 0)
-      oldPeersIdx++;
+    memmove(newPeers + newPeersIdx++, (cmp <= 0 ? oldPeers + oldPeersIdx : updatePeers + updatePeersIdx),
+            sizeof(*newPeers));
+    if (cmp <= 0) oldPeersIdx++;
     if (cmp > 0) {
-      rasConnDisconnect(updatePeers+updatePeersIdx);
+      rasConnDisconnect(updatePeers + updatePeersIdx);
       struct rasEventNotification event = {
-        .eventType = "PEER_DEAD",
-        .details = "",
-        .peerInfo = nullptr,
-        .peerAddr = updatePeers+updatePeersIdx
+        .eventType = "PEER_DEAD", .details = "", .peerInfo = nullptr, .peerAddr = updatePeers + updatePeersIdx
       };
       rasClientsNotifyEvent(RAS_EVENT_LIFECYCLE, &event);
     }
-    if (cmp >= 0)
-      updatePeersIdx++;
+    if (cmp >= 0) updatePeersIdx++;
   }
   *nUpdatePeers = newPeersIdx - nRasDeadPeers;
   nRasDeadPeers = newPeersIdx;
@@ -900,7 +869,7 @@ static ncclResult_t rasDeadPeersUpdate(union ncclSocketAddress* updatePeers, int
     rasDeadPeersSize = nNewPeers;
   }
 
-  rasDeadPeersHash = getHash((const char*)rasDeadPeers, nRasDeadPeers*sizeof(*rasDeadPeers));
+  rasDeadPeersHash = getHash((const char*)rasDeadPeers, nRasDeadPeers * sizeof(*rasDeadPeers));
 
   return ncclSuccess;
 }
@@ -908,11 +877,11 @@ static ncclResult_t rasDeadPeersUpdate(union ncclSocketAddress* updatePeers, int
 // Returns the index of the first available entry in the rasDeadPeers array, enlarging the array if necessary.
 static ncclResult_t getNewDeadEntry(union ncclSocketAddress** pAddr) {
   if (nRasDeadPeers == rasDeadPeersSize) {
-    NCCLCHECK(ncclRealloc(&rasDeadPeers, rasDeadPeersSize, rasDeadPeersSize+RAS_INCREMENT));
+    NCCLCHECK(ncclRealloc(&rasDeadPeers, rasDeadPeersSize, rasDeadPeersSize + RAS_INCREMENT));
     rasDeadPeersSize += RAS_INCREMENT;
   }
 
-  *pAddr = rasDeadPeers+(nRasDeadPeers++);
+  *pAddr = rasDeadPeers + (nRasDeadPeers++);
   return ncclSuccess;
 }
 
@@ -921,7 +890,6 @@ bool rasPeerIsDead(const union ncclSocketAddress* addr) {
   return (rasDeadPeers != nullptr &&
           bsearch(addr, rasDeadPeers, nRasDeadPeers, sizeof(*rasDeadPeers), ncclSocketsCompare) != nullptr);
 }
-
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Auxiliary functions -- primarily sorting/searching callbacks, plus some debug output support. //
@@ -960,7 +928,7 @@ static int rasRanksCompare(const void* e1, const void* e2) {
     if (cmp == 0) {
       // There should be no complete duplicates within the rank array.
       INFO(NCCL_RAS, "RAS ranks discrepancy for %s: identical entries with index difference %td -- internal error?",
-           ncclSocketToString(&r1->addr, rasLine), r2-r1);
+           ncclSocketToString(&r1->addr, rasLine), r2 - r1);
     }
   }
   return cmp;
@@ -975,8 +943,7 @@ int ncclSocketsCompare(const void* p1, const void* p2) {
   // AF_INET (2) is less than AF_INET6 (10).
   int family = a1->sa.sa_family;
   if (family != a2->sa.sa_family) {
-    if (family > 0 && a2->sa.sa_family > 0)
-      return (family < a2->sa.sa_family ? -1 : 1);
+    if (family > 0 && a2->sa.sa_family > 0) return (family < a2->sa.sa_family ? -1 : 1);
     else // Put empty addresses at the end (not that it matters...).
       return (family > 0 ? -1 : 1);
   }
@@ -986,15 +953,13 @@ int ncclSocketsCompare(const void* p1, const void* p2) {
     if ((cmp = memcmp(&a1->sin.sin_addr, &a2->sin.sin_addr, sizeof(a1->sin.sin_addr))) == 0) {
       cmp = memcmp(&a1->sin.sin_port, &a2->sin.sin_port, sizeof(a1->sin.sin_port));
     }
-  }
-  else if (family == AF_INET6) {
+  } else if (family == AF_INET6) {
     if ((cmp = memcmp(&a1->sin6.sin6_addr, &a2->sin6.sin6_addr, sizeof(a1->sin6.sin6_addr))) == 0) {
       cmp = memcmp(&a1->sin6.sin6_port, &a2->sin6.sin6_port, sizeof(a1->sin6.sin6_port));
     }
   } else {
     // The only remaining valid case are empty addresses.
-    if (family != 0)
-      INFO(NCCL_RAS, "RAS invalid address family %d -- internal error?", family);
+    if (family != 0) INFO(NCCL_RAS, "RAS invalid address family %d -- internal error?", family);
     cmp = 0; // Two empty addresses are equal...
   }
 
@@ -1005,43 +970,38 @@ int ncclSocketsCompare(const void* p1, const void* p2) {
 bool ncclSocketsSameNode(const union ncclSocketAddress* a1, const union ncclSocketAddress* a2) {
   // AF_INET (2) is less than AF_INET6 (10).
   int family = a1->sa.sa_family;
-  if (family != a2->sa.sa_family)
-    return false;
+  if (family != a2->sa.sa_family) return false;
 
-  if (family == AF_INET)
-    return (memcmp(&a1->sin.sin_addr, &a2->sin.sin_addr, sizeof(a1->sin.sin_addr)) == 0);
+  if (family == AF_INET) return (memcmp(&a1->sin.sin_addr, &a2->sin.sin_addr, sizeof(a1->sin.sin_addr)) == 0);
   else if (family == AF_INET6)
     return (memcmp(&a1->sin6.sin6_addr, &a2->sin6.sin6_addr, sizeof(a1->sin6.sin6_addr)) == 0);
-  else
-    return true; // Two empty addresses are equal...
+  else return true; // Two empty addresses are equal...
 }
 
 // Debug output routine: dumps the rasPeers array.
 static void rasPeersDump() {
   for (int p = 0; p < nRasPeers; p++) {
-    const struct rasPeerInfo* peer = rasPeers+p;
+    const struct rasPeerInfo* peer = rasPeers + p;
     INFO(NCCL_RAS, "RAS peer %d: %s%s", p, rasPeerDump(peer, rasLine, sizeof(rasLine)),
          (p == myPeerIdx ? " [this process]" : ""));
   }
-  if (nRasPeers > 0)
-    INFO(NCCL_RAS, "RAS peersHash 0x%lx", rasPeersHash);
+  if (nRasPeers > 0) INFO(NCCL_RAS, "RAS peersHash 0x%lx", rasPeersHash);
 }
 
 // Debug output routine: dumps the rasDeadPeers array.
 static void rasDeadPeersDump() {
   for (int p = 0; p < nRasDeadPeers; p++) {
-    int deadPeerIdx = rasPeerFind(rasDeadPeers+p);
+    int deadPeerIdx = rasPeerFind(rasDeadPeers + p);
     INFO(NCCL_RAS, "RAS dead peer %d: %s", p,
-         (deadPeerIdx >= 0 ? rasPeerDump(rasPeers+deadPeerIdx, rasLine, sizeof(rasLine)) :
-          ncclSocketToString(rasDeadPeers+p, rasLine)));
+         (deadPeerIdx >= 0 ? rasPeerDump(rasPeers + deadPeerIdx, rasLine, sizeof(rasLine)) :
+                             ncclSocketToString(rasDeadPeers + p, rasLine)));
   }
-  if (nRasDeadPeers > 0)
-    INFO(NCCL_RAS, "RAS deadPeersHash 0x%lx", rasDeadPeersHash);
+  if (nRasDeadPeers > 0) INFO(NCCL_RAS, "RAS deadPeersHash 0x%lx", rasDeadPeersHash);
 }
 
 // Debug output routine: dumps part of an individual element from the rasPeers array.
 static char* rasPeerDump(const struct rasPeerInfo* peer, char* result, size_t nres) {
-  char line[SOCKET_NAME_MAXLEN+1], line2[1024];
+  char line[SOCKET_NAME_MAXLEN + 1], line2[1024];
   snprintf(result, nres, "socket %s, pid %d, GPU%s %s", ncclSocketToString(&peer->addr, line), peer->pid,
            (COMPILER_POPCOUNT64(peer->cudaDevs) > 1 ? "s" : ""),
            rasGpuDevsToString(peer->cudaDevs, peer->nvmlDevs, line2, sizeof(line2)));
@@ -1051,7 +1011,7 @@ static char* rasPeerDump(const struct rasPeerInfo* peer, char* result, size_t nr
 // Formats a peer description by looking up the address in the global peers array.
 // Returns the formatted peer description, or just the address if the peer is not found.
 const char* rasPeerToString(const union ncclSocketAddress* addr, char* buf, size_t size) {
-  char hostBuf[SOCKET_NAME_MAXLEN+1];
+  char hostBuf[SOCKET_NAME_MAXLEN + 1];
   int peerIdx = rasPeerFind(addr);
   if (peerIdx >= 0) {
     const struct rasPeerInfo* peer = rasPeers + peerIdx;

--- a/projects/rccl/src/ras/ras.cc
+++ b/projects/rccl/src/ras/ras.cc
@@ -55,7 +55,7 @@ struct pollfd* rasPfds;
 static int nRasPfds;
 
 // We use it all over the place; no point in wasting the stack...
-char rasLine[SOCKET_NAME_MAXLEN+1];
+char rasLine[SOCKET_NAME_MAXLEN + 1];
 
 // An array holding the addresses of all NCCL communicators.  Modified by the NCCL threads (hence the mutex), read by
 // the RAS thread.
@@ -96,10 +96,10 @@ ncclResult_t ncclRasCommInit(struct ncclComm* comm, struct rasRankInit* myRank) 
       memcpy(&addr, &myRank->addr, sizeof(addr));
       (addr.sa.sa_family == AF_INET ? addr.sin.sin_port : addr.sin6.sin6_port) = htons(0);
       NCCLCHECKGOTO(ncclSocketInit(&rasNetListeningSocket, &addr, NCCL_SOCKET_MAGIC, ncclSocketTypeRasNetwork,
-                                   /*abortFlag*/nullptr, /*asyncFlag*/1), ret, fail);
+                                   /*abortFlag*/ nullptr, /*asyncFlag*/ 1),
+                    ret, fail);
       NCCLCHECKGOTO(ncclSocketListen(&rasNetListeningSocket), ret, fail);
-      INFO(NCCL_RAS, "RAS network listening socket at %s",
-           ncclSocketToString(&rasNetListeningSocket.addr, rasLine));
+      INFO(NCCL_RAS, "RAS network listening socket at %s", ncclSocketToString(&rasNetListeningSocket.addr, rasLine));
 
       (void)rasClientInitSocket();
 
@@ -120,27 +120,23 @@ ncclResult_t ncclRasCommInit(struct ncclComm* comm, struct rasRankInit* myRank) 
 
     int i;
     for (i = 0; i < nNcclComms; i++) {
-      if (ncclComms[i] == nullptr)
-        break;
+      if (ncclComms[i] == nullptr) break;
     }
     if (i == nNcclComms) {
-      NCCLCHECK(ncclRealloc(&ncclComms, nNcclComms, nNcclComms+RAS_INCREMENT*8));
-      nNcclComms += RAS_INCREMENT*8;
+      NCCLCHECK(ncclRealloc(&ncclComms, nNcclComms, nNcclComms + RAS_INCREMENT * 8));
+      nNcclComms += RAS_INCREMENT * 8;
     }
     ncclComms[i] = comm;
     ncclCommsSorted = false;
   }
 
-  if (myRank != nullptr)
-    memcpy(&myRank->addr, &rasNetListeningSocket.addr, sizeof(myRank->addr));
+  if (myRank != nullptr) memcpy(&myRank->addr, &rasNetListeningSocket.addr, sizeof(myRank->addr));
 
 exit:
   return ret;
 fail:
-  if (rasNotificationPipe[1] != 0)
-    (void)close(rasNotificationPipe[1]);
-  if (rasNotificationPipe[0] != 0)
-    (void)close(rasNotificationPipe[0]);
+  if (rasNotificationPipe[1] != 0) (void)close(rasNotificationPipe[1]);
+  if (rasNotificationPipe[0] != 0) (void)close(rasNotificationPipe[0]);
   (void)close(rasClientListeningSocket);
   (void)ncclSocketClose(&rasNetListeningSocket);
   goto exit;
@@ -148,8 +144,7 @@ fail:
 
 // Invoked by regular NCCL threads on every comm termination.
 ncclResult_t ncclRasCommFini(const struct ncclComm* comm) {
-  if (!rasInitialized)
-    return ncclSuccess;
+  if (!rasInitialized) return ncclSuccess;
   {
     std::lock_guard<std::mutex> lock(ncclCommsMutex);
     for (int i = 0; i < nNcclComms; i++) {
@@ -168,12 +163,10 @@ ncclResult_t ncclRasCommFini(const struct ncclComm* comm) {
 // and terminate.  Waits for the thread to terminate.
 static void rasTerminate() {
   struct rasNotification msg;
-  if (!rasInitialized)
-    return;
+  if (!rasInitialized) return;
   memset(&msg, '\0', sizeof(msg));
   msg.type = RAS_TERMINATE;
-  if (rasLocalNotify(&msg) == ncclSuccess)
-    rasThread.join();
+  if (rasLocalNotify(&msg) == ncclSuccess) rasThread.join();
 }
 
 // Invoked by regular NCCL threads on every (non-split) comm initialization.  Provides info on all the ranks within
@@ -190,8 +183,7 @@ ncclResult_t ncclRasAddRanks(struct rasRankInit* ranks, int nranks) {
 
 // Internal function running on regular NCCL threads -- asynchronously notifies the RAS thread.
 static ncclResult_t rasLocalNotify(const struct rasNotification* msg) {
-  if (!rasInitialized)
-    return ncclSuccess;
+  if (!rasInitialized) return ncclSuccess;
 
   // Take an exclusive lock here to avoid multiplexing between multiple user threads (not sure if it's
   // strictly required, but it won't hurt)...
@@ -204,7 +196,6 @@ static ncclResult_t rasLocalNotify(const struct rasNotification* msg) {
   }
   return ncclSuccess;
 }
-
 
 /////////////////////////////////////////////////////////////////////////////////
 // Functions related to the handling of local notifications from NCCL threads. //
@@ -268,7 +259,6 @@ static void rasThreadCleanup() {
   nRasPfds = 0;
 }
 
-
 ////////////////////////////////////////////////
 // Generic functions related to RAS messages. //
 ////////////////////////////////////////////////
@@ -304,10 +294,8 @@ void rasConnEnqueueMsg(struct rasConnection* conn, struct rasMsg* msg, size_t ms
   meta->offset = 0;
   meta->length = msgLen;
 
-  if (front)
-    ncclIntruQueueEnqueueFront(&conn->sendQ, meta);
-  else
-    ncclIntruQueueEnqueue(&conn->sendQ, meta);
+  if (front) ncclIntruQueueEnqueueFront(&conn->sendQ, meta);
+  else ncclIntruQueueEnqueue(&conn->sendQ, meta);
 
   if (conn->sock) {
     if (conn->sock->status == RAS_SOCK_READY ||
@@ -318,10 +306,11 @@ void rasConnEnqueueMsg(struct rasConnection* conn, struct rasMsg* msg, size_t ms
   }
   if (!ready) {
     // It's not a bug, unless it's for things like keep-alive messages...
-    INFO(NCCL_RAS, "RAS enqueued message type %d on a non-ready connection with %s "
+    INFO(NCCL_RAS,
+         "RAS enqueued message type %d on a non-ready connection with %s "
          "(experiencingDelays %d, startRetryTime %.2fs, socket status %d)",
-         msg->type, ncclSocketToString(&conn->addr, rasLine),
-         conn->experiencingDelays, (conn->startRetryTime ? (clockNano()-conn->startRetryTime)/1e9 : 0.0),
+         msg->type, ncclSocketToString(&conn->addr, rasLine), conn->experiencingDelays,
+         (conn->startRetryTime ? (clockNano() - conn->startRetryTime) / 1e9 : 0.0),
          (conn->sock ? conn->sock->status : -1));
   }
 }
@@ -340,18 +329,14 @@ ncclResult_t rasConnSendMsg(struct rasConnection* conn, int* closed, bool* allSe
       // Send the length of the message.
       NCCLCHECK(ncclSocketProgress(NCCL_SOCKET_SEND, &conn->sock->sock, &meta->length, sizeof(meta->length),
                                    &meta->offset, closed));
-      if (*closed)
-        return ncclSuccess;
-      if (meta->offset < sizeof(meta->length))
-        break;
+      if (*closed) return ncclSuccess;
+      if (meta->offset < sizeof(meta->length)) break;
     }
     // Send the body of the message.
-    NCCLCHECK(ncclSocketProgress(NCCL_SOCKET_SEND, &conn->sock->sock, ((char*)&meta->msg)-sizeof(meta->length),
-                                 meta->length+sizeof(meta->length), &meta->offset, closed));
-    if (*closed)
-      return ncclSuccess;
-    if (meta->offset < meta->length+sizeof(meta->length))
-      break;
+    NCCLCHECK(ncclSocketProgress(NCCL_SOCKET_SEND, &conn->sock->sock, ((char*)&meta->msg) - sizeof(meta->length),
+                                 meta->length + sizeof(meta->length), &meta->offset, closed));
+    if (*closed) return ncclSuccess;
+    if (meta->offset < meta->length + sizeof(meta->length)) break;
     ncclIntruQueueDequeue(&conn->sendQ);
     free(meta);
   }
@@ -368,15 +353,13 @@ ncclResult_t rasMsgRecv(struct rasSocket* sock, struct rasMsg** msg, int* closed
     // Receive the length of the message.
     NCCLCHECK(ncclSocketProgress(NCCL_SOCKET_RECV, &sock->sock, &sock->recvLength, sizeof(sock->recvLength),
                                  &sock->recvOffset, closed));
-    if (*closed || sock->recvOffset < sizeof(sock->recvLength))
-      return ncclSuccess;
+    if (*closed || sock->recvOffset < sizeof(sock->recvLength)) return ncclSuccess;
     NCCLCHECK(ncclCalloc((char**)&sock->recvMsg, sock->recvLength));
   }
   // Receive the body of the message.
-  NCCLCHECK(ncclSocketProgress(NCCL_SOCKET_RECV, &sock->sock, ((char*)sock->recvMsg)-sizeof(sock->recvLength),
-                               sock->recvLength+sizeof(sock->recvLength), &sock->recvOffset, closed));
-  if (*closed || sock->recvOffset < sock->recvLength+sizeof(sock->recvLength))
-    return ncclSuccess;
+  NCCLCHECK(ncclSocketProgress(NCCL_SOCKET_RECV, &sock->sock, ((char*)sock->recvMsg) - sizeof(sock->recvLength),
+                               sock->recvLength + sizeof(sock->recvLength), &sock->recvOffset, closed));
+  if (*closed || sock->recvOffset < sock->recvLength + sizeof(sock->recvLength)) return ncclSuccess;
 
   *msg = sock->recvMsg;
   sock->recvMsg = nullptr;
@@ -384,7 +367,6 @@ ncclResult_t rasMsgRecv(struct rasSocket* sock, struct rasMsg** msg, int* closed
 
   return ncclSuccess;
 }
-
 
 //////////////////////////////////////////////////////////////////
 // Functions related to the handling of specific message types. //
@@ -419,7 +401,7 @@ static ncclResult_t rasMsgHandleConnInit(const struct rasMsg* msg, struct rasSoc
   int peerIdx;
   struct rasMsg* newMsg = nullptr;
   int newMsgLen;
-  char line[SOCKET_NAME_MAXLEN+1];
+  char line[SOCKET_NAME_MAXLEN + 1];
   char versionLocal[16], versionRemote[16];
 
   INFO(NCCL_RAS, "RAS handling connInit from %s (version %s, listeningAddr %s, peersHash 0x%lx, deadPeersHash 0x%lx)",
@@ -434,7 +416,7 @@ static ncclResult_t rasMsgHandleConnInit(const struct rasMsg* msg, struct rasSoc
          ncclVersionToString(NCCL_VERSION_CODE, versionLocal, sizeof(versionLocal)),
          ncclVersionToString(msg->connInit.ncclVersion, versionRemote, sizeof(versionRemote)));
     rasNetSendNack(sock);
-    rasSocketTerminate(sock, /*finalize*/true);
+    rasSocketTerminate(sock, /*finalize*/ true);
     ret = ncclInvalidUsage;
     goto exit;
   }
@@ -444,7 +426,7 @@ static ncclResult_t rasMsgHandleConnInit(const struct rasMsg* msg, struct rasSoc
     INFO(NCCL_RAS, "RAS connection from peer %s that is considered dead!",
          ncclSocketToString(&msg->connInit.listeningAddr, rasLine));
     rasNetSendNack(sock);
-    rasSocketTerminate(sock, /*finalize*/true);
+    rasSocketTerminate(sock, /*finalize*/ true);
     goto exit;
   }
 
@@ -453,12 +435,12 @@ static ncclResult_t rasMsgHandleConnInit(const struct rasMsg* msg, struct rasSoc
   if (conn) {
     INFO(NCCL_RAS,
          "RAS found a matching existing connection (sendQ %sempty, experiencingDelays %d, startRetryTime %.2fs)",
-         (ncclIntruQueueEmpty(&conn->sendQ) ? "" : "not "),
-         conn->experiencingDelays, (conn->startRetryTime ? (clockNano()-conn->startRetryTime)/1e9 : 0.0));
+         (ncclIntruQueueEmpty(&conn->sendQ) ? "" : "not "), conn->experiencingDelays,
+         (conn->startRetryTime ? (clockNano() - conn->startRetryTime) / 1e9 : 0.0));
 
     if (conn->sock) {
-      INFO(NCCL_RAS, "RAS found an alternative existing socket (status %d, createTime %.2fs)",
-           conn->sock->status, (clockNano()-conn->sock->createTime)/1e9);
+      INFO(NCCL_RAS, "RAS found an alternative existing socket (status %d, createTime %.2fs)", conn->sock->status,
+           (clockNano() - conn->sock->createTime) / 1e9);
       // In general we prefer to keep the newer connection, but "newer" can be a relative term: we may have
       // a race where both sides attempt to establish a connection at roughly the same time, so the other side's
       // incoming connection ends up looking newer than the locally-initiated one -- for *both* of them.
@@ -469,7 +451,7 @@ static ncclResult_t rasMsgHandleConnInit(const struct rasMsg* msg, struct rasSoc
       // side) and terminate the old one (that it presumably just opened).
       if (ncclSocketsCompare(&rasNetListeningSocket.addr, &conn->addr) < 0) {
         INFO(NCCL_RAS, "RAS terminating the new socket");
-        rasSocketTerminate(sock, /*finalize*/true);
+        rasSocketTerminate(sock, /*finalize*/ true);
         goto exit;
       } else {
         INFO(NCCL_RAS, "RAS keeping the new socket and terminating the existing one");
@@ -486,10 +468,7 @@ static ncclResult_t rasMsgHandleConnInit(const struct rasMsg* msg, struct rasSoc
 
   {
     struct rasEventNotification event = {
-      .eventType = "PEER_CONNECTING",
-      .details = "",
-      .peerInfo = nullptr,
-      .peerAddr = &msg->connInit.listeningAddr
+      .eventType = "PEER_CONNECTING", .details = "", .peerInfo = nullptr, .peerAddr = &msg->connInit.listeningAddr
     };
     rasClientsNotifyEvent(RAS_EVENT_TRACE, &event);
   }
@@ -514,7 +493,7 @@ static ncclResult_t rasMsgHandleConnInit(const struct rasMsg* msg, struct rasSoc
   NCCLCHECK(rasMsgAlloc(&newMsg, newMsgLen));
   newMsg->type = RAS_MSG_CONNINITACK;
   newMsg->connInitAck.nack = 0;
-  rasConnEnqueueMsg(conn, newMsg, newMsgLen, /*front*/true);
+  rasConnEnqueueMsg(conn, newMsg, newMsgLen, /*front*/ true);
 
   conn->lastRecvPeersHash = msg->connInit.peersHash;
   conn->lastRecvDeadPeersHash = msg->connInit.deadPeersHash;
@@ -531,8 +510,8 @@ exit:
 
 // Handles the second message sent over a RAS socket as part of the handshake.
 static ncclResult_t rasMsgHandleConnInitAck(const struct rasMsg* msg, struct rasSocket* sock) {
-  INFO(NCCL_RAS, "RAS handling connInitAck from %s (nack %d)",
-       ncclSocketToString(&sock->sock.addr, rasLine), msg->connInitAck.nack);
+  INFO(NCCL_RAS, "RAS handling connInitAck from %s (nack %d)", ncclSocketToString(&sock->sock.addr, rasLine),
+       msg->connInitAck.nack);
 
   if (msg->connInitAck.nack) {
     // The remote peer doesn't want to talk to us.  The easiest way to prevent it is by declaring it dead.
@@ -584,15 +563,13 @@ static ncclResult_t rasNetSendNack(struct rasSocket* sock) {
   msg.connInitAck.nack = 1;
   offset = 0;
   NCCLCHECK(ncclSocketProgress(NCCL_SOCKET_SEND, &sock->sock, &length, sizeof(length), &offset, &closed));
-  if (closed || offset < sizeof(length))
-    return ncclSuccess;
+  if (closed || offset < sizeof(length)) return ncclSuccess;
   offset = 0;
   NCCLCHECK(ncclSocketProgress(NCCL_SOCKET_SEND, &sock->sock, &msg, length, &offset, &closed));
   // We are closing this socket anyway -- it doesn't matter to us if we succeeded or not.
 
   return ncclSuccess;
 }
-
 
 /////////////////////////////////////////////////////////////////
 // Functions related to the main event loop of the RAS thread. //
@@ -621,22 +598,20 @@ static void* rasThreadMain(void*) {
   rasPfds[pfd].events = POLLIN;
 
   // Main event loop of the RAS thread.
-  for (int64_t nextWakeup=0;;) {
+  for (int64_t nextWakeup = 0;;) {
     int timeout, nEvents;
     int64_t now = clockNano();
     if (nextWakeup > 0) {
       // The "1" below helps avoid round-downs and especially zeroes.
-      if (nextWakeup > now)
-        timeout = (nextWakeup - now) / (CLOCK_UNITS_PER_SEC / 1000) + 1;
-      else
-        timeout = 1;
+      if (nextWakeup > now) timeout = (nextWakeup - now) / (CLOCK_UNITS_PER_SEC / 1000) + 1;
+      else timeout = 1;
     } else {
       timeout = 1000; // 1 second.
     }
 
     nEvents = poll(rasPfds, nRasPfds, timeout);
 
-    nextWakeup = clockNano()+CLOCK_UNITS_PER_SEC;
+    nextWakeup = clockNano() + CLOCK_UNITS_PER_SEC;
     if (nEvents == -1 && errno != EINTR)
       INFO(NCCL_RAS, "RAS continuing in spite of an unexpected error from poll: %s", strerror(errno));
 
@@ -647,15 +622,14 @@ static void* rasThreadMain(void*) {
         if (rasPfds[pollIdx].revents & POLLNVAL) {
           // We passed an invalid file descriptor.  For now mark it to be ignored at the next iteration.  Hopefully
           // in the meantime one of the event handlers will terminate it.
-          INFO(NCCL_RAS, "RAS poll returned POLLNVAL on pollIdx %d (fd %d) -- internal error?",
-               pollIdx, rasPfds[pollIdx].fd);
+          INFO(NCCL_RAS, "RAS poll returned POLLNVAL on pollIdx %d (fd %d) -- internal error?", pollIdx,
+               rasPfds[pollIdx].fd);
           rasPfds[pollIdx].fd = POLL_FD_IGNORE;
         }
         if (rasPfds[pollIdx].fd == rasNotificationPipe[0]) {
           bool terminate = false;
           NCCLCHECKGOTO(rasLocalHandle(&terminate), ret, exit);
-          if (terminate)
-            goto exit;
+          if (terminate) goto exit;
         } else if (rasPfds[pollIdx].fd == rasNetListeningSocketFd) {
           (void)rasNetAcceptNewSocket();
         } else if (rasPfds[pollIdx].fd == rasClientListeningSocket) {
@@ -708,16 +682,14 @@ exit:
 ncclResult_t rasGetNewPollEntry(int* index) {
   int i;
   for (i = 0; i < nRasPfds; i++)
-    if (rasPfds[i].fd == NCCL_INVALID_SOCKET)
-      break;
+    if (rasPfds[i].fd == NCCL_INVALID_SOCKET) break;
   if (i == nRasPfds) {
-    NCCLCHECK(ncclRealloc(&rasPfds, nRasPfds, nRasPfds+RAS_INCREMENT));
+    NCCLCHECK(ncclRealloc(&rasPfds, nRasPfds, nRasPfds + RAS_INCREMENT));
     nRasPfds += RAS_INCREMENT;
-    for (int j = i; j < nRasPfds; j++)
-      rasPfds[j].fd = NCCL_INVALID_SOCKET;
+    for (int j = i; j < nRasPfds; j++) rasPfds[j].fd = NCCL_INVALID_SOCKET;
   }
 
-  memset(rasPfds+i, '\0', sizeof(*rasPfds));
+  memset(rasPfds + i, '\0', sizeof(*rasPfds));
   rasPfds[i].fd = NCCL_INVALID_SOCKET;
 
   *index = i;

--- a/projects/rccl/src/ras/ras_internal.h
+++ b/projects/rccl/src/ras/ras_internal.h
@@ -137,7 +137,7 @@ struct rasMsg {
       int nDeadPeers;
       struct rasPeerInfo peers[0]; // Variable length.
       // The peers array is followed by:
-      //union ncclSocketAddress deadPeers[0]; // Variable length.
+      // union ncclSocketAddress deadPeers[0]; // Variable length.
     } peersUpdate;
     struct {
       int protocol; // Protocol version, sent to the client.
@@ -155,14 +155,14 @@ struct rasMsg {
 static inline size_t rasCollDataLength(rasCollectiveType type) {
   struct rasCollRequest* data;
   switch (type) {
-    case RAS_BC_DEADPEER:
-      return offsetof(struct rasCollRequest, deadPeer) + sizeof(data->deadPeer);
-    case RAS_COLL_CONNS:
-      return offsetof(struct rasCollRequest, conns) + sizeof(data->conns);
-    case RAS_COLL_COMMS:
-      return offsetof(struct rasCollRequest, comms) + sizeof(data->comms);
-    case RAS_MSG_NONE:
-      return 0;
+  case RAS_BC_DEADPEER:
+    return offsetof(struct rasCollRequest, deadPeer) + sizeof(data->deadPeer);
+  case RAS_COLL_CONNS:
+    return offsetof(struct rasCollRequest, conns) + sizeof(data->conns);
+  case RAS_COLL_COMMS:
+    return offsetof(struct rasCollRequest, comms) + sizeof(data->comms);
+  case RAS_MSG_NONE:
+    return 0;
   };
   return 0;
 }
@@ -171,18 +171,18 @@ static inline size_t rasCollDataLength(rasCollectiveType type) {
 static inline size_t rasMsgLength(rasMsgType type, rasCollectiveType collType = RAS_MSG_NONE) {
   struct rasMsg* msg;
   switch (type) {
-    case RAS_MSG_CONNINIT:
-      return offsetof(struct rasMsg, connInit) + sizeof(msg->connInit);
-    case RAS_MSG_CONNINITACK:
-      return offsetof(struct rasMsg, connInitAck) + sizeof(msg->connInitAck);
-    case RAS_MSG_KEEPALIVE:
-      return offsetof(struct rasMsg, keepAlive) + sizeof(msg->keepAlive);
-    case RAS_MSG_PEERSUPDATE:
-      return offsetof(struct rasMsg, peersUpdate) + sizeof(msg->peersUpdate);
-    case RAS_MSG_COLLREQ:
-      return offsetof(struct rasMsg, collReq) + rasCollDataLength(collType);
-    case RAS_MSG_COLLRESP:
-      return offsetof(struct rasMsg, collResp) + sizeof(msg->collResp);
+  case RAS_MSG_CONNINIT:
+    return offsetof(struct rasMsg, connInit) + sizeof(msg->connInit);
+  case RAS_MSG_CONNINITACK:
+    return offsetof(struct rasMsg, connInitAck) + sizeof(msg->connInitAck);
+  case RAS_MSG_KEEPALIVE:
+    return offsetof(struct rasMsg, keepAlive) + sizeof(msg->keepAlive);
+  case RAS_MSG_PEERSUPDATE:
+    return offsetof(struct rasMsg, peersUpdate) + sizeof(msg->peersUpdate);
+  case RAS_MSG_COLLREQ:
+    return offsetof(struct rasMsg, collReq) + rasCollDataLength(collType);
+  case RAS_MSG_COLLRESP:
+    return offsetof(struct rasMsg, collResp) + sizeof(msg->collResp);
   };
   return 0;
 }
@@ -198,41 +198,42 @@ static inline size_t rasMsgLength(rasMsgType type, rasCollectiveType collType = 
 #define CLOCK_UNITS_PER_SEC (1000000000LL)
 
 // Keep-alive messages are sent no sooner than a second after the last message was sent down a particular connection.
-#define RAS_KEEPALIVE_INTERVAL (1*CLOCK_UNITS_PER_SEC*ncclParamRasTimeoutFactor())
+#define RAS_KEEPALIVE_INTERVAL (1 * CLOCK_UNITS_PER_SEC * ncclParamRasTimeoutFactor())
 
 // If no message arrives in 5 seconds via a particular connection that uses keep-alive messages, generate a warning
 // and try alternative connections.
-#define RAS_KEEPALIVE_TIMEOUT_WARN (5*CLOCK_UNITS_PER_SEC*ncclParamRasTimeoutFactor())
+#define RAS_KEEPALIVE_TIMEOUT_WARN (5 * CLOCK_UNITS_PER_SEC * ncclParamRasTimeoutFactor())
 
 // Abort a socket that uses keep-alive messages if no message arrives in 20 seconds.
 // We will try to re-establish communication via that connection (until RAS_PEER_DEAD_TIMEOUT).
 #define RAS_KEEPALIVE_TIMEOUT_ERROR RAS_STUCK_TIMEOUT
 
 // Retry connecting on failing sockets (ECONNREFUSED, etc.) once a second.
-#define RAS_CONNECT_RETRY (1*CLOCK_UNITS_PER_SEC*ncclParamRasTimeoutFactor())
+#define RAS_CONNECT_RETRY (1 * CLOCK_UNITS_PER_SEC * ncclParamRasTimeoutFactor())
 
 // If we can't connect in 5 seconds, we generate a warning and try alternative connections.
 #define RAS_CONNECT_WARN RAS_KEEPALIVE_TIMEOUT_WARN
 
 // Abort a busy socket (one we are trying to send on, or one that was being established) if there's been
 // no sign of progress in 20 second.  We will try to re-establish communication (up to RAS_PEER_DEAD_TIMEOUT).
-#define RAS_STUCK_TIMEOUT (20*CLOCK_UNITS_PER_SEC*ncclParamRasTimeoutFactor())
+#define RAS_STUCK_TIMEOUT (20 * CLOCK_UNITS_PER_SEC * ncclParamRasTimeoutFactor())
 
 // Terminate ad-hoc connections that have not been used in 60 seconds.
-#define RAS_IDLE_TIMEOUT (60*CLOCK_UNITS_PER_SEC*ncclParamRasTimeoutFactor())
+#define RAS_IDLE_TIMEOUT (60 * CLOCK_UNITS_PER_SEC * ncclParamRasTimeoutFactor())
 
 // If the socket is closed by peer within 5 seconds from the idle timeout, do not attempt to re-establish.
-#define RAS_IDLE_GRACE_PERIOD (5*CLOCK_UNITS_PER_SEC*ncclParamRasTimeoutFactor())
+#define RAS_IDLE_GRACE_PERIOD (5 * CLOCK_UNITS_PER_SEC * ncclParamRasTimeoutFactor())
 
 // Declare a peer as dead and don't retry communicating with it if we couldn't reach it for 60 seconds.
-#define RAS_PEER_DEAD_TIMEOUT (60*CLOCK_UNITS_PER_SEC*ncclParamRasTimeoutFactor())
+#define RAS_PEER_DEAD_TIMEOUT (60 * CLOCK_UNITS_PER_SEC * ncclParamRasTimeoutFactor())
 
 // Abort a leg of a collective operation if the response takes more than 5 seconds to arrive *and* one of the
 // connections experiences delays.
-#define RAS_COLLECTIVE_LEG_TIMEOUT (RAS_COLLECTIVE_LEG_TIMEOUT_SEC*CLOCK_UNITS_PER_SEC*ncclParamRasTimeoutFactor())
+#define RAS_COLLECTIVE_LEG_TIMEOUT (RAS_COLLECTIVE_LEG_TIMEOUT_SEC * CLOCK_UNITS_PER_SEC * ncclParamRasTimeoutFactor())
 
 // Abort a whole collective operation after at most RAS_COLLECTIVE_LEG_TIMEOUT+RAS_COLLECTIVE_EXTRA_TIMEOUT (10s).
-#define RAS_COLLECTIVE_EXTRA_TIMEOUT (RAS_COLLECTIVE_EXTRA_TIMEOUT_SEC*CLOCK_UNITS_PER_SEC*ncclParamRasTimeoutFactor())
+#define RAS_COLLECTIVE_EXTRA_TIMEOUT \
+  (RAS_COLLECTIVE_EXTRA_TIMEOUT_SEC * CLOCK_UNITS_PER_SEC * ncclParamRasTimeoutFactor())
 
 // Structure used for tracking the progress of sending a RAS message.
 struct rasMsgMeta {
@@ -513,15 +514,14 @@ struct rasClient {
   struct rasCollective* coll;
 };
 
-
 // ras.cc
 extern struct pollfd* rasPfds;
 extern struct ncclSocket rasNetListeningSocket;
 extern std::mutex ncclCommsMutex;
 extern struct ncclComm** ncclComms;
 extern int nNcclComms;
-extern  bool ncclCommsSorted;
-extern char rasLine[SOCKET_NAME_MAXLEN+1];
+extern bool ncclCommsSorted;
+extern char rasLine[SOCKET_NAME_MAXLEN + 1];
 
 int64_t ncclParamRasTimeoutFactor();
 ncclResult_t rasMsgAlloc(struct rasMsg** msg, size_t msgLen);
@@ -533,13 +533,12 @@ ncclResult_t rasMsgHandle(struct rasMsg* msg, struct rasSocket* sock);
 void rasMsgHandleBCDeadPeer(struct rasCollRequest** pReq, size_t* pReqLen, bool* pDone);
 ncclResult_t rasGetNewPollEntry(int* index);
 
-
 // rasnet.cc
 extern struct rasLink rasNextLink, rasPrevLink;
 extern struct rasConnection* rasConnsHead;
 extern struct rasConnection* rasConnsTail;
-extern struct rasSocket *rasSocketsHead;
-extern struct rasSocket *rasSocketsTail;
+extern struct rasSocket* rasSocketsHead;
+extern struct rasSocket* rasSocketsTail;
 
 ncclResult_t getNewConnEntry(struct rasConnection** pConn);
 ncclResult_t rasConnCreate(const union ncclSocketAddress* addr, struct rasConnection** pConn);
@@ -556,7 +555,6 @@ ncclResult_t rasMsgHandleKeepAlive(const struct rasMsg* msg, struct rasSocket* s
 ncclResult_t rasLinkAddFallback(struct rasLink* link, const struct rasConnection* conn);
 ncclResult_t rasLinkConnUpdate(struct rasLink* link, struct rasConnection* conn, int peerIdx);
 void rasNetTerminate();
-
 
 // peers.cc
 extern struct rasPeerInfo* rasPeers;
@@ -578,7 +576,6 @@ int ncclSocketsCompare(const void* p1, const void* p2);
 bool ncclSocketsSameNode(const union ncclSocketAddress* a1, const union ncclSocketAddress* a2);
 void rasPeersTerminate();
 
-
 // collectives.cc
 extern struct rasCollective* rasCollectivesHead;
 extern struct rasCollective* rasCollectivesTail;
@@ -592,7 +589,6 @@ void rasCollsPurgeConn(struct rasConnection* conn);
 void rasCollFree(struct rasCollective* coll);
 void rasCollsHandleTimeouts(int64_t now, int64_t* nextWakeup);
 void rasCollectivesTerminate();
-
 
 // client_support.cc
 extern int rasClientListeningSocket;

--- a/projects/rccl/src/ras/rasnet.cc
+++ b/projects/rccl/src/ras/rasnet.cc
@@ -17,8 +17,8 @@ struct rasConnection* rasConnsHead;
 struct rasConnection* rasConnsTail;
 
 // Sockets implementing the RAS network.
-struct rasSocket *rasSocketsHead;
-struct rasSocket *rasSocketsTail;
+struct rasSocket* rasSocketsHead;
+struct rasSocket* rasSocketsTail;
 
 static void freeConnEntry(struct rasConnection* conn);
 static void rasConnOpen(struct rasConnection* conn);
@@ -41,7 +41,6 @@ static ncclResult_t rasLinkConnAddExternal(struct rasLink* link, struct rasConne
 static void rasLinkConnDrop(struct rasLink* link, const struct rasConnection* conn, bool external = false);
 static struct rasLinkConn* rasLinkConnFind(const struct rasLink* link, const struct rasConnection* conn,
                                            int* pLinkIdx = nullptr);
-
 
 ///////////////////////////////////////////////
 // Functions related to the RAS connections. //
@@ -71,17 +70,12 @@ ncclResult_t getNewConnEntry(struct rasConnection** pConn) {
 
 // Frees an entry from the rasConns list.
 static void freeConnEntry(struct rasConnection* conn) {
-  if (conn == nullptr)
-    return;
+  if (conn == nullptr) return;
 
-  if (conn == rasConnsHead)
-    rasConnsHead = rasConnsHead->next;
-  if (conn == rasConnsTail)
-    rasConnsTail = rasConnsTail->prev;
-  if (conn->prev)
-    conn->prev->next = conn->next;
-  if (conn->next)
-    conn->next->prev = conn->prev;
+  if (conn == rasConnsHead) rasConnsHead = rasConnsHead->next;
+  if (conn == rasConnsTail) rasConnsTail = rasConnsTail->prev;
+  if (conn->prev) conn->prev->next = conn->next;
+  if (conn->next) conn->next->prev = conn->prev;
   free(conn);
 }
 
@@ -95,8 +89,7 @@ ncclResult_t rasConnCreate(const union ncclSocketAddress* addr, struct rasConnec
 
   if (conn && conn->sock) {
     // An entry exists and has a socket associated with it -- nothing left for us to do.
-    if (pConn)
-      *pConn = conn;
+    if (pConn) *pConn = conn;
     goto exit;
   }
 
@@ -107,8 +100,7 @@ ncclResult_t rasConnCreate(const union ncclSocketAddress* addr, struct rasConnec
     conn->startRetryTime = clockNano();
   }
 
-  if (pConn)
-    *pConn = conn;
+  if (pConn) *pConn = conn;
 
   rasConnOpen(conn);
 
@@ -125,7 +117,8 @@ static void rasConnOpen(struct rasConnection* conn) {
 
   NCCLCHECKGOTO(getNewSockEntry(&sock), ret, fail);
   NCCLCHECKGOTO(ncclSocketInit(&sock->sock, &conn->addr, NCCL_SOCKET_MAGIC, ncclSocketTypeRasNetwork, nullptr,
-                               /*asyncFlag*/1, /*customRetry*/1), ret, fail);
+                               /*asyncFlag*/ 1, /*customRetry*/ 1),
+                ret, fail);
   closeSocketOnFail = true;
   NCCLCHECKGOTO(ncclSocketConnect(&sock->sock), ret, fail);
   NCCLCHECKGOTO(ncclSocketReady(&sock->sock, &ready), ret, fail);
@@ -149,8 +142,7 @@ exit:
   // We deliberately ignore ret as this function will be retried later if needed.
   return;
 fail:
-  if (closeSocketOnFail)
-    (void)ncclSocketClose(&sock->sock);
+  if (closeSocketOnFail) (void)ncclSocketClose(&sock->sock);
   freeSockEntry(sock);
   goto exit;
 }
@@ -170,7 +162,7 @@ static ncclResult_t rasConnPrepare(struct rasConnection* conn) {
   msg->connInit.deadPeersHash = rasDeadPeersHash;
   // We don't update lastSent[Dead]PeersHash because we aren't actually sending the peers themselves here.
 
-  rasConnEnqueueMsg(conn, msg, msgLen, /*front*/true);
+  rasConnEnqueueMsg(conn, msg, msgLen, /*front*/ true);
 
   // We'll finish the initialization in rasMsgHandleConnInitAck, after the other side responds.
   return ncclSuccess;
@@ -179,8 +171,7 @@ static ncclResult_t rasConnPrepare(struct rasConnection* conn) {
 // Searches through rasConns for a connection with a provided address.
 struct rasConnection* rasConnFind(const union ncclSocketAddress* addr) {
   for (struct rasConnection* conn = rasConnsHead; conn; conn = conn->next) {
-    if (memcmp(&conn->addr, addr, sizeof(conn->addr)) == 0)
-      return conn;
+    if (memcmp(&conn->addr, addr, sizeof(conn->addr)) == 0) return conn;
   }
 
   return nullptr;
@@ -204,47 +195,44 @@ void rasConnsHandleTimeouts(int64_t now, int64_t* nextWakeup) {
           if (ncclSocketReady(&conn->sock->sock, &ready) != ncclSuccess) {
             INFO(NCCL_RAS, "Unexpected error from ncclSocketReady; terminating the socket connection with %s",
                  ncclSocketToString(&conn->addr, rasLine));
-            rasSocketTerminate(conn->sock, /*finalize*/true);
+            rasSocketTerminate(conn->sock, /*finalize*/ true);
             // We will retry below in the same loop.
             sockTerminated = true;
           } else {
             // We update lastSendTime even if !ready because we need it up-to-date for timeout calculations.
             conn->sock->lastSendTime = clockNano();
             if (!ready && conn->sock->sock.state == ncclSocketStateConnecting)
-              *nextWakeup = std::min(*nextWakeup, static_cast<int64_t>(conn->sock->lastSendTime+RAS_CONNECT_RETRY));
+              *nextWakeup = std::min(*nextWakeup, static_cast<int64_t>(conn->sock->lastSendTime + RAS_CONNECT_RETRY));
             else
               rasPfds[conn->sock->pfd].fd = conn->sock->sock.socketDescriptor; // Enable the handling via the main loop.
           } // if (ncclSocketReady)
         } else {
-          *nextWakeup = std::min(*nextWakeup, static_cast<int64_t>(conn->sock->lastSendTime+RAS_CONNECT_RETRY));
+          *nextWakeup = std::min(*nextWakeup, static_cast<int64_t>(conn->sock->lastSendTime + RAS_CONNECT_RETRY));
         }
       } // if (conn->sock->status == RAS_SOCK_CONNECTING && conn->sock->sock.state == ncclSocketStateConnecting)
 
       // For connections that have data to send but that we've been unable to send a message on for a while,
       // consider their sockets lost and terminate them.
       if (!sockTerminated && !ncclIntruQueueEmpty(&conn->sendQ) && conn->sock->status == RAS_SOCK_READY) {
-        if (now - std::max(conn->sock->lastSendTime,
-                           ncclIntruQueueHead(&conn->sendQ)->enqueueTime) > RAS_STUCK_TIMEOUT) {
+        if (now - std::max(conn->sock->lastSendTime, ncclIntruQueueHead(&conn->sendQ)->enqueueTime) >
+            RAS_STUCK_TIMEOUT) {
           char details[256];
-          long timeoutSecs = (now - std::max(conn->sock->lastSendTime, ncclIntruQueueHead(&conn->sendQ)->enqueueTime)) / CLOCK_UNITS_PER_SEC;
-          snprintf(details, sizeof(details),
-                   "send operation stuck for %" PRId64 "s, terminating connection", (int64_t)timeoutSecs);
-          struct rasEventNotification event = {
-            "PEER_SEND_STUCK",
-            details,
-            nullptr,
-            &conn->addr
-          };
+          long timeoutSecs = (now - std::max(conn->sock->lastSendTime, ncclIntruQueueHead(&conn->sendQ)->enqueueTime)) /
+                             CLOCK_UNITS_PER_SEC;
+          snprintf(details, sizeof(details), "send operation stuck for %" PRId64 "s, terminating connection",
+                   (int64_t)timeoutSecs);
+          struct rasEventNotification event = {"PEER_SEND_STUCK", details, nullptr, &conn->addr};
           rasClientsNotifyEvent(RAS_EVENT_TRACE, &event);
 
           INFO(NCCL_RAS, "RAS send stuck timeout error (%" PRId64 "s) on socket connection with %s",
                (int64_t)timeoutSecs, ncclSocketToString(&conn->addr, rasLine));
-          rasSocketTerminate(conn->sock, /*finalize*/false, RAS_STUCK_TIMEOUT);
+          rasSocketTerminate(conn->sock, /*finalize*/ false, RAS_STUCK_TIMEOUT);
           // We will retry below in the same loop.
         } else {
-          *nextWakeup = std::min(*nextWakeup,
-                                 static_cast<int64_t>(std::max(conn->sock->lastSendTime, ncclIntruQueueHead(&conn->sendQ)->enqueueTime)+
-                                 RAS_STUCK_TIMEOUT));
+          *nextWakeup =
+            std::min(*nextWakeup, static_cast<int64_t>(std::max(conn->sock->lastSendTime,
+                                                                ncclIntruQueueHead(&conn->sendQ)->enqueueTime) +
+                                                       RAS_STUCK_TIMEOUT));
         }
       } // if (!ncclIntruQueueEmpty(&conn->sendQ) && conn->sock->status == RAS_SOCK_READY)
     } // if (conn->sock)
@@ -258,19 +246,13 @@ void rasConnsHandleTimeouts(int64_t now, int64_t* nextWakeup) {
       if (now - conn->startRetryTime > RAS_PEER_DEAD_TIMEOUT) {
         struct rasCollRequest bCast;
         char details[256];
-        snprintf(details, sizeof(details),
-                 "peer failed to respond for %" PRId64 "s, declaring dead",
-                 (int64_t)((now-conn->startRetryTime)/CLOCK_UNITS_PER_SEC));
-        struct rasEventNotification event = {
-          "PEER_TIMEOUT_DEAD",
-          details,
-          nullptr,
-          &conn->addr
-        };
+        snprintf(details, sizeof(details), "peer failed to respond for %" PRId64 "s, declaring dead",
+                 (int64_t)((now - conn->startRetryTime) / CLOCK_UNITS_PER_SEC));
+        struct rasEventNotification event = {"PEER_TIMEOUT_DEAD", details, nullptr, &conn->addr};
         rasClientsNotifyEvent(RAS_EVENT_TRACE, &event);
 
         INFO(NCCL_RAS, "RAS connect retry timeout (%" PRId64 "s) on socket connection with %s",
-             (int64_t)((now-conn->startRetryTime)/CLOCK_UNITS_PER_SEC), ncclSocketToString(&conn->addr, rasLine));
+             (int64_t)((now - conn->startRetryTime) / CLOCK_UNITS_PER_SEC), ncclSocketToString(&conn->addr, rasLine));
 
         // Broadcast the info about a dead peer to everybody.  This will handle it locally as well, including
         // declaring the peer dead and terminating the connection.
@@ -281,7 +263,7 @@ void rasConnsHandleTimeouts(int64_t now, int64_t* nextWakeup) {
 
         connTerminated = true;
       } else {
-        *nextWakeup = std::min(*nextWakeup, static_cast<int64_t>(conn->startRetryTime+RAS_PEER_DEAD_TIMEOUT));
+        *nextWakeup = std::min(*nextWakeup, static_cast<int64_t>(conn->startRetryTime + RAS_PEER_DEAD_TIMEOUT));
       }
 
       // RAS_STUCK_TIMEOUT has already been handled in the socket function (we'll pick it up later via
@@ -293,18 +275,13 @@ void rasConnsHandleTimeouts(int64_t now, int64_t* nextWakeup) {
         if (now - conn->startRetryTime > RAS_CONNECT_WARN) {
           if (!conn->experiencingDelays) {
             char details[256];
-            snprintf(details, sizeof(details),
-                     "peer not responding for %" PRId64 "s (connect timeout)",
+            snprintf(details, sizeof(details), "peer not responding for %" PRId64 "s (connect timeout)",
                      (int64_t)((now - conn->startRetryTime) / CLOCK_UNITS_PER_SEC));
-            struct rasEventNotification event = {
-              "PEER_UNRESPONSIVE",
-              details,
-              nullptr,
-              &conn->addr
-            };
+            struct rasEventNotification event = {"PEER_UNRESPONSIVE", details, nullptr, &conn->addr};
             rasClientsNotifyEvent(RAS_EVENT_TRACE, &event);
             INFO(NCCL_RAS, "RAS connect timeout warning (%" PRId64 "s) on socket connection with %s",
-                 (int64_t)((now-conn->startRetryTime) / CLOCK_UNITS_PER_SEC), ncclSocketToString(&conn->addr, rasLine));
+                 (int64_t)((now - conn->startRetryTime) / CLOCK_UNITS_PER_SEC),
+                 ncclSocketToString(&conn->addr, rasLine));
 
             // See if the connection was meant to be a part of a RAS link and if so, try to initiate fallback
             // connection(s).  At this point, it's mostly just a precaution; we will continue trying to establish
@@ -317,7 +294,7 @@ void rasConnsHandleTimeouts(int64_t now, int64_t* nextWakeup) {
             rasCollsPurgeConn(conn);
           } // if (!conn->experiencingDelays)
         } else {
-          *nextWakeup = std::min(*nextWakeup, static_cast<int64_t>(conn->startRetryTime+RAS_CONNECT_WARN));
+          *nextWakeup = std::min(*nextWakeup, static_cast<int64_t>(conn->startRetryTime + RAS_CONNECT_WARN));
         }
 
         // If a socket was terminated (or never opened, due to some error), try to open it now.
@@ -329,21 +306,16 @@ void rasConnsHandleTimeouts(int64_t now, int64_t* nextWakeup) {
               snprintf(details, sizeof(details),
                        "connection attempt timed out after %" PRId64 "s, attempting reconnect",
                        (int64_t)((now - conn->startRetryTime) / CLOCK_UNITS_PER_SEC));
-              struct rasEventNotification event = {
-                "PEER_RETRY",
-                details,
-                nullptr,
-                &conn->addr
-              };
+              struct rasEventNotification event = {"PEER_RETRY", details, nullptr, &conn->addr};
               rasClientsNotifyEvent(RAS_EVENT_TRACE, &event);
             }
             INFO(NCCL_RAS, "RAS trying to reconnect with %s (experiencingDelays %d, startRetryTime %.2fs)",
                  ncclSocketToString(&conn->addr, rasLine), conn->experiencingDelays,
-                 (conn->startRetryTime ? (now-conn->startRetryTime)/1e9 : 0.0));
+                 (conn->startRetryTime ? (now - conn->startRetryTime) / 1e9 : 0.0));
             rasConnOpen(conn);
           }
           if (conn->sock == nullptr)
-            *nextWakeup = std::min(*nextWakeup, static_cast<int64_t>(conn->lastRetryTime+RAS_CONNECT_RETRY));
+            *nextWakeup = std::min(*nextWakeup, static_cast<int64_t>(conn->lastRetryTime + RAS_CONNECT_RETRY));
         }
       } // if (!connTerminated)
     } // if (conn->startRetryTime)
@@ -371,8 +343,7 @@ static void rasConnTerminate(struct rasConnection* conn) {
   // Make sure there are no lingering rasSockets pointing to it.
   for (struct rasSocket* sock = rasSocketsHead; sock;) {
     struct rasSocket* sockNext = sock->next;
-    if (sock->conn == conn)
-      rasSocketTerminate(sock, /*finalize*/true);
+    if (sock->conn == conn) rasSocketTerminate(sock, /*finalize*/ true);
     sock = sockNext;
   }
 
@@ -388,7 +359,6 @@ static void rasConnTerminate(struct rasConnection* conn) {
   freeConnEntry(conn);
 }
 
-
 ///////////////////////////////////////////
 // Functions related to the RAS sockets. //
 ///////////////////////////////////////////
@@ -403,7 +373,8 @@ ncclResult_t rasNetAcceptNewSocket() {
   NCCLCHECKGOTO(getNewSockEntry(&sock), ret, fail);
 
   NCCLCHECKGOTO(ncclSocketInit(&sock->sock, nullptr, NCCL_SOCKET_MAGIC, ncclSocketTypeRasNetwork, nullptr,
-                               /*asyncFlag*/1), ret, fail);
+                               /*asyncFlag*/ 1),
+                ret, fail);
   socketInitialized = true;
   NCCLCHECKGOTO(ncclSocketAccept(&sock->sock, &rasNetListeningSocket), ret, fail);
   NCCLCHECKGOTO(ncclSocketReady(&sock->sock, &ready), ret, fail);
@@ -414,7 +385,7 @@ ncclResult_t rasNetAcceptNewSocket() {
   NCCLCHECKGOTO(rasGetNewPollEntry(&sock->pfd), ret, fail);
   rasPfds[sock->pfd].fd = sock->sock.socketDescriptor;
   rasPfds[sock->pfd].events = POLLIN; // Initially we'll just wait for a handshake from the other side.  This also
-                                      // helps the code tell the sides apart.
+  // helps the code tell the sides apart.
   sock->status = RAS_SOCK_CONNECTING;
 
   INFO(NCCL_RAS, "RAS new incoming socket connection from %s", ncclSocketToString(&sock->sock.addr, rasLine));
@@ -422,8 +393,7 @@ ncclResult_t rasNetAcceptNewSocket() {
 exit:
   return ret;
 fail:
-  if (socketInitialized)
-    NCCLCHECK(ncclSocketClose(&sock->sock));
+  if (socketInitialized) NCCLCHECK(ncclSocketClose(&sock->sock));
   freeSockEntry(sock);
   goto exit;
 }
@@ -451,17 +421,12 @@ static ncclResult_t getNewSockEntry(struct rasSocket** pSock) {
 
 // Frees an entry from the rasSockets list.
 static void freeSockEntry(struct rasSocket* sock) {
-  if (sock == nullptr)
-    return;
+  if (sock == nullptr) return;
 
-  if (sock == rasSocketsHead)
-    rasSocketsHead = rasSocketsHead->next;
-  if (sock == rasSocketsTail)
-    rasSocketsTail = rasSocketsTail->prev;
-  if (sock->prev)
-    sock->prev->next = sock->next;
-  if (sock->next)
-    sock->next->prev = sock->prev;
+  if (sock == rasSocketsHead) rasSocketsHead = rasSocketsHead->next;
+  if (sock == rasSocketsTail) rasSocketsTail = rasSocketsTail->prev;
+  if (sock->prev) sock->prev->next = sock->next;
+  if (sock->next) sock->next->prev = sock->prev;
   free(sock);
 }
 
@@ -475,52 +440,43 @@ void rasSocksHandleTimeouts(int64_t now, int64_t* nextWakeup) {
       if (now - sock->createTime > RAS_STUCK_TIMEOUT) {
         char details[256];
         if (sock->conn == nullptr) {
-          snprintf(details, sizeof(details),
-                   "handshake completion timed out after %" PRId64 "s (incoming connection)",
-                   (int64_t)((now-sock->createTime)/CLOCK_UNITS_PER_SEC));
-          struct rasEventNotification event = {
-            "PEER_INIT_TIMEOUT",
-            details,
-            nullptr,
-            &sock->sock.addr
-          };
+          snprintf(details, sizeof(details), "handshake completion timed out after %" PRId64 "s (incoming connection)",
+                   (int64_t)((now - sock->createTime) / CLOCK_UNITS_PER_SEC));
+          struct rasEventNotification event = {"PEER_INIT_TIMEOUT", details, nullptr, &sock->sock.addr};
           rasClientsNotifyEvent(RAS_EVENT_TRACE, &event);
 
           INFO(NCCL_RAS, "RAS init timeout error (%" PRId64 "s) on incoming socket connection from %s",
-               (int64_t)((now-sock->createTime)/CLOCK_UNITS_PER_SEC), ncclSocketToString(&sock->sock.addr, rasLine));
+               (int64_t)((now - sock->createTime) / CLOCK_UNITS_PER_SEC),
+               ncclSocketToString(&sock->sock.addr, rasLine));
         } else {
-          snprintf(details, sizeof(details),
-                   "handshake completion timed out after %" PRId64 "s (outgoing connection)",
-                   (int64_t)((now-sock->createTime)/CLOCK_UNITS_PER_SEC));
-          struct rasEventNotification event = {
-            "PEER_INIT_TIMEOUT",
-            details,
-            nullptr,
-            &sock->sock.addr
-          };
+          snprintf(details, sizeof(details), "handshake completion timed out after %" PRId64 "s (outgoing connection)",
+                   (int64_t)((now - sock->createTime) / CLOCK_UNITS_PER_SEC));
+          struct rasEventNotification event = {"PEER_INIT_TIMEOUT", details, nullptr, &sock->sock.addr};
           rasClientsNotifyEvent(RAS_EVENT_TRACE, &event);
 
-          INFO(NCCL_RAS, "RAS init timeout error (%" PRId64 "s) on socket connection with %s "
+          INFO(NCCL_RAS,
+               "RAS init timeout error (%" PRId64 "s) on socket connection with %s "
                "(experiencingDelays %d, startRetryTime %.2fs, socket status %d)",
-               (int64_t)((now-sock->createTime)/CLOCK_UNITS_PER_SEC), ncclSocketToString(&sock->sock.addr, rasLine),
+               (int64_t)((now - sock->createTime) / CLOCK_UNITS_PER_SEC), ncclSocketToString(&sock->sock.addr, rasLine),
                sock->conn->experiencingDelays,
-               (sock->conn->startRetryTime ? (now-sock->conn->startRetryTime)/1e9 : 0.0), sock->status);
+               (sock->conn->startRetryTime ? (now - sock->conn->startRetryTime) / 1e9 : 0.0), sock->status);
         }
-        rasSocketTerminate(sock, /*finalize*/true);
+        rasSocketTerminate(sock, /*finalize*/ true);
         // We may retry later.
       } else {
-        *nextWakeup = std::min(*nextWakeup, static_cast<int64_t>(sock->createTime+RAS_STUCK_TIMEOUT));
+        *nextWakeup = std::min(*nextWakeup, static_cast<int64_t>(sock->createTime + RAS_STUCK_TIMEOUT));
       }
     } else if (sock->status == RAS_SOCK_TERMINATING) {
       // For sockets that are being terminated, force finalization of the ones that haven't made progress in too long.
       if (now - std::max(sock->lastSendTime, sock->lastRecvTime) > RAS_STUCK_TIMEOUT) {
         INFO(NCCL_RAS, "RAS termination stuck timeout error (%" PRId64 "s) on socket connection with %s",
-             (int64_t)((now-std::max(sock->lastSendTime, sock->lastRecvTime)) / CLOCK_UNITS_PER_SEC),
+             (int64_t)((now - std::max(sock->lastSendTime, sock->lastRecvTime)) / CLOCK_UNITS_PER_SEC),
              ncclSocketToString(&sock->sock.addr, rasLine));
-        rasSocketTerminate(sock, /*finalize*/true);
+        rasSocketTerminate(sock, /*finalize*/ true);
         // This socket is presumably already being re-established, if needed.
       } else {
-        *nextWakeup = std::min(*nextWakeup, static_cast<int64_t>(std::max(sock->lastSendTime, sock->lastRecvTime)+RAS_STUCK_TIMEOUT));
+        *nextWakeup = std::min(*nextWakeup, static_cast<int64_t>(std::max(sock->lastSendTime, sock->lastRecvTime) +
+                                                                 RAS_STUCK_TIMEOUT));
       }
     } else if (sock->status == RAS_SOCK_READY) {
       // Terminate sockets that haven't been used in a good while.  In principle this shouldn't trigger for anything
@@ -530,10 +486,11 @@ void rasSocksHandleTimeouts(int64_t now, int64_t* nextWakeup) {
         INFO(NCCL_RAS, "RAS idle timeout (%" PRId64 "s) on socket connection with %s",
              (int64_t)((now - std::max(sock->lastSendTime, sock->lastRecvTime)) / CLOCK_UNITS_PER_SEC),
              ncclSocketToString(&sock->sock.addr, rasLine));
-        rasSocketTerminate(sock, /*finalize*/false, /*startRetryOffset*/0, /*retry*/false);
+        rasSocketTerminate(sock, /*finalize*/ false, /*startRetryOffset*/ 0, /*retry*/ false);
         // The RAS network timeout handler will terminate the conn it was associated with, if any.
       } else {
-        *nextWakeup = std::min(*nextWakeup, static_cast<int64_t>(std::max(sock->lastSendTime, sock->lastRecvTime)+RAS_IDLE_TIMEOUT));
+        *nextWakeup = std::min(*nextWakeup, static_cast<int64_t>(std::max(sock->lastSendTime, sock->lastRecvTime) +
+                                                                 RAS_IDLE_TIMEOUT));
       }
     } // if (sock->status == RAS_SOCK_READY)
 
@@ -690,12 +647,8 @@ void rasSockEventLoop(struct rasSocket* sock, int pollIdx) {
         rasSocketTerminate(sock);
         // We may retry further down.
       } else if (closed) {
-        struct rasEventNotification event = {
-          "PEER_DISCONNECTED",
-          "peer closed connection during send operation",
-          nullptr,
-          &sock->sock.addr
-        };
+        struct rasEventNotification event = {"PEER_DISCONNECTED", "peer closed connection during send operation",
+                                             nullptr, &sock->sock.addr};
         rasClientsNotifyEvent(RAS_EVENT_TRACE, &event);
 
         INFO(NCCL_RAS, "RAS socket connection with %s closed by peer on send; terminating it",
@@ -704,8 +657,7 @@ void rasSockEventLoop(struct rasSocket* sock, int pollIdx) {
         // We may retry further down.
       } else {
         sock->lastSendTime = clockNano();
-        if (allSent)
-          rasPfds[sock->pfd].events &= ~POLLOUT; // Nothing more to send for now.
+        if (allSent) rasPfds[sock->pfd].events &= ~POLLOUT; // Nothing more to send for now.
       }
     }
     if (rasPfds[pollIdx].revents & POLLIN) {
@@ -716,32 +668,22 @@ void rasSockEventLoop(struct rasSocket* sock, int pollIdx) {
         if (rasMsgRecv(sock, &msg, &closed) != ncclSuccess) {
           INFO(NCCL_RAS, "RAS unexpected error from rasMsgRecv; terminating the socket connection with %s",
                ncclSocketToString(&sock->sock.addr, rasLine));
-          rasSocketTerminate(sock, /*finalize*/true);
+          rasSocketTerminate(sock, /*finalize*/ true);
           // We may retry further down.
         } else if (closed) {
           const char* socketType;
-          if (sock->conn == nullptr)
-            socketType = "incoming";
-          else if (sock->conn->sock != sock)
-            socketType = "old";
-          else if (sock->status == RAS_SOCK_HANDSHAKE)
-            socketType = "new";
-          else
-            socketType = "current";
+          if (sock->conn == nullptr) socketType = "incoming";
+          else if (sock->conn->sock != sock) socketType = "old";
+          else if (sock->status == RAS_SOCK_HANDSHAKE) socketType = "new";
+          else socketType = "current";
           char details[256];
-          snprintf(details, sizeof(details),
-                   "peer closed %s connection during receive operation", socketType);
-          struct rasEventNotification event = {
-            "PEER_DISCONNECTED",
-            details,
-            nullptr,
-            &sock->sock.addr
-          };
+          snprintf(details, sizeof(details), "peer closed %s connection during receive operation", socketType);
+          struct rasEventNotification event = {"PEER_DISCONNECTED", details, nullptr, &sock->sock.addr};
           rasClientsNotifyEvent(RAS_EVENT_TRACE, &event);
 
-          INFO(NCCL_RAS, "RAS %s socket connection with %s closed by peer on receive; terminating it",
-               socketType, ncclSocketToString(&sock->sock.addr, rasLine));
-          rasSocketTerminate(sock, /*finalize*/true);
+          INFO(NCCL_RAS, "RAS %s socket connection with %s closed by peer on receive; terminating it", socketType,
+               ncclSocketToString(&sock->sock.addr, rasLine));
+          rasSocketTerminate(sock, /*finalize*/ true);
           // We may retry further down.
         } else { // !closed
           sock->lastRecvTime = clockNano();
@@ -750,8 +692,7 @@ void rasSockEventLoop(struct rasSocket* sock, int pollIdx) {
             free(msg);
             // Message handlers can terminate a socket in various cases.  We re-check rasPfds.events to ensure that
             // this hasn't happened here (rasSocketTerminate will reset it when finalizing a socket).
-            if (!(rasPfds[pollIdx].revents & POLLIN))
-              break;
+            if (!(rasPfds[pollIdx].revents & POLLIN)) break;
           }
           if (sock->conn) {
             if (sock->conn->sock == sock && (sock->conn->startRetryTime || sock->conn->experiencingDelays))
@@ -763,7 +704,6 @@ void rasSockEventLoop(struct rasSocket* sock, int pollIdx) {
   } // RAS_SOCK_HANDSHAKE || RAS_SOCK_READY || RAS_SOCK_TERMINATING
 }
 
-
 ////////////////////////////////////////////////////////////////
 // Functions related to the handling of RAS network timeouts. //
 ////////////////////////////////////////////////////////////////
@@ -773,8 +713,7 @@ void rasNetHandleTimeouts(int64_t now, int64_t* nextWakeup) {
   // A connection can belong to multiple links but, when it comes to various timeouts, we want to handle each
   // connection just once.  We solve that with a simple flag within a connection.  This also allows us to distinguish
   // connections that are part of a link from those that are not.
-  for (struct rasConnection* conn = rasConnsHead; conn; conn = conn->next)
-    conn->linkFlag = false;
+  for (struct rasConnection* conn = rasConnsHead; conn; conn = conn->next) conn->linkFlag = false;
 
   (void)rasLinkHandleNetTimeouts(&rasNextLink, now, nextWakeup);
   (void)rasLinkHandleNetTimeouts(&rasPrevLink, now, nextWakeup);
@@ -783,8 +722,7 @@ void rasNetHandleTimeouts(int64_t now, int64_t* nextWakeup) {
     struct rasConnection* connNext = conn->next;
     if (!conn->linkFlag) {
       // The connection is not part of any link.  Check if it should be terminated.
-      if (conn->sock == nullptr && ncclIntruQueueEmpty(&conn->sendQ))
-        rasConnTerminate(conn);
+      if (conn->sock == nullptr && ncclIntruQueueEmpty(&conn->sendQ)) rasConnTerminate(conn);
     }
     conn = connNext;
   }
@@ -803,7 +741,7 @@ static ncclResult_t rasLinkHandleNetTimeouts(struct rasLink* link, int64_t now, 
       // than the peer.  If that peer fails to initiate within RAS_CONNECT_WARN, we need to take action.
       if (now - link->lastUpdatePeersTime > RAS_CONNECT_WARN) {
         INFO(NCCL_RAS, "RAS peer connect timeout warning (%" PRId64 "s) on socket connection from %s",
-             (int64_t)((now-link->lastUpdatePeersTime) / CLOCK_UNITS_PER_SEC),
+             (int64_t)((now - link->lastUpdatePeersTime) / CLOCK_UNITS_PER_SEC),
              ncclSocketToString(&rasPeers[linkConn->peerIdx].addr, rasLine));
         NCCLCHECK(rasConnCreate(&rasPeers[linkConn->peerIdx].addr, &linkConn->conn));
         if (linkConn->conn) {
@@ -811,7 +749,7 @@ static ncclResult_t rasLinkHandleNetTimeouts(struct rasLink* link, int64_t now, 
         }
         link->lastUpdatePeersTime = 0;
       } else {
-        *nextWakeup = std::min(*nextWakeup, static_cast<int64_t>(link->lastUpdatePeersTime+RAS_CONNECT_WARN));
+        *nextWakeup = std::min(*nextWakeup, static_cast<int64_t>(link->lastUpdatePeersTime + RAS_CONNECT_WARN));
       }
     } // if (linkConn == link->conns && link->lastUpdatePeerTime != 0)
   } // for (linkConn)
@@ -828,7 +766,7 @@ static void rasConnHandleNetTimeouts(struct rasConnection* conn, int64_t now, in
         if (now - conn->sock->lastSendTime > RAS_KEEPALIVE_INTERVAL) {
           rasConnSendKeepAlive(conn);
         } else {
-          *nextWakeup = std::min(*nextWakeup, static_cast<int64_t>(conn->sock->lastSendTime+RAS_KEEPALIVE_INTERVAL));
+          *nextWakeup = std::min(*nextWakeup, static_cast<int64_t>(conn->sock->lastSendTime + RAS_KEEPALIVE_INTERVAL));
         }
       }
 
@@ -836,18 +774,13 @@ static void rasConnHandleNetTimeouts(struct rasConnection* conn, int64_t now, in
       if (now - conn->sock->lastRecvTime > RAS_KEEPALIVE_TIMEOUT_WARN) {
         if (!conn->experiencingDelays) {
           char details[256];
-          snprintf(details, sizeof(details),
-                   "peer not responding for %" PRId64 "s (keepalive warning)",
+          snprintf(details, sizeof(details), "peer not responding for %" PRId64 "s (keepalive warning)",
                    (int64_t)((now - conn->sock->lastRecvTime) / CLOCK_UNITS_PER_SEC));
-          struct rasEventNotification event = {
-            "PEER_UNRESPONSIVE",
-            details,
-            nullptr,
-            &conn->addr
-          };
+          struct rasEventNotification event = {"PEER_UNRESPONSIVE", details, nullptr, &conn->addr};
           rasClientsNotifyEvent(RAS_EVENT_TRACE, &event);
           INFO(NCCL_RAS, "RAS keep-alive timeout warning (%" PRId64 "s) on socket connection with %s",
-               (int64_t)((now-conn->sock->lastRecvTime) / CLOCK_UNITS_PER_SEC), ncclSocketToString(&conn->addr, rasLine));
+               (int64_t)((now - conn->sock->lastRecvTime) / CLOCK_UNITS_PER_SEC),
+               ncclSocketToString(&conn->addr, rasLine));
 
           // At this point, it's mostly just a precaution; we will continue with the primary connection until
           // RAS_PEER_DEAD_TIMEOUT expires.
@@ -859,29 +792,26 @@ static void rasConnHandleNetTimeouts(struct rasConnection* conn, int64_t now, in
           rasCollsPurgeConn(conn);
         }
       } else {
-        *nextWakeup = std::min(*nextWakeup, static_cast<int64_t>(conn->sock->lastRecvTime+RAS_KEEPALIVE_TIMEOUT_WARN));
+        *nextWakeup =
+          std::min(*nextWakeup, static_cast<int64_t>(conn->sock->lastRecvTime + RAS_KEEPALIVE_TIMEOUT_WARN));
       }
 
       // For long timeouts we need to act.
       if (now - conn->sock->lastRecvTime > RAS_KEEPALIVE_TIMEOUT_ERROR) {
         char details[256];
-        snprintf(details, sizeof(details),
-                 "keepalive timeout after %" PRId64 "s, terminating connection",
-                 (int64_t)((now-conn->sock->lastRecvTime) / CLOCK_UNITS_PER_SEC));
-        struct rasEventNotification event = {
-          "PEER_KEEPALIVE_TIMEOUT",
-          details,
-          nullptr,
-          &conn->addr
-        };
+        snprintf(details, sizeof(details), "keepalive timeout after %" PRId64 "s, terminating connection",
+                 (int64_t)((now - conn->sock->lastRecvTime) / CLOCK_UNITS_PER_SEC));
+        struct rasEventNotification event = {"PEER_KEEPALIVE_TIMEOUT", details, nullptr, &conn->addr};
         rasClientsNotifyEvent(RAS_EVENT_TRACE, &event);
 
         INFO(NCCL_RAS, "RAS keep-alive timeout error (%" PRId64 "s) on socket connection with %s",
-             (int64_t)((now-conn->sock->lastRecvTime) / CLOCK_UNITS_PER_SEC), ncclSocketToString(&conn->addr, rasLine));
-        rasSocketTerminate(conn->sock, /*finalize*/true, RAS_KEEPALIVE_TIMEOUT_ERROR);
+             (int64_t)((now - conn->sock->lastRecvTime) / CLOCK_UNITS_PER_SEC),
+             ncclSocketToString(&conn->addr, rasLine));
+        rasSocketTerminate(conn->sock, /*finalize*/ true, RAS_KEEPALIVE_TIMEOUT_ERROR);
         *nextWakeup = now; // Retry will be in the next iteration of the main loop so ensure we don't wait.
       } else {
-        *nextWakeup = std::min(*nextWakeup, static_cast<int64_t>(conn->sock->lastRecvTime+RAS_KEEPALIVE_TIMEOUT_ERROR));
+        *nextWakeup =
+          std::min(*nextWakeup, static_cast<int64_t>(conn->sock->lastRecvTime + RAS_KEEPALIVE_TIMEOUT_ERROR));
       }
     } // if (conn->sock->status == RAS_SOCK_READY)
   } // if (conn->sock)
@@ -919,13 +849,15 @@ ncclResult_t rasMsgHandleKeepAlive(const struct rasMsg* msg, struct rasSocket* s
 
   if (sock->conn == nullptr) {
     // Should never happen.
-    INFO(NCCL_RAS, "RAS received a keep-alive message on socket with %s that lacks a connection: status %d -- "
-         "internal error?", ncclSocketToString(&sock->sock.addr, rasLine), sock->status);
+    INFO(NCCL_RAS,
+         "RAS received a keep-alive message on socket with %s that lacks a connection: status %d -- "
+         "internal error?",
+         ncclSocketToString(&sock->sock.addr, rasLine), sock->status);
     return ncclInternalError;
   }
   clockRealtime(&currentTime);
-  travelTime = (currentTime.tv_sec-msg->keepAlive.realTime.tv_sec)*1000*1000*1000 +
-    (currentTime.tv_nsec-msg->keepAlive.realTime.tv_nsec);
+  travelTime = (currentTime.tv_sec - msg->keepAlive.realTime.tv_sec) * 1000 * 1000 * 1000 +
+               (currentTime.tv_nsec - msg->keepAlive.realTime.tv_nsec);
 
   if (msg->keepAlive.peersHash != sock->conn->lastRecvPeersHash) {
     sock->conn->lastRecvPeersHash = msg->keepAlive.peersHash;
@@ -940,14 +872,10 @@ ncclResult_t rasMsgHandleKeepAlive(const struct rasMsg* msg, struct rasSocket* s
   peerIdx = rasPeerFind(&sock->conn->addr);
   // Note: it's possible for peerIdx to be -1 at this point if, due to races, the keepAlive arrives before
   // the peers update.
-  if (msg->keepAlive.linkMask & 1)
-    (void)rasLinkConnAddExternal(&rasNextLink, sock->conn, peerIdx);
-  else
-    rasLinkConnDrop(&rasNextLink, sock->conn, /*external*/true);
-  if (msg->keepAlive.linkMask & 2)
-    (void)rasLinkConnAddExternal(&rasPrevLink, sock->conn, peerIdx);
-  else
-    rasLinkConnDrop(&rasPrevLink, sock->conn, /*external*/true);
+  if (msg->keepAlive.linkMask & 1) (void)rasLinkConnAddExternal(&rasNextLink, sock->conn, peerIdx);
+  else rasLinkConnDrop(&rasNextLink, sock->conn, /*external*/ true);
+  if (msg->keepAlive.linkMask & 2) (void)rasLinkConnAddExternal(&rasPrevLink, sock->conn, peerIdx);
+  else rasLinkConnDrop(&rasPrevLink, sock->conn, /*external*/ true);
 
   // If the keep-alive message is from a peer that doesn't actually need this connection (i.e., for that peer the
   // connection is just an external fallback), we should check if *we* still need it.  It might be that we don't,
@@ -957,14 +885,12 @@ ncclResult_t rasMsgHandleKeepAlive(const struct rasMsg* msg, struct rasSocket* s
     if (rasLinkConnFind(&rasNextLink, sock->conn) == nullptr && rasLinkConnFind(&rasPrevLink, sock->conn) == nullptr) {
       // We don't need this connection either.  Notify the peer about it.  To avoid an infinite loop, we set the
       // special nack flag in the message to distinguish it from regular keep-alives.
-      rasConnSendKeepAlive(sock->conn, /*nack*/true);
+      rasConnSendKeepAlive(sock->conn, /*nack*/ true);
     }
   }
 
-  if (sock->conn->travelTimeMin > travelTime)
-    sock->conn->travelTimeMin = travelTime;
-  if (sock->conn->travelTimeMax < travelTime)
-    sock->conn->travelTimeMax = travelTime;
+  if (sock->conn->travelTimeMin > travelTime) sock->conn->travelTimeMin = travelTime;
+  if (sock->conn->travelTimeMax < travelTime) sock->conn->travelTimeMax = travelTime;
   sock->conn->travelTimeSum += travelTime;
   sock->conn->travelTimeCount++;
 
@@ -980,7 +906,6 @@ ncclResult_t rasMsgHandleKeepAlive(const struct rasMsg* msg, struct rasSocket* s
   }
   return ncclSuccess;
 }
-
 
 ///////////////////////////////////////////////////////////////////////////////
 // Functions related to the RAS links and recovery from connection failures. //
@@ -1020,23 +945,20 @@ ncclResult_t rasLinkAddFallback(struct rasLink* link, const struct rasConnection
             firstExtLinkConn = linkConn;
             firstExtLinkIdx = i;
           }
-          if (foundLinkConn)
-            break; // Break out of the loop if we already have all the data we might need.
+          if (foundLinkConn) break; // Break out of the loop if we already have all the data we might need.
         } // linkConn->external && linkConn->peerIdx != -1
       } // if (!linkConn->conn->experiencingDelays)
     } // if (linkConn->conn && linkConn->conn != conn)
 
     if (linkConn->conn == conn) {
-      if (linkConn->external)
-        goto exit; // We don't add fallbacks for external connections...
+      if (linkConn->external) goto exit; // We don't add fallbacks for external connections...
       foundLinkConn = linkConn;
       // We are not breaking out of the loop here because we want to check for active connections on *all* potentially
       // viable elements (in particular, there could be some external ones beyond this one).
     }
   }
 
-  if (foundLinkConn == nullptr)
-    goto exit;
+  if (foundLinkConn == nullptr) goto exit;
 
   if (foundLinkConn->peerIdx == -1) {
     // Should never happen.
@@ -1047,7 +969,7 @@ ncclResult_t rasLinkAddFallback(struct rasLink* link, const struct rasConnection
   }
   // We found an existing element so the connection is part of the link.  No existing non-external connections of this
   // link are active, so a fallback is needed.
-  newPeerIdx = rasLinkCalculatePeer(link, foundLinkConn->peerIdx, /*isFallback*/(foundLinkConn != link->conns));
+  newPeerIdx = rasLinkCalculatePeer(link, foundLinkConn->peerIdx, /*isFallback*/ (foundLinkConn != link->conns));
   // In principle we want to add (at most) one fallback.  However, if the found fallback connection already exists
   // and is also experiencing delays, we need to keep iterating.
   while (newPeerIdx != -1) {
@@ -1058,11 +980,11 @@ ncclResult_t rasLinkAddFallback(struct rasLink* link, const struct rasConnection
     if (firstExtLinkConn) {
       linkIdx = -1;
       // Calculate the index that the newly found fallback would have (pretend mode).
-      NCCLCHECK(rasLinkConnAdd(link, newConn, newPeerIdx, /*pretend*/true, &linkIdx));
+      NCCLCHECK(rasLinkConnAdd(link, newConn, newPeerIdx, /*pretend*/ true, &linkIdx));
       if (linkIdx == -1) {
         // Should never happen.
-        INFO(NCCL_RAS, "RAS link %d: could not add a fallback connection with %s -- internal error?",
-             link->direction, ncclSocketToString(&conn->addr, rasLine));
+        INFO(NCCL_RAS, "RAS link %d: could not add a fallback connection with %s -- internal error?", link->direction,
+             ncclSocketToString(&conn->addr, rasLine));
         ret = ncclInternalError;
         goto exit;
       }
@@ -1072,13 +994,13 @@ ncclResult_t rasLinkAddFallback(struct rasLink* link, const struct rasConnection
         goto exit;
       }
     }
-    NCCLCHECK(rasLinkConnAdd(link, newConn, newPeerIdx, /*pretend*/false, &linkIdx, &newLinkConn));
+    NCCLCHECK(rasLinkConnAdd(link, newConn, newPeerIdx, /*pretend*/ false, &linkIdx, &newLinkConn));
     if (firstExtLinkConn && linkIdx <= firstExtLinkIdx)
       firstExtLinkIdx++; // Adjust if we inserted a new entry ahead of this one.
 
-    INFO(NCCL_RAS, "RAS link %d: %s fallback connection %d with %s",
-         link->direction, (newConn == nullptr ? "opening new" : "calculated existing"),
-         linkIdx, ncclSocketToString(&rasPeers[newPeerIdx].addr, rasLine));
+    INFO(NCCL_RAS, "RAS link %d: %s fallback connection %d with %s", link->direction,
+         (newConn == nullptr ? "opening new" : "calculated existing"), linkIdx,
+         ncclSocketToString(&rasPeers[newPeerIdx].addr, rasLine));
     // Note that we don't follow here our convention of "lower address is the one establishing connections" --
     // that convention is for optimizing regular operations, but we don't want to take chances during fault
     // recovery. It may temporarily result in duplicate connections, but we have a mechanism to deal with those.
@@ -1088,18 +1010,16 @@ ncclResult_t rasLinkAddFallback(struct rasLink* link, const struct rasConnection
     }
 
     // If the fallback connection is also experiencing delays, we need to keep trying.
-    if (!newConn->experiencingDelays)
-      break;
+    if (!newConn->experiencingDelays) break;
     INFO(NCCL_RAS, "RAS connection experiencingDelays %d, startRetryTime %.2fs, socket status %d",
-         newConn->experiencingDelays, (newConn->startRetryTime ? (clockNano()-newConn->startRetryTime)/1e9 : 0.0),
+         newConn->experiencingDelays, (newConn->startRetryTime ? (clockNano() - newConn->startRetryTime) / 1e9 : 0.0),
          (newConn->sock ? newConn->sock->status : -1));
 
-    newPeerIdx = rasLinkCalculatePeer(link, newPeerIdx, /*isFallback*/true);
+    newPeerIdx = rasLinkCalculatePeer(link, newPeerIdx, /*isFallback*/ true);
   }
   if (newPeerIdx == -1) {
     int nConns = 0;
-    for (struct rasLinkConn* linkConn = link->conns; linkConn; linkConn = linkConn->next)
-      nConns++;
+    for (struct rasLinkConn* linkConn = link->conns; linkConn; linkConn = linkConn->next) nConns++;
     INFO(NCCL_RAS, "RAS link %d: no more fallbacks to add (total %d)", link->direction, nConns);
   }
 exit:
@@ -1113,23 +1033,14 @@ static void rasConnResume(struct rasConnection* conn) {
     INFO(NCCL_RAS, "RAS %s connection with %s (sendQ %sempty, experiencingDelays %d, startRetryTime %.2fs)",
          (conn->experiencingDelays && conn->startRetryTime == 0 ? "recovered" : "established"),
          ncclSocketToString(&conn->addr, rasLine), (ncclIntruQueueEmpty(&conn->sendQ) ? "" : "not "),
-         conn->experiencingDelays, (conn->startRetryTime ? (clockNano()-conn->startRetryTime)/1e9 : 0.0));
+         conn->experiencingDelays, (conn->startRetryTime ? (clockNano() - conn->startRetryTime) / 1e9 : 0.0));
 
     if (conn->experiencingDelays) {
-      struct rasEventNotification event = {
-        "PEER_RECOVERED",
-        "peer responding again",
-        nullptr,
-        &conn->addr
-      };
+      struct rasEventNotification event = {"PEER_RECOVERED", "peer responding again", nullptr, &conn->addr};
       rasClientsNotifyEvent(RAS_EVENT_TRACE, &event);
     } else {
-      struct rasEventNotification event = {
-        "PEER_CONNECTED",
-        "connection established successfully",
-        nullptr,
-        &conn->addr
-      };
+      struct rasEventNotification event = {"PEER_CONNECTED", "connection established successfully", nullptr,
+                                           &conn->addr};
       rasClientsNotifyEvent(RAS_EVENT_TRACE, &event);
     }
 
@@ -1140,8 +1051,7 @@ static void rasConnResume(struct rasConnection* conn) {
     rasLinkSanitizeFallbacks(&rasNextLink);
     rasLinkSanitizeFallbacks(&rasPrevLink);
 
-    if (!ncclIntruQueueEmpty(&conn->sendQ))
-      rasPfds[conn->sock->pfd].events |= POLLOUT;
+    if (!ncclIntruQueueEmpty(&conn->sendQ)) rasPfds[conn->sock->pfd].events |= POLLOUT;
   }
 }
 
@@ -1155,9 +1065,8 @@ static void rasLinkSanitizeFallbacks(struct rasLink* link) {
       int i = 1;
       for (struct rasLinkConn* linkConn = link->conns->next; linkConn; i++) {
         struct rasLinkConn* linkConnNext = linkConn->next;
-        INFO(NCCL_RAS, "RAS link %d: dropping %sfallback connection %d with %s",
-             link->direction, (linkConn->external ? "external " : ""), i,
-             ncclSocketToString(&linkConn->conn->addr, rasLine));
+        INFO(NCCL_RAS, "RAS link %d: dropping %sfallback connection %d with %s", link->direction,
+             (linkConn->external ? "external " : ""), i, ncclSocketToString(&linkConn->conn->addr, rasLine));
         free(linkConn);
         linkConn = linkConnNext;
       }
@@ -1187,7 +1096,8 @@ static ncclResult_t rasLinkConnAdd(struct rasLink* link, struct rasConnection* c
 
   if (peerIdx == -1) {
     // Should never happen.
-    INFO(NCCL_RAS, "RAS link %d: rasLinkConnAdd invoked with invalid peerIdx (pretend %d, insert %d) -- internal error?",
+    INFO(NCCL_RAS,
+         "RAS link %d: rasLinkConnAdd invoked with invalid peerIdx (pretend %d, insert %d) -- internal error?",
          link->direction, pretend, insert);
     ret = ncclInternalError;
     goto exit;
@@ -1196,12 +1106,12 @@ static ncclResult_t rasLinkConnAdd(struct rasLink* link, struct rasConnection* c
     // Start by checking if we already have an element with this conn.
     oldLinkConn = rasLinkConnFind(link, conn, &oldLinkIdx);
     if (oldLinkConn) {
-      if (pLinkConn)
-        *pLinkConn = oldLinkConn;
+      if (pLinkConn) *pLinkConn = oldLinkConn;
       if (oldLinkConn->peerIdx != -1) {
         if (oldLinkConn->peerIdx != peerIdx) {
           // Should never happen.
-          INFO(NCCL_RAS, "RAS link %d: rasLinkConnAdd peerIdx %d mismatch with connection with %s "
+          INFO(NCCL_RAS,
+               "RAS link %d: rasLinkConnAdd peerIdx %d mismatch with connection with %s "
                "(pretend %d, insert %d, oldLinkConn->peerIdx %d) -- internal error?",
                link->direction, peerIdx, ncclSocketToString(&oldLinkConn->conn->addr, rasLine), pretend, insert,
                oldLinkConn->peerIdx);
@@ -1209,10 +1119,8 @@ static ncclResult_t rasLinkConnAdd(struct rasLink* link, struct rasConnection* c
           goto exit;
         }
 
-        if (!pretend)
-          oldLinkConn->external = false; // Ensure that external is cleared.
-        if (pLinkIdx)
-          *pLinkIdx = oldLinkIdx;
+        if (!pretend) oldLinkConn->external = false; // Ensure that external is cleared.
+        if (pLinkIdx) *pLinkIdx = oldLinkIdx;
         goto exit; // Nothing more to do if both conn and peerIdx are up to date.
       } // if (oldLinkConn->peerIdx != -1)
 
@@ -1228,8 +1136,9 @@ static ncclResult_t rasLinkConnAdd(struct rasLink* link, struct rasConnection* c
       // The exact linkConn element already exists.
       if (linkConn->conn && linkConn->conn != conn) {
         // Should never happen.
-        char line[SOCKET_NAME_MAXLEN+1];
-        INFO(NCCL_RAS, "RAS link %d: rasLinkConnAdd connection mismatch: linkConn %s, conn %s "
+        char line[SOCKET_NAME_MAXLEN + 1];
+        INFO(NCCL_RAS,
+             "RAS link %d: rasLinkConnAdd connection mismatch: linkConn %s, conn %s "
              "(peerIdx %d, pretend %d, insert %d) -- internal error?",
              link->direction, ncclSocketToString(&linkConn->conn->addr, line), ncclSocketToString(&conn->addr, rasLine),
              peerIdx, pretend, insert);
@@ -1238,8 +1147,7 @@ static ncclResult_t rasLinkConnAdd(struct rasLink* link, struct rasConnection* c
       }
 
       if (!pretend) {
-        if (linkConn->conn == nullptr)
-          linkConn->conn = conn;
+        if (linkConn->conn == nullptr) linkConn->conn = conn;
         linkConn->external = false; // Ensure that external is cleared.
         if (linkConn == link->conns) {
           // We received a connection from the remote peer that matches the primary connection we've been
@@ -1247,19 +1155,15 @@ static ncclResult_t rasLinkConnAdd(struct rasLink* link, struct rasConnection* c
           rasLinkSanitizeFallbacks(link);
         }
       } // if (!pretend)
-      if (pLinkIdx)
-        *pLinkIdx = i;
-      if (pLinkConn)
-        *pLinkConn = linkConn;
+      if (pLinkIdx) *pLinkIdx = i;
+      if (pLinkConn) *pLinkConn = linkConn;
       goto exit;
     } // if (linkConn->peerIdx == peerIdx)
 
     // Ensure that the previous element is valid.
-    if (linkConnPrev == nullptr)
-      continue;
+    if (linkConnPrev == nullptr) continue;
     // linkConns with peerIdx == -1 are stored at the end, so if we reach one of them, we are done.
-    if (linkConn->peerIdx == -1)
-      break;
+    if (linkConn->peerIdx == -1) break;
     // Detect a roll-over and handle it specially.
     if (link->direction * (linkConnPrev->peerIdx - linkConn->peerIdx) > 0) {
       if (link->direction * (peerIdx - linkConnPrev->peerIdx) > 0 ||
@@ -1273,17 +1177,16 @@ static ncclResult_t rasLinkConnAdd(struct rasLink* link, struct rasConnection* c
   } // for (linkConn)
 
   // The new element should be inserted after linkConnPrev (which is at index i-1).
-  if (pLinkIdx)
-    *pLinkIdx = i;
-  if (pretend)
-    goto exit;
+  if (pLinkIdx) *pLinkIdx = i;
+  if (pretend) goto exit;
 
   if (oldLinkConn) {
     if (i != oldLinkIdx) {
       // We already have the entry, but we need to move it to a new spot (which must be earlier in the list).
       if (i >= oldLinkIdx) {
         // Should never happen.
-        INFO(NCCL_RAS, "RAS link %d: rasLinkConnAdd new link index %d later in the list than the old one "
+        INFO(NCCL_RAS,
+             "RAS link %d: rasLinkConnAdd new link index %d later in the list than the old one "
              "(insert %d, oldLinkConn %s, oldLinkIdx %d) -- internal error?",
              link->direction, i, insert, ncclSocketToString(&oldLinkConn->conn->addr, rasLine), oldLinkIdx);
         ret = ncclInternalError;
@@ -1311,8 +1214,10 @@ static ncclResult_t rasLinkConnAdd(struct rasLink* link, struct rasConnection* c
     } else {
       if (link->conns != nullptr) {
         // Should never happen -- we don't add an element that would replace an existing primary.
-        INFO(NCCL_RAS, "RAS link %d: rasLinkConnAdd attempting to replace an existing primary connection with %s "
-             "-- internal error?", link->direction, ncclSocketToString(&link->conns->conn->addr, rasLine));
+        INFO(NCCL_RAS,
+             "RAS link %d: rasLinkConnAdd attempting to replace an existing primary connection with %s "
+             "-- internal error?",
+             link->direction, ncclSocketToString(&link->conns->conn->addr, rasLine));
         ret = ncclInternalError;
         goto exit;
       }
@@ -1322,8 +1227,7 @@ static ncclResult_t rasLinkConnAdd(struct rasLink* link, struct rasConnection* c
     linkConn->peerIdx = peerIdx;
     linkConn->conn = conn;
     linkConn->external = false;
-    if (pLinkConn)
-      *pLinkConn = linkConn;
+    if (pLinkConn) *pLinkConn = linkConn;
   } // oldLinkConn == nullptr && insert
 
 exit:
@@ -1353,7 +1257,8 @@ static ncclResult_t rasLinkConnAddExternal(struct rasLink* link, struct rasConne
   if (oldLinkConn) {
     if (oldLinkConn->peerIdx != -1 && oldLinkConn->peerIdx != peerIdx) {
       // Should never happen.
-      INFO(NCCL_RAS, "RAS link %d: rasLinkConnAddExternald peerIdx %d mismatch with connection with %s "
+      INFO(NCCL_RAS,
+           "RAS link %d: rasLinkConnAddExternald peerIdx %d mismatch with connection with %s "
            "(oldLinkConn->peerIdx %d) -- internal error?",
            link->direction, peerIdx, ncclSocketToString(&oldLinkConn->conn->addr, rasLine), oldLinkConn->peerIdx);
       ret = ncclInternalError;
@@ -1362,7 +1267,7 @@ static ncclResult_t rasLinkConnAddExternal(struct rasLink* link, struct rasConne
 
     if (oldLinkConn->peerIdx == peerIdx)
       goto exit; // Nothing more to do if both conn and peerIdx are up to date.  Note that we neither check nor
-                 // update the value of external here.
+    // update the value of external here.
 
     // Otherwise (oldLinkConn->peerIdx == -1 && peerIdx != -1) oldLinkConn, due to its -1 peerIdx, is in
     // a wrong place in the array -- we need to find the right spot.  oldLinkConn->peerIdx == -1 can only happen for
@@ -1380,16 +1285,16 @@ static ncclResult_t rasLinkConnAddExternal(struct rasLink* link, struct rasConne
       // The exact linkConn element already exists.
       if (linkConn->conn && linkConn->conn != conn) {
         // Should never happen.
-        char line[SOCKET_NAME_MAXLEN+1];
-        INFO(NCCL_RAS, "RAS link %d: rasLinkConnAddExternal connection mismatch: linkConn %s, conn %s "
+        char line[SOCKET_NAME_MAXLEN + 1];
+        INFO(NCCL_RAS,
+             "RAS link %d: rasLinkConnAddExternal connection mismatch: linkConn %s, conn %s "
              "(peerIdx %d) -- internal error?",
              link->direction, ncclSocketToString(&linkConn->conn->addr, line), ncclSocketToString(&conn->addr, rasLine),
              peerIdx);
         ret = ncclInternalError;
         goto exit;
       }
-      if (linkConn->conn == nullptr)
-        linkConn->conn = conn;
+      if (linkConn->conn == nullptr) linkConn->conn = conn;
       if (linkConn == link->conns) {
         // We received a connection from the remote peer that matches the primary connection we've been
         // waiting for.  This shouldn't trigger for external connections (rasLinkConnUpdate should be invoked first,
@@ -1401,11 +1306,9 @@ static ncclResult_t rasLinkConnAddExternal(struct rasLink* link, struct rasConne
     } // if (linkConn->peerIdx == peerIdx)
 
     // Ensure that the previous element is valid.
-    if (linkConnPrev == nullptr)
-      continue;
+    if (linkConnPrev == nullptr) continue;
     // linkConns with peerIdx == -1 are stored at the end, so if we reach one of them, we are done.
-    if (linkConn->peerIdx == -1)
-      break;
+    if (linkConn->peerIdx == -1) break;
     // Detect a roll-over and handle it specially.
     if (link->direction * (linkConnPrev->peerIdx - linkConn->peerIdx) > 0) {
       if (link->direction * (peerIdx - linkConnPrev->peerIdx) > 0 ||
@@ -1424,7 +1327,8 @@ static ncclResult_t rasLinkConnAddExternal(struct rasLink* link, struct rasConne
       // We already have the entry, but we need to move it to a new spot (which must be earlier in the list).
       if (i >= oldLinkIdx) {
         // Should never happen.
-        INFO(NCCL_RAS, "RAS link %d: rasLinkConnAddExternal new link index %d later in the list than the old one "
+        INFO(NCCL_RAS,
+             "RAS link %d: rasLinkConnAddExternal new link index %d later in the list than the old one "
              "(oldLinkConn %s, oldLinkIdx %d) -- internal error?",
              link->direction, i, ncclSocketToString(&oldLinkConn->conn->addr, rasLine), oldLinkIdx);
         ret = ncclInternalError;
@@ -1483,8 +1387,8 @@ ncclResult_t rasLinkConnUpdate(struct rasLink* link, struct rasConnection* conn,
     goto exit;
   }
 
-  NCCLCHECK(rasLinkConnAdd(link, conn, peerIdx, /*pretend*/false, /*pLinkIdx*/nullptr, /*pLinkConn*/nullptr,
-                           /*insert*/false));
+  NCCLCHECK(rasLinkConnAdd(link, conn, peerIdx, /*pretend*/ false, /*pLinkIdx*/ nullptr, /*pLinkConn*/ nullptr,
+                           /*insert*/ false));
 exit:
   return ret;
 }
@@ -1498,22 +1402,21 @@ static void rasLinkConnDrop(struct rasLink* link, const struct rasConnection* co
   for (struct rasLinkConn* linkConn = link->conns; linkConn; linkConnPrev = linkConn, linkConn = linkConn->next, i++) {
     if (linkConn->conn == conn && (!external || linkConn->external)) {
       if (linkConnPrev) {
-        INFO(NCCL_RAS, "RAS link %d: dropping %sfallback connection %d with %s",
-             link->direction, (linkConn->external ? "external " : ""), i,
-             ncclSocketToString(&conn->addr, rasLine));
+        INFO(NCCL_RAS, "RAS link %d: dropping %sfallback connection %d with %s", link->direction,
+             (linkConn->external ? "external " : ""), i, ncclSocketToString(&conn->addr, rasLine));
         linkConnPrev->next = linkConn->next;
         free(linkConn);
       } else { // linkConnPrev == nullptr
-        INFO(NCCL_RAS, "RAS link %d: dropping primary connection with %s",
-             link->direction, ncclSocketToString(&conn->addr, rasLine));
+        INFO(NCCL_RAS, "RAS link %d: dropping primary connection with %s", link->direction,
+             ncclSocketToString(&conn->addr, rasLine));
         if (linkConn->next) {
           link->conns = linkConn->next;
           // Ensure that the conn becoming the primary is not marked as external (we don't want to lose it if
           // the remote peer loses interest in it).
           link->conns->external = false;
           if (link->conns->conn)
-            INFO(NCCL_RAS, "RAS link %d: former fallback connection 1 with %s is the new primary",
-                 link->direction, ncclSocketToString(&link->conns->conn->addr, rasLine));
+            INFO(NCCL_RAS, "RAS link %d: former fallback connection 1 with %s is the new primary", link->direction,
+                 ncclSocketToString(&link->conns->conn->addr, rasLine));
           rasLinkSanitizeFallbacks(link);
           free(linkConn);
         } else { // linkConn->next == nullptr
@@ -1535,13 +1438,11 @@ static struct rasLinkConn* rasLinkConnFind(const struct rasLink* link, const str
   int i = 0;
   for (struct rasLinkConn* linkConn = link->conns; linkConn; linkConn = linkConn->next, i++) {
     if (linkConn->conn == conn) {
-      if (pLinkIdx)
-        *pLinkIdx = i;
+      if (pLinkIdx) *pLinkIdx = i;
       return linkConn;
     }
   }
-  if (pLinkIdx)
-    *pLinkIdx = -1;
+  if (pLinkIdx) *pLinkIdx = -1;
   return nullptr;
 }
 

--- a/projects/rccl/src/rccl_wrap.cc
+++ b/projects/rccl/src/rccl_wrap.cc
@@ -31,7 +31,6 @@ THE SOFTWARE.
 #include "include/graph.h"
 #include "register.h"
 
-
 // Use this param to experiment pipelining new data types besides bfloat16
 // Make sure you generate the device code with the new data type (i.e. in generate.py)
 RCCL_PARAM(PipelineAllDTypes, "PIPELINE_ALL_DATA_TYPES", 0);
@@ -55,26 +54,21 @@ RCCL_PARAM(WarpSpeedARThreshold, "WARP_SPEED_AR_THRESHOLD", 67108864);  // 64 MB
 #endif
 
 static inline bool rcclCollSupportsRing(ncclFunc_t func) {
-  return (func == ncclFuncAllReduce ||
-          func == ncclFuncAllGather ||
-          func == ncclFuncReduceScatter ||
-          func == ncclFuncBroadcast ||
-          func == ncclFuncReduce);
+  return (func == ncclFuncAllReduce || func == ncclFuncAllGather || func == ncclFuncReduceScatter ||
+          func == ncclFuncBroadcast || func == ncclFuncReduce);
 }
 
-int32_t rcclGetProtoForGfx12(ncclFunc_t collectiveFunc, size_t sizePerRank){
+int32_t rcclGetProtoForGfx12(ncclFunc_t collectiveFunc, size_t sizePerRank) {
   int returnVal = NCCL_PROTO_SIMPLE;
-  int SingleNodeLLCutoffs[] = {
-    /*ncclFuncBroadcast*/     1536,
-    /*ncclFuncReduce*/        8192,
-    /*ncclFuncAllGather*/     98304,
-    /*ncclFuncReduceScatter*/ 98304,
-    /*ncclFuncAllReduce*/     913532,
-    /*ncclFuncSendRecv*/      0,
-    /*ncclFuncSend*/          0,
-    /*ncclFuncRecv*/          0
-  };
-  if(collectiveFunc < sizeof(SingleNodeLLCutoffs)/sizeof(int)) {
+  int SingleNodeLLCutoffs[] = {/*ncclFuncBroadcast*/ 1536,
+                               /*ncclFuncReduce*/ 8192,
+                               /*ncclFuncAllGather*/ 98304,
+                               /*ncclFuncReduceScatter*/ 98304,
+                               /*ncclFuncAllReduce*/ 913532,
+                               /*ncclFuncSendRecv*/ 0,
+                               /*ncclFuncSend*/ 0,
+                               /*ncclFuncRecv*/ 0};
+  if (collectiveFunc < sizeof(SingleNodeLLCutoffs) / sizeof(int)) {
     returnVal = (sizePerRank <= SingleNodeLLCutoffs[collectiveFunc]) ? NCCL_PROTO_LL : NCCL_PROTO_SIMPLE;
   }
   return returnVal;
@@ -85,31 +79,36 @@ void rcclUpdateCollectiveProtocol(struct ncclComm* comm, size_t const& nBytes, s
   static int userProtocolInput = -2;
   size_t sizePerRank = rcclGetSizePerRank(info->func, nBytes, comm->nRanks);
   if (userProtocolInput == -2) {
-    const char *protoStr = getenv("NCCL_PROTO");
+    const char* protoStr = getenv("NCCL_PROTO");
     userProtocolInput = !protoStr ? 0 : 1;
   }
 
-  if (!userProtocolInput && IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950") && comm->nNodes == 1 && (info->func == ncclFuncAllGather) && sizePerRank <= 88448) {
+  if (!userProtocolInput && IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950") && comm->nNodes == 1 &&
+      (info->func == ncclFuncAllGather) && sizePerRank <= 88448) {
     // Change LL protocol threshold
     info->protocol = NCCL_PROTO_LL;
-  } else if (!userProtocolInput && IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950") && comm->nNodes == 1 && (info->func == ncclFuncReduceScatter) && sizePerRank <= 131072) {
+  } else if (!userProtocolInput && IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950") &&
+             comm->nNodes == 1 && (info->func == ncclFuncReduceScatter) && sizePerRank <= 131072) {
     // Change LL protocol threshold
     info->protocol = NCCL_PROTO_LL;
-  } else if (!userProtocolInput && IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942") && comm->nNodes == 1 && (info->func == ncclFuncReduceScatter) && sizePerRank <= 352128) {
+  } else if (!userProtocolInput && IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942") &&
+             comm->nNodes == 1 && (info->func == ncclFuncReduceScatter) && sizePerRank <= 352128) {
     // Change LL protocol threshold
     info->protocol = NCCL_PROTO_LL;
-  } else if (!userProtocolInput && IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx12")){
-    if ( comm->nNodes == 1 ) {
-      info->protocol = rcclGetProtoForGfx12( info->func,sizePerRank);
+  } else if (!userProtocolInput && IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx12")) {
+    if (comm->nNodes == 1) {
+      info->protocol = rcclGetProtoForGfx12(info->func, sizePerRank);
     }
     const char* str = ncclGetEnv("NCCL_P2P_DISABLE");
-    if (str) { 
+    if (str) {
       int disable = strtol(str, NULL, 0);
       if (disable == 1) {
         info->protocol = NCCL_PROTO_SIMPLE;
-      } 
-    }  
-  } else if(!userProtocolInput && comm->nNodes >= 2 && (info->func == ncclFuncReduceScatter || info->func == ncclFuncAllGather || info->func == ncclFuncAllReduce || info->func == ncclFuncBroadcast || info->func == ncclFuncReduce)) {
+      }
+    }
+  } else if (!userProtocolInput && comm->nNodes >= 2 &&
+             (info->func == ncclFuncReduceScatter || info->func == ncclFuncAllGather ||
+              info->func == ncclFuncAllReduce || info->func == ncclFuncBroadcast || info->func == ncclFuncReduce)) {
     auto tunableIndex = rcclGetTunableIndex(info->func);
     auto llMin = comm->minMaxLLRange[tunableIndex][NCCL_PROTO_LL][RCCL_PROTOCOL_MIN_IDX];
     auto llMax = comm->minMaxLLRange[tunableIndex][NCCL_PROTO_LL][RCCL_PROTOCOL_MAX_IDX];
@@ -128,7 +127,7 @@ void rcclUpdateCollectiveProtocol(struct ncclComm* comm, size_t const& nBytes, s
       // When LL128 is performant, the next condition overrides the previous LL choice
       if (comm->topo->ll128Enabled) {
         if (info->func == ncclFuncAllReduce) {
-          if(comm->nNodes > 2) {
+          if (comm->nNodes > 2) {
             ll128Max *= 3.8; // Scale max message size for n > 2 since Tree has special behavior at 2 nodes
           }
           // ll128Max += (log2i(comm->nNodes) - 1) * comm->minMaxLLRange[tunableIndex][NCCL_PROTO_LL128][RCCL_PROTOCOL_FACTOR_IDX];
@@ -152,8 +151,8 @@ void rcclUpdateCollectiveProtocol(struct ncclComm* comm, size_t const& nBytes, s
   }
 }
 
-ncclResult_t rcclGetAlgoProtoIndex(const char *envStr, const char* algoProtoString[], int nEntries, int& result) {
-  if(envStr) {
+ncclResult_t rcclGetAlgoProtoIndex(const char* envStr, const char* algoProtoString[], int nEntries, int& result) {
+  if (envStr) {
     for (int i = 0; i < nEntries; ++i) {
       if (strcasecmp(envStr, algoProtoString[i]) == 0) {
         result = i;
@@ -175,7 +174,7 @@ extern int64_t ncclParamMaxNchannels();
 RCCL_PARAM(ChannelTuningEnable, "CHANNEL_TUNING_ENABLE", 1);
 
 ncclResult_t rcclOverrideChannels(struct ncclComm* comm, ncclFunc_t coll, size_t nBytes, int& nc) {
-  if(comm->nNodes < 2 || !rcclParamChannelTuningEnable()) {
+  if (comm->nNodes < 2 || !rcclParamChannelTuningEnable()) {
     INFO(NCCL_TUNING, "RCCL Channel Tuning not applied");
     return ncclSuccess;
   }
@@ -186,7 +185,7 @@ ncclResult_t rcclOverrideChannels(struct ncclComm* comm, ncclFunc_t coll, size_t
   }
 
   auto tunableIndex = rcclGetTunableIndex(coll);
-  if(tunableIndex == RCCL_UNSUPPORTED_TUNABLE){
+  if (tunableIndex == RCCL_UNSUPPORTED_TUNABLE) {
     INFO(NCCL_TUNING, "tunableIndex:%i not supported", tunableIndex);
     return ncclSuccess;
   }
@@ -195,7 +194,7 @@ ncclResult_t rcclOverrideChannels(struct ncclComm* comm, ncclFunc_t coll, size_t
   int maxCTAs = comm->config.maxCTAs;
   int scalingFactor = 1;
 #ifdef ENABLE_WARP_SPEED
-  if(comm->topo->warpSpeedEnabled) {
+  if (comm->topo->warpSpeedEnabled) {
     scalingFactor = comm->warpSpeedChannelMultiplier; // each CU can handle 4 warps
   }
 #endif
@@ -203,35 +202,44 @@ ncclResult_t rcclOverrideChannels(struct ncclComm* comm, ncclFunc_t coll, size_t
   int maxNChannels = std::max(comm->nChannels / scalingFactor, static_cast<int>(ncclParamMaxNchannels()));
   size_t bytesPerRank = divUp(nBytes, comm->nRanks);
 
-  for(int channelCountIndex = 0; channelCountIndex < RCCL_CHANNELS_TUNABLE_ENTRIES; ++channelCountIndex){
+  for (int channelCountIndex = 0; channelCountIndex < RCCL_CHANNELS_TUNABLE_ENTRIES; ++channelCountIndex) {
     size_t minByteThreshold = comm->minMaxChannelThresholds[tunableIndex][channelCountIndex][0];
     size_t maxByteThreshold = comm->minMaxChannelThresholds[tunableIndex][channelCountIndex][1];
-    INFO(NCCL_TUNING, "nBytes:%lu bytesPerRank:%lu minByteThreshold:%lu maxByteThreshold:%lu  NCCL_MIN_NCHANNELS:%i or NCCL_MAX_NCHANNELS:%i minCTAs:%i maxCTAs:%i", nBytes, bytesPerRank, minByteThreshold, maxByteThreshold, minNChannels, maxNChannels, minCTAs, maxCTAs);
-    if(minByteThreshold == CHAN_THRESHOLDS_UNDEFINED || maxByteThreshold == CHAN_THRESHOLDS_UNDEFINED) {
+    INFO(NCCL_TUNING,
+         "nBytes:%lu bytesPerRank:%lu minByteThreshold:%lu maxByteThreshold:%lu  NCCL_MIN_NCHANNELS:%i or "
+         "NCCL_MAX_NCHANNELS:%i minCTAs:%i maxCTAs:%i",
+         nBytes, bytesPerRank, minByteThreshold, maxByteThreshold, minNChannels, maxNChannels, minCTAs, maxCTAs);
+    if (minByteThreshold == CHAN_THRESHOLDS_UNDEFINED || maxByteThreshold == CHAN_THRESHOLDS_UNDEFINED) {
       INFO(NCCL_TUNING, "RCCL tuning model does not define threshold for coll:%i and nbytes:%lu", coll, nBytes);
       break; // Skip undefined thresholds
     }
 
-    if(bytesPerRank > minByteThreshold && bytesPerRank <= maxByteThreshold){
+    if (bytesPerRank > minByteThreshold && bytesPerRank <= maxByteThreshold) {
       int channelCount = comm->minMaxChannelThresholds[tunableIndex][channelCountIndex][2];
 
-      //honor user's min/max channels defined through NCCL_MIN_NCHANNELS and NCCL_MAX_NCHANNELS
-      if(channelCount >= minNChannels && channelCount <= maxNChannels && channelCount >= minCTAs && channelCount <= maxCTAs){
+      // honor user's min/max channels defined through NCCL_MIN_NCHANNELS and NCCL_MAX_NCHANNELS
+      if (channelCount >= minNChannels && channelCount <= maxNChannels && channelCount >= minCTAs &&
+          channelCount <= maxCTAs) {
         nc = comm->minMaxChannelThresholds[tunableIndex][channelCountIndex][2];
-        INFO(NCCL_TUNING, "RCCL tuning model overrides nchannels to %i, channels may be decreased further due to MinTrafficPerchannel thresholds", channelCount);
-      }
-      else{
-        INFO(NCCL_TUNING, "RCCL tuning model cannot override nchannels to %i due to conflicting NCCL_MIN_NCHANNELS:%i or NCCL_MAX_NCHANNELS:%i minCTAs:%i maxCTAs:%i", channelCount, minNChannels, maxNChannels, minCTAs, maxCTAs);
+        INFO(NCCL_TUNING,
+             "RCCL tuning model overrides nchannels to %i, channels may be decreased further due to "
+             "MinTrafficPerchannel thresholds",
+             channelCount);
+      } else {
+        INFO(NCCL_TUNING,
+             "RCCL tuning model cannot override nchannels to %i due to conflicting NCCL_MIN_NCHANNELS:%i or "
+             "NCCL_MAX_NCHANNELS:%i minCTAs:%i maxCTAs:%i",
+             channelCount, minNChannels, maxNChannels, minCTAs, maxCTAs);
       }
 
       break;
     }
-
   }
   return ncclSuccess;
 }
 
-ncclResult_t rcclOverrideProtocol(const char* ncclProtoStr[], float table[][NCCL_NUM_PROTOCOLS], struct ncclTaskColl* info) {
+ncclResult_t rcclOverrideProtocol(const char* ncclProtoStr[], float table[][NCCL_NUM_PROTOCOLS],
+                                  struct ncclTaskColl* info) {
   static const char* protoOverrideEnv = ncclGetEnv("RCCL_OVERRIDE_PROTO");
   static bool validInput = true;
   if (!validInput) return ncclInvalidUsage;
@@ -246,7 +254,8 @@ ncclResult_t rcclOverrideProtocol(const char* ncclProtoStr[], float table[][NCCL
     }
     if (protoVal > NCCL_PROTO_UNDEF) {
       if (table[info->algorithm][protoVal] == NCCL_ALGO_PROTO_IGNORE) {
-        WARN("Failed to force unsupported protocol %s for function %s with datatype %s", protoOverrideEnv, ncclFuncToString(info->func), ncclDatatypeToString(info->datatype));
+        WARN("Failed to force unsupported protocol %s for function %s with datatype %s", protoOverrideEnv,
+             ncclFuncToString(info->func), ncclDatatypeToString(info->datatype));
         return ncclInternalError;
       } else {
         info->protocol = protoVal;
@@ -256,7 +265,8 @@ ncclResult_t rcclOverrideProtocol(const char* ncclProtoStr[], float table[][NCCL
   return ncclSuccess;
 }
 
-ncclResult_t rcclOverrideAlgorithm(const char* ncclAlgoStr[], float table[][NCCL_NUM_PROTOCOLS], struct ncclTaskColl* info) {
+ncclResult_t rcclOverrideAlgorithm(const char* ncclAlgoStr[], float table[][NCCL_NUM_PROTOCOLS],
+                                   struct ncclTaskColl* info) {
   static const char* algoOverrideEnv = ncclGetEnv("RCCL_OVERRIDE_ALGO");
   static bool validInput = true;
   if (!validInput) return ncclInvalidUsage;
@@ -271,7 +281,8 @@ ncclResult_t rcclOverrideAlgorithm(const char* ncclAlgoStr[], float table[][NCCL
     }
     if (algoVal > NCCL_ALGO_UNDEF) {
       if (table[algoVal][info->protocol] == NCCL_ALGO_PROTO_IGNORE) {
-        WARN("Failed to force unsupported algorithm %s for function %s with datatype %s", algoOverrideEnv, ncclFuncToString(info->func), ncclDatatypeToString(info->datatype));
+        WARN("Failed to force unsupported algorithm %s for function %s with datatype %s", algoOverrideEnv,
+             ncclFuncToString(info->func), ncclDatatypeToString(info->datatype));
         return ncclInternalError;
       } else {
         info->algorithm = algoVal;
@@ -281,11 +292,12 @@ ncclResult_t rcclOverrideAlgorithm(const char* ncclAlgoStr[], float table[][NCCL
   return ncclSuccess;
 }
 
-void rcclUpdateThreadThreshold(struct ncclComm* comm, size_t const& nBytes, struct ncclTaskColl* info, int& threadThreshold) {
+void rcclUpdateThreadThreshold(struct ncclComm* comm, size_t const& nBytes, struct ncclTaskColl* info,
+                               int& threadThreshold) {
   // Honor user input for thread thresholds
   static int userChannelControlInput = -2;
   if (userChannelControlInput == -2) {
-    const char *inputStr = getenv("NCCL_THREAD_THRESHOLDS");
+    const char* inputStr = getenv("NCCL_THREAD_THRESHOLDS");
     if (!inputStr) {
       inputStr = getenv("NCCL_MAX_NCHANNELS");
     }
@@ -295,10 +307,11 @@ void rcclUpdateThreadThreshold(struct ncclComm* comm, size_t const& nBytes, stru
     userChannelControlInput = !inputStr ? 0 : 1;
   }
 
-  if(!userChannelControlInput && comm->nNodes >= 2 && (info->func == ncclFuncReduceScatter || info->func == ncclFuncAllGather)) {
+  if (!userChannelControlInput && comm->nNodes >= 2 &&
+      (info->func == ncclFuncReduceScatter || info->func == ncclFuncAllGather)) {
     auto tunableIndex = rcclGetTunableIndex(info->func);
     auto tunedThreshold = comm->minMaxLLRange[tunableIndex][info->protocol][RCCL_PROTOCOL_THREAD_THRESHOLD_IDX];
-    if(tunedThreshold != RCCL_LL_LIMITS_UNDEFINED) {
+    if (tunedThreshold != RCCL_LL_LIMITS_UNDEFINED) {
       threadThreshold = tunedThreshold * comm->nRanks;
     }
   }
@@ -313,37 +326,34 @@ void rcclSetPipelining(struct ncclComm* comm, size_t const& nBytes, struct ncclT
 
   if (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942") && dtypeOK) {
     switch (info->func) {
-      // For multi-node case, we check if the number of bytes (`nBytes`) satisfies
-      // the Bf16 Limit Equation for bf16 all_reduce on MI300:
-      // 512MB × 2^(log2[nNodes] - 1), nNodes > 1
-      // The above equation is derived from the tuning results of the bf16 all_reduce on MI300.
-      case ncclFuncAllReduce:
-        if ( comm->nNodes == 1 ||
-             ((comm->nNodes > 1) &&
-               nBytes <= (1ULL << 29 /*512MB*/) * (1ULL << (log2i(comm->nNodes) - 1))) ) {
-          info->pipeline = 1;
-        }
-        break;
-
-      case ncclFuncReduceScatter:
-      case ncclFuncReduce:
+    // For multi-node case, we check if the number of bytes (`nBytes`) satisfies
+    // the Bf16 Limit Equation for bf16 all_reduce on MI300:
+    // 512MB × 2^(log2[nNodes] - 1), nNodes > 1
+    // The above equation is derived from the tuning results of the bf16 all_reduce on MI300.
+    case ncclFuncAllReduce:
+      if (comm->nNodes == 1 ||
+          ((comm->nNodes > 1) && nBytes <= (1ULL << 29 /*512MB*/) * (1ULL << (log2i(comm->nNodes) - 1)))) {
         info->pipeline = 1;
-        break;
+      }
+      break;
 
-      default:
-        break;
+    case ncclFuncReduceScatter:
+    case ncclFuncReduce:
+      info->pipeline = 1;
+      break;
+
+    default:
+      break;
     }
   }
 }
 
-extern ncclResult_t getAlgoInfo(
-    struct ncclComm* comm, struct ncclTaskColl* task,
-    int collNetSupport, int nvlsSupport, int numPipeOps, ncclSimInfo_t* simInfo = NULL
-);
+extern ncclResult_t getAlgoInfo(struct ncclComm* comm, struct ncclTaskColl* task, int collNetSupport, int nvlsSupport,
+                                int numPipeOps, ncclSimInfo_t* simInfo = NULL);
 
 ncclResult_t rcclGetAlgoInfo(struct ncclComm* comm, ncclFunc_t coll, uint64_t count, ncclDataType_t dataType,
-                             int collNetSupport, int nvlsSupport, int numPipeOps,
-                             int* algo, int* protocol, int* maxChannels) {
+                             int collNetSupport, int nvlsSupport, int numPipeOps, int* algo, int* protocol,
+                             int* maxChannels) {
   RCCL_STATIC_EXPOSE_CHECK();
   int nRanks;
   NCCLCHECK(ncclCommCount(comm, &nRanks));
@@ -387,8 +397,8 @@ ncclResult_t rcclGetAlgoInfo(struct ncclComm* comm, ncclFunc_t coll, uint64_t co
     // For hierarchical algorithm, only the inter-comm protocol/channels are
     // reported in rccl-tests -A output.
     // The intra-comm values are logged below for debugging purposes
-    INFO(NCCL_COLL, "Hierarchical AG inter: proto=%d channels=%d, intra: proto=%d channels=%d",
-        *protocol, *maxChannels, intraProto, intraChan);
+    INFO(NCCL_COLL, "Hierarchical AG inter: proto=%d channels=%d, intra: proto=%d channels=%d", *protocol, *maxChannels,
+         intraProto, intraChan);
     return ncclSuccess;
   }
   if (coll == ncclFuncAllGather && rcclUseAllGatherDirect(comm, msgSize)) {
@@ -404,8 +414,8 @@ ncclResult_t rcclGetAlgoInfo(struct ncclComm* comm, ncclFunc_t coll, uint64_t co
   NCCLCHECK(getAlgoInfo(comm, &task, collNetSupport, nvlsSupport, numPipeOps));
   *protocol = task.protocol;
 #ifdef ENABLE_WARP_SPEED
-  *maxChannels = task.useWarpSpeed? task.nMaxChannels / task.nWarps : task.nMaxChannels;
-  *algo = task.useWarpSpeed? rcclAddonAlgos_t::RCCL_WARP_SPEED : task.algorithm;
+  *maxChannels = task.useWarpSpeed ? task.nMaxChannels / task.nWarps : task.nMaxChannels;
+  *algo = task.useWarpSpeed ? rcclAddonAlgos_t::RCCL_WARP_SPEED : task.algorithm;
 #else
   *maxChannels = task.nMaxChannels;
   *algo = task.algorithm;
@@ -415,17 +425,22 @@ ncclResult_t rcclGetAlgoInfo(struct ncclComm* comm, ncclFunc_t coll, uint64_t co
 
 static int symkHostRedOpToDev(ncclRedOp_t op) {
   switch ((int)op) {
-  case ncclSum:  return (int)ncclDevSum;
-  case ncclProd: return (int)ncclDevProd;
+  case ncclSum:
+    return (int)ncclDevSum;
+  case ncclProd:
+    return (int)ncclDevProd;
   case ncclMin:
-  case ncclMax:  return (int)ncclDevMinMax;
-  case ncclAvg:  return (int)ncclDevSumPostDiv;
-  default:       return -1;
+  case ncclMax:
+    return (int)ncclDevMinMax;
+  case ncclAvg:
+    return (int)ncclDevSumPostDiv;
+  default:
+    return -1;
   }
 }
 
-ncclResult_t rcclSymKGetInfo(struct ncclComm* comm, ncclFunc_t coll, uint64_t count, ncclDataType_t dataType, ncclRedOp_t op,
-    int* algo, int* protocol, int* maxChannels) {
+ncclResult_t rcclSymKGetInfo(struct ncclComm* comm, ncclFunc_t coll, uint64_t count, ncclDataType_t dataType,
+                             ncclRedOp_t op, int* algo, int* protocol, int* maxChannels) {
   RCCL_STATIC_EXPOSE_CHECK();
   if (algo == nullptr || protocol == nullptr || maxChannels == nullptr) return ncclInvalidArgument;
   if (coll != ncclFuncAllReduce && coll != ncclFuncAllGather && coll != ncclFuncReduceScatter)
@@ -438,7 +453,8 @@ ncclResult_t rcclSymKGetInfo(struct ncclComm* comm, ncclFunc_t coll, uint64_t co
   ncclSymkKernelId kernelId;
   int nWarps;
   bool forced = false;
-  NCCLCHECK(ncclSymkPickKernel(comm, coll, devOp, dataType, (size_t)count, (size_t)count, 1, (ncclSymRegType_t)0, &estTimeUs, &kernelId, maxChannels, &nWarps, &forced));
+  NCCLCHECK(ncclSymkPickKernel(comm, coll, devOp, dataType, (size_t)count, (size_t)count, 1, (ncclSymRegType_t)0,
+                               &estTimeUs, &kernelId, maxChannels, &nWarps, &forced));
   if (kernelId == ncclSymkKernelId_Count) return ncclInvalidArgument;
   *algo = (int)rcclAddonAlgos_t::RCCL_SYMMETRIC;
   *protocol = rcclSymkKernelIdIsLL((int)kernelId) ? NCCL_PROTO_LL : NCCL_PROTO_SIMPLE;
@@ -451,25 +467,25 @@ ncclResult_t rcclGetAlgoName(int algo, const char** algoName) {
     WARN("Invalid algorithm value: %d", algo);
     return ncclInvalidArgument;
   }
-  if(algo >= NCCL_NUM_ALGORITHMS) {
-    switch(algo) {
-      case rcclAddonAlgos_t::RCCL_DIRECT_ALLGATHER:
-        *algoName = "Direct";
-        break;
-      case rcclAddonAlgos_t::RCCL_HIERARCHICAL_ALLGATHER:
-        *algoName = "Hier";
-        break;
+  if (algo >= NCCL_NUM_ALGORITHMS) {
+    switch (algo) {
+    case rcclAddonAlgos_t::RCCL_DIRECT_ALLGATHER:
+      *algoName = "Direct";
+      break;
+    case rcclAddonAlgos_t::RCCL_HIERARCHICAL_ALLGATHER:
+      *algoName = "Hier";
+      break;
 #ifdef ENABLE_WARP_SPEED
-      case rcclAddonAlgos_t::RCCL_WARP_SPEED:
-        *algoName = "RING*"; // WarpSpeed (*) uses RING algorithm
-        break;
+    case rcclAddonAlgos_t::RCCL_WARP_SPEED:
+      *algoName = "RING*"; // WarpSpeed (*) uses RING algorithm
+      break;
 #endif
-      case rcclAddonAlgos_t::RCCL_SYMMETRIC:
-        *algoName = "SYM";
-        break;
-      default:
-        WARN("Invalid algorithm value: %d", algo);
-        return ncclInvalidArgument;
+    case rcclAddonAlgos_t::RCCL_SYMMETRIC:
+      *algoName = "SYM";
+      break;
+    default:
+      WARN("Invalid algorithm value: %d", algo);
+      return ncclInvalidArgument;
     }
     return ncclSuccess;
   }
@@ -487,11 +503,11 @@ ncclResult_t rcclGetProtocolName(int protocol, const char** protocolName) {
 }
 
 bool rcclUseAlltoAllGda(struct ncclComm* comm) {
-
 #ifdef ENABLE_ROCSHMEM
-  if (comm->enableRocshmem && comm->nNodes > 1 && (comm->nRanks/comm->nNodes == 8) && comm->rocshmemThreshold <= 1048576) {
-      INFO(NCCL_INIT, "Enabling GDA alltoall for RCCL");
-      return true;
+  if (comm->enableRocshmem && comm->nNodes > 1 && (comm->nRanks / comm->nNodes == 8) &&
+      comm->rocshmemThreshold <= 1048576) {
+    INFO(NCCL_INIT, "Enabling GDA alltoall for RCCL");
+    return true;
   }
 #endif
   return false;
@@ -535,7 +551,7 @@ bool rcclUseAllGatherDirect(struct ncclComm* comm, size_t& msgSize) {
   // Check if user explicitly set threshold
   static int userThresholdInput = -2;
   if (userThresholdInput == -2) {
-    const char *thresholdStr = getenv("RCCL_DIRECT_ALLGATHER_THRESHOLD");
+    const char* thresholdStr = getenv("RCCL_DIRECT_ALLGATHER_THRESHOLD");
     userThresholdInput = !thresholdStr ? 0 : 1;
   }
 
@@ -544,8 +560,8 @@ bool rcclUseAllGatherDirect(struct ncclComm* comm, size_t& msgSize) {
   // Disable Direct AllGather for all architectures when CE-based AllGather is active.
   // CTAPolicy ZERO indicates CE dispatch is enabled; Direct AllGather conflicts with it on
   // single-node topologies regardless of GPU architecture.
-  if (!userThresholdInput && comm->nNodes == 1 &&
-      comm->symmetricSupport && comm->config.CTAPolicy == NCCL_CTA_POLICY_ZERO) {
+  if (!userThresholdInput && comm->nNodes == 1 && comm->symmetricSupport &&
+      comm->config.CTAPolicy == NCCL_CTA_POLICY_ZERO) {
     INFO(NCCL_INIT, "RCCL Direct AllGather disabled: CTA policy ZERO, using CE-based AllGather.");
     return false;
   }
@@ -561,13 +577,13 @@ bool rcclUseAllGatherDirect(struct ncclComm* comm, size_t& msgSize) {
     threshold = 4194304;
   }
 
-  comm->enableCustColl = IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950") || IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942");
+  comm->enableCustColl = IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950") ||
+                         IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942");
 
   int rankMultiple = comm->nRanks % 8;
 
-  //return (comm->enableCustColl && (comm->nNodes > 1) && (msgSize <= threshold) && (threshold != -1))
-  return (comm->enableCustColl && (msgSize <= threshold) && (threshold != -1) && !rankMultiple)
-    ;
+  // return (comm->enableCustColl && (comm->nNodes > 1) && (msgSize <= threshold) && (threshold != -1))
+  return (comm->enableCustColl && (msgSize <= threshold) && (threshold != -1) && !rankMultiple);
 }
 
 bool rcclUseReduceScatterDirect(struct ncclComm* comm, size_t& msgSize) {
@@ -577,7 +593,7 @@ bool rcclUseReduceScatterDirect(struct ncclComm* comm, size_t& msgSize) {
   // - 4 nodes: enable up to 4MiB
   // - 8 and 16 nodes: enable up to 8MiB
   static int userDirectReduceScatterInput = rcclParamDirectReduceScatterDisable();
-  if (userDirectReduceScatterInput !=0) {
+  if (userDirectReduceScatterInput != 0) {
     INFO(NCCL_INIT, "RCCL DIRECT REDUCE-SCATTER has been disabled by environment variable.");
     return false;
   }
@@ -585,13 +601,13 @@ bool rcclUseReduceScatterDirect(struct ncclComm* comm, size_t& msgSize) {
   if (!archGfx950) return false;
 
   // Check if PXN is disabled - Direct Reduce Scatter requires PXN to be enabled
-  if(ncclPxnDisable(comm) != 0) {
+  if (ncclPxnDisable(comm) != 0) {
     INFO(NCCL_INIT, "RCCL DIRECT REDUCE-SCATTER disabled due to PXN being disabled.");
     return false;
   }
 
   size_t threshold = rcclParamDirectReduceScatterThreshold();
-  if (threshold > -1) { 
+  if (threshold > -1) {
     // Set threshold to 8MiB hard limit
     // NOTE: If the DirectReduceScatterThreshold / hard-limit is increased, ensure TEMP_BUFF_SIZE (init.cc)
     // is increased accordingly -> TEMP_BUFF_SIZE >= 2 * (max enabled msgSize) for headroom.
@@ -610,51 +626,49 @@ bool rcclUseReduceScatterDirect(struct ncclComm* comm, size_t& msgSize) {
   return false;
 }
 
-
-void rcclSetPxn(struct ncclComm* comm,  int& rcclPxnDisable) {
+void rcclSetPxn(struct ncclComm* comm, int& rcclPxnDisable) {
   if (comm->pxnDisable != RCCL_VALUE_UNSET) {
     rcclPxnDisable = comm->pxnDisable;
     return;
   }
-  const char *inputStr = getenv("NCCL_PXN_DISABLE");
+  const char* inputStr = getenv("NCCL_PXN_DISABLE");
   const bool archGfx942 = IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942");
   const bool archGfx950 = IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950");
   comm->enableCustColl = (archGfx942 || archGfx950) && (inputStr && !atoi(inputStr));
 
-  if((!archGfx942 && !archGfx950) || inputStr) {
+  if ((!archGfx942 && !archGfx950) || inputStr) {
     rcclPxnDisable = comm->pxnDisable = RCCL_VALUE_INVALID;
     return;
   }
-  const int ranksThreshold = (archGfx942)? 64 : 32;
-  int pxnDisable = (comm->nRanks >= ranksThreshold)? 0 : 1;
-  INFO(NCCL_INIT, "RCCL PXN set as %s (nRanks=%d threshold=%d)",
-       !pxnDisable ? "enabled" : "disabled", comm->nRanks, ranksThreshold);
+  const int ranksThreshold = (archGfx942) ? 64 : 32;
+  int pxnDisable = (comm->nRanks >= ranksThreshold) ? 0 : 1;
+  INFO(NCCL_INIT, "RCCL PXN set as %s (nRanks=%d threshold=%d)", !pxnDisable ? "enabled" : "disabled", comm->nRanks,
+       ranksThreshold);
   comm->enableCustColl = !pxnDisable;
   rcclPxnDisable = comm->pxnDisable = pxnDisable;
 }
 
-void rcclSetP2pNetChunkSize(struct ncclComm* comm,  int& rcclP2pNetChunkSize) {
+void rcclSetP2pNetChunkSize(struct ncclComm* comm, int& rcclP2pNetChunkSize) {
   if (comm->p2pNetChunkSize != RCCL_VALUE_UNSET) {
     rcclP2pNetChunkSize = comm->p2pNetChunkSize;
     return;
   }
-  const char *inputStr = getenv("NCCL_P2P_NET_CHUNKSIZE");
+  const char* inputStr = getenv("NCCL_P2P_NET_CHUNKSIZE");
   const bool archGfx942 = IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942");
   const bool archGfx950 = IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950");
-  if((!archGfx942 && !archGfx950) || inputStr) {
+  if ((!archGfx942 && !archGfx950) || inputStr) {
     rcclP2pNetChunkSize = comm->p2pNetChunkSize = RCCL_VALUE_INVALID;
     return;
   }
 
   int p2pNetChunkSize = RCCL_VALUE_UNSET;
-  if(archGfx942)
-    p2pNetChunkSize = (comm->nRanks >= 64)? (1 << 19) : (1 << 17);
-  else if(archGfx950)
+  if (archGfx942) p2pNetChunkSize = (comm->nRanks >= 64) ? (1 << 19) : (1 << 17);
+  else if (archGfx950)
     p2pNetChunkSize = (comm->nRanks >= 32) ? (1 << 19) : (comm->nRanks >= 16 ? (1 << 18) : (1 << 17));
   else
-    WARN("RCCL P2P attempt to set P2P net chunk size for unsupported arch: %s", comm->topo->nodes[GPU].nodes[0].gpu.gcn);
-  INFO(NCCL_INIT, "RCCL P2P net chunk size default set to: %d (nRanks=%d)",
-       p2pNetChunkSize, comm->nRanks);
+    WARN("RCCL P2P attempt to set P2P net chunk size for unsupported arch: %s",
+         comm->topo->nodes[GPU].nodes[0].gpu.gcn);
+  INFO(NCCL_INIT, "RCCL P2P net chunk size default set to: %d (nRanks=%d)", p2pNetChunkSize, comm->nRanks);
   comm->p2pNetChunkSize = p2pNetChunkSize;
   rcclP2pNetChunkSize = p2pNetChunkSize;
 }
@@ -663,11 +677,11 @@ void rcclSetWarpSpeedCUs(struct ncclComm* comm, int algo, int threadsPerBlock, i
   static int userChannelControlInput = RCCL_VALUE_UNSET;
   int warpsPerBlock = threadsPerBlock / comm->WarpSize;
   // only adjust channels for RING algorithm
-  if(algo != NCCL_ALGO_RING) {
+  if (algo != NCCL_ALGO_RING) {
     return;
   }
   if (userChannelControlInput == RCCL_VALUE_UNSET) {
-    const char *inputStr = getenv("NCCL_THREAD_THRESHOLDS");
+    const char* inputStr = getenv("NCCL_THREAD_THRESHOLDS");
     if (!inputStr) {
       inputStr = getenv("NCCL_MAX_NCHANNELS");
     }
@@ -676,17 +690,19 @@ void rcclSetWarpSpeedCUs(struct ncclComm* comm, int algo, int threadsPerBlock, i
     }
     userChannelControlInput = !inputStr ? 0 : 1;
   }
-  if(comm->topo->warpSpeedEnabled) {
-    if(!userChannelControlInput) {
-      if(rcclParamWarpSpeedCuCount() != 0) {
+  if (comm->topo->warpSpeedEnabled) {
+    if (!userChannelControlInput) {
+      if (rcclParamWarpSpeedCuCount() != 0) {
         rcclWarpSpeedChannels = rcclParamWarpSpeedCuCount() * warpsPerBlock;
-        INFO(NCCL_INIT, "RCCL Warp CU count set to user defined %ld resulting in %d channels", (long)rcclParamWarpSpeedCuCount(), rcclWarpSpeedChannels);
+        INFO(NCCL_INIT, "RCCL Warp CU count set to user defined %ld resulting in %d channels",
+             (long)rcclParamWarpSpeedCuCount(), rcclWarpSpeedChannels);
         return;
       }
     }
     // reuse the existing channel tuning logic if possible
     rcclWarpSpeedChannels = std::min(MAXCHANNELS, rcclWarpSpeedChannels * warpsPerBlock);
-    INFO(NCCL_INIT, "RCCL Warp Speed Channels set to %d. Warps per block is set to %d", rcclWarpSpeedChannels, warpsPerBlock);
+    INFO(NCCL_INIT, "RCCL Warp Speed Channels set to %d. Warps per block is set to %d", rcclWarpSpeedChannels,
+         warpsPerBlock);
   }
 }
 
@@ -711,28 +727,30 @@ bool rcclWarpSpeedSupported(struct ncclComm* comm, struct ncclKernelPlan* plan) 
   return (!hasP2p && !hasNonRing);
 }
 
-bool rcclIsAboveWarpSpeedThreshold (struct ncclComm* comm, struct ncclTaskColl* info, size_t nBytes){
-  //single node, full subscription thresholds for AllGather and ReduceScatter
-  if(info->func == ncclFuncAllReduce && nBytes >= rcclParamWarpSpeedARThreshold()) {
+bool rcclIsAboveWarpSpeedThreshold(struct ncclComm* comm, struct ncclTaskColl* info, size_t nBytes) {
+  // single node, full subscription thresholds for AllGather and ReduceScatter
+  if (info->func == ncclFuncAllReduce && nBytes >= rcclParamWarpSpeedARThreshold()) {
+    return true;
+  } else if (info->func == ncclFuncAllGather && nBytes >= rcclParamWarpSpeedAGThreshold()) {
+    return true;
+  } else if (info->func == ncclFuncReduceScatter && nBytes >= rcclParamWarpSpeedRSThreshold()) {
     return true;
   }
-  else if(info->func == ncclFuncAllGather && nBytes >= rcclParamWarpSpeedAGThreshold()) {
-    return true;
-  }
-  else if(info->func == ncclFuncReduceScatter && nBytes >= rcclParamWarpSpeedRSThreshold()) {
-    return true;
-  }
-  INFO(NCCL_TUNING, "RCCL WarpSpeed not enabled for %s at %zu bytes as it below the warpSpeed threshold", ncclFuncToString(info->func), nBytes);
+  INFO(NCCL_TUNING, "RCCL WarpSpeed not enabled for %s at %zu bytes as it below the warpSpeed threshold",
+       ncclFuncToString(info->func), nBytes);
   return false;
-  }
-
-bool rcclCanUseWarpSpeedAuto(struct ncclComm* comm, int nNodes) {
-  return IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950") && (nNodes == 1) && (rcclParamWarpSpeedAutoMode() != 0);
 }
 
-ncclResult_t validChannelsForWarpSpeed(struct ncclComm* comm, struct ncclTaskColl* info){
-  if(info->useWarpSpeed && comm->nChannels > (MAXCHANNELS)/2){
-    WARN("WarpSpeed does not support more than %d channels. Current number of channels is %d. To avoid hang, run with RCCL_WARP_SPEED_AUTO=0", MAXCHANNELS/2, comm->nChannels);
+bool rcclCanUseWarpSpeedAuto(struct ncclComm* comm, int nNodes) {
+  return IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950") && (nNodes == 1) &&
+         (rcclParamWarpSpeedAutoMode() != 0);
+}
+
+ncclResult_t validChannelsForWarpSpeed(struct ncclComm* comm, struct ncclTaskColl* info) {
+  if (info->useWarpSpeed && comm->nChannels > (MAXCHANNELS) / 2) {
+    WARN("WarpSpeed does not support more than %d channels. Current number of channels is %d. To avoid hang, run with "
+         "RCCL_WARP_SPEED_AUTO=0",
+         MAXCHANNELS / 2, comm->nChannels);
     return ncclInvalidArgument;
   }
   return ncclSuccess;
@@ -741,31 +759,32 @@ ncclResult_t validChannelsForWarpSpeed(struct ncclComm* comm, struct ncclTaskCol
 ncclResult_t rcclSetWarpSpeedAuto(struct ncclComm* comm, struct ncclTaskColl* info, size_t nBytes) {
   info->useWarpSpeed = false;
   static bool unrollFactorSet = getenv("RCCL_UNROLL_FACTOR") != nullptr;
-  if(!comm->topo->warpSpeedEnabled) return ncclSuccess;
-  commSetUnrollFactor(comm);  // TODO: reset unroll factor per task rather than per comm
-  if(!rcclCollSupportsRing(info->func)) return ncclSuccess;
+  if (!comm->topo->warpSpeedEnabled) return ncclSuccess;
+  commSetUnrollFactor(comm); // TODO: reset unroll factor per task rather than per comm
+  if (!rcclCollSupportsRing(info->func)) return ncclSuccess;
   if (rcclParamWarpSpeedForceEnable() > 0) { // Manual performance mode
-    if(info->algorithm != NCCL_ALGO_RING) {
-      INFO(NCCL_TUNING, "Overriding %s algorithm with RING for nccl%s at %zu bytes as WarpSpeed is requested and only supports RING", ncclAlgoToString(info->algorithm), ncclFuncToString(info->func), nBytes);
+    if (info->algorithm != NCCL_ALGO_RING) {
+      INFO(NCCL_TUNING,
+           "Overriding %s algorithm with RING for nccl%s at %zu bytes as WarpSpeed is requested and only supports RING",
+           ncclAlgoToString(info->algorithm), ncclFuncToString(info->func), nBytes);
       info->algorithm = NCCL_ALGO_RING; // Force Ring when WarpSpeed is enabled in manual mode as it only supports Ring
     }
     // TODO: Remove unroll update when all collectives are optimized
-    if(!unrollFactorSet) comm->unroll =  NCCL_UNROLL_2;
+    if (!unrollFactorSet) comm->unroll = NCCL_UNROLL_2;
     info->useWarpSpeed = true;
-  } else if(rcclCanUseWarpSpeedAuto(comm, comm->nNodes)) { // Auto performance mode
+  } else if (rcclCanUseWarpSpeedAuto(comm, comm->nNodes)) { // Auto performance mode
     // No early return based on the algorithm at the start of the function
     // to allow unroll factor to be reverted to default.
     // This can be changed once per-task unroll factor setting is implemented.
-    if(info->algorithm != NCCL_ALGO_RING) {
+    if (info->algorithm != NCCL_ALGO_RING) {
       return ncclSuccess; // If Ring is not selected, assume it is suboptimal and return
     }
-    if(info->func == ncclFuncAllReduce || info->func == ncclFuncAllGather || info->func == ncclFuncReduceScatter) {
-       // allReduce now benefits from unroll factor of 2 in all modes due to changing its slicing strategy
-       // TODO: Remove unroll update when all collectives are optimized
-      if(!unrollFactorSet) comm->unroll =  NCCL_UNROLL_2;
+    if (info->func == ncclFuncAllReduce || info->func == ncclFuncAllGather || info->func == ncclFuncReduceScatter) {
+      // allReduce now benefits from unroll factor of 2 in all modes due to changing its slicing strategy
+      // TODO: Remove unroll update when all collectives are optimized
+      if (!unrollFactorSet) comm->unroll = NCCL_UNROLL_2;
     }
-    if(rcclIsAboveWarpSpeedThreshold(comm, info, nBytes)) 
-    {
+    if (rcclIsAboveWarpSpeedThreshold(comm, info, nBytes)) {
       info->nWarps = 4;
       info->useWarpSpeed = true;
     }
@@ -776,12 +795,13 @@ ncclResult_t rcclSetWarpSpeedAuto(struct ncclComm* comm, struct ncclTaskColl* in
 
 int rcclGetMaxWarpsPerBlock(struct ncclComm* comm) {
   int warpsPerBlock;
-  if(comm->nNodes == 1) {
-    warpsPerBlock = RCCL_SINGLE_NODE_MAX_NTHREADS / comm->WarpSize; // For single node, we use half the number of threads for perf reasons.
+  if (comm->nNodes == 1) {
+    warpsPerBlock = RCCL_SINGLE_NODE_MAX_NTHREADS /
+                    comm->WarpSize; // For single node, we use half the number of threads for perf reasons.
   } else {
-    warpsPerBlock = IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950")?
-                                                          RCCL_GFX950_MAX_NTHREADS / comm->WarpSize:
-                                                          RCCL_DEFAULT_MAX_NTHREADS / comm->WarpSize;
+    warpsPerBlock = IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950") ?
+                      RCCL_GFX950_MAX_NTHREADS / comm->WarpSize :
+                      RCCL_DEFAULT_MAX_NTHREADS / comm->WarpSize;
   }
   return warpsPerBlock;
 }
@@ -799,13 +819,13 @@ void rcclGetMaxNthreads(struct ncclComm* comm, int maxNthreads[]) {
 void rcclOptThreadBlockSize(struct ncclComm* comm, struct ncclTaskColl* info, size_t nBytes, int& nThreads) {
   static int maxNthreads[NCCL_NUM_PROTOCOLS] = {0};
   if (maxNthreads[NCCL_PROTO_SIMPLE] == 0) rcclGetMaxNthreads(comm, maxNthreads);
-  if(rcclParamThreadsPerBlock() != -1) {
+  if (rcclParamThreadsPerBlock() != -1) {
     nThreads = rcclParamThreadsPerBlock();
-    if(nThreads % comm->WarpSize != 0) {
+    if (nThreads % comm->WarpSize != 0) {
       nThreads = ((nThreads / comm->WarpSize) + 1) * comm->WarpSize;
       INFO(NCCL_INIT, "RCCL Threads per block adjusted to %d to be multiple of warp size %d", nThreads, comm->WarpSize);
     }
-    if(nThreads > maxNthreads[NCCL_PROTO_SIMPLE]) {
+    if (nThreads > maxNthreads[NCCL_PROTO_SIMPLE]) {
       nThreads = maxNthreads[NCCL_PROTO_SIMPLE];
       INFO(NCCL_INIT, "RCCL Threads per block reduced to %d to match max threads", nThreads);
     } else if (nThreads < 3 * comm->WarpSize) {
@@ -815,20 +835,24 @@ void rcclOptThreadBlockSize(struct ncclComm* comm, struct ncclTaskColl* info, si
     return;
   }
   if (info->algorithm == NCCL_ALGO_TREE) nThreads = maxNthreads[NCCL_PROTO_SIMPLE]; // Tree now uses all threads always.
-  if (info->algorithm == NCCL_ALGO_PAT)  nThreads = maxNthreads[NCCL_PROTO_SIMPLE];
-  if (comm->nNodes == 1) nThreads = RCCL_SINGLE_NODE_MAX_NTHREADS; // For single node, we use half the number of threads for perf reasons.
+  if (info->algorithm == NCCL_ALGO_PAT) nThreads = maxNthreads[NCCL_PROTO_SIMPLE];
+  if (comm->nNodes == 1)
+    nThreads = RCCL_SINGLE_NODE_MAX_NTHREADS; // For single node, we use half the number of threads for perf reasons.
   // The following should be already set correctly by getNthreads
   // but need to override the changes for TREE and PAT in the previous lines
-  else if (info->protocol == NCCL_PROTO_LL) nThreads =  maxNthreads[NCCL_PROTO_LL];
+  else if (info->protocol == NCCL_PROTO_LL) nThreads = maxNthreads[NCCL_PROTO_LL];
   // ReduceScatter small count optimization
-  if (info->func == ncclFuncReduceScatter && divUp(nBytes, comm->nRanks) <= 524288) nThreads = maxNthreads[NCCL_PROTO_LL];
+  if (info->func == ncclFuncReduceScatter && divUp(nBytes, comm->nRanks) <= 524288)
+    nThreads = maxNthreads[NCCL_PROTO_LL];
 }
 
 void rcclSetDefaultBuffSizes(struct ncclComm* comm, int defaultBuffSizes[]) {
   static int maxNthreads[NCCL_NUM_PROTOCOLS] = {0};
   if (maxNthreads[NCCL_PROTO_SIMPLE] == 0) rcclGetMaxNthreads(comm, maxNthreads);
-  defaultBuffSizes[NCCL_PROTO_LL]     = NCCL_LL_LINES_PER_THREAD*maxNthreads[NCCL_PROTO_LL]*NCCL_STEPS*sizeof(union ncclLLFifoLine);
-  defaultBuffSizes[NCCL_PROTO_LL128]  = rcclLL128ElemsPerThreadFromArch(comm->archName)*maxNthreads[NCCL_PROTO_LL128]*NCCL_STEPS*sizeof(uint64_t);
+  defaultBuffSizes[NCCL_PROTO_LL] =
+    NCCL_LL_LINES_PER_THREAD * maxNthreads[NCCL_PROTO_LL] * NCCL_STEPS * sizeof(union ncclLLFifoLine);
+  defaultBuffSizes[NCCL_PROTO_LL128] =
+    rcclLL128ElemsPerThreadFromArch(comm->archName) * maxNthreads[NCCL_PROTO_LL128] * NCCL_STEPS * sizeof(uint64_t);
   defaultBuffSizes[NCCL_PROTO_SIMPLE] = (1 << 22); /* 4MiB */
 }
 
@@ -839,35 +863,32 @@ ncclResult_t rcclFuncMaxSendRecvCount(ncclFunc_t func, int nRanks, size_t count,
 }
 
 ncclResult_t commSetUnrollFactor(struct ncclComm* comm) {
-  if( rcclParamUnrollFactor() != -1 ) {
+  if (rcclParamUnrollFactor() != -1) {
     comm->unroll = rcclParamUnrollFactor(); //-1 to map to 0 based indexing
-    if(comm->unroll < NCCL_UNROLL_1 || comm->unroll >= NCCL_NUM_UNROLLS) {
-      WARN("Invalid RCCL_UNROLL_FACTOR %d specified. Valid values are 0 to 2 corresponding to unroll factors of 1, 2, and 4 respectively.", comm->unroll);
+    if (comm->unroll < NCCL_UNROLL_1 || comm->unroll >= NCCL_NUM_UNROLLS) {
+      WARN("Invalid RCCL_UNROLL_FACTOR %d specified. Valid values are 0 to 2 corresponding to unroll factors of 1, 2, "
+           "and 4 respectively.",
+           comm->unroll);
       return ncclInvalidArgument;
     }
-    INFO(NCCL_INIT, "RCCL Unroll Factor (user set): %d", (int) (pow(2.0, (double)comm->unroll)));
+    INFO(NCCL_INIT, "RCCL Unroll Factor (user set): %d", (int)(pow(2.0, (double)comm->unroll)));
     return ncclSuccess;
   }
-  if(IsArchMatch(comm->archName, "gfx950")) {
-    if(comm->nNodes == 1)
-      comm->unroll = NCCL_UNROLL_1;
-    else
-      comm->unroll = NCCL_UNROLL_2;
-  }
-  else if(IsArchMatch(comm->archName, "gfx908") || ((IsArchMatch(comm->archName, "gfx942") && comm->cuCount > 80)))
+  if (IsArchMatch(comm->archName, "gfx950")) {
+    if (comm->nNodes == 1) comm->unroll = NCCL_UNROLL_1;
+    else comm->unroll = NCCL_UNROLL_2;
+  } else if (IsArchMatch(comm->archName, "gfx908") || ((IsArchMatch(comm->archName, "gfx942") && comm->cuCount > 80)))
     comm->unroll = NCCL_UNROLL_2;
-  else
-    comm->unroll = NCCL_UNROLL_4;
+  else comm->unroll = NCCL_UNROLL_4;
 
-  INFO(NCCL_INIT, "RCCL Unroll Factor (pre-set): %d", (int) (pow(2.0, (double)comm->unroll)));
+  INFO(NCCL_INIT, "RCCL Unroll Factor (pre-set): %d", (int)(pow(2.0, (double)comm->unroll)));
   return ncclSuccess;
 }
-
 
 RCCL_PARAM(P2pChannelShiftSize, "P2P_SHIFT_SIZE", -1);
 ncclResult_t rcclCommSetP2pShiftSize(struct ncclComm* comm) {
   int nP2pChannels = comm->p2pnChannels;
-  int nChannelsLog2 = countOneBits(nP2pChannels-1);
+  int nChannelsLog2 = countOneBits(nP2pChannels - 1);
   int shiftSize = rcclParamP2pChannelShiftSize();
 
   // Use bit-reversal for default/invalid shiftSize (device uses shiftSize==-1 for that path).
@@ -888,8 +909,9 @@ int getFirmwareVersion() {
   return fw_version;
 }
 
-bool validHsaScratchEnvSetting(const char*hsaScratchEnv, int hipRuntimeVersion, int firmwareVersion, char const* archName) {
-  bool hsaScratchEnvSet = (hsaScratchEnv && strcmp(hsaScratchEnv,"1") == 0);
+bool validHsaScratchEnvSetting(const char* hsaScratchEnv, int hipRuntimeVersion, int firmwareVersion,
+                               char const* archName) {
+  bool hsaScratchEnvSet = (hsaScratchEnv && strcmp(hsaScratchEnv, "1") == 0);
   if (hsaScratchEnvSet) {
     return true;
   }
@@ -909,14 +931,17 @@ bool rcclIsArchSupportedForFunc(struct ncclTaskColl* info, const char* archName)
   if (info->protocol == NCCL_PROTO_LL128) {
 #if defined(ENABLE_LL128)
     if (info->acc)
-      supported = (IsArchMatch(archName, "gfx942") || IsArchMatch(archName, "gfx950") || IsArchMatch(archName, "gfx1250"));
+      supported =
+        (IsArchMatch(archName, "gfx942") || IsArchMatch(archName, "gfx950") || IsArchMatch(archName, "gfx1250"));
     else
-      supported = (IsArchMatch(archName, "gfx942") || IsArchMatch(archName, "gfx950") || IsArchMatch(archName, "gfx90a") || IsArchMatch(archName, "gfx1250"));
+      supported = (IsArchMatch(archName, "gfx942") || IsArchMatch(archName, "gfx950") ||
+                   IsArchMatch(archName, "gfx90a") || IsArchMatch(archName, "gfx1250"));
 #else
     supported = false;
 #endif
   } else if (info->acc) {
-    supported = (IsArchMatch(archName, "gfx942") || IsArchMatch(archName, "gfx950") || IsArchMatch(archName, "gfx1250"));
+    supported =
+      (IsArchMatch(archName, "gfx942") || IsArchMatch(archName, "gfx950") || IsArchMatch(archName, "gfx1250"));
   }
 
   return supported;

--- a/projects/rccl/src/register/coll_reg.cc
+++ b/projects/rccl/src/register/coll_reg.cc
@@ -10,7 +10,8 @@
 #include "enqueue.h"
 #include "register_inline.h"
 
-static ncclResult_t registerCheckP2PConnection(struct ncclComm* comm, struct ncclConnector* conn, struct ncclTopoGraph* graph, int peer, bool* needReg) {
+static ncclResult_t registerCheckP2PConnection(struct ncclComm* comm, struct ncclConnector* conn,
+                                               struct ncclTopoGraph* graph, int peer, bool* needReg) {
   if (conn->connected) {
     if (conn->conn.flags & (NCCL_P2P_READ | NCCL_P2P_WRITE)) {
       *needReg = true;
@@ -33,12 +34,9 @@ static ncclResult_t registerCheckP2PConnection(struct ncclComm* comm, struct ncc
 }
 
 ncclResult_t ncclRegisterCollNvlsBuffers(
-    struct ncclComm* comm, struct ncclTaskColl* info,
-    void* outRegBufSend[NCCL_MAX_LOCAL_RANKS],
-    void* outRegBufRecv[NCCL_MAX_LOCAL_RANKS],
-    struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>* cleanupQueue,
-    bool* regNeedConnect
-  ) {
+  struct ncclComm* comm, struct ncclTaskColl* info, void* outRegBufSend[NCCL_MAX_LOCAL_RANKS],
+  void* outRegBufRecv[NCCL_MAX_LOCAL_RANKS],
+  struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>* cleanupQueue, bool* regNeedConnect) {
   ncclResult_t result = ncclSuccess;
 
   info->regBufType = NCCL_REGULAR_BUFFER;
@@ -49,33 +47,40 @@ ncclResult_t ncclRegisterCollNvlsBuffers(
     if (!comm->nvlsRegSupport || info->opDev.op == ncclDevPreMulSum) goto exit;
     int nvlsReged = 0;
     int collnetReged = 0;
-    const void *sendbuff = info->sendbuff;
-    void *recvbuff = info->recvbuff;
+    const void* sendbuff = info->sendbuff;
+    void* recvbuff = info->recvbuff;
     void *recvHandle = NULL, *sendHandle = NULL;
     if (info->func == ncclFuncAllGather) sendbuff = NULL;
     if (info->func == ncclFuncReduceScatter) recvbuff = NULL;
     size_t elementSize = ncclTypeSize(info->datatype);
-    size_t sendbuffSize = elementSize*ncclFuncSendCount(info->func, comm->nRanks, info->count);
-    size_t recvbuffSize = elementSize*ncclFuncRecvCount(info->func, comm->nRanks, info->count);
+    size_t sendbuffSize = elementSize * ncclFuncSendCount(info->func, comm->nRanks, info->count);
+    size_t recvbuffSize = elementSize * ncclFuncRecvCount(info->func, comm->nRanks, info->count);
 
     /* first try graph registration. */
     if (comm->planner.persistent && ncclParamGraphRegister()) {
-      ncclNvlsGraphRegisterBuffer(comm, sendbuff, recvbuff, sendbuffSize, recvbuffSize, &nvlsReged, outRegBufSend, outRegBufRecv, cleanupQueue, &info->nCleanupQueueElts);
+      ncclNvlsGraphRegisterBuffer(comm, sendbuff, recvbuff, sendbuffSize, recvbuffSize, &nvlsReged, outRegBufSend,
+                                  outRegBufRecv, cleanupQueue, &info->nCleanupQueueElts);
     }
 
     if (nvlsReged == 0 && ncclParamLocalRegister()) {
-      ncclNvlsLocalRegisterBuffer(comm, sendbuff, recvbuff, sendbuffSize, recvbuffSize, &nvlsReged, outRegBufSend, outRegBufRecv);
+      ncclNvlsLocalRegisterBuffer(comm, sendbuff, recvbuff, sendbuffSize, recvbuffSize, &nvlsReged, outRegBufSend,
+                                  outRegBufRecv);
     }
 
     if (nvlsReged && comm->nNodes > 1 && info->algorithm == NCCL_ALGO_NVLS) {
       if (comm->planner.persistent && ncclParamGraphRegister()) {
         if (info->func == ncclFuncAllGather) {
-          ncclCollnetGraphRegisterBuffer(comm, info->sendbuff, sendbuffSize, collNetSend, &collnetReged, &sendHandle, cleanupQueue, &info->nCleanupQueueElts);
+          ncclCollnetGraphRegisterBuffer(comm, info->sendbuff, sendbuffSize, collNetSend, &collnetReged, &sendHandle,
+                                         cleanupQueue, &info->nCleanupQueueElts);
         } else if (info->func == ncclFuncReduceScatter) {
-          ncclCollnetGraphRegisterBuffer(comm, info->recvbuff, recvbuffSize, collNetRecv, &collnetReged, &recvHandle, cleanupQueue, &info->nCleanupQueueElts);
+          ncclCollnetGraphRegisterBuffer(comm, info->recvbuff, recvbuffSize, collNetRecv, &collnetReged, &recvHandle,
+                                         cleanupQueue, &info->nCleanupQueueElts);
         } else if (info->func == ncclFuncAllReduce) {
-          ncclCollnetGraphRegisterBuffer(comm, info->recvbuff, recvbuffSize, collNetRecv, &collnetReged, &recvHandle, cleanupQueue, &info->nCleanupQueueElts);
-          if (collnetReged) ncclCollnetGraphRegisterBuffer(comm, info->recvbuff, recvbuffSize, collNetSend, &collnetReged, &sendHandle, cleanupQueue, &info->nCleanupQueueElts);
+          ncclCollnetGraphRegisterBuffer(comm, info->recvbuff, recvbuffSize, collNetRecv, &collnetReged, &recvHandle,
+                                         cleanupQueue, &info->nCleanupQueueElts);
+          if (collnetReged)
+            ncclCollnetGraphRegisterBuffer(comm, info->recvbuff, recvbuffSize, collNetSend, &collnetReged, &sendHandle,
+                                           cleanupQueue, &info->nCleanupQueueElts);
         }
       }
 
@@ -86,7 +91,8 @@ ncclResult_t ncclRegisterCollNvlsBuffers(
           ncclCollnetLocalRegisterBuffer(comm, info->recvbuff, recvbuffSize, collNetRecv, &collnetReged, &recvHandle);
         } else if (info->func == ncclFuncAllReduce) {
           ncclCollnetLocalRegisterBuffer(comm, info->recvbuff, recvbuffSize, collNetRecv, &collnetReged, &recvHandle);
-          if (collnetReged) ncclCollnetLocalRegisterBuffer(comm, info->recvbuff, recvbuffSize, collNetSend, &collnetReged, &sendHandle);
+          if (collnetReged)
+            ncclCollnetLocalRegisterBuffer(comm, info->recvbuff, recvbuffSize, collNetSend, &collnetReged, &sendHandle);
         }
       }
     }
@@ -106,18 +112,15 @@ ncclResult_t ncclRegisterCollNvlsBuffers(
       info->recvMhandle = recvHandle;
     }
   }
-  #endif
+#endif
 exit:
   return result;
 }
 
 ncclResult_t ncclRegisterCollBuffers(
-    struct ncclComm* comm, struct ncclTaskColl* info,
-    void* outRegBufSend[NCCL_MAX_LOCAL_RANKS],
-    void* outRegBufRecv[NCCL_MAX_LOCAL_RANKS],
-    struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>* cleanupQueue,
-    bool* regNeedConnect
-  ) {
+  struct ncclComm* comm, struct ncclTaskColl* info, void* outRegBufSend[NCCL_MAX_LOCAL_RANKS],
+  void* outRegBufRecv[NCCL_MAX_LOCAL_RANKS],
+  struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>* cleanupQueue, bool* regNeedConnect) {
   ncclResult_t result = ncclSuccess;
 
   info->regBufType = NCCL_REGULAR_BUFFER;
@@ -129,33 +132,39 @@ ncclResult_t ncclRegisterCollBuffers(
     if (!comm->nvlsRegSupport || info->opDev.op == ncclDevPreMulSum) goto exit;
     int nvlsReged = 0;
     int collnetReged = 0;
-    const void *sendbuff = info->sendbuff;
-    void *recvbuff = info->recvbuff;
+    const void* sendbuff = info->sendbuff;
+    void* recvbuff = info->recvbuff;
     void *recvHandle = NULL, *sendHandle = NULL;
     if (info->func == ncclFuncAllGather) sendbuff = NULL;
     if (info->func == ncclFuncReduceScatter) recvbuff = NULL;
     size_t elementSize = ncclTypeSize(info->datatype);
-    size_t sendbuffSize = elementSize*ncclFuncSendCount(info->func, comm->nRanks, info->count);
-    size_t recvbuffSize = elementSize*ncclFuncRecvCount(info->func, comm->nRanks, info->count);
+    size_t sendbuffSize = elementSize * ncclFuncSendCount(info->func, comm->nRanks, info->count);
+    size_t recvbuffSize = elementSize * ncclFuncRecvCount(info->func, comm->nRanks, info->count);
 
     /* first try local registration. */
     if (ncclParamLocalRegister()) {
-      ncclNvlsLocalRegisterBuffer(comm, sendbuff, recvbuff, sendbuffSize, recvbuffSize, &nvlsReged, outRegBufSend, outRegBufRecv);
+      ncclNvlsLocalRegisterBuffer(comm, sendbuff, recvbuff, sendbuffSize, recvbuffSize, &nvlsReged, outRegBufSend,
+                                  outRegBufRecv);
     }
 
     if (nvlsReged == 0 && comm->planner.persistent && ncclParamGraphRegister()) {
-      ncclNvlsGraphRegisterBuffer(comm, sendbuff, recvbuff, sendbuffSize, recvbuffSize, &nvlsReged, outRegBufSend, outRegBufRecv, cleanupQueue, &info->nCleanupQueueElts);
+      ncclNvlsGraphRegisterBuffer(comm, sendbuff, recvbuff, sendbuffSize, recvbuffSize, &nvlsReged, outRegBufSend,
+                                  outRegBufRecv, cleanupQueue, &info->nCleanupQueueElts);
     }
 
     if (comm->nNodes > 1 && info->algorithm == NCCL_ALGO_NVLS) {
       if (ncclParamLocalRegister()) {
         ncclCollnetLocalRegisterBuffer(comm, info->recvbuff, recvbuffSize, collNetSend, &collnetReged, &sendHandle);
-        if (collnetReged) ncclCollnetLocalRegisterBuffer(comm, info->recvbuff, recvbuffSize, collNetRecv, &collnetReged, &recvHandle);
+        if (collnetReged)
+          ncclCollnetLocalRegisterBuffer(comm, info->recvbuff, recvbuffSize, collNetRecv, &collnetReged, &recvHandle);
       }
 
       if (collnetReged == 0 && comm->planner.persistent && ncclParamGraphRegister()) {
-        ncclCollnetGraphRegisterBuffer(comm, info->recvbuff, recvbuffSize, collNetSend, &collnetReged, &sendHandle, cleanupQueue, &info->nCleanupQueueElts);
-        if (collnetReged) ncclCollnetGraphRegisterBuffer(comm, info->recvbuff, recvbuffSize, collNetRecv, &collnetReged, &recvHandle, cleanupQueue, &info->nCleanupQueueElts);
+        ncclCollnetGraphRegisterBuffer(comm, info->recvbuff, recvbuffSize, collNetSend, &collnetReged, &sendHandle,
+                                       cleanupQueue, &info->nCleanupQueueElts);
+        if (collnetReged)
+          ncclCollnetGraphRegisterBuffer(comm, info->recvbuff, recvbuffSize, collNetRecv, &collnetReged, &recvHandle,
+                                         cleanupQueue, &info->nCleanupQueueElts);
       }
     }
 
@@ -166,8 +175,7 @@ ncclResult_t ncclRegisterCollBuffers(
       if (comm->nNodes == 1) {
         if (info->func == ncclFuncReduceScatter)
           info->nMaxChannels = std::max(comm->config.minCTAs, std::min(comm->config.maxCTAs, 5));
-        else
-          info->nMaxChannels = std::max(comm->config.minCTAs, std::min(comm->config.maxCTAs, 4));
+        else info->nMaxChannels = std::max(comm->config.minCTAs, std::min(comm->config.maxCTAs, 4));
       } else {
         info->nMaxChannels = std::max(comm->config.minCTAs, std::min(comm->config.maxCTAs, 6));
       }
@@ -184,17 +192,20 @@ ncclResult_t ncclRegisterCollBuffers(
     if (info->func == ncclFuncReduceScatter && info->algorithm != NCCL_ALGO_COLLNET_DIRECT) goto exit;
     // Skip IPC buffer registration for AllReduceWithBias
     if (info->func == ncclFuncAllReduce && info->acc != nullptr) goto exit;
-    if (info->algorithm == NCCL_ALGO_RING && ((info->func == ncclFuncAllReduce && info->sendbuff == info->recvbuff) || info->func == ncclFuncReduce)) goto exit;
+    if (info->algorithm == NCCL_ALGO_RING &&
+        ((info->func == ncclFuncAllReduce && info->sendbuff == info->recvbuff) || info->func == ncclFuncReduce))
+      goto exit;
     // Disable buffer registration for TREE in-place and for cross-clique due to buffer conflicts
     if (info->algorithm == NCCL_ALGO_TREE && (info->sendbuff == info->recvbuff || comm->p2pCrossClique)) goto exit;
-    if (info->algorithm == NCCL_ALGO_COLLNET_CHAIN && info->sendbuff == info->recvbuff && comm->maxLocalRanks > 1) goto exit;
+    if (info->algorithm == NCCL_ALGO_COLLNET_CHAIN && info->sendbuff == info->recvbuff && comm->maxLocalRanks > 1)
+      goto exit;
     if (info->func == ncclFuncAllGather && info->algorithm == NCCL_ALGO_PAT) goto exit;
 
     int peerRanks[NCCL_MAX_LOCAL_RANKS];
     int nPeers = 0;
     size_t elementSize = ncclTypeSize(info->datatype);
-    size_t sendbuffSize = elementSize*ncclFuncSendCount(info->func, comm->nRanks, info->count);
-    size_t recvbuffSize = elementSize*ncclFuncRecvCount(info->func, comm->nRanks, info->count);
+    size_t sendbuffSize = elementSize * ncclFuncSendCount(info->func, comm->nRanks, info->count);
+    size_t recvbuffSize = elementSize * ncclFuncRecvCount(info->func, comm->nRanks, info->count);
     int regBufFlag = 0;
     memset(peerRanks, 0xff, sizeof(int) * NCCL_MAX_LOCAL_RANKS);
 
@@ -210,7 +221,8 @@ ncclResult_t ncclRegisterCollBuffers(
               struct ncclConnector* peerConn = &channel->peers[peer]->recv[0];
               bool needReg = false;
 
-              NCCLCHECK(registerCheckP2PConnection(comm, peerConn, &comm->graphs[NCCL_ALGO_COLLNET_DIRECT], peer, &needReg));
+              NCCLCHECK(registerCheckP2PConnection(comm, peerConn, &comm->graphs[NCCL_ALGO_COLLNET_DIRECT], peer,
+                                                   &needReg));
               if (needReg) {
                 bool found = false;
                 for (int p = 0; p < nPeers; ++p) {
@@ -227,12 +239,20 @@ ncclResult_t ncclRegisterCollBuffers(
 
         if (nPeers > 0) {
           if (comm->planner.persistent && ncclParamGraphRegister()) {
-            ncclIpcGraphRegisterBuffer(comm, info->sendbuff, sendbuffSize, peerRanks, nPeers, NCCL_IPC_COLLECTIVE, &ipcSendRegFlag, &info->sendbuffOffset, &info->sendbuffRmtAddrs, cleanupQueue, &info->nCleanupQueueElts);
-            ncclIpcGraphRegisterBuffer(comm, info->recvbuff, recvbuffSize, peerRanks, nPeers, NCCL_IPC_COLLECTIVE, &ipcRecvRegFlag, &info->recvbuffOffset, &info->recvbuffRmtAddrs, cleanupQueue, &info->nCleanupQueueElts);
+            ncclIpcGraphRegisterBuffer(comm, info->sendbuff, sendbuffSize, peerRanks, nPeers, NCCL_IPC_COLLECTIVE,
+                                       &ipcSendRegFlag, &info->sendbuffOffset, &info->sendbuffRmtAddrs, cleanupQueue,
+                                       &info->nCleanupQueueElts);
+            ncclIpcGraphRegisterBuffer(comm, info->recvbuff, recvbuffSize, peerRanks, nPeers, NCCL_IPC_COLLECTIVE,
+                                       &ipcRecvRegFlag, &info->recvbuffOffset, &info->recvbuffRmtAddrs, cleanupQueue,
+                                       &info->nCleanupQueueElts);
           }
           if (ncclParamLocalRegister()) {
-            if (!ipcSendRegFlag) ncclIpcLocalRegisterBuffer(comm, info->sendbuff, sendbuffSize, peerRanks, nPeers, NCCL_IPC_COLLECTIVE, &ipcSendRegFlag, &info->sendbuffOffset, &info->sendbuffRmtAddrs);
-            if (!ipcRecvRegFlag) ncclIpcLocalRegisterBuffer(comm, info->recvbuff, recvbuffSize, peerRanks, nPeers, NCCL_IPC_COLLECTIVE, &ipcRecvRegFlag, &info->recvbuffOffset, &info->recvbuffRmtAddrs);
+            if (!ipcSendRegFlag)
+              ncclIpcLocalRegisterBuffer(comm, info->sendbuff, sendbuffSize, peerRanks, nPeers, NCCL_IPC_COLLECTIVE,
+                                         &ipcSendRegFlag, &info->sendbuffOffset, &info->sendbuffRmtAddrs);
+            if (!ipcRecvRegFlag)
+              ncclIpcLocalRegisterBuffer(comm, info->recvbuff, recvbuffSize, peerRanks, nPeers, NCCL_IPC_COLLECTIVE,
+                                         &ipcRecvRegFlag, &info->recvbuffOffset, &info->recvbuffRmtAddrs);
           }
         }
 
@@ -244,21 +264,26 @@ ncclResult_t ncclRegisterCollBuffers(
       }
 
       // register collnet buffer
-      if (info->opDev.op != ncclDevPreMulSum && info->opDev.op != ncclDevSumPostDiv && !(info->func == ncclFuncAllReduce && !comm->isOneRPN)) {
+      if (info->opDev.op != ncclDevPreMulSum && info->opDev.op != ncclDevSumPostDiv &&
+          !(info->func == ncclFuncAllReduce && !comm->isOneRPN)) {
         if (comm->planner.persistent && ncclParamGraphRegister()) {
-          ncclCollnetGraphRegisterBuffer(comm, info->sendbuff, sendbuffSize, collNetSend, &netSendRegFlag, &sendHandle, cleanupQueue, &info->nCleanupQueueElts);
-          ncclCollnetGraphRegisterBuffer(comm, info->recvbuff, recvbuffSize, collNetRecv, &netRecvRegFlag, &recvHandle, cleanupQueue, &info->nCleanupQueueElts);
+          ncclCollnetGraphRegisterBuffer(comm, info->sendbuff, sendbuffSize, collNetSend, &netSendRegFlag, &sendHandle,
+                                         cleanupQueue, &info->nCleanupQueueElts);
+          ncclCollnetGraphRegisterBuffer(comm, info->recvbuff, recvbuffSize, collNetRecv, &netRecvRegFlag, &recvHandle,
+                                         cleanupQueue, &info->nCleanupQueueElts);
           info->sendMhandle = sendHandle;
           info->recvMhandle = recvHandle;
         }
 
         if (ncclParamLocalRegister()) {
           if (!netSendRegFlag) {
-            ncclCollnetLocalRegisterBuffer(comm, info->sendbuff, sendbuffSize, collNetSend, &netSendRegFlag, &sendHandle);
+            ncclCollnetLocalRegisterBuffer(comm, info->sendbuff, sendbuffSize, collNetSend, &netSendRegFlag,
+                                           &sendHandle);
             info->sendMhandle = sendHandle;
           }
           if (!netRecvRegFlag) {
-            ncclCollnetLocalRegisterBuffer(comm, info->recvbuff, recvbuffSize, collNetRecv, &netRecvRegFlag, &recvHandle);
+            ncclCollnetLocalRegisterBuffer(comm, info->recvbuff, recvbuffSize, collNetRecv, &netRecvRegFlag,
+                                           &recvHandle);
             info->recvMhandle = recvHandle;
           }
         }
@@ -269,7 +294,8 @@ ncclResult_t ncclRegisterCollBuffers(
           }
         } else if (info->func == ncclFuncAllGather) {
           if (comm->isOneRPN) {
-            info->regBufType = (netSendRegFlag && netRecvRegFlag) ? (info->regBufType | NCCL_NET_REG_BUFFER) : info->regBufType;
+            info->regBufType =
+              (netSendRegFlag && netRecvRegFlag) ? (info->regBufType | NCCL_NET_REG_BUFFER) : info->regBufType;
           } else {
             info->regBufType = (netSendRegFlag) ? (info->regBufType | NCCL_NET_REG_BUFFER) : info->regBufType;
           }
@@ -293,7 +319,8 @@ ncclResult_t ncclRegisterCollBuffers(
       NCCLCHECK(ncclRegFind(comm, info->recvbuff, recvbuffSize, &recvRegRecord));
       if (recvRegRecord == NULL && !(comm->planner.persistent && ncclParamGraphRegister())) goto exit;
       NCCLCHECK(ncclRegFind(comm, info->sendbuff, sendbuffSize, &sendRegRecord));
-      if (comm->nNodes > 1 && sendRegRecord == NULL && !(comm->planner.persistent && ncclParamGraphRegister())) goto exit;
+      if (comm->nNodes > 1 && sendRegRecord == NULL && !(comm->planner.persistent && ncclParamGraphRegister()))
+        goto exit;
       NCCLCHECK(ncclCalloc(&sendNetConns, comm->nChannels));
       NCCLCHECK(ncclCalloc(&sendNetHandles, comm->nChannels));
       NCCLCHECK(ncclCalloc(&recvNetConns, comm->nChannels));
@@ -334,10 +361,13 @@ ncclResult_t ncclRegisterCollBuffers(
       }
       if (nPeers > 0 && comm->isAllDirectP2p) {
         if (comm->planner.persistent && ncclParamGraphRegister()) {
-          ncclIpcGraphRegisterBuffer(comm, info->recvbuff, recvbuffSize, peerRanks, nPeers, NCCL_IPC_COLLECTIVE, &regBufFlag, &info->recvbuffOffset, &info->recvbuffRmtAddrs, cleanupQueue, &info->nCleanupQueueElts);
+          ncclIpcGraphRegisterBuffer(comm, info->recvbuff, recvbuffSize, peerRanks, nPeers, NCCL_IPC_COLLECTIVE,
+                                     &regBufFlag, &info->recvbuffOffset, &info->recvbuffRmtAddrs, cleanupQueue,
+                                     &info->nCleanupQueueElts);
         }
         if (!regBufFlag && ncclParamLocalRegister()) {
-          ncclIpcLocalRegisterBuffer(comm, info->recvbuff, recvbuffSize, peerRanks, nPeers, NCCL_IPC_COLLECTIVE, &regBufFlag, &info->recvbuffOffset, &info->recvbuffRmtAddrs);
+          ncclIpcLocalRegisterBuffer(comm, info->recvbuff, recvbuffSize, peerRanks, nPeers, NCCL_IPC_COLLECTIVE,
+                                     &regBufFlag, &info->recvbuffOffset, &info->recvbuffRmtAddrs);
         }
       }
       if (regBufFlag) {
@@ -347,24 +377,32 @@ ncclResult_t ncclRegisterCollBuffers(
       // start net registration
       regBufFlag = 0;
 
-      if (!comm->useNetPXN && comm->useGdr && comm->netDeviceType != NCCL_NET_DEVICE_UNPACK && !(info->func == ncclFuncAllReduce && (info->opDev.op == ncclDevPreMulSum || info->opDev.op == ncclDevSumPostDiv))) {
+      if (!comm->useNetPXN && comm->useGdr && comm->netDeviceType != NCCL_NET_DEVICE_UNPACK &&
+          !(info->func == ncclFuncAllReduce &&
+            (info->opDev.op == ncclDevPreMulSum || info->opDev.op == ncclDevSumPostDiv))) {
         if (comm->planner.persistent && ncclParamGraphRegister()) {
           if (hasSendNetPeer) {
-            ncclNetGraphRegisterBuffer(comm, info->sendbuff, sendbuffSize, sendNetConns, sendNetPeers, &regBufFlag, sendNetHandles, cleanupQueue, &info->nCleanupQueueElts);
+            ncclNetGraphRegisterBuffer(comm, info->sendbuff, sendbuffSize, sendNetConns, sendNetPeers, &regBufFlag,
+                                       sendNetHandles, cleanupQueue, &info->nCleanupQueueElts);
             if (regBufFlag)
-              ncclNetGraphRegisterBuffer(comm, info->recvbuff, recvbuffSize, sendNetConns, sendNetPeers, &regBufFlag, srecvNetHandles, cleanupQueue, &info->nCleanupQueueElts);
+              ncclNetGraphRegisterBuffer(comm, info->recvbuff, recvbuffSize, sendNetConns, sendNetPeers, &regBufFlag,
+                                         srecvNetHandles, cleanupQueue, &info->nCleanupQueueElts);
           }
           if ((regBufFlag || !hasSendNetPeer) && hasRecvNetPeer)
-            ncclNetGraphRegisterBuffer(comm, info->recvbuff, recvbuffSize, recvNetConns, recvNetPeers, &regBufFlag, recvNetHandles, cleanupQueue, &info->nCleanupQueueElts);
+            ncclNetGraphRegisterBuffer(comm, info->recvbuff, recvbuffSize, recvNetConns, recvNetPeers, &regBufFlag,
+                                       recvNetHandles, cleanupQueue, &info->nCleanupQueueElts);
         }
         if (!regBufFlag && ncclParamLocalRegister()) {
           if (hasSendNetPeer) {
-            ncclNetLocalRegisterBuffer(comm, info->sendbuff, sendbuffSize, sendNetConns, sendNetPeers, &regBufFlag, sendNetHandles);
+            ncclNetLocalRegisterBuffer(comm, info->sendbuff, sendbuffSize, sendNetConns, sendNetPeers, &regBufFlag,
+                                       sendNetHandles);
             if (regBufFlag)
-              ncclNetLocalRegisterBuffer(comm, info->recvbuff, recvbuffSize, sendNetConns, sendNetPeers, &regBufFlag, srecvNetHandles);
+              ncclNetLocalRegisterBuffer(comm, info->recvbuff, recvbuffSize, sendNetConns, sendNetPeers, &regBufFlag,
+                                         srecvNetHandles);
           }
           if ((regBufFlag || !hasSendNetPeer) && hasRecvNetPeer)
-            ncclNetLocalRegisterBuffer(comm, info->recvbuff, recvbuffSize, recvNetConns, recvNetPeers, &regBufFlag, recvNetHandles);
+            ncclNetLocalRegisterBuffer(comm, info->recvbuff, recvbuffSize, recvNetConns, recvNetPeers, &regBufFlag,
+                                       recvNetHandles);
         }
       }
 
@@ -396,10 +434,8 @@ ncclResult_t ncclRegisterCollBuffers(
           struct ncclTree* tree = NULL;
           int peers[NCCL_MAX_TREE_ARITY + 1];
 
-          if (info->algorithm == NCCL_ALGO_TREE)
-            tree = &channel->tree;
-          else
-            tree = &channel->collnetChain;
+          if (info->algorithm == NCCL_ALGO_TREE) tree = &channel->tree;
+          else tree = &channel->collnetChain;
           for (int p = 0; p < NCCL_MAX_TREE_ARITY; ++p) peers[p] = tree->down[p];
           peers[NCCL_MAX_TREE_ARITY] = tree->up;
           for (int p = 0; p < NCCL_MAX_TREE_ARITY + 1; ++p) {
@@ -425,10 +461,13 @@ ncclResult_t ncclRegisterCollBuffers(
         }
         if (nPeers > 0) {
           if (comm->planner.persistent && ncclParamGraphRegister()) {
-            ncclIpcGraphRegisterBuffer(comm, info->recvbuff, recvbuffSize, peerRanks, nPeers, NCCL_IPC_COLLECTIVE, &regBufFlag, &info->recvbuffOffset, &info->recvbuffRmtAddrs, cleanupQueue, &info->nCleanupQueueElts);
+            ncclIpcGraphRegisterBuffer(comm, info->recvbuff, recvbuffSize, peerRanks, nPeers, NCCL_IPC_COLLECTIVE,
+                                       &regBufFlag, &info->recvbuffOffset, &info->recvbuffRmtAddrs, cleanupQueue,
+                                       &info->nCleanupQueueElts);
           }
           if (!regBufFlag && ncclParamLocalRegister()) {
-            ncclIpcLocalRegisterBuffer(comm, info->recvbuff, recvbuffSize, peerRanks, nPeers, NCCL_IPC_COLLECTIVE, &regBufFlag, &info->recvbuffOffset, &info->recvbuffRmtAddrs);
+            ncclIpcLocalRegisterBuffer(comm, info->recvbuff, recvbuffSize, peerRanks, nPeers, NCCL_IPC_COLLECTIVE,
+                                       &regBufFlag, &info->recvbuffOffset, &info->recvbuffRmtAddrs);
           }
         }
         if (regBufFlag) {
@@ -437,23 +476,28 @@ ncclResult_t ncclRegisterCollBuffers(
       }
 
       // register collnet chain 1RPN buffer
-      if (info->algorithm == NCCL_ALGO_COLLNET_CHAIN && info->opDev.op != ncclDevPreMulSum && info->opDev.op != ncclDevSumPostDiv && comm->isOneRPN) {
+      if (info->algorithm == NCCL_ALGO_COLLNET_CHAIN && info->opDev.op != ncclDevPreMulSum &&
+          info->opDev.op != ncclDevSumPostDiv && comm->isOneRPN) {
         if (comm->planner.persistent && ncclParamGraphRegister()) {
-          ncclCollnetGraphRegisterBuffer(comm, info->sendbuff, sendbuffSize, collNetSend, &netSendRegFlag, &sendHandle, cleanupQueue, &info->nCleanupQueueElts);
+          ncclCollnetGraphRegisterBuffer(comm, info->sendbuff, sendbuffSize, collNetSend, &netSendRegFlag, &sendHandle,
+                                         cleanupQueue, &info->nCleanupQueueElts);
           info->sendMhandle = sendHandle;
           if (netSendRegFlag) {
-            ncclCollnetGraphRegisterBuffer(comm, info->recvbuff, recvbuffSize, collNetRecv, &netRecvRegFlag, &recvHandle, cleanupQueue, &info->nCleanupQueueElts);
+            ncclCollnetGraphRegisterBuffer(comm, info->recvbuff, recvbuffSize, collNetRecv, &netRecvRegFlag,
+                                           &recvHandle, cleanupQueue, &info->nCleanupQueueElts);
             info->recvMhandle = recvHandle;
           }
         }
 
         if ((netSendRegFlag == 0 || netRecvRegFlag == 0) && ncclParamLocalRegister()) {
           if (!netSendRegFlag) {
-            ncclCollnetLocalRegisterBuffer(comm, info->sendbuff, sendbuffSize, collNetSend, &netSendRegFlag, &sendHandle);
+            ncclCollnetLocalRegisterBuffer(comm, info->sendbuff, sendbuffSize, collNetSend, &netSendRegFlag,
+                                           &sendHandle);
             info->sendMhandle = sendHandle;
           }
           if (netSendRegFlag && !netRecvRegFlag) {
-            ncclCollnetLocalRegisterBuffer(comm, info->recvbuff, recvbuffSize, collNetRecv, &netRecvRegFlag, &recvHandle);
+            ncclCollnetLocalRegisterBuffer(comm, info->recvbuff, recvbuffSize, collNetRecv, &netRecvRegFlag,
+                                           &recvHandle);
             info->recvMhandle = recvHandle;
           }
         }
@@ -465,7 +509,8 @@ ncclResult_t ncclRegisterCollBuffers(
       }
     }
 
-    if (info->regBufType == NCCL_IPC_REG_BUFFER && comm->nNodes == 1 && 16 < info->nMaxChannels && info->nMaxChannels <= 24) {
+    if (info->regBufType == NCCL_IPC_REG_BUFFER && comm->nNodes == 1 && 16 < info->nMaxChannels &&
+        info->nMaxChannels <= 24) {
       info->nMaxChannels = 16;
     }
   }

--- a/projects/rccl/src/register/register.cc
+++ b/projects/rccl/src/register/register.cc
@@ -22,12 +22,10 @@ NCCL_PARAM(LocalRegister, "LOCAL_REGISTER", 1);
 NCCL_PARAM(LocalRegister, "LOCAL_REGISTER", 0);
 #endif
 
-ncclResult_t ncclRegLocalIsValid(struct ncclReg *reg, bool *isValid) {
+ncclResult_t ncclRegLocalIsValid(struct ncclReg* reg, bool* isValid) {
   if (reg && isValid) {
-    if (reg->localRefs)
-      *isValid = true;
-    else
-      *isValid = false;
+    if (reg->localRefs) *isValid = true;
+    else *isValid = false;
   }
   return ncclSuccess;
 }
@@ -38,7 +36,7 @@ ncclResult_t ncclRegister(struct ncclComm* comm, void* data, size_t size, bool i
   struct ncclRegCache* cache = &comm->regCache;
   uintptr_t pageSize = cache->pageSize;
   uintptr_t begAddr = (uintptr_t)data & -pageSize;
-  uintptr_t endAddr = ((uintptr_t)data + size + pageSize-1) & -pageSize;
+  uintptr_t endAddr = ((uintptr_t)data + size + pageSize - 1) & -pageSize;
 
   if (comm->checkMode != ncclCheckModeDefault) NCCLCHECK(CudaPtrCheck(data, comm, "buff", "ncclCommRegister"));
 
@@ -48,36 +46,38 @@ ncclResult_t ncclRegister(struct ncclComm* comm, void* data, size_t size, bool i
     size_t baseSize;
     int numSegments;
     int legacyIpcCap;
-    CUCHECK(cuMemGetAddressRange(&base, &baseSize, (CUdeviceptr) data));
+    CUCHECK(cuMemGetAddressRange(&base, &baseSize, (CUdeviceptr)data));
     CUmemorytype memType;
-    CUCHECK(cuPointerGetAttribute(&memType, CU_POINTER_ATTRIBUTE_MEMORY_TYPE, (CUdeviceptr) data));
+    CUCHECK(cuPointerGetAttribute(&memType, CU_POINTER_ATTRIBUTE_MEMORY_TYPE, (CUdeviceptr)data));
     if (memType == CU_MEMORYTYPE_HOST) {
       hasSysmemSegment = true;
     } else {
       // Check for a Sysmem segment is only valid with cuMem based allocators, so a IS_LEGACY_CUDA_IPC check is required to ensure
       // that we're calling ncclCuMemGetAddressRange only when necessary.
-      CUCHECK(cuPointerGetAttribute((void*)&legacyIpcCap, CU_POINTER_ATTRIBUTE_IS_LEGACY_CUDA_IPC_CAPABLE, (CUdeviceptr) base));
+      CUCHECK(cuPointerGetAttribute((void*)&legacyIpcCap, CU_POINTER_ATTRIBUTE_IS_LEGACY_CUDA_IPC_CAPABLE,
+                                    (CUdeviceptr)base));
       if (!legacyIpcCap) {
-        NCCLCHECK(ncclCuMemGetAddressRange((CUdeviceptr) data, size, (CUdeviceptr *)&base, &baseSize, &numSegments, &hasSysmemSegment));
+        NCCLCHECK(ncclCuMemGetAddressRange((CUdeviceptr)data, size, (CUdeviceptr*)&base, &baseSize, &numSegments,
+                                           &hasSysmemSegment));
       }
     }
   }
   if (hasSysmemSegment) {
-    INFO(NCCL_REG, "Skipping registration for buffer %p size %zi since it contains segments backed by CPU memory",
-        data, size);
+    INFO(NCCL_REG, "Skipping registration for buffer %p size %zi since it contains segments backed by CPU memory", data,
+         size);
     return ncclSuccess;
   } else {
     INFO(NCCL_REG, "register comm %p buffer %p size %zi", comm, data, size);
   }
 
-  for (int slot=0; /*true*/; slot++) {
+  for (int slot = 0; /*true*/; slot++) {
     if ((slot == cache->population) || (begAddr < cache->slots[slot]->begAddr)) {
       if (cache->population == cache->capacity) { // must grow cache
-        cache->capacity = cache->capacity < 32 ? 32 : 2*cache->capacity;
+        cache->capacity = cache->capacity < 32 ? 32 : 2 * cache->capacity;
         NCCLCHECK(ncclRealloc(&cache->slots, cache->population, cache->capacity));
       }
-      memmove(cache->slots+slot+1, cache->slots+slot, (cache->population-slot)*sizeof(struct ncclReg*));
-      NCCLCHECK(ncclCalloc(cache->slots+slot, 1));
+      memmove(cache->slots + slot + 1, cache->slots + slot, (cache->population - slot) * sizeof(struct ncclReg*));
+      NCCLCHECK(ncclCalloc(cache->slots + slot, 1));
       struct ncclReg* regSlot = cache->slots[slot];
       regSlot->begAddr = begAddr;
       regSlot->endAddr = endAddr;
@@ -86,8 +86,7 @@ ncclResult_t ncclRegister(struct ncclComm* comm, void* data, size_t size, bool i
       cache->population += 1;
       *handle = regSlot;
       goto exit;
-    } else if ((cache->slots[slot]->begAddr <= begAddr) &&
-               (cache->slots[slot]->endAddr >= endAddr)) {
+    } else if ((cache->slots[slot]->begAddr <= begAddr) && (cache->slots[slot]->endAddr >= endAddr)) {
       if (isGraph) cache->slots[slot]->graphRefs++;
       else cache->slots[slot]->localRefs++;
       *handle = cache->slots[slot];
@@ -103,9 +102,10 @@ static ncclResult_t regCleanup(struct ncclComm* comm, struct ncclReg* reg) {
   if (reg->state & NET_REG_COMPLETE) {
     struct ncclRegNetHandles* netHandle = reg->netHandleHead;
     struct ncclRegNetHandles* netHandlePrev;
-    while(netHandle) {
+    while (netHandle) {
       if (ncclNetDeregBuffer(comm, netHandle->proxyConn, netHandle->handle) != ncclSuccess) {
-        WARN("rank %d deregister NET buffer handle %p proxy rank %d failed", comm->rank, netHandle->handle, netHandle->proxyConn->rank);
+        WARN("rank %d deregister NET buffer handle %p proxy rank %d failed", comm->rank, netHandle->handle,
+             netHandle->proxyConn->rank);
       }
       netHandlePrev = netHandle;
       netHandle = netHandle->next;
@@ -113,14 +113,17 @@ static ncclResult_t regCleanup(struct ncclComm* comm, struct ncclReg* reg) {
     }
   }
   if (reg->state & NVLS_REG_COMPLETE) {
-    if (ncclNvlsDeregBuffer(comm, &reg->mcHandle, reg->regAddr, reg->dev, reg->regUCSize, reg->regMCSize) != ncclSuccess) {
-      WARN("rank %d deregister NVLS buffer %p dev %d ucsize %ld mcsize %ld failed", comm->rank, (void*)reg->regAddr, reg->dev, reg->regUCSize, reg->regMCSize);
+    if (ncclNvlsDeregBuffer(comm, &reg->mcHandle, reg->regAddr, reg->dev, reg->regUCSize, reg->regMCSize) !=
+        ncclSuccess) {
+      WARN("rank %d deregister NVLS buffer %p dev %d ucsize %ld mcsize %ld failed", comm->rank, (void*)reg->regAddr,
+           reg->dev, reg->regUCSize, reg->regMCSize);
     }
     reg->regAddr = (CUdeviceptr)NULL;
   }
   if (reg->state & COLLNET_REG_COMPLETE) {
     if (ncclCollnetDeregBuffer(comm, reg->collnetProxyconn, reg->collnetHandle) != ncclSuccess) {
-      WARN("rank %d deregister COLLNET buffer handle %p proxy rank %d failed", comm->rank, reg->collnetHandle, reg->collnetProxyconn->rank);
+      WARN("rank %d deregister COLLNET buffer handle %p proxy rank %d failed", comm->rank, reg->collnetHandle,
+           reg->collnetProxyconn->rank);
     }
   }
   if (reg->state & IPC_REG_COMPLETE) {
@@ -128,7 +131,8 @@ static ncclResult_t regCleanup(struct ncclComm* comm, struct ncclReg* reg) {
       for (int i = 0; i < reg->ipcInfosSize; ++i)
         if (reg->ipcInfos[i]) {
           if (ncclIpcDeregBuffer(comm, reg->ipcInfos[i]) != ncclSuccess) {
-            WARN("rank %d deregister IPC buffer %p peerRank %d failed", comm->rank, reg->ipcInfos[i]->baseAddr, reg->ipcInfos[i]->peerRank);
+            WARN("rank %d deregister IPC buffer %p peerRank %d failed", comm->rank, reg->ipcInfos[i]->baseAddr,
+                 reg->ipcInfos[i]->peerRank);
           }
           free(reg->ipcInfos[i]);
         }
@@ -144,7 +148,8 @@ ncclResult_t ncclRegCleanup(struct ncclComm* comm) {
   struct ncclRegCache* cache = &comm->regCache;
   for (int i = 0; i < cache->population; i++) {
     struct ncclReg* reg = cache->slots[i];
-    INFO(NCCL_DESTROY, "Cleanup buffer %p pages %lx", (void*)reg->begAddr, (reg->endAddr-reg->begAddr)/cache->pageSize);
+    INFO(NCCL_DESTROY, "Cleanup buffer %p pages %lx", (void*)reg->begAddr,
+         (reg->endAddr - reg->begAddr) / cache->pageSize);
     NCCLCHECK(regCleanup(comm, reg));
     free(reg);
   }
@@ -157,8 +162,7 @@ NCCL_API(ncclResult_t, ncclCommRegister, const ncclComm_t comm, void* buff, size
 ncclResult_t ncclCommRegister_impl(const ncclComm_t comm, void* buff, size_t size, void** handle) {
   ncclResult_t ret = ncclSuccess;
 
-  if (!ncclParamLocalRegister())
-    *handle = NULL;
+  if (!ncclParamLocalRegister()) *handle = NULL;
   else {
     INFO(NCCL_INIT, "RCCL: ncclCommRegister");
     NCCLCHECKGOTO(ncclRegister(comm, buff, size, false, handle), ret, end);
@@ -172,15 +176,15 @@ end:
 ncclResult_t ncclCommGraphRegister(const ncclComm_t comm, void* buff, size_t size, void** handle) {
   if (ncclP2pUsesMemcpy()) {
     *handle = NULL;
-    INFO(NCCL_REG, "Skipping graph registration for buffer %p size %zi (P2pUsesMemcpy=%d)",
-         buff, size, ncclP2pUsesMemcpy());
+    INFO(NCCL_REG, "Skipping graph registration for buffer %p size %zi (P2pUsesMemcpy=%d)", buff, size,
+         ncclP2pUsesMemcpy());
   } else {
     NCCLCHECK(ncclRegister(comm, buff, size, true, handle));
   }
   return ncclSuccess;
 }
 
-static ncclResult_t commDeregister(struct ncclComm *comm, bool isGraph, struct ncclReg* reg) {
+static ncclResult_t commDeregister(struct ncclComm* comm, bool isGraph, struct ncclReg* reg) {
   NCCLCHECK(CommCheck(comm, "ncclCommRegister", "comm"));
   struct ncclRegCache* cache = &comm->regCache;
   int slot;
@@ -206,14 +210,14 @@ exit:
 }
 
 NCCL_API(ncclResult_t, ncclCommDeregister, const ncclComm_t comm, void* handle);
-ncclResult_t ncclCommDeregister_impl(const ncclComm_t comm, void *handle) {
+ncclResult_t ncclCommDeregister_impl(const ncclComm_t comm, void* handle) {
   NCCLCHECK(Recorder::instance().record(rrCommDeregister, comm, handle));
 
   NCCLCHECK(commDeregister(comm, false, (struct ncclReg*)handle));
   return ncclSuccess;
 }
 
-ncclResult_t ncclCommGraphDeregister(const ncclComm_t comm, struct ncclReg *handle) {
+ncclResult_t ncclCommGraphDeregister(const ncclComm_t comm, struct ncclReg* handle) {
   NCCLCHECK(commDeregister(comm, true, handle));
   return ncclSuccess;
 }

--- a/projects/rccl/src/register/sendrecv_reg.cc
+++ b/projects/rccl/src/register/sendrecv_reg.cc
@@ -8,7 +8,9 @@
 #include "register.h"
 #include "transport.h"
 
-ncclResult_t ncclRegisterP2pNetBuffer(struct ncclComm* comm, void* userbuff, size_t size, struct ncclConnector* conn, int* regFlag, void** handle, struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>* cleanupQueue) {
+ncclResult_t ncclRegisterP2pNetBuffer(
+  struct ncclComm* comm, void* userbuff, size_t size, struct ncclConnector* conn, int* regFlag, void** handle,
+  struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>* cleanupQueue) {
   ncclResult_t ret = ncclSuccess;
 
   *regFlag = 0;
@@ -23,20 +25,22 @@ ncclResult_t ncclRegisterP2pNetBuffer(struct ncclComm* comm, void* userbuff, siz
   return ret;
 }
 
-ncclResult_t ncclRegisterP2pIpcBuffer(struct ncclComm* comm, void* userbuff, size_t size, int peerRank, int* regFlag, void** regAddr, struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>* cleanupQueue) {
+ncclResult_t ncclRegisterP2pIpcBuffer(
+  struct ncclComm* comm, void* userbuff, size_t size, int peerRank, int* regFlag, void** regAddr,
+  struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>* cleanupQueue) {
   ncclResult_t ret = ncclSuccess;
   uintptr_t offset = 0;
   uintptr_t* peerRmtAddrs = NULL;
 
   *regFlag = 0;
   if (comm->planner.persistent && ncclParamGraphRegister()) {
-    ncclIpcGraphRegisterBuffer(comm, userbuff, size, &peerRank, 1, NCCL_IPC_SENDRECV, regFlag, &offset, &peerRmtAddrs, reinterpret_cast<void*>(cleanupQueue), NULL);
+    ncclIpcGraphRegisterBuffer(comm, userbuff, size, &peerRank, 1, NCCL_IPC_SENDRECV, regFlag, &offset, &peerRmtAddrs,
+                               reinterpret_cast<void*>(cleanupQueue), NULL);
   }
   if (*regFlag == 0 && ncclParamLocalRegister()) {
     ncclIpcLocalRegisterBuffer(comm, userbuff, size, &peerRank, 1, NCCL_IPC_SENDRECV, regFlag, &offset, &peerRmtAddrs);
   }
 
-  if (*regFlag)
-    *regAddr = (void*)((uintptr_t)peerRmtAddrs + offset);
+  if (*regFlag) *regAddr = (void*)((uintptr_t)peerRmtAddrs + offset);
   return ret;
 }

--- a/projects/rccl/src/rma/rma.cc
+++ b/projects/rccl/src/rma/rma.cc
@@ -21,7 +21,7 @@ static bool isLsaAccessible(struct ncclComm* comm, int rank) {
   return false;
 }
 
-ncclResult_t ncclRmaWaitSignal(struct ncclComm* comm, struct ncclKernelPlan* plan, cudaStream_t stream){
+ncclResult_t ncclRmaWaitSignal(struct ncclComm* comm, struct ncclKernelPlan* plan, cudaStream_t stream) {
   ncclResult_t ret = ncclSuccess;
 
   // If we have both proxy and CE tasks, execute them in parallel
@@ -42,11 +42,9 @@ ncclResult_t ncclRmaWaitSignal(struct ncclComm* comm, struct ncclKernelPlan* pla
     // Synchronize streams
     CUDACHECKGOTO(cudaEventRecord(ceEvent, ceStream), ret, fail);
     CUDACHECKGOTO(cudaStreamWaitEvent(stream, ceEvent, 0), ret, fail);
-  }
-  else if (plan->rmaArgs->nRmaTasksProxy > 0) {
+  } else if (plan->rmaArgs->nRmaTasksProxy > 0) {
     NCCLCHECKGOTO(ncclRmaProxyWaitLaunch(comm, plan, stream), ret, fail);
-  }
-  else if (plan->rmaArgs->nRmaTasksCe > 0) {
+  } else if (plan->rmaArgs->nRmaTasksCe > 0) {
     NCCLCHECKGOTO(ncclRmaCeWaitLaunch(comm, plan, stream), ret, fail);
   }
 
@@ -56,8 +54,7 @@ fail:
   goto exit;
 }
 
-
-ncclResult_t ncclRmaPut(struct ncclComm* comm, struct ncclKernelPlan* plan, cudaStream_t stream){
+ncclResult_t ncclRmaPut(struct ncclComm* comm, struct ncclKernelPlan* plan, cudaStream_t stream) {
   ncclResult_t ret = ncclSuccess;
 
   // If we have both proxy and CE tasks, execute them in parallel
@@ -78,11 +75,9 @@ ncclResult_t ncclRmaPut(struct ncclComm* comm, struct ncclKernelPlan* plan, cuda
     // Synchronize streams
     CUDACHECKGOTO(cudaEventRecord(ceEvent, ceStream), ret, fail);
     CUDACHECKGOTO(cudaStreamWaitEvent(stream, ceEvent, 0), ret, fail);
-  }
-  else if (plan->rmaArgs->nRmaTasksProxy > 0) {
+  } else if (plan->rmaArgs->nRmaTasksProxy > 0) {
     NCCLCHECKGOTO(ncclRmaProxyPutLaunch(comm, plan, stream), ret, fail);
-  }
-  else if (plan->rmaArgs->nRmaTasksCe > 0) {
+  } else if (plan->rmaArgs->nRmaTasksCe > 0) {
     NCCLCHECKGOTO(ncclRmaCePutLaunch(comm, plan, stream), ret, fail);
   }
 
@@ -97,17 +92,17 @@ ncclResult_t ncclLaunchRma(struct ncclComm* comm, struct ncclKernelPlan* plan) {
   cudaStream_t stream = comm->planner.streams->stream;
 
   switch (plan->rmaArgs->func) {
-    case ncclFuncPutSignal:
-      NCCLCHECKGOTO(ncclRmaPut(comm, plan, stream), ret, fail);
-      break;
-    case ncclFuncSignal:
-      NCCLCHECKGOTO(ncclRmaPut(comm, plan, stream), ret, fail);
-      break;
-    case ncclFuncWaitSignal:
-      NCCLCHECKGOTO(ncclRmaWaitSignal(comm, plan, stream), ret, fail);
-      break;
-    default:
-      ret = ncclInvalidUsage;
+  case ncclFuncPutSignal:
+    NCCLCHECKGOTO(ncclRmaPut(comm, plan, stream), ret, fail);
+    break;
+  case ncclFuncSignal:
+    NCCLCHECKGOTO(ncclRmaPut(comm, plan, stream), ret, fail);
+    break;
+  case ncclFuncWaitSignal:
+    NCCLCHECKGOTO(ncclRmaWaitSignal(comm, plan, stream), ret, fail);
+    break;
+  default:
+    ret = ncclInvalidUsage;
   }
 
 exit:
@@ -203,7 +198,8 @@ ncclResult_t scheduleRmaTasksToPlan(struct ncclComm* comm, struct ncclKernelPlan
 
     // Initialize the CE task if there are CE peers
     if (npeersCe > 0) {
-      struct ncclTaskRma* waitSignalTaskCe = ncclMemoryPoolAlloc<struct ncclTaskRma>(&comm->memPool_ncclTaskRma, &comm->memPermanent);
+      struct ncclTaskRma* waitSignalTaskCe =
+        ncclMemoryPoolAlloc<struct ncclTaskRma>(&comm->memPool_ncclTaskRma, &comm->memPermanent);
       waitSignalTaskCe->func = ncclFuncWaitSignal;
       waitSignalTaskCe->ctx = firstTask->ctx;
       waitSignalTaskCe->signalMode = firstTask->signalMode;
@@ -218,7 +214,8 @@ ncclResult_t scheduleRmaTasksToPlan(struct ncclComm* comm, struct ncclKernelPlan
 
     // Initialize the Proxy task if there are Proxy peers
     if (npeersProxy > 0) {
-      struct ncclTaskRma* waitSignalTaskProxy = ncclMemoryPoolAlloc<struct ncclTaskRma>(&comm->memPool_ncclTaskRma, &comm->memPermanent);
+      struct ncclTaskRma* waitSignalTaskProxy =
+        ncclMemoryPoolAlloc<struct ncclTaskRma>(&comm->memPool_ncclTaskRma, &comm->memPermanent);
       waitSignalTaskProxy->func = ncclFuncWaitSignal;
       waitSignalTaskProxy->ctx = firstTask->ctx;
       waitSignalTaskProxy->signalMode = firstTask->signalMode;

--- a/projects/rccl/src/rma/rma_ce.cc
+++ b/projects/rccl/src/rma/rma_ce.cc
@@ -19,7 +19,7 @@
 #include "rma/rma.h"
 #include "rma/rma_ce.h"
 
-ncclResult_t ncclRmaCeInit(struct ncclComm* comm){
+ncclResult_t ncclRmaCeInit(struct ncclComm* comm) {
   ncclResult_t ret = ncclSuccess;
   uint64_t* signalsDevBase = nullptr;
   uint64_t* ackInitHost = nullptr;
@@ -47,7 +47,9 @@ ncclResult_t ncclRmaCeInit(struct ncclComm* comm){
     ncclWindow_vidmem* signalsWinDevHost;
 
     NCCLCHECKGOTO(ncclMemAlloc((void**)&signalsDevBase, signalsBufSize), ret, fail);
-    NCCLCHECKGOTO(ncclDevrWindowRegisterInGroup(comm, signalsDevBase, signalsBufSize, NCCL_WIN_COLL_SYMMETRIC, &signalsWinDev), ret, fail);
+    NCCLCHECKGOTO(ncclDevrWindowRegisterInGroup(comm, signalsDevBase, signalsBufSize, NCCL_WIN_COLL_SYMMETRIC,
+                                                &signalsWinDev),
+                  ret, fail);
     NCCLCHECKGOTO(ncclShadowPoolToHost(&comm->devrState.shadows, signalsWinDev, &signalsWinDevHost), ret, fail);
 
     // Get the ncclDevrWindow from the winHost field
@@ -79,7 +81,6 @@ ncclResult_t ncclRmaCeInit(struct ncclComm* comm){
     // Allocate per-rank operation sequence counters
     NCCLCHECKGOTO(ncclCalloc(&ceCtx->signalOpSeqs, comm->nRanks), ret, fail);
     NCCLCHECKGOTO(ncclCudaCalloc(&ceCtx->signalOpSeqsDev, 1, comm->memManager), ret, fail);
-
   }
 
   INFO(NCCL_INIT, "Rank %d: finished init RMA CE contexts, numRmaCeCtxs %d", comm->rank, comm->config.numRmaCtx);
@@ -100,7 +101,7 @@ fail:
   goto exit;
 }
 
-ncclResult_t ncclRmaCeFinalize(struct ncclComm* comm){
+ncclResult_t ncclRmaCeFinalize(struct ncclComm* comm) {
   ncclResult_t ret = ncclSuccess;
 
   // Clean up rmaCeInitTaskQueue
@@ -157,7 +158,7 @@ fail:
   goto exit;
 }
 
-ncclResult_t ncclRmaCePutLaunch(struct ncclComm* comm, struct ncclKernelPlan* plan, cudaStream_t stream){
+ncclResult_t ncclRmaCePutLaunch(struct ncclComm* comm, struct ncclKernelPlan* plan, cudaStream_t stream) {
   ncclResult_t ret = ncclSuccess;
 
   // Make sure the RMA CE is initialized
@@ -198,7 +199,8 @@ ncclResult_t ncclRmaCePutLaunch(struct ncclComm* comm, struct ncclKernelPlan* pl
     if (bytes > 0) {
       // Get the peer buffer from the peer window
       void* peerBuff;
-      NCCLCHECKGOTO(ncclDevrGetLsaRankPtr(comm, task->peerWinHost, task->peerWinOffset, peerLsaRank, &peerBuff), ret, fail);
+      NCCLCHECKGOTO(ncclDevrGetLsaRankPtr(comm, task->peerWinHost, task->peerWinOffset, peerLsaRank, &peerBuff), ret,
+                    fail);
 
       // Validate peer buffer
       if (peerBuff == NULL) {
@@ -219,7 +221,9 @@ ncclResult_t ncclRmaCePutLaunch(struct ncclComm* comm, struct ncclKernelPlan* pl
       if (!persistent) {
         // Non-graph: write incrementing sequence to peer's signalsDev
         void* peerSignal;
-        NCCLCHECKGOTO(ncclDevrGetLsaRankPtr(comm, ceCtx->signalsWin, ceCtx->signalOffset + rankSlot, peerLsaRank, &peerSignal), ret, fail);
+        NCCLCHECKGOTO(ncclDevrGetLsaRankPtr(comm, ceCtx->signalsWin, ceCtx->signalOffset + rankSlot, peerLsaRank,
+                                            &peerSignal),
+                      ret, fail);
         ceCtx->signalOpSeqs[task->peer]++;
         // [RCCL] cuStreamWriteValue64 driver entry isn't available on HIP; use a
         // single-op batch write
@@ -229,12 +233,18 @@ ncclResult_t ncclRmaCePutLaunch(struct ncclComm* comm, struct ncclKernelPlan* pl
         writeOp[0].writeValue.value64 = ceCtx->signalOpSeqs[task->peer];
         writeOp[0].writeValue.flags = CU_STREAM_WRITE_VALUE_DEFAULT;
         NCCLCHECKGOTO(ncclCuStreamBatchMemOp(stream, 1, writeOp), ret, fail);
-        CUDACHECKGOTO(cudaMemcpyAsync(peerSignal, ceCtx->signalOpSeqsDev, sizeof(uint64_t), cudaMemcpyDeviceToDevice, stream), ret, fail);
+        CUDACHECKGOTO(cudaMemcpyAsync(peerSignal, ceCtx->signalOpSeqsDev, sizeof(uint64_t), cudaMemcpyDeviceToDevice,
+                                      stream),
+                      ret, fail);
       } else {
         // Graph: write signal=1 to peer's graphSignalsDev (separate from non-graph signals)
         void* peerGraphSignal;
-        NCCLCHECKGOTO(ncclDevrGetLsaRankPtr(comm, ceCtx->signalsWin, ceCtx->graphSignalOffset + rankSlot, peerLsaRank, &peerGraphSignal), ret, fail);
-        CUDACHECKGOTO(cudaMemcpyAsync(peerGraphSignal, ceCtx->signalConstOneDev, sizeof(uint64_t), cudaMemcpyDeviceToDevice, stream), ret, fail);
+        NCCLCHECKGOTO(ncclDevrGetLsaRankPtr(comm, ceCtx->signalsWin, ceCtx->graphSignalOffset + rankSlot, peerLsaRank,
+                                            &peerGraphSignal),
+                      ret, fail);
+        CUDACHECKGOTO(cudaMemcpyAsync(peerGraphSignal, ceCtx->signalConstOneDev, sizeof(uint64_t),
+                                      cudaMemcpyDeviceToDevice, stream),
+                      ret, fail);
       }
     }
 
@@ -248,8 +258,7 @@ fail:
   goto exit;
 }
 
-
-ncclResult_t ncclRmaCeWaitLaunch(struct ncclComm* comm, struct ncclKernelPlan* plan, cudaStream_t stream){
+ncclResult_t ncclRmaCeWaitLaunch(struct ncclComm* comm, struct ncclKernelPlan* plan, cudaStream_t stream) {
   ncclResult_t ret = ncclSuccess;
   hipStreamBatchMemOpParams* batchParams = nullptr;
 
@@ -291,8 +300,7 @@ ncclResult_t ncclRmaCeWaitLaunch(struct ncclComm* comm, struct ncclKernelPlan* p
         opIdx++;
       }
       NCCLCHECKGOTO(ncclCuStreamBatchMemOp(stream, opIdx, batchParams), ret, fail);
-    }
-    else {
+    } else {
       // Graph: wait-reset-ack cycle using separate graphSignalsDev (isolated from non-graph)
       for (int i = 0; i < task->npeers; i++) {
         int peerRank = task->peers[i];
@@ -313,8 +321,13 @@ ncclResult_t ncclRmaCeWaitLaunch(struct ncclComm* comm, struct ncclKernelPlan* p
           NCCLCHECKGOTO(ncclCuStreamBatchMemOp(stream, 2, signalOps), ret, fail);
 
           void* peerAck;
-          NCCLCHECKGOTO(ncclDevrGetLsaRankPtr(comm, ceCtx->signalsWin, ceCtx->graphAckOffset + comm->rank * sizeof(uint64_t), peerLsaRank, &peerAck), ret, fail);
-          CUDACHECKGOTO(cudaMemcpyAsync(peerAck, ceCtx->signalConstOneDev, sizeof(uint64_t), cudaMemcpyDeviceToDevice, stream), ret, fail);
+          NCCLCHECKGOTO(ncclDevrGetLsaRankPtr(comm, ceCtx->signalsWin,
+                                              ceCtx->graphAckOffset + comm->rank * sizeof(uint64_t), peerLsaRank,
+                                              &peerAck),
+                        ret, fail);
+          CUDACHECKGOTO(cudaMemcpyAsync(peerAck, ceCtx->signalConstOneDev, sizeof(uint64_t), cudaMemcpyDeviceToDevice,
+                                        stream),
+                        ret, fail);
         }
       }
     }

--- a/projects/rccl/src/rma/rma_proxy.cc
+++ b/projects/rccl/src/rma/rma_proxy.cc
@@ -34,7 +34,6 @@ NCCL_PARAM(RmaProxyDumpSignal, "RMA_PROXY_DUMP_SIGNAL", -1);
 NCCL_PARAM(RmaProxyQueueSize, "RMA_PROXY_QUEUE_SIZE", -1);
 RCCL_PARAM(RmaProxyUseDMABUF, "RMA_USE_DMABUF", 0);
 
-
 #include <signal.h>
 static ncclRmaProxyState* ncclLastRmaProxyState;
 
@@ -43,9 +42,8 @@ void ncclDumpRmaProxyState(int signal);
 
 // ---- Internal helpers ----
 
-#if !defined(__HIP_PLATFORM_AMD__) && ! defined(__HIPCC__)
-static ncclResult_t getDmaBufFd(void *addr, size_t length, int *fd,
-                                bool forceNonDataDirect = false) {
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
+static ncclResult_t getDmaBufFd(void* addr, size_t length, int* fd, bool forceNonDataDirect = false) {
   if (ncclParamDmaBufEnable() == 0) return ncclInvalidUsage;
 
 #if CUDA_VERSION >= 11070
@@ -55,13 +53,13 @@ static ncclResult_t getDmaBufFd(void *addr, size_t length, int *fd,
 
 #if CUDA_VERSION >= 12080
   if (ncclParamIbDataDirect() && !forceNonDataDirect) {
-    CUresult status = pfn_cuMemGetHandleForAddressRange(
-      (void *)fd, (CUdeviceptr)addr, alignedSize, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
-      CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE);
+    CUresult status =
+      pfn_cuMemGetHandleForAddressRange((void*)fd, (CUdeviceptr)addr, alignedSize, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
+                                        CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE);
     if (status == CUDA_SUCCESS) return ncclSuccess;
   }
 #endif
-  CUresult status = pfn_cuMemGetHandleForAddressRange((void *)fd, (CUdeviceptr)addr, alignedSize,
+  CUresult status = pfn_cuMemGetHandleForAddressRange((void*)fd, (CUdeviceptr)addr, alignedSize,
                                                       CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0);
   if (status == CUDA_SUCCESS) return ncclSuccess;
 #endif
@@ -69,8 +67,7 @@ static ncclResult_t getDmaBufFd(void *addr, size_t length, int *fd,
   return ncclInvalidUsage;
 }
 #else
-static ncclResult_t getDmaBufFd(void *addr, size_t length, int *fd,
-                                bool sym_buffer) {
+static ncclResult_t getDmaBufFd(void* addr, size_t length, int* fd, bool sym_buffer) {
   if (ncclParamDmaBufEnable() == 0) return ncclInvalidUsage;
 #if HIP_VERSION >= 70000000
   static size_t hostPageSize = ncclOsGetPageSize();
@@ -80,7 +77,7 @@ static ncclResult_t getDmaBufFd(void *addr, size_t length, int *fd,
   ALIGN_SIZE(alignedSize, hostPageSize);
 #if HIP_VERSION >= 71260540
   if (ncclCuMemEnable() && sym_buffer) {
-    CUCHECK(cuMemGetHandleForAddressRange((void *)fd, (CUdeviceptr)addr, alignedSize,
+    CUCHECK(cuMemGetHandleForAddressRange((void*)fd, (CUdeviceptr)addr, alignedSize,
                                           CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0));
   } else
 #endif
@@ -97,9 +94,9 @@ fail:
 
 // Check if the GIN plugin supports DMA-BUF, if so we can try to get the DMA-BUF handle from CUDA,
 // if that fails we fallback to non-DMA-BUF
-static ncclResult_t ncclRmaProxyRegMrSym(ncclGin_t *ginComm, void *ginCollComm, ncclNetProperties_t props, void *addr,
-                                         size_t size, int type, int mr_flags, void **mhandle,
-                                         void **ginHandle, bool sym_buffer=false) {
+static ncclResult_t ncclRmaProxyRegMrSym(ncclGin_t* ginComm, void* ginCollComm, ncclNetProperties_t props, void* addr,
+                                         size_t size, int type, int mr_flags, void** mhandle, void** ginHandle,
+                                         bool sym_buffer = false) {
   if (type == NCCL_PTR_HOST) {
     NCCLCHECK(ginComm->regMrSym(ginCollComm, addr, size, type, mr_flags, mhandle, ginHandle));
   } else if (type == NCCL_PTR_CUDA) {
@@ -109,8 +106,8 @@ static ncclResult_t ncclRmaProxyRegMrSym(ncclGin_t *ginComm, void *ginCollComm, 
       int dmabufFd = -1;
       dmabufResult = getDmaBufFd(addr, size, &dmabufFd, sym_buffer);
       if (dmabufResult == ncclSuccess) {
-        registrationResult = ginComm->regMrSymDmaBuf(ginCollComm, addr, size, type, 0, dmabufFd,
-                                                     mr_flags, mhandle, ginHandle);
+        registrationResult =
+          ginComm->regMrSymDmaBuf(ginCollComm, addr, size, type, 0, dmabufFd, mr_flags, mhandle, ginHandle);
         close(dmabufFd);
       }
     }
@@ -124,11 +121,14 @@ static ncclResult_t ncclRmaProxyRegMrSym(ncclGin_t *ginComm, void *ginCollComm, 
 
   return ncclSuccess;
 }
-static uint64_t isPowerOfTwo(uint64_t n) { return (n > 0) && ((n & (n - 1)) == 0); }
+static uint64_t isPowerOfTwo(uint64_t n) {
+  return (n > 0) && ((n & (n - 1)) == 0);
+}
 
 // ---- Context lifecycle ----
 
-static ncclResult_t ncclRmaProxyCtxAlloc(struct ncclComm* comm, ncclGin_t* ginComm, struct ncclRmaProxyCtx* rmaProxyCtx) {
+static ncclResult_t ncclRmaProxyCtxAlloc(struct ncclComm* comm, ncclGin_t* ginComm,
+                                         struct ncclRmaProxyCtx* rmaProxyCtx) {
   // The clean up in case of failure will be done by the ncclRmaProxyDestroyContext function invoked by the caller.
   // Allocate the signals on the GPU and then register the memory region with the GIN plugin.
   // Enforcing strong ordering on the signals mr is vital to ensure ordering between puts and signals.
@@ -137,27 +137,27 @@ static ncclResult_t ncclRmaProxyCtxAlloc(struct ncclComm* comm, ncclGin_t* ginCo
   if (rcclParamRmaProxyUseDMABUF() == 0) {
     props_tmp.ptrSupport &= ~NCCL_PTR_DMABUF;
   }
-#if !defined(__HIP_PLATFORM_AMD__) && ! defined(__HIPCC__)
-  NCCLCHECK(ncclCuMemAlloc((void **)&rmaProxyCtx->signalsDev, &rmaProxyCtx->signalsCumemhandle,
-                           CU_MEM_HANDLE_TYPE_NONE, signalsBufSize , comm->memManager));
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
+  NCCLCHECK(ncclCuMemAlloc((void**)&rmaProxyCtx->signalsDev, &rmaProxyCtx->signalsCumemhandle, CU_MEM_HANDLE_TYPE_NONE,
+                           signalsBufSize, comm->memManager));
 #else
   CUDACHECK(hipExtMallocWithFlags((void**)&rmaProxyCtx->signalsDev, signalsBufSize, hipDeviceMallocUncached));
 #endif
   CUDACHECK(cudaMemset(rmaProxyCtx->signalsDev, 0, signalsBufSize));
   NCCLCHECK(ncclRmaProxyRegMrSym(ginComm, rmaProxyCtx->ginCollComm, props_tmp, rmaProxyCtx->signalsDev, signalsBufSize,
-                                 NCCL_PTR_CUDA, NCCL_NET_MR_FLAG_FORCE_SO,
-                                 &rmaProxyCtx->signalsMhandle, &rmaProxyCtx->signalsGinHandle));
+                                 NCCL_PTR_CUDA, NCCL_NET_MR_FLAG_FORCE_SO, &rmaProxyCtx->signalsMhandle,
+                                 &rmaProxyCtx->signalsGinHandle));
   // Allocate the host buffer to track the expected values of the signals
   NCCLCHECK(ncclCalloc(&rmaProxyCtx->signalsHost, signalsBufSize));
   // Allocate the sequence numbers for the per-rank network function descriptors
   // These are allocated as CPU-accessible memory (either GDR or host memory)
-  NCCLCHECK(allocMemCPUAccessible(&rmaProxyCtx->opSeqs, &rmaProxyCtx->opSeqsDev,
-                                  comm->nRanks, 0, &rmaProxyCtx->opSeqsGdrHandle, comm->memManager));
+  NCCLCHECK(allocMemCPUAccessible(&rmaProxyCtx->opSeqs, &rmaProxyCtx->opSeqsDev, comm->nRanks, 0,
+                                  &rmaProxyCtx->opSeqsGdrHandle, comm->memManager));
   for (int i = 0; i < comm->nRanks; i++) rmaProxyCtx->opSeqs[i] = 1;
-  NCCLCHECK(allocMemCPUAccessible(&rmaProxyCtx->readySeqs, &rmaProxyCtx->readySeqsDev,
-                                  comm->nRanks, 0, &rmaProxyCtx->readySeqsGdrHandle, comm->memManager));
-  NCCLCHECK(allocMemCPUAccessible(&rmaProxyCtx->doneSeqs, &rmaProxyCtx->doneSeqsDev,
-                                  comm->nRanks, 0, &rmaProxyCtx->doneSeqsGdrHandle, comm->memManager));
+  NCCLCHECK(allocMemCPUAccessible(&rmaProxyCtx->readySeqs, &rmaProxyCtx->readySeqsDev, comm->nRanks, 0,
+                                  &rmaProxyCtx->readySeqsGdrHandle, comm->memManager));
+  NCCLCHECK(allocMemCPUAccessible(&rmaProxyCtx->doneSeqs, &rmaProxyCtx->doneSeqsDev, comm->nRanks, 0,
+                                  &rmaProxyCtx->doneSeqsGdrHandle, comm->memManager));
   // Sanitize and set up the lock-free circular buffer queue size
   uint64_t queueSize = ncclParamRmaProxyQueueSize();
   uint32_t maxRequests = NCCL_NET_MAX_REQUESTS * rmaProxyCtx->props.maxRecvs;
@@ -166,18 +166,17 @@ static ncclResult_t ncclRmaProxyCtxAlloc(struct ncclComm* comm, ncclGin_t* ginCo
   }
   if (queueSize > maxRequests) {
     INFO(NCCL_NET,
-         "NCCL_RMA_PROXY_QUEUE_SIZE is greater than the maximum outstanding requests (%d), using the default/maximum value instead",
+         "NCCL_RMA_PROXY_QUEUE_SIZE is greater than the maximum outstanding requests (%d), using the default/maximum "
+         "value instead",
          maxRequests);
     queueSize = maxRequests;
   }
   if (queueSize < 1) {
-    INFO(NCCL_NET,
-         "NCCL_RMA_PROXY_QUEUE_SIZE is less than 1, using the default/maximum value instead");
+    INFO(NCCL_NET, "NCCL_RMA_PROXY_QUEUE_SIZE is less than 1, using the default/maximum value instead");
     queueSize = maxRequests;
   }
   if (!isPowerOfTwo(queueSize)) {
-    INFO(NCCL_NET,
-         "NCCL_RMA_PROXY_QUEUE_SIZE is not a power of two, using the default/maximum value instead");
+    INFO(NCCL_NET, "NCCL_RMA_PROXY_QUEUE_SIZE is not a power of two, using the default/maximum value instead");
     queueSize = maxRequests;
   }
   rmaProxyCtx->queueSize = queueSize;
@@ -189,7 +188,9 @@ static ncclResult_t ncclRmaProxyCtxAlloc(struct ncclComm* comm, ncclGin_t* ginCo
   NCCLCHECK(ncclCalloc(&rmaProxyCtx->cis, comm->nRanks));
 
   // Allocate per-peer InProgress queues (kept as linked list, single consumer)
-  rmaProxyCtx->inProgressQueues = ncclMemoryStackAlloc<struct ncclIntruQueue<struct ncclRmaProxyDesc, &ncclRmaProxyDesc::next>>(&comm->memPermanent, comm->nRanks);
+  rmaProxyCtx->inProgressQueues =
+    ncclMemoryStackAlloc<struct ncclIntruQueue<struct ncclRmaProxyDesc, &ncclRmaProxyDesc::next>>(&comm->memPermanent,
+                                                                                                  comm->nRanks);
   for (int i = 0; i < comm->nRanks; i++) {
     ncclIntruQueueConstruct(&rmaProxyCtx->inProgressQueues[i]);
   }
@@ -197,7 +198,8 @@ static ncclResult_t ncclRmaProxyCtxAlloc(struct ncclComm* comm, ncclGin_t* ginCo
   return ncclSuccess;
 }
 
-static ncclResult_t ncclRmaProxyCtxAllocGraph(struct ncclComm* comm, ncclGin_t* ginComm, struct ncclRmaProxyCtx* rmaProxyCtx) {
+static ncclResult_t ncclRmaProxyCtxAllocGraph(struct ncclComm* comm, ncclGin_t* ginComm,
+                                              struct ncclRmaProxyCtx* rmaProxyCtx) {
   // The clean up in case of failure will be done by the ncclRmaProxyDestroyContext function invoked by the caller.
   size_t signalsBufSize = (comm->nRanks + 1) * sizeof(uint64_t);
 
@@ -209,45 +211,47 @@ static ncclResult_t ncclRmaProxyCtxAllocGraph(struct ncclComm* comm, ncclGin_t* 
   }
 
   // Allocate the CPU-accessible signal for graph capture and then register the memory region with the GIN plugin.
-  NCCLCHECK(allocMemCPUAccessible(&rmaProxyCtx->cpuAccessSignals, &rmaProxyCtx->cpuAccessSignalsDev,
-                                  comm->nRanks + 1, 0, &rmaProxyCtx->cpuAccessSignalsGdrHandle, comm->memManager));
-  NCCLCHECK(ncclRmaProxyRegMrSym(ginComm, rmaProxyCtx->ginCollComm, props_tmp, rmaProxyCtx->cpuAccessSignalsDev, signalsBufSize,
-                                 NCCL_PTR_CUDA, NCCL_NET_MR_FLAG_FORCE_SO,
+  NCCLCHECK(allocMemCPUAccessible(&rmaProxyCtx->cpuAccessSignals, &rmaProxyCtx->cpuAccessSignalsDev, comm->nRanks + 1,
+                                  0, &rmaProxyCtx->cpuAccessSignalsGdrHandle, comm->memManager));
+  NCCLCHECK(ncclRmaProxyRegMrSym(ginComm, rmaProxyCtx->ginCollComm, props_tmp, rmaProxyCtx->cpuAccessSignalsDev,
+                                 signalsBufSize, NCCL_PTR_CUDA, NCCL_NET_MR_FLAG_FORCE_SO,
                                  &rmaProxyCtx->cpuAccessSignalsMhandle, &rmaProxyCtx->cpuAccessSignalsGinHandle));
   // Allocate the host buffer to track the expected values of the signals
   NCCLCHECK(ncclCalloc(&rmaProxyCtx->cpuAccessSignalsHost, signalsBufSize));
 
   // Allocate the flush buffer on the GPU and then register the memory region with the GIN plugin.
   size_t flushBufSize = comm->nRanks * sizeof(uint64_t);
-#if !defined(__HIP_PLATFORM_AMD__) && ! defined(__HIPCC__)
-  NCCLCHECK(ncclCuMemAlloc((void **)&rmaProxyCtx->flushBufDev, &rmaProxyCtx->flushBufCumemhandle,
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
+  NCCLCHECK(ncclCuMemAlloc((void**)&rmaProxyCtx->flushBufDev, &rmaProxyCtx->flushBufCumemhandle,
                            CU_MEM_HANDLE_TYPE_NONE, flushBufSize, comm->memManager));
 #else
   CUDACHECK(hipExtMallocWithFlags((void**)&rmaProxyCtx->flushBufDev, flushBufSize, hipDeviceMallocFinegrained));
 #endif
   CUDACHECK(cudaMemset(rmaProxyCtx->flushBufDev, 0, flushBufSize));
-  NCCLCHECK(ncclRmaProxyRegMrSym(ginComm, rmaProxyCtx->ginCollComm, rmaProxyCtx->props, rmaProxyCtx->flushBufDev, flushBufSize,
-                                  NCCL_PTR_HOST, NCCL_NET_MR_FLAG_FORCE_SO,
-                                  &rmaProxyCtx->flushBufMhandle, &rmaProxyCtx->flushBufGinHandle));
+  NCCLCHECK(ncclRmaProxyRegMrSym(ginComm, rmaProxyCtx->ginCollComm, rmaProxyCtx->props, rmaProxyCtx->flushBufDev,
+                                 flushBufSize, NCCL_PTR_HOST, NCCL_NET_MR_FLAG_FORCE_SO, &rmaProxyCtx->flushBufMhandle,
+                                 &rmaProxyCtx->flushBufGinHandle));
   // Allocate and initialize persistent descriptor queue
-  rmaProxyCtx->persistentQueues = ncclMemoryStackAlloc<struct ncclIntruQueue<struct ncclRmaProxyDesc, &ncclRmaProxyDesc::next>>(&comm->memPermanent, comm->nRanks);
+  rmaProxyCtx->persistentQueues =
+    ncclMemoryStackAlloc<struct ncclIntruQueue<struct ncclRmaProxyDesc, &ncclRmaProxyDesc::next>>(&comm->memPermanent,
+                                                                                                  comm->nRanks);
   for (int i = 0; i < comm->nRanks; i++) {
     ncclIntruQueueConstruct(&rmaProxyCtx->persistentQueues[i]);
   }
   return ncclSuccess;
 }
 
-ncclResult_t ncclRmaProxyCreateContext(struct ncclComm *comm, void *collComm, ncclNetProperties_t props,
-                                       void **outRmaProxyCtx, ncclNetDeviceHandle_t **outDevHandle) {
+ncclResult_t ncclRmaProxyCreateContext(struct ncclComm* comm, void* collComm, ncclNetProperties_t props,
+                                       void** outRmaProxyCtx, ncclNetDeviceHandle_t** outDevHandle) {
   ncclResult_t ret = ncclSuccess;
   // Get the GIN plugin interface
-  ncclGin_t *ginComm = (ncclGin_t *)comm->rmaState.rmaProxyState.ncclGin;
-  ncclNetDeviceHandle_t *devHandle = nullptr;
+  ncclGin_t* ginComm = (ncclGin_t*)comm->rmaState.rmaProxyState.ncclGin;
+  ncclNetDeviceHandle_t* devHandle = nullptr;
 
-  ncclGinConfig_t config = { 0, 0, 1, 0, comm->config.trafficClass };
+  ncclGinConfig_t config = {0, 0, 1, 0, comm->config.trafficClass};
 
   // Allocate the RMA proxy context
-  struct ncclRmaProxyCtx *rmaProxyCtx = nullptr;
+  struct ncclRmaProxyCtx* rmaProxyCtx = nullptr;
   NCCLCHECKGOTO(ncclCalloc(&rmaProxyCtx, 1), ret, fail);
 
   rmaProxyCtx->comm = comm;
@@ -262,7 +266,7 @@ ncclResult_t ncclRmaProxyCreateContext(struct ncclComm *comm, void *collComm, nc
   NCCLCHECKGOTO(ncclCalloc(&devHandle, 1), ret, fail);
   devHandle->netDeviceType = NCCL_NET_DEVICE_GIN_PROXY;
   devHandle->netDeviceVersion = NCCL_GIN_PROXY_VERSION;
-  devHandle->handle = (void *)rmaProxyCtx;
+  devHandle->handle = (void*)rmaProxyCtx;
   devHandle->size = 0;
   devHandle->needsProxyProgress = 1;
 
@@ -277,9 +281,9 @@ fail:
   return ret;
 }
 
-ncclResult_t ncclRmaProxyDestroyContext(ncclGin_t* ginComm, void* rmaProxyCtx){
+ncclResult_t ncclRmaProxyDestroyContext(ncclGin_t* ginComm, void* rmaProxyCtx) {
   if (!rmaProxyCtx) return ncclSuccess;
-  struct ncclRmaProxyCtx *ctx = (struct ncclRmaProxyCtx *)rmaProxyCtx;
+  struct ncclRmaProxyCtx* ctx = (struct ncclRmaProxyCtx*)rmaProxyCtx;
 
   NCCLCHECK(ginComm->destroyContext(ctx->ginCtx));
 
@@ -291,7 +295,7 @@ ncclResult_t ncclRmaProxyDestroyContext(ncclGin_t* ginComm, void* rmaProxyCtx){
       // Free any remaining pending descriptors
       for (uint32_t j = ci; j < pi; j++) {
         uint32_t idx = j & (ctx->queueSize - 1);
-        struct ncclRmaProxyDesc *desc = ctx->circularBuffers[i * ctx->queueSize + idx];
+        struct ncclRmaProxyDesc* desc = ctx->circularBuffers[i * ctx->queueSize + idx];
         if (desc != NULL) {
           NCCLCHECK(ncclRmaProxyDestroyDescNonPersistent(desc));
         }
@@ -307,9 +311,9 @@ ncclResult_t ncclRmaProxyDestroyContext(ncclGin_t* ginComm, void* rmaProxyCtx){
   // Free InProgress queues and their Descs
   if (ctx->inProgressQueues) {
     for (int i = 0; i < ctx->comm->nRanks; i++) {
-      struct ncclRmaProxyDesc *desc = ncclIntruQueueHead(&ctx->inProgressQueues[i]);
+      struct ncclRmaProxyDesc* desc = ncclIntruQueueHead(&ctx->inProgressQueues[i]);
       while (desc != NULL) {
-        struct ncclRmaProxyDesc *nextDesc = desc->next;
+        struct ncclRmaProxyDesc* nextDesc = desc->next;
         ncclIntruQueueDequeue(&ctx->inProgressQueues[i]);
         NCCLCHECK(ncclRmaProxyDestroyDescNonPersistent(desc));
         desc = nextDesc;
@@ -320,9 +324,9 @@ ncclResult_t ncclRmaProxyDestroyContext(ncclGin_t* ginComm, void* rmaProxyCtx){
   // Free persistent descriptor queue and their Descs
   if (ctx->persistentQueues) {
     for (int i = 0; i < ctx->comm->nRanks; i++) {
-      struct ncclRmaProxyDesc *desc = ncclIntruQueueHead(&ctx->persistentQueues[i]);
+      struct ncclRmaProxyDesc* desc = ncclIntruQueueHead(&ctx->persistentQueues[i]);
       while (desc != NULL) {
-        struct ncclRmaProxyDesc *nextDesc = desc->next;
+        struct ncclRmaProxyDesc* nextDesc = desc->next;
         ncclIntruQueueDequeue(&ctx->persistentQueues[i]);
         NCCLCHECK(ncclRmaProxyDestroyDescPersistent(ctx->comm, desc));
         desc = nextDesc;
@@ -338,16 +342,15 @@ ncclResult_t ncclRmaProxyDestroyContext(ncclGin_t* ginComm, void* rmaProxyCtx){
   // Free signals
   if (ginComm && ctx->ginCollComm && ctx->signalsMhandle)
     NCCLCHECK(ginComm->deregMrSym(ctx->ginCollComm, ctx->signalsMhandle));
-#if !defined(__HIP_PLATFORM_AMD__) && ! defined(__HIPCC__)
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
   if (ctx->signalsDev) NCCLCHECK(ncclCudaFree(ctx->signalsDev, ctx->comm->memManager));
 #else
   if (ctx->signalsDev) CUDACHECK(hipFree(ctx->signalsDev));
 #endif
 
   // Free flush buffer
-  if (ginComm && ctx->ginCollComm && ctx->flushBufMhandle)
-    ginComm->deregMrSym(ctx->ginCollComm, ctx->flushBufMhandle);
-#if !defined(__HIP_PLATFORM_AMD__) && ! defined(__HIPCC__)
+  if (ginComm && ctx->ginCollComm && ctx->flushBufMhandle) ginComm->deregMrSym(ctx->ginCollComm, ctx->flushBufMhandle);
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
   if (ctx->flushBufDev) ncclCudaFree(ctx->flushBufDev, ctx->comm->memManager);
 #else
   if (ctx->flushBufDev) CUDACHECK(hipFree(ctx->flushBufDev));
@@ -356,7 +359,8 @@ ncclResult_t ncclRmaProxyDestroyContext(ncclGin_t* ginComm, void* rmaProxyCtx){
   // Free CPU-accessible signals
   if (ginComm && ctx->ginCollComm && ctx->cpuAccessSignalsMhandle)
     ginComm->deregMrSym(ctx->ginCollComm, ctx->cpuAccessSignalsMhandle);
-  if (ctx->cpuAccessSignals) freeMemCPUAccessible(ctx->cpuAccessSignals, ctx->cpuAccessSignalsGdrHandle, ctx->comm->memManager);
+  if (ctx->cpuAccessSignals)
+    freeMemCPUAccessible(ctx->cpuAccessSignals, ctx->cpuAccessSignalsGdrHandle, ctx->comm->memManager);
 
   // Free host signals buffers
   free(ctx->signalsHost);
@@ -373,7 +377,7 @@ ncclResult_t ncclRmaProxyDestroyContext(ncclGin_t* ginComm, void* rmaProxyCtx){
 // ---- Memory registration ----
 ncclResult_t ncclRmaProxyRegister(struct ncclComm* comm, void* address, size_t size,
                                   void* rmaHostWins[NCCL_GIN_MAX_CONNECTIONS],
-                                  ncclGinWindow_t rmaDevWins[NCCL_GIN_MAX_CONNECTIONS]){
+                                  ncclGinWindow_t rmaDevWins[NCCL_GIN_MAX_CONNECTIONS]) {
   struct ncclRmaProxyState* rmaProxyState = &comm->rmaState.rmaProxyState;
   for (int n = 0; n < rmaProxyState->ginCommCount; n++) {
     ncclNetProperties_t props_tmp = rmaProxyState->props[n];
@@ -387,7 +391,7 @@ ncclResult_t ncclRmaProxyRegister(struct ncclComm* comm, void* address, size_t s
     }
 #endif
     NCCLCHECK(ncclRmaProxyRegMrSym(rmaProxyState->ncclGin, rmaProxyState->ginComms[n], props_tmp, address, size,
-                                       NCCL_PTR_CUDA, 0, &rmaHostWins[n], &rmaDevWins[n], true));
+                                   NCCL_PTR_CUDA, 0, &rmaHostWins[n], &rmaDevWins[n], true));
     if (rmaHostWins[n] == NULL) {
       WARN("rank %d - GIN Symmetric register failed: buff %p, size %ld", comm->rank, address, size);
       return ncclSystemError;
@@ -396,7 +400,7 @@ ncclResult_t ncclRmaProxyRegister(struct ncclComm* comm, void* address, size_t s
   return ncclSuccess;
 }
 
-ncclResult_t ncclRmaProxyDeregister(struct ncclComm* comm, void* rmaHostWins[NCCL_GIN_MAX_CONNECTIONS]){
+ncclResult_t ncclRmaProxyDeregister(struct ncclComm* comm, void* rmaHostWins[NCCL_GIN_MAX_CONNECTIONS]) {
   struct ncclRmaProxyState* rmaProxyState = &comm->rmaState.rmaProxyState;
   for (int n = 0; n < rmaProxyState->ginCommCount; n++) {
     NCCLCHECK(rmaProxyState->ncclGin->deregMrSym(rmaProxyState->ginComms[n], rmaHostWins[n]));
@@ -415,11 +419,11 @@ void* ncclRmaProxyProgressThread(struct ncclRmaProxyState* rmaProxyState_) {
     std::unique_lock<std::mutex> lock(rmaProxyState->mutex);
     if (rmaProxyState->ginProgress == 1) {
       lock.unlock();
-      for (int n=0; n<rmaProxyState->rmaProxyCtxCount; n++) {
+      for (int n = 0; n < rmaProxyState->rmaProxyCtxCount; n++) {
         ncclResult_t ret = ncclRmaProxyProgress(rmaProxyState->ncclGin, rmaProxyState->rmaProxyCtxs[n]);
         if (ret != ncclSuccess) {
           COMPILER_ATOMIC_STORE_32(&rmaProxyState->asyncResult, ret, std::memory_order_release);
-          INFO(NCCL_ALL,"%s:%d -> %d [RMA Proxy Progress Thread]", __FILE__, __LINE__, ret);
+          INFO(NCCL_ALL, "%s:%d -> %d [RMA Proxy Progress Thread]", __FILE__, __LINE__, ret);
           rmaProxyState->ginProgress = -2;
           return NULL;
         }
@@ -436,7 +440,8 @@ void* ncclRmaProxyProgressThread(struct ncclRmaProxyState* rmaProxyState_) {
     } else if (rmaProxyState->ginProgress == 0) {
       rmaProxyState->cond.wait(lock);
     } else {
-      INFO(NCCL_ALL,"%s:%d -> [RMA Proxy Progress Thread] state unknown %d", __FILE__, __LINE__, rmaProxyState->ginProgress);
+      INFO(NCCL_ALL, "%s:%d -> [RMA Proxy Progress Thread] state unknown %d", __FILE__, __LINE__,
+           rmaProxyState->ginProgress);
       rmaProxyState->ginProgress = -2;
       return NULL;
     }
@@ -445,7 +450,7 @@ void* ncclRmaProxyProgressThread(struct ncclRmaProxyState* rmaProxyState_) {
 
 ncclResult_t ncclRmaProxyConnectOnce(struct ncclComm* comm) {
   ncclResult_t ret = ncclSuccess;
-  struct ncclRmaProxyState *rmaProxyState = &comm->rmaState.rmaProxyState;
+  struct ncclRmaProxyState* rmaProxyState = &comm->rmaState.rmaProxyState;
   rmaProxyState->comm = comm;
   if (rmaProxyState->ncclGin == NULL) {
     WARN("GIN not supported.");
@@ -507,16 +512,13 @@ ncclResult_t ncclRmaProxyConnectOnce(struct ncclComm* comm) {
 
   for (int n = 0; n < ginCommCount; n++) {
     void* listenComm;
-    NCCLCHECKGOTO(
-      rmaProxyState->ncclGin->listen(rmaProxyState->ginInstance, localGinDevs[n],
-                                allHandles + NCCL_NET_HANDLE_MAXSIZE * comm->rank, &listenComm),
-      ret, fail);
-    NCCLCHECKGOTO(bootstrapAllGather(comm->bootstrap, allHandles, NCCL_NET_HANDLE_MAXSIZE), ret,
-                  fail);
-    NCCLCHECKGOTO(
-      rmaProxyState->ncclGin->connect(comm->netContext, handles, comm->nRanks, comm->rank,
-                                      listenComm, rmaProxyState->ginComms + n),
-      ret, fail);
+    NCCLCHECKGOTO(rmaProxyState->ncclGin->listen(rmaProxyState->ginInstance, localGinDevs[n],
+                                                 allHandles + NCCL_NET_HANDLE_MAXSIZE * comm->rank, &listenComm),
+                  ret, fail);
+    NCCLCHECKGOTO(bootstrapAllGather(comm->bootstrap, allHandles, NCCL_NET_HANDLE_MAXSIZE), ret, fail);
+    NCCLCHECKGOTO(rmaProxyState->ncclGin->connect(comm->netContext, handles, comm->nRanks, comm->rank, listenComm,
+                                                  rmaProxyState->ginComms + n),
+                  ret, fail);
     NCCLCHECKGOTO(rmaProxyState->ncclGin->getProperties(localGinDevs[n], &rmaProxyState->props[n]), ret, fail);
     NCCLCHECKGOTO(rmaProxyState->ncclGin->closeListen(listenComm), ret, fail);
   }
@@ -533,7 +535,7 @@ ncclResult_t ncclRmaProxyConnectOnce(struct ncclComm* comm) {
     // Round-robin mapping to physical GIN communicator contexts
     int ginCommIdx = n % rmaProxyState->ginCommCount;
     NCCLCHECKGOTO(ncclRmaProxyCreateContext(comm, rmaProxyState->ginComms[ginCommIdx], rmaProxyState->props[ginCommIdx],
-                                              &rmaProxyState->rmaProxyCtxs[n], &rmaProxyState->rmaProxyDevHandles[n]),
+                                            &rmaProxyState->rmaProxyCtxs[n], &rmaProxyState->rmaProxyDevHandles[n]),
                   ret, fail);
   }
 
@@ -548,7 +550,8 @@ ncclResult_t ncclRmaProxyConnectOnce(struct ncclComm* comm) {
     ncclSetThreadName(rmaProxyState->thread, "NCCL RMA Proxy Progress%2d", comm->cudaDev);
   }
 
-  INFO(NCCL_INIT, "Rank %d ncclRmaProxyConnectOnce: ginCommCount %d rmaProxyCtxCount:%d needsProxyProgress %d", comm->rank, ginCommCount, rmaProxyState->rmaProxyCtxCount, rmaProxyState->needsProxyProgress);
+  INFO(NCCL_INIT, "Rank %d ncclRmaProxyConnectOnce: ginCommCount %d rmaProxyCtxCount:%d needsProxyProgress %d",
+       comm->rank, ginCommCount, rmaProxyState->rmaProxyCtxCount, rmaProxyState->needsProxyProgress);
 
 exit:
   if (ret == ncclSuccess) rmaProxyState->connected = true;
@@ -632,8 +635,8 @@ ncclResult_t dumpRmaProxyState(struct ncclRmaProxyState* rmaProxyState) {
           uint64_t opSeq = COMPILER_ATOMIC_LOAD(&ctx->opSeqs[peer], std::memory_order_acquire);
           uint32_t pi = COMPILER_ATOMIC_LOAD_32(&ctx->pis[peer], std::memory_order_acquire);
           uint32_t ci = COMPILER_ATOMIC_LOAD_32(&ctx->cis[peer], std::memory_order_acquire);
-          printf("      Peer %d: readySeq: %lu, doneSeq: %lu, opSeq: %lu, PI: %u, CI: %u\n",
-                 peer, readySeq, doneSeq, opSeq, pi, ci);
+          printf("      Peer %d: readySeq: %lu, doneSeq: %lu, opSeq: %lu, PI: %u, CI: %u\n", peer, readySeq, doneSeq,
+                 opSeq, pi, ci);
 
           // Count and print pending Descs from circular buffer
           int pendingCount = pi - ci;
@@ -642,8 +645,8 @@ ncclResult_t dumpRmaProxyState(struct ncclRmaProxyState* rmaProxyState) {
             uint32_t idx = j & (ctx->queueSize - 1);
             struct ncclRmaProxyDesc* desc = ctx->circularBuffers[peer * ctx->queueSize + idx];
             if (desc != NULL) {
-              printf("          Desc: seq=%lu targetRank=%d size=%zu\n",
-                    desc->opSeq, desc->putSignal.targetRank, desc->putSignal.size);
+              printf("          Desc: seq=%lu targetRank=%d size=%zu\n", desc->opSeq, desc->putSignal.targetRank,
+                     desc->putSignal.size);
             }
           }
 
@@ -658,8 +661,8 @@ ncclResult_t dumpRmaProxyState(struct ncclRmaProxyState* rmaProxyState) {
           // print all in-progress Descs
           desc = ncclIntruQueueHead(&ctx->inProgressQueues[peer]);
           while (desc != NULL) {
-            printf("          Desc: seq=%lu targetRank=%d size=%zu\n",
-                  desc->opSeq, desc->putSignal.targetRank, desc->putSignal.size);
+            printf("          Desc: seq=%lu targetRank=%d size=%zu\n", desc->opSeq, desc->putSignal.targetRank,
+                   desc->putSignal.size);
             desc = desc->next;
           }
         }

--- a/projects/rccl/src/rma/rma_proxy_launch.cc
+++ b/projects/rccl/src/rma/rma_proxy_launch.cc
@@ -32,12 +32,13 @@ ncclResult_t ncclCuStreamBatchMemOp(hipStream_t stream, unsigned int numOps, hip
   for (int opIdx = 0; opIdx < numOps; opIdx++) {
     if (batchParams[opIdx].operation == CU_STREAM_MEM_OP_WRITE_VALUE_64) {
       CUCHECKGOTO(hipStreamWriteValue64(stream, batchParams[opIdx].writeValue.address,
-                                        batchParams[opIdx].writeValue.value64,
-                                       batchParams[opIdx].writeValue.flags), ret, fail);
+                                        batchParams[opIdx].writeValue.value64, batchParams[opIdx].writeValue.flags),
+                  ret, fail);
     } else if (batchParams[opIdx].operation == CU_STREAM_MEM_OP_WAIT_VALUE_64) {
       CUCHECKGOTO(hipStreamWaitValue64(stream, batchParams[opIdx].waitValue.address,
-                                        batchParams[opIdx].waitValue.value64,
-                                       batchParams[opIdx].waitValue.flags, UINT64_MAX), ret, fail);
+                                       batchParams[opIdx].waitValue.value64, batchParams[opIdx].waitValue.flags,
+                                       UINT64_MAX),
+                  ret, fail);
     }
   }
 #endif
@@ -51,8 +52,8 @@ fail:
 // ---- Descriptor build ----
 
 static ncclResult_t ncclRmaProxyPutDescFromTask(struct ncclComm* comm, struct ncclRmaProxyCtx* rmaProxyCtx,
-                          struct ncclKernelPlan* plan, struct ncclTaskRma* task, struct ncclRmaProxyDesc* desc)
-{
+                                                struct ncclKernelPlan* plan, struct ncclTaskRma* task,
+                                                struct ncclRmaProxyDesc* desc) {
   ncclResult_t ret = ncclSuccess;
   bool persistent = plan->persistent;
 
@@ -73,35 +74,37 @@ static ncclResult_t ncclRmaProxyPutDescFromTask(struct ncclComm* comm, struct nc
     desc->doneSeq = &rmaProxyCtx->doneSeqs[task->peer];
     desc->doneSeqDev = &rmaProxyCtx->doneSeqsDev[task->peer];
     desc->doneSeqGdrHandle = rmaProxyCtx->doneSeqsGdrHandle;
-  }
-  else {
+  } else {
     desc->opSeq = 1;
     // Allocation during graph capture, off the execution critical path
-    NCCLCHECKGOTO(allocMemCPUAccessible(&desc->readySeq, &desc->readySeqDev, 1, 0, &desc->readySeqGdrHandle, comm->memManager), ret, fail);
-    NCCLCHECKGOTO(allocMemCPUAccessible(&desc->doneSeq, &desc->doneSeqDev, 1, 0, &desc->doneSeqGdrHandle, comm->memManager), ret, fail);
+    NCCLCHECKGOTO(allocMemCPUAccessible(&desc->readySeq, &desc->readySeqDev, 1, 0, &desc->readySeqGdrHandle,
+                                        comm->memManager),
+                  ret, fail);
+    NCCLCHECKGOTO(allocMemCPUAccessible(&desc->doneSeq, &desc->doneSeqDev, 1, 0, &desc->doneSeqGdrHandle,
+                                        comm->memManager),
+                  ret, fail);
     desc->persistPlan = plan;
   }
 
   if (task->signalMode == NCCL_SIGNAL_NONE) {
     desc->putSignal.signal.op = 0;
-  }
-  else if (task->signalMode == NCCL_SIGNAL) {
+  } else if (task->signalMode == NCCL_SIGNAL) {
     desc->putSignal.signal.op = NCCL_NET_SIGNAL_OP_ADD;
     desc->putSignal.signal.offset = comm->rank * sizeof(uint64_t);
-    desc->putSignal.signal.signalMhandle = persistent ? rmaProxyCtx->cpuAccessSignalsMhandle : rmaProxyCtx->signalsMhandle;
+    desc->putSignal.signal.signalMhandle =
+      persistent ? rmaProxyCtx->cpuAccessSignalsMhandle : rmaProxyCtx->signalsMhandle;
     desc->putSignal.signal.val = 1;
   }
 exit:
   return ret;
 fail:
-  if (desc->readySeq)
-    freeMemCPUAccessible(desc->readySeq, desc->readySeqGdrHandle, comm->memManager);
+  if (desc->readySeq) freeMemCPUAccessible(desc->readySeq, desc->readySeqGdrHandle, comm->memManager);
   goto exit;
 }
 
 static ncclResult_t ncclRmaProxyWaitDescFromTask(struct ncclComm* comm, struct ncclRmaProxyCtx* rmaProxyCtx,
-                          struct ncclKernelPlan* plan, struct ncclTaskRma* task, struct ncclRmaProxyDesc* desc)
-{
+                                                 struct ncclKernelPlan* plan, struct ncclTaskRma* task,
+                                                 struct ncclRmaProxyDesc* desc) {
   ncclResult_t ret = ncclSuccess;
   bool persistent = plan->persistent;
 
@@ -111,8 +114,7 @@ static ncclResult_t ncclRmaProxyWaitDescFromTask(struct ncclComm* comm, struct n
   if (!persistent) {
     desc->waitSignal.waitPeers = task->peers;
     desc->waitSignal.waitSignals = task->nsignals;
-  }
-  else {
+  } else {
     desc->opSeq = 1;
     desc->waitSignal.waitPeers = task->peers;
     desc->waitSignal.waitSignals = task->nsignals;
@@ -121,15 +123,18 @@ static ncclResult_t ncclRmaProxyWaitDescFromTask(struct ncclComm* comm, struct n
     task->peers = nullptr;
     task->nsignals = nullptr;
     // Allocation during graph capture, off the execution critical path
-    NCCLCHECKGOTO(allocMemCPUAccessible(&desc->readySeq, &desc->readySeqDev, 1, 0, &desc->readySeqGdrHandle, comm->memManager), ret, fail);
-    NCCLCHECKGOTO(allocMemCPUAccessible(&desc->doneSeq, &desc->doneSeqDev, 1, 0, &desc->doneSeqGdrHandle, comm->memManager), ret, fail);
+    NCCLCHECKGOTO(allocMemCPUAccessible(&desc->readySeq, &desc->readySeqDev, 1, 0, &desc->readySeqGdrHandle,
+                                        comm->memManager),
+                  ret, fail);
+    NCCLCHECKGOTO(allocMemCPUAccessible(&desc->doneSeq, &desc->doneSeqDev, 1, 0, &desc->doneSeqGdrHandle,
+                                        comm->memManager),
+                  ret, fail);
     desc->persistPlan = plan;
   }
 exit:
   return ret;
 fail:
-  if (desc->readySeq)
-    freeMemCPUAccessible(desc->readySeq, desc->readySeqGdrHandle, comm->memManager);
+  if (desc->readySeq) freeMemCPUAccessible(desc->readySeq, desc->readySeqGdrHandle, comm->memManager);
   goto exit;
 }
 
@@ -169,8 +174,8 @@ bool ncclRmaProxyCircularBufEmpty(struct ncclRmaProxyCtx* ctx, int peer) {
   return ci >= pi;
 }
 
-static inline ncclResult_t ncclRmaProxyEnqueueNonPersistentDesc(
-    struct ncclRmaProxyCtx* ctx, int peer, struct ncclRmaProxyDesc* desc) {
+static inline ncclResult_t ncclRmaProxyEnqueueNonPersistentDesc(struct ncclRmaProxyCtx* ctx, int peer,
+                                                                struct ncclRmaProxyDesc* desc) {
   uint32_t pi = COMPILER_ATOMIC_LOAD_32(&ctx->pis[peer], std::memory_order_relaxed);
   uint32_t idx = pi & (ctx->queueSize - 1);
   ctx->circularBuffers[peer * ctx->queueSize + idx] = desc;
@@ -179,8 +184,8 @@ static inline ncclResult_t ncclRmaProxyEnqueueNonPersistentDesc(
   return ncclSuccess;
 }
 
-static inline ncclResult_t ncclRmaProxyEnqueuePersistentDesc(
-    struct ncclRmaProxyCtx* ctx, int peer, struct ncclRmaProxyDesc* desc) {
+static inline ncclResult_t ncclRmaProxyEnqueuePersistentDesc(struct ncclRmaProxyCtx* ctx, int peer,
+                                                             struct ncclRmaProxyDesc* desc) {
   ncclIntruQueueEnqueue(&ctx->persistentQueues[peer], desc);
   // Transition to persistent with RELEASE to guarantee all preceding writes are visible to proxy
   COMPILER_ATOMIC_STORE(&desc->persistDescValid, true, std::memory_order_release);
@@ -200,10 +205,10 @@ ncclResult_t ncclRmaProxyPutLaunch(struct ncclComm* comm, struct ncclKernelPlan*
   bool persistent = plan->persistent;
   int ctx = plan->rmaArgs->ctx;
   int nRmaTasksProxy = plan->rmaArgs->nRmaTasksProxy;
-  struct ncclRmaProxyCtx * rmaProxyCtx = (struct ncclRmaProxyCtx *)comm->rmaState.rmaProxyState.rmaProxyCtxs[ctx];
+  struct ncclRmaProxyCtx* rmaProxyCtx = (struct ncclRmaProxyCtx*)comm->rmaState.rmaProxyState.rmaProxyCtxs[ctx];
 
   int opsPerTask = persistent ? 3 : 2;
-  struct ncclRmaProxyDesc *desc = nullptr;
+  struct ncclRmaProxyDesc* desc = nullptr;
   hipStreamBatchMemOpParams* batchParams = nullptr;
   NCCLCHECK(ncclCalloc(&batchParams, opsPerTask * nRmaTasksProxy));
 
@@ -237,10 +242,10 @@ ncclResult_t ncclRmaProxyPutLaunch(struct ncclComm* comm, struct ncclKernelPlan*
     batchParams[batchIdx].writeValue.flags = CU_STREAM_WRITE_VALUE_DEFAULT;
 
     // Prepare the doneSeq wait operation
-    batchParams[batchIdx+nRmaTasksProxy].waitValue.operation = CU_STREAM_MEM_OP_WAIT_VALUE_64;
-    batchParams[batchIdx+nRmaTasksProxy].waitValue.address = (CUdeviceptr)desc->doneSeqDev;
-    batchParams[batchIdx+nRmaTasksProxy].waitValue.value64 = desc->opSeq;
-    batchParams[batchIdx+nRmaTasksProxy].waitValue.flags = CU_STREAM_WAIT_VALUE_GEQ;
+    batchParams[batchIdx + nRmaTasksProxy].waitValue.operation = CU_STREAM_MEM_OP_WAIT_VALUE_64;
+    batchParams[batchIdx + nRmaTasksProxy].waitValue.address = (CUdeviceptr)desc->doneSeqDev;
+    batchParams[batchIdx + nRmaTasksProxy].waitValue.value64 = desc->opSeq;
+    batchParams[batchIdx + nRmaTasksProxy].waitValue.flags = CU_STREAM_WAIT_VALUE_GEQ;
 
     // Graph: extra reset op for doneSeq
     if (persistent) {
@@ -250,8 +255,11 @@ ncclResult_t ncclRmaProxyPutLaunch(struct ncclComm* comm, struct ncclKernelPlan*
       batchParams[batchIdx + 2 * nRmaTasksProxy].writeValue.flags = CU_STREAM_WRITE_VALUE_DEFAULT;
     }
 
-    INFO(NCCL_COLL, "ncclRmaProxyPutLaunch enqueued Desc: rank=%d peer=%d ctx=%d size=%ld signalMode=%d readySeq=%lu doneSeq=%lu persistent=%d",
-      comm->rank, task->peer, ctx, task->count * ncclTypeSize(task->datatype), task->signalMode, (uint64_t)desc->opSeq, (uint64_t)desc->opSeq, persistent);
+    INFO(NCCL_COLL,
+         "ncclRmaProxyPutLaunch enqueued Desc: rank=%d peer=%d ctx=%d size=%ld signalMode=%d readySeq=%lu doneSeq=%lu "
+         "persistent=%d",
+         comm->rank, task->peer, ctx, task->count * ncclTypeSize(task->datatype), task->signalMode,
+         (uint64_t)desc->opSeq, (uint64_t)desc->opSeq, persistent);
 
     // Enqueue descriptor to appropriate queue
     if (!persistent) {
@@ -269,10 +277,10 @@ ncclResult_t ncclRmaProxyPutLaunch(struct ncclComm* comm, struct ncclKernelPlan*
 
   // Execute batch
   if (batchIdx == nRmaTasksProxy) {
-    NCCLCHECKGOTO(ncclCuStreamBatchMemOp(stream, opsPerTask*nRmaTasksProxy, batchParams), ret, fail);
+    NCCLCHECKGOTO(ncclCuStreamBatchMemOp(stream, opsPerTask * nRmaTasksProxy, batchParams), ret, fail);
   } else {
     NCCLCHECKGOTO(ncclCuStreamBatchMemOp(stream, batchIdx, batchParams), ret, fail);
-    NCCLCHECKGOTO(ncclCuStreamBatchMemOp(stream, batchIdx, batchParams+nRmaTasksProxy), ret, fail);
+    NCCLCHECKGOTO(ncclCuStreamBatchMemOp(stream, batchIdx, batchParams + nRmaTasksProxy), ret, fail);
   }
 
 exit:
@@ -282,8 +290,6 @@ fail:
   free(desc);
   goto exit;
 }
-
-
 
 ncclResult_t ncclRmaProxyWaitLaunch(struct ncclComm* comm, struct ncclKernelPlan* plan, cudaStream_t stream) {
   ncclResult_t ret = ncclSuccess;
@@ -324,8 +330,7 @@ ncclResult_t ncclRmaProxyWaitLaunch(struct ncclComm* comm, struct ncclKernelPlan
         opIdx++;
       }
       NCCLCHECKGOTO(ncclCuStreamBatchMemOp(stream, opIdx, batchParams), ret, fail);
-    }
-    else {
+    } else {
       // Graph: create persistent desc, proxy polls CPU-accessible signals
       NCCLCHECKGOTO(ncclCalloc(&batchParams, 3), ret, fail);
       NCCLCHECKGOTO(ncclCalloc(&desc, 1), ret, fail);
@@ -417,7 +422,7 @@ ncclResult_t ncclRmaProxyReclaimPlan(struct ncclComm* comm, struct ncclKernelPla
     std::unique_lock<std::mutex> lock(proxyState->mutex);
     proxyState->ginProgress = 2;
     proxyState->cond.notify_one();
-    proxyState->cond.wait(lock, [&]{ return proxyState->ginProgress == 0; });
+    proxyState->cond.wait(lock, [&] { return proxyState->ginProgress == 0; });
   }
 
   // Step 2: Free persistent descs on main thread

--- a/projects/rccl/src/rma/rma_proxy_progress.cc
+++ b/projects/rccl/src/rma/rma_proxy_progress.cc
@@ -13,19 +13,21 @@
 
 // Poll and test completion of InProgress Descs for a given peer
 // Returns after testing head Desc (stops on first incomplete to enforce FIFO)
-static ncclResult_t ncclRmaProxyPollNonPersistCompletion(ncclGin_t *ncclGin, struct ncclRmaProxyCtx *ctx, int peer) {
+static ncclResult_t ncclRmaProxyPollNonPersistCompletion(ncclGin_t* ncclGin, struct ncclRmaProxyCtx* ctx, int peer) {
   while (true) {
-    struct ncclRmaProxyDesc *inProgressDesc = ncclIntruQueueHead(&ctx->inProgressQueues[peer]);
+    struct ncclRmaProxyDesc* inProgressDesc = ncclIntruQueueHead(&ctx->inProgressQueues[peer]);
     if (inProgressDesc == NULL) break;  // No InProgress Descs
 
     int done = 0;
     NCCLCHECK(ncclGin->test(ctx->ginCollComm, inProgressDesc->putSignal.request, &done));
     if (done) {
-      INFO(NCCL_COLL, "Rank %d ncclRmaProxyPollNonPersistCompletion: targetRank=%d descSeq=%lu COMPLETED, updating doneSeq",
-        ctx->comm->rank, inProgressDesc->putSignal.targetRank, inProgressDesc->opSeq);
+      INFO(NCCL_COLL,
+           "Rank %d ncclRmaProxyPollNonPersistCompletion: targetRank=%d descSeq=%lu COMPLETED, updating doneSeq",
+           ctx->comm->rank, inProgressDesc->putSignal.targetRank, inProgressDesc->opSeq);
 
       // Update the doneSeq for the target rank with RELEASE to ensure GPU sees it
-      COMPILER_ATOMIC_STORE(inProgressDesc->doneSeq, inProgressDesc->opSeq, std::memory_order_release); // sync with the custreamWait aquire semantic
+      COMPILER_ATOMIC_STORE(inProgressDesc->doneSeq, inProgressDesc->opSeq,
+                            std::memory_order_release); // sync with the custreamWait aquire semantic
       // Dequeue and free the completed Desc
       ncclIntruQueueDequeue(&ctx->inProgressQueues[peer]);
       NCCLCHECK(ncclRmaProxyDestroyDescNonPersistent(inProgressDesc));
@@ -39,13 +41,13 @@ static ncclResult_t ncclRmaProxyPollNonPersistCompletion(ncclGin_t *ncclGin, str
 
 // Poll and issue ready Pending Descs for a given peer
 // Moves ready Descs from pending queue to InProgress queue
-static ncclResult_t ncclRmaProxyPollNonPersistDesc(ncclGin_t *ncclGin, struct ncclRmaProxyCtx *ctx, int peer) {
+static ncclResult_t ncclRmaProxyPollNonPersistDesc(ncclGin_t* ncclGin, struct ncclRmaProxyCtx* ctx, int peer) {
   while (true) {
     if (ncclRmaProxyCircularBufEmpty(ctx, peer)) break;
 
     uint32_t ci = COMPILER_ATOMIC_LOAD_32(&ctx->cis[peer], std::memory_order_relaxed);
     uint32_t idx = ci & (ctx->queueSize - 1);
-    struct ncclRmaProxyDesc *pendingDesc = ctx->circularBuffers[peer * ctx->queueSize + idx];
+    struct ncclRmaProxyDesc* pendingDesc = ctx->circularBuffers[peer * ctx->queueSize + idx];
 
     // Check if this Desc is ready to be issued
     uint64_t readySeq = COMPILER_ATOMIC_LOAD(pendingDesc->readySeq, std::memory_order_acquire);
@@ -56,24 +58,28 @@ static ncclResult_t ncclRmaProxyPollNonPersistDesc(ncclGin_t *ncclGin, struct nc
       // Issue the network operation
       if (pendingDesc->putSignal.signal.op == 0) {
         // No signal operation
-        NCCLCHECK(ncclGin->iput(ctx->ginCtx, 0,
-          pendingDesc->putSignal.srcOff, pendingDesc->putSignal.srcHandle, pendingDesc->putSignal.size,
-          pendingDesc->putSignal.dstOff, pendingDesc->putSignal.dstHandle,
-          pendingDesc->putSignal.targetRank, &pendingDesc->putSignal.request));
+        NCCLCHECK(ncclGin->iput(ctx->ginCtx, 0, pendingDesc->putSignal.srcOff, pendingDesc->putSignal.srcHandle,
+                                pendingDesc->putSignal.size, pendingDesc->putSignal.dstOff,
+                                pendingDesc->putSignal.dstHandle, pendingDesc->putSignal.targetRank,
+                                &pendingDesc->putSignal.request));
       } else {
         // Signal operation needed
-        NCCLCHECK(ncclGin->iputSignal(ctx->ginCtx, 0,
-          pendingDesc->putSignal.srcOff, pendingDesc->putSignal.srcHandle, pendingDesc->putSignal.size,
-          pendingDesc->putSignal.dstOff, pendingDesc->putSignal.dstHandle,
-          pendingDesc->putSignal.targetRank, pendingDesc->putSignal.signal.offset, pendingDesc->putSignal.signal.signalMhandle,
+        NCCLCHECK(ncclGin->iputSignal(
+          ctx->ginCtx, 0, pendingDesc->putSignal.srcOff, pendingDesc->putSignal.srcHandle, pendingDesc->putSignal.size,
+          pendingDesc->putSignal.dstOff, pendingDesc->putSignal.dstHandle, pendingDesc->putSignal.targetRank,
+          pendingDesc->putSignal.signal.offset, pendingDesc->putSignal.signal.signalMhandle,
           pendingDesc->putSignal.signal.val, pendingDesc->putSignal.signal.op, &pendingDesc->putSignal.request));
       }
 
       // Enqueue to InProgress queue (no lock needed - progress thread only)
       ncclIntruQueueEnqueue(&ctx->inProgressQueues[peer], pendingDesc);
 
-      INFO(NCCL_COLL, "Rank %d ncclRmaProxyPollNonPersistDesc: targetRank=%d descSeq=%lu readySeq=%lu srcOff=%lu srcHandle=%p dstOff=%lu dstHandle=%p size=%lu - issuing network operation",
-        ctx->comm->rank, pendingDesc->putSignal.targetRank, pendingDesc->opSeq, readySeq, pendingDesc->putSignal.srcOff, pendingDesc->putSignal.srcHandle, pendingDesc->putSignal.dstOff, pendingDesc->putSignal.dstHandle, pendingDesc->putSignal.size);
+      INFO(NCCL_COLL,
+           "Rank %d ncclRmaProxyPollNonPersistDesc: targetRank=%d descSeq=%lu readySeq=%lu srcOff=%lu srcHandle=%p "
+           "dstOff=%lu dstHandle=%p size=%lu - issuing network operation",
+           ctx->comm->rank, pendingDesc->putSignal.targetRank, pendingDesc->opSeq, readySeq,
+           pendingDesc->putSignal.srcOff, pendingDesc->putSignal.srcHandle, pendingDesc->putSignal.dstOff,
+           pendingDesc->putSignal.dstHandle, pendingDesc->putSignal.size);
     } else {
       // ReadySeq not ready yet - stop processing this peer's pending queue to maintain FIFO order
       break;
@@ -86,11 +92,11 @@ static ncclResult_t ncclRmaProxyPollNonPersistDesc(ncclGin_t *ncclGin, struct nc
 // Issues a local iput to the flush buffer registered with strict ordering and
 // spins until the NIC reports completion, guaranteeing that all prior data
 // written through the NIC-GPU path is visible in vidmem.
-static ncclResult_t ncclRmaProxyFlushNicGpuPath(ncclGin_t *ncclGin, struct ncclRmaProxyCtx *ctx) {
+static ncclResult_t ncclRmaProxyFlushNicGpuPath(ncclGin_t* ncclGin, struct ncclRmaProxyCtx* ctx) {
   void* request = NULL;
   size_t flushOff = (size_t)ctx->comm->rank * sizeof(uint64_t);
-  NCCLCHECK(ncclGin->iput(ctx->ginCtx, 0, flushOff, ctx->flushBufMhandle, sizeof(uint64_t),
-            flushOff, ctx->flushBufMhandle, ctx->comm->rank, &request));
+  NCCLCHECK(ncclGin->iput(ctx->ginCtx, 0, flushOff, ctx->flushBufMhandle, sizeof(uint64_t), flushOff,
+                          ctx->flushBufMhandle, ctx->comm->rank, &request));
   int done = 0;
   while (!done) {
     NCCLCHECK(ncclGin->test(ctx->ginCollComm, request, &done));
@@ -99,8 +105,8 @@ static ncclResult_t ncclRmaProxyFlushNicGpuPath(ncclGin_t *ncclGin, struct ncclR
 }
 
 // Poll persistent descriptors for a given peer (graph mode).
-static ncclResult_t ncclRmaProxyPollPersistDesc(ncclGin_t *ncclGin, struct ncclRmaProxyCtx *ctx, int peer) {
-  struct ncclRmaProxyDesc *desc = ncclIntruQueueHead(&ctx->persistentQueues[peer]);
+static ncclResult_t ncclRmaProxyPollPersistDesc(ncclGin_t* ncclGin, struct ncclRmaProxyCtx* ctx, int peer) {
+  struct ncclRmaProxyDesc* desc = ncclIntruQueueHead(&ctx->persistentQueues[peer]);
   while (desc != NULL) {
     if (!COMPILER_ATOMIC_LOAD(&desc->persistDescValid, std::memory_order_acquire)) {
       desc = desc->next;
@@ -114,23 +120,21 @@ static ncclResult_t ncclRmaProxyPollPersistDesc(ncclGin_t *ncclGin, struct ncclR
           COMPILER_ATOMIC_STORE(desc->readySeq, (uint64_t)0, std::memory_order_relaxed);
 
           if (desc->putSignal.signal.op == 0) {
-            NCCLCHECK(ncclGin->iput(ctx->ginCtx, 0,
-              desc->putSignal.srcOff, desc->putSignal.srcHandle, desc->putSignal.size,
-              desc->putSignal.dstOff, desc->putSignal.dstHandle,
-              desc->putSignal.targetRank, &desc->putSignal.request));
+            NCCLCHECK(ncclGin->iput(ctx->ginCtx, 0, desc->putSignal.srcOff, desc->putSignal.srcHandle,
+                                    desc->putSignal.size, desc->putSignal.dstOff, desc->putSignal.dstHandle,
+                                    desc->putSignal.targetRank, &desc->putSignal.request));
           } else {
-            NCCLCHECK(ncclGin->iputSignal(ctx->ginCtx, 0,
-              desc->putSignal.srcOff, desc->putSignal.srcHandle, desc->putSignal.size,
-              desc->putSignal.dstOff, desc->putSignal.dstHandle,
-              desc->putSignal.targetRank, desc->putSignal.signal.offset, desc->putSignal.signal.signalMhandle,
-              desc->putSignal.signal.val, desc->putSignal.signal.op, &desc->putSignal.request));
+            NCCLCHECK(ncclGin->iputSignal(ctx->ginCtx, 0, desc->putSignal.srcOff, desc->putSignal.srcHandle,
+                                          desc->putSignal.size, desc->putSignal.dstOff, desc->putSignal.dstHandle,
+                                          desc->putSignal.targetRank, desc->putSignal.signal.offset,
+                                          desc->putSignal.signal.signalMhandle, desc->putSignal.signal.val,
+                                          desc->putSignal.signal.op, &desc->putSignal.request));
           }
 
           desc->rmaDescState = ncclRmaDescStateInProgress;
           INFO(NCCL_COLL, "Rank %d ncclRmaProxyPollPersistDesc: peer=%d PutSignal issued", ctx->comm->rank, peer);
         }
-      }
-      else if (desc->rmaDescState == ncclRmaDescStateInProgress) {
+      } else if (desc->rmaDescState == ncclRmaDescStateInProgress) {
         int done = 0;
         NCCLCHECK(ncclGin->test(ctx->ginCollComm, desc->putSignal.request, &done));
         if (done) {
@@ -138,21 +142,19 @@ static ncclResult_t ncclRmaProxyPollPersistDesc(ncclGin_t *ncclGin, struct ncclR
           COMPILER_ATOMIC_STORE(desc->doneSeq, (uint64_t)1, std::memory_order_release);
           desc->rmaDescState = ncclRmaDescStateReady;
           INFO(NCCL_COLL, "Rank %d ncclRmaProxyPollPersistDesc: peer=%d PutSignal completed, doneSeq set",
-            ctx->comm->rank, peer);
+               ctx->comm->rank, peer);
         }
       }
-    }
-    else if (desc->rmaDescType == ncclRmaDescTypeWaitSignal) {
+    } else if (desc->rmaDescType == ncclRmaDescTypeWaitSignal) {
       if (desc->rmaDescState == ncclRmaDescStateReady) {
         uint64_t readyVal = COMPILER_ATOMIC_LOAD(desc->readySeq, std::memory_order_acquire);
         if (readyVal == 1) {
           COMPILER_ATOMIC_STORE(desc->readySeq, (uint64_t)0, std::memory_order_relaxed);
           desc->rmaDescState = ncclRmaDescStateInProgress;
           INFO(NCCL_COLL, "Rank %d ncclRmaProxyPollPersistDesc: peer=%d WaitSignal ready, start polling signals",
-            ctx->comm->rank, peer);
+               ctx->comm->rank, peer);
         }
-      }
-      else if (desc->rmaDescState == ncclRmaDescStateInProgress) {
+      } else if (desc->rmaDescState == ncclRmaDescStateInProgress) {
         bool signalsAllArrived = true;
         for (int i = 0; i < desc->waitSignal.npeers; i++) {
           int peerRank = desc->waitSignal.waitPeers[i];
@@ -176,7 +178,7 @@ static ncclResult_t ncclRmaProxyPollPersistDesc(ncclGin_t *ncclGin, struct ncclR
           COMPILER_ATOMIC_STORE(desc->doneSeq, (uint64_t)1, std::memory_order_release);
           desc->rmaDescState = ncclRmaDescStateReady;
           INFO(NCCL_COLL, "Rank %d ncclRmaProxyPollPersistDesc: peer=%d WaitSignal all arrived, doneSeq set",
-            ctx->comm->rank, peer);
+               ctx->comm->rank, peer);
         }
       }
     }
@@ -187,8 +189,8 @@ static ncclResult_t ncclRmaProxyPollPersistDesc(ncclGin_t *ncclGin, struct ncclR
 }
 
 // Checks the RMA proxy progress.
-ncclResult_t ncclRmaProxyProgress(ncclGin_t *ncclGin, void *rmaProxyCtx) {
-  struct ncclRmaProxyCtx *ctx = (struct ncclRmaProxyCtx *)rmaProxyCtx;
+ncclResult_t ncclRmaProxyProgress(ncclGin_t* ncclGin, void* rmaProxyCtx) {
+  struct ncclRmaProxyCtx* ctx = (struct ncclRmaProxyCtx*)rmaProxyCtx;
 
   // Loop through each peer's queues
   for (int i = 0; i < ctx->comm->nRanks; i++) {

--- a/projects/rccl/src/scheduler/allgatherv_sched.cc
+++ b/projects/rccl/src/scheduler/allgatherv_sched.cc
@@ -5,7 +5,6 @@
  * See LICENSE.txt for more license information
  *************************************************************************/
 
-
 #ifndef NCCL_ALLGATHERV_SCHED_H_
 #define NCCL_ALLGATHERV_SCHED_H_
 
@@ -15,16 +14,20 @@
 // Mirrors enqueue.cc's static rcclProtoGrainSize() (which is file-local there).
 static int rcclProtoGrainSize(int proto, ncclComm* comm) {
   switch (proto) {
-    case NCCL_PROTO_LL: return 16;
-    case NCCL_PROTO_LL128: return comm->WarpSize*NCCL_LL128_SHMEM_ELEMS_PER_THREAD*comm->ll128DataElems*sizeof(uint64_t)/comm->ll128LineElems;
-    case NCCL_PROTO_SIMPLE: return 512;
-    default: return -1;
+  case NCCL_PROTO_LL:
+    return 16;
+  case NCCL_PROTO_LL128:
+    return comm->WarpSize * NCCL_LL128_SHMEM_ELEMS_PER_THREAD * comm->ll128DataElems * sizeof(uint64_t) /
+           comm->ll128LineElems;
+  case NCCL_PROTO_SIMPLE:
+    return 512;
+  default:
+    return -1;
   }
 }
 
-ncclResult_t ncclScheduleBcastTasksToPlan(
-    struct ncclComm* comm, struct ncclKernelPlan* plan, struct ncclKernelPlanBudget* budget
-) {
+ncclResult_t ncclScheduleBcastTasksToPlan(struct ncclComm* comm, struct ncclKernelPlan* plan,
+                                          struct ncclKernelPlanBudget* budget) {
   struct ncclKernelPlanner* planner = &comm->planner;
   int nChannels = comm->nChannels;
   int nRanks = comm->nRanks;
@@ -37,12 +40,14 @@ ncclResult_t ncclScheduleBcastTasksToPlan(
 
     // Make a batch consisting of one bcast from each peer.
     if (plan->nWorkBatches != 0) return ncclSuccess;
-    for (int peer=planner->bcast_info.minBcastPeer; peer <= planner->bcast_info.maxBcastPeer; peer++) {
+    for (int peer = planner->bcast_info.minBcastPeer; peer <= planner->bcast_info.maxBcastPeer; peer++) {
       struct ncclTaskBcast* t = ncclIntruQueueHead(&planner->peers[peer].bcastQueue);
       if (t == nullptr) continue;
       // see if we can fit another batch to args, and a bunch of bcast to workStorage
       // Each batch can fit 64 bcast, if batchTasks > 64 we use nextExtends to extend the batch.
-      if (!ncclTestBudget(budget, nChannels * DIVUP(batchTasks+1, 64), (batchTasks+1) * sizeof(struct ncclDevWorkBcast)) || batchTasks+1 == maxitem) {
+      if (!ncclTestBudget(budget, nChannels * DIVUP(batchTasks + 1, 64),
+                          (batchTasks + 1) * sizeof(struct ncclDevWorkBcast)) ||
+          batchTasks + 1 == maxitem) {
         break;
       }
       sumBcastBytes += t->count;
@@ -62,27 +67,28 @@ ncclResult_t ncclScheduleBcastTasksToPlan(
     tcoll.datatype = ncclInt8;
     tcoll.algorithm = NCCL_ALGO_RING;
     tcoll.protocol = NCCL_PROTO_UNDEF;
-    NCCLCHECK(ncclGetAlgoInfo(comm, &tcoll, /*collNetSupport=*/0, /*nvlsSupport=*/0, /*nTasksPerChannel=*/1, /*simInfo=*/nullptr));
+    NCCLCHECK(ncclGetAlgoInfo(comm, &tcoll, /*collNetSupport=*/0, /*nvlsSupport=*/0, /*nTasksPerChannel=*/1,
+                              /*simInfo=*/nullptr));
 
     // calculate chunk size
     int proto = tcoll.protocol;
     int chunkSteps = 1;
     int sliceSteps = 1;
-    int stepSize = comm->buffSizes[proto]/NCCL_STEPS;
-    int chunkSize = chunkSteps*stepSize;
-    if (proto == NCCL_PROTO_LL) chunkSize = chunkSize/2;
-    if (proto == NCCL_PROTO_LL128) chunkSize = (chunkSize/NCCL_LL128_LINEELEMS)*NCCL_LL128_DATAELEMS;
+    int stepSize = comm->buffSizes[proto] / NCCL_STEPS;
+    int chunkSize = chunkSteps * stepSize;
+    if (proto == NCCL_PROTO_LL) chunkSize = chunkSize / 2;
+    if (proto == NCCL_PROTO_LL128) chunkSize = (chunkSize / NCCL_LL128_LINEELEMS) * NCCL_LL128_DATAELEMS;
     size_t grainSize = rcclProtoGrainSize(proto, comm);
     nChannels = tcoll.nMaxChannels;
     chunkSize = chunkSize / grainSize * grainSize;
 
-
     // Determine thread count per block
-    int threadPerBlock = (int)std::max((int)(tcoll.nWarps * WARP_SIZE), (int)(64 * sizeof(ncclDevWorkBcast) / 16 + 3 * WARP_SIZE));
+    int threadPerBlock =
+      (int)std::max((int)(tcoll.nWarps * WARP_SIZE), (int)(64 * sizeof(ncclDevWorkBcast) / 16 + 3 * WARP_SIZE));
     plan->threadPerBlock = threadPerBlock;
 
     // Choose kernel for plan. Based on proto, algo=ring
-    int funcIndex = ncclDevFuncId(ncclFuncAllGatherV, /*devRedOp,type=*/0,0, NCCL_ALGO_RING, proto);
+    int funcIndex = ncclDevFuncId(ncclFuncAllGatherV, /*devRedOp,type=*/0, 0, NCCL_ALGO_RING, proto);
     if (!plan->kernelSpecialized) {
       // RCCL doesn't expose the upstream ncclDevKernelForFunc[] lookup. The
       // unroll-indexed ncclKerns table (file-local in enqueue.cc) is the
@@ -92,31 +98,31 @@ ncclResult_t ncclScheduleBcastTasksToPlan(
     }
 
     // Compute opCount for proxy work.
-    uint64_t proxyOpCount = uint64_t(comm->collOpCount++)<<1 | /*bcast=*/0;
+    uint64_t proxyOpCount = uint64_t(comm->collOpCount++) << 1 | /*bcast=*/0;
 
     // Break each bcast into nParts evenly, each part assigned to a channel.
     int nParts = nChannels;
     uint32_t channelWorkBytes[MAXCHANNELS] = {0};
-    for (int part=0; part < nParts; part++) {
+    for (int part = 0; part < nParts; part++) {
       // Sort tasks according to ring depth upstream from us.
       int nTasks = batchTasks;
       int channelId = part;
 
       // reset comm->ringTasks
       struct ncclTaskBcast** ringTasks = (struct ncclTaskBcast**)comm->ringTasks;
-      for (int r=0; r < nRanks; r++) ringTasks[r] = nullptr;
+      for (int r = 0; r < nRanks; r++) ringTasks[r] = nullptr;
 
       // calculate, and find min and max ring depth among this plan's tasks
       int minRingDepth = INT_MAX;
       int maxRingDepth = INT_MIN;
       struct ncclTaskBcast* t = nullptr;
-      for (int peer=planner->bcast_info.minBcastPeer; nTasks != 0; peer++) {
+      for (int peer = planner->bcast_info.minBcastPeer; nTasks != 0; peer++) {
         t = ncclIntruQueueHead(&planner->peers[peer].bcastQueue);
         if (t != nullptr) {
           nTasks -= 1;
           int index = comm->channels[channelId].ring.rankToIndex[peer];
           // Need to flip from "downstream from us" to "upstream from us".
-          int ringDepth = (index == 0) ? 0 : nRanks-index;
+          int ringDepth = (index == 0) ? 0 : nRanks - index;
           ringTasks[ringDepth] = t;
           t->ringDepth = ringDepth;
           minRingDepth = std::min(minRingDepth, ringDepth);
@@ -125,29 +131,30 @@ ncclResult_t ncclScheduleBcastTasksToPlan(
       }
 
       // Start an empty dev work batch.
-      int sendSlices=0, recvSlices=0;
-      int maxSendSlices=0, maxRecvSlices=0;
+      int sendSlices = 0, recvSlices = 0;
+      int maxSendSlices = 0, maxRecvSlices = 0;
       // Add each task to the batch in ring depth order.
       int nBcasts = 0;
       int slices = 0;
 
-      for (int ringDepth=minRingDepth; ringDepth <= maxRingDepth; ringDepth++) {
+      for (int ringDepth = minRingDepth; ringDepth <= maxRingDepth; ringDepth++) {
         t = ringTasks[ringDepth];
         if (t != nullptr) {
           size_t partBytes = divUp(t->count, nParts);
-          size_t offset_lo = std::min<size_t>(alignUp((part+0)*partBytes, 256), t->count);
-          size_t offset_hi = std::min<size_t>(alignUp((part+1)*partBytes, 256), t->count);
+          size_t offset_lo = std::min<size_t>(alignUp((part + 0) * partBytes, 256), t->count);
+          size_t offset_hi = std::min<size_t>(alignUp((part + 1) * partBytes, 256), t->count);
           if (offset_hi == offset_lo) {
             continue;
           }
-          plan->channelMask.masks[channelId/64] |= uint64_t(1) << (channelId % 64);
-          struct ncclWorkList* workNode = ncclMemoryStackAllocInlineArray<ncclWorkList, ncclDevWorkBcast>(&comm->memScoped, 1);
+          plan->channelMask.masks[channelId / 64] |= uint64_t(1) << (channelId % 64);
+          struct ncclWorkList* workNode =
+            ncclMemoryStackAllocInlineArray<ncclWorkList, ncclDevWorkBcast>(&comm->memScoped, 1);
           workNode->workType = ncclDevWorkTypeBcast;
           workNode->size = sizeof(struct ncclDevWorkBcast);
           ncclIntruQueueEnqueue(&plan->workQueue, workNode);
-          struct ncclDevWorkBcast* work = (struct ncclDevWorkBcast*)(workNode+1);
+          struct ncclDevWorkBcast* work = (struct ncclDevWorkBcast*)(workNode + 1);
           work->recvbuff = (char*)t->recvbuff + offset_lo;
-          work->bytes = offset_hi-offset_lo;
+          work->bytes = offset_hi - offset_lo;
           work->ringDepth = ringDepth;
           work->chunkSize = chunkSize;
           if (work->bytes != 0) {
@@ -156,7 +163,7 @@ ncclResult_t ncclScheduleBcastTasksToPlan(
               recvSlices += slices;
               maxRecvSlices = std::max(maxRecvSlices, slices);
             }
-            if (ringDepth != nRanks-1) {
+            if (ringDepth != nRanks - 1) {
               sendSlices += slices;
               maxSendSlices = std::max(maxSendSlices, slices);
             }
@@ -166,10 +173,11 @@ ncclResult_t ncclScheduleBcastTasksToPlan(
             channelWorkBytes[channelId] += sizeof(ncclDevWorkBcast);
           }
           nBcasts += 1;
-          ncclAddWorkBatchToPlan(comm, plan, channelId, ncclDevWorkTypeBcast, funcIndex, plan->workBytes, /*p2pEpoch=*/-1, /*p2pRound=*/-1, newBatch);
+          ncclAddWorkBatchToPlan(comm, plan, channelId, ncclDevWorkTypeBcast, funcIndex, plan->workBytes,
+                                 /*p2pEpoch=*/-1, /*p2pRound=*/-1, newBatch);
           newBatch = false;
           plan->workBytes += sizeof(ncclDevWorkBcast);
-      }
+        }
       }
 
       // calculate proxy for this channel
@@ -212,7 +220,7 @@ ncclResult_t ncclScheduleBcastTasksToPlan(
     }
     int nTasks = batchTasks;
     planner->nTasksBcast -= nTasks;
-    for (int peer=planner->bcast_info.minBcastPeer; nTasks != 0; peer++) {
+    for (int peer = planner->bcast_info.minBcastPeer; nTasks != 0; peer++) {
       struct ncclTaskBcast* t = ncclIntruQueueTryDequeue(&planner->peers[peer].bcastQueue);
       if (t != nullptr) {
         --nTasks;

--- a/projects/rccl/src/scheduler/symmetric_sched.cc
+++ b/projects/rccl/src/scheduler/symmetric_sched.cc
@@ -27,7 +27,7 @@ ncclDevRedOp_t symkRedOp(ncclRedOp_t redOp, ncclDevRedOp_t devRedOp) {
   return devRedOp;
 }
 
-void convertCollTaskToSymmetricTask(struct ncclComm* comm,struct ncclTaskColl* task) {
+void convertCollTaskToSymmetricTask(struct ncclComm* comm, struct ncclTaskColl* task) {
   task->opDev.op = symkRedOp(task->opHost, task->opDev.op);
   if (task->opDev.op == ncclDevSumPostDiv) {
     // LDMC uses the same accumulator type as data type. Do not re-pack the scalar.
@@ -35,39 +35,43 @@ void convertCollTaskToSymmetricTask(struct ncclComm* comm,struct ncclTaskColl* t
       return;
     }
     union {
-      __half f16; float f32; uint64_t u64;
-      void *ptr;
+      __half f16;
+      float f32;
+      uint64_t u64;
+      void* ptr;
     };
     u64 = 0;
     switch (task->datatype) {
       // 16-bit floats use a float accumulator; bf16 reduces in float on HIP, and
       // on HIP fp8 also reduces in float (see ncclSymkAccumType in primitives.cuh).
-      case ncclFloat16:
+    case ncclFloat16:
 #if defined(__CUDA_BF16_TYPES_EXIST__) || defined(__HIP_PLATFORM_AMD__)
-      case ncclBfloat16:
+    case ncclBfloat16:
 #endif
 #if defined(__HIP_PLATFORM_AMD__)
-      case ncclFloat8e4m3:
-      case ncclFloat8e5m2:
+    case ncclFloat8e4m3:
+    case ncclFloat8e5m2:
 #endif
-        f32 = float(1.0/comm->nRanks);  // ncclDevSumPostDiv actually multiplies by the scalar, not divides.
-        task->opDev.scalarArg = u64;
-        return;
+      f32 = float(1.0 / comm->nRanks);  // ncclDevSumPostDiv actually multiplies by the scalar, not divides.
+      task->opDev.scalarArg = u64;
+      return;
       // CUDA: fp8 reduces in a half accumulator; pack the scalar as half.
 #if defined(__CUDA_FP8_TYPES_EXIST__)
-      case ncclFloat8e4m3:
-      case ncclFloat8e5m2:
-        f16 = __float2half(float(1.0/comm->nRanks));
-        task->opDev.scalarArg = u64;
-        return;
+    case ncclFloat8e4m3:
+    case ncclFloat8e5m2:
+      f16 = __float2half(float(1.0 / comm->nRanks));
+      task->opDev.scalarArg = u64;
+      return;
 #endif
-      default:
-        break;
-      }
+    default:
+      break;
+    }
   }
 }
 
-ncclResult_t ncclMakeSymmetricTaskList(struct ncclComm* comm, struct ncclTaskColl* task, struct ncclIntruQueue<struct ncclTaskColl, &ncclTaskColl::next>* symTaskQueue, struct ncclTaskColl** remainTasksHead) {
+ncclResult_t ncclMakeSymmetricTaskList(struct ncclComm* comm, struct ncclTaskColl* task,
+                                       struct ncclIntruQueue<struct ncclTaskColl, &ncclTaskColl::next>* symTaskQueue,
+                                       struct ncclTaskColl** remainTasksHead) {
   ncclResult_t ret = ncclSuccess;
   int fnOpTySymCount = 0;
   struct ncclTaskColl* tasksSymByFnOpTy[ncclNumFuncs * ncclNumDevRedOps * ncclNumTypes * ncclNumSymRegTypes];
@@ -92,7 +96,9 @@ ncclResult_t ncclMakeSymmetricTaskList(struct ncclComm* comm, struct ncclTaskCol
       NCCLCHECK(ncclDevrFindWindow(comm, task->recvbuff, &task->recvWin));
       NCCLCHECK(ncclGetSymRegType(task->sendWin, task->recvWin, &task->winRegType));
 
-      index = (((int)task->func * ncclNumDevRedOps + symkOp) * ncclNumTypes + (int)task->datatype) * ncclNumSymRegTypes + (int)task->winRegType;
+      index =
+        (((int)task->func * ncclNumDevRedOps + symkOp) * ncclNumTypes + (int)task->datatype) * ncclNumSymRegTypes +
+        (int)task->winRegType;
       if (tasksSymByFnOpTy[index] == nullptr) fnOpTySymIndices[fnOpTySymCount++] = index;
       task->next = tasksSymByFnOpTy[index];
       tasksSymByFnOpTy[index] = task;
@@ -141,9 +147,8 @@ ncclResult_t ncclMakeSymmetricTaskList(struct ncclComm* comm, struct ncclTaskCol
         }
         task = task->next;
       }
-      NCCLCHECK(ncclSymkPickKernel(comm, headTask->func, symkOp, headTask->datatype,
-                                   countTotal, countMax, nWorks, headTask->winRegType,
-                                   &estTimeUs, &kernelId, &nChannels, &nWarps, &forced));
+      NCCLCHECK(ncclSymkPickKernel(comm, headTask->func, symkOp, headTask->datatype, countTotal, countMax, nWorks,
+                                   headTask->winRegType, &estTimeUs, &kernelId, &nChannels, &nWarps, &forced));
       task = headTask;
       bool isLLKernel = (1 << kernelId) & ncclSymkLLKernelMask();
       bool isOneThreadMultiGpus = comm->intraRanks > 1 && !ncclParamSingleProcMemRegEnable();
@@ -165,7 +170,8 @@ ncclResult_t ncclMakeSymmetricTaskList(struct ncclComm* comm, struct ncclTaskCol
           if (!needFallback) {
             // First query legacy tuning
             int collNetSupport = 0;
-            int nvlsSupport = comm->nvlsSupport && (ncclNvlsSupported(task->opDev.op, headTask->datatype) || headTask->func == ncclFuncAllGather);
+            int nvlsSupport = comm->nvlsSupport && (ncclNvlsSupported(task->opDev.op, headTask->datatype) ||
+                                                    headTask->func == ncclFuncAllGather);
             NCCLCHECK(ncclGetCollNetSupport(comm, headTask, &collNetSupport));
             NOWARN(ncclGetAlgoInfo(comm, headTask, collNetSupport, nvlsSupport, 1), NCCL_COLL);
             needFallback = (headTask->protocol != NCCL_PROTO_LL);
@@ -176,7 +182,8 @@ ncclResult_t ncclMakeSymmetricTaskList(struct ncclComm* comm, struct ncclTaskCol
       // Override needFallback when buffers are registered but VAs contain sysmem segments.
       // The below functions return false when the window is NULL, so this covers non-reg cases as well.
       if (!needFallback) {
-        bool hasSysmemSegment = ncclDevrWindowHasSysmemSegment(headTask->sendWin) || ncclDevrWindowHasSysmemSegment(headTask->recvWin);
+        bool hasSysmemSegment =
+          ncclDevrWindowHasSysmemSegment(headTask->sendWin) || ncclDevrWindowHasSysmemSegment(headTask->recvWin);
         needFallback = hasSysmemSegment;
       }
 
@@ -223,7 +230,9 @@ exit:
   return ret;
 }
 
-ncclResult_t ncclSymmetricTaskScheduler(struct ncclComm* comm, struct ncclIntruQueue<struct ncclTaskColl, &ncclTaskColl::next>* symTaskQueue, struct ncclKernelPlan* plan) {
+ncclResult_t ncclSymmetricTaskScheduler(struct ncclComm* comm,
+                                        struct ncclIntruQueue<struct ncclTaskColl, &ncclTaskColl::next>* symTaskQueue,
+                                        struct ncclKernelPlan* plan) {
   struct ncclTaskColl* headTask = ncclIntruQueueHead(symTaskQueue);
   int devFuncId = headTask->devFuncId;
   struct ncclTaskColl* task = NULL;
@@ -254,7 +263,7 @@ ncclResult_t ncclSymmetricTaskScheduler(struct ncclComm* comm, struct ncclIntruQ
   int kernelIndex = ncclSymkGetKernelIndex(kernelId, headTask->opDev.op, headTask->datatype);
   plan->kernelFn = ncclSymkKernelList[kernelIndex];
   int maxDynamicSmem = ncclSymkKernelMaxDynamicSmem[kernelIndex];
-  plan->kernelDynSmem = (1 & ncclSymkDynamicSmemKernelMask()>>(int)kernelId) ? maxDynamicSmem : 0;
+  plan->kernelDynSmem = (1 & ncclSymkDynamicSmemKernelMask() >> (int)kernelId) ? maxDynamicSmem : 0;
   task = headTask;
   while (task != nullptr && task->devFuncId == devFuncId) {
     workCount++;
@@ -287,7 +296,7 @@ ncclResult_t ncclSymmetricTaskScheduler(struct ncclComm* comm, struct ncclIntruQ
     NCCLCHECKGOTO(ncclSymkMakeDevWork(comm, task, &devWork), ret, fail);
 
     cellLeft = taskCell = DIVUP(task->count, cellCount);
-    for (;curChannel < nMaxChannels;) {
+    for (; curChannel < nMaxChannels;) {
       workRangePtr[curChannel].workHi = workIndex;
       if (curChannelWork == 0) {
         if (devWork.nChannels == 0) {
@@ -297,7 +306,8 @@ ncclResult_t ncclSymmetricTaskScheduler(struct ncclComm* comm, struct ncclIntruQ
           // the last segment of the task
           assert(devWork.nChannels > 0);
           // if the remaining cell is less than 1024 bytes, we can fuse the last channel
-          if ((remainCell - cellLeft) * NCCL_SYM_KERNEL_CELL_SIZE <= (1 << 10) || ncclIntruQueueEmpty(symTaskQueue)) devWork.nChannels++;
+          if ((remainCell - cellLeft) * NCCL_SYM_KERNEL_CELL_SIZE <= (1 << 10) || ncclIntruQueueEmpty(symTaskQueue))
+            devWork.nChannels++;
         } else {
           // middle segment of the task
           devWork.nChannels++;
@@ -365,4 +375,3 @@ fail:
   goto exit;
 }
 #endif // NCCL_SYMMETRIC_SCHED_H_
-

--- a/projects/rccl/src/sym_kernels.cc
+++ b/projects/rccl/src/sym_kernels.cc
@@ -35,72 +35,53 @@ constexpr char const* kernelName[] = {
   "ReduceScatter_RailA2A_LsaLDMC"
 };
 
-constexpr uint32_t kernelMask_STMC = 1<<ncclSymkKernelId_AllGather_LLMC |
-                                     1<<ncclSymkKernelId_AllGather_STMC |
-                                     1<<ncclSymkKernelId_AllGather_TmaSTMC |
-                                     1<<ncclSymkKernelId_AllReduce_AGxLLMC_R |
-                                     1<<ncclSymkKernelId_AllReduce_RSxLDMC_AGxSTMC |
-                                     1<<ncclSymkKernelId_ReduceScatter_LDMC |
-                                     1<<ncclSymkKernelId_AllGather_RailRing_LsaSTMC;
+constexpr uint32_t kernelMask_STMC =
+  1 << ncclSymkKernelId_AllGather_LLMC | 1 << ncclSymkKernelId_AllGather_STMC |
+  1 << ncclSymkKernelId_AllGather_TmaSTMC | 1 << ncclSymkKernelId_AllReduce_AGxLLMC_R |
+  1 << ncclSymkKernelId_AllReduce_RSxLDMC_AGxSTMC | 1 << ncclSymkKernelId_ReduceScatter_LDMC |
+  1 << ncclSymkKernelId_AllGather_RailRing_LsaSTMC;
 
-constexpr uint32_t kernelMask_LDMC = 1<<ncclSymkKernelId_AllReduce_RSxLDMC_AGxSTMC |
-                                     1<<ncclSymkKernelId_ReduceScatter_LDMC |
-                                     1<<ncclSymkKernelId_ReduceScatter_RailA2A_LsaLDMC;
+constexpr uint32_t kernelMask_LDMC = 1 << ncclSymkKernelId_AllReduce_RSxLDMC_AGxSTMC |
+                                     1 << ncclSymkKernelId_ReduceScatter_LDMC |
+                                     1 << ncclSymkKernelId_ReduceScatter_RailA2A_LsaLDMC;
 
-constexpr uint32_t kernelMask_LL = 1<<ncclSymkKernelId_AllReduce_AGxLL_R |
-                                   1<<ncclSymkKernelId_AllReduce_AGxLLMC_R |
-                                   1<<ncclSymkKernelId_AllGather_LL |
-                                   1<<ncclSymkKernelId_AllGather_LLMC |
-                                   1<<ncclSymkKernelId_ReduceScatter_LL;
+constexpr uint32_t kernelMask_LL = 1 << ncclSymkKernelId_AllReduce_AGxLL_R | 1 << ncclSymkKernelId_AllReduce_AGxLLMC_R |
+                                   1 << ncclSymkKernelId_AllGather_LL | 1 << ncclSymkKernelId_AllGather_LLMC |
+                                   1 << ncclSymkKernelId_ReduceScatter_LL;
 
-constexpr uint32_t kernelMask_AG = 1<<ncclSymkKernelId_AllGather_LL |
-                                   1<<ncclSymkKernelId_AllGather_LLMC |
-                                   1<<ncclSymkKernelId_AllGather_ST |
-                                   1<<ncclSymkKernelId_AllGather_STMC |
-                                   1<<ncclSymkKernelId_AllGather_TmaST |
-                                   1<<ncclSymkKernelId_AllGather_TmaSTMC |
-                                   1<<ncclSymkKernelId_AllGather_RailRing_LsaSTMC;
+constexpr uint32_t kernelMask_AG = 1 << ncclSymkKernelId_AllGather_LL | 1 << ncclSymkKernelId_AllGather_LLMC |
+                                   1 << ncclSymkKernelId_AllGather_ST | 1 << ncclSymkKernelId_AllGather_STMC |
+                                   1 << ncclSymkKernelId_AllGather_TmaST | 1 << ncclSymkKernelId_AllGather_TmaSTMC |
+                                   1 << ncclSymkKernelId_AllGather_RailRing_LsaSTMC;
 
-constexpr uint32_t kernelMask_AR = 1<<ncclSymkKernelId_AllReduce_AGxLLMC_R |
-                                   1<<ncclSymkKernelId_AllReduce_AGxLL_R |
-                                   1<<ncclSymkKernelId_AllReduce_RSxLDMC_AGxSTMC |
-                                   1<<ncclSymkKernelId_AllReduce_RSxLD_AGxST |
-                                   1<<ncclSymkKernelId_AllReduce_RSxTmaLD_AGxTmaST;
+constexpr uint32_t kernelMask_AR = 1 << ncclSymkKernelId_AllReduce_AGxLLMC_R | 1 << ncclSymkKernelId_AllReduce_AGxLL_R |
+                                   1 << ncclSymkKernelId_AllReduce_RSxLDMC_AGxSTMC |
+                                   1 << ncclSymkKernelId_AllReduce_RSxLD_AGxST |
+                                   1 << ncclSymkKernelId_AllReduce_RSxTmaLD_AGxTmaST;
 
-constexpr uint32_t kernelMask_RS = 1<<ncclSymkKernelId_ReduceScatter_LD |
-                                   1<<ncclSymkKernelId_ReduceScatter_LDMC |
-                                   1<<ncclSymkKernelId_ReduceScatter_TmaLD |
-                                   1<<ncclSymkKernelId_ReduceScatter_LL |
-                                   1<<ncclSymkKernelId_ReduceScatter_RailA2A_LsaLD |
-                                   1<<ncclSymkKernelId_ReduceScatter_RailA2A_LsaLDMC;
+constexpr uint32_t kernelMask_RS = 1 << ncclSymkKernelId_ReduceScatter_LD | 1 << ncclSymkKernelId_ReduceScatter_LDMC |
+                                   1 << ncclSymkKernelId_ReduceScatter_TmaLD | 1 << ncclSymkKernelId_ReduceScatter_LL |
+                                   1 << ncclSymkKernelId_ReduceScatter_RailA2A_LsaLD |
+                                   1 << ncclSymkKernelId_ReduceScatter_RailA2A_LsaLDMC;
 
-constexpr uint32_t kernelMask_LSA = 1<<ncclSymkKernelId_AllReduce_AGxLL_R |
-                                    1<<ncclSymkKernelId_AllReduce_AGxLLMC_R |
-                                    1<<ncclSymkKernelId_AllReduce_RSxLD_AGxST |
-                                    1<<ncclSymkKernelId_AllReduce_RSxLDMC_AGxSTMC |
-                                    1<<ncclSymkKernelId_AllReduce_RSxTmaLD_AGxTmaST |
-                                    1<<ncclSymkKernelId_AllGather_LL |
-                                    1<<ncclSymkKernelId_AllGather_LLMC |
-                                    1<<ncclSymkKernelId_AllGather_ST |
-                                    1<<ncclSymkKernelId_AllGather_STMC |
-                                    1<<ncclSymkKernelId_AllGather_TmaST |
-                                    1<<ncclSymkKernelId_AllGather_TmaSTMC |
-                                    1<<ncclSymkKernelId_ReduceScatter_LL |
-                                    1<<ncclSymkKernelId_ReduceScatter_LD |
-                                    1<<ncclSymkKernelId_ReduceScatter_LDMC |
-                                    1<<ncclSymkKernelId_ReduceScatter_TmaLD;
+constexpr uint32_t kernelMask_LSA =
+  1 << ncclSymkKernelId_AllReduce_AGxLL_R | 1 << ncclSymkKernelId_AllReduce_AGxLLMC_R |
+  1 << ncclSymkKernelId_AllReduce_RSxLD_AGxST | 1 << ncclSymkKernelId_AllReduce_RSxLDMC_AGxSTMC |
+  1 << ncclSymkKernelId_AllReduce_RSxTmaLD_AGxTmaST | 1 << ncclSymkKernelId_AllGather_LL |
+  1 << ncclSymkKernelId_AllGather_LLMC | 1 << ncclSymkKernelId_AllGather_ST | 1 << ncclSymkKernelId_AllGather_STMC |
+  1 << ncclSymkKernelId_AllGather_TmaST | 1 << ncclSymkKernelId_AllGather_TmaSTMC |
+  1 << ncclSymkKernelId_ReduceScatter_LL | 1 << ncclSymkKernelId_ReduceScatter_LD |
+  1 << ncclSymkKernelId_ReduceScatter_LDMC | 1 << ncclSymkKernelId_ReduceScatter_TmaLD;
 
-constexpr uint32_t kernelMask_Gin = 1<<ncclSymkKernelId_ReduceScatter_RailA2A_LsaLD |
-                                    1<<ncclSymkKernelId_ReduceScatter_RailA2A_LsaLDMC |
-                                    1<<ncclSymkKernelId_AllGather_RailRing_LsaSTMC;
+constexpr uint32_t kernelMask_Gin = 1 << ncclSymkKernelId_ReduceScatter_RailA2A_LsaLD |
+                                    1 << ncclSymkKernelId_ReduceScatter_RailA2A_LsaLDMC |
+                                    1 << ncclSymkKernelId_AllGather_RailRing_LsaSTMC;
 
-constexpr uint32_t kernelMask_Tma = 1<<ncclSymkKernelId_AllGather_TmaST |
-                                    1<<ncclSymkKernelId_AllGather_TmaSTMC |
-                                    1<<ncclSymkKernelId_AllReduce_RSxTmaLD_AGxTmaST |
-                                    1<<ncclSymkKernelId_ReduceScatter_TmaLD;
+constexpr uint32_t kernelMask_Tma = 1 << ncclSymkKernelId_AllGather_TmaST | 1 << ncclSymkKernelId_AllGather_TmaSTMC |
+                                    1 << ncclSymkKernelId_AllReduce_RSxTmaLD_AGxTmaST |
+                                    1 << ncclSymkKernelId_ReduceScatter_TmaLD;
 
-constexpr uint32_t kernelMask_DynamicSmem = (kernelMask_Gin & kernelMask_RS) |
-                                            kernelMask_Tma;
+constexpr uint32_t kernelMask_DynamicSmem = (kernelMask_Gin & kernelMask_RS) | kernelMask_Tma;
 
 int ncclSymkLLKernelMask() {
   return kernelMask_LL;
@@ -111,10 +92,14 @@ int ncclSymkDynamicSmemKernelMask() {
 
 static uint32_t kernelMask_coll(ncclFunc_t coll) {
   switch (coll) {
-  case ncclFuncAllGather: return kernelMask_AG;
-  case ncclFuncAllReduce: return kernelMask_AR;
-  case ncclFuncReduceScatter: return kernelMask_RS;
-  default: return 0;
+  case ncclFuncAllGather:
+    return kernelMask_AG;
+  case ncclFuncAllReduce:
+    return kernelMask_AR;
+  case ncclFuncReduceScatter:
+    return kernelMask_RS;
+  default:
+    return 0;
   }
 }
 
@@ -127,13 +112,13 @@ static uint32_t kernelMask_user() {
     char const* name = ncclGetEnv("NCCL_SYM_KERNEL");
     if (name == nullptr || strcmp(name, "^") == 0) {
       static_assert((int)ncclSymkKernelId_Count < 32, "Use more than 32 bits");
-      got = (1<<(int)ncclSymkKernelId_Count)-1;
+      got = (1 << (int)ncclSymkKernelId_Count) - 1;
     } else {
       got = 0;
-      for (int k=0; k < (int)ncclSymkKernelId_Count; k++) {
+      for (int k = 0; k < (int)ncclSymkKernelId_Count; k++) {
         if (strcmp(kernelName[k], name) == 0) {
-          COMPILER_ATOMIC_STORE(&cache, uint32_t(1<<k), std::memory_order_relaxed);
-          got = 1<<k;
+          COMPILER_ATOMIC_STORE(&cache, uint32_t(1 << k), std::memory_order_relaxed);
+          got = 1 << k;
           break;
         }
       }
@@ -148,8 +133,17 @@ NCCL_PARAM(SymGinKernelsEnable, "SYM_GIN_KERNELS_ENABLE", 1)
 NCCL_PARAM(SymTmaEnable, "SYM_TMA_ENABLE", 0)
 RCCL_PARAM(SymModel, "SYM_MODEL", 0)
 
-enum rcclSymkColl { rcclSymkColl_AllReduce = 0, rcclSymkColl_AllGather = 1, rcclSymkColl_ReduceScatter = 2, rcclSymkColl_Count = 3 };
-enum rcclSymkProto { rcclSymkProto_LL = 0, rcclSymkProto_Simple = 1, rcclSymkProto_Count = 2 };
+enum rcclSymkColl {
+  rcclSymkColl_AllReduce = 0,
+  rcclSymkColl_AllGather = 1,
+  rcclSymkColl_ReduceScatter = 2,
+  rcclSymkColl_Count = 3
+};
+enum rcclSymkProto {
+  rcclSymkProto_LL = 0,
+  rcclSymkProto_Simple = 1,
+  rcclSymkProto_Count = 2
+};
 
 struct rcclSymkTuningModel {
   double baseLat[rcclSymkColl_Count][rcclSymkProto_Count];
@@ -162,53 +156,34 @@ struct rcclSymkTuningModel {
 static constexpr struct rcclSymkTuningModel rcclSymkTuningModel_0 = {
   .baseLat = {
              //         LL     Simple
-             /* AR */ { 11.0,  19.5 },
-             /* AG */ { 8.5,   13.0 },
-             /* RS */ { 11.0,  15.0 },
+    /* AR */ {11.0, 19.5},
+    /* AG */ {8.5, 13.0},
+    /* RS */ {11.0, 15.0},
   },
-  .smBw = {
-                      { 25.0,   5.0  },
-                      { 22.0,   5.0  },
-                      { 10.0,   20.0 }
-  },
-  .peakBw =           { 800.0, 1200.0, 1200.0 },
+  .smBw = {{25.0, 5.0}, {22.0, 5.0}, {10.0, 20.0}},
+  .peakBw = {800.0, 1200.0, 1200.0},
   // The higher, the more conservative the model (less LL usage, more ST usage)
-  .llBusFactor =      { 12.0,  4.0,   3.0 },
+  .llBusFactor = {12.0, 4.0, 3.0},
   // The higher, the more conservative the model (less CTAs)
-  .withinPeakFactor = {
-                      { 1.100, 1.005 },
-                      { 1.015, 1.015 },
-                      { 1.025, 1.005 }
-  }
+  .withinPeakFactor = {{1.100, 1.005}, {1.015, 1.015}, {1.025, 1.005}}
 };
 
 static constexpr struct rcclSymkTuningModel rcclSymkTuningModel_1 = {
   .baseLat = {
              //         LL     Simple
-             /* AR */ { 11.0,  19.5 },
-             /* AG */ { 8.5,   13.0 },
-             /* RS */ { 11.0,  13.0 },
+    /* AR */ {11.0, 19.5},
+    /* AG */ {8.5, 13.0},
+    /* RS */ {11.0, 13.0},
   },
-  .smBw = {
-                      { 25.0,   5.0  },
-                      { 22.0,   5.0  },
-                      { 25.0,   20.0 }
-  },
-  .peakBw =           { 800.0, 1200.0, 1200.0 },
+  .smBw = {{25.0, 5.0}, {22.0, 5.0}, {25.0, 20.0}},
+  .peakBw = {800.0, 1200.0, 1200.0},
   // The higher, the more conservative the model (less LL usage, more ST usage)
-  .llBusFactor =      { 12.0,  4.0,   9.0 },
+  .llBusFactor = {12.0, 4.0, 9.0},
   // The higher, the more conservative the model (less CTAs)
-  .withinPeakFactor = {
-                      { 1.100, 1.005 },
-                      { 1.015, 1.015 },
-                      { 1.025, 1.025 }
-  }
+  .withinPeakFactor = {{1.100, 1.005}, {1.015, 1.015}, {1.025, 1.025}}
 };
 
-static constexpr struct rcclSymkTuningModel rcclSymkTuningModels[] = {
-  rcclSymkTuningModel_0,
-  rcclSymkTuningModel_1 
-};
+static constexpr struct rcclSymkTuningModel rcclSymkTuningModels[] = {rcclSymkTuningModel_0, rcclSymkTuningModel_1};
 static constexpr int rcclSymkTuningModelCount = int(sizeof(rcclSymkTuningModels) / sizeof(rcclSymkTuningModels[0]));
 
 static int rcclSymkTuningModelIndex() {
@@ -216,8 +191,8 @@ static int rcclSymkTuningModelIndex() {
   if (s_cache < 0) {
     int64_t env = rcclParamSymModel();
     if (env < 0 || env >= rcclSymkTuningModelCount) {
-      INFO(NCCL_ENV, "RCCL_SYM_MODEL %ld is out of range [0, %d); using RCCL_SYM_MODEL 0",
-            (long)env, rcclSymkTuningModelCount);
+      INFO(NCCL_ENV, "RCCL_SYM_MODEL %ld is out of range [0, %d); using RCCL_SYM_MODEL 0", (long)env,
+           rcclSymkTuningModelCount);
       // Use default model
       // We can have model selection logic here in the future
       s_cache = 0;
@@ -231,18 +206,18 @@ static int rcclSymkTuningModelIndex() {
 
 static double softmin(double x, double ceiling, double softness) {
   // looks like a smooth version of: min(x, ceiling)
-  return ceiling - softness*std::log1p((std::exp(ceiling/softness) - 1)*std::exp(-x/softness));
+  return ceiling - softness * std::log1p((std::exp(ceiling / softness) - 1) * std::exp(-x / softness));
 }
 
 static double softplus(double x, double softness) {
   // looks like a smooth version of: max(0, x)
-  double z = x/softness;
-  return 100.0 <= z ? x : softness*std::log1p(std::exp(z));
+  double z = x / softness;
+  return 100.0 <= z ? x : softness * std::log1p(std::exp(z));
 }
 
 static double model(double busBytes, double baseLat, int nSMs, double smBw, double busMultiplier, double peakBw) {
-  double bw = softmin(nSMs*smBw*busMultiplier, peakBw, smBw);
-  return baseLat + softplus(busBytes/bw - 1, 1);
+  double bw = softmin(nSMs * smBw * busMultiplier, peakBw, smBw);
+  return baseLat + softplus(busBytes / bw - 1, 1);
 }
 
 // Given the kernel and bytes, return the minimum number of blocks to run on such that
@@ -252,7 +227,7 @@ static void queryModel_gin(struct ncclComm* comm, ncclSymkKernelId k, size_t nBy
 static void queryModel_lsa(struct ncclComm* comm, ncclSymkKernelId k, size_t nBytes, float* timeUs, int* nBlocks);
 
 static void queryModel(struct ncclComm* comm, ncclSymkKernelId k, size_t nBytes, float* timeUs, int* nBlocks) {
-  if (kernelMask_Gin>>k & 1) {
+  if (kernelMask_Gin >> k & 1) {
     queryModel_gin(comm, k, nBytes, timeUs, nBlocks);
   } else {
     queryModel_lsa(comm, k, nBytes, timeUs, nBlocks);
@@ -276,31 +251,28 @@ static const float nvlinkBws[NCCL_NVLINK_BW_IDX_NUM] = {
 // helpers, plus calcSatBlocks/getRequirements_gin used by the scheduler.
 static double getLsaBw(struct ncclComm* comm) {
   int compCapIndex = comm->minCompCap >= 100 ? NCCL_NVLINK_BW_IDX_BLACKWELL : NCCL_NVLINK_BW_IDX_HOPPER;
-  return (/*byte/sec*/1.e9)*nvlinkBws[compCapIndex];
+  return (/*byte/sec*/ 1.e9) * nvlinkBws[compCapIndex];
 }
 
 static double getGinLat(struct ncclComm* comm) {
-  return (/*sec/usec*/1.e-6)*comm->tunerConstants.hwLatencies[NCCL_HW_NET][NCCL_ALGO_RING][NCCL_PROTO_SIMPLE];
+  return (/*sec/usec*/ 1.e-6) * comm->tunerConstants.hwLatencies[NCCL_HW_NET][NCCL_ALGO_RING][NCCL_PROTO_SIMPLE];
 }
 
 static double getGinBw(struct ncclComm* comm) {
-  return (/*byte/sec*/1.e9)*comm->minNetBw;
+  return (/*byte/sec*/ 1.e9) * comm->minNetBw;
 }
 
-static void getBusMul_ReduceScatter_RailA2A(
-    struct ncclComm* comm, bool ldmc,
-    double* out_smMul, double* out_lsaMul, double* out_ginMul
-  ) {
+static void getBusMul_ReduceScatter_RailA2A(struct ncclComm* comm, bool ldmc, double* out_smMul, double* out_lsaMul,
+                                            double* out_ginMul) {
   int lsaRanks = ncclTeamLsa(comm).nRanks;
   int railRanks = ncclTeamRail(comm).nRanks;
   *out_lsaMul = std::max(
-    /*inbound*/(ldmc ? lsaRanks : lsaRanks-1)*railRanks,
-    /*outbound*/(lsaRanks-1)*railRanks
-  );
-  *out_ginMul = railRanks-1;
+    /*inbound*/ (ldmc ? lsaRanks : lsaRanks - 1) * railRanks,
+    /*outbound*/ (lsaRanks - 1) * railRanks);
+  *out_ginMul = railRanks - 1;
   *out_smMul =
-    /*stage 0*/(lsaRanks == 1 ? 0 : (ldmc ? 1 : lsaRanks)*(railRanks-1)) +
-    /*stage 1*/(ldmc ? 1 : lsaRanks) + (railRanks-1);
+    /*stage 0*/ (lsaRanks == 1 ? 0 : (ldmc ? 1 : lsaRanks) * (railRanks - 1)) +
+    /*stage 1*/ (ldmc ? 1 : lsaRanks) + (railRanks - 1);
 }
 
 static double getSmBw_ReduceScatter_RailA2A(struct ncclComm* comm, bool ldmc) {
@@ -321,11 +293,11 @@ static int calcSatBlocks_ReduceScatter_RailA2A(struct ncclComm* comm, bool ldmc)
   double smBw = getSmBw_ReduceScatter_RailA2A(comm, ldmc);
   double smMul, lsaMul, ginMul;
   getBusMul_ReduceScatter_RailA2A(comm, ldmc, &smMul, &lsaMul, &ginMul);
-  double minLsaGinEffBw = std::min(lsaBw/lsaMul, ginBw/ginMul);
-  return std::ceil(std::min(double(1<<30), minLsaGinEffBw/(smBw/smMul)));
+  double minLsaGinEffBw = std::min(lsaBw / lsaMul, ginBw / ginMul);
+  return std::ceil(std::min(double(1 << 30), minLsaGinEffBw / (smBw / smMul)));
 }
 
-static void getRequirements_gin(struct ncclComm* comm, int* out_nBlocks, size_t* out_bufSize ) {
+static void getRequirements_gin(struct ncclComm* comm, int* out_nBlocks, size_t* out_bufSize) {
   *out_nBlocks = 0;
   *out_bufSize = 0;
   for (int ldmc = 0; ldmc <= 1; ldmc++) {
@@ -335,12 +307,13 @@ static void getRequirements_gin(struct ncclComm* comm, int* out_nBlocks, size_t*
     double smLat = getSmLat_ReduceScatter_RailA2A(comm, ldmc);
     double smMul, lsaMul, ginMul;
     getBusMul_ReduceScatter_RailA2A(comm, ldmc, &smMul, &lsaMul, &ginMul);
-    double ginBwRenorm = std::min(lsaBw/lsaMul, ginBw/ginMul)*ginMul;
-    size_t bufSize = ginBwRenorm*(ginLat + smLat);
+    double ginBwRenorm = std::min(lsaBw / lsaMul, ginBw / ginMul) * ginMul;
+    size_t bufSize = ginBwRenorm * (ginLat + smLat);
     int nBlocks = calcSatBlocks_ReduceScatter_RailA2A(comm, ldmc);
     if (comm->rank == 0) {
-      double minLsaGinEffBw = std::min(lsaBw/lsaMul, ginBw/ginMul);
-      INFO(NCCL_TUNING, "ReduceScatter_RailA2A_Lsa%s : satblocks=%d bufsize=%d effbw=%g", ldmc ? "LDMC" : "LD", nBlocks, (int)bufSize, minLsaGinEffBw*smMul);
+      double minLsaGinEffBw = std::min(lsaBw / lsaMul, ginBw / ginMul);
+      INFO(NCCL_TUNING, "ReduceScatter_RailA2A_Lsa%s : satblocks=%d bufsize=%d effbw=%g", ldmc ? "LDMC" : "LD", nBlocks,
+           (int)bufSize, minLsaGinEffBw * smMul);
     }
     *out_nBlocks = std::max(*out_nBlocks, nBlocks);
     *out_bufSize = std::max(*out_bufSize, bufSize);
@@ -369,7 +342,8 @@ static void queryModel_gin(struct ncclComm* comm, ncclSymkKernelId k, size_t nBy
   *timeUs = FLT_MAX;
   *nBlocks = 0;
   switch (k) {
-  case ncclSymkKernelId_AllGather_RailRing_LsaSTMC: {
+  case ncclSymkKernelId_AllGather_RailRing_LsaSTMC:
+    {
       constexpr int railChunkSize = ncclSymkAllGather_RailRing_ChunkSize;
       int requiredBlocks = DIVUP(nBytes, railChunkSize);
       float intraBw = lsaBw;
@@ -379,27 +353,31 @@ static void queryModel_gin(struct ncclComm* comm, ncclSymkKernelId k, size_t nBy
       uint32_t steps = DIVUP(nBytes, railChunkSize) * (rail.nRanks - 1);
       *timeUs = steps * ginLat + std::max(intraTime, interTime);
       *nBlocks = std::max(nMinBlocks, std::min(nMaxBlocks, requiredBlocks));
-    } break;
+    }
+    break;
   case ncclSymkKernelId_ReduceScatter_RailA2A_LsaLD:
-  case ncclSymkKernelId_ReduceScatter_RailA2A_LsaLDMC: {
+  case ncclSymkKernelId_ReduceScatter_RailA2A_LsaLDMC:
+    {
       bool ldmc = k == ncclSymkKernelId_ReduceScatter_RailA2A_LsaLDMC;
       nMaxBlocks = std::min(nMaxBlocks, symk->maxGinInboxBlocks);
       nMaxBlocks = std::min(nMaxBlocks, calcSatBlocks_ReduceScatter_RailA2A(comm, ldmc));
-      constexpr int chunkSize = 64<<10;
+      constexpr int chunkSize = 64 << 10;
       double smBw = getSmBw_ReduceScatter_RailA2A(comm, ldmc);
       double smMul, lsaMul, ginMul;
       getBusMul_ReduceScatter_RailA2A(comm, ldmc, &smMul, &lsaMul, &ginMul);
       *nBlocks = divUp(nBytes, chunkSize);
       *nBlocks = std::max(nMinBlocks, std::min(nMaxBlocks, *nBlocks));
-      double effBw = (*nBlocks)*(smBw/smMul);
-      effBw = std::min(effBw, lsaBw/lsaMul);
-      effBw = std::min(effBw, ginBw/ginMul);
-      double time = nBytes/effBw;
-      time += std::min<size_t>(nBytes, chunkSize*(*nBlocks))*(lsaMul/lsaBw + ginMul/ginBw);
+      double effBw = (*nBlocks) * (smBw / smMul);
+      effBw = std::min(effBw, lsaBw / lsaMul);
+      effBw = std::min(effBw, ginBw / ginMul);
+      double time = nBytes / effBw;
+      time += std::min<size_t>(nBytes, chunkSize * (*nBlocks)) * (lsaMul / lsaBw + ginMul / ginBw);
       time += ginLat;
-      *timeUs = (/*usec/sec=*/1.e6)*time;
-    } break;
-  default: break;
+      *timeUs = (/*usec/sec=*/1.e6) * time;
+    }
+    break;
+  default:
+    break;
   }
 }
 
@@ -414,54 +392,54 @@ static void queryModel_lsa(struct ncclComm* comm, ncclSymkKernelId k, size_t nBy
 
   switch (k) {
   default:
-    busBytes = size_t(1)<<50;
+    busBytes = size_t(1) << 50;
     break;
 
   case ncclSymkKernelId_AllReduce_AGxLL_R:
-    busBytes = nRanks*nBytes*LL_BusFactor;
+    busBytes = nRanks * nBytes * LL_BusFactor;
     break;
   case ncclSymkKernelId_AllReduce_AGxLLMC_R:
-    busBytes = nRanks*nBytes*LL_BusFactor;
+    busBytes = nRanks * nBytes * LL_BusFactor;
     busMultiplier = 1.1; // To beat non-MC LL
     break;
   case ncclSymkKernelId_AllReduce_RSxTmaLD_AGxTmaST:
   case ncclSymkKernelId_AllReduce_RSxLD_AGxST:
-    busBytes = 2*nBytes*(nRanks-1)/nRanks;
+    busBytes = 2 * nBytes * (nRanks - 1) / nRanks;
     break;
   case ncclSymkKernelId_AllReduce_RSxLDMC_AGxSTMC:
-    busBytes = nBytes/nRanks + nBytes;
+    busBytes = nBytes / nRanks + nBytes;
     busMultiplier = nRanks;
     nMaxBlocks = nMaxBlocksNvls;
     break;
 
   case ncclSymkKernelId_AllGather_LL:
-    busBytes = nRanks*nBytes*LL_BusFactor;
+    busBytes = nRanks * nBytes * LL_BusFactor;
     break;
   case ncclSymkKernelId_AllGather_LLMC:
-    busBytes = nRanks*nBytes*LL_BusFactor;
+    busBytes = nRanks * nBytes * LL_BusFactor;
     busMultiplier = 1.1; // To beat non-MC LL
     break;
   case ncclSymkKernelId_AllGather_TmaST:
   case ncclSymkKernelId_AllGather_ST:
-    busBytes = (nRanks-1)*nBytes;
+    busBytes = (nRanks - 1) * nBytes;
     break;
   case ncclSymkKernelId_AllGather_TmaSTMC:
   case ncclSymkKernelId_AllGather_STMC:
-    busBytes = (nRanks-1)*nBytes; // Wrong. Should be nRanks*nBytes but we want to beat non-MC.
-    busMultiplier = 0.55*nRanks;
+    busBytes = (nRanks - 1) * nBytes; // Wrong. Should be nRanks*nBytes but we want to beat non-MC.
+    busMultiplier = 0.55 * nRanks;
     nMaxBlocks = nMaxBlocksNvls;
     break;
 
   case ncclSymkKernelId_ReduceScatter_LL:
-    busBytes = nRanks*nBytes*LL_BusFactor;
+    busBytes = nRanks * nBytes * LL_BusFactor;
     break;
   case ncclSymkKernelId_ReduceScatter_TmaLD:
   case ncclSymkKernelId_ReduceScatter_LD:
-    busBytes = (nRanks-1)*nBytes;
+    busBytes = (nRanks - 1) * nBytes;
     break;
   case ncclSymkKernelId_ReduceScatter_LDMC:
-    busBytes = (nRanks-1)*nBytes; // Wrong. Should be nRanks*nBytes but we want to beat non-MC.
-    busMultiplier = 0.55*nRanks;
+    busBytes = (nRanks - 1) * nBytes; // Wrong. Should be nRanks*nBytes but we want to beat non-MC.
+    busMultiplier = 0.55 * nRanks;
     nMaxBlocks = nMaxBlocksNvls;
     break;
   }
@@ -472,17 +450,15 @@ static void queryModel_lsa(struct ncclComm* comm, ncclSymkKernelId k, size_t nBy
   int nUserCTAs = std::min<int>(ncclSymkMaxBlocks, ncclParamSymCTAs());
   if (nUserCTAs > 0) nMinBlocks = nMaxBlocks = nUserCTAs;
 
-  bool isLL = kernelMask_LL>>k & 1;
-  bool isAG = kernelMask_AG>>k & 1;
-  bool isAR = kernelMask_AR>>k & 1;
-  constexpr double GBps = (1<<30)/1.e6;
+  bool isLL = kernelMask_LL >> k & 1;
+  bool isAG = kernelMask_AG >> k & 1;
+  bool isAR = kernelMask_AR >> k & 1;
+  constexpr double GBps = (1 << 30) / 1.e6;
   double baseLat, smBw, peakBw;
   double withinPeakFactor = 1.025;
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
   {
-    int c = isAR   ? rcclSymkColl_AllReduce
-        : isAG   ? rcclSymkColl_AllGather
-                 : rcclSymkColl_ReduceScatter;
+    int c = isAR ? rcclSymkColl_AllReduce : isAG ? rcclSymkColl_AllGather : rcclSymkColl_ReduceScatter;
     int p = isLL ? rcclSymkProto_LL : rcclSymkProto_Simple;
     const struct rcclSymkTuningModel& m = rcclSymkTuningModels[rcclSymkTuningModelIndex()];
     baseLat = m.baseLat[c][p];
@@ -494,12 +470,12 @@ static void queryModel_lsa(struct ncclComm* comm, ncclSymkKernelId k, size_t nBy
 #else
   if (comm->cudaArch < 1000) {
     baseLat = isLL ? 4.5 : 7.8;
-    smBw = isAR ? 65*GBps : 44*GBps;
-    peakBw = k == ncclSymkKernelId_AllReduce_RSxLDMC_AGxSTMC ? 480*GBps : 320*GBps;
+    smBw = isAR ? 65 * GBps : 44 * GBps;
+    peakBw = k == ncclSymkKernelId_AllReduce_RSxLDMC_AGxSTMC ? 480 * GBps : 320 * GBps;
   } else {
     baseLat = isLL ? (isAG ? 8.5 : 11) : (isAR ? 19.5 : 13.0);
-    smBw = 55*GBps;
-    peakBw = k == ncclSymkKernelId_AllReduce_RSxLDMC_AGxSTMC ? 1000*GBps : 600*GBps;
+    smBw = 55 * GBps;
+    peakBw = k == ncclSymkKernelId_AllReduce_RSxLDMC_AGxSTMC ? 1000 * GBps : 600 * GBps;
   }
 #endif
   *nBlocks = nMaxBlocks;
@@ -507,7 +483,7 @@ static void queryModel_lsa(struct ncclComm* comm, ncclSymkKernelId k, size_t nBy
   // Use least number of blocks that puts us within a tolerance of peak performance.
   for (int bn = nMinBlocks; bn < nMaxBlocks; bn++) {
     double time = model(busBytes, baseLat, bn, smBw, busMultiplier, peakBw);
-    if (time <= withinPeakFactor*(*timeUs)) {
+    if (time <= withinPeakFactor * (*timeUs)) {
       *nBlocks = bn;
       *timeUs = time;
       break;
@@ -529,10 +505,9 @@ ncclResult_t ncclSymkInitOnce(struct ncclComm* comm) {
     reqs.lsaBarrierCount = ncclSymkMaxBlocks;
 
     struct ncclDevResourceRequirements lla2aReq;
-    ncclLLA2ACreateRequirement(
-      ncclSymkMaxBlocks, ncclLLA2ACalcSlots(ncclTeamLsa(comm).nRanks*ncclSymkMaxThreads, ncclSymkLLMaxEltSize),
-      &symk->kcomm.lsaLLA2A, &lla2aReq
-    );
+    ncclLLA2ACreateRequirement(ncclSymkMaxBlocks,
+                               ncclLLA2ACalcSlots(ncclTeamLsa(comm).nRanks * ncclSymkMaxThreads, ncclSymkLLMaxEltSize),
+                               &symk->kcomm.lsaLLA2A, &lla2aReq);
     lla2aReq.next = reqs.resourceRequirementsList;
     reqs.resourceRequirementsList = &lla2aReq;
 
@@ -550,17 +525,12 @@ ncclResult_t ncclSymkInitOnce(struct ncclComm* comm) {
       maxBlocks = std::min(maxBlocks, ncclSymkMaxBlocks);
       symk->maxGinInboxBlocks = maxBlocks;
 
-      ncclGinInboxA2ACreateRequirement(
-        ncclTeamRail(comm), maxBlocks, log2Up(bufSize),
-        &symk->kcomm.ginInboxRail, &ginInboxRailReq
-      );
+      ncclGinInboxA2ACreateRequirement(ncclTeamRail(comm), maxBlocks, log2Up(bufSize), &symk->kcomm.ginInboxRail,
+                                       &ginInboxRailReq);
       ginInboxRailReq.next = reqs.resourceRequirementsList;
       reqs.resourceRequirementsList = &ginInboxRailReq;
 
-      ncclGinOutboxCreateRequirement(
-        maxBlocks, log2Up(bufSize),
-        &symk->kcomm.ginOutbox, &ginOutboxReq
-      );
+      ncclGinOutboxCreateRequirement(maxBlocks, log2Up(bufSize), &symk->kcomm.ginOutbox, &ginOutboxReq);
       ginOutboxReq.next = reqs.resourceRequirementsList;
       reqs.resourceRequirementsList = &ginOutboxReq;
 
@@ -592,7 +562,7 @@ ncclResult_t ncclSymkFinalize(struct ncclComm* comm) {
   return ncclSuccess;
 }
 
-static bool ncclSymkImplemented(ncclFunc_t coll, int/*ncclDevRedOp_t*/ red, ncclDataType_t ty) {
+static bool ncclSymkImplemented(ncclFunc_t coll, int /*ncclDevRedOp_t*/ red, ncclDataType_t ty) {
   bool isFloat;
   switch (ty) {
   case ncclFloat64:
@@ -628,7 +598,8 @@ static bool ncclSymkImplemented(ncclFunc_t coll, int/*ncclDevRedOp_t*/ red, nccl
   }
 }
 
-static uint32_t ncclSymkMask(struct ncclComm* comm, ncclFunc_t coll, int/*ncclDevRedOp_t*/ red, ncclDataType_t ty, size_t nElts) {
+static uint32_t ncclSymkMask(struct ncclComm* comm, ncclFunc_t coll, int /*ncclDevRedOp_t*/ red, ncclDataType_t ty,
+                             size_t nElts) {
   uint32_t kmask = kernelMask_coll(coll);
   kmask &= kernelMask_user();
 
@@ -653,19 +624,20 @@ static uint32_t ncclSymkMask(struct ncclComm* comm, ncclFunc_t coll, int/*ncclDe
     case ncclDouble:
       hasLDMC = red == ncclDevSum || red == ncclDevSumPostDiv;
       break;
-    default: break;
+    default:
+      break;
     }
   }
   if (!hasSTMC) kmask &= ~kernelMask_STMC;
   if (!hasLDMC) kmask &= ~kernelMask_LDMC;
 
-  size_t nBytes = nElts*ncclTypeSize(ty);
-  size_t nBusBytes = (coll == ncclFuncAllReduce ? 1 : comm->nRanks)*nBytes;
+  size_t nBytes = nElts * ncclTypeSize(ty);
+  size_t nBusBytes = (coll == ncclFuncAllReduce ? 1 : comm->nRanks) * nBytes;
   // LL kernels use 32-bit ints to track element counts and indices.
-  if (nBusBytes >= (size_t(2)<<30)) kmask &= ~kernelMask_LL;
+  if (nBusBytes >= (size_t(2) << 30)) kmask &= ~kernelMask_LL;
   // Any kernel might use 32-bit int to track unrolled loop chunks (which are going
   // to be at least 32 bytes per chunk)
-  if (nBusBytes >= 32*(size_t(2)<<30)) kmask = 0;
+  if (nBusBytes >= 32 * (size_t(2) << 30)) kmask = 0;
 
   bool hasTma = comm->minCompCap >= 100 && ncclParamSymTmaEnable();
   if (!hasTma) kmask &= ~kernelMask_Tma;
@@ -677,27 +649,22 @@ static uint32_t ncclSymkMask(struct ncclComm* comm, ncclFunc_t coll, int/*ncclDe
   return kmask;
 }
 
-bool ncclSymkAvailable(struct ncclComm* comm, ncclFunc_t coll, int/*ncclDevRedOp_t*/ red,
-                       ncclDataType_t ty, size_t nElts) {
-  if (!comm->isAllDirectNvlink)
-    return false;
-  if (!ncclSymkImplemented(coll, red, ty))
-    return false;
+bool ncclSymkAvailable(struct ncclComm* comm, ncclFunc_t coll, int /*ncclDevRedOp_t*/ red, ncclDataType_t ty,
+                       size_t nElts) {
+  if (!comm->isAllDirectNvlink) return false;
+  if (!ncclSymkImplemented(coll, red, ty)) return false;
 
   return (ncclSymkMask(comm, coll, red, ty, nElts) != 0);
 }
 
-ncclResult_t ncclSymkPickKernel(
-    struct ncclComm* comm, ncclFunc_t coll, int/*ncclDevRedOp_t*/ red, ncclDataType_t ty,
-    size_t nEltsTotal, size_t nEltsMax, int nWorks, ncclSymRegType_t winRegType,
-    float* estTimeUs, ncclSymkKernelId* kernelId, int* nBlocks, int* nWarps, bool* forced
-  ) {
+ncclResult_t ncclSymkPickKernel(struct ncclComm* comm, ncclFunc_t coll, int /*ncclDevRedOp_t*/ red, ncclDataType_t ty,
+                                size_t nEltsTotal, size_t nEltsMax, int nWorks, ncclSymRegType_t winRegType,
+                                float* estTimeUs, ncclSymkKernelId* kernelId, int* nBlocks, int* nWarps, bool* forced) {
   uint32_t kmask = ncclSymkMask(comm, coll, red, ty, nEltsMax);
 
-  *forced = !(kernelMask_user() == (1<<(int)ncclSymkKernelId_Count)-1);
+  *forced = !(kernelMask_user() == (1 << (int)ncclSymkKernelId_Count) - 1);
   // We currently don't support grouping for LL kernels.
-  if (nWorks > 1)
-    kmask &= ~kernelMask_LL;
+  if (nWorks > 1) kmask &= ~kernelMask_LL;
 
   if (coll == ncclFuncAllReduce) {
     if (winRegType != ncclSymSendRegRecvReg) kmask &= kernelMask_LL;
@@ -711,7 +678,7 @@ ncclResult_t ncclSymkPickKernel(
   ncclSymkKernelId bestKernel = ncclSymkKernelId_Count;
   float bestTime = 1.e30f;
   int bestBlocks = 999;
-  size_t nBytes = nEltsTotal*ncclTypeSize(ty);
+  size_t nBytes = nEltsTotal * ncclTypeSize(ty);
 
   constexpr float smPenalty = .025f; // 2.5% percent increase in time per SM
   uint32_t kmaskRemain = kmask;
@@ -720,7 +687,7 @@ ncclResult_t ncclSymkPickKernel(
     float kTime;
     int kBlocks;
     queryModel(comm, k, nBytes, &kTime, &kBlocks);
-    if (kTime*(1.0f + smPenalty*kBlocks) < bestTime*(1.0f + smPenalty*bestBlocks)) {
+    if (kTime * (1.0f + smPenalty * kBlocks) < bestTime * (1.0f + smPenalty * bestBlocks)) {
       bestKernel = k;
       bestTime = kTime;
       bestBlocks = kBlocks;
@@ -728,10 +695,10 @@ ncclResult_t ncclSymkPickKernel(
   }
 
   *kernelId = bestKernel;
-  *estTimeUs = kmask==0 || kernelMask_user() == (1<<ncclSymkKernelId_Count)-1 ? bestTime : 0.0f;
+  *estTimeUs = kmask == 0 || kernelMask_user() == (1 << ncclSymkKernelId_Count) - 1 ? bestTime : 0.0f;
   *nBlocks = bestBlocks;
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-  *nWarps = ncclSymkMaxThreads/comm->WarpSize;
+  *nWarps = ncclSymkMaxThreads / comm->WarpSize;
 #else
   *nWarps = 16;
 #endif
@@ -745,12 +712,13 @@ const char* ncclSymkKernelIdToString(int kernelId) {
   return kernelName[kernelId];
 }
 
-int ncclSymkMaxChunkElts(struct ncclComm* comm, ncclSymkKernelId kernelId, int/*ncclDevRedOp_t*/ red, ncclDataType_t ty) {
-  bool isReduce = 1 & ((kernelMask_AR|kernelMask_RS) >> (int)kernelId);
+int ncclSymkMaxChunkElts(struct ncclComm* comm, ncclSymkKernelId kernelId, int /*ncclDevRedOp_t*/ red,
+                         ncclDataType_t ty) {
+  bool isReduce = 1 & ((kernelMask_AR | kernelMask_RS) >> (int)kernelId);
   int eltSize = ncclTypeSize(ty);
   int accMult = !isReduce ? 1 : eltSize < 4 ? 2 : 1;
   int kernelIndex = ncclSymkGetKernelIndex(kernelId, red, ty);
-  return ncclSymkKernelMaxDynamicSmem[kernelIndex]/(eltSize*accMult);
+  return ncclSymkKernelMaxDynamicSmem[kernelIndex] / (eltSize * accMult);
 }
 
 /* this function fills in the devWork except nextWorkOffset */
@@ -759,15 +727,18 @@ ncclResult_t ncclSymkMakeDevWork(struct ncclComm* comm, struct ncclTaskColl* tas
   outDevWork->redOpArg = task->opDev.scalarArg;
   outDevWork->nElts = task->count;
   outDevWork->inputWin = task->sendWin ? task->sendWin->vidmem : nullptr;
-  outDevWork->inputOff = task->sendWin ? (uint8_t*)task->sendbuff - (uint8_t*)task->sendWin->userPtr : (size_t)task->sendbuff;
+  outDevWork->inputOff =
+    task->sendWin ? (uint8_t*)task->sendbuff - (uint8_t*)task->sendWin->userPtr : (size_t)task->sendbuff;
   outDevWork->outputWin = task->recvWin ? task->recvWin->vidmem : nullptr;
-  outDevWork->outputOff = task->recvWin ? (uint8_t*)task->recvbuff - (uint8_t*)task->recvWin->userPtr : (size_t)task->recvbuff;
+  outDevWork->outputOff =
+    task->recvWin ? (uint8_t*)task->recvbuff - (uint8_t*)task->recvWin->userPtr : (size_t)task->recvbuff;
   outDevWork->sChannelId = 0xffff;
   outDevWork->nChannels = 0;
   return ncclSuccess;
 }
 
-ncclResult_t ncclGetSymRegType(struct ncclDevrWindow* sendWin, struct ncclDevrWindow* recvWin, ncclSymRegType_t* winRegType) {
+ncclResult_t ncclGetSymRegType(struct ncclDevrWindow* sendWin, struct ncclDevrWindow* recvWin,
+                               ncclSymRegType_t* winRegType) {
   bool isSendSymmReg = false;
   bool isRecvSymmReg = false;
   if (sendWin && (sendWin->winFlags & NCCL_WIN_COLL_SYMMETRIC)) isSendSymmReg = true;
@@ -796,7 +767,7 @@ bool rcclSymkKernelIdIsLL(int kernelId) {
 // queryModel_gin path so the link succeeds. These stubs make every
 // kernel path return "no kernel available" -- the scheduler then falls
 // back to the regular non-symmetric kernels.
-void* ncclSymkGetKernelPtr(ncclSymkKernelId kernelId, int/*ncclDevRedOp_t*/ red, ncclDataType_t ty) {
+void* ncclSymkGetKernelPtr(ncclSymkKernelId kernelId, int /*ncclDevRedOp_t*/ red, ncclDataType_t ty) {
   return nullptr;
 }
 

--- a/projects/rccl/src/transport.cc
+++ b/projects/rccl/src/transport.cc
@@ -12,18 +12,16 @@
 #include "timer.h"
 #include "transport.h"
 
-struct ncclTransport* ncclTransports[NTRANSPORTS+1] = {
-  &p2pTransport,
-  &shmTransport,
-  &netTransport,
-  &collNetTransport,
+struct ncclTransport* ncclTransports[NTRANSPORTS + 1] = {
+  &p2pTransport, &shmTransport, &netTransport, &collNetTransport,
   &profilerTransport // Not really used for transport, only to create proxy ops polling on profiler counters.
 };
 
 template <int type>
-static ncclResult_t selectTransport(struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclConnect* connect, int channelId, int peer, int connIndex, int* transportType, bool* needsProxy) {
-  struct ncclPeerInfo* myInfo = comm->peerInfo+comm->rank;
-  struct ncclPeerInfo* peerInfo = comm->peerInfo+peer;
+static ncclResult_t selectTransport(struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclConnect* connect,
+                                    int channelId, int peer, int connIndex, int* transportType, bool* needsProxy) {
+  struct ncclPeerInfo* myInfo = comm->peerInfo + comm->rank;
+  struct ncclPeerInfo* peerInfo = comm->peerInfo + peer;
   struct ncclConnector* connector = (type == 1) ? comm->channels[channelId].peers[peer]->send + connIndex :
                                                   comm->channels[channelId].peers[peer]->recv + connIndex;
   // handle intra-node network connections
@@ -35,10 +33,11 @@ static ncclResult_t selectTransport(struct ncclComm* comm, struct ncclTopoGraph*
   bool xgmi;
   NCCLCHECK(ncclTopoGetLinkType(comm->topo, myInfo->cudaDev, peerInfo->cudaDev, &xgmi));
 
-  for (int t=0; t<NTRANSPORTS; t++) {
-    if (graph == NULL && connIndex == NCCL_CONN_IDX_P2P_NET && (t == TRANSPORT_SHM || (!xgmi && t == TRANSPORT_P2P))) continue;
+  for (int t = 0; t < NTRANSPORTS; t++) {
+    if (graph == NULL && connIndex == NCCL_CONN_IDX_P2P_NET && (t == TRANSPORT_SHM || (!xgmi && t == TRANSPORT_P2P)))
+      continue;
     if (graph && n1 >= 0 && n2 >= 0 && t != TRANSPORT_NET) continue;
-    struct ncclTransport *transport = ncclTransports[t];
+    struct ncclTransport* transport = ncclTransports[t];
     struct ncclTransportComm* transportComm = type == 1 ? &transport->send : &transport->recv;
     int ret = 0;
     NCCLCHECK(transport->canConnect(&ret, comm, graph, myInfo, peerInfo));
@@ -50,36 +49,40 @@ static ncclResult_t selectTransport(struct ncclComm* comm, struct ncclTopoGraph*
       return ncclSuccess;
     }
   }
-  WARN("No transport found for rank %d[%lx] -> rank %d[%lx]", myInfo->rank, myInfo->busId, peerInfo->rank, peerInfo->busId);
+  WARN("No transport found for rank %d[%lx] -> rank %d[%lx]", myInfo->rank, myInfo->busId, peerInfo->rank,
+       peerInfo->busId);
   return ncclSystemError;
 }
 
-ncclResult_t ncclTransportP2pConnect(struct ncclComm* comm, int channelId, int nrecv, int* peerRecv, int nsend, int* peerSend, int connIndex) {
+ncclResult_t ncclTransportP2pConnect(struct ncclComm* comm, int channelId, int nrecv, int* peerRecv, int nsend,
+                                     int* peerSend, int connIndex) {
   TRACE(NCCL_INIT, "nsend %d nrecv %d", nsend, nrecv);
   struct ncclChannel* channel = &comm->channels[channelId];
-  //uint64_t mask = 1UL << channel->id;
+  // uint64_t mask = 1UL << channel->id;
   uint64_t mask = 1UL << (channel->id % 64);
 
-  for (int i=0; i<nrecv; i++) {
+  for (int i = 0; i < nrecv; i++) {
     int peer = peerRecv[i];
-    if (peer == -1 || peer >= comm->nRanks || peer == comm->rank || channel->peers[peer]->recv[connIndex].connected) continue;
-    //comm->connectRecv[peer+comm->nRanks*(connIndex == NCCL_CONN_IDX_P2P_NET ? NCCL_CONN_IDX_P2P_NET : 0)] |= mask;
-    comm->connectRecv[peer+CHANNEL_MASK_OFFSET(comm->nRanks, connIndex)].masks[channel->id / 64] |= mask;
+    if (peer == -1 || peer >= comm->nRanks || peer == comm->rank || channel->peers[peer]->recv[connIndex].connected)
+      continue;
+    // comm->connectRecv[peer+comm->nRanks*(connIndex == NCCL_CONN_IDX_P2P_NET ? NCCL_CONN_IDX_P2P_NET : 0)] |= mask;
+    comm->connectRecv[peer + CHANNEL_MASK_OFFSET(comm->nRanks, connIndex)].masks[channel->id / 64] |= mask;
   }
-  for (int i=0; i<nsend; i++) {
+  for (int i = 0; i < nsend; i++) {
     int peer = peerSend[i];
-    if (peer == -1 || peer >= comm->nRanks || peer == comm->rank || channel->peers[peer]->send[connIndex].connected) continue;
-    //comm->connectSend[peer+comm->nRanks*(connIndex == NCCL_CONN_IDX_P2P_NET ? NCCL_CONN_IDX_P2P_NET : 0)] |= mask;
-    comm->connectSend[peer+CHANNEL_MASK_OFFSET(comm->nRanks, connIndex)].masks[channel->id / 64] |= mask;
+    if (peer == -1 || peer >= comm->nRanks || peer == comm->rank || channel->peers[peer]->send[connIndex].connected)
+      continue;
+    // comm->connectSend[peer+comm->nRanks*(connIndex == NCCL_CONN_IDX_P2P_NET ? NCCL_CONN_IDX_P2P_NET : 0)] |= mask;
+    comm->connectSend[peer + CHANNEL_MASK_OFFSET(comm->nRanks, connIndex)].masks[channel->id / 64] |= mask;
   }
   return ncclSuccess;
 }
 
 void dumpData(struct ncclConnect* data, int ndata) {
-  for (int n=0; n<ndata; n++) {
+  for (int n = 0; n < ndata; n++) {
     printf("[%d] ", n);
     uint8_t* d = (uint8_t*)data;
-    for (int i=0; i<sizeof(struct ncclConnect); i++) printf("%02x", d[i]);
+    for (int i = 0; i < sizeof(struct ncclConnect); i++) printf("%02x", d[i]);
     printf("\n");
   }
 }
@@ -108,8 +111,8 @@ ncclResult_t ncclTransportCheckP2pType(struct ncclComm* comm, bool* isAllDirectP
       int canConnect = 0;
       int intermediateRank = -1;
       int cudaP2p = 0;
-      NCCLCHECK(ncclTopoCheckP2p(comm, comm->topo, ipeerInfo->rank, jpeerInfo->rank,
-                                 &canConnect, NULL, &intermediateRank, &cudaP2p));
+      NCCLCHECK(ncclTopoCheckP2p(comm, comm->topo, ipeerInfo->rank, jpeerInfo->rank, &canConnect, NULL,
+                                 &intermediateRank, &cudaP2p));
       if (!canConnect || intermediateRank != -1) {
         ncclP2pFlag = false;
       }
@@ -127,12 +130,13 @@ ncclResult_t ncclTransportCheckP2pType(struct ncclComm* comm, bool* isAllDirectP
   *isAllDirectP2p = ncclP2pFlag;
   *directMode = directFlag;
   *isAllCudaP2p = cudaP2pFlag;
-  INFO(NCCL_INIT, "Check P2P Type isAllDirectP2p %d directMode %d isAllCudaP2p %d",
-       *isAllDirectP2p, *directMode, *isAllCudaP2p);
+  INFO(NCCL_INIT, "Check P2P Type isAllDirectP2p %d directMode %d isAllCudaP2p %d", *isAllDirectP2p, *directMode,
+       *isAllCudaP2p);
   return ncclSuccess;
 }
 
-ncclResult_t ncclTransportP2pSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, int connIndex, bool* needsProxy/*=NULL*/) {
+ncclResult_t ncclTransportP2pSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, int connIndex,
+                                   bool* needsProxy /*=NULL*/) {
   // Stream used during transport setup; need for P2P pre-connect + CUDA Graph
   ncclResult_t ret = ncclSuccess;
   bool needsProxyResult = false;
@@ -149,38 +153,42 @@ ncclResult_t ncclTransportP2pSetup(struct ncclComm* comm, struct ncclTopoGraph* 
   cudaStream_t hostStream, deviceStream;
 
   int count = 0;
-  int num = MAXCHANNELS/64;
+  int num = MAXCHANNELS / 64;
 
   NCCLCHECK(ncclCalloc(&data, maxPeers));
   NCCLCHECKGOTO(ncclCalloc(&recvData, maxPeers), ret, fail);
   NCCLCHECKGOTO(ncclCalloc(&sendData, maxPeers), ret, fail);
 
-  NCCLCHECKGOTO(ncclStrongStreamAcquire(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->hostStream, /*concurrent=*/false, &hostStream), ret, fail);
-  NCCLCHECKGOTO(ncclStrongStreamAcquire(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->deviceStream, /*concurrent=*/false, &deviceStream), ret, fail);
+  NCCLCHECKGOTO(ncclStrongStreamAcquire(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->hostStream,
+                                        /*concurrent=*/false, &hostStream),
+                ret, fail);
+  NCCLCHECKGOTO(ncclStrongStreamAcquire(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->deviceStream,
+                                        /*concurrent=*/false, &deviceStream),
+                ret, fail);
   // First time initialization
-  for (int i=1; i<comm->nRanks; i++) {
-    int bootstrapTag = (i<<8) + (graph ? graph->id+1 : 0);
+  for (int i = 1; i < comm->nRanks; i++) {
+    int bootstrapTag = (i << 8) + (graph ? graph->id + 1 : 0);
     int recvPeer = (comm->rank - i + comm->nRanks) % comm->nRanks;
     int sendPeer = (comm->rank + i) % comm->nRanks;
     /*uint64_t recvMask = comm->connectRecv[recvPeer+comm->nRanks*(connIndex == NCCL_CONN_IDX_P2P_NET ? NCCL_CONN_IDX_P2P_NET : 0)];
     uint64_t sendMask = comm->connectSend[sendPeer+comm->nRanks*(connIndex == NCCL_CONN_IDX_P2P_NET ? NCCL_CONN_IDX_P2P_NET : 0)];*/
-    struct channelMasks recvMask = comm->connectRecv[recvPeer+CHANNEL_MASK_OFFSET(comm->nRanks, connIndex)];
-    struct channelMasks sendMask = comm->connectSend[sendPeer+CHANNEL_MASK_OFFSET(comm->nRanks, connIndex)];
+    struct channelMasks recvMask = comm->connectRecv[recvPeer + CHANNEL_MASK_OFFSET(comm->nRanks, connIndex)];
+    struct channelMasks sendMask = comm->connectSend[sendPeer + CHANNEL_MASK_OFFSET(comm->nRanks, connIndex)];
 
     // Data[i] contains all ncclConnect information for all send and receive connections with a given send and recv peer
     // This data is packed in the array based on the number of sendChannels and recvChannels connected with these peers
     // The first N entries contain recvData, connection information for recv connections
     // The next M entries contain sendData, connection information for send connections
     // It's not guaranteed that each entry of data has the same number of total or send/recv specific connections
-    int p = i-(done+1);
+    int p = i - (done + 1);
     count = 0;
     for (int j = 0; j < num; j++) {
-        if ((recvMask.masks[j]) || (sendMask.masks[j])) {
-                count++;
-        }
+      if ((recvMask.masks[j]) || (sendMask.masks[j])) {
+        count++;
+      }
     }
 
-    //if ((recvMask.masks[0]) || (sendMask.masks[0])) NCCLCHECK(ncclCalloc(data+p, 2*MAXCHANNELS));
+    // if ((recvMask.masks[0]) || (sendMask.masks[0])) NCCLCHECK(ncclCalloc(data+p, 2*MAXCHANNELS));
     if (count) {
       if (data[p] == NULL) NCCLCHECKGOTO(ncclCalloc(data + p, 2 * MAXCHANNELS), ret, fail);
 
@@ -191,19 +199,23 @@ ncclResult_t ncclTransportP2pSetup(struct ncclComm* comm, struct ncclTopoGraph* 
     int type;
     bool proxy;
     TIME_START(0);
-    for (int c=0; c<MAXCHANNELS; c++) {
-      //if (recvMask & (1UL<<c)) {
-      if (recvMask.masks[c/64] & (1UL<<(c%64))) {
-        NCCLCHECKGOTO(selectTransport<0>(comm, graph, recvData[p]+recvChannels++, c, recvPeer, connIndex, &type, &proxy), ret, fail);
+    for (int c = 0; c < MAXCHANNELS; c++) {
+      // if (recvMask & (1UL<<c)) {
+      if (recvMask.masks[c / 64] & (1UL << (c % 64))) {
+        NCCLCHECKGOTO(selectTransport<0>(comm, graph, recvData[p] + recvChannels++, c, recvPeer, connIndex, &type,
+                                         &proxy),
+                      ret, fail);
       }
     }
     TIME_STOP(0);
     TIME_START(1);
-    sendData[p] = recvData[p]+recvChannels;
-    for (int c=0; c<MAXCHANNELS; c++) {
-      //if (sendMask & (1UL<<c)) {
-      if (sendMask.masks[c/64] & (1UL<<(c%64))) {
-        NCCLCHECKGOTO(selectTransport<1>(comm, graph, sendData[p]+sendChannels++, c, sendPeer, connIndex, &type, &proxy), ret, fail);
+    sendData[p] = recvData[p] + recvChannels;
+    for (int c = 0; c < MAXCHANNELS; c++) {
+      // if (sendMask & (1UL<<c)) {
+      if (sendMask.masks[c / 64] & (1UL << (c % 64))) {
+        NCCLCHECKGOTO(selectTransport<1>(comm, graph, sendData[p] + sendChannels++, c, sendPeer, connIndex, &type,
+                                         &proxy),
+                      ret, fail);
         needsProxyResult |= proxy;
       }
     }
@@ -211,49 +223,69 @@ ncclResult_t ncclTransportP2pSetup(struct ncclComm* comm, struct ncclTopoGraph* 
 
     TIME_START(2);
     if (sendPeer == recvPeer) {
-      if (recvChannels+sendChannels) {
-        NCCLCHECKGOTO(bootstrapSend(comm->bootstrap, recvPeer, bootstrapTag, data[p], sizeof(struct ncclConnect)*(recvChannels+sendChannels)), ret, fail);
-        NCCLCHECKGOTO(bootstrapRecv(comm->bootstrap, recvPeer, bootstrapTag, data[p], sizeof(struct ncclConnect)*(recvChannels+sendChannels)), ret, fail);
+      if (recvChannels + sendChannels) {
+        NCCLCHECKGOTO(bootstrapSend(comm->bootstrap, recvPeer, bootstrapTag, data[p],
+                                    sizeof(struct ncclConnect) * (recvChannels + sendChannels)),
+                      ret, fail);
+        NCCLCHECKGOTO(bootstrapRecv(comm->bootstrap, recvPeer, bootstrapTag, data[p],
+                                    sizeof(struct ncclConnect) * (recvChannels + sendChannels)),
+                      ret, fail);
         sendData[p] = data[p];
-        recvData[p] = data[p]+sendChannels;
+        recvData[p] = data[p] + sendChannels;
       }
     } else {
-      if (recvChannels) NCCLCHECKGOTO(bootstrapSend(comm->bootstrap, recvPeer, bootstrapTag, recvData[p], sizeof(struct ncclConnect)*recvChannels), ret, fail);
-      if (sendChannels) NCCLCHECKGOTO(bootstrapSend(comm->bootstrap, sendPeer, bootstrapTag, sendData[p], sizeof(struct ncclConnect)*sendChannels), ret, fail);
-      if (sendChannels) NCCLCHECKGOTO(bootstrapRecv(comm->bootstrap, sendPeer, bootstrapTag, sendData[p], sizeof(struct ncclConnect)*sendChannels), ret, fail);
-      if (recvChannels) NCCLCHECKGOTO(bootstrapRecv(comm->bootstrap, recvPeer, bootstrapTag, recvData[p], sizeof(struct ncclConnect)*recvChannels), ret, fail);
+      if (recvChannels)
+        NCCLCHECKGOTO(bootstrapSend(comm->bootstrap, recvPeer, bootstrapTag, recvData[p],
+                                    sizeof(struct ncclConnect) * recvChannels),
+                      ret, fail);
+      if (sendChannels)
+        NCCLCHECKGOTO(bootstrapSend(comm->bootstrap, sendPeer, bootstrapTag, sendData[p],
+                                    sizeof(struct ncclConnect) * sendChannels),
+                      ret, fail);
+      if (sendChannels)
+        NCCLCHECKGOTO(bootstrapRecv(comm->bootstrap, sendPeer, bootstrapTag, sendData[p],
+                                    sizeof(struct ncclConnect) * sendChannels),
+                      ret, fail);
+      if (recvChannels)
+        NCCLCHECKGOTO(bootstrapRecv(comm->bootstrap, recvPeer, bootstrapTag, recvData[p],
+                                    sizeof(struct ncclConnect) * recvChannels),
+                      ret, fail);
     }
     TIME_STOP(2);
 
-    if (i-done == maxPeers || i == comm->nRanks-1) {
+    if (i - done == maxPeers || i == comm->nRanks - 1) {
       // Loop until all channels with all ranks have been connected
       bool allChannelsConnected;
       allChannelsConnected = false;
       while (!allChannelsConnected) {
         allChannelsConnected = true;
-        for (int j=done+1; j<=i; j++) {
+        for (int j = done + 1; j <= i; j++) {
           int recvPeer = (comm->rank - j + comm->nRanks) % comm->nRanks;
           int sendPeer = (comm->rank + j) % comm->nRanks;
           /*uint64_t recvMask = comm->connectRecv[recvPeer+comm->nRanks*(connIndex == NCCL_CONN_IDX_P2P_NET ? NCCL_CONN_IDX_P2P_NET : 0)];
           uint64_t sendMask = comm->connectSend[sendPeer+comm->nRanks*(connIndex == NCCL_CONN_IDX_P2P_NET ? NCCL_CONN_IDX_P2P_NET : 0)];*/
-          struct channelMasks recvMask = comm->connectRecv[recvPeer+CHANNEL_MASK_OFFSET(comm->nRanks, connIndex)];
-          struct channelMasks sendMask = comm->connectSend[sendPeer+CHANNEL_MASK_OFFSET(comm->nRanks, connIndex)];
+          struct channelMasks recvMask = comm->connectRecv[recvPeer + CHANNEL_MASK_OFFSET(comm->nRanks, connIndex)];
+          struct channelMasks sendMask = comm->connectSend[sendPeer + CHANNEL_MASK_OFFSET(comm->nRanks, connIndex)];
 
-          int p = j-(done+1);
+          int p = j - (done + 1);
           int sendDataOffset = 0;
           int recvDataOffset = 0;
-          for (int c=0; c<MAXCHANNELS; c++) {
+          for (int c = 0; c < MAXCHANNELS; c++) {
             TIME_START(3);
-            //if (sendMask & (1UL<<c)) {
-      if (sendMask.masks[c/64] & (1UL<<(c%64))) {
+            // if (sendMask & (1UL<<c)) {
+            if (sendMask.masks[c / 64] & (1UL << (c % 64))) {
               struct ncclConnector* conn = comm->channels[c].peers[sendPeer]->send + connIndex;
               // This connector hasn't completed connection yet
               if (conn->connected == 0) {
-                NCCLCHECKGOTO(conn->transportComm->connect(comm, sendData[p] + sendDataOffset, 1, comm->rank, conn), ret, fail);
+                NCCLCHECKGOTO(conn->transportComm->connect(comm, sendData[p] + sendDataOffset, 1, comm->rank, conn),
+                              ret, fail);
                 if (ret == ncclSuccess) {
                   conn->connected = 1;
                   /* comm->channels[c].devPeers[sendPeer]->send[connIndex] is a device memory access. */
-                  CUDACHECKGOTO(cudaMemcpyAsync(&comm->channels[c].devPeersHostPtr[sendPeer]->send[connIndex], &conn->conn, sizeof(struct ncclConnInfo), cudaMemcpyHostToDevice, hostStream), ret, fail);
+                  CUDACHECKGOTO(cudaMemcpyAsync(&comm->channels[c].devPeersHostPtr[sendPeer]->send[connIndex],
+                                                &conn->conn, sizeof(struct ncclConnInfo), cudaMemcpyHostToDevice,
+                                                hostStream),
+                                ret, fail);
                 } else if (ret == ncclInProgress) {
                   allChannelsConnected = false;
                 }
@@ -264,16 +296,20 @@ ncclResult_t ncclTransportP2pSetup(struct ncclComm* comm, struct ncclTopoGraph* 
 
             // Start with recv channels
             TIME_START(4);
-            //if (recvMask & (1UL<<c)) {
-      if (recvMask.masks[c/64] & (1UL<<(c%64))) {
+            // if (recvMask & (1UL<<c)) {
+            if (recvMask.masks[c / 64] & (1UL << (c % 64))) {
               struct ncclConnector* conn = comm->channels[c].peers[recvPeer]->recv + connIndex;
               // This connector hasn't completed connection yet
               if (conn->connected == 0) {
-                NCCLCHECKGOTO(conn->transportComm->connect(comm, recvData[p] + recvDataOffset, 1, comm->rank, conn), ret, fail);
+                NCCLCHECKGOTO(conn->transportComm->connect(comm, recvData[p] + recvDataOffset, 1, comm->rank, conn),
+                              ret, fail);
                 if (ret == ncclSuccess) {
                   conn->connected = 1;
                   /* comm->channels[c].devPeers[recvPeer]->recv[connIndex] is a device memory access. */
-                  CUDACHECKGOTO(cudaMemcpyAsync(&comm->channels[c].devPeersHostPtr[recvPeer]->recv[connIndex], &conn->conn, sizeof(struct ncclConnInfo), cudaMemcpyHostToDevice, hostStream), ret, fail);
+                  CUDACHECKGOTO(cudaMemcpyAsync(&comm->channels[c].devPeersHostPtr[recvPeer]->recv[connIndex],
+                                                &conn->conn, sizeof(struct ncclConnInfo), cudaMemcpyHostToDevice,
+                                                hostStream),
+                                ret, fail);
                 } else if (ret == ncclInProgress) {
                   allChannelsConnected = false;
                 }
@@ -290,7 +326,8 @@ ncclResult_t ncclTransportP2pSetup(struct ncclComm* comm, struct ncclTopoGraph* 
             float elapsed = (now.tv_sec - timeStart.tv_sec) * 1.0 + (now.tv_usec - timeStart.tv_usec) * 1e-6;
             float remaining = elapsed * (comm->nRanks - done) / done;
             printf("%sP2p connect: %g%% Elapsed %d:%02d Remaining %d:%02d                                       ",
-              timeReported ? "\r" : "", done * 100.0 / comm->nRanks, ((int)elapsed) / 60, ((int)elapsed) % 60, ((int)remaining) / 60, ((int)remaining) % 60);
+                   timeReported ? "\r" : "", done * 100.0 / comm->nRanks, ((int)elapsed) / 60, ((int)elapsed) % 60,
+                   ((int)remaining) / 60, ((int)remaining) % 60);
             fflush(stdout);
             timeReported = true;
             timeLast = now; // struct copy;
@@ -306,53 +343,61 @@ ncclResult_t ncclTransportP2pSetup(struct ncclComm* comm, struct ncclTopoGraph* 
   {
     struct timeval now;
     gettimeofday(&now, NULL);
-    float elapsed = (now.tv_sec - timeStart.tv_sec)*1.0 + (now.tv_usec-timeStart.tv_usec)*1e-6;
-    if (elapsed > 1.0) INFO(NCCL_PROFILE, "timings: rank %d nranks %d P2p connect done in %.2f", comm->rank, comm->nRanks, elapsed);
+    float elapsed = (now.tv_sec - timeStart.tv_sec) * 1.0 + (now.tv_usec - timeStart.tv_usec) * 1e-6;
+    if (elapsed > 1.0)
+      INFO(NCCL_PROFILE, "timings: rank %d nranks %d P2p connect done in %.2f", comm->rank, comm->nRanks, elapsed);
     if (timeReported) {
       printf("\rP2p connect done in %d:%02d                                                                       \n",
-            ((int)elapsed)/60, ((int)elapsed)%60);
+             ((int)elapsed) / 60, ((int)elapsed) % 60);
       fflush(stdout);
     }
   }
 
   /* We need to sync ranks here since some ranks might run too fast after connection setup
-  * and start to destroy the connection after returning from this function; however, the
-  * others might still be trying to connect and import the buffer. No sync can lead to invalid
-  * shmem/cuda buffer. In addition, we also clear all connect masks and free each connectInfo array */
+   * and start to destroy the connection after returning from this function; however, the
+   * others might still be trying to connect and import the buffer. No sync can lead to invalid
+   * shmem/cuda buffer. In addition, we also clear all connect masks and free each connectInfo array */
   for (int i = 1; i < comm->nRanks; i++) {
     int bootstrapTag = (i << 8) + (1 << 7) + (graph ? graph->id + 1 : 0);
     int recvPeer = (comm->rank - i + comm->nRanks) % comm->nRanks;
     int sendPeer = (comm->rank + i) % comm->nRanks;
 
-    for (int j = 0; j < MAXCHANNELS/64; j++) {
-    if (recvPeer != sendPeer) {
-      if (comm->connectSend[sendPeer].masks[j] != 0UL) NCCLCHECKGOTO(bootstrapSend(comm->bootstrap, sendPeer, bootstrapTag, NULL, 0), ret, fail);
-      if (comm->connectRecv[recvPeer].masks[j] != 0UL) NCCLCHECKGOTO(bootstrapSend(comm->bootstrap, recvPeer, bootstrapTag, NULL, 0), ret, fail);
-      if (comm->connectSend[sendPeer].masks[j] != 0UL) NCCLCHECKGOTO(bootstrapRecv(comm->bootstrap, sendPeer, bootstrapTag, NULL, 0), ret, fail);
-      if (comm->connectRecv[recvPeer].masks[j] != 0UL) NCCLCHECKGOTO(bootstrapRecv(comm->bootstrap, recvPeer, bootstrapTag, NULL, 0), ret, fail);
-    } else {
-      if (comm->connectSend[sendPeer].masks[j] != 0UL || comm->connectRecv[recvPeer].masks[j] != 0UL) {
-        NCCLCHECKGOTO(bootstrapSend(comm->bootstrap, sendPeer, bootstrapTag, NULL, 0), ret, fail);
-        NCCLCHECKGOTO(bootstrapRecv(comm->bootstrap, sendPeer, bootstrapTag, NULL, 0), ret, fail);
+    for (int j = 0; j < MAXCHANNELS / 64; j++) {
+      if (recvPeer != sendPeer) {
+        if (comm->connectSend[sendPeer].masks[j] != 0UL)
+          NCCLCHECKGOTO(bootstrapSend(comm->bootstrap, sendPeer, bootstrapTag, NULL, 0), ret, fail);
+        if (comm->connectRecv[recvPeer].masks[j] != 0UL)
+          NCCLCHECKGOTO(bootstrapSend(comm->bootstrap, recvPeer, bootstrapTag, NULL, 0), ret, fail);
+        if (comm->connectSend[sendPeer].masks[j] != 0UL)
+          NCCLCHECKGOTO(bootstrapRecv(comm->bootstrap, sendPeer, bootstrapTag, NULL, 0), ret, fail);
+        if (comm->connectRecv[recvPeer].masks[j] != 0UL)
+          NCCLCHECKGOTO(bootstrapRecv(comm->bootstrap, recvPeer, bootstrapTag, NULL, 0), ret, fail);
+      } else {
+        if (comm->connectSend[sendPeer].masks[j] != 0UL || comm->connectRecv[recvPeer].masks[j] != 0UL) {
+          NCCLCHECKGOTO(bootstrapSend(comm->bootstrap, sendPeer, bootstrapTag, NULL, 0), ret, fail);
+          NCCLCHECKGOTO(bootstrapRecv(comm->bootstrap, sendPeer, bootstrapTag, NULL, 0), ret, fail);
+        }
       }
-    }
-    comm->connectRecv[recvPeer+CHANNEL_MASK_OFFSET(comm->nRanks, connIndex)].masks[j] = comm->connectSend[sendPeer+CHANNEL_MASK_OFFSET(comm->nRanks, connIndex)].masks[j] = 0UL;
+      comm->connectRecv[recvPeer + CHANNEL_MASK_OFFSET(comm->nRanks, connIndex)].masks[j] =
+        comm->connectSend[sendPeer + CHANNEL_MASK_OFFSET(comm->nRanks, connIndex)].masks[j] = 0UL;
     }
   }
 
   if (needsProxy != NULL) *needsProxy = needsProxyResult;
   TIME_PRINT("P2P Setup/Connect");
 exit:
-  for(int i=0; i<maxPeers; ++i){
-    if(data[i]) free(data[i]);
+  for (int i = 0; i < maxPeers; ++i) {
+    if (data[i]) free(data[i]);
   }
   free(data);
   if (sendData) free(sendData);
   if (recvData) free(recvData);
 
   NCCLCHECK(ncclStreamWaitStream(deviceStream, hostStream, comm->sharedRes->scratchEvent));
-  NCCLCHECK(ncclStrongStreamRelease(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->hostStream, /*concurrent=*/false));
-  NCCLCHECK(ncclStrongStreamRelease(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->deviceStream, /*concurrent=*/false));
+  NCCLCHECK(ncclStrongStreamRelease(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->hostStream,
+                                    /*concurrent=*/false));
+  NCCLCHECK(ncclStrongStreamRelease(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->deviceStream,
+                                    /*concurrent=*/false));
   return ret;
 fail:
   goto exit;
@@ -362,7 +407,9 @@ extern struct ncclTransport collNetTransport;
 
 // All ranks must participate in collNetSetup call
 // We do not NCCLCHECK this call because we would fall back to P2P network in case CollNet setup fails
-bool ncclTransportCollNetSetup(struct ncclComm* comm, struct ncclTopoGraph* collNetGraph, struct ncclChannel* channel, int masterRank, int masterPeer, int collNetGraphChannelId, int type, ncclConnect* connect) {
+bool ncclTransportCollNetSetup(struct ncclComm* comm, struct ncclTopoGraph* collNetGraph, struct ncclChannel* channel,
+                               int masterRank, int masterPeer, int collNetGraphChannelId, int type,
+                               ncclConnect* connect) {
   ncclResult_t ret = ncclSuccess;
   int rank = comm->rank;
   int nranks = comm->nRanks;
@@ -370,32 +417,34 @@ bool ncclTransportCollNetSetup(struct ncclComm* comm, struct ncclTopoGraph* coll
   int isMaster = (rank == masterRank) ? 1 : 0;
 
   // check if we can connect to collnet, whose root is the nranks-th rank
-  struct ncclPeerInfo *myInfo = comm->peerInfo+rank, *peerInfo = comm->peerInfo+nranks;
+  struct ncclPeerInfo *myInfo = comm->peerInfo + rank, *peerInfo = comm->peerInfo + nranks;
   peerInfo->rank = nranks;
 
   if (isMaster && type == collNetSend) {
-    TRACE(NCCL_INIT, "CollNet [send] : rank %d collNetRank %d collNetNranks %d received connect from rank %d", rank, comm->node, nMasters, masterPeer);
+    TRACE(NCCL_INIT, "CollNet [send] : rank %d collNetRank %d collNetNranks %d received connect from rank %d", rank,
+          comm->node, nMasters, masterPeer);
   }
 
   // select
   struct ncclChannelPeer* root = channel->peers[nranks];
   // connector index: 0 for recv, 1 for send
-  struct ncclConnector* conn = (type == collNetRecv) ? root->recv+type : root->send+type;
+  struct ncclConnector* conn = (type == collNetRecv) ? root->recv + type : root->send + type;
   struct ncclTransportComm* transportComm = (type == collNetRecv) ? &(collNetTransport.recv) : &(collNetTransport.send);
   conn->transportComm = transportComm;
   // setup
-  struct ncclConnect myConnect = { 0 };
+  struct ncclConnect myConnect = {0};
   struct {
     int isMaster;
     ncclConnect connect;
-  } *allConnects = NULL;
-  ncclConnect *masterConnects = NULL;
+  }* allConnects = NULL;
+  ncclConnect* masterConnects = NULL;
   if (isMaster) {
-    NCCLCHECK(transportComm->setup(comm, collNetGraph, myInfo, peerInfo, &myConnect, conn, collNetGraphChannelId, type));
+    NCCLCHECK(transportComm->setup(comm, collNetGraph, myInfo, peerInfo, &myConnect, conn, collNetGraphChannelId,
+                                   type));
   }
   // prepare connect handles
   NCCLCHECK(ncclCalloc(&masterConnects, nMasters));
-  if (type == collNetRecv) {  // recv side: AllGather
+  if (type == collNetRecv) { // recv side: AllGather
     // all ranks must participate
     NCCLCHECKGOTO(ncclCalloc(&allConnects, nranks), ret, cleanup);
     allConnects[rank].isMaster = isMaster;
@@ -405,24 +454,28 @@ bool ncclTransportCollNetSetup(struct ncclComm* comm, struct ncclTopoGraph* coll
     int c = 0;
     for (int r = 0; r < nranks; r++) {
       if (allConnects[r].isMaster) {
-        memcpy(masterConnects+c, &(allConnects[r].connect), sizeof(struct ncclConnect));
+        memcpy(masterConnects + c, &(allConnects[r].connect), sizeof(struct ncclConnect));
         c++;
       }
     }
   } else { // send side : copy in connect info received from peer recv master
-    if (isMaster) memcpy(masterConnects+comm->node, connect, sizeof(struct ncclConnect));
+    if (isMaster) memcpy(masterConnects + comm->node, connect, sizeof(struct ncclConnect));
   }
   // connect
   if (isMaster) {
     NCCLCHECKGOTO(transportComm->connect(comm, masterConnects, nMasters, comm->node, conn), ret, cleanup);
     struct ncclDevChannelPeer* devRoot;
-    CUDACHECKGOTO(cudaMemcpy(&devRoot, channel->devPeers + nranks, sizeof(struct ncclDevChannelPeer*), cudaMemcpyDeviceToHost), ret, cleanup);
+    CUDACHECKGOTO(cudaMemcpy(&devRoot, channel->devPeers + nranks, sizeof(struct ncclDevChannelPeer*),
+                             cudaMemcpyDeviceToHost),
+                  ret, cleanup);
     struct ncclConnInfo* devConnInfo = (type == collNetRecv) ? devRoot->recv + type : devRoot->send + type;
-    CUDACHECKGOTO(cudaMemcpy(devConnInfo, &conn->conn, sizeof(struct ncclConnInfo), cudaMemcpyHostToDevice), ret, cleanup);
+    CUDACHECKGOTO(cudaMemcpy(devConnInfo, &conn->conn, sizeof(struct ncclConnInfo), cudaMemcpyHostToDevice), ret,
+                  cleanup);
   }
   if (isMaster && type == collNetRecv) {
-    memcpy(connect, masterConnects+comm->node, sizeof(struct ncclConnect));
-    TRACE(NCCL_INIT, "CollNet [recv] : rank %d collNetRank %d collNetNranks %d sent connect to rank %d", rank, comm->node, nMasters, masterPeer);
+    memcpy(connect, masterConnects + comm->node, sizeof(struct ncclConnect));
+    TRACE(NCCL_INIT, "CollNet [recv] : rank %d collNetRank %d collNetNranks %d sent connect to rank %d", rank,
+          comm->node, nMasters, masterPeer);
   }
 cleanup:
   if (allConnects != NULL) free(allConnects);
@@ -434,8 +487,9 @@ ncclResult_t ncclTransportCollNetCheck(struct ncclComm* comm, int collNetSetupFa
   // AllGather collNet setup results
   int allGatherFailures[NCCL_MAX_LOCAL_RANKS] = {0};
   allGatherFailures[comm->localRank] = collNetSetupFail;
-  NCCLCHECK(bootstrapIntraNodeAllGather(comm->bootstrap, comm->localRankToRank, comm->localRank, comm->localRanks, allGatherFailures, sizeof(int)));
-  for (int i=0; i<comm->localRanks; i++) {
+  NCCLCHECK(bootstrapIntraNodeAllGather(comm->bootstrap, comm->localRankToRank, comm->localRank, comm->localRanks,
+                                        allGatherFailures, sizeof(int)));
+  for (int i = 0; i < comm->localRanks; i++) {
     if (allGatherFailures[i] != 0) {
       collNetSetupFail = 1;
       break;
@@ -450,17 +504,17 @@ ncclResult_t ncclTransportCollNetCheck(struct ncclComm* comm, int collNetSetupFa
 
 ncclResult_t ncclTransportCollNetFree(struct ncclComm* comm) {
   // Free collNet resources
-  for (int r=0; r<comm->nChannels; r++) {
-    struct ncclChannel* channel = comm->channels+r;
+  for (int r = 0; r < comm->nChannels; r++) {
+    struct ncclChannel* channel = comm->channels + r;
     struct ncclChannelPeer* peer = channel->peers[comm->nRanks];
     if (peer) {
       if (ncclAtomicRefCountDecrement(&peer->refCount) == 0) {
-        for (int b=0; b<NCCL_MAX_CONNS; b++) {
+        for (int b = 0; b < NCCL_MAX_CONNS; b++) {
           struct ncclConnector* send = peer->send + b;
           if (send->transportResources && send->transportComm) NCCLCHECK(send->transportComm->free(comm, send));
           send->transportResources = NULL; // avoid double free
         }
-        for (int b=0; b<NCCL_MAX_CONNS; b++) {
+        for (int b = 0; b < NCCL_MAX_CONNS; b++) {
           struct ncclConnector* recv = peer->recv + b;
           if (recv->transportResources && recv->transportComm) NCCLCHECK(recv->transportComm->free(comm, recv));
           recv->transportResources = NULL; // avoid double free

--- a/projects/rccl/src/transport/coll_net.cc
+++ b/projects/rccl/src/transport/coll_net.cc
@@ -32,7 +32,7 @@ struct collNetSendConnectInfo {
 static_assert(sizeof(collNetSendConnectInfo) <= CONNECT_SIZE, "Collnet Send Connect info is too large");
 
 #define COLLNET_GROUP_NSUBS 8
-#define COLLNET_MAX_GROUPS (NCCL_PROXY_MAX_SUBS/COLLNET_GROUP_NSUBS)
+#define COLLNET_MAX_GROUPS (NCCL_PROXY_MAX_SUBS / COLLNET_GROUP_NSUBS)
 
 #define NCCL_NET_MAP_HOSTMEM 0
 #define NCCL_NET_MAP_DEVMEM 1
@@ -43,24 +43,24 @@ static_assert(sizeof(collNetSendConnectInfo) <= CONNECT_SIZE, "Collnet Send Conn
 
 #define NCCL_NET_MAP_MASK_DEVMEM 0x40000000
 #define NCCL_NET_MAP_MASK_SHARED 0x80000000
-#define NCCL_NET_MAP_MASK_USED   0x20000000
+#define NCCL_NET_MAP_MASK_USED 0x20000000
 #define NCCL_NET_MAP_MASK_OFFSET 0x1fffffff
 
-#define NCCL_NET_MAP_OFFSET_BANK(mapStruct, offsetName) \
-  ((mapStruct)->offsets.offsetName >> 30)
+#define NCCL_NET_MAP_OFFSET_BANK(mapStruct, offsetName) ((mapStruct)->offsets.offsetName >> 30)
 
-#define NCCL_NET_MAP_OFFSET_NULL(mapStruct, offsetName) \
-  (((mapStruct)->offsets.offsetName >> 29) == 0)
+#define NCCL_NET_MAP_OFFSET_NULL(mapStruct, offsetName) (((mapStruct)->offsets.offsetName >> 29) == 0)
 
 #define NCCL_NET_MAP_GET_POINTER(mapStruct, cpuOrGpu, offsetName) \
-  (NCCL_NET_MAP_OFFSET_NULL(mapStruct, offsetName) ? NULL : \
-   (mapStruct)->mems[NCCL_NET_MAP_OFFSET_BANK(mapStruct, offsetName)].cpuOrGpu##Ptr + ((mapStruct)->offsets.offsetName & NCCL_NET_MAP_MASK_OFFSET))
+  (NCCL_NET_MAP_OFFSET_NULL(mapStruct, offsetName) ? \
+     NULL : \
+     (mapStruct)->mems[NCCL_NET_MAP_OFFSET_BANK(mapStruct, offsetName)].cpuOrGpu##Ptr + \
+       ((mapStruct)->offsets.offsetName & NCCL_NET_MAP_MASK_OFFSET))
 
-#define NCCL_NET_MAP_DEV_MEM(mapStruct, offsetName) \
-  (((mapStruct)->offsets.offsetName & NCCL_NET_MAP_MASK_DEVMEM) != 0)
+#define NCCL_NET_MAP_DEV_MEM(mapStruct, offsetName) (((mapStruct)->offsets.offsetName & NCCL_NET_MAP_MASK_DEVMEM) != 0)
 
-#define NCCL_NET_MAP_ADD_POINTER(mapStruct, shared, dev, memSize, offsetName) do { \
-    int bank = NCCL_NET_MAP_MASK_USED + (dev)*NCCL_NET_MAP_MASK_DEVMEM + (shared)*NCCL_NET_MAP_MASK_SHARED; \
+#define NCCL_NET_MAP_ADD_POINTER(mapStruct, shared, dev, memSize, offsetName) \
+  do { \
+    int bank = NCCL_NET_MAP_MASK_USED + (dev) * NCCL_NET_MAP_MASK_DEVMEM + (shared) * NCCL_NET_MAP_MASK_SHARED; \
     if ((shared) == 0) { \
       if (dev) { \
         (mapStruct)->offsets.offsetName = bank + (mapStruct)->mems[NCCL_NET_MAP_DEVMEM].size; \
@@ -72,9 +72,9 @@ static_assert(sizeof(collNetSendConnectInfo) <= CONNECT_SIZE, "Collnet Send Conn
     } else { \
       (mapStruct)->offsets.offsetName = bank; \
     } \
-} while (0);
+  } while (0);
 
-struct connectMapMem{
+struct connectMapMem {
   char* gpuPtr;
   char* cpuPtr;
   int size;
@@ -116,7 +116,7 @@ struct sendResources {
   struct reqSlot (*reqFifo)[NCCL_STEPS];
   int collNetRank;
   size_t maxCollBytes;
-  volatile uint32_t* curr_hdp_reg;  // Curr GPU in ring (for rdma transport use only)
+  volatile uint32_t* curr_hdp_reg; // Curr GPU in ring (for rdma transport use only)
 };
 
 struct recvResources {
@@ -139,10 +139,11 @@ struct recvResources {
   struct reqSlot reqFifo[COLLNET_MAX_GROUPS][NCCL_STEPS];
   int collNetRank;
   size_t maxCollBytes;
-  volatile uint32_t* curr_hdp_reg;  // Curr GPU in ring (for rdma transport use only)
+  volatile uint32_t* curr_hdp_reg; // Curr GPU in ring (for rdma transport use only)
 };
 
-static ncclResult_t canConnect(int* ret, struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* info1, struct ncclPeerInfo* info2) {
+static ncclResult_t canConnect(int* ret, struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* info1,
+                               struct ncclPeerInfo* info2) {
   // This transport cannot be used for p2p
   *ret = 0;
   return ncclSuccess;
@@ -165,11 +166,12 @@ struct setupReq {
   struct ncclCollNetSharedRes* collNet;
 };
 
-
 /* Setup send connector, and return connect information for others in the coll
  * communicator to connect to me */
-static ncclResult_t sendSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* myInfo, struct ncclPeerInfo* peerInfo, struct ncclConnect* connectInfo, struct ncclConnector* send, int channelId, int connIndex) {
-  struct setupReq req = { 0 };
+static ncclResult_t sendSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* myInfo,
+                              struct ncclPeerInfo* peerInfo, struct ncclConnect* connectInfo,
+                              struct ncclConnector* send, int channelId, int connIndex) {
+  struct setupReq req = {0};
 
   int proxyRank;
   int64_t netId;
@@ -183,13 +185,16 @@ static ncclResult_t sendSetup(struct ncclComm* comm, struct ncclTopoGraph* graph
   req.collNet = comm->collNetSharedRes;
   NCCLCHECK(ncclProxyCallBlocking(comm, &send->proxyConn, ncclProxyMsgSetup, &req, sizeof(req), NULL, 0));
 
-  INFO(NCCL_INIT|NCCL_NET,"CollNet %02d/%1d : %d [send] via COLLNET/%s/%d%s%s comm %p nRanks %02d", channelId, connIndex, myInfo->rank, collNetName(comm), req.netDev,
-      req.useGdr ? "/GDRDMA" : "", req.useGdr==ncclTopoGdrModePci ? "(PCI)" : "", comm, comm->nRanks);
+  INFO(NCCL_INIT | NCCL_NET, "CollNet %02d/%1d : %d [send] via COLLNET/%s/%d%s%s comm %p nRanks %02d", channelId,
+       connIndex, myInfo->rank, collNetName(comm), req.netDev, req.useGdr ? "/GDRDMA" : "",
+       req.useGdr == ncclTopoGdrModePci ? "(PCI)" : "", comm, comm->nRanks);
   return ncclSuccess;
 }
 
-static ncclResult_t recvSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* myInfo, struct ncclPeerInfo* peerInfo, struct ncclConnect* connectInfo, struct ncclConnector* recv, int channelId, int connIndex) {
-  struct setupReq req = { 0 };
+static ncclResult_t recvSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* myInfo,
+                              struct ncclPeerInfo* peerInfo, struct ncclConnect* connectInfo,
+                              struct ncclConnector* recv, int channelId, int connIndex) {
+  struct setupReq req = {0};
 
   int proxyRank;
   int64_t netId;
@@ -202,39 +207,39 @@ static ncclResult_t recvSetup(struct ncclComm* comm, struct ncclTopoGraph* graph
   recv->proxyConn.tpLocalRank = comm->topParentLocalRanks[comm->localRank];
   NCCLCHECK(ncclProxyConnect(comm, TRANSPORT_COLLNET, 0, myInfo->rank, &recv->proxyConn));
   static_assert(sizeof(collNetRecvConnectInfo) <= sizeof(struct ncclConnect), "Collnet Recv Connect info is too big");
-  struct collNetRecvConnectInfo* info = (struct collNetRecvConnectInfo*) connectInfo;
+  struct collNetRecvConnectInfo* info = (struct collNetRecvConnectInfo*)connectInfo;
   ncclAtomicRefCountIncrement(&comm->collNetSharedRes->refCount);
   req.collNet = comm->collNetSharedRes;
-  NCCLCHECK(ncclProxyCallBlocking(comm, &recv->proxyConn, ncclProxyMsgSetup, &req, sizeof(req), &info->collNetHandle, sizeof(collNetHandle_t)));
+  NCCLCHECK(ncclProxyCallBlocking(comm, &recv->proxyConn, ncclProxyMsgSetup, &req, sizeof(req), &info->collNetHandle,
+                                  sizeof(collNetHandle_t)));
 
-  INFO(NCCL_INIT|NCCL_NET,"CollNet %02d/%1d : %d [receive] via COLLNET/%s/%d%s%s comm %p nRanks %02d", channelId, connIndex, myInfo->rank, collNetName(comm), req.netDev,
-      req.useGdr ? "/GDRDMA" : "", req.useGdr==ncclTopoGdrModePci ? "(PCI)" : "", comm, comm->nRanks);
+  INFO(NCCL_INIT | NCCL_NET, "CollNet %02d/%1d : %d [receive] via COLLNET/%s/%d%s%s comm %p nRanks %02d", channelId,
+       connIndex, myInfo->rank, collNetName(comm), req.netDev, req.useGdr ? "/GDRDMA" : "",
+       req.useGdr == ncclTopoGdrModePci ? "(PCI)" : "", comm, comm->nRanks);
   return ncclSuccess;
 }
 
 static ncclResult_t collNetDumpMap(struct connectMap* map) {
   printf("Dump map\n");
-  struct connectMapMem *mem = map->mems+NCCL_NET_MAP_HOSTMEM;
+  struct connectMapMem* mem = map->mems + NCCL_NET_MAP_HOSTMEM;
   printf("Mem 0: Host mem (%x B) CPU %p GPU %p\n", mem->size, mem->cpuPtr, mem->gpuPtr);
-  mem = map->mems+NCCL_NET_MAP_DEVMEM;
+  mem = map->mems + NCCL_NET_MAP_DEVMEM;
   printf("Mem 1: Vid  mem CPU (%x B) %p GPU %p\n", mem->size, mem->cpuPtr, mem->gpuPtr);
-  mem = map->mems+NCCL_NET_MAP_SHARED_HOSTMEM;
+  mem = map->mems + NCCL_NET_MAP_SHARED_HOSTMEM;
   printf("Mem 2: Shared Host mem (%x B) CPU %p GPU %p\n", mem->size, mem->cpuPtr, mem->gpuPtr);
-  mem = map->mems+NCCL_NET_MAP_SHARED_DEVMEM;
+  mem = map->mems + NCCL_NET_MAP_SHARED_DEVMEM;
   printf("Mem 3: Shared Vid  (%x B) mem CPU %p GPU %p\n", mem->size, mem->cpuPtr, mem->gpuPtr);
-  printf("SendMem -> Used %d Bank %d Offset %x, cpu %p gpu %p\n",
-      map->offsets.sendMem & NCCL_NET_MAP_MASK_USED ? 1 : 0,
-      NCCL_NET_MAP_OFFSET_BANK(map, sendMem), map->offsets.sendMem & NCCL_NET_MAP_MASK_OFFSET,
-      NCCL_NET_MAP_GET_POINTER(map, cpu, sendMem), NCCL_NET_MAP_GET_POINTER(map, gpu, sendMem));
-  printf("RecvMem -> Used %d Bank %d Offset %x, cpu %p gpu %p\n",
-      map->offsets.recvMem & NCCL_NET_MAP_MASK_USED ? 1 : 0,
-      NCCL_NET_MAP_OFFSET_BANK(map, recvMem), map->offsets.recvMem & NCCL_NET_MAP_MASK_OFFSET,
-      NCCL_NET_MAP_GET_POINTER(map, cpu, recvMem), NCCL_NET_MAP_GET_POINTER(map, gpu, recvMem));
-  for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
+  printf("SendMem -> Used %d Bank %d Offset %x, cpu %p gpu %p\n", map->offsets.sendMem & NCCL_NET_MAP_MASK_USED ? 1 : 0,
+         NCCL_NET_MAP_OFFSET_BANK(map, sendMem), map->offsets.sendMem & NCCL_NET_MAP_MASK_OFFSET,
+         NCCL_NET_MAP_GET_POINTER(map, cpu, sendMem), NCCL_NET_MAP_GET_POINTER(map, gpu, sendMem));
+  printf("RecvMem -> Used %d Bank %d Offset %x, cpu %p gpu %p\n", map->offsets.recvMem & NCCL_NET_MAP_MASK_USED ? 1 : 0,
+         NCCL_NET_MAP_OFFSET_BANK(map, recvMem), map->offsets.recvMem & NCCL_NET_MAP_MASK_OFFSET,
+         NCCL_NET_MAP_GET_POINTER(map, cpu, recvMem), NCCL_NET_MAP_GET_POINTER(map, gpu, recvMem));
+  for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) {
     printf("Proto %d -> Used %d Bank %d Offset %x, cpu %p, gpu %p\n", p,
-        map->offsets.buffs[p] & NCCL_NET_MAP_MASK_USED ? 1 : 0,
-        NCCL_NET_MAP_OFFSET_BANK(map, buffs[p]), map->offsets.buffs[p] & NCCL_NET_MAP_MASK_OFFSET,
-        NCCL_NET_MAP_GET_POINTER(map, cpu, buffs[p]), NCCL_NET_MAP_GET_POINTER(map, gpu, buffs[p]));
+           map->offsets.buffs[p] & NCCL_NET_MAP_MASK_USED ? 1 : 0, NCCL_NET_MAP_OFFSET_BANK(map, buffs[p]),
+           map->offsets.buffs[p] & NCCL_NET_MAP_MASK_OFFSET, NCCL_NET_MAP_GET_POINTER(map, cpu, buffs[p]),
+           NCCL_NET_MAP_GET_POINTER(map, gpu, buffs[p]));
   }
   printf("End of dump\n");
   return ncclSuccess;
@@ -248,31 +253,32 @@ struct collNetConnectArgs {
 
 static ncclResult_t sendProxyProgress(struct ncclProxyState* proxyState, struct ncclProxyArgs* args);
 
-static ncclResult_t sendConnect(struct ncclComm* comm, struct ncclConnect* connectInfos, int nranks, int rank, struct ncclConnector* send) {
+static ncclResult_t sendConnect(struct ncclComm* comm, struct ncclConnect* connectInfos, int nranks, int rank,
+                                struct ncclConnector* send) {
   // We're on the same process as the proxy. We can pass a pointer to a struct.
-  struct collNetConnectArgs args = { rank, nranks, connectInfos };
+  struct collNetConnectArgs args = {rank, nranks, connectInfos};
   struct connectMap* map;
-  NCCLCHECK(ncclProxyCallBlocking(comm, &send->proxyConn, ncclProxyMsgConnect, &args, sizeof(struct collNetConnectArgs), &map, sizeof(struct connectMap*)));
+  NCCLCHECK(ncclProxyCallBlocking(comm, &send->proxyConn, ncclProxyMsgConnect, &args, sizeof(struct collNetConnectArgs),
+                                  &map, sizeof(struct connectMap*)));
 
   // If collnet connect failed, propagate error to fallback on regular p2p
   if (map == NULL) return ncclSystemError;
 
-  //NCCLCHECK(collNetDumpMap(map));
+  // NCCLCHECK(collNetDumpMap(map));
 
-  struct ncclSendMem *sendMem = (struct ncclSendMem*) NCCL_NET_MAP_GET_POINTER(map, gpu, sendMem);
+  struct ncclSendMem* sendMem = (struct ncclSendMem*)NCCL_NET_MAP_GET_POINTER(map, gpu, sendMem);
   void* gdcMem = map->mems[NCCL_NET_MAP_GDCMEM].gpuPtr;
   send->conn.head = gdcMem ? (uint64_t*)gdcMem : &sendMem->head;
 
-  struct ncclRecvMem *recvMem = (struct ncclRecvMem*) NCCL_NET_MAP_GET_POINTER(map, gpu, recvMem);
+  struct ncclRecvMem* recvMem = (struct ncclRecvMem*)NCCL_NET_MAP_GET_POINTER(map, gpu, recvMem);
   send->conn.tail = &recvMem->tail;
   send->conn.connFifo = recvMem->connFifo;
-  for (int i=0; i<NCCL_STEPS; i++) {
+  for (int i = 0; i < NCCL_STEPS; i++) {
     send->conn.connFifo[i].size = -1;
     send->conn.connFifo[i].mode = NCCL_MODE_OFFSET;
   }
 
-  for (int p=0; p<NCCL_NUM_PROTOCOLS; p++)
-    send->conn.buffs[p] = NCCL_NET_MAP_GET_POINTER(map, gpu, buffs[p]);
+  for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) send->conn.buffs[p] = NCCL_NET_MAP_GET_POINTER(map, gpu, buffs[p]);
 
   send->proxyConn.proxyProgress = sendProxyProgress;
 
@@ -281,29 +287,31 @@ static ncclResult_t sendConnect(struct ncclComm* comm, struct ncclConnect* conne
 
 static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct ncclProxyArgs* args);
 
-static ncclResult_t recvConnect(struct ncclComm* comm, struct ncclConnect* connectInfos, int nranks, int rank, struct ncclConnector* recv) {
+static ncclResult_t recvConnect(struct ncclComm* comm, struct ncclConnect* connectInfos, int nranks, int rank,
+                                struct ncclConnector* recv) {
   // We're on the same process as the proxy. We can pass a pointer to a struct.
-  struct collNetConnectArgs args = { rank, nranks, connectInfos };
+  struct collNetConnectArgs args = {rank, nranks, connectInfos};
   struct connectMap* map;
-  NCCLCHECK(ncclProxyCallBlocking(comm, &recv->proxyConn, ncclProxyMsgConnect, &args, sizeof(struct collNetConnectArgs), &map, sizeof(struct connectMap*)));
+  NCCLCHECK(ncclProxyCallBlocking(comm, &recv->proxyConn, ncclProxyMsgConnect, &args, sizeof(struct collNetConnectArgs),
+                                  &map, sizeof(struct connectMap*)));
 
   // If collnet connect failed, propagate error to fallback on regular p2p
   if (map == NULL) return ncclSystemError;
 
-  //NCCLCHECK(collNetDumpMap(map));
+  // NCCLCHECK(collNetDumpMap(map));
 
-  struct ncclSendMem *sendMem = (struct ncclSendMem*) NCCL_NET_MAP_GET_POINTER(map, gpu, sendMem);
+  struct ncclSendMem* sendMem = (struct ncclSendMem*)NCCL_NET_MAP_GET_POINTER(map, gpu, sendMem);
   recv->conn.head = &sendMem->head;
 
-  struct ncclRecvMem *recvMem = (struct ncclRecvMem*) NCCL_NET_MAP_GET_POINTER(map, gpu, recvMem);
+  struct ncclRecvMem* recvMem = (struct ncclRecvMem*)NCCL_NET_MAP_GET_POINTER(map, gpu, recvMem);
   void* gdcMem = map->mems[NCCL_NET_MAP_GDCMEM].gpuPtr;
   recv->conn.tail = gdcMem ? (uint64_t*)gdcMem : &recvMem->tail;
   recv->conn.connFifo = recvMem->connFifo;
-  for (int i=0; i<NCCL_STEPS; i++) {
+  for (int i = 0; i < NCCL_STEPS; i++) {
     recv->conn.connFifo[i].mode = NCCL_MODE_OFFSET;
   }
 
-  for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
+  for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) {
     recv->conn.buffs[p] = NCCL_NET_MAP_GET_POINTER(map, gpu, buffs[p]);
   }
 
@@ -320,7 +328,8 @@ static ncclResult_t recvFree(struct ncclComm* comm, struct ncclConnector* recv) 
   return ncclSuccess;
 }
 
-static ncclResult_t sendProxySetup(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
+static ncclResult_t sendProxySetup(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState,
+                                   void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
   struct setupReq* req = (struct setupReq*)reqBuff;
   if (reqSize != sizeof(struct setupReq)) return ncclInternalError;
 
@@ -338,9 +347,10 @@ static ncclResult_t sendProxySetup(struct ncclProxyConnection* connection, struc
   resources->useDmaBuf = resources->useGdr && proxyState->dmaBufSupport && (props.ptrSupport & NCCL_PTR_DMABUF);
   /* collective size limits*/
   resources->maxCollBytes = props.maxCollBytes;
-  if((resources->maxCollBytes <= 0) || (resources->maxCollBytes > NCCL_MAX_NET_SIZE_BYTES)) {
+  if ((resources->maxCollBytes <= 0) || (resources->maxCollBytes > NCCL_MAX_NET_SIZE_BYTES)) {
     WARN("sendProxySetup: collnet plugin returned invalid value for maxCollBytes %ld \
-      [allowed range: %ld - %ld] \n", resources->maxCollBytes, 0L, NCCL_MAX_NET_SIZE_BYTES);
+      [allowed range: %ld - %ld] \n",
+         resources->maxCollBytes, 0L, NCCL_MAX_NET_SIZE_BYTES);
     return ncclInternalError;
   }
   return ncclSuccess;
@@ -352,30 +362,32 @@ struct sharedResources {
   int commRefCount[NCCL_MAX_NETDEVS];
 };
 
-static ncclResult_t sharedListen(struct ncclProxyState* proxyState, int netDev, struct ncclCollNetSharedRes* collNet, void* collNetHandle) {
+static ncclResult_t sharedListen(struct ncclProxyState* proxyState, int netDev, struct ncclCollNetSharedRes* collNet,
+                                 void* collNetHandle) {
   struct sharedResources* resources = (struct sharedResources*)collNet->resources;
   if (resources == NULL) {
     NCCLCHECK(ncclCalloc(&resources, 1));
     collNet->resources = resources;
   }
   if (resources->collNetComms[netDev] == NULL)
-    NCCLCHECK(proxyState->ncclCollNet->listen(proxyState->collNetContext, netDev, collNetHandle, resources->collNetListenComms + netDev));
+    NCCLCHECK(proxyState->ncclCollNet->listen(proxyState->collNetContext, netDev, collNetHandle,
+                                              resources->collNetListenComms + netDev));
   return ncclSuccess;
 }
 
-static ncclResult_t sharedConnect(struct ncclProxyState* proxyState, int netDev, struct ncclConnect* connectInfos, int nranks, int rank, struct ncclCollNetSharedRes* collNet, void** collNetComm) {
+static ncclResult_t sharedConnect(struct ncclProxyState* proxyState, int netDev, struct ncclConnect* connectInfos,
+                                  int nranks, int rank, struct ncclCollNetSharedRes* collNet, void** collNetComm) {
   struct sharedResources* resources = (struct sharedResources*)collNet->resources;
   if (resources->collNetComms[netDev] == NULL) {
     // Connect to coll comm
     collNetHandle_t** handlePtrs = NULL;
     NCCLCHECK(ncclCalloc(&handlePtrs, nranks));
     for (int i = 0; i < nranks; i++) {
-      struct collNetRecvConnectInfo* info = (struct collNetRecvConnectInfo*)(connectInfos+i);
+      struct collNetRecvConnectInfo* info = (struct collNetRecvConnectInfo*)(connectInfos + i);
       handlePtrs[i] = &(info->collNetHandle);
     }
-    ncclResult_t ret = proxyState->ncclCollNet->connect((void**)handlePtrs, nranks, rank,
-          resources->collNetListenComms[netDev],
-          resources->collNetComms+netDev);
+    ncclResult_t ret = proxyState->ncclCollNet->connect(
+      (void**)handlePtrs, nranks, rank, resources->collNetListenComms[netDev], resources->collNetComms + netDev);
     free(handlePtrs);
     if (ret == ncclSuccess) {
       // Close listen comm
@@ -395,13 +407,15 @@ static ncclResult_t sharedFree(struct ncclProxyState* proxyState, struct ncclCol
   if (resources->commRefCount[netDev] == 0) {
     NCCLCHECK(proxyState->ncclCollNet->closeColl(resources->collNetComms[netDev]));
   }
-  for (int n=0; n<NCCL_MAX_NETDEVS; n++) if (resources->commRefCount[n]) return ncclSuccess;
+  for (int n = 0; n < NCCL_MAX_NETDEVS; n++)
+    if (resources->commRefCount[n]) return ncclSuccess;
   collNet->resources = NULL;
   free(resources);
   return ncclSuccess;
 }
 
-static ncclResult_t sharedBuffersInit(struct ncclCollNetSharedRes* collNet, int cuda, char** gpuPtr, char** cpuPtr, int* size, struct ncclMemManager* manager) {
+static ncclResult_t sharedBuffersInit(struct ncclCollNetSharedRes* collNet, int cuda, char** gpuPtr, char** cpuPtr,
+                                      int* size, struct ncclMemManager* manager) {
   if (collNet->size == 0) {
     collNet->size = 2 * collNet->nChannels * collNet->buffSize;
   }
@@ -410,9 +424,11 @@ static ncclResult_t sharedBuffersInit(struct ncclCollNetSharedRes* collNet, int 
 
   if (cuda && collNet->cudaBuff == NULL) {
 #if defined(HIP_UNCACHED_MEMORY)
-    NCCLCHECK(ncclCudaCalloc(&collNet->cudaBuff, *size, manager, ncclMemPersist, cuda ? hipDeviceMallocUncached : hipDeviceMallocDefault));
+    NCCLCHECK(ncclCudaCalloc(&collNet->cudaBuff, *size, manager, ncclMemPersist,
+                             cuda ? hipDeviceMallocUncached : hipDeviceMallocDefault));
 #else
-    NCCLCHECK(ncclCudaCalloc(&collNet->cudaBuff, *size, manager, ncclMemPersist, cuda ? hipDeviceMallocFinegrained : hipDeviceMallocDefault));
+    NCCLCHECK(ncclCudaCalloc(&collNet->cudaBuff, *size, manager, ncclMemPersist,
+                             cuda ? hipDeviceMallocFinegrained : hipDeviceMallocDefault));
 #endif
   }
   if (!cuda && collNet->hostBuff == NULL) {
@@ -431,9 +447,10 @@ static ncclResult_t sharedBuffersDestroy(struct ncclCollNetSharedRes* collNet, s
   return ncclSuccess;
 }
 
-static ncclResult_t recvProxySetup(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
+static ncclResult_t recvProxySetup(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState,
+                                   void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
   struct setupReq* req = (struct setupReq*)reqBuff;
-  if (reqSize != sizeof (struct setupReq)) return ncclInternalError;
+  if (reqSize != sizeof(struct setupReq)) return ncclInternalError;
 
   struct recvResources* resources;
   NCCLCHECK(ncclCalloc(&resources, 1));
@@ -449,39 +466,47 @@ static ncclResult_t recvProxySetup(struct ncclProxyConnection* connection, struc
   /* DMA-BUF support */
   resources->useDmaBuf = resources->useGdr && proxyState->dmaBufSupport && (props.ptrSupport & NCCL_PTR_DMABUF);
   resources->maxCollBytes = props.maxCollBytes;
-  if((resources->maxCollBytes <= 0) || (resources->maxCollBytes > NCCL_MAX_NET_SIZE_BYTES)) {
+  if ((resources->maxCollBytes <= 0) || (resources->maxCollBytes > NCCL_MAX_NET_SIZE_BYTES)) {
     WARN("sendProxySetup: collnet plugin returned invalid value for maxCollBytes %ld \
-      [allowed range: %ld - %ld] \n", resources->maxCollBytes, 0L, NCCL_MAX_NET_SIZE_BYTES);
+      [allowed range: %ld - %ld] \n",
+         resources->maxCollBytes, 0L, NCCL_MAX_NET_SIZE_BYTES);
     return ncclInternalError;
   }
 
-  collNetHandle_t* netHandle = (collNetHandle_t*) respBuff;
+  collNetHandle_t* netHandle = (collNetHandle_t*)respBuff;
   if (respSize != sizeof(collNetHandle_t)) return ncclInternalError;
 
   NCCLCHECK(sharedListen(proxyState, req->netDev, req->collNet, netHandle));
   return ncclSuccess;
 }
 
-static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
+static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState,
+                                     void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
   ncclResult_t ret = ncclSuccess;
-  if (reqSize != sizeof(struct collNetConnectArgs)) { WARN("sendProxyConnect: reqSize is %d != %ld", reqSize, sizeof(struct collNetConnectArgs)); return ncclInternalError; }
+  if (reqSize != sizeof(struct collNetConnectArgs)) {
+    WARN("sendProxyConnect: reqSize is %d != %ld", reqSize, sizeof(struct collNetConnectArgs));
+    return ncclInternalError;
+  }
   struct collNetConnectArgs* args = (struct collNetConnectArgs*)reqBuff;
   static_assert(sizeof(collNetSendConnectInfo) <= sizeof(struct ncclConnect), "Collnet Send Connect info is too big");
-  struct collNetSendConnectInfo* info = (struct collNetSendConnectInfo*)(args->connectInfos+args->rank);
+  struct collNetSendConnectInfo* info = (struct collNetSendConnectInfo*)(args->connectInfos + args->rank);
 
   struct sendResources* resources = (struct sendResources*)(connection->transportResources);
 
   // Get info from recv side
   resources->collNetRank = args->rank;
-  resources->reqFifo = (struct reqSlot (*)[NCCL_STEPS])(info->reqFifo);
+  resources->reqFifo = (struct reqSlot(*)[NCCL_STEPS])(info->reqFifo);
 
-  for (int p=0; p<NCCL_NUM_PROTOCOLS; p++)
-    resources->recvMhandles[p] = info->mhandles[p];
+  for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) resources->recvMhandles[p] = info->mhandles[p];
 
-  NCCLCHECK(sharedConnect(proxyState, resources->netDev, args->connectInfos, args->nranks, args->rank, connection->collNet, &resources->collNetComm));
+  NCCLCHECK(sharedConnect(proxyState, resources->netDev, args->connectInfos, args->nranks, args->rank,
+                          connection->collNet, &resources->collNetComm));
 
   // Collnet connect is allowed to fail. Gracefully handle that case by returning NULL to the caller.
-  if (respSize != sizeof(struct connectMap*)) { WARN("sendProxyConnect: respSize is %d != %ld", respSize, sizeof(void*)); return ncclInternalError; }
+  if (respSize != sizeof(struct connectMap*)) {
+    WARN("sendProxyConnect: respSize is %d != %ld", respSize, sizeof(void*));
+    return ncclInternalError;
+  }
   if (resources->collNetComm == NULL) {
     *((struct connectMap**)respBuff) = NULL;
     return ncclSuccess;
@@ -500,21 +525,22 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
     NCCLCHECK(ncclGdrCudaCalloc(&cpuPtr, &gpuPtr, 1, &resources->gdrDesc, proxyState->memManager));
 
     resources->gdcSync = cpuPtr;
-    struct connectMapMem* gdcMem = map->mems+NCCL_NET_MAP_GDCMEM;
+    struct connectMapMem* gdcMem = map->mems + NCCL_NET_MAP_GDCMEM;
     gdcMem->cpuPtr = (char*)cpuPtr;
     gdcMem->gpuPtr = (char*)gpuPtr;
     gdcMem->size = sizeof(uint64_t); // sendMem->head
   }
 
-  resources->sendMem = (struct ncclSendMem*) NCCL_NET_MAP_GET_POINTER(map, cpu, sendMem);
-  resources->recvMem = (struct ncclRecvMem*) NCCL_NET_MAP_GET_POINTER(map, cpu, recvMem);
+  resources->sendMem = (struct ncclSendMem*)NCCL_NET_MAP_GET_POINTER(map, cpu, sendMem);
+  resources->recvMem = (struct ncclRecvMem*)NCCL_NET_MAP_GET_POINTER(map, cpu, recvMem);
   // Don't give credits yet in shared mode.
   (resources->gdcSync ? *resources->gdcSync : resources->sendMem->head) = -NCCL_STEPS;
 
   // Allocate & Register shared buffers for the Simple protocol
   int bank = resources->useGdr ? NCCL_NET_MAP_SHARED_DEVMEM : NCCL_NET_MAP_SHARED_HOSTMEM;
-  struct connectMapMem* mapMem = map->mems+bank;
-  NCCLCHECK(sharedBuffersInit(connection->collNet, resources->useGdr, &mapMem->gpuPtr, &mapMem->cpuPtr, &mapMem->size, proxyState->memManager));
+  struct connectMapMem* mapMem = map->mems + bank;
+  NCCLCHECK(sharedBuffersInit(connection->collNet, resources->useGdr, &mapMem->gpuPtr, &mapMem->cpuPtr, &mapMem->size,
+                              proxyState->memManager));
   NCCL_NET_MAP_ADD_POINTER(map, 1, resources->useGdr ? 1 : 0, mapMem->size, buffs[NCCL_PROTO_SIMPLE]);
 
   int dmabuf_fd = -1;
@@ -523,7 +549,10 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
 #if CUDA_VERSION >= 11070 || HIP_VERSION >= 71260540
   /* DMA-BUF support */
   if (resources->useGdr && resources->useDmaBuf && ncclCuMemEnable()) {
-    CUCHECKGOTO(cuMemGetHandleForAddressRange((void *)&dmabuf_fd, (CUdeviceptr)mapMem->cpuPtr, mapMem->size, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, getHandleForAddressRangeFlags(resources->useGdr)), ret, peermem_send);
+    CUCHECKGOTO(cuMemGetHandleForAddressRange((void*)&dmabuf_fd, (CUdeviceptr)mapMem->cpuPtr, mapMem->size,
+                                              CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
+                                              getHandleForAddressRangeFlags(resources->useGdr)),
+                ret, peermem_send);
     NCCLCHECKGOTO(proxyState->ncclCollNet->regMrDmaBuf(resources->collNetComm, mapMem->cpuPtr, mapMem->size,
                                                        NCCL_PTR_CUDA, 0ULL, dmabuf_fd,
                                                        &resources->sendMhandles[NCCL_PROTO_SIMPLE]),
@@ -533,9 +562,11 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
   }
 peermem_send:
 #else
-  if (resources->useGdr && resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf && proxyState->ncclCollNet->regMrDmaBuf) {
+  if (resources->useGdr && resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf &&
+      proxyState->ncclCollNet->regMrDmaBuf) {
     uint64_t offset;
-    HSACHECKGOTO(hsa_amd_portable_export_dmabuf((const void*)mapMem->cpuPtr, mapMem->size, &dmabuf_fd, &offset), ret, peermem_send);
+    HSACHECKGOTO(hsa_amd_portable_export_dmabuf((const void*)mapMem->cpuPtr, mapMem->size, &dmabuf_fd, &offset), ret,
+                 peermem_send);
     NCCLCHECKGOTO(proxyState->ncclCollNet->regMrDmaBuf(resources->collNetComm, mapMem->cpuPtr, mapMem->size,
                                                        NCCL_PTR_CUDA, offset, dmabuf_fd,
                                                        &resources->sendMhandles[NCCL_PROTO_SIMPLE]),
@@ -547,8 +578,9 @@ peermem_send:
 #endif
   if (needReg) {
     NCCLCHECKGOTO(proxyState->ncclCollNet->regMr(resources->collNetComm, mapMem->cpuPtr, mapMem->size,
-                                            resources->useGdr ? NCCL_PTR_CUDA : NCCL_PTR_HOST,
-                                            &resources->sendMhandles[NCCL_PROTO_SIMPLE]), ret, fail);
+                                                 resources->useGdr ? NCCL_PTR_CUDA : NCCL_PTR_HOST,
+                                                 &resources->sendMhandles[NCCL_PROTO_SIMPLE]),
+                  ret, fail);
   }
 
   *((struct connectMap**)respBuff) = &resources->map;
@@ -562,19 +594,27 @@ fail:
   goto exit;
 }
 
-static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
+static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState,
+                                     void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
   ncclResult_t ret = ncclSuccess;
-  if (reqSize != sizeof(struct collNetConnectArgs)) { WARN("recvProxyConnect: reqSize is %d != %ld", reqSize, sizeof(struct collNetConnectArgs)); return ncclInternalError; }
+  if (reqSize != sizeof(struct collNetConnectArgs)) {
+    WARN("recvProxyConnect: reqSize is %d != %ld", reqSize, sizeof(struct collNetConnectArgs));
+    return ncclInternalError;
+  }
   struct collNetConnectArgs* args = (struct collNetConnectArgs*)reqBuff;
 
   struct recvResources* resources = (struct recvResources*)(connection->transportResources);
-  struct collNetSendConnectInfo* info = (struct collNetSendConnectInfo*)(args->connectInfos+args->rank);
+  struct collNetSendConnectInfo* info = (struct collNetSendConnectInfo*)(args->connectInfos + args->rank);
   resources->collNetRank = args->rank;
 
-  NCCLCHECK(sharedConnect(proxyState, resources->netDev, args->connectInfos, args->nranks, args->rank, connection->collNet, &resources->collNetComm));
+  NCCLCHECK(sharedConnect(proxyState, resources->netDev, args->connectInfos, args->nranks, args->rank,
+                          connection->collNet, &resources->collNetComm));
 
   // Collnet connect is allowed to fail. Gracefully handle that case by returning NULL to the caller.
-  if (respSize != sizeof(struct connectMap*)) { WARN("sendProxyConnect: respSize is %d != %ld", respSize, sizeof(void*)); return ncclInternalError; }
+  if (respSize != sizeof(struct connectMap*)) {
+    WARN("sendProxyConnect: respSize is %d != %ld", respSize, sizeof(void*));
+    return ncclInternalError;
+  }
   if (resources->collNetComm == NULL) {
     *((struct connectMap**)respBuff) = NULL;
     return ncclSuccess;
@@ -597,7 +637,7 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
       // No flush needed if control flow is mapped on the PCIe instead of C2C
       if (gdcFlag == GDR_PIN_FLAG_FORCE_PCIE) resources->needFlush = ncclTopoFlushNone;
       resources->gdcSync = cpuPtr;
-      struct connectMapMem* gdcMem = map->mems+NCCL_NET_MAP_GDCMEM;
+      struct connectMapMem* gdcMem = map->mems + NCCL_NET_MAP_GDCMEM;
       gdcMem->cpuPtr = (char*)cpuPtr;
       gdcMem->gpuPtr = (char*)gpuPtr;
       gdcMem->size = sizeof(uint64_t);
@@ -605,22 +645,26 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
     if (ncclParamGdrCopyFlushEnable()) resources->gdcFlush = cpuPtr + 1;
   }
 
-  resources->sendMem = (struct ncclSendMem*) NCCL_NET_MAP_GET_POINTER(map, cpu, sendMem);
-  resources->recvMem = (struct ncclRecvMem*) NCCL_NET_MAP_GET_POINTER(map, cpu, recvMem);
+  resources->sendMem = (struct ncclSendMem*)NCCL_NET_MAP_GET_POINTER(map, cpu, sendMem);
+  resources->recvMem = (struct ncclRecvMem*)NCCL_NET_MAP_GET_POINTER(map, cpu, recvMem);
 
   // Allocate & Register shared buffers for the Simple protocol
   int bank = resources->useGdr ? NCCL_NET_MAP_SHARED_DEVMEM : NCCL_NET_MAP_SHARED_HOSTMEM;
-  struct connectMapMem* mapMem = map->mems+bank;
-  NCCLCHECK(sharedBuffersInit(connection->collNet, resources->useGdr, &mapMem->gpuPtr, &mapMem->cpuPtr, &mapMem->size, proxyState->memManager));
+  struct connectMapMem* mapMem = map->mems + bank;
+  NCCLCHECK(sharedBuffersInit(connection->collNet, resources->useGdr, &mapMem->gpuPtr, &mapMem->cpuPtr, &mapMem->size,
+                              proxyState->memManager));
   NCCL_NET_MAP_ADD_POINTER(map, 1, resources->useGdr ? 1 : 0, mapMem->size, buffs[NCCL_PROTO_SIMPLE]);
-  
+
   int dmabuf_fd = -1;
   (void)dmabuf_fd; /*compiler warnings fix - unused variable*/
   bool needReg = true;
 #if CUDA_VERSION >= 11070 || HIP_VERSION >= 71260540
   /* DMA-BUF support */
   if (resources->useGdr && resources->useDmaBuf && ncclCuMemEnable()) {
-    CUCHECKGOTO(cuMemGetHandleForAddressRange((void *)&dmabuf_fd, (CUdeviceptr)mapMem->cpuPtr, mapMem->size, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, getHandleForAddressRangeFlags(resources->useGdr)), ret, peermem_recv);
+    CUCHECKGOTO(cuMemGetHandleForAddressRange((void*)&dmabuf_fd, (CUdeviceptr)mapMem->cpuPtr, mapMem->size,
+                                              CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
+                                              getHandleForAddressRangeFlags(resources->useGdr)),
+                ret, peermem_recv);
     NCCLCHECKGOTO(proxyState->ncclCollNet->regMrDmaBuf(resources->collNetComm, mapMem->cpuPtr, mapMem->size,
                                                        NCCL_PTR_CUDA, 0ULL, dmabuf_fd,
                                                        &resources->mhandles[NCCL_PROTO_SIMPLE]),
@@ -630,9 +674,11 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
   }
 peermem_recv:
 #else
-  if (resources->useGdr && resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf && proxyState->ncclCollNet->regMrDmaBuf) {
+  if (resources->useGdr && resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf &&
+      proxyState->ncclCollNet->regMrDmaBuf) {
     uint64_t offset;
-    HSACHECKGOTO(hsa_amd_portable_export_dmabuf((const void*)mapMem->cpuPtr, mapMem->size, &dmabuf_fd, &offset), ret, peermem_recv);
+    HSACHECKGOTO(hsa_amd_portable_export_dmabuf((const void*)mapMem->cpuPtr, mapMem->size, &dmabuf_fd, &offset), ret,
+                 peermem_recv);
     NCCLCHECKGOTO(proxyState->ncclCollNet->regMrDmaBuf(resources->collNetComm, mapMem->cpuPtr, mapMem->size,
                                                        NCCL_PTR_CUDA, offset, dmabuf_fd,
                                                        &resources->mhandles[NCCL_PROTO_SIMPLE]),
@@ -644,16 +690,19 @@ peermem_recv:
 #endif
   if (needReg) {
     NCCLCHECKGOTO(proxyState->ncclCollNet->regMr(resources->collNetComm, mapMem->cpuPtr, mapMem->size,
-                                            resources->useGdr ? NCCL_PTR_CUDA : NCCL_PTR_HOST,
-                                            &resources->mhandles[NCCL_PROTO_SIMPLE]), ret, fail);
+                                                 resources->useGdr ? NCCL_PTR_CUDA : NCCL_PTR_HOST,
+                                                 &resources->mhandles[NCCL_PROTO_SIMPLE]),
+                  ret, fail);
   }
 
   // Pass info to send side
   info->reqFifo = resources->reqFifo;
-  for (int p=0; p<NCCL_NUM_PROTOCOLS; p++)
-    info->mhandles[p] = resources->mhandles[p];
+  for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) info->mhandles[p] = resources->mhandles[p];
 
-  if (respSize != sizeof(struct connectMap*)) { WARN("recvProxyConnect: respSize is %d != %ld", respSize, sizeof(void*)); return ncclInternalError; }
+  if (respSize != sizeof(struct connectMap*)) {
+    WARN("recvProxyConnect: respSize is %d != %ld", respSize, sizeof(void*));
+    return ncclInternalError;
+  }
   *((struct connectMap**)respBuff) = &resources->map;
 
 exit:
@@ -702,7 +751,7 @@ static ncclResult_t recvProxyFree(struct ncclProxyConnection* connection, struct
       free(memHandle);
     }
 
-    for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
+    for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) {
       if (resources->mhandles[p]) {
         NCCLCHECK(proxyState->ncclCollNet->deregMr(resources->collNetComm, resources->mhandles[p]));
       }
@@ -724,46 +773,45 @@ static size_t calcAlgoOffset(struct ncclProxyArgs* args, int isAllNotOne, int su
   int nNodes = args->specifics.collnetDirect.nNodes;
   int node = args->specifics.collnetDirect.node;
   size_t sizePerRank = args->specifics.collnetDirect.sizePerRank;
-  size_t offset = (step*(args->nsubs) + sub)*chunkSize;
+  size_t offset = (step * (args->nsubs) + sub) * chunkSize;
   if (isAllNotOne) {
-    offset = std::min<size_t>(offset, nNodes*sizePerRank);
+    offset = std::min<size_t>(offset, nNodes * sizePerRank);
   } else {
-    offset = std::max<size_t>(offset, (node+0)*sizePerRank);
-    offset = std::min<size_t>(offset, (node+1)*sizePerRank);
+    offset = std::max<size_t>(offset, (node + 0) * sizePerRank);
+    offset = std::min<size_t>(offset, (node + 1) * sizePerRank);
   }
   return offset;
 }
 
-static ssize_t calcRegionOffset(
-    struct ncclProxyArgs* args, int isRecvNotSend, int sub, uint64_t step,
-    int side // 0=begin, 1=end
-  ) {
+static ssize_t calcRegionOffset(struct ncclProxyArgs* args, int isRecvNotSend, int sub, uint64_t step,
+                                int side // 0=begin, 1=end
+) {
   struct ncclCollNetSharedRes* collNet = args->subs[0].connection->collNet;
-  ssize_t slotSize = collNet->buffSize/NCCL_STEPS;
+  ssize_t slotSize = collNet->buffSize / NCCL_STEPS;
   ssize_t chunkSize = args->chunkSize;
-  ssize_t base = isRecvNotSend*NCCL_STEPS + (step%NCCL_STEPS);
-  base *= collNet->nChannels*slotSize;
+  ssize_t base = isRecvNotSend * NCCL_STEPS + (step % NCCL_STEPS);
+  base *= collNet->nChannels * slotSize;
   if (args->coll == ncclFuncAllReduce) {
-    return base + (sub+side)*chunkSize;
+    return base + (sub + side) * chunkSize;
   } else {
     int isAllNotOne = isRecvNotSend ^ (args->coll == ncclFuncReduceScatter);
-    int sub0 = sub - (sub%COLLNET_GROUP_NSUBS);
-    size_t off = sub0*slotSize;
-    off += calcAlgoOffset(args, isAllNotOne, sub+side, step)
-         - calcAlgoOffset(args, isAllNotOne, sub0, step);
+    int sub0 = sub - (sub % COLLNET_GROUP_NSUBS);
+    size_t off = sub0 * slotSize;
+    off += calcAlgoOffset(args, isAllNotOne, sub + side, step) - calcAlgoOffset(args, isAllNotOne, sub0, step);
     return base + off;
   }
 }
 
-#define LAST_OF_GROUP(args, s) \
-  ((s)%COLLNET_GROUP_NSUBS == COLLNET_GROUP_NSUBS-1 || (s) == (args)->nsubs-1)
+#define LAST_OF_GROUP(args, s) ((s) % COLLNET_GROUP_NSUBS == COLLNET_GROUP_NSUBS - 1 || (s) == (args)->nsubs - 1)
 
 static constexpr int calcStepsPerGroup(int nGroups) {
-  //return NCCL_STEPS/nGroups;
+  // return NCCL_STEPS/nGroups;
   return NCCL_STEPS;
 }
 
-static ncclResult_t collNetRegIallreduce(struct ncclProxyState* proxyState, struct sendResources *resources, struct ncclProxyArgs *args, struct ncclProxySubArgs *sub, int groupStart, ssize_t *nBytesInOut, void **request) {
+static ncclResult_t collNetRegIallreduce(struct ncclProxyState* proxyState, struct sendResources* resources,
+                                         struct ncclProxyArgs* args, struct ncclProxySubArgs* sub, int groupStart,
+                                         ssize_t* nBytesInOut, void** request) {
   ssize_t loopSize, winOffset, nBytes;
   ssize_t eltSize = ncclTypeSize((ncclDataType_t)args->dtype);
   // for UB iallreduce 1RPN case, user's send and recv buffers are both directly accessed by collnet network.
@@ -784,39 +832,52 @@ static ncclResult_t collNetRegIallreduce(struct ncclProxyState* proxyState, stru
   }
 
   if (nBytes > 0) {
-    NCCLCHECK(proxyState->ncclCollNet->iallreduce(resources->collNetComm, sub->sendbuff + winOffset, sub->recvbuff + winOffset, nBytes / eltSize, (ncclDataType_t)args->dtype, (ncclRedOp_t)args->redOp, sub->sendMhandle, sub->recvMhandle, request));
+    NCCLCHECK(proxyState->ncclCollNet->iallreduce(
+      resources->collNetComm, sub->sendbuff + winOffset, sub->recvbuff + winOffset, nBytes / eltSize,
+      (ncclDataType_t)args->dtype, (ncclRedOp_t)args->redOp, sub->sendMhandle, sub->recvMhandle, request));
     if (*request) {
       // if issued successfully, we need to move the pointer forward and reduce the existing nbytes.
       sub->nbytes -= loopSize;
       sub->sendbuff += loopSize;
       sub->recvbuff += loopSize;
-      TRACE(NCCL_NET, "sendProxy [%ld/%d/%d] registered Iallreduce posted sendbuff %p recvbuff %p size %ld loopSize %ld winOffset %ld isOneRPN %d req %p", (long)sub->transmitted, sub->nsteps, groupStart, sub->sendbuff, sub->recvbuff, nBytes, loopSize, winOffset, sub->isOneRPN, *request);
+      TRACE(NCCL_NET,
+            "sendProxy [%ld/%d/%d] registered Iallreduce posted sendbuff %p recvbuff %p size %ld loopSize %ld "
+            "winOffset %ld isOneRPN %d req %p",
+            (long)sub->transmitted, sub->nsteps, groupStart, sub->sendbuff, sub->recvbuff, nBytes, loopSize, winOffset,
+            sub->isOneRPN, *request);
     }
   }
   *nBytesInOut = nBytes;
   return ncclSuccess;
 }
 
-static ncclResult_t collNetIallreduce(struct ncclProxyState* proxyState, struct sendResources *resources, struct ncclProxyArgs *args, struct ncclProxySubArgs *sub, ssize_t nBytes, ssize_t sendBeg, ssize_t recvBeg, void **request) {
-  void *sendMhandle = resources->sendMhandles[NCCL_PROTO_SIMPLE];
-  void *recvMhandle = resources->recvMhandles[NCCL_PROTO_SIMPLE];
-  char *region = NCCL_NET_MAP_GET_POINTER(&resources->map, gpu, buffs[NCCL_PROTO_SIMPLE]);
+static ncclResult_t collNetIallreduce(struct ncclProxyState* proxyState, struct sendResources* resources,
+                                      struct ncclProxyArgs* args, struct ncclProxySubArgs* sub, ssize_t nBytes,
+                                      ssize_t sendBeg, ssize_t recvBeg, void** request) {
+  void* sendMhandle = resources->sendMhandles[NCCL_PROTO_SIMPLE];
+  void* recvMhandle = resources->recvMhandles[NCCL_PROTO_SIMPLE];
+  char* region = NCCL_NET_MAP_GET_POINTER(&resources->map, gpu, buffs[NCCL_PROTO_SIMPLE]);
   ssize_t eltSize = ncclTypeSize((ncclDataType_t)args->dtype);
   // non-UB iallreduce, region is intermediate buffer and sendBeg/recvBeg is the corresponding offset
   // for send and recv data. The send and recv mem handle are retrieved from resources.
-  NCCLCHECK(proxyState->ncclCollNet->iallreduce(resources->collNetComm, region + sendBeg, region + recvBeg, nBytes / eltSize, (ncclDataType_t)args->dtype, (ncclRedOp_t)args->redOp, sendMhandle, recvMhandle, request));
+  NCCLCHECK(proxyState->ncclCollNet->iallreduce(resources->collNetComm, region + sendBeg, region + recvBeg,
+                                                nBytes / eltSize, (ncclDataType_t)args->dtype, (ncclRedOp_t)args->redOp,
+                                                sendMhandle, recvMhandle, request));
   if (*request)
-    TRACE(NCCL_NET, "sendProxy [%ld/%d] Iallreduce posted size %ld sendBeg %ld recvBeg %ld req %p", (long)sub->transmitted, sub->nsteps, nBytes, sendBeg, recvBeg, *request);
+    TRACE(NCCL_NET, "sendProxy [%ld/%d] Iallreduce posted size %ld sendBeg %ld recvBeg %ld req %p",
+          (long)sub->transmitted, sub->nsteps, nBytes, sendBeg, recvBeg, *request);
   return ncclSuccess;
 }
 
-static ncclResult_t collNetRegIallgather(struct ncclProxyState* proxyState, struct sendResources *resources, struct ncclProxyArgs *args, struct ncclProxySubArgs *sub, ssize_t nBytesIn, ssize_t allBeg, ssize_t recvBeg, void *recvMhandle, void **request) {
+static ncclResult_t collNetRegIallgather(struct ncclProxyState* proxyState, struct sendResources* resources,
+                                         struct ncclProxyArgs* args, struct ncclProxySubArgs* sub, ssize_t nBytesIn,
+                                         ssize_t allBeg, ssize_t recvBeg, void* recvMhandle, void** request) {
   ncclNetSGE_t recvParts;
   ssize_t sizePerRank = args->specifics.collnetDirect.sizePerRank;
-  char *region = NCCL_NET_MAP_GET_POINTER(&resources->map, gpu, buffs[NCCL_PROTO_SIMPLE]);
+  char* region = NCCL_NET_MAP_GET_POINTER(&resources->map, gpu, buffs[NCCL_PROTO_SIMPLE]);
   ssize_t nBytes;
   ssize_t winOffset;
-  void *sendbuff;
+  void* sendbuff;
   // UB iallgather 1RPN logic is the same as iallreduce.
   // If iallgather is not 1RPN, we can let collnet network directly access sendbuff but not recvbuff;
   // the main reason is non-1RPN case will cause non-contiguous recv data from network, so
@@ -840,22 +901,29 @@ static ncclResult_t collNetRegIallgather(struct ncclProxyState* proxyState, stru
   } else {
     sendbuff = sub->sendbuff;
   }
-  NCCLCHECK(proxyState->ncclCollNet->iallgather(resources->collNetComm, sendbuff, 1, &recvParts, sizePerRank, winOffset, nBytes, sub->sendMhandle, request));
+  NCCLCHECK(proxyState->ncclCollNet->iallgather(resources->collNetComm, sendbuff, 1, &recvParts, sizePerRank, winOffset,
+                                                nBytes, sub->sendMhandle, request));
   if (*request) {
     if (sub->isOneRPN) {
       sub->recvbuff += nBytes;
       sub->nbytes -= nBytes;
       sub->offset += nBytes;
     }
-    TRACE(NCCL_NET, "sendProxy [%ld/%d] registered Iallgather posted sizePerRank %ld winOffset %ld recvSize %ld isOneRPN %d request %p", sub->transmitted, sub->nsteps, sizePerRank, winOffset, nBytes, sub->isOneRPN, *request);
+    TRACE(NCCL_NET,
+          "sendProxy [%ld/%d] registered Iallgather posted sizePerRank %ld winOffset %ld recvSize %ld isOneRPN %d "
+          "request %p",
+          sub->transmitted, sub->nsteps, sizePerRank, winOffset, nBytes, sub->isOneRPN, *request);
   }
   return ncclSuccess;
 }
 
-static ncclResult_t collNetIallgather(struct ncclProxyState* proxyState, struct sendResources *resources, struct ncclProxyArgs *args, struct ncclProxySubArgs *sub, ssize_t nBytes, ssize_t allBeg, ssize_t sendBeg, ssize_t recvBeg, void *sendMhandle, void *recvMhandle, void **request) {
+static ncclResult_t collNetIallgather(struct ncclProxyState* proxyState, struct sendResources* resources,
+                                      struct ncclProxyArgs* args, struct ncclProxySubArgs* sub, ssize_t nBytes,
+                                      ssize_t allBeg, ssize_t sendBeg, ssize_t recvBeg, void* sendMhandle,
+                                      void* recvMhandle, void** request) {
   ncclNetSGE_t recvParts;
   ssize_t sizePerRank = args->specifics.collnetDirect.sizePerRank;
-  char *region = NCCL_NET_MAP_GET_POINTER(&resources->map, gpu, buffs[NCCL_PROTO_SIMPLE]);
+  char* region = NCCL_NET_MAP_GET_POINTER(&resources->map, gpu, buffs[NCCL_PROTO_SIMPLE]);
   recvParts.mhandle = recvMhandle;
   recvParts.address = region + recvBeg;
   recvParts.size = nBytes;
@@ -863,19 +931,23 @@ static ncclResult_t collNetIallgather(struct ncclProxyState* proxyState, struct 
   // sendMhandle and recvMhandle are send and recv mem handles for region, and allBeg is
   // the global window offset of recv buffer. sendBeg and recvBeg are offset to the region
   // for intermediate data.
-  NCCLCHECK(proxyState->ncclCollNet->iallgather(resources->collNetComm, region + sendBeg, 1, &recvParts, sizePerRank, allBeg, nBytes, sendMhandle, request));
+  NCCLCHECK(proxyState->ncclCollNet->iallgather(resources->collNetComm, region + sendBeg, 1, &recvParts, sizePerRank,
+                                                allBeg, nBytes, sendMhandle, request));
   if (*request)
-    TRACE(NCCL_NET, "sendProxy [%ld/%d] Iallgather posted sizePerRank %ld winOffset %ld recvSize %ld request %p", sub->transmitted, sub->nsteps, sizePerRank, allBeg, nBytes, *request);
+    TRACE(NCCL_NET, "sendProxy [%ld/%d] Iallgather posted sizePerRank %ld winOffset %ld recvSize %ld request %p",
+          sub->transmitted, sub->nsteps, sizePerRank, allBeg, nBytes, *request);
   return ncclSuccess;
 }
 
-static ncclResult_t collNetRegIreducescatter(struct ncclProxyState* proxyState, struct sendResources *resources, struct ncclProxyArgs *args, struct ncclProxySubArgs *sub, ssize_t nBytesIn, ssize_t allBeg, ssize_t sendBeg, void *sendMhandle, void **request) {
+static ncclResult_t collNetRegIreducescatter(struct ncclProxyState* proxyState, struct sendResources* resources,
+                                             struct ncclProxyArgs* args, struct ncclProxySubArgs* sub, ssize_t nBytesIn,
+                                             ssize_t allBeg, ssize_t sendBeg, void* sendMhandle, void** request) {
   ncclNetSGE_t sendParts;
   ssize_t sizePerRank = args->specifics.collnetDirect.sizePerRank;
-  char *region = NCCL_NET_MAP_GET_POINTER(&resources->map, gpu, buffs[NCCL_PROTO_SIMPLE]);
+  char* region = NCCL_NET_MAP_GET_POINTER(&resources->map, gpu, buffs[NCCL_PROTO_SIMPLE]);
   ssize_t nBytes;
   size_t winOffset;
-  void *recvbuff;
+  void* recvbuff;
   // Similar to iallgather, if ireducescatter is not 1RPN, we can let collnet network
   // directly access recvbuff but not sendbuff. We use intermediate buffer "region" to
   // send data and directly recv into the recvbuff.
@@ -896,42 +968,53 @@ static ncclResult_t collNetRegIreducescatter(struct ncclProxyState* proxyState, 
   } else {
     recvbuff = sub->recvbuff;
   }
-  NCCLCHECK(proxyState->ncclCollNet->ireducescatter(resources->collNetComm, 1, &sendParts, recvbuff, sizePerRank, winOffset, nBytes, (ncclDataType_t)args->dtype, (ncclRedOp_t)args->redOp, sub->recvMhandle, request));
+  NCCLCHECK(proxyState->ncclCollNet->ireducescatter(resources->collNetComm, 1, &sendParts, recvbuff, sizePerRank,
+                                                    winOffset, nBytes, (ncclDataType_t)args->dtype,
+                                                    (ncclRedOp_t)args->redOp, sub->recvMhandle, request));
   if (*request) {
     if (sub->isOneRPN) {
       sub->sendbuff += nBytes;
       sub->nbytes -= nBytes;
       sub->offset += nBytes;
     }
-    TRACE(NCCL_NET, "sendProxy [%ld/%d] registered Ireducescatter posted sizePerRank %ld winOffset %ld sendSize %ld isOneRPN %d request %p", sub->transmitted, sub->nsteps, sizePerRank, winOffset, nBytes, sub->isOneRPN, *request);
+    TRACE(NCCL_NET,
+          "sendProxy [%ld/%d] registered Ireducescatter posted sizePerRank %ld winOffset %ld sendSize %ld isOneRPN %d "
+          "request %p",
+          sub->transmitted, sub->nsteps, sizePerRank, winOffset, nBytes, sub->isOneRPN, *request);
   }
   return ncclSuccess;
 }
 
-static ncclResult_t collNetIreducescatter(struct ncclProxyState* proxyState, struct sendResources *resources, struct ncclProxyArgs *args, struct ncclProxySubArgs *sub, ssize_t nBytes, ssize_t allBeg, ssize_t sendBeg, ssize_t recvBeg, void *sendMhandle, void *recvMhandle, void **request) {
+static ncclResult_t collNetIreducescatter(struct ncclProxyState* proxyState, struct sendResources* resources,
+                                          struct ncclProxyArgs* args, struct ncclProxySubArgs* sub, ssize_t nBytes,
+                                          ssize_t allBeg, ssize_t sendBeg, ssize_t recvBeg, void* sendMhandle,
+                                          void* recvMhandle, void** request) {
   ncclNetSGE_t sendParts;
   ssize_t sizePerRank = args->specifics.collnetDirect.sizePerRank;
-  char *region = NCCL_NET_MAP_GET_POINTER(&resources->map, gpu, buffs[NCCL_PROTO_SIMPLE]);
+  char* region = NCCL_NET_MAP_GET_POINTER(&resources->map, gpu, buffs[NCCL_PROTO_SIMPLE]);
   sendParts.mhandle = sendMhandle;
   sendParts.address = region + sendBeg;
   sendParts.size = nBytes;
   // non-UB ireducescatter is the same as non-UB iallgather but in the reverse direction.
-  NCCLCHECK(proxyState->ncclCollNet->ireducescatter(resources->collNetComm, 1, &sendParts, region + recvBeg, sizePerRank, allBeg, nBytes, (ncclDataType_t)args->dtype, (ncclRedOp_t)args->redOp, recvMhandle, request));
+  NCCLCHECK(proxyState->ncclCollNet->ireducescatter(resources->collNetComm, 1, &sendParts, region + recvBeg,
+                                                    sizePerRank, allBeg, nBytes, (ncclDataType_t)args->dtype,
+                                                    (ncclRedOp_t)args->redOp, recvMhandle, request));
   if (*request)
-    TRACE(NCCL_NET, "sendProxy [%ld/%d] Ireducescatter posted sizePerRank %ld winOffset %ld sendSize %ld request %p", sub->transmitted, sub->nsteps, sizePerRank, allBeg, nBytes, *request);
+    TRACE(NCCL_NET, "sendProxy [%ld/%d] Ireducescatter posted sizePerRank %ld winOffset %ld sendSize %ld request %p",
+          sub->transmitted, sub->nsteps, sizePerRank, allBeg, nBytes, *request);
   return ncclSuccess;
 }
 
 static ncclResult_t sendProxyProgress(struct ncclProxyState* proxyState, struct ncclProxyArgs* args) {
   if (args->state == ncclProxyOpReady) {
-    for (int s=0; s<args->nsubs; s++) {
-      struct ncclProxySubArgs* sub = args->subs+s;
-      struct sendResources* resources = (struct sendResources*) (sub->connection->transportResources);
+    for (int s = 0; s < args->nsubs; s++) {
+      struct ncclProxySubArgs* sub = args->subs + s;
+      struct sendResources* resources = (struct sendResources*)(sub->connection->transportResources);
       // Round to next multiple of sliceSteps
       sub->base = ROUNDUP(resources->step, args->chunkSteps);
       sub->posted = sub->received = sub->transmitted = sub->done = 0;
       resources->step = sub->base + sub->nsteps;
-      //adjust nsteps for registerd buffers as device signals a single step
+      // adjust nsteps for registerd buffers as device signals a single step
       if (sub->reg && sub->isOneRPN) sub->nsteps = DIVUP((size_t)sub->nbytes, resources->maxCollBytes);
     }
     args->state = ncclProxyOpProgress;
@@ -941,40 +1024,44 @@ static ncclResult_t sendProxyProgress(struct ncclProxyState* proxyState, struct 
   if (args->state == ncclProxyOpProgress) {
     int p = NCCL_PROTO_SIMPLE;
     int nGroups = DIVUP(args->nsubs, COLLNET_GROUP_NSUBS);
-    for (int s=0; s<args->nsubs; s++) {
-      struct ncclProxySubArgs* sub = args->subs+s;
-      struct sendResources* resources = (struct sendResources*) (sub->connection->transportResources);
+    for (int s = 0; s < args->nsubs; s++) {
+      struct ncclProxySubArgs* sub = args->subs + s;
+      struct sendResources* resources = (struct sendResources*)(sub->connection->transportResources);
       void* sendMhandle = resources->sendMhandles[p];
       void* recvMhandle = resources->recvMhandles[p];
       auto reqFifo = resources->reqFifo;
-      int group = s/COLLNET_GROUP_NSUBS;
-      int groupStart = s - (s%COLLNET_GROUP_NSUBS);
+      int group = s / COLLNET_GROUP_NSUBS;
+      int groupStart = s - (s % COLLNET_GROUP_NSUBS);
 
       if (sub->posted < sub->nsteps && sub->posted < sub->done + NCCL_STEPS) {
-        int buffSlot = (sub->base+sub->posted)%NCCL_STEPS;
+        int buffSlot = (sub->base + sub->posted) % NCCL_STEPS;
         if (sub->reg == 0 || (!sub->isOneRPN && args->coll == ncclFuncReduceScatter)) {
           resources->recvMem->connFifo[buffSlot].offset = calcRegionOffset(args, 0, s, sub->posted, 0);
           std::atomic_thread_fence(std::memory_order_seq_cst);
         }
         volatile uint64_t* sendHead = resources->gdcSync ? resources->gdcSync : &resources->sendMem->head;
-        TRACE(NCCL_NET, "sendProxy [%ld/%d/%d/%d] posted offset %d @ %p signal %ld->%ld", long(sub->posted), group, buffSlot, sub->nsteps, resources->recvMem->connFifo[buffSlot].offset, &resources->recvMem->connFifo[buffSlot].offset, long(*sendHead), long(sub->base + sub->posted + args->sliceSteps - NCCL_STEPS));
+        TRACE(NCCL_NET, "sendProxy [%ld/%d/%d/%d] posted offset %d @ %p signal %ld->%ld", long(sub->posted), group,
+              buffSlot, sub->nsteps, resources->recvMem->connFifo[buffSlot].offset,
+              &resources->recvMem->connFifo[buffSlot].offset, long(*sendHead),
+              long(sub->base + sub->posted + args->sliceSteps - NCCL_STEPS));
         sub->posted += args->sliceSteps;
         // Only post one credit for registered buffer
-        if (sub->reg == 0 || !sub->isOneRPN || sub->posted == args->sliceSteps) *sendHead = sub->base + sub->posted - NCCL_STEPS;
+        if (sub->reg == 0 || !sub->isOneRPN || sub->posted == args->sliceSteps)
+          *sendHead = sub->base + sub->posted - NCCL_STEPS;
         if (resources->gdcSync) wc_store_fence(); // Flush out WC write
       }
       if (sub->received < sub->posted && sub->received < sub->done + calcStepsPerGroup(nGroups)) {
-        int buffSlot = (sub->base+sub->received)%NCCL_STEPS;
+        int buffSlot = (sub->base + sub->received) % NCCL_STEPS;
         volatile struct ncclConnFifo* connFifo = (volatile struct ncclConnFifo*)resources->recvMem->connFifo;
         volatile uint64_t* recvTail = &resources->recvMem->tail;
-        //device progresses tail by only 1 for registered buffers
+        // device progresses tail by only 1 for registered buffers
         uint64_t tail = sub->base + (sub->reg && sub->isOneRPN ? 0 : sub->received);
         if ((connFifo[buffSlot].size != -1 || sub->reg) && (*recvTail > tail)) {
           if (args->coll != ncclFuncAllReduce && sub->reg == 0) {
             int sendBeg = calcRegionOffset(args, 0, s, sub->received, 0);
             int sendEnd = calcRegionOffset(args, 0, s, sub->received, 1);
-            if (sendEnd-sendBeg != connFifo[buffSlot].size) {
-              WARN("CollNet sizes: want=%d got=%ld", sendEnd-sendBeg, connFifo[buffSlot].size);
+            if (sendEnd - sendBeg != connFifo[buffSlot].size) {
+              WARN("CollNet sizes: want=%d got=%ld", sendEnd - sendBeg, connFifo[buffSlot].size);
               return ncclInternalError;
             }
           }
@@ -984,46 +1071,52 @@ static ncclResult_t sendProxyProgress(struct ncclProxyState* proxyState, struct 
         }
       }
       // Enforce collective ordering of collnet ops.
-      bool ordered = s==0 ? args->subs[args->nsubs-1].transmitted == sub->transmitted
-                          : sub->transmitted < (sub-1)->transmitted;
+      bool ordered = s == 0 ? args->subs[args->nsubs - 1].transmitted == sub->transmitted :
+                              sub->transmitted < (sub - 1)->transmitted;
       if (ordered && (sub->transmitted < sub->received)) {
         if (LAST_OF_GROUP(args, s)) {
-          int buffSlot = (sub->base+sub->transmitted)%NCCL_STEPS;
+          int buffSlot = (sub->base + sub->transmitted) % NCCL_STEPS;
           if (!reqFifo[group][buffSlot].turnIsSendNotRecv) continue;
 
           ssize_t allBeg = calcAlgoOffset(args, 1, groupStart, sub->transmitted);
-          ssize_t allEnd = calcAlgoOffset(args, 1, s+1, sub->transmitted);
+          ssize_t allEnd = calcAlgoOffset(args, 1, s + 1, sub->transmitted);
           ssize_t sendBeg = calcRegionOffset(args, 0, groupStart, sub->transmitted, 0);
           ssize_t sendEnd = calcRegionOffset(args, 0, s, sub->transmitted, 1);
           ssize_t recvBeg = calcRegionOffset(args, 1, groupStart, sub->transmitted, 0);
           ssize_t recvEnd = calcRegionOffset(args, 1, s, sub->transmitted, 1);
           reqFifo[group][buffSlot].size = recvEnd - recvBeg;
 
-          if (sendBeg==sendEnd && recvBeg==recvEnd) {
+          if (sendBeg == sendEnd && recvBeg == recvEnd) {
             sub->requests[buffSlot] = nullptr; // trivally finished request
           } else {
             ssize_t nBytes = 0;
             if (args->coll == ncclFuncAllReduce) {
               nBytes = sendEnd - sendBeg;
               if (sub->reg) {
-                NCCLCHECK(collNetRegIallreduce(proxyState, resources, args, sub, groupStart, &nBytes, &sub->requests[buffSlot]));
+                NCCLCHECK(collNetRegIallreduce(proxyState, resources, args, sub, groupStart, &nBytes,
+                                               &sub->requests[buffSlot]));
               } else {
-                NCCLCHECK(collNetIallreduce(proxyState, resources, args, sub, nBytes, sendBeg, recvBeg, &sub->requests[buffSlot]));
+                NCCLCHECK(collNetIallreduce(proxyState, resources, args, sub, nBytes, sendBeg, recvBeg,
+                                            &sub->requests[buffSlot]));
               }
             } else if (args->coll == ncclFuncAllGather) {
               nBytes = allEnd - allBeg;
               if (sub->reg) {
-                NCCLCHECK(collNetRegIallgather(proxyState, resources, args, sub, nBytes, allBeg, recvBeg, recvMhandle, &sub->requests[buffSlot]));
+                NCCLCHECK(collNetRegIallgather(proxyState, resources, args, sub, nBytes, allBeg, recvBeg, recvMhandle,
+                                               &sub->requests[buffSlot]));
               } else {
-                NCCLCHECK(collNetIallgather(proxyState, resources, args, sub, nBytes, allBeg, sendBeg, recvBeg, sendMhandle, recvMhandle, &sub->requests[buffSlot]));
+                NCCLCHECK(collNetIallgather(proxyState, resources, args, sub, nBytes, allBeg, sendBeg, recvBeg,
+                                            sendMhandle, recvMhandle, &sub->requests[buffSlot]));
               }
             } else {
               // reducescatter
               nBytes = allEnd - allBeg;
               if (sub->reg) {
-                NCCLCHECK(collNetRegIreducescatter(proxyState, resources, args, sub, nBytes, allBeg, sendBeg, sendMhandle, &sub->requests[buffSlot]));
+                NCCLCHECK(collNetRegIreducescatter(proxyState, resources, args, sub, nBytes, allBeg, sendBeg,
+                                                   sendMhandle, &sub->requests[buffSlot]));
               } else {
-                NCCLCHECK(collNetIreducescatter(proxyState, resources, args, sub, nBytes, allBeg, sendBeg, recvBeg, sendMhandle, recvMhandle, &sub->requests[buffSlot]));
+                NCCLCHECK(collNetIreducescatter(proxyState, resources, args, sub, nBytes, allBeg, sendBeg, recvBeg,
+                                                sendMhandle, recvMhandle, &sub->requests[buffSlot]));
               }
             }
             if (nBytes > 0 && sub->requests[buffSlot] == nullptr) continue;
@@ -1036,18 +1129,23 @@ static ncclResult_t sendProxyProgress(struct ncclProxyState* proxyState, struct 
       // Check whether the network has completed some send operations.
       if (LAST_OF_GROUP(args, s) && sub->done < sub->transmitted) {
         int done, size;
-        int buffSlot = (sub->base+sub->done)%NCCL_STEPS;
+        int buffSlot = (sub->base + sub->done) % NCCL_STEPS;
         done = 1;
-        if (sub->requests[buffSlot]) NCCLCHECK(proxyState->ncclCollNet->test((void*)(sub->requests[buffSlot]), &done, &size));
+        if (sub->requests[buffSlot])
+          NCCLCHECK(proxyState->ncclCollNet->test((void*)(sub->requests[buffSlot]), &done, &size));
         if (done) {
-          TRACE(NCCL_NET, "sendProxy [%ld/%d/%d] request %p done, size %d", (long)sub->done, group, buffSlot, sub->requests[buffSlot], size);
+          TRACE(NCCL_NET, "sendProxy [%ld/%d/%d] request %p done, size %d", (long)sub->done, group, buffSlot,
+                sub->requests[buffSlot], size);
           sub->requests[buffSlot] = nullptr;
           reqFifo[group][buffSlot].turnIsSendNotRecv = false; // Notify recvProxy
-          for (int i=groupStart; i<=s; i++) args->subs[i].done += args->sliceSteps;
+          for (int i = groupStart; i <= s; i++) args->subs[i].done += args->sliceSteps;
           args->idle = 0;
           int allDone = 1;
-          for (int i=0; i<args->nsubs; i++) {
-            if (args->subs[i].done < args->subs[i].nsteps) { allDone = 0; break; }
+          for (int i = 0; i < args->nsubs; i++) {
+            if (args->subs[i].done < args->subs[i].nsteps) {
+              allDone = 0;
+              break;
+            }
           }
           if (allDone) {
             args->state = ncclProxyOpNone;
@@ -1060,8 +1158,10 @@ static ncclResult_t sendProxyProgress(struct ncclProxyState* proxyState, struct 
   return ncclSuccess;
 }
 
-static ncclResult_t collNetRecvFlush(struct ncclProxyState* proxyState, struct recvResources *resources, struct ncclProxyArgs *args, struct ncclProxySubArgs *sub, int groupStart, ssize_t nBytesIn, ssize_t recvBeg, void **request) {
-  char *region = NCCL_NET_MAP_GET_POINTER(&resources->map, gpu, buffs[NCCL_PROTO_SIMPLE]);
+static ncclResult_t collNetRecvFlush(struct ncclProxyState* proxyState, struct recvResources* resources,
+                                     struct ncclProxyArgs* args, struct ncclProxySubArgs* sub, int groupStart,
+                                     ssize_t nBytesIn, ssize_t recvBeg, void** request) {
+  char* region = NCCL_NET_MAP_GET_POINTER(&resources->map, gpu, buffs[NCCL_PROTO_SIMPLE]);
   if (sub->reg && (sub->isOneRPN || args->coll != ncclFuncAllGather)) {
     ssize_t nBytes, loopSize;
     ssize_t offset = sub->offset + groupStart * args->chunkSize;
@@ -1094,28 +1194,30 @@ static ncclResult_t collNetRecvFlush(struct ncclProxyState* proxyState, struct r
           offset = 0;
         }
       }
-      NCCLCHECK(proxyState->ncclCollNet->iflush(resources->collNetComm, sub->recvbuff + offset + sub->loopOffset, nBytes, sub->recvMhandle, request));
+      NCCLCHECK(proxyState->ncclCollNet->iflush(resources->collNetComm, sub->recvbuff + offset + sub->loopOffset,
+                                                nBytes, sub->recvMhandle, request));
       if (*request) {
         sub->nbytes -= loopSize;
         sub->offset += loopSize;
       }
     }
   } else {
-    NCCLCHECK(proxyState->ncclCollNet->iflush(resources->collNetComm, region + recvBeg, nBytesIn, resources->mhandles[NCCL_PROTO_SIMPLE], request));
+    NCCLCHECK(proxyState->ncclCollNet->iflush(resources->collNetComm, region + recvBeg, nBytesIn,
+                                              resources->mhandles[NCCL_PROTO_SIMPLE], request));
   }
   return ncclSuccess;
 }
 
 static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct ncclProxyArgs* args) {
   if (args->state == ncclProxyOpReady) {
-    for (int s=0; s<args->nsubs; s++) {
-      struct ncclProxySubArgs* sub = args->subs+s;
-      struct recvResources* resources = (struct recvResources*) (sub->connection->transportResources);
+    for (int s = 0; s < args->nsubs; s++) {
+      struct ncclProxySubArgs* sub = args->subs + s;
+      struct recvResources* resources = (struct recvResources*)(sub->connection->transportResources);
       // Round to next multiple of sliceSteps
       sub->base = ROUNDUP(resources->step, args->chunkSteps);
       sub->posted = sub->received = sub->flushed = sub->transmitted = sub->done = 0;
       resources->step = sub->base + sub->nsteps;
-      //adjust nsteps for registerd buffers as device signals a single step
+      // adjust nsteps for registerd buffers as device signals a single step
       if (sub->reg && sub->isOneRPN) sub->nsteps = DIVUP((size_t)sub->nbytes, resources->maxCollBytes);
       memset(sub->requests, 0, sizeof(sub->requests));
     }
@@ -1124,16 +1226,17 @@ static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct 
   args->idle = 1;
   if (args->state == ncclProxyOpProgress) {
     int nGroups = DIVUP(args->nsubs, COLLNET_GROUP_NSUBS);
-    for (int s=0; s<args->nsubs; s++) {
-      int group = s/COLLNET_GROUP_NSUBS;
-      int groupStart = s - (s%COLLNET_GROUP_NSUBS);
-      struct ncclProxySubArgs* sub = args->subs+s;
-      struct recvResources* resources = (struct recvResources*) (sub->connection->transportResources);
+    for (int s = 0; s < args->nsubs; s++) {
+      int group = s / COLLNET_GROUP_NSUBS;
+      int groupStart = s - (s % COLLNET_GROUP_NSUBS);
+      struct ncclProxySubArgs* sub = args->subs + s;
+      struct recvResources* resources = (struct recvResources*)(sub->connection->transportResources);
       auto reqFifo = resources->reqFifo;
 
       // Enforce sync between operations of the same group.
-      if (LAST_OF_GROUP(args, s) && (sub->posted < sub->done + calcStepsPerGroup(nGroups)) && (sub->posted < sub->nsteps)) {
-        int buffSlot = (sub->base+sub->posted)%NCCL_STEPS;
+      if (LAST_OF_GROUP(args, s) && (sub->posted < sub->done + calcStepsPerGroup(nGroups)) &&
+          (sub->posted < sub->nsteps)) {
+        int buffSlot = (sub->base + sub->posted) % NCCL_STEPS;
         reqFifo[group][buffSlot].turnIsSendNotRecv = true;
         TRACE(NCCL_NET, "recvProxy [%ld/%d/%d] posted buffer", (long)sub->posted, group, buffSlot);
         sub->posted += args->sliceSteps;
@@ -1141,25 +1244,27 @@ static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct 
         continue;
       }
       if (LAST_OF_GROUP(args, s) && (sub->received < sub->posted)) {
-        int buffSlot = (sub->base+sub->received)%NCCL_STEPS;
+        int buffSlot = (sub->base + sub->received) % NCCL_STEPS;
         if (!reqFifo[group][buffSlot].turnIsSendNotRecv) { // Buffer is cleared : coll is complete
           ssize_t recvBeg = calcRegionOffset(args, 1, groupStart, sub->received, 0);
           ssize_t recvEnd = calcRegionOffset(args, 1, s, sub->received, 1);
           ssize_t totalSize = recvEnd - recvBeg;
-          TRACE(NCCL_NET, "recvProxy [%ld/%d/%d] received, size %ld chunkSize=%ld", (long)sub->received, group, buffSlot, totalSize, args->chunkSize);
+          TRACE(NCCL_NET, "recvProxy [%ld/%d/%d] received, size %ld chunkSize=%ld", (long)sub->received, group,
+                buffSlot, totalSize, args->chunkSize);
           sub->received += args->sliceSteps;
           if ((reqFifo[group][buffSlot].size > 0 || sub->reg) && resources->useGdr && resources->needFlush) {
             // GDRCOPY support
             if (resources->gdcFlush) {
-#if defined (__x86_64__)
+#if defined(__x86_64__)
               // Force a PCI-E read from GPU memory
-              asm volatile ("mov (%0), %%eax" :: "l"(resources->gdcFlush) : "%eax", "memory");
+              asm volatile("mov (%0), %%eax" ::"l"(resources->gdcFlush) : "%eax", "memory");
 #else
               WARN("NET: GDR Flush only supported on x86_64");
               return ncclInternalError;
 #endif
             } else {
-              NCCLCHECK(collNetRecvFlush(proxyState, resources, args, sub, groupStart, totalSize, recvBeg, &sub->requests[buffSlot]));
+              NCCLCHECK(collNetRecvFlush(proxyState, resources, args, sub, groupStart, totalSize, recvBeg,
+                                         &sub->requests[buffSlot]));
             }
           }
           args->idle = 0;
@@ -1168,20 +1273,20 @@ static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct 
       }
       if (LAST_OF_GROUP(args, s) && (sub->flushed < sub->received)) {
         // Progress flush operations
-        int buffSlot = (sub->base + sub->flushed)%NCCL_STEPS;
+        int buffSlot = (sub->base + sub->flushed) % NCCL_STEPS;
         int done = 1;
         if (sub->requests[buffSlot]) NCCLCHECK(proxyState->ncclCollNet->test(sub->requests[buffSlot], &done, NULL));
         if (done) {
           sub->requests[buffSlot] = nullptr;
           TRACE(NCCL_NET, "recvProxy [%ld/%d/%d] flushed", (long)sub->flushed, group, buffSlot);
-          for (int i=group*COLLNET_GROUP_NSUBS; i<=s; i++) args->subs[i].flushed += args->sliceSteps;
+          for (int i = group * COLLNET_GROUP_NSUBS; i <= s; i++) args->subs[i].flushed += args->sliceSteps;
           args->idle = 0;
-          //continue;
+          // continue;
         }
       }
       if (sub->transmitted < sub->flushed) {
         if (sub->reg == 0 || (!sub->isOneRPN && args->coll == ncclFuncAllGather)) {
-          int buffSlot = (sub->base + sub->transmitted)%NCCL_STEPS;
+          int buffSlot = (sub->base + sub->transmitted) % NCCL_STEPS;
           volatile struct ncclConnFifo* connFifo = (volatile struct ncclConnFifo*)resources->recvMem->connFifo;
           connFifo[buffSlot].offset = calcRegionOffset(args, 1, s, sub->transmitted, 0);
           std::atomic_thread_fence(std::memory_order_seq_cst);
@@ -1201,14 +1306,13 @@ static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct 
       // Enforce sync here to make sure the last sub doesn't increase "done" before all others in the group have
       // reached the same point, otherwise we would start posting buffers to the send proxy before we're done
       // processing all the shared buffer.
-      bool groupSync = s==0 ? args->subs[args->nsubs-1].done == sub->done
-                            : (sub-1)->done > sub->done;
+      bool groupSync = s == 0 ? args->subs[args->nsubs - 1].done == sub->done : (sub - 1)->done > sub->done;
       volatile uint64_t* sendHead = &resources->sendMem->head;
       int done = sub->reg && sub->isOneRPN ? 0 : sub->done;
       if (groupSync && sub->done < sub->transmitted && sub->base + done < *sendHead) {
         sub->done += args->sliceSteps;
         args->idle = 0;
-        if (sub->done == sub->nsteps && s == args->nsubs-1) {
+        if (sub->done == sub->nsteps && s == args->nsubs - 1) {
           args->state = ncclProxyOpNone;
           TRACE(NCCL_NET, "recvProxy [%ld/%d] stopped", (long)sub->done, s);
         }
@@ -1223,7 +1327,8 @@ struct collnetRegInfo {
   size_t size;
 };
 
-static ncclResult_t collnetRegisterBuffer(struct ncclComm* comm, const void* userbuff, size_t buffSize, int type, struct ncclReg* regRecord, int* outRegBufFlag, void** outHandle) {
+static ncclResult_t collnetRegisterBuffer(struct ncclComm* comm, const void* userbuff, size_t buffSize, int type,
+                                          struct ncclReg* regRecord, int* outRegBufFlag, void** outHandle) {
   ncclResult_t ret = ncclSuccess;
   int gdrEnable = -1;
   if (regRecord) {
@@ -1231,24 +1336,31 @@ static ncclResult_t collnetRegisterBuffer(struct ncclComm* comm, const void* use
       // reuse previous registration
       *outRegBufFlag = 2;
       *outHandle = regRecord->collnetHandle;
-      INFO(NCCL_REG, "rank %d - COLLNET reuse register userbuff %p (handle %p), buffSize %ld, type %s", comm->rank, userbuff, regRecord->collnetHandle, buffSize, type == collNetRecv ? "Recv" : "Send");
+      INFO(NCCL_REG, "rank %d - COLLNET reuse register userbuff %p (handle %p), buffSize %ld, type %s", comm->rank,
+           userbuff, regRecord->collnetHandle, buffSize, type == collNetRecv ? "Recv" : "Send");
       goto exit;
     } else {
       /* start register collnet buffer */
-      struct collnetRegInfo info = { regRecord->begAddr, regRecord->endAddr - regRecord->begAddr };
+      struct collnetRegInfo info = {regRecord->begAddr, regRecord->endAddr - regRecord->begAddr};
       void* handle = NULL;
-      struct ncclConnInfo* conn = (type == collNetRecv) ? &comm->channels[0].peers[comm->nRanks]->recv[type].conn : &comm->channels[0].peers[comm->nRanks]->send[type].conn;
+      struct ncclConnInfo* conn = (type == collNetRecv) ? &comm->channels[0].peers[comm->nRanks]->recv[type].conn :
+                                                          &comm->channels[0].peers[comm->nRanks]->send[type].conn;
 
       if (conn->flags & NCCL_DIRECT_NIC) {
-        struct ncclProxyConnector* proxyconn = (type == collNetRecv) ? &comm->channels[0].peers[comm->nRanks]->recv[type].proxyConn : &comm->channels[0].peers[comm->nRanks]->send[type].proxyConn;
+        struct ncclProxyConnector* proxyconn = (type == collNetRecv) ?
+                                                 &comm->channels[0].peers[comm->nRanks]->recv[type].proxyConn :
+                                                 &comm->channels[0].peers[comm->nRanks]->send[type].proxyConn;
         gdrEnable = 1;
-        NCCLCHECKGOTO(ncclProxyCallBlocking(comm, proxyconn, ncclProxyMsgRegister, &info, sizeof(struct collnetRegInfo), &handle, sizeof(void*)), ret, fail);
+        NCCLCHECKGOTO(ncclProxyCallBlocking(comm, proxyconn, ncclProxyMsgRegister, &info, sizeof(struct collnetRegInfo),
+                                            &handle, sizeof(void*)),
+                      ret, fail);
         if (handle) {
           regRecord->state |= COLLNET_REG_COMPLETE;
           regRecord->collnetProxyconn = proxyconn;
           *outHandle = regRecord->collnetHandle = handle;
           *outRegBufFlag = 1;
-          INFO(NCCL_REG, "rank %d - COLLNET register userbuff %p (handle %p), buffSize %ld, type %s", comm->rank, userbuff, handle, buffSize, type == collNetRecv ? "Recv" : "Send");
+          INFO(NCCL_REG, "rank %d - COLLNET register userbuff %p (handle %p), buffSize %ld, type %s", comm->rank,
+               userbuff, handle, buffSize, type == collNetRecv ? "Recv" : "Send");
         }
       } else {
         gdrEnable = 0;
@@ -1261,15 +1373,17 @@ exit:
 fail:
   *outRegBufFlag = 0;
   *outHandle = NULL;
-  INFO(NCCL_REG, "rank %d - COLLNET failed to register userbuff %p, buffSize %ld, type %s, GDR %d", comm->rank, userbuff, buffSize, type == collNetRecv ? "Recv" : "Send", gdrEnable);
+  INFO(NCCL_REG, "rank %d - COLLNET failed to register userbuff %p, buffSize %ld, type %s, GDR %d", comm->rank,
+       userbuff, buffSize, type == collNetRecv ? "Recv" : "Send", gdrEnable);
   goto exit;
 }
 
-ncclResult_t ncclCollnetLocalRegisterBuffer(struct ncclComm* comm, const void* userbuff, size_t buffSize, int type, int* outRegBufFlag, void** outHandle) {
+ncclResult_t ncclCollnetLocalRegisterBuffer(struct ncclComm* comm, const void* userbuff, size_t buffSize, int type,
+                                            int* outRegBufFlag, void** outHandle) {
   ncclResult_t ret = ncclSuccess;
-  struct ncclReg *regRecord = NULL;
+  struct ncclReg* regRecord = NULL;
   bool isValid = false;
-  void *base = NULL;
+  void* base = NULL;
   size_t baseSize = 0;
 
   *outRegBufFlag = 0;
@@ -1278,10 +1392,11 @@ ncclResult_t ncclCollnetLocalRegisterBuffer(struct ncclComm* comm, const void* u
     NCCLCHECKGOTO(ncclRegFind(comm, userbuff, buffSize, &regRecord), ret, fail);
     NCCLCHECKGOTO(ncclRegLocalIsValid(regRecord, &isValid), ret, fail);
     if (isValid) {
-      CUCHECKGOTO(cuMemGetAddressRange((CUdeviceptr *)&base, &baseSize, (CUdeviceptr)userbuff), ret, fail);
+      CUCHECKGOTO(cuMemGetAddressRange((CUdeviceptr*)&base, &baseSize, (CUdeviceptr)userbuff), ret, fail);
       if ((uint64_t)base + baseSize < (uint64_t)userbuff + buffSize) goto exit;
     }
-    NCCLCHECKGOTO(collnetRegisterBuffer(comm, userbuff, buffSize, type, regRecord, outRegBufFlag, outHandle), ret, fail);
+    NCCLCHECKGOTO(collnetRegisterBuffer(comm, userbuff, buffSize, type, regRecord, outRegBufFlag, outHandle), ret,
+                  fail);
   }
 exit:
   return ret;
@@ -1292,8 +1407,8 @@ fail:
 
 struct ncclCollnetCleanupCallback {
   struct ncclCommCallback base;
-  struct ncclComm *comm;
-  struct ncclReg *reg;
+  struct ncclComm* comm;
+  struct ncclReg* reg;
 };
 
 static ncclResult_t cleanupCollnet(struct ncclComm* comm, struct ncclCommCallback* cb) {
@@ -1303,19 +1418,22 @@ static ncclResult_t cleanupCollnet(struct ncclComm* comm, struct ncclCommCallbac
   return ncclSuccess;
 }
 
-ncclResult_t ncclCollnetGraphRegisterBuffer(struct ncclComm* comm, const void* userbuff, size_t buffSize, int type, int* outRegBufFlag, void** outHandle, struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>* cleanupQueue, int* nCleanupQueueElts) {
+ncclResult_t ncclCollnetGraphRegisterBuffer(
+  struct ncclComm* comm, const void* userbuff, size_t buffSize, int type, int* outRegBufFlag, void** outHandle,
+  struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>* cleanupQueue, int* nCleanupQueueElts) {
   ncclResult_t ret = ncclSuccess;
   struct ncclCollnetCleanupCallback* record = NULL;
-  struct ncclReg *regRecord = NULL;
-  void *base = NULL;
+  struct ncclReg* regRecord = NULL;
+  void* base = NULL;
   size_t baseSize = 0;
 
   *outRegBufFlag = 0;
   if (comm && userbuff && buffSize > 0) {
-    CUCHECKGOTO(cuMemGetAddressRange((CUdeviceptr *)&base, &baseSize, (CUdeviceptr)userbuff), ret, fail);
+    CUCHECKGOTO(cuMemGetAddressRange((CUdeviceptr*)&base, &baseSize, (CUdeviceptr)userbuff), ret, fail);
     if ((uint64_t)base + baseSize < (uint64_t)userbuff + buffSize) goto exit;
     NCCLCHECKGOTO(ncclCommGraphRegister(comm, base, baseSize, (void**)&regRecord), ret, fail);
-    NCCLCHECKGOTO(collnetRegisterBuffer(comm, userbuff, buffSize, type, regRecord, outRegBufFlag, outHandle), ret, fail);
+    NCCLCHECKGOTO(collnetRegisterBuffer(comm, userbuff, buffSize, type, regRecord, outRegBufFlag, outHandle), ret,
+                  fail);
 
     if (*outRegBufFlag) {
       record = (struct ncclCollnetCleanupCallback*)malloc(sizeof(struct ncclCollnetCleanupCallback));
@@ -1347,7 +1465,8 @@ ncclResult_t ncclCollnetDeregBuffer(struct ncclComm* comm, struct ncclProxyConne
   return ncclSuccess;
 }
 
-static ncclResult_t sendProxyRegBuffer(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
+static ncclResult_t sendProxyRegBuffer(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState,
+                                       void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
   void* handle = NULL;
   struct collnetRegInfo* info = (struct collnetRegInfo*)reqBuff;
   struct sendResources* resources = (struct sendResources*)(connection->transportResources);
@@ -1358,21 +1477,30 @@ static ncclResult_t sendProxyRegBuffer(struct ncclProxyConnection* connection, s
   assert(respSize == sizeof(void*));
 
   int dmabuf_fd = -1;
-  #if CUDART_VERSION >= 11070 || HIP_VERSION >= 71260540
+#if CUDART_VERSION >= 11070 || HIP_VERSION >= 71260540
   /* DMA-BUF support */
   if (resources->useGdr && resources->useDmaBuf && ncclCuMemEnable()) {
-    CUCHECKGOTO(cuMemGetHandleForAddressRange((void *)&dmabuf_fd, (CUdeviceptr)info->buffer, info->size, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, getHandleForAddressRangeFlags(resources->useGdr)), ret, peermem);
-    NCCLCHECKGOTO(proxyState->ncclCollNet->regMrDmaBuf(resources->collNetComm, (void*)info->buffer, info->size, NCCL_PTR_CUDA, 0ULL, dmabuf_fd, &handle), ret, peermem);
+    CUCHECKGOTO(cuMemGetHandleForAddressRange((void*)&dmabuf_fd, (CUdeviceptr)info->buffer, info->size,
+                                              CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
+                                              getHandleForAddressRangeFlags(resources->useGdr)),
+                ret, peermem);
+    NCCLCHECKGOTO(proxyState->ncclCollNet->regMrDmaBuf(resources->collNetComm, (void*)info->buffer, info->size,
+                                                       NCCL_PTR_CUDA, 0ULL, dmabuf_fd, &handle),
+                  ret, peermem);
     (void)close(dmabuf_fd);
     dmabuf_fd = -1;
     needReg = false;
   }
 peermem:
 #else
-  if (resources->useGdr && resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf && proxyState->ncclCollNet->regMrDmaBuf) {
+  if (resources->useGdr && resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf &&
+      proxyState->ncclCollNet->regMrDmaBuf) {
     uint64_t offset;
-    HSACHECKGOTO(hsa_amd_portable_export_dmabuf((const void*)info->buffer, info->size, &dmabuf_fd, &offset), ret, peermem);
-    NCCLCHECKGOTO(proxyState->ncclCollNet->regMrDmaBuf(resources->collNetComm, (void*)info->buffer, info->size, NCCL_PTR_CUDA, offset, dmabuf_fd, &handle), ret, peermem);
+    HSACHECKGOTO(hsa_amd_portable_export_dmabuf((const void*)info->buffer, info->size, &dmabuf_fd, &offset), ret,
+                 peermem);
+    NCCLCHECKGOTO(proxyState->ncclCollNet->regMrDmaBuf(resources->collNetComm, (void*)info->buffer, info->size,
+                                                       NCCL_PTR_CUDA, offset, dmabuf_fd, &handle),
+                  ret, peermem);
     (void)close(dmabuf_fd);
     dmabuf_fd = -1;
     needReg = false;
@@ -1380,7 +1508,9 @@ peermem:
 peermem:
 #endif
   if (needReg) {
-    NCCLCHECKGOTO(proxyState->ncclCollNet->regMr(resources->collNetComm, (void*)info->buffer, info->size, NCCL_PTR_CUDA, &handle), ret, fail);
+    NCCLCHECKGOTO(proxyState->ncclCollNet->regMr(resources->collNetComm, (void*)info->buffer, info->size, NCCL_PTR_CUDA,
+                                                 &handle),
+                  ret, fail);
   }
 
 exit:
@@ -1398,7 +1528,8 @@ fail:
   goto exit;
 }
 
-static ncclResult_t recvProxyRegBuffer(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
+static ncclResult_t recvProxyRegBuffer(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState,
+                                       void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
   void* handle = NULL;
   struct collnetRegInfo* info = (struct collnetRegInfo*)reqBuff;
   struct recvResources* resources = (struct recvResources*)(connection->transportResources);
@@ -1411,18 +1542,27 @@ static ncclResult_t recvProxyRegBuffer(struct ncclProxyConnection* connection, s
 #if CUDART_VERSION >= 11070 || HIP_VERSION >= 71260540
   /* DMA-BUF support */
   if (resources->useGdr && resources->useDmaBuf && ncclCuMemEnable()) {
-    CUCHECKGOTO(cuMemGetHandleForAddressRange((void *)&dmabuf_fd, (CUdeviceptr)info->buffer, info->size, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, getHandleForAddressRangeFlags(resources->useGdr)), ret, peermem);
-    NCCLCHECKGOTO(proxyState->ncclCollNet->regMrDmaBuf(resources->collNetComm, (void*)info->buffer, info->size, NCCL_PTR_CUDA, 0ULL, dmabuf_fd, &handle), ret, peermem);
+    CUCHECKGOTO(cuMemGetHandleForAddressRange((void*)&dmabuf_fd, (CUdeviceptr)info->buffer, info->size,
+                                              CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
+                                              getHandleForAddressRangeFlags(resources->useGdr)),
+                ret, peermem);
+    NCCLCHECKGOTO(proxyState->ncclCollNet->regMrDmaBuf(resources->collNetComm, (void*)info->buffer, info->size,
+                                                       NCCL_PTR_CUDA, 0ULL, dmabuf_fd, &handle),
+                  ret, peermem);
     (void)close(dmabuf_fd);
     dmabuf_fd = -1;
     needReg = false;
   }
 peermem:
 #else
-  if (resources->useGdr && resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf && proxyState->ncclCollNet->regMrDmaBuf) {
+  if (resources->useGdr && resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf &&
+      proxyState->ncclCollNet->regMrDmaBuf) {
     uint64_t offset;
-    HSACHECKGOTO(hsa_amd_portable_export_dmabuf((const void*)info->buffer, info->size, &dmabuf_fd, &offset), ret, peermem);
-    NCCLCHECKGOTO(proxyState->ncclCollNet->regMrDmaBuf(resources->collNetComm, (void*)info->buffer, info->size, NCCL_PTR_CUDA, offset, dmabuf_fd, &handle), ret, peermem);
+    HSACHECKGOTO(hsa_amd_portable_export_dmabuf((const void*)info->buffer, info->size, &dmabuf_fd, &offset), ret,
+                 peermem);
+    NCCLCHECKGOTO(proxyState->ncclCollNet->regMrDmaBuf(resources->collNetComm, (void*)info->buffer, info->size,
+                                                       NCCL_PTR_CUDA, offset, dmabuf_fd, &handle),
+                  ret, peermem);
     (void)close(dmabuf_fd);
     dmabuf_fd = -1;
     needReg = false;
@@ -1430,7 +1570,9 @@ peermem:
 peermem:
 #endif
   if (needReg) {
-    NCCLCHECKGOTO(proxyState->ncclCollNet->regMr(resources->collNetComm, (void*)info->buffer, info->size, NCCL_PTR_CUDA, &handle), ret, fail);
+    NCCLCHECKGOTO(proxyState->ncclCollNet->regMr(resources->collNetComm, (void*)info->buffer, info->size, NCCL_PTR_CUDA,
+                                                 &handle),
+                  ret, fail);
   }
 
 exit:
@@ -1452,7 +1594,8 @@ static bool collnetHandleCmp(struct proxyMemHandle* a, struct proxyMemHandle* b)
   return a->handle == b->handle;
 }
 
-static ncclResult_t sendProxyDeregBuffer(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, int* done) {
+static ncclResult_t sendProxyDeregBuffer(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState,
+                                         void* reqBuff, int reqSize, int* done) {
   void* handle;
   struct sendResources* resources = (struct sendResources*)(connection->transportResources);
 
@@ -1470,7 +1613,8 @@ static ncclResult_t sendProxyDeregBuffer(struct ncclProxyConnection* connection,
   return ncclSuccess;
 }
 
-static ncclResult_t recvProxyDeregBuffer(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, int* done) {
+static ncclResult_t recvProxyDeregBuffer(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState,
+                                         void* reqBuff, int reqSize, int* done) {
   void* handle;
   struct recvResources* resources = (struct recvResources*)(connection->transportResources);
 
@@ -1496,20 +1640,21 @@ ncclResult_t ncclCollNetChainBufferSetup(ncclComm_t comm) {
   // Connect Collnet + chain
   for (int c = 0; c < comm->nChannels; c++) {
     struct ncclChannel* channel = comm->channels + c;
-    NCCLCHECKGOTO(ncclTransportP2pConnect(comm, c, 1, &channel->collnetChain.up, 1, channel->collnetChain.down, 0), ret, fail);
+    NCCLCHECKGOTO(ncclTransportP2pConnect(comm, c, 1, &channel->collnetChain.up, 1, channel->collnetChain.down, 0), ret,
+                  fail);
   }
   NCCLCHECKGOTO(ncclTransportP2pSetup(comm, &comm->graphs[NCCL_ALGO_COLLNET_CHAIN], 0), ret, fail);
   for (int c = 0; c < comm->nChannels; c++) {
     struct ncclChannel* channel = comm->channels + c;
-    NCCLCHECKGOTO(ncclTransportP2pConnect(comm, c, 1, channel->collnetChain.down, 1, &channel->collnetChain.up, 1), ret, fail);
+    NCCLCHECKGOTO(ncclTransportP2pConnect(comm, c, 1, channel->collnetChain.down, 1, &channel->collnetChain.up, 1), ret,
+                  fail);
   }
   NCCLCHECKGOTO(ncclTransportP2pSetup(comm, &comm->graphs[NCCL_ALGO_COLLNET_CHAIN], 1), ret, fail);
 
   line[0] = '\0';
   for (int c = 0; c < comm->nChannels; c++) {
     struct ncclTree* chain = &comm->channels[c].collnetChain;
-    snprintf(line + strlen(line), 1023 - strlen(line), " [%d] %d->%d->%d",
-      c, chain->down[0], comm->rank, chain->up);
+    snprintf(line + strlen(line), 1023 - strlen(line), " [%d] %d->%d->%d", c, chain->down[0], comm->rank, chain->up);
   }
   line[1023] = '\0';
 
@@ -1529,13 +1674,17 @@ ncclResult_t ncclCollNetDirectBufferSetup(ncclComm_t comm) {
   // Connect intra-node CollNet + Direct
   for (int c = 0; c < comm->nChannels; c++) {
     struct ncclChannel* channelRecv = comm->channels + c;
-    NCCLCHECKGOTO(ncclTransportP2pConnect(comm, c, NCCL_MAX_DIRECT_ARITY, channelRecv->collnetDirect.up, NCCL_MAX_DIRECT_ARITY, channelRecv->collnetDirect.down, 0), ret, fail);
+    NCCLCHECKGOTO(ncclTransportP2pConnect(comm, c, NCCL_MAX_DIRECT_ARITY, channelRecv->collnetDirect.up,
+                                          NCCL_MAX_DIRECT_ARITY, channelRecv->collnetDirect.down, 0),
+                  ret, fail);
   }
   NCCLCHECKGOTO(ncclTransportP2pSetup(comm, &comm->graphs[NCCL_ALGO_COLLNET_DIRECT], 0), ret, fail);
 
   for (int c = 0; c < comm->nChannels; c++) {
     struct ncclChannel* channelSend = comm->channels + c;
-    NCCLCHECKGOTO(ncclTransportP2pConnect(comm, c, NCCL_MAX_DIRECT_ARITY, channelSend->collnetDirect.down, NCCL_MAX_DIRECT_ARITY, channelSend->collnetDirect.up, 1), ret, fail);
+    NCCLCHECKGOTO(ncclTransportP2pConnect(comm, c, NCCL_MAX_DIRECT_ARITY, channelSend->collnetDirect.down,
+                                          NCCL_MAX_DIRECT_ARITY, channelSend->collnetDirect.up, 1),
+                  ret, fail);
   }
   NCCLCHECKGOTO(ncclTransportP2pSetup(comm, &comm->graphs[NCCL_ALGO_COLLNET_DIRECT], 1), ret, fail);
 
@@ -1557,7 +1706,10 @@ static ncclResult_t collNetInitRailRankMap(ncclComm_t comm) {
   comm->collNetUserToDenseRank[rank] = -1;
   for (int h = 0; h < comm->collNetHeadsNum; h++) {
     nonHeadMask ^= 1ull << comm->rankToLocalRank[comm->collNetHeads[h]];
-    if (comm->collNetHeads[h] == rank) { comm->collNetUserToDenseRank[rank] = h; break; }
+    if (comm->collNetHeads[h] == rank) {
+      comm->collNetUserToDenseRank[rank] = h;
+      break;
+    }
   }
   if (comm->collNetUserToDenseRank[rank] == -1) {
     comm->collNetUserToDenseRank[rank] = COMPILER_POPCOUNT64(nonHeadMask & ((1ull << comm->localRank) - 1));
@@ -1594,7 +1746,7 @@ ncclResult_t ncclCollNetSetup(ncclComm_t comm, ncclComm_t parent, struct ncclTop
       int head = collNetGraph->intra[c * comm->localRanks + 0];
       assert(comm->rankToNode[head] == comm->node);
       uint64_t mask0 = mask;
-      mask |= 1ull<<comm->rankToLocalRank[head];
+      mask |= 1ull << comm->rankToLocalRank[head];
       if (mask != mask0) comm->collNetHeads[comm->collNetHeadsNum++] = head;
     }
   } else {
@@ -1637,8 +1789,7 @@ ncclResult_t ncclCollNetSetup(ncclComm_t comm, ncclComm_t parent, struct ncclTop
       NCCLCHECKGOTO(bootstrapAllGather(comm->bootstrap, infos, sizeof(struct collnetShareInfo)), ret, fail);
       for (int i = 0; i < comm->nRanks; ++i) {
         if (infos[i].isMaster) {
-          if (prev == INT_MIN)
-            prev = infos[i].headPosition;
+          if (prev == INT_MIN) prev = infos[i].headPosition;
 
           if (infos[i].headPosition == -1 || prev != infos[i].headPosition) {
             share = false;
@@ -1650,15 +1801,15 @@ ncclResult_t ncclCollNetSetup(ncclComm_t comm, ncclComm_t parent, struct ncclTop
       if (share) {
         if (myinfo->isMaster) {
           comm->collNetSharedRes = parent->collNetSharedRes;
-          for (int c = 0; c < comm->nChannels; ++c)
-            NCCLCHECKGOTO(initCollnetChannel(comm, c, parent, true), ret, fail);
+          for (int c = 0; c < comm->nChannels; ++c) NCCLCHECKGOTO(initCollnetChannel(comm, c, parent, true), ret, fail);
         }
 
         NCCLCHECKGOTO(collNetInitRailRankMap(comm), ret, fail);
       } else {
         collNetSetupFail = 1;
         if (comm->rank == 0) {
-          WARN("Child comms (nRanks %d) fails to share parent comms (nRanks %d) sharp resources", comm->nRanks, parent->nRanks);
+          WARN("Child comms (nRanks %d) fails to share parent comms (nRanks %d) sharp resources", comm->nRanks,
+               parent->nRanks);
         }
         goto fail;
       }
@@ -1678,8 +1829,11 @@ ncclResult_t ncclCollNetSetup(ncclComm_t comm, ncclComm_t parent, struct ncclTop
       for (int h = 0; h < comm->collNetHeadsNum; h++) {
         const int head = comm->collNetHeads[h];
         ncclConnect connect;
-        collNetSetupFail |= ncclTransportCollNetSetup(comm, collNetGraph, channel, head, head, h, collNetRecv, &connect);
-        if (!collNetSetupFail) collNetSetupFail |= ncclTransportCollNetSetup(comm, collNetGraph, channel, head, head, h, collNetSend, &connect);
+        collNetSetupFail |=
+          ncclTransportCollNetSetup(comm, collNetGraph, channel, head, head, h, collNetRecv, &connect);
+        if (!collNetSetupFail)
+          collNetSetupFail |=
+            ncclTransportCollNetSetup(comm, collNetGraph, channel, head, head, h, collNetSend, &connect);
       }
       // Verify CollNet setup across ranks after trying the first channel
       if (c == 0) {
@@ -1696,28 +1850,28 @@ ncclResult_t ncclCollNetSetup(ncclComm_t comm, ncclComm_t parent, struct ncclTop
       /* Initialize all entries in collNetSupportMatrix[redop][type]. Since some
       ranks don't connect to sharp we enable a (redop,type) if any rank claims
       support. */
-      uint8_t(*matrix)[4][ncclNumTypes];
+      uint8_t (*matrix)[4][ncclNumTypes];
       bool isHead = false;
       matrix = nullptr;
       NCCLCHECKGOTO(ncclCalloc(&matrix, comm->nRanks), ret, matrix_end);
       for (int h = 0; h < comm->collNetHeadsNum; h++) isHead |= (comm->collNetHeads[h] == comm->rank);
       if (isHead) {
-        for (int ty=0; ty < ncclNumTypes; ty++) {
-          for (int op=0; op < 4; op++) {
+        for (int ty = 0; ty < ncclNumTypes; ty++) {
+          for (int op = 0; op < 4; op++) {
             int support = 0;
             NCCLCHECKGOTO(collNetReduceSupport(comm, (ncclDataType_t)ty, (ncclRedOp_t)op, &support), ret, matrix_end);
             // bit 0 = not supported, bit 1 = supported
-            matrix[rank][op][ty] = 1<<(support ? 1 : 0);
+            matrix[rank][op][ty] = 1 << (support ? 1 : 0);
           }
         }
       }
       NCCLCHECKGOTO(bootstrapAllGather(comm->bootstrap, matrix, sizeof(*matrix)), ret, matrix_end);
-      for (int ty=0; ty < ncclNumTypes; ty++) {
-        for (int op=0; op < 4; op++) {
+      for (int ty = 0; ty < ncclNumTypes; ty++) {
+        for (int op = 0; op < 4; op++) {
           uint8_t accum = 0;
-          for (int r=0; r < comm->nRanks; r++) accum |= matrix[r][op][ty];
+          for (int r = 0; r < comm->nRanks; r++) accum |= matrix[r][op][ty];
           // We support (redop, type) if some rank supports it and no rank doesn't support it
-          comm->collNetSupportMatrix[op][ty] = (accum == (1<<1));
+          comm->collNetSupportMatrix[op][ty] = (accum == (1 << 1));
         }
       }
     matrix_end:
@@ -1739,9 +1893,9 @@ fail:
   goto exit;
 }
 
-struct ncclTransport collNetTransport = {
-  "COL",
-  canConnect,
-  { sendSetup, sendConnect, sendFree, NULL, sendProxySetup, sendProxyConnect, sendProxyFree, sendProxyProgress, sendProxyRegBuffer, sendProxyDeregBuffer },
-  { recvSetup, recvConnect, recvFree, NULL, recvProxySetup, recvProxyConnect, recvProxyFree, recvProxyProgress, recvProxyRegBuffer, recvProxyDeregBuffer }
-};
+struct ncclTransport collNetTransport = {"COL",
+                                         canConnect,
+                                         {sendSetup, sendConnect, sendFree, NULL, sendProxySetup, sendProxyConnect,
+                                          sendProxyFree, sendProxyProgress, sendProxyRegBuffer, sendProxyDeregBuffer},
+                                         {recvSetup, recvConnect, recvFree, NULL, recvProxySetup, recvProxyConnect,
+                                          recvProxyFree, recvProxyProgress, recvProxyRegBuffer, recvProxyDeregBuffer}};

--- a/projects/rccl/src/transport/generic.cc
+++ b/projects/rccl/src/transport/generic.cc
@@ -52,8 +52,10 @@ ncclResult_t ncclTransportTreeConnect(struct ncclComm* comm) {
     // Connect Trees
     for (int c = 0; c < comm->nChannels; c++) {
       struct ncclChannel* channel = comm->channels + c;
-      NCCLCHECKGOTO(ncclTransportP2pConnect(comm, c, NCCL_MAX_TREE_ARITY, channel->tree.down, 1, &channel->tree.up, 0), ret, fail);
-      NCCLCHECKGOTO(ncclTransportP2pConnect(comm, c, 1, &channel->tree.up, NCCL_MAX_TREE_ARITY, channel->tree.down, 0), ret, fail);
+      NCCLCHECKGOTO(ncclTransportP2pConnect(comm, c, NCCL_MAX_TREE_ARITY, channel->tree.down, 1, &channel->tree.up, 0),
+                    ret, fail);
+      NCCLCHECKGOTO(ncclTransportP2pConnect(comm, c, 1, &channel->tree.up, NCCL_MAX_TREE_ARITY, channel->tree.down, 0),
+                    ret, fail);
     }
     NCCLCHECKGOTO(ncclTransportP2pSetup(comm, &comm->graphs[NCCL_ALGO_TREE], 0), ret, fail);
     INFO(NCCL_INIT, "Connected all trees");
@@ -67,7 +69,7 @@ fail:
 ncclResult_t ncclTransportPatConnect(struct ncclComm* comm) {
   ncclResult_t ret = ncclSuccess;
   if (comm && comm->nRanks > 1) {
-    for (int mask=1; mask<comm->nRanks; mask<<=1) {
+    for (int mask = 1; mask < comm->nRanks; mask <<= 1) {
       int prevPeer = (comm->rank + mask) % comm->nRanks;
       int nextPeer = (comm->rank + comm->nRanks - mask) % comm->nRanks;
       for (int c = 0; c < comm->nChannels; c++) {

--- a/projects/rccl/src/transport/net.cc
+++ b/projects/rccl/src/transport/net.cc
@@ -43,24 +43,24 @@ static_assert(sizeof(ncclNetHandle_t) <= CONNECT_SIZE, "NET Connect info is too 
 
 #define NCCL_NET_MAP_MASK_DEVMEM 0x40000000
 #define NCCL_NET_MAP_MASK_SHARED 0x80000000
-#define NCCL_NET_MAP_MASK_USED   0x20000000
+#define NCCL_NET_MAP_MASK_USED 0x20000000
 #define NCCL_NET_MAP_MASK_OFFSET 0x1fffffff
 
-#define NCCL_NET_MAP_OFFSET_BANK(mapStruct, offsetName) \
-  ((mapStruct)->offsets.offsetName >> 30)
+#define NCCL_NET_MAP_OFFSET_BANK(mapStruct, offsetName) ((mapStruct)->offsets.offsetName >> 30)
 
-#define NCCL_NET_MAP_OFFSET_NULL(mapStruct, offsetName) \
-  (((mapStruct)->offsets.offsetName >> 29) == 0)
+#define NCCL_NET_MAP_OFFSET_NULL(mapStruct, offsetName) (((mapStruct)->offsets.offsetName >> 29) == 0)
 
 #define NCCL_NET_MAP_GET_POINTER(mapStruct, cpuOrGpu, offsetName) \
-  (NCCL_NET_MAP_OFFSET_NULL(mapStruct, offsetName) ? NULL : \
-  (mapStruct)->mems[NCCL_NET_MAP_OFFSET_BANK(mapStruct, offsetName)].cpuOrGpu##Ptr + ((mapStruct)->offsets.offsetName & NCCL_NET_MAP_MASK_OFFSET))
+  (NCCL_NET_MAP_OFFSET_NULL(mapStruct, offsetName) ? \
+     NULL : \
+     (mapStruct)->mems[NCCL_NET_MAP_OFFSET_BANK(mapStruct, offsetName)].cpuOrGpu##Ptr + \
+       ((mapStruct)->offsets.offsetName & NCCL_NET_MAP_MASK_OFFSET))
 
-#define NCCL_NET_MAP_DEV_MEM(mapStruct, offsetName) \
-  (((mapStruct)->offsets.offsetName & NCCL_NET_MAP_MASK_DEVMEM) != 0)
+#define NCCL_NET_MAP_DEV_MEM(mapStruct, offsetName) (((mapStruct)->offsets.offsetName & NCCL_NET_MAP_MASK_DEVMEM) != 0)
 
-#define NCCL_NET_MAP_ADD_POINTER(mapStruct, shared, dev, memSize, offsetName) do { \
-    int bank = NCCL_NET_MAP_MASK_USED + (dev)*NCCL_NET_MAP_MASK_DEVMEM + (shared)*NCCL_NET_MAP_MASK_SHARED; \
+#define NCCL_NET_MAP_ADD_POINTER(mapStruct, shared, dev, memSize, offsetName) \
+  do { \
+    int bank = NCCL_NET_MAP_MASK_USED + (dev) * NCCL_NET_MAP_MASK_DEVMEM + (shared) * NCCL_NET_MAP_MASK_SHARED; \
     if ((shared) == 0) { \
       if (dev) { \
         (mapStruct)->offsets.offsetName = bank + (mapStruct)->mems[NCCL_NET_MAP_DEVMEM].size; \
@@ -72,9 +72,9 @@ static_assert(sizeof(ncclNetHandle_t) <= CONNECT_SIZE, "NET Connect info is too 
     } else { \
       (mapStruct)->offsets.offsetName = bank; \
     } \
-} while (0);
+  } while (0);
 
-struct connectMapMem{
+struct connectMapMem {
   char* gpuPtr;
   char* cpuPtr;
   int size;
@@ -116,7 +116,7 @@ struct sendNetResources {
   int shared;
   int channelId;
   int connIndex;
-  int sameDevice;  // proxy and kernel are on the same CUDA device
+  int sameDevice; // proxy and kernel are on the same CUDA device
   char* buffers[NCCL_NUM_PROTOCOLS];
   int buffSizes[NCCL_NUM_PROTOCOLS];
   void* mhandles[NCCL_NUM_PROTOCOLS];
@@ -126,7 +126,7 @@ struct sendNetResources {
   ncclNetDeviceType netDeviceType;
   ncclNetDeviceHandle_t* netDeviceHandle;
   size_t maxP2pBytes;
-  volatile uint32_t* curr_hdp_reg;  // Curr GPU in ring (for rdma transport use only)
+  volatile uint32_t* curr_hdp_reg; // Curr GPU in ring (for rdma transport use only)
   int isP2p;
 };
 
@@ -152,7 +152,7 @@ struct recvNetResources {
   int shared;
   int channelId;
   int connIndex;
-  int sameDevice;  // proxy and kernel are on the same CUDA device
+  int sameDevice; // proxy and kernel are on the same CUDA device
   char* buffers[NCCL_NUM_PROTOCOLS];
   int buffSizes[NCCL_NUM_PROTOCOLS];
   void* mhandles[NCCL_NUM_PROTOCOLS];
@@ -162,7 +162,7 @@ struct recvNetResources {
   ncclNetDeviceType netDeviceType;
   ncclNetDeviceHandle_t* netDeviceHandle;
   size_t maxP2pBytes;
-  volatile uint32_t* curr_hdp_reg;  // Curr GPU in ring (for rdma transport use only)
+  volatile uint32_t* curr_hdp_reg; // Curr GPU in ring (for rdma transport use only)
 };
 
 struct netRegInfo {
@@ -173,7 +173,8 @@ struct netRegInfo {
 };
 
 /* Determine if two peers can communicate with NET */
-static ncclResult_t canConnect(int* ret, struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* info1, struct ncclPeerInfo* info2) {
+static ncclResult_t canConnect(int* ret, struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* info1,
+                               struct ncclPeerInfo* info2) {
   *ret = 1;
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
 #else
@@ -204,7 +205,7 @@ struct setupReq {
   int connIndex;
   uint32_t* curr_hdp_reg;
   int isP2p;
-  int sameDevice;  // proxy and kernel are on the same CUDA device
+  int sameDevice; // proxy and kernel are on the same CUDA device
 };
 
 NCCL_PARAM(NetOptionalRecvCompletion, "NET_OPTIONAL_RECV_COMPLETION", 1);
@@ -237,15 +238,14 @@ static int readIBNicRate(const char* devName) {
 }
 
 static void rcclDetectIBNics() {
-  #define MAX_VENDOR_LEN 16
-  #define MAX_IB_DEVS 32
+#define MAX_VENDOR_LEN 16
+#define MAX_IB_DEVS 32
   /* Map of vendor/device pairs to rcclIBNicType:
    Note: Vendor ID should be exact value, device id can be a prefix or a wildcard*/
-  std::map<std::pair<std::string, std::string>, rcclIBNicType> vendorNames = {
-    {{"0x15b3", "*"}, rcclIBNicTypeMLX},
-    {{"0x1dd8", "0x10"}, rcclIBNicTypeAINIC},
-    {{"0x14e4", "0x1760"}, rcclIBNicTypeBNXT2}
-  };
+  std::map<std::pair<std::string, std::string>, rcclIBNicType> vendorNames = {{{"0x15b3", "*"}, rcclIBNicTypeMLX},
+                                                                              {{"0x1dd8", "0x10"}, rcclIBNicTypeAINIC},
+                                                                              {{"0x14e4", "0x1760"},
+                                                                               rcclIBNicTypeBNXT2}};
 
   int _Nnics[rcclIBNicTypeMax]{};
   int _NicsRate[rcclIBNicTypeMax]{};
@@ -254,14 +254,14 @@ static void rcclDetectIBNics() {
   /* NCCL_NET=ROCM-IB forces AINIC mode regardless of detected hardware */
   const char* envNet = ncclGetEnv("NCCL_NET");
   if (envNet && strcasecmp(envNet, "ROCM-IB") == 0) {
-    INFO(NCCL_NET|NCCL_INIT, "RCCL: AINIC mode forced by NCCL_NET=ROCM-IB");
+    INFO(NCCL_NET | NCCL_INIT, "RCCL: AINIC mode forced by NCCL_NET=ROCM-IB");
     rcclPrimaryNicInfo.type = rcclIBNicTypeAINIC;
     return;
   }
 
   /* respect user preference for AINIC */
   if (rcclParamAinicRoce() == 1) {
-    INFO(NCCL_NET|NCCL_INIT, "RCCL: AINIC detection: enforced by user settings");
+    INFO(NCCL_NET | NCCL_INIT, "RCCL: AINIC detection: enforced by user settings");
   }
 
   struct netIf userIfs[MAX_IB_DEVS];
@@ -271,10 +271,9 @@ static void rcclDetectIBNics() {
   if (userIbEnv && (userIbEnv[0] == '=')) userIbEnv++;
   int nUserIfs = parseStringList(userIbEnv, userIfs, MAX_IB_DEVS);
 
-  
   DIR* dir = opendir(sysfsIBPath);
   if (dir == NULL) {
-    INFO(NCCL_NET|NCCL_INIT, "RCCL: No InfiniBand devices found (cannot open %s)", sysfsIBPath);
+    INFO(NCCL_NET | NCCL_INIT, "RCCL: No InfiniBand devices found (cannot open %s)", sysfsIBPath);
     rcclPrimaryNicInfo.type = rcclIBNicTypeDefault;
     return;
   }
@@ -315,7 +314,7 @@ static void rcclDetectIBNics() {
       }
     }
     if (!detected) {
-    /* Unknown vendor/device pair or generic device */
+      /* Unknown vendor/device pair or generic device */
       _Nnics[rcclIBNicTypeDefault]++;
       totalNnics++;
     }
@@ -331,8 +330,8 @@ static void rcclDetectIBNics() {
     }
   }
 
-  INFO(NCCL_NET|NCCL_INIT, "RCCL: Detected %d IB devices, primary type: %d (count: %d)", 
-       totalNnics, primaryNicsType, maxCount);
+  INFO(NCCL_NET | NCCL_INIT, "RCCL: Detected %d IB devices, primary type: %d (count: %d)", totalNnics, primaryNicsType,
+       maxCount);
   rcclPrimaryNicInfo.type = primaryNicsType;
   rcclPrimaryNicInfo.rate = _NicsRate[primaryNicsType];
   rcclPrimaryNicInfo.count = maxCount;
@@ -350,7 +349,8 @@ rcclIBNicInfo rcclPrimaryNic() {
   return rcclPrimaryNicInfo;
 }
 
-static_assert(sizeof(ncclNetHandle_t) + sizeof(int) <= CONNECT_SIZE, "Not large enough ncclConnect to hold ncclNetHandle_t and useGdr flag");
+static_assert(sizeof(ncclNetHandle_t) + sizeof(int) <= CONNECT_SIZE,
+              "Not large enough ncclConnect to hold ncclNetHandle_t and useGdr flag");
 
 // Common function to initialize network attributes from a ncclComm
 static void populateCommNetAttrs(struct ncclComm* comm, struct ncclConnector* conn, ncclNetAttr_t* netAttr) {
@@ -369,8 +369,8 @@ static void populateCommNetAttrs(struct ncclComm* comm, struct ncclConnector* co
     netAttr->sendCommAttr.maxFlowsPerPeer = comm->p2pnChannelsPerPeer;
     netAttr->recvCommAttr.maxConcurrentPeers = maxConcPeers;
     netAttr->recvCommAttr.maxFlowsPerPeer = comm->p2pnChannelsPerPeer;
-    netAttr->op = BIT(ncclFuncSend) | BIT(ncclFuncRecv) |
-                  BIT(ncclFuncAlltoAll) | BIT(ncclFuncScatter) | BIT(ncclFuncGather);
+    netAttr->op =
+      BIT(ncclFuncSend) | BIT(ncclFuncRecv) | BIT(ncclFuncAlltoAll) | BIT(ncclFuncScatter) | BIT(ncclFuncGather);
   } else {
     size_t maxConcPeers = (NCCL_MAX_TREE_ARITY - 1) * 2;
     if (comm->nRanks < maxConcPeers) maxConcPeers = comm->nRanks;
@@ -382,42 +382,38 @@ static void populateCommNetAttrs(struct ncclComm* comm, struct ncclConnector* co
 }
 
 // Apply the netAttr to the netComm
-void setNetAttrs(struct ncclProxyState* proxyState, ncclNetAttr_t* netAttr)
-{
+void setNetAttrs(struct ncclProxyState* proxyState, ncclNetAttr_t* netAttr) {
   if (proxyState->ncclNet->setNetAttr) {
     proxyState->ncclNet->setNetAttr(proxyState->netContext, netAttr);
     proxyState->netAttr = *netAttr;
   }
 }
 
-void printNetAttrs(ncclNetAttr_t* netAttr, const char *task)
-{
-  const int opBufLen = ncclNumFuncs*32;
+void printNetAttrs(ncclNetAttr_t* netAttr, const char* task) {
+  const int opBufLen = ncclNumFuncs * 32;
   char opBuf[opBufLen] = "";
-  const int algoBufLen = NCCL_NUM_ALGORITHMS*32;
+  const int algoBufLen = NCCL_NUM_ALGORITHMS * 32;
   char algoBuf[algoBufLen] = "";
-  const int protoBufLen = NCCL_NUM_PROTOCOLS*32;
+  const int protoBufLen = NCCL_NUM_PROTOCOLS * 32;
   char protoBuf[protoBufLen] = "";
 
   ncclBitsToString(netAttr->op, MASK(ncclNumFuncs), (const char* (*)(int))ncclFuncToString, opBuf, opBufLen, "*");
   ncclBitsToString(netAttr->algo, MASK(NCCL_NUM_ALGORITHMS), ncclAlgoToString, algoBuf, algoBufLen, "*");
   ncclBitsToString(netAttr->proto, MASK(NCCL_NUM_PROTOCOLS), ncclProtoToString, protoBuf, protoBufLen, "*");
 
-  TRACE(NCCL_NET, "%s hints, send peers/flows: [%d-%d][%d-%d] recv peers/flows: [%d-%d][%d-%d] op: %s algo: %s proto: %s",
-        task, netAttr->sendCommAttr.minConcurrentPeers, netAttr->sendCommAttr.maxConcurrentPeers,
+  TRACE(NCCL_NET,
+        "%s hints, send peers/flows: [%d-%d][%d-%d] recv peers/flows: [%d-%d][%d-%d] op: %s algo: %s proto: %s", task,
+        netAttr->sendCommAttr.minConcurrentPeers, netAttr->sendCommAttr.maxConcurrentPeers,
         netAttr->sendCommAttr.minFlowsPerPeer, netAttr->sendCommAttr.maxFlowsPerPeer,
         netAttr->recvCommAttr.minConcurrentPeers, netAttr->recvCommAttr.maxConcurrentPeers,
-        netAttr->recvCommAttr.minFlowsPerPeer, netAttr->recvCommAttr.maxFlowsPerPeer,
-        opBuf, algoBuf, protoBuf);
+        netAttr->recvCommAttr.minFlowsPerPeer, netAttr->recvCommAttr.maxFlowsPerPeer, opBuf, algoBuf, protoBuf);
 }
 
 // Set the netAttr for a transfer operation
-void setXferNetAttrs(struct ncclProxyState* proxyState, struct ncclProxyArgs* args, int send)
-{
+void setXferNetAttrs(struct ncclProxyState* proxyState, struct ncclProxyArgs* args, int send) {
   ncclNetAttr_t netAttr;
 
-  if (!proxyState->ncclNet->setNetAttr)
-    return;
+  if (!proxyState->ncclNet->setNetAttr) return;
 
   netAttr = proxyState->netAttr;
 
@@ -460,17 +456,21 @@ static inline int getHandleForAddressRangeFlags(ncclTopoGdrMode useGdr) {
 }
 
 /* Determine if we will use this transport for this peer and return connect
-* information for this peer */
-static ncclResult_t sendSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* myInfo, struct ncclPeerInfo* peerInfo, struct ncclConnect* connectInfo, struct ncclConnector* send, int channelId, int connIndex) {
-  struct setupReq req = { 0 };
+ * information for this peer */
+static ncclResult_t sendSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* myInfo,
+                              struct ncclPeerInfo* peerInfo, struct ncclConnect* connectInfo,
+                              struct ncclConnector* send, int channelId, int connIndex) {
+  struct setupReq req = {0};
 
-  send->conn.shared = req.shared = (graph || connIndex == 0) ? 0 : ncclParamNetSharedBuffers() != -2 ? ncclParamNetSharedBuffers() : 1;
+  send->conn.shared = req.shared = (graph || connIndex == 0)         ? 0 :
+                                   ncclParamNetSharedBuffers() != -2 ? ncclParamNetSharedBuffers() :
+                                                                       1;
   req.channelId = channelId;
   req.connIndex = connIndex;
   req.curr_hdp_reg = 0;
   req.netDev = -1;
   // Determine if this is a P2P connection or not based on the graph pointer
-  if(graph == NULL) {
+  if (graph == NULL) {
     req.isP2p = 1;
   } else {
     req.isP2p = 0;
@@ -478,13 +478,17 @@ static ncclResult_t sendSetup(struct ncclComm* comm, struct ncclTopoGraph* graph
 
   int proxyRank = myInfo->rank;
   int64_t netId;
-  if (connIndex == NCCL_CONN_IDX_P2P_NET) NCCLCHECK(ncclTopoGetIntraNetDev(comm->topo, myInfo->rank, graph, channelId, 1, &netId, &req.netDev));
-  if (req.netDev < 0) NCCLCHECK(ncclTopoGetNetDev(comm, myInfo->rank, graph, channelId, peerInfo->rank, &netId, &req.netDev, &proxyRank));
+  if (connIndex == NCCL_CONN_IDX_P2P_NET)
+    NCCLCHECK(ncclTopoGetIntraNetDev(comm->topo, myInfo->rank, graph, channelId, 1, &netId, &req.netDev));
+  if (req.netDev < 0)
+    NCCLCHECK(ncclTopoGetNetDev(comm, myInfo->rank, graph, channelId, peerInfo->rank, &netId, &req.netDev, &proxyRank));
   NCCLCHECK(ncclTopoCheckGdr(comm->topo, myInfo->rank, netId, 1, &req.useGdr));
   send->conn.flags |= req.useGdr ? NCCL_DIRECT_NIC : 0;
   if (!req.useGdr && connIndex == 0) comm->useGdr = 0;
   if (proxyRank != myInfo->rank && connIndex == 0) comm->useNetPXN = true;
-  if (req.useGdr && !IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx90a") && !IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942") && !IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950")) {
+  if (req.useGdr && !IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx90a") &&
+      !IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942") &&
+      !IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950")) {
     CUDACHECK(hipDeviceGetAttribute((int*)&req.curr_hdp_reg, hipDeviceAttributeHdpMemFlushCntl, myInfo->cudaDev));
     send->conn.curr_hdp_reg = req.curr_hdp_reg;
   }
@@ -497,14 +501,15 @@ static ncclResult_t sendSetup(struct ncclComm* comm, struct ncclTopoGraph* graph
   NCCLCHECK(ncclProxyCallBlocking(comm, &send->proxyConn, ncclProxyMsgSetup, &req, sizeof(req), NULL, 0));
 
   if (proxyRank == myInfo->rank) {
-    INFO(NCCL_INIT|NCCL_NET,"Channel %02d/%d : %d[%d] -> %d[%d] [send] via NET/%s/%d%s%s%s comm %p nRanks %02d", channelId, connIndex, myInfo->rank, myInfo->nvmlDev, peerInfo->rank, peerInfo->nvmlDev, comm->ncclNet->name, req.netDev,
-        req.useGdr ? "/GDRDMA" : "", req.useGdr==ncclTopoGdrModePci ? "(PCI)" : "",
-        req.shared ? "/Shared" : "", comm, comm->nRanks);
+    INFO(NCCL_INIT | NCCL_NET, "Channel %02d/%d : %d[%d] -> %d[%d] [send] via NET/%s/%d%s%s%s comm %p nRanks %02d",
+         channelId, connIndex, myInfo->rank, myInfo->nvmlDev, peerInfo->rank, peerInfo->nvmlDev, comm->ncclNet->name,
+         req.netDev, req.useGdr ? "/GDRDMA" : "", req.useGdr == ncclTopoGdrModePci ? "(PCI)" : "",
+         req.shared ? "/Shared" : "", comm, comm->nRanks);
   } else {
-    INFO(NCCL_INIT|NCCL_NET,"Channel %02d/%d : %d[%d] -> %d[%d] [send] via NET/%s/%d(%d)%s%s%s comm %p nRanks %02d", channelId, connIndex, myInfo->rank, myInfo->nvmlDev, peerInfo->rank, peerInfo->nvmlDev, comm->ncclNet->name, req.netDev,
-        proxyRank,
-        req.useGdr ? "/GDRDMA" : "", req.useGdr==ncclTopoGdrModePci ? "(PCI)" : "",
-        req.shared ? "/Shared" : "", comm, comm->nRanks);
+    INFO(NCCL_INIT | NCCL_NET, "Channel %02d/%d : %d[%d] -> %d[%d] [send] via NET/%s/%d(%d)%s%s%s comm %p nRanks %02d",
+         channelId, connIndex, myInfo->rank, myInfo->nvmlDev, peerInfo->rank, peerInfo->nvmlDev, comm->ncclNet->name,
+         req.netDev, proxyRank, req.useGdr ? "/GDRDMA" : "", req.useGdr == ncclTopoGdrModePci ? "(PCI)" : "",
+         req.shared ? "/Shared" : "", comm, comm->nRanks);
   }
   *((int*)connectInfo) = comm->topParentRanks[proxyRank];
   memcpy((uint8_t*)connectInfo + sizeof(ncclNetHandle_t), &req.useGdr, sizeof(int));
@@ -517,10 +522,14 @@ NCCL_PARAM(GdrCopySyncEnable, "GDRCOPY_SYNC_ENABLE", 1);
 NCCL_PARAM(GdrCopyFlushEnable, "GDRCOPY_FLUSH_ENABLE", 0);
 
 /* Setup recv connector */
-static ncclResult_t recvSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* myInfo, struct ncclPeerInfo* peerInfo, struct ncclConnect* connectInfo, struct ncclConnector* recv, int channelId, int connIndex) {
-  struct setupReq req = { 0 };
+static ncclResult_t recvSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* myInfo,
+                              struct ncclPeerInfo* peerInfo, struct ncclConnect* connectInfo,
+                              struct ncclConnector* recv, int channelId, int connIndex) {
+  struct setupReq req = {0};
 
-  recv->conn.shared = req.shared = (graph || connIndex == 0) ? 0 : ncclParamNetSharedBuffers() != -2 ? ncclParamNetSharedBuffers() : 1;
+  recv->conn.shared = req.shared = (graph || connIndex == 0)         ? 0 :
+                                   ncclParamNetSharedBuffers() != -2 ? ncclParamNetSharedBuffers() :
+                                                                       1;
   req.channelId = channelId;
   req.connIndex = connIndex;
   req.netDev = -1;
@@ -528,8 +537,11 @@ static ncclResult_t recvSetup(struct ncclComm* comm, struct ncclTopoGraph* graph
   // Use myInfo->rank as the receiver uses its own NIC
   int proxyRank = myInfo->rank;
   int64_t netId;
-  if (connIndex == NCCL_CONN_IDX_P2P_NET) NCCLCHECK(ncclTopoGetIntraNetDev(comm->topo, myInfo->rank, graph, channelId, 0, &netId, &req.netDev));
-  if (req.netDev < 0) NCCLCHECK(ncclTopoGetNetDev(comm, myInfo->rank, graph, channelId, /*peerRank=*/myInfo->rank, &netId, &req.netDev, &proxyRank));
+  if (connIndex == NCCL_CONN_IDX_P2P_NET)
+    NCCLCHECK(ncclTopoGetIntraNetDev(comm->topo, myInfo->rank, graph, channelId, 0, &netId, &req.netDev));
+  if (req.netDev < 0)
+    NCCLCHECK(ncclTopoGetNetDev(comm, myInfo->rank, graph, channelId, /*peerRank=*/myInfo->rank, &netId, &req.netDev,
+                                &proxyRank));
   NCCLCHECK(ncclTopoCheckGdr(comm->topo, myInfo->rank, netId, 0, &req.useGdr));
   recv->conn.flags |= req.useGdr ? NCCL_DIRECT_NIC : 0;
   if (!req.useGdr && connIndex == 0) comm->useGdr = 0;
@@ -551,47 +563,49 @@ static ncclResult_t recvSetup(struct ncclComm* comm, struct ncclTopoGraph* graph
   req.tpRank = comm->topParentRanks[myInfo->rank];
   req.tpRemoteRank = comm->topParentRanks[peerInfo->rank];
   req.sameDevice = (comm->peerInfo[proxyRank].cudaDev == comm->cudaDev);
-  NCCLCHECK(ncclProxyCallBlocking(comm, &recv->proxyConn, ncclProxyMsgSetup, &req, sizeof(req), connectInfo, sizeof(ncclNetHandle_t)));
+  NCCLCHECK(ncclProxyCallBlocking(comm, &recv->proxyConn, ncclProxyMsgSetup, &req, sizeof(req), connectInfo,
+                                  sizeof(ncclNetHandle_t)));
   memcpy((uint8_t*)connectInfo + sizeof(ncclNetHandle_t), &req.useGdr, sizeof(int));
-  INFO(NCCL_INIT|NCCL_NET,"Channel %02d/%d : %d[%d] -> %d[%d] [receive] via NET/%s/%d%s%s%s comm %p nRanks %02d", channelId, connIndex, peerInfo->rank, peerInfo->nvmlDev, myInfo->rank, myInfo->nvmlDev, comm->ncclNet->name, req.netDev,
-      req.useGdr ? "/GDRDMA" : "", req.useGdr==ncclTopoGdrModePci ? "(PCI)" : "",
-      req.shared ? "/Shared" : "", comm, comm->nRanks);
+  INFO(NCCL_INIT | NCCL_NET, "Channel %02d/%d : %d[%d] -> %d[%d] [receive] via NET/%s/%d%s%s%s comm %p nRanks %02d",
+       channelId, connIndex, peerInfo->rank, peerInfo->nvmlDev, myInfo->rank, myInfo->nvmlDev, comm->ncclNet->name,
+       req.netDev, req.useGdr ? "/GDRDMA" : "", req.useGdr == ncclTopoGdrModePci ? "(PCI)" : "",
+       req.shared ? "/Shared" : "", comm, comm->nRanks);
   return ncclSuccess;
 }
 
-static ncclResult_t netMapShm(struct ncclComm *comm, struct ncclProxyConnector* proxyConn, struct connectMapMem* mem) {
-  NCCLCHECK(ncclShmImportShareableBuffer(comm, proxyConn->rank, &mem->createDesc, (void**)&mem->cpuPtr, (void**)&mem->gpuPtr, &mem->attachDesc));
+static ncclResult_t netMapShm(struct ncclComm* comm, struct ncclProxyConnector* proxyConn, struct connectMapMem* mem) {
+  NCCLCHECK(ncclShmImportShareableBuffer(comm, proxyConn->rank, &mem->createDesc, (void**)&mem->cpuPtr,
+                                         (void**)&mem->gpuPtr, &mem->attachDesc));
   return ncclSuccess;
 }
 
 static ncclResult_t netCreateShm(struct ncclProxyState* proxyState, struct connectMapMem* mem) {
-  NCCLCHECK(ncclShmAllocateShareableBuffer(mem->size, false, &mem->createDesc, (void**)&mem->cpuPtr, (void**)&mem->gpuPtr));
+  NCCLCHECK(ncclShmAllocateShareableBuffer(mem->size, false, &mem->createDesc, (void**)&mem->cpuPtr,
+                                           (void**)&mem->gpuPtr));
   return ncclSuccess;
 }
 
 static ncclResult_t netDumpMap(struct connectMap* map) {
   printf("Dump map same process %d shared %d\n", map->sameProcess, map->shared);
-  struct connectMapMem *mem = map->mems+NCCL_NET_MAP_HOSTMEM;
+  struct connectMapMem* mem = map->mems + NCCL_NET_MAP_HOSTMEM;
   printf("Mem 0: Host mem (%x B) CPU %p GPU %p\n", mem->size, mem->cpuPtr, mem->gpuPtr);
-  mem = map->mems+NCCL_NET_MAP_DEVMEM;
+  mem = map->mems + NCCL_NET_MAP_DEVMEM;
   printf("Mem 1: Vid  mem (%x B) CPU %p GPU %p\n", mem->size, mem->cpuPtr, mem->gpuPtr);
-  mem = map->mems+NCCL_NET_MAP_SHARED_HOSTMEM;
+  mem = map->mems + NCCL_NET_MAP_SHARED_HOSTMEM;
   printf("Mem 2: Shared Host mem (%x B) CPU %p GPU %p\n", mem->size, mem->cpuPtr, mem->gpuPtr);
-  mem = map->mems+NCCL_NET_MAP_SHARED_DEVMEM;
+  mem = map->mems + NCCL_NET_MAP_SHARED_DEVMEM;
   printf("Mem 3: Shared Vid mem (%x B) CPU %p GPU %p\n", mem->size, mem->cpuPtr, mem->gpuPtr);
-  printf("SendMem -> Used %d Bank %d Offset %x, cpu %p gpu %p\n",
-      map->offsets.sendMem & NCCL_NET_MAP_MASK_USED ? 1 : 0,
-      NCCL_NET_MAP_OFFSET_BANK(map, sendMem), map->offsets.sendMem & NCCL_NET_MAP_MASK_OFFSET,
-      NCCL_NET_MAP_GET_POINTER(map, cpu, sendMem), NCCL_NET_MAP_GET_POINTER(map, gpu, sendMem));
-  printf("RecvMem -> Used %d Bank %d Offset %x, cpu %p gpu %p\n",
-      map->offsets.recvMem & NCCL_NET_MAP_MASK_USED ? 1 : 0,
-      NCCL_NET_MAP_OFFSET_BANK(map, recvMem), map->offsets.recvMem & NCCL_NET_MAP_MASK_OFFSET,
-      NCCL_NET_MAP_GET_POINTER(map, cpu, recvMem), NCCL_NET_MAP_GET_POINTER(map, gpu, recvMem));
-  for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
+  printf("SendMem -> Used %d Bank %d Offset %x, cpu %p gpu %p\n", map->offsets.sendMem & NCCL_NET_MAP_MASK_USED ? 1 : 0,
+         NCCL_NET_MAP_OFFSET_BANK(map, sendMem), map->offsets.sendMem & NCCL_NET_MAP_MASK_OFFSET,
+         NCCL_NET_MAP_GET_POINTER(map, cpu, sendMem), NCCL_NET_MAP_GET_POINTER(map, gpu, sendMem));
+  printf("RecvMem -> Used %d Bank %d Offset %x, cpu %p gpu %p\n", map->offsets.recvMem & NCCL_NET_MAP_MASK_USED ? 1 : 0,
+         NCCL_NET_MAP_OFFSET_BANK(map, recvMem), map->offsets.recvMem & NCCL_NET_MAP_MASK_OFFSET,
+         NCCL_NET_MAP_GET_POINTER(map, cpu, recvMem), NCCL_NET_MAP_GET_POINTER(map, gpu, recvMem));
+  for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) {
     printf("Proto %d -> Used %d Bank %d Offset %x, cpu %p, gpu %p\n", p,
-        map->offsets.buffs[p] & NCCL_NET_MAP_MASK_USED ? 1 : 0,
-        NCCL_NET_MAP_OFFSET_BANK(map, buffs[p]), map->offsets.buffs[p] & NCCL_NET_MAP_MASK_OFFSET,
-        NCCL_NET_MAP_GET_POINTER(map, cpu, buffs[p]), NCCL_NET_MAP_GET_POINTER(map, gpu, buffs[p]));
+           map->offsets.buffs[p] & NCCL_NET_MAP_MASK_USED ? 1 : 0, NCCL_NET_MAP_OFFSET_BANK(map, buffs[p]),
+           map->offsets.buffs[p] & NCCL_NET_MAP_MASK_OFFSET, NCCL_NET_MAP_GET_POINTER(map, cpu, buffs[p]),
+           NCCL_NET_MAP_GET_POINTER(map, gpu, buffs[p]));
   }
   printf("End of dump\n");
   return ncclSuccess;
@@ -607,8 +621,9 @@ struct netRecvConnectArgs {
   ncclNetAttr_t netAttr;
 };
 
-static ncclResult_t sendConnect(struct ncclComm* comm, struct ncclConnect* connectInfo, int nranks, int rank, struct ncclConnector* send) {
-  struct connectMap* map = (connectMap*) send->transportResources;
+static ncclResult_t sendConnect(struct ncclComm* comm, struct ncclConnect* connectInfo, int nranks, int rank,
+                                struct ncclConnector* send) {
+  struct connectMap* map = (connectMap*)send->transportResources;
   void* opId;
   int recvUseGdr;
 
@@ -622,14 +637,15 @@ static ncclResult_t sendConnect(struct ncclComm* comm, struct ncclConnect* conne
     send->transportResources = map;
     opId = send;
     INFO(NCCL_PROXY, "sendConnect ncclProxyCallAsync opId=%p", opId);
-    netSendConnectArgs args = {{},{}};
+    netSendConnectArgs args = {{}, {}};
     memcpy(&args.handle, connectInfo, sizeof(ncclNetHandle_t));
 
     populateCommNetAttrs(comm, send, &args.netAttr);
 
-    NCCLCHECK(ncclProxyCallAsync(comm, &send->proxyConn, ncclProxyMsgConnect, &args, sizeof(netSendConnectArgs), sizeof(struct connectMap), opId));
+    NCCLCHECK(ncclProxyCallAsync(comm, &send->proxyConn, ncclProxyMsgConnect, &args, sizeof(netSendConnectArgs),
+                                 sizeof(struct connectMap), opId));
   } else {
-    opId =  send;
+    opId = send;
   }
 
   ncclResult_t ret;
@@ -659,11 +675,9 @@ static ncclResult_t sendConnect(struct ncclComm* comm, struct ncclConnect* conne
     if (map->mems[NCCL_NET_MAP_DEVMEM].size) {
       map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr = NULL;
       // NET transport import: No ownerVA available, mark as Persist (do not release)
-      NCCLCHECK(ncclP2pImportShareableBuffer(comm, send->proxyConn.rank,
-                                            map->mems[NCCL_NET_MAP_DEVMEM].size,
-                                            &map->mems[NCCL_NET_MAP_DEVMEM].ipcDesc,
-                                            (void**)&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr,
-                                            nullptr, ncclMemPersist));
+      NCCLCHECK(ncclP2pImportShareableBuffer(comm, send->proxyConn.rank, map->mems[NCCL_NET_MAP_DEVMEM].size,
+                                             &map->mems[NCCL_NET_MAP_DEVMEM].ipcDesc,
+                                             (void**)&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, nullptr, ncclMemPersist));
       map->mems[NCCL_NET_MAP_DEVMEM].cpuPtr = NULL;
     }
     if (map->mems[NCCL_NET_MAP_SHARED_DEVMEM].size) {
@@ -671,41 +685,37 @@ static ncclResult_t sendConnect(struct ncclComm* comm, struct ncclConnect* conne
       if (*sharedDevMemPtr == NULL) {
         map->mems[NCCL_NET_MAP_SHARED_DEVMEM].gpuPtr = NULL;
         // NET transport shared import: No ownerVA, mark as Persist (do not release)
-        NCCLCHECK(ncclP2pImportShareableBuffer(comm, send->proxyConn.rank,
-                                              map->mems[NCCL_NET_MAP_SHARED_DEVMEM].size,
-                                              &map->mems[NCCL_NET_MAP_SHARED_DEVMEM].ipcDesc,
-                                              sharedDevMemPtr,
-                                              nullptr, ncclMemPersist));
+        NCCLCHECK(ncclP2pImportShareableBuffer(comm, send->proxyConn.rank, map->mems[NCCL_NET_MAP_SHARED_DEVMEM].size,
+                                               &map->mems[NCCL_NET_MAP_SHARED_DEVMEM].ipcDesc, sharedDevMemPtr, nullptr,
+                                               ncclMemPersist));
       }
       map->mems[NCCL_NET_MAP_SHARED_DEVMEM].gpuPtr = (char*)(*sharedDevMemPtr);
       map->mems[NCCL_NET_MAP_SHARED_DEVMEM].cpuPtr = NULL;
     }
   }
-  //NCCLCHECK(netDumpMap(map));
+  // NCCLCHECK(netDumpMap(map));
 
-  struct ncclSendMem *sendMem = (struct ncclSendMem*) NCCL_NET_MAP_GET_POINTER(map, gpu, sendMem);
+  struct ncclSendMem* sendMem = (struct ncclSendMem*)NCCL_NET_MAP_GET_POINTER(map, gpu, sendMem);
   void* gdcMem = map->mems[NCCL_NET_MAP_GDCMEM].gpuPtr;
   send->conn.head = gdcMem ? (uint64_t*)gdcMem : &sendMem->head;
 
-  struct ncclRecvMem *recvMem = (struct ncclRecvMem*) NCCL_NET_MAP_GET_POINTER(map, gpu, recvMem);
+  struct ncclRecvMem* recvMem = (struct ncclRecvMem*)NCCL_NET_MAP_GET_POINTER(map, gpu, recvMem);
   send->conn.tail = &recvMem->tail;
-  send->conn.stepSize = comm->buffSizes[NCCL_PROTO_SIMPLE]/NCCL_STEPS;
+  send->conn.stepSize = comm->buffSizes[NCCL_PROTO_SIMPLE] / NCCL_STEPS;
   send->conn.connFifo = recvMem->connFifo;
-  struct ncclRecvMem *recvMemCpu = (struct ncclRecvMem*) NCCL_NET_MAP_GET_POINTER(map, cpu, recvMem);
-  for (int i=0; i<NCCL_STEPS; i++) {
+  struct ncclRecvMem* recvMemCpu = (struct ncclRecvMem*)NCCL_NET_MAP_GET_POINTER(map, cpu, recvMem);
+  for (int i = 0; i < NCCL_STEPS; i++) {
     recvMemCpu->connFifo[i].offset = -1;
     recvMemCpu->connFifo[i].mode = map->shared ? NCCL_MODE_OFFSET : NCCL_MODE_NORMAL;
   }
 
-  for (int p=0; p<NCCL_NUM_PROTOCOLS; p++)
-    send->conn.buffs[p] = NCCL_NET_MAP_GET_POINTER(map, gpu, buffs[p]);
+  for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) send->conn.buffs[p] = NCCL_NET_MAP_GET_POINTER(map, gpu, buffs[p]);
 
   if (send->proxyConn.sameProcess) {
     if (send->proxyConn.connection->netDeviceHandle) {
       send->conn.netDeviceHandle = *send->proxyConn.connection->netDeviceHandle;
 
-      for (int p=0; p<NCCL_NUM_PROTOCOLS; p++)
-        send->conn.mhandles[p] = send->proxyConn.connection->mhandles[p];
+      for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) send->conn.mhandles[p] = send->proxyConn.connection->mhandles[p];
     }
 
     if (send->proxyConn.connection->needsProxyProgress) {
@@ -724,8 +734,9 @@ static ncclResult_t sendConnect(struct ncclComm* comm, struct ncclConnect* conne
 static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct ncclProxyArgs* args);
 
 /* Connect to this peer */
-static ncclResult_t recvConnect(struct ncclComm* comm, struct ncclConnect* connectInfo, int nranks, int rank, struct ncclConnector* recv) {
-  struct connectMap* map = (connectMap*) recv->transportResources;
+static ncclResult_t recvConnect(struct ncclComm* comm, struct ncclConnect* connectInfo, int nranks, int rank,
+                                struct ncclConnector* recv) {
+  struct connectMap* map = (connectMap*)recv->transportResources;
   void* opId;
   int sendUseGdr;
 
@@ -737,14 +748,15 @@ static ncclResult_t recvConnect(struct ncclComm* comm, struct ncclConnect* conne
     recv->transportResources = map;
     // Use recv connector as unique identifier
     opId = recv;
-    INFO(NCCL_PROXY, "recvConnect ncclProxyCallAsync opId=%p &recv->proxyConn=%p connectInfo=%p",
-      opId, &recv->proxyConn, connectInfo);
+    INFO(NCCL_PROXY, "recvConnect ncclProxyCallAsync opId=%p &recv->proxyConn=%p connectInfo=%p", opId,
+         &recv->proxyConn, connectInfo);
     netRecvConnectArgs args = {0};
     args.proxyRank = *((int*)connectInfo);
 
     populateCommNetAttrs(comm, recv, &args.netAttr);
 
-    NCCLCHECK(ncclProxyCallAsync(comm, &recv->proxyConn, ncclProxyMsgConnect, &args, sizeof(netRecvConnectArgs), sizeof(struct connectMap), opId));
+    NCCLCHECK(ncclProxyCallAsync(comm, &recv->proxyConn, ncclProxyMsgConnect, &args, sizeof(netRecvConnectArgs),
+                                 sizeof(struct connectMap), opId));
   } else {
     opId = recv;
   }
@@ -759,30 +771,28 @@ static ncclResult_t recvConnect(struct ncclComm* comm, struct ncclConnect* conne
     return ret;
   }
   INFO(NCCL_PROXY, "recvConnect ncclPollProxyResponse opId=%p", opId);
-  //NCCLCHECK(netDumpMap(map));
+  // NCCLCHECK(netDumpMap(map));
 
-  struct ncclSendMem *sendMem = (struct ncclSendMem*) NCCL_NET_MAP_GET_POINTER(map, gpu, sendMem);
+  struct ncclSendMem* sendMem = (struct ncclSendMem*)NCCL_NET_MAP_GET_POINTER(map, gpu, sendMem);
   recv->conn.head = &sendMem->head;
 
-  struct ncclRecvMem *recvMem = (struct ncclRecvMem*) NCCL_NET_MAP_GET_POINTER(map, gpu, recvMem);
+  struct ncclRecvMem* recvMem = (struct ncclRecvMem*)NCCL_NET_MAP_GET_POINTER(map, gpu, recvMem);
   void* gdcMem = map->mems[NCCL_NET_MAP_GDCMEM].gpuPtr;
   recv->conn.tail = gdcMem ? (uint64_t*)gdcMem : &recvMem->tail;
-  recv->conn.stepSize = comm->buffSizes[NCCL_PROTO_SIMPLE]/NCCL_STEPS;
+  recv->conn.stepSize = comm->buffSizes[NCCL_PROTO_SIMPLE] / NCCL_STEPS;
   recv->conn.connFifo = recvMem->connFifo;
   // Only fuse P2P buffers, continue to allocate dedicated buffers for ring/tree
-  for (int i=0; i<NCCL_STEPS; i++) {
+  for (int i = 0; i < NCCL_STEPS; i++) {
     recvMem->connFifo[i].mode = map->shared ? NCCL_MODE_OFFSET : NCCL_MODE_NORMAL;
   }
 
-  for (int p=0; p<NCCL_NUM_PROTOCOLS; p++)
-    recv->conn.buffs[p] = NCCL_NET_MAP_GET_POINTER(map, gpu, buffs[p]);
+  for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) recv->conn.buffs[p] = NCCL_NET_MAP_GET_POINTER(map, gpu, buffs[p]);
 
   if (recv->proxyConn.sameProcess) {
     if (recv->proxyConn.connection->netDeviceHandle) {
       recv->conn.netDeviceHandle = *recv->proxyConn.connection->netDeviceHandle;
 
-      for (int p=0; p<NCCL_NUM_PROTOCOLS; p++)
-        recv->conn.mhandles[p] = recv->proxyConn.connection->mhandles[p];
+      for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) recv->conn.mhandles[p] = recv->proxyConn.connection->mhandles[p];
     }
 
     if (recv->proxyConn.connection->needsProxyProgress) {
@@ -829,11 +839,12 @@ static ncclResult_t recvFree(struct ncclComm* comm, struct ncclConnector* recv) 
 }
 
 #define NCCL_SHARED_STEPS 16
-static ncclResult_t sharedNetBuffersInit(struct ncclProxyState* proxyState, int cuda, int tpLocalRank, int type, int sameProcess,
-    int nChannels, char** gpuPtr, char** cpuPtr, int* size, ncclIpcDesc *ipcDesc) {
+static ncclResult_t sharedNetBuffersInit(struct ncclProxyState* proxyState, int cuda, int tpLocalRank, int type,
+                                         int sameProcess, int nChannels, char** gpuPtr, char** cpuPtr, int* size,
+                                         ncclIpcDesc* ipcDesc) {
   if (cuda == 0 && sameProcess == 0) {
-      WARN("PXN should not use host buffers for data");
-      return ncclInternalError;
+    WARN("PXN should not use host buffers for data");
+    return ncclInternalError;
   }
   if ((unsigned)tpLocalRank >= (unsigned)proxyState->tpLocalnRanks) {
     WARN("sharedNetBuffersInit: tpLocalRank %d out of range [0,%d)", tpLocalRank, proxyState->tpLocalnRanks);
@@ -852,26 +863,28 @@ static ncclResult_t sharedNetBuffersInit(struct ncclProxyState* proxyState, int 
   state->refcount++;
   if (state->size == 0) {
     state->size = (int64_t)nChannels * NCCL_SHARED_STEPS * proxyState->p2pChunkSize;
-
   }
 
   if (size) *size = state->size;
 
   if (cuda && state->cudaBuff == NULL) {
     if (sameProcess == 0 || ncclCuMemEnable()) {
-      NCCLCHECK(ncclP2pAllocateShareableBuffer(state->size, 0, &state->ipcDesc, (void**)&state->cudaBuff, /*peerRank=*/-1, proxyState->memManager));
+      NCCLCHECK(ncclP2pAllocateShareableBuffer(state->size, 0, &state->ipcDesc, (void**)&state->cudaBuff,
+                                               /*peerRank=*/-1, proxyState->memManager));
     } else {
 #if defined(HIP_UNCACHED_MEMORY)
 #if defined(HIP_CONTIGUOUS_MEMORY)
       NCCLCHECK(ncclCudaCalloc(&state->cudaBuff, state->size, proxyState->memManager, ncclMemPersist,
-        cuda ? (rcclParamNetContiguousMem() ? hipDeviceMallocContiguous : hipDeviceMallocUncached) : hipDeviceMallocDefault));
+                               cuda ?
+                                 (rcclParamNetContiguousMem() ? hipDeviceMallocContiguous : hipDeviceMallocUncached) :
+                                 hipDeviceMallocDefault));
 #else
       NCCLCHECK(ncclCudaCalloc(&state->cudaBuff, state->size, proxyState->memManager, ncclMemPersist,
-        cuda ? hipDeviceMallocUncached : hipDeviceMallocDefault));
+                               cuda ? hipDeviceMallocUncached : hipDeviceMallocDefault));
 #endif
 #else
       NCCLCHECK(ncclCudaCalloc(&state->cudaBuff, state->size, proxyState->memManager, ncclMemPersist,
-        cuda ? hipDeviceMallocFinegrained : hipDeviceMallocDefault));
+                               cuda ? hipDeviceMallocFinegrained : hipDeviceMallocDefault));
 #endif
     }
   }
@@ -884,15 +897,17 @@ static ncclResult_t sharedNetBuffersInit(struct ncclProxyState* proxyState, int 
   return ncclSuccess;
 }
 
-static ncclResult_t sharedBuffersGet(struct ncclProxyState* proxyState, int channel, int slot, int* offset, size_t* size) {
+static ncclResult_t sharedBuffersGet(struct ncclProxyState* proxyState, int channel, int slot, int* offset,
+                                     size_t* size) {
   // Use different pools for different channels and also separate send/recv.
-  int globalSlot = (channel*NCCL_SHARED_STEPS)+slot;
+  int globalSlot = (channel * NCCL_SHARED_STEPS) + slot;
   *offset = proxyState->p2pChunkSize * globalSlot;
   if (size) *size = proxyState->p2pChunkSize;
   return ncclSuccess;
 }
 
-static ncclResult_t sharedNetBuffersDestroy(struct ncclProxyState* proxyState, int tpLocalRank, int type, struct ncclProxyConnection* connection) {
+static ncclResult_t sharedNetBuffersDestroy(struct ncclProxyState* proxyState, int tpLocalRank, int type,
+                                            struct ncclProxyConnection* connection) {
   if ((unsigned)tpLocalRank >= (unsigned)proxyState->tpLocalnRanks) {
     WARN("sharedNetBuffersDestroy: tpLocalRank %d out of range [0,%d)", tpLocalRank, proxyState->tpLocalnRanks);
     return ncclInvalidArgument;
@@ -925,16 +940,18 @@ static ncclResult_t sharedNetBuffersDestroy(struct ncclProxyState* proxyState, i
   return ncclSuccess;
 }
 
-static ncclResult_t proxySharedInit(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, int nChannels) {
+static ncclResult_t proxySharedInit(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState,
+                                    int nChannels) {
   static int is_wsl2 = -1;
-  if (is_wsl2 == -1)
-    is_wsl2 = (access("/dev/dxg", F_OK) == -1) ? 0 : 1;
-  NCCLCHECK(sharedNetBuffersInit(proxyState, is_wsl2 == 0 ? 1 : 0, connection->tpLocalRank, 0, connection->sameProcess, nChannels, NULL, NULL, NULL, NULL));
+  if (is_wsl2 == -1) is_wsl2 = (access("/dev/dxg", F_OK) == -1) ? 0 : 1;
+  NCCLCHECK(sharedNetBuffersInit(proxyState, is_wsl2 == 0 ? 1 : 0, connection->tpLocalRank, 0, connection->sameProcess,
+                                 nChannels, NULL, NULL, NULL, NULL));
   return ncclSuccess;
 }
 
-static ncclResult_t sendProxySetup(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
-  struct setupReq* req = (struct setupReq*) reqBuff;
+static ncclResult_t sendProxySetup(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState,
+                                   void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
+  struct setupReq* req = (struct setupReq*)reqBuff;
   if (reqSize != sizeof(struct setupReq)) return ncclInternalError;
   if ((unsigned)req->tpLocalRank >= (unsigned)proxyState->tpLocalnRanks) {
     WARN("sendProxySetup: tpLocalRank %d out of range [0,%d)", req->tpLocalRank, proxyState->tpLocalnRanks);
@@ -975,9 +992,10 @@ static ncclResult_t sendProxySetup(struct ncclProxyConnection* connection, struc
 
   /* point-to-point size limits*/
   resources->maxP2pBytes = props.maxP2pBytes;
-  if((resources->maxP2pBytes <= 0) || (resources->maxP2pBytes > NCCL_MAX_NET_SIZE_BYTES)) {
+  if ((resources->maxP2pBytes <= 0) || (resources->maxP2pBytes > NCCL_MAX_NET_SIZE_BYTES)) {
     WARN("sendProxySetup: net plugin returned invalid value for maxP2pBytes %ld \
-      [allowed range: %ld - %ld] \n", resources->maxP2pBytes, 0L, NCCL_MAX_NET_SIZE_BYTES);
+      [allowed range: %ld - %ld] \n",
+         resources->maxP2pBytes, 0L, NCCL_MAX_NET_SIZE_BYTES);
     return ncclInternalError;
   }
 
@@ -987,8 +1005,9 @@ static ncclResult_t sendProxySetup(struct ncclProxyConnection* connection, struc
   return ncclSuccess;
 }
 
-static ncclResult_t recvProxySetup(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
-  struct setupReq* req = (struct setupReq*) reqBuff;
+static ncclResult_t recvProxySetup(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState,
+                                   void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
+  struct setupReq* req = (struct setupReq*)reqBuff;
   if (reqSize != sizeof(struct setupReq)) return ncclInternalError;
   if ((unsigned)req->tpLocalRank >= (unsigned)proxyState->tpLocalnRanks) {
     WARN("recvProxySetup: tpLocalRank %d out of range [0,%d)", req->tpLocalRank, proxyState->tpLocalnRanks);
@@ -1028,9 +1047,10 @@ static ncclResult_t recvProxySetup(struct ncclProxyConnection* connection, struc
   resources->netDeviceType = props.netDeviceType;
   /* point-to-point size limits*/
   resources->maxP2pBytes = props.maxP2pBytes;
-  if((resources->maxP2pBytes <= 0) || (resources->maxP2pBytes > NCCL_MAX_NET_SIZE_BYTES)) {
+  if ((resources->maxP2pBytes <= 0) || (resources->maxP2pBytes > NCCL_MAX_NET_SIZE_BYTES)) {
     WARN("recvProxySetup: net plugin returned invalid value for maxP2pBytes %ld \
-      [allowed range: %ld - %ld] \n", resources->maxP2pBytes, 0L, NCCL_MAX_NET_SIZE_BYTES);
+      [allowed range: %ld - %ld] \n",
+         resources->maxP2pBytes, 0L, NCCL_MAX_NET_SIZE_BYTES);
     return ncclInternalError;
   }
 
@@ -1042,12 +1062,13 @@ static ncclResult_t recvProxySetup(struct ncclProxyConnection* connection, struc
 }
 
 // This function embeds plugin-specific rules given the current versions
-static ncclResult_t ncclNetGetDeviceHandle(ncclNetDeviceType type, int version, bool isRecv, ncclNetDeviceHandle_t** handle) {
-  bool needsDeviceHandle  = false;
+static ncclResult_t ncclNetGetDeviceHandle(ncclNetDeviceType type, int version, bool isRecv,
+                                           ncclNetDeviceHandle_t** handle) {
+  bool needsDeviceHandle = false;
 
   if (type == NCCL_NET_DEVICE_UNPACK) {
     if (version == NCCL_NET_DEVICE_UNPACK_VERSION && isRecv) {
-      needsDeviceHandle  = true;
+      needsDeviceHandle = true;
     }
   }
 
@@ -1063,18 +1084,20 @@ static ncclResult_t ncclNetGetDeviceHandle(ncclNetDeviceType type, int version, 
   return ncclSuccess;
 }
 
-static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
+static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState,
+                                     void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
   ncclNet_ctxt_t ncclNetCtxt = {};
   struct sendNetResources* resources = (struct sendNetResources*)(connection->transportResources);
   bool rcclAinicRoce = rcclUseAinic();
   if (reqSize != sizeof(netSendConnectArgs)) return ncclInternalError;
   ncclResult_t ret = ncclSuccess;
-  netSendConnectArgs* req = (netSendConnectArgs*) reqBuff;
+  netSendConnectArgs* req = (netSendConnectArgs*)reqBuff;
 
   setNetAttrs(proxyState, &req->netAttr);
 
-  NCCLCHECK(ncclNetGetDeviceHandle(resources->netDeviceType, resources->netDeviceVersion, false /*isRecv*/, &resources->netDeviceHandle));
-  
+  NCCLCHECK(ncclNetGetDeviceHandle(resources->netDeviceType, resources->netDeviceVersion, false /*isRecv*/,
+                                   &resources->netDeviceHandle));
+
   // Only call rcclNetP2pPolicy for ncclNetIb
   if (proxyState->ncclNet == &ncclNetIb) {
     NCCLCHECK(rcclNetP2pPolicy(req->handle, resources->isP2p));
@@ -1085,7 +1108,7 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
     NCCLCHECK(rcclCastNetP2pPolicy(req->handle, resources->isP2p));
   }
 #endif
-  
+
   if (resources->shared) {
     // Shared buffers
     struct ncclProxyProgressState* progressState = &proxyState->progressState;
@@ -1107,15 +1130,16 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
       // let only one localrank connect to a tpRemoteRank to avoid duplicate connections
       if (comms->activeConnect[resources->channelId] == 0)
         comms->activeConnect[resources->channelId] = (resources->tpLocalRank + 1);
-      if (comms->sendComm[resources->channelId] == NULL
-          && comms->activeConnect[resources->channelId] == (resources->tpLocalRank + 1)) {
+      if (comms->sendComm[resources->channelId] == NULL &&
+          comms->activeConnect[resources->channelId] == (resources->tpLocalRank + 1)) {
         if (rcclAinicRoce) {
           ncclNetCtxt.chId = resources->channelId;
-          ret = proxyState->ncclNet->connect(proxyState->netContext, resources->netDev, req->handle,
-            comms->sendComm + resources->channelId, (ncclNetDeviceHandle_t **)&ncclNetCtxt);
+          ret =
+            proxyState->ncclNet->connect(proxyState->netContext, resources->netDev, req->handle,
+                                         comms->sendComm + resources->channelId, (ncclNetDeviceHandle_t**)&ncclNetCtxt);
         } else {
           ret = proxyState->ncclNet->connect(proxyState->netContext, resources->netDev, req->handle,
-            comms->sendComm + resources->channelId, &resources->netDeviceHandle);
+                                             comms->sendComm + resources->channelId, &resources->netDeviceHandle);
         }
       }
       resources->netSendComm = comms->sendComm[resources->channelId];
@@ -1123,18 +1147,22 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
     } else {
       if (rcclAinicRoce) {
         ncclNetCtxt.chId = resources->channelId;
-        ret = proxyState->ncclNet->connect(proxyState->netContext, resources->netDev, req->handle, &resources->netSendComm, (ncclNetDeviceHandle_t **)&ncclNetCtxt);
+        ret = proxyState->ncclNet->connect(proxyState->netContext, resources->netDev, req->handle,
+                                           &resources->netSendComm, (ncclNetDeviceHandle_t**)&ncclNetCtxt);
       } else {
-        ret = proxyState->ncclNet->connect(proxyState->netContext, resources->netDev, req->handle, &resources->netSendComm, &resources->netDeviceHandle);
+        ret = proxyState->ncclNet->connect(proxyState->netContext, resources->netDev, req->handle,
+                                           &resources->netSendComm, &resources->netDeviceHandle);
       }
     }
   } else {
     // Connect to remote peer
     if (rcclAinicRoce) {
       ncclNetCtxt.chId = resources->channelId;
-      ret = proxyState->ncclNet->connect(proxyState->netContext, resources->netDev, req->handle, &resources->netSendComm, (ncclNetDeviceHandle_t **)&ncclNetCtxt);
+      ret = proxyState->ncclNet->connect(proxyState->netContext, resources->netDev, req->handle,
+                                         &resources->netSendComm, (ncclNetDeviceHandle_t**)&ncclNetCtxt);
     } else {
-      ret = proxyState->ncclNet->connect(proxyState->netContext, resources->netDev, req->handle, &resources->netSendComm, &resources->netDeviceHandle);
+      ret = proxyState->ncclNet->connect(proxyState->netContext, resources->netDev, req->handle,
+                                         &resources->netSendComm, &resources->netDeviceHandle);
     }
     connection->proxyAppendPtr = &connection->proxyAppend;
   }
@@ -1164,21 +1192,23 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
   CUDACHECK(cudaGetDevice(&map->cudaDev));
 
   if (resources->shared == 0) { // Only allocate dedicated buffers for ring/tree, not for p2p
-    for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
-      NCCL_NET_MAP_ADD_POINTER(map, 0, p!= NCCL_PROTO_LL && resources->useGdr ? 1 : 0, proxyState->buffSizes[p], buffs[p]);
+    for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) {
+      NCCL_NET_MAP_ADD_POINTER(map, 0, p != NCCL_PROTO_LL && resources->useGdr ? 1 : 0, proxyState->buffSizes[p],
+                               buffs[p]);
       resources->buffSizes[p] = proxyState->buffSizes[p];
     }
   } else {
     // Get shared buffers
     int bank = resources->useGdr ? NCCL_NET_MAP_SHARED_DEVMEM : NCCL_NET_MAP_SHARED_HOSTMEM;
-    struct connectMapMem* mapMem = map->mems+bank;
-    NCCLCHECK(sharedNetBuffersInit(
-          proxyState, resources->useGdr, resources->tpLocalRank, 0, map->sameProcess, proxyState->p2pnChannels,
-          &mapMem->gpuPtr, &mapMem->cpuPtr, &mapMem->size, &mapMem->ipcDesc));
+    struct connectMapMem* mapMem = map->mems + bank;
+    NCCLCHECK(sharedNetBuffersInit(proxyState, resources->useGdr, resources->tpLocalRank, 0, map->sameProcess,
+                                   proxyState->p2pnChannels, &mapMem->gpuPtr, &mapMem->cpuPtr, &mapMem->size,
+                                   &mapMem->ipcDesc));
     resources->buffSizes[NCCL_PROTO_SIMPLE] = mapMem->size;
 
     if (proxyState->allocP2pNetLLBuffers) {
-      NCCL_NET_MAP_ADD_POINTER(map, 0, 0 /*p == NCCL_PROTO_LL*/, proxyState->buffSizes[NCCL_PROTO_LL], buffs[NCCL_PROTO_LL]);
+      NCCL_NET_MAP_ADD_POINTER(map, 0, 0 /*p == NCCL_PROTO_LL*/, proxyState->buffSizes[NCCL_PROTO_LL],
+                               buffs[NCCL_PROTO_LL]);
       resources->buffSizes[NCCL_PROTO_LL] = proxyState->buffSizes[NCCL_PROTO_LL];
     }
 
@@ -1188,38 +1218,43 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
   NCCL_NET_MAP_ADD_POINTER(map, 0, 0, sizeof(struct ncclSendMem), sendMem);
   NCCL_NET_MAP_ADD_POINTER(map, 0, 0, sizeof(struct ncclRecvMem), recvMem);
 
-  map->mems[NCCL_NET_MAP_DEVMEM].dmaBufFd = -1;  // Initialize to invalid fd
+  map->mems[NCCL_NET_MAP_DEVMEM].dmaBufFd = -1; // Initialize to invalid fd
   if (map->mems[NCCL_NET_MAP_DEVMEM].size) {
     if (resources->shared == 0) {
       if (!map->sameProcess || ncclCuMemEnable()) {
         ALIGN_SIZE(map->mems[NCCL_NET_MAP_DEVMEM].size, CUDA_IPC_MIN);
-        NCCLCHECK(ncclP2pAllocateShareableBuffer(map->mems[NCCL_NET_MAP_DEVMEM].size, 0, &map->mems[NCCL_NET_MAP_DEVMEM].ipcDesc,
-                                                (void**)&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, /*peerRank=*/-1, proxyState->memManager));
+        NCCLCHECK(ncclP2pAllocateShareableBuffer(
+          map->mems[NCCL_NET_MAP_DEVMEM].size, 0, &map->mems[NCCL_NET_MAP_DEVMEM].ipcDesc,
+          (void**)&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, /*peerRank=*/-1, proxyState->memManager));
 #if CUDA_VERSION >= 11070 || HIP_VERSION >= 71260540
         // Get DMA-BUF fd for cuMem VMM allocations via cuMemGetHandleForAddressRange.
         // Required even when DMA-BUF is globally disabled: ibv_reg_mr on cuMem RDMA
         // memory fails ("Bad address") and corrupts VMM state, so ibv_reg_dmabuf_mr
         // must be used instead.
         if (ncclCuMemEnable()) {
-          CUCHECK(cuMemGetHandleForAddressRange((void *)&map->mems[NCCL_NET_MAP_DEVMEM].dmaBufFd,
-                                                (CUdeviceptr)map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr,
-                                                map->mems[NCCL_NET_MAP_DEVMEM].size,
-                                                CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
-                                                getHandleForAddressRangeFlags(resources->useGdr)));
+          CUCHECK(cuMemGetHandleForAddressRange(
+            (void*)&map->mems[NCCL_NET_MAP_DEVMEM].dmaBufFd, (CUdeviceptr)map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr,
+            map->mems[NCCL_NET_MAP_DEVMEM].size, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
+            getHandleForAddressRangeFlags(resources->useGdr)));
         }
 #endif
       } else {
 #if defined(HIP_UNCACHED_MEMORY)
 #if defined(HIP_CONTIGUOUS_MEMORY)
-        NCCLCHECK(ncclCudaCalloc(&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, map->mems[NCCL_NET_MAP_DEVMEM].size, proxyState->memManager, ncclMemPersist,
-          resources->useGdr ? (rcclParamNetContiguousMem() ? hipDeviceMallocContiguous : hipDeviceMallocUncached) : hipDeviceMallocDefault));
+        NCCLCHECK(ncclCudaCalloc(&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, map->mems[NCCL_NET_MAP_DEVMEM].size,
+                                 proxyState->memManager, ncclMemPersist,
+                                 resources->useGdr ?
+                                   (rcclParamNetContiguousMem() ? hipDeviceMallocContiguous : hipDeviceMallocUncached) :
+                                   hipDeviceMallocDefault));
 #else
-        NCCLCHECK(ncclCudaCalloc(&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, map->mems[NCCL_NET_MAP_DEVMEM].size, proxyState->memManager, ncclMemPersist,
-          resources->useGdr ? hipDeviceMallocUncached : hipDeviceMallocDefault));
+        NCCLCHECK(ncclCudaCalloc(&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, map->mems[NCCL_NET_MAP_DEVMEM].size,
+                                 proxyState->memManager, ncclMemPersist,
+                                 resources->useGdr ? hipDeviceMallocUncached : hipDeviceMallocDefault));
 #endif
 #else
-        NCCLCHECK(ncclCudaCalloc(&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, map->mems[NCCL_NET_MAP_DEVMEM].size, proxyState->memManager, ncclMemPersist,
-          resources->useGdr ? hipDeviceMallocFinegrained : hipDeviceMallocDefault));
+        NCCLCHECK(ncclCudaCalloc(&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, map->mems[NCCL_NET_MAP_DEVMEM].size,
+                                 proxyState->memManager, ncclMemPersist,
+                                 resources->useGdr ? hipDeviceMallocFinegrained : hipDeviceMallocDefault));
 #endif
       }
       map->mems[NCCL_NET_MAP_DEVMEM].cpuPtr = map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr;
@@ -1229,7 +1264,7 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
     NCCLCHECK(ncclCudaHostCalloc(&map->mems[NCCL_NET_MAP_HOSTMEM].cpuPtr, map->mems[NCCL_NET_MAP_HOSTMEM].size));
     map->mems[NCCL_NET_MAP_HOSTMEM].gpuPtr = map->mems[NCCL_NET_MAP_HOSTMEM].cpuPtr;
   } else {
-    NCCLCHECK(netCreateShm(proxyState, map->mems+NCCL_NET_MAP_HOSTMEM));
+    NCCLCHECK(netCreateShm(proxyState, map->mems + NCCL_NET_MAP_HOSTMEM));
     void* sendMem = (void*)NCCL_NET_MAP_GET_POINTER(map, cpu, sendMem);
     void* recvMem = (void*)NCCL_NET_MAP_GET_POINTER(map, cpu, recvMem);
     memset(sendMem, 0, sizeof(struct ncclSendMem));
@@ -1240,21 +1275,20 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
     NCCLCHECK(ncclGdrCudaCalloc(&cpuPtr, &gpuPtr, 1, &resources->gdrDesc, proxyState->memManager));
 
     resources->gdcSync = cpuPtr;
-    struct connectMapMem* gdcMem = map->mems+NCCL_NET_MAP_GDCMEM;
+    struct connectMapMem* gdcMem = map->mems + NCCL_NET_MAP_GDCMEM;
     gdcMem->cpuPtr = (char*)cpuPtr;
     gdcMem->gpuPtr = (char*)gpuPtr;
     gdcMem->size = sizeof(uint64_t); // sendMem->head
   }
 
-  resources->sendMem = (struct ncclSendMem*) NCCL_NET_MAP_GET_POINTER(map, cpu, sendMem);
-  resources->recvMem = (struct ncclRecvMem*) NCCL_NET_MAP_GET_POINTER(map, cpu, recvMem);
+  resources->sendMem = (struct ncclSendMem*)NCCL_NET_MAP_GET_POINTER(map, cpu, sendMem);
+  resources->recvMem = (struct ncclRecvMem*)NCCL_NET_MAP_GET_POINTER(map, cpu, recvMem);
 
   // Don't give credits yet in shared mode.
-  (resources->gdcSync ? *resources->gdcSync : resources->sendMem->head) =
-    (map->shared ? -NCCL_STEPS : 0);
-  for (int i=0; i<NCCL_STEPS; i++) resources->recvMem->connFifo[i].size = -1;
+  (resources->gdcSync ? *resources->gdcSync : resources->sendMem->head) = (map->shared ? -NCCL_STEPS : 0);
+  for (int i = 0; i < NCCL_STEPS; i++) resources->recvMem->connFifo[i].size = -1;
 
-  for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
+  for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) {
     resources->buffers[p] = NCCL_NET_MAP_GET_POINTER(map, cpu, buffs[p]);
     if (resources->buffers[p]) {
 #if CUDA_VERSION >= 11070 || HIP_VERSION >= 71260540
@@ -1264,47 +1298,61 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
         int bank = NCCL_NET_MAP_OFFSET_BANK(map, buffs[p]);
         if (bank == NCCL_NET_MAP_DEVMEM && map->mems[NCCL_NET_MAP_DEVMEM].dmaBufFd >= 0) {
           uint64_t offset = (char*)resources->buffers[p] - map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr;
-          NCCLCHECK(proxyState->ncclNet->regMrDmaBuf(resources->netSendComm, resources->buffers[p], resources->buffSizes[p], type, offset, map->mems[NCCL_NET_MAP_DEVMEM].dmaBufFd, &resources->mhandles[p]));
+          NCCLCHECK(proxyState->ncclNet->regMrDmaBuf(resources->netSendComm, resources->buffers[p],
+                                                     resources->buffSizes[p], type, offset,
+                                                     map->mems[NCCL_NET_MAP_DEVMEM].dmaBufFd, &resources->mhandles[p]));
         } else {
           int dmabuf_fd;
-          CUCHECK(cuMemGetHandleForAddressRange((void *)&dmabuf_fd, (CUdeviceptr)resources->buffers[p], resources->buffSizes[p], CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, getHandleForAddressRangeFlags(resources->useGdr)));
-          NCCLCHECK(proxyState->ncclNet->regMrDmaBuf(resources->netSendComm, resources->buffers[p], resources->buffSizes[p], type, 0ULL, dmabuf_fd, &resources->mhandles[p]));
+          CUCHECK(cuMemGetHandleForAddressRange((void*)&dmabuf_fd, (CUdeviceptr)resources->buffers[p],
+                                                resources->buffSizes[p], CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
+                                                getHandleForAddressRangeFlags(resources->useGdr)));
+          NCCLCHECK(proxyState->ncclNet->regMrDmaBuf(resources->netSendComm, resources->buffers[p],
+                                                     resources->buffSizes[p], type, 0ULL, dmabuf_fd,
+                                                     &resources->mhandles[p]));
           (void)close(dmabuf_fd);
         }
       } else // FALL-THROUGH to nv_peermem GDR path
 #else
       /* DMA-BUF support */
       int type = NCCL_NET_MAP_DEV_MEM(map, buffs[p]) ? NCCL_PTR_CUDA : NCCL_PTR_HOST;
-      if (type == NCCL_PTR_CUDA && resources->useDmaBuf && proxyState->dmaBufSupport && pfn_hsa_amd_portable_export_dmabuf) {
+      if (type == NCCL_PTR_CUDA && resources->useDmaBuf && proxyState->dmaBufSupport &&
+          pfn_hsa_amd_portable_export_dmabuf) {
         int dmabuf_fd;
         uint64_t offset;
-        HSACHECK(hsa_amd_portable_export_dmabuf((const void*)resources->buffers[p], resources->buffSizes[p], &dmabuf_fd, &offset));
-        NCCLCHECK(proxyState->ncclNet->regMrDmaBuf(resources->netSendComm, resources->buffers[p], resources->buffSizes[p], type, offset, dmabuf_fd, &resources->mhandles[p]));
+        HSACHECK(hsa_amd_portable_export_dmabuf((const void*)resources->buffers[p], resources->buffSizes[p], &dmabuf_fd,
+                                                &offset));
+        NCCLCHECK(proxyState->ncclNet->regMrDmaBuf(resources->netSendComm, resources->buffers[p],
+                                                   resources->buffSizes[p], type, offset, dmabuf_fd,
+                                                   &resources->mhandles[p]));
         (void)close(dmabuf_fd);
-        TRACE(NCCL_INIT|NCCL_NET, "hsa_amd_portable_export_dmabuf buffer %p size %d handle %x offset %ld",
-          (const void*)resources->buffers[p], resources->buffSizes[p], dmabuf_fd, offset);
+        TRACE(NCCL_INIT | NCCL_NET, "hsa_amd_portable_export_dmabuf buffer %p size %d handle %x offset %ld",
+              (const void*)resources->buffers[p], resources->buffSizes[p], dmabuf_fd, offset);
       } else // FALL-THROUGH to nv_peermem GDR path
 #endif
       {
-        NCCLCHECK(proxyState->ncclNet->regMr(resources->netSendComm, resources->buffers[p], resources->buffSizes[p], NCCL_NET_MAP_DEV_MEM(map, buffs[p]) ? NCCL_PTR_CUDA : NCCL_PTR_HOST, &resources->mhandles[p]));
+        NCCLCHECK(proxyState->ncclNet->regMr(resources->netSendComm, resources->buffers[p], resources->buffSizes[p],
+                                             NCCL_NET_MAP_DEV_MEM(map, buffs[p]) ? NCCL_PTR_CUDA : NCCL_PTR_HOST,
+                                             &resources->mhandles[p]));
       }
 
       // Copy the mhandle dptr, if implemented
       if (resources->netDeviceHandle && proxyState->ncclNet->getDeviceMr)
-        NCCLCHECK(proxyState->ncclNet->getDeviceMr(resources->netSendComm, resources->mhandles[p], &connection->mhandles[p]));
+        NCCLCHECK(proxyState->ncclNet->getDeviceMr(resources->netSendComm, resources->mhandles[p],
+                                                   &connection->mhandles[p]));
     }
   }
 
-  //NCCLCHECK(netDumpMap(map));
+  // NCCLCHECK(netDumpMap(map));
   if (respSize != sizeof(struct connectMap)) return ncclInternalError;
   memcpy(respBuff, map, sizeof(struct connectMap));
   return ncclSuccess;
 }
 
-static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
+static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState,
+                                     void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
   if (reqSize != sizeof(netRecvConnectArgs)) return ncclInternalError;
   struct recvNetResources* resources = (struct recvNetResources*)(connection->transportResources);
-  netRecvConnectArgs* req = (netRecvConnectArgs*) reqBuff;
+  netRecvConnectArgs* req = (netRecvConnectArgs*)reqBuff;
   resources->tpRemoteProxyRank = req->proxyRank;
   ncclResult_t ret = ncclSuccess;
   ncclNet_ctxt_t ncclNetCtxt = {};
@@ -1312,7 +1360,8 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
 
   setNetAttrs(proxyState, &req->netAttr);
 
-  NCCLCHECK(ncclNetGetDeviceHandle(resources->netDeviceType, resources->netDeviceVersion, true /*isRecv*/, &resources->netDeviceHandle));
+  NCCLCHECK(ncclNetGetDeviceHandle(resources->netDeviceType, resources->netDeviceVersion, true /*isRecv*/,
+                                   &resources->netDeviceHandle));
   // Finish connection establishment from remote peer
   if (resources->shared) {
     // Shared buffers
@@ -1335,16 +1384,16 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
       // reuse handle to for netdev/remote rank to avoid duplicate connections
       if (comms->activeAccept[resources->channelId] == 0)
         comms->activeAccept[resources->channelId] = (resources->tpLocalRank + 1);
-      //try connecting while comm is null
-      if (comms->recvComm[resources->channelId] == NULL
-         && comms->activeAccept[resources->channelId] == (resources->tpLocalRank + 1)) {
+      // try connecting while comm is null
+      if (comms->recvComm[resources->channelId] == NULL &&
+          comms->activeAccept[resources->channelId] == (resources->tpLocalRank + 1)) {
         if (rcclAinicRoce) {
           ncclNetCtxt.chId = resources->channelId;
-          ret = proxyState->ncclNet->accept(resources->netListenComm,
-            comms->recvComm+resources->channelId, (ncclNetDeviceHandle_t **)&ncclNetCtxt);
+          ret = proxyState->ncclNet->accept(resources->netListenComm, comms->recvComm + resources->channelId,
+                                            (ncclNetDeviceHandle_t**)&ncclNetCtxt);
         } else {
-          ret = proxyState->ncclNet->accept(resources->netListenComm,
-              comms->recvComm+resources->channelId, &resources->netDeviceHandle);
+          ret = proxyState->ncclNet->accept(resources->netListenComm, comms->recvComm + resources->channelId,
+                                            &resources->netDeviceHandle);
         }
       }
       resources->netRecvComm = comms->recvComm[resources->channelId];
@@ -1352,16 +1401,19 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
     } else {
       if (rcclAinicRoce) {
         ncclNetCtxt.chId = resources->channelId;
-        ret = proxyState->ncclNet->accept(resources->netListenComm, &resources->netRecvComm, (ncclNetDeviceHandle_t **)&ncclNetCtxt);
+        ret = proxyState->ncclNet->accept(resources->netListenComm, &resources->netRecvComm,
+                                          (ncclNetDeviceHandle_t**)&ncclNetCtxt);
       } else {
-        ret = proxyState->ncclNet->accept(resources->netListenComm, &resources->netRecvComm, &resources->netDeviceHandle);
+        ret =
+          proxyState->ncclNet->accept(resources->netListenComm, &resources->netRecvComm, &resources->netDeviceHandle);
       }
     }
   } else {
     // Connect to remote peer
     if (rcclAinicRoce) {
       ncclNetCtxt.chId = resources->channelId;
-      ret = proxyState->ncclNet->accept(resources->netListenComm, &resources->netRecvComm, (ncclNetDeviceHandle_t **)&ncclNetCtxt);
+      ret = proxyState->ncclNet->accept(resources->netListenComm, &resources->netRecvComm,
+                                        (ncclNetDeviceHandle_t**)&ncclNetCtxt);
     } else {
       ret = proxyState->ncclNet->accept(resources->netListenComm, &resources->netRecvComm, &resources->netDeviceHandle);
     }
@@ -1392,17 +1444,16 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
   map->shared = resources->shared;
 
   if (resources->shared == 0) { // Only allocate dedicated buffers for ring/tree, not for p2p
-    for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
+    for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) {
       NCCL_NET_MAP_ADD_POINTER(map, 0, resources->useGdr ? 1 : 0, proxyState->buffSizes[p], buffs[p]);
       resources->buffSizes[p] = proxyState->buffSizes[p];
     }
   } else {
     // Get shared buffers
     int bank = resources->useGdr ? NCCL_NET_MAP_SHARED_DEVMEM : NCCL_NET_MAP_SHARED_HOSTMEM;
-    struct connectMapMem* mapMem = map->mems+bank;
-    NCCLCHECK(sharedNetBuffersInit(
-          proxyState, resources->useGdr, resources->tpLocalRank, 1, 1, proxyState->p2pnChannels,
-          &mapMem->gpuPtr, &mapMem->cpuPtr, &mapMem->size, NULL));
+    struct connectMapMem* mapMem = map->mems + bank;
+    NCCLCHECK(sharedNetBuffersInit(proxyState, resources->useGdr, resources->tpLocalRank, 1, 1,
+                                   proxyState->p2pnChannels, &mapMem->gpuPtr, &mapMem->cpuPtr, &mapMem->size, NULL));
     resources->buffSizes[NCCL_PROTO_SIMPLE] = mapMem->size;
     NCCL_NET_MAP_ADD_POINTER(map, 1, resources->useGdr ? 1 : 0, mapMem->size, buffs[NCCL_PROTO_SIMPLE]);
   }
@@ -1415,35 +1466,40 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
     resources->buffSizes[NCCL_PROTO_LL] = proxyState->buffSizes[NCCL_PROTO_LL];
   }
 
-  map->mems[NCCL_NET_MAP_DEVMEM].dmaBufFd = -1;  // Initialize to invalid fd
+  map->mems[NCCL_NET_MAP_DEVMEM].dmaBufFd = -1; // Initialize to invalid fd
   if (map->mems[NCCL_NET_MAP_DEVMEM].size) {
     if (resources->shared == 0) {
       if (ncclCuMemEnable()) {
-        NCCLCHECK(ncclP2pAllocateShareableBuffer(map->mems[NCCL_NET_MAP_DEVMEM].size, 0, &map->mems[NCCL_NET_MAP_DEVMEM].ipcDesc,
-                                                (void**)&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, /*peerRank=*/-1, proxyState->memManager));
+        NCCLCHECK(ncclP2pAllocateShareableBuffer(
+          map->mems[NCCL_NET_MAP_DEVMEM].size, 0, &map->mems[NCCL_NET_MAP_DEVMEM].ipcDesc,
+          (void**)&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, /*peerRank=*/-1, proxyState->memManager));
 #if CUDA_VERSION >= 11070 || HIP_VERSION >= 71260540
         // Get DMA-BUF fd for cuMem VMM allocations. Required even when DMA-BUF is
         // globally disabled to avoid ibv_reg_mr on VMM memory.
         {
-          CUCHECK(cuMemGetHandleForAddressRange((void *)&map->mems[NCCL_NET_MAP_DEVMEM].dmaBufFd,
-                                                (CUdeviceptr)map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr,
-                                                map->mems[NCCL_NET_MAP_DEVMEM].size,
-                                                CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
-                                                getHandleForAddressRangeFlags(resources->useGdr)));
+          CUCHECK(cuMemGetHandleForAddressRange(
+            (void*)&map->mems[NCCL_NET_MAP_DEVMEM].dmaBufFd, (CUdeviceptr)map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr,
+            map->mems[NCCL_NET_MAP_DEVMEM].size, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
+            getHandleForAddressRangeFlags(resources->useGdr)));
         }
 #endif
       } else {
 #if defined(HIP_UNCACHED_MEMORY)
 #if defined(HIP_CONTIGUOUS_MEMORY)
-        NCCLCHECK(ncclCudaCalloc(&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, map->mems[NCCL_NET_MAP_DEVMEM].size, proxyState->memManager, ncclMemPersist,
-          resources->useGdr ? (rcclParamNetContiguousMem() ? hipDeviceMallocContiguous : hipDeviceMallocUncached) : hipDeviceMallocDefault));
+        NCCLCHECK(ncclCudaCalloc(&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, map->mems[NCCL_NET_MAP_DEVMEM].size,
+                                 proxyState->memManager, ncclMemPersist,
+                                 resources->useGdr ?
+                                   (rcclParamNetContiguousMem() ? hipDeviceMallocContiguous : hipDeviceMallocUncached) :
+                                   hipDeviceMallocDefault));
 #else
-        NCCLCHECK(ncclCudaCalloc(&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, map->mems[NCCL_NET_MAP_DEVMEM].size, proxyState->memManager, ncclMemPersist,
-          resources->useGdr ? hipDeviceMallocUncached : hipDeviceMallocDefault));
+        NCCLCHECK(ncclCudaCalloc(&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, map->mems[NCCL_NET_MAP_DEVMEM].size,
+                                 proxyState->memManager, ncclMemPersist,
+                                 resources->useGdr ? hipDeviceMallocUncached : hipDeviceMallocDefault));
 #endif
 #else
-        NCCLCHECK(ncclCudaCalloc(&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, map->mems[NCCL_NET_MAP_DEVMEM].size, proxyState->memManager, ncclMemPersist,
-          resources->useGdr ? hipDeviceMallocFinegrained : hipDeviceMallocDefault));
+        NCCLCHECK(ncclCudaCalloc(&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, map->mems[NCCL_NET_MAP_DEVMEM].size,
+                                 proxyState->memManager, ncclMemPersist,
+                                 resources->useGdr ? hipDeviceMallocFinegrained : hipDeviceMallocDefault));
 #endif
       }
       map->mems[NCCL_NET_MAP_DEVMEM].cpuPtr = map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr;
@@ -1460,7 +1516,7 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
       // No flush needed if control flow is mapped on the PCIe instead of C2C
       if (gdcFlag == GDR_PIN_FLAG_FORCE_PCIE) resources->needFlush = ncclTopoFlushNone;
       resources->gdcSync = cpuPtr;
-      struct connectMapMem* gdcMem = map->mems+NCCL_NET_MAP_GDCMEM;
+      struct connectMapMem* gdcMem = map->mems + NCCL_NET_MAP_GDCMEM;
       gdcMem->cpuPtr = (char*)cpuPtr;
       gdcMem->gpuPtr = (char*)gpuPtr;
       gdcMem->size = sizeof(uint64_t);
@@ -1468,10 +1524,10 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
     if (ncclParamGdrCopyFlushEnable()) resources->gdcFlush = cpuPtr + 1;
   }
 
-  resources->sendMem = (struct ncclSendMem*) NCCL_NET_MAP_GET_POINTER(map, cpu, sendMem);
-  resources->recvMem = (struct ncclRecvMem*) NCCL_NET_MAP_GET_POINTER(map, cpu, recvMem);
+  resources->sendMem = (struct ncclSendMem*)NCCL_NET_MAP_GET_POINTER(map, cpu, sendMem);
+  resources->recvMem = (struct ncclRecvMem*)NCCL_NET_MAP_GET_POINTER(map, cpu, recvMem);
   for (int i = 0; i < NCCL_STEPS; i++) resources->recvMem->connFifo[i].size = -1;
-  for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
+  for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) {
     resources->buffers[p] = NCCL_NET_MAP_GET_POINTER(map, cpu, buffs[p]);
     if (resources->buffers[p]) {
 #if CUDA_VERSION >= 11070 || HIP_VERSION >= 71260540
@@ -1481,38 +1537,51 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
         int bank = NCCL_NET_MAP_OFFSET_BANK(map, buffs[p]);
         if (bank == NCCL_NET_MAP_DEVMEM && map->mems[NCCL_NET_MAP_DEVMEM].dmaBufFd >= 0) {
           uint64_t offset = (char*)resources->buffers[p] - map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr;
-          NCCLCHECK(proxyState->ncclNet->regMrDmaBuf(resources->netRecvComm, resources->buffers[p], resources->buffSizes[p], type, offset, map->mems[NCCL_NET_MAP_DEVMEM].dmaBufFd, &resources->mhandles[p]));
+          NCCLCHECK(proxyState->ncclNet->regMrDmaBuf(resources->netRecvComm, resources->buffers[p],
+                                                     resources->buffSizes[p], type, offset,
+                                                     map->mems[NCCL_NET_MAP_DEVMEM].dmaBufFd, &resources->mhandles[p]));
         } else {
           int dmabuf_fd;
-          CUCHECK(cuMemGetHandleForAddressRange((void *)&dmabuf_fd, (CUdeviceptr)resources->buffers[p], resources->buffSizes[p], CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, getHandleForAddressRangeFlags(resources->useGdr)));
-          NCCLCHECK(proxyState->ncclNet->regMrDmaBuf(resources->netRecvComm, resources->buffers[p], resources->buffSizes[p], type, 0ULL, dmabuf_fd, &resources->mhandles[p]));
+          CUCHECK(cuMemGetHandleForAddressRange((void*)&dmabuf_fd, (CUdeviceptr)resources->buffers[p],
+                                                resources->buffSizes[p], CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
+                                                getHandleForAddressRangeFlags(resources->useGdr)));
+          NCCLCHECK(proxyState->ncclNet->regMrDmaBuf(resources->netRecvComm, resources->buffers[p],
+                                                     resources->buffSizes[p], type, 0ULL, dmabuf_fd,
+                                                     &resources->mhandles[p]));
           (void)close(dmabuf_fd);
         }
       } else // FALL-THROUGH to nv_peermem GDR path
 #else
       /* DMA-BUF support */
       int type = NCCL_NET_MAP_DEV_MEM(map, buffs[p]) ? NCCL_PTR_CUDA : NCCL_PTR_HOST;
-      if (type == NCCL_PTR_CUDA && resources->useDmaBuf && proxyState->dmaBufSupport && pfn_hsa_amd_portable_export_dmabuf) {
+      if (type == NCCL_PTR_CUDA && resources->useDmaBuf && proxyState->dmaBufSupport &&
+          pfn_hsa_amd_portable_export_dmabuf) {
         int dmabuf_fd;
         uint64_t offset;
-        HSACHECK(hsa_amd_portable_export_dmabuf((const void*)resources->buffers[p], resources->buffSizes[p], &dmabuf_fd, &offset));
-        NCCLCHECK(proxyState->ncclNet->regMrDmaBuf(resources->netRecvComm, resources->buffers[p], resources->buffSizes[p], type, offset, dmabuf_fd, &resources->mhandles[p]));
+        HSACHECK(hsa_amd_portable_export_dmabuf((const void*)resources->buffers[p], resources->buffSizes[p], &dmabuf_fd,
+                                                &offset));
+        NCCLCHECK(proxyState->ncclNet->regMrDmaBuf(resources->netRecvComm, resources->buffers[p],
+                                                   resources->buffSizes[p], type, offset, dmabuf_fd,
+                                                   &resources->mhandles[p]));
         (void)close(dmabuf_fd);
-        TRACE(NCCL_INIT|NCCL_NET, "hsa_amd_portable_export_dmabuf buffer %p size %d handle %x offset %ld",
-          (const void*)resources->buffers[p], resources->buffSizes[p], dmabuf_fd, offset);
+        TRACE(NCCL_INIT | NCCL_NET, "hsa_amd_portable_export_dmabuf buffer %p size %d handle %x offset %ld",
+              (const void*)resources->buffers[p], resources->buffSizes[p], dmabuf_fd, offset);
       } else // FALL-THROUGH to nv_peermem GDR path
 #endif
       {
-        NCCLCHECK(proxyState->ncclNet->regMr(resources->netRecvComm, resources->buffers[p], resources->buffSizes[p], NCCL_NET_MAP_DEV_MEM(map, buffs[p]) ? NCCL_PTR_CUDA : NCCL_PTR_HOST, &resources->mhandles[p]));
+        NCCLCHECK(proxyState->ncclNet->regMr(resources->netRecvComm, resources->buffers[p], resources->buffSizes[p],
+                                             NCCL_NET_MAP_DEV_MEM(map, buffs[p]) ? NCCL_PTR_CUDA : NCCL_PTR_HOST,
+                                             &resources->mhandles[p]));
       }
 
       // Copy the mhandle dptr
       if (resources->netDeviceType != NCCL_NET_DEVICE_HOST && proxyState->ncclNet->getDeviceMr)
-        NCCLCHECK(proxyState->ncclNet->getDeviceMr(resources->netRecvComm, resources->mhandles[p], &connection->mhandles[p]));
+        NCCLCHECK(proxyState->ncclNet->getDeviceMr(resources->netRecvComm, resources->mhandles[p],
+                                                   &connection->mhandles[p]));
     }
   }
 
-  //NCCLCHECK(netDumpMap(map));
+  // NCCLCHECK(netDumpMap(map));
   if (respSize != sizeof(struct connectMap)) return ncclInternalError;
   memcpy(respBuff, map, sizeof(struct connectMap));
   return ncclSuccess;
@@ -1532,7 +1601,7 @@ static ncclResult_t sendProxyFree(struct ncclProxyConnection* connection, struct
       free(memHandle);
     }
 
-    for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
+    for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) {
       if (resources->buffers[p]) {
         NCCLCHECK(proxyState->ncclNet->deregMr(resources->netSendComm, resources->mhandles[p]));
       }
@@ -1559,9 +1628,11 @@ static ncclResult_t sendProxyFree(struct ncclProxyConnection* connection, struct
     if (resources->shared) {
       NCCLCHECK(sharedNetBuffersDestroy(proxyState, resources->tpLocalRank, 0, connection));
       if (resources->maxRecvs > 1 && ncclParamNetSharedComms()) {
-        struct ncclSharedNetComms* comms = proxyState->progressState.netComms[resources->netDev]+resources->tpRemoteRank;
+        struct ncclSharedNetComms* comms =
+          proxyState->progressState.netComms[resources->netDev] + resources->tpRemoteRank;
         comms->sendRefCount[resources->channelId]--;
-        if (comms->sendRefCount[resources->channelId] == 0) NCCLCHECK(proxyState->ncclNet->closeSend(comms->sendComm[resources->channelId]));
+        if (comms->sendRefCount[resources->channelId] == 0)
+          NCCLCHECK(proxyState->ncclNet->closeSend(comms->sendComm[resources->channelId]));
       } else {
         NCCLCHECK(proxyState->ncclNet->closeSend(resources->netSendComm));
       }
@@ -1588,7 +1659,7 @@ static ncclResult_t recvProxyFree(struct ncclProxyConnection* connection, struct
       free(memHandle);
     }
 
-    for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
+    for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) {
       if (resources->buffers[p]) {
         NCCLCHECK(proxyState->ncclNet->deregMr(resources->netRecvComm, resources->mhandles[p]));
       }
@@ -1611,9 +1682,11 @@ static ncclResult_t recvProxyFree(struct ncclProxyConnection* connection, struct
     if (resources->shared) {
       NCCLCHECK(sharedNetBuffersDestroy(proxyState, resources->tpLocalRank, 1, connection));
       if (resources->maxRecvs > 1 && ncclParamNetSharedComms()) {
-        struct ncclSharedNetComms* comms = proxyState->progressState.netComms[resources->netDev] + resources->tpRemoteProxyRank;
+        struct ncclSharedNetComms* comms =
+          proxyState->progressState.netComms[resources->netDev] + resources->tpRemoteProxyRank;
         comms->recvRefCount[resources->channelId]--;
-        if (comms->recvRefCount[resources->channelId] == 0) NCCLCHECK(proxyState->ncclNet->closeRecv(comms->recvComm[resources->channelId]));
+        if (comms->recvRefCount[resources->channelId] == 0)
+          NCCLCHECK(proxyState->ncclNet->closeRecv(comms->recvComm[resources->channelId]));
       } else {
         NCCLCHECK(proxyState->ncclNet->closeRecv(resources->netRecvComm));
       }
@@ -1631,17 +1704,16 @@ static_assert(NCCL_STEPS <= NCCL_NET_MAX_REQUESTS, "Not enough net requests to c
 static ncclResult_t sendProxyProgress(struct ncclProxyState* proxyState, struct ncclProxyArgs* args) {
   int checkedNetAttr = 0;
   if (args->state == ncclProxyOpReady) {
-    for (int s=0; s<args->nsubs; s++) {
-      struct ncclProxySubArgs* sub = args->subs+s;
-      struct sendNetResources* resources = (struct sendNetResources*) (sub->connection->transportResources);
+    for (int s = 0; s < args->nsubs; s++) {
+      struct ncclProxySubArgs* sub = args->subs + s;
+      struct sendNetResources* resources = (struct sendNetResources*)(sub->connection->transportResources);
       // Round to next multiple of sliceSteps
       sub->base = ROUNDUP(resources->step, args->chunkSteps);
       // Set step base for next op
       resources->step = sub->base + sub->nsteps;
       sub->posted = sub->transmitted = sub->done = 0;
       ncclProfilerRecordProxyOpEventState(s, args, ncclProfilerProxyOpInProgress_v4);
-      if (!sub->reg)
-        sub->sendMhandle = resources->mhandles[args->protocol];
+      if (!sub->reg) sub->sendMhandle = resources->mhandles[args->protocol];
     }
     args->state = ncclProxyOpProgress;
     args->hdp_flushed = 0;
@@ -1649,26 +1721,26 @@ static ncclResult_t sendProxyProgress(struct ncclProxyState* proxyState, struct 
   args->idle = 1;
   if (args->state == ncclProxyOpProgress) {
     int p = args->protocol;
-    int maxDepth = std::min(NCCL_STEPS, NCCL_SHARED_STEPS/args->nsubs);
-    for (int s=0; s<args->nsubs; s++) {
-      struct ncclProxySubArgs* sub = args->subs+s;
+    int maxDepth = std::min(NCCL_STEPS, NCCL_SHARED_STEPS / args->nsubs);
+    for (int s = 0; s < args->nsubs; s++) {
+      struct ncclProxySubArgs* sub = args->subs + s;
       int postedStepId = sub->posted;
       int transmittedStepId = sub->transmitted;
       int doneStepId = sub->done;
       if (sub->done == sub->nsteps) continue;
-      struct sendNetResources* resources = (struct sendNetResources*) (sub->connection->transportResources);
+      struct sendNetResources* resources = (struct sendNetResources*)(sub->connection->transportResources);
       volatile struct ncclConnFifo* connFifo = (volatile struct ncclConnFifo*)resources->recvMem->connFifo;
       int stepSize = resources->buffSizes[p] / NCCL_STEPS;
       char* localBuff = NCCL_NET_MAP_GET_POINTER(&resources->map, cpu, buffs[p]);
       // Post buffers to the GPU
       if (sub->posted < sub->nsteps && sub->posted < sub->done + maxDepth) {
         ncclProfilerStartSendProxyStepEvent(s, args, postedStepId);
-        int buffSlot = (sub->base+sub->posted)%NCCL_STEPS;
+        int buffSlot = (sub->base + sub->posted) % NCCL_STEPS;
         if (resources->shared) {
           if (!sub->reg) {
-            int sharedBuffSlot = sub->posted%maxDepth;
+            int sharedBuffSlot = sub->posted % maxDepth;
             int offset;
-            NCCLCHECK(sharedBuffersGet(proxyState, sub->channelId, sharedBuffSlot*args->nsubs+s, &offset, NULL));
+            NCCLCHECK(sharedBuffersGet(proxyState, sub->channelId, sharedBuffSlot * args->nsubs + s, &offset, NULL));
             __atomic_store_n(&resources->recvMem->connFifo[buffSlot].offset, offset, __ATOMIC_RELAXED);
             std::atomic_thread_fence(std::memory_order_seq_cst);
           }
@@ -1680,50 +1752,59 @@ static ncclResult_t sendProxyProgress(struct ncclProxyState* proxyState, struct 
           sub->posted += args->sliceSteps;
         }
         ncclProfilerRecordProxyStepEventState(s, args, postedStepId, ncclProfilerProxyStepSendGPUWait);
-        ncclProfilerRecordProxyDiagState(s, args, ncclProxyDiagPosted, (int64_t)sub->posted, 0, NCCL_PROXY_DIAG_FLAG_TIMESTAMP);
+        ncclProfilerRecordProxyDiagState(s, args, ncclProxyDiagPosted, (int64_t)sub->posted, 0,
+                                         NCCL_PROXY_DIAG_FLAG_TIMESTAMP);
         args->idle = 0;
         continue;
       }
       // Check whether we received data from the GPU and send it to the network
       if (sub->transmitted < sub->posted && sub->transmitted < sub->done + NCCL_STEPS) {
-        int buffSlot = (sub->base+sub->transmitted)%NCCL_STEPS;
+        int buffSlot = (sub->base + sub->transmitted) % NCCL_STEPS;
         volatile uint64_t* recvTail = &resources->recvMem->tail;
         uint64_t tail = sub->base + sub->transmitted;
         ncclProfilerRecordProxyDiagState(s, args, ncclProxyDiagRecvTail, (int64_t)*recvTail, 0, 0);
         ncclProfilerRecordProxyDiagState(s, args, ncclProxyDiagTailOrHead, (int64_t)tail, 0, 0);
-        ncclProfilerRecordProxyDiagState(s, args, ncclProxyDiagFifoSzOrHeadCache, (int64_t)connFifo[buffSlot].size, 0, 0);
-          
+        ncclProfilerRecordProxyDiagState(s, args, ncclProxyDiagFifoSzOrHeadCache, (int64_t)connFifo[buffSlot].size, 0,
+                                         0);
+
         if (connFifo[buffSlot].size != -1 && (*recvTail > tail || p == NCCL_PROTO_LL)) {
           // We have something to receive, let's check if it's completely ready.
           int size = connFifo[buffSlot].size;
           bool shared = (p == NCCL_PROTO_SIMPLE) && resources->shared;
-          char* buff = shared ? localBuff+connFifo[buffSlot].offset : localBuff+buffSlot*stepSize;
+          char* buff = shared ? localBuff + connFifo[buffSlot].offset : localBuff + buffSlot * stepSize;
           int ready = 1;
           if (p == NCCL_PROTO_LL128) {
             ready = resources->useGdr;
             if (!ready) {
               // When data is in sysmem, we need to wait until all flags are correct since the GPU only
               // called threadfence()
-              uint64_t flag = sub->base+sub->transmitted+1;
-              int nFifoLines = DIVUP(connFifo[buffSlot].size, sizeof(uint64_t)*proxyState->ll128LineElems);
+              uint64_t flag = sub->base + sub->transmitted + 1;
+              int nFifoLines = DIVUP(connFifo[buffSlot].size, sizeof(uint64_t) * proxyState->ll128LineElems);
               volatile uint64_t* lines = (volatile uint64_t*)buff;
               ready = 1;
-              for (int i=0; i<nFifoLines; i++) {
-                if (lines[i*proxyState->ll128LineElems+proxyState->ll128DataElems] != flag) { ready = 0; break; }
+              for (int i = 0; i < nFifoLines; i++) {
+                if (lines[i * proxyState->ll128LineElems + proxyState->ll128DataElems] != flag) {
+                  ready = 0;
+                  break;
+                }
               }
             }
           } else if (p == NCCL_PROTO_LL) {
-            uint32_t flag = NCCL_LL_FLAG(sub->base+sub->transmitted+1);
+            uint32_t flag = NCCL_LL_FLAG(sub->base + sub->transmitted + 1);
             int nFifoLines = DIVUP(size, sizeof(union ncclLLFifoLine));
             union ncclLLFifoLine* lines = (union ncclLLFifoLine*)buff;
-            for (int i=0; i<nFifoLines; i++) {
-              volatile uint32_t *f1 = &lines[i].flag1;
-              volatile uint32_t *f2 = &lines[i].flag2;
-              if (f1[0] != flag || f2[0] != flag) { ready = 0; break; }
+            for (int i = 0; i < nFifoLines; i++) {
+              volatile uint32_t* f1 = &lines[i].flag1;
+              volatile uint32_t* f2 = &lines[i].flag2;
+              if (f1[0] != flag || f2[0] != flag) {
+                ready = 0;
+                break;
+              }
             }
           } else if (p == NCCL_PROTO_SIMPLE) {
             if (resources->shared) {
-              buff = sub->reg ? (char*)sub->sendbuff + sub->transmitted * NCCL_MAX_NET_SIZE : localBuff + resources->recvMem->connFifo[buffSlot].offset;
+              buff = sub->reg ? (char*)sub->sendbuff + sub->transmitted * NCCL_MAX_NET_SIZE :
+                                localBuff + resources->recvMem->connFifo[buffSlot].offset;
             } else if (sub->reg) {
               size_t sendSize;
               sub->ringAlgo->getNextSendAddr(sub->transmitted, (uint8_t**)&buff, &sendSize, &sub->sendMhandle);
@@ -1737,25 +1818,31 @@ static ncclResult_t sendProxyProgress(struct ncclProxyState* proxyState, struct 
               *resources->curr_hdp_reg = 1;
             }
             ncclProfilerRecordProxyStepEventState(s, args, transmittedStepId, ncclProfilerProxyStepSendPeerWait_v4);
-            ncclProfilerRecordProxyDiagState(s, args, ncclProxyDiagKernelCopyReady, sub->reg ? 1 : (int64_t)(sub->transmitted + args->sliceSteps), 0, 0);
+            ncclProfilerRecordProxyDiagState(s, args, ncclProxyDiagKernelCopyReady,
+                                             sub->reg ? 1 : (int64_t)(sub->transmitted + args->sliceSteps), 0, 0);
             // Data is ready, try to send.
             // Coverity complains about the size here as pointing to an out-of-scope temporary.  Which is nonsense,
             // since size is a plain integer.
             // coverity[use_invalid:FALSE]
-            void* phandle = &sub->pHandles[DIVUP(transmittedStepId, args->sliceSteps)%NCCL_STEPS];
-            if (!checkedNetAttr++)
-              setXferNetAttrs(proxyState, args, 1);
-            void **requestPtr = sub->requests+buffSlot;
+            void* phandle = &sub->pHandles[DIVUP(transmittedStepId, args->sliceSteps) % NCCL_STEPS];
+            if (!checkedNetAttr++) setXferNetAttrs(proxyState, args, 1);
+            void** requestPtr = sub->requests + buffSlot;
             // for LL/LL128 protocols, completion event for write operation is not needed on the receiver side as
             // the LL flags are actively polled to detect if full data is received or not, so this hint can be used
             // by network plugin to optimize the transport for LL/LL128
-            bool ignoreCompletion = ncclParamNetOptionalRecvCompletion() && ((args->protocol == NCCL_PROTO_LL128) || (args->protocol == NCCL_PROTO_LL));
-            if (ignoreCompletion) *requestPtr = (void *)NCCL_NET_OPTIONAL_RECV_COMPLETION;
-            NCCLCHECK(proxyState->ncclNet->isend(resources->netSendComm, buff, size, resources->tpRank, sub->sendMhandle, phandle, requestPtr));
+            bool ignoreCompletion = ncclParamNetOptionalRecvCompletion() &&
+                                    ((args->protocol == NCCL_PROTO_LL128) || (args->protocol == NCCL_PROTO_LL));
+            if (ignoreCompletion) *requestPtr = (void*)NCCL_NET_OPTIONAL_RECV_COMPLETION;
+            NCCLCHECK(proxyState->ncclNet->isend(resources->netSendComm, buff, size, resources->tpRank,
+                                                 sub->sendMhandle, phandle, requestPtr));
             if (*requestPtr != NULL) {
               ncclProfilerRecordProxyDiagState(s, args, ncclProxyDiagKernelCopyReady, 0, 0,
-                NCCL_PROXY_DIAG_FLAG_TIMESTAMP | NCCL_PROXY_DIAG_FLAG_COUNTER_SKIP);
-              TRACE(NCCL_NET, "sendProxy [%ld/%d/%d] Isend posted, req %p, buff %p, size %d, proto %d, myRank %d, channelId %d, mhandle %p", sub->transmitted, buffSlot, sub->nsteps, sub->requests[buffSlot], buff, size, p, proxyState->tpRank, sub->channelId, sub->sendMhandle);
+                                               NCCL_PROXY_DIAG_FLAG_TIMESTAMP | NCCL_PROXY_DIAG_FLAG_COUNTER_SKIP);
+              TRACE(NCCL_NET,
+                    "sendProxy [%ld/%d/%d] Isend posted, req %p, buff %p, size %d, proto %d, myRank %d, channelId %d, "
+                    "mhandle %p",
+                    sub->transmitted, buffSlot, sub->nsteps, sub->requests[buffSlot], buff, size, p, proxyState->tpRank,
+                    sub->channelId, sub->sendMhandle);
               sub->transSize = size;
               sub->transmitted += args->sliceSteps;
               ncclProfilerRecordProxyStepEventState(s, args, transmittedStepId, ncclProfilerProxyStepSendWait);
@@ -1770,13 +1857,14 @@ static ncclResult_t sendProxyProgress(struct ncclProxyState* proxyState, struct 
       if (sub->done < sub->transmitted) {
         int done;
         int size;
-        int buffSlot = (sub->base+sub->done)%NCCL_STEPS;
+        int buffSlot = (sub->base + sub->done) % NCCL_STEPS;
         NCCLCHECK(proxyState->ncclNet->test(sub->requests[buffSlot], &done, &size));
         if (done) {
           // Make sure size is reset to -1 before we update the head.
           connFifo[buffSlot].size = -1;
           std::atomic_thread_fence(std::memory_order_seq_cst);
-          TRACE(NCCL_NET, "sendProxy [%ld/%d/%d] request %p done", sub->done, buffSlot, sub->nsteps, sub->requests[buffSlot]);
+          TRACE(NCCL_NET, "sendProxy [%ld/%d/%d] request %p done", sub->done, buffSlot, sub->nsteps,
+                sub->requests[buffSlot]);
           sub->done += args->sliceSteps;
           ncclProfilerStopProxyStepEvent(s, args, doneStepId);
           ncclProfilerRecordProxyDiagState(s, args, ncclProxyDiagDone, (int64_t)sub->done, 0, 0);
@@ -1795,7 +1883,7 @@ static ncclResult_t sendProxyProgress(struct ncclProxyState* proxyState, struct 
       }
     }
     if (args->done == args->nsubs) {
-      for (int s=0; s<args->nsubs; s++) {
+      for (int s = 0; s < args->nsubs; s++) {
         ncclProfilerStopProxyOpEvent(s, args);
       }
       args->state = ncclProxyOpNone;
@@ -1813,14 +1901,15 @@ static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct 
     void* recvComm;
     int groupSize = 0;
     int maxRecvs = 1;
-    for (int s=0; s<args->nsubs; s++) {
-      struct ncclProxySubArgs* sub = args->subs+s;
+    for (int s = 0; s < args->nsubs; s++) {
+      struct ncclProxySubArgs* sub = args->subs + s;
       if (groupSize == maxRecvs) {
         groupSize = 0;
-      } else if (s>0) { // Find next sub with the same recvComm
+      } else if (s > 0) { // Find next sub with the same recvComm
         int next;
-        for (next=s; next<args->nsubs; next++) {
-          struct recvNetResources* nextRes = (struct recvNetResources*) (args->subs[next].connection->transportResources);
+        for (next = s; next < args->nsubs; next++) {
+          struct recvNetResources* nextRes =
+            (struct recvNetResources*)(args->subs[next].connection->transportResources);
           if (nextRes->netRecvComm == recvComm) break;
         }
         if (next == args->nsubs) { // Not found
@@ -1828,12 +1917,12 @@ static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct 
         } else if (s != next) { // We found a sub later with the same recvComm ; swap subs
           struct ncclProxySubArgs temp;
           memcpy(&temp, sub, sizeof(struct ncclProxySubArgs));
-          memcpy(sub, args->subs+next, sizeof(struct ncclProxySubArgs));
-          memcpy(args->subs+next, &temp, sizeof(struct ncclProxySubArgs));
+          memcpy(sub, args->subs + next, sizeof(struct ncclProxySubArgs));
+          memcpy(args->subs + next, &temp, sizeof(struct ncclProxySubArgs));
         }
       }
       groupSize++;
-      struct recvNetResources* resources = (struct recvNetResources*) (sub->connection->transportResources);
+      struct recvNetResources* resources = (struct recvNetResources*)(sub->connection->transportResources);
       maxRecvs = resources->maxRecvs;
       recvComm = resources->netRecvComm;
       // Round to next multiple of sliceSteps
@@ -1842,35 +1931,37 @@ static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct 
       resources->step = sub->base + sub->nsteps;
       sub->posted = sub->received = sub->transmitted = sub->done = 0;
       sub->regBufferReady = 0;
-      for (int i=0; i<groupSize; i++) sub[-i].groupSize = groupSize;
+      for (int i = 0; i < groupSize; i++) sub[-i].groupSize = groupSize;
       ncclProfilerRecordProxyOpEventState(s, args, ncclProfilerProxyOpInProgress_v4);
-      if (!sub->reg)
-        sub->recvMhandle = resources->mhandles[args->protocol];
+      if (!sub->reg) sub->recvMhandle = resources->mhandles[args->protocol];
     }
     args->state = ncclProxyOpProgress;
   }
   args->idle = 1;
   if (args->state == ncclProxyOpProgress) {
     int p = args->protocol;
-    int maxDepth = std::min(NCCL_STEPS, NCCL_SHARED_STEPS/args->nsubs);
-    for (int s=0; s<args->nsubs; s+=args->subs[s].groupSize) {
-      struct ncclProxySubArgs* subGroup = args->subs+s;
+    int maxDepth = std::min(NCCL_STEPS, NCCL_SHARED_STEPS / args->nsubs);
+    for (int s = 0; s < args->nsubs; s += args->subs[s].groupSize) {
+      struct ncclProxySubArgs* subGroup = args->subs + s;
       int subCount = 0;
       void* ptrs[NCCL_PROXY_MAX_SUBS];
       size_t sizes[NCCL_PROXY_MAX_SUBS];
       int tags[NCCL_PROXY_MAX_SUBS];
       void* mhandles[NCCL_PROXY_MAX_SUBS];
       void* phandles[NCCL_PROXY_MAX_SUBS];
-      for (int i=0; i<subGroup->groupSize; i++) {
+      for (int i = 0; i < subGroup->groupSize; i++) {
         struct ncclProxySubArgs* sub = subGroup + i;
         int postedStepId = sub->posted;
         if (sub->posted < sub->nsteps) {
-          if (sub->posted >= sub->done + maxDepth) { subCount = 0; break; }
-          ncclProfilerStartRecvProxyStepEvent(s+i, args, postedStepId);
-          struct recvNetResources* resources = (struct recvNetResources*) (sub->connection->transportResources);
+          if (sub->posted >= sub->done + maxDepth) {
+            subCount = 0;
+            break;
+          }
+          ncclProfilerStartRecvProxyStepEvent(s + i, args, postedStepId);
+          struct recvNetResources* resources = (struct recvNetResources*)(sub->connection->transportResources);
           int stepSize = resources->buffSizes[p] / NCCL_STEPS;
           char* localBuff = NCCL_NET_MAP_GET_POINTER(&resources->map, cpu, buffs[p]);
-          int buffSlot = (sub->base+sub->posted)%NCCL_STEPS;
+          int buffSlot = (sub->base + sub->posted) % NCCL_STEPS;
           volatile struct ncclConnFifo* connFifo = (volatile struct ncclConnFifo*)resources->recvMem->connFifo;
           if (p == NCCL_PROTO_SIMPLE) {
             if (resources->shared) {
@@ -1879,11 +1970,13 @@ static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct 
                 if (!sub->regBufferReady && connFifo[sub->base % NCCL_STEPS].size == -1) continue;
                 sub->regBufferReady = 1;
                 ptrs[subCount] = sub->recvbuff + sub->posted * NCCL_MAX_NET_SIZE;
-                sizes[subCount] = std::min((ssize_t)NCCL_MAX_NET_SIZE, (ssize_t)(sub->nbytes - sub->posted * NCCL_MAX_NET_SIZE));
+                sizes[subCount] =
+                  std::min((ssize_t)NCCL_MAX_NET_SIZE, (ssize_t)(sub->nbytes - sub->posted * NCCL_MAX_NET_SIZE));
               } else {
                 int sharedBuffSlot = sub->posted % maxDepth;
                 int offset;
-                NCCLCHECK(sharedBuffersGet(proxyState, sub->channelId, sharedBuffSlot * args->nsubs + s + i, &offset, sizes + subCount));
+                NCCLCHECK(sharedBuffersGet(proxyState, sub->channelId, sharedBuffSlot * args->nsubs + s + i, &offset,
+                                           sizes + subCount));
                 __atomic_store_n(&connFifo[buffSlot].offset, offset, __ATOMIC_RELAXED);
                 ptrs[subCount] = localBuff + offset;
               }
@@ -1891,43 +1984,49 @@ static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct 
               if (sub->reg) {
                 if (!sub->regBufferReady && connFifo[sub->base % NCCL_STEPS].size == -1) continue;
                 sub->regBufferReady = 1;
-                sub->ringAlgo->getNextRecvAddr(sub->posted, (uint8_t**)&ptrs[subCount], &sizes[subCount], &sub->recvMhandle);
+                sub->ringAlgo->getNextRecvAddr(sub->posted, (uint8_t**)&ptrs[subCount], &sizes[subCount],
+                                               &sub->recvMhandle);
               } else {
                 ptrs[subCount] = localBuff + buffSlot * stepSize;
                 sizes[subCount] = stepSize * args->sliceSteps;
               }
             }
           } else {
-            ptrs[subCount] = localBuff+buffSlot*stepSize;
-            sizes[subCount] = stepSize*args->sliceSteps;
+            ptrs[subCount] = localBuff + buffSlot * stepSize;
+            sizes[subCount] = stepSize * args->sliceSteps;
           }
           // if (sub->nbytes < sizes[subCount]) sizes[subCount] = sub->nbytes;
           tags[subCount] = resources->tpRemoteRank;
           mhandles[subCount] = sub->recvMhandle;
-          phandles[subCount] = &sub->pHandles[DIVUP(postedStepId, args->sliceSteps)%NCCL_STEPS];
+          phandles[subCount] = &sub->pHandles[DIVUP(postedStepId, args->sliceSteps) % NCCL_STEPS];
           subCount++;
         }
       }
       if (subCount) {
         uint64_t step = subGroup->posted;
-        struct recvNetResources* resources = (struct recvNetResources*) (subGroup->connection->transportResources);
-        void** requestPtr = subGroup->requests+(step%NCCL_STEPS);
-        bool ignoreCompletion = ncclParamNetOptionalRecvCompletion() && ((args->protocol == NCCL_PROTO_LL128) || (args->protocol == NCCL_PROTO_LL)) && (subCount == 1);
-        if (!checkedNetAttr++)
-          setXferNetAttrs(proxyState, args, 0);
-        if (ignoreCompletion) *requestPtr = (void *)NCCL_NET_OPTIONAL_RECV_COMPLETION;
-        NCCLCHECK(proxyState->ncclNet->irecv(resources->netRecvComm, subCount, ptrs, sizes, tags, mhandles, phandles, requestPtr));
+        struct recvNetResources* resources = (struct recvNetResources*)(subGroup->connection->transportResources);
+        void** requestPtr = subGroup->requests + (step % NCCL_STEPS);
+        bool ignoreCompletion = ncclParamNetOptionalRecvCompletion() &&
+                                ((args->protocol == NCCL_PROTO_LL128) || (args->protocol == NCCL_PROTO_LL)) &&
+                                (subCount == 1);
+        if (!checkedNetAttr++) setXferNetAttrs(proxyState, args, 0);
+        if (ignoreCompletion) *requestPtr = (void*)NCCL_NET_OPTIONAL_RECV_COMPLETION;
+        NCCLCHECK(proxyState->ncclNet->irecv(resources->netRecvComm, subCount, ptrs, sizes, tags, mhandles, phandles,
+                                             requestPtr));
         if (*requestPtr) {
-          subGroup->recvRequestsCache[step%NCCL_STEPS] = *requestPtr;
+          subGroup->recvRequestsCache[step % NCCL_STEPS] = *requestPtr;
           subGroup->recvRequestsSubCount = subCount;
-          for (int i=0; i<subGroup->groupSize; i++) {
-            struct ncclProxySubArgs* sub = subGroup+i;
+          for (int i = 0; i < subGroup->groupSize; i++) {
+            struct ncclProxySubArgs* sub = subGroup + i;
             int postedStepId = sub->posted;
-            TRACE(NCCL_NET, "recvProxy [%ld/%ld/%d] Irecv posted, buff %p, size %ld, myRank %d, channelId %d, mhandle %p", sub->posted, (sub->base + sub->posted) % NCCL_STEPS, sub->nsteps, ptrs[i], sizes[i], proxyState->tpRank, sub->channelId, mhandles[i]);
+            TRACE(NCCL_NET,
+                  "recvProxy [%ld/%ld/%d] Irecv posted, buff %p, size %ld, myRank %d, channelId %d, mhandle %p",
+                  sub->posted, (sub->base + sub->posted) % NCCL_STEPS, sub->nsteps, ptrs[i], sizes[i],
+                  proxyState->tpRank, sub->channelId, mhandles[i]);
 
             sub->posted += args->sliceSteps;
-            ncclProfilerRecordProxyStepEventState(s+i, args, postedStepId, ncclProfilerProxyStepRecvWait);
-            ncclProfilerRecordProxyDiagState(s+i, args, ncclProxyDiagPosted, (int64_t)sub->posted, 0, 0);
+            ncclProfilerRecordProxyStepEventState(s + i, args, postedStepId, ncclProfilerProxyStepRecvWait);
+            ncclProfilerRecordProxyDiagState(s + i, args, ncclProxyDiagPosted, (int64_t)sub->posted, 0, 0);
           }
           args->idle = 0;
         }
@@ -1935,21 +2034,21 @@ static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct 
     }
     if (args->idle == 0) return ncclSuccess;
 
-    for (int s=0; s<args->nsubs; s+=args->subs[s].groupSize) {
-      struct ncclProxySubArgs* subGroup = args->subs+s;
+    for (int s = 0; s < args->nsubs; s += args->subs[s].groupSize) {
+      struct ncclProxySubArgs* subGroup = args->subs + s;
       if (subGroup->posted > subGroup->received) {
         uint64_t step = subGroup->received;
         int done;
         void* ptrs[NCCL_PROXY_MAX_SUBS];
         int sizes[NCCL_PROXY_MAX_SUBS];
         void* mhandles[NCCL_PROXY_MAX_SUBS];
-        for (int i=0; i<NCCL_PROXY_MAX_SUBS; i++) sizes[i] = 0;
-        NCCLCHECK(proxyState->ncclNet->test(subGroup->requests[step%NCCL_STEPS], &done, sizes));
+        for (int i = 0; i < NCCL_PROXY_MAX_SUBS; i++) sizes[i] = 0;
+        NCCLCHECK(proxyState->ncclNet->test(subGroup->requests[step % NCCL_STEPS], &done, sizes));
         if (done) {
           int needFlush = 0;
           int totalSize = 0;
-          for (int i=0; i<NCCL_PROXY_MAX_SUBS; i++) totalSize += sizes[i];
-          for (int i=0; i<subGroup->groupSize; i++) {
+          for (int i = 0; i < NCCL_PROXY_MAX_SUBS; i++) totalSize += sizes[i];
+          for (int i = 0; i < subGroup->groupSize; i++) {
             struct ncclProxySubArgs* sub = subGroup + i;
 
             int receivedStepId = sub->received;
@@ -1959,17 +2058,17 @@ static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct 
             connFifo[buffSlot].size = -1;
             sub->transSize = sizes[i];
             sub->received += args->sliceSteps;
-            ncclProfilerRecordProxyStepEventState(s+i, args, receivedStepId, ncclProfilerProxyStepRecvFlushWait);
-            ncclProfilerRecordProxyDiagState(s+i, args, ncclProxyDiagReceived, (int64_t)sub->received, 0, 0);
+            ncclProfilerRecordProxyStepEventState(s + i, args, receivedStepId, ncclProfilerProxyStepRecvFlushWait);
+            ncclProfilerRecordProxyDiagState(s + i, args, ncclProxyDiagReceived, (int64_t)sub->received, 0, 0);
             if (step < sub->nsteps) {
-              struct recvNetResources* resources = (struct recvNetResources*) (sub->connection->transportResources);
+              struct recvNetResources* resources = (struct recvNetResources*)(sub->connection->transportResources);
               if (resources->useGdr) needFlush |= resources->needFlush;
             }
           }
-          subGroup->requests[step%NCCL_STEPS] = NULL;
+          subGroup->requests[step % NCCL_STEPS] = NULL;
           if (totalSize > 0 && p == NCCL_PROTO_SIMPLE && needFlush) {
             // GDRCOPY support
-            struct recvNetResources* resources = (struct recvNetResources*) (subGroup->connection->transportResources);
+            struct recvNetResources* resources = (struct recvNetResources*)(subGroup->connection->transportResources);
             if (rcclParamNetHdpFlush() && resources->curr_hdp_reg) {
               static bool once = true;
               *resources->curr_hdp_reg = 0x1;
@@ -1980,10 +2079,10 @@ static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct 
               }
             }
             if (resources->gdcFlush) {
-#if defined (__x86_64__)
+#if defined(__x86_64__)
               // Force a PCI-E read from GPU memory
               static bool once = true;
-              asm volatile ("mov (%0), %%eax" :: "l"(resources->gdcFlush) : "%eax");
+              asm volatile("mov (%0), %%eax" ::"l"(resources->gdcFlush) : "%eax");
               if (once) {
                 once = false;
                 INFO(NCCL_INIT, "%s: issued GDC flush", __func__);
@@ -1995,15 +2094,16 @@ static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct 
             } else {
               int subCount = 0;
               static bool once = true;
-              for (int i=0; i<subGroup->groupSize; i++) {
+              for (int i = 0; i < subGroup->groupSize; i++) {
                 struct ncclProxySubArgs* sub = subGroup + i;
                 if (step < sub->nsteps) {
-                  struct recvNetResources* resources = (struct recvNetResources*) (sub->connection->transportResources);
+                  struct recvNetResources* resources = (struct recvNetResources*)(sub->connection->transportResources);
                   int stepSize = resources->buffSizes[p] / NCCL_STEPS;
                   char* localBuff = NCCL_NET_MAP_GET_POINTER(&resources->map, cpu, buffs[p]);
-                  int buffSlot = (sub->base+sub->received-args->sliceSteps)%NCCL_STEPS;
+                  int buffSlot = (sub->base + sub->received - args->sliceSteps) % NCCL_STEPS;
                   if (resources->shared) {
-                    ptrs[subCount] = sub->reg ? (char*)sub->recvbuff + step * NCCL_MAX_NET_SIZE : localBuff + resources->recvMem->connFifo[buffSlot].offset;
+                    ptrs[subCount] = sub->reg ? (char*)sub->recvbuff + step * NCCL_MAX_NET_SIZE :
+                                                localBuff + resources->recvMem->connFifo[buffSlot].offset;
                   } else {
                     if (sub->reg) {
                       sub->ringAlgo->getNextRecvAddr(step, (uint8_t**)&ptrs[subCount], NULL, &sub->recvMhandle);
@@ -2015,13 +2115,14 @@ static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct 
                   subCount++;
                 }
               }
-              struct recvNetResources* resources = (struct recvNetResources*) (subGroup->connection->transportResources);
-              NCCLCHECK(proxyState->ncclNet->iflush(resources->netRecvComm, subCount, ptrs, sizes, mhandles, subGroup->requests+(step%NCCL_STEPS)));
+              struct recvNetResources* resources = (struct recvNetResources*)(subGroup->connection->transportResources);
+              NCCLCHECK(proxyState->ncclNet->iflush(resources->netRecvComm, subCount, ptrs, sizes, mhandles,
+                                                    subGroup->requests + (step % NCCL_STEPS)));
               // [Added-comment] iflush has been posted for this subGroup at `step`
-              if (subGroup->requests[step%NCCL_STEPS]){
-                for(int i=0; i<subGroup->groupSize; i++) {
+              if (subGroup->requests[step % NCCL_STEPS]) {
+                for (int i = 0; i < subGroup->groupSize; i++) {
                   struct ncclProxySubArgs* sub = subGroup + i;
-                  ncclProfilerRecordProxyDiagState(s+i, args, ncclProxyDiagFlushed, (int64_t)sub->received, 0, 0);
+                  ncclProfilerRecordProxyDiagState(s + i, args, ncclProxyDiagFlushed, (int64_t)sub->received, 0, 0);
                 }
               }
               if (once) {
@@ -2036,27 +2137,27 @@ static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct 
     }
     if (args->idle == 0) return ncclSuccess;
 
-    for (int s=0; s<args->nsubs; s+=args->subs[s].groupSize) {
-      struct ncclProxySubArgs* subGroup = args->subs+s;
+    for (int s = 0; s < args->nsubs; s += args->subs[s].groupSize) {
+      struct ncclProxySubArgs* subGroup = args->subs + s;
       if (subGroup->received > subGroup->transmitted) {
         uint64_t step = subGroup->transmitted;
         int done = 1;
-        void* request = subGroup->requests[step%NCCL_STEPS];
+        void* request = subGroup->requests[step % NCCL_STEPS];
         if (request) NCCLCHECK(proxyState->ncclNet->test(request, &done, NULL));
         if (done) {
-          for (int i=0; i<subGroup->groupSize; i++) {
+          for (int i = 0; i < subGroup->groupSize; i++) {
             struct ncclProxySubArgs* sub = subGroup + i;
             int transmittedStepId = sub->transmitted;
 
             sub->transmitted += args->sliceSteps;
-            ncclProfilerRecordProxyStepEventState(s+i, args, transmittedStepId, ncclProfilerProxyStepRecvGPUWait);
-            ncclProfilerRecordProxyDiagState(s+i, args, ncclProxyDiagTransmitted, (int64_t)sub->transmitted, 0, 0);
+            ncclProfilerRecordProxyStepEventState(s + i, args, transmittedStepId, ncclProfilerProxyStepRecvGPUWait);
+            ncclProfilerRecordProxyDiagState(s + i, args, ncclProxyDiagTransmitted, (int64_t)sub->transmitted, 0, 0);
             if (step < sub->nsteps) {
               std::atomic_thread_fence(std::memory_order_seq_cst);
-              struct recvNetResources* resources = (struct recvNetResources*) (sub->connection->transportResources);
+              struct recvNetResources* resources = (struct recvNetResources*)(sub->connection->transportResources);
               volatile uint64_t* recvTail = resources->gdcSync ? resources->gdcSync : &resources->recvMem->tail;
               *recvTail = sub->base + sub->transmitted;
-              ncclProfilerRecordProxyDiagState(s+i, args, ncclProxyDiagRecvTail, (int64_t)*recvTail, 0, 0);
+              ncclProfilerRecordProxyDiagState(s + i, args, ncclProxyDiagRecvTail, (int64_t)*recvTail, 0, 0);
               if (resources->gdcSync) wc_store_fence(); // Flush out WC write
             }
           }
@@ -2066,30 +2167,33 @@ static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct 
     }
     if (args->idle == 0) return ncclSuccess;
 
-    for (int s=0; s<args->nsubs; s+=args->subs[s].groupSize) {
-      struct ncclProxySubArgs* subGroup = args->subs+s;
-      for (int i=0; i<subGroup->groupSize; i++) {
+    for (int s = 0; s < args->nsubs; s += args->subs[s].groupSize) {
+      struct ncclProxySubArgs* subGroup = args->subs + s;
+      for (int i = 0; i < subGroup->groupSize; i++) {
         struct ncclProxySubArgs* sub = subGroup + i;
         if (sub->done == sub->nsteps) continue;
         if (sub->transmitted > sub->done) {
-          struct recvNetResources* resources = (struct recvNetResources*) (sub->connection->transportResources);
+          struct recvNetResources* resources = (struct recvNetResources*)(sub->connection->transportResources);
           volatile uint64_t* sendHead = &resources->sendMem->head;
           uint64_t done = *sendHead;
-          ncclProfilerRecordProxyDiagState(s+i, args, ncclProxyDiagTailOrHead, (int64_t)done, 0, 0);
-          ncclProfilerRecordProxyDiagState(s+i, args, ncclProxyDiagFifoSzOrHeadCache, (int64_t)(sub->base + sub->done), 0, 0);
-          while (done > sub->base + sub->done &&
-              // LL and LL128 can acknowledge 0-bytes send before they even happen. Don't go past what we transmitted.
-              sub->transmitted > sub->done) {
-            if (subGroup->recvRequestsCache[sub->done%NCCL_STEPS]) {
+          ncclProfilerRecordProxyDiagState(s + i, args, ncclProxyDiagTailOrHead, (int64_t)done, 0, 0);
+          ncclProfilerRecordProxyDiagState(s + i, args, ncclProxyDiagFifoSzOrHeadCache,
+                                           (int64_t)(sub->base + sub->done), 0, 0);
+          while (
+            done > sub->base + sub->done &&
+            // LL and LL128 can acknowledge 0-bytes send before they even happen. Don't go past what we transmitted.
+            sub->transmitted > sub->done) {
+            if (subGroup->recvRequestsCache[sub->done % NCCL_STEPS]) {
               // the multirecv requests are only cached in the first sub.
               if (proxyState->ncclNet->irecvConsumed)
-                NCCLCHECK(proxyState->ncclNet->irecvConsumed(resources->netRecvComm, subGroup->recvRequestsSubCount, subGroup->recvRequestsCache[sub->done%NCCL_STEPS]));
-              subGroup->recvRequestsCache[sub->done%NCCL_STEPS] = NULL;
+                NCCLCHECK(proxyState->ncclNet->irecvConsumed(resources->netRecvComm, subGroup->recvRequestsSubCount,
+                                                             subGroup->recvRequestsCache[sub->done % NCCL_STEPS]));
+              subGroup->recvRequestsCache[sub->done % NCCL_STEPS] = NULL;
             }
             int doneStepId = sub->done;
             sub->done += args->sliceSteps;
-            ncclProfilerStopProxyStepEvent(s+i, args, doneStepId);
-            ncclProfilerRecordProxyDiagState(s+i, args, ncclProxyDiagDone, (int64_t)sub->done, 0, 0);
+            ncclProfilerStopProxyStepEvent(s + i, args, doneStepId);
+            ncclProfilerRecordProxyDiagState(s + i, args, ncclProxyDiagDone, (int64_t)sub->done, 0, 0);
             args->idle = 0;
             if (sub->done == sub->nsteps) {
               args->done++;
@@ -2103,7 +2207,7 @@ static ncclResult_t recvProxyProgress(struct ncclProxyState* proxyState, struct 
     }
     if (args->done == args->nsubs) {
       args->state = ncclProxyOpNone;
-      for (int s=0; s<args->nsubs; s++) {
+      for (int s = 0; s < args->nsubs; s++) {
         ncclProfilerStopProxyOpEvent(s, args);
       }
     }
@@ -2117,7 +2221,9 @@ ncclResult_t ncclNetDeregBuffer(struct ncclComm* comm, struct ncclProxyConnector
   return ncclSuccess;
 }
 
-static ncclResult_t netRegisterBuffer(ncclComm* comm, const void* userbuff, size_t buffSize, struct ncclConnector** peerConns, int nPeers, struct ncclReg* regRecord, int* outRegBufFlag, void** outHandle, int numSegments) {
+static ncclResult_t netRegisterBuffer(ncclComm* comm, const void* userbuff, size_t buffSize,
+                                      struct ncclConnector** peerConns, int nPeers, struct ncclReg* regRecord,
+                                      int* outRegBufFlag, void** outHandle, int numSegments) {
   ncclResult_t ret = ncclSuccess;
   int gdrFlag = 1;
 
@@ -2140,13 +2246,16 @@ static ncclResult_t netRegisterBuffer(ncclComm* comm, const void* userbuff, size
       if (found) {
         *outRegBufFlag = 1;
         outHandle[p] = netHandle->handle;
-        INFO(NCCL_REG, "rank %d - NET reuse buffer %p size %ld (baseAddr %p size %ld) handle %p", comm->rank, userbuff, buffSize, (void*)regRecord->begAddr, regRecord->endAddr - regRecord->begAddr, netHandle->handle);
+        INFO(NCCL_REG, "rank %d - NET reuse buffer %p size %ld (baseAddr %p size %ld) handle %p", comm->rank, userbuff,
+             buffSize, (void*)regRecord->begAddr, regRecord->endAddr - regRecord->begAddr, netHandle->handle);
       } else {
-        struct netRegInfo info = { regRecord->begAddr, regRecord->endAddr - regRecord->begAddr, numSegments};
+        struct netRegInfo info = {regRecord->begAddr, regRecord->endAddr - regRecord->begAddr, numSegments};
         void* handle = NULL;
 
         if (peerConn->conn.flags & NCCL_DIRECT_NIC) {
-          NCCLCHECKGOTO(ncclProxyCallBlocking(comm, peerProxyConn, ncclProxyMsgRegister, &info, sizeof(struct netRegInfo), &handle, sizeof(void*)), ret, fail);
+          NCCLCHECKGOTO(ncclProxyCallBlocking(comm, peerProxyConn, ncclProxyMsgRegister, &info,
+                                              sizeof(struct netRegInfo), &handle, sizeof(void*)),
+                        ret, fail);
           if (handle) {
             struct ncclRegNetHandles* netHandle;
             regRecord->state |= NET_REG_COMPLETE;
@@ -2157,7 +2266,8 @@ static ncclResult_t netRegisterBuffer(ncclComm* comm, const void* userbuff, size
             regRecord->netHandleHead = netHandle;
             outHandle[p] = handle;
             *outRegBufFlag = 1;
-            INFO(NCCL_REG, "rank %d - NET register userbuff %p (handle %p), buffSize %ld", comm->rank, userbuff, handle, buffSize);
+            INFO(NCCL_REG, "rank %d - NET register userbuff %p (handle %p), buffSize %ld", comm->rank, userbuff, handle,
+                 buffSize);
           } else {
             goto fail;
           }
@@ -2173,15 +2283,18 @@ exit:
   return ret;
 fail:
   *outRegBufFlag = 0;
-  INFO(NCCL_REG, "rank %d failed to NET register userbuff %p buffSize %ld GDR flag %d", comm->rank, userbuff, buffSize, gdrFlag);
+  INFO(NCCL_REG, "rank %d failed to NET register userbuff %p buffSize %ld GDR flag %d", comm->rank, userbuff, buffSize,
+       gdrFlag);
   goto exit;
 }
 
-ncclResult_t ncclNetLocalRegisterBuffer(ncclComm* comm, const void* userbuff, size_t buffSize, struct ncclConnector** peerConns, int nPeers, int* outRegBufFlag, void** outHandle) {
+ncclResult_t ncclNetLocalRegisterBuffer(ncclComm* comm, const void* userbuff, size_t buffSize,
+                                        struct ncclConnector** peerConns, int nPeers, int* outRegBufFlag,
+                                        void** outHandle) {
   ncclResult_t ret = ncclSuccess;
-  struct ncclReg *regRecord = NULL;
+  struct ncclReg* regRecord = NULL;
   bool isValid = false;
-  void *base = NULL;
+  void* base = NULL;
   size_t baseSize = 0;
 
   *outRegBufFlag = 0;
@@ -2190,9 +2303,12 @@ ncclResult_t ncclNetLocalRegisterBuffer(ncclComm* comm, const void* userbuff, si
     NCCLCHECKGOTO(ncclRegLocalIsValid(regRecord, &isValid), ret, fail);
     if (isValid) {
       int numSegments = 0;
-      NCCLCHECK(ncclCuMemGetAddressRange((CUdeviceptr) userbuff, buffSize, (CUdeviceptr*)&base, &baseSize, &numSegments));
+      NCCLCHECK(ncclCuMemGetAddressRange((CUdeviceptr)userbuff, buffSize, (CUdeviceptr*)&base, &baseSize,
+                                         &numSegments));
       if (numSegments > 1 && !ncclParamMultiSegmentRegister()) goto exit;
-      NCCLCHECKGOTO(netRegisterBuffer(comm, userbuff, buffSize, peerConns, nPeers, regRecord, outRegBufFlag, outHandle, numSegments), ret, fail);
+      NCCLCHECKGOTO(netRegisterBuffer(comm, userbuff, buffSize, peerConns, nPeers, regRecord, outRegBufFlag, outHandle,
+                                      numSegments),
+                    ret, fail);
     }
   }
 
@@ -2205,8 +2321,8 @@ fail:
 
 struct ncclNetCleanupCallback {
   struct ncclCommCallback base;
-  struct ncclComm *comm;
-  struct ncclReg *reg;
+  struct ncclComm* comm;
+  struct ncclReg* reg;
 };
 
 static ncclResult_t cleanupNet(struct ncclComm* comm, struct ncclCommCallback* cb) {
@@ -2216,20 +2332,25 @@ static ncclResult_t cleanupNet(struct ncclComm* comm, struct ncclCommCallback* c
   return ncclSuccess;
 }
 
-ncclResult_t ncclNetGraphRegisterBuffer(ncclComm* comm, const void* userbuff, size_t buffSize, struct ncclConnector** peerConns, int nPeers, int* outRegBufFlag, void** outHandle, struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>* cleanupQueue, int* nCleanupQueueElts) {
+ncclResult_t ncclNetGraphRegisterBuffer(
+  ncclComm* comm, const void* userbuff, size_t buffSize, struct ncclConnector** peerConns, int nPeers,
+  int* outRegBufFlag, void** outHandle,
+  struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>* cleanupQueue, int* nCleanupQueueElts) {
   ncclResult_t ret = ncclSuccess;
-  struct ncclNetCleanupCallback *record = NULL;
-  struct ncclReg *regRecord = NULL;
-  void *base = NULL;
+  struct ncclNetCleanupCallback* record = NULL;
+  struct ncclReg* regRecord = NULL;
+  void* base = NULL;
   size_t baseSize = 0;
 
   *outRegBufFlag = 0;
   if (comm && userbuff && buffSize > 0 && nPeers > 0) {
     int numSegments = 0;
-    NCCLCHECK(ncclCuMemGetAddressRange((CUdeviceptr) userbuff, buffSize, (CUdeviceptr*)&base, &baseSize, &numSegments));
+    NCCLCHECK(ncclCuMemGetAddressRange((CUdeviceptr)userbuff, buffSize, (CUdeviceptr*)&base, &baseSize, &numSegments));
     if (numSegments > 1 && !ncclParamMultiSegmentRegister()) goto exit;
     NCCLCHECKGOTO(ncclCommGraphRegister(comm, base, baseSize, (void**)&regRecord), ret, fail);
-    NCCLCHECKGOTO(netRegisterBuffer(comm, userbuff, buffSize, peerConns, nPeers, regRecord, outRegBufFlag, outHandle, numSegments), ret, fail);
+    NCCLCHECKGOTO(netRegisterBuffer(comm, userbuff, buffSize, peerConns, nPeers, regRecord, outRegBufFlag, outHandle,
+                                    numSegments),
+                  ret, fail);
     if (*outRegBufFlag) {
       NCCLCHECKGOTO(ncclCalloc(&record, 1), ret, fail);
       record->base.fn = cleanupNet;
@@ -2248,7 +2369,8 @@ fail:
   goto exit;
 }
 
-static ncclResult_t sendProxyRegBuffer(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
+static ncclResult_t sendProxyRegBuffer(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState,
+                                       void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
   void* handle = NULL;
   struct netRegInfo* info = (struct netRegInfo*)reqBuff;
   int numSegments = info->numSegments;
@@ -2264,8 +2386,13 @@ static ncclResult_t sendProxyRegBuffer(struct ncclProxyConnection* connection, s
   /* DMA-BUF support */
   if (resources->useDmaBuf && ncclCuMemEnable()) {
     int dmabuf_fd;
-    CUCHECKGOTO(cuMemGetHandleForAddressRange((void*)&dmabuf_fd, (CUdeviceptr)info->buffer, info->size, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, getHandleForAddressRangeFlags(resources->useGdr)), ret, peermem);
-    NCCLCHECKGOTO(proxyState->ncclNet->regMrDmaBuf(resources->netSendComm, (void*)info->buffer, info->size, NCCL_PTR_CUDA, 0ULL, dmabuf_fd, &handle), ret, peermem);
+    CUCHECKGOTO(cuMemGetHandleForAddressRange((void*)&dmabuf_fd, (CUdeviceptr)info->buffer, info->size,
+                                              CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
+                                              getHandleForAddressRangeFlags(resources->useGdr)),
+                ret, peermem);
+    NCCLCHECKGOTO(proxyState->ncclNet->regMrDmaBuf(resources->netSendComm, (void*)info->buffer, info->size,
+                                                   NCCL_PTR_CUDA, 0ULL, dmabuf_fd, &handle),
+                  ret, peermem);
     (void)close(dmabuf_fd);
     needReg = false;
   }
@@ -2274,8 +2401,11 @@ peermem:
   if (resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf) {
     int dmabuf_fd;
     uint64_t offset;
-    HSACHECKGOTO(hsa_amd_portable_export_dmabuf((const void*)info->buffer, info->size, &dmabuf_fd, &offset), ret, peermem);
-    NCCLCHECKGOTO(proxyState->ncclNet->regMrDmaBuf(resources->netSendComm, (void*)info->buffer, info->size, NCCL_PTR_CUDA, offset, dmabuf_fd, &handle), ret, peermem);
+    HSACHECKGOTO(hsa_amd_portable_export_dmabuf((const void*)info->buffer, info->size, &dmabuf_fd, &offset), ret,
+                 peermem);
+    NCCLCHECKGOTO(proxyState->ncclNet->regMrDmaBuf(resources->netSendComm, (void*)info->buffer, info->size,
+                                                   NCCL_PTR_CUDA, offset, dmabuf_fd, &handle),
+                  ret, peermem);
     (void)close(dmabuf_fd);
     needReg = false;
   }
@@ -2284,10 +2414,15 @@ peermem:
   if (needReg) {
     // Non-dmabuf regMr does not support multiple physical segments
     if (numSegments > 1) {
-      INFO(NCCL_NET|NCCL_REG, "Buffer %p (size %zu, numSegments %d) not registered as DMABuf is not available. Non-DMABuf registration currently does not support multiple segments.", (void *)info->buffer, info->size, numSegments);
+      INFO(NCCL_NET | NCCL_REG,
+           "Buffer %p (size %zu, numSegments %d) not registered as DMABuf is not available. Non-DMABuf registration "
+           "currently does not support multiple segments.",
+           (void*)info->buffer, info->size, numSegments);
       goto fail;
     } else {
-      NCCLCHECKGOTO(proxyState->ncclNet->regMr(resources->netSendComm, (void*)info->buffer, info->size, NCCL_PTR_CUDA, &handle), ret, fail);
+      NCCLCHECKGOTO(proxyState->ncclNet->regMr(resources->netSendComm, (void*)info->buffer, info->size, NCCL_PTR_CUDA,
+                                               &handle),
+                    ret, fail);
     }
   }
 
@@ -2306,7 +2441,8 @@ fail:
   goto exit;
 }
 
-static ncclResult_t recvProxyRegBuffer(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
+static ncclResult_t recvProxyRegBuffer(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState,
+                                       void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
   void* handle = NULL;
   struct netRegInfo* info = (struct netRegInfo*)reqBuff;
   int numSegments = info->numSegments;
@@ -2322,8 +2458,13 @@ static ncclResult_t recvProxyRegBuffer(struct ncclProxyConnection* connection, s
   /* DMA-BUF support */
   if (resources->useDmaBuf && ncclCuMemEnable()) {
     int dmabuf_fd;
-    CUCHECKGOTO(cuMemGetHandleForAddressRange((void*)&dmabuf_fd, (CUdeviceptr)info->buffer, info->size, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, getHandleForAddressRangeFlags(resources->useGdr)), ret, peermem);
-    NCCLCHECKGOTO(proxyState->ncclNet->regMrDmaBuf(resources->netRecvComm, (void*)info->buffer, info->size, NCCL_PTR_CUDA, 0ULL, dmabuf_fd, &handle), ret, peermem);
+    CUCHECKGOTO(cuMemGetHandleForAddressRange((void*)&dmabuf_fd, (CUdeviceptr)info->buffer, info->size,
+                                              CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
+                                              getHandleForAddressRangeFlags(resources->useGdr)),
+                ret, peermem);
+    NCCLCHECKGOTO(proxyState->ncclNet->regMrDmaBuf(resources->netRecvComm, (void*)info->buffer, info->size,
+                                                   NCCL_PTR_CUDA, 0ULL, dmabuf_fd, &handle),
+                  ret, peermem);
     (void)close(dmabuf_fd);
     needReg = false;
   }
@@ -2332,8 +2473,11 @@ peermem:
   if (resources->useDmaBuf && pfn_hsa_amd_portable_export_dmabuf) {
     int dmabuf_fd;
     uint64_t offset;
-    HSACHECKGOTO(hsa_amd_portable_export_dmabuf((const void*)info->buffer, info->size, &dmabuf_fd, &offset), ret, peermem);
-    NCCLCHECKGOTO(proxyState->ncclNet->regMrDmaBuf(resources->netRecvComm, (void*)info->buffer, info->size, NCCL_PTR_CUDA, offset, dmabuf_fd, &handle), ret, peermem);
+    HSACHECKGOTO(hsa_amd_portable_export_dmabuf((const void*)info->buffer, info->size, &dmabuf_fd, &offset), ret,
+                 peermem);
+    NCCLCHECKGOTO(proxyState->ncclNet->regMrDmaBuf(resources->netRecvComm, (void*)info->buffer, info->size,
+                                                   NCCL_PTR_CUDA, offset, dmabuf_fd, &handle),
+                  ret, peermem);
     (void)close(dmabuf_fd);
     needReg = false;
   }
@@ -2342,10 +2486,15 @@ peermem:
   if (needReg) {
     // Non-dmabuf regMr does not support multiple physical segments
     if (numSegments > 1) {
-      INFO(NCCL_NET|NCCL_REG, "Buffer %p (size %zu, numSegments %d) not registered as DMABuf is not available. Non-DMABuf registration currently does not support multiple segments.", (void *)info->buffer, info->size, numSegments);
+      INFO(NCCL_NET | NCCL_REG,
+           "Buffer %p (size %zu, numSegments %d) not registered as DMABuf is not available. Non-DMABuf registration "
+           "currently does not support multiple segments.",
+           (void*)info->buffer, info->size, numSegments);
       goto fail;
     } else {
-      NCCLCHECKGOTO(proxyState->ncclNet->regMr(resources->netRecvComm, (void*)info->buffer, info->size, NCCL_PTR_CUDA, &handle), ret, fail);
+      NCCLCHECKGOTO(proxyState->ncclNet->regMr(resources->netRecvComm, (void*)info->buffer, info->size, NCCL_PTR_CUDA,
+                                               &handle),
+                    ret, fail);
     }
   }
 
@@ -2368,7 +2517,8 @@ static bool netHandleCmp(struct proxyMemHandle* a, struct proxyMemHandle* b) {
   return a->handle == b->handle;
 }
 
-static ncclResult_t sendProxyDeregBuffer(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, int* done) {
+static ncclResult_t sendProxyDeregBuffer(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState,
+                                         void* reqBuff, int reqSize, int* done) {
   void* handle;
   struct sendNetResources* resources = (struct sendNetResources*)(connection->transportResources);
 
@@ -2386,7 +2536,8 @@ static ncclResult_t sendProxyDeregBuffer(struct ncclProxyConnection* connection,
   return ncclSuccess;
 }
 
-static ncclResult_t recvProxyDeregBuffer(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, int* done) {
+static ncclResult_t recvProxyDeregBuffer(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState,
+                                         void* reqBuff, int reqSize, int* done) {
   void* handle;
   struct recvNetResources* resources = (struct recvNetResources*)(connection->transportResources);
 
@@ -2407,6 +2558,8 @@ static ncclResult_t recvProxyDeregBuffer(struct ncclProxyConnection* connection,
 struct ncclTransport netTransport = {
   "NET",
   canConnect,
-  { sendSetup, sendConnect, sendFree, proxySharedInit, sendProxySetup, sendProxyConnect, sendProxyFree, sendProxyProgress, sendProxyRegBuffer, sendProxyDeregBuffer },
-  { recvSetup, recvConnect, recvFree, proxySharedInit, recvProxySetup, recvProxyConnect, recvProxyFree, recvProxyProgress, recvProxyRegBuffer, recvProxyDeregBuffer }
+  {sendSetup, sendConnect, sendFree, proxySharedInit, sendProxySetup, sendProxyConnect, sendProxyFree,
+   sendProxyProgress, sendProxyRegBuffer, sendProxyDeregBuffer},
+  {recvSetup, recvConnect, recvFree, proxySharedInit, recvProxySetup, recvProxyConnect, recvProxyFree,
+   recvProxyProgress, recvProxyRegBuffer, recvProxyDeregBuffer}
 };

--- a/projects/rccl/src/transport/net_ib/common.cc
+++ b/projects/rccl/src/transport/net_ib/common.cc
@@ -8,7 +8,7 @@
 #include "common.h"
 #include "p2p_resiliency.h"
 
-char ncclIbIfName[MAX_IF_NAME_SIZE+1];
+char ncclIbIfName[MAX_IF_NAME_SIZE + 1];
 union ncclSocketAddress ncclIbIfAddr;
 
 int ncclNMergedIbDevs = -1;
@@ -21,11 +21,10 @@ ncclProfilerCallback_t ncclProfilerFunction;
 
 NCCL_PARAM(IbSplitDataOnQps, "IB_SPLIT_DATA_ON_QPS", 0);
 NCCL_PARAM(IbPrepostReceiveWorkRequests, "IB_PREPOST_RECEIVE_WORK_REQUESTS", -2);
-NCCL_PARAM(IbAsyncEvents,"IB_RETURN_ASYNC_EVENTS",1);
+NCCL_PARAM(IbAsyncEvents, "IB_RETURN_ASYNC_EVENTS", 1);
 extern int ncclParamIbReceiverSideMatchingScheme();
 extern int ncclParamIbOooRq();
 extern int ncclParamIbResiliencyPortFailover();
-
 
 ncclResult_t ncclIbStatsCheckFatalCount(struct ncclIbStats* stat, const char* funcName) {
   if (ncclParamIbAsyncEvents() && COMPILER_ATOMIC_LOAD(&stat->fatalErrorCount, std::memory_order_relaxed)) {
@@ -38,18 +37,18 @@ ncclResult_t ncclIbStatsCheckFatalCount(struct ncclIbStats* stat, const char* fu
 
 struct ncclIbNetCommDevBase* ncclIbGetNetCommDevBase(ncclIbNetCommBase* base, int devIndex) {
   if (base->isSend) {
-    struct ncclIbSendComm* sComm = (struct ncclIbSendComm*) base;
+    struct ncclIbSendComm* sComm = (struct ncclIbSendComm*)base;
     return &sComm->devs[devIndex].base;
   } else {
-    struct ncclIbRecvComm* rComm = (struct ncclIbRecvComm*) base;
+    struct ncclIbRecvComm* rComm = (struct ncclIbRecvComm*)base;
     return &rComm->devs[devIndex].base;
   }
 }
 
 ncclResult_t ncclIbBaseCommInit(struct ncclIbNetCommBase* baseComm, bool isSend) {
   for (int i = 0; i < NCCL_IB_MAX_QPS; i++) {
-    baseComm->qps[i].devIndex= -1;
-    baseComm->qps[i].remDevIdx= -1;
+    baseComm->qps[i].devIndex = -1;
+    baseComm->qps[i].remDevIdx = -1;
     baseComm->activeQps[i] = &baseComm->qps[i];
     baseComm->qps[i].eceSupported = 0;
     baseComm->qps[i].ece = {0};
@@ -64,7 +63,8 @@ ncclResult_t ncclIbBaseCommInit(struct ncclIbNetCommBase* baseComm, bool isSend)
   baseComm->ready = 0;
 
   NCCLCHECK(ncclIbResiliencyInit(baseComm, &baseComm->resiliency));
-  baseComm->recvMatchingScheme = ncclParamIbReceiverSideMatchingScheme() == -2 ? BY_INDEX : ncclParamIbReceiverSideMatchingScheme();
+  baseComm->recvMatchingScheme =
+    ncclParamIbReceiverSideMatchingScheme() == -2 ? BY_INDEX : ncclParamIbReceiverSideMatchingScheme();
 
   if (ncclParamIbOooRq() || (ncclParamIbResiliencyPortFailover() == 1)) {
     baseComm->recvMatchingScheme = BY_ID;
@@ -78,14 +78,10 @@ ncclResult_t ncclIbBaseCommInit(struct ncclIbNetCommBase* baseComm, bool isSend)
 
 ncclResult_t ncclIbRecvCommInit(struct ncclIbRecvComm* recvComm) {
   NCCLCHECK(ncclIbBaseCommInit(&recvComm->base, false));
-  recvComm->ibRecvWorkRequest = {
-    .wr_id = NCCL_IB_RECV_WR_ID_DUMMY,
-    .next = NULL,
-    .sg_list = NULL,
-    .num_sge = 0
-  };
+  recvComm->ibRecvWorkRequest = {.wr_id = NCCL_IB_RECV_WR_ID_DUMMY, .next = NULL, .sg_list = NULL, .num_sge = 0};
 
-  recvComm->prepostReceiveWorkRequests = (ncclParamIbPrepostReceiveWorkRequests() == -2) ? false : ncclParamIbPrepostReceiveWorkRequests();
+  recvComm->prepostReceiveWorkRequests =
+    (ncclParamIbPrepostReceiveWorkRequests() == -2) ? false : ncclParamIbPrepostReceiveWorkRequests();
 
   if (recvComm->base.resiliency) {
     if (ncclParamIbPrepostReceiveWorkRequests() == 0) {
@@ -100,7 +96,8 @@ ncclResult_t ncclIbRecvCommInit(struct ncclIbRecvComm* recvComm) {
     recvComm->prepostReceiveWorkRequests = true;
   }
 
-  INFO(NCCL_NET, "NET/IB: %s: Receive work requests will be %s", __func__, recvComm->prepostReceiveWorkRequests ? "pre-posted" : "posted on-demand");
+  INFO(NCCL_NET, "NET/IB: %s: Receive work requests will be %s", __func__,
+       recvComm->prepostReceiveWorkRequests ? "pre-posted" : "posted on-demand");
   return ncclSuccess;
 }
 
@@ -114,12 +111,16 @@ void* ncclIbAsyncThreadMain(void* args) {
   struct ncclIbDev* dev = (struct ncclIbDev*)args;
   while (1) {
     struct ibv_async_event event;
-    if (ncclSuccess != wrap_ibv_get_async_event(dev->context, &event)) { break; }
-    char *str;
+    if (ncclSuccess != wrap_ibv_get_async_event(dev->context, &event)) {
+      break;
+    }
+    char* str;
     struct ibv_cq* cq = event.element.cq;    // only valid if CQ error
     struct ibv_qp* qp = event.element.qp;    // only valid if QP error
     struct ibv_srq* srq = event.element.srq; // only valid if SRQ error
-    if (ncclSuccess != wrap_ibv_event_type_str(&str, event.event_type)) { break; }
+    if (ncclSuccess != wrap_ibv_event_type_str(&str, event.event_type)) {
+      break;
+    }
     switch (event.event_type) {
     case IBV_EVENT_DEVICE_FATAL:
       // the above is device fatal error
@@ -166,7 +167,9 @@ void* ncclIbAsyncThreadMain(void* args) {
       break;
     }
     // acknowledgment needs to happen last to avoid user-after-free
-    if (ncclSuccess != wrap_ibv_ack_async_event(&event)) { break; }
+    if (ncclSuccess != wrap_ibv_ack_async_event(&event)) {
+      break;
+    }
   }
   return NULL;
 }

--- a/projects/rccl/src/transport/net_ib/common.h
+++ b/projects/rccl/src/transport/net_ib/common.h
@@ -36,29 +36,29 @@
 
 #define MAXSUFFIXSIZE 16
 #define MAXNAMESIZE (64 + MAXSUFFIXSIZE)
-extern char ncclIbIfName[MAX_IF_NAME_SIZE+1];
+extern char ncclIbIfName[MAX_IF_NAME_SIZE + 1];
 extern union ncclSocketAddress ncclIbIfAddr;
 
 enum ncclIbRequestMatchingScheme {
-  BY_INDEX=0,
-  BY_ID=1,
+  BY_INDEX = 0,
+  BY_ID = 1,
 };
 
 struct ncclIbMr {
   uintptr_t addr;
   size_t pages;
   int refs;
-  ibv_mr *mr;
+  ibv_mr* mr;
 };
 
 struct ncclIbMrCache {
-  struct ncclIbMr *slots;
+  struct ncclIbMr* slots;
   int capacity, population;
 };
 
 extern int ncclNMergedIbDevs;
 #define NCCL_IB_MAX_DEVS_PER_NIC NCCL_NET_MAX_DEVS_PER_NIC
-#define MAX_MERGED_DEV_NAME (MAXNAMESIZE*NCCL_IB_MAX_DEVS_PER_NIC)+NCCL_IB_MAX_DEVS_PER_NIC
+#define MAX_MERGED_DEV_NAME (MAXNAMESIZE * NCCL_IB_MAX_DEVS_PER_NIC) + NCCL_IB_MAX_DEVS_PER_NIC
 struct alignas(64) ncclIbMergedDev {
   ncclNetVDeviceProps_t vProps;
   int speed;
@@ -106,13 +106,14 @@ struct alignas(64) ncclIbDev {
   } capsProvider;
 };
 
-#define MAX_IB_DEVS  32
-#define MAX_IB_VDEVS MAX_IB_DEVS*8
+#define MAX_IB_DEVS 32
+#define MAX_IB_VDEVS MAX_IB_DEVS * 8
 extern struct ncclIbMergedDev ncclIbMergedDevs[MAX_IB_VDEVS];
 extern struct ncclIbDev ncclIbDevs[MAX_IB_DEVS];
 extern int ncclIbRelaxedOrderingEnabled;
 
-#define NCCL_IB_LLSTR(ll) (((ll) == IBV_LINK_LAYER_INFINIBAND) ? "IB" : (((ll) == IBV_LINK_LAYER_ETHERNET) ? "RoCE" : "UNSPECIFIED"))
+#define NCCL_IB_LLSTR(ll) \
+  (((ll) == IBV_LINK_LAYER_INFINIBAND) ? "IB" : (((ll) == IBV_LINK_LAYER_ETHERNET) ? "RoCE" : "UNSPECIFIED"))
 
 // Per-Dev connection metadata
 struct ncclIbDevInfo {
@@ -134,7 +135,7 @@ struct ncclIbDevInfo {
   // registered the completion records structure (on the specific device).
   uint32_t rkey;
 
-  //remote dev info
+  // remote dev info
   union ibv_gid remoteGid;
   int ibv_dev_index;
 };
@@ -298,8 +299,9 @@ struct ncclIbQp {
 };
 
 // We need to support NCCL_NET_MAX_REQUESTS for each concurrent receive
-#define NET_IB_MAX_REQUESTS (NCCL_NET_MAX_REQUESTS*NCCL_NET_IB_MAX_RECVS)
-static_assert(NET_IB_MAX_REQUESTS <= 256, "request id are encoded in wr_id and we need up to 8 requests ids per completion");
+#define NET_IB_MAX_REQUESTS (NCCL_NET_MAX_REQUESTS * NCCL_NET_IB_MAX_RECVS)
+static_assert(NET_IB_MAX_REQUESTS <= 256,
+              "request id are encoded in wr_id and we need up to 8 requests ids per completion");
 
 // Structure to describe the completion records on the sender side.
 struct ncclIbRemCompletionsRecords {
@@ -324,7 +326,6 @@ struct alignas(8) ncclIbSendCommDev {
   struct ibv_mr* cmplsRecordsMr;
   struct ibv_sge sge;
 };
-
 
 // Wrapper to track an MR per-device, if needed
 struct ncclIbMrHandle {
@@ -363,9 +364,10 @@ struct ncclIbNetCommDevBase* ncclIbGetNetCommDevBase(ncclIbNetCommBase* base, in
 
 // qpIndex is the index relative to a device.
 // For example, if a device has 2 QPs, qpIndex can be 0 or 1.
-static inline ncclResult_t ncclIbCommBaseGetQpByIndex(struct ncclIbNetCommBase* commBase, int devIndex, int qpIndex, ncclIbQp** qp) {
+static inline ncclResult_t ncclIbCommBaseGetQpByIndex(struct ncclIbNetCommBase* commBase, int devIndex, int qpIndex,
+                                                      ncclIbQp** qp) {
   assert(devIndex >= 0 && devIndex < commBase->vProps.ndevs);
-  *qp = commBase->activeQps[commBase->vProps.ndevs*qpIndex + devIndex];
+  *qp = commBase->activeQps[commBase->vProps.ndevs * qpIndex + devIndex];
   return ncclSuccess;
 }
 
@@ -377,7 +379,8 @@ static inline ncclResult_t ncclIbCommBaseGetQpByIndex(struct ncclIbNetCommBase* 
 // The function outputs the selected QP in the outQp argument and populates the
 // outQpIndex argument with the index of the selected QP. Note that the
 // outQpIndex is the index of the QP in the base::qps[] array.
-static inline ncclResult_t ncclIbCommBaseGetQpForRequest(struct ncclIbNetCommBase* baseComm, const uint64_t id, const uint8_t qpIndex, ncclIbQp** outQp, int* outQpIndex) {
+static inline ncclResult_t ncclIbCommBaseGetQpForRequest(struct ncclIbNetCommBase* baseComm, const uint64_t id,
+                                                         const uint8_t qpIndex, ncclIbQp** outQp, int* outQpIndex) {
   *outQpIndex = (id + qpIndex) % baseComm->nqps;
   *outQp = baseComm->activeQps[*outQpIndex];
   assert(*outQp != NULL);
@@ -386,12 +389,14 @@ static inline ncclResult_t ncclIbCommBaseGetQpForRequest(struct ncclIbNetCommBas
 
 // Get a QP object from a QP number. If not NULL, qpIndex will also return the
 // index of the QP in the ncclIbNetCommBase::qps[] array.
-static inline ncclResult_t ncclIbCommBaseGetQpByQpNum(struct ncclIbNetCommBase* commBase, int devIndex, uint32_t qpNum, ncclIbQp** qp, int* qpIndex) {
+static inline ncclResult_t ncclIbCommBaseGetQpByQpNum(struct ncclIbNetCommBase* commBase, int devIndex, uint32_t qpNum,
+                                                      ncclIbQp** qp, int* qpIndex) {
   assert(devIndex >= 0 && devIndex < commBase->vProps.ndevs);
   assert(qp != NULL);
-  TRACE(NCCL_NET, "NET/IB: %s: Looking for QP num %u on devIndex %d among %d QPs", __func__, qpNum, devIndex, commBase->nqps / commBase->vProps.ndevs);
+  TRACE(NCCL_NET, "NET/IB: %s: Looking for QP num %u on devIndex %d among %d QPs", __func__, qpNum, devIndex,
+        commBase->nqps / commBase->vProps.ndevs);
   for (int qpIndexInDev = 0; qpIndexInDev < (commBase->nqps / commBase->vProps.ndevs); qpIndexInDev++) {
-    *qp = &(commBase->qps[commBase->vProps.ndevs*qpIndexInDev + devIndex]);
+    *qp = &(commBase->qps[commBase->vProps.ndevs * qpIndexInDev + devIndex]);
     if ((*qp)->qp->qp_num == qpNum) {
       if (qpIndex != NULL) {
         *qpIndex = *qp - commBase->qps;
@@ -447,7 +452,8 @@ struct ncclIbSendComm {
 // The SendFifo needs to be 32-byte aligned and each element needs
 // to be a 32-byte multiple, so that an entry does not get split and
 // written out of order when IB Relaxed Ordering is enabled
-static_assert((sizeof(struct ncclIbNetCommBase) % 32) == 0, "ncclIbNetCommBase size must be 32-byte multiple to ensure ctsFifo is at proper offset");
+static_assert((sizeof(struct ncclIbNetCommBase) % 32) == 0,
+              "ncclIbNetCommBase size must be 32-byte multiple to ensure ctsFifo is at proper offset");
 static_assert((offsetof(struct ncclIbSendComm, ctsFifo) % 32) == 0, "ncclIbSendComm ctsFifo must be 32-byte aligned");
 static_assert((sizeof(struct ncclIbSendFifo) % 32) == 0, "ncclIbSendFifo element size must be 32-byte multiples");
 static_assert((offsetof(struct ncclIbSendComm, sges) % 32) == 0, "sges must be 32-byte aligned");
@@ -520,7 +526,8 @@ struct ncclIbRecvComm {
   // and only the wr_id is updated before posting a receive work request.
   struct ibv_recv_wr ibRecvWorkRequest;
 };
-static_assert((offsetof(struct ncclIbRecvComm, remCtsFifo) % 32) == 0, "ncclIbRecvComm ctsFifo must be 32-byte aligned");
+static_assert((offsetof(struct ncclIbRecvComm, remCtsFifo) % 32) == 0,
+              "ncclIbRecvComm ctsFifo must be 32-byte aligned");
 
 ncclResult_t ncclIbBaseCommInit(struct ncclIbNetCommBase* baseComm, bool isSend);
 ncclResult_t ncclIbRecvCommInit(struct ncclIbRecvComm* recvComm);
@@ -536,7 +543,7 @@ static ncclResult_t ncclIbStatsInit(struct ncclIbStats* stat) {
   COMPILER_ATOMIC_STORE(&stat->fatalErrorCount, 0, std::memory_order_relaxed);
   return ncclSuccess;
 }
-static void ncclIbStatsFatalError(struct ncclIbStats* stat){
+static void ncclIbStatsFatalError(struct ncclIbStats* stat) {
   COMPILER_ATOMIC_FETCH_ADD(&stat->fatalErrorCount, 1, std::memory_order_relaxed);
 }
 static void ncclIbQpFatalError(struct ibv_qp* qp) {
@@ -569,29 +576,35 @@ static inline bool ncclIbRequestHasEvents(struct ncclIbRequest* r) {
   return false;
 }
 
-ncclResult_t ncclIbGetGidIndex(struct ibv_context *context, uint8_t portNum, struct ibv_port_attr* portAttr, int *gidIndex);
+ncclResult_t ncclIbGetGidIndex(struct ibv_context* context, uint8_t portNum, struct ibv_port_attr* portAttr,
+                               int* gidIndex);
 ncclResult_t ncclIbGetRequest(struct ncclIbNetCommBase* base, struct ncclIbRequest** req);
 ncclResult_t ncclIbFreeRequest(struct ncclIbRequest* r);
 
-ncclResult_t ncclIbRegMrDmaBufInternal(ncclIbNetCommDevBase* base, void* data, size_t size, int type, uint64_t offset, int fd, ibv_mr** mhandle);
+ncclResult_t ncclIbRegMrDmaBufInternal(ncclIbNetCommDevBase* base, void* data, size_t size, int type, uint64_t offset,
+                                       int fd, ibv_mr** mhandle);
 
 int ncclIbGetTrafficClass(void* ctx);
 void ncclIbSetTrafficClass(void* ctx, int trafficClass);
 
 // Net IB plugin entry functions.
 ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallback_t profFunction);
-ncclResult_t ncclIbInit(void** ctx, uint64_t commId, ncclNetCommConfig_t* config, ncclDebugLogger_t logFunction, ncclProfilerCallback_t profFunction);
+ncclResult_t ncclIbInit(void** ctx, uint64_t commId, ncclNetCommConfig_t* config, ncclDebugLogger_t logFunction,
+                        ncclProfilerCallback_t profFunction);
 ncclResult_t ncclIbDevices(int* ndev);
 ncclResult_t ncclIbGetProperties(int dev, ncclNetProperties_t* props);
 ncclResult_t ncclIbGetPhysProperties(int dev, ncclNetProperties_t* props);
 ncclResult_t ncclIbListen(void* ctx, int dev, void* opaqueHandle, void** listenComm);
-ncclResult_t ncclIbConnect(void* ctx, int dev, void* opaqueHandle, void** sendComm, ncclNetDeviceHandle_t** /*sendDevComm*/);
+ncclResult_t ncclIbConnect(void* ctx, int dev, void* opaqueHandle, void** sendComm,
+                           ncclNetDeviceHandle_t** /*sendDevComm*/);
 ncclResult_t ncclIbAccept(void* listenComm, void** recvComm, ncclNetDeviceHandle_t** /*recvDevComm*/);
 ncclResult_t ncclIbRegMr(void* comm, void* data, size_t size, int type, void** mhandle);
 ncclResult_t ncclIbRegMrDmaBuf(void* comm, void* data, size_t size, int type, uint64_t offset, int fd, void** mhandle);
 ncclResult_t ncclIbDeregMr(void* comm, void* mhandle);
-ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void* mhandle, void* phandle, void** request);
-ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles, void** phandles, void** request);
+ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void* mhandle, void* phandle,
+                         void** request);
+ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles, void** phandles,
+                         void** request);
 ncclResult_t ncclIbIflush(void* recvComm, int n, void** data, int* sizes, void** mhandles, void** request);
 ncclResult_t ncclIbTest(void* request, int* done, int* sizes);
 ncclResult_t ncclIbCloseSend(void* sendComm);
@@ -600,7 +613,6 @@ ncclResult_t ncclIbCloseListen(void* listenComm);
 ncclResult_t ncclIbMakeVDevice(int* d, ncclNetVDeviceProps_t* props);
 ncclResult_t ncclIbFinalizeDevices(void);
 ncclResult_t ncclIbFinalize(void* ctx);
-ncclResult_t ncclIbSetNetAttr(void *ctx, ncclNetAttr_t *netAttr);
+ncclResult_t ncclIbSetNetAttr(void* ctx, ncclNetAttr_t* netAttr);
 
 #endif
-

--- a/projects/rccl/src/transport/net_ib/connect.cc
+++ b/projects/rccl/src/transport/net_ib/connect.cc
@@ -19,7 +19,7 @@ NCCL_PARAM(IbUseInline, "IB_USE_INLINE", 0);
 NCCL_PARAM(IbSl, "IB_SL", -1);
 NCCL_PARAM(IbTc, "IB_TC", -1);
 NCCL_PARAM(IbFifoTc, "IB_FIFO_TC", -1);
-NCCL_PARAM(IbEceEnable,"IB_ECE_ENABLE",1);
+NCCL_PARAM(IbEceEnable, "IB_ECE_ENABLE", 1);
 
 extern int64_t ncclParamIbOooRq();
 
@@ -60,13 +60,11 @@ RCCL_PARAM(IbQpsPerP2p, "IB_QPS_PER_P2P", 0);
 
 // Calculate number of QPs based on P2P flag and device counts
 static int ncclIbCalculateNqps(int isP2p, int localNdevs, int remoteNdevs, const char* funcName) {
-  auto qp_multiplier = (rcclParamIbQpsPerP2p() > 0 && isP2p) ?
-                       rcclParamIbQpsPerP2p() : ncclParamIbQpsPerConn();
+  auto qp_multiplier = (rcclParamIbQpsPerP2p() > 0 && isP2p) ? rcclParamIbQpsPerP2p() : ncclParamIbQpsPerConn();
   int localNqps = qp_multiplier * localNdevs;
   int remoteNqps = qp_multiplier * remoteNdevs;
   int maxNqps = (remoteNqps > localNqps) ? remoteNqps : localNqps;
-  INFO(NCCL_NET, "NET/IB: %s Max Nqps=%d, localNqps=%d, remoteNqps=%d",
-       funcName, maxNqps, localNqps, remoteNqps);
+  INFO(NCCL_NET, "NET/IB: %s Max Nqps=%d, localNqps=%d, remoteNqps=%d", funcName, maxNqps, localNqps, remoteNqps);
   return maxNqps;
 }
 
@@ -99,13 +97,11 @@ ncclResult_t ncclIbDestroyBase(struct ncclIbNetCommDevBase* base) {
 // GID Format
 // global:  |              64b  - subnet-prefix                |                 64b - EUI                          |
 // raw   :  | 10b fixed | 22b 0 | 16b FLID | 16b subnet-prefix |                 64b - EUI                          |
-static uint16_t ncclIbExtractLocalSubnetPrefix(uint64_t subnet_prefix)
-{
+static uint16_t ncclIbExtractLocalSubnetPrefix(uint64_t subnet_prefix) {
   return (be64toh(subnet_prefix) & 0xffff);
 }
 
-static int ncclIbExtractFlid (union ibv_gid *gid)
-{
+static int ncclIbExtractFlid(union ibv_gid* gid) {
   return ntohs(*((uint16_t*)((uintptr_t)(gid->raw) + 4)));
 }
 
@@ -131,7 +127,7 @@ static void* envIbAddrRange(sa_family_t af, int* mask) {
   *mask = 0;
   static struct in_addr addr;
   static struct in6_addr addr6;
-  void *ret = (af == AF_INET) ? (void *)&addr : (void *)&addr6;
+  void* ret = (af == AF_INET) ? (void*)&addr : (void*)&addr6;
 
   const char* env = ncclGetEnv("NCCL_IB_ADDR_RANGE");
   if (NULL == env || strlen(env) == 0) {
@@ -140,27 +136,30 @@ static void* envIbAddrRange(sa_family_t af, int* mask) {
 
   INFO(NCCL_ENV, "NCCL_IB_ADDR_RANGE set by environment to %s", env);
 
-  char addrString[128] = { 0 };
+  char addrString[128] = {0};
   snprintf(addrString, 128, "%s", env);
-  char *addrStrPtr = addrString;
-  char *maskStrPtr = strstr(addrString, "/");
+  char* addrStrPtr = addrString;
+  char* maskStrPtr = strstr(addrString, "/");
   if (NULL == maskStrPtr) {
     return NULL;
   }
   *(maskStrPtr++) = '\0';
 
   if (inet_pton(af, addrStrPtr, ret) == 0) {
-    INFO(NCCL_INIT|NCCL_NET, "NET/IB: Ip address '%s' is invalid for family %s, ignoring address", addrStrPtr, (af == AF_INET) ? "AF_INET" : "AF_INET6");
+    INFO(NCCL_INIT | NCCL_NET, "NET/IB: Ip address '%s' is invalid for family %s, ignoring address", addrStrPtr,
+         (af == AF_INET) ? "AF_INET" : "AF_INET6");
     return NULL;
   }
 
   *mask = (int)strtol(maskStrPtr, NULL, 10);
   if (af == AF_INET && *mask > 32) {
-    INFO(NCCL_INIT|NCCL_NET, "NET/IB: Ip address mask '%d' is invalid for family %s, ignoring mask", *mask, (af == AF_INET) ? "AF_INET" : "AF_INET6");
+    INFO(NCCL_INIT | NCCL_NET, "NET/IB: Ip address mask '%d' is invalid for family %s, ignoring mask", *mask,
+         (af == AF_INET) ? "AF_INET" : "AF_INET6");
     *mask = 0;
     ret = NULL;
   } else if (af == AF_INET6 && *mask > 128) {
-    INFO(NCCL_INIT|NCCL_NET, "NET/IB: Ip address mask '%d' is invalid for family %s, ignoring mask", *mask, (af == AF_INET) ? "AF_INET" : "AF_INET6");
+    INFO(NCCL_INIT | NCCL_NET, "NET/IB: Ip address mask '%d' is invalid for family %s, ignoring mask", *mask,
+         (af == AF_INET) ? "AF_INET" : "AF_INET6");
     *mask = 0;
     ret = NULL;
   }
@@ -169,22 +168,24 @@ static void* envIbAddrRange(sa_family_t af, int* mask) {
 }
 
 static sa_family_t getGidAddrFamily(union ibv_gid* gid) {
-  const struct in6_addr *a = (struct in6_addr *)gid->raw;
+  const struct in6_addr* a = (struct in6_addr*)gid->raw;
   bool isIpV4Mapped = ((a->s6_addr32[0] | a->s6_addr32[1]) | (a->s6_addr32[2] ^ htonl(0x0000ffff))) == 0UL;
-  bool isIpV4MappedMulticast = (a->s6_addr32[0] == htonl(0xff0e0000) && ((a->s6_addr32[1] | (a->s6_addr32[2] ^ htonl(0x0000ffff))) == 0UL));
+  bool isIpV4MappedMulticast =
+    (a->s6_addr32[0] == htonl(0xff0e0000) && ((a->s6_addr32[1] | (a->s6_addr32[2] ^ htonl(0x0000ffff))) == 0UL));
   return (isIpV4Mapped || isIpV4MappedMulticast) ? AF_INET : AF_INET6;
 }
 
 static bool matchGidAddrPrefix(sa_family_t af, void* prefix, int prefixlen, union ibv_gid* gid) {
-  struct in_addr *base = NULL;
-  struct in6_addr *base6 = NULL;
-  struct in6_addr *addr6 = NULL;;
+  struct in_addr* base = NULL;
+  struct in6_addr* base6 = NULL;
+  struct in6_addr* addr6 = NULL;
+  ;
   if (af == AF_INET) {
-    base = (struct in_addr *)prefix;
+    base = (struct in_addr*)prefix;
   } else {
-    base6 = (struct in6_addr *)prefix;
+    base6 = (struct in6_addr*)prefix;
   }
-  addr6 = (struct in6_addr *)gid->raw;
+  addr6 = (struct in6_addr*)gid->raw;
 
 #define NETMASK(bits) (htonl(0xffffffff ^ ((1 << (32 - bits)) - 1)))
 
@@ -218,7 +219,7 @@ static bool matchGidAddrPrefix(sa_family_t af, void* prefix, int prefixlen, unio
 }
 
 static bool configuredGid(union ibv_gid* gid) {
-  const struct in6_addr *a = (struct in6_addr *)gid->raw;
+  const struct in6_addr* a = (struct in6_addr*)gid->raw;
   int trailer = (a->s6_addr32[1] | a->s6_addr32[2] | a->s6_addr32[3]);
   if (((a->s6_addr32[0] | trailer) == 0UL) || ((a->s6_addr32[0] == htonl(0xfe800000)) && (trailer == 0UL))) {
     return false;
@@ -227,7 +228,7 @@ static bool configuredGid(union ibv_gid* gid) {
 }
 
 static bool linkLocalGid(union ibv_gid* gid) {
-  const struct in6_addr *a = (struct in6_addr *)gid->raw;
+  const struct in6_addr* a = (struct in6_addr*)gid->raw;
   if (a->s6_addr32[0] == htonl(0xfe800000) && a->s6_addr32[1] == 0UL) {
     return true;
   }
@@ -239,9 +240,10 @@ static bool validGid(union ibv_gid* gid) {
 }
 
 static ncclResult_t ncclIbRoceGetVersionNum(const char* deviceName, int portNum, int gidIndex, int* version) {
-  char gidRoceVerStr[16] = { 0 };
-  char roceTypePath[PATH_MAX] = { 0 };
-  snprintf(roceTypePath, sizeof(roceTypePath), "/sys/class/infiniband/%s/ports/%d/gid_attrs/types/%d", deviceName, portNum, gidIndex);
+  char gidRoceVerStr[16] = {0};
+  char roceTypePath[PATH_MAX] = {0};
+  snprintf(roceTypePath, sizeof(roceTypePath), "/sys/class/infiniband/%s/ports/%d/gid_attrs/types/%d", deviceName,
+           portNum, gidIndex);
 
   int fd = open(roceTypePath, O_RDONLY);
   if (fd == -1) {
@@ -260,7 +262,8 @@ static ncclResult_t ncclIbRoceGetVersionNum(const char* deviceName, int portNum,
   }
 
   if (strlen(gidRoceVerStr)) {
-    if (strncmp(gidRoceVerStr, "IB/RoCE v1", strlen("IB/RoCE v1")) == 0 || strncmp(gidRoceVerStr, "RoCE v1", strlen("RoCE v1")) == 0) {
+    if (strncmp(gidRoceVerStr, "IB/RoCE v1", strlen("IB/RoCE v1")) == 0 ||
+        strncmp(gidRoceVerStr, "RoCE v1", strlen("RoCE v1")) == 0) {
       *version = 1;
     } else if (strncmp(gidRoceVerStr, "RoCE v2", strlen("RoCE v2")) == 0) {
       *version = 2;
@@ -270,7 +273,8 @@ static ncclResult_t ncclIbRoceGetVersionNum(const char* deviceName, int portNum,
   return ncclSuccess;
 }
 
-static ncclResult_t ncclUpdateGidIndex(struct ibv_context* context, uint8_t portNum, sa_family_t af, void* prefix, int prefixlen, int roceVer, int gidIndexCandidate, int* gidIndex) {
+static ncclResult_t ncclUpdateGidIndex(struct ibv_context* context, uint8_t portNum, sa_family_t af, void* prefix,
+                                       int prefixlen, int roceVer, int gidIndexCandidate, int* gidIndex) {
   union ibv_gid gid, gidCandidate;
   NCCLCHECK(wrap_ibv_query_gid(context, portNum, *gidIndex, &gid));
   NCCLCHECK(wrap_ibv_query_gid(context, portNum, gidIndexCandidate, &gidCandidate));
@@ -299,10 +303,11 @@ static ncclResult_t ncclUpdateGidIndex(struct ibv_context* context, uint8_t port
   return ncclSuccess;
 }
 
-ncclResult_t ncclIbGetGidIndex(struct ibv_context *context, uint8_t portNum, struct ibv_port_attr* portAttr, int *gidIndex) {
+ncclResult_t ncclIbGetGidIndex(struct ibv_context* context, uint8_t portNum, struct ibv_port_attr* portAttr,
+                               int* gidIndex) {
   int gidTblLen = portAttr->gid_tbl_len;
 
-  //for IB, choose GID Index that will have routable FLID if present
+  // for IB, choose GID Index that will have routable FLID if present
   if (portAttr->link_layer == IBV_LINK_LAYER_INFINIBAND) {
     union ibv_gid gid;
     int routableGidIndex = ncclParamIbRoutableFlidIbGidIndex();
@@ -317,7 +322,7 @@ ncclResult_t ncclIbGetGidIndex(struct ibv_context *context, uint8_t portNum, str
     return ncclSuccess;
   }
 
-  //for ROCE
+  // for ROCE
   *gidIndex = ncclParamIbGidIndex();
   if (*gidIndex >= 0) {
     return ncclSuccess;
@@ -326,11 +331,12 @@ ncclResult_t ncclIbGetGidIndex(struct ibv_context *context, uint8_t portNum, str
   sa_family_t userAddrFamily = envIbAddrFamily();
   int userRoceVersion = ncclParamIbRoceVersionNum();
   int prefixlen;
-  void *prefix = envIbAddrRange(userAddrFamily, &prefixlen);
+  void* prefix = envIbAddrRange(userAddrFamily, &prefixlen);
 
   *gidIndex = 0;
   for (int gidIndexNext = 1; gidIndexNext < gidTblLen; ++gidIndexNext) {
-    NCCLCHECK(ncclUpdateGidIndex(context, portNum, userAddrFamily, prefix, prefixlen, userRoceVersion, gidIndexNext, gidIndex));
+    NCCLCHECK(ncclUpdateGidIndex(context, portNum, userAddrFamily, prefix, prefixlen, userRoceVersion, gidIndexNext,
+                                 gidIndex));
   }
 
   return ncclSuccess;
@@ -351,7 +357,7 @@ static ncclResult_t ncclIbCreateQpMlx5(struct ncclIbQpCreateAttr* createQpAttrs,
   struct ibv_qp_init_attr_ex qpInitAttr;
   struct mlx5dv_qp_init_attr dvAttr;
   memset(&qpInitAttr, 0, sizeof(struct ibv_qp_init_attr_ex));
-  memset(&dvAttr, 0 , sizeof(struct mlx5dv_qp_init_attr));
+  memset(&dvAttr, 0, sizeof(struct mlx5dv_qp_init_attr));
   qpInitAttr.qp_context = createQpAttrs->qpContext;
   qpInitAttr.send_cq = createQpAttrs->cq;
   qpInitAttr.recv_cq = createQpAttrs->cq;
@@ -370,14 +376,17 @@ static ncclResult_t ncclIbCreateQpMlx5(struct ncclIbQpCreateAttr* createQpAttrs,
     dvAttr.comp_mask |= MLX5DV_QP_INIT_ATTR_MASK_QP_CREATE_FLAGS;
   }
   qp->qp = wrap_mlx5dv_create_qp(createQpAttrs->pd->context, &qpInitAttr, &dvAttr);
-  if (qp->qp == NULL) { WARN("NET/IB: %s: mlx5dv_create_qp failed to create QP: %m", __func__);  return ncclInternalError; }
+  if (qp->qp == NULL) {
+    WARN("NET/IB: %s: mlx5dv_create_qp failed to create QP: %m", __func__);
+    return ncclInternalError;
+  }
   return ncclSuccess;
 }
 
 ncclResult_t ncclIbQpCreate(struct ncclIbQp* qp, struct ncclIbQpCreateAttr* createQpAttrs) {
   if (createQpAttrs->oooRq) {
-     NCCLCHECK(ncclIbCreateQpMlx5(createQpAttrs, qp));
-     return ncclSuccess;
+    NCCLCHECK(ncclIbCreateQpMlx5(createQpAttrs, qp));
+    return ncclSuccess;
   }
   struct ibv_qp_init_attr qpInitAttr;
   memset(&qpInitAttr, 0, sizeof(struct ibv_qp_init_attr));
@@ -417,7 +426,7 @@ ncclResult_t ncclIbQpRtr(struct ncclIbQp* qp) {
     qpAttr.ah_attr.grh.hop_limit = 255;
     qpAttr.ah_attr.grh.traffic_class = rtrAttr->tc;
   } else {
-    //pick lid if subnet prefixs are same, FLID if they are not
+    // pick lid if subnet prefixs are same, FLID if they are not
     if (ncclIbExtractLocalSubnetPrefix(rtrAttr->localGid.global.subnet_prefix) ==
         ncclIbExtractLocalSubnetPrefix(rtrAttr->remoteGid.global.subnet_prefix)) {
       qpAttr.ah_attr.is_global = 0;
@@ -425,7 +434,8 @@ ncclResult_t ncclIbQpRtr(struct ncclIbQp* qp) {
     } else {
       uint16_t flid = ncclIbExtractFlid(&rtrAttr->remoteGid);
       if (flid == 0) {
-        WARN("Warning: remote FLID configured as zero even when endpoints are on different subnets, using dlid as fallback");
+        WARN("Warning: remote FLID configured as zero even when endpoints are on different subnets, using dlid as "
+             "fallback");
         qpAttr.ah_attr.dlid = rtrAttr->remoteLid;
       } else {
         qpAttr.ah_attr.dlid = ncclIbExtractFlid(&rtrAttr->remoteGid);
@@ -440,7 +450,9 @@ ncclResult_t ncclIbQpRtr(struct ncclIbQp* qp) {
   qpAttr.ah_attr.sl = rtrAttr->sl;
   qpAttr.ah_attr.src_path_bits = 0;
   qpAttr.ah_attr.port_num = rtrAttr->localIbPort;
-  TRACE(NCCL_NET, "NET/IB: %s: qpn=%u mtu=%d dst=%u ll=%u port=%u sl: %d tc: %d", __func__, qp->qp->qp_num, qpAttr.path_mtu, qpAttr.dest_qp_num, rtrAttr->linkLayer, qpAttr.ah_attr.port_num, qpAttr.ah_attr.sl, qpAttr.ah_attr.grh.traffic_class);
+  TRACE(NCCL_NET, "NET/IB: %s: qpn=%u mtu=%d dst=%u ll=%u port=%u sl: %d tc: %d", __func__, qp->qp->qp_num,
+        qpAttr.path_mtu, qpAttr.dest_qp_num, rtrAttr->linkLayer, qpAttr.ah_attr.port_num, qpAttr.ah_attr.sl,
+        qpAttr.ah_attr.grh.traffic_class);
   NCCLCHECK(wrap_ibv_modify_qp(qp->qp, &qpAttr, attrMask));
   return ncclSuccess;
 }
@@ -483,7 +495,7 @@ ncclResult_t ncclIbListen(void* ctx, int dev, void* opaqueHandle, void** listenC
   ncclResult_t ret = ncclSuccess;
   struct ncclIbListenComm* comm;
   NCCLCHECK(ncclCalloc(&comm, 1));
-  struct ncclIbHandle* handle = (struct ncclIbHandle*) opaqueHandle;
+  struct ncclIbHandle* handle = (struct ncclIbHandle*)opaqueHandle;
   static_assert(sizeof(struct ncclIbHandle) < NCCL_NET_HANDLE_MAXSIZE, "ncclIbHandle size too large");
   memset(handle, 0, sizeof(struct ncclIbHandle));
   comm->dev = dev;
@@ -517,7 +529,7 @@ static ncclResult_t ncclIbSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbCon
   qpCreateAttrs.type = IBV_QPT_RC;
   qpCreateAttrs.maxRecvWorkRequest = 0;
   // Send requests are sent using at most 2 messages (RDMA Write and RDMA Write with Immediate)
-  qpCreateAttrs.maxSendWorkRequest = 2*NET_IB_MAX_REQUESTS;
+  qpCreateAttrs.maxSendWorkRequest = 2 * NET_IB_MAX_REQUESTS;
   for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
     // The QPs are created in a "striped" manner across the available devices.
     // For example, if there are 2 devices and 4 QPs, the QPs will be created
@@ -536,33 +548,28 @@ static ncclResult_t ncclIbSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbCon
 
     if (ibDev->ibProvider == IB_PROVIDER_MLX5 && ncclParamIbOooRq()) {
       if (ibDev->ar == 0) {
-        WARN("NET/IB: %s: OOO RQ is force enabled but AR is not enabled, which is required for OOO RQ (device=%s)", __func__, ibDev->devName);
+        WARN("NET/IB: %s: OOO RQ is force enabled but AR is not enabled, which is required for OOO RQ (device=%s)",
+             __func__, ibDev->devName);
         return ncclInternalError;
       }
       qpCreateAttrs.oooRq = (comm->base.remOooRq && comm->base.localOooRq);
       if (!qpCreateAttrs.oooRq) {
-        WARN("NET/IB: %s: OOO RQ is force enabled but not supported on both sides of the connection (device=%s, localOooRq=%d, remOooRq=%d)",
-          __func__, ibDev->devName, comm->base.localOooRq, comm->base.remOooRq);
+        WARN("NET/IB: %s: OOO RQ is force enabled but not supported on both sides of the connection (device=%s, "
+             "localOooRq=%d, remOooRq=%d)",
+             __func__, ibDev->devName, comm->base.localOooRq, comm->base.remOooRq);
         return ncclInternalError;
       }
     }
 
     NCCLCHECK(ncclIbQpCreate(localQp, &qpCreateAttrs));
-    INFO(NCCL_NET, "NET/IB: %s: QP created: port=%d dev=%d devName=%s ndevs=%d nmdevs=%d qp_num=%u pkey=%u pd=%p oooRq=%d",
-        __func__,
-        ibDev->portNum,
-        commDev->base.ibDevN,
-        ncclIbDevs[commDev->base.ibDevN].devName,
-        ncclNIbDevs,
-        ncclNMergedIbDevs,
-        localQp->qp->qp_num,
-        (uint16_t)ncclParamIbPkey(),
-        commDev->base.pd,
-        qpCreateAttrs.oooRq);
+    INFO(NCCL_NET,
+         "NET/IB: %s: QP created: port=%d dev=%d devName=%s ndevs=%d nmdevs=%d qp_num=%u pkey=%u pd=%p oooRq=%d",
+         __func__, ibDev->portNum, commDev->base.ibDevN, ncclIbDevs[commDev->base.ibDevN].devName, ncclNIbDevs,
+         ncclNMergedIbDevs, localQp->qp->qp_num, (uint16_t)ncclParamIbPkey(), commDev->base.pd, qpCreateAttrs.oooRq);
     localQp->devIndex = devIndex;
 
     // Populate the metadata that will be delivered to the remote peer
-    localQpInfo->qpn      = localQp->qp->qp_num;
+    localQpInfo->qpn = localQp->qp->qp_num;
     localQpInfo->devIndex = localQp->devIndex;
 
     // Transition the QP to INIT state
@@ -608,13 +615,17 @@ static ncclResult_t ncclIbSenderQpsToRts(ncclIbSendComm* comm, struct ncclIbConn
     ncclIbQp* localQp = &comm->base.qps[qpIndex];
     ncclIbSendCommDev* commDev = &comm->devs[localQp->devIndex];
     ncclIbDev* ibDev = &ncclIbDevs[commDev->base.ibDevN];
-    ncclIbQpInfo* remQpInfo   = &remMeta->qpInfo[qpIndex];
+    ncclIbQpInfo* remQpInfo = &remMeta->qpInfo[qpIndex];
     ncclIbDevInfo* remDevInfo = &remMeta->devs[remQpInfo->devIndex];
 
     localQp->remDevIdx = remQpInfo->devIndex;
 
     if (localQp->eceSupported && remQpInfo->ece_supported) {
-      INFO(NCCL_NET,"NET/IB: %s: Set ECE: IbDev %d Port %d qp_num %d set_ece={supported=%d, vendor_id=0x%x, options=0x%x, comp_mask=0x%x}", __func__, commDev->base.ibDevN, ibDev->portNum, localQp->qp->qp_num, remQpInfo->ece_supported, remQpInfo->ece.vendor_id, remQpInfo->ece.options, remQpInfo->ece.comp_mask);
+      INFO(NCCL_NET,
+           "NET/IB: %s: Set ECE: IbDev %d Port %d qp_num %d set_ece={supported=%d, vendor_id=0x%x, options=0x%x, "
+           "comp_mask=0x%x}",
+           __func__, commDev->base.ibDevN, ibDev->portNum, localQp->qp->qp_num, remQpInfo->ece_supported,
+           remQpInfo->ece.vendor_id, remQpInfo->ece.options, remQpInfo->ece.comp_mask);
       // Set the reduced ECE received from the receiver side
       NCCLCHECK(wrap_ibv_set_ece(localQp->qp, &remQpInfo->ece, &localQp->eceSupported));
       // Store the reduced ECE locally as well
@@ -625,7 +636,7 @@ static ncclResult_t ncclIbSenderQpsToRts(ncclIbSendComm* comm, struct ncclIbConn
       localQp->ece = {0};
     }
 
-    struct ncclIbQpRtrAttr *rtrAttr = &localQp->rtrAttr;
+    struct ncclIbQpRtrAttr* rtrAttr = &localQp->rtrAttr;
     rtrAttr->mtu = std::min(remDevInfo->mtu, ibDev->portAttr.active_mtu);
     rtrAttr->linkLayer = remDevInfo->link_layer;
     rtrAttr->tc = remDevInfo->link_layer == IBV_LINK_LAYER_ETHERNET ? remMeta->tc : -1;
@@ -660,9 +671,10 @@ void ncclIbSetTrafficClass(void* ctx, int trafficClass) {
   if (config) config->trafficClass = trafficClass;
 }
 
-ncclResult_t ncclIbConnect(void* ctx, int dev, void* opaqueHandle, void** sendComm, ncclNetDeviceHandle_t** /*sendDevComm*/) {
+ncclResult_t ncclIbConnect(void* ctx, int dev, void* opaqueHandle, void** sendComm,
+                           ncclNetDeviceHandle_t** /*sendDevComm*/) {
   ncclResult_t ret = ncclSuccess;
-  struct ncclIbHandle* handle = (struct ncclIbHandle*) opaqueHandle;
+  struct ncclIbHandle* handle = (struct ncclIbHandle*)opaqueHandle;
   struct ncclIbCommStage* stage = &handle->stage;
   struct ncclIbSendComm* comm = (struct ncclIbSendComm*)stage->comm;
   int ready;
@@ -670,12 +682,12 @@ ncclResult_t ncclIbConnect(void* ctx, int dev, void* opaqueHandle, void** sendCo
   uint8_t link_layer = IBV_LINK_LAYER_UNSPECIFIED;
   *sendComm = NULL;
 
-  if (stage->state == ncclIbCommStateConnect)      goto ib_connect_check;
-  if (stage->state == ncclIbCommStateSendDevList)  goto ib_send_dev_list;
-  if (stage->state == ncclIbCommStateRecvDevList)  goto ib_recv_dev_list;
-  if (stage->state == ncclIbCommStateSend)         goto ib_send;
-  if (stage->state == ncclIbCommStateConnecting)   goto ib_connect;
-  if (stage->state == ncclIbCommStateConnected)    goto ib_send_ready;
+  if (stage->state == ncclIbCommStateConnect) goto ib_connect_check;
+  if (stage->state == ncclIbCommStateSendDevList) goto ib_send_dev_list;
+  if (stage->state == ncclIbCommStateRecvDevList) goto ib_recv_dev_list;
+  if (stage->state == ncclIbCommStateSend) goto ib_send;
+  if (stage->state == ncclIbCommStateConnecting) goto ib_connect;
+  if (stage->state == ncclIbCommStateConnected) goto ib_send_ready;
   if (stage->state != ncclIbCommStateStart) {
     WARN("Error: trying to connect already connected sendComm");
     return ncclInternalError;
@@ -685,7 +697,8 @@ ncclResult_t ncclIbConnect(void* ctx, int dev, void* opaqueHandle, void** sendCo
   NCCLCHECK(ncclIbMalloc((void**)&comm, sizeof(struct ncclIbSendComm)));
   NCCLCHECKGOTO(ncclIbSendCommInit(comm), ret, fail);
   NCCLCHECKGOTO(ncclIbStatsInit(&comm->base.stats), ret, fail);
-  NCCLCHECKGOTO(ncclSocketInit(&comm->base.sock, &handle->connectAddr, handle->magic, ncclSocketTypeNetIb, NULL, 1), ret, fail);
+  NCCLCHECKGOTO(ncclSocketInit(&comm->base.sock, &handle->connectAddr, handle->magic, ncclSocketTypeNetIb, NULL, 1),
+                ret, fail);
   stage->comm = comm;
   stage->state = ncclIbCommStateConnect;
   NCCLCHECKGOTO(ncclSocketConnect(&comm->base.sock), ret, fail);
@@ -717,24 +730,26 @@ ib_connect_check:
     exProps.oooRq = exProps.oooRq && ncclIbDevs[ibDevN].oooRqSize;
   }
   comm->base.localOooRq = exProps.oooRq;
-  memcpy((char *)stage->buffer + sizeof(ncclNetVDeviceProps_t), &exProps, sizeof(struct ncclIbDevExtraProps));
+  memcpy((char*)stage->buffer + sizeof(ncclNetVDeviceProps_t), &exProps, sizeof(struct ncclIbDevExtraProps));
 
 // In the case of mismatched nDevs, we will make sure that both sides of a logical connection have the same number of RC qps
 ib_send_dev_list:
-  NCCLCHECK(ncclSocketProgress(NCCL_SOCKET_SEND, &comm->base.sock, stage->buffer, sizeof(ncclNetVDeviceProps_t) + sizeof(struct ncclIbDevExtraProps), &stage->offset));
+  NCCLCHECK(ncclSocketProgress(NCCL_SOCKET_SEND, &comm->base.sock, stage->buffer,
+                               sizeof(ncclNetVDeviceProps_t) + sizeof(struct ncclIbDevExtraProps), &stage->offset));
   if (stage->offset != (sizeof(ncclNetVDeviceProps_t) + sizeof(struct ncclIbDevExtraProps))) return ncclSuccess;
 
   stage->state = ncclIbCommStateRecvDevList;
   stage->offset = 0;
 
 ib_recv_dev_list:
-  NCCLCHECK(ncclSocketProgress(NCCL_SOCKET_RECV, &comm->base.sock, stage->buffer, sizeof(ncclNetVDeviceProps_t) + sizeof(struct ncclIbDevExtraProps), &stage->offset));
+  NCCLCHECK(ncclSocketProgress(NCCL_SOCKET_RECV, &comm->base.sock, stage->buffer,
+                               sizeof(ncclNetVDeviceProps_t) + sizeof(struct ncclIbDevExtraProps), &stage->offset));
   if (stage->offset != (sizeof(ncclNetVDeviceProps_t) + sizeof(struct ncclIbDevExtraProps))) return ncclSuccess;
   stage->offset = 0;
   ncclNetVDeviceProps_t remoteVProps;
   int trafficClass;
   memcpy(&remoteVProps, stage->buffer, sizeof(ncclNetVDeviceProps_t));
-  memcpy(&exProps, (char *)stage->buffer + sizeof(ncclNetVDeviceProps_t), sizeof(exProps));
+  memcpy(&exProps, (char*)stage->buffer + sizeof(ncclNetVDeviceProps_t), sizeof(exProps));
   comm->base.remOooRq = exProps.oooRq;
 
   mergedDev = ncclIbMergedDevs + dev;
@@ -742,8 +757,7 @@ ib_recv_dev_list:
   // Read isP2p from handle
   isP2p = handle->isP2p;
   INFO(NCCL_NET, "NET/IB: ncclIbConnect isP2p=%d", isP2p);
-  comm->base.nqps = ncclIbCalculateNqps(isP2p, comm->base.vProps.ndevs,
-                                         remoteVProps.ndevs, __func__);
+  comm->base.nqps = ncclIbCalculateNqps(isP2p, comm->base.vProps.ndevs, remoteVProps.ndevs, __func__);
 
   comm->base.nDataQps = std::max(comm->base.vProps.ndevs, remoteVProps.ndevs);
 
@@ -756,7 +770,7 @@ ib_recv_dev_list:
   // Sender's CQ size needs to accomodate the upper bound of number of send
   // requests multiplied by the number of QPs used per request.
   int cqSize;
-  cqSize = NET_IB_MAX_REQUESTS*ncclParamIbQpsPerConn();
+  cqSize = NET_IB_MAX_REQUESTS * ncclParamIbQpsPerConn();
   for (int i = 0; i < comm->base.vProps.ndevs; i++) {
     int ibDevN = comm->base.vProps.devs[i];
     if (comm->base.resiliency) {
@@ -782,21 +796,29 @@ ib_recv_dev_list:
 
     // Write to the metadata struct via this pointer
     ncclIbDevInfo* devInfo = meta.devs + i;
-    devInfo->ib_port       = ibDev->portNum;
-    devInfo->mtu           = ibDev->portAttr.active_mtu;
-    devInfo->lid           = ibDev->portAttr.lid;
+    devInfo->ib_port = ibDev->portNum;
+    devInfo->mtu = ibDev->portAttr.active_mtu;
+    devInfo->lid = ibDev->portAttr.lid;
 
     // Prepare GIN Put Signal scratchpad (for RDMA Atomic result)
-    NCCLCHECKGOTO(wrap_ibv_reg_mr(&commDev->putSignalScratchpadMr, commDev->base.pd, &comm->putSignalScratchpad, sizeof(comm->putSignalScratchpad), IBV_ACCESS_LOCAL_WRITE), ret, fail);
+    NCCLCHECKGOTO(wrap_ibv_reg_mr(&commDev->putSignalScratchpadMr, commDev->base.pd, &comm->putSignalScratchpad,
+                                  sizeof(comm->putSignalScratchpad), IBV_ACCESS_LOCAL_WRITE),
+                  ret, fail);
 
     // Prepare my CTS FIFO
-    NCCLCHECKGOTO(wrap_ibv_reg_mr(&commDev->ctsFifoMr, commDev->base.pd, comm->ctsFifo, sizeof(comm->ctsFifo), IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
+    NCCLCHECKGOTO(wrap_ibv_reg_mr(&commDev->ctsFifoMr, commDev->base.pd, comm->ctsFifo, sizeof(comm->ctsFifo),
+                                  IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ),
+                  ret, fail);
     devInfo->rkey = commDev->ctsFifoMr->rkey;
 
     // Pack local GID info
     devInfo->link_layer = commDev->base.gidInfo.link_layer = ibDev->portAttr.link_layer;
-    NCCLCHECKGOTO(ncclIbGetGidIndex(ibDev->context, ibDev->portNum, &ibDev->portAttr, &commDev->base.gidInfo.localGidIndex), ret, fail);
-    NCCLCHECKGOTO(wrap_ibv_query_gid(ibDev->context, ibDev->portNum, commDev->base.gidInfo.localGidIndex, &commDev->base.gidInfo.localGid), ret, fail);
+    NCCLCHECKGOTO(ncclIbGetGidIndex(ibDev->context, ibDev->portNum, &ibDev->portAttr,
+                                    &commDev->base.gidInfo.localGidIndex),
+                  ret, fail);
+    NCCLCHECKGOTO(wrap_ibv_query_gid(ibDev->context, ibDev->portNum, commDev->base.gidInfo.localGidIndex,
+                                     &commDev->base.gidInfo.localGid),
+                  ret, fail);
     devInfo->gid.global.subnet_prefix = commDev->base.gidInfo.localGid.global.subnet_prefix;
     devInfo->gid.global.interface_id = commDev->base.gidInfo.localGid.global.interface_id;
 
@@ -805,37 +827,49 @@ ib_recv_dev_list:
       // Print just the QPs for this dev
       if (comm->base.qps[q].devIndex == i) {
         if (devInfo->link_layer == IBV_LINK_LAYER_INFINIBAND) { // IB
-          INFO(NCCL_NET,"NET/IB: %s: %s %d IbDev %d Port %d qp_num %d mtu %d LID %d subnet-prefix %lu  FLID %d ctsFifoRkey=0x%x ctsFifoLkey=0x%x", __func__,
-               comm->base.vProps.ndevs > 2 ? "NCCL MergedDev" : "NCCL Dev",
-               dev, commDev->base.ibDevN, ibDev->portNum, meta.qpInfo[q].qpn, devInfo->mtu, devInfo->lid,
-               devInfo->gid.global.subnet_prefix, ncclIbExtractFlid(&devInfo->gid), commDev->ctsFifoMr->rkey, commDev->ctsFifoMr->lkey);
+          INFO(NCCL_NET,
+               "NET/IB: %s: %s %d IbDev %d Port %d qp_num %d mtu %d LID %d subnet-prefix %lu  FLID %d ctsFifoRkey=0x%x "
+               "ctsFifoLkey=0x%x",
+               __func__, comm->base.vProps.ndevs > 2 ? "NCCL MergedDev" : "NCCL Dev", dev, commDev->base.ibDevN,
+               ibDev->portNum, meta.qpInfo[q].qpn, devInfo->mtu, devInfo->lid, devInfo->gid.global.subnet_prefix,
+               ncclIbExtractFlid(&devInfo->gid), commDev->ctsFifoMr->rkey, commDev->ctsFifoMr->lkey);
         } else { // RoCE
-          INFO(NCCL_NET,"NET/IB: %s: %s %d IbDev %d Port %d qp_num %d mtu %d GID %ld (%lX/%lX) ctsFifoRkey=0x%x ctsFifoLkey=0x%x", __func__,
-               comm->base.vProps.ndevs > 2 ? "NCCL MergedDev" : "NCCL Dev", dev,
-               commDev->base.ibDevN, ibDev->portNum, meta.qpInfo[q].qpn, devInfo->mtu,
-               (int64_t)commDev->base.gidInfo.localGidIndex,
-               devInfo->gid.global.subnet_prefix, devInfo->gid.global.interface_id, commDev->ctsFifoMr->rkey, commDev->ctsFifoMr->lkey);
+          INFO(
+            NCCL_NET,
+            "NET/IB: %s: %s %d IbDev %d Port %d qp_num %d mtu %d GID %ld (%lX/%lX) ctsFifoRkey=0x%x ctsFifoLkey=0x%x",
+            __func__, comm->base.vProps.ndevs > 2 ? "NCCL MergedDev" : "NCCL Dev", dev, commDev->base.ibDevN,
+            ibDev->portNum, meta.qpInfo[q].qpn, devInfo->mtu, (int64_t)commDev->base.gidInfo.localGidIndex,
+            devInfo->gid.global.subnet_prefix, devInfo->gid.global.interface_id, commDev->ctsFifoMr->rkey,
+            commDev->ctsFifoMr->lkey);
         }
         // Log ECE info
         if (meta.qpInfo[q].ece_supported) {
-          INFO(NCCL_NET,"NET/IB: %s: IbDev %d Port %d qp_num %d query_ece={supported=%d, vendor_id=0x%x, options=0x%x, comp_mask=0x%x}", __func__,
-               commDev->base.ibDevN, ibDev->portNum, meta.qpInfo[q].qpn,
-               meta.qpInfo[q].ece_supported, meta.qpInfo[q].ece.vendor_id, meta.qpInfo[q].ece.options, meta.qpInfo[q].ece.comp_mask);
+          INFO(NCCL_NET,
+               "NET/IB: %s: IbDev %d Port %d qp_num %d query_ece={supported=%d, vendor_id=0x%x, options=0x%x, "
+               "comp_mask=0x%x}",
+               __func__, commDev->base.ibDevN, ibDev->portNum, meta.qpInfo[q].qpn, meta.qpInfo[q].ece_supported,
+               meta.qpInfo[q].ece.vendor_id, meta.qpInfo[q].ece.options, meta.qpInfo[q].ece.comp_mask);
         }
       }
     }
     if (link_layer == IBV_LINK_LAYER_UNSPECIFIED) link_layer = devInfo->link_layer;
     if (link_layer != devInfo->link_layer) {
       int ibDev0 = comm->devs[0].base.ibDevN;
-      WARN("NET/IB : Attempted to connect incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of only one link type using NCCL_IB_HCA",
-           commDev->base.ibDevN, ibDev->devName, ibDev->portNum, NCCL_IB_LLSTR(ibDev->portAttr.link_layer), ibDev0, ncclIbDevs[ibDev0].devName, ncclIbDevs[ibDev0].portNum, NCCL_IB_LLSTR(link_layer));
+      WARN("NET/IB : Attempted to connect incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of "
+           "only one link type using NCCL_IB_HCA",
+           commDev->base.ibDevN, ibDev->devName, ibDev->portNum, NCCL_IB_LLSTR(ibDev->portAttr.link_layer), ibDev0,
+           ncclIbDevs[ibDev0].devName, ncclIbDevs[ibDev0].portNum, NCCL_IB_LLSTR(link_layer));
       return ncclInternalError;
     }
   }
   trafficClass = ncclIbGetTrafficClass(ctx);
   meta.addr = (uint64_t)comm->ctsFifo;
-  meta.sl = (ncclParamIbSl() != -1) ? ncclParamIbSl() : (trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? trafficClass : NCCL_IB_SL_DEFAULT;
-  meta.tc = (ncclParamIbTc() != -1) ? ncclParamIbTc() : (trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? trafficClass : NCCL_IB_TC_DEFAULT;
+  meta.sl = (ncclParamIbSl() != -1)                        ? ncclParamIbSl() :
+            (trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? trafficClass :
+                                                             NCCL_IB_SL_DEFAULT;
+  meta.tc = (ncclParamIbTc() != -1)                        ? ncclParamIbTc() :
+            (trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? trafficClass :
+                                                             NCCL_IB_TC_DEFAULT;
   strncpy(meta.devName, mergedDev->devName, MAX_MERGED_DEV_NAME);
 
   stage->state = ncclIbCommStateSend;
@@ -844,7 +878,8 @@ ib_recv_dev_list:
   memcpy(stage->buffer, &meta, sizeof(meta));
 
 ib_send:
-  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_SEND, &comm->base.sock, stage->buffer, sizeof(meta), &stage->offset), ret, fail);
+  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_SEND, &comm->base.sock, stage->buffer, sizeof(meta), &stage->offset),
+                ret, fail);
   if (stage->offset != sizeof(meta)) return ncclSuccess;
 
   stage->state = ncclIbCommStateConnecting;
@@ -854,7 +889,9 @@ ib_send:
 
 ib_connect:
   struct ncclIbConnectionMetadata remMeta;
-  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_RECV, &comm->base.sock, stage->buffer, sizeof(ncclIbConnectionMetadata), &stage->offset), ret, fail);
+  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_RECV, &comm->base.sock, stage->buffer, sizeof(ncclIbConnectionMetadata),
+                                   &stage->offset),
+                ret, fail);
   if (stage->offset != sizeof(remMeta)) return ncclSuccess;
 
   memcpy(&remMeta, stage->buffer, sizeof(ncclIbConnectionMetadata));
@@ -865,8 +902,10 @@ ib_connect:
     link_layer = ncclIbDevs[ibDev0].portAttr.link_layer;
     for (int i = 0; i < remMeta.ndevs; i++) {
       if (remMeta.devs[i].link_layer != link_layer) {
-        WARN("NET/IB : Remote %s device is incompatible with the local [%d]%s:%d/%s. Try selecting NICs of only one link type using NCCL_IB_HCA",
-             NCCL_IB_LLSTR(remMeta.devs[i].link_layer), ibDev0, ncclIbDevs[ibDev0].devName, ncclIbDevs[ibDev0].portNum, NCCL_IB_LLSTR(link_layer));
+        WARN("NET/IB : Remote %s device is incompatible with the local [%d]%s:%d/%s. Try selecting NICs of only one "
+             "link type using NCCL_IB_HCA",
+             NCCL_IB_LLSTR(remMeta.devs[i].link_layer), ibDev0, ncclIbDevs[ibDev0].devName, ncclIbDevs[ibDev0].portNum,
+             NCCL_IB_LLSTR(link_layer));
         return ncclInternalError;
       }
     }
@@ -887,13 +926,18 @@ ib_connect:
   for (int i = 0; i < comm->base.nRemDevs; i++) {
     comm->remCmplsRecords.rkeys[i] = remMeta.devs[i].rkey;
     if (comm->base.resiliency) {
-      NCCLCHECKGOTO(ncclIbResiliencyRemoteCompletionRecordsSet(comm->base.resiliency, comm->remCmplsRecords.rkeys[i], comm->remCmplsRecords.addr, i), ret, fail);
+      NCCLCHECKGOTO(ncclIbResiliencyRemoteCompletionRecordsSet(comm->base.resiliency, comm->remCmplsRecords.rkeys[i],
+                                                               comm->remCmplsRecords.addr, i),
+                    ret, fail);
     }
   }
 
-  for (int i=0; i < comm->base.vProps.ndevs; i++) {
+  for (int i = 0; i < comm->base.vProps.ndevs; i++) {
     ncclIbSendCommDev* commDev = comm->devs + i;
-    NCCLCHECKGOTO(wrap_ibv_reg_mr(&commDev->cmplsRecordsMr, comm->devs[i].base.pd, &comm->remCmplsRecords.elems, sizeof(comm->remCmplsRecords.elems), IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
+    NCCLCHECKGOTO(wrap_ibv_reg_mr(&commDev->cmplsRecordsMr, comm->devs[i].base.pd, &comm->remCmplsRecords.elems,
+                                  sizeof(comm->remCmplsRecords.elems),
+                                  IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ),
+                  ret, fail);
     comm->devs[i].sge.lkey = comm->devs[i].cmplsRecordsMr->lkey;
   }
 
@@ -904,7 +948,8 @@ ib_connect:
   stage->offset = 0;
 
 ib_send_ready:
-  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_SEND, &comm->base.sock, &comm->base.ready, sizeof(int), &stage->offset), ret, fail);
+  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_SEND, &comm->base.sock, &comm->base.ready, sizeof(int), &stage->offset),
+                ret, fail);
   if (stage->offset != sizeof(int)) return ncclSuccess;
 
   *sendComm = comm;
@@ -920,7 +965,7 @@ fail:
 NCCL_PARAM(IbWarnRailLocal, "IB_WARN_RAIL_LOCAL", 0);
 
 ncclResult_t ncclIbCheckVProps(ncclNetVDeviceProps_t* vProps1, ncclNetVDeviceProps_t* vProps2) {
-  ncclNetVDeviceProps_t  outVProps = {0};
+  ncclNetVDeviceProps_t outVProps = {0};
   ncclNetVDeviceProps_t* minVProps = vProps2;
   ncclNetVDeviceProps_t* maxVProps = vProps1;
   if (vProps2->ndevs > vProps1->ndevs) {
@@ -945,17 +990,20 @@ ncclResult_t ncclIbCheckVProps(ncclNetVDeviceProps_t* vProps1, ncclNetVDevicePro
     int cursor = 1;
     snprintf(local, sizeof(local), "%d", vProps1->devs[0]);
     for (int i = 1; i < vProps1->ndevs; i++) {
-      snprintf(local+cursor, sizeof(local)-cursor, ",%d", vProps1->devs[i]);
+      snprintf(local + cursor, sizeof(local) - cursor, ",%d", vProps1->devs[i]);
       cursor += 2;
     }
     char remote[128];
     snprintf(remote, sizeof(remote), "%d", vProps2->devs[0]);
     cursor = 1;
     for (int i = 1; i < vProps2->ndevs; i++) {
-      snprintf(remote+cursor, sizeof(remote)-cursor, ",%d", vProps2->devs[i]);
+      snprintf(remote + cursor, sizeof(remote) - cursor, ",%d", vProps2->devs[i]);
       cursor += 2;
     }
-    INFO(NCCL_NET, "NET/IB : There are mismatched physical devices between local (%s) and remote (%s). To disable this warning, set NCCL_IB_WARN_RAIL_LOCAL=0", local, remote);
+    INFO(NCCL_NET,
+         "NET/IB : There are mismatched physical devices between local (%s) and remote (%s). To disable this warning, "
+         "set NCCL_IB_WARN_RAIL_LOCAL=0",
+         local, remote);
   }
 
   return ncclSuccess;
@@ -966,7 +1014,8 @@ ncclResult_t ncclIbCheckVProps(ncclNetVDeviceProps_t* vProps1, ncclNetVDevicePro
 // the remote metadata structure, provided to the function (remMeta), with the
 // QPs' information so that data structure could be delivered to the remote
 // side (sender) as part of the connection establishment process.
-static ncclResult_t ncclIbReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct ncclIbConnectionMetadata* remMeta, struct ncclIbConnectionMetadata* meta) {
+static ncclResult_t ncclIbReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct ncclIbConnectionMetadata* remMeta,
+                                                 struct ncclIbConnectionMetadata* meta) {
   uint nqps = rComm->base.nqps;
   struct ncclIbQpCreateAttr qpCreateAttrs;
   memset(&qpCreateAttrs, 0, sizeof(struct ncclIbQpCreateAttr));
@@ -1004,37 +1053,33 @@ static ncclResult_t ncclIbReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
     }
     if (ibDev->ibProvider == IB_PROVIDER_MLX5 && ncclParamIbOooRq()) {
       if (ibDev->ar == 0) {
-        WARN("NET/IB: %s: OOO RQ is force enabled but AR is not enabled, which is required for OOO RQ (device=%s)", __func__, ibDev->devName);
+        WARN("NET/IB: %s: OOO RQ is force enabled but AR is not enabled, which is required for OOO RQ (device=%s)",
+             __func__, ibDev->devName);
         return ncclInternalError;
       }
       qpCreateAttrs.oooRq = (rComm->base.remOooRq && rComm->base.localOooRq);
       // out-of-order recv prerequisite: oooRq is supported on both sides
       if (!qpCreateAttrs.oooRq) {
-        WARN("NET/IB: %s: OOO RQ is force enabled but not supported on both sides of the connection (device=%s, localOooRq=%d, remOooRq=%d)",
-          __func__, ibDev->devName, rComm->base.localOooRq, rComm->base.remOooRq);
+        WARN("NET/IB: %s: OOO RQ is force enabled but not supported on both sides of the connection (device=%s, "
+             "localOooRq=%d, remOooRq=%d)",
+             __func__, ibDev->devName, rComm->base.localOooRq, rComm->base.remOooRq);
         return ncclInternalError;
       }
       // out-of-order recv prerequisite: oooRq size requirements are met
       if (ibDev->oooRqSize < qpCreateAttrs.maxRecvWorkRequest) {
-        WARN("NET/IB: %s: OOO RQ is force enabled but size %u is less than the required recv work request size %u on device:%s",
-          __func__, ibDev->oooRqSize, qpCreateAttrs.maxRecvWorkRequest, ibDev->devName);
+        WARN("NET/IB: %s: OOO RQ is force enabled but size %u is less than the required recv work request size %u on "
+             "device:%s",
+             __func__, ibDev->oooRqSize, qpCreateAttrs.maxRecvWorkRequest, ibDev->devName);
         return ncclInternalError;
       }
     }
     NCCLCHECK(ncclIbQpCreate(localQp, &qpCreateAttrs));
-    INFO(NCCL_NET, "NET/IB: %s: QP created: port=%d dev=%d devName=%s ndevs=%d nmdevs=%d qp_num=%u pkey=%u pd=%p oooRq=%d",
-        __func__,
-        ibDev->portNum,
-        rCommDev->base.ibDevN,
-        ncclIbDevs[rCommDev->base.ibDevN].devName,
-        ncclNIbDevs,
-        ncclNMergedIbDevs,
-        localQp->qp->qp_num,
-        (uint16_t)ncclParamIbPkey(),
-        rCommDev->base.pd,
-        qpCreateAttrs.oooRq);
+    INFO(NCCL_NET,
+         "NET/IB: %s: QP created: port=%d dev=%d devName=%s ndevs=%d nmdevs=%d qp_num=%u pkey=%u pd=%p oooRq=%d",
+         __func__, ibDev->portNum, rCommDev->base.ibDevN, ncclIbDevs[rCommDev->base.ibDevN].devName, ncclNIbDevs,
+         ncclNMergedIbDevs, localQp->qp->qp_num, (uint16_t)ncclParamIbPkey(), rCommDev->base.pd, qpCreateAttrs.oooRq);
 
-    localQpInfo->qpn      = localQp->qp->qp_num;
+    localQpInfo->qpn = localQp->qp->qp_num;
     localQpInfo->devIndex = localQp->devIndex;
 
     // Transition the QP to INIT state
@@ -1059,10 +1104,12 @@ static ncclResult_t ncclIbReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
     // Reduce the local MTU to match the remote MTU if needed
     ibDev->portAttr.active_mtu = std::min(ibDev->portAttr.active_mtu, remDevInfo->mtu);
 
-    struct ncclIbQpRtrAttr *rtrAttr = &localQp->rtrAttr;
+    struct ncclIbQpRtrAttr* rtrAttr = &localQp->rtrAttr;
     rtrAttr->mtu = ibDev->portAttr.active_mtu;
     rtrAttr->linkLayer = remDevInfo->link_layer;
-    rtrAttr->tc = (remDevInfo->link_layer == IBV_LINK_LAYER_ETHERNET && ncclParamIbFifoTc() != -1) ? ncclParamIbFifoTc() : remMeta->tc;
+    rtrAttr->tc = (remDevInfo->link_layer == IBV_LINK_LAYER_ETHERNET && ncclParamIbFifoTc() != -1) ?
+                    ncclParamIbFifoTc() :
+                    remMeta->tc;
     rtrAttr->sl = remMeta->sl;
     rtrAttr->remoteQpNum = remQpInfo->qpn;
     rtrAttr->remoteLid = remDevInfo->lid;
@@ -1103,16 +1150,10 @@ static ncclResult_t ncclIbReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
       qpCreateAttrs.maxSendWorkRequest = NET_IB_MAX_REQUESTS;
       qpCreateAttrs.qpContext = &rComm->base.stats;
       NCCLCHECK(ncclIbQpCreate(&rCommDev->gpuFlush.qp, &qpCreateAttrs));
-      INFO(NCCL_NET, "NET/IB: %s: Flush QP created: port=%d dev=%d devName=%s ndevs=%d nmdevs=%d qp_num=%u pkey=%u pd=%p",
-          __func__,
-          ibDev->portNum,
-          rCommDev->base.ibDevN,
-          ncclIbDevs[rCommDev->base.ibDevN].devName,
-          ncclNIbDevs,
-          ncclNMergedIbDevs,
-          rCommDev->gpuFlush.qp.qp->qp_num,
-          (uint16_t)ncclParamIbPkey(),
-          rCommDev->base.pd);
+      INFO(NCCL_NET,
+           "NET/IB: %s: Flush QP created: port=%d dev=%d devName=%s ndevs=%d nmdevs=%d qp_num=%u pkey=%u pd=%p",
+           __func__, ibDev->portNum, rCommDev->base.ibDevN, ncclIbDevs[rCommDev->base.ibDevN].devName, ncclNIbDevs,
+           ncclNMergedIbDevs, rCommDev->gpuFlush.qp.qp->qp_num, (uint16_t)ncclParamIbPkey(), rCommDev->base.pd);
 
       ncclIbQp* flushQp = &rCommDev->gpuFlush.qp;
 
@@ -1124,7 +1165,7 @@ static ncclResult_t ncclIbReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
       initAttr->qpAccessFlags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ;
       NCCLCHECK(ncclIbQpInit(flushQp));
 
-      struct ncclIbQpRtrAttr *rtrAttr = &flushQp->rtrAttr;
+      struct ncclIbQpRtrAttr* rtrAttr = &flushQp->rtrAttr;
       rtrAttr->mtu = ibDev->portAttr.active_mtu;
       rtrAttr->linkLayer = ibDev->portAttr.link_layer;
       // TODO: Flush QP is a "loopback QP" (connected to itself), so it should
@@ -1157,7 +1198,8 @@ ncclResult_t ncclIbPostReceiveWorkRequestsOnQp(struct ncclIbRecvComm* recvComm, 
   if (recvComm->base.resiliency) {
     ncclIbResiliencyDataRqSizeGet(recvComm->base.resiliency, dataQp->devIndex, &nRecvWorkRequestsPerQp);
   }
-  INFO(NCCL_NET, "NET/IB: %s: Pre-posting %d Receive WQEs on QP (qp_num=%d, comm=%p)", __func__, nRecvWorkRequestsPerQp, dataQp->qp->qp_num, recvComm);
+  INFO(NCCL_NET, "NET/IB: %s: Pre-posting %d Receive WQEs on QP (qp_num=%d, comm=%p)", __func__, nRecvWorkRequestsPerQp,
+       dataQp->qp->qp_num, recvComm);
   for (int j = 0; j < nRecvWorkRequestsPerQp; j++) {
     NCCLCHECK(ncclIbPostRecvWorkRequest(dataQp->qp, &recvComm->ibRecvWorkRequest));
   }
@@ -1194,7 +1236,7 @@ ncclResult_t ncclIbAccept(void* listenComm, void** recvComm, ncclNetDeviceHandle
   bool forceDmaBuf = false;
   *recvComm = NULL;
 
-  if (stage->state == ncclIbCommStateAccept)   goto ib_accept_check;
+  if (stage->state == ncclIbCommStateAccept) goto ib_accept_check;
   if (stage->state == ncclIbCommStateRecvDevList) goto ib_recv_dev_list;
   if (stage->state == ncclIbCommStateSendDevList) goto ib_send_dev_list;
   if (stage->state == ncclIbCommStateRecv) goto ib_recv;
@@ -1227,7 +1269,8 @@ ib_accept_check:
 
 // In the case of mismatched nDevs, we will make sure that both sides of a logical connection have the same number of RC qps
 ib_recv_dev_list:
-  NCCLCHECK(ncclSocketProgress(NCCL_SOCKET_RECV, &rComm->base.sock, stage->buffer, sizeof(ncclNetVDeviceProps_t) + sizeof(struct ncclIbDevExtraProps), &stage->offset));
+  NCCLCHECK(ncclSocketProgress(NCCL_SOCKET_RECV, &rComm->base.sock, stage->buffer,
+                               sizeof(ncclNetVDeviceProps_t) + sizeof(struct ncclIbDevExtraProps), &stage->offset));
   if (stage->offset != (sizeof(ncclNetVDeviceProps_t) + sizeof(struct ncclIbDevExtraProps))) return ncclSuccess;
   ncclNetVDeviceProps_t remoteVProps;
   memcpy(&remoteVProps, stage->buffer, sizeof(ncclNetVDeviceProps_t));
@@ -1236,7 +1279,7 @@ ib_recv_dev_list:
     return ncclInternalError;
   }
 
-  memcpy(&exProps, (char *)stage->buffer + sizeof(ncclNetVDeviceProps_t), sizeof(exProps));
+  memcpy(&exProps, (char*)stage->buffer + sizeof(ncclNetVDeviceProps_t), sizeof(exProps));
   rComm->base.remOooRq = exProps.oooRq;
 
   // Reduce the physical device list and store in the connection base
@@ -1261,23 +1304,25 @@ ib_recv_dev_list:
     exProps.oooRq = exProps.oooRq && ncclIbDevs[ibDevN].oooRqSize;
   }
   rComm->base.localOooRq = exProps.oooRq;
-  memcpy((char *)stage->buffer + sizeof(ncclNetVDeviceProps_t), &exProps, sizeof(struct ncclIbDevExtraProps));
+  memcpy((char*)stage->buffer + sizeof(ncclNetVDeviceProps_t), &exProps, sizeof(struct ncclIbDevExtraProps));
 
 ib_send_dev_list:
-  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_SEND, &rComm->base.sock, stage->buffer, sizeof(ncclNetVDeviceProps_t) + sizeof(struct ncclIbDevExtraProps), &stage->offset), ret, fail);
+  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_SEND, &rComm->base.sock, stage->buffer,
+                                   sizeof(ncclNetVDeviceProps_t) + sizeof(struct ncclIbDevExtraProps), &stage->offset),
+                ret, fail);
   if (stage->offset != (sizeof(ncclNetVDeviceProps_t) + sizeof(struct ncclIbDevExtraProps))) return ncclSuccess;
 
   stage->offset = 0;
   stage->state = ncclIbCommStateRecv;
 
 ib_recv:
-  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_RECV, &rComm->base.sock, stage->buffer, sizeof(remMeta), &stage->offset), ret, fail);
+  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_RECV, &rComm->base.sock, stage->buffer, sizeof(remMeta), &stage->offset),
+                ret, fail);
   if (stage->offset != sizeof(remMeta)) return ncclSuccess;
 
   /* copy back the received info */
   memcpy(&remMeta, stage->buffer, sizeof(struct ncclIbConnectionMetadata));
-  rComm->base.nqps = ncclIbCalculateNqps(remMeta.isP2p, rComm->base.vProps.ndevs,
-                                          remMeta.ndevs, __func__);
+  rComm->base.nqps = ncclIbCalculateNqps(remMeta.isP2p, rComm->base.vProps.ndevs, remMeta.ndevs, __func__);
 
   // IB setup
   // Pre-declare variables because of goto
@@ -1289,7 +1334,7 @@ ib_recv:
 
   if (remMeta.ndevs != rComm->base.vProps.ndevs) {
     INFO(NCCL_NET, "NET/IB : Local mergedDev %s has a different number of devices=%d as remote %s %d",
-      mergedDev->devName, rComm->base.vProps.ndevs, remMeta.devName, remMeta.ndevs);
+         mergedDev->devName, rComm->base.vProps.ndevs, remMeta.devName, remMeta.ndevs);
   }
 
   // Metadata to send back to requestor (sender)
@@ -1299,7 +1344,7 @@ ib_recv:
   // up to 2 completions (one for the CTS message and one for the completion
   // of a receive request) per QP, in the worst case.
   int cqSize;
-  cqSize = 3*NET_IB_MAX_REQUESTS*ncclParamIbQpsPerConn();
+  cqSize = 3 * NET_IB_MAX_REQUESTS * ncclParamIbQpsPerConn();
   for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
     rCommDev = rComm->devs + i;
     ibDevN = rComm->base.vProps.devs[i];
@@ -1311,13 +1356,19 @@ ib_recv:
       NCCLCHECKGOTO(ncclIbResiliencyDevInit(rComm->base.resiliency, i, &ncclIbDevs[ibDevN]), ret, fail);
     }
     ibDev = ncclIbDevs + ibDevN;
-    NCCLCHECKGOTO(ncclIbGetGidIndex(ibDev->context, ibDev->portNum, &ibDev->portAttr, &rCommDev->base.gidInfo.localGidIndex), ret, fail);
-    NCCLCHECKGOTO(wrap_ibv_query_gid(ibDev->context, ibDev->portNum, rCommDev->base.gidInfo.localGidIndex, &rCommDev->base.gidInfo.localGid), ret, fail);
+    NCCLCHECKGOTO(ncclIbGetGidIndex(ibDev->context, ibDev->portNum, &ibDev->portAttr,
+                                    &rCommDev->base.gidInfo.localGidIndex),
+                  ret, fail);
+    NCCLCHECKGOTO(wrap_ibv_query_gid(ibDev->context, ibDev->portNum, rCommDev->base.gidInfo.localGidIndex,
+                                     &rCommDev->base.gidInfo.localGid),
+                  ret, fail);
     if (link_layer == IBV_LINK_LAYER_UNSPECIFIED) link_layer = ibDev->portAttr.link_layer;
     if (link_layer != ibDev->portAttr.link_layer) {
       int ibDev0 = rComm->devs[0].base.ibDevN;
-      WARN("NET/IB : Attempted to connect incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of only one link type using NCCL_IB_HCA",
-           ibDevN, ibDev->devName, ibDev->portNum, NCCL_IB_LLSTR(ibDev->portAttr.link_layer), ibDev0, ncclIbDevs[ibDev0].devName, ncclIbDevs[ibDev0].portNum, NCCL_IB_LLSTR(link_layer));
+      WARN("NET/IB : Attempted to connect incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of "
+           "only one link type using NCCL_IB_HCA",
+           ibDevN, ibDev->devName, ibDev->portNum, NCCL_IB_LLSTR(ibDev->portAttr.link_layer), ibDev0,
+           ncclIbDevs[ibDev0].devName, ncclIbDevs[ibDev0].portNum, NCCL_IB_LLSTR(link_layer));
       return ncclInternalError;
     }
   }
@@ -1327,8 +1378,10 @@ ib_recv:
   for (int i = 0; i < remMeta.ndevs; i++) {
     if (remMeta.devs[i].link_layer != link_layer) {
       int ibDev0 = rComm->devs[0].base.ibDevN;
-      WARN("NET/IB : Remote %s device is incompatible with the local [%d]%s:%d/%s. Try selecting NICs of only one link type using NCCL_IB_HCA",
-           NCCL_IB_LLSTR(remMeta.devs[i].link_layer), ibDev0, ncclIbDevs[ibDev0].devName, ncclIbDevs[ibDev0].portNum, NCCL_IB_LLSTR(link_layer));
+      WARN("NET/IB : Remote %s device is incompatible with the local [%d]%s:%d/%s. Try selecting NICs of only one link "
+           "type using NCCL_IB_HCA",
+           NCCL_IB_LLSTR(remMeta.devs[i].link_layer), ibDev0, ncclIbDevs[ibDev0].devName, ncclIbDevs[ibDev0].portNum,
+           NCCL_IB_LLSTR(link_layer));
       return ncclInternalError;
     }
   }
@@ -1339,7 +1392,7 @@ ib_recv:
   // Store the remote GID information per-device provided by the remote peer
   for (int i = 0; i < rComm->base.nRemDevs; i++) {
     rComm->base.remDevs[i] = remMeta.devs[i];
-    rComm->base.remDevs[i].remoteGid.global.interface_id  = rComm->base.remDevs[i].gid.global.interface_id;
+    rComm->base.remDevs[i].remoteGid.global.interface_id = rComm->base.remDevs[i].gid.global.interface_id;
     rComm->base.remDevs[i].remoteGid.global.subnet_prefix = rComm->base.remDevs[i].gid.global.subnet_prefix;
   }
 
@@ -1356,26 +1409,28 @@ ib_recv:
     // RCCL_FORCE_ENABLE_DMABUF=1: always try DMAbuf, skip peermem
     useDmaBuf = dmabufAvailable;
     if (dmabufAvailable) {
-      INFO(NCCL_INIT|NCCL_NET, "NET/IB: Using GPU Direct RDMA (DMAbuf - forced) for device %d", lComm->dev);
+      INFO(NCCL_INIT | NCCL_NET, "NET/IB: Using GPU Direct RDMA (DMAbuf - forced) for device %d", lComm->dev);
     } else {
-      WARN("NET/IB: RCCL_FORCE_ENABLE_DMABUF=1 but DMAbuf not available, GPU Direct RDMA disabled for device %d", lComm->dev);
+      WARN("NET/IB: RCCL_FORCE_ENABLE_DMABUF=1 but DMAbuf not available, GPU Direct RDMA disabled for device %d",
+           lComm->dev);
     }
   } else {
     // Normal path: prefer peermem over dmabuf
     useDmaBuf = !peermemAvailable && dmabufAvailable;
     if (peermemAvailable) {
-      INFO(NCCL_INIT|NCCL_NET, "NET/IB: Using GPU Direct RDMA (peermem) for device %d", lComm->dev);
+      INFO(NCCL_INIT | NCCL_NET, "NET/IB: Using GPU Direct RDMA (peermem) for device %d", lComm->dev);
     } else if (useDmaBuf) {
       WARN("NET/IB: Peermem not available, falling back to GPU Direct RDMA (DMAbuf) for device %d", lComm->dev);
     } else if (!peermemAvailable && dmabufSupported && !dmabufEnabled) {
-      WARN("NET/IB: Peermem not available and DMAbuf is disabled (NCCL_DMABUF_ENABLE=0), GPU Direct RDMA disabled for device %d", lComm->dev);
+      WARN("NET/IB: Peermem not available and DMAbuf is disabled (NCCL_DMABUF_ENABLE=0), GPU Direct RDMA disabled for "
+           "device %d",
+           lComm->dev);
     } else {
       WARN("NET/IB: GPU Direct RDMA not available for device %d", lComm->dev);
     }
   }
 
-  rComm->flushEnabled = ((peermemAvailable || useDmaBuf)
-                            && (ncclParamIbGdrFlushDisable() == 0)) ? 1 : 0;              
+  rComm->flushEnabled = ((peermemAvailable || useDmaBuf) && (ncclParamIbGdrFlushDisable() == 0)) ? 1 : 0;
 
   NCCLCHECKGOTO(ncclIbReceiverQpsCreateToRts(rComm, &remMeta, &meta), ret, fail);
   if (rComm->prepostReceiveWorkRequests) {
@@ -1391,13 +1446,18 @@ ib_recv:
   for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
     rCommDev = rComm->devs + i;
 
-    NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->ctsFifoMr, rCommDev->base.pd, &rComm->remCtsFifo.elems, sizeof(rComm->remCtsFifo.elems), IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
+    NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->ctsFifoMr, rCommDev->base.pd, &rComm->remCtsFifo.elems,
+                                  sizeof(rComm->remCtsFifo.elems),
+                                  IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ),
+                  ret, fail);
     rCommDev->sge.lkey = rCommDev->ctsFifoMr->lkey;
 
     // Register completion records
-    NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->cmplsRecordsMr, rCommDev->base.pd, &rComm->cmplsRecords, sizeof(rComm->cmplsRecords), IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
+    NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->cmplsRecordsMr, rCommDev->base.pd, &rComm->cmplsRecords,
+                                  sizeof(rComm->cmplsRecords),
+                                  IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ),
+                  ret, fail);
     meta.devs[i].rkey = rCommDev->cmplsRecordsMr->rkey;
-
   }
   if (ncclParamIbUseInline()) rComm->remCtsFifo.flags = IBV_SEND_INLINE;
 
@@ -1413,19 +1473,21 @@ ib_recv:
       rCommDev->gpuFlush.dmabuf_fd = -1;
 
       if (rcclParamIbGdrFlushGpuMemNoRelaxedOrdering()) {
-        #if CUDA_VERSION >= 11070 || HIP_VERSION >= 71260540
+#if CUDA_VERSION >= 11070 || HIP_VERSION >= 71260540
         if (ncclCuMemEnable()) {
           NCCLCHECKGOTO(ncclMemAlloc((void**)&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int)), ret, fail);
           CUCHECKGOTO(cuMemGetHandleForAddressRange((void*)&rCommDev->gpuFlush.dmabuf_fd,
-                      (CUdeviceptr)rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int),
-                      CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0), ret, cumem_flush_hsa);
-          NCCLCHECKGOTO(wrap_ibv_reg_dmabuf_mr(&rCommDev->gpuFlush.gpuMr, rCommDev->base.pd,
-                        0, sizeof(int), (uint64_t)rCommDev->gpuFlush.gpuFlushGpuMem,
-                        rCommDev->gpuFlush.dmabuf_fd,
-                        IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ), ret, cumem_flush_hsa);
+                                                    (CUdeviceptr)rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int),
+                                                    CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0),
+                      ret, cumem_flush_hsa);
+          NCCLCHECKGOTO(
+            wrap_ibv_reg_dmabuf_mr(&rCommDev->gpuFlush.gpuMr, rCommDev->base.pd, 0, sizeof(int),
+                                   (uint64_t)rCommDev->gpuFlush.gpuFlushGpuMem, rCommDev->gpuFlush.dmabuf_fd,
+                                   IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ),
+            ret, cumem_flush_hsa);
           gpuFlushRegistered = true;
           goto flush_reg_done;
-cumem_flush_hsa:
+        cumem_flush_hsa:
           if (rCommDev->gpuFlush.dmabuf_fd >= 0) {
             close(rCommDev->gpuFlush.dmabuf_fd);
             rCommDev->gpuFlush.dmabuf_fd = -1;
@@ -1433,52 +1495,61 @@ cumem_flush_hsa:
         }
 #else
 #if defined(HIP_UNCACHED_MEMORY)
-        NCCLCHECKGOTO(ncclCudaCalloc(&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), /*manager=*/nullptr, ncclMemPersist, hipDeviceMallocUncached), ret, fail);
+        NCCLCHECKGOTO(ncclCudaCalloc(&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), /*manager=*/nullptr,
+                                     ncclMemPersist, hipDeviceMallocUncached),
+                      ret, fail);
 #else
-        NCCLCHECKGOTO(ncclCudaCalloc(&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), /*manager=*/nullptr, ncclMemPersist, hipDeviceMallocFinegrained), ret, fail);
+        NCCLCHECKGOTO(ncclCudaCalloc(&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), /*manager=*/nullptr,
+                                     ncclMemPersist, hipDeviceMallocFinegrained),
+                      ret, fail);
 #endif
-        if (useDmaBuf)
-        {
+        if (useDmaBuf) {
           uint64_t export_offset = 0;
-          void *aligned_ptr = NULL;
+          void* aligned_ptr = NULL;
           size_t aligned_size = 0;
           get_aligned_ptr_and_size(rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), &aligned_ptr, &aligned_size);
-          HSACHECKGOTO(hsa_amd_portable_export_dmabuf(aligned_ptr, aligned_size, &rCommDev->gpuFlush.dmabuf_fd, &export_offset), ret, peermem_flush);
+          HSACHECKGOTO(hsa_amd_portable_export_dmabuf(aligned_ptr, aligned_size, &rCommDev->gpuFlush.dmabuf_fd,
+                                                      &export_offset),
+                       ret, peermem_flush);
           if (wrap_ibv_reg_dmabuf_mr(&rCommDev->gpuFlush.gpuMr, rCommDev->base.pd, export_offset, sizeof(int),
-                        (uint64_t)rCommDev->gpuFlush.gpuFlushGpuMem, rCommDev->gpuFlush.dmabuf_fd,
-                        IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ) != ncclSuccess) goto peermem_flush;
+                                     (uint64_t)rCommDev->gpuFlush.gpuFlushGpuMem, rCommDev->gpuFlush.dmabuf_fd,
+                                     IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ) !=
+              ncclSuccess)
+            goto peermem_flush;
           gpuFlushRegistered = true;
           goto flush_reg_done;
-peermem_flush:
+        peermem_flush:
           if (rCommDev->gpuFlush.dmabuf_fd >= 0) {
             close(rCommDev->gpuFlush.dmabuf_fd);
             rCommDev->gpuFlush.dmabuf_fd = -1;
           }
         }
-        #endif
-        flush_reg_done:
-                if (!gpuFlushRegistered) {
-                  if (rCommDev->gpuFlush.gpuFlushGpuMem) {
-                    ncclCudaFree(rCommDev->gpuFlush.gpuFlushGpuMem, /*manager=*/nullptr);
-                    rCommDev->gpuFlush.gpuFlushGpuMem = nullptr;
-                  }
-                  rCommDev->gpuFlush.gpuMr = nullptr;
+#endif
+      flush_reg_done:
+        if (!gpuFlushRegistered) {
+          if (rCommDev->gpuFlush.gpuFlushGpuMem) {
+            ncclCudaFree(rCommDev->gpuFlush.gpuFlushGpuMem, /*manager=*/nullptr);
+            rCommDev->gpuFlush.gpuFlushGpuMem = nullptr;
+          }
+          rCommDev->gpuFlush.gpuMr = nullptr;
         }
       }
-      NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->gpuFlush.hostMr, rCommDev->base.pd, &rComm->gpuFlushHostMem, sizeof(int), IBV_ACCESS_LOCAL_WRITE), ret, fail);
+      NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->gpuFlush.hostMr, rCommDev->base.pd, &rComm->gpuFlushHostMem, sizeof(int),
+                                    IBV_ACCESS_LOCAL_WRITE),
+                    ret, fail);
       rCommDev->gpuFlush.sge.addr = (uint64_t)&rComm->gpuFlushHostMem;
       rCommDev->gpuFlush.sge.length = 1;
       rCommDev->gpuFlush.sge.lkey = rCommDev->gpuFlush.hostMr->lkey;
     }
 
     // Fill Handle
-    meta.devs[i].lid                            = ibDev->portAttr.lid;
-    meta.devs[i].link_layer                     = rCommDev->base.gidInfo.link_layer = ibDev->portAttr.link_layer;
-    meta.devs[i].ib_port                        = ibDev->portNum;
-    meta.devs[i].gid.global.subnet_prefix       = rCommDev->base.gidInfo.localGid.global.subnet_prefix;
-    meta.devs[i].gid.global.interface_id        = rCommDev->base.gidInfo.localGid.global.interface_id;
-    meta.devs[i].mtu                            = ibDev->portAttr.active_mtu;
-    meta.devs[i].ibv_dev_index                  = rCommDev->base.ibDevN;
+    meta.devs[i].lid = ibDev->portAttr.lid;
+    meta.devs[i].link_layer = rCommDev->base.gidInfo.link_layer = ibDev->portAttr.link_layer;
+    meta.devs[i].ib_port = ibDev->portNum;
+    meta.devs[i].gid.global.subnet_prefix = rCommDev->base.gidInfo.localGid.global.subnet_prefix;
+    meta.devs[i].gid.global.interface_id = rCommDev->base.gidInfo.localGid.global.interface_id;
+    meta.devs[i].mtu = ibDev->portAttr.active_mtu;
+    meta.devs[i].ibv_dev_index = rCommDev->base.ibDevN;
   }
   meta.addr = (uint64_t)rComm->cmplsRecords;
   meta.sl = remMeta.sl;
@@ -1498,14 +1569,18 @@ peermem_flush:
   memcpy(stage->buffer, &meta, sizeof(struct ncclIbConnectionMetadata));
 
 ib_send:
-  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_SEND, &rComm->base.sock, stage->buffer, sizeof(struct ncclIbConnectionMetadata), &stage->offset), ret, fail);
+  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_SEND, &rComm->base.sock, stage->buffer,
+                                   sizeof(struct ncclIbConnectionMetadata), &stage->offset),
+                ret, fail);
   if (stage->offset < sizeof(struct ncclIbConnectionMetadata)) return ncclSuccess;
 
   stage->offset = 0;
   stage->state = ncclIbCommStatePendingReady;
 
 ib_recv_ready:
-  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_RECV,  &rComm->base.sock, &rComm->base.ready, sizeof(int), &stage->offset), ret, fail);
+  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_RECV, &rComm->base.sock, &rComm->base.ready, sizeof(int),
+                                   &stage->offset),
+                ret, fail);
   if (stage->offset != sizeof(int)) return ncclSuccess;
 
   *recvComm = rComm;
@@ -1536,10 +1611,9 @@ ncclResult_t ncclIbCloseSend(void* sendComm) {
       struct ncclIbSendCommDev* commDev = comm->devs + i;
       if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
       if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
-      if (commDev->putSignalScratchpadMr != NULL)
-        NCCLCHECK(wrap_ibv_dereg_mr(commDev->putSignalScratchpadMr));
+      if (commDev->putSignalScratchpadMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->putSignalScratchpadMr));
       if (comm->base.resiliency) {
-         NCCLCHECK(ncclIbResiliencyDevDestroy(comm->base.resiliency, i));
+        NCCLCHECK(ncclIbResiliencyDevDestroy(comm->base.resiliency, i));
       }
       NCCLCHECK(ncclIbDestroyBase(&commDev->base));
     }
@@ -1572,7 +1646,9 @@ ncclResult_t ncclIbCloseRecv(void* recvComm) {
           commDev->gpuFlush.gpuFlushGpuMem = nullptr;
           if (commDev->gpuFlush.gpuMr != nullptr) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.gpuMr));
           commDev->gpuFlush.gpuMr = nullptr;
-          if(commDev->gpuFlush.dmabuf_fd > 0) { close(commDev->gpuFlush.dmabuf_fd);}
+          if (commDev->gpuFlush.dmabuf_fd > 0) {
+            close(commDev->gpuFlush.dmabuf_fd);
+          }
         }
         if (commDev->gpuFlush.qp.qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(commDev->gpuFlush.qp.qp));
         if (commDev->gpuFlush.hostMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.hostMr));

--- a/projects/rccl/src/transport/net_ib/gdaki/gin_host_gdaki.cc
+++ b/projects/rccl/src/transport/net_ib/gdaki/gin_host_gdaki.cc
@@ -26,25 +26,25 @@
 #include "nccl_device/gin/gdaki/gin_gdaki_device_host_common.h"
 #include "../gin.h"
 
-#define DOCACHECK(call)                 \
-  do {                                  \
-    doca_error_t err = call;            \
-    if (err != DOCA_SUCCESS) {          \
-      /* Print the back trace*/         \
-      WARN("DOCA failure %d", err);     \
-      return ncclSystemError;           \
-    }                                   \
+#define DOCACHECK(call) \
+  do { \
+    doca_error_t err = call; \
+    if (err != DOCA_SUCCESS) { \
+      /* Print the back trace*/ \
+      WARN("DOCA failure %d", err); \
+      return ncclSystemError; \
+    } \
   } while (0)
 
 #define DOCACHECKGOTO(call, RES, label) \
-  do {                                  \
-    doca_error_t err = call;            \
-    if (err != DOCA_SUCCESS) {          \
-      /* Print the back trace*/         \
-      WARN("DOCA failure %d", err);     \
-      RES = ncclSystemError;            \
-      goto label;                       \
-    }                                   \
+  do { \
+    doca_error_t err = call; \
+    if (err != DOCA_SUCCESS) { \
+      /* Print the back trace*/ \
+      WARN("DOCA failure %d", err); \
+      RES = ncclSystemError; \
+      goto label; \
+    } \
   } while (0)
 
 #define VERBS_TEST_DBR_SIZE (8)
@@ -88,8 +88,7 @@ static inline bool gdakiRelaxedOrderingEnabled() {
   return relaxedOrderingEnabled;
 }
 
-static ncclResult_t gdakiRegMrDmaBuf(struct ibv_mr **mr, struct ibv_pd *pd, void *addr,
-                                     size_t length, int access) {
+static ncclResult_t gdakiRegMrDmaBuf(struct ibv_mr** mr, struct ibv_pd* pd, void* addr, size_t length, int access) {
   int status = 0;
   int dmabuf_fd = -1;
 
@@ -102,7 +101,7 @@ static ncclResult_t gdakiRegMrDmaBuf(struct ibv_mr **mr, struct ibv_pd *pd, void
 
 #if CUDA_VERSION >= 12080
   if (ncclParamIbDataDirect()) {
-    status = pfn_cuMemGetHandleForAddressRange((void *)&dmabuf_fd, (CUdeviceptr)addr, aligned_size,
+    status = pfn_cuMemGetHandleForAddressRange((void*)&dmabuf_fd, (CUdeviceptr)addr, aligned_size,
                                                CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
                                                CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE);
     if (status) {
@@ -112,8 +111,8 @@ static ncclResult_t gdakiRegMrDmaBuf(struct ibv_mr **mr, struct ibv_pd *pd, void
            status);
       goto try_legacy;
     }
-    status = wrap_mlx5dv_reg_dmabuf_mr(mr, pd, 0, aligned_size, 0, dmabuf_fd, access,
-                                       MLX5DV_REG_DMABUF_ACCESS_DATA_DIRECT);
+    status =
+      wrap_mlx5dv_reg_dmabuf_mr(mr, pd, 0, aligned_size, 0, dmabuf_fd, access, MLX5DV_REG_DMABUF_ACCESS_DATA_DIRECT);
     if (status) {
       INFO(NCCL_NET,
            "Failed to register memory with DMA-BUF and data direct, error=%d. Trying a different "
@@ -121,19 +120,16 @@ static ncclResult_t gdakiRegMrDmaBuf(struct ibv_mr **mr, struct ibv_pd *pd, void
            status);
       close(dmabuf_fd);
       dmabuf_fd = -1;
-    } else
-      goto out;
+    } else goto out;
   }
 try_legacy:
 
 #endif
 
-  CUCHECK(cuMemGetHandleForAddressRange((void *)&dmabuf_fd, (CUdeviceptr)addr, aligned_size,
+  CUCHECK(cuMemGetHandleForAddressRange((void*)&dmabuf_fd, (CUdeviceptr)addr, aligned_size,
                                         CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0));
   status = wrap_ibv_reg_dmabuf_mr(mr, pd, 0, aligned_size, 0, dmabuf_fd, access);
-  if (status)
-    INFO(NCCL_NET, "Failed to register memory with DMA-BUF, error=%d. Trying a different method.",
-         status);
+  if (status) INFO(NCCL_NET, "Failed to register memory with DMA-BUF, error=%d. Trying a different method.", status);
 #else
   status = ncclInvalidUsage;
 #endif
@@ -147,12 +143,11 @@ out:
   return (ncclResult_t)status;
 }
 
-static ncclResult_t gdakiRegMr(struct ibv_mr **mr, struct ibv_pd *pd, void *addr, size_t length,
-                               int access, bool force_strict_ordering = false) {
+static ncclResult_t gdakiRegMr(struct ibv_mr** mr, struct ibv_pd* pd, void* addr, size_t length, int access,
+                               bool force_strict_ordering = false) {
   int status = 0;
 
-  if (!force_strict_ordering && gdakiRelaxedOrderingEnabled())
-    access |= IBV_ACCESS_RELAXED_ORDERING;
+  if (!force_strict_ordering && gdakiRelaxedOrderingEnabled()) access |= IBV_ACCESS_RELAXED_ORDERING;
 
   NOWARN(status = gdakiRegMrDmaBuf(mr, pd, addr, length, access), NCCL_NET);
   if (status == ncclSuccess) return ncclSuccess;
@@ -163,19 +158,19 @@ static ncclResult_t gdakiRegMr(struct ibv_mr **mr, struct ibv_pd *pd, void *addr
 
 template <typename T>
 class GdakiHostGPUMemHandle {
- private:
+private:
   CUmemGenericAllocationHandle cumemhandle;
   unsigned int num_elements;
 
- public:
-  T *host_buf;
-  T *gpu_buf;
+public:
+  T* host_buf;
+  T* gpu_buf;
 
   ncclResult_t allocate(unsigned int num_elements) {
-    this->host_buf = (T *)calloc(num_elements, sizeof(T));
+    this->host_buf = (T*)calloc(num_elements, sizeof(T));
     EQCHECK(this->host_buf, nullptr);
 
-    NCCLCHECK(ncclCuMemAlloc((void **)&this->gpu_buf, &this->cumemhandle, CU_MEM_HANDLE_TYPE_NONE,
+    NCCLCHECK(ncclCuMemAlloc((void**)&this->gpu_buf, &this->cumemhandle, CU_MEM_HANDLE_TYPE_NONE,
                              num_elements * sizeof(T), nullptr));
 
     this->num_elements = num_elements;
@@ -205,26 +200,26 @@ class GdakiHostGPUMemHandle {
     return ncclSuccess;
   }
 
-  GdakiHostGPUMemHandle() : cumemhandle(0), num_elements(0), host_buf(nullptr), gpu_buf(nullptr){};
+  GdakiHostGPUMemHandle() : cumemhandle(0), num_elements(0), host_buf(nullptr), gpu_buf(nullptr) {};
 
   ~GdakiHostGPUMemHandle() {
      // Should only be used in error cleanup path as it ignores return code
-     this->deallocate();
+    this->deallocate();
   }
 };
 
 template <typename T>
 class GdakiGlobalGPUBufferTable {
- private:
+private:
   CUmemGenericAllocationHandle cumemhandle;
   unsigned int num_elements;
   unsigned int next_unused_idx;
   unsigned int num_ranks;
   GdakiHostGPUMemHandle<__be32> rkeys_hd_mhandle;
 
- public:
-  T *gpu_ptr;
-  struct ibv_mr *mr;
+public:
+  T* gpu_ptr;
+  struct ibv_mr* mr;
 
   ncclResult_t allocate(unsigned int num_elements, unsigned int num_ranks) {
     this->num_elements = num_elements;
@@ -232,7 +227,7 @@ class GdakiGlobalGPUBufferTable {
     this->next_unused_idx = 0;
     if (num_elements == 0) return ncclSuccess;
 
-    NCCLCHECK(ncclCuMemAlloc((void **)&this->gpu_ptr, &this->cumemhandle, CU_MEM_HANDLE_TYPE_NONE,
+    NCCLCHECK(ncclCuMemAlloc((void**)&this->gpu_ptr, &this->cumemhandle, CU_MEM_HANDLE_TYPE_NONE,
                              num_elements * sizeof(T), nullptr));
     CUDACHECK(cudaMemset(this->gpu_ptr, 0, num_elements * sizeof(T)));
     NCCLCHECK(this->rkeys_hd_mhandle.allocate(num_ranks));
@@ -247,7 +242,7 @@ class GdakiGlobalGPUBufferTable {
     return ncclSuccess;
   }
 
-  ncclResult_t register_mr(struct ibv_pd *ib_pd, bool force_strict_ordering = false) {
+  ncclResult_t register_mr(struct ibv_pd* ib_pd, bool force_strict_ordering = false) {
     if (this->num_elements == 0) return ncclSuccess;
     NCCLCHECK(gdakiRegMr(&this->mr, ib_pd, this->gpu_ptr, this->num_elements * sizeof(T),
                          IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ |
@@ -264,7 +259,7 @@ class GdakiGlobalGPUBufferTable {
     return ncclSuccess;
   }
 
-  ncclResult_t exchange_info(struct ncclGinIbCollComm *cComm) {
+  ncclResult_t exchange_info(struct ncclGinIbCollComm* cComm) {
     if (this->num_elements == 0) return ncclSuccess;
     __be32 rkey = htobe32(this->mr->rkey);
     NCCLCHECK(cComm->allGather(cComm, &rkey, this->rkeys_hd_mhandle.host_buf, sizeof(__be32)));
@@ -272,7 +267,7 @@ class GdakiGlobalGPUBufferTable {
     return ncclSuccess;
   }
 
-  ncclResult_t allocate_elements(unsigned int num_elements, unsigned int *out_start_idx) {
+  ncclResult_t allocate_elements(unsigned int num_elements, unsigned int* out_start_idx) {
     if (this->next_unused_idx + num_elements > this->num_elements) {
       WARN("Not enough space to get elements");
       return ncclInvalidUsage;
@@ -288,22 +283,23 @@ class GdakiGlobalGPUBufferTable {
     // No op for now as we don't allow reusing elements.
   }
 
-  uint32_t *get_rkeys_d() { return this->rkeys_hd_mhandle.gpu_buf; }
+  uint32_t* get_rkeys_d() {
+    return this->rkeys_hd_mhandle.gpu_buf;
+  }
 
-  GdakiGlobalGPUBufferTable()
-    : cumemhandle(0), num_elements(0), next_unused_idx(0), gpu_ptr(nullptr), mr(nullptr) {};
+  GdakiGlobalGPUBufferTable() : cumemhandle(0), num_elements(0), next_unused_idx(0), gpu_ptr(nullptr), mr(nullptr) {};
   ~GdakiGlobalGPUBufferTable() {
      // Should only be used in error cleanup path as it ignores return codes
-     this->deregister_mr();
-     this->deallocate();
+    this->deregister_mr();
+    this->deallocate();
   }
 };
 
 struct gdaki_mem_handle {
   int type;
-  struct ibv_mr *mr;
-  GdakiHostGPUMemHandle<struct ncclGinGdakiMemHandle> *gdaki_mhandle_hd_mhandle;
-  GdakiHostGPUMemHandle<uint32_t> *rkeys_hd_mhandle;
+  struct ibv_mr* mr;
+  GdakiHostGPUMemHandle<struct ncclGinGdakiMemHandle>* gdaki_mhandle_hd_mhandle;
+  GdakiHostGPUMemHandle<uint32_t>* rkeys_hd_mhandle;
 };
 
 struct gdaki_exch_info {
@@ -316,9 +312,9 @@ struct gdaki_exch_info {
 
 struct gdaki_context {
   int cuda_id;
-  struct doca_gpu *gdev;
-  struct ibv_device *ib_dev;
-  struct doca_verbs_ah_attr *ah; /* DOCA Verbs address handle */
+  struct doca_gpu* gdev;
+  struct ibv_device* ib_dev;
+  struct doca_verbs_ah_attr* ah; /* DOCA Verbs address handle */
   struct ibv_device_attr ib_dev_attr;
   struct doca_verbs_gid gid;
 
@@ -329,22 +325,22 @@ struct gdaki_context {
 
   uint32_t qp_rq_size;
   uint32_t qp_sq_size;
-  struct doca_gpu_verbs_qp_group_hl **gqp_groups;
-  struct doca_gpu_verbs_qp_hl **gqps;
-  struct doca_gpu_verbs_qp_hl **companion_gqps;
+  struct doca_gpu_verbs_qp_group_hl** gqp_groups;
+  struct doca_gpu_verbs_qp_hl** gqps;
+  struct doca_gpu_verbs_qp_hl** companion_gqps;
 
-  GdakiGlobalGPUBufferTable<uint64_t> *counters_table;
-  GdakiGlobalGPUBufferTable<uint64_t> *signals_table;
-  GdakiHostGPUMemHandle<struct ncclGinGdakiGPUContext> *gin_gdaki_gpu_ctx_hd_mhandle;
+  GdakiGlobalGPUBufferTable<uint64_t>* counters_table;
+  GdakiGlobalGPUBufferTable<uint64_t>* signals_table;
+  GdakiHostGPUMemHandle<struct ncclGinGdakiGPUContext>* gin_gdaki_gpu_ctx_hd_mhandle;
   struct {
-    void *addr;
-    struct ibv_mr *mr;
+    void* addr;
+    struct ibv_mr* mr;
     CUmemGenericAllocationHandle mhandle;
   } sink_buffer;
   uint64_t last_error_query_time;
 
-  struct ncclGinIbCollComm *collComm;
-  ncclNetDeviceHandle_t *devHandle;
+  struct ncclGinIbCollComm* collComm;
+  ncclNetDeviceHandle_t* devHandle;
   int nContexts;
 };
 
@@ -353,8 +349,8 @@ static inline T gdaki_round_up(T x, T y) {
   return ((x + y - 1) / y) * y;
 }
 
-static void gdakiFillExchInfo(struct gdaki_exch_info *exch_info, struct gdaki_context *gdaki_ctx,
-                              struct doca_gpu_verbs_qp_hl *gqp) {
+static void gdakiFillExchInfo(struct gdaki_exch_info* exch_info, struct gdaki_context* gdaki_ctx,
+                              struct doca_gpu_verbs_qp_hl* gqp) {
   exch_info->lid = gdaki_ctx->port_attr.lid;
   exch_info->qpn = doca_verbs_qp_get_qpn(gqp->qp);
   memcpy(exch_info->gid.raw, gdaki_ctx->rgid.raw, sizeof(union ibv_gid));
@@ -362,7 +358,7 @@ static void gdakiFillExchInfo(struct gdaki_exch_info *exch_info, struct gdaki_co
   exch_info->gid_index = gdaki_ctx->gid_index;
 }
 
-static ncclResult_t gdakiCreateVerbsAh(struct gdaki_context *ctx, struct ibv_context* ib_context, int ib_sl, int ib_tc,
+static ncclResult_t gdakiCreateVerbsAh(struct gdaki_context* ctx, struct ibv_context* ib_context, int ib_sl, int ib_tc,
                                        int ib_gid_index) {
   ncclResult_t status = ncclSuccess;
 
@@ -370,12 +366,10 @@ static ncclResult_t gdakiCreateVerbsAh(struct gdaki_context *ctx, struct ibv_con
 
   if (ctx->port_attr.link_layer == IBV_LINK_LAYER_INFINIBAND) {
     DOCACHECKGOTO(doca_verbs_ah_attr_set_sl(ctx->ah, ib_sl), status, destroy_verbs_ah);
-    DOCACHECKGOTO(doca_verbs_ah_attr_set_addr_type(ctx->ah, DOCA_VERBS_ADDR_TYPE_IB_NO_GRH),
-                  status, destroy_verbs_ah);
+    DOCACHECKGOTO(doca_verbs_ah_attr_set_addr_type(ctx->ah, DOCA_VERBS_ADDR_TYPE_IB_NO_GRH), status, destroy_verbs_ah);
   } else {
     DOCACHECKGOTO(doca_verbs_ah_attr_set_traffic_class(ctx->ah, ib_tc), status, destroy_verbs_ah);
-    DOCACHECKGOTO(doca_verbs_ah_attr_set_addr_type(ctx->ah, DOCA_VERBS_ADDR_TYPE_IPv4),
-                  status, destroy_verbs_ah);
+    DOCACHECKGOTO(doca_verbs_ah_attr_set_addr_type(ctx->ah, DOCA_VERBS_ADDR_TYPE_IPv4), status, destroy_verbs_ah);
   }
 
   // set_port_num?
@@ -389,85 +383,66 @@ destroy_verbs_ah:
   return status;
 }
 
-static ncclResult_t gdakiConnectQp(struct gdaki_context *ctx, struct doca_gpu_verbs_qp_hl *gqp,
-                                   struct gdaki_exch_info *exch_info) {
+static ncclResult_t gdakiConnectQp(struct gdaki_context* ctx, struct doca_gpu_verbs_qp_hl* gqp,
+                                   struct gdaki_exch_info* exch_info) {
   ncclResult_t status = ncclSuccess;
-  struct doca_verbs_qp_attr *verbs_qp_attr = nullptr;
-  int max_dest_rd_atomic = ncclParamGinGdakiMaxDestRdAtomic() > 0 ? ncclParamGinGdakiMaxDestRdAtomic() : ctx->ib_dev_attr.max_qp_rd_atom;
-  int max_qp_rd_atomic = ncclParamGinGdakiMaxQpRdAtomic() > 0 ? ncclParamGinGdakiMaxQpRdAtomic() : ctx->ib_dev_attr.max_qp_rd_atom;
+  struct doca_verbs_qp_attr* verbs_qp_attr = nullptr;
+  int max_dest_rd_atomic =
+    ncclParamGinGdakiMaxDestRdAtomic() > 0 ? ncclParamGinGdakiMaxDestRdAtomic() : ctx->ib_dev_attr.max_qp_rd_atom;
+  int max_qp_rd_atomic =
+    ncclParamGinGdakiMaxQpRdAtomic() > 0 ? ncclParamGinGdakiMaxQpRdAtomic() : ctx->ib_dev_attr.max_qp_rd_atom;
 
   DOCACHECK(doca_verbs_ah_attr_set_gid(ctx->ah, exch_info->vgid));
   DOCACHECK(doca_verbs_ah_attr_set_dlid(ctx->ah, exch_info->lid));
   DOCACHECK(doca_verbs_qp_attr_create(&verbs_qp_attr));
-  DOCACHECKGOTO(
-    doca_verbs_qp_attr_set_path_mtu(verbs_qp_attr, DOCA_VERBS_MTU_SIZE_4K_BYTES),
-    status, destroy_verbs_qp_attr);
+  DOCACHECKGOTO(doca_verbs_qp_attr_set_path_mtu(verbs_qp_attr, DOCA_VERBS_MTU_SIZE_4K_BYTES), status,
+                destroy_verbs_qp_attr);
   DOCACHECKGOTO(doca_verbs_qp_attr_set_rq_psn(verbs_qp_attr, 0), status, destroy_verbs_qp_attr);
 
   DOCACHECKGOTO(doca_verbs_qp_attr_set_sq_psn(verbs_qp_attr, 0), status, destroy_verbs_qp_attr);
-  DOCACHECKGOTO(doca_verbs_qp_attr_set_port_num(verbs_qp_attr, ctx->port_num),
-                status, destroy_verbs_qp_attr);
-  DOCACHECKGOTO(doca_verbs_qp_attr_set_ack_timeout(verbs_qp_attr, ncclParamIbTimeout()),
-                status, destroy_verbs_qp_attr);
-  DOCACHECKGOTO(doca_verbs_qp_attr_set_retry_cnt(verbs_qp_attr, ncclParamIbRetryCnt()),
-                status, destroy_verbs_qp_attr);
-  DOCACHECKGOTO(doca_verbs_qp_attr_set_rnr_retry(verbs_qp_attr, 7), status,
+  DOCACHECKGOTO(doca_verbs_qp_attr_set_port_num(verbs_qp_attr, ctx->port_num), status, destroy_verbs_qp_attr);
+  DOCACHECKGOTO(doca_verbs_qp_attr_set_ack_timeout(verbs_qp_attr, ncclParamIbTimeout()), status, destroy_verbs_qp_attr);
+  DOCACHECKGOTO(doca_verbs_qp_attr_set_retry_cnt(verbs_qp_attr, ncclParamIbRetryCnt()), status, destroy_verbs_qp_attr);
+  DOCACHECKGOTO(doca_verbs_qp_attr_set_rnr_retry(verbs_qp_attr, 7), status, destroy_verbs_qp_attr);
+  DOCACHECKGOTO(doca_verbs_qp_attr_set_min_rnr_timer(verbs_qp_attr, 12), status, destroy_verbs_qp_attr);
+  DOCACHECKGOTO(doca_verbs_qp_attr_set_next_state(verbs_qp_attr, DOCA_VERBS_QP_STATE_INIT), status,
                 destroy_verbs_qp_attr);
-  DOCACHECKGOTO(doca_verbs_qp_attr_set_min_rnr_timer(verbs_qp_attr, 12),
-                status, destroy_verbs_qp_attr);
-  DOCACHECKGOTO(
-    doca_verbs_qp_attr_set_next_state(verbs_qp_attr, DOCA_VERBS_QP_STATE_INIT),
-    status, destroy_verbs_qp_attr);
-  DOCACHECKGOTO(doca_verbs_qp_attr_set_allow_remote_write(verbs_qp_attr, 1),
-                status, destroy_verbs_qp_attr);
-  DOCACHECKGOTO(doca_verbs_qp_attr_set_allow_remote_read(verbs_qp_attr, 1),
-                status, destroy_verbs_qp_attr);
-  DOCACHECKGOTO(doca_verbs_qp_attr_set_allow_remote_atomic(
-                  verbs_qp_attr, DOCA_VERBS_QP_ATOMIC_MODE_IB_SPEC),
-                status, destroy_verbs_qp_attr);
-  DOCACHECKGOTO(doca_verbs_qp_attr_set_ah_attr(verbs_qp_attr, ctx->ah),
-                status, destroy_verbs_qp_attr);
-  DOCACHECKGOTO(doca_verbs_qp_attr_set_dest_qp_num(verbs_qp_attr, exch_info->qpn),
-                status, destroy_verbs_qp_attr);
-  DOCACHECKGOTO(doca_verbs_qp_attr_set_pkey_index(verbs_qp_attr, ncclParamIbPkey()),
+  DOCACHECKGOTO(doca_verbs_qp_attr_set_allow_remote_write(verbs_qp_attr, 1), status, destroy_verbs_qp_attr);
+  DOCACHECKGOTO(doca_verbs_qp_attr_set_allow_remote_read(verbs_qp_attr, 1), status, destroy_verbs_qp_attr);
+  DOCACHECKGOTO(doca_verbs_qp_attr_set_allow_remote_atomic(verbs_qp_attr, DOCA_VERBS_QP_ATOMIC_MODE_IB_SPEC), status,
+                destroy_verbs_qp_attr);
+  DOCACHECKGOTO(doca_verbs_qp_attr_set_ah_attr(verbs_qp_attr, ctx->ah), status, destroy_verbs_qp_attr);
+  DOCACHECKGOTO(doca_verbs_qp_attr_set_dest_qp_num(verbs_qp_attr, exch_info->qpn), status, destroy_verbs_qp_attr);
+  DOCACHECKGOTO(doca_verbs_qp_attr_set_pkey_index(verbs_qp_attr, ncclParamIbPkey()), status, destroy_verbs_qp_attr);
+
+  DOCACHECKGOTO(doca_verbs_qp_modify(gqp->qp, verbs_qp_attr,
+                                     DOCA_VERBS_QP_ATTR_NEXT_STATE | DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_WRITE |
+                                       DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_READ | DOCA_VERBS_QP_ATTR_PKEY_INDEX |
+                                       DOCA_VERBS_QP_ATTR_PORT_NUM),
                 status, destroy_verbs_qp_attr);
 
-  DOCACHECKGOTO(doca_verbs_qp_modify(
-                  gqp->qp, verbs_qp_attr,
-                  DOCA_VERBS_QP_ATTR_NEXT_STATE | DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_WRITE |
-                    DOCA_VERBS_QP_ATTR_ALLOW_REMOTE_READ | DOCA_VERBS_QP_ATTR_PKEY_INDEX |
-                    DOCA_VERBS_QP_ATTR_PORT_NUM),
+  DOCACHECKGOTO(doca_verbs_qp_attr_set_max_dest_rd_atomic(verbs_qp_attr, max_dest_rd_atomic), status,
+                destroy_verbs_qp_attr);
+
+  DOCACHECKGOTO(doca_verbs_qp_attr_set_next_state(verbs_qp_attr, DOCA_VERBS_QP_STATE_RTR), status,
+                destroy_verbs_qp_attr);
+
+  DOCACHECKGOTO(doca_verbs_qp_modify(gqp->qp, verbs_qp_attr,
+                                     DOCA_VERBS_QP_ATTR_NEXT_STATE | DOCA_VERBS_QP_ATTR_RQ_PSN |
+                                       DOCA_VERBS_QP_ATTR_DEST_QP_NUM | DOCA_VERBS_QP_ATTR_PATH_MTU |
+                                       DOCA_VERBS_QP_ATTR_AH_ATTR | DOCA_VERBS_QP_ATTR_MIN_RNR_TIMER |
+                                       DOCA_VERBS_QP_ATTR_MAX_DEST_RD_ATOMIC),
                 status, destroy_verbs_qp_attr);
 
+  DOCACHECKGOTO(doca_verbs_qp_attr_set_max_rd_atomic(verbs_qp_attr, max_qp_rd_atomic), status, destroy_verbs_qp_attr);
 
-  DOCACHECKGOTO(
-    doca_verbs_qp_attr_set_max_dest_rd_atomic(verbs_qp_attr, max_dest_rd_atomic),
-    status, destroy_verbs_qp_attr);
+  DOCACHECKGOTO(doca_verbs_qp_attr_set_next_state(verbs_qp_attr, DOCA_VERBS_QP_STATE_RTS), status,
+                destroy_verbs_qp_attr);
 
-  DOCACHECKGOTO(
-    doca_verbs_qp_attr_set_next_state(verbs_qp_attr, DOCA_VERBS_QP_STATE_RTR),
-    status, destroy_verbs_qp_attr);
-
-  DOCACHECKGOTO(doca_verbs_qp_modify(
-                  gqp->qp, verbs_qp_attr,
-                  DOCA_VERBS_QP_ATTR_NEXT_STATE | DOCA_VERBS_QP_ATTR_RQ_PSN |
-                    DOCA_VERBS_QP_ATTR_DEST_QP_NUM | DOCA_VERBS_QP_ATTR_PATH_MTU |
-                    DOCA_VERBS_QP_ATTR_AH_ATTR | DOCA_VERBS_QP_ATTR_MIN_RNR_TIMER | DOCA_VERBS_QP_ATTR_MAX_DEST_RD_ATOMIC),
-                status, destroy_verbs_qp_attr);
-
-  DOCACHECKGOTO(
-    doca_verbs_qp_attr_set_max_rd_atomic(verbs_qp_attr, max_qp_rd_atomic),
-    status, destroy_verbs_qp_attr);
-
-  DOCACHECKGOTO(
-    doca_verbs_qp_attr_set_next_state(verbs_qp_attr, DOCA_VERBS_QP_STATE_RTS),
-    status, destroy_verbs_qp_attr);
-
-  DOCACHECKGOTO(doca_verbs_qp_modify(
-                  gqp->qp, verbs_qp_attr,
-                  DOCA_VERBS_QP_ATTR_NEXT_STATE | DOCA_VERBS_QP_ATTR_SQ_PSN |
-                    DOCA_VERBS_QP_ATTR_ACK_TIMEOUT | DOCA_VERBS_QP_ATTR_RETRY_CNT |
-                    DOCA_VERBS_QP_ATTR_RNR_RETRY | DOCA_VERBS_QP_ATTR_MAX_QP_RD_ATOMIC),
+  DOCACHECKGOTO(doca_verbs_qp_modify(gqp->qp, verbs_qp_attr,
+                                     DOCA_VERBS_QP_ATTR_NEXT_STATE | DOCA_VERBS_QP_ATTR_SQ_PSN |
+                                       DOCA_VERBS_QP_ATTR_ACK_TIMEOUT | DOCA_VERBS_QP_ATTR_RETRY_CNT |
+                                       DOCA_VERBS_QP_ATTR_RNR_RETRY | DOCA_VERBS_QP_ATTR_MAX_QP_RD_ATOMIC),
                 status, destroy_verbs_qp_attr);
 
   DOCACHECK(doca_verbs_qp_attr_destroy(verbs_qp_attr));
@@ -481,11 +456,11 @@ destroy_verbs_qp_attr:
 
 NCCL_PARAM(GinGdakiUseReliableDB, "GDAKI_USE_RELIABLE_DB", 0);
 
-ncclResult_t ncclGinGdakiCreateContext(void *collComm, int nSignals, int nCounters, int nContexts, int queueDepth,
-                                       int trafficClass, void **outGinCtx, ncclNetDeviceHandle_t **outDevHandle) {
+ncclResult_t ncclGinGdakiCreateContext(void* collComm, int nSignals, int nCounters, int nContexts, int queueDepth,
+                                       int trafficClass, void** outGinCtx, ncclNetDeviceHandle_t** outDevHandle) {
   ncclResult_t status = ncclSuccess;
 
-  struct ncclGinIbCollComm *cComm = (struct ncclGinIbCollComm *)collComm;
+  struct ncclGinIbCollComm* cComm = (struct ncclGinIbCollComm*)collComm;
 
   char pciBusId[MAX_PCI_ADDRESS_LEN];
 
@@ -496,36 +471,39 @@ ncclResult_t ncclGinGdakiCreateContext(void *collComm, int nSignals, int nCounte
   const int nqps_for_comm = nqps_per_rank * nranks;  // Number of QPs for communication
   const int ncompanion_qps = nqps_for_comm * 2;      // Number of companion QPs for communication
                                                      // Double because we connect to self.
-  const int nqps =
-    nqps_per_rank * (nranks + 1);  // +1 for the local rank.
+  const int nqps = nqps_per_rank * (nranks + 1);  // +1 for the local rank.
                                    // The last group is the responder of the local rank.
 
   // TODO: Take these config parameters from the environment variables or users.
   const int num_counters = nCounters;
   const int num_signals = nSignals;
   ncclNetProperties_t props;
-  ncclNetDeviceHandle_t *devHandle = nullptr;
-  struct gdaki_context *gdaki_ctx = nullptr;
-  struct gdaki_exch_info *local_exch_info = nullptr;
-  struct gdaki_exch_info *remote_exch_info = nullptr;
+  ncclNetDeviceHandle_t* devHandle = nullptr;
+  struct gdaki_context* gdaki_ctx = nullptr;
+  struct gdaki_exch_info* local_exch_info = nullptr;
+  struct gdaki_exch_info* remote_exch_info = nullptr;
 
   struct doca_gpu_verbs_qp_init_attr_hl qp_init_attr;
 
-  uint64_t *sink_buffer = nullptr;
-  struct ibv_mr *sink_buffer_mr = nullptr;
+  uint64_t* sink_buffer = nullptr;
+  struct ibv_mr* sink_buffer_mr = nullptr;
   CUmemGenericAllocationHandle sink_buffer_mhandle;
 
   bool need_cpu_proxy = false;
 
-  struct doca_gpu_verbs_qp **gverbs_qps = nullptr;
+  struct doca_gpu_verbs_qp** gverbs_qps = nullptr;
 
-  GdakiHostGPUMemHandle<struct ncclGinGdakiGPUContext> *gin_gdaki_gpu_ctx_hd_mhandle =
+  GdakiHostGPUMemHandle<struct ncclGinGdakiGPUContext>* gin_gdaki_gpu_ctx_hd_mhandle =
     new GdakiHostGPUMemHandle<struct ncclGinGdakiGPUContext>();
-  GdakiGlobalGPUBufferTable<uint64_t> *counters_table = new GdakiGlobalGPUBufferTable<uint64_t>();
-  GdakiGlobalGPUBufferTable<uint64_t> *signals_table = new GdakiGlobalGPUBufferTable<uint64_t>();
+  GdakiGlobalGPUBufferTable<uint64_t>* counters_table = new GdakiGlobalGPUBufferTable<uint64_t>();
+  GdakiGlobalGPUBufferTable<uint64_t>* signals_table = new GdakiGlobalGPUBufferTable<uint64_t>();
 
-  const int ib_sl = (ncclParamIbSl() != -1) ? ncclParamIbSl() : (trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? trafficClass : NCCL_IB_SL_DEFAULT;
-  const int ib_tc = (ncclParamIbTc() != -1) ? ncclParamIbTc() : (trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? trafficClass : NCCL_IB_TC_DEFAULT;
+  const int ib_sl = (ncclParamIbSl() != -1)                        ? ncclParamIbSl() :
+                    (trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? trafficClass :
+                                                                     NCCL_IB_SL_DEFAULT;
+  const int ib_tc = (ncclParamIbTc() != -1)                        ? ncclParamIbTc() :
+                    (trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? trafficClass :
+                                                                     NCCL_IB_TC_DEFAULT;
   int ib_gid_index = 0;
 
   NCCLCHECK(cComm->getProperties(cComm->dev, &props));
@@ -534,29 +512,27 @@ ncclResult_t ncclGinGdakiCreateContext(void *collComm, int nSignals, int nCounte
   NCCLCHECKGOTO(counters_table->allocate(num_counters * ncontexts, nranks), status, out);
   NCCLCHECKGOTO(signals_table->allocate(num_signals * ncontexts, nranks), status, out);
 
-  gdaki_ctx = (struct gdaki_context *)calloc(1, sizeof(*gdaki_ctx));
+  gdaki_ctx = (struct gdaki_context*)calloc(1, sizeof(*gdaki_ctx));
   EQCHECKGOTO(gdaki_ctx, nullptr, status, out);
 
-  devHandle = (ncclNetDeviceHandle_t *)calloc(1, sizeof(*devHandle));
+  devHandle = (ncclNetDeviceHandle_t*)calloc(1, sizeof(*devHandle));
   EQCHECKGOTO(devHandle, nullptr, status, out);
 
-  gdaki_ctx->gqp_groups = (struct doca_gpu_verbs_qp_group_hl **)calloc(
-    nqps_for_comm, sizeof(*gdaki_ctx->gqp_groups));
+  gdaki_ctx->gqp_groups = (struct doca_gpu_verbs_qp_group_hl**)calloc(nqps_for_comm, sizeof(*gdaki_ctx->gqp_groups));
   EQCHECKGOTO(gdaki_ctx->gqp_groups, nullptr, status, out);
 
   // Main QP
-  gdaki_ctx->gqps = (struct doca_gpu_verbs_qp_hl **)calloc(nqps, sizeof(*gdaki_ctx->gqps));
+  gdaki_ctx->gqps = (struct doca_gpu_verbs_qp_hl**)calloc(nqps, sizeof(*gdaki_ctx->gqps));
   EQCHECKGOTO(gdaki_ctx->gqps, nullptr, status, out);
 
   // Companion QP
-  gdaki_ctx->companion_gqps =
-    (struct doca_gpu_verbs_qp_hl **)calloc(ncompanion_qps, sizeof(*gdaki_ctx->companion_gqps));
+  gdaki_ctx->companion_gqps = (struct doca_gpu_verbs_qp_hl**)calloc(ncompanion_qps, sizeof(*gdaki_ctx->companion_gqps));
   EQCHECKGOTO(gdaki_ctx->companion_gqps, nullptr, status, out);
 
-  local_exch_info = (struct gdaki_exch_info *)calloc(nranks, sizeof(*local_exch_info));
+  local_exch_info = (struct gdaki_exch_info*)calloc(nranks, sizeof(*local_exch_info));
   EQCHECKGOTO(local_exch_info, nullptr, status, out);
 
-  remote_exch_info = (struct gdaki_exch_info *)calloc(nranks, sizeof(*remote_exch_info));
+  remote_exch_info = (struct gdaki_exch_info*)calloc(nranks, sizeof(*remote_exch_info));
   EQCHECKGOTO(remote_exch_info, nullptr, status, out);
 
   CUDACHECK(cudaGetDevice(&gdaki_ctx->cuda_id));
@@ -574,15 +550,14 @@ ncclResult_t ncclGinGdakiCreateContext(void *collComm, int nSignals, int nCounte
   NCCLCHECKGOTO(signals_table->exchange_info(cComm), status, out);
 
   gdaki_ctx->port_num = 1; // assume 1 for mlx5 devices
-  NCCLCHECKGOTO(wrap_ibv_query_port(cComm->ib.context, gdaki_ctx->port_num, &gdaki_ctx->port_attr),
-                status, out);
+  NCCLCHECKGOTO(wrap_ibv_query_port(cComm->ib.context, gdaki_ctx->port_num, &gdaki_ctx->port_attr), status, out);
 
   // Get the GID index
-  NCCLCHECKGOTO(cComm->getGidIndex(cComm->ib.context, gdaki_ctx->port_num, &gdaki_ctx->port_attr, &ib_gid_index), status, out);
+  NCCLCHECKGOTO(cComm->getGidIndex(cComm->ib.context, gdaki_ctx->port_num, &gdaki_ctx->port_attr, &ib_gid_index),
+                status, out);
   gdaki_ctx->gid_index = ib_gid_index;
 
-  NCCLCHECKGOTO(wrap_ibv_query_gid(cComm->ib.context, 1, ib_gid_index, &gdaki_ctx->rgid), status,
-                out);
+  NCCLCHECKGOTO(wrap_ibv_query_gid(cComm->ib.context, 1, ib_gid_index, &gdaki_ctx->rgid), status, out);
 
   NCCLCHECKGOTO(gdakiCreateVerbsAh(gdaki_ctx, cComm->ib.context, ib_sl, ib_tc, ib_gid_index), status, out);
 
@@ -593,16 +568,14 @@ ncclResult_t ncclGinGdakiCreateContext(void *collComm, int nSignals, int nCounte
   qp_init_attr.gpu_dev = gdaki_ctx->gdev;
   qp_init_attr.ibpd = cComm->ib.pd;
   qp_init_attr.sq_nwqe = gdaki_ctx->qp_sq_size;
-  qp_init_attr.nic_handler =
-    (enum doca_gpu_dev_verbs_nic_handler)ncclParamGinGdakiNicHandler();
+  qp_init_attr.nic_handler = (enum doca_gpu_dev_verbs_nic_handler)ncclParamGinGdakiNicHandler();
   qp_init_attr.mreg_type = DOCA_GPUNETIO_VERBS_MEM_REG_TYPE_DEFAULT;
   if (ncclParamGinGdakiUseReliableDB())
     qp_init_attr.send_dbr_mode_ext = DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_HW;
-  else
-    qp_init_attr.send_dbr_mode_ext = DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_VALID_DBR;
+  else qp_init_attr.send_dbr_mode_ext = DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_VALID_DBR;
 
   for (int qp_idx = 0; qp_idx < nqps_for_comm; qp_idx++) {
-retry_create_qp_group_hl:
+  retry_create_qp_group_hl:
     doca_error_t docaStatus = doca_gpu_verbs_create_qp_group_hl(&qp_init_attr, &gdaki_ctx->gqp_groups[qp_idx]);
     if (docaStatus != DOCA_SUCCESS) {
       if (qp_init_attr.send_dbr_mode_ext == DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_HW) {
@@ -610,8 +583,8 @@ retry_create_qp_group_hl:
         goto retry_create_qp_group_hl;
       }
 
-      if ((qp_init_attr.send_dbr_mode_ext == DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_SW_EMULATED)
-          && ncclParamGinGdakiUseReliableDB() == 2) {
+      if ((qp_init_attr.send_dbr_mode_ext == DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_SW_EMULATED) &&
+          ncclParamGinGdakiUseReliableDB() == 2) {
         qp_init_attr.send_dbr_mode_ext = DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_VALID_DBR;
         goto retry_create_qp_group_hl;
       }
@@ -624,29 +597,24 @@ retry_create_qp_group_hl:
     gdaki_ctx->gqps[qp_idx] = &gdaki_ctx->gqp_groups[qp_idx]->qp_main;
     gdaki_ctx->companion_gqps[qp_idx] = &gdaki_ctx->gqp_groups[qp_idx]->qp_companion;
 
-    const char *dbr_opt_str =
-      qp_init_attr.send_dbr_mode_ext == DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_HW ? "HW"
-      : qp_init_attr.send_dbr_mode_ext == DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_SW_EMULATED
-        ? "SW emulation"
-        : "disabled";
-    INFO(NCCL_NET,
-         "[%d] Created a QP group: qp_idx=%d, main_qpn=%#x, companion_qpn=%#x, reliable_db=%s",
-         rank, qp_idx, doca_verbs_qp_get_qpn(gdaki_ctx->gqps[qp_idx]->qp),
+    const char* dbr_opt_str =
+      qp_init_attr.send_dbr_mode_ext == DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_HW          ? "HW" :
+      qp_init_attr.send_dbr_mode_ext == DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_NO_DBR_SW_EMULATED ? "SW emulation" :
+                                                                                                   "disabled";
+    INFO(NCCL_NET, "[%d] Created a QP group: qp_idx=%d, main_qpn=%#x, companion_qpn=%#x, reliable_db=%s", rank, qp_idx,
+         doca_verbs_qp_get_qpn(gdaki_ctx->gqps[qp_idx]->qp),
          doca_verbs_qp_get_qpn(gdaki_ctx->companion_gqps[qp_idx]->qp), dbr_opt_str);
   }
 
   qp_init_attr.send_dbr_mode_ext = DOCA_GPUNETIO_VERBS_SEND_DBR_MODE_EXT_VALID_DBR;
   for (int qp_idx = nqps_for_comm; qp_idx < nqps; qp_idx++) {
-    DOCACHECKGOTO(doca_gpu_verbs_create_qp_hl(&qp_init_attr, &gdaki_ctx->gqps[qp_idx]),
-                  status, out);
+    DOCACHECKGOTO(doca_gpu_verbs_create_qp_hl(&qp_init_attr, &gdaki_ctx->gqps[qp_idx]), status, out);
     INFO(NCCL_NET, "[%d] Created a self-loop peer QP: qp_idx=%d, qpn=%#x", rank, qp_idx,
          doca_verbs_qp_get_qpn(gdaki_ctx->gqps[qp_idx]->qp));
   }
 
   for (int qp_idx = nqps_for_comm; qp_idx < ncompanion_qps; qp_idx++) {
-    DOCACHECKGOTO(
-      doca_gpu_verbs_create_qp_hl(&qp_init_attr, &gdaki_ctx->companion_gqps[qp_idx]),
-      status, out);
+    DOCACHECKGOTO(doca_gpu_verbs_create_qp_hl(&qp_init_attr, &gdaki_ctx->companion_gqps[qp_idx]), status, out);
     INFO(NCCL_NET, "[%d] Created a self-loop peer companion QP: qp_idx=%d, qpn=%#x", rank, qp_idx,
          doca_verbs_qp_get_qpn(gdaki_ctx->companion_gqps[qp_idx]->qp));
   }
@@ -659,23 +627,18 @@ retry_create_qp_group_hl:
     }
 
     // Exchange information with peers
-    NCCLCHECKGOTO(
-      cComm->allToAll(cComm, local_exch_info, remote_exch_info, sizeof(struct gdaki_exch_info)),
-      status, out);
+    NCCLCHECKGOTO(cComm->allToAll(cComm, local_exch_info, remote_exch_info, sizeof(struct gdaki_exch_info)), status,
+                  out);
 
     for (int rank_idx = 0; rank_idx < nranks; rank_idx++) {
       int qp_idx = rank_idx + ctx_idx * nranks;
       if (rank_idx == rank)
-        gdakiFillExchInfo(&remote_exch_info[rank_idx], gdaki_ctx,
-                          gdaki_ctx->gqps[nqps_for_comm + ctx_idx]);
+        gdakiFillExchInfo(&remote_exch_info[rank_idx], gdaki_ctx, gdaki_ctx->gqps[nqps_for_comm + ctx_idx]);
 
-      NCCLCHECKGOTO(gdakiConnectQp(gdaki_ctx, gdaki_ctx->gqps[qp_idx], &remote_exch_info[rank_idx]),
-                    status, out);
+      NCCLCHECKGOTO(gdakiConnectQp(gdaki_ctx, gdaki_ctx->gqps[qp_idx], &remote_exch_info[rank_idx]), status, out);
 
-      INFO(NCCL_NET,
-           "[%d] Connected main QP: qp_idx=%d, main_qpn=%#x, remote_rank=%d, remote_qpn=%#x", rank,
-           qp_idx, doca_verbs_qp_get_qpn(gdaki_ctx->gqps[qp_idx]->qp), rank_idx,
-           remote_exch_info[rank_idx].qpn);
+      INFO(NCCL_NET, "[%d] Connected main QP: qp_idx=%d, main_qpn=%#x, remote_rank=%d, remote_qpn=%#x", rank, qp_idx,
+           doca_verbs_qp_get_qpn(gdaki_ctx->gqps[qp_idx]->qp), rank_idx, remote_exch_info[rank_idx].qpn);
     }
   }
 
@@ -684,51 +647,45 @@ retry_create_qp_group_hl:
     struct gdaki_exch_info exch_info;
     gdakiFillExchInfo(&exch_info, gdaki_ctx, gdaki_ctx->gqps[qp_idx * nranks + rank]);
     NCCLCHECKGOTO(gdakiConnectQp(gdaki_ctx, gdaki_ctx->gqps[peer_qp_idx], &exch_info), status, out);
-    INFO(NCCL_NET, "[%d] Connected self-loop peer QP: qp_idx=%d, qpn=%#x, main_qpn=%#x", rank,
-         peer_qp_idx, doca_verbs_qp_get_qpn(gdaki_ctx->gqps[peer_qp_idx]->qp), exch_info.qpn);
+    INFO(NCCL_NET, "[%d] Connected self-loop peer QP: qp_idx=%d, qpn=%#x, main_qpn=%#x", rank, peer_qp_idx,
+         doca_verbs_qp_get_qpn(gdaki_ctx->gqps[peer_qp_idx]->qp), exch_info.qpn);
   }
 
   for (int qp_idx = 0; qp_idx < nqps_for_comm; qp_idx++) {
     int peer_qp_idx = nqps_for_comm + qp_idx;
     struct gdaki_exch_info exch_info;
     gdakiFillExchInfo(&exch_info, gdaki_ctx, gdaki_ctx->companion_gqps[peer_qp_idx]);
-    NCCLCHECKGOTO(gdakiConnectQp(gdaki_ctx, gdaki_ctx->companion_gqps[qp_idx], &exch_info), status,
-                  out);
-    INFO(NCCL_NET,
-         "[%d] Connected companion QP: qp_idx=%d, companion_qpn=%#x, peer_companion_qpn=%#x", rank,
-         qp_idx, doca_verbs_qp_get_qpn(gdaki_ctx->companion_gqps[qp_idx]->qp), exch_info.qpn);
+    NCCLCHECKGOTO(gdakiConnectQp(gdaki_ctx, gdaki_ctx->companion_gqps[qp_idx], &exch_info), status, out);
+    INFO(NCCL_NET, "[%d] Connected companion QP: qp_idx=%d, companion_qpn=%#x, peer_companion_qpn=%#x", rank, qp_idx,
+         doca_verbs_qp_get_qpn(gdaki_ctx->companion_gqps[qp_idx]->qp), exch_info.qpn);
 
     gdakiFillExchInfo(&exch_info, gdaki_ctx, gdaki_ctx->companion_gqps[qp_idx]);
-    NCCLCHECKGOTO(gdakiConnectQp(gdaki_ctx, gdaki_ctx->companion_gqps[peer_qp_idx], &exch_info),
-                  status, out);
+    NCCLCHECKGOTO(gdakiConnectQp(gdaki_ctx, gdaki_ctx->companion_gqps[peer_qp_idx], &exch_info), status, out);
     INFO(NCCL_NET,
          "[%d] Connected self-loop peer companion QP: qp_idx=%d, peer_companion_qpn=%#x, "
          "companion_qpn=%#x",
-         rank, peer_qp_idx, doca_verbs_qp_get_qpn(gdaki_ctx->companion_gqps[peer_qp_idx]->qp),
-         exch_info.qpn);
+         rank, peer_qp_idx, doca_verbs_qp_get_qpn(gdaki_ctx->companion_gqps[peer_qp_idx]->qp), exch_info.qpn);
   }
 
-  NCCLCHECKGOTO(ncclCuMemAlloc((void **)&sink_buffer, &sink_buffer_mhandle, CU_MEM_HANDLE_TYPE_NONE,
-                               sizeof(uint64_t), nullptr),
+  NCCLCHECKGOTO(ncclCuMemAlloc((void**)&sink_buffer, &sink_buffer_mhandle, CU_MEM_HANDLE_TYPE_NONE, sizeof(uint64_t),
+                               nullptr),
                 status, out);
 
   NCCLCHECKGOTO(gdakiRegMr(&sink_buffer_mr, cComm->ib.pd, sink_buffer, sizeof(uint64_t),
-                           IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE |
-                             IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_ATOMIC),
+                           IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ |
+                             IBV_ACCESS_REMOTE_ATOMIC),
                 status, out);
 
-  gverbs_qps = (struct doca_gpu_verbs_qp **)calloc(nranks, sizeof(struct doca_gpu_verbs_qp *));
+  gverbs_qps = (struct doca_gpu_verbs_qp**)calloc(nranks, sizeof(struct doca_gpu_verbs_qp*));
   for (int ctx_idx = 0; ctx_idx < ncontexts; ctx_idx++) {
-    struct ncclGinGdakiGPUContext *gin_gdaki_gpu_ctx =
-      &gin_gdaki_gpu_ctx_hd_mhandle->host_buf[ctx_idx];
+    struct ncclGinGdakiGPUContext* gin_gdaki_gpu_ctx = &gin_gdaki_gpu_ctx_hd_mhandle->host_buf[ctx_idx];
 
     unsigned int buffer_start;
     for (int qp_idx = 0; qp_idx < nranks; qp_idx++) {
       gverbs_qps[qp_idx] = gdaki_ctx->gqps[(ctx_idx * nranks) + qp_idx]->qp_gverbs;
       need_cpu_proxy |= (gverbs_qps[qp_idx]->cpu_proxy);
     }
-    DOCACHECKGOTO(doca_gpu_verbs_export_multi_qps_dev(gdaki_ctx->gdev, gverbs_qps, nranks,
-                                                      &gin_gdaki_gpu_ctx->gdqp),
+    DOCACHECKGOTO(doca_gpu_verbs_export_multi_qps_dev(gdaki_ctx->gdev, gverbs_qps, nranks, &gin_gdaki_gpu_ctx->gdqp),
                   status, out);
 
     for (int qp_idx = 0; qp_idx < nranks; qp_idx++) {
@@ -760,7 +717,7 @@ retry_create_qp_group_hl:
 
   devHandle->netDeviceType = NCCL_NET_DEVICE_GIN_GDAKI;
   devHandle->netDeviceVersion = NCCL_GIN_GDAKI_VERSION;
-  devHandle->handle = (void *)gin_gdaki_gpu_ctx_hd_mhandle->gpu_buf;
+  devHandle->handle = (void*)gin_gdaki_gpu_ctx_hd_mhandle->gpu_buf;
   devHandle->size = 0;
   devHandle->needsProxyProgress = need_cpu_proxy;
 
@@ -783,7 +740,7 @@ out:
       // Clean up any allocated GPU memory
       if (gdaki_ctx->gin_gdaki_gpu_ctx_hd_mhandle) {
         for (int ctx_idx = 0; ctx_idx < ncontexts; ctx_idx++) {
-          struct ncclGinGdakiGPUContext *gin_gdaki_gpu_ctx =
+          struct ncclGinGdakiGPUContext* gin_gdaki_gpu_ctx =
             &gdaki_ctx->gin_gdaki_gpu_ctx_hd_mhandle->host_buf[ctx_idx];
           if (gin_gdaki_gpu_ctx->gdqp) {
             for (int qp_idx = 0; qp_idx < nranks; qp_idx++) {
@@ -796,7 +753,8 @@ out:
             for (int qp_idx = 0; qp_idx < nranks; qp_idx++) {
               gverbs_qps[qp_idx] = gdaki_ctx->companion_gqps[(ctx_idx * nranks) + qp_idx]->qp_gverbs;
             }
-            doca_gpu_verbs_unexport_multi_qps_dev(gdaki_ctx->gdev, gverbs_qps, nranks, gin_gdaki_gpu_ctx->companion_gdqp);
+            doca_gpu_verbs_unexport_multi_qps_dev(gdaki_ctx->gdev, gverbs_qps, nranks,
+                                                  gin_gdaki_gpu_ctx->companion_gdqp);
             gin_gdaki_gpu_ctx->companion_gdqp = nullptr;
           }
         }
@@ -846,26 +804,25 @@ out:
   return status;
 }
 
-ncclResult_t ncclGinGdakiDestroyContext(void *ginCtx) {
+ncclResult_t ncclGinGdakiDestroyContext(void* ginCtx) {
   if (!ginCtx) return ncclInvalidArgument;
 
-  struct gdaki_context *gdaki_ctx = (struct gdaki_context *)ginCtx;
-  struct ncclGinIbCollComm *cComm = gdaki_ctx->collComm;
+  struct gdaki_context* gdaki_ctx = (struct gdaki_context*)ginCtx;
+  struct ncclGinIbCollComm* cComm = gdaki_ctx->collComm;
   const int nranks = cComm->nranks;
   const int ncontexts = gdaki_ctx->nContexts;
   const int nqps_per_rank = ncontexts;
   const int nqps_for_comm = nqps_per_rank * nranks;  // Number of QPs for communication
   const int ncompanion_qps = nqps_for_comm * 2;      // Number of companion QPs for communication
                                                      // Double because we connect to self.
-  const int nqps =
-    nqps_per_rank * (nranks + 1);  // +1 for the local rank.
+  const int nqps = nqps_per_rank * (nranks + 1);  // +1 for the local rank.
                                    // The last group is the responder of the local rank.
 
   if (gdaki_ctx->gin_gdaki_gpu_ctx_hd_mhandle) {
-    struct doca_gpu_verbs_qp **gverbs_qps = (struct doca_gpu_verbs_qp **)calloc(nranks, sizeof(struct doca_gpu_verbs_qp *));
+    struct doca_gpu_verbs_qp** gverbs_qps =
+      (struct doca_gpu_verbs_qp**)calloc(nranks, sizeof(struct doca_gpu_verbs_qp*));
     for (int ctx_idx = 0; ctx_idx < ncontexts; ctx_idx++) {
-      struct ncclGinGdakiGPUContext *gin_gdaki_gpu_ctx =
-        &gdaki_ctx->gin_gdaki_gpu_ctx_hd_mhandle->host_buf[ctx_idx];
+      struct ncclGinGdakiGPUContext* gin_gdaki_gpu_ctx = &gdaki_ctx->gin_gdaki_gpu_ctx_hd_mhandle->host_buf[ctx_idx];
       if (gin_gdaki_gpu_ctx->gdqp) {
         for (int qp_idx = 0; qp_idx < nranks; qp_idx++) {
           gverbs_qps[qp_idx] = gdaki_ctx->gqps[(ctx_idx * nranks) + qp_idx]->qp_gverbs;
@@ -877,7 +834,8 @@ ncclResult_t ncclGinGdakiDestroyContext(void *ginCtx) {
         for (int qp_idx = 0; qp_idx < nranks; qp_idx++) {
           gverbs_qps[qp_idx] = gdaki_ctx->companion_gqps[(ctx_idx * nranks) + qp_idx]->qp_gverbs;
         }
-        DOCACHECK(doca_gpu_verbs_unexport_multi_qps_dev(gdaki_ctx->gdev, gverbs_qps, nranks, gin_gdaki_gpu_ctx->companion_gdqp));
+        DOCACHECK(doca_gpu_verbs_unexport_multi_qps_dev(gdaki_ctx->gdev, gverbs_qps, nranks,
+                                                        gin_gdaki_gpu_ctx->companion_gdqp));
         gin_gdaki_gpu_ctx->companion_gdqp = nullptr;
       }
     }
@@ -932,26 +890,26 @@ ncclResult_t ncclGinGdakiDestroyContext(void *ginCtx) {
   return ncclSuccess;
 }
 
-ncclResult_t ncclGinGdakiRegMrSym(void *collComm, void *data, size_t size, int type, uint64_t mr_flags, void **mhandle,
-                                  void **ginHandle) {
-  struct ncclGinIbCollComm *cComm = (struct ncclGinIbCollComm *)collComm;
+ncclResult_t ncclGinGdakiRegMrSym(void* collComm, void* data, size_t size, int type, uint64_t mr_flags, void** mhandle,
+                                  void** ginHandle) {
+  struct ncclGinIbCollComm* cComm = (struct ncclGinIbCollComm*)collComm;
   ncclResult_t status = ncclSuccess;
 
-  struct ibv_mr *mr = nullptr;
-  GdakiHostGPUMemHandle<struct ncclGinGdakiMemHandle> *gdaki_mhandle_hd_mhandle =
+  struct ibv_mr* mr = nullptr;
+  GdakiHostGPUMemHandle<struct ncclGinGdakiMemHandle>* gdaki_mhandle_hd_mhandle =
     new GdakiHostGPUMemHandle<struct ncclGinGdakiMemHandle>();
-  GdakiHostGPUMemHandle<__be32> *rkeys_hd_mhandle =
-    new GdakiHostGPUMemHandle<__be32>();
+  GdakiHostGPUMemHandle<__be32>* rkeys_hd_mhandle = new GdakiHostGPUMemHandle<__be32>();
   __be32 rkey;
 
-  struct gdaki_mem_handle *gdaki_mhandle = nullptr;
-  gdaki_mhandle = (struct gdaki_mem_handle *)calloc(1, sizeof(*gdaki_mhandle));
+  struct gdaki_mem_handle* gdaki_mhandle = nullptr;
+  gdaki_mhandle = (struct gdaki_mem_handle*)calloc(1, sizeof(*gdaki_mhandle));
   EQCHECK(gdaki_mhandle, nullptr);
 
   bool force_strict_ordering = (mr_flags & NCCL_NET_MR_FLAG_FORCE_SO);
   NCCLCHECK(gdakiRegMr(&mr, cComm->ib.pd, data, size,
                        IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ |
-                         IBV_ACCESS_REMOTE_ATOMIC, force_strict_ordering));
+                         IBV_ACCESS_REMOTE_ATOMIC,
+                       force_strict_ordering));
 
   rkey = htobe32(mr->rkey);
   NCCLCHECKGOTO(rkeys_hd_mhandle->allocate(cComm->nranks), status, out);
@@ -968,11 +926,11 @@ ncclResult_t ncclGinGdakiRegMrSym(void *collComm, void *data, size_t size, int t
   gdaki_mhandle->gdaki_mhandle_hd_mhandle = gdaki_mhandle_hd_mhandle;
   gdaki_mhandle->rkeys_hd_mhandle = rkeys_hd_mhandle;
 
-  INFO(NCCL_NET, "[%d] Registered MR: data=%p, size=%zu, lkey(be32)=%#x, rkey(be32)=%#x",
-       cComm->rank, data, size, htobe32(mr->lkey), htobe32(mr->rkey));
+  INFO(NCCL_NET, "[%d] Registered MR: data=%p, size=%zu, lkey(be32)=%#x, rkey(be32)=%#x", cComm->rank, data, size,
+       htobe32(mr->lkey), htobe32(mr->rkey));
 
-  *mhandle = (void *)gdaki_mhandle;
-  *ginHandle = (void *)gdaki_mhandle_hd_mhandle->gpu_buf;
+  *mhandle = (void*)gdaki_mhandle;
+  *ginHandle = (void*)gdaki_mhandle_hd_mhandle->gpu_buf;
 
 out:
   if (status != ncclSuccess) {
@@ -982,13 +940,13 @@ out:
   return status;
 }
 
-ncclResult_t ncclGinGdakiDeregMrSym(void *collComm, void *mhandle) {
-  struct ncclGinIbCollComm *cComm = (struct ncclGinIbCollComm *)collComm;
-  struct gdaki_mem_handle *gdaki_mhandle = (struct gdaki_mem_handle *)mhandle;
-  struct ibv_mr *mr = gdaki_mhandle->mr;
+ncclResult_t ncclGinGdakiDeregMrSym(void* collComm, void* mhandle) {
+  struct ncclGinIbCollComm* cComm = (struct ncclGinIbCollComm*)collComm;
+  struct gdaki_mem_handle* gdaki_mhandle = (struct gdaki_mem_handle*)mhandle;
+  struct ibv_mr* mr = gdaki_mhandle->mr;
 
-  INFO(NCCL_NET, "[%d] Unregistering MR: lkey(be32)=%#x, rkey(be32)=%#x", cComm->rank,
-       htobe32(mr->lkey), htobe32(mr->rkey));
+  INFO(NCCL_NET, "[%d] Unregistering MR: lkey(be32)=%#x, rkey(be32)=%#x", cComm->rank, htobe32(mr->lkey),
+       htobe32(mr->rkey));
 
   NCCLCHECK(wrap_ibv_dereg_mr(mr));
 
@@ -1004,8 +962,8 @@ ncclResult_t ncclGinGdakiDeregMrSym(void *collComm, void *mhandle) {
   return ncclSuccess;
 }
 
-ncclResult_t ncclGinGdakiProgress(void *ctx) {
-  struct gdaki_context *gdakiCtx = (struct gdaki_context *)ctx;
+ncclResult_t ncclGinGdakiProgress(void* ctx) {
+  struct gdaki_context* gdakiCtx = (struct gdaki_context*)ctx;
   const int ncontexts = gdakiCtx->nContexts;
   const int nranks = gdakiCtx->collComm->nranks;
   const int nqpsPerRank = ncontexts;
@@ -1016,7 +974,7 @@ ncclResult_t ncclGinGdakiProgress(void *ctx) {
   while (has_progressed) {
     has_progressed = false;
     for (int qpIdx = 0; qpIdx < nqpsForComm; qpIdx++) {
-      struct doca_gpu_verbs_qp *qp = gdakiCtx->gqps[qpIdx]->qp_gverbs;
+      struct doca_gpu_verbs_qp* qp = gdakiCtx->gqps[qpIdx]->qp_gverbs;
       if (qp->cpu_proxy) {
         DOCACHECK(doca_gpu_verbs_cpu_proxy_progress(qp, &progressed));
         has_progressed |= progressed;
@@ -1033,8 +991,8 @@ ncclResult_t ncclGinGdakiProgress(void *ctx) {
   return ncclSuccess;
 }
 
-ncclResult_t ncclGinGdakiQueryLastError(void *ginCtx, bool *hasError) {
-  struct gdaki_context *gdakiCtx = (struct gdaki_context *)ginCtx;
+ncclResult_t ncclGinGdakiQueryLastError(void* ginCtx, bool* hasError) {
+  struct gdaki_context* gdakiCtx = (struct gdaki_context*)ginCtx;
   bool hasError_ = false;
   const int ncontexts = gdakiCtx->nContexts;
   const int nranks = gdakiCtx->collComm->nranks;
@@ -1049,7 +1007,7 @@ ncclResult_t ncclGinGdakiQueryLastError(void *ginCtx, bool *hasError) {
   gdakiCtx->last_error_query_time = now;
 
   for (int qpIdx = 0; qpIdx < nqpsForComm; qpIdx++) {
-    struct doca_gpu_verbs_qp *qp = gdakiCtx->gqps[qpIdx]->qp_gverbs;
+    struct doca_gpu_verbs_qp* qp = gdakiCtx->gqps[qpIdx]->qp_gverbs;
     struct doca_gpu_verbs_qp_error_info errorInfo;
     DOCACHECK(doca_gpu_verbs_query_last_error(qp, &errorInfo));
     hasError_ |= errorInfo.has_error;

--- a/projects/rccl/src/transport/net_ib/gdaki/gin_host_gdaki.h
+++ b/projects/rccl/src/transport/net_ib/gdaki/gin_host_gdaki.h
@@ -25,13 +25,13 @@
 #include "nccl.h"
 #include "gin/gin_host.h"
 
-ncclResult_t ncclGinGdakiCreateContext(void *collComm, int nSignals, int nCounters, int nContexts, int queueDepth,
-                                       int trafficClass, void **outGinCtx, ncclNetDeviceHandle_t **outDevHandle);
-ncclResult_t ncclGinGdakiDestroyContext(void *ginCtx);
-ncclResult_t ncclGinGdakiRegMrSym(void *collComm, void *data, size_t size, int type, uint64_t mr_flags, void **mhandle,
-                                  void **ginHandle);
-ncclResult_t ncclGinGdakiDeregMrSym(void *collComm, void *mhandle);
-ncclResult_t ncclGinGdakiProgress(void *ginCtx);
-ncclResult_t ncclGinGdakiQueryLastError(void *ginCtx, bool *hasError);
+ncclResult_t ncclGinGdakiCreateContext(void* collComm, int nSignals, int nCounters, int nContexts, int queueDepth,
+                                       int trafficClass, void** outGinCtx, ncclNetDeviceHandle_t** outDevHandle);
+ncclResult_t ncclGinGdakiDestroyContext(void* ginCtx);
+ncclResult_t ncclGinGdakiRegMrSym(void* collComm, void* data, size_t size, int type, uint64_t mr_flags, void** mhandle,
+                                  void** ginHandle);
+ncclResult_t ncclGinGdakiDeregMrSym(void* collComm, void* mhandle);
+ncclResult_t ncclGinGdakiProgress(void* ginCtx);
+ncclResult_t ncclGinGdakiQueryLastError(void* ginCtx, bool* hasError);
 
 #endif

--- a/projects/rccl/src/transport/net_ib/gdr.cc
+++ b/projects/rccl/src/transport/net_ib/gdr.cc
@@ -39,15 +39,14 @@ static void ibGdrSupportInitOnce() {
     // this `memory_peers` directory is either not created (go to else-if condition)
     // or created under a different path like `/sys/kernel/` or `/sys/` (depending on your ib_peer_mem module)
     const char* memory_peers_paths[] = {"/sys/kernel/mm/memory_peers/amdkfd/version",
-                                  "/sys/kernel/memory_peers/amdkfd/version",
-                                  "/sys/memory_peers/amdkfd/version",
-                                  NULL};
+                                        "/sys/kernel/memory_peers/amdkfd/version", "/sys/memory_peers/amdkfd/version",
+                                        NULL};
     int i = 0;
 
     while (memory_peers_paths[i]) {
       if (access(memory_peers_paths[i], F_OK) == 0) {
         ncclIbGdrModuleLoaded = 1;
-        INFO(NCCL_INIT,"Found %s", memory_peers_paths[i]);
+        INFO(NCCL_INIT, "Found %s", memory_peers_paths[i]);
         break;
       } else {
         ncclIbGdrModuleLoaded = 0;
@@ -60,25 +59,24 @@ static void ibGdrSupportInitOnce() {
     if (strncmp("Hyper-V UEFI Release", strValue, 20) == 0) {
       int roMode = ncclParamIbPciRelaxedOrdering();
       (void)ncclTopoGetStrFromSys("/proc/sys/kernel", "numa_balancing", strValue);
-      if (strcmp(strValue, "1") == 0 && roMode == 0)
-        ncclIbGdrModuleLoaded = 0;
+      if (strcmp(strValue, "1") == 0 && roMode == 0) ncclIbGdrModuleLoaded = 0;
     }
 
     if (ncclIbGdrModuleLoaded == 0) {
       // Check for `ib_register_peer_memory_client` symbol in `/proc/kallsyms`
       // if your system uses native OS ib_peer module
       char buf[256];
-      FILE *fp = NULL;
+      FILE* fp = NULL;
       fp = fopen("/proc/kallsyms", "r");
 
       if (fp == NULL) {
-        INFO(NCCL_INIT,"Could not open /proc/kallsyms");
+        INFO(NCCL_INIT, "Could not open /proc/kallsyms");
       } else {
         while (fgets(buf, sizeof(buf), fp) != NULL) {
           if (strstr(buf, "t ib_register_peer_memory_client") != NULL ||
               strstr(buf, "T ib_register_peer_memory_client") != NULL) {
             ncclIbGdrModuleLoaded = 1;
-            INFO(NCCL_INIT,"Found ib_register_peer_memory_client in /proc/kallsyms");
+            INFO(NCCL_INIT, "Found ib_register_peer_memory_client in /proc/kallsyms");
             break;
           }
         }
@@ -97,8 +95,7 @@ static void ibGdrSupportInitOnce() {
 ncclResult_t ncclIbGdrSupport() {
   static std::once_flag once;
   std::call_once(once, ibGdrSupportInitOnce);
-  if (!ncclIbGdrModuleLoaded)
-    return ncclSystemError;
+  if (!ncclIbGdrModuleLoaded) return ncclSystemError;
   return ncclSuccess;
 }
 
@@ -111,8 +108,7 @@ static void ibPeerMemSupportInitOnce() {
 ncclResult_t ncclIbPeerMemSupport() {
   static std::once_flag once;
   std::call_once(once, ibPeerMemSupportInitOnce);
-  if (!ncclIbPeerMemModuleLoaded)
-    return ncclSystemError;
+  if (!ncclIbPeerMemModuleLoaded) return ncclSystemError;
   return ncclSuccess;
 }
 

--- a/projects/rccl/src/transport/net_ib/gin.cc
+++ b/projects/rccl/src/transport/net_ib/gin.cc
@@ -16,9 +16,8 @@ const int NCCL_GIN_IB_ALLTOALL_TAG = 0xa1;
 // Check GDR support for GIN. This is run at init, so we don't know yet whether the GPU will support DMA-BUF.
 static ncclResult_t ncclGinIbGdrSupport(bool* gdrSupport, bool gdaki) {
   *gdrSupport = true;
-  bool peerMemSupport =
-     gdaki ? ncclIbPeerMemSupport() == ncclSuccess : // GDAKI does not support nv_peer_mem.
-     ncclIbGdrSupport() == ncclSuccess;
+  bool peerMemSupport = gdaki ? ncclIbPeerMemSupport() == ncclSuccess : // GDAKI does not support nv_peer_mem.
+                                ncclIbGdrSupport() == ncclSuccess;
   if (peerMemSupport) return ncclSuccess;
 
   if (ncclIbDmaBufSupport(0) == ncclSuccess) return ncclSuccess;
@@ -30,9 +29,8 @@ static ncclResult_t ncclGinIbGdrSupport(bool* gdrSupport, bool gdaki) {
 
 // Check the current GPU supports GDR for GIN. This is run during connect().
 static ncclResult_t ncclGinIbGdrGpuSupport(bool gdaki) {
-  bool peerMemSupport =
-     gdaki ? ncclIbPeerMemSupport() == ncclSuccess : // GDAKI does not support nv_peer_mem.
-     ncclIbGdrSupport() == ncclSuccess;
+  bool peerMemSupport = gdaki ? ncclIbPeerMemSupport() == ncclSuccess : // GDAKI does not support nv_peer_mem.
+                                ncclIbGdrSupport() == ncclSuccess;
   if (peerMemSupport) return ncclSuccess;
 
 #if !defined(__HIP_PLATFORM_AMD__)
@@ -81,7 +79,8 @@ extern ncclGin_t ncclGinIbProxy;
 
 // Initlialize GDAKI or PROXY backend. ginType can force a particular backend.
 // If provided, overwrite ginIb with the backend (generic ginIb case).
-ncclResult_t ncclGinIbInitType(void** ctx, uint64_t commId, ncclDebugLogger_t logFunction, int ginType, ncclGin_t* ginIb) {
+ncclResult_t ncclGinIbInitType(void** ctx, uint64_t commId, ncclDebugLogger_t logFunction, int ginType,
+                               ncclGin_t* ginIb) {
   NCCLCHECK(ncclIbInitDevices(logFunction, nullptr));
   if (ncclNIbDevs == 0) return ncclInternalError; // Caught in plugin init code, not propagated to user.
 
@@ -90,7 +89,7 @@ ncclResult_t ncclGinIbInitType(void** ctx, uint64_t commId, ncclDebugLogger_t lo
 #endif // !defined(__HIP_PLATFORM_AMD__)
   if (ginType == NCCL_GIN_TYPE_PROXY) goto try_proxy;
   if (ginType != -1) {
-    INFO(NCCL_INIT|NCCL_NET, "NET_IB: no support for GIN type %ld", ncclParamGinType());
+    INFO(NCCL_INIT | NCCL_NET, "NET_IB: no support for GIN type %ld", ncclParamGinType());
     return ncclInternalError;
   }
 
@@ -127,20 +126,20 @@ ncclResult_t ncclGinIbInit(void** ctx, uint64_t commId, ncclDebugLogger_t logFun
 
 // Forward declarations for Proxy functions referenced in ncclGinIb dispatcher below.
 ncclResult_t ncclGinIbProxyGetProperties(int dev, ncclNetProperties_t* props);
-ncclResult_t ncclGinIbProxyRegMrSym(void* collComm, void* data, size_t size, int type, uint64_t mr_flags, void** mhandle, void **ginHandle);
-ncclResult_t ncclGinIbProxyRegMrSymDmaBuf(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd, uint64_t mr_flags, void** mhandle, void **ginHandle);
+ncclResult_t ncclGinIbProxyRegMrSym(void* collComm, void* data, size_t size, int type, uint64_t mr_flags,
+                                    void** mhandle, void** ginHandle);
+ncclResult_t ncclGinIbProxyRegMrSymDmaBuf(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd,
+                                          uint64_t mr_flags, void** mhandle, void** ginHandle);
 ncclResult_t ncclGinIbProxyDeregMrSym(void* collComm, void* mhandle);
-ncclResult_t ncclGinIbProxyIPut(void *collComm, uint64_t srcOff, void *srcMhandle, size_t size,
-                                uint64_t dstOff, void *dstMhandle, uint32_t rank, int connectionId,
-                                void **request);
-ncclResult_t ncclGinIbProxyIPutSignal(void *collComm, uint64_t srcOff, void *srcMhandle,
-                                      size_t size, uint64_t dstOff, void *dstMhandle, uint32_t rank,
-                                      uint64_t signalOff, void *signalMhandle, uint64_t signalValue,
-                                      uint32_t signalOp, int connectionId, void **request);
-ncclResult_t ncclGinIbProxyTest(void *collComm, void *request, int *done);
-ncclResult_t ncclGinIbFinalize(void *ctx);
-ncclResult_t ncclGinIbConnect(void *ctx, void *handles[], int nranks, int rank, int nConnections,
-                              int queueDepth, void *listenComm, void **collComm);
+ncclResult_t ncclGinIbProxyIPut(void* collComm, uint64_t srcOff, void* srcMhandle, size_t size, uint64_t dstOff,
+                                void* dstMhandle, uint32_t rank, int connectionId, void** request);
+ncclResult_t ncclGinIbProxyIPutSignal(void* collComm, uint64_t srcOff, void* srcMhandle, size_t size, uint64_t dstOff,
+                                      void* dstMhandle, uint32_t rank, uint64_t signalOff, void* signalMhandle,
+                                      uint64_t signalValue, uint32_t signalOp, int connectionId, void** request);
+ncclResult_t ncclGinIbProxyTest(void* collComm, void* request, int* done);
+ncclResult_t ncclGinIbFinalize(void* ctx);
+ncclResult_t ncclGinIbConnect(void* ctx, void* handles[], int nranks, int rank, int nConnections, int queueDepth,
+                              void* listenComm, void** collComm);
 ncclResult_t ncclGinIbCloseColl(void* collComm);
 
 // [RCCL] ncclGinIb (the "GIN_IB" built-in) is defined *after* ncclGinIbProxy,
@@ -148,124 +147,104 @@ ncclResult_t ncclGinIbCloseColl(void* collComm);
 // to the v13-shaped (NCCL 2.30) ncclGin_t op definitions further down, not to
 // the stale v12-era forward declarations above (which would mis-shape it).
 
-ncclResult_t ncclGinIbFinalize(void *ctx) {
+ncclResult_t ncclGinIbFinalize(void* ctx) {
   if (ctx) free(ctx);
   return ncclIbFinalizeDevices();
 }
 
-static ncclResult_t ncclGinIbAllGather(struct ncclGinIbCollComm *cComm, void *srcBuf, void *recvBuf, size_t len) {
+static ncclResult_t ncclGinIbAllGather(struct ncclGinIbCollComm* cComm, void* srcBuf, void* recvBuf, size_t len) {
   ncclResult_t status = ncclSuccess;
   void *rMhandle = NULL, *sMhandle = NULL;
   void *srequest = NULL, *rrequest = NULL;
   int speer;
   int rpeer;
-  void *rbuf;
+  void* rbuf;
   int tag;
   int done;
 
-  NCCLCHECKGOTO(ncclNetIb.regMr(cComm->recvComm, recvBuf,
-                                cComm->nranks * len, NCCL_PTR_HOST,
-                                &rMhandle),
-                status, out);
-  NCCLCHECKGOTO(ncclNetIb.regMr(cComm->sendComm, recvBuf,
-                                cComm->nranks * len, NCCL_PTR_HOST,
-                                &sMhandle),
-                status, out);
+  NCCLCHECKGOTO(ncclNetIb.regMr(cComm->recvComm, recvBuf, cComm->nranks * len, NCCL_PTR_HOST, &rMhandle), status, out);
+  NCCLCHECKGOTO(ncclNetIb.regMr(cComm->sendComm, recvBuf, cComm->nranks * len, NCCL_PTR_HOST, &sMhandle), status, out);
 
   speer = cComm->rank;
-  memcpy((void *)((uintptr_t)recvBuf + speer * len), srcBuf, len);
+  memcpy((void*)((uintptr_t)recvBuf + speer * len), srcBuf, len);
   for (int i = 0; i < cComm->nranks - 1; i++) {
     rpeer = (speer - 1 + cComm->nranks) % cComm->nranks;
     while (srequest == NULL || rrequest == NULL) {
-      rbuf = (void *)((uintptr_t)recvBuf + rpeer * len);
+      rbuf = (void*)((uintptr_t)recvBuf + rpeer * len);
       tag = NCCL_GIN_IB_ALLGATHER_TAG;
       if (srequest == NULL)
-        NCCLCHECKGOTO(ncclNetIb.isend(cComm->sendComm,
-                                      (void *)((uintptr_t)recvBuf + speer * len),
-                                      len, tag, sMhandle, NULL, &srequest),
+        NCCLCHECKGOTO(ncclNetIb.isend(cComm->sendComm, (void*)((uintptr_t)recvBuf + speer * len), len, tag, sMhandle,
+                                      NULL, &srequest),
                       status, out);
       if (rrequest == NULL)
-        NCCLCHECKGOTO(ncclNetIb.irecv(cComm->recvComm, 1, &rbuf, &len,
-                                      &tag, &rMhandle, NULL, &rrequest),
-                      status, out);
+        NCCLCHECKGOTO(ncclNetIb.irecv(cComm->recvComm, 1, &rbuf, &len, &tag, &rMhandle, NULL, &rrequest), status, out);
     }
     while (srequest || rrequest) {
-      if (rrequest)
-        NCCLCHECKGOTO(ncclNetIb.test(rrequest, &done, NULL),
-                      status, out);
-      if (done)
-        rrequest = NULL;
-      if (srequest)
-        NCCLCHECKGOTO(ncclNetIb.test(srequest, &done, NULL),
-                      status, out);
-      if (done)
-        srequest = NULL;
+      if (rrequest) NCCLCHECKGOTO(ncclNetIb.test(rrequest, &done, NULL), status, out);
+      if (done) rrequest = NULL;
+      if (srequest) NCCLCHECKGOTO(ncclNetIb.test(srequest, &done, NULL), status, out);
+      if (done) srequest = NULL;
     }
     speer = rpeer;
   }
 
 out:
-  if (rMhandle)
-    ncclNetIb.deregMr(cComm->recvComm, rMhandle);
+  if (rMhandle) ncclNetIb.deregMr(cComm->recvComm, rMhandle);
 
-  if (sMhandle)
-    ncclNetIb.deregMr(cComm->sendComm, sMhandle);
+  if (sMhandle) ncclNetIb.deregMr(cComm->sendComm, sMhandle);
 
   return status;
 }
 
-static ncclResult_t ncclGinIbAllToAll(struct ncclGinIbCollComm *cComm, void *src_buf, void *recv_buf, size_t len) {
+static ncclResult_t ncclGinIbAllToAll(struct ncclGinIbCollComm* cComm, void* src_buf, void* recv_buf, size_t len) {
   ncclResult_t status = ncclSuccess;
 
-  void *tmp_buf = nullptr;
-  NCCLCHECK(ncclIbMalloc((void **)&tmp_buf, cComm->nranks * cComm->nranks * len));
+  void* tmp_buf = nullptr;
+  NCCLCHECK(ncclIbMalloc((void**)&tmp_buf, cComm->nranks * cComm->nranks * len));
   NCCLCHECKGOTO(cComm->allGather(cComm, src_buf, tmp_buf, cComm->nranks * len), status, out);
 
   for (int i = 0; i < cComm->nranks; i++) {
-    memcpy((void *)((uintptr_t)recv_buf + i * len), (void *)((uintptr_t)tmp_buf + i * cComm->nranks * len + cComm->rank * len), len);
+    memcpy((void*)((uintptr_t)recv_buf + i * len),
+           (void*)((uintptr_t)tmp_buf + i * cComm->nranks * len + cComm->rank * len), len);
   }
 
 out:
-  if (tmp_buf)
-    free(tmp_buf);
+  if (tmp_buf) free(tmp_buf);
 
   return status;
 }
 
-ncclResult_t ncclGinIbP2PBarrier(struct ncclGinIbCollComm *cComm) {
+ncclResult_t ncclGinIbP2PBarrier(struct ncclGinIbCollComm* cComm) {
   // TODO: move allocation to init or use zero-byte allgather
-  int *dummy;
-  NCCLCHECK(ncclIbMalloc((void **)&dummy, cComm->nranks * sizeof(int)));
+  int* dummy;
+  NCCLCHECK(ncclIbMalloc((void**)&dummy, cComm->nranks * sizeof(int)));
   NCCLCHECK(ncclGinIbAllGather(cComm, dummy + cComm->rank, dummy, sizeof(int)));
   free(dummy);
   return ncclSuccess;
 }
 
-ncclResult_t ncclGinIbConnect(void *ctx, void *handles[], int nranks, int rank,
-                              void *listenComm, void **collComm) {
-  struct ncclIbListenComm *lComm = (struct ncclIbListenComm *)listenComm;
-  struct ncclGinIbCollComm *cCommArray = nullptr;
+ncclResult_t ncclGinIbConnect(void* ctx, void* handles[], int nranks, int rank, void* listenComm, void** collComm) {
+  struct ncclIbListenComm* lComm = (struct ncclIbListenComm*)listenComm;
+  struct ncclGinIbCollComm* cCommArray = nullptr;
   int next;
 
   *collComm = NULL;
-  NCCLCHECK(ncclIbMalloc((void **)&cCommArray, sizeof(*cCommArray)));
+  NCCLCHECK(ncclIbMalloc((void**)&cCommArray, sizeof(*cCommArray)));
 
-  struct ncclGinIbCollComm *cComm = cCommArray;
+  struct ncclGinIbCollComm* cComm = cCommArray;
   cComm->ctx = ctx;
   cComm->nranks = nranks;
   cComm->rank = rank;
 
   next = (cComm->rank + 1) % nranks;
-  do
-  {
+  do {
     if (cComm->sendComm == NULL) {
       NCCLCHECK(ncclNetIb.connect(ctx, lComm->dev, handles[next], &cComm->sendComm, NULL));
     }
-    if (cComm->recvComm == NULL)
-      NCCLCHECK(ncclNetIb.accept(lComm, &cComm->recvComm, NULL));
+    if (cComm->recvComm == NULL) NCCLCHECK(ncclNetIb.accept(lComm, &cComm->recvComm, NULL));
   } while (cComm->sendComm == NULL || cComm->recvComm == NULL);
 
-  cComm->getProperties = (ncclResult_t(*)(int dev, void *props))ncclIbGetProperties;
+  cComm->getProperties = (ncclResult_t (*)(int dev, void* props))ncclIbGetProperties;
   cComm->allGather = ncclGinIbAllGather;
   cComm->allToAll = ncclGinIbAllToAll;
   cComm->getGidIndex = ncclIbGetGidIndex;
@@ -282,7 +261,7 @@ ncclResult_t ncclGinIbCloseColl(void* collComm) {
   struct ncclGinIbCollComm* cCommArray = (struct ncclGinIbCollComm*)collComm;
   if (!cCommArray) return ncclSuccess;
 
-  struct ncclGinIbCollComm *cComm = cCommArray;
+  struct ncclGinIbCollComm* cComm = cCommArray;
   if (cComm->recvComm) {
     NCCLCHECK(ncclNetIb.closeRecv(cComm->recvComm));
     cComm->recvComm = NULL;
@@ -315,7 +294,8 @@ ncclResult_t ncclGinIbGdakiDevices(int* ndev) {
 ncclResult_t ncclGinIbGdakiGetProperties(int dev, ncclNetProperties_t* props) {
   std::lock_guard<std::mutex> lock(ncclGinIbGdakiLockMutex);
   if (dev >= ncclGinIbGdakiNDevs) {
-    WARN("NET/IB : Requested properties for GIN GDAKI NIC %d, only %d GIN GDAKI NICs have been created", dev, ncclGinIbGdakiNDevs);
+    WARN("NET/IB : Requested properties for GIN GDAKI NIC %d, only %d GIN GDAKI NICs have been created", dev,
+         ncclGinIbGdakiNDevs);
     return ncclInvalidUsage;
   }
   NCCLCHECK(ncclIbGetPhysProperties(ncclGinIbGdakiDevIndexes[dev], props));
@@ -330,78 +310,76 @@ ncclResult_t ncclGinIbGdakiListen(void* ctx, int dev, void* opaqueHandle, void**
   return ncclNetIb.listen(ctx, ncclGinIbGdakiDevIndexes[dev], opaqueHandle, listenComm);
 }
 
-ncclResult_t ncclGinIbGdakiConnect(void *ctx, void *handles[], int nranks, int rank,
-                                   void *listenComm, void **collComm) {
+ncclResult_t ncclGinIbGdakiConnect(void* ctx, void* handles[], int nranks, int rank, void* listenComm,
+                                   void** collComm) {
   // Check the current GPU supports GDR
   NCCLCHECK(ncclGinIbGdrGpuSupport(/*gdaki*/ true));
 
-  NCCLCHECK(
-    ncclGinIbConnect(ctx, handles, nranks, rank, listenComm, collComm));
+  NCCLCHECK(ncclGinIbConnect(ctx, handles, nranks, rank, listenComm, collComm));
 
-  struct ncclGinIbCollComm *cComm = (struct ncclGinIbCollComm *)*collComm;
-  cComm->getProperties = (ncclResult_t(*)(int dev, void *props))ncclGinIbGdakiGetProperties;
+  struct ncclGinIbCollComm* cComm = (struct ncclGinIbCollComm*)*collComm;
+  cComm->getProperties = (ncclResult_t (*)(int dev, void* props))ncclGinIbGdakiGetProperties;
   return ncclSuccess;
 }
 
-ncclResult_t ncclGinIbGdakiCreateContext(void* collComm, ncclGinConfig_v13_t* config, void **ginCtx, ncclNetDeviceHandle_t** devHandle) {
+ncclResult_t ncclGinIbGdakiCreateContext(void* collComm, ncclGinConfig_v13_t* config, void** ginCtx,
+                                         ncclNetDeviceHandle_t** devHandle) {
   struct ncclGinIbCollComm* cComm = (struct ncclGinIbCollComm*)collComm;
 
-  NCCLCHECK(ncclGinGdakiCreateContext(cComm, config->nSignals, config->nCounters, config->nContexts, config->queueDepth, config->trafficClass, ginCtx, devHandle));
+  NCCLCHECK(ncclGinGdakiCreateContext(cComm, config->nSignals, config->nCounters, config->nContexts, config->queueDepth,
+                                      config->trafficClass, ginCtx, devHandle));
 
   return ncclSuccess;
 }
 
-ncclResult_t ncclGinIbGdakiRegMrSym(void* collComm, void* data, size_t size, int type, uint64_t mr_flags, void** mhandle, void **ginHandle) {
-  return ncclGinGdakiRegMrSym((struct ncclGinIbCollComm *)collComm, data, size, type, mr_flags, mhandle, ginHandle);
+ncclResult_t ncclGinIbGdakiRegMrSym(void* collComm, void* data, size_t size, int type, uint64_t mr_flags,
+                                    void** mhandle, void** ginHandle) {
+  return ncclGinGdakiRegMrSym((struct ncclGinIbCollComm*)collComm, data, size, type, mr_flags, mhandle, ginHandle);
 }
 
 ncclResult_t ncclGinIbGdakiDeregMrSym(void* collComm, void* mhandle) {
-  return ncclGinGdakiDeregMrSym((struct ncclGinIbCollComm *)collComm, mhandle);
+  return ncclGinGdakiDeregMrSym((struct ncclGinIbCollComm*)collComm, mhandle);
 }
 
 ncclResult_t ncclGinIbGdakiDestroyContext(void* ginCtx) {
   return ncclGinGdakiDestroyContext(ginCtx);
 }
 
-ncclResult_t ncclGinIbGdakiProgress(void *collComm)
-{
+ncclResult_t ncclGinIbGdakiProgress(void* collComm) {
   return ncclGinGdakiProgress(collComm);
 }
 
-ncclResult_t ncclGinIbGdakiQueryLastError(void *ginCtx, bool *hasError) {
+ncclResult_t ncclGinIbGdakiQueryLastError(void* ginCtx, bool* hasError) {
   return ncclGinGdakiQueryLastError(ginCtx, hasError);
 }
 
-ncclGin_t ncclGinIbGdaki = {
-  "GIN_IB_GDAKI",
-  ncclGinIbGdakiInit,
-  ncclGinIbGdakiDevices,
-  ncclGinIbGdakiGetProperties,
-  ncclGinIbGdakiListen,
-  ncclGinIbGdakiConnect,
-  ncclGinIbGdakiCreateContext,
-  ncclGinIbGdakiRegMrSym,
-  NULL, // regMrSymDmaBuf
-  ncclGinIbGdakiDeregMrSym,
-  ncclGinIbGdakiDestroyContext,
-  ncclGinIbCloseColl,
-  ncclIbCloseListen,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  ncclGinIbGdakiProgress,
-  ncclGinIbGdakiQueryLastError,
-  ncclGinIbFinalize
-};
+ncclGin_t ncclGinIbGdaki = {"GIN_IB_GDAKI",
+                            ncclGinIbGdakiInit,
+                            ncclGinIbGdakiDevices,
+                            ncclGinIbGdakiGetProperties,
+                            ncclGinIbGdakiListen,
+                            ncclGinIbGdakiConnect,
+                            ncclGinIbGdakiCreateContext,
+                            ncclGinIbGdakiRegMrSym,
+                            NULL, // regMrSymDmaBuf
+                            ncclGinIbGdakiDeregMrSym,
+                            ncclGinIbGdakiDestroyContext,
+                            ncclGinIbCloseColl,
+                            ncclIbCloseListen,
+                            NULL,
+                            NULL,
+                            NULL,
+                            NULL,
+                            NULL,
+                            ncclGinIbGdakiProgress,
+                            ncclGinIbGdakiQueryLastError,
+                            ncclGinIbFinalize};
 #endif // !defined(__HIP_PLATFORM_AMD__)
 
-
 struct ncclIbGinProxyMrHandle {
-  struct ncclIbMrHandle *mrHandle;
-  uintptr_t *base_vas;
-  uint32_t *rkeys;
+  struct ncclIbMrHandle* mrHandle;
+  uintptr_t* base_vas;
+  uint32_t* rkeys;
 };
 
 ncclResult_t ncclGinIbProxyInit(void** ctx, uint64_t commId, ncclDebugLogger_t logFunction) {
@@ -414,28 +392,28 @@ ncclResult_t ncclGinIbProxyGetProperties(int dev, ncclNetProperties_t* props) {
   return ncclSuccess;
 }
 
-ncclResult_t ncclGinIbProxyConnect(void *ctx, void *handles[], int nranks, int rank,
-                                   void *listenComm, void **collComm) {
+ncclResult_t ncclGinIbProxyConnect(void* ctx, void* handles[], int nranks, int rank, void* listenComm,
+                                   void** collComm) {
   // Check the current GPU supports GDR
   NCCLCHECK(ncclGinIbGdrGpuSupport(/*gdaki*/ false));
 
   // Connect.
-  NCCLCHECK(
-    ncclGinIbConnect(ctx, handles, nranks, rank, listenComm, collComm));
+  NCCLCHECK(ncclGinIbConnect(ctx, handles, nranks, rank, listenComm, collComm));
 
   return ncclSuccess;
 }
 
 struct ncclGinIbProxyCtx {
-  void**        fullRecvComm;
-  void**        fullSendComm;
+  void** fullRecvComm;
+  void** fullSendComm;
   int rank, nranks;
   int nContexts;
 };
 
-ncclResult_t ncclGinIbProxyCreateContext(void* collComm, ncclGinConfig_v13_t* config, void** ginCtx, ncclNetDeviceHandle_v11_t** devHandle) {
+ncclResult_t ncclGinIbProxyCreateContext(void* collComm, ncclGinConfig_v13_t* config, void** ginCtx,
+                                         ncclNetDeviceHandle_v11_t** devHandle) {
   ncclResult_t ret = ncclSuccess;
-  struct ncclGinIbCollComm *cComm = (struct ncclGinIbCollComm *)collComm;
+  struct ncclGinIbCollComm* cComm = (struct ncclGinIbCollComm*)collComm;
   // Make sure all QP we create use the provided traffic class.
   ncclIbSetTrafficClass(cComm->ctx, config->trafficClass);
 
@@ -451,18 +429,18 @@ ncclResult_t ncclGinIbProxyCreateContext(void* collComm, ncclGinConfig_v13_t* co
   ginProxyCtx[0].nContexts = config->nContexts;
   ginProxyCtx[0].nranks = nranks = cComm->nranks;
 
-  void *lComm = NULL;
-  char* handle = NULL, *handles = NULL;
-  NCCLCHECKGOTO(ncclIbMalloc((void**)&handles, NCCL_NET_HANDLE_MAXSIZE*cComm->nranks), ret, end);
-  handle = handles + NCCL_NET_HANDLE_MAXSIZE*cComm->rank;
+  void* lComm = NULL;
+  char *handle = NULL, *handles = NULL;
+  NCCLCHECKGOTO(ncclIbMalloc((void**)&handles, NCCL_NET_HANDLE_MAXSIZE * cComm->nranks), ret, end);
+  handle = handles + NCCL_NET_HANDLE_MAXSIZE * cComm->rank;
 
   NCCLCHECKGOTO(ncclNetIb.listen(cComm->ctx, cComm->dev, handle, &lComm), ret, end);
   NCCLCHECKGOTO(cComm->allGather(cComm, handle, handles, NCCL_NET_HANDLE_MAXSIZE), ret, end);
 
-  for (int c=0; c<config->nContexts; c++) {
-    struct ncclGinIbProxyCtx* gc = ginProxyCtx+c;
-    NCCLCHECKGOTO(ncclIbMalloc((void**)&gc->fullSendComm, sizeof(void *) * nranks), ret, end);
-    NCCLCHECKGOTO(ncclIbMalloc((void**)&gc->fullRecvComm, sizeof(void *) * nranks), ret, end);
+  for (int c = 0; c < config->nContexts; c++) {
+    struct ncclGinIbProxyCtx* gc = ginProxyCtx + c;
+    NCCLCHECKGOTO(ncclIbMalloc((void**)&gc->fullSendComm, sizeof(void*) * nranks), ret, end);
+    NCCLCHECKGOTO(ncclIbMalloc((void**)&gc->fullRecvComm, sizeof(void*) * nranks), ret, end);
     gc->rank = cComm->rank;
 
     for (int i = 0; i < nranks; i++) {
@@ -470,11 +448,12 @@ ncclResult_t ncclGinIbProxyCreateContext(void* collComm, ncclGinConfig_v13_t* co
       int acceptPeer = (cComm->rank - i + nranks) % nranks;
       do {
         if (gc->fullSendComm[connectPeer] == NULL)
-          NCCLCHECKGOTO(ncclNetIb.connect(cComm->ctx, cComm->dev, handles+NCCL_NET_HANDLE_MAXSIZE*connectPeer, &gc->fullSendComm[connectPeer], NULL), ret, end);
+          NCCLCHECKGOTO(ncclNetIb.connect(cComm->ctx, cComm->dev, handles + NCCL_NET_HANDLE_MAXSIZE * connectPeer,
+                                          &gc->fullSendComm[connectPeer], NULL),
+                        ret, end);
         if (gc->fullRecvComm[acceptPeer] == NULL)
           NCCLCHECKGOTO(ncclNetIb.accept(lComm, &gc->fullRecvComm[acceptPeer], NULL), ret, end);
-      } while ((gc->fullSendComm[connectPeer] == NULL) ||
-          (gc->fullRecvComm[acceptPeer] == NULL));
+      } while ((gc->fullSendComm[connectPeer] == NULL) || (gc->fullRecvComm[acceptPeer] == NULL));
       NCCLCHECKGOTO(ncclGinIbP2PBarrier(cComm), ret, end);
     }
   }
@@ -491,9 +470,9 @@ ncclResult_t ncclGinIbProxyDestroyContext(void* ginCtx) {
   struct ncclGinIbProxyCtx* gc = (struct ncclGinIbProxyCtx*)ginCtx;
   int nContexts = gc[0].nContexts;
   int nranks = gc[0].nranks;
-  for (int c=0; c<nContexts; c++) {
+  for (int c = 0; c < nContexts; c++) {
     if (gc[c].fullRecvComm) {
-      for (int i=0; i<nranks; i++) {
+      for (int i = 0; i < nranks; i++) {
         NCCLCHECK(ncclNetIb.closeRecv(gc[c].fullRecvComm[i]));
       }
       free(gc[c].fullRecvComm);
@@ -501,7 +480,7 @@ ncclResult_t ncclGinIbProxyDestroyContext(void* ginCtx) {
     }
 
     if (gc[c].fullSendComm) {
-      for (int i=0; i<nranks; i++) {
+      for (int i = 0; i < nranks; i++) {
         NCCLCHECK(ncclNetIb.closeSend(gc[c].fullSendComm[i]));
       }
       free(gc[c].fullSendComm);
@@ -511,12 +490,14 @@ ncclResult_t ncclGinIbProxyDestroyContext(void* ginCtx) {
   return ncclSuccess;
 }
 
-ncclResult_t ncclGinIbProxyRegMrSymDmaBuf(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd, uint64_t mr_flags, void** mhandle, void **ginHandle) {
-  struct ncclGinIbCollComm *cComm = (struct ncclGinIbCollComm *)collComm;
-  struct ncclIbGinProxyMrHandle *ginMrHandle;
+ncclResult_t ncclGinIbProxyRegMrSymDmaBuf(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd,
+                                          uint64_t mr_flags, void** mhandle, void** ginHandle) {
+  struct ncclGinIbCollComm* cComm = (struct ncclGinIbCollComm*)collComm;
+  struct ncclIbGinProxyMrHandle* ginMrHandle;
   NCCLCHECK(ncclCalloc(&ginMrHandle, 1));
 
-  NCCLCHECKNOWARN(ncclIbRegMrDmaBuf(cComm->recvComm, data, size, type, offset, fd, (void**)&ginMrHandle->mrHandle), NCCL_NET);
+  NCCLCHECKNOWARN(ncclIbRegMrDmaBuf(cComm->recvComm, data, size, type, offset, fd, (void**)&ginMrHandle->mrHandle),
+                  NCCL_NET);
 
   NCCLCHECK(ncclCalloc(&ginMrHandle->base_vas, cComm->nranks));
   NCCLCHECK(ncclCalloc(&ginMrHandle->rkeys, cComm->nranks));
@@ -530,13 +511,14 @@ ncclResult_t ncclGinIbProxyRegMrSymDmaBuf(void* collComm, void* data, size_t siz
   return ncclSuccess;
 }
 
-ncclResult_t ncclGinIbProxyRegMrSym(void* collComm, void* data, size_t size, int type, uint64_t mr_flags, void** mhandle, void **ginHandle) {
+ncclResult_t ncclGinIbProxyRegMrSym(void* collComm, void* data, size_t size, int type, uint64_t mr_flags,
+                                    void** mhandle, void** ginHandle) {
   return ncclGinIbProxyRegMrSymDmaBuf(collComm, data, size, type, 0, -1, mr_flags, mhandle, ginHandle);
 }
 
 ncclResult_t ncclGinIbProxyDeregMrSym(void* collComm, void* mhandle) {
-  struct ncclGinIbCollComm *cComm = (struct ncclGinIbCollComm *)collComm;
-  struct ncclIbGinProxyMrHandle *ginMrHandle = (struct ncclIbGinProxyMrHandle *)mhandle;
+  struct ncclGinIbCollComm* cComm = (struct ncclGinIbCollComm*)collComm;
+  struct ncclIbGinProxyMrHandle* ginMrHandle = (struct ncclIbGinProxyMrHandle*)mhandle;
 
   NCCLCHECK(ncclNetIb.deregMr(cComm->recvComm, ginMrHandle->mrHandle));
   free(ginMrHandle->base_vas);
@@ -550,21 +532,20 @@ ncclResult_t ncclGinIbProxyCloseColl(void* collComm) {
   return ncclSuccess;
 }
 
-ncclResult_t ncclGinIbProxyIPut(void *ginCtx, int context, uint64_t srcOff, void *srcMhandle, size_t size,
-                                uint64_t dstOff, void *dstMhandle, uint32_t rank,
-                                void **request) {
+ncclResult_t ncclGinIbProxyIPut(void* ginCtx, int context, uint64_t srcOff, void* srcMhandle, size_t size,
+                                uint64_t dstOff, void* dstMhandle, uint32_t rank, void** request) {
   struct ncclGinIbProxyCtx* ginProxyCtx = &((struct ncclGinIbProxyCtx*)ginCtx)[context];
 
-  struct ncclIbGinProxyMrHandle *srcMrHandle = (struct ncclIbGinProxyMrHandle *)srcMhandle;
-  struct ncclIbGinProxyMrHandle *dstMrHandle = (struct ncclIbGinProxyMrHandle *)dstMhandle;
+  struct ncclIbGinProxyMrHandle* srcMrHandle = (struct ncclIbGinProxyMrHandle*)srcMhandle;
+  struct ncclIbGinProxyMrHandle* dstMrHandle = (struct ncclIbGinProxyMrHandle*)dstMhandle;
 
-  void *srcPtr = (void *)(srcMrHandle->base_vas[ginProxyCtx->rank] + srcOff);
-  void *dstPtr = (void *)(dstMrHandle->base_vas[rank] + dstOff);
+  void* srcPtr = (void*)(srcMrHandle->base_vas[ginProxyCtx->rank] + srcOff);
+  void* dstPtr = (void*)(dstMrHandle->base_vas[rank] + dstOff);
   uint32_t lkey = srcMrHandle->mrHandle->mrs[0]->lkey;
   uint32_t rkey = dstMrHandle->rkeys[rank];
 
   struct ncclIbSendComm* comm = (struct ncclIbSendComm*)ginProxyCtx->fullSendComm[rank];
-  struct ncclIbQp *qp = &comm->base.qps[0];
+  struct ncclIbQp* qp = &comm->base.qps[0];
 
   struct ncclIbRequest* req;
   NCCLCHECK(ncclIbGetRequest(&comm->base, &req));
@@ -581,12 +562,12 @@ ncclResult_t ncclGinIbProxyIPut(void *ginCtx, int context, uint64_t srcOff, void
   struct ibv_sge sge;
   memset(&sge, 0, sizeof(sge));
 
-  wr.opcode                  = IBV_WR_RDMA_WRITE;
-  wr.send_flags              = IBV_SEND_SIGNALED;
-  wr.wr_id                   = req - comm->base.reqs;
-  wr.next                    = NULL;
-  wr.wr.rdma.remote_addr     = (uint64_t)dstPtr;
-  wr.wr.rdma.rkey            = rkey;
+  wr.opcode = IBV_WR_RDMA_WRITE;
+  wr.send_flags = IBV_SEND_SIGNALED;
+  wr.wr_id = req - comm->base.reqs;
+  wr.next = NULL;
+  wr.wr.rdma.remote_addr = (uint64_t)dstPtr;
+  wr.wr.rdma.rkey = rkey;
   wr.sg_list = &sge;
   wr.num_sge = 1;
 
@@ -602,16 +583,15 @@ ncclResult_t ncclGinIbProxyIPut(void *ginCtx, int context, uint64_t srcOff, void
   return ncclSuccess;
 }
 
-ncclResult_t ncclGinIbProxyIGet(void *ginCtx, int context, uint64_t remoteOffset, void *remoteMhandle,
-                                 size_t size, uint64_t localOffset, void *localMhandle, uint32_t rank,
-                                 void **request) {
+ncclResult_t ncclGinIbProxyIGet(void* ginCtx, int context, uint64_t remoteOffset, void* remoteMhandle, size_t size,
+                                uint64_t localOffset, void* localMhandle, uint32_t rank, void** request) {
   struct ncclGinIbProxyCtx* ginProxyCtx = &((struct ncclGinIbProxyCtx*)ginCtx)[context];
 
-  struct ncclIbGinProxyMrHandle *remoteMrHandle = (struct ncclIbGinProxyMrHandle *)remoteMhandle;
-  struct ncclIbGinProxyMrHandle *localMrHandle = (struct ncclIbGinProxyMrHandle *)localMhandle;
+  struct ncclIbGinProxyMrHandle* remoteMrHandle = (struct ncclIbGinProxyMrHandle*)remoteMhandle;
+  struct ncclIbGinProxyMrHandle* localMrHandle = (struct ncclIbGinProxyMrHandle*)localMhandle;
 
   struct ncclIbSendComm* comm = (struct ncclIbSendComm*)ginProxyCtx->fullSendComm[rank];
-  struct ncclIbQp *qp = &comm->base.qps[0];
+  struct ncclIbQp* qp = &comm->base.qps[0];
 
   struct ncclIbRequest* req;
   NCCLCHECK(ncclIbGetRequest(&comm->base, &req));
@@ -623,8 +603,8 @@ ncclResult_t ncclGinIbProxyIGet(void *ginCtx, int context, uint64_t remoteOffset
     req->devBases[i] = &comm->devs[i].base;
   }
 
-  void *remotePtr = (void *)(remoteMrHandle->base_vas[rank] + remoteOffset);
-  void *localPtr = (void *)(localMrHandle->base_vas[ginProxyCtx->rank] + localOffset);
+  void* remotePtr = (void*)(remoteMrHandle->base_vas[rank] + remoteOffset);
+  void* localPtr = (void*)(localMrHandle->base_vas[ginProxyCtx->rank] + localOffset);
   uint32_t rkey = remoteMrHandle->rkeys[rank];
   uint32_t lkey = localMrHandle->mrHandle->mrs[0]->lkey;
 
@@ -633,12 +613,12 @@ ncclResult_t ncclGinIbProxyIGet(void *ginCtx, int context, uint64_t remoteOffset
   struct ibv_sge sge;
   memset(&sge, 0, sizeof(sge));
 
-  wr.opcode                  = IBV_WR_RDMA_READ;
-  wr.send_flags              = IBV_SEND_SIGNALED; // TODO: Potentially optimize this?
-  wr.wr_id                   = req - comm->base.reqs;
-  wr.next                    = NULL;
-  wr.wr.rdma.remote_addr     = (uint64_t)remotePtr;
-  wr.wr.rdma.rkey            = rkey;
+  wr.opcode = IBV_WR_RDMA_READ;
+  wr.send_flags = IBV_SEND_SIGNALED; // TODO: Potentially optimize this?
+  wr.wr_id = req - comm->base.reqs;
+  wr.next = NULL;
+  wr.wr.rdma.remote_addr = (uint64_t)remotePtr;
+  wr.wr.rdma.rkey = rkey;
   wr.sg_list = &sge;
   wr.num_sge = 1;
 
@@ -654,10 +634,9 @@ ncclResult_t ncclGinIbProxyIGet(void *ginCtx, int context, uint64_t remoteOffset
   return ncclSuccess;
 }
 
-ncclResult_t ncclGinIbProxyIPutSignal(void *ginCtx, int context, uint64_t srcOff, void *srcMhandle,
-                                      size_t size, uint64_t dstOff, void *dstMhandle, uint32_t rank,
-                                      uint64_t signalOff, void *signalMhandle, uint64_t signalValue,
-                                      uint32_t signalOp, void **request) {
+ncclResult_t ncclGinIbProxyIPutSignal(void* ginCtx, int context, uint64_t srcOff, void* srcMhandle, size_t size,
+                                      uint64_t dstOff, void* dstMhandle, uint32_t rank, uint64_t signalOff,
+                                      void* signalMhandle, uint64_t signalValue, uint32_t signalOp, void** request) {
   if (signalOp != NCCL_NET_SIGNAL_OP_INC && signalOp != NCCL_NET_SIGNAL_OP_ADD) {
     WARN("ncclGinIbProxyIPutSignal: Unsupported signalOp %u", signalOp);
     return ncclInvalidArgument;
@@ -665,12 +644,12 @@ ncclResult_t ncclGinIbProxyIPutSignal(void *ginCtx, int context, uint64_t srcOff
 
   struct ncclGinIbProxyCtx* ginProxyCtx = &((struct ncclGinIbProxyCtx*)ginCtx)[context];
 
-  struct ncclIbGinProxyMrHandle *srcMrHandle = (struct ncclIbGinProxyMrHandle *)srcMhandle;
-  struct ncclIbGinProxyMrHandle *dstMrHandle = (struct ncclIbGinProxyMrHandle *)dstMhandle;
-  struct ncclIbGinProxyMrHandle *signalMrHandle = (struct ncclIbGinProxyMrHandle *)signalMhandle;
+  struct ncclIbGinProxyMrHandle* srcMrHandle = (struct ncclIbGinProxyMrHandle*)srcMhandle;
+  struct ncclIbGinProxyMrHandle* dstMrHandle = (struct ncclIbGinProxyMrHandle*)dstMhandle;
+  struct ncclIbGinProxyMrHandle* signalMrHandle = (struct ncclIbGinProxyMrHandle*)signalMhandle;
 
   struct ncclIbSendComm* comm = (struct ncclIbSendComm*)ginProxyCtx->fullSendComm[rank];
-  struct ncclIbQp *qp = &comm->base.qps[0];
+  struct ncclIbQp* qp = &comm->base.qps[0];
   int devIndex = qp->devIndex;
 
   struct ncclIbRequest* req;
@@ -690,18 +669,18 @@ ncclResult_t ncclGinIbProxyIPutSignal(void *ginCtx, int context, uint64_t srcOff
 
   // If size is 0, we only need to send the signal. srcMrHandle must be non-NULL
   if (size > 0 && dstMrHandle) {
-    void *srcPtr = (void *)(srcMrHandle->base_vas[ginProxyCtx->rank] + srcOff);
-    void *dstPtr = (void *)(dstMrHandle->base_vas[rank] + dstOff);
+    void* srcPtr = (void*)(srcMrHandle->base_vas[ginProxyCtx->rank] + srcOff);
+    void* dstPtr = (void*)(dstMrHandle->base_vas[rank] + dstOff);
     uint32_t lkey = srcMrHandle->mrHandle->mrs[0]->lkey;
     uint32_t rkey = dstMrHandle->rkeys[rank];
 
     // PUT
-    wr[0].opcode                  = IBV_WR_RDMA_WRITE;
-    wr[0].send_flags              = 0; // We only need the CQE from the signal
-    wr[0].wr_id                   = req - comm->base.reqs;
-    wr[0].next                    = &wr[1];
-    wr[0].wr.rdma.remote_addr     = (uint64_t)dstPtr;
-    wr[0].wr.rdma.rkey            = rkey;
+    wr[0].opcode = IBV_WR_RDMA_WRITE;
+    wr[0].send_flags = 0; // We only need the CQE from the signal
+    wr[0].wr_id = req - comm->base.reqs;
+    wr[0].next = &wr[1];
+    wr[0].wr.rdma.remote_addr = (uint64_t)dstPtr;
+    wr[0].wr.rdma.rkey = rkey;
     wr[0].sg_list = &sge[0];
     wr[0].num_sge = 1;
 
@@ -710,17 +689,17 @@ ncclResult_t ncclGinIbProxyIPutSignal(void *ginCtx, int context, uint64_t srcOff
     sge[0].lkey = lkey;  // Local key
   }
 
-  void *signalPtr = (void *)(signalMrHandle->base_vas[rank] + signalOff);
+  void* signalPtr = (void*)(signalMrHandle->base_vas[rank] + signalOff);
   uint32_t signalRkey = signalMrHandle->rkeys[rank];
 
   // SIGNAL
-  wr[1].opcode                  = IBV_WR_ATOMIC_FETCH_AND_ADD;
-  wr[1].send_flags              = IBV_SEND_SIGNALED;
-  wr[1].wr_id                   = req - comm->base.reqs;  // used for matching completions with request
-  wr[1].next                    = NULL;
-  wr[1].wr.atomic.remote_addr   = (uint64_t)signalPtr;
-  wr[1].wr.atomic.compare_add   = signalOp == NCCL_NET_SIGNAL_OP_INC ? 1 : signalValue;
-  wr[1].wr.atomic.rkey          = signalRkey;
+  wr[1].opcode = IBV_WR_ATOMIC_FETCH_AND_ADD;
+  wr[1].send_flags = IBV_SEND_SIGNALED;
+  wr[1].wr_id = req - comm->base.reqs;  // used for matching completions with request
+  wr[1].next = NULL;
+  wr[1].wr.atomic.remote_addr = (uint64_t)signalPtr;
+  wr[1].wr.atomic.compare_add = signalOp == NCCL_NET_SIGNAL_OP_INC ? 1 : signalValue;
+  wr[1].wr.atomic.rkey = signalRkey;
   wr[1].sg_list = &sge[1];
   wr[1].num_sge = 1;
 
@@ -736,7 +715,7 @@ ncclResult_t ncclGinIbProxyIPutSignal(void *ginCtx, int context, uint64_t srcOff
   return ncclSuccess;
 }
 
-ncclResult_t ncclGinIbProxyTest(void* collComm, void *request, int *done) {
+ncclResult_t ncclGinIbProxyTest(void* collComm, void* request, int* done) {
   struct ncclIbRequest* req = (struct ncclIbRequest*)request;
   struct ncclGinIbProxyCtx* ginProxyCtx = (struct ncclGinIbProxyCtx*)req->ginProxyCtx;
   int rank = req->iput.rank;
@@ -768,17 +747,18 @@ ncclResult_t ncclGinIbProxyTest(void* collComm, void *request, int *done) {
       ncclSocketGetAddr(req->sock, &addr);
       char localGidString[INET6_ADDRSTRLEN] = "";
       char remoteGidString[INET6_ADDRSTRLEN] = "";
-      const char* localGidStr = NULL, *remoteGidStr = NULL;
+      const char *localGidStr = NULL, *remoteGidStr = NULL;
       if (req->devBases[i]->gidInfo.link_layer == IBV_LINK_LAYER_ETHERNET) {
         localGidStr = ibvGetGidStr(&devBase->gidInfo.localGid, localGidString, sizeof(localGidString));
         remoteGidStr = ibvGetGidStr(&commBase->remDevs[i].remoteGid, remoteGidString, sizeof(remoteGidString));
       }
 
-      char line[SOCKET_NAME_MAXLEN+1];
-      char *hcaName = devBase->pd->context->device->name;
+      char line[SOCKET_NAME_MAXLEN + 1];
+      char* hcaName = devBase->pd->context->device->name;
       WARN("NET/IB/GIN: Got completion from peer %s with status=%d opcode=%d len=%u vendor err %u (%s)%s%s%s%s hca %s",
-          ncclSocketToString(&addr, line), wc[i].status, wc[i].opcode, wc[i].byte_len, wc[i].vendor_err, ncclIbReqTypeStr[req->type],
-          localGidStr ?  " localGid ":"", localGidString, remoteGidStr ? " remoteGids":"", remoteGidString, hcaName);
+           ncclSocketToString(&addr, line), wc[i].status, wc[i].opcode, wc[i].byte_len, wc[i].vendor_err,
+           ncclIbReqTypeStr[req->type], localGidStr ? " localGid " : "", localGidString,
+           remoteGidStr ? " remoteGids" : "", remoteGidString, hcaName);
       return ncclRemoteError;
     }
 
@@ -793,11 +773,11 @@ ncclResult_t ncclGinIbProxyTest(void* collComm, void *request, int *done) {
   return ncclSuccess;
 }
 
-ncclResult_t ncclGinIbProxyIFlush(void *ginCtx, int context, void* mhandle, uint32_t rank, void **request) {
+ncclResult_t ncclGinIbProxyIFlush(void* ginCtx, int context, void* mhandle, uint32_t rank, void** request) {
   struct ncclGinIbProxyCtx* ginProxyCtx = &((struct ncclGinIbProxyCtx*)ginCtx)[context];
   struct ncclIbRecvComm* comm = (struct ncclIbRecvComm*)ginProxyCtx->fullRecvComm[rank];
-  struct ncclIbGinProxyMrHandle *ginMrHandle = (struct ncclIbGinProxyMrHandle *)mhandle;
-  struct ncclIbQp *qp = &comm->devs[0].gpuFlush.qp;
+  struct ncclIbGinProxyMrHandle* ginMrHandle = (struct ncclIbGinProxyMrHandle*)mhandle;
+  struct ncclIbQp* qp = &comm->devs[0].gpuFlush.qp;
 
   struct ncclIbRequest* req;
   NCCLCHECK(ncclIbGetRequest(&comm->base, &req));
@@ -810,7 +790,7 @@ ncclResult_t ncclGinIbProxyIFlush(void *ginCtx, int context, void* mhandle, uint
   memset(&wr, 0, sizeof(wr));
   wr.wr_id = req - comm->base.reqs;
 
-  void *flushPtr = (void *)(ginMrHandle->base_vas[rank]);
+  void* flushPtr = (void*)(ginMrHandle->base_vas[rank]);
   wr.wr.rdma.remote_addr = (uint64_t)flushPtr;
   wr.wr.rdma.rkey = ginMrHandle->rkeys[rank];
   wr.sg_list = &comm->devs[qp->devIndex].gpuFlush.sge;
@@ -818,7 +798,8 @@ ncclResult_t ncclGinIbProxyIFlush(void *ginCtx, int context, void* mhandle, uint
   wr.opcode = IBV_WR_RDMA_READ;
   wr.send_flags = IBV_SEND_SIGNALED;
 
-  TRACE(NCCL_NET, "NET/IB: %s: Posting a flush request (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base, wr.wr_id);
+  TRACE(NCCL_NET, "NET/IB: %s: Posting a flush request (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base,
+        wr.wr_id);
   TIME_START(4);
   struct ibv_send_wr* bad_wr;
   NCCLCHECK(wrap_ibv_post_send(qp->qp, &wr, &bad_wr));
@@ -833,29 +814,27 @@ ncclResult_t ncclGinIbProxyIFlush(void *ginCtx, int context, void* mhandle, uint
 }
 
 // No support for NCCL_IB_SPLIT_DATA_ON_QPS or NCCL_IB_MERGE_NICS
-ncclGin_t ncclGinIbProxy = {
-  "GIN_IB_PROXY",
-  ncclGinIbProxyInit,
-  ncclIbDevices,
-  ncclGinIbProxyGetProperties,
-  ncclIbListen,
-  ncclGinIbProxyConnect,
-  ncclGinIbProxyCreateContext,
-  ncclGinIbProxyRegMrSym,
-  ncclGinIbProxyRegMrSymDmaBuf,
-  ncclGinIbProxyDeregMrSym,
-  ncclGinIbProxyDestroyContext,
-  ncclGinIbCloseColl,
-  ncclIbCloseListen,
-  ncclGinIbProxyIPut,
-  ncclGinIbProxyIPutSignal,
-  ncclGinIbProxyIGet,
-  ncclGinIbProxyIFlush,
-  ncclGinIbProxyTest,
-  NULL,
-  NULL,
-  ncclGinIbFinalize
-};
+ncclGin_t ncclGinIbProxy = {"GIN_IB_PROXY",
+                            ncclGinIbProxyInit,
+                            ncclIbDevices,
+                            ncclGinIbProxyGetProperties,
+                            ncclIbListen,
+                            ncclGinIbProxyConnect,
+                            ncclGinIbProxyCreateContext,
+                            ncclGinIbProxyRegMrSym,
+                            ncclGinIbProxyRegMrSymDmaBuf,
+                            ncclGinIbProxyDeregMrSym,
+                            ncclGinIbProxyDestroyContext,
+                            ncclGinIbCloseColl,
+                            ncclIbCloseListen,
+                            ncclGinIbProxyIPut,
+                            ncclGinIbProxyIPutSignal,
+                            ncclGinIbProxyIGet,
+                            ncclGinIbProxyIFlush,
+                            ncclGinIbProxyTest,
+                            NULL,
+                            NULL,
+                            ncclGinIbFinalize};
 
 // [RCCL] NCCL 2.29.7 introduced a top-level "ncclGinIb" dispatcher that picks
 // between GDAKI and Proxy at runtime. AMD doesn't ship the GDAKI driver-mode
@@ -864,26 +843,24 @@ ncclGin_t ncclGinIbProxy = {
 // so it binds to the v13 ncclGin_t layout (NCCL 2.30). It mirrors the prior
 // behaviour exactly: same ops as before, with the new v13-only slots
 // (createContext/destroyContext/iget/iflush) left NULL as in the v12 subset.
-ncclGin_t ncclGinIb = {
-  "GIN_IB",
-  ncclGinIbInit,                 // dispatcher init (honours NCCL_GIN_TYPE)
-  ncclIbDevices,
-  ncclGinIbProxyGetProperties,
-  ncclIbListen,
-  ncclGinIbConnect,
-  NULL,                          // createContext (subset; NULL as in prior v12 table)
-  ncclGinIbProxyRegMrSym,
-  ncclGinIbProxyRegMrSymDmaBuf,
-  ncclGinIbProxyDeregMrSym,
-  NULL,                          // destroyContext (subset)
-  ncclGinIbCloseColl,
-  ncclIbCloseListen,
-  ncclGinIbProxyIPut,
-  ncclGinIbProxyIPutSignal,
-  NULL,                          // iget (added in v13 ncclGin_t; GIN_IB has no get)
-  NULL,                          // iflush (added in v13 ncclGin_t)
-  ncclGinIbProxyTest,
-  NULL,                          // ginProgress
-  NULL,                          // queryLastError
-  ncclGinIbFinalize
-};
+ncclGin_t ncclGinIb = {"GIN_IB",
+                       ncclGinIbInit,                 // dispatcher init (honours NCCL_GIN_TYPE)
+                       ncclIbDevices,
+                       ncclGinIbProxyGetProperties,
+                       ncclIbListen,
+                       ncclGinIbConnect,
+                       NULL,                          // createContext (subset; NULL as in prior v12 table)
+                       ncclGinIbProxyRegMrSym,
+                       ncclGinIbProxyRegMrSymDmaBuf,
+                       ncclGinIbProxyDeregMrSym,
+                       NULL,                          // destroyContext (subset)
+                       ncclGinIbCloseColl,
+                       ncclIbCloseListen,
+                       ncclGinIbProxyIPut,
+                       ncclGinIbProxyIPutSignal,
+                       NULL,                          // iget (added in v13 ncclGin_t; GIN_IB has no get)
+                       NULL,                          // iflush (added in v13 ncclGin_t)
+                       ncclGinIbProxyTest,
+                       NULL,                          // ginProgress
+                       NULL,                          // queryLastError
+                       ncclGinIbFinalize};

--- a/projects/rccl/src/transport/net_ib/gin.h
+++ b/projects/rccl/src/transport/net_ib/gin.h
@@ -13,26 +13,27 @@
 #include "nccl.h"
 
 struct ncclGinIbCollComm {
-  void*         ctx;
-  int           rank;
-  int           nranks;
-  int           connectionId;
-  int           nConnections;
-  int           queueDepth;
-  void*         recvComm;
-  void*         sendComm;
-  void**        fullRecvComm;
-  void**        fullSendComm;
-  int           dev;
-  void*         ginCtx;
+  void* ctx;
+  int rank;
+  int nranks;
+  int connectionId;
+  int nConnections;
+  int queueDepth;
+  void* recvComm;
+  void* sendComm;
+  void** fullRecvComm;
+  void** fullSendComm;
+  int dev;
+  void* ginCtx;
   struct {
     struct ibv_context* context;
-    struct ibv_pd *pd;
-  }ib;
-  ncclResult_t (*getProperties)(int dev, void *props);
-  ncclResult_t (*allGather)(struct ncclGinIbCollComm *cComm, void *srcBuf, void *recvBuf, size_t len);
-  ncclResult_t (*allToAll)(struct ncclGinIbCollComm *cComm, void *srcBuf, void *recvBuf, size_t len);
-  ncclResult_t (*getGidIndex)(struct ibv_context *context, uint8_t portNum, struct ibv_port_attr* portAttr, int *gidIndex);
+    struct ibv_pd* pd;
+  } ib;
+  ncclResult_t (*getProperties)(int dev, void* props);
+  ncclResult_t (*allGather)(struct ncclGinIbCollComm* cComm, void* srcBuf, void* recvBuf, size_t len);
+  ncclResult_t (*allToAll)(struct ncclGinIbCollComm* cComm, void* srcBuf, void* recvBuf, size_t len);
+  ncclResult_t (*getGidIndex)(struct ibv_context* context, uint8_t portNum, struct ibv_port_attr* portAttr,
+                              int* gidIndex);
 };
 
 #endif

--- a/projects/rccl/src/transport/net_ib/init.cc
+++ b/projects/rccl/src/transport/net_ib/init.cc
@@ -12,10 +12,10 @@ ncclResult_t pciPathToInt64(char* path, int64_t* id);
 
 NCCL_PARAM(IbPciRelaxedOrdering, "IB_PCI_RELAXED_ORDERING", 2);
 NCCL_PARAM(IbAdaptiveRouting, "IB_ADAPTIVE_ROUTING", -2);
-NCCL_PARAM(IbDataDirect,"IB_DATA_DIRECT",1);
+NCCL_PARAM(IbDataDirect, "IB_DATA_DIRECT", 1);
 
 // default to 0 to disable ooo rq, if set to 1, ooo rq will be enabled or failed
-NCCL_PARAM(IbOooRq,"IB_OOO_RQ", 0)
+NCCL_PARAM(IbOooRq, "IB_OOO_RQ", 0)
 
 static std::mutex ncclIbMutex;
 
@@ -37,16 +37,16 @@ extern int64_t ncclParamIbArThreshold();
 static int ncclIbMatchVfPath(char* path1, char* path2) {
   // Merge multi-port NICs into the same PCI device
   if (ncclParamIbMergeVfs()) {
-    return strncmp(path1, path2, strlen(path1)-4) == 0;
+    return strncmp(path1, path2, strlen(path1) - 4) == 0;
   } else {
-    return strncmp(path1, path2, strlen(path1)-1) == 0;
+    return strncmp(path1, path2, strlen(path1) - 1) == 0;
   }
 }
 
 /**
  * Assumes PCIe path ends with xxxx:xx:xx.x
  */
- static void ncclIbNormalizePciPath(const char* in, char* out, size_t out_size) {
+static void ncclIbNormalizePciPath(const char* in, char* out, size_t out_size) {
   if (!in || !out || out_size == 0) return;
   // Safe copy with truncation
   size_t len = strnlen(in, out_size - 1);
@@ -65,57 +65,52 @@ static int ncclIbMatchVfPath(char* path1, char* path2) {
 /**
  * Extract the PCIe root complex (domain:bus) from a Linux sysfs PCI device path.
  */
-static ncclResult_t ncclIbGetPciRootFromPath(
-    const char* pciPath,
-    char* root,
-    size_t rootLen
-) {
-    if (pciPath == NULL || root == NULL || rootLen < 8){
-        return ncclInvalidUsage;
-    }
-    const char* p = strstr(pciPath, "pci");
-    while (p != NULL) {
-        int domain, bus;
-        int chars_read = 0;
-        if (sscanf(p, "pci%4x:%2x%n", &domain, &bus, &chars_read) == 2 &&
-            chars_read == 10) {
-            snprintf(root, rootLen, "%04x:%02x", domain, bus);
-            return ncclSuccess;
-        }
-        p = strstr(p + 1, "pci");
-    }
+static ncclResult_t ncclIbGetPciRootFromPath(const char* pciPath, char* root, size_t rootLen) {
+  if (pciPath == NULL || root == NULL || rootLen < 8) {
     return ncclInvalidUsage;
+  }
+  const char* p = strstr(pciPath, "pci");
+  while (p != NULL) {
+    int domain, bus;
+    int chars_read = 0;
+    if (sscanf(p, "pci%4x:%2x%n", &domain, &bus, &chars_read) == 2 && chars_read == 10) {
+      snprintf(root, rootLen, "%04x:%02x", domain, bus);
+      return ncclSuccess;
+    }
+    p = strstr(p + 1, "pci");
+  }
+  return ncclInvalidUsage;
 }
 
 /**
  * Determine the NUMA node associated with a PCI device from its sysfs path.
  */
 static int ncclIbGetNumaNodeFromPath(const char* pciPath) {
-    if (pciPath == NULL) {
-        return -1;
-    }
-    char numaPath[PATH_MAX];
-    if (snprintf(numaPath, sizeof(numaPath), "%s/numa_node", pciPath) >= PATH_MAX) {
-        return -1;
-    }
+  if (pciPath == NULL) {
+    return -1;
+  }
+  char numaPath[PATH_MAX];
+  if (snprintf(numaPath, sizeof(numaPath), "%s/numa_node", pciPath) >= PATH_MAX) {
+    return -1;
+  }
 
-    int fd = open(numaPath, O_RDONLY);
-    if (fd < 0) return -1;
+  int fd = open(numaPath, O_RDONLY);
+  if (fd < 0) return -1;
 
-    char buf[32];
-    ssize_t n = read(fd, buf, sizeof(buf) - 1);
-    close(fd);
+  char buf[32];
+  ssize_t n = read(fd, buf, sizeof(buf) - 1);
+  close(fd);
 
-    if (n <= 0) return -1;
-    buf[n] = '\0';
+  if (n <= 0) return -1;
+  buf[n] = '\0';
 
-    char* endptr;
-    errno = 0;
-    long numa = strtol(buf, &endptr, 10);
-    if (endptr == buf || errno == ERANGE) {
-        return -1;
-    }
-    return (int)numa;
+  char* endptr;
+  errno = 0;
+  long numa = strtol(buf, &endptr, 10);
+  if (endptr == buf || errno == ERANGE) {
+    return -1;
+  }
+  return (int)numa;
 }
 
 static int ncclIbCompareDevs(const void* dev1, const void* dev2) {
@@ -166,7 +161,7 @@ static ncclResult_t ncclIbGetRealPort(char* pciPath, int* realPort, int devIdx) 
   return ncclSuccess;
 }
 
-static int ibvWidths[] = { 1, 4, 8, 12, 2 };
+static int ibvWidths[] = {1, 4, 8, 12, 2};
 static int ibvSpeeds[] = {
   2500,  /* SDR */
   5000,  /* DDR */
@@ -181,14 +176,14 @@ static int ibvSpeeds[] = {
 
 static int firstBitSet(int val, int max) {
   int i = 0;
-  while (i<max && ((val & (1<<i)) == 0)) i++;
+  while (i < max && ((val & (1 << i)) == 0)) i++;
   return i;
 }
 static int ncclIbWidth(int width) {
-  return ibvWidths[firstBitSet(width, sizeof(ibvWidths)/sizeof(int)-1)];
+  return ibvWidths[firstBitSet(width, sizeof(ibvWidths) / sizeof(int) - 1)];
 }
 static int ncclIbSpeed(int speed) {
-  return ibvSpeeds[firstBitSet(speed, sizeof(ibvSpeeds)/sizeof(int)-1)];
+  return ibvSpeeds[firstBitSet(speed, sizeof(ibvSpeeds) / sizeof(int) - 1)];
 }
 
 // Determine whether RELAXED_ORDERING is enabled and possible
@@ -202,7 +197,7 @@ static int ncclIbRelaxedOrderingCapable(void) {
   return r == ncclInternalError ? 0 : 1;
 }
 
-static bool ncclMlx5dvDmaBufCapable(ibv_context *context){
+static bool ncclMlx5dvDmaBufCapable(ibv_context* context) {
   ncclResult_t res;
   int dev_fail = 0;
 
@@ -211,7 +206,8 @@ static bool ncclMlx5dvDmaBufCapable(ibv_context *context){
   // Test kernel DMA-BUF support with a dummy call (fd=-1)
   (void)wrap_direct_ibv_reg_dmabuf_mr(pd, 0ULL /*offset*/, 0ULL /*len*/, 0ULL /*iova*/, -1 /*fd*/, 0 /*flags*/);
   // ibv_reg_dmabuf_mr() will fail with EOPNOTSUPP/EPROTONOSUPPORT if not supported (EBADF otherwise)
-  (void)wrap_direct_mlx5dv_reg_dmabuf_mr(pd, 0ULL /*offset*/, 0ULL /*len*/, 0ULL /*iova*/, -1 /*fd*/, 0 /*flags*/, 0 /* mlx5 flags*/);
+  (void)wrap_direct_mlx5dv_reg_dmabuf_mr(pd, 0ULL /*offset*/, 0ULL /*len*/, 0ULL /*iova*/, -1 /*fd*/, 0 /*flags*/,
+                                         0 /* mlx5 flags*/);
   // mlx5dv_reg_dmabuf_mr() will fail with EOPNOTSUPP/EPROTONOSUPPORT if not supported (EBADF otherwise)
   dev_fail |= (errno == EOPNOTSUPP) || (errno == EPROTONOSUPPORT);
   NCCLCHECKGOTO(wrap_ibv_dealloc_pd(pd), res, failure);
@@ -225,7 +221,7 @@ failure:
 extern int64_t ncclParamIbPrepostReceiveWorkRequests();
 extern int64_t ncclParamIbReceiverSideMatchingScheme();
 
-static ncclResult_t ncclIbQueryOooRqSize(struct ibv_context* ibvCtx, const char *devName, uint32_t* oooRqSize) {
+static ncclResult_t ncclIbQueryOooRqSize(struct ibv_context* ibvCtx, const char* devName, uint32_t* oooRqSize) {
   ncclResult_t ret;
   if (!oooRqSize) return ncclInvalidArgument;
   *oooRqSize = 0;
@@ -241,7 +237,6 @@ static ncclResult_t ncclIbQueryOooRqSize(struct ibv_context* ibvCtx, const char 
     *oooRqSize = dvCtx.ooo_recv_wrs_caps.max_rc;
   }
 
-
   return ncclSuccess;
 fail:
   return ncclInternalError;
@@ -254,8 +249,8 @@ ncclResult_t ncclIbMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
   }
 
   if (props->ndevs == 0) {
-      WARN("NET/IB : Can't make virtual NIC with 0 devices");
-      return ncclInvalidUsage;
+    WARN("NET/IB : Can't make virtual NIC with 0 devices");
+    return ncclInvalidUsage;
   }
 
   if (ncclNMergedIbDevs == MAX_IB_VDEVS) {
@@ -265,15 +260,15 @@ ncclResult_t ncclIbMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
 
   // Always count up number of merged devices
   ncclIbMergedDev tmp;
-  memset(&tmp,0,sizeof(tmp));
+  memset(&tmp, 0, sizeof(tmp));
   bool used[MAX_IB_DEVS] = {0};
 
   for (int i = 0; i < props->ndevs; i++) {
-    if( props->devs[i]  < 0 || props->devs[i] >= ncclNIbDevs ) {
+    if (props->devs[i] < 0 || props->devs[i] >= ncclNIbDevs) {
       WARN("NET/IB : Cannot use physical device %d, max %d", props->devs[i], ncclNIbDevs);
       return ncclInvalidUsage;
     }
-    if(used[props->devs[i]]) continue;
+    if (used[props->devs[i]]) continue;
     const ncclIbDev* dev = ncclIbDevs + props->devs[i];
     if (tmp.vProps.ndevs == NCCL_IB_MAX_DEVS_PER_NIC) return ncclInvalidUsage;
     tmp.vProps.devs[tmp.vProps.ndevs++] = props->devs[i];
@@ -284,8 +279,8 @@ ncclResult_t ncclIbMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
       snprintf(tmp.devName + off, sizeof(tmp.devName) - off, "+%s", dev->devName);
     // First time, copy the plain name
     } else {
-      strncpy(tmp.devName, dev->devName, MAXNAMESIZE-1);
-      tmp.devName[MAXNAMESIZE-1] = '\0';
+      strncpy(tmp.devName, dev->devName, MAXNAMESIZE - 1);
+      tmp.devName[MAXNAMESIZE - 1] = '\0';
     }
     used[props->devs[i]] = true;
   }
@@ -295,14 +290,16 @@ ncclResult_t ncclIbMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
   for (int i = 1; i < tmp.vProps.ndevs; i++) {
     const ncclIbDev* dev = ncclIbDevs + tmp.vProps.devs[i];
     if (dev->link != dev0->link) {
-      WARN("NET/IB : Attempted to merge incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of only one link type using NCCL_IB_HCA",
-        tmp.vProps.devs[0], dev0->devName, dev0->portNum, NCCL_IB_LLSTR(dev0->link),tmp.vProps.devs[i], dev->devName, dev->portNum, NCCL_IB_LLSTR(dev->link));
+      WARN("NET/IB : Attempted to merge incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of "
+           "only one link type using NCCL_IB_HCA",
+           tmp.vProps.devs[0], dev0->devName, dev0->portNum, NCCL_IB_LLSTR(dev0->link), tmp.vProps.devs[i],
+           dev->devName, dev->portNum, NCCL_IB_LLSTR(dev->link));
       return ncclInvalidUsage;
     }
   }
 
   int numa0 = ncclIbGetNumaNodeFromPath(dev0->pciPath);
-  //format -> 0000:00
+  // format -> 0000:00
   char root0[8];
   ncclIbGetPciRootFromPath(dev0->pciPath, root0, sizeof(root0));
   for (int i = 1; i < tmp.vProps.ndevs; i++) {
@@ -327,7 +324,8 @@ ncclResult_t ncclIbMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
   }
   ncclIbMergedDevs[ncclNMergedIbDevs] = tmp;
   *d = ncclNMergedIbDevs++;
-  INFO(NCCL_NET, "NET/IB : Made virtual device [%d] name=%s speed=%d ndevs=%d", *d, tmp.devName, tmp.speed, tmp.vProps.ndevs);
+  INFO(NCCL_NET, "NET/IB : Made virtual device [%d] name=%s speed=%d ndevs=%d", *d, tmp.devName, tmp.speed,
+       tmp.vProps.ndevs);
   return ncclSuccess;
 }
 
@@ -335,10 +333,9 @@ ncclResult_t ncclIbMakeVDevice(int* d, ncclNetVDeviceProps_t* props) {
   std::lock_guard<std::mutex> lock(ncclIbMutex);
   ncclResult_t res = ncclIbMakeVDeviceInternal(d, props);
   return res;
-
 }
 
-ncclResult_t ncclIbSetNetAttr(void *ctx, ncclNetAttr_t *netAttr) {
+ncclResult_t ncclIbSetNetAttr(void* ctx, ncclNetAttr_t* netAttr) {
   (void)ctx;
   (void)netAttr;
   return ncclSuccess;
@@ -362,8 +359,12 @@ ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
   ncclProfilerFunction = profFunction;
   if (ncclParamIbDisable()) return ncclInternalError;
   static int shownIbHcaEnv = 0;
-  if(wrap_ibv_symbols() != ncclSuccess) { return ncclInternalError; }
-  if(wrap_mlx5dv_symbols() != ncclSuccess) { INFO(NCCL_NET, "NET/IB : Failed to open mlx5dv symbols. Advance features like CX-8 Direct-NIC will be disabled."); }
+  if (wrap_ibv_symbols() != ncclSuccess) {
+    return ncclInternalError;
+  }
+  if (wrap_mlx5dv_symbols() != ncclSuccess) {
+    INFO(NCCL_NET, "NET/IB : Failed to open mlx5dv symbols. Advance features like CX-8 Direct-NIC will be disabled.");
+  }
 
   if (ncclNIbDevs == -1) {
     std::lock_guard<std::mutex> lock(ncclIbMutex);
@@ -384,7 +385,7 @@ ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
 
       // Check if user defined which IB device:port to use
       const char* userIbEnv = ncclGetEnv("NCCL_IB_HCA");
-      if (userIbEnv != NULL && shownIbHcaEnv++ == 0) INFO(NCCL_NET|NCCL_ENV, "NCCL_IB_HCA set to %s", userIbEnv);
+      if (userIbEnv != NULL && shownIbHcaEnv++ == 0) INFO(NCCL_NET | NCCL_ENV, "NCCL_IB_HCA set to %s", userIbEnv);
       struct netIf userIfs[MAX_IB_DEVS];
       bool searchNot = userIbEnv && userIbEnv[0] == '^';
       if (searchNot) userIbEnv++;
@@ -392,16 +393,19 @@ ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
       if (searchExact) userIbEnv++;
       int nUserIfs = parseStringList(userIbEnv, userIfs, MAX_IB_DEVS);
 
-      if (ncclSuccess != wrap_ibv_get_device_list(&devices, &nIbDevs)) { ret = ncclInternalError; goto fail; }
+      if (ncclSuccess != wrap_ibv_get_device_list(&devices, &nIbDevs)) {
+        ret = ncclInternalError;
+        goto fail;
+      }
 
-      for (int d=0; d<nIbDevs && ncclNIbDevs<MAX_IB_DEVS; d++) {
-        struct ibv_context * context = NULL;
+      for (int d = 0; d < nIbDevs && ncclNIbDevs < MAX_IB_DEVS; d++) {
+        struct ibv_context* context = NULL;
         if (ncclSuccess != wrap_ibv_open_device(&context, devices[d]) || context == NULL) {
           WARN("NET/IB : Unable to open device %s", devices[d]->name);
           continue;
         }
         char dataDirectDevicePath[PATH_MAX] = "/sys";
-        int devCount = /*undefined*/-1, devOffset = 0;
+        int devCount = /*undefined*/ -1, devOffset = 0;
 
         uint32_t oooRqSize = 0;
         enum ncclIbProvider ibProvider = wrap_mlx5dv_is_supported(devices[d]) ? IB_PROVIDER_MLX5 : IB_PROVIDER_NONE;
@@ -414,102 +418,119 @@ ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
         memset(&devAttr, 0, sizeof(devAttr));
         if (ncclSuccess != wrap_ibv_query_device(context, &devAttr)) {
           WARN("NET/IB : Unable to query device %s", devices[d]->name);
-          if (ncclSuccess != wrap_ibv_close_device(context)) { ret = ncclInternalError; goto fail; }
+          if (ncclSuccess != wrap_ibv_close_device(context)) {
+            ret = ncclInternalError;
+            goto fail;
+          }
           continue;
         }
         for (int port_num = 1; port_num <= devAttr.phys_port_cnt; port_num++) {
-            struct ibv_port_attr portAttr;
-            if (ncclSuccess != wrap_ibv_query_port(context, port_num, &portAttr)) {
-              WARN("NET/IB : Unable to query port_num %d", port_num);
-              continue;
-            }
-            if (portAttr.state != IBV_PORT_ACTIVE) continue;
-            if (portAttr.link_layer != IBV_LINK_LAYER_INFINIBAND && portAttr.link_layer != IBV_LINK_LAYER_ETHERNET) continue;
+          struct ibv_port_attr portAttr;
+          if (ncclSuccess != wrap_ibv_query_port(context, port_num, &portAttr)) {
+            WARN("NET/IB : Unable to query port_num %d", port_num);
+            continue;
+          }
+          if (portAttr.state != IBV_PORT_ACTIVE) continue;
+          if (portAttr.link_layer != IBV_LINK_LAYER_INFINIBAND && portAttr.link_layer != IBV_LINK_LAYER_ETHERNET)
+            continue;
 
             // check against user specified HCAs/ports
-            if (! (matchIfList(devices[d]->name, port_num, userIfs, nUserIfs, searchExact) ^ searchNot)) {
-              continue;
-            }
+          if (!(matchIfList(devices[d]->name, port_num, userIfs, nUserIfs, searchExact) ^ searchNot)) {
+            continue;
+          }
 
             // check for mlx5 data direct support only once for a each device
-            if (devCount == -1) {
-              devCount = 1;
-              devOffset = 0;
-              if (ncclParamIbDataDirect() > 0 && ibProvider == IB_PROVIDER_MLX5 && ncclMlx5dvDmaBufCapable(context)) {
-                int pathLen = strlen(dataDirectDevicePath);
-                ncclResult_t res = wrap_mlx5dv_get_data_direct_sysfs_path(context, dataDirectDevicePath + pathLen, sizeof(dataDirectDevicePath) - pathLen);
-                if (res == ncclSuccess) {
-                  // data direct devices are exposed twice: with the C2C + PCIe link and with the data direct link
-                  devCount = 2;
-                  // by default only expose the data direct NIC (devOffset = 1), unless set to 2 by the user
-                  devOffset = (ncclParamIbDataDirect() == 2) ? 0 : 1;
-                  INFO(NCCL_INIT | NCCL_NET, "NET/IB: Data Direct DMA Interface is detected for device %s", devices[d]->name);
-                } else if (res == ncclInvalidArgument) {
-                  TRACE(NCCL_NET, "NET/IB: Device %s does not support Data Direct DMA.", devices[d]->name);
-                } else {
-                  WARN("NET/IB: Error in mlx5dv_get_data_direct_sysfs_path with device %s", devices[d]->name);
-                  return res;
-                }
-              }
-            }
-            for (int dev = devOffset; dev < devCount; ++dev) {
-              ncclIbDevs[ncclNIbDevs].device = d;
-              ncclIbDevs[ncclNIbDevs].ibProvider = ibProvider;
-              ncclIbDevs[ncclNIbDevs].guid = devAttr.sys_image_guid;
-              ncclIbDevs[ncclNIbDevs].portAttr = portAttr;
-              ncclIbDevs[ncclNIbDevs].portNum = port_num;
-              ncclIbDevs[ncclNIbDevs].link = portAttr.link_layer;
-              if (portAttr.active_speed_ex) {
-                // A non-zero active_speed_ex indicates XDR rate (0x100) or higher
-                ncclIbDevs[ncclNIbDevs].speed = ncclIbSpeed(portAttr.active_speed_ex) * ncclIbWidth(portAttr.active_width);
+          if (devCount == -1) {
+            devCount = 1;
+            devOffset = 0;
+            if (ncclParamIbDataDirect() > 0 && ibProvider == IB_PROVIDER_MLX5 && ncclMlx5dvDmaBufCapable(context)) {
+              int pathLen = strlen(dataDirectDevicePath);
+              ncclResult_t res = wrap_mlx5dv_get_data_direct_sysfs_path(context, dataDirectDevicePath + pathLen,
+                                                                        sizeof(dataDirectDevicePath) - pathLen);
+              if (res == ncclSuccess) {
+                // data direct devices are exposed twice: with the C2C + PCIe link and with the data direct link
+                devCount = 2;
+                // by default only expose the data direct NIC (devOffset = 1), unless set to 2 by the user
+                devOffset = (ncclParamIbDataDirect() == 2) ? 0 : 1;
+                INFO(NCCL_INIT | NCCL_NET, "NET/IB: Data Direct DMA Interface is detected for device %s",
+                     devices[d]->name);
+              } else if (res == ncclInvalidArgument) {
+                TRACE(NCCL_NET, "NET/IB: Device %s does not support Data Direct DMA.", devices[d]->name);
               } else {
-                ncclIbDevs[ncclNIbDevs].speed = ncclIbSpeed(portAttr.active_speed) * ncclIbWidth(portAttr.active_width);
+                WARN("NET/IB: Error in mlx5dv_get_data_direct_sysfs_path with device %s", devices[d]->name);
+                return res;
               }
-              ncclIbDevs[ncclNIbDevs].context = context;
-              ncclIbDevs[ncclNIbDevs].pdRefs = 0;
-              ncclIbDevs[ncclNIbDevs].pd = NULL;
-              // for dev==1 (data direct device), pciPath is given by mlx5
-              strncpy(ncclIbDevs[ncclNIbDevs].devName, devices[d]->name, MAXNAMESIZE);
-              NCCLCHECKGOTO(ncclIbGetPciPath(ncclIbDevs[ncclNIbDevs].devName, (dev == 1) ? NULL : &ncclIbDevs[ncclNIbDevs].pciPath, ncclIbDevs[ncclNIbDevs].fullPciPath), ret, fail);
-              if (dev == 1) {
-                snprintf(ncclIbDevs[ncclNIbDevs].devName, MAXNAMESIZE, "%s_dma", devices[d]->name);
-                NCCLCHECK(ncclCalloc(&ncclIbDevs[ncclNIbDevs].pciPath, PATH_MAX));
-                strncpy(ncclIbDevs[ncclNIbDevs].pciPath, dataDirectDevicePath, PATH_MAX);
-                ncclIbDevs[ncclNIbDevs].capsProvider.mlx5.dataDirect = 1;
-              }
-
-              ncclIbDevs[ncclNIbDevs].maxQp = devAttr.max_qp;
-              ncclIbDevs[ncclNIbDevs].oooRqSize = oooRqSize;
-              ncclIbDevs[ncclNIbDevs].mrCache.capacity = 0;
-              ncclIbDevs[ncclNIbDevs].mrCache.population = 0;
-              ncclIbDevs[ncclNIbDevs].mrCache.slots = NULL;
-              NCCLCHECK(ncclIbStatsInit(&ncclIbDevs[ncclNIbDevs].stats));
-
-              // Enable ADAPTIVE_ROUTING by default on IB networks
-              // But allow it to be overloaded by an env parameter
-              ncclIbDevs[ncclNIbDevs].ar = (portAttr.link_layer == IBV_LINK_LAYER_INFINIBAND) ? 1 : 0;
-              if (ncclParamIbAdaptiveRouting() != -2) ncclIbDevs[ncclNIbDevs].ar = ncclParamIbAdaptiveRouting();
-
-
-              INFO(NCCL_NET, "NET/IB: [%d] %s:%s:%d/%s provider=%s speed=%d context=%p pciPath=%s ar=%d oooRqSize=%d", d, devices[d]->name, devices[d]->dev_name,
-                   ncclIbDevs[ncclNIbDevs].portNum, NCCL_IB_LLSTR(portAttr.link_layer), ibProviderName[ncclIbDevs[ncclNIbDevs].ibProvider], ncclIbDevs[ncclNIbDevs].speed, context,
-                   ncclIbDevs[ncclNIbDevs].pciPath, ncclIbDevs[ncclNIbDevs].ar, ncclIbDevs[ncclNIbDevs].oooRqSize);
-
-              ncclIbAsyncThread = std::thread(ncclIbAsyncThreadMain, ncclIbDevs + ncclNIbDevs);
-              ncclSetThreadName(ncclIbAsyncThread, "NCCL IbAsync %2d", ncclNIbDevs);
-              ncclIbAsyncThread.detach();
-
-              ncclNIbDevs++;
-              nPorts++;
             }
+          }
+          for (int dev = devOffset; dev < devCount; ++dev) {
+            ncclIbDevs[ncclNIbDevs].device = d;
+            ncclIbDevs[ncclNIbDevs].ibProvider = ibProvider;
+            ncclIbDevs[ncclNIbDevs].guid = devAttr.sys_image_guid;
+            ncclIbDevs[ncclNIbDevs].portAttr = portAttr;
+            ncclIbDevs[ncclNIbDevs].portNum = port_num;
+            ncclIbDevs[ncclNIbDevs].link = portAttr.link_layer;
+            if (portAttr.active_speed_ex) {
+              // A non-zero active_speed_ex indicates XDR rate (0x100) or higher
+              ncclIbDevs[ncclNIbDevs].speed =
+                ncclIbSpeed(portAttr.active_speed_ex) * ncclIbWidth(portAttr.active_width);
+            } else {
+              ncclIbDevs[ncclNIbDevs].speed = ncclIbSpeed(portAttr.active_speed) * ncclIbWidth(portAttr.active_width);
+            }
+            ncclIbDevs[ncclNIbDevs].context = context;
+            ncclIbDevs[ncclNIbDevs].pdRefs = 0;
+            ncclIbDevs[ncclNIbDevs].pd = NULL;
+            // for dev==1 (data direct device), pciPath is given by mlx5
+            strncpy(ncclIbDevs[ncclNIbDevs].devName, devices[d]->name, MAXNAMESIZE);
+            NCCLCHECKGOTO(ncclIbGetPciPath(ncclIbDevs[ncclNIbDevs].devName,
+                                           (dev == 1) ? NULL : &ncclIbDevs[ncclNIbDevs].pciPath,
+                                           ncclIbDevs[ncclNIbDevs].fullPciPath),
+                          ret, fail);
+            if (dev == 1) {
+              snprintf(ncclIbDevs[ncclNIbDevs].devName, MAXNAMESIZE, "%s_dma", devices[d]->name);
+              NCCLCHECK(ncclCalloc(&ncclIbDevs[ncclNIbDevs].pciPath, PATH_MAX));
+              strncpy(ncclIbDevs[ncclNIbDevs].pciPath, dataDirectDevicePath, PATH_MAX);
+              ncclIbDevs[ncclNIbDevs].capsProvider.mlx5.dataDirect = 1;
+            }
+
+            ncclIbDevs[ncclNIbDevs].maxQp = devAttr.max_qp;
+            ncclIbDevs[ncclNIbDevs].oooRqSize = oooRqSize;
+            ncclIbDevs[ncclNIbDevs].mrCache.capacity = 0;
+            ncclIbDevs[ncclNIbDevs].mrCache.population = 0;
+            ncclIbDevs[ncclNIbDevs].mrCache.slots = NULL;
+            NCCLCHECK(ncclIbStatsInit(&ncclIbDevs[ncclNIbDevs].stats));
+
+            // Enable ADAPTIVE_ROUTING by default on IB networks
+            // But allow it to be overloaded by an env parameter
+            ncclIbDevs[ncclNIbDevs].ar = (portAttr.link_layer == IBV_LINK_LAYER_INFINIBAND) ? 1 : 0;
+            if (ncclParamIbAdaptiveRouting() != -2) ncclIbDevs[ncclNIbDevs].ar = ncclParamIbAdaptiveRouting();
+
+            INFO(NCCL_NET, "NET/IB: [%d] %s:%s:%d/%s provider=%s speed=%d context=%p pciPath=%s ar=%d oooRqSize=%d", d,
+                 devices[d]->name, devices[d]->dev_name, ncclIbDevs[ncclNIbDevs].portNum,
+                 NCCL_IB_LLSTR(portAttr.link_layer), ibProviderName[ncclIbDevs[ncclNIbDevs].ibProvider],
+                 ncclIbDevs[ncclNIbDevs].speed, context, ncclIbDevs[ncclNIbDevs].pciPath, ncclIbDevs[ncclNIbDevs].ar,
+                 ncclIbDevs[ncclNIbDevs].oooRqSize);
+
+            ncclIbAsyncThread = std::thread(ncclIbAsyncThreadMain, ncclIbDevs + ncclNIbDevs);
+            ncclSetThreadName(ncclIbAsyncThread, "NCCL IbAsync %2d", ncclNIbDevs);
+            ncclIbAsyncThread.detach();
+
+            ncclNIbDevs++;
+            nPorts++;
+          }
         }
-        if (nPorts == 0 && ncclSuccess != wrap_ibv_close_device(context)) { ret = ncclInternalError; goto fail; }
+        if (nPorts == 0 && ncclSuccess != wrap_ibv_close_device(context)) {
+          ret = ncclInternalError;
+          goto fail;
+        }
       }
 
-      if (devices && (ncclSuccess != wrap_ibv_free_device_list(devices))) { ret = ncclInternalError; goto fail; }
+      if (devices && (ncclSuccess != wrap_ibv_free_device_list(devices))) {
+        ret = ncclInternalError;
+        goto fail;
+      }
     }
     if (ncclNIbDevs == 0) {
-      INFO(NCCL_INIT|NCCL_NET, "NET/IB : No device found.");
+      INFO(NCCL_INIT | NCCL_NET, "NET/IB : No device found.");
     }
     // Determine whether RELAXED_ORDERING is enabled and possible
     ncclIbRelaxedOrderingEnabled = ncclIbRelaxedOrderingCapable();
@@ -519,7 +540,7 @@ ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
       if (ncclParamIbOooRq()) {
         INFO(NCCL_NET, "NET/IB: OOO RQ is enabled, AR threshold will be ignored.");
       } else {
-        ncclIbArThreshold = ncclParamIbArThreshold();  // set explicitly by user
+        ncclIbArThreshold = ncclParamIbArThreshold(); // set explicitly by user
       }
     }
     // sort devices to ensure a consistent order across nodes
@@ -529,7 +550,8 @@ ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
     char line[2048] = "";
     for (int d = 0; d < ncclNIbDevs; d++) {
       NCCLCHECKGOTO(ncclIbGetRealPort(ncclIbDevs[d].pciPath, &ncclIbDevs[d].realPort, d), ret, fail);
-      snprintf(line + strlen(line), sizeof(line) - strlen(line), " [%d]%s:%d/%s", d, ncclIbDevs[d].devName, ncclIbDevs[d].portNum, NCCL_IB_LLSTR(ncclIbDevs[d].link));
+      snprintf(line + strlen(line), sizeof(line) - strlen(line), " [%d]%s:%d/%s", d, ncclIbDevs[d].devName,
+               ncclIbDevs[d].portNum, NCCL_IB_LLSTR(ncclIbDevs[d].link));
 
       // Add this plain physical device to the list of virtual devices (after sorting)
       int vDev;
@@ -538,24 +560,28 @@ ncclResult_t ncclIbInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
       vProps.devs[0] = d;
       NCCLCHECK(ncclIbMakeVDeviceInternal(&vDev, &vProps));
     }
-    char addrline[SOCKET_NAME_MAXLEN+1];
-    INFO(NCCL_INIT | NCCL_NET, "NET/IB : Using%s %s; OOB %s:%s", line, ncclIbRelaxedOrderingEnabled ? "[RO]" : "", ncclIbIfName, ncclSocketToString(&ncclIbIfAddr, addrline));
+    char addrline[SOCKET_NAME_MAXLEN + 1];
+    INFO(NCCL_INIT | NCCL_NET, "NET/IB : Using%s %s; OOB %s:%s", line, ncclIbRelaxedOrderingEnabled ? "[RO]" : "",
+         ncclIbIfName, ncclSocketToString(&ncclIbIfAddr, addrline));
   }
 exit:
   return ret;
 fail:
-  if(devices != NULL && ncclSuccess != wrap_ibv_free_device_list(devices)){WARN("NET/IB : Unable to free device list");}
+  if (devices != NULL && ncclSuccess != wrap_ibv_free_device_list(devices)) {
+    WARN("NET/IB : Unable to free device list");
+  }
   goto exit;
 }
 
-ncclResult_t ncclIbInit(void** ctx, uint64_t commId, ncclNetCommConfig_t* config, ncclDebugLogger_t logFunction, ncclProfilerCallback_t profFunction) {
+ncclResult_t ncclIbInit(void** ctx, uint64_t commId, ncclNetCommConfig_t* config, ncclDebugLogger_t logFunction,
+                        ncclProfilerCallback_t profFunction) {
   ncclResult_t ret = ncclSuccess;
   ncclNetCommConfig_t* netCommConfig = nullptr;
   NCCLCHECK(ncclIbInitDevices(logFunction, profFunction));
   NCCLCHECK(ncclIbPortRecoveryThreadStart());
   NCCLCHECK(ncclCalloc(&netCommConfig, 1));
   netCommConfig->trafficClass = config->trafficClass;
-  *ctx = (void *)netCommConfig;
+  *ctx = (void*)netCommConfig;
   return ret;
 }
 
@@ -587,7 +613,7 @@ ncclResult_t ncclIbGetPhysProperties(int dev, ncclNetProperties_t* props) {
   props->port = ibDev->portNum + ibDev->realPort;
   props->maxComms = ibDev->maxQp;
   props->maxRecvs = NCCL_NET_IB_MAX_RECVS;
-  props->netDeviceType    = NCCL_NET_DEVICE_HOST;
+  props->netDeviceType = NCCL_NET_DEVICE_HOST;
   props->netDeviceVersion = NCCL_NET_DEVICE_INVALID_VERSION;
   props->maxP2pBytes = NCCL_MAX_NET_SIZE_BYTES;
   props->maxCollBytes = MAX_COLLNET_SIZE;

--- a/projects/rccl/src/transport/net_ib/p2p.cc
+++ b/projects/rccl/src/transport/net_ib/p2p.cc
@@ -18,11 +18,11 @@ NCCL_PARAM(IbReceiverSideMatchingScheme, "IB_RECEIVER_SIDE_MATCHING_SCHEME", -2)
 RCCL_PARAM(IbSplitDataThreshold, "IB_SPLIT_DATA_THRESHOLD", 128);
 RCCL_PARAM(IbGdrFlushGpuMemNoRelaxedOrdering, "GDR_FLUSH_GPU_MEM_NO_RELAXED_ORDERING", 1);
 
-const char* ncclIbReqTypeStr[] = { "Unused", "Send", "Recv", "Flush", "IPut", "IGet", "Failed" };
+const char* ncclIbReqTypeStr[] = {"Unused", "Send", "Recv", "Flush", "IPut", "IGet", "Failed"};
 
 ncclResult_t ncclIbGetRequest(struct ncclIbNetCommBase* base, struct ncclIbRequest** req) {
-  for (int i=0; i<NET_IB_MAX_REQUESTS; i++) {
-    struct ncclIbRequest* r = base->reqs+i;
+  for (int i = 0; i < NET_IB_MAX_REQUESTS; i++) {
+    struct ncclIbRequest* r = base->reqs + i;
     if (r->type == NCCL_NET_IB_REQ_UNUSED) {
       r->base = base;
       r->sock = NULL;
@@ -48,7 +48,6 @@ void ncclIbAddEvent(struct ncclIbRequest* req, int devIndex) {
   req->devBases[devIndex] = base;
 }
 
-
 #ifdef ENABLE_TRACE
 static ncclResult_t ncclIbPrintWr(struct ibv_send_wr* wr, char* wrStr) {
   if (wr == NULL) {
@@ -57,32 +56,24 @@ static ncclResult_t ncclIbPrintWr(struct ibv_send_wr* wr, char* wrStr) {
   }
   const char* opcodeStr = ibvWrOpcodeStr(wr->opcode);
   switch (wr->opcode) {
-    case IBV_WR_RDMA_WRITE:
-      sprintf(wrStr, "wr=%p, wr_id=%ld, opcode=%s, num_sge=%d, sge[0].length=%" PRIu32 ", sge[0].addr=0x%016" PRIx64 ", rdma.remote_addr=0x%016" PRIx64 ", rdma.rkey=0x%x",
-        wr,
-        wr->wr_id,
-        opcodeStr,
-        wr->num_sge,
-        (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->length : 0,
-        (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->addr : 0,
-        wr->wr.rdma.remote_addr,
-        wr->wr.rdma.rkey);
-      break;
-    case IBV_WR_RDMA_WRITE_WITH_IMM:
-      sprintf(wrStr, "wr=%p, wr_id=%ld, opcode=%s, num_sge=%d, sge[0].length=%" PRIu32 ", sge[0].addr=0x%016" PRIx64 ", rdma.remote_addr=0x%016" PRIx64 ",  rdma.rkey=0x%x, imm_data=0x%x",
-        wr,
-        wr->wr_id,
-        opcodeStr,
-        wr->num_sge,
-        (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->length : 0,
-        (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->addr : 0,
-        wr->wr.rdma.remote_addr,
-        wr->wr.rdma.rkey,
-        wr->imm_data);
-      break;
-    default:
-      WARN("NET/IB: %s: No format specified for opcode=%d", __func__, wr->opcode);
-      return ncclInternalError;
+  case IBV_WR_RDMA_WRITE:
+    sprintf(wrStr,
+            "wr=%p, wr_id=%ld, opcode=%s, num_sge=%d, sge[0].length=%" PRIu32 ", sge[0].addr=0x%016" PRIx64
+            ", rdma.remote_addr=0x%016" PRIx64 ", rdma.rkey=0x%x",
+            wr, wr->wr_id, opcodeStr, wr->num_sge, (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->length : 0,
+            (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->addr : 0, wr->wr.rdma.remote_addr, wr->wr.rdma.rkey);
+    break;
+  case IBV_WR_RDMA_WRITE_WITH_IMM:
+    sprintf(wrStr,
+            "wr=%p, wr_id=%ld, opcode=%s, num_sge=%d, sge[0].length=%" PRIu32 ", sge[0].addr=0x%016" PRIx64
+            ", rdma.remote_addr=0x%016" PRIx64 ",  rdma.rkey=0x%x, imm_data=0x%x",
+            wr, wr->wr_id, opcodeStr, wr->num_sge, (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->length : 0,
+            (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->addr : 0, wr->wr.rdma.remote_addr, wr->wr.rdma.rkey,
+            wr->imm_data);
+    break;
+  default:
+    WARN("NET/IB: %s: No format specified for opcode=%d", __func__, wr->opcode);
+    return ncclInternalError;
   }
   return ncclSuccess;
 }
@@ -97,22 +88,23 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
   int nreqs = slots[0].nreqs;
   if (nreqs > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
 
-  TRACE(NCCL_NET, "NET/IB: %s: Posting a send request (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d)", __func__, reqs[0], reqs[0]->base, reqs[0]->id, slot, nreqs);
+  TRACE(NCCL_NET, "NET/IB: %s: Posting a send request (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d)", __func__, reqs[0],
+        reqs[0]->base, reqs[0]->id, slot, nreqs);
 
   int nqps = ncclIbCommBaseGetNqpsPerRequest(&comm->base);
   ncclResult_t ret;
   uint64_t wr_id = 0ULL;
-  for (int r=0; r<nreqs; r++) {
-    struct ibv_send_wr* wr = comm->wrs+r;
+  for (int r = 0; r < nreqs; r++) {
+    struct ibv_send_wr* wr = comm->wrs + r;
     memset(wr, 0, sizeof(struct ibv_send_wr));
 
-    struct ibv_sge* sge = comm->sges+r;
-    sge->addr=(uintptr_t)reqs[r]->send.data;
+    struct ibv_sge* sge = comm->sges + r;
+    sge->addr = (uintptr_t)reqs[r]->send.data;
     wr->opcode = IBV_WR_RDMA_WRITE;
     wr->send_flags = 0;
     wr->wr.rdma.remote_addr = slots[r].addr;
     wr->next = wr + 1;
-    wr_id += (uint64_t)(slot & 0xff) << (r*8);
+    wr_id += (uint64_t)(slot & 0xff) << (r * 8);
     wr->wr_id = wr_id;
 #ifdef NCCL_ENABLE_NET_PROFILING
     reqs[r]->pInfo[0].nEventHandles = 0;
@@ -138,15 +130,16 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
   //      written to directly to remote completion records array
   uint32_t immData = comm->base.recvMatchingScheme == BY_ID ? (uint32_t)(reqs[0]->id % UINT32_MAX) : reqs[0]->send.size;
 
-  struct ibv_send_wr* lastWr = comm->wrs+nreqs-1;
-  if (nreqs > 1 || (!(comm->base.remOooRq && comm->base.localOooRq) && comm->ar && reqs[0]->send.size > ncclIbArThreshold)) {
+  struct ibv_send_wr* lastWr = comm->wrs + nreqs - 1;
+  if (nreqs > 1 ||
+      (!(comm->base.remOooRq && comm->base.localOooRq) && comm->ar && reqs[0]->send.size > ncclIbArThreshold)) {
     // When Adaptive Routing is enabled, send the bulk of the data first as an
     // RDMA Write.
     lastWr++;
     memset(lastWr, 0, sizeof(struct ibv_send_wr));
     if (nreqs > 1) {
       // Write remote sizes array
-      lastWr->wr.rdma.remote_addr = comm->remCmplsRecords.addr + slot*sizeof(struct ncclIbRequestCompletionRecord);
+      lastWr->wr.rdma.remote_addr = comm->remCmplsRecords.addr + slot * sizeof(struct ncclIbRequestCompletionRecord);
       lastWr->num_sge = 1;
     }
   }
@@ -166,22 +159,27 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
   for (int i = 0; i < nqps; i++) {
     NCCLCHECK(ncclIbCommBaseGetQpForRequest(&comm->base, reqs[0]->id, i, &qp, &qpIndex));
 
-    TRACE(NCCL_NET, "NET/IB: %s: Posting send (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld) on QP (qp_num=%u, devIndex=%d, qpIndex=%d)", __func__, reqs[0], reqs[0]->base, reqs[0]->id, slot, nreqs, wr_id, qp->qp->qp_num, qp->devIndex, qpIndex);
+    TRACE(NCCL_NET,
+          "NET/IB: %s: Posting send (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld) on QP (qp_num=%u, "
+          "devIndex=%d, qpIndex=%d)",
+          __func__, reqs[0], reqs[0]->base, reqs[0]->id, slot, nreqs, wr_id, qp->qp->qp_num, qp->devIndex, qpIndex);
 
     // Selective retransmission
     if (comm->base.resiliency && reqs[0]->send.sentData[qpIndex] == true) {
-      for (int r=0; r<nreqs; r++) {
+      for (int r = 0; r < nreqs; r++) {
         comm->wrs[r].sg_list->addr += comm->wrs[r].sg_list->length;
         comm->wrs[r].wr.rdma.remote_addr += comm->wrs[r].sg_list->length;
       }
-      INFO(NCCL_NET, "NET/IB: %s: Skipping retransmission on QP index %d (req=%p, slot=%d) as it was already delivered.", __func__, qpIndex, reqs[0], slot);
+      INFO(NCCL_NET,
+           "NET/IB: %s: Skipping retransmission on QP index %d (req=%p, slot=%d) as it was already delivered.",
+           __func__, qpIndex, reqs[0], slot);
       continue;
     }
 
     int devIndex = qp->devIndex;
-    for (int r=0; r<nreqs; r++) {
+    for (int r = 0; r < nreqs; r++) {
       // Track this event for completion
-      //ncclIbAddEvent(reqs[r], devIndex);
+      // ncclIbAddEvent(reqs[r], devIndex);
 
       // Select proper rkey (needed even for 0-size send)
       comm->wrs[r].wr.rdma.rkey = slots[r].rkeys[qp->remDevIdx];
@@ -197,7 +195,7 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
       }
       // Check the data left to send. If the send is too small, it might be
       // that on the current QP there is no data left to be sent.
-      comm->wrs[r].sg_list->length = std::min<uint32_t>(reqs[r]->send.size-sendOffsets[r], chunkSize);
+      comm->wrs[r].sg_list->length = std::min<uint32_t>(reqs[r]->send.size - sendOffsets[r], chunkSize);
       if (comm->wrs[r].sg_list->length == 0) {
         comm->wrs[r].num_sge = 0;
       } else {
@@ -211,7 +209,7 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
       // Note that the lkey is already correct from the initialization phase.
       lastWr->sg_list = &(comm->devs[devIndex].sge);
       lastWr->sg_list[0].addr = (uint64_t)(comm->remCmplsRecords.elems[slot]);
-      lastWr->sg_list[0].length = nreqs*sizeof(int);
+      lastWr->sg_list[0].length = nreqs * sizeof(int);
       // Populate the correct RKey based on the device used
       lastWr->wr.rdma.rkey = comm->remCmplsRecords.rkeys[devIndex];
     }
@@ -219,7 +217,7 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
     struct ibv_send_wr* bad_wr;
 #ifdef NCCL_ENABLE_NET_PROFILING
     // QP profiling loop
-    for (int r=0; r<nreqs; r++) {
+    for (int r = 0; r < nreqs; r++) {
       // Store the qpIndex for this request
       int nEventHandles = reqs[r]->pInfo[0].nEventHandles;
       assert(nEventHandles < MAX_QPS_PER_REQ);
@@ -233,13 +231,16 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
       reqs[r]->pInfo[0].data.qp.qpNum = qp->qp->qp_num;
       reqs[r]->pInfo[0].data.qp.length = comm->sges[r].length;
       void* pHandle = reqs[r]->pInfo[0].pHandle;
-      NCCLCHECK(ncclProfilerFunction(&reqs[r]->pInfo[0].qpEventHandles[nEventHandles], ncclProfilerNetEventStart, pHandle, pluginId, &reqs[r]->pInfo[0].data));
+      NCCLCHECK(ncclProfilerFunction(&reqs[r]->pInfo[0].qpEventHandles[nEventHandles], ncclProfilerNetEventStart,
+                                     pHandle, pluginId, &reqs[r]->pInfo[0].data));
       reqs[r]->pInfo[0].nEventHandles++;
     }
 #endif
 #ifdef ENABLE_TRACE
     for (int r = 0; r < nreqs; r++) {
-      TRACE(NCCL_NET, "NET/IB: %s: Posting send work request on QP (qpn=%u, devIndex=%d, qpIndex=%d) (slot=%d, req[r=%d]=%p)", __func__, qp->qp->qp_num, qp->devIndex, qpIndex, slot, r, reqs[r]);
+      TRACE(NCCL_NET,
+            "NET/IB: %s: Posting send work request on QP (qpn=%u, devIndex=%d, qpIndex=%d) (slot=%d, req[r=%d]=%p)",
+            __func__, qp->qp->qp_num, qp->devIndex, qpIndex, slot, r, reqs[r]);
     }
     int wrIdx = 0;
     char wrStr[1024];
@@ -262,26 +263,35 @@ ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot) {
 
     // Update the send offset and addresses for the next QP according to the
     // actual data size that was sent on the current QP, for every request
-    for (int r=0; r<nreqs; r++) {
+    for (int r = 0; r < nreqs; r++) {
       sendOffsets[r] = std::min<uint32_t>(sendOffsets[r] + comm->wrs[r].sg_list->length, reqs[r]->send.size);
       comm->wrs[r].sg_list->addr += comm->wrs[r].sg_list->length;
       comm->wrs[r].wr.rdma.remote_addr += comm->wrs[r].sg_list->length;
-      TRACE(NCCL_NET, "NET/IB: %s: Send request (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, reqIdx=%d, wr_id=%ld) posted %d bytes on QP index %d (devIndex=%d, qp_num=%u), total posted %d/%d bytes", __func__, reqs[r], reqs[0]->base, reqs[r]->id, slot, nreqs, r, comm->wrs[r].wr_id, comm->wrs[r].sg_list->length, qpIndex, devIndex, qp->qp->qp_num, sendOffsets[r], reqs[r]->send.size);
+      TRACE(NCCL_NET,
+            "NET/IB: %s: Send request (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, reqIdx=%d, wr_id=%ld) posted %d "
+            "bytes on QP index %d (devIndex=%d, qp_num=%u), total posted %d/%d bytes",
+            __func__, reqs[r], reqs[0]->base, reqs[r]->id, slot, nreqs, r, comm->wrs[r].wr_id,
+            comm->wrs[r].sg_list->length, qpIndex, devIndex, qp->qp->qp_num, sendOffsets[r], reqs[r]->send.size);
       reqs[r]->send.sentData[qpIndex] = true;
       // TODO: add ibv_dev_index to remDevs struct to enable full TRACE log with remote device info
-      TRACE(NCCL_VERBS, "Posted send wr_id=%lu, wr_indx=%d, qp_num=%d, src_nic=%d, opcode=%d, send_flags=%d, imm_data=%d, remote_addr=%lx, rkey=%x, length=%d, lkey=%x",
-        comm->wrs[r].wr_id, r, qp->qp->qp_num, comm->devs[qp->devIndex].base.ibDevN,
-        comm->wrs[r].opcode, comm->wrs[r].send_flags, comm->wrs[r].imm_data, comm->wrs[r].wr.rdma.remote_addr,
-        comm->wrs[r].wr.rdma.rkey, comm->wrs[r].sg_list ? comm->wrs[r].sg_list->length : 0, comm->wrs[r].sg_list ? comm->wrs[r].sg_list->lkey : 0);
+      TRACE(NCCL_VERBS,
+            "Posted send wr_id=%lu, wr_indx=%d, qp_num=%d, src_nic=%d, opcode=%d, send_flags=%d, imm_data=%d, "
+            "remote_addr=%lx, rkey=%x, length=%d, lkey=%x",
+            comm->wrs[r].wr_id, r, qp->qp->qp_num, comm->devs[qp->devIndex].base.ibDevN, comm->wrs[r].opcode,
+            comm->wrs[r].send_flags, comm->wrs[r].imm_data, comm->wrs[r].wr.rdma.remote_addr, comm->wrs[r].wr.rdma.rkey,
+            comm->wrs[r].sg_list ? comm->wrs[r].sg_list->length : 0,
+            comm->wrs[r].sg_list ? comm->wrs[r].sg_list->lkey : 0);
     }
   }
 
-  TRACE(NCCL_NET, "NET/IB: %s: Send request posted (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld)", __func__, reqs[0], reqs[0]->base, reqs[0]->id, slot, nreqs, wr_id);
+  TRACE(NCCL_NET, "NET/IB: %s: Send request posted (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld)", __func__,
+        reqs[0], reqs[0]->base, reqs[0]->id, slot, nreqs, wr_id);
 
   return ncclSuccess;
 }
 
-ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void* mhandle, void* phandle, void** request) {
+ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void* mhandle, void* phandle,
+                         void** request) {
   struct ncclIbSendComm* comm = (struct ncclIbSendComm*)sendComm;
   ncclResult_t ret = ncclSuccess;
   if (comm->base.ready == 0) {
@@ -289,7 +299,7 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
     *request = NULL;
     return ncclInternalError;
   }
-  struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*) mhandle;
+  struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*)mhandle;
 
   // Wait for the receiver to have posted the corresponding receive
   int nreqs = 0;
@@ -298,20 +308,24 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
   int slot = comm->base.fifoHead % NET_IB_MAX_REQUESTS;
   struct ncclIbRequest** reqs = comm->sendReqs[slot];
   slots = comm->ctsFifo[slot];
-  uint64_t idx = comm->base.fifoHead+1;
+  uint64_t idx = comm->base.fifoHead + 1;
   int nqps = ncclIbCommBaseGetNqpsPerRequest(&comm->base);
   int qpIndex = -1;
   ncclIbQp* qp = NULL;
   struct ncclIbRequest* req = NULL;
 
-  NCCLCHECKGOTO(ncclIbStatsCheckFatalCount(&comm->base.stats,__func__), ret, isendFail);
+  NCCLCHECKGOTO(ncclIbStatsCheckFatalCount(&comm->base.stats, __func__), ret, isendFail);
 
-  if (slots[0].idx != idx) { *request = NULL; return ncclSuccess; }
+  if (slots[0].idx != idx) {
+    *request = NULL;
+    return ncclSuccess;
+  }
   nreqs = slots[0].nreqs;
   // Wait until all data has arrived
-  for (int r=1; r<nreqs; r++) while(slots[r].idx != idx);
+  for (int r = 1; r < nreqs; r++)
+    while (slots[r].idx != idx);
   std::atomic_thread_fence(std::memory_order_seq_cst); // order the nreqsPtr load against tag/rkey/addr loads below
-  for (int r=0; r<nreqs; r++) {
+  for (int r = 0; r < nreqs; r++) {
     if (reqs[r] != NULL || slots[r].tag != tag) continue;
 
     if (size > slots[r].size) size = slots[r].size;
@@ -320,8 +334,8 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
       char line[SOCKET_NAME_MAXLEN + 1];
       union ncclSocketAddress addr;
       ncclSocketGetAddr(&comm->base.sock, &addr);
-      WARN("NET/IB : req %d/%d tag %x peer %s posted incorrect receive info: size %ld addr %lx rkeys[0]=%x",
-        r, nreqs, tag, ncclSocketToString(&addr, line), slots[r].size, slots[r].addr, slots[r].rkeys[0]);
+      WARN("NET/IB : req %d/%d tag %x peer %s posted incorrect receive info: size %ld addr %lx rkeys[0]=%x", r, nreqs,
+           tag, ncclSocketToString(&addr, line), slots[r].size, slots[r].addr, slots[r].rkeys[0]);
       return ncclInternalError;
     }
 
@@ -356,7 +370,10 @@ ncclResult_t ncclIbIsend(void* sendComm, void* data, size_t size, int tag, void*
     // and be sent to the receiver.
     comm->remCmplsRecords.elems[slot][r] = req->send.size;
 
-    TRACE(NCCL_NET, "NET/IB: %s: Send request created (req=%p, comm=%p, id=%ld, slot=%d, reqIdx=%d, nreqs=%d, tag=%x, size=%ld, data=0x%016" PRIx64 ", mhandle=%p, size=%ld)", __func__, req, req->base, req->id, slot, r, nreqs, tag, size, (uint64_t)data, mhandle, size);
+    TRACE(NCCL_NET,
+          "NET/IB: %s: Send request created (req=%p, comm=%p, id=%ld, slot=%d, reqIdx=%d, nreqs=%d, tag=%x, size=%ld, "
+          "data=0x%016" PRIx64 ", mhandle=%p, size=%ld)",
+          __func__, req, req->base, req->id, slot, r, nreqs, tag, size, (uint64_t)data, mhandle, size);
 
     *request = reqs[r] = req;
 
@@ -399,12 +416,13 @@ isendFail:
 }
 
 ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* req, int slot) {
-  ncclIbQp* ctsQp = NULL;;
+  ncclIbQp* ctsQp = NULL;
+  ;
   NCCLCHECK(ncclIbRecvCommGetQpForCts(comm, req->id, &ctsQp));
 
   struct ibv_send_wr wr;
   memset(&wr, 0, sizeof(wr));
-  wr.wr.rdma.remote_addr = comm->remCtsFifo.addr + slot*NCCL_NET_IB_MAX_RECVS*sizeof(struct ncclIbSendFifo);
+  wr.wr.rdma.remote_addr = comm->remCtsFifo.addr + slot * NCCL_NET_IB_MAX_RECVS * sizeof(struct ncclIbSendFifo);
 
   // Lookup the correct rkey
   wr.wr.rdma.rkey = comm->base.remDevs[ctsQp->remDevIdx].rkey;
@@ -414,7 +432,7 @@ ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* r
   struct ncclIbSendFifo* localElem = comm->remCtsFifo.elems[slot];
   wr.sg_list = &(comm->devs[ctsQp->devIndex].sge);
   wr.sg_list[0].addr = (uint64_t)localElem;
-  wr.sg_list[0].length = req->nreqs*sizeof(struct ncclIbSendFifo);
+  wr.sg_list[0].length = req->nreqs * sizeof(struct ncclIbSendFifo);
   wr.num_sge = 1;
 
   wr.opcode = IBV_WR_RDMA_WRITE;
@@ -448,16 +466,26 @@ ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* r
     wr.wr_id = slot;
   }
 
-  TRACE(NCCL_NET, "NET/IB: %s: Posting a CTS (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld, opcode=%d, send_flags=%d, qp_num=%u)", __func__, req, req->base, req->id, slot, req->nreqs, wr.wr_id, wr.opcode, wr.send_flags, ctsQp->qp->qp_num);
+  TRACE(NCCL_NET,
+        "NET/IB: %s: Posting a CTS (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld, opcode=%d, send_flags=%d, "
+        "qp_num=%u)",
+        __func__, req, req->base, req->id, slot, req->nreqs, wr.wr_id, wr.opcode, wr.send_flags, ctsQp->qp->qp_num);
 
   struct ibv_send_wr* bad_wr;
   ncclResult_t postFifoRet;
   NCCLCHECKGOTO(wrap_ibv_post_send(ctsQp->qp, &wr, &bad_wr), postFifoRet, postFifoFail);
-  TRACE(NCCL_VERBS, "Posted send wr_id=%lu, wr_indx=%d, qp_num=%d, src_nic=%d, dst_nic=%d, dlid=%u, opcode=%d, send_flags=%d, imm_data=%d, remote_addr=%lx, rkey=%x, length=%d, lkey=%x",
-        wr.wr_id, 0, ctsQp->qp->qp_num, comm->devs[ctsQp->devIndex].base.ibDevN, comm->base.remDevs[ctsQp->remDevIdx].ibv_dev_index, comm->base.remDevs[ctsQp->remDevIdx].lid,
-        wr.opcode, wr.send_flags, wr.imm_data, wr.wr.rdma.remote_addr, wr.wr.rdma.rkey, wr.sg_list ? wr.sg_list->length : 0, wr.sg_list ? wr.sg_list->lkey : 0);
+  TRACE(NCCL_VERBS,
+        "Posted send wr_id=%lu, wr_indx=%d, qp_num=%d, src_nic=%d, dst_nic=%d, dlid=%u, opcode=%d, send_flags=%d, "
+        "imm_data=%d, remote_addr=%lx, rkey=%x, length=%d, lkey=%x",
+        wr.wr_id, 0, ctsQp->qp->qp_num, comm->devs[ctsQp->devIndex].base.ibDevN,
+        comm->base.remDevs[ctsQp->remDevIdx].ibv_dev_index, comm->base.remDevs[ctsQp->remDevIdx].lid, wr.opcode,
+        wr.send_flags, wr.imm_data, wr.wr.rdma.remote_addr, wr.wr.rdma.rkey, wr.sg_list ? wr.sg_list->length : 0,
+        wr.sg_list ? wr.sg_list->lkey : 0);
 
-  TRACE(NCCL_NET, "NET/IB: %s: CTS posted (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld, opcode=%d, send_flags=%d, qp_num=%u)", __func__, req, req->base, req->id, slot, req->nreqs, wr.wr_id, wr.opcode, wr.send_flags, ctsQp->qp->qp_num);
+  TRACE(NCCL_NET,
+        "NET/IB: %s: CTS posted (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld, opcode=%d, send_flags=%d, "
+        "qp_num=%u)",
+        __func__, req, req->base, req->id, slot, req->nreqs, wr.wr_id, wr.opcode, wr.send_flags, ctsQp->qp->qp_num);
 
   return ncclSuccess;
 
@@ -466,7 +494,8 @@ postFifoFail:
   return postFifoRet;
 }
 
-ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles, void** phandles, void** request) {
+ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles, void** phandles,
+                         void** request) {
   struct ncclIbRecvComm* comm = (struct ncclIbRecvComm*)recvComm;
   ncclResult_t ret = ncclSuccess;
   struct ncclIbRequest* req = NULL;
@@ -481,7 +510,7 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
     return ncclInternalError;
   }
   if (n > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
-  NCCLCHECKGOTO(ncclIbStatsCheckFatalCount(&comm->base.stats,__func__), ret, irecvFail);
+  NCCLCHECKGOTO(ncclIbStatsCheckFatalCount(&comm->base.stats, __func__), ret, irecvFail);
 
   NCCLCHECKGOTO(ncclIbGetRequest(&comm->base, &req), ret, irecvFail);
   slot = comm->base.fifoHead % NET_IB_MAX_REQUESTS;
@@ -495,7 +524,8 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
       req->devBases[devIndex] = ncclIbGetNetCommDevBase(&comm->base, devIndex);
     }
   }
-  TRACE(NCCL_NET, "NET/IB: %s: Recv request created (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, tag[0]=%x)", __func__, req, req->base, req->id, slot, n, tags[0]);
+  TRACE(NCCL_NET, "NET/IB: %s: Recv request created (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, tag[0]=%x)", __func__,
+        req, req->base, req->id, slot, n, tags[0]);
 
 #ifdef NCCL_ENABLE_NET_PROFILING
   for (int r = 0; r < n && phandles; r++) req->pInfo[r].nEventHandles = 0;
@@ -526,7 +556,8 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
       req->pInfo[r].data.qp.device = qp->devIndex;
       req->pInfo[r].data.qp.wr_id = comm->ibRecvWorkRequest.wr_id;
       req->pInfo[r].data.qp.qpNum = qp->qp->qp_num;
-      NCCLCHECK(ncclProfilerFunction(&req->pInfo[r].qpEventHandles[nEventHandles], ncclProfilerNetEventStart, phandles[r], pluginId, &req->pInfo[r].data));
+      NCCLCHECK(ncclProfilerFunction(&req->pInfo[r].qpEventHandles[nEventHandles], ncclProfilerNetEventStart,
+                                     phandles[r], pluginId, &req->pInfo[r].data));
       req->pInfo[r].nEventHandles++;
     }
 #endif
@@ -535,12 +566,12 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
 
   req->recv.aggSize = 0;
   req->recv.cmplsRecords = &comm->cmplsRecords[slot];
-  memset(req->recv.cmplsRecords->sizes, 0, sizeof(int)*n);
+  memset(req->recv.cmplsRecords->sizes, 0, sizeof(int) * n);
   memset(req->recv.cmplsRecords->completions, 0, sizeof(req->recv.cmplsRecords->completions));
   localElem = comm->remCtsFifo.elems[slot];
-  for (int i=0; i<n; i++) {
+  for (int i = 0; i < n; i++) {
     localElem[i].addr = (uint64_t)data[i];
-    struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*) mhandles[i];
+    struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*)mhandles[i];
     // Send all applicable rkeys
     for (int j = 0; j < comm->base.vProps.ndevs; j++) {
       localElem[i].rkeys[j] = mhandleWrapper->mrs[j]->rkey;
@@ -548,7 +579,7 @@ ncclResult_t ncclIbIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
     localElem[i].nreqs = n;
     localElem[i].size = sizes[i]; // Sanity/Debugging
     localElem[i].tag = tags[i];
-    localElem[i].idx = comm->base.fifoHead+1;
+    localElem[i].idx = comm->base.fifoHead + 1;
   }
 
   // Post to FIFO to notify sender
@@ -591,11 +622,12 @@ ncclResult_t ncclIbIflush(void* recvComm, int n, void** data, int* sizes, void**
   struct ncclIbRequest* req = NULL;
   struct ncclIbMrHandle* mhandle = NULL;
   int last = -1;
-  for (int i=0; i<n; i++) if (sizes[i]) last = i;
+  for (int i = 0; i < n; i++)
+    if (sizes[i]) last = i;
   if (comm->flushEnabled == 0 || last == -1) return ncclSuccess;
 
   // Only flush once using the last non-zero receive
-  mhandle = (struct ncclIbMrHandle*) mhandles[last];
+  mhandle = (struct ncclIbMrHandle*)mhandles[last];
   NCCLCHECKGOTO(ncclIbGetRequest(&comm->base, &req), ret, iflushFail);
   req->type = NCCL_NET_IB_REQ_FLUSH;
   req->sock = &comm->base.sock;
@@ -606,8 +638,7 @@ ncclResult_t ncclIbIflush(void* recvComm, int n, void** data, int* sizes, void**
     // Check if GPU flush buffer was successfully registered
     // If not, fall back to using user data buffer for flush
     bool useGpuFlushMem = rcclParamIbGdrFlushGpuMemNoRelaxedOrdering() &&
-                          comm->devs[i].gpuFlush.gpuFlushGpuMem != nullptr &&
-                          comm->devs[i].gpuFlush.gpuMr != nullptr;
+                          comm->devs[i].gpuFlush.gpuFlushGpuMem != nullptr && comm->devs[i].gpuFlush.gpuMr != nullptr;
     memset(&wr, 0, sizeof(wr));
     wr.wr_id = (req - comm->base.reqs) + NCCL_IB_FLUSH_REQ_WR_ID_OFFSET;
 
@@ -635,7 +666,8 @@ ncclResult_t ncclIbIflush(void* recvComm, int n, void** data, int* sizes, void**
     wr.opcode = IBV_WR_RDMA_READ;
     wr.send_flags = IBV_SEND_SIGNALED;
 
-    TRACE(NCCL_NET, "NET/IB: %s: Posting a flush request (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base, wr.wr_id);
+    TRACE(NCCL_NET, "NET/IB: %s: Posting a flush request (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base,
+          wr.wr_id);
     TIME_START(4);
     struct ibv_send_wr* bad_wr;
     NCCLCHECKGOTO(wrap_ibv_post_send(comm->devs[i].gpuFlush.qp.qp, &wr, &bad_wr), iflushRet, iflushFail);
@@ -643,7 +675,8 @@ ncclResult_t ncclIbIflush(void* recvComm, int n, void** data, int* sizes, void**
 
     ncclIbAddEvent(req, i);
 
-    TRACE(NCCL_NET, "NET/IB: %s: Flush request posted (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base, wr.wr_id);
+    TRACE(NCCL_NET, "NET/IB: %s: Flush request posted (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base,
+          wr.wr_id);
   }
 
   *request = req;
@@ -684,7 +717,8 @@ static int getReqQpIndex(struct ncclIbRequest* req, int request, int qpNumber) {
 }
 #endif
 
-static inline ncclResult_t ncclIbRequestRetrieveFromCompletion(struct ncclIbNetCommBase* base, ibv_wc* wc, ncclIbRequest** req) {
+static inline ncclResult_t ncclIbRequestRetrieveFromCompletion(struct ncclIbNetCommBase* base, ibv_wc* wc,
+                                                               ncclIbRequest** req) {
   assert(req != NULL);
   assert(wc != NULL);
 
@@ -692,10 +726,12 @@ static inline ncclResult_t ncclIbRequestRetrieveFromCompletion(struct ncclIbNetC
   // of the completion are valid.
   assert(wc->status == IBV_WC_SUCCESS);
 
-  TRACE(NCCL_NET, "NET/IB: %s: Retrieving a %s request (wr_id=%ld, opcode=%s)", __func__, base->isSend ? "send" : "recv", wc->wr_id, ibvWcOpcodeStr(wc->opcode));
+  TRACE(NCCL_NET, "NET/IB: %s: Retrieving a %s request (wr_id=%ld, opcode=%s)", __func__,
+        base->isSend ? "send" : "recv", wc->wr_id, ibvWcOpcodeStr(wc->opcode));
 
   if (!base->isSend && wc->opcode == IBV_WC_RECV_RDMA_WITH_IMM && base->recvMatchingScheme == BY_ID) {
-    TRACE(NCCL_NET, "NET/IB: %s: Retrieving a receive request (wr_id=%ld, opcode=%s, imm_data=%d, byte_len=%d)", __func__, wc->wr_id, ibvWcOpcodeStr(wc->opcode), be32toh(wc->imm_data), wc->byte_len);
+    TRACE(NCCL_NET, "NET/IB: %s: Retrieving a receive request (wr_id=%ld, opcode=%s, imm_data=%d, byte_len=%d)",
+          __func__, wc->wr_id, ibvWcOpcodeStr(wc->opcode), be32toh(wc->imm_data), wc->byte_len);
     struct ncclIbRecvComm* recvComm = (struct ncclIbRecvComm*)base;
     *req = recvComm->recvReqs[be32toh(wc->imm_data) % NET_IB_MAX_REQUESTS];
   } else if (!base->isSend && wc->opcode == IBV_WC_RDMA_READ) { // Flush request completion
@@ -710,12 +746,17 @@ static inline ncclResult_t ncclIbRequestRetrieveFromCompletion(struct ncclIbNetC
     // wr_id.,
     *req = sendComm->sendReqs[wc->wr_id & 0xff][0];
   }
-  TRACE(NCCL_NET, "NET/IB: %s: Retrieved a %s request (req=%p, comm=%p, id=%ld, type=%s, wc.wr_id=%ld, wc.opcode=%s, wc.imm_data=%d, wc.byte_len=%d, wc.qp_num=%u)", __func__, base->isSend ? "send" : "recv", *req, (*req)->base, (*req)->id, ncclIbReqTypeStr[(*req)->type], wc->wr_id, ibvWcOpcodeStr(wc->opcode), be32toh(wc->imm_data), wc->byte_len, wc->qp_num);
+  TRACE(NCCL_NET,
+        "NET/IB: %s: Retrieved a %s request (req=%p, comm=%p, id=%ld, type=%s, wc.wr_id=%ld, wc.opcode=%s, "
+        "wc.imm_data=%d, wc.byte_len=%d, wc.qp_num=%u)",
+        __func__, base->isSend ? "send" : "recv", *req, (*req)->base, (*req)->id, ncclIbReqTypeStr[(*req)->type],
+        wc->wr_id, ibvWcOpcodeStr(wc->opcode), be32toh(wc->imm_data), wc->byte_len, wc->qp_num);
   return ncclSuccess;
 }
 
-static inline bool ncclIbRequestIsComplete(struct ncclIbRequest *request) {
-  bool complete = (request->events[0] == 0 && request->events[1] == 0 && request->events[2] == 0 && request->events[3] == 0);
+static inline bool ncclIbRequestIsComplete(struct ncclIbRequest* request) {
+  bool complete =
+    (request->events[0] == 0 && request->events[1] == 0 && request->events[2] == 0 && request->events[3] == 0);
   if (!complete && request->base->resiliency) {
     NCCLCHECK(ncclIbResiliencyRequestIsComplete(request, &complete));
   }
@@ -723,12 +764,15 @@ static inline bool ncclIbRequestIsComplete(struct ncclIbRequest *request) {
 }
 
 static inline ncclResult_t ncclIbRequestComplete(struct ncclIbRequest* r, int* done, int* sizes) {
-  TRACE(NCCL_NET, "NET/IB: %s: %s request completed (req=%p, comm=%p, id=%ld, type=%s)", __func__, r->base->isSend ? "Send" : "Recv", r, r->base, r->id, ncclIbReqTypeStr[r->type]);
+  TRACE(NCCL_NET, "NET/IB: %s: %s request completed (req=%p, comm=%p, id=%ld, type=%s)", __func__,
+        r->base->isSend ? "Send" : "Recv", r, r->base, r->id, ncclIbReqTypeStr[r->type]);
   *done = 1;
   if (sizes && r->type == NCCL_NET_IB_REQ_RECV) {
-    TRACE(NCCL_NET, "NET/IB: %s: Recv request completed (req=%p, comm=%p, id=%ld, type=%s, nreqs=%d)", __func__, r, r->base, r->id, ncclIbReqTypeStr[r->type], r->nreqs);
-    int *sizesToReport = (r->nreqs > 1 || r->recv.cmplsRecords->sizes[0] > 0) ? r->recv.cmplsRecords->sizes : &(r->recv.aggSize);
-    for (int i=0; i<r->nreqs; i++) {
+    TRACE(NCCL_NET, "NET/IB: %s: Recv request completed (req=%p, comm=%p, id=%ld, type=%s, nreqs=%d)", __func__, r,
+          r->base, r->id, ncclIbReqTypeStr[r->type], r->nreqs);
+    int* sizesToReport =
+      (r->nreqs > 1 || r->recv.cmplsRecords->sizes[0] > 0) ? r->recv.cmplsRecords->sizes : &(r->recv.aggSize);
+    for (int i = 0; i < r->nreqs; i++) {
       sizes[i] = sizesToReport[i];
 #ifdef NCCL_ENABLE_NET_PROFILING
       for (int j = 0; j < r->pInfo[i].nEventHandles; j++) {
@@ -741,11 +785,11 @@ static inline ncclResult_t ncclIbRequestComplete(struct ncclIbRequest* r, int* d
     TRACE(NCCL_NET, "NET/IB: %s: Send request completed (req=%p, comm=%p, id=%ld)", __func__, r, r->base, r->id);
     if (sizes) {
       sizes[0] = r->send.size;
-  #ifdef NCCL_ENABLE_NET_PROFILING
+#ifdef NCCL_ENABLE_NET_PROFILING
       for (int j = 0; j < r->pInfo[0].nEventHandles; j++) {
         NCCLCHECK(ncclProfilerFunction(&r->pInfo[0].qpEventHandles[j], ncclProfilerNetEventStop, NULL, 0, NULL));
       }
-  #endif
+#endif
     }
     int slot = r->id % NET_IB_MAX_REQUESTS;
     struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)r->base;
@@ -767,44 +811,52 @@ static ncclResult_t ncclIbLogCompletionWithError(struct ncclIbNetCommBase* commB
   struct ncclIbNetCommDevBase* devBase = ncclIbGetNetCommDevBase(commBase, devIndex);
   char localGidString[INET6_ADDRSTRLEN] = "";
   char remoteGidString[INET6_ADDRSTRLEN] = "";
-  const char* localGidStr = NULL, *remoteGidStr = NULL;
+  const char *localGidStr = NULL, *remoteGidStr = NULL;
   if (devBase->gidInfo.link_layer == IBV_LINK_LAYER_ETHERNET) {
     localGidStr = ibvGetGidStr(&devBase->gidInfo.localGid, localGidString, sizeof(localGidString));
     remoteGidStr = ibvGetGidStr(&commBase->remDevs[devIndex].remoteGid, remoteGidString, sizeof(remoteGidString));
   }
 
-  char sockStr[SOCKET_NAME_MAXLEN+1];
+  char sockStr[SOCKET_NAME_MAXLEN + 1];
   union ncclSocketAddress addr;
   ncclSocketGetAddr(&commBase->sock, &addr);
   ncclSocketToString(&addr, sockStr);
-  char *hcaName = devBase->pd->context->device->name;
-  WARN("NET/IB: Got completion from peer %s with status=%s(%d) opcode=%s(%d) vendor_err=%u %s%s%s%s hca %s",
-      sockStr, ibvWcStatusStr(wc->status), wc->status,
-      ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->vendor_err,
-      localGidStr ?  " localGid ":"", localGidString, remoteGidStr ? " remoteGids":"", remoteGidString, hcaName);
+  char* hcaName = devBase->pd->context->device->name;
+  WARN("NET/IB: Got completion from peer %s with status=%s(%d) opcode=%s(%d) vendor_err=%u %s%s%s%s hca %s", sockStr,
+       ibvWcStatusStr(wc->status), wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->vendor_err,
+       localGidStr ? " localGid " : "", localGidString, remoteGidStr ? " remoteGids" : "", remoteGidString, hcaName);
   return ncclSuccess;
 }
 
-static inline ncclResult_t ncclIbCompletionEventProcess(struct ncclIbNetCommBase* commBase, struct ibv_wc* wc, int devIndex) {
+static inline ncclResult_t ncclIbCompletionEventProcess(struct ncclIbNetCommBase* commBase, struct ibv_wc* wc,
+                                                        int devIndex) {
   union ncclSocketAddress addr;
   ncclSocketGetAddr(&commBase->sock, &addr);
 
   struct ncclIbRequest* req = NULL;
   NCCLCHECK(ncclIbRequestRetrieveFromCompletion(commBase, wc, &req));
   if (req == NULL) {
-    WARN("NET/IB: %s: %s comm could not retreive a request found for a successful completion (comm=%p, wc.wr_id=%ld, opcode=%d, qp_num=%u)", __func__, commBase->isSend ? "Send" : "Recv", commBase, wc->wr_id, wc->opcode, wc->qp_num);
+    WARN("NET/IB: %s: %s comm could not retreive a request found for a successful completion (comm=%p, wc.wr_id=%ld, "
+         "opcode=%d, qp_num=%u)",
+         __func__, commBase->isSend ? "Send" : "Recv", commBase, wc->wr_id, wc->opcode, wc->qp_num);
     return ncclInternalError;
   }
 
-  #ifdef ENABLE_TRACE
-  char line[SOCKET_NAME_MAXLEN+1];
-  TRACE(NCCL_NET, "Got completion from peer %s with status=%d opcode=%d len=%u wr_id=%lu r=%p type=%d events={%d,%d,%d,%d}, devIndex=%d",
-    ncclSocketToString(&addr, line), wc->status, wc->opcode,wc->byte_len, wc->wr_id, req, req->type, req->events[0], req->events[1], req->events[2], req->events[3], devIndex);
-  #endif
+#ifdef ENABLE_TRACE
+  char line[SOCKET_NAME_MAXLEN + 1];
+  TRACE(NCCL_NET,
+        "Got completion from peer %s with status=%d opcode=%d len=%u wr_id=%lu r=%p type=%d events={%d,%d,%d,%d}, "
+        "devIndex=%d",
+        ncclSocketToString(&addr, line), wc->status, wc->opcode, wc->byte_len, wc->wr_id, req, req->type,
+        req->events[0], req->events[1], req->events[2], req->events[3], devIndex);
+#endif
 
   if (commBase->isSend) {
     if (req->type != NCCL_NET_IB_REQ_SEND) {
-      WARN("NET/IB: %s: Sender expected a 'send' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=%ld, wc.opcode=%s(%d), wc.qp_num=%u)", __func__, ncclIbReqTypeStr[req->type], req, commBase, req->id, wc->wr_id, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num);
+      WARN("NET/IB: %s: Sender expected a 'send' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=%ld, "
+           "wc.opcode=%s(%d), wc.qp_num=%u)",
+           __func__, ncclIbReqTypeStr[req->type], req, commBase, req->id, wc->wr_id, ibvWcOpcodeStr(wc->opcode),
+           wc->opcode, wc->qp_num);
       return ncclInternalError;
     }
     struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)commBase;
@@ -813,35 +865,46 @@ static inline ncclResult_t ncclIbCompletionEventProcess(struct ncclIbNetCommBase
     for (int j = 0; j < req->nreqs; j++) {
       sendReq = sendComm->sendReqs[slot][j];
       if (!commBase->resiliency && (sendReq->events[devIndex] <= 0)) {
-        WARN("NET/IB: sendReq(%p)->events={%d,%d,%d,%d}, devIndex=%d, reqIdx=%d <= 0", sendReq, sendReq->events[0], sendReq->events[1], sendReq->events[2], sendReq->events[3], devIndex, j);
+        WARN("NET/IB: sendReq(%p)->events={%d,%d,%d,%d}, devIndex=%d, reqIdx=%d <= 0", sendReq, sendReq->events[0],
+             sendReq->events[1], sendReq->events[2], sendReq->events[3], devIndex, j);
         return ncclInternalError;
       }
       sendReq->events[devIndex]--;
-      TRACE(NCCL_NET, "NET/IB: %s: Got completion for a send request (req=%p, comm=%p, id=%ld, devIndex=%d, qp_num=%u)", __func__, sendReq, sendReq->base, sendReq->id, devIndex, wc->qp_num);
+      TRACE(NCCL_NET, "NET/IB: %s: Got completion for a send request (req=%p, comm=%p, id=%ld, devIndex=%d, qp_num=%u)",
+            __func__, sendReq, sendReq->base, sendReq->id, devIndex, wc->qp_num);
 #ifdef NCCL_ENABLE_NET_PROFILING
       // Stop Qp event for sendReq
       int qpIndex = getReqQpIndex(sendReq, j, wc->qp_num);
-      NCCLCHECK(ncclProfilerFunction(&sendReq->pInfo[j].qpEventHandles[qpIndex], ncclProfilerNetEventStop, NULL, 0, NULL));
+      NCCLCHECK(ncclProfilerFunction(&sendReq->pInfo[j].qpEventHandles[qpIndex], ncclProfilerNetEventStop, NULL, 0,
+                                     NULL));
 #endif
     }
   } else {
     if (wc->opcode == IBV_WC_RECV_RDMA_WITH_IMM) {
       if (req->type == NCCL_NET_IB_REQ_UNUSED && commBase->resiliency) {
-        INFO(NCCL_NET, "NET/IB: %s: Receiver got a completion for a data transfer but retrieved an 'unused' request (req=%p, comm=%p, id=%ld, wc.status=%s(%d), wc.wr_id=%ld, wc.imm_data=%d, wc.opcode=%s(%d), wc.qp_num=%u)", __func__, req, commBase, req->id, ibvWcStatusStr(wc->status), wc->status, wc->wr_id, be32toh(wc->imm_data), ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num);
+        INFO(NCCL_NET,
+             "NET/IB: %s: Receiver got a completion for a data transfer but retrieved an 'unused' request (req=%p, "
+             "comm=%p, id=%ld, wc.status=%s(%d), wc.wr_id=%ld, wc.imm_data=%d, wc.opcode=%s(%d), wc.qp_num=%u)",
+             __func__, req, commBase, req->id, ibvWcStatusStr(wc->status), wc->status, wc->wr_id, be32toh(wc->imm_data),
+             ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num);
         return ncclSuccess;
       }
       if (req->type != NCCL_NET_IB_REQ_RECV && !commBase->resiliency) {
-        WARN("NET/IB: %s: Receiver expected a 'recv' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=%ld, wc.status=%s(%d) wc.opcode=%s(%d), wc.qp_num=%u)", __func__, ncclIbReqTypeStr[req->type], req, req->base, req->id, wc->wr_id, ibvWcStatusStr(wc->status), wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num);
+        WARN("NET/IB: %s: Receiver expected a 'recv' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=%ld, "
+             "wc.status=%s(%d) wc.opcode=%s(%d), wc.qp_num=%u)",
+             __func__, ncclIbReqTypeStr[req->type], req, req->base, req->id, wc->wr_id, ibvWcStatusStr(wc->status),
+             wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num);
         return ncclInternalError;
       }
       if (req->nreqs == 1) {
         if (commBase->recvMatchingScheme == BY_INDEX) {
           req->recv.cmplsRecords->sizes[0] = be32toh(wc->imm_data);
         } else if (req->recv.cmplsRecords->sizes[0] == 0) {
-          req->recv.aggSize+= wc->byte_len;
+          req->recv.aggSize += wc->byte_len;
         }
       }
-      TRACE(NCCL_NET, "NET/IB: %s: Got completion for a recv request (req=%p, comm=%p, id=%ld, devIndex=%d, qp_num=%u)", __func__, req, req->base, req->id, devIndex, wc->qp_num);
+      TRACE(NCCL_NET, "NET/IB: %s: Got completion for a recv request (req=%p, comm=%p, id=%ld, devIndex=%d, qp_num=%u)",
+            __func__, req, req->base, req->id, devIndex, wc->qp_num);
       struct ncclIbRecvComm* recvComm = (struct ncclIbRecvComm*)commBase;
       if (recvComm->prepostReceiveWorkRequests) {
         // Post another receive work request on the QP
@@ -853,17 +916,27 @@ static inline ncclResult_t ncclIbCompletionEventProcess(struct ncclIbNetCommBase
       }
       req->events[devIndex]--;
     } else if (wc->opcode == IBV_WC_RDMA_READ) {
-      TRACE(NCCL_NET, "NET/IB: %s: Got completion for a flush request (req=%p, comm=%p, id=%ld, devIndex=%d, qp_num=%u)", __func__, req, req->base, req->id, devIndex, wc->qp_num);
+      TRACE(NCCL_NET,
+            "NET/IB: %s: Got completion for a flush request (req=%p, comm=%p, id=%ld, devIndex=%d, qp_num=%u)",
+            __func__, req, req->base, req->id, devIndex, wc->qp_num);
       req->events[devIndex]--;
     } else if (wc->opcode == IBV_WC_RDMA_WRITE) {
       // This is a CTS completion
-      TRACE(NCCL_NET, "NET/IB: %s: Got completion for a CTS (req=%p, comm=%p, id=%ld, devIndex=%d, qp_num=%u)", __func__, req, req->base, req->id, devIndex, wc->qp_num);
+      TRACE(NCCL_NET, "NET/IB: %s: Got completion for a CTS (req=%p, comm=%p, id=%ld, devIndex=%d, qp_num=%u)",
+            __func__, req, req->base, req->id, devIndex, wc->qp_num);
       if (req->type == NCCL_NET_IB_REQ_UNUSED) {
-        INFO(NCCL_NET, "NET/IB: %s: Receiver got a completion for a CTS but retrieved an 'unused' request (req=%p, comm=%p, id=%ld, wc.wr_id=%ld, wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=%d)", __func__, req, req->base, req->id, wc->wr_id, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num, be32toh(wc->imm_data));
+        INFO(NCCL_NET,
+             "NET/IB: %s: Receiver got a completion for a CTS but retrieved an 'unused' request (req=%p, comm=%p, "
+             "id=%ld, wc.wr_id=%ld, wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=%d)",
+             __func__, req, req->base, req->id, wc->wr_id, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num,
+             be32toh(wc->imm_data));
         return ncclSuccess;
       }
     } else {
-      WARN("NET/IB: %s: Unknown completion (req=%p, comm=%p, id=%ld, devIndex=%d, req->type=%s, wc.wr_id=%ld, wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=%d)", __func__, req, commBase, req ? req->id : -1, devIndex, ncclIbReqTypeStr[req->type], wc->wr_id, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num, be32toh(wc->imm_data));
+      WARN("NET/IB: %s: Unknown completion (req=%p, comm=%p, id=%ld, devIndex=%d, req->type=%s, wc.wr_id=%ld, "
+           "wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=%d)",
+           __func__, req, commBase, req ? req->id : -1, devIndex, ncclIbReqTypeStr[req->type], wc->wr_id,
+           ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num, be32toh(wc->imm_data));
       return ncclInternalError;
     }
 #ifdef NCCL_ENABLE_NET_PROFILING
@@ -878,7 +951,7 @@ static inline ncclResult_t ncclIbCompletionEventProcess(struct ncclIbNetCommBase
 }
 
 ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
-  struct ncclIbRequest *r = (struct ncclIbRequest*)request;
+  struct ncclIbRequest* r = (struct ncclIbRequest*)request;
   *done = 0;
   ncclResult_t ret = ncclSuccess;
   int failDevIdx = -1;
@@ -891,7 +964,7 @@ ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
   int wrDone = 0;
   struct ibv_wc wcs[4];
   do {
-    NCCLCHECKGOTO(ncclIbStatsCheckFatalCount(&r->base->stats,__func__), ret, fail);
+    NCCLCHECKGOTO(ncclIbStatsCheckFatalCount(&r->base->stats, __func__), ret, fail);
     if (ncclIbRequestIsComplete(r)) {
       NCCLCHECK(ncclIbRequestComplete(r, done, sizes));
       return ncclSuccess;
@@ -909,30 +982,37 @@ ncclResult_t ncclIbTest(void* request, int* done, int* sizes) {
       TIME_START(3);
       ret = wrap_ibv_poll_cq(r->devBases[i]->cq, 4, wcs, &wrDone);
       if (ret != ncclSuccess) {
-         failDevIdx = i;
-         goto fail;
+        failDevIdx = i;
+        goto fail;
       }
-      if (wrDone == 0) { TIME_CANCEL(3); } else { TIME_STOP(3); }
+      if (wrDone == 0) {
+        TIME_CANCEL(3);
+      } else {
+        TIME_STOP(3);
+      }
       if (wrDone == 0) continue;
       totalWrDone += wrDone;
-      for (int w=0; w<wrDone; w++) {
-        struct ibv_wc *wc = wcs+w;
+      for (int w = 0; w < wrDone; w++) {
+        struct ibv_wc* wc = wcs + w;
         if (wc->status != IBV_WC_SUCCESS) {
           if (r->base->resiliency == NULL) {
-            WARN("NET/IB: %s: Got CQE with error (devIndex=%d, req=%p, comm=%p (%s), wr_id=%lu, qp_num=%d)", __func__, i, r, r->base, r->base->isSend ? "send" : "recv", wc->wr_id, wc->qp_num);
+            WARN("NET/IB: %s: Got CQE with error (devIndex=%d, req=%p, comm=%p (%s), wr_id=%lu, qp_num=%d)", __func__,
+                 i, r, r->base, r->base->isSend ? "send" : "recv", wc->wr_id, wc->qp_num);
             ncclIbLogCompletionWithError(r->base, wc, i);
             // If resiliency is not enabled, we cannot recover from any error.
             return ncclRemoteError;
           }
           NCCLCHECK(ncclIbResiliencyHandleCompletionError(r->base->resiliency, wc, i));
         } else {
-          TRACE(NCCL_NET, "NET/IB: %s: Processing a completion event (devIndex=%d, comm=%p (%s), req=%p, wr_id=%lu, qp_num=%d)", __func__, i, r->base, r->base->isSend ? "send" : "recv", r, wc->wr_id, wc->qp_num);
+          TRACE(NCCL_NET,
+                "NET/IB: %s: Processing a completion event (devIndex=%d, comm=%p (%s), req=%p, wr_id=%lu, qp_num=%d)",
+                __func__, i, r->base, r->base->isSend ? "send" : "recv", r, wc->wr_id, wc->qp_num);
           NCCLCHECK(ncclIbCompletionEventProcess(r->base, wc, i));
         }
       }
       // Once the IB fatal event is reported in the async thread, we want to propagate this error
       // to communicator and prevent further polling to reduce error pollution.
-      ret = ncclIbStatsCheckFatalCount(&ncclIbDevs[r->devBases[i]->ibDevN].stats,__func__);
+      ret = ncclIbStatsCheckFatalCount(&ncclIbDevs[r->devBases[i]->ibDevN].stats, __func__);
       if (ret != ncclSuccess) {
         failDevIdx = i;
         goto fail;

--- a/projects/rccl/src/transport/net_ib/p2p.h
+++ b/projects/rccl/src/transport/net_ib/p2p.h
@@ -11,8 +11,10 @@
 #include "common.h"
 
 #define NCCL_IB_FLUSH_REQ_WR_ID_OFFSET 0x1000
-static_assert(NCCL_IB_FLUSH_REQ_WR_ID_OFFSET > NET_IB_MAX_REQUESTS, "wr_id offset for flush requests must be greater than NET_IB_MAX_REQUESTS");
-static_assert(NCCL_IB_FLUSH_REQ_WR_ID_OFFSET <= UINT64_MAX - NET_IB_MAX_REQUESTS, "wr_id for flush requests must fit in 64 bits since ibv_send_wr::wr_id is 64 bits");
+static_assert(NCCL_IB_FLUSH_REQ_WR_ID_OFFSET > NET_IB_MAX_REQUESTS,
+              "wr_id offset for flush requests must be greater than NET_IB_MAX_REQUESTS");
+static_assert(NCCL_IB_FLUSH_REQ_WR_ID_OFFSET <= UINT64_MAX - NET_IB_MAX_REQUESTS,
+              "wr_id for flush requests must fit in 64 bits since ibv_send_wr::wr_id is 64 bits");
 
 ncclResult_t ncclIbPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* req, int slot);
 ncclResult_t ncclIbMultiSend(struct ncclIbSendComm* comm, int slot);
@@ -28,12 +30,12 @@ static inline ncclResult_t ncclIbRecvCommGetQpForCts(struct ncclIbRecvComm* recv
 
 static inline ncclResult_t ncclIbRequestRetrieveAsIndex(ncclIbRequest* reqs, uint32_t reqIndex, ncclIbRequest** req) {
   if (reqIndex < 0 || reqIndex >= NET_IB_MAX_REQUESTS) {
-    WARN("NET/IB: %s: Invalid request index %d. Not in the range [%d, %d). Cannot retrieve request.", __func__, reqIndex, 0, NET_IB_MAX_REQUESTS);
+    WARN("NET/IB: %s: Invalid request index %d. Not in the range [%d, %d). Cannot retrieve request.", __func__,
+         reqIndex, 0, NET_IB_MAX_REQUESTS);
     return ncclInternalError;
   }
   *req = &reqs[reqIndex];
   return ncclSuccess;
 }
-
 
 #endif // NET_IB_P2P_H_

--- a/projects/rccl/src/transport/net_ib/p2p_resiliency.cc
+++ b/projects/rccl/src/transport/net_ib/p2p_resiliency.cc
@@ -21,7 +21,8 @@ extern int64_t ncclParamIbTimeout();
 #define MSEC_TO_NSEC 1000000ULL
 
 // Checks if the error indicated in the given work completion is fatal or not.
-static ncclResult_t ncclIbResiliencyCheckErrorNotFatal(struct ncclIbResiliency* resCtx, struct ibv_wc *wc, int devIndex) {
+static ncclResult_t ncclIbResiliencyCheckErrorNotFatal(struct ncclIbResiliency* resCtx, struct ibv_wc* wc,
+                                                       int devIndex) {
   int nFailedDevices = 0;
   bool fatalCompletionStatus = true;
   const char* failureReason = NULL;
@@ -33,17 +34,19 @@ static ncclResult_t ncclIbResiliencyCheckErrorNotFatal(struct ncclIbResiliency* 
   }
 
   switch (wc->status) {
-    case IBV_WC_WR_FLUSH_ERR:
-    case IBV_WC_RETRY_EXC_ERR:
-      fatalCompletionStatus = false;
-      break;
-    default:
-      WARN("NET/IB: %s: Unsupported completion status %s (%d)", __func__, ibvWcStatusStr(wc->status), wc->status);
-      break;
+  case IBV_WC_WR_FLUSH_ERR:
+  case IBV_WC_RETRY_EXC_ERR:
+    fatalCompletionStatus = false;
+    break;
+  default:
+    WARN("NET/IB: %s: Unsupported completion status %s (%d)", __func__, ibvWcStatusStr(wc->status), wc->status);
+    break;
   }
 
   if (nFailedDevices > 1) {
-    WARN("NET/IB: %s: Fatal error. Detected %d failed devices out of %d devices on the %s communicator (comm=%p). No support for more than a single failed device.", __func__, nFailedDevices, resCtx->ndevs, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
+    WARN("NET/IB: %s: Fatal error. Detected %d failed devices out of %d devices on the %s communicator (comm=%p). No "
+         "support for more than a single failed device.",
+         __func__, nFailedDevices, resCtx->ndevs, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
     return ncclRemoteError;
   }
 
@@ -92,26 +95,34 @@ static ncclResult_t ncclIbResiliencyReplaceQps(struct ncclIbResiliency* resCtx, 
       newDevState = resCtx->devs[newDevIndex].state.load(std::memory_order_acquire);
       if (newDevState != ncclIbResiliencyDevStateOk) {
         offset++;
-        WARN("NET/IB: %s: Cannot replace QP with qpIndex=%d because the new QP (qpIndex=%d, devIndex=%d) is not on a functional device (state=%d)", __func__, failedQpIndex, newQpIndex, newDevIndex, newDevState);
+        WARN("NET/IB: %s: Cannot replace QP with qpIndex=%d because the new QP (qpIndex=%d, devIndex=%d) is not on a "
+             "functional device (state=%d)",
+             __func__, failedQpIndex, newQpIndex, newDevIndex, newDevState);
         continue;
       }
 
-      INFO(NCCL_NET, "NET/IB: %s: Replacing QP: qpIndex=%d (qp_num=%u, devIndex=%d) to qpIndex=%d (qp_num=%u, devIndex=%d) on %s communicator (comm=%p)", __func__, failedQpIndex, resCtx->baseComm->qps[failedQpIndex].qp->qp_num, resCtx->baseComm->qps[failedQpIndex].devIndex, newQpIndex, resCtx->baseComm->qps[newQpIndex].qp->qp_num, resCtx->baseComm->qps[newQpIndex].devIndex, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
+      INFO(NCCL_NET,
+           "NET/IB: %s: Replacing QP: qpIndex=%d (qp_num=%u, devIndex=%d) to qpIndex=%d (qp_num=%u, devIndex=%d) on %s "
+           "communicator (comm=%p)",
+           __func__, failedQpIndex, resCtx->baseComm->qps[failedQpIndex].qp->qp_num,
+           resCtx->baseComm->qps[failedQpIndex].devIndex, newQpIndex, resCtx->baseComm->qps[newQpIndex].qp->qp_num,
+           resCtx->baseComm->qps[newQpIndex].devIndex, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
       activeQps[qpIndex] = &resCtx->baseComm->qps[newQpIndex];
       replaced = true;
 
     } while (replaced == false && newQpIndex != failedQpIndex);
 
     if (!replaced) {
-      WARN("NET/IB: %s: Could not find a replacement QP for the failed QP with qpIndex=%d (devIndex=%d)", __func__, failedQpIndex, failedQp->devIndex);
+      WARN("NET/IB: %s: Could not find a replacement QP for the failed QP with qpIndex=%d (devIndex=%d)", __func__,
+           failedQpIndex, failedQp->devIndex);
       return ncclInternalError;
     }
-
   }
   return ncclSuccess;
 }
 
-static ncclResult_t ncclIbResiliencySendRequestInit(struct ncclIbResiliencySend* sendResCtx, ncclIbRequest* request, int devIndex) {
+static ncclResult_t ncclIbResiliencySendRequestInit(struct ncclIbResiliencySend* sendResCtx, ncclIbRequest* request,
+                                                    int devIndex) {
   int slot = request->id % NET_IB_MAX_REQUESTS;
   struct ncclIbResiliencyRequestSend* failedSendRequest = &sendResCtx->failedRequests[slot];
 
@@ -121,22 +132,33 @@ static ncclResult_t ncclIbResiliencySendRequestInit(struct ncclIbResiliencySend*
       // It might be that a different send request that is part of this
       // multi-send request already got an error and is being replayed.
       // No need to initate a new tracking.
-      INFO(NCCL_NET, "NET/IB: %s: No need to add this failed request (req=%p, comm=%p, id=%ld) while another request (req=%p, comm=%p, id=%ld) is already being tracked in the same slot (slot=%d).", __func__, request, request->base, request->id, failedSendRequest->request, failedSendRequest->request->base, failedSendRequest->request->id, slot);
+      INFO(NCCL_NET,
+           "NET/IB: %s: No need to add this failed request (req=%p, comm=%p, id=%ld) while another request (req=%p, "
+           "comm=%p, id=%ld) is already being tracked in the same slot (slot=%d).",
+           __func__, request, request->base, request->id, failedSendRequest->request, failedSendRequest->request->base,
+           failedSendRequest->request->id, slot);
       return ncclSuccess;
     } else {
       // The request was already replayed and released. The CQE should be ignored.
-      INFO(NCCL_NET, "NET/IB: %s: Attempting to initiate a replay protocol but the failed request was already handled (req=%p, comm=%p, id=%ld, slot=%d, req.type=%s).", __func__, request, request->base, request->id, slot, ncclIbReqTypeStr[request->type]);
+      INFO(NCCL_NET,
+           "NET/IB: %s: Attempting to initiate a replay protocol but the failed request was already handled (req=%p, "
+           "comm=%p, id=%ld, slot=%d, req.type=%s).",
+           __func__, request, request->base, request->id, slot, ncclIbReqTypeStr[request->type]);
       return ncclSuccess;
     }
   }
 
   if (request->id + 1 <= failedSendRequest->id) {
-    WARN("NET/IB: %s: Attempting to initiate a replay using an old request (req=%p, comm=%p, id=%ld, slot=%d, failedSendRequest.id=%ld).", __func__, request, request->base, request->id, slot, failedSendRequest->id);
+    WARN("NET/IB: %s: Attempting to initiate a replay using an old request (req=%p, comm=%p, id=%ld, slot=%d, "
+         "failedSendRequest.id=%ld).",
+         __func__, request, request->base, request->id, slot, failedSendRequest->id);
     return ncclInternalError;
   }
 
   if (request->type != NCCL_NET_IB_REQ_SEND) {
-    WARN("NET/IB: %s: Attempting to initiate a failed request using a '%s' request while expecting a 'send' request (req=%p, comm=%p, id=%ld, slot=%d, failedSendRequest.id=%ld).", __func__, ncclIbReqTypeStr[request->type], request, request->base, request->id, slot, failedSendRequest->id);
+    WARN("NET/IB: %s: Attempting to initiate a failed request using a '%s' request while expecting a 'send' request "
+         "(req=%p, comm=%p, id=%ld, slot=%d, failedSendRequest.id=%ld).",
+         __func__, ncclIbReqTypeStr[request->type], request, request->base, request->id, slot, failedSendRequest->id);
     return ncclInternalError;
   }
 
@@ -145,21 +167,28 @@ static ncclResult_t ncclIbResiliencySendRequestInit(struct ncclIbResiliencySend*
   failedSendRequest->errorInfo.devIndex = devIndex;
   failedSendRequest->errorInfo.time = clockNano();
   failedSendRequest->failedAttempts = 0;
-  failedSendRequest->id = request->id+1;
+  failedSendRequest->id = request->id + 1;
   sendResCtx->base.outstandingRequests++;
   sendResCtx->base.inProgress = true;
-  INFO(NCCL_NET, "NET/IB: %s: Tracking a new failed send request (req=%p, comm=%p, id=%ld, slot=%d, devIndex=%d, time=%ld, total tracked requests: %d).", __func__, request, request->base, request->id, slot, devIndex, failedSendRequest->errorInfo.time, sendResCtx->base.outstandingRequests);
+  INFO(NCCL_NET,
+       "NET/IB: %s: Tracking a new failed send request (req=%p, comm=%p, id=%ld, slot=%d, devIndex=%d, time=%ld, total "
+       "tracked requests: %d).",
+       __func__, request, request->base, request->id, slot, devIndex, failedSendRequest->errorInfo.time,
+       sendResCtx->base.outstandingRequests);
   return ncclSuccess;
 }
 
-static ncclResult_t ncclIbResiliencySendRequestFree(struct ncclIbResiliencySend* sendResCtx, struct ncclIbResiliencyRequestSend* failedSendRequest) {
+static ncclResult_t ncclIbResiliencySendRequestFree(struct ncclIbResiliencySend* sendResCtx,
+                                                    struct ncclIbResiliencyRequestSend* failedSendRequest) {
   assert(failedSendRequest != NULL);
   if (failedSendRequest->request == NULL) {
     int slot = failedSendRequest - sendResCtx->failedRequests;
     WARN("NET/IB: %s: Attempting to free a non-existent failed request (slot=%d).", __func__, slot);
     return ncclInternalError;
   }
-  INFO(NCCL_NET, "NET/IB: %s: Done handling failed send request (req=%p, comm=%p, id=%ld, slot=%ld).", __func__, failedSendRequest->request, failedSendRequest->request->base, failedSendRequest->request->id, failedSendRequest->request->id % NET_IB_MAX_REQUESTS);
+  INFO(NCCL_NET, "NET/IB: %s: Done handling failed send request (req=%p, comm=%p, id=%ld, slot=%ld).", __func__,
+       failedSendRequest->request, failedSendRequest->request->base, failedSendRequest->request->id,
+       failedSendRequest->request->id % NET_IB_MAX_REQUESTS);
 
   // Note that ID is not reset to allow ignoring old CQEs that might still be
   // in the CQ even after the failed send request was handled completely and
@@ -181,45 +210,53 @@ static ncclResult_t ncclIbResiliencyRepostRequest(struct ncclIbRequest* request)
   }
   int slot = request->id % NET_IB_MAX_REQUESTS;
   if (request->type == NCCL_NET_IB_REQ_SEND) {
-      struct ncclIbResiliencySend* sendResCtx = (struct ncclIbResiliencySend*)request->base->resiliency;
-      struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)request->base;
-      struct ncclIbRequest** sendReqs = sendComm->sendReqs[slot];
-      for (int r = 0; r < request->nreqs; r++) {
+    struct ncclIbResiliencySend* sendResCtx = (struct ncclIbResiliencySend*)request->base->resiliency;
+    struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)request->base;
+    struct ncclIbRequest** sendReqs = sendComm->sendReqs[slot];
+    for (int r = 0; r < request->nreqs; r++) {
         // Clear all event counters and later on increment only the required
         // ones based on the probing results on which QP a retransmission is
         // required.
-        memset(sendReqs[r]->events, 0, sizeof(sendReqs[r]->events));
+      memset(sendReqs[r]->events, 0, sizeof(sendReqs[r]->events));
 
         // Populate events
-        int nqps = ncclIbCommBaseGetNqpsPerRequest(sendReqs[r]->base);
-        int qpIndex = -1;
-        ncclIbQp* qp = NULL;
-        for (int i = 0; i < nqps; i++) {
+      int nqps = ncclIbCommBaseGetNqpsPerRequest(sendReqs[r]->base);
+      int qpIndex = -1;
+      ncclIbQp* qp = NULL;
+      for (int i = 0; i < nqps; i++) {
           // TODO: This code does not handle the case where a send request fails twice!
           // If that device that is used for retransmission fails during retransmission,
           // the logic here will retrieve the QP that was used for the first send attempt
           // and not the QP that was used for the second send attempt! Causing
           // probably data corruption or a hang.
-          NCCLCHECK(ncclIbCommBaseGetQpForRequest(sendReqs[r]->base, sendReqs[r]->id, i, &qp, &qpIndex));
+        NCCLCHECK(ncclIbCommBaseGetQpForRequest(sendReqs[r]->base, sendReqs[r]->id, i, &qp, &qpIndex));
 
           // Selective Retransmission:
           // If the probing result shows that the data was delivered successfully on this QP,
           // we don't need to retransmit it.
-          if (sendResCtx->probingResults[slot][qpIndex] == true) {
-            INFO(NCCL_NET, "NET/IB: %s: Skipping retransmission on QP index %d (req=%p, comm=%p, id=%ld, slot=%d) as it was already delivered.", __func__, qpIndex, sendReqs[r], sendReqs[r]->base, sendReqs[r]->id, slot);
-            continue;
-          }
-
-          INFO(NCCL_NET, "NET/IB: %s: Retransmitting reqIndex=%d on qp_num=%u (req=%p, comm=%p, id=%ld, slot=%d) as it was not delivered.", __func__, r, qp->qp->qp_num, sendReqs[r], sendReqs[r]->base, sendReqs[r]->id, slot);
-          // Reset the sentData for this QP since we are going to retransmit it.
-          sendReqs[r]->send.sentData[qpIndex] = false;
-          ncclIbAddEvent(sendReqs[r], qp->devIndex);
+        if (sendResCtx->probingResults[slot][qpIndex] == true) {
+          INFO(NCCL_NET,
+               "NET/IB: %s: Skipping retransmission on QP index %d (req=%p, comm=%p, id=%ld, slot=%d) as it was "
+               "already delivered.",
+               __func__, qpIndex, sendReqs[r], sendReqs[r]->base, sendReqs[r]->id, slot);
+          continue;
         }
+
+        INFO(NCCL_NET,
+             "NET/IB: %s: Retransmitting reqIndex=%d on qp_num=%u (req=%p, comm=%p, id=%ld, slot=%d) as it was not "
+             "delivered.",
+             __func__, r, qp->qp->qp_num, sendReqs[r], sendReqs[r]->base, sendReqs[r]->id, slot);
+          // Reset the sentData for this QP since we are going to retransmit it.
+        sendReqs[r]->send.sentData[qpIndex] = false;
+        ncclIbAddEvent(sendReqs[r], qp->devIndex);
       }
-      INFO(NCCL_NET, "NET/IB: %s: Reposting send request (request=%p, comm=%p, id=%ld, slot=%ld, nreqs=%d)", __func__, request, request->base, request->id, request->id % NET_IB_MAX_REQUESTS, request->nreqs);
-      NCCLCHECK(ncclIbMultiSend((struct ncclIbSendComm*)request->base, slot));
+    }
+    INFO(NCCL_NET, "NET/IB: %s: Reposting send request (request=%p, comm=%p, id=%ld, slot=%ld, nreqs=%d)", __func__,
+         request, request->base, request->id, request->id % NET_IB_MAX_REQUESTS, request->nreqs);
+    NCCLCHECK(ncclIbMultiSend((struct ncclIbSendComm*)request->base, slot));
   } else if (request->type == NCCL_NET_IB_REQ_RECV) {
-    INFO(NCCL_NET, "NET/IB: %s: Reposting CTS (request=%p, comm=%p, id=%ld, slot=%ld)", __func__, request, request->base, request->id, request->id % NET_IB_MAX_REQUESTS);
+    INFO(NCCL_NET, "NET/IB: %s: Reposting CTS (request=%p, comm=%p, id=%ld, slot=%ld)", __func__, request,
+         request->base, request->id, request->id % NET_IB_MAX_REQUESTS);
     NCCLCHECK(ncclIbPostFifo((struct ncclIbRecvComm*)request->base, request, slot));
   } else {
     WARN("NET/IB: %s: Unsupported type of request reposting (type=%d, id=%ld).", __func__, request->type, request->id);
@@ -228,12 +265,15 @@ static ncclResult_t ncclIbResiliencyRepostRequest(struct ncclIbRequest* request)
   return ncclSuccess;
 }
 
-static ncclResult_t ncclIbResiliencyHandleCompletionErrorReceiver(struct ncclIbResiliency* resCtx, struct ibv_wc* wc, int devIndex) {
-  INFO(NCCL_NET,"NET/IB: %s: Handling an error on the receiver side (comm %p)", __func__, resCtx->baseComm);
+static ncclResult_t ncclIbResiliencyHandleCompletionErrorReceiver(struct ncclIbResiliency* resCtx, struct ibv_wc* wc,
+                                                                  int devIndex) {
+  INFO(NCCL_NET, "NET/IB: %s: Handling an error on the receiver side (comm %p)", __func__, resCtx->baseComm);
   bool inRecvRange = (wc->wr_id >= 0 && wc->wr_id <= NET_IB_MAX_REQUESTS);
-  bool inFlushRange = (wc->wr_id >= NCCL_IB_FLUSH_REQ_WR_ID_OFFSET && wc->wr_id < (NCCL_IB_FLUSH_REQ_WR_ID_OFFSET + NET_IB_MAX_REQUESTS));
+  bool inFlushRange =
+    (wc->wr_id >= NCCL_IB_FLUSH_REQ_WR_ID_OFFSET && wc->wr_id < (NCCL_IB_FLUSH_REQ_WR_ID_OFFSET + NET_IB_MAX_REQUESTS));
   if (!inRecvRange && !inFlushRange && (wc->wr_id != NCCL_IB_RECV_WR_ID_DUMMY)) {
-    WARN("NET/IB: %s: Invalid wr_id (%ld). Unable to retrieve a request on the receiver side (comm=%p)", __func__, wc->wr_id, resCtx->baseComm);
+    WARN("NET/IB: %s: Invalid wr_id (%ld). Unable to retrieve a request on the receiver side (comm=%p)", __func__,
+         wc->wr_id, resCtx->baseComm);
     return ncclInternalError;
   }
   if (wc->wr_id == NCCL_IB_RECV_WR_ID_DUMMY) {
@@ -243,7 +283,8 @@ static ncclResult_t ncclIbResiliencyHandleCompletionErrorReceiver(struct ncclIbR
     // now flushed.
     assert(wc->status == IBV_WC_WR_FLUSH_ERR);
     // In this case, there is nothing left to do.
-    INFO(NCCL_NET, "NET/IB: %s: Ignoring flush error on a QP (comm=%p, wc.wr_id=%ld, wc.status=%s(%d)).", __func__, resCtx->baseComm, wc->wr_id, ibvWcStatusStr(wc->status), wc->status);
+    INFO(NCCL_NET, "NET/IB: %s: Ignoring flush error on a QP (comm=%p, wc.wr_id=%ld, wc.status=%s(%d)).", __func__,
+         resCtx->baseComm, wc->wr_id, ibvWcStatusStr(wc->status), wc->status);
     return ncclSuccess;
   }
 
@@ -256,27 +297,29 @@ static ncclResult_t ncclIbResiliencyHandleCompletionErrorReceiver(struct ncclIbR
     request = recvComm->recvReqs[wc->wr_id];
   }
 
-  INFO(NCCL_NET, "NET/IB: %s: The receiver side request that got an error is %p (req=%p, comm=%p, id=%ld)", __func__, request, request, request->base, request->id);
+  INFO(NCCL_NET, "NET/IB: %s: The receiver side request that got an error is %p (req=%p, comm=%p, id=%ld)", __func__,
+       request, request, request->base, request->id);
 
   switch (request->type) {
-    case NCCL_NET_IB_REQ_FLUSH:
+  case NCCL_NET_IB_REQ_FLUSH:
       // When a flush request encounters an error, it's ignored and the event
       // counter on that device is set to zero, so the flush request could be
       // completed on other devices if needed.
-      request->events[devIndex] = 0;
-      INFO(NCCL_NET, "NET/IB: %s: Ignoring error on flush request (req=%p, comm=%p, id=%ld) on device index %d", __func__, request, request->base, request->id, devIndex);
-      break;
-    case NCCL_NET_IB_REQ_RECV:
+    request->events[devIndex] = 0;
+    INFO(NCCL_NET, "NET/IB: %s: Ignoring error on flush request (req=%p, comm=%p, id=%ld) on device index %d", __func__,
+         request, request->base, request->id, devIndex);
+    break;
+  case NCCL_NET_IB_REQ_RECV:
       // Assert it's a CTS message that got an error.
       // When error occurs the CQE's opcode is not valid and cannot be read!
       // The only valid fields are: wr_id, status, qp_num, and vendor_err.
       // From: https://www.rdmamojo.com/2013/02/15/ibv_poll_cq/
       // Assert the CQE belongs to a CTS and not a data transfer.
-      assert(wc->wr_id != NCCL_IB_RECV_WR_ID_DUMMY);
+    assert(wc->wr_id != NCCL_IB_RECV_WR_ID_DUMMY);
       // CTS is reposted immediately
-      NCCLCHECK(ncclIbResiliencyRepostRequest(request));
-      break;
-    case (NCCL_NET_IB_REQ_UNUSED):
+    NCCLCHECK(ncclIbResiliencyRepostRequest(request));
+    break;
+  case (NCCL_NET_IB_REQ_UNUSED):
       // This might happen for a CTS message. Consider a case where a HW ack
       // failed for a CTS message but before the receiver got a CQE with error
       // because of a HW timeout, the sender already completed the data transfer
@@ -284,16 +327,19 @@ static ncclResult_t ncclIbResiliencyHandleCompletionErrorReceiver(struct ncclIbR
       // verify if the CTS was completed for every receive request before
       // completing a receive request.
       // When error occurs the CQE's opcode is not valid and cannot be read!
-      WARN("NET/IB: %s: Unrecognized request. It might be a CTS message for which the request was already completed. Continue.", __func__);
-      break;
-    default:
-      WARN("NET/IB: %s: Unrecognized request type. request->type=%d", __func__, request->type);
-      return ncclInternalError;
+    WARN("NET/IB: %s: Unrecognized request. It might be a CTS message for which the request was already completed. "
+         "Continue.",
+         __func__);
+    break;
+  default:
+    WARN("NET/IB: %s: Unrecognized request type. request->type=%d", __func__, request->type);
+    return ncclInternalError;
   }
   return ncclSuccess;
 }
 
-static ncclResult_t ncclIbResiliencyHandleCompletionErrorSender(struct ncclIbResiliency* resCtx, struct ibv_wc* wc, int devIndex) {
+static ncclResult_t ncclIbResiliencyHandleCompletionErrorSender(struct ncclIbResiliency* resCtx, struct ibv_wc* wc,
+                                                                int devIndex) {
   ncclResult_t res;
   ncclIbRequest* request = NULL;
 
@@ -302,14 +348,20 @@ static ncclResult_t ncclIbResiliencyHandleCompletionErrorSender(struct ncclIbRes
   request = sendComm->sendReqs[slot][0];
 
   if (request == NULL) {
-    WARN("NET/IB: %s: Encountered a stale CQE with error for slot=%ld. Slot was already handled (comm=%p, wc.wr_id=%ld, wc.status=%s(%d), wc.opcode=%s(%d)).", __func__, slot, resCtx->baseComm, wc->wr_id, ibvWcStatusStr(wc->status), wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode);
+    WARN("NET/IB: %s: Encountered a stale CQE with error for slot=%ld. Slot was already handled (comm=%p, "
+         "wc.wr_id=%ld, wc.status=%s(%d), wc.opcode=%s(%d)).",
+         __func__, slot, resCtx->baseComm, wc->wr_id, ibvWcStatusStr(wc->status), wc->status,
+         ibvWcOpcodeStr(wc->opcode), wc->opcode);
     return ncclSuccess;
   }
 
   struct ncclIbResiliencySend* sendResCtx = (struct ncclIbResiliencySend*)resCtx;
   res = ncclIbResiliencySendRequestInit(sendResCtx, request, devIndex);
   if (res != ncclSuccess) {
-    WARN("NET/IB: %s: Failed to initialize a resiliency send request (req=%p, comm=%p, id=%ld, type=%s, wc.wr_id=%ld, wc.status=%s(%d), wc.opcode=%s(%d), slot=%ld).", __func__, request, request->base, request->id, ncclIbReqTypeStr[request->type], wc->wr_id, ibvWcStatusStr(wc->status), wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, slot);
+    WARN("NET/IB: %s: Failed to initialize a resiliency send request (req=%p, comm=%p, id=%ld, type=%s, wc.wr_id=%ld, "
+         "wc.status=%s(%d), wc.opcode=%s(%d), slot=%ld).",
+         __func__, request, request->base, request->id, ncclIbReqTypeStr[request->type], wc->wr_id,
+         ibvWcStatusStr(wc->status), wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, slot);
     return res;
   }
 
@@ -322,7 +374,9 @@ static ncclResult_t ncclIbResiliencyHandleDeviceFailure(struct ncclIbResiliency*
   ncclResult_t res = ncclSuccess;
   enum ncclIbResiliencyDevState devState = resCtx->devs[devIndex].state.load(std::memory_order_acquire);
   if (devState == ncclIbResiliencyDevStateOk) {
-    WARN("NET/IB: %s: Device %d marked as failed. Initiating recovery? %s (%s comm=%p, outstandingRecovery=%d)", __func__, devIndex, resCtx->recoveryEnabled ? "Yes" : "No", resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm, resCtx->outstandingRecovery);
+    WARN("NET/IB: %s: Device %d marked as failed. Initiating recovery? %s (%s comm=%p, outstandingRecovery=%d)",
+         __func__, devIndex, resCtx->recoveryEnabled ? "Yes" : "No", resCtx->baseComm->isSend ? "send" : "recv",
+         resCtx->baseComm, resCtx->outstandingRecovery);
     resCtx->devs[devIndex].state.store(ncclIbResiliencyDevStateError, std::memory_order_release);
     NCCLCHECK(ncclIbResiliencyReplaceQps(resCtx, devIndex));
     if (resCtx->recoveryEnabled) {
@@ -334,7 +388,8 @@ static ncclResult_t ncclIbResiliencyHandleDeviceFailure(struct ncclIbResiliency*
       } else {
         for (int i = 0; i < resCtx->ndevs; i++) {
           if (i != devIndex) continue;
-          INFO(NCCL_NET, "NET/IB: %s: Marking device %d as permanently failed (%s comm=%p)", __func__, i, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
+          INFO(NCCL_NET, "NET/IB: %s: Marking device %d as permanently failed (%s comm=%p)", __func__, i,
+               resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
           resCtx->devs[i].state.store(ncclIbResiliencyDevStateErrorPermanent, std::memory_order_release);
         }
       }
@@ -352,7 +407,8 @@ static ncclResult_t ncclIbResiliencyHandleDeviceFailure(struct ncclIbResiliency*
 // After a probe is completed, handle the results of the probe. If the probe
 // shows that the request was completed successfully on all QPs, the request
 // is completed. Otherwise, the request is reposted.
-static ncclResult_t ncclIbResiliencyHandleProbeCompleted(struct ncclIbResiliencySend* sendResCtx, struct ncclIbResiliencyRequestSend* failedRequest) {
+static ncclResult_t ncclIbResiliencyHandleProbeCompleted(struct ncclIbResiliencySend* sendResCtx,
+                                                         struct ncclIbResiliencyRequestSend* failedRequest) {
   int slot = failedRequest->request->id % NET_IB_MAX_REQUESTS;
   bool missingData = false;
   for (int qpIndex = 0; qpIndex < NCCL_IB_MAX_QPS; qpIndex++) {
@@ -366,12 +422,17 @@ static ncclResult_t ncclIbResiliencyHandleProbeCompleted(struct ncclIbResiliency
       continue;
     }
     missingData = true;
-    INFO(NCCL_NET, "NET/IB: %s: Missing data from QP index %d (req=%p, slot=%d devIndex=%d)", __func__, qpIndex, failedRequest->request, slot, failedRequest->request->base->qps[qpIndex].devIndex);
+    INFO(NCCL_NET, "NET/IB: %s: Missing data from QP index %d (req=%p, slot=%d devIndex=%d)", __func__, qpIndex,
+         failedRequest->request, slot, failedRequest->request->base->qps[qpIndex].devIndex);
     break;
   }
   if (!missingData) {
     // All data was delivered to the sender and no need for retransmission.
-    INFO(NCCL_NET, "NET/IB: %s: Probing conclusion: All data was delivered for request %p (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d). Completing the request.", __func__, failedRequest->request, failedRequest->request, failedRequest->request->base, failedRequest->request->id, slot, failedRequest->request->nreqs);
+    INFO(NCCL_NET,
+         "NET/IB: %s: Probing conclusion: All data was delivered for request %p (req=%p, comm=%p, id=%ld, slot=%d, "
+         "nreqs=%d). Completing the request.",
+         __func__, failedRequest->request, failedRequest->request, failedRequest->request->base,
+         failedRequest->request->id, slot, failedRequest->request->nreqs);
     // Clear all events on the request so it could be completed towards the
     // user as well. Note that in case of a multi-send requests, all requests
     // are also cleared.
@@ -379,7 +440,8 @@ static ncclResult_t ncclIbResiliencyHandleProbeCompleted(struct ncclIbResiliency
     struct ncclIbRequest** sendReqs = sendComm->sendReqs[slot];
     for (int r = 0; r < failedRequest->request->nreqs; r++) {
       memset(sendReqs[r]->events, 0, sizeof(sendReqs[r]->events));
-      INFO(NCCL_NET, "NET/IB: %s: Clearing events on send request %p (req=%p, comm=%p, id=%ld, slot=%d, reqIdx=%d)", __func__, sendReqs[r], sendReqs[r], sendReqs[r]->base, sendReqs[r]->id, slot, r);
+      INFO(NCCL_NET, "NET/IB: %s: Clearing events on send request %p (req=%p, comm=%p, id=%ld, slot=%d, reqIdx=%d)",
+           __func__, sendReqs[r], sendReqs[r], sendReqs[r]->base, sendReqs[r]->id, slot, r);
     }
     return ncclSuccess;
   } else {
@@ -391,11 +453,15 @@ static ncclResult_t ncclIbResiliencyHandleProbeCompleted(struct ncclIbResiliency
 
 // Posts a probe (RDMA Read) operation to check the status of a send request
 // that encountered an error.
-static ncclResult_t ncclIbResiliencyProbePost(struct ncclIbResiliencySend* sendResCtx, struct ncclIbResiliencyRequestSend* failedSendRequest) {
+static ncclResult_t ncclIbResiliencyProbePost(struct ncclIbResiliencySend* sendResCtx,
+                                              struct ncclIbResiliencyRequestSend* failedSendRequest) {
   assert(failedSendRequest->state == ncclIbResiliencyRequestStatePending);
 
   if (failedSendRequest->failedAttempts > ncclParamIbResiliencyPortFailoverMaxAttempts()) {
-    WARN("NET/IB: %s: Maximum number of probing attempts (%ld) reached for request %p (id=%ld). Cannot post another probe.", __func__, ncclParamIbResiliencyPortFailoverMaxAttempts(), failedSendRequest->request, failedSendRequest->request->id);
+    WARN("NET/IB: %s: Maximum number of probing attempts (%ld) reached for request %p (id=%ld). Cannot post another "
+         "probe.",
+         __func__, ncclParamIbResiliencyPortFailoverMaxAttempts(), failedSendRequest->request,
+         failedSendRequest->request->id);
     return ncclRemoteError;
   }
 
@@ -408,7 +474,8 @@ static ncclResult_t ncclIbResiliencyProbePost(struct ncclIbResiliencySend* sendR
     return ncclSuccess;
   }
 
-  INFO(NCCL_NET, "NET/IB: %s: Probe delay elapsed (%llu ms) for request %p, posting the probe", __func__, elapsedTime / MSEC_TO_NSEC, failedSendRequest->request);
+  INFO(NCCL_NET, "NET/IB: %s: Probe delay elapsed (%llu ms) for request %p, posting the probe", __func__,
+       elapsedTime / MSEC_TO_NSEC, failedSendRequest->request);
 
   // Iterate over devices until a functional device is found to send a probe
   int devIndex = 0;
@@ -421,7 +488,8 @@ static ncclResult_t ncclIbResiliencyProbePost(struct ncclIbResiliencySend* sendR
   }
 
   if (devIndex == sendResCtx->base.ndevs) {
-    WARN("NET/IB: %s: Could not find a functional device to post the probe for request %p (id=%ld)", __func__, failedSendRequest->request, failedSendRequest->request->id);
+    WARN("NET/IB: %s: Could not find a functional device to post the probe for request %p (id=%ld)", __func__,
+         failedSendRequest->request, failedSendRequest->request->id);
     return ncclInternalError;
   }
 
@@ -455,7 +523,8 @@ static ncclResult_t ncclIbResiliencyProbePost(struct ncclIbResiliencySend* sendR
   probeWr.wr.rdma.remote_addr = remoteAddr;
   probeWr.wr.rdma.rkey = sendResCtx->remCmplRecordsInfo[probingQp->remDevIdx].rkey;
 
-  INFO(NCCL_NET, "NET/IB: %s: Posting probe (slot=%d, id=%ld, devIndex=%d, qp_num=%u)", __func__, slot, failedSendRequest->request->id, devIndex, probingQp->qp->qp_num);
+  INFO(NCCL_NET, "NET/IB: %s: Posting probe (slot=%d, id=%ld, devIndex=%d, qp_num=%u)", __func__, slot,
+       failedSendRequest->request->id, devIndex, probingQp->qp->qp_num);
 
   struct ibv_send_wr* bad_wr;
   NCCLCHECK(wrap_ibv_post_send(probingQp->qp, &probeWr, &bad_wr));
@@ -465,9 +534,11 @@ static ncclResult_t ncclIbResiliencyProbePost(struct ncclIbResiliencySend* sendR
   return ncclSuccess;
 }
 
-static ncclResult_t ncclIbResiliencyProbeHandleCompletionEvent(struct ncclIbResiliencySend* sendResCtx, struct ibv_wc* probeWc, int devIndex) {
-
-  INFO(NCCL_NET, "NET/IB: %s: Got probing completion (devIndex=%d, wc->status=%d, wc->opcode=%d, wc->wr_id=%ld, wc->qp_num=%u)", __func__, devIndex, probeWc->status, probeWc->opcode, probeWc->wr_id, probeWc->qp_num);
+static ncclResult_t ncclIbResiliencyProbeHandleCompletionEvent(struct ncclIbResiliencySend* sendResCtx,
+                                                               struct ibv_wc* probeWc, int devIndex) {
+  INFO(NCCL_NET,
+       "NET/IB: %s: Got probing completion (devIndex=%d, wc->status=%d, wc->opcode=%d, wc->wr_id=%ld, wc->qp_num=%u)",
+       __func__, devIndex, probeWc->status, probeWc->opcode, probeWc->wr_id, probeWc->qp_num);
 
   struct ncclIbResiliencyRequestSend* failedRequest = &sendResCtx->failedRequests[probeWc->wr_id % NET_IB_MAX_REQUESTS];
 
@@ -493,7 +564,7 @@ static ncclResult_t ncclIbResiliencyProbeHandleCompletionEvent(struct ncclIbResi
 static ncclResult_t ncclIbResiliencyProbeProgress(struct ncclIbResiliencySend* sendResCtx) {
   struct ibv_wc wcs[MAX_PROBE_WC];
   int nCompletions = 0;
-  struct ncclIbResiliencyDev *resDev = NULL;
+  struct ncclIbResiliencyDev* resDev = NULL;
   for (int devIndex = 0; devIndex < sendResCtx->base.ndevs; devIndex++) {
     resDev = &sendResCtx->base.devs[devIndex];
     // Note that even if the device failed, we still want to drain all the CQEs
@@ -525,7 +596,8 @@ ncclResult_t ncclIbResiliencyInit(struct ncclIbNetCommBase* baseComm, struct ncc
   assert(baseComm != NULL);
   assert(resCtx != NULL);
   if (ncclParamIbResiliencyPortFailover() == 0) {
-    INFO(NCCL_NET, "NET/IB: %s: Resiliency is disabled on the %s communicator (comm=%p)", __func__, baseComm->isSend ? "send" : "recv", baseComm);
+    INFO(NCCL_NET, "NET/IB: %s: Resiliency is disabled on the %s communicator (comm=%p)", __func__,
+         baseComm->isSend ? "send" : "recv", baseComm);
     *resCtx = NULL;
     return ncclSuccess;
   }
@@ -551,13 +623,16 @@ ncclResult_t ncclIbResiliencyInit(struct ncclIbNetCommBase* baseComm, struct ncc
 
   NCCLCHECK(ncclIbPortRecoveryInit(baseCtx));
   if (baseCtx->recoveryEnabled) {
-    INFO(NCCL_NET, "NET/IB: %s: Port recovery is enabled for the resiliency context on the %s communicator (comm=%p)", __func__, baseComm->isSend ? "send" : "recv", baseComm);
+    INFO(NCCL_NET, "NET/IB: %s: Port recovery is enabled for the resiliency context on the %s communicator (comm=%p)",
+         __func__, baseComm->isSend ? "send" : "recv", baseComm);
     baseCtx->outstandingRecovery = 0;
   } else {
-    INFO(NCCL_NET, "NET/IB: %s: Port recovery is disabled for the resiliency context on the %s communicator (comm=%p)", __func__, baseComm->isSend ? "send" : "recv", baseComm);
+    INFO(NCCL_NET, "NET/IB: %s: Port recovery is disabled for the resiliency context on the %s communicator (comm=%p)",
+         __func__, baseComm->isSend ? "send" : "recv", baseComm);
   }
 
-  INFO(NCCL_NET, "NET/IB: %s: Resiliency context was initialized on the %s communicator (comm=%p)", __func__, baseComm->isSend ? "send" : "recv", baseComm);
+  INFO(NCCL_NET, "NET/IB: %s: Resiliency context was initialized on the %s communicator (comm=%p)", __func__,
+       baseComm->isSend ? "send" : "recv", baseComm);
   return ncclSuccess;
 }
 
@@ -572,7 +647,8 @@ ncclResult_t ncclIbResiliencyDestroy(struct ncclIbResiliency** resCtx) {
 
 ncclResult_t ncclIbResiliencyDevInit(struct ncclIbResiliency* resCtx, uint devIndex, ncclIbDev* ibDev) {
   assert(resCtx != NULL);
-  INFO(NCCL_NET, "NET/IB: %s: Initializing resiliency context on devIndex %d for %s communicator (comm=%p)", __func__, devIndex, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
+  INFO(NCCL_NET, "NET/IB: %s: Initializing resiliency context on devIndex %d for %s communicator (comm=%p)", __func__,
+       devIndex, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
   assert(devIndex < resCtx->ndevs);
   struct ncclIbResiliencyDev* resDev = &resCtx->devs[devIndex];
   resDev->state.store(ncclIbResiliencyDevStateOk, std::memory_order_release);
@@ -582,16 +658,20 @@ ncclResult_t ncclIbResiliencyDevInit(struct ncclIbResiliency* resCtx, uint devIn
     cqSize = NET_IB_MAX_REQUESTS;
     struct ncclIbResiliencySend* sendResCtx = (struct ncclIbResiliencySend*)resCtx;
     struct ncclIbNetCommDevBase* devBase = ncclIbGetNetCommDevBase(resCtx->baseComm, devIndex);
-    NCCLCHECK(wrap_ibv_reg_mr(&resDev->probingResultMr, devBase->pd, &sendResCtx->probingResults, sizeof(sendResCtx->probingResults), IBV_ACCESS_LOCAL_WRITE));
-    INFO(NCCL_NET, "NET/IB: %s: Registered probing results memory (%p) on device %d for resiliency context (comm=%p)", __func__, &sendResCtx->probingResults, devIndex, resCtx->baseComm);
+    NCCLCHECK(wrap_ibv_reg_mr(&resDev->probingResultMr, devBase->pd, &sendResCtx->probingResults,
+                              sizeof(sendResCtx->probingResults), IBV_ACCESS_LOCAL_WRITE));
+    INFO(NCCL_NET, "NET/IB: %s: Registered probing results memory (%p) on device %d for resiliency context (comm=%p)",
+         __func__, &sendResCtx->probingResults, devIndex, resCtx->baseComm);
   } else {
     // It's not allowed to create a CQ with size 0 so set it to 1 although
     // no CQEs are expected to be generated on this CQ (on the receiver side).
     cqSize = 1;
   }
-  INFO(NCCL_NET, "NET/IB: %s: Creating probing CQ on device %d for resiliency context (%s comm=%p, cq_size=%d)", __func__, devIndex, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm, cqSize);
+  INFO(NCCL_NET, "NET/IB: %s: Creating probing CQ on device %d for resiliency context (%s comm=%p, cq_size=%d)",
+       __func__, devIndex, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm, cqSize);
   NCCLCHECK(wrap_ibv_create_cq(&resDev->probingCq, ibDev->context, cqSize, cqContext, NULL, 0));
-  INFO(NCCL_NET, "NET/IB: %s: Created probing CQ (cq=%p) on device %d for resiliency context (%s comm=%p, cq_size=%d)", __func__, resDev->probingCq, devIndex, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm, cqSize);
+  INFO(NCCL_NET, "NET/IB: %s: Created probing CQ (cq=%p) on device %d for resiliency context (%s comm=%p, cq_size=%d)",
+       __func__, resDev->probingCq, devIndex, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm, cqSize);
 
   if (resCtx->recoveryEnabled) {
     NCCLCHECK(ncclIbPortRecoveryDevInit(resCtx, devIndex, ibDev));
@@ -604,7 +684,8 @@ ncclResult_t ncclIbResiliencyDevDestroy(struct ncclIbResiliency* resCtx, uint de
   struct ncclIbResiliencyDev* resDev = &resCtx->devs[devIndex];
   if (resDev->probingCq) {
     NCCLCHECK(wrap_ibv_destroy_cq(resDev->probingCq));
-    INFO(NCCL_NET, "NET/IB: %s: Destroyed probing CQ (cq=%p) on device %d for resiliency context (comm=%p)", __func__, resDev->probingCq, devIndex, resCtx->baseComm);
+    INFO(NCCL_NET, "NET/IB: %s: Destroyed probing CQ (cq=%p) on device %d for resiliency context (comm=%p)", __func__,
+         resDev->probingCq, devIndex, resCtx->baseComm);
   }
 
   if (resCtx->recoveryEnabled) {
@@ -615,7 +696,9 @@ ncclResult_t ncclIbResiliencyDevDestroy(struct ncclIbResiliency* resCtx, uint de
     struct ncclIbResiliencySend* sendResCtx = (struct ncclIbResiliencySend*)resCtx;
     if (resDev->probingResultMr) {
       NCCLCHECK(wrap_ibv_dereg_mr(resDev->probingResultMr));
-      INFO(NCCL_NET, "NET/IB: %s: Deregistered probing results memory (%p) on device %d for resiliency context (comm=%p)", __func__, &sendResCtx->probingResults, devIndex, resCtx->baseComm);
+      INFO(NCCL_NET,
+           "NET/IB: %s: Deregistered probing results memory (%p) on device %d for resiliency context (comm=%p)",
+           __func__, &sendResCtx->probingResults, devIndex, resCtx->baseComm);
     }
   }
   return ncclSuccess;
@@ -639,7 +722,8 @@ ncclResult_t ncclIbResiliencyDataCqSizeGet(struct ncclIbResiliency* resCtx, uint
   // completions of all other requests.
   assert(resCtx->ndevs > 0);
   *cqSize = (*cqSize) * resCtx->ndevs;
-  INFO(NCCL_NET, "NET/IB: %s: CQ size should be %d on device %d for %s communicator (comm=%p)", __func__, *cqSize, devIndex, baseComm->isSend ? "send" : "recv", baseComm);
+  INFO(NCCL_NET, "NET/IB: %s: CQ size should be %d on device %d for %s communicator (comm=%p)", __func__, *cqSize,
+       devIndex, baseComm->isSend ? "send" : "recv", baseComm);
   return ncclSuccess;
 }
 
@@ -664,10 +748,14 @@ ncclResult_t ncclIbResiliencyDeviceNumSet(struct ncclIbResiliency* resCtx, int n
   assert(nRemDevs > 0);
 
   if (nLocalDevs <= 1) {
-    INFO(NCCL_NET, "NET/IB: %s: Resiliency is being enabled on a communicator (comm=%p) with a single local device. In case of failure there will be no device to fail-over to.", __func__, resCtx->baseComm);
+    INFO(NCCL_NET,
+         "NET/IB: %s: Resiliency is being enabled on a communicator (comm=%p) with a single local device. In case of "
+         "failure there will be no device to fail-over to.",
+         __func__, resCtx->baseComm);
   }
 
-  INFO(NCCL_NET, "NET/IB: %s: Resiliency context (comm=%p) is configured with %d local devices and %d remote devices", __func__, resCtx->baseComm, nLocalDevs, nRemDevs);
+  INFO(NCCL_NET, "NET/IB: %s: Resiliency context (comm=%p) is configured with %d local devices and %d remote devices",
+       __func__, resCtx->baseComm, nLocalDevs, nRemDevs);
 
   resCtx->ndevs = nLocalDevs;
   if (resCtx->baseComm->isSend) {
@@ -690,20 +778,25 @@ ncclResult_t ncclIbResiliencyDeviceNumSet(struct ncclIbResiliency* resCtx, int n
   // of devices supported.
   assert(resCtx->nProbingQps <= NCCL_IB_MAX_DEVS_PER_NIC);
   if (resCtx->nProbingQps <= 1) {
-    WARN("NET/IB: %s: Resiliency is enabled on a %s communicator (comm=%p) with a single device. This does not make sense since there is no other device to fail over to.", __func__, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
+    WARN("NET/IB: %s: Resiliency is enabled on a %s communicator (comm=%p) with a single device. This does not make "
+         "sense since there is no other device to fail over to.",
+         __func__, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
   }
-  INFO(NCCL_NET, "NET/IB: %s: Resiliency context (comm=%p) is configured with %d probing QPs", __func__, resCtx->baseComm, resCtx->nProbingQps);
+  INFO(NCCL_NET, "NET/IB: %s: Resiliency context (comm=%p) is configured with %d probing QPs", __func__,
+       resCtx->baseComm, resCtx->nProbingQps);
   if (resCtx->recoveryEnabled) {
     resCtx->nPortRecoveryQps = std::max(nLocalDevs, nRemDevs);
   } else {
     resCtx->nPortRecoveryQps = 0;
   }
   assert(resCtx->nPortRecoveryQps <= NCCL_IB_MAX_DEVS_PER_NIC);
-  INFO(NCCL_NET, "NET/IB: %s: Resiliency context (comm=%p) is configured with %d recovery QPs", __func__, resCtx->baseComm, resCtx->nPortRecoveryQps);
+  INFO(NCCL_NET, "NET/IB: %s: Resiliency context (comm=%p) is configured with %d recovery QPs", __func__,
+       resCtx->baseComm, resCtx->nPortRecoveryQps);
   return ncclSuccess;
 }
 
-ncclResult_t ncclIbResiliencySenderCreateQps(struct ncclIbResiliency* resCtx, struct ncclIbResiliencyInfo* localResiliencyInfo) {
+ncclResult_t ncclIbResiliencySenderCreateQps(struct ncclIbResiliency* resCtx,
+                                             struct ncclIbResiliencyInfo* localResiliencyInfo) {
   ncclIbSendComm* sendComm = (ncclIbSendComm*)resCtx->baseComm;
   void* qpContext = (void*)&sendComm->base.stats;
   struct ncclIbQpCreateAttr qpCreateAttrs;
@@ -739,7 +832,8 @@ ncclResult_t ncclIbResiliencySenderCreateQps(struct ncclIbResiliency* resCtx, st
   }
 
   if (resCtx->recoveryEnabled) {
-    NCCLCHECK(ncclIbPortRecoverySenderQpsCreate(resCtx, localResiliencyInfo->portRecoveryQpsInfo, resCtx->nPortRecoveryQps));
+    NCCLCHECK(ncclIbPortRecoverySenderQpsCreate(resCtx, localResiliencyInfo->portRecoveryQpsInfo,
+                                                resCtx->nPortRecoveryQps));
   }
 
   return ncclSuccess;
@@ -778,7 +872,9 @@ ncclResult_t ncclIbResiliencySenderQpsToRts(struct ncclIbResiliency* resCtx, str
     rtsAttr->timeout = ncclParamIbTimeout();
     rtsAttr->retryCnt = ncclParamIbRetryCnt();
     NCCLCHECK(ncclIbQpRts(localQp));
-    INFO(NCCL_NET, "NET/IB: %s: Send to RTS done on probing QP (index=%d, qp_num=%u, dest_qp_num=%u, deviceIndex=%d, comm=%p)", __func__, localQpIndex, localQp->qp->qp_num, rtrAttr->remoteQpNum, localDevIndex, resCtx->baseComm);
+    INFO(NCCL_NET,
+         "NET/IB: %s: Send to RTS done on probing QP (index=%d, qp_num=%u, dest_qp_num=%u, deviceIndex=%d, comm=%p)",
+         __func__, localQpIndex, localQp->qp->qp_num, rtrAttr->remoteQpNum, localDevIndex, resCtx->baseComm);
   }
 
   if (resCtx->recoveryEnabled) {
@@ -787,7 +883,9 @@ ncclResult_t ncclIbResiliencySenderQpsToRts(struct ncclIbResiliency* resCtx, str
   return ncclSuccess;
 }
 
-ncclResult_t ncclIbResiliencyReceiverQpsCreateToRts(struct ncclIbResiliency* resCtx, struct ncclIbConnectionMetadata* remInfo, struct ncclIbResiliencyInfo* localResiliencyInfo) {
+ncclResult_t ncclIbResiliencyReceiverQpsCreateToRts(struct ncclIbResiliency* resCtx,
+                                                    struct ncclIbConnectionMetadata* remInfo,
+                                                    struct ncclIbResiliencyInfo* localResiliencyInfo) {
   ncclIbRecvComm* recvComm = (ncclIbRecvComm*)resCtx->baseComm;
   void* qpContext = (void*)&recvComm->base.stats;
   struct ncclIbQpCreateAttr qpCreateAttrs;
@@ -841,11 +939,14 @@ ncclResult_t ncclIbResiliencyReceiverQpsCreateToRts(struct ncclIbResiliency* res
     rtsAttr->timeout = ncclParamIbTimeout();
     rtsAttr->retryCnt = ncclParamIbRetryCnt();
     NCCLCHECK(ncclIbQpRts(localQp));
-    INFO(NCCL_NET, "NET/IB: %s: Recv to RTS done on probing QP (index=%d, qp_num=%u, dest_qp_num=%u, deviceIndex=%d, comm=%p)", __func__, localQpIndex, localQp->qp->qp_num, rtrAttr->remoteQpNum, localDevIndex, resCtx->baseComm);
+    INFO(NCCL_NET,
+         "NET/IB: %s: Recv to RTS done on probing QP (index=%d, qp_num=%u, dest_qp_num=%u, deviceIndex=%d, comm=%p)",
+         __func__, localQpIndex, localQp->qp->qp_num, rtrAttr->remoteQpNum, localDevIndex, resCtx->baseComm);
   }
 
   if (resCtx->recoveryEnabled) {
-    NCCLCHECK(ncclIbPortRecoveryReceiverQpsCreateToRts(resCtx, remInfo, localResiliencyInfo->portRecoveryQpsInfo, resCtx->nPortRecoveryQps));
+    NCCLCHECK(ncclIbPortRecoveryReceiverQpsCreateToRts(resCtx, remInfo, localResiliencyInfo->portRecoveryQpsInfo,
+                                                       resCtx->nPortRecoveryQps));
   }
 
   return ncclSuccess;
@@ -856,20 +957,25 @@ ncclResult_t ncclIbResiliencyClose(struct ncclIbResiliency* resCtx) {
     WARN("NET/IB: %s: Resiliency context is NULL. Nothing to destroy.", __func__);
     return ncclSuccess;
   }
-  INFO(NCCL_NET, "NET/IB: %s: Resiliency context close for %s communicator (comm=%p)", __func__, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
+  INFO(NCCL_NET, "NET/IB: %s: Resiliency context close for %s communicator (comm=%p)", __func__,
+       resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
 
-  INFO(NCCL_NET, "NET/IB: %s: Destroying %d probing QPs for resiliency context (%s comm=%p)", __func__, resCtx->nProbingQps, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
+  INFO(NCCL_NET, "NET/IB: %s: Destroying %d probing QPs for resiliency context (%s comm=%p)", __func__,
+       resCtx->nProbingQps, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
   for (int qpIndex = 0; qpIndex < resCtx->nProbingQps; qpIndex++) {
     struct ncclIbQp* probingQp = &resCtx->probingQps[qpIndex];
     if (probingQp->qp == NULL) {
       continue;
     }
-    INFO(NCCL_NET, "NET/IB: %s: Destroying probing QP (index=%d, qp=%p, qp_num=%u) for resiliency context (comm=%p)", __func__, qpIndex, probingQp->qp, probingQp->qp->qp_num, resCtx->baseComm);
+    INFO(NCCL_NET, "NET/IB: %s: Destroying probing QP (index=%d, qp=%p, qp_num=%u) for resiliency context (comm=%p)",
+         __func__, qpIndex, probingQp->qp, probingQp->qp->qp_num, resCtx->baseComm);
     NCCLCHECK(wrap_ibv_destroy_qp(probingQp->qp));
   }
   if (resCtx->recoveryEnabled) {
     if (resCtx->outstandingRecovery > 0) {
-      WARN("NET/IB: %s: There are still %d outstanding recovery operations on the resiliency context (comm=%p) being destroyed.", __func__, resCtx->outstandingRecovery, resCtx->baseComm);
+      WARN("NET/IB: %s: There are still %d outstanding recovery operations on the resiliency context (comm=%p) being "
+           "destroyed.",
+           __func__, resCtx->outstandingRecovery, resCtx->baseComm);
     }
     NCCLCHECK(ncclIbPortRecoveryClose(resCtx));
     NCCLCHECK(ncclIbPortRecoveryQpsDestroy(resCtx, resCtx->nPortRecoveryQps));
@@ -877,18 +983,20 @@ ncclResult_t ncclIbResiliencyClose(struct ncclIbResiliency* resCtx) {
   return ncclSuccess;
 }
 
-ncclResult_t ncclIbResiliencyRemoteCompletionRecordsSet(struct ncclIbResiliency* resCtx, uint32_t cmplsRecordsRkey, uint64_t cmplsRecordsAddr, uint devIndex) {
+ncclResult_t ncclIbResiliencyRemoteCompletionRecordsSet(struct ncclIbResiliency* resCtx, uint32_t cmplsRecordsRkey,
+                                                        uint64_t cmplsRecordsAddr, uint devIndex) {
   assert(resCtx != NULL);
   assert(resCtx->baseComm->isSend);
   assert(devIndex <= resCtx->nProbingQps);
   struct ncclIbResiliencySend* sendResCtx = (struct ncclIbResiliencySend*)resCtx;
   sendResCtx->remCmplRecordsInfo[devIndex].rkey = cmplsRecordsRkey;
   sendResCtx->remCmplRecordsInfo[devIndex].addr = cmplsRecordsAddr;
-  INFO(NCCL_NET, "NET/IB: %s: Set remote completion records info (comm=%p, addr=0x%lx, rkey=0x%x)", __func__, &resCtx->baseComm, cmplsRecordsAddr, cmplsRecordsRkey);
+  INFO(NCCL_NET, "NET/IB: %s: Set remote completion records info (comm=%p, addr=0x%lx, rkey=0x%x)", __func__,
+       &resCtx->baseComm, cmplsRecordsAddr, cmplsRecordsRkey);
   return ncclSuccess;
 }
 
-ncclResult_t ncclIbResiliencyRequestIsComplete(struct ncclIbRequest *request, bool *isComplete) {
+ncclResult_t ncclIbResiliencyRequestIsComplete(struct ncclIbRequest* request, bool* isComplete) {
   assert(isComplete != NULL);
 
   if (request == NULL) {
@@ -926,14 +1034,19 @@ ncclResult_t ncclIbResiliencyRequestIsComplete(struct ncclIbRequest *request, bo
   *isComplete = ((remainingEventsSum == 0) || (abs(negativeEventsSum) == remainingEventsSum));
 #ifdef ENABLE_TRACE
   if (*isComplete == 1) {
-    TRACE(NCCL_NET, "NET/IB: %s: request=%p, remainingEventsSum=%d, negativeEventsSum=%d, completed? %s", __func__, request, remainingEventsSum, negativeEventsSum, *isComplete ? "yes" : "no");
+    TRACE(NCCL_NET, "NET/IB: %s: request=%p, remainingEventsSum=%d, negativeEventsSum=%d, completed? %s", __func__,
+          request, remainingEventsSum, negativeEventsSum, *isComplete ? "yes" : "no");
   }
 #endif // ENABLE_TRACE
   return ncclSuccess;
 }
 
 ncclResult_t ncclIbResiliencyHandleCompletionError(struct ncclIbResiliency* resCtx, struct ibv_wc* wc, int devIndex) {
-  INFO(NCCL_NET, "NET/IB: %s: Got completion with error (devIndex=%d, wc->status=(%s)%d, wc->opcode=(%s)%d, wc->wr_id=%ld, wc->qp_num=%u, wc->byte_len=%d)", __func__, devIndex, ibvWcStatusStr(wc->status), wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->wr_id, wc->qp_num, wc->byte_len);
+  INFO(NCCL_NET,
+       "NET/IB: %s: Got completion with error (devIndex=%d, wc->status=(%s)%d, wc->opcode=(%s)%d, wc->wr_id=%ld, "
+       "wc->qp_num=%u, wc->byte_len=%d)",
+       __func__, devIndex, ibvWcStatusStr(wc->status), wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->wr_id,
+       wc->qp_num, wc->byte_len);
   NCCLCHECK(ncclIbResiliencyCheckErrorNotFatal(resCtx, wc, devIndex));
 
   // Before handling the request that got an error, first the device is
@@ -955,7 +1068,8 @@ static ncclResult_t ncclIbResiliencyActiveQpsRestore(struct ncclIbResiliency* re
     if (qpToRestore->devIndex != restoredDevIndex) {
       continue;
     }
-    INFO(NCCL_NET, "NET/IB: %s: Restoring QP (index=%d, qp_num=%u) on device %d (comm=%p)", __func__, qpIndex, qpToRestore->qp->qp_num, restoredDevIndex, resCtx->baseComm);
+    INFO(NCCL_NET, "NET/IB: %s: Restoring QP (index=%d, qp_num=%u) on device %d (comm=%p)", __func__, qpIndex,
+         qpToRestore->qp->qp_num, restoredDevIndex, resCtx->baseComm);
     resCtx->baseComm->activeQps[qpIndex] = qpToRestore;
   }
   return ncclSuccess;
@@ -994,16 +1108,24 @@ ncclResult_t ncclIbResiliencyProgress(struct ncclIbResiliency* resCtx) {
     // Check if recovery operations are completed.
     for (int devIndex = 0; devIndex < resCtx->ndevs; devIndex++) {
       enum ncclIbResiliencyDevState devState = resCtx->devs[devIndex].state.load(std::memory_order_acquire);
-      TRACE(NCCL_NET, "NET/IB: %s: Checking dev state for device %d: state=%d (comm=%p).", __func__, devIndex, devState, resCtx->baseComm);
+      TRACE(NCCL_NET, "NET/IB: %s: Checking dev state for device %d: state=%d (comm=%p).", __func__, devIndex, devState,
+            resCtx->baseComm);
       if (devState == ncclIbResiliencyDevStateRecovered) {
         resCtx->outstandingRecovery--;
-        INFO(NCCL_NET, "NET/IB: %s: Device %d has been recovered for resiliency context (%s comm=%p, outstandingRecovery=%d)", __func__, devIndex, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm, resCtx->outstandingRecovery);
+        INFO(NCCL_NET,
+             "NET/IB: %s: Device %d has been recovered for resiliency context (%s comm=%p, outstandingRecovery=%d)",
+             __func__, devIndex, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm,
+             resCtx->outstandingRecovery);
         ncclIbResiliencyActiveQpsRestore(resCtx, devIndex);
         resCtx->devs[devIndex].state.store(ncclIbResiliencyDevStateOk, std::memory_order_release);
       }
       if (devState == ncclIbResiliencyDevStateRecoveryFailed) {
         resCtx->outstandingRecovery--;
-        INFO(NCCL_NET, "NET/IB: %s: Device %d will not be attempted to be recovered any more (%s comm=%p, outstandingRecovery=%d).", __func__, devIndex, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm, resCtx->outstandingRecovery);
+        INFO(
+          NCCL_NET,
+          "NET/IB: %s: Device %d will not be attempted to be recovered any more (%s comm=%p, outstandingRecovery=%d).",
+          __func__, devIndex, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm,
+          resCtx->outstandingRecovery);
         resCtx->devs[devIndex].state.store(ncclIbResiliencyDevStateErrorPermanent, std::memory_order_release);
         continue;
       }
@@ -1011,7 +1133,10 @@ ncclResult_t ncclIbResiliencyProgress(struct ncclIbResiliency* resCtx) {
   }
 
   if (resCtx->outstandingRequests == 0 && resCtx->outstandingRecovery == 0) {
-    INFO(NCCL_NET, "NET/IB: %s: All resiliency operations are completed for resiliency context (%s comm=%p). Marking progress as completed.", __func__, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
+    INFO(NCCL_NET,
+         "NET/IB: %s: All resiliency operations are completed for resiliency context (%s comm=%p). Marking progress as "
+         "completed.",
+         __func__, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
     resCtx->inProgress = false;
   }
   return ncclSuccess;

--- a/projects/rccl/src/transport/net_ib/p2p_resiliency.h
+++ b/projects/rccl/src/transport/net_ib/p2p_resiliency.h
@@ -155,7 +155,7 @@ struct ncclIbResiliencySend {
 // Data path APIs
 // -----------------------------
 
-ncclResult_t ncclIbResiliencyRequestIsComplete(struct ncclIbRequest *request, bool *isComplete);
+ncclResult_t ncclIbResiliencyRequestIsComplete(struct ncclIbRequest* request, bool* isComplete);
 
 // First checks if the error is recoverable or not. If yes, performs QPs
 // replacement on the communicator for all QPs that are associated
@@ -193,13 +193,16 @@ ncclResult_t ncclIbResiliencyDeviceNumSet(struct ncclIbResiliency* resCtx, int n
 
 // The local info should be populated by the function with the information of
 // the QPs created so it could be passed to the receiver side.
-ncclResult_t ncclIbResiliencySenderCreateQps(struct ncclIbResiliency* resCtx, struct ncclIbResiliencyInfo* localResiliencyInfo);
+ncclResult_t ncclIbResiliencySenderCreateQps(struct ncclIbResiliency* resCtx,
+                                             struct ncclIbResiliencyInfo* localResiliencyInfo);
 // The remote info should be used for modifying the QPs required for resiliency
 // on the sender side to RTS state.
 ncclResult_t ncclIbResiliencySenderQpsToRts(struct ncclIbResiliency* resCtx, struct ncclIbConnectionMetadata* remInfo);
 // The local info should be populated with the information of the QPs created
 // so it could be passed to the sender side.
-ncclResult_t ncclIbResiliencyReceiverQpsCreateToRts(struct ncclIbResiliency* resCtx, struct ncclIbConnectionMetadata* remInfo, struct ncclIbResiliencyInfo* localResiliencyInfo);
+ncclResult_t ncclIbResiliencyReceiverQpsCreateToRts(struct ncclIbResiliency* resCtx,
+                                                    struct ncclIbConnectionMetadata* remInfo,
+                                                    struct ncclIbResiliencyInfo* localResiliencyInfo);
 
 ncclResult_t ncclIbResiliencyClose(struct ncclIbResiliency* resCtx);
 
@@ -208,6 +211,7 @@ ncclResult_t ncclIbResiliencyClose(struct ncclIbResiliency* resCtx);
 // memory info to the sender side. This function should be called on the sender
 // side to allow the resiliency context to access the completion records
 // structure on the receiver side.
-ncclResult_t ncclIbResiliencyRemoteCompletionRecordsSet(struct ncclIbResiliency* resCtx, uint32_t cmplsRecordsRkey, uint64_t cmplsRecordsAddr, uint devIndex);
+ncclResult_t ncclIbResiliencyRemoteCompletionRecordsSet(struct ncclIbResiliency* resCtx, uint32_t cmplsRecordsRkey,
+                                                        uint64_t cmplsRecordsAddr, uint devIndex);
 
 #endif // NET_IB_P2P_RESILIENCY_H_

--- a/projects/rccl/src/transport/net_ib/p2p_resiliency_recovery.cc
+++ b/projects/rccl/src/transport/net_ib/p2p_resiliency_recovery.cc
@@ -9,10 +9,12 @@
 
 NCCL_PARAM(IbResiliencyPortRecovery, "IB_RESILIENCY_PORT_RECOVERY", 0);
 NCCL_PARAM(IbResiliencyPortRecoveryStartDelay, "IB_RESILIENCY_PORT_RECOVERY_START_DELAY", 200); // In milliseconds
-NCCL_PARAM(IbResiliencyPortRecoveryAliveMsgBatchInterval, "IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_INTERVAL", 500); // In milliseconds
+NCCL_PARAM(IbResiliencyPortRecoveryAliveMsgBatchInterval, "IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_INTERVAL",
+           500); // In milliseconds
 NCCL_PARAM(IbResiliencyPortRecoveryAliveMsgBatchSize, "IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE", 5);
 NCCL_PARAM(IbResiliencyPortRecoveryAliveMsgSequenceSize, "IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_SEQUENCE_SIZE", 5);
-NCCL_PARAM(IbResiliencyPortRecoveryAliveMsgTimeout, "IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_TIMEOUT", 4000); // In milliseconds
+NCCL_PARAM(IbResiliencyPortRecoveryAliveMsgTimeout, "IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_TIMEOUT",
+           4000); // In milliseconds
 NCCL_PARAM(IbResiliencyPortRecoveryAckTimeout, "IB_RESILIENCY_PORT_RECOVERY_ACK_TIMEOUT", 5000); // In milliseconds
 NCCL_PARAM(IbResiliencyPortRecoveryAttemptsMax, "IB_RESILIENCY_PORT_RECOVERY_ATTEMPTS_MAX", 5);
 
@@ -29,7 +31,7 @@ extern int64_t ncclParamIbPkey();
 // The asynchronous thread should be be able to handle the CQ fast enough so
 // no more than two batches of "alive" messsages should be pending in the CQ at
 // any time.
-#define NCCL_IB_RESILIENCY_PORT_RECOVERY_CQ_SIZE (NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX*2)
+#define NCCL_IB_RESILIENCY_PORT_RECOVERY_CQ_SIZE (NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX * 2)
 
 // Asynchronous thread to handle port recovery operations
 std::thread ncclIbPortRecoveryAsyncThread;
@@ -159,7 +161,9 @@ static inline ncclResult_t ncclIbPortRecoveryQpsToError(ncclIbPortRecoveryContex
       // The QP is not on the failed device; skip
       continue;
     }
-    INFO(NCCL_NET, "NET/IB: %s: Transitioning QP %u on device %d to ERROR state (comm=%p, devIndex=%d, qp_num=%u)", __func__, localQp->qp->qp_num, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex, localQp->qp->qp_num);
+    INFO(NCCL_NET, "NET/IB: %s: Transitioning QP %u on device %d to ERROR state (comm=%p, devIndex=%d, qp_num=%u)",
+         __func__, localQp->qp->qp_num, recoveryContext->devIndex, recoveryContext->resCtx->baseComm,
+         recoveryContext->devIndex, localQp->qp->qp_num);
     NCCLCHECK(ncclIbQpError(localQp));
   }
   return ncclSuccess;
@@ -169,10 +173,7 @@ static inline ncclResult_t ncclIbPortRecoveryQpsToError(ncclIbPortRecoveryContex
 #define NCCL_IB_PORT_RECOVERY_WR_ID (0xAAAA)
 
 static struct ibv_recv_wr ncclIbResiliencyPortRecoveryRecvWr = {
-    .wr_id = NCCL_IB_PORT_RECOVERY_WR_ID,
-    .next = NULL,
-    .sg_list = NULL,
-    .num_sge = 0
+  .wr_id = NCCL_IB_PORT_RECOVERY_WR_ID, .next = NULL, .sg_list = NULL, .num_sge = 0
 };
 
 inline static ncclResult_t ncclIbPortRecoveryPostRecvWorkRequest(struct ibv_qp* qp) {
@@ -182,7 +183,8 @@ inline static ncclResult_t ncclIbPortRecoveryPostRecvWorkRequest(struct ibv_qp* 
 
 // Helper function to drain CQEs on the provided CQ and fill a Receive WQE for
 // every CQE drained on the provided QP.
-static ncclResult_t ncclIbPortRecoveryDrainCqAndPostReceiveWRs(struct ncclIbPortRecoveryContext* recoveryContext, bool* success) {
+static ncclResult_t ncclIbPortRecoveryDrainCqAndPostReceiveWRs(struct ncclIbPortRecoveryContext* recoveryContext,
+                                                               bool* success) {
   struct ibv_cq* cq = recoveryContext->recoveryCq;
   struct ibv_qp* qp = recoveryContext->resCtx->portRecoveryQps[recoveryContext->devIndex].qp;
   int wrDone = 0;
@@ -193,15 +195,18 @@ static ncclResult_t ncclIbPortRecoveryDrainCqAndPostReceiveWRs(struct ncclIbPort
   do {
     ret = wrap_ibv_poll_cq(cq, numMsgs, wcs, &wrDone);
     if (ret != ncclSuccess) {
-      INFO(NCCL_NET, "NET/IB: %s: Failed to poll recovery CQ %p for device %d (comm=%p)", __func__, cq, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Failed to poll recovery CQ %p for device %d (comm=%p)", __func__, cq,
+           recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
       *success = false;
       return ncclSuccess;
     }
-    INFO(NCCL_NET, "NET/IB: %s: Drained %d CQEs from recovery CQ %p for device %d (comm=%p)", __func__, wrDone, cq, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+    INFO(NCCL_NET, "NET/IB: %s: Drained %d CQEs from recovery CQ %p for device %d (comm=%p)", __func__, wrDone, cq,
+         recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
     for (int i = 0; i < wrDone; i++) {
       ret = ncclIbPortRecoveryPostRecvWorkRequest(qp);
       if (ret != ncclSuccess) {
-        INFO(NCCL_NET, "NET/IB: %s: Failed to post recv WR on recovery QP %p for device %d (comm=%p)", __func__, qp, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+        INFO(NCCL_NET, "NET/IB: %s: Failed to post recv WR on recovery QP %p for device %d (comm=%p)", __func__, qp,
+             recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
         *success = false;
         return ncclSuccess;
       }
@@ -211,7 +216,8 @@ static ncclResult_t ncclIbPortRecoveryDrainCqAndPostReceiveWRs(struct ncclIbPort
   return ncclSuccess;
 }
 
-static inline ncclResult_t ncclIbPortRecoveryContextInit(struct ncclIbResiliency* resCtx, int failedDevIndex, ncclIbPortRecoveryContext** outRecoveryCtx) {
+static inline ncclResult_t ncclIbPortRecoveryContextInit(struct ncclIbResiliency* resCtx, int failedDevIndex,
+                                                         ncclIbPortRecoveryContext** outRecoveryCtx) {
   ncclResult_t res = ncclSuccess;
   if (!outRecoveryCtx) return ncclInternalError;
   ncclIbPortRecoveryContext* recoveryCtx = (ncclIbPortRecoveryContext*)malloc(sizeof(ncclIbPortRecoveryContext));
@@ -245,7 +251,8 @@ static inline ncclResult_t ncclIbPortRecoveryContextInit(struct ncclIbResiliency
   // Transitioning all QPs on the failed device to ERROR state
   res = ncclIbPortRecoveryQpsToError(recoveryCtx);
   if (res != ncclSuccess) {
-    INFO(NCCL_NET, "NET/IB: %s: Failed to transition QPs to ERROR state for device %d (comm=%p)", __func__, failedDevIndex, resCtx->baseComm);
+    INFO(NCCL_NET, "NET/IB: %s: Failed to transition QPs to ERROR state for device %d (comm=%p)", __func__,
+         failedDevIndex, resCtx->baseComm);
     free(recoveryCtx);
     return res;
   }
@@ -254,21 +261,26 @@ static inline ncclResult_t ncclIbPortRecoveryContextInit(struct ncclIbResiliency
     recoveryCtx->send.aliveMsgPosted = false;
     recoveryCtx->send.aliveMsgCompleted = false;
     // Required for the ACK from the receiver
-    INFO(NCCL_NET, "NET/IB: %s: Sender posting initial (%d) recv WRs for port recovery for device %d (comm=%p)", __func__, 1, recoveryCtx->devIndex, recoveryCtx->resCtx->baseComm);
+    INFO(NCCL_NET, "NET/IB: %s: Sender posting initial (%d) recv WRs for port recovery for device %d (comm=%p)",
+         __func__, 1, recoveryCtx->devIndex, recoveryCtx->resCtx->baseComm);
     res = ncclIbPortRecoveryPostRecvWorkRequest(recoveryCtx->resCtx->portRecoveryQps[recoveryCtx->devIndex].qp);
     if (res != ncclSuccess) {
-      INFO(NCCL_NET, "NET/IB: %s: Sender failed to post recv WR on recovery QP for device %d (comm=%p)", __func__, recoveryCtx->devIndex, recoveryCtx->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Sender failed to post recv WR on recovery QP for device %d (comm=%p)", __func__,
+           recoveryCtx->devIndex, recoveryCtx->resCtx->baseComm);
       free(recoveryCtx);
       return res;
     }
   } else {
     recoveryCtx->recv.nInOrderMsgsReceived = 0;
     // Required for the alive messages and final ACK from the sender
-    INFO(NCCL_NET, "NET/IB: %s: Receiver posting initial (%d) recv WRs for port recovery for device %d (comm=%p)", __func__, NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX, recoveryCtx->devIndex, recoveryCtx->resCtx->baseComm);
+    INFO(NCCL_NET, "NET/IB: %s: Receiver posting initial (%d) recv WRs for port recovery for device %d (comm=%p)",
+         __func__, NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX, recoveryCtx->devIndex,
+         recoveryCtx->resCtx->baseComm);
     for (int i = 0; i < NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX; i++) {
       res = ncclIbPortRecoveryPostRecvWorkRequest(recoveryCtx->resCtx->portRecoveryQps[recoveryCtx->devIndex].qp);
       if (res != ncclSuccess) {
-        INFO(NCCL_NET, "NET/IB: %s: Receiver failed to post recv WR on recovery QP for device %d (comm=%p)", __func__, recoveryCtx->devIndex, recoveryCtx->resCtx->baseComm);
+        INFO(NCCL_NET, "NET/IB: %s: Receiver failed to post recv WR on recovery QP for device %d (comm=%p)", __func__,
+             recoveryCtx->devIndex, recoveryCtx->resCtx->baseComm);
         free(recoveryCtx);
         return res;
       }
@@ -281,7 +293,9 @@ static inline ncclResult_t ncclIbPortRecoveryContextInit(struct ncclIbResiliency
 
 static inline ncclResult_t ncclIbPortRecoveryContextDestroy(ncclIbPortRecoveryContext* recoveryContext) {
   assert(recoveryContext);
-  INFO(NCCL_NET, "NET/IB: %s: Destroying port recovery context for device %d (%s comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
+  INFO(NCCL_NET, "NET/IB: %s: Destroying port recovery context for device %d (%s comm=%p)", __func__,
+       recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv",
+       recoveryContext->resCtx->baseComm);
   free(recoveryContext);
   return ncclSuccess;
 }
@@ -290,8 +304,10 @@ ncclResult_t ncclIbPortRecoveryDevInit(struct ncclIbResiliency* resCtx, int devI
   assert(resCtx->recoveryEnabled);
   struct ncclIbResiliencyDev* resDev = &resCtx->devs[devIndex];
   void* cqContext = (void*)&resCtx->baseComm->stats;
-  INFO(NCCL_NET, "NET/IB: %s: Created port recovery CQ is enabled for resiliency context (%s comm=%p) on device %d", __func__, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm, devIndex);
-  NCCLCHECK(wrap_ibv_create_cq(&resDev->portRecoveryCq, ibDev->context, NCCL_IB_RESILIENCY_PORT_RECOVERY_CQ_SIZE, cqContext, NULL, 0));
+  INFO(NCCL_NET, "NET/IB: %s: Created port recovery CQ is enabled for resiliency context (%s comm=%p) on device %d",
+       __func__, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm, devIndex);
+  NCCLCHECK(wrap_ibv_create_cq(&resDev->portRecoveryCq, ibDev->context, NCCL_IB_RESILIENCY_PORT_RECOVERY_CQ_SIZE,
+                               cqContext, NULL, 0));
   return ncclSuccess;
 }
 
@@ -300,11 +316,13 @@ ncclResult_t ncclIbPortRecoveryDevDestroy(struct ncclIbResiliency* resCtx, int d
   if (resDev->portRecoveryCq) {
     NCCLCHECK(wrap_ibv_destroy_cq(resDev->portRecoveryCq));
   }
-  INFO(NCCL_NET, "NET/IB: %s: Destroyed port recovery CQ (cq=%p) on device %d for resiliency context (comm=%p)", __func__, resDev->portRecoveryCq, devIndex, resCtx->baseComm);
+  INFO(NCCL_NET, "NET/IB: %s: Destroyed port recovery CQ (cq=%p) on device %d for resiliency context (comm=%p)",
+       __func__, resDev->portRecoveryCq, devIndex, resCtx->baseComm);
   return ncclSuccess;
 }
 
-ncclResult_t ncclIbPortRecoverySenderQpsCreate(struct ncclIbResiliency* resCtx, struct ncclIbQpInfo* localPortRecoveryQpsInfo, int nQps) {
+ncclResult_t ncclIbPortRecoverySenderQpsCreate(struct ncclIbResiliency* resCtx,
+                                               struct ncclIbQpInfo* localPortRecoveryQpsInfo, int nQps) {
   assert(nQps > 0);
   assert(resCtx->recoveryEnabled);
   ncclIbSendComm* sendComm = (ncclIbSendComm*)resCtx->baseComm;
@@ -340,14 +358,16 @@ ncclResult_t ncclIbPortRecoverySenderQpsCreate(struct ncclIbResiliency* resCtx, 
   return ncclSuccess;
 }
 
-ncclResult_t ncclIbPortRecoverySenderQpsToRts(struct ncclIbResiliency* resCtx, struct ncclIbConnectionMetadata* remInfo, int nQps) {
+ncclResult_t ncclIbPortRecoverySenderQpsToRts(struct ncclIbResiliency* resCtx, struct ncclIbConnectionMetadata* remInfo,
+                                              int nQps) {
   assert(nQps > 0);
   assert(resCtx->recoveryEnabled);
   ncclIbSendComm* sendComm = (ncclIbSendComm*)resCtx->baseComm;
   ncclIbQp* localQp = NULL;
   ncclIbQpInfo* remQpInfo = NULL;
   for (int localQpIndex = 0; localQpIndex < nQps; localQpIndex++) {
-    int localDevIndex = localQpIndex % sendComm->base.vProps.ndevs;;
+    int localDevIndex = localQpIndex % sendComm->base.vProps.ndevs;
+    ;
     ncclIbSendCommDev* sendCommDev = &sendComm->devs[localDevIndex];
     ncclIbDev* ibDev = &ncclIbDevs[sendCommDev->base.ibDevN];
     localQp = &resCtx->portRecoveryQps[localQpIndex];
@@ -372,12 +392,16 @@ ncclResult_t ncclIbPortRecoverySenderQpsToRts(struct ncclIbResiliency* resCtx, s
     NCCLCHECK(ncclIbQpRtr(localQp));
 
     NCCLCHECK(ncclIbQpRts(localQp));
-    INFO(NCCL_NET, "NET/IB: %s: To RTS done on recovery QP (index=%d, qp_num=%u, dest_qp_num=%u, deviceIndex=%d, comm=%p)", __func__, localQpIndex, localQp->qp->qp_num, rtrAttr->remoteQpNum, localDevIndex, resCtx->baseComm);
+    INFO(NCCL_NET,
+         "NET/IB: %s: To RTS done on recovery QP (index=%d, qp_num=%u, dest_qp_num=%u, deviceIndex=%d, comm=%p)",
+         __func__, localQpIndex, localQp->qp->qp_num, rtrAttr->remoteQpNum, localDevIndex, resCtx->baseComm);
   }
   return ncclSuccess;
 }
 
-ncclResult_t ncclIbPortRecoveryReceiverQpsCreateToRts(struct ncclIbResiliency* resCtx, struct ncclIbConnectionMetadata* remInfo, struct ncclIbQpInfo* localPortRecoveryQpsInfo, int nQps) {
+ncclResult_t ncclIbPortRecoveryReceiverQpsCreateToRts(struct ncclIbResiliency* resCtx,
+                                                      struct ncclIbConnectionMetadata* remInfo,
+                                                      struct ncclIbQpInfo* localPortRecoveryQpsInfo, int nQps) {
   ncclIbRecvComm* recvComm = (ncclIbRecvComm*)resCtx->baseComm;
   void* qpContext = (void*)&recvComm->base.stats;
   struct ncclIbQpCreateAttr qpCreateAttrs;
@@ -425,7 +449,9 @@ ncclResult_t ncclIbPortRecoveryReceiverQpsCreateToRts(struct ncclIbResiliency* r
     NCCLCHECK(ncclIbQpRtr(localQp));
 
     NCCLCHECK(ncclIbQpRts(localQp));
-    INFO(NCCL_NET, "NET/IB: %s: To RTS done on recovery QP (index=%d, qp_num=%u, dest_qp_num=%u, deviceIndex=%d, comm=%p)", __func__, localQpIndex, localQp->qp->qp_num, rtrAttr->remoteQpNum, localDevIndex, resCtx->baseComm);
+    INFO(NCCL_NET,
+         "NET/IB: %s: To RTS done on recovery QP (index=%d, qp_num=%u, dest_qp_num=%u, deviceIndex=%d, comm=%p)",
+         __func__, localQpIndex, localQp->qp->qp_num, rtrAttr->remoteQpNum, localDevIndex, resCtx->baseComm);
   }
   return ncclSuccess;
 }
@@ -436,7 +462,9 @@ ncclResult_t ncclIbPortRecoveryQpsDestroy(struct ncclIbResiliency* resCtx, int n
     if (!recoveryQp->qp) {
       continue;
     }
-    INFO(NCCL_NET, "NET/IB: %s: Destroying port recovery QP (index=%d, qp=%p, qp_num=%u) for resiliency context (comm=%p)", __func__, qpIndex, recoveryQp->qp, recoveryQp->qp->qp_num, resCtx->baseComm);
+    INFO(NCCL_NET,
+         "NET/IB: %s: Destroying port recovery QP (index=%d, qp=%p, qp_num=%u) for resiliency context (comm=%p)",
+         __func__, qpIndex, recoveryQp->qp, recoveryQp->qp->qp_num, resCtx->baseComm);
     NCCLCHECK(wrap_ibv_destroy_qp(recoveryQp->qp));
   }
   return ncclSuccess;
@@ -452,48 +480,64 @@ static inline ncclResult_t ncclIbPortRecoveryQpsRestore(ncclIbPortRecoveryContex
       continue;
     }
 
-    INFO(NCCL_NET, "NET/IB: %s: Restoring QP %d on device %d (comm=%p, devIndex=%d, qp_num=%u)", __func__, qpIndex, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex, localQp->qp->qp_num);
+    INFO(NCCL_NET, "NET/IB: %s: Restoring QP %d on device %d (comm=%p, devIndex=%d, qp_num=%u)", __func__, qpIndex,
+         recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex, localQp->qp->qp_num);
     res = ncclIbQpReset(localQp);
     if (res != ncclSuccess) {
-      INFO(NCCL_NET, "NET/IB: %s: Failed to reset QP index %d on device %d (comm=%p, devIndex=%d, qp_num=%u)", __func__, qpIndex, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex, localQp->qp->qp_num);
+      INFO(NCCL_NET, "NET/IB: %s: Failed to reset QP index %d on device %d (comm=%p, devIndex=%d, qp_num=%u)", __func__,
+           qpIndex, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex,
+           localQp->qp->qp_num);
       *success = false;
       return ncclSuccess;
     }
     res = ncclIbQpInit(localQp);
     if (res != ncclSuccess) {
-      INFO(NCCL_NET, "NET/IB: %s: Failed to init QP index %d on device %d (comm=%p, devIndex=%d, qp_num=%u)", __func__, qpIndex, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex, localQp->qp->qp_num);
+      INFO(NCCL_NET, "NET/IB: %s: Failed to init QP index %d on device %d (comm=%p, devIndex=%d, qp_num=%u)", __func__,
+           qpIndex, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex,
+           localQp->qp->qp_num);
       *success = false;
       return ncclSuccess;
     }
     if (localQp->eceSupported) {
       res = wrap_ibv_set_ece(localQp->qp, &localQp->ece, &localQp->eceSupported);
       if (res != ncclSuccess) {
-        INFO(NCCL_NET, "NET/IB: %s: Failed to set ECE for QP index %d on device %d (comm=%p, devIndex=%d, qp_num=%u)", __func__, qpIndex, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex, localQp->qp->qp_num);
+        INFO(NCCL_NET, "NET/IB: %s: Failed to set ECE for QP index %d on device %d (comm=%p, devIndex=%d, qp_num=%u)",
+             __func__, qpIndex, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex,
+             localQp->qp->qp_num);
         *success = false;
         return ncclSuccess;
       }
     }
     res = ncclIbQpRtr(localQp);
     if (res != ncclSuccess) {
-      INFO(NCCL_NET, "NET/IB: %s: Failed to modify to RTR QP index %d on device %d (comm=%p, devIndex=%d, qp_num=%u)", __func__, qpIndex, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex, localQp->qp->qp_num);
+      INFO(NCCL_NET, "NET/IB: %s: Failed to modify to RTR QP index %d on device %d (comm=%p, devIndex=%d, qp_num=%u)",
+           __func__, qpIndex, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex,
+           localQp->qp->qp_num);
       *success = false;
       return ncclSuccess;
     }
     res = ncclIbQpRts(localQp);
     if (res != ncclSuccess) {
-      INFO(NCCL_NET, "NET/IB: %s: Failed to modify to RTS QP index %d on device %d (comm=%p, devIndex=%d, qp_num=%u)", __func__, qpIndex, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex, localQp->qp->qp_num);
+      INFO(NCCL_NET, "NET/IB: %s: Failed to modify to RTS QP index %d on device %d (comm=%p, devIndex=%d, qp_num=%u)",
+           __func__, qpIndex, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex,
+           localQp->qp->qp_num);
       *success = false;
       return ncclSuccess;
     }
-    INFO(NCCL_NET, "NET/IB: %s: Restored QP %d on device %d (comm=%p, devIndex=%d, qp_num=%u)", __func__, qpIndex, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex, localQp->qp->qp_num);
+    INFO(NCCL_NET, "NET/IB: %s: Restored QP %d on device %d (comm=%p, devIndex=%d, qp_num=%u)", __func__, qpIndex,
+         recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex, localQp->qp->qp_num);
 
     if (!recoveryContext->resCtx->baseComm->isSend) {
       // Pre-post receive work requests on the restored QP if this is a receiver.
-      INFO(NCCL_NET, "NET/IB: %s: Posting receive work requests on the restored QP (comm=%p, qp_num=%u)", __func__, recoveryContext->resCtx->baseComm, localQp->qp->qp_num);
+      INFO(NCCL_NET, "NET/IB: %s: Posting receive work requests on the restored QP (comm=%p, qp_num=%u)", __func__,
+           recoveryContext->resCtx->baseComm, localQp->qp->qp_num);
       struct ncclIbRecvComm* recvComm = (struct ncclIbRecvComm*)recoveryContext->resCtx->baseComm;
       res = ncclIbPostReceiveWorkRequestsOnQp(recvComm, localQp);
       if (res != ncclSuccess) {
-        INFO(NCCL_NET, "NET/IB: %s: Failed to post recv WQEs on QP index %d on device %d (comm=%p, devIndex=%d, qp_num=%u)", __func__, qpIndex, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex, localQp->qp->qp_num);
+        INFO(NCCL_NET,
+             "NET/IB: %s: Failed to post recv WQEs on QP index %d on device %d (comm=%p, devIndex=%d, qp_num=%u)",
+             __func__, qpIndex, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex,
+             localQp->qp->qp_num);
         *success = false;
         return ncclSuccess;
       }
@@ -508,32 +552,42 @@ static inline ncclResult_t ncclIbPortRecoveryQpsRestore(ncclIbPortRecoveryContex
         if (i != recoveryContext->devIndex) continue;
         struct ncclIbRecvCommDev* rCommDev = &recvComm->devs[i];
         ncclIbQp* flushQp = &rCommDev->gpuFlush.qp;
-        TRACE(NCCL_NET, "NET/IB: %s: Restoring Flush QP on device %d (comm=%p)", __func__, i, recoveryContext->resCtx->baseComm);
+        TRACE(NCCL_NET, "NET/IB: %s: Restoring Flush QP on device %d (comm=%p)", __func__, i,
+              recoveryContext->resCtx->baseComm);
         res = ncclIbQpReset(flushQp);
         if (res != ncclSuccess) {
-          INFO(NCCL_NET, "NET/IB: %s: Failed to reset Flush QP on device %d (comm=%p, devIndex=%d, qp_num=%u)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex, flushQp->qp->qp_num);
+          INFO(NCCL_NET, "NET/IB: %s: Failed to reset Flush QP on device %d (comm=%p, devIndex=%d, qp_num=%u)",
+               __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex,
+               flushQp->qp->qp_num);
           *success = false;
           return ncclSuccess;
         }
         res = ncclIbQpInit(flushQp);
         if (res != ncclSuccess) {
-          INFO(NCCL_NET, "NET/IB: %s: Failed to init Flush QP on device %d (comm=%p, devIndex=%d, qp_num=%u)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex, flushQp->qp->qp_num);
+          INFO(NCCL_NET, "NET/IB: %s: Failed to init Flush QP on device %d (comm=%p, devIndex=%d, qp_num=%u)", __func__,
+               recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex,
+               flushQp->qp->qp_num);
           *success = false;
           return ncclSuccess;
         }
         res = ncclIbQpRtr(flushQp);
         if (res != ncclSuccess) {
-          INFO(NCCL_NET, "NET/IB: %s: Failed to modify to RTR Flush QP on device %d (comm=%p, devIndex=%d, qp_num=%u)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex, flushQp->qp->qp_num);
+          INFO(NCCL_NET, "NET/IB: %s: Failed to modify to RTR Flush QP on device %d (comm=%p, devIndex=%d, qp_num=%u)",
+               __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex,
+               flushQp->qp->qp_num);
           *success = false;
           return ncclSuccess;
         }
         res = ncclIbQpRts(flushQp);
         if (res != ncclSuccess) {
-          INFO(NCCL_NET, "NET/IB: %s: Failed to modify to RTS Flush QP on device %d (comm=%p, devIndex=%d, qp_num=%u)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex, flushQp->qp->qp_num);
+          INFO(NCCL_NET, "NET/IB: %s: Failed to modify to RTS Flush QP on device %d (comm=%p, devIndex=%d, qp_num=%u)",
+               __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex,
+               flushQp->qp->qp_num);
           *success = false;
           return ncclSuccess;
         }
-        INFO(NCCL_NET, "NET/IB: %s: Restored Flush QP on device %d (comm=%p)", __func__, i, recoveryContext->resCtx->baseComm);
+        INFO(NCCL_NET, "NET/IB: %s: Restored Flush QP on device %d (comm=%p)", __func__, i,
+             recoveryContext->resCtx->baseComm);
       }
     }
   }
@@ -543,17 +597,25 @@ static inline ncclResult_t ncclIbPortRecoveryQpsRestore(ncclIbPortRecoveryContex
 
 #define NCCL_IB_RESILIENCY_PORT_RECOVERY_ACK_MSG_ID (0x1234)
 
-static inline ncclResult_t ncclIbPortRecoveryHandleCompletionReceiver(struct ncclIbPortRecoveryContext* recoveryContext, struct ibv_wc completion, bool* success) {
+static inline ncclResult_t ncclIbPortRecoveryHandleCompletionReceiver(struct ncclIbPortRecoveryContext* recoveryContext,
+                                                                      struct ibv_wc completion, bool* success) {
   ncclResult_t res = ncclSuccess;
-  INFO(NCCL_NET, "NET/IB: %s: Receiver received completion for device %d (comm=%p, wr_id=%lu, opcode=%s, imm_data=%u)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, completion.wr_id, ibvWcOpcodeStr(completion.opcode), completion.imm_data);
+  INFO(NCCL_NET, "NET/IB: %s: Receiver received completion for device %d (comm=%p, wr_id=%lu, opcode=%s, imm_data=%u)",
+       __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, completion.wr_id,
+       ibvWcOpcodeStr(completion.opcode), completion.imm_data);
   if (recoveryContext->state == ncclIbPortRecoveryStateAliveMessages) {
     if (recoveryContext->ackPosted) {
       // Receiver waits for it's own local ACK completion
       if (completion.opcode == IBV_WC_RECV) {
-        INFO(NCCL_NET, "NET/IB: %s: Receiver expected local completion of ACK message for device %d (comm=%p) but got completion with opcode: %s", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, ibvWcOpcodeStr(completion.opcode));
-        res = ncclIbPortRecoveryPostRecvWorkRequest(recoveryContext->resCtx->portRecoveryQps[recoveryContext->devIndex].qp);
+        INFO(NCCL_NET,
+             "NET/IB: %s: Receiver expected local completion of ACK message for device %d (comm=%p) but got completion "
+             "with opcode: %s",
+             __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, ibvWcOpcodeStr(completion.opcode));
+        res =
+          ncclIbPortRecoveryPostRecvWorkRequest(recoveryContext->resCtx->portRecoveryQps[recoveryContext->devIndex].qp);
         if (res != ncclSuccess) {
-          INFO(NCCL_NET, "NET/IB: %s: Receiver failed to post recv WR on data QP for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+          INFO(NCCL_NET, "NET/IB: %s: Receiver failed to post recv WR on data QP for device %d (comm=%p)", __func__,
+               recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
           *success = false;
           return ncclSuccess;
         }
@@ -565,24 +627,33 @@ static inline ncclResult_t ncclIbPortRecoveryHandleCompletionReceiver(struct ncc
       }
       assert(completion.opcode == IBV_WC_SEND);
       recoveryContext->ackCompleted = true;
-      INFO(NCCL_NET, "NET/IB: %s: Receiver's ACK message completed locally for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Receiver's ACK message completed locally for device %d (comm=%p)", __func__,
+           recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
     } else {
       assert(completion.opcode == IBV_WC_RECV);
       if (completion.imm_data == recoveryContext->aliveMsgNextId) {
         // In-order alive message
         recoveryContext->recv.nInOrderMsgsReceived++;
         recoveryContext->aliveMsgNextId++;
-        INFO(NCCL_NET, "NET/IB: %s: Receiver received in-order alive message %u for device %d (nInOrderMsgsReceived=%d, comm=%p)", __func__, completion.imm_data, recoveryContext->devIndex, recoveryContext->recv.nInOrderMsgsReceived, recoveryContext->resCtx->baseComm);
+        INFO(NCCL_NET,
+             "NET/IB: %s: Receiver received in-order alive message %u for device %d (nInOrderMsgsReceived=%d, comm=%p)",
+             __func__, completion.imm_data, recoveryContext->devIndex, recoveryContext->recv.nInOrderMsgsReceived,
+             recoveryContext->resCtx->baseComm);
       } else {
         // Out-of-order alive message
-        INFO(NCCL_NET, "NET/IB: %s: Receiver received out-of-order alive message %u (expected %u) for device %d (comm=%p)", __func__, completion.imm_data, recoveryContext->aliveMsgNextId, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+        INFO(NCCL_NET,
+             "NET/IB: %s: Receiver received out-of-order alive message %u (expected %u) for device %d (comm=%p)",
+             __func__, completion.imm_data, recoveryContext->aliveMsgNextId, recoveryContext->devIndex,
+             recoveryContext->resCtx->baseComm);
         recoveryContext->aliveMsgNextId = completion.imm_data + 1;
         recoveryContext->recv.nInOrderMsgsReceived = 0;
       }
       recoveryContext->timeLastMsg = clockNano();
-      res = ncclIbPortRecoveryPostRecvWorkRequest(recoveryContext->resCtx->portRecoveryQps[recoveryContext->devIndex].qp);
+      res =
+        ncclIbPortRecoveryPostRecvWorkRequest(recoveryContext->resCtx->portRecoveryQps[recoveryContext->devIndex].qp);
       if (res != ncclSuccess) {
-          INFO(NCCL_NET, "NET/IB: %s: Receiver failed to post recv WR on recovery QP for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+        INFO(NCCL_NET, "NET/IB: %s: Receiver failed to post recv WR on recovery QP for device %d (comm=%p)", __func__,
+             recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
         *success = false;
         return ncclSuccess;
       }
@@ -591,22 +662,28 @@ static inline ncclResult_t ncclIbPortRecoveryHandleCompletionReceiver(struct ncc
   if (recoveryContext->state == ncclIbPortRecoveryStateAck) {
     assert(completion.opcode == IBV_WC_RECV);
     assert(completion.imm_data == NCCL_IB_RESILIENCY_PORT_RECOVERY_ACK_MSG_ID);
-    INFO(NCCL_NET, "NET/IB: %s: Receiver received final ACK message for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+    INFO(NCCL_NET, "NET/IB: %s: Receiver received final ACK message for device %d (comm=%p)", __func__,
+         recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
     recoveryContext->ackReceived = true;
   }
   *success = true;
   return ncclSuccess;
 }
 
-static inline ncclResult_t ncclIbPortRecoveryHandleCompletionSender(struct ncclIbPortRecoveryContext* recoveryContext, struct ibv_wc completion, bool* success) {
-  INFO(NCCL_NET, "NET/IB: %s: Sender received completion for device %d (comm=%p, wr_id=%lu, opcode=%s, imm_data=%u)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, completion.wr_id, ibvWcOpcodeStr(completion.opcode), completion.imm_data);
+static inline ncclResult_t ncclIbPortRecoveryHandleCompletionSender(struct ncclIbPortRecoveryContext* recoveryContext,
+                                                                    struct ibv_wc completion, bool* success) {
+  INFO(NCCL_NET, "NET/IB: %s: Sender received completion for device %d (comm=%p, wr_id=%lu, opcode=%s, imm_data=%u)",
+       __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, completion.wr_id,
+       ibvWcOpcodeStr(completion.opcode), completion.imm_data);
   if (recoveryContext->state == ncclIbPortRecoveryStateAliveMessages) {
     if (completion.opcode == IBV_WC_SEND) {
       assert(!recoveryContext->send.aliveMsgCompleted);
-      INFO(NCCL_NET, "NET/IB: %s: Sender's alive messages batch completed locally for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Sender's alive messages batch completed locally for device %d (comm=%p)", __func__,
+           recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
       recoveryContext->send.aliveMsgCompleted = true;
     } else {
-      INFO(NCCL_NET, "NET/IB: %s: Sender received unexpected message completion for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Sender received unexpected message completion for device %d (comm=%p)", __func__,
+           recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
       *success = false;
       return ncclSuccess;
     }
@@ -616,14 +693,16 @@ static inline ncclResult_t ncclIbPortRecoveryHandleCompletionSender(struct ncclI
       // Sender waits for ACK from receiver
       assert(completion.opcode == IBV_WC_RECV);
       assert(completion.imm_data == NCCL_IB_RESILIENCY_PORT_RECOVERY_ACK_MSG_ID);
-      INFO(NCCL_NET, "NET/IB: %s: Sender received an ACK message from the receiver for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Sender received an ACK message from the receiver for device %d (comm=%p)", __func__,
+           recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
       recoveryContext->ackReceived = true;
       *success = true;
       return ncclSuccess;
     } else {
       // Sender waits for it's own local final ACK completion
       assert(completion.opcode == IBV_WC_SEND);
-      INFO(NCCL_NET, "NET/IB: %s: Sender's final ACK message completed locally for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Sender's final ACK message completed locally for device %d (comm=%p)", __func__,
+           recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
       recoveryContext->ackCompleted = true;
       *success = true;
       return ncclSuccess;
@@ -639,7 +718,8 @@ static inline ncclResult_t ncclIbPortRecoveryPollCq(struct ncclIbPortRecoveryCon
 
   ncclResult_t ret = wrap_ibv_poll_cq(recoveryContext->recoveryCq, 1, &completion, &completions);
   if (ret != ncclSuccess) {
-    INFO(NCCL_NET, "NET/IB: %s: Failed to poll recovery CQ %p for device %d (comm=%p)", __func__, recoveryContext->recoveryCq, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+    INFO(NCCL_NET, "NET/IB: %s: Failed to poll recovery CQ %p for device %d (comm=%p)", __func__,
+         recoveryContext->recoveryCq, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
     *success = false;
     return ncclSuccess;
   }
@@ -651,7 +731,8 @@ static inline ncclResult_t ncclIbPortRecoveryPollCq(struct ncclIbPortRecoveryCon
 
   if (completion.status != IBV_WC_SUCCESS) {
     *success = false;
-    INFO(NCCL_NET, "NET/IB: %s: Work completion error on recovery CQ %p: status=%s(%d)", __func__, recoveryContext->recoveryCq, ibvWcStatusStr(completion.status), completion.status);
+    INFO(NCCL_NET, "NET/IB: %s: Work completion error on recovery CQ %p: status=%s(%d)", __func__,
+         recoveryContext->recoveryCq, ibvWcStatusStr(completion.status), completion.status);
     return ncclSuccess;
   }
 
@@ -661,7 +742,9 @@ static inline ncclResult_t ncclIbPortRecoveryPollCq(struct ncclIbPortRecoveryCon
     NCCLCHECK(ncclIbPortRecoveryHandleCompletionReceiver(recoveryContext, completion, success));
   }
   if (!*success) {
-    INFO(NCCL_NET, "NET/IB: %s: Failed to handle %s completion for device %d (comm=%p, wc.opcode=%s(%d), wc.wr_id=%ld)", __func__, recoveryContext->resCtx->baseComm->isSend ? "sender" : "receiver", recoveryContext->devIndex, recoveryContext->resCtx->baseComm, ibvWcOpcodeStr(completion.opcode), completion.opcode, completion.wr_id);
+    INFO(NCCL_NET, "NET/IB: %s: Failed to handle %s completion for device %d (comm=%p, wc.opcode=%s(%d), wc.wr_id=%ld)",
+         __func__, recoveryContext->resCtx->baseComm->isSend ? "sender" : "receiver", recoveryContext->devIndex,
+         recoveryContext->resCtx->baseComm, ibvWcOpcodeStr(completion.opcode), completion.opcode, completion.wr_id);
   }
   return ncclSuccess;
 }
@@ -673,12 +756,14 @@ enum ncclIbPortRecoveryStateProgressResult {
   ncclIbPortRecoveryStateProgressResultFailed
 };
 
-static inline ncclResult_t ncclIbPortRecoveryPostAliveMessages(struct ncclIbPortRecoveryContext* recoveryContext, bool* success) {
-  struct ibv_send_wr *bad_wr = NULL;
+static inline ncclResult_t ncclIbPortRecoveryPostAliveMessages(struct ncclIbPortRecoveryContext* recoveryContext,
+                                                               bool* success) {
+  struct ibv_send_wr* bad_wr = NULL;
   struct ibv_send_wr wr[NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX];
   int nMsgsToPost = ncclParamIbResiliencyPortRecoveryAliveMsgSequenceSize();
   if (nMsgsToPost > NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX) {
-    WARN("NET/IB: %s: Requested alive message batch size %d exceeds maximum supported %d", __func__, nMsgsToPost, NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX);
+    WARN("NET/IB: %s: Requested alive message batch size %d exceeds maximum supported %d", __func__, nMsgsToPost,
+         NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX);
     return ncclInternalError;
   }
   for (int i = 0; i < nMsgsToPost; i++) {
@@ -694,14 +779,16 @@ static inline ncclResult_t ncclIbPortRecoveryPostAliveMessages(struct ncclIbPort
     } else {
       wr[i].next = NULL;
     }
-    INFO(NCCL_NET, "NET/IB: %s: Sender prepared alive message %u for device %d (comm=%p)", __func__, recoveryContext->aliveMsgNextId, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+    INFO(NCCL_NET, "NET/IB: %s: Sender prepared alive message %u for device %d (comm=%p)", __func__,
+         recoveryContext->aliveMsgNextId, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
     recoveryContext->aliveMsgNextId++;
   }
 
   // Post the send operation on the recovery QP.
   struct ncclIbQp* recoveryQp = &recoveryContext->resCtx->portRecoveryQps[recoveryContext->devIndex];
   if (ibv_post_send(recoveryQp->qp, &wr[0], &bad_wr)) {
-    INFO(NCCL_NET, "NET/IB: %s: Sender failed to post alive messages batch on device %d (comm=%p, qp_num=%u)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryQp->qp->qp_num);
+    INFO(NCCL_NET, "NET/IB: %s: Sender failed to post alive messages batch on device %d (comm=%p, qp_num=%u)", __func__,
+         recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryQp->qp->qp_num);
     *success = false;
     return ncclSuccess;
   }
@@ -713,7 +800,7 @@ static inline ncclResult_t ncclIbPortRecoveryPostAliveMessages(struct ncclIbPort
 }
 
 static inline ncclResult_t ncclIbPortRecoveryPostAck(ncclIbPortRecoveryContext* recoveryContext, bool* success) {
-  struct ibv_send_wr *bad_wr = NULL;
+  struct ibv_send_wr* bad_wr = NULL;
   struct ibv_send_wr wr;
   memset(&wr, 0, sizeof(wr));
   wr.wr_id = recoveryContext->aliveMsgNextId;
@@ -723,12 +810,15 @@ static inline ncclResult_t ncclIbPortRecoveryPostAck(ncclIbPortRecoveryContext* 
   wr.sg_list = NULL;
   wr.num_sge = 0;
 
-  INFO(NCCL_NET, "NET/IB: %s: %s posting ACK message for device %d (comm=%p)", __func__, recoveryContext->resCtx->baseComm->isSend ? "Sender" : "Receiver", recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+  INFO(NCCL_NET, "NET/IB: %s: %s posting ACK message for device %d (comm=%p)", __func__,
+       recoveryContext->resCtx->baseComm->isSend ? "Sender" : "Receiver", recoveryContext->devIndex,
+       recoveryContext->resCtx->baseComm);
 
   // Post the send operation on the recovery QP.
   struct ncclIbQp* recoveryQp = &recoveryContext->resCtx->portRecoveryQps[recoveryContext->devIndex];
   if (ibv_post_send(recoveryQp->qp, &wr, &bad_wr)) {
-    INFO(NCCL_NET, "NET/IB: %s: Failed to post ack message on device %d (comm=%p, qp_num=%u)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryQp->qp->qp_num);
+    INFO(NCCL_NET, "NET/IB: %s: Failed to post ack message on device %d (comm=%p, qp_num=%u)", __func__,
+         recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryQp->qp->qp_num);
     *success = false;
     return ncclSuccess;
   }
@@ -737,7 +827,8 @@ static inline ncclResult_t ncclIbPortRecoveryPostAck(ncclIbPortRecoveryContext* 
   return ncclSuccess;
 }
 
-static inline ncclResult_t ncclIbPortRecoveryProgressAliveMessagesSender(ncclIbPortRecoveryContext* recoveryContext, enum ncclIbPortRecoveryStateProgressResult* outResult) {
+static inline ncclResult_t ncclIbPortRecoveryProgressAliveMessagesSender(
+  ncclIbPortRecoveryContext* recoveryContext, enum ncclIbPortRecoveryStateProgressResult* outResult) {
   // Sender can either post new alive messages or poll for completions of previously
   // posted alive messages.
   if (!recoveryContext->send.aliveMsgPosted) {
@@ -748,11 +839,13 @@ static inline ncclResult_t ncclIbPortRecoveryProgressAliveMessagesSender(ncclIbP
       return ncclSuccess;
     }
     // Post a new batch of alive messages
-    INFO(NCCL_NET, "NET/IB: %s: Posting alive message batch for device %d (comm=%p, devIndex=%d)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex);
+    INFO(NCCL_NET, "NET/IB: %s: Posting alive message batch for device %d (comm=%p, devIndex=%d)", __func__,
+         recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex);
     bool success = false;
     NCCLCHECK(ncclIbPortRecoveryPostAliveMessages(recoveryContext, &success));
     if (!success) {
-      INFO(NCCL_NET, "NET/IB: %s: Failed to post alive messages batch for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Failed to post alive messages batch for device %d (comm=%p)", __func__,
+           recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
       *outResult = ncclIbPortRecoveryStateProgressResultFailed;
       return ncclSuccess;
     }
@@ -762,12 +855,14 @@ static inline ncclResult_t ncclIbPortRecoveryProgressAliveMessagesSender(ncclIbP
     bool success = false;
     NCCLCHECK(ncclIbPortRecoveryPollCq(recoveryContext, &success));
     if (!success) {
-      INFO(NCCL_NET, "NET/IB: %s: Failed to poll CQ for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Failed to poll CQ for device %d (comm=%p)", __func__, recoveryContext->devIndex,
+           recoveryContext->resCtx->baseComm);
       *outResult = ncclIbPortRecoveryStateProgressResultFailed;
       return ncclSuccess;
     }
     if (recoveryContext->send.aliveMsgCompleted) {
-      INFO(NCCL_NET, "NET/IB: %s: Sender marked that alive messages batch completed for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Sender marked that alive messages batch completed for device %d (comm=%p)", __func__,
+           recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
       *outResult = ncclIbPortRecoveryStateProgressResultGoToNextState;
     } else {
       *outResult = ncclIbPortRecoveryStateProgressResultInProgress;
@@ -776,13 +871,15 @@ static inline ncclResult_t ncclIbPortRecoveryProgressAliveMessagesSender(ncclIbP
   return ncclSuccess;
 }
 
-static inline ncclResult_t ncclIbPortRecoveryProgressAliveMessagesReceiver(ncclIbPortRecoveryContext* recoveryContext, enum ncclIbPortRecoveryStateProgressResult* outResult) {
+static inline ncclResult_t ncclIbPortRecoveryProgressAliveMessagesReceiver(
+  ncclIbPortRecoveryContext* recoveryContext, enum ncclIbPortRecoveryStateProgressResult* outResult) {
   bool success = false;
   ncclResult_t res = ncclSuccess;
   if (recoveryContext->ackPosted == false) {
     NCCLCHECK(ncclIbPortRecoveryPollCq(recoveryContext, &success));
     if (!success) {
-      INFO(NCCL_NET, "NET/IB: %s: Failed to poll CQ for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Failed to poll CQ for device %d (comm=%p)", __func__, recoveryContext->devIndex,
+           recoveryContext->resCtx->baseComm);
       *outResult = ncclIbPortRecoveryStateProgressResultFailed;
       return ncclSuccess;
     }
@@ -793,20 +890,26 @@ static inline ncclResult_t ncclIbPortRecoveryProgressAliveMessagesReceiver(ncclI
       // previous state, it will not see stale alive messages.
       NCCLCHECK(ncclIbPortRecoveryDrainCqAndPostReceiveWRs(recoveryContext, &success));
       if (!success) {
-        INFO(NCCL_NET, "NET/IB: %s: Failed to drain CQ and post recv WRs for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+        INFO(NCCL_NET, "NET/IB: %s: Failed to drain CQ and post recv WRs for device %d (comm=%p)", __func__,
+             recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
         *outResult = ncclIbPortRecoveryStateProgressResultFailed;
         return ncclSuccess;
       }
-      INFO(NCCL_NET, "NET/IB: %s: Receiver received enough in-order alive messages for device %d (comm=%p). Restoring QPs and posting ACK message.", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET,
+           "NET/IB: %s: Receiver received enough in-order alive messages for device %d (comm=%p). Restoring QPs and "
+           "posting ACK message.",
+           __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
       NCCLCHECK(ncclIbPortRecoveryQpsRestore(recoveryContext, &success));
       if (!success) {
-        INFO(NCCL_NET, "NET/IB: %s: Receiver failed to restore QPs on device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+        INFO(NCCL_NET, "NET/IB: %s: Receiver failed to restore QPs on device %d (comm=%p)", __func__,
+             recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
         *outResult = ncclIbPortRecoveryStateProgressResultFailed;
         return ncclSuccess;
       }
       NCCLCHECK(ncclIbPortRecoveryPostAck(recoveryContext, &success));
       if (!success) {
-        INFO(NCCL_NET, "NET/IB: %s: Failed to post ACK message for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+        INFO(NCCL_NET, "NET/IB: %s: Failed to post ACK message for device %d (comm=%p)", __func__,
+             recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
         *outResult = ncclIbPortRecoveryStateProgressResultFailed;
         return ncclSuccess;
       }
@@ -815,9 +918,13 @@ static inline ncclResult_t ncclIbPortRecoveryProgressAliveMessagesReceiver(ncclI
       uint64_t now = clockNano();
       if (now - recoveryContext->timeLastMsg > ncclParamIbResiliencyPortRecoveryAliveMsgTimeout() * MSEC_TO_NSEC) {
         recoveryContext->nFailedAttempts++;
-        INFO(NCCL_NET, "NET/IB: %s: Alive message sequence timeout for device %d (%s comm=%p, failedAttempts=%d)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm, recoveryContext->nFailedAttempts);
+        INFO(NCCL_NET, "NET/IB: %s: Alive message sequence timeout for device %d (%s comm=%p, failedAttempts=%d)",
+             __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv",
+             recoveryContext->resCtx->baseComm, recoveryContext->nFailedAttempts);
         if (recoveryContext->nFailedAttempts >= ncclParamIbResiliencyPortRecoveryAttemptsMax()) {
-          INFO(NCCL_NET, "NET/IB: %s: Recovery for device %d failed due to max attempts reached (%s comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
+          INFO(NCCL_NET, "NET/IB: %s: Recovery for device %d failed due to max attempts reached (%s comm=%p)", __func__,
+               recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv",
+               recoveryContext->resCtx->baseComm);
           *outResult = ncclIbPortRecoveryStateProgressResultFailed;
           return ncclSuccess;
         }
@@ -830,7 +937,8 @@ static inline ncclResult_t ncclIbPortRecoveryProgressAliveMessagesReceiver(ncclI
     bool success = false;
     NCCLCHECK(ncclIbPortRecoveryPollCq(recoveryContext, &success));
     if (!success) {
-      INFO(NCCL_NET, "NET/IB: %s: Failed to poll CQ for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Failed to poll CQ for device %d (comm=%p)", __func__, recoveryContext->devIndex,
+           recoveryContext->resCtx->baseComm);
       *outResult = ncclIbPortRecoveryStateProgressResultFailed;
       return ncclSuccess;
     }
@@ -840,9 +948,13 @@ static inline ncclResult_t ncclIbPortRecoveryProgressAliveMessagesReceiver(ncclI
       uint64_t now = clockNano();
       if (now - recoveryContext->timeLastMsg > ncclParamIbResiliencyPortRecoveryAckTimeout() * MSEC_TO_NSEC) {
         recoveryContext->nFailedAttempts++;
-        INFO(NCCL_NET, "NET/IB: %s: ACK message timeout for device %d (%s comm=%p, failedAttempts=%d)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm, recoveryContext->nFailedAttempts);
+        INFO(NCCL_NET, "NET/IB: %s: ACK message timeout for device %d (%s comm=%p, failedAttempts=%d)", __func__,
+             recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv",
+             recoveryContext->resCtx->baseComm, recoveryContext->nFailedAttempts);
         if (recoveryContext->nFailedAttempts >= ncclParamIbResiliencyPortRecoveryAttemptsMax()) {
-          INFO(NCCL_NET, "NET/IB: %s: Recovery for device %d failed due to max attempts reached (%s comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
+          INFO(NCCL_NET, "NET/IB: %s: Recovery for device %d failed due to max attempts reached (%s comm=%p)", __func__,
+               recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv",
+               recoveryContext->resCtx->baseComm);
           *outResult = ncclIbPortRecoveryStateProgressResultFailed;
           return ncclSuccess;
         }
@@ -851,11 +963,15 @@ static inline ncclResult_t ncclIbPortRecoveryProgressAliveMessagesReceiver(ncclI
         recoveryContext->ackCompleted = false;
         recoveryContext->timeLastMsg = now;
         *outResult = ncclIbPortRecoveryStateProgressResultGoToPrevState;
-        INFO(NCCL_NET, "NET/IB: %s: Receiver posting (%d) recv WRs on device %d (comm=%p)", __func__, NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+        INFO(NCCL_NET, "NET/IB: %s: Receiver posting (%d) recv WRs on device %d (comm=%p)", __func__,
+             NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX, recoveryContext->devIndex,
+             recoveryContext->resCtx->baseComm);
         for (int i = 0; i < NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX; i++) {
-          res = ncclIbPortRecoveryPostRecvWorkRequest(recoveryContext->resCtx->portRecoveryQps[recoveryContext->devIndex].qp);
+          res = ncclIbPortRecoveryPostRecvWorkRequest(
+            recoveryContext->resCtx->portRecoveryQps[recoveryContext->devIndex].qp);
           if (res != ncclSuccess) {
-            INFO(NCCL_NET, "NET/IB: %s: Receiver failed to post recv WR on recovery QP for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+            INFO(NCCL_NET, "NET/IB: %s: Receiver failed to post recv WR on recovery QP for device %d (comm=%p)",
+                 __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
             *outResult = ncclIbPortRecoveryStateProgressResultFailed;
             return ncclSuccess;
           }
@@ -876,30 +992,37 @@ static inline ncclResult_t ncclIbPortRecoveryProgressAliveMessages(ncclIbPortRec
     NCCLCHECK(ncclIbPortRecoveryProgressAliveMessagesReceiver(recoveryContext, &progressResult));
   }
   switch (progressResult) {
-    case ncclIbPortRecoveryStateProgressResultGoToPrevState:
-      WARN("NET/IB: %s: Unexpected GoToPrevState result in AliveMessages state for device %d (%s comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
-      return ncclInternalError;
-    case ncclIbPortRecoveryStateProgressResultGoToNextState:
-      INFO(NCCL_NET, "NET/IB: %s: Alive messages phase completed for device %d. Moving to next phase (%s comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
-      recoveryContext->state = ncclIbPortRecoveryStateAck;
-      break;
-    case ncclIbPortRecoveryStateProgressResultFailed:
-      INFO(NCCL_NET, "NET/IB: %s: Recovery for device %d failed (%s comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
-      recoveryContext->state = ncclIbPortRecoveryStateFailed;
-      break;
-    case ncclIbPortRecoveryStateProgressResultInProgress:
-      // Do nothing
-      break;
+  case ncclIbPortRecoveryStateProgressResultGoToPrevState:
+    WARN("NET/IB: %s: Unexpected GoToPrevState result in AliveMessages state for device %d (%s comm=%p)", __func__,
+         recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv",
+         recoveryContext->resCtx->baseComm);
+    return ncclInternalError;
+  case ncclIbPortRecoveryStateProgressResultGoToNextState:
+    INFO(NCCL_NET, "NET/IB: %s: Alive messages phase completed for device %d. Moving to next phase (%s comm=%p)",
+         __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv",
+         recoveryContext->resCtx->baseComm);
+    recoveryContext->state = ncclIbPortRecoveryStateAck;
+    break;
+  case ncclIbPortRecoveryStateProgressResultFailed:
+    INFO(NCCL_NET, "NET/IB: %s: Recovery for device %d failed (%s comm=%p)", __func__, recoveryContext->devIndex,
+         recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
+    recoveryContext->state = ncclIbPortRecoveryStateFailed;
+    break;
+  case ncclIbPortRecoveryStateProgressResultInProgress:
+    // Do nothing
+    break;
   }
   return ncclSuccess;
 }
 
-static inline ncclResult_t ncclIbPortRecoveryProgressAckSender(ncclIbPortRecoveryContext* recoveryContext, enum ncclIbPortRecoveryStateProgressResult* outResult) {
+static inline ncclResult_t ncclIbPortRecoveryProgressAckSender(ncclIbPortRecoveryContext* recoveryContext,
+                                                               enum ncclIbPortRecoveryStateProgressResult* outResult) {
   bool success = false;
   if (!recoveryContext->ackReceived) {
     NCCLCHECK(ncclIbPortRecoveryPollCq(recoveryContext, &success));
     if (!success) {
-      INFO(NCCL_NET, "NET/IB: %s: Failed to poll CQ for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Failed to poll CQ for device %d (comm=%p)", __func__, recoveryContext->devIndex,
+           recoveryContext->resCtx->baseComm);
       *outResult = ncclIbPortRecoveryStateProgressResultFailed;
       return ncclSuccess;
     }
@@ -908,9 +1031,11 @@ static inline ncclResult_t ncclIbPortRecoveryProgressAckSender(ncclIbPortRecover
       uint64_t now = clockNano();
       if (now - recoveryContext->timeLastMsg > ncclParamIbResiliencyPortRecoveryAckTimeout() * MSEC_TO_NSEC) {
         recoveryContext->nFailedAttempts++;
-        INFO(NCCL_NET, "NET/IB: %s: Port recovery attempt #%d failed for devIndex=%d (comm=%p)", __func__, recoveryContext->nFailedAttempts, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+        INFO(NCCL_NET, "NET/IB: %s: Port recovery attempt #%d failed for devIndex=%d (comm=%p)", __func__,
+             recoveryContext->nFailedAttempts, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
         if (recoveryContext->nFailedAttempts >= ncclParamIbResiliencyPortRecoveryAttemptsMax()) {
-          INFO(NCCL_NET, "NET/IB: %s: Recovery for device %d failed due to max attempts reached (send comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+          INFO(NCCL_NET, "NET/IB: %s: Recovery for device %d failed due to max attempts reached (send comm=%p)",
+               __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
           *outResult = ncclIbPortRecoveryStateProgressResultFailed;
           return ncclSuccess;
         }
@@ -928,13 +1053,15 @@ static inline ncclResult_t ncclIbPortRecoveryProgressAckSender(ncclIbPortRecover
   if (recoveryContext->ackPosted == false) {
     NCCLCHECK(ncclIbPortRecoveryQpsRestore(recoveryContext, &success));
     if (!success) {
-      INFO(NCCL_NET, "NET/IB: %s: Sender failed to restore QPs on device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Sender failed to restore QPs on device %d (comm=%p)", __func__,
+           recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
       *outResult = ncclIbPortRecoveryStateProgressResultFailed;
       return ncclSuccess;
     }
     NCCLCHECK(ncclIbPortRecoveryPostAck(recoveryContext, &success));
     if (!success) {
-      INFO(NCCL_NET, "NET/IB: %s: Failed to post ack for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Failed to post ack for device %d (comm=%p)", __func__, recoveryContext->devIndex,
+           recoveryContext->resCtx->baseComm);
       *outResult = ncclIbPortRecoveryStateProgressResultFailed;
       return ncclSuccess;
     }
@@ -944,7 +1071,8 @@ static inline ncclResult_t ncclIbPortRecoveryProgressAckSender(ncclIbPortRecover
   if (!recoveryContext->ackCompleted) {
     NCCLCHECK(ncclIbPortRecoveryPollCq(recoveryContext, &success));
     if (!success) {
-      INFO(NCCL_NET, "NET/IB: %s: Failed to poll CQ for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Failed to poll CQ for device %d (comm=%p)", __func__, recoveryContext->devIndex,
+           recoveryContext->resCtx->baseComm);
       *outResult = ncclIbPortRecoveryStateProgressResultFailed;
       return ncclSuccess;
     }
@@ -957,11 +1085,13 @@ static inline ncclResult_t ncclIbPortRecoveryProgressAckSender(ncclIbPortRecover
   return ncclSuccess;
 }
 
-static inline ncclResult_t ncclIbPortRecoveryProgressAckReceiver(ncclIbPortRecoveryContext* recoveryContext, enum ncclIbPortRecoveryStateProgressResult* outResult) {
+static inline ncclResult_t ncclIbPortRecoveryProgressAckReceiver(
+  ncclIbPortRecoveryContext* recoveryContext, enum ncclIbPortRecoveryStateProgressResult* outResult) {
   bool success = false;
   NCCLCHECK(ncclIbPortRecoveryPollCq(recoveryContext, &success));
   if (!success) {
-    INFO(NCCL_NET, "NET/IB: %s: Failed to poll CQ for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+    INFO(NCCL_NET, "NET/IB: %s: Failed to poll CQ for device %d (comm=%p)", __func__, recoveryContext->devIndex,
+         recoveryContext->resCtx->baseComm);
     *outResult = ncclIbPortRecoveryStateProgressResultFailed;
     return ncclSuccess;
   }
@@ -970,7 +1100,8 @@ static inline ncclResult_t ncclIbPortRecoveryProgressAckReceiver(ncclIbPortRecov
     uint64_t now = clockNano();
     if (now - recoveryContext->timeLastMsg > ncclParamIbResiliencyPortRecoveryAckTimeout() * MSEC_TO_NSEC) {
       recoveryContext->nFailedAttempts++;
-      INFO(NCCL_NET, "NET/IB: %s: Port recovery attempt #%d failed for devIndex=%d (comm=%p)", __func__, recoveryContext->nFailedAttempts, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Port recovery attempt #%d failed for devIndex=%d (comm=%p)", __func__,
+           recoveryContext->nFailedAttempts, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
       if (recoveryContext->nFailedAttempts >= ncclParamIbResiliencyPortRecoveryAttemptsMax()) {
         *outResult = ncclIbPortRecoveryStateProgressResultFailed;
         return ncclSuccess;
@@ -982,7 +1113,8 @@ static inline ncclResult_t ncclIbPortRecoveryProgressAckReceiver(ncclIbPortRecov
       recoveryContext->recv.nInOrderMsgsReceived = 0;
       NCCLCHECK(ncclIbPortRecoveryDrainCqAndPostReceiveWRs(recoveryContext, &success));
       if (!success) {
-        INFO(NCCL_NET, "NET/IB: %s: Failed to drain CQ and post recv WRs for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+        INFO(NCCL_NET, "NET/IB: %s: Failed to drain CQ and post recv WRs for device %d (comm=%p)", __func__,
+             recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
         *outResult = ncclIbPortRecoveryStateProgressResultFailed;
         return ncclSuccess;
       }
@@ -1003,26 +1135,31 @@ static inline ncclResult_t ncclIbPortRecoveryProgressAck(ncclIbPortRecoveryConte
     NCCLCHECK(ncclIbPortRecoveryProgressAckReceiver(recoveryContext, &progressResult));
   }
   switch (progressResult) {
-    case ncclIbPortRecoveryStateProgressResultGoToPrevState:
-      INFO(NCCL_NET, "NET/IB: %s: Restarting alive messages phase for device %d (%s comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
-      recoveryContext->state = ncclIbPortRecoveryStateAliveMessages;
-      break;
-    case ncclIbPortRecoveryStateProgressResultGoToNextState:
-      INFO(NCCL_NET, "NET/IB: %s: ACK phase completed for device %d (%s comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
-      recoveryContext->state = ncclIbPortRecoveryStateSuccess;
-      break;
-    case ncclIbPortRecoveryStateProgressResultFailed:
-      INFO(NCCL_NET, "NET/IB: %s: Recovery for device %d failed (%s comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
-      recoveryContext->state = ncclIbPortRecoveryStateFailed;
-      break;
-    case ncclIbPortRecoveryStateProgressResultInProgress:
-      // Do nothing
-      break;
+  case ncclIbPortRecoveryStateProgressResultGoToPrevState:
+    INFO(NCCL_NET, "NET/IB: %s: Restarting alive messages phase for device %d (%s comm=%p)", __func__,
+         recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv",
+         recoveryContext->resCtx->baseComm);
+    recoveryContext->state = ncclIbPortRecoveryStateAliveMessages;
+    break;
+  case ncclIbPortRecoveryStateProgressResultGoToNextState:
+    INFO(NCCL_NET, "NET/IB: %s: ACK phase completed for device %d (%s comm=%p)", __func__, recoveryContext->devIndex,
+         recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
+    recoveryContext->state = ncclIbPortRecoveryStateSuccess;
+    break;
+  case ncclIbPortRecoveryStateProgressResultFailed:
+    INFO(NCCL_NET, "NET/IB: %s: Recovery for device %d failed (%s comm=%p)", __func__, recoveryContext->devIndex,
+         recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
+    recoveryContext->state = ncclIbPortRecoveryStateFailed;
+    break;
+  case ncclIbPortRecoveryStateProgressResultInProgress:
+    // Do nothing
+    break;
   }
   return ncclSuccess;
 }
 
-static inline ncclResult_t ncclIbPortRecoveryContextProgress(ncclIbPortRecoveryContext* recoveryContext, bool* outDone) {
+static inline ncclResult_t ncclIbPortRecoveryContextProgress(ncclIbPortRecoveryContext* recoveryContext,
+                                                             bool* outDone) {
   assert(recoveryContext);
   assert(outDone);
 
@@ -1032,9 +1169,11 @@ static inline ncclResult_t ncclIbPortRecoveryContextProgress(ncclIbPortRecoveryC
       *outDone = false;
       return ncclSuccess;
     }
-    INFO(NCCL_NET, "NET/IB: %s: Starting port recovery for %s comm=%p devIndex=%d", __func__, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm, recoveryContext->devIndex);
+    INFO(NCCL_NET, "NET/IB: %s: Starting port recovery for %s comm=%p devIndex=%d", __func__,
+         recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm,
+         recoveryContext->devIndex);
     if (recoveryContext->resCtx->baseComm->isSend) {
-      recoveryContext-> timeLastMsg = 0;
+      recoveryContext->timeLastMsg = 0;
     }
     recoveryContext->state = ncclIbPortRecoveryStateAliveMessages;
   }
@@ -1048,21 +1187,27 @@ static inline ncclResult_t ncclIbPortRecoveryContextProgress(ncclIbPortRecoveryC
   }
 
   if (recoveryContext->state == ncclIbPortRecoveryStateSuccess) {
-    INFO(NCCL_NET, "NET/IB: %s: Port recovery succeeded for devIndex=%d (%s comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
+    INFO(NCCL_NET, "NET/IB: %s: Port recovery succeeded for devIndex=%d (%s comm=%p)", __func__,
+         recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv",
+         recoveryContext->resCtx->baseComm);
     for (int i = 0; i < recoveryContext->resCtx->ndevs; i++) {
-        if (i != recoveryContext->devIndex) continue;
-        INFO(NCCL_NET, "NET/IB: %s: Marking device %d as recovered (%s comm=%p)", __func__, i, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
-        recoveryContext->resCtx->devs[i].state.store(ncclIbResiliencyDevStateRecovered, std::memory_order_release);
-        break;
-      }
+      if (i != recoveryContext->devIndex) continue;
+      INFO(NCCL_NET, "NET/IB: %s: Marking device %d as recovered (%s comm=%p)", __func__, i,
+           recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
+      recoveryContext->resCtx->devs[i].state.store(ncclIbResiliencyDevStateRecovered, std::memory_order_release);
+      break;
+    }
     *outDone = true;
   }
 
   if (recoveryContext->state == ncclIbPortRecoveryStateFailed) {
-    INFO(NCCL_NET, "NET/IB: %s: Port recovery failed for %s comm=%p devIndex=%d", __func__, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm, recoveryContext->devIndex);
+    INFO(NCCL_NET, "NET/IB: %s: Port recovery failed for %s comm=%p devIndex=%d", __func__,
+         recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm,
+         recoveryContext->devIndex);
     for (int i = 0; i < recoveryContext->resCtx->ndevs; i++) {
       if (i != recoveryContext->devIndex) continue;
-      INFO(NCCL_NET, "NET/IB: %s: Marking device %d as permanently failed (%s comm=%p)", __func__, i, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Marking device %d as permanently failed (%s comm=%p)", __func__, i,
+           recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
       recoveryContext->resCtx->devs[i].state.store(ncclIbResiliencyDevStateRecoveryFailed, std::memory_order_release);
     }
     *outDone = true;
@@ -1074,18 +1219,17 @@ static inline ncclResult_t ncclIbPortRecoveryContextProgress(ncclIbPortRecoveryC
 // Scan recoveryQueue and remove (destroy) any contexts belonging to the
 // resiliency contexts referenced by the close requests.
 static void ncclIbPortRecoveryHandleCloseRequests(std::vector<ncclIbPortRecoveryCloseRequest*>& closeRequests,
-                                                 std::list<ncclIbPortRecoveryContext*>& recoveryQueue) {
+                                                  std::list<ncclIbPortRecoveryContext*>& recoveryQueue) {
   for (auto it = closeRequests.begin(); it != closeRequests.end(); ++it) {
     ncclIbPortRecoveryCloseRequest* closeReq = *it;
     int removedForThisReq = 0;
 
     // Iterate through the recovery queue and remove items belonging to this resCtx
-    for (auto qIt = recoveryQueue.begin(); qIt != recoveryQueue.end(); ) {
+    for (auto qIt = recoveryQueue.begin(); qIt != recoveryQueue.end();) {
       ncclIbPortRecoveryContext* recoveryContext = *qIt;
       if (recoveryContext->resCtx == closeReq->resCtx) {
         INFO(NCCL_NET, "NET/IB: %s: Removing recovery context for device %d belonging to closing resCtx (%s comm=%p)",
-             __func__, recoveryContext->devIndex,
-             recoveryContext->resCtx->baseComm->isSend ? "send" : "recv",
+             __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv",
              recoveryContext->resCtx->baseComm);
         ncclIbPortRecoveryContextDestroy(recoveryContext);
         qIt = recoveryQueue.erase(qIt);
@@ -1095,8 +1239,8 @@ static void ncclIbPortRecoveryHandleCloseRequests(std::vector<ncclIbPortRecovery
       }
     }
 
-    INFO(NCCL_NET, "NET/IB: %s: Close request completed for resCtx=%p, removed %d items",
-         __func__, closeReq->resCtx, removedForThisReq);
+    INFO(NCCL_NET, "NET/IB: %s: Close request completed for resCtx=%p, removed %d items", __func__, closeReq->resCtx,
+         removedForThisReq);
   }
 }
 
@@ -1116,9 +1260,7 @@ ncclResult_t ncclIbPortRecoveryAsyncThreadMain() {
     {
       std::unique_lock<std::mutex> lock(ncclIbPortRecoveryMutex);
       ncclIbPortRecoveryCond.wait(lock, [&] {
-        return !ncclIbPortRecoveryThreadActive.load() ||
-               !recoveryInbox.empty() ||
-               !recoveryQueue.empty() ||
+        return !ncclIbPortRecoveryThreadActive.load() || !recoveryInbox.empty() || !recoveryQueue.empty() ||
                !recoveryCloseRequests.empty();
       });
 
@@ -1148,12 +1290,14 @@ ncclResult_t ncclIbPortRecoveryAsyncThreadMain() {
     if (!ncclIbPortRecoveryThreadActive.load()) break;
 
     // Iterate and advance recovery protocol on all nodes
-    for (auto it = recoveryQueue.begin(); it != recoveryQueue.end(); ) {
+    for (auto it = recoveryQueue.begin(); it != recoveryQueue.end();) {
       bool isDone = false;
       ncclIbPortRecoveryContext* recoveryContext = *it;
       NCCLCHECK(ncclIbPortRecoveryContextProgress(recoveryContext, &isDone));
       if (isDone) {
-        INFO(NCCL_NET, "NET/IB: %s: Port recovery context done for device %d (%s comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
+        INFO(NCCL_NET, "NET/IB: %s: Port recovery context done for device %d (%s comm=%p)", __func__,
+             recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv",
+             recoveryContext->resCtx->baseComm);
         NCCLCHECK(ncclIbPortRecoveryContextDestroy(recoveryContext));
         it = recoveryQueue.erase(it);
       } else {
@@ -1181,8 +1325,8 @@ ncclResult_t ncclIbPortRecoveryAsyncThreadMain() {
 ncclResult_t ncclIbPortRecoveryInit(struct ncclIbResiliency* resCtx) {
   resCtx->recoveryEnabled = ncclIbPortRecoveryThreadActive.load();
   INFO(NCCL_NET, "NET/IB: %s: Port recovery %s (%s comm=%p)", __func__,
-       resCtx->recoveryEnabled ? "initialized" : "disabled",
-       resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
+       resCtx->recoveryEnabled ? "initialized" : "disabled", resCtx->baseComm->isSend ? "send" : "recv",
+       resCtx->baseComm);
   return ncclSuccess;
 }
 
@@ -1191,10 +1335,12 @@ ncclResult_t ncclIbPortRecoveryClose(struct ncclIbResiliency* resCtx) {
     return ncclSuccess;
   }
   if (!ncclIbPortRecoveryThreadActive.load()) {
-    INFO(NCCL_NET, "NET/IB: %s: Recovery thread already stopped, skipping close (%s comm=%p)", __func__, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
+    INFO(NCCL_NET, "NET/IB: %s: Recovery thread already stopped, skipping close (%s comm=%p)", __func__,
+         resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
     return ncclSuccess;
   }
-  INFO(NCCL_NET, "NET/IB: %s: Closing port recovery for resiliency context (%s comm=%p)", __func__, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
+  INFO(NCCL_NET, "NET/IB: %s: Closing port recovery for resiliency context (%s comm=%p)", __func__,
+       resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
 
   // Create a close request to remove any potential queue items belonging to
   // this resCtx
@@ -1213,12 +1359,11 @@ ncclResult_t ncclIbPortRecoveryClose(struct ncclIbResiliency* resCtx) {
   // Wait for the close request to be completed by the async thread
   {
     std::unique_lock<std::mutex> lock(ncclIbPortRecoveryMutex);
-    ncclIbPortRecoveryCloseCond.wait(lock, [&] {
-      return closeReq.completed;
-    });
+    ncclIbPortRecoveryCloseCond.wait(lock, [&] { return closeReq.completed; });
   }
 
-  INFO(NCCL_NET, "NET/IB: %s: Port recovery closed (%s comm=%p)", __func__, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
+  INFO(NCCL_NET, "NET/IB: %s: Port recovery closed (%s comm=%p)", __func__, resCtx->baseComm->isSend ? "send" : "recv",
+       resCtx->baseComm);
   return ncclSuccess;
 }
 
@@ -1274,7 +1419,8 @@ ncclResult_t ncclIbPortRecoveryHandleFailure(struct ncclIbResiliency* resCtx, in
 
   res = ncclIbPortRecoveryContextInit(resCtx, devIndex, &recoveryCtx);
   if (res != ncclSuccess) {
-    INFO(NCCL_NET,"NET/IB: %s: Failed to initialize recovery context for device %d (comm=%p)", __func__, devIndex, resCtx->baseComm);
+    INFO(NCCL_NET, "NET/IB: %s: Failed to initialize recovery context for device %d (comm=%p)", __func__, devIndex,
+         resCtx->baseComm);
     return res;
   }
 
@@ -1288,6 +1434,7 @@ ncclResult_t ncclIbPortRecoveryHandleFailure(struct ncclIbResiliency* resCtx, in
   // Wake up the async recovery thread
   ncclIbPortRecoveryCond.notify_one();
 
-  INFO(NCCL_NET, "NET/IB: %s: Added device %d into the recovery queue (%s comm=%p, devIndex=%d, isSend=%d)", __func__, devIndex, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm, devIndex, resCtx->baseComm->isSend);
+  INFO(NCCL_NET, "NET/IB: %s: Added device %d into the recovery queue (%s comm=%p, devIndex=%d, isSend=%d)", __func__,
+       devIndex, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm, devIndex, resCtx->baseComm->isSend);
   return ncclSuccess;
 }

--- a/projects/rccl/src/transport/net_ib/p2p_resiliency_recovery.h
+++ b/projects/rccl/src/transport/net_ib/p2p_resiliency_recovery.h
@@ -18,10 +18,14 @@ ncclResult_t ncclIbPortRecoveryClose(struct ncclIbResiliency* resCtx);
 ncclResult_t ncclIbPortRecoveryDevInit(struct ncclIbResiliency* resCtx, int devIndex, ncclIbDev* ibDev);
 ncclResult_t ncclIbPortRecoveryDevDestroy(struct ncclIbResiliency* resCtx, int devIndex);
 
-ncclResult_t ncclIbPortRecoverySenderQpsCreate(struct ncclIbResiliency* resCtx, struct ncclIbQpInfo* localResiliencyInfo, int nQps);
-ncclResult_t ncclIbPortRecoverySenderQpsToRts(struct ncclIbResiliency* resCtx, struct ncclIbConnectionMetadata* remInfo, int nQps);
+ncclResult_t ncclIbPortRecoverySenderQpsCreate(struct ncclIbResiliency* resCtx,
+                                               struct ncclIbQpInfo* localResiliencyInfo, int nQps);
+ncclResult_t ncclIbPortRecoverySenderQpsToRts(struct ncclIbResiliency* resCtx, struct ncclIbConnectionMetadata* remInfo,
+                                              int nQps);
 
-ncclResult_t ncclIbPortRecoveryReceiverQpsCreateToRts(struct ncclIbResiliency* resCtx, struct ncclIbConnectionMetadata* remInfo, struct ncclIbQpInfo* localPortRecoveryQpsInfo, int nQps);
+ncclResult_t ncclIbPortRecoveryReceiverQpsCreateToRts(struct ncclIbResiliency* resCtx,
+                                                      struct ncclIbConnectionMetadata* remInfo,
+                                                      struct ncclIbQpInfo* localPortRecoveryQpsInfo, int nQps);
 
 ncclResult_t ncclIbPortRecoveryQpsDestroy(struct ncclIbResiliency* resCtx, int nQps);
 

--- a/projects/rccl/src/transport/net_ib/reg.cc
+++ b/projects/rccl/src/transport/net_ib/reg.cc
@@ -7,43 +7,47 @@
 
 #include "common.h"
 
-ncclResult_t ncclIbRegMrDmaBufInternal(ncclIbNetCommDevBase* base, void* data, size_t size, int type, uint64_t offset, int fd, ibv_mr** mhandle) {
+ncclResult_t ncclIbRegMrDmaBufInternal(ncclIbNetCommDevBase* base, void* data, size_t size, int type, uint64_t offset,
+                                       int fd, ibv_mr** mhandle) {
   static thread_local uintptr_t pageSize = 0;
   if (pageSize == 0) pageSize = sysconf(_SC_PAGESIZE);
   struct ncclIbMrCache* cache = &ncclIbDevs[base->ibDevN].mrCache;
   uintptr_t addr = (uintptr_t)data & -pageSize;
-  size_t pages = ((uintptr_t)data + size - addr + pageSize-1)/pageSize;
+  size_t pages = ((uintptr_t)data + size - addr + pageSize - 1) / pageSize;
   std::lock_guard<std::mutex> lock(ncclIbDevs[base->ibDevN].mutex);
-  for (int slot=0; /*true*/; slot++) {
+  for (int slot = 0; /*true*/; slot++) {
     if (slot == cache->population || addr < cache->slots[slot].addr) { // didn't find in cache
       if (cache->population == cache->capacity) { // must grow cache
-        cache->capacity = cache->capacity < 32 ? 32 : 2*cache->capacity;
+        cache->capacity = cache->capacity < 32 ? 32 : 2 * cache->capacity;
         NCCLCHECK(ncclRealloc(&cache->slots, cache->population, cache->capacity));
       }
       // Deregister / register
       struct ibv_mr* mr;
       // REMOTE_ATOMIC required for GIN proxy atomic fetch-add on signal MR;
       // without it mlx5 returns WC_REM_ACCESS_ERR (vendor_err 0x88).
-      unsigned int flags = IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_REMOTE_READ|IBV_ACCESS_REMOTE_ATOMIC;
+      unsigned int flags =
+        IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_ATOMIC;
       if (ncclIbRelaxedOrderingEnabled) flags |= IBV_ACCESS_RELAXED_ORDERING;
       if (fd != -1) {
         /* DMA-BUF support */
         if (!ncclIbDevs[base->ibDevN].capsProvider.mlx5.dataDirect) {
-          NCCLCHECK(wrap_ibv_reg_dmabuf_mr(&mr, base->pd, offset, pages*pageSize, addr, fd, flags));
+          NCCLCHECK(wrap_ibv_reg_dmabuf_mr(&mr, base->pd, offset, pages * pageSize, addr, fd, flags));
         } else {
-          NCCLCHECK(wrap_mlx5dv_reg_dmabuf_mr(&mr, base->pd, offset, pages*pageSize, addr, fd, flags, MLX5DV_REG_DMABUF_ACCESS_DATA_DIRECT));
+          NCCLCHECK(wrap_mlx5dv_reg_dmabuf_mr(&mr, base->pd, offset, pages * pageSize, addr, fd, flags,
+                                              MLX5DV_REG_DMABUF_ACCESS_DATA_DIRECT));
         }
       } else {
         if (ncclIbRelaxedOrderingEnabled) {
           // Use IBVERBS_1.8 API - needed for IBV_ACCESS_RELAXED_ORDERING support
-          NCCLCHECK(wrap_ibv_reg_mr_iova2(&mr, base->pd, (void*)addr, pages*pageSize, addr, flags));
-        }
-        else {
-          NCCLCHECK(wrap_ibv_reg_mr(&mr, base->pd, (void*)addr, pages*pageSize, flags));
+          NCCLCHECK(wrap_ibv_reg_mr_iova2(&mr, base->pd, (void*)addr, pages * pageSize, addr, flags));
+        } else {
+          NCCLCHECK(wrap_ibv_reg_mr(&mr, base->pd, (void*)addr, pages * pageSize, flags));
         }
       }
-      TRACE(NCCL_INIT|NCCL_NET,"regAddr=0x%lx size=%lld rkey=0x%x lkey=0x%x fd=%d", (unsigned long)addr, (long long)pages*pageSize, mr->rkey, mr->lkey, fd);
-      if (slot != cache->population) memmove(cache->slots+slot+1, cache->slots+slot, (cache->population-slot)*sizeof(struct ncclIbMr));
+      TRACE(NCCL_INIT | NCCL_NET, "regAddr=0x%lx size=%lld rkey=0x%x lkey=0x%x fd=%d", (unsigned long)addr,
+            (long long)pages * pageSize, mr->rkey, mr->lkey, fd);
+      if (slot != cache->population)
+        memmove(cache->slots + slot + 1, cache->slots + slot, (cache->population - slot) * sizeof(struct ncclIbMr));
       cache->slots[slot].addr = addr;
       cache->slots[slot].pages = pages;
       cache->slots[slot].refs = 1;
@@ -52,7 +56,7 @@ ncclResult_t ncclIbRegMrDmaBufInternal(ncclIbNetCommDevBase* base, void* data, s
       *mhandle = mr;
       return ncclSuccess;
     } else if ((addr >= cache->slots[slot].addr) &&
-        ((addr-cache->slots[slot].addr)/pageSize+pages) <= cache->slots[slot].pages) {
+               ((addr - cache->slots[slot].addr) / pageSize + pages) <= cache->slots[slot].pages) {
       cache->slots[slot].refs += 1;
       *mhandle = cache->slots[slot].mr;
       return ncclSuccess;
@@ -65,15 +69,18 @@ ncclResult_t ncclIbRegMrDmaBufInternal(ncclIbNetCommDevBase* base, void* data, s
 ncclResult_t ncclIbRegMrDmaBuf(void* comm, void* data, size_t size, int type, uint64_t offset, int fd, void** mhandle) {
   ncclResult_t ret = ncclSuccess;
   assert(size > 0);
-  struct ncclIbNetCommBase* base = (struct ncclIbNetCommBase*) comm;
-  struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*) malloc(sizeof(struct ncclIbMrHandle));
-  if (mhandleWrapper == nullptr) { WARN("Failed to allocate IB MR handle wrapper"); return ncclSystemError; }
+  struct ncclIbNetCommBase* base = (struct ncclIbNetCommBase*)comm;
+  struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*)malloc(sizeof(struct ncclIbMrHandle));
+  if (mhandleWrapper == nullptr) {
+    WARN("Failed to allocate IB MR handle wrapper");
+    return ncclSystemError;
+  }
   for (int i = 0; i < base->vProps.ndevs; i++) {
     // Each ncclIbNetCommDevBase is at different offset in send and recv netComms
     struct ncclIbNetCommDevBase* devComm = ncclIbGetNetCommDevBase(base, i);
     NCCLCHECKGOTO(ncclIbRegMrDmaBufInternal(devComm, data, size, type, offset, fd, mhandleWrapper->mrs + i), ret, fail);
   }
-  *mhandle = (void*) mhandleWrapper;
+  *mhandle = (void*)mhandleWrapper;
 exit:
   return ret;
 fail:
@@ -88,7 +95,7 @@ ncclResult_t ncclIbRegMr(void* comm, void* data, size_t size, int type, void** m
 ncclResult_t ncclIbDeregMrInternal(ncclIbNetCommDevBase* base, ibv_mr* mhandle) {
   struct ncclIbMrCache* cache = &ncclIbDevs[base->ibDevN].mrCache;
   std::lock_guard<std::mutex> lock(ncclIbDevs[base->ibDevN].mutex);
-  for (int i=0; i < cache->population; i++) {
+  for (int i = 0; i < cache->population; i++) {
     if (mhandle == cache->slots[i].mr) {
       if (0 == --cache->slots[i].refs) {
         memmove(&cache->slots[i], &cache->slots[--cache->population], sizeof(struct ncclIbMr));
@@ -109,8 +116,8 @@ ncclResult_t ncclIbDeregMrInternal(ncclIbNetCommDevBase* base, ibv_mr* mhandle) 
 ncclResult_t ncclIbDeregMr(void* comm, void* mhandle) {
   if (mhandle == NULL) return ncclSuccess;
 
-  struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*) mhandle;
-  struct ncclIbNetCommBase* base = (struct ncclIbNetCommBase*) comm;
+  struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*)mhandle;
+  struct ncclIbNetCommBase* base = (struct ncclIbNetCommBase*)comm;
   for (int i = 0; i < base->vProps.ndevs; i++) {
     // Each ncclIbNetCommDevBase is at different offset in send and recv netComms
     struct ncclIbNetCommDevBase* devComm = ncclIbGetNetCommDevBase(base, i);

--- a/projects/rccl/src/transport/net_ib_cast/common.cc
+++ b/projects/rccl/src/transport/net_ib_cast/common.cc
@@ -8,7 +8,7 @@
 #include "common_cast.h"
 #include "p2p_resiliency_cast.h"
 
-char IbCastIfName[MAX_IF_NAME_SIZE+1];
+char IbCastIfName[MAX_IF_NAME_SIZE + 1];
 union ncclSocketAddress IbCastIfAddr;
 
 int IbCastNMergedDevs = -1;
@@ -21,11 +21,10 @@ ncclProfilerCallback_t IbCastProfilerFunction;
 
 NCCL_PARAM(IbCastSplitDataOnQps, "IB_SPLIT_DATA_ON_QPS", 0);
 NCCL_PARAM(IbCastPrepostReceiveWorkRequests, "IB_PREPOST_RECEIVE_WORK_REQUESTS", -2);
-NCCL_PARAM(IbCastAsyncEvents,"IB_RETURN_ASYNC_EVENTS",1);
+NCCL_PARAM(IbCastAsyncEvents, "IB_RETURN_ASYNC_EVENTS", 1);
 extern int ncclParamIbCastReceiverSideMatchingScheme();
 extern int ncclParamIbCastOooRq();
 extern int ncclParamIbCastResiliencyPortFailover();
-
 
 ncclResult_t IbCastStatsCheckFatalCount(struct ncclIbStats* stat, const char* funcName) {
   if (ncclParamIbCastAsyncEvents() && COMPILER_ATOMIC_LOAD(&stat->fatalErrorCount, std::memory_order_relaxed)) {
@@ -38,18 +37,18 @@ ncclResult_t IbCastStatsCheckFatalCount(struct ncclIbStats* stat, const char* fu
 
 struct ncclIbNetCommDevBase* IbCastGetNetCommDevBase(ncclIbNetCommBase* base, int devIndex) {
   if (base->isSend) {
-    struct ncclIbSendComm* sComm = (struct ncclIbSendComm*) base;
+    struct ncclIbSendComm* sComm = (struct ncclIbSendComm*)base;
     return &sComm->devs[devIndex].base;
   } else {
-    struct ncclIbRecvComm* rComm = (struct ncclIbRecvComm*) base;
+    struct ncclIbRecvComm* rComm = (struct ncclIbRecvComm*)base;
     return &rComm->devs[devIndex].base;
   }
 }
 
 ncclResult_t IbCastBaseCommInit(struct ncclIbNetCommBase* baseComm, bool isSend) {
   for (int i = 0; i < NCCL_IB_MAX_QPS; i++) {
-    baseComm->qps[i].devIndex= -1;
-    baseComm->qps[i].remDevIdx= -1;
+    baseComm->qps[i].devIndex = -1;
+    baseComm->qps[i].remDevIdx = -1;
     baseComm->activeQps[i] = &baseComm->qps[i];
     baseComm->qps[i].eceSupported = 0;
     baseComm->qps[i].ece = {0};
@@ -64,7 +63,8 @@ ncclResult_t IbCastBaseCommInit(struct ncclIbNetCommBase* baseComm, bool isSend)
   baseComm->ready = 0;
 
   NCCLCHECK(IbCastResiliencyInit(baseComm, &baseComm->resiliency));
-  baseComm->recvMatchingScheme = ncclParamIbCastReceiverSideMatchingScheme() == -2 ? BY_INDEX : ncclParamIbCastReceiverSideMatchingScheme();
+  baseComm->recvMatchingScheme =
+    ncclParamIbCastReceiverSideMatchingScheme() == -2 ? BY_INDEX : ncclParamIbCastReceiverSideMatchingScheme();
 
   if (ncclParamIbCastOooRq() || (ncclParamIbCastResiliencyPortFailover() == 1)) {
     baseComm->recvMatchingScheme = BY_ID;
@@ -78,14 +78,10 @@ ncclResult_t IbCastBaseCommInit(struct ncclIbNetCommBase* baseComm, bool isSend)
 
 ncclResult_t IbCastRecvCommInit(struct ncclIbRecvComm* recvComm) {
   NCCLCHECK(IbCastBaseCommInit(&recvComm->base, false));
-  recvComm->ibRecvWorkRequest = {
-    .wr_id = NCCL_IB_RECV_WR_ID_DUMMY,
-    .next = NULL,
-    .sg_list = NULL,
-    .num_sge = 0
-  };
+  recvComm->ibRecvWorkRequest = {.wr_id = NCCL_IB_RECV_WR_ID_DUMMY, .next = NULL, .sg_list = NULL, .num_sge = 0};
 
-  recvComm->prepostReceiveWorkRequests = (ncclParamIbCastPrepostReceiveWorkRequests() == -2) ? false : ncclParamIbCastPrepostReceiveWorkRequests();
+  recvComm->prepostReceiveWorkRequests =
+    (ncclParamIbCastPrepostReceiveWorkRequests() == -2) ? false : ncclParamIbCastPrepostReceiveWorkRequests();
 
   if (recvComm->base.resiliency) {
     if (ncclParamIbCastPrepostReceiveWorkRequests() == 0) {
@@ -100,7 +96,8 @@ ncclResult_t IbCastRecvCommInit(struct ncclIbRecvComm* recvComm) {
     recvComm->prepostReceiveWorkRequests = true;
   }
 
-  INFO(NCCL_NET, "NET/IB: %s: Receive work requests will be %s", __func__, recvComm->prepostReceiveWorkRequests ? "pre-posted" : "posted on-demand");
+  INFO(NCCL_NET, "NET/IB: %s: Receive work requests will be %s", __func__,
+       recvComm->prepostReceiveWorkRequests ? "pre-posted" : "posted on-demand");
   return ncclSuccess;
 }
 
@@ -114,12 +111,16 @@ void* IbCastAsyncThreadMain(void* args) {
   struct ncclIbDev* dev = (struct ncclIbDev*)args;
   while (1) {
     struct ibv_async_event event;
-    if (ncclSuccess != wrap_ibv_get_async_event(dev->context, &event)) { break; }
-    char *str;
+    if (ncclSuccess != wrap_ibv_get_async_event(dev->context, &event)) {
+      break;
+    }
+    char* str;
     struct ibv_cq* cq = event.element.cq;    // only valid if CQ error
     struct ibv_qp* qp = event.element.qp;    // only valid if QP error
     struct ibv_srq* srq = event.element.srq; // only valid if SRQ error
-    if (ncclSuccess != wrap_ibv_event_type_str(&str, event.event_type)) { break; }
+    if (ncclSuccess != wrap_ibv_event_type_str(&str, event.event_type)) {
+      break;
+    }
     switch (event.event_type) {
     case IBV_EVENT_DEVICE_FATAL:
       // the above is device fatal error
@@ -166,7 +167,9 @@ void* IbCastAsyncThreadMain(void* args) {
       break;
     }
     // acknowledgment needs to happen last to avoid user-after-free
-    if (ncclSuccess != wrap_ibv_ack_async_event(&event)) { break; }
+    if (ncclSuccess != wrap_ibv_ack_async_event(&event)) {
+      break;
+    }
   }
   return NULL;
 }

--- a/projects/rccl/src/transport/net_ib_cast/common_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/common_cast.h
@@ -60,30 +60,30 @@
 
 #define MAXSUFFIXSIZE 16
 #define MAXNAMESIZE (64 + MAXSUFFIXSIZE)
-extern char IbCastIfName[MAX_IF_NAME_SIZE+1];
+extern char IbCastIfName[MAX_IF_NAME_SIZE + 1];
 extern union ncclSocketAddress IbCastIfAddr;
 
 enum ncclIbRequestMatchingScheme {
-  BY_INDEX=0,
-  BY_ID=1,
-  BY_ORDER=2, // send requests are posted in the order they are received (CTS OFFLOAD)
+  BY_INDEX = 0,
+  BY_ID = 1,
+  BY_ORDER = 2, // send requests are posted in the order they are received (CTS OFFLOAD)
 };
 
 struct ncclIbMr {
   uintptr_t addr;
   size_t pages;
   int refs;
-  ibv_mr *mr;
+  ibv_mr* mr;
 };
 
 struct ncclIbMrCache {
-  struct ncclIbMr *slots;
+  struct ncclIbMr* slots;
   int capacity, population;
 };
 
 extern int IbCastNMergedDevs;
 #define NCCL_IB_MAX_DEVS_PER_NIC NCCL_NET_MAX_DEVS_PER_NIC
-#define MAX_MERGED_DEV_NAME (MAXNAMESIZE*NCCL_IB_MAX_DEVS_PER_NIC)+NCCL_IB_MAX_DEVS_PER_NIC
+#define MAX_MERGED_DEV_NAME (MAXNAMESIZE * NCCL_IB_MAX_DEVS_PER_NIC) + NCCL_IB_MAX_DEVS_PER_NIC
 struct alignas(64) ncclIbMergedDev {
   ncclNetVDeviceProps_t vProps;
   int speed;
@@ -131,25 +131,25 @@ struct alignas(64) ncclIbDev {
   } capsProvider;
 };
 
-#define MAX_IB_DEVS  32
-#define MAX_IB_VDEVS MAX_IB_DEVS*8
+#define MAX_IB_DEVS 32
+#define MAX_IB_VDEVS MAX_IB_DEVS * 8
 extern struct ncclIbMergedDev IbCastMergedDevs[MAX_IB_VDEVS];
 extern struct ncclIbDev IbCastDevs[MAX_IB_DEVS];
 extern int IbCastRelaxedOrderingEnabled;
 extern bool IbCastUseInline;
 
-
-#define WR_IMM_RX_REQ_IDX_MASK  0xff
+#define WR_IMM_RX_REQ_IDX_MASK 0xff
 #define WR_IMM_RX_REQ_IDX_SHIFT 24
-#define WR_IMM_SPLIT_DATA_FLAG  0x00800000
-#define WR_IMM_SIZE_MASK        0x007fffff
+#define WR_IMM_SPLIT_DATA_FLAG 0x00800000
+#define WR_IMM_SIZE_MASK 0x007fffff
 extern int IbCastGdrFlushDisable;
 extern bool IbCastAinicRoce;
 extern bool rcclCtsInlineData;
 extern bool IbCastOffloadEnabled;
 extern int64_t rcclParamIbCastP2pDisableCts();
 
-#define NCCL_IB_LLSTR(ll) (((ll) == IBV_LINK_LAYER_INFINIBAND) ? "IB" : (((ll) == IBV_LINK_LAYER_ETHERNET) ? "RoCE" : "UNSPECIFIED"))
+#define NCCL_IB_LLSTR(ll) \
+  (((ll) == IBV_LINK_LAYER_INFINIBAND) ? "IB" : (((ll) == IBV_LINK_LAYER_ETHERNET) ? "RoCE" : "UNSPECIFIED"))
 
 // Per-Dev connection metadata
 struct ncclIbDevInfo {
@@ -171,7 +171,7 @@ struct ncclIbDevInfo {
   // registered the completion records structure (on the specific device).
   uint32_t rkey;
 
-  //remote dev info
+  // remote dev info
   union ibv_gid remoteGid;
   int ibv_dev_index;
 };
@@ -203,79 +203,78 @@ struct ncclProfilerInfo {
 extern const char* IbCastReqTypeStr[];
 
 struct ncclIbQpSchedParms {
-    bool enable;
-    bool wrrEnable;
-    uint64_t updateInterval; // in nsec
-    uint64_t resetInterval;  // in nsec
-    double weightNew;        // fractional weight applied to most recent RTT sample
-    uint32_t splitDataMin;   // in bytes
-    bool splitData;          // init from NCCL_IB_SPLIT_DATA_ON_QPS
-    bool doWrr;
-    bool resetRtt;
-    bool logEnable;
-    uint64_t logInterval;    // in nsec
-  };
-  extern struct ncclIbQpSchedParms castGlobalQpSchedParms;
-  
+  bool enable;
+  bool wrrEnable;
+  uint64_t updateInterval; // in nsec
+  uint64_t resetInterval;  // in nsec
+  double weightNew;        // fractional weight applied to most recent RTT sample
+  uint32_t splitDataMin;   // in bytes
+  bool splitData;          // init from NCCL_IB_SPLIT_DATA_ON_QPS
+  bool doWrr;
+  bool resetRtt;
+  bool logEnable;
+  uint64_t logInterval;    // in nsec
+};
+extern struct ncclIbQpSchedParms castGlobalQpSchedParms;
+
   // Data about QP transmission
-  struct ncclIbQpTxData {
-    uint64_t startTimeNs;
-    uint64_t bytes;
-  };
-  
-  // For remapping work request ID so that additional info is avail at
-  // completion time of sends
-  struct ncclIbRemapWrId {
-    int state; // in use or unused
-    uint64_t origWrId;
-    int qpIndex;
-    struct ncclIbQpTxData tx;
-    struct ncclIbQpSchedParms parms;
-  };
-  
-  // Stats for scheduling QP transmissions
-  struct ncclIbQpTxStats {
-    uint64_t minRttSample;
-    uint64_t totRtt;
-    uint64_t numMeasurements;
-    double rtt;
-  };
-  
-  // Scratchpad for computing scheduler weights
-  struct ncclIbQpTxSchedScratchpad {
-    double rtt[NCCL_IB_MAX_QPS];
-  };
-  
-  // Scheduler for QP transmissions
-  struct ncclIbQpTxSched {
-    double weight;    // fraction of sub-chunk to be transmitted on QP
-    double minWeight; // min value of weight used
-    double maxWeight; // max value of weight used
-  };
-  
-  #define NCCL_IB_TARGET_TOT_TOKENS 100
-  
-  // Tokens for weighted round-robin QP scheduler
-  struct ncclIbRrTokens {
-    int totTokens;
-    int qpTokens[NCCL_IB_MAX_QPS];
-  };
-  
-  // Scheduler for weighted round-robin QP transmissions
-  struct ncclIbRrQpTxSched {
-    struct ncclIbRrTokens initTokens;
-    struct ncclIbRrTokens activeTokens;
-    int qpIndex;
-  };
-  
-  // QP scheduling descriptor
-  struct IbCastQpSchedDesc {
-    bool wrrSched;
-    int nqps;
-    int startQpIndex;
-    struct ncclIbQpSchedParms parms;
+struct ncclIbQpTxData {
+  uint64_t startTimeNs;
+  uint64_t bytes;
 };
 
+  // For remapping work request ID so that additional info is avail at
+  // completion time of sends
+struct ncclIbRemapWrId {
+  int state; // in use or unused
+  uint64_t origWrId;
+  int qpIndex;
+  struct ncclIbQpTxData tx;
+  struct ncclIbQpSchedParms parms;
+};
+
+  // Stats for scheduling QP transmissions
+struct ncclIbQpTxStats {
+  uint64_t minRttSample;
+  uint64_t totRtt;
+  uint64_t numMeasurements;
+  double rtt;
+};
+
+  // Scratchpad for computing scheduler weights
+struct ncclIbQpTxSchedScratchpad {
+  double rtt[NCCL_IB_MAX_QPS];
+};
+
+  // Scheduler for QP transmissions
+struct ncclIbQpTxSched {
+  double weight;    // fraction of sub-chunk to be transmitted on QP
+  double minWeight; // min value of weight used
+  double maxWeight; // max value of weight used
+};
+
+#define NCCL_IB_TARGET_TOT_TOKENS 100
+
+  // Tokens for weighted round-robin QP scheduler
+struct ncclIbRrTokens {
+  int totTokens;
+  int qpTokens[NCCL_IB_MAX_QPS];
+};
+
+  // Scheduler for weighted round-robin QP transmissions
+struct ncclIbRrQpTxSched {
+  struct ncclIbRrTokens initTokens;
+  struct ncclIbRrTokens activeTokens;
+  int qpIndex;
+};
+
+  // QP scheduling descriptor
+struct IbCastQpSchedDesc {
+  bool wrrSched;
+  int nqps;
+  int startQpIndex;
+  struct ncclIbQpSchedParms parms;
+};
 
 // Tracks data transfers between sender and receiver. A multi-recv/send uses a
 // single record.
@@ -425,8 +424,9 @@ struct ncclIbQp {
 };
 
 // We need to support NCCL_NET_MAX_REQUESTS for each concurrent receive
-#define NET_IB_MAX_REQUESTS (NCCL_NET_MAX_REQUESTS*NCCL_NET_IB_MAX_RECVS)
-static_assert(NET_IB_MAX_REQUESTS <= 256, "request id are encoded in wr_id and we need up to 8 requests ids per completion");
+#define NET_IB_MAX_REQUESTS (NCCL_NET_MAX_REQUESTS * NCCL_NET_IB_MAX_RECVS)
+static_assert(NET_IB_MAX_REQUESTS <= 256,
+              "request id are encoded in wr_id and we need up to 8 requests ids per completion");
 
 // Structure to describe the completion records on the sender side.
 struct ncclIbRemCompletionsRecords {
@@ -452,7 +452,6 @@ struct alignas(8) ncclIbSendCommDev {
   struct ibv_sge sge;
 };
 
-
 // Wrapper to track an MR per-device, if needed
 struct ncclIbMrHandle {
   ibv_mr* mrs[NCCL_IB_MAX_DEVS_PER_NIC];
@@ -470,7 +469,7 @@ struct alignas(32) ncclIbNetCommBase {
   // The pointers point to QPs in the ncclIbNetCommBase::qps[] array.
   struct ncclIbQp* activeQps[NCCL_IB_MAX_QPS];
 
-  //NET-IB-CAST: QP scheduler state
+  // NET-IB-CAST: QP scheduler state
   struct ncclIbRemapWrId remapWrId[NET_IB_MAX_REQUESTS];
   struct ncclIbQpTxStats qpTxStats[NCCL_IB_MAX_QPS];
   uint64_t nextQpTxStatsResetNs;
@@ -503,7 +502,7 @@ struct alignas(32) ncclIbNetCommBase {
   struct ncclIbStats stats;
 #ifdef ENABLE_FAULT_INJECTION
   uint32_t faultQpDelayUs[NCCL_IB_MAX_QPS];
-  bool     faultQpError[NCCL_IB_MAX_QPS];
+  bool faultQpError[NCCL_IB_MAX_QPS];
 #endif
   struct ncclIbResiliency* resiliency;
 };
@@ -512,9 +511,10 @@ struct ncclIbNetCommDevBase* IbCastGetNetCommDevBase(ncclIbNetCommBase* base, in
 
 // qpIndex is the index relative to a device.
 // For example, if a device has 2 QPs, qpIndex can be 0 or 1.
-static inline ncclResult_t IbCastCommBaseGetQpByIndex(struct ncclIbNetCommBase* commBase, int devIndex, int qpIndex, ncclIbQp** qp) {
+static inline ncclResult_t IbCastCommBaseGetQpByIndex(struct ncclIbNetCommBase* commBase, int devIndex, int qpIndex,
+                                                      ncclIbQp** qp) {
   assert(devIndex >= 0 && devIndex < commBase->vProps.ndevs);
-  *qp = commBase->activeQps[commBase->vProps.ndevs*qpIndex + devIndex];
+  *qp = commBase->activeQps[commBase->vProps.ndevs * qpIndex + devIndex];
   return ncclSuccess;
 }
 
@@ -526,7 +526,8 @@ static inline ncclResult_t IbCastCommBaseGetQpByIndex(struct ncclIbNetCommBase* 
 // The function outputs the selected QP in the outQp argument and populates the
 // outQpIndex argument with the index of the selected QP. Note that the
 // outQpIndex is the index of the QP in the base::qps[] array.
-static inline ncclResult_t IbCastCommBaseGetQpForRequest(struct ncclIbNetCommBase* baseComm, const uint64_t id, const uint8_t qpIndex, ncclIbQp** outQp, int* outQpIndex) {
+static inline ncclResult_t IbCastCommBaseGetQpForRequest(struct ncclIbNetCommBase* baseComm, const uint64_t id,
+                                                         const uint8_t qpIndex, ncclIbQp** outQp, int* outQpIndex) {
   *outQpIndex = (id + qpIndex) % baseComm->nqps;
   *outQp = baseComm->activeQps[*outQpIndex];
   assert(*outQp != NULL);
@@ -535,12 +536,14 @@ static inline ncclResult_t IbCastCommBaseGetQpForRequest(struct ncclIbNetCommBas
 
 // Get a QP object from a QP number. If not NULL, qpIndex will also return the
 // index of the QP in the ncclIbNetCommBase::qps[] array.
-static inline ncclResult_t IbCastCommBaseGetQpByQpNum(struct ncclIbNetCommBase* commBase, int devIndex, uint32_t qpNum, ncclIbQp** qp, int* qpIndex) {
+static inline ncclResult_t IbCastCommBaseGetQpByQpNum(struct ncclIbNetCommBase* commBase, int devIndex, uint32_t qpNum,
+                                                      ncclIbQp** qp, int* qpIndex) {
   assert(devIndex >= 0 && devIndex < commBase->vProps.ndevs);
   assert(qp != NULL);
-  TRACE(NCCL_NET, "NET/IB: %s: Looking for QP num %u on devIndex %d among %d QPs", __func__, qpNum, devIndex, commBase->nqps / commBase->vProps.ndevs);
+  TRACE(NCCL_NET, "NET/IB: %s: Looking for QP num %u on devIndex %d among %d QPs", __func__, qpNum, devIndex,
+        commBase->nqps / commBase->vProps.ndevs);
   for (int qpIndexInDev = 0; qpIndexInDev < (commBase->nqps / commBase->vProps.ndevs); qpIndexInDev++) {
-    *qp = &(commBase->qps[commBase->vProps.ndevs*qpIndexInDev + devIndex]);
+    *qp = &(commBase->qps[commBase->vProps.ndevs * qpIndexInDev + devIndex]);
     if ((*qp)->qp->qp_num == qpNum) {
       if (qpIndex != NULL) {
         *qpIndex = *qp - commBase->qps;
@@ -596,10 +599,12 @@ struct ncclIbSendComm {
 // The SendFifo needs to be 32-byte aligned and each element needs
 // to be a 32-byte multiple, so that an entry does not get split and
 // written out of order when IB Relaxed Ordering is enabled
-static_assert((sizeof(struct ncclIbNetCommBase) % 32) == 0, "ncclIbNetCommBase size must be 32-byte multiple to ensure ctsFifo is at proper offset");
+static_assert((sizeof(struct ncclIbNetCommBase) % 32) == 0,
+              "ncclIbNetCommBase size must be 32-byte multiple to ensure ctsFifo is at proper offset");
 static_assert((offsetof(struct ncclIbSendComm, ctsFifo) % 32) == 0, "ncclIbSendComm ctsFifo must be 32-byte aligned");
 static_assert((sizeof(struct ncclIbSendFifo) % 32) == 0, "ncclIbSendFifo element size must be 32-byte multiples");
-static_assert((sizeof(struct ncclIbSendFifoCtsInline) % 32) == 0, "ncclIbSendFifoCtsInline element size must be 32-byte multiples");
+static_assert((sizeof(struct ncclIbSendFifoCtsInline) % 32) == 0,
+              "ncclIbSendFifoCtsInline element size must be 32-byte multiples");
 static_assert((offsetof(struct ncclIbSendComm, sges) % 32) == 0, "sges must be 32-byte aligned");
 static_assert((offsetof(struct ncclIbSendComm, wrs) % 32) == 0, "wrs must be 32-byte aligned");
 
@@ -671,7 +676,8 @@ struct ncclIbRecvComm {
   struct ibv_recv_wr ibRecvWorkRequest;
   bool useCtsOffload;
 };
-static_assert((offsetof(struct ncclIbRecvComm, remCtsFifo) % 32) == 0, "ncclIbRecvComm ctsFifo must be 32-byte aligned");
+static_assert((offsetof(struct ncclIbRecvComm, remCtsFifo) % 32) == 0,
+              "ncclIbRecvComm ctsFifo must be 32-byte aligned");
 
 ncclResult_t IbCastBaseCommInit(struct ncclIbNetCommBase* baseComm, bool isSend);
 ncclResult_t IbCastRecvCommInit(struct ncclIbRecvComm* recvComm);
@@ -687,7 +693,7 @@ static ncclResult_t IbCastStatsInit(struct ncclIbStats* stat) {
   COMPILER_ATOMIC_STORE(&stat->fatalErrorCount, 0, std::memory_order_relaxed);
   return ncclSuccess;
 }
-static void IbCastStatsFatalError(struct ncclIbStats* stat){
+static void IbCastStatsFatalError(struct ncclIbStats* stat) {
   COMPILER_ATOMIC_FETCH_ADD(&stat->fatalErrorCount, 1, std::memory_order_relaxed);
 }
 static void IbCastQpFatalError(struct ibv_qp* qp) {
@@ -712,29 +718,35 @@ ncclResult_t IbCastDmaBufSupport(int dev);
 
 void IbCastAddEvent(struct ncclIbRequest* req, int devIndex);
 void IbCastAddEventCTS(struct ncclIbRequest* req, int devIndex);
-ncclResult_t IbCastGetGidIndex(struct ibv_context *context, uint8_t portNum, struct ibv_port_attr* portAttr, int *gidIndex);
+ncclResult_t IbCastGetGidIndex(struct ibv_context* context, uint8_t portNum, struct ibv_port_attr* portAttr,
+                               int* gidIndex);
 ncclResult_t IbCastGetRequest(struct ncclIbNetCommBase* base, struct ncclIbRequest** req);
 ncclResult_t IbCastFreeRequest(struct ncclIbRequest* r);
 
-ncclResult_t IbCastRegMrDmaBufInternal(void* comm, void* data, size_t size, int type, uint64_t offset, int fd, uint64_t mrFlags, void** mhandle);
+ncclResult_t IbCastRegMrDmaBufInternal(void* comm, void* data, size_t size, int type, uint64_t offset, int fd,
+                                       uint64_t mrFlags, void** mhandle);
 
 int IbCastGetTrafficClass(void* ctx);
 void IbCastSetTrafficClass(void* ctx, int trafficClass);
 
 // Net IB plugin entry functions.
 ncclResult_t IbCastInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallback_t profFunction);
-ncclResult_t IbCastInit(void** ctx, uint64_t commId, ncclNetCommConfig_t* config, ncclDebugLogger_t logFunction, ncclProfilerCallback_t profFunction);
+ncclResult_t IbCastInit(void** ctx, uint64_t commId, ncclNetCommConfig_t* config, ncclDebugLogger_t logFunction,
+                        ncclProfilerCallback_t profFunction);
 ncclResult_t IbCastDevices(int* ndev);
 ncclResult_t IbCastGetProperties(int dev, ncclNetProperties_t* props);
 ncclResult_t IbCastGetPhysProperties(int dev, ncclNetProperties_t* props);
 ncclResult_t IbCastListen(void* ctx, int dev, void* opaqueHandle, void** listenComm);
-ncclResult_t IbCastConnect(void* ctx, int dev, void* opaqueHandle, void** sendComm, ncclNetDeviceHandle_t** /*sendDevComm*/);
+ncclResult_t IbCastConnect(void* ctx, int dev, void* opaqueHandle, void** sendComm,
+                           ncclNetDeviceHandle_t** /*sendDevComm*/);
 ncclResult_t IbCastAccept(void* listenComm, void** recvComm, ncclNetDeviceHandle_t** /*recvDevComm*/);
 ncclResult_t IbCastRegMr(void* comm, void* data, size_t size, int type, void** mhandle);
 ncclResult_t IbCastRegMrDmaBuf(void* comm, void* data, size_t size, int type, uint64_t offset, int fd, void** mhandle);
 ncclResult_t IbCastDeregMr(void* comm, void* mhandle);
-ncclResult_t IbCastIsend(void* sendComm, void* data, size_t size, int tag, void* mhandle, void* phandle, void** request);
-ncclResult_t IbCastIrecv(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles, void** phandles, void** request);
+ncclResult_t IbCastIsend(void* sendComm, void* data, size_t size, int tag, void* mhandle, void* phandle,
+                         void** request);
+ncclResult_t IbCastIrecv(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles, void** phandles,
+                         void** request);
 ncclResult_t IbCastIflush(void* recvComm, int n, void** data, int* sizes, void** mhandles, void** request);
 ncclResult_t IbCastTest(void* request, int* done, int* sizes);
 ncclResult_t IbCastCloseSend(void* sendComm);
@@ -743,39 +755,38 @@ ncclResult_t IbCastCloseListen(void* listenComm);
 ncclResult_t IbCastMakeVDevice(int* d, ncclNetVDeviceProps_t* props);
 ncclResult_t IbCastFinalizeDevices(void);
 ncclResult_t IbCastFinalize(void* ctx);
-ncclResult_t IbCastSetNetAttr(void *ctx, ncclNetAttr_t *netAttr);
-
+ncclResult_t IbCastSetNetAttr(void* ctx, ncclNetAttr_t* netAttr);
 
 // AINIC-specific infrastructure
 #define NCCL_CTS_QP_SLOT_INVALID 0xFF
 
 // IB-CAST specific infrastructure
 
-#define NSEC_PER_USEC           1000ULL
-#define NSEC_PER_MSEC           (NSEC_PER_USEC * 1000)
-#define NSEC_PER_SEC            (NSEC_PER_MSEC * 1000)
-#define NSEC_PER_MIN            (NSEC_PER_SEC * 60)
+#define NSEC_PER_USEC 1000ULL
+#define NSEC_PER_MSEC (NSEC_PER_USEC * 1000)
+#define NSEC_PER_SEC (NSEC_PER_MSEC * 1000)
+#define NSEC_PER_MIN (NSEC_PER_SEC * 60)
 
-#define QP_SCHED_RESET_MIN      NSEC_PER_MSEC
-#define QP_SCHED_RESET_NEVER    0
+#define QP_SCHED_RESET_MIN NSEC_PER_MSEC
+#define QP_SCHED_RESET_NEVER 0
 
-#define QP_SCHED_UPDATE_MIN     NSEC_PER_USEC
-#define QP_SCHED_UPDATE_MAX     NSEC_PER_MIN
+#define QP_SCHED_UPDATE_MIN NSEC_PER_USEC
+#define QP_SCHED_UPDATE_MAX NSEC_PER_MIN
 
-#define QP_SCHED_WEIGHT_NONE    0
-#define QP_SCHED_WEIGHT_MIN     QP_SCHED_WEIGHT_NONE
-#define QP_SCHED_WEIGHT_MAX     1.0
+#define QP_SCHED_WEIGHT_NONE 0
+#define QP_SCHED_WEIGHT_MIN QP_SCHED_WEIGHT_NONE
+#define QP_SCHED_WEIGHT_MAX 1.0
 
-#define QP_SCHED_DISABLE        0
-#define QP_SCHED_ENABLE         1
+#define QP_SCHED_DISABLE 0
+#define QP_SCHED_ENABLE 1
 
-#define QP_SCHED_ENABLE_DEF             QP_SCHED_ENABLE
-#define QP_SCHED_WRR_ENABLE_DEF         QP_SCHED_ENABLE
-#define QP_SCHED_RESET_DEF              (NSEC_PER_SEC * 60)
-#define QP_SCHED_UPDATE_DEF             (NSEC_PER_USEC * 50)
-#define QP_SCHED_WEIGHT_DEF             QP_SCHED_WEIGHT_NONE
-#define QP_SCHED_SPLIT_DATA_MIN_DEF     (64 * 1024)
-#define QP_SCHED_LOG_DEF                NSEC_PER_SEC
+#define QP_SCHED_ENABLE_DEF QP_SCHED_ENABLE
+#define QP_SCHED_WRR_ENABLE_DEF QP_SCHED_ENABLE
+#define QP_SCHED_RESET_DEF (NSEC_PER_SEC * 60)
+#define QP_SCHED_UPDATE_DEF (NSEC_PER_USEC * 50)
+#define QP_SCHED_WEIGHT_DEF QP_SCHED_WEIGHT_NONE
+#define QP_SCHED_SPLIT_DATA_MIN_DEF (64 * 1024)
+#define QP_SCHED_LOG_DEF NSEC_PER_SEC
 
 // CAST – each variable is accessible as RCCL_IB_QP_SCHED_* or NCCL_IB_QP_SCHED_*
 // Declarations only — definitions live in scheduler.cc to avoid duplicate symbols.
@@ -786,23 +797,20 @@ extern int64_t rcclParamIbQpSchedUpdateInterval();
 extern int64_t rcclParamIbQpSchedSplitDataMin();
 extern int64_t rcclParamIbQpSchedLogInterval();
 
-#define QP_SCHED_WEIGHT_ENV_VAR           "RCCL_IB_QP_SCHED_WEIGHT"
-#define QP_SCHED_WEIGHT_ENV_VAR_ALIAS     "NCCL_IB_QP_SCHED_WEIGHT"
-#define QP_SCHED_LOG_PATH_ENV_VAR         "RCCL_IB_QP_SCHED_LOG_PATH"
-#define QP_SCHED_LOG_PATH_ENV_VAR_ALIAS   "NCCL_IB_QP_SCHED_LOG_PATH"
+#define QP_SCHED_WEIGHT_ENV_VAR "RCCL_IB_QP_SCHED_WEIGHT"
+#define QP_SCHED_WEIGHT_ENV_VAR_ALIAS "NCCL_IB_QP_SCHED_WEIGHT"
+#define QP_SCHED_LOG_PATH_ENV_VAR "RCCL_IB_QP_SCHED_LOG_PATH"
+#define QP_SCHED_LOG_PATH_ENV_VAR_ALIAS "NCCL_IB_QP_SCHED_LOG_PATH"
 
-#define QP_SCHED_LOG_FILE_NAME_PREFIX	"cast_log_"
+#define QP_SCHED_LOG_FILE_NAME_PREFIX "cast_log_"
 #define NCCL_NET_IB_REMAP_UNUSED 0
-#define NCCL_NET_IB_REMAP_USED   1
+#define NCCL_NET_IB_REMAP_USED 1
 
 #define BITS_PER_BYTE 8
-#define MEG           1000000
+#define MEG 1000000
 
-#define TIMESPEC_TO_NSEC(TS_PTR)                   \
-  ((((uint64_t) (TS_PTR)->tv_sec) * NSEC_PER_SEC) + \
-   ((uint64_t) (TS_PTR)->tv_nsec))
+#define TIMESPEC_TO_NSEC(TS_PTR) ((((uint64_t)(TS_PTR)->tv_sec) * NSEC_PER_SEC) + ((uint64_t)(TS_PTR)->tv_nsec))
 
-  
 // Control block for staged dynamic scheduling parameters
 struct ncclIbQpSchedParmsCB {
   ncclFunc_t collType;
@@ -812,13 +820,13 @@ struct ncclIbQpSchedParmsCB {
 };
 
 bool rcclUseIbCastQpSched();
-ncclResult_t IbCastQpSchedInitParms(struct ncclIbQpSchedParms *parms);
-void IbCastLogSched(struct ncclIbSendComm *comm);
-void IbCastUpdateSchedParmsTry(struct ncclIbNetCommBase *base, int nreqs, int size);
-void IbCastQpSchedUpdateTx(struct ncclIbNetCommBase *base);
-void IbCastQpSchedUpdateTxStats(struct ncclIbRemapWrId *remap,
-  struct ncclIbNetCommBase *base);
-int IbCastQpSchedGetEffectiveTxNqps(struct ncclIbRequest* req, int *startQpIndex, bool *wrrSched);
-ncclResult_t IbCastQpSchedGetRemap(struct ncclIbNetCommBase* base, uint64_t wrId, int qpIndex, struct ncclIbRemapWrId** remap);
+ncclResult_t IbCastQpSchedInitParms(struct ncclIbQpSchedParms* parms);
+void IbCastLogSched(struct ncclIbSendComm* comm);
+void IbCastUpdateSchedParmsTry(struct ncclIbNetCommBase* base, int nreqs, int size);
+void IbCastQpSchedUpdateTx(struct ncclIbNetCommBase* base);
+void IbCastQpSchedUpdateTxStats(struct ncclIbRemapWrId* remap, struct ncclIbNetCommBase* base);
+int IbCastQpSchedGetEffectiveTxNqps(struct ncclIbRequest* req, int* startQpIndex, bool* wrrSched);
+ncclResult_t IbCastQpSchedGetRemap(struct ncclIbNetCommBase* base, uint64_t wrId, int qpIndex,
+                                   struct ncclIbRemapWrId** remap);
 ncclResult_t IbCastQpSchedFreeRemap(struct ncclIbRemapWrId* r);
 #endif

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -20,7 +20,7 @@ NCCL_PARAM(IbCastGdrFlushDisable, "GDR_FLUSH_DISABLE", 1);
 NCCL_PARAM(IbCastSl, "IB_SL", -1);
 NCCL_PARAM(IbCastTc, "IB_TC", -1);
 NCCL_PARAM(IbCastFifoTc, "IB_FIFO_TC", -1);
-NCCL_PARAM(IbCastEceEnable,"IB_ECE_ENABLE",1);
+NCCL_PARAM(IbCastEceEnable, "IB_ECE_ENABLE", 1);
 
 extern int64_t ncclParamIbCastOooRq();
 
@@ -28,35 +28,32 @@ struct ncclIbDevExtraProps {
   bool oooRq;
 };
 
-
 NCCL_PARAM(IbCastQpsPerConn, "IB_QPS_PER_CONNECTION", 2);
 extern int64_t rcclParamIbCastQpsPerP2p();
 extern int64_t rcclParamIbCastGdrFlushGpuMemNoRelaxedOrdering();
 
 // Calculate number of QPs based on P2P flag and device counts
 static int IbCastCalculateNqps(int isP2p, int localNdevs, int remoteNdevs, const char* funcName) {
-  auto qpMultiplier = (rcclParamIbCastQpsPerP2p() > 0 && isP2p) ? 
-                       rcclParamIbCastQpsPerP2p() : ncclParamIbCastQpsPerConn();
+  auto qpMultiplier =
+    (rcclParamIbCastQpsPerP2p() > 0 && isP2p) ? rcclParamIbCastQpsPerP2p() : ncclParamIbCastQpsPerConn();
   int localNqps = qpMultiplier * localNdevs;
   int remoteNqps = qpMultiplier * remoteNdevs;
   int maxNqps = (remoteNqps > localNqps) ? remoteNqps : localNqps;
-  INFO(NCCL_NET, "NET/IB: %s Max Nqps=%d, localNqps=%d, remoteNqps=%d", 
-       funcName, maxNqps, localNqps, remoteNqps);
+  INFO(NCCL_NET, "NET/IB: %s Max Nqps=%d, localNqps=%d, remoteNqps=%d", funcName, maxNqps, localNqps, remoteNqps);
   return maxNqps;
 }
 
-
 #define NCCL_CTS_QP_SLOT_INVALID 0xFF
 enum ncclIbChannelType {
-  ncclIbChannelTypeCts  = 0,
+  ncclIbChannelTypeCts = 0,
   ncclIbChannelTypeData = 1,
-  ncclIbChannelTypeMax  = 2
+  ncclIbChannelTypeMax = 2
 };
 
 struct ncclChannelToUd {
-    int channelId;
-    bool udId;
-    bool udAllocated;
+  int channelId;
+  bool udId;
+  bool udAllocated;
 };
 
 static ncclChannelToUd nccl_channel_ud_map[MAX_IB_DEVS][MAXCHANNELS][ncclIbChannelTypeMax];
@@ -95,13 +92,11 @@ ncclResult_t IbCastDestroyBase(struct ncclIbNetCommDevBase* base) {
 // GID Format
 // global:  |              64b  - subnet-prefix                |                 64b - EUI                          |
 // raw   :  | 10b fixed | 22b 0 | 16b FLID | 16b subnet-prefix |                 64b - EUI                          |
-static uint16_t IbCastExtractLocalSubnetPrefix(uint64_t subnet_prefix)
-{
+static uint16_t IbCastExtractLocalSubnetPrefix(uint64_t subnet_prefix) {
   return (be64toh(subnet_prefix) & 0xffff);
 }
 
-static int IbCastExtractFlid (union ibv_gid *gid)
-{
+static int IbCastExtractFlid(union ibv_gid* gid) {
   return ntohs(*((uint16_t*)((uintptr_t)(gid->raw) + 4)));
 }
 
@@ -127,7 +122,7 @@ static void* envIbAddrRange(sa_family_t af, int* mask) {
   *mask = 0;
   static struct in_addr addr;
   static struct in6_addr addr6;
-  void *ret = (af == AF_INET) ? (void *)&addr : (void *)&addr6;
+  void* ret = (af == AF_INET) ? (void*)&addr : (void*)&addr6;
 
   const char* env = ncclGetEnv("NCCL_IB_ADDR_RANGE");
   if (NULL == env || strlen(env) == 0) {
@@ -136,27 +131,30 @@ static void* envIbAddrRange(sa_family_t af, int* mask) {
 
   INFO(NCCL_ENV, "NCCL_IB_ADDR_RANGE set by environment to %s", env);
 
-  char addrString[128] = { 0 };
+  char addrString[128] = {0};
   snprintf(addrString, 128, "%s", env);
-  char *addrStrPtr = addrString;
-  char *maskStrPtr = strstr(addrString, "/");
+  char* addrStrPtr = addrString;
+  char* maskStrPtr = strstr(addrString, "/");
   if (NULL == maskStrPtr) {
     return NULL;
   }
   *(maskStrPtr++) = '\0';
 
   if (inet_pton(af, addrStrPtr, ret) == 0) {
-    INFO(NCCL_INIT|NCCL_NET, "NET/IB: Ip address '%s' is invalid for family %s, ignoring address", addrStrPtr, (af == AF_INET) ? "AF_INET" : "AF_INET6");
+    INFO(NCCL_INIT | NCCL_NET, "NET/IB: Ip address '%s' is invalid for family %s, ignoring address", addrStrPtr,
+         (af == AF_INET) ? "AF_INET" : "AF_INET6");
     return NULL;
   }
 
   *mask = (int)strtol(maskStrPtr, NULL, 10);
   if (af == AF_INET && *mask > 32) {
-    INFO(NCCL_INIT|NCCL_NET, "NET/IB: Ip address mask '%d' is invalid for family %s, ignoring mask", *mask, (af == AF_INET) ? "AF_INET" : "AF_INET6");
+    INFO(NCCL_INIT | NCCL_NET, "NET/IB: Ip address mask '%d' is invalid for family %s, ignoring mask", *mask,
+         (af == AF_INET) ? "AF_INET" : "AF_INET6");
     *mask = 0;
     ret = NULL;
   } else if (af == AF_INET6 && *mask > 128) {
-    INFO(NCCL_INIT|NCCL_NET, "NET/IB: Ip address mask '%d' is invalid for family %s, ignoring mask", *mask, (af == AF_INET) ? "AF_INET" : "AF_INET6");
+    INFO(NCCL_INIT | NCCL_NET, "NET/IB: Ip address mask '%d' is invalid for family %s, ignoring mask", *mask,
+         (af == AF_INET) ? "AF_INET" : "AF_INET6");
     *mask = 0;
     ret = NULL;
   }
@@ -165,22 +163,24 @@ static void* envIbAddrRange(sa_family_t af, int* mask) {
 }
 
 static sa_family_t getGidAddrFamily(union ibv_gid* gid) {
-  const struct in6_addr *a = (struct in6_addr *)gid->raw;
+  const struct in6_addr* a = (struct in6_addr*)gid->raw;
   bool isIpV4Mapped = ((a->s6_addr32[0] | a->s6_addr32[1]) | (a->s6_addr32[2] ^ htonl(0x0000ffff))) == 0UL;
-  bool isIpV4MappedMulticast = (a->s6_addr32[0] == htonl(0xff0e0000) && ((a->s6_addr32[1] | (a->s6_addr32[2] ^ htonl(0x0000ffff))) == 0UL));
+  bool isIpV4MappedMulticast =
+    (a->s6_addr32[0] == htonl(0xff0e0000) && ((a->s6_addr32[1] | (a->s6_addr32[2] ^ htonl(0x0000ffff))) == 0UL));
   return (isIpV4Mapped || isIpV4MappedMulticast) ? AF_INET : AF_INET6;
 }
 
 static bool matchGidAddrPrefix(sa_family_t af, void* prefix, int prefixlen, union ibv_gid* gid) {
-  struct in_addr *base = NULL;
-  struct in6_addr *base6 = NULL;
-  struct in6_addr *addr6 = NULL;;
+  struct in_addr* base = NULL;
+  struct in6_addr* base6 = NULL;
+  struct in6_addr* addr6 = NULL;
+  ;
   if (af == AF_INET) {
-    base = (struct in_addr *)prefix;
+    base = (struct in_addr*)prefix;
   } else {
-    base6 = (struct in6_addr *)prefix;
+    base6 = (struct in6_addr*)prefix;
   }
-  addr6 = (struct in6_addr *)gid->raw;
+  addr6 = (struct in6_addr*)gid->raw;
 
 #define NETMASK(bits) (htonl(0xffffffff ^ ((1 << (32 - bits)) - 1)))
 
@@ -214,7 +214,7 @@ static bool matchGidAddrPrefix(sa_family_t af, void* prefix, int prefixlen, unio
 }
 
 static bool configuredGid(union ibv_gid* gid) {
-  const struct in6_addr *a = (struct in6_addr *)gid->raw;
+  const struct in6_addr* a = (struct in6_addr*)gid->raw;
   int trailer = (a->s6_addr32[1] | a->s6_addr32[2] | a->s6_addr32[3]);
   if (((a->s6_addr32[0] | trailer) == 0UL) || ((a->s6_addr32[0] == htonl(0xfe800000)) && (trailer == 0UL))) {
     return false;
@@ -223,7 +223,7 @@ static bool configuredGid(union ibv_gid* gid) {
 }
 
 static bool linkLocalGid(union ibv_gid* gid) {
-  const struct in6_addr *a = (struct in6_addr *)gid->raw;
+  const struct in6_addr* a = (struct in6_addr*)gid->raw;
   if (a->s6_addr32[0] == htonl(0xfe800000) && a->s6_addr32[1] == 0UL) {
     return true;
   }
@@ -235,9 +235,10 @@ static bool validGid(union ibv_gid* gid) {
 }
 
 static ncclResult_t IbCastRoceGetVersionNum(const char* deviceName, int portNum, int gidIndex, int* version) {
-  char gidRoceVerStr[16] = { 0 };
-  char roceTypePath[PATH_MAX] = { 0 };
-  snprintf(roceTypePath, sizeof(roceTypePath), "/sys/class/infiniband/%s/ports/%d/gid_attrs/types/%d", deviceName, portNum, gidIndex);
+  char gidRoceVerStr[16] = {0};
+  char roceTypePath[PATH_MAX] = {0};
+  snprintf(roceTypePath, sizeof(roceTypePath), "/sys/class/infiniband/%s/ports/%d/gid_attrs/types/%d", deviceName,
+           portNum, gidIndex);
 
   int fd = open(roceTypePath, O_RDONLY);
   if (fd == -1) {
@@ -256,7 +257,8 @@ static ncclResult_t IbCastRoceGetVersionNum(const char* deviceName, int portNum,
   }
 
   if (strlen(gidRoceVerStr)) {
-    if (strncmp(gidRoceVerStr, "IB/RoCE v1", strlen("IB/RoCE v1")) == 0 || strncmp(gidRoceVerStr, "RoCE v1", strlen("RoCE v1")) == 0) {
+    if (strncmp(gidRoceVerStr, "IB/RoCE v1", strlen("IB/RoCE v1")) == 0 ||
+        strncmp(gidRoceVerStr, "RoCE v1", strlen("RoCE v1")) == 0) {
       *version = 1;
     } else if (strncmp(gidRoceVerStr, "RoCE v2", strlen("RoCE v2")) == 0) {
       *version = 2;
@@ -266,7 +268,8 @@ static ncclResult_t IbCastRoceGetVersionNum(const char* deviceName, int portNum,
   return ncclSuccess;
 }
 
-static ncclResult_t ncclUpdateGidIndex(struct ibv_context* context, uint8_t portNum, sa_family_t af, void* prefix, int prefixlen, int roceVer, int gidIndexCandidate, int* gidIndex) {
+static ncclResult_t ncclUpdateGidIndex(struct ibv_context* context, uint8_t portNum, sa_family_t af, void* prefix,
+                                       int prefixlen, int roceVer, int gidIndexCandidate, int* gidIndex) {
   union ibv_gid gid, gidCandidate;
   NCCLCHECK(wrap_ibv_query_gid(context, portNum, *gidIndex, &gid));
   NCCLCHECK(wrap_ibv_query_gid(context, portNum, gidIndexCandidate, &gidCandidate));
@@ -295,10 +298,11 @@ static ncclResult_t ncclUpdateGidIndex(struct ibv_context* context, uint8_t port
   return ncclSuccess;
 }
 
-ncclResult_t IbCastGetGidIndex(struct ibv_context *context, uint8_t portNum, struct ibv_port_attr* portAttr, int *gidIndex) {
+ncclResult_t IbCastGetGidIndex(struct ibv_context* context, uint8_t portNum, struct ibv_port_attr* portAttr,
+                               int* gidIndex) {
   int gidTblLen = portAttr->gid_tbl_len;
 
-  //for IB, choose GID Index that will have routable FLID if present
+  // for IB, choose GID Index that will have routable FLID if present
   if (portAttr->link_layer == IBV_LINK_LAYER_INFINIBAND) {
     union ibv_gid gid;
     int routableGidIndex = ncclParamIbCastRoutableFlidIbGidIndex();
@@ -313,7 +317,7 @@ ncclResult_t IbCastGetGidIndex(struct ibv_context *context, uint8_t portNum, str
     return ncclSuccess;
   }
 
-  //for ROCE
+  // for ROCE
   *gidIndex = ncclParamIbCastGidIndex();
   if (*gidIndex >= 0) {
     return ncclSuccess;
@@ -322,11 +326,12 @@ ncclResult_t IbCastGetGidIndex(struct ibv_context *context, uint8_t portNum, str
   sa_family_t userAddrFamily = envIbAddrFamily();
   int userRoceVersion = ncclParamIbCastRoceVersionNum();
   int prefixlen;
-  void *prefix = envIbAddrRange(userAddrFamily, &prefixlen);
+  void* prefix = envIbAddrRange(userAddrFamily, &prefixlen);
 
   *gidIndex = 0;
   for (int gidIndexNext = 1; gidIndexNext < gidTblLen; ++gidIndexNext) {
-    NCCLCHECK(ncclUpdateGidIndex(context, portNum, userAddrFamily, prefix, prefixlen, userRoceVersion, gidIndexNext, gidIndex));
+    NCCLCHECK(ncclUpdateGidIndex(context, portNum, userAddrFamily, prefix, prefixlen, userRoceVersion, gidIndexNext,
+                                 gidIndex));
   }
 
   return ncclSuccess;
@@ -347,7 +352,7 @@ static ncclResult_t ncclIbCreateQpMlx5(struct ncclIbQpCreateAttr* createQpAttrs,
   struct ibv_qp_init_attr_ex qpInitAttr;
   struct mlx5dv_qp_init_attr dvAttr;
   memset(&qpInitAttr, 0, sizeof(struct ibv_qp_init_attr_ex));
-  memset(&dvAttr, 0 , sizeof(struct mlx5dv_qp_init_attr));
+  memset(&dvAttr, 0, sizeof(struct mlx5dv_qp_init_attr));
   qpInitAttr.qp_context = createQpAttrs->qpContext;
   qpInitAttr.send_cq = createQpAttrs->cq;
   qpInitAttr.recv_cq = createQpAttrs->cq;
@@ -356,7 +361,7 @@ static ncclResult_t ncclIbCreateQpMlx5(struct ncclIbQpCreateAttr* createQpAttrs,
   qpInitAttr.cap.max_send_wr = createQpAttrs->maxSendWorkRequest;
   qpInitAttr.cap.max_send_sge = 1;
   qpInitAttr.cap.max_recv_sge = 1;
-  qpInitAttr.cap.max_inline_data = IbCastUseInline ? sizeof(struct ncclIbSendFifo)*NCCL_NET_IB_MAX_RECVS : 0;
+  qpInitAttr.cap.max_inline_data = IbCastUseInline ? sizeof(struct ncclIbSendFifo) * NCCL_NET_IB_MAX_RECVS : 0;
 
   qpInitAttr.comp_mask = IBV_QP_INIT_ATTR_PD;
   qpInitAttr.pd = createQpAttrs->pd;
@@ -366,7 +371,10 @@ static ncclResult_t ncclIbCreateQpMlx5(struct ncclIbQpCreateAttr* createQpAttrs,
     dvAttr.comp_mask |= MLX5DV_QP_INIT_ATTR_MASK_QP_CREATE_FLAGS;
   }
   qp->qp = wrap_mlx5dv_create_qp(createQpAttrs->pd->context, &qpInitAttr, &dvAttr);
-  if (qp->qp == NULL) { WARN("NET/IB: %s: mlx5dv_create_qp failed to create QP: %m", __func__);  return ncclInternalError; }
+  if (qp->qp == NULL) {
+    WARN("NET/IB: %s: mlx5dv_create_qp failed to create QP: %m", __func__);
+    return ncclInternalError;
+  }
   return ncclSuccess;
 }
 
@@ -382,7 +390,7 @@ static ncclResult_t ncclIbCreateQpIonic(struct ncclIbQpCreateAttr* createQpAttrs
   qpInitAttr.cap.max_send_wr = createQpAttrs->maxSendWorkRequest;
   qpInitAttr.cap.max_send_sge = 1;
   qpInitAttr.cap.max_recv_sge = 1;
-  qpInitAttr.cap.max_inline_data = IbCastUseInline ? sizeof(struct ncclIbSendFifo)*NCCL_NET_IB_MAX_RECVS : 0;
+  qpInitAttr.cap.max_inline_data = IbCastUseInline ? sizeof(struct ncclIbSendFifo) * NCCL_NET_IB_MAX_RECVS : 0;
   if (createQpAttrs->isCtsEnabled) {
     qpInitAttr.cap.max_inline_data = MAX_INLINE_DATA_SIZE;
   }
@@ -404,7 +412,7 @@ static ncclResult_t ncclIbCreateQpIonic(struct ncclIbQpCreateAttr* createQpAttrs
     nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udId = lud;
     nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udAllocated = true;
     nccl_channel_last_ud[createQpAttrs->ibDevN][channel_type] =
-        !(nccl_channel_last_ud[createQpAttrs->ibDevN][channel_type]);
+      !(nccl_channel_last_ud[createQpAttrs->ibDevN][channel_type]);
   }
   if (nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udId) {
     wrap_ionicdv_pd_set_udma_mask(createQpAttrs->pd, IONIC_UDMA_MASK_HIGH);
@@ -442,8 +450,8 @@ void IbCastBuildDataQpCreateAttr(struct ncclIbNetCommBase* base, int devIndex, s
 
 ncclResult_t IbCastQpCreate(struct ncclIbQp* qp, struct ncclIbQpCreateAttr* createQpAttrs) {
   if (createQpAttrs->oooRq) {
-     NCCLCHECK(ncclIbCreateQpMlx5(createQpAttrs, qp));
-     return ncclSuccess;
+    NCCLCHECK(ncclIbCreateQpMlx5(createQpAttrs, qp));
+    return ncclSuccess;
   }
   if (createQpAttrs->useIonic && createQpAttrs->type != IBV_QPT_UD) {
     NCCLCHECK(ncclIbCreateQpIonic(createQpAttrs, qp));
@@ -459,7 +467,7 @@ ncclResult_t IbCastQpCreate(struct ncclIbQp* qp, struct ncclIbQpCreateAttr* crea
   qpInitAttr.cap.max_send_wr = createQpAttrs->maxSendWorkRequest;
   qpInitAttr.cap.max_send_sge = 1;
   qpInitAttr.cap.max_recv_sge = 1;
-  qpInitAttr.cap.max_inline_data = IbCastUseInline ? sizeof(struct ncclIbSendFifo)*NCCL_NET_IB_MAX_RECVS : 0;
+  qpInitAttr.cap.max_inline_data = IbCastUseInline ? sizeof(struct ncclIbSendFifo) * NCCL_NET_IB_MAX_RECVS : 0;
   NCCLCHECK(wrap_ibv_create_qp(&qp->qp, createQpAttrs->pd, &qpInitAttr));
   return ncclSuccess;
 }
@@ -487,7 +495,7 @@ ncclResult_t IbCastQpRtr(struct ncclIbQp* qp) {
     qpAttr.ah_attr.grh.hop_limit = 255;
     qpAttr.ah_attr.grh.traffic_class = rtrAttr->tc;
   } else {
-    //pick lid if subnet prefixs are same, FLID if they are not
+    // pick lid if subnet prefixs are same, FLID if they are not
     if (IbCastExtractLocalSubnetPrefix(rtrAttr->localGid.global.subnet_prefix) ==
         IbCastExtractLocalSubnetPrefix(rtrAttr->remoteGid.global.subnet_prefix)) {
       qpAttr.ah_attr.is_global = 0;
@@ -495,7 +503,8 @@ ncclResult_t IbCastQpRtr(struct ncclIbQp* qp) {
     } else {
       uint16_t flid = IbCastExtractFlid(&rtrAttr->remoteGid);
       if (flid == 0) {
-        WARN("Warning: remote FLID configured as zero even when endpoints are on different subnets, using dlid as fallback");
+        WARN("Warning: remote FLID configured as zero even when endpoints are on different subnets, using dlid as "
+             "fallback");
         qpAttr.ah_attr.dlid = rtrAttr->remoteLid;
       } else {
         qpAttr.ah_attr.dlid = IbCastExtractFlid(&rtrAttr->remoteGid);
@@ -510,7 +519,9 @@ ncclResult_t IbCastQpRtr(struct ncclIbQp* qp) {
   qpAttr.ah_attr.sl = rtrAttr->sl;
   qpAttr.ah_attr.src_path_bits = 0;
   qpAttr.ah_attr.port_num = rtrAttr->localIbPort;
-  TRACE(NCCL_NET, "NET/IB: %s: qpn=%u mtu=%d dst=%u ll=%u port=%u sl: %d tc: %d", __func__, qp->qp->qp_num, qpAttr.path_mtu, qpAttr.dest_qp_num, rtrAttr->linkLayer, qpAttr.ah_attr.port_num, qpAttr.ah_attr.sl, qpAttr.ah_attr.grh.traffic_class);
+  TRACE(NCCL_NET, "NET/IB: %s: qpn=%u mtu=%d dst=%u ll=%u port=%u sl: %d tc: %d", __func__, qp->qp->qp_num,
+        qpAttr.path_mtu, qpAttr.dest_qp_num, rtrAttr->linkLayer, qpAttr.ah_attr.port_num, qpAttr.ah_attr.sl,
+        qpAttr.ah_attr.grh.traffic_class);
   NCCLCHECK(wrap_ibv_modify_qp(qp->qp, &qpAttr, attrMask));
   return ncclSuccess;
 }
@@ -553,7 +564,7 @@ ncclResult_t IbCastListen(void* ctx, int dev, void* opaqueHandle, void** listenC
   ncclResult_t ret = ncclSuccess;
   struct ncclIbListenComm* comm;
   NCCLCHECK(ncclCalloc(&comm, 1));
-  struct ncclIbHandle* handle = (struct ncclIbHandle*) opaqueHandle;
+  struct ncclIbHandle* handle = (struct ncclIbHandle*)opaqueHandle;
   static_assert(sizeof(struct ncclIbHandle) < NCCL_NET_HANDLE_MAXSIZE, "ncclIbHandle size too large");
   memset(handle, 0, sizeof(struct ncclIbHandle));
   comm->dev = dev;
@@ -587,7 +598,7 @@ static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbCon
   qpCreateAttrs.type = IBV_QPT_RC;
   qpCreateAttrs.maxRecvWorkRequest = 0;
   // Send requests are sent using at most 2 messages (RDMA Write and RDMA Write with Immediate)
-  qpCreateAttrs.maxSendWorkRequest = 2*NET_IB_MAX_REQUESTS;
+  qpCreateAttrs.maxSendWorkRequest = 2 * NET_IB_MAX_REQUESTS;
   for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
     // The QPs are created in a "striped" manner across the available devices.
     // For example, if there are 2 devices and 4 QPs, the QPs will be created
@@ -613,36 +624,32 @@ static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbCon
 
     if (ibDev->ibProvider == IB_PROVIDER_MLX5 && ncclParamIbCastOooRq()) {
       if (ibDev->ar == 0) {
-        WARN("NET/IB: %s: OOO RQ is force enabled but AR is not enabled, which is required for OOO RQ (device=%s)", __func__, ibDev->devName);
+        WARN("NET/IB: %s: OOO RQ is force enabled but AR is not enabled, which is required for OOO RQ (device=%s)",
+             __func__, ibDev->devName);
         return ncclInternalError;
       }
       qpCreateAttrs.oooRq = (comm->base.remOooRq && comm->base.localOooRq);
       if (!qpCreateAttrs.oooRq) {
-        WARN("NET/IB: %s: OOO RQ is force enabled but not supported on both sides of the connection (device=%s, localOooRq=%d, remOooRq=%d)",
-          __func__, ibDev->devName, comm->base.localOooRq, comm->base.remOooRq);
+        WARN("NET/IB: %s: OOO RQ is force enabled but not supported on both sides of the connection (device=%s, "
+             "localOooRq=%d, remOooRq=%d)",
+             __func__, ibDev->devName, comm->base.localOooRq, comm->base.remOooRq);
         return ncclInternalError;
       }
     }
 
     NCCLCHECK(IbCastQpCreate(localQp, &qpCreateAttrs));
 
-    INFO(NCCL_NET, "NET/IB: %s: QP created: port=%d dev=%d devName=%s ndevs=%d nmdevs=%d qp_num=%u pkey=%u pd=%p oooRq=%d",
-        __func__,
-        ibDev->portNum,
-        commDev->base.ibDevN,
-        IbCastDevs[commDev->base.ibDevN].devName,
-        IbCastNDevs,
-        IbCastNMergedDevs,
-        localQp->qp->qp_num,
-        (uint16_t)ncclParamIbCastPkey(),
-        commDev->base.pd,
-        qpCreateAttrs.oooRq);
+    INFO(NCCL_NET,
+         "NET/IB: %s: QP created: port=%d dev=%d devName=%s ndevs=%d nmdevs=%d qp_num=%u pkey=%u pd=%p oooRq=%d",
+         __func__, ibDev->portNum, commDev->base.ibDevN, IbCastDevs[commDev->base.ibDevN].devName, IbCastNDevs,
+         IbCastNMergedDevs, localQp->qp->qp_num, (uint16_t)ncclParamIbCastPkey(), commDev->base.pd,
+         qpCreateAttrs.oooRq);
     localQp->devIndex = devIndex;
     localQp->channelId = channelId;
     localQp->isDataQp = qpCreateAttrs.isDataQp;
 
     // Populate the metadata that will be delivered to the remote peer
-    localQpInfo->qpn      = localQp->qp->qp_num;
+    localQpInfo->qpn = localQp->qp->qp_num;
     localQpInfo->devIndex = localQp->devIndex;
 
     // Transition the QP to INIT state
@@ -688,13 +695,17 @@ static ncclResult_t IbCastSenderQpsToRts(ncclIbSendComm* comm, struct ncclIbConn
     ncclIbQp* localQp = &comm->base.qps[qpIndex];
     ncclIbSendCommDev* commDev = &comm->devs[localQp->devIndex];
     ncclIbDev* ibDev = &IbCastDevs[commDev->base.ibDevN];
-    ncclIbQpInfo* remQpInfo   = &remMeta->qpInfo[qpIndex];
+    ncclIbQpInfo* remQpInfo = &remMeta->qpInfo[qpIndex];
     ncclIbDevInfo* remDevInfo = &remMeta->devs[remQpInfo->devIndex];
 
     localQp->remDevIdx = remQpInfo->devIndex;
 
     if (localQp->eceSupported && remQpInfo->ece_supported) {
-      INFO(NCCL_NET,"NET/IB: %s: Set ECE: IbDev %d Port %d qp_num %d set_ece={supported=%d, vendor_id=0x%x, options=0x%x, comp_mask=0x%x}", __func__, commDev->base.ibDevN, ibDev->portNum, localQp->qp->qp_num, remQpInfo->ece_supported, remQpInfo->ece.vendor_id, remQpInfo->ece.options, remQpInfo->ece.comp_mask);
+      INFO(NCCL_NET,
+           "NET/IB: %s: Set ECE: IbDev %d Port %d qp_num %d set_ece={supported=%d, vendor_id=0x%x, options=0x%x, "
+           "comp_mask=0x%x}",
+           __func__, commDev->base.ibDevN, ibDev->portNum, localQp->qp->qp_num, remQpInfo->ece_supported,
+           remQpInfo->ece.vendor_id, remQpInfo->ece.options, remQpInfo->ece.comp_mask);
       // Set the reduced ECE received from the receiver side
       NCCLCHECK(wrap_ibv_set_ece(localQp->qp, &remQpInfo->ece, &localQp->eceSupported));
       // Store the reduced ECE locally as well
@@ -705,7 +716,7 @@ static ncclResult_t IbCastSenderQpsToRts(ncclIbSendComm* comm, struct ncclIbConn
       localQp->ece = {0};
     }
 
-    struct ncclIbQpRtrAttr *rtrAttr = &localQp->rtrAttr;
+    struct ncclIbQpRtrAttr* rtrAttr = &localQp->rtrAttr;
     rtrAttr->mtu = std::min(remDevInfo->mtu, ibDev->portAttr.active_mtu);
     rtrAttr->linkLayer = remDevInfo->link_layer;
     rtrAttr->tc = remDevInfo->link_layer == IBV_LINK_LAYER_ETHERNET ? remMeta->tc : -1;
@@ -740,28 +751,29 @@ void IbCastSetTrafficClass(void* ctx, int trafficClass) {
   if (config) config->trafficClass = trafficClass;
 }
 
-ncclResult_t IbCastConnect(void* ctx, int dev, void* opaqueHandle, void** sendComm, ncclNetDeviceHandle_t** sendDevComm) {
+ncclResult_t IbCastConnect(void* ctx, int dev, void* opaqueHandle, void** sendComm,
+                           ncclNetDeviceHandle_t** sendDevComm) {
   ncclResult_t ret = ncclSuccess;
-  struct ncclIbHandle* handle = (struct ncclIbHandle*) opaqueHandle;
+  struct ncclIbHandle* handle = (struct ncclIbHandle*)opaqueHandle;
   struct ncclIbCommStage* stage = &handle->stage;
   struct ncclIbSendComm* comm = (struct ncclIbSendComm*)stage->comm;
   int ready;
 
   uint8_t link_layer = IBV_LINK_LAYER_UNSPECIFIED;
   int channelId = 0;
-  int isP2p = 0; 
+  int isP2p = 0;
   *sendComm = NULL;
 
   if (IbCastAinicRoce && sendDevComm) {
-    channelId = ((ncclNet_ctxt_t *)sendDevComm)->chId;
+    channelId = ((ncclNet_ctxt_t*)sendDevComm)->chId;
   }
 
-  if (stage->state == ncclIbCommStateConnect)      goto ib_connect_check;
-  if (stage->state == ncclIbCommStateSendDevList)  goto ib_send_dev_list;
-  if (stage->state == ncclIbCommStateRecvDevList)  goto ib_recv_dev_list;
-  if (stage->state == ncclIbCommStateSend)         goto ib_send;
-  if (stage->state == ncclIbCommStateConnecting)   goto ib_connect;
-  if (stage->state == ncclIbCommStateConnected)    goto ib_send_ready;
+  if (stage->state == ncclIbCommStateConnect) goto ib_connect_check;
+  if (stage->state == ncclIbCommStateSendDevList) goto ib_send_dev_list;
+  if (stage->state == ncclIbCommStateRecvDevList) goto ib_recv_dev_list;
+  if (stage->state == ncclIbCommStateSend) goto ib_send;
+  if (stage->state == ncclIbCommStateConnecting) goto ib_connect;
+  if (stage->state == ncclIbCommStateConnected) goto ib_send_ready;
   if (stage->state != ncclIbCommStateStart) {
     WARN("Error: trying to connect already connected sendComm");
     return ncclInternalError;
@@ -771,7 +783,8 @@ ncclResult_t IbCastConnect(void* ctx, int dev, void* opaqueHandle, void** sendCo
   NCCLCHECK(ncclIbMalloc((void**)&comm, sizeof(struct ncclIbSendComm)));
   NCCLCHECKGOTO(IbCastSendCommInit(comm), ret, fail);
   NCCLCHECKGOTO(IbCastStatsInit(&comm->base.stats), ret, fail);
-  NCCLCHECKGOTO(ncclSocketInit(&comm->base.sock, &handle->connectAddr, handle->magic, ncclSocketTypeNetIb, NULL, 1), ret, fail);
+  NCCLCHECKGOTO(ncclSocketInit(&comm->base.sock, &handle->connectAddr, handle->magic, ncclSocketTypeNetIb, NULL, 1),
+                ret, fail);
   stage->comm = comm;
   stage->state = ncclIbCommStateConnect;
   NCCLCHECKGOTO(ncclSocketConnect(&comm->base.sock), ret, fail);
@@ -803,24 +816,26 @@ ib_connect_check:
     exProps.oooRq = exProps.oooRq && IbCastDevs[ibDevN].oooRqSize;
   }
   comm->base.localOooRq = exProps.oooRq;
-  memcpy((char *)stage->buffer + sizeof(ncclNetVDeviceProps_t), &exProps, sizeof(struct ncclIbDevExtraProps));
+  memcpy((char*)stage->buffer + sizeof(ncclNetVDeviceProps_t), &exProps, sizeof(struct ncclIbDevExtraProps));
 
 // In the case of mismatched nDevs, we will make sure that both sides of a logical connection have the same number of RC qps
 ib_send_dev_list:
-  NCCLCHECK(ncclSocketProgress(NCCL_SOCKET_SEND, &comm->base.sock, stage->buffer, sizeof(ncclNetVDeviceProps_t) + sizeof(struct ncclIbDevExtraProps), &stage->offset));
+  NCCLCHECK(ncclSocketProgress(NCCL_SOCKET_SEND, &comm->base.sock, stage->buffer,
+                               sizeof(ncclNetVDeviceProps_t) + sizeof(struct ncclIbDevExtraProps), &stage->offset));
   if (stage->offset != (sizeof(ncclNetVDeviceProps_t) + sizeof(struct ncclIbDevExtraProps))) return ncclSuccess;
 
   stage->state = ncclIbCommStateRecvDevList;
   stage->offset = 0;
 
 ib_recv_dev_list:
-  NCCLCHECK(ncclSocketProgress(NCCL_SOCKET_RECV, &comm->base.sock, stage->buffer, sizeof(ncclNetVDeviceProps_t) + sizeof(struct ncclIbDevExtraProps), &stage->offset));
+  NCCLCHECK(ncclSocketProgress(NCCL_SOCKET_RECV, &comm->base.sock, stage->buffer,
+                               sizeof(ncclNetVDeviceProps_t) + sizeof(struct ncclIbDevExtraProps), &stage->offset));
   if (stage->offset != (sizeof(ncclNetVDeviceProps_t) + sizeof(struct ncclIbDevExtraProps))) return ncclSuccess;
   stage->offset = 0;
   ncclNetVDeviceProps_t remoteVProps;
   int trafficClass;
   memcpy(&remoteVProps, stage->buffer, sizeof(ncclNetVDeviceProps_t));
-  memcpy(&exProps, (char *)stage->buffer + sizeof(ncclNetVDeviceProps_t), sizeof(exProps));
+  memcpy(&exProps, (char*)stage->buffer + sizeof(ncclNetVDeviceProps_t), sizeof(exProps));
   comm->base.remOooRq = exProps.oooRq;
 
   mergedDev = IbCastMergedDevs + dev;
@@ -833,8 +848,7 @@ ib_recv_dev_list:
   }
 
   INFO(NCCL_NET, "NET/IB: IbCastConnect isP2p=%d isRMA=%d", isP2p, handle->isRMA);
-  comm->base.nqps = IbCastCalculateNqps(isP2p, comm->base.vProps.ndevs, 
-                                         remoteVProps.ndevs, __func__);
+  comm->base.nqps = IbCastCalculateNqps(isP2p, comm->base.vProps.ndevs, remoteVProps.ndevs, __func__);
   if (handle->isRMA) {
     comm->base.nqps = 1;
   }
@@ -850,7 +864,7 @@ ib_recv_dev_list:
   // Sender's CQ size needs to accomodate the upper bound of number of send
   // requests multiplied by the number of QPs used per request.
   int cqSize;
-  cqSize = 3*NET_IB_MAX_REQUESTS*ncclParamIbCastQpsPerConn();
+  cqSize = 3 * NET_IB_MAX_REQUESTS * ncclParamIbCastQpsPerConn();
   for (int i = 0; i < comm->base.vProps.ndevs; i++) {
     int ibDevN = comm->base.vProps.devs[i];
     if (comm->base.resiliency) {
@@ -877,22 +891,30 @@ ib_recv_dev_list:
 
     // Write to the metadata struct via this pointer
     ncclIbDevInfo* devInfo = meta.devs + i;
-    devInfo->ib_port       = ibDev->portNum;
-    devInfo->mtu           = ibDev->portAttr.active_mtu;
-    devInfo->lid           = ibDev->portAttr.lid;
+    devInfo->ib_port = ibDev->portNum;
+    devInfo->mtu = ibDev->portAttr.active_mtu;
+    devInfo->lid = ibDev->portAttr.lid;
     devInfo->ibv_dev_index = commDev->base.ibDevN;
 
     // Prepare GIN Put Signal scratchpad (for RDMA Atomic result)
-    NCCLCHECKGOTO(wrap_ibv_reg_mr(&commDev->putSignalScratchpadMr, commDev->base.pd, &comm->putSignalScratchpad, sizeof(comm->putSignalScratchpad), IBV_ACCESS_LOCAL_WRITE), ret, fail);
+    NCCLCHECKGOTO(wrap_ibv_reg_mr(&commDev->putSignalScratchpadMr, commDev->base.pd, &comm->putSignalScratchpad,
+                                  sizeof(comm->putSignalScratchpad), IBV_ACCESS_LOCAL_WRITE),
+                  ret, fail);
 
     // Prepare my CTS FIFO
-    NCCLCHECKGOTO(wrap_ibv_reg_mr(&commDev->ctsFifoMr, commDev->base.pd, comm->ctsFifo, sizeof(comm->ctsFifo), IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
+    NCCLCHECKGOTO(wrap_ibv_reg_mr(&commDev->ctsFifoMr, commDev->base.pd, comm->ctsFifo, sizeof(comm->ctsFifo),
+                                  IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ),
+                  ret, fail);
     devInfo->rkey = commDev->ctsFifoMr->rkey;
 
     // Pack local GID info
     devInfo->link_layer = commDev->base.gidInfo.link_layer = ibDev->portAttr.link_layer;
-    NCCLCHECKGOTO(IbCastGetGidIndex(ibDev->context, ibDev->portNum, &ibDev->portAttr, &commDev->base.gidInfo.localGidIndex), ret, fail);
-    NCCLCHECKGOTO(wrap_ibv_query_gid(ibDev->context, ibDev->portNum, commDev->base.gidInfo.localGidIndex, &commDev->base.gidInfo.localGid), ret, fail);
+    NCCLCHECKGOTO(IbCastGetGidIndex(ibDev->context, ibDev->portNum, &ibDev->portAttr,
+                                    &commDev->base.gidInfo.localGidIndex),
+                  ret, fail);
+    NCCLCHECKGOTO(wrap_ibv_query_gid(ibDev->context, ibDev->portNum, commDev->base.gidInfo.localGidIndex,
+                                     &commDev->base.gidInfo.localGid),
+                  ret, fail);
     devInfo->gid.global.subnet_prefix = commDev->base.gidInfo.localGid.global.subnet_prefix;
     devInfo->gid.global.interface_id = commDev->base.gidInfo.localGid.global.interface_id;
 
@@ -901,37 +923,50 @@ ib_recv_dev_list:
       // Print just the QPs for this dev
       if (comm->base.qps[q].devIndex == i) {
         if (devInfo->link_layer == IBV_LINK_LAYER_INFINIBAND) { // IB
-          INFO(NCCL_NET,"NET/IB: %s: %s %d IbDev %d Port %d qp_num %d mtu %d LID %d subnet-prefix %lu  FLID %d ctsFifoRkey=0x%x ctsFifoLkey=0x%x", __func__,
-               comm->base.vProps.ndevs > 2 ? "NCCL MergedDev" : "NCCL Dev",
-               dev, commDev->base.ibDevN, ibDev->portNum, meta.qpInfo[q].qpn, devInfo->mtu, devInfo->lid,
-               (uint64_t)devInfo->gid.global.subnet_prefix, IbCastExtractFlid(&devInfo->gid), commDev->ctsFifoMr->rkey, commDev->ctsFifoMr->lkey);
+          INFO(NCCL_NET,
+               "NET/IB: %s: %s %d IbDev %d Port %d qp_num %d mtu %d LID %d subnet-prefix %lu  FLID %d ctsFifoRkey=0x%x "
+               "ctsFifoLkey=0x%x",
+               __func__, comm->base.vProps.ndevs > 2 ? "NCCL MergedDev" : "NCCL Dev", dev, commDev->base.ibDevN,
+               ibDev->portNum, meta.qpInfo[q].qpn, devInfo->mtu, devInfo->lid,
+               (uint64_t)devInfo->gid.global.subnet_prefix, IbCastExtractFlid(&devInfo->gid), commDev->ctsFifoMr->rkey,
+               commDev->ctsFifoMr->lkey);
         } else { // RoCE
-          INFO(NCCL_NET,"NET/IB: %s: %s %d IbDev %d Port %d qp_num %d mtu %d GID %ld (%lX/%lX) ctsFifoRkey=0x%x ctsFifoLkey=0x%x", __func__,
-               comm->base.vProps.ndevs > 2 ? "NCCL MergedDev" : "NCCL Dev", dev,
-               commDev->base.ibDevN, ibDev->portNum, meta.qpInfo[q].qpn, devInfo->mtu,
-               (int64_t)commDev->base.gidInfo.localGidIndex,
-               (uint64_t)devInfo->gid.global.subnet_prefix, devInfo->gid.global.interface_id, commDev->ctsFifoMr->rkey, commDev->ctsFifoMr->lkey);
+          INFO(
+            NCCL_NET,
+            "NET/IB: %s: %s %d IbDev %d Port %d qp_num %d mtu %d GID %ld (%lX/%lX) ctsFifoRkey=0x%x ctsFifoLkey=0x%x",
+            __func__, comm->base.vProps.ndevs > 2 ? "NCCL MergedDev" : "NCCL Dev", dev, commDev->base.ibDevN,
+            ibDev->portNum, meta.qpInfo[q].qpn, devInfo->mtu, (int64_t)commDev->base.gidInfo.localGidIndex,
+            (uint64_t)devInfo->gid.global.subnet_prefix, devInfo->gid.global.interface_id, commDev->ctsFifoMr->rkey,
+            commDev->ctsFifoMr->lkey);
         }
         // Log ECE info
         if (meta.qpInfo[q].ece_supported) {
-          INFO(NCCL_NET,"NET/IB: %s: IbDev %d Port %d qp_num %d query_ece={supported=%d, vendor_id=0x%x, options=0x%x, comp_mask=0x%x}", __func__,
-               commDev->base.ibDevN, ibDev->portNum, meta.qpInfo[q].qpn,
-               meta.qpInfo[q].ece_supported, meta.qpInfo[q].ece.vendor_id, meta.qpInfo[q].ece.options, meta.qpInfo[q].ece.comp_mask);
+          INFO(NCCL_NET,
+               "NET/IB: %s: IbDev %d Port %d qp_num %d query_ece={supported=%d, vendor_id=0x%x, options=0x%x, "
+               "comp_mask=0x%x}",
+               __func__, commDev->base.ibDevN, ibDev->portNum, meta.qpInfo[q].qpn, meta.qpInfo[q].ece_supported,
+               meta.qpInfo[q].ece.vendor_id, meta.qpInfo[q].ece.options, meta.qpInfo[q].ece.comp_mask);
         }
       }
     }
     if (link_layer == IBV_LINK_LAYER_UNSPECIFIED) link_layer = devInfo->link_layer;
     if (link_layer != devInfo->link_layer) {
       int ibDev0 = comm->devs[0].base.ibDevN;
-      WARN("NET/IB : Attempted to connect incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of only one link type using NCCL_IB_HCA",
-           commDev->base.ibDevN, ibDev->devName, ibDev->portNum, NCCL_IB_LLSTR(ibDev->portAttr.link_layer), ibDev0, IbCastDevs[ibDev0].devName, IbCastDevs[ibDev0].portNum, NCCL_IB_LLSTR(link_layer));
+      WARN("NET/IB : Attempted to connect incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of "
+           "only one link type using NCCL_IB_HCA",
+           commDev->base.ibDevN, ibDev->devName, ibDev->portNum, NCCL_IB_LLSTR(ibDev->portAttr.link_layer), ibDev0,
+           IbCastDevs[ibDev0].devName, IbCastDevs[ibDev0].portNum, NCCL_IB_LLSTR(link_layer));
       return ncclInternalError;
     }
   }
   trafficClass = IbCastGetTrafficClass(ctx);
   meta.addr = (uint64_t)comm->ctsFifo;
-  meta.sl = (ncclParamIbCastSl() != -1) ? ncclParamIbCastSl() : (trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? trafficClass : NCCL_IB_SL_DEFAULT;
-  meta.tc = (ncclParamIbCastTc() != -1) ? ncclParamIbCastTc() : (trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? trafficClass : NCCL_IB_TC_DEFAULT;
+  meta.sl = (ncclParamIbCastSl() != -1)                    ? ncclParamIbCastSl() :
+            (trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? trafficClass :
+                                                             NCCL_IB_SL_DEFAULT;
+  meta.tc = (ncclParamIbCastTc() != -1)                    ? ncclParamIbCastTc() :
+            (trafficClass != NCCL_NET_TRAFFIC_CLASS_UNDEF) ? trafficClass :
+                                                             NCCL_IB_TC_DEFAULT;
   strncpy(meta.devName, mergedDev->devName, MAX_MERGED_DEV_NAME);
 
   stage->state = ncclIbCommStateSend;
@@ -940,7 +975,8 @@ ib_recv_dev_list:
   memcpy(stage->buffer, &meta, sizeof(meta));
 
 ib_send:
-  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_SEND, &comm->base.sock, stage->buffer, sizeof(meta), &stage->offset), ret, fail);
+  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_SEND, &comm->base.sock, stage->buffer, sizeof(meta), &stage->offset),
+                ret, fail);
   if (stage->offset != sizeof(meta)) return ncclSuccess;
 
   stage->state = ncclIbCommStateConnecting;
@@ -950,7 +986,9 @@ ib_send:
 
 ib_connect:
   struct ncclIbConnectionMetadata remMeta;
-  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_RECV, &comm->base.sock, stage->buffer, sizeof(ncclIbConnectionMetadata), &stage->offset), ret, fail);
+  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_RECV, &comm->base.sock, stage->buffer, sizeof(ncclIbConnectionMetadata),
+                                   &stage->offset),
+                ret, fail);
   if (stage->offset != sizeof(remMeta)) return ncclSuccess;
 
   memcpy(&remMeta, stage->buffer, sizeof(ncclIbConnectionMetadata));
@@ -961,8 +999,10 @@ ib_connect:
     link_layer = IbCastDevs[ibDev0].portAttr.link_layer;
     for (int i = 0; i < remMeta.ndevs; i++) {
       if (remMeta.devs[i].link_layer != link_layer) {
-        WARN("NET/IB : Remote %s device is incompatible with the local [%d]%s:%d/%s. Try selecting NICs of only one link type using NCCL_IB_HCA",
-             NCCL_IB_LLSTR(remMeta.devs[i].link_layer), ibDev0, IbCastDevs[ibDev0].devName, IbCastDevs[ibDev0].portNum, NCCL_IB_LLSTR(link_layer));
+        WARN("NET/IB : Remote %s device is incompatible with the local [%d]%s:%d/%s. Try selecting NICs of only one "
+             "link type using NCCL_IB_HCA",
+             NCCL_IB_LLSTR(remMeta.devs[i].link_layer), ibDev0, IbCastDevs[ibDev0].devName, IbCastDevs[ibDev0].portNum,
+             NCCL_IB_LLSTR(link_layer));
         return ncclInternalError;
       }
     }
@@ -983,13 +1023,18 @@ ib_connect:
   for (int i = 0; i < comm->base.nRemDevs; i++) {
     comm->remCmplsRecords.rkeys[i] = remMeta.devs[i].rkey;
     if (comm->base.resiliency) {
-      NCCLCHECKGOTO(IbCastResiliencyRemoteCompletionRecordsSet(comm->base.resiliency, comm->remCmplsRecords.rkeys[i], comm->remCmplsRecords.addr, i), ret, fail);
+      NCCLCHECKGOTO(IbCastResiliencyRemoteCompletionRecordsSet(comm->base.resiliency, comm->remCmplsRecords.rkeys[i],
+                                                               comm->remCmplsRecords.addr, i),
+                    ret, fail);
     }
   }
 
-  for (int i=0; i < comm->base.vProps.ndevs; i++) {
+  for (int i = 0; i < comm->base.vProps.ndevs; i++) {
     ncclIbSendCommDev* commDev = comm->devs + i;
-    NCCLCHECKGOTO(wrap_ibv_reg_mr(&commDev->cmplsRecordsMr, comm->devs[i].base.pd, &comm->remCmplsRecords.elems, sizeof(comm->remCmplsRecords.elems), IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
+    NCCLCHECKGOTO(wrap_ibv_reg_mr(&commDev->cmplsRecordsMr, comm->devs[i].base.pd, &comm->remCmplsRecords.elems,
+                                  sizeof(comm->remCmplsRecords.elems),
+                                  IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ),
+                  ret, fail);
     comm->devs[i].sge.lkey = comm->devs[i].cmplsRecordsMr->lkey;
   }
 
@@ -1000,7 +1045,8 @@ ib_connect:
   stage->offset = 0;
 
 ib_send_ready:
-  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_SEND, &comm->base.sock, &comm->base.ready, sizeof(int), &stage->offset), ret, fail);
+  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_SEND, &comm->base.sock, &comm->base.ready, sizeof(int), &stage->offset),
+                ret, fail);
   if (stage->offset != sizeof(int)) return ncclSuccess;
 
   *sendComm = comm;
@@ -1016,7 +1062,7 @@ fail:
 NCCL_PARAM(IbCastWarnRailLocal, "IB_WARN_RAIL_LOCAL", 0);
 
 ncclResult_t IbCastCheckVProps(ncclNetVDeviceProps_t* vProps1, ncclNetVDeviceProps_t* vProps2) {
-  ncclNetVDeviceProps_t  outVProps = {0};
+  ncclNetVDeviceProps_t outVProps = {0};
   ncclNetVDeviceProps_t* minVProps = vProps2;
   ncclNetVDeviceProps_t* maxVProps = vProps1;
   if (vProps2->ndevs > vProps1->ndevs) {
@@ -1041,17 +1087,20 @@ ncclResult_t IbCastCheckVProps(ncclNetVDeviceProps_t* vProps1, ncclNetVDevicePro
     int cursor = 1;
     snprintf(local, sizeof(local), "%d", vProps1->devs[0]);
     for (int i = 1; i < vProps1->ndevs; i++) {
-      snprintf(local+cursor, sizeof(local)-cursor, ",%d", vProps1->devs[i]);
+      snprintf(local + cursor, sizeof(local) - cursor, ",%d", vProps1->devs[i]);
       cursor += 2;
     }
     char remote[128];
     snprintf(remote, sizeof(remote), "%d", vProps2->devs[0]);
     cursor = 1;
     for (int i = 1; i < vProps2->ndevs; i++) {
-      snprintf(remote+cursor, sizeof(remote)-cursor, ",%d", vProps2->devs[i]);
+      snprintf(remote + cursor, sizeof(remote) - cursor, ",%d", vProps2->devs[i]);
       cursor += 2;
     }
-    INFO(NCCL_NET, "NET/IB : There are mismatched physical devices between local (%s) and remote (%s). To disable this warning, set NCCL_IB_WARN_RAIL_LOCAL=0", local, remote);
+    INFO(NCCL_NET,
+         "NET/IB : There are mismatched physical devices between local (%s) and remote (%s). To disable this warning, "
+         "set NCCL_IB_WARN_RAIL_LOCAL=0",
+         local, remote);
   }
 
   return ncclSuccess;
@@ -1062,7 +1111,8 @@ ncclResult_t IbCastCheckVProps(ncclNetVDeviceProps_t* vProps1, ncclNetVDevicePro
 // the remote metadata structure, provided to the function (remMeta), with the
 // QPs' information so that data structure could be delivered to the remote
 // side (sender) as part of the connection establishment process.
-static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct ncclIbConnectionMetadata* remMeta, struct ncclIbConnectionMetadata* meta, int channelId) {
+static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct ncclIbConnectionMetadata* remMeta,
+                                                 struct ncclIbConnectionMetadata* meta, int channelId) {
   uint nqps = rComm->base.nqps;
   struct ncclIbQpCreateAttr qpCreateAttrs;
   memset(&qpCreateAttrs, 0, sizeof(struct ncclIbQpCreateAttr));
@@ -1108,20 +1158,23 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
     }
     if (ibDev->ibProvider == IB_PROVIDER_MLX5 && ncclParamIbCastOooRq()) {
       if (ibDev->ar == 0) {
-        WARN("NET/IB: %s: OOO RQ is force enabled but AR is not enabled, which is required for OOO RQ (device=%s)", __func__, ibDev->devName);
+        WARN("NET/IB: %s: OOO RQ is force enabled but AR is not enabled, which is required for OOO RQ (device=%s)",
+             __func__, ibDev->devName);
         return ncclInternalError;
       }
       qpCreateAttrs.oooRq = (rComm->base.remOooRq && rComm->base.localOooRq);
       // out-of-order recv prerequisite: oooRq is supported on both sides
       if (!qpCreateAttrs.oooRq) {
-        WARN("NET/IB: %s: OOO RQ is force enabled but not supported on both sides of the connection (device=%s, localOooRq=%d, remOooRq=%d)",
-          __func__, ibDev->devName, rComm->base.localOooRq, rComm->base.remOooRq);
+        WARN("NET/IB: %s: OOO RQ is force enabled but not supported on both sides of the connection (device=%s, "
+             "localOooRq=%d, remOooRq=%d)",
+             __func__, ibDev->devName, rComm->base.localOooRq, rComm->base.remOooRq);
         return ncclInternalError;
       }
       // out-of-order recv prerequisite: oooRq size requirements are met
       if (ibDev->oooRqSize < qpCreateAttrs.maxRecvWorkRequest) {
-        WARN("NET/IB: %s: OOO RQ is force enabled but size %u is less than the required recv work request size %u on device:%s",
-          __func__, ibDev->oooRqSize, qpCreateAttrs.maxRecvWorkRequest, ibDev->devName);
+        WARN("NET/IB: %s: OOO RQ is force enabled but size %u is less than the required recv work request size %u on "
+             "device:%s",
+             __func__, ibDev->oooRqSize, qpCreateAttrs.maxRecvWorkRequest, ibDev->devName);
         return ncclInternalError;
       }
     }
@@ -1129,19 +1182,13 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
     localQp->channelId = channelId;
     localQp->isDataQp = qpCreateAttrs.isDataQp;
 
-    INFO(NCCL_NET, "NET/IB: %s: QP created: port=%d dev=%d devName=%s ndevs=%d nmdevs=%d qp_num=%u pkey=%u pd=%p oooRq=%d",
-        __func__,
-        ibDev->portNum,
-        rCommDev->base.ibDevN,
-        IbCastDevs[rCommDev->base.ibDevN].devName,
-        IbCastNDevs,
-        IbCastNMergedDevs,
-        localQp->qp->qp_num,
-        (uint16_t)ncclParamIbCastPkey(),
-        rCommDev->base.pd,
-        qpCreateAttrs.oooRq);
+    INFO(NCCL_NET,
+         "NET/IB: %s: QP created: port=%d dev=%d devName=%s ndevs=%d nmdevs=%d qp_num=%u pkey=%u pd=%p oooRq=%d",
+         __func__, ibDev->portNum, rCommDev->base.ibDevN, IbCastDevs[rCommDev->base.ibDevN].devName, IbCastNDevs,
+         IbCastNMergedDevs, localQp->qp->qp_num, (uint16_t)ncclParamIbCastPkey(), rCommDev->base.pd,
+         qpCreateAttrs.oooRq);
 
-    localQpInfo->qpn      = localQp->qp->qp_num;
+    localQpInfo->qpn = localQp->qp->qp_num;
     localQpInfo->devIndex = localQp->devIndex;
 
     // Transition the QP to INIT state
@@ -1166,10 +1213,12 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
     // Reduce the local MTU to match the remote MTU if needed
     ibDev->portAttr.active_mtu = std::min(ibDev->portAttr.active_mtu, remDevInfo->mtu);
 
-    struct ncclIbQpRtrAttr *rtrAttr = &localQp->rtrAttr;
+    struct ncclIbQpRtrAttr* rtrAttr = &localQp->rtrAttr;
     rtrAttr->mtu = ibDev->portAttr.active_mtu;
     rtrAttr->linkLayer = remDevInfo->link_layer;
-    rtrAttr->tc = (remDevInfo->link_layer == IBV_LINK_LAYER_ETHERNET && ncclParamIbCastFifoTc() != -1) ? ncclParamIbCastFifoTc() : remMeta->tc;
+    rtrAttr->tc = (remDevInfo->link_layer == IBV_LINK_LAYER_ETHERNET && ncclParamIbCastFifoTc() != -1) ?
+                    ncclParamIbCastFifoTc() :
+                    remMeta->tc;
     rtrAttr->sl = remMeta->sl;
     rtrAttr->remoteQpNum = remQpInfo->qpn;
     rtrAttr->remoteLid = remDevInfo->lid;
@@ -1220,16 +1269,10 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
       rCommDev->gpuFlush.qp.channelId = channelId;
       rCommDev->gpuFlush.qp.isDataQp = qpCreateAttrs.isDataQp;
 
-      INFO(NCCL_NET, "NET/IB: %s: Flush QP created: port=%d dev=%d devName=%s ndevs=%d nmdevs=%d qp_num=%u pkey=%u pd=%p",
-          __func__,
-          ibDev->portNum,
-          rCommDev->base.ibDevN,
-          IbCastDevs[rCommDev->base.ibDevN].devName,
-          IbCastNDevs,
-          IbCastNMergedDevs,
-          rCommDev->gpuFlush.qp.qp->qp_num,
-          (uint16_t)ncclParamIbCastPkey(),
-          rCommDev->base.pd);
+      INFO(NCCL_NET,
+           "NET/IB: %s: Flush QP created: port=%d dev=%d devName=%s ndevs=%d nmdevs=%d qp_num=%u pkey=%u pd=%p",
+           __func__, ibDev->portNum, rCommDev->base.ibDevN, IbCastDevs[rCommDev->base.ibDevN].devName, IbCastNDevs,
+           IbCastNMergedDevs, rCommDev->gpuFlush.qp.qp->qp_num, (uint16_t)ncclParamIbCastPkey(), rCommDev->base.pd);
 
       ncclIbQp* flushQp = &rCommDev->gpuFlush.qp;
 
@@ -1241,7 +1284,7 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
       initAttr->qpAccessFlags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_WRITE;
       NCCLCHECK(IbCastQpInit(flushQp));
 
-      struct ncclIbQpRtrAttr *rtrAttr = &flushQp->rtrAttr;
+      struct ncclIbQpRtrAttr* rtrAttr = &flushQp->rtrAttr;
       rtrAttr->mtu = ibDev->portAttr.active_mtu;
       rtrAttr->linkLayer = ibDev->portAttr.link_layer;
       // TODO: Flush QP is a "loopback QP" (connected to itself), so it should
@@ -1274,7 +1317,8 @@ ncclResult_t IbCastPostReceiveWorkRequestsOnQp(struct ncclIbRecvComm* recvComm, 
   if (recvComm->base.resiliency) {
     IbCastResiliencyDataRqSizeGet(recvComm->base.resiliency, dataQp->devIndex, &nRecvWorkRequestsPerQp);
   }
-  INFO(NCCL_NET, "NET/IB: %s: Pre-posting %d Receive WQEs on QP (qp_num=%d, comm=%p)", __func__, nRecvWorkRequestsPerQp, dataQp->qp->qp_num, recvComm);
+  INFO(NCCL_NET, "NET/IB: %s: Pre-posting %d Receive WQEs on QP (qp_num=%d, comm=%p)", __func__, nRecvWorkRequestsPerQp,
+       dataQp->qp->qp_num, recvComm);
   for (int j = 0; j < nRecvWorkRequestsPerQp; j++) {
     NCCLCHECK(IbCastPostRecvWorkRequest(dataQp->qp, &recvComm->ibRecvWorkRequest));
   }
@@ -1305,10 +1349,10 @@ ncclResult_t IbCastAccept(void* listenComm, void** recvComm, ncclNetDeviceHandle
   *recvComm = NULL;
 
   if (IbCastAinicRoce && recvDevComm) {
-    channelId = ((ncclNet_ctxt_t *) recvDevComm)->chId;
+    channelId = ((ncclNet_ctxt_t*)recvDevComm)->chId;
   }
 
-  if (stage->state == ncclIbCommStateAccept)   goto ib_accept_check;
+  if (stage->state == ncclIbCommStateAccept) goto ib_accept_check;
   if (stage->state == ncclIbCommStateRecvDevList) goto ib_recv_dev_list;
   if (stage->state == ncclIbCommStateSendDevList) goto ib_send_dev_list;
   if (stage->state == ncclIbCommStateRecv) goto ib_recv;
@@ -1341,7 +1385,8 @@ ib_accept_check:
 
 // In the case of mismatched nDevs, we will make sure that both sides of a logical connection have the same number of RC qps
 ib_recv_dev_list:
-  NCCLCHECK(ncclSocketProgress(NCCL_SOCKET_RECV, &rComm->base.sock, stage->buffer, sizeof(ncclNetVDeviceProps_t) + sizeof(struct ncclIbDevExtraProps), &stage->offset));
+  NCCLCHECK(ncclSocketProgress(NCCL_SOCKET_RECV, &rComm->base.sock, stage->buffer,
+                               sizeof(ncclNetVDeviceProps_t) + sizeof(struct ncclIbDevExtraProps), &stage->offset));
   if (stage->offset != (sizeof(ncclNetVDeviceProps_t) + sizeof(struct ncclIbDevExtraProps))) return ncclSuccess;
   ncclNetVDeviceProps_t remoteVProps;
   memcpy(&remoteVProps, stage->buffer, sizeof(ncclNetVDeviceProps_t));
@@ -1350,7 +1395,7 @@ ib_recv_dev_list:
     return ncclInternalError;
   }
 
-  memcpy(&exProps, (char *)stage->buffer + sizeof(ncclNetVDeviceProps_t), sizeof(exProps));
+  memcpy(&exProps, (char*)stage->buffer + sizeof(ncclNetVDeviceProps_t), sizeof(exProps));
   rComm->base.remOooRq = exProps.oooRq;
 
   // Reduce the physical device list and store in the connection base
@@ -1372,17 +1417,20 @@ ib_recv_dev_list:
     exProps.oooRq = exProps.oooRq && IbCastDevs[ibDevN].oooRqSize;
   }
   rComm->base.localOooRq = exProps.oooRq;
-  memcpy((char *)stage->buffer + sizeof(ncclNetVDeviceProps_t), &exProps, sizeof(struct ncclIbDevExtraProps));
+  memcpy((char*)stage->buffer + sizeof(ncclNetVDeviceProps_t), &exProps, sizeof(struct ncclIbDevExtraProps));
 
 ib_send_dev_list:
-  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_SEND, &rComm->base.sock, stage->buffer, sizeof(ncclNetVDeviceProps_t) + sizeof(struct ncclIbDevExtraProps), &stage->offset), ret, fail);
+  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_SEND, &rComm->base.sock, stage->buffer,
+                                   sizeof(ncclNetVDeviceProps_t) + sizeof(struct ncclIbDevExtraProps), &stage->offset),
+                ret, fail);
   if (stage->offset != (sizeof(ncclNetVDeviceProps_t) + sizeof(struct ncclIbDevExtraProps))) return ncclSuccess;
 
   stage->offset = 0;
   stage->state = ncclIbCommStateRecv;
 
 ib_recv:
-  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_RECV, &rComm->base.sock, stage->buffer, sizeof(remMeta), &stage->offset), ret, fail);
+  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_RECV, &rComm->base.sock, stage->buffer, sizeof(remMeta), &stage->offset),
+                ret, fail);
   if (stage->offset != sizeof(remMeta)) return ncclSuccess;
 
   /* copy back the received info */
@@ -1392,9 +1440,9 @@ ib_recv:
   if (rComm->useCtsOffload) {
     rComm->base.recvMatchingScheme = BY_ORDER;
   }
-  INFO(NCCL_NET, "NET/IB: ncclIbAccept isP2p=%d useCtsOffload=%d (IbP2pDisableCts=%d)", remMeta.isP2p, rComm->useCtsOffload, rcclParamIbCastP2pDisableCts());
-  rComm->base.nqps = IbCastCalculateNqps(remMeta.isP2p, rComm->base.vProps.ndevs,
-                                         remMeta.ndevs, __func__);
+  INFO(NCCL_NET, "NET/IB: ncclIbAccept isP2p=%d useCtsOffload=%d (IbP2pDisableCts=%d)", remMeta.isP2p,
+       rComm->useCtsOffload, rcclParamIbCastP2pDisableCts());
+  rComm->base.nqps = IbCastCalculateNqps(remMeta.isP2p, rComm->base.vProps.ndevs, remMeta.ndevs, __func__);
   rComm->base.nDataQps = std::max(rComm->base.vProps.ndevs, remMeta.ndevs);
 
   // IB setup
@@ -1407,7 +1455,7 @@ ib_recv:
 
   if (remMeta.ndevs != rComm->base.vProps.ndevs) {
     INFO(NCCL_NET, "NET/IB : Local mergedDev %s has a different number of devices=%d as remote %s %d",
-      mergedDev->devName, rComm->base.vProps.ndevs, remMeta.devName, remMeta.ndevs);
+         mergedDev->devName, rComm->base.vProps.ndevs, remMeta.devName, remMeta.ndevs);
   }
 
   // Metadata to send back to requestor (sender)
@@ -1417,7 +1465,7 @@ ib_recv:
   // up to 2 completions (one for the CTS message and one for the completion
   // of a receive request) per QP, in the worst case.
   int cqSize;
-  cqSize = 3*NET_IB_MAX_REQUESTS*ncclParamIbCastQpsPerConn();
+  cqSize = 3 * NET_IB_MAX_REQUESTS * ncclParamIbCastQpsPerConn();
   for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
     rCommDev = rComm->devs + i;
     ibDevN = rComm->base.vProps.devs[i];
@@ -1429,13 +1477,19 @@ ib_recv:
       NCCLCHECKGOTO(IbCastResiliencyDevInit(rComm->base.resiliency, i, &IbCastDevs[ibDevN]), ret, fail);
     }
     ibDev = IbCastDevs + ibDevN;
-    NCCLCHECKGOTO(IbCastGetGidIndex(ibDev->context, ibDev->portNum, &ibDev->portAttr, &rCommDev->base.gidInfo.localGidIndex), ret, fail);
-    NCCLCHECKGOTO(wrap_ibv_query_gid(ibDev->context, ibDev->portNum, rCommDev->base.gidInfo.localGidIndex, &rCommDev->base.gidInfo.localGid), ret, fail);
+    NCCLCHECKGOTO(IbCastGetGidIndex(ibDev->context, ibDev->portNum, &ibDev->portAttr,
+                                    &rCommDev->base.gidInfo.localGidIndex),
+                  ret, fail);
+    NCCLCHECKGOTO(wrap_ibv_query_gid(ibDev->context, ibDev->portNum, rCommDev->base.gidInfo.localGidIndex,
+                                     &rCommDev->base.gidInfo.localGid),
+                  ret, fail);
     if (link_layer == IBV_LINK_LAYER_UNSPECIFIED) link_layer = ibDev->portAttr.link_layer;
     if (link_layer != ibDev->portAttr.link_layer) {
       int ibDev0 = rComm->devs[0].base.ibDevN;
-      WARN("NET/IB : Attempted to connect incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of only one link type using NCCL_IB_HCA",
-           ibDevN, ibDev->devName, ibDev->portNum, NCCL_IB_LLSTR(ibDev->portAttr.link_layer), ibDev0, IbCastDevs[ibDev0].devName, IbCastDevs[ibDev0].portNum, NCCL_IB_LLSTR(link_layer));
+      WARN("NET/IB : Attempted to connect incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of "
+           "only one link type using NCCL_IB_HCA",
+           ibDevN, ibDev->devName, ibDev->portNum, NCCL_IB_LLSTR(ibDev->portAttr.link_layer), ibDev0,
+           IbCastDevs[ibDev0].devName, IbCastDevs[ibDev0].portNum, NCCL_IB_LLSTR(link_layer));
       return ncclInternalError;
     }
   }
@@ -1445,8 +1499,10 @@ ib_recv:
   for (int i = 0; i < remMeta.ndevs; i++) {
     if (remMeta.devs[i].link_layer != link_layer) {
       int ibDev0 = rComm->devs[0].base.ibDevN;
-      WARN("NET/IB : Remote %s device is incompatible with the local [%d]%s:%d/%s. Try selecting NICs of only one link type using NCCL_IB_HCA",
-           NCCL_IB_LLSTR(remMeta.devs[i].link_layer), ibDev0, IbCastDevs[ibDev0].devName, IbCastDevs[ibDev0].portNum, NCCL_IB_LLSTR(link_layer));
+      WARN("NET/IB : Remote %s device is incompatible with the local [%d]%s:%d/%s. Try selecting NICs of only one link "
+           "type using NCCL_IB_HCA",
+           NCCL_IB_LLSTR(remMeta.devs[i].link_layer), ibDev0, IbCastDevs[ibDev0].devName, IbCastDevs[ibDev0].portNum,
+           NCCL_IB_LLSTR(link_layer));
       return ncclInternalError;
     }
   }
@@ -1457,15 +1513,18 @@ ib_recv:
   // Store the remote GID information per-device provided by the remote peer
   for (int i = 0; i < rComm->base.nRemDevs; i++) {
     rComm->base.remDevs[i] = remMeta.devs[i];
-    rComm->base.remDevs[i].remoteGid.global.interface_id  = rComm->base.remDevs[i].gid.global.interface_id;
+    rComm->base.remDevs[i].remoteGid.global.interface_id = rComm->base.remDevs[i].gid.global.interface_id;
     rComm->base.remDevs[i].remoteGid.global.subnet_prefix = rComm->base.remDevs[i].gid.global.subnet_prefix;
   }
 
   // Determine if Flush is enabled for this Comm. Must be done before creating
   // QPs. If Flush is enabled, extra QPs will be created for Flush operations.
-  useDmaBuf  = (IbCastDmaBufSupport(lComm->dev) == ncclSuccess && ncclParamDmaBufEnable());
-  rComm->flushEnabled = (((IbCastGdrSupport() == ncclSuccess || useDmaBuf) && (!IbCastOffloadEnabled)
-                            && (ncclParamIbCastGdrFlushDisable() == 0)) || remMeta.isRMA) ? 1 : 0;
+  useDmaBuf = (IbCastDmaBufSupport(lComm->dev) == ncclSuccess && ncclParamDmaBufEnable());
+  rComm->flushEnabled = (((IbCastGdrSupport() == ncclSuccess || useDmaBuf) && (!IbCastOffloadEnabled) &&
+                          (ncclParamIbCastGdrFlushDisable() == 0)) ||
+                         remMeta.isRMA) ?
+                          1 :
+                          0;
 
   NCCLCHECKGOTO(IbCastReceiverQpsCreateToRts(rComm, &remMeta, &meta, channelId), ret, fail);
   if (rComm->prepostReceiveWorkRequests) {
@@ -1481,13 +1540,18 @@ ib_recv:
   for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
     rCommDev = rComm->devs + i;
 
-    NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->ctsFifoMr, rCommDev->base.pd, &rComm->remCtsFifo.elems, sizeof(rComm->remCtsFifo.elems), IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
+    NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->ctsFifoMr, rCommDev->base.pd, &rComm->remCtsFifo.elems,
+                                  sizeof(rComm->remCtsFifo.elems),
+                                  IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ),
+                  ret, fail);
     rCommDev->sge.lkey = rCommDev->ctsFifoMr->lkey;
 
     // Register completion records
-    NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->cmplsRecordsMr, rCommDev->base.pd, &rComm->cmplsRecords, sizeof(rComm->cmplsRecords), IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_REMOTE_READ), ret, fail);
+    NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->cmplsRecordsMr, rCommDev->base.pd, &rComm->cmplsRecords,
+                                  sizeof(rComm->cmplsRecords),
+                                  IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ),
+                  ret, fail);
     meta.devs[i].rkey = rCommDev->cmplsRecordsMr->rkey;
-
   }
   if (IbCastUseInline && (!IbCastAinicRoce || rComm->useCtsOffload)) rComm->remCtsFifo.flags = IBV_SEND_INLINE;
 
@@ -1506,48 +1570,55 @@ ib_recv:
         // RCCL: allocate the GDR flush buffer directly via HIP (never cuMem/VMM)
         // so hsa_amd_portable_export_dmabuf can export it. cuMem/VMM allocations
         // fail to export through the HSA portable exporter on some ROCm/NIC stacks.
-        CUDACHECKGOTO(
-          hipExtMallocWithFlags((void**)&rCommDev->gpuFlush.gpuFlushGpuMem,
-                                sizeof(int), gpuFlushFlags),
-          ret, fail);
-        CUDACHECKGOTO(hipMemset(rCommDev->gpuFlush.gpuFlushGpuMem, 0,
-                                sizeof(int)),
+        CUDACHECKGOTO(hipExtMallocWithFlags((void**)&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), gpuFlushFlags),
                       ret, fail);
+        CUDACHECKGOTO(hipMemset(rCommDev->gpuFlush.gpuFlushGpuMem, 0, sizeof(int)), ret, fail);
 
         if (useDmaBuf) {
           uint64_t exportOffset = 0;
-          void *aligned_ptr = NULL;
+          void* aligned_ptr = NULL;
           size_t alignedSize = 0;
-          get_aligned_ptr_and_size(rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int) /*devicebuffersize*/, &aligned_ptr, &alignedSize);
-          hsa_status_t exportStatus = pfn_hsa_amd_portable_export_dmabuf(aligned_ptr, alignedSize, &rCommDev->gpuFlush.dmabufFd, &exportOffset);
+          get_aligned_ptr_and_size(rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int) /*devicebuffersize*/, &aligned_ptr,
+                                   &alignedSize);
+          hsa_status_t exportStatus =
+            pfn_hsa_amd_portable_export_dmabuf(aligned_ptr, alignedSize, &rCommDev->gpuFlush.dmabufFd, &exportOffset);
           if (rCommDev->gpuFlush.dmabufFd < 0 || exportStatus != HSA_STATUS_SUCCESS) {
             WARN("Failed to export DMA BUF");
             goto fail;
           }
-          NCCLCHECKGOTO(wrap_ibv_reg_dmabuf_mr(&rCommDev->gpuFlush.gpuMr, rCommDev->base.pd, exportOffset, sizeof(int), (uint64_t)rCommDev->gpuFlush.gpuFlushGpuMem /*iova*/, rCommDev->gpuFlush.dmabufFd, IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ), ret, fail);
+          NCCLCHECKGOTO(
+            wrap_ibv_reg_dmabuf_mr(&rCommDev->gpuFlush.gpuMr, rCommDev->base.pd, exportOffset, sizeof(int),
+                                   (uint64_t)rCommDev->gpuFlush.gpuFlushGpuMem /*iova*/, rCommDev->gpuFlush.dmabufFd,
+                                   IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ),
+            ret, fail);
         } else {
           rCommDev->gpuFlush.dmabufFd = -1;
-          NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->gpuFlush.gpuMr, rCommDev->base.pd, rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ), ret, fail);
+          NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->gpuFlush.gpuMr, rCommDev->base.pd, rCommDev->gpuFlush.gpuFlushGpuMem,
+                                        sizeof(int),
+                                        IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ),
+                        ret, fail);
         }
       } else {
         rCommDev->gpuFlush.gpuFlushGpuMem = nullptr;
         rCommDev->gpuFlush.gpuMr = nullptr;
         rCommDev->gpuFlush.dmabufFd = -1;
       }
-      NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->gpuFlush.hostMr, rCommDev->base.pd, &rComm->gpuFlushHostMem, sizeof(int), IBV_ACCESS_LOCAL_WRITE), ret, fail);
+      NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->gpuFlush.hostMr, rCommDev->base.pd, &rComm->gpuFlushHostMem, sizeof(int),
+                                    IBV_ACCESS_LOCAL_WRITE),
+                    ret, fail);
       rCommDev->gpuFlush.sge.addr = (uint64_t)&rComm->gpuFlushHostMem;
       rCommDev->gpuFlush.sge.length = 1;
       rCommDev->gpuFlush.sge.lkey = rCommDev->gpuFlush.hostMr->lkey;
     }
 
     // Fill Handle
-    meta.devs[i].lid                            = ibDev->portAttr.lid;
-    meta.devs[i].link_layer                     = rCommDev->base.gidInfo.link_layer = ibDev->portAttr.link_layer;
-    meta.devs[i].ib_port                        = ibDev->portNum;
-    meta.devs[i].gid.global.subnet_prefix       = rCommDev->base.gidInfo.localGid.global.subnet_prefix;
-    meta.devs[i].gid.global.interface_id        = rCommDev->base.gidInfo.localGid.global.interface_id;
-    meta.devs[i].mtu                            = ibDev->portAttr.active_mtu;
-    meta.devs[i].ibv_dev_index                  = rCommDev->base.ibDevN;
+    meta.devs[i].lid = ibDev->portAttr.lid;
+    meta.devs[i].link_layer = rCommDev->base.gidInfo.link_layer = ibDev->portAttr.link_layer;
+    meta.devs[i].ib_port = ibDev->portNum;
+    meta.devs[i].gid.global.subnet_prefix = rCommDev->base.gidInfo.localGid.global.subnet_prefix;
+    meta.devs[i].gid.global.interface_id = rCommDev->base.gidInfo.localGid.global.interface_id;
+    meta.devs[i].mtu = ibDev->portAttr.active_mtu;
+    meta.devs[i].ibv_dev_index = rCommDev->base.ibDevN;
   }
   meta.addr = (uint64_t)rComm->cmplsRecords;
   meta.sl = remMeta.sl;
@@ -1567,14 +1638,18 @@ ib_recv:
   memcpy(stage->buffer, &meta, sizeof(struct ncclIbConnectionMetadata));
 
 ib_send:
-  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_SEND, &rComm->base.sock, stage->buffer, sizeof(struct ncclIbConnectionMetadata), &stage->offset), ret, fail);
+  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_SEND, &rComm->base.sock, stage->buffer,
+                                   sizeof(struct ncclIbConnectionMetadata), &stage->offset),
+                ret, fail);
   if (stage->offset < sizeof(struct ncclIbConnectionMetadata)) return ncclSuccess;
 
   stage->offset = 0;
   stage->state = ncclIbCommStatePendingReady;
 
 ib_recv_ready:
-  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_RECV,  &rComm->base.sock, &rComm->base.ready, sizeof(int), &stage->offset), ret, fail);
+  NCCLCHECKGOTO(ncclSocketProgress(NCCL_SOCKET_RECV, &rComm->base.sock, &rComm->base.ready, sizeof(int),
+                                   &stage->offset),
+                ret, fail);
   if (stage->offset != sizeof(int)) return ncclSuccess;
 
   *recvComm = rComm;
@@ -1605,10 +1680,9 @@ ncclResult_t IbCastCloseSend(void* sendComm) {
       struct ncclIbSendCommDev* commDev = comm->devs + i;
       if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
       if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
-      if (commDev->putSignalScratchpadMr != NULL)
-        NCCLCHECK(wrap_ibv_dereg_mr(commDev->putSignalScratchpadMr));
+      if (commDev->putSignalScratchpadMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->putSignalScratchpadMr));
       if (comm->base.resiliency) {
-         NCCLCHECK(IbCastResiliencyDevDestroy(comm->base.resiliency, i));
+        NCCLCHECK(IbCastResiliencyDevDestroy(comm->base.resiliency, i));
       }
       NCCLCHECK(IbCastDestroyBase(&commDev->base));
     }
@@ -1641,7 +1715,9 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
           commDev->gpuFlush.gpuFlushGpuMem = nullptr;
           if (commDev->gpuFlush.gpuMr != nullptr) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.gpuMr));
           commDev->gpuFlush.gpuMr = nullptr;
-          if(commDev->gpuFlush.dmabufFd > 0) { close(commDev->gpuFlush.dmabufFd);}
+          if (commDev->gpuFlush.dmabufFd > 0) {
+            close(commDev->gpuFlush.dmabufFd);
+          }
         }
         if (commDev->gpuFlush.qp.qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(commDev->gpuFlush.qp.qp));
         if (commDev->gpuFlush.hostMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.hostMr));

--- a/projects/rccl/src/transport/net_ib_cast/gdr.cc
+++ b/projects/rccl/src/transport/net_ib_cast/gdr.cc
@@ -35,14 +35,13 @@ static void ibGdrSupportInitOnce() {
     // this `memory_peers` directory is either not created (go to else-if condition)
     // or created under a different path like `/sys/kernel/` or `/sys/` (depending on your ib_peer_mem module)
     const char* memory_peers_paths[] = {"/sys/kernel/mm/memory_peers/amdkfd/version",
-                                  "/sys/kernel/memory_peers/amdkfd/version",
-                                  "/sys/memory_peers/amdkfd/version",
-                                  NULL};
+                                        "/sys/kernel/memory_peers/amdkfd/version", "/sys/memory_peers/amdkfd/version",
+                                        NULL};
     int i = 0;
     while (memory_peers_paths[i]) {
       if (access(memory_peers_paths[i], F_OK) == 0) {
         IbCastGdrModuleLoaded = 1;
-        INFO(NCCL_INIT,"Found %s", memory_peers_paths[i]);
+        INFO(NCCL_INIT, "Found %s", memory_peers_paths[i]);
         break;
       } else {
         IbCastGdrModuleLoaded = 0;
@@ -55,25 +54,24 @@ static void ibGdrSupportInitOnce() {
     if (strncmp("Hyper-V UEFI Release", strValue, 20) == 0) {
       int roMode = ncclParamIbCastPciRelaxedOrdering();
       ncclTopoGetStrFromSys("/proc/sys/kernel", "numa_balancing", strValue);
-      if (strcmp(strValue, "1") == 0 && roMode == 0)
-        IbCastGdrModuleLoaded = 0;
+      if (strcmp(strValue, "1") == 0 && roMode == 0) IbCastGdrModuleLoaded = 0;
     }
 
     if (IbCastGdrModuleLoaded == 0) {
       // Check for `ib_register_peer_memory_client` symbol in `/proc/kallsyms`
       // if your system uses native OS ib_peer module
       char buf[256];
-      FILE *fp = NULL;
+      FILE* fp = NULL;
       fp = fopen("/proc/kallsyms", "r");
-  
+
       if (fp == NULL) {
-        INFO(NCCL_INIT,"Could not open /proc/kallsyms");
+        INFO(NCCL_INIT, "Could not open /proc/kallsyms");
       } else {
         while (fgets(buf, sizeof(buf), fp) != NULL) {
           if (strstr(buf, "t ib_register_peer_memory_client") != NULL ||
               strstr(buf, "T ib_register_peer_memory_client") != NULL) {
             IbCastGdrModuleLoaded = 1;
-            INFO(NCCL_INIT,"Found ib_register_peer_memory_client in /proc/kallsyms");
+            INFO(NCCL_INIT, "Found ib_register_peer_memory_client in /proc/kallsyms");
             break;
           }
         }
@@ -92,8 +90,7 @@ static void ibGdrSupportInitOnce() {
 ncclResult_t IbCastGdrSupport() {
   static std::once_flag once;
   std::call_once(once, ibGdrSupportInitOnce);
-  if (!IbCastGdrModuleLoaded)
-    return ncclSystemError;
+  if (!IbCastGdrModuleLoaded) return ncclSystemError;
   return ncclSuccess;
 }
 
@@ -106,8 +103,7 @@ static void ibPeerMemSupportInitOnce() {
 ncclResult_t IbCastPeerMemSupport() {
   static std::once_flag once;
   std::call_once(once, ibPeerMemSupportInitOnce);
-  if (!IbCastPeerMemModuleLoaded)
-    return ncclSystemError;
+  if (!IbCastPeerMemModuleLoaded) return ncclSystemError;
   return ncclSuccess;
 }
 

--- a/projects/rccl/src/transport/net_ib_cast/gin.cc
+++ b/projects/rccl/src/transport/net_ib_cast/gin.cc
@@ -18,9 +18,8 @@ const int IBCAST_GIN_IB_ALLTOALL_TAG = 0xa1;
 static ncclResult_t IbCastGinIbGdrSupport(bool* gdrSupport, bool gdaki) {
   *gdrSupport = true;
 #ifdef RCCL_NET_IB_CAST_ENABLE_GDAKI
-  bool peerMemSupport =
-     gdaki ? IbCastPeerMemSupport() == ncclSuccess : // GDAKI does not support nv_peer_mem.
-     IbCastGdrSupport() == ncclSuccess;
+  bool peerMemSupport = gdaki ? IbCastPeerMemSupport() == ncclSuccess : // GDAKI does not support nv_peer_mem.
+                                IbCastGdrSupport() == ncclSuccess;
 #else
   bool peerMemSupport = IbCastGdrSupport() == ncclSuccess;
 #endif
@@ -41,9 +40,8 @@ static ncclResult_t IbCastGinIbGdrGpuSupport(bool gdaki) {
   if (IbCastGdrSupport() == ncclSuccess) return ncclSuccess;
   WARN("Unable to use GIN: Peermem is not supported, and DMA-BUF is not available.");
 #else
-  bool peerMemSupport =
-     gdaki ? IbCastPeerMemSupport() == ncclSuccess : // GDAKI does not support nv_peer_mem.
-     IbCastGdrSupport() == ncclSuccess;
+  bool peerMemSupport = gdaki ? IbCastPeerMemSupport() == ncclSuccess : // GDAKI does not support nv_peer_mem.
+                                IbCastGdrSupport() == ncclSuccess;
   if (peerMemSupport) return ncclSuccess;
 
   int cudaDev;
@@ -87,7 +85,8 @@ extern ncclGin_t IbCastGinIbProxy;
 
 // Initlialize GDAKI or PROXY backend. ginType can force a particular backend.
 // If provided, overwrite ginIb with the backend (generic ginIb case).
-ncclResult_t IbCastGinIbInitType(void** ctx, uint64_t commId, ncclDebugLogger_t logFunction, int ginType, ncclGin_t* ginIb) {
+ncclResult_t IbCastGinIbInitType(void** ctx, uint64_t commId, ncclDebugLogger_t logFunction, int ginType,
+                                 ncclGin_t* ginIb) {
   NCCLCHECK(IbCastInitDevices(logFunction, nullptr));
   if (IbCastNDevs == 0) return ncclInternalError; // Caught in plugin init code, not propagated to user.
 
@@ -96,7 +95,7 @@ ncclResult_t IbCastGinIbInitType(void** ctx, uint64_t commId, ncclDebugLogger_t 
 #endif
   if (ginType == NCCL_GIN_TYPE_PROXY) goto try_proxy;
   if (ginType != -1) {
-    INFO(NCCL_INIT|NCCL_NET, "NET_IB: no support for GIN type %ld", ncclParamCastGinType());
+    INFO(NCCL_INIT | NCCL_NET, "NET_IB: no support for GIN type %ld", ncclParamCastGinType());
     return ncclInternalError;
   }
 
@@ -132,130 +131,115 @@ ncclResult_t IbCastGinIbInit(void** ctx, uint64_t commId, ncclDebugLogger_t logF
 }
 
 // GIN Entry point, which will then morph into either the GDAKI or PROXY backend
-ncclGin_t IbCastGinIb = {
-  "GIN_IB",
-  IbCastGinIbInit,
-  NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL
-};
+ncclGin_t IbCastGinIb = {"GIN_IB", IbCastGinIbInit,
+                         NULL,     NULL,
+                         NULL,     NULL,
+                         NULL,     NULL,
+                         NULL,     NULL,
+                         NULL,     NULL,
+                         NULL,     NULL,
+                         NULL,     NULL,
+                         NULL,     NULL,
+                         NULL};
 
-ncclResult_t IbCastGinIbFinalize(void *ctx) {
+ncclResult_t IbCastGinIbFinalize(void* ctx) {
   if (ctx) free(ctx);
   return IbCastFinalizeDevices();
 }
 
-static ncclResult_t IbCastGinIbAllGather(struct CastIbGinCollComm *cComm, void *srcBuf, void *recvBuf, size_t len) {
+static ncclResult_t IbCastGinIbAllGather(struct CastIbGinCollComm* cComm, void* srcBuf, void* recvBuf, size_t len) {
   ncclResult_t status = ncclSuccess;
   void *rMhandle = NULL, *sMhandle = NULL;
   void *srequest = NULL, *rrequest = NULL;
   int speer;
   int rpeer;
-  void *rbuf;
+  void* rbuf;
   int tag;
   int done;
 
-  NCCLCHECKGOTO(netIbCast.regMr(cComm->recvComm, recvBuf,
-                                cComm->nranks * len, NCCL_PTR_HOST,
-                                &rMhandle),
-                status, out);
-  NCCLCHECKGOTO(netIbCast.regMr(cComm->sendComm, recvBuf,
-                                cComm->nranks * len, NCCL_PTR_HOST,
-                                &sMhandle),
-                status, out);
+  NCCLCHECKGOTO(netIbCast.regMr(cComm->recvComm, recvBuf, cComm->nranks * len, NCCL_PTR_HOST, &rMhandle), status, out);
+  NCCLCHECKGOTO(netIbCast.regMr(cComm->sendComm, recvBuf, cComm->nranks * len, NCCL_PTR_HOST, &sMhandle), status, out);
 
   speer = cComm->rank;
-  memcpy((void *)((uintptr_t)recvBuf + speer * len), srcBuf, len);
+  memcpy((void*)((uintptr_t)recvBuf + speer * len), srcBuf, len);
   for (int i = 0; i < cComm->nranks - 1; i++) {
     rpeer = (speer - 1 + cComm->nranks) % cComm->nranks;
     while (srequest == NULL || rrequest == NULL) {
-      rbuf = (void *)((uintptr_t)recvBuf + rpeer * len);
+      rbuf = (void*)((uintptr_t)recvBuf + rpeer * len);
       tag = IBCAST_GIN_IB_ALLGATHER_TAG;
       if (srequest == NULL)
-        NCCLCHECKGOTO(netIbCast.isend(cComm->sendComm,
-                                      (void *)((uintptr_t)recvBuf + speer * len),
-                                      len, tag, sMhandle, NULL, &srequest),
+        NCCLCHECKGOTO(netIbCast.isend(cComm->sendComm, (void*)((uintptr_t)recvBuf + speer * len), len, tag, sMhandle,
+                                      NULL, &srequest),
                       status, out);
       if (rrequest == NULL)
-        NCCLCHECKGOTO(netIbCast.irecv(cComm->recvComm, 1, &rbuf, &len,
-                                      &tag, &rMhandle, NULL, &rrequest),
-                      status, out);
+        NCCLCHECKGOTO(netIbCast.irecv(cComm->recvComm, 1, &rbuf, &len, &tag, &rMhandle, NULL, &rrequest), status, out);
     }
     while (srequest || rrequest) {
-      if (rrequest)
-        NCCLCHECKGOTO(netIbCast.test(rrequest, &done, NULL),
-                      status, out);
-      if (done)
-        rrequest = NULL;
-      if (srequest)
-        NCCLCHECKGOTO(netIbCast.test(srequest, &done, NULL),
-                      status, out);
-      if (done)
-        srequest = NULL;
+      if (rrequest) NCCLCHECKGOTO(netIbCast.test(rrequest, &done, NULL), status, out);
+      if (done) rrequest = NULL;
+      if (srequest) NCCLCHECKGOTO(netIbCast.test(srequest, &done, NULL), status, out);
+      if (done) srequest = NULL;
     }
     speer = rpeer;
   }
 
 out:
-  if (rMhandle)
-    netIbCast.deregMr(cComm->recvComm, rMhandle);
+  if (rMhandle) netIbCast.deregMr(cComm->recvComm, rMhandle);
 
-  if (sMhandle)
-    netIbCast.deregMr(cComm->sendComm, sMhandle);
+  if (sMhandle) netIbCast.deregMr(cComm->sendComm, sMhandle);
 
   return status;
 }
 
-static ncclResult_t IbCastGinIbAllToAll(struct CastIbGinCollComm *cComm, void *src_buf, void *recv_buf, size_t len) {
+static ncclResult_t IbCastGinIbAllToAll(struct CastIbGinCollComm* cComm, void* src_buf, void* recv_buf, size_t len) {
   ncclResult_t status = ncclSuccess;
 
-  void *tmp_buf = nullptr;
-  NCCLCHECK(ncclIbMalloc((void **)&tmp_buf, cComm->nranks * cComm->nranks * len));
+  void* tmp_buf = nullptr;
+  NCCLCHECK(ncclIbMalloc((void**)&tmp_buf, cComm->nranks * cComm->nranks * len));
   NCCLCHECKGOTO(cComm->allGather(cComm, src_buf, tmp_buf, cComm->nranks * len), status, out);
 
   for (int i = 0; i < cComm->nranks; i++) {
-    memcpy((void *)((uintptr_t)recv_buf + i * len), (void *)((uintptr_t)tmp_buf + i * cComm->nranks * len + cComm->rank * len), len);
+    memcpy((void*)((uintptr_t)recv_buf + i * len),
+           (void*)((uintptr_t)tmp_buf + i * cComm->nranks * len + cComm->rank * len), len);
   }
 
 out:
-  if (tmp_buf)
-    free(tmp_buf);
+  if (tmp_buf) free(tmp_buf);
 
   return status;
 }
 
-ncclResult_t IbCastGinIbP2PBarrier(struct CastIbGinCollComm *cComm) {
+ncclResult_t IbCastGinIbP2PBarrier(struct CastIbGinCollComm* cComm) {
   // TODO: move allocation to init or use zero-byte allgather
-  int *dummy;
-  NCCLCHECK(ncclIbMalloc((void **)&dummy, cComm->nranks * sizeof(int)));
+  int* dummy;
+  NCCLCHECK(ncclIbMalloc((void**)&dummy, cComm->nranks * sizeof(int)));
   NCCLCHECK(IbCastGinIbAllGather(cComm, dummy + cComm->rank, dummy, sizeof(int)));
   free(dummy);
   return ncclSuccess;
 }
 
-ncclResult_t IbCastGinIbConnect(void *ctx, void *handles[], int nranks, int rank,
-                              void *listenComm, void **collComm) {
-  struct ncclIbListenComm *lComm = (struct ncclIbListenComm *)listenComm;
-  struct CastIbGinCollComm *cCommArray = nullptr;
+ncclResult_t IbCastGinIbConnect(void* ctx, void* handles[], int nranks, int rank, void* listenComm, void** collComm) {
+  struct ncclIbListenComm* lComm = (struct ncclIbListenComm*)listenComm;
+  struct CastIbGinCollComm* cCommArray = nullptr;
   int next;
 
   *collComm = NULL;
-  NCCLCHECK(ncclIbMalloc((void **)&cCommArray, sizeof(*cCommArray)));
+  NCCLCHECK(ncclIbMalloc((void**)&cCommArray, sizeof(*cCommArray)));
 
-  struct CastIbGinCollComm *cComm = cCommArray;
+  struct CastIbGinCollComm* cComm = cCommArray;
   cComm->ctx = ctx;
   cComm->nranks = nranks;
   cComm->rank = rank;
 
   next = (cComm->rank + 1) % nranks;
-  do
-  {
+  do {
     if (cComm->sendComm == NULL) {
       NCCLCHECK(netIbCast.connect(ctx, lComm->dev, handles[next], &cComm->sendComm, NULL));
     }
-    if (cComm->recvComm == NULL)
-      NCCLCHECK(netIbCast.accept(lComm, &cComm->recvComm, NULL));
+    if (cComm->recvComm == NULL) NCCLCHECK(netIbCast.accept(lComm, &cComm->recvComm, NULL));
   } while (cComm->sendComm == NULL || cComm->recvComm == NULL);
 
-  cComm->getProperties = (ncclResult_t(*)(int dev, void *props))IbCastGetProperties;
+  cComm->getProperties = (ncclResult_t (*)(int dev, void* props))IbCastGetProperties;
   cComm->allGather = IbCastGinIbAllGather;
   cComm->allToAll = IbCastGinIbAllToAll;
   cComm->getGidIndex = IbCastGetGidIndex;
@@ -272,7 +256,7 @@ ncclResult_t IbCastGinIbCloseColl(void* collComm) {
   struct CastIbGinCollComm* cCommArray = (struct CastIbGinCollComm*)collComm;
   if (!cCommArray) return ncclSuccess;
 
-  struct CastIbGinCollComm *cComm = cCommArray;
+  struct CastIbGinCollComm* cComm = cCommArray;
   if (cComm->recvComm) {
     NCCLCHECK(netIbCast.closeRecv(cComm->recvComm));
     cComm->recvComm = NULL;
@@ -305,7 +289,8 @@ ncclResult_t IbCastGinIbGdakiDevices(int* ndev) {
 ncclResult_t IbCastGinIbGdakiGetProperties(int dev, ncclNetProperties_t* props) {
   std::lock_guard<std::mutex> lock(IbCastGinGdakiLockMutex);
   if (dev >= IbCastGinGdakiNDevs) {
-    WARN("NET/IB : Requested properties for GIN GDAKI NIC %d, only %d GIN GDAKI NICs have been created", dev, IbCastGinGdakiNDevs);
+    WARN("NET/IB : Requested properties for GIN GDAKI NIC %d, only %d GIN GDAKI NICs have been created", dev,
+         IbCastGinGdakiNDevs);
     return ncclInvalidUsage;
   }
   NCCLCHECK(IbCastGetPhysProperties(IbCastGinGdakiDevIndexes[dev], props));
@@ -320,78 +305,76 @@ ncclResult_t IbCastGinIbGdakiListen(void* ctx, int dev, void* opaqueHandle, void
   return netIbCast.listen(ctx, IbCastGinGdakiDevIndexes[dev], opaqueHandle, listenComm);
 }
 
-ncclResult_t IbCastGinIbGdakiConnect(void *ctx, void *handles[], int nranks, int rank,
-                                   void *listenComm, void **collComm) {
+ncclResult_t IbCastGinIbGdakiConnect(void* ctx, void* handles[], int nranks, int rank, void* listenComm,
+                                     void** collComm) {
   // Check the current GPU supports GDR
   NCCLCHECK(IbCastGinIbGdrGpuSupport(/*gdaki*/ true));
 
-  NCCLCHECK(
-    IbCastGinIbConnect(ctx, handles, nranks, rank, listenComm, collComm));
+  NCCLCHECK(IbCastGinIbConnect(ctx, handles, nranks, rank, listenComm, collComm));
 
-  struct CastIbGinCollComm *cComm = (struct CastIbGinCollComm *)*collComm;
-  cComm->getProperties = (ncclResult_t(*)(int dev, void *props))IbCastGinIbGdakiGetProperties;
+  struct CastIbGinCollComm* cComm = (struct CastIbGinCollComm*)*collComm;
+  cComm->getProperties = (ncclResult_t (*)(int dev, void* props))IbCastGinIbGdakiGetProperties;
   return ncclSuccess;
 }
 
-ncclResult_t IbCastGinIbGdakiCreateContext(void* collComm, ncclGinConfig_v13_t* config, void **ginCtx, ncclNetDeviceHandle_t** devHandle) {
+ncclResult_t IbCastGinIbGdakiCreateContext(void* collComm, ncclGinConfig_v13_t* config, void** ginCtx,
+                                           ncclNetDeviceHandle_t** devHandle) {
   struct CastIbGinCollComm* cComm = (struct CastIbGinCollComm*)collComm;
 
-  NCCLCHECK(ncclGinGdakiCreateContext(cComm, config->nSignals, config->nCounters, config->nContexts, config->queueDepth, config->trafficClass, ginCtx, devHandle));
+  NCCLCHECK(ncclGinGdakiCreateContext(cComm, config->nSignals, config->nCounters, config->nContexts, config->queueDepth,
+                                      config->trafficClass, ginCtx, devHandle));
 
   return ncclSuccess;
 }
 
-ncclResult_t IbCastGinIbGdakiRegMrSym(void* collComm, void* data, size_t size, int type, uint64_t mr_flags, void** mhandle, void **ginHandle) {
-  return ncclGinGdakiRegMrSym((struct CastIbGinCollComm *)collComm, data, size, type, mr_flags, mhandle, ginHandle);
+ncclResult_t IbCastGinIbGdakiRegMrSym(void* collComm, void* data, size_t size, int type, uint64_t mr_flags,
+                                      void** mhandle, void** ginHandle) {
+  return ncclGinGdakiRegMrSym((struct CastIbGinCollComm*)collComm, data, size, type, mr_flags, mhandle, ginHandle);
 }
 
 ncclResult_t IbCastGinIbGdakiDeregMrSym(void* collComm, void* mhandle) {
-  return ncclGinGdakiDeregMrSym((struct CastIbGinCollComm *)collComm, mhandle);
+  return ncclGinGdakiDeregMrSym((struct CastIbGinCollComm*)collComm, mhandle);
 }
 
 ncclResult_t IbCastGinIbGdakiDestroyContext(void* ginCtx) {
   return ncclGinGdakiDestroyContext(ginCtx);
 }
 
-ncclResult_t IbCastGinIbGdakiProgress(void *collComm)
-{
+ncclResult_t IbCastGinIbGdakiProgress(void* collComm) {
   return ncclGinGdakiProgress(collComm);
 }
 
-ncclResult_t IbCastGinIbGdakiQueryLastError(void *ginCtx, bool *hasError) {
+ncclResult_t IbCastGinIbGdakiQueryLastError(void* ginCtx, bool* hasError) {
   return ncclGinGdakiQueryLastError(ginCtx, hasError);
 }
 
-ncclGin_t IbCastGinIbGdaki = {
-  "GIN_IB_GDAKI",
-  IbCastGinIbGdakiInit,
-  IbCastGinIbGdakiDevices,
-  IbCastGinIbGdakiGetProperties,
-  IbCastGinIbGdakiListen,
-  IbCastGinIbGdakiConnect,
-  IbCastGinIbGdakiCreateContext,
-  IbCastGinIbGdakiRegMrSym,
-  NULL, // regMrSymDmaBuf
-  IbCastGinIbGdakiDeregMrSym,
-  IbCastGinIbGdakiDestroyContext,
-  IbCastGinIbCloseColl,
-  IbCastCloseListen,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  IbCastGinIbGdakiProgress,
-  IbCastGinIbGdakiQueryLastError,
-  IbCastGinIbFinalize
-};
+ncclGin_t IbCastGinIbGdaki = {"GIN_IB_GDAKI",
+                              IbCastGinIbGdakiInit,
+                              IbCastGinIbGdakiDevices,
+                              IbCastGinIbGdakiGetProperties,
+                              IbCastGinIbGdakiListen,
+                              IbCastGinIbGdakiConnect,
+                              IbCastGinIbGdakiCreateContext,
+                              IbCastGinIbGdakiRegMrSym,
+                              NULL, // regMrSymDmaBuf
+                              IbCastGinIbGdakiDeregMrSym,
+                              IbCastGinIbGdakiDestroyContext,
+                              IbCastGinIbCloseColl,
+                              IbCastCloseListen,
+                              NULL,
+                              NULL,
+                              NULL,
+                              NULL,
+                              NULL,
+                              IbCastGinIbGdakiProgress,
+                              IbCastGinIbGdakiQueryLastError,
+                              IbCastGinIbFinalize};
 #endif // RCCL_NET_IB_CAST_ENABLE_GDAKI
 
-
 struct IbCastGinProxyMrHandle {
-  struct ncclIbMrHandle *mrHandle;
-  uintptr_t *base_vas;
-  uint32_t *rkeys;
+  struct ncclIbMrHandle* mrHandle;
+  uintptr_t* base_vas;
+  uint32_t* rkeys;
 };
 
 ncclResult_t IbCastGinIbProxyInit(void** ctx, uint64_t commId, ncclDebugLogger_t logFunction) {
@@ -404,28 +387,28 @@ ncclResult_t IbCastGinIbProxyGetProperties(int dev, ncclNetProperties_t* props) 
   return ncclSuccess;
 }
 
-ncclResult_t IbCastGinIbProxyConnect(void *ctx, void *handles[], int nranks, int rank,
-                                   void *listenComm, void **collComm) {
+ncclResult_t IbCastGinIbProxyConnect(void* ctx, void* handles[], int nranks, int rank, void* listenComm,
+                                     void** collComm) {
   // Check the current GPU supports GDR
   NCCLCHECK(IbCastGinIbGdrGpuSupport(/*gdaki*/ false));
 
   // Connect.
-  NCCLCHECK(
-    IbCastGinIbConnect(ctx, handles, nranks, rank, listenComm, collComm));
+  NCCLCHECK(IbCastGinIbConnect(ctx, handles, nranks, rank, listenComm, collComm));
 
   return ncclSuccess;
 }
 
 struct IbCastGinIbProxyCtx {
-  void**        fullRecvComm;
-  void**        fullSendComm;
+  void** fullRecvComm;
+  void** fullSendComm;
   int rank, nranks;
   int nContexts;
 };
 
-ncclResult_t IbCastGinIbProxyCreateContext(void* collComm, ncclGinConfig_v13_t* config, void** ginCtx, ncclNetDeviceHandle_v11_t** devHandle) {
+ncclResult_t IbCastGinIbProxyCreateContext(void* collComm, ncclGinConfig_v13_t* config, void** ginCtx,
+                                           ncclNetDeviceHandle_v11_t** devHandle) {
   ncclResult_t ret = ncclSuccess;
-  struct CastIbGinCollComm *cComm = (struct CastIbGinCollComm *)collComm;
+  struct CastIbGinCollComm* cComm = (struct CastIbGinCollComm*)collComm;
   // Make sure all QP we create use the provided traffic class.
   IbCastSetTrafficClass(cComm->ctx, config->trafficClass);
 
@@ -441,21 +424,21 @@ ncclResult_t IbCastGinIbProxyCreateContext(void* collComm, ncclGinConfig_v13_t* 
   ginProxyCtx[0].nContexts = config->nContexts;
   ginProxyCtx[0].nranks = nranks = cComm->nranks;
 
-  void *lComm = NULL;
-  char* handle = NULL, *handles = NULL;
-  NCCLCHECKGOTO(ncclIbMalloc((void**)&handles, NCCL_NET_HANDLE_MAXSIZE*cComm->nranks), ret, end);
-  handle = handles + NCCL_NET_HANDLE_MAXSIZE*cComm->rank;
+  void* lComm = NULL;
+  char *handle = NULL, *handles = NULL;
+  NCCLCHECKGOTO(ncclIbMalloc((void**)&handles, NCCL_NET_HANDLE_MAXSIZE * cComm->nranks), ret, end);
+  handle = handles + NCCL_NET_HANDLE_MAXSIZE * cComm->rank;
 
-  //Mark communicator as RMA communicator: 1QP, Flush enabled, no CTS offload.
+  // Mark communicator as RMA communicator: 1QP, Flush enabled, no CTS offload.
   ((struct ncclIbHandle*)handle)->isRMA = true;
 
   NCCLCHECKGOTO(netIbCast.listen(cComm->ctx, cComm->dev, handle, &lComm), ret, end);
   NCCLCHECKGOTO(cComm->allGather(cComm, handle, handles, NCCL_NET_HANDLE_MAXSIZE), ret, end);
 
-  for (int c=0; c<config->nContexts; c++) {
-    struct IbCastGinIbProxyCtx* gc = ginProxyCtx+c;
-    NCCLCHECKGOTO(ncclIbMalloc((void**)&gc->fullSendComm, sizeof(void *) * nranks), ret, end);
-    NCCLCHECKGOTO(ncclIbMalloc((void**)&gc->fullRecvComm, sizeof(void *) * nranks), ret, end);
+  for (int c = 0; c < config->nContexts; c++) {
+    struct IbCastGinIbProxyCtx* gc = ginProxyCtx + c;
+    NCCLCHECKGOTO(ncclIbMalloc((void**)&gc->fullSendComm, sizeof(void*) * nranks), ret, end);
+    NCCLCHECKGOTO(ncclIbMalloc((void**)&gc->fullRecvComm, sizeof(void*) * nranks), ret, end);
     gc->rank = cComm->rank;
 
     for (int i = 0; i < nranks; i++) {
@@ -463,11 +446,12 @@ ncclResult_t IbCastGinIbProxyCreateContext(void* collComm, ncclGinConfig_v13_t* 
       int acceptPeer = (cComm->rank - i + nranks) % nranks;
       do {
         if (gc->fullSendComm[connectPeer] == NULL)
-          NCCLCHECKGOTO(netIbCast.connect(cComm->ctx, cComm->dev, handles+NCCL_NET_HANDLE_MAXSIZE*connectPeer, &gc->fullSendComm[connectPeer], NULL), ret, end);
+          NCCLCHECKGOTO(netIbCast.connect(cComm->ctx, cComm->dev, handles + NCCL_NET_HANDLE_MAXSIZE * connectPeer,
+                                          &gc->fullSendComm[connectPeer], NULL),
+                        ret, end);
         if (gc->fullRecvComm[acceptPeer] == NULL)
           NCCLCHECKGOTO(netIbCast.accept(lComm, &gc->fullRecvComm[acceptPeer], NULL), ret, end);
-      } while ((gc->fullSendComm[connectPeer] == NULL) ||
-          (gc->fullRecvComm[acceptPeer] == NULL));
+      } while ((gc->fullSendComm[connectPeer] == NULL) || (gc->fullRecvComm[acceptPeer] == NULL));
       NCCLCHECKGOTO(IbCastGinIbP2PBarrier(cComm), ret, end);
     }
   }
@@ -484,9 +468,9 @@ ncclResult_t IbCastGinIbProxyDestroyContext(void* ginCtx) {
   struct IbCastGinIbProxyCtx* gc = (struct IbCastGinIbProxyCtx*)ginCtx;
   int nContexts = gc[0].nContexts;
   int nranks = gc[0].nranks;
-  for (int c=0; c<nContexts; c++) {
+  for (int c = 0; c < nContexts; c++) {
     if (gc[c].fullRecvComm) {
-      for (int i=0; i<nranks; i++) {
+      for (int i = 0; i < nranks; i++) {
         NCCLCHECK(netIbCast.closeRecv(gc[c].fullRecvComm[i]));
       }
       free(gc[c].fullRecvComm);
@@ -494,7 +478,7 @@ ncclResult_t IbCastGinIbProxyDestroyContext(void* ginCtx) {
     }
 
     if (gc[c].fullSendComm) {
-      for (int i=0; i<nranks; i++) {
+      for (int i = 0; i < nranks; i++) {
         NCCLCHECK(netIbCast.closeSend(gc[c].fullSendComm[i]));
       }
       free(gc[c].fullSendComm);
@@ -504,12 +488,15 @@ ncclResult_t IbCastGinIbProxyDestroyContext(void* ginCtx) {
   return ncclSuccess;
 }
 
-ncclResult_t IbCastGinIbProxyRegMrSymDmaBuf(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd, uint64_t mr_flags, void** mhandle, void **ginHandle) {
-  struct CastIbGinCollComm *cComm = (struct CastIbGinCollComm *)collComm;
-  struct IbCastGinProxyMrHandle *ginMrHandle;
+ncclResult_t IbCastGinIbProxyRegMrSymDmaBuf(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd,
+                                            uint64_t mr_flags, void** mhandle, void** ginHandle) {
+  struct CastIbGinCollComm* cComm = (struct CastIbGinCollComm*)collComm;
+  struct IbCastGinProxyMrHandle* ginMrHandle;
   NCCLCHECK(ncclCalloc(&ginMrHandle, 1));
 
-  NCCLCHECKNOWARN(IbCastRegMrDmaBufInternal(cComm->recvComm, data, size, type, offset, fd, mr_flags, (void **)&ginMrHandle->mrHandle), NCCL_NET);
+  NCCLCHECKNOWARN(IbCastRegMrDmaBufInternal(cComm->recvComm, data, size, type, offset, fd, mr_flags,
+                                            (void**)&ginMrHandle->mrHandle),
+                  NCCL_NET);
 
   NCCLCHECK(ncclCalloc(&ginMrHandle->base_vas, cComm->nranks));
   NCCLCHECK(ncclCalloc(&ginMrHandle->rkeys, cComm->nranks));
@@ -523,13 +510,14 @@ ncclResult_t IbCastGinIbProxyRegMrSymDmaBuf(void* collComm, void* data, size_t s
   return ncclSuccess;
 }
 
-ncclResult_t IbCastGinIbProxyRegMrSym(void* collComm, void* data, size_t size, int type, uint64_t mr_flags, void** mhandle, void **ginHandle) {
+ncclResult_t IbCastGinIbProxyRegMrSym(void* collComm, void* data, size_t size, int type, uint64_t mr_flags,
+                                      void** mhandle, void** ginHandle) {
   return IbCastGinIbProxyRegMrSymDmaBuf(collComm, data, size, type, 0, -1, mr_flags, mhandle, ginHandle);
 }
 
 ncclResult_t IbCastGinIbProxyDeregMrSym(void* collComm, void* mhandle) {
-  struct CastIbGinCollComm *cComm = (struct CastIbGinCollComm *)collComm;
-  struct IbCastGinProxyMrHandle *ginMrHandle = (struct IbCastGinProxyMrHandle *)mhandle;
+  struct CastIbGinCollComm* cComm = (struct CastIbGinCollComm*)collComm;
+  struct IbCastGinProxyMrHandle* ginMrHandle = (struct IbCastGinProxyMrHandle*)mhandle;
 
   NCCLCHECK(netIbCast.deregMr(cComm->recvComm, ginMrHandle->mrHandle));
   free(ginMrHandle->base_vas);
@@ -543,21 +531,20 @@ ncclResult_t IbCastGinIbProxyCloseColl(void* collComm) {
   return ncclSuccess;
 }
 
-ncclResult_t IbCastGinIbProxyIPut(void *ginCtx, int context, uint64_t srcOff, void *srcMhandle, size_t size,
-                                uint64_t dstOff, void *dstMhandle, uint32_t rank,
-                                void **request) {
+ncclResult_t IbCastGinIbProxyIPut(void* ginCtx, int context, uint64_t srcOff, void* srcMhandle, size_t size,
+                                  uint64_t dstOff, void* dstMhandle, uint32_t rank, void** request) {
   struct IbCastGinIbProxyCtx* ginProxyCtx = &((struct IbCastGinIbProxyCtx*)ginCtx)[context];
 
-  struct IbCastGinProxyMrHandle *srcMrHandle = (struct IbCastGinProxyMrHandle *)srcMhandle;
-  struct IbCastGinProxyMrHandle *dstMrHandle = (struct IbCastGinProxyMrHandle *)dstMhandle;
+  struct IbCastGinProxyMrHandle* srcMrHandle = (struct IbCastGinProxyMrHandle*)srcMhandle;
+  struct IbCastGinProxyMrHandle* dstMrHandle = (struct IbCastGinProxyMrHandle*)dstMhandle;
 
-  void *srcPtr = (void *)(srcMrHandle->base_vas[ginProxyCtx->rank] + srcOff);
-  void *dstPtr = (void *)(dstMrHandle->base_vas[rank] + dstOff);
+  void* srcPtr = (void*)(srcMrHandle->base_vas[ginProxyCtx->rank] + srcOff);
+  void* dstPtr = (void*)(dstMrHandle->base_vas[rank] + dstOff);
   uint32_t lkey = srcMrHandle->mrHandle->mrs[0]->lkey;
   uint32_t rkey = dstMrHandle->rkeys[rank];
 
   struct ncclIbSendComm* comm = (struct ncclIbSendComm*)ginProxyCtx->fullSendComm[rank];
-  struct ncclIbQp *qp = &comm->base.qps[0];
+  struct ncclIbQp* qp = &comm->base.qps[0];
 
   struct ncclIbRequest* req;
   NCCLCHECK(IbCastGetRequest(&comm->base, &req));
@@ -574,12 +561,12 @@ ncclResult_t IbCastGinIbProxyIPut(void *ginCtx, int context, uint64_t srcOff, vo
   struct ibv_sge sge;
   memset(&sge, 0, sizeof(sge));
 
-  wr.opcode                  = IBV_WR_RDMA_WRITE;
-  wr.send_flags              = IBV_SEND_SIGNALED;
-  wr.wr_id                   = req - comm->base.reqs;
-  wr.next                    = NULL;
-  wr.wr.rdma.remote_addr     = (uint64_t)dstPtr;
-  wr.wr.rdma.rkey            = rkey;
+  wr.opcode = IBV_WR_RDMA_WRITE;
+  wr.send_flags = IBV_SEND_SIGNALED;
+  wr.wr_id = req - comm->base.reqs;
+  wr.next = NULL;
+  wr.wr.rdma.remote_addr = (uint64_t)dstPtr;
+  wr.wr.rdma.rkey = rkey;
   wr.sg_list = &sge;
   wr.num_sge = 1;
 
@@ -595,16 +582,15 @@ ncclResult_t IbCastGinIbProxyIPut(void *ginCtx, int context, uint64_t srcOff, vo
   return ncclSuccess;
 }
 
-ncclResult_t IbCastGinIbProxyIGet(void *ginCtx, int context, uint64_t remoteOffset, void *remoteMhandle,
-                                 size_t size, uint64_t localOffset, void *localMhandle, uint32_t rank,
-                                 void **request) {
+ncclResult_t IbCastGinIbProxyIGet(void* ginCtx, int context, uint64_t remoteOffset, void* remoteMhandle, size_t size,
+                                  uint64_t localOffset, void* localMhandle, uint32_t rank, void** request) {
   struct IbCastGinIbProxyCtx* ginProxyCtx = &((struct IbCastGinIbProxyCtx*)ginCtx)[context];
 
-  struct IbCastGinProxyMrHandle *remoteMrHandle = (struct IbCastGinProxyMrHandle *)remoteMhandle;
-  struct IbCastGinProxyMrHandle *localMrHandle = (struct IbCastGinProxyMrHandle *)localMhandle;
+  struct IbCastGinProxyMrHandle* remoteMrHandle = (struct IbCastGinProxyMrHandle*)remoteMhandle;
+  struct IbCastGinProxyMrHandle* localMrHandle = (struct IbCastGinProxyMrHandle*)localMhandle;
 
   struct ncclIbSendComm* comm = (struct ncclIbSendComm*)ginProxyCtx->fullSendComm[rank];
-  struct ncclIbQp *qp = &comm->base.qps[0];
+  struct ncclIbQp* qp = &comm->base.qps[0];
 
   struct ncclIbRequest* req;
   NCCLCHECK(IbCastGetRequest(&comm->base, &req));
@@ -616,8 +602,8 @@ ncclResult_t IbCastGinIbProxyIGet(void *ginCtx, int context, uint64_t remoteOffs
     req->devBases[i] = &comm->devs[i].base;
   }
 
-  void *remotePtr = (void *)(remoteMrHandle->base_vas[rank] + remoteOffset);
-  void *localPtr = (void *)(localMrHandle->base_vas[ginProxyCtx->rank] + localOffset);
+  void* remotePtr = (void*)(remoteMrHandle->base_vas[rank] + remoteOffset);
+  void* localPtr = (void*)(localMrHandle->base_vas[ginProxyCtx->rank] + localOffset);
   uint32_t rkey = remoteMrHandle->rkeys[rank];
   uint32_t lkey = localMrHandle->mrHandle->mrs[0]->lkey;
 
@@ -626,12 +612,12 @@ ncclResult_t IbCastGinIbProxyIGet(void *ginCtx, int context, uint64_t remoteOffs
   struct ibv_sge sge;
   memset(&sge, 0, sizeof(sge));
 
-  wr.opcode                  = IBV_WR_RDMA_READ;
-  wr.send_flags              = IBV_SEND_SIGNALED; // TODO: Potentially optimize this?
-  wr.wr_id                   = req - comm->base.reqs;
-  wr.next                    = NULL;
-  wr.wr.rdma.remote_addr     = (uint64_t)remotePtr;
-  wr.wr.rdma.rkey            = rkey;
+  wr.opcode = IBV_WR_RDMA_READ;
+  wr.send_flags = IBV_SEND_SIGNALED; // TODO: Potentially optimize this?
+  wr.wr_id = req - comm->base.reqs;
+  wr.next = NULL;
+  wr.wr.rdma.remote_addr = (uint64_t)remotePtr;
+  wr.wr.rdma.rkey = rkey;
   wr.sg_list = &sge;
   wr.num_sge = 1;
 
@@ -647,10 +633,9 @@ ncclResult_t IbCastGinIbProxyIGet(void *ginCtx, int context, uint64_t remoteOffs
   return ncclSuccess;
 }
 
-ncclResult_t IbCastGinIbProxyIPutSignal(void *ginCtx, int context, uint64_t srcOff, void *srcMhandle,
-                                      size_t size, uint64_t dstOff, void *dstMhandle, uint32_t rank,
-                                      uint64_t signalOff, void *signalMhandle, uint64_t signalValue,
-                                      uint32_t signalOp, void **request) {
+ncclResult_t IbCastGinIbProxyIPutSignal(void* ginCtx, int context, uint64_t srcOff, void* srcMhandle, size_t size,
+                                        uint64_t dstOff, void* dstMhandle, uint32_t rank, uint64_t signalOff,
+                                        void* signalMhandle, uint64_t signalValue, uint32_t signalOp, void** request) {
   if (signalOp != NCCL_NET_SIGNAL_OP_INC && signalOp != NCCL_NET_SIGNAL_OP_ADD) {
     WARN("IbCastGinIbProxyIPutSignal: Unsupported signalOp %u", signalOp);
     return ncclInvalidArgument;
@@ -658,12 +643,12 @@ ncclResult_t IbCastGinIbProxyIPutSignal(void *ginCtx, int context, uint64_t srcO
 
   struct IbCastGinIbProxyCtx* ginProxyCtx = &((struct IbCastGinIbProxyCtx*)ginCtx)[context];
 
-  struct IbCastGinProxyMrHandle *srcMrHandle = (struct IbCastGinProxyMrHandle *)srcMhandle;
-  struct IbCastGinProxyMrHandle *dstMrHandle = (struct IbCastGinProxyMrHandle *)dstMhandle;
-  struct IbCastGinProxyMrHandle *signalMrHandle = (struct IbCastGinProxyMrHandle *)signalMhandle;
+  struct IbCastGinProxyMrHandle* srcMrHandle = (struct IbCastGinProxyMrHandle*)srcMhandle;
+  struct IbCastGinProxyMrHandle* dstMrHandle = (struct IbCastGinProxyMrHandle*)dstMhandle;
+  struct IbCastGinProxyMrHandle* signalMrHandle = (struct IbCastGinProxyMrHandle*)signalMhandle;
 
   struct ncclIbSendComm* comm = (struct ncclIbSendComm*)ginProxyCtx->fullSendComm[rank];
-  struct ncclIbQp *qp = &comm->base.qps[0];
+  struct ncclIbQp* qp = &comm->base.qps[0];
   int devIndex = qp->devIndex;
 
   struct ncclIbRequest* req;
@@ -683,18 +668,18 @@ ncclResult_t IbCastGinIbProxyIPutSignal(void *ginCtx, int context, uint64_t srcO
 
   // If size is 0, we only need to send the signal. srcMrHandle must be non-NULL
   if (size > 0 && dstMrHandle) {
-    void *srcPtr = (void *)(srcMrHandle->base_vas[ginProxyCtx->rank] + srcOff);
-    void *dstPtr = (void *)(dstMrHandle->base_vas[rank] + dstOff);
+    void* srcPtr = (void*)(srcMrHandle->base_vas[ginProxyCtx->rank] + srcOff);
+    void* dstPtr = (void*)(dstMrHandle->base_vas[rank] + dstOff);
     uint32_t lkey = srcMrHandle->mrHandle->mrs[0]->lkey;
     uint32_t rkey = dstMrHandle->rkeys[rank];
 
     // PUT
-    wr[0].opcode                  = IBV_WR_RDMA_WRITE;
-    wr[0].send_flags              = 0; // We only need the CQE from the signal
-    wr[0].wr_id                   = req - comm->base.reqs;
-    wr[0].next                    = &wr[1];
-    wr[0].wr.rdma.remote_addr     = (uint64_t)dstPtr;
-    wr[0].wr.rdma.rkey            = rkey;
+    wr[0].opcode = IBV_WR_RDMA_WRITE;
+    wr[0].send_flags = 0; // We only need the CQE from the signal
+    wr[0].wr_id = req - comm->base.reqs;
+    wr[0].next = &wr[1];
+    wr[0].wr.rdma.remote_addr = (uint64_t)dstPtr;
+    wr[0].wr.rdma.rkey = rkey;
     wr[0].sg_list = &sge[0];
     wr[0].num_sge = 1;
 
@@ -703,17 +688,17 @@ ncclResult_t IbCastGinIbProxyIPutSignal(void *ginCtx, int context, uint64_t srcO
     sge[0].lkey = lkey;  // Local key
   }
 
-  void *signalPtr = (void *)(signalMrHandle->base_vas[rank] + signalOff);
+  void* signalPtr = (void*)(signalMrHandle->base_vas[rank] + signalOff);
   uint32_t signalRkey = signalMrHandle->rkeys[rank];
 
   // SIGNAL
-  wr[1].opcode                  = IBV_WR_ATOMIC_FETCH_AND_ADD;
-  wr[1].send_flags              = IBV_SEND_SIGNALED;
-  wr[1].wr_id                   = req - comm->base.reqs;  // used for matching completions with request
-  wr[1].next                    = NULL;
-  wr[1].wr.atomic.remote_addr   = (uint64_t)signalPtr;
-  wr[1].wr.atomic.compare_add   = signalOp == NCCL_NET_SIGNAL_OP_INC ? 1 : signalValue;
-  wr[1].wr.atomic.rkey          = signalRkey;
+  wr[1].opcode = IBV_WR_ATOMIC_FETCH_AND_ADD;
+  wr[1].send_flags = IBV_SEND_SIGNALED;
+  wr[1].wr_id = req - comm->base.reqs;  // used for matching completions with request
+  wr[1].next = NULL;
+  wr[1].wr.atomic.remote_addr = (uint64_t)signalPtr;
+  wr[1].wr.atomic.compare_add = signalOp == NCCL_NET_SIGNAL_OP_INC ? 1 : signalValue;
+  wr[1].wr.atomic.rkey = signalRkey;
   wr[1].sg_list = &sge[1];
   wr[1].num_sge = 1;
 
@@ -729,7 +714,7 @@ ncclResult_t IbCastGinIbProxyIPutSignal(void *ginCtx, int context, uint64_t srcO
   return ncclSuccess;
 }
 
-ncclResult_t IbCastGinIbProxyTest(void* collComm, void *request, int *done) {
+ncclResult_t IbCastGinIbProxyTest(void* collComm, void* request, int* done) {
   struct ncclIbRequest* req = (struct ncclIbRequest*)request;
   struct IbCastGinIbProxyCtx* ginProxyCtx = (struct IbCastGinIbProxyCtx*)req->ginProxyCtx;
   int rank = req->iput.rank;
@@ -761,17 +746,18 @@ ncclResult_t IbCastGinIbProxyTest(void* collComm, void *request, int *done) {
       ncclSocketGetAddr(req->sock, &addr);
       char localGidString[INET6_ADDRSTRLEN] = "";
       char remoteGidString[INET6_ADDRSTRLEN] = "";
-      const char* localGidStr = NULL, *remoteGidStr = NULL;
+      const char *localGidStr = NULL, *remoteGidStr = NULL;
       if (req->devBases[i]->gidInfo.link_layer == IBV_LINK_LAYER_ETHERNET) {
         localGidStr = ibvGetGidStr(&devBase->gidInfo.localGid, localGidString, sizeof(localGidString));
         remoteGidStr = ibvGetGidStr(&commBase->remDevs[i].remoteGid, remoteGidString, sizeof(remoteGidString));
       }
 
-      char line[SOCKET_NAME_MAXLEN+1];
-      char *hcaName = devBase->pd->context->device->name;
+      char line[SOCKET_NAME_MAXLEN + 1];
+      char* hcaName = devBase->pd->context->device->name;
       WARN("NET/IB/GIN: Got completion from peer %s with status=%d opcode=%d len=%u vendor err %u (%s)%s%s%s%s hca %s",
-          ncclSocketToString(&addr, line), wc[i].status, wc[i].opcode, wc[i].byte_len, wc[i].vendor_err, IbCastReqTypeStr[req->type],
-          localGidStr ?  " localGid ":"", localGidString, remoteGidStr ? " remoteGids":"", remoteGidString, hcaName);
+           ncclSocketToString(&addr, line), wc[i].status, wc[i].opcode, wc[i].byte_len, wc[i].vendor_err,
+           IbCastReqTypeStr[req->type], localGidStr ? " localGid " : "", localGidString,
+           remoteGidStr ? " remoteGids" : "", remoteGidString, hcaName);
       return ncclRemoteError;
     }
 
@@ -786,11 +772,11 @@ ncclResult_t IbCastGinIbProxyTest(void* collComm, void *request, int *done) {
   return ncclSuccess;
 }
 
-ncclResult_t IbCastGinIbProxyIFlush(void *ginCtx, int context, void* mhandle, uint32_t rank, void **request) {
+ncclResult_t IbCastGinIbProxyIFlush(void* ginCtx, int context, void* mhandle, uint32_t rank, void** request) {
   struct IbCastGinIbProxyCtx* ginProxyCtx = &((struct IbCastGinIbProxyCtx*)ginCtx)[context];
   struct ncclIbRecvComm* comm = (struct ncclIbRecvComm*)ginProxyCtx->fullRecvComm[rank];
-  struct IbCastGinProxyMrHandle *ginMrHandle = (struct IbCastGinProxyMrHandle *)mhandle;
-  struct ncclIbQp *qp = &comm->devs[0].gpuFlush.qp;
+  struct IbCastGinProxyMrHandle* ginMrHandle = (struct IbCastGinProxyMrHandle*)mhandle;
+  struct ncclIbQp* qp = &comm->devs[0].gpuFlush.qp;
 
   struct ncclIbRequest* req;
   NCCLCHECK(IbCastGetRequest(&comm->base, &req));
@@ -802,12 +788,12 @@ ncclResult_t IbCastGinIbProxyIFlush(void *ginCtx, int context, void* mhandle, ui
   struct ibv_send_wr wr;
   memset(&wr, 0, sizeof(wr));
   wr.wr_id = req - comm->base.reqs;
- 
+
   // The flush QP is a loopback (self-connected on the local recv comm), so the
   // RDMA READ target must be locally-registered memory. Use localRank, not rank
   // (the remote peer): rkeys[rank] is the remote's rkey, invalid in the local PD.
   int localRank = ginProxyCtx->rank;
-  void *flushPtr = (void *)(ginMrHandle->base_vas[localRank]);
+  void* flushPtr = (void*)(ginMrHandle->base_vas[localRank]);
   wr.wr.rdma.remote_addr = (uint64_t)flushPtr;
   wr.wr.rdma.rkey = ginMrHandle->rkeys[localRank];
   wr.sg_list = &comm->devs[qp->devIndex].gpuFlush.sge;
@@ -815,7 +801,8 @@ ncclResult_t IbCastGinIbProxyIFlush(void *ginCtx, int context, void* mhandle, ui
   wr.opcode = IBV_WR_RDMA_READ;
   wr.send_flags = IBV_SEND_SIGNALED;
 
-  TRACE(NCCL_NET, "NET/IB: %s: Posting a flush request (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base, wr.wr_id);
+  TRACE(NCCL_NET, "NET/IB: %s: Posting a flush request (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base,
+        wr.wr_id);
   TIME_START(4);
   struct ibv_send_wr* bad_wr;
   NCCLCHECK(wrap_ibv_post_send(qp->qp, &wr, &bad_wr));
@@ -830,26 +817,24 @@ ncclResult_t IbCastGinIbProxyIFlush(void *ginCtx, int context, void* mhandle, ui
 }
 
 // No support for NCCL_IB_SPLIT_DATA_ON_QPS or NCCL_IB_MERGE_NICS
-ncclGin_t IbCastGinIbProxy = {
-  "GIN_IB_PROXY",
-  IbCastGinIbProxyInit,
-  IbCastDevices,
-  IbCastGinIbProxyGetProperties,
-  IbCastListen,
-  IbCastGinIbProxyConnect,
-  IbCastGinIbProxyCreateContext,
-  IbCastGinIbProxyRegMrSym,
-  IbCastGinIbProxyRegMrSymDmaBuf,
-  IbCastGinIbProxyDeregMrSym,
-  IbCastGinIbProxyDestroyContext,
-  IbCastGinIbCloseColl,
-  IbCastCloseListen,
-  IbCastGinIbProxyIPut,
-  IbCastGinIbProxyIPutSignal,
-  IbCastGinIbProxyIGet,
-  IbCastGinIbProxyIFlush,
-  IbCastGinIbProxyTest,
-  NULL,
-  NULL,
-  IbCastGinIbFinalize
-};
+ncclGin_t IbCastGinIbProxy = {"GIN_IB_PROXY",
+                              IbCastGinIbProxyInit,
+                              IbCastDevices,
+                              IbCastGinIbProxyGetProperties,
+                              IbCastListen,
+                              IbCastGinIbProxyConnect,
+                              IbCastGinIbProxyCreateContext,
+                              IbCastGinIbProxyRegMrSym,
+                              IbCastGinIbProxyRegMrSymDmaBuf,
+                              IbCastGinIbProxyDeregMrSym,
+                              IbCastGinIbProxyDestroyContext,
+                              IbCastGinIbCloseColl,
+                              IbCastCloseListen,
+                              IbCastGinIbProxyIPut,
+                              IbCastGinIbProxyIPutSignal,
+                              IbCastGinIbProxyIGet,
+                              IbCastGinIbProxyIFlush,
+                              IbCastGinIbProxyTest,
+                              NULL,
+                              NULL,
+                              IbCastGinIbFinalize};

--- a/projects/rccl/src/transport/net_ib_cast/gin_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/gin_cast.h
@@ -13,20 +13,21 @@
 #include "nccl.h"
 
 struct CastIbGinCollComm {
-  void*         ctx;
-  int           rank;
-  int           nranks;
-  void*         recvComm;
-  void*         sendComm;
-  int           dev;
+  void* ctx;
+  int rank;
+  int nranks;
+  void* recvComm;
+  void* sendComm;
+  int dev;
   struct {
     struct ibv_context* context;
-    struct ibv_pd *pd;
-  }ib;
-  ncclResult_t (*getProperties)(int dev, void *props);
-  ncclResult_t (*allGather)(struct CastIbGinCollComm *cComm, void *srcBuf, void *recvBuf, size_t len);
-  ncclResult_t (*allToAll)(struct CastIbGinCollComm *cComm, void *srcBuf, void *recvBuf, size_t len);
-  ncclResult_t (*getGidIndex)(struct ibv_context *context, uint8_t portNum, struct ibv_port_attr* portAttr, int *gidIndex);
+    struct ibv_pd* pd;
+  } ib;
+  ncclResult_t (*getProperties)(int dev, void* props);
+  ncclResult_t (*allGather)(struct CastIbGinCollComm* cComm, void* srcBuf, void* recvBuf, size_t len);
+  ncclResult_t (*allToAll)(struct CastIbGinCollComm* cComm, void* srcBuf, void* recvBuf, size_t len);
+  ncclResult_t (*getGidIndex)(struct ibv_context* context, uint8_t portNum, struct ibv_port_attr* portAttr,
+                              int* gidIndex);
 };
 
 #endif

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -32,10 +32,10 @@ ncclResult_t pciPathToInt64(char* path, int64_t* id);
 
 NCCL_PARAM(IbCastPciRelaxedOrdering, "IB_PCI_RELAXED_ORDERING", 2);
 NCCL_PARAM(IbCastAdaptiveRouting, "IB_ADAPTIVE_ROUTING", -2);
-NCCL_PARAM(IbCastDataDirect,"IB_DATA_DIRECT",1);
+NCCL_PARAM(IbCastDataDirect, "IB_DATA_DIRECT", 1);
 
 // default to 0 to disable ooo rq, if set to 1, ooo rq will be enabled or failed
-NCCL_PARAM(IbCastOooRq,"IB_OOO_RQ", 0)
+NCCL_PARAM(IbCastOooRq, "IB_OOO_RQ", 0)
 
 static std::mutex IbCastMutex;
 
@@ -57,9 +57,9 @@ extern int64_t ncclParamIbCastArThreshold();
 static int IbCastMatchVfPath(char* path1, char* path2) {
   // Merge multi-port NICs into the same PCI device
   if (ncclParamIbCastMergeVfs()) {
-    return strncmp(path1, path2, strlen(path1)-4) == 0;
+    return strncmp(path1, path2, strlen(path1) - 4) == 0;
   } else {
-    return strncmp(path1, path2, strlen(path1)-1) == 0;
+    return strncmp(path1, path2, strlen(path1) - 1) == 0;
   }
 }
 
@@ -89,9 +89,9 @@ static ncclResult_t IbCastGetPciPath(char* devName, char** path, char* fullPath)
     WARN("Could not find real path of %s (%s)", devName, devicePath);
   } else {
     // Merge multi-port NICs into the same PCI device
-    p[strlen(p)-1] = '0';
+    p[strlen(p) - 1] = '0';
     // Also merge virtual functions (VF) into the same device
-    if (ncclParamIbCastMergeVfs()) p[strlen(p)-3] = p[strlen(p)-4] = '0';
+    if (ncclParamIbCastMergeVfs()) p[strlen(p) - 3] = p[strlen(p) - 4] = '0';
   }
   if (path) {
     *path = p;
@@ -112,7 +112,7 @@ static ncclResult_t IbCastGetRealPort(char* pciPath, int* realPort, int devIdx) 
   return ncclSuccess;
 }
 
-static int ibvWidths[] = { 1, 4, 8, 12, 2 };
+static int ibvWidths[] = {1, 4, 8, 12, 2};
 static int ibvSpeeds[] = {
   2500,  /* SDR */
   5000,  /* DDR */
@@ -126,14 +126,14 @@ static int ibvSpeeds[] = {
 
 static int firstBitSet(int val, int max) {
   int i = 0;
-  while (i<max && ((val & (1<<i)) == 0)) i++;
+  while (i < max && ((val & (1 << i)) == 0)) i++;
   return i;
 }
 static int IbCastWidth(int width) {
-  return ibvWidths[firstBitSet(width, sizeof(ibvWidths)/sizeof(int)-1)];
+  return ibvWidths[firstBitSet(width, sizeof(ibvWidths) / sizeof(int) - 1)];
 }
 static int IbCastSpeed(int speed) {
-  return ibvSpeeds[firstBitSet(speed, sizeof(ibvSpeeds)/sizeof(int)-1)];
+  return ibvSpeeds[firstBitSet(speed, sizeof(ibvSpeeds) / sizeof(int) - 1)];
 }
 
 // Determine whether RELAXED_ORDERING is enabled and possible
@@ -147,7 +147,7 @@ static int IbCastRelaxedOrderingCapable(void) {
   return r == ncclInternalError ? 0 : 1;
 }
 
-static bool ncclMlx5dvDmaBufCapable(ibv_context *context){
+static bool ncclMlx5dvDmaBufCapable(ibv_context* context) {
   ncclResult_t res;
   int dev_fail = 0;
 
@@ -156,7 +156,8 @@ static bool ncclMlx5dvDmaBufCapable(ibv_context *context){
   // Test kernel DMA-BUF support with a dummy call (fd=-1)
   (void)wrap_direct_ibv_reg_dmabuf_mr(pd, 0ULL /*offset*/, 0ULL /*len*/, 0ULL /*iova*/, -1 /*fd*/, 0 /*flags*/);
   dev_fail |= (errno == EOPNOTSUPP) || (errno == EPROTONOSUPPORT);
-  (void)wrap_direct_mlx5dv_reg_dmabuf_mr(pd, 0ULL /*offset*/, 0ULL /*len*/, 0ULL /*iova*/, -1 /*fd*/, 0 /*flags*/, 0 /* mlx5 flags*/);
+  (void)wrap_direct_mlx5dv_reg_dmabuf_mr(pd, 0ULL /*offset*/, 0ULL /*len*/, 0ULL /*iova*/, -1 /*fd*/, 0 /*flags*/,
+                                         0 /* mlx5 flags*/);
   dev_fail |= (errno == EOPNOTSUPP) || (errno == EPROTONOSUPPORT);
   NCCLCHECKGOTO(wrap_ibv_dealloc_pd(pd), res, failure);
   // stop the search and goto failure
@@ -169,7 +170,7 @@ failure:
 extern int64_t ncclParamIbCastPrepostReceiveWorkRequests();
 extern int64_t ncclParamIbCastReceiverSideMatchingScheme();
 
-static ncclResult_t IbCastQueryOooRqSize(struct ibv_context* ibvCtx, const char *devName, uint32_t* oooRqSize) {
+static ncclResult_t IbCastQueryOooRqSize(struct ibv_context* ibvCtx, const char* devName, uint32_t* oooRqSize) {
   ncclResult_t ret;
   if (!oooRqSize) return ncclInvalidArgument;
   *oooRqSize = 0;
@@ -185,7 +186,6 @@ static ncclResult_t IbCastQueryOooRqSize(struct ibv_context* ibvCtx, const char 
     *oooRqSize = dvCtx.ooo_recv_wrs_caps.max_rc;
   }
 
-
   return ncclSuccess;
 fail:
   return ncclInternalError;
@@ -195,8 +195,7 @@ ncclResult_t IbCastMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
   // On AINIC, NIC fusion (cast) is disabled by default: each NIC runs independently.
   // User must explicitly set NCCL_IB_MERGE_NICS=1 to override.
   if (props->ndevs > 1) {
-    if (ncclParamIbCastMergeNics() == 0 ||
-        (rcclUseAinic() && ncclParamIbCastMergeNics() != 1)) {
+    if (ncclParamIbCastMergeNics() == 0 || (rcclUseAinic() && ncclParamIbCastMergeNics() != 1)) {
       WARN("NET/IB : Skipping makeVDevice%s, Please set NCCL_IB_MERGE_NICS=1",
            rcclUseAinic() ? " (disabled by default on AINIC)" : "");
       return ncclInvalidUsage;
@@ -204,8 +203,8 @@ ncclResult_t IbCastMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
   }
 
   if (props->ndevs == 0) {
-      WARN("NET/IB : Can't make virtual NIC with 0 devices");
-      return ncclInvalidUsage;
+    WARN("NET/IB : Can't make virtual NIC with 0 devices");
+    return ncclInvalidUsage;
   }
 
   if (IbCastNMergedDevs == MAX_IB_VDEVS) {
@@ -225,7 +224,8 @@ ncclResult_t IbCastMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
     mDev->speed += dev->speed;
     // Each successive time, copy the name '+' new name
     if (mDev->vProps.ndevs > 1) {
-      snprintf(mDev->devName + strlen(mDev->devName), sizeof(mDev->devName) - strlen(mDev->devName), "+%s", dev->devName);
+      snprintf(mDev->devName + strlen(mDev->devName), sizeof(mDev->devName) - strlen(mDev->devName), "+%s",
+               dev->devName);
     // First time, copy the plain name
     } else {
       strncpy(mDev->devName, dev->devName, MAXNAMESIZE);
@@ -241,15 +241,17 @@ ncclResult_t IbCastMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
     }
     ncclIbDev* dev = IbCastDevs + props->devs[i];
     if (dev->link != dev0->link) {
-      WARN("NET/IB : Attempted to merge incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of only one link type using NCCL_IB_HCA",
-        props->devs[0], dev0->devName, dev0->portNum, NCCL_IB_LLSTR(dev0->link), props->devs[i], dev->devName, dev->portNum, NCCL_IB_LLSTR(dev->link));
+      WARN("NET/IB : Attempted to merge incompatible devices: [%d]%s:%d/%s and [%d]%s:%d/%s. Try selecting NICs of "
+           "only one link type using NCCL_IB_HCA",
+           props->devs[0], dev0->devName, dev0->portNum, NCCL_IB_LLSTR(dev0->link), props->devs[i], dev->devName,
+           dev->portNum, NCCL_IB_LLSTR(dev->link));
       return ncclInvalidUsage;
     }
   }
 
   int numa0 = IbCastGetNumaNodeFromPath(dev0->pciPath);
-  //format -> 0000:00 
-  char root0[8]; 
+  // format -> 0000:00
+  char root0[8];
   IbCastGetPciRootFromPath(dev0->pciPath, root0, sizeof(root0));
   for (int i = 1; i < props->ndevs; i++) {
     ncclIbDev* dev = IbCastDevs + props->devs[i];
@@ -276,13 +278,15 @@ ncclResult_t IbCastMakeVDeviceInternal(int* d, ncclNetVDeviceProps_t* props) {
   // (NCCL_IB_MERGE_NICS). Disable them when a multi-NIC vNIC is created.
   if (props->ndevs > 1) {
     if (IbCastOffloadEnabled) {
-      INFO(NCCL_INIT|NCCL_NET, "NET/IB : NIC Fusion (ndevs=%d) - disabling CTS Offload (not yet supported with merge)", props->ndevs);
+      INFO(NCCL_INIT | NCCL_NET,
+           "NET/IB : NIC Fusion (ndevs=%d) - disabling CTS Offload (not yet supported with merge)", props->ndevs);
       IbCastOffloadEnabled = false;
     }
   }
 
   *d = IbCastNMergedDevs++;
-  INFO(NCCL_NET, "NET/IB : Made virtual device [%d] name=%s speed=%d ndevs=%d", *d, mDev->devName, mDev->speed, mDev->vProps.ndevs);
+  INFO(NCCL_NET, "NET/IB : Made virtual device [%d] name=%s speed=%d ndevs=%d", *d, mDev->devName, mDev->speed,
+       mDev->vProps.ndevs);
   return ncclSuccess;
 }
 
@@ -290,10 +294,9 @@ ncclResult_t IbCastMakeVDevice(int* d, ncclNetVDeviceProps_t* props) {
   std::lock_guard<std::mutex> lock(IbCastMutex);
   ncclResult_t res = IbCastMakeVDeviceInternal(d, props);
   return res;
-
 }
 
-ncclResult_t IbCastSetNetAttr(void *ctx, ncclNetAttr_t *netAttr) {
+ncclResult_t IbCastSetNetAttr(void* ctx, ncclNetAttr_t* netAttr) {
   (void)ctx;
   (void)netAttr;
   return ncclSuccess;
@@ -316,10 +319,15 @@ ncclResult_t IbCastInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
   IbCastProfilerFunction = profFunction;
   if (ncclParamIbCastDisable()) return ncclInternalError;
   static int shownIbHcaEnv = 0;
-  if(wrap_ibv_symbols() != ncclSuccess) { return ncclInternalError; }
-  if(wrap_mlx5dv_symbols() != ncclSuccess) { INFO(NCCL_NET, "NET/IB : Failed to open mlx5dv symbols. Advance features like CX-8 Direct-NIC will be disabled."); }
-  if(wrap_ionicdv_symbols() != ncclSuccess) {
-    INFO(NCCL_NET, "NET/IB : Failed to open ionicdv symbols. Advance features like AINIC UD load balancing will be disabled.");
+  if (wrap_ibv_symbols() != ncclSuccess) {
+    return ncclInternalError;
+  }
+  if (wrap_mlx5dv_symbols() != ncclSuccess) {
+    INFO(NCCL_NET, "NET/IB : Failed to open mlx5dv symbols. Advance features like CX-8 Direct-NIC will be disabled.");
+  }
+  if (wrap_ionicdv_symbols() != ncclSuccess) {
+    INFO(NCCL_NET,
+         "NET/IB : Failed to open ionicdv symbols. Advance features like AINIC UD load balancing will be disabled.");
     return ncclInternalError;
   }
 
@@ -344,7 +352,7 @@ ncclResult_t IbCastInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
 
       // Check if user defined which IB device:port to use
       const char* userIbEnv = ncclGetEnv("NCCL_IB_HCA");
-      if (userIbEnv != NULL && shownIbHcaEnv++ == 0) INFO(NCCL_NET|NCCL_ENV, "NCCL_IB_HCA set to %s", userIbEnv);
+      if (userIbEnv != NULL && shownIbHcaEnv++ == 0) INFO(NCCL_NET | NCCL_ENV, "NCCL_IB_HCA set to %s", userIbEnv);
       struct netIf userIfs[MAX_IB_DEVS];
       bool searchNot = userIbEnv && userIbEnv[0] == '^';
       if (searchNot) userIbEnv++;
@@ -352,16 +360,19 @@ ncclResult_t IbCastInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
       if (searchExact) userIbEnv++;
       int nUserIfs = parseStringList(userIbEnv, userIfs, MAX_IB_DEVS);
 
-      if (ncclSuccess != wrap_ibv_get_device_list(&devices, &nIbDevs)) { ret = ncclInternalError; goto fail; }
+      if (ncclSuccess != wrap_ibv_get_device_list(&devices, &nIbDevs)) {
+        ret = ncclInternalError;
+        goto fail;
+      }
 
-      for (int d=0; d<nIbDevs && IbCastNDevs<MAX_IB_DEVS; d++) {
-        struct ibv_context * context = NULL;
+      for (int d = 0; d < nIbDevs && IbCastNDevs < MAX_IB_DEVS; d++) {
+        struct ibv_context* context = NULL;
         if (ncclSuccess != wrap_ibv_open_device(&context, devices[d]) || context == NULL) {
           WARN("NET/IB : Unable to open device %s", devices[d]->name);
           continue;
         }
         char dataDirectDevicePath[PATH_MAX] = "/sys";
-        int devCount = /*undefined*/-1, devOffset = 0;
+        int devCount = /*undefined*/ -1, devOffset = 0;
 
         uint32_t oooRqSize = 0;
         enum ncclIbProvider ibProvider = wrap_mlx5dv_is_supported(devices[d]) ? IB_PROVIDER_MLX5 : IB_PROVIDER_NONE;
@@ -374,102 +385,119 @@ ncclResult_t IbCastInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
         memset(&devAttr, 0, sizeof(devAttr));
         if (ncclSuccess != wrap_ibv_query_device(context, &devAttr)) {
           WARN("NET/IB : Unable to query device %s", devices[d]->name);
-          if (ncclSuccess != wrap_ibv_close_device(context)) { ret = ncclInternalError; goto fail; }
+          if (ncclSuccess != wrap_ibv_close_device(context)) {
+            ret = ncclInternalError;
+            goto fail;
+          }
           continue;
         }
         for (int port_num = 1; port_num <= devAttr.phys_port_cnt; port_num++) {
-            struct ibv_port_attr portAttr;
-            if (ncclSuccess != wrap_ibv_query_port(context, port_num, &portAttr)) {
-              WARN("NET/IB : Unable to query port_num %d", port_num);
-              continue;
-            }
-            if (portAttr.state != IBV_PORT_ACTIVE) continue;
-            if (portAttr.link_layer != IBV_LINK_LAYER_INFINIBAND && portAttr.link_layer != IBV_LINK_LAYER_ETHERNET) continue;
+          struct ibv_port_attr portAttr;
+          if (ncclSuccess != wrap_ibv_query_port(context, port_num, &portAttr)) {
+            WARN("NET/IB : Unable to query port_num %d", port_num);
+            continue;
+          }
+          if (portAttr.state != IBV_PORT_ACTIVE) continue;
+          if (portAttr.link_layer != IBV_LINK_LAYER_INFINIBAND && portAttr.link_layer != IBV_LINK_LAYER_ETHERNET)
+            continue;
 
             // check against user specified HCAs/ports
-            if (! (matchIfList(devices[d]->name, port_num, userIfs, nUserIfs, searchExact) ^ searchNot)) {
-              continue;
-            }
+          if (!(matchIfList(devices[d]->name, port_num, userIfs, nUserIfs, searchExact) ^ searchNot)) {
+            continue;
+          }
 
             // check for mlx5 data direct support only once for a each device
-            if (devCount == -1) {
-              devCount = 1;
-              devOffset = 0;
-              if (ncclParamIbCastDataDirect() > 0 && ibProvider == IB_PROVIDER_MLX5 && ncclMlx5dvDmaBufCapable(context)) {
-                int pathLen = strlen(dataDirectDevicePath);
-                ncclResult_t res = wrap_mlx5dv_get_data_direct_sysfs_path(context, dataDirectDevicePath + pathLen, sizeof(dataDirectDevicePath) - pathLen);
-                if (res == ncclSuccess) {
-                  // data direct devices are exposed twice: with the C2C + PCIe link and with the data direct link
-                  devCount = 2;
-                  // by default only expose the data direct NIC (devOffset = 1), unless set to 2 by the user
-                  devOffset = (ncclParamIbCastDataDirect() == 2) ? 0 : 1;
-                  INFO(NCCL_INIT | NCCL_NET, "NET/IB: Data Direct DMA Interface is detected for device %s", devices[d]->name);
-                } else if (res == ncclInvalidArgument) {
-                  TRACE(NCCL_NET, "NET/IB: Device %s does not support Data Direct DMA.", devices[d]->name);
-                } else {
-                  WARN("NET/IB: Error in mlx5dv_get_data_direct_sysfs_path with device %s", devices[d]->name);
-                  return res;
-                }
-              }
-            }
-            for (int dev = devOffset; dev < devCount; ++dev) {
-              IbCastDevs[IbCastNDevs].device = d;
-              IbCastDevs[IbCastNDevs].ibProvider = ibProvider;
-              IbCastDevs[IbCastNDevs].guid = devAttr.sys_image_guid;
-              IbCastDevs[IbCastNDevs].portAttr = portAttr;
-              IbCastDevs[IbCastNDevs].portNum = port_num;
-              IbCastDevs[IbCastNDevs].link = portAttr.link_layer;
-              if (portAttr.active_speed_ex) {
-                // A non-zero active_speed_ex indicates XDR rate (0x100) or higher
-                IbCastDevs[IbCastNDevs].speed = IbCastSpeed(portAttr.active_speed_ex) * IbCastWidth(portAttr.active_width);
+          if (devCount == -1) {
+            devCount = 1;
+            devOffset = 0;
+            if (ncclParamIbCastDataDirect() > 0 && ibProvider == IB_PROVIDER_MLX5 && ncclMlx5dvDmaBufCapable(context)) {
+              int pathLen = strlen(dataDirectDevicePath);
+              ncclResult_t res = wrap_mlx5dv_get_data_direct_sysfs_path(context, dataDirectDevicePath + pathLen,
+                                                                        sizeof(dataDirectDevicePath) - pathLen);
+              if (res == ncclSuccess) {
+                // data direct devices are exposed twice: with the C2C + PCIe link and with the data direct link
+                devCount = 2;
+                // by default only expose the data direct NIC (devOffset = 1), unless set to 2 by the user
+                devOffset = (ncclParamIbCastDataDirect() == 2) ? 0 : 1;
+                INFO(NCCL_INIT | NCCL_NET, "NET/IB: Data Direct DMA Interface is detected for device %s",
+                     devices[d]->name);
+              } else if (res == ncclInvalidArgument) {
+                TRACE(NCCL_NET, "NET/IB: Device %s does not support Data Direct DMA.", devices[d]->name);
               } else {
-                IbCastDevs[IbCastNDevs].speed = IbCastSpeed(portAttr.active_speed) * IbCastWidth(portAttr.active_width);
+                WARN("NET/IB: Error in mlx5dv_get_data_direct_sysfs_path with device %s", devices[d]->name);
+                return res;
               }
-              IbCastDevs[IbCastNDevs].context = context;
-              IbCastDevs[IbCastNDevs].pdRefs = 0;
-              IbCastDevs[IbCastNDevs].pd = NULL;
-              // for dev==1 (data direct device), pciPath is given by mlx5
-              strncpy(IbCastDevs[IbCastNDevs].devName, devices[d]->name, MAXNAMESIZE);
-              NCCLCHECKGOTO(IbCastGetPciPath(IbCastDevs[IbCastNDevs].devName, (dev == 1) ? NULL : &IbCastDevs[IbCastNDevs].pciPath, IbCastDevs[IbCastNDevs].fullPciPath), ret, fail);
-              if (dev == 1) {
-                snprintf(IbCastDevs[IbCastNDevs].devName, MAXNAMESIZE, "%s_dma", devices[d]->name);
-                NCCLCHECK(ncclCalloc(&IbCastDevs[IbCastNDevs].pciPath, PATH_MAX));
-                strncpy(IbCastDevs[IbCastNDevs].pciPath, dataDirectDevicePath, PATH_MAX);
-                IbCastDevs[IbCastNDevs].capsProvider.mlx5.dataDirect = 1;
-              }
-
-              IbCastDevs[IbCastNDevs].maxQp = devAttr.max_qp;
-              IbCastDevs[IbCastNDevs].oooRqSize = oooRqSize;
-              IbCastDevs[IbCastNDevs].mrCache.capacity = 0;
-              IbCastDevs[IbCastNDevs].mrCache.population = 0;
-              IbCastDevs[IbCastNDevs].mrCache.slots = NULL;
-              NCCLCHECK(IbCastStatsInit(&IbCastDevs[IbCastNDevs].stats));
-
-              // Enable ADAPTIVE_ROUTING by default on IB networks
-              // But allow it to be overloaded by an env parameter
-              IbCastDevs[IbCastNDevs].ar = (portAttr.link_layer == IBV_LINK_LAYER_INFINIBAND) ? 1 : 0;
-              if (ncclParamIbCastAdaptiveRouting() != -2) IbCastDevs[IbCastNDevs].ar = ncclParamIbCastAdaptiveRouting();
-
-
-              INFO(NCCL_NET, "NET/IB: [%d] %s:%s:%d/%s provider=%s speed=%d context=%p pciPath=%s ar=%d oooRqSize=%d", d, devices[d]->name, devices[d]->dev_name,
-                   IbCastDevs[IbCastNDevs].portNum, NCCL_IB_LLSTR(portAttr.link_layer), ibCastProviderName[IbCastDevs[IbCastNDevs].ibProvider], IbCastDevs[IbCastNDevs].speed, context,
-                   IbCastDevs[IbCastNDevs].pciPath, IbCastDevs[IbCastNDevs].ar, IbCastDevs[IbCastNDevs].oooRqSize);
-
-              IbCastAsyncThread = std::thread(IbCastAsyncThreadMain, IbCastDevs + IbCastNDevs);
-              ncclSetThreadName(IbCastAsyncThread.native_handle(), "NCCL IbAsync %2d", IbCastNDevs);
-              IbCastAsyncThread.detach();
-
-              IbCastNDevs++;
-              nPorts++;
             }
+          }
+          for (int dev = devOffset; dev < devCount; ++dev) {
+            IbCastDevs[IbCastNDevs].device = d;
+            IbCastDevs[IbCastNDevs].ibProvider = ibProvider;
+            IbCastDevs[IbCastNDevs].guid = devAttr.sys_image_guid;
+            IbCastDevs[IbCastNDevs].portAttr = portAttr;
+            IbCastDevs[IbCastNDevs].portNum = port_num;
+            IbCastDevs[IbCastNDevs].link = portAttr.link_layer;
+            if (portAttr.active_speed_ex) {
+              // A non-zero active_speed_ex indicates XDR rate (0x100) or higher
+              IbCastDevs[IbCastNDevs].speed =
+                IbCastSpeed(portAttr.active_speed_ex) * IbCastWidth(portAttr.active_width);
+            } else {
+              IbCastDevs[IbCastNDevs].speed = IbCastSpeed(portAttr.active_speed) * IbCastWidth(portAttr.active_width);
+            }
+            IbCastDevs[IbCastNDevs].context = context;
+            IbCastDevs[IbCastNDevs].pdRefs = 0;
+            IbCastDevs[IbCastNDevs].pd = NULL;
+            // for dev==1 (data direct device), pciPath is given by mlx5
+            strncpy(IbCastDevs[IbCastNDevs].devName, devices[d]->name, MAXNAMESIZE);
+            NCCLCHECKGOTO(IbCastGetPciPath(IbCastDevs[IbCastNDevs].devName,
+                                           (dev == 1) ? NULL : &IbCastDevs[IbCastNDevs].pciPath,
+                                           IbCastDevs[IbCastNDevs].fullPciPath),
+                          ret, fail);
+            if (dev == 1) {
+              snprintf(IbCastDevs[IbCastNDevs].devName, MAXNAMESIZE, "%s_dma", devices[d]->name);
+              NCCLCHECK(ncclCalloc(&IbCastDevs[IbCastNDevs].pciPath, PATH_MAX));
+              strncpy(IbCastDevs[IbCastNDevs].pciPath, dataDirectDevicePath, PATH_MAX);
+              IbCastDevs[IbCastNDevs].capsProvider.mlx5.dataDirect = 1;
+            }
+
+            IbCastDevs[IbCastNDevs].maxQp = devAttr.max_qp;
+            IbCastDevs[IbCastNDevs].oooRqSize = oooRqSize;
+            IbCastDevs[IbCastNDevs].mrCache.capacity = 0;
+            IbCastDevs[IbCastNDevs].mrCache.population = 0;
+            IbCastDevs[IbCastNDevs].mrCache.slots = NULL;
+            NCCLCHECK(IbCastStatsInit(&IbCastDevs[IbCastNDevs].stats));
+
+            // Enable ADAPTIVE_ROUTING by default on IB networks
+            // But allow it to be overloaded by an env parameter
+            IbCastDevs[IbCastNDevs].ar = (portAttr.link_layer == IBV_LINK_LAYER_INFINIBAND) ? 1 : 0;
+            if (ncclParamIbCastAdaptiveRouting() != -2) IbCastDevs[IbCastNDevs].ar = ncclParamIbCastAdaptiveRouting();
+
+            INFO(NCCL_NET, "NET/IB: [%d] %s:%s:%d/%s provider=%s speed=%d context=%p pciPath=%s ar=%d oooRqSize=%d", d,
+                 devices[d]->name, devices[d]->dev_name, IbCastDevs[IbCastNDevs].portNum,
+                 NCCL_IB_LLSTR(portAttr.link_layer), ibCastProviderName[IbCastDevs[IbCastNDevs].ibProvider],
+                 IbCastDevs[IbCastNDevs].speed, context, IbCastDevs[IbCastNDevs].pciPath, IbCastDevs[IbCastNDevs].ar,
+                 IbCastDevs[IbCastNDevs].oooRqSize);
+
+            IbCastAsyncThread = std::thread(IbCastAsyncThreadMain, IbCastDevs + IbCastNDevs);
+            ncclSetThreadName(IbCastAsyncThread.native_handle(), "NCCL IbAsync %2d", IbCastNDevs);
+            IbCastAsyncThread.detach();
+
+            IbCastNDevs++;
+            nPorts++;
+          }
         }
-        if (nPorts == 0 && ncclSuccess != wrap_ibv_close_device(context)) { ret = ncclInternalError; goto fail; }
+        if (nPorts == 0 && ncclSuccess != wrap_ibv_close_device(context)) {
+          ret = ncclInternalError;
+          goto fail;
+        }
       }
 
-      if (devices && (ncclSuccess != wrap_ibv_free_device_list(devices))) { ret = ncclInternalError; goto fail; }
+      if (devices && (ncclSuccess != wrap_ibv_free_device_list(devices))) {
+        ret = ncclInternalError;
+        goto fail;
+      }
     }
     if (IbCastNDevs == 0) {
-      INFO(NCCL_INIT|NCCL_NET, "NET/IB : No device found.");
+      INFO(NCCL_INIT | NCCL_NET, "NET/IB : No device found.");
     }
     // Determine whether RELAXED_ORDERING is enabled and possible
     IbCastRelaxedOrderingEnabled = IbCastRelaxedOrderingCapable();
@@ -479,7 +507,7 @@ ncclResult_t IbCastInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
       if (ncclParamIbCastOooRq()) {
         INFO(NCCL_NET, "NET/IB: OOO RQ is enabled, AR threshold will be ignored.");
       } else {
-        IbCastArThreshold = ncclParamIbCastArThreshold();  // set explicitly by user
+        IbCastArThreshold = ncclParamIbCastArThreshold(); // set explicitly by user
       }
     }
     // sort devices to ensure a consistent order across nodes
@@ -489,7 +517,8 @@ ncclResult_t IbCastInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
     char line[2048] = "";
     for (int d = 0; d < IbCastNDevs; d++) {
       NCCLCHECKGOTO(IbCastGetRealPort(IbCastDevs[d].pciPath, &IbCastDevs[d].realPort, d), ret, fail);
-      snprintf(line + strlen(line), sizeof(line) - strlen(line), " [%d]%s:%d/%s", d, IbCastDevs[d].devName, IbCastDevs[d].portNum, NCCL_IB_LLSTR(IbCastDevs[d].link));
+      snprintf(line + strlen(line), sizeof(line) - strlen(line), " [%d]%s:%d/%s", d, IbCastDevs[d].devName,
+               IbCastDevs[d].portNum, NCCL_IB_LLSTR(IbCastDevs[d].link));
 
       // Add this plain physical device to the list of virtual devices (after sorting)
       int vDev;
@@ -498,12 +527,12 @@ ncclResult_t IbCastInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
       vProps.devs[0] = d;
       NCCLCHECK(IbCastMakeVDeviceInternal(&vDev, &vProps));
     }
-    char addrline[SOCKET_NAME_MAXLEN+1];
-    INFO(NCCL_INIT | NCCL_NET, "NET/IB : Using%s %s; OOB %s:%s", line, IbCastRelaxedOrderingEnabled ? "[RO]" : "", IbCastIfName, ncclSocketToString(&IbCastIfAddr, addrline));
-
+    char addrline[SOCKET_NAME_MAXLEN + 1];
+    INFO(NCCL_INIT | NCCL_NET, "NET/IB : Using%s %s; OOB %s:%s", line, IbCastRelaxedOrderingEnabled ? "[RO]" : "",
+         IbCastIfName, ncclSocketToString(&IbCastIfAddr, addrline));
 
     IbCastUseInline = ncclParamIbCastUseInline();
-    IbCastGdrFlushDisable = ncclParamIbCastGdrFlushDisable(); 
+    IbCastGdrFlushDisable = ncclParamIbCastGdrFlushDisable();
 
     if (IbCastAinicRoce) {
       // for AINIC, these params are defaulted to enabled unless user forces it to disable(0).
@@ -512,46 +541,50 @@ ncclResult_t IbCastInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
       // CTS Offload and CTS Inline are mutually dependent — both must be
       // enabled for either to function. Disable both if either is missing.
       if (IbCastOffloadEnabled && rcclUseIbCastQpSched()) {
-        INFO(NCCL_INIT|NCCL_NET, "NET/IB : CAST enabled - disabling CTS Inline Data and CTS Offload (not yet supported with CAST)");
+        INFO(NCCL_INIT | NCCL_NET,
+             "NET/IB : CAST enabled - disabling CTS Inline Data and CTS Offload (not yet supported with CAST)");
         IbCastOffloadEnabled = false;
       }
       // for AINIC IbUseInline is enabled by default always
       IbCastUseInline = true;
 
-      INFO(NCCL_INIT|NCCL_NET, "NET/IB : AINIC RoCEv2 optimizations enabled: CTS Inline Data: %s; CTS Offload: %s; "
-           "IB Use Inline: enabled; GDR Flush: disabled", IbCastUseInline ? "Enabled": "Disabled",
-           IbCastOffloadEnabled ? "Enabled": "Disabled");
+      INFO(NCCL_INIT | NCCL_NET,
+           "NET/IB : AINIC RoCEv2 optimizations enabled: CTS Inline Data: %s; CTS Offload: %s; "
+           "IB Use Inline: enabled; GDR Flush: disabled",
+           IbCastUseInline ? "Enabled" : "Disabled", IbCastOffloadEnabled ? "Enabled" : "Disabled");
     }
   }
 exit:
-  if (ret == ncclSuccess)
-    ret = IbCastQpSchedInitParms(&castGlobalQpSchedParms);
+  if (ret == ncclSuccess) ret = IbCastQpSchedInitParms(&castGlobalQpSchedParms);
   if (ret == ncclSuccess && castGlobalQpSchedParms.enable &&
       (ncclParamIbCastResiliencyPortFailover() || ncclParamIbCastResiliencyPortRecovery())) {
-    INFO(NCCL_INIT|NCCL_NET, "NET/IB : PORT_FAILOVER/RECOVERY enabled - disabling QP scheduler "
-         "(load balancer integration with resiliency is pending)");
+    INFO(NCCL_INIT | NCCL_NET, "NET/IB : PORT_FAILOVER/RECOVERY enabled - disabling QP scheduler "
+                               "(load balancer integration with resiliency is pending)");
     castGlobalQpSchedParms.enable = false;
   }
   if (ret == ncclSuccess && IbCastOffloadEnabled &&
       (ncclParamIbCastResiliencyPortFailover() || ncclParamIbCastResiliencyPortRecovery())) {
-    INFO(NCCL_INIT|NCCL_NET, "NET/IB : PORT_FAILOVER/RECOVERY enabled - disabling CTS offload "
-         "(not compatible with resiliency)");
+    INFO(NCCL_INIT | NCCL_NET, "NET/IB : PORT_FAILOVER/RECOVERY enabled - disabling CTS offload "
+                               "(not compatible with resiliency)");
     IbCastOffloadEnabled = false;
   }
   return ret;
 fail:
-  if(devices && (ncclSuccess != wrap_ibv_free_device_list(devices))){WARN("NET/IB : Unable to free device list");}
+  if (devices && (ncclSuccess != wrap_ibv_free_device_list(devices))) {
+    WARN("NET/IB : Unable to free device list");
+  }
   goto exit;
 }
 
-ncclResult_t IbCastInit(void** ctx, uint64_t commId, ncclNetCommConfig_t* config, ncclDebugLogger_t logFunction, ncclProfilerCallback_t profFunction) {
+ncclResult_t IbCastInit(void** ctx, uint64_t commId, ncclNetCommConfig_t* config, ncclDebugLogger_t logFunction,
+                        ncclProfilerCallback_t profFunction) {
   ncclResult_t ret = ncclSuccess;
   ncclNetCommConfig_t* netCommConfig = nullptr;
   NCCLCHECK(IbCastInitDevices(logFunction, profFunction));
   NCCLCHECK(IbCastPortRecoveryThreadStart());
   NCCLCHECK(ncclCalloc(&netCommConfig, 1));
   netCommConfig->trafficClass = config->trafficClass;
-  *ctx = (void *)netCommConfig;
+  *ctx = (void*)netCommConfig;
   return ret;
 }
 
@@ -583,11 +616,11 @@ ncclResult_t IbCastGetPhysProperties(int dev, ncclNetProperties_t* props) {
   props->port = ibDev->portNum + ibDev->realPort;
   props->maxComms = ibDev->maxQp;
   if (IbCastOffloadEnabled && !rcclParamIbCastP2pDisableCts()) {
-    props->maxRecvs = 1; 
+    props->maxRecvs = 1;
   } else {
     props->maxRecvs = NCCL_NET_IB_MAX_RECVS;
   }
-  props->netDeviceType    = NCCL_NET_DEVICE_HOST;
+  props->netDeviceType = NCCL_NET_DEVICE_HOST;
   props->netDeviceVersion = NCCL_NET_DEVICE_INVALID_VERSION;
   props->maxP2pBytes = NCCL_MAX_NET_SIZE_BYTES;
   props->maxCollBytes = MAX_COLLNET_SIZE;
@@ -614,7 +647,6 @@ ncclResult_t IbCastFinalize(void* ctx) {
   NCCLCHECK(IbCastPortRecoveryThreadStop());
   return IbCastFinalizeDevices();
 }
-
 
 /**
  * Extract the PCIe root complex (domain:bus) from a Linux sysfs PCI device path.
@@ -644,26 +676,21 @@ ncclResult_t IbCastFinalize(void* ctx) {
  * - The loop is bounded by the length of the string and cannot hang.
  * - This function does not allocate memory.
  */
-static ncclResult_t IbCastGetPciRootFromPath(
-    const char* pciPath,
-    char* root,
-    size_t rootLen
-) {
-    if (pciPath == NULL || root == NULL || rootLen < 8){
-        return ncclInvalidUsage;
-    }
-    const char* p = strstr(pciPath, "pci");
-    while (p != NULL) {
-        int domain, bus;
-        int charsRead = 0;
-        if (sscanf(p, "pci%4x:%2x%n", &domain, &bus, &charsRead) == 2 &&
-            charsRead == 10) {
-            snprintf(root, rootLen, "%04x:%02x", domain, bus);
-            return ncclSuccess;
-        }
-        p = strstr(p + 1, "pci");
-    }
+static ncclResult_t IbCastGetPciRootFromPath(const char* pciPath, char* root, size_t rootLen) {
+  if (pciPath == NULL || root == NULL || rootLen < 8) {
     return ncclInvalidUsage;
+  }
+  const char* p = strstr(pciPath, "pci");
+  while (p != NULL) {
+    int domain, bus;
+    int charsRead = 0;
+    if (sscanf(p, "pci%4x:%2x%n", &domain, &bus, &charsRead) == 2 && charsRead == 10) {
+      snprintf(root, rootLen, "%04x:%02x", domain, bus);
+      return ncclSuccess;
+    }
+    p = strstr(p + 1, "pci");
+  }
+  return ncclInvalidUsage;
 }
 /**
  * Determine the NUMA node associated with a PCI device from its sysfs path.
@@ -690,31 +717,31 @@ static ncclResult_t IbCastGetPciRootFromPath(
  * - Uses strtol for robust numeric parsing and overflow detection.
  * - A return value of -1 may indicate either "no NUMA affinity" or an error;
  *   callers should treat it as "unknown or unspecified".
-*/
+ */
 static int IbCastGetNumaNodeFromPath(const char* pciPath) {
-    if (pciPath == NULL) {
-        return -1;
-    }
-    char numaPath[PATH_MAX];
-    if (snprintf(numaPath, sizeof(numaPath), "%s/numa_node", pciPath) >= PATH_MAX) {
-        return -1; 
-    }
+  if (pciPath == NULL) {
+    return -1;
+  }
+  char numaPath[PATH_MAX];
+  if (snprintf(numaPath, sizeof(numaPath), "%s/numa_node", pciPath) >= PATH_MAX) {
+    return -1;
+  }
 
-    int fd = open(numaPath, O_RDONLY);
-    if (fd < 0) return -1;
+  int fd = open(numaPath, O_RDONLY);
+  if (fd < 0) return -1;
 
-    char buf[32];
-    ssize_t n = read(fd, buf, sizeof(buf) - 1);
-    close(fd);
+  char buf[32];
+  ssize_t n = read(fd, buf, sizeof(buf) - 1);
+  close(fd);
 
-    if (n <= 0) return -1;
-    buf[n] = '\0';
-    
-    char* endptr;
-    errno = 0;
-    long numa = strtol(buf, &endptr, 10);
-    if (endptr == buf || errno == ERANGE) {
-        return -1;
-    }
-    return (int)numa;
+  if (n <= 0) return -1;
+  buf[n] = '\0';
+
+  char* endptr;
+  errno = 0;
+  long numa = strtol(buf, &endptr, 10);
+  if (endptr == buf || errno == ERANGE) {
+    return -1;
+  }
+  return (int)numa;
 }

--- a/projects/rccl/src/transport/net_ib_cast/net_ib_cast_inspect.h
+++ b/projects/rccl/src/transport/net_ib_cast/net_ib_cast_inspect.h
@@ -25,17 +25,17 @@ extern "C" {
  */
 
 struct ncclIbCastSchedState {
-  int      nqps;
-  int      qpIndex;          /* current WRR cursor */
-  int      initTotTokens;
-  int      initQpTokens[NCCL_IB_MAX_QPS];
-  int      activeTotTokens;
-  int      activeQpTokens[NCCL_IB_MAX_QPS];
+  int nqps;
+  int qpIndex;          /* current WRR cursor */
+  int initTotTokens;
+  int initQpTokens[NCCL_IB_MAX_QPS];
+  int activeTotTokens;
+  int activeQpTokens[NCCL_IB_MAX_QPS];
   uint32_t splitDataMin;
-  bool     schedInit;        /* true once IbCastQpSchedUpdateTx has fired */
-  bool     schedEnable;
-  bool     doWrr;
-  bool     splitData;
+  bool schedInit;        /* true once IbCastQpSchedUpdateTx has fired */
+  bool schedEnable;
+  bool doWrr;
+  bool splitData;
 };
 
 /* Copy scheduler state out of a connected sendComm.
@@ -47,11 +47,8 @@ ncclResult_t ncclIbCastGetSchedState(void* sendComm, struct ncclIbCastSchedState
 ncclResult_t ncclIbCastSetTokens(void* sendComm, const int* qpTokens, int nqps);
 
 /* Override schedParms; takes effect on the next isend, no reconnect needed. */
-ncclResult_t ncclIbCastSetSchedParms(void* sendComm,
-                                      bool schedEnable,
-                                      bool doWrr,
-                                      bool splitData,
-                                      uint32_t splitDataMin);
+ncclResult_t ncclIbCastSetSchedParms(void* sendComm, bool schedEnable, bool doWrr, bool splitData,
+                                     uint32_t splitDataMin);
 
 /* ── Resiliency state introspection (requires ENABLE_FAULT_INJECTION) ── */
 #ifdef ENABLE_FAULT_INJECTION
@@ -59,11 +56,11 @@ ncclResult_t ncclIbCastSetSchedParms(void* sendComm,
 struct ncclIbCastResiliencyState {
   bool recoveryEnabled;
   bool inProgress;
-  int  outstandingRequests;
-  int  outstandingRecovery;
-  int  ndevs;
-  int  devState[NCCL_NET_MAX_DEVS_PER_NIC];
-  int  recoveryCount[NCCL_NET_MAX_DEVS_PER_NIC];
+  int outstandingRequests;
+  int outstandingRecovery;
+  int ndevs;
+  int devState[NCCL_NET_MAX_DEVS_PER_NIC];
+  int recoveryCount[NCCL_NET_MAX_DEVS_PER_NIC];
 };
 
 /* Fills out with the current resiliency state of the communicator.

--- a/projects/rccl/src/transport/net_ib_cast/net_ib_fault_inject.h
+++ b/projects/rccl/src/transport/net_ib_cast/net_ib_fault_inject.h
@@ -84,8 +84,8 @@ ncclResult_t ncclIbCastFaultOpsSetPostRecvError(void* recvComm, int qpIdx, int e
  *  injectCount   : completions to corrupt; <0 = unlimited.
  *  injectWhenIdle: if true, synthesize an error WC when poll_cq is idle;
  *                  if false, only rewrite the status of real matching completions. */
-ncclResult_t ncclIbCastFaultOpsSetPollCqError(void* comm, int qpIdx, int wcStatus,
-                                              int injectCount, bool injectWhenIdle);
+ncclResult_t ncclIbCastFaultOpsSetPollCqError(void* comm, int qpIdx, int wcStatus, int injectCount,
+                                              bool injectWhenIdle);
 
 /* Clear all ops-overload fault config on the connection (shims stay installed). */
 ncclResult_t ncclIbCastFaultOpsClear(void* comm);

--- a/projects/rccl/src/transport/net_ib_cast/net_ib_ops_fault.cc
+++ b/projects/rccl/src/transport/net_ib_cast/net_ib_ops_fault.cc
@@ -19,10 +19,10 @@ namespace {
 // Per-QP fault configuration. A zero/disarmed value leaves the corresponding op
 // forwarding to the saved real op.
 struct QpFault {
-  int  sendErrno      = 0;      // returned from post_send when != 0
-  int  recvErrno      = 0;      // returned from post_recv when != 0
-  int  pollWcStatus   = 0;      // ibv_wc_status applied when != 0 (0 == IBV_WC_SUCCESS)
-  int  pollInjectCount = 0;     // remaining completions to corrupt; <0 == unlimited
+  int sendErrno = 0;      // returned from post_send when != 0
+  int recvErrno = 0;      // returned from post_recv when != 0
+  int pollWcStatus = 0;      // ibv_wc_status applied when != 0 (0 == IBV_WC_SUCCESS)
+  int pollInjectCount = 0;     // remaining completions to corrupt; <0 == unlimited
   bool injectWhenIdle = false;  // synthesize an error WC when real poll returns 0
 };
 
@@ -166,11 +166,11 @@ ncclResult_t ncclIbOpsFaultInstall(struct ibv_context* ctx) {
   OpsEntry entry;
   entry.realPostSend = ctx->ops.post_send;
   entry.realPostRecv = ctx->ops.post_recv;
-  entry.realPollCq   = ctx->ops.poll_cq;
+  entry.realPollCq = ctx->ops.poll_cq;
   g_ctxFaults.emplace(ctx, entry);
   ctx->ops.post_send = shimPostSend;
   ctx->ops.post_recv = shimPostRecv;
-  ctx->ops.poll_cq   = shimPollCq;
+  ctx->ops.poll_cq = shimPollCq;
   INFO(NCCL_NET, "NET/IB ops-fault: installed shims on context %p", ctx);
   return ncclSuccess;
 }
@@ -182,7 +182,7 @@ ncclResult_t ncclIbOpsFaultRemove(struct ibv_context* ctx) {
   if (ctxIt == g_ctxFaults.end()) return ncclSuccess;
   ctx->ops.post_send = ctxIt->second.realPostSend;
   ctx->ops.post_recv = ctxIt->second.realPostRecv;
-  ctx->ops.poll_cq   = ctxIt->second.realPollCq;
+  ctx->ops.poll_cq = ctxIt->second.realPollCq;
   g_ctxFaults.erase(ctxIt);
   return ncclSuccess;
 }
@@ -205,8 +205,8 @@ ncclResult_t ncclIbOpsFaultArmPostRecv(struct ibv_context* ctx, uint32_t qpNum, 
   return ncclSuccess;
 }
 
-ncclResult_t ncclIbOpsFaultArmPollCq(struct ibv_context* ctx, uint32_t qpNum,
-                                     int wcStatus, int injectCount, bool injectWhenIdle) {
+ncclResult_t ncclIbOpsFaultArmPollCq(struct ibv_context* ctx, uint32_t qpNum, int wcStatus, int injectCount,
+                                     bool injectWhenIdle) {
   if (!ctx) return ncclInvalidArgument;
   std::lock_guard<std::mutex> lk(g_faultMtx);
   auto ctxIt = g_ctxFaults.find(ctx);

--- a/projects/rccl/src/transport/net_ib_cast/net_ib_ops_fault.h
+++ b/projects/rccl/src/transport/net_ib_cast/net_ib_ops_fault.h
@@ -59,8 +59,8 @@ ncclResult_t ncclIbOpsFaultArmPostRecv(struct ibv_context* ctx, uint32_t qpNum, 
  *  injectWhenIdle: if true, synthesize one error WC when the real poll_cq
  *                  returns 0 completions; if false, only rewrite the status of
  *                  real completions whose qp_num matches. */
-ncclResult_t ncclIbOpsFaultArmPollCq(struct ibv_context* ctx, uint32_t qpNum,
-                                     int wcStatus, int injectCount, bool injectWhenIdle);
+ncclResult_t ncclIbOpsFaultArmPollCq(struct ibv_context* ctx, uint32_t qpNum, int wcStatus, int injectCount,
+                                     bool injectWhenIdle);
 
 /* Clear all ops-fault config for ctx (does not uninstall the shims). */
 ncclResult_t ncclIbOpsFaultClear(struct ibv_context* ctx);

--- a/projects/rccl/src/transport/net_ib_cast/p2p.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p.cc
@@ -20,11 +20,11 @@ int64_t IbCastArThreshold = 8192;
 NCCL_PARAM(IbCastReceiverSideMatchingScheme, "IB_RECEIVER_SIDE_MATCHING_SCHEME", -2);
 RCCL_PARAM(IbCastGdrFlushGpuMemNoRelaxedOrdering, "GDR_FLUSH_GPU_MEM_NO_RELAXED_ORDERING", 1);
 
-const char* IbCastReqTypeStr[] = { "Unused", "Send", "Recv", "Flush", "IPut" };
+const char* IbCastReqTypeStr[] = {"Unused", "Send", "Recv", "Flush", "IPut"};
 
 ncclResult_t IbCastGetRequest(struct ncclIbNetCommBase* base, struct ncclIbRequest** req) {
-  for (int i=0; i<NET_IB_MAX_REQUESTS; i++) {
-    struct ncclIbRequest* r = base->reqs+i;
+  for (int i = 0; i < NET_IB_MAX_REQUESTS; i++) {
+    struct ncclIbRequest* r = base->reqs + i;
     if (r->type == NCCL_NET_IB_REQ_UNUSED) {
       r->base = base;
       r->sock = NULL;
@@ -64,32 +64,24 @@ static ncclResult_t IbCastPrintWr(struct ibv_send_wr* wr, char* wrStr) {
   }
   const char* opcodeStr = ibvWrOpcodeStr(wr->opcode);
   switch (wr->opcode) {
-    case IBV_WR_RDMA_WRITE:
-      sprintf(wrStr, "wr=%p, wr_id=%ld, opcode=%s, num_sge=%d, sge[0].length=%" PRIu32 ", sge[0].addr=0x%016" PRIx64 ", rdma.remote_addr=0x%016" PRIx64 ", rdma.rkey=0x%x",
-        wr,
-        wr->wr_id,
-        opcodeStr,
-        wr->num_sge,
-        (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->length : 0,
-        (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->addr : 0,
-        wr->wr.rdma.remote_addr,
-        wr->wr.rdma.rkey);
-      break;
-    case IBV_WR_RDMA_WRITE_WITH_IMM:
-      sprintf(wrStr, "wr=%p, wr_id=%ld, opcode=%s, num_sge=%d, sge[0].length=%" PRIu32 ", sge[0].addr=0x%016" PRIx64 ", rdma.remote_addr=0x%016" PRIx64 ",  rdma.rkey=0x%x, imm_data=0x%x",
-        wr,
-        wr->wr_id,
-        opcodeStr,
-        wr->num_sge,
-        (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->length : 0,
-        (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->addr : 0,
-        wr->wr.rdma.remote_addr,
-        wr->wr.rdma.rkey,
-        wr->imm_data);
-      break;
-    default:
-      WARN("NET/IB: %s: No format specified for opcode=%d", __func__, wr->opcode);
-      return ncclInternalError;
+  case IBV_WR_RDMA_WRITE:
+    sprintf(wrStr,
+            "wr=%p, wr_id=%ld, opcode=%s, num_sge=%d, sge[0].length=%" PRIu32 ", sge[0].addr=0x%016" PRIx64
+            ", rdma.remote_addr=0x%016" PRIx64 ", rdma.rkey=0x%x",
+            wr, wr->wr_id, opcodeStr, wr->num_sge, (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->length : 0,
+            (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->addr : 0, wr->wr.rdma.remote_addr, wr->wr.rdma.rkey);
+    break;
+  case IBV_WR_RDMA_WRITE_WITH_IMM:
+    sprintf(wrStr,
+            "wr=%p, wr_id=%ld, opcode=%s, num_sge=%d, sge[0].length=%" PRIu32 ", sge[0].addr=0x%016" PRIx64
+            ", rdma.remote_addr=0x%016" PRIx64 ",  rdma.rkey=0x%x, imm_data=0x%x",
+            wr, wr->wr_id, opcodeStr, wr->num_sge, (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->length : 0,
+            (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->addr : 0, wr->wr.rdma.remote_addr, wr->wr.rdma.rkey,
+            wr->imm_data);
+    break;
+  default:
+    WARN("NET/IB: %s: No format specified for opcode=%d", __func__, wr->opcode);
+    return ncclInternalError;
   }
   return ncclSuccess;
 }
@@ -98,27 +90,29 @@ static ncclResult_t IbCastPrintWr(struct ibv_send_wr* wr, char* wrStr) {
 // The alignment for IB writes that is required to make LL and LL128 protocols work
 #define IB_WRITE_CHUNK_ALIGNMENT 128
 
-ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, int startQpIndex, bool wrrSched, bool useWriteOp) {
+ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, int startQpIndex, bool wrrSched,
+                             bool useWriteOp) {
   struct ncclIbRequest** reqs = comm->sendReqs[slot];
   volatile struct ncclIbSendFifo* slots = comm->ctsFifo[slot];
   int nreqs = comm->useCtsOffload ? 1 : slots[0].nreqs;
   uint64_t nowNs = 0;
   if (nreqs > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
 
-  TRACE(NCCL_NET, "NET/IB: %s: Posting a send request (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d)", __func__, reqs[0], reqs[0]->base, reqs[0]->id, slot, nreqs);
+  TRACE(NCCL_NET, "NET/IB: %s: Posting a send request (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d)", __func__, reqs[0],
+        reqs[0]->base, reqs[0]->id, slot, nreqs);
 
   uint64_t wr_id = 0ULL;
-  for (int r=0; r<nreqs; r++) {
-    struct ibv_send_wr* wr = comm->wrs+r;
+  for (int r = 0; r < nreqs; r++) {
+    struct ibv_send_wr* wr = comm->wrs + r;
     memset(wr, 0, sizeof(struct ibv_send_wr));
 
-    struct ibv_sge* sge = comm->sges+r;
-    sge->addr=(uintptr_t)reqs[r]->send.data;
+    struct ibv_sge* sge = comm->sges + r;
+    sge->addr = (uintptr_t)reqs[r]->send.data;
     wr->opcode = IBV_WR_RDMA_WRITE;
     wr->send_flags = 0;
     wr->wr.rdma.remote_addr = comm->useCtsOffload ? 0xdeadbeef : slots[r].addr;
     wr->next = wr + 1;
-    wr_id += (uint64_t)(slot & 0xff) << (r*8);
+    wr_id += (uint64_t)(slot & 0xff) << (r * 8);
     wr->wr_id = wr_id;
 #ifdef NCCL_ENABLE_NET_PROFILING
     reqs[r]->pInfo[0].nEventHandles = 0;
@@ -142,7 +136,7 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
   //   bits [22:0]  - unused; receiver always uses wc->byte_len for size
   // - nreqs > 1
   //      Sizes are written directly to remote completion records array
-  struct ibv_send_wr* lastWr = comm->wrs+nreqs-1;
+  struct ibv_send_wr* lastWr = comm->wrs + nreqs - 1;
   if (!useWriteOp) {
     uint32_t immData;
     if (comm->base.recvMatchingScheme != BY_INDEX) {
@@ -155,15 +149,15 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
       }
     }
 
-    
-    if (nreqs > 1 || (!(comm->base.remOooRq && comm->base.localOooRq) && comm->ar && reqs[0]->send.size > IbCastArThreshold)) {
+    if (nreqs > 1 ||
+        (!(comm->base.remOooRq && comm->base.localOooRq) && comm->ar && reqs[0]->send.size > IbCastArThreshold)) {
       // When Adaptive Routing is enabled, send the bulk of the data first as an
       // RDMA Write.
       lastWr++;
       memset(lastWr, 0, sizeof(struct ibv_send_wr));
       if (nreqs > 1) {
         // Write remote sizes array
-        lastWr->wr.rdma.remote_addr = comm->remCmplsRecords.addr + slot*sizeof(struct ncclIbRequestCompletionRecord);
+        lastWr->wr.rdma.remote_addr = comm->remCmplsRecords.addr + slot * sizeof(struct ncclIbRequestCompletionRecord);
         lastWr->num_sge = 1;
       }
     }
@@ -181,38 +175,40 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
   for (int i = 0; i < nqps; i++) {
     NCCLCHECK(IbCastCommBaseGetQpForRequest(&comm->base, startQpIndex, i, &qp, &qpIndex));
 
-    TRACE(NCCL_NET, "NET/IB: %s: Posting send (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld) on QP (qp_num=%u, devIndex=%d, qpIndex=%d)", __func__, reqs[0], reqs[0]->base, reqs[0]->id, slot, nreqs, wr_id, qp->qp->qp_num, qp->devIndex, qpIndex);
+    TRACE(NCCL_NET,
+          "NET/IB: %s: Posting send (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld) on QP (qp_num=%u, "
+          "devIndex=%d, qpIndex=%d)",
+          __func__, reqs[0], reqs[0]->base, reqs[0]->id, slot, nreqs, wr_id, qp->qp->qp_num, qp->devIndex, qpIndex);
 
     // Selective retransmission
     if (comm->base.resiliency && reqs[0]->send.sentData[qpIndex] == true) {
-      for (int r=0; r<nreqs; r++) {
+      for (int r = 0; r < nreqs; r++) {
         comm->wrs[r].sg_list->addr += comm->wrs[r].sg_list->length;
         comm->wrs[r].wr.rdma.remote_addr += comm->wrs[r].sg_list->length;
       }
-      INFO(NCCL_NET, "NET/IB: %s: Skipping retransmission on QP index %d (req=%p, slot=%d) as it was already delivered.", __func__, qpIndex, reqs[0], slot);
+      INFO(NCCL_NET,
+           "NET/IB: %s: Skipping retransmission on QP index %d (req=%p, slot=%d) as it was already delivered.",
+           __func__, qpIndex, reqs[0], slot);
       continue;
     }
-    
+
     int devIndex = qp->devIndex;
-    for (int r=0; r<nreqs; r++) {
+    for (int r = 0; r < nreqs; r++) {
       // Track this event for completion
-      //IbCastAddEvent(reqs[r], devIndex);
+      // IbCastAddEvent(reqs[r], devIndex);
 
       // Select proper rkey (needed even for 0-size send)
       comm->wrs[r].wr.rdma.rkey = comm->useCtsOffload ? 0xbade : slots[r].rkeys[qp->remDevIdx];
 
       int chunkSize, length;
       if ((nqps > 1) && reqs[r]->desc.parms.enable && comm->base.qpTxSchedInit) {
-        int weightedSendSize = (int) (((double) reqs[r]->send.size) *
-                                      comm->base.qpTxSched[qpIndex].weight);
+        int weightedSendSize = (int)(((double)reqs[r]->send.size) * comm->base.qpTxSched[qpIndex].weight);
         chunkSize = (weightedSendSize / align) * align;
-        if (i == (nqps-1))
-          length = std::max((int)(reqs[r]->send.size-sendOffsets[r]), chunkSize);
-        else
-          length = chunkSize;
+        if (i == (nqps - 1)) length = std::max((int)(reqs[r]->send.size - sendOffsets[r]), chunkSize);
+        else length = chunkSize;
       } else {
         chunkSize = DIVUP(DIVUP(reqs[r]->send.size, nqps), align) * align;
-        length = std::min((int)(reqs[r]->send.size-sendOffsets[r]), chunkSize);
+        length = std::min((int)(reqs[r]->send.size - sendOffsets[r]), chunkSize);
       }
 
       // Check the data left to send. If the send is too small, it might be
@@ -225,24 +221,23 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
         // Select proper lkey
         comm->sges[r].lkey = reqs[r]->send.lkeys[devIndex];
         comm->sges[r].length = length;
-        comm->wrs[r].sg_list = comm->sges+r;
+        comm->wrs[r].sg_list = comm->sges + r;
         comm->wrs[r].num_sge = 1;
       }
 
       // wr_id remapping is only used for CAST scheduler RTT timing (BY_INDEX).
       // BY_ID (used by PORT_FAILOVER/RECOVERY) and BY_ORDER skip remapping.
       if ((r == (nreqs - 1)) && (comm->base.recvMatchingScheme == BY_INDEX)) {
-        struct ncclIbRemapWrId *remapWrId;
+        struct ncclIbRemapWrId* remapWrId;
         NCCLCHECK(IbCastQpSchedGetRemap(&comm->base, wr_id, qpIndex, &remapWrId));
-        lastWr->wr_id = (uint64_t) remapWrId;
+        lastWr->wr_id = (uint64_t)remapWrId;
         /* save tx data for measuring QP performance */
         remapWrId->parms = reqs[r]->desc.parms;
         remapWrId->tx.bytes = length;
         nowNs = 0;
         if (reqs[r]->desc.parms.enable && ((nqps > 1) || reqs[r]->desc.parms.doWrr)) {
           struct timespec txStartTime;
-          if (!clock_gettime(CLOCK_MONOTONIC, &txStartTime))
-            nowNs = TIMESPEC_TO_NSEC(&txStartTime);
+          if (!clock_gettime(CLOCK_MONOTONIC, &txStartTime)) nowNs = TIMESPEC_TO_NSEC(&txStartTime);
           remapWrId->tx.startTimeNs = nowNs;
         }
       }
@@ -254,7 +249,7 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
       // Note that the lkey is already correct from the initialization phase.
       lastWr->sg_list = &(comm->devs[devIndex].sge);
       lastWr->sg_list[0].addr = (uint64_t)(comm->remCmplsRecords.elems[slot]);
-      lastWr->sg_list[0].length = nreqs*sizeof(int);
+      lastWr->sg_list[0].length = nreqs * sizeof(int);
       // Populate the correct RKey based on the device used
       lastWr->wr.rdma.rkey = comm->remCmplsRecords.rkeys[devIndex];
     }
@@ -262,7 +257,7 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
     struct ibv_send_wr* bad_wr;
 #ifdef NCCL_ENABLE_NET_PROFILING
     // QP profiling loop
-    for (int r=0; r<nreqs; r++) {
+    for (int r = 0; r < nreqs; r++) {
       // Store the qpIndex for this request
       int nEventHandles = reqs[r]->pInfo[0].nEventHandles;
       assert(nEventHandles < MAX_QPS_PER_REQ);
@@ -276,13 +271,16 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
       reqs[r]->pInfo[0].data.qp.qpNum = qp->qp->qp_num;
       reqs[r]->pInfo[0].data.qp.length = comm->sges[r].length;
       void* pHandle = reqs[r]->pInfo[0].pHandle;
-      NCCLCHECK(IbCastProfilerFunction(&reqs[r]->pInfo[0].qpEventHandles[nEventHandles], ncclProfilerNetEventStart, pHandle, pluginId, &reqs[r]->pInfo[0].data));
+      NCCLCHECK(IbCastProfilerFunction(&reqs[r]->pInfo[0].qpEventHandles[nEventHandles], ncclProfilerNetEventStart,
+                                       pHandle, pluginId, &reqs[r]->pInfo[0].data));
       reqs[r]->pInfo[0].nEventHandles++;
     }
 #endif
 #ifdef ENABLE_TRACE
     for (int r = 0; r < nreqs; r++) {
-      TRACE(NCCL_NET, "NET/IB: %s: Posting send work request on QP (qpn=%u, devIndex=%d, qpIndex=%d) (slot=%d, req[r=%d]=%p)", __func__, qp->qp->qp_num, qp->devIndex, qpIndex, slot, r, reqs[r]);
+      TRACE(NCCL_NET,
+            "NET/IB: %s: Posting send work request on QP (qpn=%u, devIndex=%d, qpIndex=%d) (slot=%d, req[r=%d]=%p)",
+            __func__, qp->qp->qp_num, qp->devIndex, qpIndex, slot, r, reqs[r]);
     }
     int wrIdx = 0;
     char wrStr[1024];
@@ -308,31 +306,33 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
 
     // Update the send offset and addresses for the next QP according to the
     // actual data size that was sent on the current QP, for every request
-    for (int r=0; r<nreqs; r++) {
+    for (int r = 0; r < nreqs; r++) {
       int chunkSize;
 
       if (reqs[r]->desc.parms.enable && comm->base.qpTxSchedInit) {
-        int weightedSendSize = (int) (((double) reqs[r]->send.size) *
-                                      comm->base.qpTxSched[qpIndex].weight);
+        int weightedSendSize = (int)(((double)reqs[r]->send.size) * comm->base.qpTxSched[qpIndex].weight);
         chunkSize = (weightedSendSize / align) * align;
-        if (i == (nqps-1))
-          chunkSize = std::max((int)(reqs[r]->send.size-sendOffsets[r]), chunkSize);
-      } else
-        chunkSize = DIVUP(DIVUP(reqs[r]->send.size, nqps), align) * align;
+        if (i == (nqps - 1)) chunkSize = std::max((int)(reqs[r]->send.size - sendOffsets[r]), chunkSize);
+      } else chunkSize = DIVUP(DIVUP(reqs[r]->send.size, nqps), align) * align;
 
       sendOffsets[r] += chunkSize;
       comm->sges[r].addr += chunkSize;
       comm->wrs[r].wr.rdma.remote_addr += chunkSize;
       reqs[r]->send.sentData[qpIndex] = true;
 
-      TRACE(NCCL_VERBS, "Posted send wr_id=%lu, wr_indx=%d, qp_num=%d, src_nic=%d, dst_nic=%d, dlid=%d, opcode=%d, send_flags=%d, imm_data=%d, remote_addr=%lx, rkey=%x, length=%d, lkey=%x",
-        comm->wrs[r].wr_id, r, qp->qp->qp_num, comm->devs[qp->devIndex].base.ibDevN , comm->base.remDevs[qp->remDevIdx].ibv_dev_index, comm->base.remDevs[qp->remDevIdx].lid,
-        comm->wrs[r].opcode, comm->wrs[r].send_flags, comm->wrs[r].imm_data, comm->wrs[r].wr.rdma.remote_addr,
-        comm->wrs[r].wr.rdma.rkey,comm->wrs[r].sg_list ? comm->wrs[r].sg_list->length : 0, comm->wrs[r].sg_list ? comm->wrs[r].sg_list->lkey : 0);
+      TRACE(NCCL_VERBS,
+            "Posted send wr_id=%lu, wr_indx=%d, qp_num=%d, src_nic=%d, dst_nic=%d, dlid=%d, opcode=%d, send_flags=%d, "
+            "imm_data=%d, remote_addr=%lx, rkey=%x, length=%d, lkey=%x",
+            comm->wrs[r].wr_id, r, qp->qp->qp_num, comm->devs[qp->devIndex].base.ibDevN,
+            comm->base.remDevs[qp->remDevIdx].ibv_dev_index, comm->base.remDevs[qp->remDevIdx].lid, comm->wrs[r].opcode,
+            comm->wrs[r].send_flags, comm->wrs[r].imm_data, comm->wrs[r].wr.rdma.remote_addr, comm->wrs[r].wr.rdma.rkey,
+            comm->wrs[r].sg_list ? comm->wrs[r].sg_list->length : 0,
+            comm->wrs[r].sg_list ? comm->wrs[r].sg_list->lkey : 0);
     }
   }
 
-  TRACE(NCCL_NET, "NET/IB: %s: Send request posted (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld)", __func__, reqs[0], reqs[0]->base, reqs[0]->id, slot, nreqs, wr_id);
+  TRACE(NCCL_NET, "NET/IB: %s: Send request posted (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld)", __func__,
+        reqs[0], reqs[0]->base, reqs[0]->id, slot, nreqs, wr_id);
   if (nowNs) {
     if (comm->base.nextQpTxSchedUpdateNs == 0)
       comm->base.nextQpTxSchedUpdateNs = nowNs + comm->base.schedParms.updateInterval;
@@ -341,8 +341,7 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
       comm->base.nextQpTxSchedUpdateNs = nowNs + comm->base.schedParms.updateInterval;
     }
     if (comm->base.schedParms.logEnable) {
-      if (comm->base.nextSchedLogNs == 0)
-        comm->base.nextSchedLogNs = nowNs + comm->base.schedParms.logInterval;
+      if (comm->base.nextSchedLogNs == 0) comm->base.nextSchedLogNs = nowNs + comm->base.schedParms.logInterval;
       else if (nowNs >= comm->base.nextSchedLogNs) {
         IbCastLogSched(comm);
         comm->base.nextSchedLogNs = nowNs + comm->base.schedParms.logInterval;
@@ -352,17 +351,18 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
   return ncclSuccess;
 }
 
-ncclResult_t IbCastIsend(void* sendComm, void* data, size_t size, int tag, void* mhandle, void* phandle, void** request) {
+ncclResult_t IbCastIsend(void* sendComm, void* data, size_t size, int tag, void* mhandle, void* phandle,
+                         void** request) {
   struct ncclIbSendComm* comm = (struct ncclIbSendComm*)sendComm;
-  bool useWriteOp = (comm->useCtsOffload &&(*request == (void *)NCCL_NET_OPTIONAL_RECV_COMPLETION)) ? true : false;
+  bool useWriteOp = (comm->useCtsOffload && (*request == (void*)NCCL_NET_OPTIONAL_RECV_COMPLETION)) ? true : false;
   if (comm->base.ready == 0) {
     WARN("NET/IB: IbCastIsend() called when comm->base.ready == 0");
     *request = NULL;
     return ncclInternalError;
   }
-  NCCLCHECK(IbCastStatsCheckFatalCount(&comm->base.stats,__func__));
+  NCCLCHECK(IbCastStatsCheckFatalCount(&comm->base.stats, __func__));
 
-  struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*) mhandle;
+  struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*)mhandle;
   // Wait for the receiver to have posted the corresponding receive
   int nreqs = 1;
   volatile struct ncclIbSendFifo* slots;
@@ -371,16 +371,19 @@ ncclResult_t IbCastIsend(void* sendComm, void* data, size_t size, int tag, void*
   struct ncclIbRequest** reqs = comm->sendReqs[slot];
   if (!comm->useCtsOffload) {
     slots = comm->ctsFifo[slot];
-    uint64_t idx = comm->base.fifoHead+1;
-    if (slots[0].idx != idx) { *request = NULL; return ncclSuccess; }
+    uint64_t idx = comm->base.fifoHead + 1;
+    if (slots[0].idx != idx) {
+      *request = NULL;
+      return ncclSuccess;
+    }
     nreqs = slots[0].nreqs;
     // Wait until all data has arrived
-    for (int r=1; r<nreqs; r++) while(slots[r].idx != idx);
+    for (int r = 1; r < nreqs; r++)
+      while (slots[r].idx != idx);
     std::atomic_thread_fence(std::memory_order_seq_cst); // order the nreqsPtr load against tag/rkey/addr loads below
   }
 
-
-  for (int r=0; r<nreqs; r++) {
+  for (int r = 0; r < nreqs; r++) {
     if (!comm->useCtsOffload) {
       if (reqs[r] != NULL || slots[r].tag != tag) continue;
 
@@ -390,8 +393,8 @@ ncclResult_t IbCastIsend(void* sendComm, void* data, size_t size, int tag, void*
         char line[SOCKET_NAME_MAXLEN + 1];
         union ncclSocketAddress addr;
         ncclSocketGetAddr(&comm->base.sock, &addr);
-        WARN("NET/IB : req %d/%d tag %x peer %s posted incorrect receive info: size %ld addr %lx rkeys[0]=%x",
-          r, nreqs, tag, ncclSocketToString(&addr, line), slots[r].size, slots[r].addr, slots[r].rkeys[0]);
+        WARN("NET/IB : req %d/%d tag %x peer %s posted incorrect receive info: size %ld addr %lx rkeys[0]=%x", r, nreqs,
+             tag, ncclSocketToString(&addr, line), slots[r].size, slots[r].addr, slots[r].rkeys[0]);
         return ncclInternalError;
       }
     }
@@ -435,7 +438,7 @@ ncclResult_t IbCastIsend(void* sendComm, void* data, size_t size, int tag, void*
         startQpIndex = req->desc.startQpIndex = reqs[j]->desc.startQpIndex;
         wrrSched = req->desc.wrrSched = reqs[j]->desc.wrrSched;
       }
-      
+
       // Populate events
       int qpIndex = -1;
       ncclIbQp* qp = NULL;
@@ -453,7 +456,6 @@ ncclResult_t IbCastIsend(void* sendComm, void* data, size_t size, int tag, void*
       IbCastAddEvent(req, qp->devIndex);
     }
 
-
     // Store all lkeys
     for (int i = 0; i < comm->base.vProps.ndevs; i++) {
       req->send.lkeys[i] = mhandleWrapper->mrs[i]->lkey;
@@ -464,7 +466,10 @@ ncclResult_t IbCastIsend(void* sendComm, void* data, size_t size, int tag, void*
     // and be sent to the receiver.
     comm->remCmplsRecords.elems[slot][r] = req->send.size;
 
-    TRACE(NCCL_NET, "NET/IB: %s: Send request created (req=%p, comm=%p, id=%ld, slot=%d, reqIdx=%d, nreqs=%d, tag=%x, size=%ld, data=0x%016" PRIx64 ", mhandle=%p, size=%ld)", __func__, req, req->base, req->id, slot, r, nreqs, tag, size, (uint64_t)data, mhandle, size);
+    TRACE(NCCL_NET,
+          "NET/IB: %s: Send request created (req=%p, comm=%p, id=%ld, slot=%d, reqIdx=%d, nreqs=%d, tag=%x, size=%ld, "
+          "data=0x%016" PRIx64 ", mhandle=%p, size=%ld)",
+          __func__, req, req->base, req->id, slot, r, nreqs, tag, size, (uint64_t)data, mhandle, size);
 
     *request = reqs[r] = req;
 
@@ -490,7 +495,7 @@ ncclResult_t IbCastPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* r
 
   struct ibv_send_wr wr;
   memset(&wr, 0, sizeof(wr));
-  wr.wr.rdma.remote_addr = comm->remCtsFifo.addr + slot*NCCL_NET_IB_MAX_RECVS*sizeof(struct ncclIbSendFifo);
+  wr.wr.rdma.remote_addr = comm->remCtsFifo.addr + slot * NCCL_NET_IB_MAX_RECVS * sizeof(struct ncclIbSendFifo);
 
   // Lookup the correct rkey
   wr.wr.rdma.rkey = comm->base.remDevs[ctsQp->remDevIdx].rkey;
@@ -500,7 +505,7 @@ ncclResult_t IbCastPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* r
   struct ncclIbSendFifo* localElem = comm->remCtsFifo.elems[slot];
   wr.sg_list = &(comm->devs[ctsQp->devIndex].sge);
   wr.sg_list[0].addr = (uint64_t)localElem;
-  wr.sg_list[0].length = comm->useCtsOffload ? MAX_INLINE_DATA_SIZE : n*sizeof(struct ncclIbSendFifo);
+  wr.sg_list[0].length = comm->useCtsOffload ? MAX_INLINE_DATA_SIZE : n * sizeof(struct ncclIbSendFifo);
   wr.num_sge = 1;
 
   wr.opcode = IBV_WR_RDMA_WRITE;
@@ -539,17 +544,24 @@ ncclResult_t IbCastPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* r
     IbCastAddEventCTS(req, ctsQp->devIndex);
   }
 
-  TRACE(NCCL_NET, "NET/IB: %s: Posting a CTS (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld, opcode=%d, send_flags=%d, qp_num=%u)", __func__, req, req->base, req->id, slot, req->nreqs, wr.wr_id, wr.opcode, wr.send_flags, ctsQp->qp->qp_num);
+  TRACE(NCCL_NET,
+        "NET/IB: %s: Posting a CTS (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld, opcode=%d, send_flags=%d, "
+        "qp_num=%u)",
+        __func__, req, req->base, req->id, slot, req->nreqs, wr.wr_id, wr.opcode, wr.send_flags, ctsQp->qp->qp_num);
 
   struct ibv_send_wr* bad_wr;
   NCCLCHECK(wrap_ibv_post_send(ctsQp->qp, &wr, &bad_wr));
 
-  TRACE(NCCL_NET, "NET/IB: %s: CTS posted (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld, opcode=%d, send_flags=%d, qp_num=%u)", __func__, req, req->base, req->id, slot, req->nreqs, wr.wr_id, wr.opcode, wr.send_flags, ctsQp->qp->qp_num);
+  TRACE(NCCL_NET,
+        "NET/IB: %s: CTS posted (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld, opcode=%d, send_flags=%d, "
+        "qp_num=%u)",
+        __func__, req, req->base, req->id, slot, req->nreqs, wr.wr_id, wr.opcode, wr.send_flags, ctsQp->qp->qp_num);
 
   return ncclSuccess;
 }
 
-ncclResult_t IbCastIrecv(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles, void** phandles, void** request) {
+ncclResult_t IbCastIrecv(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles, void** phandles,
+                         void** request) {
   struct ncclIbRecvComm* comm = (struct ncclIbRecvComm*)recvComm;
   uint16_t rxReqIndex = 0;
   ncclResult_t res = ncclSuccess;
@@ -560,9 +572,9 @@ ncclResult_t IbCastIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
     return ncclInternalError;
   }
   if (n > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
-  NCCLCHECK(IbCastStatsCheckFatalCount(&comm->base.stats,__func__));
+  NCCLCHECK(IbCastStatsCheckFatalCount(&comm->base.stats, __func__));
   if (comm->useCtsOffload) {
-    if (*request == (void *)NCCL_NET_OPTIONAL_RECV_COMPLETION) {
+    if (*request == (void*)NCCL_NET_OPTIONAL_RECV_COMPLETION) {
       netOptRecvCompletionEnabled = true;
     }
   }
@@ -571,7 +583,7 @@ ncclResult_t IbCastIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
   int slot = comm->base.fifoHead % NET_IB_MAX_REQUESTS;
 
   NCCLCHECK(IbCastGetRequest(&comm->base, &req));
-  rxReqIndex = (uint16_t) (req - comm->base.reqs);
+  rxReqIndex = (uint16_t)(req - comm->base.reqs);
   req->id = comm->base.fifoHead;
   req->type = NCCL_NET_IB_REQ_RECV;
   req->sock = &comm->base.sock;
@@ -580,7 +592,8 @@ ncclResult_t IbCastIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
     req->devBases[devIndex] = IbCastGetNetCommDevBase(&comm->base, devIndex);
   }
 
-  TRACE(NCCL_NET, "NET/IB: %s: Recv request created (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, tag[0]=%x)", __func__, req, req->base, req->id, slot, n, tags[0]);
+  TRACE(NCCL_NET, "NET/IB: %s: Recv request created (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, tag[0]=%x)", __func__,
+        req, req->base, req->id, slot, n, tags[0]);
 
 #ifdef NCCL_ENABLE_NET_PROFILING
   for (int r = 0; r < n && phandles; r++) req->pInfo[r].nEventHandles = 0;
@@ -591,7 +604,7 @@ ncclResult_t IbCastIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
 
   req->recv.aggSize = 0;
   req->recv.cmplsRecords = &comm->cmplsRecords[slot];
-  memset(req->recv.cmplsRecords->sizes, 0, sizeof(int)*n);
+  memset(req->recv.cmplsRecords->sizes, 0, sizeof(int) * n);
   memset(req->recv.cmplsRecords->completions, 0, sizeof(req->recv.cmplsRecords->completions));
 
   if (!netOptRecvCompletionEnabled) {
@@ -616,7 +629,7 @@ ncclResult_t IbCastIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
         comm->ibRecvWorkRequest.wr_id = req - comm->base.reqs;
         NCCLCHECK(IbCastPostRecvWorkRequest(qp->qp, &comm->ibRecvWorkRequest));
       }
-  #ifdef NCCL_ENABLE_NET_PROFILING
+#ifdef NCCL_ENABLE_NET_PROFILING
       // Start a QP event for every request in the multirecv and every qp
       for (int r = 0; r < n; r++) {
         int nEventHandles = req->pInfo[r].nEventHandles;
@@ -628,17 +641,18 @@ ncclResult_t IbCastIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
         req->pInfo[r].data.qp.device = qp->devIndex;
         req->pInfo[r].data.qp.wr_id = comm->ibRecvWorkRequest.wr_id;
         req->pInfo[r].data.qp.qpNum = qp->qp->qp_num;
-        NCCLCHECK(IbCastProfilerFunction(&req->pInfo[r].qpEventHandles[nEventHandles], ncclProfilerNetEventStart, phandles[r], pluginId, &req->pInfo[r].data));
+        NCCLCHECK(IbCastProfilerFunction(&req->pInfo[r].qpEventHandles[nEventHandles], ncclProfilerNetEventStart,
+                                         phandles[r], pluginId, &req->pInfo[r].data));
         req->pInfo[r].nEventHandles++;
       }
-  #endif
+#endif
     }
     TIME_STOP(1);
   }
 
   struct ncclIbSendFifo* localElem = comm->remCtsFifo.elems[slot];
-  for (int i=0; i<n; i++) {
-    struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*) mhandles[i];
+  for (int i = 0; i < n; i++) {
+    struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*)mhandles[i];
     if (comm->useCtsOffload) {
       struct ncclIbSendFifoCtsInline* localElemCtsInline = (struct ncclIbSendFifoCtsInline*)&localElem[i];
       localElemCtsInline[i].addr = (uint64_t)data[i];
@@ -655,7 +669,7 @@ ncclResult_t IbCastIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
       localElem[i].nreqs = n;
       localElem[i].size = sizes[i]; // Sanity/Debugging
       localElem[i].tag = tags[i];
-      localElem[i].idx = comm->base.fifoHead+1;
+      localElem[i].idx = comm->base.fifoHead + 1;
       localElem[i].rxReqIndex = rxReqIndex;
     }
   }
@@ -670,7 +684,7 @@ ncclResult_t IbCastIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
   return res;
 err:
   if (req) {
-      IbCastFreeRequest(req);
+    IbCastFreeRequest(req);
   }
   return res;
 }
@@ -678,7 +692,8 @@ err:
 ncclResult_t IbCastIflush(void* recvComm, int n, void** data, int* sizes, void** mhandles, void** request) {
   struct ncclIbRecvComm* comm = (struct ncclIbRecvComm*)recvComm;
   int last = -1;
-  for (int i=0; i<n; i++) if (sizes[i]) last = i;
+  for (int i = 0; i < n; i++)
+    if (sizes[i]) last = i;
   if (comm->flushEnabled == 0 || last == -1) return ncclSuccess;
 
   // Only flush once using the last non-zero receive
@@ -686,7 +701,7 @@ ncclResult_t IbCastIflush(void* recvComm, int n, void** data, int* sizes, void**
   NCCLCHECK(IbCastGetRequest(&comm->base, &req));
   req->type = NCCL_NET_IB_REQ_FLUSH;
   req->sock = &comm->base.sock;
-  struct ncclIbMrHandle* mhandle = (struct ncclIbMrHandle*) mhandles[last];
+  struct ncclIbMrHandle* mhandle = (struct ncclIbMrHandle*)mhandles[last];
 
   // We don't know which devIndex the recv was on, so we flush on all devices
   for (int i = 0; i < comm->base.vProps.ndevs; i++) {
@@ -701,7 +716,8 @@ ncclResult_t IbCastIflush(void* recvComm, int n, void** data, int* sizes, void**
     wr.opcode = IBV_WR_RDMA_READ;
     wr.send_flags = IBV_SEND_SIGNALED;
 
-    TRACE(NCCL_NET, "NET/IB: %s: Posting a flush request (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base, wr.wr_id);
+    TRACE(NCCL_NET, "NET/IB: %s: Posting a flush request (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base,
+          wr.wr_id);
     TIME_START(4);
     struct ibv_send_wr* bad_wr;
     NCCLCHECK(wrap_ibv_post_send(comm->devs[i].gpuFlush.qp.qp, &wr, &bad_wr));
@@ -709,7 +725,8 @@ ncclResult_t IbCastIflush(void* recvComm, int n, void** data, int* sizes, void**
 
     IbCastAddEvent(req, i);
 
-    TRACE(NCCL_NET, "NET/IB: %s: Flush request posted (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base, wr.wr_id);
+    TRACE(NCCL_NET, "NET/IB: %s: Flush request posted (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base,
+          wr.wr_id);
   }
 
   *request = req;
@@ -728,7 +745,8 @@ static int getReqQpIndex(struct ncclIbRequest* req, int request, int qpNumber) {
 }
 #endif
 
-static inline ncclResult_t IbCastRequestRetrieveFromCompletion(struct ncclIbNetCommBase* base, ibv_wc* wc, ncclIbRequest** req) {
+static inline ncclResult_t IbCastRequestRetrieveFromCompletion(struct ncclIbNetCommBase* base, ibv_wc* wc,
+                                                               ncclIbRequest** req) {
   assert(req != NULL);
   assert(wc != NULL);
 
@@ -736,9 +754,11 @@ static inline ncclResult_t IbCastRequestRetrieveFromCompletion(struct ncclIbNetC
   // of the completion are valid.
   assert(wc->status == IBV_WC_SUCCESS);
 
-  TRACE(NCCL_NET, "NET/IB: %s: Retrieving a %s request (wr_id=%ld, opcode=%s)", __func__, base->isSend ? "send" : "recv", wc->wr_id, ibvWcOpcodeStr(wc->opcode));
+  TRACE(NCCL_NET, "NET/IB: %s: Retrieving a %s request (wr_id=%ld, opcode=%s)", __func__,
+        base->isSend ? "send" : "recv", wc->wr_id, ibvWcOpcodeStr(wc->opcode));
   if (!base->isSend && wc->opcode == IBV_WC_RECV_RDMA_WITH_IMM && base->recvMatchingScheme == BY_ID) {
-    TRACE(NCCL_NET, "NET/IB: %s: Retrieving a receive request (wr_id=%ld, opcode=%s, imm_data=%d, byte_len=%d)", __func__, wc->wr_id, ibvWcOpcodeStr(wc->opcode), be32toh(wc->imm_data), wc->byte_len);
+    TRACE(NCCL_NET, "NET/IB: %s: Retrieving a receive request (wr_id=%ld, opcode=%s, imm_data=%d, byte_len=%d)",
+          __func__, wc->wr_id, ibvWcOpcodeStr(wc->opcode), be32toh(wc->imm_data), wc->byte_len);
     struct ncclIbRecvComm* recvComm = (struct ncclIbRecvComm*)base;
     *req = recvComm->recvReqs[be32toh(wc->imm_data) % NET_IB_MAX_REQUESTS];
   } else if (!base->isSend && wc->opcode == IBV_WC_RECV_RDMA_WITH_IMM && base->recvMatchingScheme == BY_INDEX) {
@@ -752,7 +772,7 @@ static inline ncclResult_t IbCastRequestRetrieveFromCompletion(struct ncclIbNetC
     struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)base;
     if (base->recvMatchingScheme == BY_INDEX) {
       // BY_INDEX: wr_id was remapped by CAST scheduler for RTT timing
-      struct ncclIbRemapWrId *remapWrId = (struct ncclIbRemapWrId *) wc->wr_id;
+      struct ncclIbRemapWrId* remapWrId = (struct ncclIbRemapWrId*)wc->wr_id;
       assert(remapWrId != NULL);
       assert(remapWrId->state == NCCL_NET_IB_REMAP_USED);
       *req = sendComm->sendReqs[remapWrId->origWrId & 0xff][0];
@@ -763,12 +783,17 @@ static inline ncclResult_t IbCastRequestRetrieveFromCompletion(struct ncclIbNetC
       *req = sendComm->sendReqs[wc->wr_id & 0xff][0];
     }
   }
-  TRACE(NCCL_NET, "NET/IB: %s: Retrieved a %s request (req=%p, comm=%p, id=%ld, type=%s, wc.wr_id=%ld, wc.opcode=%s, wc.imm_data=%d, wc.byte_len=%d, wc.qp_num=%u)", __func__, base->isSend ? "send" : "recv", *req, (*req)->base, (*req)->id, IbCastReqTypeStr[(*req)->type], wc->wr_id, ibvWcOpcodeStr(wc->opcode), be32toh(wc->imm_data), wc->byte_len, wc->qp_num);
+  TRACE(NCCL_NET,
+        "NET/IB: %s: Retrieved a %s request (req=%p, comm=%p, id=%ld, type=%s, wc.wr_id=%ld, wc.opcode=%s, "
+        "wc.imm_data=%d, wc.byte_len=%d, wc.qp_num=%u)",
+        __func__, base->isSend ? "send" : "recv", *req, (*req)->base, (*req)->id, IbCastReqTypeStr[(*req)->type],
+        wc->wr_id, ibvWcOpcodeStr(wc->opcode), be32toh(wc->imm_data), wc->byte_len, wc->qp_num);
   return ncclSuccess;
 }
 
-static inline bool IbCastRequestIsComplete(struct ncclIbRequest *request) {
-  bool complete = (request->events[0] == 0 && request->events[1] == 0 && request->events[2] == 0 && request->events[3] == 0);
+static inline bool IbCastRequestIsComplete(struct ncclIbRequest* request) {
+  bool complete =
+    (request->events[0] == 0 && request->events[1] == 0 && request->events[2] == 0 && request->events[3] == 0);
   if (!complete && request->base->resiliency) {
     NCCLCHECK(IbCastResiliencyRequestIsComplete(request, &complete));
   }
@@ -776,12 +801,15 @@ static inline bool IbCastRequestIsComplete(struct ncclIbRequest *request) {
 }
 
 static inline ncclResult_t IbCastRequestComplete(struct ncclIbRequest* r, int* done, int* sizes) {
-  TRACE(NCCL_NET, "NET/IB: %s: %s request completed (req=%p, comm=%p, id=%ld, type=%s)", __func__, r->base->isSend ? "Send" : "Recv", r, r->base, r->id, IbCastReqTypeStr[r->type]);
+  TRACE(NCCL_NET, "NET/IB: %s: %s request completed (req=%p, comm=%p, id=%ld, type=%s)", __func__,
+        r->base->isSend ? "Send" : "Recv", r, r->base, r->id, IbCastReqTypeStr[r->type]);
   *done = 1;
   if (sizes && r->type == NCCL_NET_IB_REQ_RECV) {
-    TRACE(NCCL_NET, "NET/IB: %s: Recv request completed (req=%p, comm=%p, id=%ld, type=%s, nreqs=%d)", __func__, r, r->base, r->id, IbCastReqTypeStr[r->type], r->nreqs);
-    int *sizesToReport = (r->nreqs > 1 || r->recv.cmplsRecords->sizes[0] > 0) ? r->recv.cmplsRecords->sizes : &(r->recv.aggSize);
-    for (int i=0; i<r->nreqs; i++) {
+    TRACE(NCCL_NET, "NET/IB: %s: Recv request completed (req=%p, comm=%p, id=%ld, type=%s, nreqs=%d)", __func__, r,
+          r->base, r->id, IbCastReqTypeStr[r->type], r->nreqs);
+    int* sizesToReport =
+      (r->nreqs > 1 || r->recv.cmplsRecords->sizes[0] > 0) ? r->recv.cmplsRecords->sizes : &(r->recv.aggSize);
+    for (int i = 0; i < r->nreqs; i++) {
       sizes[i] = sizesToReport[i];
 #ifdef NCCL_ENABLE_NET_PROFILING
       for (int j = 0; j < r->pInfo[i].nEventHandles; j++) {
@@ -794,11 +822,11 @@ static inline ncclResult_t IbCastRequestComplete(struct ncclIbRequest* r, int* d
     TRACE(NCCL_NET, "NET/IB: %s: Send request completed (req=%p, comm=%p, id=%ld)", __func__, r, r->base, r->id);
     if (sizes) {
       sizes[0] = r->send.size;
-  #ifdef NCCL_ENABLE_NET_PROFILING
+#ifdef NCCL_ENABLE_NET_PROFILING
       for (int j = 0; j < r->pInfo[0].nEventHandles; j++) {
         NCCLCHECK(IbCastProfilerFunction(&r->pInfo[0].qpEventHandles[j], ncclProfilerNetEventStop, NULL, 0, NULL));
       }
-  #endif
+#endif
     }
     int slot = r->id % NET_IB_MAX_REQUESTS;
     struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)r->base;
@@ -820,21 +848,20 @@ static ncclResult_t IbCastLogCompletionWithError(struct ncclIbNetCommBase* commB
   struct ncclIbNetCommDevBase* devBase = IbCastGetNetCommDevBase(commBase, devIndex);
   char localGidString[INET6_ADDRSTRLEN] = "";
   char remoteGidString[INET6_ADDRSTRLEN] = "";
-  const char* localGidStr = NULL, *remoteGidStr = NULL;
+  const char *localGidStr = NULL, *remoteGidStr = NULL;
   if (devBase->gidInfo.link_layer == IBV_LINK_LAYER_ETHERNET) {
     localGidStr = ibvGetGidStr(&devBase->gidInfo.localGid, localGidString, sizeof(localGidString));
     remoteGidStr = ibvGetGidStr(&commBase->remDevs[devIndex].remoteGid, remoteGidString, sizeof(remoteGidString));
   }
 
-  char sockStr[SOCKET_NAME_MAXLEN+1];
+  char sockStr[SOCKET_NAME_MAXLEN + 1];
   union ncclSocketAddress addr;
   ncclSocketGetAddr(&commBase->sock, &addr);
   ncclSocketToString(&addr, sockStr);
-  char *hcaName = devBase->pd->context->device->name;
-  WARN("NET/IB: Got completion from peer %s with status=%s(%d) opcode=%s(%d) vendor_err=%u %s%s%s%s hca %s",
-      sockStr, ibvWcStatusStr(wc->status), wc->status,
-      ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->vendor_err,
-      localGidStr ?  " localGid ":"", localGidString, remoteGidStr ? " remoteGids":"", remoteGidString, hcaName);
+  char* hcaName = devBase->pd->context->device->name;
+  WARN("NET/IB: Got completion from peer %s with status=%s(%d) opcode=%s(%d) vendor_err=%u %s%s%s%s hca %s", sockStr,
+       ibvWcStatusStr(wc->status), wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->vendor_err,
+       localGidStr ? " localGid " : "", localGidString, remoteGidStr ? " remoteGids" : "", remoteGidString, hcaName);
   return ncclSuccess;
 }
 
@@ -844,7 +871,8 @@ static ncclResult_t IbCastCompletionEventByOrder(struct ncclIbNetCommBase* commB
   assert(wc->status == IBV_WC_SUCCESS);
   ncclIbRequest* req = nullptr;
 
-  TRACE(NCCL_NET, "NET/IB: %s: Retrieving a %s request (wr_id=%ld, opcode=%s)", __func__, commBase->isSend ? "send" : "recv", wc->wr_id, ibvWcOpcodeStr(wc->opcode));
+  TRACE(NCCL_NET, "NET/IB: %s: Retrieving a %s request (wr_id=%ld, opcode=%s)", __func__,
+        commBase->isSend ? "send" : "recv", wc->wr_id, ibvWcOpcodeStr(wc->opcode));
   if (commBase->recvMatchingScheme != BY_ORDER) {
     WARN("NET/IB: %s: recvMatchingScheme not supported", __func__);
     return ncclInternalError;
@@ -857,21 +885,29 @@ static ncclResult_t IbCastCompletionEventByOrder(struct ncclIbNetCommBase* commB
   }
 
   if (req == NULL) {
-    WARN("NET/IB: %s: %s comm could not retreive a request found for a successful completion (comm=%p, wc.wr_id=%ld, opcode=%d, qp_num=%u)", __func__, commBase->isSend ? "Send" : "Recv", commBase, wc->wr_id, wc->opcode, wc->qp_num);
+    WARN("NET/IB: %s: %s comm could not retreive a request found for a successful completion (comm=%p, wc.wr_id=%ld, "
+         "opcode=%d, qp_num=%u)",
+         __func__, commBase->isSend ? "Send" : "Recv", commBase, wc->wr_id, wc->opcode, wc->qp_num);
     return ncclInternalError;
   }
 
 #ifdef ENABLE_TRACE
-  char line[SOCKET_NAME_MAXLEN+1];
+  char line[SOCKET_NAME_MAXLEN + 1];
   union ncclSocketAddress addr;
   ncclSocketGetAddr(&commBase->sock, &addr);
-  TRACE(NCCL_NET, "Got completion from peer %s with status=%d opcode=%d len=%u wr_id=%lu r=%p type=%d events={%d,%d,%d,%d}, devIndex=%d",
-    ncclSocketToString(&addr, line), wc->status, wc->opcode,wc->byte_len, wc->wr_id, req, req->type, req->events[0], req->events[1], req->events[2], req->events[3], devIndex);
-  #endif
+  TRACE(NCCL_NET,
+        "Got completion from peer %s with status=%d opcode=%d len=%u wr_id=%lu r=%p type=%d events={%d,%d,%d,%d}, "
+        "devIndex=%d",
+        ncclSocketToString(&addr, line), wc->status, wc->opcode, wc->byte_len, wc->wr_id, req, req->type,
+        req->events[0], req->events[1], req->events[2], req->events[3], devIndex);
+#endif
 
   if (commBase->isSend) {
     if (req->type != NCCL_NET_IB_REQ_SEND) {
-      WARN("NET/IB: %s: Sender expected a 'send' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=%ld, wc.opcode=%s(%d), wc.qp_num=%u)", __func__, IbCastReqTypeStr[req->type], req, commBase, req->id, wc->wr_id, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num);
+      WARN("NET/IB: %s: Sender expected a 'send' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=%ld, "
+           "wc.opcode=%s(%d), wc.qp_num=%u)",
+           __func__, IbCastReqTypeStr[req->type], req, commBase, req->id, wc->wr_id, ibvWcOpcodeStr(wc->opcode),
+           wc->opcode, wc->qp_num);
       return ncclInternalError;
     }
     struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)commBase;
@@ -880,74 +916,96 @@ static ncclResult_t IbCastCompletionEventByOrder(struct ncclIbNetCommBase* commB
     for (int j = 0; j < req->nreqs; j++) {
       sendReq = sendComm->sendReqs[slot][j];
       if (!commBase->resiliency && (sendReq->events[devIndex] <= 0)) {
-        WARN("NET/IB: sendReq(%p)->events={%d,%d,%d,%d}, devIndex=%d, reqIdx=%d <= 0", sendReq, sendReq->events[0], sendReq->events[1], sendReq->events[2], sendReq->events[3], devIndex, j);
+        WARN("NET/IB: sendReq(%p)->events={%d,%d,%d,%d}, devIndex=%d, reqIdx=%d <= 0", sendReq, sendReq->events[0],
+             sendReq->events[1], sendReq->events[2], sendReq->events[3], devIndex, j);
         return ncclInternalError;
       }
       sendReq->events[devIndex]--;
-      TRACE(NCCL_NET, "NET/IB: %s: Got completion for a send request (req=%p, comm=%p, id=%ld, devIndex=%d, qp_num=%u)", __func__, sendReq, sendReq->base, sendReq->id, devIndex, wc->qp_num);
+      TRACE(NCCL_NET, "NET/IB: %s: Got completion for a send request (req=%p, comm=%p, id=%ld, devIndex=%d, qp_num=%u)",
+            __func__, sendReq, sendReq->base, sendReq->id, devIndex, wc->qp_num);
 #ifdef NCCL_ENABLE_NET_PROFILING
       // Stop Qp event for sendReq
       int qpIndex = getReqQpIndex(sendReq, j, wc->qp_num);
-      NCCLCHECK(IbCastProfilerFunction(&sendReq->pInfo[j].qpEventHandles[qpIndex], ncclProfilerNetEventStop, NULL, 0, NULL));
+      NCCLCHECK(IbCastProfilerFunction(&sendReq->pInfo[j].qpEventHandles[qpIndex], ncclProfilerNetEventStop, NULL, 0,
+                                       NULL));
 #endif
     }
   } else {
     if (wc->opcode == IBV_WC_RECV_RDMA_WITH_IMM) {
       if (req->type != NCCL_NET_IB_REQ_RECV && !commBase->resiliency) {
-        WARN("NET/IB: %s: Receiver expected a 'recv' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=%ld, wc.status=%s(%d) wc.opcode=%s(%d), wc.qp_num=%u)", __func__, IbCastReqTypeStr[req->type], req, req->base, req->id, wc->wr_id, ibvWcStatusStr(wc->status), wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num);
+        WARN("NET/IB: %s: Receiver expected a 'recv' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=%ld, "
+             "wc.status=%s(%d) wc.opcode=%s(%d), wc.qp_num=%u)",
+             __func__, IbCastReqTypeStr[req->type], req, req->base, req->id, wc->wr_id, ibvWcStatusStr(wc->status),
+             wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num);
         return ncclInternalError;
       }
       if (req->nreqs == 1) {
         if (commBase->recvMatchingScheme != BY_ID) {
           req->recv.cmplsRecords->sizes[0] += wc->byte_len;
         } else if (req->recv.cmplsRecords->sizes[0] == 0) {
-          req->recv.aggSize+= wc->byte_len;
+          req->recv.aggSize += wc->byte_len;
         }
       }
-      TRACE(NCCL_NET, "NET/IB: %s: Got completion for a recv request (req=%p, comm=%p, id=%ld, devIndex=%d, qp_num=%u)", __func__, req, req->base, req->id, devIndex, wc->qp_num);
+      TRACE(NCCL_NET, "NET/IB: %s: Got completion for a recv request (req=%p, comm=%p, id=%ld, devIndex=%d, qp_num=%u)",
+            __func__, req, req->base, req->id, devIndex, wc->qp_num);
       req->events[devIndex]--;
     } else if (wc->opcode == IBV_WC_RDMA_READ) {
-      TRACE(NCCL_NET, "NET/IB: %s: Got completion for a flush request (req=%p, comm=%p, id=%ld, devIndex=%d, qp_num=%u)", __func__, req, req->base, req->id, devIndex, wc->qp_num);
+      TRACE(NCCL_NET,
+            "NET/IB: %s: Got completion for a flush request (req=%p, comm=%p, id=%ld, devIndex=%d, qp_num=%u)",
+            __func__, req, req->base, req->id, devIndex, wc->qp_num);
       req->events[devIndex]--;
     } else if (wc->opcode == IBV_WC_RDMA_WRITE) {
       TRACE(NCCL_NET, "NET/IB: %s: Got completion for a CTS (devIndex=%d, qp_num=%u)", __func__, devIndex, wc->qp_num);
       req->events[devIndex]--;
       return ncclSuccess;
     } else {
-      WARN("NET/IB: %s: Unknown completion (req=%p, comm=%p, id=%ld, devIndex=%d, req->type=%s, wc.wr_id=%ld, wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=%d)", __func__, req, commBase, req ? req->id : -1, devIndex, IbCastReqTypeStr[req->type], wc->wr_id, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num, be32toh(wc->imm_data));
+      WARN("NET/IB: %s: Unknown completion (req=%p, comm=%p, id=%ld, devIndex=%d, req->type=%s, wc.wr_id=%ld, "
+           "wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=%d)",
+           __func__, req, commBase, req ? req->id : -1, devIndex, IbCastReqTypeStr[req->type], wc->wr_id,
+           ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num, be32toh(wc->imm_data));
       return ncclInternalError;
     }
 #ifdef NCCL_ENABLE_NET_PROFILING
     // Stop Qp event for workFifo
     for (int j = 0; j < req->nreqs; j++) {
       int qpIndex = getReqQpIndex(req, j, wc->qp_num);
-      NCCLCHECK(IbCastProfilerFunction(&req->pInfo[j].qpEventHandles[qpIndex], ncclProfilerNetEventStop, NULL, 0, NULL));
+      NCCLCHECK(IbCastProfilerFunction(&req->pInfo[j].qpEventHandles[qpIndex], ncclProfilerNetEventStop, NULL, 0,
+                                       NULL));
     }
 #endif
   }
   return ncclSuccess;
 }
 
-static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase* commBase, struct ibv_wc* wc, int devIndex) {
+static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase* commBase, struct ibv_wc* wc,
+                                                        int devIndex) {
   union ncclSocketAddress addr;
   ncclSocketGetAddr(&commBase->sock, &addr);
 
   struct ncclIbRequest* req = NULL;
   NCCLCHECK(IbCastRequestRetrieveFromCompletion(commBase, wc, &req));
   if (req == NULL) {
-    WARN("NET/IB: %s: %s comm could not retreive a request found for a successful completion (comm=%p, wc.wr_id=%ld, opcode=%d, qp_num=%u)", __func__, commBase->isSend ? "Send" : "Recv", commBase, wc->wr_id, wc->opcode, wc->qp_num);
+    WARN("NET/IB: %s: %s comm could not retreive a request found for a successful completion (comm=%p, wc.wr_id=%ld, "
+         "opcode=%d, qp_num=%u)",
+         __func__, commBase->isSend ? "Send" : "Recv", commBase, wc->wr_id, wc->opcode, wc->qp_num);
     return ncclInternalError;
   }
 
-  #ifdef ENABLE_TRACE
-  char line[SOCKET_NAME_MAXLEN+1];
-  TRACE(NCCL_NET, "Got completion from peer %s with status=%d opcode=%d len=%u wr_id=%lu r=%p type=%d events={%d,%d,%d,%d}, devIndex=%d",
-    ncclSocketToString(&addr, line), wc->status, wc->opcode,wc->byte_len, wc->wr_id, req, req->type, req->events[0], req->events[1], req->events[2], req->events[3], devIndex);
-  #endif
+#ifdef ENABLE_TRACE
+  char line[SOCKET_NAME_MAXLEN + 1];
+  TRACE(NCCL_NET,
+        "Got completion from peer %s with status=%d opcode=%d len=%u wr_id=%lu r=%p type=%d events={%d,%d,%d,%d}, "
+        "devIndex=%d",
+        ncclSocketToString(&addr, line), wc->status, wc->opcode, wc->byte_len, wc->wr_id, req, req->type,
+        req->events[0], req->events[1], req->events[2], req->events[3], devIndex);
+#endif
 
   if (commBase->isSend) {
     if (req->type != NCCL_NET_IB_REQ_SEND) {
-      WARN("NET/IB: %s: Sender expected a 'send' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=%ld, wc.opcode=%s(%d), wc.qp_num=%u)", __func__, IbCastReqTypeStr[req->type], req, commBase, req->id, wc->wr_id, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num);
+      WARN("NET/IB: %s: Sender expected a 'send' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=%ld, "
+           "wc.opcode=%s(%d), wc.qp_num=%u)",
+           __func__, IbCastReqTypeStr[req->type], req, commBase, req->id, wc->wr_id, ibvWcOpcodeStr(wc->opcode),
+           wc->opcode, wc->qp_num);
       return ncclInternalError;
     }
     struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)commBase;
@@ -956,35 +1014,46 @@ static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase
     for (int j = 0; j < req->nreqs; j++) {
       sendReq = sendComm->sendReqs[slot][j];
       if (!commBase->resiliency && (sendReq->events[devIndex] <= 0)) {
-        WARN("NET/IB: sendReq(%p)->events={%d,%d,%d,%d}, devIndex=%d, reqIdx=%d <= 0", sendReq, sendReq->events[0], sendReq->events[1], sendReq->events[2], sendReq->events[3], devIndex, j);
+        WARN("NET/IB: sendReq(%p)->events={%d,%d,%d,%d}, devIndex=%d, reqIdx=%d <= 0", sendReq, sendReq->events[0],
+             sendReq->events[1], sendReq->events[2], sendReq->events[3], devIndex, j);
         return ncclInternalError;
       }
       sendReq->events[devIndex]--;
-      TRACE(NCCL_NET, "NET/IB: %s: Got completion for a send request (req=%p, comm=%p, id=%ld, devIndex=%d, qp_num=%u)", __func__, sendReq, sendReq->base, sendReq->id, devIndex, wc->qp_num);
+      TRACE(NCCL_NET, "NET/IB: %s: Got completion for a send request (req=%p, comm=%p, id=%ld, devIndex=%d, qp_num=%u)",
+            __func__, sendReq, sendReq->base, sendReq->id, devIndex, wc->qp_num);
 #ifdef NCCL_ENABLE_NET_PROFILING
       // Stop Qp event for sendReq
       int qpIndex = getReqQpIndex(sendReq, j, wc->qp_num);
-      NCCLCHECK(IbCastProfilerFunction(&sendReq->pInfo[j].qpEventHandles[qpIndex], ncclProfilerNetEventStop, NULL, 0, NULL));
+      NCCLCHECK(IbCastProfilerFunction(&sendReq->pInfo[j].qpEventHandles[qpIndex], ncclProfilerNetEventStop, NULL, 0,
+                                       NULL));
 #endif
     }
   } else {
     if (wc->opcode == IBV_WC_RECV_RDMA_WITH_IMM) {
       if (req->type == NCCL_NET_IB_REQ_UNUSED && commBase->resiliency) {
-        INFO(NCCL_NET, "NET/IB: %s: Receiver got a completion for a data transfer but retrieved an 'unused' request (req=%p, comm=%p, id=%ld, wc.status=%s(%d), wc.wr_id=%ld, wc.imm_data=%d, wc.opcode=%s(%d), wc.qp_num=%u)", __func__, req, commBase, req->id, ibvWcStatusStr(wc->status), wc->status, wc->wr_id, be32toh(wc->imm_data), ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num);
+        INFO(NCCL_NET,
+             "NET/IB: %s: Receiver got a completion for a data transfer but retrieved an 'unused' request (req=%p, "
+             "comm=%p, id=%ld, wc.status=%s(%d), wc.wr_id=%ld, wc.imm_data=%d, wc.opcode=%s(%d), wc.qp_num=%u)",
+             __func__, req, commBase, req->id, ibvWcStatusStr(wc->status), wc->status, wc->wr_id, be32toh(wc->imm_data),
+             ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num);
         return ncclSuccess;
       }
       if (req->type != NCCL_NET_IB_REQ_RECV && !commBase->resiliency) {
-        WARN("NET/IB: %s: Receiver expected a 'recv' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=%ld, wc.status=%s(%d) wc.opcode=%s(%d), wc.qp_num=%u)", __func__, IbCastReqTypeStr[req->type], req, req->base, req->id, wc->wr_id, ibvWcStatusStr(wc->status), wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num);
+        WARN("NET/IB: %s: Receiver expected a 'recv' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=%ld, "
+             "wc.status=%s(%d) wc.opcode=%s(%d), wc.qp_num=%u)",
+             __func__, IbCastReqTypeStr[req->type], req, req->base, req->id, wc->wr_id, ibvWcStatusStr(wc->status),
+             wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num);
         return ncclInternalError;
       }
       if (req->nreqs == 1) {
         if (commBase->recvMatchingScheme != BY_ID) {
           req->recv.cmplsRecords->sizes[0] += wc->byte_len;
         } else if (req->recv.cmplsRecords->sizes[0] == 0) {
-          req->recv.aggSize+= wc->byte_len;
+          req->recv.aggSize += wc->byte_len;
         }
       }
-      TRACE(NCCL_NET, "NET/IB: %s: Got completion for a recv request (req=%p, comm=%p, id=%ld, devIndex=%d, qp_num=%u)", __func__, req, req->base, req->id, devIndex, wc->qp_num);
+      TRACE(NCCL_NET, "NET/IB: %s: Got completion for a recv request (req=%p, comm=%p, id=%ld, devIndex=%d, qp_num=%u)",
+            __func__, req, req->base, req->id, devIndex, wc->qp_num);
       struct ncclIbRecvComm* recvComm = (struct ncclIbRecvComm*)commBase;
 
       if (recvComm->prepostReceiveWorkRequests) {
@@ -1004,10 +1073,10 @@ static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase
         if (be32toh(wc->imm_data) & WR_IMM_SPLIT_DATA_FLAG) {
           req->events[devIndex]--;
         } else { // Single QP send path
-                // The receiver posted recvs on all QPs, but the sender used a single QP
-                // (no split-data), so only one QP received the RDMA Write with IMM.
-                // Recvs posted on other QPs won't complete for this request.
-                // Reset events to only wait for signaled CTS completions.
+          // The receiver posted recvs on all QPs, but the sender used a single QP
+          // (no split-data), so only one QP received the RDMA Write with IMM.
+          // Recvs posted on other QPs won't complete for this request.
+          // Reset events to only wait for signaled CTS completions.
           for (int d = 0; d < NCCL_IB_MAX_DEVS_PER_NIC; d++) {
             req->events[d] = req->ctsEvents[d];
           }
@@ -1016,36 +1085,47 @@ static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase
         req->events[devIndex]--;
       }
     } else if (wc->opcode == IBV_WC_RDMA_READ) {
-      TRACE(NCCL_NET, "NET/IB: %s: Got completion for a flush request (req=%p, comm=%p, id=%ld, devIndex=%d, qp_num=%u)", __func__, req, req->base, req->id, devIndex, wc->qp_num);
+      TRACE(NCCL_NET,
+            "NET/IB: %s: Got completion for a flush request (req=%p, comm=%p, id=%ld, devIndex=%d, qp_num=%u)",
+            __func__, req, req->base, req->id, devIndex, wc->qp_num);
       req->events[devIndex]--;
     } else if (wc->opcode == IBV_WC_RDMA_WRITE) {
       req->events[devIndex]--;
       req->ctsEvents[devIndex]--;
       // This is a CTS completion
-      TRACE(NCCL_NET, "NET/IB: %s: Got completion for a CTS (req=%p, comm=%p, id=%ld, devIndex=%d, qp_num=%u)", __func__, req, req->base, req->id, devIndex, wc->qp_num);
+      TRACE(NCCL_NET, "NET/IB: %s: Got completion for a CTS (req=%p, comm=%p, id=%ld, devIndex=%d, qp_num=%u)",
+            __func__, req, req->base, req->id, devIndex, wc->qp_num);
       if (req->type == NCCL_NET_IB_REQ_UNUSED) {
-        INFO(NCCL_NET, "NET/IB: %s: Receiver got a completion for a CTS but retrieved an 'unused' request (req=%p, comm=%p, id=%ld, wc.wr_id=%ld, wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=%d)", __func__, req, req->base, req->id, wc->wr_id, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num, be32toh(wc->imm_data));
+        INFO(NCCL_NET,
+             "NET/IB: %s: Receiver got a completion for a CTS but retrieved an 'unused' request (req=%p, comm=%p, "
+             "id=%ld, wc.wr_id=%ld, wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=%d)",
+             __func__, req, req->base, req->id, wc->wr_id, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num,
+             be32toh(wc->imm_data));
         return ncclSuccess;
       }
     } else {
-      WARN("NET/IB: %s: Unknown completion (req=%p, comm=%p, id=%ld, devIndex=%d, req->type=%s, wc.wr_id=%ld, wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=%d)", __func__, req, commBase, req ? req->id : -1, devIndex, IbCastReqTypeStr[req->type], wc->wr_id, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num, be32toh(wc->imm_data));
+      WARN("NET/IB: %s: Unknown completion (req=%p, comm=%p, id=%ld, devIndex=%d, req->type=%s, wc.wr_id=%ld, "
+           "wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=%d)",
+           __func__, req, commBase, req ? req->id : -1, devIndex, IbCastReqTypeStr[req->type], wc->wr_id,
+           ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num, be32toh(wc->imm_data));
       return ncclInternalError;
     }
 #ifdef NCCL_ENABLE_NET_PROFILING
     // Stop Qp event for workFifo
     for (int j = 0; j < req->nreqs; j++) {
       int qpIndex = getReqQpIndex(req, j, wc->qp_num);
-      NCCLCHECK(IbCastProfilerFunction(&req->pInfo[j].qpEventHandles[qpIndex], ncclProfilerNetEventStop, NULL, 0, NULL));
+      NCCLCHECK(IbCastProfilerFunction(&req->pInfo[j].qpEventHandles[qpIndex], ncclProfilerNetEventStop, NULL, 0,
+                                       NULL));
     }
 #endif
   }
   return ncclSuccess;
 }
 
-#define NCCL_CQ_POLL_MAX_EVENT        16
+#define NCCL_CQ_POLL_MAX_EVENT 16
 
 ncclResult_t IbCastTest(void* request, int* done, int* sizes) {
-  struct ncclIbRequest *r = (struct ncclIbRequest*)request;
+  struct ncclIbRequest* r = (struct ncclIbRequest*)request;
   *done = 0;
 
   if (r->base->resiliency && r->base->resiliency->inProgress) {
@@ -1060,7 +1140,7 @@ ncclResult_t IbCastTest(void* request, int* done, int* sizes) {
     cqMaxPollEvent = NCCL_CQ_POLL_MAX_EVENT;
   }
   do {
-    NCCLCHECK(IbCastStatsCheckFatalCount(&r->base->stats,__func__));
+    NCCLCHECK(IbCastStatsCheckFatalCount(&r->base->stats, __func__));
     if (IbCastRequestIsComplete(r)) {
       NCCLCHECK(IbCastRequestComplete(r, done, sizes));
       return ncclSuccess;
@@ -1077,21 +1157,28 @@ ncclResult_t IbCastTest(void* request, int* done, int* sizes) {
       }
       TIME_START(3);
       NCCLCHECK(wrap_ibv_poll_cq(r->devBases[i]->cq, cqMaxPollEvent, wcs, &wrDone));
-      if (wrDone == 0) { TIME_CANCEL(3); } else { TIME_STOP(3); }
+      if (wrDone == 0) {
+        TIME_CANCEL(3);
+      } else {
+        TIME_STOP(3);
+      }
       if (wrDone == 0) continue;
       totalWrDone += wrDone;
-      for (int w=0; w<wrDone; w++) {
-        struct ibv_wc *wc = wcs+w;
+      for (int w = 0; w < wrDone; w++) {
+        struct ibv_wc* wc = wcs + w;
         if (wc->status != IBV_WC_SUCCESS) {
           if (r->base->resiliency == NULL) {
-            WARN("NET/IB: %s: Got CQE with error (devIndex=%d, req=%p, comm=%p (%s), wr_id=%lu, qp_num=%d)", __func__, i, r, r->base, r->base->isSend ? "send" : "recv", wc->wr_id, wc->qp_num);
+            WARN("NET/IB: %s: Got CQE with error (devIndex=%d, req=%p, comm=%p (%s), wr_id=%lu, qp_num=%d)", __func__,
+                 i, r, r->base, r->base->isSend ? "send" : "recv", wc->wr_id, wc->qp_num);
             IbCastLogCompletionWithError(r->base, wc, i);
             // If resiliency is not enabled, we cannot recover from any error.
             return ncclRemoteError;
           }
           NCCLCHECK(IbCastResiliencyHandleCompletionError(r->base->resiliency, wc, i));
         } else {
-          TRACE(NCCL_NET, "NET/IB: %s: Processing a completion event (devIndex=%d, comm=%p (%s), req=%p, wr_id=%lu, qp_num=%d)", __func__, i, r->base, r->base->isSend ? "send" : "recv", r, wc->wr_id, wc->qp_num);
+          TRACE(NCCL_NET,
+                "NET/IB: %s: Processing a completion event (devIndex=%d, comm=%p (%s), req=%p, wr_id=%lu, qp_num=%d)",
+                __func__, i, r->base, r->base->isSend ? "send" : "recv", r, wc->wr_id, wc->qp_num);
           if (r->base->recvMatchingScheme != BY_ORDER) {
             NCCLCHECK(IbCastCompletionEventProcess(r->base, wc, i));
           } else {
@@ -1101,7 +1188,7 @@ ncclResult_t IbCastTest(void* request, int* done, int* sizes) {
       }
       // Once the IB fatal event is reported in the async thread, we want to propagate this error
       // to communicator and prevent further polling to reduce error pollution.
-      NCCLCHECK(IbCastStatsCheckFatalCount(&IbCastDevs[r->devBases[i]->ibDevN].stats,__func__));
+      NCCLCHECK(IbCastStatsCheckFatalCount(&IbCastDevs[r->devBases[i]->ibDevN].stats, __func__));
     }
   } while (totalWrDone > 0);
 
@@ -1172,13 +1259,13 @@ ncclResult_t ncclIbCastFaultCheckErrorFatal(void* sendComm, int wcStatus, bool* 
   // HandleCompletionError which modifies device state and QP pointers.
   bool fatal = true;
   switch ((enum ibv_wc_status)wcStatus) {
-    case IBV_WC_WR_FLUSH_ERR:
-    case IBV_WC_RETRY_EXC_ERR:
-      fatal = false;
-      break;
-    default:
-      fatal = true;
-      break;
+  case IBV_WC_WR_FLUSH_ERR:
+  case IBV_WC_RETRY_EXC_ERR:
+    fatal = false;
+    break;
+  default:
+    fatal = true;
+    break;
   }
   *isFatal = fatal;
   return ncclSuccess;
@@ -1191,8 +1278,8 @@ ncclResult_t ncclIbCastFaultCheckErrorFatal(void* sendComm, int wcStatus, bool* 
 // [NCCL_IB_FLUSH_REQ_WR_ID_OFFSET, +NET_IB_MAX_REQUESTS); else the receiver
 // would treat it as a real slot. Fail the build if the ranges ever overlap it.
 static_assert(NCCL_IB_OPS_FAULT_SYNTH_WR_ID > NET_IB_MAX_REQUESTS &&
-              (NCCL_IB_OPS_FAULT_SYNTH_WR_ID < NCCL_IB_FLUSH_REQ_WR_ID_OFFSET ||
-               NCCL_IB_OPS_FAULT_SYNTH_WR_ID >= NCCL_IB_FLUSH_REQ_WR_ID_OFFSET + NET_IB_MAX_REQUESTS),
+                (NCCL_IB_OPS_FAULT_SYNTH_WR_ID < NCCL_IB_FLUSH_REQ_WR_ID_OFFSET ||
+                 NCCL_IB_OPS_FAULT_SYNTH_WR_ID >= NCCL_IB_FLUSH_REQ_WR_ID_OFFSET + NET_IB_MAX_REQUESTS),
               "synthesized fault wr_id collides with a receiver wr_id range");
 
 ncclResult_t ncclIbCastFaultOpsSetPostSendError(void* sendComm, int qpIdx, int errnoVal) {
@@ -1215,8 +1302,8 @@ ncclResult_t ncclIbCastFaultOpsSetPostRecvError(void* recvComm, int qpIdx, int e
   return ncclIbOpsFaultArmPostRecv(qp->context, qp->qp_num, errnoVal);
 }
 
-ncclResult_t ncclIbCastFaultOpsSetPollCqError(void* comm, int qpIdx, int wcStatus,
-                                              int injectCount, bool injectWhenIdle) {
+ncclResult_t ncclIbCastFaultOpsSetPollCqError(void* comm, int qpIdx, int wcStatus, int injectCount,
+                                              bool injectWhenIdle) {
   if (!comm) return ncclInvalidArgument;
   // Both send and recv comms share ncclIbNetCommBase as their first member.
   struct ncclIbNetCommBase* base = (struct ncclIbNetCommBase*)comm;
@@ -1234,8 +1321,7 @@ ncclResult_t ncclIbCastFaultOpsClear(void* comm) {
   // while its context stays alive and armed. The PD context survives teardown.
   for (int devIndex = 0; devIndex < base->vProps.ndevs; devIndex++) {
     struct ncclIbNetCommDevBase* devBase = IbCastGetNetCommDevBase(base, devIndex);
-    if (devBase && devBase->pd && devBase->pd->context)
-      NCCLCHECK(ncclIbOpsFaultClear(devBase->pd->context));
+    if (devBase && devBase->pd && devBase->pd->context) NCCLCHECK(ncclIbOpsFaultClear(devBase->pd->context));
   }
   return ncclSuccess;
 }

--- a/projects/rccl/src/transport/net_ib_cast/p2p_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_cast.h
@@ -11,11 +11,14 @@
 #include "common_cast.h"
 
 #define NCCL_IB_FLUSH_REQ_WR_ID_OFFSET 0x1000
-static_assert(NCCL_IB_FLUSH_REQ_WR_ID_OFFSET > NET_IB_MAX_REQUESTS, "wr_id offset for flush requests must be greater than NET_IB_MAX_REQUESTS");
-static_assert(NCCL_IB_FLUSH_REQ_WR_ID_OFFSET <= UINT64_MAX - NET_IB_MAX_REQUESTS, "wr_id for flush requests must fit in 64 bits since ibv_send_wr::wr_id is 64 bits");
+static_assert(NCCL_IB_FLUSH_REQ_WR_ID_OFFSET > NET_IB_MAX_REQUESTS,
+              "wr_id offset for flush requests must be greater than NET_IB_MAX_REQUESTS");
+static_assert(NCCL_IB_FLUSH_REQ_WR_ID_OFFSET <= UINT64_MAX - NET_IB_MAX_REQUESTS,
+              "wr_id for flush requests must fit in 64 bits since ibv_send_wr::wr_id is 64 bits");
 
 ncclResult_t IbCastPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* req, int slot, int n);
-ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, int startQpIndex, bool wrrSched, bool useWriteOp);
+ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, int startQpIndex, bool wrrSched,
+                             bool useWriteOp);
 
 static inline ncclResult_t IbCastRecvCommGetQpForCts(struct ncclIbRecvComm* recvComm, uint32_t id, ncclIbQp** qp) {
   // AINIC requires CTS and data to be posted on the same QP.
@@ -33,12 +36,12 @@ static inline ncclResult_t IbCastRecvCommGetQpForCts(struct ncclIbRecvComm* recv
 
 static inline ncclResult_t IbCastRequestRetrieveAsIndex(ncclIbRequest* reqs, uint32_t reqIndex, ncclIbRequest** req) {
   if (reqIndex >= NET_IB_MAX_REQUESTS) {
-    WARN("NET/IB: %s: Invalid request index %u. Not in the range [%u, %u). Cannot retrieve request.", __func__, reqIndex, 0u, NET_IB_MAX_REQUESTS);
+    WARN("NET/IB: %s: Invalid request index %u. Not in the range [%u, %u). Cannot retrieve request.", __func__,
+         reqIndex, 0u, NET_IB_MAX_REQUESTS);
     return ncclInternalError;
   }
   *req = &reqs[reqIndex];
   return ncclSuccess;
 }
-
 
 #endif // NET_IB_P2P_H_

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency.cc
@@ -21,7 +21,8 @@ extern int64_t ncclParamIbCastTimeout();
 #define MSEC_TO_NSEC 1000000ULL
 
 // Checks if the error indicated in the given work completion is fatal or not.
-static ncclResult_t IbCastResiliencyCheckErrorNotFatal(struct ncclIbResiliency* resCtx, struct ibv_wc *wc, int devIndex) {
+static ncclResult_t IbCastResiliencyCheckErrorNotFatal(struct ncclIbResiliency* resCtx, struct ibv_wc* wc,
+                                                       int devIndex) {
   int nFailedDevices = 0;
   bool fatalCompletionStatus = true;
   const char* failureReason = NULL;
@@ -33,17 +34,19 @@ static ncclResult_t IbCastResiliencyCheckErrorNotFatal(struct ncclIbResiliency* 
   }
 
   switch (wc->status) {
-    case IBV_WC_WR_FLUSH_ERR:
-    case IBV_WC_RETRY_EXC_ERR:
-      fatalCompletionStatus = false;
-      break;
-    default:
-      WARN("NET/IB: %s: Unsupported completion status %s (%d)", __func__, ibvWcStatusStr(wc->status), wc->status);
-      break;
+  case IBV_WC_WR_FLUSH_ERR:
+  case IBV_WC_RETRY_EXC_ERR:
+    fatalCompletionStatus = false;
+    break;
+  default:
+    WARN("NET/IB: %s: Unsupported completion status %s (%d)", __func__, ibvWcStatusStr(wc->status), wc->status);
+    break;
   }
 
   if (nFailedDevices > 1) {
-    WARN("NET/IB: %s: Fatal error. Detected %d failed devices out of %d devices on the %s communicator (comm=%p). No support for more than a single failed device.", __func__, nFailedDevices, resCtx->ndevs, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
+    WARN("NET/IB: %s: Fatal error. Detected %d failed devices out of %d devices on the %s communicator (comm=%p). No "
+         "support for more than a single failed device.",
+         __func__, nFailedDevices, resCtx->ndevs, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
     return ncclRemoteError;
   }
 
@@ -92,26 +95,34 @@ static ncclResult_t IbCastResiliencyReplaceQps(struct ncclIbResiliency* resCtx, 
       newDevState = resCtx->devs[newDevIndex].state.load(std::memory_order_acquire);
       if (newDevState != ncclIbResiliencyDevStateOk) {
         offset++;
-        WARN("NET/IB: %s: Cannot replace QP with qpIndex=%d because the new QP (qpIndex=%d, devIndex=%d) is not on a functional device (state=%d)", __func__, failedQpIndex, newQpIndex, newDevIndex, newDevState);
+        WARN("NET/IB: %s: Cannot replace QP with qpIndex=%d because the new QP (qpIndex=%d, devIndex=%d) is not on a "
+             "functional device (state=%d)",
+             __func__, failedQpIndex, newQpIndex, newDevIndex, newDevState);
         continue;
       }
 
-      INFO(NCCL_NET, "NET/IB: %s: Replacing QP: qpIndex=%d (qp_num=%u, devIndex=%d) to qpIndex=%d (qp_num=%u, devIndex=%d) on %s communicator (comm=%p)", __func__, failedQpIndex, resCtx->baseComm->qps[failedQpIndex].qp->qp_num, resCtx->baseComm->qps[failedQpIndex].devIndex, newQpIndex, resCtx->baseComm->qps[newQpIndex].qp->qp_num, resCtx->baseComm->qps[newQpIndex].devIndex, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
+      INFO(NCCL_NET,
+           "NET/IB: %s: Replacing QP: qpIndex=%d (qp_num=%u, devIndex=%d) to qpIndex=%d (qp_num=%u, devIndex=%d) on %s "
+           "communicator (comm=%p)",
+           __func__, failedQpIndex, resCtx->baseComm->qps[failedQpIndex].qp->qp_num,
+           resCtx->baseComm->qps[failedQpIndex].devIndex, newQpIndex, resCtx->baseComm->qps[newQpIndex].qp->qp_num,
+           resCtx->baseComm->qps[newQpIndex].devIndex, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
       activeQps[qpIndex] = &resCtx->baseComm->qps[newQpIndex];
       replaced = true;
 
     } while (replaced == false && newQpIndex != failedQpIndex);
 
     if (!replaced) {
-      WARN("NET/IB: %s: Could not find a replacement QP for the failed QP with qpIndex=%d (devIndex=%d)", __func__, failedQpIndex, failedQp->devIndex);
+      WARN("NET/IB: %s: Could not find a replacement QP for the failed QP with qpIndex=%d (devIndex=%d)", __func__,
+           failedQpIndex, failedQp->devIndex);
       return ncclInternalError;
     }
-
   }
   return ncclSuccess;
 }
 
-static ncclResult_t IbCastResiliencySendRequestInit(struct ncclIbResiliencySend* sendResCtx, ncclIbRequest* request, int devIndex) {
+static ncclResult_t IbCastResiliencySendRequestInit(struct ncclIbResiliencySend* sendResCtx, ncclIbRequest* request,
+                                                    int devIndex) {
   int slot = request->id % NET_IB_MAX_REQUESTS;
   struct ncclIbResiliencyRequestSend* failedSendRequest = &sendResCtx->failedRequests[slot];
 
@@ -121,22 +132,33 @@ static ncclResult_t IbCastResiliencySendRequestInit(struct ncclIbResiliencySend*
       // It might be that a different send request that is part of this
       // multi-send request already got an error and is being replayed.
       // No need to initate a new tracking.
-      INFO(NCCL_NET, "NET/IB: %s: No need to add this failed request (req=%p, comm=%p, id=%ld) while another request (req=%p, comm=%p, id=%ld) is already being tracked in the same slot (slot=%d).", __func__, request, request->base, request->id, failedSendRequest->request, failedSendRequest->request->base, failedSendRequest->request->id, slot);
+      INFO(NCCL_NET,
+           "NET/IB: %s: No need to add this failed request (req=%p, comm=%p, id=%ld) while another request (req=%p, "
+           "comm=%p, id=%ld) is already being tracked in the same slot (slot=%d).",
+           __func__, request, request->base, request->id, failedSendRequest->request, failedSendRequest->request->base,
+           failedSendRequest->request->id, slot);
       return ncclSuccess;
     } else {
       // The request was already replayed and released. The CQE should be ignored.
-      INFO(NCCL_NET, "NET/IB: %s: Attempting to initiate a replay protocol but the failed request was already handled (req=%p, comm=%p, id=%ld, slot=%d, req.type=%s).", __func__, request, request->base, request->id, slot, IbCastReqTypeStr[request->type]);
+      INFO(NCCL_NET,
+           "NET/IB: %s: Attempting to initiate a replay protocol but the failed request was already handled (req=%p, "
+           "comm=%p, id=%ld, slot=%d, req.type=%s).",
+           __func__, request, request->base, request->id, slot, IbCastReqTypeStr[request->type]);
       return ncclSuccess;
     }
   }
 
   if (request->id + 1 <= failedSendRequest->id) {
-    WARN("NET/IB: %s: Attempting to initiate a replay using an old request (req=%p, comm=%p, id=%ld, slot=%d, failedSendRequest.id=%ld).", __func__, request, request->base, request->id, slot, failedSendRequest->id);
+    WARN("NET/IB: %s: Attempting to initiate a replay using an old request (req=%p, comm=%p, id=%ld, slot=%d, "
+         "failedSendRequest.id=%ld).",
+         __func__, request, request->base, request->id, slot, failedSendRequest->id);
     return ncclInternalError;
   }
 
   if (request->type != NCCL_NET_IB_REQ_SEND) {
-    WARN("NET/IB: %s: Attempting to initiate a failed request using a '%s' request while expecting a 'send' request (req=%p, comm=%p, id=%ld, slot=%d, failedSendRequest.id=%ld).", __func__, IbCastReqTypeStr[request->type], request, request->base, request->id, slot, failedSendRequest->id);
+    WARN("NET/IB: %s: Attempting to initiate a failed request using a '%s' request while expecting a 'send' request "
+         "(req=%p, comm=%p, id=%ld, slot=%d, failedSendRequest.id=%ld).",
+         __func__, IbCastReqTypeStr[request->type], request, request->base, request->id, slot, failedSendRequest->id);
     return ncclInternalError;
   }
 
@@ -145,21 +167,28 @@ static ncclResult_t IbCastResiliencySendRequestInit(struct ncclIbResiliencySend*
   failedSendRequest->errorInfo.devIndex = devIndex;
   failedSendRequest->errorInfo.time = clockNano();
   failedSendRequest->failedAttempts = 0;
-  failedSendRequest->id = request->id+1;
+  failedSendRequest->id = request->id + 1;
   sendResCtx->base.outstandingRequests++;
   sendResCtx->base.inProgress = true;
-  INFO(NCCL_NET, "NET/IB: %s: Tracking a new failed send request (req=%p, comm=%p, id=%ld, slot=%d, devIndex=%d, time=%ld, total tracked requests: %d).", __func__, request, request->base, request->id, slot, devIndex, failedSendRequest->errorInfo.time, sendResCtx->base.outstandingRequests);
+  INFO(NCCL_NET,
+       "NET/IB: %s: Tracking a new failed send request (req=%p, comm=%p, id=%ld, slot=%d, devIndex=%d, time=%ld, total "
+       "tracked requests: %d).",
+       __func__, request, request->base, request->id, slot, devIndex, failedSendRequest->errorInfo.time,
+       sendResCtx->base.outstandingRequests);
   return ncclSuccess;
 }
 
-static ncclResult_t IbCastResiliencySendRequestFree(struct ncclIbResiliencySend* sendResCtx, struct ncclIbResiliencyRequestSend* failedSendRequest) {
+static ncclResult_t IbCastResiliencySendRequestFree(struct ncclIbResiliencySend* sendResCtx,
+                                                    struct ncclIbResiliencyRequestSend* failedSendRequest) {
   assert(failedSendRequest != NULL);
   if (failedSendRequest->request == NULL) {
     int slot = failedSendRequest - sendResCtx->failedRequests;
     WARN("NET/IB: %s: Attempting to free a non-existent failed request (slot=%d).", __func__, slot);
     return ncclInternalError;
   }
-  INFO(NCCL_NET, "NET/IB: %s: Done handling failed send request (req=%p, comm=%p, id=%ld, slot=%ld).", __func__, failedSendRequest->request, failedSendRequest->request->base, failedSendRequest->request->id, failedSendRequest->request->id % NET_IB_MAX_REQUESTS);
+  INFO(NCCL_NET, "NET/IB: %s: Done handling failed send request (req=%p, comm=%p, id=%ld, slot=%ld).", __func__,
+       failedSendRequest->request, failedSendRequest->request->base, failedSendRequest->request->id,
+       failedSendRequest->request->id % NET_IB_MAX_REQUESTS);
 
   // Note that ID is not reset to allow ignoring old CQEs that might still be
   // in the CQ even after the failed send request was handled completely and
@@ -181,47 +210,56 @@ static ncclResult_t IbCastResiliencyRepostRequest(struct ncclIbRequest* request)
   }
   int slot = request->id % NET_IB_MAX_REQUESTS;
   if (request->type == NCCL_NET_IB_REQ_SEND) {
-      struct ncclIbResiliencySend* sendResCtx = (struct ncclIbResiliencySend*)request->base->resiliency;
-      struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)request->base;
-      struct ncclIbRequest** sendReqs = sendComm->sendReqs[slot];
-      for (int r = 0; r < request->nreqs; r++) {
+    struct ncclIbResiliencySend* sendResCtx = (struct ncclIbResiliencySend*)request->base->resiliency;
+    struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)request->base;
+    struct ncclIbRequest** sendReqs = sendComm->sendReqs[slot];
+    for (int r = 0; r < request->nreqs; r++) {
         // Clear all event counters and later on increment only the required
         // ones based on the probing results on which QP a retransmission is
         // required.
-        memset(sendReqs[r]->events, 0, sizeof(sendReqs[r]->events));
+      memset(sendReqs[r]->events, 0, sizeof(sendReqs[r]->events));
 
         // Populate events
-        int nqps = IbCastCommBaseGetNqpsPerRequest(sendReqs[r]->base);
-        int qpIndex = -1;
-        ncclIbQp* qp = NULL;
-        for (int i = 0; i < nqps; i++) {
+      int nqps = IbCastCommBaseGetNqpsPerRequest(sendReqs[r]->base);
+      int qpIndex = -1;
+      ncclIbQp* qp = NULL;
+      for (int i = 0; i < nqps; i++) {
           // TODO: This code does not handle the case where a send request fails twice!
           // If that device that is used for retransmission fails during retransmission,
           // the logic here will retrieve the QP that was used for the first send attempt
           // and not the QP that was used for the second send attempt! Causing
           // probably data corruption or a hang.
-          NCCLCHECK(IbCastCommBaseGetQpForRequest(sendReqs[r]->base, sendReqs[r]->id, i, &qp, &qpIndex));
+        NCCLCHECK(IbCastCommBaseGetQpForRequest(sendReqs[r]->base, sendReqs[r]->id, i, &qp, &qpIndex));
 
           // Selective Retransmission:
           // If the probing result shows that the data was delivered successfully on this QP,
           // we don't need to retransmit it.
-          if (sendResCtx->probingResults[slot][qpIndex] == true) {
-            INFO(NCCL_NET, "NET/IB: %s: Skipping retransmission on QP index %d (req=%p, comm=%p, id=%ld, slot=%d) as it was already delivered.", __func__, qpIndex, sendReqs[r], sendReqs[r]->base, sendReqs[r]->id, slot);
-            continue;
-          }
-
-          INFO(NCCL_NET, "NET/IB: %s: Retransmitting reqIndex=%d on qp_num=%u (req=%p, comm=%p, id=%ld, slot=%d) as it was not delivered.", __func__, r, qp->qp->qp_num, sendReqs[r], sendReqs[r]->base, sendReqs[r]->id, slot);
-          // Reset the sentData for this QP since we are going to retransmit it.
-          sendReqs[r]->send.sentData[qpIndex] = false;
-          IbCastAddEvent(sendReqs[r], qp->devIndex);
+        if (sendResCtx->probingResults[slot][qpIndex] == true) {
+          INFO(NCCL_NET,
+               "NET/IB: %s: Skipping retransmission on QP index %d (req=%p, comm=%p, id=%ld, slot=%d) as it was "
+               "already delivered.",
+               __func__, qpIndex, sendReqs[r], sendReqs[r]->base, sendReqs[r]->id, slot);
+          continue;
         }
+
+        INFO(NCCL_NET,
+             "NET/IB: %s: Retransmitting reqIndex=%d on qp_num=%u (req=%p, comm=%p, id=%ld, slot=%d) as it was not "
+             "delivered.",
+             __func__, r, qp->qp->qp_num, sendReqs[r], sendReqs[r]->base, sendReqs[r]->id, slot);
+          // Reset the sentData for this QP since we are going to retransmit it.
+        sendReqs[r]->send.sentData[qpIndex] = false;
+        IbCastAddEvent(sendReqs[r], qp->devIndex);
       }
-      INFO(NCCL_NET, "NET/IB: %s: Reposting send request (request=%p, comm=%p, id=%ld, slot=%ld, nreqs=%d)", __func__, request, request->base, request->id, request->id % NET_IB_MAX_REQUESTS, request->nreqs);
-      request->base->resiliency->repostCount++;
-      struct ncclIbRequest* firstReq = ((struct ncclIbSendComm*)request->base)->sendReqs[slot][0];
-      NCCLCHECK(IbCastMultiSend((struct ncclIbSendComm*)request->base, slot, firstReq->desc.nqps, firstReq->desc.startQpIndex, firstReq->desc.wrrSched, false));
+    }
+    INFO(NCCL_NET, "NET/IB: %s: Reposting send request (request=%p, comm=%p, id=%ld, slot=%ld, nreqs=%d)", __func__,
+         request, request->base, request->id, request->id % NET_IB_MAX_REQUESTS, request->nreqs);
+    request->base->resiliency->repostCount++;
+    struct ncclIbRequest* firstReq = ((struct ncclIbSendComm*)request->base)->sendReqs[slot][0];
+    NCCLCHECK(IbCastMultiSend((struct ncclIbSendComm*)request->base, slot, firstReq->desc.nqps,
+                              firstReq->desc.startQpIndex, firstReq->desc.wrrSched, false));
   } else if (request->type == NCCL_NET_IB_REQ_RECV) {
-    INFO(NCCL_NET, "NET/IB: %s: Reposting CTS (request=%p, comm=%p, id=%ld, slot=%ld)", __func__, request, request->base, request->id, request->id % NET_IB_MAX_REQUESTS);
+    INFO(NCCL_NET, "NET/IB: %s: Reposting CTS (request=%p, comm=%p, id=%ld, slot=%ld)", __func__, request,
+         request->base, request->id, request->id % NET_IB_MAX_REQUESTS);
     NCCLCHECK(IbCastPostFifo((struct ncclIbRecvComm*)request->base, request, slot, request->nreqs));
   } else {
     WARN("NET/IB: %s: Unsupported type of request reposting (type=%d, id=%ld).", __func__, request->type, request->id);
@@ -230,12 +268,15 @@ static ncclResult_t IbCastResiliencyRepostRequest(struct ncclIbRequest* request)
   return ncclSuccess;
 }
 
-static ncclResult_t IbCastResiliencyHandleCompletionErrorReceiver(struct ncclIbResiliency* resCtx, struct ibv_wc* wc, int devIndex) {
-  INFO(NCCL_NET,"NET/IB: %s: Handling an error on the receiver side (comm %p)", __func__, resCtx->baseComm);
+static ncclResult_t IbCastResiliencyHandleCompletionErrorReceiver(struct ncclIbResiliency* resCtx, struct ibv_wc* wc,
+                                                                  int devIndex) {
+  INFO(NCCL_NET, "NET/IB: %s: Handling an error on the receiver side (comm %p)", __func__, resCtx->baseComm);
   bool inRecvRange = (wc->wr_id >= 0 && wc->wr_id <= NET_IB_MAX_REQUESTS);
-  bool inFlushRange = (wc->wr_id >= NCCL_IB_FLUSH_REQ_WR_ID_OFFSET && wc->wr_id < (NCCL_IB_FLUSH_REQ_WR_ID_OFFSET + NET_IB_MAX_REQUESTS));
+  bool inFlushRange =
+    (wc->wr_id >= NCCL_IB_FLUSH_REQ_WR_ID_OFFSET && wc->wr_id < (NCCL_IB_FLUSH_REQ_WR_ID_OFFSET + NET_IB_MAX_REQUESTS));
   if (!inRecvRange && !inFlushRange && (wc->wr_id != NCCL_IB_RECV_WR_ID_DUMMY)) {
-    WARN("NET/IB: %s: Invalid wr_id (%ld). Unable to retrieve a request on the receiver side (comm=%p)", __func__, wc->wr_id, resCtx->baseComm);
+    WARN("NET/IB: %s: Invalid wr_id (%ld). Unable to retrieve a request on the receiver side (comm=%p)", __func__,
+         wc->wr_id, resCtx->baseComm);
     return ncclInternalError;
   }
   if (wc->wr_id == NCCL_IB_RECV_WR_ID_DUMMY) {
@@ -245,7 +286,8 @@ static ncclResult_t IbCastResiliencyHandleCompletionErrorReceiver(struct ncclIbR
     // now flushed.
     assert(wc->status == IBV_WC_WR_FLUSH_ERR);
     // In this case, there is nothing left to do.
-    INFO(NCCL_NET, "NET/IB: %s: Ignoring flush error on a QP (comm=%p, wc.wr_id=%ld, wc.status=%s(%d)).", __func__, resCtx->baseComm, wc->wr_id, ibvWcStatusStr(wc->status), wc->status);
+    INFO(NCCL_NET, "NET/IB: %s: Ignoring flush error on a QP (comm=%p, wc.wr_id=%ld, wc.status=%s(%d)).", __func__,
+         resCtx->baseComm, wc->wr_id, ibvWcStatusStr(wc->status), wc->status);
     return ncclSuccess;
   }
 
@@ -258,27 +300,29 @@ static ncclResult_t IbCastResiliencyHandleCompletionErrorReceiver(struct ncclIbR
     request = recvComm->recvReqs[wc->wr_id];
   }
 
-  INFO(NCCL_NET, "NET/IB: %s: The receiver side request that got an error is %p (req=%p, comm=%p, id=%ld)", __func__, request, request, request->base, request->id);
+  INFO(NCCL_NET, "NET/IB: %s: The receiver side request that got an error is %p (req=%p, comm=%p, id=%ld)", __func__,
+       request, request, request->base, request->id);
 
   switch (request->type) {
-    case NCCL_NET_IB_REQ_FLUSH:
+  case NCCL_NET_IB_REQ_FLUSH:
       // When a flush request encounters an error, it's ignored and the event
       // counter on that device is set to zero, so the flush request could be
       // completed on other devices if needed.
-      request->events[devIndex] = 0;
-      INFO(NCCL_NET, "NET/IB: %s: Ignoring error on flush request (req=%p, comm=%p, id=%ld) on device index %d", __func__, request, request->base, request->id, devIndex);
-      break;
-    case NCCL_NET_IB_REQ_RECV:
+    request->events[devIndex] = 0;
+    INFO(NCCL_NET, "NET/IB: %s: Ignoring error on flush request (req=%p, comm=%p, id=%ld) on device index %d", __func__,
+         request, request->base, request->id, devIndex);
+    break;
+  case NCCL_NET_IB_REQ_RECV:
       // Assert it's a CTS message that got an error.
       // When error occurs the CQE's opcode is not valid and cannot be read!
       // The only valid fields are: wr_id, status, qp_num, and vendor_err.
       // From: https://www.rdmamojo.com/2013/02/15/ibv_poll_cq/
       // Assert the CQE belongs to a CTS and not a data transfer.
-      assert(wc->wr_id != NCCL_IB_RECV_WR_ID_DUMMY);
+    assert(wc->wr_id != NCCL_IB_RECV_WR_ID_DUMMY);
       // CTS is reposted immediately
-      NCCLCHECK(IbCastResiliencyRepostRequest(request));
-      break;
-    case (NCCL_NET_IB_REQ_UNUSED):
+    NCCLCHECK(IbCastResiliencyRepostRequest(request));
+    break;
+  case (NCCL_NET_IB_REQ_UNUSED):
       // This might happen for a CTS message. Consider a case where a HW ack
       // failed for a CTS message but before the receiver got a CQE with error
       // because of a HW timeout, the sender already completed the data transfer
@@ -286,16 +330,19 @@ static ncclResult_t IbCastResiliencyHandleCompletionErrorReceiver(struct ncclIbR
       // verify if the CTS was completed for every receive request before
       // completing a receive request.
       // When error occurs the CQE's opcode is not valid and cannot be read!
-      WARN("NET/IB: %s: Unrecognized request. It might be a CTS message for which the request was already completed. Continue.", __func__);
-      break;
-    default:
-      WARN("NET/IB: %s: Unrecognized request type. request->type=%d", __func__, request->type);
-      return ncclInternalError;
+    WARN("NET/IB: %s: Unrecognized request. It might be a CTS message for which the request was already completed. "
+         "Continue.",
+         __func__);
+    break;
+  default:
+    WARN("NET/IB: %s: Unrecognized request type. request->type=%d", __func__, request->type);
+    return ncclInternalError;
   }
   return ncclSuccess;
 }
 
-static ncclResult_t IbCastResiliencyHandleCompletionErrorSender(struct ncclIbResiliency* resCtx, struct ibv_wc* wc, int devIndex) {
+static ncclResult_t IbCastResiliencyHandleCompletionErrorSender(struct ncclIbResiliency* resCtx, struct ibv_wc* wc,
+                                                                int devIndex) {
   ncclResult_t res;
   ncclIbRequest* request = NULL;
 
@@ -304,14 +351,20 @@ static ncclResult_t IbCastResiliencyHandleCompletionErrorSender(struct ncclIbRes
   request = sendComm->sendReqs[slot][0];
 
   if (request == NULL) {
-    WARN("NET/IB: %s: Encountered a stale CQE with error for slot=%ld. Slot was already handled (comm=%p, wc.wr_id=%ld, wc.status=%s(%d), wc.opcode=%s(%d)).", __func__, slot, resCtx->baseComm, wc->wr_id, ibvWcStatusStr(wc->status), wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode);
+    WARN("NET/IB: %s: Encountered a stale CQE with error for slot=%ld. Slot was already handled (comm=%p, "
+         "wc.wr_id=%ld, wc.status=%s(%d), wc.opcode=%s(%d)).",
+         __func__, slot, resCtx->baseComm, wc->wr_id, ibvWcStatusStr(wc->status), wc->status,
+         ibvWcOpcodeStr(wc->opcode), wc->opcode);
     return ncclSuccess;
   }
 
   struct ncclIbResiliencySend* sendResCtx = (struct ncclIbResiliencySend*)resCtx;
   res = IbCastResiliencySendRequestInit(sendResCtx, request, devIndex);
   if (res != ncclSuccess) {
-    WARN("NET/IB: %s: Failed to initialize a resiliency send request (req=%p, comm=%p, id=%ld, type=%s, wc.wr_id=%ld, wc.status=%s(%d), wc.opcode=%s(%d), slot=%ld).", __func__, request, request->base, request->id, IbCastReqTypeStr[request->type], wc->wr_id, ibvWcStatusStr(wc->status), wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, slot);
+    WARN("NET/IB: %s: Failed to initialize a resiliency send request (req=%p, comm=%p, id=%ld, type=%s, wc.wr_id=%ld, "
+         "wc.status=%s(%d), wc.opcode=%s(%d), slot=%ld).",
+         __func__, request, request->base, request->id, IbCastReqTypeStr[request->type], wc->wr_id,
+         ibvWcStatusStr(wc->status), wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, slot);
     return res;
   }
 
@@ -324,7 +377,9 @@ static ncclResult_t IbCastResiliencyHandleDeviceFailure(struct ncclIbResiliency*
   ncclResult_t res = ncclSuccess;
   enum ncclIbResiliencyDevState devState = resCtx->devs[devIndex].state.load(std::memory_order_acquire);
   if (devState == ncclIbResiliencyDevStateOk) {
-    WARN("NET/IB: %s: Device %d marked as failed. Initiating recovery? %s (%s comm=%p, outstandingRecovery=%d)", __func__, devIndex, resCtx->recoveryEnabled ? "Yes" : "No", resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm, resCtx->outstandingRecovery);
+    WARN("NET/IB: %s: Device %d marked as failed. Initiating recovery? %s (%s comm=%p, outstandingRecovery=%d)",
+         __func__, devIndex, resCtx->recoveryEnabled ? "Yes" : "No", resCtx->baseComm->isSend ? "send" : "recv",
+         resCtx->baseComm, resCtx->outstandingRecovery);
     resCtx->devs[devIndex].state.store(ncclIbResiliencyDevStateError, std::memory_order_release);
     NCCLCHECK(IbCastResiliencyReplaceQps(resCtx, devIndex));
     if (resCtx->recoveryEnabled) {
@@ -336,7 +391,8 @@ static ncclResult_t IbCastResiliencyHandleDeviceFailure(struct ncclIbResiliency*
       } else {
         for (int i = 0; i < resCtx->ndevs; i++) {
           if (i != devIndex) continue;
-          INFO(NCCL_NET, "NET/IB: %s: Marking device %d as permanently failed (%s comm=%p)", __func__, i, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
+          INFO(NCCL_NET, "NET/IB: %s: Marking device %d as permanently failed (%s comm=%p)", __func__, i,
+               resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
           resCtx->devs[i].state.store(ncclIbResiliencyDevStateErrorPermanent, std::memory_order_release);
         }
       }
@@ -354,7 +410,8 @@ static ncclResult_t IbCastResiliencyHandleDeviceFailure(struct ncclIbResiliency*
 // After a probe is completed, handle the results of the probe. If the probe
 // shows that the request was completed successfully on all QPs, the request
 // is completed. Otherwise, the request is reposted.
-static ncclResult_t IbCastResiliencyHandleProbeCompleted(struct ncclIbResiliencySend* sendResCtx, struct ncclIbResiliencyRequestSend* failedRequest) {
+static ncclResult_t IbCastResiliencyHandleProbeCompleted(struct ncclIbResiliencySend* sendResCtx,
+                                                         struct ncclIbResiliencyRequestSend* failedRequest) {
   int slot = failedRequest->request->id % NET_IB_MAX_REQUESTS;
   bool missingData = false;
   for (int qpIndex = 0; qpIndex < NCCL_IB_MAX_QPS; qpIndex++) {
@@ -368,12 +425,17 @@ static ncclResult_t IbCastResiliencyHandleProbeCompleted(struct ncclIbResiliency
       continue;
     }
     missingData = true;
-    INFO(NCCL_NET, "NET/IB: %s: Missing data from QP index %d (req=%p, slot=%d devIndex=%d)", __func__, qpIndex, failedRequest->request, slot, failedRequest->request->base->qps[qpIndex].devIndex);
+    INFO(NCCL_NET, "NET/IB: %s: Missing data from QP index %d (req=%p, slot=%d devIndex=%d)", __func__, qpIndex,
+         failedRequest->request, slot, failedRequest->request->base->qps[qpIndex].devIndex);
     break;
   }
   if (!missingData) {
     // All data was delivered to the sender and no need for retransmission.
-    INFO(NCCL_NET, "NET/IB: %s: Probing conclusion: All data was delivered for request %p (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d). Completing the request.", __func__, failedRequest->request, failedRequest->request, failedRequest->request->base, failedRequest->request->id, slot, failedRequest->request->nreqs);
+    INFO(NCCL_NET,
+         "NET/IB: %s: Probing conclusion: All data was delivered for request %p (req=%p, comm=%p, id=%ld, slot=%d, "
+         "nreqs=%d). Completing the request.",
+         __func__, failedRequest->request, failedRequest->request, failedRequest->request->base,
+         failedRequest->request->id, slot, failedRequest->request->nreqs);
     // Clear all events on the request so it could be completed towards the
     // user as well. Note that in case of a multi-send requests, all requests
     // are also cleared.
@@ -381,7 +443,8 @@ static ncclResult_t IbCastResiliencyHandleProbeCompleted(struct ncclIbResiliency
     struct ncclIbRequest** sendReqs = sendComm->sendReqs[slot];
     for (int r = 0; r < failedRequest->request->nreqs; r++) {
       memset(sendReqs[r]->events, 0, sizeof(sendReqs[r]->events));
-      INFO(NCCL_NET, "NET/IB: %s: Clearing events on send request %p (req=%p, comm=%p, id=%ld, slot=%d, reqIdx=%d)", __func__, sendReqs[r], sendReqs[r], sendReqs[r]->base, sendReqs[r]->id, slot, r);
+      INFO(NCCL_NET, "NET/IB: %s: Clearing events on send request %p (req=%p, comm=%p, id=%ld, slot=%d, reqIdx=%d)",
+           __func__, sendReqs[r], sendReqs[r], sendReqs[r]->base, sendReqs[r]->id, slot, r);
     }
     return ncclSuccess;
   } else {
@@ -393,11 +456,15 @@ static ncclResult_t IbCastResiliencyHandleProbeCompleted(struct ncclIbResiliency
 
 // Posts a probe (RDMA Read) operation to check the status of a send request
 // that encountered an error.
-static ncclResult_t IbCastResiliencyProbePost(struct ncclIbResiliencySend* sendResCtx, struct ncclIbResiliencyRequestSend* failedSendRequest) {
+static ncclResult_t IbCastResiliencyProbePost(struct ncclIbResiliencySend* sendResCtx,
+                                              struct ncclIbResiliencyRequestSend* failedSendRequest) {
   assert(failedSendRequest->state == ncclIbResiliencyRequestStatePending);
 
   if (failedSendRequest->failedAttempts > ncclParamIbCastResiliencyPortFailoverMaxAttempts()) {
-    WARN("NET/IB: %s: Maximum number of probing attempts (%ld) reached for request %p (id=%ld). Cannot post another probe.", __func__, ncclParamIbCastResiliencyPortFailoverMaxAttempts(), failedSendRequest->request, failedSendRequest->request->id);
+    WARN("NET/IB: %s: Maximum number of probing attempts (%ld) reached for request %p (id=%ld). Cannot post another "
+         "probe.",
+         __func__, ncclParamIbCastResiliencyPortFailoverMaxAttempts(), failedSendRequest->request,
+         failedSendRequest->request->id);
     return ncclRemoteError;
   }
 
@@ -410,7 +477,8 @@ static ncclResult_t IbCastResiliencyProbePost(struct ncclIbResiliencySend* sendR
     return ncclSuccess;
   }
 
-  INFO(NCCL_NET, "NET/IB: %s: Probe delay elapsed (%llu ms) for request %p, posting the probe", __func__, elapsedTime / MSEC_TO_NSEC, failedSendRequest->request);
+  INFO(NCCL_NET, "NET/IB: %s: Probe delay elapsed (%llu ms) for request %p, posting the probe", __func__,
+       elapsedTime / MSEC_TO_NSEC, failedSendRequest->request);
 
   // Iterate over devices until a functional device is found to send a probe
   int devIndex = 0;
@@ -423,7 +491,8 @@ static ncclResult_t IbCastResiliencyProbePost(struct ncclIbResiliencySend* sendR
   }
 
   if (devIndex == sendResCtx->base.ndevs) {
-    WARN("NET/IB: %s: Could not find a functional device to post the probe for request %p (id=%ld)", __func__, failedSendRequest->request, failedSendRequest->request->id);
+    WARN("NET/IB: %s: Could not find a functional device to post the probe for request %p (id=%ld)", __func__,
+         failedSendRequest->request, failedSendRequest->request->id);
     return ncclInternalError;
   }
 
@@ -457,7 +526,8 @@ static ncclResult_t IbCastResiliencyProbePost(struct ncclIbResiliencySend* sendR
   probeWr.wr.rdma.remote_addr = remoteAddr;
   probeWr.wr.rdma.rkey = sendResCtx->remCmplRecordsInfo[probingQp->remDevIdx].rkey;
 
-  INFO(NCCL_NET, "NET/IB: %s: Posting probe (slot=%d, id=%ld, devIndex=%d, qp_num=%u)", __func__, slot, failedSendRequest->request->id, devIndex, probingQp->qp->qp_num);
+  INFO(NCCL_NET, "NET/IB: %s: Posting probe (slot=%d, id=%ld, devIndex=%d, qp_num=%u)", __func__, slot,
+       failedSendRequest->request->id, devIndex, probingQp->qp->qp_num);
 
   struct ibv_send_wr* bad_wr;
   NCCLCHECK(wrap_ibv_post_send(probingQp->qp, &probeWr, &bad_wr));
@@ -467,9 +537,11 @@ static ncclResult_t IbCastResiliencyProbePost(struct ncclIbResiliencySend* sendR
   return ncclSuccess;
 }
 
-static ncclResult_t IbCastResiliencyProbeHandleCompletionEvent(struct ncclIbResiliencySend* sendResCtx, struct ibv_wc* probeWc, int devIndex) {
-
-  INFO(NCCL_NET, "NET/IB: %s: Got probing completion (devIndex=%d, wc->status=%d, wc->opcode=%d, wc->wr_id=%ld, wc->qp_num=%u)", __func__, devIndex, probeWc->status, probeWc->opcode, probeWc->wr_id, probeWc->qp_num);
+static ncclResult_t IbCastResiliencyProbeHandleCompletionEvent(struct ncclIbResiliencySend* sendResCtx,
+                                                               struct ibv_wc* probeWc, int devIndex) {
+  INFO(NCCL_NET,
+       "NET/IB: %s: Got probing completion (devIndex=%d, wc->status=%d, wc->opcode=%d, wc->wr_id=%ld, wc->qp_num=%u)",
+       __func__, devIndex, probeWc->status, probeWc->opcode, probeWc->wr_id, probeWc->qp_num);
 
   struct ncclIbResiliencyRequestSend* failedRequest = &sendResCtx->failedRequests[probeWc->wr_id % NET_IB_MAX_REQUESTS];
 
@@ -495,7 +567,7 @@ static ncclResult_t IbCastResiliencyProbeHandleCompletionEvent(struct ncclIbResi
 static ncclResult_t IbCastResiliencyProbeProgress(struct ncclIbResiliencySend* sendResCtx) {
   struct ibv_wc wcs[MAX_PROBE_WC];
   int nCompletions = 0;
-  struct ncclIbResiliencyDev *resDev = NULL;
+  struct ncclIbResiliencyDev* resDev = NULL;
   for (int devIndex = 0; devIndex < sendResCtx->base.ndevs; devIndex++) {
     resDev = &sendResCtx->base.devs[devIndex];
     // Note that even if the device failed, we still want to drain all the CQEs
@@ -527,7 +599,8 @@ ncclResult_t IbCastResiliencyInit(struct ncclIbNetCommBase* baseComm, struct ncc
   assert(baseComm != NULL);
   assert(resCtx != NULL);
   if (ncclParamIbCastResiliencyPortFailover() == 0) {
-    INFO(NCCL_NET, "NET/IB: %s: Resiliency is disabled on the %s communicator (comm=%p)", __func__, baseComm->isSend ? "send" : "recv", baseComm);
+    INFO(NCCL_NET, "NET/IB: %s: Resiliency is disabled on the %s communicator (comm=%p)", __func__,
+         baseComm->isSend ? "send" : "recv", baseComm);
     *resCtx = NULL;
     return ncclSuccess;
   }
@@ -553,13 +626,16 @@ ncclResult_t IbCastResiliencyInit(struct ncclIbNetCommBase* baseComm, struct ncc
 
   NCCLCHECK(IbCastPortRecoveryInit(baseCtx));
   if (baseCtx->recoveryEnabled) {
-    INFO(NCCL_NET, "NET/IB: %s: Port recovery is enabled for the resiliency context on the %s communicator (comm=%p)", __func__, baseComm->isSend ? "send" : "recv", baseComm);
+    INFO(NCCL_NET, "NET/IB: %s: Port recovery is enabled for the resiliency context on the %s communicator (comm=%p)",
+         __func__, baseComm->isSend ? "send" : "recv", baseComm);
     baseCtx->outstandingRecovery = 0;
   } else {
-    INFO(NCCL_NET, "NET/IB: %s: Port recovery is disabled for the resiliency context on the %s communicator (comm=%p)", __func__, baseComm->isSend ? "send" : "recv", baseComm);
+    INFO(NCCL_NET, "NET/IB: %s: Port recovery is disabled for the resiliency context on the %s communicator (comm=%p)",
+         __func__, baseComm->isSend ? "send" : "recv", baseComm);
   }
 
-  INFO(NCCL_NET, "NET/IB: %s: Resiliency context was initialized on the %s communicator (comm=%p)", __func__, baseComm->isSend ? "send" : "recv", baseComm);
+  INFO(NCCL_NET, "NET/IB: %s: Resiliency context was initialized on the %s communicator (comm=%p)", __func__,
+       baseComm->isSend ? "send" : "recv", baseComm);
   return ncclSuccess;
 }
 
@@ -574,7 +650,8 @@ ncclResult_t IbCastResiliencyDestroy(struct ncclIbResiliency** resCtx) {
 
 ncclResult_t IbCastResiliencyDevInit(struct ncclIbResiliency* resCtx, uint devIndex, ncclIbDev* ibDev) {
   assert(resCtx != NULL);
-  INFO(NCCL_NET, "NET/IB: %s: Initializing resiliency context on devIndex %d for %s communicator (comm=%p)", __func__, devIndex, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
+  INFO(NCCL_NET, "NET/IB: %s: Initializing resiliency context on devIndex %d for %s communicator (comm=%p)", __func__,
+       devIndex, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
   assert(devIndex < resCtx->ndevs);
   struct ncclIbResiliencyDev* resDev = &resCtx->devs[devIndex];
   resDev->state.store(ncclIbResiliencyDevStateOk, std::memory_order_release);
@@ -585,16 +662,20 @@ ncclResult_t IbCastResiliencyDevInit(struct ncclIbResiliency* resCtx, uint devIn
     cqSize = NET_IB_MAX_REQUESTS;
     struct ncclIbResiliencySend* sendResCtx = (struct ncclIbResiliencySend*)resCtx;
     struct ncclIbNetCommDevBase* devBase = IbCastGetNetCommDevBase(resCtx->baseComm, devIndex);
-    NCCLCHECK(wrap_ibv_reg_mr(&resDev->probingResultMr, devBase->pd, &sendResCtx->probingResults, sizeof(sendResCtx->probingResults), IBV_ACCESS_LOCAL_WRITE));
-    INFO(NCCL_NET, "NET/IB: %s: Registered probing results memory (%p) on device %d for resiliency context (comm=%p)", __func__, &sendResCtx->probingResults, devIndex, resCtx->baseComm);
+    NCCLCHECK(wrap_ibv_reg_mr(&resDev->probingResultMr, devBase->pd, &sendResCtx->probingResults,
+                              sizeof(sendResCtx->probingResults), IBV_ACCESS_LOCAL_WRITE));
+    INFO(NCCL_NET, "NET/IB: %s: Registered probing results memory (%p) on device %d for resiliency context (comm=%p)",
+         __func__, &sendResCtx->probingResults, devIndex, resCtx->baseComm);
   } else {
     // It's not allowed to create a CQ with size 0 so set it to 1 although
     // no CQEs are expected to be generated on this CQ (on the receiver side).
     cqSize = 1;
   }
-  INFO(NCCL_NET, "NET/IB: %s: Creating probing CQ on device %d for resiliency context (%s comm=%p, cq_size=%d)", __func__, devIndex, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm, cqSize);
+  INFO(NCCL_NET, "NET/IB: %s: Creating probing CQ on device %d for resiliency context (%s comm=%p, cq_size=%d)",
+       __func__, devIndex, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm, cqSize);
   NCCLCHECK(wrap_ibv_create_cq(&resDev->probingCq, ibDev->context, cqSize, cqContext, NULL, 0));
-  INFO(NCCL_NET, "NET/IB: %s: Created probing CQ (cq=%p) on device %d for resiliency context (%s comm=%p, cq_size=%d)", __func__, resDev->probingCq, devIndex, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm, cqSize);
+  INFO(NCCL_NET, "NET/IB: %s: Created probing CQ (cq=%p) on device %d for resiliency context (%s comm=%p, cq_size=%d)",
+       __func__, resDev->probingCq, devIndex, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm, cqSize);
 
   if (resCtx->recoveryEnabled) {
     NCCLCHECK(IbCastPortRecoveryDevInit(resCtx, devIndex, ibDev));
@@ -607,7 +688,8 @@ ncclResult_t IbCastResiliencyDevDestroy(struct ncclIbResiliency* resCtx, uint de
   struct ncclIbResiliencyDev* resDev = &resCtx->devs[devIndex];
   if (resDev->probingCq) {
     NCCLCHECK(wrap_ibv_destroy_cq(resDev->probingCq));
-    INFO(NCCL_NET, "NET/IB: %s: Destroyed probing CQ (cq=%p) on device %d for resiliency context (comm=%p)", __func__, resDev->probingCq, devIndex, resCtx->baseComm);
+    INFO(NCCL_NET, "NET/IB: %s: Destroyed probing CQ (cq=%p) on device %d for resiliency context (comm=%p)", __func__,
+         resDev->probingCq, devIndex, resCtx->baseComm);
   }
 
   if (resCtx->recoveryEnabled) {
@@ -618,7 +700,9 @@ ncclResult_t IbCastResiliencyDevDestroy(struct ncclIbResiliency* resCtx, uint de
     struct ncclIbResiliencySend* sendResCtx = (struct ncclIbResiliencySend*)resCtx;
     if (resDev->probingResultMr) {
       NCCLCHECK(wrap_ibv_dereg_mr(resDev->probingResultMr));
-      INFO(NCCL_NET, "NET/IB: %s: Deregistered probing results memory (%p) on device %d for resiliency context (comm=%p)", __func__, &sendResCtx->probingResults, devIndex, resCtx->baseComm);
+      INFO(NCCL_NET,
+           "NET/IB: %s: Deregistered probing results memory (%p) on device %d for resiliency context (comm=%p)",
+           __func__, &sendResCtx->probingResults, devIndex, resCtx->baseComm);
     }
   }
   return ncclSuccess;
@@ -642,7 +726,8 @@ ncclResult_t IbCastResiliencyDataCqSizeGet(struct ncclIbResiliency* resCtx, uint
   // completions of all other requests.
   assert(resCtx->ndevs > 0);
   *cqSize = (*cqSize) * resCtx->ndevs;
-  INFO(NCCL_NET, "NET/IB: %s: CQ size should be %d on device %d for %s communicator (comm=%p)", __func__, *cqSize, devIndex, baseComm->isSend ? "send" : "recv", baseComm);
+  INFO(NCCL_NET, "NET/IB: %s: CQ size should be %d on device %d for %s communicator (comm=%p)", __func__, *cqSize,
+       devIndex, baseComm->isSend ? "send" : "recv", baseComm);
   return ncclSuccess;
 }
 
@@ -667,10 +752,14 @@ ncclResult_t IbCastResiliencyDeviceNumSet(struct ncclIbResiliency* resCtx, int n
   assert(nRemDevs > 0);
 
   if (nLocalDevs <= 1) {
-    INFO(NCCL_NET, "NET/IB: %s: Resiliency is being enabled on a communicator (comm=%p) with a single local device. In case of failure there will be no device to fail-over to.", __func__, resCtx->baseComm);
+    INFO(NCCL_NET,
+         "NET/IB: %s: Resiliency is being enabled on a communicator (comm=%p) with a single local device. In case of "
+         "failure there will be no device to fail-over to.",
+         __func__, resCtx->baseComm);
   }
 
-  INFO(NCCL_NET, "NET/IB: %s: Resiliency context (comm=%p) is configured with %d local devices and %d remote devices", __func__, resCtx->baseComm, nLocalDevs, nRemDevs);
+  INFO(NCCL_NET, "NET/IB: %s: Resiliency context (comm=%p) is configured with %d local devices and %d remote devices",
+       __func__, resCtx->baseComm, nLocalDevs, nRemDevs);
 
   resCtx->ndevs = nLocalDevs;
   if (resCtx->baseComm->isSend) {
@@ -693,20 +782,25 @@ ncclResult_t IbCastResiliencyDeviceNumSet(struct ncclIbResiliency* resCtx, int n
   // of devices supported.
   assert(resCtx->nProbingQps <= NCCL_IB_MAX_DEVS_PER_NIC);
   if (resCtx->nProbingQps <= 1) {
-    WARN("NET/IB: %s: Resiliency is enabled on a %s communicator (comm=%p) with a single device. This does not make sense since there is no other device to fail over to.", __func__, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
+    WARN("NET/IB: %s: Resiliency is enabled on a %s communicator (comm=%p) with a single device. This does not make "
+         "sense since there is no other device to fail over to.",
+         __func__, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
   }
-  INFO(NCCL_NET, "NET/IB: %s: Resiliency context (comm=%p) is configured with %d probing QPs", __func__, resCtx->baseComm, resCtx->nProbingQps);
+  INFO(NCCL_NET, "NET/IB: %s: Resiliency context (comm=%p) is configured with %d probing QPs", __func__,
+       resCtx->baseComm, resCtx->nProbingQps);
   if (resCtx->recoveryEnabled) {
     resCtx->nPortRecoveryQps = std::max(nLocalDevs, nRemDevs);
   } else {
     resCtx->nPortRecoveryQps = 0;
   }
   assert(resCtx->nPortRecoveryQps <= NCCL_IB_MAX_DEVS_PER_NIC);
-  INFO(NCCL_NET, "NET/IB: %s: Resiliency context (comm=%p) is configured with %d recovery QPs", __func__, resCtx->baseComm, resCtx->nPortRecoveryQps);
+  INFO(NCCL_NET, "NET/IB: %s: Resiliency context (comm=%p) is configured with %d recovery QPs", __func__,
+       resCtx->baseComm, resCtx->nPortRecoveryQps);
   return ncclSuccess;
 }
 
-ncclResult_t IbCastResiliencySenderCreateQps(struct ncclIbResiliency* resCtx, struct ncclIbResiliencyInfo* localResiliencyInfo) {
+ncclResult_t IbCastResiliencySenderCreateQps(struct ncclIbResiliency* resCtx,
+                                             struct ncclIbResiliencyInfo* localResiliencyInfo) {
   ncclIbSendComm* sendComm = (ncclIbSendComm*)resCtx->baseComm;
   void* qpContext = (void*)&sendComm->base.stats;
   struct ncclIbQpCreateAttr qpCreateAttrs;
@@ -742,7 +836,8 @@ ncclResult_t IbCastResiliencySenderCreateQps(struct ncclIbResiliency* resCtx, st
   }
 
   if (resCtx->recoveryEnabled) {
-    NCCLCHECK(IbCastPortRecoverySenderQpsCreate(resCtx, localResiliencyInfo->portRecoveryQpsInfo, resCtx->nPortRecoveryQps));
+    NCCLCHECK(IbCastPortRecoverySenderQpsCreate(resCtx, localResiliencyInfo->portRecoveryQpsInfo,
+                                                resCtx->nPortRecoveryQps));
   }
 
   return ncclSuccess;
@@ -781,7 +876,9 @@ ncclResult_t IbCastResiliencySenderQpsToRts(struct ncclIbResiliency* resCtx, str
     rtsAttr->timeout = ncclParamIbCastTimeout();
     rtsAttr->retryCnt = ncclParamIbCastRetryCnt();
     NCCLCHECK(IbCastQpRts(localQp));
-    INFO(NCCL_NET, "NET/IB: %s: Send to RTS done on probing QP (index=%d, qp_num=%u, dest_qp_num=%u, deviceIndex=%d, comm=%p)", __func__, localQpIndex, localQp->qp->qp_num, rtrAttr->remoteQpNum, localDevIndex, resCtx->baseComm);
+    INFO(NCCL_NET,
+         "NET/IB: %s: Send to RTS done on probing QP (index=%d, qp_num=%u, dest_qp_num=%u, deviceIndex=%d, comm=%p)",
+         __func__, localQpIndex, localQp->qp->qp_num, rtrAttr->remoteQpNum, localDevIndex, resCtx->baseComm);
   }
 
   if (resCtx->recoveryEnabled) {
@@ -790,7 +887,9 @@ ncclResult_t IbCastResiliencySenderQpsToRts(struct ncclIbResiliency* resCtx, str
   return ncclSuccess;
 }
 
-ncclResult_t IbCastResiliencyReceiverQpsCreateToRts(struct ncclIbResiliency* resCtx, struct ncclIbConnectionMetadata* remInfo, struct ncclIbResiliencyInfo* localResiliencyInfo) {
+ncclResult_t IbCastResiliencyReceiverQpsCreateToRts(struct ncclIbResiliency* resCtx,
+                                                    struct ncclIbConnectionMetadata* remInfo,
+                                                    struct ncclIbResiliencyInfo* localResiliencyInfo) {
   ncclIbRecvComm* recvComm = (ncclIbRecvComm*)resCtx->baseComm;
   void* qpContext = (void*)&recvComm->base.stats;
   struct ncclIbQpCreateAttr qpCreateAttrs;
@@ -844,11 +943,14 @@ ncclResult_t IbCastResiliencyReceiverQpsCreateToRts(struct ncclIbResiliency* res
     rtsAttr->timeout = ncclParamIbCastTimeout();
     rtsAttr->retryCnt = ncclParamIbCastRetryCnt();
     NCCLCHECK(IbCastQpRts(localQp));
-    INFO(NCCL_NET, "NET/IB: %s: Recv to RTS done on probing QP (index=%d, qp_num=%u, dest_qp_num=%u, deviceIndex=%d, comm=%p)", __func__, localQpIndex, localQp->qp->qp_num, rtrAttr->remoteQpNum, localDevIndex, resCtx->baseComm);
+    INFO(NCCL_NET,
+         "NET/IB: %s: Recv to RTS done on probing QP (index=%d, qp_num=%u, dest_qp_num=%u, deviceIndex=%d, comm=%p)",
+         __func__, localQpIndex, localQp->qp->qp_num, rtrAttr->remoteQpNum, localDevIndex, resCtx->baseComm);
   }
 
   if (resCtx->recoveryEnabled) {
-    NCCLCHECK(IbCastPortRecoveryReceiverQpsCreateToRts(resCtx, remInfo, localResiliencyInfo->portRecoveryQpsInfo, resCtx->nPortRecoveryQps));
+    NCCLCHECK(IbCastPortRecoveryReceiverQpsCreateToRts(resCtx, remInfo, localResiliencyInfo->portRecoveryQpsInfo,
+                                                       resCtx->nPortRecoveryQps));
   }
 
   return ncclSuccess;
@@ -859,20 +961,25 @@ ncclResult_t IbCastResiliencyClose(struct ncclIbResiliency* resCtx) {
     WARN("NET/IB: %s: Resiliency context is NULL. Nothing to destroy.", __func__);
     return ncclSuccess;
   }
-  INFO(NCCL_NET, "NET/IB: %s: Resiliency context close for %s communicator (comm=%p)", __func__, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
+  INFO(NCCL_NET, "NET/IB: %s: Resiliency context close for %s communicator (comm=%p)", __func__,
+       resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
 
-  INFO(NCCL_NET, "NET/IB: %s: Destroying %d probing QPs for resiliency context (%s comm=%p)", __func__, resCtx->nProbingQps, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
+  INFO(NCCL_NET, "NET/IB: %s: Destroying %d probing QPs for resiliency context (%s comm=%p)", __func__,
+       resCtx->nProbingQps, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
   for (int qpIndex = 0; qpIndex < resCtx->nProbingQps; qpIndex++) {
     struct ncclIbQp* probingQp = &resCtx->probingQps[qpIndex];
     if (probingQp->qp == NULL) {
       continue;
     }
-    INFO(NCCL_NET, "NET/IB: %s: Destroying probing QP (index=%d, qp=%p, qp_num=%u) for resiliency context (comm=%p)", __func__, qpIndex, probingQp->qp, probingQp->qp->qp_num, resCtx->baseComm);
+    INFO(NCCL_NET, "NET/IB: %s: Destroying probing QP (index=%d, qp=%p, qp_num=%u) for resiliency context (comm=%p)",
+         __func__, qpIndex, probingQp->qp, probingQp->qp->qp_num, resCtx->baseComm);
     NCCLCHECK(wrap_ibv_destroy_qp(probingQp->qp));
   }
   if (resCtx->recoveryEnabled) {
     if (resCtx->outstandingRecovery > 0) {
-      WARN("NET/IB: %s: There are still %d outstanding recovery operations on the resiliency context (comm=%p) being destroyed.", __func__, resCtx->outstandingRecovery, resCtx->baseComm);
+      WARN("NET/IB: %s: There are still %d outstanding recovery operations on the resiliency context (comm=%p) being "
+           "destroyed.",
+           __func__, resCtx->outstandingRecovery, resCtx->baseComm);
     }
     NCCLCHECK(IbCastPortRecoveryClose(resCtx));
     NCCLCHECK(IbCastPortRecoveryQpsDestroy(resCtx, resCtx->nPortRecoveryQps));
@@ -880,18 +987,20 @@ ncclResult_t IbCastResiliencyClose(struct ncclIbResiliency* resCtx) {
   return ncclSuccess;
 }
 
-ncclResult_t IbCastResiliencyRemoteCompletionRecordsSet(struct ncclIbResiliency* resCtx, uint32_t cmplsRecordsRkey, uint64_t cmplsRecordsAddr, uint devIndex) {
+ncclResult_t IbCastResiliencyRemoteCompletionRecordsSet(struct ncclIbResiliency* resCtx, uint32_t cmplsRecordsRkey,
+                                                        uint64_t cmplsRecordsAddr, uint devIndex) {
   assert(resCtx != NULL);
   assert(resCtx->baseComm->isSend);
   assert(devIndex <= resCtx->nProbingQps);
   struct ncclIbResiliencySend* sendResCtx = (struct ncclIbResiliencySend*)resCtx;
   sendResCtx->remCmplRecordsInfo[devIndex].rkey = cmplsRecordsRkey;
   sendResCtx->remCmplRecordsInfo[devIndex].addr = cmplsRecordsAddr;
-  INFO(NCCL_NET, "NET/IB: %s: Set remote completion records info (comm=%p, addr=0x%lx, rkey=0x%x)", __func__, &resCtx->baseComm, cmplsRecordsAddr, cmplsRecordsRkey);
+  INFO(NCCL_NET, "NET/IB: %s: Set remote completion records info (comm=%p, addr=0x%lx, rkey=0x%x)", __func__,
+       &resCtx->baseComm, cmplsRecordsAddr, cmplsRecordsRkey);
   return ncclSuccess;
 }
 
-ncclResult_t IbCastResiliencyRequestIsComplete(struct ncclIbRequest *request, bool *isComplete) {
+ncclResult_t IbCastResiliencyRequestIsComplete(struct ncclIbRequest* request, bool* isComplete) {
   assert(isComplete != NULL);
 
   if (request == NULL) {
@@ -929,14 +1038,19 @@ ncclResult_t IbCastResiliencyRequestIsComplete(struct ncclIbRequest *request, bo
   *isComplete = ((remainingEventsSum == 0) || (abs(negativeEventsSum) == remainingEventsSum));
 #ifdef ENABLE_TRACE
   if (*isComplete == 1) {
-    TRACE(NCCL_NET, "NET/IB: %s: request=%p, remainingEventsSum=%d, negativeEventsSum=%d, completed? %s", __func__, request, remainingEventsSum, negativeEventsSum, *isComplete ? "yes" : "no");
+    TRACE(NCCL_NET, "NET/IB: %s: request=%p, remainingEventsSum=%d, negativeEventsSum=%d, completed? %s", __func__,
+          request, remainingEventsSum, negativeEventsSum, *isComplete ? "yes" : "no");
   }
 #endif // ENABLE_TRACE
   return ncclSuccess;
 }
 
 ncclResult_t IbCastResiliencyHandleCompletionError(struct ncclIbResiliency* resCtx, struct ibv_wc* wc, int devIndex) {
-  INFO(NCCL_NET, "NET/IB: %s: Got completion with error (devIndex=%d, wc->status=(%s)%d, wc->opcode=(%s)%d, wc->wr_id=%ld, wc->qp_num=%u, wc->byte_len=%d)", __func__, devIndex, ibvWcStatusStr(wc->status), wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->wr_id, wc->qp_num, wc->byte_len);
+  INFO(NCCL_NET,
+       "NET/IB: %s: Got completion with error (devIndex=%d, wc->status=(%s)%d, wc->opcode=(%s)%d, wc->wr_id=%ld, "
+       "wc->qp_num=%u, wc->byte_len=%d)",
+       __func__, devIndex, ibvWcStatusStr(wc->status), wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->wr_id,
+       wc->qp_num, wc->byte_len);
   NCCLCHECK(IbCastResiliencyCheckErrorNotFatal(resCtx, wc, devIndex));
 
   // Before handling the request that got an error, first the device is
@@ -958,7 +1072,8 @@ static ncclResult_t IbCastResiliencyActiveQpsRestore(struct ncclIbResiliency* re
     if (qpToRestore->devIndex != restoredDevIndex) {
       continue;
     }
-    INFO(NCCL_NET, "NET/IB: %s: Restoring QP (index=%d, qp_num=%u) on device %d (comm=%p)", __func__, qpIndex, qpToRestore->qp->qp_num, restoredDevIndex, resCtx->baseComm);
+    INFO(NCCL_NET, "NET/IB: %s: Restoring QP (index=%d, qp_num=%u) on device %d (comm=%p)", __func__, qpIndex,
+         qpToRestore->qp->qp_num, restoredDevIndex, resCtx->baseComm);
     resCtx->baseComm->activeQps[qpIndex] = qpToRestore;
   }
   return ncclSuccess;
@@ -997,17 +1112,26 @@ ncclResult_t IbCastResiliencyProgress(struct ncclIbResiliency* resCtx) {
     // Check if recovery operations are completed.
     for (int devIndex = 0; devIndex < resCtx->ndevs; devIndex++) {
       enum ncclIbResiliencyDevState devState = resCtx->devs[devIndex].state.load(std::memory_order_acquire);
-      TRACE(NCCL_NET, "NET/IB: %s: Checking dev state for device %d: state=%d (comm=%p).", __func__, devIndex, devState, resCtx->baseComm);
+      TRACE(NCCL_NET, "NET/IB: %s: Checking dev state for device %d: state=%d (comm=%p).", __func__, devIndex, devState,
+            resCtx->baseComm);
       if (devState == ncclIbResiliencyDevStateRecovered) {
         resCtx->outstandingRecovery--;
         resCtx->devs[devIndex].recoveryCount++;
-        INFO(NCCL_NET, "NET/IB: %s: Device %d has been recovered for resiliency context (%s comm=%p, outstandingRecovery=%d, recoveryCount=%d)", __func__, devIndex, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm, resCtx->outstandingRecovery, resCtx->devs[devIndex].recoveryCount);
+        INFO(NCCL_NET,
+             "NET/IB: %s: Device %d has been recovered for resiliency context (%s comm=%p, outstandingRecovery=%d, "
+             "recoveryCount=%d)",
+             __func__, devIndex, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm,
+             resCtx->outstandingRecovery, resCtx->devs[devIndex].recoveryCount);
         IbCastResiliencyActiveQpsRestore(resCtx, devIndex);
         resCtx->devs[devIndex].state.store(ncclIbResiliencyDevStateOk, std::memory_order_release);
       }
       if (devState == ncclIbResiliencyDevStateRecoveryFailed) {
         resCtx->outstandingRecovery--;
-        INFO(NCCL_NET, "NET/IB: %s: Device %d will not be attempted to be recovered any more (%s comm=%p, outstandingRecovery=%d).", __func__, devIndex, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm, resCtx->outstandingRecovery);
+        INFO(
+          NCCL_NET,
+          "NET/IB: %s: Device %d will not be attempted to be recovered any more (%s comm=%p, outstandingRecovery=%d).",
+          __func__, devIndex, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm,
+          resCtx->outstandingRecovery);
         resCtx->devs[devIndex].state.store(ncclIbResiliencyDevStateErrorPermanent, std::memory_order_release);
         continue;
       }
@@ -1015,7 +1139,10 @@ ncclResult_t IbCastResiliencyProgress(struct ncclIbResiliency* resCtx) {
   }
 
   if (resCtx->outstandingRequests == 0 && resCtx->outstandingRecovery == 0) {
-    INFO(NCCL_NET, "NET/IB: %s: All resiliency operations are completed for resiliency context (%s comm=%p). Marking progress as completed.", __func__, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
+    INFO(NCCL_NET,
+         "NET/IB: %s: All resiliency operations are completed for resiliency context (%s comm=%p). Marking progress as "
+         "completed.",
+         __func__, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
     resCtx->inProgress = false;
   }
   return ncclSuccess;

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_cast.h
@@ -184,7 +184,7 @@ struct ncclIbResiliencySend {
 // Data path APIs
 // -----------------------------
 
-ncclResult_t IbCastResiliencyRequestIsComplete(struct ncclIbRequest *request, bool *isComplete);
+ncclResult_t IbCastResiliencyRequestIsComplete(struct ncclIbRequest* request, bool* isComplete);
 
 // First checks if the error is recoverable or not. If yes, performs QPs
 // replacement on the communicator for all QPs that are associated
@@ -222,13 +222,16 @@ ncclResult_t IbCastResiliencyDeviceNumSet(struct ncclIbResiliency* resCtx, int n
 
 // The local info should be populated by the function with the information of
 // the QPs created so it could be passed to the receiver side.
-ncclResult_t IbCastResiliencySenderCreateQps(struct ncclIbResiliency* resCtx, struct ncclIbResiliencyInfo* localResiliencyInfo);
+ncclResult_t IbCastResiliencySenderCreateQps(struct ncclIbResiliency* resCtx,
+                                             struct ncclIbResiliencyInfo* localResiliencyInfo);
 // The remote info should be used for modifying the QPs required for resiliency
 // on the sender side to RTS state.
 ncclResult_t IbCastResiliencySenderQpsToRts(struct ncclIbResiliency* resCtx, struct ncclIbConnectionMetadata* remInfo);
 // The local info should be populated with the information of the QPs created
 // so it could be passed to the sender side.
-ncclResult_t IbCastResiliencyReceiverQpsCreateToRts(struct ncclIbResiliency* resCtx, struct ncclIbConnectionMetadata* remInfo, struct ncclIbResiliencyInfo* localResiliencyInfo);
+ncclResult_t IbCastResiliencyReceiverQpsCreateToRts(struct ncclIbResiliency* resCtx,
+                                                    struct ncclIbConnectionMetadata* remInfo,
+                                                    struct ncclIbResiliencyInfo* localResiliencyInfo);
 
 ncclResult_t IbCastResiliencyClose(struct ncclIbResiliency* resCtx);
 
@@ -237,6 +240,7 @@ ncclResult_t IbCastResiliencyClose(struct ncclIbResiliency* resCtx);
 // memory info to the sender side. This function should be called on the sender
 // side to allow the resiliency context to access the completion records
 // structure on the receiver side.
-ncclResult_t IbCastResiliencyRemoteCompletionRecordsSet(struct ncclIbResiliency* resCtx, uint32_t cmplsRecordsRkey, uint64_t cmplsRecordsAddr, uint devIndex);
+ncclResult_t IbCastResiliencyRemoteCompletionRecordsSet(struct ncclIbResiliency* resCtx, uint32_t cmplsRecordsRkey,
+                                                        uint64_t cmplsRecordsAddr, uint devIndex);
 
 #endif // NET_IB_P2P_RESILIENCY_H_

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery.cc
@@ -10,10 +10,12 @@
 
 NCCL_PARAM(IbCastResiliencyPortRecovery, "IB_RESILIENCY_PORT_RECOVERY", 0);
 NCCL_PARAM(IbCastResiliencyPortRecoveryStartDelay, "IB_RESILIENCY_PORT_RECOVERY_START_DELAY", 200); // In milliseconds
-NCCL_PARAM(IbCastResiliencyPortRecoveryAliveMsgBatchInterval, "IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_INTERVAL", 500); // In milliseconds
+NCCL_PARAM(IbCastResiliencyPortRecoveryAliveMsgBatchInterval, "IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_INTERVAL",
+           500); // In milliseconds
 NCCL_PARAM(IbCastResiliencyPortRecoveryAliveMsgBatchSize, "IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE", 5);
 NCCL_PARAM(IbCastResiliencyPortRecoveryAliveMsgSequenceSize, "IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_SEQUENCE_SIZE", 5);
-NCCL_PARAM(IbCastResiliencyPortRecoveryAliveMsgTimeout, "IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_TIMEOUT", 4000); // In milliseconds
+NCCL_PARAM(IbCastResiliencyPortRecoveryAliveMsgTimeout, "IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_TIMEOUT",
+           4000); // In milliseconds
 NCCL_PARAM(IbCastResiliencyPortRecoveryAckTimeout, "IB_RESILIENCY_PORT_RECOVERY_ACK_TIMEOUT", 5000); // In milliseconds
 NCCL_PARAM(IbCastResiliencyPortRecoveryAttemptsMax, "IB_RESILIENCY_PORT_RECOVERY_ATTEMPTS_MAX", 5);
 
@@ -30,7 +32,7 @@ extern int64_t ncclParamIbCastPkey();
 // The asynchronous thread should be be able to handle the CQ fast enough so
 // no more than two batches of "alive" messsages should be pending in the CQ at
 // any time.
-#define NCCL_IB_RESILIENCY_PORT_RECOVERY_CQ_SIZE (NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX*2)
+#define NCCL_IB_RESILIENCY_PORT_RECOVERY_CQ_SIZE (NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX * 2)
 
 static ncclResult_t IbCastPortRecoveryQpInitUd(struct ncclIbQp* qp, int pkeyIndex, int portNum) {
   struct ibv_qp_attr attr;
@@ -39,8 +41,7 @@ static ncclResult_t IbCastPortRecoveryQpInitUd(struct ncclIbQp* qp, int pkeyInde
   attr.pkey_index = pkeyIndex;
   attr.port_num = portNum;
   attr.qkey = NCCL_IB_RECOVERY_QKEY;
-  NCCLCHECK(wrap_ibv_modify_qp(qp->qp, &attr,
-      IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_QKEY));
+  NCCLCHECK(wrap_ibv_modify_qp(qp->qp, &attr, IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_QKEY));
   return ncclSuccess;
 }
 
@@ -104,7 +105,6 @@ static std::vector<ncclIbPortRecoveryCloseRequest*> recoveryCloseRequests;
 // Condition variable to signal completion of close requests
 static std::condition_variable IbCastPortRecoveryCloseCond;
 
-
 // Shared inbox for new recovery contexts - protected by IbCastPortRecoveryMutex.
 // Producer threads add items here; the async thread drains it under lock.
 static std::list<ncclIbPortRecoveryContext*> recoveryInbox;
@@ -117,7 +117,9 @@ static inline ncclResult_t IbCastPortRecoveryQpsToError(ncclIbPortRecoveryContex
       // The QP is not on the failed device; skip
       continue;
     }
-    INFO(NCCL_NET, "NET/IB: %s: Transitioning QP %u on device %d to ERROR state (comm=%p, devIndex=%d, qp_num=%u)", __func__, localQp->qp->qp_num, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex, localQp->qp->qp_num);
+    INFO(NCCL_NET, "NET/IB: %s: Transitioning QP %u on device %d to ERROR state (comm=%p, devIndex=%d, qp_num=%u)",
+         __func__, localQp->qp->qp_num, recoveryContext->devIndex, recoveryContext->resCtx->baseComm,
+         recoveryContext->devIndex, localQp->qp->qp_num);
     NCCLCHECK(IbCastQpError(localQp));
   }
   return ncclSuccess;
@@ -126,7 +128,8 @@ static inline ncclResult_t IbCastPortRecoveryQpsToError(ncclIbPortRecoveryContex
 // Predefined work ID for receive work request for port recovery messages
 #define NCCL_IB_PORT_RECOVERY_WR_ID (0xAAAA)
 
-inline static ncclResult_t IbCastPortRecoveryPostRecvWorkRequest(struct ibv_qp* qp, struct ncclIbResiliencyDev* resDev) {
+inline static ncclResult_t IbCastPortRecoveryPostRecvWorkRequest(struct ibv_qp* qp,
+                                                                 struct ncclIbResiliencyDev* resDev) {
   struct ibv_sge sge;
   sge.addr = (uintptr_t)resDev->portRecoveryGrhBuf;
   sge.length = sizeof(resDev->portRecoveryGrhBuf);
@@ -142,7 +145,8 @@ inline static ncclResult_t IbCastPortRecoveryPostRecvWorkRequest(struct ibv_qp* 
 
 // Helper function to drain CQEs on the provided CQ and fill a Receive WQE for
 // every CQE drained on the provided QP.
-static ncclResult_t IbCastPortRecoveryDrainCqAndPostReceiveWRs(struct ncclIbPortRecoveryContext* recoveryContext, bool* success) {
+static ncclResult_t IbCastPortRecoveryDrainCqAndPostReceiveWRs(struct ncclIbPortRecoveryContext* recoveryContext,
+                                                               bool* success) {
   struct ibv_cq* cq = recoveryContext->recoveryCq;
   struct ibv_qp* qp = recoveryContext->resCtx->portRecoveryQps[recoveryContext->devIndex].qp;
   int wrDone = 0;
@@ -153,15 +157,18 @@ static ncclResult_t IbCastPortRecoveryDrainCqAndPostReceiveWRs(struct ncclIbPort
   do {
     ret = wrap_ibv_poll_cq(cq, numMsgs, wcs, &wrDone);
     if (ret != ncclSuccess) {
-      INFO(NCCL_NET, "NET/IB: %s: Failed to poll recovery CQ %p for device %d (comm=%p)", __func__, cq, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Failed to poll recovery CQ %p for device %d (comm=%p)", __func__, cq,
+           recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
       *success = false;
       return ncclSuccess;
     }
-    INFO(NCCL_NET, "NET/IB: %s: Drained %d CQEs from recovery CQ %p for device %d (comm=%p)", __func__, wrDone, cq, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+    INFO(NCCL_NET, "NET/IB: %s: Drained %d CQEs from recovery CQ %p for device %d (comm=%p)", __func__, wrDone, cq,
+         recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
     for (int i = 0; i < wrDone; i++) {
       ret = IbCastPortRecoveryPostRecvWorkRequest(qp, &recoveryContext->resCtx->devs[recoveryContext->devIndex]);
       if (ret != ncclSuccess) {
-        INFO(NCCL_NET, "NET/IB: %s: Failed to post recv WR on recovery QP %p for device %d (comm=%p)", __func__, qp, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+        INFO(NCCL_NET, "NET/IB: %s: Failed to post recv WR on recovery QP %p for device %d (comm=%p)", __func__, qp,
+             recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
         *success = false;
         return ncclSuccess;
       }
@@ -171,7 +178,8 @@ static ncclResult_t IbCastPortRecoveryDrainCqAndPostReceiveWRs(struct ncclIbPort
   return ncclSuccess;
 }
 
-static inline ncclResult_t IbCastPortRecoveryContextInit(struct ncclIbResiliency* resCtx, int failedDevIndex, ncclIbPortRecoveryContext** outRecoveryCtx) {
+static inline ncclResult_t IbCastPortRecoveryContextInit(struct ncclIbResiliency* resCtx, int failedDevIndex,
+                                                         ncclIbPortRecoveryContext** outRecoveryCtx) {
   ncclResult_t res = ncclSuccess;
   if (!outRecoveryCtx) return ncclInternalError;
   ncclIbPortRecoveryContext* recoveryCtx = (ncclIbPortRecoveryContext*)malloc(sizeof(ncclIbPortRecoveryContext));
@@ -207,7 +215,8 @@ static inline ncclResult_t IbCastPortRecoveryContextInit(struct ncclIbResiliency
   // Transitioning all QPs on the failed device to ERROR state
   res = IbCastPortRecoveryQpsToError(recoveryCtx);
   if (res != ncclSuccess) {
-    INFO(NCCL_NET, "NET/IB: %s: Failed to transition QPs to ERROR state for device %d (comm=%p)", __func__, failedDevIndex, resCtx->baseComm);
+    INFO(NCCL_NET, "NET/IB: %s: Failed to transition QPs to ERROR state for device %d (comm=%p)", __func__,
+         failedDevIndex, resCtx->baseComm);
     free(recoveryCtx);
     return res;
   }
@@ -216,10 +225,13 @@ static inline ncclResult_t IbCastPortRecoveryContextInit(struct ncclIbResiliency
     recoveryCtx->send.aliveMsgPosted = false;
     recoveryCtx->send.aliveMsgCompleted = false;
     // Required for the ACK from the receiver
-    INFO(NCCL_NET, "NET/IB: %s: Sender posting initial (%d) recv WRs for port recovery for device %d (comm=%p)", __func__, 1, recoveryCtx->devIndex, recoveryCtx->resCtx->baseComm);
-    res = IbCastPortRecoveryPostRecvWorkRequest(recoveryCtx->resCtx->portRecoveryQps[recoveryCtx->devIndex].qp, &recoveryCtx->resCtx->devs[recoveryCtx->devIndex]);
+    INFO(NCCL_NET, "NET/IB: %s: Sender posting initial (%d) recv WRs for port recovery for device %d (comm=%p)",
+         __func__, 1, recoveryCtx->devIndex, recoveryCtx->resCtx->baseComm);
+    res = IbCastPortRecoveryPostRecvWorkRequest(recoveryCtx->resCtx->portRecoveryQps[recoveryCtx->devIndex].qp,
+                                                &recoveryCtx->resCtx->devs[recoveryCtx->devIndex]);
     if (res != ncclSuccess) {
-      INFO(NCCL_NET, "NET/IB: %s: Sender failed to post recv WR on recovery QP for device %d (comm=%p)", __func__, recoveryCtx->devIndex, recoveryCtx->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Sender failed to post recv WR on recovery QP for device %d (comm=%p)", __func__,
+           recoveryCtx->devIndex, recoveryCtx->resCtx->baseComm);
       free(recoveryCtx);
       return res;
     }
@@ -227,11 +239,15 @@ static inline ncclResult_t IbCastPortRecoveryContextInit(struct ncclIbResiliency
     recoveryCtx->recv.windowBase = 0;
     recoveryCtx->recv.receivedBits = 0;
     // Required for the alive messages and final ACK from the sender
-    INFO(NCCL_NET, "NET/IB: %s: Receiver posting initial (%d) recv WRs for port recovery for device %d (comm=%p)", __func__, NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX, recoveryCtx->devIndex, recoveryCtx->resCtx->baseComm);
+    INFO(NCCL_NET, "NET/IB: %s: Receiver posting initial (%d) recv WRs for port recovery for device %d (comm=%p)",
+         __func__, NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX, recoveryCtx->devIndex,
+         recoveryCtx->resCtx->baseComm);
     for (int i = 0; i < NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX; i++) {
-      res = IbCastPortRecoveryPostRecvWorkRequest(recoveryCtx->resCtx->portRecoveryQps[recoveryCtx->devIndex].qp, &recoveryCtx->resCtx->devs[recoveryCtx->devIndex]);
+      res = IbCastPortRecoveryPostRecvWorkRequest(recoveryCtx->resCtx->portRecoveryQps[recoveryCtx->devIndex].qp,
+                                                  &recoveryCtx->resCtx->devs[recoveryCtx->devIndex]);
       if (res != ncclSuccess) {
-        INFO(NCCL_NET, "NET/IB: %s: Receiver failed to post recv WR on recovery QP for device %d (comm=%p)", __func__, recoveryCtx->devIndex, recoveryCtx->resCtx->baseComm);
+        INFO(NCCL_NET, "NET/IB: %s: Receiver failed to post recv WR on recovery QP for device %d (comm=%p)", __func__,
+             recoveryCtx->devIndex, recoveryCtx->resCtx->baseComm);
         free(recoveryCtx);
         return res;
       }
@@ -244,7 +260,9 @@ static inline ncclResult_t IbCastPortRecoveryContextInit(struct ncclIbResiliency
 
 static inline ncclResult_t IbCastPortRecoveryContextDestroy(ncclIbPortRecoveryContext* recoveryContext) {
   assert(recoveryContext);
-  INFO(NCCL_NET, "NET/IB: %s: Destroying port recovery context for device %d (%s comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
+  INFO(NCCL_NET, "NET/IB: %s: Destroying port recovery context for device %d (%s comm=%p)", __func__,
+       recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv",
+       recoveryContext->resCtx->baseComm);
   free(recoveryContext);
   return ncclSuccess;
 }
@@ -253,12 +271,16 @@ ncclResult_t IbCastPortRecoveryDevInit(struct ncclIbResiliency* resCtx, int devI
   assert(resCtx->recoveryEnabled);
   struct ncclIbResiliencyDev* resDev = &resCtx->devs[devIndex];
   void* cqContext = (void*)&resCtx->baseComm->stats;
-  NCCLCHECK(wrap_ibv_create_cq(&resDev->portRecoveryCq, ibDev->context, NCCL_IB_RESILIENCY_PORT_RECOVERY_CQ_SIZE, cqContext, NULL, 0));
+  NCCLCHECK(wrap_ibv_create_cq(&resDev->portRecoveryCq, ibDev->context, NCCL_IB_RESILIENCY_PORT_RECOVERY_CQ_SIZE,
+                               cqContext, NULL, 0));
   memset(resDev->portRecoveryGrhBuf, 0, sizeof(resDev->portRecoveryGrhBuf));
-  NCCLCHECK(wrap_ibv_reg_mr(&resDev->portRecoveryGrhMr, ibDev->pd, resDev->portRecoveryGrhBuf, sizeof(resDev->portRecoveryGrhBuf), IBV_ACCESS_LOCAL_WRITE));
+  NCCLCHECK(wrap_ibv_reg_mr(&resDev->portRecoveryGrhMr, ibDev->pd, resDev->portRecoveryGrhBuf,
+                            sizeof(resDev->portRecoveryGrhBuf), IBV_ACCESS_LOCAL_WRITE));
   // Register QPN send buffer against this device's PD so ACK sends use a matching lkey.
-  NCCLCHECK(wrap_ibv_reg_mr(&resDev->portRecoveryQpnMr, ibDev->pd, resCtx->portRecoveryQpnBuf, sizeof(resCtx->portRecoveryQpnBuf), IBV_ACCESS_LOCAL_WRITE));
-  INFO(NCCL_NET, "NET/IB: %s: Created port recovery CQ and GRH MR for resiliency context (%s comm=%p) on device %d", __func__, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm, devIndex);
+  NCCLCHECK(wrap_ibv_reg_mr(&resDev->portRecoveryQpnMr, ibDev->pd, resCtx->portRecoveryQpnBuf,
+                            sizeof(resCtx->portRecoveryQpnBuf), IBV_ACCESS_LOCAL_WRITE));
+  INFO(NCCL_NET, "NET/IB: %s: Created port recovery CQ and GRH MR for resiliency context (%s comm=%p) on device %d",
+       __func__, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm, devIndex);
   return ncclSuccess;
 }
 
@@ -275,11 +297,13 @@ ncclResult_t IbCastPortRecoveryDevDestroy(struct ncclIbResiliency* resCtx, int d
     wrap_ibv_dereg_mr(resDev->portRecoveryQpnMr);
     resDev->portRecoveryQpnMr = nullptr;
   }
-  INFO(NCCL_NET, "NET/IB: %s: Destroyed port recovery CQ and GRH MR on device %d for resiliency context (comm=%p)", __func__, devIndex, resCtx->baseComm);
+  INFO(NCCL_NET, "NET/IB: %s: Destroyed port recovery CQ and GRH MR on device %d for resiliency context (comm=%p)",
+       __func__, devIndex, resCtx->baseComm);
   return ncclSuccess;
 }
 
-ncclResult_t IbCastPortRecoverySenderQpsCreate(struct ncclIbResiliency* resCtx, struct ncclIbQpInfo* localPortRecoveryQpsInfo, int nQps) {
+ncclResult_t IbCastPortRecoverySenderQpsCreate(struct ncclIbResiliency* resCtx,
+                                               struct ncclIbQpInfo* localPortRecoveryQpsInfo, int nQps) {
   assert(nQps > 0);
   assert(resCtx->recoveryEnabled);
   ncclIbSendComm* sendComm = (ncclIbSendComm*)resCtx->baseComm;
@@ -307,7 +331,8 @@ ncclResult_t IbCastPortRecoverySenderQpsCreate(struct ncclIbResiliency* resCtx, 
   return ncclSuccess;
 }
 
-ncclResult_t IbCastPortRecoverySenderQpsToRts(struct ncclIbResiliency* resCtx, struct ncclIbConnectionMetadata* remInfo, int nQps) {
+ncclResult_t IbCastPortRecoverySenderQpsToRts(struct ncclIbResiliency* resCtx, struct ncclIbConnectionMetadata* remInfo,
+                                              int nQps) {
   assert(nQps > 0);
   assert(resCtx->recoveryEnabled);
   ncclIbSendComm* sendComm = (ncclIbSendComm*)resCtx->baseComm;
@@ -342,12 +367,16 @@ ncclResult_t IbCastPortRecoverySenderQpsToRts(struct ncclIbResiliency* resCtx, s
     NCCLCHECK(wrap_ibv_create_ah(&resCtx->portRecoveryAh[localDevIndex], sendCommDev->base.pd, &ahAttr));
     resCtx->portRecoveryRemoteQpn[localDevIndex] = remQpInfo->qpn;
 
-    INFO(NCCL_NET, "NET/IB: %s: To RTS done on recovery UD QP (index=%d, qp_num=%u, remote_qpn=%u, deviceIndex=%d, comm=%p)", __func__, localQpIndex, localQp->qp->qp_num, remQpInfo->qpn, localDevIndex, resCtx->baseComm);
+    INFO(NCCL_NET,
+         "NET/IB: %s: To RTS done on recovery UD QP (index=%d, qp_num=%u, remote_qpn=%u, deviceIndex=%d, comm=%p)",
+         __func__, localQpIndex, localQp->qp->qp_num, remQpInfo->qpn, localDevIndex, resCtx->baseComm);
   }
   return ncclSuccess;
 }
 
-ncclResult_t IbCastPortRecoveryReceiverQpsCreateToRts(struct ncclIbResiliency* resCtx, struct ncclIbConnectionMetadata* remInfo, struct ncclIbQpInfo* localPortRecoveryQpsInfo, int nQps) {
+ncclResult_t IbCastPortRecoveryReceiverQpsCreateToRts(struct ncclIbResiliency* resCtx,
+                                                      struct ncclIbConnectionMetadata* remInfo,
+                                                      struct ncclIbQpInfo* localPortRecoveryQpsInfo, int nQps) {
   ncclIbRecvComm* recvComm = (ncclIbRecvComm*)resCtx->baseComm;
   void* qpContext = (void*)&recvComm->base.stats;
   struct ncclIbQpCreateAttr qpCreateAttrs;
@@ -391,7 +420,9 @@ ncclResult_t IbCastPortRecoveryReceiverQpsCreateToRts(struct ncclIbResiliency* r
     }
     NCCLCHECK(wrap_ibv_create_ah(&resCtx->portRecoveryAh[localDevIndex], recvCommDev->base.pd, &ahAttr));
     resCtx->portRecoveryRemoteQpn[localDevIndex] = remQpInfo->qpn;
-    INFO(NCCL_NET, "NET/IB: %s: To RTS done on recovery UD QP (index=%d, qp_num=%u, remote_qpn=%u, deviceIndex=%d, comm=%p)", __func__, localQpIndex, localQp->qp->qp_num, remQpInfo->qpn, localDevIndex, resCtx->baseComm);
+    INFO(NCCL_NET,
+         "NET/IB: %s: To RTS done on recovery UD QP (index=%d, qp_num=%u, remote_qpn=%u, deviceIndex=%d, comm=%p)",
+         __func__, localQpIndex, localQp->qp->qp_num, remQpInfo->qpn, localDevIndex, resCtx->baseComm);
   }
   return ncclSuccess;
 }
@@ -406,7 +437,8 @@ ncclResult_t IbCastPortRecoveryQpsDestroy(struct ncclIbResiliency* resCtx, int n
     if (!recoveryQp->qp) {
       continue;
     }
-    INFO(NCCL_NET, "NET/IB: %s: Destroying port recovery UD QP (index=%d, qp_num=%u) for resiliency context (comm=%p)", __func__, qpIndex, recoveryQp->qp->qp_num, resCtx->baseComm);
+    INFO(NCCL_NET, "NET/IB: %s: Destroying port recovery UD QP (index=%d, qp_num=%u) for resiliency context (comm=%p)",
+         __func__, qpIndex, recoveryQp->qp->qp_num, resCtx->baseComm);
     NCCLCHECK(wrap_ibv_destroy_qp(recoveryQp->qp));
   }
   return ncclSuccess;
@@ -422,8 +454,7 @@ static inline ncclResult_t IbCastPortRecoveryQpsRestore(ncclIbPortRecoveryContex
       *success = false;
       return ncclSuccess;
     }
-    if (recoveryContext->resCtx->baseComm->isSend &&
-        IbCastPortRecoveryQpsToRtsAinic(recoveryContext) != ncclSuccess) {
+    if (recoveryContext->resCtx->baseComm->isSend && IbCastPortRecoveryQpsToRtsAinic(recoveryContext) != ncclSuccess) {
       *success = false;
       return ncclSuccess;
     }
@@ -439,48 +470,64 @@ static inline ncclResult_t IbCastPortRecoveryQpsRestore(ncclIbPortRecoveryContex
       continue;
     }
 
-    INFO(NCCL_NET, "NET/IB: %s: Restoring QP %d on device %d (comm=%p, devIndex=%d, qp_num=%u)", __func__, qpIndex, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex, localQp->qp->qp_num);
+    INFO(NCCL_NET, "NET/IB: %s: Restoring QP %d on device %d (comm=%p, devIndex=%d, qp_num=%u)", __func__, qpIndex,
+         recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex, localQp->qp->qp_num);
     res = IbCastQpReset(localQp);
     if (res != ncclSuccess) {
-      INFO(NCCL_NET, "NET/IB: %s: Failed to reset QP index %d on device %d (comm=%p, devIndex=%d, qp_num=%u)", __func__, qpIndex, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex, localQp->qp->qp_num);
+      INFO(NCCL_NET, "NET/IB: %s: Failed to reset QP index %d on device %d (comm=%p, devIndex=%d, qp_num=%u)", __func__,
+           qpIndex, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex,
+           localQp->qp->qp_num);
       *success = false;
       return ncclSuccess;
     }
     res = IbCastQpInit(localQp);
     if (res != ncclSuccess) {
-      INFO(NCCL_NET, "NET/IB: %s: Failed to init QP index %d on device %d (comm=%p, devIndex=%d, qp_num=%u)", __func__, qpIndex, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex, localQp->qp->qp_num);
+      INFO(NCCL_NET, "NET/IB: %s: Failed to init QP index %d on device %d (comm=%p, devIndex=%d, qp_num=%u)", __func__,
+           qpIndex, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex,
+           localQp->qp->qp_num);
       *success = false;
       return ncclSuccess;
     }
     if (localQp->eceSupported) {
       res = wrap_ibv_set_ece(localQp->qp, &localQp->ece, &localQp->eceSupported);
       if (res != ncclSuccess) {
-        INFO(NCCL_NET, "NET/IB: %s: Failed to set ECE for QP index %d on device %d (comm=%p, devIndex=%d, qp_num=%u)", __func__, qpIndex, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex, localQp->qp->qp_num);
+        INFO(NCCL_NET, "NET/IB: %s: Failed to set ECE for QP index %d on device %d (comm=%p, devIndex=%d, qp_num=%u)",
+             __func__, qpIndex, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex,
+             localQp->qp->qp_num);
         *success = false;
         return ncclSuccess;
       }
     }
     res = IbCastQpRtr(localQp);
     if (res != ncclSuccess) {
-      INFO(NCCL_NET, "NET/IB: %s: Failed to modify to RTR QP index %d on device %d (comm=%p, devIndex=%d, qp_num=%u)", __func__, qpIndex, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex, localQp->qp->qp_num);
+      INFO(NCCL_NET, "NET/IB: %s: Failed to modify to RTR QP index %d on device %d (comm=%p, devIndex=%d, qp_num=%u)",
+           __func__, qpIndex, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex,
+           localQp->qp->qp_num);
       *success = false;
       return ncclSuccess;
     }
     res = IbCastQpRts(localQp);
     if (res != ncclSuccess) {
-      INFO(NCCL_NET, "NET/IB: %s: Failed to modify to RTS QP index %d on device %d (comm=%p, devIndex=%d, qp_num=%u)", __func__, qpIndex, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex, localQp->qp->qp_num);
+      INFO(NCCL_NET, "NET/IB: %s: Failed to modify to RTS QP index %d on device %d (comm=%p, devIndex=%d, qp_num=%u)",
+           __func__, qpIndex, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex,
+           localQp->qp->qp_num);
       *success = false;
       return ncclSuccess;
     }
-    INFO(NCCL_NET, "NET/IB: %s: Restored QP %d on device %d (comm=%p, devIndex=%d, qp_num=%u)", __func__, qpIndex, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex, localQp->qp->qp_num);
+    INFO(NCCL_NET, "NET/IB: %s: Restored QP %d on device %d (comm=%p, devIndex=%d, qp_num=%u)", __func__, qpIndex,
+         recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex, localQp->qp->qp_num);
 
     if (!recoveryContext->resCtx->baseComm->isSend) {
       // Pre-post receive work requests on the restored QP if this is a receiver.
-      INFO(NCCL_NET, "NET/IB: %s: Posting receive work requests on the restored QP (comm=%p, qp_num=%u)", __func__, recoveryContext->resCtx->baseComm, localQp->qp->qp_num);
+      INFO(NCCL_NET, "NET/IB: %s: Posting receive work requests on the restored QP (comm=%p, qp_num=%u)", __func__,
+           recoveryContext->resCtx->baseComm, localQp->qp->qp_num);
       struct ncclIbRecvComm* recvComm = (struct ncclIbRecvComm*)recoveryContext->resCtx->baseComm;
       res = IbCastPostReceiveWorkRequestsOnQp(recvComm, localQp);
       if (res != ncclSuccess) {
-        INFO(NCCL_NET, "NET/IB: %s: Failed to post recv WQEs on QP index %d on device %d (comm=%p, devIndex=%d, qp_num=%u)", __func__, qpIndex, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex, localQp->qp->qp_num);
+        INFO(NCCL_NET,
+             "NET/IB: %s: Failed to post recv WQEs on QP index %d on device %d (comm=%p, devIndex=%d, qp_num=%u)",
+             __func__, qpIndex, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex,
+             localQp->qp->qp_num);
         *success = false;
         return ncclSuccess;
       }
@@ -495,32 +542,42 @@ static inline ncclResult_t IbCastPortRecoveryQpsRestore(ncclIbPortRecoveryContex
         if (i != recoveryContext->devIndex) continue;
         struct ncclIbRecvCommDev* rCommDev = &recvComm->devs[i];
         ncclIbQp* flushQp = &rCommDev->gpuFlush.qp;
-        TRACE(NCCL_NET, "NET/IB: %s: Restoring Flush QP on device %d (comm=%p)", __func__, i, recoveryContext->resCtx->baseComm);
+        TRACE(NCCL_NET, "NET/IB: %s: Restoring Flush QP on device %d (comm=%p)", __func__, i,
+              recoveryContext->resCtx->baseComm);
         res = IbCastQpReset(flushQp);
         if (res != ncclSuccess) {
-          INFO(NCCL_NET, "NET/IB: %s: Failed to reset Flush QP on device %d (comm=%p, devIndex=%d, qp_num=%u)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex, flushQp->qp->qp_num);
+          INFO(NCCL_NET, "NET/IB: %s: Failed to reset Flush QP on device %d (comm=%p, devIndex=%d, qp_num=%u)",
+               __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex,
+               flushQp->qp->qp_num);
           *success = false;
           return ncclSuccess;
         }
         res = IbCastQpInit(flushQp);
         if (res != ncclSuccess) {
-          INFO(NCCL_NET, "NET/IB: %s: Failed to init Flush QP on device %d (comm=%p, devIndex=%d, qp_num=%u)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex, flushQp->qp->qp_num);
+          INFO(NCCL_NET, "NET/IB: %s: Failed to init Flush QP on device %d (comm=%p, devIndex=%d, qp_num=%u)", __func__,
+               recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex,
+               flushQp->qp->qp_num);
           *success = false;
           return ncclSuccess;
         }
         res = IbCastQpRtr(flushQp);
         if (res != ncclSuccess) {
-          INFO(NCCL_NET, "NET/IB: %s: Failed to modify to RTR Flush QP on device %d (comm=%p, devIndex=%d, qp_num=%u)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex, flushQp->qp->qp_num);
+          INFO(NCCL_NET, "NET/IB: %s: Failed to modify to RTR Flush QP on device %d (comm=%p, devIndex=%d, qp_num=%u)",
+               __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex,
+               flushQp->qp->qp_num);
           *success = false;
           return ncclSuccess;
         }
         res = IbCastQpRts(flushQp);
         if (res != ncclSuccess) {
-          INFO(NCCL_NET, "NET/IB: %s: Failed to modify to RTS Flush QP on device %d (comm=%p, devIndex=%d, qp_num=%u)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex, flushQp->qp->qp_num);
+          INFO(NCCL_NET, "NET/IB: %s: Failed to modify to RTS Flush QP on device %d (comm=%p, devIndex=%d, qp_num=%u)",
+               __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex,
+               flushQp->qp->qp_num);
           *success = false;
           return ncclSuccess;
         }
-        INFO(NCCL_NET, "NET/IB: %s: Restored Flush QP on device %d (comm=%p)", __func__, i, recoveryContext->resCtx->baseComm);
+        INFO(NCCL_NET, "NET/IB: %s: Restored Flush QP on device %d (comm=%p)", __func__, i,
+             recoveryContext->resCtx->baseComm);
       }
     }
   }
@@ -528,18 +585,26 @@ static inline ncclResult_t IbCastPortRecoveryQpsRestore(ncclIbPortRecoveryContex
   return ncclSuccess;
 }
 
-
-static inline ncclResult_t IbCastPortRecoveryHandleCompletionReceiver(struct ncclIbPortRecoveryContext* recoveryContext, struct ibv_wc completion, bool* success) {
+static inline ncclResult_t IbCastPortRecoveryHandleCompletionReceiver(struct ncclIbPortRecoveryContext* recoveryContext,
+                                                                      struct ibv_wc completion, bool* success) {
   ncclResult_t res = ncclSuccess;
-  INFO(NCCL_NET, "NET/IB: %s: Receiver received completion for device %d (comm=%p, wr_id=%lu, opcode=%s, imm_data=%u)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, completion.wr_id, ibvWcOpcodeStr(completion.opcode), completion.imm_data);
+  INFO(NCCL_NET, "NET/IB: %s: Receiver received completion for device %d (comm=%p, wr_id=%lu, opcode=%s, imm_data=%u)",
+       __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, completion.wr_id,
+       ibvWcOpcodeStr(completion.opcode), completion.imm_data);
   if (recoveryContext->state == ncclIbPortRecoveryStateAliveMessages) {
     if (recoveryContext->ackPosted) {
       // Receiver waits for it's own local ACK completion
       if (completion.opcode == IBV_WC_RECV) {
-        INFO(NCCL_NET, "NET/IB: %s: Receiver expected local completion of ACK message for device %d (comm=%p) but got completion with opcode: %s", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, ibvWcOpcodeStr(completion.opcode));
-        res = IbCastPortRecoveryPostRecvWorkRequest(recoveryContext->resCtx->portRecoveryQps[recoveryContext->devIndex].qp, &recoveryContext->resCtx->devs[recoveryContext->devIndex]);
+        INFO(NCCL_NET,
+             "NET/IB: %s: Receiver expected local completion of ACK message for device %d (comm=%p) but got completion "
+             "with opcode: %s",
+             __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, ibvWcOpcodeStr(completion.opcode));
+        res =
+          IbCastPortRecoveryPostRecvWorkRequest(recoveryContext->resCtx->portRecoveryQps[recoveryContext->devIndex].qp,
+                                                &recoveryContext->resCtx->devs[recoveryContext->devIndex]);
         if (res != ncclSuccess) {
-          INFO(NCCL_NET, "NET/IB: %s: Receiver failed to post recv WR on data QP for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+          INFO(NCCL_NET, "NET/IB: %s: Receiver failed to post recv WR on data QP for device %d (comm=%p)", __func__,
+               recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
           *success = false;
           return ncclSuccess;
         }
@@ -551,7 +616,8 @@ static inline ncclResult_t IbCastPortRecoveryHandleCompletionReceiver(struct ncc
       }
       assert(completion.opcode == IBV_WC_SEND);
       recoveryContext->ackCompleted = true;
-      INFO(NCCL_NET, "NET/IB: %s: Receiver's ACK message completed locally for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Receiver's ACK message completed locally for device %d (comm=%p)", __func__,
+           recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
     } else {
       assert(completion.opcode == IBV_WC_RECV);
       uint32_t id = completion.imm_data;
@@ -559,19 +625,27 @@ static inline ncclResult_t IbCastPortRecoveryHandleCompletionReceiver(struct ncc
       uint32_t windowEnd = recoveryContext->recv.windowBase + seqSize;
       if (id >= recoveryContext->recv.windowBase && id < windowEnd) {
         recoveryContext->recv.receivedBits |= (1u << (id - recoveryContext->recv.windowBase));
-        INFO(NCCL_NET, "NET/IB: %s: Receiver got alive message %u in window [%u,%u) for device %d (bits=0x%x, comm=%p)", __func__, id, recoveryContext->recv.windowBase, windowEnd, recoveryContext->devIndex, recoveryContext->recv.receivedBits, recoveryContext->resCtx->baseComm);
+        INFO(NCCL_NET, "NET/IB: %s: Receiver got alive message %u in window [%u,%u) for device %d (bits=0x%x, comm=%p)",
+             __func__, id, recoveryContext->recv.windowBase, windowEnd, recoveryContext->devIndex,
+             recoveryContext->recv.receivedBits, recoveryContext->resCtx->baseComm);
       } else if (id >= windowEnd) {
         uint32_t newBase = id - (id % seqSize);
         recoveryContext->recv.windowBase = newBase;
         recoveryContext->recv.receivedBits = (1u << (id - newBase));
-        INFO(NCCL_NET, "NET/IB: %s: Receiver shifted window to [%u,%u) on alive message %u for device %d (comm=%p)", __func__, newBase, newBase + seqSize, id, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+        INFO(NCCL_NET, "NET/IB: %s: Receiver shifted window to [%u,%u) on alive message %u for device %d (comm=%p)",
+             __func__, newBase, newBase + seqSize, id, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
       } else {
-        INFO(NCCL_NET, "NET/IB: %s: Receiver ignoring stale alive message %u (window base=%u) for device %d (comm=%p)", __func__, id, recoveryContext->recv.windowBase, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+        INFO(NCCL_NET, "NET/IB: %s: Receiver ignoring stale alive message %u (window base=%u) for device %d (comm=%p)",
+             __func__, id, recoveryContext->recv.windowBase, recoveryContext->devIndex,
+             recoveryContext->resCtx->baseComm);
       }
       recoveryContext->timeLastMsg = clockNano();
-      res = IbCastPortRecoveryPostRecvWorkRequest(recoveryContext->resCtx->portRecoveryQps[recoveryContext->devIndex].qp, &recoveryContext->resCtx->devs[recoveryContext->devIndex]);
+      res =
+        IbCastPortRecoveryPostRecvWorkRequest(recoveryContext->resCtx->portRecoveryQps[recoveryContext->devIndex].qp,
+                                              &recoveryContext->resCtx->devs[recoveryContext->devIndex]);
       if (res != ncclSuccess) {
-          INFO(NCCL_NET, "NET/IB: %s: Receiver failed to post recv WR on recovery QP for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+        INFO(NCCL_NET, "NET/IB: %s: Receiver failed to post recv WR on recovery QP for device %d (comm=%p)", __func__,
+             recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
         *success = false;
         return ncclSuccess;
       }
@@ -580,7 +654,8 @@ static inline ncclResult_t IbCastPortRecoveryHandleCompletionReceiver(struct ncc
   if (recoveryContext->state == ncclIbPortRecoveryStateAck) {
     assert(completion.opcode == IBV_WC_RECV);
     assert(completion.imm_data == NCCL_IB_RESILIENCY_PORT_RECOVERY_ACK_MSG_ID);
-    INFO(NCCL_NET, "NET/IB: %s: Receiver received final ACK message for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+    INFO(NCCL_NET, "NET/IB: %s: Receiver received final ACK message for device %d (comm=%p)", __func__,
+         recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
     IbCastPortRecoveryExtractQpnsAinic(recoveryContext, &completion);
     recoveryContext->ackReceived = true;
   }
@@ -588,15 +663,20 @@ static inline ncclResult_t IbCastPortRecoveryHandleCompletionReceiver(struct ncc
   return ncclSuccess;
 }
 
-static inline ncclResult_t IbCastPortRecoveryHandleCompletionSender(struct ncclIbPortRecoveryContext* recoveryContext, struct ibv_wc completion, bool* success) {
-  INFO(NCCL_NET, "NET/IB: %s: Sender received completion for device %d (comm=%p, wr_id=%lu, opcode=%s, imm_data=%u)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, completion.wr_id, ibvWcOpcodeStr(completion.opcode), completion.imm_data);
+static inline ncclResult_t IbCastPortRecoveryHandleCompletionSender(struct ncclIbPortRecoveryContext* recoveryContext,
+                                                                    struct ibv_wc completion, bool* success) {
+  INFO(NCCL_NET, "NET/IB: %s: Sender received completion for device %d (comm=%p, wr_id=%lu, opcode=%s, imm_data=%u)",
+       __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, completion.wr_id,
+       ibvWcOpcodeStr(completion.opcode), completion.imm_data);
   if (recoveryContext->state == ncclIbPortRecoveryStateAliveMessages) {
     if (completion.opcode == IBV_WC_SEND) {
       assert(!recoveryContext->send.aliveMsgCompleted);
-      INFO(NCCL_NET, "NET/IB: %s: Sender's alive messages batch completed locally for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Sender's alive messages batch completed locally for device %d (comm=%p)", __func__,
+           recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
       recoveryContext->send.aliveMsgCompleted = true;
     } else {
-      INFO(NCCL_NET, "NET/IB: %s: Sender received unexpected message completion for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Sender received unexpected message completion for device %d (comm=%p)", __func__,
+           recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
       *success = false;
       return ncclSuccess;
     }
@@ -606,7 +686,8 @@ static inline ncclResult_t IbCastPortRecoveryHandleCompletionSender(struct ncclI
       // Sender waits for ACK from receiver
       assert(completion.opcode == IBV_WC_RECV);
       assert(completion.imm_data == NCCL_IB_RESILIENCY_PORT_RECOVERY_ACK_MSG_ID);
-      INFO(NCCL_NET, "NET/IB: %s: Sender received an ACK message from the receiver for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Sender received an ACK message from the receiver for device %d (comm=%p)", __func__,
+           recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
       IbCastPortRecoveryExtractQpnsAinic(recoveryContext, &completion);
       recoveryContext->ackReceived = true;
       *success = true;
@@ -614,7 +695,8 @@ static inline ncclResult_t IbCastPortRecoveryHandleCompletionSender(struct ncclI
     } else {
       // Sender waits for it's own local final ACK completion
       assert(completion.opcode == IBV_WC_SEND);
-      INFO(NCCL_NET, "NET/IB: %s: Sender's final ACK message completed locally for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Sender's final ACK message completed locally for device %d (comm=%p)", __func__,
+           recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
       recoveryContext->ackCompleted = true;
       *success = true;
       return ncclSuccess;
@@ -630,7 +712,8 @@ static inline ncclResult_t IbCastPortRecoveryPollCq(struct ncclIbPortRecoveryCon
 
   ncclResult_t ret = wrap_ibv_poll_cq(recoveryContext->recoveryCq, 1, &completion, &completions);
   if (ret != ncclSuccess) {
-    INFO(NCCL_NET, "NET/IB: %s: Failed to poll recovery CQ %p for device %d (comm=%p)", __func__, recoveryContext->recoveryCq, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+    INFO(NCCL_NET, "NET/IB: %s: Failed to poll recovery CQ %p for device %d (comm=%p)", __func__,
+         recoveryContext->recoveryCq, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
     *success = false;
     return ncclSuccess;
   }
@@ -642,7 +725,8 @@ static inline ncclResult_t IbCastPortRecoveryPollCq(struct ncclIbPortRecoveryCon
 
   if (completion.status != IBV_WC_SUCCESS) {
     *success = false;
-    INFO(NCCL_NET, "NET/IB: %s: Work completion error on recovery CQ %p: status=%s(%d)", __func__, recoveryContext->recoveryCq, ibvWcStatusStr(completion.status), completion.status);
+    INFO(NCCL_NET, "NET/IB: %s: Work completion error on recovery CQ %p: status=%s(%d)", __func__,
+         recoveryContext->recoveryCq, ibvWcStatusStr(completion.status), completion.status);
     return ncclSuccess;
   }
 
@@ -652,7 +736,9 @@ static inline ncclResult_t IbCastPortRecoveryPollCq(struct ncclIbPortRecoveryCon
     NCCLCHECK(IbCastPortRecoveryHandleCompletionReceiver(recoveryContext, completion, success));
   }
   if (!*success) {
-    INFO(NCCL_NET, "NET/IB: %s: Failed to handle %s completion for device %d (comm=%p, wc.opcode=%s(%d), wc.wr_id=%ld)", __func__, recoveryContext->resCtx->baseComm->isSend ? "sender" : "receiver", recoveryContext->devIndex, recoveryContext->resCtx->baseComm, ibvWcOpcodeStr(completion.opcode), completion.opcode, completion.wr_id);
+    INFO(NCCL_NET, "NET/IB: %s: Failed to handle %s completion for device %d (comm=%p, wc.opcode=%s(%d), wc.wr_id=%ld)",
+         __func__, recoveryContext->resCtx->baseComm->isSend ? "sender" : "receiver", recoveryContext->devIndex,
+         recoveryContext->resCtx->baseComm, ibvWcOpcodeStr(completion.opcode), completion.opcode, completion.wr_id);
   }
   return ncclSuccess;
 }
@@ -664,12 +750,14 @@ enum ncclIbPortRecoveryStateProgressResult {
   ncclIbPortRecoveryStateProgressResultFailed
 };
 
-static inline ncclResult_t IbCastPortRecoveryPostAliveMessages(struct ncclIbPortRecoveryContext* recoveryContext, bool* success) {
-  struct ibv_send_wr *bad_wr = NULL;
+static inline ncclResult_t IbCastPortRecoveryPostAliveMessages(struct ncclIbPortRecoveryContext* recoveryContext,
+                                                               bool* success) {
+  struct ibv_send_wr* bad_wr = NULL;
   struct ibv_send_wr wr[NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX];
   int nMsgsToPost = ncclParamIbCastResiliencyPortRecoveryAliveMsgSequenceSize();
   if (nMsgsToPost > NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX) {
-    WARN("NET/IB: %s: Requested alive message batch size %d exceeds maximum supported %d", __func__, nMsgsToPost, NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX);
+    WARN("NET/IB: %s: Requested alive message batch size %d exceeds maximum supported %d", __func__, nMsgsToPost,
+         NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX);
     return ncclInternalError;
   }
   int devIdx = recoveryContext->devIndex;
@@ -689,14 +777,16 @@ static inline ncclResult_t IbCastPortRecoveryPostAliveMessages(struct ncclIbPort
     } else {
       wr[i].next = NULL;
     }
-    INFO(NCCL_NET, "NET/IB: %s: Sender prepared alive message %u for device %d (comm=%p)", __func__, recoveryContext->aliveMsgNextId, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+    INFO(NCCL_NET, "NET/IB: %s: Sender prepared alive message %u for device %d (comm=%p)", __func__,
+         recoveryContext->aliveMsgNextId, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
     recoveryContext->aliveMsgNextId++;
   }
 
   // Post the send operation on the recovery QP.
   struct ncclIbQp* recoveryQp = &recoveryContext->resCtx->portRecoveryQps[recoveryContext->devIndex];
   if (wrap_ibv_post_send(recoveryQp->qp, &wr[0], &bad_wr) != ncclSuccess) {
-    INFO(NCCL_NET, "NET/IB: %s: Sender failed to post alive messages batch on device %d (comm=%p, qp_num=%u)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryQp->qp->qp_num);
+    INFO(NCCL_NET, "NET/IB: %s: Sender failed to post alive messages batch on device %d (comm=%p, qp_num=%u)", __func__,
+         recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryQp->qp->qp_num);
     *success = false;
     return ncclSuccess;
   }
@@ -711,7 +801,7 @@ static inline ncclResult_t IbCastPortRecoveryPostAck(ncclIbPortRecoveryContext* 
   if (IbCastAinicRoce) {
     return IbCastPortRecoveryPostAckWithQpnsAinic(recoveryContext, success);
   }
-  struct ibv_send_wr *bad_wr = NULL;
+  struct ibv_send_wr* bad_wr = NULL;
   struct ibv_send_wr wr;
   memset(&wr, 0, sizeof(wr));
   int devIdx = recoveryContext->devIndex;
@@ -725,12 +815,15 @@ static inline ncclResult_t IbCastPortRecoveryPostAck(ncclIbPortRecoveryContext* 
   wr.wr.ud.remote_qpn = recoveryContext->resCtx->portRecoveryRemoteQpn[devIdx];
   wr.wr.ud.remote_qkey = NCCL_IB_RECOVERY_QKEY;
 
-  INFO(NCCL_NET, "NET/IB: %s: %s posting ACK message for device %d (comm=%p)", __func__, recoveryContext->resCtx->baseComm->isSend ? "Sender" : "Receiver", recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+  INFO(NCCL_NET, "NET/IB: %s: %s posting ACK message for device %d (comm=%p)", __func__,
+       recoveryContext->resCtx->baseComm->isSend ? "Sender" : "Receiver", recoveryContext->devIndex,
+       recoveryContext->resCtx->baseComm);
 
   // Post the send operation on the recovery QP.
   struct ncclIbQp* recoveryQp = &recoveryContext->resCtx->portRecoveryQps[recoveryContext->devIndex];
   if (wrap_ibv_post_send(recoveryQp->qp, &wr, &bad_wr) != ncclSuccess) {
-    INFO(NCCL_NET, "NET/IB: %s: Failed to post ack message on device %d (comm=%p, qp_num=%u)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryQp->qp->qp_num);
+    INFO(NCCL_NET, "NET/IB: %s: Failed to post ack message on device %d (comm=%p, qp_num=%u)", __func__,
+         recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryQp->qp->qp_num);
     *success = false;
     return ncclSuccess;
   }
@@ -739,22 +832,26 @@ static inline ncclResult_t IbCastPortRecoveryPostAck(ncclIbPortRecoveryContext* 
   return ncclSuccess;
 }
 
-static inline ncclResult_t IbCastPortRecoveryProgressAliveMessagesSender(ncclIbPortRecoveryContext* recoveryContext, enum ncclIbPortRecoveryStateProgressResult* outResult) {
+static inline ncclResult_t IbCastPortRecoveryProgressAliveMessagesSender(
+  ncclIbPortRecoveryContext* recoveryContext, enum ncclIbPortRecoveryStateProgressResult* outResult) {
   // Sender can either post new alive messages or poll for completions of previously
   // posted alive messages.
   if (!recoveryContext->send.aliveMsgPosted) {
     // Check if sender should send a new batch of alive messages
     uint64_t now = clockNano();
-    if (now - recoveryContext->timeLastMsg < ncclParamIbCastResiliencyPortRecoveryAliveMsgBatchInterval() * MSEC_TO_NSEC) {
+    if (now - recoveryContext->timeLastMsg <
+        ncclParamIbCastResiliencyPortRecoveryAliveMsgBatchInterval() * MSEC_TO_NSEC) {
       *outResult = ncclIbPortRecoveryStateProgressResultInProgress;
       return ncclSuccess;
     }
     // Post a new batch of alive messages
-    INFO(NCCL_NET, "NET/IB: %s: Posting alive message batch for device %d (comm=%p, devIndex=%d)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex);
+    INFO(NCCL_NET, "NET/IB: %s: Posting alive message batch for device %d (comm=%p, devIndex=%d)", __func__,
+         recoveryContext->devIndex, recoveryContext->resCtx->baseComm, recoveryContext->devIndex);
     bool success = false;
     NCCLCHECK(IbCastPortRecoveryPostAliveMessages(recoveryContext, &success));
     if (!success) {
-      INFO(NCCL_NET, "NET/IB: %s: Failed to post alive messages batch for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Failed to post alive messages batch for device %d (comm=%p)", __func__,
+           recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
       *outResult = ncclIbPortRecoveryStateProgressResultFailed;
       return ncclSuccess;
     }
@@ -764,12 +861,14 @@ static inline ncclResult_t IbCastPortRecoveryProgressAliveMessagesSender(ncclIbP
     bool success = false;
     NCCLCHECK(IbCastPortRecoveryPollCq(recoveryContext, &success));
     if (!success) {
-      INFO(NCCL_NET, "NET/IB: %s: Failed to poll CQ for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Failed to poll CQ for device %d (comm=%p)", __func__, recoveryContext->devIndex,
+           recoveryContext->resCtx->baseComm);
       *outResult = ncclIbPortRecoveryStateProgressResultFailed;
       return ncclSuccess;
     }
     if (recoveryContext->send.aliveMsgCompleted) {
-      INFO(NCCL_NET, "NET/IB: %s: Sender marked that alive messages batch completed for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Sender marked that alive messages batch completed for device %d (comm=%p)", __func__,
+           recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
       *outResult = ncclIbPortRecoveryStateProgressResultGoToNextState;
     } else {
       *outResult = ncclIbPortRecoveryStateProgressResultInProgress;
@@ -778,13 +877,15 @@ static inline ncclResult_t IbCastPortRecoveryProgressAliveMessagesSender(ncclIbP
   return ncclSuccess;
 }
 
-static inline ncclResult_t IbCastPortRecoveryProgressAliveMessagesReceiver(ncclIbPortRecoveryContext* recoveryContext, enum ncclIbPortRecoveryStateProgressResult* outResult) {
+static inline ncclResult_t IbCastPortRecoveryProgressAliveMessagesReceiver(
+  ncclIbPortRecoveryContext* recoveryContext, enum ncclIbPortRecoveryStateProgressResult* outResult) {
   bool success = false;
   ncclResult_t res = ncclSuccess;
   if (recoveryContext->ackPosted == false) {
     NCCLCHECK(IbCastPortRecoveryPollCq(recoveryContext, &success));
     if (!success) {
-      INFO(NCCL_NET, "NET/IB: %s: Failed to poll CQ for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Failed to poll CQ for device %d (comm=%p)", __func__, recoveryContext->devIndex,
+           recoveryContext->resCtx->baseComm);
       *outResult = ncclIbPortRecoveryStateProgressResultFailed;
       return ncclSuccess;
     }
@@ -796,20 +897,26 @@ static inline ncclResult_t IbCastPortRecoveryProgressAliveMessagesReceiver(ncclI
       // previous state, it will not see stale alive messages.
       NCCLCHECK(IbCastPortRecoveryDrainCqAndPostReceiveWRs(recoveryContext, &success));
       if (!success) {
-        INFO(NCCL_NET, "NET/IB: %s: Failed to drain CQ and post recv WRs for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+        INFO(NCCL_NET, "NET/IB: %s: Failed to drain CQ and post recv WRs for device %d (comm=%p)", __func__,
+             recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
         *outResult = ncclIbPortRecoveryStateProgressResultFailed;
         return ncclSuccess;
       }
-      INFO(NCCL_NET, "NET/IB: %s: Receiver received enough in-order alive messages for device %d (comm=%p). Restoring QPs and posting ACK message.", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET,
+           "NET/IB: %s: Receiver received enough in-order alive messages for device %d (comm=%p). Restoring QPs and "
+           "posting ACK message.",
+           __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
       NCCLCHECK(IbCastPortRecoveryQpsRestore(recoveryContext, &success));
       if (!success) {
-        INFO(NCCL_NET, "NET/IB: %s: Receiver failed to restore QPs on device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+        INFO(NCCL_NET, "NET/IB: %s: Receiver failed to restore QPs on device %d (comm=%p)", __func__,
+             recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
         *outResult = ncclIbPortRecoveryStateProgressResultFailed;
         return ncclSuccess;
       }
       NCCLCHECK(IbCastPortRecoveryPostAck(recoveryContext, &success));
       if (!success) {
-        INFO(NCCL_NET, "NET/IB: %s: Failed to post ACK message for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+        INFO(NCCL_NET, "NET/IB: %s: Failed to post ACK message for device %d (comm=%p)", __func__,
+             recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
         *outResult = ncclIbPortRecoveryStateProgressResultFailed;
         return ncclSuccess;
       }
@@ -818,9 +925,13 @@ static inline ncclResult_t IbCastPortRecoveryProgressAliveMessagesReceiver(ncclI
       uint64_t now = clockNano();
       if (now - recoveryContext->timeLastMsg > ncclParamIbCastResiliencyPortRecoveryAliveMsgTimeout() * MSEC_TO_NSEC) {
         recoveryContext->nFailedAttempts++;
-        INFO(NCCL_NET, "NET/IB: %s: Alive message sequence timeout for device %d (%s comm=%p, failedAttempts=%d)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm, recoveryContext->nFailedAttempts);
+        INFO(NCCL_NET, "NET/IB: %s: Alive message sequence timeout for device %d (%s comm=%p, failedAttempts=%d)",
+             __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv",
+             recoveryContext->resCtx->baseComm, recoveryContext->nFailedAttempts);
         if (recoveryContext->nFailedAttempts >= ncclParamIbCastResiliencyPortRecoveryAttemptsMax()) {
-          INFO(NCCL_NET, "NET/IB: %s: Recovery for device %d failed due to max attempts reached (%s comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
+          INFO(NCCL_NET, "NET/IB: %s: Recovery for device %d failed due to max attempts reached (%s comm=%p)", __func__,
+               recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv",
+               recoveryContext->resCtx->baseComm);
           *outResult = ncclIbPortRecoveryStateProgressResultFailed;
           return ncclSuccess;
         }
@@ -833,7 +944,8 @@ static inline ncclResult_t IbCastPortRecoveryProgressAliveMessagesReceiver(ncclI
     bool success = false;
     NCCLCHECK(IbCastPortRecoveryPollCq(recoveryContext, &success));
     if (!success) {
-      INFO(NCCL_NET, "NET/IB: %s: Failed to poll CQ for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Failed to poll CQ for device %d (comm=%p)", __func__, recoveryContext->devIndex,
+           recoveryContext->resCtx->baseComm);
       *outResult = ncclIbPortRecoveryStateProgressResultFailed;
       return ncclSuccess;
     }
@@ -843,9 +955,13 @@ static inline ncclResult_t IbCastPortRecoveryProgressAliveMessagesReceiver(ncclI
       uint64_t now = clockNano();
       if (now - recoveryContext->timeLastMsg > ncclParamIbCastResiliencyPortRecoveryAckTimeout() * MSEC_TO_NSEC) {
         recoveryContext->nFailedAttempts++;
-        INFO(NCCL_NET, "NET/IB: %s: ACK message timeout for device %d (%s comm=%p, failedAttempts=%d)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm, recoveryContext->nFailedAttempts);
+        INFO(NCCL_NET, "NET/IB: %s: ACK message timeout for device %d (%s comm=%p, failedAttempts=%d)", __func__,
+             recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv",
+             recoveryContext->resCtx->baseComm, recoveryContext->nFailedAttempts);
         if (recoveryContext->nFailedAttempts >= ncclParamIbCastResiliencyPortRecoveryAttemptsMax()) {
-          INFO(NCCL_NET, "NET/IB: %s: Recovery for device %d failed due to max attempts reached (%s comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
+          INFO(NCCL_NET, "NET/IB: %s: Recovery for device %d failed due to max attempts reached (%s comm=%p)", __func__,
+               recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv",
+               recoveryContext->resCtx->baseComm);
           *outResult = ncclIbPortRecoveryStateProgressResultFailed;
           return ncclSuccess;
         }
@@ -860,11 +976,16 @@ static inline ncclResult_t IbCastPortRecoveryProgressAliveMessagesReceiver(ncclI
         recoveryContext->nRemoteQpns = 0;
         recoveryContext->timeLastMsg = now;
         *outResult = ncclIbPortRecoveryStateProgressResultGoToPrevState;
-        INFO(NCCL_NET, "NET/IB: %s: Receiver posting (%d) recv WRs on device %d (comm=%p)", __func__, NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+        INFO(NCCL_NET, "NET/IB: %s: Receiver posting (%d) recv WRs on device %d (comm=%p)", __func__,
+             NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX, recoveryContext->devIndex,
+             recoveryContext->resCtx->baseComm);
         for (int i = 0; i < NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX; i++) {
-          res = IbCastPortRecoveryPostRecvWorkRequest(recoveryContext->resCtx->portRecoveryQps[recoveryContext->devIndex].qp, &recoveryContext->resCtx->devs[recoveryContext->devIndex]);
+          res = IbCastPortRecoveryPostRecvWorkRequest(
+            recoveryContext->resCtx->portRecoveryQps[recoveryContext->devIndex].qp,
+            &recoveryContext->resCtx->devs[recoveryContext->devIndex]);
           if (res != ncclSuccess) {
-            INFO(NCCL_NET, "NET/IB: %s: Receiver failed to post recv WR on recovery QP for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+            INFO(NCCL_NET, "NET/IB: %s: Receiver failed to post recv WR on recovery QP for device %d (comm=%p)",
+                 __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
             *outResult = ncclIbPortRecoveryStateProgressResultFailed;
             return ncclSuccess;
           }
@@ -885,30 +1006,37 @@ static inline ncclResult_t IbCastPortRecoveryProgressAliveMessages(ncclIbPortRec
     NCCLCHECK(IbCastPortRecoveryProgressAliveMessagesReceiver(recoveryContext, &progressResult));
   }
   switch (progressResult) {
-    case ncclIbPortRecoveryStateProgressResultGoToPrevState:
-      WARN("NET/IB: %s: Unexpected GoToPrevState result in AliveMessages state for device %d (%s comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
-      return ncclInternalError;
-    case ncclIbPortRecoveryStateProgressResultGoToNextState:
-      INFO(NCCL_NET, "NET/IB: %s: Alive messages phase completed for device %d. Moving to next phase (%s comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
-      recoveryContext->state = ncclIbPortRecoveryStateAck;
-      break;
-    case ncclIbPortRecoveryStateProgressResultFailed:
-      INFO(NCCL_NET, "NET/IB: %s: Recovery for device %d failed (%s comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
-      recoveryContext->state = ncclIbPortRecoveryStateFailed;
-      break;
-    case ncclIbPortRecoveryStateProgressResultInProgress:
-      // Do nothing
-      break;
+  case ncclIbPortRecoveryStateProgressResultGoToPrevState:
+    WARN("NET/IB: %s: Unexpected GoToPrevState result in AliveMessages state for device %d (%s comm=%p)", __func__,
+         recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv",
+         recoveryContext->resCtx->baseComm);
+    return ncclInternalError;
+  case ncclIbPortRecoveryStateProgressResultGoToNextState:
+    INFO(NCCL_NET, "NET/IB: %s: Alive messages phase completed for device %d. Moving to next phase (%s comm=%p)",
+         __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv",
+         recoveryContext->resCtx->baseComm);
+    recoveryContext->state = ncclIbPortRecoveryStateAck;
+    break;
+  case ncclIbPortRecoveryStateProgressResultFailed:
+    INFO(NCCL_NET, "NET/IB: %s: Recovery for device %d failed (%s comm=%p)", __func__, recoveryContext->devIndex,
+         recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
+    recoveryContext->state = ncclIbPortRecoveryStateFailed;
+    break;
+  case ncclIbPortRecoveryStateProgressResultInProgress:
+    // Do nothing
+    break;
   }
   return ncclSuccess;
 }
 
-static inline ncclResult_t IbCastPortRecoveryProgressAckSender(ncclIbPortRecoveryContext* recoveryContext, enum ncclIbPortRecoveryStateProgressResult* outResult) {
+static inline ncclResult_t IbCastPortRecoveryProgressAckSender(ncclIbPortRecoveryContext* recoveryContext,
+                                                               enum ncclIbPortRecoveryStateProgressResult* outResult) {
   bool success = false;
   if (!recoveryContext->ackReceived) {
     NCCLCHECK(IbCastPortRecoveryPollCq(recoveryContext, &success));
     if (!success) {
-      INFO(NCCL_NET, "NET/IB: %s: Failed to poll CQ for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Failed to poll CQ for device %d (comm=%p)", __func__, recoveryContext->devIndex,
+           recoveryContext->resCtx->baseComm);
       *outResult = ncclIbPortRecoveryStateProgressResultFailed;
       return ncclSuccess;
     }
@@ -917,9 +1045,11 @@ static inline ncclResult_t IbCastPortRecoveryProgressAckSender(ncclIbPortRecover
       uint64_t now = clockNano();
       if (now - recoveryContext->timeLastMsg > ncclParamIbCastResiliencyPortRecoveryAckTimeout() * MSEC_TO_NSEC) {
         recoveryContext->nFailedAttempts++;
-        INFO(NCCL_NET, "NET/IB: %s: Port recovery attempt #%d failed for devIndex=%d (comm=%p)", __func__, recoveryContext->nFailedAttempts, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+        INFO(NCCL_NET, "NET/IB: %s: Port recovery attempt #%d failed for devIndex=%d (comm=%p)", __func__,
+             recoveryContext->nFailedAttempts, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
         if (recoveryContext->nFailedAttempts >= ncclParamIbCastResiliencyPortRecoveryAttemptsMax()) {
-          INFO(NCCL_NET, "NET/IB: %s: Recovery for device %d failed due to max attempts reached (send comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+          INFO(NCCL_NET, "NET/IB: %s: Recovery for device %d failed due to max attempts reached (send comm=%p)",
+               __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
           *outResult = ncclIbPortRecoveryStateProgressResultFailed;
           return ncclSuccess;
         }
@@ -937,13 +1067,15 @@ static inline ncclResult_t IbCastPortRecoveryProgressAckSender(ncclIbPortRecover
   if (recoveryContext->ackPosted == false) {
     NCCLCHECK(IbCastPortRecoveryQpsRestore(recoveryContext, &success));
     if (!success) {
-      INFO(NCCL_NET, "NET/IB: %s: Sender failed to restore QPs on device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Sender failed to restore QPs on device %d (comm=%p)", __func__,
+           recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
       *outResult = ncclIbPortRecoveryStateProgressResultFailed;
       return ncclSuccess;
     }
     NCCLCHECK(IbCastPortRecoveryPostAck(recoveryContext, &success));
     if (!success) {
-      INFO(NCCL_NET, "NET/IB: %s: Failed to post ack for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Failed to post ack for device %d (comm=%p)", __func__, recoveryContext->devIndex,
+           recoveryContext->resCtx->baseComm);
       *outResult = ncclIbPortRecoveryStateProgressResultFailed;
       return ncclSuccess;
     }
@@ -953,7 +1085,8 @@ static inline ncclResult_t IbCastPortRecoveryProgressAckSender(ncclIbPortRecover
   if (!recoveryContext->ackCompleted) {
     NCCLCHECK(IbCastPortRecoveryPollCq(recoveryContext, &success));
     if (!success) {
-      INFO(NCCL_NET, "NET/IB: %s: Failed to poll CQ for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Failed to poll CQ for device %d (comm=%p)", __func__, recoveryContext->devIndex,
+           recoveryContext->resCtx->baseComm);
       *outResult = ncclIbPortRecoveryStateProgressResultFailed;
       return ncclSuccess;
     }
@@ -966,11 +1099,13 @@ static inline ncclResult_t IbCastPortRecoveryProgressAckSender(ncclIbPortRecover
   return ncclSuccess;
 }
 
-static inline ncclResult_t IbCastPortRecoveryProgressAckReceiver(ncclIbPortRecoveryContext* recoveryContext, enum ncclIbPortRecoveryStateProgressResult* outResult) {
+static inline ncclResult_t IbCastPortRecoveryProgressAckReceiver(
+  ncclIbPortRecoveryContext* recoveryContext, enum ncclIbPortRecoveryStateProgressResult* outResult) {
   bool success = false;
   NCCLCHECK(IbCastPortRecoveryPollCq(recoveryContext, &success));
   if (!success) {
-    INFO(NCCL_NET, "NET/IB: %s: Failed to poll CQ for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+    INFO(NCCL_NET, "NET/IB: %s: Failed to poll CQ for device %d (comm=%p)", __func__, recoveryContext->devIndex,
+         recoveryContext->resCtx->baseComm);
     *outResult = ncclIbPortRecoveryStateProgressResultFailed;
     return ncclSuccess;
   }
@@ -979,7 +1114,8 @@ static inline ncclResult_t IbCastPortRecoveryProgressAckReceiver(ncclIbPortRecov
     uint64_t now = clockNano();
     if (now - recoveryContext->timeLastMsg > ncclParamIbCastResiliencyPortRecoveryAckTimeout() * MSEC_TO_NSEC) {
       recoveryContext->nFailedAttempts++;
-      INFO(NCCL_NET, "NET/IB: %s: Port recovery attempt #%d failed for devIndex=%d (comm=%p)", __func__, recoveryContext->nFailedAttempts, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Port recovery attempt #%d failed for devIndex=%d (comm=%p)", __func__,
+           recoveryContext->nFailedAttempts, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
       if (recoveryContext->nFailedAttempts >= ncclParamIbCastResiliencyPortRecoveryAttemptsMax()) {
         *outResult = ncclIbPortRecoveryStateProgressResultFailed;
         return ncclSuccess;
@@ -994,7 +1130,8 @@ static inline ncclResult_t IbCastPortRecoveryProgressAckReceiver(ncclIbPortRecov
       recoveryContext->nRemoteQpns = 0;
       NCCLCHECK(IbCastPortRecoveryDrainCqAndPostReceiveWRs(recoveryContext, &success));
       if (!success) {
-        INFO(NCCL_NET, "NET/IB: %s: Failed to drain CQ and post recv WRs for device %d (comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
+        INFO(NCCL_NET, "NET/IB: %s: Failed to drain CQ and post recv WRs for device %d (comm=%p)", __func__,
+             recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
         *outResult = ncclIbPortRecoveryStateProgressResultFailed;
         return ncclSuccess;
       }
@@ -1017,26 +1154,31 @@ static inline ncclResult_t IbCastPortRecoveryProgressAck(ncclIbPortRecoveryConte
     NCCLCHECK(IbCastPortRecoveryProgressAckReceiver(recoveryContext, &progressResult));
   }
   switch (progressResult) {
-    case ncclIbPortRecoveryStateProgressResultGoToPrevState:
-      INFO(NCCL_NET, "NET/IB: %s: Restarting alive messages phase for device %d (%s comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
-      recoveryContext->state = ncclIbPortRecoveryStateAliveMessages;
-      break;
-    case ncclIbPortRecoveryStateProgressResultGoToNextState:
-      INFO(NCCL_NET, "NET/IB: %s: ACK phase completed for device %d (%s comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
-      recoveryContext->state = ncclIbPortRecoveryStateSuccess;
-      break;
-    case ncclIbPortRecoveryStateProgressResultFailed:
-      INFO(NCCL_NET, "NET/IB: %s: Recovery for device %d failed (%s comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
-      recoveryContext->state = ncclIbPortRecoveryStateFailed;
-      break;
-    case ncclIbPortRecoveryStateProgressResultInProgress:
-      // Do nothing
-      break;
+  case ncclIbPortRecoveryStateProgressResultGoToPrevState:
+    INFO(NCCL_NET, "NET/IB: %s: Restarting alive messages phase for device %d (%s comm=%p)", __func__,
+         recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv",
+         recoveryContext->resCtx->baseComm);
+    recoveryContext->state = ncclIbPortRecoveryStateAliveMessages;
+    break;
+  case ncclIbPortRecoveryStateProgressResultGoToNextState:
+    INFO(NCCL_NET, "NET/IB: %s: ACK phase completed for device %d (%s comm=%p)", __func__, recoveryContext->devIndex,
+         recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
+    recoveryContext->state = ncclIbPortRecoveryStateSuccess;
+    break;
+  case ncclIbPortRecoveryStateProgressResultFailed:
+    INFO(NCCL_NET, "NET/IB: %s: Recovery for device %d failed (%s comm=%p)", __func__, recoveryContext->devIndex,
+         recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
+    recoveryContext->state = ncclIbPortRecoveryStateFailed;
+    break;
+  case ncclIbPortRecoveryStateProgressResultInProgress:
+    // Do nothing
+    break;
   }
   return ncclSuccess;
 }
 
-static inline ncclResult_t IbCastPortRecoveryContextProgress(ncclIbPortRecoveryContext* recoveryContext, bool* outDone) {
+static inline ncclResult_t IbCastPortRecoveryContextProgress(ncclIbPortRecoveryContext* recoveryContext,
+                                                             bool* outDone) {
   assert(recoveryContext);
   assert(outDone);
 
@@ -1046,9 +1188,11 @@ static inline ncclResult_t IbCastPortRecoveryContextProgress(ncclIbPortRecoveryC
       *outDone = false;
       return ncclSuccess;
     }
-    INFO(NCCL_NET, "NET/IB: %s: Starting port recovery for %s comm=%p devIndex=%d", __func__, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm, recoveryContext->devIndex);
+    INFO(NCCL_NET, "NET/IB: %s: Starting port recovery for %s comm=%p devIndex=%d", __func__,
+         recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm,
+         recoveryContext->devIndex);
     if (recoveryContext->resCtx->baseComm->isSend) {
-      recoveryContext-> timeLastMsg = 0;
+      recoveryContext->timeLastMsg = 0;
     }
     recoveryContext->state = ncclIbPortRecoveryStateAliveMessages;
   }
@@ -1062,21 +1206,27 @@ static inline ncclResult_t IbCastPortRecoveryContextProgress(ncclIbPortRecoveryC
   }
 
   if (recoveryContext->state == ncclIbPortRecoveryStateSuccess) {
-    INFO(NCCL_NET, "NET/IB: %s: Port recovery succeeded for devIndex=%d (%s comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
+    INFO(NCCL_NET, "NET/IB: %s: Port recovery succeeded for devIndex=%d (%s comm=%p)", __func__,
+         recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv",
+         recoveryContext->resCtx->baseComm);
     for (int i = 0; i < recoveryContext->resCtx->ndevs; i++) {
-        if (i != recoveryContext->devIndex) continue;
-        INFO(NCCL_NET, "NET/IB: %s: Marking device %d as recovered (%s comm=%p)", __func__, i, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
-        recoveryContext->resCtx->devs[i].state.store(ncclIbResiliencyDevStateRecovered, std::memory_order_release);
-        break;
-      }
+      if (i != recoveryContext->devIndex) continue;
+      INFO(NCCL_NET, "NET/IB: %s: Marking device %d as recovered (%s comm=%p)", __func__, i,
+           recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
+      recoveryContext->resCtx->devs[i].state.store(ncclIbResiliencyDevStateRecovered, std::memory_order_release);
+      break;
+    }
     *outDone = true;
   }
 
   if (recoveryContext->state == ncclIbPortRecoveryStateFailed) {
-    INFO(NCCL_NET, "NET/IB: %s: Port recovery failed for %s comm=%p devIndex=%d", __func__, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm, recoveryContext->devIndex);
+    INFO(NCCL_NET, "NET/IB: %s: Port recovery failed for %s comm=%p devIndex=%d", __func__,
+         recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm,
+         recoveryContext->devIndex);
     for (int i = 0; i < recoveryContext->resCtx->ndevs; i++) {
       if (i != recoveryContext->devIndex) continue;
-      INFO(NCCL_NET, "NET/IB: %s: Marking device %d as permanently failed (%s comm=%p)", __func__, i, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
+      INFO(NCCL_NET, "NET/IB: %s: Marking device %d as permanently failed (%s comm=%p)", __func__, i,
+           recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
       recoveryContext->resCtx->devs[i].state.store(ncclIbResiliencyDevStateRecoveryFailed, std::memory_order_release);
     }
     *outDone = true;
@@ -1088,18 +1238,17 @@ static inline ncclResult_t IbCastPortRecoveryContextProgress(ncclIbPortRecoveryC
 // Scan recoveryQueue and remove (destroy) any contexts belonging to the
 // resiliency contexts referenced by the close requests.
 static void IbCastPortRecoveryHandleCloseRequests(std::vector<ncclIbPortRecoveryCloseRequest*>& closeRequests,
-                                                 std::list<ncclIbPortRecoveryContext*>& recoveryQueue) {
+                                                  std::list<ncclIbPortRecoveryContext*>& recoveryQueue) {
   for (auto it = closeRequests.begin(); it != closeRequests.end(); ++it) {
     ncclIbPortRecoveryCloseRequest* closeReq = *it;
     int removedForThisReq = 0;
 
     // Iterate through the recovery queue and remove items belonging to this resCtx
-    for (auto qIt = recoveryQueue.begin(); qIt != recoveryQueue.end(); ) {
+    for (auto qIt = recoveryQueue.begin(); qIt != recoveryQueue.end();) {
       ncclIbPortRecoveryContext* recoveryContext = *qIt;
       if (recoveryContext->resCtx == closeReq->resCtx) {
         INFO(NCCL_NET, "NET/IB: %s: Removing recovery context for device %d belonging to closing resCtx (%s comm=%p)",
-             __func__, recoveryContext->devIndex,
-             recoveryContext->resCtx->baseComm->isSend ? "send" : "recv",
+             __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv",
              recoveryContext->resCtx->baseComm);
         IbCastPortRecoveryContextDestroy(recoveryContext);
         qIt = recoveryQueue.erase(qIt);
@@ -1109,8 +1258,8 @@ static void IbCastPortRecoveryHandleCloseRequests(std::vector<ncclIbPortRecovery
       }
     }
 
-    INFO(NCCL_NET, "NET/IB: %s: Close request completed for resCtx=%p, removed %d items",
-         __func__, closeReq->resCtx, removedForThisReq);
+    INFO(NCCL_NET, "NET/IB: %s: Close request completed for resCtx=%p, removed %d items", __func__, closeReq->resCtx,
+         removedForThisReq);
   }
 }
 
@@ -1130,9 +1279,7 @@ ncclResult_t IbCastPortRecoveryAsyncThreadMain() {
     {
       std::unique_lock<std::mutex> lock(IbCastPortRecoveryMutex);
       IbCastPortRecoveryCond.wait(lock, [&] {
-        return !IbCastPortRecoveryThreadActive.load() ||
-               !recoveryInbox.empty() ||
-               !recoveryQueue.empty() ||
+        return !IbCastPortRecoveryThreadActive.load() || !recoveryInbox.empty() || !recoveryQueue.empty() ||
                !recoveryCloseRequests.empty();
       });
 
@@ -1162,12 +1309,14 @@ ncclResult_t IbCastPortRecoveryAsyncThreadMain() {
     if (!IbCastPortRecoveryThreadActive.load()) break;
 
     // Iterate and advance recovery protocol on all nodes
-    for (auto it = recoveryQueue.begin(); it != recoveryQueue.end(); ) {
+    for (auto it = recoveryQueue.begin(); it != recoveryQueue.end();) {
       bool isDone = false;
       ncclIbPortRecoveryContext* recoveryContext = *it;
       NCCLCHECK(IbCastPortRecoveryContextProgress(recoveryContext, &isDone));
       if (isDone) {
-        INFO(NCCL_NET, "NET/IB: %s: Port recovery context done for device %d (%s comm=%p)", __func__, recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv", recoveryContext->resCtx->baseComm);
+        INFO(NCCL_NET, "NET/IB: %s: Port recovery context done for device %d (%s comm=%p)", __func__,
+             recoveryContext->devIndex, recoveryContext->resCtx->baseComm->isSend ? "send" : "recv",
+             recoveryContext->resCtx->baseComm);
         NCCLCHECK(IbCastPortRecoveryContextDestroy(recoveryContext));
         it = recoveryQueue.erase(it);
       } else {
@@ -1195,8 +1344,8 @@ ncclResult_t IbCastPortRecoveryAsyncThreadMain() {
 ncclResult_t IbCastPortRecoveryInit(struct ncclIbResiliency* resCtx) {
   resCtx->recoveryEnabled = IbCastPortRecoveryThreadActive.load();
   INFO(NCCL_NET, "NET/IB: %s: Port recovery %s (%s comm=%p)", __func__,
-       resCtx->recoveryEnabled ? "initialized" : "disabled",
-       resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
+       resCtx->recoveryEnabled ? "initialized" : "disabled", resCtx->baseComm->isSend ? "send" : "recv",
+       resCtx->baseComm);
   return ncclSuccess;
 }
 
@@ -1205,10 +1354,12 @@ ncclResult_t IbCastPortRecoveryClose(struct ncclIbResiliency* resCtx) {
     return ncclSuccess;
   }
   if (!IbCastPortRecoveryThreadActive.load()) {
-    INFO(NCCL_NET, "NET/IB: %s: Recovery thread already stopped, skipping close (%s comm=%p)", __func__, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
+    INFO(NCCL_NET, "NET/IB: %s: Recovery thread already stopped, skipping close (%s comm=%p)", __func__,
+         resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
     return ncclSuccess;
   }
-  INFO(NCCL_NET, "NET/IB: %s: Closing port recovery for resiliency context (%s comm=%p)", __func__, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
+  INFO(NCCL_NET, "NET/IB: %s: Closing port recovery for resiliency context (%s comm=%p)", __func__,
+       resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
 
   // Create a close request to remove any potential queue items belonging to
   // this resCtx
@@ -1227,12 +1378,11 @@ ncclResult_t IbCastPortRecoveryClose(struct ncclIbResiliency* resCtx) {
   // Wait for the close request to be completed by the async thread
   {
     std::unique_lock<std::mutex> lock(IbCastPortRecoveryMutex);
-    IbCastPortRecoveryCloseCond.wait(lock, [&] {
-      return closeReq.completed;
-    });
+    IbCastPortRecoveryCloseCond.wait(lock, [&] { return closeReq.completed; });
   }
 
-  INFO(NCCL_NET, "NET/IB: %s: Port recovery closed (%s comm=%p)", __func__, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm);
+  INFO(NCCL_NET, "NET/IB: %s: Port recovery closed (%s comm=%p)", __func__, resCtx->baseComm->isSend ? "send" : "recv",
+       resCtx->baseComm);
   return ncclSuccess;
 }
 
@@ -1288,7 +1438,8 @@ ncclResult_t IbCastPortRecoveryHandleFailure(struct ncclIbResiliency* resCtx, in
 
   res = IbCastPortRecoveryContextInit(resCtx, devIndex, &recoveryCtx);
   if (res != ncclSuccess) {
-    INFO(NCCL_NET,"NET/IB: %s: Failed to initialize recovery context for device %d (comm=%p)", __func__, devIndex, resCtx->baseComm);
+    INFO(NCCL_NET, "NET/IB: %s: Failed to initialize recovery context for device %d (comm=%p)", __func__, devIndex,
+         resCtx->baseComm);
     return res;
   }
 
@@ -1302,6 +1453,7 @@ ncclResult_t IbCastPortRecoveryHandleFailure(struct ncclIbResiliency* resCtx, in
   // Wake up the async recovery thread
   IbCastPortRecoveryCond.notify_one();
 
-  INFO(NCCL_NET, "NET/IB: %s: Added device %d into the recovery queue (%s comm=%p, devIndex=%d, isSend=%d)", __func__, devIndex, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm, devIndex, resCtx->baseComm->isSend);
+  INFO(NCCL_NET, "NET/IB: %s: Added device %d into the recovery queue (%s comm=%p, devIndex=%d, isSend=%d)", __func__,
+       devIndex, resCtx->baseComm->isSend ? "send" : "recv", resCtx->baseComm, devIndex, resCtx->baseComm->isSend);
   return ncclSuccess;
 }

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery_ainic.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery_ainic.cc
@@ -30,9 +30,8 @@ ncclResult_t IbCastPortRecoveryQpsRestoreAinic(struct ncclIbPortRecoveryContext*
     }
 
     uint32_t oldQpn = localQp->qp->qp_num;
-    INFO(NCCL_NET, "NET/IB: %s: Destroying QP %d on device %d (comm=%p, old_qp_num=%u)",
-         __func__, qpIndex, recoveryContext->devIndex,
-         recoveryContext->resCtx->baseComm, oldQpn);
+    INFO(NCCL_NET, "NET/IB: %s: Destroying QP %d on device %d (comm=%p, old_qp_num=%u)", __func__, qpIndex,
+         recoveryContext->devIndex, recoveryContext->resCtx->baseComm, oldQpn);
 
     NCCLCHECK(wrap_ibv_destroy_qp(localQp->qp));
     localQp->qp = NULL;
@@ -45,9 +44,8 @@ ncclResult_t IbCastPortRecoveryQpsRestoreAinic(struct ncclIbPortRecoveryContext*
     // CTS offload is disabled when resiliency features are enabled (init.cc).
     NCCLCHECK(IbCastQpCreate(localQp, &createAttr));
 
-    INFO(NCCL_NET, "NET/IB: %s: Recreated QP %d on device %d (comm=%p, old_qp_num=%u, new_qp_num=%u)",
-         __func__, qpIndex, recoveryContext->devIndex,
-         recoveryContext->resCtx->baseComm, oldQpn, localQp->qp->qp_num);
+    INFO(NCCL_NET, "NET/IB: %s: Recreated QP %d on device %d (comm=%p, old_qp_num=%u, new_qp_num=%u)", __func__,
+         qpIndex, recoveryContext->devIndex, recoveryContext->resCtx->baseComm, oldQpn, localQp->qp->qp_num);
 
     NCCLCHECK(IbCastQpInit(localQp));
 
@@ -65,8 +63,8 @@ ncclResult_t IbCastPortRecoveryQpsRestoreAinic(struct ncclIbPortRecoveryContext*
         if (i != recoveryContext->devIndex) continue;
         struct ncclIbRecvCommDev* rCommDev = &recvComm->devs[i];
         ncclIbQp* flushQp = &rCommDev->gpuFlush.qp;
-        INFO(NCCL_NET, "NET/IB: %s: Destroying Flush QP on device %d (comm=%p, old_qp_num=%u)",
-             __func__, i, recoveryContext->resCtx->baseComm, flushQp->qp->qp_num);
+        INFO(NCCL_NET, "NET/IB: %s: Destroying Flush QP on device %d (comm=%p, old_qp_num=%u)", __func__, i,
+             recoveryContext->resCtx->baseComm, flushQp->qp->qp_num);
         NCCLCHECK(wrap_ibv_destroy_qp(flushQp->qp));
         flushQp->qp = NULL;
         struct ncclIbQpCreateAttr flushCreateAttr;
@@ -76,16 +74,15 @@ ncclResult_t IbCastPortRecoveryQpsRestoreAinic(struct ncclIbPortRecoveryContext*
         flushCreateAttr.channelId = flushQp->channelId;
         flushCreateAttr.isDataQp = flushQp->isDataQp;
         NCCLCHECK(IbCastQpCreate(flushQp, &flushCreateAttr));
-        INFO(NCCL_NET, "NET/IB: %s: Recreated Flush QP on device %d (comm=%p, new_qp_num=%u)",
-             __func__, i, recoveryContext->resCtx->baseComm, flushQp->qp->qp_num);
+        INFO(NCCL_NET, "NET/IB: %s: Recreated Flush QP on device %d (comm=%p, new_qp_num=%u)", __func__, i,
+             recoveryContext->resCtx->baseComm, flushQp->qp->qp_num);
         NCCLCHECK(IbCastQpInit(flushQp));
       }
     }
   }
 
-  INFO(NCCL_NET, "NET/IB: %s: Phase A complete: %d QPs destroyed+recreated on device %d (comm=%p)",
-       __func__, recoveryContext->nLocalQpns, recoveryContext->devIndex,
-       recoveryContext->resCtx->baseComm);
+  INFO(NCCL_NET, "NET/IB: %s: Phase A complete: %d QPs destroyed+recreated on device %d (comm=%p)", __func__,
+       recoveryContext->nLocalQpns, recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
   return ncclSuccess;
 }
 
@@ -111,16 +108,14 @@ ncclResult_t IbCastPortRecoveryQpsToRtsAinic(struct ncclIbPortRecoveryContext* r
       }
     }
     if (!found) {
-      WARN("NET/IB: %s: No remote QPN found for QP index %d on device %d (comm=%p)",
-           __func__, qpIndex, recoveryContext->devIndex,
-           recoveryContext->resCtx->baseComm);
+      WARN("NET/IB: %s: No remote QPN found for QP index %d on device %d (comm=%p)", __func__, qpIndex,
+           recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
       return ncclInternalError;
     }
 
     localQp->rtrAttr.remoteQpNum = remoteQpn;
-    INFO(NCCL_NET, "NET/IB: %s: QP %d RTR with remoteQpn=%u (comm=%p, qp_num=%u)",
-         __func__, qpIndex, remoteQpn, recoveryContext->resCtx->baseComm,
-         localQp->qp->qp_num);
+    INFO(NCCL_NET, "NET/IB: %s: QP %d RTR with remoteQpn=%u (comm=%p, qp_num=%u)", __func__, qpIndex, remoteQpn,
+         recoveryContext->resCtx->baseComm, localQp->qp->qp_num);
 
     if (localQp->eceSupported) {
       NCCLCHECK(wrap_ibv_set_ece(localQp->qp, &localQp->ece, &localQp->eceSupported));
@@ -128,9 +123,8 @@ ncclResult_t IbCastPortRecoveryQpsToRtsAinic(struct ncclIbPortRecoveryContext* r
     NCCLCHECK(IbCastQpRtr(localQp));
     NCCLCHECK(IbCastQpRts(localQp));
 
-    INFO(NCCL_NET, "NET/IB: %s: Restored QP %d on device %d (comm=%p, qp_num=%u)",
-         __func__, qpIndex, recoveryContext->devIndex,
-         recoveryContext->resCtx->baseComm, localQp->qp->qp_num);
+    INFO(NCCL_NET, "NET/IB: %s: Restored QP %d on device %d (comm=%p, qp_num=%u)", __func__, qpIndex,
+         recoveryContext->devIndex, recoveryContext->resCtx->baseComm, localQp->qp->qp_num);
 
     if (!recoveryContext->resCtx->baseComm->isSend) {
       struct ncclIbRecvComm* recvComm = (struct ncclIbRecvComm*)recoveryContext->resCtx->baseComm;
@@ -149,8 +143,8 @@ ncclResult_t IbCastPortRecoveryQpsToRtsAinic(struct ncclIbPortRecoveryContext* r
         flushQp->rtrAttr.remoteQpNum = flushQp->qp->qp_num;
         NCCLCHECK(IbCastQpRtr(flushQp));
         NCCLCHECK(IbCastQpRts(flushQp));
-        INFO(NCCL_NET, "NET/IB: %s: Restored Flush QP on device %d (comm=%p, qp_num=%u)",
-             __func__, i, recoveryContext->resCtx->baseComm, flushQp->qp->qp_num);
+        INFO(NCCL_NET, "NET/IB: %s: Restored Flush QP on device %d (comm=%p, qp_num=%u)", __func__, i,
+             recoveryContext->resCtx->baseComm, flushQp->qp->qp_num);
       }
     }
   }
@@ -164,8 +158,8 @@ ncclResult_t IbCastPortRecoveryPostAckWithQpnsAinic(struct ncclIbPortRecoveryCon
   struct ncclIbResiliency* resCtx = recoveryContext->resCtx;
 
   if (recoveryContext->nLocalQpns > NCCL_IB_MAX_RECOVERY_QPN_ENTRIES) {
-    WARN("NET/IB: %s: Too many QPN entries (%d) for recovery ACK payload (max %d)",
-         __func__, recoveryContext->nLocalQpns, NCCL_IB_MAX_RECOVERY_QPN_ENTRIES);
+    WARN("NET/IB: %s: Too many QPN entries (%d) for recovery ACK payload (max %d)", __func__,
+         recoveryContext->nLocalQpns, NCCL_IB_MAX_RECOVERY_QPN_ENTRIES);
     return ncclInternalError;
   }
   int payloadSize = recoveryContext->nLocalQpns * sizeof(struct RecoveryQpnEntry);
@@ -188,15 +182,14 @@ ncclResult_t IbCastPortRecoveryPostAckWithQpnsAinic(struct ncclIbPortRecoveryCon
   wr.wr.ud.remote_qpn = resCtx->portRecoveryRemoteQpn[devIdx];
   wr.wr.ud.remote_qkey = NCCL_IB_RECOVERY_QKEY;
 
-  INFO(NCCL_NET, "NET/IB: %s: %s posting ACK with %d QPN entries for device %d (comm=%p)",
-       __func__, resCtx->baseComm->isSend ? "Sender" : "Receiver",
-       recoveryContext->nLocalQpns, devIdx, resCtx->baseComm);
+  INFO(NCCL_NET, "NET/IB: %s: %s posting ACK with %d QPN entries for device %d (comm=%p)", __func__,
+       resCtx->baseComm->isSend ? "Sender" : "Receiver", recoveryContext->nLocalQpns, devIdx, resCtx->baseComm);
 
   struct ibv_send_wr* bad_wr = NULL;
   struct ncclIbQp* recoveryQp = &resCtx->portRecoveryQps[devIdx];
   if (wrap_ibv_post_send(recoveryQp->qp, &wr, &bad_wr) != ncclSuccess) {
-    INFO(NCCL_NET, "NET/IB: %s: Failed to post ACK with QPNs on device %d (comm=%p, qp_num=%u)",
-         __func__, devIdx, resCtx->baseComm, recoveryQp->qp->qp_num);
+    INFO(NCCL_NET, "NET/IB: %s: Failed to post ACK with QPNs on device %d (comm=%p, qp_num=%u)", __func__, devIdx,
+         resCtx->baseComm, recoveryQp->qp->qp_num);
     *success = false;
     return ncclSuccess;
   }
@@ -223,9 +216,8 @@ void IbCastPortRecoveryExtractQpnsAinic(struct ncclIbPortRecoveryContext* recove
   recoveryContext->nRemoteQpns = nEntries;
 
   for (int i = 0; i < nEntries; i++) {
-    INFO(NCCL_NET, "NET/IB: %s: Extracted remote QPN: qpIndex=%u newQpn=%u (comm=%p)",
-         __func__, recoveryContext->remoteQpns[i].qpIndex,
-         recoveryContext->remoteQpns[i].newQpn,
+    INFO(NCCL_NET, "NET/IB: %s: Extracted remote QPN: qpIndex=%u newQpn=%u (comm=%p)", __func__,
+         recoveryContext->remoteQpns[i].qpIndex, recoveryContext->remoteQpns[i].newQpn,
          recoveryContext->resCtx->baseComm);
   }
 }

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery_cast.h
@@ -18,10 +18,14 @@ ncclResult_t IbCastPortRecoveryClose(struct ncclIbResiliency* resCtx);
 ncclResult_t IbCastPortRecoveryDevInit(struct ncclIbResiliency* resCtx, int devIndex, ncclIbDev* ibDev);
 ncclResult_t IbCastPortRecoveryDevDestroy(struct ncclIbResiliency* resCtx, int devIndex);
 
-ncclResult_t IbCastPortRecoverySenderQpsCreate(struct ncclIbResiliency* resCtx, struct ncclIbQpInfo* localResiliencyInfo, int nQps);
-ncclResult_t IbCastPortRecoverySenderQpsToRts(struct ncclIbResiliency* resCtx, struct ncclIbConnectionMetadata* remInfo, int nQps);
+ncclResult_t IbCastPortRecoverySenderQpsCreate(struct ncclIbResiliency* resCtx,
+                                               struct ncclIbQpInfo* localResiliencyInfo, int nQps);
+ncclResult_t IbCastPortRecoverySenderQpsToRts(struct ncclIbResiliency* resCtx, struct ncclIbConnectionMetadata* remInfo,
+                                              int nQps);
 
-ncclResult_t IbCastPortRecoveryReceiverQpsCreateToRts(struct ncclIbResiliency* resCtx, struct ncclIbConnectionMetadata* remInfo, struct ncclIbQpInfo* localPortRecoveryQpsInfo, int nQps);
+ncclResult_t IbCastPortRecoveryReceiverQpsCreateToRts(struct ncclIbResiliency* resCtx,
+                                                      struct ncclIbConnectionMetadata* remInfo,
+                                                      struct ncclIbQpInfo* localPortRecoveryQpsInfo, int nQps);
 
 ncclResult_t IbCastPortRecoveryQpsDestroy(struct ncclIbResiliency* resCtx, int nQps);
 

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery_internal.h
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery_internal.h
@@ -13,8 +13,8 @@
 #include "p2p_resiliency_recovery_cast.h"
 
 #define NCCL_IB_RESILIENCY_PORT_RECOVERY_ACK_MSG_ID (0x1234)
-#define NCCL_IB_RECOVERY_QKEY                        0x1234ABCD
-#define NCCL_IB_MAX_RECOVERY_QPN_ENTRIES             NCCL_IB_MAX_QPS
+#define NCCL_IB_RECOVERY_QKEY 0x1234ABCD
+#define NCCL_IB_MAX_RECOVERY_QPN_ENTRIES NCCL_IB_MAX_QPS
 
 enum ncclIbPortRecoveryState {
   ncclIbPortRecoveryStateInit,

--- a/projects/rccl/src/transport/net_ib_cast/reg.cc
+++ b/projects/rccl/src/transport/net_ib_cast/reg.cc
@@ -7,42 +7,46 @@
 
 #include "common_cast.h"
 
-ncclResult_t ncclIbRegMrDmaBufInternal2(ncclIbNetCommDevBase* base, void* data, size_t size, int type, uint64_t offset, int fd, uint64_t mrFlags, ibv_mr** mhandle) {
+ncclResult_t ncclIbRegMrDmaBufInternal2(ncclIbNetCommDevBase* base, void* data, size_t size, int type, uint64_t offset,
+                                        int fd, uint64_t mrFlags, ibv_mr** mhandle) {
   static thread_local uintptr_t pageSize = 0;
   if (pageSize == 0) pageSize = sysconf(_SC_PAGESIZE);
   struct ncclIbMrCache* cache = &IbCastDevs[base->ibDevN].mrCache;
   uintptr_t addr = (uintptr_t)data & -pageSize;
-  size_t pages = ((uintptr_t)data + size - addr + pageSize-1)/pageSize;
+  size_t pages = ((uintptr_t)data + size - addr + pageSize - 1) / pageSize;
   std::lock_guard<std::mutex> lock(IbCastDevs[base->ibDevN].mutex);
-  for (int slot=0; /*true*/; slot++) {
+  for (int slot = 0; /*true*/; slot++) {
     if (slot == cache->population || addr < cache->slots[slot].addr) { // didn't find in cache
       if (cache->population == cache->capacity) { // must grow cache
-        cache->capacity = cache->capacity < 32 ? 32 : 2*cache->capacity;
+        cache->capacity = cache->capacity < 32 ? 32 : 2 * cache->capacity;
         NCCLCHECK(ncclRealloc(&cache->slots, cache->population, cache->capacity));
       }
       // Deregister / register
       struct ibv_mr* mr;
-      unsigned int flags = IBV_ACCESS_LOCAL_WRITE|IBV_ACCESS_REMOTE_WRITE|IBV_ACCESS_REMOTE_READ|IBV_ACCESS_REMOTE_ATOMIC;
+      unsigned int flags =
+        IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_ATOMIC;
       bool relaxedOrdering = IbCastRelaxedOrderingEnabled && (mrFlags & NCCL_NET_MR_FLAG_FORCE_SO) == 0;
       if (relaxedOrdering) flags |= IBV_ACCESS_RELAXED_ORDERING;
       if (fd != -1) {
         /* DMA-BUF support */
         if (!IbCastDevs[base->ibDevN].capsProvider.mlx5.dataDirect) {
-          NCCLCHECK(wrap_ibv_reg_dmabuf_mr(&mr, base->pd, offset, pages*pageSize, addr, fd, flags));
+          NCCLCHECK(wrap_ibv_reg_dmabuf_mr(&mr, base->pd, offset, pages * pageSize, addr, fd, flags));
         } else {
-          NCCLCHECK(wrap_mlx5dv_reg_dmabuf_mr(&mr, base->pd, offset, pages*pageSize, addr, fd, flags, MLX5DV_REG_DMABUF_ACCESS_DATA_DIRECT));
+          NCCLCHECK(wrap_mlx5dv_reg_dmabuf_mr(&mr, base->pd, offset, pages * pageSize, addr, fd, flags,
+                                              MLX5DV_REG_DMABUF_ACCESS_DATA_DIRECT));
         }
       } else {
         if (relaxedOrdering) {
           // Use IBVERBS_1.8 API - needed for IBV_ACCESS_RELAXED_ORDERING support
-          NCCLCHECK(wrap_ibv_reg_mr_iova2(&mr, base->pd, (void*)addr, pages*pageSize, addr, flags));
-        }
-        else {
-          NCCLCHECK(wrap_ibv_reg_mr(&mr, base->pd, (void*)addr, pages*pageSize, flags));
+          NCCLCHECK(wrap_ibv_reg_mr_iova2(&mr, base->pd, (void*)addr, pages * pageSize, addr, flags));
+        } else {
+          NCCLCHECK(wrap_ibv_reg_mr(&mr, base->pd, (void*)addr, pages * pageSize, flags));
         }
       }
-      TRACE(NCCL_INIT|NCCL_NET,"regAddr=0x%lx size=%lld rkey=0x%x lkey=0x%x fd=%d", (unsigned long)addr, (long long)pages*pageSize, mr->rkey, mr->lkey, fd);
-      if (slot != cache->population) memmove(cache->slots+slot+1, cache->slots+slot, (cache->population-slot)*sizeof(struct ncclIbMr));
+      TRACE(NCCL_INIT | NCCL_NET, "regAddr=0x%lx size=%lld rkey=0x%x lkey=0x%x fd=%d", (unsigned long)addr,
+            (long long)pages * pageSize, mr->rkey, mr->lkey, fd);
+      if (slot != cache->population)
+        memmove(cache->slots + slot + 1, cache->slots + slot, (cache->population - slot) * sizeof(struct ncclIbMr));
       cache->slots[slot].addr = addr;
       cache->slots[slot].pages = pages;
       cache->slots[slot].refs = 1;
@@ -51,7 +55,7 @@ ncclResult_t ncclIbRegMrDmaBufInternal2(ncclIbNetCommDevBase* base, void* data, 
       *mhandle = mr;
       return ncclSuccess;
     } else if ((addr >= cache->slots[slot].addr) &&
-        ((addr-cache->slots[slot].addr)/pageSize+pages) <= cache->slots[slot].pages) {
+               ((addr - cache->slots[slot].addr) / pageSize + pages) <= cache->slots[slot].pages) {
       cache->slots[slot].refs += 1;
       *mhandle = cache->slots[slot].mr;
       return ncclSuccess;
@@ -61,11 +65,12 @@ ncclResult_t ncclIbRegMrDmaBufInternal2(ncclIbNetCommDevBase* base, void* data, 
 }
 
 /* DMA-BUF support */
-ncclResult_t IbCastRegMrDmaBufInternal(void* comm, void* data, size_t size, int type, uint64_t offset, int fd, uint64_t mrFlags, void** mhandle) {
+ncclResult_t IbCastRegMrDmaBufInternal(void* comm, void* data, size_t size, int type, uint64_t offset, int fd,
+                                       uint64_t mrFlags, void** mhandle) {
   ncclResult_t ret = ncclSuccess;
   assert(size > 0);
-  struct ncclIbNetCommBase* base = (struct ncclIbNetCommBase*) comm;
-  struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*) malloc(sizeof(struct ncclIbMrHandle));
+  struct ncclIbNetCommBase* base = (struct ncclIbNetCommBase*)comm;
+  struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*)malloc(sizeof(struct ncclIbMrHandle));
   if (mhandleWrapper == nullptr) {
     WARN("Failed to allocate IB MR handle wrapper");
     return ncclSystemError;
@@ -73,9 +78,10 @@ ncclResult_t IbCastRegMrDmaBufInternal(void* comm, void* data, size_t size, int 
   for (int i = 0; i < base->vProps.ndevs; i++) {
     // Each ncclIbNetCommDevBase is at different offset in send and recv netComms
     struct ncclIbNetCommDevBase* devComm = IbCastGetNetCommDevBase(base, i);
-    NCCLCHECKGOTO(ncclIbRegMrDmaBufInternal2(devComm, data, size, type, offset, fd, mrFlags, mhandleWrapper->mrs + i), ret, fail);
+    NCCLCHECKGOTO(ncclIbRegMrDmaBufInternal2(devComm, data, size, type, offset, fd, mrFlags, mhandleWrapper->mrs + i),
+                  ret, fail);
   }
-  *mhandle = (void*) mhandleWrapper;
+  *mhandle = (void*)mhandleWrapper;
 exit:
   return ret;
 fail:
@@ -94,7 +100,7 @@ ncclResult_t IbCastRegMr(void* comm, void* data, size_t size, int type, void** m
 ncclResult_t IbCastDeregMrInternal(ncclIbNetCommDevBase* base, ibv_mr* mhandle) {
   struct ncclIbMrCache* cache = &IbCastDevs[base->ibDevN].mrCache;
   std::lock_guard<std::mutex> lock(IbCastDevs[base->ibDevN].mutex);
-  for (int i=0; i < cache->population; i++) {
+  for (int i = 0; i < cache->population; i++) {
     if (mhandle == cache->slots[i].mr) {
       if (0 == --cache->slots[i].refs) {
         memmove(&cache->slots[i], &cache->slots[--cache->population], sizeof(struct ncclIbMr));
@@ -115,8 +121,8 @@ ncclResult_t IbCastDeregMrInternal(ncclIbNetCommDevBase* base, ibv_mr* mhandle) 
 ncclResult_t IbCastDeregMr(void* comm, void* mhandle) {
   if (mhandle == NULL) return ncclSuccess;
 
-  struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*) mhandle;
-  struct ncclIbNetCommBase* base = (struct ncclIbNetCommBase*) comm;
+  struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*)mhandle;
+  struct ncclIbNetCommBase* base = (struct ncclIbNetCommBase*)comm;
   for (int i = 0; i < base->vProps.ndevs; i++) {
     // Each ncclIbNetCommDevBase is at different offset in send and recv netComms
     struct ncclIbNetCommDevBase* devComm = IbCastGetNetCommDevBase(base, i);

--- a/projects/rccl/src/transport/net_ib_cast/scheduler.cc
+++ b/projects/rccl/src/transport/net_ib_cast/scheduler.cc
@@ -1,10 +1,9 @@
 #include "common_cast.h"
 extern int64_t ncclParamIbCastQpsPerConn();
 
-
 struct ncclIbQpSchedParms castGlobalQpSchedParms;
 pthread_mutex_t ncclIbQpSchedParmsLock = PTHREAD_MUTEX_INITIALIZER;
-struct ncclIbQpSchedParmsCB stagedSchedParms { ncclNumFuncs };
+struct ncclIbQpSchedParmsCB stagedSchedParms{ncclNumFuncs};
 ncclFunc_t IbCastQpSchedProxyPrevCollType = ncclNumFuncs;
 size_t IbCastQpSchedProxyPrevMsgSz;
 
@@ -17,7 +16,7 @@ RCCL_PARAM_NCCL_ALIAS(IbQpSchedUpdateInterval, "IB_QP_SCHED_UPDATE_INTERVAL", -1
 RCCL_PARAM_NCCL_ALIAS(IbQpSchedSplitDataMin, "IB_QP_SCHED_SPLIT_DATA_MIN", -1);
 RCCL_PARAM_NCCL_ALIAS(IbQpSchedLogInterval, "IB_QP_SCHED_LOG_INTERVAL", -1);
 
-FILE *IbCastQpSchedLogStream;
+FILE* IbCastQpSchedLogStream;
 
 // Returns true if the QP scheduler (CAST) should be enabled.
 // Priority:
@@ -28,174 +27,159 @@ bool rcclUseIbCastQpSched() {
   int64_t schedParam = rcclParamIbCastQpSchedEnable();
   if (schedParam != -1) {
     bool enabled = (schedParam != 0);
-    INFO(NCCL_NET|NCCL_ENV, "(IB-CAST) NCCL_IB_QP_SCHED_ENABLE explicitly set to %s",
+    INFO(NCCL_NET | NCCL_ENV, "(IB-CAST) NCCL_IB_QP_SCHED_ENABLE explicitly set to %s",
          enabled ? "enabled" : "disabled");
     return enabled;
   }
 
   const char* netEnv = ncclGetEnv("NCCL_NET");
   if (netEnv && strcasecmp(netEnv, "ib-cast") == 0) {
-    INFO(NCCL_NET|NCCL_ENV, "(IB-CAST) NCCL_NET=ib-cast: forcing QP scheduler enabled");
+    INFO(NCCL_NET | NCCL_ENV, "(IB-CAST) NCCL_NET=ib-cast: forcing QP scheduler enabled");
     return (bool)QP_SCHED_ENABLE_DEF;
   }
 
   if (rcclUseAinic()) {
-    INFO(NCCL_NET|NCCL_ENV, "(IB-CAST) AINIC detected: QP scheduler disabled by default "
-         "(set NCCL_IB_QP_SCHED_ENABLE=1 or NCCL_NET=ib-cast to override)");
+    INFO(NCCL_NET | NCCL_ENV, "(IB-CAST) AINIC detected: QP scheduler disabled by default "
+                              "(set NCCL_IB_QP_SCHED_ENABLE=1 or NCCL_NET=ib-cast to override)");
     return false;
   }
 
   return (bool)QP_SCHED_ENABLE_DEF;
 }
 
-ncclResult_t IbCastQpSchedInitParms(struct ncclIbQpSchedParms *parms) {
-    char *str, *logFileName = NULL;
-    int val;
-    double weight;
-    uint64_t nsec;
-    ncclResult_t ret = ncclSuccess;
+ncclResult_t IbCastQpSchedInitParms(struct ncclIbQpSchedParms* parms) {
+  char *str, *logFileName = NULL;
+  int val;
+  double weight;
+  uint64_t nsec;
+  ncclResult_t ret = ncclSuccess;
 
-    parms->enable = QP_SCHED_ENABLE_DEF;
-    parms->wrrEnable = QP_SCHED_WRR_ENABLE_DEF;
-    parms->resetInterval = QP_SCHED_RESET_DEF;
-    parms->updateInterval = QP_SCHED_UPDATE_DEF;
-    parms->weightNew = QP_SCHED_WEIGHT_DEF;
-    parms->splitData = ncclParamIbCastSplitDataOnQps();
-    parms->splitDataMin = QP_SCHED_SPLIT_DATA_MIN_DEF;
-    parms->logInterval = QP_SCHED_LOG_DEF;
-    parms->logEnable = false;
-    if (!parms->enable)
-      parms->doWrr = false;
-    else if (!parms->splitData)
-      parms->doWrr = true;
-    else if (parms->wrrEnable)
-      parms->doWrr = true;
-    else
-      parms->doWrr = false;
+  parms->enable = QP_SCHED_ENABLE_DEF;
+  parms->wrrEnable = QP_SCHED_WRR_ENABLE_DEF;
+  parms->resetInterval = QP_SCHED_RESET_DEF;
+  parms->updateInterval = QP_SCHED_UPDATE_DEF;
+  parms->weightNew = QP_SCHED_WEIGHT_DEF;
+  parms->splitData = ncclParamIbCastSplitDataOnQps();
+  parms->splitDataMin = QP_SCHED_SPLIT_DATA_MIN_DEF;
+  parms->logInterval = QP_SCHED_LOG_DEF;
+  parms->logEnable = false;
+  if (!parms->enable) parms->doWrr = false;
+  else if (!parms->splitData) parms->doWrr = true;
+  else if (parms->wrrEnable) parms->doWrr = true;
+  else parms->doWrr = false;
 
-    if (rcclUseIbCastQpSched()) {
-      parms->enable = true;
-      INFO(NCCL_NET|NCCL_ENV, "(IB-CAST) QP scheduler enabled");
-    } else {
-      parms->enable = false;
-      INFO(NCCL_NET|NCCL_ENV, "(IB-CAST) QP scheduler disabled");
+  if (rcclUseIbCastQpSched()) {
+    parms->enable = true;
+    INFO(NCCL_NET | NCCL_ENV, "(IB-CAST) QP scheduler enabled");
+  } else {
+    parms->enable = false;
+    INFO(NCCL_NET | NCCL_ENV, "(IB-CAST) QP scheduler disabled");
+    goto exit;
+  }
+
+  if (parms->splitData) {
+    if (rcclParamIbQpSchedWrrEnable()) {
+      parms->doWrr = true;
+      INFO(NCCL_NET | NCCL_ENV, "(IB-CAST) RCCL_IB_QP_SCHED_WRR_ENABLE set to enabled");
+    }
+  } else parms->doWrr = true;
+
+  val = (int)rcclParamIbQpSchedResetInterval();
+  if (val >= 0) {
+    nsec = (val * NSEC_PER_MSEC);
+    if (nsec > 0 && nsec < QP_SCHED_RESET_MIN) goto getUpdateParm;
+    parms->resetInterval = nsec;
+    INFO(NCCL_NET | NCCL_ENV, "(IB-CAST) RCCL_IB_QP_SCHED_RESET_INTERVAL set to %lu nsec", nsec);
+  }
+
+getUpdateParm:
+  val = (int)rcclParamIbQpSchedUpdateInterval();
+  if (val >= 0) {
+    nsec = (val * NSEC_PER_USEC);
+    if ((nsec >= QP_SCHED_UPDATE_MIN) && (nsec <= QP_SCHED_UPDATE_MAX)) {
+      parms->updateInterval = nsec;
+      INFO(NCCL_NET | NCCL_ENV, "(IB-CAST) RCCL_IB_QP_SCHED_UPDATE_INTERVAL set to %lu nsec", nsec);
+    }
+  }
+
+  str = getenv(QP_SCHED_WEIGHT_ENV_VAR);
+  if (!str) str = getenv(QP_SCHED_WEIGHT_ENV_VAR_ALIAS);
+  if (str) {
+    weight = atof(str);
+    if (weight != QP_SCHED_WEIGHT_NONE) {
+      if (weight <= QP_SCHED_WEIGHT_MAX && weight >= QP_SCHED_WEIGHT_MIN) {
+        parms->weightNew = weight;
+        INFO(NCCL_NET | NCCL_ENV, "(IB-CAST) RCCL_IB_QP_SCHED_WEIGHT set to %f", weight);
+      }
+    }
+  }
+
+  val = (int)rcclParamIbQpSchedSplitDataMin();
+  if (val > 0) {
+    parms->splitDataMin = val;
+    INFO(NCCL_NET | NCCL_ENV, "(IB-CAST) RCCL_IB_QP_SCHED_SPLIT_DATA_MIN set to %d bytes", val);
+  }
+
+  str = getenv(QP_SCHED_LOG_PATH_ENV_VAR);
+  if (!str) str = getenv(QP_SCHED_LOG_PATH_ENV_VAR_ALIAS);
+  if (str != NULL) {
+    char hostName[HOST_NAME_MAX + 1], pid[32];
+    size_t fileNameLen;
+
+    gethostname(hostName, HOST_NAME_MAX);
+    snprintf(pid, sizeof(pid), "%d", getpid());
+    fileNameLen = strlen(str) + 1 + strlen(QP_SCHED_LOG_FILE_NAME_PREFIX) + strlen(hostName) + 1 + strlen(pid);
+    logFileName = (char*)calloc(1, fileNameLen + 1);
+    if (logFileName == NULL) {
+      WARN("(IB-CAST) NCCL_IB_QP_SCHED_LOG_PATH: calloc failed");
+      goto err_exit;
+    }
+    snprintf(logFileName, fileNameLen + 1, "%s/%s%s_%s", str, QP_SCHED_LOG_FILE_NAME_PREFIX, hostName, pid);
+    IbCastQpSchedLogStream = fopen(logFileName, "w");
+    if (IbCastQpSchedLogStream == NULL) {
+      WARN("(IB-CAST) NCCL_IB_QP_SCHED_LOG_PATH: fopen failed: %s (logging disabled)", strerror(errno));
+      parms->logEnable = false;
       goto exit;
     }
-  
-    if (parms->splitData) {
-      if (rcclParamIbQpSchedWrrEnable()) {
-        parms->doWrr = true;
-        INFO(NCCL_NET|NCCL_ENV, "(IB-CAST) RCCL_IB_QP_SCHED_WRR_ENABLE set to enabled");
-      }
-    } else
-      parms->doWrr = true;
-  
-    val = (int)rcclParamIbQpSchedResetInterval();
-    if (val >= 0) {
-      nsec = (val * NSEC_PER_MSEC);
-      if (nsec > 0 && nsec < QP_SCHED_RESET_MIN)
-        goto getUpdateParm;
-      parms->resetInterval = nsec;
-      INFO(NCCL_NET|NCCL_ENV, "(IB-CAST) RCCL_IB_QP_SCHED_RESET_INTERVAL set to %lu nsec", nsec);
-    }
-  
-  getUpdateParm:
-    val = (int)rcclParamIbQpSchedUpdateInterval();
+    INFO(NCCL_NET | NCCL_ENV, "(IB-CAST) NCCL_IB_QP_SCHED_LOG_PATH: opened %s", logFileName);
+    parms->logEnable = true;
+
+    val = (int)rcclParamIbQpSchedLogInterval();
     if (val >= 0) {
       nsec = (val * NSEC_PER_USEC);
       if ((nsec >= QP_SCHED_UPDATE_MIN) && (nsec <= QP_SCHED_UPDATE_MAX)) {
-        parms->updateInterval = nsec;
-        INFO(NCCL_NET|NCCL_ENV, "(IB-CAST) RCCL_IB_QP_SCHED_UPDATE_INTERVAL set to %lu nsec", nsec);
+        parms->logInterval = nsec;
+        INFO(NCCL_NET | NCCL_ENV, "(IB-CAST) RCCL_IB_QP_SCHED_LOG_INTERVAL set to %lu nsec", nsec);
       }
     }
-  
-    str = getenv(QP_SCHED_WEIGHT_ENV_VAR);
-    if (!str)
-      str = getenv(QP_SCHED_WEIGHT_ENV_VAR_ALIAS);
-    if (str) {
-      weight = atof(str);
-      if (weight != QP_SCHED_WEIGHT_NONE) {
-        if (weight <= QP_SCHED_WEIGHT_MAX && weight >= QP_SCHED_WEIGHT_MIN) {
-          parms->weightNew = weight;
-          INFO(NCCL_NET|NCCL_ENV, "(IB-CAST) RCCL_IB_QP_SCHED_WEIGHT set to %f", weight);
-        }
-      }
-    }
-  
-    val = (int)rcclParamIbQpSchedSplitDataMin();
-    if (val > 0) {
-      parms->splitDataMin = val;
-      INFO(NCCL_NET|NCCL_ENV, "(IB-CAST) RCCL_IB_QP_SCHED_SPLIT_DATA_MIN set to %d bytes", val);
-    }
-  
-    str = getenv(QP_SCHED_LOG_PATH_ENV_VAR);
-    if (!str)
-      str = getenv(QP_SCHED_LOG_PATH_ENV_VAR_ALIAS);
-    if (str != NULL) {
-      char hostName[HOST_NAME_MAX + 1], pid[32];
-      size_t fileNameLen;
-  
-      gethostname(hostName, HOST_NAME_MAX);
-      snprintf(pid, sizeof(pid), "%d", getpid());
-      fileNameLen = strlen(str) + 1 + strlen(QP_SCHED_LOG_FILE_NAME_PREFIX) +
-                strlen(hostName) + 1 + strlen(pid);
-      logFileName = (char *) calloc(1, fileNameLen + 1);
-      if (logFileName == NULL) {
-        WARN("(IB-CAST) NCCL_IB_QP_SCHED_LOG_PATH: calloc failed");
-        goto err_exit;
-      }
-      snprintf(logFileName, fileNameLen + 1, "%s/%s%s_%s", str, QP_SCHED_LOG_FILE_NAME_PREFIX, hostName, pid);
-      IbCastQpSchedLogStream = fopen(logFileName, "w");
-      if (IbCastQpSchedLogStream == NULL) {
-        WARN("(IB-CAST) NCCL_IB_QP_SCHED_LOG_PATH: fopen failed: %s (logging disabled)", strerror(errno));
-        parms->logEnable = false;
-        goto exit;
-      }
-      INFO(NCCL_NET|NCCL_ENV, "(IB-CAST) NCCL_IB_QP_SCHED_LOG_PATH: opened %s", logFileName);
-      parms->logEnable = true;
-  
-      val = (int)rcclParamIbQpSchedLogInterval();
-      if (val >= 0) {
-        nsec = (val * NSEC_PER_USEC);
-        if ((nsec >= QP_SCHED_UPDATE_MIN) && (nsec <= QP_SCHED_UPDATE_MAX)) {
-          parms->logInterval = nsec;
-          INFO(NCCL_NET|NCCL_ENV, "(IB-CAST) RCCL_IB_QP_SCHED_LOG_INTERVAL set to %lu nsec", nsec);
-        }
-      }
-    }
-  
-    INFO(NCCL_NET|NCCL_ENV, "(IB-CAST) NCCL_IB_QPS_PER_CONNECTION set to %ld", ncclParamIbCastQpsPerConn());
-  
-  exit:
-    free(logFileName);
-    return ret;
-  
-  err_exit:
-    ret = ncclInternalError;
-    goto exit;
-  }
-  
-  void IbCastLogSched(struct ncclIbSendComm *comm) {
-    
-    fprintf(IbCastQpSchedLogStream, "comm %p: num qp's %d ndevs %d\n", comm, comm->base.nqps, comm->base.vProps.ndevs);
-    for (int i = 0; i < comm->base.nqps; i++) {
-      ncclIbQp* qp = comm->base.qps + i;
-      int devArrayIdx = qp->devIndex;
-      int ibDevN = comm->devs[devArrayIdx].base.ibDevN;
-      fprintf(IbCastQpSchedLogStream, "  qp[%02d]: dev[%d]=%s (ibDev %d): minW=%.4f curW=%.4f maxW=%.4f lat=%.2fus\n",
-              i,
-              devArrayIdx,
-              IbCastDevs[ibDevN].devName,
-              ibDevN,
-              comm->base.qpTxSched[i].minWeight,
-              comm->base.qpTxSched[i].weight,
-              comm->base.qpTxSched[i].maxWeight,
-              comm->base.qpTxStats[i].rtt / 1000.0);  // Convert ns to us
-    }
-    fflush(IbCastQpSchedLogStream);
   }
 
-void IbCastUpdateSchedParmsTry(struct ncclIbNetCommBase *base, int nreqs, int size) {
+  INFO(NCCL_NET | NCCL_ENV, "(IB-CAST) NCCL_IB_QPS_PER_CONNECTION set to %ld", ncclParamIbCastQpsPerConn());
+
+exit:
+  free(logFileName);
+  return ret;
+
+err_exit:
+  ret = ncclInternalError;
+  goto exit;
+}
+
+void IbCastLogSched(struct ncclIbSendComm* comm) {
+  fprintf(IbCastQpSchedLogStream, "comm %p: num qp's %d ndevs %d\n", comm, comm->base.nqps, comm->base.vProps.ndevs);
+  for (int i = 0; i < comm->base.nqps; i++) {
+    ncclIbQp* qp = comm->base.qps + i;
+    int devArrayIdx = qp->devIndex;
+    int ibDevN = comm->devs[devArrayIdx].base.ibDevN;
+    fprintf(IbCastQpSchedLogStream, "  qp[%02d]: dev[%d]=%s (ibDev %d): minW=%.4f curW=%.4f maxW=%.4f lat=%.2fus\n", i,
+            devArrayIdx, IbCastDevs[ibDevN].devName, ibDevN, comm->base.qpTxSched[i].minWeight,
+            comm->base.qpTxSched[i].weight, comm->base.qpTxSched[i].maxWeight,
+            comm->base.qpTxStats[i].rtt / 1000.0);  // Convert ns to us
+  }
+  fflush(IbCastQpSchedLogStream);
+}
+
+void IbCastUpdateSchedParmsTry(struct ncclIbNetCommBase* base, int nreqs, int size) {
   if (!base->schedParmsInit) {
     base->schedParms = castGlobalQpSchedParms;
     base->schedParmsInit = true;
@@ -217,11 +201,10 @@ void IbCastUpdateSchedParmsTry(struct ncclIbNetCommBase *base, int nreqs, int si
     }
     base->schedParms = stagedSchedParms.parms;
     base->stagedParmsConEpoch = stagedSchedParms.prodEpoch;
-    if (base->schedParms.resetRtt)
-      base->resetRttDone = false;
+    if (base->schedParms.resetRtt) base->resetRttDone = false;
     pthread_mutex_unlock(&ncclIbQpSchedParmsLock);
     if (msgSzChanged || collTypeChanged) {
-      const char *collStr;
+      const char* collStr;
       switch (collType) {
       case ncclFuncBroadcast:
         collStr = "Broadcast";
@@ -243,20 +226,20 @@ void IbCastUpdateSchedParmsTry(struct ncclIbNetCommBase *base, int nreqs, int si
         break;
       }
       if (collStr == NULL)
-        INFO(NCCL_NET, "PID %d: CollType = %d  MsgSz = %lu  ChunkSz = %d  NumChunks = %d",
-             getpid(), collType, msgSz, size, nreqs);
+        INFO(NCCL_NET, "PID %d: CollType = %d  MsgSz = %lu  ChunkSz = %d  NumChunks = %d", getpid(), collType, msgSz,
+             size, nreqs);
       else
-        INFO(NCCL_NET, "PID %d: CollType = %s  MsgSz = %lu  ChunkSz = %d  NumChunks = %d",
-             getpid(), collStr, msgSz, size, nreqs);
+        INFO(NCCL_NET, "PID %d: CollType = %s  MsgSz = %lu  ChunkSz = %d  NumChunks = %d", getpid(), collStr, msgSz,
+             size, nreqs);
     }
   }
 }
-void IbCastQpSchedUpdateTx(struct ncclIbNetCommBase *base) {
+void IbCastQpSchedUpdateTx(struct ncclIbNetCommBase* base) {
   int qp;
   uint64_t minRttSample;
   double minRtt = DBL_MAX, rttSum = 0.0;
   struct ncclIbQpTxSchedScratchpad s;
-  struct ncclIbRrTokens *tokens;
+  struct ncclIbRrTokens* tokens;
 
   for (qp = 0; qp < base->nqps; qp++) {
     if (base->qpTxStats[qp].rtt < minRtt) {
@@ -266,26 +249,21 @@ void IbCastQpSchedUpdateTx(struct ncclIbNetCommBase *base) {
   }
 
   for (qp = 0; qp < base->nqps; qp++) {
-    if (base->qpTxStats[qp].rtt == 0.0)
-      return;
+    if (base->qpTxStats[qp].rtt == 0.0) return;
     double denom = (base->qpTxStats[qp].rtt - minRtt) + minRttSample;
-    if (denom <= 0.0)
-      return;
+    if (denom <= 0.0) return;
     s.rtt[qp] = 1.0 / denom;
     rttSum += s.rtt[qp];
   }
 
   if (rttSum == 0.0) {
-    for (qp = 0; qp < base->nqps; qp++)
-      base->qpTxSched[qp].weight = 1.0 / ((double) base->nqps);
+    for (qp = 0; qp < base->nqps; qp++) base->qpTxSched[qp].weight = 1.0 / ((double)base->nqps);
   } else {
-    for (qp = 0; qp < base->nqps; qp++)
-        base->qpTxSched[qp].weight = s.rtt[qp] / rttSum;
+    for (qp = 0; qp < base->nqps; qp++) base->qpTxSched[qp].weight = s.rtt[qp] / rttSum;
   }
   if (base->schedParms.logEnable) {
     if (!base->qpTxSchedInit) {
-      for (qp = 0; qp < base->nqps; qp++)
-        base->qpTxSched[qp].minWeight = DBL_MAX;
+      for (qp = 0; qp < base->nqps; qp++) base->qpTxSched[qp].minWeight = DBL_MAX;
     }
 
     for (qp = 0; qp < base->nqps; qp++) {
@@ -301,12 +279,10 @@ void IbCastQpSchedUpdateTx(struct ncclIbNetCommBase *base) {
   for (qp = 0; qp < base->nqps; qp++) {
     double temp, temp3;
     int temp2;
-    temp = ((double) NCCL_IB_TARGET_TOT_TOKENS) *
-           base->qpTxSched[qp].weight;
-    temp2 = (int) temp;
-    temp3 = (double) temp2;
-    if (((temp - temp3) > 0.5) || (temp2 == 0))
-      temp2++;
+    temp = ((double)NCCL_IB_TARGET_TOT_TOKENS) * base->qpTxSched[qp].weight;
+    temp2 = (int)temp;
+    temp3 = (double)temp2;
+    if (((temp - temp3) > 0.5) || (temp2 == 0)) temp2++;
     tokens->qpTokens[qp] = temp2;
     tokens->totTokens += temp2;
   }
@@ -314,11 +290,10 @@ void IbCastQpSchedUpdateTx(struct ncclIbNetCommBase *base) {
   // Clamp activeTokens to the new initTokens so activeTotTokens <= initTotTokens
   // always holds, even when the RTT timer fires mid-round.
   {
-    struct ncclIbRrTokens *active = &base->rrQpTxSched.activeTokens;
+    struct ncclIbRrTokens* active = &base->rrQpTxSched.activeTokens;
     active->totTokens = 0;
     for (qp = 0; qp < base->nqps; qp++) {
-      if (active->qpTokens[qp] > tokens->qpTokens[qp])
-        active->qpTokens[qp] = tokens->qpTokens[qp];
+      if (active->qpTokens[qp] > tokens->qpTokens[qp]) active->qpTokens[qp] = tokens->qpTokens[qp];
       active->totTokens += active->qpTokens[qp];
     }
   }
@@ -326,19 +301,15 @@ void IbCastQpSchedUpdateTx(struct ncclIbNetCommBase *base) {
   base->qpTxSchedInit = true;
 }
 
-
-void IbCastQpSchedUpdateTxStats(struct ncclIbRemapWrId *remap,
-                            struct ncclIbNetCommBase *base) {
+void IbCastQpSchedUpdateTxStats(struct ncclIbRemapWrId* remap, struct ncclIbNetCommBase* base) {
   uint64_t nowNs, sampleNs, sampleTxTimeNs, rtt, resetInterval;
   double sampleTxTime, weightNew, weightPrev;
   struct timespec now;
-  struct ncclIbQpTxStats *qpTxStats;
+  struct ncclIbQpTxStats* qpTxStats;
 
-  if (remap->tx.startTimeNs == 0)
-    return;
+  if (remap->tx.startTimeNs == 0) return;
 
-  if (clock_gettime(CLOCK_MONOTONIC, &now))
-    return;
+  if (clock_gettime(CLOCK_MONOTONIC, &now)) return;
 
   nowNs = TIMESPEC_TO_NSEC(&now);
   bool resetRtt = false;
@@ -347,9 +318,7 @@ void IbCastQpSchedUpdateTxStats(struct ncclIbRemapWrId *remap,
     base->resetRttDone = true;
   }
   resetInterval = remap->parms.resetInterval;
-  if ((resetInterval != QP_SCHED_RESET_NEVER) &&
-      (nowNs >= base->nextQpTxStatsResetNs))
-    resetRtt = true;
+  if ((resetInterval != QP_SCHED_RESET_NEVER) && (nowNs >= base->nextQpTxStatsResetNs)) resetRtt = true;
   if (resetRtt) {
     for (int qp = 0; qp < base->nqps; qp++) {
       base->qpTxStats[qp].totRtt = 0;
@@ -363,31 +332,27 @@ void IbCastQpSchedUpdateTxStats(struct ncclIbRemapWrId *remap,
   // Get the IB device index: qp->devIndex is index into vProps.devs[], which contains actual IB device indices
   int qpDevArrayIndex = base->qps[remap->qpIndex].devIndex;
   int ibDevIndex = base->vProps.devs[qpDevArrayIndex];
-  sampleTxTime = (((double) remap->tx.bytes) * ((double) BITS_PER_BYTE)) /
-                 (((double) IbCastDevs[ibDevIndex].speed) * ((double) MEG));
-  sampleTxTimeNs = (uint64_t) (sampleTxTime * ((double) NSEC_PER_SEC));
+  sampleTxTime =
+    (((double)remap->tx.bytes) * ((double)BITS_PER_BYTE)) / (((double)IbCastDevs[ibDevIndex].speed) * ((double)MEG));
+  sampleTxTimeNs = (uint64_t)(sampleTxTime * ((double)NSEC_PER_SEC));
   rtt = sampleNs - sampleTxTimeNs;
   qpTxStats->totRtt += rtt;
   qpTxStats->numMeasurements++;
-  if ((qpTxStats->minRttSample == 0) || (rtt < qpTxStats->minRttSample))
-    qpTxStats->minRttSample = rtt;
+  if ((qpTxStats->minRttSample == 0) || (rtt < qpTxStats->minRttSample)) qpTxStats->minRttSample = rtt;
   if (qpTxStats->numMeasurements == 1) {
-    qpTxStats->rtt = (double) rtt;
+    qpTxStats->rtt = (double)rtt;
     return;
   }
   weightNew = remap->parms.weightNew;
   weightPrev = 1.0 - weightNew;
-  if (weightNew == ((double) QP_SCHED_WEIGHT_NONE))
-    qpTxStats->rtt = ((double) qpTxStats->totRtt) /
-                     ((double) qpTxStats->numMeasurements);
-  else
-    qpTxStats->rtt = (qpTxStats->rtt * weightPrev) +
-                     (((double) rtt) * weightNew);
+  if (weightNew == ((double)QP_SCHED_WEIGHT_NONE))
+    qpTxStats->rtt = ((double)qpTxStats->totRtt) / ((double)qpTxStats->numMeasurements);
+  else qpTxStats->rtt = (qpTxStats->rtt * weightPrev) + (((double)rtt) * weightNew);
 }
 
-int IbCastQpSchedGetEffectiveTxNqps(struct ncclIbRequest* req, int *startQpIndex, bool *wrrSched) {
+int IbCastQpSchedGetEffectiveTxNqps(struct ncclIbRequest* req, int* startQpIndex, bool* wrrSched) {
   int dataPerQp, qpIndex = req->base->qpIndex, nqps = req->base->nqps;
-  struct ncclIbQpSchedParms *parms = &req->desc.parms;
+  struct ncclIbQpSchedParms* parms = &req->desc.parms;
 
   *wrrSched = false;
 
@@ -396,11 +361,9 @@ int IbCastQpSchedGetEffectiveTxNqps(struct ncclIbRequest* req, int *startQpIndex
     goto exit;
   }
 
-  if (req->base->nqps == 1)
-    goto exit;
+  if (req->base->nqps == 1) goto exit;
 
-  if (!parms->splitData)
-    goto oneQp;
+  if (!parms->splitData) goto oneQp;
 
   dataPerQp = (req->send.size * req->nreqs) / req->base->nqps;
   if (dataPerQp >= parms->splitDataMin) {
@@ -417,11 +380,11 @@ oneQp:
       if (req->base->rrQpTxSched.activeTokens.qpTokens[qpIndex]) {
         req->base->rrQpTxSched.activeTokens.qpTokens[qpIndex]--;
         req->base->rrQpTxSched.activeTokens.totTokens--;
-        req->base->rrQpTxSched.qpIndex = (qpIndex+1) % req->base->nqps;
+        req->base->rrQpTxSched.qpIndex = (qpIndex + 1) % req->base->nqps;
         *wrrSched = true;
         break;
       }
-      qpIndex = (qpIndex+1) % req->base->nqps;
+      qpIndex = (qpIndex + 1) % req->base->nqps;
     }
   }
 
@@ -430,9 +393,10 @@ exit:
   return nqps;
 }
 
-ncclResult_t IbCastQpSchedGetRemap(struct ncclIbNetCommBase* base, uint64_t wrId, int qpIndex, struct ncclIbRemapWrId** remap) {
-  for (int i=0; i<NET_IB_MAX_REQUESTS; i++) {
-    struct ncclIbRemapWrId* r = base->remapWrId+i;
+ncclResult_t IbCastQpSchedGetRemap(struct ncclIbNetCommBase* base, uint64_t wrId, int qpIndex,
+                                   struct ncclIbRemapWrId** remap) {
+  for (int i = 0; i < NET_IB_MAX_REQUESTS; i++) {
+    struct ncclIbRemapWrId* r = base->remapWrId + i;
     if (r->state == NCCL_NET_IB_REMAP_UNUSED) {
       r->origWrId = wrId;
       r->qpIndex = qpIndex;
@@ -462,25 +426,25 @@ ncclResult_t IbCastQpSchedFreeRemap(struct ncclIbRemapWrId* r) {
 // Returns ncclInvalidArgument if sendComm or out is null.
 extern "C" ncclResult_t ncclIbCastGetSchedState(void* sendComm, struct ncclIbCastSchedState* out) {
   if (!sendComm || !out) return ncclInvalidArgument;
-  struct ncclIbSendComm* comm = (struct ncclIbSendComm*) sendComm;
+  struct ncclIbSendComm* comm = (struct ncclIbSendComm*)sendComm;
   struct ncclIbNetCommBase* base = &comm->base;
 
-  out->nqps      = base->nqps;
+  out->nqps = base->nqps;
   out->schedInit = base->qpTxSchedInit;
-  out->qpIndex   = base->rrQpTxSched.qpIndex;
+  out->qpIndex = base->rrQpTxSched.qpIndex;
 
-  out->initTotTokens   = base->rrQpTxSched.initTokens.totTokens;
+  out->initTotTokens = base->rrQpTxSched.initTokens.totTokens;
   out->activeTotTokens = base->rrQpTxSched.activeTokens.totTokens;
 
   int n = (base->nqps < NCCL_IB_MAX_QPS) ? base->nqps : NCCL_IB_MAX_QPS;
   for (int i = 0; i < n; i++) {
-    out->initQpTokens[i]   = base->rrQpTxSched.initTokens.qpTokens[i];
+    out->initQpTokens[i] = base->rrQpTxSched.initTokens.qpTokens[i];
     out->activeQpTokens[i] = base->rrQpTxSched.activeTokens.qpTokens[i];
   }
 
-  out->schedEnable  = base->schedParms.enable;
-  out->doWrr        = base->schedParms.doWrr;
-  out->splitData    = base->schedParms.splitData;
+  out->schedEnable = base->schedParms.enable;
+  out->doWrr = base->schedParms.doWrr;
+  out->splitData = base->schedParms.splitData;
   out->splitDataMin = base->schedParms.splitDataMin;
 
   return ncclSuccess;
@@ -490,50 +454,43 @@ extern "C" ncclResult_t ncclIbCastGetSchedState(void* sendComm, struct ncclIbCas
 // Bypasses the RTT-based IbCastQpSchedUpdateTx; immediately arms the scheduler.
 // qpTokens must have nqps entries; totTokens is computed as their sum.
 extern "C" ncclResult_t ncclIbCastSetTokens(void* sendComm, const int* qpTokens, int nqps) {
-  if (!sendComm || !qpTokens || nqps <= 0 || nqps > NCCL_IB_MAX_QPS)
-    return ncclInvalidArgument;
-  struct ncclIbSendComm* comm = (struct ncclIbSendComm*) sendComm;
+  if (!sendComm || !qpTokens || nqps <= 0 || nqps > NCCL_IB_MAX_QPS) return ncclInvalidArgument;
+  struct ncclIbSendComm* comm = (struct ncclIbSendComm*)sendComm;
   struct ncclIbNetCommBase* base = &comm->base;
 
   // If the connection is already established, nqps must match the real QP count.
-  if (base->nqps > 0 && nqps != base->nqps)
-    return ncclInvalidArgument;
+  if (base->nqps > 0 && nqps != base->nqps) return ncclInvalidArgument;
 
   struct ncclIbRrTokens* t = &base->rrQpTxSched.initTokens;
   t->totTokens = 0;
   for (int i = 0; i < nqps; i++) {
     t->qpTokens[i] = qpTokens[i];
-    t->totTokens  += qpTokens[i];
+    t->totTokens += qpTokens[i];
   }
   // Zero out entries beyond nqps so stale values from a previous call cannot
   // be observed by the WRR cursor if base->nqps ever changes.
-  for (int i = nqps; i < NCCL_IB_MAX_QPS; i++)
-    t->qpTokens[i] = 0;
+  for (int i = nqps; i < NCCL_IB_MAX_QPS; i++) t->qpTokens[i] = 0;
 
   base->rrQpTxSched.activeTokens = *t;
-  base->rrQpTxSched.qpIndex      = 0;
+  base->rrQpTxSched.qpIndex = 0;
   base->qpTxSchedInit = true;
 
   return ncclSuccess;
 }
 
-
 // ncclIbCastSetSchedParms — override schedParms fields for testing.
 // Takes effect on the very next isend; does not require re-connection.
 // Only the four fields most relevant to path-selection are exposed.
-extern "C" ncclResult_t ncclIbCastSetSchedParms(void* sendComm,
-                                                bool schedEnable,
-                                                bool doWrr,
-                                                bool splitData,
+extern "C" ncclResult_t ncclIbCastSetSchedParms(void* sendComm, bool schedEnable, bool doWrr, bool splitData,
                                                 uint32_t splitDataMin) {
-    if (!sendComm) return ncclInvalidArgument;
-    struct ncclIbSendComm* comm = (struct ncclIbSendComm*) sendComm;
-    struct ncclIbNetCommBase* base = &comm->base;
-    base->schedParms.enable       = schedEnable;
-    base->schedParms.doWrr        = doWrr;
-    base->schedParms.splitData    = splitData;
-    base->schedParms.splitDataMin = splitDataMin;
-    return ncclSuccess;
+  if (!sendComm) return ncclInvalidArgument;
+  struct ncclIbSendComm* comm = (struct ncclIbSendComm*)sendComm;
+  struct ncclIbNetCommBase* base = &comm->base;
+  base->schedParms.enable = schedEnable;
+  base->schedParms.doWrr = doWrr;
+  base->schedParms.splitData = splitData;
+  base->schedParms.splitDataMin = splitDataMin;
+  return ncclSuccess;
 }
 
 #ifdef ENABLE_FAULT_INJECTION
@@ -541,15 +498,15 @@ extern "C" ncclResult_t ncclIbCastSetSchedParms(void* sendComm,
 
 extern "C" ncclResult_t ncclIbCastGetResiliencyState(void* sendComm, struct ncclIbCastResiliencyState* out) {
   if (!sendComm || !out) return ncclInvalidArgument;
-  struct ncclIbSendComm* comm = (struct ncclIbSendComm*) sendComm;
+  struct ncclIbSendComm* comm = (struct ncclIbSendComm*)sendComm;
   struct ncclIbResiliency* res = comm->base.resiliency;
   if (!res) return ncclInvalidArgument;
 
-  out->recoveryEnabled    = res->recoveryEnabled;
-  out->inProgress         = res->inProgress;
+  out->recoveryEnabled = res->recoveryEnabled;
+  out->inProgress = res->inProgress;
   out->outstandingRequests = res->outstandingRequests;
   out->outstandingRecovery = res->outstandingRecovery;
-  out->ndevs              = res->ndevs;
+  out->ndevs = res->ndevs;
   for (int i = 0; i < res->ndevs && i < NCCL_IB_MAX_DEVS_PER_NIC; i++) {
     out->devState[i] = (int)res->devs[i].state.load(std::memory_order_acquire);
     out->recoveryCount[i] = res->devs[i].recoveryCount;
@@ -560,7 +517,7 @@ extern "C" ncclResult_t ncclIbCastGetResiliencyState(void* sendComm, struct nccl
 
 extern "C" ncclResult_t ncclIbCastGetRepostCount(void* sendComm, int* out) {
   if (!sendComm || !out) return ncclInvalidArgument;
-  struct ncclIbSendComm* comm = (struct ncclIbSendComm*) sendComm;
+  struct ncclIbSendComm* comm = (struct ncclIbSendComm*)sendComm;
   struct ncclIbResiliency* res = comm->base.resiliency;
   if (!res) return ncclInvalidArgument;
   *out = res->repostCount;

--- a/projects/rccl/src/transport/net_socket.cc
+++ b/projects/rccl/src/transport/net_socket.cc
@@ -47,33 +47,34 @@ static ncclProfilerCallback_t ncclProfilerFunction;
 // context support is added to the plugin the ref counter can be removed.
 static int netRefCount;
 
-ncclResult_t ncclNetSocketInit(void** ctx, uint64_t commId, ncclNetCommConfig_t* config, ncclDebugLogger_t logFunction, ncclProfilerCallback_t profFunction) {
+ncclResult_t ncclNetSocketInit(void** ctx, uint64_t commId, ncclNetCommConfig_t* config, ncclDebugLogger_t logFunction,
+                               ncclProfilerCallback_t profFunction) {
   if (netRefCount++) return ncclSuccess;
   ncclProfilerFunction = profFunction;
   if (ncclNetIfs == -1) {
     std::lock_guard<std::mutex> lock(ncclNetSocketMutex);
     if (ncclNetIfs == -1) {
-      char names[MAX_IF_NAME_SIZE*MAX_IFS];
+      char names[MAX_IF_NAME_SIZE * MAX_IFS];
       union ncclSocketAddress addrs[MAX_IFS];
       NCCLCHECK(ncclFindInterfaces(names, addrs, MAX_IF_NAME_SIZE, MAX_IFS, &ncclNetIfs));
       if (ncclNetIfs <= 0) {
         WARN("NET/Socket : no interface found");
         return ncclInternalError;
       } else {
-        #define MAX_LINE_LEN (2047)
-        char line[MAX_LINE_LEN+1];
-        char addrline[SOCKET_NAME_MAXLEN+1];
+#define MAX_LINE_LEN (2047)
+        char line[MAX_LINE_LEN + 1];
+        char addrline[SOCKET_NAME_MAXLEN + 1];
         line[0] = '\0';
         addrline[SOCKET_NAME_MAXLEN] = '\0';
-        for (int i=0; i<ncclNetIfs; i++) {
-          strcpy(ncclNetSocketDevs[i].devName, names+i*MAX_IF_NAME_SIZE);
-          memcpy(&ncclNetSocketDevs[i].addr, addrs+i, sizeof(union ncclSocketAddress));
+        for (int i = 0; i < ncclNetIfs; i++) {
+          strcpy(ncclNetSocketDevs[i].devName, names + i * MAX_IF_NAME_SIZE);
+          memcpy(&ncclNetSocketDevs[i].addr, addrs + i, sizeof(union ncclSocketAddress));
           NCCLCHECK(ncclNetSocketGetPciPath(ncclNetSocketDevs[i].devName, &ncclNetSocketDevs[i].pciPath));
-          snprintf(line+strlen(line), MAX_LINE_LEN-strlen(line), " [%d]%s:%s", i, names+i*MAX_IF_NAME_SIZE,
-              ncclSocketToString(&addrs[i], addrline));
+          snprintf(line + strlen(line), MAX_LINE_LEN - strlen(line), " [%d]%s:%s", i, names + i * MAX_IF_NAME_SIZE,
+                   ncclSocketToString(&addrs[i], addrline));
         }
         line[MAX_LINE_LEN] = '\0';
-        INFO(NCCL_INIT|NCCL_NET,"NET/Socket : Using%s", line);
+        INFO(NCCL_INIT | NCCL_NET, "NET/Socket : Using%s", line);
       }
     }
   }
@@ -89,7 +90,7 @@ static ncclResult_t ncclNetSocketGetSpeed(char* devName, int* speed) {
   ncclResult_t ret = ncclSuccess;
   *speed = 0;
 
-  #if defined(NCCL_OS_WINDOWS)
+#if defined(NCCL_OS_WINDOWS)
   // On Windows, use GetAdaptersAddresses to get network interface speed
   ULONG bufferSize = 15000;
   IP_ADAPTER_ADDRESSES* adapterAddresses = NULL;
@@ -148,7 +149,7 @@ static ncclResult_t ncclNetSocketGetSpeed(char* devName, int* speed) {
     char speedStr[] = "        ";
     int n;
     // Allow this to silently fail
-    n = read(fd, speedStr, sizeof(speedStr)-1);
+    n = read(fd, speedStr, sizeof(speedStr) - 1);
     if (n > 0) {
       *speed = strtol(speedStr, NULL, 0);
     }
@@ -174,7 +175,7 @@ ncclResult_t ncclNetSocketGetProperties(int dev, ncclNetProperties_t* props) {
   props->port = 0;
   props->maxComms = 65536;
   props->maxRecvs = 1;
-  props->netDeviceType    = NCCL_NET_DEVICE_HOST;
+  props->netDeviceType = NCCL_NET_DEVICE_HOST;
   props->netDeviceVersion = NCCL_NET_DEVICE_INVALID_VERSION;
   props->maxP2pBytes = NCCL_MAX_NET_SIZE_BYTES;
   props->maxCollBytes = MAX_COLLNET_SIZE;
@@ -286,39 +287,40 @@ struct ncclNetSocketComm {
   struct ncclNetSocketThreadResources threadResources[MAX_THREADS];
 };
 
-void* persistentSocketThread(void *args_) {
+void* persistentSocketThread(void* args_) {
   struct ncclNetSocketThreadResources* resource = (struct ncclNetSocketThreadResources*)args_;
   struct ncclNetSocketComm* comm = resource->comm;
   struct ncclNetSocketTaskQueue* myQueue = &resource->threadTaskQueue;
   int nSocksPerThread = comm->nSocks / comm->nThreads;
 #ifdef NCCL_ENABLE_NET_PROFILING
-  void* eHandle[MAX_REQUESTS*MAX_SOCKETS] = { 0 };
+  void* eHandle[MAX_REQUESTS * MAX_SOCKETS] = {0};
 #endif
   while (1) {
     int idle = 1;
     int mark = myQueue->next; // mark newest task seen
-    for (int i=0; i<myQueue->len; i+=nSocksPerThread) {
+    for (int i = 0; i < myQueue->len; i += nSocksPerThread) {
       int repeat;
       do {
         repeat = 0;
-        for (int j=0; j<nSocksPerThread; j++) {
-          struct ncclNetSocketTask* r = myQueue->tasks+i+j;
+        for (int j = 0; j < nSocksPerThread; j++) {
+          struct ncclNetSocketTask* r = myQueue->tasks + i + j;
           if (r != NULL && r->used == 1 && r->offset < r->size) {
 #ifdef NCCL_ENABLE_NET_PROFILING
-            if (!eHandle[i+j]) {
+            if (!eHandle[i + j]) {
               ncclProfilerNetSockDescr_v1_t data;
               data.type = ncclProfileSocket;
               data.sock.fd = r->sock->socketDescriptor;
               data.sock.op = r->op;
               data.sock.length = r->size;
-              ncclProfilerFunction(&eHandle[i+j], ncclProfilerNetEventStart, resource->pInfo->pHandle, NCCL_PROFILER_NET_TYPE_SOCK | 1, &data);
+              ncclProfilerFunction(&eHandle[i + j], ncclProfilerNetEventStart, resource->pInfo->pHandle,
+                                   NCCL_PROFILER_NET_TYPE_SOCK | 1, &data);
             }
 #endif
             r->result = ncclSocketProgress(r->op, r->sock, r->data, r->size, &r->offset);
             if (r->result != ncclSuccess) {
 #ifdef NCCL_ENABLE_NET_PROFILING
-              ncclProfilerFunction(&eHandle[i+j], ncclProfilerNetEventStop, NULL, 0, NULL);
-              eHandle[i+j] = NULL;
+              ncclProfilerFunction(&eHandle[i + j], ncclProfilerNetEventStop, NULL, 0, NULL);
+              eHandle[i + j] = NULL;
 #endif
               WARN("NET/Socket : socket progress error");
               return NULL;
@@ -327,8 +329,8 @@ void* persistentSocketThread(void *args_) {
             if (r->offset < r->size) repeat = 1;
 #ifdef NCCL_ENABLE_NET_PROFILING
             if (repeat == 0) {
-              ncclProfilerFunction(&eHandle[i+j], ncclProfilerNetEventStop, NULL, 0, NULL);
-              eHandle[i+j] = NULL;
+              ncclProfilerFunction(&eHandle[i + j], ncclProfilerNetEventStop, NULL, 0, NULL);
+              eHandle[i + j] = NULL;
             }
 #endif
           }
@@ -355,7 +357,7 @@ ncclResult_t ncclNetSocketGetNsockNthread(int dev, int* ns, int* nt) {
   int nSocks;
   if (nThreads == -2 || nSocksPerThread == -2) {
     // Auto-detection
-    int autoNt=0, autoNs=1; // By default, we only use the main thread and do not spawn extra threads
+    int autoNt = 0, autoNs = 1; // By default, we only use the main thread and do not spawn extra threads
     char vendorPath[PATH_MAX];
     snprintf(vendorPath, PATH_MAX, "/sys/class/net/%s/device/vendor", ncclNetSocketDevs[dev].devName);
     // Coverity is wrong.  NULL second argument to realpath() is OK by POSIX.1-2008.
@@ -379,14 +381,16 @@ ncclResult_t ncclNetSocketGetNsockNthread(int dev, int* ns, int* nt) {
       autoNt = 4;
       autoNs = 1;
     }
-end:
+  end:
     if (nThreads == -2) nThreads = autoNt;
     if (nSocksPerThread == -2) nSocksPerThread = autoNs;
   }
   nSocks = nSocksPerThread * nThreads;
   if (nSocks > MAX_SOCKETS) {
-    nSocksPerThread = MAX_SOCKETS/nThreads;
-    WARN("NET/Socket : the total number of sockets is greater than the maximum allowed, setting NCCL_NSOCKS_PERTHREAD to %d", nSocksPerThread);
+    nSocksPerThread = MAX_SOCKETS / nThreads;
+    WARN("NET/Socket : the total number of sockets is greater than the maximum allowed, setting NCCL_NSOCKS_PERTHREAD "
+         "to %d",
+         nSocksPerThread);
     nSocks = nSocksPerThread * nThreads;
   }
   *ns = nSocks;
@@ -405,13 +409,15 @@ ncclResult_t ncclNetSocketListen(void* ctx, int dev, void* opaqueHandle, void** 
     return ncclInternalError;
   }
   ncclResult_t ret = ncclSuccess;
-  struct ncclNetSocketHandle* handle = (struct ncclNetSocketHandle*) opaqueHandle;
+  struct ncclNetSocketHandle* handle = (struct ncclNetSocketHandle*)opaqueHandle;
   memset(handle, 0, sizeof(struct ncclNetSocketHandle));
   static_assert(sizeof(struct ncclNetSocketHandle) <= NCCL_NET_HANDLE_MAXSIZE, "ncclNetSocketHandle size too large");
   struct ncclNetSocketListenComm* comm;
   NCCLCHECK(ncclCalloc(&comm, 1));
   handle->magic = NCCL_SOCKET_MAGIC;
-  NCCLCHECKGOTO(ncclSocketInit(&comm->sock, &ncclNetSocketDevs[dev].addr, handle->magic, ncclSocketTypeNetSocket, NULL, 1), ret, fail);
+  NCCLCHECKGOTO(ncclSocketInit(&comm->sock, &ncclNetSocketDevs[dev].addr, handle->magic, ncclSocketTypeNetSocket, NULL,
+                               1),
+                ret, fail);
   NCCLCHECKGOTO(ncclSocketListen(&comm->sock), ret, fail);
   NCCLCHECKGOTO(ncclSocketGetAddr(&comm->sock, &handle->connectAddr), ret, fail);
   NCCLCHECKGOTO(ncclNetSocketGetNsockNthread(dev, &comm->nSocks, &comm->nThreads), ret, fail);
@@ -428,13 +434,14 @@ fail:
 }
 
 #define SOCKET_CTRL_SIZE (sizeof(int))
-ncclResult_t ncclNetSocketConnect(void* ctx, int dev, void* opaqueHandle, void** sendComm, ncclNetDeviceHandle_t** /*sendDevComm*/) {
+ncclResult_t ncclNetSocketConnect(void* ctx, int dev, void* opaqueHandle, void** sendComm,
+                                  ncclNetDeviceHandle_t** /*sendDevComm*/) {
   if (dev < 0 || dev >= ncclNetIfs) { // data transfer socket is based on specified dev
     return ncclInternalError;
   }
 
   int ready;
-  struct ncclNetSocketHandle* handle = (struct ncclNetSocketHandle*) opaqueHandle;
+  struct ncclNetSocketHandle* handle = (struct ncclNetSocketHandle*)opaqueHandle;
   struct ncclNetSocketCommStage* stage = &handle->stage;
   struct ncclNetSocketComm* comm = stage->comm;
   uint8_t i = stage->iteration;
@@ -450,8 +457,8 @@ ncclResult_t ncclNetSocketConnect(void* ctx, int dev, void* opaqueHandle, void**
   comm->nThreads = handle->nThreads;
   comm->dev = dev;
   CUDACHECK(cudaGetDevice(&comm->cudaDev));
-  for (; i<comm->nSocks+1; i++) {
-    sock = (i == comm->nSocks) ? &comm->ctrlSock : comm->socks+i;
+  for (; i < comm->nSocks + 1; i++) {
+    sock = (i == comm->nSocks) ? &comm->ctrlSock : comm->socks + i;
     NCCLCHECK(ncclSocketInit(sock, &handle->connectAddr, handle->magic, ncclSocketTypeNetSocket, NULL, 1));
 
     stage->sock = sock;
@@ -459,12 +466,12 @@ ncclResult_t ncclNetSocketConnect(void* ctx, int dev, void* opaqueHandle, void**
     stage->iteration = i;
     NCCLCHECK(ncclSocketConnect(sock));
 
-socket_connect_check:
+  socket_connect_check:
     NCCLCHECK(ncclSocketReady(sock, &ready));
-    if (! ready) return ncclSuccess;
+    if (!ready) return ncclSuccess;
     stage->state = ncclNetSocketCommStateSend;
 
-socket_send:
+  socket_send:
     int done = 0;
     NCCLCHECK(ncclSocketProgress(NCCL_SOCKET_SEND, sock, &i, sizeof(uint8_t), &done));
     if (done == 0) return ncclSuccess;
@@ -492,7 +499,7 @@ ncclResult_t ncclNetSocketAccept(void* listenComm, void** recvComm, ncclNetDevic
   rComm->nThreads = lComm->nThreads;
   rComm->dev = lComm->dev;
   CUDACHECK(cudaGetDevice(&rComm->cudaDev));
-  for (; i<rComm->nSocks+1; i++) {
+  for (; i < rComm->nSocks + 1; i++) {
     uint8_t sendSockIdx;
 
     NCCLCHECK(ncclCalloc(&sock, 1));
@@ -502,20 +509,18 @@ ncclResult_t ncclNetSocketAccept(void* listenComm, void** recvComm, ncclNetDevic
     stage->iteration = i;
     NCCLCHECK(ncclSocketAccept(sock, &lComm->sock));
 
-socket_accept_check:
+  socket_accept_check:
     NCCLCHECK(ncclSocketReady(sock, &ready));
     if (!ready) return ncclSuccess;
 
     stage->state = ncclNetSocketCommStateRecv;
-socket_recv:
+  socket_recv:
     int done = 0;
     NCCLCHECK(ncclSocketProgress(NCCL_SOCKET_RECV, sock, &sendSockIdx, sizeof(uint8_t), &done));
     if (done == 0) return ncclSuccess;
 
-    if (sendSockIdx == rComm->nSocks)
-      rComm->ctrlSock = *sock;
-    else
-      rComm->socks[sendSockIdx] = *sock;
+    if (sendSockIdx == rComm->nSocks) rComm->ctrlSock = *sock;
+    else rComm->socks[sendSockIdx] = *sock;
     free(sock);
   }
   NCCLCHECK(ncclCalloc(&rComm->inlineData, MAX_REQUESTS * (SOCKET_CTRL_SIZE + ncclParamSocketInlineSize())));
@@ -529,9 +534,10 @@ socket_recv:
   return ncclSuccess;
 }
 
-ncclResult_t ncclNetSocketGetRequest(struct ncclNetSocketComm* comm, int op, void* data, int size, struct ncclNetSocketRequest** req) {
-  for (int i=0; i<MAX_REQUESTS; i++) {
-    struct ncclNetSocketRequest* r = comm->requests+i;
+ncclResult_t ncclNetSocketGetRequest(struct ncclNetSocketComm* comm, int op, void* data, int size,
+                                     struct ncclNetSocketRequest** req) {
+  for (int i = 0; i < MAX_REQUESTS; i++) {
+    struct ncclNetSocketRequest* r = comm->requests + i;
     if (r->used == 0) {
       r->op = op;
       r->data = data;
@@ -549,9 +555,10 @@ ncclResult_t ncclNetSocketGetRequest(struct ncclNetSocketComm* comm, int op, voi
   return ncclInternalError;
 }
 
-ncclResult_t ncclNetSocketGetTask(struct ncclNetSocketComm* comm, struct ncclProfilerInfo* pInfo, int op, void* data, int size, struct ncclNetSocketTask** req) {
+ncclResult_t ncclNetSocketGetTask(struct ncclNetSocketComm* comm, struct ncclProfilerInfo* pInfo, int op, void* data,
+                                  int size, struct ncclNetSocketTask** req) {
   int tid = comm->nextSock % comm->nThreads;
-  struct ncclNetSocketThreadResources* res = comm->threadResources+tid;
+  struct ncclNetSocketThreadResources* res = comm->threadResources + tid;
   struct ncclNetSocketTaskQueue* queue = &res->threadTaskQueue;
   // create helper threads and prepare per-thread task queue
   if (queue->tasks == NULL) {
@@ -566,9 +573,10 @@ ncclResult_t ncclNetSocketGetTask(struct ncclNetSocketComm* comm, struct ncclPro
     res->pInfo = pInfo;
 #endif
     comm->helperThread[tid] = std::thread(persistentSocketThread, res);
-    ncclSetThreadName(comm->helperThread[tid], "NCCL Sock%c%1u%2u%2u", op == NCCL_SOCKET_SEND ? 'S' : 'R', comm->dev, tid, comm->cudaDev);
+    ncclSetThreadName(comm->helperThread[tid], "NCCL Sock%c%1u%2u%2u", op == NCCL_SOCKET_SEND ? 'S' : 'R', comm->dev,
+                      tid, comm->cudaDev);
   }
-  struct ncclNetSocketTask* r = queue->tasks+queue->next;
+  struct ncclNetSocketTask* r = queue->tasks + queue->next;
   if (r->used == 0) {
     r->op = op;
     r->data = data;
@@ -580,7 +588,7 @@ ncclResult_t ncclNetSocketGetTask(struct ncclNetSocketComm* comm, struct ncclPro
     r->used = 1;
     *req = r;
     std::lock_guard<std::mutex> lock(res->threadMutex);
-    queue->next = (queue->next+1)%queue->len;
+    queue->next = (queue->next + 1) % queue->len;
     res->threadCond.notify_one();
     return ncclSuccess;
   }
@@ -589,11 +597,13 @@ ncclResult_t ncclNetSocketGetTask(struct ncclNetSocketComm* comm, struct ncclPro
 }
 
 // if the dataSize is smaller than the inline size, return the inline size; if not, return 0 to avoid the extra copy.
-static int ncclNetSocketInlineSize(int dataSize) { return (dataSize <= ncclParamSocketInlineSize()) ? dataSize : 0; }
+static int ncclNetSocketInlineSize(int dataSize) {
+  return (dataSize <= ncclParamSocketInlineSize()) ? dataSize : 0;
+}
 
 ncclResult_t ncclNetSocketTest(void* request, int* done, int* size) {
   *done = 0;
-  struct ncclNetSocketRequest *r = (struct ncclNetSocketRequest*)request;
+  struct ncclNetSocketRequest* r = (struct ncclNetSocketRequest*)request;
   if (r == NULL) {
     WARN("NET/Socket : test called with NULL request");
     return ncclInternalError;
@@ -619,8 +629,10 @@ ncclResult_t ncclNetSocketTest(void* request, int* done, int* size) {
         char line[SOCKET_NAME_MAXLEN + 1];
         union ncclSocketAddress addr;
         NCCLCHECK(ncclSocketGetAddr(r->ctrlSock, &addr));
-        WARN("NET/Socket : peer %s message truncated : receiving %d bytes instead of %d. If you believe your socket network is in a healthy state, "
-             "there may be a mismatch in collective sizes or environment settings (e.g. NCCL_PROTO, NCCL_ALGO) between ranks",
+        WARN("NET/Socket : peer %s message truncated : receiving %d bytes instead of %d. If you believe your socket "
+             "network is in a healthy state, "
+             "there may be a mismatch in collective sizes or environment settings (e.g. NCCL_PROTO, NCCL_ALGO) between "
+             "ranks",
              ncclSocketToString(&addr, line), senderSize, r->size);
         return ncclInvalidUsage;
       }
@@ -646,7 +658,8 @@ ncclResult_t ncclNetSocketTest(void* request, int* done, int* size) {
       int taskSize = std::max((int)ncclParamSocketMinTaskSize(), DIVUP(r->size - r->offset, r->comm->nSocks));
       while (chunkOffset < r->size) {
         int chunkSize = std::min(taskSize, r->size - chunkOffset);
-        NCCLCHECK(ncclNetSocketGetTask(r->comm, &r->pInfo, r->op, (char*)(r->data) + chunkOffset, chunkSize, r->tasks + i++));
+        NCCLCHECK(ncclNetSocketGetTask(r->comm, &r->pInfo, r->op, (char*)(r->data) + chunkOffset, chunkSize,
+                                       r->tasks + i++));
         chunkOffset += chunkSize;
       }
     }
@@ -655,7 +668,7 @@ ncclResult_t ncclNetSocketTest(void* request, int* done, int* size) {
   if (r->used == 2) { // already exchanged size
     if (r->nSubs > 0) {
       int nCompleted = 0;
-      for (int i=0; i<r->nSubs; i++) {
+      for (int i = 0; i < r->nSubs; i++) {
         struct ncclNetSocketTask* sub = r->tasks[i];
         if (sub->result != ncclSuccess) return sub->result;
         if (sub->offset == sub->size) nCompleted++;
@@ -664,7 +677,7 @@ ncclResult_t ncclNetSocketTest(void* request, int* done, int* size) {
         if (size) *size = r->size;
         *done = 1;
         r->used = 0;
-        for (int i=0; i<r->nSubs; i++) {
+        for (int i = 0; i < r->nSubs; i++) {
           struct ncclNetSocketTask* sub = r->tasks[i];
           sub->used = 0;
         }
@@ -677,7 +690,8 @@ ncclResult_t ncclNetSocketTest(void* request, int* done, int* size) {
         data.sock.fd = r->ctrlSock->socketDescriptor;
         data.sock.op = r->op;
         data.sock.length = r->size;
-        ncclProfilerFunction(&r->pInfo.eHandle, ncclProfilerNetEventStart, r->pInfo.pHandle, NCCL_PROFILER_NET_TYPE_SOCK | 1, &data);
+        ncclProfilerFunction(&r->pInfo.eHandle, ncclProfilerNetEventStart, r->pInfo.pHandle,
+                             NCCL_PROFILER_NET_TYPE_SOCK | 1, &data);
       }
 #endif
       if (r->offset < r->size) {
@@ -700,26 +714,31 @@ ncclResult_t ncclNetSocketTest(void* request, int* done, int* size) {
 ncclResult_t ncclNetSocketRegMr(void* comm, void* data, size_t size, int type, void** mhandle) {
   return (type != NCCL_PTR_HOST) ? ncclInternalError : ncclSuccess;
 }
-ncclResult_t ncclNetSocketDeregMr(void* comm, void* mhandle) { return ncclSuccess; }
+ncclResult_t ncclNetSocketDeregMr(void* comm, void* mhandle) {
+  return ncclSuccess;
+}
 
-ncclResult_t ncclNetSocketIsend(void* sendComm, void* data, size_t size, int tag, void* mhandle, void* phandle, void** request) {
+ncclResult_t ncclNetSocketIsend(void* sendComm, void* data, size_t size, int tag, void* mhandle, void* phandle,
+                                void** request) {
   struct ncclNetSocketComm* comm = (struct ncclNetSocketComm*)sendComm;
-  NCCLCHECK(ncclNetSocketGetRequest(comm, NCCL_SOCKET_SEND, data, (int) size, (struct ncclNetSocketRequest**)request));
+  NCCLCHECK(ncclNetSocketGetRequest(comm, NCCL_SOCKET_SEND, data, (int)size, (struct ncclNetSocketRequest**)request));
 #ifdef NCCL_ENABLE_NET_PROFILING
   // NCCL core profiler callback
-  struct ncclNetSocketRequest* req = *(struct ncclNetSocketRequest **)request;
+  struct ncclNetSocketRequest* req = *(struct ncclNetSocketRequest**)request;
   req->pInfo.pHandle = phandle;
 #endif
   return ncclSuccess;
 }
 
-ncclResult_t ncclNetSocketIrecv(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles, void** phandles, void** request) {
+ncclResult_t ncclNetSocketIrecv(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles,
+                                void** phandles, void** request) {
   struct ncclNetSocketComm* comm = (struct ncclNetSocketComm*)recvComm;
   if (n != 1) return ncclInternalError;
-  NCCLCHECK(ncclNetSocketGetRequest(comm, NCCL_SOCKET_RECV, data[0], (int)sizes[0], (struct ncclNetSocketRequest**)request));
+  NCCLCHECK(ncclNetSocketGetRequest(comm, NCCL_SOCKET_RECV, data[0], (int)sizes[0],
+                                    (struct ncclNetSocketRequest**)request));
 #ifdef NCCL_ENABLE_NET_PROFILING
   // NCCL core profiler callback
-  struct ncclNetSocketRequest* req = *(struct ncclNetSocketRequest **)request;
+  struct ncclNetSocketRequest* req = *(struct ncclNetSocketRequest**)request;
   if (phandles) req->pInfo.pHandle = phandles[0];
 #endif
   return ncclSuccess;
@@ -744,8 +763,8 @@ ncclResult_t ncclNetSocketCloseListen(void* opaqueComm) {
 ncclResult_t ncclNetSocketClose(void* opaqueComm) {
   struct ncclNetSocketComm* comm = (struct ncclNetSocketComm*)opaqueComm;
   if (comm) {
-    for (int i=0; i<comm->nThreads; i++) {
-      struct ncclNetSocketThreadResources* res = comm->threadResources+i;
+    for (int i = 0; i < comm->nThreads; i++) {
+      struct ncclNetSocketThreadResources* res = comm->threadResources + i;
       if (comm->helperThread[i].joinable()) {
         {
           std::lock_guard<std::mutex> lock(res->threadMutex);
@@ -759,11 +778,11 @@ ncclResult_t ncclNetSocketClose(void* opaqueComm) {
     int ready;
     NCCLCHECK(ncclSocketReady(&comm->ctrlSock, &ready));
     if (ready) NCCLCHECK(ncclSocketClose(&comm->ctrlSock));
-    for (int i=0; i<comm->nSocks; i++) {
+    for (int i = 0; i < comm->nSocks; i++) {
       NCCLCHECK(ncclSocketReady(&comm->socks[i], &ready));
       if (ready) NCCLCHECK(ncclSocketClose(&comm->socks[i]));
     }
-    if(comm->inlineData) free(comm->inlineData);
+    if (comm->inlineData) free(comm->inlineData);
     delete comm;
   }
   return ncclSuccess;

--- a/projects/rccl/src/transport/nvls.cc
+++ b/projects/rccl/src/transport/nvls.cc
@@ -29,7 +29,8 @@ struct localRegData {
   int handleTypes;
 };
 
-ncclResult_t nvlsCanConnect(int* ret, struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* info1, struct ncclPeerInfo* info2) {
+ncclResult_t nvlsCanConnect(int* ret, struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* info1,
+                            struct ncclPeerInfo* info2) {
   // This transport cannot be used for p2p
   *ret = 0;
   return ncclSuccess;
@@ -43,14 +44,13 @@ ncclResult_t nvlsRecvFree(struct ncclComm* comm, struct ncclConnector* recv) {
   return ncclSuccess;
 }
 
-struct ncclTransport nvlsTransport = {
-  "NVLS",
-  nvlsCanConnect,
-  { NULL, NULL, nvlsSendFree, NULL, NULL, NULL, NULL, NULL },
-  { NULL, NULL, nvlsRecvFree, NULL, NULL, NULL, NULL, NULL }
-};
+struct ncclTransport nvlsTransport = {"NVLS",
+                                      nvlsCanConnect,
+                                      {NULL, NULL, nvlsSendFree, NULL, NULL, NULL, NULL, NULL},
+                                      {NULL, NULL, nvlsRecvFree, NULL, NULL, NULL, NULL, NULL}};
 
-ncclResult_t ncclNvlsGroupCreate(struct ncclComm *comm, CUmulticastObjectProp *prop, int rank, unsigned int nranks, CUmemGenericAllocationHandle *mcHandle, char *shareableHandle) {
+ncclResult_t ncclNvlsGroupCreate(struct ncclComm* comm, CUmulticastObjectProp* prop, int rank, unsigned int nranks,
+                                 CUmemGenericAllocationHandle* mcHandle, char* shareableHandle) {
   CUmemAllocationHandleType type = ncclCuMemHandleType;
   size_t size = prop->size;
 
@@ -62,8 +62,7 @@ ncclResult_t ncclNvlsGroupCreate(struct ncclComm *comm, CUmulticastObjectProp *p
   if (type == CU_MEM_HANDLE_TYPE_FABRIC) {
     // Get a handle to pass to other ranks
     CUCHECK(cuMemExportToShareableHandle(shareableHandle, *mcHandle, ncclCuMemHandleType, 0));
-  }
-  else {
+  } else {
     memcpy(shareableHandle, mcHandle, sizeof(CUmemGenericAllocationHandle));
   }
 
@@ -72,7 +71,8 @@ ncclResult_t ncclNvlsGroupCreate(struct ncclComm *comm, CUmulticastObjectProp *p
   return ncclSuccess;
 }
 
-ncclResult_t ncclNvlsGroupConnect(struct ncclComm *comm, char *shareableHandle, int rank, CUmemGenericAllocationHandle *mcHandle) {
+ncclResult_t ncclNvlsGroupConnect(struct ncclComm* comm, char* shareableHandle, int rank,
+                                  CUmemGenericAllocationHandle* mcHandle) {
   CUmemAllocationHandleType type = ncclCuMemHandleType;
   int fd = -1;
   ncclResult_t ret = ncclSuccess;
@@ -82,14 +82,15 @@ ncclResult_t ncclNvlsGroupConnect(struct ncclComm *comm, char *shareableHandle, 
   if (type == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) {
     // cuMem UDS support
     TRACE(NCCL_NVLS, "NVLS rank %d Importing shareable handle %p from rank %d", comm->localRank, shareableHandle, rank);
-    TRACE(NCCL_NVLS, "NVLS rank %d request conversion of handle 0x%lx from rank %d", comm->localRank, *(uint64_t*)shareableHandle, rank);
+    TRACE(NCCL_NVLS, "NVLS rank %d request conversion of handle 0x%lx from rank %d", comm->localRank,
+          *(uint64_t*)shareableHandle, rank);
     NCCLCHECKGOTO(ncclProxyClientGetFdBlocking(comm, rank, shareableHandle, &fd), ret, fail);
     TRACE(NCCL_NVLS, "NVLS rank %d received converted fd %d from rank %d", comm->localRank, fd, rank);
-    CUCHECKGOTO(cuMemImportFromShareableHandle(mcHandle, (void *)(uintptr_t)fd, type), ret, fail);
+    CUCHECKGOTO(cuMemImportFromShareableHandle(mcHandle, (void*)(uintptr_t)fd, type), ret, fail);
     SYSCHECK(close(fd), "close");
   } else {
     if (type == CU_MEM_HANDLE_TYPE_FABRIC) {
-      CUCHECKGOTO(cuMemImportFromShareableHandle(mcHandle, (void *)shareableHandle, type), ret, fail);
+      CUCHECKGOTO(cuMemImportFromShareableHandle(mcHandle, (void*)shareableHandle, type), ret, fail);
     } else {
       memcpy(mcHandle, shareableHandle, sizeof(CUmemGenericAllocationHandle));
     }
@@ -101,29 +102,34 @@ fail:
   goto exit;
 }
 
-ncclResult_t nvlsGroupUnbind(struct ncclComm *comm, size_t size, CUmemGenericAllocationHandle* mcHandle) {
+ncclResult_t nvlsGroupUnbind(struct ncclComm* comm, size_t size, CUmemGenericAllocationHandle* mcHandle) {
   int dev = comm->cudaDev;
   INFO(NCCL_NVLS, "NVLS Unbind MC handle %llx size %zu dev %d", *mcHandle, size, dev);
 
   // Unbind physical memory from group for the given device
-  if (size) CUCHECK(cuMulticastUnbind(*mcHandle, dev, 0/*mcOffset*/, size));
+  if (size) CUCHECK(cuMulticastUnbind(*mcHandle, dev, 0 /*mcOffset*/, size));
 
   return ncclSuccess;
 }
 
-ncclResult_t ncclNvlsDeregBuffer(struct ncclComm* comm, CUmemGenericAllocationHandle *mcHandler, CUdeviceptr ptr, int dev, size_t ucsize, size_t mcsize) {
+ncclResult_t ncclNvlsDeregBuffer(struct ncclComm* comm, CUmemGenericAllocationHandle* mcHandler, CUdeviceptr ptr,
+                                 int dev, size_t ucsize, size_t mcsize) {
   // unbind can trigger RM error if buffer is freed already by users
   // however, it is safe to ignore the error, and unbind will succeed anyway
-  CUCALL(cuMulticastUnbind(*mcHandler, dev, 0/*mcOffset*/, ucsize));
+  CUCALL(cuMulticastUnbind(*mcHandler, dev, 0 /*mcOffset*/, ucsize));
   CUCHECK(cuMemUnmap(ptr, mcsize));
   CUCHECK(cuMemAddressFree(ptr, mcsize));
   CUCHECK(cuMemRelease(*mcHandler));
-  INFO(NCCL_NVLS, "rank %d - NVLS deregistered buffer %p on device %d ucsize %ld mcsize %ld", comm->rank, (void*)ptr, dev, ucsize, mcsize);
+  INFO(NCCL_NVLS, "rank %d - NVLS deregistered buffer %p on device %d ucsize %ld mcsize %ld", comm->rank, (void*)ptr,
+       dev, ucsize, mcsize);
   return ncclSuccess;
 }
 
-ncclResult_t nvlsGroupUnmapMem(struct ncclComm *comm, size_t ucsize, void* ucptr, CUmemGenericAllocationHandle* ucHandle, size_t mcsize, void* mcptr, CUmemGenericAllocationHandle* mcHandle) {
-  INFO(NCCL_NVLS, "NVLS Unmap mem UC handle 0x%llx(%p) ucsize %zu MC handle 0x%llx(%p) mcsize %zd", *ucHandle, ucptr, ucsize, *mcHandle, mcptr, mcsize);
+ncclResult_t nvlsGroupUnmapMem(struct ncclComm* comm, size_t ucsize, void* ucptr,
+                               CUmemGenericAllocationHandle* ucHandle, size_t mcsize, void* mcptr,
+                               CUmemGenericAllocationHandle* mcHandle) {
+  INFO(NCCL_NVLS, "NVLS Unmap mem UC handle 0x%llx(%p) ucsize %zu MC handle 0x%llx(%p) mcsize %zd", *ucHandle, ucptr,
+       ucsize, *mcHandle, mcptr, mcsize);
 
   // Release the UC memory and mapping
   if (ucptr) {
@@ -151,41 +157,42 @@ ncclResult_t nvlsGroupUnmapMem(struct ncclComm *comm, size_t ucsize, void* ucptr
 #define NVLS_NCHANNELS_SM100_NVL 24
 
 NCCL_PARAM(NvlsEnable, "NVLS_ENABLE", 2);
-NCCL_PARAM(NvlsChunkSize, "NVLS_CHUNKSIZE", 128*1024);
+NCCL_PARAM(NvlsChunkSize, "NVLS_CHUNKSIZE", 128 * 1024);
 NCCL_PARAM(NvlsTreeMaxChunkSize, "NVLSTREE_MAX_CHUNKSIZE", -2);
 
 // Returns optimal NVLSTree tuning parameters for SM100 multi-node configurations.
-static ncclResult_t ncclNvlsTreeSm100Tuning(struct ncclComm* comm, int* nChannels, int* chunkSize, int* treeMaxChunkSize) {
+static ncclResult_t ncclNvlsTreeSm100Tuning(struct ncclComm* comm, int* nChannels, int* chunkSize,
+                                            int* treeMaxChunkSize) {
   int nNodes = comm->nNodes;
   int ppn = comm->minLocalRanks;
   float nicBw = comm->minNetBw;
   int gpuToNicPathType = comm->graphs[NCCL_ALGO_NVLS].typeInter;
 
-  *chunkSize = 128*1024;
+  *chunkSize = 128 * 1024;
 
   if (nNodes == 2 && nicBw >= 48.0f) {
     *nChannels = 32;
-    *treeMaxChunkSize = 128*1024;
+    *treeMaxChunkSize = 128 * 1024;
     if (ppn <= 4) {
-      *chunkSize = 256*1024;
-      *treeMaxChunkSize = 256*1024;
+      *chunkSize = 256 * 1024;
+      *treeMaxChunkSize = 256 * 1024;
     } else if (ppn >= 16 || (ppn <= 8 && gpuToNicPathType <= PATH_PXB && nicBw < 96.0f)) {
-      *treeMaxChunkSize = 64*1024;
+      *treeMaxChunkSize = 64 * 1024;
     }
   } else if (nicBw >= 96.0f) {
     if (ppn <= 8) {
       *nChannels = 24;
-      *chunkSize = 256*1024;
-      *treeMaxChunkSize = 256*1024;
+      *chunkSize = 256 * 1024;
+      *treeMaxChunkSize = 256 * 1024;
     } else {
       *nChannels = 32;
-      *treeMaxChunkSize = (ppn < 32) ? 128*1024 : 64*1024;
+      *treeMaxChunkSize = (ppn < 32) ? 128 * 1024 : 64 * 1024;
     }
   } else if (nicBw >= 48.0f) {
     *nChannels = 24;
-    *treeMaxChunkSize = 128*1024;
+    *treeMaxChunkSize = 128 * 1024;
     if (gpuToNicPathType <= PATH_PXB) {
-      *treeMaxChunkSize = 64*1024;
+      *treeMaxChunkSize = 64 * 1024;
     }
   }
 
@@ -219,7 +226,7 @@ ncclResult_t ncclNvlsTuning(struct ncclComm* comm) {
   // Determine final treeMaxChunkSize: env var > tuning > fallback
   int envTreeMaxChunkSize = (int)ncclParamNvlsTreeMaxChunkSize();
   if (envTreeMaxChunkSize == -2 && treeMaxChunkSize == 0) {
-    treeMaxChunkSize = (comm->nNodes >=4) ? 65536 : chunkSize;
+    treeMaxChunkSize = (comm->nNodes >= 4) ? 65536 : chunkSize;
   } else if (envTreeMaxChunkSize != -2) {
     treeMaxChunkSize = envTreeMaxChunkSize;
   }
@@ -232,8 +239,8 @@ ncclResult_t ncclNvlsTuning(struct ncclComm* comm) {
   comm->nvlsChunkSize = chunkSize;
   comm->nvlsTreeMaxChunkSize = treeMaxChunkSize;
 
-  INFO(NCCL_INIT, "NVLS tuning: nChannels %d chunkSize %d treeMaxChunkSize %d",
-       comm->nvlsChannels, comm->nvlsChunkSize, comm->nvlsTreeMaxChunkSize);
+  INFO(NCCL_INIT, "NVLS tuning: nChannels %d chunkSize %d treeMaxChunkSize %d", comm->nvlsChannels, comm->nvlsChunkSize,
+       comm->nvlsTreeMaxChunkSize);
 
   return ncclSuccess;
 }
@@ -261,8 +268,7 @@ ncclResult_t ncclNvlsInit(struct ncclComm* comm) {
     comm->nvlsSupport = 1;
   }
 
-  INFO(NCCL_INIT, "NVLS multicast support is %savailable on dev %d",
-       comm->nvlsSupport ? "" : "not ", dev);
+  INFO(NCCL_INIT, "NVLS multicast support is %savailable on dev %d", comm->nvlsSupport ? "" : "not ", dev);
   return ncclSuccess;
 }
 
@@ -271,8 +277,12 @@ ncclResult_t ncclNvlsTreeConnect(struct ncclComm* comm) {
   if (comm && comm->nvlsSupport && comm->nNodes > 1) {
     for (int c = 0; c < comm->nvlsChannels; c++) {
       struct ncclChannel* channel = comm->channels + c;
-      NCCLCHECKGOTO(ncclTransportP2pConnect(comm, c, NCCL_MAX_NVLS_TREE_ARITY, channel->nvls.treeDown, 1, &channel->nvls.treeUp, 0), ret, fail);
-      NCCLCHECKGOTO(ncclTransportP2pConnect(comm, c, 1, &channel->nvls.treeUp, NCCL_MAX_NVLS_TREE_ARITY, channel->nvls.treeDown, 0), ret, fail);
+      NCCLCHECKGOTO(ncclTransportP2pConnect(comm, c, NCCL_MAX_NVLS_TREE_ARITY, channel->nvls.treeDown, 1,
+                                            &channel->nvls.treeUp, 0),
+                    ret, fail);
+      NCCLCHECKGOTO(ncclTransportP2pConnect(comm, c, 1, &channel->nvls.treeUp, NCCL_MAX_NVLS_TREE_ARITY,
+                                            channel->nvls.treeDown, 0),
+                    ret, fail);
     }
     NCCLCHECKGOTO(ncclTransportP2pSetup(comm, &comm->graphs[NCCL_ALGO_NVLS], 0), ret, fail);
     INFO(NCCL_INIT, "Connected NVLS tree");
@@ -283,7 +293,9 @@ fail:
   goto exit;
 }
 
-static ncclResult_t nvlsAllocateMem(struct ncclComm* comm, const CUmemAccessDesc* desc, size_t size, CUmemGenericAllocationHandle* ucHandle, CUmemGenericAllocationHandle* mcHandle, void** ucptr, void** mcptr, size_t* ucsizePtr, size_t* mcsizePtr) {
+static ncclResult_t nvlsAllocateMem(struct ncclComm* comm, const CUmemAccessDesc* desc, size_t size,
+                                    CUmemGenericAllocationHandle* ucHandle, CUmemGenericAllocationHandle* mcHandle,
+                                    void** ucptr, void** mcptr, size_t* ucsizePtr, size_t* mcsizePtr) {
   char shareableHandle[NVLS_HANDLE_SIZE];
   CUmulticastObjectProp mcprop;
   CUmemAllocationProp ucprop;
@@ -307,11 +319,16 @@ static ncclResult_t nvlsAllocateMem(struct ncclComm* comm, const CUmemAccessDesc
   mcprop.size = mcsize;
 
   if (comm->localRank == 0) {
-    NCCLCHECKGOTO(ncclNvlsGroupCreate(comm, &mcprop, comm->localRank, comm->localRanks, mcHandle, shareableHandle), ret, fail);
+    NCCLCHECKGOTO(ncclNvlsGroupCreate(comm, &mcprop, comm->localRank, comm->localRanks, mcHandle, shareableHandle), ret,
+                  fail);
     allocMcHandle = 1;
-    NCCLCHECKGOTO(bootstrapIntraNodeBroadcast(comm->bootstrap, comm->localRankToRank, comm->localRank, comm->localRanks, 0, shareableHandle, NVLS_HANDLE_SIZE), ret, fail);
+    NCCLCHECKGOTO(bootstrapIntraNodeBroadcast(comm->bootstrap, comm->localRankToRank, comm->localRank, comm->localRanks,
+                                              0, shareableHandle, NVLS_HANDLE_SIZE),
+                  ret, fail);
   } else {
-    NCCLCHECKGOTO(bootstrapIntraNodeBroadcast(comm->bootstrap, comm->localRankToRank, comm->localRank, comm->localRanks, 0, shareableHandle, NVLS_HANDLE_SIZE), ret, fail);
+    NCCLCHECKGOTO(bootstrapIntraNodeBroadcast(comm->bootstrap, comm->localRankToRank, comm->localRank, comm->localRanks,
+                                              0, shareableHandle, NVLS_HANDLE_SIZE),
+                  ret, fail);
     NCCLCHECKGOTO(ncclNvlsGroupConnect(comm, shareableHandle, comm->localRankToRank[0], mcHandle), ret, fail);
     allocMcHandle = 1;
   }
@@ -334,19 +351,24 @@ static ncclResult_t nvlsAllocateMem(struct ncclComm* comm, const CUmemAccessDesc
   CUCHECKGOTO(cuMemSetAccess((CUdeviceptr)*ucptr, ucsize, desc, 1), ret, fail3);
   CUDACHECKGOTO(cudaMemset(*ucptr, 0, ucsize), ret, fail3);
   // Track NVLS buffer as persistent memory
-  NCCLCHECKGOTO(ncclMemTrack(comm->memManager, *ucptr, ucsize, *ucHandle, ncclCuMemHandleType, ncclMemPersist), ret, fail3);
+  NCCLCHECKGOTO(ncclMemTrack(comm->memManager, *ucptr, ucsize, *ucHandle, ncclCuMemHandleType, ncclMemPersist), ret,
+                fail3);
 
   // intra-node barrier to mitigate the possible hang in cuMulticastBindMem during abort
-  NCCLCHECKGOTO(bootstrapIntraNodeBarrier(comm->bootstrap, comm->localRankToRank, comm->localRank, comm->localRanks, comm->localRankToRank[0]), ret, fail3);
+  NCCLCHECKGOTO(bootstrapIntraNodeBarrier(comm->bootstrap, comm->localRankToRank, comm->localRank, comm->localRanks,
+                                          comm->localRankToRank[0]),
+                ret, fail3);
   // Bind physical memory to the Multicast group
   // NB: It will block until all ranks have been added to the Group
   // This is where we normally see issues if the system NVLS/Multicast support is broken
-  err = CUPFN(cuMulticastBindMem(*mcHandle, 0/*mcOffset*/, *ucHandle, 0/*memOffset*/, ucsize, 0/*flags*/));
+  err = CUPFN(cuMulticastBindMem(*mcHandle, 0 /*mcOffset*/, *ucHandle, 0 /*memOffset*/, ucsize, 0 /*flags*/));
   if (err != CUDA_SUCCESS) {
-    const char *errStr;                                                 \
-    (void) pfn_cuGetErrorString(err, &errStr);                          \
-    // Fail the job as NVLS support is not functional
-    WARN("Failed to bind NVLink SHARP (NVLS) Multicast memory of size %ld : CUDA error %d '%s'.\nThis is usually caused by a system or configuration error in the Fabric Manager or NVSwitches.\nDisable NVLS (NCCL_NVLS_ENABLE=0) if you wish to avoid this error in the future.", ucsize, err, errStr );
+    const char* errStr;
+    (void)pfn_cuGetErrorString(err, &errStr);    // Fail the job as NVLS support is not functional
+    WARN("Failed to bind NVLink SHARP (NVLS) Multicast memory of size %ld : CUDA error %d '%s'.\nThis is usually "
+         "caused by a system or configuration error in the Fabric Manager or NVSwitches.\nDisable NVLS "
+         "(NCCL_NVLS_ENABLE=0) if you wish to avoid this error in the future.",
+         ucsize, err, errStr);
     ret = ncclUnhandledCudaError;
     goto fail3;
   }
@@ -358,7 +380,10 @@ static ncclResult_t nvlsAllocateMem(struct ncclComm* comm, const CUmemAccessDesc
   *ucsizePtr = ucsize;
   *mcsizePtr = mcsize;
 
-  INFO(NCCL_NVLS, "NVLS rank %d (dev %d) alloc done, ucptr %p ucgran %ld mcptr %p mcgran %ld ucsize %ld mcsize %ld (inputsize %ld)", comm->rank, comm->cudaDev, *ucptr, ucgran, *mcptr, mcgran, ucsize, mcsize, size);
+  INFO(
+    NCCL_NVLS,
+    "NVLS rank %d (dev %d) alloc done, ucptr %p ucgran %ld mcptr %p mcgran %ld ucsize %ld mcsize %ld (inputsize %ld)",
+    comm->rank, comm->cudaDev, *ucptr, ucgran, *mcptr, mcgran, ucsize, mcsize, size);
 
 exit:
   return ret;
@@ -396,13 +421,21 @@ ncclResult_t ncclNvlsBufferSetup(struct ncclComm* comm) {
   nvlsPerRankSize = nChannels * 2 * buffSize;
   nvlsTotalSize = nvlsPerRankSize * nHeads;
 
-  INFO(NCCL_INIT | NCCL_NVLS, "NVLS comm %p headRank %d nHeads %d nvlsRanks %d buffSize %zu nvlsPerRankSize %zu nvlsTotalSize %zu",
-       comm, headRank, nHeads, comm->localRanks, buffSize, nvlsPerRankSize, nvlsTotalSize);
+  INFO(NCCL_INIT | NCCL_NVLS,
+       "NVLS comm %p headRank %d nHeads %d nvlsRanks %d buffSize %zu nvlsPerRankSize %zu nvlsTotalSize %zu", comm,
+       headRank, nHeads, comm->localRanks, buffSize, nvlsPerRankSize, nvlsTotalSize);
 
-  NCCLCHECKGOTO(nvlsAllocateMem(comm, &resources->accessDesc, nvlsTotalSize, &resources->ucBuffHandle, &resources->mcBuffHandle, (void**)&resources->ucBuff, (void**)&resources->mcBuff, &resources->buffUCSize, &resources->buffMCSize), res, fail);
+  NCCLCHECKGOTO(nvlsAllocateMem(comm, &resources->accessDesc, nvlsTotalSize, &resources->ucBuffHandle,
+                                &resources->mcBuffHandle, (void**)&resources->ucBuff, (void**)&resources->mcBuff,
+                                &resources->buffUCSize, &resources->buffMCSize),
+                res, fail);
 
-  NCCLCHECKGOTO(ncclStrongStreamAcquire(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->hostStream, /*concurrent=*/false, &hostStream), res, fail);
-  NCCLCHECKGOTO(ncclStrongStreamAcquire(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->deviceStream, /*concurrent=*/false, &deviceStream), res, fail);
+  NCCLCHECKGOTO(ncclStrongStreamAcquire(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->hostStream,
+                                        /*concurrent=*/false, &hostStream),
+                res, fail);
+  NCCLCHECKGOTO(ncclStrongStreamAcquire(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->deviceStream,
+                                        /*concurrent=*/false, &deviceStream),
+                res, fail);
   for (int h = 0; h < nHeads; h++) {
     int nvlsPeer = comm->nRanks + 1 + h;
     for (int c = 0; c < nChannels; c++) {
@@ -417,18 +450,32 @@ ncclResult_t ncclNvlsBufferSetup(struct ncclComm* comm) {
       peer->recv[1].conn.buffs[NCCL_PROTO_SIMPLE] = resources->ucBuff + ((h * 2 + 1) * nChannels + c) * buffSize;
       peer->send[0].conn.buffs[NCCL_PROTO_SIMPLE] = resources->mcBuff + ((h * 2 + 1) * nChannels + c) * buffSize;
 
-      CUDACHECKGOTO(cudaMemcpyAsync(&comm->channels[c].devPeersHostPtr[nvlsPeer]->send[0], &peer->send[0].conn, sizeof(struct ncclConnInfo), cudaMemcpyHostToDevice, hostStream), res, fail);
-      CUDACHECKGOTO(cudaMemcpyAsync(&comm->channels[c].devPeersHostPtr[nvlsPeer]->recv[0], &peer->recv[0].conn, sizeof(struct ncclConnInfo), cudaMemcpyHostToDevice, hostStream), res, fail);
-      CUDACHECKGOTO(cudaMemcpyAsync(&comm->channels[c].devPeersHostPtr[nvlsPeer]->send[1], &peer->send[1].conn, sizeof(struct ncclConnInfo), cudaMemcpyHostToDevice, hostStream), res, fail);
-      CUDACHECKGOTO(cudaMemcpyAsync(&comm->channels[c].devPeersHostPtr[nvlsPeer]->recv[1], &peer->recv[1].conn, sizeof(struct ncclConnInfo), cudaMemcpyHostToDevice, hostStream), res, fail);
+      CUDACHECKGOTO(cudaMemcpyAsync(&comm->channels[c].devPeersHostPtr[nvlsPeer]->send[0], &peer->send[0].conn,
+                                    sizeof(struct ncclConnInfo), cudaMemcpyHostToDevice, hostStream),
+                    res, fail);
+      CUDACHECKGOTO(cudaMemcpyAsync(&comm->channels[c].devPeersHostPtr[nvlsPeer]->recv[0], &peer->recv[0].conn,
+                                    sizeof(struct ncclConnInfo), cudaMemcpyHostToDevice, hostStream),
+                    res, fail);
+      CUDACHECKGOTO(cudaMemcpyAsync(&comm->channels[c].devPeersHostPtr[nvlsPeer]->send[1], &peer->send[1].conn,
+                                    sizeof(struct ncclConnInfo), cudaMemcpyHostToDevice, hostStream),
+                    res, fail);
+      CUDACHECKGOTO(cudaMemcpyAsync(&comm->channels[c].devPeersHostPtr[nvlsPeer]->recv[1], &peer->recv[1].conn,
+                                    sizeof(struct ncclConnInfo), cudaMemcpyHostToDevice, hostStream),
+                    res, fail);
     }
   }
 
   NCCLCHECKGOTO(ncclStreamWaitStream(deviceStream, hostStream, comm->sharedRes->scratchEvent), res, fail);
-  NCCLCHECKGOTO(ncclStrongStreamRelease(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->deviceStream, /*concurrent=*/false), res, fail);
-  NCCLCHECKGOTO(ncclStrongStreamRelease(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->hostStream, /*concurrent=*/false), res, fail);
+  NCCLCHECKGOTO(ncclStrongStreamRelease(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->deviceStream,
+                                        /*concurrent=*/false),
+                res, fail);
+  NCCLCHECKGOTO(ncclStrongStreamRelease(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->hostStream,
+                                        /*concurrent=*/false),
+                res, fail);
   // For now, the barrier is a must that guarantees all buffers are mc-mapped before accessing peer's buffer
-  NCCLCHECKGOTO(bootstrapIntraNodeBarrier(comm->bootstrap, comm->localRankToRank, comm->localRank, comm->localRanks, comm->localRankToRank[0]), res, fail);
+  NCCLCHECKGOTO(bootstrapIntraNodeBarrier(comm->bootstrap, comm->localRankToRank, comm->localRank, comm->localRanks,
+                                          comm->localRankToRank[0]),
+                res, fail);
   comm->nvlsResources->inited = true;
 
 exit:
@@ -442,7 +489,7 @@ ncclResult_t ncclNvlsSetup(struct ncclComm* comm, struct ncclComm* parent) {
   ncclResult_t res = ncclSuccess;
   size_t typeSize;
   char shmPath[sizeof("/dev/shm/nccl-XXXXXX")];
-  uintptr_t *nvlsShmem = NULL;
+  uintptr_t* nvlsShmem = NULL;
   bool nvlsShare = parent && parent->nvlsSupport && parent->shareResources && parent->localRanks == comm->localRanks;
 
   if (comm->nvlsSupport == 0 || comm->nvlsChannels == 0) return ncclSuccess;
@@ -497,11 +544,18 @@ ncclResult_t ncclNvlsSetup(struct ncclComm* comm, struct ncclComm* parent) {
     resources->accessDesc.location.id = comm->cudaDev;
     resources->dev = comm->cudaDev;
 
-    NCCLCHECKGOTO(nvlsAllocateMem(comm, &resources->accessDesc, creditSize, &resources->ucCreditHandle, &resources->mcCreditHandle, (void**)&resources->ucCredit, (void**)&resources->mcCredit, &resources->creditUCSize, &resources->creditMCSize), res, fail);
+    NCCLCHECKGOTO(nvlsAllocateMem(comm, &resources->accessDesc, creditSize, &resources->ucCreditHandle,
+                                  &resources->mcCreditHandle, (void**)&resources->ucCredit,
+                                  (void**)&resources->mcCredit, &resources->creditUCSize, &resources->creditMCSize),
+                  res, fail);
 
     // Set up head and tail only for now
-    NCCLCHECKGOTO(ncclStrongStreamAcquire(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->hostStream, /*concurrent=*/false, &hostStream), res, fail);
-    NCCLCHECKGOTO(ncclStrongStreamAcquire(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->deviceStream, /*concurrent=*/false, &deviceStream), res, fail);
+    NCCLCHECKGOTO(ncclStrongStreamAcquire(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->hostStream,
+                                          /*concurrent=*/false, &hostStream),
+                  res, fail);
+    NCCLCHECKGOTO(ncclStrongStreamAcquire(ncclCudaGraphNone(comm->config.graphUsageMode),
+                                          &comm->sharedRes->deviceStream, /*concurrent=*/false, &deviceStream),
+                  res, fail);
     for (int h = 0; h < nHeads; h++) {
       int nvlsPeer = comm->nRanks + 1 + h;
       for (int c = 0; c < nChannels; c++) {
@@ -539,15 +593,27 @@ ncclResult_t ncclNvlsSetup(struct ncclComm* comm, struct ncclComm* parent) {
         peer->send[0].conn.stepSize = nvlsStepSize;
         peer->send[0].conn.flags |= NCCL_NVLS_MIN_POLL;
 
-        CUDACHECKGOTO(cudaMemcpyAsync(&comm->channels[c].devPeersHostPtr[nvlsPeer]->send[0], &peer->send[0].conn, sizeof(struct ncclConnInfo), cudaMemcpyHostToDevice, hostStream), res, fail);
-        CUDACHECKGOTO(cudaMemcpyAsync(&comm->channels[c].devPeersHostPtr[nvlsPeer]->recv[0], &peer->recv[0].conn, sizeof(struct ncclConnInfo), cudaMemcpyHostToDevice, hostStream), res, fail);
-        CUDACHECKGOTO(cudaMemcpyAsync(&comm->channels[c].devPeersHostPtr[nvlsPeer]->send[1], &peer->send[1].conn, sizeof(struct ncclConnInfo), cudaMemcpyHostToDevice, hostStream), res, fail);
-        CUDACHECKGOTO(cudaMemcpyAsync(&comm->channels[c].devPeersHostPtr[nvlsPeer]->recv[1], &peer->recv[1].conn, sizeof(struct ncclConnInfo), cudaMemcpyHostToDevice, hostStream), res, fail);
+        CUDACHECKGOTO(cudaMemcpyAsync(&comm->channels[c].devPeersHostPtr[nvlsPeer]->send[0], &peer->send[0].conn,
+                                      sizeof(struct ncclConnInfo), cudaMemcpyHostToDevice, hostStream),
+                      res, fail);
+        CUDACHECKGOTO(cudaMemcpyAsync(&comm->channels[c].devPeersHostPtr[nvlsPeer]->recv[0], &peer->recv[0].conn,
+                                      sizeof(struct ncclConnInfo), cudaMemcpyHostToDevice, hostStream),
+                      res, fail);
+        CUDACHECKGOTO(cudaMemcpyAsync(&comm->channels[c].devPeersHostPtr[nvlsPeer]->send[1], &peer->send[1].conn,
+                                      sizeof(struct ncclConnInfo), cudaMemcpyHostToDevice, hostStream),
+                      res, fail);
+        CUDACHECKGOTO(cudaMemcpyAsync(&comm->channels[c].devPeersHostPtr[nvlsPeer]->recv[1], &peer->recv[1].conn,
+                                      sizeof(struct ncclConnInfo), cudaMemcpyHostToDevice, hostStream),
+                      res, fail);
       }
     }
     NCCLCHECKGOTO(ncclStreamWaitStream(deviceStream, hostStream, comm->sharedRes->scratchEvent), res, fail);
-    NCCLCHECKGOTO(ncclStrongStreamRelease(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->hostStream, /*concurrent=*/false), res, fail);
-    NCCLCHECKGOTO(ncclStrongStreamRelease(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->deviceStream, /*concurrent=*/false), res, fail);
+    NCCLCHECKGOTO(ncclStrongStreamRelease(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->hostStream,
+                                          /*concurrent=*/false),
+                  res, fail);
+    NCCLCHECKGOTO(ncclStrongStreamRelease(ncclCudaGraphNone(comm->config.graphUsageMode),
+                                          &comm->sharedRes->deviceStream, /*concurrent=*/false),
+                  res, fail);
   }
 
   // MNNVL does not support NVLS buffer registration
@@ -557,17 +623,30 @@ ncclResult_t ncclNvlsSetup(struct ncclComm* comm, struct ncclComm* parent) {
 
     if (comm->localRank == 0) {
       shmPath[0] = '\0';
-      NCCLCHECKGOTO(ncclShmOpen(shmPath, sizeof(shmPath), (CACHE_LINE_SIZE * comm->localRanks + typeSize * comm->localRanks) * 2, (void**)&nvlsShmem, NULL, comm->localRanks - 1, &comm->nvlsResources->nvlsShmemHandle), res, fail);
-      NCCLCHECKGOTO(bootstrapIntraNodeBroadcast(comm->bootstrap, comm->localRankToRank, comm->localRank, comm->localRanks, 0, shmPath, sizeof(shmPath)), res, fail);
+      NCCLCHECKGOTO(ncclShmOpen(shmPath, sizeof(shmPath),
+                                (CACHE_LINE_SIZE * comm->localRanks + typeSize * comm->localRanks) * 2,
+                                (void**)&nvlsShmem, NULL, comm->localRanks - 1, &comm->nvlsResources->nvlsShmemHandle),
+                    res, fail);
+      NCCLCHECKGOTO(bootstrapIntraNodeBroadcast(comm->bootstrap, comm->localRankToRank, comm->localRank,
+                                                comm->localRanks, 0, shmPath, sizeof(shmPath)),
+                    res, fail);
     } else {
-      NCCLCHECKGOTO(bootstrapIntraNodeBroadcast(comm->bootstrap, comm->localRankToRank, comm->localRank, comm->localRanks, 0, shmPath, sizeof(shmPath)), res, fail);
-      NCCLCHECKGOTO(ncclShmOpen(shmPath, sizeof(shmPath), (CACHE_LINE_SIZE * comm->localRanks + typeSize * comm->localRanks) * 2, (void**)&nvlsShmem, NULL, -1, &comm->nvlsResources->nvlsShmemHandle), res, fail);
+      NCCLCHECKGOTO(bootstrapIntraNodeBroadcast(comm->bootstrap, comm->localRankToRank, comm->localRank,
+                                                comm->localRanks, 0, shmPath, sizeof(shmPath)),
+                    res, fail);
+      NCCLCHECKGOTO(ncclShmOpen(shmPath, sizeof(shmPath),
+                                (CACHE_LINE_SIZE * comm->localRanks + typeSize * comm->localRanks) * 2,
+                                (void**)&nvlsShmem, NULL, -1, &comm->nvlsResources->nvlsShmemHandle),
+                    res, fail);
     }
     /* need 2 pools and a shared counter for shmem-based collectives */
     comm->nvlsResources->nvlsShmem.cnt[0] = (size_t*)nvlsShmem;
-    comm->nvlsResources->nvlsShmem.ptr[0] = (void*)((char*)comm->nvlsResources->nvlsShmem.cnt[0] + CACHE_LINE_SIZE * comm->localRanks);
-    comm->nvlsResources->nvlsShmem.cnt[1] = (size_t*)((char*)comm->nvlsResources->nvlsShmem.ptr[0] + typeSize * comm->localRanks);
-    comm->nvlsResources->nvlsShmem.ptr[1] = (void*)((char*)comm->nvlsResources->nvlsShmem.cnt[1] + CACHE_LINE_SIZE * comm->localRanks);
+    comm->nvlsResources->nvlsShmem.ptr[0] =
+      (void*)((char*)comm->nvlsResources->nvlsShmem.cnt[0] + CACHE_LINE_SIZE * comm->localRanks);
+    comm->nvlsResources->nvlsShmem.cnt[1] =
+      (size_t*)((char*)comm->nvlsResources->nvlsShmem.ptr[0] + typeSize * comm->localRanks);
+    comm->nvlsResources->nvlsShmem.ptr[1] =
+      (void*)((char*)comm->nvlsResources->nvlsShmem.cnt[1] + CACHE_LINE_SIZE * comm->localRanks);
     comm->nvlsResources->nvlsShmem.round = 0;
     comm->nvlsResources->nvlsShmem.maxTypeSize = typeSize;
   }
@@ -584,17 +663,18 @@ ncclResult_t ncclNvlsFree(struct ncclComm* comm) {
   if (resources == NULL) return ncclSuccess;
 
   if (ncclAtomicRefCountDecrement(&resources->refCount) == 0) {
-    if (!comm->MNNVL && resources->nvlsShmemHandle)
-      NCCLCHECK(ncclShmClose(resources->nvlsShmemHandle));
+    if (!comm->MNNVL && resources->nvlsShmemHandle) NCCLCHECK(ncclShmClose(resources->nvlsShmemHandle));
 
     if (resources->ucCredit || resources->mcCredit) {
       NCCLCHECK(nvlsGroupUnbind(comm, resources->creditUCSize, &resources->mcCreditHandle));
-      NCCLCHECK(nvlsGroupUnmapMem(comm, resources->creditUCSize, resources->ucCredit, &resources->ucCreditHandle, resources->creditMCSize, resources->mcCredit, &resources->mcCreditHandle));
+      NCCLCHECK(nvlsGroupUnmapMem(comm, resources->creditUCSize, resources->ucCredit, &resources->ucCreditHandle,
+                                  resources->creditMCSize, resources->mcCredit, &resources->mcCreditHandle));
     }
 
     if (comm->nvlsResources->inited) {
       NCCLCHECK(nvlsGroupUnbind(comm, resources->buffUCSize, &resources->mcBuffHandle));
-      NCCLCHECK(nvlsGroupUnmapMem(comm, resources->buffUCSize, resources->ucBuff, &resources->ucBuffHandle, resources->buffMCSize, resources->mcBuff, &resources->mcBuffHandle));
+      NCCLCHECK(nvlsGroupUnmapMem(comm, resources->buffUCSize, resources->ucBuff, &resources->ucBuffHandle,
+                                  resources->buffMCSize, resources->mcBuff, &resources->mcBuffHandle));
     }
     free(resources);
     comm->nvlsResources = NULL;
@@ -602,9 +682,10 @@ ncclResult_t ncclNvlsFree(struct ncclComm* comm) {
   return ncclSuccess;
 }
 
-ncclResult_t tryRegisterBuffer(struct ncclComm *comm, uintptr_t userBuff, size_t buffSize, CUdeviceptr *regAddr, int *regUsed) {
+ncclResult_t tryRegisterBuffer(struct ncclComm* comm, uintptr_t userBuff, size_t buffSize, CUdeviceptr* regAddr,
+                               int* regUsed) {
   ncclResult_t ret = ncclSuccess;
-  struct ncclReg *regRecord = NULL;
+  struct ncclReg* regRecord = NULL;
   CUdeviceptr regPtr = 0;
   CUmulticastObjectProp mcprop;
   CUmemAllocationProp ucprop;
@@ -656,7 +737,9 @@ ncclResult_t tryRegisterBuffer(struct ncclComm *comm, uintptr_t userBuff, size_t
     }
   }
 
-  NCCLCHECKGOTO(ncclShmemAllgather(comm, &comm->nvlsResources->nvlsShmem, regData + comm->localRank, regData, sizeof(struct localRegData)), ret, fail);
+  NCCLCHECKGOTO(ncclShmemAllgather(comm, &comm->nvlsResources->nvlsShmem, regData + comm->localRank, regData,
+                                   sizeof(struct localRegData)),
+                ret, fail);
 
   for (int i = 0; i < comm->localRanks; ++i) {
     if ((regData[i].reg.state & NVLS_REG_POSSIBLE) == 0) {
@@ -667,8 +750,7 @@ ncclResult_t tryRegisterBuffer(struct ncclComm *comm, uintptr_t userBuff, size_t
       goto fail;
     }
     /* get minimal reg size of nvls buffers */
-    if (minSize > regData[i].reg.regUCSize)
-      minSize = regData[i].reg.regUCSize;
+    if (minSize > regData[i].reg.regUCSize) minSize = regData[i].reg.regUCSize;
   }
 
   /* start registration */
@@ -679,17 +761,24 @@ ncclResult_t tryRegisterBuffer(struct ncclComm *comm, uintptr_t userBuff, size_t
   mcprop.size = mcsize;
 
   if (comm->localRank == 0) {
-    NCCLCHECKGOTO(ncclNvlsGroupCreate(comm, &mcprop, comm->localRank, comm->localRanks, &mcHandle, shareableHandle), ret, fail);
-    NCCLCHECKGOTO(bootstrapIntraNodeBroadcast(comm->bootstrap, comm->localRankToRank, comm->localRank, comm->localRanks, 0, shareableHandle, NVLS_HANDLE_SIZE), ret, fail);
+    NCCLCHECKGOTO(ncclNvlsGroupCreate(comm, &mcprop, comm->localRank, comm->localRanks, &mcHandle, shareableHandle),
+                  ret, fail);
+    NCCLCHECKGOTO(bootstrapIntraNodeBroadcast(comm->bootstrap, comm->localRankToRank, comm->localRank, comm->localRanks,
+                                              0, shareableHandle, NVLS_HANDLE_SIZE),
+                  ret, fail);
   } else {
-    NCCLCHECKGOTO(bootstrapIntraNodeBroadcast(comm->bootstrap, comm->localRankToRank, comm->localRank, comm->localRanks, 0, shareableHandle, NVLS_HANDLE_SIZE), ret, fail);
+    NCCLCHECKGOTO(bootstrapIntraNodeBroadcast(comm->bootstrap, comm->localRankToRank, comm->localRank, comm->localRanks,
+                                              0, shareableHandle, NVLS_HANDLE_SIZE),
+                  ret, fail);
     NCCLCHECKGOTO(ncclNvlsGroupConnect(comm, shareableHandle, comm->localRankToRank[0], &mcHandle), ret, fail);
   }
 
   CUCHECKGOTO(cuMulticastAddDevice(mcHandle, comm->nvlsResources->dev), ret, fail);
   // intra-node barrier to mitigate the possible hang in cuMulticastBindAddr during abort
   // It also ensures that if cuMulticastBindAddr fails, the cleanup code won't race with the UDS proxy
-  NCCLCHECKGOTO(bootstrapIntraNodeBarrier(comm->bootstrap, comm->localRankToRank, comm->localRank, comm->localRanks, comm->localRankToRank[0]), ret, fail);
+  NCCLCHECKGOTO(bootstrapIntraNodeBarrier(comm->bootstrap, comm->localRankToRank, comm->localRank, comm->localRanks,
+                                          comm->localRankToRank[0]),
+                ret, fail);
   // Coverity complains that regRecord could be NULL.  That won't in practice be the case because we've already checked
   // (regData[i].reg.state & NVLS_REG_POSSIBLE) of all local ranks, which would catch it and bail out.
   // coverity[var_deref_op]
@@ -698,7 +787,7 @@ ncclResult_t tryRegisterBuffer(struct ncclComm *comm, uintptr_t userBuff, size_t
   if (err != CUDA_SUCCESS) {
     // Don't print an error in case of buffers that are incompatible with MC.
     if (err != CUDA_ERROR_INVALID_VALUE) {
-      const char *errStr;
+      const char* errStr;
       CUCALL(cuGetErrorString(err, &errStr));
       INFO(NCCL_REG, "Failed to multicast-bind user buffer: CUDA error %d '%s'", err, errStr);
     }
@@ -715,7 +804,9 @@ ncclResult_t tryRegisterBuffer(struct ncclComm *comm, uintptr_t userBuff, size_t
 
   /* get all buffer addresses */
   regRecord->caddrs[comm->localRank] = regRecord->begAddr;
-  NCCLCHECKGOTO(ncclShmemAllgather(comm, &comm->nvlsResources->nvlsShmem, regRecord->caddrs + comm->localRank, regRecord->caddrs, sizeof(uintptr_t)), ret, fail);
+  NCCLCHECKGOTO(ncclShmemAllgather(comm, &comm->nvlsResources->nvlsShmem, regRecord->caddrs + comm->localRank,
+                                   regRecord->caddrs, sizeof(uintptr_t)),
+                ret, fail);
 
   regRecord->regAddr = regPtr;
   regRecord->regUCSize = ucsize;
@@ -735,17 +826,20 @@ fail:
     CUCALL(cuMemAddressFree(regPtr, mcsize));
   }
   if (mcHandle) {
-    if (bindComplete) CUCALL(cuMulticastUnbind(mcHandle, comm->nvlsResources->dev, 0/*mcOffset*/, ucsize));
+    if (bindComplete) CUCALL(cuMulticastUnbind(mcHandle, comm->nvlsResources->dev, 0 /*mcOffset*/, ucsize));
     CUCALL(cuMemRelease(mcHandle));
   }
   *regUsed = 0;
   goto exit;
 }
 
-static ncclResult_t nvlsRegisterBuffer(struct ncclComm *comm, const void *sendbuff, void *recvbuff, size_t sendbuffSize, size_t recvbuffSize, struct ncclReg *sendRegRecord, struct ncclReg *recvRegRecord, int *outRegBufUsed, void **outRegBufSend, void **outRegBufRecv) {
+static ncclResult_t nvlsRegisterBuffer(struct ncclComm* comm, const void* sendbuff, void* recvbuff, size_t sendbuffSize,
+                                       size_t recvbuffSize, struct ncclReg* sendRegRecord,
+                                       struct ncclReg* recvRegRecord, int* outRegBufUsed, void** outRegBufSend,
+                                       void** outRegBufRecv) {
   ncclResult_t ret = ncclSuccess;
   int regBufUsed = 0;
-  struct localRegData *regData = NULL;
+  struct localRegData* regData = NULL;
   bool sendNeedReg = false, recvNeedReg = false;
   CUdeviceptr regSendPtr = 0;
   CUdeviceptr regRecvPtr = 0;
@@ -758,7 +852,8 @@ static ncclResult_t nvlsRegisterBuffer(struct ncclComm *comm, const void *sendbu
   }
   if (sendbuff) {
     CUCHECKGOTO(cuPointerGetAttribute((void*)&regData[comm->localRank * 2].handleTypes,
-                                      CU_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES, (CUdeviceptr)sendbuff), ret, fail);
+                                      CU_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES, (CUdeviceptr)sendbuff),
+                ret, fail);
   }
 
   if (recvRegRecord) {
@@ -767,18 +862,23 @@ static ncclResult_t nvlsRegisterBuffer(struct ncclComm *comm, const void *sendbu
   }
   if (recvbuff) {
     CUCHECKGOTO(cuPointerGetAttribute((void*)&regData[comm->localRank * 2 + 1].handleTypes,
-                                      CU_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES, (CUdeviceptr)recvbuff), ret, fail);
+                                      CU_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES, (CUdeviceptr)recvbuff),
+                ret, fail);
   }
 
-  NCCLCHECKGOTO(ncclShmemAllgather(comm, &comm->nvlsResources->nvlsShmem, regData + comm->localRank * 2, regData, sizeof(struct localRegData) * 2), ret, fail);
+  NCCLCHECKGOTO(ncclShmemAllgather(comm, &comm->nvlsResources->nvlsShmem, regData + comm->localRank * 2, regData,
+                                   sizeof(struct localRegData) * 2),
+                ret, fail);
 
   /* first check whether all local ranks find their registered buffer */
   for (int i = 0; i < comm->localRanks; ++i) {
-    if ((regData[i * 2].reg.state & NVLS_REG_COMPLETE) == 0 || regData[comm->localRank * 2].reg.caddrs[i] != regData[i * 2].reg.begAddr) {
+    if ((regData[i * 2].reg.state & NVLS_REG_COMPLETE) == 0 ||
+        regData[comm->localRank * 2].reg.caddrs[i] != regData[i * 2].reg.begAddr) {
       sendNeedReg = true;
     }
 
-    if ((regData[i * 2 + 1].reg.state & NVLS_REG_COMPLETE) == 0 || regData[comm->localRank * 2 + 1].reg.caddrs[i] != regData[i * 2 + 1].reg.begAddr) {
+    if ((regData[i * 2 + 1].reg.state & NVLS_REG_COMPLETE) == 0 ||
+        regData[comm->localRank * 2 + 1].reg.caddrs[i] != regData[i * 2 + 1].reg.begAddr) {
       recvNeedReg = true;
     }
 
@@ -818,7 +918,10 @@ static ncclResult_t nvlsRegisterBuffer(struct ncclComm *comm, const void *sendbu
 
   if ((!sendNeedReg || sendbuff == NULL) && (!recvNeedReg || recvbuff == NULL)) {
     regBufUsed = 1;
-    INFO(NCCL_REG, "rank %d reuse registered NVLS sendbuff %p, recvbuff %p, sendbuff size %ld, recvbuff size %ld, reg sendbuff %p, reg recvbuff %p", comm->rank, sendbuff, recvbuff, sendbuffSize, recvbuffSize, (void*)regSendPtr, (void*)regRecvPtr);
+    INFO(NCCL_REG,
+         "rank %d reuse registered NVLS sendbuff %p, recvbuff %p, sendbuff size %ld, recvbuff size %ld, reg sendbuff "
+         "%p, reg recvbuff %p",
+         comm->rank, sendbuff, recvbuff, sendbuffSize, recvbuffSize, (void*)regSendPtr, (void*)regRecvPtr);
     goto exit;
   }
 
@@ -834,7 +937,10 @@ static ncclResult_t nvlsRegisterBuffer(struct ncclComm *comm, const void *sendbu
     if (regBufUsed == 0) goto fail;
   }
 
-  INFO(NCCL_REG, "rank %d successfully registered NVLS sendbuff %p, recvbuff %p, sendbuff size %ld, recvbuff size %ld, reg sendbuff %p, reg recvbuff %p", comm->rank, sendbuff, recvbuff, sendbuffSize, recvbuffSize, (void*)regSendPtr, (void*)regRecvPtr);
+  INFO(NCCL_REG,
+       "rank %d successfully registered NVLS sendbuff %p, recvbuff %p, sendbuff size %ld, recvbuff size %ld, reg "
+       "sendbuff %p, reg recvbuff %p",
+       comm->rank, sendbuff, recvbuff, sendbuffSize, recvbuffSize, (void*)regSendPtr, (void*)regRecvPtr);
 
 exit:
   *outRegBufSend = (void*)regSendPtr;
@@ -844,17 +950,20 @@ exit:
   return ncclSuccess;
 fail:
   regBufUsed = 0;
-  INFO(NCCL_REG, "rank %d failed to NVLS register sendbuff %p sendbuffSize %ld recvbuff %p recvbuffSize %ld", comm->rank, sendbuff, sendbuffSize, recvbuff, recvbuffSize);
+  INFO(NCCL_REG, "rank %d failed to NVLS register sendbuff %p sendbuffSize %ld recvbuff %p recvbuffSize %ld",
+       comm->rank, sendbuff, sendbuffSize, recvbuff, recvbuffSize);
   goto exit;
 }
 
-ncclResult_t ncclNvlsLocalRegisterBuffer(struct ncclComm *comm, const void *sendbuff, void *recvbuff, size_t sendbuffSize, size_t recvbuffSize, int *outRegBufUsed, void **outRegBufSend, void **outRegBufRecv) {
-  struct ncclReg *sendRegRecord = NULL;
-  struct ncclReg *recvRegRecord = NULL;
+ncclResult_t ncclNvlsLocalRegisterBuffer(struct ncclComm* comm, const void* sendbuff, void* recvbuff,
+                                         size_t sendbuffSize, size_t recvbuffSize, int* outRegBufUsed,
+                                         void** outRegBufSend, void** outRegBufRecv) {
+  struct ncclReg* sendRegRecord = NULL;
+  struct ncclReg* recvRegRecord = NULL;
   bool sendIsValid = false;
   bool recvIsValid = false;
-  void *baseSend = NULL;
-  void *baseRecv = NULL;
+  void* baseSend = NULL;
+  void* baseRecv = NULL;
   size_t baseSendSize = 0;
   size_t baseRecvSize = 0;
 
@@ -864,7 +973,8 @@ ncclResult_t ncclNvlsLocalRegisterBuffer(struct ncclComm *comm, const void *send
     NCCLCHECK(ncclRegLocalIsValid(sendRegRecord, &sendIsValid));
     if (sendIsValid) {
       int numSegments = 0;
-      NCCLCHECK(ncclCuMemGetAddressRange((CUdeviceptr) sendbuff, sendbuffSize, (CUdeviceptr*)&baseSend, &baseSendSize, &numSegments));
+      NCCLCHECK(ncclCuMemGetAddressRange((CUdeviceptr)sendbuff, sendbuffSize, (CUdeviceptr*)&baseSend, &baseSendSize,
+                                         &numSegments));
       if (numSegments > 1 && !ncclParamMultiSegmentRegister()) goto exit;
     }
   } else {
@@ -876,7 +986,8 @@ ncclResult_t ncclNvlsLocalRegisterBuffer(struct ncclComm *comm, const void *send
     NCCLCHECK(ncclRegLocalIsValid(recvRegRecord, &recvIsValid));
     if (recvIsValid) {
       int numSegments = 0;
-      NCCLCHECK(ncclCuMemGetAddressRange((CUdeviceptr) recvbuff, recvbuffSize, (CUdeviceptr *)&baseRecv, &baseRecvSize, &numSegments));
+      NCCLCHECK(ncclCuMemGetAddressRange((CUdeviceptr)recvbuff, recvbuffSize, (CUdeviceptr*)&baseRecv, &baseRecvSize,
+                                         &numSegments));
       if (numSegments > 1 && !ncclParamMultiSegmentRegister()) goto exit;
     }
   } else {
@@ -884,7 +995,8 @@ ncclResult_t ncclNvlsLocalRegisterBuffer(struct ncclComm *comm, const void *send
   }
 
   if (sendIsValid && recvIsValid)
-    NCCLCHECK(nvlsRegisterBuffer(comm, sendbuff, recvbuff, sendbuffSize, recvbuffSize, sendRegRecord, recvRegRecord, outRegBufUsed, outRegBufSend, outRegBufRecv));
+    NCCLCHECK(nvlsRegisterBuffer(comm, sendbuff, recvbuff, sendbuffSize, recvbuffSize, sendRegRecord, recvRegRecord,
+                                 outRegBufUsed, outRegBufSend, outRegBufRecv));
 
 exit:
   return ncclSuccess;
@@ -892,8 +1004,8 @@ exit:
 
 struct ncclNvlsCleanupCallback {
   struct ncclCommCallback base;
-  struct ncclReg *reg;
-  struct ncclComm *comm;
+  struct ncclReg* reg;
+  struct ncclComm* comm;
 };
 
 static ncclResult_t cleanupNvls(struct ncclComm* comm, struct ncclCommCallback* cb) {
@@ -904,35 +1016,37 @@ static ncclResult_t cleanupNvls(struct ncclComm* comm, struct ncclCommCallback* 
 }
 
 ncclResult_t ncclNvlsGraphRegisterBuffer(
-    struct ncclComm *comm, const void *sendbuff, void *recvbuff, size_t sendbuffSize, size_t recvbuffSize,
-    int *outRegBufUsed, void **outRegBufSend, void **outRegBufRecv,
-    struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>* cleanupQueue, int* nCleanupQueueEltsAdded
-  ) {
+  struct ncclComm* comm, const void* sendbuff, void* recvbuff, size_t sendbuffSize, size_t recvbuffSize,
+  int* outRegBufUsed, void** outRegBufSend, void** outRegBufRecv,
+  struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>* cleanupQueue, int* nCleanupQueueEltsAdded) {
   struct ncclNvlsCleanupCallback* sendRecord = NULL;
   struct ncclNvlsCleanupCallback* recvRecord = NULL;
-  void *baseSend = NULL;
-  void *baseRecv = NULL;
+  void* baseSend = NULL;
+  void* baseRecv = NULL;
   size_t baseSendSize = 0;
   size_t baseRecvSize = 0;
-  struct ncclReg *sendRegRecord = NULL;
-  struct ncclReg *recvRegRecord = NULL;
+  struct ncclReg* sendRegRecord = NULL;
+  struct ncclReg* recvRegRecord = NULL;
 
   *outRegBufUsed = 0;
   if (sendbuff) {
     int numSegments = 0;
-    NCCLCHECK(ncclCuMemGetAddressRange((CUdeviceptr) sendbuff, sendbuffSize, (CUdeviceptr*)&baseSend, &baseSendSize, &numSegments));
+    NCCLCHECK(ncclCuMemGetAddressRange((CUdeviceptr)sendbuff, sendbuffSize, (CUdeviceptr*)&baseSend, &baseSendSize,
+                                       &numSegments));
     if (numSegments > 1 && !ncclParamMultiSegmentRegister()) goto exit;
     NCCLCHECK(ncclCommGraphRegister(comm, baseSend, baseSendSize, (void**)&sendRegRecord));
   }
 
   if (recvbuff) {
     int numSegments = 0;
-    NCCLCHECK(ncclCuMemGetAddressRange((CUdeviceptr) recvbuff, recvbuffSize, (CUdeviceptr*)&baseRecv, &baseRecvSize, &numSegments));
+    NCCLCHECK(ncclCuMemGetAddressRange((CUdeviceptr)recvbuff, recvbuffSize, (CUdeviceptr*)&baseRecv, &baseRecvSize,
+                                       &numSegments));
     if (numSegments > 1 && !ncclParamMultiSegmentRegister()) goto exit;
     NCCLCHECK(ncclCommGraphRegister(comm, baseRecv, baseRecvSize, (void**)&recvRegRecord));
   }
 
-  NCCLCHECK(nvlsRegisterBuffer(comm, sendbuff, recvbuff, sendbuffSize, recvbuffSize, sendRegRecord, recvRegRecord, outRegBufUsed, outRegBufSend, outRegBufRecv));
+  NCCLCHECK(nvlsRegisterBuffer(comm, sendbuff, recvbuff, sendbuffSize, recvbuffSize, sendRegRecord, recvRegRecord,
+                               outRegBufUsed, outRegBufSend, outRegBufRecv));
 
   if (*outRegBufUsed) {
     if (sendRegRecord) {
@@ -975,17 +1089,20 @@ ncclResult_t ncclNvlsRegResourcesQuery(struct ncclComm* comm, struct ncclTaskCol
   if (comm->nNodes == 1) {
     if (info->func == ncclFuncReduceScatter) {
       factor = (comm->compCap >= 100 ? 6 : 5) * 8;
-      *recChannels = std::max(comm->config.minCTAs, std::min(comm->config.maxCTAs, DIVUP(factor, comm->nvlsResources->nHeads)));
+      *recChannels =
+        std::max(comm->config.minCTAs, std::min(comm->config.maxCTAs, DIVUP(factor, comm->nvlsResources->nHeads)));
     } else if (info->func == ncclFuncAllGather) {
       factor = 4 * 8;
-      *recChannels = std::max(comm->config.minCTAs, std::min(comm->config.maxCTAs, DIVUP(factor, comm->nvlsResources->nHeads)));
+      *recChannels =
+        std::max(comm->config.minCTAs, std::min(comm->config.maxCTAs, DIVUP(factor, comm->nvlsResources->nHeads)));
     } else if (info->func == ncclFuncAllReduce) {
       if (comm->compCap >= 100) {
         factor = 8 * 8;
       } else {
         factor = 4 * 8;
       }
-      *recChannels = std::max(comm->config.minCTAs, std::min(comm->config.maxCTAs, DIVUP(factor, comm->nvlsResources->nHeads)));
+      *recChannels =
+        std::max(comm->config.minCTAs, std::min(comm->config.maxCTAs, DIVUP(factor, comm->nvlsResources->nHeads)));
     } else {
       goto fail;
     }
@@ -993,13 +1110,16 @@ ncclResult_t ncclNvlsRegResourcesQuery(struct ncclComm* comm, struct ncclTaskCol
     // Further tweaks for Blackwell with NVLS registered buffers
     if (info->func == ncclFuncReduceScatter) {
       factor = (comm->bandwidths[ncclFuncReduceScatter][NCCL_ALGO_NVLS][NCCL_PROTO_SIMPLE] > 400 ? 7 : 6) * 8;
-      *recChannels = std::max(comm->config.minCTAs, std::min(comm->config.maxCTAs, DIVUP(factor, comm->nvlsResources->nHeads)));
+      *recChannels =
+        std::max(comm->config.minCTAs, std::min(comm->config.maxCTAs, DIVUP(factor, comm->nvlsResources->nHeads)));
     } else if (info->func == ncclFuncAllGather) {
       factor = 6 * 8;
-      *recChannels = std::max(comm->config.minCTAs, std::min(comm->config.maxCTAs, DIVUP(factor, comm->nvlsResources->nHeads)));
+      *recChannels =
+        std::max(comm->config.minCTAs, std::min(comm->config.maxCTAs, DIVUP(factor, comm->nvlsResources->nHeads)));
     } else if (info->func == ncclFuncAllReduce) {
       factor = (comm->compCap >= 100 ? 7 : 6) * 8;
-      *recChannels = std::max(comm->config.minCTAs, std::min(comm->config.maxCTAs, DIVUP(factor, comm->nvlsResources->nHeads)));
+      *recChannels =
+        std::max(comm->config.minCTAs, std::min(comm->config.maxCTAs, DIVUP(factor, comm->nvlsResources->nHeads)));
     } else {
       goto fail;
     }
@@ -1040,20 +1160,22 @@ ncclResult_t ncclNvlsTreeConnect(struct ncclComm* comm) {
 }
 
 ncclResult_t ncclNvlsGraphRegisterBuffer(
-    struct ncclComm *comm, const void *sendbuff, void *recvbuff, size_t sendbuffSize, size_t recvbuffSize,
-    int *outRegBufUsed, void **outRegBufSend, void **outRegBufRecv,
-    struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>* cleanupQueue, int* nCleanupQueueEltsAdded
-  ) {
+  struct ncclComm* comm, const void* sendbuff, void* recvbuff, size_t sendbuffSize, size_t recvbuffSize,
+  int* outRegBufUsed, void** outRegBufSend, void** outRegBufRecv,
+  struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>* cleanupQueue, int* nCleanupQueueEltsAdded) {
   *outRegBufUsed = false;
   return ncclSuccess;
 }
 
-ncclResult_t ncclNvlsLocalRegisterBuffer(struct ncclComm *comm, const void *sendbuff, void *recvbuff, size_t sendbuffSize, size_t recvbuffSize, int *outRegBufUsed, void **outRegBufSend, void **outRegBufRecv) {
+ncclResult_t ncclNvlsLocalRegisterBuffer(struct ncclComm* comm, const void* sendbuff, void* recvbuff,
+                                         size_t sendbuffSize, size_t recvbuffSize, int* outRegBufUsed,
+                                         void** outRegBufSend, void** outRegBufRecv) {
   *outRegBufUsed = false;
   return ncclSuccess;
 }
 
-ncclResult_t ncclNvlsDeregBuffer(struct ncclComm* comm, CUmemGenericAllocationHandle *mcHandler, CUdeviceptr ptr, int dev, size_t ucsize, size_t mcsize) {
+ncclResult_t ncclNvlsDeregBuffer(struct ncclComm* comm, CUmemGenericAllocationHandle* mcHandler, CUdeviceptr ptr,
+                                 int dev, size_t ucsize, size_t mcsize) {
   return ncclSuccess;
 }
 

--- a/projects/rccl/src/transport/p2p.cc
+++ b/projects/rccl/src/transport/p2p.cc
@@ -20,7 +20,12 @@
 #include "shm.h"
 #include "register_inline.h"
 
-enum p2pType { P2P_DIRECT, P2P_INTERMEDIATE, P2P_IPC, P2P_CUMEM };
+enum p2pType {
+  P2P_DIRECT,
+  P2P_INTERMEDIATE,
+  P2P_IPC,
+  P2P_CUMEM
+};
 
 struct ncclP2pBuff {
   void* directPtr;
@@ -108,13 +113,10 @@ NCCL_PARAM(LegacyCudaRegister, "LEGACY_CUDA_REGISTER", 0);
 /* Convert a PCI busId string into a local cudaDev device index (cf. CUDA_VISIBLE_DEVICES) */
 static int busIdToCudaDev(int64_t busId) {
   int ndev;
-  if (!CUDASUCCESS(cudaGetDeviceCount(&ndev)))
-    return -1;
+  if (!CUDASUCCESS(cudaGetDeviceCount(&ndev))) return -1;
   for (int i = 0; i < ndev; i++) {
     char devBusIdStr[NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE];
-    if (!CUDASUCCESS(cudaDeviceGetPCIBusId(
-            devBusIdStr, NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE, i)))
-      return -1;
+    if (!CUDASUCCESS(cudaDeviceGetPCIBusId(devBusIdStr, NVML_DEVICE_PCI_BUS_ID_BUFFER_SIZE, i))) return -1;
     int64_t devBusId;
     NCCLCHECK(busIdToInt64(devBusIdStr, &devBusId));
     if (busId == devBusId) return i;
@@ -128,15 +130,16 @@ NCCL_PARAM(P2pUseCudaMemcpy, "P2P_USE_CUDA_MEMCPY", 0);
 static int useMemcpy = 0;
 static void initCeOperation();
 
-
 extern int64_t ncclParamMNNVLEnable();
 
 /* Determine if two peers can communicate through p2p */
-ncclResult_t p2pCanConnect(int* ret, struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* info1, struct ncclPeerInfo* info2) {
+ncclResult_t p2pCanConnect(int* ret, struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* info1,
+                           struct ncclPeerInfo* info2) {
   initCeOperation();
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-  if (!info1->hasFineGrain || !info2->hasFineGrain)  {
-    TRACE(NCCL_P2P, "p2pCanConnect rank%d->rank%d: ret=0 hasFineGrain info1=%d info2=%d", info1->rank, info2->rank, info1->hasFineGrain, info2->hasFineGrain);
+  if (!info1->hasFineGrain || !info2->hasFineGrain) {
+    TRACE(NCCL_P2P, "p2pCanConnect rank%d->rank%d: ret=0 hasFineGrain info1=%d info2=%d", info1->rank, info2->rank,
+          info1->hasFineGrain, info2->hasFineGrain);
     *ret = 0;
     return ncclSuccess;
   }
@@ -159,8 +162,7 @@ ncclResult_t p2pCanConnect(int* ret, struct ncclComm* comm, struct ncclTopoGraph
     return ncclSuccess;
   }
 
-  if (info1->hostHash != comm->peerInfo[comm->rank].hostHash ||
-      info1->hostHash != info2->hostHash) {
+  if (info1->hostHash != comm->peerInfo[comm->rank].hostHash || info1->hostHash != info2->hostHash) {
     // If either peer is non-local then we are done.
     return ncclSuccess;
   }
@@ -185,8 +187,8 @@ ncclResult_t p2pCanConnect(int* ret, struct ncclComm* comm, struct ncclTopoGraph
     // This is useful for multi-rank GPUs. cudaDeviceCanAccessPeer would indicate that it is not allowed.
     p2p = 1;
   } else if (!CUDASUCCESS(cudaDeviceCanAccessPeer(&p2p, cudaDev1, cudaDev2))) {
-    INFO(NCCL_INIT|NCCL_P2P,"peer query failed between dev %d(=%lx) and dev %d(=%lx)",
-        cudaDev1, info1->busId, cudaDev2, info2->busId);
+    INFO(NCCL_INIT | NCCL_P2P, "peer query failed between dev %d(=%lx) and dev %d(=%lx)", cudaDev1, info1->busId,
+         cudaDev2, info2->busId);
     *ret = 0;
     return ncclSuccess;
   }
@@ -202,11 +204,11 @@ ncclResult_t p2pCanConnect(int* ret, struct ncclComm* comm, struct ncclTopoGraph
       return ncclSuccess;
     }
     // Check that legacy IPC support is available (WSL WAR)
-    char *dummy;
+    char* dummy;
     cudaIpcMemHandle_t ipc;
     NCCLCHECK(ncclCudaMalloc(&dummy, CUDA_IPC_MIN, comm->memManager, ncclMemOffload));
     if (!CUDASUCCESS(cudaIpcGetMemHandle(&ipc, dummy))) {
-      INFO(NCCL_INIT|NCCL_P2P,"Legacy IPC not supported");
+      INFO(NCCL_INIT | NCCL_P2P, "Legacy IPC not supported");
       *ret = 0;
     }
     NCCLCHECK(ncclCudaFree(dummy, comm->memManager));
@@ -216,23 +218,24 @@ ncclResult_t p2pCanConnect(int* ret, struct ncclComm* comm, struct ncclTopoGraph
 #endif
 
   if (p2p == 0) {
-    INFO(NCCL_INIT|NCCL_P2P,"Could not enable P2P between dev %d(=%lx) and dev %d(=%lx)",
-        cudaDev1, info1->busId, cudaDev2, info2->busId);
+    INFO(NCCL_INIT | NCCL_P2P, "Could not enable P2P between dev %d(=%lx) and dev %d(=%lx)", cudaDev1, info1->busId,
+         cudaDev2, info2->busId);
     *ret = 0;
     return ncclSuccess;
   }
   return ncclSuccess;
 }
 
-#define TRACE_DUMP_IPC(DEVIPC)                                                             \
-  do {                                                                                     \
-    unsigned long *devIpc = (unsigned long *) (DEVIPC);                                    \
-    TRACE(P2P,"IPC: %016lx %016lx %016lx %016lx", devIpc[0], devIpc[1], devIpc[2], devIpc[3]); \
-    TRACE(P2P,"IPC: %016lx %016lx %016lx %016lx", devIpc[4], devIpc[5], devIpc[6], devIpc[7]); \
+#define TRACE_DUMP_IPC(DEVIPC) \
+  do { \
+    unsigned long* devIpc = (unsigned long*)(DEVIPC); \
+    TRACE(P2P, "IPC: %016lx %016lx %016lx %016lx", devIpc[0], devIpc[1], devIpc[2], devIpc[3]); \
+    TRACE(P2P, "IPC: %016lx %016lx %016lx %016lx", devIpc[4], devIpc[5], devIpc[6], devIpc[7]); \
   } while (0)
 
 // cuMem API support
-ncclResult_t ncclP2pAllocateShareableBuffer(size_t size, int refcount, ncclIpcDesc *ipcDesc, void **ptr, int peerRank, struct ncclMemManager* manager, ncclMemType_t memtype) {
+ncclResult_t ncclP2pAllocateShareableBuffer(size_t size, int refcount, ncclIpcDesc* ipcDesc, void** ptr, int peerRank,
+                                            struct ncclMemManager* manager, ncclMemType_t memtype) {
   if (ncclCuMemEnable()) {
 #if ROCM_VERSION >= 70000
     CUmemAllocationHandleType type = ncclCuMemHandleType;
@@ -249,19 +252,23 @@ ncclResult_t ncclP2pAllocateShareableBuffer(size_t size, int refcount, ncclIpcDe
     } else {
       CUCHECK(cuMemExportToShareableHandle(&ipcDesc->cuDesc, handle, type, 0));
 #ifdef ENABLE_TRACE
-      unsigned char *hbytes = (unsigned char*)&ipcDesc->cuDesc;
+      unsigned char* hbytes = (unsigned char*)&ipcDesc->cuDesc;
       static_assert(sizeof(ipcDesc->cuDesc) == 64, "cuDesc size changed — update handle byte-dump indices");
-      TRACE(NCCL_P2P, "ncclP2pAllocateShareableBuffer: exported handle[0..31]= %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x type=%d",
-           hbytes[0],hbytes[1],hbytes[2],hbytes[3],hbytes[4],hbytes[5],hbytes[6],hbytes[7],
-           hbytes[8],hbytes[9],hbytes[10],hbytes[11],hbytes[12],hbytes[13],hbytes[14],hbytes[15],
-           hbytes[16],hbytes[17],hbytes[18],hbytes[19],hbytes[20],hbytes[21],hbytes[22],hbytes[23],
-           hbytes[24],hbytes[25],hbytes[26],hbytes[27],hbytes[28],hbytes[29],hbytes[30],hbytes[31],
-           (int)type);
-      TRACE(NCCL_P2P, "ncclP2pAllocateShareableBuffer: exported handle[32..63]= %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x",
-           hbytes[32],hbytes[33],hbytes[34],hbytes[35],hbytes[36],hbytes[37],hbytes[38],hbytes[39],
-           hbytes[40],hbytes[41],hbytes[42],hbytes[43],hbytes[44],hbytes[45],hbytes[46],hbytes[47],
-           hbytes[48],hbytes[49],hbytes[50],hbytes[51],hbytes[52],hbytes[53],hbytes[54],hbytes[55],
-           hbytes[56],hbytes[57],hbytes[58],hbytes[59],hbytes[60],hbytes[61],hbytes[62],hbytes[63]);
+      TRACE(
+        NCCL_P2P,
+        "ncclP2pAllocateShareableBuffer: exported handle[0..31]= %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x "
+        "%02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x type=%d",
+        hbytes[0], hbytes[1], hbytes[2], hbytes[3], hbytes[4], hbytes[5], hbytes[6], hbytes[7], hbytes[8], hbytes[9],
+        hbytes[10], hbytes[11], hbytes[12], hbytes[13], hbytes[14], hbytes[15], hbytes[16], hbytes[17], hbytes[18],
+        hbytes[19], hbytes[20], hbytes[21], hbytes[22], hbytes[23], hbytes[24], hbytes[25], hbytes[26], hbytes[27],
+        hbytes[28], hbytes[29], hbytes[30], hbytes[31], (int)type);
+      TRACE(NCCL_P2P,
+            "ncclP2pAllocateShareableBuffer: exported handle[32..63]= %02x%02x%02x%02x %02x%02x%02x%02x "
+            "%02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x",
+            hbytes[32], hbytes[33], hbytes[34], hbytes[35], hbytes[36], hbytes[37], hbytes[38], hbytes[39], hbytes[40],
+            hbytes[41], hbytes[42], hbytes[43], hbytes[44], hbytes[45], hbytes[46], hbytes[47], hbytes[48], hbytes[49],
+            hbytes[50], hbytes[51], hbytes[52], hbytes[53], hbytes[54], hbytes[55], hbytes[56], hbytes[57], hbytes[58],
+            hbytes[59], hbytes[60], hbytes[61], hbytes[62], hbytes[63]);
 #endif
     }
     if (refcount) {
@@ -274,9 +281,9 @@ ncclResult_t ncclP2pAllocateShareableBuffer(size_t size, int refcount, ncclIpcDe
   } else {
     // Allocate a CUDA buffer and generate an IPC handle for it
 #if defined(HIP_UNCACHED_MEMORY)
-    NCCLCHECK(ncclCudaCalloc((char **)ptr, size, manager, memtype, hipDeviceMallocUncached));
+    NCCLCHECK(ncclCudaCalloc((char**)ptr, size, manager, memtype, hipDeviceMallocUncached));
 #else
-    NCCLCHECK(ncclCudaCalloc((char **)ptr, size, manager, memtype, hipDeviceMallocFinegrained));
+    NCCLCHECK(ncclCudaCalloc((char**)ptr, size, manager, memtype, hipDeviceMallocFinegrained));
 #endif
     cudaError_t res = cudaIpcGetMemHandle(&ipcDesc->devIpc, *ptr);
     if (res != cudaSuccess) {
@@ -285,23 +292,24 @@ ncclResult_t ncclP2pAllocateShareableBuffer(size_t size, int refcount, ncclIpcDe
       CUDACHECK(res);
     }
   }
-  INFO(NCCL_P2P|NCCL_ALLOC, "Allocated shareable buffer %p size %zu ipcDesc %p", *ptr, size, ipcDesc);
+  INFO(NCCL_P2P | NCCL_ALLOC, "Allocated shareable buffer %p size %zu ipcDesc %p", *ptr, size, ipcDesc);
 
   return ncclSuccess;
 }
 
-ncclResult_t ncclP2pFreeShareableBuffer(ncclIpcDesc *ipcDesc) {
+ncclResult_t ncclP2pFreeShareableBuffer(ncclIpcDesc* ipcDesc) {
   return ncclSuccess;
 }
 
-ncclResult_t ncclP2pImportShareableBuffer(struct ncclComm *comm, int peer, size_t size, ncclIpcDesc *ipcDesc, void **devMemPtr, void* ownerPtr, ncclMemType_t memType) {
+ncclResult_t ncclP2pImportShareableBuffer(struct ncclComm* comm, int peer, size_t size, ncclIpcDesc* ipcDesc,
+                                          void** devMemPtr, void* ownerPtr, ncclMemType_t memType) {
   if (ncclCuMemEnable()) {
 #if ROCM_VERSION >= 70000
     // cuMem API support
     CUdeviceptr dptr = 0;
     CUmemAllocationHandleType type = ncclCuMemHandleType;
     CUmemGenericAllocationHandle handle;
-    ncclCuDesc *cuDesc = &ipcDesc->cuDesc;
+    ncclCuDesc* cuDesc = &ipcDesc->cuDesc;
     CUmemAllocationProp prop = {};
     size_t granularity = 0;
 
@@ -329,26 +337,31 @@ ncclResult_t ncclP2pImportShareableBuffer(struct ncclComm *comm, int peer, size_
     } else {
 #ifdef ENABLE_TRACE
       // Log handle bytes to verify correct data received cross-node
-      unsigned char *hbytes = (unsigned char*)cuDesc;
+      unsigned char* hbytes = (unsigned char*)cuDesc;
       static_assert(sizeof(*cuDesc) == 64, "cuDesc size changed — update handle byte-dump indices");
-      TRACE(NCCL_P2P, "ncclP2pImportShareableBuffer: handle[0..31]= %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x type=%d dev=%d size=%zu",
-           hbytes[0],hbytes[1],hbytes[2],hbytes[3],hbytes[4],hbytes[5],hbytes[6],hbytes[7],
-           hbytes[8],hbytes[9],hbytes[10],hbytes[11],hbytes[12],hbytes[13],hbytes[14],hbytes[15],
-           hbytes[16],hbytes[17],hbytes[18],hbytes[19],hbytes[20],hbytes[21],hbytes[22],hbytes[23],
-           hbytes[24],hbytes[25],hbytes[26],hbytes[27],hbytes[28],hbytes[29],hbytes[30],hbytes[31],
-           (int)type, comm->cudaDev, size);
-      TRACE(NCCL_P2P, "ncclP2pImportShareableBuffer: handle[32..63]= %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x",
-           hbytes[32],hbytes[33],hbytes[34],hbytes[35],hbytes[36],hbytes[37],hbytes[38],hbytes[39],
-           hbytes[40],hbytes[41],hbytes[42],hbytes[43],hbytes[44],hbytes[45],hbytes[46],hbytes[47],
-           hbytes[48],hbytes[49],hbytes[50],hbytes[51],hbytes[52],hbytes[53],hbytes[54],hbytes[55],
-           hbytes[56],hbytes[57],hbytes[58],hbytes[59],hbytes[60],hbytes[61],hbytes[62],hbytes[63]);
+      TRACE(
+        NCCL_P2P,
+        "ncclP2pImportShareableBuffer: handle[0..31]= %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x "
+        "%02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x type=%d dev=%d size=%zu",
+        hbytes[0], hbytes[1], hbytes[2], hbytes[3], hbytes[4], hbytes[5], hbytes[6], hbytes[7], hbytes[8], hbytes[9],
+        hbytes[10], hbytes[11], hbytes[12], hbytes[13], hbytes[14], hbytes[15], hbytes[16], hbytes[17], hbytes[18],
+        hbytes[19], hbytes[20], hbytes[21], hbytes[22], hbytes[23], hbytes[24], hbytes[25], hbytes[26], hbytes[27],
+        hbytes[28], hbytes[29], hbytes[30], hbytes[31], (int)type, comm->cudaDev, size);
+      TRACE(NCCL_P2P,
+            "ncclP2pImportShareableBuffer: handle[32..63]= %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x "
+            "%02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x %02x%02x%02x%02x",
+            hbytes[32], hbytes[33], hbytes[34], hbytes[35], hbytes[36], hbytes[37], hbytes[38], hbytes[39], hbytes[40],
+            hbytes[41], hbytes[42], hbytes[43], hbytes[44], hbytes[45], hbytes[46], hbytes[47], hbytes[48], hbytes[49],
+            hbytes[50], hbytes[51], hbytes[52], hbytes[53], hbytes[54], hbytes[55], hbytes[56], hbytes[57], hbytes[58],
+            hbytes[59], hbytes[60], hbytes[61], hbytes[62], hbytes[63]);
 #endif
       CUCHECK(cuMemImportFromShareableHandle(&handle, (void*)cuDesc, type));
     }
     CUCHECK(cuMemAddressReserve(&dptr, size, /* alignment */ 0, /* addr */ 0, /* flags */ 0));
     CUCHECK(cuMemMap(dptr, size, /* offset */ 0, handle, /* flags */ 0));
 
-    TRACE(NCCL_P2P, "Imported shareable buffer size %zu handle %p dptr %p", size, (void*)(uintptr_t)handle, (void*)dptr);
+    TRACE(NCCL_P2P, "Imported shareable buffer size %zu handle %p dptr %p", size, (void*)(uintptr_t)handle,
+          (void*)dptr);
 
     // Allow access by the local GPU
     CUmemAccessDesc accessDesc = {};
@@ -358,11 +371,11 @@ ncclResult_t ncclP2pImportShareableBuffer(struct ncclComm *comm, int peer, size_
     CUCHECK(cuMemSetAccess(dptr, size, &accessDesc, 1));
     TRACE(NCCL_P2P, "Set Access for %p size %zu on dev %d", (void*)dptr, size, accessDesc.location.id);
 
-    *devMemPtr = (void *)dptr;
+    *devMemPtr = (void*)dptr;
 
     // Track imported buffer
-    NCCLCHECK(ncclMemTrackImportFromPeer(comm->memManager, (void*)dptr, size, handle, type, memType,
-                                         peer, comm->peerInfo[peer].cudaDev, ownerPtr));
+    NCCLCHECK(ncclMemTrackImportFromPeer(comm->memManager, (void*)dptr, size, handle, type, memType, peer,
+                                         comm->peerInfo[peer].cudaDev, ownerPtr));
 #else
     return ncclInternalError;
 #endif
@@ -380,9 +393,11 @@ ncclResult_t ncclP2pImportShareableBuffer(struct ncclComm *comm, int peer, size_
 NCCL_PARAM(P2pReadEnable, "P2P_READ_ENABLE", -2);
 NCCL_PARAM(P2pDirectDisable, "P2P_DIRECT_DISABLE", 0);
 
-#define P2P_SAME_PID(MYINFO, PEERINFO) ((MYINFO->hostHash == PEERINFO->hostHash) && (MYINFO->pidHash == PEERINFO->pidHash))
+#define P2P_SAME_PID(MYINFO, PEERINFO) \
+  ((MYINFO->hostHash == PEERINFO->hostHash) && (MYINFO->pidHash == PEERINFO->pidHash))
 
-static ncclResult_t p2pGetInfo(struct ncclComm* comm, struct ncclPeerInfo* info1, struct ncclPeerInfo* info2, int* read, int* intermediateRank) {
+static ncclResult_t p2pGetInfo(struct ncclComm* comm, struct ncclPeerInfo* info1, struct ncclPeerInfo* info2, int* read,
+                               int* intermediateRank) {
   int p2p;
   // Queries the topology to see if the GPUs are Ampere and
   // connected via NVLink, if so we enable P2P Read by default
@@ -393,7 +408,8 @@ static ncclResult_t p2pGetInfo(struct ncclComm* comm, struct ncclPeerInfo* info1
   return ncclSuccess;
 }
 
-static ncclResult_t p2pMap(struct ncclComm *comm, struct ncclProxyConnector* proxyConn, struct ncclPeerInfo* myInfo, struct ncclPeerInfo* peerInfo, struct ncclP2pBuff* p2pBuff, void** devMem, void** ipcPtr) {
+static ncclResult_t p2pMap(struct ncclComm* comm, struct ncclProxyConnector* proxyConn, struct ncclPeerInfo* myInfo,
+                           struct ncclPeerInfo* peerInfo, struct ncclP2pBuff* p2pBuff, void** devMem, void** ipcPtr) {
   if (P2P_SAME_PID(myInfo, peerInfo)) {
     if (peerInfo->cudaDev != myInfo->cudaDev) {
       // Same PID different GPUs, enable P2P access
@@ -402,8 +418,8 @@ static ncclResult_t p2pMap(struct ncclComm *comm, struct ncclProxyConnector* pro
       if (err == cudaErrorPeerAccessAlreadyEnabled) {
         (void)cudaGetLastError();
       } else if (err != cudaSuccess) {
-        WARN("failed to peer with device %d(=%lx): %d %s",
-            peerInfo->cudaDev, peerInfo->busId, err, cudaGetErrorString(err));
+        WARN("failed to peer with device %d(=%lx): %d %s", peerInfo->cudaDev, peerInfo->busId, err,
+             cudaGetErrorString(err));
         return ncclInternalError;
       }
       if (ncclCuMemEnable()) {
@@ -416,9 +432,8 @@ static ncclResult_t p2pMap(struct ncclComm *comm, struct ncclProxyConnector* pro
 
         // Track as imported peer memory for dynamic memory management.
         // Pass handle=0 since we already released the reference above; suspend shouldn't release again.
-        NCCLCHECK(ncclMemTrackImportFromPeer(comm->memManager, *devMem, p2pBuff->size,
-                                             0, ncclCuMemHandleType, ncclMemOffload,
-                                             peerInfo->rank, peerInfo->cudaDev, p2pBuff->directPtr));
+        NCCLCHECK(ncclMemTrackImportFromPeer(comm->memManager, *devMem, p2pBuff->size, 0, ncclCuMemHandleType,
+                                             ncclMemOffload, peerInfo->rank, peerInfo->cudaDev, p2pBuff->directPtr));
 #endif
       } else {
         *devMem = p2pBuff->directPtr;
@@ -431,15 +446,17 @@ static ncclResult_t p2pMap(struct ncclComm *comm, struct ncclProxyConnector* pro
   } else {
     // Different PID
     // Pass p2pBuff->directPtr as ownerPtr for P2P handle exchange during restore
-    NCCLCHECK(ncclP2pImportShareableBuffer(comm, peerInfo->rank, p2pBuff->size, &p2pBuff->ipcDesc, devMem, p2pBuff->directPtr, ncclMemOffload));
+    NCCLCHECK(ncclP2pImportShareableBuffer(comm, peerInfo->rank, p2pBuff->size, &p2pBuff->ipcDesc, devMem,
+                                           p2pBuff->directPtr, ncclMemOffload));
     *ipcPtr = *devMem;
   }
   return ncclSuccess;
 }
 
 /* Send: Create and return connect structures for this peer to connect to me */
-ncclResult_t p2pSendSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* myInfo, struct ncclPeerInfo* peerInfo,
-    struct ncclConnect* connectInfo, struct ncclConnector* send, int channelId, int connIndex) {
+ncclResult_t p2pSendSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* myInfo,
+                          struct ncclPeerInfo* peerInfo, struct ncclConnect* connectInfo, struct ncclConnector* send,
+                          int channelId, int connIndex) {
   struct p2pResources* resources;
   struct ncclP2pRequest req;
   NCCLCHECK(ncclCalloc(&resources, 1));
@@ -451,12 +468,17 @@ ncclResult_t p2pSendSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, st
   resources->next_hdp_reg = 0;
   bool isXGMI;
   if (ncclTopoGetLinkType(comm->topo, myInfo->cudaDev, peerInfo->cudaDev, &isXGMI) != ncclSuccess) {
-    INFO(NCCL_INIT|NCCL_P2P,"Ring %02d : %d -> %d failed to get link type and hop count", channelId, myInfo->rank, peerInfo->rank);
+    INFO(NCCL_INIT | NCCL_P2P, "Ring %02d : %d -> %d failed to get link type and hop count", channelId, myInfo->rank,
+         peerInfo->rank);
     return ncclInternalError;
   }
-  if (!isXGMI && !IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx90a") && !IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942") && !IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950")) {
-    CUDACHECK(hipDeviceGetAttribute((int*)&resources->next_hdp_reg, hipDeviceAttributeHdpMemFlushCntl,peerInfo->cudaDev));
-    TRACE(NCCL_INIT|NCCL_P2P,"Ring %02d : %d -> %d HDP %p", channelId, myInfo->rank, peerInfo->rank, resources->next_hdp_reg);
+  if (!isXGMI && !IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx90a") &&
+      !IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942") &&
+      !IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950")) {
+    CUDACHECK(hipDeviceGetAttribute((int*)&resources->next_hdp_reg, hipDeviceAttributeHdpMemFlushCntl,
+                                    peerInfo->cudaDev));
+    TRACE(NCCL_INIT | NCCL_P2P, "Ring %02d : %d -> %d HDP %p", channelId, myInfo->rank, peerInfo->rank,
+          resources->next_hdp_reg);
   }
 
   static_assert(sizeof(struct p2pConnectInfo) <= sizeof(struct ncclConnect), "p2p Connect Info is too big");
@@ -475,44 +497,54 @@ ncclResult_t p2pSendSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, st
     info->rank = myInfo->rank;
     if (P2P_SAME_PID(myInfo, peerInfo) && ncclParamP2pDirectDisable() == 0 && useMemcpy == 0) {
       resources->type = P2P_DIRECT;
-      INFO(NCCL_INIT|NCCL_P2P, "Channel %02d/%01d : %d[%lx] -> %d[%lx] via P2P/direct pointer%s comm %p nRanks %02d",
-          channelId, connIndex, myInfo->rank, myInfo->busId, peerInfo->rank, peerInfo->busId, useReadStr, comm, comm->nRanks);
+      INFO(NCCL_INIT | NCCL_P2P, "Channel %02d/%01d : %d[%lx] -> %d[%lx] via P2P/direct pointer%s comm %p nRanks %02d",
+           channelId, connIndex, myInfo->rank, myInfo->busId, peerInfo->rank, peerInfo->busId, useReadStr, comm,
+           comm->nRanks);
     } else {
       // cuMem API support
       if (ncclCuMemEnable()) {
         resources->type = P2P_CUMEM;
-        const char *MNNVL = comm->MNNVL ? "MNNVL" : "CUMEM";
-        INFO(NCCL_INIT|NCCL_P2P,"Channel %02d/%01d : %d[%x] -> %d[%x] via P2P/CUMEM%s%s%s comm %p nRanks %02d",
-            channelId, connIndex, myInfo->rank, myInfo->cudaDev, peerInfo->rank, peerInfo->cudaDev, MNNVL, useReadStr, useMemcpy ? "/CE" : "", comm, comm->nRanks);;
+        const char* MNNVL = comm->MNNVL ? "MNNVL" : "CUMEM";
+        INFO(NCCL_INIT | NCCL_P2P, "Channel %02d/%01d : %d[%x] -> %d[%x] via P2P/CUMEM%s%s%s comm %p nRanks %02d",
+             channelId, connIndex, myInfo->rank, myInfo->cudaDev, peerInfo->rank, peerInfo->cudaDev, MNNVL, useReadStr,
+             useMemcpy ? "/CE" : "", comm, comm->nRanks);
+        ;
       } else {
         // Legacy CUDA IPC
         resources->type = P2P_IPC;
-        INFO(NCCL_INIT|NCCL_P2P,"Channel %02d/%01d : %d[%lx] -> %d[%lx] via P2P/IPC%s%s comm %p nRanks %02d",
-            channelId, connIndex, myInfo->rank, myInfo->busId, peerInfo->rank, peerInfo->busId, useReadStr, useMemcpy ? "/CE" : "", comm, comm->nRanks);
+        INFO(NCCL_INIT | NCCL_P2P, "Channel %02d/%01d : %d[%lx] -> %d[%lx] via P2P/IPC%s%s comm %p nRanks %02d",
+             channelId, connIndex, myInfo->rank, myInfo->busId, peerInfo->rank, peerInfo->busId, useReadStr,
+             useMemcpy ? "/CE" : "", comm, comm->nRanks);
       }
     }
     send->conn.flags |= info->read ? NCCL_P2P_READ : NCCL_P2P_WRITE;
   } else {
     resources->type = P2P_INTERMEDIATE;
     info->rank = intermediateRank;
-    INFO(NCCL_INIT|NCCL_P2P, "Channel %02d/%01d : %d[%lx] -> %d[%lx] via P2P/indirect/%d[%lx]%s comm %p nRanks %02d",
-        channelId, connIndex, myInfo->rank, myInfo->busId, peerInfo->rank, peerInfo->busId, intermediateRank,
-    comm->peerInfo[intermediateRank].busId, useReadStr, comm, comm->nRanks);
+    INFO(NCCL_INIT | NCCL_P2P, "Channel %02d/%01d : %d[%lx] -> %d[%lx] via P2P/indirect/%d[%lx]%s comm %p nRanks %02d",
+         channelId, connIndex, myInfo->rank, myInfo->busId, peerInfo->rank, peerInfo->busId, intermediateRank,
+         comm->peerInfo[intermediateRank].busId, useReadStr, comm, comm->nRanks);
   }
 
   memset(&req, '\0', sizeof(req));
   req.size = sendSize;
   req.refcount = 0;
   req.peerRank = peerInfo->rank;  // Track which peer will import this buffer
-  if (P2P_SAME_PID((comm->peerInfo + info->rank), peerInfo) && (comm->peerInfo[info->rank].cudaDev != peerInfo->cudaDev)) req.refcount++;
-  if (P2P_SAME_PID((comm->peerInfo + info->rank), myInfo) && (comm->peerInfo[info->rank].cudaDev != myInfo->cudaDev)) req.refcount++;
+  if (P2P_SAME_PID((comm->peerInfo + info->rank), peerInfo) &&
+      (comm->peerInfo[info->rank].cudaDev != peerInfo->cudaDev))
+    req.refcount++;
+  if (P2P_SAME_PID((comm->peerInfo + info->rank), myInfo) && (comm->peerInfo[info->rank].cudaDev != myInfo->cudaDev))
+    req.refcount++;
   NCCLCHECK(ncclProxyConnect(comm, TRANSPORT_P2P, 1, info->rank, &send->proxyConn));
   if (useMemcpy) {
-    NCCLCHECK(ncclProxyCallBlocking(comm, &send->proxyConn, ncclProxyMsgSetup, NULL, 0, &resources->proxyInfo, sizeof(struct p2pShmProxyInfo)));
+    NCCLCHECK(ncclProxyCallBlocking(comm, &send->proxyConn, ncclProxyMsgSetup, NULL, 0, &resources->proxyInfo,
+                                    sizeof(struct p2pShmProxyInfo)));
     memcpy(&info->desc, &resources->proxyInfo.desc, sizeof(ncclShmIpcDesc_t));
   } else {
-    NCCLCHECK(ncclProxyCallBlocking(comm, &send->proxyConn, ncclProxyMsgSetup, &req, sizeof(struct ncclP2pRequest), &info->p2pBuff, sizeof(struct ncclP2pBuff)));
-    NCCLCHECK(p2pMap(comm, &send->proxyConn, myInfo, comm->peerInfo+info->rank, &info->p2pBuff, (void**)&resources->sendDevMem, &resources->sendMemIpc));
+    NCCLCHECK(ncclProxyCallBlocking(comm, &send->proxyConn, ncclProxyMsgSetup, &req, sizeof(struct ncclP2pRequest),
+                                    &info->p2pBuff, sizeof(struct ncclP2pBuff)));
+    NCCLCHECK(p2pMap(comm, &send->proxyConn, myInfo, comm->peerInfo + info->rank, &info->p2pBuff,
+                     (void**)&resources->sendDevMem, &resources->sendMemIpc));
     resources->sendMemSameProc = P2P_SAME_PID(myInfo, (comm->peerInfo + info->rank));
   }
 
@@ -520,8 +552,9 @@ ncclResult_t p2pSendSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, st
 }
 
 /* Create and return connect structures for this peer to connect to me */
-ncclResult_t p2pRecvSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* myInfo, struct ncclPeerInfo* peerInfo,
-    struct ncclConnect* connectInfo, struct ncclConnector * recv, int channelId, int connIndex) {
+ncclResult_t p2pRecvSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* myInfo,
+                          struct ncclPeerInfo* peerInfo, struct ncclConnect* connectInfo, struct ncclConnector* recv,
+                          int channelId, int connIndex) {
   struct p2pResources* resources;
   struct ncclP2pRequest req;
   NCCLCHECK(ncclCalloc(&resources, 1));
@@ -537,7 +570,8 @@ ncclResult_t p2pRecvSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, st
 
   int recvSize = sizeof(struct ncclRecvMem);
   // For P2P Read the SIMPLE buffer is tagged on the end of the ncclSendMem structure
-  for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) if (!(info->read && p == NCCL_PROTO_SIMPLE)) recvSize += comm->buffSizes[p];
+  for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++)
+    if (!(info->read && p == NCCL_PROTO_SIMPLE)) recvSize += comm->buffSizes[p];
   ALIGN_SIZE(recvSize, CUDA_IPC_MIN);
 
   if (intermediateRank == -1) {
@@ -548,8 +582,8 @@ ncclResult_t p2pRecvSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, st
       if (ncclCuMemEnable()) {
         // cuMem API support
         resources->type = P2P_CUMEM;
-        TRACE(NCCL_INIT|NCCL_P2P,"Ring %02d : %d[%d] <- %d[%d] via P2P/CUMEM",
-              channelId, myInfo->rank, myInfo->cudaDev, peerInfo->rank, peerInfo->cudaDev);
+        TRACE(NCCL_INIT | NCCL_P2P, "Ring %02d : %d[%d] <- %d[%d] via P2P/CUMEM", channelId, myInfo->rank,
+              myInfo->cudaDev, peerInfo->rank, peerInfo->cudaDev);
       } else {
         // Legacy CUDA IPC
         resources->type = P2P_IPC;
@@ -565,44 +599,52 @@ ncclResult_t p2pRecvSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, st
   req.size = recvSize;
   req.refcount = 0;
   req.peerRank = peerInfo->rank;  // Track which peer will import this buffer
-  if (P2P_SAME_PID((comm->peerInfo + info->rank), peerInfo) && (comm->peerInfo[info->rank].cudaDev != peerInfo->cudaDev)) req.refcount++;
-  if (P2P_SAME_PID((comm->peerInfo + info->rank), myInfo) && (comm->peerInfo[info->rank].cudaDev != myInfo->cudaDev)) req.refcount++;
+  if (P2P_SAME_PID((comm->peerInfo + info->rank), peerInfo) &&
+      (comm->peerInfo[info->rank].cudaDev != peerInfo->cudaDev))
+    req.refcount++;
+  if (P2P_SAME_PID((comm->peerInfo + info->rank), myInfo) && (comm->peerInfo[info->rank].cudaDev != myInfo->cudaDev))
+    req.refcount++;
   NCCLCHECK(ncclProxyConnect(comm, TRANSPORT_P2P, 0, info->rank, &recv->proxyConn));
-  NCCLCHECK(ncclProxyCallBlocking(comm, &recv->proxyConn, ncclProxyMsgSetup, &req, sizeof(struct ncclP2pRequest), &info->p2pBuff, sizeof(struct ncclP2pBuff)));
+  NCCLCHECK(ncclProxyCallBlocking(comm, &recv->proxyConn, ncclProxyMsgSetup, &req, sizeof(struct ncclP2pRequest),
+                                  &info->p2pBuff, sizeof(struct ncclP2pBuff)));
 
-  NCCLCHECK(p2pMap(comm, &recv->proxyConn, myInfo, comm->peerInfo+info->rank, &info->p2pBuff, (void**)&resources->recvDevMem, &resources->recvMemIpc));
+  NCCLCHECK(p2pMap(comm, &recv->proxyConn, myInfo, comm->peerInfo + info->rank, &info->p2pBuff,
+                   (void**)&resources->recvDevMem, &resources->recvMemIpc));
   resources->recvMemSameProc = P2P_SAME_PID(myInfo, (comm->peerInfo + info->rank));
   return ncclSuccess;
 }
 
 /* Connect/Send to this peer */
-static ncclResult_t p2pSendConnect(struct ncclComm* comm, struct ncclConnect* connectInfo, int nranks, int rank, struct ncclConnector* send) {
+static ncclResult_t p2pSendConnect(struct ncclComm* comm, struct ncclConnect* connectInfo, int nranks, int rank,
+                                   struct ncclConnector* send) {
   struct p2pResources* resources = (struct p2pResources*)send->transportResources;
   struct ncclRecvMem* remDevMem = NULL;
   struct p2pConnectInfo* info = (struct p2pConnectInfo*)connectInfo;
 
-  NCCLCHECK(p2pMap(comm, &send->proxyConn, comm->peerInfo+rank, comm->peerInfo+info->rank, &info->p2pBuff, (void**)&remDevMem, &resources->recvMemIpc));
+  NCCLCHECK(p2pMap(comm, &send->proxyConn, comm->peerInfo + rank, comm->peerInfo + info->rank, &info->p2pBuff,
+                   (void**)&remDevMem, &resources->recvMemIpc));
   resources->recvMemSameProc = P2P_SAME_PID((comm->peerInfo + rank), (comm->peerInfo + info->rank));
 
-  char* buff = (char*)(remDevMem+1);
-  for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
+  char* buff = (char*)(remDevMem + 1);
+  for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) {
     if (info->read && p == NCCL_PROTO_SIMPLE) {
       /* For P2P Read the SIMPLE buffer is local (ncclSendMem) */
       if (resources->sendDevMem == NULL) return ncclInternalError; // We should not use read + memcpy
-      send->conn.buffs[p] = (char*)(resources->sendDevMem+1);
+      send->conn.buffs[p] = (char*)(resources->sendDevMem + 1);
     } else {
       send->conn.buffs[p] = buff;
       buff += comm->buffSizes[p];
     }
   }
-  send->conn.stepSize = comm->buffSizes[NCCL_PROTO_SIMPLE]/NCCL_STEPS;
+  send->conn.stepSize = comm->buffSizes[NCCL_PROTO_SIMPLE] / NCCL_STEPS;
 
   if (useMemcpy) {
     send->conn.tail = &resources->proxyInfo.ceRecvMem->tail;
     send->conn.connFifo = resources->proxyInfo.ceRecvMem->connFifo;
     send->conn.head = &resources->proxyInfo.devShm->sendMem.head;
     // Send SIMPLE buff to proxy, and replace it by local buffer
-    NCCLCHECK(ncclProxyCallBlocking(comm, &send->proxyConn, ncclProxyMsgConnect, &send->conn.buffs[NCCL_PROTO_SIMPLE], sizeof(void*), NULL, 0));
+    NCCLCHECK(ncclProxyCallBlocking(comm, &send->proxyConn, ncclProxyMsgConnect, &send->conn.buffs[NCCL_PROTO_SIMPLE],
+                                    sizeof(void*), NULL, 0));
     send->conn.buffs[NCCL_PROTO_SIMPLE] = resources->proxyInfo.ceDevBuff;
   } else {
     send->conn.tail = &remDevMem->tail;
@@ -616,7 +658,8 @@ static ncclResult_t p2pSendConnect(struct ncclComm* comm, struct ncclConnect* co
 }
 
 /* Connect/Recv from this peer */
-ncclResult_t p2pRecvConnect(struct ncclComm* comm, struct ncclConnect* connectInfo, int nranks, int rank, struct ncclConnector* recv) {
+ncclResult_t p2pRecvConnect(struct ncclComm* comm, struct ncclConnect* connectInfo, int nranks, int rank,
+                            struct ncclConnector* recv) {
   struct p2pResources* resources = (struct p2pResources*)recv->transportResources;
   struct p2pConnectInfo* info = (struct p2pConnectInfo*)connectInfo;
 
@@ -624,12 +667,14 @@ ncclResult_t p2pRecvConnect(struct ncclComm* comm, struct ncclConnect* connectIn
 
   if (useMemcpy) {
     // Attach to peer's SHM segment
-    NCCLCHECK(ncclShmImportShareableBuffer(comm, info->rank, &info->desc, (void**)&resources->shm, (void**)&resources->devShm, &resources->desc));
+    NCCLCHECK(ncclShmImportShareableBuffer(comm, info->rank, &info->desc, (void**)&resources->shm,
+                                           (void**)&resources->devShm, &resources->desc));
 
     recv->conn.tail = &resources->devShm->recvMem.tail;
     recv->conn.head = &resources->devShm->sendMem.head;
   } else {
-    NCCLCHECK(p2pMap(comm, &recv->proxyConn, comm->peerInfo+rank, comm->peerInfo+info->rank, &info->p2pBuff, (void**)&remDevMem, &resources->sendMemIpc));
+    NCCLCHECK(p2pMap(comm, &recv->proxyConn, comm->peerInfo + rank, comm->peerInfo + info->rank, &info->p2pBuff,
+                     (void**)&remDevMem, &resources->sendMemIpc));
     resources->sendMemSameProc = P2P_SAME_PID((comm->peerInfo + rank), (comm->peerInfo + info->rank));
 
     struct ncclRecvMem* devMem = resources->recvDevMem;
@@ -638,14 +683,14 @@ ncclResult_t p2pRecvConnect(struct ncclComm* comm, struct ncclConnect* connectIn
     recv->conn.ptrExchange = &remDevMem->ptrExchange;
     recv->conn.redOpArgExchange = remDevMem->redOpArgExchange;
   }
-  recv->conn.stepSize = comm->buffSizes[NCCL_PROTO_SIMPLE]/NCCL_STEPS;
+  recv->conn.stepSize = comm->buffSizes[NCCL_PROTO_SIMPLE] / NCCL_STEPS;
 
-  char* buff = (char*)(resources->recvDevMem+1);
-  for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
+  char* buff = (char*)(resources->recvDevMem + 1);
+  for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) {
     if (info->read && p == NCCL_PROTO_SIMPLE) {
       if (remDevMem == NULL) return ncclInternalError; // We should not use read + memcpy
       /* For P2P Read the SIMPLE buffer is remote (ncclSendMem) */
-      recv->conn.buffs[p] = (char*)(remDevMem+1);
+      recv->conn.buffs[p] = (char*)(remDevMem + 1);
     } else {
       recv->conn.buffs[p] = buff;
       buff += comm->buffSizes[p];
@@ -676,8 +721,7 @@ ncclResult_t p2pSendFree(struct ncclComm* comm, struct ncclConnector* send) {
           NCCLCHECK(ncclCudaFree(resources->recvMemIpc, mgr));
         }
       }
-    }
-    else {
+    } else {
       if (resources->sendMemIpc) CUDACHECK(cudaIpcCloseMemHandle(resources->sendMemIpc));
       if (resources->recvMemIpc) CUDACHECK(cudaIpcCloseMemHandle(resources->recvMemIpc));
     }
@@ -708,8 +752,7 @@ ncclResult_t p2pRecvFree(struct ncclComm* comm, struct ncclConnector* recv) {
           NCCLCHECK(ncclCudaFree(resources->recvMemIpc, mgr));
         }
       }
-    }
-    else {
+    } else {
       if (resources->sendMemIpc) CUDACHECK(cudaIpcCloseMemHandle(resources->sendMemIpc));
       if (resources->recvMemIpc) CUDACHECK(cudaIpcCloseMemHandle(resources->recvMemIpc));
       if (useMemcpy) {
@@ -721,7 +764,8 @@ ncclResult_t p2pRecvFree(struct ncclComm* comm, struct ncclConnector* recv) {
   return ncclSuccess;
 }
 
-static ncclResult_t p2pSendProxySetup(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
+static ncclResult_t p2pSendProxySetup(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState,
+                                      void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
   if (useMemcpy) {
     // CE memcpy support
     struct p2pShmProxyInfo* proxyInfo;
@@ -732,14 +776,17 @@ static ncclResult_t p2pSendProxySetup(struct ncclProxyConnection* connection, st
     connection->transportResources = proxyInfo;
 
 #if defined(HIP_UNCACHED_MEMORY)
-    NCCLCHECK(ncclCudaCalloc(&proxyInfo->ceDevBuff, proxyState->buffSizes[NCCL_PROTO_SIMPLE], proxyState->memManager, ncclMemPersist, hipDeviceMallocUncached));
+    NCCLCHECK(ncclCudaCalloc(&proxyInfo->ceDevBuff, proxyState->buffSizes[NCCL_PROTO_SIMPLE], proxyState->memManager,
+                             ncclMemPersist, hipDeviceMallocUncached));
 #else
-    NCCLCHECK(ncclCudaCalloc(&proxyInfo->ceDevBuff, proxyState->buffSizes[NCCL_PROTO_SIMPLE], proxyState->memManager, ncclMemPersist, hipDeviceMallocFinegrained));
+    NCCLCHECK(ncclCudaCalloc(&proxyInfo->ceDevBuff, proxyState->buffSizes[NCCL_PROTO_SIMPLE], proxyState->memManager,
+                             ncclMemPersist, hipDeviceMallocFinegrained));
 #endif
 
     // Create a SHM segment for the peer to attach to
     shmSize = sizeof(struct ncclSendMem) + sizeof(struct ncclRecvMem);
-    NCCLCHECK(ncclShmAllocateShareableBuffer(shmSize, false, &proxyInfo->desc, (void**)&proxyInfo->shm, (void**)&proxyInfo->devShm));
+    NCCLCHECK(ncclShmAllocateShareableBuffer(shmSize, false, &proxyInfo->desc, (void**)&proxyInfo->shm,
+                                             (void**)&proxyInfo->devShm));
 
     NCCLCHECK(ncclCudaHostCalloc(&proxyInfo->ceRecvMem, 1));
     memcpy(respBuff, proxyInfo, sizeof(struct p2pShmProxyInfo));
@@ -749,7 +796,8 @@ static ncclResult_t p2pSendProxySetup(struct ncclProxyConnection* connection, st
     int size = req->size;
     if (respSize != sizeof(struct ncclP2pBuff)) return ncclInternalError;
     struct ncclP2pBuff* p2pBuff = (struct ncclP2pBuff*)respBuff;
-    NCCLCHECK(ncclP2pAllocateShareableBuffer(size, req->refcount, &p2pBuff->ipcDesc, &p2pBuff->directPtr, req->peerRank, proxyState->memManager, ncclMemOffload));
+    NCCLCHECK(ncclP2pAllocateShareableBuffer(size, req->refcount, &p2pBuff->ipcDesc, &p2pBuff->directPtr, req->peerRank,
+                                             proxyState->memManager, ncclMemOffload));
     p2pBuff->size = size;
     if (ncclCuMemEnable()) {
       // cuMem API support
@@ -765,13 +813,15 @@ static ncclResult_t p2pSendProxySetup(struct ncclProxyConnection* connection, st
   return ncclSuccess;
 }
 
-static ncclResult_t p2pRecvProxySetup(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
+static ncclResult_t p2pRecvProxySetup(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState,
+                                      void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
   struct ncclP2pRequest* req = (struct ncclP2pRequest*)reqBuff;
   if (reqSize != sizeof(struct ncclP2pRequest)) return ncclInternalError;
   int size = req->size;
   if (respSize != sizeof(struct ncclP2pBuff)) return ncclInternalError;
   struct ncclP2pBuff* p2pBuff = (struct ncclP2pBuff*)respBuff;
-  NCCLCHECK(ncclP2pAllocateShareableBuffer(size, req->refcount, &p2pBuff->ipcDesc, &p2pBuff->directPtr, req->peerRank, proxyState->memManager, ncclMemOffload));
+  NCCLCHECK(ncclP2pAllocateShareableBuffer(size, req->refcount, &p2pBuff->ipcDesc, &p2pBuff->directPtr, req->peerRank,
+                                           proxyState->memManager, ncclMemOffload));
   p2pBuff->size = size;
   if (ncclCuMemEnable()) {
     // cuMem API support
@@ -786,26 +836,29 @@ static ncclResult_t p2pRecvProxySetup(struct ncclProxyConnection* connection, st
   return ncclSuccess;
 }
 
-static ncclResult_t p2pSendProxyConnect(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
+static ncclResult_t p2pSendProxyConnect(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState,
+                                        void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
   struct p2pShmProxyInfo* proxyInfo = (struct p2pShmProxyInfo*)connection->transportResources;
 
   if (reqSize != sizeof(void*)) return ncclInternalError;
   proxyInfo->recvFifo = *((char**)reqBuff);
 
   CUDACHECK(cudaStreamCreateWithFlags(&proxyInfo->stream, cudaStreamNonBlocking));
-  for (int i=0; i<NCCL_STEPS; i++) {
-    CUDACHECK(cudaEventCreate(proxyInfo->events+i));
+  for (int i = 0; i < NCCL_STEPS; i++) {
+    CUDACHECK(cudaEventCreate(proxyInfo->events + i));
   }
   connection->proxyAppendPtr = &connection->proxyAppend;
   return ncclSuccess;
 }
 
-static ncclResult_t p2pDeregisterMemHandle(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, struct ncclIpcImpInfo* ipcInfo) {
+static ncclResult_t p2pDeregisterMemHandle(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState,
+                                           struct ncclIpcImpInfo* ipcInfo) {
   if (ipcInfo->legacyIpcCap) {
     CUDACHECK(cudaIpcCloseMemHandle((void*)((uintptr_t)ipcInfo->rmtRegAddr - ipcInfo->offset)));
   } else {
     if (connection->sameProcess) {
-      NCCLCHECK(ncclCuMemFreeAddr((void*)((uintptr_t)ipcInfo->rmtRegAddr - ipcInfo->offset), proxyState->memManager, ipcInfo->numSegments));
+      NCCLCHECK(ncclCuMemFreeAddr((void*)((uintptr_t)ipcInfo->rmtRegAddr - ipcInfo->offset), proxyState->memManager,
+                                  ipcInfo->numSegments));
     } else {
       NCCLCHECK(ncclCudaFree((void*)((uintptr_t)ipcInfo->rmtRegAddr - ipcInfo->offset), nullptr, ipcInfo->numSegments));
     }
@@ -829,7 +882,7 @@ static ncclResult_t p2pSendProxyFree(struct ncclProxyConnection* connection, str
       NCCLCHECK(ncclCudaHostFree(proxyInfo->ceRecvMem));
       NCCLCHECK(ncclCudaFree(proxyInfo->ceDevBuff, proxyState->memManager));
       CUDACHECK(cudaStreamDestroy(proxyInfo->stream));
-      for (int i=0; i<NCCL_STEPS; i++) {
+      for (int i = 0; i < NCCL_STEPS; i++) {
         CUDACHECK(cudaEventDestroy(proxyInfo->events[i]));
       }
       free(proxyInfo);
@@ -837,9 +890,9 @@ static ncclResult_t p2pSendProxyFree(struct ncclProxyConnection* connection, str
   } else {
     if (ncclCuMemEnable()) {
       // cuMem API support
-      struct p2pCuMemProxyInfo *proxyInfo = (struct p2pCuMemProxyInfo *) connection->transportResources;
+      struct p2pCuMemProxyInfo* proxyInfo = (struct p2pCuMemProxyInfo*)connection->transportResources;
       if (proxyInfo) {
-        struct ncclP2pBuff *p2pBuff = &proxyInfo->p2pBuff;
+        struct ncclP2pBuff* p2pBuff = &proxyInfo->p2pBuff;
         ncclP2pFreeShareableBuffer(&p2pBuff->ipcDesc);
         ncclCudaFree(p2pBuff->directPtr, proxyState->memManager);
         free(proxyInfo);
@@ -861,9 +914,9 @@ static ncclResult_t p2pRecvProxyFree(struct ncclProxyConnection* connection, str
   }
 
   if (ncclCuMemEnable()) {
-    struct p2pCuMemProxyInfo *proxyInfo = (struct p2pCuMemProxyInfo *) connection->transportResources;
+    struct p2pCuMemProxyInfo* proxyInfo = (struct p2pCuMemProxyInfo*)connection->transportResources;
     if (proxyInfo) {
-      struct ncclP2pBuff *p2pBuff = &proxyInfo->p2pBuff;
+      struct ncclP2pBuff* p2pBuff = &proxyInfo->p2pBuff;
       ncclP2pFreeShareableBuffer(&p2pBuff->ipcDesc);
       ncclCudaFree(p2pBuff->directPtr, proxyState->memManager);
       free(proxyInfo);
@@ -878,9 +931,9 @@ static ncclResult_t p2pRecvProxyFree(struct ncclProxyConnection* connection, str
 // CE memcpy support
 static ncclResult_t p2pSendProxyProgress(struct ncclProxyState* proxyState, struct ncclProxyArgs* args) {
   if (args->state == ncclProxyOpReady) {
-    for (int s=0; s<args->nsubs; s++) {
-      struct ncclProxySubArgs* sub = args->subs+s;
-      struct p2pShmProxyInfo* resources = (struct p2pShmProxyInfo*) (sub->connection->transportResources);
+    for (int s = 0; s < args->nsubs; s++) {
+      struct ncclProxySubArgs* sub = args->subs + s;
+      struct p2pShmProxyInfo* resources = (struct p2pShmProxyInfo*)(sub->connection->transportResources);
       // Round to next multiple of sliceSteps
       sub->base = ROUNDUP(resources->step, args->chunkSteps);
       sub->posted = sub->transmitted = sub->done = 0;
@@ -891,28 +944,30 @@ static ncclResult_t p2pSendProxyProgress(struct ncclProxyState* proxyState, stru
   if (args->state == ncclProxyOpProgress) {
     int p = args->protocol;
     int stepSize = proxyState->buffSizes[p] / NCCL_STEPS;
-    for (int s=0; s<args->nsubs; s++) {
-      struct ncclProxySubArgs* sub = args->subs+s;
-      struct p2pShmProxyInfo* resources = (struct p2pShmProxyInfo*) (sub->connection->transportResources);
+    for (int s = 0; s < args->nsubs; s++) {
+      struct ncclProxySubArgs* sub = args->subs + s;
+      struct p2pShmProxyInfo* resources = (struct p2pShmProxyInfo*)(sub->connection->transportResources);
       if (p != NCCL_PROTO_SIMPLE) { // Only Simple uses cudaMemcpy
-          resources->step = sub->base + sub->nsteps;
-          args->done++;
-          continue;
+        resources->step = sub->base + sub->nsteps;
+        args->done++;
+        continue;
       }
       if (sub->transmitted < sub->done + NCCL_STEPS && sub->transmitted < sub->nsteps) {
-        int buffSlot = (sub->base+sub->transmitted)%NCCL_STEPS;
+        int buffSlot = (sub->base + sub->transmitted) % NCCL_STEPS;
         volatile struct ncclConnFifo* connFifo = resources->ceRecvMem->connFifo;
         volatile uint64_t* recvTail = &resources->ceRecvMem->tail;
         // Check GPU has sent everything
-        if ((*recvTail > sub->base+sub->transmitted)) {
+        if ((*recvTail > sub->base + sub->transmitted)) {
           int size = connFifo[buffSlot].size;
-          CUDACHECK(cudaMemcpyAsync(resources->recvFifo+buffSlot*stepSize, resources->ceDevBuff+buffSlot*stepSize, size, cudaMemcpyDeviceToDevice, resources->stream));
+          CUDACHECK(cudaMemcpyAsync(resources->recvFifo + buffSlot * stepSize,
+                                    resources->ceDevBuff + buffSlot * stepSize, size, cudaMemcpyDeviceToDevice,
+                                    resources->stream));
           CUDACHECK(cudaEventRecord(resources->events[buffSlot], resources->stream));
           sub->transmitted += args->sliceSteps;
         }
       }
       if (sub->done < sub->transmitted) {
-        int buffSlot = (sub->base+sub->done)%NCCL_STEPS;
+        int buffSlot = (sub->base + sub->done) % NCCL_STEPS;
         cudaError_t res = CUDACLEARERROR(cudaEventQuery(resources->events[buffSlot]));
         if (res != cudaErrorNotReady) CUDACHECK(res);
         if (res == cudaSuccess) {
@@ -933,7 +988,9 @@ static ncclResult_t p2pSendProxyProgress(struct ncclProxyState* proxyState, stru
   return ncclSuccess;
 }
 
-ncclResult_t ipcHandleMultiSegmentRegistration(CUdeviceptr userBuff, size_t userBuffSize, ncclComm* comm, struct ncclProxyConnector* proxyConn, size_t* totalMappedBufferSize, int* numSegments, struct p2pIpcExpInfo** ipcInfos) {
+ncclResult_t ipcHandleMultiSegmentRegistration(CUdeviceptr userBuff, size_t userBuffSize, ncclComm* comm,
+                                               struct ncclProxyConnector* proxyConn, size_t* totalMappedBufferSize,
+                                               int* numSegments, struct p2pIpcExpInfo** ipcInfos) {
   ncclResult_t ret = ncclSuccess;
   *totalMappedBufferSize = 0;
   *numSegments = 0;
@@ -944,7 +1001,7 @@ ncclResult_t ipcHandleMultiSegmentRegistration(CUdeviceptr userBuff, size_t user
   size_t tmpBaseSize;
   CUmemGenericAllocationHandle* segmentHandles = nullptr;
   int* expFds = nullptr;
-  int *impFds = nullptr;
+  int* impFds = nullptr;
   int capacity = 2;
   // Minimum of two segments in this codepath
   NCCLCHECK(ncclCalloc(ipcInfos, capacity));
@@ -972,11 +1029,14 @@ ncclResult_t ipcHandleMultiSegmentRegistration(CUdeviceptr userBuff, size_t user
     struct p2pIpcExpInfo* ipcInfo = *ipcInfos + segment;
     CUCHECKGOTO(cuMemGetAddressRange(&tmpBase, &tmpBaseSize, mappedPtrEnd), ret, fail);
     ipcInfo->size = tmpBaseSize;
-    CUCHECKGOTO(cuMemRetainAllocationHandle(&segmentHandles[segment], (void *) tmpBase), ret, fail);
+    CUCHECKGOTO(cuMemRetainAllocationHandle(&segmentHandles[segment], (void*)tmpBase), ret, fail);
     // Increment numSegments here so that retained handles are released if exporting a segment fails
     *numSegments = *numSegments + 1;
     if (*numSegments > NCCL_P2P_MAX_PHYSICAL_SEGMENTS) {
-      INFO(NCCL_REG, "Number of segments exceeded maximum number of supported physical segments for p2p (%d). Skipping multi-segment registration.", NCCL_P2P_MAX_PHYSICAL_SEGMENTS);
+      INFO(NCCL_REG,
+           "Number of segments exceeded maximum number of supported physical segments for p2p (%d). Skipping "
+           "multi-segment registration.",
+           NCCL_P2P_MAX_PHYSICAL_SEGMENTS);
       ret = ncclInternalError;
       goto fail;
     }
@@ -984,9 +1044,12 @@ ncclResult_t ipcHandleMultiSegmentRegistration(CUdeviceptr userBuff, size_t user
       memcpy(&ipcInfo->ipcDesc.memHandle, &segmentHandles[segment], sizeof(CUmemGenericAllocationHandle));
     } else {
       if (ncclCuMemHandleType == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) {
-        CUCHECKGOTO(cuMemExportToShareableHandle(&expFds[segment], segmentHandles[segment], ncclCuMemHandleType, 0), ret, fail);
+        CUCHECKGOTO(cuMemExportToShareableHandle(&expFds[segment], segmentHandles[segment], ncclCuMemHandleType, 0),
+                    ret, fail);
       } else {
-        CUCHECKGOTO(cuMemExportToShareableHandle(&ipcInfo->ipcDesc.cuDesc.handle, segmentHandles[segment], ncclCuMemHandleType, 0), ret, fail);
+        CUCHECKGOTO(cuMemExportToShareableHandle(&ipcInfo->ipcDesc.cuDesc.handle, segmentHandles[segment],
+                                                 ncclCuMemHandleType, 0),
+                    ret, fail);
       }
     }
 
@@ -1000,7 +1063,7 @@ ncclResult_t ipcHandleMultiSegmentRegistration(CUdeviceptr userBuff, size_t user
   }
   for (int segment = 0; segment < *numSegments; segment++) {
     struct p2pIpcExpInfo* ipcInfo = *ipcInfos + segment;
-     if (!proxyConn->sameProcess) {
+    if (!proxyConn->sameProcess) {
       if (ncclCuMemHandleType == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) {
         ipcInfo->impFd = impFds[segment];
         close(expFds[segment]);
@@ -1010,7 +1073,8 @@ ncclResult_t ipcHandleMultiSegmentRegistration(CUdeviceptr userBuff, size_t user
     CUCHECKGOTO(cuMemRelease(segmentHandles[segment]), ret, fail);
   }
 
-  TRACE(NCCL_REG, "Populated multi-segment IPC infos. totalMappedBufferSize : %zu, Num segments : %d", *totalMappedBufferSize, *numSegments);
+  TRACE(NCCL_REG, "Populated multi-segment IPC infos. totalMappedBufferSize : %zu, Num segments : %d",
+        *totalMappedBufferSize, *numSegments);
 
 exit:
   free(expFds);
@@ -1034,9 +1098,9 @@ fail:
   goto exit;
 }
 
-
-static ncclResult_t ipcRegisterBuffer(ncclComm* comm, const void* userbuff, size_t buffSize, int* peerRanks, int nPeers, ncclIpcRegType type, struct ncclReg* regRecord, int* regBufFlag, uintptr_t* offsetOut, uintptr_t** peerRmtAddrsOut, bool* isLegacyIpc) {
-
+static ncclResult_t ipcRegisterBuffer(ncclComm* comm, const void* userbuff, size_t buffSize, int* peerRanks, int nPeers,
+                                      ncclIpcRegType type, struct ncclReg* regRecord, int* regBufFlag,
+                                      uintptr_t* offsetOut, uintptr_t** peerRmtAddrsOut, bool* isLegacyIpc) {
   ncclResult_t ret = ncclSuccess;
   struct p2pIpcExpInfo* ipcInfo = nullptr;
   struct ncclIpcRegInfo* newInfo = NULL;
@@ -1071,7 +1135,11 @@ static ncclResult_t ipcRegisterBuffer(ncclComm* comm, const void* userbuff, size
         // We already have IPC info for this peer, no need to register it, we can reuse it
         *regBufFlag = 1;
         if (isLegacyIpc) *isLegacyIpc = regRecord->ipcInfos[peerIndex]->impInfo.legacyIpcCap;
-        INFO(NCCL_REG, "rank %d - IPC reuse buffer %p size %zu (baseAddr %p size %zu numSegments %d) to peer %d regAddr %p", comm->rank, userbuff, buffSize, (void*)regRecord->begAddr, regRecord->endAddr - regRecord->begAddr, regRecord->ipcInfos[peerIndex]->impInfo.numSegments, peerRank, regRecord->ipcInfos[peerIndex]->impInfo.rmtRegAddr);
+        INFO(NCCL_REG,
+             "rank %d - IPC reuse buffer %p size %zu (baseAddr %p size %zu numSegments %d) to peer %d regAddr %p",
+             comm->rank, userbuff, buffSize, (void*)regRecord->begAddr, regRecord->endAddr - regRecord->begAddr,
+             regRecord->ipcInfos[peerIndex]->impInfo.numSegments, peerRank,
+             regRecord->ipcInfos[peerIndex]->impInfo.rmtRegAddr);
       } else {
         // Register buffer with peerLocalRank
         struct ncclProxyConnector* proxyConn = NULL;
@@ -1081,7 +1149,9 @@ static ncclResult_t ipcRegisterBuffer(ncclComm* comm, const void* userbuff, size
         if (baseAddr == NULL) {
           CUCHECKGOTO(cuMemGetAddressRange((CUdeviceptr*)&baseAddr, &baseSize, (CUdeviceptr)userbuff), ret, fail);
 #if HIP_VERSION >= 71260540
-          CUCHECKGOTO(cuPointerGetAttribute((void*)&legacyIpcCap, CU_POINTER_ATTRIBUTE_IS_LEGACY_CUDA_IPC_CAPABLE, (CUdeviceptr)baseAddr), ret, fail);
+          CUCHECKGOTO(cuPointerGetAttribute((void*)&legacyIpcCap, CU_POINTER_ATTRIBUTE_IS_LEGACY_CUDA_IPC_CAPABLE,
+                                            (CUdeviceptr)baseAddr),
+                      ret, fail);
 #else
           // Legacy CUDA IPC support
           if (ncclParamLegacyCudaRegister()) {
@@ -1107,7 +1177,9 @@ static ncclResult_t ipcRegisterBuffer(ncclComm* comm, const void* userbuff, size
         if (ncclCuMemEnable()) {
 #if ROCM_VERSION >= 70000
           if (multiSegment) {
-            NCCLCHECKGOTO(ipcHandleMultiSegmentRegistration((CUdeviceptr) userbuff, buffSize, comm, proxyConn, &totalMappedSize, &numSegments, &ipcInfo), ret, fail);
+            NCCLCHECKGOTO(ipcHandleMultiSegmentRegistration((CUdeviceptr)userbuff, buffSize, comm, proxyConn,
+                                                            &totalMappedSize, &numSegments, &ipcInfo),
+                          ret, fail);
           } else {
             CUmemGenericAllocationHandle handle;
             if (CUPFN(cuMemRetainAllocationHandle(&handle, baseAddr)) != CUDA_SUCCESS) {
@@ -1130,7 +1202,8 @@ static ncclResult_t ipcRegisterBuffer(ncclComm* comm, const void* userbuff, size
                   SYSCHECKGOTO(close(expFd), "close", ret, fail);
                 } else {
                   // Allow this to silently fail for cases where the user buff cannot be registered
-                  if (CUPFN(cuMemExportToShareableHandle(&ipcInfo->ipcDesc.cuDesc.handle, handle, ncclCuMemHandleType, 0)) != CUDA_SUCCESS) {
+                  if (CUPFN(cuMemExportToShareableHandle(&ipcInfo->ipcDesc.cuDesc.handle, handle, ncclCuMemHandleType,
+                                                         0)) != CUDA_SUCCESS) {
                     CUCHECKGOTO(cuMemRelease(handle), ret, fail);
                     goto fail;
                   }
@@ -1159,8 +1232,12 @@ static ncclResult_t ipcRegisterBuffer(ncclComm* comm, const void* userbuff, size
         // Now ipcInfo contains all necessary registration info. Start to register buffer on proxy side
         // and get the remote register address back.
         if (proxyConn) {
-          INFO(NCCL_REG, "rank %d - IPC registering buffer %p size %zu (baseAddr %p totalSize %zu numSegments %d) to peer %d", comm->rank, userbuff, buffSize, (void*)regRecord->begAddr, totalMappedSize, numSegments, peerRank);
-          NCCLCHECKGOTO(ncclProxyCallBlocking(comm, proxyConn, ncclProxyMsgRegister, ipcInfo, sizeof(p2pIpcExpInfo) * numSegments, &rmtRegAddr, sizeof(void*)), ret, fail);
+          INFO(NCCL_REG,
+               "rank %d - IPC registering buffer %p size %zu (baseAddr %p totalSize %zu numSegments %d) to peer %d",
+               comm->rank, userbuff, buffSize, (void*)regRecord->begAddr, totalMappedSize, numSegments, peerRank);
+          NCCLCHECKGOTO(ncclProxyCallBlocking(comm, proxyConn, ncclProxyMsgRegister, ipcInfo,
+                                              sizeof(p2pIpcExpInfo) * numSegments, &rmtRegAddr, sizeof(void*)),
+                        ret, fail);
         }
         if (rmtRegAddr) {
           NCCLCHECKGOTO(ncclCalloc(&newInfo, 1), ret, fail);
@@ -1180,7 +1257,11 @@ static ncclResult_t ipcRegisterBuffer(ncclComm* comm, const void* userbuff, size
           regRecord->regIpcAddrs.hostPeerRmtAddrs[peerIndex] = (uintptr_t)rmtRegAddr;
           needUpdate = true;
           *regBufFlag = 1;
-          INFO(NCCL_REG, "rank %d - IPC register buffer %p size %zu (baseAddr %p totalSize %zu numSegments %d) to peer %d regAddr %p offsetOut %ld", comm->rank, userbuff, buffSize, (void*)regRecord->begAddr, totalMappedSize, numSegments, peerRank, rmtRegAddr, (uintptr_t)userbuff - regRecord->begAddr);
+          INFO(NCCL_REG,
+               "rank %d - IPC register buffer %p size %zu (baseAddr %p totalSize %zu numSegments %d) to peer %d "
+               "regAddr %p offsetOut %ld",
+               comm->rank, userbuff, buffSize, (void*)regRecord->begAddr, totalMappedSize, numSegments, peerRank,
+               rmtRegAddr, (uintptr_t)userbuff - regRecord->begAddr);
         }
       }
     }
@@ -1188,28 +1269,52 @@ static ncclResult_t ipcRegisterBuffer(ncclComm* comm, const void* userbuff, size
     if (*regBufFlag) {
       if (needUpdate) {
         cudaStream_t hostStream, deviceStream;
-        NCCLCHECKGOTO(ncclStrongStreamAcquire(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->hostStream, /*concurrent=*/false, &hostStream), ret, fail);
-        NCCLCHECKGOTO(ncclStrongStreamAcquire(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->deviceStream, /*concurrent=*/false, &deviceStream), ret, fail);
+        NCCLCHECKGOTO(ncclStrongStreamAcquire(ncclCudaGraphNone(comm->config.graphUsageMode),
+                                              &comm->sharedRes->hostStream, /*concurrent=*/false, &hostStream),
+                      ret, fail);
+        NCCLCHECKGOTO(ncclStrongStreamAcquire(ncclCudaGraphNone(comm->config.graphUsageMode),
+                                              &comm->sharedRes->deviceStream, /*concurrent=*/false, &deviceStream),
+                      ret, fail);
         if (regRecord->regIpcAddrs.devPeerRmtAddrs == NULL)
-          NCCLCHECKGOTO(ncclCudaCallocAsync(&regRecord->regIpcAddrs.devPeerRmtAddrs, ipcIndexSize, hostStream, comm->memManager), ret, fail);
-        NCCLCHECKGOTO(ncclCudaMemcpyAsync(regRecord->regIpcAddrs.devPeerRmtAddrs, regRecord->regIpcAddrs.hostPeerRmtAddrs, ipcIndexSize, hostStream), ret, fail);
+          NCCLCHECKGOTO(ncclCudaCallocAsync(&regRecord->regIpcAddrs.devPeerRmtAddrs, ipcIndexSize, hostStream,
+                                            comm->memManager),
+                        ret, fail);
+        NCCLCHECKGOTO(ncclCudaMemcpyAsync(regRecord->regIpcAddrs.devPeerRmtAddrs,
+                                          regRecord->regIpcAddrs.hostPeerRmtAddrs, ipcIndexSize, hostStream),
+                      ret, fail);
         NCCLCHECKGOTO(ncclStreamWaitStream(deviceStream, hostStream, comm->sharedRes->scratchEvent), ret, fail);
-        NCCLCHECKGOTO(ncclStrongStreamRelease(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->hostStream, /*concurrent=*/false), ret, fail);
-        NCCLCHECKGOTO(ncclStrongStreamRelease(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->deviceStream, /*concurrent=*/false), ret, fail);
+        NCCLCHECKGOTO(ncclStrongStreamRelease(ncclCudaGraphNone(comm->config.graphUsageMode),
+                                              &comm->sharedRes->hostStream, /*concurrent=*/false),
+                      ret, fail);
+        NCCLCHECKGOTO(ncclStrongStreamRelease(ncclCudaGraphNone(comm->config.graphUsageMode),
+                                              &comm->sharedRes->deviceStream, /*concurrent=*/false),
+                      ret, fail);
       }
       if (type == NCCL_IPC_COLLECTIVE) {
         // for collective, store registered remote buffers into dev memory for future reference
         if (regRecord->regIpcAddrs.devPeerRmtAddrs == NULL || needUpdate) {
           cudaStream_t hostStream, deviceStream;
-          NCCLCHECKGOTO(ncclStrongStreamAcquire(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->hostStream, /*concurrent=*/false, &hostStream), ret, fail);
-          NCCLCHECKGOTO(ncclStrongStreamAcquire(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->deviceStream, /*concurrent=*/false, &deviceStream), ret, fail);
+          NCCLCHECKGOTO(ncclStrongStreamAcquire(ncclCudaGraphNone(comm->config.graphUsageMode),
+                                                &comm->sharedRes->hostStream, /*concurrent=*/false, &hostStream),
+                        ret, fail);
+          NCCLCHECKGOTO(ncclStrongStreamAcquire(ncclCudaGraphNone(comm->config.graphUsageMode),
+                                                &comm->sharedRes->deviceStream, /*concurrent=*/false, &deviceStream),
+                        ret, fail);
           if (regRecord->regIpcAddrs.devPeerRmtAddrs == NULL)
-            NCCLCHECKGOTO(ncclCudaCallocAsync(&regRecord->regIpcAddrs.devPeerRmtAddrs, comm->localRanks, hostStream, comm->memManager), ret, fail);
+            NCCLCHECKGOTO(ncclCudaCallocAsync(&regRecord->regIpcAddrs.devPeerRmtAddrs, comm->localRanks, hostStream,
+                                              comm->memManager),
+                          ret, fail);
           if (needUpdate)
-            NCCLCHECKGOTO(ncclCudaMemcpyAsync(regRecord->regIpcAddrs.devPeerRmtAddrs, regRecord->regIpcAddrs.hostPeerRmtAddrs, comm->localRanks, hostStream), ret, fail);
+            NCCLCHECKGOTO(ncclCudaMemcpyAsync(regRecord->regIpcAddrs.devPeerRmtAddrs,
+                                              regRecord->regIpcAddrs.hostPeerRmtAddrs, comm->localRanks, hostStream),
+                          ret, fail);
           NCCLCHECKGOTO(ncclStreamWaitStream(deviceStream, hostStream, comm->sharedRes->scratchEvent), ret, fail);
-          NCCLCHECKGOTO(ncclStrongStreamRelease(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->hostStream, /*concurrent=*/false), ret, fail);
-          NCCLCHECKGOTO(ncclStrongStreamRelease(ncclCudaGraphNone(comm->config.graphUsageMode), &comm->sharedRes->deviceStream, /*concurrent=*/false), ret, fail);
+          NCCLCHECKGOTO(ncclStrongStreamRelease(ncclCudaGraphNone(comm->config.graphUsageMode),
+                                                &comm->sharedRes->hostStream, /*concurrent=*/false),
+                        ret, fail);
+          NCCLCHECKGOTO(ncclStrongStreamRelease(ncclCudaGraphNone(comm->config.graphUsageMode),
+                                                &comm->sharedRes->deviceStream, /*concurrent=*/false),
+                        ret, fail);
         }
         peerRmtAddrs = regRecord->regIpcAddrs.devPeerRmtAddrs;
       } else {
@@ -1229,13 +1334,17 @@ fail:
   *offsetOut = 0;
   *peerRmtAddrsOut = NULL;
   if (newInfo) free(newInfo);
-  INFO(NCCL_REG, "rank %d failed to IPC register userbuff %p buffSize %ld nPeers %d isLegacyIpc %d type %s", comm->rank, userbuff, buffSize, nPeers, isLegacyIpc ? *isLegacyIpc : -1, ncclCuMemHandleType == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR ? "POSIX_FD" : "FABRIC");
+  INFO(NCCL_REG, "rank %d failed to IPC register userbuff %p buffSize %ld nPeers %d isLegacyIpc %d type %s", comm->rank,
+       userbuff, buffSize, nPeers, isLegacyIpc ? *isLegacyIpc : -1,
+       ncclCuMemHandleType == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR ? "POSIX_FD" : "FABRIC");
   goto exit;
 }
 
-ncclResult_t ncclIpcLocalRegisterBuffer(ncclComm* comm, const void* userbuff, size_t buffSize, int* peerRanks, int nPeers, ncclIpcRegType type, int* regBufFlag, uintptr_t* offsetOut, uintptr_t** peerRmtAddrsOut) {
+ncclResult_t ncclIpcLocalRegisterBuffer(ncclComm* comm, const void* userbuff, size_t buffSize, int* peerRanks,
+                                        int nPeers, ncclIpcRegType type, int* regBufFlag, uintptr_t* offsetOut,
+                                        uintptr_t** peerRmtAddrsOut) {
   ncclResult_t ret = ncclSuccess;
-  struct ncclReg *regRecord = NULL;
+  struct ncclReg* regRecord = NULL;
   bool isValid = false;
   *regBufFlag = 0;
   *offsetOut = 0;
@@ -1244,7 +1353,9 @@ ncclResult_t ncclIpcLocalRegisterBuffer(ncclComm* comm, const void* userbuff, si
     NCCLCHECKGOTO(ncclRegFind(comm, userbuff, buffSize, &regRecord), ret, fail);
     NCCLCHECKGOTO(ncclRegLocalIsValid(regRecord, &isValid), ret, fail);
     if (isValid) {
-      NCCLCHECKGOTO(ipcRegisterBuffer(comm, userbuff, buffSize, peerRanks, nPeers, type, regRecord, regBufFlag, offsetOut, peerRmtAddrsOut, NULL), ret, fail);
+      NCCLCHECKGOTO(ipcRegisterBuffer(comm, userbuff, buffSize, peerRanks, nPeers, type, regRecord, regBufFlag,
+                                      offsetOut, peerRmtAddrsOut, NULL),
+                    ret, fail);
     }
   }
 
@@ -1259,8 +1370,8 @@ fail:
 
 struct ncclIpcCleanupCallback {
   struct ncclCommCallback base;
-  struct ncclComm *comm;
-  struct ncclReg *reg;
+  struct ncclComm* comm;
+  struct ncclReg* reg;
 };
 
 static ncclResult_t cleanupIpc(struct ncclComm* comm, struct ncclCommCallback* cb) {
@@ -1270,21 +1381,27 @@ static ncclResult_t cleanupIpc(struct ncclComm* comm, struct ncclCommCallback* c
   return ncclSuccess;
 }
 
-ncclResult_t ncclIpcGraphRegisterBuffer(ncclComm* comm, const void* userbuff, size_t buffSize, int* peerRanks, int nPeers, ncclIpcRegType type, int* regBufFlag, uintptr_t* offsetOut, uintptr_t** peerRmtAddrsOut, void* cleanupQueuePtr, int* nCleanupQueueElts) {
+ncclResult_t ncclIpcGraphRegisterBuffer(ncclComm* comm, const void* userbuff, size_t buffSize, int* peerRanks,
+                                        int nPeers, ncclIpcRegType type, int* regBufFlag, uintptr_t* offsetOut,
+                                        uintptr_t** peerRmtAddrsOut, void* cleanupQueuePtr, int* nCleanupQueueElts) {
   ncclResult_t ret = ncclSuccess;
   void* baseAddr = nullptr;
   size_t baseSize = 0;
-  struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>* cleanupQueue = reinterpret_cast<struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>*>(cleanupQueuePtr);
+  struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>* cleanupQueue =
+    reinterpret_cast<struct ncclIntruQueue<struct ncclCommCallback, &ncclCommCallback::next>*>(cleanupQueuePtr);
   bool isLegacyIpc = false;
-  struct ncclReg *regRecord = NULL;
+  struct ncclReg* regRecord = NULL;
 
   *regBufFlag = 0;
   *offsetOut = 0;
   *peerRmtAddrsOut = NULL;
   if (comm && userbuff && buffSize > 0 && nPeers > 0) {
-    NCCLCHECKGOTO(ncclCuMemGetAddressRange((CUdeviceptr) userbuff, buffSize, (CUdeviceptr*)&baseAddr, &baseSize, NULL), ret, fail);
+    NCCLCHECKGOTO(ncclCuMemGetAddressRange((CUdeviceptr)userbuff, buffSize, (CUdeviceptr*)&baseAddr, &baseSize, NULL),
+                  ret, fail);
     NCCLCHECKGOTO(ncclCommGraphRegister(comm, baseAddr, baseSize, (void**)&regRecord), ret, fail);
-    NCCLCHECKGOTO(ipcRegisterBuffer(comm, userbuff, buffSize, peerRanks, nPeers, type, regRecord, regBufFlag, offsetOut, peerRmtAddrsOut, &isLegacyIpc), ret, fail);
+    NCCLCHECKGOTO(ipcRegisterBuffer(comm, userbuff, buffSize, peerRanks, nPeers, type, regRecord, regBufFlag, offsetOut,
+                                    peerRmtAddrsOut, &isLegacyIpc),
+                  ret, fail);
     if (*regBufFlag) {
       struct ncclIpcCleanupCallback* record;
       NCCLCHECKGOTO(ncclCalloc(&record, 1), ret, fail);
@@ -1313,12 +1430,15 @@ fail:
 }
 
 ncclResult_t ncclIpcDeregBuffer(struct ncclComm* comm, struct ncclIpcRegInfo* regInfo) {
-  NCCLCHECK(ncclProxyCallBlocking(comm, regInfo->ipcProxyconn, ncclProxyMsgDeregister, &regInfo->impInfo, sizeof(struct ncclIpcImpInfo), NULL, 0));
-  INFO(NCCL_REG, "rank %d - IPC deregistered buffer %p peer %d ipc remote buffer %p", comm->rank, regInfo->baseAddr, regInfo->peerRank, regInfo->impInfo.rmtRegAddr);
+  NCCLCHECK(ncclProxyCallBlocking(comm, regInfo->ipcProxyconn, ncclProxyMsgDeregister, &regInfo->impInfo,
+                                  sizeof(struct ncclIpcImpInfo), NULL, 0));
+  INFO(NCCL_REG, "rank %d - IPC deregistered buffer %p peer %d ipc remote buffer %p", comm->rank, regInfo->baseAddr,
+       regInfo->peerRank, regInfo->impInfo.rmtRegAddr);
   return ncclSuccess;
 }
 
-static ncclResult_t p2pProxyRegister(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
+static ncclResult_t p2pProxyRegister(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState,
+                                     void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
   struct p2pIpcExpInfo* ipcExpInfo = (struct p2pIpcExpInfo*)reqBuff;
   void* regAddr = NULL;
   ncclResult_t ret = ncclSuccess;
@@ -1331,13 +1451,16 @@ static ncclResult_t p2pProxyRegister(struct ncclProxyConnection* connection, str
   assert(sizeof(struct p2pIpcExpInfo) == reqSize);
   assert(sizeof(void*) == respSize);
 
-  INFO(NCCL_REG, "Proxy rank %d register reqBuff %p size %ld offset %ld legacyIpcCap %d sameProcess %d", proxyState->tpRank, reqBuff, ipcExpInfo->size, ipcExpInfo->offset, ipcExpInfo->legacyIpcCap, connection->sameProcess);
+  INFO(NCCL_REG, "Proxy rank %d register reqBuff %p size %ld offset %ld legacyIpcCap %d sameProcess %d",
+       proxyState->tpRank, reqBuff, ipcExpInfo->size, ipcExpInfo->offset, ipcExpInfo->legacyIpcCap,
+       connection->sameProcess);
 
   // request peer passes all necessary buffer info to import. The proxy thread would register
   // the buffer locally and return register addr back
   if (ipcExpInfo->legacyIpcCap) {
     // legacy import
-    CUDACHECKGOTO(cudaIpcOpenMemHandle(&regAddr, ipcExpInfo->ipcDesc.devIpc, cudaIpcMemLazyEnablePeerAccess), ret, fail);
+    CUDACHECKGOTO(cudaIpcOpenMemHandle(&regAddr, ipcExpInfo->ipcDesc.devIpc, cudaIpcMemLazyEnablePeerAccess), ret,
+                  fail);
     regAddr = (void*)((uintptr_t)regAddr + ipcExpInfo->offset);
   } else {
 #if ROCM_VERSION >= 70000
@@ -1348,14 +1471,18 @@ static ncclResult_t p2pProxyRegister(struct ncclProxyConnection* connection, str
     } else {
       if (ncclCuMemHandleType == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) {
         // For POSIX_FD, pass the fd value (not a pointer to fd) cast as void*
-        CUCHECKGOTO(cuMemImportFromShareableHandle(&handle, (void*)(uintptr_t)ipcExpInfo->impFd, ncclCuMemHandleType), ret, fail);
+        CUCHECKGOTO(cuMemImportFromShareableHandle(&handle, (void*)(uintptr_t)ipcExpInfo->impFd, ncclCuMemHandleType),
+                    ret, fail);
         SYSCHECKGOTO(close(ipcExpInfo->impFd), "close", ret, fail);
       } else {
-        CUCHECKGOTO(cuMemImportFromShareableHandle(&handle, (void*)&ipcExpInfo->ipcDesc.cuDesc, ncclCuMemHandleType), ret, fail);
+        CUCHECKGOTO(cuMemImportFromShareableHandle(&handle, (void*)&ipcExpInfo->ipcDesc.cuDesc, ncclCuMemHandleType),
+                    ret, fail);
       }
     }
     imported = true;
-    CUCHECKGOTO(cuMemAddressReserve((CUdeviceptr*)&regAddr, ipcExpInfo->size, /* alignment */ 0, /* addr */ 0, /* flags */ 0), ret, fail);
+    CUCHECKGOTO(cuMemAddressReserve((CUdeviceptr*)&regAddr, ipcExpInfo->size, /* alignment */ 0, /* addr */ 0,
+                                    /* flags */ 0),
+                ret, fail);
     CUCHECKGOTO(cuMemMap((CUdeviceptr)regAddr, ipcExpInfo->size, /* offset */ 0, handle, /* flags */ 0), ret, fail);
     mapped = true;
     // Allow access by the local GPU
@@ -1367,7 +1494,9 @@ static ncclResult_t p2pProxyRegister(struct ncclProxyConnection* connection, str
     regAddr = (void*)((uintptr_t)regAddr + ipcExpInfo->offset);
 #endif
   }
-  INFO(NCCL_REG, "Proxy rank %d register success regAddr %p size %ld offset %ld legacyIpcCap %d sameProcess %d", proxyState->tpRank, regAddr, ipcExpInfo->size, ipcExpInfo->offset, ipcExpInfo->legacyIpcCap, connection->sameProcess);
+  INFO(NCCL_REG, "Proxy rank %d register success regAddr %p size %ld offset %ld legacyIpcCap %d sameProcess %d",
+       proxyState->tpRank, regAddr, ipcExpInfo->size, ipcExpInfo->offset, ipcExpInfo->legacyIpcCap,
+       connection->sameProcess);
 
 exit:
   // Enqueue the imported handle (single segment) so p2pProxyDeregister()
@@ -1402,10 +1531,12 @@ fail:
 static bool p2pHandleCmp(struct proxyMemHandle* a, struct proxyMemHandle* b) {
   struct ncclIpcImpInfo* ipcInfoA = (struct ncclIpcImpInfo*)a->handle;
   struct ncclIpcImpInfo* ipcInfoB = (struct ncclIpcImpInfo*)b->handle;
-  return ipcInfoA->rmtRegAddr == ipcInfoB->rmtRegAddr && ipcInfoA->offset == ipcInfoB->offset && ipcInfoA->legacyIpcCap == ipcInfoB->legacyIpcCap && ipcInfoA->numSegments == ipcInfoB->numSegments;
+  return ipcInfoA->rmtRegAddr == ipcInfoB->rmtRegAddr && ipcInfoA->offset == ipcInfoB->offset &&
+         ipcInfoA->legacyIpcCap == ipcInfoB->legacyIpcCap && ipcInfoA->numSegments == ipcInfoB->numSegments;
 }
 
-static ncclResult_t p2pProxyDeregister(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, int* done) {
+static ncclResult_t p2pProxyDeregister(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState,
+                                       void* reqBuff, int reqSize, int* done) {
   ncclResult_t ret = ncclSuccess;
   struct ncclIpcImpInfo* ipcInfo = (struct ncclIpcImpInfo*)reqBuff;
   assert(sizeof(struct ncclIpcImpInfo) == reqSize);
@@ -1426,12 +1557,12 @@ fail:
   goto exit;
 }
 
-struct ncclTransport p2pTransport = {
-  "P2P",
-  p2pCanConnect,
-  { p2pSendSetup, p2pSendConnect, p2pSendFree, NULL, p2pSendProxySetup, NULL, p2pSendProxyFree, NULL, p2pProxyRegister, p2pProxyDeregister },
-  { p2pRecvSetup, p2pRecvConnect, p2pRecvFree, NULL, p2pRecvProxySetup, NULL, p2pRecvProxyFree, NULL, p2pProxyRegister, p2pProxyDeregister }
-};
+struct ncclTransport p2pTransport = {"P2P",
+                                     p2pCanConnect,
+                                     {p2pSendSetup, p2pSendConnect, p2pSendFree, NULL, p2pSendProxySetup, NULL,
+                                      p2pSendProxyFree, NULL, p2pProxyRegister, p2pProxyDeregister},
+                                     {p2pRecvSetup, p2pRecvConnect, p2pRecvFree, NULL, p2pRecvProxySetup, NULL,
+                                      p2pRecvProxyFree, NULL, p2pProxyRegister, p2pProxyDeregister}};
 
 static void initCeOperation() {
   static int init = 0;

--- a/projects/rccl/src/transport/profiler.cc
+++ b/projects/rccl/src/transport/profiler.cc
@@ -9,7 +9,8 @@
 #include "profiler.h"
 #include "device.h"
 
-static ncclResult_t profilerProxyConnect(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
+static ncclResult_t profilerProxyConnect(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState,
+                                         void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
   connection->proxyAppendPtr = &connection->proxyAppend;
   connection->shared = 0;
   return ncclSuccess;
@@ -34,11 +35,12 @@ static ncclResult_t profilerProxyProgress(struct ncclProxyState* proxyState, str
     int stopping = proxyState->progressState.stop;
     for (int s = 0; s < args->nsubs; s++) {
       struct ncclProxySubArgs* sub = args->subs + s;
-      struct ncclDevProfiler* workStarted = (struct ncclDevProfiler *)sub->sendbuff;
-      struct ncclDevProfiler* workCompleted = (struct ncclDevProfiler *)sub->recvbuff;
+      struct ncclDevProfiler* workStarted = (struct ncclDevProfiler*)sub->sendbuff;
+      struct ncclDevProfiler* workCompleted = (struct ncclDevProfiler*)sub->recvbuff;
       if (sub->posted < sub->nsteps) {
-        if (sub->base <= workStarted[sub->channelId].data[sub->base%MAX_PROFILER_EVENTS_PER_CHANNEL].counter) {
-          ncclProfilerStartKernelChEvent(args, s, workStarted[sub->channelId].data[sub->base%MAX_PROFILER_EVENTS_PER_CHANNEL].timestamp);
+        if (sub->base <= workStarted[sub->channelId].data[sub->base % MAX_PROFILER_EVENTS_PER_CHANNEL].counter) {
+          ncclProfilerStartKernelChEvent(
+            args, s, workStarted[sub->channelId].data[sub->base % MAX_PROFILER_EVENTS_PER_CHANNEL].timestamp);
           sub->posted = sub->nsteps;
           continue; // allow events on every channel to start
         }
@@ -51,8 +53,9 @@ static ncclResult_t profilerProxyProgress(struct ncclProxyState* proxyState, str
         continue;
       }
       if (sub->transmitted < sub->nsteps) {
-        if (sub->base <= workCompleted[sub->channelId].data[sub->base%MAX_PROFILER_EVENTS_PER_CHANNEL].counter) {
-          ncclProfilerStopKernelChEvent(args, s, workCompleted[sub->channelId].data[sub->base%MAX_PROFILER_EVENTS_PER_CHANNEL].timestamp);
+        if (sub->base <= workCompleted[sub->channelId].data[sub->base % MAX_PROFILER_EVENTS_PER_CHANNEL].counter) {
+          ncclProfilerStopKernelChEvent(
+            args, s, workCompleted[sub->channelId].data[sub->base % MAX_PROFILER_EVENTS_PER_CHANNEL].timestamp);
           sub->transmitted = sub->nsteps;
           args->done++;
         } else if (stopping) {
@@ -68,9 +71,8 @@ static ncclResult_t profilerProxyProgress(struct ncclProxyState* proxyState, str
   return ncclSuccess;
 }
 
-struct ncclTransport profilerTransport = {
-  "Prof",
-  NULL,
-  { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL },
-  { NULL, NULL, NULL, NULL, NULL, profilerProxyConnect, NULL, profilerProxyProgress, NULL, NULL }
-};
+struct ncclTransport profilerTransport = {"Prof",
+                                          NULL,
+                                          {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL},
+                                          {NULL, NULL, NULL, NULL, NULL, profilerProxyConnect, NULL,
+                                           profilerProxyProgress, NULL, NULL}};

--- a/projects/rccl/src/transport/shm.cc
+++ b/projects/rccl/src/transport/shm.cc
@@ -15,8 +15,8 @@
 #define SHM_HANDLE_TYPE ncclCuMemHandleType
 
 struct shmBuffInfo {
-  void *hptr;
-  void *dptr;
+  void* hptr;
+  void* dptr;
 };
 
 struct shmConnectInfo {
@@ -74,7 +74,8 @@ static int shmLocality = 0;
 static void initCeOperation();
 
 /* Determine two peers can communicate with SHM */
-static ncclResult_t shmCanConnect(int* ret, struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* info1, struct ncclPeerInfo* info2) {
+static ncclResult_t shmCanConnect(int* ret, struct ncclComm* comm, struct ncclTopoGraph* graph,
+                                  struct ncclPeerInfo* info1, struct ncclPeerInfo* info2) {
   *ret = 0;
   initCeOperation();
 
@@ -85,11 +86,11 @@ static ncclResult_t shmCanConnect(int* ret, struct ncclComm* comm, struct ncclTo
   if (useNet) return ncclSuccess;
 
   // Same host?
-  TRACE(NCCL_INIT|NCCL_SHM, "peer1 hostHash %lx peer2 hostHash %lx", info1->hostHash, info2->hostHash);
+  TRACE(NCCL_INIT | NCCL_SHM, "peer1 hostHash %lx peer2 hostHash %lx", info1->hostHash, info2->hostHash);
   if (info1->hostHash != info2->hostHash) return ncclSuccess;
 
   // Common /dev/shm (between containers) ?
-  TRACE(NCCL_INIT|NCCL_SHM, "peer1 shmDev %lx peer2 shmDev %lx", info1->shmDev, info2->shmDev);
+  TRACE(NCCL_INIT | NCCL_SHM, "peer1 shmDev %lx peer2 shmDev %lx", info1->shmDev, info2->shmDev);
   if (info1->shmDev != info2->shmDev) return ncclSuccess;
 
   *ret = 1;
@@ -100,7 +101,9 @@ static ncclResult_t shmCanConnect(int* ret, struct ncclComm* comm, struct ncclTo
 #define MAX_SHM_NAME_LEN 1024
 
 /* Create and return connect structures for this peer to connect to me */
-static ncclResult_t shmSendSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* myInfo, struct ncclPeerInfo* peerInfo, struct ncclConnect* connectInfo, struct ncclConnector* send, int channelId, int connIndex) {
+static ncclResult_t shmSendSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* myInfo,
+                                 struct ncclPeerInfo* peerInfo, struct ncclConnect* connectInfo,
+                                 struct ncclConnector* send, int channelId, int connIndex) {
   struct shmSendResources* resources;
   struct shmConnectInfo* info = (struct shmConnectInfo*)connectInfo;
   size_t shmSize = sizeof(struct ncclSendMem);
@@ -112,26 +115,29 @@ static ncclResult_t shmSendSetup(struct ncclComm* comm, struct ncclTopoGraph* gr
   send->transportResources = resources;
 
   if (shmLocality == SHM_SEND_SIDE) {
-    for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) shmSize += comm->buffSizes[p];
+    for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) shmSize += comm->buffSizes[p];
   }
   req.size = shmSize;
-  if (myInfo->hostHash == peerInfo->hostHash && myInfo->pidHash == peerInfo->pidHash)
-    req.legacy = true;
-  else
-    req.legacy = false;
+  if (myInfo->hostHash == peerInfo->hostHash && myInfo->pidHash == peerInfo->pidHash) req.legacy = true;
+  else req.legacy = false;
 
   NCCLCHECK(ncclProxyConnect(comm, TRANSPORT_SHM, 1, myInfo->rank, &send->proxyConn));
-  NCCLCHECK(ncclProxyCallBlocking(comm, &send->proxyConn, ncclProxyMsgSetup, (void*)&req, sizeof(struct shmRequest), (void*)info, sizeof(struct shmConnectInfo)));
+  NCCLCHECK(ncclProxyCallBlocking(comm, &send->proxyConn, ncclProxyMsgSetup, (void*)&req, sizeof(struct shmRequest),
+                                  (void*)info, sizeof(struct shmConnectInfo)));
 
   info->rank = comm->rank;
   resources->hostMem = (struct ncclSendMem*)info->buf.hptr;
   resources->devHostMem = (struct ncclSendMem*)info->buf.dptr;
 
-  INFO(NCCL_INIT|NCCL_SHM,"Channel %02d : %d[%lx] -> %d[%lx] via SHM/%s/%s comm %p nRanks %02d", channelId, myInfo->rank, myInfo->busId, peerInfo->rank, peerInfo->busId, useMemcpySend?"CE":"direct", useMemcpyRecv?"CE":"direct", comm, comm->nRanks);
+  INFO(NCCL_INIT | NCCL_SHM, "Channel %02d : %d[%lx] -> %d[%lx] via SHM/%s/%s comm %p nRanks %02d", channelId,
+       myInfo->rank, myInfo->busId, peerInfo->rank, peerInfo->busId, useMemcpySend ? "CE" : "direct",
+       useMemcpyRecv ? "CE" : "direct", comm, comm->nRanks);
   return ncclSuccess;
 }
 
-static ncclResult_t shmRecvSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* myInfo, struct ncclPeerInfo* peerInfo, struct ncclConnect* connectInfo, struct ncclConnector* recv, int channelId, int connIndex) {
+static ncclResult_t shmRecvSetup(struct ncclComm* comm, struct ncclTopoGraph* graph, struct ncclPeerInfo* myInfo,
+                                 struct ncclPeerInfo* peerInfo, struct ncclConnect* connectInfo,
+                                 struct ncclConnector* recv, int channelId, int connIndex) {
   struct shmRecvResources* resources;
   struct shmConnectInfo* info = (struct shmConnectInfo*)connectInfo;
   size_t shmSize = sizeof(struct ncclRecvMem);
@@ -143,16 +149,15 @@ static ncclResult_t shmRecvSetup(struct ncclComm* comm, struct ncclTopoGraph* gr
   static_assert(sizeof(struct shmConnectInfo) <= sizeof(struct ncclConnect), "shm Connect Info is too big");
 
   if (shmLocality == SHM_RECV_SIDE) {
-    for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) shmSize += comm->buffSizes[p];
+    for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) shmSize += comm->buffSizes[p];
   }
   req.size = shmSize;
-  if (myInfo->hostHash == peerInfo->hostHash && myInfo->pidHash == peerInfo->pidHash)
-    req.legacy = true;
-  else
-    req.legacy = false;
+  if (myInfo->hostHash == peerInfo->hostHash && myInfo->pidHash == peerInfo->pidHash) req.legacy = true;
+  else req.legacy = false;
 
   NCCLCHECK(ncclProxyConnect(comm, TRANSPORT_SHM, 0, myInfo->rank, &recv->proxyConn));
-  NCCLCHECK(ncclProxyCallBlocking(comm, &recv->proxyConn, ncclProxyMsgSetup, (void*)&req, sizeof(struct shmRequest), (void*)info, sizeof(struct shmConnectInfo)));
+  NCCLCHECK(ncclProxyCallBlocking(comm, &recv->proxyConn, ncclProxyMsgSetup, (void*)&req, sizeof(struct shmRequest),
+                                  (void*)info, sizeof(struct shmConnectInfo)));
 
   info->rank = comm->rank;
   resources->hostMem = (struct ncclRecvMem*)info->buf.hptr;
@@ -162,29 +167,33 @@ static ncclResult_t shmRecvSetup(struct ncclComm* comm, struct ncclTopoGraph* gr
 }
 
 /* Connect to this peer */
-static ncclResult_t shmSendConnect(struct ncclComm* comm, struct ncclConnect* connectInfo, int nranks, int rank, struct ncclConnector* send) {
+static ncclResult_t shmSendConnect(struct ncclComm* comm, struct ncclConnect* connectInfo, int nranks, int rank,
+                                   struct ncclConnector* send) {
   // Setup device pointers
   struct shmConnectInfo* info = (struct shmConnectInfo*)connectInfo;
   struct shmSendResources* resources = (struct shmSendResources*)send->transportResources;
   char* buff;
 
-  NCCLCHECK(ncclShmImportShareableBuffer(comm, info->rank, &info->desc, (void**)&resources->remHostMem, (void**)&resources->devRemHostMem, &resources->remDesc));
+  NCCLCHECK(ncclShmImportShareableBuffer(comm, info->rank, &info->desc, (void**)&resources->remHostMem,
+                                         (void**)&resources->devRemHostMem, &resources->remDesc));
 
   buff = shmLocality == SHM_SEND_SIDE ? (char*)(resources->devHostMem + 1) : (char*)(resources->devRemHostMem + 1);
-  for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
+  for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) {
     send->conn.buffs[p] = buff;
     buff += comm->buffSizes[p];
   }
   send->conn.tail = &resources->devRemHostMem->tail;
   send->conn.head = &resources->devHostMem->head;
-  send->conn.stepSize = comm->buffSizes[NCCL_PROTO_SIMPLE]/NCCL_STEPS;
+  send->conn.stepSize = comm->buffSizes[NCCL_PROTO_SIMPLE] / NCCL_STEPS;
 
   if (useMemcpyRecv) {
     send->conn.connFifo = resources->devRemHostMem->connFifo;
   }
   if (useMemcpySend) {
-    struct shmProxyInfo proxyInfo = { NULL, NULL, send->conn.buffs[NCCL_PROTO_SIMPLE], resources->hostMem, resources->remHostMem };
-    NCCLCHECK(ncclProxyCallBlocking(comm, &send->proxyConn, ncclProxyMsgConnect, &proxyInfo, sizeof(struct shmProxyInfo), &proxyInfo, sizeof(struct shmProxyInfo)));
+    struct shmProxyInfo proxyInfo = {NULL, NULL, send->conn.buffs[NCCL_PROTO_SIMPLE], resources->hostMem,
+                                     resources->remHostMem};
+    NCCLCHECK(ncclProxyCallBlocking(comm, &send->proxyConn, ncclProxyMsgConnect, &proxyInfo,
+                                    sizeof(struct shmProxyInfo), &proxyInfo, sizeof(struct shmProxyInfo)));
     send->conn.buffs[NCCL_PROTO_SIMPLE] = proxyInfo.devFifo;
     send->conn.tail = &proxyInfo.ceRecvMem->tail;
     send->conn.connFifo = proxyInfo.ceRecvMem->connFifo;
@@ -196,26 +205,30 @@ static ncclResult_t shmSendConnect(struct ncclComm* comm, struct ncclConnect* co
   return ncclSuccess;
 }
 
-static ncclResult_t shmRecvConnect(struct ncclComm* comm, struct ncclConnect* connectInfo, int nranks, int rank, struct ncclConnector* recv) {
+static ncclResult_t shmRecvConnect(struct ncclComm* comm, struct ncclConnect* connectInfo, int nranks, int rank,
+                                   struct ncclConnector* recv) {
   // Setup device pointers
   struct shmRecvResources* resources = (struct shmRecvResources*)recv->transportResources;
   struct shmConnectInfo* info = (struct shmConnectInfo*)connectInfo;
   char* buff;
 
-  NCCLCHECK(ncclShmImportShareableBuffer(comm, info->rank, &info->desc, (void**)&resources->remHostMem, (void**)&resources->devRemHostMem, &resources->remDesc));
+  NCCLCHECK(ncclShmImportShareableBuffer(comm, info->rank, &info->desc, (void**)&resources->remHostMem,
+                                         (void**)&resources->devRemHostMem, &resources->remDesc));
 
   buff = shmLocality == SHM_RECV_SIDE ? (char*)(resources->devHostMem + 1) : (char*)(resources->devRemHostMem + 1);
-  for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
+  for (int p = 0; p < NCCL_NUM_PROTOCOLS; p++) {
     recv->conn.buffs[p] = buff;
     buff += comm->buffSizes[p];
   }
   recv->conn.head = &resources->devRemHostMem->head;
   recv->conn.tail = &resources->devHostMem->tail;
-  recv->conn.stepSize = comm->buffSizes[NCCL_PROTO_SIMPLE]/NCCL_STEPS;
+  recv->conn.stepSize = comm->buffSizes[NCCL_PROTO_SIMPLE] / NCCL_STEPS;
 
   if (useMemcpyRecv) {
-    struct shmProxyInfo proxyInfo = { NULL, NULL, recv->conn.buffs[NCCL_PROTO_SIMPLE], resources->remHostMem, resources->hostMem };
-    NCCLCHECK(ncclProxyCallBlocking(comm, &recv->proxyConn, ncclProxyMsgConnect, &proxyInfo, sizeof(struct shmProxyInfo), &proxyInfo, sizeof(struct shmProxyInfo)));
+    struct shmProxyInfo proxyInfo = {NULL, NULL, recv->conn.buffs[NCCL_PROTO_SIMPLE], resources->remHostMem,
+                                     resources->hostMem};
+    NCCLCHECK(ncclProxyCallBlocking(comm, &recv->proxyConn, ncclProxyMsgConnect, &proxyInfo,
+                                    sizeof(struct shmProxyInfo), &proxyInfo, sizeof(struct shmProxyInfo)));
     recv->conn.buffs[NCCL_PROTO_SIMPLE] = proxyInfo.devFifo;
     recv->conn.tail = &proxyInfo.ceRecvMem->tail;
   }
@@ -246,7 +259,8 @@ static ncclResult_t shmRecvFree(struct ncclComm* comm, struct ncclConnector* rec
   return ncclSuccess;
 }
 
-static ncclResult_t shmSendProxyConnect(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
+static ncclResult_t shmSendProxyConnect(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState,
+                                        void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
   ncclResult_t ret = ncclSuccess;
   if (reqSize != sizeof(struct shmProxyInfo) || respSize != sizeof(struct shmProxyInfo)) return ncclInternalError;
   struct shmProxyInfo* proxyInfo;
@@ -256,11 +270,12 @@ static ncclResult_t shmSendProxyConnect(struct ncclProxyConnection* connection, 
   proxyInfo->shmFifo = reqInfo->shmFifo;
   proxyInfo->sendMem = reqInfo->sendMem;
   proxyInfo->recvMem = reqInfo->recvMem;
-  NCCLCHECKGOTO(ncclCudaCalloc(&proxyInfo->devFifo, proxyState->buffSizes[NCCL_PROTO_SIMPLE], proxyState->memManager), ret, fail);
+  NCCLCHECKGOTO(ncclCudaCalloc(&proxyInfo->devFifo, proxyState->buffSizes[NCCL_PROTO_SIMPLE], proxyState->memManager),
+                ret, fail);
   NCCLCHECKGOTO(ncclCudaHostCalloc(&proxyInfo->ceRecvMem, 1), ret, fail);
   CUDACHECKGOTO(cudaStreamCreateWithFlags(&proxyInfo->stream, cudaStreamNonBlocking), ret, fail);
-  for (int i=0; i<NCCL_STEPS; i++) {
-    CUDACHECKGOTO(cudaEventCreate(proxyInfo->events+i), ret, fail);
+  for (int i = 0; i < NCCL_STEPS; i++) {
+    CUDACHECKGOTO(cudaEventCreate(proxyInfo->events + i), ret, fail);
   }
   connection->proxyAppendPtr = &connection->proxyAppend;
   connection->transportResources = proxyInfo;
@@ -276,7 +291,8 @@ fail:
   goto exit;
 }
 
-static ncclResult_t shmRecvProxyConnect(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
+static ncclResult_t shmRecvProxyConnect(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState,
+                                        void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
   ncclResult_t ret = ncclSuccess;
   if (reqSize != sizeof(struct shmProxyInfo) || respSize != sizeof(struct shmProxyInfo)) return ncclInternalError;
   struct shmProxyInfo* proxyInfo;
@@ -286,11 +302,12 @@ static ncclResult_t shmRecvProxyConnect(struct ncclProxyConnection* connection, 
   proxyInfo->shmFifo = reqInfo->shmFifo;
   proxyInfo->sendMem = reqInfo->sendMem;
   proxyInfo->recvMem = reqInfo->recvMem;
-  NCCLCHECKGOTO(ncclCudaCalloc(&proxyInfo->devFifo, proxyState->buffSizes[NCCL_PROTO_SIMPLE], proxyState->memManager), ret, fail);
+  NCCLCHECKGOTO(ncclCudaCalloc(&proxyInfo->devFifo, proxyState->buffSizes[NCCL_PROTO_SIMPLE], proxyState->memManager),
+                ret, fail);
   NCCLCHECKGOTO(ncclCudaHostCalloc(&proxyInfo->ceRecvMem, 1), ret, fail);
   CUDACHECKGOTO(cudaStreamCreateWithFlags(&proxyInfo->stream, cudaStreamNonBlocking), ret, fail);
-  for (int i=0; i<NCCL_STEPS; i++) {
-    CUDACHECKGOTO(cudaEventCreate(proxyInfo->events+i), ret, fail);
+  for (int i = 0; i < NCCL_STEPS; i++) {
+    CUDACHECKGOTO(cudaEventCreate(proxyInfo->events + i), ret, fail);
   }
   connection->proxyAppendPtr = &connection->proxyAppend;
   memcpy(respBuff, proxyInfo, respSize);
@@ -312,7 +329,7 @@ static ncclResult_t shmSendProxyFree(struct ncclProxyConnection* connection, str
       CUDACHECK(cudaStreamDestroy(resources->stream));
       NCCLCHECK(ncclCudaFree(resources->devFifo, proxyState->memManager));
       NCCLCHECK(ncclCudaHostFree(resources->ceRecvMem));
-      for (int i=0; i<NCCL_STEPS; i++) {
+      for (int i = 0; i < NCCL_STEPS; i++) {
         CUDACHECK(cudaEventDestroy(resources->events[i]));
       }
     }
@@ -331,7 +348,7 @@ static ncclResult_t shmRecvProxyFree(struct ncclProxyConnection* connection, str
       CUDACHECK(cudaStreamDestroy(resources->stream));
       NCCLCHECK(ncclCudaFree(resources->devFifo, proxyState->memManager));
       NCCLCHECK(ncclCudaHostFree(resources->ceRecvMem));
-      for (int i=0; i<NCCL_STEPS; i++) {
+      for (int i = 0; i < NCCL_STEPS; i++) {
         CUDACHECK(cudaEventDestroy(resources->events[i]));
       }
     }
@@ -344,9 +361,9 @@ static ncclResult_t shmRecvProxyFree(struct ncclProxyConnection* connection, str
 
 static ncclResult_t shmSendProxyProgress(struct ncclProxyState* proxyState, struct ncclProxyArgs* args) {
   if (args->state == ncclProxyOpReady) {
-    for (int s=0; s<args->nsubs; s++) {
-      struct ncclProxySubArgs* sub = args->subs+s;
-      struct shmProxyInfo* resources = (struct shmProxyInfo*) (sub->connection->transportResources);
+    for (int s = 0; s < args->nsubs; s++) {
+      struct ncclProxySubArgs* sub = args->subs + s;
+      struct shmProxyInfo* resources = (struct shmProxyInfo*)(sub->connection->transportResources);
       // Round to next multiple of sliceSteps
       sub->base = ROUNDUP(resources->step, args->chunkSteps);
       sub->posted = sub->transmitted = sub->done = 0;
@@ -357,22 +374,23 @@ static ncclResult_t shmSendProxyProgress(struct ncclProxyState* proxyState, stru
   if (args->state == ncclProxyOpProgress) {
     int p = args->protocol;
     int stepSize = proxyState->buffSizes[p] / NCCL_STEPS;
-    for (int s=0; s<args->nsubs; s++) {
-      struct ncclProxySubArgs* sub = args->subs+s;
-      struct shmProxyInfo* resources = (struct shmProxyInfo*) (sub->connection->transportResources);
+    for (int s = 0; s < args->nsubs; s++) {
+      struct ncclProxySubArgs* sub = args->subs + s;
+      struct shmProxyInfo* resources = (struct shmProxyInfo*)(sub->connection->transportResources);
       if (p != NCCL_PROTO_SIMPLE) { // Only Simple uses cudaMemcpy
-          resources->step = sub->base + sub->nsteps;
-          args->done++;
-          continue;
+        resources->step = sub->base + sub->nsteps;
+        args->done++;
+        continue;
       }
       if (sub->transmitted < sub->done + NCCL_STEPS && sub->transmitted < sub->nsteps) {
-        int buffSlot = (sub->base+sub->transmitted)%NCCL_STEPS;
+        int buffSlot = (sub->base + sub->transmitted) % NCCL_STEPS;
         volatile struct ncclConnFifo* connFifo = resources->ceRecvMem->connFifo;
         volatile uint64_t* recvTail = &resources->ceRecvMem->tail;
         // Check GPU has sent everything
-        if ((*recvTail > sub->base+sub->transmitted)) {
+        if ((*recvTail > sub->base + sub->transmitted)) {
           int size = connFifo[buffSlot].size;
-          CUDACHECK(cudaMemcpyAsync(resources->shmFifo+buffSlot*stepSize, resources->devFifo+buffSlot*stepSize, size, cudaMemcpyDeviceToHost, resources->stream));
+          CUDACHECK(cudaMemcpyAsync(resources->shmFifo + buffSlot * stepSize, resources->devFifo + buffSlot * stepSize,
+                                    size, cudaMemcpyDeviceToHost, resources->stream));
           CUDACHECK(cudaEventRecord(resources->events[buffSlot], resources->stream));
           resources->recvMem->connFifo[buffSlot].size = size;
           std::atomic_thread_fence(std::memory_order_seq_cst); // make sure connFifo[].size is visible
@@ -380,7 +398,7 @@ static ncclResult_t shmSendProxyProgress(struct ncclProxyState* proxyState, stru
         }
       }
       if (sub->done < sub->transmitted) {
-        int buffSlot = (sub->base+sub->done)%NCCL_STEPS;
+        int buffSlot = (sub->base + sub->done) % NCCL_STEPS;
         cudaError_t res = CUDACLEARERROR(cudaEventQuery(resources->events[buffSlot]));
         if (res != cudaErrorNotReady) CUDACHECK(res);
         if (res == cudaSuccess) {
@@ -403,9 +421,9 @@ static ncclResult_t shmSendProxyProgress(struct ncclProxyState* proxyState, stru
 
 static ncclResult_t shmRecvProxyProgress(struct ncclProxyState* proxyState, struct ncclProxyArgs* args) {
   if (args->state == ncclProxyOpReady) {
-    for (int s=0; s<args->nsubs; s++) {
-      struct ncclProxySubArgs* sub = args->subs+s;
-      struct shmProxyInfo* resources = (struct shmProxyInfo*) (sub->connection->transportResources);
+    for (int s = 0; s < args->nsubs; s++) {
+      struct ncclProxySubArgs* sub = args->subs + s;
+      struct shmProxyInfo* resources = (struct shmProxyInfo*)(sub->connection->transportResources);
       // Round to next multiple of sliceSteps
       sub->base = ROUNDUP(resources->step, args->chunkSteps);
       sub->posted = sub->transmitted = sub->done = 0;
@@ -416,28 +434,29 @@ static ncclResult_t shmRecvProxyProgress(struct ncclProxyState* proxyState, stru
   if (args->state == ncclProxyOpProgress) {
     int p = args->protocol;
     int stepSize = proxyState->buffSizes[p] / NCCL_STEPS;
-    for (int s=0; s<args->nsubs; s++) {
-      struct ncclProxySubArgs* sub = args->subs+s;
-      struct shmProxyInfo* resources = (struct shmProxyInfo*) (sub->connection->transportResources);
+    for (int s = 0; s < args->nsubs; s++) {
+      struct ncclProxySubArgs* sub = args->subs + s;
+      struct shmProxyInfo* resources = (struct shmProxyInfo*)(sub->connection->transportResources);
       if (p != NCCL_PROTO_SIMPLE) { // Only Simple uses cudaMemcpy
-          resources->step = sub->base + sub->nsteps;
-          args->done++;
-          continue;
+        resources->step = sub->base + sub->nsteps;
+        args->done++;
+        continue;
       }
       if (sub->transmitted < sub->done + NCCL_STEPS && sub->transmitted < sub->nsteps) {
-        int buffSlot = (sub->base+sub->transmitted)%NCCL_STEPS;
+        int buffSlot = (sub->base + sub->transmitted) % NCCL_STEPS;
         volatile struct ncclConnFifo* connFifo = resources->recvMem->connFifo;
         volatile uint64_t* recvTail = &resources->recvMem->tail;
         // Check data is ready in SHM
-        if ((*recvTail > sub->base+sub->transmitted)) {
+        if ((*recvTail > sub->base + sub->transmitted)) {
           int size = connFifo[buffSlot].size;
-          CUDACHECK(cudaMemcpyAsync(resources->devFifo+buffSlot*stepSize, resources->shmFifo+buffSlot*stepSize, size, cudaMemcpyHostToDevice, resources->stream));
+          CUDACHECK(cudaMemcpyAsync(resources->devFifo + buffSlot * stepSize, resources->shmFifo + buffSlot * stepSize,
+                                    size, cudaMemcpyHostToDevice, resources->stream));
           CUDACHECK(cudaEventRecord(resources->events[buffSlot], resources->stream));
           sub->transmitted += args->sliceSteps;
         }
       }
       if (sub->done < sub->transmitted) {
-        int buffSlot = (sub->base+sub->done)%NCCL_STEPS;
+        int buffSlot = (sub->base + sub->done) % NCCL_STEPS;
         cudaError_t res = CUDACLEARERROR(cudaEventQuery(resources->events[buffSlot]));
         if (res != cudaErrorNotReady) CUDACHECK(res);
         if (res == cudaSuccess) {
@@ -458,7 +477,8 @@ static ncclResult_t shmRecvProxyProgress(struct ncclProxyState* proxyState, stru
   return ncclSuccess;
 }
 
-static ncclResult_t shmSendProxySetup(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
+static ncclResult_t shmSendProxySetup(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState,
+                                      void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
   ncclResult_t result = ncclSuccess;
   struct shmRequest* req = (struct shmRequest*)reqBuff;
   /* check message size */
@@ -469,7 +489,9 @@ static ncclResult_t shmSendProxySetup(struct ncclProxyConnection* connection, st
   struct shmProxyInfo* proxyInfo;
 
   NCCLCHECK(ncclCalloc(&proxyInfo, 1));
-  NCCLCHECKGOTO(ncclShmAllocateShareableBuffer(req->size, req->legacy, &proxyInfo->desc, &info->buf.hptr, &info->buf.dptr), result, fail);
+  NCCLCHECKGOTO(ncclShmAllocateShareableBuffer(req->size, req->legacy, &proxyInfo->desc, &info->buf.hptr,
+                                               &info->buf.dptr),
+                result, fail);
   memcpy(&info->desc, &proxyInfo->desc, sizeof(ncclShmIpcDesc_t));
   connection->transportResources = proxyInfo;
 exit:
@@ -479,7 +501,8 @@ fail:
   goto exit;
 }
 
-static ncclResult_t shmRecvProxySetup(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState, void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
+static ncclResult_t shmRecvProxySetup(struct ncclProxyConnection* connection, struct ncclProxyState* proxyState,
+                                      void* reqBuff, int reqSize, void* respBuff, int respSize, int* done) {
   ncclResult_t result = ncclSuccess;
   struct shmRequest* req = (struct shmRequest*)reqBuff;
   /* check message size */
@@ -490,7 +513,9 @@ static ncclResult_t shmRecvProxySetup(struct ncclProxyConnection* connection, st
   struct shmProxyInfo* proxyInfo;
 
   NCCLCHECK(ncclCalloc(&proxyInfo, 1));
-  NCCLCHECKGOTO(ncclShmAllocateShareableBuffer(req->size, req->legacy, &proxyInfo->desc, &info->buf.hptr, &info->buf.dptr), result, fail);
+  NCCLCHECKGOTO(ncclShmAllocateShareableBuffer(req->size, req->legacy, &proxyInfo->desc, &info->buf.hptr,
+                                               &info->buf.dptr),
+                result, fail);
   memcpy(&info->desc, &proxyInfo->desc, sizeof(ncclShmIpcDesc_t));
   connection->transportResources = proxyInfo;
 exit:
@@ -522,7 +547,8 @@ static void initCeOperation() {
   }
 }
 
-ncclResult_t ncclShmAllocateShareableBuffer(size_t size, bool legacy, ncclShmIpcDesc_t *desc, void **hptr, void **dptr) {
+ncclResult_t ncclShmAllocateShareableBuffer(size_t size, bool legacy, ncclShmIpcDesc_t* desc, void** hptr,
+                                            void** dptr) {
   if (desc == NULL || hptr == NULL) {
     WARN("Invalid argument desc %p, hptr %p", desc, hptr);
     return ncclInvalidArgument;
@@ -546,7 +572,7 @@ ncclResult_t ncclShmAllocateShareableBuffer(size_t size, bool legacy, ncclShmIpc
     desc->legacy = false;
     INFO(NCCL_SHM, "CUMEM allocated shareable buffer %p size %zi", desc->shmci.ptr, desc->shmci.size);
   } else {
-    char shmPath[SHM_PATH_MAX] = { '\0' };
+    char shmPath[SHM_PATH_MAX] = {'\0'};
     desc->shmli.shmSize = size;
     NCCLCHECK(ncclShmOpen(shmPath, sizeof(shmPath), size, hptr, dptr, 1, &desc->shmli.handle));
 #if defined(NCCL_OS_LINUX)
@@ -559,7 +585,7 @@ ncclResult_t ncclShmAllocateShareableBuffer(size_t size, bool legacy, ncclShmIpc
     INFO(NCCL_SHM, "MMAP allocated shareable host buffer %s size %zi ptr %p", shmPath, desc->shmli.shmSize, *hptr);
   }
 #else /* CUDART_VERSION >= 12020 */
-  char shmPath[SHM_PATH_MAX] = { '\0' };
+  char shmPath[SHM_PATH_MAX] = {'\0'};
   desc->shmli.shmSize = size;
   NCCLCHECK(ncclShmOpen(shmPath, sizeof(shmPath), size, hptr, dptr, 1, &desc->shmli.handle));
 #if defined(NCCL_OS_LINUX)
@@ -574,7 +600,8 @@ ncclResult_t ncclShmAllocateShareableBuffer(size_t size, bool legacy, ncclShmIpc
   return ncclSuccess;
 }
 
-ncclResult_t ncclShmImportShareableBuffer(struct ncclComm *comm, int proxyRank, ncclShmIpcDesc_t *desc, void **hptr, void **dptr, ncclShmIpcDesc_t *descOut) {
+ncclResult_t ncclShmImportShareableBuffer(struct ncclComm* comm, int proxyRank, ncclShmIpcDesc_t* desc, void** hptr,
+                                          void** dptr, ncclShmIpcDesc_t* descOut) {
   if (comm == NULL || desc == NULL || hptr == NULL || descOut == NULL) {
     WARN("Invalid argument comm %p, desc %p, hptr %p, descOut %p", comm, desc, hptr, descOut);
     return ncclInvalidArgument;
@@ -599,8 +626,8 @@ ncclResult_t ncclShmImportShareableBuffer(struct ncclComm *comm, int proxyRank, 
       int fd = -1;
       // Send cuMem handle to remote for conversion to an fd
       NCCLCHECK(ncclProxyClientGetFdBlocking(comm, proxyRank, &desc->shmci.data, &fd));
-      CUCHECK(cuMemImportFromShareableHandle(&handle, (void *)(uintptr_t)fd, type));
-      (void) close(fd);
+      CUCHECK(cuMemImportFromShareableHandle(&handle, (void*)(uintptr_t)fd, type));
+      (void)close(fd);
     } else {
       CUCHECK(cuMemImportFromShareableHandle(&handle, &desc->shmci.handle, type));
     }
@@ -636,10 +663,11 @@ ncclResult_t ncclShmImportShareableBuffer(struct ncclComm *comm, int proxyRank, 
     accessDesc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
     CUCHECK(cuMemSetAccess(hostptr, size, &accessDesc, 1));
 
-    descOut->shmci.ptr = *hptr = (void *)hostptr;
+    descOut->shmci.ptr = *hptr = (void*)hostptr;
     descOut->legacy = false;
-    if (dptr) *dptr = (void *)hostptr;
-    INFO(NCCL_SHM, "CUMEM imported shareable host buffer from proxyRank %d size %zi ptr %p, granularity %ld", proxyRank, desc->shmci.size, descOut->shmci.ptr, granularity);
+    if (dptr) *dptr = (void*)hostptr;
+    INFO(NCCL_SHM, "CUMEM imported shareable host buffer from proxyRank %d size %zi ptr %p, granularity %ld", proxyRank,
+         desc->shmci.size, descOut->shmci.ptr, granularity);
   } else {
     char shmPath[SHM_PATH_MAX];
 #if defined(NCCL_OS_LINUX)
@@ -665,7 +693,7 @@ ncclResult_t ncclShmImportShareableBuffer(struct ncclComm *comm, int proxyRank, 
   return ncclSuccess;
 }
 
-ncclResult_t ncclShmIpcClose(ncclShmIpcDesc_t *desc) {
+ncclResult_t ncclShmIpcClose(ncclShmIpcDesc_t* desc) {
   if (desc) {
 #if CUDART_VERSION >= 12020
     if (ncclCuMemEnable() && ncclCuMemHostEnable() && !desc->legacy) {
@@ -684,6 +712,6 @@ ncclResult_t ncclShmIpcClose(ncclShmIpcDesc_t *desc) {
 struct ncclTransport shmTransport = {
   "SHM",
   shmCanConnect,
-  { shmSendSetup, shmSendConnect, shmSendFree, NULL, shmSendProxySetup, NULL, shmSendProxyFree, NULL },
-  { shmRecvSetup, shmRecvConnect, shmRecvFree, NULL, shmRecvProxySetup, NULL, shmRecvProxyFree, NULL }
+  {shmSendSetup, shmSendConnect, shmSendFree, NULL, shmSendProxySetup, NULL, shmSendProxyFree, NULL},
+  {shmRecvSetup, shmRecvConnect, shmRecvFree, NULL, shmRecvProxySetup, NULL, shmRecvProxyFree, NULL}
 };

--- a/projects/rccl/test/RegisterTests.cpp
+++ b/projects/rccl/test/RegisterTests.cpp
@@ -1,13 +1,21 @@
 /*************************************************************************
- * Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
  *
  * See LICENSE.txt for license information
  ************************************************************************/
 
 #include <gtest/gtest.h>
 #include <rccl/rccl.h>
+#include <atomic>
+#include <new>
 #include <cstdlib>
 #include <cstdio>
+#include <cstring>
+#include <vector>
+
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 #include "common/ErrCode.hpp"
 #include "common/ProcessIsolatedTestRunner.hpp"
@@ -21,6 +29,42 @@ static bool hasGpuAvailable() {
     int numDevices = 0;
     hipError_t err = hipGetDeviceCount(&numDevices);
     return (err == hipSuccess && numDevices >= 1);
+}
+
+// The GH#1859 user-buffer IPC registration path that this test exercises only
+// behaves as intended on the CDNA datacenter GPUs (gfx942 / gfx950 families).
+// On other architectures (e.g. the RDNA gfx11xx consumer parts) the IPC /
+// collective registration machinery differs and the test cannot meaningfully
+// reproduce the defect, so we skip rather than report a misleading pass/fail.
+static bool isArchSupportedForP2pCollTest(const char* gcnArchName) {
+    // gcnArchName looks like "gfx942:sramecc+:xnack-"; compare the gfxNNN prefix.
+    static const char* kSupportedArchs[] = {"gfx942", "gfx950"};
+    for (const char* arch : kSupportedArchs) {
+        if (strncmp(gcnArchName, arch, strlen(arch)) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Queries every visible device and returns true only if all of them are a
+// supported architecture for the P2P+collective registration test.
+static bool allDevicesSupportP2pCollTest(int numDevices, char* unsupportedArchOut,
+                                         size_t outLen) {
+    for (int dev = 0; dev < numDevices; dev++) {
+        hipDeviceProp_t prop;
+        if (hipGetDeviceProperties(&prop, dev) != hipSuccess) {
+            return false;
+        }
+        if (!isArchSupportedForP2pCollTest(prop.gcnArchName)) {
+            if (unsupportedArchOut && outLen > 0) {
+                strncpy(unsupportedArchOut, prop.gcnArchName, outLen - 1);
+                unsupportedArchOut[outLen - 1] = '\0';
+            }
+            return false;
+        }
+    }
+    return true;
 }
 
 // Macro to skip test if no GPU is available
@@ -173,6 +217,312 @@ static void testVariableSizeBuffers(bool expectNonNull) {
 }
 
 /**
+ * @brief Regression test for NCCL GH#1859 / v2.29.2-1 fix:
+ *        "Fixes crash that can happen when calling p2p and then collectives
+ *         while using the same user buffer."
+ *
+ * Root cause: in p2p.cc the NCCL_IPC_COLLECTIVE branch allocates
+ * devPeerRmtAddrs but only copies hostPeerRmtAddrs → devPeerRmtAddrs when
+ * needUpdate==true.  If P2P ran first on the same regRecord, needUpdate is
+ * already false by the time the collective resolves addresses, so
+ * devPeerRmtAddrs is left zeroed and the GPU kernel dereferences a null
+ * remote pointer → illegal memory access / crash.
+ *
+ * Sequence that triggers the bug (requires ≥ 2 intra-node GPUs), run with
+ * one forked process per rank (see below):
+ *   1. ncclCommInitRank in each rank's own process (one GPU per rank), using
+ *      a shared ncclUniqueId.
+ *   2. ncclCommRegister the same device buffer on each rank
+ *      (NCCL_LOCAL_REGISTER=1 ensures real IPC registration).
+ *   3. ncclSend / ncclRecv group call on the registered buffer → sync.
+ *      (populates hostPeerRmtAddrs; leaves devPeerRmtAddrs NULL for the
+ *       collective branch because only the P2P branch ran.)
+ *   4. ncclAllReduce group call on the same registered buffer → sync.
+ *      (buggy: allocates devPeerRmtAddrs, skips memcpy, crashes;
+ *       fixed:  allocates devPeerRmtAddrs and always copies on first alloc.)
+ *   5. Verify ncclSuccess and correct AllReduce output.
+ *
+ * Skipped when fewer than 2 GPUs are visible (intra-node IPC path requires
+ * at least 2 ranks on the same node) or when the two GPUs cannot do direct
+ * GPU-to-GPU P2P.  The GH#1859 fix lives in ipcRegisterBuffer, which is only
+ * reached when the collective takes the direct-P2P/IPC transport.  On systems
+ * where the GPUs are not P2P-capable (e.g. PCIE-only consumer cards) RCCL
+ * falls back to the SHM transport, ipcRegisterBuffer is never called, and the
+ * test would pass without exercising the fixed code path at all.
+ *
+ * --- Why fork() + ncclCommInitRank instead of ncclCommInitAll ---
+ *
+ * comm->directMode is set true by ncclTransportCheckP2pType whenever any two
+ * local ranks share the same pid.  ipcRegisterBuffer's legacy IPC path then
+ * hits:
+ *     if (comm->directMode || !ncclParamLegacyCudaRegister()) goto fail;
+ * and bypasses the fixed code path entirely.  ncclCommInitAll runs all ranks
+ * in one process, so directMode is always true and the GH#1859 fix is never
+ * exercised.  We therefore fork() one child process per rank and use
+ * ncclCommInitRank with a shared ncclUniqueId; each rank is its own process,
+ * directMode stays false, and ipcRegisterBuffer is reachable.
+ *
+ * The ProcessIsolatedTestRunner re-execs each test into its own process but
+ * cannot split a single test across one-process-per-rank, so the fork() is
+ * done here inside the test body.
+ */
+
+// Shared-memory bootstrap written by rank-0's child before the others proceed.
+namespace {
+// Bootstrap state published by rank 0's child to the other ranks.
+enum class P2pCollState : int {
+    NotReady = 0,  // rank 0 has not yet published the unique ID
+    Ready    = 1,  // unique ID is valid and ready to be read
+    Skip     = -1, // rank 0 hit a skip/fatal precondition; others should skip
+};
+
+struct P2pCollShared {
+    ncclUniqueId id;
+    std::atomic<P2pCollState> state;
+};
+
+// Child-process error handling: print and return a non-zero code rather than
+// using GTest assertions (which do not propagate across fork()).
+#define CHILD_HC(x)                                                          \
+    do {                                                                     \
+        hipError_t _e = (x);                                                 \
+        if (_e != hipSuccess) {                                              \
+            printf("[rank %d] HIP error %d (%s) @ %s:%d\n", rank, _e,        \
+                   hipGetErrorString(_e), __FILE__, __LINE__);               \
+            return 1;                                                        \
+        }                                                                    \
+    } while (0)
+
+#define CHILD_NC(x)                                                          \
+    do {                                                                     \
+        ncclResult_t _e = (x);                                               \
+        if (_e != ncclSuccess) {                                             \
+            printf("[rank %d] NCCL error %d (%s) @ %s:%d\n", rank, _e,       \
+                   ncclGetErrorString(_e), __FILE__, __LINE__);              \
+            return 1;                                                        \
+        }                                                                    \
+    } while (0)
+
+// Child exit codes communicated back to the parent test body.
+enum P2pCollChildExit {
+    CHILD_OK   = 0,  // ran the full sequence, result correct
+    CHILD_FAIL = 1,  // a HIP/NCCL error or a wrong AllReduce result
+    CHILD_SKIP = 2,  // preconditions not met (too few GPUs / no direct P2P)
+};
+
+// Runs entirely inside a forked child process — first HIP/NCCL call is here.
+static int p2pCollRunRank(int rank, int nranks, P2pCollShared* shared)
+{
+    // Must exceed nChannels * NCCL_P2P_LL_THRESHOLD (default 8192 bytes) so
+    // that addP2pToPlan selects NCCL_PROTO_SIMPLE. Only with SIMPLE does it
+    // enter the ncclRegisterP2pIpcBuffer branch that leads to ipcRegisterBuffer
+    // (lines 1188-1222, where the GH#1859 fix lives). 16k floats = 65536 bytes
+    // is above the threshold for any plausible channel count.
+    const size_t numElements = 16 * 1024;                  // 64 KB of float
+    const size_t bufBytes    = numElements * sizeof(float);
+
+    if (rank == 0) {
+        int numDevices = 0;
+        CHILD_HC(hipGetDeviceCount(&numDevices));
+        if (numDevices < nranks) {
+            printf("Requires %d GPUs (detected %d).\n", nranks, numDevices);
+            shared->state.store(P2pCollState::Skip, std::memory_order_release);
+            return CHILD_SKIP;
+        }
+
+        // The GH#1859 defect only reproduces on the CDNA datacenter GPUs
+        // (gfx942 / gfx950).  On other architectures (e.g. RDNA gfx11xx) the
+        // registration path differs and the test is meaningless, so skip.
+        char unsupportedArch[256] = {0};
+        if (!allDevicesSupportP2pCollTest(nranks, unsupportedArch, sizeof(unsupportedArch))) {
+            printf("Unsupported GPU architecture '%s' for the P2P+collective "
+                   "user-buffer registration test (requires gfx942 or gfx950).\n",
+                   unsupportedArch);
+            shared->state.store(P2pCollState::Skip, std::memory_order_release);
+            return CHILD_SKIP;
+        }
+
+        // The IPC registration path is only reached with direct GPU-to-GPU P2P;
+        // without it RCCL falls back to SHM and ipcRegisterBuffer is never
+        // exercised, so skip rather than report a misleading pass.
+        int canAccess01 = 0, canAccess10 = 0;
+        CHILD_HC(hipDeviceCanAccessPeer(&canAccess01, 0, 1));
+        CHILD_HC(hipDeviceCanAccessPeer(&canAccess10, 1, 0));
+        if (!canAccess01 || !canAccess10) {
+            printf("No direct P2P (canAccessPeer 0->1=%d 1->0=%d): SHM transport "
+                   "would be used, ipcRegisterBuffer NOT exercised.\n",
+                   canAccess01, canAccess10);
+            shared->state.store(P2pCollState::Skip, std::memory_order_release);
+            return CHILD_SKIP;
+        }
+
+        // Generate the unique ID and publish it to the other children.  The
+        // release store ensures the id write above is visible before the flag.
+        CHILD_NC(ncclGetUniqueId(&shared->id));
+        shared->state.store(P2pCollState::Ready, std::memory_order_release);
+    } else {
+        // Wait for rank 0 to publish the ID (or signal skip/error).  The
+        // acquire load pairs with rank 0's release store so that, once we
+        // observe a non-NotReady state, the id write is visible to us.
+        P2pCollState st;
+        while ((st = shared->state.load(std::memory_order_acquire)) ==
+               P2pCollState::NotReady) { /* spin */ }
+        if (st == P2pCollState::Skip) return CHILD_SKIP;  // rank 0 reported skip/error
+    }
+
+    ncclUniqueId id = shared->id;
+
+    CHILD_HC(hipSetDevice(rank));
+
+    ncclComm_t comm;
+    CHILD_NC(ncclCommInitRank(&comm, nranks, id, rank));
+
+    hipStream_t stream;
+    CHILD_HC(hipStreamCreate(&stream));
+
+    // Input buffer filled with rank+1; separate out-of-place output buffer.
+    void *devBuf = nullptr, *devOut = nullptr;
+    CHILD_HC(hipMalloc(&devBuf, bufBytes));
+    CHILD_HC(hipMalloc(&devOut, bufBytes));
+    std::vector<float> hostIn(numElements, static_cast<float>(rank + 1));
+    CHILD_HC(hipMemcpy(devBuf, hostIn.data(), bufBytes, hipMemcpyHostToDevice));
+    CHILD_HC(hipMemset(devOut, 0, bufBytes));
+
+    // Register the input buffer — used for both the P2P and the AllReduce.
+    void* regHandle = nullptr;
+    CHILD_NC(ncclCommRegister(comm, devBuf, bufBytes, &regHandle));
+    if (regHandle == nullptr) {
+        printf("[rank %d] ncclCommRegister returned NULL handle "
+               "(is NCCL_LOCAL_REGISTER=1 set?).\n", rank);
+        return CHILD_FAIL;
+    }
+
+    // Also register the AllReduce *output* buffer.  ncclRegisterCollBuffers
+    // calls ncclRegFind on the recvbuff for RING/TREE and bails out via
+    // `goto exit` (skipping the NCCL_IPC_COLLECTIVE ipcRegisterBuffer path)
+    // if it is not registered — which would mean the bug is never exercised.
+    void* regHandleOut = nullptr;
+    CHILD_NC(ncclCommRegister(comm, devOut, bufBytes, &regHandleOut));
+    if (regHandleOut == nullptr) {
+        printf("[rank %d] ncclCommRegister (output) returned NULL handle "
+               "(is NCCL_LOCAL_REGISTER=1 set?).\n", rank);
+        return CHILD_FAIL;
+    }
+
+    // --- Step 1: P2P send/recv on the registered buffer ---
+    // Rank 0 sends devBuf -> rank 1; rank 1 receives into its devBuf.  This
+    // populates regRecord->regIpcAddrs.hostPeerRmtAddrs for the P2P path but
+    // leaves the NCCL_IPC_COLLECTIVE devPeerRmtAddrs uninitialised.
+    CHILD_NC(ncclGroupStart());
+    if (rank == 0) CHILD_NC(ncclSend(devBuf, numElements, ncclFloat, 1, comm, stream));
+    if (rank == 1) CHILD_NC(ncclRecv(devBuf, numElements, ncclFloat, 0, comm, stream));
+    CHILD_NC(ncclGroupEnd());
+    CHILD_HC(hipStreamSynchronize(stream));
+
+    // --- Step 2: AllReduce on the *same* registered buffer (bug trigger) ---
+    // The collective registers its *recvbuff* for NCCL_IPC_COLLECTIVE.  By using
+    // devBuf (already IPC-registered during the P2P) as the recvbuff, the
+    // collective hits the *reuse* branch in ipcRegisterBuffer, which leaves
+    // needUpdate=false and therefore skips the devPeerRmtAddrs memcpy.  Without
+    // the fix this crashes with an illegal memory access because devPeerRmtAddrs
+    // is allocated but never populated.  RING in-place AllReduce
+    // (sendbuff==recvbuff) is skipped by the registration path, so this must be
+    // out-of-place: seed devOut from devBuf and reduce devOut -> devBuf.
+    CHILD_HC(hipMemcpy(devOut, devBuf, bufBytes, hipMemcpyDeviceToDevice));
+    CHILD_NC(ncclGroupStart());
+    CHILD_NC(ncclAllReduce(devOut, devBuf, numElements, ncclFloat, ncclSum, comm, stream));
+    CHILD_NC(ncclGroupEnd());
+    CHILD_HC(hipStreamSynchronize(stream));
+
+    // --- Verify AllReduce result ---
+    // After the P2P both ranks hold 1.0f in devBuf (rank 0 kept its own value,
+    // rank 1 received 1.0f from rank 0), so the sum is numRanks per element.
+    const float expectedSum = static_cast<float>(nranks);
+    std::vector<float> hostOut(numElements, -1.0f);
+    CHILD_HC(hipMemcpy(hostOut.data(), devBuf, bufBytes, hipMemcpyDeviceToHost));
+    int rc = CHILD_OK;
+    for (size_t i = 0; i < numElements; i++) {
+        if (hostOut[i] != expectedSum) {
+            printf("[rank %d] MISMATCH elem %zu: expected %f got %f\n",
+                   rank, i, expectedSum, hostOut[i]);
+            rc = CHILD_FAIL;
+            break;
+        }
+    }
+
+    CHILD_NC(ncclCommDeregister(comm, regHandle));
+    CHILD_NC(ncclCommDeregister(comm, regHandleOut));
+    CHILD_HC(hipFree(devBuf));
+    CHILD_HC(hipFree(devOut));
+    CHILD_HC(hipStreamDestroy(stream));
+    CHILD_NC(ncclCommDestroy(comm));
+
+    return rc;
+}
+} // namespace
+
+static void testP2pThenCollectiveSameBuffer()
+{
+    const int numRanks = 2;
+
+    // Set up shared memory BEFORE fork and BEFORE any HIP/NCCL call.  The
+    // HIP/HSA runtime is not fork-safe, so the parent does no HIP/NCCL work at
+    // all — rank-0's child generates the ncclUniqueId here and signals the
+    // others through this MAP_SHARED region.
+    P2pCollShared* shared = static_cast<P2pCollShared*>(mmap(
+        nullptr, sizeof(P2pCollShared),
+        PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0));
+    ASSERT_NE(shared, MAP_FAILED) << "mmap for shared bootstrap failed";
+    // Construct the atomic in place in the shared region before forking so all
+    // children operate on the same object.  MAP_ANONYMOUS zeroes the page, but
+    // the atomic is initialised explicitly for clarity and correctness.
+    new (&shared->state) std::atomic<P2pCollState>(P2pCollState::NotReady);
+
+    std::vector<pid_t> pids(numRanks, -1);
+    for (int r = 0; r < numRanks; r++) {
+        pids[r] = fork();
+        ASSERT_GE(pids[r], 0) << "fork() failed for rank " << r;
+        if (pids[r] == 0) {
+            // Child: first HIP/NCCL calls happen here, on a clean runtime.
+            int rc = p2pCollRunRank(r, numRanks, shared);
+            _exit(rc);
+        }
+    }
+
+    // Parent: reap children and translate their exit codes into the GTest
+    // result.  No HIP/NCCL calls here.
+    bool anySkip = false;
+    bool anyFail = false;
+    for (int r = 0; r < numRanks; r++) {
+        int status = 0;
+        waitpid(pids[r], &status, 0);
+        if (WIFEXITED(status)) {
+            int code = WEXITSTATUS(status);
+            if (code == CHILD_SKIP) {
+                anySkip = true;
+            } else if (code != CHILD_OK) {
+                anyFail = true;
+                ADD_FAILURE() << "Rank " << r << " child exited with failure code "
+                              << code << ".";
+            }
+        } else {
+            anyFail = true;
+            ADD_FAILURE() << "Rank " << r << " child terminated abnormally "
+                          << "(status " << status << ") — likely the GH#1859 "
+                          << "crash (illegal memory access in the collective).";
+        }
+    }
+
+    munmap(shared, sizeof(P2pCollShared));
+
+    if (anySkip && !anyFail) {
+        GTEST_SKIP() << "Test requires " << numRanks << " supported GPUs "
+                        "(gfx942 / gfx950) with direct GPU-to-GPU P2P access; "
+                        "preconditions not met.";
+    }
+}
+
+/**
  * @brief Test deregistering NULL handle (should succeed as no-op)
  */
 static void testDeregisterNullHandle() {
@@ -280,6 +630,18 @@ TEST(Register, ProcessIsolatedRegisterTests)
 
         // DeregisterNullHandle test (no enable/disable variants needed)
         ProcessIsolatedTestRunner::TestConfig("DeregisterNullHandle", testDeregisterNullHandle),
+
+        // Regression test: NCCL GH#1859 — p2p followed by collective on the same
+        // registered user buffer must not crash (requires ≥ 2 GPUs).
+        ProcessIsolatedTestRunner::TestConfig(
+            "P2pThenCollective_SameBuffer", testP2pThenCollectiveSameBuffer)
+            .withEnvironment({{"NCCL_LOCAL_REGISTER", "1"},
+                              {"NCCL_P2P_LL_THRESHOLD", "0"},
+                              {"NCCL_LEGACY_CUDA_REGISTER", "1"},
+                              {"NCCL_DEBUG", "INFO"},
+                              {"NCCL_DEBUG_SUBSYS", "REG,P2P"}})
+            .withNumGpus(2)
+            .withTimeout(std::chrono::seconds(120)),
 
         // Force the non-sym path (NCCL_CUMEM_ENABLE=0 => symmetricSupport=false) so the
         // non-symmetric register/teardown is exercised; NCCL_LOCAL_REGISTER=1 ensures the register path runs.


### PR DESCRIPTION
Adopt NCCL's clang-format configuration and tooling in RCCL and reformat
the src/ tree to match, in preparation for upcoming NCCL syncs (reduces
formatting-only merge conflicts).

Changes:
- Add the NCCL clang-format config and associated tooling.
- Reformat src/ with clang-format to match NCCL style.
- Add the reformat commit to .git-blame-ignore-revs so blame skips it.
- Fix cmake/scripts/add_unroll.sh: the reformat changed device template
  declarations from `template<typename ...>` to `template <typename ...>`.
  Two perl substitutions in the script matched only the no-space form and
  silently stopped injecting the RCCL-only USE_ACC/COLL_UNROLL/Pipeline
  template parameters into the primary templates, while the trailing sed
  rules still appended them to the partial specializations — producing
  specializations that referenced undeclared identifiers and broke the
  device build. The regexes now accept either spacing (`template\s*<`).

Testing:
- `./install.sh -l -t --no_clean` builds cleanly (librccl.so + rccl-UnitTests).

JIRA ID : AICOMRCCL-1472