### PR TITLE
Populate control packet in producer/consumer test harness

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/tests/producer_consumer.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/tests/producer_consumer.cpp
@@ -152,7 +152,13 @@ start_threads(rocprofiler_thread_trace_shader_data_callback_t cb_fn,
     auto factory = std::make_unique<aql::ThreadTraceAQLPacketFactory>(
         *agent, params, *table.core_, *table.amd_ext_);
     auto control_packet = factory->construct_control_packet();
-    auto buffer_packet  = std::make_unique<MockPackets>(control_packet->GetHandle(), query_fn);
+    // Mirror ThreadTracerAgent::start_thread_trace: the producer loop submits the
+    // start packets (before_krn_pkt) and, on stop, after_krn_pkt.at(0). Those
+    // vectors are only filled by populate_before()/populate_after(), so populate
+    // them here or the producer aborts with small_vector::at out_of_range.
+    control_packet->populate_before();
+    control_packet->populate_after();
+    auto buffer_packet = std::make_unique<MockPackets>(control_packet->GetHandle(), query_fn);
 
     auto mock_queue          = make_mock_queue(*agent);
     auto worker_data         = std::make_shared<triple_buffer_shared_data_t>();


### PR DESCRIPTION
### Fix for the aborting `unit.thread_trace.*` producer/consumer tests

The producer/consumer unit tests (`init_shutdown`, `status_query`, `multiple_calls`, `read_offset`, `data_integrity`, `slow_cpu`, `slow_gpu`, `restart_after_overflow`, `buffer_alternation`) abort with `std::out_of_range: small_vector::at`.

**Root cause:** `start_threads()` in `producer_consumer.cpp` builds `producer_data` directly from `factory->construct_control_packet()`, but `construct_control_packet()` ends with `clear()`, so `before_krn_pkt` / `after_krn_pkt` are empty. The producer submits `before_krn_pkt` on start and `after_krn_pkt.at(0)` on stop, so `stop_trace()` throws immediately (every test tears the producer down, so all of them hit it).

The production path (`ThreadTracerAgent::start_thread_trace`) calls `populate_before()` / `populate_after()` before handing the packet to the producer — the test harness just needs to mirror that.

**Fix** (2 lines in `producer_consumer.cpp`, right after constructing the control packet):

    control_packet->populate_before();
    control_packet->populate_after();

**Verification:**
- Local (gfx942): all 17 `unit.thread_trace.*` pass (20 consecutive runs) + 8/8
  `thread-trace-api-*` GPU integration tests. Confirmed causally by reverting just these two lines → the same 9 tests fail again.
- CI: I took this fix, **rebased it onto the latest `develop`** together with this
  branch's commits, and ran the `rocprofiler-sdk` workflow — **`Core • mi325 • ubuntu-22.04` passed**: https://github.com/ROCm/rocm-systems/actions/runs/28808413518/job/85429886395

Note: the green CI run above was on a **rebase onto latest `develop`** (develop + quickscan + this fix). This PR itself contains only the single test-only commit against `users/gbaraldi/quickscan`.