### PR TITLE
test(rocprofv3): expand PMC kernel-filter coverage and add unit tests

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/CMakeLists.txt
@@ -4,11 +4,19 @@
 
 rocprofiler_activate_clang_tidy()
 
-set(TOOL_HEADERS att_no_intercept.hpp att_no_intercept_impl.hpp config.hpp
-                 execution_profile.hpp graph_stack.hpp helper.hpp stream_stack.hpp)
+set(TOOL_HEADERS
+    att_no_intercept.hpp
+    att_no_intercept_impl.hpp
+    config.hpp
+    execution_profile.hpp
+    graph_stack.hpp
+    helper.hpp
+    kernel_filter_range.hpp
+    kernel_iteration_filter.hpp
+    stream_stack.hpp)
 
-set(TOOL_SOURCES att_no_intercept.cpp config.cpp graph_stack.cpp main.c tool.cpp
-                 stream_stack.cpp)
+set(TOOL_SOURCES att_no_intercept.cpp config.cpp graph_stack.cpp kernel_filter_range.cpp
+                 kernel_iteration_filter.cpp main.c stream_stack.cpp tool.cpp)
 
 if(rocprof-trace-decoder_FOUND)
     list(APPEND TOOL_SOURCES att_no_intercept_quick_scan.cpp)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/config.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/config.cpp
@@ -22,6 +22,7 @@
 //
 
 #include "config.hpp"
+#include "kernel_filter_range.hpp"
 
 #include "lib/common/defines.hpp"
 #include "lib/common/demangle.hpp"
@@ -99,38 +100,6 @@ has_counter_format(std::string const& str)
     return std::find_if(str.begin(), str.end(), [](unsigned char ch) {
                return (isalnum(ch) != 0 || ch == '_');
            }) != str.end();
