### PR TITLE
fix(rocprofiler-systems): handle indexed GPU counter files

### DIFF
--- a/projects/rocprofiler-systems/tests/pytest/conftest.py
+++ b/projects/rocprofiler-systems/tests/pytest/conftest.py
@@ -2441,14 +2441,20 @@ def assert_rocpd(subtests, tests_dir, request):
                     gpu_category_to_skip=gpu_category_to_skip,
                 )
 
-            passing_output, failures = _validate_rocpd_candidates(
+            passing_output, failures, global_failure = _validate_rocpd_candidates(
                 rocpd_files,
                 validate_candidate,
                 pass_regex=pass_regex,
                 fail_regex=fail_regex,
             )
 
-            if passing_output is None:
+            if global_failure is not None:
+                msg = fail_message or f"ROCpd validation failed:\n{global_failure}"
+                if skip_on_fail:
+                    pytest.skip(msg)
+                else:
+                    pytest.fail(msg, pytrace=False)
+            elif passing_output is None:
                 output = "\n\n--- Next ROCpd candidate ---\n\n".join(failures)
                 msg = fail_message or f"ROCpd validation failed:\n{output}"
                 if skip_on_fail:
@@ -2465,18 +2471,23 @@ def _validate_rocpd_candidates(
     validate_candidate: Callable[[Path], ValidationResult],
     pass_regex: Optional[list[str]] = None,
     fail_regex: Optional[list[str]] = None,
-) -> tuple[Optional[str], list[str]]:
+) -> tuple[Optional[str], list[str], Optional[str]]:
     """Validate ROCpd candidates and return the first passing output.
 
     Multi-process runs can emit multiple ROCpd databases. Some rank-local
     databases may not contain the GPU rows required by a rule set, so the
-    validation succeeds if any emitted candidate fully validates.
+    validation succeeds if any emitted candidate fully validates. A fail regex
+    match is a global failure and stops validation immediately.
     """
     failures: list[str] = []
 
     for rocpd_file in rocpd_files:
         validation = validate_candidate(rocpd_file)
         output = f"Command: {validation.command}\n\n{validation.message}"
+        if fail_regex:
+            for pattern in fail_regex:
+                if re.search(pattern, validation.stdout):
+                    return None, failures, f"Fail regex found: {pattern}\n{output}"
         if not validation.is_valid:
             failures.append(output)
             continue
