### PR TITLE
fix(rccl-tests): Guard ctaPolicy and NCCL_CTA_POLICY_ZERO

### DIFF
--- a/projects/rccl-tests/src/common.cu
+++ b/projects/rccl-tests/src/common.cu
@@ -1111,12 +1111,14 @@ testResult_t TimeTest(struct threadArgs* args, ncclDataType_t type, const char* 
           const char* algoName = NULL;
           const char* protoName = NULL;
           bool fromSymk = false;
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2,27,0)
           if (test_ncclVersion >= NCCL_VERSION(2,27,0) && local_register == SYMMETRIC_REGISTER && ctaPolicy != NCCL_CTA_POLICY_ZERO && rcclTestsGetSymkInfo) {
             if (args->collTest->getSymkInfo) {
               TESTCHECK(args->collTest->getSymkInfo(args->comms[0], args->nbytes / wordSize(type), type, op, &algo, &proto, &nchannels));
               fromSymk = true;
             }
           }
+#endif
           if (!fromSymk) {
             TESTCHECK(args->collTest->getAlgoProtoChannels(args->comms[0], args->nbytes / wordSize(type), type, &algo, &proto, &nchannels));
           }


### PR DESCRIPTION
## Motivation

Building rccl-tests against older NCCL/ROCm versions (pre-2.27) fails to compile because the algorithm/protocol/channel reporting path references symbols that only exist in NCCL 2.27.0+:

```
common.cu.cpp:1115:99: error: use of undeclared identifier 'ctaPolicy'
common.cu.cpp:1115:112: error: use of undeclared identifier 'NCCL_CTA_POLICY_ZERO'
```

The `ctaPolicy` variable is only declared under `NCCL_VERSION_CODE >= NCCL_VERSION(2,27,0)`, and `NCCL_CTA_POLICY_ZERO` is likewise only defined in NCCL 2.27.0. Referencing them unconditionally breaks the build on lower ROCm versions. This PR restores compatibility with those older toolchains.

## Technical Details

In `TimeTest()` in common.cu, the symmetric-kernel (symk) info branch inside the `output_algo_proto_channels` reporting block was guarded with a preprocessor check:

```cpp
#if NCCL_VERSION_CODE >= NCCL_VERSION(2,27,0)
  if (test_ncclVersion >= NCCL_VERSION(2,27,0) && local_register == SYMMETRIC_REGISTER && ctaPolicy != NCCL_CTA_POLICY_ZERO && rcclTestsGetSymkInfo) {
    ...
    fromSymk = true;
  }
#endif
```

- On NCCL < 2.27, the block is compiled out entirely, so `ctaPolicy` and `NCCL_CTA_POLICY_ZERO` are never referenced and the build succeeds.
- `fromSymk` remains `false`, so execution falls through to the existing `getAlgoProtoChannels()` path, preserving the prior behavior on older versions.
- On NCCL 2.27.0+, behavior is unchanged — the runtime `test_ncclVersion` check still gates the symk path as before.

The change is minimal (2 added lines, wrapping the existing condition) and has no functional impact on supported newer versions.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
ISSUE ID : https://github.com/ROCm/rocm-systems/issues/8103

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
