### PR TITLE
ci(lstt-formatting): emit pre-commit check to satisfy systems-pr-bot

### DIFF
--- a/.github/workflows/lstt-formatting.yml
+++ b/.github/workflows/lstt-formatting.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  pre-commit:
+  format:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -50,3 +50,19 @@ jobs:
           --color=always
           --from-ref origin/${{ github.event.pull_request.base.ref || 'develop' }}
           --to-ref HEAD
+
+  # Emit a single check named "pre-commit" so systems-pr-bot's required check
+  # (required_check_runs: [pre-commit]) is satisfied for these projects, whose
+  # per-project legs above are named amdsmi/rdc/rocm-smi-lib, not "pre-commit".
+  pre-commit:
+    needs: format
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Confirm all project pre-commit runs passed
+        run: |
+          if [ "${{ needs.format.result }}" != "success" ]; then
+            echo "A project pre-commit leg did not pass: ${{ needs.format.result }}"
+            exit 1
+          fi
+          echo "All project pre-commit legs passed."


### PR DESCRIPTION
## Motivation

`therock-pr-bot` gates PRs on a check named exactly `pre-commit`
(`tools/systems_pr_bot/policy.yml` -> `required_check_runs: [pre-commit]`, matched by exact name). For amdsmi / rdc / rocm-smi-lib PRs, pre-commit runs via this workflow, but its matrix job used `name: ${{ matrix.project }}`, so the check runs are named `amdsmi` / `rdc` / `rocm-smi-lib` -- never `pre-commit`. The bot never finds `pre-commit`, polls for its full 900s timeout, and fails even when every policy row and every per-project pre-commit leg is green.

`rocprofiler-compute-formatting.yml` and `rocjitsu-formatting.yml` already satisfy the bot because their job is plainly named `pre-commit`; this aligns `lstt-formatting.yml` with that same contract.

## Technical Details

- Rename the matrix job `pre-commit` -> `format`. The per-project check names come from `name: ${{ matrix.project }}`, so `amdsmi` / `rdc` / `rocm-smi-lib` are unchanged.
- Add a small aggregate gate job `pre-commit` (`needs: format`, `if: always()`) that emits one check named `pre-commit`, failing if any project leg did not pass. This gives systems-pr-bot the exact check name it requires.

No change to what pre-commit actually runs per project.

## JIRA ID

Related PRs: #7721, #5264

## Test Plan

- This PR edits `.github/workflows/lstt-formatting.yml`, which is in the workflow's own `paths` filter, so it self-triggers: confirm the run now produces `amdsmi`, `rdc`, `rocm-smi-lib`, and `pre-commit` checks.
- After merge, re-run #7721 / #5264 and confirm `therock-pr-bot` turns green.

## Test Result

- To be confirmed by CI on this PR (expect the `pre-commit` check present and green).

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
