### PR TITLE
refactor(hipfile): Use dependency injection for the global state

### DIFF
--- a/projects/hipfile/src/amd_detail/CMakeLists.txt
+++ b/projects/hipfile/src/amd_detail/CMakeLists.txt
@@ -26,6 +26,7 @@ set(HIPFILE_SOURCES
     hipfile-stats.cpp
     io.cpp
     mountinfo.cpp
+    runtime.cpp
     state.cpp
     stats.cpp
     stream.cpp

--- a/projects/hipfile/src/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/src/amd_detail/batch/batch.cpp
@@ -105,7 +105,7 @@ BatchContext::get_capacity() const noexcept
 }
 
 void
-BatchContext::submit_operations(const hipFileIOParams_t *params, unsigned num_params, DriverState &state)
+BatchContext::submit_operations(const hipFileIOParams_t *params, unsigned num_params, IDriverState &state)
 {
     std::unique_lock<std::shared_mutex> _ulock{context_mutex};
 

--- a/projects/hipfile/src/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/src/amd_detail/batch/batch.cpp
@@ -5,7 +5,6 @@
 
 #include "batch.h"
 #include "buffer.h"
-#include "context.h"
 #include "file.h"
 #include "hipfile.h"
 #include "state.h"
@@ -106,7 +105,7 @@ BatchContext::get_capacity() const noexcept
 }
 
 void
-BatchContext::submit_operations(const hipFileIOParams_t *params, unsigned num_params)
+BatchContext::submit_operations(const hipFileIOParams_t *params, unsigned num_params, DriverState &state)
 {
     std::unique_lock<std::shared_mutex> _ulock{context_mutex};
 
@@ -128,9 +127,8 @@ BatchContext::submit_operations(const hipFileIOParams_t *params, unsigned num_pa
         auto param_copy = std::make_unique<const hipFileIOParams_t>(params[i]);
         // flags currently unused. Ambiguous if flags in hipFileBatchIOSubmit is for buffer or
         // file flags.
-        auto [_file, _buffer] =
-            Context<DriverState>::get()->getFileAndBuffer(param_copy->fh, param_copy->u.batch.devPtr_base);
-        auto op = std::make_shared<BatchOperation>(std::move(param_copy), _buffer, _file);
+        auto [_file, _buffer] = state.getFileAndBuffer(param_copy->fh, param_copy->u.batch.devPtr_base);
+        auto op               = std::make_shared<BatchOperation>(std::move(param_copy), _buffer, _file);
 
         pending_ops.push_back(std::move(op));
     }

--- a/projects/hipfile/src/amd_detail/batch/batch.h
+++ b/projects/hipfile/src/amd_detail/batch/batch.h
@@ -20,7 +20,7 @@ namespace hipFile {
 class IFile;
 }
 namespace hipFile {
-class DriverState;
+class IDriverState;
 }
 
 namespace hipFile {
@@ -57,10 +57,10 @@ class IBatchContext {
 public:
     static constexpr unsigned MAX_SIZE = 128;
 
-    virtual ~IBatchContext()                               = default;
-    virtual unsigned get_capacity() const noexcept         = 0;
+    virtual ~IBatchContext()                                = default;
+    virtual unsigned get_capacity() const noexcept          = 0;
     virtual void     submit_operations(const hipFileIOParams_t *params, unsigned num_params,
-                                       DriverState &state) = 0;
+                                       IDriverState &state) = 0;
 };
 
 class BatchContext : public IBatchContext {
@@ -81,7 +81,7 @@ public:
     ///       will be submitted.
     ///
     void submit_operations(const hipFileIOParams_t *params, const unsigned num_params,
-                           DriverState &state) override;
+                           IDriverState &state) override;
 
 private:
     const unsigned capacity;

--- a/projects/hipfile/src/amd_detail/batch/batch.h
+++ b/projects/hipfile/src/amd_detail/batch/batch.h
@@ -19,6 +19,9 @@ class IBuffer;
 namespace hipFile {
 class IFile;
 }
+namespace hipFile {
+class DriverState;
+}
 
 namespace hipFile {
 
@@ -54,9 +57,10 @@ class IBatchContext {
 public:
     static constexpr unsigned MAX_SIZE = 128;
 
-    virtual ~IBatchContext()                                                                 = default;
-    virtual unsigned get_capacity() const noexcept                                           = 0;
-    virtual void     submit_operations(const hipFileIOParams_t *params, unsigned num_params) = 0;
+    virtual ~IBatchContext()                               = default;
+    virtual unsigned get_capacity() const noexcept         = 0;
+    virtual void     submit_operations(const hipFileIOParams_t *params, unsigned num_params,
+                                       DriverState &state) = 0;
 };
 
 class BatchContext : public IBatchContext {
@@ -76,7 +80,8 @@ public:
     /// @note This is an All or None operation. If one submitted operation is not valid, no operations
     ///       will be submitted.
     ///
-    void submit_operations(const hipFileIOParams_t *params, const unsigned num_params) override;
+    void submit_operations(const hipFileIOParams_t *params, const unsigned num_params,
+                           DriverState &state) override;
 
 private:
     const unsigned capacity;

--- a/projects/hipfile/src/amd_detail/context.cpp
+++ b/projects/hipfile/src/amd_detail/context.cpp
@@ -5,7 +5,7 @@
 
 #include "context.h"
 #include "hip.h"
-#include "state.h"
+#include "runtime.h"
 #include "stats.h"
 #include "sys.h"
 
@@ -17,7 +17,7 @@ hipFileInit()
     Context<Hip>::get();
     Context<Sys>::get();
     Context<IStatsServer>::get();
-    Context<DriverState>::get();
+    Runtime::instance();
 }
 
 }

--- a/projects/hipfile/src/amd_detail/hipfile-private.h
+++ b/projects/hipfile/src/amd_detail/hipfile-private.h
@@ -19,4 +19,14 @@ class DriverState;
 ssize_t hipFileIo(hipFile::IoType type, hipFileHandle_t fh, const void *buffer_base, size_t size,
                   hoff_t file_offset, hoff_t buffer_offset, hipFile::DriverState &state,
                   const std::vector<std::shared_ptr<hipFile::Backend>> &backends);
+
+hipFileError_t hipFileIOAsync(hipFile::IoType io_type, hipFileHandle_t fh, void *buffer_base, size_t *size_p,
+                              hoff_t *file_offset_p, hoff_t *buffer_offset_p, ssize_t *bytes_transferred_p,
+                              hipStream_t hipStream, hipFile::DriverState &state);
+
+hipFileError_t hipFileBatchSetUp(hipFileBatchHandle_t *batch_idp, unsigned max_nr,
+                                 hipFile::DriverState &state);
+
+hipFileError_t hipFileBatchSubmit(hipFileBatchHandle_t batch_idp, unsigned nr, hipFileIOParams_t *iocbp,
+                                  unsigned flags, hipFile::DriverState &state);
 }

--- a/projects/hipfile/src/amd_detail/hipfile-private.h
+++ b/projects/hipfile/src/amd_detail/hipfile-private.h
@@ -14,19 +14,19 @@
 namespace hipFile {
 enum class IoType;
 struct Backend;
-class DriverState;
+class IDriverState;
 
 ssize_t hipFileIo(hipFile::IoType type, hipFileHandle_t fh, const void *buffer_base, size_t size,
-                  hoff_t file_offset, hoff_t buffer_offset, hipFile::DriverState &state,
+                  hoff_t file_offset, hoff_t buffer_offset, hipFile::IDriverState &state,
                   const std::vector<std::shared_ptr<hipFile::Backend>> &backends);
 
 hipFileError_t hipFileIOAsync(hipFile::IoType io_type, hipFileHandle_t fh, void *buffer_base, size_t *size_p,
                               hoff_t *file_offset_p, hoff_t *buffer_offset_p, ssize_t *bytes_transferred_p,
-                              hipStream_t hipStream, hipFile::DriverState &state);
+                              hipStream_t hipStream, hipFile::IDriverState &state);
 
 hipFileError_t hipFileBatchSetUp(hipFileBatchHandle_t *batch_idp, unsigned max_nr,
-                                 hipFile::DriverState &state);
+                                 hipFile::IDriverState &state);
 
 hipFileError_t hipFileBatchSubmit(hipFileBatchHandle_t batch_idp, unsigned nr, hipFileIOParams_t *iocbp,
-                                  unsigned flags, hipFile::DriverState &state);
+                                  unsigned flags, hipFile::IDriverState &state);
 }

--- a/projects/hipfile/src/amd_detail/hipfile-private.h
+++ b/projects/hipfile/src/amd_detail/hipfile-private.h
@@ -14,8 +14,9 @@
 namespace hipFile {
 enum class IoType;
 struct Backend;
+class DriverState;
 
 ssize_t hipFileIo(hipFile::IoType type, hipFileHandle_t fh, const void *buffer_base, size_t size,
-                  hoff_t file_offset, hoff_t buffer_offset,
+                  hoff_t file_offset, hoff_t buffer_offset, hipFile::DriverState &state,
                   const std::vector<std::shared_ptr<hipFile::Backend>> &backends);
 }

--- a/projects/hipfile/src/amd_detail/hipfile.cpp
+++ b/projects/hipfile/src/amd_detail/hipfile.cpp
@@ -12,7 +12,6 @@
 #include "hip.h"
 #include "hipfile.h"
 #include "hipfile-private.h"
-#include "hipfile-warnings.h"
 #include "api_trace/api-trace-internal.h"
 #include "io.h"
 #include "runtime.h"
@@ -173,16 +172,6 @@ catch (...) {
     return handle_exception();
 }
 
-/// @brief Get the cached list of backends obtained from DriverState
-static const vector<shared_ptr<Backend>> &
-getCachedBackends()
-{
-    HIPFILE_WARN_NO_EXIT_DTOR_OFF
-    static const auto backends{Context<DriverState>::get()->getBackends()};
-    HIPFILE_WARN_NO_EXIT_DTOR_ON
-    return backends;
-}
-
 ssize_t
 hipFileIo(IoType type, hipFileHandle_t fh, const void *buffer_base, size_t size, hoff_t file_offset,
           hoff_t buffer_offset, DriverState &state, const vector<shared_ptr<Backend>> &backends)
