### PR TITLE
fix: [RCCL] test_runner coverage summary + loaded-librccl provenance

### DIFF
--- a/projects/rccl/tools/scripts/test_runner/lib/results_emitter.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/results_emitter.py
@@ -139,12 +139,73 @@ def parse_perf_output(text):
     return rows, avg_busbw
 
 
+def parse_coverage_index_html(index_html_path):
+    """
+    Parse the authoritative overall coverage summary from llvm-cov's
+    ``index.html`` ``Totals`` row. This is the correct source for a run's overall
+    percentages: unlike the ``--show-functions`` text report (which has only
+    per-file ``TOTAL`` lines and no grand total), the HTML ``Totals`` row is the
+    single run-wide roll-up.
+
+    The ``Totals`` columns are, in order, Function, Line, Region, Branch -- note
+    this differs from the plain ``llvm-cov report`` column order -- each formatted
+    ``PCT% (covered/total)``. Returns a dict with ``regions_pct``,
+    ``functions_pct``, ``lines_pct``, ``branches_pct`` (branch may be None on
+    older llvm-cov) plus a ``raw`` sub-dict, or None if the file is absent or the
+    ``Totals`` row can't be found.
+    """
+    if not index_html_path or not os.path.isfile(index_html_path):
+        return None
+    try:
+        with open(index_html_path, encoding="utf-8", errors="replace") as f:
+            html = f.read()
+    except OSError:
+        return None
+
+    m = re.search(r"Totals</pre>.*?</tr>", html, re.S)
+    if not m:
+        return None
+    # Each tuple is (pct, covered, total). index.html order: Function, Line,
+    # Region, Branch. Branch may be absent, so require only the first three.
+    vals = re.findall(r">\s*([0-9.]+)%\s*\((\d+)/(\d+)\)", m.group(0))
+    if len(vals) < 3:
+        return None
+
+    order = ["functions", "lines", "regions", "branches"]
+    totals = {}
+    for i, name in enumerate(order):
+        if i < len(vals):
+            pct, covered, total = vals[i]
+            totals[name] = {"pct": float(pct), "covered": int(covered), "total": int(total)}
+
+    def _pct(name):
+        return totals[name]["pct"] if name in totals else None
+
+    return {
+        "regions_pct": _pct("regions"),
+        "functions_pct": _pct("functions"),
+        "lines_pct": _pct("lines"),
+        "branches_pct": _pct("branches"),
+        "raw": {"source": "index.html", "totals": totals},
+    }
+
+
 def parse_coverage_report(report_txt_path):
     """
-    Parse the ``TOTAL`` line of an llvm-cov ``report`` text file into coverage
-    percentages. llvm-cov emits, in order, region / function / line / branch
-    coverage, each with a trailing ``NN.NN%`` column. Returns None if the file is
-    absent or has no TOTAL line.
+    Parse the grand-``TOTAL`` line of a *plain* ``llvm-cov report`` text file
+    (one produced WITHOUT ``--show-functions``) into coverage percentages. A
+    plain report's ``TOTAL`` columns are, in order, region / function / line /
+    branch, each with a trailing ``NN.NN%``.
+
+    This is a last-resort fallback for :func:`parse_coverage_index_html`. Do NOT
+    rely on it for a ``--show-functions`` report (e.g.
+    ``function_coverage_report.txt``): that report emits one ``TOTAL`` line *per
+    file* and has no grand total, so any single ``TOTAL`` is a per-file figure,
+    not the run's overall coverage. To avoid silently emitting a bogus per-file
+    total, this returns None when it sees more than one ``TOTAL`` line.
+
+    Returns None if the file is absent, has no ``TOTAL`` line, or looks like a
+    per-file ``--show-functions`` report.
     """
     if not report_txt_path or not os.path.isfile(report_txt_path):
         return None
@@ -154,15 +215,20 @@ def parse_coverage_report(report_txt_path):
     except OSError:
         return None
 
-    total_line = next((ln for ln in lines if ln.strip().startswith("TOTAL")), None)
-    if not total_line:
+    total_lines = [ln for ln in lines if ln.strip().startswith("TOTAL")]
+    if not total_lines:
         return None
