### PR TITLE
fix: [clr]Fix eval-order, optimize SetPacket

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -3017,9 +3017,9 @@ VirtualGPU* Device::xferQueue() const {
     }
     if (xferQueue_->gpu_queue() == nullptr) {
       void* md_rb = nullptr;
-      xferQueue_->SetGpuQueue(
-          thisDevice->AcquireActiveQueue(amd::CommandQueue::Priority::Normal,
-                                         nullptr, nullptr, &md_rb), md_rb);
+      auto* queue = thisDevice->AcquireActiveQueue(amd::CommandQueue::Priority::Normal,
+                                                   nullptr, nullptr, &md_rb);
+      xferQueue_->SetGpuQueue(queue, md_rb);
     }
   }
   xferQueue_->enableSyncBlit();

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1154,7 +1154,8 @@ void VirtualGPU::AcquireQueueWithPreference() {
   std::scoped_lock lock(execution());
   if (!dedicated_queue_ && gpu_queue_ == nullptr && last_hwq_ != nullptr) {
     void* md_rb = nullptr;
-    SetGpuQueue(roc_device_.AcquireActiveQueue(priority_, last_hwq_, nullptr, &md_rb), md_rb);
+    auto* queue = roc_device_.AcquireActiveQueue(priority_, last_hwq_, nullptr, &md_rb);
+    SetGpuQueue(queue, md_rb);
     last_hwq_ = nullptr;
   }
 }
@@ -1171,7 +1172,8 @@ bool VirtualGPU::ReacquireQueueExcluding(const std::unordered_set<uint64_t>& exc
     gpu_queue_ = nullptr;
   }
   void* md_rb = nullptr;
-  SetGpuQueue(roc_device_.AcquireActiveQueue(priority_, nullptr, &excluded_ids, &md_rb), md_rb);
+  auto* queue = roc_device_.AcquireActiveQueue(priority_, nullptr, &excluded_ids, &md_rb);
+  SetGpuQueue(queue, md_rb);
   return gpu_queue_ != nullptr;
 }
 
@@ -1181,7 +1183,8 @@ uint64_t VirtualGPU::getQueueID() {
   // Dedicated queues keep their HW queue, never acquire from pool
   if (!dedicated_queue_ && gpu_queue_ == nullptr) {
     void* md_rb = nullptr;
-    SetGpuQueue(roc_device_.AcquireActiveQueue(priority_, nullptr, nullptr, &md_rb), md_rb);
+    auto* queue = roc_device_.AcquireActiveQueue(priority_, nullptr, nullptr, &md_rb);
+    SetGpuQueue(queue, md_rb);
   }
   return gpu_queue_->id;
 }
@@ -1546,11 +1549,18 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPack
   fence_state_ = static_cast<Device::CacheState>(expected_fence_state);
 
   const size_t kPeriod = DEBUG_HIP_GRAPH_BATCH_SIZE;
