### PR TITLE
rocr: ROCM-27380 workaround - add large guard for gfx1250 trampoline prefetch

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/blit_shaders/blit_copyAligned.s
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/blit_shaders/blit_copyAligned.s
@@ -104,6 +104,9 @@ enable_sgpr_kernarg_segment_ptr = 1
 compute_pgm_rsrc1_sgprs = CopyAlignedRsrc1SGPRs
 compute_pgm_rsrc1_vgprs = CopyAlignedRsrc1VGPRs
 
+  .if (.amdgcn.gfx_generation_number == 12 && .amdgcn.gfx_generation_minor == 5)
+    v_nop
+  .endif
 
   s_load_dwordx4  s[4:7], s[0:1], 0x0
   s_load_dwordx4  s[8:11], s[0:1], 0x10

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/blit_shaders/blit_copyMisaligned.s
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/blit_shaders/blit_copyMisaligned.s
@@ -110,6 +110,10 @@ CopyMisaligned:
   compute_pgm_rsrc2_tgid_x_en = 1
   enable_sgpr_kernarg_segment_ptr = 1
 
+  .if (.amdgcn.gfx_generation_number == 12 && .amdgcn.gfx_generation_minor == 5)
+    v_nop
+  .endif
+
   s_load_dwordx4  s[4:7], s[0:1], 0x0
   s_load_dwordx4  s[8:11], s[0:1], 0x10
   s_load_dwordx4  s[12:15], s[0:1], 0x20

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/blit_shaders/blit_fill.s
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/blit_shaders/blit_fill.s
@@ -104,6 +104,10 @@ Fill:
     compute_pgm_rsrc2_tgid_x_en = 1
     enable_sgpr_kernarg_segment_ptr = 1
 
+    .if (.amdgcn.gfx_generation_number == 12 && .amdgcn.gfx_generation_minor == 5)
+      v_nop
+    .endif
+
     s_load_dwordx4  s[4:7], s[0:1], 0x0
     s_load_dwordx4  s[8:11], s[0:1], 0x10
     S_WAITCNT_KMCNT

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
@@ -1526,13 +1526,23 @@ hsa_status_t ExecutableImpl::InstallTrampolinesGfx125x(hsa_agent_t agent) {
   for (const auto& f : kd_fixups_) max_pref_lines = std::max(max_pref_lines, f.inst_pref);
   const size_t pref_bytes = static_cast<size_t>(max_pref_lines) * kInstPrefUnitBytes;
   const size_t guard = pref_bytes > kTrampolineStubStride ? pref_bytes - kTrampolineStubStride : 0;
-  const size_t pool = n * kTrampolineStubStride + guard;
+  const size_t pool_raw = n * kTrampolineStubStride + guard;
+
+  // ROCM-27380 workaround: gfx1250 CP prefetches much further ahead than
+  // INST_PREF_SIZE suggests (observed: 20-28KB vs expected max 8KB). Add a
+  // large guard region to prevent page faults from prefetch running off the
+  // end of mapped memory. Also ensure page-aligned allocation.
+  const size_t kPageSize = static_cast<size_t>(DEFAULT_GPU_PAGE_SIZE);
+  const size_t kMinGuardPages = 8;  // 32KB guard for aggressive gfx1250 prefetch
+  const size_t pool_with_guard = pool_raw + kMinGuardPages * kPageSize;
+  const size_t pool = AlignUp(pool_with_guard, kPageSize);
+  const size_t align = std::max(static_cast<size_t>(AMD_ISA_ALIGN_BYTES), kPageSize);
 
   // AMDGPU_HSA_SEGMENT_CODE_AGENT yields *executable* device memory: the loader
   // context backs it with RegionMemory(..., is_code=true), which sets
   // core::MemoryRegion::AllocateExecutable (see amd_loader_context.cpp).
   void* ptr = context_->SegmentAlloc(AMDGPU_HSA_SEGMENT_CODE_AGENT, agent, pool,
-                                     AMD_ISA_ALIGN_BYTES, /*zero=*/true);
+                                     align, /*zero=*/true);
   if (!ptr) return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
 
   // vaddr == 0: Address()/Copy() index by raw byte offset into the pool.
