### PR TITLE
AIRUNTIME-2073 - Support D3D11-GL video interOp in Rocr in Windows

### DIFF
--- a/projects/clr/opencl/amdocl/cl_gl.cpp
+++ b/projects/clr/opencl/amdocl/cl_gl.cpp
@@ -764,7 +764,7 @@ RUNTIME_EXIT
  */
 
 /*! \brief This f-n is defined in CL extension cl_khr_gl_sharing and serves
- *  the purpose of quering current device and all devices that support
+ *  the purpose of querying current device and all devices that support
  *  CL-GL interoperability.
  *
  *  \param properties points to an <attribute list>, which is a array of

--- a/projects/clr/rocclr/device/rocm/rocd3d10interop.cpp
+++ b/projects/clr/rocclr/device/rocm/rocd3d10interop.cpp
@@ -13,8 +13,8 @@
 #include <D3D10.h>
 #include <dxgi.h>
 #include <mutex>
-#include <unordered_map>
 
+#include "platform/context.hpp"
 #include "platform/DxxInteropExt.h"
 #include "platform/interop_d3d10.hpp"
 
@@ -22,10 +22,27 @@ namespace amd {
 namespace roc {
 namespace D3D10Interop {
 
-static std::unordered_map<const Device*, CachedExt> gExtCache;
-static std::mutex gExtCacheLock;
+static PFNAmdDxExtCreate gAmdDxExtCreate = nullptr;
+static std::once_flag gAmdDxExtCreateFlag;
 
-bool associateD3D10Device(const Device* device, ID3D10Device* pd3d10Device) {
+static PFNAmdDxExtCreate GetAmdDxExtCreate() {
+  std::call_once(gAmdDxExtCreateFlag, []() {
+#if defined _WIN64
+    static constexpr CHAR dxxModuleName[13] = "atidxx64.dll";
+#else
+    static constexpr CHAR dxxModuleName[13] = "atidxx32.dll";
+#endif
+    HMODULE hDLL = GetModuleHandle(dxxModuleName);
+    if (hDLL) {
+      gAmdDxExtCreate = reinterpret_cast<PFNAmdDxExtCreate>(
+          GetProcAddress(hDLL, "AmdDxExtCreate"));
+    }
+  });
+  return gAmdDxExtCreate;
+}
+
+bool associateD3D10Device(const Device* device, ID3D10Device* pd3d10Device,
+                          void* gfxContext, bool validateOnly) {
   if (!device || !pd3d10Device) {
     return false;
   }
@@ -63,69 +80,69 @@ bool associateD3D10Device(const Device* device, ID3D10Device* pd3d10Device) {
     return false;
   }
 
-  // Create and cache AMD DXX extension objects for this device
-#if defined _WIN64
-  static constexpr CHAR dxxModuleName[13] = "atidxx64.dll";
-#else
-  static constexpr CHAR dxxModuleName[13] = "atidxx32.dll";
-#endif
-
-  HMODULE hDLL = GetModuleHandle(dxxModuleName);
-  if (!hDLL) {
-    LogError("atidxx DLL not loaded; D3D10 SRD queries will be unavailable");
-    return true;  // LUID matched; proceed without SRD support
-  }
-
-  PFNAmdDxExtCreate AmdDxExtCreate =
-      reinterpret_cast<PFNAmdDxExtCreate>(GetProcAddress(hDLL, "AmdDxExtCreate"));
-  if (!AmdDxExtCreate) {
+  if (validateOnly) {
     return true;
   }
 
-  IAmdDxExt* pExt = nullptr;
-  hr = AmdDxExtCreate(pd3d10Device, &pExt);
-  if (FAILED(hr) || !pExt) {
-    return true;
+  PFNAmdDxExtCreate AmdDxExtCreate = GetAmdDxExtCreate();
+  if (AmdDxExtCreate) {
+    IAmdDxExt* pExt = nullptr;
+    HRESULT hr = AmdDxExtCreate(pd3d10Device, &pExt);
+    if (SUCCEEDED(hr) && pExt) {
+      IAmdDxExtCLInterop* pCLExt =
+          static_cast<IAmdDxExtCLInterop*>(pExt->GetExtInterface(AmdDxExtCLInteropID));
+      if (pCLExt) {
+        amd::Context* ctx = static_cast<amd::Context*>(gfxContext);
+        ctx->setD3D10Ext(pd3d10Device, pExt, pCLExt);
+      } else {
+        pExt->Release();
+      }
+    }
   }
-
-  IAmdDxExtCLInterop* pCLExt =
-      static_cast<IAmdDxExtCLInterop*>(pExt->GetExtInterface(AmdDxExtCLInteropID));
-  if (!pCLExt) {
-    pExt->Release();
-    return true;
-  }
-
-  std::lock_guard<std::mutex> sl(gExtCacheLock);
-  gExtCache[device] = {pExt, pCLExt};
 
   return true;
 }
 
-void dissociateD3D10Device(const Device* device) {
-  std::lock_guard<std::mutex> sl(gExtCacheLock);
-  auto it = gExtCache.find(device);
-  if (it != gExtCache.end()) {
-    if (it->second.pCLExt) it->second.pCLExt->Release();
-    if (it->second.pExt) it->second.pExt->Release();
-    gExtCache.erase(it);
+void dissociateD3D10Device(const Device* device, void* const gfxDevice[], void* gfxContext) {
+  if (!gfxDevice || !gfxContext) return;
+  void* d3d10Device = gfxDevice[amd::Context::DeviceFlagIdx::D3D10DeviceKhrIdx];
+  if (!d3d10Device) return;
+
+  amd::Context* ctx = static_cast<amd::Context*>(gfxContext);
+  void* pExt = nullptr;
+  void* pCLExt = nullptr;
+  if (ctx->removeD3D10Ext(d3d10Device, &pExt, &pCLExt)) {
+    if (pCLExt) static_cast<IAmdDxExtCLInterop*>(pCLExt)->Release();
+    if (pExt)   static_cast<IAmdDxExt*>(pExt)->Release();
   }
 }
 
-bool Export(const Memory* memory, ID3D10Resource* d3d10Resource,
-            UINT subresource, hsa_handle_t* handle, int* offset,
+bool Export(const Memory* memory, D3D10Object* d3d10Obj,
+            hsa_handle_t* handle, int* offset,
             void* srd, UINT* srdSize, hsa_interop_map_flag_t* mapFlags) {
+  auto d3d10Resource = d3d10Obj->getD3D10Resource();
   if (!memory || !d3d10Resource || !handle || !offset || !mapFlags) {
     return false;
   }
 
-  // Use cached extension to query SRD
   if (srd && srdSize) {
-    std::lock_guard<std::mutex> sl(gExtCacheLock);
-    auto it = gExtCache.find(&memory->dev());
-    if (it != gExtCache.end() && it->second.pCLExt) {
-      HRESULT hr = it->second.pCLExt->CLQueryResource(d3d10Resource, srd, srdSize);
+    ID3D10Device* pOwnerDevice = nullptr;
+    d3d10Resource->GetDevice(&pOwnerDevice);
+    if (pOwnerDevice) {
+      amd::Context& ctx = memory->owner()->getContext();
+      IAmdDxExtCLInterop* pCLExt =
+          static_cast<IAmdDxExtCLInterop*>(ctx.getD3D10Ext(pOwnerDevice));
+      pOwnerDevice->Release();
+
+      if (!pCLExt) {
+        LogError("D3D10 device not associated with context; call clCreateContext with D3D10 device");
+        return false;
+      }
+
+      HRESULT hr = pCLExt->CLQueryResource(d3d10Resource, 0, srd, srdSize);
       if (FAILED(hr)) {
-        LogError("CLQueryResource failed for D3D10 resource");
+        LogPrintfError("CLQueryResource failed for D3D10 resource: 0x%xh", hr);
+        return false;
       }
     }
   }

--- a/projects/clr/rocclr/device/rocm/rocd3d10interop.cpp
+++ b/projects/clr/rocclr/device/rocm/rocd3d10interop.cpp
@@ -84,6 +84,11 @@ bool associateD3D10Device(const Device* device, ID3D10Device* pd3d10Device,
     return true;
   }
 
+  amd::Context* ctx = static_cast<amd::Context*>(gfxContext);
+  if (ctx->getD3D10Ext(pd3d10Device)) {
+    return true;
+  }
+
   PFNAmdDxExtCreate AmdDxExtCreate = GetAmdDxExtCreate();
   if (AmdDxExtCreate) {
     IAmdDxExt* pExt = nullptr;
@@ -92,7 +97,6 @@ bool associateD3D10Device(const Device* device, ID3D10Device* pd3d10Device,
       IAmdDxExtCLInterop* pCLExt =
           static_cast<IAmdDxExtCLInterop*>(pExt->GetExtInterface(AmdDxExtCLInteropID));
       if (pCLExt) {
-        amd::Context* ctx = static_cast<amd::Context*>(gfxContext);
         ctx->setD3D10Ext(pd3d10Device, pExt, pCLExt);
       } else {
         pExt->Release();

--- a/projects/clr/rocclr/device/rocm/rocd3d10interop.hpp
+++ b/projects/clr/rocclr/device/rocm/rocd3d10interop.hpp
@@ -36,7 +36,9 @@ namespace D3D10Interop {
  */
 bool associateD3D10Device(
     const Device* device,
-    ID3D10Device* d3d10Device
+    ID3D10Device* d3d10Device,
+    void* gfxContext,
+    bool validateOnly
 );
 
 /**
@@ -46,7 +48,7 @@ bool associateD3D10Device(
  *
  * @param device ROCr device
  */
