### PR TITLE
fix(rocprofiler-systems): Display missing CLI help topics

### DIFF
--- a/projects/rocprofiler-systems/source/bin/common/common_utils.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/common_utils.cpp
@@ -13,6 +13,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <iterator>
 #include <numeric>
@@ -521,32 +522,81 @@ line_contains_flag(const std::string& line, const std::string& flag)
 }
 }  // namespace
 
-const help_topic_map&
-get_help_topic_map()
+namespace
 {
-    static const help_topic_map map = {
-        { "preset", { "[PRESET OPTIONS]", "[DOMAIN OPTIONS]", "[EXPORT OPTIONS]" } },
-        { "general", { "[GENERAL OPTIONS]" } },
-        { "tracing", { "[TRACING OPTIONS]" } },
-        { "profiling", { "[PROFILE OPTIONS]" } },
-        { "output", { "[OUTPUT FORMAT OPTIONS]" } },
+// ---------------------------------------------------------------------------
+// Ordered source of truth for the group/domain help topic tables.
+//
+// Each group-topic entry carries everything the help system needs:
+//   * name     - the token accepted by --help=<name>
+//   * blurb    - the one-line description shown in the compact --help listing
+//   * sections - the option-section header(s) surfaced by --help=<name>
+//   * tools    - names of the tools ("run", "sample") whose compact
+//                listing should advertise this topic; empty means "all tools".
+//
+// get_help_topic_map() / get_domain_help_map() are derived views built from
+// these tables, and print_compact_help() iterates the same tables to render
+// the "Group topics"/"Domain topics" listing.
+// ---------------------------------------------------------------------------
+
+// Minimum column width for the topic name in the compact listing. The width is
+// grown at print time if a topic name would otherwise touch its blurb
+constexpr int k_topic_col_width = 13;
+
+struct group_topic_desc
+{
+    const char*                   name;
+    const char*                   blurb;
+    help_group_names              sections;
+    std::vector<std::string_view> tools;  // empty => shown for all tools
+};
+
+const std::vector<group_topic_desc>&
+group_topic_table()
+{
+    static const std::vector<group_topic_desc> table = {
+        { "preset",
+          "Preset, domain, and export options",
+          { "[PRESET OPTIONS]", "[DOMAIN OPTIONS]", "[EXPORT OPTIONS]" } },
+        { "general",
+          "General options (output, trace, profile)",
+          { "[GENERAL OPTIONS]" } },
+        { "tracing", "Tracing-specific options", { "[TRACING OPTIONS]" } },
+        { "profiling", "Profile output format options", { "[PROFILE OPTIONS]" } },
+        { "output",
+          "Output format selection (proto/rocpd/json/text)",
+          { "[OUTPUT FORMAT OPTIONS]" } },
         { "sampling",
+          "Sampling frequency and timer options",
           { "[GENERAL SAMPLING OPTIONS]", "[SAMPLING TIMER OPTIONS]",
             "[ADVANCED SAMPLING OPTIONS]" } },
-        { "process", { "[HOST/DEVICE (PROCESS SAMPLING) OPTIONS]" } },
-        { "counters", { "[HARDWARE COUNTER OPTIONS]" } },
-        { "backend", { "[BACKEND OPTIONS]" } },
-        { "debug", { "[DEBUG OPTIONS]" } },
-        { "execution", { "[EXECUTION OPTIONS]" } },
-        { "misc", { "[MISCELLANEOUS OPTIONS]" } },
+        { "process",
+          "Host/device process sampling options",
+          { "[HOST/DEVICE (PROCESS SAMPLING) OPTIONS]" } },
+        { "counters",
+          "Hardware counter options (CPU/GPU events)",
+          { "[HARDWARE COUNTER OPTIONS]" } },
+        { "backend", "Backend options (include/exclude)", { "[BACKEND OPTIONS]" } },
+        { "execution",
+          "Execution control options (e.g., --fork)",
+          { "[EXECUTION OPTIONS]" },
+          { "run" } },
+        { "debug", "Debug, logging, and verbosity options", { "[DEBUG OPTIONS]" } },
+        { "misc", "Miscellaneous options", { "[MISCELLANEOUS OPTIONS]" } },
     };
-    return map;
+    return table;
 }
 
-const domain_help_map&
-get_domain_help_map()
+struct domain_topic_desc
 {
-    static const domain_help_map map = {
+    const char*       name;
+    domain_help_entry info;
+};
+
+const std::vector<domain_topic_desc>&
+domain_topic_table()
+{
+    static const std::vector<domain_topic_desc> table = {
         { "gpu",
           { "GPU metrics, device sampling, GPU counters",
             { "--gpu", "-D", "--device", "--gpus", "--process-freq", "--process-wait",
@@ -566,6 +616,31 @@ get_domain_help_map()
           { "MPI, OpenMP, Kokkos, RCCL options",
             { "--parallel", "-I", "--include", "-E", "--exclude" } } },
     };
+    return table;
+}
+}  // namespace
+
+const help_topic_map&
+get_help_topic_map()
+{
+    static const help_topic_map map = [] {
+        help_topic_map result;
+        for(const auto& topic : group_topic_table())
+            result.emplace(topic.name, topic.sections);
+        return result;
+    }();
+    return map;
+}
+
+const domain_help_map&
+get_domain_help_map()
+{
+    static const domain_help_map map = [] {
+        domain_help_map result;
+        for(const auto& domain : domain_topic_table())
+            result.emplace(domain.name, domain.info);
+        return result;
+    }();
     return map;
 }
 
@@ -632,25 +707,44 @@ print_compact_help(std::string_view tool_name, std::ostream& out)
         << "\n"
         << "HELP TOPICS (use --help=<topic> for details)\n"
         << "\n"
-        << "  Group topics:\n"
-        << "    all          Full help output (all options)\n"
-        << "    preset       Preset, domain, and export options\n"
-        << "    general      General options (output, trace, profile)\n"
-        << "    tracing      Tracing-specific options\n"
-        << "    profiling    Profile output format options\n"
-        << "    sampling     Sampling frequency and timer options\n"
-        << "    process      Host/device process sampling options\n"
-        << "    counters     Hardware counter options (CPU/GPU events)\n"
-        << "    backend      Backend options (include/exclude)\n"
-        << "    debug        Debug, logging, and verbosity options\n"
-        << "    misc         Miscellaneous options\n"
-        << "\n"
-        << "  Domain topics:\n"
-        << "    gpu          GPU metrics, device sampling, GPU counters\n"
-        << "    cpu          CPU sampling, timers, CPU counters\n"
-        << "    rocm         ROCm API tracing options\n"
-        << "    parallel     MPI, OpenMP, Kokkos, RCCL options\n"
-        << "\n"
+        << "  Group topics:\n";
+
+    // Grow the name column if any topic name would otherwise touch its blurb.
+    // "all" is synthetic (emitted below) but still participates in alignment.
+    const int name_width = [] {
+        std::size_t longest = std::string_view{ "all" }.size();
+        for(const auto& topic : group_topic_table())
+            longest = std::max(longest, std::string_view{ topic.name }.size());
+        for(const auto& domain : domain_topic_table())
+            longest = std::max(longest, std::string_view{ domain.name }.size());
+        return std::max<int>(k_topic_col_width, static_cast<int>(longest) + 2);
+    }();
+
+    // A topic is listed when it targets no specific tool (empty => all tools)
+    // or explicitly names the current tool
+    auto shown_for_tool = [&](const std::vector<std::string_view>& tools) {
+        return tools.empty() ||
+               std::find(tools.begin(), tools.end(), tool_name) != tools.end();
+    };
+
+    const auto saved_flags = out.flags();
+    out << std::left;
+
+    // "all" is a synthetic entry (dumps the full parser help) rather than a
+    // registered topic, so it is emitted here rather than living in the table.
+    out << "    " << std::setw(name_width) << "all" << "Full help output (all options)\n";
+    for(const auto& topic : group_topic_table())
+    {
+        if(!shown_for_tool(topic.tools)) continue;
+        out << "    " << std::setw(name_width) << topic.name << topic.blurb << "\n";
+    }
+    out << "\n  Domain topics:\n";
+    for(const auto& domain : domain_topic_table())
+        out << "    " << std::setw(name_width) << domain.name << domain.info.description
+            << "\n";
+
+    out.flags(saved_flags);
+    out << "\n"
         << "EXAMPLES\n"
         << "  rocprof-sys-" << tool_name << " --preset=balanced -- ./myapp\n"
         << "  rocprof-sys-" << tool_name << " --preset=trace-hpc --rocm -- ./hpc_app\n"

--- a/projects/rocprofiler-systems/source/bin/common/common_utils.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/common_utils.cpp
@@ -541,14 +541,15 @@ namespace
 
 // Minimum column width for the topic name in the compact listing. The width is
 // grown at print time if a topic name would otherwise touch its blurb
-constexpr int k_topic_col_width = 13;
+constexpr int topic_col_width = 13;
+constexpr int name_blurb_gap  = 2;
 
 struct group_topic_desc
 {
     const char*                   name;
     const char*                   blurb;
     help_group_names              sections;
-    std::vector<std::string_view> tools;  // empty => shown for all tools
+    std::vector<std::string_view> tools{};  // empty => shown for all tools
 };
 
 const std::vector<group_topic_desc>&
@@ -618,6 +619,17 @@ domain_topic_table()
     };
     return table;
 }
+
+// A topic is listed for a tool when it targets no specific tool (empty =>
+// all tools) or explicitly names the current tool. Shared by the compact
+// --help listing and the unknown-topic error so both stay in sync (e.g. the
+// 'execution' topic is gated to rocprof-sys-run only).
+bool
+shown_for_tool(const std::vector<std::string_view>& tools, std::string_view tool_name)
+{
+    return tools.empty() ||
+           std::find(tools.begin(), tools.end(), tool_name) != tools.end();
+}
 }  // namespace
 
 const help_topic_map&
@@ -682,6 +694,40 @@ print_see_also(std::string_view topic, std::ostream& out)
 }
 
 void