+    # More than one TOTAL => a per-file --show-functions report with no grand
+    # total; refuse rather than mistake the first per-file TOTAL for the overall.
+    if len(total_lines) > 1:
+        return None
+    total_line = total_lines[0]
 
     pcts = [float(p) for p in re.findall(r"([0-9]+\.[0-9]+)%", total_line)]
-    # Region, Function, Line, Branch (branch may be absent in older llvm-cov).
+    # Plain report order: Region, Function, Line, Branch (branch may be absent).
     keys = ["regions_pct", "functions_pct", "lines_pct", "branches_pct"]
     cov = {k: (pcts[i] if i < len(pcts) else None) for i, k in enumerate(keys)}
-    cov["raw"] = {"total_line": total_line.strip(), "percents": pcts}
+    cov["raw"] = {"source": "report.txt", "total_line": total_line.strip(), "percents": pcts}
     return cov
 
 

--- a/projects/rccl/tools/scripts/test_runner/lib/results_emitter.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/results_emitter.py
@@ -167,6 +167,7 @@ def parse_coverage_index_html(index_html_path):
         return None
     # Each tuple is (pct, covered, total). index.html order: Function, Line,
     # Region, Branch. Branch may be absent, so require only the first three.
+    # NB: column order reflects current llvm-cov HTML; revisit if it changes.
     vals = re.findall(r">\s*([0-9.]+)%\s*\((\d+)/(\d+)\)", m.group(0))
     if len(vals) < 3:
         return None
@@ -224,11 +225,13 @@ def parse_coverage_report(report_txt_path):
         return None
     total_line = total_lines[0]
 
-    pcts = [float(p) for p in re.findall(r"([0-9]+\.[0-9]+)%", total_line)]
+    pcts = [float(p) for p in re.findall(r"([0-9.]+)%", total_line)]
     # Plain report order: Region, Function, Line, Branch (branch may be absent).
+    # NB: column order reflects current llvm-cov `report`; revisit if a future
+    # llvm-cov reorders columns.
     keys = ["regions_pct", "functions_pct", "lines_pct", "branches_pct"]
     cov = {k: (pcts[i] if i < len(pcts) else None) for i, k in enumerate(keys)}
-    cov["raw"] = {"source": "report.txt", "total_line": total_line.strip(), "percents": pcts}
+    cov["raw"] = {"source": "plain-report", "total_line": total_line.strip(), "percents": pcts}
     return cov
 
 

--- a/projects/rccl/tools/scripts/test_runner/lib/results_emitter.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/results_emitter.py
@@ -400,10 +400,21 @@ class ResultsEmitter:
                               json.dumps(self.manifest["coverage"], indent=2, default=str))
 
             # Bundle captured logs + coverage report into the run dir so the
-            # tarball is self-contained for the dashboard scrape.
+            # tarball is self-contained for the dashboard scrape. To minimize
+            # bloat, only failing tests' logs are bundled: drop the per-test log
+            # files of passing/skipped tests (any non-per-test file is kept).
             if log_dir and os.path.isdir(log_dir):
                 dst = os.path.join(run_dir, "logs")
-                shutil.copytree(log_dir, dst, dirs_exist_ok=True)
+                drop = set()
+                for t in self.tests:
+                    rel = t.get("log_relpath")
+                    status = (t.get("status") or t.get("result") or "").upper()
+                    if rel and status not in ("FAILED", "TIMEOUT"):
+                        drop.add(os.path.basename(rel))
+                shutil.copytree(
+                    log_dir, dst, dirs_exist_ok=True,
+                    ignore=lambda _dir, names: [n for n in names if n in drop],
+                )
             if report_dir and os.path.isdir(report_dir):
                 dst = os.path.join(run_dir, "report")
                 shutil.copytree(report_dir, dst, dirs_exist_ok=True)

--- a/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
@@ -2251,6 +2251,103 @@ class TestExecutor:
         print(f"Text report: {text_report}")
         print(f"Summary report: {summary_report}")
 
