### PR TITLE
fix(clr): correct dangling completion signal tracking

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1145,7 +1145,7 @@ void VirtualGPU::SetGpuQueue(hsa_queue_t* queue, void* metadata_ring_buffer) {
   // not dereference a stale completion-signal handle.
   last_write_index_ = kInvalidQueueIndex;
   last_packet_with_signal_index_ = kInvalidQueueIndex;
-  last_completion_signal_.handle = 0;
+  SetLastCompletionSignal(nullptr);
   metadata_preloader_.SetQueueBase(metadata_ring_buffer,
                                    roc_device_.MetadataVersionHeader());
 }
@@ -1916,6 +1916,59 @@ void VirtualGPU::dispatchBarrierValuePacket(uint16_t packetHeader, bool resolveD
 }
 
 // ================================================================================================
+void VirtualGPU::SetLastCompletionSignal(ProfilingSignal* signal) {
+  if (last_completion_psignal_ == signal) {
+    return;
+  }
+  if (signal != nullptr) {
+    signal->retain();
+  }
+  if (last_completion_psignal_ != nullptr) {
+    last_completion_psignal_->release();
+  }
+  last_completion_psignal_ = signal;
+}
+
+// ================================================================================================
+void VirtualGPU::TrackQueueProgress(hsa_signal_t completion_signal, uint64_t index,
+                                    bool skip_signal) {
+  last_write_index_ = index;
+  if (skip_signal) {
+    SetLastCompletionSignal(nullptr);
+  } else if (completion_signal.handle != 0) {
+    // Only adopt the signal for idle tracking when it is owned by this queue's signal tracker
+    ProfilingSignal* owner = Barriers().GetLastSignal();
+    if ((owner != nullptr) && (owner->signal_.handle == completion_signal.handle)) {
+      last_packet_with_signal_index_ = index;
+      SetLastCompletionSignal(owner);
+    } else {
+      SetLastCompletionSignal(nullptr);
+    }
+  }
+}
+
+// ================================================================================================
+bool VirtualGPU::IsQueueIdle() const {
+  if (gpu_queue_ == nullptr) {
+    return true;
+  }
+
+  // Make sure the last packet contained a completion signal
+  if (last_packet_with_signal_index_ == last_write_index_) {
+    if (last_completion_psignal_ == nullptr) {
+      // No tracked completion signal is outstanding. A fresh queue (no writes) is idle; otherwise
+      // the last packet carried no owned signal, so idleness cannot be proven.
+      return (last_write_index_ == kInvalidQueueIndex);
+    }
+    // The retained reference keeps the owning ProfilingSignal (and its HSA signal) alive, so this
+    // load can never dereference a recycled/destroyed handle.
+    return (Hsa::signal_load_relaxed(last_completion_psignal_->signal_) == 0);
+  }
+
+  return false;
+}
+
+// ================================================================================================
 void VirtualGPU::ResetQueueStates() {
   // Release all memory dependencies
   memoryDependency().clear();
@@ -2058,6 +2111,9 @@ VirtualGPU::~VirtualGPU() {
     std::scoped_lock l(execution());
     SetCoalesceWindow(0, nullptr);
   }
+  // Drop the retained reference on the last tracked completion signal (if any) so its owning
+  // ProfilingSignal can be reclaimed when the signal tracker is torn down below.
+  SetLastCompletionSignal(nullptr);
 
   if (timestamp_ != nullptr) {
     timestamp_->release();

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -719,40 +719,27 @@ class VirtualGPU : public device::VirtualDevice {
   //! Resets the current queue state. Note: should be called after AQL queue becomes idle
   void ResetQueueStates();
 
+  //! Replaces the completion signal tracked for queue-idle detection. A retained reference is
+  //! held on the owning ProfilingSignal so that neither the ProfilingSignal nor its underlying
+  //! HSA signal can be recycled/destroyed while IsQueueIdle() may still read it.
+  void SetLastCompletionSignal(ProfilingSignal* signal);
+
   //! Track the progress of the queue based on the last write index and completion signal.
   //! When skip_signal is true, only the write index is advanced and the completion signal
   //! is cleared. Used for graph pre-patched dispatches whose signals are externally
   //! managed and freed after graph completion.
+  void TrackQueueProgress(hsa_signal_t completion_signal, uint64_t index,
+                          bool skip_signal = false);
+
   template <typename AqlPacket>
   inline void TrackQueueProgress(const AqlPacket& packet, uint64_t index,
                                  bool skip_signal = false) {
-    last_write_index_ = index;
-    if (skip_signal) {
-      last_completion_signal_.handle = 0;
-    } else if (packet.completion_signal.handle != 0) {
-      last_packet_with_signal_index_ = index;
-      last_completion_signal_ = packet.completion_signal;
-    }
+    TrackQueueProgress(packet.completion_signal, index, skip_signal);
   }
 
   //! Returns true if the queue is considered as idle. That means all submitted packets are
   //! complete. Note: it doesn't track the state of caches
-  bool IsQueueIdle() const {
-    if (gpu_queue_ == nullptr) {
-      return true;
-    }
-
-    // Make sure the last packet contained a completion signal
-    if (last_packet_with_signal_index_ == last_write_index_) {
-      if ((last_write_index_ == kInvalidQueueIndex) && (last_completion_signal_.handle == 0)) {
-        return true;
-      } else {
-        return (Hsa::signal_load_relaxed(last_completion_signal_) == 0);
-      }
-    }
-
-    return false;
-  }
+  bool IsQueueIdle() const;
 
   //! True if this marker records the same event as the preceding barrier with no
   //! intervening dispatch or sync. Caller must hold the execution() lock.
@@ -888,8 +875,8 @@ class VirtualGPU : public device::VirtualDevice {
   uint64_t last_write_index_ = kInvalidQueueIndex; //!< The last HW queue write index for any packet
   uint64_t last_packet_with_signal_index_ = kInvalidQueueIndex; //!< The last HW queue write index for a packet
                                               //!< with a completion signal
-  hsa_signal_t last_completion_signal_{};     //!< The last completion signal
-
+  ProfilingSignal* last_completion_psignal_ = nullptr; //!< Owning (retained) ProfilingSignal whose HSA
+                                              //!< signal is used for queue-idle detection.
   //! SDMA engine affinity tracking for this VirtualGPU/stream
   uint32_t assigned_sdma_engine_ = 0;           //!< Assigned SDMA engine mask for all operations
 


### PR DESCRIPTION
## Motivation

RVS can abort or segfault during teardown after AGFHC GST stress tests because `VirtualGPU` may keep a raw `hsa_signal_t` handle for queue-idle detection after the owning profiling signal has been recycled or destroyed. A later idle check can then call `hsa_signal_load_relaxed()` on an invalid signal handle.

This PR updates the queue-idle tracking path to keep the owning `ProfilingSignal` alive while it is used for the last completion signal check.

Ported from change https://github.com/AMD-ROCm-Internal/rocm-systems/pull/1198

## Technical Details

- Replace the stored raw `hsa_signal_t last_completion_signal_` with a retained `ProfilingSignal* last_completion_psignal_`.
- Add `SetLastCompletionSignal()` to retain the new profiling signal before releasing the previous one.
- Only track a packet completion signal when it is owned by this queue's signal tracker.
- Clear the retained last completion signal during `VirtualGPU` destruction before signal tracker teardown.

## JIRA ID

JIRA ID: ROCM-27035

## Test Plan

- Build and run RVS 1.5.118 in a Docker-only environment against an AGFHC-like GST FP8 config.

## Test Result
The issue could not be reproduced locally on MI300X machine. Need access to hjbog-srdc-45

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
