### PR TITLE
feat: [RCCL] test_runner structured result emission + optional PostgreSQL

### DIFF
--- a/projects/rccl/tools/scripts/test_runner/.gitignore
+++ b/projects/rccl/tools/scripts/test_runner/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+*.pyo

--- a/projects/rccl/tools/scripts/test_runner/README.md
+++ b/projects/rccl/tools/scripts/test_runner/README.md
@@ -461,6 +461,11 @@ Optional:
   --stop-on-rerun-failure   Stop testing immediately if a rerun also fails (requires --rerun-failed)
   --overwrite               Overwrite previous workspace directories
   --report-suffix SUFFIX    Suffix for report directory (default: blank)
+  --emit-results            Emit structured results (JSON/JSONL + tarball) for the dashboard
+  --results-dir DIR         Directory for emitted results + tarballs (default: <workspace>/results)
+  --run-label LABEL         Optional label stored with the emitted run (e.g. 'nightly', a PR number)
+  --db-push                 Also push results to PostgreSQL (DSN from RCCL_RESULTS_DSN); implies --emit-results
+  --db-timeout SECONDS      PostgreSQL connect + statement timeout for --db-push (default: 10)
   -h, --help                Show help message and exit
 ```
 
@@ -497,6 +502,46 @@ When `--coverage-report` is specified, the runner generates:
 - Merges profiles with `llvm-profdata`
 - Generates reports with `llvm-cov show` and `llvm-cov report`
 - Filters out irrelevant files (test/, gtest, external dependencies)
+
+## Result Emission & Dashboard
+
+The runner can emit structured, machine-readable results, either as local files
+(picked up by the dashboard's periodic sweep) or pushed directly to PostgreSQL.
+
+### Emitting results
+
+```bash
+# Local files only (durable; feeds the dashboard sweep):
+python test_runner.py -c configs/rccl_perf_tests.json --emit-results --results-dir /path/to/results
+
+# Local files + best-effort direct DB push:
+export RCCL_RESULTS_DSN='postgresql://<user>:<pass>@<host>:5432/<db>'
+python test_runner.py -c configs/rccl_perf_tests.json --db-push
+```
+
+- `--db-push` implies `--emit-results`. If the DB push fails or times out, the
+  run still succeeds and the local tarball is retained for the sweep.
+- The DSN is read only from `RCCL_RESULTS_DSN`; it is never hardcoded or written
+  into the emitted files.
+- Enabling emission also turns on per-test log capture so `busbw`/`algbw` can be
+  parsed from rccl-tests output. Default behaviour (no capture) is unchanged when
+  emission is off.
+
+### What is emitted
+
+Per invocation, under `--results-dir` (default `<workspace>/results`):
+
+- `run.json` - run manifest: RCCL SHA, host/telemetry metadata, config, env, summary.
+- `tests.jsonl` - one line per test (status PASSED/FAILED/SKIPPED/TIMEOUT, exec mode, dtype, duration).
+- `perf.jsonl` - one line per (size, place) perf row (latency, algbw, busbw).
+- `coverage.json` - llvm-cov totals (only when `--coverage-report` produced a report).
+- `<run_id>.tar.gz` and `latest.tar.gz` - self-contained snapshots the sweep pulls.
+
+Coverage is emitted only where the host has an instrumented build plus
+`llvm-profdata`/`llvm-cov`; perf and per-test results do not require them.
+
+See [`db/README.md`](db/README.md) for the database schema and the full
+emission and scrape/sweep contract.
 
 ## Examples
 

--- a/projects/rccl/tools/scripts/test_runner/README.md
+++ b/projects/rccl/tools/scripts/test_runner/README.md
@@ -464,6 +464,8 @@ Optional:
   --emit-results            Emit structured results (JSON/JSONL + tarball) for the dashboard
   --results-dir DIR         Directory for emitted results + tarballs (default: <workspace>/results)
   --run-label LABEL         Optional label stored with the emitted run (e.g. 'nightly', a PR number)
+  --tag TAG                 Tag to attach to the emitted run for dashboard filtering (repeatable)
+  --tags A,B,C              Comma-separated tags to attach to the emitted run (merged with --tag)
   --db-push                 Also push results to PostgreSQL (DSN from RCCL_RESULTS_DSN); implies --emit-results
   --db-timeout SECONDS      PostgreSQL connect + statement timeout for --db-push (default: 10)
   -h, --help                Show help message and exit
@@ -531,7 +533,7 @@ python test_runner.py -c configs/rccl_perf_tests.json --db-push
 
 Per invocation, under `--results-dir` (default `<workspace>/results`):
 
-- `run.json` - run manifest: RCCL SHA, host/telemetry metadata, config, env, summary.
+- `run.json` - run manifest: RCCL SHA, host/telemetry metadata, config, env, summary, tags.
 - `tests.jsonl` - one line per test (status PASSED/FAILED/SKIPPED/TIMEOUT, exec mode, dtype, duration).
 - `perf.jsonl` - one line per (size, place) perf row (latency, algbw, busbw).
 - `coverage.json` - llvm-cov totals (only when `--coverage-report` produced a report).
@@ -539,6 +541,18 @@ Per invocation, under `--results-dir` (default `<workspace>/results`):
 
 Coverage is emitted only where the host has an instrumented build plus
 `llvm-profdata`/`llvm-cov`; perf and per-test results do not require them.
+
+### Tagging runs
+
+Attach tags at emit time for later filtering in the dashboard:
+
+```bash
+python test_runner.py -c <config> --emit-results --tag nightly --tag mi300x
+# or: --tags nightly,mi300x
+```
+
+Tags set here are the run's initial tags. Once a run is ingested, its tags are
+mutable only by dashboard admins.
 
 See [`db/README.md`](db/README.md) for the database schema and the full
 emission and scrape/sweep contract.

--- a/projects/rccl/tools/scripts/test_runner/db/README.md
+++ b/projects/rccl/tools/scripts/test_runner/db/README.md
@@ -1,0 +1,73 @@
+# Test Runner -> results dashboard: results emission & scrape contract
+
+This documents how `test_runner.py` emits results and how the results
+dashboard consumes them.
+
+## Two writers, one schema
+
+Both paths write the same schema (`schema.sql`) and are idempotent on
+`runs.run_id`, so a run may be delivered by either or both without duplication:
+
+1. `test_runner.py --db-push` — best-effort direct push from the test host.
+2. Dashboard-side ingest job — reads scraped `*.tar.gz` and upserts.
+
+`run_id` is generated once per invocation as `YYYYMMDDThhmmssZ-<8hex>`.
+
+## Enabling emission
+
+```bash
+# Local files only (durable; feeds the hourly scrape):
+python3 test_runner.py -c configs/rccl_perf_tests.json --emit-results
+
+# Local files + best-effort direct DB push:
+export RCCL_RESULTS_DSN='postgresql://rccl_writer:***@dash-host:5432/rccl'
+python3 test_runner.py -c configs/rccl_perf_tests.json --db-push
+```
+
+- `--db-push` implies `--emit-results`.
+- If the DB push fails/times out, the run still succeeds and the local tarball is
+  retained for the scrape. The DSN is read only from `RCCL_RESULTS_DSN`; it is
+  never hardcoded or written into the emitted files.
+- Enabling emission also turns on per-test **log capture** (via `tee`), which is
+  what lets the emitter parse `busbw`/`algbw` from rccl-tests output. Default
+  behaviour (no capture) is unchanged when emission is off.
+
+## Output layout (`--results-dir`, default `<workspace>/results`)
+
+```
+results/
+  <run_id>/
+    run.json         # run manifest (sha, host, config, env, summary, coverage)
+    tests.jsonl      # one line per test result
+    perf.jsonl       # one line per (size, place) perf row, with collective/avg
+    coverage.json    # llvm-cov TOTAL percentages (if --coverage-report)
+    logs/            # captured per-test logs (+ coverage rawfiles)
+    report/          # llvm-cov HTML + function_coverage_report.txt (if generated)
+  <run_id>.tar.gz    # self-contained snapshot of <run_id>/
+  latest.tar.gz      # copy of the most recent snapshot (stable scrape target)
+  latest.json        # most recent run manifest
+  index.jsonl        # append-only: one summary line per run
+```
+
+## Scrape contract (hourly cron + scp)
+
+The dashboard host pulls new snapshots on a schedule and ingests them:
+
+```cron
+# On the dashboard host. Pulls any new run tarballs, then ingests.
+0 * * * * rsync -az --ignore-existing \
+    testhost:/path/to/results/*.tar.gz /var/lib/rccl-dashboard/incoming/ \
+    && /var/lib/rccl-dashboard/ingest.py /var/lib/rccl-dashboard/incoming
+```
+
+Notes:
+- `rsync --ignore-existing` (or `scp` of only-new files) makes the pull
+  idempotent; the ingest job is also idempotent on `run_id`.
+- Scrapers that only want the newest run can grab `latest.tar.gz` / `latest.json`.
+- `index.jsonl` lets a scraper enumerate historical runs without untarring.
+
+## Applying the schema
+
+```bash
+psql "$RCCL_RESULTS_DSN" -f schema.sql
+```

--- a/projects/rccl/tools/scripts/test_runner/db/README.md
+++ b/projects/rccl/tools/scripts/test_runner/db/README.md
@@ -13,6 +13,10 @@ Both paths write the same schema (`schema.sql`) and are idempotent on
 
 `run_id` is generated once per invocation as `YYYYMMDDThhmmssZ-<8hex>`.
 
+Runs may carry **tags** (`--tag`/`--tags`) for dashboard filtering. Tags are set
+at emit time; on re-ingest they are left untouched, so once a run is in the DB
+its tags are mutable only via the dashboard (admin-gated).
+
 ## Enabling emission
 
 ```bash
@@ -37,7 +41,7 @@ python3 test_runner.py -c configs/rccl_perf_tests.json --db-push
 ```
 results/
   <run_id>/
-    run.json         # run manifest (sha, host, config, env, summary, coverage)
+    run.json         # run manifest (sha, host, config, env, summary, coverage, tags)
     tests.jsonl      # one line per test result
     perf.jsonl       # one line per (size, place) perf row, with collective/avg
     coverage.json    # llvm-cov TOTAL percentages (if --coverage-report)

--- a/projects/rccl/tools/scripts/test_runner/db/schema.sql
+++ b/projects/rccl/tools/scripts/test_runner/db/schema.sql
@@ -1,0 +1,133 @@
+-- RCCL Test Runner -> results dashboard schema
+--
+-- Shared by two writers:
+--   1. test_runner.py --db-push  (best-effort direct push from the test host)
+--   2. the dashboard-side ingest job (reads scraped *.tar.gz -> upserts here)
+--
+-- Both writers are idempotent on runs.run_id, so re-ingesting a tarball that a
+-- direct push already landed is a no-op. run_id is generated once per test-runner
+-- invocation (see lib/results_emitter.py), so it is stable across both paths.
+--
+-- Apply with:  psql "$RCCL_RESULTS_DSN" -f schema.sql
+
+CREATE TABLE IF NOT EXISTS runs (
+    run_id           TEXT PRIMARY KEY,
+    run_number       BIGINT,             -- immutable, monotonic, DB-assigned on first insert
+    official         BOOLEAN     NOT NULL DEFAULT false,  -- CI/trusted source -> gets CI badge on timelines
+    schema_version   INTEGER     NOT NULL DEFAULT 1,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    started_at       TIMESTAMPTZ,
+    finished_at      TIMESTAMPTZ,
+    rccl_sha         TEXT,
+    rccl_branch      TEXT,
+    rocm_version     TEXT,
+    host             TEXT,               -- controller hostname
+    hosts            JSONB,              -- MPI hosts (host_list / hostfile contents)
+    gpu_arch         TEXT,               -- e.g. gfx942, gfx90a, gfx1100
+    node_names       JSONB,              -- specific compute node hostnames used by the job
+    num_nodes        INTEGER,
+    gpus_per_node    INTEGER,
+    config_name      TEXT,               -- system_configurations.name
+    config_description TEXT,
+    runner_version   TEXT,
+    label            TEXT,               -- optional --run-label
+    env              JSONB,              -- global env fingerprint
+    metadata         JSONB,              -- rich host/telemetry snapshot (versions, GPU BDFs/CUs, firmware, UALink station mask, ...)
+    summary          JSONB,              -- {total,passed,failed,timeout,skipped,duration_s}
+    ingested_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS test_results (
+    id            BIGSERIAL PRIMARY KEY,
+    run_id        TEXT NOT NULL REFERENCES runs(run_id) ON DELETE CASCADE,
+    suite         TEXT,
+    test_name     TEXT NOT NULL,
+    test_binary   TEXT,
+    is_gtest      BOOLEAN,
+    num_nodes     INTEGER,
+    gpus_per_node INTEGER,
+    num_ranks     INTEGER,
+    dtype         TEXT,
+    exec_mode     TEXT,                  -- mpi | threaded | single
+    nthreads      INTEGER,
+    status        TEXT NOT NULL,         -- PASSED | FAILED | TIMEOUT | SKIPPED
+    duration_s    DOUBLE PRECISION,
+    exit_code     INTEGER,
+    error         TEXT,
+    log_relpath   TEXT,                  -- path inside the run tarball
+    UNIQUE (run_id, suite, test_name)
+);
+
+CREATE TABLE IF NOT EXISTS perf_rows (
+    id             BIGSERIAL PRIMARY KEY,
+    run_id         TEXT NOT NULL REFERENCES runs(run_id) ON DELETE CASCADE,
+    test_result_id BIGINT REFERENCES test_results(id) ON DELETE CASCADE,
+    collective     TEXT,                 -- derived from binary (e.g. all_reduce)
+    size_bytes     BIGINT,
+    count_elements BIGINT,
+    dtype          TEXT,
+    redop          TEXT,
+    root           TEXT,
+    place          TEXT,                 -- 'out_of_place' | 'in_place'
+    time_us        DOUBLE PRECISION,
+    algbw_gbs      DOUBLE PRECISION,
+    busbw_gbs      DOUBLE PRECISION,
+    wrong          TEXT,
+    avg_busbw_gbs  DOUBLE PRECISION      -- run/test-level "Avg bus bandwidth" if present
+);
+
+CREATE TABLE IF NOT EXISTS coverage (
+    run_id         TEXT PRIMARY KEY REFERENCES runs(run_id) ON DELETE CASCADE,
+    regions_pct    DOUBLE PRECISION,
+    functions_pct  DOUBLE PRECISION,
+    lines_pct      DOUBLE PRECISION,
+    branches_pct   DOUBLE PRECISION,
+    raw            JSONB                  -- full parsed TOTAL line / extra metrics
+);
+
+CREATE TABLE IF NOT EXISTS file_coverage (
+    id             BIGSERIAL PRIMARY KEY,
+    run_id         TEXT NOT NULL REFERENCES runs(run_id) ON DELETE CASCADE,
+    filename       TEXT NOT NULL,        -- repo-relative RCCL source path
+    regions_pct    DOUBLE PRECISION,
+    lines_pct      DOUBLE PRECISION,
+    branches_pct   DOUBLE PRECISION,
+    functions_pct  DOUBLE PRECISION,
+    lines_covered  INTEGER,
+    lines_total    INTEGER,
+    regions_covered INTEGER,
+    regions_total  INTEGER,
+    branches_covered INTEGER,
+    branches_total INTEGER,
+    UNIQUE (run_id, filename)
+);
+
+CREATE INDEX IF NOT EXISTS idx_file_coverage_run      ON file_coverage(run_id);
+CREATE INDEX IF NOT EXISTS idx_file_coverage_file     ON file_coverage(filename);
+CREATE INDEX IF NOT EXISTS idx_test_results_run       ON test_results(run_id);
+CREATE INDEX IF NOT EXISTS idx_perf_rows_run          ON perf_rows(run_id);
+CREATE INDEX IF NOT EXISTS idx_perf_rows_collective   ON perf_rows(collective, size_bytes);
+CREATE INDEX IF NOT EXISTS idx_runs_created_at        ON runs(created_at);
+CREATE INDEX IF NOT EXISTS idx_runs_sha               ON runs(rccl_sha);
+CREATE INDEX IF NOT EXISTS idx_runs_host              ON runs(host);
+CREATE INDEX IF NOT EXISTS idx_runs_gpu_arch          ON runs(gpu_arch);
+
+-- Immutable, monotonic run number: DB-assigned on first insert (writers never
+-- set it), preserved across idempotent upserts, and protected from any change.
+CREATE SEQUENCE IF NOT EXISTS runs_run_number_seq;
+ALTER TABLE runs ALTER COLUMN run_number SET DEFAULT nextval('runs_run_number_seq');
+CREATE UNIQUE INDEX IF NOT EXISTS idx_runs_run_number ON runs(run_number);
+
+CREATE OR REPLACE FUNCTION runs_run_number_immutable() RETURNS trigger AS $$
+BEGIN
+    IF NEW.run_number IS DISTINCT FROM OLD.run_number THEN
+        RAISE EXCEPTION 'run_number is immutable once assigned (run_id=%)', OLD.run_id;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_runs_run_number_immutable ON runs;
+CREATE TRIGGER trg_runs_run_number_immutable
+    BEFORE UPDATE ON runs FOR EACH ROW
+    EXECUTE FUNCTION runs_run_number_immutable();

--- a/projects/rccl/tools/scripts/test_runner/db/schema.sql
+++ b/projects/rccl/tools/scripts/test_runner/db/schema.sql
@@ -31,6 +31,7 @@ CREATE TABLE IF NOT EXISTS runs (
     config_description TEXT,
     runner_version   TEXT,
     label            TEXT,               -- optional --run-label
+    tags             TEXT[],             -- --tag/--tags at emit time; mutable only by dashboard admins afterwards
     env              JSONB,              -- global env fingerprint
     metadata         JSONB,              -- rich host/telemetry snapshot (versions, GPU BDFs/CUs, firmware, UALink station mask, ...)
     summary          JSONB,              -- {total,passed,failed,timeout,skipped,duration_s}
@@ -111,6 +112,7 @@ CREATE INDEX IF NOT EXISTS idx_runs_created_at        ON runs(created_at);
 CREATE INDEX IF NOT EXISTS idx_runs_sha               ON runs(rccl_sha);
 CREATE INDEX IF NOT EXISTS idx_runs_host              ON runs(host);
 CREATE INDEX IF NOT EXISTS idx_runs_gpu_arch          ON runs(gpu_arch);
+CREATE INDEX IF NOT EXISTS idx_runs_tags              ON runs USING GIN (tags);
 
 -- Immutable, monotonic run number: DB-assigned on first insert (writers never
 -- set it), preserved across idempotent upserts, and protected from any change.

--- a/projects/rccl/tools/scripts/test_runner/lib/__init__.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/__init__.py
@@ -6,6 +6,7 @@ Provides modules for test configuration, parsing, and execution
 from .test_config import TestConfigProcessor
 from .test_parser import ArgumentParserInterface, parse_test_output
 from .test_executor import TestExecutor, ExitCode, TestResult, glob_filter_matches
+from .results_emitter import ResultsEmitter, parse_perf_output, parse_coverage_report
 
 __all__ = [
     'TestConfigProcessor',
@@ -15,6 +16,9 @@ __all__ = [
     'ExitCode',
     'TestResult',
     'glob_filter_matches',
+    'ResultsEmitter',
+    'parse_perf_output',
+    'parse_coverage_report',
 ]
 
 __version__ = '1.0.0'

--- a/projects/rccl/tools/scripts/test_runner/lib/host_metadata.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/host_metadata.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE.txt for license information
+"""
+Host metadata collector.
+
+Best-effort snapshot of the test node's hardware/software state, captured at run
+time and stored with the run so the dashboard can show exactly what a result ran
+on. Every probe is wrapped and failure-tolerant -- collection never fails the run.
+
+Scale-up fabric telemetry (UALink) is gated on capability presence: it is
+collected only when the UALink sysfs (/sys/class/drm/card*/device/ualink/...)
+exists, rather than guessing from product/arch strings. Every probe reads
+standard sysfs or ROCm CLIs; nothing here is hardcoded to a specific host,
+cluster, or product.
+"""
+
+import glob
+import os
+import re
+import socket
+import subprocess
+
+
+def _run(cmd, timeout=20):
+    """Run a command, returning stripped stdout or None. Best-effort."""
+    try:
+        out = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        return out.stdout.strip() if out.returncode == 0 else None
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def _read(path):
+    try:
+        with open(path, encoding="utf-8", errors="replace") as f:
+            return f.read().strip()
+    except OSError:
+        return None
+
+
+def _sudo_read(path_glob):
+    """Read one-or-more files (glob) that may require sudo. Returns {path: text}."""
+    result = {}
+    paths = sorted(glob.glob(path_glob))
+    for p in paths:
+        txt = _read(p)
+        if txt is None:
+            # Retry via sudo -n (non-interactive); silently skip if unavailable.
+            txt = _run(["sudo", "-n", "cat", p], timeout=10)
+        if txt is not None:
+            result[p] = txt.strip()
+    return result
+
+
+def _os_pretty_name():
+    data = _read("/etc/os-release") or ""
+    m = re.search(r'^PRETTY_NAME="?([^"\n]+)"?', data, re.MULTILINE)
+    return m.group(1) if m else None
+
+
+def _open_file_limit():
+    try:
+        import resource
+        return resource.getrlimit(resource.RLIMIT_NOFILE)[0]
+    except Exception:
+        return None
+
+
+def _gpu_arch():
+    out = _run(["rocm_agent_enumerator"], timeout=15)
+    if out:
+        for tok in out.split():
+            if tok.startswith("gfx") and tok != "gfx000":
+                return tok
+    info = _run(["rocminfo"], timeout=25) or ""
+    m = re.search(r"\bgfx[0-9a-f]+\b", info)
+    return m.group(0) if m else None
+
+
+def _compute_units():
+    info = _run(["rocminfo"], timeout=25) or ""
+    m = re.search(r"Compute Unit:\s*(\d+)", info)
+    return int(m.group(1)) if m else None
+
+
+def _gpu_bdfs():
+    """PCI BDFs of the amdgpu devices."""
+    bdfs = []
+    for path in sorted(glob.glob("/sys/bus/pci/drivers/amdgpu/0000:*")):
+        bdfs.append(os.path.basename(path))
+    return bdfs or None
+
+
+def _firmware_versions():
+    """Parse `rocm-smi --showfwinfo` into {component: version} (first GPU block)."""
+    out = _run(["rocm-smi", "--showfwinfo"], timeout=30)
+    if not out:
+        return None
+    fw = {}
+    for line in out.splitlines():
+        # e.g. "GPU[0]  : MEC FW version: 0x000000a5"
+        m = re.search(r"([A-Za-z0-9_ ]+?)\s*FW version:\s*(\S+)", line)
+        if m:
+            key = m.group(1).strip().split()[-1].lower()
+            fw.setdefault(key, m.group(2))
+    return fw or None
+
+
+def _cmdline():
+    return _read("/proc/cmdline") or ""
+
+
+def _check_iommu_pt():
+    """RCCL/RDMA want the kernel booted with iommu=pt (passthrough)."""
+    cl = _cmdline()
+    pt = "iommu=pt" in cl
+    return {
+        "status": "OK" if pt else "WARN",
+        "value": "iommu=pt" if pt else "iommu=pt not on kernel cmdline",
+        "amd_iommu_on": ("amd_iommu=on" in cl or "iommu=on" in cl),
+    }
+
+
+def _check_acs():
+    """ACS should be disabled for GPU P2P / RDMA. SrcValid+ => still enabled."""
+    out = _run(["sudo", "-n", "bash", "-c", "lspci -vvv 2>/dev/null | grep ACSCtl"], timeout=40)
+    if out is None:
+        out = _run(["bash", "-c", "lspci -vvv 2>/dev/null | grep ACSCtl"], timeout=40)
+    if not out:
+        return {"status": "SKIP", "value": "needs root / lspci"}
+    enabled = "SrcValid+" in out
+    return {"status": "WARN" if enabled else "OK",
+            "value": "ACS not disabled" if enabled else "ACS disabled"}
+
+
+def _check_limits():
+    checks = {}
+    try:
+        import resource
+        nofile = resource.getrlimit(resource.RLIMIT_NOFILE)[0]
+        checks["nofile"] = {"status": "OK" if nofile >= 1048576 else "WARN", "value": nofile}
+        memlock = resource.getrlimit(resource.RLIMIT_MEMLOCK)[0]
+        unlim = memlock == resource.RLIM_INFINITY
+        checks["memlock"] = {"status": "OK" if unlim else "WARN",
+                             "value": "unlimited" if unlim else memlock}
+    except Exception:
+        pass
+    return checks
+
+
+def _rdma_metadata():
+    """RDMA NIC (RoCE/IB) port state -- the inter-node scale-out fabric RCCL uses.
+    Passive sysfs read (no tool/root needed). Returns None if no ibverbs devices."""
+    base = "/sys/class/infiniband"
+    if not os.path.isdir(base):
+        return None
+    devices = []
+    active = total = 0
+    try:
+        devs = sorted(os.listdir(base))
+    except OSError:
+        return None
+    for dev in devs:
+        ports_dir = os.path.join(base, dev, "ports")
+        if not os.path.isdir(ports_dir):
+            continue
+        for port in sorted(os.listdir(ports_dir)):
+            p = os.path.join(ports_dir, port)
+            state = _read(os.path.join(p, "state"))
+            total += 1
+            is_active = bool(state and "ACTIVE" in state)
+            active += 1 if is_active else 0
+            devices.append({
+                "device": dev, "port": port,
+                "state": state,
+                "phys_state": _read(os.path.join(p, "phys_state")),
+                "rate": _read(os.path.join(p, "rate")),
+                "link_layer": _read(os.path.join(p, "link_layer")),
+                "active": is_active,
+            })
+    if not devices:
+        return None
+    return {"present": True, "active_ports": active, "total_ports": total, "devices": devices}
+
+
+def _xgmi_metadata():
+    """XGMI / Infinity Fabric topology -- an intra-node scale-up fabric.
+    Best-effort; records the topology matrix when XGMI links are present."""
+    topo = _run(["amd-smi", "topology"], timeout=40)
+    src = "amd-smi topology"
+    if not topo or "XGMI" not in topo.upper():
+        topo = _run(["rocm-smi", "--showtopo"], timeout=40)
+        src = "rocm-smi --showtopo"
+    if not topo or "XGMI" not in topo.upper():
+        return None
+    return {
+        "present": True,
+        "source": src,
+        "xgmi_link_mentions": topo.upper().count("XGMI"),
+        "raw": topo[:8000],
+    }
+
+
+def _ualink_metadata():
+    """UALink scale-up fabric telemetry -- gated on the UALink sysfs. Returns
+    None when absent (i.e. not a UALink-capable machine)."""
+    ualink_dirs = glob.glob("/sys/class/drm/card*/device/ualink")
+    if not ualink_dirs:
+        return None
+
+    md = {"present": True}
+
+    # Station lane-enable bitmaps: 18-char hex per GPU, 'f'=active, '0'=masked.
+    masks = _sudo_read("/sys/class/drm/card*/device/ualink/stations/lane_en_bitmap")
+    # Key by card name for readability.
+    station_mask = {}
+    for path, val in masks.items():
+        m = re.search(r"(card\d+)", path)
+        station_mask[m.group(1) if m else path] = val.strip()
+    if station_mask:
+        md["station_mask"] = station_mask
+
+    # Fabric manager version/device, best-effort (may need sudo).
+    afmctl_ver = _run(["afmctl", "--version"], timeout=15) or _run(["sudo", "-n", "afmctl", "--version"], timeout=15)
+    if afmctl_ver:
+        md["afmctl_version"] = afmctl_ver.splitlines()[0] if afmctl_ver else None
+    dev = _run(["sudo", "-n", "afmctl", "show", "device"], timeout=30)
+    if dev:
+        md["afmctl_device"] = dev
+    return md
+
+
+def collect(rocm_version=None):
+    """Collect the host metadata snapshot. `rocm_version` may be passed in from the
+    caller (test_runner already resolves it); everything else is probed here."""
+    md = {
+        "hostname": socket.gethostname(),
+        "kernel": _run(["uname", "-r"]),
+        "os": _os_pretty_name(),
+        "cmdline": _read("/proc/cmdline"),
+        "numa_balancing": _read("/proc/sys/kernel/numa_balancing"),
+        "open_file_limit": _open_file_limit(),
+        "gpu_recovery": _read("/sys/module/amdgpu/parameters/gpu_recovery"),
+    }
+
+    lsmod = _run(["lsmod"]) or ""
+    md["modules"] = {
+        "amdgpu": bool(re.search(r"^amdgpu\b", lsmod, re.MULTILINE)),
+    }
+
+    md["gpu"] = {
+        "arch": _gpu_arch(),
+        "compute_units": _compute_units(),
+        "bdfs": _gpu_bdfs(),
+    }
+
+    hip = _run(["hipconfig", "--version"], timeout=15)
+    ucx = _run(["ucx_info", "-v"], timeout=15)
+    mpi = _run(["mpirun", "--version"], timeout=15)
+    md["versions"] = {
+        "rocm": rocm_version,
+        "amdgpu": _read("/sys/module/amdgpu/version"),
+        "sbios": _read("/sys/class/dmi/id/bios_version"),
+        "kernel": md["kernel"],
+        "hip": hip.splitlines()[0] if hip else None,
+        "ucx": (re.search(r"Library version:\s*(\S+)", ucx).group(1) if ucx and re.search(r"Library version:\s*(\S+)", ucx) else None),
+        "mpi": mpi.splitlines()[0] if mpi else None,
+    }
+    fw = _firmware_versions()
+    if fw:
+        md["firmware"] = fw
+
+    # Config-correctness checks (record + flag; never gates the run).
+    md["checks"] = {
+        "iommu_pt": _check_iommu_pt(),
+        "acs": _check_acs(),
+        "numa_balancing": {
+            "status": "OK" if md.get("numa_balancing") == "0" else "WARN",
+            "value": md.get("numa_balancing"),
+        },
+        **_check_limits(),
+    }
+
+    # Scale-out fabric: RDMA NICs (RoCE/IB) -- gated on ibverbs presence.
+    rdma = _rdma_metadata()
+    md["rdma"] = rdma if rdma else {"present": False}
+
+    # Intra-node scale-up: XGMI / Infinity Fabric -- gated on XGMI topology presence.
+    xgmi = _xgmi_metadata()
+    md["xgmi"] = xgmi if xgmi else {"present": False}
+
+    # Intra-node scale-up: UALink -- gated on ualink sysfs presence.
+    ualink = _ualink_metadata()
+    md["ualink"] = ualink if ualink else {"present": False}
+
+    return md
+
+
+if __name__ == "__main__":
+    import json
+    print(json.dumps(collect(), indent=2, default=str))

--- a/projects/rccl/tools/scripts/test_runner/lib/results_emitter.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/results_emitter.py
@@ -416,16 +416,18 @@ class ResultsEmitter:
             INSERT INTO runs (run_id, schema_version, created_at, started_at,
                 finished_at, rccl_sha, rccl_branch, rocm_version, host, hosts,
                 gpu_arch, node_names, num_nodes, gpus_per_node, config_name,
-                config_description, runner_version, label, env, summary, metadata)
+                config_description, runner_version, label, tags, env, summary, metadata)
             VALUES (%(run_id)s, %(schema_version)s, %(created_at)s, %(started_at)s,
                 %(finished_at)s, %(rccl_sha)s, %(rccl_branch)s, %(rocm_version)s,
                 %(host)s, %(hosts)s, %(gpu_arch)s, %(node_names)s, %(num_nodes)s,
                 %(gpus_per_node)s, %(config_name)s, %(config_description)s,
-                %(runner_version)s, %(label)s, %(env)s, %(summary)s, %(metadata)s)
+                %(runner_version)s, %(label)s, %(tags)s, %(env)s, %(summary)s, %(metadata)s)
             ON CONFLICT (run_id) DO UPDATE SET
                 finished_at = EXCLUDED.finished_at,
                 summary     = EXCLUDED.summary,
                 ingested_at = now()
+                -- NOTE: tags intentionally NOT updated on conflict; once a run is
+                -- in the DB, tags are mutable only via the admin dashboard.
             """,
             {
                 "run_id": m["run_id"],
@@ -446,6 +448,7 @@ class ResultsEmitter:
                 "config_description": m.get("config_description"),
                 "runner_version": m.get("emitter_version"),
                 "label": m.get("label"),
+                "tags": m.get("tags"),  # list -> TEXT[]; None -> NULL
                 "env": json.dumps(m.get("env")) if m.get("env") is not None else None,
                 "summary": json.dumps(m.get("summary")) if m.get("summary") is not None else None,
                 "metadata": json.dumps(m.get("metadata")) if m.get("metadata") is not None else None,

--- a/projects/rccl/tools/scripts/test_runner/lib/results_emitter.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/results_emitter.py
@@ -1,0 +1,554 @@
+#!/usr/bin/env python3
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE.txt for license information
+"""
+Results Emitter
+
+Structured, machine-readable result emission for the RCCL test runner. Feeds the
+results dashboard.
+
+Two independent sinks, both driven off the same in-memory records so they never
+diverge:
+
+  1. Local files (always, when --emit-results is set) -- the durable source of
+     truth. A per-run directory of JSON/JSONL plus a ``<run_id>.tar.gz`` snapshot
+     and a stable ``latest.tar.gz`` that an hourly ``cron`` + ``scp`` job on the
+     dashboard host scrapes.
+
+  2. PostgreSQL (optional, when --db-push is set) -- best effort. If the connect
+     or write fails or times out we log a warning and carry on; the local tarball
+     is still written, so the dashboard-side ingest job can pick the run up on the
+     next scrape. The DB push is never allowed to fail the test run.
+
+The DSN is read from the ``RCCL_RESULTS_DSN`` environment variable (libpq URL or
+key/value string). It is never hardcoded and never written to the emitted files.
+"""
+
+import datetime
+import json
+import logging
+import os
+import re
+import shutil
+import socket
+import subprocess
+import tarfile
+
+log = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+EMITTER_VERSION = "1.0.0"
+
+# rccl-tests binary name -> logical collective name.
+_COLLECTIVE_FROM_BINARY = {
+    "all_reduce_perf": "all_reduce",
+    "all_gather_perf": "all_gather",
+    "alltoall_perf": "alltoall",
+    "alltoallv_perf": "alltoallv",
+    "broadcast_perf": "broadcast",
+    "gather_perf": "gather",
+    "scatter_perf": "scatter",
+    "reduce_perf": "reduce",
+    "reduce_scatter_perf": "reduce_scatter",
+    "sendrecv_perf": "sendrecv",
+    "hypercube_perf": "hypercube",
+}
+
+
+def collective_from_binary(binary):
+    """Map an rccl-tests perf binary name to a logical collective name."""
+    if not binary:
+        return None
+    base = os.path.basename(str(binary))
+    if base in _COLLECTIVE_FROM_BINARY:
+        return _COLLECTIVE_FROM_BINARY[base]
+    # Fall back to trimming a trailing _perf.
+    return base[:-5] if base.endswith("_perf") else base
+
+
+def _to_float(tok):
+    try:
+        return float(tok)
+    except (TypeError, ValueError):
+        return None
+
+
+def parse_perf_output(text):
+    """
+    Parse rccl-tests perf table output into structured rows.
+
+    rccl-tests prints two performance triplets per size -- out-of-place then
+    in-place -- each ``time algbw busbw #wrong``. Leading columns are
+    ``size count type`` and, for reduction collectives, ``redop root``. We anchor
+    on the trailing 8 numeric columns so the parser works for both reduction and
+    non-reduction collectives regardless of how many label columns precede them.
+
+    Returns (rows, avg_busbw) where rows is a list of per-(size, place) dicts and
+    avg_busbw is the run's "Avg bus bandwidth" summary line if present.
+    """
+    rows = []
+    avg_busbw = None
+    if not text:
+        return rows, avg_busbw
+
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        if line.startswith("#"):
+            m = re.search(r"Avg bus bandwidth\s*:\s*([0-9.]+)", line)
+            if m:
+                avg_busbw = _to_float(m.group(1))
+            continue
+
+        toks = line.split()
+        # Need at least: size count type + 8 trailing perf columns.
+        if len(toks) < 11:
+            continue
+        if not toks[0].isdigit() or not toks[1].isdigit():
+            continue
+
+        tail = toks[-8:]
+        oop_time, oop_alg, oop_bus = _to_float(tail[0]), _to_float(tail[1]), _to_float(tail[2])
+        ip_time, ip_alg, ip_bus = _to_float(tail[4]), _to_float(tail[5]), _to_float(tail[6])
+        # A real data row has numeric perf columns; header/units lines do not.
+        if None in (oop_time, oop_alg, oop_bus, ip_time, ip_alg, ip_bus):
+            continue
+
+        size = int(toks[0])
+        count = int(toks[1])
+        dtype = toks[2]
+        mid = toks[3:len(toks) - 8]  # 0..2 of {redop, root}
+        redop = mid[0] if len(mid) >= 1 else None
+        root = mid[1] if len(mid) >= 2 else None
+
+        rows.append({
+            "size_bytes": size, "count_elements": count, "dtype": dtype,
+            "redop": redop, "root": root, "place": "out_of_place",
+            "time_us": oop_time, "algbw_gbs": oop_alg, "busbw_gbs": oop_bus,
+            "wrong": tail[3],
+        })
+        rows.append({
+            "size_bytes": size, "count_elements": count, "dtype": dtype,
+            "redop": redop, "root": root, "place": "in_place",
+            "time_us": ip_time, "algbw_gbs": ip_alg, "busbw_gbs": ip_bus,
+            "wrong": tail[7],
+        })
+
+    return rows, avg_busbw
+
+
+def parse_coverage_report(report_txt_path):
+    """
+    Parse the ``TOTAL`` line of an llvm-cov ``report`` text file into coverage
+    percentages. llvm-cov emits, in order, region / function / line / branch
+    coverage, each with a trailing ``NN.NN%`` column. Returns None if the file is
+    absent or has no TOTAL line.
+    """
+    if not report_txt_path or not os.path.isfile(report_txt_path):
+        return None
+    try:
+        with open(report_txt_path, encoding="utf-8", errors="replace") as f:
+            lines = f.readlines()
+    except OSError:
+        return None
+
+    total_line = next((ln for ln in lines if ln.strip().startswith("TOTAL")), None)
+    if not total_line:
+        return None
+
+    pcts = [float(p) for p in re.findall(r"([0-9]+\.[0-9]+)%", total_line)]
+    # Region, Function, Line, Branch (branch may be absent in older llvm-cov).
+    keys = ["regions_pct", "functions_pct", "lines_pct", "branches_pct"]
+    cov = {k: (pcts[i] if i < len(pcts) else None) for i, k in enumerate(keys)}
+    cov["raw"] = {"total_line": total_line.strip(), "percents": pcts}
+    return cov
+
+
+def git_info(start_dir):
+    """Return (sha, branch) for the git repo containing start_dir, or (None, None).
+
+    Normal pipeline runs build a named branch, so branch is e.g. 'develop'. When
+    the checkout is on a raw commit/ref, git reports the branch as 'HEAD'; record
+    it explicitly as 'detached (<short-sha>)' so it reads as detached-HEAD state
+    rather than a branch literally named 'HEAD'."""
+    def _git(*args):
+        try:
+            out = subprocess.run(
+                ["git", "-C", start_dir, *args],
+                capture_output=True, text=True, timeout=10,
+            )
+            return out.stdout.strip() if out.returncode == 0 else None
+        except (OSError, subprocess.SubprocessError):
+            return None
+
+    sha = _git("rev-parse", "HEAD")
+    branch = _git("rev-parse", "--abbrev-ref", "HEAD")
+    if branch == "HEAD":
+        branch = f"detached ({sha[:12]})" if sha else "detached HEAD"
+    return sha, branch
+
+
+def gpu_arch():
+    """Best-effort GPU arch (e.g. gfx942). Tries rocm_agent_enumerator then rocminfo."""
+    try:
+        out = subprocess.run(["rocm_agent_enumerator"], capture_output=True, text=True, timeout=15)
+        if out.returncode == 0:
+            for tok in out.stdout.split():
+                if tok.startswith("gfx") and tok != "gfx000":
+                    return tok
+    except (OSError, subprocess.SubprocessError):
+        pass
+    try:
+        out = subprocess.run(["rocminfo"], capture_output=True, text=True, timeout=20)
+        if out.returncode == 0:
+            m = re.search(r"\bgfx[0-9a-f]+\b", out.stdout)
+            if m:
+                return m.group(0)
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return None
+
+
+def node_names_from_mpi_hosts(mpi_hosts):
+    """Distinct compute node hostnames a job used, from SLURM host_list or a hostfile."""
+    if not mpi_hosts:
+        return []
+    seen = []
+    if "host_list" in mpi_hosts:
+        for part in str(mpi_hosts["host_list"]).split(","):
+            host = part.strip().split(":")[0].strip()
+            if host and host not in seen:
+                seen.append(host)
+    elif "hostfile" in mpi_hosts:
+        try:
+            with open(mpi_hosts["hostfile"], encoding="utf-8", errors="replace") as hf:
+                for line in hf:
+                    line = line.split("#")[0].strip()
+                    if not line:
+                        continue
+                    host = line.split()[0].strip()
+                    if host and host not in seen:
+                        seen.append(host)
+        except OSError:
+            pass
+    return seen
+
+
+def _rocm_version(rocm_path):
+    for rel in (".info/version", ".info/version-dev"):
+        p = os.path.join(rocm_path, rel)
+        try:
+            if os.path.isfile(p):
+                with open(p, encoding="utf-8", errors="replace") as f:
+                    return f.read().strip()
+        except OSError:
+            pass
+    return None
+
+
+def _atomic_write(path, text):
+    tmp = f"{path}.tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        f.write(text)
+    os.replace(tmp, path)
+
+
+class ResultsEmitter:
+    """Collects run + test + perf + coverage records and emits them locally and
+    (optionally) to PostgreSQL."""
+
+    def __init__(self, run_manifest, results_dir):
+        self.manifest = dict(run_manifest)
+        self.manifest.setdefault("schema_version", SCHEMA_VERSION)
+        self.manifest.setdefault("emitter_version", EMITTER_VERSION)
+        self.results_dir = results_dir
+        self.run_id = self.manifest["run_id"]
+        self.tests = []   # list of test_result dicts (+ nested "perf_rows")
+
+    def add_test(self, record):
+        """Attach one test result. If record has a readable ``log_file`` and looks
+        like a perf (non-gtest) test, parse perf rows out of its captured log."""
+        rec = dict(record)
+        perf_rows = []
+        avg_busbw = None
+        log_file = rec.get("log_file")
+        if log_file and os.path.isfile(log_file) and not rec.get("is_gtest", True):
+            try:
+                with open(log_file, encoding="utf-8", errors="replace") as f:
+                    perf_rows, avg_busbw = parse_perf_output(f.read())
+            except OSError as e:
+                log.warning("results_emitter: could not read log %s: %s", log_file, e)
+        collective = collective_from_binary(rec.get("binary"))
+        for row in perf_rows:
+            row["collective"] = collective
+            row["avg_busbw_gbs"] = avg_busbw
+        rec["perf_rows"] = perf_rows
+        # Store log path relative to the run dir for portability in the tarball.
+        if log_file:
+            rec["log_relpath"] = os.path.join("logs", os.path.basename(log_file))
+        self.tests.append(rec)
+
+    def set_coverage(self, coverage):
+        if coverage:
+            self.manifest["coverage"] = coverage
+
+    def finalize_summary(self, summary):
+        self.manifest["summary"] = summary
+        self.manifest.setdefault(
+            "finished_at", datetime.datetime.now(datetime.timezone.utc).isoformat()
+        )
+
+    # -- local emission (durable) ------------------------------------------
+    def write_local(self, log_dir=None, report_dir=None):
+        """Write the per-run directory, roll a ``<run_id>.tar.gz`` snapshot,
+        refresh ``latest.tar.gz``/``latest.json`` and append to ``index.jsonl``.
+        Returns the tarball path (or None on failure)."""
+        try:
+            os.makedirs(self.results_dir, exist_ok=True)
+            run_dir = os.path.join(self.results_dir, self.run_id)
+            os.makedirs(run_dir, exist_ok=True)
+
+            _atomic_write(os.path.join(run_dir, "run.json"),
+                          json.dumps(self.manifest, indent=2, default=str))
+
+            with open(os.path.join(run_dir, "tests.jsonl"), "w", encoding="utf-8") as f:
+                for t in self.tests:
+                    slim = {k: v for k, v in t.items() if k != "perf_rows"}
+                    f.write(json.dumps(slim, default=str) + "\n")
+
+            with open(os.path.join(run_dir, "perf.jsonl"), "w", encoding="utf-8") as f:
+                for t in self.tests:
+                    for row in t.get("perf_rows", []):
+                        out = dict(row)
+                        out["suite"] = t.get("suite")
+                        out["test_name"] = t.get("test_name")
+                        f.write(json.dumps(out, default=str) + "\n")
+
+            if self.manifest.get("coverage"):
+                _atomic_write(os.path.join(run_dir, "coverage.json"),
+                              json.dumps(self.manifest["coverage"], indent=2, default=str))
+
+            # Bundle captured logs + coverage report into the run dir so the
+            # tarball is self-contained for the dashboard scrape.
+            if log_dir and os.path.isdir(log_dir):
+                dst = os.path.join(run_dir, "logs")
+                shutil.copytree(log_dir, dst, dirs_exist_ok=True)
+            if report_dir and os.path.isdir(report_dir):
+                dst = os.path.join(run_dir, "report")
+                shutil.copytree(report_dir, dst, dirs_exist_ok=True)
+
+            tarball = os.path.join(self.results_dir, f"{self.run_id}.tar.gz")
+            tmp_tar = f"{tarball}.tmp"
+            with tarfile.open(tmp_tar, "w:gz") as tar:
+                tar.add(run_dir, arcname=self.run_id)
+            os.replace(tmp_tar, tarball)
+
+            # Stable scrape targets. Write latest.tar.gz atomically (tmp + replace)
+            # so a concurrent scraper never observes a partially written gzip.
+            latest_tar = os.path.join(self.results_dir, "latest.tar.gz")
+            tmp_latest = f"{latest_tar}.tmp"
+            shutil.copyfile(tarball, tmp_latest)
+            os.replace(tmp_latest, latest_tar)
+            _atomic_write(os.path.join(self.results_dir, "latest.json"),
+                          json.dumps(self.manifest, indent=2, default=str))
+
+            index_line = json.dumps({
+                "run_id": self.run_id,
+                "created_at": self.manifest.get("created_at"),
+                "rccl_sha": self.manifest.get("rccl_sha"),
+                "tarball": os.path.basename(tarball),
+                "summary": self.manifest.get("summary"),
+            }, default=str)
+            with open(os.path.join(self.results_dir, "index.jsonl"), "a", encoding="utf-8") as f:
+                f.write(index_line + "\n")
+
+            log.info("results_emitter: wrote local results + tarball: %s", tarball)
+            print(f"Results written: {tarball}")
+            return tarball
+        except Exception as e:  # never let emission break the run
+            log.warning("results_emitter: local write failed: %s", e)
+            print(f"WARNING: results emission (local) failed: {e}")
+            return None
+
+    # -- optional PostgreSQL push (best effort) ----------------------------
+    def push_postgres(self, dsn=None, timeout=10):
+        """Push records to PostgreSQL. Best effort: any failure/timeout is logged
+        and swallowed so the test run's exit status is unaffected. Idempotent on
+        run_id."""
+        dsn = dsn or os.environ.get("RCCL_RESULTS_DSN")
+        if not dsn:
+            print("WARNING: --db-push set but RCCL_RESULTS_DSN is empty; skipping DB push")
+            return False
+
+        connect, driver = _load_pg_driver()
+        if connect is None:
+            print("WARNING: no PostgreSQL driver (psycopg / psycopg2) available; "
+                  "skipping DB push. Local tarball still written.")
+            return False
+
+        conn = None
+        try:
+            conn = connect(dsn, timeout)
+            with conn:
+                with conn.cursor() as cur:
+                    cur.execute(f"SET statement_timeout = {int(timeout) * 1000}")
+                    self._upsert(cur)
+            print("Results pushed to PostgreSQL")
+            return True
+        except Exception as e:  # graceful: local tarball is the source of truth
+            log.warning("results_emitter: DB push failed (%s): %s", driver, e)
+            print(f"WARNING: DB push failed ({driver}): {e}. "
+                  "Local tarball retained for the dashboard scrape.")
+            return False
+        finally:
+            if conn is not None:
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+
+    def _upsert(self, cur):
+        m = self.manifest
+        cur.execute(
+            """
+            INSERT INTO runs (run_id, schema_version, created_at, started_at,
+                finished_at, rccl_sha, rccl_branch, rocm_version, host, hosts,
+                gpu_arch, node_names, num_nodes, gpus_per_node, config_name,
+                config_description, runner_version, label, env, summary, metadata)
+            VALUES (%(run_id)s, %(schema_version)s, %(created_at)s, %(started_at)s,
+                %(finished_at)s, %(rccl_sha)s, %(rccl_branch)s, %(rocm_version)s,
+                %(host)s, %(hosts)s, %(gpu_arch)s, %(node_names)s, %(num_nodes)s,
+                %(gpus_per_node)s, %(config_name)s, %(config_description)s,
+                %(runner_version)s, %(label)s, %(env)s, %(summary)s, %(metadata)s)
+            ON CONFLICT (run_id) DO UPDATE SET
+                finished_at = EXCLUDED.finished_at,
+                summary     = EXCLUDED.summary,
+                ingested_at = now()
+            """,
+            {
+                "run_id": m["run_id"],
+                "schema_version": m.get("schema_version", SCHEMA_VERSION),
+                "created_at": m.get("created_at"),
+                "started_at": m.get("started_at"),
+                "finished_at": m.get("finished_at"),
+                "rccl_sha": m.get("rccl_sha"),
+                "rccl_branch": m.get("rccl_branch"),
+                "rocm_version": m.get("rocm_version"),
+                "host": m.get("host"),
+                "hosts": json.dumps(m.get("hosts")) if m.get("hosts") is not None else None,
+                "gpu_arch": m.get("gpu_arch"),
+                "node_names": json.dumps(m.get("node_names")) if m.get("node_names") is not None else None,
+                "num_nodes": m.get("num_nodes"),
+                "gpus_per_node": m.get("gpus_per_node"),
+                "config_name": m.get("config_name"),
+                "config_description": m.get("config_description"),
+                "runner_version": m.get("emitter_version"),
+                "label": m.get("label"),
+                "env": json.dumps(m.get("env")) if m.get("env") is not None else None,
+                "summary": json.dumps(m.get("summary")) if m.get("summary") is not None else None,
+                "metadata": json.dumps(m.get("metadata")) if m.get("metadata") is not None else None,
+            },
+        )
+
+        for t in self.tests:
+            cur.execute(
+                """
+                INSERT INTO test_results (run_id, suite, test_name, test_binary,
+                    is_gtest, num_nodes, gpus_per_node, num_ranks, dtype, exec_mode,
+                    nthreads, status, duration_s, exit_code, error, log_relpath)
+                VALUES (%(run_id)s, %(suite)s, %(test_name)s, %(test_binary)s,
+                    %(is_gtest)s, %(num_nodes)s, %(gpus_per_node)s, %(num_ranks)s,
+                    %(dtype)s, %(exec_mode)s, %(nthreads)s, %(status)s, %(duration_s)s,
+                    %(exit_code)s, %(error)s, %(log_relpath)s)
+                ON CONFLICT (run_id, suite, test_name) DO UPDATE SET
+                    status = EXCLUDED.status, duration_s = EXCLUDED.duration_s,
+                    exit_code = EXCLUDED.exit_code, error = EXCLUDED.error
+                RETURNING id
+                """,
+                {
+                    "run_id": m["run_id"],
+                    "suite": t.get("suite"),
+                    "test_name": t.get("test_name"),
+                    "test_binary": t.get("binary"),
+                    "is_gtest": t.get("is_gtest"),
+                    "num_nodes": t.get("num_nodes"),
+                    "gpus_per_node": t.get("num_gpus"),
+                    "num_ranks": t.get("num_ranks"),
+                    "dtype": t.get("dtype"),
+                    "exec_mode": t.get("exec_mode"),
+                    "nthreads": t.get("nthreads"),
+                    "status": t.get("status") or t.get("result"),
+                    "duration_s": t.get("duration_s") or t.get("duration"),
+                    "exit_code": t.get("exit_code"),
+                    "error": t.get("error"),
+                    "log_relpath": t.get("log_relpath"),
+                },
+            )
+            test_result_id = cur.fetchone()[0]
+
+            # Re-ingest safety: clear any prior perf rows for this test result.
+            cur.execute("DELETE FROM perf_rows WHERE test_result_id = %s", (test_result_id,))
+            for row in t.get("perf_rows", []):
+                cur.execute(
+                    """
+                    INSERT INTO perf_rows (run_id, test_result_id, collective,
+                        size_bytes, count_elements, dtype, redop, root, place,
+                        time_us, algbw_gbs, busbw_gbs, wrong, avg_busbw_gbs)
+                    VALUES (%(run_id)s, %(trid)s, %(collective)s, %(size_bytes)s,
+                        %(count_elements)s, %(dtype)s, %(redop)s, %(root)s,
+                        %(place)s, %(time_us)s, %(algbw_gbs)s, %(busbw_gbs)s,
+                        %(wrong)s, %(avg_busbw_gbs)s)
+                    """,
+                    {"run_id": m["run_id"], "trid": test_result_id, **row},
+                )
+
+        cov = m.get("coverage")
+        if cov:
+            cur.execute(
+                """
+                INSERT INTO coverage (run_id, regions_pct, functions_pct,
+                    lines_pct, branches_pct, raw)
+                VALUES (%(run_id)s, %(regions_pct)s, %(functions_pct)s,
+                    %(lines_pct)s, %(branches_pct)s, %(raw)s)
+                ON CONFLICT (run_id) DO UPDATE SET
+                    regions_pct = EXCLUDED.regions_pct,
+                    functions_pct = EXCLUDED.functions_pct,
+                    lines_pct = EXCLUDED.lines_pct,
+                    branches_pct = EXCLUDED.branches_pct,
+                    raw = EXCLUDED.raw
+                """,
+                {
+                    "run_id": m["run_id"],
+                    "regions_pct": cov.get("regions_pct"),
+                    "functions_pct": cov.get("functions_pct"),
+                    "lines_pct": cov.get("lines_pct"),
+                    "branches_pct": cov.get("branches_pct"),
+                    "raw": json.dumps(cov.get("raw")) if cov.get("raw") is not None else None,
+                },
+            )
+
+
+def _load_pg_driver():
+    """Return (connect_fn, driver_name). connect_fn(dsn, timeout) -> connection.
+    Tries psycopg (v3) then psycopg2. Returns (None, None) if neither is present."""
+    try:
+        import psycopg  # type: ignore
+
+        def _connect(dsn, timeout):
+            return psycopg.connect(dsn, connect_timeout=int(timeout))
+
+        return _connect, "psycopg"
+    except ImportError:
+        pass
+    try:
+        import psycopg2  # type: ignore
+
+        def _connect(dsn, timeout):
+            return psycopg2.connect(dsn, connect_timeout=int(timeout))
+
+        return _connect, "psycopg2"
+    except ImportError:
+        pass
+    return None, None

--- a/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
@@ -296,6 +296,14 @@ class TestExecutor:
         self.test_durations = []
         self.test_suites = []
 
+        # Structured result emission (dashboard). Enabling either --emit-results or
+        # --db-push turns on per-test log capture so perf output can be parsed.
+        self.emit_enabled = bool(
+            getattr(args, "emit_results", False) or getattr(args, "db_push", False)
+        )
+        self.test_records = []       # rich per-test records for the emitter
+        self._emit_log_counter = 0   # keeps captured-log filenames unique
+
         # Rerun tracking
         self.failed_test_info = []  # Store info needed to rerun failed tests
         self.rerun_results = []
@@ -357,6 +365,13 @@ class TestExecutor:
                 print(f"  (Custom path via {'--build-dir' if self.args.build_dir else 'RCCL_LIB_PATH/RCCL_BUILD_DIR'})")
             print(f"Log directory:    {self.log_dir}")
             print(f"Report directory: {self.report_dir}")
+
+    def _emit_log_path(self, test_name):
+        """Unique per-test captured-log path under log_dir (used when result
+        emission is enabled)."""
+        self._emit_log_counter += 1
+        safe = re.sub(r'[^A-Za-z0-9_.-]+', '_', str(test_name or "test"))
+        return os.path.join(self.log_dir, f"{self._emit_log_counter:04d}_{safe}.log")
 
     @property
     def mpi_hostfile(self):
@@ -1032,6 +1047,16 @@ class TestExecutor:
         test_args = test_config.get("command_args", "")
         custom_args = f"{base_args} {test_args}".strip()
 
+        # rccl-tests dtype flag (-d <type>) for result emission; None for gtests.
+        _dtype_match = re.search(r'(?:^|\s)-d\s+(\S+)', custom_args)
+        perf_dtype = _dtype_match.group(1) if _dtype_match else None
+
+        # Execution mode: MPI (>1 rank -> mpirun) vs single-process multithreaded
+        # (-t N) vs single. Recorded per test so results are attributable.
+        _t_match = re.search(r'(?:^|\s)-t\s+(\d+)', custom_args)
+        perf_nthreads = int(_t_match.group(1)) if _t_match else 1
+        exec_mode = "mpi" if num_ranks > 1 else ("threaded" if perf_nthreads > 1 else "single")
+
         # Merge environment variables
         merged_env = {
             **self.global_env,
@@ -1339,14 +1364,30 @@ class TestExecutor:
         # subprocess.run(timeout=...) only SIGKILLs the immediate /bin/sh child,
         # leaving mpirun and all of its ranks running (and holding the GPUs),
         # which is exactly the orphaned-process behaviour seen on timeout.
+        # When result emission is enabled, tee output to a per-test log so perf
+        # (busbw/algbw) numbers can be parsed afterwards, while still streaming to
+        # the console. ``set -o pipefail`` keeps the pipeline's exit status equal to
+        # the test's (not tee's). Default behaviour (inherited stdout, no capture)
+        # is unchanged when emission is off.
+        emit_log_path = None
         start_time = time.time()
-        proc = subprocess.Popen(
-            cmd,
-            shell=True,
-            cwd=os.path.join(self.build_dir, "test"),
-            env=env,
-            start_new_session=True,
-        )
+        if self.emit_enabled:
+            emit_log_path = self._emit_log_path(test_name)
+            wrapped = f"set -o pipefail; ({cmd}) 2>&1 | tee {shlex.quote(emit_log_path)}"
+            proc = subprocess.Popen(
+                ["bash", "-c", wrapped],
+                cwd=os.path.join(self.build_dir, "test"),
+                env=env,
+                start_new_session=True,
+            )
+        else:
+            proc = subprocess.Popen(
+                cmd,
+                shell=True,
+                cwd=os.path.join(self.build_dir, "test"),
+                env=env,
+                start_new_session=True,
+            )
         try:
             try:
                 returncode = proc.wait(timeout=timeout if timeout > 0 else None)
@@ -1360,6 +1401,10 @@ class TestExecutor:
                     "result": TestResult.RESULT_TIMEOUT.value,
                     "duration": duration,
                     "error": f"Test timed out after {timeout} seconds",
+                    "binary": binary, "is_gtest": is_gtest, "dtype": perf_dtype,
+                    "num_nodes": num_nodes, "num_gpus": num_gpus,
+                    "num_ranks": num_ranks, "log_file": emit_log_path,
+                    "exec_mode": exec_mode, "nthreads": perf_nthreads,
                 }
             except KeyboardInterrupt:
                 # Make sure Ctrl-C tears down the whole MPI job, not just the shell.
@@ -1397,6 +1442,10 @@ class TestExecutor:
                 "result": test_result,
                 "duration": duration,
                 "exit_code": int(returncode) if returncode is not None else -1,
+                "binary": binary, "is_gtest": is_gtest, "dtype": perf_dtype,
+                "num_nodes": num_nodes, "num_gpus": num_gpus,
+                "num_ranks": num_ranks, "log_file": emit_log_path,
+                "exec_mode": exec_mode, "nthreads": perf_nthreads,
             }
         finally:
             if gtest_json_path:
