### PR TITLE
ci: enable gfx125x tests conditionally for runtime subtree changes

### DIFF
--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -162,6 +162,24 @@ def check_for_non_skippable_path(paths: Optional[Iterable[str]]) -> bool:
     return any(not is_path_skippable(p) for p in paths)
 
 
+GFX125X_TEST_SUBTREES = {
+    "projects/hip",
+    "projects/clr",
+    "projects/hip-tests",
+    "projects/rocr-runtime",
+}
+
+
+def check_gfx125x_test_changes(modified_paths: Optional[Iterable[str]]) -> bool:
+    """Returns true if any files under the runtime subtrees that gate gfx125x tests were modified."""
+    if modified_paths is None:
+        return False
+    return any(
+        any(path.startswith(subtree + "/") or path == subtree for subtree in GFX125X_TEST_SUBTREES)
+        for path in modified_paths
+    )
+
+
 def check_rccl_changes(modified_paths: Optional[Iterable[str]]) -> bool:
     """Returns true if any files under projects/rccl/ were modified."""
     if modified_paths is None:
@@ -403,6 +421,18 @@ def run(args):
                 outputs["run_linux_rccl_ci"] = "true"
             else:
                 outputs["run_linux_rccl_ci"] = "false"
+
+        # Determine if gfx125x tests should run: only when runtime subtrees are touched.
+        # On nightly or workflow_dispatch (all subtrees), always enable tests.
+        if args.get("is_nightly") or args.get("is_workflow_dispatch"):
+            outputs["run_gfx125x_tests"] = "true"
+        else:
+            base_ref = args.get("base_ref")
+            modified_paths = get_modified_paths(base_ref)
+            if check_gfx125x_test_changes(modified_paths):
+                outputs["run_gfx125x_tests"] = "true"
+            else:
+                outputs["run_gfx125x_tests"] = "false"
 
     set_github_output(outputs)
     return outputs

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -19,6 +19,10 @@ on:
       build_runs_on:
         type: string
         default: "azure-linux-scale-rocm"
+      run_gfx125x_tests:
+        type: boolean
+        default: false
+        description: "Enable tests for gfx125X-dcgpu. Only set when runtime subtrees (hip, clr, hip-tests, rocr-runtime) are touched."
 
 
 permissions:
@@ -136,8 +140,8 @@ jobs:
     name: "Test"
     needs: [therock-build-linux]
     # TODO(TheRock#3288): Re-enable gfx950-dcgpu runners once we get more capacity
-    # gfx125X-dcgpu: build only, no test runners available yet
-    if: ${{ inputs.amdgpu_families != 'gfx950-dcgpu' && inputs.amdgpu_families != 'gfx125X-dcgpu' }}
+    # gfx125X-dcgpu: run tests only when runtime subtrees (hip, clr, hip-tests, rocr-runtime) are touched
+    if: ${{ inputs.amdgpu_families != 'gfx950-dcgpu' && (inputs.amdgpu_families != 'gfx125X-dcgpu' || inputs.run_gfx125x_tests) }}
     uses: ./.github/workflows/therock-test-packages.yml
     with:
       projects_to_test: ${{ inputs.projects_to_test }}

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -47,6 +47,7 @@ jobs:
       linux_projects: ${{ steps.linux_projects.outputs.projects }}
       windows_projects: ${{ steps.windows_projects.outputs.projects }}
       run_linux_rccl_ci: ${{ steps.linux_projects.outputs.run_linux_rccl_ci }}
+      run_gfx125x_tests: ${{ steps.linux_projects.outputs.run_gfx125x_tests }}
       package_version: ${{ steps.rocm_package_version.outputs.rocm_package_version }}
       linux_package_targets: ${{ steps.configure_linux.outputs.package_targets }}
       windows_package_targets: ${{ steps.configure_windows.outputs.package_targets }}
@@ -156,6 +157,7 @@ jobs:
       amdgpu_families: ${{ matrix.target_bundle.amdgpu_family }}
       test_runs_on: ${{ matrix.target_bundle.test_machine }}
       build_runs_on: ${{ needs.setup.outputs.linux_build_runs_on }}
+      run_gfx125x_tests: ${{ needs.setup.outputs.run_gfx125x_tests == 'true' }}
 
   therock-rccl-ci-linux:
     name: TheRock RCCL CI Linux


### PR DESCRIPTION
Add run_gfx125x_tests flag that gates the gfx125X-dcgpu test stage on whether the PR touches any of the runtime subtrees: projects/hip, projects/clr, projects/hip-tests, or projects/rocr-runtime.


## Motivation

Enabling tests for only for hip/clr and rocr component due to lack of test nodes

## Technical Details

- therock_configure_ci.py: detect runtime subtree changes and emit run_gfx125x_tests output (true/false); always true on nightly and workflow_dispatch
- therock-ci.yml: propagate run_gfx125x_tests from setup outputs into the therock-ci-linux workflow call
- therock-ci-linux.yml: add run_gfx125x_tests boolean input and use it in the test job condition alongside the existing gfx950-dcgpu skip

## Test Plan

  - [ ] PR touching `projects/hip` → gfx125X-dcgpu test job runs
  - [ ] PR touching only `projects/rocm-smi-lib` → gfx125X-dcgpu test job skipped
  - [ ] Nightly / `workflow_dispatch` → gfx125X-dcgpu test job always runs
