### PR TITLE
fix(rocprofiler-sdk): harden env-var dlopen and pickle attach cache (…

### DIFF
--- a/projects/rocprofiler-sdk/source/bin/rocprofv3.py
+++ b/projects/rocprofiler-sdk/source/bin/rocprofv3.py
@@ -2390,17 +2390,52 @@ def main(argv=None):
             if args.collection_period:
                 fatal_error("--collection-period is not compatible with attach mode")
 
+            # SECURITY: this cache file lives at a predictable path in a world-writable
+            # directory (/tmp) and is deserialized with pickle, which would execute
+            # arbitrary code if another user on a shared system planted a malicious
+            # payload. To prevent this, the file is created exclusively (O_EXCL) with
+            # 0600 permissions and is only ever read back if it is owned by the current
+            # user; O_NOFOLLOW prevents symlink redirection attacks. As a result, we only
+            # ever unpickle a file that we created ourselves.
             fname = f"/tmp/rocprofv3_attach_{args.pid}.pkl"
-            if not os.path.exists(fname):
-                # if this is the first attachment, write the temp configuration file for future attachments
-                with open(fname, "wb") as ofs:
+            try:
+                # if this is the first attachment, exclusively create the temp
+                # configuration file for future attachments
+                fd = os.open(
+                    fname, os.O_CREAT | os.O_EXCL | os.O_WRONLY | os.O_NOFOLLOW, 0o600
+                )
+            except FileExistsError:
+                fd = None
+
+            if fd is not None:
+                with os.fdopen(fd, "wb") as ofs:
                     if args.log_level in ("config", "info", "trace"):
                         print(f"Saving attach configuration to {fname}...")
                     pickle.dump(args, ofs)
             else:
                 # if this is not the first attachment
-                # load the configuration from the previous attachment
-                with open(fname, "rb") as ifs:
+                # load the configuration from the previous attachment.
+                # O_NOFOLLOW rejects symlinks; a stale file owned by another user (from a
+                # crashed session that reused this PID) surfaces here as PermissionError
+                # (0600) or via the ownership check below. Translate any such failure into a
+                # clear, actionable message instead of an unhandled traceback.
+                try:
+                    rfd = os.open(fname, os.O_RDONLY | os.O_NOFOLLOW)
+                except OSError as _e:
+                    fatal_error(
+                        f"Could not open attach configuration file {fname}: {_e}. "
+                        "It may be stale or owned by another user; remove it and retry "
+                        "(or wait for the target PID's previous session to clean it up)."
+                    )
+                with os.fdopen(rfd, "rb") as ifs:
+                    # refuse to unpickle a configuration file that is not owned by the
+                    # current user (e.g. planted by another user on a shared system)
+                    if os.fstat(rfd).st_uid != os.getuid():
+                        fatal_error(
+                            f"Refusing to load attach configuration from {fname}: "
+                            f"file is not owned by the current user (uid={os.getuid()}). "
+                            "It may be stale or owned by another user; remove it and retry."
+                        )
                     if args.log_level in ("config", "info", "trace"):
                         print(f"Loading attach configuration from {fname}...")
                     prev_args = pickle.load(ifs)

--- a/projects/rocprofiler-sdk/source/lib/common/environment.cpp
+++ b/projects/rocprofiler-sdk/source/lib/common/environment.cpp
@@ -26,6 +26,7 @@
 
 #include <fmt/format.h>
 
+#include <sys/auxv.h>
 #include <cctype>
 #include <cstdint>
 #include <cstdio>
@@ -204,6 +205,16 @@ SPECIALIZE_SET_ENV(uint16_t)
 SPECIALIZE_SET_ENV(uint32_t)
 SPECIALIZE_SET_ENV(uint64_t)
 }  // namespace impl
+
+bool
+is_at_secure()
+{
+    // AT_SECURE is set by the kernel when the program was executed in a way that
+    // requires "secure execution" (setuid/setgid, file capabilities, etc.).
+    // Cache the value since it cannot change during the lifetime of the process.
+    static const bool _v = (::getauxval(AT_SECURE) != 0);
+    return _v;
+}
 
 env_store::env_store(std::initializer_list<env_config>&& _container)
 {

--- a/projects/rocprofiler-sdk/source/lib/common/environment.hpp
+++ b/projects/rocprofiler-sdk/source/lib/common/environment.hpp
@@ -112,6 +112,15 @@ set_env(std::string_view env_id, Tp&& value, int override = 0)
     return impl::set_env(env_id, std::forward<Tp>(value), override);
 }
 
+// Returns true if the process is running in a "secure" execution context, i.e.
+// the AT_SECURE auxiliary-vector entry is set (setuid/setgid binaries, files
+// with capabilities, etc.). In such contexts, environment variables that are
+// controllable by an unprivileged user must NOT be honored to load code (e.g.
+// dlopen of tool libraries), otherwise a local attacker could inject a library
+// into a privileged process. The result is cached on first call.
+bool
+is_at_secure();
+
 struct env_config
 {
     std::string env_name  = {};

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
@@ -296,9 +296,15 @@ setup(int pid)
         return status;
     }
 
