### PR TITLE
fix(hotswap): enable gfx12.5 entry trampolines by default

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/functional/hotswap/fixtures/gfx1250_min.s
+++ b/projects/rocr-runtime/rocrtst/suites/functional/hotswap/fixtures/gfx1250_min.s
@@ -6,6 +6,32 @@
 .p2align 8
 .type empty_kernel,@function
 empty_kernel:
+  v_mov_b32_e32 v0, 0
   s_endpgm
 .Lfunc_end0:
   .size empty_kernel, .Lfunc_end0-empty_kernel
+
+.rodata
+.p2align 8
+.amdhsa_kernel empty_kernel
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 1
+  .amdhsa_inst_pref_size 7
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: empty_kernel
+      .symbol: empty_kernel.kd
+      .sgpr_count: 8
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
@@ -253,12 +253,12 @@ rocr::hotswap::AgentGfxRevision MakeRevision(const std::string& gfx_target,
   return revision;
 }
 
-TEST(HotswapRewriteDecision, A0RetargetsWithEntryTrampolinesWhenEnabled) {
+TEST(HotswapRewriteDecision, A0RetargetsWithDefaultEntryTrampolines) {
   struct TestCase {
     rocr::hotswap::RewriteOptions options;
     bool request_entry_trampolines;
   };
-  const TestCase cases[] = {{{}, false}, {{true}, true}, {{false}, false}};
+  const TestCase cases[] = {{{}, true}, {{true}, true}, {{false}, false}};
   for (const TestCase& test_case : cases) {
     SCOPED_TRACE(test_case.request_entry_trampolines
                      ? "entry trampolines enabled"
@@ -275,11 +275,14 @@ TEST(HotswapRewriteDecision, A0RetargetsWithEntryTrampolinesWhenEnabled) {
   }
 }
 
-TEST(HotswapRewriteDecision, EntryTrampolinesDefaultOffBlocksNonA0Gfx1250) {
+TEST(HotswapRewriteDecision, EntryTrampolinesDefaultOnRoutesNonA0Gfx1250) {
   const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
       MakeRevision("gfx1250", 1), kGfx1250Isa, kGfx1250Isa, {});
 
-  EXPECT_FALSE(decision.has_value());
+  ASSERT_TRUE(decision.has_value());
+  EXPECT_EQ(decision->source_isa, kGfx1250B0Isa);
+  EXPECT_EQ(decision->target_isa, kGfx1250B0Isa);
+  EXPECT_TRUE(decision->request_entry_trampolines);
 }
 
 TEST(HotswapRewriteDecision, EntryTrampolinesEnabledRoutesNonA0Gfx1250) {
@@ -448,6 +451,7 @@ TEST(HotswapRewrite, RuntimeLoadUsesRewrittenCodeObject) {
 TEST(HotswapRewrite, RuntimeLoadA0EntryTrampolinesChangeRewrittenCodeObject) {
   ResetRuntimeTestEnv();
   if (!NewComgrHotswapApiAvailable()) return;
+  g_fake_env_vars["AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES"] = "0";
   LoadRecorder legacy_load;
   const hsa_executable_t legacy_executable = MakeTestExecutable(0x502);
 
@@ -475,7 +479,6 @@ TEST(HotswapRewrite, RuntimeLoadA0EntryTrampolinesChangeRewrittenCodeObject) {
       0u);
 
   ResetRuntimeTestEnv();
-  g_fake_env_vars["AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES"] = "1";
   LoadRecorder entry_load;
   const hsa_executable_t entry_executable = MakeTestExecutable(0x503);
 
@@ -504,8 +507,9 @@ TEST(HotswapRewrite, RuntimeLoadA0EntryTrampolinesChangeRewrittenCodeObject) {
       0u);
 }
 
-TEST(HotswapRewrite, RuntimeLoadNonA0DefaultsToOriginal) {
+TEST(HotswapRewrite, RuntimeLoadNonA0DefaultsToEntryTrampolines) {
   ResetRuntimeTestEnv();
+  if (!NewComgrHotswapApiAvailable()) return;
   g_fake_hsa_env.asic_revision = 1;
   LoadRecorder load;
   const hsa_executable_t executable = MakeTestExecutable(0x504);
@@ -516,8 +520,11 @@ TEST(HotswapRewrite, RuntimeLoadNonA0DefaultsToOriginal) {
 
   EXPECT_EQ(status, HSA_STATUS_SUCCESS);
   ASSERT_EQ(load.calls.size(), 1u);
-  EXPECT_EQ(load.calls[0].path, LoadPath::kOriginal);
-  EXPECT_EQ(load.calls[0].code_object, static_cast<const void*>(kGfx1250MinCo));
+  EXPECT_EQ(load.calls[0].path, LoadPath::kRewritten);
+  EXPECT_EQ(
+      rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 1u);
+
+  rocr::hotswap::ReleaseRetainedRewrittenElfBuffers(executable);
   EXPECT_EQ(
       rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 0u);
 }

--- a/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
@@ -241,7 +241,7 @@ rocr::hotswap::AgentGfxRevision MakeRevision(const std::string& gfx_target,
 }
 
 TEST(HotswapRewriteDecision, A0RetargetsThroughLegacyPathRegardlessOfOptions) {
-  const rocr::hotswap::RewriteOptions options[] = {{}, {false}};
+  const rocr::hotswap::RewriteOptions options[] = {{}, {true}, {false}};
   for (const auto& option : options) {
     SCOPED_TRACE(option.gfx12_5_rewrite_enabled ? "entry trampolines enabled"
                                                 : "entry trampolines disabled");
@@ -255,9 +255,16 @@ TEST(HotswapRewriteDecision, A0RetargetsThroughLegacyPathRegardlessOfOptions) {
   }
 }
 
-TEST(HotswapRewriteDecision, EntryTrampolinesDefaultOnRoutesNonA0Gfx1250) {
+TEST(HotswapRewriteDecision, EntryTrampolinesDefaultOffBlocksNonA0Gfx1250) {
   const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
       MakeRevision("gfx1250", 1), kGfx1250Isa, kGfx1250Isa, {});
+
+  EXPECT_FALSE(decision.has_value());
+}
+
+TEST(HotswapRewriteDecision, EntryTrampolinesEnabledRoutesNonA0Gfx1250) {
+  const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
+      MakeRevision("gfx1250", 1), kGfx1250Isa, kGfx1250Isa, {true});
 
   ASSERT_TRUE(decision.has_value());
   EXPECT_EQ(decision->source_isa, kGfx1250B0Isa);
@@ -274,10 +281,10 @@ TEST(HotswapRewriteDecision, EntryTrampolinesDisabledBlocksNonA0Gfx1250) {
 
 TEST(HotswapRewriteDecision, EntryTrampolinesRouteGfx12_5Family) {
   const auto concrete = rocr::hotswap::DecideHotswapRewriteForTesting(
-      MakeRevision("gfx1251", 1), kGfx1251Isa, kGfx1251Isa, {});
+      MakeRevision("gfx1251", 1), kGfx1251Isa, kGfx1251Isa, {true});
   const auto generic = rocr::hotswap::DecideHotswapRewriteForTesting(
       MakeRevision("gfx12-5-generic", 1), kGfx12_5GenericIsa,
-      kGfx12_5GenericIsa, {});
+      kGfx12_5GenericIsa, {true});
 
   ASSERT_TRUE(concrete.has_value());
   EXPECT_EQ(concrete->source_isa, kGfx1251Isa);
@@ -291,7 +298,7 @@ TEST(HotswapRewriteDecision, EntryTrampolinesRouteGfx12_5Family) {
 
 TEST(HotswapRewriteDecision, EntryTrampolinesUseGenericSourceAsTarget) {
   const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
-      MakeRevision("gfx1251", 1), kGfx12_5GenericIsa, kGfx1251Isa, {});
+      MakeRevision("gfx1251", 1), kGfx12_5GenericIsa, kGfx1251Isa, {true});
 
   ASSERT_TRUE(decision.has_value());
   EXPECT_EQ(decision->source_isa, kGfx12_5GenericIsa);
@@ -301,7 +308,7 @@ TEST(HotswapRewriteDecision, EntryTrampolinesUseGenericSourceAsTarget) {
 
 TEST(HotswapRewriteDecision, EntryTrampolinesBlockNonGfx12_5) {
   const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
-      MakeRevision("gfx942", 0), kGfx942Isa, kGfx942Isa, {});
+      MakeRevision("gfx942", 0), kGfx942Isa, kGfx942Isa, {true});
 
   EXPECT_FALSE(decision.has_value());
 }
@@ -418,36 +425,11 @@ TEST(HotswapRewrite, RuntimeLoadUsesRewrittenCodeObject) {
       rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 0u);
 }
 
-TEST(HotswapRewrite, RuntimeLoadNonA0UsesDefaultEntryTrampolines) {
+TEST(HotswapRewrite, RuntimeLoadNonA0DefaultsToOriginal) {
   ResetRuntimeTestEnv();
-  if (!NewComgrHotswapApiAvailable()) return;
   g_fake_hsa_env.asic_revision = 1;
   LoadRecorder load;
   const hsa_executable_t executable = MakeTestExecutable(0x502);
-
-  const hsa_status_t status = rocr::hotswap::LoadAgentCodeObjectWithHotswap(
-      executable, MakeTestAgent(), MakeRealCodeObjectView(), nullptr, nullptr,
-      MakeLoadCallbacks(&load));
-
-  EXPECT_EQ(status, HSA_STATUS_SUCCESS);
-  ASSERT_EQ(load.calls.size(), 1u);
-  EXPECT_EQ(load.calls[0].path, LoadPath::kRewritten);
-  EXPECT_NE(load.calls[0].code_object, static_cast<const void*>(kGfx1250MinCo));
-  EXPECT_GT(load.calls[0].code_object_size, 0u);
-  EXPECT_EQ(
-      rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 1u);
-
-  rocr::hotswap::ReleaseRetainedRewrittenElfBuffers(executable);
-  EXPECT_EQ(
-      rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 0u);
-}
-
-TEST(HotswapRewrite, RuntimeLoadNonA0FallsBackWhenEntryTrampolinesAreZero) {
-  ResetRuntimeTestEnv();
-  g_fake_hsa_env.asic_revision = 1;
-  g_fake_env_vars["AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES"] = "0";
-  LoadRecorder load;
-  const hsa_executable_t executable = MakeTestExecutable(0x503);
 
   const hsa_status_t status = rocr::hotswap::LoadAgentCodeObjectWithHotswap(
       executable, MakeTestAgent(), MakeRealCodeObjectView(), nullptr, nullptr,
@@ -461,9 +443,34 @@ TEST(HotswapRewrite, RuntimeLoadNonA0FallsBackWhenEntryTrampolinesAreZero) {
       rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 0u);
 }
 
-TEST(HotswapRewrite, RuntimeLoadNonA0UsesEntryTrampolinesUnlessEnvIsZero) {
+TEST(HotswapRewrite, RuntimeLoadNonA0FallsBackWhenEntryTrampolinesDisabled) {
+  const char* const env_values[] = {"0", "false", "off", ""};
+  uint64_t executable_handle = 0x503;
+  for (const char* env_value : env_values) {
+    SCOPED_TRACE(env_value);
+    ResetRuntimeTestEnv();
+    g_fake_hsa_env.asic_revision = 1;
+    g_fake_env_vars["AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES"] = env_value;
+    LoadRecorder load;
+    const hsa_executable_t executable =
+        MakeTestExecutable(executable_handle++);
+
+    const hsa_status_t status = rocr::hotswap::LoadAgentCodeObjectWithHotswap(
+        executable, MakeTestAgent(), MakeRealCodeObjectView(), nullptr, nullptr,
+        MakeLoadCallbacks(&load));
+
+    EXPECT_EQ(status, HSA_STATUS_SUCCESS);
+    ASSERT_EQ(load.calls.size(), 1u);
+    EXPECT_EQ(load.calls[0].path, LoadPath::kOriginal);
+    EXPECT_EQ(load.calls[0].code_object, static_cast<const void*>(kGfx1250MinCo));
+    EXPECT_EQ(
+        rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 0u);
+  }
+}
+
+TEST(HotswapRewrite, RuntimeLoadNonA0UsesEntryTrampolinesWhenEnabled) {
   if (!NewComgrHotswapApiAvailable()) return;
-  const char* const env_values[] = {"false", ""};
+  const char* const env_values[] = {"1", "true", "on"};
   uint64_t executable_handle = 0x504;
   for (const char* env_value : env_values) {
     SCOPED_TRACE(env_value);

--- a/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
@@ -230,6 +230,19 @@ rocr::hotswap::CodeObjectView MakeRealCodeObjectView() {
   return code_object;
 }
 
+std::vector<unsigned char> CopyLoadedCodeObject(const LoadCall& call) {
+  const auto* bytes = static_cast<const unsigned char*>(call.code_object);
+  return std::vector<unsigned char>(bytes, bytes + call.code_object_size);
+}
+
+bool LoadedCodeObjectDiffersFrom(const LoadCall& call,
+                                 const std::vector<unsigned char>& expected) {
+  if (call.code_object_size != expected.size()) {
+    return true;
+  }
+  return std::memcmp(call.code_object, expected.data(), expected.size()) != 0;
+}
+
 rocr::hotswap::AgentGfxRevision MakeRevision(const std::string& gfx_target,
                                              uint32_t asic_revision,
                                              bool has_asic_revision = true) {
@@ -432,35 +445,70 @@ TEST(HotswapRewrite, RuntimeLoadUsesRewrittenCodeObject) {
       rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 0u);
 }
 
-TEST(HotswapRewrite, RuntimeLoadA0UsesEntryTrampolinesWhenEnabled) {
+TEST(HotswapRewrite, RuntimeLoadA0EntryTrampolinesChangeRewrittenCodeObject) {
   ResetRuntimeTestEnv();
   if (!NewComgrHotswapApiAvailable()) return;
-  g_fake_env_vars["AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES"] = "1";
-  LoadRecorder load;
-  const hsa_executable_t executable = MakeTestExecutable(0x502);
+  LoadRecorder legacy_load;
+  const hsa_executable_t legacy_executable = MakeTestExecutable(0x502);
 
   const hsa_status_t status = rocr::hotswap::LoadAgentCodeObjectWithHotswap(
-      executable, MakeTestAgent(), MakeRealCodeObjectView(), nullptr, nullptr,
-      MakeLoadCallbacks(&load));
+      legacy_executable, MakeTestAgent(), MakeRealCodeObjectView(), nullptr,
+      nullptr, MakeLoadCallbacks(&legacy_load));
 
   EXPECT_EQ(status, HSA_STATUS_SUCCESS);
-  ASSERT_EQ(load.calls.size(), 1u);
-  EXPECT_EQ(load.calls[0].path, LoadPath::kRewritten);
-  EXPECT_NE(load.calls[0].code_object, static_cast<const void*>(kGfx1250MinCo));
-  EXPECT_GT(load.calls[0].code_object_size, 0u);
+  ASSERT_EQ(legacy_load.calls.size(), 1u);
+  ASSERT_EQ(legacy_load.calls[0].path, LoadPath::kRewritten);
+  ASSERT_NE(legacy_load.calls[0].code_object,
+            static_cast<const void*>(kGfx1250MinCo));
+  ASSERT_GT(legacy_load.calls[0].code_object_size, 0u);
+  const std::vector<unsigned char> legacy_code_object =
+      CopyLoadedCodeObject(legacy_load.calls[0]);
   EXPECT_EQ(
-      rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 1u);
+      rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(
+          legacy_executable),
+      1u);
 
-  rocr::hotswap::ReleaseRetainedRewrittenElfBuffers(executable);
+  rocr::hotswap::ReleaseRetainedRewrittenElfBuffers(legacy_executable);
   EXPECT_EQ(
-      rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 0u);
+      rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(
+          legacy_executable),
+      0u);
+
+  ResetRuntimeTestEnv();
+  g_fake_env_vars["AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES"] = "1";
+  LoadRecorder entry_load;
+  const hsa_executable_t entry_executable = MakeTestExecutable(0x503);
+
+  const hsa_status_t entry_status =
+      rocr::hotswap::LoadAgentCodeObjectWithHotswap(
+          entry_executable, MakeTestAgent(), MakeRealCodeObjectView(), nullptr,
+          nullptr, MakeLoadCallbacks(&entry_load));
+
+  EXPECT_EQ(entry_status, HSA_STATUS_SUCCESS);
+  ASSERT_EQ(entry_load.calls.size(), 1u);
+  EXPECT_EQ(entry_load.calls[0].path, LoadPath::kRewritten);
+  EXPECT_NE(entry_load.calls[0].code_object,
+            static_cast<const void*>(kGfx1250MinCo));
+  EXPECT_GT(entry_load.calls[0].code_object_size, 0u);
+  EXPECT_TRUE(
+      LoadedCodeObjectDiffersFrom(entry_load.calls[0], legacy_code_object));
+  EXPECT_EQ(
+      rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(
+          entry_executable),
+      1u);
+
+  rocr::hotswap::ReleaseRetainedRewrittenElfBuffers(entry_executable);
+  EXPECT_EQ(
+      rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(
+          entry_executable),
+      0u);
 }
 
 TEST(HotswapRewrite, RuntimeLoadNonA0DefaultsToOriginal) {
   ResetRuntimeTestEnv();
   g_fake_hsa_env.asic_revision = 1;
   LoadRecorder load;
-  const hsa_executable_t executable = MakeTestExecutable(0x503);
+  const hsa_executable_t executable = MakeTestExecutable(0x504);
 
   const hsa_status_t status = rocr::hotswap::LoadAgentCodeObjectWithHotswap(
       executable, MakeTestAgent(), MakeRealCodeObjectView(), nullptr, nullptr,
@@ -476,7 +524,7 @@ TEST(HotswapRewrite, RuntimeLoadNonA0DefaultsToOriginal) {
 
 TEST(HotswapRewrite, RuntimeLoadNonA0FallsBackWhenEntryTrampolinesDisabled) {
   const char* const env_values[] = {"0", "false", "off", ""};
-  uint64_t executable_handle = 0x504;
+  uint64_t executable_handle = 0x510;
   for (const char* env_value : env_values) {
     SCOPED_TRACE(env_value);
     ResetRuntimeTestEnv();

--- a/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
@@ -240,18 +240,25 @@ rocr::hotswap::AgentGfxRevision MakeRevision(const std::string& gfx_target,
   return revision;
 }
 
-TEST(HotswapRewriteDecision, A0RetargetsThroughLegacyPathRegardlessOfOptions) {
-  const rocr::hotswap::RewriteOptions options[] = {{}, {true}, {false}};
-  for (const auto& option : options) {
-    SCOPED_TRACE(option.gfx12_5_rewrite_enabled ? "entry trampolines enabled"
-                                                : "entry trampolines disabled");
+TEST(HotswapRewriteDecision, A0RetargetsWithEntryTrampolinesWhenEnabled) {
+  struct TestCase {
+    rocr::hotswap::RewriteOptions options;
+    bool request_entry_trampolines;
+  };
+  const TestCase cases[] = {{{}, false}, {{true}, true}, {{false}, false}};
+  for (const TestCase& test_case : cases) {
+    SCOPED_TRACE(test_case.request_entry_trampolines
+                     ? "entry trampolines enabled"
+                     : "entry trampolines disabled");
     const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
-        MakeRevision("gfx1250", 0), kGfx1250Isa, kGfx1250Isa, option);
+        MakeRevision("gfx1250", 0), kGfx1250Isa, kGfx1250Isa,
+        test_case.options);
 
     ASSERT_TRUE(decision.has_value());
     EXPECT_EQ(decision->source_isa, kGfx1250B0Isa);
     EXPECT_EQ(decision->target_isa, kGfx1250A0Isa);
-    EXPECT_FALSE(decision->request_entry_trampolines);
+    EXPECT_EQ(decision->request_entry_trampolines,
+              test_case.request_entry_trampolines);
   }
 }
 
@@ -425,11 +432,35 @@ TEST(HotswapRewrite, RuntimeLoadUsesRewrittenCodeObject) {
       rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 0u);
 }
 
+TEST(HotswapRewrite, RuntimeLoadA0UsesEntryTrampolinesWhenEnabled) {
+  ResetRuntimeTestEnv();
+  if (!NewComgrHotswapApiAvailable()) return;
+  g_fake_env_vars["AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES"] = "1";
+  LoadRecorder load;
+  const hsa_executable_t executable = MakeTestExecutable(0x502);
+
+  const hsa_status_t status = rocr::hotswap::LoadAgentCodeObjectWithHotswap(
+      executable, MakeTestAgent(), MakeRealCodeObjectView(), nullptr, nullptr,
+      MakeLoadCallbacks(&load));
+
+  EXPECT_EQ(status, HSA_STATUS_SUCCESS);
+  ASSERT_EQ(load.calls.size(), 1u);
+  EXPECT_EQ(load.calls[0].path, LoadPath::kRewritten);
+  EXPECT_NE(load.calls[0].code_object, static_cast<const void*>(kGfx1250MinCo));
+  EXPECT_GT(load.calls[0].code_object_size, 0u);
+  EXPECT_EQ(
+      rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 1u);
+
+  rocr::hotswap::ReleaseRetainedRewrittenElfBuffers(executable);
+  EXPECT_EQ(
+      rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 0u);
+}
+
 TEST(HotswapRewrite, RuntimeLoadNonA0DefaultsToOriginal) {
   ResetRuntimeTestEnv();
   g_fake_hsa_env.asic_revision = 1;
   LoadRecorder load;
-  const hsa_executable_t executable = MakeTestExecutable(0x502);
+  const hsa_executable_t executable = MakeTestExecutable(0x503);
 
   const hsa_status_t status = rocr::hotswap::LoadAgentCodeObjectWithHotswap(
       executable, MakeTestAgent(), MakeRealCodeObjectView(), nullptr, nullptr,
@@ -445,7 +476,7 @@ TEST(HotswapRewrite, RuntimeLoadNonA0DefaultsToOriginal) {
 
 TEST(HotswapRewrite, RuntimeLoadNonA0FallsBackWhenEntryTrampolinesDisabled) {
   const char* const env_values[] = {"0", "false", "off", ""};
-  uint64_t executable_handle = 0x503;
+  uint64_t executable_handle = 0x504;
   for (const char* env_value : env_values) {
     SCOPED_TRACE(env_value);
     ResetRuntimeTestEnv();
@@ -471,7 +502,7 @@ TEST(HotswapRewrite, RuntimeLoadNonA0FallsBackWhenEntryTrampolinesDisabled) {
 TEST(HotswapRewrite, RuntimeLoadNonA0UsesEntryTrampolinesWhenEnabled) {
   if (!NewComgrHotswapApiAvailable()) return;
   const char* const env_values[] = {"1", "true", "on"};
-  uint64_t executable_handle = 0x504;
+  uint64_t executable_handle = 0x509;
   for (const char* env_value : env_values) {
     SCOPED_TRACE(env_value);
     ResetRuntimeTestEnv();

--- a/projects/rocr-runtime/runtime/docs/data/env_variables.rst
+++ b/projects/rocr-runtime/runtime/docs/data/env_variables.rst
@@ -107,9 +107,9 @@
 
     * - | ``AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES``
         | Controls whether ROCr requests COMGR entry-trampoline HotSwap rewriting for gfx12.5 targets.
-      - ``0``
-      - | Unset, empty, 0, ``false``, ``off``, ``no``, ``n``, or ``f``: Disable entry-trampoline rewrites.
-        | Any other non-empty value: Enable entry-trampoline rewrites for gfx125* and ``gfx12-5-generic`` targets.
+      - ``1``
+      - | Unset or any non-empty value except false-like values: Enable entry-trampoline rewrites for gfx125* and ``gfx12-5-generic`` targets.
+        | Empty, 0, ``false``, ``off``, ``no``, ``n``, or ``f``: Disable entry-trampoline rewrites.
 
     * - | ``HSA_ENABLE_DXG_DETECTION``
         | Controls detection of the DXG driver (/dev/dxg) on WSL2.

--- a/projects/rocr-runtime/runtime/docs/data/env_variables.rst
+++ b/projects/rocr-runtime/runtime/docs/data/env_variables.rst
@@ -107,9 +107,9 @@
 
     * - | ``AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES``
         | Controls whether ROCr requests COMGR entry-trampoline HotSwap rewriting for gfx12.5 targets.
-      - ``1``
-      - | 0: Disable entry-trampoline rewrites.
-        | Unset or any other value, including empty: Enable entry-trampoline rewrites for gfx125* and ``gfx12-5-generic`` targets.
+      - ``0``
+      - | Unset, empty, 0, ``false``, ``off``, ``no``, ``n``, or ``f``: Disable entry-trampoline rewrites.
+        | Any other non-empty value: Enable entry-trampoline rewrites for gfx125* and ``gfx12-5-generic`` targets.
 
     * - | ``HSA_ENABLE_DXG_DETECTION``
         | Controls detection of the DXG driver (/dev/dxg) on WSL2.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap.hpp
@@ -65,8 +65,10 @@ struct CodeObjectView {
   std::string uri;
 };
 
+inline constexpr bool kDefaultGfx12_5EntryTrampolinesEnabled = false;
+
 struct RewriteOptions {
-  bool gfx12_5_rewrite_enabled = true;
+  bool gfx12_5_rewrite_enabled = kDefaultGfx12_5EntryTrampolinesEnabled;
 };
 
 struct RewriteDecision {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap.hpp
@@ -65,7 +65,7 @@ struct CodeObjectView {
   std::string uri;
 };
 
-inline constexpr bool kDefaultGfx12_5EntryTrampolinesEnabled = false;
+inline constexpr bool kDefaultGfx12_5EntryTrampolinesEnabled = true;
 
 struct RewriteOptions {
   bool gfx12_5_rewrite_enabled = kDefaultGfx12_5EntryTrampolinesEnabled;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap.cpp
@@ -298,7 +298,7 @@ std::optional<RewriteDecision> DecideHotswapRewrite(
     return RewriteDecision{
         WithGfx1250SteppingFeature(source_isa, Gfx1250Stepping::kB0),
         WithGfx1250SteppingFeature(target_isa, Gfx1250Stepping::kA0),
-        false};
+        options.gfx12_5_rewrite_enabled};
   }
 
   if (!options.gfx12_5_rewrite_enabled ||

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap.cpp
@@ -98,8 +98,10 @@ bool IsHotswapDisabledByEnv() { return IsEnvFlagEnabled("HSA_HOTSWAP_DISABLE"); 
 
 bool IsGfx12_5RewriteRequested() {
   constexpr char kEnvName[] = "AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES";
-  // Default-on policy owned by ROCR: only literal "0" opts out.
-  return !os::IsEnvVarSet(kEnvName) || os::GetEnvVar(kEnvName) != "0";
+  if (!os::IsEnvVarSet(kEnvName)) {
+    return kDefaultGfx12_5EntryTrampolinesEnabled;
+  }
+  return IsEnvFlagEnabled(kEnvName);
 }
 
 bool IsVerboseLoggingEnabled() {


### PR DESCRIPTION
## JIRA ID

JIRA ID - ROCM-27304

## Summary
- Enable `AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES` by default in ROCr; unset now requests COMGR entry-trampoline rewriting for gfx12.5 targets.
- Keep explicit false-like values (`0`, `false`, `off`, `no`, `n`, `f`, or empty) as the escape hatch to disable entry-trampoline rewrites.
- Keep gfx1250 A0 B0-to-A0 hotswap enabled by default, and request kernel-entry trampolines on that same A0 rewrite by default.
- Keep gfx125* and `gfx12-5-generic` entry-trampoline routing covered by the same policy.
- Update hotswap tests and env-var docs for default-on semantics.

## Testing
- `git diff --check`
- `cmake --build build-rocrtst-hotswap-review --target hotswap_rewrite hotswap_gfx_query -j 8`
- `ctest --test-dir build-rocrtst-hotswap-review -R hotswap --output-on-failure`
- `LD_LIBRARY_PATH=/tmp/rocm-systems-comgr-3.2-test build-rocrtst-hotswap-review/hotswap_rewrite`