### PR TITLE
[rocprofiler-sdk] use therock-ci-config to update runners

### DIFF
--- a/.github/actions/rocprofiler-sdk-util/resolve-ci-config/action.yml
+++ b/.github/actions/rocprofiler-sdk-util/resolve-ci-config/action.yml
@@ -2,14 +2,6 @@ name: Resolve CI config
 description: Resolve runner labels from ROCm/therock-ci-config
 
 inputs:
-  config-repository:
-    description: Repository containing the shared CI config
-    required: false
-    default: ROCm/therock-ci-config
-  config-ref:
-    description: Ref to checkout from the shared CI config repository
-    required: false
-    default: main
   config-path:
     description: Local checkout path for the shared CI config
     required: false
@@ -37,8 +29,8 @@ runs:
     - name: Checkout CI config
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
-        repository: ${{ inputs.config-repository }}
-        ref: ${{ inputs.config-ref }}
+        repository: ROCm/therock-ci-config
+        ref: main
         path: ${{ inputs.config-path }}
       continue-on-error: true
 

--- a/.github/actions/rocprofiler-sdk-util/resolve-ci-config/action.yml
+++ b/.github/actions/rocprofiler-sdk-util/resolve-ci-config/action.yml
@@ -1,0 +1,80 @@
+name: Resolve CI config
+description: Resolve runner labels from ROCm/therock-ci-config
+
+inputs:
+  config-repository:
+    description: Repository containing the shared CI config
+    required: false
+    default: ROCm/therock-ci-config
+  config-ref:
+    description: Ref to checkout from the shared CI config repository
+    required: false
+    default: main
+  config-path:
+    description: Local checkout path for the shared CI config
+    required: false
+    default: ci-config
+  fallback-gfx94x-runner:
+    description: Runner label to use if the shared CI config cannot be loaded
+    required: false
+    default: linux-gfx942-1gpu-ccs-csp-ossci-rocm
+
+outputs:
+  gfx94x_runner:
+    description: Linux gfx94x test runner label
+    value: ${{ steps.runner.outputs.gfx94x_runner }}
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout CI config
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        repository: ${{ inputs.config-repository }}
+        ref: ${{ inputs.config-ref }}
+        path: ${{ inputs.config-path }}
+      continue-on-error: true
+
+    - name: Resolve runner labels
+      id: runner
+      shell: bash
+      env:
+        CI_CONFIG_PATH: ${{ inputs.config-path }}
+        FALLBACK_GFX94X_RUNNER: ${{ inputs.fallback-gfx94x-runner }}
+      run: |
+        python3 <<'PY'
+        import os
+        import sys
+        from pathlib import Path
+
+        fallback_runner = os.environ["FALLBACK_GFX94X_RUNNER"]
+        runner = fallback_runner
+        config_path = Path(os.environ["CI_CONFIG_PATH"])
+
+        if config_path.exists():
+            sys.path.insert(0, str(config_path))
+            try:
+                from ci_config_api import load_config_v1
+
+                config = load_config_v1(config_path)
+                runner = (
+                    config.get_gpu_families(["presubmit"])
+                    .get("gfx94x", {})
+                    .get("linux", {})
+                    .get("test-runs-on", fallback_runner)
+                ) or fallback_runner
+            except Exception as exc:
+                print(
+                    f"::warning::Failed to load CI config: {exc}. "
+                    f"Using fallback runner {fallback_runner}."
+                )
+        else:
+            print(
+                "::warning::CI config checkout missing. "
+                f"Using fallback runner {fallback_runner}."
+            )
+
+        print(f"Using gfx94x runner: {runner}")
+        with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+            output.write(f"gfx94x_runner={runner}\n")
+        PY

--- a/.github/actions/rocprofiler-sdk-util/resolve-ci-config/action.yml
+++ b/.github/actions/rocprofiler-sdk-util/resolve-ci-config/action.yml
@@ -18,11 +18,18 @@ inputs:
     description: Runner label to use if the shared CI config cannot be loaded
     required: false
     default: linux-gfx942-1gpu-ccs-csp-ossci-rocm
+  fallback-gfx94x-sandbox-runner:
+    description: Sandbox runner label to use if the shared CI config cannot be loaded
+    required: false
+    default: linux-mi325-gpu-rocm-cpu-sandbox
 
 outputs:
   gfx94x_runner:
     description: Linux gfx94x test runner label
     value: ${{ steps.runner.outputs.gfx94x_runner }}
+  gfx94x_sandbox_runner:
+    description: Linux gfx94x sandbox test runner label
+    value: ${{ steps.runner.outputs.gfx94x_sandbox_runner }}
 
 runs:
   using: composite
@@ -41,40 +48,5 @@ runs:
       env:
         CI_CONFIG_PATH: ${{ inputs.config-path }}
         FALLBACK_GFX94X_RUNNER: ${{ inputs.fallback-gfx94x-runner }}
-      run: |
-        python3 <<'PY'
-        import os
-        import sys
-        from pathlib import Path
-
-        fallback_runner = os.environ["FALLBACK_GFX94X_RUNNER"]
-        runner = fallback_runner
-        config_path = Path(os.environ["CI_CONFIG_PATH"])
-
-        if config_path.exists():
-            sys.path.insert(0, str(config_path))
-            try:
-                from ci_config_api import load_config_v1
-
-                config = load_config_v1(config_path)
-                runner = (
-                    config.get_gpu_families(["presubmit"])
-                    .get("gfx94x", {})
-                    .get("linux", {})
-                    .get("test-runs-on", fallback_runner)
-                ) or fallback_runner
-            except Exception as exc:
-                print(
-                    f"::warning::Failed to load CI config: {exc}. "
-                    f"Using fallback runner {fallback_runner}."
-                )
-        else:
-            print(
-                "::warning::CI config checkout missing. "
-                f"Using fallback runner {fallback_runner}."
-            )
-
-        print(f"Using gfx94x runner: {runner}")
-        with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
-            output.write(f"gfx94x_runner={runner}\n")
-        PY
+        FALLBACK_GFX94X_SANDBOX_RUNNER: ${{ inputs.fallback-gfx94x-sandbox-runner }}
+      run: python3 "${GITHUB_ACTION_PATH}/resolve_ci_config.py"

