### PR TITLE
[rocprofiler-sdk] Bypass idle inline queue interposition without active consumers

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
@@ -326,17 +326,6 @@ start_context(rocprofiler_context_id_t context_id)
         get_num_active_contexts().fetch_add(1, std::memory_order_release);
     }
 
-    // Notify queue interposition that this context is starting BEFORE publishing it into the
-    // active-context array below. stop_context()/deactivate_client_contexts() only ever
-    // learn about this context by observing it in that array (via an acquire-synchronized
-    // load paired with the release/seq_cst CAS that publishes it a few lines down), so
-    // incrementing first guarantees any concurrent stop-notify for this same context is
-    // ordered strictly after this increment. This closes a race where a concurrent
-    // stop_context() could observe the just-published context and decrement the counter
-    // (to 0) before this thread's own increment ran, leaving the counter permanently
-    // stuck positive after the context is already fully stopped. If the publish below
-    // fails (another thread concurrently claimed this slot), the increment is undone
-    // immediately below, mirroring the existing get_num_active_contexts() compensation.
     rocprofiler::hsa::queue_interposition::notify_queue_interposition_consumer_context_started(cfg);
 
     // atomic swap the pointer into the "active" array used internally
@@ -459,13 +448,6 @@ stop_client_contexts(rocprofiler_client_id_t client_id)
 void
 deactivate_client_contexts(rocprofiler_client_id_t client_id)
 {
-    // Hold the same lock stop_context() uses, and claim each slot via CAS (rather than an
-    // unconditional store), so that a concurrent stop_context() (or a second, concurrent
-    // deactivate_client_contexts() call) cannot observe and process the same active-context
-    // slot at the same time. Without this, both could independently call
-    // notify_queue_interposition_consumer_context_stopped() for the same context,
-    // double-decrementing the queue-interposition active-consumer count below its correct
-    // value.
     auto _lk = std::unique_lock<std::mutex>{get_contexts_mutex()};
     for(auto& itr : get_active_contexts_impl())
     {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
@@ -326,7 +326,7 @@ start_context(rocprofiler_context_id_t context_id)
         get_num_active_contexts().fetch_add(1, std::memory_order_release);
     }
 
-    // Notify inline-QI that this context is starting BEFORE publishing it into the
+    // Notify queue interposition that this context is starting BEFORE publishing it into the
     // active-context array below. stop_context()/deactivate_client_contexts() only ever
     // learn about this context by observing it in that array (via an acquire-synchronized
     // load paired with the release/seq_cst CAS that publishes it a few lines down), so
@@ -337,7 +337,7 @@ start_context(rocprofiler_context_id_t context_id)
     // stuck positive after the context is already fully stopped. If the publish below
     // fails (another thread concurrently claimed this slot), the increment is undone
     // immediately below, mirroring the existing get_num_active_contexts() compensation.
-    rocprofiler::hsa::queue_interposition::notify_inline_qi_consumer_context_started(cfg);
+    rocprofiler::hsa::queue_interposition::notify_queue_interposition_consumer_context_started(cfg);
 
     // atomic swap the pointer into the "active" array used internally
     const context* _expected = nullptr;
@@ -346,7 +346,8 @@ start_context(rocprofiler_context_id_t context_id)
 
     if(!success)
     {
-        rocprofiler::hsa::queue_interposition::notify_inline_qi_consumer_context_stopped(cfg);
+        rocprofiler::hsa::queue_interposition::notify_queue_interposition_consumer_context_stopped(
+            cfg);
         get_num_active_contexts().fetch_sub(1, std::memory_order_release);
         return ROCPROFILER_STATUS_ERROR_CONTEXT_NOT_STARTED;
     }
@@ -397,8 +398,8 @@ stop_context(rocprofiler_context_id_t idx)
                 if(_expected->dispatch_thread_trace)
                     _expected->dispatch_thread_trace->stop_context();
 
-                rocprofiler::hsa::queue_interposition::notify_inline_qi_consumer_context_stopped(
-                    _expected);
+                rocprofiler::hsa::queue_interposition::
+                    notify_queue_interposition_consumer_context_stopped(_expected);
 
                 if(_expected->device_counter_collection)
                 {
@@ -462,8 +463,9 @@ deactivate_client_contexts(rocprofiler_client_id_t client_id)
     // unconditional store), so that a concurrent stop_context() (or a second, concurrent
     // deactivate_client_contexts() call) cannot observe and process the same active-context
     // slot at the same time. Without this, both could independently call
-    // notify_inline_qi_consumer_context_stopped() for the same context, double-decrementing
-    // the inline-QI active-consumer count below its correct value.
+    // notify_queue_interposition_consumer_context_stopped() for the same context,
+    // double-decrementing the queue-interposition active-consumer count below its correct
+    // value.
     auto _lk = std::unique_lock<std::mutex>{get_contexts_mutex()};
     for(auto& itr : get_active_contexts_impl())
     {
@@ -472,8 +474,8 @@ deactivate_client_contexts(rocprofiler_client_id_t client_id)
         {
             if(itr.compare_exchange_strong(itr_v, nullptr))
             {
-                rocprofiler::hsa::queue_interposition::notify_inline_qi_consumer_context_stopped(
-                    itr_v);
+                rocprofiler::hsa::queue_interposition::
+                    notify_queue_interposition_consumer_context_stopped(itr_v);
             }
         }
     }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
@@ -326,6 +326,19 @@ start_context(rocprofiler_context_id_t context_id)
         get_num_active_contexts().fetch_add(1, std::memory_order_release);
     }
 
+    // Notify inline-QI that this context is starting BEFORE publishing it into the
+    // active-context array below. stop_context()/deactivate_client_contexts() only ever
+    // learn about this context by observing it in that array (via an acquire-synchronized
+    // load paired with the release/seq_cst CAS that publishes it a few lines down), so
+    // incrementing first guarantees any concurrent stop-notify for this same context is
+    // ordered strictly after this increment. This closes a race where a concurrent
+    // stop_context() could observe the just-published context and decrement the counter
+    // (to 0) before this thread's own increment ran, leaving the counter permanently
+    // stuck positive after the context is already fully stopped. If the publish below
+    // fails (another thread concurrently claimed this slot), the increment is undone
+    // immediately below, mirroring the existing get_num_active_contexts() compensation.
+    rocprofiler::hsa::queue_interposition::notify_inline_qi_consumer_context_started(cfg);
+
     // atomic swap the pointer into the "active" array used internally
     const context* _expected = nullptr;
     bool           success   = active_contexts.at(idx).compare_exchange_strong(
@@ -333,6 +346,7 @@ start_context(rocprofiler_context_id_t context_id)
 
     if(!success)
     {
+        rocprofiler::hsa::queue_interposition::notify_inline_qi_consumer_context_stopped(cfg);
         get_num_active_contexts().fetch_sub(1, std::memory_order_release);
         return ROCPROFILER_STATUS_ERROR_CONTEXT_NOT_STARTED;
     }
@@ -347,8 +361,6 @@ start_context(rocprofiler_context_id_t context_id)
 #if ROCPROFILER_SDK_HSA_PC_SAMPLING > 0
     if(cfg->pc_sampler) status = rocprofiler::pc_sampling::start_service(cfg);
 #endif
-
-    rocprofiler::hsa::queue_interposition::notify_inline_qi_consumer_context_started(cfg);
 
     return status;
 }
@@ -446,13 +458,23 @@ stop_client_contexts(rocprofiler_client_id_t client_id)
 void
 deactivate_client_contexts(rocprofiler_client_id_t client_id)
 {
+    // Hold the same lock stop_context() uses, and claim each slot via CAS (rather than an
+    // unconditional store), so that a concurrent stop_context() (or a second, concurrent
+    // deactivate_client_contexts() call) cannot observe and process the same active-context
+    // slot at the same time. Without this, both could independently call
+    // notify_inline_qi_consumer_context_stopped() for the same context, double-decrementing
+    // the inline-QI active-consumer count below its correct value.
+    auto _lk = std::unique_lock<std::mutex>{get_contexts_mutex()};
     for(auto& itr : get_active_contexts_impl())
     {
-        const auto* itr_v = itr.load();
+        const context* itr_v = itr.load(std::memory_order_acquire);
         if(itr_v && itr_v->client_idx == client_id.handle)
         {
-            rocprofiler::hsa::queue_interposition::notify_inline_qi_consumer_context_stopped(itr_v);
-            itr.store(nullptr);
+            if(itr.compare_exchange_strong(itr_v, nullptr))
+            {
+                rocprofiler::hsa::queue_interposition::notify_inline_qi_consumer_context_stopped(
+                    itr_v);
+            }
         }
     }
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
@@ -28,6 +28,7 @@
 #include "lib/common/utility.hpp"
 #include "lib/rocprofiler-sdk/buffer.hpp"
 #include "lib/rocprofiler-sdk/counters/core.hpp"
+#include "lib/rocprofiler-sdk/hsa/queue_interposition.hpp"
 #include "lib/rocprofiler-sdk/pc_sampling/service.hpp"
 #include "lib/rocprofiler-sdk/thread_trace/core.hpp"
 
@@ -347,6 +348,8 @@ start_context(rocprofiler_context_id_t context_id)
     if(cfg->pc_sampler) status = rocprofiler::pc_sampling::start_service(cfg);
 #endif
 
+    rocprofiler::hsa::queue_interposition::notify_inline_qi_consumer_context_started(cfg);
+
     return status;
 }
 
@@ -381,6 +384,9 @@ stop_context(rocprofiler_context_id_t idx)
                 if(_expected->device_thread_trace) _expected->device_thread_trace->stop_context();
                 if(_expected->dispatch_thread_trace)
                     _expected->dispatch_thread_trace->stop_context();
+
+                rocprofiler::hsa::queue_interposition::notify_inline_qi_consumer_context_stopped(
+                    _expected);
 
                 if(_expected->device_counter_collection)
                 {
@@ -445,6 +451,7 @@ deactivate_client_contexts(rocprofiler_client_id_t client_id)
         const auto* itr_v = itr.load();
         if(itr_v && itr_v->client_idx == client_id.handle)
         {
+            rocprofiler::hsa::queue_interposition::notify_inline_qi_consumer_context_stopped(itr_v);
             itr.store(nullptr);
         }
     }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
@@ -569,13 +569,13 @@ enable_queue_intercept()
 }
 
 bool
