### PR TITLE
fix(clr): use tracker-owned signal for queue idle

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1160,8 +1160,7 @@ void VirtualGPU::SetGpuQueue(hsa_queue_t* queue, void* metadata_ring_buffer) {
   // indices refer to a different queue. Reset to the "empty queue" sentinel so IsQueueIdle() does
   // not dereference a stale completion-signal handle.
   last_write_index_ = kInvalidQueueIndex;
-  last_packet_with_signal_index_ = kInvalidQueueIndex;
-  last_completion_signal_.handle = 0;
+  MarkQueueIdle();
   metadata_preloader_.SetQueueBase(metadata_ring_buffer,
                                    roc_device_.MetadataVersionHeader());
 }
@@ -1432,6 +1431,7 @@ bool VirtualGPU::dispatchGenericAqlPacket(AqlPacket* packet, uint16_t header, ui
                      packet->completion_signal.handle);
       return false;
     }
+    MarkQueueIdle();
   }
 
   return true;
@@ -1766,6 +1766,7 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPack
       profilingEnd();
       return false;
     }
+    MarkQueueIdle();
   }
 
   profilingEnd();
@@ -1956,6 +1957,7 @@ bool VirtualGPU::releaseGpuMemoryFence(bool skip_cpu_wait) {
   // Check if runtime could skip CPU wait
   if (!skip_cpu_wait) {
     Barriers().WaitCurrent();
+    MarkQueueIdle();
 
     ResetQueueStates();
   }
@@ -3977,6 +3979,7 @@ void VirtualGPU::submitVirtualMap(amd::VirtualMapCommand& vcmd) {
   } else {
     dispatchBarrierPacket(kBarrierPacketHeader, false);
     Barriers().WaitCurrent();
+    MarkQueueIdle();
 
     amd::Memory* vaddr_sub_obj = amd::MemObjMap::FindMemObj(vcmd.ptr());
     assert(vaddr_sub_obj != nullptr);

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1821,7 +1821,11 @@ void VirtualGPU::dispatchBarrierPacket(uint16_t packetHeader, bool skipSignal,
   setFenceDirty(true);
   auto cache_state = extractAqlBits(packetHeader, HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE,
                                     HSA_PACKET_HEADER_WIDTH_SCRELEASE_FENCE_SCOPE);
-  if (!skipSignal && (signal.handle == 0)) {
+  // Tracker-owned only when the signal comes from Barriers().ActiveSignal() below; an externally
+  // provided signal (managed-buffer pool, IPC) is a different object, so it is not usable for idle
+  // detection and must be treated like skip_signal.
+  const bool external_signal = skipSignal || (signal.handle != 0);
+  if (!external_signal) {
     // Get active signal for current dispatch if profiling is necessary
     barrier_packet_.completion_signal = Barriers().ActiveSignal(kInitSignalValueOne, timestamp_);
   } else {
@@ -1829,7 +1833,7 @@ void VirtualGPU::dispatchBarrierPacket(uint16_t packetHeader, bool skipSignal,
     barrier_packet_.completion_signal = signal;
   }
 
-  TrackQueueProgress(barrier_packet_, index);
+  TrackQueueProgress(barrier_packet_, index, external_signal);
 
   // Reset fence_dirty_ flag if we submit a barrier with system scopes
   if (cache_state == amd::Device::kCacheStateSystem) {
@@ -1895,7 +1899,11 @@ void VirtualGPU::dispatchBarrierValuePacket(uint16_t packetHeader, bool resolveD
   auto cache_state = extractAqlBits(packetHeader, HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE,
                                     HSA_PACKET_HEADER_WIDTH_SCRELEASE_FENCE_SCOPE);
 
-  if (completionSignal.handle == 0) {
+  // Tracker-owned only when the signal comes from Barriers().ActiveSignal() below; an externally
+  // provided completion signal is a different object, so it is not usable for idle detection and
+  // must be treated like skip_signal.
+  const bool external_signal = (completionSignal.handle != 0);
+  if (!external_signal) {
     // Get active signal for current dispatch if profiling is necessary
     barrier_value_packet_.completion_signal =
         Barriers().ActiveSignal(kInitSignalValueOne, skipTs ? nullptr : timestamp_);
@@ -1911,7 +1919,7 @@ void VirtualGPU::dispatchBarrierValuePacket(uint16_t packetHeader, bool resolveD
 
   uint64_t index = Hsa::queue_add_write_index_screlease(gpu_queue_, 1);
 
-  TrackQueueProgress(barrier_value_packet_, index);
+  TrackQueueProgress(barrier_value_packet_, index, external_signal);
 
   WaitForQueueSlot(index, queueMask);
   hsa_amd_barrier_value_packet_t* aql_loc = &(reinterpret_cast<hsa_amd_barrier_value_packet_t*>(
@@ -1940,7 +1948,7 @@ bool VirtualGPU::IsQueueIdle() const {
     return true;
   }
 
-  // The last packet must have carried a queue-owned completion signal; otherwise idleness
+  // The last packet must have carried the queue-owned completion signal; otherwise idleness
   // cannot be proven.
   if (last_packet_with_signal_index_ != last_write_index_) {
     return false;

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1156,11 +1156,10 @@ void VirtualGPU::SetGpuQueue(hsa_queue_t* queue, void* metadata_ring_buffer) {
   cached_read_dispatch_id_ = 0;
   // The cached queue-progress state belongs to the previously assigned HW queue. When the HW
   // queue changes (released back to / reacquired from the shared dynamic-queue pool), that state
-  // is stale: the recorded completion signal may have been recycled/destroyed and the write
-  // indices refer to a different queue. Reset to the "empty queue" sentinel so IsQueueIdle() does
-  // not dereference a stale completion-signal handle.
+  // is stale: the write indices refer to a different queue. Reset to the "empty queue" sentinel
+  // so IsQueueIdle() reports idle for the freshly assigned queue.
   last_write_index_ = kInvalidQueueIndex;
-  MarkQueueIdle();
+  last_packet_with_signal_index_ = kInvalidQueueIndex;
   metadata_preloader_.SetQueueBase(metadata_ring_buffer,
                                    roc_device_.MetadataVersionHeader());
 }
@@ -1431,7 +1430,6 @@ bool VirtualGPU::dispatchGenericAqlPacket(AqlPacket* packet, uint16_t header, ui
                      packet->completion_signal.handle);
       return false;
     }
-    MarkQueueIdle();
   }
 
   return true;
@@ -1766,7 +1764,6 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPack
       profilingEnd();
       return false;
     }
-    MarkQueueIdle();
   }
 
   profilingEnd();
@@ -1933,6 +1930,30 @@ void VirtualGPU::dispatchBarrierValuePacket(uint16_t packetHeader, bool resolveD
 }
 
 // ================================================================================================
+bool VirtualGPU::IsQueueIdle() const {
+  if (gpu_queue_ == nullptr) {
+    return true;
+  }
+
+  // Nothing has been submitted to this HW queue yet.
+  if (last_write_index_ == kInvalidQueueIndex) {
+    return true;
+  }
+
+  // The last packet must have carried a queue-owned completion signal; otherwise idleness
+  // cannot be proven.
+  if (last_packet_with_signal_index_ != last_write_index_) {
+    return false;
+  }
+
+  // Read the tracker-owned completion signal instead of a cached handle. The tracker owns this
+  // signal for the lifetime of the HW queue, so this never dereferences a recycled/destroyed
+  // signal (unlike a copied hsa_signal_t handle, which was the source of the teardown segfault).
+  const ProfilingSignal* signal = barriers_.GetLastSignal();
+  return (signal == nullptr) || (Hsa::signal_load_relaxed(signal->signal_) == 0);
+}
+
+// ================================================================================================
 void VirtualGPU::ResetQueueStates() {
   // Release all memory dependencies
   memoryDependency().clear();
@@ -1957,7 +1978,6 @@ bool VirtualGPU::releaseGpuMemoryFence(bool skip_cpu_wait) {
   // Check if runtime could skip CPU wait
   if (!skip_cpu_wait) {
     Barriers().WaitCurrent();
-    MarkQueueIdle();
 
     ResetQueueStates();
   }
@@ -3979,7 +3999,6 @@ void VirtualGPU::submitVirtualMap(amd::VirtualMapCommand& vcmd) {
   } else {
     dispatchBarrierPacket(kBarrierPacketHeader, false);
     Barriers().WaitCurrent();
-    MarkQueueIdle();
 
     amd::Memory* vaddr_sub_obj = amd::MemObjMap::FindMemObj(vcmd.ptr());
     assert(vaddr_sub_obj != nullptr);

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -725,23 +725,24 @@ class VirtualGPU : public device::VirtualDevice {
   //! Resets the current queue state. Note: should be called after AQL queue becomes idle
   void ResetQueueStates();
 
-  //! Marks queue progress when a packet is submitted. The queue is considered busy until an
-  //! explicit synchronization path observes completion and marks it idle again.
+  //! Track the progress of the queue based on the last write index and whether the last packet
+  //! carried a queue-owned completion signal. When skip_signal is true, the last packet's signal
+  //! is externally managed (graph pre-patched dispatches), so it is not usable for idle detection.
+  //! No HSA signal handle is cached here: idleness is derived at check time from the tracker-owned
+  //! signal, whose lifetime matches the queue's signal tracker.
   template <typename AqlPacket>
   inline void TrackQueueProgress(const AqlPacket& packet, uint64_t index,
                                  bool skip_signal = false) {
-    (void)packet;
-    (void)skip_signal;
     last_write_index_ = index;
-    queue_idle_ = false;
+    if (!skip_signal && packet.completion_signal.handle != 0) {
+      last_packet_with_signal_index_ = index;
+    }
   }
 
-  //! Marks the current queue as synchronized. Call only after submitted packets are known complete.
-  void MarkQueueIdle() { queue_idle_ = true; }
-
   //! Returns true if the queue is considered as idle. That means all submitted packets are
-  //! complete. Note: it doesn't track the state of caches
-  bool IsQueueIdle() const { return (gpu_queue_ == nullptr) || queue_idle_; }
+  //! complete. Note: it doesn't track the state of caches. Defined out-of-line because it reads
+  //! ProfilingSignal, which is incomplete in this header.
+  bool IsQueueIdle() const;
 
   //! True if this marker records the same event as the preceding barrier with no
   //! intervening dispatch or sync. Caller must hold the execution() lock.
@@ -875,7 +876,8 @@ class VirtualGPU : public device::VirtualDevice {
                                           //!< fence after hidden heap init.
 
   uint64_t last_write_index_ = kInvalidQueueIndex; //!< The last HW queue write index for any packet
-  bool queue_idle_ = true;                         //!< True when submitted packets are known complete
+  uint64_t last_packet_with_signal_index_ = kInvalidQueueIndex; //!< The last HW queue write index for a packet
+                                              //!< with a completion signal
 
   //! SDMA engine affinity tracking for this VirtualGPU/stream
   uint32_t assigned_sdma_engine_ = 0;           //!< Assigned SDMA engine mask for all operations

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -725,11 +725,9 @@ class VirtualGPU : public device::VirtualDevice {
   //! Resets the current queue state. Note: should be called after AQL queue becomes idle
   void ResetQueueStates();
 
-  //! Track the progress of the queue based on the last write index and whether the last packet
-  //! carried a queue-owned completion signal. When skip_signal is true, the last packet's signal
-  //! is externally managed (graph pre-patched dispatches), so it is not usable for idle detection.
-  //! No HSA signal handle is cached here: idleness is derived at check time from the tracker-owned
-  //! signal, whose lifetime matches the queue's signal tracker.
+  //! Record the last write index and whether the last packet is idle-trackable. Only tracker-owned
+  //! signals (from Barriers().ActiveSignal()) qualify; set skip_signal for externally-provided or
+  //! absent completion signals. IsQueueIdle() reads the tracker-owned signal at check time.
   template <typename AqlPacket>
   inline void TrackQueueProgress(const AqlPacket& packet, uint64_t index,
                                  bool skip_signal = false) {
@@ -739,9 +737,8 @@ class VirtualGPU : public device::VirtualDevice {
     }
   }
 
-  //! Returns true if the queue is considered as idle. That means all submitted packets are
-  //! complete. Note: it doesn't track the state of caches. Defined out-of-line because it reads
-  //! ProfilingSignal, which is incomplete in this header.
+  //! Returns true if the queue is considered as idle, i.e. all submitted packets are complete.
+  //! Note: it doesn't track the state of caches.
   bool IsQueueIdle() const;
 
   //! True if this marker records the same event as the preceding barrier with no

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -725,40 +725,23 @@ class VirtualGPU : public device::VirtualDevice {
   //! Resets the current queue state. Note: should be called after AQL queue becomes idle
   void ResetQueueStates();
 
-  //! Track the progress of the queue based on the last write index and completion signal.
-  //! When skip_signal is true, only the write index is advanced and the completion signal
-  //! is cleared. Used for graph pre-patched dispatches whose signals are externally
-  //! managed and freed after graph completion.
+  //! Marks queue progress when a packet is submitted. The queue is considered busy until an
+  //! explicit synchronization path observes completion and marks it idle again.
   template <typename AqlPacket>
   inline void TrackQueueProgress(const AqlPacket& packet, uint64_t index,
                                  bool skip_signal = false) {
+    (void)packet;
+    (void)skip_signal;
     last_write_index_ = index;
-    if (skip_signal) {
-      last_completion_signal_.handle = 0;
-    } else if (packet.completion_signal.handle != 0) {
-      last_packet_with_signal_index_ = index;
-      last_completion_signal_ = packet.completion_signal;
-    }
+    queue_idle_ = false;
   }
+
+  //! Marks the current queue as synchronized. Call only after submitted packets are known complete.
+  void MarkQueueIdle() { queue_idle_ = true; }
 
   //! Returns true if the queue is considered as idle. That means all submitted packets are
   //! complete. Note: it doesn't track the state of caches
-  bool IsQueueIdle() const {
-    if (gpu_queue_ == nullptr) {
-      return true;
-    }
-
-    // Make sure the last packet contained a completion signal
-    if (last_packet_with_signal_index_ == last_write_index_) {
-      if ((last_write_index_ == kInvalidQueueIndex) && (last_completion_signal_.handle == 0)) {
-        return true;
-      } else {
-        return (Hsa::signal_load_relaxed(last_completion_signal_) == 0);
-      }
-    }
-
-    return false;
-  }
+  bool IsQueueIdle() const { return (gpu_queue_ == nullptr) || queue_idle_; }
 
   //! True if this marker records the same event as the preceding barrier with no
   //! intervening dispatch or sync. Caller must hold the execution() lock.
@@ -892,9 +875,7 @@ class VirtualGPU : public device::VirtualDevice {
                                           //!< fence after hidden heap init.
 
   uint64_t last_write_index_ = kInvalidQueueIndex; //!< The last HW queue write index for any packet
-  uint64_t last_packet_with_signal_index_ = kInvalidQueueIndex; //!< The last HW queue write index for a packet
-                                              //!< with a completion signal
-  hsa_signal_t last_completion_signal_{};     //!< The last completion signal
+  bool queue_idle_ = true;                         //!< True when submitted packets are known complete
 
   //! SDMA engine affinity tracking for this VirtualGPU/stream
   uint32_t assigned_sdma_engine_ = 0;           //!< Assigned SDMA engine mask for all operations


### PR DESCRIPTION
## Motivation

Avoid a CLR use-after-free crash in queue-idle detection. The failing ROCM-27035 signature shows `IsQueueIdle()` reaching `hsa_signal_load_relaxed()` through `libamdhip64`/`libhsa-runtime64` after the cached completion signal can be recycled or destroyed.

## Technical Details

- Stop caching a raw `hsa_signal_t` completion-signal handle for queue-idle detection.
- Keep only queue-progress bookkeeping for the last queue write index and whether the last submitted packet used the queue tracker-owned completion signal.
- Move `VirtualGPU::IsQueueIdle()` out of line and derive idleness by reading `barriers_.GetLastSignal()` at check time.
- Reset queue-progress state when switching/reassigning hardware queues.
- Treat externally supplied completion signals, graph pre-patched dispatches, managed-buffer-pool signals, IPC signals, and packets without queue-owned completion signals as not usable for idle detection.
- Only consider the queue idle-trackable when the last packet used the queue's tracker-owned signal from `Barriers().ActiveSignal()`.

This avoids dereferencing stale or recycled signal handles while preserving the requirement that queue release only happens when completion can be proven from a queue-owned signal.

## JIRA ID

JIRA ID: ROCM-27035

## Test Plan

The issue could only be reproduced with the specific workflow from ROCM-27035 so far and only on specific system. Could not capture the failure in a unit test.

## Test Result

The  segfault seen in ROCM-27035 was reproduced on hjbog-srdc-45. Verified that no segfault is not seen after the fix with repeated runs.


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