@@ -1641,6 +1690,12 @@ class TestExecutor:
             self.test_results.append(result["result"])
             self.test_durations.append(result["duration"])
             self.test_suites.append(suite_name)
+
+            if self.emit_enabled:
+                record = dict(result)
+                record["suite"] = suite_name
+                record["test_name"] = test_name
+                self.test_records.append(record)
 
             # If test failed and rerun flag is set, rerun immediately
             if self.args.rerun_failed and result["result"] in [TestResult.RESULT_FAILED.value, TestResult.RESULT_TIMEOUT.value]:
@@ -2151,4 +2206,118 @@ class TestExecutor:
         print(f"Report directory: {self.report_dir}")
         print(f"HTML report: {self.report_dir}/index.html")
         print(f"Text report: {text_report}")
+
+    def emit_results(self):
+        """Emit structured results for the results dashboard.
+
+        Always writes local JSON/JSONL + a .tar.gz snapshot (the durable source of
+        truth). When --db-push is set, additionally pushes to PostgreSQL on a best
+        effort basis -- a DB failure/timeout is logged but never fails the run.
+
+        No-op unless --emit-results or --db-push was passed.
+        """
+        if not self.emit_enabled:
+            return
+
+        import socket
+        import uuid
+        from lib import results_emitter as re_mod
+        from lib import host_metadata
+
+        print(f"\n{'='*80}")
+        print("EMITTING RESULTS")
+        print(f"{'='*80}")
+
+        stamp = datetime.datetime.now(datetime.timezone.utc)
+        run_id = f"{stamp.strftime('%Y%m%dT%H%M%SZ')}-{uuid.uuid4().hex[:8]}"
+
+        sha, branch = re_mod.git_info(os.path.dirname(os.path.abspath(__file__)))
+
+        # num_nodes: largest node count seen across recorded tests (falls back to 1).
+        node_counts = [r.get("num_nodes") for r in self.test_records
+                       if isinstance(r.get("num_nodes"), int)]
+        num_nodes = max(node_counts) if node_counts else 1
+
+        sys_cfg = {}
+        try:
+            sys_cfg = self.config_processor.config.get("system_configurations", {}) or {}
+        except AttributeError:
+            sys_cfg = {}
+
+        def _redact_sensitive_env(env):
+            # Persist env for debugging, but mask values of secret-like keys so
+            # tokens/passwords/DSNs never land in the tarball or DB.
+            if not env:
+                return None
+            sensitive = re.compile(r"(?i)(pass|secret|token|api[_-]?key|access[_-]?key|credential|dsn)")
+            return {k: ("***redacted***" if sensitive.search(k) else v) for k, v in env.items()}
+
+        manifest = {
+            "run_id": run_id,
+            "created_at": stamp.isoformat(),
+            "started_at": stamp.isoformat(),
+            "rccl_sha": sha,
+            "rccl_branch": branch,
+            "rocm_version": re_mod._rocm_version(self._rocm_root()),
+            "host": socket.gethostname(),
+            "hosts": self.mpi_hosts or None,
+            "gpu_arch": re_mod.gpu_arch(),
+            "node_names": re_mod.node_names_from_mpi_hosts(self.mpi_hosts) or [socket.gethostname()],
+            "num_nodes": num_nodes,
+            "gpus_per_node": self.gpus_per_node or None,
+            "config_name": sys_cfg.get("name"),
+            "config_description": sys_cfg.get("description"),
+            "label": getattr(self.args, "run_label", "") or None,
+            "env": _redact_sensitive_env(self.global_env),
+        }
+
+        # Rich host/telemetry snapshot (best-effort; scale-up fabric gated on capability).
+        try:
+            md = host_metadata.collect(rocm_version=re_mod._rocm_version(self._rocm_root()))
+
+            # RCCL build type (perf configs should use a Release build).
+            install_flags = self.build_config.get("install_flags", []) if isinstance(self.build_config, dict) else []
+            if getattr(self, "using_custom_lib", False):
+                build_type = "custom"
+            elif any(f in install_flags for f in ("--debug", "--debug-fast")):
+                build_type = "debug"
+            else:
+                build_type = "release"
+            md["rccl_build_type"] = build_type
+            md["mpi_impl"] = self.mpi_impl
+            md.setdefault("checks", {})["release_build"] = {
+                "status": "OK" if build_type == "release" else ("SKIP" if build_type == "custom" else "WARN"),
+                "value": build_type + (" (perf should use release)" if build_type == "debug" else ""),
+            }
+            manifest["metadata"] = md
+        except Exception as e:
+            print(f"WARNING: host metadata collection failed: {e}")
+
+        results_dir = (getattr(self.args, "results_dir", "") or
+                       os.path.join(self.workspace_dir, "results"))
+
+        emitter = re_mod.ResultsEmitter(manifest, results_dir)
+        for record in self.test_records:
+            emitter.add_test(record)
+
+        # Attach coverage if a report was generated this run.
+        cov = re_mod.parse_coverage_report(
+            os.path.join(self.report_dir, "function_coverage_report.txt")
+        )
+        emitter.set_coverage(cov)
+
+        summary = {
+            "total": len(self.test_results),
+            "passed": self.test_results.count(TestResult.RESULT_PASSED.value),
+            "failed": self.test_results.count(TestResult.RESULT_FAILED.value),
+            "timeout": self.test_results.count(TestResult.RESULT_TIMEOUT.value),
+            "skipped": self.test_results.count(TestResult.RESULT_SKIPPED.value),
+            "duration_s": sum(self.test_durations) if self.test_durations else 0,
+        }
+        emitter.finalize_summary(summary)
+
+        emitter.write_local(log_dir=self.log_dir, report_dir=self.report_dir)
+
+        if getattr(self.args, "db_push", False):
+            emitter.push_postgres(timeout=getattr(self.args, "db_timeout", 10))
 