+print_topic_listing(std::string_view tool_name, std::ostream& out)
+{
+    // Grow the name column if any topic name would otherwise touch its blurb.
+    // "all" is synthetic (emitted below) but still participates in alignment.
+    const int name_width = [] {
+        std::size_t longest = std::string_view{ "all" }.size();
+        for(const auto& topic : group_topic_table())
+            longest = std::max(longest, std::string_view{ topic.name }.size());
+        for(const auto& domain : domain_topic_table())
+            longest = std::max(longest, std::string_view{ domain.name }.size());
+        return std::max<int>(topic_col_width, static_cast<int>(longest) + name_blurb_gap);
+    }();
+
+    const auto saved_flags = out.flags();
+    out << std::left;
+
+    out << "  Group topics:\n";
+    // "all" is a synthetic entry (dumps the full parser help) rather than a
+    // registered topic, so it is emitted here rather than living in the table.
+    out << "    " << std::setw(name_width) << "all" << "Full help output (all options)\n";
+    for(const auto& topic : group_topic_table())
+    {
+        if(!shown_for_tool(topic.tools, tool_name)) continue;
+        out << "    " << std::setw(name_width) << topic.name << topic.blurb << "\n";
+    }
+    out << "\n  Domain topics:\n";
+    for(const auto& domain : domain_topic_table())
+        out << "    " << std::setw(name_width) << domain.name << domain.info.description
+            << "\n";
+
+    out.flags(saved_flags);
+}
+
+void
 print_compact_help(std::string_view tool_name, std::ostream& out)
 {
     out << "Usage: rocprof-sys-" << tool_name << " [OPTIONS] -- <command> [args...]\n"
@@ -706,44 +752,10 @@ print_compact_help(std::string_view tool_name, std::ostream& out)
         << "  -v, --verbose          Increase verbosity\n"
         << "\n"
         << "HELP TOPICS (use --help=<topic> for details)\n"
-        << "\n"
-        << "  Group topics:\n";
+        << "\n";
 
-    // Grow the name column if any topic name would otherwise touch its blurb.
-    // "all" is synthetic (emitted below) but still participates in alignment.
-    const int name_width = [] {
-        std::size_t longest = std::string_view{ "all" }.size();
-        for(const auto& topic : group_topic_table())
-            longest = std::max(longest, std::string_view{ topic.name }.size());
-        for(const auto& domain : domain_topic_table())
-            longest = std::max(longest, std::string_view{ domain.name }.size());
-        return std::max<int>(k_topic_col_width, static_cast<int>(longest) + 2);
-    }();
+    print_topic_listing(tool_name, out);
 
-    // A topic is listed when it targets no specific tool (empty => all tools)
-    // or explicitly names the current tool
-    auto shown_for_tool = [&](const std::vector<std::string_view>& tools) {
-        return tools.empty() ||
-               std::find(tools.begin(), tools.end(), tool_name) != tools.end();
-    };
-
-    const auto saved_flags = out.flags();
-    out << std::left;
-
-    // "all" is a synthetic entry (dumps the full parser help) rather than a
-    // registered topic, so it is emitted here rather than living in the table.
-    out << "    " << std::setw(name_width) << "all" << "Full help output (all options)\n";
-    for(const auto& topic : group_topic_table())
-    {
-        if(!shown_for_tool(topic.tools)) continue;
-        out << "    " << std::setw(name_width) << topic.name << topic.blurb << "\n";
-    }
-    out << "\n  Domain topics:\n";
-    for(const auto& domain : domain_topic_table())
-        out << "    " << std::setw(name_width) << domain.name << domain.info.description
-            << "\n";
-
-    out.flags(saved_flags);
     out << "\n"
         << "EXAMPLES\n"
         << "  rocprof-sys-" << tool_name << " --preset=balanced -- ./myapp\n"
@@ -776,7 +788,6 @@ print_help_for_topic(const std::string& captured, std::string_view topic,
         size_t      end;
         std::string header;
     };
-    size_t               preamble_end = lines.size();
     std::vector<Section> sections;
 
     for(size_t line_idx = 0; line_idx < lines.size(); ++line_idx)
@@ -784,10 +795,7 @@ print_help_for_topic(const std::string& captured, std::string_view topic,
         std::string bracket_name;
         if(is_section_header(lines[line_idx], bracket_name))
         {
-            if(sections.empty())
-                preamble_end = line_idx;
-            else
-                sections.back().end = line_idx;
+            if(!sections.empty()) sections.back().end = line_idx;
             sections.push_back({ line_idx, lines.size(), bracket_name });
         }
     }

--- a/projects/rocprofiler-systems/source/bin/common/common_utils.hpp
+++ b/projects/rocprofiler-systems/source/bin/common/common_utils.hpp
@@ -80,6 +80,15 @@ get_domain_help_map();
 void
 print_compact_help(std::string_view tool_name, std::ostream& out = std::cout);
 
+/**
+ * Print the "Group topics"/"Domain topics" listing for @p tool_name.
+ * Topics carrying a tool allowlist (e.g. the run-only "execution" topic)
+ * are shown only for the tools they target. Shared by print_compact_help()
+ * and the unknown-topic fallback in dispatch_help() so both stay in sync.
+ */
+void
+print_topic_listing(std::string_view tool_name, std::ostream& out = std::cout);
+
 [[nodiscard]] bool
 print_help_for_topic(const std::string& captured_help, std::string_view topic,
                      std::string_view tool_name, std::ostream& out = std::cout);
@@ -189,15 +198,9 @@ dispatch_help(ParserT& parser, std::string_view tool_name, int exit_code)
         else
         {
             std::cerr << "[rocprof-sys] Unknown help topic '" << topic << "'.\n\n"
-                      << "Available topics (use --help=<topic>):\n";
+                      << "Available topics (use --help=<topic>):\n\n";
 
-            std::cerr << "\n  Group topics:\n";
-            for(const auto& [name, groups] : get_help_topic_map())
-                std::cerr << "    " << name << "\n";
-
-            std::cerr << "\n  Domain topics:\n";
-            for(const auto& [name, info] : get_domain_help_map())
-                std::cerr << "    " << name << "  - " << info.description << "\n";
+            print_topic_listing(tool_name, std::cerr);
 
             std::cerr << "\n  --help=all  Show all options\n";
         }

--- a/projects/rocprofiler-systems/source/bin/common/tests/test_help_system.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/tests/test_help_system.cpp
@@ -157,6 +157,25 @@ TEST_F(help_system_test, compact_help_uses_tool_name)
     EXPECT_NE(oss_sample.str().find("rocprof-sys-sample"), std::string::npos);
 }
 