+    def _resolve_rccl_lib(self):
+        """Best-effort: identify the librccl.so the tests actually loaded, and --
+        if it came from a ROCm install rather than a fresh build -- which one.
+
+        Resolution mirrors the loader search order the runner sets in
+        LD_LIBRARY_PATH: the (test) build_dir first, then the caller's
+        LD_LIBRARY_PATH, then <rocm_root>/lib, then the system ldconfig cache.
+        Returns a dict describing the chosen lib (or {"resolved": False, ...}).
+        Never raises -- provenance metadata must not break a run."""
+        try:
+            import glob as _glob
+
+            cand_dirs = []
+            build_dir = getattr(self, "build_dir", None)
+            if build_dir:
+                cand_dirs.append(build_dir)
+            for d in (os.environ.get("LD_LIBRARY_PATH", "") or "").split(":"):
+                if d:
+                    cand_dirs.append(d)
+            rocm_root = None
+            try:
+                rocm_root = self._rocm_root()
+            except Exception:
+                rocm_root = None
+            if rocm_root:
+                cand_dirs.append(os.path.join(rocm_root, "lib"))
+
+            found = None
+            for d in cand_dirs:
+                if not d:
+                    continue
+                for name in ("librccl.so", "librccl.so.1"):
+                    p = os.path.join(d, name)
+                    if os.path.isfile(p) or os.path.islink(p):
+                        found = p
+                        break
+                if not found:
+                    hits = sorted(_glob.glob(os.path.join(d, "librccl.so*")))
+                    if hits:
+                        found = hits[0]
+                if found:
+                    break
+
+            if not found:  # system loader cache
+                try:
+                    out = subprocess.run(["ldconfig", "-p"], capture_output=True, text=True, timeout=10)
+                    m = re.search(r"librccl\.so\S*\s+.*=>\s+(\S+)", out.stdout or "")
+                    if m:
+                        found = m.group(1)
+                except (OSError, subprocess.SubprocessError):
+                    pass
+
+            if not found:
+                return {"resolved": False,
+                        "note": "librccl.so not found on the test LD_LIBRARY_PATH or in ldconfig"}
+
+            real = os.path.realpath(found)
+            info = {"resolved": True, "path": found, "realpath": real}
+            try:
+                st = os.stat(real)
+                info["size"] = st.st_size
+                info["mtime"] = datetime.datetime.fromtimestamp(
+                    st.st_mtime, datetime.timezone.utc).isoformat()
+            except OSError:
+                pass
+
+            sm = re.search(r"librccl\.so\.([0-9][0-9.]*)$", real)
+            if sm:
+                info["soname_version"] = sm.group(1)
+
+            bd = os.path.realpath(build_dir) if build_dir else None
+            if bd and (real == os.path.join(bd, os.path.basename(real)) or real.startswith(bd + os.sep)):
+                info["source"] = "custom" if getattr(self, "using_custom_lib", False) else "test-build"
+            else:
+                # Walk up to the ROCm root (the dir holding .info/version).
+                root = None
+                d = os.path.dirname(real)
+                for _ in range(6):
+                    if os.path.isfile(os.path.join(d, ".info", "version")):
+                        root = d
+                        break
+                    nd = os.path.dirname(d)
+                    if nd == d:
+                        break
+                    d = nd
+                if root:
+                    info["source"] = "rocm-install"
+                    info["rocm_root"] = root
+                    rv = re_mod._rocm_version(root)
+                    if rv:
+                        info["rocm_version"] = rv
+                else:
+                    info["source"] = "system"
+            return info
+        except Exception as e:  # provenance is best-effort
+            return {"resolved": False, "note": f"rccl lib resolution failed: {e}"}
+
     def emit_results(self):
         """Emit structured results for the results dashboard.
 
@@ -2337,6 +2434,11 @@ class TestExecutor:
                 build_type = "release"
             md["rccl_build_type"] = build_type
             md["mpi_impl"] = self.mpi_impl
+            # Which librccl.so the tests actually loaded (and, if it came from a
+            # ROCm install rather than a fresh build, which install). rccl_sha/
+            # rccl_branch describe the *source* checkout, which may differ from
+            # the loaded lib on --no-build / system-RCCL runs.
+            md["rccl_lib"] = self._resolve_rccl_lib()
             md.setdefault("checks", {})["release_build"] = {
                 "status": "OK" if build_type == "release" else ("SKIP" if build_type == "custom" else "WARN"),
                 "value": build_type + (" (perf should use release)" if build_type == "debug" else ""),

--- a/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
@@ -2208,12 +2208,48 @@ class TestExecutor:
             if self.args.verbose:
                 print(f"Command was: {' '.join(text_cmd)}")
 
+        # Generate a plain (no --show-functions) llvm-cov report. Unlike the
+        # per-file --show-functions report above, a plain report ends in a single
+        # grand-TOTAL line, so it is a valid overall summary. This is the fallback
+        # the emitter parses when index.html is unavailable.
+        print("Generating plain coverage summary report...")
+        summary_report = os.path.join(self.report_dir, "coverage_summary.txt")
+        summary_cmd = [
+            llvm_cov,
+            "report",
+            f"--instr-profile={merged_profdata}",
+            "--Xdemangler=c++filt"
+        ]
+        summary_cmd.extend(object_files)
+        summary_cmd.extend([
+            f"--ignore-filename-regex={ignore_regex}",
+            "--sources",
+            self.build_dir
+        ])
+
+        try:
+            with open(summary_report, 'w') as f:
+                subprocess.run(
+                    summary_cmd,
+                    stdout=f,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                    check=True
+                )
+            print(f"Coverage summary report generated: {summary_report}")
+        except subprocess.CalledProcessError as e:
+            print(f"ERROR: Failed to generate plain coverage summary report")
+            print(f"Error: {e.stderr}")
+            if self.args.verbose:
+                print(f"Command was: {' '.join(summary_cmd)}")
+
         print(f"\n{'='*80}")
         print("COVERAGE REPORT GENERATION COMPLETE")
         print(f"{'='*80}")
         print(f"Report directory: {self.report_dir}")
         print(f"HTML report: {self.report_dir}/index.html")
         print(f"Text report: {text_report}")
+        print(f"Summary report: {summary_report}")
 
     def emit_results(self):
         """Emit structured results for the results dashboard.
@@ -2317,15 +2353,16 @@ class TestExecutor:
             emitter.add_test(record)
 
         # Attach coverage if a report was generated this run. The authoritative
-        # overall summary is llvm-cov's index.html Totals row; the text report is
-        # a --show-functions dump with only per-file totals, so it is a last
-        # resort used only when index.html is missing.
+        # overall summary is llvm-cov's index.html Totals row. The fallback is the
+        # plain (no --show-functions) report, whose single grand-TOTAL line is a
+        # valid overall summary; the --show-functions function_coverage_report.txt
+        # is deliberately NOT used here (it has only per-file totals).
         cov = re_mod.parse_coverage_index_html(
             os.path.join(self.report_dir, "index.html")
         )
         if not cov:
             cov = re_mod.parse_coverage_report(
-                os.path.join(self.report_dir, "function_coverage_report.txt")
+                os.path.join(self.report_dir, "coverage_summary.txt")
             )
         emitter.set_coverage(cov)
 

--- a/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
@@ -2262,6 +2262,7 @@ class TestExecutor:
         Never raises -- provenance metadata must not break a run."""
         try:
             import glob as _glob
+            from lib import results_emitter as re_mod
 
             cand_dirs = []
             build_dir = getattr(self, "build_dir", None)

--- a/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
@@ -2238,7 +2238,7 @@ class TestExecutor:
                 )
             print(f"Coverage summary report generated: {summary_report}")
         except subprocess.CalledProcessError as e:
-            print(f"ERROR: Failed to generate plain coverage summary report")
+            print("ERROR: Failed to generate plain coverage summary report")
             print(f"Error: {e.stderr}")
             if self.args.verbose:
                 print(f"Command was: {' '.join(summary_cmd)}")
@@ -2249,7 +2249,8 @@ class TestExecutor:
         print(f"Report directory: {self.report_dir}")
         print(f"HTML report: {self.report_dir}/index.html")
         print(f"Text report: {text_report}")
-        print(f"Summary report: {summary_report}")
+        if os.path.isfile(summary_report):
+            print(f"Summary report: {summary_report}")
 
     def _resolve_rccl_lib(self):
         """Best-effort: identify the librccl.so the tests actually loaded, and --
@@ -2261,7 +2262,6 @@ class TestExecutor:
         Returns a dict describing the chosen lib (or {"resolved": False, ...}).
         Never raises -- provenance metadata must not break a run."""
         try:
-            import glob as _glob
             from lib import results_emitter as re_mod
 
             cand_dirs = []
@@ -2289,7 +2289,7 @@ class TestExecutor:
                         found = p
                         break
                 if not found:
-                    hits = sorted(_glob.glob(os.path.join(d, "librccl.so*")))
+                    hits = sorted(glob.glob(os.path.join(d, "librccl.so*")))
                     if hits:
                         found = hits[0]
                 if found:
@@ -2323,7 +2323,7 @@ class TestExecutor:
                 info["soname_version"] = sm.group(1)
 
             bd = os.path.realpath(build_dir) if build_dir else None
-            if bd and (real == os.path.join(bd, os.path.basename(real)) or real.startswith(bd + os.sep)):
+            if bd and real.startswith(bd + os.sep):
                 info["source"] = "custom" if getattr(self, "using_custom_lib", False) else "test-build"
             else:
                 # Walk up to the ROCm root (the dir holding .info/version).

--- a/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
@@ -2316,10 +2316,17 @@ class TestExecutor:
         for record in self.test_records:
             emitter.add_test(record)
 
-        # Attach coverage if a report was generated this run.
-        cov = re_mod.parse_coverage_report(
-            os.path.join(self.report_dir, "function_coverage_report.txt")
+        # Attach coverage if a report was generated this run. The authoritative
+        # overall summary is llvm-cov's index.html Totals row; the text report is
+        # a --show-functions dump with only per-file totals, so it is a last
+        # resort used only when index.html is missing.
+        cov = re_mod.parse_coverage_index_html(
+            os.path.join(self.report_dir, "index.html")
         )
+        if not cov:
+            cov = re_mod.parse_coverage_report(
+                os.path.join(self.report_dir, "function_coverage_report.txt")
+            )
         emitter.set_coverage(cov)
 
         summary = {


### PR DESCRIPTION
## Motivation

Two `test_runner` result-emission issues: (1) the `--coverage-report` emitter recorded a bogus overall coverage summary (0% / near-empty totals) into `run.json` even when a full, correct llvm-cov report was generated; (2) emitted runs recorded only the *source checkout's* git identity, not the librccl.so the tests actually loaded — which can differ on `--no-build` / system-RCCL runs.

## Technical Details

Coverage summary:
- `parse_coverage_report()` scanned `function_coverage_report.txt` for the first `TOTAL` line. That file is produced with `llvm-cov ... --show-functions`, which emits one `TOTAL` per file and has no grand total, so the first `TOTAL` is a single (often tiny) file's figure, not the run's overall coverage.
- Add `parse_coverage_index_html()` to parse the authoritative `Totals` row of llvm-cov's `index.html` (column order Function/Line/Region/Branch, remapped to canonical fields; branch optional). `emit_results()` now prefers it.
- Add a plain (non-`--show-functions`) `llvm-cov report` (`coverage_summary.txt`) as the fallback, whose single grand-`TOTAL` line is a valid overall summary; harden `parse_coverage_report()` to refuse `--show-functions` input (more than one `TOTAL`).

Loaded-librccl provenance:
- Capture `metadata.rccl_lib`: the resolved librccl.so path/realpath, whether it is a fresh build or a ROCm install, and the ROCm root/version in the install case. Best-effort; never raises.

## JIRA ID

JIRA ID : AICOMRCCL-1482

## Test Plan

Parsed a captured gfx1250 coverage run's `Totals` row and confirmed the emitted summary matches the report; verified the guarded text parser returns `None` on a `--show-functions` report and still parses a valid single-`TOTAL` plain report; validated the librccl resolver against a ROCm install.

## Test Result

Parser yields Functions 56.73% / Lines 42.45% / Regions 17.22% / Branches 14.51% (matching `index.html`), versus the previous 0% / near-empty output. The multi-`TOTAL` bug path now returns `None`. The librccl resolver reports source=rocm-install with the correct ROCm root + version.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.