### PR TITLE
rocr: make HotSwap entry trampolines opt-in

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
@@ -255,9 +255,16 @@ TEST(HotswapRewriteDecision, A0RetargetsThroughLegacyPathRegardlessOfOptions) {
   }
 }
 
-TEST(HotswapRewriteDecision, EntryTrampolinesDefaultOnRoutesNonA0Gfx1250) {
+TEST(HotswapRewriteDecision, EntryTrampolinesDefaultOffBlocksNonA0Gfx1250) {
   const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
       MakeRevision("gfx1250", 1), kGfx1250Isa, kGfx1250Isa, {});
+
+  EXPECT_FALSE(decision.has_value());
+}
+
+TEST(HotswapRewriteDecision, EntryTrampolinesExplicitlyEnabledRoutesNonA0Gfx1250) {
+  const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
+      MakeRevision("gfx1250", 1), kGfx1250Isa, kGfx1250Isa, {true});
 
   ASSERT_TRUE(decision.has_value());
   EXPECT_EQ(decision->source_isa, kGfx1250B0Isa);
@@ -274,10 +281,10 @@ TEST(HotswapRewriteDecision, EntryTrampolinesDisabledBlocksNonA0Gfx1250) {
 
 TEST(HotswapRewriteDecision, EntryTrampolinesRouteGfx12_5Family) {
   const auto concrete = rocr::hotswap::DecideHotswapRewriteForTesting(
-      MakeRevision("gfx1251", 1), kGfx1251Isa, kGfx1251Isa, {});
+      MakeRevision("gfx1251", 1), kGfx1251Isa, kGfx1251Isa, {true});
   const auto generic = rocr::hotswap::DecideHotswapRewriteForTesting(
       MakeRevision("gfx12-5-generic", 1), kGfx12_5GenericIsa,
-      kGfx12_5GenericIsa, {});
+      kGfx12_5GenericIsa, {true});
 
   ASSERT_TRUE(concrete.has_value());
   EXPECT_EQ(concrete->source_isa, kGfx1251Isa);
@@ -291,7 +298,7 @@ TEST(HotswapRewriteDecision, EntryTrampolinesRouteGfx12_5Family) {
 
 TEST(HotswapRewriteDecision, EntryTrampolinesUseGenericSourceAsTarget) {
   const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
-      MakeRevision("gfx1251", 1), kGfx12_5GenericIsa, kGfx1251Isa, {});
+      MakeRevision("gfx1251", 1), kGfx12_5GenericIsa, kGfx1251Isa, {true});
 
   ASSERT_TRUE(decision.has_value());
   EXPECT_EQ(decision->source_isa, kGfx12_5GenericIsa);
@@ -418,9 +425,8 @@ TEST(HotswapRewrite, RuntimeLoadUsesRewrittenCodeObject) {
       rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 0u);
 }
 