-}
-
-// validate kernel names
-std::unordered_set<size_t>
-get_kernel_filter_range(const std::string& kernel_filter)
-{
-    if(kernel_filter.empty()) return {};
-
-    auto delim     = rocprofiler::sdk::parse::tokenize(kernel_filter, "[], ");
-    auto range_set = std::unordered_set<size_t>{};
-    for(const auto& itr : delim)
-    {
-        if(itr.find('-') != std::string::npos)
-        {
-            auto drange = rocprofiler::sdk::parse::tokenize(itr, "- ");
-
-            ROCP_FATAL_IF(drange.size() != 2)
-                << "bad range format for '" << itr << "'. Expected [A-B] where A and B are numbers";
-
-            size_t start_range = std::stoul(drange.front());
-            size_t end_range   = std::stoul(drange.back());
-            for(auto i = start_range; i <= end_range; i++)
-                range_set.emplace(i);
-        }
-        else
-        {
-            ROCP_FATAL_IF(itr.find_first_not_of("0123456789") != std::string::npos)
-                << "expected integer for " << itr << ". Non-integer value detected";
-            range_set.emplace(std::stoul(itr));
-        }
-    }
-    return range_set;
 }
 
 std::vector<att_perfcounter>

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/kernel_filter_range.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/kernel_filter_range.cpp
@@ -1,0 +1,67 @@
+// MIT License
+//
+// Copyright (c) 2023-2026 Advanced Micro Devices, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#include "kernel_filter_range.hpp"
+
+#include "lib/common/logging.hpp"
+
+#include <rocprofiler-sdk/cxx/details/tokenize.hpp>
+
+#include <string>
+
+namespace rocprofiler
+{
+namespace tool
+{
+std::unordered_set<size_t>
+get_kernel_filter_range(const std::string& kernel_filter)
+{
+    if(kernel_filter.empty()) return {};
+
+    auto delim     = rocprofiler::sdk::parse::tokenize(kernel_filter, "[], ");
+    auto range_set = std::unordered_set<size_t>{};
+    for(const auto& itr : delim)
+    {
+        if(itr.find('-') != std::string::npos)
+        {
+            auto drange = rocprofiler::sdk::parse::tokenize(itr, "- ");
+
+            ROCP_FATAL_IF(drange.size() != 2)
+                << "bad range format for '" << itr << "'. Expected [A-B] where A and B are numbers";
+
+            size_t start_range = std::stoul(drange.front());
+            size_t end_range   = std::stoul(drange.back());
+            for(auto i = start_range; i <= end_range; i++)
+                range_set.emplace(i);
+        }
+        else
+        {
+            ROCP_FATAL_IF(itr.find_first_not_of("0123456789") != std::string::npos)
+                << "expected integer for " << itr << ". Non-integer value detected";
+            range_set.emplace(std::stoul(itr));
+        }
+    }
+    return range_set;
+}
+}  // namespace tool
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/kernel_filter_range.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/kernel_filter_range.hpp
@@ -1,0 +1,41 @@
+// MIT License
+//
+// Copyright (c) 2023-2026 Advanced Micro Devices, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <unordered_set>
+
+namespace rocprofiler
+{
+namespace tool
+{
+// Parse a kernel-iteration-range string into the set of 1-based launch indices,
+// e.g. "[1, 3, 5, [8-12]]" -> {1,3,5,8,9,10,11,12}, "3-6" -> {3,4,5,6}, "3" ->
+// {3}. Empty string -> empty set (== all iterations). Malformed / non-integer
+// input aborts via ROCP_FATAL.
+std::unordered_set<size_t>
+get_kernel_filter_range(const std::string& kernel_filter);
+}  // namespace tool
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/kernel_iteration_filter.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/kernel_iteration_filter.cpp
@@ -1,0 +1,55 @@
+// MIT License
+//
+// Copyright (c) 2023-2026 Advanced Micro Devices, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#include "kernel_iteration_filter.hpp"
+
+namespace rocprofiler
+{
+namespace tool
+{
+bool
+is_targeted_kernel_iteration(uint64_t                      kernel_id,
+                             const kernel_target_map_t&    targeted_kernels,
+                             kernel_iteration_count_map_t& kernel_iteration,
+                             bool                          advanced_thread_trace)
+{
+    auto target_itr = targeted_kernels.find(kernel_id);
+    // only targeted kernels are counted or profiled
+    if(target_itr == targeted_kernels.end()) return false;
+
+    const auto& range = target_itr->second;
+
+    // 1-based per-kernel counter (operator[] starts at 0, so first ++ yields 1)
+    const size_t iteration = ++kernel_iteration[kernel_id];
+
+    // empty range: all iterations (PMC) or only the first (thread trace)
+    if(range.empty())
+    {
+        if(!advanced_thread_trace) return true;
+        return iteration == 1;
+    }
+
+    return range.find(iteration) != range.end();
+}
+}  // namespace tool
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/kernel_iteration_filter.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/kernel_iteration_filter.hpp
@@ -1,0 +1,52 @@
+// MIT License
+//
+// Copyright (c) 2023-2026 Advanced Micro Devices, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace rocprofiler
+{
+namespace tool
+{
+// kernel_id -> set of 1-based launch indices to profile (empty == all)
+using kernel_target_map_t = std::unordered_map<uint64_t, std::unordered_set<size_t>>;
+// kernel_id -> launches seen so far (1-based)
+using kernel_iteration_count_map_t = std::unordered_map<uint64_t, size_t>;
+
+// Advance kernel_id's 1-based counter and decide whether this dispatch is
+// profiled. Pure core of is_targeted_kernel(), extracted for unit testing.
+//   - kernel_id not targeted    -> false (not counted)
+//   - empty range, PMC          -> every iteration
+//   - empty range, thread trace -> first iteration only
+//   - non-empty range           -> iterations in the range
+bool
+is_targeted_kernel_iteration(uint64_t                      kernel_id,
+                             const kernel_target_map_t&    targeted_kernels,
+                             kernel_iteration_count_map_t& kernel_iteration,
+                             bool                          advanced_thread_trace);
+}  // namespace tool
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -28,6 +28,7 @@
 #include "execution_profile.hpp"
 #include "graph_stack.hpp"
 #include "helper.hpp"
+#include "kernel_iteration_filter.hpp"
 #include "stream_stack.hpp"
 
 #include "lib/att-tool/att_lib_wrapper.hpp"
@@ -333,47 +334,21 @@ bool
 is_targeted_kernel(uint64_t                                        _kern_id,
                    common::Synchronized<kernel_iteration_t, true>& _kernel_iteration)
 {
-    const std::unordered_set<size_t>* range = target_kernels.rlock(
-        [](const auto& _targets_v, uint64_t _kern_id_v) -> const std::unordered_set<size_t>* {
-            if(_targets_v.find(_kern_id_v) != _targets_v.end()) return &_targets_v.at(_kern_id_v);
-            return nullptr;
+    // hold target_kernels around kernel_iteration so the range stays valid; both
+    // are only locked here / in add_kernel_target(), so the nesting is safe
+    return target_kernels.rlock(
+        [&_kernel_iteration](const targeted_kernels_map_t& _targets_v, uint64_t _kern_id_v) {
+            return _kernel_iteration.wlock(
+                [&_targets_v](kernel_iteration_t& _kernel_iter, uint64_t _kernel_id) {
+                    return tool::is_targeted_kernel_iteration(
+                        _kernel_id,
+                        _targets_v,
+                        _kernel_iter,
+                        tool::get_config().advanced_thread_trace);
+                },
+                _kern_id_v);
         },
         _kern_id);
-
-    if(range)
-    {
-        _kernel_iteration.wlock(
-            [](auto& _kernel_iter, rocprofiler_kernel_id_t _kernel_id) {
-                auto itr = _kernel_iter.find(_kernel_id);
-                if(itr == _kernel_iter.end())
-                    _kernel_iter.emplace(_kernel_id, 1);
-                else
-                    itr->second++;
-            },
-            _kern_id);
-
-        return _kernel_iteration.rlock(
-            [](const auto&                       _kernel_iter,
-               uint64_t                          _kernel_id,
-               const std::unordered_set<size_t>& _range) {
-                auto itr = _kernel_iter.at(_kernel_id);
-                // If the iteration range is not given then all iterations of the kernel is profiled
-                if(_range.empty())
-                {
-                    if(!tool::get_config().advanced_thread_trace)
-                        return true;
-                    else if(itr == 1)
-                        return true;
-                }
-                else if(_range.find(itr) != _range.end())
-                    return true;
-                return false;
-            },
-            _kern_id,
-            *range);
-    }
-
-    return false;
 }
 
 auto&

--- a/projects/rocprofiler-sdk/source/lib/tests/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/tests/CMakeLists.txt
@@ -4,3 +4,4 @@
 add_subdirectory(buffering)
 add_subdirectory(common)
 add_subdirectory(codeobj)
+add_subdirectory(tool)

--- a/projects/rocprofiler-sdk/source/lib/tests/tool/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/tests/tool/CMakeLists.txt
@@ -1,0 +1,31 @@
+#
+# Tests for the rocprofv3 tool library (GPU-independent logic)
+#
+project(rocprofiler-sdk-tests-tool LANGUAGES CXX)
+
+include(GoogleTest)
+
+set(tool_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../rocprofiler-sdk-tool)
+
+set(tool_test_sources kernel_filter_range.cpp kernel_iteration_filter.cpp)
+
+# compile the GPU-independent tool logic directly into the test so it can be exercised
+# without loading the tool runtime (which requires a GPU)
+set(tool_lib_sources ${tool_dir}/kernel_filter_range.cpp
+                     ${tool_dir}/kernel_iteration_filter.cpp)
+
+add_executable(tool-tests)
+target_sources(tool-tests PRIVATE ${tool_test_sources} ${tool_lib_sources})
+target_include_directories(tool-tests PRIVATE ${tool_dir})
+target_link_libraries(
+    tool-tests
+    PRIVATE rocprofiler-sdk::rocprofiler-sdk-headers
+            rocprofiler-sdk::rocprofiler-sdk-common-library GTest::gtest
+            GTest::gtest_main)
+
+rocprofiler_add_unit_test(
+    TARGET tool-tests
+    SOURCES ${tool_test_sources}
+    ENVIRONMENT
+        "LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}:${CMAKE_LIBRARY_OUTPUT_DIRECTORY}:${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/llvm/lib:${ROCM_PATH}/lib:${ROCM_PATH}/llvm/lib:$ENV{LD_LIBRARY_PATH}"
+    )

--- a/projects/rocprofiler-sdk/source/lib/tests/tool/kernel_filter_range.cpp
+++ b/projects/rocprofiler-sdk/source/lib/tests/tool/kernel_filter_range.cpp
@@ -1,0 +1,83 @@
+// MIT License
+//
+// Copyright (c) 2023-2026 Advanced Micro Devices, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "kernel_filter_range.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <string>
+#include <unordered_set>
+
+namespace
+{
+using set_t = std::unordered_set<size_t>;
+using rocprofiler::tool::get_kernel_filter_range;
+}  // namespace
+
+TEST(kernel_filter_range, mixed_singles_and_ranges)
+{
+    // singles and an inclusive nested range
+    EXPECT_EQ(get_kernel_filter_range("[1, 3, 5, [8-12]]"), (set_t{1, 3, 5, 8, 9, 10, 11, 12}));
+}
+
+TEST(kernel_filter_range, bare_range_without_brackets)
+{
+    EXPECT_EQ(get_kernel_filter_range("3-6"), (set_t{3, 4, 5, 6}));
+}
+
+TEST(kernel_filter_range, single_bracketed_range)
+{
+    EXPECT_EQ(get_kernel_filter_range("[8-12]"), (set_t{8, 9, 10, 11, 12}));
+}
+
+TEST(kernel_filter_range, single_integer) { EXPECT_EQ(get_kernel_filter_range("3"), (set_t{3})); }
+
+TEST(kernel_filter_range, empty_string_means_all_iterations)
+{
+    // empty set is the sentinel callers treat as "profile all iterations"
+    EXPECT_TRUE(get_kernel_filter_range("").empty());
+}
+
+TEST(kernel_filter_range, comma_join_form_matches_bracket_form)
+{
+    // the CLI joins multi-token ranges (e.g. `--kernel-iteration-range 1 2`)
+    // with ", " before parsing; assert that form is equivalent to "[1-2]"
+    EXPECT_EQ(get_kernel_filter_range("1, 2"), get_kernel_filter_range("[1-2]"));
+    EXPECT_EQ(get_kernel_filter_range("1, 2"), (set_t{1, 2}));
+}
+
+TEST(kernel_filter_range, duplicate_indices_collapse)
+{
+    // overlapping specifications collapse to a set (no duplicates)
+    EXPECT_EQ(get_kernel_filter_range("[2, [1-3]]"), (set_t{1, 2, 3}));
+}
+
+TEST(kernel_filter_range, malformed_range_aborts)
+{
+    EXPECT_DEATH(get_kernel_filter_range("[1-]"), "bad range format");
+}
+
+TEST(kernel_filter_range, non_integer_token_aborts)
+{
+    EXPECT_DEATH(get_kernel_filter_range("[a]"), "Non-integer value detected");
+}

--- a/projects/rocprofiler-sdk/source/lib/tests/tool/kernel_iteration_filter.cpp
+++ b/projects/rocprofiler-sdk/source/lib/tests/tool/kernel_iteration_filter.cpp
@@ -1,0 +1,124 @@
+// MIT License
+//
+// Copyright (c) 2023-2026 Advanced Micro Devices, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "kernel_iteration_filter.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+
+namespace
+{
+using rocprofiler::tool::is_targeted_kernel_iteration;
+using rocprofiler::tool::kernel_iteration_count_map_t;
+using rocprofiler::tool::kernel_target_map_t;
+
+constexpr bool PMC = false;  // advanced_thread_trace == false
+constexpr bool ATT = true;   // advanced_thread_trace == true
+
+// call is_targeted_kernel_iteration n times for one kernel and return the
+// per-launch decisions as a string of '1' (profiled) / '0' (skipped)
+std::string
+profile_sequence(uint64_t                   kernel_id,
+                 const kernel_target_map_t& targets,
+                 bool                       advanced_thread_trace,
+                 int                        n)
+{
+    kernel_iteration_count_map_t counter;
+    std::string                  out;
+    out.reserve(n);
+    for(int i = 0; i < n; ++i)
+        out.push_back(
+            is_targeted_kernel_iteration(kernel_id, targets, counter, advanced_thread_trace) ? '1'
+                                                                                             : '0');
+    return out;
+}
+}  // namespace
+
+TEST(kernel_iteration_filter, untargeted_kernel_never_profiled_or_counted)
+{
+    kernel_target_map_t          targets = {{1, {}}};
+    kernel_iteration_count_map_t counter;
+
+    // kernel 2 is not in the target map -> false, and must not be counted
+    EXPECT_FALSE(is_targeted_kernel_iteration(2, targets, counter, PMC));
+    EXPECT_FALSE(is_targeted_kernel_iteration(2, targets, counter, PMC));
+    EXPECT_EQ(counter.find(2), counter.end());
+}
+
+TEST(kernel_iteration_filter, empty_range_pmc_profiles_all_iterations)
+{
+    kernel_target_map_t targets = {{7, {}}};  // empty range == all iterations
+    EXPECT_EQ(profile_sequence(7, targets, PMC, 5), "11111");
+}
+
+TEST(kernel_iteration_filter, empty_range_att_profiles_only_first_iteration)
+{
+    kernel_target_map_t targets = {{7, {}}};
+    EXPECT_EQ(profile_sequence(7, targets, ATT, 4), "1000");
+}
+
+TEST(kernel_iteration_filter, first_dispatch_is_iteration_one)
+{
+    // range {1} must match the very first dispatch and nothing else
+    kernel_target_map_t targets = {{9, {1}}};
+    EXPECT_EQ(profile_sequence(9, targets, PMC, 3), "100");
+}
+
+TEST(kernel_iteration_filter, range_selects_exact_iterations_both_directions)
+{
+    // range {2,4} over 5 launches -> only iterations 2 and 4 are profiled
+    kernel_target_map_t targets = {{3, {2, 4}}};
+    EXPECT_EQ(profile_sequence(3, targets, PMC, 5), "01010");
+}
+
+TEST(kernel_iteration_filter, out_of_bounds_range_profiles_nothing)
+{
+    // range references iterations beyond the number of launches -> no profiling
+    kernel_target_map_t targets = {{3, {99}}};
+    EXPECT_EQ(profile_sequence(3, targets, PMC, 4), "0000");
+}
+
+TEST(kernel_iteration_filter, distinct_kernels_have_independent_counters)
+{
+    // interleave two kernels; each maintains its own 1-based counter. kernel 10
+    // wants iteration 1, kernel 20 wants iteration 2.
+    kernel_target_map_t          targets = {{10, {1}}, {20, {2}}};
+    kernel_iteration_count_map_t counter;
+
+    EXPECT_TRUE(is_targeted_kernel_iteration(10, targets, counter, PMC));   // 10 -> iter 1 (hit)
+    EXPECT_FALSE(is_targeted_kernel_iteration(20, targets, counter, PMC));  // 20 -> iter 1 (miss)
+    EXPECT_FALSE(is_targeted_kernel_iteration(10, targets, counter, PMC));  // 10 -> iter 2 (miss)
+    EXPECT_TRUE(is_targeted_kernel_iteration(20, targets, counter, PMC));   // 20 -> iter 2 (hit)
+
+    EXPECT_EQ(counter[10], 2u);
+    EXPECT_EQ(counter[20], 2u);
+}
+
+TEST(kernel_iteration_filter, range_with_gaps_and_multiple_kernels)
+{
+    // both kernels share range {1,3}; verify per-kernel independence over 4 launches
+    kernel_target_map_t targets = {{100, {1, 3}}, {200, {1, 3}}};
+    EXPECT_EQ(profile_sequence(100, targets, PMC, 4), "1010");
+    EXPECT_EQ(profile_sequence(200, targets, PMC, 4), "1010");
+}

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/kernel_filtering/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/kernel_filtering/CMakeLists.txt
@@ -47,6 +47,8 @@ rocprofiler_add_integration_validate_test(
          ${CMAKE_CURRENT_BINARY_DIR}/json_input/pass_4/out_counter_collection.csv
          --input-json-pass4
          ${CMAKE_CURRENT_BINARY_DIR}/json_input/pass_4/out_results.json
+         --iteration-config
+         ${CMAKE_CURRENT_BINARY_DIR}/input.json
     TIMEOUT 120
     LABELS "integration-tests"
     FIXTURES_REQUIRED rocprofv3-test-counter-collection-kernel-filtering-input-json)
@@ -75,6 +77,42 @@ rocprofiler_add_integration_validate_test(
     TIMEOUT 120
     LABELS "integration-tests"
     FIXTURES_REQUIRED rocprofv3-test-counter-collection-kernel-filtering-input-cmd)
+
+# iteration-range on the command line; defined once so the CLI and validator args match
+set(_ITER_RANGE "[1-2]")
+
+# --kernel-trace exposes the full (unfiltered) kernel_dispatch trace so the validator can
+# prove which iterations were captured
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-counter-collection-kernel-filtering-input-cmd-iteration-range
+    COMMAND
+        $<TARGET_FILE:rocprofiler-sdk::rocprofv3> -i ${CMAKE_CURRENT_BINARY_DIR}/input.txt
+        --kernel-include-regex ".*_kernel" --kernel-iteration-range "${_ITER_RANGE}"
+        --kernel-trace -T -d ${CMAKE_CURRENT_BINARY_DIR}/cmd_iteration_range_input -o out
+        --output-format csv json -- $<TARGET_FILE:vector-ops> 3 1
+    DEPENDS vector-ops
+    TIMEOUT 120
+    LABELS "integration-tests"
+    PRELOAD "${PRELOAD_ENV}"
+    FIXTURES_SETUP
+        rocprofv3-test-counter-collection-kernel-filtering-input-cmd-iteration-range)
+
+rocprofiler_add_integration_validate_test(
+    rocprofv3-test-counter-collection-kernel-filtering-input-cmd-iteration-range
+    TEST_PATHS validate.py
+    COPY conftest.py input.txt input.json input.yml
+    CONFIG pytest.ini
+    DISCOVERY_ARGS -k iteration_range
+    ARGS --input-csv-iteration-range
+         ${CMAKE_CURRENT_BINARY_DIR}/cmd_iteration_range_input/pmc_1/out_counter_collection.csv
+         --input-json-iteration-range
+         ${CMAKE_CURRENT_BINARY_DIR}/cmd_iteration_range_input/pmc_1/out_results.json
+         --kernel-iteration-range
+         "${_ITER_RANGE}"
+    TIMEOUT 120
+    LABELS "integration-tests"
+    FIXTURES_REQUIRED
+        rocprofv3-test-counter-collection-kernel-filtering-input-cmd-iteration-range)
 
 rocprofiler_add_integration_execute_test(
     rocprofv3-test-counter-collection-kernel-filtering-input-yaml
@@ -110,6 +148,233 @@ rocprofiler_add_integration_validate_test(
          ${CMAKE_CURRENT_BINARY_DIR}/yaml_input/pass_4/out_counter_collection.csv
          --input-json-pass4
          ${CMAKE_CURRENT_BINARY_DIR}/yaml_input/pass_4/out_results.json
+         --iteration-config
+         ${CMAKE_CURRENT_BINARY_DIR}/input.yml
     TIMEOUT 120
     LABELS "integration-tests" FIXTURES
            rocprofv3-test-counter-collection-kernel-filtering-input-yaml)
+
+# CLI filter coverage: --kernel-include-regex / --kernel-exclude-regex /
+# --kernel-iteration-range on the command line, plus edge cases.
+
+# defined once so the CLI argument and the validator argument cannot drift
+set(_CLI_ITER_RANGE "[1-2]")
+
+# single included kernel + iteration range; --kernel-trace lets the validator recover the
+# exact captured iterations
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-counter-collection-kernel-filtering-cli-single-kernel
+    COMMAND
+        $<TARGET_FILE:rocprofiler-sdk::rocprofv3> --pmc SQ_WAVES --kernel-include-regex
+        "addition_kernel" --kernel-iteration-range "${_CLI_ITER_RANGE}" --kernel-trace -T
+        -d ${CMAKE_CURRENT_BINARY_DIR}/cli_single_kernel -o out --output-format csv json
+        -- $<TARGET_FILE:vector-ops> 8 1
+    DEPENDS vector-ops
+    TIMEOUT 120
+    LABELS "integration-tests"
+    PRELOAD "${PRELOAD_ENV}"
+    FIXTURES_SETUP rocprofv3-test-counter-collection-kernel-filtering-cli-single-kernel)
+
+rocprofiler_add_integration_validate_test(
+    rocprofv3-test-counter-collection-kernel-filtering-cli-single-kernel
+    TEST_PATHS validate.py
+    COPY conftest.py
+    CONFIG pytest.ini
+    DISCOVERY_ARGS -k cli_single_kernel
+    ARGS --input-csv-file
+         ${CMAKE_CURRENT_BINARY_DIR}/cli_single_kernel/out_counter_collection.csv
+         --input-json-file
+         ${CMAKE_CURRENT_BINARY_DIR}/cli_single_kernel/out_results.json
+         --kernel-iteration-range
+         "${_CLI_ITER_RANGE}"
+    TIMEOUT 120
+    LABELS "integration-tests"
+    FIXTURES_REQUIRED rocprofv3-test-counter-collection-kernel-filtering-cli-single-kernel
+    )
+
+# multi-token range ("1" "2") must produce the same result as "[1-2]"
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-counter-collection-kernel-filtering-cli-multitoken-range
+    COMMAND
+        $<TARGET_FILE:rocprofiler-sdk::rocprofv3> --pmc SQ_WAVES --kernel-include-regex
+        "addition_kernel" --kernel-iteration-range "1" "2" --kernel-trace -T -d
+        ${CMAKE_CURRENT_BINARY_DIR}/cli_multitoken_range -o out --output-format csv json
+        -- $<TARGET_FILE:vector-ops> 8 1
+    DEPENDS vector-ops
+    TIMEOUT 120
+    LABELS "integration-tests"
+    PRELOAD "${PRELOAD_ENV}"
+    FIXTURES_SETUP rocprofv3-test-counter-collection-kernel-filtering-cli-multitoken-range
+    )
+
+rocprofiler_add_integration_validate_test(
+    rocprofv3-test-counter-collection-kernel-filtering-cli-multitoken-range
+    TEST_PATHS validate.py
+    COPY conftest.py
+    CONFIG pytest.ini
+    DISCOVERY_ARGS -k cli_single_kernel
+    ARGS --input-csv-file
+         ${CMAKE_CURRENT_BINARY_DIR}/cli_multitoken_range/out_counter_collection.csv
+         --input-json-file
+         ${CMAKE_CURRENT_BINARY_DIR}/cli_multitoken_range/out_results.json
+         --kernel-iteration-range
+         "${_CLI_ITER_RANGE}"
+    TIMEOUT 120
+    LABELS "integration-tests"
+    FIXTURES_REQUIRED
+        rocprofv3-test-counter-collection-kernel-filtering-cli-multitoken-range)
+
+# exclude one kernel from the included set
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-counter-collection-kernel-filtering-cli-exclude
+    COMMAND
+        $<TARGET_FILE:rocprofiler-sdk::rocprofv3> --pmc SQ_WAVES --kernel-include-regex
+        ".*_kernel" --kernel-exclude-regex "multiply" -T -d
+        ${CMAKE_CURRENT_BINARY_DIR}/cli_exclude -o out --output-format csv --
+        $<TARGET_FILE:vector-ops> 8 1
+    DEPENDS vector-ops
+    TIMEOUT 120
+    LABELS "integration-tests"
+    PRELOAD "${PRELOAD_ENV}"
+    FIXTURES_SETUP rocprofv3-test-counter-collection-kernel-filtering-cli-exclude)
+
+rocprofiler_add_integration_validate_test(
+    rocprofv3-test-counter-collection-kernel-filtering-cli-exclude
+    TEST_PATHS validate.py
+    COPY conftest.py
+    CONFIG pytest.ini
+    DISCOVERY_ARGS -k cli_exclude_csv
+    ARGS --input-csv-file
+         ${CMAKE_CURRENT_BINARY_DIR}/cli_exclude/out_counter_collection.csv
+    TIMEOUT 120
+    LABELS "integration-tests"
+    FIXTURES_REQUIRED rocprofv3-test-counter-collection-kernel-filtering-cli-exclude)
+
+# --mangled-kernels: regex matches the mangled symbol
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-counter-collection-kernel-filtering-cli-mangled
+    COMMAND
+        $<TARGET_FILE:rocprofiler-sdk::rocprofv3> --pmc SQ_WAVES --kernel-include-regex
+        "addition_kernel" -M -d ${CMAKE_CURRENT_BINARY_DIR}/cli_mangled -o out
+        --output-format csv -- $<TARGET_FILE:vector-ops> 8 1
+    DEPENDS vector-ops
+    TIMEOUT 120
+    LABELS "integration-tests"
+    PRELOAD "${PRELOAD_ENV}"
+    FIXTURES_SETUP rocprofv3-test-counter-collection-kernel-filtering-cli-mangled)
+
+rocprofiler_add_integration_validate_test(
+    rocprofv3-test-counter-collection-kernel-filtering-cli-mangled
+    TEST_PATHS validate.py
+    COPY conftest.py
+    CONFIG pytest.ini
+    DISCOVERY_ARGS -k cli_mangled_csv
+    ARGS --input-csv-file
+         ${CMAKE_CURRENT_BINARY_DIR}/cli_mangled/out_counter_collection.csv
+    TIMEOUT 120
+    LABELS "integration-tests"
+    FIXTURES_REQUIRED rocprofv3-test-counter-collection-kernel-filtering-cli-mangled)
+
+# runs that complete successfully with zero counter records: exclude cancels the include
+# set, no-match include regex, and an out-of-bounds range (--kernel-trace forces an output
+# file to validate against)
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-counter-collection-kernel-filtering-cli-exclude-all
+    COMMAND
+        $<TARGET_FILE:rocprofiler-sdk::rocprofv3> --pmc SQ_WAVES --kernel-include-regex
+        ".*_kernel" --kernel-exclude-regex ".*_kernel" --kernel-trace -T -d
+        ${CMAKE_CURRENT_BINARY_DIR}/cli_exclude_all -o out --output-format json --
+        $<TARGET_FILE:vector-ops> 8 1
+    DEPENDS vector-ops
+    TIMEOUT 120
+    LABELS "integration-tests"
+    PRELOAD "${PRELOAD_ENV}"
+    FIXTURES_SETUP rocprofv3-test-counter-collection-kernel-filtering-cli-exclude-all)
+
+rocprofiler_add_integration_validate_test(
+    rocprofv3-test-counter-collection-kernel-filtering-cli-exclude-all
+    TEST_PATHS validate.py
+    COPY conftest.py
+    CONFIG pytest.ini
+    DISCOVERY_ARGS -k cli_empty_result_json
+    ARGS --input-json-file ${CMAKE_CURRENT_BINARY_DIR}/cli_exclude_all/out_results.json
+    TIMEOUT 120
+    LABELS "integration-tests"
+    FIXTURES_REQUIRED rocprofv3-test-counter-collection-kernel-filtering-cli-exclude-all)
+
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-counter-collection-kernel-filtering-cli-empty-match
+    COMMAND
+        $<TARGET_FILE:rocprofiler-sdk::rocprofv3> --pmc SQ_WAVES --kernel-include-regex
+        "no_such_kernel" --kernel-trace -T -d ${CMAKE_CURRENT_BINARY_DIR}/cli_empty_match
+        -o out --output-format json -- $<TARGET_FILE:vector-ops> 8 1
+    DEPENDS vector-ops
+    TIMEOUT 120
+    LABELS "integration-tests"
+    PRELOAD "${PRELOAD_ENV}"
+    FIXTURES_SETUP rocprofv3-test-counter-collection-kernel-filtering-cli-empty-match)
+
+rocprofiler_add_integration_validate_test(
+    rocprofv3-test-counter-collection-kernel-filtering-cli-empty-match
+    TEST_PATHS validate.py
+    COPY conftest.py
+    CONFIG pytest.ini
+    DISCOVERY_ARGS -k cli_empty_result_json
+    ARGS --input-json-file ${CMAKE_CURRENT_BINARY_DIR}/cli_empty_match/out_results.json
+    TIMEOUT 120
+    LABELS "integration-tests"
+    FIXTURES_REQUIRED rocprofv3-test-counter-collection-kernel-filtering-cli-empty-match)
+
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-counter-collection-kernel-filtering-cli-range-out-of-bounds
+    COMMAND
+        $<TARGET_FILE:rocprofiler-sdk::rocprofv3> --pmc SQ_WAVES --kernel-include-regex
+        ".*_kernel" --kernel-iteration-range "[99]" --kernel-trace -T -d
+        ${CMAKE_CURRENT_BINARY_DIR}/cli_range_out_of_bounds -o out --output-format json --
+        $<TARGET_FILE:vector-ops> 8 1
+    DEPENDS vector-ops
+    TIMEOUT 120
+    LABELS "integration-tests"
+    PRELOAD "${PRELOAD_ENV}"
+    FIXTURES_SETUP
+        rocprofv3-test-counter-collection-kernel-filtering-cli-range-out-of-bounds)
+
+rocprofiler_add_integration_validate_test(
+    rocprofv3-test-counter-collection-kernel-filtering-cli-range-out-of-bounds
+    TEST_PATHS validate.py
+    COPY conftest.py
+    CONFIG pytest.ini
+    DISCOVERY_ARGS -k cli_empty_result_json
+    ARGS --input-json-file
+         ${CMAKE_CURRENT_BINARY_DIR}/cli_range_out_of_bounds/out_results.json
+    TIMEOUT 120
+    LABELS "integration-tests"
+    FIXTURES_REQUIRED
+        rocprofv3-test-counter-collection-kernel-filtering-cli-range-out-of-bounds)
+
+# malformed / non-integer ranges must abort with a fatal message. The abort (SIGABRT)
+# matches ROCPROFILER_DEFAULT_FAIL_REGEX, so the run is piped to grep and grep's status
+# becomes the result. That asserts the diagnostic is emitted, which only happens on the
+# fatal path; the tool's own exit status is consumed by the pipeline and not checked.
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-counter-collection-kernel-filtering-cli-malformed-range
+    COMMAND
+        sh -c
+        "$<TARGET_FILE:rocprofiler-sdk::rocprofv3> --pmc SQ_WAVES --kernel-include-regex '.*_kernel' --kernel-iteration-range '[1-]' -T -d ${CMAKE_CURRENT_BINARY_DIR}/cli_malformed_range -o out --output-format json -- $<TARGET_FILE:vector-ops> 8 1 2>&1 | grep 'bad range format'"
+    DEPENDS vector-ops
+    TIMEOUT 120
+    LABELS "integration-tests"
+    PRELOAD "${PRELOAD_ENV}"
+    FIXTURES_SETUP rocprofv3-test-counter-collection-kernel-filtering-cli-malformed-range)
+
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-counter-collection-kernel-filtering-cli-noninteger-range
+    COMMAND
+        sh -c
+        "$<TARGET_FILE:rocprofiler-sdk::rocprofv3> --pmc SQ_WAVES --kernel-include-regex '.*_kernel' --kernel-iteration-range '[a]' -T -d ${CMAKE_CURRENT_BINARY_DIR}/cli_noninteger_range -o out --output-format json -- $<TARGET_FILE:vector-ops> 8 1 2>&1 | grep 'Non-integer value detected'"
+    DEPENDS vector-ops
+    TIMEOUT 120
+    LABELS "integration-tests"
+    PRELOAD "${PRELOAD_ENV}"
+    FIXTURES_SETUP rocprofv3-test-counter-collection-kernel-filtering-cli-noninteger-range
+    )

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/kernel_filtering/conftest.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/kernel_filtering/conftest.py
@@ -86,6 +86,59 @@ def pytest_addoption(parser):
         help="Path to CSV file.",
     )
 