--- a/.github/actions/rocprofiler-sdk-util/resolve-ci-config/resolve_ci_config.py
+++ b/.github/actions/rocprofiler-sdk-util/resolve-ci-config/resolve_ci_config.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def warn(message: str) -> None:
+    print(f"::warning::{message}")
+
+
+def load_gfx94x_linux_config(config_path: Path) -> dict[str, Any]:
+    if not config_path.exists():
+        warn("CI config checkout missing. Using fallback runner labels.")
+        return {}
+
+    sys.path.insert(0, str(config_path))
+    try:
+        from ci_config_api import load_config_v1
+
+        config = load_config_v1(config_path)
+        return (
+            config.get_gpu_families(["presubmit"])
+            .get("gfx94x", {})
+            .get("linux", {})
+        )
+    except Exception as exc:
+        warn(f"Failed to load CI config: {exc}. Using fallback runner labels.")
+        return {}
+
+
+def set_outputs(outputs: dict[str, str]) -> None:
+    with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output_file:
+        for key, value in outputs.items():
+            output_file.write(f"{key}={value}\n")
+
+
+def main() -> None:
+    config_path = Path(os.environ["CI_CONFIG_PATH"])
+    fallback_runner = os.environ["FALLBACK_GFX94X_RUNNER"]
+    fallback_sandbox_runner = os.environ["FALLBACK_GFX94X_SANDBOX_RUNNER"]
+
+    gfx94x_linux_config = load_gfx94x_linux_config(config_path)
+    runner = gfx94x_linux_config.get("test-runs-on") or fallback_runner
+    sandbox_runner = (
+        gfx94x_linux_config.get("test-runs-on-sandbox") or fallback_sandbox_runner
+    )
+
+    print(f"Using gfx94x runner: {runner}")
+    print(f"Using gfx94x sandbox runner: {sandbox_runner}")
+    set_outputs(
+        {
+            "gfx94x_runner": runner,
+            "gfx94x_sandbox_runner": sandbox_runner,
+        }
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/aqlprofile-continuous_integration.yml
+++ b/.github/workflows/aqlprofile-continuous_integration.yml
@@ -13,6 +13,7 @@ on:
       - '!projects/aqlprofile/CODEOWNERS'
       - '!projects/aqlprofile/source/docs/**'
       - '.github/workflows/aqlprofile-continuous_integration.yml'
+      - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/**'
   pull_request:
     paths:
       - 'projects/aqlprofile/**'
@@ -20,6 +21,7 @@ on:
       - '!projects/aqlprofile/CODEOWNERS'
       - '!projects/aqlprofile/source/docs/**'
       - '.github/workflows/aqlprofile-continuous_integration.yml'
+      - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -45,8 +47,29 @@ env:
   navi4_EXCLUDE_LABEL_REGEX: ""
 
 jobs:
+  ci_config:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
+    name: Load CI config
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      gfx94x_runner: ${{ steps.runner.outputs.gfx94x_runner }}
+      gfx94x_sandbox_runner: ${{ steps.runner.outputs.gfx94x_sandbox_runner }}
+    steps:
+      - name: Checkout workflow actions
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions/rocprofiler-sdk-util/resolve-ci-config
+          set-safe-directory: true
+
+      - name: Resolve runner labels
+        id: runner
+        uses: ./.github/actions/rocprofiler-sdk-util/resolve-ci-config
+
   core-deb:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
+    needs: ci_config
     name: Core • ${{ matrix.system.gpu }} • ${{ matrix.system.os }}
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     strategy:
@@ -55,9 +78,9 @@ jobs:
         system:
           # - { gpu: 'navi4', runner: 'linux-gfx120X-gpu-rocm', os: 'ubuntu-22.04', build-type: 'RelWithDebInfo', gpu-target: 'gfx120X' }
           # - { gpu: 'navi3', runner: 'linux-gfx110X-gpu-rocm', os: 'ubuntu-22.04', build-type: 'RelWithDebInfo', gpu-target: 'gfx110X' }
-          - { gpu: 'mi325', runner: 'linux-gfx942-1gpu-core42-ossci-rocm', os: 'ubuntu-22.04', build-type: 'RelWithDebInfo', gpu-target: 'gfx94X' }
+          - { gpu: 'mi325', os: 'ubuntu-22.04', build-type: 'RelWithDebInfo', gpu-target: 'gfx94X' }
 
-    runs-on: ${{ matrix.system.runner }}
+    runs-on: ${{ needs.ci_config.outputs.gfx94x_runner }}
     container:
       image: docker.io/rocm/rocprofiler-private:${{ matrix.system.os }}-${{ matrix.system.gpu-target }}-latest
       credentials:
@@ -115,7 +138,7 @@ jobs:
         PATH=~/.local/bin:${{ env.ROCM_PATH }}/bin:${PATH}
         LD_LIBRARY_PATH=$(pwd)/build:${{ env.ROCM_PATH }}/lib:$LD_LIBRARY_PATH
         ctest --output-on-failure --verbose -DCTEST_SOURCE_DIRECTORY="$(pwd)"
-          -DCTEST_BINARY_DIRECTORY="$(pwd)/build" -DAQLPROFILE_BUILD_NUM_JOBS="16" -DCTEST_SITE="${{ matrix.system.runner }}"
+          -DCTEST_BINARY_DIRECTORY="$(pwd)/build" -DAQLPROFILE_BUILD_NUM_JOBS="16" -DCTEST_SITE="${{ needs.ci_config.outputs.gfx94x_runner }}"
           -DCTEST_BUILD_NAME=PR_${{ github.ref_name }}_${{ github.repository }}-${{ matrix.system.os }}-${{ matrix.system.gpu }}-core
           -DCMAKE_CTEST_ARGUMENTS=""
           -DAQLPROFILE_BUILD_TESTS=ON
@@ -124,17 +147,18 @@ jobs:
 
   core-rpm:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
+    needs: ci_config
     name: Core • ${{ matrix.system.gpu }} • ${{ matrix.system.os }}
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     strategy:
       fail-fast: false
       matrix:
         system:
-          - { gpu: 'mi325', runner: 'linux-gfx942-1gpu-core42-ossci-rocm', os: 'rhel-8.8', build-type: 'RelWithDebInfo', gpu-target: 'gfx94X' }
-          - { gpu: 'mi325', runner: 'linux-gfx942-1gpu-core42-ossci-rocm', os: 'rhel-9.5', build-type: 'RelWithDebInfo', gpu-target: 'gfx94X' }
-          - { gpu: 'mi325', runner: 'linux-gfx942-1gpu-core42-ossci-rocm', os: 'sles-15.6', build-type: 'RelWithDebInfo', gpu-target: 'gfx94X' }
+          - { gpu: 'mi325', os: 'rhel-8.8', build-type: 'RelWithDebInfo', gpu-target: 'gfx94X' }
+          - { gpu: 'mi325', os: 'rhel-9.5', build-type: 'RelWithDebInfo', gpu-target: 'gfx94X' }
+          - { gpu: 'mi325', os: 'sles-15.6', build-type: 'RelWithDebInfo', gpu-target: 'gfx94X' }
 
-    runs-on: ${{ matrix.system.runner }}
+    runs-on: ${{ needs.ci_config.outputs.gfx94x_runner }}
     container:
       image: docker.io/rocm/rocprofiler-private:${{ matrix.system.os }}-${{ matrix.system.gpu-target }}-latest
       credentials:
@@ -188,7 +212,7 @@ jobs:
         LD_LIBRARY_PATH=$(pwd)/build:${{ env.ROCM_PATH }}/lib:$LD_LIBRARY_PATH
         ctest --output-on-failure --verbose -DCTEST_SOURCE_DIRECTORY="$(pwd)"
           -DCTEST_BINARY_DIRECTORY="$(pwd)/build" -DAQLPROFILE_BUILD_NUM_JOBS="16"
-          -DCTEST_SITE=${{ matrix.system.runner }}
+          -DCTEST_SITE=${{ needs.ci_config.outputs.gfx94x_runner }}
           -DCTEST_BUILD_NAME=PR_${{ github.ref_name }}_${{ github.repository }}-${{ matrix.system.os }}-${{ matrix.system.gpu }}-core
           -DCMAKE_CTEST_ARGUMENTS=""
           -DAQLPROFILE_BUILD_TESTS=ON

--- a/.github/workflows/rocprof-trace-decoder-continuous_integration.yml
+++ b/.github/workflows/rocprof-trace-decoder-continuous_integration.yml
@@ -12,6 +12,7 @@ on:
       - '!projects/rocprof-trace-decoder/docs/**'
       - '.github/workflows/rocprof-trace-decoder-continuous_integration.yml'
       - '.github/actions/rocprofiler-sdk-util/action.yml'
+      - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/action.yml'
   pull_request:
     paths:
       - 'projects/rocprof-trace-decoder/**'
@@ -20,6 +21,7 @@ on:
       - '!projects/rocprof-trace-decoder/docs/**'
       - '.github/workflows/rocprof-trace-decoder-continuous_integration.yml'
       - '.github/actions/rocprofiler-sdk-util/action.yml'
+      - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/action.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -47,11 +49,31 @@ env:
   SUBMODULE_PATHS: "projects/rocprofiler-sdk projects/aqlprofile projects/rocprofiler-register projects/rocprof-trace-decoder projects/rocr-runtime projects/clr projects/hip"
 
 jobs:
+  ci_config:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
+    name: Load CI config
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      gfx94x_runner: ${{ steps.runner.outputs.gfx94x_runner }}
+    steps:
+      - name: Checkout workflow actions
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions/rocprofiler-sdk-util/resolve-ci-config
+          set-safe-directory: true
+
+      - name: Resolve runner labels
+        id: runner
+        uses: ./.github/actions/rocprofiler-sdk-util/resolve-ci-config
+
   build-and-test-ubuntu:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
+    needs: ci_config
     name: Build & Test • mi325 • Ubuntu 22.04
 
-    runs-on: linux-gfx942-1gpu-core42-ossci-rocm
+    runs-on: ${{ needs.ci_config.outputs.gfx94x_runner }}
     container:
       image: docker.io/rocm/rocprofiler-private:ubuntu-22.04-gfx94X-latest
       credentials:
@@ -117,15 +139,16 @@ jobs:
   # ---------------------------------------------------------------------------
   build-and-test-rocprofiler-sdk-rpm:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
+    needs: ci_config
     name: Build & Test rocprofiler-sdk • ${{ matrix.system.gpu }} • ${{ matrix.system.os }}
     timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
         system:
-          - { os: 'rhel-9.5',  runner: 'linux-gfx942-1gpu-core42-ossci-rocm', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
-          - { os: 'sles-15.6', runner: 'linux-gfx942-1gpu-core42-ossci-rocm', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
-    runs-on: ${{ matrix.system.runner }}
+          - { os: 'rhel-9.5',  gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
+          - { os: 'sles-15.6', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
+    runs-on: ${{ needs.ci_config.outputs.gfx94x_runner }}
     container:
       image: docker.io/rocm/rocprofiler-private:${{ matrix.system.os }}-${{ matrix.system.gpu-target }}-latest
       credentials:
@@ -204,7 +227,7 @@ jobs:
           enable-rocprofiler-register-build: ${{ env.ENABLE_ROCPROFILER_REGISTER_BUILD }}
           enable-aqlprofile-build: ${{ env.ENABLE_AQLPROFILE_BUILD }}
           enable-rocprof-trace-decoder-build: 'true'
-          ccache-key: sccache-trace-decoder-${{ matrix.system.os }}-${{ matrix.system.runner }}-${{ matrix.system.gpu }}
+          ccache-key: sccache-trace-decoder-${{ matrix.system.os }}-${{ needs.ci_config.outputs.gfx94x_runner }}-${{ matrix.system.gpu }}
           ccache-variant: sccache
 
       - name: Configure, Build, and Test
@@ -218,7 +241,7 @@ jobs:
             --name ${{ github.repository }}-${{ github.ref_name }}-${{ matrix.system.os }}-${{ matrix.system.gpu }}-trace-decoder-core \
             --mode ${CI_MODE} \
             --build-jobs 16 \
-            --site ${{ matrix.system.runner }} \
+            --site ${{ needs.ci_config.outputs.gfx94x_runner }} \
             --gpu-targets ${{ env.GPU_TARGETS }} \
             --run-attempt ${{ github.run_attempt }} \
             -- \

--- a/.github/workflows/rocprof-trace-decoder-continuous_integration.yml
+++ b/.github/workflows/rocprof-trace-decoder-continuous_integration.yml
@@ -12,7 +12,7 @@ on:
       - '!projects/rocprof-trace-decoder/docs/**'
       - '.github/workflows/rocprof-trace-decoder-continuous_integration.yml'
       - '.github/actions/rocprofiler-sdk-util/action.yml'
-      - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/action.yml'
+      - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/**'
   pull_request:
     paths:
       - 'projects/rocprof-trace-decoder/**'
@@ -21,7 +21,7 @@ on:
       - '!projects/rocprof-trace-decoder/docs/**'
       - '.github/workflows/rocprof-trace-decoder-continuous_integration.yml'
       - '.github/actions/rocprofiler-sdk-util/action.yml'
-      - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/action.yml'
+      - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -57,6 +57,7 @@ jobs:
       contents: read
     outputs:
       gfx94x_runner: ${{ steps.runner.outputs.gfx94x_runner }}
+      gfx94x_sandbox_runner: ${{ steps.runner.outputs.gfx94x_sandbox_runner }}
     steps:
       - name: Checkout workflow actions
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/rocprofiler-register-continuous-integration.yml
+++ b/.github/workflows/rocprofiler-register-continuous-integration.yml
@@ -14,7 +14,7 @@ on:
       - '!**/.readthedocs.yaml'
       - '!**/.spellcheck.local.yaml'
       - '!**/.wordlist.txt'
-      - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/action.yml'
+      - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/**'
   pull_request:
     paths:
       - 'projects/rocprofiler-register/**'
@@ -26,7 +26,7 @@ on:
       - '!**/.readthedocs.yaml'
       - '!**/.spellcheck.local.yaml'
       - '!**/.wordlist.txt'
-      - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/action.yml'
+      - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -41,16 +41,17 @@ jobs:
       contents: read
     outputs:
       gfx94x_runner: ${{ steps.runner.outputs.gfx94x_runner }}
+      gfx94x_sandbox_runner: ${{ steps.runner.outputs.gfx94x_sandbox_runner }}
     steps:
-    - name: Checkout workflow actions
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        sparse-checkout: .github/actions/rocprofiler-sdk-util/resolve-ci-config
-        set-safe-directory: true
+      - name: Checkout workflow actions
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions/rocprofiler-sdk-util/resolve-ci-config
+          set-safe-directory: true
 
-    - name: Resolve runner labels
-      id: runner
-      uses: ./.github/actions/rocprofiler-sdk-util/resolve-ci-config
+      - name: Resolve runner labels
+        id: runner
+        uses: ./.github/actions/rocprofiler-sdk-util/resolve-ci-config
 
   ci:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
@@ -95,7 +96,7 @@ jobs:
         #     ci-tag: '-undefined-behavior-sanitizer'
         #     runner_type: 'sandbox'
 
-    runs-on: ${{ matrix.runner_type == 'sandbox' && 'linux-mi325-gpu-rocm-cpu-sandbox' || needs.ci_config.outputs.gfx94x_runner }}
+    runs-on: ${{ matrix.runner_type == 'sandbox' && needs.ci_config.outputs.gfx94x_sandbox_runner || needs.ci_config.outputs.gfx94x_runner }}
     container:
       image: docker.io/rocm/rocprofiler-private:ubuntu-22.04-gfx94X-latest
       credentials:

--- a/.github/workflows/rocprofiler-register-continuous-integration.yml
+++ b/.github/workflows/rocprofiler-register-continuous-integration.yml
@@ -14,6 +14,7 @@ on:
       - '!**/.readthedocs.yaml'
       - '!**/.spellcheck.local.yaml'
       - '!**/.wordlist.txt'
+      - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/action.yml'
   pull_request:
     paths:
       - 'projects/rocprofiler-register/**'
@@ -25,55 +26,76 @@ on:
       - '!**/.readthedocs.yaml'
       - '!**/.spellcheck.local.yaml'
       - '!**/.wordlist.txt'
+      - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/action.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  ci_config:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
+    name: Load CI config
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      gfx94x_runner: ${{ steps.runner.outputs.gfx94x_runner }}
+    steps:
+    - name: Checkout workflow actions
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        sparse-checkout: .github/actions/rocprofiler-sdk-util/resolve-ci-config
+        set-safe-directory: true
+
+    - name: Resolve runner labels
+      id: runner
+      uses: ./.github/actions/rocprofiler-sdk-util/resolve-ci-config
+
   ci:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
+    needs: ci_config
     strategy:
       fail-fast: false
       matrix:
         compiler: ['clang-14', 'clang-15', 'gcc-11', 'gcc-12']
         ci-args: ['']
         ci-tag: ['']
-        runner: ['linux-gfx942-1gpu-core42-ossci-rocm']
+        runner_type: ['gfx94x']
         include:
           - compiler: 'gcc-12'
             ci-args: '--coverage'
             ci-tag: '-codecov'
-            runner: 'linux-gfx942-1gpu-core42-ossci-rocm'
+            runner_type: 'gfx94x'
           - compiler: 'clang-15'
             ci-args: '--linter clang-tidy'
             ci-tag: '-clang-tidy'
-            runner: 'linux-gfx942-1gpu-core42-ossci-rocm'
+            runner_type: 'gfx94x'
           - compiler: 'clang-13'
             ci-args: ''
             ci-tag: ''
-            runner: 'linux-gfx942-1gpu-core42-ossci-rocm'
+            runner_type: 'gfx94x'
           - compiler: 'gcc-12'
             ci-args: '--memcheck ThreadSanitizer'
             ci-tag: '-thread-sanitizer'
             # DO NOT UPDATE: sanitizer builds and tests cause issue on prod machines
-            runner: 'linux-mi325-gpu-rocm-cpu-sandbox'
+            runner_type: 'sandbox'
           - compiler: 'gcc-12'
             ci-args: '--memcheck AddressSanitizer'
             ci-tag: '-address-sanitizer'
             # DO NOT UPDATE: sanitizer builds and tests cause issue on prod machines
-            runner: 'linux-mi325-gpu-rocm-cpu-sandbox'
+            runner_type: 'sandbox'
           - compiler: 'gcc-12'
             ci-args: '--memcheck LeakSanitizer'
             ci-tag: '-leak-sanitizer'
             # DO NOT UPDATE: sanitizer builds and tests cause issue on prod machines
-            runner: 'linux-mi325-gpu-rocm-cpu-sandbox'
+            runner_type: 'sandbox'
         #   - compiler: 'gcc-12'
         #     ci-args: '--memcheck UndefinedBehaviorSanitizer'
         #     ci-tag: '-undefined-behavior-sanitizer'
-        #     runner: 'linux-mi325-8gpu-ossci-rocm-sandbox'
+        #     runner_type: 'sandbox'
 
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ matrix.runner_type == 'sandbox' && 'linux-mi325-gpu-rocm-cpu-sandbox' || needs.ci_config.outputs.gfx94x_runner }}
     container:
       image: docker.io/rocm/rocprofiler-private:ubuntu-22.04-gfx94X-latest
       credentials:

--- a/.github/workflows/rocprofiler-sdk-code_coverage.yml
+++ b/.github/workflows/rocprofiler-sdk-code_coverage.yml
@@ -12,7 +12,7 @@ on:
       - 'projects/rocprofiler-sdk/**'
       - '.github/workflows/rocprofiler-sdk-code_coverage.yml'
       - '.github/actions/rocprofiler-sdk-util/action.yml'
-      - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/action.yml'
+      - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/**'
       - '!**/*.md'
       - '!**/*.rtf'
       - '!**/*.rst'
@@ -27,7 +27,7 @@ on:
       - 'projects/rocprofiler-sdk/**'
       - '.github/workflows/rocprofiler-sdk-code_coverage.yml'
       - '.github/actions/rocprofiler-sdk-util/action.yml'
-      - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/action.yml'
+      - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/**'
       - '!**/*.md'
       - '!**/*.rtf'
       - '!**/*.rst'
@@ -84,16 +84,17 @@ jobs:
       contents: read
     outputs:
       gfx94x_runner: ${{ steps.runner.outputs.gfx94x_runner }}
+      gfx94x_sandbox_runner: ${{ steps.runner.outputs.gfx94x_sandbox_runner }}
     steps:
-    - name: Checkout workflow actions
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        sparse-checkout: .github/actions/rocprofiler-sdk-util/resolve-ci-config
-        set-safe-directory: true
+      - name: Checkout workflow actions
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions/rocprofiler-sdk-util/resolve-ci-config
+          set-safe-directory: true
 
-    - name: Resolve runner labels
-      id: runner
-      uses: ./.github/actions/rocprofiler-sdk-util/resolve-ci-config
+      - name: Resolve runner labels
+        id: runner
+        uses: ./.github/actions/rocprofiler-sdk-util/resolve-ci-config
 
   code-coverage:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/rocprofiler-sdk-code_coverage.yml
+++ b/.github/workflows/rocprofiler-sdk-code_coverage.yml
@@ -12,6 +12,7 @@ on:
       - 'projects/rocprofiler-sdk/**'
       - '.github/workflows/rocprofiler-sdk-code_coverage.yml'
       - '.github/actions/rocprofiler-sdk-util/action.yml'
+      - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/action.yml'
       - '!**/*.md'
       - '!**/*.rtf'
       - '!**/*.rst'
@@ -26,6 +27,7 @@ on:
       - 'projects/rocprofiler-sdk/**'
       - '.github/workflows/rocprofiler-sdk-code_coverage.yml'
       - '.github/actions/rocprofiler-sdk-util/action.yml'
+      - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/action.yml'
       - '!**/*.md'
       - '!**/*.rtf'
       - '!**/*.rst'
@@ -74,8 +76,28 @@ env:
   ENABLE_ROCJPEG_BUILD: "true"
 
 jobs:
+  ci_config:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
+    name: Load CI config
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      gfx94x_runner: ${{ steps.runner.outputs.gfx94x_runner }}
+    steps:
+    - name: Checkout workflow actions
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        sparse-checkout: .github/actions/rocprofiler-sdk-util/resolve-ci-config
+        set-safe-directory: true
+
+    - name: Resolve runner labels
+      id: runner
+      uses: ./.github/actions/rocprofiler-sdk-util/resolve-ci-config
+
   code-coverage:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
+    needs: ci_config
     name: Code Coverage • ${{ matrix.system.gpu }} • ${{ matrix.system.os }}
     permissions:
       contents: write
@@ -84,9 +106,9 @@ jobs:
       # fail-fast: false
       matrix:
         system:
-          - { gpu: 'mi325', runner: 'linux-gfx942-1gpu-core42-ossci-rocm', os: 'ubuntu-22.04', build-type: 'Release', gpu-target: 'gfx94X' }
+          - { gpu: 'mi325', os: 'ubuntu-22.04', build-type: 'Release', gpu-target: 'gfx94X' }
 
-    runs-on: ${{ matrix.system.runner }}
+    runs-on: ${{ needs.ci_config.outputs.gfx94x_runner }}
     container:
       image: docker.io/rocm/rocprofiler-private:${{ matrix.system.os }}-${{ matrix.system.gpu-target }}-latest
       credentials:
@@ -99,7 +121,7 @@ jobs:
     # define this for containers
     env:
       GIT_DISCOVERY_ACROSS_FILESYSTEM: 1
-      GPU_RUNNER: ${{ matrix.system.runner }}
+      GPU_RUNNER: ${{ needs.ci_config.outputs.gfx94x_runner }}
       GCC_COMPILER_VERSION: 11
 
     steps:
@@ -218,7 +240,7 @@ jobs:
         enable-aqlprofile-build: ${{ env.ENABLE_AQLPROFILE_BUILD }}
         enable-rocdecode-build: ${{ env.ENABLE_ROCDECODE_BUILD }}
         enable-rocjpeg-build: ${{ env.ENABLE_ROCJPEG_BUILD }}
-        ccache-key: ccache-${{ matrix.system.os }}-${{ matrix.system.runner }}-${{ matrix.system.gpu }}
+        ccache-key: ccache-${{ matrix.system.os }}-${{ needs.ci_config.outputs.gfx94x_runner }}-${{ matrix.system.gpu }}
         ccache-variant: ccache
 
     - name: Configure, Build, and Test (Total Code Coverage)
@@ -229,7 +251,7 @@ jobs:
         python3 ./source/scripts/run-ci.py -B build
           --name ${{ github.repository }}-${{ github.ref_name }}-${{ matrix.system.os }}-${{ matrix.system.gpu }}-codecov
           --build-jobs 16
-          --site ${{ matrix.system.runner }}
+          --site ${{ needs.ci_config.outputs.gfx94x_runner }}
           --gpu-targets ${{ env.GPU_TARGETS }}
           --coverage all
           --run-attempt ${{ github.run_attempt }}
@@ -252,7 +274,7 @@ jobs:
         python3 ./source/scripts/run-ci.py -B build
           --name ${{ github.repository }}-${{ github.ref_name }}-${{ matrix.system.os }}-${{ matrix.system.gpu }}-codecov-tests
           --build-jobs 16
-          --site ${{ matrix.system.runner }}
+          --site ${{ needs.ci_config.outputs.gfx94x_runner }}
           --gpu-targets ${{ env.GPU_TARGETS }}
           --coverage tests
           --run-attempt ${{ github.run_attempt }}
@@ -275,7 +297,7 @@ jobs:
         python3 ./source/scripts/run-ci.py -B build
           --name ${{ github.repository }}-${{ github.ref_name }}-${{ matrix.system.os }}-${{ matrix.system.gpu }}-codecov-samples
           --build-jobs 16
-          --site ${{ matrix.system.runner }}
+          --site ${{ needs.ci_config.outputs.gfx94x_runner }}
           --gpu-targets ${{ env.GPU_TARGETS }}
           --coverage samples
           --run-attempt ${{ github.run_attempt }}

--- a/.github/workflows/rocprofiler-sdk-continuous_integration.yml
+++ b/.github/workflows/rocprofiler-sdk-continuous_integration.yml
@@ -10,6 +10,7 @@ on:
       - 'projects/rocprofiler-sdk/**'
       - '.github/workflows/rocprofiler-sdk-continuous_integration.yml'
       - '.github/actions/rocprofiler-sdk-util/action.yml'
+      - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/action.yml'
       - '!**/*.md'
       - '!**/*.rtf'
       - '!**/*.rst'
@@ -24,6 +25,7 @@ on:
       - 'projects/rocprofiler-sdk/**'
       - '.github/workflows/rocprofiler-sdk-continuous_integration.yml'
       - '.github/actions/rocprofiler-sdk-util/action.yml'
+      - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/action.yml'
       - '!**/*.md'
       - '!**/*.rtf'
       - '!**/*.rst'
@@ -87,11 +89,31 @@ env:
 
 
 jobs:
+  ci_config:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
+    name: Load CI config
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      gfx94x_runner: ${{ steps.runner.outputs.gfx94x_runner }}
+    steps:
+      - name: Checkout workflow actions
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions/rocprofiler-sdk-util/resolve-ci-config
+          set-safe-directory: true
+
+      - name: Resolve runner labels
+        id: runner
+        uses: ./.github/actions/rocprofiler-sdk-util/resolve-ci-config
+
   # -----------------------------------------------------------------------------
   # Ubuntu / DEB job(s)
   # -----------------------------------------------------------------------------
   core-deb:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
+    needs: ci_config
     name: Core • ${{ matrix.system.gpu }} • ${{ matrix.system.os }}
     strategy:
       fail-fast: false
@@ -100,8 +122,8 @@ jobs:
           # TEMPORARILY DISABLED: navi3/navi4 jobs pending CI stabilization
           # - { gpu: 'navi4', runner: 'rocprofiler-navi4-dind', os: 'ubuntu-22.04', build-type: 'RelWithDebInfo', ci-flags: '--linter clang-tidy', gpu-target: 'gfx120X' }
           # - { gpu: 'navi3', runner: 'rocprofiler-navi3-dind', os: 'ubuntu-22.04', build-type: 'RelWithDebInfo', ci-flags: '--linter clang-tidy', gpu-target: 'gfx110X' }
-          - { gpu: 'mi325', runner: 'linux-gfx942-1gpu-core42-ossci-rocm', os: 'ubuntu-22.04', build-type: 'RelWithDebInfo', ci-flags: '--linter clang-tidy', gpu-target: 'gfx94X' }
-    runs-on: ${{ matrix.system.runner }}
+          - { gpu: 'mi325', os: 'ubuntu-22.04', build-type: 'RelWithDebInfo', ci-flags: '--linter clang-tidy', gpu-target: 'gfx94X' }
+    runs-on: ${{ needs.ci_config.outputs.gfx94x_runner }}
     container:
       image: docker.io/rocm/rocprofiler-private:${{ matrix.system.os }}-${{ matrix.system.gpu-target }}-latest
       credentials:
@@ -201,7 +223,7 @@ jobs:
           enable-rocdecode-build: ${{ env.ENABLE_ROCDECODE_BUILD }}
           enable-rocjpeg-build: ${{ env.ENABLE_ROCJPEG_BUILD }}
           enable-rocprof-trace-decoder-build: 'true'
-          ccache-key: ccache-${{ matrix.system.os }}-${{ matrix.system.runner }}-${{ matrix.system.gpu }}
+          ccache-key: ccache-${{ matrix.system.os }}-${{ needs.ci_config.outputs.gfx94x_runner }}-${{ matrix.system.gpu }}
           ccache-variant: ccache
 
       - name: Enable PC Sampling
@@ -222,7 +244,7 @@ jobs:
             --name ${{ github.repository }}-${{ github.ref_name }}-${{ matrix.system.os }}-${{ matrix.system.gpu }}-core \
             --build-jobs 16 \
             --mode ${CI_MODE} \
-            --site ${{ matrix.system.runner }} \
+            --site ${{ needs.ci_config.outputs.gfx94x_runner }} \
             --gpu-targets ${{ env.GPU_TARGETS }} \
             --run-attempt ${{ github.run_attempt }} \
             ${{ matrix.system.ci-flags }} -- \
@@ -320,15 +342,16 @@ jobs:
   # -----------------------------------------------------------------------------
   core-rpm:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
+    needs: ci_config
     name: Core • ${{ matrix.system.gpu }} • ${{ matrix.system.os }}
     strategy:
       fail-fast: false
       matrix:
         system:
-          - { os: 'rhel-8.8', runner: 'linux-gfx942-1gpu-core42-ossci-rocm', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo', ci-flags: '' }
-          - { os: 'rhel-9.5', runner: 'linux-gfx942-1gpu-core42-ossci-rocm', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo', ci-flags: '' }
-          - { os: 'sles-15.6', runner: 'linux-gfx942-1gpu-core42-ossci-rocm', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo', ci-flags: '' }
-    runs-on: ${{ matrix.system.runner }}
+          - { os: 'rhel-8.8', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo', ci-flags: '' }
+          - { os: 'rhel-9.5', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo', ci-flags: '' }
+          - { os: 'sles-15.6', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo', ci-flags: '' }
+    runs-on: ${{ needs.ci_config.outputs.gfx94x_runner }}
     container:
       image: docker.io/rocm/rocprofiler-private:${{ matrix.system.os }}-${{ matrix.system.gpu-target }}-latest
       credentials:
@@ -413,7 +436,7 @@ jobs:
           enable-rocprofiler-register-build: ${{ env.ENABLE_ROCPROFILER_REGISTER_BUILD }}
           enable-aqlprofile-build: ${{ env.ENABLE_AQLPROFILE_BUILD }}
           enable-rocprof-trace-decoder-build: 'true'
-          ccache-key: ccache-${{ matrix.system.os }}-${{ matrix.system.runner }}-${{ matrix.system.gpu }}
+          ccache-key: ccache-${{ matrix.system.os }}-${{ needs.ci_config.outputs.gfx94x_runner }}-${{ matrix.system.gpu }}
           ccache-variant: sccache
 
       - name: Enable PC Sampling
@@ -434,7 +457,7 @@ jobs:
             --name ${{ github.repository }}-${{ github.ref_name }}-${{ matrix.system.os }}-${{ matrix.system.gpu }}-core \
             --mode ${CI_MODE} \
             --build-jobs 16 \
-            --site ${{ matrix.system.runner }} \
+            --site ${{ needs.ci_config.outputs.gfx94x_runner }} \
             --gpu-targets ${{ env.GPU_TARGETS }} \
             --run-attempt ${{ github.run_attempt }} \
             ${{ matrix.system.ci-flags }} \

--- a/.github/workflows/rocprofiler-sdk-continuous_integration.yml
+++ b/.github/workflows/rocprofiler-sdk-continuous_integration.yml
@@ -10,7 +10,7 @@ on:
       - 'projects/rocprofiler-sdk/**'
       - '.github/workflows/rocprofiler-sdk-continuous_integration.yml'
       - '.github/actions/rocprofiler-sdk-util/action.yml'
-      - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/action.yml'
+      - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/**'
       - '!**/*.md'
       - '!**/*.rtf'
       - '!**/*.rst'
@@ -25,7 +25,7 @@ on:
       - 'projects/rocprofiler-sdk/**'
       - '.github/workflows/rocprofiler-sdk-continuous_integration.yml'
       - '.github/actions/rocprofiler-sdk-util/action.yml'
-      - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/action.yml'
+      - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/**'
       - '!**/*.md'
       - '!**/*.rtf'
       - '!**/*.rst'
@@ -97,6 +97,7 @@ jobs:
       contents: read
     outputs:
       gfx94x_runner: ${{ steps.runner.outputs.gfx94x_runner }}
+      gfx94x_sandbox_runner: ${{ steps.runner.outputs.gfx94x_sandbox_runner }}
     steps:
       - name: Checkout workflow actions
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -476,17 +477,18 @@ jobs:
 
   sanitizers:
     if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    needs: ci_config
     name: ${{ matrix.system.sanitizer }} • ${{ matrix.system.gpu }} • ${{ matrix.system.os }}
     strategy:
       fail-fast: false
       matrix:
         system:
-          - { sanitizer: 'AddressSanitizer', os: 'ubuntu-22.04', runner: 'linux-mi325-gpu-rocm-cpu-sandbox', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
-          - { sanitizer: 'ThreadSanitizer', os: 'ubuntu-22.04', runner: 'linux-mi325-gpu-rocm-cpu-sandbox', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
-          - { sanitizer: 'LeakSanitizer', os: 'ubuntu-22.04', runner: 'linux-mi325-gpu-rocm-cpu-sandbox', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
-          - { sanitizer: 'UndefinedBehaviorSanitizer', os: 'ubuntu-22.04', runner: 'linux-mi325-gpu-rocm-cpu-sandbox', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
+          - { sanitizer: 'AddressSanitizer', os: 'ubuntu-22.04', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
+          - { sanitizer: 'ThreadSanitizer', os: 'ubuntu-22.04', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
+          - { sanitizer: 'LeakSanitizer', os: 'ubuntu-22.04', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
+          - { sanitizer: 'UndefinedBehaviorSanitizer', os: 'ubuntu-22.04', gpu: 'mi325', gpu-target: 'gfx94X', build-type: 'RelWithDebInfo' }
 
-    runs-on: ${{ matrix.system.runner }}
+    runs-on: ${{ needs.ci_config.outputs.gfx94x_sandbox_runner }}
     container:
       image: docker.io/rocm/rocprofiler-private:${{ matrix.system.os }}-${{ matrix.system.gpu-target }}-latest
       credentials:
@@ -582,7 +584,7 @@ jobs:
         enable-rocprofiler-register-build: ${{ env.ENABLE_ROCPROFILER_REGISTER_BUILD }}
         enable-aqlprofile-build: ${{ env.ENABLE_AQLPROFILE_BUILD }}
         enable-rocprof-trace-decoder-build: 'true'
-        ccache-key: ccache-${{ matrix.system.os }}-${{ matrix.system.runner }}-${{ matrix.system.gpu }}-${{ matrix.system.sanitizer}}
+        ccache-key: ccache-${{ matrix.system.os }}-${{ needs.ci_config.outputs.gfx94x_sandbox_runner }}-${{ matrix.system.gpu }}-${{ matrix.system.sanitizer}}
         ccache-variant: ccache
 
     - name: Configure, Build, and Test
@@ -597,7 +599,7 @@ jobs:
           --name ${{ github.repository }}-${{ github.ref_name }}-${{ matrix.system.os }}-${{ matrix.system.gpu }}-${{ matrix.system.sanitizer }} \
           --build-jobs 16 \
           --mode ${CI_MODE} \
-          --site ${{ matrix.system.runner }} \
+          --site ${{ needs.ci_config.outputs.gfx94x_sandbox_runner }} \
           --gpu-targets ${{ env.GPU_TARGETS }} \
           --memcheck ${{ matrix.system.sanitizer }} \
           --run-attempt ${{ github.run_attempt }} \

--- a/.github/workflows/rocprofiler-sdk-docs.yml
+++ b/.github/workflows/rocprofiler-sdk-docs.yml
@@ -14,7 +14,7 @@ on:
       - 'projects/rocprofiler-sdk/.github/workflows/docs.yml'
       - '.github/workflows/rocprofiler-sdk-docs.yml'
       - '.github/actions/rocprofiler-sdk-util/action.yml'
-      - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/action.yml'
+      - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/**'
   pull_request:
     paths:
       - 'projects/rocprofiler-sdk/*.md'
@@ -25,7 +25,7 @@ on:
       - 'projects/rocprofiler-sdk/.github/workflows/docs.yml'
       - '.github/workflows/rocprofiler-sdk-docs.yml'
       - '.github/actions/rocprofiler-sdk-util/action.yml'
-      - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/action.yml'
+      - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -49,6 +49,7 @@ jobs:
       contents: read
     outputs:
       gfx94x_runner: ${{ steps.runner.outputs.gfx94x_runner }}
+      gfx94x_sandbox_runner: ${{ steps.runner.outputs.gfx94x_sandbox_runner }}
     steps:
       - name: Checkout workflow actions
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/rocprofiler-sdk-docs.yml
+++ b/.github/workflows/rocprofiler-sdk-docs.yml
@@ -14,6 +14,7 @@ on:
       - 'projects/rocprofiler-sdk/.github/workflows/docs.yml'
       - '.github/workflows/rocprofiler-sdk-docs.yml'
       - '.github/actions/rocprofiler-sdk-util/action.yml'
+      - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/action.yml'
   pull_request:
     paths:
       - 'projects/rocprofiler-sdk/*.md'
@@ -24,6 +25,7 @@ on:
       - 'projects/rocprofiler-sdk/.github/workflows/docs.yml'
       - '.github/workflows/rocprofiler-sdk-docs.yml'
       - '.github/actions/rocprofiler-sdk-util/action.yml'
+      - '.github/actions/rocprofiler-sdk-util/resolve-ci-config/action.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -39,6 +41,25 @@ env:
   SUBMODULE_PATHS: "projects/rocprofiler-sdk projects/rocr-runtime projects/clr projects/hip"
 
 jobs:
+  ci_config:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
+    name: Load CI config
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      gfx94x_runner: ${{ steps.runner.outputs.gfx94x_runner }}
+    steps:
+      - name: Checkout workflow actions
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions/rocprofiler-sdk-util/resolve-ci-config
+          set-safe-directory: true
+
+      - name: Resolve runner labels
+        id: runner
+        uses: ./.github/actions/rocprofiler-sdk-util/resolve-ci-config
+
   build-docs:
     runs-on: ubuntu-latest
     container: continuumio/miniconda3
@@ -84,7 +105,8 @@ jobs:
 
   build-docs-from-source:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
-    runs-on: linux-gfx942-1gpu-core42-ossci-rocm
+    needs: ci_config
+    runs-on: ${{ needs.ci_config.outputs.gfx94x_runner }}
     container:
       image: docker.io/rocm/rocprofiler-private:ubuntu-22.04-gfx94X-latest
       credentials:


### PR DESCRIPTION
## Motivation

- Replace the decommissioned `linux-gfx942-1gpu-core42-ossci-rocm` runner label in rocprofiler/aqlprofile CI with runner labels resolved dynamically from ROCm/therock-ci-config, so future runner migrations are picked up without per-workflow hard-coded label changes.

- stopped all checks except: https://github.com/ROCm/rocm-systems/actions/runs/28532793576/job/84586617350?pr=8070 to verify

## Technical Details

- Added `.github/actions/rocprofiler-sdk-util/resolve-ci-config` to use `ROCm/therock-ci-config` and get gfx94x_runner. updated the affected workflows to route GPU jobs through a ci_config setup job output via `needs.ci_config.outputs.gfx94x_runner`.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
