### PR TITLE
Fix ROCM-27034: P2P/IPC transport setup fails under asymmetric HIP_VISIBLE_DEVICES

### DIFF
--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -1372,6 +1372,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   int* nvbPeers = NULL;
   struct ncclProxyConnector proxyConn;
   int* pxnPeers = NULL;
+  int64_t* localBusIds = NULL;
   int *topParentLocalRanks = NULL;
   int p2pLevel = -1;
   bool globalNicFused = false;
@@ -1637,7 +1638,22 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   allXgmi = true;
   hasPeerAccess = true;
 
-  if (cudaGetDeviceCount(&localDevCount) != cudaSuccess) localDevCount = 0;
+  if (CUDACLEARERROR(cudaGetDeviceCount(&localDevCount)) != cudaSuccess) {
+    WARN("cudaGetDeviceCount failed; treating all peers as non-accessible for "
+         "clique setup");
+    localDevCount = 0;
+  }
+
+  // RCCL: HIP_VISIBLE_DEVICES may differ per rank, so precompute each rank's
+  // busId so we compare them later.
+  NCCLCHECKGOTO(ncclCalloc(&localBusIds, nranks), ret, fail);
+  for (int j = 0; j < nranks; j++) {
+    int cudaDevJ = comm->peerInfo[j].cudaDev;
+    if (cudaDevJ < 0 || cudaDevJ >= localDevCount ||
+        getBusId(cudaDevJ, &localBusIds[j]) != ncclSuccess) {
+      localBusIds[j] = -1;
+    }
+  }
 
   // Check that all the GPUs have peer access to one another and are XGMI connected
   for (int i = 0; i < nranks && hasPeerAccess; i++) {
@@ -1647,17 +1663,21 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
       int cudaDev2 = comm->peerInfo[j].cudaDev;
       int p2p;
 
-      // RCCL: under asymmetric HIP_VISIBLE_DEVICES a peer ordinal may be out
-      // of range here; hipDeviceCanAccessPeer would return hipErrorInvalidDevice
-      // and leave a sticky error. Treat such a pair as no peer access.
+      // RCCL: HIP_VISIBLE_DEVICES may differ per rank, so check that the peer
+      // device is visible in this process and that its busId matches.
       if (cudaDev1 < 0 || cudaDev1 >= localDevCount || cudaDev2 < 0 ||
           cudaDev2 >= localDevCount) {
         hasPeerAccess = false;
         break;
       }
 
-      if (hipDeviceCanAccessPeer(&p2p, cudaDev1, cudaDev2) != hipSuccess || !p2p)
-      {
+      if (localBusIds[j] == -1 || localBusIds[j] != comm->peerInfo[j].busId) {
+        hasPeerAccess = false;
+        break;
+      }
+
+      if (hipDeviceCanAccessPeer(&p2p, cudaDev1, cudaDev2) != hipSuccess ||
+          !p2p) {
         hasPeerAccess = false;
         break;
       }
@@ -2263,6 +2283,7 @@ exit:
   free(rings);
   free(nvbPeers);
   free(pxnPeers);
+  free(localBusIds);
   return ret;
 fail:
   goto exit;

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -1633,8 +1633,12 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   timers[TIMER_INIT_GRAPHS] = clockNano() - timers[TIMER_INIT_GRAPHS];
 
   bool allXgmi, hasPeerAccess;
+  int localDevCount;
   allXgmi = true;
   hasPeerAccess = true;
+
+  if (cudaGetDeviceCount(&localDevCount) != cudaSuccess) localDevCount = 0;
+
   // Check that all the GPUs have peer access to one another and are XGMI connected
   for (int i = 0; i < nranks && hasPeerAccess; i++) {
     int cudaDev1 = comm->peerInfo[i].cudaDev;
@@ -1642,6 +1646,16 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
       if (i == j) continue;
       int cudaDev2 = comm->peerInfo[j].cudaDev;
       int p2p;
+
+      // RCCL: under asymmetric HIP_VISIBLE_DEVICES a peer ordinal may be out
+      // of range here; hipDeviceCanAccessPeer would return hipErrorInvalidDevice
+      // and leave a sticky error. Treat such a pair as no peer access.
+      if (cudaDev1 < 0 || cudaDev1 >= localDevCount || cudaDev2 < 0 ||
+          cudaDev2 >= localDevCount) {
+        hasPeerAccess = false;
+        break;
+      }
+
       if (hipDeviceCanAccessPeer(&p2p, cudaDev1, cudaDev2) != hipSuccess || !p2p)
       {
         hasPeerAccess = false;

--- a/projects/rccl/src/mnnvl.cc
+++ b/projects/rccl/src/mnnvl.cc
@@ -23,6 +23,11 @@ ncclResult_t ncclMnnvlCheck(struct ncclComm* comm) {
   CUDACHECK(cuDeviceGet(&currentDev, cudaDev));
   // Ignore error if CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED is not supported
   (void) cuDeviceGetAttribute(&flag, CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED, currentDev);
+
+  // RCCL: On ROCm builds where this attribute is unsupported the query records
+  // a pending HIP error; clear it so a successful init leaves no dirty HIP error
+  (void) hipGetLastError();
+
   if (!flag) return ncclSuccess;
 
 #if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)

--- a/projects/rccl/test/AsymmetricVisibilityTests.cpp
+++ b/projects/rccl/test/AsymmetricVisibilityTests.cpp
@@ -31,6 +31,8 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <csignal>
+
 #include <cerrno>
 #include <cstdio>
 #include <cstdlib>
@@ -48,9 +50,13 @@ constexpr const char* kEnvUid = "RCCL_ASYM_UID"; // hex-encoded ncclUniqueId
 
 constexpr int kNumRanks = 2;
 
+// Coordinator process exit code signalling "not enough GPUs"; the parent
+// translates it to a gtest skip. Kept outside the WorkerStatus range (2-8).
+constexpr int kCoordSkip = 10;
+
 // Worker process exit codes; distinct values so the orchestrator failure log
-// identifies which step failed. Values start at 2 to avoid colliding with the
-// exit code 1 that gtest itself returns on an assertion failure.
+// identifies which step failed. Non-zero codes start at 2 to avoid colliding
+// with the exit code 1 that gtest itself returns on an assertion failure.
 enum WorkerStatus {
   kOk = 0,
   kSetDeviceFailed = 2,
@@ -130,7 +136,9 @@ int runWorker(int rank, int localDev, const ncclUniqueId& id) {
   }
 
   const float value = static_cast<float>(rank + 1);
-  hipMemcpy(sendbuf, &value, sizeof(float), hipMemcpyHostToDevice);
+  if (hipMemcpy(sendbuf, &value, sizeof(float), hipMemcpyHostToDevice) !=
+        hipSuccess && !rc)
+    rc = kHipSetupFailed;
 
   nres = ncclAllReduce(sendbuf, recvbuf, 1, ncclFloat32, ncclSum, comm, stream);
   if (nres != ncclSuccess) {
@@ -139,27 +147,32 @@ int runWorker(int rank, int localDev, const ncclUniqueId& id) {
     if (!rc) rc = kAllReduceFailed;
   }
 
-  if (!rc && hipStreamSynchronize(stream) != hipSuccess) {
+  if (hipStreamSynchronize(stream) != hipSuccess && !rc) {
     fprintf(stderr, "[asym rank%d] hipStreamSynchronize failed\n", rank);
     rc = kSyncFailed;
   }
 
   if (!rc) {
     float result = 0.0f;
-    hipMemcpy(&result, recvbuf, sizeof(float), hipMemcpyDeviceToHost);
-    const float expected =
-      static_cast<float>(kNumRanks) * (kNumRanks + 1) / 2.0f;
-    if (result != expected) {
-      fprintf(stderr,
-              "[asym rank%d] wrong AllReduce result %.1f (expected %.1f)\n",
-              rank, result, expected);
-      rc = kWrongResult;
+    if (hipMemcpy(&result, recvbuf, sizeof(float), hipMemcpyDeviceToHost) !=
+        hipSuccess) {
+      fprintf(stderr, "[asym rank%d] result copy back to host failed\n", rank);
+      rc = kHipSetupFailed;
+    } else {
+      const float expected =
+        static_cast<float>(kNumRanks) * (kNumRanks + 1) / 2.0f;
+      if (result != expected) {
+        fprintf(stderr,
+                "[asym rank%d] wrong AllReduce result %.1f (expected %.1f)\n",
+                rank, result, expected);
+        rc = kWrongResult;
+      }
     }
   }
 
-  hipFree(sendbuf);
-  hipFree(recvbuf);
-  hipStreamDestroy(stream);
+  (void)hipFree(sendbuf);
+  (void)hipFree(recvbuf);
+  (void)hipStreamDestroy(stream);
   ncclCommDestroy(comm);
   return rc;
 }
@@ -189,6 +202,48 @@ pid_t spawnWorker(int rank, const char* visibleDevices, int localDev,
   _exit(127);
 }
 
+// Coordinator body. Runs in a process forked from the main gtest process so
+// that the main process never initializes the HIP/NCCL runtime: TestBed forks a
+// fresh child for every collective test, and HIP is not fork-safe once
+// initialized in the parent, so touching it here would crash later TestBed
+// children. Returns an exit code the parent maps to skip/pass/fail.
+int runCoordinator() {
+  int numDevices = 0;
+  if (hipGetDeviceCount(&numDevices) != hipSuccess) return kHipSetupFailed;
+  if (numDevices < 3) return kCoordSkip;
+
+  ncclUniqueId id;
+  if (ncclGetUniqueId(&id) != ncclSuccess) return kInitRankFailed;
+  const std::string uidHex = toHex(id);
+
+  // rank0: HIP_VISIBLE_DEVICES=0,1 -> bind ordinal 1; rank1: =2 -> bind ordinal 0.
+  const pid_t child0 = spawnWorker(0, "0,1", 1, uidHex);
+  const pid_t child1 = (child0 > 0) ? spawnWorker(1, "2", 0, uidHex) : -1;
+  if (child0 <= 0 || child1 <= 0) {
+    if (child0 > 0) { kill(child0, SIGKILL); waitpid(child0, nullptr, 0); }
+    if (child1 > 0) { kill(child1, SIGKILL); waitpid(child1, nullptr, 0); }
+    fprintf(stderr, "[asym] fork failed (child0=%d, child1=%d)\n", child0,
+            child1);
+    return kSetDeviceFailed;
+  }
+
+  int rc = kOk;
+  auto reap = [&rc](pid_t pid, int rank) {
+    int status = 0;
+    if (waitpid(pid, &status, 0) != pid || !WIFEXITED(status)) {
+      fprintf(stderr, "[asym] rank %d terminated abnormally\n", rank);
+      if (!rc) rc = kInitRankFailed;
+    } else if (WEXITSTATUS(status) != kOk) {
+      fprintf(stderr, "[asym] rank %d worker returned %d\n", rank,
+              WEXITSTATUS(status));
+      if (!rc) rc = WEXITSTATUS(status);
+    }
+  };
+  reap(child0, 0);
+  reap(child1, 1);
+  return rc;
+}
+
 } // namespace
 
 // Worker entry point: only active when re-exec'd by the orchestrator (i.e. when
@@ -208,39 +263,35 @@ TEST(AsymmetricVisibilityWorker, Run) {
   ncclUniqueId id;
   ASSERT_TRUE(fromHex(uidEnv, id)) << "malformed ncclUniqueId in environment";
 
-  ASSERT_EQ(runWorker(rank, atoi(devEnv), id), kOk)
-    << "asymmetric-visibility worker rank " << rank << " failed";
+  // Exit with the step-specific WorkerStatus so the orchestrator's WEXITSTATUS
+  // pinpoints the failing step instead of gtest's generic code.
+  const int rc = runWorker(rank, atoi(devEnv), id);
+  if (rc != kOk) _exit(rc);
 }
 
 // Orchestrator: reproduces the ROCM-27034 asymmetric topology with two workers,
 // rank0 seeing devices {0,1} and binding ordinal 1, rank1 seeing device {2} and
-// binding ordinal 0.
+// binding ordinal 0. All HIP/NCCL work happens in a forked coordinator so the
+// main gtest process stays HIP-clean for TestBed's per-test forks.
 TEST(AsymmetricVisibility, CommInitRankAllReduce) {
-  int numDevices = 0;
-  ASSERT_EQ(hipGetDeviceCount(&numDevices), hipSuccess);
-  if (numDevices < 3)
+  const char* cumemEnv = getenv("NCCL_CUMEM_ENABLE");
+  if (cumemEnv != nullptr && atoi(cumemEnv) == 0)
+    GTEST_SKIP() << "NCCL_CUMEM_ENABLE explicitly disabled; this test requires "
+                    "the cuMem path";
+
+  const pid_t coord = fork();
+  if (coord == 0) _exit(runCoordinator());
+  ASSERT_GT(coord, 0) << "fork of coordinator process failed";
+
+  int status = 0;
+  ASSERT_EQ(waitpid(coord, &status, 0), coord);
+  ASSERT_TRUE(WIFEXITED(status)) << "coordinator terminated abnormally";
+  const int code = WEXITSTATUS(status);
+  if (code == kCoordSkip)
     GTEST_SKIP() << "requires at least 3 GPUs for an asymmetric topology";
-
-  ncclUniqueId id;
-  ASSERT_EQ(ncclGetUniqueId(&id), ncclSuccess);
-  const std::string uidHex = toHex(id);
-
-  // rank0: HIP_VISIBLE_DEVICES=0,1 -> bind ordinal 1; rank1: =2 -> bind ordinal 0.
-  const pid_t child0 = spawnWorker(0, "0,1", 1, uidHex);
-  ASSERT_GT(child0, 0) << "fork failed for rank 0";
-  const pid_t child1 = spawnWorker(1, "2", 0, uidHex);
-  ASSERT_GT(child1, 0) << "fork failed for rank 1";
-
-  auto waitOk = [](pid_t pid, int rank) {
-    int status = 0;
-    ASSERT_EQ(waitpid(pid, &status, 0), pid);
-    ASSERT_TRUE(WIFEXITED(status))
-      << "rank " << rank << " terminated abnormally";
-    ASSERT_EQ(WEXITSTATUS(status), 0)
-      << "rank " << rank << " worker returned failure";
-  };
-  waitOk(child0, 0);
-  waitOk(child1, 1);
+  EXPECT_EQ(code, kOk)
+    << "asymmetric-visibility workers reported failure (exit code " << code
+    << "); see stderr for the failing rank";
 }
 
 } // namespace RcclUnitTesting

--- a/projects/rccl/test/AsymmetricVisibilityTests.cpp
+++ b/projects/rccl/test/AsymmetricVisibilityTests.cpp
@@ -50,22 +50,17 @@ constexpr const char* kEnvUid = "RCCL_ASYM_UID"; // hex-encoded ncclUniqueId
 
 constexpr int kNumRanks = 2;
 
-// Coordinator process exit code signalling "not enough GPUs"; the parent
-// translates it to a gtest skip. Kept outside the WorkerStatus range (2-8).
-constexpr int kCoordSkip = 10;
+// Minimum GPUs for the asymmetric topology: rank0 sees 2 devices, rank1 sees
+// a third, disjoint device.
+constexpr int kMinDevices = 3;
 
-// Worker process exit codes; distinct values so the orchestrator failure log
-// identifies which step failed. Non-zero codes start at 2 to avoid colliding
-// with the exit code 1 that gtest itself returns on an assertion failure.
+// Process exit codes shared between workers and coordinator. kCoordSkip is
+// returned by the coordinator when there aren't enough GPUs; the parent maps
+// it to a gtest skip.
 enum WorkerStatus {
   kOk = 0,
-  kSetDeviceFailed = 2,
-  kInitRankFailed = 3,
-  kHipSetupFailed = 4,
-  kAllReduceFailed = 5,
-  kSyncFailed = 6,
-  kWrongResult = 7,
-  kPendingHipError = 8,
+  kWorkerFailed = 1,
+  kCoordSkip = 2,
 };
 
 std::string toHex(const ncclUniqueId& id) {
@@ -81,107 +76,134 @@ std::string toHex(const ncclUniqueId& id) {
 }
 
 bool fromHex(const std::string& hex, ncclUniqueId& id) {
-  if (hex.size() != sizeof(ncclUniqueId) * 2) return false;
+  if (hex.size() != sizeof(ncclUniqueId) * 2) { return false; }
   unsigned char* bytes = reinterpret_cast<unsigned char*>(&id);
   for (size_t i = 0; i < sizeof(ncclUniqueId); ++i) {
     unsigned int v = 0;
-    if (sscanf(hex.c_str() + i * 2, "%02x", &v) != 1) return false;
+    const int parsed = sscanf(hex.c_str() + i * 2, "%02x", &v);
+    if (parsed != 1) { return false; }
     bytes[i] = static_cast<unsigned char>(v);
   }
   return true;
 }
 
+// RAII holder for a worker's AllReduce resources, so every early return
+// cleans up automatically instead of duplicating hipFree/hipStreamDestroy at
+// each exit point. ncclCommDestroy only runs after a confirmed success: on
+// any failure the process exits right away, and the coordinator kills a
+// hung peer outright (see runCoordinator), so there's no peer left to
+// coordinate a graceful comm teardown with.
+struct WorkerResources {
+  hipStream_t stream = nullptr;
+  float* sendbuf = nullptr;
+  float* recvbuf = nullptr;
+  ncclComm_t comm = nullptr;
+  bool success = false;
+
+  WorkerResources() = default;
+  WorkerResources(const WorkerResources&) = delete;
+  WorkerResources& operator=(const WorkerResources&) = delete;
+
+  ~WorkerResources() {
+    if (sendbuf) { (void)hipFree(sendbuf); }
+    if (recvbuf) { (void)hipFree(recvbuf); }
+    if (stream) { (void)hipStreamDestroy(stream); }
+    if (comm && success) { ncclCommDestroy(comm); }
+  }
+};
+
+// File-local check macros. We don't use the shared HIPCHECK/NCCLCHECK from
+// TestChecks.hpp because those return a raw ncclResult_t (whose values would
+// collide with our WorkerStatus exit codes) and log without a rank prefix,
+// which two concurrent workers interleaving on stderr need. On failure these
+// log the failing call, then run onFail (a return with the caller's own code).
+#define ASYM_HIPCHECK(cmd, tag, onFail)                                        \
+  do {                                                                         \
+    err = (cmd);                                                               \
+    if (err != hipSuccess) {                                                   \
+      fprintf(stderr, "%s %s failed: %s\n", tag, #cmd,                         \
+              hipGetErrorString(err));                                         \
+      onFail;                                                                  \
+    }                                                                          \
+  } while (0)
+
+#define ASYM_NCCLCHECK(cmd, tag, onFail)                                       \
+  do {                                                                         \
+    nres = (cmd);                                                              \
+    if (nres != ncclSuccess) {                                                 \
+      fprintf(stderr, "%s %s failed: %s\n", tag, #cmd,                         \
+              ncclGetErrorString(nres));                                       \
+      onFail;                                                                  \
+    }                                                                          \
+  } while (0)
+
 // Body executed inside a re-exec'd worker process. Returns kOk on success.
 int runWorker(int rank, int localDev, const ncclUniqueId& id) {
-  if (hipSetDevice(localDev) != hipSuccess) {
-    fprintf(stderr, "[asym rank%d] hipSetDevice(%d) failed\n", rank, localDev);
-    return kSetDeviceFailed;
-  }
+  char tag[32];
+  snprintf(tag, sizeof(tag), "[asym rank%d]", rank);
+
+  hipError_t err;
+  ASYM_HIPCHECK(hipSetDevice(localDev), tag, return kWorkerFailed);
 
   // Clear any pre-existing HIP error so the check below reflects only what
   // happened during ncclCommInitRank.
   (void)hipGetLastError();
 
-  ncclComm_t comm = nullptr;
-  ncclResult_t nres = ncclCommInitRank(&comm, kNumRanks, id, rank);
-  if (nres != ncclSuccess) {
-    fprintf(stderr, "[asym rank%d] ncclCommInitRank failed: %s\n", rank,
-            ncclGetErrorString(nres));
-    return kInitRankFailed;
-  }
+  WorkerResources res;
+  ncclResult_t nres;
+  ASYM_NCCLCHECK(ncclCommInitRank(&res.comm, kNumRanks, id, rank), tag,
+                 return kWorkerFailed);
 
   // Core of the ROCM-27034 regression: a successful ncclCommInitRank must not
   // leave a pending HIP error behind.
-  hipError_t pendingHipError = hipGetLastError();
-  int rc = kOk;
-  if (pendingHipError != hipSuccess) {
-    fprintf(stderr,
-            "[asym rank%d] ncclCommInitRank left a pending HIP error: %s\n",
-            rank, hipGetErrorString(pendingHipError));
-    rc = kPendingHipError;
+  err = hipGetLastError();
+  if (err != hipSuccess) {
+    fprintf(stderr, "%s ncclCommInitRank left a pending HIP error: %s\n", tag,
+            hipGetErrorString(err));
+    return kWorkerFailed;
   }
 
-  // Also verify the communicator actually works with a small AllReduce. Both
-  // ranks must reach the collective, so a failure recorded above is returned
-  // only after it - bailing out early here would deadlock the peer rank.
-  hipStream_t stream = nullptr;
-  float* sendbuf = nullptr;
-  float* recvbuf = nullptr;
-  if (hipStreamCreate(&stream) != hipSuccess ||
-      hipMalloc(&sendbuf, sizeof(float)) != hipSuccess ||
-      hipMalloc(&recvbuf, sizeof(float)) != hipSuccess) {
-    fprintf(stderr, "[asym rank%d] HIP setup for AllReduce failed\n", rank);
-    ncclCommAbort(comm);
-    return rc ? rc : kHipSetupFailed;
-  }
+  // Also verify the communicator actually works with a small AllReduce.
+  ASYM_HIPCHECK(hipStreamCreate(&res.stream), tag, return kWorkerFailed);
+  ASYM_HIPCHECK(hipMalloc(&res.sendbuf, sizeof(float)), tag,
+                return kWorkerFailed);
+  ASYM_HIPCHECK(hipMalloc(&res.recvbuf, sizeof(float)), tag,
+                return kWorkerFailed);
 
   const float value = static_cast<float>(rank + 1);
-  if (hipMemcpy(sendbuf, &value, sizeof(float), hipMemcpyHostToDevice) !=
-        hipSuccess && !rc)
-    rc = kHipSetupFailed;
+  ASYM_HIPCHECK(hipMemcpy(res.sendbuf, &value, sizeof(float),
+                          hipMemcpyHostToDevice),
+                tag, return kWorkerFailed);
 
-  nres = ncclAllReduce(sendbuf, recvbuf, 1, ncclFloat32, ncclSum, comm, stream);
-  if (nres != ncclSuccess) {
-    fprintf(stderr, "[asym rank%d] ncclAllReduce failed: %s\n", rank,
-            ncclGetErrorString(nres));
-    if (!rc) rc = kAllReduceFailed;
+  ASYM_NCCLCHECK(ncclAllReduce(res.sendbuf, res.recvbuf, 1, ncclFloat32,
+                               ncclSum, res.comm, res.stream),
+                 tag, return kWorkerFailed);
+
+  ASYM_HIPCHECK(hipStreamSynchronize(res.stream), tag, return kWorkerFailed);
+
+  float result = 0.0f;
+  ASYM_HIPCHECK(hipMemcpy(&result, res.recvbuf, sizeof(float),
+                          hipMemcpyDeviceToHost),
+                tag, return kWorkerFailed);
+
+  const float expected = static_cast<float>(kNumRanks) * (kNumRanks + 1) / 2.0f;
+  if (result != expected) {
+    fprintf(stderr, "%s wrong AllReduce result %.1f (expected %.1f)\n", tag,
+            result, expected);
+    return kWorkerFailed;
   }
 
-  if (hipStreamSynchronize(stream) != hipSuccess && !rc) {
-    fprintf(stderr, "[asym rank%d] hipStreamSynchronize failed\n", rank);
-    rc = kSyncFailed;
-  }
-
-  if (!rc) {
-    float result = 0.0f;
-    if (hipMemcpy(&result, recvbuf, sizeof(float), hipMemcpyDeviceToHost) !=
-        hipSuccess) {
-      fprintf(stderr, "[asym rank%d] result copy back to host failed\n", rank);
-      rc = kHipSetupFailed;
-    } else {
-      const float expected =
-        static_cast<float>(kNumRanks) * (kNumRanks + 1) / 2.0f;
-      if (result != expected) {
-        fprintf(stderr,
-                "[asym rank%d] wrong AllReduce result %.1f (expected %.1f)\n",
-                rank, result, expected);
-        rc = kWrongResult;
-      }
-    }
-  }
-
-  (void)hipFree(sendbuf);
-  (void)hipFree(recvbuf);
-  (void)hipStreamDestroy(stream);
-  ncclCommDestroy(comm);
-  return rc;
+  res.success = true;
+  return kOk;
 }
 
 // Spawn one worker: fork, set the asymmetric environment, re-exec the worker.
 pid_t spawnWorker(int rank, const char* visibleDevices, int localDev,
                   const std::string& uidHex) {
   pid_t pid = fork();
-  if (pid != 0) return pid; // parent (or fork error, reported by caller)
+  if (pid != 0) {
+    return pid; // parent (or fork error, reported by caller)
+  }
 
   // Child: set the per-rank environment BEFORE HIP initializes, then re-exec
   // a fresh image so the restricted visibility takes effect cleanly.
@@ -208,39 +230,61 @@ pid_t spawnWorker(int rank, const char* visibleDevices, int localDev,
 // initialized in the parent, so touching it here would crash later TestBed
 // children. Returns an exit code the parent maps to skip/pass/fail.
 int runCoordinator() {
+  const char* tag = "[asym]";
+
   int numDevices = 0;
-  if (hipGetDeviceCount(&numDevices) != hipSuccess) return kHipSetupFailed;
-  if (numDevices < 3) return kCoordSkip;
+  hipError_t err;
+  ASYM_HIPCHECK(hipGetDeviceCount(&numDevices), tag, return kWorkerFailed);
+  if (numDevices < kMinDevices) { return kCoordSkip; }
 
   ncclUniqueId id;
-  if (ncclGetUniqueId(&id) != ncclSuccess) return kInitRankFailed;
+  ncclResult_t nres;
+  ASYM_NCCLCHECK(ncclGetUniqueId(&id), tag, return kWorkerFailed);
   const std::string uidHex = toHex(id);
 
   // rank0: HIP_VISIBLE_DEVICES=0,1 -> bind ordinal 1; rank1: =2 -> bind ordinal 0.
   const pid_t child0 = spawnWorker(0, "0,1", 1, uidHex);
   const pid_t child1 = (child0 > 0) ? spawnWorker(1, "2", 0, uidHex) : -1;
   if (child0 <= 0 || child1 <= 0) {
-    if (child0 > 0) { kill(child0, SIGKILL); waitpid(child0, nullptr, 0); }
-    if (child1 > 0) { kill(child1, SIGKILL); waitpid(child1, nullptr, 0); }
-    fprintf(stderr, "[asym] fork failed (child0=%d, child1=%d)\n", child0,
+    if (child0 > 0) {
+      kill(child0, SIGKILL);
+      waitpid(child0, nullptr, 0);
+    }
+    if (child1 > 0) {
+      kill(child1, SIGKILL);
+      waitpid(child1, nullptr, 0);
+    }
+    fprintf(stderr, "%s fork failed (child0=%d, child1=%d)\n", tag, child0,
             child1);
-    return kSetDeviceFailed;
+    return kWorkerFailed;
   }
 
+  // Reap whichever worker exits first. If it failed, kill its peer right
+  // away instead of waiting on it - a rank already blocked in ncclAllReduce
+  // would otherwise hang forever for a partner that already gave up.
+  const pid_t children[kNumRanks] = {child0, child1};
+  bool reaped[kNumRanks] = {false, false};
   int rc = kOk;
-  auto reap = [&rc](pid_t pid, int rank) {
+  for (int done_count = 0; done_count < kNumRanks; ++done_count) {
     int status = 0;
-    if (waitpid(pid, &status, 0) != pid || !WIFEXITED(status)) {
-      fprintf(stderr, "[asym] rank %d terminated abnormally\n", rank);
-      if (!rc) rc = kInitRankFailed;
-    } else if (WEXITSTATUS(status) != kOk) {
-      fprintf(stderr, "[asym] rank %d worker returned %d\n", rank,
-              WEXITSTATUS(status));
-      if (!rc) rc = WEXITSTATUS(status);
+    const pid_t done = waitpid(-1, &status, 0);
+    if (done < 0) {
+      fprintf(stderr, "%s waitpid failed: %s\n", tag, strerror(errno));
+      if (!rc) { rc = kWorkerFailed; }
+      continue;
     }
-  };
-  reap(child0, 0);
-  reap(child1, 1);
+
+    const int rank = (done == child0) ? 0 : 1;
+    reaped[rank] = true;
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != kOk) {
+      fprintf(stderr, "%s rank %d failed or terminated abnormally\n", tag,
+              rank);
+      if (!rc) { rc = kWorkerFailed; }
+      // Only signal the peer if it hasn't already been reaped
+      const int peer = 1 - rank;
+      if (!reaped[peer]) { kill(children[peer], SIGKILL); }
+    }
+  }
   return rc;
 }
 
@@ -250,9 +294,10 @@ int runCoordinator() {
 // the rank env var is present). In a normal full-suite run it skips.
 TEST(AsymmetricVisibilityWorker, Run) {
   const char* rankEnv = getenv(kEnvRank);
-  if (rankEnv == nullptr)
+  if (rankEnv == nullptr) {
     GTEST_SKIP() << "worker entry point, driven by "
                     "AsymmetricVisibility.CommInitRankAllReduce";
+  }
 
   const int rank = atoi(rankEnv);
   const char* devEnv = getenv(kEnvLocalDev);
@@ -263,10 +308,10 @@ TEST(AsymmetricVisibilityWorker, Run) {
   ncclUniqueId id;
   ASSERT_TRUE(fromHex(uidEnv, id)) << "malformed ncclUniqueId in environment";
 
-  // Exit with the step-specific WorkerStatus so the orchestrator's WEXITSTATUS
-  // pinpoints the failing step instead of gtest's generic code.
+  // Exit with the WorkerStatus code so the orchestrator's WEXITSTATUS reflects
+  // this worker's own result rather than gtest's generic exit code.
   const int rc = runWorker(rank, atoi(devEnv), id);
-  if (rc != kOk) _exit(rc);
+  if (rc != kOk) { _exit(rc); }
 }
 
 // Orchestrator: reproduces the ROCM-27034 asymmetric topology with two workers,
@@ -275,20 +320,24 @@ TEST(AsymmetricVisibilityWorker, Run) {
 // main gtest process stays HIP-clean for TestBed's per-test forks.
 TEST(AsymmetricVisibility, CommInitRankAllReduce) {
   const char* cumemEnv = getenv("NCCL_CUMEM_ENABLE");
-  if (cumemEnv != nullptr && atoi(cumemEnv) == 0)
+  const int cumemValue = cumemEnv != nullptr ? atoi(cumemEnv) : 1;
+  if (cumemValue == 0) {
     GTEST_SKIP() << "NCCL_CUMEM_ENABLE explicitly disabled; this test requires "
                     "the cuMem path";
+  }
 
   const pid_t coord = fork();
-  if (coord == 0) _exit(runCoordinator());
+  if (coord == 0) { _exit(runCoordinator()); }
   ASSERT_GT(coord, 0) << "fork of coordinator process failed";
 
   int status = 0;
   ASSERT_EQ(waitpid(coord, &status, 0), coord);
   ASSERT_TRUE(WIFEXITED(status)) << "coordinator terminated abnormally";
   const int code = WEXITSTATUS(status);
-  if (code == kCoordSkip)
-    GTEST_SKIP() << "requires at least 3 GPUs for an asymmetric topology";
+  if (code == kCoordSkip) {
+    GTEST_SKIP() << "requires at least " << kMinDevices
+                 << " GPUs for an asymmetric topology";
+  }
   EXPECT_EQ(code, kOk)
     << "asymmetric-visibility workers reported failure (exit code " << code
     << "); see stderr for the failing rank";

--- a/projects/rccl/test/AsymmetricVisibilityTests.cpp
+++ b/projects/rccl/test/AsymmetricVisibilityTests.cpp
@@ -1,0 +1,246 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Regression test for ROCM-27034: RCCL communicator setup under an asymmetric
+// HIP_VISIBLE_DEVICES topology (each rank sees a different device subset).
+//
+// The bug: RCCL's clique peer-access check in init.cc queried
+// hipDeviceCanAccessPeer() with a peer rank's own-process ordinal, which can be
+// out of range in the local process under asymmetric visibility. That records a
+// pending HIP error (hipErrorInvalidDevice) which ncclCommInitRank returns
+// successfully, but which PyTorch's allocator then reports as "invalid device
+// ordinal" on the first tensor allocation.
+//
+// This test spawns its own worker processes via fork()+execv(), each with a
+// distinct HIP_VISIBLE_DEVICES set before HIP is initialized.
+// The orchestrator generates the ncclUniqueId and hands it to the workers
+// hex-encoded in the environment. Each worker binds its device, joins a
+// 2-rank communicator, asserts that init left no pending HIP error, and runs a
+// small AllReduce to confirm the communicator is functional.
+//
+// Note: the legacy IPC path requires the cuMem/VMM handle path to survive
+// asymmetric visibility, so the workers run with NCCL_CUMEM_ENABLE=1.
+
+#include <gtest/gtest.h>
+#include <rccl/rccl.h>
+#include <hip/hip_runtime.h>
+
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+namespace RcclUnitTesting {
+namespace {
+
+// Env var names shared between orchestrator and worker.
+constexpr const char* kEnvRank = "RCCL_ASYM_RANK"; // worker rank (0 or 1)
+constexpr const char* kEnvLocalDev =
+  "RCCL_ASYM_LOCALDEV"; // ordinal to bind within visible set
+constexpr const char* kEnvUid = "RCCL_ASYM_UID"; // hex-encoded ncclUniqueId
+
+constexpr int kNumRanks = 2;
+
+// Worker process exit codes; distinct values so the orchestrator failure log
+// identifies which step failed. Values start at 2 to avoid colliding with the
+// exit code 1 that gtest itself returns on an assertion failure.
+enum WorkerStatus {
+  kOk = 0,
+  kSetDeviceFailed = 2,
+  kInitRankFailed = 3,
+  kHipSetupFailed = 4,
+  kAllReduceFailed = 5,
+  kSyncFailed = 6,
+  kWrongResult = 7,
+  kPendingHipError = 8,
+};
+
+std::string toHex(const ncclUniqueId& id) {
+  const unsigned char* bytes = reinterpret_cast<const unsigned char*>(&id);
+  std::string out;
+  out.reserve(sizeof(ncclUniqueId) * 2);
+  char buf[3];
+  for (size_t i = 0; i < sizeof(ncclUniqueId); ++i) {
+    snprintf(buf, sizeof(buf), "%02x", bytes[i]);
+    out += buf;
+  }
+  return out;
+}
+
+bool fromHex(const std::string& hex, ncclUniqueId& id) {
+  if (hex.size() != sizeof(ncclUniqueId) * 2) return false;
+  unsigned char* bytes = reinterpret_cast<unsigned char*>(&id);
+  for (size_t i = 0; i < sizeof(ncclUniqueId); ++i) {
+    unsigned int v = 0;
+    if (sscanf(hex.c_str() + i * 2, "%02x", &v) != 1) return false;
+    bytes[i] = static_cast<unsigned char>(v);
+  }
+  return true;
+}
+
+// Body executed inside a re-exec'd worker process. Returns kOk on success.
+int runWorker(int rank, int localDev, const ncclUniqueId& id) {
+  if (hipSetDevice(localDev) != hipSuccess) {
+    fprintf(stderr, "[asym rank%d] hipSetDevice(%d) failed\n", rank, localDev);
+    return kSetDeviceFailed;
+  }
+
+  // Clear any pre-existing HIP error so the check below reflects only what
+  // happened during ncclCommInitRank.
+  (void)hipGetLastError();
+
+  ncclComm_t comm = nullptr;
+  ncclResult_t nres = ncclCommInitRank(&comm, kNumRanks, id, rank);
+  if (nres != ncclSuccess) {
+    fprintf(stderr, "[asym rank%d] ncclCommInitRank failed: %s\n", rank,
+            ncclGetErrorString(nres));
+    return kInitRankFailed;
+  }
+
+  // Core of the ROCM-27034 regression: a successful ncclCommInitRank must not
+  // leave a pending HIP error behind.
+  hipError_t pendingHipError = hipGetLastError();
+  int rc = kOk;
+  if (pendingHipError != hipSuccess) {
+    fprintf(stderr,
+            "[asym rank%d] ncclCommInitRank left a pending HIP error: %s\n",
+            rank, hipGetErrorString(pendingHipError));
+    rc = kPendingHipError;
+  }
+
+  // Also verify the communicator actually works with a small AllReduce. Both
+  // ranks must reach the collective, so a failure recorded above is returned
+  // only after it - bailing out early here would deadlock the peer rank.
+  hipStream_t stream = nullptr;
+  float* sendbuf = nullptr;
+  float* recvbuf = nullptr;
+  if (hipStreamCreate(&stream) != hipSuccess ||
+      hipMalloc(&sendbuf, sizeof(float)) != hipSuccess ||
+      hipMalloc(&recvbuf, sizeof(float)) != hipSuccess) {
+    fprintf(stderr, "[asym rank%d] HIP setup for AllReduce failed\n", rank);
+    ncclCommAbort(comm);
+    return rc ? rc : kHipSetupFailed;
+  }
+
+  const float value = static_cast<float>(rank + 1);
+  hipMemcpy(sendbuf, &value, sizeof(float), hipMemcpyHostToDevice);
+
+  nres = ncclAllReduce(sendbuf, recvbuf, 1, ncclFloat32, ncclSum, comm, stream);
+  if (nres != ncclSuccess) {
+    fprintf(stderr, "[asym rank%d] ncclAllReduce failed: %s\n", rank,
+            ncclGetErrorString(nres));
+    if (!rc) rc = kAllReduceFailed;
+  }
+
+  if (!rc && hipStreamSynchronize(stream) != hipSuccess) {
+    fprintf(stderr, "[asym rank%d] hipStreamSynchronize failed\n", rank);
+    rc = kSyncFailed;
+  }
+
+  if (!rc) {
+    float result = 0.0f;
+    hipMemcpy(&result, recvbuf, sizeof(float), hipMemcpyDeviceToHost);
+    const float expected =
+      static_cast<float>(kNumRanks) * (kNumRanks + 1) / 2.0f;
+    if (result != expected) {
+      fprintf(stderr,
+              "[asym rank%d] wrong AllReduce result %.1f (expected %.1f)\n",
+              rank, result, expected);
+      rc = kWrongResult;
+    }
+  }
+
+  hipFree(sendbuf);
+  hipFree(recvbuf);
+  hipStreamDestroy(stream);
+  ncclCommDestroy(comm);
+  return rc;
+}
+
+// Spawn one worker: fork, set the asymmetric environment, re-exec the worker.
+pid_t spawnWorker(int rank, const char* visibleDevices, int localDev,
+                  const std::string& uidHex) {
+  pid_t pid = fork();
+  if (pid != 0) return pid; // parent (or fork error, reported by caller)
+
+  // Child: set the per-rank environment BEFORE HIP initializes, then re-exec
+  // a fresh image so the restricted visibility takes effect cleanly.
+  setenv("HIP_VISIBLE_DEVICES", visibleDevices, 1);
+  setenv("CUDA_VISIBLE_DEVICES", visibleDevices, 1);
+  setenv(kEnvRank, std::to_string(rank).c_str(), 1);
+  setenv(kEnvLocalDev, std::to_string(localDev).c_str(), 1);
+  setenv(kEnvUid, uidHex.c_str(), 1);
+  setenv("NCCL_CUMEM_ENABLE", "1", 0);
+
+  std::string filter = "--gtest_filter=AsymmetricVisibilityWorker.Run";
+  char argv0[] = "rccl-UnitTests";
+  char color[] = "--gtest_color=no";
+  char* argv[] = {argv0, filter.data(), color, nullptr};
+  execv("/proc/self/exe", argv);
+  // Only reached if execv failed.
+  fprintf(stderr, "[asym rank%d] execv failed: %s\n", rank, strerror(errno));
+  _exit(127);
+}
+
+} // namespace
+
+// Worker entry point: only active when re-exec'd by the orchestrator (i.e. when
+// the rank env var is present). In a normal full-suite run it skips.
+TEST(AsymmetricVisibilityWorker, Run) {
+  const char* rankEnv = getenv(kEnvRank);
+  if (rankEnv == nullptr)
+    GTEST_SKIP() << "worker entry point, driven by "
+                    "AsymmetricVisibility.CommInitRankAllReduce";
+
+  const int rank = atoi(rankEnv);
+  const char* devEnv = getenv(kEnvLocalDev);
+  const char* uidEnv = getenv(kEnvUid);
+  ASSERT_NE(devEnv, nullptr);
+  ASSERT_NE(uidEnv, nullptr);
+
+  ncclUniqueId id;
+  ASSERT_TRUE(fromHex(uidEnv, id)) << "malformed ncclUniqueId in environment";
+
+  ASSERT_EQ(runWorker(rank, atoi(devEnv), id), kOk)
+    << "asymmetric-visibility worker rank " << rank << " failed";
+}
+
+// Orchestrator: reproduces the ROCM-27034 asymmetric topology with two workers,
+// rank0 seeing devices {0,1} and binding ordinal 1, rank1 seeing device {2} and
+// binding ordinal 0.
+TEST(AsymmetricVisibility, CommInitRankAllReduce) {
+  int numDevices = 0;
+  ASSERT_EQ(hipGetDeviceCount(&numDevices), hipSuccess);
+  if (numDevices < 3)
+    GTEST_SKIP() << "requires at least 3 GPUs for an asymmetric topology";
+
+  ncclUniqueId id;
+  ASSERT_EQ(ncclGetUniqueId(&id), ncclSuccess);
+  const std::string uidHex = toHex(id);
+
+  // rank0: HIP_VISIBLE_DEVICES=0,1 -> bind ordinal 1; rank1: =2 -> bind ordinal 0.
+  const pid_t child0 = spawnWorker(0, "0,1", 1, uidHex);
+  ASSERT_GT(child0, 0) << "fork failed for rank 0";
+  const pid_t child1 = spawnWorker(1, "2", 0, uidHex);
+  ASSERT_GT(child1, 0) << "fork failed for rank 1";
+
+  auto waitOk = [](pid_t pid, int rank) {
+    int status = 0;
+    ASSERT_EQ(waitpid(pid, &status, 0), pid);
+    ASSERT_TRUE(WIFEXITED(status))
+      << "rank " << rank << " terminated abnormally";
+    ASSERT_EQ(WEXITSTATUS(status), 0)
+      << "rank " << rank << " worker returned failure";
+  };
+  waitOk(child0, 0);
+  waitOk(child1, 1);
+}
+
+} // namespace RcclUnitTesting

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -170,6 +170,7 @@ if(BUILD_TESTS)
     AllReduceTests.cpp
     AllToAllTests.cpp
     AllToAllVTests.cpp
+    AsymmetricVisibilityTests.cpp
     BroadcastTests.cpp
     GatherTests.cpp
     GroupCallTests.cpp

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -3124,6 +3124,12 @@
       "enabled": true
     },
     {
+      "name": "Asymmetric Visibility",
+      "description": "Comm init + AllReduce under asymmetric HIP_VISIBLE_DEVICES",
+      "config": "asymmetric_visibility",
+      "enabled": true
+    },
+    {
       "name": "Unit Tests - Standard Collectives",
       "description": "Basic collective operation tests",
       "config": "unit_tests_standard",
@@ -3643,12 +3649,6 @@
       "name": "Host API Tests - Default",
       "description": "Host API tests with default memory support",
       "config": "host_api_tests_default",
-      "enabled": true
-    },
-    {
-      "name": "Asymmetric Visibility",
-      "description": "Comm init + AllReduce under asymmetric HIP_VISIBLE_DEVICES",
-      "config": "asymmetric_visibility",
       "enabled": true
     }
   ]

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -745,6 +745,23 @@
         {"name": "CollTraceUtils.getSizeMb", "description": "CollTrace utils get size MB", "test_filter": "CollTraceUtilsTest.getSizeMbTest"}
       ]
     },
+    "asymmetric_visibility": {
+      "is_gtest": true,
+      "binary": "rccl-UnitTests",
+      "num_ranks": 1,
+      "num_nodes": 1,
+      "num_gpus": 3,
+      "timeout": 120,
+      "env_variables": {
+        "NCCL_CUMEM_ENABLE": "1"
+      },
+      "rerun_env_variables": {
+        "NCCL_DEBUG": "INFO"
+      },
+      "tests": [
+        {"name": "AsymmetricVisibility.CommInitRankAllReduce", "description": "ROCM-27034: RCCL comm init + AllReduce under asymmetric HIP_VISIBLE_DEVICES", "test_filter": "AsymmetricVisibility.CommInitRankAllReduce"}
+      ]
+    },
     "debug_tests": {
       "is_gtest": true,
       "binary": "rccl-UnitTests",
@@ -3626,6 +3643,12 @@
       "name": "Host API Tests - Default",
       "description": "Host API tests with default memory support",
       "config": "host_api_tests_default",
+      "enabled": true
+    },
+    {
+      "name": "Asymmetric Visibility",
+      "description": "Comm init + AllReduce under asymmetric HIP_VISIBLE_DEVICES",
+      "config": "asymmetric_visibility",
       "enabled": true
     }
   ]


### PR DESCRIPTION
## Motivation

Fixes ROCM-27034: `ncclCommInitRank` leaves a sticky HIP error behind under an asymmetric `HIP_VISIBLE_DEVICES` topology (each rank sees a different device subset). Init still returns `ncclSuccess`, but the pending error surfaces later as an "invalid device ordinal" failure on the first framework allocation (e.g. PyTorch), well away from its real cause.

The PR contains three changes:
- Bounds-check peer ordinals in the clique peer-access scan (`init.cc`).
- Clear the pending HIP error left by the optional MNNVL fabric-support probe (`mnnvl.cc`).
- Add a self-contained regression test reproducing the asymmetric topology.

## Technical Details

- `src/init.cc`: query `cudaGetDeviceCount` once and skip any peer pair whose ordinal falls outside `[0, localDevCount)`, treating it as no peer access instead of calling `hipDeviceCanAccessPeer` with an invalid device. This removes the `hipErrorInvalidDevice` at its source.
- `src/mnnvl.cc`: the `cuDeviceGetAttribute(CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED)` probe is best-effort and its result is intentionally ignored, but on ROCm builds where the attribute is unsupported it records a pending HIP error. Clear it with `hipGetLastError` so a successful init leaves clean error state.
- `test/AsymmetricVisibilityTests.cpp`: an orchestrator forks two workers via `fork()+execv()`, each with a distinct `HIP_VISIBLE_DEVICES` set before HIP initializes (rank0 sees `{0,1}` and binds ordinal 1, rank1 sees `{2}` and binds ordinal 0). Each worker joins a 2-rank communicator, asserts `hipGetLastError() == hipSuccess` after init (the ROCM-27034 invariant), and runs a small `AllReduce` to confirm the communicator is functional. The test requires at least 3 GPUs and runs with `NCCL_CUMEM_ENABLE=1`, since the IPC path relies on the cuMem/VMM handle path under asymmetric visibility. Registered in `test/CMakeLists.txt` and enabled in the `mi300x_mellanox_ib` test suite.

## JIRA ID

JIRA ID : ROCM-27034

## Test Plan

CI tests complition

## Test Result

In progress

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