+    parser.addoption(
+        "--input-csv-iteration-range",
+        action="store",
+        help="Path to CSV file.",
+    )
+
+    parser.addoption(
+        "--input-json-iteration-range",
+        action="store",
+        help="Path to JSON file.",
+    )
+
+    parser.addoption(
+        "--kernel-iteration-range",
+        action="store",
+        help="Kernel iteration range passed on the command line.",
+    )
+
+    parser.addoption(
+        "--iteration-config",
+        action="store",
+        help="Path to the input config (JSON/YAML) whose per-pass "
+        "kernel_iteration_range is used to check captured dispatch counts.",
+    )
+
+    parser.addoption(
+        "--input-csv-file",
+        action="store",
+        help="Path to a generic CSV file (used by the CLI filter tests).",
+    )
+
+    parser.addoption(
+        "--input-json-file",
+        action="store",
+        help="Path to a generic JSON file (used by the CLI filter tests).",
+    )
+
+
+def tokenize(kernel_iteration_range):
+    range_str = kernel_iteration_range.replace("[", "").replace("]", "")
+    split_list = range_str.split(",")
+    _range = []
+    for split_string in split_list:
+        if "-" in split_string:
+            interval = split_string.split("-")
+            [
+                _range.append(i)
+                for i in list(range((int)(interval[0]), (int)(interval[1]) + 1))
+            ]
+        else:
+            _range.append(int(split_string))
+    return _range
+
 
 @pytest.fixture
 def input_csv_pass1(request):