+TEST_F(help_system_test, compact_help_lists_tool_specific_topics)
+{
+    std::ostringstream oss_run, oss_sample;
+    print_compact_help("run", oss_run);
+    print_compact_help("sample", oss_sample);
+    const auto run_out    = oss_run.str();
+    const auto sample_out = oss_sample.str();
+
+    // The 'execution' topic ([EXECUTION OPTIONS]) is gated behind --fork and
+    // only exists for rocprof-sys-run.
+    // (Blurb text is matched to avoid colliding with flag names.)
+    EXPECT_NE(run_out.find("Execution control options"), std::string::npos);
+    EXPECT_EQ(sample_out.find("Execution control options"), std::string::npos);
+
+    // A tool-agnostic topic (empty 'tools' list) is advertised for both tools.
+    EXPECT_NE(run_out.find("Output format selection"), std::string::npos);
+    EXPECT_NE(sample_out.find("Output format selection"), std::string::npos);
+}
+
 // ============================================================================
 // Topic-based help extraction tests
 // ============================================================================

--- a/projects/rocprofiler-systems/source/bin/common/tests/test_help_system.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/tests/test_help_system.cpp
@@ -177,6 +177,45 @@ TEST_F(help_system_test, compact_help_lists_tool_specific_topics)
 }
 
 // ============================================================================
