### PR TITLE
AIRUNTIME-2396 - Update ext-dispatch vendor packet to fix device enqueue

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -4513,8 +4513,11 @@ bool VirtualGPU::submitKernelInternal(const amd::NDRangeContainer& sizes, const 
                               (1 << HSA_PACKET_HEADER_BARRIER) |
                               (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_ACQUIRE_FENCE_SCOPE) |
                               (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_RELEASE_FENCE_SCOPE);
-        aql_packet->setup = static_cast<uint8_t>(sizes.dimensions()
-                              << HSA_KERNEL_DISPATCH_PACKET_SETUP_DIMENSIONS);
+        // For an ext-dispatch vendor packet byte+2 is amd_format, not setup; set
+        // amd_format=EXT_KERNEL_DISPATCH and shift setup (dimensions) into byte+3.
+        aql_packet->setup = static_cast<uint16_t>(HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH
+                              | ((sizes.dimensions()
+                                  << HSA_KERNEL_DISPATCH_PACKET_SETUP_DIMENSIONS) << 8));
       } else {
         aql_packet->header = (HSA_PACKET_TYPE_KERNEL_DISPATCH << HSA_PACKET_HEADER_TYPE) |
                               (1 << HSA_PACKET_HEADER_BARRIER) |


### PR DESCRIPTION
## Motivation

### Root cause

1. OpenCL device-side enqueue tests (OCLDynamic, OCLDynamicBLines, CTS progvar_prog_scope_init) crashed with an access violation while processing AQL packet.
2. the device-enqueue scheduler's self-relaunch packet (scheduler_aql) was built with header type  
  VENDOR_SPECIFIC and setup=dimensions written into byte+2 — the byte the AMD vendor ABI reserves for           
  amd_format. 
3. setup=1 collided with AMD_AQL_FORMAT_PM4_IB (=1), so the model decoded the dispatch packet as a PM4 indirect
   buffer, computed a bogus ib_address=0x400000001, and dereferenced unmapped memory.

### Fix
1. In rocvirtual.cpp (scheduler relaunch-packet copy path), set amd_format =
  HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH (3) in byte+2 and shift setup (dimensions) into byte+3.
2. Verified: ocltst OCLDynamic/OCLDynamicBLines pass, CTS progvar_prog_scope_init recovered (+1), zero
  regressions across both suites.
## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