@@ -120,6 +173,73 @@ def input_csv_pmc1(request):
     filename = request.config.getoption("--input-csv-pmc1")
     with open(filename, "r") as inp:
         return pd.read_csv(inp)
+
+
+@pytest.fixture
+def input_csv_iteration_range(request):
+    filename = request.config.getoption("--input-csv-iteration-range")
+    with open(filename, "r") as inp:
+        return pd.read_csv(inp)
+
+
+@pytest.fixture
+def input_csv_file(request):
+    filename = request.config.getoption("--input-csv-file")
+    with open(filename, "r") as inp:
+        return pd.read_csv(inp)
+
+
+@pytest.fixture
+def input_json_file(request):
+    filename = request.config.getoption("--input-json-file")
+    with open(filename, "r") as inp:
+        return dotdict(collapse_dict_list(json.load(inp)))
+
+
+@pytest.fixture
+def input_json_iteration_range(request):
+    filename = request.config.getoption("--input-json-iteration-range")
+    with open(filename, "r") as inp:
+        return dotdict(collapse_dict_list(json.load(inp)))
+
+
+@pytest.fixture
+def iteration_range(request):
+    kernel_iteration_range = request.config.getoption("--kernel-iteration-range")
+    return tokenize(kernel_iteration_range.strip())
+
+
+def _load_config_jobs(config_path):
+    if config_path.endswith((".yml", ".yaml")):
+        import yaml
+
+        with open(config_path, "r") as inp:
+            return yaml.safe_load(inp)["jobs"]
+    with open(config_path, "r") as inp:
+        return json.load(inp)["jobs"]
+
+
+def _iteration_range_for_pass(config_path, pass_index):
+    # match rocprofv3: a YAML list of ranges joins with ", " like the CLI
+    kernel_iteration_range = _load_config_jobs(config_path)[pass_index].get(
+        "kernel_iteration_range", ""
+    )
+    if isinstance(kernel_iteration_range, list):
+        kernel_iteration_range = ", ".join(kernel_iteration_range)
+    kernel_iteration_range = kernel_iteration_range.strip()
+    if not kernel_iteration_range:
+        return None
+    return tokenize(kernel_iteration_range)
+
+
+@pytest.fixture
+def iteration_range_pass1(request):
+    return _iteration_range_for_pass(request.config.getoption("--iteration-config"), 0)
+
+
+@pytest.fixture
+def iteration_range_pass2(request):
+    return _iteration_range_for_pass(request.config.getoption("--iteration-config"), 1)
 
 
 @pytest.fixture

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/kernel_filtering/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/kernel_filtering/validate.py
@@ -28,6 +28,8 @@ import numpy as np
 import pandas as pd
 import re
 