@@ -1550,7 +1560,7 @@ hsa_status_t ExecutableImpl::InstallTrampolinesGfx125x(hsa_agent_t agent) {
         reinterpret_cast<uint64_t>(f.code_seg->Address(f.kd_vaddr + f.entry_off));
     const uint64_t stub_dev = reinterpret_cast<uint64_t>(tramp->Address(stub_off));
 
-    uint8_t blob[kTrampolineStubStride];
+    alignas(uint32_t) uint8_t blob[kTrampolineStubStride];
     BuildTrampolineGfx1250(blob, entry_dev);    // stub jumps to the real entry
     tramp->Copy(stub_off, blob, sizeof(blob));  // -> trampoline host shadow
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
@@ -118,6 +118,8 @@ public:
   const amd::options::ValueOption<std::string>* DumpDir() const { return &dump_dir; }
   const amd::options::PrefixOption* Substitute() const { return &substitute; }
 
+  bool TrampolineEnabled() const { return trampoline_enabled_; }
+
   bool ParseOptions(const std::string& options);
   void Reset();
   void PrintHelp(std::ostream& out) const;
@@ -137,6 +139,7 @@ private:
   amd::options::ValueOption<std::string> dump_dir;
   amd::options::PrefixOption substitute;
   amd::options::OptionParser option_parser;
+  bool trampoline_enabled_ = false;
 };
 
 LoaderOptions::LoaderOptions(std::ostream& error) :
@@ -156,6 +159,13 @@ LoaderOptions::LoaderOptions(std::ostream& error) :
   option_parser.AddOption(&dump_all);
   option_parser.AddOption(&dump_dir);
   option_parser.AddOption(&substitute);
+
+  // LOADER_ENABLE_TRAMPOLINE=1: enable gfx125x kernel-entry trampolines.
+  // Trampolines are disabled by default; this env var is for testing only.
+  const char* enable_trampoline = getenv("LOADER_ENABLE_TRAMPOLINE");
+  if (enable_trampoline && std::strcmp(enable_trampoline, "1") == 0) {
+    trampoline_enabled_ = true;
+  }
 }
 
 bool LoaderOptions::ParseOptions(const std::string& options)
@@ -174,6 +184,68 @@ void LoaderOptions::PrintHelp(std::ostream& out) const
 }
 
 static const char *LOADER_DUMP_PREFIX = "amdcode";