+// Topic listing tests
+// ----------------------------------------------------------------------------
+// print_topic_listing() is the single source of truth for the "Group
+// topics"/"Domain topics" listing rendered by both the compact --help screen
+// and the unknown-topic fallback in dispatch_help(). It must be tool-aware
+// ============================================================================
+
+TEST_F(help_system_test, topic_listing_is_tool_aware)
+{
+    std::ostringstream oss_run, oss_sample;
+    print_topic_listing("run", oss_run);
+    print_topic_listing("sample", oss_sample);
+    const auto run_out    = oss_run.str();
+    const auto sample_out = oss_sample.str();
+
+    // 'execution' is a run-only group topic: listed for run, hidden for sample.
+    // (Blurb text is matched to avoid colliding with flag names.)
+    EXPECT_NE(run_out.find("Execution control options"), std::string::npos);
+    EXPECT_EQ(sample_out.find("Execution control options"), std::string::npos);
+
+    // Tool-agnostic group topics are advertised for both tools.
+    EXPECT_NE(run_out.find("Output format selection"), std::string::npos);
+    EXPECT_NE(sample_out.find("Output format selection"), std::string::npos);
+}
+
+TEST_F(help_system_test, topic_listing_lists_synthetic_and_domain_topics)
+{
+    std::ostringstream oss;
+    print_topic_listing("sample", oss);
+    const auto out = oss.str();
+
+    // The synthetic 'all' entry and every (tool-agnostic) domain topic appear.
+    EXPECT_NE(out.find("all"), std::string::npos);
+    EXPECT_NE(out.find("Full help output"), std::string::npos);
+    for(const auto* domain : { "gpu", "cpu", "rocm", "parallel" })
+        EXPECT_NE(out.find(domain), std::string::npos);
+}
+
+// ============================================================================
 // Topic-based help extraction tests
 // ============================================================================
 


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

