### PR TITLE
fix(rocprofiler-sdk): prevent roctxMark from leaking kernel renames

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/kokkosp/kokkosp.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/kokkosp/kokkosp.cpp
@@ -60,6 +60,19 @@ struct Section
 
 bool tool_globfences  = false;
 auto kokkosp_sections = std::vector<Section>{};
+
+// Emit an instantaneous Kokkos milestone into the marker timeline without perturbing kernel
+// renaming. rocprofv3's --kernel-rename (implied by --kokkos-trace) treats roctxMark as a
+// sticky rename that relabels every subsequent kernel dispatched on the thread. Using a
+// balanced roctxRangePush/roctxRangePop instead keeps the timeline marker but leaves the
+// kernel-rename stack net-unchanged (nothing is dispatched between the push and pop), so
+// non-Kokkos kernels retain their real names under --kokkos-trace.
+void
+kokkosp_emit_milestone(const char* name)
+{
+    roctxRangePush(name);
+    roctxRangePop();
+}
 }  // namespace
 
 extern "C" {
@@ -159,7 +172,7 @@ kokkosp_init_library(const int      loadSeq,
               << ", version: " << interfaceVer << ")\n"
               << "-----------------------------------------------------------\n";
 
-    roctxMark("Kokkos::Initialization Complete");
+    kokkosp_emit_milestone("Kokkos::Initialization Complete");
 }
 
 void
@@ -171,7 +184,7 @@ KokkosP: Finalization of rocprofv3 Connector. Complete.
 -----------------------------------------------------------
 )";
 
-    roctxMark("Kokkos::Finalization Complete");
+    kokkosp_emit_milestone("Kokkos::Finalization Complete");
 }
 
 void
@@ -253,7 +266,7 @@ kokkosp_destroy_profile_section(const uint32_t)
 void
 kokkosp_profile_event(const char* name)
 {
-    roctxMark(name);
+    kokkosp_emit_milestone(name);
 }
 
 void


### PR DESCRIPTION
  Root cause:                                                                                                                                                                                                                                                                                                                                                                                                                              
  Under --kokkos-trace (which implies --kernel-rename), the KokkosP connector emitted roctxMark for its init/finalize/profile_event milestones. rocprofv3 treats roctxMark (roctxMarkA) as a sticky kernel rename:               
  kernel_rename_callback pushes the mark's message onto the thread-local rename stack on the EXIT phase and never pops it (a mark is instantaneous). As a result, every subsequent kernel dispatched on that thread was relabeled
   to the last mark's message. This made all non-Kokkos (raw HIP) kernels "disappear" from --kernel-trace, showing up as e.g. Kokkos::Finalization Complete instead of their real names. 

Fix:
Rather than change the generic roctxMark rename semantics — which other tools and integration tests (kernel-rename, summary) intentionally rely on to label groups of kernels — the fix is on the Kokkos side. The three       
  milestone marks are emitted as a balanced roctxRangePush + roctxRangePop pair (kokkosp_emit_milestone). Nothing is dispatched between the push and pop, so the rename stack is left net-unchanged while the milestone still    
  appears in the marker timeline. Kokkos parallel regions continue to rename their kernels via their existing roctxRangePush/roctxRangePop scopes, and non-Kokkos kernels retain their real names. 
## Motivation


<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
JIRA ID : ROCM-27097
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
