### PR TITLE
[rocprofiler-sdk] Add gfx11.5 GL1A/TA counter definitions to config.yaml

### DIFF
--- a/projects/rocprofiler-sdk/source/share/rocprofiler-sdk/config.yaml
+++ b/projects/rocprofiler-sdk/source/share/rocprofiler-sdk/config.yaml
@@ -450,6 +450,10 @@ rocprofiler-sdk:
           event: 23
         - architectures:
             - gfx1250
+            - gfx1150
+            - gfx1151
+            - gfx1152
+            - gfx1153
           block: CPF
           event: 24
     - name: CPF_CPF_STAT_IDLE
@@ -855,6 +859,10 @@ rocprofiler-sdk:
       definitions:
         - architectures:
             - gfx1250
+            - gfx1150
+            - gfx1151
+            - gfx1152
+            - gfx1153
           block: GL1A
           event: 0
     - name: GL1A_CYCLE
@@ -865,6 +873,13 @@ rocprofiler-sdk:
             - gfx1250
           block: GL1A
           event: 77
+        - architectures:
+            - gfx1150
+            - gfx1151
+            - gfx1152
+            - gfx1153
+          block: GL1A
+          event: 23
     - name: GL1C_GL2_REQ_READ_LEVEL
       description: Number of cycles in-flight for reads, atomics with return, NOP_RTN0. Average GL2 
         read latency = GL1C_PERF_SEL_GL2_REQ_READ_LEVEL/SUM_OF_REQ_COUNTERS
@@ -6741,6 +6756,10 @@ rocprofiler-sdk:
         - architectures:
             - gfx90a
             - gfx908
+            - gfx1150
+            - gfx1151
+            - gfx1152
+            - gfx1153
           block: TA
           event: 54
         - architectures:
@@ -6771,6 +6790,10 @@ rocprofiler-sdk:
         - architectures:
             - gfx90a
             - gfx908
+            - gfx1150
+            - gfx1151
+            - gfx1152
+            - gfx1153
           block: TA
           event: 55
         - architectures:
@@ -6966,6 +6989,10 @@ rocprofiler-sdk:
         - architectures:
             - gfx90a
             - gfx908
+            - gfx1150
+            - gfx1151
+            - gfx1152
+            - gfx1153
           block: TA
           event: 49
         - architectures:


### PR DESCRIPTION
Several counters that the gfx11.5 (RDNA3.5) hardware supports were only defined for other architectures in `config.yaml`, so they could not be collected on gfx11.5 via rocprofv3.

Add gfx11.5 architectures with the correct SOC21 event IDs (checked against `projects/aqlprofile/linux/soc21_enum.h`):
```
  GL1A_BUSY                     event 0
  GL1A_CYCLE                    event 23   (new gfx11.5 definition)
  TA_BUFFER_TOTAL_CYCLES        event 49
  TA_ADDR_STALLED_BY_TC_CYCLES  event 54
  TA_ADDR_STALLED_BY_TD_CYCLES  event 55
```
GL1A_CYCLE needs a separate definition because its gfx11.5 event (23) differs from the existing gfx1250 entry (77); the other four share the event with an existing definition.

Verified on gfx1151 (Strix Halo): all five collect valid per-instance data under rocprofv3 --pmc.