When using `rocprof-sys-run --help` or `rocprof-sys-sample --help`, the "output" _Group Topic_ would be absent. However, `rocprof-sys-run --help=output` is valid.

This should be displayed to the user when using `--help`. Helps in HIP training.

E.g., when I use `rocprof-sys-run --help` today:
```
HELP TOPICS (use --help=<topic> for details)

  Group topics:
    all          Full help output (all options)
    preset       Preset, domain, and export options
    general      General options (output, trace, profile)
    tracing      Tracing-specific options
    profiling    Profile output format options
    sampling     Sampling frequency and timer options
    process      Host/device process sampling options
    counters     Hardware counter options (CPU/GPU events)
    backend      Backend options (include/exclude)
    debug        Debug, logging, and verbosity options
    misc         Miscellaneous options
```
Where is `output` and `execution`?
Note that `execution` should not be present for `rocprof-sys-sample`.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

 - Refactored the group/domain help definitions into ordered tables. That way, `group_topic_table(), domain_topic_table(), get_help_topic_map, get_domain_help_map` are derived from them, and `print_compact_help()` iterates the same tables instead of a separately maintained list.
 - Added per topic tool targeting (`tools` allowlist on `group_topic_desc` so that empty is all tools, and you can specify either `run` or `sample` so that topic only appears there, which is used for `execution`, only used in `rocprof-sys-run`).
   - Unit test for this was added
 - Auto-grow the topic-name column/width at print time so alignment stays correct if something longer is added down the line.
 - Save/restore stream flags in `print_compact_help` to avoid leaking stick `std::left` justification into the output stream.

## JIRA ID

Jira ID: AIPROFSYST-594

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Unit tests + Manual output:

## Test Result

New unit test passes.

Manual output passes:

With `rocprof-sys-run --help` (both `execution` and `output` are present)
```
HELP TOPICS (use --help=<topic> for details)

  Group topics:
    all          Full help output (all options)
    preset       Preset, domain, and export options
    general      General options (output, trace, profile)
    tracing      Tracing-specific options
    profiling    Profile output format options
    output       Output format selection (proto/rocpd/json/text)
    sampling     Sampling frequency and timer options
    process      Host/device process sampling options
    counters     Hardware counter options (CPU/GPU events)
    backend      Backend options (include/exclude)
    execution    Execution control options (e.g., --fork)
    debug        Debug, logging, and verbosity options
    misc         Miscellaneous options
```

With `rocprof-sys-sample --help` (no `execution`, but `output` is still present)
```
HELP TOPICS (use --help=<topic> for details)

  Group topics:
    all          Full help output (all options)
    preset       Preset, domain, and export options
    general      General options (output, trace, profile)
    tracing      Tracing-specific options
    profiling    Profile output format options
    output       Output format selection (proto/rocpd/json/text)
    sampling     Sampling frequency and timer options
    process      Host/device process sampling options
    counters     Hardware counter options (CPU/GPU events)
    backend      Backend options (include/exclude)
    debug        Debug, logging, and verbosity options
    misc         Miscellaneous options
```

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