+  // Ramp-up: submit a small first (lead) chunk so the doorbell is rung after
+  // copying only kLead packets instead of a full kPeriod. The GPU starts
+  // executing the lead while the CPU keeps copying the remaining
+  // packet+metadata payload, overlapping the bulk copy with GPU execution and
+  // cutting the one-time startup idle that grew with the 256B/packet metadata.
+  constexpr size_t kLead = 8;
   auto* first_loc = reinterpret_cast<uint32_t*>(
       queueBase + (startIndex & queueMask) * kPacketSize);
 
   for (size_t chunkStart = 0; chunkStart < numPackets; ) {
-    const size_t chunkEnd  = std::min(chunkStart + kPeriod, numPackets);
+    const size_t period = (chunkStart == 0) ? kLead : kPeriod;
+    const size_t chunkEnd  = std::min(chunkStart + period, numPackets);
     const size_t thisChunk = chunkEnd - chunkStart;
     const bool isFirstChunk = (chunkStart == 0);
     const bool isLastChunk  = (chunkEnd == numPackets);
@@ -2008,7 +2018,8 @@ VirtualGPU::~VirtualGPU() {
     // Dedicated queues keep their HW queue, never acquire from pool
     if (!dedicated_queue_ && gpu_queue_ == nullptr) {
       void* md_rb = nullptr;
-      SetGpuQueue(roc_device_.AcquireActiveQueue(priority_, nullptr, nullptr, &md_rb), md_rb);
+      auto* queue = roc_device_.AcquireActiveQueue(priority_, nullptr, nullptr, &md_rb);
+      SetGpuQueue(queue, md_rb);
     }
     // Windows requires an interrupt in more cases than Linux for OS fence updates
     force_irq_ = IS_WINDOWS;
@@ -2077,8 +2088,9 @@ bool VirtualGPU::create() {
   // Pick a reasonable queue size
   uint32_t queue_size = ROC_AQL_QUEUE_SIZE;
   void* md_rb = nullptr;
-  SetGpuQueue(roc_device_.acquireQueue(queue_size, cooperative_, cuMask_, priority_, false,
-                                       dedicated_queue_, nullptr, nullptr, &md_rb), md_rb);
+  auto* queue = roc_device_.acquireQueue(queue_size, cooperative_, cuMask_, priority_, false,
+                                         dedicated_queue_, nullptr, nullptr, &md_rb);
+  SetGpuQueue(queue, md_rb);
   if (!gpu_queue_) return false;
 
   if (dev().isa().versionMajor() == 12 && dev().isa().versionMinor() >= 5) {
@@ -2306,7 +2318,8 @@ void VirtualGPU::profilingBegin(amd::Command& command, bool sdmaProfiling) {
   // Dedicated queues keep their HW queue, never acquire from pool
   if (!dedicated_queue_ && gpu_queue_ == nullptr) {
     void* md_rb = nullptr;
-    SetGpuQueue(roc_device_.AcquireActiveQueue(priority_, nullptr, nullptr, &md_rb), md_rb);
+    auto* queue = roc_device_.AcquireActiveQueue(priority_, nullptr, nullptr, &md_rb);
+    SetGpuQueue(queue, md_rb);
   }
   // Track the current command
   command_ = &command;
@@ -4680,7 +4693,8 @@ void VirtualGPU::submitMarker(amd::Marker& vcmd) {
     // HSA signal callback
     if (!dedicated_queue_ && gpu_queue_ == nullptr) {
       void* md_rb = nullptr;
-      SetGpuQueue(roc_device_.AcquireActiveQueue(priority_, nullptr, nullptr, &md_rb), md_rb);
+      auto* queue = roc_device_.AcquireActiveQueue(priority_, nullptr, nullptr, &md_rb);
+      SetGpuQueue(queue, md_rb);
     }
     flush(vcmd.GetBatchHead());
     SetCoalesceWindow(0, nullptr);
@@ -5017,41 +5031,38 @@ void VirtualGPU::MetaDataPreloader::SetPacket(
   if (preload_length > 0) {
     const uint8_t* kernargs = reinterpret_cast<const uint8_t*>(aql->kernarg_address);
     assert(kernargs);
-    // Kernarg preload offset is in DWORDs
     const uint8_t* src = kernargs + pending_preload_offset_ * sizeof(uint32_t);
     uint16_t remain = preload_length;
 
-    // Copy kernarg_preload 0-14
-    uint16_t n = std::min<uint16_t>(
-        remain, sizeof(metadata->kernarg_preload_0_14) / sizeof(uint32_t));
-    if (n < (sizeof(metadata->kernarg_preload_0_14) / sizeof(uint32_t))) {
-      std::memset(metadata->kernarg_preload_0_14, 0, sizeof(metadata->kernarg_preload_0_14));
-    }
+    constexpr uint16_t kSec0 = sizeof(metadata->kernarg_preload_0_14) / sizeof(uint32_t);
+    constexpr uint16_t kSec1 = sizeof(metadata->kernarg_preload_15_29) / sizeof(uint32_t);
+    constexpr uint16_t kSec2 = sizeof(metadata->kernarg_preload_30_31) / sizeof(uint32_t);
+
+    // Copy data first, zero only the tail — avoids double-writing the prefix
+    // that the old memset+memcpy pattern caused.
+    uint16_t n = std::min<uint16_t>(remain, kSec0);
     std::memcpy(metadata->kernarg_preload_0_14, src, n * sizeof(uint32_t));
+    if (n < kSec0) {
+      std::memset(&metadata->kernarg_preload_0_14[n], 0, (kSec0 - n) * sizeof(uint32_t));
+    }
     remain -= n;
 
-    // Copy kernarg_preload 15-29
     if (remain > 0) {
       src += n * sizeof(uint32_t);
-      n = std::min<uint16_t>(
-          remain, sizeof(metadata->kernarg_preload_15_29) / sizeof(uint32_t));
-      if (n < (sizeof(metadata->kernarg_preload_15_29) / sizeof(uint32_t))) {
-        std::memset(metadata->kernarg_preload_15_29, 0,
-                    sizeof(metadata->kernarg_preload_15_29));
-      }
+      n = std::min<uint16_t>(remain, kSec1);
       std::memcpy(metadata->kernarg_preload_15_29, src, n * sizeof(uint32_t));
+      if (n < kSec1) {
+        std::memset(&metadata->kernarg_preload_15_29[n], 0, (kSec1 - n) * sizeof(uint32_t));
+      }
       remain -= n;
 
-      // Copy kernarg_preload 30-31
       if (remain > 0) {
         src += n * sizeof(uint32_t);
-        n = std::min<uint16_t>(
-            remain, sizeof(metadata->kernarg_preload_30_31) / sizeof(uint32_t));
-        if (n < (sizeof(metadata->kernarg_preload_30_31) / sizeof(uint32_t))) {
-          std::memset(metadata->kernarg_preload_30_31, 0,
-                      sizeof(metadata->kernarg_preload_30_31));
-        }
+        n = std::min<uint16_t>(remain, kSec2);
         std::memcpy(metadata->kernarg_preload_30_31, src, n * sizeof(uint32_t));
+        if (n < kSec2) {
+          std::memset(&metadata->kernarg_preload_30_31[n], 0, (kSec2 - n) * sizeof(uint32_t));
+        }
       }
     }
   }
@@ -5060,6 +5071,7 @@ void VirtualGPU::MetaDataPreloader::SetPacket(
   // Plain stores are sufficient here: the subsequent packet_store_release on the main
   // AQL dispatch header provides a release fence that orders all metadata writes (body
   // and headers) before the CP sees the valid dispatch packet.
+
   uint32_t metadata_header = GetType(header) | metadata_version_header_;
   metadata->header3 = metadata_header;
   metadata->header2 = metadata_header;


### PR DESCRIPTION
- Fix undefined argument evaluation order in SetGpuQueue calls where AcquireActiveQueue writes md_rb via out-param in unspecified order relative to the second argument read of md_rb (GCC compiled the stale nullptr, breaking metadata ring attachment).

- Hardcode lead chunk size to 8 packets in dispatchAqlPacketBatchFlat so the doorbell rings early, overlapping GPU execution of the lead with the CPU's bulk metadata+packet copy for the remainder.

- Optimize SetPacket kernarg_preload fill: copy data first then zero only the tail, eliminating the double-write from the old memset(full)+memcpy(partial) pattern.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

JIRA ID: AIRUNTIME-0

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