--- a/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
@@ -2252,6 +2252,13 @@ class TestExecutor:
             sensitive = re.compile(r"(?i)(pass|secret|token|api[_-]?key|access[_-]?key|credential|dsn)")
             return {k: ("***redacted***" if sensitive.search(k) else v) for k, v in env.items()}
 
+        # Run tags (from --tag / --tags), de-duplicated in order.
+        run_tags = list(getattr(self.args, "tag", []) or [])
+        for _t in (getattr(self.args, "tags", "") or "").split(","):
+            _t = _t.strip()
+            if _t and _t not in run_tags:
+                run_tags.append(_t)
+
         manifest = {
             "run_id": run_id,
             "created_at": stamp.isoformat(),
@@ -2268,6 +2275,7 @@ class TestExecutor:
             "config_name": sys_cfg.get("name"),
             "config_description": sys_cfg.get("description"),
             "label": getattr(self.args, "run_label", "") or None,
+            "tags": run_tags or None,
             "env": _redact_sensitive_env(self.global_env),
         }
 

--- a/projects/rccl/tools/scripts/test_runner/lib/test_parser.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_parser.py
@@ -133,6 +133,41 @@ Examples:
             default=False,
             help="Use MPICH syntax (-env) instead of OpenMPI (-x) for passing env vars to mpirun"
         )
