### PR TITLE
fix: [clr] Correct graph metadata prefetch packet publishing

### DIFF
--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -1641,13 +1641,16 @@ void GraphExec::PacketBatch::rebuildFilteredLists(
       enabledKernelNames.push_back(dispatchKernelNames[i]);
       appendPacketToFlatBuffer(dispatchPackets[i], filteredFlatPacketData,
                                filteredValidPacketFullHeaders);
-      // Append corresponding metadata slot (zero-filled for barriers)
+      // Append corresponding metadata slot. Slots without captured metadata are
+      // published as HSA_PACKET_TYPE_INVALID so the CP prefetch engine skips them.
       if (hasMetadata) {
         size_t metaOff = filteredFlatMetadataData.size();
         filteredFlatMetadataData.resize(metaOff + kMetadataPktSize, 0);
+        uint8_t* slot = filteredFlatMetadataData.data() + metaOff;
         if (i < dispatchMetadataPackets.size() && dispatchMetadataPackets[i] != nullptr) {
-          std::memcpy(filteredFlatMetadataData.data() + metaOff,
-                      dispatchMetadataPackets[i], kMetadataPktSize);
+          std::memcpy(slot, dispatchMetadataPackets[i], kMetadataPktSize);
+        } else {
+          invalidateMetadataSlot(slot);
         }
       }
       packetToFilteredIndex[dispatchPackets[i]] = filteredIdx;
@@ -2073,6 +2076,18 @@ void GraphExec::PacketBatch::appendPacketToFlatBuffer(const uint8_t* pkt_raw,
 }
 
 // ================================================================================================
+// Publish an empty metadata slot as HSA_PACKET_TYPE_INVALID. The four metadata packet headers
+// live at offsets {0, 64, 128, 192} within the 256-byte AqlMetadataPrefetchPacket layout, and
+// the low byte of each is the packet type.
+void GraphExec::PacketBatch::invalidateMetadataSlot(uint8_t* slot) {
+  static constexpr size_t kHdrOff[4] = {0, 64, 128, 192};
+  static constexpr uint32_t kInvalidMetadataHeader = 1;  // HSA_PACKET_TYPE_INVALID
+  for (size_t h = 0; h < 4; ++h) {
+    std::memcpy(slot + kHdrOff[h], &kInvalidMetadataHeader, sizeof(kInvalidMetadataHeader));
+  }
+}
+
+// ================================================================================================
 // Rebuild the flat packet buffer from the current dispatchPackets contents.
 void GraphExec::PacketBatch::rebuildFlatBuffer() {
   const size_t n = dispatchPackets.size();
@@ -2086,13 +2101,16 @@ void GraphExec::PacketBatch::rebuildFlatBuffer() {
     appendPacketToFlatBuffer(pkt_raw, flatPacketData, validPacketFullHeaders);
   }
   // Build flat metadata buffer (kMetadataPktSize per slot).
-  // Entries without metadata (barriers) are zero-filled.
+  // Slots without captured metadata (barriers, uncaptured dispatches) are published as
+  // HSA_PACKET_TYPE_INVALID so the CP prefetch engine skips them.
   if (!dispatchMetadataPackets.empty()) {
     flatMetadataData.resize(n * kMetadataPktSize, 0);
-    for (size_t i = 0; i < n && i < dispatchMetadataPackets.size(); ++i) {
-      if (dispatchMetadataPackets[i] != nullptr) {
-        std::memcpy(flatMetadataData.data() + i * kMetadataPktSize,
-                    dispatchMetadataPackets[i], kMetadataPktSize);
+    for (size_t i = 0; i < n; ++i) {
+      uint8_t* slot = flatMetadataData.data() + i * kMetadataPktSize;
+      if (i < dispatchMetadataPackets.size() && dispatchMetadataPackets[i] != nullptr) {
+        std::memcpy(slot, dispatchMetadataPackets[i], kMetadataPktSize);
+      } else {
+        invalidateMetadataSlot(slot);
       }
     }
   }

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -1194,6 +1194,9 @@ class GraphExec : public amd::ReferenceCountedObject, public Graph {
     static void appendPacketToFlatBuffer(const uint8_t* pkt_raw,
                                          std::vector<uint8_t>& flatData,
                                          std::vector<uint32_t>& fullHeaders);
+    // Stamp the four packet headers of a 256-byte metadata slot with
+    // HSA_PACKET_TYPE_INVALID (type=1) so the CP metadata-prefetch engine skips it.
+    static void invalidateMetadataSlot(uint8_t* slot);
   };
 
   //! Structure linking packet batches to segments
@@ -2085,7 +2088,7 @@ class GraphMemcpyNode1D : public GraphMemcpyNode {
     amd::Memory* srcMemory = getMemoryObjectForCurrentDevice(src_, sOffset);
     size_t dOffset = 0;
     amd::Memory* dstMemory = getMemoryObjectForCurrentDevice(dst_, dOffset);
-    
+
     hip::MemcpyType memType = hipHostToHost;
     if (srcMemory != nullptr && dstMemory == nullptr) {
         memType = ihipGetMemcpyType(srcMemory, dst_);

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1580,18 +1580,34 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPack
              (thisChunk - firstCount) * kPacketSize);
     }
 
-    // Copy this chunk's metadata packets to the metadata ring buffer.
+    // Copy this chunk's metadata packets to the metadata ring buffer, following the
+    // same publish protocol as the live single-dispatch path (MetaDataPreloader::Set):
+    // write each packet body first with the headers held at HSA_PACKET_TYPE_INVALID,
+    // then arm the four packet headers last. This guarantees the CP prefetch engine
+    // never observes an armed header over a partially-written body. The captured
+    // buffer already carries the armed header value for real slots and INVALID for
+    // slots without metadata (barriers), so re-arming from it preserves both cases.
     if (flatMetadataData != nullptr && metadata_preloader_.HasMetadataQueue()) {
       static constexpr size_t kMetaSize = 256;
+      // Header dword offsets within a 256B AqlMetadataPrefetchPacket.
+      static constexpr size_t kHdrOff[4] = {0, 64, 128, 192};
+      static constexpr uint32_t kInvalidMetaHeader = HSA_PACKET_TYPE_INVALID;
       auto* metaBase = static_cast<uint8_t*>(metadata_preloader_.GetQueueBase());
-      const uint8_t* metaSrc = flatMetadataData->data() + chunkStart * kMetaSize;
-      if (chunkSlot + thisChunk <= queueSize) {
-        memcpy(metaBase + chunkSlot * kMetaSize, metaSrc, thisChunk * kMetaSize);
-      } else {
-        const size_t firstCount = queueSize - chunkSlot;
-        memcpy(metaBase + chunkSlot * kMetaSize, metaSrc, firstCount * kMetaSize);
-        memcpy(metaBase, metaSrc + firstCount * kMetaSize,
-               (thisChunk - firstCount) * kMetaSize);
+      for (size_t j = 0; j < thisChunk; ++j) {
+        const uint64_t slot = (startIndex + chunkStart + j) & queueMask;
+        uint8_t* dst = metaBase + slot * kMetaSize;
+        const uint8_t* src = flatMetadataData->data() + (chunkStart + j) * kMetaSize;
+        for (size_t h = 0; h < 4; ++h) {
+          // Hold the header INVALID while the body region after it is copied.
+          std::memcpy(dst + kHdrOff[h], &kInvalidMetaHeader, sizeof(kInvalidMetaHeader));
+          const size_t bodyStart = kHdrOff[h] + sizeof(uint32_t);
+          const size_t bodyEnd = (h + 1 < 4) ? kHdrOff[h + 1] : kMetaSize;
+          std::memcpy(dst + bodyStart, src + bodyStart, bodyEnd - bodyStart);
+        }
+        // Arm the headers last, in reverse order (header3 -> header0)
+        for (size_t h = 4; h-- > 0;) {
+          std::memcpy(dst + kHdrOff[h], src + kHdrOff[h], sizeof(uint32_t));
+        }
       }
     }
 

--- a/projects/clr/rocclr/platform/command.hpp
+++ b/projects/clr/rocclr/platform/command.hpp
@@ -403,11 +403,17 @@ class Command : public Event {
 
   //! Allocates and returns a metadata packet buffer for graph capture.
   //! Returns nullptr if metadata capture is not enabled.
+  //! The buffer is initialized with HSA_PACKET_TYPE_INVALID
   uint8_t* getMetadataPacket() const {
     if (gpuMetadataPackets_ == nullptr) {
       return nullptr;
     }
     uint8_t* packet = new uint8_t[256]();
+    static constexpr size_t kHdrOff[4] = {0, 64, 128, 192};
+    static constexpr uint32_t kInvalidMetadataHeader = 1;  // HSA_PACKET_TYPE_INVALID
+    for (size_t h = 0; h < 4; ++h) {
+      memcpy(packet + kHdrOff[h], &kInvalidMetadataHeader, sizeof(kInvalidMetadataHeader));
+    }
     gpuMetadataPackets_->push_back(packet);
     return packet;
   }


### PR DESCRIPTION
The graph batch path zero-filled metadata ring slots without captured metadata (barriers, uncaptured dispatches). Zero header0 = type 0 (VENDOR_SPECIFIC), a processable type, so the CP prefetch engine consumed bogus zero-filled packets and hung on gfx1250. Publish those slots as HSA_PACKET_TYPE_INVALID (type=1) so the engine skips them.

Also stop bulk-copying pre-armed metadata packets into the ring. Write each packet body with headers held INVALID, then arm header3..header0 last (header0 = the CP's gate), mirroring MetaDataPreloader::SetPacket and the primary queue's hold-back of packet-0's header. Prevents the engine from observing an armed header over a partially-written body.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

JIRA ID : AIRUNTIME-0

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
