### PR TITLE
libhsakmt: gate FabricHandleSupported on ualink accel_state == ready

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/topology.c
+++ b/projects/rocr-runtime/libhsakmt/src/topology.c
@@ -1112,7 +1112,7 @@ static int topology_get_node_props_from_drm(HsaNodeProperties *props)
 	if (file) {
 		char accel_state[16] = {0};
 		if (fgets(accel_state, sizeof(accel_state), file) &&
-		    strncmp(accel_state, "ready", 5) == 0)
+		    strncmp(accel_state, "ready", sizeof("ready") - 1) == 0)
 			props->FabricHandleSupported = 1;
 		fclose(file);
 	}

--- a/projects/rocr-runtime/libhsakmt/src/topology.c
+++ b/projects/rocr-runtime/libhsakmt/src/topology.c
@@ -1098,13 +1098,23 @@ static int topology_get_node_props_from_drm(HsaNodeProperties *props)
 	props->Integrated = !!(gpu_info.ids_flags & AMDGPU_IDS_FLAGS_FUSION);
 	props->WallClockKHz = gpu_info.gpu_counter_freq;
 
-	snprintf(fabric_handle_supported_path, 256, "/sys/class/drm/renderD%d/device/ualink", props->DrmRenderMinor);
+	/*
+	 * Fabric (UALink) handle support must mirror the driver's readiness gate:
+	 * the DRM_AMDGPU_UALINK_HANDLE ioctl returns -EOPNOTSUPP unless the fabric
+	 * accel_state == "ready". Merely opening the ualink directory is not enough
+	 * (the node exists whenever the ASIC has UALink HW, even with the fabric
+	 * down), so this is relying on the "ready" state provided by the driver via
+	 * ualink/accel_state before advertising FabricHandleSupported.
+	 */
+	snprintf(fabric_handle_supported_path, 256, "/sys/class/drm/renderD%d/device/ualink/accel_state", props->DrmRenderMinor);
 	FILE *file = fopen(fabric_handle_supported_path, "r");
+	props->FabricHandleSupported = 0;
 	if (file) {
-		props->FabricHandleSupported = 1;
+		char accel_state[16] = {0};
+		if (fgets(accel_state, sizeof(accel_state), file) &&
+		    strncmp(accel_state, "ready", 5) == 0)
+			props->FabricHandleSupported = 1;
 		fclose(file);
-	} else {
-		props->FabricHandleSupported = 0;
 	}
 
 err_query_gpu_info:


### PR DESCRIPTION
The UALink fabric-handle probe previously set FabricHandleSupported=1 by merely fopen-ing the /sys/class/drm/renderD*/device/ualink directory, which exists whenever the ASIC has UALink HW regardless of fabric readiness. On a box without an AFM-provisioned fabric this over-reports support, so the hip-test skip guard never fires and the doomed export (DRM_AMDGPU_UALINK_HANDLE ioctl returning -EOPNOTSUPP when accel_state != ready) runs and FAILs instead of SKIPping.

Mirror the driver readiness gate: read ualink/accel_state and only advertise support when it reads "ready".

## Motivation

On systems without an AFM-provisioned UALink fabric, the hip-test Unit_hipMemExportFabricHandleToStdout_Positive_Basic FAILS instead of SKIPPING. The test's skip guard checks hipDeviceAttributeHandleTypeFabricSupported, which is over-reported as supported on any box that merely has UALink hardware, so the guard never fires and the doomed export runs and fails.

## Technical Details

topology_get_node_props_from_drm() in libhsakmt/src/topology.c set FabricHandleSupported = 1 by fopen()-ing the director  /sys/class/drm/renderD%d/device/ualink, which exists whenever the ASIC has UALink HW regardless of fabric readiness. Meanwhile the driver gates the actual export ioctl (DRM_AMDGPU_UALINK_HANDLE) on accel_state == ready, returning -EOPNOTSUPP otherwise.

This change makes the thunk mirror the driver's readiness gate: it reads /sys/class/drm/renderD%d/device/ualink/accel_state and only advertises FabricHandleSupported when it reads ready. A comment records that this relies on the driver-provided ready state.

## JIRA ID

ROCM-27354

## Test Plan

Run on a single GPU with no AFM fabric provisioned:
  ROCR_VISIBLE_DEVICES=0 ./VirtualMemoryManagementTest "Unit_hipMemExportFabricHandleToStdout_Positive_Basic" -s
  Also confirm behavior on an AFM-provisioned box where accel_state == ready.

## Test Result

Non-AFM box (accel_state = unconfigured): before this change the test FAILS with hipErrorInvalidValue; after, it SKIPS ("Fabric Handle Support not
  found. Skipping Test"). AFM-provisioned box (accel_state = ready): capability reports supported, test runs and the export succeeds

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
