### PR TITLE
fix(rccl) : [ROCM-26926] [RCCL] Gate P2P batch auto-enable on multi-node for gfx950

### DIFF
--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -1087,6 +1087,7 @@ RCCL_PARAM(P2pBatchThreshold, "P2P_BATCH_THRESHOLD", 1 << 16);  // 64k per-rank 
 static int rcclEffectiveP2pBatchEnable(struct ncclComm* comm) {
   auto userInput = rcclParamP2pBatchEnable();
   if (userInput >= 0) return userInput;
+  if (comm->nNodes <= 1) return 0;
   bool isGfx950 = IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950");
   return (isGfx950 && !rcclUseAinic()) ? 1 : 0;
 }

--- a/projects/rccl/test/AllToAllTests.cpp
+++ b/projects/rccl/test/AllToAllTests.cpp
@@ -112,26 +112,4 @@ namespace RcclUnitTesting
       }
     }
   }
-
-  TEST(AlltoAll, P2pBatchDisabledOnSingleNode)
-  {
-    TestBed testBed;
-
-    setenv("RCCL_P2P_BATCH_ENABLE", "0", 1);
-
-    std::vector<ncclFunc_t>     const funcTypes       = {ncclCollAlltoAll};
-    std::vector<ncclDataType_t> const dataTypes       = {ncclFloat32};
-    std::vector<ncclRedOp_t>    const redOps          = {ncclSum};
-    std::vector<int>            const roots           = {0};
-    std::vector<int>            const numElements     = {1048576, 1024};
-    std::vector<bool>           const inPlaceList     = {false};
-    std::vector<bool>           const managedMemList  = {false};
-    std::vector<bool>           const useHipGraphList = {false};
-
-    testBed.RunSimpleSweep(funcTypes, dataTypes, redOps, roots, numElements,
-                           inPlaceList, managedMemList, useHipGraphList);
-    testBed.Finalize();
-
-    unsetenv("RCCL_P2P_BATCH_ENABLE");
-  }
 }

--- a/projects/rccl/test/AllToAllTests.cpp
+++ b/projects/rccl/test/AllToAllTests.cpp
@@ -112,4 +112,26 @@ namespace RcclUnitTesting
       }
     }
   }
+
+  TEST(AlltoAll, P2pBatchDisabledOnSingleNode)
+  {
+    TestBed testBed;
+
+    setenv("RCCL_P2P_BATCH_ENABLE", "0", 1);
+
+    std::vector<ncclFunc_t>     const funcTypes       = {ncclCollAlltoAll};
+    std::vector<ncclDataType_t> const dataTypes       = {ncclFloat32};
+    std::vector<ncclRedOp_t>    const redOps          = {ncclSum};
+    std::vector<int>            const roots           = {0};
+    std::vector<int>            const numElements     = {1048576, 1024};
+    std::vector<bool>           const inPlaceList     = {false};
+    std::vector<bool>           const managedMemList  = {false};
+    std::vector<bool>           const useHipGraphList = {false};
+
+    testBed.RunSimpleSweep(funcTypes, dataTypes, redOps, roots, numElements,
+                           inPlaceList, managedMemList, useHipGraphList);
+    testBed.Finalize();
+
+    unsetenv("RCCL_P2P_BATCH_ENABLE");
+  }
 }

