### PR TITLE
[hipfile] fixed blurb, appearance of landing page + added license to toc

### DIFF
--- a/projects/hipfile/docs/index.rst
+++ b/projects/hipfile/docs/index.rst
@@ -8,7 +8,7 @@
 hipFile documentation
 **********************
 
-hipFile is AMD's Infinity Storage library that provides direct-to-GPU I/O for the ROCm platform. The library provides C and Python APIs for synchronous, asynchronous, and batch I/O operations. hipFile automatically falls back to POSIX I/O when operations are unable to use the direct-to-GPU path.
+hipFile is AMD's Infinity Storage library that provides direct-to-GPU I/O without requiring a host-side buffer. The library provides C and Python APIs for synchronous, asynchronous, and batch I/O operations. hipFile automatically falls back to POSIX I/O when operations are unable to use the direct-to-GPU path.
 
 hipFile is delivered as part of `TheRock <https://github.com/ROCm/TheRock>`_. The hipFile source code is located at https://github.com/ROCm/rocm-systems/tree/develop/projects/hipfile.
 
@@ -20,6 +20,9 @@ hipFile is delivered as part of `TheRock <https://github.com/ROCm/TheRock>`_. Th
       * :doc:`Install hipFile <install/install>`
       * :doc:`Build hipFile from source <install/build-from-source>`
       * :doc:`Install the hipFile Python bindings <install/python-bindings>`
+
+.. grid:: 2
+   :gutter: 3
 
    .. grid-item-card:: How to
 
@@ -49,8 +52,5 @@ hipFile is delivered as part of `TheRock <https://github.com/ROCm/TheRock>`_. Th
 
       * :doc:`Troubleshooting <troubleshooting/troubleshooting>`
       * :doc:`Known issues <troubleshooting/known-issues>`
-
-To contribute to the documentation, refer to
-`Contributing to ROCm <https://rocm.docs.amd.com/en/latest/contribute/contributing.html>`_.
 
 Licensing information is in the `LICENSE.md <https://github.com/ROCm/rocm-systems/blob/develop/projects/hipfile/LICENSE.md>`_ file in the repository.

--- a/projects/hipfile/docs/sphinx/_toc.yml.in
+++ b/projects/hipfile/docs/sphinx/_toc.yml.in
@@ -59,3 +59,6 @@ subtrees:
         title: Troubleshooting
       - file: troubleshooting/known-issues
         title: Known issues
+  - caption: About
+    entries:
+      - file: license.rst


### PR DESCRIPTION
## Motivation

The landing page blurb wasn't clear and it's been fixed up. The boxes have been better aligned. The license has been added to the toc under "about"