-    // Build and write tool library path to target process
+    // Build and write tool library path to target process. Do not honor the
+    // user-controllable ROCPROF_ATTACH_TOOL_LIBRARY override in a secure-execution
+    // context (setuid/setgid, file capabilities, etc.), so an unprivileged user
+    // cannot cause a privileged attach helper to inject an arbitrary library.
     auto tool_lib_path_env =
-        rocprofiler::common::get_env("ROCPROF_ATTACH_TOOL_LIBRARY", "librocprofiler-sdk-tool.so");
+        rocprofiler::common::is_at_secure()
+            ? std::string{"librocprofiler-sdk-tool.so"}
+            : rocprofiler::common::get_env("ROCPROF_ATTACH_TOOL_LIBRARY",
+                                           "librocprofiler-sdk-tool.so");
     const char* tool_lib_path = tool_lib_path_env.c_str();
     ROCP_TRACE << "[rocprofiler-sdk-rocattach] Tool library path: " << tool_lib_path;
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
@@ -300,12 +300,11 @@ setup(int pid)
     // user-controllable ROCPROF_ATTACH_TOOL_LIBRARY override in a secure-execution
     // context (setuid/setgid, file capabilities, etc.), so an unprivileged user
     // cannot cause a privileged attach helper to inject an arbitrary library.
-    auto tool_lib_path_env =
-        rocprofiler::common::is_at_secure()
-            ? std::string{"librocprofiler-sdk-tool.so"}
-            : rocprofiler::common::get_env("ROCPROF_ATTACH_TOOL_LIBRARY",
-                                           "librocprofiler-sdk-tool.so");
-    const char* tool_lib_path = tool_lib_path_env.c_str();
+    auto        tool_lib_path_env = rocprofiler::common::is_at_secure()
+                                        ? std::string{"librocprofiler-sdk-tool.so"}
+                                        : rocprofiler::common::get_env("ROCPROF_ATTACH_TOOL_LIBRARY",
+                                                                "librocprofiler-sdk-tool.so");
+    const char* tool_lib_path     = tool_lib_path_env.c_str();
     ROCP_TRACE << "[rocprofiler-sdk-rocattach] Tool library path: " << tool_lib_path;
 
     size_t               tool_lib_path_len = strlen(tool_lib_path) + 1;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/config.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/config.cpp
@@ -261,6 +261,19 @@ config::config()
 , att_param_perfcounters{
       parse_att_counters(get_env("ROCPROF_ATT_PARAM_PERFCOUNTERS", std::string{}))}
 {
+    // SECURITY: ROCPROF_ATT_LIBRARY_PATH selects the directory from which the
+    // advanced-thread-trace decoder library (librocprof-trace-decoder.so) is
+    // dlopen'd. Do not honor this user-controllable environment variable in a
+    // secure-execution context (setuid/setgid binaries, file capabilities, etc.),
+    // otherwise an unprivileged local user could inject an arbitrary shared
+    // library into a privileged process. Fall back to the default library search.
+    if(common::is_at_secure() && !att_library_path.empty())
+    {
+        ROCP_WARNING << "[ROCPROF_ATT_LIBRARY_PATH] ignoring environment variable because the "
+                        "process is running in a secure-execution context (AT_SECURE)";
+        att_library_path.clear();
+    }
+
     if(kernel_filter_include.empty()) kernel_filter_include = std::string{".*"};
 
     std::unordered_map<std::string_view, rocprofiler_pc_sampling_unit_t> pc_sampling_unit_map = {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/registration.cpp
@@ -392,6 +392,18 @@ find_clients()
     }
 
     auto get_env_libs = []() {
+        // Never honor ROCP_TOOL_LIBRARIES in a secure-execution context (setuid/
+        // setgid binaries, file capabilities, etc.). Otherwise an unprivileged
+        // local user could inject an arbitrary shared library (via dlopen) into a
+        // privileged process by setting this environment variable.
+        if(common::is_at_secure())
+        {
+            ROCP_CI_LOG(WARNING) << "[ROCP_TOOL_LIBRARIES] ignoring environment variable because "
+                                    "the process is running in a secure-execution context "
+                                    "(AT_SECURE)";
+            return std::vector<std::string>{};
+        }
+
         auto       val       = common::get_env("ROCP_TOOL_LIBRARIES", std::string{});
         auto       val_arr   = std::vector<std::string>{};
         size_t     pos       = 0;


### PR DESCRIPTION
…SEC-00398, SEC-00752)

Address two AI security-scan findings:

SEC-00398: An unprivileged local user could inject an arbitrary shared library into a privileged (setuid/setgid/file-capabilities) process via ROCP_TOOL_LIBRARIES or ROCPROF_ATTACH_TOOL_LIBRARY, which are passed to dlopen. Add a common::is_at_secure() helper (getauxval(AT_SECURE)) and ignore both environment variables in secure-execution contexts.

SEC-00752: The attach-mode cache file at the predictable path /tmp/rocprofv3_attach_<pid>.pkl was deserialized with pickle, enabling arbitrary code execution if another user planted a payload. Create the file exclusively (O_CREAT|O_EXCL|O_WRONLY|O_NOFOLLOW, 0600) and only unpickle it when opened with O_RDONLY|O_NOFOLLOW and owned by the current user, so we only ever load a file we created ourselves. Failures are converted into clear fatal_error messages.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
JIRA ID: ROCM-26858
JIRA ID: ROCM-26869
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