--- a/projects/rccl/test/transport/P2pMPITests.cpp
+++ b/projects/rccl/test/transport/P2pMPITests.cpp
@@ -1708,6 +1708,12 @@ TEST_F(P2pMPITest, IpcGraphRegisterBufferTest)
 // (comm->nNodes <= 1), so the channel-base mapping matches pre-7.14 behaviour.
 TEST_F(P2pMPITest, P2pBatchAutoDisableOnSingleNode)
 {
+    if(getenv("RCCL_P2P_BATCH_ENABLE"))
+    {
+        GTEST_SKIP() << "RCCL_P2P_BATCH_ENABLE is explicitly set — "
+                        "cannot test auto-detect path";
+    }
+
     ASSERT_TRUE(validateTestPrerequisites(kMinProcessesForMPI,
                                           kNoProcessLimit,
                                           kRequirePowerOfTwo,
@@ -1717,13 +1723,6 @@ TEST_F(P2pMPITest, P2pBatchAutoDisableOnSingleNode)
 
     setupP2PBuffers();
     ASSERT_MPI_SUCCESS(createTestCommunicator());
-
-    // Save and clear RCCL_P2P_BATCH_ENABLE so the auto-detect path (-1) is
-    // exercised.  Restored after the test to avoid polluting subsequent tests.
-    const char*       saved_env = getenv("RCCL_P2P_BATCH_ENABLE");
-    const std::string saved_val = saved_env ? saved_env : "";
-    const bool        had_env   = (saved_env != nullptr);
-    unsetenv("RCCL_P2P_BATCH_ENABLE");
 
     if(config.world_rank == 0)
     {
@@ -1782,10 +1781,6 @@ TEST_F(P2pMPITest, P2pBatchAutoDisableOnSingleNode)
                               << ": Data validation failed at index " << error_idx
                               << ": expected " << expected_val
                               << ", got " << actual_val;
-
-    // Restore original env state
-    if(had_env)
-        setenv("RCCL_P2P_BATCH_ENABLE", saved_val.c_str(), 1);
 
     if(config.world_rank == 0)
     {

--- a/projects/rccl/test/transport/P2pMPITests.cpp
+++ b/projects/rccl/test/transport/P2pMPITests.cpp
@@ -1718,8 +1718,11 @@ TEST_F(P2pMPITest, P2pBatchAutoDisableOnSingleNode)
     setupP2PBuffers();
     ASSERT_MPI_SUCCESS(createTestCommunicator());
 
-    // Ensure default auto-detect (-1) is active; RCCL_PARAM caches the first
-    // read per process, so this must be unset before the first RCCL call.
+    // Save and clear RCCL_P2P_BATCH_ENABLE so the auto-detect path (-1) is
+    // exercised.  Restored after the test to avoid polluting subsequent tests.
+    const char*       saved_env = getenv("RCCL_P2P_BATCH_ENABLE");
+    const std::string saved_val = saved_env ? saved_env : "";
+    const bool        had_env   = (saved_env != nullptr);
     unsetenv("RCCL_P2P_BATCH_ENABLE");
 
     if(config.world_rank == 0)
@@ -1779,6 +1782,10 @@ TEST_F(P2pMPITest, P2pBatchAutoDisableOnSingleNode)
                               << ": Data validation failed at index " << error_idx
                               << ": expected " << expected_val
                               << ", got " << actual_val;
+
+    // Restore original env state
+    if(had_env)
+        setenv("RCCL_P2P_BATCH_ENABLE", saved_val.c_str(), 1);
 
     if(config.world_rank == 0)
     {

--- a/projects/rccl/test/transport/P2pMPITests.cpp
+++ b/projects/rccl/test/transport/P2pMPITests.cpp
@@ -1702,5 +1702,117 @@ TEST_F(P2pMPITest, IpcGraphRegisterBufferTest)
     }
 }
 
+// ROCM-26926: Verify P2P send/recv correctness when P2P batch auto-enable is
+// gated on multi-node (comm->nNodes <= 1 returns 0).  On a single-node MPI
+// run the auto-enable path should disable batching; explicit overrides (0, 1)
+// must still be honoured.
+TEST_F(P2pMPITest, P2pBatchAutoDisableOnSingleNode)
+{
+    ASSERT_TRUE(validateTestPrerequisites(kMinProcessesForMPI,
+                                          kNoProcessLimit,
+                                          kRequirePowerOfTwo,
+                                          1,
+                                          kRequireSingleNode))
+        << "Test requirements not met - all ranks must meet requirements";
+
+    setupP2PBuffers();
+    ASSERT_MPI_SUCCESS(createTestCommunicator());
+
+    if(config.world_rank == 0)
+    {
+        TEST_INFO("ROCM-26926: Testing P2P batch auto-disable on single node (%d processes)",
+                  config.world_size);
+    }
+
+    // Run send/recv under three RCCL_P2P_BATCH_ENABLE settings:
+    //   unset (-1 default) : auto-detect, should disable for single-node
+    //   "0"                : explicit disable
+    //   "1"                : explicit enable (must still produce correct results)
+    const std::vector<std::pair<const char*, const char*>> settings = {
+        {nullptr, "default (-1, auto-detect)"},
+        {"0",     "explicit disable"},
+        {"1",     "explicit enable"},
+    };
+
+    for(const auto& [env_val, label] : settings)
+    {
+        if(env_val)
+            setenv("RCCL_P2P_BATCH_ENABLE", env_val, 1);
+        else
+            unsetenv("RCCL_P2P_BATCH_ENABLE");
+
+        if(config.world_rank == 0)
+        {
+            TEST_INFO("  Sub-test: RCCL_P2P_BATCH_ENABLE=%s", label);
+        }
+
+        const size_t count = p2p_config.buffer_size / sizeof(float);
+        const int    peer  = (config.world_rank == 0) ? 1 : 0;
+
+        auto nccl_result = ncclGroupStart();
+        ASSERT_EQ(ncclSuccess, nccl_result);
+
+        nccl_result = ncclSend(p2p_config.send_buffer,
+                               count,
+                               ncclFloat,
+                               peer,
+                               getActiveCommunicator(),
+                               getActiveStream());
+        ASSERT_EQ(ncclSuccess, nccl_result)
+            << "Rank " << config.world_rank << ": ncclSend failed (" << label << ")";
+
+        nccl_result = ncclRecv(p2p_config.recv_buffer,
+                               count,
+                               ncclFloat,
+                               peer,
+                               getActiveCommunicator(),
+                               getActiveStream());
+        ASSERT_EQ(ncclSuccess, nccl_result)
+            << "Rank " << config.world_rank << ": ncclRecv failed (" << label << ")";
+
+        nccl_result = ncclGroupEnd();
+        ASSERT_EQ(ncclSuccess, nccl_result);
+
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        ASSERT_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()))
+            << "Rank " << config.world_rank << ": Stream sync failed (" << label << ")";
+
+        size_t error_idx;
+        float  expected_val, actual_val;
+        bool   data_correct = verifyBufferData<float>(
+            p2p_config.recv_buffer,
+            count,
+            [peer_rank = peer](size_t i) {
+                return static_cast<float>(peer_rank * kDefaultPatternMultiplier + i);
+            },
+            kMaxValidationElements,
+            1e-5,
+            &error_idx,
+            &expected_val,
+            &actual_val);
+
+        EXPECT_TRUE(data_correct) << "Rank " << config.world_rank
+                                  << ": Data validation failed (" << label << ") at index "
+                                  << error_idx << ": expected " << expected_val
+                                  << ", got " << actual_val;
+
+        // Re-zero recv buffer for next iteration
+        ASSERT_EQ(hipSuccess,
+                  hipMemset(p2p_config.recv_buffer, 0, p2p_config.buffer_size));
+        ASSERT_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
+
+        MPI_Barrier(MPI_COMM_WORLD);
+    }
+
+    // Restore env to default
+    unsetenv("RCCL_P2P_BATCH_ENABLE");
+
+    if(config.world_rank == 0)
+    {
+        TEST_INFO("ROCM-26926: P2P batch auto-disable test completed successfully");
+    }
+}
+
 #endif // MPI_TESTS_ENABLED
 

--- a/projects/rccl/test/transport/P2pMPITests.cpp
+++ b/projects/rccl/test/transport/P2pMPITests.cpp
@@ -1702,10 +1702,10 @@ TEST_F(P2pMPITest, IpcGraphRegisterBufferTest)
     }
 }
 