-void dissociateD3D10Device(const Device* device);
+void dissociateD3D10Device(const Device* device, void* const gfxDevice[], void* gfxContext);
 
 /**
  * @brief Export D3D10 resource to HSA handle for interop
@@ -55,16 +57,14 @@ void dissociateD3D10Device(const Device* device);
  * as HSA handle for memory mapping
  *
  * @param memory ROCr memory object
- * @param d3d10Resource D3D10 resource to export
- * @param subresource Subresource index (for textures with mips)
+ * @param d3d10Obj D3D10 object to export
  * @param handle Output HSA handle
  * @param offset Output offset into resource
  * @return true if export succeeded, false otherwise
  */
 bool Export(
     const Memory* memory,
-    ID3D10Resource* d3d10Resource,
-    UINT subresource,
+    D3D10Object* d3d10Obj,
     hsa_handle_t* handle,
     int* offset,
     void* srd,

--- a/projects/clr/rocclr/device/rocm/rocd3d11interop.cpp
+++ b/projects/clr/rocclr/device/rocm/rocd3d11interop.cpp
@@ -22,9 +22,8 @@ namespace amd {
 namespace roc {
 namespace D3D11Interop {
 
-// Per-device set of ROCr devices that have been LUID-verified against a D3D11 adapter.
-// Only LUID association is cached; extension objects are created per-query from the
-// resource's owning ID3D11Device to handle multiple D3D11 devices on the same adapter.
+// Extension objects are cached per-ID3D11Device in the OpenCL context to support
+// multiple D3D11 devices on the same adapter across contexts/threads.
 static PFNAmdDxExtCreate11 gAmdDxExtCreate11 = nullptr;
 static std::once_flag gAmdDxExtCreate11Flag;
 
@@ -87,6 +86,11 @@ bool associateD3D11Device(const Device* device, ID3D11Device* pd3d11Device,
     return true;
   }
 
+  amd::Context* ctx = static_cast<amd::Context*>(gfxContext);
+  if (ctx->getD3D11Ext(pd3d11Device)) {
+    return true;
+  }
+
   // Create and cache IAmdDxExtCLInterop in the context, keyed by pd3d11Device.
   // This avoids per-query extension creation in multithread/multicontext scenarios.
   PFNAmdDxExtCreate11 AmdDxExtCreate11 = GetAmdDxExtCreate11();
@@ -97,7 +101,6 @@ bool associateD3D11Device(const Device* device, ID3D11Device* pd3d11Device,
       IAmdDxExtCLInterop* pCLExt =
           static_cast<IAmdDxExtCLInterop*>(pExt->GetExtInterface(AmdDxExtCLInteropID));
       if (pCLExt) {
-        amd::Context* ctx = static_cast<amd::Context*>(gfxContext);
         ctx->setD3D11Ext(pd3d11Device, pExt, pCLExt);
       } else {
         pExt->Release();
@@ -146,12 +149,12 @@ bool Export(const Memory* memory, D3D11Object* d3d11Obj,
     }
   }
 
-  // Query SRD using an extension created from the resource's owning ID3D11Device.
-  // Extension objects are not cached because multiple ID3D11Device instances may exist
-  // on the same adapter across contexts/threads; each must use its own extension object.
+  // Query SRD using an extension cached in the OpenCL context, keyed by the resource's ownving
+  // ID3D11Device. This supports multiple ID3D11Device instances on the same adapter across
+  // contexts/threads.
   if (srd && srdSize) {
     // plane -1 means "full resource" which is no longer valid; treat as plane 0.
-    // Because Pal in D3D doesn't support quering SRD of the full resource of types
+    // Because Pal in D3D doesn't support querying SRD of the full resource of types
     // DXGI_FORMAT_NV12 and DXGI_FORMAT_P010.
     UINT planeIndex = 0;
     if (isYUV) {
@@ -164,7 +167,7 @@ bool Export(const Memory* memory, D3D11Object* d3d11Obj,
           planeIndex = 1;
           break;
         default:
-          LogPrintfError("Unexpexted plane %d", d3d11Obj->getPlane());
+          LogPrintfError("Unexpected plane %d", d3d11Obj->getPlane());
           return false;
       }
     }

--- a/projects/clr/rocclr/device/rocm/rocd3d11interop.cpp
+++ b/projects/clr/rocclr/device/rocm/rocd3d11interop.cpp
@@ -13,8 +13,8 @@
 #include <D3D11.h>
 #include <dxgi.h>
 #include <mutex>
-#include <unordered_map>
 
+#include "platform/context.hpp"
 #include "platform/DxxInteropExt.h"
 #include "platform/interop_d3d11.hpp"
 
@@ -22,10 +22,30 @@ namespace amd {
 namespace roc {
 namespace D3D11Interop {
 
-static std::unordered_map<const Device*, CachedExt> gExtCache;
-static std::mutex gExtCacheLock;
+// Per-device set of ROCr devices that have been LUID-verified against a D3D11 adapter.
+// Only LUID association is cached; extension objects are created per-query from the
+// resource's owning ID3D11Device to handle multiple D3D11 devices on the same adapter.
+static PFNAmdDxExtCreate11 gAmdDxExtCreate11 = nullptr;
+static std::once_flag gAmdDxExtCreate11Flag;
 
-bool associateD3D11Device(const Device* device, ID3D11Device* pd3d11Device) {
+static PFNAmdDxExtCreate11 GetAmdDxExtCreate11() {
+  std::call_once(gAmdDxExtCreate11Flag, []() {
+#if defined _WIN64
+    static constexpr CHAR dxxModuleName[13] = "atidxx64.dll";
+#else
+    static constexpr CHAR dxxModuleName[13] = "atidxx32.dll";
+#endif
+    HMODULE hDLL = GetModuleHandle(dxxModuleName);
+    if (hDLL) {
+      gAmdDxExtCreate11 = reinterpret_cast<PFNAmdDxExtCreate11>(
+          GetProcAddress(hDLL, "AmdDxExtCreate11"));
+    }
+  });
+  return gAmdDxExtCreate11;
+}
+
+bool associateD3D11Device(const Device* device, ID3D11Device* pd3d11Device,
+                          void* gfxContext, bool validateOnly) {
   if (!device || !pd3d11Device) {
     return false;
   }
@@ -63,58 +83,52 @@ bool associateD3D11Device(const Device* device, ID3D11Device* pd3d11Device) {
     return false;
   }
 
-  // Create and cache AMD DXX extension objects for this device
-#if defined _WIN64
-  static constexpr CHAR dxxModuleName[13] = "atidxx64.dll";
-#else
-  static constexpr CHAR dxxModuleName[13] = "atidxx32.dll";
-#endif
-
-  HMODULE hDLL = GetModuleHandle(dxxModuleName);
-  if (!hDLL) {
-    LogError("atidxx DLL not loaded; D3D11 SRD queries will be unavailable");
-    return true;  // LUID matched; proceed without SRD support
-  }
-
-  PFNAmdDxExtCreate11 AmdDxExtCreate11 =
-      reinterpret_cast<PFNAmdDxExtCreate11>(GetProcAddress(hDLL, "AmdDxExtCreate11"));
-  if (!AmdDxExtCreate11) {
+  if (validateOnly) {
     return true;
   }
 
-  IAmdDxExt* pExt = nullptr;
-  hr = AmdDxExtCreate11(pd3d11Device, &pExt);
-  if (FAILED(hr) || !pExt) {
-    return true;
+  // Create and cache IAmdDxExtCLInterop in the context, keyed by pd3d11Device.
+  // This avoids per-query extension creation in multithread/multicontext scenarios.
+  PFNAmdDxExtCreate11 AmdDxExtCreate11 = GetAmdDxExtCreate11();
+  if (AmdDxExtCreate11) {
+    IAmdDxExt* pExt = nullptr;
+    HRESULT hr = AmdDxExtCreate11(pd3d11Device, &pExt);
+    if (SUCCEEDED(hr) && pExt) {
+      IAmdDxExtCLInterop* pCLExt =
+          static_cast<IAmdDxExtCLInterop*>(pExt->GetExtInterface(AmdDxExtCLInteropID));
+      if (pCLExt) {
+        amd::Context* ctx = static_cast<amd::Context*>(gfxContext);
+        ctx->setD3D11Ext(pd3d11Device, pExt, pCLExt);
+      } else {
+        pExt->Release();
+      }
+    }
   }
-
-  IAmdDxExtCLInterop* pCLExt =
-      static_cast<IAmdDxExtCLInterop*>(pExt->GetExtInterface(AmdDxExtCLInteropID));
-  if (!pCLExt) {
-    pExt->Release();
-    return true;
-  }
-
-  std::lock_guard<std::mutex> sl(gExtCacheLock);
-  gExtCache[device] = {pExt, pCLExt};
 
   return true;
 }
 
-void dissociateD3D11Device(const Device* device) {
-  std::lock_guard<std::mutex> sl(gExtCacheLock);
-  auto it = gExtCache.find(device);
-  if (it != gExtCache.end()) {
-    if (it->second.pCLExt) it->second.pCLExt->Release();
-    if (it->second.pExt) it->second.pExt->Release();
-    gExtCache.erase(it);
+void dissociateD3D11Device(const Device* device, void* const gfxDevice[], void* gfxContext) {
+  if (!gfxDevice || !gfxContext) return;
+  void* d3d11Device = gfxDevice[amd::Context::DeviceFlagIdx::D3D11DeviceKhrIdx];
+  if (!d3d11Device) return;
+
+  amd::Context* ctx = static_cast<amd::Context*>(gfxContext);
+  void* pExt = nullptr;
+  void* pCLExt = nullptr;
+  if (ctx->removeD3D11Ext(d3d11Device, &pExt, &pCLExt)) {
+    if (pCLExt) static_cast<IAmdDxExtCLInterop*>(pCLExt)->Release();
+    if (pExt)   static_cast<IAmdDxExt*>(pExt)->Release();
   }
 }
 
-bool Export(const Memory* memory, ID3D11Resource* d3d11Resource,
-            UINT subresource, hsa_handle_t* handle, int* offset,
+bool Export(const Memory* memory, D3D11Object* d3d11Obj,
+            hsa_handle_t* handle, int* offset,
             void* srd, UINT* srdSize, hsa_interop_map_flag_t* mapFlags,
             size_t* sizeHint) {
+  auto d3d11Resource = d3d11Obj->getD3D11Resource();
+  bool isYUV = (d3d11Obj->getDxgiFormat() == DXGI_FORMAT_NV12 ||
+                d3d11Obj->getDxgiFormat() == DXGI_FORMAT_P010);
   if (!memory || !d3d11Resource || !handle || !offset || !mapFlags) {
     return false;
   }
@@ -132,14 +146,46 @@ bool Export(const Memory* memory, ID3D11Resource* d3d11Resource,
     }
   }
 
-  // Use cached extension to query SRD
+  // Query SRD using an extension created from the resource's owning ID3D11Device.
+  // Extension objects are not cached because multiple ID3D11Device instances may exist
+  // on the same adapter across contexts/threads; each must use its own extension object.
   if (srd && srdSize) {
-    std::lock_guard<std::mutex> sl(gExtCacheLock);
-    auto it = gExtCache.find(&memory->dev());
-    if (it != gExtCache.end() && it->second.pCLExt) {
-      HRESULT hr = it->second.pCLExt->CLQueryResource11(d3d11Resource, srd, srdSize);
+    // plane -1 means "full resource" which is no longer valid; treat as plane 0.
+    // Because Pal in D3D doesn't support quering SRD of the full resource of types
+    // DXGI_FORMAT_NV12 and DXGI_FORMAT_P010.
+    UINT planeIndex = 0;
+    if (isYUV) {
+      switch (d3d11Obj->getPlane()) {
+        case -1:
+        case 0:
+          planeIndex = 0;
+          break;
+        case 1:
+          planeIndex = 1;
+          break;
+        default:
+          LogPrintfError("Unexpexted plane %d", d3d11Obj->getPlane());
+          return false;
+      }
+    }
+
+    ID3D11Device* pOwnerDevice = nullptr;
+    d3d11Resource->GetDevice(&pOwnerDevice);
+    if (pOwnerDevice) {
+      amd::Context& ctx = memory->owner()->getContext();
+      IAmdDxExtCLInterop* pCLExt =
+          static_cast<IAmdDxExtCLInterop*>(ctx.getD3D11Ext(pOwnerDevice));
+      pOwnerDevice->Release();
+
+      if (!pCLExt) {
+        LogError("D3D11 device not associated with context; call clCreateContext with D3D11 device");
+        return false;
+      }
+
+      HRESULT hr = pCLExt->CLQueryResource11(d3d11Resource, planeIndex, srd, srdSize);
       if (FAILED(hr)) {
-        LogError("CLQueryResource11 failed for D3D11 resource");
+        LogPrintfError("CLQueryResource11 failed for D3D11 resource: 0x%xh", hr);
+        return false;
       }
     }
   }
@@ -164,6 +210,16 @@ bool Export(const Memory* memory, ID3D11Resource* d3d11Resource,
   *handle = reinterpret_cast<hsa_handle_t>(hShared);
   *offset = 0;
   *mapFlags = HSA_INTEROP_MAP_FLAG_KMT_HANDLE;
+
+  if (isYUV && d3d11Obj->getPlane() == 1) {
+    uint32_t w = d3d11Obj->getWidth() * 2u;
+    uint32_t h = d3d11Obj->getHeight() * 2u;
+    const uint32_t pitchAlign = memory->dev().info().imagePitchAlignment_;
+    // Y plane (plane 0) element size for pitch calculation
+    const uint32_t elemBytes =
+        static_cast<uint32_t>(d3d11Obj->getElementBytes(d3d11Obj->getDxgiFormat(), 0));
+    *offset = amd::alignUp(w * elemBytes, pitchAlign) * h;
+  }
   return true;
 }
 

--- a/projects/clr/rocclr/device/rocm/rocd3d11interop.hpp
+++ b/projects/clr/rocclr/device/rocm/rocd3d11interop.hpp
@@ -36,7 +36,9 @@ namespace D3D11Interop {
  */
 bool associateD3D11Device(
     const Device* device,
-    ID3D11Device* d3d11Device
+    ID3D11Device* d3d11Device,
+    void* gfxContext,
+    bool validateOnly
 );
 
 /**
@@ -46,7 +48,7 @@ bool associateD3D11Device(
  *
  * @param device ROCr device
  */
-void dissociateD3D11Device(const Device* device);
+void dissociateD3D11Device(const Device* device, void* const gfxDevice[], void* gfxContext);
 
 /**
  * @brief Export D3D11 resource to HSA handle for interop
@@ -55,16 +57,14 @@ void dissociateD3D11Device(const Device* device);
  * as HSA handle for memory mapping
  *
  * @param memory ROCr memory object
- * @param d3d11Resource D3D11 resource to export
- * @param subresource Subresource index (for textures with mips)
+ * @param d3d11Obj D3D11 object to export
  * @param handle Output HSA handle
  * @param offset Output offset into resource
  * @return true if export succeeded, false otherwise
  */
 bool Export(
     const Memory* memory,
-    ID3D11Resource* d3d11Resource,
-    UINT subresource,
+    D3D11Object* d3d11Obj,
     hsa_handle_t* handle,
     int* offset,
     void* srd,

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -1913,7 +1913,7 @@ bool Device::bindExternalDevice(uint flags, void* const gfxDevice[], void* gfxCo
   // Handle D3D10 device binding
   if (flags & amd::Context::Flags::D3D10DeviceKhr) {
     void* d3d10Device = gfxDevice[amd::Context::DeviceFlagIdx::D3D10DeviceKhrIdx];
-    if (!D3D10Interop::associateD3D10Device(this, static_cast<ID3D10Device*>(d3d10Device))) {
+    if (!D3D10Interop::associateD3D10Device(this, static_cast<ID3D10Device*>(d3d10Device), gfxContext, validateOnly)) {
       LogError("Failed D3D10Interop::associateD3D10Device()");
       success = false;
     }
@@ -1922,7 +1922,7 @@ bool Device::bindExternalDevice(uint flags, void* const gfxDevice[], void* gfxCo
   // Handle D3D11 device binding
   if (flags & amd::Context::Flags::D3D11DeviceKhr) {
     void* d3d11Device = gfxDevice[amd::Context::DeviceFlagIdx::D3D11DeviceKhrIdx];
-    if (!D3D11Interop::associateD3D11Device(this, static_cast<ID3D11Device*>(d3d11Device))) {
+    if (!D3D11Interop::associateD3D11Device(this, static_cast<ID3D11Device*>(d3d11Device), gfxContext, validateOnly)) {
       LogError("Failed D3D11Interop::associateD3D11Device()");
       success = false;
     }
@@ -1949,12 +1949,12 @@ bool Device::unbindExternalDevice(uint flags, void* const gfxDevice[], void* gfx
 #ifdef _WIN32
   // Handle D3D10 device cleanup
   if (flags & amd::Context::Flags::D3D10DeviceKhr) {
-    D3D10Interop::dissociateD3D10Device(this);
+    D3D10Interop::dissociateD3D10Device(this, gfxDevice, gfxContext);
   }
 
   // Handle D3D11 device cleanup
   if (flags & amd::Context::Flags::D3D11DeviceKhr) {
-    D3D11Interop::dissociateD3D11Device(this);
+    D3D11Interop::dissociateD3D11Device(this, gfxDevice, gfxContext);
   }
 #endif  // _WIN32
 

--- a/projects/clr/rocclr/device/rocm/rocglinterop_windows.cpp
+++ b/projects/clr/rocclr/device/rocm/rocglinterop_windows.cpp
@@ -183,12 +183,8 @@ bool Export(amd::Memory* mem, GLenum targetType, int miplevel, hsa_handle_t* han
   *handle = reinterpret_cast<hsa_handle_t>(glResourceData.handle);
   *resHandle = reinterpret_cast<hsa_handle_t>(glResourceData.mbResHandle);
   *offset = static_cast<int>(glResourceData.offset);
-  if (image_srd_size >= glResourceData.textureSRDSize) {
+  if (image_srd && image_srd_size >= glResourceData.textureSRDSize) {
     std::memcpy(image_srd, glResourceData.textureSRD, glResourceData.textureSRDSize);
-  } else {
-    LogPrintfError("image_srd_size %u < glResourceData.textureSRDSize %u", image_srd_size,
-                   glResourceData.textureSRDSize);
-    return false;
   }
   return true;
 }

--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -225,9 +225,9 @@ hsa_status_t Memory::interopMapBuffer(hsa_handle_t fdn, hsa_interop_map_flag_t f
                                                           &metadata_size, (const void**)&metadata
 #endif
   );
-  ClPrint(amd::LOG_DEBUG, amd::LOG_MEM, "Map Interop memory %p, size 0x%zx", interop_deviceMemory_,
-          size);
-  deviceMemory_ = static_cast<char*>(interop_deviceMemory_);  // + out.buf_offset;
+  ClPrint(amd::LOG_DEBUG, amd::LOG_MEM, "fd %zu, Map Interop memory %p, size 0x%zx, status = 0x%xh",
+          size_t(fd), interop_deviceMemory_, size, status);
+  deviceMemory_ = static_cast<char*>(interop_deviceMemory_);
   if (status != HSA_STATUS_SUCCESS) return status;
   // if map_buffer wrote a legitimate SRD, copy it to amdImageDesc_
   // Note: Check if amdImageDesc_ is valid, because VA library maps linear planes of YUV image
@@ -253,21 +253,25 @@ bool Memory::createInteropBuffer(GLenum targetType, int miplevel) {
 
   static_assert(alignof(hsa_amd_image_descriptor_t) == alignof(uint32_t),
                 "Unexpected alignment for hsa_amd_image_descriptor_t");
-  amdImageDesc_ = reinterpret_cast<hsa_amd_image_descriptor_t*>(
-      new uint32_t[MaxMetadataSizeDwords + HeaderSizeDwords]());
+  const bool isImage = (owner()->asImage() != nullptr);
 
-  if (amdImageDesc_ == nullptr) {
-    return false;
+  if (isImage) {
+    amdImageDesc_ = reinterpret_cast<hsa_amd_image_descriptor_t*>(
+        new uint32_t[MaxMetadataSizeDwords + HeaderSizeDwords]());
+
+    if (amdImageDesc_ == nullptr) {
+      return false;
+    }
+
+    hsa_agent_t agent = dev().getBackendDevice();
+    uint32_t id;
+    Hsa::agent_get_info(agent, static_cast<hsa_agent_info_t>(HSA_AMD_AGENT_INFO_CHIP_ID), &id);
+
+    static constexpr uint32_t DeviceIdVendorShift = 16u;
+
+    amdImageDesc_->version = 1;
+    amdImageDesc_->deviceID = (AmdVendor << DeviceIdVendorShift) | id;
   }
-
-  hsa_agent_t agent = dev().getBackendDevice();
-  uint32_t id;
-  Hsa::agent_get_info(agent, static_cast<hsa_agent_info_t>(HSA_AMD_AGENT_INFO_CHIP_ID), &id);
-
-  static constexpr uint32_t DeviceIdVendorShift = 16u;
-
-  amdImageDesc_->version = 1;
-  amdImageDesc_->deviceID = (AmdVendor << DeviceIdVendorShift) | id;
 
 #if IS_WINDOWS
   hsa_handle_t handle = 0, resHandle = 0;
@@ -276,30 +280,30 @@ bool Memory::createInteropBuffer(GLenum targetType, int miplevel) {
 
   // Check if this is D3D interop (vs GL interop)
   amd::InteropObject* interopObj = owner()->getInteropObj();
-  UINT srdSize = MaxMetadataSizeDwords * sizeof(uint32_t);
+  // SRD and size are only needed for images; pass nullptr for plain buffers.
+  void* srdPtr = isImage ? amdImageDesc_->data : nullptr;
+  UINT srdSize = isImage ? MaxMetadataSizeDwords * sizeof(uint32_t) : 0;
   size_t sizeHint = 0;
   if (interopObj->asD3D11Object()) {
     // D3D11 interop
     D3D11Object* d3d11Obj = interopObj->asD3D11Object();
-    if (!D3D11Interop::Export(this, d3d11Obj->getD3D11Resource(),
-                              d3d11Obj->getSubresource(), &handle, &offset,
-                              amdImageDesc_->data, &srdSize, &mapFlags, &sizeHint)) {
+    if (!D3D11Interop::Export(this, d3d11Obj, &handle, &offset,
+                              srdPtr, isImage ? &srdSize : nullptr, &mapFlags, &sizeHint)) {
       LogError("D3D11Interop::Export failed for buffer");
       return false;
     }
   } else if (interopObj->asD3D10Object()) {
     // D3D10 interop
     D3D10Object* d3d10Obj = interopObj->asD3D10Object();
-    if (!D3D10Interop::Export(this, d3d10Obj->getD3D10Resource(),
-                              d3d10Obj->getSubresource(), &handle, &offset,
-                              amdImageDesc_->data, &srdSize, &mapFlags)) {
+    if (!D3D10Interop::Export(this, d3d10Obj, &handle, &offset,
+                              srdPtr, isImage ? &srdSize : nullptr, &mapFlags)) {
       LogError("D3D10Interop::Export failed for buffer");
       return false;
     }
   } else if (interopObj->asGLObject()) {
     // GL interop
     if (!GlInterop::Export(owner(), targetType, miplevel, &handle, &resHandle, &offset,
-                           amdImageDesc_->data, MaxMetadataSizeDwords * sizeof(uint32_t))) {
+                           srdPtr, srdSize)) {
       return false;
     }
   } else {
@@ -336,8 +340,8 @@ bool Memory::createInteropBuffer(GLenum targetType, int miplevel) {
   in.target = targetType;
   in.obj = owner()->getInteropObj()->asGLObject()->getGLName();
   in.miplevel = miplevel;
-  in.out_driver_data_size = MaxMetadataSizeBytes;
-  in.out_driver_data = &amdImageDesc_->data[0];
+  in.out_driver_data_size = isImage ? MaxMetadataSizeBytes : 0;
+  in.out_driver_data = isImage ? &amdImageDesc_->data[0] : nullptr;
 
   const auto& glenv = owner()->getContext().glenv();
   if (glenv->isEGL()) {
@@ -362,7 +366,7 @@ bool Memory::createInteropBuffer(GLenum targetType, int miplevel) {
 void Memory::destroyInteropBuffer() {
   assert(kind_ == MEMORY_KIND_INTEROP && "Memory must be interop type.");
   Hsa::interop_unmap_buffer(interop_deviceMemory_);
-  ClPrint(amd::LOG_DEBUG, amd::LOG_MEM, "Unmap GL memory %p", deviceMemory_);
+  ClPrint(amd::LOG_DEBUG, amd::LOG_MEM, "Unmap interop memory %p", deviceMemory_);
   deviceMemory_ = nullptr;
 }
 

--- a/projects/clr/rocclr/device/rocm/rocmemory.hpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.hpp
@@ -148,7 +148,7 @@ class Memory : public device::Memory {
   void* deviceMemory_;
 
   // Pointer to the interop device memory, which has an offset from deviceMemory_
-  void* interop_deviceMemory_;
+  void* interop_deviceMemory_ = nullptr;
 
   // Track if this memory is interop, lock, gart, or normal.
   MEMORY_KIND kind_;

--- a/projects/clr/rocclr/device/rocm/rocsettings.cpp
+++ b/projects/clr/rocclr/device/rocm/rocsettings.cpp
@@ -201,6 +201,7 @@ bool Settings::create(bool fullProfile, const amd::Isa& isa, bool enableXNACK, b
     // and D3D9 sharing extension is not supported on any hardware as it is deprecated.
     enableExtension(ClKhrD3d10Sharing);
     enableExtension(ClKhrD3d11Sharing);
+    enableExtension(ClAmdPlanarYuv);
   }
 #endif
 

--- a/projects/clr/rocclr/platform/DxxInteropExt.h
+++ b/projects/clr/rocclr/platform/DxxInteropExt.h
@@ -67,11 +67,13 @@ class IAmdDxExtCLInterop : public IAmdDxExtInterface {
 
   virtual HRESULT CLAcquireResource(ID3D10Resource* pResource, UINT* gpuIdBitmask) = 0;
   virtual HRESULT CLReleaseResource(ID3D10Resource* pResource, UINT* gpuIdBitmask) = 0;
-  virtual HRESULT CLQueryResource(ID3D10Resource* pResource, VOID* pSrd, UINT* pSrdSize) = 0;
+  virtual HRESULT CLQueryResource(ID3D10Resource* pResource, UINT planeIndex,
+                                  VOID* pSrd, UINT* pSrdSize) = 0;
 
   virtual HRESULT CLAcquireResource11(ID3D11Resource* pResource, UINT* gpuIdBitmask) = 0;
   virtual HRESULT CLReleaseResource11(ID3D11Resource* pResource, UINT* gpuIdBitmask) = 0;
-  virtual HRESULT CLQueryResource11(ID3D11Resource* pResource, VOID* pSrd, UINT* pSrdSize) = 0;
+  virtual HRESULT CLQueryResource11(ID3D11Resource* pResource, UINT planeIndex,
+                                    VOID* pSrd, UINT* pSrdSize) = 0;
 
   virtual HRESULT CLAcquireResource9(IDirect3DSurface9* pResource, UINT* gpuIdBitmask) = 0;
   virtual HRESULT CLReleaseResource9(IDirect3DSurface9* pResource, UINT* gpuIdBitmask) = 0;

--- a/projects/clr/rocclr/platform/context.cpp
+++ b/projects/clr/rocclr/platform/context.cpp
@@ -55,9 +55,15 @@ Context::~Context() {
 
   // Loop through all devices
   for (const auto& it : devices_) {
-    // Dissociate OCL context with any external device
-    if (info_.flags_ & (GLDeviceKhr | D3D10DeviceKhr | D3D11DeviceKhr)) {
-      it->unbindExternalDevice(info_.flags_, info_.hDev_, info_.hCtx_, VALIDATE_ONLY);
+    // Dissociate OCL context with any external device.
+    // D3D10/D3D11 interop requires amd::Context* (this); GL uses the API context handle.
+    if (info_.flags_ & (D3D10DeviceKhr | D3D11DeviceKhr)) {
+      uint d3dFlags = info_.flags_ & (D3D10DeviceKhr | D3D11DeviceKhr);
+      it->unbindExternalDevice(d3dFlags, info_.hDev_, this, VALIDATE_ONLY);
+    }
+    if (info_.flags_ & GLDeviceKhr) {
+      uint glFlags = info_.flags_ & GLDeviceKhr;
+      it->unbindExternalDevice(glFlags, info_.hDev_, info_.hCtx_, VALIDATE_ONLY);
     }
 
     // Notify device about context destroy
@@ -250,8 +256,20 @@ int Context::create(const intptr_t* properties) {
                       D3D9DeviceEXKhr | D3D9DeviceVAKhr)) {
     // Loop through all devices
     for (const auto& it : devices_) {
-      if (!it->bindExternalDevice(info_.flags_, info_.hDev_, info_.hCtx_, VALIDATE_ONLY)) {
-        result = CL_INVALID_VALUE;
+      // D3D10/D3D11 interop requires amd::Context* (this) as the context pointer so that
+      // extension objects can be cached per-ID3D11Device inside the OpenCL context.
+      // GL and D3D9 interop use the API-level context handle stored in info_.hCtx_.
+      if (info_.flags_ & (D3D10DeviceKhr | D3D11DeviceKhr)) {
+        uint d3dFlags = info_.flags_ & (D3D10DeviceKhr | D3D11DeviceKhr);
+        if (!it->bindExternalDevice(d3dFlags, info_.hDev_, this, VALIDATE_ONLY)) {
+          result = CL_INVALID_VALUE;
+        }
+      }
+      if (info_.flags_ & (GLDeviceKhr | D3D9DeviceKhr | D3D9DeviceEXKhr | D3D9DeviceVAKhr)) {
+        uint glFlags = info_.flags_ & (GLDeviceKhr | D3D9DeviceKhr | D3D9DeviceEXKhr | D3D9DeviceVAKhr);
+        if (!it->bindExternalDevice(glFlags, info_.hDev_, info_.hCtx_, VALIDATE_ONLY)) {
+          result = CL_INVALID_VALUE;
+        }
       }
     }
   }

--- a/projects/clr/rocclr/platform/context.hpp
+++ b/projects/clr/rocclr/platform/context.hpp
@@ -12,8 +12,9 @@
 #include "platform/object.hpp"
 #include "platform/agent.hpp"
 
-#include <vector>
+#include <mutex>
 #include <unordered_map>
+#include <vector>
 
 namespace amd {
 
@@ -199,6 +200,52 @@ class Context : public RuntimeObject {
     deviceQueues_[&dev].defDeviceQueue_ = queue;
   };
 
+ public:
+#ifdef _WIN32
+  // D3D11 interop extension cache: ID3D11Device* (as void*) -> {pExt, pCLExt}
+  // pCLExt is IAmdDxExtCLInterop*, pExt is IAmdDxExt* kept alive as long as pCLExt is used.
+  struct D3D11ExtEntry {
+    void* pExt   = nullptr;   //!< IAmdDxExt*
+    void* pCLExt = nullptr;   //!< IAmdDxExtCLInterop*
+  };
+  void setD3D11Ext(void* d3d11Device, void* pExt, void* pCLExt) {
+    std::lock_guard<std::mutex> lock(d3d11ExtCacheLock_);
+    d3d11ExtCache_[d3d11Device] = {pExt, pCLExt};
+  }
+  void* getD3D11Ext(void* d3d11Device) const {
+    std::lock_guard<std::mutex> lock(d3d11ExtCacheLock_);
+    auto it = d3d11ExtCache_.find(d3d11Device);
+    return (it != d3d11ExtCache_.end()) ? it->second.pCLExt : nullptr;
+  }
+  bool removeD3D11Ext(void* d3d11Device, void** ppExt, void** ppCLExt) {
+    std::lock_guard<std::mutex> lock(d3d11ExtCacheLock_);
+    auto it = d3d11ExtCache_.find(d3d11Device);
+    if (it == d3d11ExtCache_.end()) return false;
+    if (ppExt)   *ppExt   = it->second.pExt;
+    if (ppCLExt) *ppCLExt = it->second.pCLExt;
+    d3d11ExtCache_.erase(it);
+    return true;
+  }
+  void setD3D10Ext(void* d3d10Device, void* pExt, void* pCLExt) {
+    std::lock_guard<std::mutex> lock(d3d10ExtCacheLock_);
+    d3d10ExtCache_[d3d10Device] = {pExt, pCLExt};
+  }
+  void* getD3D10Ext(void* d3d10Device) const {
+    std::lock_guard<std::mutex> lock(d3d10ExtCacheLock_);
+    auto it = d3d10ExtCache_.find(d3d10Device);
+    return (it != d3d10ExtCache_.end()) ? it->second.pCLExt : nullptr;
+  }
+  bool removeD3D10Ext(void* d3d10Device, void** ppExt, void** ppCLExt) {
+    std::lock_guard<std::mutex> lock(d3d10ExtCacheLock_);
+    auto it = d3d10ExtCache_.find(d3d10Device);
+    if (it == d3d10ExtCache_.end()) return false;
+    if (ppExt)   *ppExt   = it->second.pExt;
+    if (ppCLExt) *ppCLExt = it->second.pCLExt;
+    d3d10ExtCache_.erase(it);
+    return true;
+  }
+#endif  // _WIN32
+
  private:
   Info info_;                            //!< Context info structure
   cl_context_properties* properties_;    //!< Original properties
@@ -207,6 +254,12 @@ class Context : public RuntimeObject {
   std::vector<Device*> svmAllocDevice_;  //!< Devices can support SVM allocations
   std::unordered_map<const Device*, DeviceQueueInfo> deviceQueues_;  //!< Device queues mapping
   mutable Monitor ctxLock_;  //!< Lock for the context access
+#ifdef _WIN32
+  std::unordered_map<void*, D3D11ExtEntry> d3d11ExtCache_;
+  mutable std::mutex d3d11ExtCacheLock_;
+  std::unordered_map<void*, D3D11ExtEntry> d3d10ExtCache_;
+  mutable std::mutex d3d10ExtCacheLock_;
+#endif
 };
 
 /*! @}

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/image_lut_gfx11.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/image_lut_gfx11.cpp
@@ -147,7 +147,7 @@ namespace image {
      {0, 0, 0, 0},
      {0, 0, 0, 0},
      {0, 0, 0, 0},
-     {0, 0, 0, 0},
+     {RW, 4, FMT_2_10_10_10, TYPE_UNORM}, // big endian
      {RW, 4, FMT_8_8_8_8, TYPE_SINT},
      {RW, 8, FMT_16_16_16_16, TYPE_SINT},
      {RW, 16, FMT_32_32_32_32, TYPE_SINT},

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/image_lut_kv.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/image_lut_kv.cpp
@@ -154,7 +154,7 @@ const ImageProperty ImageLutKv::kPropLut_[ORDER_COUNT][TYPE_COUNT] = {
      {0, 0, 0, 0},
      {0, 0, 0, 0},
      {0, 0, 0, 0},
-     {0, 0, 0, 0},
+     {RW, 4, FMT_2_10_10_10, TYPE_UNORM}, // big endian
      {RW, 4, FMT_8_8_8_8, TYPE_SINT},
      {RW, 8, FMT_16_16_16_16, TYPE_SINT},
      {RW, 16, FMT_32_32_32_32, TYPE_SINT},

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_gfx11.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_gfx11.cpp
@@ -266,8 +266,11 @@ hsa_status_t ImageManagerGfx11::PopulateImageSrd(Image& image,
 
   ImageProperty image_prop = ImageLut().MapFormat(image.desc.format, image.desc.geometry);
   if ((image_prop.cap == HSA_EXT_IMAGE_CAPABILITY_NOT_SUPPORTED) ||
-     (image_prop.element_size == 0))
+     (image_prop.element_size == 0)) {
+      fprintf(stderr, "ImageManagerGfx11::PopulateImageSrd(order=0x%xh, type=0x%xh) not supported\n",
+            image.desc.format.channel_order, image.desc.format.channel_type);
     return (hsa_status_t)HSA_EXT_STATUS_ERROR_IMAGE_FORMAT_UNSUPPORTED;
+  }
 
   const Swizzle swizzle = ImageLut().MapSwizzle(image.desc.format.channel_order);
 
@@ -284,6 +287,26 @@ hsa_status_t ImageManagerGfx11::PopulateImageSrd(Image& image,
   image.srd[5] = desc->word5.u32All;
   image.srd[6] = desc->word6.u32All;
   image.srd[7] = desc->word7.u32All;
+
+  if (image.desc.geometry == HSA_EXT_IMAGE_GEOMETRY_2D ||
+      image.desc.geometry == HSA_EXT_IMAGE_GEOMETRY_2DA) {
+    SQ_IMG_RSRC_WORD1 w1;
+    SQ_IMG_RSRC_WORD2 w2;
+    w1.u32All = image.srd[1];
+    w2.u32All = image.srd[2];
+    uint32_t srd_width  = (w2.f.WIDTH_HI << 2) | w1.f.WIDTH;
+    uint32_t srd_height = w2.f.HEIGHT;
+    uint32_t img_width  = static_cast<uint32_t>(image.desc.width) - 1;
+    uint32_t img_height = static_cast<uint32_t>(image.desc.height ? image.desc.height : 1) - 1;
+    if (img_width < srd_width || img_height < srd_height) {
+      fprintf(stderr, "updated size!\n");
+      w1.f.WIDTH    = img_width & 0x3u;
+      w2.f.WIDTH_HI = img_width >> 2;
+      w2.f.HEIGHT   = img_height;
+      image.srd[1]  = w1.u32All;
+      image.srd[2]  = w2.u32All;
+    }
+  }
 
   if (image.desc.geometry == HSA_EXT_IMAGE_GEOMETRY_1DB) {
     SQ_BUF_RSRC_WORD0 word0;

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_gfx11.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_gfx11.cpp
@@ -267,8 +267,6 @@ hsa_status_t ImageManagerGfx11::PopulateImageSrd(Image& image,
   ImageProperty image_prop = ImageLut().MapFormat(image.desc.format, image.desc.geometry);
   if ((image_prop.cap == HSA_EXT_IMAGE_CAPABILITY_NOT_SUPPORTED) ||
      (image_prop.element_size == 0)) {
-      fprintf(stderr, "ImageManagerGfx11::PopulateImageSrd(order=0x%xh, type=0x%xh) not supported\n",
-            image.desc.format.channel_order, image.desc.format.channel_type);
     return (hsa_status_t)HSA_EXT_STATUS_ERROR_IMAGE_FORMAT_UNSUPPORTED;
   }
 
@@ -299,7 +297,6 @@ hsa_status_t ImageManagerGfx11::PopulateImageSrd(Image& image,
     uint32_t img_width  = static_cast<uint32_t>(image.desc.width) - 1;
     uint32_t img_height = static_cast<uint32_t>(image.desc.height ? image.desc.height : 1) - 1;
     if (img_width < srd_width || img_height < srd_height) {
-      fprintf(stderr, "updated size!\n");
       w1.f.WIDTH    = img_width & 0x3u;
       w2.f.WIDTH_HI = img_width >> 2;
       w2.f.HEIGHT   = img_height;

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_gfx12.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_gfx12.cpp
@@ -370,7 +370,6 @@ hsa_status_t ImageManagerGfx12::PopulateImageSrd(Image& image,
       uint32_t img_width  = static_cast<uint32_t>(image.desc.width) - 1;
       uint32_t img_height = static_cast<uint32_t>(image.desc.height ? image.desc.height : 1) - 1;
       if (img_width < srd_width || img_height < srd_height) {
-        fprintf(stderr, "updated size!\n");
         w1.f.WIDTH    = img_width & 0x3u;
         w2.f.WIDTH_HI = img_width >> 2;
         w2.f.HEIGHT   = img_height;

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_gfx12.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_gfx12.cpp
@@ -358,6 +358,26 @@ hsa_status_t ImageManagerGfx12::PopulateImageSrd(Image& image,
       reinterpret_cast<SQ_IMG_RSRC_WORD3*>(&image.srd[3])->bits.TYPE =
           ImageLut().MapGeometry(image.desc.geometry);
     }
+
+    if (image.desc.geometry == HSA_EXT_IMAGE_GEOMETRY_2D ||
+        image.desc.geometry == HSA_EXT_IMAGE_GEOMETRY_2DA) {
+      SQ_IMG_RSRC_WORD1 w1;
+      SQ_IMG_RSRC_WORD2 w2;
+      w1.val = image.srd[1];
+      w2.val = image.srd[2];
+      uint32_t srd_width  = (w2.f.WIDTH_HI << 2) | w1.f.WIDTH;
+      uint32_t srd_height = w2.f.HEIGHT;
+      uint32_t img_width  = static_cast<uint32_t>(image.desc.width) - 1;
+      uint32_t img_height = static_cast<uint32_t>(image.desc.height ? image.desc.height : 1) - 1;
+      if (img_width < srd_width || img_height < srd_height) {
+        fprintf(stderr, "updated size!\n");
+        w1.f.WIDTH    = img_width & 0x3u;
+        w2.f.WIDTH_HI = img_width >> 2;
+        w2.f.HEIGHT   = img_height;
+        image.srd[1]  = w1.val;
+        image.srd[2]  = w2.val;
+      }
+    }
   }
 
   // Looks like this is only used for CPU copies.

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_nv.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_nv.cpp
@@ -272,6 +272,26 @@ hsa_status_t ImageManagerNv::PopulateImageSrd(Image& image,
   image.srd[6] = desc->word6.u32All;
   image.srd[7] = desc->word7.u32All;
 
+  if (image.desc.geometry == HSA_EXT_IMAGE_GEOMETRY_2D ||
+      image.desc.geometry == HSA_EXT_IMAGE_GEOMETRY_2DA) {
+    SQ_IMG_RSRC_WORD1 w1;
+    SQ_IMG_RSRC_WORD2 w2;
+    w1.u32All = image.srd[1];
+    w2.u32All = image.srd[2];
+    uint32_t srd_width  = (w2.f.WIDTH_HI << 2) | w1.f.WIDTH;
+    uint32_t srd_height = w2.f.HEIGHT;
+    uint32_t img_width  = static_cast<uint32_t>(image.desc.width) - 1;
+    uint32_t img_height = static_cast<uint32_t>(image.desc.height ? image.desc.height : 1) - 1;
+    if (img_width < srd_width || img_height < srd_height) {
+      fprintf(stderr, "updated size!\n");
+      w1.f.WIDTH    = img_width & 0x3u;
+      w2.f.WIDTH_HI = img_width >> 2;
+      w2.f.HEIGHT   = img_height;
+      image.srd[1]  = w1.u32All;
+      image.srd[2]  = w2.u32All;
+    }
+  }
+
   if (image.desc.geometry == HSA_EXT_IMAGE_GEOMETRY_1DB) {
     SQ_BUF_RSRC_WORD0 word0;
     SQ_BUF_RSRC_WORD1 word1;

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_nv.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/image_manager_nv.cpp
@@ -283,7 +283,6 @@ hsa_status_t ImageManagerNv::PopulateImageSrd(Image& image,
     uint32_t img_width  = static_cast<uint32_t>(image.desc.width) - 1;
     uint32_t img_height = static_cast<uint32_t>(image.desc.height ? image.desc.height : 1) - 1;
     if (img_width < srd_width || img_height < srd_height) {
-      fprintf(stderr, "updated size!\n");
       w1.f.WIDTH    = img_width & 0x3u;
       w2.f.WIDTH_HI = img_width >> 2;
       w2.f.HEIGHT   = img_height;


### PR DESCRIPTION
## Motivation

Follow up of AIRUNTIME-186

1.Support cl_amd_planar_yuv  extension and clGetPlaneFromImageAMD() to query Y, UV planes for video formats,

 DXGI_FORMAT_NV12, DXGI_FORMAT_P010

2.Support DXGI_FORMAT_YUY2 and its conversion with R10G10B10A2, 420P,  BGRA, RGBA16, UYVY, NV12. P010 formats for Amf_test:ConvertTool test.

3.Support multi-contexts

4.Many improvements

## Technical Details

Support video formats and optimize code

## JIRA ID

AIRUNTIME-2073

## Test Plan

Amf_test should pass 

## Test Result

Passed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