@@ -2487,18 +2498,13 @@ def _validate_rocpd_candidates(
                 if not re.search(pattern, validation.stdout):
                     regex_failure = f"Pass regex not found: {pattern}"
                     break
-        if regex_failure is None and fail_regex:
-            for pattern in fail_regex:
-                if re.search(pattern, validation.stdout):
-                    regex_failure = f"Fail regex found: {pattern}"
-                    break
         if regex_failure is not None:
             failures.append(f"{regex_failure}\n{output}")
             continue
 
-        return output, failures
+        return output, failures, None
 
-    return None, failures
+    return None, failures, None
 
 
 @pytest.fixture

--- a/projects/rocprofiler-systems/tests/pytest/conftest.py
+++ b/projects/rocprofiler-systems/tests/pytest/conftest.py
@@ -38,6 +38,7 @@ from rocprofsys import (
     get_target_gpu_arch,
     get_xnack_support,
     TestResult,
+    ValidationResult,
     validate_regex,
     validate_file_regex,
     validate_perfetto_trace,
@@ -2431,38 +2432,21 @@ def assert_rocpd(subtests, tests_dir, request):
                 if not existing_rules:
                     pytest.fail("No validation rules found")
 
-            failures = []
-            passing_output = None
-            for rocpd_file in rocpd_files:
-                validation = validate_rocpd_database(
+            def validate_candidate(rocpd_file: Path) -> ValidationResult:
+                return validate_rocpd_database(
                     rocpd_file,
                     tests_dir=tests_dir,
                     rules_files=existing_rules,
                     timeout=timeout,
                     gpu_category_to_skip=gpu_category_to_skip,
                 )
-                output = f"Command: {validation.command}\n\n{validation.message}"
-                if not validation.is_valid:
-                    failures.append(output)
-                    continue
 
-                regex_failure = None
-                if pass_regex:
-                    for pattern in pass_regex:
-                        if not re.search(pattern, validation.stdout):
-                            regex_failure = f"Pass regex not found: {pattern}"
-                            break
-                if regex_failure is None and fail_regex:
-                    for pattern in fail_regex:
-                        if re.search(pattern, validation.stdout):
-                            regex_failure = f"Fail regex found: {pattern}"
-                            break
-                if regex_failure is not None:
-                    failures.append(f"{regex_failure}\n{output}")
-                    continue
-
-                passing_output = output
-                break
+            passing_output, failures = _validate_rocpd_candidates(
+                rocpd_files,
+                validate_candidate,
+                pass_regex=pass_regex,
+                fail_regex=fail_regex,
+            )
 
             if passing_output is None:
                 output = "\n\n--- Next ROCpd candidate ---\n\n".join(failures)
@@ -2470,11 +2454,51 @@ def assert_rocpd(subtests, tests_dir, request):
                 if skip_on_fail:
                     pytest.skip(msg)
                 else:
-                    pytest.fail(msg)
-            output = passing_output
-            _print_subtest_output(request, subtest_name, output)
+                    pytest.fail(msg, pytrace=False)
+            _print_subtest_output(request, subtest_name, passing_output)
 
     return _assert_rocpd
+
+
+def _validate_rocpd_candidates(
+    rocpd_files: list[Path],
+    validate_candidate: Callable[[Path], ValidationResult],
+    pass_regex: Optional[list[str]] = None,
+    fail_regex: Optional[list[str]] = None,
+) -> tuple[Optional[str], list[str]]:
+    """Validate ROCpd candidates and return the first passing output.
+
+    Multi-process runs can emit multiple ROCpd databases. Some rank-local
+    databases may not contain the GPU rows required by a rule set, so the
+    validation succeeds if any emitted candidate fully validates.
+    """
+    failures: list[str] = []
+
+    for rocpd_file in rocpd_files:
+        validation = validate_candidate(rocpd_file)
+        output = f"Command: {validation.command}\n\n{validation.message}"
+        if not validation.is_valid:
+            failures.append(output)
+            continue
+
+        regex_failure = None
+        if pass_regex:
+            for pattern in pass_regex:
+                if not re.search(pattern, validation.stdout):
+                    regex_failure = f"Pass regex not found: {pattern}"
+                    break
+        if regex_failure is None and fail_regex:
+            for pattern in fail_regex:
+                if re.search(pattern, validation.stdout):
+                    regex_failure = f"Fail regex found: {pattern}"
+                    break
+        if regex_failure is not None:
+            failures.append(f"{regex_failure}\n{output}")
+            continue
+
+        return output, failures
+
+    return None, failures
 
 
 @pytest.fixture

--- a/projects/rocprofiler-systems/tests/pytest/conftest.py
+++ b/projects/rocprofiler-systems/tests/pytest/conftest.py
@@ -2421,8 +2421,8 @@ def assert_rocpd(subtests, tests_dir, request):
         with subtests.test(subtest_name):
             if not check_use_rocpd():
                 pytest.skip("ROCpd is disabled")
-            rocpd_file = result.rocpd_file
-            if rocpd_file is None:
+            rocpd_files = result.rocpd_files
+            if not rocpd_files:
                 pytest.fail("ROCpd database not created")
 
             existing_rules = None
@@ -2431,32 +2431,47 @@ def assert_rocpd(subtests, tests_dir, request):
                 if not existing_rules:
                     pytest.fail("No validation rules found")
 
-            validation = validate_rocpd_database(
-                rocpd_file,
-                tests_dir=tests_dir,
-                rules_files=existing_rules,
-                timeout=timeout,
-                gpu_category_to_skip=gpu_category_to_skip,
-            )
-            output = f"Command: {validation.command}\n\n{validation.message}"
-            if not validation.is_valid:
+            failures = []
+            passing_output = None
+            for rocpd_file in rocpd_files:
+                validation = validate_rocpd_database(
+                    rocpd_file,
+                    tests_dir=tests_dir,
+                    rules_files=existing_rules,
+                    timeout=timeout,
+                    gpu_category_to_skip=gpu_category_to_skip,
+                )
+                output = f"Command: {validation.command}\n\n{validation.message}"
+                if not validation.is_valid:
+                    failures.append(output)
+                    continue
+
+                regex_failure = None
+                if pass_regex:
+                    for pattern in pass_regex:
+                        if not re.search(pattern, validation.stdout):
+                            regex_failure = f"Pass regex not found: {pattern}"
+                            break
+                if regex_failure is None and fail_regex:
+                    for pattern in fail_regex:
+                        if re.search(pattern, validation.stdout):
+                            regex_failure = f"Fail regex found: {pattern}"
+                            break
+                if regex_failure is not None:
+                    failures.append(f"{regex_failure}\n{output}")
+                    continue
+
+                passing_output = output
+                break
+
+            if passing_output is None:
+                output = "\n\n--- Next ROCpd candidate ---\n\n".join(failures)
                 msg = fail_message or f"ROCpd validation failed:\n{output}"
                 if skip_on_fail:
                     pytest.skip(msg)
                 else:
                     pytest.fail(msg)
-            if pass_regex:
-                for pattern in pass_regex:
-                    if not re.search(pattern, validation.stdout):
-                        pytest.fail(
-                            f"Pass regex not found: {pattern}\n{output}", pytrace=False
-                        )
-            if fail_regex:
-                for pattern in fail_regex:
-                    if re.search(pattern, validation.stdout):
-                        pytest.fail(
-                            f"Fail regex found: {pattern}\n{output}", pytrace=False
-                        )
+            output = passing_output
             _print_subtest_output(request, subtest_name, output)
 
     return _assert_rocpd

--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/gpu.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/gpu.py
@@ -81,9 +81,10 @@ class GPUInfo:
 
         Returns glob patterns that match any device ID (0-9), since the device
         number in the filename depends on device_type_index which varies by
-        GPU topology.
+        GPU topology. The optional trailing suffix matches per-output indices
+        such as ``rocprof-device-0-SQ_WAVES-0.txt``.
         """
-        return [f"rocprof-device-[0-9]-{name}.txt" for name in self.counter_names]
+        return [f"rocprof-device-[0-9]-{name}*.txt" for name in self.counter_names]
 
 
 def get_rocminfo(rocm_path: Optional[Path] = None) -> Optional[Path]:

--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/runners.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/runners.py
@@ -66,6 +66,7 @@ class TestResult:
     extra_output: Optional[str] = None
     duration: Optional[float] = None
     _instrumented_files: list[Path] = field(default_factory=list)
+    __test__ = False
 
     @property
     def success(self) -> bool:
@@ -87,11 +88,6 @@ class TestResult:
                 return candidate
         protos = list(self.output_dir.glob("perfetto-trace*.proto"))
         return protos[0] if protos else None
-
-    @property
-    def rocpd_file(self) -> Optional[Path]:
-        files = self.rocpd_files
-        return files[0] if files else None
 
     @property
     def rocpd_files(self) -> list[Path]:

--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/runners.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/runners.py
@@ -90,12 +90,15 @@ class TestResult:
 
     @property
     def rocpd_file(self) -> Optional[Path]:
+        files = self.rocpd_files
+        return files[0] if files else None
+
+    @property
+    def rocpd_files(self) -> list[Path]:
         candidate = self.output_dir / "rocpd.db"
         if candidate.exists():
-            return candidate
-        # Try globbing
-        dbs = list(self.output_dir.glob("*.db"))
-        return dbs[0] if dbs else None
+            return [candidate]
+        return sorted(self.output_dir.glob("*.db"))
 
     @property
     def timemory_files(self) -> list[Path]:

--- a/projects/rocprofiler-systems/tests/pytest/test_pytest_impl.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_pytest_impl.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import pytest
 from conftest import RocprofsysTest, _validate_rocpd_candidates
-from rocprofsys import GPUInfo, TestResult, ValidationResult
+from rocprofsys import GPUInfo, TestResult as RocprofsysTestResult, ValidationResult
 
 pytestmark = [pytest.mark.pytest_impl]
 
@@ -81,10 +81,9 @@ class TestTestResult(RocprofsysTest):
         default_db.touch()
         rank_db.touch()
 
-        result = TestResult(0, "", tmp_path, [], {})
+        result = RocprofsysTestResult(0, "", tmp_path, [], {})
 
         assert result.rocpd_files == [default_db]
-        assert result.rocpd_file == default_db
 
     def test_rocpd_files_returns_sorted_rank_databases(self, tmp_path):
         higher_pid_db = tmp_path / "rocpd-66607-0.db"
@@ -92,10 +91,9 @@ class TestTestResult(RocprofsysTest):
         higher_pid_db.touch()
         lower_pid_db.touch()
 
-        result = TestResult(0, "", tmp_path, [], {})
+        result = RocprofsysTestResult(0, "", tmp_path, [], {})
 
         assert result.rocpd_files == [lower_pid_db, higher_pid_db]
-        assert result.rocpd_file == lower_pid_db
 
     def test_rocpd_candidates_accepts_later_valid_candidate(
         self,
@@ -123,7 +121,7 @@ class TestTestResult(RocprofsysTest):
                 command=f"validate {db_path.name}",
             )
 
-        passing_output, failures = _validate_rocpd_candidates(
+        passing_output, failures, global_failure = _validate_rocpd_candidates(
             [invalid_db, valid_db],
             validate_rocpd_database,
             pass_regex=[r"rocpd validated"],
@@ -131,6 +129,7 @@ class TestTestResult(RocprofsysTest):
 
         assert calls == [invalid_db, valid_db]
         assert passing_output == f"Command: validate {valid_db.name}\n\nvalid candidate"
+        assert global_failure is None
         assert failures == [
             f"Command: validate {invalid_db.name}\n\nmissing GPU counter rows"
         ]
@@ -152,13 +151,53 @@ class TestTestResult(RocprofsysTest):
                 command=f"validate {db_path.name}",
             )
 
-        passing_output, failures = _validate_rocpd_candidates(
+        passing_output, failures, global_failure = _validate_rocpd_candidates(
             [first_db, second_db],
             validate_rocpd_database,
         )
 
         assert passing_output is None
+        assert global_failure is None
         message = "\n\n--- Next ROCpd candidate ---\n\n".join(failures)
         assert "rocpd-66606-0.db is missing GPU counter rows" in message
         assert "rocpd-7-0.db is missing GPU counter rows" in message
         assert "--- Next ROCpd candidate ---" in message
+
+    def test_rocpd_candidates_fail_regex_is_global(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        invalid_db = tmp_path / "rocpd-66606-0.db"
+        valid_db = tmp_path / "rocpd-66607-0.db"
+        invalid_db.touch()
+        valid_db.touch()
+        calls: list[Path] = []
+
+        def validate_rocpd_database(db_path: Path) -> ValidationResult:
+            calls.append(db_path)
+            if db_path == invalid_db:
+                return ValidationResult(
+                    False,
+                    "invalid candidate",
+                    stdout="validation failed with FORBIDDEN marker",
+                    command=f"validate {db_path.name}",
+                )
+            return ValidationResult(
+                True,
+                "valid candidate",
+                stdout="rocpd validated",
+                command=f"validate {db_path.name}",
+            )
+
+        passing_output, failures, global_failure = _validate_rocpd_candidates(
+            [invalid_db, valid_db],
+            validate_rocpd_database,
+            fail_regex=[r"FORBIDDEN"],
+        )
+
+        assert calls == [invalid_db]
+        assert passing_output is None
+        assert failures == []
+        assert global_failure is not None
+        assert "Fail regex found: FORBIDDEN" in global_failure
+        assert f"validate {invalid_db.name}" in global_failure

--- a/projects/rocprofiler-systems/tests/pytest/test_pytest_impl.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_pytest_impl.py
@@ -6,9 +6,11 @@ Unit tests for GPU-specific test counter selection.
 """
 
 from __future__ import annotations
+from pathlib import Path
+
 import pytest
-from conftest import RocprofsysTest
-from rocprofsys import GPUInfo, TestResult
+from conftest import RocprofsysTest, _validate_rocpd_candidates
+from rocprofsys import GPUInfo, TestResult, ValidationResult
 
 pytestmark = [pytest.mark.pytest_impl]
 
@@ -94,3 +96,69 @@ class TestTestResult(RocprofsysTest):
 
         assert result.rocpd_files == [lower_pid_db, higher_pid_db]
         assert result.rocpd_file == lower_pid_db
+
+    def test_rocpd_candidates_accepts_later_valid_candidate(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        invalid_db = tmp_path / "rocpd-66606-0.db"
+        valid_db = tmp_path / "rocpd-66607-0.db"
+        invalid_db.touch()
+        valid_db.touch()
+        calls: list[Path] = []
+
+        def validate_rocpd_database(db_path: Path) -> ValidationResult:
+            calls.append(db_path)
+            if db_path == valid_db:
+                return ValidationResult(
+                    True,
+                    "valid candidate",
+                    stdout="rocpd validated",
+                    command=f"validate {db_path.name}",
+                )
+            return ValidationResult(
+                False,
+                "missing GPU counter rows",
+                stdout="validation failed",
+                command=f"validate {db_path.name}",
+            )
+
+        passing_output, failures = _validate_rocpd_candidates(
+            [invalid_db, valid_db],
+            validate_rocpd_database,
+            pass_regex=[r"rocpd validated"],
+        )
+
+        assert calls == [invalid_db, valid_db]
+        assert passing_output == f"Command: validate {valid_db.name}\n\nvalid candidate"
+        assert failures == [
+            f"Command: validate {invalid_db.name}\n\nmissing GPU counter rows"
+        ]
+
+    def test_rocpd_candidates_reports_all_candidate_failures(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        first_db = tmp_path / "rocpd-66606-0.db"
+        second_db = tmp_path / "rocpd-7-0.db"
+        first_db.touch()
+        second_db.touch()
+
+        def validate_rocpd_database(db_path: Path) -> ValidationResult:
+            return ValidationResult(
+                False,
+                f"{db_path.name} is missing GPU counter rows",
+                stdout="validation failed",
+                command=f"validate {db_path.name}",
+            )
+
+        passing_output, failures = _validate_rocpd_candidates(
+            [first_db, second_db],
+            validate_rocpd_database,
+        )
+
+        assert passing_output is None
+        message = "\n\n--- Next ROCpd candidate ---\n\n".join(failures)
+        assert "rocpd-66606-0.db is missing GPU counter rows" in message
+        assert "rocpd-7-0.db is missing GPU counter rows" in message
+        assert "--- Next ROCpd candidate ---" in message

--- a/projects/rocprofiler-systems/tests/pytest/test_pytest_impl.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_pytest_impl.py
@@ -8,7 +8,7 @@ Unit tests for GPU-specific test counter selection.
 from __future__ import annotations
 import pytest
 from conftest import RocprofsysTest
-from rocprofsys import GPUInfo
+from rocprofsys import GPUInfo, TestResult
 
 pytestmark = [pytest.mark.pytest_impl]
 
@@ -34,10 +34,10 @@ class TestGPUInfo(RocprofsysTest):
             "TX_VCA_VCA_BUSY",
         ]
         assert gpu_info.expected_counter_files == [
-            "rocprof-device-[0-9]-GRBM_COUNT.txt",
-            "rocprof-device-[0-9]-SQ_WAVES.txt",
-            "rocprof-device-[0-9]-SQ_INSTS_VALU.txt",
-            "rocprof-device-[0-9]-TX_VCA_VCA_BUSY.txt",
+            "rocprof-device-[0-9]-GRBM_COUNT*.txt",
+            "rocprof-device-[0-9]-SQ_WAVES*.txt",
+            "rocprof-device-[0-9]-SQ_INSTS_VALU*.txt",
+            "rocprof-device-[0-9]-TX_VCA_VCA_BUSY*.txt",
         ]
 
     def test_mi300_and_later_keep_ta_ta_busy(self):
@@ -69,3 +69,28 @@ class TestGPUInfo(RocprofsysTest):
 
         assert gpu_info.rocm_events_for_test == "SQ_WAVES"
         assert gpu_info.counter_names == ["SQ_WAVES"]
+
+
+@pytest.mark.class_name("test-result")
+class TestTestResult(RocprofsysTest):
+    def test_rocpd_files_prefers_default_database(self, tmp_path):
+        default_db = tmp_path / "rocpd.db"
+        rank_db = tmp_path / "rocpd-2-0.db"
+        default_db.touch()
+        rank_db.touch()
+
+        result = TestResult(0, "", tmp_path, [], {})
+
+        assert result.rocpd_files == [default_db]
+        assert result.rocpd_file == default_db
+
+    def test_rocpd_files_returns_sorted_rank_databases(self, tmp_path):
+        higher_pid_db = tmp_path / "rocpd-66607-0.db"
+        lower_pid_db = tmp_path / "rocpd-66606-0.db"
+        higher_pid_db.touch()
+        lower_pid_db.touch()
+
+        result = TestResult(0, "", tmp_path, [], {})
+
+        assert result.rocpd_files == [lower_pid_db, higher_pid_db]
+        assert result.rocpd_file == lower_pid_db


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
ROCProfiler counter validation tests were failing on gfx1250 even though the requested counters were available and counter output files were generated.
The failing tests were:
- `transpose-rocprofiler-sampling`
- `transpose-rocprofiler-binary-rewrite`
The runtime generated files such as:
- `rocprof-device-0-GRBM_COUNT-0.txt`
- `rocprof-device-0-SQ_WAVES-0.txt`
- `rocprof-device-0-SQ_INSTS_VALU-0.txt`
- `rocprof-device-0-TX_VCA_VCA_BUSY-0.txt`
but the pytest validation expected filenames without the trailing output index, for example:
- `rocprof-device-[0-9]-GRBM_COUNT.txt`
This caused a Systems-side validation failure even though the counter data was present.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Updated the ROCProfiler counter test harness to accept indexed counter output filenames by changing the expected glob from: rocprof-device-[0-9]-<counter>.txt
to:
rocprof-device-[0-9]-<counter>*.txt
Also made ROCpd validation more robust for MPI runs. MPI tests can emit multiple rank/process ROCpd databases. The validation now considers all emitted ROCpd DB candidates and passes if one validates, avoiding failures caused by selecting a rank DB that does not contain the GPU counter rows.

Updated lightweight pytest coverage for:
- gfx1250 expected counter file patterns
- deterministic ROCpd DB candidate discovery

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
JIRA ID - AIPROFSYST-590

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
gfx1250 targeted validation with public TheRock ROCm 7.15.0a20260630 and ROCprofiler-SDK 1.3.2:
ctest --test-dir build/public-gfx125x-rocm715 \
   -V -R '^(transpose-rocprofiler-sampling|transpose-rocprofiler-binary-rewrite|transpose-gpu-perf-counters)$' \
   --output-on-failure

## Test Result

<!-- Briefly summarize test outcomes. -->
gfx1250 targeted CTest passed:
- transpose-rocprofiler-sampling
- transpose-rocprofiler-binary-rewrite
- transpose-gpu-perf-counters

<img width="440" height="578" alt="image" src="https://github.com/user-attachments/assets/7a68ebea-4fc3-4cff-bafe-ff763ed75017" />

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