-TEST(HotswapRewrite, RuntimeLoadNonA0UsesDefaultEntryTrampolines) {
+TEST(HotswapRewrite, RuntimeLoadNonA0UsesOriginalPathByDefault) {
   ResetRuntimeTestEnv();
-  if (!NewComgrHotswapApiAvailable()) return;
   g_fake_hsa_env.asic_revision = 1;
   LoadRecorder load;
   const hsa_executable_t executable = MakeTestExecutable(0x502);
@@ -431,21 +437,16 @@ TEST(HotswapRewrite, RuntimeLoadNonA0UsesDefaultEntryTrampolines) {
 
   EXPECT_EQ(status, HSA_STATUS_SUCCESS);
   ASSERT_EQ(load.calls.size(), 1u);
-  EXPECT_EQ(load.calls[0].path, LoadPath::kRewritten);
-  EXPECT_NE(load.calls[0].code_object, static_cast<const void*>(kGfx1250MinCo));
-  EXPECT_GT(load.calls[0].code_object_size, 0u);
-  EXPECT_EQ(
-      rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 1u);
-
-  rocr::hotswap::ReleaseRetainedRewrittenElfBuffers(executable);
+  EXPECT_EQ(load.calls[0].path, LoadPath::kOriginal);
+  EXPECT_EQ(load.calls[0].code_object, static_cast<const void*>(kGfx1250MinCo));
   EXPECT_EQ(
       rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 0u);
 }
 
-TEST(HotswapRewrite, RuntimeLoadNonA0FallsBackWhenEntryTrampolinesAreZero) {
+TEST(HotswapRewrite, RuntimeLoadNonA0FallsBackWhenEntryTrampolinesAreNotOne) {
   ResetRuntimeTestEnv();
   g_fake_hsa_env.asic_revision = 1;
-  g_fake_env_vars["AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES"] = "0";
+  g_fake_env_vars["AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES"] = "false";
   LoadRecorder load;
   const hsa_executable_t executable = MakeTestExecutable(0x503);
 
@@ -461,35 +462,29 @@ TEST(HotswapRewrite, RuntimeLoadNonA0FallsBackWhenEntryTrampolinesAreZero) {
       rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 0u);
 }
 
-TEST(HotswapRewrite, RuntimeLoadNonA0UsesEntryTrampolinesUnlessEnvIsZero) {
+TEST(HotswapRewrite, RuntimeLoadNonA0UsesEntryTrampolinesWhenEnvIsOne) {
   if (!NewComgrHotswapApiAvailable()) return;
-  const char* const env_values[] = {"false", ""};
-  uint64_t executable_handle = 0x504;
-  for (const char* env_value : env_values) {
-    SCOPED_TRACE(env_value);
-    ResetRuntimeTestEnv();
-    g_fake_hsa_env.asic_revision = 1;
-    g_fake_env_vars["AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES"] = env_value;
-    LoadRecorder load;
-    const hsa_executable_t executable =
-        MakeTestExecutable(executable_handle++);
+  ResetRuntimeTestEnv();
+  g_fake_hsa_env.asic_revision = 1;
+  g_fake_env_vars["AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES"] = "1";
+  LoadRecorder load;
+  const hsa_executable_t executable = MakeTestExecutable(0x504);
 
-    const hsa_status_t status = rocr::hotswap::LoadAgentCodeObjectWithHotswap(
-        executable, MakeTestAgent(), MakeRealCodeObjectView(), nullptr, nullptr,
-        MakeLoadCallbacks(&load));
+  const hsa_status_t status = rocr::hotswap::LoadAgentCodeObjectWithHotswap(
+      executable, MakeTestAgent(), MakeRealCodeObjectView(), nullptr, nullptr,
+      MakeLoadCallbacks(&load));
 
-    EXPECT_EQ(status, HSA_STATUS_SUCCESS);
-    ASSERT_EQ(load.calls.size(), 1u);
-    EXPECT_EQ(load.calls[0].path, LoadPath::kRewritten);
-    EXPECT_EQ(
-        rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable),
-        1u);
+  EXPECT_EQ(status, HSA_STATUS_SUCCESS);
+  ASSERT_EQ(load.calls.size(), 1u);
+  EXPECT_EQ(load.calls[0].path, LoadPath::kRewritten);
+  EXPECT_EQ(
+      rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable),
+      1u);
 
-    rocr::hotswap::ReleaseRetainedRewrittenElfBuffers(executable);
-    EXPECT_EQ(
-        rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable),
-        0u);
-  }
+  rocr::hotswap::ReleaseRetainedRewrittenElfBuffers(executable);
+  EXPECT_EQ(
+      rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable),
+      0u);
 }
 
 TEST(HotswapRewrite, RuntimeLoadDisableEnvFallsBackToOriginal) {

--- a/projects/rocr-runtime/runtime/docs/data/env_variables.rst
+++ b/projects/rocr-runtime/runtime/docs/data/env_variables.rst
@@ -107,9 +107,9 @@
 
     * - | ``AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES``
         | Controls whether ROCr requests COMGR entry-trampoline HotSwap rewriting for gfx12.5 targets.
-      - ``1``
-      - | 0: Disable entry-trampoline rewrites.
-        | Unset or any other value, including empty: Enable entry-trampoline rewrites for gfx125* and ``gfx12-5-generic`` targets.
+      - ``0``
+      - | 1: Enable entry-trampoline rewrites for gfx125* and ``gfx12-5-generic`` targets.
+        | Unset or any other value, including empty: Disable entry-trampoline rewrites. This does not disable the default B0-to-A0 HotSwap translation path.
 
     * - | ``HSA_ENABLE_DXG_DETECTION``
         | Controls detection of the DXG driver (/dev/dxg) on WSL2.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap.cpp
@@ -98,8 +98,9 @@ bool IsHotswapDisabledByEnv() { return IsEnvFlagEnabled("HSA_HOTSWAP_DISABLE"); 
 
 bool IsGfx12_5RewriteRequested() {
   constexpr char kEnvName[] = "AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES";
-  // Default-on policy owned by ROCR: only literal "0" opts out.
-  return !os::IsEnvVarSet(kEnvName) || os::GetEnvVar(kEnvName) != "0";
+  // Entry-trampoline rewrites are opt-in. The legacy B0-to-A0 HotSwap
+  // translation path remains enabled by default for supported agents.
+  return os::IsEnvVarSet(kEnvName) && os::GetEnvVar(kEnvName) == "1";
 }
 
 bool IsVerboseLoggingEnabled() {


### PR DESCRIPTION
## Summary
- keep the existing B0-to-A0 HotSwap translation path enabled by default
- make gfx12.5 HotSwap entry-trampoline rewrites opt-in via AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES=1
- update ROCr tests and environment variable docs for the new default

## Notes
This leaves HSA_HOTSWAP_DISABLE behavior unchanged; it only changes the default for the entry-trampoline mode that replaced the older ROCr trampoline path.