### PR TITLE
[clr] [hip-tests] Flush caches with system scope before graph host-no…

### DIFF
--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -2901,8 +2901,13 @@ class GraphHostNode : public GraphNode {
     amd::Command::EventWaitList waitList;
     commands_.reserve(1);
     amd::Command* command = new amd::Marker(*stream, !kMarkerDisableFlush, waitList);
-    // This is just to invoke a callback, so no need to flush caches.
-    command->setCommandEntryScope(amd::Device::kCacheStateIgnore);
+    // The host callback runs on the CPU and may read memory produced by an
+    // upstream GPU node (e.g. a DtoH copy feeding this node). Use a system-scope
+    // fence so the barrier preceding the callback flushes/invalidates the L2 and
+    // the producer's writes are visible to the CPU. A NOP-scope barrier only
+    // orders GPU work and leaves the data invisible to the host on GPUs where
+    // the producer's agent-scope release is not host-visible.
+    command->setCommandEntryScope(amd::Device::kCacheStateSystem);
     commands_.emplace_back(command);
     return hipSuccess;
   }

--- a/projects/hip-tests/catch/config/configs/unit/graph.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/graph.yaml
@@ -170,6 +170,9 @@ graph:
   Unit_hipGraphAddHostNode_BasicFunc:
     <<: *level_2
     tags: [node]
+  Unit_hipGraphAddHostNode_CallbackSeesUpstreamDtoH:
+    <<: *level_2
+    tags: [node]
   Unit_hipGraphAddMemcpyNodeFromSymbol_Negative:
     <<: *level_2
     tags: [node]

