### PR TITLE
fix(hip-tests): add YAML config for Unit_hipMemset_UnalignedKernelCornerCases

### DIFF
--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -793,6 +793,9 @@ memory:
   Unit_hipMemsetD8Async_KernelBuffer:
     <<: *level_2
     tags: [memset]
+  Unit_hipMemset_UnalignedKernelCornerCases:
+    <<: *level_2
+    tags: [memset]
   Unit_hipMemsetD16_UnalignedPatternFill:
     <<: *level_2
     tags: [memset]


### PR DESCRIPTION
## Motivation

  PR #3872 (AIRUNTIME-124) added 5 new test cases to hipMemsetFunctional.cc but only registered 4 of them in the YAML config. The missing entry caused CI to fail
   with:

  [check_sources] ERROR: The following Catch2 test cases have no entry in their YAML config:
    memory/Unit_hipMemset_UnalignedKernelCornerCases

  ## Technical Details

  Added the missing `Unit_hipMemset_UnalignedKernelCornerCases` entry to `catch/config/configs/unit/memory.yaml`, matching the same `*level_2` + `[memset]` tag
  pattern as the other 4 entries added in #3872.

  ## JIRA ID

ROCM-27468

  ## Test Plan

  Ran `check_sources.py` locally:
  python3 catch/config/check_sources.py catch/config/configs catch/

  ## Test Result

  Script exits 0 with no errors after the fix.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
