### PR TITLE
fix(rccl): avoid address-taken DevFunc table in -fgpu-rdc build

### DIFF
--- a/projects/rccl/CMakeLists.txt
+++ b/projects/rccl/CMakeLists.txt
@@ -745,6 +745,7 @@ endif()
 rocm_install(TARGETS rcclras)
 
 if(BUILD_TESTS)
+  enable_testing()
   rocm_package_setup_component(clients)
   rocm_package_setup_client_component(tests PACKAGE_NAME unittests)
   if(BUILD_EXT_EXAMPLES)

--- a/projects/rccl/cmake/DeviceLinker.cmake
+++ b/projects/rccl/cmake/DeviceLinker.cmake
@@ -365,7 +365,7 @@ foreach(DL_GPU_TARGET ${DL_GPU_TARGETS})
         -x hip --offload-device-only --offload-arch=${DL_GPU_TARGET}
         ${DL_HIP_COMPILER_FLAGS}
         -gline-tables-only
-        -std=c++17 -w ${DL_OPT_FLAGS}
+        -std=c++17 ${DL_OPT_FLAGS}
         -emit-llvm -S
         -o ${IR_OUT}
         ${SRC}
@@ -440,7 +440,6 @@ add_custom_command(
     ${DL_OPT_FLAGS}
     -std=c++17
     -fPIC
-    -w
     ${DL_HOST_COMPRESS}
     -c -o ${COMMON_FAT_OBJ}
     ${HIPIFY_DIR}/src/device/common.cu.cpp
@@ -465,7 +464,6 @@ add_custom_command(
     ${DL_OPT_FLAGS}
     -std=c++17
     -fPIC
-    -w
     -c -o ${ONERANK_FAT_OBJ}
     ${HIPIFY_DIR}/src/device/onerank.cu.cpp
   DEPENDS ${HIPIFY_DIR}/src/device/onerank.cu.cpp
@@ -499,7 +497,6 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.20")
       ${DL_OPT_FLAGS}
       -std=c++17
       -fPIC
-      -w
       -MD -MF ${COLLECTIVES_DEPFILE}
       -c -o ${COLLECTIVES_FAT_OBJ}
       ${HIPIFY_DIR}/src/collectives.cc
@@ -520,7 +517,6 @@ else()
       ${DL_OPT_FLAGS}
       -std=c++17
       -fPIC
-      -w
       -c -o ${COLLECTIVES_FAT_OBJ}
       ${HIPIFY_DIR}/src/collectives.cc
     DEPENDS ${HIPIFY_DIR}/src/collectives.cc
@@ -550,7 +546,6 @@ add_custom_command(
     ${DL_OPT_FLAGS}
     -std=c++17
     -fPIC
-    -w
     -c -o ${DDA_ALL_REDUCE_IPC_FAT_OBJ}
     ${HIPIFY_DIR}/src/dda_all_reduce_ipc.cu.cpp
   DEPENDS ${HIPIFY_DIR}/src/dda_all_reduce_ipc.cu.cpp
@@ -569,7 +564,6 @@ add_custom_command(
     ${DL_OPT_FLAGS}
     -std=c++17
     -fPIC
-    -w
     -c -o ${DDA_REDUCE_SCATTER_IPC_FAT_OBJ}
     ${HIPIFY_DIR}/src/dda_reduce_scatter_ipc.cu.cpp
   DEPENDS ${HIPIFY_DIR}/src/dda_reduce_scatter_ipc.cu.cpp
@@ -588,7 +582,6 @@ add_custom_command(
     ${DL_OPT_FLAGS}
     -std=c++17
     -fPIC
-    -w
     -c -o ${DDA_ALL_GATHER_IPC_FAT_OBJ}
     ${HIPIFY_DIR}/src/dda_all_gather_ipc.cu.cpp
   DEPENDS ${HIPIFY_DIR}/src/dda_all_gather_ipc.cu.cpp
@@ -607,7 +600,6 @@ add_custom_command(
     ${DL_OPT_FLAGS}
     -std=c++17
     -fPIC
-    -w
     -c -o ${DDA_ALLTOALL_IPC_FAT_OBJ}
     ${HIPIFY_DIR}/src/dda_alltoall_ipc.cu.cpp
   DEPENDS ${HIPIFY_DIR}/src/dda_alltoall_ipc.cu.cpp
@@ -619,16 +611,6 @@ add_custom_command(
 # Symmetric kernels: per-instantiation device TUs from gensrc/symmetric/.
 # Each instantiation file defines a handful of __global__ ncclSymkDevKernel_*
 # entries. Compiled standalone as multi-arch fat objects, mirroring onerank.o.
-#
-# RCCL_DEVICE_TABLE_OMIT mirrors what specialized .cpp files do: it suppresses
-# the cross-TU ncclDevFuncTable_2 emission inside common.h. Without this guard
-# each sym TU pulls in the table and demands ncclDevFunc_* definitions that
-# only live in other TUs, breaking amdgcn-link on stricter toolchains
-# (lld error: undefined hidden symbol: ncclDevFunc_*).
-#
-# Compile every .cpp under gensrc/symmetric/. Some files (all_gather.cpp)
-# define __global__ kernels directly; others (all_reduce.cpp, reduce_scatter.cpp)
-# are include-only stubs that compile to empty objects — harmless.
 #
 # SYM_FAT_OBJS is plural (vs the singular COMMON/ONERANK/COLLECTIVES_FAT_OBJ
 # siblings) because the symmetric generator emits one TU per instantiation.
@@ -645,13 +627,11 @@ if(GENERATE_SYM_KERNELS)
         -x hip ${DL_OFFLOAD_ARCH_FLAGS}
         ${DL_HIP_COMPILER_FLAGS}
         -DRCCL_DEVICE_LINKER
-        -DRCCL_DEVICE_TABLE_OMIT
         ${_link_def_flags}
         ${_host_inc_flags}
         ${DL_OPT_FLAGS}
         -std=c++17
         -fPIC
-        -w
         -c -o ${_sym_obj}
         ${_sym_src}
       DEPENDS ${_sym_src}

--- a/projects/rccl/src/debug.cc
+++ b/projects/rccl/src/debug.cc
@@ -447,7 +447,8 @@ void ncclResetDebugInitInternal() {
 #ifdef pncclResetDebugInit
 #undef pncclResetDebugInit
 #endif
-#if defined(NCCL_OS_LINUX)
+#if defined(NCCL_OS_LINUX) && !defined(__HIP_DEVICE_COMPILE__)
+// Doesn't work on device
 __attribute__ ((visibility("default")))
 __attribute__ ((alias("ncclResetDebugInit")))
 #endif

--- a/projects/rccl/src/device/common.h
+++ b/projects/rccl/src/device/common.h
@@ -560,7 +560,6 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
     if (0 <= SpecializedFnId && ncclShmem.funcId == (unsigned)SpecializedFnId) {
       SpecializedRunWorkBatch().run();
     } else {
-#ifndef RCCL_DEVICE_TABLE_OMIT
 #if defined(USE_INDIRECT_FUNCTION_CALL) || defined(RCCL_DEVICE_LINKER)
       if (COLL_UNROLL == 1)
         ncclDevFuncTable_1[ncclShmem.funcId]();
@@ -575,7 +574,6 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
         NCCL_CALL_FUNCTIONS_2(ncclShmem.funcId);
       else
         NCCL_CALL_FUNCTIONS_4(ncclShmem.funcId);
-#endif
 #endif
     }
 
@@ -606,16 +604,14 @@ __global__ void ncclDevKernel_Generic_4(ncclDevKernelArgsDefaultStorage NCCL_GRI
 #define DEFINE_ncclDevKernel_nop(suffix, coll, redop, ty, algo, proto, specializedFnId) \
   __global__ void ncclDevKernel_##suffix(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {}
 
-#if defined(USE_INDIRECT_FUNCTION_CALL) || defined(RCCL_DEVICE_LINKER)
-#define DEFINE_ncclDevFunc(suffix, coll, redop, ty, algo, proto, acc, pipeline, unroll) \
-  __device__ void ncclDevFunc_##suffix() { \
-    RunWorkBatch<coll, ty, redop<ty>, algo, proto, acc, unroll, pipeline>().run(); \
-  }
-#else
-#define DEFINE_ncclDevFunc(suffix, coll, redop, ty, algo, proto, acc, pipeline, unroll) \
-  __device__ __attribute__((noinline)) void ncclDevFunc_##suffix() { \
-    RunWorkBatch<coll, ty, redop<ty>, algo, proto, acc, unroll, pipeline>().run(); \
-  }
+// noinline iff RCCL_DEVICE_LINKER, via RCCL_DEVFUNC_ATTR (defined in the generated
+// device_table.h).
+#ifndef RCCL_DEVFUNC_ATTR
+#define RCCL_DEVFUNC_ATTR
 #endif
+#define DEFINE_ncclDevFunc(suffix, coll, redop, ty, algo, proto, acc, pipeline, unroll) \
+  __device__ RCCL_DEVFUNC_ATTR void ncclDevFunc_##suffix() { \
+    RunWorkBatch<coll, ty, redop<ty>, algo, proto, acc, unroll, pipeline>().run(); \
+  }
 
 #endif

--- a/projects/rccl/src/device/common.h
+++ b/projects/rccl/src/device/common.h
@@ -604,14 +604,17 @@ __global__ void ncclDevKernel_Generic_4(ncclDevKernelArgsDefaultStorage NCCL_GRI
 #define DEFINE_ncclDevKernel_nop(suffix, coll, redop, ty, algo, proto, specializedFnId) \
   __global__ void ncclDevKernel_##suffix(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {}
 
-// noinline iff RCCL_DEVICE_LINKER, via RCCL_DEVFUNC_ATTR (defined in the generated
-// device_table.h).
-#ifndef RCCL_DEVFUNC_ATTR
-#define RCCL_DEVFUNC_ATTR
-#endif
+// noinline iff RCCL_DEVICE_LINKER (each devfunc is a standalone shard).
+#ifdef RCCL_DEVICE_LINKER
 #define DEFINE_ncclDevFunc(suffix, coll, redop, ty, algo, proto, acc, pipeline, unroll) \
-  __device__ RCCL_DEVFUNC_ATTR void ncclDevFunc_##suffix() { \
+  __device__ __attribute__((noinline)) void ncclDevFunc_##suffix() { \
     RunWorkBatch<coll, ty, redop<ty>, algo, proto, acc, unroll, pipeline>().run(); \
   }
+#else
+#define DEFINE_ncclDevFunc(suffix, coll, redop, ty, algo, proto, acc, pipeline, unroll) \
+  __device__ void ncclDevFunc_##suffix() { \
+    RunWorkBatch<coll, ty, redop<ty>, algo, proto, acc, unroll, pipeline>().run(); \
+  }
+#endif
 
 #endif

--- a/projects/rccl/src/device/generate.py
+++ b/projects/rccl/src/device/generate.py
@@ -398,20 +398,15 @@ with open(os.path.join(gensrc, "device_table.h"), "w") as f:
   print("-- Generating %s" % os.path.join(gensrc, "device_table.h"))
   out = f.write
 
-  # noinline is applied to every ncclDevFunc_* ONLY in the device-linker build.
-  out("#if defined(RCCL_DEVICE_LINKER)\n")
-  out("#define RCCL_DEVFUNC_ATTR __attribute__((noinline))\n")
-  out("#else\n")
-  out("#define RCCL_DEVFUNC_ATTR\n")
-  out("#endif\n\n")
-
+  # Plain forward declarations; noinline (device-linker only) is controlled
+  # solely by DEFINE_ncclDevFunc in common.h.
   for fn in primary_funcs:
     sym = paste("_", "ncclDevFunc", *fn)
     guard = get_arch_guard(fn)
     if guard:
-      out("#if %s\n__device__ RCCL_DEVFUNC_ATTR void %s();\n#endif\n" % (guard, sym))
+      out("#if %s\n__device__ void %s();\n#endif\n" % (guard, sym))
     else:
-      out("__device__ RCCL_DEVFUNC_ATTR void %s();\n" % sym)
+      out("__device__ void %s();\n" % sym)
   out("\n")
 
   index = {val: None for val in all_unrolls}
@@ -452,9 +447,8 @@ with open(os.path.join(gensrc, "device_table.h"), "w") as f:
           f"      : Caller{unroll}<m, l>::call{unroll}(funcIndex);\n"
           "  }\n"
           "};\n\n")
-      i = 0
-      for fn in primary_funcs:
-        if fn.unroll != unroll: continue
+      unroll_fns = [fn for fn in primary_funcs if fn.unroll == unroll]
+      for i, fn in enumerate(unroll_fns):
         sym = paste("_", "ncclDevFunc", *fn)
         guard = get_arch_guard(fn)
         spec = f"template<> struct Caller{unroll}<{i}, {i+1}> {{ static __forceinline__ __device__ void call{unroll}(unsigned short) noexcept"
@@ -469,10 +463,9 @@ with open(os.path.join(gensrc, "device_table.h"), "w") as f:
           out("#endif\n")
         else:
           out(f"{spec} {{ {sym}(); }} }};\n")
-        i += 1
       out("\n")
       out(f"__forceinline__ __device__ void NCCL_CALL_FUNCTIONS_{unroll}(unsigned short funcIndex) noexcept {{\n")
-      out(f"  Caller{unroll}<0, {i}>::call{unroll}(funcIndex);\n")
+      out(f"  Caller{unroll}<0, {len(unroll_fns)}>::call{unroll}(funcIndex);\n")
       out("}\n\n")
     out("#endif // !USE_INDIRECT_FUNCTION_CALL && !RCCL_DEVICE_LINKER\n")
 

--- a/projects/rccl/src/device/generate.py
+++ b/projects/rccl/src/device/generate.py
@@ -462,7 +462,10 @@ with open(os.path.join(gensrc, "device_table.h"), "w") as f:
           out(f"#if {guard}\n")
           out(f"{spec} {{ {sym}(); }} }};\n")
           out("#else\n")
-          out(f"{spec} {{}} }};\n")
+          # Arch-guarded-out slot: the function does not exist for this arch.
+          # Trap instead of a silent no-op so an out-of-range/inconsistent funcId
+          # fails fast, matching the nullptr entries of the function-pointer table.
+          out(f"{spec} {{ __builtin_trap(); }} }};\n")
           out("#endif\n")
         else:
           out(f"{spec} {{ {sym}(); }} }};\n")

--- a/projects/rccl/src/device/generate.py
+++ b/projects/rccl/src/device/generate.py
@@ -398,24 +398,31 @@ with open(os.path.join(gensrc, "device_table.h"), "w") as f:
   print("-- Generating %s" % os.path.join(gensrc, "device_table.h"))
   out = f.write
 
-  if is_ifc: func_declaration = "__device__ void"
-  else: func_declaration = "__device__ __attribute__((noinline)) void"
+  # noinline is applied to every ncclDevFunc_* ONLY in the device-linker build.
+  out("#if defined(RCCL_DEVICE_LINKER)\n")
+  out("#define RCCL_DEVFUNC_ATTR __attribute__((noinline))\n")
+  out("#else\n")
+  out("#define RCCL_DEVFUNC_ATTR\n")
+  out("#endif\n\n")
 
   for fn in primary_funcs:
     sym = paste("_", "ncclDevFunc", *fn)
     guard = get_arch_guard(fn)
     if guard:
-      out("#if %s\n%s %s();\n#endif\n" % (guard, func_declaration, sym))
+      out("#if %s\n__device__ RCCL_DEVFUNC_ATTR void %s();\n#endif\n" % (guard, sym))
     else:
-      out("%s %s();\n" % (func_declaration, sym))
+      out("__device__ RCCL_DEVFUNC_ATTR void %s();\n" % sym)
   out("\n")
 
   index = {val: None for val in all_unrolls}
-  out("#ifndef RCCL_DEVICE_TABLE_OMIT\n")
+
+  # Function-pointer table. Only the builds that dispatch through it at RUNTIME
+  # emit it: the device-linker build and the legacy indirect-function-call build.
+  out("#if defined(USE_INDIRECT_FUNCTION_CALL) || defined(RCCL_DEVICE_LINKER)\n")
   out("typedef void(*ncclDevFuncPtr_t)();\n\n")
   for unroll in all_unrolls:
     index[unroll] = 0
-    out("__device__ ncclDevFuncPtr_t const ncclDevFuncTable_%s[] = {\n" % unroll)
+    out("static __device__ ncclDevFuncPtr_t const ncclDevFuncTable_%s[] = {\n" % unroll)
     for fn in primary_funcs:
       if fn.unroll != unroll: continue
       sym = paste("_", "ncclDevFunc", *fn)
@@ -427,12 +434,17 @@ with open(os.path.join(gensrc, "device_table.h"), "w") as f:
       index[unroll] += 1
     out("nullptr};\n")
     out("\n")
+  out("#endif // USE_INDIRECT_FUNCTION_CALL || RCCL_DEVICE_LINKER\n\n")
 
   if not is_ifc:
+    # Pure-RDC dispatch: a compile-time binary search whose leaves call each
+    # ncclDevFunc_* DIRECTLY BY NAME -- no function-pointer table is referenced,
+    # so nothing is address-taken.
+    out("#if !defined(USE_INDIRECT_FUNCTION_CALL) && !defined(RCCL_DEVICE_LINKER)\n")
     for unroll in all_unrolls:
       out(f"template<unsigned short f, unsigned short l>\n"
           f"struct Caller{unroll} {{\n"
-          "  static __forceinline__ __device__ __host__\n"
+          "  static __forceinline__ __device__\n"
           f"  void call{unroll}(unsigned short funcIndex) noexcept {{\n"
           "    constexpr unsigned short m = f + (l - f) / 2;\n"
           f"    return (funcIndex < m)\n"
@@ -440,21 +452,26 @@ with open(os.path.join(gensrc, "device_table.h"), "w") as f:
           f"      : Caller{unroll}<m, l>::call{unroll}(funcIndex);\n"
           "  }\n"
           "};\n\n")
-
-      out(f"template<unsigned short f>\n"
-          f"struct Caller{unroll}<f, f + 1> {{\n"
-          "  static __forceinline__ __device__ __host__\n"
-          f"  void call{unroll}(unsigned short funcIndex) noexcept {{\n"
-          f"    ncclDevFuncTable_{unroll}[f]();\n"
-          "  }\n"
-          "};\n\n")
-
-      # emit NCCL_CALL_FUNCTIONS_<unroll> wrapper using last index value
+      i = 0
+      for fn in primary_funcs:
+        if fn.unroll != unroll: continue
+        sym = paste("_", "ncclDevFunc", *fn)
+        guard = get_arch_guard(fn)
+        spec = f"template<> struct Caller{unroll}<{i}, {i+1}> {{ static __forceinline__ __device__ void call{unroll}(unsigned short) noexcept"
+        if guard:
+          out(f"#if {guard}\n")
+          out(f"{spec} {{ {sym}(); }} }};\n")
+          out("#else\n")
+          out(f"{spec} {{}} }};\n")
+          out("#endif\n")
+        else:
+          out(f"{spec} {{ {sym}(); }} }};\n")
+        i += 1
+      out("\n")
       out(f"__forceinline__ __device__ void NCCL_CALL_FUNCTIONS_{unroll}(unsigned short funcIndex) noexcept {{\n")
-      out(f"  Caller{unroll}<0, {index[unroll]}>::call{unroll}(funcIndex);\n")
+      out(f"  Caller{unroll}<0, {i}>::call{unroll}(funcIndex);\n")
       out("}\n\n")
-
-  out("#endif // RCCL_DEVICE_TABLE_OMIT\n")
+    out("#endif // !USE_INDIRECT_FUNCTION_CALL && !RCCL_DEVICE_LINKER\n")
 
 # Generate <gensrc>/host_table.cpp
 with open(os.path.join(gensrc, "host_table.cpp"), "w") as f:
@@ -619,7 +636,6 @@ for fn in primary_funcs:
 
   with open(filepath, "w") as f:
     out = f.write
-    out('#define RCCL_DEVICE_TABLE_OMIT\n')
     out('#include "common.h"\n')
     out('#include "%s.h"\n\n' % lower_coll)
     if guard:

--- a/projects/rccl/src/device/test_generate_device_table.py
+++ b/projects/rccl/src/device/test_generate_device_table.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Unit tests for src/device/generate.py device_table.h dispatch generation.
+
+These guard the -fgpu-rdc (non device-linker) code path introduced to avoid
+taking the address of any ncclDevFunc_* in a function-pointer table (issue
+#8129). The generator emits, from a single header:
+
+  * the function-pointer table (ncclDevFuncTable_*), used ONLY when
+    RCCL_DEVICE_LINKER (or the legacy USE_INDIRECT_FUNCTION_CALL) is defined,
+    and declared `static` so unused copies are dead-stripped; and
+  * a compile-time templated binary-search dispatcher (Caller* /
+    NCCL_CALL_FUNCTIONS_*) for the pure-RDC build, whose leaves call each
+    ncclDevFunc_* directly by name (nothing address-taken).
+
+The header is mode-agnostic (generated once); which arm is active is decided at
+compile time by the macros. So these tests assert the *structure/gating* of the
+generated text rather than compiling it.
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+GENERATE_PY = os.path.join(HERE, "generate.py")
+
+# A small, fast slice of collectives. "AllReduce RING SIMPLE Sum f32" expands to
+# both an unguarded primary and an arch-guarded variant, which exercises the
+# guarded-out (trap) leaf below.
+ONLY_FUNCS = "AllReduce RING SIMPLE Sum f32|SendRecv"
+
+
+def _generate(tmpdir, ifc="OFF"):
+    """Run generate.py into tmpdir and return the device_table.h contents."""
+    # argv: gensrc, IFC, (unused), local_gpu_only, rocshmem, ONLY_FUNCS
+    # local_gpu_only=OFF avoids needing rocminfo/a local GPU.
+    subprocess.run(
+        [sys.executable, GENERATE_PY, tmpdir, ifc, "OFF", "OFF", "OFF", ONLY_FUNCS],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    with open(os.path.join(tmpdir, "device_table.h")) as f:
+        return f.read()
+
+
+class DeviceTableGenerationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.exists(GENERATE_PY):
+            raise unittest.SkipTest("generate.py not found next to test")
+        cls._dir = tempfile.mkdtemp(prefix="rccl_devtable_")
+        cls.header = _generate(cls._dir)
+
+    def test_noinline_selector_is_device_linker_gated(self):
+        # RCCL_DEVFUNC_ATTR = noinline iff RCCL_DEVICE_LINKER.
+        self.assertIn("#if defined(RCCL_DEVICE_LINKER)", self.header)
+        self.assertIn("#define RCCL_DEVFUNC_ATTR __attribute__((noinline))", self.header)
+        self.assertIn("__device__ RCCL_DEVFUNC_ATTR void ncclDevFunc_", self.header)
+
+    def test_table_is_static_and_runtime_dispatch_gated(self):
+        # Table only for the runtime-dispatch builds, and internal linkage.
+        self.assertIn(
+            "#if defined(USE_INDIRECT_FUNCTION_CALL) || defined(RCCL_DEVICE_LINKER)",
+            self.header,
+        )
+        self.assertIn("static __device__ ncclDevFuncPtr_t const ncclDevFuncTable_", self.header)
+
+    def test_pure_rdc_dispatch_block_present(self):
+        # Compile-time binary search only when NEITHER runtime-dispatch macro is set.
+        self.assertIn(
+            "#if !defined(USE_INDIRECT_FUNCTION_CALL) && !defined(RCCL_DEVICE_LINKER)",
+            self.header,
+        )
+        self.assertIn("NCCL_CALL_FUNCTIONS_", self.header)
+        # One explicit leaf specialization per index, dispatched by name.
+        self.assertIn("struct Caller1<0, 1>", self.header)
+        self.assertRegex(self.header, r"Caller1<0, \d+>::call1")
+
+    def test_guarded_out_leaf_traps_not_noop(self):
+        # Arch-guarded-out slots must fail fast (matching the old nullptr table
+        # entries), not silently no-op.
+        self.assertIn("__builtin_trap();", self.header)
+
+    def test_no_obsolete_table_omit_macro(self):
+        # RCCL_DEVICE_TABLE_OMIT was retired by the static-table change.
+        self.assertNotIn("RCCL_DEVICE_TABLE_OMIT", self.header)
+
+    def test_specialized_shards_do_not_omit(self):
+        # Specialized shards no longer #define RCCL_DEVICE_TABLE_OMIT.
+        spec_dir = os.path.join(self._dir, "specialized")
+        self.assertTrue(os.path.isdir(spec_dir))
+        for name in os.listdir(spec_dir):
+            with open(os.path.join(spec_dir, name)) as f:
+                self.assertNotIn("RCCL_DEVICE_TABLE_OMIT", f.read())
+
+    def test_ifc_build_keeps_table_and_no_rdc_dispatch(self):
+        # Don't break the legacy indirect-function-call path: with IFC on, the
+        # table is still emitted and the pure-RDC dispatcher is not.
+        with tempfile.TemporaryDirectory(prefix="rccl_devtable_ifc_") as d:
+            header = _generate(d, ifc="ON")
+        self.assertIn("static __device__ ncclDevFuncPtr_t const ncclDevFuncTable_", header)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/projects/rccl/src/device/test_generate_device_table.py
+++ b/projects/rccl/src/device/test_generate_device_table.py
@@ -54,11 +54,14 @@ class DeviceTableGenerationTest(unittest.TestCase):
         cls._dir = tempfile.mkdtemp(prefix="rccl_devtable_")
         cls.header = _generate(cls._dir)
 
-    def test_noinline_selector_is_device_linker_gated(self):
-        # RCCL_DEVFUNC_ATTR = noinline iff RCCL_DEVICE_LINKER.
-        self.assertIn("#if defined(RCCL_DEVICE_LINKER)", self.header)
-        self.assertIn("#define RCCL_DEVFUNC_ATTR __attribute__((noinline))", self.header)
-        self.assertIn("__device__ RCCL_DEVFUNC_ATTR void ncclDevFunc_", self.header)
+    def test_forward_declarations_are_plain(self):
+        # noinline is applied only by DEFINE_ncclDevFunc (common.h), gated on
+        # RCCL_DEVICE_LINKER. The generated forward declarations must stay plain:
+        # a stray noinline here leaks into the definition (attribute is a union
+        # across decl+def) and would force pure-RDC funcs noinline.
+        self.assertIn("__device__ void ncclDevFunc_", self.header)
+        self.assertNotIn("noinline", self.header)
+        self.assertNotIn("RCCL_DEVFUNC_ATTR", self.header)
 
     def test_table_is_static_and_runtime_dispatch_gated(self):
         # Table only for the runtime-dispatch builds, and internal linkage.

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -16,6 +16,15 @@ if(BUILD_TESTS)
     message("MPI-based tests are enabled")
   endif()
 
+  # CPU-only generator unit test: guards the -fgpu-rdc device-function dispatch
+  # codegen in src/device/generate.py. Needs no GPU and no built library.
+  find_package(Python3 COMPONENTS Interpreter REQUIRED)
+  add_test(
+    NAME rccl-generate-device-table
+    COMMAND "${Python3_EXECUTABLE}"
+            "${PROJECT_SOURCE_DIR}/src/device/test_generate_device_table.py"
+  )
+
   if (ENABLE_CODE_COVERAGE)
     add_compile_options("SHELL:-Xarch_host -fprofile-instr-generate" "SHELL:-Xarch_host -fcoverage-mapping")
     add_link_options("SHELL:-Xarch_host -fprofile-instr-generate" "SHELL:-Xarch_host -fcoverage-mapping")


### PR DESCRIPTION
Fixes #8129

Code generation in the `-fgpu-rdc` build was constrained because the device
function-pointer table caused address-taken to be set on the primary
`ncclDevFunc_*` device functions, blocking launch-bound/register propagation in
the whole-program link. Also removes `-w` from the device-linker build (it was
hiding warnings), and guards a Linux-only `alias(...)` in `debug.cc` out of the
HIP device compilation pass (pre-existing breakage that blocked the RDC build).

## Motivation

Restore the performance of the non device-linker (`-fgpu-rdc`) build.

## Technical Details

- Use a compile-time templated binary search in the non device-linker build,
  eliminating the function-pointer table and thus avoiding address-taken on the
  internal `ncclDevFunc_*`; the dispatch leaves call each function directly by name.
- Emit the function-pointer table only for the runtime-dispatch builds
  (`RCCL_DEVICE_LINKER` / legacy `USE_INDIRECT_FUNCTION_CALL`) and declare it
  `static` so unused copies are dead-stripped -- this retires `RCCL_DEVICE_TABLE_OMIT`.
- Apply `noinline` to `ncclDevFunc_*` only under `RCCL_DEVICE_LINKER` via a shared
  `RCCL_DEVFUNC_ATTR` macro (matched on both the forward declaration and definition).
- Arch-guarded-out dispatch leaves `__builtin_trap()` (fail-fast, matching the old
  `nullptr` table entries) rather than silently no-op.

## Test Plan

- New `src/device/test_generate_device_table.py` unit test locks in the dispatch
  gating (static/runtime-only table, pure-RDC by-name dispatch, noinline gating,
  no `RCCL_DEVICE_TABLE_OMIT`, guarded-out leaves trap, IFC still emits the table).
- RCCL unit tests on gfx90a.

## Test Result

- Generator unit test: pass.
- Verified the built `-fgpu-rdc` `librccl.so` device code has no `ncclDevFuncTable_*`
  symbol and no table-indexed indirect dispatch.
- RCCL unit tests: pass on 7 GPUs.