--- a/projects/hip-tests/catch/unit/graph/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/graph/CMakeLists.txt
@@ -119,6 +119,7 @@ set(TEST_SRC
   hipGraphDestroy.cc
   hipThreadExchangeStreamCaptureMode.cc
   hipLaunchHostFuncWithGraph.cc
+  hipGraphHostNodeCacheVisibility.cc
   hipUserObjectCreate.cc
   hipUserObjectRelease.cc
   hipUserObjectRetain.cc

--- a/projects/hip-tests/catch/unit/graph/hipGraphHostNodeCacheVisibility.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphHostNodeCacheVisibility.cc
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <hip_test_common.hh>
+
+/**
+ * @addtogroup hipGraphAddHostNode hipGraphAddHostNode
+ * @{
+ * @ingroup GraphTest
+ */
+
+namespace {
+__global__ void produceValue(int* dst, int value) { *dst = value; }
+}  // namespace
+
+/**
+ * Test Description
+ * ------------------------
+ *    - Regression test for the GraphHostNode callback fence scope (clr:
+ *      hipamd/src/hip_graph_internal.hpp). A host node's callback runs on the
+ *      CPU and may read host memory produced by an upstream GPU node. The marker
+ *      that gates the callback must carry a system-scope release fence so the
+ *      producer's writes are flushed past L2 and are visible to the CPU before
+ *      the callback executes.
+ *
+ *      Minimal graph (no multi-stream setup — the bug is stream-independent):
+ *
+ *        producerNode  write *devProduced = kProducedValue
+ *            │
+ *            ▼  (dependency)
+ *        copyNode      devProduced → hostProduced   (captured DtoH memcpy)
+ *            │
+ *            ▼  (dependency)
+ *        callbackNode  callback copies *hostProduced → *hostObserved
+ *
+ *      No spin/delay is needed: ordering is guaranteed by the dependency chain,
+ *      and the visibility bug is deterministic on the callback marker's fence
+ *      scope, not on timing (a NOP-scope release leaves the DtoH write invisible
+ *      to the CPU regardless of how long the callback waits).
+ *
+ *      With the system-scope fence (fix): the DtoH write is CPU-visible, so the
+ *      callback observes kProducedValue → hostObserved == kProducedValue ✓
+ *      With a NOP-scope fence (bug): the callback reads un-flushed/stale memory
+ *      on GPUs whose producer release is not host-visible (e.g. gfx1201)
+ *      → hostObserved != kProducedValue  FAIL ✗
+ *
+ *      hostProduced is set to 0 on the host before launch, so if the DtoH write
+ *      is not flushed the callback reads back the host's own cached 0
+ *      (!= kProducedValue) and the test fails. The bug is deterministic, so a
+ *      single launch suffices — no iteration loop is needed.
+ * Test source
+ * ------------------------
+ *    - catch/unit/graph/hipGraphHostNodeCacheVisibility.cc
+ * Test requirements
+ * ------------------------
+ *    - HIP_VERSION >= 5.3
+ */
+HIP_TEST_CASE(Unit_hipGraphAddHostNode_CallbackSeesUpstreamDtoH) {
+  constexpr int kProducedValue = 0x5A5A5A5A;
+
+  int* hostProduced{};  // DtoH destination (GPU-produced host memory)
+  int* hostObserved{};  // value the callback read back from hostProduced
+  HIP_CHECK(hipHostMalloc(&hostProduced, sizeof(int), hipHostMallocDefault));
+  HIP_CHECK(hipHostMalloc(&hostObserved, sizeof(int), hipHostMallocDefault));
+
+  int* devProduced{};
+  HIP_CHECK(hipMalloc(&devProduced, sizeof(int)));
+
+  hipGraph_t hostFuncGraph{};
+  HIP_CHECK(hipGraphCreate(&hostFuncGraph, 0));
+
+  // Kernel node params are captured at instantiate; kProducedValue is a fixed
+  // nonzero value baked into the graph.
+  int producedValue = kProducedValue;
+  void* producerArgs[] = {&devProduced, &producedValue};
+
+  // producerNode: write kProducedValue into device memory.
+  hipGraphNode_t producerNode{};
+  {
+    hipKernelNodeParams params{};
+    params.func = reinterpret_cast<void*>(produceValue);
+    params.gridDim = dim3(1);
+    params.blockDim = dim3(1);
+    params.kernelParams = producerArgs;
+    HIP_CHECK(hipGraphAddKernelNode(&producerNode, hostFuncGraph, nullptr, 0, &params));
+  }
+
+  // copyNode: captured DtoH devProduced → hostProduced, depends on producerNode.
+  hipGraphNode_t copyNode{};
+  HIP_CHECK(hipGraphAddMemcpyNode1D(&copyNode, hostFuncGraph, &producerNode, 1, hostProduced,
+                                    devProduced, sizeof(int), hipMemcpyDeviceToHost));
+
+  // callbackNode: uncaptured host callback reads the GPU-produced hostProduced.
+  struct CallbackContext { int* produced; int* observed; };
+  CallbackContext callbackContext{hostProduced, hostObserved};
+  hipGraphNode_t callbackNode{};
+  hipHostNodeParams callbackParams{};
+  callbackParams.fn = [](void* userData) {
+    auto* ctx = static_cast<CallbackContext*>(userData);
+    *ctx->observed = *ctx->produced;
+  };
+  callbackParams.userData = &callbackContext;
+  HIP_CHECK(hipGraphAddHostNode(&callbackNode, hostFuncGraph, &copyNode, 1, &callbackParams));
+
+  hipGraphExec_t hostFuncGraphExec{};
+  HIP_CHECK(hipGraphInstantiate(&hostFuncGraphExec, hostFuncGraph, nullptr, nullptr, 0));
+  hipStream_t launchStream{};
+  HIP_CHECK(hipStreamCreate(&launchStream));
+
+  // Plant a known host-cached value: if the DtoH write is not flushed to be
+  // CPU-visible, the callback reads back this 0 instead of kProducedValue.
+  *hostProduced = 0;
+
+  HIP_CHECK(hipGraphLaunch(hostFuncGraphExec, launchStream));
+  HIP_CHECK(hipStreamSynchronize(launchStream));
+
+  INFO("expected=" << kProducedValue << " observed=" << *hostObserved);
+  REQUIRE(*hostObserved == kProducedValue);  // stale/un-flushed read → reads 0
+
+  HIP_CHECK(hipGraphExecDestroy(hostFuncGraphExec));
+  HIP_CHECK(hipGraphDestroy(hostFuncGraph));
+  HIP_CHECK(hipStreamDestroy(launchStream));
+  HIP_CHECK(hipFree(devProduced));
+  HIP_CHECK(hipHostFree(hostObserved));
+  HIP_CHECK(hipHostFree(hostProduced));
+}
+
+/**
+ * End doxygen group GraphTest.
+ * @}
+ */


### PR DESCRIPTION
…de callback.

## Motivation

A HIP graph host node's callback runs on the CPU and often reads host memory produced by an upstream GPU node (e.g. a device-to-host copy feeding the callback). The callback marker was created with a NOP-scope fence (kCacheStateIgnore), which only orders GPU work and does not flush the GPU L2 to system-visible memory. On GPUs where the producer's agent-scope release is not host-visible (observed on gfx1201 / NAVI48), the CPU callback reads stale data, while gfx1100 / NAVI3x happens to pass. This is a silent, architecture-specific data-correctness bug. Ordering was never the problem — the marker correctly waited for the producer to complete — the produced data simply wasn't made visible to the CPU before the callback ran.

## Technical Details

Fix (clr): in GraphHostNode::CreateCommand (hipamd/src/hip_graph_internal.hpp), the callback marker's command entry scope is changed from kCacheStateIgnore to kCacheStateSystem.

## JIRA ID

ROCM-27311

## Test Plan

New test added to test coherency
Unit_hipLaunchHostFunc_CrossStreamDep_UncapturedFirstNode

## Test Result

Unit_hipLaunchHostFunc_CrossStreamDep_UncapturedFirstNode pass
Unit_hipGraphAddHostNode_CallbackSeesUpstreamDtoH pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.