-// ROCM-26926: Verify P2P send/recv correctness when P2P batch auto-enable is
-// gated on multi-node (comm->nNodes <= 1 returns 0).  On a single-node MPI
-// run the auto-enable path should disable batching; explicit overrides (0, 1)
-// must still be honoured.
+// ROCM-26926: Verify P2P send/recv correctness when the P2P batch auto-enable
+// path is gated on multi-node.  With RCCL_P2P_BATCH_ENABLE unset (default -1),
+// rcclEffectiveP2pBatchEnable returns 0 for single-node communicators
+// (comm->nNodes <= 1), so the channel-base mapping matches pre-7.14 behaviour.
 TEST_F(P2pMPITest, P2pBatchAutoDisableOnSingleNode)
 {
     ASSERT_TRUE(validateTestPrerequisites(kMinProcessesForMPI,
@@ -1718,95 +1718,67 @@ TEST_F(P2pMPITest, P2pBatchAutoDisableOnSingleNode)
     setupP2PBuffers();
     ASSERT_MPI_SUCCESS(createTestCommunicator());
 
+    // Ensure default auto-detect (-1) is active; RCCL_PARAM caches the first
+    // read per process, so this must be unset before the first RCCL call.
+    unsetenv("RCCL_P2P_BATCH_ENABLE");
+
     if(config.world_rank == 0)
     {
-        TEST_INFO("ROCM-26926: Testing P2P batch auto-disable on single node (%d processes)",
+        TEST_INFO("ROCM-26926: Testing P2P send/recv with default auto-detect "
+                  "on single node (%d processes)",
                   config.world_size);
     }
 
-    // Run send/recv under three RCCL_P2P_BATCH_ENABLE settings:
-    //   unset (-1 default) : auto-detect, should disable for single-node
-    //   "0"                : explicit disable
-    //   "1"                : explicit enable (must still produce correct results)
-    const std::vector<std::pair<const char*, const char*>> settings = {
-        {nullptr, "default (-1, auto-detect)"},
-        {"0",     "explicit disable"},
-        {"1",     "explicit enable"},
-    };
+    const size_t count = p2p_config.buffer_size / sizeof(float);
+    const int    peer  = (config.world_rank == 0) ? 1 : 0;
 
-    for(const auto& [env_val, label] : settings)
-    {
-        if(env_val)
-            setenv("RCCL_P2P_BATCH_ENABLE", env_val, 1);
-        else
-            unsetenv("RCCL_P2P_BATCH_ENABLE");
+    auto nccl_result = ncclGroupStart();
+    ASSERT_EQ(ncclSuccess, nccl_result);
 
-        if(config.world_rank == 0)
-        {
-            TEST_INFO("  Sub-test: RCCL_P2P_BATCH_ENABLE=%s", label);
-        }
+    nccl_result = ncclSend(p2p_config.send_buffer,
+                           count,
+                           ncclFloat,
+                           peer,
+                           getActiveCommunicator(),
+                           getActiveStream());
+    ASSERT_EQ(ncclSuccess, nccl_result)
+        << "Rank " << config.world_rank << ": ncclSend failed";
 
-        const size_t count = p2p_config.buffer_size / sizeof(float);
-        const int    peer  = (config.world_rank == 0) ? 1 : 0;
+    nccl_result = ncclRecv(p2p_config.recv_buffer,
+                           count,
+                           ncclFloat,
+                           peer,
+                           getActiveCommunicator(),
+                           getActiveStream());
+    ASSERT_EQ(ncclSuccess, nccl_result)
+        << "Rank " << config.world_rank << ": ncclRecv failed";
 
-        auto nccl_result = ncclGroupStart();
-        ASSERT_EQ(ncclSuccess, nccl_result);
+    nccl_result = ncclGroupEnd();
+    ASSERT_EQ(ncclSuccess, nccl_result);
 
-        nccl_result = ncclSend(p2p_config.send_buffer,
-                               count,
-                               ncclFloat,
-                               peer,
-                               getActiveCommunicator(),
-                               getActiveStream());
-        ASSERT_EQ(ncclSuccess, nccl_result)
-            << "Rank " << config.world_rank << ": ncclSend failed (" << label << ")";
+    MPI_Barrier(MPI_COMM_WORLD);
 
-        nccl_result = ncclRecv(p2p_config.recv_buffer,
-                               count,
-                               ncclFloat,
-                               peer,
-                               getActiveCommunicator(),
-                               getActiveStream());
-        ASSERT_EQ(ncclSuccess, nccl_result)
-            << "Rank " << config.world_rank << ": ncclRecv failed (" << label << ")";
+    ASSERT_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()))
+        << "Rank " << config.world_rank << ": Stream sync failed";
 
-        nccl_result = ncclGroupEnd();
-        ASSERT_EQ(ncclSuccess, nccl_result);
+    size_t error_idx;
+    float  expected_val, actual_val;
+    bool   data_correct = verifyBufferData<float>(
+        p2p_config.recv_buffer,
+        count,
+        [peer_rank = peer](size_t i) {
+            return static_cast<float>(peer_rank * kDefaultPatternMultiplier + i);
+        },
+        kMaxValidationElements,
+        1e-5,
+        &error_idx,
+        &expected_val,
+        &actual_val);
 
-        MPI_Barrier(MPI_COMM_WORLD);
-
-        ASSERT_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()))
-            << "Rank " << config.world_rank << ": Stream sync failed (" << label << ")";
-
-        size_t error_idx;
-        float  expected_val, actual_val;
-        bool   data_correct = verifyBufferData<float>(
-            p2p_config.recv_buffer,
-            count,
-            [peer_rank = peer](size_t i) {
-                return static_cast<float>(peer_rank * kDefaultPatternMultiplier + i);
-            },
-            kMaxValidationElements,
-            1e-5,
-            &error_idx,
-            &expected_val,
-            &actual_val);
-
-        EXPECT_TRUE(data_correct) << "Rank " << config.world_rank
-                                  << ": Data validation failed (" << label << ") at index "
-                                  << error_idx << ": expected " << expected_val
-                                  << ", got " << actual_val;
-
-        // Re-zero recv buffer for next iteration
-        ASSERT_EQ(hipSuccess,
-                  hipMemset(p2p_config.recv_buffer, 0, p2p_config.buffer_size));
-        ASSERT_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
-
-        MPI_Barrier(MPI_COMM_WORLD);
-    }
-
-    // Restore env to default
-    unsetenv("RCCL_P2P_BATCH_ENABLE");
+    EXPECT_TRUE(data_correct) << "Rank " << config.world_rank
+                              << ": Data validation failed at index " << error_idx
+                              << ": expected " << expected_val
+                              << ", got " << actual_val;
 
     if(config.world_rank == 0)
     {


### PR DESCRIPTION


## Motivation

Observing Perf Drop of ~5% to ~22% on few RCCL-Perf tags in  DPX + NPS2 mode

## Technical Details

P2P batching was re-enabled by default for gfx950 + non-AINIC in d05a88560d.  The auto-enable unconditionally changes the channel-base computation in ncclP2pChannelBaseForRound (via batchP2PEnableEnv) even when actual batching never fires — batching only activates for nNodes >= 16 with messages below the 64 KB per-rank threshold.

On single-node DPX + NPS2 topologies (16 GPUs, non-uniform XGMI) the altered channel-base mapping distributes P2P traffic sub-optimally across the non-uniform cross-socket/cross-NUMA links, causing a 5-22% bandwidth regression on alltoall, alltoallv, gather, and scatter at 1 GB.  SPX mode is unaffected because its uniform XGMI mesh is insensitive to channel assignment.

Add a multi-node guard to rcclEffectiveP2pBatchEnable so the auto-enable path returns 0 for single-node communicators.  Explicit user overrides (RCCL_P2P_BATCH_ENABLE=0 or =1) are still honoured.
## JIRA ID

JIRA ID : ROCM-26926

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
