### PR TITLE
Refactor batch copy and delay processing broadcast batch copies

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -760,7 +760,7 @@ void AddCopyListEntry(const hsa_amd_memory_copy_op_t& operation, size_t size,
 }
 
 void PushLinearOperation(CopyListStorage pending,
-                         std::vector<hsa_amd_memory_copy_op_t>& final_operations,
+                         std::vector<hsa_amd_memory_copy_op_t>& submission_ops,
                          std::vector<CopyListStorage>& copy_list_storage) {
   if (pending.srcs.empty()) {
     return;
@@ -776,7 +776,7 @@ void PushLinearOperation(CopyListStorage pending,
     operation.dst = pending.dsts[0];
     operation.dst_agent = pending.dst_agents[0];
     operation.size = pending.sizes[0];
-    final_operations.push_back(operation);
+    submission_ops.push_back(operation);
   } else {
     operation.src_list = pending.srcs.data();
     operation.dst_list = pending.dsts.data();
@@ -784,12 +784,75 @@ void PushLinearOperation(CopyListStorage pending,
     operation.size_list = pending.sizes.data();
     operation.num_entries = static_cast<uint16_t>(pending.srcs.size());
     copy_list_storage.push_back(std::move(pending));
-    final_operations.push_back(operation);
+    submission_ops.push_back(operation);
   }
 }
 
+void PushLinearOperations(const std::vector<const hsa_amd_memory_copy_op_t*>& linear_operations,
+                          HwQueueEngine engine,
+                          std::vector<hsa_amd_memory_copy_op_t>& submission_ops,
+                          std::vector<CopyListStorage>& copy_list_storage) {
+  if (linear_operations.empty()) {
+    return;
+  }
+
+  if (engine != HwQueueEngine::SdmaD2D) {
+    // H2D and D2H batches each share one src_agent (CPU for H2D, one GPU for D2H).
+    CopyListStorage pending;
+    for (const hsa_amd_memory_copy_op_t* operation : linear_operations) {
+      AddCopyListEntry(*operation, operation->size, pending);
+    }
+    PushLinearOperation(std::move(pending), submission_ops, copy_list_storage);
+    return;
+  }
+
+  struct BroadcastEntry {
+    hsa_amd_memory_copy_op_t operation;
+    std::vector<void*> dsts;
+    std::vector<hsa_agent_t> dst_agents;
+  };
+
+  std::map<std::tuple<const void*, size_t>, BroadcastEntry> same_source_groups;
+  for (const hsa_amd_memory_copy_op_t* operation : linear_operations) {
+    auto& broadcast_entry =
+        same_source_groups[std::make_tuple(operation->src, operation->size)];
+    if (broadcast_entry.dsts.empty()) {
+      broadcast_entry.operation = *operation;
+    }
+    broadcast_entry.dsts.push_back(operation->dst);
+    broadcast_entry.dst_agents.push_back(operation->dst_agent);
+  }
+
+  CopyListStorage pending;
+  for (auto& same_source_group : same_source_groups) {
+    BroadcastEntry& broadcast_entry = same_source_group.second;
+    if (broadcast_entry.dsts.size() > 1) {
+      CopyListStorage broadcast_storage;
+      broadcast_storage.dsts = std::move(broadcast_entry.dsts);
+      broadcast_storage.dst_agents = std::move(broadcast_entry.dst_agents);
+
+      hsa_amd_memory_copy_op_t broadcast = {};
+      broadcast.version = HSA_AMD_MEMORY_COPY_OP_VERSION;
+      broadcast.type = HSA_AMD_MEMORY_COPY_OP_LINEAR_BROADCAST;
+      broadcast.src = broadcast_entry.operation.src;
+      broadcast.src_agent = broadcast_entry.operation.src_agent;
+      broadcast.dst_list = broadcast_storage.dsts.data();
+      broadcast.dst_agent_list = broadcast_storage.dst_agents.data();
+      broadcast.num_entries = static_cast<uint16_t>(broadcast_storage.dsts.size());
+      broadcast.size = broadcast_entry.operation.size;
+      copy_list_storage.push_back(std::move(broadcast_storage));
+      submission_ops.push_back(broadcast);
+      continue;
+    }
+
+    AddCopyListEntry(broadcast_entry.operation, broadcast_entry.operation.size, pending);
+  }
+
+  PushLinearOperation(std::move(pending), submission_ops, copy_list_storage);
+}
+
 void PushSwapOperations(const std::vector<const hsa_amd_memory_copy_op_t*>& swap_operations,
-                        std::vector<hsa_amd_memory_copy_op_t>& final_operations,
+                        std::vector<hsa_amd_memory_copy_op_t>& submission_ops,
                         std::vector<CopyListStorage>& copy_list_storage) {
   if (swap_operations.empty()) {
     return;
@@ -811,101 +874,11 @@ void PushSwapOperations(const std::vector<const hsa_amd_memory_copy_op_t*>& swap
   swap.size_list = pending.sizes.data();
   swap.num_entries = static_cast<uint16_t>(pending.srcs.size());
   copy_list_storage.push_back(std::move(pending));
-  final_operations.push_back(swap);
-}
-
-void PushLinearOperations(const std::vector<const hsa_amd_memory_copy_op_t*>& linear_operations,
-                          HwQueueEngine engine,
-                          std::vector<hsa_amd_memory_copy_op_t>& final_operations,
-                          std::vector<CopyListStorage>& copy_list_storage) {
-  if (linear_operations.empty()) {
-    return;
-  }
-
-  if (engine != HwQueueEngine::SdmaD2D) {
-    auto has_one_source_agent = [&]() {
-      const uint64_t src_agent_handle = linear_operations.front()->src_agent.handle;
-      for (const hsa_amd_memory_copy_op_t* operation : linear_operations) {
-        if (operation->src_agent.handle != src_agent_handle) {
-          return false;
-        }
-      }
-      return true;
-    };
-
-    if (engine == HwQueueEngine::SdmaH2D || has_one_source_agent()) {
-      CopyListStorage pending;
-      for (const hsa_amd_memory_copy_op_t* operation : linear_operations) {
-        AddCopyListEntry(*operation, operation->size, pending);
-      }
-      PushLinearOperation(std::move(pending), final_operations, copy_list_storage);
-      return;
-    }
-
-    std::map<uint64_t, CopyListStorage> pending_by_src_agent;
-    for (const hsa_amd_memory_copy_op_t* operation : linear_operations) {
-      AddCopyListEntry(*operation, operation->size,
-                       pending_by_src_agent[operation->src_agent.handle]);
-    }
-
-    for (auto& pending_entry : pending_by_src_agent) {
-      PushLinearOperation(std::move(pending_entry.second), final_operations, copy_list_storage);
-    }
-    return;
-  }
-
-  struct BroadcastEntry {
-    hsa_amd_memory_copy_op_t first_operation;
-    std::vector<void*> dsts;
-    std::vector<hsa_agent_t> dst_agents;
-  };
-
-  std::map<uint64_t, std::map<std::tuple<const void*, size_t>, BroadcastEntry>> broadcast_groups;
-  for (const hsa_amd_memory_copy_op_t* operation : linear_operations) {
-    const uint64_t src_agent_handle = operation->src_agent.handle;
-    auto& broadcast_entry =
-        broadcast_groups[src_agent_handle][std::make_tuple(operation->src, operation->size)];
-    if (broadcast_entry.dsts.empty()) {
-      broadcast_entry.first_operation = *operation;
-    }
-    broadcast_entry.dsts.push_back(operation->dst);
-    broadcast_entry.dst_agents.push_back(operation->dst_agent);
-  }
-
-  for (auto& source_group : broadcast_groups) {
-    CopyListStorage pending;
-
-    for (auto& broadcast_group : source_group.second) {
-      BroadcastEntry& broadcast_entry = broadcast_group.second;
-      if (broadcast_entry.dsts.size() > 1) {
-        CopyListStorage broadcast_storage;
-        broadcast_storage.dsts = std::move(broadcast_entry.dsts);
-        broadcast_storage.dst_agents = std::move(broadcast_entry.dst_agents);
-
-        hsa_amd_memory_copy_op_t broadcast = {};
-        broadcast.version = HSA_AMD_MEMORY_COPY_OP_VERSION;
-        broadcast.type = HSA_AMD_MEMORY_COPY_OP_LINEAR_BROADCAST;
-        broadcast.src = broadcast_entry.first_operation.src;
-        broadcast.src_agent = broadcast_entry.first_operation.src_agent;
-        broadcast.dst_list = broadcast_storage.dsts.data();
-        broadcast.dst_agent_list = broadcast_storage.dst_agents.data();
-        broadcast.num_entries = static_cast<uint16_t>(broadcast_storage.dsts.size());
-        broadcast.size = broadcast_entry.first_operation.size;
-        copy_list_storage.push_back(std::move(broadcast_storage));
-        final_operations.push_back(broadcast);
-        continue;
-      }
-
-      AddCopyListEntry(broadcast_entry.first_operation, broadcast_entry.first_operation.size,
-                       pending);
-    }
-
-    PushLinearOperation(std::move(pending), final_operations, copy_list_storage);
-  }
+  submission_ops.push_back(swap);
 }
 
 void PushIndirectOperations(const std::vector<const hsa_amd_memory_copy_op_t*>& indirect_operations,
-                            std::vector<hsa_amd_memory_copy_op_t>& final_operations,
+                            std::vector<hsa_amd_memory_copy_op_t>& submission_ops,
                             std::vector<CopyListStorage>& copy_list_storage) {
   std::map<hsa_amd_memory_copy_op_type_t, CopyListStorage> pending_by_type;
   for (const hsa_amd_memory_copy_op_t* operation : indirect_operations) {
@@ -927,7 +900,7 @@ void PushIndirectOperations(const std::vector<const hsa_amd_memory_copy_op_t*>& 
     indirect.size_list = pending.sizes.data();
     indirect.num_entries = static_cast<uint16_t>(pending.srcs.size());
     copy_list_storage.push_back(std::move(pending));
-    final_operations.push_back(indirect);
+    submission_ops.push_back(indirect);
   }
 }
 
@@ -1004,24 +977,24 @@ bool DmaBlitManager::rocrCopyBufferBatch(const std::vector<hsa_amd_memory_copy_o
       linear_operations.push_back(&operation);
     }
 
-    std::vector<hsa_amd_memory_copy_op_t> final_operations;
+    std::vector<hsa_amd_memory_copy_op_t> submission_ops;
     std::vector<CopyListStorage> copy_list_storage;
-    final_operations.reserve(ops.size());
+    submission_ops.reserve(ops.size());
     copy_list_storage.reserve((swap_operations.empty() ? 0 : 1) + linear_operations.size() +
                               indirect_operations.size());
 
-    PushSwapOperations(swap_operations, final_operations, copy_list_storage);
-    PushLinearOperations(linear_operations, engine, final_operations, copy_list_storage);
-    PushIndirectOperations(indirect_operations, final_operations, copy_list_storage);
+    PushSwapOperations(swap_operations, submission_ops, copy_list_storage);
+    PushLinearOperations(linear_operations, engine, submission_ops, copy_list_storage);
+    PushIndirectOperations(indirect_operations, submission_ops, copy_list_storage);
 
     // Assign one completion signal per op in a single place.
-    for (auto& op : final_operations) {
+    for (auto& op : submission_ops) {
       op.completion_signal = gpu().Barriers().ActiveSignal(1, gpu().timestamp());
       groupSignals.push_back(gpu().Barriers().GetLastSignal());
     }
 
-    for (size_t i = 0; i < final_operations.size(); ++i) {
-      const auto& op = final_operations[i];
+    for (size_t i = 0; i < submission_ops.size(); ++i) {
+      const auto& op = submission_ops[i];
       if (op.type == HSA_AMD_MEMORY_COPY_OP_LINEAR_BROADCAST) {
         for (uint32_t d = 0; d < op.num_entries; ++d) {
           ClPrint(amd::LOG_DEBUG, amd::LOG_COPY2,
@@ -1070,14 +1043,14 @@ bool DmaBlitManager::rocrCopyBufferBatch(const std::vector<hsa_amd_memory_copy_o
         ClPrint(amd::LOG_DEBUG, amd::LOG_COPY2,
                 "HSA BatchCopy Linear [%zu/%zu] engineOp=%s, dst=%p, src=%p, size=%zu, "
                 "src_agent=0x%zx, dst_agent=0x%zx, wait_event=0x%zx, completion_signal=0x%zx",
-                i, final_operations.size(), EngineOpName(engine), op.dst, op.src, op.size,
+                i, submission_ops.size(), EngineOpName(engine), op.dst, op.src, op.size,
                 op.src_agent.handle, op.dst_agent.handle,
                 (wait_events.size() != 0) ? wait_events[0].handle : 0, op.completion_signal.handle);
       }
     }
 
-    status = Hsa::memory_async_batch_copy(final_operations.data(),
-                                          static_cast<uint32_t>(final_operations.size()),
+    status = Hsa::memory_async_batch_copy(submission_ops.data(),
+                                          static_cast<uint32_t>(submission_ops.size()),
                                           wait_events.size(), wait_events.data());
 
     if (status != HSA_STATUS_SUCCESS) {

--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -13,6 +13,7 @@
 #include "utils/debug.hpp"
 #include <algorithm>
 #include <map>
+#include <tuple>
 
 namespace amd::roc {
 DmaBlitManager::DmaBlitManager(VirtualGPU& gpu, Setup setup)
@@ -736,6 +737,202 @@ bool DmaBlitManager::hsaCopyBatch(const std::vector<amd::BatchCopyOp>& copyOps,
   return rocrCopyBufferBatch(hsaCopyOps, externalWaitEvents, outBatchSignals);
 }
 
+namespace {
+
+// Owns list backing storage for HSA copy descriptors until the batch submission returns.
+struct CopyListStorage {
+  hsa_agent_t src_agent{};
+  std::vector<void*> srcs;
+  std::vector<void*> dsts;
+  std::vector<hsa_agent_t> dst_agents;
+  std::vector<size_t> sizes;
+};
+
+void AddCopyListEntry(const hsa_amd_memory_copy_op_t& operation, size_t size,
+                      CopyListStorage& copy_list_storage) {
+  if (copy_list_storage.srcs.empty()) {
+    copy_list_storage.src_agent = operation.src_agent;
+  }
+  copy_list_storage.srcs.push_back(const_cast<void*>(operation.src));
+  copy_list_storage.dsts.push_back(operation.dst);
+  copy_list_storage.dst_agents.push_back(operation.dst_agent);
+  copy_list_storage.sizes.push_back(size);
+}
+
+void PushLinearOperation(CopyListStorage pending,
+                         std::vector<hsa_amd_memory_copy_op_t>& final_operations,
+                         std::vector<CopyListStorage>& copy_list_storage) {
+  if (pending.srcs.empty()) {
+    return;
+  }
+
+  hsa_amd_memory_copy_op_t operation = {};
+  operation.version = HSA_AMD_MEMORY_COPY_OP_VERSION;
+  operation.type = HSA_AMD_MEMORY_COPY_OP_LINEAR;
+  operation.src_agent = pending.src_agent;
+
+  if (pending.srcs.size() == 1) {
+    operation.src = pending.srcs[0];
+    operation.dst = pending.dsts[0];
+    operation.dst_agent = pending.dst_agents[0];
+    operation.size = pending.sizes[0];
+    final_operations.push_back(operation);
+  } else {
+    operation.src_list = pending.srcs.data();
+    operation.dst_list = pending.dsts.data();
+    operation.dst_agent_list = pending.dst_agents.data();
+    operation.size_list = pending.sizes.data();
+    operation.num_entries = static_cast<uint16_t>(pending.srcs.size());
+    copy_list_storage.push_back(std::move(pending));
+    final_operations.push_back(operation);
+  }
+}
+
+void PushSwapOperations(const std::vector<const hsa_amd_memory_copy_op_t*>& swap_operations,
+                        std::vector<hsa_amd_memory_copy_op_t>& final_operations,
+                        std::vector<CopyListStorage>& copy_list_storage) {
+  if (swap_operations.empty()) {
+    return;
+  }
+
+  CopyListStorage pending;
+  for (const hsa_amd_memory_copy_op_t* operation : swap_operations) {
+    assert(operation->src_size == operation->dst_size && "Asymmetric swap not yet supported");
+    AddCopyListEntry(*operation, operation->src_size, pending);
+  }
+
+  hsa_amd_memory_copy_op_t swap = {};
+  swap.version = HSA_AMD_MEMORY_COPY_OP_VERSION;
+  swap.type = HSA_AMD_MEMORY_COPY_OP_LINEAR_SWAP;
+  swap.src_agent = pending.src_agent;
+  swap.src_list = pending.srcs.data();
+  swap.dst_list = pending.dsts.data();
+  swap.dst_agent_list = pending.dst_agents.data();
+  swap.size_list = pending.sizes.data();
+  swap.num_entries = static_cast<uint16_t>(pending.srcs.size());
+  copy_list_storage.push_back(std::move(pending));
+  final_operations.push_back(swap);
+}
+
+void PushLinearOperations(const std::vector<const hsa_amd_memory_copy_op_t*>& linear_operations,
+                          HwQueueEngine engine,
+                          std::vector<hsa_amd_memory_copy_op_t>& final_operations,
+                          std::vector<CopyListStorage>& copy_list_storage) {
+  if (linear_operations.empty()) {
+    return;
+  }
+
+  if (engine != HwQueueEngine::SdmaD2D) {
+    auto has_one_source_agent = [&]() {
+      const uint64_t src_agent_handle = linear_operations.front()->src_agent.handle;
+      for (const hsa_amd_memory_copy_op_t* operation : linear_operations) {
+        if (operation->src_agent.handle != src_agent_handle) {
+          return false;
+        }
+      }
+      return true;
+    };
+
+    if (engine == HwQueueEngine::SdmaH2D || has_one_source_agent()) {
+      CopyListStorage pending;
+      for (const hsa_amd_memory_copy_op_t* operation : linear_operations) {
+        AddCopyListEntry(*operation, operation->size, pending);
+      }
+      PushLinearOperation(std::move(pending), final_operations, copy_list_storage);
+      return;
+    }
+
+    std::map<uint64_t, CopyListStorage> pending_by_src_agent;
+    for (const hsa_amd_memory_copy_op_t* operation : linear_operations) {
+      AddCopyListEntry(*operation, operation->size,
+                       pending_by_src_agent[operation->src_agent.handle]);
+    }
+
+    for (auto& pending_entry : pending_by_src_agent) {
+      PushLinearOperation(std::move(pending_entry.second), final_operations, copy_list_storage);
+    }
+    return;
+  }
+
+  struct BroadcastEntry {
+    hsa_amd_memory_copy_op_t first_operation;
+    std::vector<void*> dsts;
+    std::vector<hsa_agent_t> dst_agents;
+  };
+
+  std::map<uint64_t, std::map<std::tuple<const void*, size_t>, BroadcastEntry>> broadcast_groups;
+  for (const hsa_amd_memory_copy_op_t* operation : linear_operations) {
+    const uint64_t src_agent_handle = operation->src_agent.handle;
+    auto& broadcast_entry =
+        broadcast_groups[src_agent_handle][std::make_tuple(operation->src, operation->size)];
+    if (broadcast_entry.dsts.empty()) {
+      broadcast_entry.first_operation = *operation;
+    }
+    broadcast_entry.dsts.push_back(operation->dst);
+    broadcast_entry.dst_agents.push_back(operation->dst_agent);
+  }
+
+  for (auto& source_group : broadcast_groups) {
+    CopyListStorage pending;
+
+    for (auto& broadcast_group : source_group.second) {
+      BroadcastEntry& broadcast_entry = broadcast_group.second;
+      if (broadcast_entry.dsts.size() > 1) {
+        CopyListStorage broadcast_storage;
+        broadcast_storage.dsts = std::move(broadcast_entry.dsts);
+        broadcast_storage.dst_agents = std::move(broadcast_entry.dst_agents);
+
+        hsa_amd_memory_copy_op_t broadcast = {};
+        broadcast.version = HSA_AMD_MEMORY_COPY_OP_VERSION;
+        broadcast.type = HSA_AMD_MEMORY_COPY_OP_LINEAR_BROADCAST;
+        broadcast.src = broadcast_entry.first_operation.src;
+        broadcast.src_agent = broadcast_entry.first_operation.src_agent;
+        broadcast.dst_list = broadcast_storage.dsts.data();
+        broadcast.dst_agent_list = broadcast_storage.dst_agents.data();
+        broadcast.num_entries = static_cast<uint16_t>(broadcast_storage.dsts.size());
+        broadcast.size = broadcast_entry.first_operation.size;
+        copy_list_storage.push_back(std::move(broadcast_storage));
+        final_operations.push_back(broadcast);
+        continue;
+      }
+
+      AddCopyListEntry(broadcast_entry.first_operation, broadcast_entry.first_operation.size,
+                       pending);
+    }
+
+    PushLinearOperation(std::move(pending), final_operations, copy_list_storage);
+  }
+}
+
+void PushIndirectOperations(const std::vector<const hsa_amd_memory_copy_op_t*>& indirect_operations,
+                            std::vector<hsa_amd_memory_copy_op_t>& final_operations,
+                            std::vector<CopyListStorage>& copy_list_storage) {
+  std::map<hsa_amd_memory_copy_op_type_t, CopyListStorage> pending_by_type;
+  for (const hsa_amd_memory_copy_op_t* operation : indirect_operations) {
+    const auto operation_type = static_cast<hsa_amd_memory_copy_op_type_t>(operation->type);
+    AddCopyListEntry(*operation, operation->size, pending_by_type[operation_type]);
+  }
+
+  for (auto& pending_entry : pending_by_type) {
+    const hsa_amd_memory_copy_op_type_t operation_type = pending_entry.first;
+    CopyListStorage pending = std::move(pending_entry.second);
+
+    hsa_amd_memory_copy_op_t indirect = {};
+    indirect.version = HSA_AMD_MEMORY_COPY_OP_VERSION;
+    indirect.type = operation_type;
+    indirect.src_agent = pending.src_agent;
+    indirect.src_list = pending.srcs.data();
+    indirect.dst_list = pending.dsts.data();
+    indirect.dst_agent_list = pending.dst_agents.data();
+    indirect.size_list = pending.sizes.data();
+    indirect.num_entries = static_cast<uint16_t>(pending.srcs.size());
+    copy_list_storage.push_back(std::move(pending));
+    final_operations.push_back(indirect);
+  }
+}
+
+}  // namespace
+
 // ================================================================================================
 bool DmaBlitManager::rocrCopyBufferBatch(const std::vector<hsa_amd_memory_copy_op_t>& copyOps,
                                          const std::vector<hsa_signal_t>* externalWaitEvents,
@@ -772,13 +969,8 @@ bool DmaBlitManager::rocrCopyBufferBatch(const std::vector<hsa_amd_memory_copy_o
     wait_events = gpu().Barriers().WaitingSignal(HwQueueEngine::Unknown);
   }
 
-  // Submit each non-empty engine group as a separate batch with its own signal.
-  // Within each group, ops are grouped by type (SWAP and each INDIRECT mode
-  // each become one multi-entry op; see the bucket declarations below).
-  // LINEAR ops are further grouped by src_agent:
-  //  - Same (src, size) with multiple dsts (SdmaD2D) → BROADCAST
-  //  - Multiple remaining ops from same src_agent    → MULTI
-  //  - Single remaining op                           → LINEAR
+  // Submit each non-empty engine group as a separate batch with its own signal. Each group is
+  // classified by copy kind, then emitted through type-specific finalOps helpers.
   hsa_status_t status = HSA_STATUS_SUCCESS;
   std::vector<ProfilingSignal*> groupSignals;
 
@@ -788,197 +980,48 @@ bool DmaBlitManager::rocrCopyBufferBatch(const std::vector<hsa_amd_memory_copy_o
 
     HwQueueEngine engine = static_cast<HwQueueEngine>(e);
 
-    // Two-level grouping: first by src_agent, then by (src, size) for broadcast.
-    struct BcastKey {
-      const void* src;
-      size_t size;
-      bool operator<(const BcastKey& o) const {
-        if (src != o.src) return src < o.src;
-        return size < o.size;
-      }
-    };
-    struct BcastEntry {
-      hsa_amd_memory_copy_op_t tmpl;
-      std::vector<void*> dsts;
-      std::vector<hsa_agent_t> dst_agents;
-    };
-    struct AgentGroup {
-      hsa_agent_t src_agent;
-      std::map<BcastKey, BcastEntry> sub_groups;
-    };
-    std::map<uint64_t, AgentGroup> agent_groups;
-
-    struct MultiArrays {
-      std::vector<void*> srcs;
-      std::vector<void*> dsts;
-      std::vector<hsa_agent_t> dst_agents;
-      std::vector<size_t> sizes;
-    };
-
-    MultiArrays swapPending;
-    hsa_agent_t swapSrcAgent = {};
-
-    // Indirect ops are bucketed by their indirect mode (SRC / DST / SRCDST)
-    // into multi-entry HSA ops, one bucket per mode.  All entries in one
-    // bucket share the same op.type because the indirect mode is encoded in
-    // op.type; src_agent is captured from the first op in each bucket.
-    struct IndirectBucket {
-      MultiArrays pending;
-      hsa_agent_t src_agent = {};
-    };
-    std::map<hsa_amd_memory_copy_op_type_t, IndirectBucket> indirectPending;
-
-    auto isIndirectType = [](hsa_amd_memory_copy_op_type_t type) -> bool {
-      switch (type) {
-        case HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRC:
-        case HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_DST:
-        case HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRCDST:
-          return true;
-        default:
-          return false;
-      }
-    };
-
-    for (const auto& op : ops) {
-      if (op.type == HSA_AMD_MEMORY_COPY_OP_LINEAR_SWAP) {
-        assert(op.src_size == op.dst_size && "Asymmetric swap not yet supported");
-        if (swapPending.srcs.empty()) swapSrcAgent = op.src_agent;
-        swapPending.srcs.push_back(op.src);
-        swapPending.dsts.push_back(op.dst);
-        swapPending.dst_agents.push_back(op.dst_agent);
-        swapPending.sizes.push_back(op.src_size);
-        continue;
-      }
-      const auto opType = static_cast<hsa_amd_memory_copy_op_type_t>(op.type);
-      if (isIndirectType(opType)) {
-        auto& bucket = indirectPending[opType];
-        if (bucket.pending.srcs.empty()) bucket.src_agent = op.src_agent;
-        bucket.pending.srcs.push_back(op.src);
-        bucket.pending.dsts.push_back(op.dst);
-        bucket.pending.dst_agents.push_back(op.dst_agent);
-        bucket.pending.sizes.push_back(op.size);
-        continue;
-      }
-      auto& ag = agent_groups[op.src_agent.handle];
-      ag.src_agent = op.src_agent;
-      BcastKey bkey{op.src, op.size};
-      auto& be = ag.sub_groups[bkey];
-      if (be.dsts.empty()) {
-        be.tmpl = op;
-      }
-      be.dsts.push_back(op.dst);
-      be.dst_agents.push_back(op.dst_agent);
-    }
-
     gpu().Barriers().SetActiveEngine(engine);
+    std::vector<const hsa_amd_memory_copy_op_t*> swap_operations;
+    std::vector<const hsa_amd_memory_copy_op_t*> linear_operations;
+    std::vector<const hsa_amd_memory_copy_op_t*> indirect_operations;
+    swap_operations.reserve(ops.size());
+    linear_operations.reserve(ops.size());
+    indirect_operations.reserve(ops.size());
 
-    std::vector<MultiArrays> multiStore;
-    // Upper-bound entries that land in multiStore: one swap bucket + one
-    // multi bucket per src_agent group + one per populated indirect-mode
-    // bucket.
-    multiStore.reserve(1 + agent_groups.size() + indirectPending.size());
-
-    std::vector<hsa_amd_memory_copy_op_t> finalOps;
-
-    // --- Emit SWAP batch ---
-    if (!swapPending.srcs.empty()) {
-      multiStore.push_back(std::move(swapPending));
-      auto& stored = multiStore.back();
-
-      hsa_amd_memory_copy_op_t swap = {};
-      swap.version = HSA_AMD_MEMORY_COPY_OP_VERSION;
-      swap.type = HSA_AMD_MEMORY_COPY_OP_LINEAR_SWAP;
-      swap.src_agent = swapSrcAgent;
-      swap.src_list = stored.srcs.data();
-      swap.dst_list = stored.dsts.data();
-      swap.dst_agent_list = stored.dst_agents.data();
-      swap.size_list = stored.sizes.data();
-      swap.num_entries = static_cast<uint16_t>(stored.srcs.size());
-      finalOps.push_back(swap);
-    }
-
-    // --- Emit LINEAR / BROADCAST batches (one group per src_agent) ---
-    for (auto& [agent_handle, ag] : agent_groups) {
-      MultiArrays pending;
-
-      for (auto& [bkey, be] : ag.sub_groups) {
-        if (be.dsts.size() > 1 && engine == HwQueueEngine::SdmaD2D) {
-          hsa_amd_memory_copy_op_t bcast = {};
-          bcast.version = HSA_AMD_MEMORY_COPY_OP_VERSION;
-          bcast.type = HSA_AMD_MEMORY_COPY_OP_LINEAR_BROADCAST;
-          bcast.src = be.tmpl.src;
-          bcast.src_agent = ag.src_agent;
-          bcast.dst_list = be.dsts.data();
-          bcast.dst_agent_list = be.dst_agents.data();
-          bcast.num_entries = static_cast<uint16_t>(be.dsts.size());
-          bcast.size = be.tmpl.size;
-          finalOps.push_back(bcast);
-        } else {
-          for (size_t i = 0; i < be.dsts.size(); ++i) {
-            pending.srcs.push_back(const_cast<void*>(be.tmpl.src));
-            pending.dsts.push_back(be.dsts[i]);
-            pending.dst_agents.push_back(be.dst_agents[i]);
-            pending.sizes.push_back(be.tmpl.size);
-          }
-        }
+    for (const auto& operation : ops) {
+      if (operation.type == HSA_AMD_MEMORY_COPY_OP_LINEAR_SWAP) {
+        swap_operations.push_back(&operation);
+        continue;
       }
 
-      if (pending.srcs.size() > 1) {
-        multiStore.push_back(std::move(pending));
-        auto& stored = multiStore.back();
-
-        hsa_amd_memory_copy_op_t multi = {};
-        multi.version = HSA_AMD_MEMORY_COPY_OP_VERSION;
-        multi.type = HSA_AMD_MEMORY_COPY_OP_LINEAR;
-        multi.src_list = stored.srcs.data();
-        multi.src_agent = ag.src_agent;
-        multi.dst_list = stored.dsts.data();
-        multi.dst_agent_list = stored.dst_agents.data();
-        multi.size_list = stored.sizes.data();
-        multi.num_entries = static_cast<uint16_t>(stored.srcs.size());
-        finalOps.push_back(multi);
-      } else if (pending.srcs.size() == 1) {
-        hsa_amd_memory_copy_op_t linear = {};
-        linear.version = HSA_AMD_MEMORY_COPY_OP_VERSION;
-        linear.type = HSA_AMD_MEMORY_COPY_OP_LINEAR;
-        linear.src = pending.srcs[0];
-        linear.src_agent = ag.src_agent;
-        linear.dst = pending.dsts[0];
-        linear.dst_agent = pending.dst_agents[0];
-        linear.size = pending.sizes[0];
-        finalOps.push_back(linear);
+      if (operation.type == HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRC ||
+          operation.type == HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_DST ||
+          operation.type == HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRCDST) {
+        indirect_operations.push_back(&operation);
+        continue;
       }
+
+      linear_operations.push_back(&operation);
     }
 
-    // --- Emit INDIRECT batches ---
-    // The runtime accepts both the multi-entry form (num_entries > 0, with
-    // *_list arrays) and the scalar form (num_entries == 0, with the scalar
-    // src/dst/size fields) for indirect dispatch. We always emit the
-    // multi-entry form here for consistency with the rest of the batch path.
-    for (auto& [type, bucket] : indirectPending) {
-      multiStore.push_back(std::move(bucket.pending));
-      auto& stored = multiStore.back();
+    std::vector<hsa_amd_memory_copy_op_t> final_operations;
+    std::vector<CopyListStorage> copy_list_storage;
+    final_operations.reserve(ops.size());
+    copy_list_storage.reserve((swap_operations.empty() ? 0 : 1) + linear_operations.size() +
+                              indirect_operations.size());
 
-      hsa_amd_memory_copy_op_t indirect = {};
-      indirect.version = HSA_AMD_MEMORY_COPY_OP_VERSION;
-      indirect.type = type;
-      indirect.src_agent = bucket.src_agent;
-      indirect.src_list = stored.srcs.data();
-      indirect.dst_list = stored.dsts.data();
-      indirect.dst_agent_list = stored.dst_agents.data();
-      indirect.size_list = stored.sizes.data();
-      indirect.num_entries = static_cast<uint16_t>(stored.srcs.size());
-      finalOps.push_back(indirect);
-    }
+    PushSwapOperations(swap_operations, final_operations, copy_list_storage);
+    PushLinearOperations(linear_operations, engine, final_operations, copy_list_storage);
+    PushIndirectOperations(indirect_operations, final_operations, copy_list_storage);
 
     // Assign one completion signal per op in a single place.
-    for (auto& op : finalOps) {
+    for (auto& op : final_operations) {
       op.completion_signal = gpu().Barriers().ActiveSignal(1, gpu().timestamp());
       groupSignals.push_back(gpu().Barriers().GetLastSignal());
     }
 
-    for (size_t i = 0; i < finalOps.size(); ++i) {
-      const auto& op = finalOps[i];
+    for (size_t i = 0; i < final_operations.size(); ++i) {
+      const auto& op = final_operations[i];
       if (op.type == HSA_AMD_MEMORY_COPY_OP_LINEAR_BROADCAST) {
         for (uint32_t d = 0; d < op.num_entries; ++d) {
           ClPrint(amd::LOG_DEBUG, amd::LOG_COPY2,
@@ -1027,16 +1070,15 @@ bool DmaBlitManager::rocrCopyBufferBatch(const std::vector<hsa_amd_memory_copy_o
         ClPrint(amd::LOG_DEBUG, amd::LOG_COPY2,
                 "HSA BatchCopy Linear [%zu/%zu] engineOp=%s, dst=%p, src=%p, size=%zu, "
                 "src_agent=0x%zx, dst_agent=0x%zx, wait_event=0x%zx, completion_signal=0x%zx",
-                i, finalOps.size(), EngineOpName(engine), op.dst, op.src, op.size,
+                i, final_operations.size(), EngineOpName(engine), op.dst, op.src, op.size,
                 op.src_agent.handle, op.dst_agent.handle,
-                (wait_events.size() != 0) ? wait_events[0].handle : 0,
-                op.completion_signal.handle);
+                (wait_events.size() != 0) ? wait_events[0].handle : 0, op.completion_signal.handle);
       }
     }
 
-    status = Hsa::memory_async_batch_copy(
-        finalOps.data(), static_cast<uint32_t>(finalOps.size()),
-        wait_events.size(), wait_events.data());
+    status = Hsa::memory_async_batch_copy(final_operations.data(),
+                                          static_cast<uint32_t>(final_operations.size()),
+                                          wait_events.size(), wait_events.data());
 
     if (status != HSA_STATUS_SUCCESS) {
       gpu().Barriers().ResetCurrentSignal();

--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -855,6 +855,12 @@ memory:
   Unit_hipMemcpyBatchAsync_P2P_Functional:
     <<: *level_2
     tags: [transfer, multigpu]
+  Unit_hipMemcpyBatchAsync_IndirectDst:
+    <<: *level_2
+    tags: [transfer]
+  Unit_hipMemcpyBatchAsync_IndirectSrc:
+    <<: *level_2
+    tags: [transfer]
   Unit_hipMemsetD2D8_BasicFunctional:
     <<: *level_2
     disabled: [amd_wsl]

--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -834,7 +834,7 @@ memory:
   Unit_hipMemcpyBatchAsync_Attrs_Negative:
     <<: *level_2
     tags: [transfer]
-  Unit_hipMemcpyBatchAsync_Attrs_Functional:
+  Unit_hipMemcpyBatchAsync_D2D_Swap:
     <<: *level_2
     tags: [transfer]
   Unit_hipMemcpyBatchAsync_H2D_Functional: *level_2

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <array>
 #include <cstddef>
+#include <cstring>
 #include <utility>
 #include <vector>
 
@@ -857,6 +858,96 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_P2P_Functional) {
   DisablePeerAccess(peer_pairs);
   HIP_CHECK(hipSetDevice(stream_device));
 }
+
+#if HT_AMD
+/**
+ * Test Description
+ * ------------------------
+ * - Verifies H2D hipMemcpyBatchAsync with hipMemcpyFlagExtOpIndirectSrc copies
+ * from the host buffer referenced by a pinned pointer slot.
+ * Test source
+ * ------------------------
+ * - catch/unit/memory/hipMemcpyBatchAsync.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.1
+ */
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_IndirectSrc) {
+  constexpr size_t copy_size = kSmallCopySize;
+
+  StreamGuard stream_guard(Streams::created);
+  LinearAllocGuard<int> src(LinearAllocs::hipHostMalloc, copy_size);
+  LinearAllocGuard<int> dst(LinearAllocs::hipMalloc, copy_size);
+  LinearAllocGuard<char> src_slot(LinearAllocs::hipHostMalloc, sizeof(void*));
+
+  const size_t copy_elements = CopyElements(copy_size);
+  std::fill_n(src.host_ptr(), copy_elements, kPatternValue);
+
+  void* src_ptr = src.ptr();
+  std::memcpy(src_slot.ptr(), &src_ptr, sizeof(void*));
+
+  std::vector<void*> dst_ptrs{dst.ptr()};
+  std::vector<void*> src_ptrs{src_slot.ptr()};
+  std::vector<size_t> sizes{copy_size};
+  hipMemcpyAttributes attr{hipMemcpySrcAccessOrderStream, {}, {}, hipMemcpyFlagExtOpIndirectSrc};
+  size_t attrs_idx = 0;
+
+  hipError_t status = hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), 1, &attr,
+                                          &attrs_idx, 1, nullptr, stream_guard.stream());
+  if (status == hipErrorNotSupported) {
+    SUCCEED("hipMemcpyFlagExtOpIndirectSrc is not supported on this device");
+  } else {
+    HIP_CHECK(status);
+    HIP_CHECK(hipStreamSynchronize(stream_guard.stream()));
+    VerifyDeviceBuffers(dst_ptrs, copy_size);
+  }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ * - Verifies D2H hipMemcpyBatchAsync with hipMemcpyFlagExtOpIndirectDst copies
+ * into the host buffer referenced by a pinned pointer slot.
+ * Test source
+ * ------------------------
+ * - catch/unit/memory/hipMemcpyBatchAsync.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.1
+ */
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_IndirectDst) {
+  constexpr size_t copy_size = kSmallCopySize;
+
+  StreamGuard stream_guard(Streams::created);
+  LinearAllocGuard<int> src(LinearAllocs::hipMalloc, copy_size);
+  LinearAllocGuard<int> dst(LinearAllocs::hipHostMalloc, copy_size);
+  LinearAllocGuard<char> dst_slot(LinearAllocs::hipHostMalloc, sizeof(void*));
+
+  const size_t copy_elements = CopyElements(copy_size);
+  std::vector<int> host_pattern(copy_elements, kPatternValue);
+  HIP_CHECK(hipMemcpy(src.ptr(), host_pattern.data(), copy_size, hipMemcpyHostToDevice));
+  std::fill_n(dst.host_ptr(), copy_elements, 0);
+
+  void* dst_ptr = dst.ptr();
+  std::memcpy(dst_slot.ptr(), &dst_ptr, sizeof(void*));
+
+  std::vector<void*> src_ptrs{src.ptr()};
+  std::vector<void*> dst_ptrs{dst_slot.ptr()};
+  std::vector<size_t> sizes{copy_size};
+  hipMemcpyAttributes attr{hipMemcpySrcAccessOrderStream, {}, {}, hipMemcpyFlagExtOpIndirectDst};
+  size_t attrs_idx = 0;
+
+  hipError_t status = hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), 1, &attr,
+                                          &attrs_idx, 1, nullptr, stream_guard.stream());
+  if (status == hipErrorNotSupported) {
+    SUCCEED("hipMemcpyFlagExtOpIndirectDst is not supported on this device");
+  } else {
+    HIP_CHECK(status);
+    HIP_CHECK(hipStreamSynchronize(stream_guard.stream()));
+    VerifyArrayFromBothEnds(dst.host_ptr(), copy_elements, kPatternValue, 0);
+  }
+}
+#endif
 
 /**
  * End doxygen group MemoryTest.

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
@@ -378,11 +378,11 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_Attrs_Negative) {
   }
 }
 
+#if HT_AMD
 /**
  * Test Description
  * ------------------------
- * - Verifies segmented host-source access attributes and swap attributes for
- * hipMemcpyBatchAsync.
+ * - Verifies D2D batch copies with hipMemcpyFlagExtOpSwap.
  * Test source
  * ------------------------
  * - catch/unit/memory/hipMemcpyBatchAsync.cc
@@ -390,81 +390,37 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_Attrs_Negative) {
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_Attrs_Functional) {
-  constexpr size_t kCopiesPerAttr = 3;
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_D2D_Swap) {
+  constexpr size_t copy_count = 3;
+  constexpr size_t copy_size = kSmallCopySize;
+  constexpr int kSwapSrcValue = 23;
+  constexpr int kSwapDstValue = 47;
+  BatchConfig config{copy_count, copy_size};
   StreamGuard stream_guard(Streams::created);
+  std::vector<LinearAllocGuard<int>> src = AllocateBatchBuffers(LinearAllocs::hipMalloc, config);
+  std::vector<LinearAllocGuard<int>> dst = AllocateBatchBuffers(LinearAllocs::hipMalloc, config);
+  std::vector<void*> src_ptrs = MakeBatchPtrs(src);
+  std::vector<void*> dst_ptrs = MakeBatchPtrs(dst);
+  std::vector<size_t> sizes(src_ptrs.size(), copy_size);
+  hipMemcpyAttributes attr{hipMemcpySrcAccessOrderStream, {}, {}, hipMemcpyFlagExtOpSwap};
+  size_t attrs_idxs[1] = {0};
 
-  SECTION("Regular attributes") {
-#if HT_AMD
-    std::array<hipMemcpyAttributes, 6> host_attrs{
-        hipMemcpyAttributes{hipMemcpySrcAccessOrderStream, {}, {}, hipMemcpyFlagDefault},
-        hipMemcpyAttributes{hipMemcpySrcAccessOrderStream, {}, {}, hipMemcpyFlagExtPreferCE},
-        hipMemcpyAttributes{hipMemcpySrcAccessOrderDuringApiCall, {}, {}, hipMemcpyFlagDefault},
-        hipMemcpyAttributes{hipMemcpySrcAccessOrderDuringApiCall, {}, {}, hipMemcpyFlagExtPreferCE},
-        hipMemcpyAttributes{hipMemcpySrcAccessOrderAny, {}, {}, hipMemcpyFlagDefault},
-        hipMemcpyAttributes{hipMemcpySrcAccessOrderAny, {}, {}, hipMemcpyFlagExtPreferCE},
-    };
-#else
-    std::array<hipMemcpyAttributes, 3> host_attrs{
-        hipMemcpyAttributes{hipMemcpySrcAccessOrderStream, {}, {}, hipMemcpyFlagDefault},
-        hipMemcpyAttributes{hipMemcpySrcAccessOrderDuringApiCall, {}, {}, hipMemcpyFlagDefault},
-        hipMemcpyAttributes{hipMemcpySrcAccessOrderAny, {}, {}, hipMemcpyFlagDefault},
-    };
-#endif
-    BatchConfig host_config{host_attrs.size() * kCopiesPerAttr, kSmallCopySize};
-    std::vector<LinearAllocGuard<int>> host_src =
-        AllocateBatchBuffers(LinearAllocs::hipHostMalloc, host_config);
-    std::vector<LinearAllocGuard<int>> dst =
-        AllocateBatchBuffers(LinearAllocs::hipMalloc, host_config);
-    std::vector<void*> host_src_ptrs = MakeBatchPtrs(host_src);
-    std::vector<void*> dst_ptrs = MakeBatchPtrs(dst);
-    std::vector<size_t> sizes(host_src_ptrs.size(), kSmallCopySize);
-    std::vector<size_t> attrs_idxs;
+  FillDeviceBuffers(src_ptrs, copy_size, kSwapSrcValue);
+  FillDeviceBuffers(dst_ptrs, copy_size, kSwapDstValue);
 
-    for (size_t attr_idx = 0; attr_idx < host_attrs.size(); ++attr_idx) {
-      attrs_idxs.push_back(attr_idx * kCopiesPerAttr);
-    }
-
-    FillHostBuffers(host_src, kSmallCopySize);
-
-    HIP_CHECK(hipMemcpyBatchAsync(dst_ptrs.data(), host_src_ptrs.data(), sizes.data(), sizes.size(),
-                                  host_attrs.data(), attrs_idxs.data(), attrs_idxs.size(), nullptr,
-                                  stream_guard.stream()));
+  hipError_t status = hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(),
+                                          src_ptrs.size(), &attr, attrs_idxs, 1, nullptr,
+                                          stream_guard.stream());
+  if (status == hipErrorNotSupported) {
+    SUCCEED("hipMemcpyFlagExtOpSwap is not supported on this device");
+  } else {
+    HIP_CHECK(status);
     HIP_CHECK(hipStreamSynchronize(stream_guard.stream()));
-    VerifyDeviceBuffers(dst_ptrs, kSmallCopySize);
+    VerifyDeviceBuffers(src_ptrs, copy_size, kSwapDstValue);
+    VerifyDeviceBuffers(dst_ptrs, copy_size, kSwapSrcValue);
   }
-
-#if HT_AMD
-  SECTION("Swap attribute") {
-    BatchConfig d2d_config{kCopiesPerAttr, kSmallCopySize};
-    std::vector<LinearAllocGuard<int>> d2d_src =
-        AllocateBatchBuffers(LinearAllocs::hipMalloc, d2d_config);
-    std::vector<LinearAllocGuard<int>> d2d_dst =
-        AllocateBatchBuffers(LinearAllocs::hipMalloc, d2d_config);
-    std::vector<void*> d2d_src_ptrs = MakeBatchPtrs(d2d_src);
-    std::vector<void*> d2d_dst_ptrs = MakeBatchPtrs(d2d_dst);
-    std::vector<size_t> sizes(d2d_src_ptrs.size(), kSmallCopySize);
-    hipMemcpyAttributes attr{hipMemcpySrcAccessOrderStream, {}, {}, hipMemcpyFlagExtOpSwap};
-    size_t attrs_idxs[1] = {0};
-    constexpr int kSwapSrcValue = 23;
-    constexpr int kSwapDstValue = 47;
-    FillDeviceBuffers(d2d_src_ptrs, kSmallCopySize, kSwapSrcValue);
-    FillDeviceBuffers(d2d_dst_ptrs, kSmallCopySize, kSwapDstValue);
-
-    hipError_t status = hipMemcpyBatchAsync(d2d_dst_ptrs.data(), d2d_src_ptrs.data(), sizes.data(),
-                                            d2d_src_ptrs.size(), &attr, attrs_idxs, 1, nullptr,
-                                            stream_guard.stream());
-    if (status == hipErrorNotSupported) {
-      SUCCEED("hipMemcpyFlagExtOpSwap is not supported on this device");
-    } else {
-      HIP_CHECK(status);
-      HIP_CHECK(hipStreamSynchronize(stream_guard.stream()));
-      VerifyDeviceBuffers(d2d_src_ptrs, kSmallCopySize, kSwapDstValue);
-      VerifyDeviceBuffers(d2d_dst_ptrs, kSmallCopySize, kSwapSrcValue);
-    }
-  }
-#endif
 }
+#endif
 
 /**
  * Test Description


### PR DESCRIPTION
## Motivation

 - Broadcast logic has performance hits when batch has many copies even if there are no broadcast copies.

## Technical Details

 - Split the processing logic based on copy types: Indirect, Swap, Linear.
 - Non-D2D copies with single source agent now doesn't take the broadcast logic path.

## JIRA ID

/ 

## Test Plan

/ 

## Test Result

/ 

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
