### PR TITLE
[rocprofiler-compute] Fix Python 3.8 incompatible with-statement syntax

### DIFF
--- a/projects/rocprofiler-compute/src/utils/analysis_orm.py
+++ b/projects/rocprofiler-compute/src/utils/analysis_orm.py
@@ -277,11 +277,9 @@ class Database:
         try:
             # Writing to disk is slow, so we built the database in memory.
             # Now copy the finished database to disk in one step.
-            with (
-                closing(cls._engine.raw_connection()) as memory_conn,
-                closing(sqlite3.connect(cls._db_name)) as disk_conn,
-            ):
-                memory_conn.backup(disk_conn)
+            with closing(cls._engine.raw_connection()) as memory_conn:
+                with closing(sqlite3.connect(cls._db_name)) as disk_conn:
+                    memory_conn.backup(disk_conn)
             console_debug("Completed writing database")
             console_warning(f"Created file: {cls._db_name}")
         except Exception as e:

--- a/projects/rocprofiler-compute/tests/test_analysis_db.py
+++ b/projects/rocprofiler-compute/tests/test_analysis_db.py
@@ -228,19 +228,19 @@ def test_evaluate_divide_by_zero_silenced_and_logged_at_debug():
     ]
 
     for expr in cases:
-        with (
-            patch(
-                "rocprof_compute_analyze.analysis_db.console_warning"
-            ) as mock_warning,
-            patch("rocprof_compute_analyze.analysis_db.console_debug") as mock_debug,
-        ):
-            result = db_analysis.evaluate(
-                "test_metric",
-                expr,
-                pmc_df,
-                sys_info,
-                parse=False,
-            )
+        with patch(
+            "rocprof_compute_analyze.analysis_db.console_warning"
+        ) as mock_warning:
+            with patch(
+                "rocprof_compute_analyze.analysis_db.console_debug"
+            ) as mock_debug:
+                result = db_analysis.evaluate(
+                    "test_metric",
+                    expr,
+                    pmc_df,
+                    sys_info,
+                    parse=False,
+                )
 
         assert result is None, f"Expected None for '{expr}', got {result}"
 
@@ -275,23 +275,21 @@ def test_calc_builtin_vars_processes_per_xcd_first():
         "DERIVED_VAR": "$PER_XCD_VAR + 5",  # Depends on PER_XCD_VAR -> 25
     }
 
-    with (
-        patch(
-            "rocprof_compute_analyze.analysis_db.mi_gpu_specs.get_gpu_series",
-            return_value="MI300",
-        ),
-        patch(
+    with patch(
+        "rocprof_compute_analyze.analysis_db.mi_gpu_specs.get_gpu_series",
+        return_value="MI300",
+    ):
+        with patch(
             "rocprof_compute_analyze.analysis_db.get_build_in_vars",
             return_value=mock_builtin_vars,
-        ),
-        patch(
-            "utils.utils_counter_defs.get_build_in_vars",
-            return_value=mock_builtin_vars,
-        ),
-    ):
-        db_analysis.calc_builtin_vars(
-            pmc_df, sys_info, ["$PER_XCD_VAR", "$DERIVED_VAR"]
-        )
+        ):
+            with patch(
+                "utils.utils_counter_defs.get_build_in_vars",
+                return_value=mock_builtin_vars,
+            ):
+                db_analysis.calc_builtin_vars(
+                    pmc_df, sys_info, ["$PER_XCD_VAR", "$DERIVED_VAR"]
+                )
 
     # Verify PER_XCD var was computed
     assert sys_info["PER_XCD_VAR"] == 20
@@ -313,23 +311,21 @@ def test_calc_builtin_vars_with_dataframe_expressions():
         "SCALED_TOTAL": "$TOTAL_COUNT * $multiplier",  # 120
     }
 
-    with (
-        patch(
-            "rocprof_compute_analyze.analysis_db.mi_gpu_specs.get_gpu_series",
-            return_value="MI300",
-        ),
-        patch(
+    with patch(
+        "rocprof_compute_analyze.analysis_db.mi_gpu_specs.get_gpu_series",
+        return_value="MI300",
+    ):
+        with patch(
             "rocprof_compute_analyze.analysis_db.get_build_in_vars",
             return_value=mock_builtin_vars,
-        ),
-        patch(
-            "utils.utils_counter_defs.get_build_in_vars",
-            return_value=mock_builtin_vars,
-        ),
-    ):
-        db_analysis.calc_builtin_vars(
-            pmc_df, sys_info, ["$TOTAL_COUNT", "$SCALED_TOTAL"]
-        )
+        ):
+            with patch(
+                "utils.utils_counter_defs.get_build_in_vars",
+                return_value=mock_builtin_vars,
+            ):
+                db_analysis.calc_builtin_vars(
+                    pmc_df, sys_info, ["$TOTAL_COUNT", "$SCALED_TOTAL"]
+                )
 
     assert sys_info["TOTAL_COUNT"] == 60
     assert sys_info["SCALED_TOTAL"] == 120
@@ -387,21 +383,21 @@ def test_calc_dataframe_expressions_with_builtin_vars():
         ],
     })
 
-    with (
-        patch(
-            "rocprof_compute_analyze.analysis_db.mi_gpu_specs.get_gpu_series",
-            return_value="MI300",
-        ),
-        patch(
+    with patch(
+        "rocprof_compute_analyze.analysis_db.mi_gpu_specs.get_gpu_series",
+        return_value="MI300",
+    ):
+        with patch(
             "rocprof_compute_analyze.analysis_db.get_build_in_vars",
             return_value=mock_builtin_vars,
-        ),
-        patch(
-            "utils.utils_counter_defs.get_build_in_vars",
-            return_value=mock_builtin_vars,
-        ),
-    ):
-        result = db_analysis.calc_dataframe_expressions(pmc_df, sys_info, expression_df)
+        ):
+            with patch(
+                "utils.utils_counter_defs.get_build_in_vars",
+                return_value=mock_builtin_vars,
+            ):
+                result = db_analysis.calc_dataframe_expressions(
+                    pmc_df, sys_info, expression_df
+                )
 
     assert result.iloc[0] == 51
     # None from evaluate becomes NaN in pandas Series
