### PR TITLE
fix(hip-tests): remove duplicate Unit_hipMemset_UnalignedKernelCornerCases entry

### DIFF
--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -796,9 +796,6 @@ memory:
   Unit_hipMemsetD8Async_KernelBuffer:
     <<: *level_2
     tags: [memset]
-  Unit_hipMemset_UnalignedKernelCornerCases:
-    <<: *level_2
-    tags: [memset]
   Unit_hipMemsetD16_UnalignedPatternFill:
     <<: *level_2
     tags: [memset]


### PR DESCRIPTION
## Summary

`develop` currently contains the `Unit_hipMemset_UnalignedKernelCornerCases`
key **twice** in `projects/hip-tests/catch/config/configs/unit/memory.yaml`
(around lines 556 and 799) — a duplicate YAML mapping key.

This happened because two PRs independently added the same missing
`check_sources.py` registration for that test case:

- #7047 (`fix(hrr)`) added it with tags `[memset, fillBuffer, unaligned]`
- #8076 (`fix(hip-tests)`) added it with tags `[memset]`

Both were squash-merged. Since the two entries landed in different
sub-sections of the mapping, git detected no textual conflict, so neither
merge flagged the collision and `develop` ended up with the key duplicated.
With a duplicate mapping key, YAML loaders keep only the last occurrence,
silently dropping the richer tag set (and stricter linters can error).

## Change

Remove the second occurrence (from #8076, `tags: [memset]`) and keep the
first (`tags: [memset, fillBuffer, unaligned]`), leaving a single entry.

## Test plan

- [x] `grep` confirms exactly one `Unit_hipMemset_UnalignedKernelCornerCases`
      entry remains in `memory.yaml`.
- [x] The remaining entry retains the fuller `[memset, fillBuffer, unaligned]`
      tags.

Made with [Cursor](https://cursor.com)