### PR TITLE
[rocprofiler-compute] Fix Memory Chart headings

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -44,6 +44,8 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 * Fixed multi-user roofline benchmarking on shared systems: the per-GPU lock file under `/tmp/rocprof-compute-benchmark/` is now created world-readable/writable (0666) so any user can acquire it, regardless of which user created it first or the active umask. Stale unreadable lock files left by older versions in a sticky `/tmp` cannot be repaired automatically and must be removed manually by their owner or an administrator.
 
+* Fixed CDNA memory chart CLI output to show the numbered `3. Memory Chart` header without repeating the default per-kernel normalization label.
+
 ### Upcoming changes
 
 ### Known issues

--- a/projects/rocprofiler-compute/src/utils/mem_chart_gfx11.py
+++ b/projects/rocprofiler-compute/src/utils/mem_chart_gfx11.py
@@ -12,7 +12,6 @@ USAGE:
 API:
     normalize_mem_chart_metrics(metric_dict) -> flat ordered dict for UIs
     plot_mem_chart(..., *, chart_title=...) -> str
-    format_mem_chart_heading(normal_unit, *, panel_id=300, section_label=...) -> str
 
 Metric dict keys must match the Memory Chart panel YAML for RDNA3.5:
 
@@ -242,21 +241,6 @@ def _print_mem_chart_scope_bar(console: Console) -> None:
         + "-" * 4
         + "|"
     )
-
-
-def format_mem_chart_heading(
-    normal_unit: str,
-    *,
-    panel_id: int = 300,
-    section_label: str = "Memory Chart",
-) -> str:
-    """Build CLI diagram title: ``{panel_id//100}. {label} (Normalization: …)``.
-
-    Matches other panels (e.g. ``3. System Speed-of-Light``) where the leading
-    number is ``Panel Config id // 100`` (panel 300 → ``3.``).
-    """
-    section = max(0, int(panel_id)) // 100
-    return f"{section}. {section_label} (Normalization: {normal_unit})"
 
 
 def normalize_mem_chart_metrics(metric_dict: dict[str, Any]) -> dict[str, Any]:
@@ -740,7 +724,7 @@ def plot_mem_chart(
     normal_unit: str,
     metric_dict: dict[str, Any],
     *,
-    chart_title: Optional[str] = None,
+    chart_title: str,
 ) -> str:
     """Plot the memory chart and return as string.
 
@@ -748,22 +732,16 @@ def plot_mem_chart(
     ``MEM_CHART_PANEL_METRIC_KEYS``. Values for bandwidth metrics are in **Bytes/s**.
     Input is normalized to a flat ordered dict before rendering.
 
-    ``chart_title``: full heading line; if omitted, uses ``format_mem_chart_heading``
-    with ``panel_id=300`` (section ``3.``).
+    ``chart_title``: full heading line printed above the diagram.
     """
     flat = normalize_mem_chart_metrics(metric_dict)
-    resolved_heading = (
-        format_mem_chart_heading(normal_unit, panel_id=300)
-        if chart_title is None
-        else chart_title
-    )
     buf = StringIO()
     console = Console(file=buf, force_terminal=True, width=200, height=80)
     create_mem_chart_diagram(
         flat,
         console,
         show_debug=False,
-        chart_title=resolved_heading,
+        chart_title=chart_title,
     )
     return buf.getvalue()
 
@@ -789,7 +767,7 @@ def main() -> None:
     else:
         metric_dict = normalize_mem_chart_metrics(DEFAULT_SAMPLE_METRICS.copy())
 
-    heading = format_mem_chart_heading(args.norm, panel_id=300)
+    heading = f"3. Memory Chart (Normalization: {args.norm})"
 
     if args.txt:
         buf = StringIO()

--- a/projects/rocprofiler-compute/src/utils/mem_chart_gfx11.py
+++ b/projects/rocprofiler-compute/src/utils/mem_chart_gfx11.py
@@ -11,7 +11,7 @@ USAGE:
 
 API:
     normalize_mem_chart_metrics(metric_dict) -> flat ordered dict for UIs
-    plot_mem_chart(..., *, chart_title=...) -> str
+    plot_mem_chart(metric_dict, *, chart_title=...) -> str
 
 Metric dict keys must match the Memory Chart panel YAML for RDNA3.5:
 