@@ -569,17 +565,17 @@ def test_calc_expressions_noise_clamp():
 
     # calc_expressions per-workload bracket.
     clear_noise_clamp_warnings()
-    with (
-        patch("rocprof_compute_analyze.analysis_db.get_build_in_vars", return_value={}),
-        patch(
-            "rocprof_compute_analyze.analysis_db.console_warning"
-        ) as console_warning_mock,
-        patch(
-            "rocprof_compute_analyze.analysis_db.print_noise_clamp_summary"
-        ) as print_noise_clamp_summary_mock,
-        patch.object(db_analysis, "validate_dual_issue_metrics"),
+    with patch(
+        "rocprof_compute_analyze.analysis_db.get_build_in_vars", return_value={}
     ):
-        analyzer.calc_expressions()
+        with patch(
+            "rocprof_compute_analyze.analysis_db.console_warning"
+        ) as console_warning_mock:
+            with patch(
+                "rocprof_compute_analyze.analysis_db.print_noise_clamp_summary"
+            ) as print_noise_clamp_summary_mock:
+                with patch.object(db_analysis, "validate_dual_issue_metrics"):
+                    analyzer.calc_expressions()
 
     variance_warning_calls = [
         warning_call

--- a/projects/rocprofiler-compute/tests/test_native_tool_finder.py
+++ b/projects/rocprofiler-compute/tests/test_native_tool_finder.py
@@ -29,15 +29,13 @@ class TestNativeToolFinder:
         def mock_build_collector(_: Path) -> None:
             self.__create_file(built_lib_path)
 
-        with (
-            patch.object(NativeToolFinder, "_generate_cmake", return_value=None),
-            patch.object(
+        with patch.object(NativeToolFinder, "_generate_cmake", return_value=None):
+            with patch.object(
                 NativeToolFinder,
                 "_build_cmake",
                 side_effect=mock_build_collector,
-            ),
-        ):
-            lib_path = NativeToolFinder(root_path).get_collector_library_path()
+            ):
+                lib_path = NativeToolFinder(root_path).get_collector_library_path()
         assert lib_path == built_lib_path
 
     def test_when_run_from_source_dir_and_collector_not_found_after_build__throws(
@@ -45,12 +43,10 @@ class TestNativeToolFinder:
     ):
         root_path, built_lib_path = sources_dir
         built_lib_path.unlink()
-        with (
-            patch.object(NativeToolFinder, "_generate_cmake", return_value=None),
-            patch.object(NativeToolFinder, "_build_cmake", return_value=None),
-        ):
-            with pytest.raises(RuntimeError):
-                NativeToolFinder(root_path).get_collector_library_path()
+        with patch.object(NativeToolFinder, "_generate_cmake", return_value=None):
+            with patch.object(NativeToolFinder, "_build_cmake", return_value=None):
+                with pytest.raises(RuntimeError):
+                    NativeToolFinder(root_path).get_collector_library_path()
 
     def test_when_run_from_source_dir_and_generation_fails__throws(
         self, sources_dir: tuple[Path, Path]

--- a/projects/rocprofiler-compute/tests/test_pc_sampling_analysis.py
+++ b/projects/rocprofiler-compute/tests/test_pc_sampling_analysis.py
@@ -1237,19 +1237,17 @@ def test_load_table_data_forwards_pc_sampling_tool_data() -> None:
     args = argparse.Namespace(debug=False)
     workload = schema.Workload()
     workload.sys_info = pd.DataFrame([{"gpu_arch": "gfx942"}])
-    with (
-        patch("utils.parser.load_non_mertrics_table") as mock_load_non_metrics,
-        patch("utils.parser.eval_metric"),
-        patch("utils.parser.apply_filters"),
-    ):
-        load_table_data(
-            workload=workload,
-            dir_path="dir",
-            is_gui=False,
-            args=args,
-            dfs_expressions={},
-            pc_sampling_tool_data=sentinel,
-        )
+    with patch("utils.parser.load_non_mertrics_table") as mock_load_non_metrics:
+        with patch("utils.parser.eval_metric"):
+            with patch("utils.parser.apply_filters"):
+                load_table_data(
+                    workload=workload,
+                    dir_path="dir",
+                    is_gui=False,
+                    args=args,
+                    dfs_expressions={},
+                    pc_sampling_tool_data=sentinel,
+                )
     mock_load_non_metrics.assert_called_once()
     assert mock_load_non_metrics.call_args.args[3] is sentinel
 


### PR DESCRIPTION
## Motivation

The project declares `requires-python = ">=3.8"`, from which Ruff infers its target version. Parenthesized context managers (PEP 617) are 3.9+ syntax and cause Ruff parser errors under the 3.8 target. Rewriting them as nested `with` statements keeps the codebase Ruff-clean without adding a separate `target-version` setting to track.

## Technical Details

- Replace parenthesized multi-manager `with (...)` blocks with nested `with` statements across `src/utils/analysis_orm.py` and six test modules
- No behavioral change; purely syntax to restore 3.8 compatibility

## JIRA ID

N/A

## Test Plan

- `ruff check` and `ruff format --check` pass at the inferred 3.8 target
- Affected unit test modules run with no new failures

## Test Result

- [x] Ruff check + format pass via pre-commit hooks
- [x] Affected unit tests: no change vs baseline (pre-existing env failures unrelated)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.