### PR TITLE
fix(hsakmt) : [ROCM-27124] fix lib loading/unloading errors in dxg fo…

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/dxg/dxcore_loader.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/dxcore_loader.cpp
@@ -85,7 +85,7 @@ bool DxcoreLoader::Initialize() {
 
 void DxcoreLoader::Shutdown() {
     if (dxcore_handle_) {
-        if (rocr::os::CloseLib(dxcore_handle_) != 0) {
+        if (!rocr::os::CloseLib(dxcore_handle_)) {
             pr_err("[DxcoreLoader] Cannot unload libdxcore.so: %s\n", rocr::os::DlError());
         } else {
             pr_info("[DxcoreLoader] libdxcore.so unloaded successfully\n");

--- a/projects/rocr-runtime/libhsakmt/src/dxg/hsa.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/hsa.cpp
@@ -40,15 +40,20 @@ bool hsakmt_hsa_loader_init() {
   // links against it), promote it to RTLD_GLOBAL so dlsym(RTLD_DEFAULT,...)
   // can resolve its symbols without a filesystem lookup.
   void *handle = dlopen("libhsa-runtime64.so.1", RTLD_NOW | RTLD_GLOBAL | RTLD_NOLOAD);
-  if (!handle) {
-    // Fallback: full load for callers that don't pre-link libhsa-runtime64.
-    handle = dlopen("libhsa-runtime64.so.1", RTLD_NOW | RTLD_GLOBAL);
+  if (handle) {
+    // Library was already resident; drop our temporary reference — the caller
+    // holds its own so the library stays loaded.
+    dlclose(handle);
+    return true;
   }
+  // Fallback: full load for callers that don't pre-link libhsa-runtime64.
+  // Do not dlclose — the library must remain resident for subsequent
+  // dlsym(RTLD_DEFAULT, ...) calls in the hsakmt_hsa_* wrappers to work.
+  handle = dlopen("libhsa-runtime64.so.1", RTLD_NOW | RTLD_GLOBAL);
   if (!handle) {
     pr_err("dlopen libhsa-runtime64.so.1 failed - %s\n", dlerror());
     return false;
   }
-  dlclose(handle);
   return true;
 }
 

--- a/projects/rocr-runtime/libhsakmt/src/dxg/hsa.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/hsa.cpp
@@ -36,12 +36,19 @@ do { \
 } while(0);
 
 bool hsakmt_hsa_loader_init() {
-  void *hsa_loader_handle = dlopen("libhsa-runtime64.so", RTLD_NOW | RTLD_GLOBAL);
-  if (hsa_loader_handle == nullptr) {
-    pr_err("dlopen libhsa-runtime64.so failed - %s\n", dlerror());
+  // If libhsa-runtime64 is already loaded in the process (e.g. rocminfo
+  // links against it), promote it to RTLD_GLOBAL so dlsym(RTLD_DEFAULT,...)
+  // can resolve its symbols without a filesystem lookup.
+  void *handle = dlopen("libhsa-runtime64.so.1", RTLD_NOW | RTLD_GLOBAL | RTLD_NOLOAD);
+  if (!handle) {
+    // Fallback: full load for callers that don't pre-link libhsa-runtime64.
+    handle = dlopen("libhsa-runtime64.so.1", RTLD_NOW | RTLD_GLOBAL);
+  }
+  if (!handle) {
+    pr_err("dlopen libhsa-runtime64.so.1 failed - %s\n", dlerror());
     return false;
   }
-  dlclose(hsa_loader_handle);
+  dlclose(handle);
   return true;
 }
 


### PR DESCRIPTION
…r wsl

## Motivation
### Issue 
- rocminfo throws errors when running in WSL without LD_LIBRARY_PATH set
  "dlopen libhsa-runtime64.so failed - libhsa-runtime64.so: cannot open shared object file: No such file or directory"
   "[Shutdown] [DxcoreLoader] Cannot unload libdxcore.so: (null)"

### Fix
- since rocminfo already links against libhsa-runtime64.so , dlopen can use RTLD_NOLOAD with exact lib name, to load this lib
- second error is due to incorrect error handling from dlclose.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