+from collections import defaultdict
+
 
 def unique(lst):
     return list(set(lst))
@@ -62,6 +64,100 @@ def validate_csv(df, kernel_list, counter_name):
     assert len(df["Counter_Value"]) > 0
     assert df["Counter_Name"].str.contains(counter_name).all()
     assert (df["Counter_Value"].astype(int).values > 0).all()
+
+
+def validate_csv_per_agent_iteration_count(df, kernel_list, iteration_range):
+
+    # range is applied per kernel per device: each (kernel, agent) pair must have
+    # exactly one row per requested iteration (device-count independent)
+    if iteration_range is None:
+        pytest.skip("input config has no kernel_iteration_range to validate")
+
+    expected_count = len(iteration_range)
+    assert expected_count > 0
+
+    filtered = df[~df["Kernel_Name"].str.contains(r"__amd_rocclr_.*", regex=True)]
+    for kernel_name in kernel_list:
+        per_kernel = filtered[filtered["Kernel_Name"] == kernel_name]
+        assert not per_kernel.empty, f"no rows captured for {kernel_name}"
+        for agent_id, per_agent in per_kernel.groupby("Agent_Id"):
+            assert len(per_agent) == expected_count, (
+                f"{kernel_name} on {agent_id} captured {len(per_agent)} "
+                f"dispatches, expected {expected_count} (iteration range "
+                f"{sorted(iteration_range)})"
+            )
+
+
+def validate_json_iteration_range(json_data, kernel_list, iteration_range):
+
+    # kernel_dispatch is the unfiltered launch trace, counter_collection the
+    # selected dispatches; assert the selected per-kernel ordinals equal the range
+    data = json_data["rocprofiler-sdk-tool"]
+    counter_collection_data = data["callback_records"]["counter_collection"]
+    kernel_dispatch_data = data["buffer_records"]["kernel_dispatch"]
+
+    def get_kernel_name(kernel_id):
+        return data["kernel_symbols"][kernel_id]["formatted_kernel_name"]
+
+    # the range is applied per kernel per device, so ordinals are counted within
+    # each (kernel, agent) pair rather than across the whole run
+    targeted_dispatches = []
+    for dispatch in kernel_dispatch_data:
+        dispatch_info = dispatch["dispatch_info"]
+        kernel_name = get_kernel_name(dispatch_info["kernel_id"])
+        if kernel_name in kernel_list:
+            targeted_dispatches.append(
+                (
+                    dispatch_info["dispatch_id"],
+                    kernel_name,
+                    dispatch_info["agent_id"]["handle"],
+                )
+            )
+
+    # assign each dispatch its 1-based ordinal in dispatch_id order
+    launches_seen = defaultdict(int)
+    ordinal_by_dispatch_id = {}
+    key_by_dispatch_id = {}
+    for dispatch_id, kernel_name, agent_handle in sorted(targeted_dispatches):
+        key = (kernel_name, agent_handle)
+        launches_seen[key] += 1
+        ordinal_by_dispatch_id[dispatch_id] = launches_seen[key]
+        key_by_dispatch_id[dispatch_id] = key
+
+    assert launches_seen, f"no launches recorded for {kernel_list}"
+
+    # need more launches than the range so ordinals are recoverable
+    expected_ordinals = set(iteration_range)
+    for key, launches in launches_seen.items():
+        assert launches > len(expected_ordinals), (
+            f"{key[0]} on agent {key[1]} launched {launches} times; expected more "
+            f"than the {len(expected_ordinals)} requested iterations so original "
+            "launch ordinals can be recovered"
+        )
+
+    # list, not set, so duplicate records are visible
+    captured_ordinals = defaultdict(list)
+    for counter in counter_collection_data:
+        dispatch_id = counter["dispatch_data"]["dispatch_info"]["dispatch_id"]
+        key = key_by_dispatch_id.get(dispatch_id)
+        if key is None:
+            continue
+        captured_ordinals[key].append(ordinal_by_dispatch_id[dispatch_id])
+
+    assert set(captured_ordinals) == set(launches_seen), (
+        f"captured kernel/agent pairs {sorted(captured_ordinals)} do not match "
+        f"the launched pairs {sorted(launches_seen)}"
+    )
+
+    for key, ordinals in captured_ordinals.items():
+        assert set(ordinals) == expected_ordinals, (
+            f"{key[0]} on agent {key[1]} captured iterations {sorted(set(ordinals))}, "
+            f"expected {sorted(expected_ordinals)}"
+        )
+        assert len(ordinals) == len(expected_ordinals), (
+            f"{key[0]} on agent {key[1]} captured {len(ordinals)} records for "
+            f"{len(expected_ordinals)} requested iterations {sorted(expected_ordinals)}"
+        )
 
 
 def validate_json(json_data, counter_name, check_dispatch):