+        self.parser.add_argument(
+            '--emit-results',
+            action='store_true',
+            default=False,
+            help="Emit structured, machine-readable results (JSON/JSONL + a .tar.gz "
+                 "snapshot) for the results dashboard. Enables per-test log "
+                 "capture so perf (busbw/algbw) numbers can be parsed."
+        )
+        self.parser.add_argument(
+            '--results-dir',
+            type=str,
+            default='',
+            help="Directory for emitted results + tarballs (default: <workspace>/results). "
+                 "The hourly dashboard scrape pulls <results-dir>/latest.tar.gz."
+        )
+        self.parser.add_argument(
+            '--run-label',
+            type=str,
+            default='',
+            help="Optional label/tag stored with the emitted run (e.g. 'nightly', a PR number)."
+        )
+        self.parser.add_argument(
+            '--db-push',
+            action='store_true',
+            default=False,
+            help="Also push results to PostgreSQL (DSN from RCCL_RESULTS_DSN). Best "
+                 "effort: on failure/timeout the run continues and the local tarball "
+                 "remains the source of truth. Implies --emit-results."
+        )
+        self.parser.add_argument(
+            '--db-timeout',
+            type=int,
+            default=10,
+            help="PostgreSQL connect + statement timeout in seconds for --db-push (default: 10)."
+        )
 
     def parse_arguments(self):
         """Parse command-line arguments"""

