### PR TITLE
fix(rocjitsu): check formatting files from PR head

### DIFF
--- a/.github/workflows/rocjitsu-formatting.yml
+++ b/.github/workflows/rocjitsu-formatting.yml
@@ -43,10 +43,11 @@ jobs:
           MERGE_BASE=$(git merge-base ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }})
 
           # List files that were added, copied, modified, or renamed in
-          # the PR, then keep only those present on disk. The sparse
-          # checkout determines which files are on disk, so this is how
-          # we scope the check to the projects listed above.
-          FILES=$(git diff --name-only --diff-filter=ACMR "$MERGE_BASE" HEAD \
+          # the PR, then keep only those present on disk. HEAD is the
+          # pull-request merge commit in GitHub Actions, so diff against
+          # the PR head SHA directly to avoid checking files that changed
+          # only on the target branch.
+          FILES=$(git diff --name-only --diff-filter=ACMR "$MERGE_BASE" ${{ github.event.pull_request.head.sha }} \
             | while IFS= read -r f; do if [ -f "$f" ]; then echo "$f"; fi; done)
 
           if [ -z "$FILES" ]; then


### PR DESCRIPTION


## Motivation

The `rocjitsu-formatting` workflow currently computes changed files with `git diff <merge-base> HEAD`.

In GitHub Actions `pull_request` workflows, `HEAD` is the synthetic merge commit. That can include files changed only on the target branch, causing unrelated base-branch formatting changes to fail a PR.

## Technical Details

Change the changed-file calculation to diff against `${{ github.event.pull_request.head.sha }}` instead of `HEAD`.

This keeps the formatting file list scoped to files changed by the PR branch.

## Test Plan

Run pre-commit on the modified workflow file.

## Test Result

- `pre-commit run --files .github/workflows/rocjitsu-formatting.yml --show-diff-on-failure`

This PR is #8157