@@ -123,9 +219,14 @@ def validate_json(json_data, counter_name, check_dispatch):
         assert di_expect == di_uniq
 
 
-def test_validate_counter_collection_csv_pass1(input_csv_pass1: pd.DataFrame):
+def test_validate_counter_collection_csv_pass1(
+    input_csv_pass1: pd.DataFrame, iteration_range_pass1
+):
     kernel_list = sorted(["addition_kernel", "subtract_kernel", "divide_kernel"])
     validate_csv(input_csv_pass1, kernel_list, "SQ_WAVES")
+    validate_csv_per_agent_iteration_count(
+        input_csv_pass1, kernel_list, iteration_range_pass1
+    )
 
 
 def test_validate_counter_collection_csv_pmc1(input_csv_pmc1: pd.DataFrame):
@@ -133,11 +234,39 @@ def test_validate_counter_collection_csv_pmc1(input_csv_pmc1: pd.DataFrame):
     validate_csv(input_csv_pmc1, kernel_list, "SQ_WAVES")
 
 
-def test_validate_counter_collection_csv_pass2(input_csv_pass2: pd.DataFrame):
+def test_validate_counter_collection_csv_iteration_range(
+    input_csv_iteration_range: pd.DataFrame, iteration_range
+):
+    kernel_list = sorted(
+        ["addition_kernel", "subtract_kernel", "multiply_kernel", "divide_kernel"]
+    )
+    validate_csv(input_csv_iteration_range, kernel_list, "SQ_WAVES")
+    validate_csv_per_agent_iteration_count(
+        input_csv_iteration_range, kernel_list, iteration_range
+    )
+
+
+def test_validate_counter_collection_json_iteration_range(
+    input_json_iteration_range, iteration_range
+):
+    kernel_list = sorted(
+        ["addition_kernel", "subtract_kernel", "multiply_kernel", "divide_kernel"]
+    )
+    validate_json_iteration_range(
+        input_json_iteration_range, kernel_list, iteration_range
+    )
+
+
+def test_validate_counter_collection_csv_pass2(
+    input_csv_pass2: pd.DataFrame, iteration_range_pass2
+):
     kernel_list = sorted(
         ["addition_kernel", "subtract_kernel", "multiply_kernel", "divide_kernel"]
     )
     validate_csv(input_csv_pass2, kernel_list, "GRBM_COUNT")
