### PR TITLE
ci: enable gfx125x (MI455) build-only in therock-ci presubmit

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -136,7 +136,8 @@ jobs:
     name: "Test"
     needs: [therock-build-linux]
     # TODO(TheRock#3288): Re-enable gfx950-dcgpu runners once we get more capacity
-    if: ${{ inputs.amdgpu_families != 'gfx950-dcgpu' }}
+    # gfx125X-dcgpu: build only, no test runners available yet
+    if: ${{ inputs.amdgpu_families != 'gfx950-dcgpu' && inputs.amdgpu_families != 'gfx125X-dcgpu' }}
     uses: ./.github/workflows/therock-test-packages.yml
     with:
       projects_to_test: ${{ inputs.projects_to_test }}

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Fetch Linux targets for build and test
         env:
           THEROCK_PACKAGE_PLATFORM: "linux"
-          AMDGPU_FAMILIES: ${{ inputs.linux_amdgpu_families || 'gfx94X, gfx950' }}
+          AMDGPU_FAMILIES: ${{ inputs.linux_amdgpu_families || 'gfx94X, gfx950, gfx125x' }}
           CI_CONFIG_PATH: ci-config
         id: configure_linux
         run: python ./TheRock/build_tools/github_actions/fetch_package_targets.py


### PR DESCRIPTION
Add gfx125x to the default Linux AMDGPU_FAMILIES in therock-ci.yml so it is included in the build matrix alongside gfx94X and gfx950. Skip the test stage for gfx125X-dcgpu in therock-ci-linux.yml since no test runners are available yet (build-only).

## Motivation

To catch the gfx1250 compilation issues for rocm-systesm in pre-commit stage itself.

## Technical Details

Only enabling build gate , Test gate will be enabled as part of seperate PR will be restricted to runtime components only and in non-blockigmode

## Test plan

  - [ ] Verify the setup job emits a `gfx125X-dcgpu` entry in `linux_package_targets`
  - [ ] Verify a build job is triggered for gfx125X-dcgpu
  - [ ] Verify no test job is triggered for gfx125X-dcgpu