### PR TITLE
fix(ci): format TheRock config resolver

### DIFF
--- a/.github/actions/rocprofiler-sdk-util/resolve-ci-config/resolve_ci_config.py
+++ b/.github/actions/rocprofiler-sdk-util/resolve-ci-config/resolve_ci_config.py
@@ -22,11 +22,7 @@ def load_gfx94x_linux_config(config_path: Path) -> dict[str, Any]:
         from ci_config_api import load_config_v1
 
         config = load_config_v1(config_path)
-        return (
-            config.get_gpu_families(["presubmit"])
-            .get("gfx94x", {})
-            .get("linux", {})
-        )
+        return config.get_gpu_families(["presubmit"]).get("gfx94x", {}).get("linux", {})
     except Exception as exc:
         warn(f"Failed to load CI config: {exc}. Using fallback runner labels.")
         return {}


### PR DESCRIPTION
## Motivation

The CI config resolver added in 3475e8fbfd3d1960a81a5ad72d67233931dd9e4f does not pass a Black formatting check.

## Technical Details

Format `.github/actions/rocprofiler-sdk-util/resolve-ci-config/resolve_ci_config.py` with Black. This is a formatting-only change.

Note that after #8157, rocjitsu's CI won't detect black formatting issue outside of rocjitsu again. 

## Test Plan

Run Black and pre-commit on the changed file.

## Test Result

- Ran Black from the rocm-systems worktree virtualenv:
  - `black, 26.5.1 (compiled: yes)`
  - `Python (CPython) 3.12.3`
  - Installed from PyPI with `pip install black`
- The Black version matches the root `.pre-commit-config.yaml` pin:
  - `https://github.com/psf/black`
  - `rev: 26.5.1`
- `pre-commit run --files .github/actions/rocprofiler-sdk-util/resolve-ci-config/resolve_ci_config.py --show-diff-on-failure`

This is PR #8156