### PR TITLE
fix(hip-tests): add YAML config for Unit_hipMemset_UnalignedKernelCornerCases

### DIFF
--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -805,6 +805,9 @@ memory:
   Unit_hipMemsetD32Async_UnalignedPatternFill:
     <<: *level_2
     tags: [memset]
+  Unit_hipMemset_UnalignedKernelCornerCases:
+    <<: *level_2
+    tags: [memset]
   Unit_hipMemcpy2DArrayToArray_Negative:
     <<: *level_2
     tags: [transfer, image]


### PR DESCRIPTION
## Motivation

CI (`Build Linux Packages`, `gfx950-dcgpu`) fails during the `hip-tests`
subproject build because a Catch2 test case has no matching entry in its
YAML config. With `THEROCK_REQUIRE_HIP_YAML_ENTRIES=1`, `check_sources.py`
treats this as a hard error and aborts the entire build:

```
[hip-tests] [check_sources] ERROR: The following Catch2 test cases have no entry in their YAML config:
[hip-tests] [check_sources]   memory/Unit_hipMemset_UnalignedKernelCornerCases
ninja: build stopped: subcommand failed.
```

This PR unblocks the build by adding the missing config entry.

## Technical Details

Commit 6c6d264 ("AIRUNTIME-124 Add Unaligned Memset kernel", #3872) added
the test case:

```cpp
TEST_CASE("Unit_hipMemset_UnalignedKernelCornerCases", "[fillBuffer][unaligned]")
```

in `projects/hip-tests/catch/unit/memory/hipMemsetFunctional.cc`, but the
YAML entries it added to `memory.yaml` use different names
(`Unit_hipMemsetD16/D32[Async]_UnalignedPatternFill`). No entry exists for
`Unit_hipMemset_UnalignedKernelCornerCases`.

This change adds the missing entry to
`projects/hip-tests/catch/config/configs/unit/memory.yaml`, matching the
existing unaligned memset entries:

```yaml
  Unit_hipMemset_UnalignedKernelCornerCases:
    <<: *level_2
    tags: [memset]
```

## JIRA ID

#3872

## Test Plan

Re-run the `hip-tests` source validation step (`check_hip_tests_sources`,
driven by `check_sources.py`) which enumerates all Catch2 `TEST_CASE`
names and requires each to have a YAML config entry.

## Test Result

`check_sources.py` no longer reports
`Unit_hipMemset_UnalignedKernelCornerCases` as missing; the hip-tests
build proceeds past the validation step.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