+    validate_csv_per_agent_iteration_count(
+        input_csv_pass2, kernel_list, iteration_range_pass2
+    )
 
 
 def test_validate_counter_collection_csv_pass3(input_csv_pass3: pd.DataFrame):
@@ -166,6 +295,79 @@ def test_validate_counter_collection_json_pass3(input_json_pass3):
 
 def test_validate_counter_collection_json_pass4(input_json_pass4):
     validate_json(input_json_pass4, "SQ_WAVES", False)
+
+
+# --------------------------------------------------------------------------- #
+# CLI filter coverage (kernel-include / kernel-exclude / kernel-iteration-range
+# passed directly on the command line, plus negative / edge-case behavior)
+# --------------------------------------------------------------------------- #
+
+
+def _non_rocclr(df):
+    return df[~df["Kernel_Name"].astype(str).str.contains(r"__amd_rocclr_.*", regex=True)]
+
+
+def validate_csv_present_absent(df, present_kernels, absent_literals, counter_name):
+    assert not df.empty
+    filtered = _non_rocclr(df)
+    names = sorted(filtered["Kernel_Name"].unique().tolist())
+    assert names == sorted(present_kernels), f"unexpected kernel set: {names}"
+    for absent in absent_literals:
+        assert (
+            not df["Kernel_Name"].astype(str).str.contains(absent, regex=False).any()
+        ), f"'{absent}' should not appear anywhere in the output"
+    assert filtered["Counter_Name"].str.contains(counter_name).all()
+    assert (filtered["Counter_Value"].astype(int).values > 0).all()
+
+
+def test_validate_cli_single_kernel_csv(input_csv_file, iteration_range):
+    # --kernel-include-regex narrows to one kernel; the other three must not
+    # appear anywhere, and the range must limit each (kernel, agent) pair.
+    kernel_list = ["addition_kernel"]
+    absent = ["subtract_kernel", "multiply_kernel", "divide_kernel"]
+    validate_csv_present_absent(input_csv_file, kernel_list, absent, "SQ_WAVES")
+    validate_csv_per_agent_iteration_count(input_csv_file, kernel_list, iteration_range)
+
+
+def test_validate_cli_single_kernel_json(input_json_file, iteration_range):
+    # exact-iteration (both-direction) proof for the single included kernel
+    validate_json_iteration_range(input_json_file, ["addition_kernel"], iteration_range)
+
+
+def test_validate_cli_exclude_csv(input_csv_file):
+    # include everything, exclude one kernel: the excluded name must be gone
+    kernel_list = ["addition_kernel", "subtract_kernel", "divide_kernel"]
+    validate_csv_present_absent(
+        input_csv_file, kernel_list, ["multiply_kernel"], "SQ_WAVES"
+    )
+
+
+def test_validate_cli_mangled_csv(input_csv_file):
+    # regex matches the mangled symbol as a substring; names stay mangled
+    filtered = _non_rocclr(input_csv_file)
+    names = set(filtered["Kernel_Name"].astype(str).unique())
+    assert len(names) >= 1, "expected the mangled addition kernel to be profiled"
+    for name in names:
+        assert "addition_kernel" in name
+        assert re.match(r"_Z[0-9]+addition_kernel", name), f"expected mangled: {name}"
+        assert name != "addition_kernel", "expected mangled, not truncated, name"
+    for other in ("subtract", "multiply", "divide"):
+        assert (
+            not input_csv_file["Kernel_Name"]
+            .astype(str)
+            .str.contains(other, regex=False)
+            .any()
+        ), f"'{other}' kernel should not be profiled"
+
+
+def test_validate_cli_empty_result_json(input_json_file):
+    # zero counter records but no crash; kernel_dispatch proves the app ran
+    data = input_json_file["rocprofiler-sdk-tool"]
+    counter_collection_data = data["callback_records"]["counter_collection"]
+    assert (
+        len(counter_collection_data) == 0
+    ), f"expected zero counter_collection records, got {len(counter_collection_data)}"
+    assert len(data["buffer_records"]["kernel_dispatch"]) > 0
 
 
 if __name__ == "__main__":

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/range_filtering/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/range_filtering/validate.py
@@ -28,6 +28,9 @@ import numpy as np
 import pandas as pd
 import re
 
