### PR TITLE
feat(clr) Add GPU ConcurrencySanitizer reporting for tsan support

### DIFF
--- a/projects/clr/rocclr/cmake/ROCclr.cmake
+++ b/projects/clr/rocclr/cmake/ROCclr.cmake
@@ -48,6 +48,7 @@ target_sources(rocclr PRIVATE
   ${ROCCLR_SRC_DIR}/device/devhcmessages.cpp
   ${ROCCLR_SRC_DIR}/device/devhcprintf.cpp
   ${ROCCLR_SRC_DIR}/device/devhostcall.cpp
+  ${ROCCLR_SRC_DIR}/device/devrpc.cpp
   ${ROCCLR_SRC_DIR}/device/device.cpp
   ${ROCCLR_SRC_DIR}/device/devkernel.cpp
   ${ROCCLR_SRC_DIR}/device/devprogram.cpp
@@ -118,6 +119,13 @@ target_include_directories(rocclr PUBLIC
   ${ROCCLR_SRC_DIR}/elf
   ${ROCCLR_SRC_DIR}/include
   ${AMD_OPENCL_INCLUDE_DIRS})
+
+# Add the compiler's LLVM libc shared include directory for the RPC interface.
+# The headers live at <compiler_bin>/../include/shared/rpc*.h.
+get_filename_component(_COMPILER_BIN_DIR "${CMAKE_CXX_COMPILER}" DIRECTORY)
+get_filename_component(_RPC_INCLUDE_DIR "${_COMPILER_BIN_DIR}/../include" REALPATH)
+set_source_files_properties(${ROCCLR_SRC_DIR}/device/devrpc.cpp PROPERTIES
+  COMPILE_OPTIONS "-I${_RPC_INCLUDE_DIR}")
 
 target_link_libraries(rocclr PUBLIC Threads::Threads)
 # IPC on Windows is not supported

--- a/projects/clr/rocclr/cmake/ROCclr.cmake
+++ b/projects/clr/rocclr/cmake/ROCclr.cmake
@@ -45,6 +45,7 @@ target_sources(rocclr PRIVATE
   ${ROCCLR_SRC_DIR}/device/blit.cpp
   ${ROCCLR_SRC_DIR}/device/blitcl.cpp
   ${ROCCLR_SRC_DIR}/device/comgrctx.cpp
+  ${ROCCLR_SRC_DIR}/device/devcsan.cpp
   ${ROCCLR_SRC_DIR}/device/devhcmessages.cpp
   ${ROCCLR_SRC_DIR}/device/devhcprintf.cpp
   ${ROCCLR_SRC_DIR}/device/devhostcall.cpp

--- a/projects/clr/rocclr/device/devcsan.cpp
+++ b/projects/clr/rocclr/device/devcsan.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "device/devcsan.hpp"
+
+#include "device/device.hpp"
+
+#include "amd_comgr/amd_comgr.h"
+
+#include <cinttypes>
+#include <cstdint>
+#include <cstdio>
+#include <mutex>
+#include <set>
+#include <string>
+#include <tuple>
+#include <utility>
+
+namespace amd {
+
+namespace {
+
+// Deduplicates races on the conflicting PC pair and kind.
+struct SanitizerTables {
+  bool isNewRace(uint32_t device, uint64_t pc, uint64_t peer_pc, unsigned kind) {
+    if (pc > peer_pc) std::swap(pc, peer_pc);
+    std::lock_guard<std::mutex> guard(mtx_);
+    return races_.insert({device, pc ^ (static_cast<uint64_t>(kind) << 56), peer_pc}).second;
+  }
+
+ private:
+  std::mutex mtx_;
+  std::set<std::tuple<uint32_t, uint64_t, uint64_t>> races_;
+};
+
+SanitizerTables& sanitizerTables() {
+  static SanitizerTables tables;
+  return tables;
+}
+
+// The symbolizer used to extract information about the program counter from the
+// loader code objects.
+struct Symbolizer {
+  amd_comgr_data_t data{};
+  amd_comgr_symbolizer_info_t info{};
+  bool haveData = false, ready = false;
+  int64_t bias = 0;
+
+  static void sink(const char* text, void* user) {
+    if (text) static_cast<std::string*>(user)->append(text);
+  }
+
+  bool init(const amd::Device::SanitizerCodeObject& co) {
+    bias = co.bias;
+    if (amd_comgr_create_data(AMD_COMGR_DATA_KIND_EXECUTABLE, &data) != AMD_COMGR_STATUS_SUCCESS)
+      return false;
+    haveData = true;
+    amd_comgr_status_t status =
+        co.memory ? amd_comgr_set_data(data, co.size, static_cast<const char*>(co.memory))
+                  : amd_comgr_set_data_from_file_slice(data, co.fd, co.offset, co.size);
+    if (status != AMD_COMGR_STATUS_SUCCESS) return false;
+    if (amd_comgr_create_symbolizer_info(data, &sink, &info) != AMD_COMGR_STATUS_SUCCESS)
+      return false;
+    ready = true;
+    return true;
+  }
+
+  ~Symbolizer() {
+    if (ready) amd_comgr_destroy_symbolizer_info(info);
+    if (haveData) amd_comgr_release_data(data);
+  }
+
+  std::string symbolize(uint64_t imageVa, bool isCode) {
+    std::string out;
+    if (ready) amd_comgr_symbolize(info, imageVa, isCode, &out);
+    while (!out.empty() && (out.back() == '\n' || out.back() == ' ')) out.pop_back();
+    if (out == "??" || out == "<invalid>") out.clear();
+    return out;
+  }
+};
+
+// Print the source frames for a device PC; comgr emits one line per inlined
+// frame.
+void printBacktrace(Symbolizer& sym, uint64_t devicePc) {
+  uint64_t imagePc = devicePc + sym.bias;
+  // The device records return addresses; step back into the call site.
+  std::string text = sym.symbolize(imagePc ? imagePc - 1 : imagePc, /*isCode=*/true);
+  if (text.empty()) {
+    fprintf(stderr, "==CSAN==     #0 ?? (0x%" PRIx64 ")\n", imagePc);
+    return;
+  }
+  unsigned frame = 0;
+  for (size_t pos = 0; pos < text.size();) {
+    size_t nl = text.find('\n', pos);
+    if (nl == std::string::npos) nl = text.size();
+    fprintf(stderr, "==CSAN==     #%u %.*s (0x%" PRIx64 ")\n", frame++, static_cast<int>(nl - pos),
+            text.c_str() + pos, imagePc);
+    pos = nl + 1;
+  }
+}
+
+}  // namespace
+
+void reportGpuCSanRace(const amd::Device& dev, const __tsan_gpu_race& race) {
+  if (!sanitizerTables().isNewRace(dev.index(), race.pc, race.peer_pc, race.kind)) return;
+
+  // Resolve the owning code object from the loader's live view every time; the
+  // reporting kernel (hence its image) is still loaded while this RPC blocks.
+  amd::Device::SanitizerCodeObject co;
+  Symbolizer sym;
+  if (dev.ResolveSanitizerCodeObject(race.pc, &co)) sym.init(co);
+
+  const char* op = (race.access_type & TSAN_GPU_ACCESS_COMPOUND) ? "Read-modify-write"
+                   : (race.access_type & TSAN_GPU_ACCESS_WRITE)  ? "Write"
+                                                                 : "Read";
+  const char* atomic = (race.access_type & TSAN_GPU_ACCESS_ATOMIC) ? "atomic " : "";
+  const char* kind = race.kind == TSAN_GPU_UNKNOWN_ORIGIN ? "data race (unknown origin)"
+                     : race.kind == TSAN_GPU_INTRA_WAVE   ? "data race (intra-wave)"
+                                                          : "data race";
+
+  fprintf(stderr, "==CSAN== WARNING: ConcurrencySanitizer: %s\n", kind);
+  fprintf(stderr,
+          "==CSAN==   %s%s of size %u at 0x%" PRIx64
+          " in block (%u,%u,%u) thread (%u,%u,%u) lane %u\n",
+          atomic, op, race.size, race.addr, race.block[0], race.block[1], race.block[2],
+          race.thread[0], race.thread[1], race.thread[2], race.lane);
+
+  printBacktrace(sym, race.pc);
+  if (race.kind == TSAN_GPU_INTRA_WAVE) {
+    // The conflicting lane executed the same instruction, so it shares the PC.
+    fprintf(stderr,
+            "==CSAN==   Previous access in block (%u,%u,%u) thread (%u,%u,%u) "
+            "lane %u\n",
+            race.block[0], race.block[1], race.block[2], race.peer_thread[0], race.peer_thread[1],
+            race.peer_thread[2], race.peer_lane);
+    printBacktrace(sym, race.pc);
+  } else if (race.peer_pc) {
+    fprintf(stderr, "==CSAN==   Previous access:\n");
+    printBacktrace(sym, race.peer_pc);
+  }
+  if (sym.ready) {
+    // comgr renders data as "name\nstart\nsize"; keep the name if it resolved.
+    std::string var = sym.symbolize(race.addr + sym.bias, /*isCode=*/false);
+    var = var.substr(0, var.find('\n'));
+    if (!var.empty() && var != "??")
+      fprintf(stderr, "==CSAN==   Address 0x%" PRIx64 " is global variable '%s'\n", race.addr,
+              var.c_str());
+  }
+}
+
+}  // namespace amd

--- a/projects/clr/rocclr/device/devcsan.hpp
+++ b/projects/clr/rocclr/device/devcsan.hpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include <sanitizer/gpu_sanitizer.h>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace amd {
+
+class Device;
+
+/// Report one GPU ConcurrencySanitizer race detected on \p dev, dropping it if
+/// it was seen before.
+void reportGpuCSanRace(const amd::Device& dev, const __tsan_gpu_race& race);
+
+}  // namespace amd

--- a/projects/clr/rocclr/device/devhostcall.cpp
+++ b/projects/clr/rocclr/device/devhostcall.cpp
@@ -10,6 +10,7 @@
 
 #include "device/devhcmessages.hpp"
 #include "device/devhostcall.hpp"
+#include "device/devrpc.hpp"
 #include "device/devsignal.hpp"
 
 #include "os/os.hpp"
@@ -210,7 +211,9 @@ void HostcallBuffer::initialize(uint32_t num_packets) {
  */
 class HostcallListener {
   std::set<HostcallBuffer*> buffers_;
-  device::Signal* doorbell_;
+  std::set<RpcBufferInfo*> rpc_buffers_;
+  device::Signal* doorbell_ = nullptr;
+  device::Signal* rpc_doorbell_ = nullptr;
   MessageHandler messages_;
   // Keep track of devices for which signal creation have already been done
   std::set<const amd::Device*> devices_;
@@ -252,7 +255,10 @@ class HostcallListener {
 
   /* \brief Return true if no buffers are registered.
    */
-  bool idle() const { return buffers_.empty(); }
+  void addRpcBuffer(RpcBufferInfo* info);
+  void removeRpcBufferByPtr(void* raw);
+  void flushRpcBufferByPtr(void* raw);
+  bool idle() const { return buffers_.empty() && rpc_buffers_.empty(); }
 
   void terminate();
   bool initSignal(const amd::Device& dev);
@@ -287,17 +293,31 @@ void HostcallListener::consumePackets() {
         kHostThreadActive.state = Init::State::kExit;
         return;
       }
-      uint64_t new_value = doorbell_->Wait(signal_value, device::Signal::Condition::Ne, timeout);
-      if (new_value != signal_value) {
-        signal_value = new_value;
-        // Reduce the timeout for quicker processing
-        timeout = timeout >> 0x1;
-        timeout = std::max(kTimeoutFloor, timeout);
+
+      bool have_hostcall = !buffers_.empty();
+      bool have_rpc = !rpc_buffers_.empty();
+
+      if (have_hostcall && !have_rpc) {
+        uint64_t new_value = doorbell_->Wait(signal_value, device::Signal::Condition::Ne, timeout);
+        if (new_value != signal_value) {
+          signal_value = new_value;
+          timeout = std::max(kTimeoutFloor, timeout >> 1);
+          break;
+        }
+        timeout = std::min(kTimeoutCeil, timeout << 1);
+      } else if (!have_hostcall && have_rpc) {
+        // RPC only — block until the device increments the doorbell.
+        rpc_doorbell_->Wait(0, device::Signal::Condition::Ne, timeout);
+        timeout = std::min(kTimeoutCeil, timeout << 1);
+        break;
+      } else {
+        uint64_t new_value =
+            doorbell_->Wait(signal_value, device::Signal::Condition::Ne, kTimeoutFloor);
+        if (new_value != signal_value) {
+          signal_value = new_value;
+        }
         break;
       }
-      // Increase the timeout since we dont need to check as frequently
-      timeout = timeout << 0x1;
-      timeout = std::min(kTimeoutCeil, timeout);
     }
 
     if (signal_value == SIGNAL_DONE) {
@@ -310,6 +330,9 @@ void HostcallListener::consumePackets() {
       for (auto ii : buffers_) {
         ii->processPackets(messages_);
       }
+      for (auto ii : rpc_buffers_) {
+        processRpcBuffer(ii);
+      }
     }
   }
 
@@ -318,8 +341,9 @@ void HostcallListener::consumePackets() {
 
 void HostcallListener::terminate() {
   if (thread_.state() >= Thread::FINISHED || amd::Os::isThreadAlive(thread_)) {
-    kHostThreadActive.state = Init::State::kExit;
+    kHostThreadActive.state = Init::State::kDestroy;
     doorbell_->Reset(SIGNAL_DONE);
+    if (rpc_doorbell_) rpc_doorbell_->Reset(1);
 
     // FIXME_lmoriche: fix termination handshake
     while (thread_.state() < Thread::FINISHED) {
@@ -332,6 +356,7 @@ void HostcallListener::terminate() {
   delete urilocator;
 #endif
 #endif
+  delete rpc_doorbell_;
   delete doorbell_;
   devices_.clear();
 }
@@ -350,6 +375,40 @@ void HostcallListener::addBuffer(HostcallBuffer* buffer) {
 void HostcallListener::removeBuffer(HostcallBuffer* buffer) {
   assert(buffers_.count(buffer) != 0 && "unknown buffer");
   buffers_.erase(buffer);
+}
+
+void HostcallListener::addRpcBuffer(RpcBufferInfo* info) {
+  info->messages = &messages_;
+  if (!rpc_doorbell_) {
+    rpc_doorbell_ = info->device->createSignal();
+#if defined(WITH_PAL_DEVICE) && !defined(_WIN32)
+    auto ws = device::Signal::WaitState::Active;
+#else
+    auto ws = device::Signal::WaitState::Blocked;
+#endif
+    rpc_doorbell_->Init(*info->device, 0, ws);
+  }
+  initRpcDoorbell(info->buffer, rpc_doorbell_->getHandle());
+  rpc_buffers_.insert(info);
+}
+
+void HostcallListener::removeRpcBufferByPtr(void* raw) {
+  for (auto* b : rpc_buffers_) {
+    if (b->buffer == raw) {
+      rpc_buffers_.erase(b);
+      delete b;
+      return;
+    }
+  }
+}
+
+void HostcallListener::flushRpcBufferByPtr(void* raw) {
+  for (auto* b : rpc_buffers_) {
+    if (b->buffer == raw) {
+      flushRpcBuffer(b);
+      return;
+    }
+  }
 }
 
 bool HostcallListener::initSignal(const amd::Device& dev) {
@@ -436,6 +495,63 @@ void disableHostcalls(void* bfr) {
     assert(bfr && "expected a hostcall buffer");
     auto buffer = reinterpret_cast<HostcallBuffer*>(bfr);
     hostcallListener->removeBuffer(buffer);
+  }
+  if (hostcallListener->idle()) {
+    hostcallListener->terminate();
+    delete hostcallListener;
+    hostcallListener = nullptr;
+    ClPrint(amd::LOG_INFO, amd::LOG_INIT, "Terminated hostcall listener");
+  }
+}
+
+bool enableRpc(const amd::Device& dev, void* bfr, uint32_t num_ports) {
+  auto* info = new RpcBufferInfo{bfr, dev.info().wavefrontWidth_, num_ports, &dev};
+
+  amd::ScopedLock lock(listenerLock);
+  if (!hostcallListener) {
+    hostcallListener = new HostcallListener();
+    if (!hostcallListener->initSignal(dev)) {
+      ClPrint(amd::LOG_ERROR, (amd::LOG_INIT | amd::LOG_QUEUE | amd::LOG_RESOURCE),
+              "Failed to launch hostcall listener for RPC");
+      delete hostcallListener;
+      hostcallListener = nullptr;
+      delete info;
+      return false;
+    }
+    ClPrint(amd::LOG_INFO, (amd::LOG_INIT | amd::LOG_QUEUE | amd::LOG_RESOURCE),
+            "Launched hostcall listener at %p (for RPC)", hostcallListener);
+  }
+#if defined(WITH_PAL_DEVICE)
+  else if (!hostcallListener->initDevice(dev)) {
+    ClPrint(amd::LOG_ERROR, (amd::LOG_INIT | amd::LOG_QUEUE | amd::LOG_RESOURCE),
+            "failed to initialize device for RPC");
+    delete info;
+    return false;
+  }
+#endif
+  hostcallListener->addRpcBuffer(info);
+  ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Registered RPC buffer %p with listener %p", bfr,
+          hostcallListener);
+  return true;
+}
+
+void flushRpc(void* bfr) {
+  amd::ScopedLock lock(listenerLock);
+  if (!hostcallListener) {
+    return;
+  }
+  assert(bfr && "expected an RPC buffer");
+  hostcallListener->flushRpcBufferByPtr(bfr);
+}
+
+void disableRpc(void* bfr) {
+  {
+    amd::ScopedLock lock(listenerLock);
+    if (!hostcallListener) {
+      return;
+    }
+    assert(bfr && "expected an RPC buffer");
+    hostcallListener->removeRpcBufferByPtr(bfr);
   }
   if (hostcallListener->idle()) {
     hostcallListener->terminate();

--- a/projects/clr/rocclr/device/devhostcall.hpp
+++ b/projects/clr/rocclr/device/devhostcall.hpp
@@ -74,6 +74,10 @@ uint32_t getHostcallBufferAlignment(void);
 bool enableHostcalls(const amd::Device& dev, void* buffer, uint32_t numPackets);
 void disableHostcalls(void* buffer);
 
+bool enableRpc(const amd::Device& dev, void* buffer, uint32_t num_ports);
+void flushRpc(void* buffer);
+void disableRpc(void* buffer);
+
 enum SignalValue { SIGNAL_DONE = 0, SIGNAL_INIT = 1 };
 
 /** \brief Packet payload

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -2416,6 +2416,21 @@ class Device : public RuntimeObject {
   //! Clears hostcall memory tracking list without releasing.
   void ClearHostcallMemories();
 
+  //! Data associated with a loaded code object for sanitizer reporting.
+  struct SanitizerCodeObject {
+    const void* memory = nullptr;  //!< ELF bytes when memory-backed, else null.
+    int fd = -1;                   //!< File descriptor when file-backed.
+    uint64_t offset = 0;           //!< Byte offset of the slice in the file.
+    uint64_t size = 0;             //!< Size of the code object in bytes.
+    int64_t bias = 0;              //!< Converts between PC and VA in the CO.
+  };
+
+  //! Identify and return the loaded code object that contains the program
+  //! counter the sanitizer event is associated with.
+  virtual bool ResolveSanitizerCodeObject(uint64_t devicePc, SanitizerCodeObject* out) const {
+    return false;
+  }
+
   //! Enable the specified extension
   char* getExtensionString();
 

--- a/projects/clr/rocclr/device/devrpc.cpp
+++ b/projects/clr/rocclr/device/devrpc.cpp
@@ -12,6 +12,7 @@
 #include "top.hpp"
 
 #include "device/devhcmessages.hpp"
+#include "device/devcsan.hpp"
 
 #if defined(__clang__)
 #if __has_feature(address_sanitizer)
@@ -121,6 +122,14 @@ static rpc::RPCStatus handleClrOpcodes(rpc::Server::Port& port, const amd::Devic
         if (!messages.handlePayload(SERVICE_PRINTF, Buffer->data)) {
           ClPrint(amd::LOG_ERROR, amd::LOG_ALWAYS, "ROCM_HOSTCALL_PRINTF: invalid message payload");
         }
+      });
+      break;
+    }
+    case TSAN_GPU_REPORT_OPCODE: {
+      static_assert(sizeof(__tsan_gpu_race) <= sizeof(rpc::Buffer),
+                    "Report must fit in a single packet");
+      port.recv([&](rpc::Buffer* Buffer, uint32_t) {
+        reportGpuCSanRace(dev, *reinterpret_cast<__tsan_gpu_race*>(Buffer->data));
       });
       break;
     }

--- a/projects/clr/rocclr/device/devrpc.cpp
+++ b/projects/clr/rocclr/device/devrpc.cpp
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "device/devrpc.hpp"
+
+#if __has_include("shared/rpc.h")
+
+#include "utils/debug.hpp"
+#include "top.hpp"
+
+#include "device/devhcmessages.hpp"
+
+#if defined(__clang__)
+#if __has_feature(address_sanitizer)
+#include "device/devsanitizer.hpp"
+#endif
+#endif
+
+#include <cstring>
+
+#include "shared/rpc.h"
+#include "shared/rpc_opcodes.h"
+#include "shared/rpc_server.h"
+
+namespace amd {
+
+bool rpcAvailable() { return true; }
+
+size_t getRpcBufferSize(uint32_t num_lanes, uint32_t num_ports) {
+  return rpc::Server::allocation_size(num_lanes, num_ports);
+}
+
+static rpc::RPCStatus handleClrOpcodes(rpc::Server::Port& port, const amd::Device& dev,
+                                       MessageHandler& messages) {
+  switch (port.get_opcode()) {
+    case LIBC_MALLOC: {
+      port.recv_and_send([&](rpc::Buffer* Buffer, uint32_t) {
+        amd::Context& ctx = dev.context();
+        uint64_t size = Buffer->data[0];
+        constexpr size_t kLargePageAlign = 2 * Mi;
+        amd::Buffer* buf =
+            new (ctx) amd::Buffer(ctx, CL_MEM_READ_WRITE, size, nullptr, kLargePageAlign);
+        uintptr_t va = 0;
+        if (buf && buf->create()) {
+          va = buf->getDeviceMemory(dev)->virtualAddress();
+          amd::MemObjMap::AddMemObj(reinterpret_cast<void*>(va), buf);
+          const_cast<amd::Device*>(&dev)->TrackHostcallMemory(buf);
+        } else if (buf) {
+          buf->release();
+        }
+        Buffer->data[0] = va;
+      });
+      break;
+    }
+    case LIBC_FREE: {
+      port.recv([&](rpc::Buffer* Buffer, uint32_t) {
+        void* Ptr = reinterpret_cast<void*>(Buffer->data[0]);
+        if (Ptr) {
+          amd::Memory* mem = amd::MemObjMap::FindMemObj(Ptr);
+          if (mem) {
+            const_cast<amd::Device*>(&dev)->RemoveHostcallMemory(mem);
+            amd::MemObjMap::RemoveMemObj(Ptr);
+            mem->release();
+          }
+        }
+      });
+      break;
+    }
+    case ROCM_HOSTCALL_FUNCTION: {
+      port.recv_and_send([&](rpc::Buffer* Buffer, uint32_t) {
+        typedef void (*HostcallFn)(uint64_t* output, const uint64_t* input);
+        auto fptr = reinterpret_cast<HostcallFn>(Buffer->data[0]);
+        uint64_t output[2] = {};
+        fptr(output, &Buffer->data[1]);
+        Buffer->data[0] = output[0];
+        Buffer->data[1] = output[1];
+      });
+      break;
+    }
+    case ROCM_HOSTCALL_DEVMEM: {
+      port.recv_and_send([&](rpc::Buffer* Buffer, uint32_t) {
+        uint64_t addr = Buffer->data[0];
+        uint64_t size = Buffer->data[1];
+        guarantee(addr != 0 || size != 0, "ROCM_HOSTCALL_DEVMEM: both addr and size are zero");
+        if (addr) {
+          amd::Memory* mem = amd::MemObjMap::FindMemObj(reinterpret_cast<void*>(addr));
+          if (mem) {
+            const_cast<amd::Device*>(&dev)->RemoveHostcallMemory(mem);
+            amd::MemObjMap::RemoveMemObj(reinterpret_cast<void*>(addr));
+            mem->release();
+          } else {
+            ClPrint(amd::LOG_ERROR, amd::LOG_ALWAYS, "ROCM_HOSTCALL_DEVMEM: unknown pointer %p",
+                    reinterpret_cast<void*>(addr));
+          }
+          Buffer->data[0] = 0;
+        } else {
+          amd::Context& ctx = dev.context();
+          amd::Buffer* buf = new (ctx)
+              amd::Buffer(ctx, CL_MEM_READ_WRITE, size, nullptr, (size == 2 * Mi) ? 2 * Mi : 0);
+          uint64_t va = 0;
+          if (buf) {
+            if (buf->create()) {
+              device::Memory* dm = buf->getDeviceMemory(dev);
+              va = dm->virtualAddress();
+              amd::MemObjMap::AddMemObj(reinterpret_cast<void*>(va), buf);
+              const_cast<amd::Device*>(&dev)->TrackHostcallMemory(buf);
+            } else {
+              buf->release();
+            }
+          }
+          Buffer->data[0] = va;
+        }
+      });
+      break;
+    }
+    case ROCM_HOSTCALL_PRINTF: {
+      port.recv_and_send([&](rpc::Buffer* Buffer, uint32_t) {
+        if (!messages.handlePayload(SERVICE_PRINTF, Buffer->data)) {
+          ClPrint(amd::LOG_ERROR, amd::LOG_ALWAYS, "ROCM_HOSTCALL_PRINTF: invalid message payload");
+        }
+      });
+      break;
+    }
+#if defined(__clang__)
+#if __has_feature(address_sanitizer)
+    case ROCM_HOSTCALL_SANITIZER: {
+      constexpr uint32_t kMaxLanes = 64;
+      uint64_t addrs[kMaxLanes] = {};
+      uint64_t callstack[1] = {};
+      uint64_t entity_id[kMaxLanes + 4] = {};
+      uint64_t access_info = 0, acc_size = 0;
+      uint32_t n_lanes = 0;
+      entity_id[0] = dev.index();
+
+      port.recv([&](rpc::Buffer* Buffer, uint32_t) {
+        addrs[n_lanes] = Buffer->data[0];
+        if (n_lanes == 0) {
+          callstack[0] = Buffer->data[1];
+          entity_id[1] = Buffer->data[2];
+          entity_id[2] = Buffer->data[3];
+          entity_id[3] = Buffer->data[4];
+        }
+        entity_id[4 + n_lanes] = Buffer->data[5];
+        access_info = Buffer->data[6];
+        acc_size = Buffer->data[7];
+        n_lanes++;
+      });
+
+      bool is_write = (access_info & 1) != 0;
+      bool is_abort = (access_info & 0xFFFFFFFF00000000ULL) == 0;
+      auto uri_fd = amd::Os::FDescInit();
+      __asan_report_nonself_error(callstack, 1, addrs, n_lanes, entity_id, n_lanes + 4, is_write,
+                                  acc_size, is_abort, "amdgpu", 0, uri_fd, 0, 0);
+      port.send([](rpc::Buffer*, uint32_t) {});
+      break;
+    }
+#endif
+#endif
+    default:
+      return rpc::RPC_UNHANDLED_OPCODE;
+  }
+  return rpc::RPC_SUCCESS;
+}
+
+static void servicePort(RpcBufferInfo* info, rpc::Server::Port& port) {
+  rpc::RPCStatus status = handleClrOpcodes(port, *info->device, *info->messages);
+
+  if (status == rpc::RPC_UNHANDLED_OPCODE)
+    status = rpc::handle_libc_opcodes(port, info->num_lanes);
+
+  if (status != rpc::RPC_SUCCESS && status != rpc::RPC_UNHANDLED_OPCODE) {
+    ClPrint(amd::LOG_ERROR, amd::LOG_ALWAYS, "RPC: Unhandled or invalid opcode");
+  }
+}
+
+void processRpcBuffer(RpcBufferInfo* info) {
+  rpc::Server server(info->port_count, info->buffer);
+
+  auto port = server.try_open(info->num_lanes);
+  if (!port) return;
+
+  servicePort(info, *port);
+}
+
+void flushRpcBuffer(RpcBufferInfo* info) {
+  rpc::Server server(info->port_count, info->buffer);
+
+  while (auto port = server.try_open(info->num_lanes)) {
+    servicePort(info, *port);
+  }
+}
+
+size_t getRpcClientSize() { return sizeof(rpc::Client); }
+
+void initRpcClient(void* staging, void* buffer, uint32_t num_ports) {
+  rpc::Client client(num_ports, buffer);
+  std::memcpy(staging, &client, sizeof(rpc::Client));
+}
+
+void initRpcDoorbell(void* buffer, void* signal_handle) {
+  // Must match the prefix of amd_signal_t in ROCR's core/inc/amd_signal.h.
+  // The KFD event fields are not exposed through the public HSA API.
+  struct AMDSignal {
+    int64_t kind;
+    int64_t value;
+    uint64_t event_mailbox_ptr;
+    uint32_t event_id;
+  };
+  auto* sig = reinterpret_cast<AMDSignal*>(signal_handle);
+  auto* doorbell =
+      reinterpret_cast<rpc::Doorbell*>(static_cast<char*>(buffer) + rpc::Server::doorbell_offset());
+  doorbell->value = reinterpret_cast<uint64_t*>(&sig->value);
+  doorbell->mailbox = reinterpret_cast<uint64_t*>(sig->event_mailbox_ptr);
+  doorbell->event_id = sig->event_id;
+}
+
+}  // namespace amd
+
+#else  // !__has_include("shared/rpc.h")
+
+namespace amd {
+
+bool rpcAvailable() { return false; }
+size_t getRpcBufferSize(uint32_t, uint32_t) { return 0; }
+void processRpcBuffer(RpcBufferInfo*) {}
+void flushRpcBuffer(RpcBufferInfo*) {}
+size_t getRpcClientSize() { return 0; }
+void initRpcClient(void*, void*, uint32_t) {}
+void initRpcDoorbell(void*, void*) {}
+
+}  // namespace amd
+
+#endif

--- a/projects/clr/rocclr/device/devrpc.hpp
+++ b/projects/clr/rocclr/device/devrpc.hpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include "top.hpp"
+#include "device/device.hpp"
+#include <cstddef>
+#include <cstdint>
+
+/// ROCm-specific RPC opcodes that replace the legacy hostcall buffer services.
+enum : uint32_t {
+  /// Calls a host-side function pointer with up to seven uint64_t arguments and
+  /// returns up to two uint64_t results.
+  ///   [in]  data[0]    = function pointer  void (*)(uint64_t *out, const uint64_t *in)
+  ///   [in]  data[1..7] = input arguments
+  ///   [out] data[0..1] = output values
+  ROCM_HOSTCALL_FUNCTION = ('r' << 24) | 0,
+
+  /// Device memory allocation and deallocation.  Replaces SERVICE_DEVMEM.
+  ///   [in]  data[0] = address (non-zero to free this VA)
+  ///   [in]  data[1] = size    (when data[0] == 0, allocate this many bytes)
+  ///   [out] data[0] = virtual address of the new allocation, or 0
+  ROCM_HOSTCALL_DEVMEM = ('r' << 24) | 1,
+
+  /// Address-sanitizer violation report.
+  ///   [in]  data[0] = faulting address
+  ///   [in]  data[1] = program counter
+  ///   [in]  data[2] = workgroup index X
+  ///   [in]  data[3] = workgroup index Y
+  ///   [in]  data[4] = workgroup index Z
+  ///   [in]  data[5] = wave ID
+  ///   [in]  data[6] = access info (bit 0 = is_write; upper 32 bits nonzero = non-fatal)
+  ///   [in]  data[7] = access size in bytes
+  ROCM_HOSTCALL_SANITIZER = ('r' << 24) | 2,
+
+  /// Hostcall-style printf/fprintf using the message descriptor protocol.
+  ///   [in]  data[0]    = message descriptor (BEGIN/END flags, length, 56-bit ID)
+  ///   [in]  data[1..7] = payload elements (count given by descriptor length field)
+  ///   [out] data[0]    = updated descriptor (with assigned ID) or printf return value
+  ///   [out] data[1]    = second return value (on END)
+  ROCM_HOSTCALL_PRINTF = ('r' << 24) | 3,
+};
+
+namespace amd {
+
+class MessageHandler;
+
+constexpr uint64_t kMaxRpcPortCount = 16384;
+
+struct RpcBufferInfo {
+  void* buffer;
+  uint32_t num_lanes;
+  uint32_t port_count;
+  const amd::Device* device;
+  MessageHandler* messages = nullptr;
+};
+
+/// Returns true if the RPC headers were found at compile time, i.e. the
+/// compiler was built with LLVM libc support.
+bool rpcAvailable();
+
+size_t getRpcBufferSize(uint32_t num_lanes, uint32_t num_ports);
+
+/// Process a single pending RPC request from the given buffer, if any.
+void processRpcBuffer(RpcBufferInfo* info);
+
+/// Drain all pending RPC requests from the given buffer.
+void flushRpcBuffer(RpcBufferInfo* info);
+
+/// Returns the expected size in bytes of the RPC client symbol.
+size_t getRpcClientSize();
+
+/// Construct an RPC client pointing at \p buffer and write the raw bytes to
+/// \p staging.
+void initRpcClient(void* staging, void* buffer, uint32_t num_ports);
+
+/// Extract the interrupt doorbell fields from \p signal and write them into the
+/// RPC buffer so the device can fire interrupts to wake the server thread.
+void initRpcDoorbell(void* buffer, void* signal_handle);
+
+}  // namespace amd

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -4462,6 +4462,96 @@ bool Device::initRpcForProgram(hsa_executable_t executable) {
 }
 
 // ================================================================================================
+namespace {
+
+// Parse the "offset=" / "size=" fields of a loader code-object URI
+// ("...#offset=N&size=N"), used for file-backed code objects.
+bool parseUriRange(const char* uri, uint64_t* offset, uint64_t* size) {
+  const char* off = strstr(uri, "offset=");
+  const char* sz = strstr(uri, "size=");
+  if (!off || !sz) return false;
+  *offset = strtoull(off + 7, nullptr, 0);
+  *size = strtoull(sz + 5, nullptr, 0);
+  return true;
+}
+
+struct ResolveContext {
+  uint64_t pc;
+  amd::Device::SanitizerCodeObject* out;
+  bool found;
+};
+
+// Fill ResolveContext::out from the loaded code object covering the PC.
+hsa_status_t resolveLoadedCodeObject(hsa_executable_t, hsa_loaded_code_object_t lco, void* data) {
+  auto* ctx = static_cast<ResolveContext*>(data);
+  const auto& ext = Device::loaderExtensionTable();
+  auto get = [&](hsa_ven_amd_loader_loaded_code_object_info_t attr, void* value) {
+    return ext.hsa_ven_amd_loader_loaded_code_object_get_info(lco, attr, value) ==
+           HSA_STATUS_SUCCESS;
+  };
+
+  uint64_t base = 0, size = 0;
+  if (!get(HSA_VEN_AMD_LOADER_LOADED_CODE_OBJECT_INFO_LOAD_BASE, &base) ||
+      !get(HSA_VEN_AMD_LOADER_LOADED_CODE_OBJECT_INFO_LOAD_SIZE, &size))
+    return HSA_STATUS_SUCCESS;
+  if (ctx->pc < base || ctx->pc >= base + size) return HSA_STATUS_SUCCESS;
+
+  int64_t delta = 0;
+  get(HSA_VEN_AMD_LOADER_LOADED_CODE_OBJECT_INFO_LOAD_DELTA, &delta);
+  ctx->out->bias = -delta;  // image_va = device_addr - load_delta.
+
+  uint32_t storage = HSA_VEN_AMD_LOADER_CODE_OBJECT_STORAGE_TYPE_NONE;
+  get(HSA_VEN_AMD_LOADER_LOADED_CODE_OBJECT_INFO_CODE_OBJECT_STORAGE_TYPE, &storage);
+  if (storage == HSA_VEN_AMD_LOADER_CODE_OBJECT_STORAGE_TYPE_MEMORY) {
+    ctx->found = get(HSA_VEN_AMD_LOADER_LOADED_CODE_OBJECT_INFO_CODE_OBJECT_STORAGE_MEMORY_BASE,
+                     &ctx->out->memory) &&
+                 get(HSA_VEN_AMD_LOADER_LOADED_CODE_OBJECT_INFO_CODE_OBJECT_STORAGE_MEMORY_SIZE,
+                     &ctx->out->size);
+  } else if (storage == HSA_VEN_AMD_LOADER_CODE_OBJECT_STORAGE_TYPE_FILE) {
+    int fd = -1;
+    uint32_t uriLen = 0;
+    if (get(HSA_VEN_AMD_LOADER_LOADED_CODE_OBJECT_INFO_CODE_OBJECT_STORAGE_FILE, &fd) &&
+        get(HSA_VEN_AMD_LOADER_LOADED_CODE_OBJECT_INFO_URI_LENGTH, &uriLen)) {
+      std::string uri(uriLen + 1, '\0');
+      if (get(HSA_VEN_AMD_LOADER_LOADED_CODE_OBJECT_INFO_URI, uri.data()) &&
+          parseUriRange(uri.c_str(), &ctx->out->offset, &ctx->out->size)) {
+        ctx->out->fd = fd;
+        ctx->found = true;
+      }
+    }
+  }
+  return HSA_STATUS_INFO_BREAK;
+}
+
+// Search a frozen executable's loaded code objects for the one covering the PC.
+hsa_status_t resolveExecutable(hsa_executable_t exec, void* data) {
+  int state = 0;
+  if (Hsa::executable_get_info(exec, HSA_EXECUTABLE_INFO_STATE, &state) != HSA_STATUS_SUCCESS ||
+      state != HSA_EXECUTABLE_STATE_FROZEN)
+    return HSA_STATUS_SUCCESS;
+
+  Device::loaderExtensionTable().hsa_ven_amd_loader_executable_iterate_loaded_code_objects(
+      exec, resolveLoadedCodeObject, data);
+
+  return static_cast<ResolveContext*>(data)->found ? HSA_STATUS_INFO_BREAK : HSA_STATUS_SUCCESS;
+}
+
+}  // namespace
+
+// ================================================================================================
+bool Device::ResolveSanitizerCodeObject(uint64_t devicePc, SanitizerCodeObject* out) const {
+  const auto& ext = loaderExtensionTable();
+  if (!ext.hsa_ven_amd_loader_iterate_executables ||
+      !ext.hsa_ven_amd_loader_executable_iterate_loaded_code_objects ||
+      !ext.hsa_ven_amd_loader_loaded_code_object_get_info)
+    return false;
+
+  ResolveContext ctx{devicePc, out, false};
+  ext.hsa_ven_amd_loader_iterate_executables(resolveExecutable, &ctx);
+  return ctx.found;
+}
+
+// ================================================================================================
 void Device::DestroyExtSemaphore(void* extSemaphore) {
   if (extSemaphore == nullptr) return;
   auto* holder = static_cast<hsa_amd_external_semaphore_t*>(extSemaphore);

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -18,6 +18,7 @@
 #include "vdi_common.hpp"
 #include "device/comgrctx.hpp"
 #include "device/devhostcall.hpp"
+#include "device/devrpc.hpp"
 #include "device/rocm/rocdevice.hpp"
 #include "device/rocm/rocblit.hpp"
 #include "device/rocm/rocvirtual.hpp"
@@ -193,6 +194,7 @@ void Device::checkAtomicSupport() {
 
 Device::~Device() {
   WaitForHsaAsyncHandlersIdle();
+  destroyRpcBuffer();
 
   // Release cached map targets
   for (uint i = 0; mapCache_ != nullptr && i < mapCache_->size(); ++i) {
@@ -4225,6 +4227,7 @@ cl_int ConvertHSAErrorIntoCLError(hsa_status_t hsa_status) {
 void callbackQueue(hsa_status_t status, hsa_queue_t* queue, void* data) {
   if (status != HSA_STATUS_SUCCESS && status != HSA_STATUS_INFO_BREAK) {
     Device* dev = reinterpret_cast<Device*>(data);
+    dev->flushRpc();
     std::string hostnameStr = GetLocalHostName();
     std::string host_tag = hostnameStr.empty() ? "" : "host: " + hostnameStr + ", ";
     std::string kernelName;
@@ -4366,11 +4369,122 @@ bool Device::importExtSemaphore(void** extSemaphore, const amd::Os::FileDesc& ha
 }
 
 // ================================================================================================
+void* Device::getOrCreateRpcBuffer() {
+  amd::ScopedLock l(active_queue_access_);
+
+  if (void* existing = rpcBuffer_.load(std::memory_order_acquire)) return existing;
+
+  auto wavesPerCu = info().maxThreadsPerCU_ / info().wavefrontWidth_;
+  rpcPortCount_ = static_cast<uint32_t>(
+      std::min(static_cast<uint64_t>(info().maxComputeUnits_ * wavesPerCu), amd::kMaxRpcPortCount));
+
+  auto size = amd::getRpcBufferSize(info().wavefrontWidth_, rpcPortCount_);
+
+  void* buffer = context().svmAlloc(size, 64, CL_MEM_SVM_FINE_GRAIN_BUFFER | CL_MEM_SVM_ATOMICS);
+  if (!buffer) {
+    ClPrint(amd::LOG_ERROR, amd::LOG_QUEUE, "Failed to allocate RPC buffer for device %p", this);
+    return nullptr;
+  }
+  std::memset(buffer, 0, size);
+
+  if (!amd::enableRpc(*this, buffer, rpcPortCount_)) {
+    ClPrint(amd::LOG_ERROR, amd::LOG_QUEUE, "Failed to enable RPC for device %p", this);
+    context().svmFree(buffer);
+    return nullptr;
+  }
+
+  rpcBuffer_.store(buffer, std::memory_order_release);
+  ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Created RPC buffer %p (ports=%u, size=%zu) for device %p",
+          buffer, rpcPortCount_, size, this);
+  return buffer;
+}
+
+// ================================================================================================
+bool Device::initRpcForProgram(hsa_executable_t executable) {
+  if (!amd::rpcAvailable()) return true;
+
+  hsa_agent_t agent = getBackendDevice();
+  hsa_executable_symbol_t rpc_symbol;
+
+  // Exit early if the program does not require an RPC server.
+  hsa_status_t status =
+      Hsa::executable_get_symbol_by_name(executable, "__llvm_rpc_client", &agent, &rpc_symbol);
+  if (status != HSA_STATUS_SUCCESS) {
+    return true;
+  }
+
+  hsa_symbol_kind_t sym_type;
+  status = Hsa::executable_symbol_get_info(rpc_symbol, HSA_EXECUTABLE_SYMBOL_INFO_TYPE, &sym_type);
+  if (status != HSA_STATUS_SUCCESS || sym_type != HSA_SYMBOL_KIND_VARIABLE) {
+    ClPrint(amd::LOG_ERROR, amd::LOG_QUEUE, "RPC: __llvm_rpc_client is not a variable symbol");
+    return false;
+  }
+
+  size_t sym_size = 0;
+  status = Hsa::executable_symbol_get_info(rpc_symbol, HSA_EXECUTABLE_SYMBOL_INFO_VARIABLE_SIZE,
+                                           &sym_size);
+  if (status != HSA_STATUS_SUCCESS) {
+    ClPrint(amd::LOG_ERROR, amd::LOG_QUEUE, "RPC: Failed to get __llvm_rpc_client size");
+    return false;
+  }
+
+  if (sym_size != amd::getRpcClientSize()) {
+    ClPrint(amd::LOG_ERROR, amd::LOG_QUEUE, "RPC: Invalid size of __llvm_rpc_client");
+    return false;
+  }
+
+  void* sym_addr = nullptr;
+  status = Hsa::executable_symbol_get_info(rpc_symbol, HSA_EXECUTABLE_SYMBOL_INFO_VARIABLE_ADDRESS,
+                                           &sym_addr);
+  if (status != HSA_STATUS_SUCCESS || !sym_addr) {
+    ClPrint(amd::LOG_ERROR, amd::LOG_QUEUE, "RPC: Failed to get __llvm_rpc_client address");
+    return false;
+  }
+
+  void* buffer = getOrCreateRpcBuffer();
+  if (!buffer) {
+    ClPrint(amd::LOG_ERROR, amd::LOG_QUEUE, "RPC: Failed to create RPC buffer for device");
+    return false;
+  }
+  auto client_staging = std::make_unique<char[]>(amd::getRpcClientSize());
+  amd::initRpcClient(client_staging.get(), buffer, rpcPortCount_);
+
+  status = Hsa::memory_copy(sym_addr, client_staging.get(), sym_size);
+  if (status != HSA_STATUS_SUCCESS) {
+    ClPrint(amd::LOG_ERROR, amd::LOG_QUEUE, "RPC: Failed to copy RPC client to device symbol");
+    return false;
+  }
+
+  ClPrint(amd::LOG_INFO, amd::LOG_QUEUE,
+          "RPC: Initialized __llvm_rpc_client at device %p (sym_addr=%p, ports=%u)", sym_addr,
+          buffer, rpcPortCount_);
+  return true;
+}
+
+// ================================================================================================
 void Device::DestroyExtSemaphore(void* extSemaphore) {
   if (extSemaphore == nullptr) return;
   auto* holder = static_cast<hsa_amd_external_semaphore_t*>(extSemaphore);
   hsa_amd_external_semaphore_handle_close(*holder);
   delete holder;
+}
+
+// ================================================================================================
+void Device::flushRpc() {
+  if (void* buffer = rpcBuffer_.load(std::memory_order_acquire)) {
+    amd::flushRpc(buffer);
+  }
+}
+
+void Device::destroyRpcBuffer() {
+  if (void* buffer = rpcBuffer_.load(std::memory_order_acquire)) {
+    // Drain any reports the device pushed before we release the buffer.
+    amd::flushRpc(buffer);
+    amd::disableRpc(buffer);
+    context().svmFree(buffer);
+    rpcBuffer_.store(nullptr, std::memory_order_release);
+    ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Destroyed RPC buffer for device %p", this);
+  }
 }
 
 }  // namespace amd::roc

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -590,6 +590,21 @@ class Device : public NullDevice {
   //! Return the pre-computed metadata packet version header bits
   uint32_t MetadataVersionHeader() const { return metadata_version_header_; }
 
+  //! Get or create the RPC buffer for this device. The buffer is lazily
+  //! allocated the first time a loaded program contains `__llvm_rpc_client`.
+  void* getOrCreateRpcBuffer();
+
+  //! Initialize the `__llvm_rpc_client` device symbol for the given
+  //! executable, pointing it at this device's RPC buffer.
+  bool initRpcForProgram(hsa_executable_t executable);
+
+  //! Drain all pending RPC requests on this device's buffer. Called before
+  //! teardown unloads images so sanitizer reports remain resolvable.
+  void flushRpc();
+
+  //! Free the device's RPC buffer during teardown.
+  void destroyRpcBuffer();
+
   //! Return multi GPU grid launch sync buffer
   address MGSync() const { return mg_sync_; }
 
@@ -763,6 +778,9 @@ class Device : public NullDevice {
                                 hsa_queue_t* preferred = nullptr,
                                 const std::unordered_set<uint64_t>* excluded_ids = nullptr,
                                 void** metadata_ring_buffer = nullptr);
+
+  std::atomic<void*> rpcBuffer_{nullptr};  //!< RPC shared memory buffer for this device
+  uint32_t rpcPortCount_ = 0;              //!< Number of RPC ports allocated
 
   //! returns value for corresponding LinkAttrbutes in a vector given Memory pool.
   virtual bool findLinkInfo(const hsa_amd_memory_pool_t& pool,

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -598,6 +598,10 @@ class Device : public NullDevice {
   //! executable, pointing it at this device's RPC buffer.
   bool initRpcForProgram(hsa_executable_t executable);
 
+  //! Resolve the loaded code object covering \p devicePc through the ROCr
+  //! loader extension, for on-demand GPU sanitizer symbolization.
+  bool ResolveSanitizerCodeObject(uint64_t devicePc, SanitizerCodeObject* out) const override;
+
   //! Drain all pending RPC requests on this device's buffer. Called before
   //! teardown unloads images so sanitizer reports remain resolvable.
   void flushRpc();

--- a/projects/clr/rocclr/device/rocm/rocprogram.cpp
+++ b/projects/clr/rocclr/device/rocm/rocprogram.cpp
@@ -30,6 +30,9 @@ static inline const char* hsa_strerror(hsa_status_t status) {
 Program::~Program() {
   // Destroy the executable.
   if (hsaExecutable_.handle != 0) {
+    // Drain pending RPC reports before unloading this executable's images so
+    // any in-flight sanitizer reports referencing its code are resolvable.
+    const_cast<roc::Device&>(rocDevice()).flushRpc();
     Hsa::executable_destroy(hsaExecutable_);
   }
   if (hsaCodeObjectReader_.handle != 0) {
@@ -277,6 +280,12 @@ bool Program::setKernels(void* binary, size_t binSize, amd::Os::FileDesc fdesc,
     buildLog_ += "Error: Freezing the executable failed: ";
     buildLog_ += hsa_strerror(status);
     buildLog_ += "\n";
+    return false;
+  }
+
+  // Initialize the RPC client if this executable contains __llvm_rpc_client.
+  if (!const_cast<roc::Device&>(rocDevice()).initRpcForProgram(hsaExecutable_)) {
+    buildLog_ += "Error: Failed to initialize RPC client for program\n";
     return false;
   }
 

--- a/projects/hip-tests/catch/unit/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/CMakeLists.txt
@@ -52,6 +52,7 @@ if(HIP_PLATFORM STREQUAL "amd")
   add_subdirectory(gl_interop) # Disabled on NVIDIA due to defect - EXSWHTEC-246
   add_subdirectory(TDM)
   add_subdirectory(cluster)
+  add_subdirectory(rpc)
 endif()
 add_subdirectory(synchronization)
 add_subdirectory(launchBounds)

--- a/projects/hip-tests/catch/unit/rpc/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/rpc/CMakeLists.txt
@@ -1,0 +1,52 @@
+# Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+#
+# SPDX-License-Identifier: MIT
+
+# The RPC headers come from the installed 'clang' compiler.
+set(_rpc_candidates "")
+
+# Explicit override wins.
+if(RPC_SHARED_INCLUDE_DIR)
+  list(APPEND _rpc_candidates "${RPC_SHARED_INCLUDE_DIR}")
+endif()
+
+# Preferred: <prefix>/include derived from the compiler's resource dir.
+execute_process(
+  COMMAND "${CMAKE_CXX_COMPILER}" -print-resource-dir
+  OUTPUT_VARIABLE _rpc_resource_dir
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  ERROR_QUIET)
+if(_rpc_resource_dir)
+  get_filename_component(_rpc_prefix "${_rpc_resource_dir}/../../.." REALPATH)
+  list(APPEND _rpc_candidates "${_rpc_prefix}/include")
+endif()
+
+# Fallback: <compiler_bin>/../include.
+get_filename_component(_rpc_bin_dir "${CMAKE_CXX_COMPILER}" DIRECTORY)
+get_filename_component(_rpc_bin_inc "${_rpc_bin_dir}/../include" REALPATH)
+list(APPEND _rpc_candidates "${_rpc_bin_inc}")
+
+set(_rpc_include "")
+foreach(_cand IN LISTS _rpc_candidates)
+  if(_cand AND EXISTS "${_cand}/shared/rpc.h")
+    set(_rpc_include "${_cand}")
+    break()
+  endif()
+endforeach()
+
+if(NOT _rpc_include)
+  message(STATUS "RPC: <shared/rpc.h> not found for this compiler; skipping RPC tests")
+  return()
+endif()
+message(STATUS "RPC: using shared headers from ${_rpc_include}")
+
+set(TEST_SRC
+    rpc_ping.cc)
+
+set_source_files_properties(rpc_ping.cc PROPERTIES
+    COMPILE_OPTIONS "-I${_rpc_include}")
+
+hip_add_exe_to_target(NAME RpcTest
+                      TEST_SRC ${TEST_SRC}
+                      TEST_TARGET_NAME build_tests
+                      PROPERTY CXX_STANDARD 17)

--- a/projects/hip-tests/catch/unit/rpc/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/rpc/CMakeLists.txt
@@ -41,9 +41,10 @@ endif()
 message(STATUS "RPC: using shared headers from ${_rpc_include}")
 
 set(TEST_SRC
-    rpc_ping.cc)
+    rpc_ping.cc
+    csan_report_test.cc)
 
-set_source_files_properties(rpc_ping.cc PROPERTIES
+set_source_files_properties(${TEST_SRC} PROPERTIES
     COMPILE_OPTIONS "-I${_rpc_include}")
 
 hip_add_exe_to_target(NAME RpcTest

--- a/projects/hip-tests/catch/unit/rpc/csan_report_test.cc
+++ b/projects/hip-tests/catch/unit/rpc/csan_report_test.cc
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <hip_test_common.hh>
+
+// Both the RPC transport and the GPU sanitizer ABI ship with the LLVM libc
+// shared headers. Skip the test when the compiler predates them.
+#if __has_include(<shared/rpc.h>) && __has_include(<sanitizer/gpu_sanitizer.h>)
+
+#include <shared/rpc.h>
+#include <shared/rpc_opcodes.h>
+#include <sanitizer/gpu_sanitizer.h>
+
+#include <unistd.h>
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <thread>
+
+namespace rpc {
+[[gnu::visibility("protected")]] __device__ Client client asm("__llvm_rpc_client");
+}  // namespace rpc
+
+// Fabricate a race report on the device and ship it to the host exactly like
+// the GPU ConcurrencySanitizer runtime would. The host decodes the packet and
+// prints a "==CSAN==" report through amd::reportGpuCSanRace.
+__global__ void rpcCSanReportKernel() {
+  __tsan_gpu_race race = {};
+  race.pc = 0x1000;
+  race.peer_pc = 0x2000;
+  race.addr = 0xdeadbeefULL;
+  race.size = 4;
+  race.access_type = TSAN_GPU_ACCESS_WRITE;
+  race.kind = TSAN_GPU_DATA_RACE;
+  race.block[0] = 1;
+  race.thread[0] = 2;
+  race.lane = 3;
+
+  static_assert(sizeof(race) <= sizeof(rpc::Buffer), "Report must fit in one packet");
+  rpc::client.open<TSAN_GPU_REPORT_OPCODE>().send(
+      [&](rpc::Buffer* buf, uint32_t) { __builtin_memcpy(buf->data, &race, sizeof(race)); });
+}
+
+namespace {
+std::string slurp(const char* path) {
+  std::string out;
+  if (std::FILE* f = std::fopen(path, "rb")) {
+    char chunk[512];
+    size_t n;
+    while ((n = std::fread(chunk, 1, sizeof(chunk), f)) > 0) out.append(chunk, n);
+    std::fclose(f);
+  }
+  return out;
+}
+}  // namespace
+
+TEST_CASE("Unit_Rpc_CSan_Report") {
+  char path[] = "/tmp/csan_report_XXXXXX";
+  int fd = mkstemp(path);
+  REQUIRE(fd != -1);
+
+  // Redirect stderr so we can scrape the host-side report.
+  fflush(stderr);
+  int saved = dup(fileno(stderr));
+  REQUIRE(saved != -1);
+  REQUIRE(dup2(fd, fileno(stderr)) != -1);
+
+  rpcCSanReportKernel<<<1, 1>>>();
+  HIP_CHECK(hipDeviceSynchronize());
+
+  // The report is delivered asynchronously by the RPC listener thread, so poll
+  // the captured output until it lands (or we give up).
+  std::string out;
+  for (int i = 0; i < 500; ++i) {
+    fflush(stderr);
+    out = slurp(path);
+    if (out.find("==CSAN==") != std::string::npos) break;
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+
+  fflush(stderr);
+  dup2(saved, fileno(stderr));
+  close(saved);
+  close(fd);
+  std::remove(path);
+
+  INFO("captured report:\n" << out);
+  REQUIRE(out.find("==CSAN==") != std::string::npos);
+  REQUIRE(out.find("ConcurrencySanitizer: data race") != std::string::npos);
+  REQUIRE(out.find("Write of size 4") != std::string::npos);
+}
+
+#endif  // __has_include(<shared/rpc.h>) && __has_include(<sanitizer/gpu_sanitizer.h>)

--- a/projects/hip-tests/catch/unit/rpc/rpc_ping.cc
+++ b/projects/hip-tests/catch/unit/rpc/rpc_ping.cc
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <hip_test_common.hh>
+
+// The RPC interface is only available when the compiler ships the LLVM libc
+// shared headers.
+#if __has_include(<shared/rpc.h>)
+
+#include <shared/rpc.h>
+#include <shared/rpc_opcodes.h>
+
+namespace rpc {
+[[gnu::visibility("protected")]] __device__ Client client asm("__llvm_rpc_client");
+}  // namespace rpc
+
+__global__ void rpcIncrementKernel(int* results, uint32_t iters) {
+  uint32_t tid = blockIdx.x * blockDim.x + threadIdx.x;
+  uint64_t cnt = 0;
+  for (uint32_t i = 0; i < iters; ++i) {
+    rpc::Client::Port port = rpc::client.open<LIBC_TEST_INCREMENT>();
+    port.send_and_recv([=](rpc::Buffer* buf, uint32_t) { buf->data[0] = cnt; },
+                       [&](rpc::Buffer* buf, uint32_t) { cnt = buf->data[0]; });
+  }
+  results[tid] = (cnt == iters) ? 1 : 0;
+}
+
+__global__ void rpcNoopKernel() {
+  if ((blockIdx.x * blockDim.x + threadIdx.x) % 2)
+    rpc::client.open<LIBC_NOOP>().send([](rpc::Buffer* buf, uint32_t) { buf->data[0] = 1; });
+  else
+    rpc::client.open<LIBC_NOOP>().send([](rpc::Buffer* buf, uint32_t) { buf->data[0] = 2; });
+}
+
+TEST_CASE("Unit_Rpc_Increment_MultiThread") {
+  constexpr uint32_t kBlocks = 2;
+  constexpr uint32_t kThreads = 64;
+  constexpr uint32_t kTotal = kBlocks * kThreads;
+  constexpr uint32_t kIters = 64;
+
+  int* results = nullptr;
+  HIP_CHECK(hipMallocManaged(&results, kTotal * sizeof(int)));
+  for (uint32_t i = 0; i < kTotal; ++i) results[i] = -1;
+
+  rpcIncrementKernel<<<kBlocks, kThreads>>>(results, kIters);
+  HIP_CHECK(hipDeviceSynchronize());
+
+  for (uint32_t i = 0; i < kTotal; ++i) {
+    INFO("thread " << i);
+    REQUIRE(results[i] == 1);
+  }
+  HIP_CHECK(hipFree(results));
+}
+
+TEST_CASE("Unit_Rpc_Noop_Divergent") {
+  rpcNoopKernel<<<2, 64>>>();
+  HIP_CHECK(hipDeviceSynchronize());
+}
+
+#endif  // __has_include(<shared/rpc.h>)


### PR DESCRIPTION
## Summary
  This adds support for the concurrency / thread sanitizer runtime. Its
job is simply to recieve an asynchronous report from the device and
print it. Doing this requires decoding the request, finding the offset
in the original image for symbolization, and printing.

The one iffy bit of this is duplicating the ABI from compiler-rt, but
that is the status quo for the asan support as well.

The existing support seems to rely on the address sanitizer runtime
being tranistively linked from the user code, but this concurrency
sanitizer is 100% GPU so we cannot rely on that. It seemed much easier
to just handle this in-tree rather than make a custom interferface in
compiler-rt. Means less cross-dependencies and divergence from LLVM.

## Motivation

Race detection support in HIP.

## Technical Details
  - Adds `device/devcsan.{cpp,hpp}` implementing `amd::reportGpuCSanRace`, which
    decodes a `__tsan_gpu_race` packet, deduplicates on the conflicting PC pair
    and race kind, and emits a `==CSAN==` report on `stderr`.
  - The reporting ABI (`__tsan_gpu_race`, `TSAN_GPU_*` flags/kinds, and
    `TSAN_GPU_REPORT_OPCODE`) is taken from the compiler's shared
    `<sanitizer/gpu_sanitizer.h>`, mirroring how the ASan path duplicates the
    compiler-rt ABI.
  - `devrpc.cpp` handles `TSAN_GPU_REPORT_OPCODE` on the existing RPC server,
    forwarding the packet to `reportGpuCSanRace`.
  - `device.hpp` gains a `SanitizerCodeObject` descriptor and a virtual
    `ResolveSanitizerCodeObject`; `rocm/rocdevice.cpp` implements it through the
    ROCr loader extension so PCs can be symbolized on demand while the reporting
    kernel's image is still resident.
  ## Test Plan
  Adds `Unit_Rpc_CSan_Report` under `projects/hip-tests/catch/unit/rpc/`.
  The upstream support is still in flux so we just test the entrypoint.
  ## Test Result
  - `Unit_Rpc_CSan_Report` passes: the fabricated write race round-trips through
    RPC and the host prints the `==CSAN== WARNING: ConcurrencySanitizer: data
    race` / `Write of size 4` diagnostic.
  - No regression to existing hostcall or RPC behavior.
  ## Submission Checklist
  - [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.