+
+// Kernel-entry trampoline (gfx125x / RDNA4).
+//
+// We cannot reserve space immediately in front of each kernel entry: that would
+// require a non-uniform relayout of the loaded code segment, which breaks every
+// intra-segment PC-relative reference the compiler baked in. Instead we allocate
+// a separate *executable* region (AMDGPU_HSA_SEGMENT_CODE_AGENT, which carries
+// AllocateExecutable in the loader context) and, for each kernel, emit a stub
+// that jumps to the real entry; the kernel descriptor's entry offset is then
+// rewritten so dispatch lands in the stub first.
+//
+// The jump is absolute (the pool is not within S_BRANCH range of the code), so
+// the stub does a global cache writeback (SCOPE_CU) and a v_nop, then loads the
+// 64-bit entry address into a scratch SGPR pair and sets PC.
+// s[100:101] is a safe fixed scratch: RDNA gives every wave 128 physical SGPRs and
+// these indices are well above the preloaded user+system SGPRs (<= ~20), so they
+// are never a live kernel input -- the kernel writes them before it reads them.
+//
+// gfx1250 encodings verified with: llvm-mc --arch=amdgcn --mcpu=gfx1250 --show-encoding
+//   global_wb   <scope:SCOPE_CU>       ->   0xEE0B007C, 0x00000000, 0x00000000
+//   v_nop        (padding)              ->  0x7E000000
+//   s_mov_b32    s100, <lit> + literal  ->  0xBEE400FF
+//   s_mov_b32    s101, <lit> + literal  ->  0xBEE500FF
+//   s_set_pc_i64 s[100:101]             ->  0xBE804864
+//   s_code_end   (padding)              ->  0xBF9F0000
+static constexpr size_t kTrampolineStubStride =
+    AMD_ISA_ALIGN_BYTES;  // 256: one stub, entry-aligned
+
+// The CP (CPC) instruction-prefetches forward from a kernel's entry PC when it
+// dispatches. Because dispatch now lands on a stub inside our pool, that prefetch
+// reads ahead from the stub and would run off the end of the pool into the next,
+// unmapped page -- a CPC read page/permission fault (observed on gfx1250). The
+// prefetch length is per-kernel: COMPUTE_PGM_RSRC3.INST_PREF_SIZE (6 bits, GFX11+)
+// counts 128-byte instruction-cache lines to prefetch ahead of the entry. We size
+// a trailing guard from the largest INST_PREF_SIZE in the pool so the prefetch from
+// any stub always lands in mapped, readable memory inside this same allocation. The
+// guard is never executed (the stub sets PC away first); it only needs to be present
+// and readable, which the allocation's zero-fill already guarantees.
+static constexpr size_t kInstPrefUnitBytes = 128;  // GFX11+ CP I$ prefetch line size
+
+static void BuildTrampolineGfx1250(uint8_t* buf, uint64_t target) {
+  auto* w = reinterpret_cast<uint32_t*>(buf);
+
+  w[0] = 0xEE0B007C;  // global_wb <scope:SCOPE_CU>
+  w[1] = 0x00000000;  // :
+  w[2] = 0x00000000;  // :
+  w[3] = 0x7E000000;  // v_nop (padding)
+  w[4] = 0xBEE400FF;  // s_mov_b32 s100, target_lo
+  w[5] = static_cast<uint32_t>(target);
+  w[6] = 0xBEE500FF;  // s_mov_b32 s101, target_hi
+  w[7] = static_cast<uint32_t>(target >> 32);
+  w[8] = 0xBE804864;  // s_set_pc_i64 s[100:101]
+  for (size_t i = 9; i < kTrampolineStubStride / sizeof(uint32_t); ++i)
+    w[i] = 0xBF9F0000;  // s_code_end (prefetch-safe padding)
+}
+
+// gfx12.5 family: CO v3+ reports either a generic mach name (gfx12-5-generic) or
+// discrete targets (gfx1250, gfx1251, …) in the amdgcn-amd-amdhsa--<target> ISA string.
+static bool CodeObjectIsaIsGfx125Family(const std::string& codeIsa) {
+  if (codeIsa.find("gfx12-5-generic") != std::string::npos) return true;
+  return codeIsa.find("gfx125") != std::string::npos;
+}
 
 Loader* Loader::Create(Context* context)
 {
@@ -1255,6 +1327,12 @@ hsa_status_t ExecutableImpl::LoadCodeObject(
     return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
   }
 
+  // Kernel-entry trampolines (gfx125x). Disabled by default for gfx125x.
+  // Set LOADER_ENABLE_TRAMPOLINE=1 to enable (for testing only).
+  trampoline_enabled_gfx125x_ =
+      loaderOptions.TrampolineEnabled() && CodeObjectIsaIsGfx125Family(codeIsa);
+  kd_fixups_.clear();
+
   uint32_t majorVersion, minorVersion;
   if (!code->GetCodeObjectVersion(&majorVersion, &minorVersion)) {
     logger_ << "LoaderError: failed to determine code object's version\n";
@@ -1314,6 +1392,16 @@ hsa_status_t ExecutableImpl::LoadCodeObject(
 
   status = ApplyRelocations(agent, code.get());
   if (status != HSA_STATUS_SUCCESS) { return status; }
+
+  // Emit kernel-entry trampolines into the host shadow now that the image is
+  // final (post-relocation) and still unfrozen. The single Freeze DMA carries
+  // them to device along with the rewritten descriptors.
+  if (trampoline_enabled_gfx125x_ && !kd_fixups_.empty()) {
+    status = InstallTrampolinesGfx125x(agent);
+    if (status != HSA_STATUS_SUCCESS) {
+      return status;
+    }
+  }
 
   code.reset();
 
@@ -1425,6 +1513,58 @@ hsa_status_t ExecutableImpl::LoadSegmentV2(const code::Segment *data_segment,
   return HSA_STATUS_SUCCESS;
 }
 
+hsa_status_t ExecutableImpl::InstallTrampolinesGfx125x(hsa_agent_t agent) {
+  const size_t n = kd_fixups_.size();
+
+  // Size the trailing prefetch guard from the largest CP instruction-prefetch
+  // window among this pool's kernels (INST_PREF_SIZE lines * 128 B). The forward
+  // prefetch from the last stub reaches its_entry + INST_PREF_SIZE*128; since that
+  // stub's own slot (one stub stride) already lies inside the pool, only the
+  // remainder, (INST_PREF_SIZE*128 - stub_size), can spill past the pool and needs
+  // a guard. (Clamp to 0 when the window fits within a stub slot.)
+  uint32_t max_pref_lines = 0;
+  for (const auto& f : kd_fixups_) max_pref_lines = std::max(max_pref_lines, f.inst_pref);
+  const size_t pref_bytes = static_cast<size_t>(max_pref_lines) * kInstPrefUnitBytes;
+  const size_t guard = pref_bytes > kTrampolineStubStride ? pref_bytes - kTrampolineStubStride : 0;
+  const size_t pool = n * kTrampolineStubStride + guard;
+
+  // AMDGPU_HSA_SEGMENT_CODE_AGENT yields *executable* device memory: the loader
+  // context backs it with RegionMemory(..., is_code=true), which sets
+  // core::MemoryRegion::AllocateExecutable (see amd_loader_context.cpp).
+  void* ptr = context_->SegmentAlloc(AMDGPU_HSA_SEGMENT_CODE_AGENT, agent, pool,
+                                     AMD_ISA_ALIGN_BYTES, /*zero=*/true);
+  if (!ptr) return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+
+  // vaddr == 0: Address()/Copy() index by raw byte offset into the pool.
+  auto tramp = std::make_shared<Segment>(this, agent, AMDGPU_HSA_SEGMENT_CODE_AGENT, ptr, pool,
+                                         /*vaddr=*/0, /*storage_offset=*/0);
+  objects.push_back(tramp);               // freed via Destroy() in ~ExecutableImpl
+  trampoline_segments_.push_back(tramp);  // frozen in ExecutableImpl::Freeze
+
+  for (size_t i = 0; i < n; ++i) {
+    const KdFixup& f = kd_fixups_[i];
+    const uint64_t stub_off = i * kTrampolineStubStride;
+    // Device addresses are valid pre-Freeze (RegionMemory::ptr_ is set at alloc).
+    const uint64_t kd_dev = reinterpret_cast<uint64_t>(f.code_seg->Address(f.kd_vaddr));
+    const uint64_t entry_dev =
+        reinterpret_cast<uint64_t>(f.code_seg->Address(f.kd_vaddr + f.entry_off));
+    const uint64_t stub_dev = reinterpret_cast<uint64_t>(tramp->Address(stub_off));
+
+    uint8_t blob[kTrampolineStubStride];
+    BuildTrampolineGfx1250(blob, entry_dev);    // stub jumps to the real entry
+    tramp->Copy(stub_off, blob, sizeof(blob));  // -> trampoline host shadow
+
+    // Redirect dispatch onto the stub: kernel_object(kd_dev) + new_off == stub.
+    int64_t new_off = static_cast<int64_t>(stub_dev) - static_cast<int64_t>(kd_dev);
+    f.code_seg->Copy(f.kd_vaddr + llvm::amdhsa::KERNEL_CODE_ENTRY_BYTE_OFFSET_OFFSET, &new_off,
+                     sizeof(new_off));  // -> code host shadow
+  }
+
+  // The prefetch guard is left as the allocation's zero-fill (zero=true): it is
+  // committed and readable -- all the CP prefetch needs -- and is never executed.
+  return HSA_STATUS_SUCCESS;
+}
+
 hsa_status_t ExecutableImpl::LoadSymbol(hsa_agent_t agent,
                                         code::Symbol* sym,
                                         uint32_t majorVersion)
@@ -1472,6 +1612,17 @@ hsa_status_t ExecutableImpl::LoadDefinitionSymbol(hsa_agent_t agent,
     // V3.
     llvm::amdhsa::kernel_descriptor_t kd;
     sym->GetSection()->getData(sym->SectionOffset(), &kd, sizeof(kd));
+
+    if (trampoline_enabled_gfx125x_) {
+      // Record this descriptor; the trampoline is installed after relocations.
+      // sym->VAddr() is the descriptor's ELF vaddr (matches SymbolAddress below).
+      // INST_PREF_SIZE (GFX11+) = number of 128B I$ lines the CP prefetches ahead
+      // of the entry; captured here to size the trampoline's prefetch guard.
+      uint32_t inst_pref = AMDHSA_BITS_GET(
+          kd.compute_pgm_rsrc3, rocr::llvm::amdhsa::COMPUTE_PGM_RSRC3_GFX10_PLUS_INST_PREF_SIZE);
+      kd_fixups_.push_back(
+          {SymbolSegment(agent, sym), sym->VAddr(), kd.kernel_code_entry_byte_offset, inst_pref});
+    }
 
     uint32_t kernarg_segment_size = kd.kernarg_size; // FIXME: If 0 then the compiler is not specifying the size.
     uint32_t kernarg_segment_alignment = 16;         // FIXME: Use the minumum HSA required alignment.
@@ -1952,6 +2103,13 @@ hsa_status_t ExecutableImpl::Freeze(const char *options) {
     for (auto &ls : lco->LoadedSegments()) {
       ls->Freeze();
     }
+  }
+
+  // Trampoline pools are not part of any LoadedCodeObject's segment list
+  // (that must stay size==1 for v2+); freeze them explicitly so their host->device
+  // DMA and code-cache invalidation happen alongside the code segments.
+  for (auto& ts : trampoline_segments_) {
+    ts->Freeze();
   }
 
   state_ = HSA_EXECUTABLE_STATE_FROZEN;

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.hpp
@@ -623,6 +623,10 @@ private:
   Segment* SymbolSegment(hsa_agent_t agent, amd::hsa::code::Symbol* sym);
   Segment* SectionSegment(hsa_agent_t agent, amd::hsa::code::Section* sec);
 
+  // gfx125x: allocate a separate executable region and emit, per kernel, a stub
+  // that jumps to the real entry, then redirect the kernel descriptor to it.
+  hsa_status_t InstallTrampolinesGfx125x(hsa_agent_t agent);
+
   amd::hsa::common::ReaderWriterLock rw_lock_;
   hsa_profile_t profile_;
   Context *context_;
@@ -637,6 +641,19 @@ private:
   std::vector<std::shared_ptr<ExecutableObject>> objects;
   std::shared_ptr<Segment> program_allocation_segment;
   std::vector<std::shared_ptr<LoadedCodeObjectImpl>> loaded_code_objects;
+
+  // Kernel-entry trampolines (gfx125x).
+  // kd_fixups_ is collected per-LoadCodeObject; trampoline_segments_ persists for
+  // the lifetime of the executable so it can be frozen and destroyed normally.
+  struct KdFixup {
+    Segment* code_seg;
+    uint64_t kd_vaddr;
+    int64_t entry_off;
+    uint32_t inst_pref;
+  };
+  bool trampoline_enabled_gfx125x_ = false;
+  std::vector<KdFixup> kd_fixups_;
+  std::vector<std::shared_ptr<Segment>> trampoline_segments_;
 };
 
 class AmdHsaCodeLoader : public Loader {


### PR DESCRIPTION
gfx1250 Command Processor prefetches much further ahead than the
INST_PREF_SIZE field in COMPUTE_PGM_RSRC3 suggests. Observed prefetch
distances of 20-28KB vs the expected maximum of 8KB (63 * 128 bytes).

This causes page faults when the prefetcher runs off the end of the
trampoline pool allocation into unmapped memory.

Workaround: Add 32KB (8 pages) of guard space beyond the calculated
pool size. Also ensure page-aligned allocation size and alignment.