+# the profiled kernel; internal rocclr helper kernels are ignored
+TARGET_KERNEL = "transpose"
+
 
 def unique(lst):
     return list(set(lst))
@@ -40,25 +43,60 @@ def validate_json(input_data):
     data = json_data["rocprofiler-sdk-tool"]
     counter_collection_data = data["callback_records"]["counter_collection"]
     kernel_dispatch_data = data["buffer_records"]["kernel_dispatch"]
-    dispatch_ids = {}
 
     def get_kernel_name(kernel_id):
         return data["kernel_symbols"][kernel_id]["formatted_kernel_name"]
 
-    iteration = 1
-    for dispatch in kernel_dispatch_data:
-        dispatch_info = dispatch["dispatch_info"]
-        kernel_name = get_kernel_name(dispatch_info["kernel_id"])
-        if kernel_name == "transpose" and iteration in iteration_list:
-            dispatch_ids[dispatch_info["dispatch_id"]] = dispatch_info
-        if kernel_name == "transpose":
-            iteration = iteration + 1
+    expected_iterations = set(iteration_list)
+    assert len(expected_iterations) > 0, "iteration range must not be empty"
 
+    # recover each launch's 1-based ordinal from the unfiltered kernel_dispatch
+    # trace, ordered by dispatch_id
+    launch_dispatch_ids = sorted(
+        dispatch["dispatch_info"]["dispatch_id"]
+        for dispatch in kernel_dispatch_data
+        if get_kernel_name(dispatch["dispatch_info"]["kernel_id"]) == TARGET_KERNEL
+    )
+    ordinal_by_dispatch_id = {
+        dispatch_id: ordinal + 1
+        for ordinal, dispatch_id in enumerate(launch_dispatch_ids)
+    }
+
+    # need more launches than the range so the ordinals are recoverable
+    assert len(launch_dispatch_ids) > len(expected_iterations), (
+        f"{TARGET_KERNEL} launched {len(launch_dispatch_ids)} times; expected "
+        f"more than the {len(expected_iterations)} requested iterations so the "
+        "original launch ordinals can be recovered"
+    )
+
+    # map each counter-collected dispatch back to its ordinal (list keeps dups)
+    captured_ordinals = []
     for counter in counter_collection_data:
-        dispatch_data = counter["dispatch_data"]["dispatch_info"]
-        dispatch_id = dispatch_data["dispatch_id"]
-        if dispatch_id in dispatch_ids.keys():
-            assert dispatch_data == dispatch_ids[dispatch_id]
+        dispatch_info = counter["dispatch_data"]["dispatch_info"]
+        kernel_name = get_kernel_name(dispatch_info["kernel_id"])
+        if kernel_name != TARGET_KERNEL:
+            continue
+        dispatch_id = dispatch_info["dispatch_id"]
+        assert dispatch_id in ordinal_by_dispatch_id, (
+            f"counter record dispatch_id {dispatch_id} not found in the "
+            f"{TARGET_KERNEL} kernel_dispatch trace"
+        )
+        captured_ordinals.append(ordinal_by_dispatch_id[dispatch_id])
+
+    captured_set = set(captured_ordinals)
+
+    # captured iterations must equal the requested set exactly
+    assert captured_set == expected_iterations, (
+        f"{TARGET_KERNEL} captured iterations {sorted(captured_set)}, "
+        f"expected {sorted(expected_iterations)}"
+    )
+
+    # exactly one record per requested iteration (no duplicates, no misses)
+    assert len(captured_ordinals) == len(expected_iterations), (
+        f"{TARGET_KERNEL} captured {len(captured_ordinals)} records "
+        f"(iterations {sorted(captured_ordinals)}); expected exactly "
+        f"{len(expected_iterations)} ({sorted(expected_iterations)})"
+    )
 
 
 def test_validate_counter_collection_pass1(input_json_pass1):


### PR DESCRIPTION
## Motivation

The `rocprofv3` PMC kernel filters (`--kernel-include-regex`, `--kernel-exclude-regex`, `--kernel-iteration-range`) were under-tested: the iteration-range checks only compared subsets (a filter that profiled *every* launch still passed), several flag combinations had no CLI coverage, and the range-parsing / iteration-counting logic had no unit tests.

## Technical Details

**Integration coverage (`tests/rocprofv3/counter-collection/`):**

- **range_filtering** – validator now asserts the *exact* set of profiled iterations per pass, plus an exact record count so duplicates cannot hide behind the set comparison.
- **kernel_filtering** – captured dispatch counts are tied to the configured `kernel_iteration_range`, read from the input config so the CLI argument and the assertion cannot drift. The range applies per kernel per device, so both the CSV and JSON validators count launch ordinals within each `(kernel, agent)` pair — the assertions hold on a multi-GPU host, not just where the workload pins one device.
- **CLI tests** for: include + iteration range; multi-token range (`"1" "2"` ≡ `"[1-2]"`); exclude; exclude-cancels-the-include-set; `--mangled-kernels` vs `--truncate-kernels`; empty-match regex; out-of-bounds range; malformed / non-integer range aborts.

**Unit tests (GPU-independent):**

- Extracted `get_kernel_filter_range()` (from `config.cpp`) and the `is_targeted_kernel()` decision core (from `tool.cpp`) into `kernel_filter_range.*` / `kernel_iteration_filter.*`; `is_targeted_kernel()` is now a locking wrapper.
- **The locking also changed:** the iteration increment and the profile/skip decision now share one write lock. Previously they were separate acquisitions, so two concurrent dispatches of the same kernel could read the same iteration number — with range `{1}`, both skip and iteration 1 is never captured. That race would make the new exact-iteration assertions flaky. Decision logic is unchanged, verified against the old implementation over an exhaustive set of range/mode/interleaving cases.
- New `tool-tests` gtest target: range parsing (with death tests for malformed / non-integer input) and 1-based per-kernel counting (PMC all-iterations, thread-trace first-only, exact range, independent per-kernel counters). Only the test sources go to `rocprofiler_add_unit_test(SOURCES ...)`, since that list is installed into the generated `tool-tests.cmake`; including the tool sources embedded build-tree paths and broke the shipped test package.

## JIRA ID

JIRA ID : AIROCVAL-61

## Test Plan

```bash
cmake -S projects/rocprofiler-sdk -B build \
  -DCMAKE_BUILD_TYPE=RelWithDebInfo -DROCPROFILER_BUILD_TESTS=ON -DGPU_TARGETS=gfx942
cmake --build build -j

ctest --test-dir build -R "kernel-filtering|range-filtering" --output-on-failure
ctest --test-dir build -R "unit.kernel_filter_range|unit.kernel_iteration_filter" --output-on-failure
ctest --test-dir build -R "counter-collection"   # regression scope
```

## Test Result

gfx942 (MI300X): integration **45/45**, unit **17/17**, both passing twice back-to-back. Wider `counter-collection` suite **102/102**.

The full `rocprofv3` sweep shows 12 failures / 437, all from two pre-existing root causes (an ATT attachment timeout and a HIP-graph segfault, each cascading to its dependent validates). Both reproduce identically on an unmodified `develop` build.

Non-vacuity checked by mutating real output: a dropped dispatch, a duplicated record, a relabelled dispatch id, and a never-collected counter each fail with a per-`(kernel, agent)` diagnostic.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests