### PR TITLE
fix(hip-tests): Add UnalignedKernelCornerCases entry in memory.yaml

### DIFF
--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -805,6 +805,9 @@ memory:
   Unit_hipMemsetD32Async_UnalignedPatternFill:
     <<: *level_2
     tags: [memset]
+  Unit_hipMemset_UnalignedKernelCornerCases:
+    <<: *level_2
+    tags: [memset]
   Unit_hipMemcpy2DArrayToArray_Negative:
     <<: *level_2
     tags: [transfer, image]


### PR DESCRIPTION
hipMemset_UnalignedKernelCornerCases was added in PR https://github.com/ROCm/rocm-systems/pull/3872, but was not included in the memory.yaml. Subsequent PRs in rocm-systems are seeing errors in TheRock build:
ERROR: The following Catch2 test cases have no entry in their YAML config.

Error was reproduced locally via:
cd projects/hip-tests
THEROCK_REQUIRE_HIP_YAML_ENTRIES=1 python3 catch/config/check_sources.py catch/config/configs catch.

Fixes issues introduced in #3872.

## Motivation
Unblock rocm-systems PRs.

## Technical Details
Missing entry in yaml file.

## JIRA ID


## Test Plan

`cd projects/hip-tests`
`THEROCK_REQUIRE_HIP_YAML_ENTRIES=1 python3 catch/config/check_sources.py catch/config/configs catch`

## Test Result

No error.
