### PR TITLE
test(rccl):  increase gpu limit in unit tests to 64

### DIFF
--- a/projects/rccl/test/MiscTests.cpp
+++ b/projects/rccl/test/MiscTests.cpp
@@ -3,8 +3,8 @@
  *
  * See LICENSE.txt for license information
  ************************************************************************/
-#include comm.h
-#include gtest/gtest.h
+#include "comm.h"
+#include "gtest/gtest.h"
 
 namespace RcclUnitTesting
 {

--- a/projects/rccl/test/MiscTests.cpp
+++ b/projects/rccl/test/MiscTests.cpp
@@ -3,8 +3,8 @@
  *
  * See LICENSE.txt for license information
  ************************************************************************/
-#include "comm.h"
-#include "gtest/gtest.h"
+#include comm.h
+#include gtest/gtest.h
 
 namespace RcclUnitTesting
 {

--- a/projects/rccl/test/common/EnvVars.cpp
+++ b/projects/rccl/test/common/EnvVars.cpp
@@ -338,6 +338,11 @@ namespace RcclUnitTesting
     return gpuPriorityOrder;
   }
 
+  int EnvVars::GetNumDetectedGpus() const
+  {
+    return numDetectedGpus;
+  }
+
   std::vector<int> const& EnvVars::GetIsMultiProcessList()
   {
     return isMultiProcessList;

--- a/projects/rccl/test/common/EnvVars.cpp
+++ b/projects/rccl/test/common/EnvVars.cpp
@@ -215,7 +215,7 @@ namespace RcclUnitTesting
     // NOTE: Cannot use HIP call prior to launching unless it is inside another child process
     numDetectedGpus = 0;
     if(!isIsolatedChild) getDeviceCount(&numDetectedGpus);
-    numDetectedGpus = min(numDetectedGpus, 16);
+    numDetectedGpus = min(numDetectedGpus, 64);
     isGfx94 = false;
     if(!isIsolatedChild) getArchInfo(&isGfx94, "gfx94");
     isGfx95 = false;

--- a/projects/rccl/test/common/EnvVars.cpp
+++ b/projects/rccl/test/common/EnvVars.cpp
@@ -215,7 +215,7 @@ namespace RcclUnitTesting
     // NOTE: Cannot use HIP call prior to launching unless it is inside another child process
     numDetectedGpus = 0;
     if(!isIsolatedChild) getDeviceCount(&numDetectedGpus);
-    numDetectedGpus = min(numDetectedGpus, 64);
+    numDetectedGpus = std::min(numDetectedGpus, 64);
     isGfx94 = false;
     if(!isIsolatedChild) getArchInfo(&isGfx94, "gfx94");
     isGfx95 = false;

--- a/projects/rccl/test/common/EnvVars.hpp
+++ b/projects/rccl/test/common/EnvVars.hpp
@@ -46,6 +46,7 @@ namespace RcclUnitTesting
     std::vector<int>            const& GetNumGpusList();
     std::vector<int>            const& GetIsMultiProcessList();
     std::vector<int>            const& GetGpuPriorityOrder();   // Orders the gpus based on the associativity of them with OAM with higher gpus linked.
+    int GetNumDetectedGpus() const;
     void ShowConfig();
 
   protected:

--- a/projects/rccl/test/test_EnvVars.cpp
+++ b/projects/rccl/test/test_EnvVars.cpp
@@ -1,0 +1,21 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+#include EnvVars.hpp
+#include common/TestChecks.hpp
+#include gtest/gtest.h
+
+namespace RcclUnitTesting
+{
+    // Verify numDetectedGpus matches hipGetDeviceCount.
+    // Fails on NPS4 if an improper GPU cap is applied (e.g. the old cap of 16).
+    TEST(EnvVarsTests, NumDetectedGpusMatchesHip)
+    {
+        int hipCount = 0;
+        HIP_CHECK(hipGetDeviceCount(&hipCount));
+        EnvVars envVars;
+        EXPECT_EQ(envVars.GetNumDetectedGpus(), hipCount);
+    }
+}


### PR DESCRIPTION
## Motivation

Currently testBed unit tests limit GPUs to 16. 
With NPS4 mode, there are 64 visible GPUs.
As a result, rccl is not tested with all available GPUs when on NPS4 mode. 
JIRA ID AICOMRCCL-1528

## Technical Details

`numDetectedGpus ` in the EnvVars constructors is allow up to 64 GPUs.

## Issue Tracking

JIRA ID AICOMRCCL-1528

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
