### PR TITLE
[rocprofiler-sdk] handle ext_kernel_dispatch packet type on gfx1250

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/dispatch_handlers.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/dispatch_handlers.cpp
@@ -99,19 +99,46 @@ queue_cb(const context::context*                                  ctx,
     dispatch_data.correlation_id = _corr_id_v;
     {
         auto dispatch_info = common::init_public_api_struct(rocprofiler_kernel_dispatch_info_t{});
-        dispatch_info.kernel_id            = kernel_id;
-        dispatch_info.dispatch_id          = dispatch_id;
-        dispatch_info.agent_id             = CHECK_NOTNULL(queue.get_agent().get_rocp_agent())->id;
-        dispatch_info.queue_id             = queue.get_id();
-        dispatch_info.private_segment_size = pkt.kernel_dispatch.private_segment_size;
-        dispatch_info.group_segment_size   = pkt.kernel_dispatch.group_segment_size;
-        dispatch_info.workgroup_size       = {pkt.kernel_dispatch.workgroup_size_x,
-                                        pkt.kernel_dispatch.workgroup_size_y,
-                                        pkt.kernel_dispatch.workgroup_size_z};
-        dispatch_info.grid_size            = {pkt.kernel_dispatch.grid_size_x,
-                                   pkt.kernel_dispatch.grid_size_y,
-                                   pkt.kernel_dispatch.grid_size_z};
-        dispatch_data.dispatch_info        = dispatch_info;
+        dispatch_info.kernel_id   = kernel_id;
+        dispatch_info.dispatch_id = dispatch_id;
+        dispatch_info.agent_id    = CHECK_NOTNULL(queue.get_agent().get_rocp_agent())->id;
+        dispatch_info.queue_id    = queue.get_id();
+        bool _is_ext_dispatch     = false;
+#if HSA_AMD_EXT_API_TABLE_STEP_VERSION >= 0x0D
+        {
+            auto _pkt_type = (pkt.kernel_dispatch.header >> HSA_PACKET_HEADER_TYPE) &
+                             ((1u << HSA_PACKET_HEADER_WIDTH_TYPE) - 1u);
+            if(_pkt_type == HSA_PACKET_TYPE_VENDOR_SPECIFIC &&
+               pkt.ext_kernel_dispatch.amd_format == HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH)
+                _is_ext_dispatch = true;
+        }
+#endif
+        if(_is_ext_dispatch)
+        {
+#if HSA_AMD_EXT_API_TABLE_STEP_VERSION >= 0x0D
+            const auto& e                      = pkt.ext_kernel_dispatch;
+            dispatch_info.private_segment_size = e.private_segment_size;
+            dispatch_info.group_segment_size   = e.group_segment_size;
+            dispatch_info.workgroup_size       = {
+                e.workgroup_size_x, e.workgroup_size_y, e.workgroup_size_z};
+            dispatch_info.grid_size = {
+                static_cast<uint32_t>(e.cluster_count_x) * e.cluster_size_x * e.workgroup_size_x,
+                static_cast<uint32_t>(e.cluster_count_y) * e.cluster_size_y * e.workgroup_size_y,
+                static_cast<uint32_t>(e.cluster_count_z) * e.cluster_size_z * e.workgroup_size_z};
+#endif
+        }
+        else
+        {
+            dispatch_info.private_segment_size = pkt.kernel_dispatch.private_segment_size;
+            dispatch_info.group_segment_size   = pkt.kernel_dispatch.group_segment_size;
+            dispatch_info.workgroup_size       = {pkt.kernel_dispatch.workgroup_size_x,
+                                            pkt.kernel_dispatch.workgroup_size_y,
+                                            pkt.kernel_dispatch.workgroup_size_z};
+            dispatch_info.grid_size            = {pkt.kernel_dispatch.grid_size_x,
+                                       pkt.kernel_dispatch.grid_size_y,
+                                       pkt.kernel_dispatch.grid_size_z};
+        }
+        dispatch_data.dispatch_info = dispatch_info;
     }
 
     info->user_cb(dispatch_data, &req_profile, user_data, info->callback_args);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kernel_dispatch/tracing.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/kernel_dispatch/tracing.cpp
@@ -47,7 +47,7 @@ get_dispatch_time(const queue_info_session_t& session, packet_data_t& packet_dat
     const auto& callback_record = packet_data.callback_record;
     const auto* _rocp_agent     = agent::get_agent(callback_record.dispatch_info.agent_id);
     auto        _hsa_agent      = agent::get_hsa_agent(_rocp_agent);
-    auto        _signal         = packet_data.kernel_packet.kernel_dispatch.completion_signal;
+    auto        _signal         = packet_data.completion_signal;
     auto        _kern_id        = callback_record.dispatch_info.kernel_id;
 
     return (_hsa_agent) ? get_dispatch_time(*_hsa_agent, _signal, _kern_id, session.enqueue_ts)


### PR DESCRIPTION
## Motivation

On gfx1250, kernel dispatches use `HSA_PACKET_TYPE_VENDOR_SPECIFIC` with `amd_format=HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH` instead of the classic `HSA_PACKET_TYPE_KERNEL_DISPATCH`. Counter collection was reading from the wrong AQL packet union member causing:

- Incorrect `workgroup_size` and `grid_size` values in counter output
- Timestamps always 0 (`completion_signal` read from wrong union offset)

## Technical Details

**`counters/dispatch_handlers.cpp`**

Detect packet type in `queue_cb()` and read `private_segment_size`, `group_segment_size`, `workgroup_size`, and `grid_size` from the correct union member.

For `ext_kernel_dispatch`, `grid_size` is computed as `cluster_count * cluster_size * workgroup_size` per dimension.

**`kernel_dispatch/tracing.cpp`**

Use `packet_data.completion_signal` in `get_dispatch_time()` instead of reading from `kernel_packet.kernel_dispatch.completion_signal` directly. `packet_data.completion_signal` is already correctly extracted for both packet types in `queue_interposition.cpp`.


## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan


## Test Result


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
