### PR TITLE
[CLR] Enable staticCO to allow concurrent reads

### DIFF
--- a/projects/clr/hipamd/src/hip_code_object.cpp
+++ b/projects/clr/hipamd/src/hip_code_object.cpp
@@ -525,76 +525,77 @@ const char* StatCO::GetFuncName(const void* hostFunction) {
 }
 
 hipError_t StatCO::GetFunc(hipFunction_t* hfunc, const void* hostFunction, int deviceId) {
-  std::shared_lock<std::shared_mutex> lock(sclock_);
+  {
+    std::shared_lock<std::shared_mutex> lock(sclock_);
 
+    auto it = functions_.find(hostFunction);
+    if (it == functions_.end()) {
+      return hipErrorInvalidSymbol;
+    }
+
+    FatBinaryInfo** module = it->second->ModuleInfo();
+    if (module == nullptr) {
+      return hipErrorInvalidDeviceFunction;
+    }
+    if (*module != nullptr) {
+      return it->second->GetStatFunc(hfunc, deviceId);
+    }
+  }
+
+  // Lazy load: upgrade to exclusive lock.
+  std::unique_lock<std::shared_mutex> wlock(sclock_);
+  // Re-find after acquiring exclusive lock (concurrent removal may have occurred).
   auto it = functions_.find(hostFunction);
   if (it == functions_.end()) {
     return hipErrorInvalidSymbol;
   }
-
   FatBinaryInfo** module = it->second->ModuleInfo();
   if (module == nullptr) {
     return hipErrorInvalidDeviceFunction;
   }
-
   if (*module == nullptr) {
-    // Lazy load: upgrade to exclusive lock.
-    lock.unlock();
-    std::unique_lock<std::shared_mutex> wlock(sclock_);
-    // Re-find after acquiring exclusive lock (concurrent removal may have occurred).
-    it = functions_.find(hostFunction);
-    if (it == functions_.end()) {
-      return hipErrorInvalidSymbol;
+    hipError_t err = DigestFatBinary(module_to_hostModule_[module], *module);
+    if (err != hipSuccess) {
+      return err;
     }
-    module = it->second->ModuleInfo();
-    if (module == nullptr) {
-      return hipErrorInvalidDeviceFunction;
-    }
-    if (*module == nullptr) {
-      hipError_t err = DigestFatBinary(module_to_hostModule_[module], *module);
-      if (err != hipSuccess) {
-        return err;
-      }
-    }
-    return it->second->GetStatFunc(hfunc, deviceId);
   }
-
   return it->second->GetStatFunc(hfunc, deviceId);
 }
 
 hipError_t StatCO::GetFuncAttr(hipFuncAttributes* func_attr, const void* hostFunction,
                                int deviceId) {
-  std::shared_lock<std::shared_mutex> lock(sclock_);
+  {
+    std::shared_lock<std::shared_mutex> lock(sclock_);
 
+    auto it = functions_.find(hostFunction);
+    if (it == functions_.end()) {
+      return hipErrorInvalidSymbol;
+    }
+
+    FatBinaryInfo** module = it->second->ModuleInfo();
+    if (module == nullptr) {
+      return hipErrorInvalidDeviceFunction;
+    }
+
+    if (*module != nullptr) {
+      return it->second->GetStatFuncAttr(func_attr, deviceId);
+    }
+  }
+
+  // Lazy load: upgrade to exclusive lock.
+  std::unique_lock<std::shared_mutex> wlock(sclock_);
+  // Re-find after acquiring exclusive lock (concurrent removal may have occurred).
   auto it = functions_.find(hostFunction);
   if (it == functions_.end()) {
     return hipErrorInvalidSymbol;
   }
-
   FatBinaryInfo** module = it->second->ModuleInfo();
   if (module == nullptr) {
     return hipErrorInvalidDeviceFunction;
   }
-
   if (*module == nullptr) {
-    // Lazy load: upgrade to exclusive lock.
-    lock.unlock();
-    std::unique_lock<std::shared_mutex> wlock(sclock_);
-    // Re-find after acquiring exclusive lock (concurrent removal may have occurred).
-    it = functions_.find(hostFunction);
-    if (it == functions_.end()) {
-      return hipErrorInvalidSymbol;
-    }
-    module = it->second->ModuleInfo();
-    if (module == nullptr) {
-      return hipErrorInvalidDeviceFunction;
-    }
-    if (*module == nullptr) {
-      std::ignore = DigestFatBinary(module_to_hostModule_[module], *module);
-    }
-    return it->second->GetStatFuncAttr(func_attr, deviceId);
+    std::ignore = DigestFatBinary(module_to_hostModule_[module], *module);
   }
-
   return it->second->GetStatFuncAttr(func_attr, deviceId);
 }
 
@@ -613,58 +614,50 @@ hipError_t StatCO::RegisterGlobalVar(const void* hostVar, Var* var) {
 
 hipError_t StatCO::GetGlobalVar(const void* hostVar, int deviceId, hipDeviceptr_t* dev_ptr,
                                 size_t* size_ptr) {
-  std::shared_lock<std::shared_mutex> lock(sclock_);
+  {
+    std::shared_lock<std::shared_mutex> lock(sclock_);
 
+    auto it = vars_.find(hostVar);
+    if (it == vars_.end()) {
+      return hipErrorInvalidSymbol;
+    }
+
+    FatBinaryInfo** module = it->second->ModuleInfo();
+    if (module == nullptr) {
+      return hipErrorInvalidSymbol;
+    }
+
+    if (*module != nullptr) {
+      amd::Memory* mem = nullptr;
+      IHIP_RETURN_ONFAIL(it->second->GetStatDeviceVar(&mem, deviceId));
+
+      // Handle size-0 globals: return null device pointer and size 0.
+      *dev_ptr = (mem == nullptr) ? 0 : memDevPtr(mem);
+      *size_ptr = (mem == nullptr) ? 0 : mem->getSize();
+      return hipSuccess;
+    }
+  }
+
+  // Lazy load: upgrade to exclusive lock.
+  std::unique_lock<std::shared_mutex> wlock(sclock_);
+  // Re-find after acquiring exclusive lock (concurrent removal may have occurred).
   auto it = vars_.find(hostVar);
   if (it == vars_.end()) {
     return hipErrorInvalidSymbol;
   }
-
   FatBinaryInfo** module = it->second->ModuleInfo();
   if (module == nullptr) {
     return hipErrorInvalidSymbol;
   }
-
   if (*module == nullptr) {
-    // Lazy load: upgrade to exclusive lock.
-    lock.unlock();
-    std::unique_lock<std::shared_mutex> wlock(sclock_);
-    // Re-find after acquiring exclusive lock (concurrent removal may have occurred).
-    it = vars_.find(hostVar);
-    if (it == vars_.end()) {
-      return hipErrorInvalidSymbol;
-    }
-    module = it->second->ModuleInfo();
-    if (module == nullptr) {
-      return hipErrorInvalidSymbol;
-    }
-    if (*module == nullptr) {
-      std::ignore = DigestFatBinary(module_to_hostModule_[module], *module);
-    }
-    amd::Memory* mem = nullptr;
-    IHIP_RETURN_ONFAIL(it->second->GetStatDeviceVar(&mem, deviceId));
-    if (mem == nullptr) {
-      // Handle size-0 globals: return null device pointer and size 0.
-      *dev_ptr = 0;
-      *size_ptr = 0;
-      return hipSuccess;
-    }
-    *dev_ptr = memDevPtr(mem);
-    *size_ptr = mem->getSize();
-    return hipSuccess;
+    std::ignore = DigestFatBinary(module_to_hostModule_[module], *module);
   }
-
   amd::Memory* mem = nullptr;
   IHIP_RETURN_ONFAIL(it->second->GetStatDeviceVar(&mem, deviceId));
 
-  if (mem == nullptr) {
-    // Handle size-0 globals: return null device pointer and size 0.
-    *dev_ptr = 0;
-    *size_ptr = 0;
-    return hipSuccess;
-  }
-  *dev_ptr = memDevPtr(mem);
-  *size_ptr = mem->getSize();
+  // Handle size-0 globals: return null device pointer and size 0.
+  *dev_ptr = (mem == nullptr) ? 0 : memDevPtr(mem);
+  *size_ptr = (mem == nullptr) ? 0 : mem->getSize();
   return hipSuccess;
 }
 

--- a/projects/clr/hipamd/src/hip_code_object.cpp
+++ b/projects/clr/hipamd/src/hip_code_object.cpp
@@ -499,6 +499,26 @@ void StatCO::RemoveAllFatBinaries() {
   modules_.clear();
 }
 
+namespace {
+
+// Helper function finds entries and returns error codes
+template <typename MapT> hipError_t FindRegistered(MapT& map, const void* key,
+                                                   hipError_t notFoundErr, hipError_t badModuleErr,
+                                                   typename MapT::mapped_type& value,
+                                                   FatBinaryInfo**& module) {
+  auto it = map.find(key);
+  if (it == map.end()) {
+    return notFoundErr;
+  }
+  value = it->second;
+  module = value->ModuleInfo();
+  if (module == nullptr) {
+    return badModuleErr;
+  }
+  return hipSuccess;
+}
+}  // namespace
+
 hipError_t StatCO::RegisterFunction(const void* hostFunction, Function* func) {
   std::scoped_lock lock(sclock_);
 
@@ -525,78 +545,67 @@ const char* StatCO::GetFuncName(const void* hostFunction) {
 }
 
 hipError_t StatCO::GetFunc(hipFunction_t* hfunc, const void* hostFunction, int deviceId) {
+  Function* func = nullptr;
+  FatBinaryInfo** module = nullptr;
   {
     std::shared_lock<std::shared_mutex> lock(sclock_);
 
-    auto it = functions_.find(hostFunction);
-    if (it == functions_.end()) {
-      return hipErrorInvalidSymbol;
-    }
-
-    FatBinaryInfo** module = it->second->ModuleInfo();
-    if (module == nullptr) {
-      return hipErrorInvalidDeviceFunction;
+    hipError_t err = FindRegistered(functions_, hostFunction, hipErrorInvalidSymbol,
+                                    hipErrorInvalidDeviceFunction, func, module);
+    if (err != hipSuccess) {
+      return err;
     }
     if (*module != nullptr) {
-      return it->second->GetStatFunc(hfunc, deviceId);
+      return func->GetStatFunc(hfunc, deviceId);
     }
   }
 
   // Lazy load: upgrade to exclusive lock.
   std::unique_lock<std::shared_mutex> wlock(sclock_);
   // Re-find after acquiring exclusive lock (concurrent removal may have occurred).
-  auto it = functions_.find(hostFunction);
-  if (it == functions_.end()) {
-    return hipErrorInvalidSymbol;
-  }
-  FatBinaryInfo** module = it->second->ModuleInfo();
-  if (module == nullptr) {
-    return hipErrorInvalidDeviceFunction;
+  hipError_t err = FindRegistered(functions_, hostFunction, hipErrorInvalidSymbol,
+                                  hipErrorInvalidDeviceFunction, func, module);
+  if (err != hipSuccess) {
+    return err;
   }
   if (*module == nullptr) {
-    hipError_t err = DigestFatBinary(module_to_hostModule_[module], *module);
+    err = DigestFatBinary(module_to_hostModule_[module], *module);
     if (err != hipSuccess) {
       return err;
     }
   }
-  return it->second->GetStatFunc(hfunc, deviceId);
+  return func->GetStatFunc(hfunc, deviceId);
 }
 
 hipError_t StatCO::GetFuncAttr(hipFuncAttributes* func_attr, const void* hostFunction,
                                int deviceId) {
+  Function* func = nullptr;
+  FatBinaryInfo** module = nullptr;
   {
     std::shared_lock<std::shared_mutex> lock(sclock_);
 
-    auto it = functions_.find(hostFunction);
-    if (it == functions_.end()) {
-      return hipErrorInvalidSymbol;
+    hipError_t err = FindRegistered(functions_, hostFunction, hipErrorInvalidSymbol,
+                                    hipErrorInvalidDeviceFunction, func, module);
+    if (err != hipSuccess) {
+      return err;
     }
-
-    FatBinaryInfo** module = it->second->ModuleInfo();
-    if (module == nullptr) {
-      return hipErrorInvalidDeviceFunction;
-    }
-
     if (*module != nullptr) {
-      return it->second->GetStatFuncAttr(func_attr, deviceId);
+      return func->GetStatFuncAttr(func_attr, deviceId);
     }
   }
 
   // Lazy load: upgrade to exclusive lock.
   std::unique_lock<std::shared_mutex> wlock(sclock_);
   // Re-find after acquiring exclusive lock (concurrent removal may have occurred).
-  auto it = functions_.find(hostFunction);
-  if (it == functions_.end()) {
-    return hipErrorInvalidSymbol;
-  }
-  FatBinaryInfo** module = it->second->ModuleInfo();
-  if (module == nullptr) {
-    return hipErrorInvalidDeviceFunction;
+  hipError_t err = FindRegistered(functions_, hostFunction, hipErrorInvalidSymbol,
+                                  hipErrorInvalidDeviceFunction, func, module);
+  if (err != hipSuccess) {
+    return err;
   }
   if (*module == nullptr) {
     std::ignore = DigestFatBinary(module_to_hostModule_[module], *module);
   }
-  return it->second->GetStatFuncAttr(func_attr, deviceId);
+  return func->GetStatFuncAttr(func_attr, deviceId);
 }
 
 hipError_t StatCO::RegisterGlobalVar(const void* hostVar, Var* var) {
@@ -614,22 +623,19 @@ hipError_t StatCO::RegisterGlobalVar(const void* hostVar, Var* var) {
 
 hipError_t StatCO::GetGlobalVar(const void* hostVar, int deviceId, hipDeviceptr_t* dev_ptr,
                                 size_t* size_ptr) {
+  Var* var = nullptr;
+  FatBinaryInfo** module = nullptr;
   {
     std::shared_lock<std::shared_mutex> lock(sclock_);
 
-    auto it = vars_.find(hostVar);
-    if (it == vars_.end()) {
-      return hipErrorInvalidSymbol;
+    hipError_t err =
+        FindRegistered(vars_, hostVar, hipErrorInvalidSymbol, hipErrorInvalidSymbol, var, module);
+    if (err != hipSuccess) {
+      return err;
     }
-
-    FatBinaryInfo** module = it->second->ModuleInfo();
-    if (module == nullptr) {
-      return hipErrorInvalidSymbol;
-    }
-
     if (*module != nullptr) {
       amd::Memory* mem = nullptr;
-      IHIP_RETURN_ONFAIL(it->second->GetStatDeviceVar(&mem, deviceId));
+      IHIP_RETURN_ONFAIL(var->GetStatDeviceVar(&mem, deviceId));
 
       // Handle size-0 globals: return null device pointer and size 0.
       *dev_ptr = (mem == nullptr) ? 0 : memDevPtr(mem);
@@ -641,19 +647,16 @@ hipError_t StatCO::GetGlobalVar(const void* hostVar, int deviceId, hipDeviceptr_
   // Lazy load: upgrade to exclusive lock.
   std::unique_lock<std::shared_mutex> wlock(sclock_);
   // Re-find after acquiring exclusive lock (concurrent removal may have occurred).
-  auto it = vars_.find(hostVar);
-  if (it == vars_.end()) {
-    return hipErrorInvalidSymbol;
-  }
-  FatBinaryInfo** module = it->second->ModuleInfo();
-  if (module == nullptr) {
-    return hipErrorInvalidSymbol;
+  hipError_t err =
+      FindRegistered(vars_, hostVar, hipErrorInvalidSymbol, hipErrorInvalidSymbol, var, module);
+  if (err != hipSuccess) {
+    return err;
   }
   if (*module == nullptr) {
     std::ignore = DigestFatBinary(module_to_hostModule_[module], *module);
   }
   amd::Memory* mem = nullptr;
-  IHIP_RETURN_ONFAIL(it->second->GetStatDeviceVar(&mem, deviceId));
+  IHIP_RETURN_ONFAIL(var->GetStatDeviceVar(&mem, deviceId));
 
   // Handle size-0 globals: return null device pointer and size 0.
   *dev_ptr = (mem == nullptr) ? 0 : memDevPtr(mem);

--- a/projects/clr/hipamd/src/hip_code_object.cpp
+++ b/projects/clr/hipamd/src/hip_code_object.cpp
@@ -681,22 +681,23 @@ void StatCO::ResizeForDevices(size_t device_count) {
   for (const auto& it : functions_) {
     it.second->ResizeDFunc(device_count);
   }
-  managedVarsDevicePtrInitalized_ = std::make_unique<std::atomic<bool>[]>(device_count);
-  for (size_t i = 0; i < device_count; ++i) managedVarsDevicePtrInitalized_[i].store(false, std::memory_order_relaxed);
-  managedVarsDevicePtrInitalizedSize_ = device_count;
+  managedVarsDevicePtrInitialized_ = std::make_unique<std::atomic<bool>[]>(device_count);
+  for (size_t i = 0; i < device_count; ++i)
+    managedVarsDevicePtrInitialized_[i].store(false, std::memory_order_relaxed);
+  managedVarsDevicePtrInitializedSize_ = device_count;
 }
 
 // ================================================================================================
 hipError_t StatCO::InitManagedVarDevicePtr(int deviceId) {
   // FAST PATH (lock-free): already initialized for this device
-  if (deviceId >= 0 && static_cast<size_t>(deviceId) < managedVarsDevicePtrInitalizedSize_ &&
-      managedVarsDevicePtrInitalized_[deviceId].load(std::memory_order_acquire)) {
+  if (deviceId >= 0 && static_cast<size_t>(deviceId) < managedVarsDevicePtrInitializedSize_ &&
+      managedVarsDevicePtrInitialized_[deviceId].load(std::memory_order_acquire)) {
     return hipSuccess;
   }
   // SLOW PATH: acquire exclusive lock, re-check, then do init work
   std::unique_lock<std::shared_mutex> lock(sclock_);
-  if (deviceId >= 0 && static_cast<size_t>(deviceId) < managedVarsDevicePtrInitalizedSize_ &&
-      managedVarsDevicePtrInitalized_[deviceId].load(std::memory_order_relaxed)) {
+  if (deviceId >= 0 && static_cast<size_t>(deviceId) < managedVarsDevicePtrInitializedSize_ &&
+      managedVarsDevicePtrInitialized_[deviceId].load(std::memory_order_relaxed)) {
     return hipSuccess;
   }
   hipError_t err = hipSuccess;
@@ -721,8 +722,8 @@ hipError_t StatCO::InitManagedVarDevicePtr(int deviceId) {
                        mem->getSize(), hipMemcpyHostToDevice, *stream);
     }
   }
-  if (deviceId >= 0 && static_cast<size_t>(deviceId) < managedVarsDevicePtrInitalizedSize_) {
-    managedVarsDevicePtrInitalized_[deviceId].store(true, std::memory_order_release);
+  if (deviceId >= 0 && static_cast<size_t>(deviceId) < managedVarsDevicePtrInitializedSize_) {
+    managedVarsDevicePtrInitialized_[deviceId].store(true, std::memory_order_release);
   }
   return err;
 }

--- a/projects/clr/hipamd/src/hip_code_object.cpp
+++ b/projects/clr/hipamd/src/hip_code_object.cpp
@@ -634,13 +634,18 @@ hipError_t StatCO::GetGlobalVar(const void* hostVar, int deviceId, hipDeviceptr_
       return err;
     }
     if (*module != nullptr) {
+      // Read-only fast path: GetDeviceVarPtr only reads dMem_[deviceId], it does not lazily
+      // initialize it. Lazy init writes dMem_ and must run under the exclusive lock (see the
+      // slow path below), so it is not safe to call GetStatDeviceVar here under the shared lock.
       amd::Memory* mem = nullptr;
-      IHIP_RETURN_ONFAIL(var->GetStatDeviceVar(&mem, deviceId));
-
-      // Handle size-0 globals: return null device pointer and size 0.
-      *dev_ptr = (mem == nullptr) ? 0 : memDevPtr(mem);
-      *size_ptr = (mem == nullptr) ? 0 : mem->getSize();
-      return hipSuccess;
+      IHIP_RETURN_ONFAIL(var->GetDeviceVarPtr(&mem, deviceId));
+      if (mem != nullptr) {
+        *dev_ptr = memDevPtr(mem);
+        *size_ptr = mem->getSize();
+        return hipSuccess;
+      }
+      // mem == nullptr: either not yet initialized, or a size-0 global. Fall through to the
+      // exclusive-lock slow path, which lazily initializes dMem_ via GetStatDeviceVar.
     }
   }
 

--- a/projects/clr/hipamd/src/hip_code_object.cpp
+++ b/projects/clr/hipamd/src/hip_code_object.cpp
@@ -299,8 +299,6 @@ StatCO::~StatCO() {
 }
 
 hipError_t StatCO::DigestFatBinary(const void* data, FatBinaryInfo*& programs) {
-  std::scoped_lock lock(sclock_);
-
   if (programs != nullptr) {
     return hipSuccess;
   }
@@ -517,7 +515,7 @@ hipError_t StatCO::RegisterFunction(const void* hostFunction, Function* func) {
 }
 
 const char* StatCO::GetFuncName(const void* hostFunction) {
-  std::scoped_lock lock(sclock_);
+  std::shared_lock<std::shared_mutex> lock(sclock_);
 
   const auto it = functions_.find(hostFunction);
   if (it == functions_.end()) {
@@ -527,25 +525,38 @@ const char* StatCO::GetFuncName(const void* hostFunction) {
 }
 
 hipError_t StatCO::GetFunc(hipFunction_t* hfunc, const void* hostFunction, int deviceId) {
-  const auto it = functions_.find(hostFunction);
+  std::shared_lock<std::shared_mutex> lock(sclock_);
+
+  auto it = functions_.find(hostFunction);
   if (it == functions_.end()) {
     return hipErrorInvalidSymbol;
   }
 
-  // Lazy load
   FatBinaryInfo** module = it->second->ModuleInfo();
-  if (module != nullptr) {
-    std::scoped_lock lock(sclock_);
-    if (*(module) == nullptr) {
-      hipError_t err = DigestFatBinary(module_to_hostModule_[module], *module);
+  if (module == nullptr) {
+    return hipErrorInvalidDeviceFunction;
+  }
 
+  if (*module == nullptr) {
+    // Lazy load: upgrade to exclusive lock.
+    lock.unlock();
+    std::unique_lock<std::shared_mutex> wlock(sclock_);
+    // Re-find after acquiring exclusive lock (concurrent removal may have occurred).
+    it = functions_.find(hostFunction);
+    if (it == functions_.end()) {
+      return hipErrorInvalidSymbol;
+    }
+    module = it->second->ModuleInfo();
+    if (module == nullptr) {
+      return hipErrorInvalidDeviceFunction;
+    }
+    if (*module == nullptr) {
+      hipError_t err = DigestFatBinary(module_to_hostModule_[module], *module);
       if (err != hipSuccess) {
         return err;
       }
     }
-  } else {
-    // Module was nullptr
-    return hipErrorInvalidDeviceFunction;
+    return it->second->GetStatFunc(hfunc, deviceId);
   }
 
   return it->second->GetStatFunc(hfunc, deviceId);
@@ -553,17 +564,35 @@ hipError_t StatCO::GetFunc(hipFunction_t* hfunc, const void* hostFunction, int d
 
 hipError_t StatCO::GetFuncAttr(hipFuncAttributes* func_attr, const void* hostFunction,
                                int deviceId) {
-  std::scoped_lock lock(sclock_);
+  std::shared_lock<std::shared_mutex> lock(sclock_);
 
-  const auto it = functions_.find(hostFunction);
+  auto it = functions_.find(hostFunction);
   if (it == functions_.end()) {
     return hipErrorInvalidSymbol;
   }
 
-  // Lazy load
   FatBinaryInfo** module = it->second->ModuleInfo();
-  if (*(module) == nullptr) {
-    std::ignore = DigestFatBinary(module_to_hostModule_[module], *module);
+  if (module == nullptr) {
+    return hipErrorInvalidDeviceFunction;
+  }
+
+  if (*module == nullptr) {
+    // Lazy load: upgrade to exclusive lock.
+    lock.unlock();
+    std::unique_lock<std::shared_mutex> wlock(sclock_);
+    // Re-find after acquiring exclusive lock (concurrent removal may have occurred).
+    it = functions_.find(hostFunction);
+    if (it == functions_.end()) {
+      return hipErrorInvalidSymbol;
+    }
+    module = it->second->ModuleInfo();
+    if (module == nullptr) {
+      return hipErrorInvalidDeviceFunction;
+    }
+    if (*module == nullptr) {
+      std::ignore = DigestFatBinary(module_to_hostModule_[module], *module);
+    }
+    return it->second->GetStatFuncAttr(func_attr, deviceId);
   }
 
   return it->second->GetStatFuncAttr(func_attr, deviceId);
@@ -584,17 +613,45 @@ hipError_t StatCO::RegisterGlobalVar(const void* hostVar, Var* var) {
 
 hipError_t StatCO::GetGlobalVar(const void* hostVar, int deviceId, hipDeviceptr_t* dev_ptr,
                                 size_t* size_ptr) {
-  std::scoped_lock lock(sclock_);
+  std::shared_lock<std::shared_mutex> lock(sclock_);
 
-  const auto it = vars_.find(hostVar);
+  auto it = vars_.find(hostVar);
   if (it == vars_.end()) {
     return hipErrorInvalidSymbol;
   }
 
-  // Lazy load
   FatBinaryInfo** module = it->second->ModuleInfo();
-  if (*(module) == nullptr) {
-    std::ignore = DigestFatBinary(module_to_hostModule_[module], *module);
+  if (module == nullptr) {
+    return hipErrorInvalidSymbol;
+  }
+
+  if (*module == nullptr) {
+    // Lazy load: upgrade to exclusive lock.
+    lock.unlock();
+    std::unique_lock<std::shared_mutex> wlock(sclock_);
+    // Re-find after acquiring exclusive lock (concurrent removal may have occurred).
+    it = vars_.find(hostVar);
+    if (it == vars_.end()) {
+      return hipErrorInvalidSymbol;
+    }
+    module = it->second->ModuleInfo();
+    if (module == nullptr) {
+      return hipErrorInvalidSymbol;
+    }
+    if (*module == nullptr) {
+      std::ignore = DigestFatBinary(module_to_hostModule_[module], *module);
+    }
+    amd::Memory* mem = nullptr;
+    IHIP_RETURN_ONFAIL(it->second->GetStatDeviceVar(&mem, deviceId));
+    if (mem == nullptr) {
+      // Handle size-0 globals: return null device pointer and size 0.
+      *dev_ptr = 0;
+      *size_ptr = 0;
+      return hipSuccess;
+    }
+    *dev_ptr = memDevPtr(mem);
+    *size_ptr = mem->getSize();
+    return hipSuccess;
   }
 
   amd::Memory* mem = nullptr;
@@ -612,6 +669,7 @@ hipError_t StatCO::GetGlobalVar(const void* hostVar, int deviceId, hipDeviceptr_
 }
 
 hipError_t StatCO::RegisterManagedVar(Var* var) {
+  std::scoped_lock lock(sclock_);
   managedVars_[var->ModuleInfo()].push_back(var);
   return hipSuccess;
 }
@@ -630,43 +688,55 @@ void StatCO::ResizeForDevices(size_t device_count) {
   for (const auto& it : functions_) {
     it.second->ResizeDFunc(device_count);
   }
+  managedVarsDevicePtrInitalized_ = std::make_unique<std::atomic<bool>[]>(device_count);
+  for (size_t i = 0; i < device_count; ++i) managedVarsDevicePtrInitalized_[i].store(false, std::memory_order_relaxed);
+  managedVarsDevicePtrInitalizedSize_ = device_count;
 }
 
 // ================================================================================================
 hipError_t StatCO::InitManagedVarDevicePtr(int deviceId) {
-  std::scoped_lock lock(sclock_);
+  // FAST PATH (lock-free): already initialized for this device
+  if (deviceId >= 0 && static_cast<size_t>(deviceId) < managedVarsDevicePtrInitalizedSize_ &&
+      managedVarsDevicePtrInitalized_[deviceId].load(std::memory_order_acquire)) {
+    return hipSuccess;
+  }
+  // SLOW PATH: acquire exclusive lock, re-check, then do init work
+  std::unique_lock<std::shared_mutex> lock(sclock_);
+  if (deviceId >= 0 && static_cast<size_t>(deviceId) < managedVarsDevicePtrInitalizedSize_ &&
+      managedVarsDevicePtrInitalized_[deviceId].load(std::memory_order_relaxed)) {
+    return hipSuccess;
+  }
   hipError_t err = hipSuccess;
-  if (managedVarsDevicePtrInitalized_.find(deviceId) == managedVarsDevicePtrInitalized_.end() ||
-      !managedVarsDevicePtrInitalized_[deviceId]) {
-    for (auto& vecIter : managedVars_) {
-      for (auto& var : vecIter.second) {
-        // Lazy load
-        FatBinaryInfo** module = var->ModuleInfo();
-        if (*(module) == nullptr) {
-          std::ignore = DigestFatBinary(module_to_hostModule_[module], *module);
-        }
-        hip::Stream* stream = g_devices.at(deviceId)->NullStream();
-        if (stream == nullptr) {
-          ClPrint(amd::LOG_ERROR, amd::LOG_API, "Host Queue is NULL");
-          return hipErrorInvalidResourceHandle;
-        }
-        // Allocate managed var for deferred loading
-        IHIP_RETURN_ONFAIL(var->AllocateManagedVarPtr());
-        // Copy from managed var host to device ptr
-        amd::Memory* mem = nullptr;
-        IHIP_RETURN_ONFAIL(var->GetStatDeviceVar(&mem, deviceId));
-        err = ihipMemcpy(reinterpret_cast<address>(memDevPtr(mem)), var->GetManagedVarPtr(),
-                         mem->getSize(), hipMemcpyHostToDevice, *stream);
+  for (auto& vecIter : managedVars_) {
+    for (auto& var : vecIter.second) {
+      // Lazy load
+      FatBinaryInfo** module = var->ModuleInfo();
+      if (*(module) == nullptr) {
+        std::ignore = DigestFatBinary(module_to_hostModule_[module], *module);
       }
+      hip::Stream* stream = g_devices.at(deviceId)->NullStream();
+      if (stream == nullptr) {
+        ClPrint(amd::LOG_ERROR, amd::LOG_API, "Host Queue is NULL");
+        return hipErrorInvalidResourceHandle;
+      }
+      // Allocate managed var for deferred loading
+      IHIP_RETURN_ONFAIL(var->AllocateManagedVarPtr());
+      // Copy from managed var host to device ptr
+      amd::Memory* mem = nullptr;
+      IHIP_RETURN_ONFAIL(var->GetStatDeviceVar(&mem, deviceId));
+      err = ihipMemcpy(reinterpret_cast<address>(memDevPtr(mem)), var->GetManagedVarPtr(),
+                       mem->getSize(), hipMemcpyHostToDevice, *stream);
     }
-    managedVarsDevicePtrInitalized_[deviceId] = true;
+  }
+  if (deviceId >= 0 && static_cast<size_t>(deviceId) < managedVarsDevicePtrInitalizedSize_) {
+    managedVarsDevicePtrInitalized_[deviceId].store(true, std::memory_order_release);
   }
   return err;
 }
 
 // ================================================================================================
 Var* StatCO::FindDeferredManagedVar(const void* ptr) {
-  std::scoped_lock lock(sclock_);
+  std::shared_lock<std::shared_mutex> lock(sclock_);
   for (const auto& [_, vars] : managedVars_) {
     for (auto* var : vars) {
       void* base = *static_cast<void**>(var->GetManagedVarPtr());
@@ -678,7 +748,7 @@ Var* StatCO::FindDeferredManagedVar(const void* ptr) {
 
 // ================================================================================================
 void StatCO::ForEachFatBinaryBlob(void (*cb)(const void*)) const {
-  std::scoped_lock lock(sclock_);
+  std::shared_lock<std::shared_mutex> lock(sclock_);
   for (const auto& [data, _] : modules_) {
     cb(data);
   }

--- a/projects/clr/hipamd/src/hip_code_object.hpp
+++ b/projects/clr/hipamd/src/hip_code_object.hpp
@@ -214,8 +214,8 @@ class StatCO : public CodeObject {
   //! Reverse mapping of vars
   std::unordered_map<FatBinaryInfo**, std::vector<const void*> > module_to_hostVars_;
   //! Tracks managed var initialization per device
-  std::unique_ptr<std::atomic<bool>[]> managedVarsDevicePtrInitalized_;
-  size_t managedVarsDevicePtrInitalizedSize_ = 0;
+  std::unique_ptr<std::atomic<bool>[]> managedVarsDevicePtrInitialized_;
+  size_t managedVarsDevicePtrInitializedSize_ = 0;
 };
 
 };  // namespace hip

--- a/projects/clr/hipamd/src/hip_code_object.hpp
+++ b/projects/clr/hipamd/src/hip_code_object.hpp
@@ -9,7 +9,10 @@
 
 #include "hip_global.hpp"
 
+#include <atomic>
 #include <cstring>
+#include <memory>
+#include <shared_mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -163,7 +166,6 @@ class StatCO : public CodeObject {
   FatBinaryInfo** AddKpackBinary(const void* hipk_metadata, const void* wrapper_addr,
                                  bool& success);
   hipError_t RemoveFatBinary(FatBinaryInfo** module);
-  hipError_t DigestFatBinary(const void* data, FatBinaryInfo*& programs);
   void RemoveAllFatBinaries();
 
   // Register vars/funcs given to use from __hipRegister[Var/Func/ManagedVar]
@@ -192,7 +194,11 @@ class StatCO : public CodeObject {
   void ForEachFatBinaryBlob(void (*cb)(const void*)) const;
 
  private:
-  mutable std::recursive_mutex sclock_;    //!< Guards Static Code object
+  // Lock ordering: sclock_ is always acquired before FatBinaryLock, never the reverse.
+  mutable std::shared_mutex sclock_;       //!< Guards Static Code object
+
+  // Precondition: caller must hold sclock_ exclusively.
+  hipError_t DigestFatBinary(const void* data, FatBinaryInfo*& programs);
   const PlatformState& owner_;             //!< Reference to owning PlatformState
   //! Populated during __hipRegisterFatBinary
   std::unordered_map<const void*, FatBinaryInfo*> modules_;
@@ -208,7 +214,8 @@ class StatCO : public CodeObject {
   //! Reverse mapping of vars
   std::unordered_map<FatBinaryInfo**, std::vector<const void*> > module_to_hostVars_;
   //! Tracks managed var initialization per device
-  std::unordered_map<int, bool> managedVarsDevicePtrInitalized_;
+  std::unique_ptr<std::atomic<bool>[]> managedVarsDevicePtrInitalized_;
+  size_t managedVarsDevicePtrInitalizedSize_ = 0;
 };
 
 };  // namespace hip

--- a/projects/clr/hipamd/src/hip_global.cpp
+++ b/projects/clr/hipamd/src/hip_global.cpp
@@ -140,7 +140,7 @@ hipError_t Function::GetStatFuncAttr(hipFuncAttributes* func_attr, int deviceId)
   IHIP_RETURN_ONFAIL(GetStatFunc(&hfunc, deviceId));
 
   const std::vector<amd::Device*>& devices = amd::Device::getDevices(CL_DEVICE_TYPE_GPU, false);
-  amd::Kernel* kernel = dFunc_[deviceId].load(std::memory_order_acquire);
+  amd::Kernel* kernel = asKernel(hfunc);
   auto* device_handle = devices[deviceId];
   const device::Kernel::WorkGroupInfo* wginfo =
       kernel->getDeviceKernel(*device_handle)->workGroupInfo();

--- a/projects/clr/hipamd/src/hip_global.cpp
+++ b/projects/clr/hipamd/src/hip_global.cpp
@@ -45,16 +45,29 @@ hipError_t ihipMallocManaged(void** ptr, size_t size, size_t align = 0, bool use
 // ================================================================================================
 Function::Function(const std::string& name, FatBinaryInfo** modules)
     : name_(name), modules_(modules) {
-  dFunc_.resize(g_devices.size());
+  dFuncSize_ = g_devices.size();
+  dFunc_ = std::make_unique<std::atomic<amd::Kernel*>[]>(dFuncSize_);
+  for (size_t i = 0; i < dFuncSize_; ++i) dFunc_[i].store(nullptr, std::memory_order_relaxed);
 }
 
 // ================================================================================================
 Function::~Function() {
-  for (auto& kernel : dFunc_) {
-    if (kernel != nullptr) {
-      kernel->release();
-    }
+  for (size_t i = 0; i < dFuncSize_; ++i) {
+    amd::Kernel* k = dFunc_[i].load(std::memory_order_relaxed);
+    if (k != nullptr) k->release();
   }
+}
+
+// ================================================================================================
+void Function::ResizeDFunc(size_t size) {
+  auto newArr = std::make_unique<std::atomic<amd::Kernel*>[]>(size);
+  size_t copyCount = (size < dFuncSize_) ? size : dFuncSize_;
+  for (size_t i = 0; i < copyCount; ++i)
+    newArr[i].store(dFunc_[i].load(std::memory_order_relaxed), std::memory_order_relaxed);
+  for (size_t i = copyCount; i < size; ++i)
+    newArr[i].store(nullptr, std::memory_order_relaxed);
+  dFunc_ = std::move(newArr);
+  dFuncSize_ = size;
 }
 
 // ================================================================================================
@@ -67,40 +80,45 @@ amd::Kernel* Function::BuildKernel(hipModule_t hmod) const {
 
 // ================================================================================================
 hipError_t Function::GetDynFunc(hipFunction_t* hfunc, hipModule_t hmod) {
-  guarantee((dFunc_.size() == g_devices.size()), "dFunc Size mismatch");
+  guarantee((dFuncSize_ == g_devices.size()), "dFunc Size mismatch");
   int dev = ihipGetDevice();
-  if (dFunc_[dev] == nullptr) {
-    dFunc_[dev] = BuildKernel(hmod);
+  amd::Kernel* k = dFunc_[dev].load(std::memory_order_acquire);
+  if (k == nullptr) {
+    k = BuildKernel(hmod);
+    dFunc_[dev].store(k, std::memory_order_release);
   }
-  *hfunc = asHipFunction(dFunc_[dev]);
+  *hfunc = asHipFunction(k);
   return hipSuccess;
 }
 
 // ================================================================================================
 bool Function::IsValidDynFunc(const void* hfunc) {
-  return (hfunc == asHipFunction(dFunc_[ihipGetDevice()]));
+  return (hfunc == asHipFunction(dFunc_[ihipGetDevice()].load(std::memory_order_acquire)));
 }
 
 // ================================================================================================
 hipError_t Function::GetStatFunc(hipFunction_t* hfunc, int deviceId) {
-  if (deviceId >= static_cast<int>(dFunc_.size())) {
+  if (deviceId >= static_cast<int>(dFuncSize_)) {
     return hipErrorNoBinaryForGpu;
   }
-  if (dFunc_[deviceId] != nullptr) {
-    *hfunc = asHipFunction(dFunc_[deviceId]);
+  amd::Kernel* k = dFunc_[deviceId].load(std::memory_order_acquire);
+  if (k != nullptr) {
+    *hfunc = asHipFunction(k);
     return hipSuccess;
   }
   std::scoped_lock lock((*modules_)->FatBinaryLock());
   // Check again after acquiring lock — another thread may have built it
-  if (dFunc_[deviceId] != nullptr) {
-    *hfunc = asHipFunction(dFunc_[deviceId]);
+  k = dFunc_[deviceId].load(std::memory_order_acquire);
+  if (k != nullptr) {
+    *hfunc = asHipFunction(k);
     return hipSuccess;
   }
   hipModule_t hmod = nullptr;
   IHIP_RETURN_ONFAIL((*modules_)->BuildProgram(deviceId));
   IHIP_RETURN_ONFAIL((*modules_)->GetModule(deviceId, &hmod));
-  dFunc_[deviceId] = BuildKernel(hmod);
-  *hfunc = asHipFunction(dFunc_[deviceId]);
+  amd::Kernel* built = BuildKernel(hmod);
+  dFunc_[deviceId].store(built, std::memory_order_release);
+  *hfunc = asHipFunction(built);
   return hipSuccess;
 }
 
@@ -114,7 +132,7 @@ hipError_t Function::GetStatFuncAttr(hipFuncAttributes* func_attr, int deviceId)
   IHIP_RETURN_ONFAIL(GetStatFunc(&hfunc, deviceId));
 
   const std::vector<amd::Device*>& devices = amd::Device::getDevices(CL_DEVICE_TYPE_GPU, false);
-  amd::Kernel* kernel = dFunc_[deviceId];
+  amd::Kernel* kernel = dFunc_[deviceId].load(std::memory_order_acquire);
   auto* device_handle = devices[deviceId];
   const device::Kernel::WorkGroupInfo* wginfo =
       kernel->getDeviceKernel(*device_handle)->workGroupInfo();

--- a/projects/clr/hipamd/src/hip_global.cpp
+++ b/projects/clr/hipamd/src/hip_global.cpp
@@ -87,12 +87,12 @@ hipError_t Function::GetDynFunc(hipFunction_t* hfunc, hipModule_t hmod) {
     // Compare and swap as two threads could race to build the kernel
     amd::Kernel* built_kernel = BuildKernel(hmod);
     amd::Kernel* expected = nullptr;
-    if (!dFunc_[dev].compare_exchange_strong(expected, built, std::memory_order_release,
+    if (!dFunc_[dev].compare_exchange_strong(expected, built_kernel, std::memory_order_release,
                                              std::memory_order_acquire)) {
-      built->release();
-      k = expected
+      built_kernel->release();
+      k = expected;
     } else {
-      k = built;
+      k = built_kernel;
     }
   }
   *hfunc = asHipFunction(k);

--- a/projects/clr/hipamd/src/hip_global.cpp
+++ b/projects/clr/hipamd/src/hip_global.cpp
@@ -84,8 +84,15 @@ hipError_t Function::GetDynFunc(hipFunction_t* hfunc, hipModule_t hmod) {
   int dev = ihipGetDevice();
   amd::Kernel* k = dFunc_[dev].load(std::memory_order_acquire);
   if (k == nullptr) {
-    k = BuildKernel(hmod);
-    dFunc_[dev].store(k, std::memory_order_release);
+    amd::kernel* built_kernel = BuildKernel(hmod);
+    amd::kernel* expected = nullptr;
+    if (!dFunc_[dev].compare_exchange_strong(expected, built, std::memory_order_release,
+                                             std::memory_order_acquire)) {
+      built->release();
+      k = expected
+    } else {
+      k = built;
+    }
   }
   *hfunc = asHipFunction(k);
   return hipSuccess;

--- a/projects/clr/hipamd/src/hip_global.cpp
+++ b/projects/clr/hipamd/src/hip_global.cpp
@@ -84,8 +84,9 @@ hipError_t Function::GetDynFunc(hipFunction_t* hfunc, hipModule_t hmod) {
   int dev = ihipGetDevice();
   amd::Kernel* k = dFunc_[dev].load(std::memory_order_acquire);
   if (k == nullptr) {
-    amd::kernel* built_kernel = BuildKernel(hmod);
-    amd::kernel* expected = nullptr;
+    // Compare and swap as two threads could race to build the kernel
+    amd::Kernel* built_kernel = BuildKernel(hmod);
+    amd::Kernel* expected = nullptr;
     if (!dFunc_[dev].compare_exchange_strong(expected, built, std::memory_order_release,
                                              std::memory_order_acquire)) {
       built->release();

--- a/projects/clr/hipamd/src/hip_global.hpp
+++ b/projects/clr/hipamd/src/hip_global.hpp
@@ -7,6 +7,8 @@
 #ifndef HIP_GLOBAL_HPP
 #define HIP_GLOBAL_HPP
 
+#include <atomic>
+#include <memory>
 #include <vector>
 #include <string>
 
@@ -41,14 +43,15 @@ class Function {
   bool IsValidDynFunc(const void* hfunc);
   hipError_t GetStatFunc(hipFunction_t* hfunc, int deviceId);
   hipError_t GetStatFuncAttr(hipFuncAttributes* func_attr, int deviceId);
-  void ResizeDFunc(size_t size) { dFunc_.resize(size); }
+  void ResizeDFunc(size_t size);
   FatBinaryInfo** ModuleInfo() { return modules_; }
   const std::string& GetName() const { return name_; }
 
  private:
   amd::Kernel* BuildKernel(hipModule_t hmod) const;
 
-  std::vector<amd::Kernel*> dFunc_;  //!< Per-device kernel objects; index matches g_devices
+  std::unique_ptr<std::atomic<amd::Kernel*>[]> dFunc_;  //!< Per-device kernel objects; index matches g_devices
+  size_t dFuncSize_ = 0;
   std::string name_;                 //!< Symbol name for kernel lookup in the program
   FatBinaryInfo** modules_;          //!< Owning fat binary; nullptr for dynamic COs
 };

--- a/projects/hip-tests/catch/config/configs/unit/dynamicLoading.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/dynamicLoading.yaml
@@ -1,5 +1,8 @@
 ---
 dynamicLoading:
+  Unit_StatCO_ConcurrentDlopenDlcloseWhileLaunching:
+    <<: *level_2
+    tags: [module]
   Unit_dynamic_loading_device_kernels_from_library:
     <<: *level_2
     # Rock_Linux_Failures_on_gfx94X

--- a/projects/hip-tests/catch/config/configs/unit/module.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/module.yaml
@@ -1,5 +1,8 @@
 ---
 module:
+  Unit_StatCO_ManagedVarConcurrentFirstTouch_InChildProcess:
+    <<: *level_2
+    tags: [module]
   Unit_hipModuleLaunchCooperativeKernel_Positive_Basic:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151

--- a/projects/hip-tests/catch/unit/dynamicLoading/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/dynamicLoading/CMakeLists.txt
@@ -5,6 +5,7 @@
 if(UNIX AND BUILD_SHARED_LIBS)
   set(TEST_SRC ${TEST_SRC}
       complex_loading_behavior.cc
+      concurrentDynamicLoad.cc
       hipApiDynamicLoad.cc
       hipGetProcAddress.cc
       hipGetProcAddressCompilerOption.cc)

--- a/projects/hip-tests/catch/unit/dynamicLoading/concurrentDynamicLoad.cc
+++ b/projects/hip-tests/catch/unit/dynamicLoading/concurrentDynamicLoad.cc
@@ -5,6 +5,7 @@
  */
 
 #include <hip_test_common.hh>
+#include <resource_guards.hh>
 #include <dlfcn.h>
 #include <pthread.h>
 #include <atomic>
@@ -88,23 +89,20 @@ struct WorkerCtx {
 static void* worker_fn(void* arg) {
   WorkerCtx* ctx = static_cast<WorkerCtx*>(arg);
 
+  if (hipSetDevice(0) != hipSuccess) {
+    g_failure.store(true);
+    return nullptr;
+  }
+
   const int n = ctx->n;
   const size_t nbytes = static_cast<size_t>(n) * sizeof(int);
 
-  /* Allocate per-thread device and host buffers. */
-  int* d_data = nullptr;
-  int* h_in = new int[n];
-  int* h_out = new int[n];
-
+  /* Per-thread RAII-managed host and device buffers. */
+  std::vector<int> h_in(n);
+  std::vector<int> h_out(n);
   for (int i = 0; i < n; ++i) h_in[i] = i;
 
-  hipError_t err = hipMalloc(reinterpret_cast<void**>(&d_data), nbytes);
-  if (err != hipSuccess) {
-    g_failure.store(true);
-    delete[] h_in;
-    delete[] h_out;
-    return nullptr;
-  }
+  LinearAllocGuard<int> d_data(LinearAllocs::hipMalloc, nbytes);
 
   /* Wait until all threads are ready to maximise contention. */
   pthread_barrier_wait(ctx->barrier);
@@ -114,15 +112,28 @@ static void* worker_fn(void* arg) {
 
   for (int iter = 0; iter < ctx->iters && !g_failure.load(); ++iter) {
     /* Reset device buffer to known input. */
-    (void)hipMemcpy(d_data, h_in, nbytes, hipMemcpyHostToDevice);
+    if (hipMemcpy(d_data.ptr(), h_in.data(), nbytes, hipMemcpyHostToDevice) != hipSuccess) {
+      g_failure.store(true);
+      break;
+    }
 
     /* Launch the kernel from THIS file's module (StatCO::GetFunc lookup). */
-    hipLaunchKernelGGL(increment_kernel, dim3(blocks), dim3(threadsPerBlock),
-                       0, 0, d_data, n);
-    (void)hipDeviceSynchronize();
+    hipLaunchKernelGGL(increment_kernel, dim3(blocks), dim3(threadsPerBlock), 0, 0, d_data.ptr(),
+                       n);
+    if (hipGetLastError() != hipSuccess) {
+      g_failure.store(true);
+      break;
+    }
+    if (hipDeviceSynchronize() != hipSuccess) {
+      g_failure.store(true);
+      break;
+    }
 
     /* Copy result back and validate. */
-    (void)hipMemcpy(h_out, d_data, nbytes, hipMemcpyDeviceToHost);
+    if (hipMemcpy(h_out.data(), d_data.ptr(), nbytes, hipMemcpyDeviceToHost) != hipSuccess) {
+      g_failure.store(true);
+      break;
+    }
 
     for (int i = 0; i < n; ++i) {
       if (h_out[i] != h_in[i] + 1) {
@@ -132,9 +143,6 @@ static void* worker_fn(void* arg) {
     }
   }
 
-  (void)hipFree(d_data);
-  delete[] h_in;
-  delete[] h_out;
   return nullptr;
 }
 

--- a/projects/hip-tests/catch/unit/dynamicLoading/concurrentDynamicLoad.cc
+++ b/projects/hip-tests/catch/unit/dynamicLoading/concurrentDynamicLoad.cc
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <hip_test_common.hh>
+#include <dlfcn.h>
+#include <pthread.h>
+#include <atomic>
+#include <thread>
+#include <vector>
+
+/**
+ * @addtogroup hipLaunchKernelGGL
+ * @{
+ * @ingroup DynamicLoading
+ */
+
+/**
+ * Test Description
+ * ------------------------
+ * - Stress-tests the thread-safety of the HIP runtime's StatCO class by
+ *   racing concurrent kernel launches (StatCO::GetFunc -> functions_.find)
+ *   against concurrent module unloads (StatCO::RemoveFatBinary ->
+ *   functions_.erase) triggered by dlopen/dlclose of libLazyLoad.so.
+ *
+ *   Worker threads repeatedly launch THIS file's own kernel (which belongs
+ *   to the main module, never removed during the test), so every kernel
+ *   launch exercises functions_.find.  Churner threads repeatedly
+ *   dlopen("./libLazyLoad.so") and dlclose it; the dlclose runs the
+ *   library's static destructors -> __hipUnregisterFatBinary ->
+ *   StatCO::RemoveFatBinary, which calls functions_.erase on the library's
+ *   entry.  The race between find and erase on the shared functions_ map
+ *   (and its surrounding lock, if any) is what this test is designed to
+ *   expose.
+ *
+ *   A pthread_barrier_t is used (C++17 lacks std::barrier) to release all
+ *   threads simultaneously, maximising contention.
+ *
+ *   The test is bounded (300 worker launch iterations, 40 churner dlopen/dlclose
+ *   cycles), uses a single GPU
+ *   (device 0), and is safe to run in normal CI.  Each worker allocates
+ *   its own device/host buffers, so there are no cross-thread data races
+ *   on user buffers.
+ *
+ *   In plain CI (without ThreadSanitizer) the test primarily catches
+ *   crashes, use-after-free, hangs (deadlock), and incorrect kernel output.
+ *   Full data-race detection requires re-running with TSAN enabled.
+ *
+ * Test source
+ * ------------------------
+ * - catch/unit/dynamicLoading/concurrentDynamicLoad.cc
+ *
+ * Test requirements
+ * ------------------------
+ * - HIP_VERSION >= 5.6
+ */
+
+/* ---------------------------------------------------------------------------
+ * Kernel owned by THIS translation unit (main module – never unloaded).
+ * Workers launch this kernel; only churners dlclose libLazyLoad.so.
+ * ---------------------------------------------------------------------------*/
+__global__ static void increment_kernel(int* data, int n) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < n) {
+    data[idx] += 1;
+  }
+}
+
+/* ---------------------------------------------------------------------------
+ * Shared failure flag set by any thread that detects wrong output.
+ * ---------------------------------------------------------------------------*/
+static std::atomic<bool> g_failure{false};
+
+/* ---------------------------------------------------------------------------
+ * Per-worker context: owns its own device/host buffers.
+ * ---------------------------------------------------------------------------*/
+struct WorkerCtx {
+  pthread_barrier_t* barrier;
+  int n;
+  int iters;
+};
+
+/* ---------------------------------------------------------------------------
+ * Worker thread: launch THIS file's kernel and validate output.
+ * ---------------------------------------------------------------------------*/
+static void* worker_fn(void* arg) {
+  WorkerCtx* ctx = static_cast<WorkerCtx*>(arg);
+
+  const int n = ctx->n;
+  const size_t nbytes = static_cast<size_t>(n) * sizeof(int);
+
+  /* Allocate per-thread device and host buffers. */
+  int* d_data = nullptr;
+  int* h_in = new int[n];
+  int* h_out = new int[n];
+
+  for (int i = 0; i < n; ++i) h_in[i] = i;
+
+  hipError_t err = hipMalloc(reinterpret_cast<void**>(&d_data), nbytes);
+  if (err != hipSuccess) {
+    g_failure.store(true);
+    delete[] h_in;
+    delete[] h_out;
+    return nullptr;
+  }
+
+  /* Wait until all threads are ready to maximise contention. */
+  pthread_barrier_wait(ctx->barrier);
+
+  const int threadsPerBlock = 256;
+  const int blocks = (n + threadsPerBlock - 1) / threadsPerBlock;
+
+  for (int iter = 0; iter < ctx->iters && !g_failure.load(); ++iter) {
+    /* Reset device buffer to known input. */
+    (void)hipMemcpy(d_data, h_in, nbytes, hipMemcpyHostToDevice);
+
+    /* Launch the kernel from THIS file's module (StatCO::GetFunc lookup). */
+    hipLaunchKernelGGL(increment_kernel, dim3(blocks), dim3(threadsPerBlock),
+                       0, 0, d_data, n);
+    (void)hipDeviceSynchronize();
+
+    /* Copy result back and validate. */
+    (void)hipMemcpy(h_out, d_data, nbytes, hipMemcpyDeviceToHost);
+
+    for (int i = 0; i < n; ++i) {
+      if (h_out[i] != h_in[i] + 1) {
+        g_failure.store(true);
+        break;
+      }
+    }
+  }
+
+  (void)hipFree(d_data);
+  delete[] h_in;
+  delete[] h_out;
+  return nullptr;
+}
+
+/* ---------------------------------------------------------------------------
+ * Churner context: owns iteration count and barrier pointer.
+ * ---------------------------------------------------------------------------*/
+struct ChurnerCtx {
+  pthread_barrier_t* barrier;
+  int iters;
+  std::atomic<int>* dlopen_success_count;
+};
+
+/* ---------------------------------------------------------------------------
+ * Churner thread: dlopen/dlclose libLazyLoad.so repeatedly.
+ * The dlclose triggers __hipUnregisterFatBinary -> StatCO::RemoveFatBinary
+ * (functions_.erase), racing against the workers' functions_.find calls.
+ * ---------------------------------------------------------------------------*/
+static void* churner_fn(void* arg) {
+  ChurnerCtx* ctx = static_cast<ChurnerCtx*>(arg);
+
+  /* Wait for all threads to be ready. */
+  pthread_barrier_wait(ctx->barrier);
+
+  for (int iter = 0; iter < ctx->iters; ++iter) {
+    void* handle = dlopen("./libLazyLoad.so", RTLD_LAZY);
+    if (!handle) {
+      /* dlopen can transiently fail (e.g., another churner holds the
+       * linker lock).  Log but do not hard-fail the test. */
+      continue;
+    }
+
+    ctx->dlopen_success_count->fetch_add(1);
+
+    void* sym = dlsym(handle, "lazyLoad");
+    if (sym) {
+      int (*fp)() = reinterpret_cast<int (*)()>(sym);
+      /* We do not assert on the return value here; the purpose of the
+       * call is just to exercise the registered fat binary path before
+       * dlclose triggers removal. */
+      (void)fp();
+    }
+
+    /* dlclose -> static destructors -> __hipUnregisterFatBinary ->
+     * StatCO::RemoveFatBinary: this is the racing erase. */
+    dlclose(handle);
+  }
+
+  return nullptr;
+}
+
+/* ---------------------------------------------------------------------------
+ * Test case
+ * ---------------------------------------------------------------------------*/
+HIP_TEST_CASE(Unit_StatCO_ConcurrentDlopenDlcloseWhileLaunching) {
+  HIPCHECK(hipSetDevice(0));
+
+  constexpr int kWorkers = 4;
+  constexpr int kChurners = 2;
+  constexpr int kTotalThreads = kWorkers + kChurners;
+  /* Worker launches are cheap (kernel launch + sync), so iterate many times to
+   * keep the functions_.find load high. Churner cycles each do a full dlopen ->
+   * fat-binary digest/kernel-build -> dlclose, which is expensive, so they are
+   * bounded to a much smaller count to keep CI runtime sane. The race is
+   * exercised on every churn cycle (each one erases the lib's funcs while the
+   * workers are finding), so a few dozen cycles still gives strong coverage. */
+  constexpr int kWorkerIters = 300;
+  constexpr int kChurnerIters = 40;
+  constexpr int kN = 1024;  /* Small buffer; latency matters, not bandwidth. */
+
+  g_failure.store(false);
+
+  pthread_barrier_t barrier;
+  REQUIRE(pthread_barrier_init(&barrier, nullptr,
+                               static_cast<unsigned>(kTotalThreads)) == 0);
+
+  std::atomic<int> dlopen_success_count{0};
+
+  /* Build contexts. */
+  std::vector<WorkerCtx> wctx(kWorkers);
+  for (int i = 0; i < kWorkers; ++i) {
+    wctx[i].barrier = &barrier;
+    wctx[i].n = kN;
+    wctx[i].iters = kWorkerIters;
+  }
+
+  std::vector<ChurnerCtx> cctx(kChurners);
+  for (int i = 0; i < kChurners; ++i) {
+    cctx[i].barrier = &barrier;
+    cctx[i].iters = kChurnerIters;
+    cctx[i].dlopen_success_count = &dlopen_success_count;
+  }
+
+  /* Spawn all threads. */
+  std::vector<pthread_t> tids(kTotalThreads);
+
+  for (int i = 0; i < kWorkers; ++i) {
+    REQUIRE(pthread_create(&tids[i], nullptr, worker_fn, &wctx[i]) == 0);
+  }
+  for (int i = 0; i < kChurners; ++i) {
+    REQUIRE(pthread_create(&tids[kWorkers + i], nullptr, churner_fn,
+                           &cctx[i]) == 0);
+  }
+
+  /* Join all threads. */
+  for (int i = 0; i < kTotalThreads; ++i) {
+    pthread_join(tids[i], nullptr);
+  }
+
+  pthread_barrier_destroy(&barrier);
+
+  /* The churners should have succeeded at dlopen at least once across all
+   * iterations; if never, the .so was simply not found — warn but allow. */
+  if (dlopen_success_count.load() == 0) {
+    WARN("libLazyLoad.so could not be opened during any churner iteration; "
+         "the concurrent-unload half of the test did not execute.");
+  }
+
+  /* Primary assertion: no kernel produced wrong results and no crash. */
+  REQUIRE(g_failure.load() == false);
+}
+
+/**
+ * End doxygen group DynamicLoading.
+ * @}
+ */

--- a/projects/hip-tests/catch/unit/module/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/module/CMakeLists.txt
@@ -436,6 +436,12 @@ target_link_libraries(hipGetFuncBySymbol_exe ${GPGPU_LINKER_LIBRARIES})
 add_dependencies(build_tests hipGetFuncBySymbol_exe)
 set_property(GLOBAL APPEND PROPERTY G_INSTALL_EXE_TARGETS hipGetFuncBySymbol_exe)
 
+add_executable(managedFirstTouch_exe EXCLUDE_FROM_ALL managedFirstTouch_exe.cc)
+set_source_files_properties(managedFirstTouch_exe.cc PROPERTIES LANGUAGE ${GPGPU_LANGUAGE})
+target_link_libraries(managedFirstTouch_exe ${GPGPU_LINKER_LIBRARIES})
+add_dependencies(build_tests managedFirstTouch_exe)
+set_property(GLOBAL APPEND PROPERTY G_INSTALL_EXE_TARGETS managedFirstTouch_exe)
+
 # Common Tests - Test independent of all platforms
 set(TEST_SRC
   hipFuncSetAttribute.cc
@@ -444,6 +450,7 @@ set(TEST_SRC
   hipManagedKeywordBasic.cc
   hipModule.cc
   hipModuleLoadMultProcessOnMultGPU.cc
+  managedFirstTouch.cc
 )
 set(AMD_TEST_SRC
     hipExtLaunchKernelGGL.cc

--- a/projects/hip-tests/catch/unit/module/managedFirstTouch.cc
+++ b/projects/hip-tests/catch/unit/module/managedFirstTouch.cc
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * @addtogroup StatCO StatCO
+ * @{
+ * @ingroup ModuleTest
+ * Validates thread-safety of StatCO::InitManagedVarDevicePtr, which lazily
+ * initialises __managed__ global variable device pointers on the first kernel
+ * launch and is protected by a per-device atomic flag with acquire/release
+ * double-checked fast path.
+ */
+
+#include <hip_test_common.hh>
+#include <hip_test_defgroups.hh>
+#include <hip_test_process.hh>
+
+/**
+ * Test Description
+ * ------------------------
+ *    - Spawn a fresh child process (managedFirstTouch_exe) that releases
+ *      N worker threads simultaneously through a pthread_barrier_t onto the
+ *      very first kernel launch of that process.  All threads touch the same
+ *      __managed__ global variable through ihipModuleLaunchKernel, exercising
+ *      the concurrent first-touch path of StatCO::InitManagedVarDevicePtr.
+ *      The child process validates that the managed variable is correctly
+ *      initialised and holds the expected value after the burst completes.
+ *      The test must run in a child process because the per-device
+ *      initialisation flag is process-global one-shot state: any earlier
+ *      kernel launch in the Catch2 runner would set the flag before this test
+ *      case executes, permanently closing the race window.
+ * Test source
+ * ------------------------
+ *    - catch/unit/module/managedFirstTouch.cc
+ * Test requirements
+ * ------------------------
+ *    - HIP_VERSION >= 6.2
+ */
+HIP_TEST_CASE(Unit_StatCO_ManagedVarConcurrentFirstTouch_InChildProcess) {
+  hip::SpawnProc proc("managedFirstTouch_exe", true);
+  REQUIRE(proc.run() == 0);
+}

--- a/projects/hip-tests/catch/unit/module/managedFirstTouch_exe.cc
+++ b/projects/hip-tests/catch/unit/module/managedFirstTouch_exe.cc
@@ -20,28 +20,7 @@
  *   InitManagedVarDevicePtr.
  *
  * WHAT RACE IS TARGETED:
- *   Before the thread-safety refactor, InitManagedVarDevicePtr read and wrote
- *   managedVarsDevicePtrInitalized_[deviceId] without any synchronisation.
- *   Two threads racing through the first launch could both read 'false', both
- *   initialise device pointers (double-init), or one thread could see a
- *   partially-written state.  The refactor introduced a per-device atomic flag
- *   with acquire/release semantics and a double-checked fast path so that only
- *   the first thread to win the CAS does the init work while all others observe
- *   the completed state with proper memory ordering.
- *
- * HOW THE TEST EXERCISES THE RACE:
- *   N_THREADS worker threads each wait on the same pthread_barrier_t, then all
- *   call hipLaunchKernelGGL simultaneously.  The barrier maximises the overlap
- *   of the first-touch paths into InitManagedVarDevicePtr on every device.
- *   Each thread then calls hipDeviceSynchronize and reads back the managed
- *   variable to verify it was initialised to the expected value.
- *
- * SANITIZER NOTE:
- *   In plain CI (no ThreadSanitizer) this test primarily catches crashes,
- *   incorrect initialisation of __managed__ global pointers, and deadlocks.
- *   The race is most reliably detected under TSan (-fsanitize=thread), which
- *   will report data races on managedVarsDevicePtrInitalized_ if the old
- *   unguarded code is reintroduced.
+ *   Tests static code object race conditions. Specifically managed variables
  *
  * IMPORTANT CONSTRAINT:
  *   No HIP kernel must be launched before the barrier-synchronised burst.

--- a/projects/hip-tests/catch/unit/module/managedFirstTouch_exe.cc
+++ b/projects/hip-tests/catch/unit/module/managedFirstTouch_exe.cc
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
+ * Child-process executable for Unit_StatCO_ManagedVarConcurrentFirstTouch.
+ *
+ * WHY A CHILD PROCESS:
+ *   StatCO::InitManagedVarDevicePtr sets a per-device atomic flag that is
+ *   PROCESS-GLOBAL state in the PlatformState singleton.  It is triggered by
+ *   the very first call to ihipModuleLaunchKernel in the process.  When tests
+ *   run inside the main Catch2 binary, earlier test cases have already launched
+ *   kernels, so the flag is already set long before this test runs and the
+ *   concurrent first-touch race window is permanently closed.  By running in a
+ *   fresh child process (spawned via hip::SpawnProc), the barrier-synchronised
+ *   threads below perform the FIRST kernel launch of the entire process,
+ *   maximising the chance of overlapping first-touch paths colliding on
+ *   InitManagedVarDevicePtr.
+ *
+ * WHAT RACE IS TARGETED:
+ *   Before the thread-safety refactor, InitManagedVarDevicePtr read and wrote
+ *   managedVarsDevicePtrInitalized_[deviceId] without any synchronisation.
+ *   Two threads racing through the first launch could both read 'false', both
+ *   initialise device pointers (double-init), or one thread could see a
+ *   partially-written state.  The refactor introduced a per-device atomic flag
+ *   with acquire/release semantics and a double-checked fast path so that only
+ *   the first thread to win the CAS does the init work while all others observe
+ *   the completed state with proper memory ordering.
+ *
+ * HOW THE TEST EXERCISES THE RACE:
+ *   N_THREADS worker threads each wait on the same pthread_barrier_t, then all
+ *   call hipLaunchKernelGGL simultaneously.  The barrier maximises the overlap
+ *   of the first-touch paths into InitManagedVarDevicePtr on every device.
+ *   Each thread then calls hipDeviceSynchronize and reads back the managed
+ *   variable to verify it was initialised to the expected value.
+ *
+ * SANITIZER NOTE:
+ *   In plain CI (no ThreadSanitizer) this test primarily catches crashes,
+ *   incorrect initialisation of __managed__ global pointers, and deadlocks.
+ *   The race is most reliably detected under TSan (-fsanitize=thread), which
+ *   will report data races on managedVarsDevicePtrInitalized_ if the old
+ *   unguarded code is reintroduced.
+ *
+ * IMPORTANT CONSTRAINT:
+ *   No HIP kernel must be launched before the barrier-synchronised burst.
+ *   Any premature launch would call ihipModuleLaunchKernel and set the flag,
+ *   closing the race window before the threads are released.
+ */
+
+#include <hip/hip_runtime.h>
+
+#include <atomic>
+#include <cstdio>
+#include <cstdlib>
+#include <pthread.h>
+#include <vector>
+
+// --------------------------------------------------------------------------
+// Managed global variable under test.  The HIP runtime must call
+// InitManagedVarDevicePtr the first time a kernel that references this
+// symbol is launched on each device.
+// --------------------------------------------------------------------------
+__managed__ int g_managedVal = 42;
+
+// --------------------------------------------------------------------------
+// Kernel: write a sentinel into the managed variable so we can verify
+// the managed pointer was correctly initialised.
+// --------------------------------------------------------------------------
+__global__ void setManagedKernel(int value) {
+  // Only thread 0 writes to avoid races between GPU threads.
+  if (threadIdx.x == 0 && blockIdx.x == 0) {
+    g_managedVal = value;
+  }
+}
+
+// --------------------------------------------------------------------------
+// Error-checking macro (plain main style, matching hipGetFuncBySymbol_exe.cc).
+// --------------------------------------------------------------------------
+#define HIP_CHECK(expr)                                                        \
+  do {                                                                         \
+    hipError_t _err = (expr);                                                  \
+    if (_err != hipSuccess) {                                                  \
+      printf("HIP error '%s' (%d) at %s:%d\n",                                \
+             hipGetErrorString(_err), _err, __FILE__, __LINE__);               \
+      return -1;                                                               \
+    }                                                                          \
+  } while (0)
+
+// --------------------------------------------------------------------------
+// Number of threads released simultaneously at the barrier.
+// --------------------------------------------------------------------------
+static constexpr int N_THREADS = 8;
+
+// --------------------------------------------------------------------------
+// Per-thread context passed via the pthread API.
+// --------------------------------------------------------------------------
+struct ThreadCtx {
+  pthread_barrier_t* barrier;    // shared barrier across all N_THREADS
+  int deviceId;                  // which device each thread targets
+  int expectedVal;               // value the kernel will write
+  std::atomic<bool>* anyError;   // set true on any failure in any thread
+};
+
+// --------------------------------------------------------------------------
+// Worker: wait at the barrier, then perform the first kernel launch on
+// the assigned device.  All N_THREADS threads release simultaneously to
+// maximise overlap inside InitManagedVarDevicePtr.
+// --------------------------------------------------------------------------
+static void* workerThread(void* arg) {
+  ThreadCtx* ctx = reinterpret_cast<ThreadCtx*>(arg);
+
+  // Select the device for this thread.  hipSetDevice must be called per-thread
+  // because HIP device context is per-thread on the host.
+  if (hipSetDevice(ctx->deviceId) != hipSuccess) {
+    ctx->anyError->store(true, std::memory_order_relaxed);
+    return nullptr;
+  }
+
+  // ---- CRITICAL: no HIP kernel may be launched before this point ----
+  // All threads synchronise here so that their subsequent kernel launches
+  // arrive at ihipModuleLaunchKernel (and InitManagedVarDevicePtr) as
+  // simultaneously as pthreads scheduling allows.
+  pthread_barrier_wait(ctx->barrier);
+  // -------------------------------------------------------------------
+
+  // First kernel launch of the entire process on this device.
+  // This call must trigger InitManagedVarDevicePtr inside the HIP runtime.
+  hipLaunchKernelGGL(setManagedKernel, dim3(1), dim3(1), 0, nullptr,
+                     ctx->expectedVal);
+
+  if (hipGetLastError() != hipSuccess) {
+    ctx->anyError->store(true, std::memory_order_relaxed);
+    return nullptr;
+  }
+
+  if (hipDeviceSynchronize() != hipSuccess) {
+    ctx->anyError->store(true, std::memory_order_relaxed);
+    return nullptr;
+  }
+
+  return nullptr;
+}
+
+// --------------------------------------------------------------------------
+// Run the concurrent first-touch burst on one device.
+// Returns 0 on success, -1 on any failure.
+// --------------------------------------------------------------------------
+static int runBurstOnDevice(int deviceId) {
+  if (hipSetDevice(deviceId) != hipSuccess) {
+    printf("hipSetDevice(%d) failed\n", deviceId);
+    return -1;
+  }
+
+  // Reset the managed variable to a known initial state before the burst so
+  // that we can verify the kernel actually wrote to it afterwards.
+  // NOTE: this is a plain host write — no kernel launch, no flag set.
+  g_managedVal = 0;
+  // Ensure the managed memory is accessible on the host side before threads
+  // start (the variable was declared __managed__ so this is valid on the host).
+  HIP_CHECK(hipDeviceSynchronize());
+
+  const int sentinel = 99;
+
+  pthread_barrier_t barrier;
+  if (pthread_barrier_init(&barrier, nullptr, N_THREADS) != 0) {
+    printf("pthread_barrier_init failed\n");
+    return -1;
+  }
+
+  std::atomic<bool> anyError{false};
+
+  std::vector<pthread_t> threads(N_THREADS);
+  std::vector<ThreadCtx> ctxs(N_THREADS);
+
+  for (int i = 0; i < N_THREADS; ++i) {
+    ctxs[i].barrier    = &barrier;
+    ctxs[i].deviceId   = deviceId;
+    ctxs[i].expectedVal = sentinel;
+    ctxs[i].anyError   = &anyError;
+  }
+
+  // Spawn all worker threads before any of them reaches the barrier.
+  for (int i = 0; i < N_THREADS; ++i) {
+    if (pthread_create(&threads[i], nullptr, workerThread, &ctxs[i]) != 0) {
+      printf("pthread_create failed for thread %d\n", i);
+      anyError.store(true, std::memory_order_relaxed);
+      // Join threads already created.
+      for (int j = 0; j < i; ++j) pthread_join(threads[j], nullptr);
+      pthread_barrier_destroy(&barrier);
+      return -1;
+    }
+  }
+
+  for (int i = 0; i < N_THREADS; ++i) {
+    pthread_join(threads[i], nullptr);
+  }
+  pthread_barrier_destroy(&barrier);
+
+  if (anyError.load(std::memory_order_relaxed)) {
+    printf("Device %d: one or more threads reported an error\n", deviceId);
+    return -1;
+  }
+
+  // After all threads have run the kernel and synchronised, the managed
+  // variable must hold the sentinel written by the last kernel to execute.
+  // Because multiple GPU threads all wrote the same value (sentinel), any
+  // ordering is acceptable — we just verify the value is correct.
+  HIP_CHECK(hipSetDevice(deviceId));
+  HIP_CHECK(hipDeviceSynchronize());
+
+  if (g_managedVal != sentinel) {
+    printf("Device %d: g_managedVal = %d, expected %d\n",
+           deviceId, g_managedVal, sentinel);
+    return -1;
+  }
+
+  printf("Device %d: OK (g_managedVal = %d)\n", deviceId, g_managedVal);
+  return 0;
+}
+
+// --------------------------------------------------------------------------
+// Entry point — plain main(), same style as hipGetFuncBySymbol_exe.cc.
+// --------------------------------------------------------------------------
+int main() {
+  int deviceCount = 0;
+  if (hipGetDeviceCount(&deviceCount) != hipSuccess || deviceCount == 0) {
+    printf("No HIP devices found\n");
+    return -1;
+  }
+
+  for (int dev = 0; dev < deviceCount; ++dev) {
+    if (runBurstOnDevice(dev) != 0) {
+      return -1;
+    }
+  }
+
+  return 0;
+}


### PR DESCRIPTION
## Motivation

Multiple threads all accessing different GPUs with different streams are all serialized when they try retrieving the function. This slows submission and increases variability in submission,

## Technical Details

The regular mutex is replaced with a shared mutex allowing concurrent accesses from multiple threads. Additionally `managedVarsDevicePtrInitalized_` now stores atomic values, which are atomically updated, this produces very little contention after setup. 

Results from multi-gpu submissions benchmarking. Significant decrease in latency and submission variablitiy

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>



  | **Averages** |  |  | %   **Change** | |  | 
-- | -- | -- | -- | -- | -- | --
  | Kernel Submission Times | | Total Run | Kernel Submission Times | | Total Run
  | Mean (Us) | Stdev | Ops/Sec | Mean | Stdev | Ops/Sec
**Baseline** | 2220.5 | 2210.5 | 1575776.5 |   |   |  
**StatCo   Concurrent** | 1108.5 | 645.5 | 2176200.5 | -50% | -71% | 38%


</body>

</html>


## JIRA ID

ROCM-27455

## Test Plan

Additional testing added to harden the feature

## Test Result

Pass locally

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