-context_needs_inline_qi_tracing(const context::context* ctx)
+context_needs_queue_interposition_tracing(const context::context* ctx)
 {
     if(!ctx) return false;
-    return ctx->is_tracing(ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH) ||
-           ctx->is_tracing(ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH) ||
-           ctx->is_tracing(ROCPROFILER_CALLBACK_TRACING_SCRATCH_MEMORY) ||
-           ctx->is_tracing(ROCPROFILER_BUFFER_TRACING_SCRATCH_MEMORY);
+    return ctx->is_tracing_one_of(ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH,
+                                  ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH,
+                                  ROCPROFILER_CALLBACK_TRACING_SCRATCH_MEMORY,
+                                  ROCPROFILER_BUFFER_TRACING_SCRATCH_MEMORY);
 }
 
 void

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
@@ -568,6 +568,16 @@ enable_queue_intercept()
     return false;
 }
 
+bool
+context_needs_inline_qi_tracing(const context::context* ctx)
+{
+    if(!ctx) return false;
+    return ctx->is_tracing(ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH) ||
+           ctx->is_tracing(ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH) ||
+           ctx->is_tracing(ROCPROFILER_CALLBACK_TRACING_SCRATCH_MEMORY) ||
+           ctx->is_tracing(ROCPROFILER_BUFFER_TRACING_SCRATCH_MEMORY);
+}
+
 void
 queue_controller_init(HsaApiTable* table)
 {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
@@ -571,10 +571,10 @@ enable_queue_intercept()
 bool
 context_needs_queue_interposition_tracing(const context::context* ctx)
 {
-    return ctx && ctx->is_tracing_one_of(ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH,
-                                         ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH,
-                                         ROCPROFILER_CALLBACK_TRACING_SCRATCH_MEMORY,
-                                         ROCPROFILER_BUFFER_TRACING_SCRATCH_MEMORY);
+    return ctx != nullptr && ctx->is_tracing_one_of(ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH,
+                                                    ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH,
+                                                    ROCPROFILER_CALLBACK_TRACING_SCRATCH_MEMORY,
+                                                    ROCPROFILER_BUFFER_TRACING_SCRATCH_MEMORY);
 }
 
 void

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
@@ -571,11 +571,10 @@ enable_queue_intercept()
 bool
 context_needs_queue_interposition_tracing(const context::context* ctx)
 {
-    if(!ctx) return false;
-    return ctx->is_tracing_one_of(ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH,
-                                  ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH,
-                                  ROCPROFILER_CALLBACK_TRACING_SCRATCH_MEMORY,
-                                  ROCPROFILER_BUFFER_TRACING_SCRATCH_MEMORY);
+    return ctx && ctx->is_tracing_one_of(ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH,
+                                         ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH,
+                                         ROCPROFILER_CALLBACK_TRACING_SCRATCH_MEMORY,
+                                         ROCPROFILER_BUFFER_TRACING_SCRATCH_MEMORY);
 }
 
 void

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.hpp
@@ -129,7 +129,6 @@ get_queue_controller();
 bool
 enable_queue_intercept();
 
-/// True when this context uses queue interposition (kernel-dispatch or scratch-memory tracing).
 bool
 context_needs_queue_interposition_tracing(const context::context* ctx);
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.hpp
@@ -38,6 +38,10 @@
 
 namespace rocprofiler
 {
+namespace context
+{
+struct context;
+}
 namespace hsa
 {
 // Tracks and manages HSA queues
@@ -124,6 +128,10 @@ get_queue_controller();
 
 bool
 enable_queue_intercept();
+
+/// True when this context uses inline QI (kernel-dispatch or scratch-memory tracing).
+bool
+context_needs_inline_qi_tracing(const context::context* ctx);
 
 void
 queue_controller_init(HsaApiTable* table);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.hpp
@@ -129,9 +129,9 @@ get_queue_controller();
 bool
 enable_queue_intercept();
 
-/// True when this context uses inline QI (kernel-dispatch or scratch-memory tracing).
+/// True when this context uses queue interposition (kernel-dispatch or scratch-memory tracing).
 bool
-context_needs_inline_qi_tracing(const context::context* ctx);
+context_needs_queue_interposition_tracing(const context::context* ctx);
 
 void
 queue_controller_init(HsaApiTable* table);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
@@ -71,7 +71,7 @@ namespace queue_interposition
 {
 namespace
 {
-auto s_active_inline_qi_consumers = std::atomic<uint32_t>{0};
+auto s_active_queue_interposition_consumers = std::atomic<uint32_t>{0};
 
 // NOTE:
 //  - "installed" is for checking whether HSA functions have been passed
@@ -83,9 +83,9 @@ auto s_intercept_active    = std::atomic<bool>{false};  // actively intercepting
 auto s_intercept_dynamic   = std::atomic<bool>{false};  // dynamically add queue states
 
 bool
-has_active_inline_qi_consumers()
+has_active_queue_interposition_consumers()
 {
-    return s_active_inline_qi_consumers.load(std::memory_order_acquire) > 0;
+    return s_active_queue_interposition_consumers.load(std::memory_order_relaxed) > 0;
 }
 
 bool
@@ -95,7 +95,7 @@ should_bypass_inline_intercept()
             !s_intercept_active.load(std::memory_order_acquire) ||
             registration::get_fini_status() != 0 ||
             // TODO: debug and enable queue interposition for attachment
-            registration::supports_attachment() || !has_active_inline_qi_consumers());
+            registration::supports_attachment() || !has_active_queue_interposition_consumers());
 }
 
 auto*&
@@ -154,28 +154,25 @@ read_queue_indices(const QueueState* state)
     indices.virtual_wptr    = state->virtual_wptr.load(std::memory_order_acquire);
     indices.next_scan_pos   = state->next_scan_pos;
     indices.next_submit_pos = state->next_submit_pos;
-    if(state->real_wdid)
-        indices.real_wdid = __atomic_load_n(state->real_wdid, __ATOMIC_ACQUIRE);
-    if(state->real_rdid)
-        indices.real_rdid = __atomic_load_n(state->real_rdid, __ATOMIC_ACQUIRE);
+    if(state->real_wdid) indices.real_wdid = __atomic_load_n(state->real_wdid, __ATOMIC_ACQUIRE);
+    if(state->real_rdid) indices.real_rdid = __atomic_load_n(state->real_rdid, __ATOMIC_ACQUIRE);
     indices.bypass    = should_bypass_inline_intercept();
-    indices.consumers = s_active_inline_qi_consumers.load(std::memory_order_acquire);
+    indices.consumers = s_active_queue_interposition_consumers.load(std::memory_order_acquire);
     return indices;
 }
 
 template <typename... Args>
 void
-log(std::string_view                event,
-    uint64_t                        seq,
-    const QueueState*               state,
-    fmt::format_string<Args...>     detail_fmt,
-    Args&&...                       detail_args)
+log(std::string_view            event,
+    uint64_t                    seq,
+    const QueueState*           state,
+    fmt::format_string<Args...> detail_fmt,
+    Args&&... detail_args)
 {
     if(!enabled()) return;
 
     const auto indices = read_queue_indices(state);
-    const auto detail =
-        fmt::format(detail_fmt, std::forward<Args>(detail_args)...);
+    const auto detail  = fmt::format(detail_fmt, std::forward<Args>(detail_args)...);
     ROCP_INFO << fmt::format(
         "[qi-dispatch-trace] event={} seq={} queue={} virtual_wptr={} real_wdid={} real_rdid={} "
         "next_scan_pos={} next_submit_pos={} bypass={} consumers={} :: {}",
@@ -495,13 +492,12 @@ async_signal_handler(hsa_signal_t                            completion_signal,
 
     if(qi_dispatch_trace::enabled())
     {
-        ROCP_INFO << fmt::format(
-            "[qi-dispatch-trace] event=async_wait_begin signal={{.handle={}}} "
-            "starting_value={} queue={} dispatch_count={}",
-            completion_signal.handle,
-            starting_value,
-            session ? session->queue.get_id().handle : uint64_t{0},
-            session ? session->packet_data.size() : 0);
+        ROCP_INFO << fmt::format("[qi-dispatch-trace] event=async_wait_begin signal={{.handle={}}} "
+                                 "starting_value={} queue={} dispatch_count={}",
+                                 completion_signal.handle,
+                                 starting_value,
+                                 session ? session->queue.get_id().handle : uint64_t{0},
+                                 session ? session->packet_data.size() : 0);
     }
 
     // Stop only on completion or finalization; never run cleanup while the kernel is live.
@@ -889,14 +885,14 @@ write_interceptor(Queue*                                queue,
         {
             if(qi_dispatch_trace::enabled())
             {
-                ROCP_INFO << fmt::format(
-                    "[qi-dispatch-trace] event=async_arm doorbell_seq={} batch_signal={{.handle={}}} "
-                    "batch_signal_value={} packet_count={} queue={}",
-                    get_doorbell_tls().trace_doorbell_seq,
-                    last_completion_signal.handle,
-                    current_signal_value,
-                    _shared_info_session->packet_data.size(),
-                    queue->get_id().handle);
+                ROCP_INFO << fmt::format("[qi-dispatch-trace] event=async_arm doorbell_seq={} "
+                                         "batch_signal={{.handle={}}} "
+                                         "batch_signal_value={} packet_count={} queue={}",
+                                         get_doorbell_tls().trace_doorbell_seq,
+                                         last_completion_signal.handle,
+                                         current_signal_value,
+                                         _shared_info_session->packet_data.size(),
+                                         queue->get_id().handle);
             }
 
             auto _task = [_signal_v          = last_completion_signal,
@@ -928,8 +924,8 @@ process_doorbell_impl(const queue_state_ptr_t& state,
 {
     if(!state) return;
 
-    auto* state_ptr            = state.get();
-    auto  deferred_async_tasks = async_signal_task_vector_t{};
+    auto*      state_ptr            = state.get();
+    auto       deferred_async_tasks = async_signal_task_vector_t{};
     const auto doorbell_seq =
         qi_dispatch_trace::enabled() ? qi_dispatch_trace::next_seq() : uint64_t{0};
 
@@ -975,8 +971,8 @@ process_doorbell_impl(const queue_state_ptr_t& state,
     // heap buffer implicated in ROCM-27116; rare large batches spill to a local vector.
     using snapshot_pkt_t = std::array<char, 64>;
     common::container::static_vector<snapshot_pkt_t, kSnapshotMaxPkts> snapshot;
-    std::vector<char> overflow_snapshot;
-    char*              source_snapshot = nullptr;
+    std::vector<char>                                                  overflow_snapshot;
+    char*                                                              source_snapshot = nullptr;
 
     if(max_pkts > kSnapshotMaxPkts)
     {
@@ -988,9 +984,8 @@ process_doorbell_impl(const queue_state_ptr_t& state,
     for(uint64_t pos = scan_pos; pos < wptr_end; ++pos)
     {
         const auto  ring_slot = pos & state_ptr->ring_mask;
-        char* const slot_base =
-            static_cast<char*>(state_ptr->ring_buf) + (ring_slot * pkt_size);
-        auto* const hdr_ptr = reinterpret_cast<volatile uint16_t*>(slot_base);
+        char* const slot_base = static_cast<char*>(state_ptr->ring_buf) + (ring_slot * pkt_size);
+        auto* const hdr_ptr   = reinterpret_cast<volatile uint16_t*>(slot_base);
 
         if((__atomic_load_n(hdr_ptr, __ATOMIC_ACQUIRE) & 0xFFu) ==
            static_cast<unsigned>(HSA_PACKET_TYPE_INVALID))
@@ -1320,11 +1315,8 @@ resync_queue_shadow_state(QueueState* state)
 
     if(qi_dispatch_trace::enabled())
     {
-        qi_dispatch_trace::log("shadow_resync",
-                               qi_dispatch_trace::next_seq(),
-                               state,
-                               "wdid={}",
-                               wdid);
+        qi_dispatch_trace::log(
+            "shadow_resync", qi_dispatch_trace::next_seq(), state, "wdid={}", wdid);
     }
 }
 
@@ -1339,33 +1331,32 @@ resync_all_queue_shadow_states()
 }  // namespace
 
 void
-notify_inline_qi_consumer_context_started(const context::context* ctx)
+notify_queue_interposition_consumer_context_started(const context::context* ctx)
 {
-    if(!context_needs_inline_qi_tracing(ctx)) return;
+    if(!context_needs_queue_interposition_tracing(ctx)) return;
 
-    const auto prev = s_active_inline_qi_consumers.load(std::memory_order_acquire);
+    const auto prev = s_active_queue_interposition_consumers.load(std::memory_order_acquire);
     if(prev == 0 && s_intercept_installed.load(std::memory_order_acquire))
         resync_all_queue_shadow_states();
 
     const auto consumers =
-        s_active_inline_qi_consumers.fetch_add(1, std::memory_order_release) + 1;
+        s_active_queue_interposition_consumers.fetch_add(1, std::memory_order_release) + 1;
     if(qi_dispatch_trace::enabled())
     {
-        ROCP_INFO << fmt::format(
-            "[qi-dispatch-trace] event=consumer_start consumers={} bypass={}",
-            consumers,
-            should_bypass_inline_intercept());
+        ROCP_INFO << fmt::format("[qi-dispatch-trace] event=consumer_start consumers={} bypass={}",
+                                 consumers,
+                                 should_bypass_inline_intercept());
     }
 }
 
 void
-notify_inline_qi_consumer_context_stopped(const context::context* ctx)
+notify_queue_interposition_consumer_context_stopped(const context::context* ctx)
 {
-    if(!context_needs_inline_qi_tracing(ctx)) return;
-    auto cur = s_active_inline_qi_consumers.load(std::memory_order_relaxed);
+    if(!context_needs_queue_interposition_tracing(ctx)) return;
+    auto cur = s_active_queue_interposition_consumers.load(std::memory_order_relaxed);
     while(cur > 0)
     {
-        if(s_active_inline_qi_consumers.compare_exchange_weak(
+        if(s_active_queue_interposition_consumers.compare_exchange_weak(
                cur, cur - 1, std::memory_order_release, std::memory_order_relaxed))
         {
             if(qi_dispatch_trace::enabled())

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
@@ -32,6 +32,7 @@
 #include "lib/rocprofiler-sdk/hsa/queue_interposition.hpp"
 #include "lib/common/container/pool.hpp"
 #include "lib/common/container/pool_object.hpp"
+#include "lib/common/container/static_vector.hpp"
 #include "lib/common/environment.hpp"
 #include "lib/common/logging.hpp"
 #include "lib/common/static_object.hpp"
@@ -55,6 +56,7 @@
 #include <hsa/hsa_api_trace.h>
 #include <pthread.h>
 
+#include <array>
 #include <atomic>
 #include <cstring>
 #include <string_view>
@@ -965,27 +967,50 @@ process_doorbell_impl(const queue_state_ptr_t& state,
         return;
     }
 
-    static thread_local auto snapshot_storage = std::vector<char>{};
-    const uint64_t           max_bytes        = (wptr_end - scan_pos) * state_ptr->pkt_size;
-    if(snapshot_storage.size() < max_bytes) snapshot_storage.resize(max_bytes);
-    char* const source_snapshot = snapshot_storage.data();
+    constexpr size_t kSnapshotMaxPkts = 16;
+    const uint64_t   max_pkts         = wptr_end - scan_pos;
+    const auto       pkt_size         = state_ptr->pkt_size;
+
+    // Fixed-capacity inline snapshot (16 packets). Avoids the persistent thread_local
+    // heap buffer implicated in ROCM-27116; rare large batches spill to a local vector.
+    using snapshot_pkt_t = std::array<char, 64>;
+    common::container::static_vector<snapshot_pkt_t, kSnapshotMaxPkts> snapshot;
+    std::vector<char> overflow_snapshot;
+    char*              source_snapshot = nullptr;
+
+    if(max_pkts > kSnapshotMaxPkts)
+    {
+        overflow_snapshot.resize(max_pkts * pkt_size);
+        source_snapshot = overflow_snapshot.data();
+    }
 
     uint64_t drained = 0;
     for(uint64_t pos = scan_pos; pos < wptr_end; ++pos)
     {
         const auto  ring_slot = pos & state_ptr->ring_mask;
         char* const slot_base =
-            static_cast<char*>(state_ptr->ring_buf) + (ring_slot * state_ptr->pkt_size);
+            static_cast<char*>(state_ptr->ring_buf) + (ring_slot * pkt_size);
         auto* const hdr_ptr = reinterpret_cast<volatile uint16_t*>(slot_base);
 
         if((__atomic_load_n(hdr_ptr, __ATOMIC_ACQUIRE) & 0xFFu) ==
            static_cast<unsigned>(HSA_PACKET_TYPE_INVALID))
             break;
 
-        ::memcpy(source_snapshot + (drained * state_ptr->pkt_size), slot_base, state_ptr->pkt_size);
+        char* dst = nullptr;
+        if(source_snapshot)
+        {
+            dst = source_snapshot + (drained * pkt_size);
+        }
+        else
+        {
+            dst = snapshot.emplace_back().data();
+        }
+        ::memcpy(dst, slot_base, pkt_size);
         __atomic_store_n(hdr_ptr, static_cast<uint16_t>(HSA_PACKET_TYPE_INVALID), __ATOMIC_RELEASE);
         ++drained;
     }
+
+    if(!source_snapshot) source_snapshot = reinterpret_cast<char*>(snapshot.data());
 
     if(drained == 0)
     {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
@@ -59,7 +59,6 @@
 #include <array>
 #include <atomic>
 #include <cstring>
-#include <string_view>
 #include <thread>
 #include <vector>
 
@@ -115,80 +114,6 @@ get_next_table()
     return _v;
 }
 }  // namespace
-
-namespace qi_dispatch_trace
-{
-inline bool
-enabled()
-{
-    static const auto _enabled = common::get_env("ROCPROFILER_QI_DISPATCH_TRACE", 0) != 0;
-    return _enabled;
-}
-
-inline uint64_t
-next_seq()
-{
-    static auto _seq = std::atomic<uint64_t>{0};
-    return _seq.fetch_add(1, std::memory_order_relaxed) + 1;
-}
-
-struct queue_indices_t
-{
-    const void* queue           = nullptr;
-    uint64_t    virtual_wptr    = 0;
-    uint64_t    real_wdid       = 0;
-    uint64_t    real_rdid       = 0;
-    uint64_t    next_scan_pos   = 0;
-    uint64_t    next_submit_pos = 0;
-    bool        bypass          = false;
-    uint32_t    consumers       = 0;
-};
-
-inline queue_indices_t
-read_queue_indices(const QueueState* state)
-{
-    queue_indices_t indices{};
-    if(!state) return indices;
-
-    indices.queue           = static_cast<const void*>(state->hsa_queue);
-    indices.virtual_wptr    = state->virtual_wptr.load(std::memory_order_acquire);
-    indices.next_scan_pos   = state->next_scan_pos;
-    indices.next_submit_pos = state->next_submit_pos;
-    if(state->real_wdid) indices.real_wdid = __atomic_load_n(state->real_wdid, __ATOMIC_ACQUIRE);
-    if(state->real_rdid) indices.real_rdid = __atomic_load_n(state->real_rdid, __ATOMIC_ACQUIRE);
-    indices.bypass    = should_bypass_inline_intercept();
-    indices.consumers = s_active_queue_interposition_consumers.load(std::memory_order_acquire);
-    return indices;
-}
-
-template <typename... Args>
-void
-log(std::string_view            event,
-    uint64_t                    seq,
-    const QueueState*           state,
-    fmt::format_string<Args...> detail_fmt,
-    Args&&... detail_args)
-{
-    if(!enabled()) return;
-
-    const auto indices = read_queue_indices(state);
-    const auto detail  = fmt::format(detail_fmt, std::forward<Args>(detail_args)...);
-    ROCP_INFO << fmt::format(
-        "[qi-dispatch-trace] event={} seq={} queue={} virtual_wptr={} real_wdid={} real_rdid={} "
-        "next_scan_pos={} next_submit_pos={} bypass={} consumers={} :: {}",
-        event,
-        seq,
-        indices.queue,
-        indices.virtual_wptr,
-        indices.real_wdid,
-        indices.real_rdid,
-        indices.next_scan_pos,
-        indices.next_submit_pos,
-        indices.bypass,
-        indices.consumers,
-        detail);
-}
-}  // namespace qi_dispatch_trace
 
 queue_registry_t&
 get_queue_registry()
@@ -283,7 +208,6 @@ struct doorbell_tls_t
     uint32_t             pkt_size                  = 64;
     const doorbell_fn_t* ring_doorbell             = nullptr;
     uint64_t             last_published_submit_pos = 0;
-    uint64_t             trace_doorbell_seq        = 0;
 };
 
 doorbell_tls_t&
@@ -311,18 +235,6 @@ publish_submitted_packets(QueueState* state, uint64_t submit_pos)
     const auto doorbell_idx = static_cast<hsa_signal_value_t>(submit_pos - 1);
     (*tls.ring_doorbell)(state->doorbell_signal, doorbell_idx);
     tls.last_published_submit_pos = submit_pos;
-
-    if(qi_dispatch_trace::enabled())
-    {
-        qi_dispatch_trace::log("publish",
-                               qi_dispatch_trace::next_seq(),
-                               state,
-                               "doorbell_idx={} submit_pos={} real_wdid_after={} real_rdid={}",
-                               static_cast<int64_t>(doorbell_idx),
-                               submit_pos,
-                               __atomic_load_n(state->real_wdid, __ATOMIC_ACQUIRE),
-                               __atomic_load_n(state->real_rdid, __ATOMIC_ACQUIRE));
-    }
 }
 
 // Ring the doorbell with the last index we have actually submitted (next_submit_pos - 1),
@@ -388,15 +300,6 @@ ring_buffer_writer(const void* pkts, uint64_t pkt_count)
             }
         }
         tls.submit_pos++;
-        if(qi_dispatch_trace::enabled())
-        {
-            qi_dispatch_trace::log("ring_write",
-                                   qi_dispatch_trace::next_seq(),
-                                   state,
-                                   "ring_slot={} submit_pos_after={}",
-                                   slot,
-                                   tls.submit_pos);
-        }
     }
 }
 
@@ -490,16 +393,6 @@ async_signal_handler(hsa_signal_t                            completion_signal,
     auto signal_value = starting_value;
     auto niterations  = uint64_t{0};
 
-    if(qi_dispatch_trace::enabled())
-    {
-        ROCP_INFO << fmt::format("[qi-dispatch-trace] event=async_wait_begin signal={{.handle={}}} "
-                                 "starting_value={} queue={} dispatch_count={}",
-                                 completion_signal.handle,
-                                 starting_value,
-                                 session ? session->queue.get_id().handle : uint64_t{0},
-                                 session ? session->packet_data.size() : 0);
-    }
-
     // Stop only on completion or finalization; never run cleanup while the kernel is live.
     while(true)
     {
@@ -531,18 +424,6 @@ async_signal_handler(hsa_signal_t                            completion_signal,
                              signal_value,
                              starting_value,
                              niterations);
-
-    if(qi_dispatch_trace::enabled())
-    {
-        ROCP_INFO << fmt::format(
-            "[qi-dispatch-trace] event=async_wait_end signal={{.handle={}}} final_value={} "
-            "starting_value={} iterations={} completed={}",
-            completion_signal.handle,
-            signal_value,
-            starting_value,
-            niterations,
-            signal_value < starting_value);
-    }
 
     if(auto delay_us = common::get_env("ROCPROFILER_TEST_INLINE_ASYNC_DELAY_US", 0); delay_us > 0)
     {
@@ -607,14 +488,6 @@ write_interceptor(Queue*                                queue,
     // We have no packets or no one who needs to be notified, do nothing.
     if(pkt_count == 0 || _contexts.empty())
     {
-        if(qi_dispatch_trace::enabled())
-        {
-            ROCP_INFO << fmt::format(
-                "[qi-dispatch-trace] event=write_passthrough_no_contexts pkt_count={} "
-                "active_contexts=0 queue={}",
-                pkt_count,
-                queue->get_id().handle);
-        }
         writer(packets, pkt_count);
         return;
     }
@@ -836,23 +709,6 @@ write_interceptor(Queue*                                queue,
             }
 
             _info_session.packet_data.emplace_back(std::move(_packet_data));
-
-            if(qi_dispatch_trace::enabled())
-            {
-                const auto& armed_packet = _info_session.packet_data.back();
-                qi_dispatch_trace::log(
-                    "dispatch_arm",
-                    qi_dispatch_trace::next_seq(),
-                    get_doorbell_tls().state,
-                    "doorbell_seq={} dispatch_id={} kernel_id={} signal={{.handle={}}} "
-                    "pooled={} submit_pos={} signal_value_after_add=1",
-                    get_doorbell_tls().trace_doorbell_seq,
-                    armed_packet.callback_record.dispatch_info.dispatch_id,
-                    armed_packet.callback_record.dispatch_info.kernel_id,
-                    armed_packet.completion_signal.handle,
-                    armed_packet.pooled_signal != nullptr,
-                    get_doorbell_tls().submit_pos);
-            }
         }
 
         auto last_completion_signal = null_signal;
@@ -883,18 +739,6 @@ write_interceptor(Queue*                                queue,
 
         if(_shared_info_session)
         {
-            if(qi_dispatch_trace::enabled())
-            {
-                ROCP_INFO << fmt::format("[qi-dispatch-trace] event=async_arm doorbell_seq={} "
-                                         "batch_signal={{.handle={}}} "
-                                         "batch_signal_value={} packet_count={} queue={}",
-                                         get_doorbell_tls().trace_doorbell_seq,
-                                         last_completion_signal.handle,
-                                         current_signal_value,
-                                         _shared_info_session->packet_data.size(),
-                                         queue->get_id().handle);
-            }
-
             auto _task = [_signal_v          = last_completion_signal,
                           _expected_signal_v = current_signal_value,
                           _session_v         = std::move(_shared_info_session)]() mutable {
@@ -924,10 +768,8 @@ process_doorbell_impl(const queue_state_ptr_t& state,
 {
     if(!state) return;
 
-    auto*      state_ptr            = state.get();
-    auto       deferred_async_tasks = async_signal_task_vector_t{};
-    const auto doorbell_seq =
-        qi_dispatch_trace::enabled() ? qi_dispatch_trace::next_seq() : uint64_t{0};
+    auto* state_ptr            = state.get();
+    auto  deferred_async_tasks = async_signal_task_vector_t{};
 
     // gate_lock serializes doorbell processing; producers never take it, so no deadlock.
     std::unique_lock<std::mutex> lock{state_ptr->gate_lock};
@@ -936,29 +778,10 @@ process_doorbell_impl(const queue_state_ptr_t& state,
 
     const uint64_t wptr_end = state_ptr->virtual_wptr.load(std::memory_order_acquire);
 
-    if(doorbell_seq != 0)
-    {
-        qi_dispatch_trace::log("doorbell",
-                               doorbell_seq,
-                               state_ptr,
-                               "doorbell_val={} scan_pos={} wptr_end={}",
-                               static_cast<int64_t>(value),
-                               scan_pos,
-                               wptr_end);
-    }
-
     if(scan_pos >= wptr_end)
     {
         // Already scanned through virtual_wptr, so `value` is <= what we have submitted and
         // cannot advertise unpublished slots; forward it (and never drop the doorbell).
-        if(doorbell_seq != 0)
-        {
-            qi_dispatch_trace::log("doorbell_forward",
-                                   doorbell_seq,
-                                   state_ptr,
-                                   "doorbell_val={} reason=scan_pos_ge_wptr_end",
-                                   static_cast<int64_t>(value));
-        }
         ring_doorbell(state_ptr->doorbell_signal, value);
         return;
     }
@@ -967,8 +790,6 @@ process_doorbell_impl(const queue_state_ptr_t& state,
     const uint64_t   max_pkts         = wptr_end - scan_pos;
     const auto       pkt_size         = state_ptr->pkt_size;
 
-    // Fixed-capacity inline snapshot (16 packets). Avoids the persistent thread_local
-    // heap buffer implicated in ROCM-27116; rare large batches spill to a local vector.
     using snapshot_pkt_t = std::array<char, 64>;
     common::container::static_vector<snapshot_pkt_t, kSnapshotMaxPkts> snapshot;
     std::vector<char>                                                  overflow_snapshot;
@@ -1012,14 +833,6 @@ process_doorbell_impl(const queue_state_ptr_t& state,
         // The next slot is claimed but not yet written by its producer, so there is
         // nothing to publish now; that producer's own later doorbell will drain it.
         // Re-ring only the last published index, not the virtual value.
-        if(doorbell_seq != 0)
-        {
-            qi_dispatch_trace::log("doorbell_rering",
-                                   doorbell_seq,
-                                   state_ptr,
-                                   "doorbell_val={} reason=drained_zero",
-                                   static_cast<int64_t>(value));
-        }
         ring_published_doorbell(state_ptr, ring_doorbell);
         return;
     }
@@ -1039,7 +852,6 @@ process_doorbell_impl(const queue_state_ptr_t& state,
     tls.pkt_size                  = state_ptr->pkt_size;
     tls.ring_doorbell             = &ring_doorbell;
     tls.last_published_submit_pos = state_ptr->next_submit_pos;
-    tls.trace_doorbell_seq        = doorbell_seq;
     uint64_t start_submit_pos     = tls.submit_pos;
 
     auto*        qc = get_queue_controller();
@@ -1081,34 +893,12 @@ process_doorbell_impl(const queue_state_ptr_t& state,
                      << ", ring_size=" << state_ptr->ring_size << ", scan_pos=" << scan_pos
                      << ", scan_end=" << scan_end
                      << ", next_submit_pos=" << state_ptr->next_submit_pos;
-        if(doorbell_seq != 0)
-        {
-            qi_dispatch_trace::log("ring_corrupt",
-                                   doorbell_seq,
-                                   state_ptr,
-                                   "ring_used={} scan_end={} pkt_count={}",
-                                   ring_used,
-                                   scan_end,
-                                   pkt_count);
-        }
     }
 
     publish_submitted_packets(state_ptr, state_ptr->next_submit_pos);
 
-    if(doorbell_seq != 0)
-    {
-        qi_dispatch_trace::log("doorbell_done",
-                               doorbell_seq,
-                               state_ptr,
-                               "pkt_count={} scan_end={} submit_pos_after={}",
-                               pkt_count,
-                               scan_end,
-                               state_ptr->next_submit_pos);
-    }
-
     tls.ring_doorbell             = nullptr;
     tls.last_published_submit_pos = 0;
-    tls.trace_doorbell_seq        = 0;
     tls.state                     = nullptr;
 
     // Arm completion waiters only after the final doorbell is visible
@@ -1259,18 +1049,6 @@ ROCP_QUEUE_LOAD_WRITE_INDEX(scacquire, std::memory_order_acquire)
     {                                                                                              \
         if(should_bypass_inline_intercept())                                                       \
         {                                                                                          \
-            if(qi_dispatch_trace::enabled())                                                       \
-            {                                                                                      \
-                constexpr auto _create_if_missing = false;                                         \
-                if(auto _state = lookup_queue_state_by_doorbell(sig, _create_if_missing); _state)  \
-                {                                                                                  \
-                    qi_dispatch_trace::log("bypass_doorbell",                                      \
-                                           qi_dispatch_trace::next_seq(),                          \
-                                           _state.get(),                                           \
-                                           "doorbell_val={}",                                      \
-                                           static_cast<int64_t>(val));                             \
-                }                                                                                  \
-            }                                                                                      \
             get_next_table()->hsa_signal_##NAME##_fn(sig, val);                                    \
             return;                                                                                \
         }                                                                                          \
@@ -1312,12 +1090,6 @@ resync_queue_shadow_state(QueueState* state)
     state->virtual_wptr.store(wdid, std::memory_order_release);
     state->next_scan_pos   = wdid;
     state->next_submit_pos = wdid;
-
-    if(qi_dispatch_trace::enabled())
-    {
-        qi_dispatch_trace::log(
-            "shadow_resync", qi_dispatch_trace::next_seq(), state, "wdid={}", wdid);
-    }
 }
 
 void
@@ -1339,14 +1111,7 @@ notify_queue_interposition_consumer_context_started(const context::context* ctx)
     if(prev == 0 && s_intercept_installed.load(std::memory_order_acquire))
         resync_all_queue_shadow_states();
 
-    const auto consumers =
-        s_active_queue_interposition_consumers.fetch_add(1, std::memory_order_release) + 1;
-    if(qi_dispatch_trace::enabled())
-    {
-        ROCP_INFO << fmt::format("[qi-dispatch-trace] event=consumer_start consumers={} bypass={}",
-                                 consumers,
-                                 should_bypass_inline_intercept());
-    }
+    s_active_queue_interposition_consumers.fetch_add(1, std::memory_order_release);
 }
 
 void
@@ -1359,13 +1124,6 @@ notify_queue_interposition_consumer_context_stopped(const context::context* ctx)
         if(s_active_queue_interposition_consumers.compare_exchange_weak(
                cur, cur - 1, std::memory_order_release, std::memory_order_relaxed))
         {
-            if(qi_dispatch_trace::enabled())
-            {
-                ROCP_INFO << fmt::format(
-                    "[qi-dispatch-trace] event=consumer_stop consumers={} bypass={}",
-                    cur - 1,
-                    should_bypass_inline_intercept());
-            }
             return;
         }
     }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
@@ -66,10 +66,10 @@ namespace hsa
 {
 namespace queue_interposition
 {
-auto s_active_inline_qi_consumers = std::atomic<uint32_t>{0};
-
 namespace
 {
+auto s_active_inline_qi_consumers = std::atomic<uint32_t>{0};
+
 // NOTE:
 //  - "installed" is for checking whether HSA functions have been passed
 //  - "active" is for controlling whether wrappers are intercepting or passing through
@@ -1067,8 +1067,13 @@ void
 notify_inline_qi_consumer_context_stopped(const context::context* ctx)
 {
     if(!context_needs_inline_qi_tracing(ctx)) return;
-    auto prev = s_active_inline_qi_consumers.fetch_sub(1, std::memory_order_release);
-    if(prev == 0) s_active_inline_qi_consumers.store(0, std::memory_order_release);
+    auto cur = s_active_inline_qi_consumers.load(std::memory_order_relaxed);
+    while(cur > 0)
+    {
+        if(s_active_inline_qi_consumers.compare_exchange_weak(
+               cur, cur - 1, std::memory_order_release, std::memory_order_relaxed))
+            return;
+    }
 }
 
 void

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
@@ -57,6 +57,7 @@
 
 #include <atomic>
 #include <cstring>
+#include <string_view>
 #include <thread>
 #include <vector>
 
@@ -112,6 +113,83 @@ get_next_table()
     return _v;
 }
 }  // namespace
+
+namespace qi_dispatch_trace
+{
+inline bool
+enabled()
+{
+    static const auto _enabled = common::get_env("ROCPROFILER_QI_DISPATCH_TRACE", 0) != 0;
+    return _enabled;
+}
+
+inline uint64_t
+next_seq()
+{
+    static auto _seq = std::atomic<uint64_t>{0};
+    return _seq.fetch_add(1, std::memory_order_relaxed) + 1;
+}
+
+struct queue_indices_t
+{
+    const void* queue           = nullptr;
+    uint64_t    virtual_wptr    = 0;
+    uint64_t    real_wdid       = 0;
+    uint64_t    real_rdid       = 0;
+    uint64_t    next_scan_pos   = 0;
+    uint64_t    next_submit_pos = 0;
+    bool        bypass          = false;
+    uint32_t    consumers       = 0;
+};
+
+inline queue_indices_t
+read_queue_indices(const QueueState* state)
+{
+    queue_indices_t indices{};
+    if(!state) return indices;
+
+    indices.queue           = static_cast<const void*>(state->hsa_queue);
+    indices.virtual_wptr    = state->virtual_wptr.load(std::memory_order_acquire);
+    indices.next_scan_pos   = state->next_scan_pos;
+    indices.next_submit_pos = state->next_submit_pos;
+    if(state->real_wdid)
+        indices.real_wdid = __atomic_load_n(state->real_wdid, __ATOMIC_ACQUIRE);
+    if(state->real_rdid)
+        indices.real_rdid = __atomic_load_n(state->real_rdid, __ATOMIC_ACQUIRE);
+    indices.bypass    = should_bypass_inline_intercept();
+    indices.consumers = s_active_inline_qi_consumers.load(std::memory_order_acquire);
+    return indices;
+}
+
+template <typename... Args>
+void
+log(std::string_view                event,
+    uint64_t                        seq,
+    const QueueState*               state,
+    fmt::format_string<Args...>     detail_fmt,
+    Args&&...                       detail_args)
+{
+    if(!enabled()) return;
+
+    const auto indices = read_queue_indices(state);
+    const auto detail =
+        fmt::format(detail_fmt, std::forward<Args>(detail_args)...);
+    ROCP_INFO << fmt::format(
+        "[qi-dispatch-trace] event={} seq={} queue={} virtual_wptr={} real_wdid={} real_rdid={} "
+        "next_scan_pos={} next_submit_pos={} bypass={} consumers={} :: {}",
+        event,
+        seq,
+        indices.queue,
+        indices.virtual_wptr,
+        indices.real_wdid,
+        indices.real_rdid,
+        indices.next_scan_pos,
+        indices.next_submit_pos,
+        indices.bypass,
+        indices.consumers,
+        detail);
+}
+}  // namespace qi_dispatch_trace
 
 queue_registry_t&
 get_queue_registry()
@@ -206,6 +284,7 @@ struct doorbell_tls_t
     uint32_t             pkt_size                  = 64;
     const doorbell_fn_t* ring_doorbell             = nullptr;
     uint64_t             last_published_submit_pos = 0;
+    uint64_t             trace_doorbell_seq        = 0;
 };
 
 doorbell_tls_t&
@@ -230,8 +309,21 @@ publish_submitted_packets(QueueState* state, uint64_t submit_pos)
         << ") regressed below last_published_submit_pos (" << tls.last_published_submit_pos << ")";
 
     __atomic_store_n(state->real_wdid, submit_pos, __ATOMIC_RELEASE);
-    (*tls.ring_doorbell)(state->doorbell_signal, static_cast<hsa_signal_value_t>(submit_pos - 1));
+    const auto doorbell_idx = static_cast<hsa_signal_value_t>(submit_pos - 1);
+    (*tls.ring_doorbell)(state->doorbell_signal, doorbell_idx);
     tls.last_published_submit_pos = submit_pos;
+
+    if(qi_dispatch_trace::enabled())
+    {
+        qi_dispatch_trace::log("publish",
+                               qi_dispatch_trace::next_seq(),
+                               state,
+                               "doorbell_idx={} submit_pos={} real_wdid_after={} real_rdid={}",
+                               static_cast<int64_t>(doorbell_idx),
+                               submit_pos,
+                               __atomic_load_n(state->real_wdid, __ATOMIC_ACQUIRE),
+                               __atomic_load_n(state->real_rdid, __ATOMIC_ACQUIRE));
+    }
 }
 
 // Ring the doorbell with the last index we have actually submitted (next_submit_pos - 1),
@@ -297,6 +389,15 @@ ring_buffer_writer(const void* pkts, uint64_t pkt_count)
             }
         }
         tls.submit_pos++;
+        if(qi_dispatch_trace::enabled())
+        {
+            qi_dispatch_trace::log("ring_write",
+                                   qi_dispatch_trace::next_seq(),
+                                   state,
+                                   "ring_slot={} submit_pos_after={}",
+                                   slot,
+                                   tls.submit_pos);
+        }
     }
 }
 
@@ -390,6 +491,17 @@ async_signal_handler(hsa_signal_t                            completion_signal,
     auto signal_value = starting_value;
     auto niterations  = uint64_t{0};
 
+    if(qi_dispatch_trace::enabled())
+    {
+        ROCP_INFO << fmt::format(
+            "[qi-dispatch-trace] event=async_wait_begin signal={{.handle={}}} "
+            "starting_value={} queue={} dispatch_count={}",
+            completion_signal.handle,
+            starting_value,
+            session ? session->queue.get_id().handle : uint64_t{0},
+            session ? session->packet_data.size() : 0);
+    }
+
     // Stop only on completion or finalization; never run cleanup while the kernel is live.
     while(true)
     {
@@ -421,6 +533,18 @@ async_signal_handler(hsa_signal_t                            completion_signal,
                              signal_value,
                              starting_value,
                              niterations);
+
+    if(qi_dispatch_trace::enabled())
+    {
+        ROCP_INFO << fmt::format(
+            "[qi-dispatch-trace] event=async_wait_end signal={{.handle={}}} final_value={} "
+            "starting_value={} iterations={} completed={}",
+            completion_signal.handle,
+            signal_value,
+            starting_value,
+            niterations,
+            signal_value < starting_value);
+    }
 
     if(auto delay_us = common::get_env("ROCPROFILER_TEST_INLINE_ASYNC_DELAY_US", 0); delay_us > 0)
     {
@@ -485,6 +609,14 @@ write_interceptor(Queue*                                queue,
     // We have no packets or no one who needs to be notified, do nothing.
     if(pkt_count == 0 || _contexts.empty())
     {
+        if(qi_dispatch_trace::enabled())
+        {
+            ROCP_INFO << fmt::format(
+                "[qi-dispatch-trace] event=write_passthrough_no_contexts pkt_count={} "
+                "active_contexts=0 queue={}",
+                pkt_count,
+                queue->get_id().handle);
+        }
         writer(packets, pkt_count);
         return;
     }
@@ -706,6 +838,23 @@ write_interceptor(Queue*                                queue,
             }
 
             _info_session.packet_data.emplace_back(std::move(_packet_data));
+
+            if(qi_dispatch_trace::enabled())
+            {
+                const auto& armed_packet = _info_session.packet_data.back();
+                qi_dispatch_trace::log(
+                    "dispatch_arm",
+                    qi_dispatch_trace::next_seq(),
+                    get_doorbell_tls().state,
+                    "doorbell_seq={} dispatch_id={} kernel_id={} signal={{.handle={}}} "
+                    "pooled={} submit_pos={} signal_value_after_add=1",
+                    get_doorbell_tls().trace_doorbell_seq,
+                    armed_packet.callback_record.dispatch_info.dispatch_id,
+                    armed_packet.callback_record.dispatch_info.kernel_id,
+                    armed_packet.completion_signal.handle,
+                    armed_packet.pooled_signal != nullptr,
+                    get_doorbell_tls().submit_pos);
+            }
         }
 
         auto last_completion_signal = null_signal;
@@ -736,6 +885,18 @@ write_interceptor(Queue*                                queue,
 
         if(_shared_info_session)
         {
+            if(qi_dispatch_trace::enabled())
+            {
+                ROCP_INFO << fmt::format(
+                    "[qi-dispatch-trace] event=async_arm doorbell_seq={} batch_signal={{.handle={}}} "
+                    "batch_signal_value={} packet_count={} queue={}",
+                    get_doorbell_tls().trace_doorbell_seq,
+                    last_completion_signal.handle,
+                    current_signal_value,
+                    _shared_info_session->packet_data.size(),
+                    queue->get_id().handle);
+            }
+
             auto _task = [_signal_v          = last_completion_signal,
                           _expected_signal_v = current_signal_value,
                           _session_v         = std::move(_shared_info_session)]() mutable {
@@ -767,6 +928,8 @@ process_doorbell_impl(const queue_state_ptr_t& state,
 
     auto* state_ptr            = state.get();
     auto  deferred_async_tasks = async_signal_task_vector_t{};
+    const auto doorbell_seq =
+        qi_dispatch_trace::enabled() ? qi_dispatch_trace::next_seq() : uint64_t{0};
 
     // gate_lock serializes doorbell processing; producers never take it, so no deadlock.
     std::unique_lock<std::mutex> lock{state_ptr->gate_lock};
@@ -775,10 +938,29 @@ process_doorbell_impl(const queue_state_ptr_t& state,
 
     const uint64_t wptr_end = state_ptr->virtual_wptr.load(std::memory_order_acquire);
 
+    if(doorbell_seq != 0)
+    {
+        qi_dispatch_trace::log("doorbell",
+                               doorbell_seq,
+                               state_ptr,
+                               "doorbell_val={} scan_pos={} wptr_end={}",
+                               static_cast<int64_t>(value),
+                               scan_pos,
+                               wptr_end);
+    }
+
     if(scan_pos >= wptr_end)
     {
         // Already scanned through virtual_wptr, so `value` is <= what we have submitted and
         // cannot advertise unpublished slots; forward it (and never drop the doorbell).
+        if(doorbell_seq != 0)
+        {
+            qi_dispatch_trace::log("doorbell_forward",
+                                   doorbell_seq,
+                                   state_ptr,
+                                   "doorbell_val={} reason=scan_pos_ge_wptr_end",
+                                   static_cast<int64_t>(value));
+        }
         ring_doorbell(state_ptr->doorbell_signal, value);
         return;
     }
@@ -810,6 +992,14 @@ process_doorbell_impl(const queue_state_ptr_t& state,
         // The next slot is claimed but not yet written by its producer, so there is
         // nothing to publish now; that producer's own later doorbell will drain it.
         // Re-ring only the last published index, not the virtual value.
+        if(doorbell_seq != 0)
+        {
+            qi_dispatch_trace::log("doorbell_rering",
+                                   doorbell_seq,
+                                   state_ptr,
+                                   "doorbell_val={} reason=drained_zero",
+                                   static_cast<int64_t>(value));
+        }
         ring_published_doorbell(state_ptr, ring_doorbell);
         return;
     }
@@ -829,6 +1019,7 @@ process_doorbell_impl(const queue_state_ptr_t& state,
     tls.pkt_size                  = state_ptr->pkt_size;
     tls.ring_doorbell             = &ring_doorbell;
     tls.last_published_submit_pos = state_ptr->next_submit_pos;
+    tls.trace_doorbell_seq        = doorbell_seq;
     uint64_t start_submit_pos     = tls.submit_pos;
 
     auto*        qc = get_queue_controller();
@@ -870,12 +1061,34 @@ process_doorbell_impl(const queue_state_ptr_t& state,
                      << ", ring_size=" << state_ptr->ring_size << ", scan_pos=" << scan_pos
                      << ", scan_end=" << scan_end
                      << ", next_submit_pos=" << state_ptr->next_submit_pos;
+        if(doorbell_seq != 0)
+        {
+            qi_dispatch_trace::log("ring_corrupt",
+                                   doorbell_seq,
+                                   state_ptr,
+                                   "ring_used={} scan_end={} pkt_count={}",
+                                   ring_used,
+                                   scan_end,
+                                   pkt_count);
+        }
     }
 
     publish_submitted_packets(state_ptr, state_ptr->next_submit_pos);
 
+    if(doorbell_seq != 0)
+    {
+        qi_dispatch_trace::log("doorbell_done",
+                               doorbell_seq,
+                               state_ptr,
+                               "pkt_count={} scan_end={} submit_pos_after={}",
+                               pkt_count,
+                               scan_end,
+                               state_ptr->next_submit_pos);
+    }
+
     tls.ring_doorbell             = nullptr;
     tls.last_published_submit_pos = 0;
+    tls.trace_doorbell_seq        = 0;
     tls.state                     = nullptr;
 
     // Arm completion waiters only after the final doorbell is visible
@@ -1026,6 +1239,18 @@ ROCP_QUEUE_LOAD_WRITE_INDEX(scacquire, std::memory_order_acquire)
     {                                                                                              \
         if(should_bypass_inline_intercept())                                                       \
         {                                                                                          \
+            if(qi_dispatch_trace::enabled())                                                       \
+            {                                                                                      \
+                constexpr auto _create_if_missing = false;                                         \
+                if(auto _state = lookup_queue_state_by_doorbell(sig, _create_if_missing); _state)  \
+                {                                                                                  \
+                    qi_dispatch_trace::log("bypass_doorbell",                                      \
+                                           qi_dispatch_trace::next_seq(),                          \
+                                           _state.get(),                                           \
+                                           "doorbell_val={}",                                      \
+                                           static_cast<int64_t>(val));                             \
+                }                                                                                  \
+            }                                                                                      \
             get_next_table()->hsa_signal_##NAME##_fn(sig, val);                                    \
             return;                                                                                \
         }                                                                                          \
@@ -1056,11 +1281,56 @@ supports_queue_interposition()
     return s_intercept_installed.load(std::memory_order_acquire);
 }
 
+namespace
+{
+void
+resync_queue_shadow_state(QueueState* state)
+{
+    if(!state || !state->real_wdid) return;
+
+    const uint64_t wdid = __atomic_load_n(state->real_wdid, __ATOMIC_ACQUIRE);
+    state->virtual_wptr.store(wdid, std::memory_order_release);
+    state->next_scan_pos   = wdid;
+    state->next_submit_pos = wdid;
+
+    if(qi_dispatch_trace::enabled())
+    {
+        qi_dispatch_trace::log("shadow_resync",
+                               qi_dispatch_trace::next_seq(),
+                               state,
+                               "wdid={}",
+                               wdid);
+    }
+}
+
+void
+resync_all_queue_shadow_states()
+{
+    get_queue_registry().rlock([](const auto& registry) {
+        for(const auto& entry : registry)
+            resync_queue_shadow_state(entry.second.get());
+    });
+}
+}  // namespace
+
 void
 notify_inline_qi_consumer_context_started(const context::context* ctx)
 {
     if(!context_needs_inline_qi_tracing(ctx)) return;
-    s_active_inline_qi_consumers.fetch_add(1, std::memory_order_release);
+
+    const auto prev = s_active_inline_qi_consumers.load(std::memory_order_acquire);
+    if(prev == 0 && s_intercept_installed.load(std::memory_order_acquire))
+        resync_all_queue_shadow_states();
+
+    const auto consumers =
+        s_active_inline_qi_consumers.fetch_add(1, std::memory_order_release) + 1;
+    if(qi_dispatch_trace::enabled())
+    {
+        ROCP_INFO << fmt::format(
+            "[qi-dispatch-trace] event=consumer_start consumers={} bypass={}",
+            consumers,
+            should_bypass_inline_intercept());
+    }
 }
 
 void
@@ -1072,7 +1342,16 @@ notify_inline_qi_consumer_context_stopped(const context::context* ctx)
     {
         if(s_active_inline_qi_consumers.compare_exchange_weak(
                cur, cur - 1, std::memory_order_release, std::memory_order_relaxed))
+        {
+            if(qi_dispatch_trace::enabled())
+            {
+                ROCP_INFO << fmt::format(
+                    "[qi-dispatch-trace] event=consumer_stop consumers={} bypass={}",
+                    cur - 1,
+                    should_bypass_inline_intercept());
+            }
             return;
+        }
     }
 }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
@@ -66,6 +66,8 @@ namespace hsa
 {
 namespace queue_interposition
 {
+auto s_active_inline_qi_consumers = std::atomic<uint32_t>{0};
+
 namespace
 {
 // NOTE:
@@ -78,13 +80,20 @@ auto s_intercept_active    = std::atomic<bool>{false};  // actively intercepting
 auto s_intercept_dynamic   = std::atomic<bool>{false};  // dynamically add queue states
 
 bool
+has_active_inline_qi_consumers()
+{
+    return s_active_inline_qi_consumers.load(std::memory_order_acquire) > 0;
+}
+
+bool
 should_bypass_inline_intercept()
 {
     return (!s_intercept_installed.load(std::memory_order_acquire) ||
             !s_intercept_active.load(std::memory_order_acquire) ||
             registration::get_fini_status() != 0 ||
             // TODO: debug and enable queue interposition for attachment
-            registration::supports_attachment());
+            registration::supports_attachment() ||
+            !has_active_inline_qi_consumers());
 }
 
 auto*&
@@ -1046,6 +1055,21 @@ bool
 supports_queue_interposition()
 {
     return s_intercept_installed.load(std::memory_order_acquire);
+}
+
+void
+notify_inline_qi_consumer_context_started(const context::context* ctx)
+{
+    if(!context_needs_inline_qi_tracing(ctx)) return;
+    s_active_inline_qi_consumers.fetch_add(1, std::memory_order_release);
+}
+
+void
+notify_inline_qi_consumer_context_stopped(const context::context* ctx)
+{
+    if(!context_needs_inline_qi_tracing(ctx)) return;
+    auto prev = s_active_inline_qi_consumers.fetch_sub(1, std::memory_order_release);
+    if(prev == 0) s_active_inline_qi_consumers.store(0, std::memory_order_release);
 }
 
 void

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
@@ -92,8 +92,7 @@ should_bypass_inline_intercept()
             !s_intercept_active.load(std::memory_order_acquire) ||
             registration::get_fini_status() != 0 ||
             // TODO: debug and enable queue interposition for attachment
-            registration::supports_attachment() ||
-            !has_active_inline_qi_consumers());
+            registration::supports_attachment() || !has_active_inline_qi_consumers());
 }
 
 auto*&

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.hpp
@@ -225,15 +225,16 @@ bool
 supports_queue_interposition();
 
 /**
- * @brief Increment/decrement the active inline-QI consumer count (hot-path bypass gate).
+ * @brief Increment/decrement the active queue-interposition consumer count (hot-path bypass
+ * gate).
  *
  * Called from context start/stop when a context uses kernel-dispatch or scratch-memory tracing.
  */
 void
-notify_inline_qi_consumer_context_started(const context::context* ctx);
+notify_queue_interposition_consumer_context_started(const context::context* ctx);
 
 void
-notify_inline_qi_consumer_context_stopped(const context::context* ctx);
+notify_queue_interposition_consumer_context_stopped(const context::context* ctx);
 
 /**
  * @brief Install interposition wrappers into the HSA core API table

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.hpp
@@ -224,12 +224,6 @@ destroy_queue_state(const hsa_queue_t* queue);
 bool
 supports_queue_interposition();
 
-/**
- * @brief Increment/decrement the active queue-interposition consumer count (hot-path bypass
- * gate).
- *
- * Called from context start/stop when a context uses kernel-dispatch or scratch-memory tracing.
- */
 void
 notify_queue_interposition_consumer_context_started(const context::context* ctx);
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.hpp
@@ -37,6 +37,10 @@
 
 namespace rocprofiler
 {
+namespace context
+{
+struct context;
+}
 namespace hsa
 {
 namespace queue_interposition
@@ -219,6 +223,17 @@ destroy_queue_state(const hsa_queue_t* queue);
  */
 bool
 supports_queue_interposition();
+
+/**
+ * @brief Increment/decrement the active inline-QI consumer count (hot-path bypass gate).
+ *
+ * Called from context start/stop when a context uses kernel-dispatch or scratch-memory tracing.
+ */
+void
+notify_inline_qi_consumer_context_started(const context::context* ctx);
+
+void
+notify_inline_qi_consumer_context_stopped(const context::context* ctx);
 
 /**
  * @brief Install interposition wrappers into the HSA core API table


### PR DESCRIPTION
## Summary

Fix ROCM-27116 by bypassing queue interposition (QI) on the hot path when no active profiling context needs kernel-dispatch or scratch-memory tracing. This prevents idle QI from virtualizing write indices and processing doorbells when auto-registered clients only use code-object callbacks.

## Changes

- `queue_interposition.cpp` / `queue_interposition.hpp` — track active queue-interposition consumers with an atomic counter; extend `should_bypass_inline_intercept()` to passthrough when the count is zero
- `queue_controller.cpp` / `queue_controller.hpp` — add `context_needs_queue_interposition_tracing()` helper
- `context.cpp` — increment/decrement the counter on context start/stop and on `deactivate_client_contexts()`

Also bundled in this branch (surfaced during review/testing of the above):
- Saturating CAS-loop decrement for the consumer counter (avoids underflow on unbalanced stop notifications)
- Resync of `virtual_wptr`/`next_scan_pos`/`next_submit_pos` to the real write-dispatch-id when the consumer count transitions 0→1, so QI doesn't publish against stale bookkeeping after bypass doorbells advanced the real queue
- Ordering fix for context start/stop notifications relative to active-context publish, and CAS-based slot claiming in `deactivate_client_contexts()`, to close a consumer-count race
- Replace the persistent `thread_local` doorbell snapshot buffer with a fixed-capacity inline snapshot (falling back to a local vector for rare large batches), removing a heap buffer implicated in the ROCM-27116 crash

## Motivation

PyTorch auto-registration installs QI by default even when only code-object tracing is registered. In a fork+exec child that inherits `ROCPROFILER_REGISTER_LIBRARY`, idle QI still intercepts HSA queue write-index and doorbell operations during minimal GPU work, corrupting the heap before exit (`corrupted double-linked list` / SIGABRT). Setting `ROCPROFILER_QUEUE_INTERPOSITION=0` avoids the crash; this change makes that behavior automatic when no QI consumer is active.

## Testing

- Built `librocprofiler-sdk.so` on banff (MI325X) and deployed into `rocm27116-parallel` PyTorch container
- PyTorch fork+exec repro (`torch.cuda.synchronize()` → `subprocess` child with `env=None` → `torch.rand`) **15/15 pass**
- Stock image reproduces ~90%+ crash rate without the fix
- Full local build + `ctest` (gfx1200): 378/379 unit tests pass (1 pre-existing, unrelated failure: `unit.rocprofiler_lib.agent`); all queue-interposition/queue-controller/context/intercept-table tests and HSA multiqueue integration tests pass

## Related Issues

JIRA ID : ROCM-27116

Made with [Cursor](https://cursor.com)