--- a/projects/rccl/tools/scripts/test_runner/lib/test_parser.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_parser.py
@@ -155,6 +155,20 @@ Examples:
             help="Optional label/tag stored with the emitted run (e.g. 'nightly', a PR number)."
         )
         self.parser.add_argument(
+            '--tag',
+            action='append',
+            default=[],
+            metavar='TAG',
+            help="Tag to attach to the emitted run for filtering in the dashboard "
+                 "(repeatable, e.g. --tag nightly --tag mi300x). Merged with --tags."
+        )
+        self.parser.add_argument(
+            '--tags',
+            type=str,
+            default='',
+            help="Comma-separated tags to attach to the emitted run (merged with --tag)."
+        )
+        self.parser.add_argument(
             '--db-push',
             action='store_true',
             default=False,

--- a/projects/rccl/tools/scripts/test_runner/test_runner.py
+++ b/projects/rccl/tools/scripts/test_runner/test_runner.py
@@ -118,6 +118,11 @@ def main():
             print("\nSKIP: Coverage report not requested (use --coverage-report to enable)")
         executor.generate_coverage_report()
 
+        # Emit structured results for the dashboard (no-op unless
+        # --emit-results / --db-push was passed). Coverage is emitted too when a
+        # report was generated above.
+        executor.emit_results()
+
         # Return based on results
         if executor.test_results:
             from lib.test_executor import TestResult


### PR DESCRIPTION
Adds a results emitter that parses perf/coverage output into structured JSON/JSONL + tarball snapshots, with an optional best-effort PostgreSQL push behind RCCL_RESULTS_DSN. Captures a failure-tolerant host/telemetry snapshot (versions, GPU info, firmware, scale-out RDMA + scale-up XGMI/UALink fabric, config checks) gated on capability presence, plus per-test execution mode (MPI/threaded/single) and build type. All probes read standard sysfs/ROCm CLIs; nothing is tied to a specific host, cluster, or product. Includes DB schema and scrape-contract docs.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

JIRA ID : AICOMRCCL-1482

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
