### PR TITLE
fix: [rocr]Raise multicast threshold to 8MB

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -29,6 +29,7 @@
 #include <vector>
 #include <atomic>
 #include <cinttypes>
+#include <mutex>
 
 #if defined(__AVX__)
 #if defined(__MINGW64__)
@@ -2316,6 +2317,35 @@ void VirtualGPU::ReleaseHwQueue() {
 }
 
 // ================================================================================================
+// hsa_amd_profiling_async_copy_enable() is a process-global toggle shared by
+// every agent/queue, so it cannot be scoped per-stream. Multiple VirtualGPUs
+// (one per stream, potentially on different host threads) may want SDMA
+// profiling enabled for their in-flight command at the same time. Guard the
+// global with a process-wide refcount under a lock: enable on the 0->1
+// transition, disable on the 1->0 transition, so it stays on exactly while at
+// least one profiled command is outstanding and is never toggled off from
+// under a concurrent profiled command on another stream.
+namespace {
+std::mutex g_sdmaProfilingLock;
+uint32_t g_sdmaProfilingRefCount = 0;
+
+void acquireSdmaProfiling() {
+  std::lock_guard<std::mutex> lock(g_sdmaProfilingLock);
+  if (g_sdmaProfilingRefCount++ == 0) {
+    Hsa::profiling_async_copy_enable(true);
+  }
+}
+
+void releaseSdmaProfiling() {
+  std::lock_guard<std::mutex> lock(g_sdmaProfilingLock);
+  assert(g_sdmaProfilingRefCount > 0 && "unbalanced SDMA profiling release");
+  if (--g_sdmaProfilingRefCount == 0) {
+    Hsa::profiling_async_copy_enable(false);
+  }
+}
+}  // namespace
+
+// ================================================================================================
 /* profilingBegin, when profiling is enabled, creates a timestamp to save in
  * virtualgpu's timestamp_, saves the pointer timestamp_ to the command's data
  * and then calls start() to get the current host timestamp.
@@ -2349,10 +2379,14 @@ void VirtualGPU::profilingBegin(amd::Command& command, bool sdmaProfiling) {
     timestamp_ = new Timestamp(this, command);
     command.data().emplace_back(timestamp_);
     timestamp_->start();
-    // Enable SDMA profiling on the first access if profiling is set
-    // Its not per command basis
-    if (sdmaProfiling && !Barriers().GetSDMAProfiling()) {
-      Barriers().SetSDMAProfiling(true);
+    // Enable SDMA profiling for this command only; disabled in profilingEnd().
+    // The underlying HSA async-copy profiling flag is process-global, so use a
+    // refcounted, locked acquire instead of a per-stream bool (which races
+    // across concurrent streams and could disable profiling out from under
+    // another stream's in-flight profiled copy).
+    if (sdmaProfiling) {
+      acquireSdmaProfiling();
+      sdma_profiling_for_cmd_ = true;
     }
   }
 
@@ -2403,6 +2437,11 @@ void VirtualGPU::profilingEnd(bool clearHwEvent) {
       }
       timestamp_ = nullptr;
     }
+  }
+
+  if (sdma_profiling_for_cmd_) {
+    releaseSdmaProfiling();
+    sdma_profiling_for_cmd_ = false;
   }
 
   // Certain commands like map/unmap memory may not need hw_events as its not a

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -301,13 +301,6 @@ class VirtualGPU : public device::VirtualDevice {
     //! Adds a raw signal for dependency tracking
     void AddDynamicQueueWait(hsa_signal_t signal) { dynamic_queue_waits_.push_back(signal); }
 
-    //! Get/Set SDMA profiling
-    bool GetSDMAProfiling() { return sdma_profiling_; }
-    void SetSDMAProfiling(bool profile) {
-      sdma_profiling_ = profile;
-      Hsa::profiling_async_copy_enable(profile);
-    }
-
    private:
     //! Creates HSA signal with the specified scope
     bool CreateSignal(ProfilingSignal* signal, bool interrupt = false) const;
@@ -323,7 +316,6 @@ class VirtualGPU : public device::VirtualDevice {
     std::stack<ProfilingSignal*> signal_pool_;       //!< The pool of free signals without interrupt
     std::vector<ProfilingSignal*> signal_list_;      //!< The pool of all signals for processing
     size_t current_id_ = 0;                          //!< Last submitted signal
-    bool sdma_profiling_ = false;                    //!< If TRUE, then SDMA profiling is enabled
     const VirtualGPU& gpu_;                          //!< VirtualGPU, associated with this tracker
     std::vector<ProfilingSignal*> external_signals_;  //!< External signals for a wait in this queue
     std::vector<hsa_signal_t> dynamic_queue_waits_;   //!< Extra raw signals for a wait in this queue
@@ -818,6 +810,7 @@ class VirtualGPU : public device::VirtualDevice {
   };
 
   Timestamp* timestamp_;
+  bool sdma_profiling_for_cmd_ = false;  //!< SDMA profiling enabled for current command
   amd::Command* command_;   //!< Current command
   //! Monotonic client coalesce id of the last barrier from submitMarker, used to
   //! coalesce consecutive records. Execution() lock only. 0 = no window open.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -1813,6 +1813,23 @@ hsa_status_t GpuAgent::DmaCopyFanOutOp(
   return coordinator->SubmitEpilogue(out_signal, kWaitValue, body_raw);
 }
 
+// Formats a destination pointer list for SDMA debug logging. Only called from
+// within LogPrint (guarded by the log flag), so it costs nothing when SDMA
+// logging is disabled. Caps the output so a large fan-out cannot flood the log.
+static std::string FormatDstList(void* const* dsts, uint32_t num) {
+  constexpr uint32_t kMaxShown = 16;
+  std::string out = "[";
+  const uint32_t shown = std::min(num, kMaxShown);
+  char buf[32];
+  for (uint32_t i = 0; i < shown; ++i) {
+    snprintf(buf, sizeof(buf), "%s%p", i ? ", " : "", dsts[i]);
+    out += buf;
+  }
+  if (num > kMaxShown) out += ", ...";
+  out += "]";
+  return out;
+}
+
 hsa_status_t GpuAgent::DmaCopyBroadcast(
     const hsa_amd_memory_copy_op_t& op,
     std::vector<core::Signal*>& dep_signals) {
@@ -1823,12 +1840,16 @@ hsa_status_t GpuAgent::DmaCopyBroadcast(
   const uint16_t num_entries = op.num_entries;
 
   // Size thresholds for multi-destination copy path selection.
-  // kMulticastMaxSize: HW multicast/broadcast packet reliable limit (256 KB).
-  //   gfx1250 multicast drops destinations above this.
-  // kB2BMinSize: minimum per-copy size for linearB2B on non-gfx1250.
-  //   Below this, the broadcast packet (2-dst) is used instead.
-  constexpr size_t kMulticastMaxSize = 256 * 1024;
+  // kMulticastMaxSize: gfx1250 multicast/fan-out crossover (8 MB).
+  //   Below this the single-engine multicast packet wins; above it fan-out
+  //   across multiple SDMA engines delivers higher aggregate bandwidth.
+  // kB2BMinSize/kB2BMaxSize: per-copy size window for linearB2B on non-gfx1250.
+  //   Below kB2BMinSize the broadcast packet (2-dst) is used instead; above
+  //   kB2BMaxSize fan-out parallelises across engines. Kept consistent with
+  //   DmaCopyMulti and independent of the gfx1250 multicast threshold.
+  constexpr size_t kMulticastMaxSize = 8 * 1024 * 1024;
   constexpr size_t kB2BMinSize = 16 * 1024;
+  constexpr size_t kB2BMaxSize = 256 * 1024;
 
   // Try HW broadcast/multicast or linearB2B on one engine.
   {
@@ -1844,25 +1865,25 @@ hsa_status_t GpuAgent::DmaCopyBroadcast(
         out_signal.async_copy_agent(core::Agent::Convert(this->public_handle()));
 
       if (sdma_blit->IsGfx1250()) {
-        // gfx1250: multicast for small copies (<= 256 KB). The multicast engine
-        // silently drops destinations above that limit, so larger copies fall
-        // through to fan-out, which parallelises the per-destination copies
-        // across SDMA engines. Fan-out measured ~3-5% faster than packing all
-        // destinations into a single-engine linearB2B command at large sizes.
-        // HSA_SDMA_FORCE_MULTICAST=1 forces the multicast packet regardless of
-        // size (debug only; large copies will fail validation by design).
-        const bool force_multicast =
-            core::Runtime::runtime_singleton_->flag().sdma_force_multicast();
-        if (force_multicast || op.size <= kMulticastMaxSize) {
+        // gfx1250: multicast for copies <= 8 MB. Below this threshold the
+        // single-engine multicast packet matches or beats fan-out (saves
+        // per-destination signal overhead). Above 8 MB, fan-out across
+        // multiple SDMA engines delivers ~15% higher aggregate bandwidth.
+        // HSA_SDMA_MULTICAST: 1=force on, 0=force off, unset=auto (threshold).
+        const auto mc_flag = core::Runtime::runtime_singleton_->flag().sdma_multicast();
+        const bool use_multicast = (mc_flag == Flag::SDMA_ENABLE) ||
+            (mc_flag == Flag::SDMA_DEFAULT && op.size <= kMulticastMaxSize);
+        if (use_multicast) {
           // SubmitLinearCopyMulticastCommand picks the fused wait/signal packet
           // when profiling is off and the timestamp-capable plain packet when on.
           std::vector<void*> dsts(op.dst_list, op.dst_list + num_entries);
           LogPrint(HSA_AMD_LOG_FLAG_SDMA,
                    "SDMA Multicast engine %02u, src=%p, num_entries=%u, size=%zu, "
-                   "dep_signal=0x%zx, completion_signal=0x%zx",
+                   "dsts=%s, dep_signal=0x%zx, completion_signal=0x%zx",
                    BlitHostToDev, op.src, num_entries, op.size,
+                   FormatDstList(op.dst_list, num_entries).c_str(),
                    dep_signals.empty() ? 0 : core::Signal::Convert(dep_signals[0]).handle,
-                   out_signal_obj->signal_);
+                   core::Signal::Convert(out_signal_obj).handle);
           return sdma_blit->SubmitLinearCopyMulticastCommand(
               dsts, op.src, op.size, dep_signals, out_signal, profiling_enabled());
         }
@@ -1875,15 +1896,16 @@ hsa_status_t GpuAgent::DmaCopyBroadcast(
         const auto b2b_flag = core::Runtime::runtime_singleton_->flag().sdma_linear_b2b();
         const bool use_linear_b2b = (b2b_flag == Flag::SDMA_ENABLE) ||
             (b2b_flag == Flag::SDMA_DEFAULT && op.size >= kB2BMinSize &&
-             op.size <= kMulticastMaxSize);
+             op.size <= kB2BMaxSize);
 
         if (use_linear_b2b) {
           LogPrint(HSA_AMD_LOG_FLAG_SDMA,
                    "SDMA linearB2B engine %02u, src=%p, num_entries=%u, size=%zu, "
-                   "dep_signal=0x%zx, completion_signal=0x%zx",
+                   "dsts=%s, dep_signal=0x%zx, completion_signal=0x%zx",
                    BlitHostToDev, op.src, num_entries, op.size,
+                   FormatDstList(op.dst_list, num_entries).c_str(),
                    dep_signals.empty() ? 0 : core::Signal::Convert(dep_signals[0]).handle,
-                   out_signal_obj->signal_);
+                   core::Signal::Convert(out_signal_obj).handle);
           std::vector<void*> dsts(op.dst_list, op.dst_list + num_entries);
           std::vector<const void*> srcs(num_entries, op.src);
           std::vector<size_t> sizes(num_entries, op.size);
@@ -1894,10 +1916,11 @@ hsa_status_t GpuAgent::DmaCopyBroadcast(
         if (sdma_blit->BroadcastSupported() && op.size < kB2BMinSize) {
           LogPrint(HSA_AMD_LOG_FLAG_SDMA,
                    "SDMA Broadcast engine %02u, src=%p, num_entries=%u, size=%zu, "
-                   "dep_signal=0x%zx, completion_signal=0x%zx",
+                   "dsts=%s, dep_signal=0x%zx, completion_signal=0x%zx",
                    BlitHostToDev, op.src, num_entries, op.size,
+                   FormatDstList(op.dst_list, num_entries).c_str(),
                    dep_signals.empty() ? 0 : core::Signal::Convert(dep_signals[0]).handle,
-                   out_signal_obj->signal_);
+                   core::Signal::Convert(out_signal_obj).handle);
           std::vector<void*> dsts(op.dst_list, op.dst_list + num_entries);
           return sdma_blit->SubmitLinearCopyBroadcastCommand(
               dsts, op.src, op.size, dep_signals, out_signal);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
@@ -346,10 +346,10 @@ class Flag {
     var = os::GetEnvVar("HSA_SDMA_LINEAR_B2B");
     sdma_linear_b2b_ = (var == "0") ? SDMA_DISABLE : ((var == "1") ? SDMA_ENABLE : SDMA_DEFAULT);
 
-    // HSA_SDMA_FORCE_MULTICAST: 1=force gfx1250 broadcast onto the multicast
-    // packet regardless of copy size (debug only; the multicast engine drops
-    // destinations above 256 KB, so large copies will produce wrong data).
-    sdma_force_multicast_ = (os::GetEnvVar("HSA_SDMA_FORCE_MULTICAST") == "1");
+    // HSA_SDMA_MULTICAST: 1=force multicast at any size, 0=force off (fan-out),
+    // unset=auto (use multicast up to kMulticastMaxSize, fan-out above).
+    var = os::GetEnvVar("HSA_SDMA_MULTICAST");
+    sdma_multicast_ = (var == "0") ? SDMA_DISABLE : ((var == "1") ? SDMA_ENABLE : SDMA_DEFAULT);
 
   }
 
@@ -493,7 +493,7 @@ class Flag {
 
   SDMA_OVERRIDE sdma_linear_b2b() const { return sdma_linear_b2b_; }
 
-  bool sdma_force_multicast() const { return sdma_force_multicast_; }
+  SDMA_OVERRIDE sdma_multicast() const { return sdma_multicast_; }
 
   [[nodiscard]]
   bool core_dump_disable() const { return core_dump_disable_; }
@@ -576,7 +576,7 @@ class Flag {
   bool enable_dxg_detection_;
   SDMA_OVERRIDE sdma_linear_b2b_ = SDMA_DEFAULT;
 
-  bool sdma_force_multicast_ = false;
+  SDMA_OVERRIDE sdma_multicast_ = SDMA_DEFAULT;
 
   SDMA_OVERRIDE enable_sdma_;
   SDMA_OVERRIDE enable_peer_sdma_;


### PR DESCRIPTION
gfx1250 SDMA multicast is now used for multi-destination copies up to 8MB instead of 256KB. With the updated SDMA firmware the multicast engine no longer drops destinations above 256KB, and measurements show multicast matches or beats the fan-out path up to ~8MB (e.g. ~13% faster at 8MB), while fan-out across multiple SDMA engines still wins above that due to higher aggregate bandwidth.

Replace the boolean HSA_SDMA_FORCE_MULTICAST debug flag with a tri-state HSA_SDMA_MULTICAST override (SDMA_OVERRIDE), matching HSA_SDMA_LINEAR_B2B:
  1 = force multicast at any size
  0 = force off (always fan-out)
  unset = auto (multicast <= kMulticastMaxSize, fan-out above)

Also scope SDMA async-copy profiling to the lifetime of the profiled command. Previously SetSDMAProfiling(true) was latched on the first profiled SDMA command and never cleared, which left the runtime's profiling_enabled() flag on permanently and forced the slower timestamp-capable SDMA packet paths for all subsequent copies. It is now enabled in profilingBegin() and cleared in profilingEnd() per command.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

JIRA ID : AIRUNTIME-0

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
