### PR TITLE
[RCCL] Fix test_runner schema validation for fault_inject_ops_unit config

### DIFF
--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -302,7 +302,7 @@
     "net_ib_coverage_env": {
       "extends": "net_ib_base",
       "timeout": 300,
-      "_comment": "Coverage-oriented re-run of core transfer tests under alternate IB env. GID_INDEX=-1 forces RoCE GID auto-select (the auto-select path is skipped when a fixed index is pinned); PCI_RELAXED_ORDERING=0 exercises the relaxed-ordering-disabled registration/connect paths; ADAPTIVE_ROUTING=1 reaches the adaptive-routing threshold path. Env knobs are NIC-agnostic.",
+      "description": "Coverage-oriented re-run of core transfer tests under alternate IB env. GID_INDEX=-1 forces RoCE GID auto-select (the auto-select path is skipped when a fixed index is pinned); PCI_RELAXED_ORDERING=0 exercises the relaxed-ordering-disabled registration/connect paths; ADAPTIVE_ROUTING=1 reaches the adaptive-routing threshold path. Env knobs are NIC-agnostic.",
       "env_variables": {
         "NCCL_IB_GID_INDEX": "-1",
         "NCCL_IB_PCI_RELAXED_ORDERING": "0",
@@ -338,7 +338,7 @@
     "net_ib_merge_disabled": {
       "extends": "net_ib_base",
       "timeout": 60,
-      "_comment": "Exercises the makeVDevice merge-disabled guard, which only runs with NCCL_IB_MERGE_NICS=0 (the rest of the suite uses 1). Without this entry MakeVirtualDeviceMergeDisabled always GTEST_SKIPs in CI.",
+      "description": "Exercises the makeVDevice merge-disabled guard, which only runs with NCCL_IB_MERGE_NICS=0 (the rest of the suite uses 1). Without this entry MakeVirtualDeviceMergeDisabled always GTEST_SKIPs in CI.",
       "env_variables": {
         "NCCL_IB_MERGE_NICS": "0"
       },
@@ -353,7 +353,7 @@
     "net_ib_vnic_validation": {
       "extends": "net_ib_base",
       "timeout": 120,
-      "_comment": "makeVDevice / CheckVProps validation and topology error paths. WARN_RAIL_LOCAL=1 so the rail-local mismatch arm in DisjointMergeRailLocal_VNic is reachable. Topology-dependent cases (cross-NUMA, disjoint >=5-NIC merge) GTEST_SKIP when the hardware doesn't provide them.",
+      "description": "makeVDevice / CheckVProps validation and topology error paths. WARN_RAIL_LOCAL=1 so the rail-local mismatch arm in DisjointMergeRailLocal_VNic is reachable. Topology-dependent cases (cross-NUMA, disjoint >=5-NIC merge) GTEST_SKIP when the hardware doesn't provide them.",
       "env_variables": {
         "NCCL_IB_WARN_RAIL_LOCAL": "1"
       },
@@ -1142,7 +1142,7 @@
       "num_nodes": 1,
       "num_gpus": 1,
       "timeout": 60,
-      "_comment": "Pure-unit coverage of the ops-overload fault mechanism: a fake ibv_context drives the inner ncclIbOpsFault* guards and shim error paths directly. Single-rank (runs under the MPI launcher but uses no MPI communication, no RDMA, no hardware).",
+      "description": "Pure-unit coverage of the ops-overload fault mechanism: a fake ibv_context drives the inner ncclIbOpsFault* guards and shim error paths directly. Single-rank (runs under the MPI launcher but uses no MPI communication, no RDMA, no hardware).",
       "tests": [
         {
           "name": "FaultInj_OpsUnit_All",

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -1142,7 +1142,7 @@
       "num_nodes": 1,
       "num_gpus": 1,
       "timeout": 60,
-      "description": "Pure-unit coverage of the ops-overload fault mechanism: a fake ibv_context drives the inner ncclIbOpsFault* guards and shim error paths directly. Single-rank (runs under the MPI launcher but uses no MPI communication, no RDMA, no hardware).",
+      "_comment": "Pure-unit coverage of the ops-overload fault mechanism: a fake ibv_context drives the inner ncclIbOpsFault* guards and shim error paths directly. Single-rank (runs under the MPI launcher but uses no MPI communication, no RDMA, no hardware).",
       "tests": [
         {
           "name": "FaultInj_OpsUnit_All",

--- a/projects/rccl/tools/scripts/test_runner/lib/schema.json
+++ b/projects/rccl/tools/scripts/test_runner/lib/schema.json
@@ -269,9 +269,9 @@
           "type": "string",
           "description": "Shared base command-line arguments for this configuration. A test's own 'command_args' is appended to this base at execution time (see test_executor.run_test). Inherited via 'extends': a child that omits command_args takes the parent's value."
         },
-        "_comment": {
+        "description": {
           "type": "string",
-          "description": "Informal annotation for this configuration block (not interpreted by the runner)"
+          "description": "Human-readable description of this configuration block (not interpreted by the runner)"
         },
         "tests": {
           "type": "array",


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _Internal._

**What were the changes?**  
Renamed the config-level `description` key to `_comment` in the `fault_inject_ops_unit` block of `tools/scripts/test_runner/configs/mi300x_mellanox_ib.json`.

**Why were the changes made?**  
The test_runner validates every config against `tools/scripts/test_runner/lib/schema.json`, whose `test_configuration` definition sets `additionalProperties: false` and allows only `_comment` (not `description`) for annotations at the configuration level. The stray `description` key made `TestConfigProcessor._validate_schema` raise `ValueError` and abort before any test ran, which broke the code-coverage CI job on `develop` with: `test_configurations -> fault_inject_ops_unit: Additional properties are not allowed ('description' was unexpected)`.

**How was the outcome achieved?**  
`description` is a valid field on `test_item`, `test_suite`, and `system_configurations` objects, but not at the top level of a `test_configurations` entry. Renaming it to the schema-approved `_comment` keeps the annotation while satisfying the schema. The human-readable text is unchanged and is already duplicated on the matching `test_suites` entry, so nothing is lost.

**Additional Documentation:**  
The offending key was introduced in #7537 ("net-ib-cast: ops-fault unit harness"). No functional/runtime behavior changes; this is a config annotation-key rename only.

## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.

_CHANGELOG not applicable: no API, user-facing, or cross-library impact (test-runner config annotation only)._