### PR TITLE
rocr: Fix out-of-bounds access in hsa_amd_signal_wait_any

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
@@ -1079,10 +1079,16 @@ uint32_t hsa_amd_signal_wait_all(uint32_t signal_count, hsa_signal_t* hsa_signal
   uint32_t valid_signal_count = valid_signals.size();
 
   std::vector<hsa_signal_value_t> satisfying_values_vec(valid_signal_count);
-  uint32_t first_satysifying_signal_idx =
+  uint32_t first_satisfying_signal_idx =
       core::Signal::WaitMultiple(valid_signal_count, valid_signals.data(), valid_conds.data(),
                                  valid_values.data(), timeout_hint, wait_hint, satisfying_values_vec, true);
 
+  // Note: on timeout (or if a signal became invalid mid-wait), WaitMultiple() returns
+  // uint32_t(-1) and satisfying_values_vec is only partially filled -- entries for
+  // signals whose condition was never met remain at their zero-initialized value and do
+  // not represent a real satisfying value. satisfying_values is still populated below in
+  // that case; callers must check the return value before treating its contents as
+  // meaningful.
   if (satisfying_values) {
     // Set 0 as satisfying value for NULL and invalid signals
     std::vector<hsa_signal_value_t> satisfying_values_vec_result(signal_count, 0);
@@ -1092,7 +1098,7 @@ uint32_t hsa_amd_signal_wait_all(uint32_t signal_count, hsa_signal_t* hsa_signal
     std::copy(satisfying_values_vec_result.begin(), satisfying_values_vec_result.end(), satisfying_values);
   }
 
-  return first_satysifying_signal_idx;
+  return first_satisfying_signal_idx;
   CATCHRET(uint32_t);
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
@@ -1117,14 +1117,21 @@ uint32_t hsa_amd_signal_wait_any(uint32_t signal_count, hsa_signal_t* hsa_signal
     return std::numeric_limits<uint32_t>::max();
   }
 
-  std::vector<hsa_signal_value_t> satisfying_value_vec(1);
-  uint32_t satisfying_signal_idx =
+  // Sized to valid_signals.size() since WaitMultiple() may return/write any index in
+  // [0, valid_signals.size()), not just 0.
+  std::vector<hsa_signal_value_t> satisfying_value_vec(valid_signals.size());
+  uint32_t local_satisfying_signal_idx =
       core::Signal::WaitMultiple(valid_signals.size(), valid_signals.data(), conds, values, timeout_hint, wait_hint,
                                  satisfying_value_vec, false);
-  //  Map back the index
-  satisfying_signal_idx = valid_signal_ids[satisfying_signal_idx];
 
-  if (satisfying_value) *satisfying_value = satisfying_value_vec.at(0);
+  if (local_satisfying_signal_idx == uint32_t(-1)) {
+    return local_satisfying_signal_idx;
+  }
+
+  if (satisfying_value) *satisfying_value = satisfying_value_vec.at(local_satisfying_signal_idx);
+
+  // Map from WaitMultiple()'s local index back to the caller's original signal array index.
+  uint32_t satisfying_signal_idx = valid_signal_ids[local_satisfying_signal_idx];
 
   return satisfying_signal_idx;
   CATCHRET(uint32_t);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
@@ -1056,10 +1056,14 @@ uint32_t hsa_amd_signal_wait_all(uint32_t signal_count, hsa_signal_t* hsa_signal
   // Treat NULL and invalid signals as already satisfied their condition and skip them
   std::vector<hsa_signal_t> valid_signals;
   std::vector<uint32_t> valid_signal_ids;
+  std::vector<hsa_signal_condition_t> valid_conds;
+  std::vector<hsa_signal_value_t> valid_values;
   for (uint32_t i = 0; i < signal_count; i++){
     if (hsa_signals[i].handle != 0 && core::SharedSignal::Convert(hsa_signals[i])->IsValid()){
       valid_signals.emplace_back(hsa_signals[i]);
       valid_signal_ids.emplace_back(i);
+      valid_conds.emplace_back(conds[i]);
+      valid_values.emplace_back(values[i]);
     }
   }
 
@@ -1076,8 +1080,8 @@ uint32_t hsa_amd_signal_wait_all(uint32_t signal_count, hsa_signal_t* hsa_signal
 
   std::vector<hsa_signal_value_t> satisfying_values_vec(valid_signal_count);
   uint32_t first_satysifying_signal_idx =
-      core::Signal::WaitMultiple(valid_signal_count, valid_signals.data(), conds, values, timeout_hint, wait_hint,
-                                 satisfying_values_vec, true);
+      core::Signal::WaitMultiple(valid_signal_count, valid_signals.data(), valid_conds.data(),
+                                 valid_values.data(), timeout_hint, wait_hint, satisfying_values_vec, true);
 
   if (satisfying_values) {
     // Set 0 as satisfying value for NULL and invalid signals
@@ -1104,10 +1108,14 @@ uint32_t hsa_amd_signal_wait_any(uint32_t signal_count, hsa_signal_t* hsa_signal
   // Ignore NULL and invalid signals
   std::vector<hsa_signal_t> valid_signals;
   std::vector<uint32_t> valid_signal_ids;
+  std::vector<hsa_signal_condition_t> valid_conds;
+  std::vector<hsa_signal_value_t> valid_values;
   for (uint32_t i = 0; i < signal_count; i++){
     if (hsa_signals[i].handle != 0 && core::SharedSignal::Convert(hsa_signals[i])->IsValid()){
       valid_signals.emplace_back(hsa_signals[i]);
       valid_signal_ids.emplace_back(i);
+      valid_conds.emplace_back(conds[i]);
+      valid_values.emplace_back(values[i]);
     }
   }
 
@@ -1117,20 +1125,23 @@ uint32_t hsa_amd_signal_wait_any(uint32_t signal_count, hsa_signal_t* hsa_signal
     return std::numeric_limits<uint32_t>::max();
   }
 
-  // Sized to valid_signals.size() since WaitMultiple() may return/write any index in
-  // [0, valid_signals.size()), not just 0.
-  std::vector<hsa_signal_value_t> satisfying_value_vec(valid_signals.size());
+  // For wait-any, WaitMultiple() only ever writes the satisfying value to slot 0.
+  std::vector<hsa_signal_value_t> satisfying_value_vec(1);
   uint32_t local_satisfying_signal_idx =
-      core::Signal::WaitMultiple(valid_signals.size(), valid_signals.data(), conds, values, timeout_hint, wait_hint,
-                                 satisfying_value_vec, false);
+      core::Signal::WaitMultiple(valid_signals.size(), valid_signals.data(), valid_conds.data(),
+                                 valid_values.data(), timeout_hint, wait_hint, satisfying_value_vec, false);
 
+  // WaitMultiple() returns uint32_t(-1) on timeout (or if a signal became invalid mid-wait);
+  // there is no local index to read a satisfying value from or map back to the caller's
+  // original signal array position in that case.
   if (local_satisfying_signal_idx == uint32_t(-1)) {
     return local_satisfying_signal_idx;
   }
 
-  if (satisfying_value) *satisfying_value = satisfying_value_vec.at(local_satisfying_signal_idx);
+  if (satisfying_value) *satisfying_value = satisfying_value_vec.at(0);
 
-  // Map from WaitMultiple()'s local index back to the caller's original signal array index.
+  //  Map back the index: the INDEX returned to the caller is in the caller's ORIGINAL
+  //  signal array position, via valid_signal_ids.
   uint32_t satisfying_signal_idx = valid_signal_ids[local_satisfying_signal_idx];
 
   return satisfying_signal_idx;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/signal.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/signal.cpp
@@ -297,10 +297,13 @@ uint32_t Signal::WaitMultiple(uint32_t signal_count, const hsa_signal_t* hsa_sig
       }
       if (condition_met) {
         it = unmet_condition_ids.erase(it);
-        satisfying_values[i] = value;
-        if (!wait_on_all)
+        if (!wait_on_all) {
+          // wait-any callers only need satisfying_values[0] per WaitMultiple()'s contract.
+          satisfying_values[0] = value;
           return i;
-        else if (unmet_condition_ids.empty())
+        }
+        satisfying_values[i] = value;
+        if (unmet_condition_ids.empty())
           return 0;
       } else {
         ++it;


### PR DESCRIPTION
## Summary
Fixes an out-of-bounds read/write in `hsa_amd_signal_wait_any` that occurs whenever the satisfying signal in a multi-signal batch is at any index other than 0.

## Root Cause
`hsa_amd_signal_wait_any` allocated `satisfying_value_vec` with a fixed size of `1`:

```cpp
std::vector<hsa_signal_value_t> satisfying_value_vec(1);
uint32_t satisfying_signal_idx =
    core::Signal::WaitMultiple(valid_signals.size(), valid_signals.data(), conds, values,
                               timeout_hint, wait_hint, satisfying_value_vec, false);
...
if (satisfying_value) *satisfying_value = satisfying_value_vec.at(0);
```

But `core::Signal::WaitMultiple()` (called with `wait_on_all=false`, i.e. "wait for any") writes `satisfying_values[i] = value` and returns `i` directly, where `i` can be any index in `[0, valid_signals.size())` — whichever signal is satisfied first. Whenever `i != 0`, `WaitMultiple()` writes out of bounds into the 1-element vector, and the subsequent `.at(0)` read (even if the OOB write somehow didn't corrupt anything) returns the wrong value regardless of which signal actually satisfied.

This also missed handling `WaitMultiple()`'s `uint32_t(-1)` timeout/invalid-signal sentinel return, which would separately index `valid_signal_ids` out of bounds when mapping the result back to the caller's original array position.

## Fix
- Size `satisfying_value_vec` to `valid_signals.size()` (matching `WaitMultiple()`'s local index space), not a fixed `1`.
- Return early on the `uint32_t(-1)` sentinel before doing any indexing.
- Read the satisfying value using `WaitMultiple()`'s *local* index into `satisfying_value_vec`, then map the *index returned to the caller* through `valid_signal_ids` back to the caller's original array position — these two index spaces are different and must not be conflated (the fix separates them explicitly with comments).

Sanity-checked `hsa_amd_signal_wait_all`'s analogous code path; it already sizes its output vector correctly (`valid_signal_count`), so no equivalent fix was needed there.

## How this was found
Discovered while prototyping a batched-signal-wait completion mechanism for rocprofiler-sdk's Queue Interposition feature (tracked separately, ROCM-27290 investigation), which calls `hsa_amd_signal_wait_any` with a multi-signal batch where the satisfying index is very commonly greater than 0 (a dedicated "wake" signal is always appended at the end of the batch). Any existing caller of `hsa_amd_signal_wait_any` with more than one signal in its batch is exposed to this bug today, independent of that follow-on work.

## Testing
- Manual code-review verification of the corrected index-space separation (implementer + independent reviewer pass).
- Exercised indirectly via a downstream rocprofiler-sdk prototype that calls `hsa_amd_signal_wait_any` with multi-signal batches where the satisfying index is >0 in the common case; before this fix, that prototype produced incorrect/garbage wake-signal values, consistent with this bug. After the fix: correct behavior confirmed across `ctest` runs and repeated stress runs.
- No dedicated unit test for `hsa_amd_signal_wait_any` with a non-zero satisfying index currently exists in this repo's test suite; recommend adding one as a follow-up (happy to add if requested).

## Related
Related to ROCM-27290 (rocprofiler-sdk Queue Interposition performance investigation) but is a standalone, independently-valid bug fix.