@@ -240,8 +229,9 @@ ssize_t
 hipFileRead(hipFileHandle_t fh, void *buffer_base, size_t size, hoff_t file_offset, hoff_t buffer_offset)
 try {
     hipFileInit();
-    auto result = hipFileIo(IoType::Read, fh, buffer_base, size, file_offset, buffer_offset,
-                            Runtime::instance().state(), getCachedBackends());
+    Runtime &rt = Runtime::instance();
+    auto     result =
+        hipFileIo(IoType::Read, fh, buffer_base, size, file_offset, buffer_offset, rt.state(), rt.backends());
 
     if (result == -hipFileDriverNotInitialized) {
         // Match cuFile behaviour
@@ -260,8 +250,9 @@ hipFileWrite(hipFileHandle_t fh, const void *buffer_base, size_t size, hoff_t fi
              hoff_t buffer_offset)
 try {
     hipFileInit();
-    auto result = hipFileIo(IoType::Write, fh, buffer_base, size, file_offset, buffer_offset,
-                            Runtime::instance().state(), getCachedBackends());
+    Runtime &rt     = Runtime::instance();
+    auto     result = hipFileIo(IoType::Write, fh, buffer_base, size, file_offset, buffer_offset, rt.state(),
+                                rt.backends());
 
     if (result == -hipFileDriverNotInitialized) {
         // Match cuFile behaviour

--- a/projects/hipfile/src/amd_detail/hipfile.cpp
+++ b/projects/hipfile/src/amd_detail/hipfile.cpp
@@ -66,7 +66,7 @@ checkNull(std::initializer_list<void *> ptrs)
 // count if the driver is already initialized. Used by hipFile to ensure its
 // behaviour is consistent on AMD and NVIDIA
 static inline void
-ensureDriverInit(DriverState &state)
+ensureDriverInit(IDriverState &state)
 {
     state.ensureInitialized();
 }
@@ -174,7 +174,7 @@ catch (...) {
 
 ssize_t
 hipFileIo(IoType type, hipFileHandle_t fh, const void *buffer_base, size_t size, hoff_t file_offset,
-          hoff_t buffer_offset, DriverState &state, const vector<shared_ptr<Backend>> &backends)
+          hoff_t buffer_offset, IDriverState &state, const vector<shared_ptr<Backend>> &backends)
 try {
     auto [file, buffer] = state.getFileAndBuffer(fh, buffer_base);
     int                      score{-1};
@@ -367,7 +367,7 @@ catch (...) {
 }
 
 hipFileError_t
-hipFileBatchSetUp(hipFileBatchHandle_t *batch_idp, unsigned max_nr, DriverState &state)
+hipFileBatchSetUp(hipFileBatchHandle_t *batch_idp, unsigned max_nr, IDriverState &state)
 try {
     if (batch_idp == nullptr) {
         return {hipFileInvalidValue, hipSuccess};
@@ -396,7 +396,7 @@ catch (...) {
 
 hipFileError_t
 hipFileBatchSubmit(hipFileBatchHandle_t batch_idp, unsigned nr, hipFileIOParams_t *iocbp, unsigned flags,
-                   DriverState &state)
+                   IDriverState &state)
 try {
     (void)flags; // Unused at this time.
 
@@ -470,7 +470,7 @@ catch (...) {
 hipFileError_t
 hipFileIOAsync(IoType io_type, hipFileHandle_t fh, void *buffer_base, size_t *size_p, hoff_t *file_offset_p,
                hoff_t *buffer_offset_p, ssize_t *bytes_transferred_p, hipStream_t hipStream,
-               DriverState &state)
+               IDriverState &state)
 try {
     if (state.getRefCount() == 0) {
         ensureDriverInit(state);

--- a/projects/hipfile/src/amd_detail/hipfile.cpp
+++ b/projects/hipfile/src/amd_detail/hipfile.cpp
@@ -15,6 +15,7 @@
 #include "hipfile-warnings.h"
 #include "api_trace/api-trace-internal.h"
 #include "io.h"
+#include "runtime.h"
 #include "state.h"
 #include "stats.h"
 
@@ -79,6 +80,8 @@ try {
         return {hipFileInvalidValue, hipSuccess};
     }
 
+    Runtime &rt = Runtime::instance();
+
     // A C caller may pass a type outside the enum's valid range, and an
     // lvalue-to-rvalue load of such a value as the enum type is undefined
     // behavior. Reinterpret the bits as the underlying integer type instead.
@@ -86,7 +89,7 @@ try {
     switch (type) {
         case hipFileHandleTypeOpaqueFD: {
             UnregisteredFile uf{descr->handle.fd};
-            *fh = Context<DriverState>::get()->registerFile(std::move(uf));
+            *fh = rt.state().registerFile(std::move(uf));
             Context<StatsCollection>::get()->fileRegistration();
             return {hipFileSuccess, hipSuccess};
         }
@@ -111,7 +114,7 @@ try {
         return;
     }
 
-    Context<DriverState>::get()->deregisterFile(fh);
+    Runtime::instance().state().deregisterFile(fh);
     return;
 }
 catch (...) {
@@ -122,7 +125,7 @@ hipFileError_t
 hipFileBufRegister(const void *buffer_base, size_t length, int flags)
 try {
     hipFileInit();
-    Context<DriverState>::get()->registerBuffer(buffer_base, length, flags);
+    Runtime::instance().state().registerBuffer(buffer_base, length, flags);
     Context<StatsCollection>::get()->bufferRegistration();
     return {hipFileSuccess, hipSuccess};
 }
@@ -152,7 +155,7 @@ hipFileError_t
 hipFileBufDeregister(const void *buffer_base)
 try {
     hipFileInit();
-    Context<DriverState>::get()->deregisterBuffer(buffer_base);
+    Runtime::instance().state().deregisterBuffer(buffer_base);
     return {hipFileSuccess, hipSuccess};
 }
 catch (const DriverNotInitialized &) {
@@ -238,7 +241,7 @@ hipFileRead(hipFileHandle_t fh, void *buffer_base, size_t size, hoff_t file_offs
 try {
     hipFileInit();
     auto result = hipFileIo(IoType::Read, fh, buffer_base, size, file_offset, buffer_offset,
-                            *Context<DriverState>::get(), getCachedBackends());
+                            Runtime::instance().state(), getCachedBackends());
 
     if (result == -hipFileDriverNotInitialized) {
         // Match cuFile behaviour
@@ -258,7 +261,7 @@ hipFileWrite(hipFileHandle_t fh, const void *buffer_base, size_t size, hoff_t fi
 try {
     hipFileInit();
     auto result = hipFileIo(IoType::Write, fh, buffer_base, size, file_offset, buffer_offset,
-                            *Context<DriverState>::get(), getCachedBackends());
+                            Runtime::instance().state(), getCachedBackends());
 
     if (result == -hipFileDriverNotInitialized) {
         // Match cuFile behaviour
@@ -276,7 +279,7 @@ hipFileError_t
 hipFileDriverOpen()
 try {
     hipFileInit();
-    Context<DriverState>::get()->incrRefCount();
+    Runtime::instance().state().incrRefCount();
 
     return {hipFileSuccess, hipSuccess};
 }
@@ -288,8 +291,9 @@ hipFileError_t
 hipFileDriverClose()
 try {
     hipFileInit();
-    if (Context<DriverState>::get()->getRefCount() > 0) {
-        Context<DriverState>::get()->decrRefCount();
+    Runtime &rt = Runtime::instance();
+    if (rt.state().getRefCount() > 0) {
+        rt.state().decrRefCount();
         return {hipFileSuccess, hipSuccess};
     }
     else {
@@ -304,7 +308,7 @@ int64_t
 hipFileUseCount()
 try {
     hipFileInit();
-    return Context<DriverState>::get()->getRefCount();
+    return Runtime::instance().state().getRefCount();
 }
 catch (...) {
     return -1;
@@ -372,14 +376,45 @@ catch (...) {
 }
 
 hipFileError_t
-hipFileBatchIOSetUp(hipFileBatchHandle_t *batch_idp, unsigned max_nr)
+hipFileBatchSetUp(hipFileBatchHandle_t *batch_idp, unsigned max_nr, DriverState &state)
 try {
-    hipFileInit();
     if (batch_idp == nullptr) {
         return {hipFileInvalidValue, hipSuccess};
     }
 
-    *batch_idp = Context<DriverState>::get()->createBatchContext(max_nr);
+    *batch_idp = state.createBatchContext(max_nr);
+
+    return {hipFileSuccess, hipSuccess};
+}
+catch (const std::invalid_argument &) {
+    return {hipFileInvalidValue, hipSuccess};
+}
+catch (...) {
+    return handle_exception();
+}
+
+hipFileError_t
+hipFileBatchIOSetUp(hipFileBatchHandle_t *batch_idp, unsigned max_nr)
+try {
+    hipFileInit();
+    return hipFileBatchSetUp(batch_idp, max_nr, Runtime::instance().state());
+}
+catch (...) {
+    return handle_exception();
+}
+
+hipFileError_t
+hipFileBatchSubmit(hipFileBatchHandle_t batch_idp, unsigned nr, hipFileIOParams_t *iocbp, unsigned flags,
+                   DriverState &state)
+try {
+    (void)flags; // Unused at this time.
+
+    if (iocbp == nullptr && nr > 0) {
+        return {hipFileInvalidValue, hipSuccess};
+    }
+
+    std::shared_ptr<IBatchContext> batch_context = state.getBatchContext(batch_idp);
+    batch_context->submit_operations(iocbp, nr, state);
 
     return {hipFileSuccess, hipSuccess};
 }
@@ -394,19 +429,7 @@ hipFileError_t
 hipFileBatchIOSubmit(hipFileBatchHandle_t batch_idp, unsigned nr, hipFileIOParams_t *iocbp, unsigned flags)
 try {
     hipFileInit();
-    (void)flags; // Unused at this time.
-
-    if (iocbp == nullptr && nr > 0) {
-        return {hipFileInvalidValue, hipSuccess};
-    }
-
-    std::shared_ptr<IBatchContext> batch_context = Context<DriverState>::get()->getBatchContext(batch_idp);
-    batch_context->submit_operations(iocbp, nr, *Context<DriverState>::get());
-
-    return {hipFileSuccess, hipSuccess};
-}
-catch (const std::invalid_argument &) {
-    return {hipFileInvalidValue, hipSuccess};
+    return hipFileBatchSubmit(batch_idp, nr, iocbp, flags, Runtime::instance().state());
 }
 catch (...) {
     return handle_exception();
@@ -453,7 +476,7 @@ catch (...) {
     return;
 }
 
-static hipFileError_t
+hipFileError_t
 hipFileIOAsync(IoType io_type, hipFileHandle_t fh, void *buffer_base, size_t *size_p, hoff_t *file_offset_p,
                hoff_t *buffer_offset_p, ssize_t *bytes_transferred_p, hipStream_t hipStream,
                DriverState &state)
@@ -493,7 +516,7 @@ hipFileReadAsync(hipFileHandle_t fh, void *buffer_base, size_t *size_p, hoff_t *
 try {
     hipFileInit();
     return hipFileIOAsync(IoType::Read, fh, buffer_base, size_p, file_offset_p, buffer_offset_p, bytes_read_p,
-                          stream, *Context<DriverState>::get());
+                          stream, Runtime::instance().state());
 }
 catch (...) {
     return handle_exception();
@@ -505,7 +528,7 @@ hipFileWriteAsync(hipFileHandle_t fh, void *buffer_base, size_t *size_p, hoff_t 
 try {
     hipFileInit();
     return hipFileIOAsync(IoType::Write, fh, buffer_base, size_p, file_offset_p, buffer_offset_p,
-                          bytes_written_p, stream, *Context<DriverState>::get());
+                          bytes_written_p, stream, Runtime::instance().state());
 }
 catch (...) {
     return handle_exception();
@@ -515,7 +538,7 @@ hipFileError_t
 hipFileStreamRegister(hipStream_t stream, unsigned flags)
 try {
     hipFileInit();
-    Context<DriverState>::get()->registerStream(stream, flags);
+    Runtime::instance().state().registerStream(stream, flags);
     return {hipFileSuccess, hipSuccess};
 }
 catch (std::invalid_argument &) {
@@ -529,7 +552,7 @@ hipFileError_t
 hipFileStreamDeregister(hipStream_t stream)
 try {
     hipFileInit();
-    Context<DriverState>::get()->deregisterStream(stream);
+    Runtime::instance().state().deregisterStream(stream);
     return {hipFileSuccess, hipSuccess};
 }
 catch (std::invalid_argument &) {

--- a/projects/hipfile/src/amd_detail/hipfile.cpp
+++ b/projects/hipfile/src/amd_detail/hipfile.cpp
@@ -66,9 +66,9 @@ checkNull(std::initializer_list<void *> ptrs)
 // count if the driver is already initialized. Used by hipFile to ensure its
 // behaviour is consistent on AMD and NVIDIA
 static inline void
-ensureDriverInit()
+ensureDriverInit(DriverState &state)
 {
-    hipFile::Context<hipFile::DriverState>::get()->ensureInitialized();
+    state.ensureInitialized();
 }
 
 hipFileError_t
@@ -182,9 +182,9 @@ getCachedBackends()
 
 ssize_t
 hipFileIo(IoType type, hipFileHandle_t fh, const void *buffer_base, size_t size, hoff_t file_offset,
-          hoff_t buffer_offset, const vector<shared_ptr<Backend>> &backends)
+          hoff_t buffer_offset, DriverState &state, const vector<shared_ptr<Backend>> &backends)
 try {
-    auto [file, buffer] = Context<DriverState>::get()->getFileAndBuffer(fh, buffer_base);
+    auto [file, buffer] = state.getFileAndBuffer(fh, buffer_base);
     int                      score{-1};
     std::shared_ptr<Backend> backend{};
 
@@ -237,8 +237,8 @@ ssize_t
 hipFileRead(hipFileHandle_t fh, void *buffer_base, size_t size, hoff_t file_offset, hoff_t buffer_offset)
 try {
     hipFileInit();
-    auto result =
-        hipFileIo(IoType::Read, fh, buffer_base, size, file_offset, buffer_offset, getCachedBackends());
+    auto result = hipFileIo(IoType::Read, fh, buffer_base, size, file_offset, buffer_offset,
+                            *Context<DriverState>::get(), getCachedBackends());
 
     if (result == -hipFileDriverNotInitialized) {
         // Match cuFile behaviour
@@ -257,8 +257,8 @@ hipFileWrite(hipFileHandle_t fh, const void *buffer_base, size_t size, hoff_t fi
              hoff_t buffer_offset)
 try {
     hipFileInit();
-    auto result =
-        hipFileIo(IoType::Write, fh, buffer_base, size, file_offset, buffer_offset, getCachedBackends());
+    auto result = hipFileIo(IoType::Write, fh, buffer_base, size, file_offset, buffer_offset,
+                            *Context<DriverState>::get(), getCachedBackends());
 
     if (result == -hipFileDriverNotInitialized) {
         // Match cuFile behaviour
@@ -401,7 +401,7 @@ try {
     }
 
     std::shared_ptr<IBatchContext> batch_context = Context<DriverState>::get()->getBatchContext(batch_idp);
-    batch_context->submit_operations(iocbp, nr);
+    batch_context->submit_operations(iocbp, nr, *Context<DriverState>::get());
 
     return {hipFileSuccess, hipSuccess};
 }
@@ -455,17 +455,17 @@ catch (...) {
 
 static hipFileError_t
 hipFileIOAsync(IoType io_type, hipFileHandle_t fh, void *buffer_base, size_t *size_p, hoff_t *file_offset_p,
-               hoff_t *buffer_offset_p, ssize_t *bytes_transferred_p, hipStream_t hipStream)
+               hoff_t *buffer_offset_p, ssize_t *bytes_transferred_p, hipStream_t hipStream,
+               DriverState &state)
 try {
-    if (Context<DriverState>::get()->getRefCount() == 0) {
-        ensureDriverInit();
+    if (state.getRefCount() == 0) {
+        ensureDriverInit(state);
         return {hipFileInvalidValue, hipSuccess};
     }
 
     checkNull({buffer_base, size_p, file_offset_p, buffer_offset_p, bytes_transferred_p});
 
-    auto [file, buffer, stream] =
-        Context<DriverState>::get()->getFileBufferAndStream(fh, buffer_base, hipStream);
+    auto [file, buffer, stream] = state.getFileBufferAndStream(fh, buffer_base, hipStream);
     Fallback().async_io(io_type, file, buffer, size_p, file_offset_p, buffer_offset_p, bytes_transferred_p,
                         stream);
 
@@ -493,7 +493,7 @@ hipFileReadAsync(hipFileHandle_t fh, void *buffer_base, size_t *size_p, hoff_t *
 try {
     hipFileInit();
     return hipFileIOAsync(IoType::Read, fh, buffer_base, size_p, file_offset_p, buffer_offset_p, bytes_read_p,
-                          stream);
+                          stream, *Context<DriverState>::get());
 }
 catch (...) {
     return handle_exception();
@@ -505,7 +505,7 @@ hipFileWriteAsync(hipFileHandle_t fh, void *buffer_base, size_t *size_p, hoff_t 
 try {
     hipFileInit();
     return hipFileIOAsync(IoType::Write, fh, buffer_base, size_p, file_offset_p, buffer_offset_p,
-                          bytes_written_p, stream);
+                          bytes_written_p, stream, *Context<DriverState>::get());
 }
 catch (...) {
     return handle_exception();

--- a/projects/hipfile/src/amd_detail/runtime.cpp
+++ b/projects/hipfile/src/amd_detail/runtime.cpp
@@ -1,0 +1,45 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "runtime.h"
+
+#include "backend/fallback.h"
+#include "backend/fastpath.h"
+#include "hipfile-warnings.h"
+
+#include <memory>
+#include <mutex>
+#include <vector>
+
+namespace hipFile {
+
+Runtime::Runtime() = default;
+
+Runtime::~Runtime() = default;
+
+Runtime &
+Runtime::instance()
+{
+    HIPFILE_WARN_NO_EXIT_DTOR_OFF
+    static Runtime runtime{};
+    HIPFILE_WARN_NO_EXIT_DTOR_ON
+    return runtime;
+}
+
+const std::vector<std::shared_ptr<Backend>> &
+Runtime::backends() const
+{
+    std::call_once(backends_once_, [this]() {
+        std::shared_ptr<Fallback> fallback_backend = std::make_shared<Fallback>();
+        std::shared_ptr<Fastpath> fastpath_backend = std::make_shared<Fastpath>();
+        fastpath_backend->register_fallback_backend(fallback_backend);
+        backends_.push_back(fallback_backend);
+        backends_.push_back(fastpath_backend);
+    });
+
+    return backends_;
+}
+
+}

--- a/projects/hipfile/src/amd_detail/runtime.h
+++ b/projects/hipfile/src/amd_detail/runtime.h
@@ -1,0 +1,64 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include "backend.h"
+#include "state.h"
+
+#include <memory>
+#include <mutex>
+#include <vector>
+
+namespace hipFile {
+
+/// @brief The single process-global root object.
+///
+/// `Runtime` owns the one `DriverState` and the one backend collection for the
+/// process. It is the *only* global touched by the C-API boundary shims in
+/// `hipfile.cpp`; everything below the shim receives its dependencies
+/// (`DriverState&`, backends) as explicit parameters. This keeps the global at
+/// the boundary and lets tests construct a fresh `DriverState` locally.
+class Runtime {
+public:
+    /// @brief Access the process-global runtime
+    /// @return A reference to the single Runtime instance
+    static Runtime &instance();
+
+    /// @brief The process-global driver state
+    /// @return A reference to the owned DriverState
+    DriverState &state()
+    {
+        return state_;
+    }
+
+    /// @brief The backends that can service IO requests
+    ///
+    /// Builds the Fallback/Fastpath pair exactly once (via std::call_once) and
+    /// returns the cached collection. This is the single home for backend
+    /// construction.
+    ///
+    /// @return A collection of backends that can service IO requests
+    const std::vector<std::shared_ptr<Backend>> &backends() const;
+
+    // Don't allow copying
+    Runtime(const Runtime &)            = delete;
+    Runtime &operator=(const Runtime &) = delete;
+
+    // Don't allow moving
+    Runtime(Runtime &&)            = delete;
+    Runtime &operator=(Runtime &&) = delete;
+
+private:
+    Runtime();
+    ~Runtime();
+
+    DriverState state_;
+
+    mutable std::vector<std::shared_ptr<Backend>> backends_;
+    mutable std::once_flag                        backends_once_;
+};
+
+}

--- a/projects/hipfile/src/amd_detail/state.cpp
+++ b/projects/hipfile/src/amd_detail/state.cpp
@@ -5,7 +5,6 @@
 
 #include "batch/batch.h"
 #include "buffer.h"
-#include "configuration.h"
 #include "file.h"
 #include "state.h"
 #include "stream.h"

--- a/projects/hipfile/src/amd_detail/state.cpp
+++ b/projects/hipfile/src/amd_detail/state.cpp
@@ -3,12 +3,9 @@
  * SPDX-License-Identifier: MIT
  */
 
-#include "backend/fallback.h"
-#include "backend/fastpath.h"
 #include "batch/batch.h"
 #include "buffer.h"
 #include "configuration.h"
-#include "context.h"
 #include "file.h"
 #include "state.h"
 #include "stream.h"
@@ -20,10 +17,6 @@
 #include <utility>
 
 using namespace std;
-
-namespace hipFile {
-struct Backend;
-}
 
 namespace hipFile {
 
@@ -269,21 +262,5 @@ DriverState::ensureInitialized()
     if (ref_count == 0) {
         ref_count++;
     }
-}
-
-std::vector<std::shared_ptr<Backend>>
-DriverState::getBackends() const
-{
-    static bool once = [&]() {
-        std::shared_ptr<Fallback> fallback_backend = std::make_shared<Fallback>();
-        std::shared_ptr<Fastpath> fastpath_backend = std::make_shared<Fastpath>();
-        fastpath_backend->register_fallback_backend(fallback_backend);
-        backends.push_back(fallback_backend);
-        backends.push_back(fastpath_backend);
-        return true;
-    }();
-    (void)once;
-
-    return backends;
 }
 }

--- a/projects/hipfile/src/amd_detail/state.h
+++ b/projects/hipfile/src/amd_detail/state.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-#include "backend.h"
 #include "batch/batch.h"
 #include "buffer.h"
 #include "file.h"
@@ -18,7 +17,6 @@
 #include <memory>
 #include <shared_mutex>
 #include <stdexcept>
-#include <vector>
 
 namespace hipFile {
 
@@ -189,14 +187,6 @@ public:
     void ensureInitialized();
 
     //
-    // Backends
-    //
-
-    /// @brief Get the backends that can service IO requests
-    /// @return A collection of backends that can service IO requests
-    virtual std::vector<std::shared_ptr<Backend>> getBackends() const;
-
-    //
     // Misc
     //
 
@@ -226,9 +216,6 @@ private:
 
     // Manages the driver's Stream objects
     std::unique_ptr<StreamMap> stream_map;
-
-    // Backends available to service IO requests
-    mutable std::vector<std::shared_ptr<Backend>> backends;
 
     /// Mutex to protect the state
     mutable std::shared_mutex state_mutex;

--- a/projects/hipfile/src/amd_detail/state.h
+++ b/projects/hipfile/src/amd_detail/state.h
@@ -21,10 +21,6 @@
 #include <vector>
 
 namespace hipFile {
-template <typename T> struct Context;
-}
-
-namespace hipFile {
 
 /// @brief The driver is not initialized
 struct DriverNotInitialized : public std::runtime_error {
@@ -212,19 +208,12 @@ public:
     DriverState(DriverState &&)            = delete;
     DriverState &operator=(DriverState &&) = delete;
 
-protected:
-    // Singletons should have private ctors.
-    // However, it prevents creating Mocks that inherit from the
-    // singleton for testing.
     DriverState();
     virtual ~DriverState();
 
 private:
     // The driver's reference count
     int64_t ref_count;
-
-    // Allows Context to manage DriverState.
-    friend struct Context<DriverState>;
 
     // Manages the driver's File objects
     std::unique_ptr<FileMap> file_map;

--- a/projects/hipfile/src/amd_detail/state.h
+++ b/projects/hipfile/src/amd_detail/state.h
@@ -196,7 +196,7 @@ public:
 // * When the driver transitions to a reference count of zero, the
 //   BufferMap and FileMap will be cleared
 //
-class DriverState : public IDriverState {
+class DriverState final : public IDriverState {
 public:
     //
     // Batch interface

--- a/projects/hipfile/src/amd_detail/state.h
+++ b/projects/hipfile/src/amd_detail/state.h
@@ -38,6 +38,146 @@ struct file_buffer_stream_tuple {
     std::shared_ptr<IStream> stream;
 };
 
+// The polymorphic interface that internal helpers depend on.
+//
+// Helpers take an `IDriverState&` so production can pass the one real
+// `DriverState` (owned by `Runtime`) while tests pass a mock that inherits this
+// interface directly. A mock therefore has no real `DriverState` behavior to fall
+// through to: an un-mocked call fails loudly instead of silently running
+// production code.
+class IDriverState {
+public:
+    virtual ~IDriverState() = default;
+
+    //
+    // Batch interface
+    //
+
+    /// @brief Create a new batch context
+    /// @param [in] capacity Maximum number of outstanding operations that this context can manage
+    /// @return An opaque handle used to reference this new batch context
+    virtual hipFileBatchHandle_t createBatchContext(unsigned capacity) = 0;
+
+    /// @brief Destroy a batch context and release all associated resources
+    /// @param [in] handle The handle for the batch context to destroy
+    virtual void destroyBatchContext(hipFileBatchHandle_t handle) = 0;
+
+    /// @brief Get a batch context
+    /// @param [in] handle The opaque handle associated with a batch context
+    /// @return A batch context
+    virtual std::shared_ptr<IBatchContext> getBatchContext(hipFileBatchHandle_t handle) = 0;
+
+    //
+    // Buffer interface
+    //
+
+    /// @brief Creates and registers a buffer
+    /// @param [in] buf Buffer pointer
+    /// @param [in] length Buffer length
+    /// @param [in] flags Buffer flags (unused)
+    virtual void registerBuffer(const void *buf, size_t length, int flags) = 0;
+
+    /// @brief Deregisters and destroys a buffer
+    /// @param [in] buf Buffer pointer
+    virtual void deregisterBuffer(const void *buf) = 0;
+
+    /// @brief Look up a registered buffer using the buffer pointer
+    /// @param [in] buf Buffer pointer
+    /// @return A registered buffer
+    virtual std::shared_ptr<IBuffer> getRegisteredBuffer(const void *buf) = 0;
+
+    /// @brief Look up a registered buffer. Returns a temporary unregistered
+    ///        buffer if no matching buffer is found.
+    /// @param [in] buf Buffer pointer
+    /// @return A registered or temporary unregistered buffer
+    virtual std::shared_ptr<IBuffer> getBuffer(const void *buf) = 0;
+
+    //
+    // File interface
+    //
+
+    /// @brief Registers a file. Files must be registered before they can be used with hipFile IO APIs
+    /// @param [in] uf An unregistered file
+    /// @return A handle to be used when calling hipFile IO APIs
+    virtual hipFileHandle_t registerFile(UnregisteredFile &&uf) = 0;
+
+    /// @brief Deregisters the file associated with the provided file handle
+    /// @param [in] fh The handle of the file to deregister
+    virtual void deregisterFile(hipFileHandle_t fh) = 0;
+
+    /// @brief Look up a file given a hipFileHandle_t
+    /// @param [in] fh The file handle to lookup the file with
+    /// @return If file handle is valid, return a shared pointer to the file, otherwise throw
+    /// FileNotRegistered.
+    virtual std::shared_ptr<IFile> getFile(hipFileHandle_t fh) = 0;
+
+    //
+    // Stream interface
+    //
+
+    // @brief Registers a stream. Streams must be registered in order to set usage flags
+    // @param [in] hip_stream A valid hipStream
+    // @param [in] flags Stream flags
+    virtual void registerStream(const hipStream_t hip_stream, uint32_t flags) = 0;
+
+    // @brief Deregisters the stream
+    // @param [in] hip_stream A valid hipStream
+    virtual void deregisterStream(const hipStream_t hip_stream) = 0;
+
+    // @brief Look up a stream given a hipStream_t
+    // @param [in] hip_stream A valid hipStream
+    // @return Return a shared pointer to the Stream
+    virtual std::shared_ptr<IStream> getStream(hipStream_t hip_stream) = 0;
+
+    //
+    // Buffer and file calls
+    //
+    // These are for reducing the number of lock calls and are implemented
+    // as needed for the hipFile code
+    //
+
+    /// @brief Look up a file and registered buffer
+    ///
+    /// This combined file + buffer getter reduces the number of lock calls.
+    ///
+    /// Like the buffer getter, this function emits a temporary unregistered buffer
+    /// if no matching registered buffer is found.
+    ///
+    /// @param [in]  fh      File handle
+    /// @param [in]  buf     Buffer pointer
+    virtual file_buffer_pair getFileAndBuffer(hipFileHandle_t fh, const void *buf) = 0;
+
+    //
+    // Buffer, file, and stream calls
+    //
+    virtual file_buffer_stream_tuple getFileBufferAndStream(hipFileHandle_t fh, const void *buf,
+                                                            hipStream_t hipStream) = 0;
+
+    //
+    // Reference counts
+    //
+
+    /// @brief Increment the driver's reference count
+    virtual void incrRefCount() = 0;
+
+    /// @brief Decrement the driver's reference count
+    ///
+    /// When the count gets to 0, the buffer and file maps will be destroyed.
+    virtual void decrRefCount() = 0;
+
+    /// @brief Get the driver's current reference count
+    /// @return The driver reference count
+    virtual int64_t getRefCount() const = 0;
+
+    /// @brief Ensure the driver is initialized
+    ///
+    /// "Initializes" the driver by setting the reference count to 1
+    /// if it is currently 0.
+    ///
+    /// @note For ensuring NVIDIA cuFile behaviour compatibility
+    virtual void ensureInitialized() = 0;
+};
+
 // hipFile "state"
 //
 // Important for:
@@ -56,135 +196,51 @@ struct file_buffer_stream_tuple {
 // * When the driver transitions to a reference count of zero, the
 //   BufferMap and FileMap will be cleared
 //
-class DriverState {
+class DriverState : public IDriverState {
 public:
     //
     // Batch interface
     //
-
-    /// @brief Create a new batch context
-    /// @param [in] capacity Maximum number of outstanding operations that this context can manage
-    /// @return An opaque handle used to reference this new batch context
-    virtual hipFileBatchHandle_t createBatchContext(unsigned capacity);
-
-    /// @brief Destroy a batch context and release all associated resources
-    /// @param [in] handle The handle for the batch context to destroy
-    virtual void destroyBatchContext(hipFileBatchHandle_t handle);
-
-    /// @brief Get a batch context
-    /// @param [in] handle The opaque handle associated with a batch context
-    /// @return A batch context
-    virtual std::shared_ptr<IBatchContext> getBatchContext(hipFileBatchHandle_t handle);
+    hipFileBatchHandle_t           createBatchContext(unsigned capacity) override;
+    void                           destroyBatchContext(hipFileBatchHandle_t handle) override;
+    std::shared_ptr<IBatchContext> getBatchContext(hipFileBatchHandle_t handle) override;
 
     //
     // Buffer interface
     //
-
-    /// @brief Creates and registers a buffer
-    /// @param [in] buf Buffer pointer
-    /// @param [in] length Buffer length
-    /// @param [in] flags Buffer flags (unused)
-    virtual void registerBuffer(const void *buf, size_t length, int flags);
-
-    /// @brief Deregisters and destroys a buffer
-    /// @param [in] buf Buffer pointer
-    virtual void deregisterBuffer(const void *buf);
-
-    /// @brief Look up a registered buffer using the buffer pointer
-    /// @param [in] buf Buffer pointer
-    /// @return A registered buffer
-    virtual std::shared_ptr<IBuffer> getRegisteredBuffer(const void *buf);
-
-    /// @brief Look up a registered buffer. Returns a temporary unregistered
-    ///        buffer if no matching buffer is found.
-    /// @param [in] buf Buffer pointer
-    /// @return A registered or temporary unregistered buffer
-    virtual std::shared_ptr<IBuffer> getBuffer(const void *buf);
+    void                     registerBuffer(const void *buf, size_t length, int flags) override;
+    void                     deregisterBuffer(const void *buf) override;
+    std::shared_ptr<IBuffer> getRegisteredBuffer(const void *buf) override;
+    std::shared_ptr<IBuffer> getBuffer(const void *buf) override;
 
     //
     // File interface
     //
-
-    /// @brief Registers a file. Files must be registered before they can be used with hipFile IO APIs
-    /// @param [in] uf An unregistered file
-    /// @return A handle to be used when calling hipFile IO APIs
-    virtual hipFileHandle_t registerFile(UnregisteredFile &&uf);
-
-    /// @brief Deregisters the file associated with the provided file handle
-    /// @param [in] fh The handle of the file to deregister
-    virtual void deregisterFile(hipFileHandle_t fh);
-
-    /// @brief Look up a file given a hipFileHandle_t
-    /// @param [in] fh The file handle to lookup the file with
-    /// @return If file handle is valid, return a shared pointer to the file, otherwise throw
-    /// FileNotRegistered.
-    virtual std::shared_ptr<IFile> getFile(hipFileHandle_t fh);
+    hipFileHandle_t        registerFile(UnregisteredFile &&uf) override;
+    void                   deregisterFile(hipFileHandle_t fh) override;
+    std::shared_ptr<IFile> getFile(hipFileHandle_t fh) override;
 
     //
     // Stream interface
     //
-
-    // @brief Registers a stream. Streams must be registered in order to set usage flags
-    // @param [in] hip_stream A valid hipStream
-    // @param [in] flags Stream flags
-    virtual void registerStream(const hipStream_t hip_stream, uint32_t flags);
-
-    // @brief Deregisters the stream
-    // @param [in] hip_stream A valid hipStream
-    virtual void deregisterStream(const hipStream_t hip_stream);
-
-    // @brief Look up a stream given a hipStream_t
-    // @param [in] hip_stream A valid hipStream
-    // @return Return a shared pointer to the Stream
-    virtual std::shared_ptr<IStream> getStream(hipStream_t hip_stream);
+    void                     registerStream(const hipStream_t hip_stream, uint32_t flags) override;
+    void                     deregisterStream(const hipStream_t hip_stream) override;
+    std::shared_ptr<IStream> getStream(hipStream_t hip_stream) override;
 
     //
-    // Buffer and file calls
+    // Combined lookups
     //
-    // These are for reducing the number of lock calls and are implemented
-    // as needed for the hipFile code
-    //
-
-    /// @brief Look up a file and registered buffer
-    ///
-    /// This combined file + buffer getter reduces the number of lock calls.
-    ///
-    /// Like the buffer getter, this function emits a temporary unregistered buffer
-    /// if no matching registered buffer is found.
-    ///
-    /// @param [in]  fh      File handle
-    /// @param [in]  buf     Buffer pointer
-    virtual file_buffer_pair getFileAndBuffer(hipFileHandle_t fh, const void *buf);
-
-    //
-    // Buffer, file, and stream calls
-    //
-    virtual file_buffer_stream_tuple getFileBufferAndStream(hipFileHandle_t fh, const void *buf,
-                                                            hipStream_t hipStream);
+    file_buffer_pair         getFileAndBuffer(hipFileHandle_t fh, const void *buf) override;
+    file_buffer_stream_tuple getFileBufferAndStream(hipFileHandle_t fh, const void *buf,
+                                                    hipStream_t hipStream) override;
 
     //
     // Reference counts
     //
-
-    /// @brief Increment the driver's reference count
-    virtual void incrRefCount();
-
-    /// @brief Decrement the driver's reference count
-    ///
-    /// When the count gets to 0, the buffer and file maps will be destroyed.
-    virtual void decrRefCount();
-
-    /// @brief Get the driver's current reference count
-    /// @return The driver reference count
-    virtual int64_t getRefCount() const;
-
-    /// @brief Ensure the driver is initialized
-    ///
-    /// "Initializes" the driver by setting the reference count to 1
-    /// if it is currently 0.
-    ///
-    /// @note For ensuring NVIDIA cuFile behaviour compatibility
-    void ensureInitialized();
+    void    incrRefCount() override;
+    void    decrRefCount() override;
+    int64_t getRefCount() const override;
+    void    ensureInitialized() override;
 
     //
     // Misc
@@ -199,7 +255,7 @@ public:
     DriverState &operator=(DriverState &&) = delete;
 
     DriverState();
-    virtual ~DriverState();
+    ~DriverState() override;
 
 private:
     // The driver's reference count

--- a/projects/hipfile/test/amd_detail/CMakeLists.txt
+++ b/projects/hipfile/test/amd_detail/CMakeLists.txt
@@ -28,6 +28,7 @@ set(TEST_SOURCE_FILES
     fastpath.cpp
     main.cpp
     mountinfo.cpp
+    runtime.cpp
     stats.cpp
     stream.cpp
 )

--- a/projects/hipfile/test/amd_detail/async.cpp
+++ b/projects/hipfile/test/amd_detail/async.cpp
@@ -11,6 +11,7 @@
 #include "file.h"
 #include "hipfile.h"
 #include "hipfile-literals.h"
+#include "hipfile-private.h"
 #include "hipfile-test.h"
 #include "hipfile-warnings.h"
 #include "hip.h"
@@ -324,10 +325,11 @@ TEST_F(HipFileAsyncMonitor, addOp_without_completeOp_prints_error_on_AsyncMonito
 HIPFILE_WARN_NO_EXIT_DTOR_OFF
 struct AsyncIoFunction {
     hipFileError_t (*function)(hipFileHandle_t, void *, size_t *, hoff_t *, hoff_t *, ssize_t *, hipStream_t);
+    IoType      io_type;
     std::string name;
 };
-static std::array<AsyncIoFunction, 2> asyncIOFns{
-    {{hipFileReadAsync, "hipFileReadAsync"}, {hipFileWriteAsync, "hipFileWriteAsync"}}};
+static std::array<AsyncIoFunction, 2> asyncIOFns{{{hipFileReadAsync, IoType::Read, "hipFileReadAsync"},
+                                                  {hipFileWriteAsync, IoType::Write, "hipFileWriteAsync"}}};
 HIPFILE_WARN_NO_EXIT_DTOR_ON
 
 struct HipFileReadWriteAsync : public HipFileOpened, public ::testing::WithParamInterface<AsyncIoFunction> {
@@ -339,6 +341,7 @@ struct HipFileReadWriteAsync : public HipFileOpened, public ::testing::WithParam
         nonnull_ssize  = reinterpret_cast<ssize_t *>(1);
         nonnull_stream = reinterpret_cast<hipStream_t>(1);
         io_op          = GetParam().function;
+        io_type        = GetParam().io_type;
         name           = GetParam().name;
     }
     StrictMock<MHip> mhip;
@@ -349,6 +352,7 @@ struct HipFileReadWriteAsync : public HipFileOpened, public ::testing::WithParam
     hoff_t          *nonnull_offset;
     hipStream_t      nonnull_stream;
     hipFileError_t (*io_op)(hipFileHandle_t, void *, size_t *, hoff_t *, hoff_t *, ssize_t *, hipStream_t);
+    IoType      io_type;
     std::string name;
 };
 
@@ -394,10 +398,10 @@ TEST_P(HipFileReadWriteAsync, unregisteredFileReturnsError)
 
 TEST_P(HipFileReadWriteAsync, badAllocReturnsHipErrorOutOfMemory)
 {
-    MDriverState driver;
+    StrictMock<MDriverState> driver;
     EXPECT_CALL(driver, getRefCount).WillOnce(Throw(std::bad_alloc()));
-    ASSERT_EQ(io_op(nonnull_void, nonnull_void, nonnull_size, nonnull_offset, nonnull_offset, nullptr,
-                    nonnull_stream),
+    ASSERT_EQ(hipFileIOAsync(io_type, nonnull_void, nonnull_void, nonnull_size, nonnull_offset,
+                             nonnull_offset, nullptr, nonnull_stream, driver),
               HipFileHipError(hipErrorOutOfMemory));
 }
 

--- a/projects/hipfile/test/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/test/amd_detail/batch/batch.cpp
@@ -267,18 +267,19 @@ struct HipFileBatchContext : public HipFileUnopened {
 
 TEST_F(HipFileBatchContext, SubmitSingleGoodOp)
 {
-    _context->submit_operations(&io_params, 1);
+    _context->submit_operations(&io_params, 1, *mock_driver_state);
 }
 
 TEST_F(HipFileBatchContext, SubmitZeroOperations)
 {
-    _context->submit_operations(nullptr, 0);
+    _context->submit_operations(nullptr, 0, *mock_driver_state);
 }
 
 TEST_F(HipFileBatchContext, SubmitOverCapacity)
 {
     // We should fail before we ever try touching the nullptr.
-    ASSERT_THROW(_context->submit_operations(nullptr, _context_capacity + 1), std::invalid_argument);
+    ASSERT_THROW(_context->submit_operations(nullptr, _context_capacity + 1, *mock_driver_state),
+                 std::invalid_argument);
 }
 
 TEST_F(HipFileBatchContext, SubmitOverCapacityOverMultipleSubmissions)
@@ -287,22 +288,22 @@ TEST_F(HipFileBatchContext, SubmitOverCapacityOverMultipleSubmissions)
     // In the future we might care that we are submitting the same operation.
     for (unsigned i = 0; i < _context_capacity; i++) {
         printf("i: %u\n", i);
-        _context->submit_operations(&io_params, 1);
+        _context->submit_operations(&io_params, 1, *mock_driver_state);
     }
 
-    ASSERT_THROW(_context->submit_operations(nullptr, 1), std::invalid_argument);
+    ASSERT_THROW(_context->submit_operations(nullptr, 1, *mock_driver_state), std::invalid_argument);
 }
 
 TEST_F(HipFileBatchContext, SubmitSingleBadBuffer)
 {
     EXPECT_CALL(*mock_driver_state, getFileAndBuffer).WillOnce(Throw(BufferNotRegistered()));
-    ASSERT_THROW(_context->submit_operations(&io_params, 1), BufferNotRegistered);
+    ASSERT_THROW(_context->submit_operations(&io_params, 1, *mock_driver_state), BufferNotRegistered);
 }
 
 TEST_F(HipFileBatchContext, SubmitSingleBadFileHandle)
 {
     EXPECT_CALL(*mock_driver_state, getFileAndBuffer).WillOnce(Throw(FileNotRegistered()));
-    ASSERT_THROW(_context->submit_operations(&io_params, 1), FileNotRegistered);
+    ASSERT_THROW(_context->submit_operations(&io_params, 1, *mock_driver_state), FileNotRegistered);
 }
 
 // BatchOperation is not mocked.
@@ -310,42 +311,42 @@ TEST_F(HipFileBatchContext, SubmitSingleBadParamBufferOffsetNegative)
 {
     hipFileIOParams_t bad_io_params     = io_params;
     bad_io_params.u.batch.devPtr_offset = -1;
-    ASSERT_THROW(_context->submit_operations(&bad_io_params, 1), std::invalid_argument);
+    ASSERT_THROW(_context->submit_operations(&bad_io_params, 1, *mock_driver_state), std::invalid_argument);
 }
 
 TEST_F(HipFileBatchContext, SubmitSingleBadParamBufferOffsetTooLarge)
 {
     hipFileIOParams_t bad_io_params     = io_params;
     bad_io_params.u.batch.devPtr_offset = default_mock_buffer_length;
-    ASSERT_THROW(_context->submit_operations(&bad_io_params, 1), std::invalid_argument);
+    ASSERT_THROW(_context->submit_operations(&bad_io_params, 1, *mock_driver_state), std::invalid_argument);
 }
 
 TEST_F(HipFileBatchContext, SubmitSingleBadParamIOSizeTooLarge)
 {
     hipFileIOParams_t bad_io_params = io_params;
     bad_io_params.u.batch.size      = static_cast<size_t>(default_mock_buffer_length + 1);
-    ASSERT_THROW(_context->submit_operations(&bad_io_params, 1), std::invalid_argument);
+    ASSERT_THROW(_context->submit_operations(&bad_io_params, 1, *mock_driver_state), std::invalid_argument);
 }
 
 TEST_F(HipFileBatchContext, SubmitSingleBadParamFileOffsetNegative)
 {
     hipFileIOParams_t bad_io_params   = io_params;
     bad_io_params.u.batch.file_offset = -1;
-    ASSERT_THROW(_context->submit_operations(&bad_io_params, 1), std::invalid_argument);
+    ASSERT_THROW(_context->submit_operations(&bad_io_params, 1, *mock_driver_state), std::invalid_argument);
 }
 
 TEST_F(HipFileBatchContext, SubmitSingleBadParamOpcodeInvalid)
 {
     hipFileIOParams_t bad_io_params = io_params;
     bad_io_params.opcode            = invalidEnum<hipFileOpcode_t>(maxEnum<hipFileOpcode_t>());
-    ASSERT_THROW(_context->submit_operations(&bad_io_params, 1), std::invalid_argument);
+    ASSERT_THROW(_context->submit_operations(&bad_io_params, 1, *mock_driver_state), std::invalid_argument);
 }
 
 TEST_F(HipFileBatchContext, SubmitSingleBadParamModeInvalid)
 {
     hipFileIOParams_t bad_io_params = io_params;
     bad_io_params.mode              = invalidEnum<hipFileBatchMode_t>(maxEnum<hipFileBatchMode_t>());
-    ASSERT_THROW(_context->submit_operations(&bad_io_params, 1), std::invalid_argument);
+    ASSERT_THROW(_context->submit_operations(&bad_io_params, 1, *mock_driver_state), std::invalid_argument);
 }
 
 HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/projects/hipfile/test/amd_detail/buffer.cpp
+++ b/projects/hipfile/test/amd_detail/buffer.cpp
@@ -4,12 +4,12 @@
  */
 
 #include "buffer.h"
-#include "context.h"
 #include "hip.h"
 #include "hipfile.h"
 #include "hipfile-test.h"
 #include "hipfile-warnings.h"
 #include "mhip.h"
+#include "runtime.h"
 #include "state.h"
 
 #include <array>
@@ -52,7 +52,7 @@ TEST_F(HipFileBuffer, register_internal_supported_hip_memory)
     for (const auto memoryType : SupportedHipMemoryTypes) {
         StrictMock<MHip> mhip;
         expect_buffer_registration(mhip, memoryType);
-        Context<DriverState>::get()->registerBuffer(nonnull_ptr, 0, 0);
+        Runtime::instance().state().registerBuffer(nonnull_ptr, 0, 0);
     }
 }
 
@@ -72,7 +72,7 @@ TEST_F(HipFileBuffer, register_internal_unsupported_hip_memory)
         hipPointerAttribute_t attrs{};
         attrs.type = memoryType;
         EXPECT_CALL(mhip, hipPointerGetAttributes).WillOnce(testing::Return(attrs));
-        ASSERT_THROW(Context<DriverState>::get()->registerBuffer(nonnull_ptr, 0, 0), InvalidMemoryType);
+        ASSERT_THROW(Runtime::instance().state().registerBuffer(nonnull_ptr, 0, 0), InvalidMemoryType);
     }
 }
 
@@ -91,7 +91,7 @@ TEST_F(HipFileBuffer, register_internal_hip_pointer_get_attributes_error)
 {
     StrictMock<MHip> mhip;
     EXPECT_CALL(mhip, hipPointerGetAttributes).WillOnce(testing::Throw(Hip::RuntimeError(hipErrorUnknown)));
-    ASSERT_THROW(Context<DriverState>::get()->registerBuffer(nonnull_ptr, 0, 0), Hip::RuntimeError);
+    ASSERT_THROW(Runtime::instance().state().registerBuffer(nonnull_ptr, 0, 0), Hip::RuntimeError);
 }
 
 TEST_F(HipFileBuffer, register_hip_pointer_get_attributes_error)
@@ -111,7 +111,7 @@ TEST_F(HipFileBuffer, register_internal_already_registered)
     StrictMock<MHip> mhip;
     expect_buffer_registration(mhip, hipMemoryTypeDevice);
     ASSERT_EQ(hipFileBufRegister(nonnull_ptr, 0, 0), HIPFILE_SUCCESS);
-    ASSERT_THROW(Context<DriverState>::get()->registerBuffer(nonnull_ptr, 0, 0), BufferAlreadyRegistered);
+    ASSERT_THROW(Runtime::instance().state().registerBuffer(nonnull_ptr, 0, 0), BufferAlreadyRegistered);
 }
 
 TEST_F(HipFileBuffer, register_already_registered)
@@ -200,7 +200,7 @@ TEST_F(HipFileBuffer, registerOverflowingRangeReturnsError)
 
 TEST_F(HipFileBuffer, deregister_internal_not_registered)
 {
-    ASSERT_THROW(Context<DriverState>::get()->deregisterBuffer(nonnull_ptr), BufferNotRegistered);
+    ASSERT_THROW(Runtime::instance().state().deregisterBuffer(nonnull_ptr), BufferNotRegistered);
 }
 
 TEST_F(HipFileBuffer, deregister_not_registered)
@@ -212,8 +212,8 @@ TEST_F(HipFileBuffer, deregister_internal)
 {
     StrictMock<MHip> mhip;
     expect_buffer_registration(mhip, hipMemoryTypeDevice);
-    Context<DriverState>::get()->registerBuffer(nonnull_ptr, 0, 0);
-    Context<DriverState>::get()->deregisterBuffer(nonnull_ptr);
+    Runtime::instance().state().registerBuffer(nonnull_ptr, 0, 0);
+    Runtime::instance().state().deregisterBuffer(nonnull_ptr);
 }
 
 TEST_F(HipFileBuffer, deregister)
@@ -228,9 +228,9 @@ TEST_F(HipFileBuffer, deregister_internal_duplicate_deregister)
 {
     StrictMock<MHip> mhip;
     expect_buffer_registration(mhip, hipMemoryTypeDevice);
-    Context<DriverState>::get()->registerBuffer(nonnull_ptr, 0, 0);
-    Context<DriverState>::get()->deregisterBuffer(nonnull_ptr);
-    ASSERT_THROW(Context<DriverState>::get()->deregisterBuffer(nonnull_ptr), BufferNotRegistered);
+    Runtime::instance().state().registerBuffer(nonnull_ptr, 0, 0);
+    Runtime::instance().state().deregisterBuffer(nonnull_ptr);
+    ASSERT_THROW(Runtime::instance().state().deregisterBuffer(nonnull_ptr), BufferNotRegistered);
 }
 
 TEST_F(HipFileBuffer, deregister_duplicate_deregister)
@@ -246,12 +246,12 @@ TEST_F(HipFileBuffer, deregister_internal_get_prevents_deregister)
 {
     StrictMock<MHip> mhip;
     expect_buffer_registration(mhip, hipMemoryTypeDevice);
-    Context<DriverState>::get()->registerBuffer(nonnull_ptr, 0, 0);
+    Runtime::instance().state().registerBuffer(nonnull_ptr, 0, 0);
     {
-        auto buffer = Context<DriverState>::get()->getRegisteredBuffer(nonnull_ptr);
-        ASSERT_THROW(Context<DriverState>::get()->deregisterBuffer(nonnull_ptr), BufferOperationsOutstanding);
+        auto buffer = Runtime::instance().state().getRegisteredBuffer(nonnull_ptr);
+        ASSERT_THROW(Runtime::instance().state().deregisterBuffer(nonnull_ptr), BufferOperationsOutstanding);
     }
-    Context<DriverState>::get()->deregisterBuffer(nonnull_ptr);
+    Runtime::instance().state().deregisterBuffer(nonnull_ptr);
 }
 
 TEST_F(HipFileBuffer, deregister_get_prevents_deregister)
@@ -260,7 +260,7 @@ TEST_F(HipFileBuffer, deregister_get_prevents_deregister)
     expect_buffer_registration(mhip, hipMemoryTypeDevice);
     ASSERT_EQ(hipFileBufRegister(nonnull_ptr, 0, 0), HIPFILE_SUCCESS);
     {
-        auto buffer = Context<DriverState>::get()->getRegisteredBuffer(nonnull_ptr);
+        auto buffer = Runtime::instance().state().getRegisteredBuffer(nonnull_ptr);
         ASSERT_EQ(hipFileBufDeregister(nonnull_ptr), HipFileOpError(hipFileInternalError));
     }
     ASSERT_EQ(hipFileBufDeregister(nonnull_ptr), HIPFILE_SUCCESS);
@@ -268,15 +268,15 @@ TEST_F(HipFileBuffer, deregister_get_prevents_deregister)
 
 TEST_F(HipFileBuffer, get_not_registered)
 {
-    ASSERT_THROW(Context<DriverState>::get()->getRegisteredBuffer(nonnull_ptr), BufferNotRegistered);
+    ASSERT_THROW(Runtime::instance().state().getRegisteredBuffer(nonnull_ptr), BufferNotRegistered);
 }
 
 TEST_F(HipFileBuffer, get_internal_after_register)
 {
     StrictMock<MHip> mhip;
     expect_buffer_registration(mhip, hipMemoryTypeDevice);
-    Context<DriverState>::get()->registerBuffer(nonnull_ptr, 0, 0);
-    auto buffer = Context<DriverState>::get()->getRegisteredBuffer(nonnull_ptr);
+    Runtime::instance().state().registerBuffer(nonnull_ptr, 0, 0);
+    auto buffer = Runtime::instance().state().getRegisteredBuffer(nonnull_ptr);
 }
 
 TEST_F(HipFileBuffer, get_after_register)
@@ -284,16 +284,16 @@ TEST_F(HipFileBuffer, get_after_register)
     StrictMock<MHip> mhip;
     expect_buffer_registration(mhip, hipMemoryTypeDevice);
     ASSERT_EQ(hipFileBufRegister(nonnull_ptr, 0, 0), HIPFILE_SUCCESS);
-    auto buffer = Context<DriverState>::get()->getRegisteredBuffer(nonnull_ptr);
+    auto buffer = Runtime::instance().state().getRegisteredBuffer(nonnull_ptr);
 }
 
 TEST_F(HipFileBuffer, get_internal_after_deregister)
 {
     StrictMock<MHip> mhip;
     expect_buffer_registration(mhip, hipMemoryTypeDevice);
-    Context<DriverState>::get()->registerBuffer(nonnull_ptr, 0, 0);
-    Context<DriverState>::get()->deregisterBuffer(nonnull_ptr);
-    ASSERT_THROW(Context<DriverState>::get()->getRegisteredBuffer(nonnull_ptr), BufferNotRegistered);
+    Runtime::instance().state().registerBuffer(nonnull_ptr, 0, 0);
+    Runtime::instance().state().deregisterBuffer(nonnull_ptr);
+    ASSERT_THROW(Runtime::instance().state().getRegisteredBuffer(nonnull_ptr), BufferNotRegistered);
 }
 
 TEST_F(HipFileBuffer, get_after_deregister)
@@ -302,14 +302,14 @@ TEST_F(HipFileBuffer, get_after_deregister)
     expect_buffer_registration(mhip, hipMemoryTypeDevice);
     ASSERT_EQ(hipFileBufRegister(nonnull_ptr, 0, 0), HIPFILE_SUCCESS);
     ASSERT_EQ(hipFileBufDeregister(nonnull_ptr), HIPFILE_SUCCESS);
-    ASSERT_THROW(Context<DriverState>::get()->getRegisteredBuffer(nonnull_ptr), BufferNotRegistered);
+    ASSERT_THROW(Runtime::instance().state().getRegisteredBuffer(nonnull_ptr), BufferNotRegistered);
 }
 
 TEST_F(HipFileBuffer, get_buffer_makes_temporary_buffer)
 {
     StrictMock<MHip> mhip;
     expect_buffer_registration(mhip, hipMemoryTypeDevice);
-    auto buffer = Context<DriverState>::get()->getBuffer(nonnull_ptr);
+    auto buffer = Runtime::instance().state().getBuffer(nonnull_ptr);
     ASSERT_EQ(buffer.use_count(), 1);
 }
 
@@ -317,16 +317,16 @@ TEST_F(HipFileBuffer, get_buffer_returns_registered_buffer)
 {
     StrictMock<MHip> mhip;
     expect_buffer_registration(mhip, hipMemoryTypeDevice);
-    Context<DriverState>::get()->registerBuffer(nonnull_ptr, 0, 0);
-    ASSERT_EQ(Context<DriverState>::get()->getBuffer(nonnull_ptr),
-              Context<DriverState>::get()->getRegisteredBuffer(nonnull_ptr));
+    Runtime::instance().state().registerBuffer(nonnull_ptr, 0, 0);
+    ASSERT_EQ(Runtime::instance().state().getBuffer(nonnull_ptr),
+              Runtime::instance().state().getRegisteredBuffer(nonnull_ptr));
 }
 
 TEST_F(HipFileBuffer, get_buffer_throws_on_getPointerAttributes_error)
 {
     StrictMock<MHip> mhip;
     EXPECT_CALL(mhip, hipPointerGetAttributes).WillOnce(testing::Throw(Hip::RuntimeError(hipErrorUnknown)));
-    ASSERT_THROW(Context<DriverState>::get()->getBuffer(nonnull_ptr), Hip::RuntimeError);
+    ASSERT_THROW(Runtime::instance().state().getBuffer(nonnull_ptr), Hip::RuntimeError);
 }
 
 HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/projects/hipfile/test/amd_detail/fallback.cpp
+++ b/projects/hipfile/test/amd_detail/fallback.cpp
@@ -6,7 +6,7 @@
 #include "backend.h"
 #include "backend/fallback.h"
 #include "buffer.h"
-#include "context.h"
+#include "runtime.h"
 #include "file.h"
 #include "hip.h"
 #include "hipfile.h"
@@ -124,11 +124,11 @@ struct FallbackIo : public HipFileOpened {
     {
 
         expect_buffer_registration(mhip, hipMemoryTypeDevice);
-        Context<DriverState>::get()->registerBuffer(buffer_data.data(), buffer_data.size(), 0);
-        buffer = Context<DriverState>::get()->getRegisteredBuffer(buffer_data.data());
+        Runtime::instance().state().registerBuffer(buffer_data.data(), buffer_data.size(), 0);
+        buffer = Runtime::instance().state().getRegisteredBuffer(buffer_data.data());
 
         expect_file_registration(msys, mlibmounthelper);
-        file = Context<DriverState>::get()->getFile(Context<DriverState>::get()->registerFile(0xBADF00D));
+        file = Runtime::instance().state().getFile(Runtime::instance().state().registerFile(0xBADF00D));
     }
 
     virtual ~FallbackIo() override
@@ -196,11 +196,11 @@ struct FallbackParam : ::testing::TestWithParam<IoType> {
 
         expect_buffer_registration(mhip, hipMemoryTypeDevice);
         void *buf{reinterpret_cast<void *>(0xFEFEFEFE)};
-        Context<DriverState>::get()->registerBuffer(buf, 4096, 0);
-        buffer = Context<DriverState>::get()->getRegisteredBuffer(buf);
+        Runtime::instance().state().registerBuffer(buf, 4096, 0);
+        buffer = Runtime::instance().state().getRegisteredBuffer(buf);
 
         expect_file_registration(msys, mlibmounthelper);
-        file = Context<DriverState>::get()->getFile(Context<DriverState>::get()->registerFile(0xBADF00D));
+        file = Runtime::instance().state().getFile(Runtime::instance().state().registerFile(0xBADF00D));
     }
 
     ~FallbackParam() override
@@ -263,8 +263,8 @@ TEST_P(FallbackParam, FallbackIoTruncatesSizeToMAX_RW_COUNT)
 {
     expect_buffer_registration(mhip, hipMemoryTypeDevice);
     auto buf{reinterpret_cast<void *>(0xABABABAB)};
-    Context<DriverState>::get()->registerBuffer(buf, hipFile::getMaxRwCount() + 1, 0);
-    auto big_buffer{Context<DriverState>::get()->getRegisteredBuffer(buf)};
+    Runtime::instance().state().registerBuffer(buf, hipFile::getMaxRwCount() + 1, 0);
+    auto big_buffer{Runtime::instance().state().getRegisteredBuffer(buf)};
 
     EXPECT_CALL(mcfg, fallback()).WillOnce(Return(true));
     EXPECT_CALL(msys, mmap).WillOnce(testing::Return(reinterpret_cast<void *>(0xFEFEFEFE)));

--- a/projects/hipfile/test/amd_detail/handle.cpp
+++ b/projects/hipfile/test/amd_detail/handle.cpp
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: MIT
  */
 
-#include "context.h"
 #include "file.h"
 #include "hipfile.h"
 #include "hipfile-test.h"
@@ -12,6 +11,7 @@
 #include "msys.h"
 #include "mmountinfo.h"
 #include "mountinfo.h"
+#include "runtime.h"
 #include "state.h"
 
 #include <cerrno>
@@ -162,7 +162,7 @@ TEST_F(HipFileHandle, register_handle_internal_linux_fd)
     int fd{0xBADF00D};
 
     ExpectUnregisteredFileBuilder(msys, mlibmounthelper).build();
-    ASSERT_NE(Context<DriverState>::get()->registerFile(fd), nullptr);
+    ASSERT_NE(Runtime::instance().state().registerFile(fd), nullptr);
 }
 
 TEST_F(HipFileHandle, file_initialization)
@@ -195,8 +195,8 @@ TEST_F(HipFileHandle, file_initialization)
         .mountinfo(mountinfo)
         .open_fd(open_fd)
         .build();
-    auto fh{Context<DriverState>::get()->registerFile(fd)};
-    auto file{Context<DriverState>::get()->getFile(fh)};
+    auto fh{Runtime::instance().state().registerFile(fd)};
+    auto file{Runtime::instance().state().getFile(fh)};
 
     EXPECT_EQ(fh, file->handle());
     EXPECT_EQ(fd, file->clientFd());
@@ -219,9 +219,9 @@ TEST_F(HipFileHandle, register_handle_internal_linux_fd_already_registered)
 {
     int fd{0xBADF00D};
     ExpectUnregisteredFileBuilder(msys, mlibmounthelper).build();
-    ASSERT_NE(Context<DriverState>::get()->registerFile(fd), nullptr);
+    ASSERT_NE(Runtime::instance().state().registerFile(fd), nullptr);
     ExpectUnregisteredFileBuilder(msys, mlibmounthelper).build();
-    ASSERT_THROW(Context<DriverState>::get()->registerFile(fd), FileAlreadyRegistered);
+    ASSERT_THROW(Runtime::instance().state().registerFile(fd), FileAlreadyRegistered);
 }
 
 TEST_F(HipFileHandle, register_handle_linux_fd)
@@ -331,7 +331,7 @@ TEST_F(HipFileHandle, register_handle_invalid_type_not_supported)
 
 TEST_F(HipFileHandle, deregister_handle_internal_throws_if_not_registered)
 {
-    ASSERT_THROW(Context<DriverState>::get()->deregisterFile(reinterpret_cast<hipFileHandle_t>(0xdeadbeef)),
+    ASSERT_THROW(Runtime::instance().state().deregisterFile(reinterpret_cast<hipFileHandle_t>(0xdeadbeef)),
                  FileNotRegistered);
 }
 
@@ -343,9 +343,9 @@ TEST_F(HipFileHandle, deregister_handle_doesnt_throw_if_not_registered)
 TEST_F(HipFileHandle, deregister_handle_internal)
 {
     ExpectUnregisteredFileBuilder(msys, mlibmounthelper).build();
-    auto fh = Context<DriverState>::get()->registerFile(0xBADF00D);
-    Context<DriverState>::get()->deregisterFile(fh);
-    ASSERT_THROW(Context<DriverState>::get()->deregisterFile(fh), FileNotRegistered);
+    auto fh = Runtime::instance().state().registerFile(0xBADF00D);
+    Runtime::instance().state().deregisterFile(fh);
+    ASSERT_THROW(Runtime::instance().state().deregisterFile(fh), FileNotRegistered);
 }
 
 TEST_F(HipFileHandle, deregister_handle)
@@ -365,12 +365,12 @@ TEST_F(HipFileHandle, deregister_handle)
 TEST_F(HipFileHandle, deregister_handle_internal_fails_when_operations_are_oustanding)
 {
     ExpectUnregisteredFileBuilder(msys, mlibmounthelper).build();
-    auto fh = Context<DriverState>::get()->registerFile(0xBADF00D);
+    auto fh = Runtime::instance().state().registerFile(0xBADF00D);
     {
-        auto file = Context<DriverState>::get()->getFile(fh);
-        ASSERT_THROW(Context<DriverState>::get()->deregisterFile(fh), FileOperationsOutstanding);
+        auto file = Runtime::instance().state().getFile(fh);
+        ASSERT_THROW(Runtime::instance().state().deregisterFile(fh), FileOperationsOutstanding);
     }
-    Context<DriverState>::get()->deregisterFile(fh);
+    Runtime::instance().state().deregisterFile(fh);
 }
 
 TEST_F(HipFileHandle, deregister_handle_fails_when_operations_are_oustanding)
@@ -384,7 +384,7 @@ TEST_F(HipFileHandle, deregister_handle_fails_when_operations_are_oustanding)
     ExpectUnregisteredFileBuilder(msys, mlibmounthelper).build();
     ASSERT_EQ(hipFileHandleRegister(&fh, &rfd), HIPFILE_SUCCESS);
     {
-        auto file = Context<DriverState>::get()->getFile(fh);
+        auto file = Runtime::instance().state().getFile(fh);
         hipFileHandleDeregister(fh);
     }
     hipFileHandleDeregister(fh);
@@ -572,8 +572,8 @@ TEST_F(HipFileHandle, IsBlockDeviceReturnsTrueForBlockDevice)
         .statx(stxbuf)
         .open_fd(open_fd)
         .build();
-    auto fh{Context<DriverState>::get()->registerFile(fd)};
-    auto file{Context<DriverState>::get()->getFile(fh)};
+    auto fh{Runtime::instance().state().registerFile(fd)};
+    auto file{Runtime::instance().state().getFile(fh)};
 
     EXPECT_TRUE(file->isBlockDevice());
 }
@@ -595,8 +595,8 @@ TEST_F(HipFileHandle, IsBlockDeviceReturnsFalseForRegularFile)
         .statx(stxbuf)
         .open_fd(open_fd)
         .build();
-    auto fh{Context<DriverState>::get()->registerFile(fd)};
-    auto file{Context<DriverState>::get()->getFile(fh)};
+    auto fh{Runtime::instance().state().registerFile(fd)};
+    auto file{Runtime::instance().state().getFile(fh)};
 
     EXPECT_FALSE(file->isBlockDevice());
 }
@@ -618,8 +618,8 @@ TEST_F(HipFileHandle, IsBlockDeviceReturnsFalseWhenStatxTypeNotAvailable)
         .statx(stxbuf)
         .open_fd(open_fd)
         .build();
-    auto fh{Context<DriverState>::get()->registerFile(fd)};
-    auto file{Context<DriverState>::get()->getFile(fh)};
+    auto fh{Runtime::instance().state().registerFile(fd)};
+    auto file{Runtime::instance().state().getFile(fh)};
 
     EXPECT_FALSE(file->isBlockDevice());
 }
@@ -641,8 +641,8 @@ TEST_F(HipFileHandle, IsRegularFileReturnsTrueForRegularFile)
         .statx(stxbuf)
         .open_fd(open_fd)
         .build();
-    auto fh{Context<DriverState>::get()->registerFile(fd)};
-    auto file{Context<DriverState>::get()->getFile(fh)};
+    auto fh{Runtime::instance().state().registerFile(fd)};
+    auto file{Runtime::instance().state().getFile(fh)};
 
     EXPECT_TRUE(file->isRegularFile());
 }
@@ -664,8 +664,8 @@ TEST_F(HipFileHandle, IsRegularFileReturnsFalseForBlockDevice)
         .statx(stxbuf)
         .open_fd(open_fd)
         .build();
-    auto fh{Context<DriverState>::get()->registerFile(fd)};
-    auto file{Context<DriverState>::get()->getFile(fh)};
+    auto fh{Runtime::instance().state().registerFile(fd)};
+    auto file{Runtime::instance().state().getFile(fh)};
 
     EXPECT_FALSE(file->isRegularFile());
 }
@@ -687,8 +687,8 @@ TEST_F(HipFileHandle, IsRegularFileReturnsFalseWhenStatxTypeNotAvailable)
         .statx(stxbuf)
         .open_fd(open_fd)
         .build();
-    auto fh{Context<DriverState>::get()->registerFile(fd)};
-    auto file{Context<DriverState>::get()->getFile(fh)};
+    auto fh{Runtime::instance().state().registerFile(fd)};
+    auto file{Runtime::instance().state().getFile(fh)};
 
     EXPECT_FALSE(file->isRegularFile());
 }
@@ -711,8 +711,8 @@ TEST_F(HipFileHandle, OnExt4OrderedReturnsTrueForExt4Ordered)
         .mountinfo(mountinfo)
         .open_fd(open_fd)
         .build();
-    auto fh{Context<DriverState>::get()->registerFile(fd)};
-    auto file{Context<DriverState>::get()->getFile(fh)};
+    auto fh{Runtime::instance().state().registerFile(fd)};
+    auto file{Runtime::instance().state().getFile(fh)};
 
     EXPECT_TRUE(file->onExt4Ordered());
 }
@@ -735,8 +735,8 @@ TEST_F(HipFileHandle, OnExt4OrderedReturnsFalseForExt4Journal)
         .mountinfo(mountinfo)
         .open_fd(open_fd)
         .build();
-    auto fh{Context<DriverState>::get()->registerFile(fd)};
-    auto file{Context<DriverState>::get()->getFile(fh)};
+    auto fh{Runtime::instance().state().registerFile(fd)};
+    auto file{Runtime::instance().state().getFile(fh)};
 
     EXPECT_FALSE(file->onExt4Ordered());
 }
@@ -758,8 +758,8 @@ TEST_F(HipFileHandle, OnExt4OrderedReturnsFalseForOtherFileSystem)
         .mountinfo(mountinfo)
         .open_fd(open_fd)
         .build();
-    auto fh{Context<DriverState>::get()->registerFile(fd)};
-    auto file{Context<DriverState>::get()->getFile(fh)};
+    auto fh{Runtime::instance().state().registerFile(fd)};
+    auto file{Runtime::instance().state().getFile(fh)};
 
     EXPECT_FALSE(file->onExt4Ordered());
 }
@@ -781,8 +781,8 @@ TEST_F(HipFileHandle, OnXfsReturnsTrueForXfs)
         .mountinfo(mountinfo)
         .open_fd(open_fd)
         .build();
-    auto fh{Context<DriverState>::get()->registerFile(fd)};
-    auto file{Context<DriverState>::get()->getFile(fh)};
+    auto fh{Runtime::instance().state().registerFile(fd)};
+    auto file{Runtime::instance().state().getFile(fh)};
 
     EXPECT_TRUE(file->onXfs());
 }
@@ -804,8 +804,8 @@ TEST_F(HipFileHandle, OnXfsReturnsFalseForOtherFileSystem)
         .mountinfo(mountinfo)
         .open_fd(open_fd)
         .build();
-    auto fh{Context<DriverState>::get()->registerFile(fd)};
-    auto file{Context<DriverState>::get()->getFile(fh)};
+    auto fh{Runtime::instance().state().registerFile(fd)};
+    auto file{Runtime::instance().state().getFile(fh)};
 
     EXPECT_FALSE(file->onXfs());
 }

--- a/projects/hipfile/test/amd_detail/hipfile-api.cpp
+++ b/projects/hipfile/test/amd_detail/hipfile-api.cpp
@@ -28,6 +28,7 @@
 #include "mmountinfo.h"
 #include "mstate.h"
 #include "msys.h"
+#include "runtime.h"
 #include "state.h"
 
 #include <array>
@@ -67,7 +68,7 @@ TEST_F(HipFileUnit, TestHipFileBatchIOSetupSuccess)
 
     EXPECT_CALL(mock_state, createBatchContext).WillOnce(Return(expected_b_handle));
 
-    auto result = hipFileBatchIOSetUp(&b_handle, 1);
+    auto result = hipFileBatchSetUp(&b_handle, 1, mock_state);
     EXPECT_EQ(result, HIPFILE_SUCCESS);
     EXPECT_EQ(b_handle, expected_b_handle);
 }
@@ -78,14 +79,14 @@ TEST_F(HipFileUnit, TestHipFileBatchIOSetupBadArgument)
 
     EXPECT_CALL(mock_state, createBatchContext).WillOnce(Throw(std::invalid_argument("")));
 
-    auto result = hipFileBatchIOSetUp(&b_handle, 0);
+    auto result = hipFileBatchSetUp(&b_handle, 0, mock_state);
     EXPECT_EQ(result, HIPFILE_INVALID_VALUE);
     EXPECT_EQ(b_handle, nullptr);
 }
 
 TEST_F(HipFileUnit, TestHipFileBatchIOSetupNullptrHandle)
 {
-    auto result = hipFileBatchIOSetUp(nullptr, 1);
+    auto result = hipFileBatchSetUp(nullptr, 1, mock_state);
     ASSERT_EQ(result, HIPFILE_INVALID_VALUE);
 }
 
@@ -98,7 +99,7 @@ TEST_F(HipFileUnit, TestHipFileBatchIOSubmitSuccess)
     EXPECT_CALL(mock_state, getBatchContext).WillOnce(Return(mock_b_context));
     EXPECT_CALL(*mock_b_context, submit_operations);
 
-    auto result = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0);
+    auto result = hipFileBatchSubmit(b_handle, 1, &io_param, 0, mock_state);
     ASSERT_EQ(result, HIPFILE_SUCCESS);
 }
 
@@ -111,7 +112,7 @@ TEST_F(HipFileUnit, TestHipFileBatchIOSubmitBadHandle)
     EXPECT_CALL(mock_state, getBatchContext).WillOnce(Throw(InvalidBatchHandle()));
     EXPECT_CALL(*mock_b_context, submit_operations).Times(0);
 
-    auto           result          = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0);
+    auto           result          = hipFileBatchSubmit(b_handle, 1, &io_param, 0, mock_state);
     hipFileError_t expected_result = {hipFileInvalidValue, hipSuccess};
     ASSERT_EQ(result, expected_result);
 }
@@ -125,7 +126,7 @@ TEST_F(HipFileUnit, TestHipFileBatchIOSubmitBadArgument)
     EXPECT_CALL(mock_state, getBatchContext).WillOnce(Return(mock_b_context));
     EXPECT_CALL(*mock_b_context, submit_operations).WillOnce(Throw(std::invalid_argument("")));
 
-    auto result = hipFileBatchIOSubmit(b_handle, 1, &io_param, 0);
+    auto result = hipFileBatchSubmit(b_handle, 1, &io_param, 0, mock_state);
     ASSERT_EQ(result, HIPFILE_INVALID_VALUE);
 }
 
@@ -139,7 +140,7 @@ TEST_F(HipFileUnit, TestHipFileBatchIOSubmitNullptrParams)
     EXPECT_CALL(mock_state, getBatchContext).Times(0);
     EXPECT_CALL(*mock_b_context, submit_operations).Times(0);
 
-    auto           result          = hipFileBatchIOSubmit(b_handle, 1, nullptr, 0);
+    auto           result          = hipFileBatchSubmit(b_handle, 1, nullptr, 0, mock_state);
     hipFileError_t expected_result = {hipFileInvalidValue, hipSuccess};
     ASSERT_EQ(result, expected_result);
 }
@@ -159,13 +160,13 @@ struct HipFileIoParam : public TestWithParam<IoType> {
             StrictMock<MSys>            msys;
             StrictMock<MLibMountHelper> mlmh;
             expect_file_registration(msys, mlmh);
-            file_handle = Context<DriverState>::get()->registerFile(0x0BADCAFE);
+            file_handle = Runtime::instance().state().registerFile(0x0BADCAFE);
         }
 
         {
             StrictMock<MHip> mhip;
             expect_buffer_registration(mhip, hipMemoryTypeDevice);
-            Context<DriverState>::get()->registerBuffer(bufptr, buflen, 0);
+            Runtime::instance().state().registerBuffer(bufptr, buflen, 0);
         }
     }
 };
@@ -175,7 +176,7 @@ TEST_P(HipFileIoParam, HipFileIoHandlesHipPointerGetAttributesError)
     StrictMock<MHip> mhip;
     EXPECT_CALL(mhip, hipPointerGetAttributes).WillOnce(testing::Throw(Hip::RuntimeError(hipErrorUnknown)));
     ASSERT_EQ(
-        hipFileIo(GetParam(), file_handle, unreg_bufptr, 0, 0, 0, *Context<DriverState>::get(), mbackends),
+        hipFileIo(GetParam(), file_handle, unreg_bufptr, 0, 0, 0, Runtime::instance().state(), mbackends),
         -hipErrorUnknown);
 }
 
@@ -186,16 +187,16 @@ TEST_P(HipFileIoParam, HipFileIoHandlesUnsupportedHipMemoryType)
         hipPointerAttribute_t attrs{};
         attrs.type = memoryType;
         EXPECT_CALL(mhip, hipPointerGetAttributes).WillOnce(testing::Return(attrs));
-        ASSERT_EQ(hipFileIo(GetParam(), file_handle, unreg_bufptr, 0, 0, 0, *Context<DriverState>::get(),
-                            mbackends),
-                  -static_cast<ssize_t>(hipFileHipMemoryTypeInvalid));
+        ASSERT_EQ(
+            hipFileIo(GetParam(), file_handle, unreg_bufptr, 0, 0, 0, Runtime::instance().state(), mbackends),
+            -static_cast<ssize_t>(hipFileHipMemoryTypeInvalid));
     }
 }
 
 TEST_P(HipFileIoParam, HipFileIoHandlesInvalidFileHandle)
 {
     auto invalid_handle{reinterpret_cast<hipFileHandle_t>(0xdeadbeef)};
-    ASSERT_EQ(hipFileIo(GetParam(), invalid_handle, bufptr, 0, 0, 0, *Context<DriverState>::get(), mbackends),
+    ASSERT_EQ(hipFileIo(GetParam(), invalid_handle, bufptr, 0, 0, 0, Runtime::instance().state(), mbackends),
               -hipFileHandleNotRegistered);
 }
 
@@ -205,8 +206,7 @@ TEST_P(HipFileIoParam, HipFileIoHandlesSysRuntimeError)
     EXPECT_CALL(*mbackend, io).WillOnce(Throw(std::system_error(EBADFD, std::generic_category())));
     errno = 0;
     ASSERT_EQ(
-        hipFileIo(GetParam(), file_handle, bufptr, buflen, 0, 0, *Context<DriverState>::get(), mbackends),
-        -1);
+        hipFileIo(GetParam(), file_handle, bufptr, buflen, 0, 0, Runtime::instance().state(), mbackends), -1);
     ASSERT_EQ(errno, EBADFD);
 }
 
@@ -215,7 +215,7 @@ TEST_P(HipFileIoParam, HipFileIoHandlesHipRuntimeError)
     EXPECT_CALL(*mbackend, score).WillOnce(Return(1));
     EXPECT_CALL(*mbackend, io).WillOnce(Throw(Hip::RuntimeError(hipErrorUnknown)));
     ASSERT_EQ(
-        hipFileIo(GetParam(), file_handle, bufptr, buflen, 0, 0, *Context<DriverState>::get(), mbackends),
+        hipFileIo(GetParam(), file_handle, bufptr, buflen, 0, 0, Runtime::instance().state(), mbackends),
         -hipErrorUnknown);
 }
 
@@ -224,7 +224,7 @@ TEST_P(HipFileIoParam, HipFileIoHandlesInvalidArgumentError)
     EXPECT_CALL(*mbackend, score).WillOnce(Return(1));
     EXPECT_CALL(*mbackend, io).WillOnce(Throw(std::invalid_argument("")));
     ASSERT_EQ(
-        hipFileIo(GetParam(), file_handle, bufptr, buflen, 0, 0, *Context<DriverState>::get(), mbackends),
+        hipFileIo(GetParam(), file_handle, bufptr, buflen, 0, 0, Runtime::instance().state(), mbackends),
         -hipFileInvalidValue);
 }
 
@@ -233,7 +233,7 @@ TEST_P(HipFileIoParam, HipFileIoHandlesBackendDisabled)
     EXPECT_CALL(*mbackend, score).WillOnce(Return(1));
     EXPECT_CALL(*mbackend, io).WillOnce(Throw(BackendDisabled()));
     ASSERT_EQ(
-        hipFileIo(GetParam(), file_handle, bufptr, buflen, 0, 0, *Context<DriverState>::get(), mbackends),
+        hipFileIo(GetParam(), file_handle, bufptr, buflen, 0, 0, Runtime::instance().state(), mbackends),
         -hipFileInternalError);
 }
 
@@ -267,23 +267,12 @@ struct HipFileIoBackendSelectionParam : public ::testing::TestWithParam<IoType> 
 
 TEST_P(HipFileIoBackendSelectionParam, HipFileIoThrowsIfThereAreNoBackends)
 {
-    auto backends{std::vector<std::shared_ptr<Backend>>()};
+    std::vector<std::shared_ptr<Backend>> backends{};
 
     EXPECT_CALL(mds, getFileAndBuffer(handle, buffer)).WillOnce(Return(file_buffer_pair{mfile, mbuffer}));
-    EXPECT_CALL(mds, getBackends).WillOnce(Return(std::move(backends)));
 
-    switch (io_type) {
-        case IoType::Read:
-            ASSERT_EQ(hipFileRead(handle, buffer, io_size, file_offset, buffer_offset),
-                      -hipFileInternalError);
-            break;
-        case IoType::Write:
-            ASSERT_EQ(hipFileWrite(handle, buffer, io_size, file_offset, buffer_offset),
-                      -hipFileInternalError);
-            break;
-        default:
-            FAIL() << "Unhandled IO Type";
-    }
+    ASSERT_EQ(hipFileIo(io_type, handle, buffer, io_size, file_offset, buffer_offset, mds, backends),
+              -hipFileInternalError);
 }
 
 TEST_P(HipFileIoBackendSelectionParam, HipFileIoThrowsIfAllBackendsRejectTheIO)
@@ -291,7 +280,6 @@ TEST_P(HipFileIoBackendSelectionParam, HipFileIoThrowsIfAllBackendsRejectTheIO)
     std::vector<std::shared_ptr<Backend>> backends{mbe1, mbe2, mbe3};
 
     EXPECT_CALL(mds, getFileAndBuffer(handle, buffer)).WillOnce(Return(file_buffer_pair{mfile, mbuffer}));
-    EXPECT_CALL(mds, getBackends).WillOnce(Return(std::move(backends)));
     EXPECT_CALL(*mbe1, score(Eq(mfile), Eq(mbuffer), io_size, file_offset, buffer_offset))
         .WillOnce(Return(-1));
     EXPECT_CALL(*mbe2, score(Eq(mfile), Eq(mbuffer), io_size, file_offset, buffer_offset))
@@ -299,18 +287,8 @@ TEST_P(HipFileIoBackendSelectionParam, HipFileIoThrowsIfAllBackendsRejectTheIO)
     EXPECT_CALL(*mbe3, score(Eq(mfile), Eq(mbuffer), io_size, file_offset, buffer_offset))
         .WillOnce(Return(-1));
 
-    switch (io_type) {
-        case IoType::Read:
-            ASSERT_EQ(hipFileRead(handle, buffer, io_size, file_offset, buffer_offset),
-                      -hipFileInternalError);
-            break;
-        case IoType::Write:
-            ASSERT_EQ(hipFileWrite(handle, buffer, io_size, file_offset, buffer_offset),
-                      -hipFileInternalError);
-            break;
-        default:
-            FAIL() << "Unhandled IO Type";
-    }
+    ASSERT_EQ(hipFileIo(io_type, handle, buffer, io_size, file_offset, buffer_offset, mds, backends),
+              -hipFileInternalError);
 }
 
 TEST_P(HipFileIoBackendSelectionParam, HipFileIoIssuesIoToHighestScoringBackend)
@@ -318,30 +296,17 @@ TEST_P(HipFileIoBackendSelectionParam, HipFileIoIssuesIoToHighestScoringBackend)
     std::vector<std::shared_ptr<Backend>> backends{mbe1, mbe2, mbe3};
 
     EXPECT_CALL(mds, getFileAndBuffer(handle, buffer)).WillOnce(Return(file_buffer_pair{mfile, mbuffer}));
-    EXPECT_CALL(mds, getBackends).WillOnce(Return(std::move(backends)));
     EXPECT_CALL(*mbe1, score(Eq(mfile), Eq(mbuffer), io_size, file_offset, buffer_offset))
         .WillOnce(Return(0));
     EXPECT_CALL(*mbe2, score(Eq(mfile), Eq(mbuffer), io_size, file_offset, buffer_offset))
         .WillOnce(Return(2));
     EXPECT_CALL(*mbe3, score(Eq(mfile), Eq(mbuffer), io_size, file_offset, buffer_offset))
         .WillOnce(Return(1));
+    EXPECT_CALL(*mbe2, io(Eq(io_type), Eq(mfile), Eq(mbuffer), io_size, file_offset, buffer_offset))
+        .WillOnce(Return(io_size));
 
-    switch (io_type) {
-        case IoType::Read:
-            EXPECT_CALL(*mbe2,
-                        io(Eq(IoType::Read), Eq(mfile), Eq(mbuffer), io_size, file_offset, buffer_offset))
-                .WillOnce(Return(io_size));
-            ASSERT_EQ(hipFileRead(handle, buffer, io_size, file_offset, buffer_offset), io_size);
-            break;
-        case IoType::Write:
-            EXPECT_CALL(*mbe2,
-                        io(Eq(IoType::Write), Eq(mfile), Eq(mbuffer), io_size, file_offset, buffer_offset))
-                .WillOnce(Return(io_size));
-            ASSERT_EQ(hipFileWrite(handle, buffer, io_size, file_offset, buffer_offset), io_size);
-            break;
-        default:
-            FAIL() << "Unhandled IO Type";
-    }
+    ASSERT_EQ(hipFileIo(io_type, handle, buffer, io_size, file_offset, buffer_offset, mds, backends),
+              io_size);
 }
 
 INSTANTIATE_TEST_SUITE_P(HipFileIoBackendSelection, HipFileIoBackendSelectionParam,

--- a/projects/hipfile/test/amd_detail/hipfile-api.cpp
+++ b/projects/hipfile/test/amd_detail/hipfile-api.cpp
@@ -174,7 +174,9 @@ TEST_P(HipFileIoParam, HipFileIoHandlesHipPointerGetAttributesError)
 {
     StrictMock<MHip> mhip;
     EXPECT_CALL(mhip, hipPointerGetAttributes).WillOnce(testing::Throw(Hip::RuntimeError(hipErrorUnknown)));
-    ASSERT_EQ(hipFileIo(GetParam(), file_handle, unreg_bufptr, 0, 0, 0, mbackends), -hipErrorUnknown);
+    ASSERT_EQ(
+        hipFileIo(GetParam(), file_handle, unreg_bufptr, 0, 0, 0, *Context<DriverState>::get(), mbackends),
+        -hipErrorUnknown);
 }
 
 TEST_P(HipFileIoParam, HipFileIoHandlesUnsupportedHipMemoryType)
@@ -184,7 +186,8 @@ TEST_P(HipFileIoParam, HipFileIoHandlesUnsupportedHipMemoryType)
         hipPointerAttribute_t attrs{};
         attrs.type = memoryType;
         EXPECT_CALL(mhip, hipPointerGetAttributes).WillOnce(testing::Return(attrs));
-        ASSERT_EQ(hipFileIo(GetParam(), file_handle, unreg_bufptr, 0, 0, 0, mbackends),
+        ASSERT_EQ(hipFileIo(GetParam(), file_handle, unreg_bufptr, 0, 0, 0, *Context<DriverState>::get(),
+                            mbackends),
                   -static_cast<ssize_t>(hipFileHipMemoryTypeInvalid));
     }
 }
@@ -192,7 +195,8 @@ TEST_P(HipFileIoParam, HipFileIoHandlesUnsupportedHipMemoryType)
 TEST_P(HipFileIoParam, HipFileIoHandlesInvalidFileHandle)
 {
     auto invalid_handle{reinterpret_cast<hipFileHandle_t>(0xdeadbeef)};
-    ASSERT_EQ(hipFileIo(GetParam(), invalid_handle, bufptr, 0, 0, 0, mbackends), -hipFileHandleNotRegistered);
+    ASSERT_EQ(hipFileIo(GetParam(), invalid_handle, bufptr, 0, 0, 0, *Context<DriverState>::get(), mbackends),
+              -hipFileHandleNotRegistered);
 }
 
 TEST_P(HipFileIoParam, HipFileIoHandlesSysRuntimeError)
@@ -200,7 +204,9 @@ TEST_P(HipFileIoParam, HipFileIoHandlesSysRuntimeError)
     EXPECT_CALL(*mbackend, score).WillOnce(Return(1));
     EXPECT_CALL(*mbackend, io).WillOnce(Throw(std::system_error(EBADFD, std::generic_category())));
     errno = 0;
-    ASSERT_EQ(hipFileIo(GetParam(), file_handle, bufptr, buflen, 0, 0, mbackends), -1);
+    ASSERT_EQ(
+        hipFileIo(GetParam(), file_handle, bufptr, buflen, 0, 0, *Context<DriverState>::get(), mbackends),
+        -1);
     ASSERT_EQ(errno, EBADFD);
 }
 
@@ -208,21 +214,27 @@ TEST_P(HipFileIoParam, HipFileIoHandlesHipRuntimeError)
 {
     EXPECT_CALL(*mbackend, score).WillOnce(Return(1));
     EXPECT_CALL(*mbackend, io).WillOnce(Throw(Hip::RuntimeError(hipErrorUnknown)));
-    ASSERT_EQ(hipFileIo(GetParam(), file_handle, bufptr, buflen, 0, 0, mbackends), -hipErrorUnknown);
+    ASSERT_EQ(
+        hipFileIo(GetParam(), file_handle, bufptr, buflen, 0, 0, *Context<DriverState>::get(), mbackends),
+        -hipErrorUnknown);
 }
 
 TEST_P(HipFileIoParam, HipFileIoHandlesInvalidArgumentError)
 {
     EXPECT_CALL(*mbackend, score).WillOnce(Return(1));
     EXPECT_CALL(*mbackend, io).WillOnce(Throw(std::invalid_argument("")));
-    ASSERT_EQ(hipFileIo(GetParam(), file_handle, bufptr, buflen, 0, 0, mbackends), -hipFileInvalidValue);
+    ASSERT_EQ(
+        hipFileIo(GetParam(), file_handle, bufptr, buflen, 0, 0, *Context<DriverState>::get(), mbackends),
+        -hipFileInvalidValue);
 }
 
 TEST_P(HipFileIoParam, HipFileIoHandlesBackendDisabled)
 {
     EXPECT_CALL(*mbackend, score).WillOnce(Return(1));
     EXPECT_CALL(*mbackend, io).WillOnce(Throw(BackendDisabled()));
-    ASSERT_EQ(hipFileIo(GetParam(), file_handle, bufptr, buflen, 0, 0, mbackends), -hipFileInternalError);
+    ASSERT_EQ(
+        hipFileIo(GetParam(), file_handle, bufptr, buflen, 0, 0, *Context<DriverState>::get(), mbackends),
+        -hipFileInternalError);
 }
 
 INSTANTIATE_TEST_SUITE_P(HipFileIo, HipFileIoParam, Values(IoType::Read, IoType::Write));

--- a/projects/hipfile/test/amd_detail/mbatch.h
+++ b/projects/hipfile/test/amd_detail/mbatch.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "batch/batch.h"
+#include "state.h"
 
 #include <gmock/gmock.h>
 
@@ -18,8 +19,8 @@ namespace hipFile {
 class MBatchContext : public IBatchContext {
 public:
     MOCK_METHOD(unsigned, get_capacity, (), (const, noexcept, override));
-    MOCK_METHOD(void, submit_operations, (const hipFileIOParams_t *params, const unsigned num_params),
-                (override));
+    MOCK_METHOD(void, submit_operations,
+                (const hipFileIOParams_t *params, const unsigned num_params, DriverState &state), (override));
 };
 
 }

--- a/projects/hipfile/test/amd_detail/mbatch.h
+++ b/projects/hipfile/test/amd_detail/mbatch.h
@@ -20,7 +20,8 @@ class MBatchContext : public IBatchContext {
 public:
     MOCK_METHOD(unsigned, get_capacity, (), (const, noexcept, override));
     MOCK_METHOD(void, submit_operations,
-                (const hipFileIOParams_t *params, const unsigned num_params, DriverState &state), (override));
+                (const hipFileIOParams_t *params, const unsigned num_params, IDriverState &state),
+                (override));
 };
 
 }

--- a/projects/hipfile/test/amd_detail/mstate.h
+++ b/projects/hipfile/test/amd_detail/mstate.h
@@ -13,7 +13,7 @@
 #include <gmock/gmock.h>
 
 /*
- * A place to create mocks for the DriverState singleton.
+ * A place to create mocks for IDriverState.
  */
 
 namespace hipFile {

--- a/projects/hipfile/test/amd_detail/mstate.h
+++ b/projects/hipfile/test/amd_detail/mstate.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-#include "context.h"
 #include "state.h"
 
 #include "mbuffer.h"
@@ -21,12 +20,6 @@ namespace hipFile {
 
 class MDriverState : public DriverState {
 public:
-    ContextOverride<DriverState> o_co;
-
-    MDriverState() : o_co{this}
-    {
-    }
-
     MOCK_METHOD(hipFileBatchHandle_t, createBatchContext, (unsigned capacity), (override));
     MOCK_METHOD(void, destroyBatchContext, (hipFileBatchHandle_t handle), (override));
     MOCK_METHOD(std::shared_ptr<IBatchContext>, getBatchContext, (hipFileBatchHandle_t handle), (override));

--- a/projects/hipfile/test/amd_detail/mstate.h
+++ b/projects/hipfile/test/amd_detail/mstate.h
@@ -18,7 +18,7 @@
 
 namespace hipFile {
 
-class MDriverState : public DriverState {
+class MDriverState : public IDriverState {
 public:
     MOCK_METHOD(hipFileBatchHandle_t, createBatchContext, (unsigned capacity), (override));
     MOCK_METHOD(void, destroyBatchContext, (hipFileBatchHandle_t handle), (override));
@@ -30,10 +30,16 @@ public:
     MOCK_METHOD(hipFileHandle_t, registerFile, (UnregisteredFile && uf), (override));
     MOCK_METHOD(void, deregisterFile, (hipFileHandle_t fh), (override));
     MOCK_METHOD(std::shared_ptr<IFile>, getFile, (hipFileHandle_t fh), (override));
+    MOCK_METHOD(void, registerStream, (const hipStream_t hip_stream, uint32_t flags), (override));
+    MOCK_METHOD(void, deregisterStream, (const hipStream_t hip_stream), (override));
+    MOCK_METHOD(std::shared_ptr<IStream>, getStream, (hipStream_t hip_stream), (override));
     MOCK_METHOD(file_buffer_pair, getFileAndBuffer, (hipFileHandle_t fh, const void *buf), (override));
+    MOCK_METHOD(file_buffer_stream_tuple, getFileBufferAndStream,
+                (hipFileHandle_t fh, const void *buf, hipStream_t hipStream), (override));
     MOCK_METHOD(void, incrRefCount, (), (override));
     MOCK_METHOD(void, decrRefCount, (), (override));
     MOCK_METHOD(int64_t, getRefCount, (), (override, const));
+    MOCK_METHOD(void, ensureInitialized, (), (override));
 };
 
 }

--- a/projects/hipfile/test/amd_detail/mstate.h
+++ b/projects/hipfile/test/amd_detail/mstate.h
@@ -34,7 +34,6 @@ public:
     MOCK_METHOD(void, incrRefCount, (), (override));
     MOCK_METHOD(void, decrRefCount, (), (override));
     MOCK_METHOD(int64_t, getRefCount, (), (override, const));
-    MOCK_METHOD(std::vector<std::shared_ptr<Backend>>, getBackends, (), (const, override));
 };
 
 }

--- a/projects/hipfile/test/amd_detail/runtime.cpp
+++ b/projects/hipfile/test/amd_detail/runtime.cpp
@@ -1,0 +1,58 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+// Tests for the process-global Runtime root object in src/amd_detail/runtime.
+//
+// Runtime::backends() is the single home for backend construction (Fallback +
+// Fastpath, built once via std::call_once). Because the C-API shims now inject
+// backends as an explicit parameter, this is the only place that construction is
+// exercised, so it gets its own coverage here.
+
+#include "backend.h"
+#include "hipfile-warnings.h"
+#include "runtime.h"
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <vector>
+
+using namespace hipFile;
+
+HIPFILE_WARN_NO_GLOBAL_CTOR_OFF
+
+// backends() must return the Fallback/Fastpath pair, both non-null.
+TEST(Runtime, BackendsAreBuiltAndNonNull)
+{
+    const std::vector<std::shared_ptr<Backend>> &backends = Runtime::instance().backends();
+
+    ASSERT_EQ(backends.size(), 2u);
+    for (const auto &backend : backends) {
+        EXPECT_NE(backend, nullptr);
+    }
+}
+
+// backends() caches via std::call_once, so repeated calls must hand back the
+// same collection (same element pointers), not rebuild it.
+TEST(Runtime, BackendsAreStableAcrossCalls)
+{
+    const std::vector<std::shared_ptr<Backend>> &first  = Runtime::instance().backends();
+    const std::vector<std::shared_ptr<Backend>> &second = Runtime::instance().backends();
+
+    ASSERT_EQ(first.size(), second.size());
+    for (size_t i = 0; i < first.size(); i++) {
+        EXPECT_EQ(first[i], second[i]);
+    }
+}
+
+// state() must hand back the one owned DriverState, stable across calls.
+TEST(Runtime, StateIsStableAcrossCalls)
+{
+    DriverState &first  = Runtime::instance().state();
+    DriverState &second = Runtime::instance().state();
+
+    EXPECT_EQ(&first, &second);
+}
+
+HIPFILE_WARN_NO_GLOBAL_CTOR_ON

--- a/projects/hipfile/test/amd_detail/state_mt.cpp
+++ b/projects/hipfile/test/amd_detail/state_mt.cpp
@@ -7,7 +7,7 @@
 //
 // Just run the program. It takes no special arguments.
 
-#include "context.h"
+#include "runtime.h"
 #include "file.h"
 #include "hipfile.h"
 #include "state.h"
@@ -84,7 +84,7 @@ thread_function(int id)
     constexpr int N_CYCLES  = 100; // # of cycles before checking the run flag
     constexpr int N_PRELOAD = 10;  // # of files/buffers to load before cycling
 
-    auto *ds = Context<DriverState>::get();
+    auto *ds = &Runtime::instance().state();
 
     vector<pair<int, hipFileHandle_t>> files;
     vector<void *>                     buffers;

--- a/projects/hipfile/test/system/async.cpp
+++ b/projects/hipfile/test/system/async.cpp
@@ -10,6 +10,7 @@
 #include "context.h"
 #include "hip.h"
 #include "io.h"
+#include "runtime.h"
 #include "state.h"
 #include "stream.h"
 #endif
@@ -247,7 +248,7 @@ public:
         ASSERT_EQ(hipStreamCreateWithFlags(&hip_stream, hipStreamNonBlocking), hipSuccess);
         ASSERT_EQ(hipFileStreamRegister(hip_stream, 0xf), HIPFILE_SUCCESS);
         auto [_file, _buffer, _stream] =
-            Context<DriverState>::get()->getFileBufferAndStream(fh, dev_ptr, hip_stream);
+            Runtime::instance().state().getFileBufferAndStream(fh, dev_ptr, hip_stream);
         file              = _file;
         buffer            = _buffer;
         stream            = _stream;


### PR DESCRIPTION
## Motivation

hipFile's driver state was reached through a process-global singleton (Context<DriverState>::get()) touched from ~15 call sites across the C-API implementation, plus batch and async paths. This coupling caused several problems:

- Tests fought the global. Mocking DriverState required a ContextOverride that swapped the global in and out. MDriverState inherited the concrete DriverState, so a test that injected the mock but forgot to EXPECT_CALL a method would silently fall through to real production code instead of failing loudly.
- The backend collection was cached twice — once in DriverState::getBackends() and again in a file-local static in hipfile.cpp (getCachedBackends()).
- The singleton was ambient, so any code below the C-API boundary could reach global state directly, making dependencies implicit and per-test isolation dependent on ctest's process-per-test model.

This PR pushes the singleton to the boundary and injects dependencies everywhere below it.

## Technical Details

- Introduced Runtime (runtime.h/runtime.cpp) as the single process-global root. It owns the one DriverState and the one backend collection, and is the only global touched by the C-API shims in hipfile.cpp. Backend construction (Fallback + Fastpath) now happens exactly once via std::call_once in Runtime::backends() — collapsing the former double cache into a single home.
- Threaded state as an explicit parameter. The internal helpers (hipFileIo, hipFileIOAsync, ensureDriverInit, BatchContext::submit_operations) now take an IDriverState& instead of fetching the global. The C-API shims grab Runtime::instance() once and pass state()/backends() down.
- Extracted an IDriverState interface. DriverState is now final : public IDriverState, and the injection seam depends on the abstraction. MDriverState was reparented onto IDriverState, so the mock has no production body to fall through to — an un-mocked call fails loudly. All 18 methods on the interface are pure virtual and fully mocked.
- Extracted batch helpers. hipFileBatchSetUp/hipFileBatchSubmit (taking IDriverState&) are declared in hipfile-private.h; the hipFileBatchIO* shims are thin hipFileInit() + delegate wrappers, and hipFileIOAsync was made non-static so tests can inject a mock directly.
- Deleted the dead singleton machinery. DriverState::getBackends(), its backends member, the friend Context<DriverState>, the double-cache getCachedBackends(), MDriverState's ContextOverride, and orphaned includes/forward-decls are all gone. The ContextOverride/Context<T> template stays — it's still used by the Hip/Sys/Stats mocks.
- Public C headers are untouched and the C11 boundary is unchanged.
- Test migration: shim-level mock tests now inject the mock directly; real-state integration tests (buffer, handle, fallback, state_mt, system async) read the same object the shims use via Runtime::instance().state(). Added test/amd_detail/runtime.cpp to unit-cover Runtime::backends() and Runtime::state(), which lost coverage when the shims switched to injecting backends.

## JIRA ID

JIRA ID: AIHIPFILE-238

## Test Plan

- [x] ctest -L unit passes (526/526) on a CPU-only node
- [x] Warning-free build with amdclang++ (-Werror posture)
- [x] Clean under ASAN (touches shared_ptr lifetimes and reference threading)
- [x] Clean under TSAN (Runtime::backends() uses std::call_once; AsyncMonitor thread still in play)
- [x] util/format-source.sh (clang-format 18) and clang-tidy clean
- [x] On real hardware: system tests pass, exercising the live async read/write round-trips (test/system/async.cpp) and the real hipFileRead/hipFileWrite → Runtime::backends() → Fallback/Fastpath selection path that CPU-only unit tests cannot cover

## Test Result

Everything passes

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