@@ -721,7 +721,6 @@ def create_mem_chart_diagram(
 
 
 def plot_mem_chart(
-    normal_unit: str,
     metric_dict: dict[str, Any],
     *,
     chart_title: str,

--- a/projects/rocprofiler-compute/src/utils/mem_chart_gfx9.py
+++ b/projects/rocprofiler-compute/src/utils/mem_chart_gfx9.py
@@ -1262,16 +1262,10 @@ def plot_mem_chart(
     normal_unit: str,
     metric_dict: dict[str, Any],
     *,
-    chart_title: Optional[str] = None,
+    chart_title: str,
 ) -> str:
     canvas = Canvas(width=234, height=42, xmax=234, ymax=42)
     mc = MemChart(0, 0, 233, 41)
     mc.draw(canvas, metric_dict)
 
-    if chart_title is None:
-        chart_title = f"3. Memory Chart (Normalization: {normal_unit})"
-
-    chart_output = canvas.plot()
-    if not chart_title:
-        return chart_output
-    return f"{chart_title}\n{chart_output}"
+    return f"{chart_title}\n{canvas.plot()}"

--- a/projects/rocprofiler-compute/src/utils/mem_chart_gfx9.py
+++ b/projects/rocprofiler-compute/src/utils/mem_chart_gfx9.py
@@ -1259,7 +1259,6 @@ class MemChart:
 
 
 def plot_mem_chart(
-    normal_unit: str,
     metric_dict: dict[str, Any],
     *,
     chart_title: str,

--- a/projects/rocprofiler-compute/src/utils/mem_chart_gfx9.py
+++ b/projects/rocprofiler-compute/src/utils/mem_chart_gfx9.py
@@ -971,15 +971,10 @@ class MemChart:
         self.y_min = y_min
         self.y_max = y_max
 
-    def draw(
-        self, canvas: Canvas, normal_unit: str, metric_dict: dict[str, Any]
-    ) -> None:
+    def draw(self, canvas: Canvas, metric_dict: dict[str, Any]) -> None:
         # ----------------------------------------
-        # Overall rect and title
+        # Overall rect
         canvas.rect(self.x_min, self.y_min, self.x_max, self.y_max)
-        canvas.text(
-            self.x_min + 2.0, self.y_max - 2.0, f"(Normalization: {normal_unit})"
-        )
 
         # FIXME: this is temp solution to filter out non-numeric string
         for k, v in metric_dict.items():
@@ -992,7 +987,7 @@ class MemChart:
         block_instr_buff = InstrBuff(label="Instr Buff")
         block_instr_buff.x_min = 2.0
         block_instr_buff.x_max = block_instr_buff.x_min + 27.0
-        block_instr_buff.y_max = self.y_max - 5.0
+        block_instr_buff.y_max = self.y_max - 4.0
         block_instr_buff.y_min = block_instr_buff.y_max - 24.0
 
         block_instr_buff.wave_occupancy = metric_dict.get("Wavefront Occupancy", "n/a")
@@ -1263,9 +1258,20 @@ class MemChart:
         block_hbm.draw(canvas)
 
 
-def plot_mem_chart(normal_unit: str, metric_dict: dict[str, Any]) -> str:
+def plot_mem_chart(
+    normal_unit: str,
+    metric_dict: dict[str, Any],
+    *,
+    chart_title: Optional[str] = None,
+) -> str:
     canvas = Canvas(width=234, height=42, xmax=234, ymax=42)
     mc = MemChart(0, 0, 233, 41)
-    mc.draw(canvas, normal_unit, metric_dict)
+    mc.draw(canvas, metric_dict)
 
-    return canvas.plot()
+    if chart_title is None:
+        chart_title = f"3. Memory Chart (Normalization: {normal_unit})"
+
+    chart_output = canvas.plot()
+    if not chart_title:
+        return chart_output
+    return f"{chart_title}\n{chart_output}"

--- a/projects/rocprofiler-compute/src/utils/tty.py
+++ b/projects/rocprofiler-compute/src/utils/tty.py
@@ -724,10 +724,10 @@ def process_table_data(
     return result_df
 
 
-def _gfx115_mem_chart_heading(panel: Optional[dict[str, Any]], normal_unit: str) -> str:
+def _mem_chart_heading(panel_id: int, normal_unit: str) -> str:
     """Section number from ``panel id // 100`` (panel 300 → ``3. Memory Chart``)."""
-    panel_id = int((panel or {}).get("id", 300))
-    return mem_chart_gfx11.format_mem_chart_heading(normal_unit, panel_id=panel_id)
+    section = max(0, int(panel_id)) // 100
+    return f"{section}. Memory Chart (Normalization: {normal_unit})"
 
 
 def _panel_is_mem_chart_only(panel: dict[str, Any]) -> bool:
@@ -824,12 +824,25 @@ def format_table_output(
                 mem_chart_gfx11.plot_mem_chart(
                     args.normal_unit,
                     mem_data,
-                    chart_title=_gfx115_mem_chart_heading(None, args.normal_unit),
+                    chart_title=_mem_chart_heading(
+                        int(table_config["id"]),
+                        args.normal_unit,
+                    ),
                 )
                 + "\n"
             )
         else:
-            content += mem_chart_gfx9.plot_mem_chart(args.normal_unit, mem_data) + "\n"
+            content += (
+                mem_chart_gfx9.plot_mem_chart(
+                    args.normal_unit,
+                    mem_data,
+                    chart_title=_mem_chart_heading(
+                        int(table_config["id"]),
+                        args.normal_unit,
+                    ),
+                )
+                + "\n"
+            )
     else:
         content += (
             get_table_string(df, transpose=transpose, decimal=args.decimal) + "\n"
@@ -1010,7 +1023,10 @@ def show_all(
 
         # Emit merged gfx115x mem_chart for the panel
         if mem_chart_data and not _tty_view_is_table(args):
-            heading = _gfx115_mem_chart_heading(panel, args.normal_unit)
+            heading = _mem_chart_heading(
+                int((panel or {}).get("id", 300)),
+                args.normal_unit,
+            )
             panel_content += (
                 mem_chart_gfx11.plot_mem_chart(
                     args.normal_unit,

--- a/projects/rocprofiler-compute/src/utils/tty.py
+++ b/projects/rocprofiler-compute/src/utils/tty.py
@@ -822,7 +822,6 @@ def format_table_output(
         if is_gfx115x(gpu_arch):
             content += (
                 mem_chart_gfx11.plot_mem_chart(
-                    args.normal_unit,
                     mem_data,
                     chart_title=_mem_chart_heading(
                         int(table_config["id"]),
@@ -834,7 +833,6 @@ def format_table_output(
         else:
             content += (
                 mem_chart_gfx9.plot_mem_chart(
-                    args.normal_unit,
                     mem_data,
                     chart_title=_mem_chart_heading(
                         int(table_config["id"]),
@@ -1029,7 +1027,6 @@ def show_all(
             )
             panel_content += (
                 mem_chart_gfx11.plot_mem_chart(
-                    args.normal_unit,
                     mem_chart_data,
                     chart_title=heading,
                 )

--- a/projects/rocprofiler-compute/tests/test_mem_chart.py
+++ b/projects/rocprofiler-compute/tests/test_mem_chart.py
@@ -12,8 +12,11 @@ Covers:
 import re
 
 import common
+import pytest
 
 from utils import mem_chart_gfx9, mem_chart_gfx11
+
+DEFAULT_TITLE = "3. Memory Chart (Normalization: per_kernel)"
 
 # =============================================================================
 # Tests for format_bw_human_readable function (gfx11)
@@ -336,7 +339,9 @@ class TestPlotMemChartGfx11:
     def test_returns_string(self):
         """Test that plot_mem_chart returns a string."""
         metrics = mem_chart_gfx11.get_sample_metrics()
-        result = mem_chart_gfx11.plot_mem_chart("per_kernel", metrics)
+        result = mem_chart_gfx11.plot_mem_chart(
+            "per_kernel", metrics, chart_title=DEFAULT_TITLE
+        )
         clean = common.strip_ansi(result)
 
         assert isinstance(result, str)
@@ -345,26 +350,13 @@ class TestPlotMemChartGfx11:
         assert "Normalization: per_kernel" in clean
         assert "GPU" in clean and "System Memory" in clean
 
-    def test_chart_title_override(self):
-        """Explicit chart_title appears in output."""
-        metrics = mem_chart_gfx11.get_sample_metrics()
-        chart_title = "7. Memory Chart (Normalization: per_kernel)"
-        output = common.strip_ansi(
-            mem_chart_gfx11.plot_mem_chart(
-                "per_kernel",
-                metrics,
-                chart_title=chart_title,
-            )
-        )
-
-        assert output.strip().splitlines()[0] == chart_title
-        assert mem_chart_gfx11.format_mem_chart_heading("per_kernel") not in output
-
     def test_contains_complete_rdna35_architecture(self):
         """RDNA3.5 output contains every rendered memory component."""
         metrics = mem_chart_gfx11.get_sample_metrics()
         output = common.strip_ansi(
-            mem_chart_gfx11.plot_mem_chart("per_kernel", metrics)
+            mem_chart_gfx11.plot_mem_chart(
+                "per_kernel", metrics, chart_title=DEFAULT_TITLE
+            )
         )
         expected_components = (
             "Kernel",
@@ -380,14 +372,16 @@ class TestPlotMemChartGfx11:
         for component in expected_components:
             assert component in output, f"Missing RDNA3.5 component: {component}"
 
-    def test_contains_heading_scope_and_directional_connectors(self):
+    def test_gfx115x_contains_heading_scope_and_directional_connectors(self):
         """RDNA3.5 output exposes chart scope and connector directions."""
         metrics = mem_chart_gfx11.get_sample_metrics()
         output = common.strip_ansi(
-            mem_chart_gfx11.plot_mem_chart("per_kernel", metrics)
+            mem_chart_gfx11.plot_mem_chart(
+                "per_kernel", metrics, chart_title=DEFAULT_TITLE
+            )
         )
 
-        assert "3. Memory Chart (Normalization: per_kernel)" in output
+        assert DEFAULT_TITLE in output
         assert "GPU" in output
         assert "System Memory" in output
         assert "Read BW" in output
@@ -400,7 +394,9 @@ class TestPlotMemChartGfx11:
     def test_contains_bandwidth_values(self):
         """Test that output contains formatted bandwidth values."""
         metrics = mem_chart_gfx11.get_sample_metrics()
-        result = mem_chart_gfx11.plot_mem_chart("per_kernel", metrics)
+        result = mem_chart_gfx11.plot_mem_chart(
+            "per_kernel", metrics, chart_title=DEFAULT_TITLE
+        )
 
         # Should contain GB/s units since sample data uses GB/s range
         assert "GB/s" in result
@@ -416,7 +412,9 @@ class TestPlotMemChartGfx11:
 
     def test_empty_metrics(self):
         """Test with empty metrics dictionary."""
-        result = mem_chart_gfx11.plot_mem_chart("per_kernel", {})
+        result = mem_chart_gfx11.plot_mem_chart(
+            "per_kernel", {}, chart_title=DEFAULT_TITLE
+        )
 
         # Should still produce output (with N/A values)
         assert isinstance(result, str)
@@ -429,7 +427,9 @@ class TestPlotMemChartGfx11:
             "GL1 Cache Utilization": 65.0,
             # Missing many other metrics
         }
-        result = mem_chart_gfx11.plot_mem_chart("per_kernel", partial_metrics)
+        result = mem_chart_gfx11.plot_mem_chart(
+            "per_kernel", partial_metrics, chart_title=DEFAULT_TITLE
+        )
 
         assert isinstance(result, str)
         assert len(result) > 0
@@ -440,7 +440,9 @@ class TestPlotMemChartGfx11:
             "DRAM Read Bandwidth": 10e12,  # 10 TB/s
             "DRAM Write Bandwidth": 5e12,  # 5 TB/s
         }
-        result = mem_chart_gfx11.plot_mem_chart("per_kernel", extreme_metrics)
+        result = mem_chart_gfx11.plot_mem_chart(
+            "per_kernel", extreme_metrics, chart_title=DEFAULT_TITLE
+        )
 
         assert "TB/s" in result
 
@@ -450,7 +452,9 @@ class TestPlotMemChartGfx11:
             "DRAM Read Bandwidth": 0,
             "DRAM Write Bandwidth": 0,
         }
-        result = mem_chart_gfx11.plot_mem_chart("per_kernel", zero_metrics)
+        result = mem_chart_gfx11.plot_mem_chart(
+            "per_kernel", zero_metrics, chart_title=DEFAULT_TITLE
+        )
 
         assert "B/s" in result  # Zero formats as "0.0 B/s"
 
@@ -518,7 +522,11 @@ class TestIntegrationGfx11:
         metrics = mem_chart_gfx11.get_sample_metrics()
 
         # Generate chart
-        chart = mem_chart_gfx11.plot_mem_chart("per_dispatch", metrics)
+        chart = mem_chart_gfx11.plot_mem_chart(
+            "per_dispatch",
+            metrics,
+            chart_title="3. Memory Chart (Normalization: per_dispatch)",
+        )
 
         # Verify chart contains expected elements
         assert isinstance(chart, str)
@@ -538,7 +546,9 @@ class TestIntegrationGfx11:
             "DRAM Write Bandwidth": 100e9,  # 100 GB/s
         }
 
-        chart = mem_chart_gfx11.plot_mem_chart("per_kernel", metrics)
+        chart = mem_chart_gfx11.plot_mem_chart(
+            "per_kernel", metrics, chart_title=DEFAULT_TITLE
+        )
 
         # All values should show in GB/s since they're in that range
         assert chart.count("GB/s") >= 6
@@ -552,7 +562,9 @@ class TestIntegrationGfx11:
             "TCP-GL1 Read Bandwidth": 50e3,  # 50 KB/s
         }
 
-        chart = mem_chart_gfx11.plot_mem_chart("per_kernel", metrics)
+        chart = mem_chart_gfx11.plot_mem_chart(
+            "per_kernel", metrics, chart_title=DEFAULT_TITLE
+        )
 
         # Should contain multiple unit types
         assert "TB/s" in chart
@@ -628,13 +640,17 @@ class TestPlotMemChartGfx9:
 
     def test_returns_non_empty_string(self):
         """Full sample metrics produce a non-empty chart string."""
-        result = mem_chart_gfx9.plot_mem_chart("per_kernel", dict(GFX9_SAMPLE_METRICS))
+        result = mem_chart_gfx9.plot_mem_chart(
+            "per_kernel", dict(GFX9_SAMPLE_METRICS), chart_title=DEFAULT_TITLE
+        )
         assert isinstance(result, str)
         assert len(result) > 0
 
     def test_empty_metrics(self):
         """Empty metric dict still produces a non-empty chart (N/A placeholders)."""
-        result = mem_chart_gfx9.plot_mem_chart("per_kernel", {})
+        result = mem_chart_gfx9.plot_mem_chart(
+            "per_kernel", {}, chart_title=DEFAULT_TITLE
+        )
         assert isinstance(result, str)
         assert len(result) > 0
 
@@ -645,7 +661,9 @@ class TestPlotMemChartGfx9:
             "L2 Hit": 75,
             "HBM Rd": 100,
         }
-        result = mem_chart_gfx9.plot_mem_chart("per_kernel", partial)
+        result = mem_chart_gfx9.plot_mem_chart(
+            "per_kernel", partial, chart_title=DEFAULT_TITLE
+        )
         assert isinstance(result, str)
         assert len(result) > 0
 
@@ -655,12 +673,14 @@ class TestPlotMemChartGfx9:
             mem_chart_gfx9.plot_mem_chart(
                 "per_kernel",
                 dict(GFX9_SAMPLE_METRICS),
+                chart_title=DEFAULT_TITLE,
             )
         )
         expected_components = (
             "Instr Buff",
             "Instr Dispatch",
             "Exec",
+            "LDS",
             "Vector L1 Cache",
             "Scalar L1D Cache",
             "Instr L1 Cache",
@@ -673,21 +693,24 @@ class TestPlotMemChartGfx9:
         for component in expected_components:
             assert component in output, f"Missing CDNA component: {component}"
 
-        assert re.search(r"\bExec\b.*\bLDS\b.*\bL2 Cache\b", output), (
-            "Missing CDNA component: LDS"
-        )
         assert re.search(r"(?<!x)GMI(?!/PCIe)", output)
 
-    def test_contains_normalization_and_directional_connectors(self):
-        """CDNA output exposes normalization and connector directions."""
+    def test_gfx9_heading_outside_chart_and_directional_connectors(self):
+        """CDNA output prints the heading once outside the chart, with connectors."""
         output = common.strip_ansi(
             mem_chart_gfx9.plot_mem_chart(
                 "per_kernel",
                 dict(GFX9_SAMPLE_METRICS),
+                chart_title=DEFAULT_TITLE,
             )
         )
+        output_lines = output.splitlines()
 
-        assert "(Normalization: per_kernel)" in output
+        assert output_lines[0] == DEFAULT_TITLE
+        assert "3. Memory Chart" not in "\n".join(output_lines[1:])
+        assert "Instr Buff" in output_lines[4]
+        assert output.count("(Normalization: per_kernel)") == 1
+
         for connector_label in ("Req", "Fetch", "Rd", "Wr", "Atomic"):
             assert connector_label in output
 
@@ -695,31 +718,26 @@ class TestPlotMemChartGfx9:
         assert re.search(r"(?<![<-])-{3,}>", output)
         assert re.search(r"<-{3,}>", output)
 
-    def test_contains_panel_heading_with_single_normalization(self):
-        """CDNA output prints the panel heading outside the chart."""
-        output = common.strip_ansi(
-            mem_chart_gfx9.plot_mem_chart(
-                "per_kernel",
-                dict(GFX9_SAMPLE_METRICS),
-            )
-        )
-        output_lines = output.splitlines()
 
-        assert output_lines[0] == "3. Memory Chart (Normalization: per_kernel)"
-        assert "3. Memory Chart" not in "\n".join(output_lines[1:])
-        assert "Instr Buff" in output_lines[4]
-        assert output.count("(Normalization: per_kernel)") == 1
+@pytest.mark.parametrize(
+    ("renderer", "metrics"),
+    [
+        pytest.param(
+            mem_chart_gfx11.plot_mem_chart,
+            mem_chart_gfx11.get_sample_metrics(),
+            id="gfx115x",
+        ),
+        pytest.param(
+            mem_chart_gfx9.plot_mem_chart,
+            dict(GFX9_SAMPLE_METRICS),
+            id="gfx9",
+        ),
+    ],
+)
+def test_chart_title_appears_as_first_line(renderer, metrics):
+    """Both renderers print the caller's chart_title as the first line."""
+    chart_title = "7. Memory Chart (Normalization: per_kernel)"
+    output = common.strip_ansi(renderer("per_kernel", metrics, chart_title=chart_title))
 
-    def test_chart_title_override(self):
-        """CDNA output uses an explicit chart title when provided."""
-        output = common.strip_ansi(
-            mem_chart_gfx9.plot_mem_chart(
-                "per_kernel",
-                dict(GFX9_SAMPLE_METRICS),
-                chart_title="7. Memory Chart (Normalization: per_kernel)",
-            )
-        )
-        output_lines = output.splitlines()
-
-        assert output_lines[0] == "7. Memory Chart (Normalization: per_kernel)"
-        assert "3. Memory Chart" not in output
+    assert output.strip().splitlines()[0] == chart_title
+    assert "3. Memory Chart" not in output

--- a/projects/rocprofiler-compute/tests/test_mem_chart.py
+++ b/projects/rocprofiler-compute/tests/test_mem_chart.py
@@ -348,14 +348,17 @@ class TestPlotMemChartGfx11:
     def test_chart_title_override(self):
         """Explicit chart_title appears in output."""
         metrics = mem_chart_gfx11.get_sample_metrics()
-        result = mem_chart_gfx11.plot_mem_chart(
-            "per_kernel",
-            metrics,
-            chart_title="3. Memory Chart (Normalization: per_kernel)",
+        chart_title = "7. Memory Chart (Normalization: per_kernel)"
+        output = common.strip_ansi(
+            mem_chart_gfx11.plot_mem_chart(
+                "per_kernel",
+                metrics,
+                chart_title=chart_title,
+            )
         )
-        assert "3. Memory Chart (Normalization: per_kernel)" in common.strip_ansi(
-            result
-        )
+
+        assert output.strip().splitlines()[0] == chart_title
+        assert mem_chart_gfx11.format_mem_chart_heading("per_kernel") not in output
 
     def test_contains_complete_rdna35_architecture(self):
         """RDNA3.5 output contains every rendered memory component."""
@@ -658,7 +661,6 @@ class TestPlotMemChartGfx9:
             "Instr Buff",
             "Instr Dispatch",
             "Exec",
-            "LDS",
             "Vector L1 Cache",
             "Scalar L1D Cache",
             "Instr L1 Cache",
@@ -671,6 +673,9 @@ class TestPlotMemChartGfx9:
         for component in expected_components:
             assert component in output, f"Missing CDNA component: {component}"
 
+        assert re.search(r"\bExec\b.*\bLDS\b.*\bL2 Cache\b", output), (
+            "Missing CDNA component: LDS"
+        )
         assert re.search(r"(?<!x)GMI(?!/PCIe)", output)
 
     def test_contains_normalization_and_directional_connectors(self):

--- a/projects/rocprofiler-compute/tests/test_mem_chart.py
+++ b/projects/rocprofiler-compute/tests/test_mem_chart.py
@@ -339,9 +339,7 @@ class TestPlotMemChartGfx11:
     def test_returns_string(self):
         """Test that plot_mem_chart returns a string."""
         metrics = mem_chart_gfx11.get_sample_metrics()
-        result = mem_chart_gfx11.plot_mem_chart(
-            "per_kernel", metrics, chart_title=DEFAULT_TITLE
-        )
+        result = mem_chart_gfx11.plot_mem_chart(metrics, chart_title=DEFAULT_TITLE)
         clean = common.strip_ansi(result)
 
         assert isinstance(result, str)
@@ -354,9 +352,7 @@ class TestPlotMemChartGfx11:
         """RDNA3.5 output contains every rendered memory component."""
         metrics = mem_chart_gfx11.get_sample_metrics()
         output = common.strip_ansi(
-            mem_chart_gfx11.plot_mem_chart(
-                "per_kernel", metrics, chart_title=DEFAULT_TITLE
-            )
+            mem_chart_gfx11.plot_mem_chart(metrics, chart_title=DEFAULT_TITLE)
         )
         expected_components = (
             "Kernel",
@@ -376,9 +372,7 @@ class TestPlotMemChartGfx11:
         """RDNA3.5 output exposes chart scope and connector directions."""
         metrics = mem_chart_gfx11.get_sample_metrics()
         output = common.strip_ansi(
-            mem_chart_gfx11.plot_mem_chart(
-                "per_kernel", metrics, chart_title=DEFAULT_TITLE
-            )
+            mem_chart_gfx11.plot_mem_chart(metrics, chart_title=DEFAULT_TITLE)
         )
 
         assert DEFAULT_TITLE in output
@@ -394,9 +388,7 @@ class TestPlotMemChartGfx11:
     def test_contains_bandwidth_values(self):
         """Test that output contains formatted bandwidth values."""
         metrics = mem_chart_gfx11.get_sample_metrics()
-        result = mem_chart_gfx11.plot_mem_chart(
-            "per_kernel", metrics, chart_title=DEFAULT_TITLE
-        )
+        result = mem_chart_gfx11.plot_mem_chart(metrics, chart_title=DEFAULT_TITLE)
 
         # Should contain GB/s units since sample data uses GB/s range
         assert "GB/s" in result
@@ -412,9 +404,7 @@ class TestPlotMemChartGfx11:
 
     def test_empty_metrics(self):
         """Test with empty metrics dictionary."""
-        result = mem_chart_gfx11.plot_mem_chart(
-            "per_kernel", {}, chart_title=DEFAULT_TITLE
-        )
+        result = mem_chart_gfx11.plot_mem_chart({}, chart_title=DEFAULT_TITLE)
 
         # Should still produce output (with N/A values)
         assert isinstance(result, str)
@@ -428,7 +418,7 @@ class TestPlotMemChartGfx11:
             # Missing many other metrics
         }
         result = mem_chart_gfx11.plot_mem_chart(
-            "per_kernel", partial_metrics, chart_title=DEFAULT_TITLE
+            partial_metrics, chart_title=DEFAULT_TITLE
         )
 
         assert isinstance(result, str)
@@ -441,7 +431,7 @@ class TestPlotMemChartGfx11:
             "DRAM Write Bandwidth": 5e12,  # 5 TB/s
         }
         result = mem_chart_gfx11.plot_mem_chart(
-            "per_kernel", extreme_metrics, chart_title=DEFAULT_TITLE
+            extreme_metrics, chart_title=DEFAULT_TITLE
         )
 
         assert "TB/s" in result
@@ -452,9 +442,7 @@ class TestPlotMemChartGfx11:
             "DRAM Read Bandwidth": 0,
             "DRAM Write Bandwidth": 0,
         }
-        result = mem_chart_gfx11.plot_mem_chart(
-            "per_kernel", zero_metrics, chart_title=DEFAULT_TITLE
-        )
+        result = mem_chart_gfx11.plot_mem_chart(zero_metrics, chart_title=DEFAULT_TITLE)
 
         assert "B/s" in result  # Zero formats as "0.0 B/s"
 
@@ -523,7 +511,6 @@ class TestIntegrationGfx11:
 
         # Generate chart
         chart = mem_chart_gfx11.plot_mem_chart(
-            "per_dispatch",
             metrics,
             chart_title="3. Memory Chart (Normalization: per_dispatch)",
         )
@@ -546,9 +533,7 @@ class TestIntegrationGfx11:
             "DRAM Write Bandwidth": 100e9,  # 100 GB/s
         }
 
-        chart = mem_chart_gfx11.plot_mem_chart(
-            "per_kernel", metrics, chart_title=DEFAULT_TITLE
-        )
+        chart = mem_chart_gfx11.plot_mem_chart(metrics, chart_title=DEFAULT_TITLE)
 
         # All values should show in GB/s since they're in that range
         assert chart.count("GB/s") >= 6
@@ -562,9 +547,7 @@ class TestIntegrationGfx11:
             "TCP-GL1 Read Bandwidth": 50e3,  # 50 KB/s
         }
 
-        chart = mem_chart_gfx11.plot_mem_chart(
-            "per_kernel", metrics, chart_title=DEFAULT_TITLE
-        )
+        chart = mem_chart_gfx11.plot_mem_chart(metrics, chart_title=DEFAULT_TITLE)
 
         # Should contain multiple unit types
         assert "TB/s" in chart
@@ -641,16 +624,14 @@ class TestPlotMemChartGfx9:
     def test_returns_non_empty_string(self):
         """Full sample metrics produce a non-empty chart string."""
         result = mem_chart_gfx9.plot_mem_chart(
-            "per_kernel", dict(GFX9_SAMPLE_METRICS), chart_title=DEFAULT_TITLE
+            dict(GFX9_SAMPLE_METRICS), chart_title=DEFAULT_TITLE
         )
         assert isinstance(result, str)
         assert len(result) > 0
 
     def test_empty_metrics(self):
         """Empty metric dict still produces a non-empty chart (N/A placeholders)."""
-        result = mem_chart_gfx9.plot_mem_chart(
-            "per_kernel", {}, chart_title=DEFAULT_TITLE
-        )
+        result = mem_chart_gfx9.plot_mem_chart({}, chart_title=DEFAULT_TITLE)
         assert isinstance(result, str)
         assert len(result) > 0
 
@@ -661,9 +642,7 @@ class TestPlotMemChartGfx9:
             "L2 Hit": 75,
             "HBM Rd": 100,
         }
-        result = mem_chart_gfx9.plot_mem_chart(
-            "per_kernel", partial, chart_title=DEFAULT_TITLE
-        )
+        result = mem_chart_gfx9.plot_mem_chart(partial, chart_title=DEFAULT_TITLE)
         assert isinstance(result, str)
         assert len(result) > 0
 
@@ -671,7 +650,6 @@ class TestPlotMemChartGfx9:
         """CDNA output contains every component enabled by the renderer."""
         output = common.strip_ansi(
             mem_chart_gfx9.plot_mem_chart(
-                "per_kernel",
                 dict(GFX9_SAMPLE_METRICS),
                 chart_title=DEFAULT_TITLE,
             )
@@ -699,7 +677,6 @@ class TestPlotMemChartGfx9:
         """CDNA output prints the heading once outside the chart, with connectors."""
         output = common.strip_ansi(
             mem_chart_gfx9.plot_mem_chart(
-                "per_kernel",
                 dict(GFX9_SAMPLE_METRICS),
                 chart_title=DEFAULT_TITLE,
             )
@@ -737,7 +714,7 @@ class TestPlotMemChartGfx9:
 def test_chart_title_appears_as_first_line(renderer, metrics):
     """Both renderers print the caller's chart_title as the first line."""
     chart_title = "7. Memory Chart (Normalization: per_kernel)"
-    output = common.strip_ansi(renderer("per_kernel", metrics, chart_title=chart_title))
+    output = common.strip_ansi(renderer(metrics, chart_title=chart_title))
 
     assert output.strip().splitlines()[0] == chart_title
     assert "3. Memory Chart" not in output

--- a/projects/rocprofiler-compute/tests/test_mem_chart.py
+++ b/projects/rocprofiler-compute/tests/test_mem_chart.py
@@ -689,3 +689,32 @@ class TestPlotMemChartGfx9:
         assert re.search(r"<(?!-+>)-{3,}", output)
         assert re.search(r"(?<![<-])-{3,}>", output)
         assert re.search(r"<-{3,}>", output)
+
+    def test_contains_panel_heading_with_single_normalization(self):
+        """CDNA output prints the panel heading outside the chart."""
+        output = common.strip_ansi(
+            mem_chart_gfx9.plot_mem_chart(
+                "per_kernel",
+                dict(GFX9_SAMPLE_METRICS),
+            )
+        )
+        output_lines = output.splitlines()
+
+        assert output_lines[0] == "3. Memory Chart (Normalization: per_kernel)"
+        assert "3. Memory Chart" not in "\n".join(output_lines[1:])
+        assert "Instr Buff" in output_lines[4]
+        assert output.count("(Normalization: per_kernel)") == 1
+
+    def test_chart_title_override(self):
+        """CDNA output uses an explicit chart title when provided."""
+        output = common.strip_ansi(
+            mem_chart_gfx9.plot_mem_chart(
+                "per_kernel",
+                dict(GFX9_SAMPLE_METRICS),
+                chart_title="7. Memory Chart (Normalization: per_kernel)",
+            )
+        )
+        output_lines = output.splitlines()
+
+        assert output_lines[0] == "7. Memory Chart (Normalization: per_kernel)"
+        assert "3. Memory Chart" not in output

--- a/projects/rocprofiler-compute/tests/test_mem_chart.py
+++ b/projects/rocprofiler-compute/tests/test_mem_chart.py
@@ -9,6 +9,8 @@ Covers:
 - mem_chart_gfx9.py  - CDNA (plotille-based) memory architecture visualization
 """
 
+import re
+
 import common
 
 from utils import mem_chart_gfx9, mem_chart_gfx11
@@ -355,19 +357,42 @@ class TestPlotMemChartGfx11:
             result
         )
 
-    def test_contains_architecture_elements(self):
-        """Test that output contains RDNA3.5 architecture elements."""
+    def test_contains_complete_rdna35_architecture(self):
+        """RDNA3.5 output contains every rendered memory component."""
         metrics = mem_chart_gfx11.get_sample_metrics()
-        result = mem_chart_gfx11.plot_mem_chart("per_kernel", metrics)
+        output = common.strip_ansi(
+            mem_chart_gfx11.plot_mem_chart("per_kernel", metrics)
+        )
+        expected_components = (
+            "Kernel",
+            "LDS",
+            "GL0 (TCP Cache)",
+            "SQC",
+            "GL1 Cache",
+            "GL2 Cache",
+            "GCEA",
+            "DRAM",
+        )
 
-        # Check for key components
-        assert "TCP" in result or "L0" in result  # L0 cache
-        assert "GL1 Cache" in result  # L1 cache
-        assert "GL2 Cache" in result  # L2 cache
-        assert (
-            "GCEA" in result
-        )  # Graphics Core Efficiency Arbiter (block label in diagram)
-        assert "DRAM" in result  # System memory
+        for component in expected_components:
+            assert component in output, f"Missing RDNA3.5 component: {component}"
+
+    def test_contains_heading_scope_and_directional_connectors(self):
+        """RDNA3.5 output exposes chart scope and connector directions."""
+        metrics = mem_chart_gfx11.get_sample_metrics()
+        output = common.strip_ansi(
+            mem_chart_gfx11.plot_mem_chart("per_kernel", metrics)
+        )
+
+        assert "3. Memory Chart (Normalization: per_kernel)" in output
+        assert "GPU" in output
+        assert "System Memory" in output
+        assert "Read BW" in output
+        assert "Write BW" in output
+        assert "Atomic" in output
+        assert re.search(r"<(?!-+>)-{3,}", output)
+        assert re.search(r"(?<![<-])-{3,}>", output)
+        assert re.search(r"<-{3,}>", output)
 
     def test_contains_bandwidth_values(self):
         """Test that output contains formatted bandwidth values."""
@@ -620,3 +645,47 @@ class TestPlotMemChartGfx9:
         result = mem_chart_gfx9.plot_mem_chart("per_kernel", partial)
         assert isinstance(result, str)
         assert len(result) > 0
+
+    def test_contains_complete_cdna_architecture(self):
+        """CDNA output contains every component enabled by the renderer."""
+        output = common.strip_ansi(
+            mem_chart_gfx9.plot_mem_chart(
+                "per_kernel",
+                dict(GFX9_SAMPLE_METRICS),
+            )
+        )
+        expected_components = (
+            "Instr Buff",
+            "Instr Dispatch",
+            "Exec",
+            "LDS",
+            "Vector L1 Cache",
+            "Scalar L1D Cache",
+            "Instr L1 Cache",
+            "L2 Cache",
+            "xGMI/PCIe",
+            "Fabric",
+            "HBM",
+        )
+
+        for component in expected_components:
+            assert component in output, f"Missing CDNA component: {component}"
+
+        assert re.search(r"(?<!x)GMI(?!/PCIe)", output)
+
+    def test_contains_normalization_and_directional_connectors(self):
+        """CDNA output exposes normalization and connector directions."""
+        output = common.strip_ansi(
+            mem_chart_gfx9.plot_mem_chart(
+                "per_kernel",
+                dict(GFX9_SAMPLE_METRICS),
+            )
+        )
+
+        assert "(Normalization: per_kernel)" in output
+        for connector_label in ("Req", "Fetch", "Rd", "Wr", "Atomic"):
+            assert connector_label in output
+
+        assert re.search(r"<(?!-+>)-{3,}", output)
+        assert re.search(r"(?<![<-])-{3,}>", output)
+        assert re.search(r"<-{3,}>", output)

--- a/projects/rocprofiler-compute/tests/test_tty.py
+++ b/projects/rocprofiler-compute/tests/test_tty.py
@@ -4,6 +4,7 @@
 """Unit tests for src/utils/tty.py."""
 
 import argparse
+from unittest.mock import Mock
 
 import pandas as pd
 import pytest
@@ -276,3 +277,60 @@ def test_edge_cases_and_error_handling() -> None:
     result = convert_time_columns(mixed_case_df, "ms")
     assert result.loc[0, "Unit"] == "ms"
     assert result.loc[1, "Unit"] == "ms"
+
+
+@pytest.mark.parametrize(
+    ("gpu_arch", "uses_gfx11"),
+    [
+        pytest.param(
+            "gfx1151",
+            True,
+            id="rdna35",
+        ),
+        pytest.param(
+            "gfx942",
+            False,
+            id="cdna",
+        ),
+    ],
+)
+def test_format_table_output_dispatches_memory_chart_renderer(
+    monkeypatch: pytest.MonkeyPatch,
+    gpu_arch: str,
+    uses_gfx11: bool,
+) -> None:
+    """Memory Chart output uses the architecture renderer and shared heading."""
+    gfx11_renderer = Mock(return_value="rendered RDNA3.5 memory chart")
+    gfx9_renderer = Mock(return_value="rendered CDNA memory chart")
+    monkeypatch.setattr(
+        "utils.tty.mem_chart_gfx11.plot_mem_chart",
+        gfx11_renderer,
+    )
+    monkeypatch.setattr(
+        "utils.tty.mem_chart_gfx9.plot_mem_chart",
+        gfx9_renderer,
+    )
+    df = pd.DataFrame({"Metric": ["Metric A"], "Value": [1]})
+
+    content = format_table_output(
+        make_args(),
+        {
+            "id": 701,
+            "title": "Memory Chart",
+            "cli_style": "mem_chart",
+        },
+        df,
+        "metric_table",
+        runs={"only": object()},
+        gpu_arch=gpu_arch,
+    )
+
+    expected_renderer = gfx11_renderer if uses_gfx11 else gfx9_renderer
+    unexpected_renderer = gfx9_renderer if uses_gfx11 else gfx11_renderer
+    expected_renderer.assert_called_once_with(
+        "per_wave",
+        {"Metric A": 1},
+        chart_title="7. Memory Chart (Normalization: per_wave)",
+    )
+    unexpected_renderer.assert_not_called()
+    assert content == f"{expected_renderer.return_value}\n"

--- a/projects/rocprofiler-compute/tests/test_tty.py
+++ b/projects/rocprofiler-compute/tests/test_tty.py
@@ -4,12 +4,12 @@
 """Unit tests for src/utils/tty.py."""
 
 import argparse
-from unittest.mock import Mock
 
 import pandas as pd
 import pytest
 
 from utils.tty import convert_time_columns, format_table_output, has_time_data
+from utils.utils_common import is_gfx115x
 
 TIME_UNITS = {"s": 10**9, "ms": 10**6, "us": 10**3, "ns": 1}
 
@@ -280,35 +280,37 @@ def test_edge_cases_and_error_handling() -> None:
 
 
 @pytest.mark.parametrize(
-    ("gpu_arch", "uses_gfx11"),
+    "gpu_arch",
     [
-        pytest.param(
-            "gfx1151",
-            True,
-            id="rdna35",
-        ),
-        pytest.param(
-            "gfx942",
-            False,
-            id="cdna",
-        ),
+        pytest.param("gfx1151", id="rdna35"),
+        pytest.param("gfx942", id="cdna"),
     ],
 )
 def test_format_table_output_dispatches_memory_chart_renderer(
     monkeypatch: pytest.MonkeyPatch,
     gpu_arch: str,
-    uses_gfx11: bool,
 ) -> None:
     """Memory Chart output uses the architecture renderer and shared heading."""
-    gfx11_renderer = Mock(return_value="rendered RDNA3.5 memory chart")
-    gfx9_renderer = Mock(return_value="rendered CDNA memory chart")
+    calls: dict[str, dict] = {}
+
+    def record(name: str, return_value: str):
+        def stub(normal_unit: str, mem_data: dict, *, chart_title: str) -> str:
+            calls[name] = {
+                "normal_unit": normal_unit,
+                "mem_data": mem_data,
+                "chart_title": chart_title,
+            }
+            return return_value
+
+        return stub
+
     monkeypatch.setattr(
         "utils.tty.mem_chart_gfx11.plot_mem_chart",
-        gfx11_renderer,
+        record("gfx11", "rendered RDNA3.5 memory chart"),
     )
     monkeypatch.setattr(
         "utils.tty.mem_chart_gfx9.plot_mem_chart",
-        gfx9_renderer,
+        record("gfx9", "rendered CDNA memory chart"),
     )
     df = pd.DataFrame({"Metric": ["Metric A"], "Value": [1]})
 
@@ -325,12 +327,17 @@ def test_format_table_output_dispatches_memory_chart_renderer(
         gpu_arch=gpu_arch,
     )
 
-    expected_renderer = gfx11_renderer if uses_gfx11 else gfx9_renderer
-    unexpected_renderer = gfx9_renderer if uses_gfx11 else gfx11_renderer
-    expected_renderer.assert_called_once_with(
-        "per_wave",
-        {"Metric A": 1},
-        chart_title="7. Memory Chart (Normalization: per_wave)",
+    expected = "gfx11" if is_gfx115x(gpu_arch) else "gfx9"
+    unexpected = "gfx9" if is_gfx115x(gpu_arch) else "gfx11"
+    assert calls[expected] == {
+        "normal_unit": "per_wave",
+        "mem_data": {"Metric A": 1},
+        "chart_title": "7. Memory Chart (Normalization: per_wave)",
+    }
+    assert unexpected not in calls
+    return_value = (
+        "rendered RDNA3.5 memory chart"
+        if is_gfx115x(gpu_arch)
+        else "rendered CDNA memory chart"
     )
-    unexpected_renderer.assert_not_called()
-    assert content == f"{expected_renderer.return_value}\n"
+    assert content == f"{return_value}\n"

--- a/projects/rocprofiler-compute/tests/test_tty.py
+++ b/projects/rocprofiler-compute/tests/test_tty.py
@@ -294,9 +294,8 @@ def test_format_table_output_dispatches_memory_chart_renderer(
     calls: dict[str, dict] = {}
 
     def record(name: str, return_value: str):
-        def stub(normal_unit: str, mem_data: dict, *, chart_title: str) -> str:
+        def stub(mem_data: dict, *, chart_title: str) -> str:
             calls[name] = {
-                "normal_unit": normal_unit,
                 "mem_data": mem_data,
                 "chart_title": chart_title,
             }
@@ -330,7 +329,6 @@ def test_format_table_output_dispatches_memory_chart_renderer(
     expected = "gfx11" if is_gfx115x(gpu_arch) else "gfx9"
     unexpected = "gfx9" if is_gfx115x(gpu_arch) else "gfx11"
     assert calls[expected] == {
-        "normal_unit": "per_wave",
         "mem_data": {"Metric A": 1},
         "chart_title": "7. Memory Chart (Normalization: per_wave)",
     }


### PR DESCRIPTION
## Motivation

Align Memory Chart CLI output across RDNA3.5 and CDNA so each renderer exposes the numbered panel title, normalization scope, rendered components, and connector directions.

Bugfix: CDNA Memory Chart output now prints the `3. Memory Chart` header once outside the diagram without repeating the default normalization label.

## Technical Details

- Make `chart_title` a required arg on both renderers; `tty._mem_chart_heading` is the single heading formatter for the CLI path.
- Remove the unused `format_mem_chart_heading` helper and the `normal_unit` parameter from `plot_mem_chart`.
- Move CDNA chart title outside the diagram.
- Add architecture component and connector assertions.
- Add TTY renderer dispatch coverage.

## JIRA ID

- JIRA ID: AIROCVAL-168
- JIRA ID: AIPROFCOMP-726

## Test Plan

- Run `pytest tests/test_mem_chart.py`.
- Run `pytest tests/test_tty.py`.

## Test Result

- [x] `pytest tests/test_mem_chart.py` passes
- [x] `pytest tests/test_tty.py` passes

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.