### PR TITLE
feat(rocjitsu): DBI: Add host-side logging ring buffer for probes

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/CMakeLists.txt
@@ -36,6 +36,7 @@ rj_add_object_library(rocjitsu_code
     patch/code_object_patcher.cpp
     patch/kernarg_extension.cpp
     patch/kernel_text_layout.cpp
+    patch/log_buffer.cpp
     patch/instrumentor.cpp
     patch/probe_callable.cpp
     patch/probe_clobber.cpp

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/log_abi.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/log_abi.h
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file log_abi.h
+/// @brief Fixed host/device ABI for the DBI logging buffer.
+///
+/// This header is intentionally dependency-light: it pulls in only <cstddef>
+/// and <cstdint> so the exact same struct definitions can be included from
+/// host C++ and from HIP device code (the `rj_log_write` probe fixture). Keep
+/// it that way -- do not add host-only includes here. The host ring-buffer
+/// class and drain logic live in log_buffer.h.
+///
+/// The type names are currently unversioned, but versioned type names can be
+/// introduced to extend the ABI while keeping compatibility.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace rocjitsu {
+
+/// @brief Magic value stamped into RjLogBufferHeader::magic ("RJLG",
+///        little-endian byte order 'R','J','L','G').
+inline constexpr uint32_t kRjLogMagic =
+    static_cast<uint32_t>('R') | (static_cast<uint32_t>('J') << 8) |
+    (static_cast<uint32_t>('L') << 16) | (static_cast<uint32_t>('G') << 24);
+
+/// @brief Current logging ABI version.
+inline constexpr uint16_t kRjLogAbiVersion = 0;
+
+/// @brief Fixed record size in bytes (power of two).
+inline constexpr uint32_t kRjLogRecordSize = 64;
+
+/// @brief Control header for a logging ring buffer.
+///
+/// The three monotonic counters (@c write_ptr, @c read_ptr, @c overflow_count)
+/// are each placed on their own 64-byte cache line to avoid false sharing
+/// between GPU producers and the host consumer. Counters are record *indices*
+/// (not byte offsets); the live slot for index @c i is @c i&(slot_count-1).
+struct alignas(64) RjLogBufferHeader {
+  // Cache line 0: immutable control fields after initialization.
+  uint32_t magic;       ///< kRjLogMagic.
+  uint16_t abi_version; ///< kRjLogAbiVersion.
+  uint16_t header_size; ///< sizeof(RjLogBufferHeader).
+  uint32_t record_size; ///< kRjLogRecordSize.
+  uint32_t slot_count;  ///< Number of records; power of two.
+  uint64_t flags;       ///< Reserved
+  uint8_t reserved_control[40];
+
+  // Cache line 1: producer-owned hot counter.
+  uint64_t write_ptr; ///< Next record index to claim.
+  uint8_t reserved_producer[56];
+
+  // Cache line 2: consumer-owned counter.
+  uint64_t read_ptr; ///< Next record index to drain.
+  uint8_t reserved_consumer[56];
+
+  // Cache line 3: diagnostics written by producers, read by host after drain.
+  uint64_t overflow_count; ///< Records dropped because the ring was full.
+  uint8_t reserved_diagnostics[56];
+};
+
+static_assert(sizeof(RjLogBufferHeader) == 256);
+static_assert(alignof(RjLogBufferHeader) == 64);
+static_assert(offsetof(RjLogBufferHeader, write_ptr) == 64);
+static_assert(offsetof(RjLogBufferHeader, read_ptr) == 128);
+static_assert(offsetof(RjLogBufferHeader, overflow_count) == 192);
+
+/// @brief One logging record.
+struct alignas(64) RjLogRecord {
+  uint32_t valid;       ///< 0 = free, 1 = record written.
+  uint16_t abi_version; ///< kRjLogAbiVersion.
+  uint16_t record_size; ///< kRjLogRecordSize.
+  uint32_t record_type; ///< Tool-defined record kind.
+  uint32_t site;        ///< Original .text byte offset of the anchor.
+  uint64_t payload;     ///< Tool-defined payload.
+  uint64_t exec_mask;   ///< Original EXEC mask at the probe site.
+  uint32_t wave_id;     ///< 0 if unavailable in the first probe.
+  uint32_t workgroup_x; ///< 0 if unavailable.
+  uint32_t workgroup_y; ///< 0 if unavailable.
+  uint32_t workgroup_z; ///< 0 if unavailable.
+  uint32_t active_lane_count;
+  uint32_t writer_lane; ///< First active lane, or 0xffffffff if unknown.
+  uint64_t reserved0;
+};
+
+static_assert(sizeof(RjLogRecord) == 64);
+static_assert(alignof(RjLogRecord) == 64);
+static_assert(sizeof(RjLogRecord) == kRjLogRecordSize);
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/log_abi.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/log_abi.h
@@ -45,7 +45,7 @@ struct alignas(64) RjLogBufferHeader {
   uint16_t header_size; ///< sizeof(RjLogBufferHeader).
   uint32_t record_size; ///< kRjLogRecordSize.
   uint32_t slot_count;  ///< Number of records; power of two.
-  uint64_t flags;       ///< Reserved
+  uint64_t flags;       ///< Reserved; must be zero for now. Readers ignore unknown bits.
   uint8_t reserved_control[40];
 
   // Cache line 1: producer-owned hot counter.
@@ -63,30 +63,62 @@ struct alignas(64) RjLogBufferHeader {
 
 static_assert(sizeof(RjLogBufferHeader) == 256);
 static_assert(alignof(RjLogBufferHeader) == 64);
+// Version discriminant offsets are FROZEN for all ABI versions: a host must be
+// able to read magic/abi_version/header_size at these fixed positions before it
+// can decide whether it understands the rest of the layout. Never move them.
+static_assert(offsetof(RjLogBufferHeader, magic) == 0);
+static_assert(offsetof(RjLogBufferHeader, abi_version) == 4);
+static_assert(offsetof(RjLogBufferHeader, header_size) == 6);
+static_assert(offsetof(RjLogBufferHeader, record_size) == 8);
+static_assert(offsetof(RjLogBufferHeader, slot_count) == 12);
+static_assert(offsetof(RjLogBufferHeader, flags) == 16);
 static_assert(offsetof(RjLogBufferHeader, write_ptr) == 64);
 static_assert(offsetof(RjLogBufferHeader, read_ptr) == 128);
 static_assert(offsetof(RjLogBufferHeader, overflow_count) == 192);
 
 /// @brief One logging record.
+///
+/// `payload` is kept last because it is the field most likely to grow in a
+/// future ABI version; trailing it lets the payload region expand without
+/// shifting the fixed metadata offsets ahead of it.
 struct alignas(64) RjLogRecord {
   uint32_t valid;       ///< 0 = free, 1 = record written.
   uint16_t abi_version; ///< kRjLogAbiVersion.
-  uint16_t record_size; ///< kRjLogRecordSize.
+  uint16_t reserved0;   ///< Reserved; must be zero for now.
+  uint32_t record_size; ///< kRjLogRecordSize.
   uint32_t record_type; ///< Tool-defined record kind.
-  uint32_t site;        ///< Original .text byte offset of the anchor.
-  uint64_t payload;     ///< Tool-defined payload.
   uint64_t exec_mask;   ///< Original EXEC mask at the probe site.
-  uint32_t wave_id;     ///< 0 if unavailable in the first probe.
+  uint32_t site;        ///< Original .text byte offset of the anchor.
+  uint32_t wave_id;     ///< 0 if unavailable.
   uint32_t workgroup_x; ///< 0 if unavailable.
   uint32_t workgroup_y; ///< 0 if unavailable.
   uint32_t workgroup_z; ///< 0 if unavailable.
   uint32_t active_lane_count;
   uint32_t writer_lane; ///< First active lane, or 0xffffffff if unknown.
-  uint64_t reserved0;
+  uint32_t reserved1;   ///< Reserved; must be zero for now.
+  uint64_t payload;     ///< Tool-defined payload. Kept last (see above).
 };
 
 static_assert(sizeof(RjLogRecord) == 64);
 static_assert(alignof(RjLogRecord) == 64);
 static_assert(sizeof(RjLogRecord) == kRjLogRecordSize);
+// Pin every field offset: a device writes this record, so a middle-field
+// reorder or width change that preserved the 64-byte total would otherwise
+// compile clean and silently desync the host reader from the device writer.
+static_assert(offsetof(RjLogRecord, valid) == 0);
+static_assert(offsetof(RjLogRecord, abi_version) == 4);
+static_assert(offsetof(RjLogRecord, reserved0) == 6);
+static_assert(offsetof(RjLogRecord, record_size) == 8);
+static_assert(offsetof(RjLogRecord, record_type) == 12);
+static_assert(offsetof(RjLogRecord, exec_mask) == 16);
+static_assert(offsetof(RjLogRecord, site) == 24);
+static_assert(offsetof(RjLogRecord, wave_id) == 28);
+static_assert(offsetof(RjLogRecord, workgroup_x) == 32);
+static_assert(offsetof(RjLogRecord, workgroup_y) == 36);
+static_assert(offsetof(RjLogRecord, workgroup_z) == 40);
+static_assert(offsetof(RjLogRecord, active_lane_count) == 44);
+static_assert(offsetof(RjLogRecord, writer_lane) == 48);
+static_assert(offsetof(RjLogRecord, reserved1) == 52);
+static_assert(offsetof(RjLogRecord, payload) == 56);
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/log_abi.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/log_abi.h
@@ -12,6 +12,11 @@
 ///
 /// The type names are currently unversioned, but versioned type names can be
 /// introduced to extend the ABI while keeping compatibility.
+///
+/// Layout handshake: the host consumer strides by a fixed sizeof(RjLogRecord), so
+/// both sides must agree on record geometry first. A producer compares the
+/// header's abi_version/record_size before writing; the host passes the header
+/// through LogBuffer::validate() before draining (see log_buffer.h).
 
 #pragma once
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/log_buffer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/log_buffer.cpp
@@ -1,0 +1,151 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/code/patch/log_buffer.h"
+
+#include "rocjitsu/code/patch/error_report.h"
+
+#include "util/bit.h"
+
+#include <cassert>
+#include <cinttypes>
+#include <cstdio>
+#include <cstring>
+#include <new>
+
+namespace rocjitsu {
+
+namespace {
+
+constexpr std::size_t kBufferAlignment = alignof(RjLogBufferHeader); // 64
+
+} // namespace
+
+void LogBuffer::AlignedStorageDeleter::operator()(void *p) const noexcept {
+  ::operator delete(p, std::align_val_t{kBufferAlignment});
+}
+
+LogBuffer::LogBuffer(void *storage, uint32_t slot_count, size_t total_bytes)
+    : storage_(storage), slot_count_(slot_count), total_bytes_(total_bytes) {}
+
+std::unique_ptr<LogBuffer> LogBuffer::create_for_host_tests(uint32_t slot_count,
+                                                            std::string *error_out) {
+  if (!util::is_power_of_2(slot_count)) {
+    report(error_out, "slot_count must be a nonzero power of two");
+    return nullptr;
+  }
+
+  // Header and records are each 64-byte sized/aligned, so the contiguous
+  // [header][slot_count * record] image is exactly the sum of the two.
+  const size_t total_bytes =
+      sizeof(RjLogBufferHeader) + static_cast<size_t>(slot_count) * sizeof(RjLogRecord);
+
+  void *storage = ::operator new(total_bytes, std::align_val_t{kBufferAlignment}, std::nothrow);
+  if (storage == nullptr) {
+    report(error_out, "failed to allocate logging buffer");
+    return nullptr;
+  }
+
+  std::memset(storage, 0, total_bytes);
+
+  // RjLogBufferHeader and RjLogRecord are implicit-lifetime types. The
+  // operator new above implicitly creates such objects in the returned storage,
+  // so the header()/records() reinterpret_casts below yield pointers to live
+  // objects without an explicit placement-new. Do not add non-trivial members
+  // to these structs or this guarantee no longer holds.
+
+  // std::unique_ptr private-ctor dance: construct, then initialize the header.
+  auto buffer = std::unique_ptr<LogBuffer>(new LogBuffer(storage, slot_count, total_bytes));
+
+  RjLogBufferHeader *hdr = buffer->header();
+  hdr->magic = kRjLogMagic;
+  hdr->abi_version = kRjLogAbiVersion;
+  hdr->header_size = static_cast<uint16_t>(sizeof(RjLogBufferHeader));
+  hdr->record_size = kRjLogRecordSize;
+  hdr->slot_count = slot_count;
+  // flags and all counters are already zeroed by the memset above.
+
+  return buffer;
+}
+
+LogBuffer::~LogBuffer() = default;
+
+RjLogBufferHeader *LogBuffer::header() { return static_cast<RjLogBufferHeader *>(storage_.get()); }
+
+const RjLogBufferHeader *LogBuffer::header() const {
+  return static_cast<const RjLogBufferHeader *>(storage_.get());
+}
+
+RjLogRecord *LogBuffer::records() { return reinterpret_cast<RjLogRecord *>(header() + 1); }
+
+const RjLogRecord *LogBuffer::records() const {
+  return reinterpret_cast<const RjLogRecord *>(header() + 1);
+}
+
+uint32_t LogBuffer::slot_count() const { return slot_count_; }
+
+uint64_t LogBuffer::overflow_count() const { return header()->overflow_count; }
+
+size_t LogBuffer::total_bytes() const { return total_bytes_; }
+
+DrainStats LogBuffer::drain(const LogRecordCallback &callback) {
+  DrainStats stats;
+  RjLogBufferHeader *hdr = header();
+  RjLogRecord *recs = records();
+  const uint32_t mask = slot_count_ - 1;
+
+  // drain runs single-threaded after dispatch completion, so these are the
+  // final settled counter values (no concurrent producer to race).
+  const uint64_t write_ptr = hdr->write_ptr;
+  const uint64_t read_ptr = hdr->read_ptr;
+  const uint64_t pending = write_ptr - read_ptr;
+
+  // Producer contract: a full ring bumps overflow_count without advancing
+  // write_ptr, so pending never exceeds slot_count and the `pending` indices
+  // map to distinct live slots. Check in debug build.
+  assert(pending <= slot_count_ &&
+         "log ring producer overran the buffer: write_ptr - read_ptr > slot_count");
+  // Walk `pending` monotonic indices, mapping each to its slot. The
+  // `read_ptr + n` and `& mask` arithmetic is unsigned and wrap-safe so the
+  // walk stays correct even if the counters roll over.
+  for (uint64_t n = 0; n < pending; ++n) {
+    RjLogRecord &record = recs[(read_ptr + n) & mask];
+    if (record.valid == 1) {
+      if (callback)
+        callback(record);
+      record.valid = 0;
+      ++stats.records_drained;
+    } else {
+      // Advertised by write_ptr but not published: a protocol error after
+      // completion, not a race to spin on.
+      ++stats.invalid_slots;
+    }
+  }
+
+  hdr->read_ptr = write_ptr;
+  stats.overflow_count = hdr->overflow_count;
+  return stats;
+}
+
+void LogBuffer::reinitialize() {
+  RjLogBufferHeader *hdr = header();
+  hdr->write_ptr = 0;
+  hdr->read_ptr = 0;
+  hdr->overflow_count = 0;
+
+  RjLogRecord *recs = records();
+  for (uint32_t i = 0; i < slot_count_; ++i)
+    recs[i].valid = 0;
+}
+
+std::string format_log_line(const RjLogRecord &record) {
+  char buf[128];
+  std::snprintf(buf, sizeof(buf),
+                "rj-log record_type=%" PRIu32 " site=0x%" PRIx32 " wave=0x%" PRIx32 " lane=%" PRIu32
+                " payload=0x%" PRIx64,
+                record.record_type, record.site, record.wave_id, record.writer_lane,
+                record.payload);
+  return std::string(buf);
+}
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/log_buffer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/log_buffer.cpp
@@ -54,13 +54,18 @@ std::unique_ptr<LogBuffer> LogBuffer::create_for_host_tests(uint32_t slot_count,
   const size_t total_bytes =
       sizeof(RjLogBufferHeader) + static_cast<size_t>(slot_count) * sizeof(RjLogRecord);
 
-  void *storage = ::operator new(total_bytes, std::align_val_t{kBufferAlignment}, std::nothrow);
+  // Own the backing allocation via RAII immediately: the wrapper allocation
+  // below is a throwing new, and until ownership transfers into the LogBuffer a
+  // bare pointer would leak (and std::bad_alloc would escape) the factory's
+  // nullptr-on-failure contract if that throw fired.
+  std::unique_ptr<void, AlignedStorageDeleter> storage(
+      ::operator new(total_bytes, std::align_val_t{kBufferAlignment}, std::nothrow));
   if (storage == nullptr) {
     report(error_out, "failed to allocate logging buffer");
     return nullptr;
   }
 
-  std::memset(storage, 0, total_bytes);
+  std::memset(storage.get(), 0, total_bytes);
 
   // RjLogBufferHeader and RjLogRecord are implicit-lifetime types. The
   // operator new above implicitly creates such objects in the returned storage,
@@ -69,7 +74,16 @@ std::unique_ptr<LogBuffer> LogBuffer::create_for_host_tests(uint32_t slot_count,
   // to these structs or this guarantee no longer holds.
 
   // std::unique_ptr private-ctor dance: construct, then initialize the header.
-  auto buffer = std::unique_ptr<LogBuffer>(new LogBuffer(storage, slot_count, total_bytes));
+  // Non-throwing new so a wrapper allocation failure returns nullptr (freeing
+  // storage) rather than throwing; ownership of storage transfers only after the
+  // LogBuffer is live.
+  auto buffer = std::unique_ptr<LogBuffer>(new (std::nothrow)
+                                               LogBuffer(storage.get(), slot_count, total_bytes));
+  if (buffer == nullptr) {
+    report(error_out, "failed to allocate logging buffer");
+    return nullptr;
+  }
+  storage.release();
   init_header(buffer->header(), slot_count);
   return buffer;
 }
@@ -131,12 +145,18 @@ DrainStats LogBuffer::drain(const LogRecordCallback &callback) {
   const uint64_t read_ptr = hdr->read_ptr;
   uint64_t pending = write_ptr - read_ptr;
 
-  // Producer contract: a full ring bumps overflow_count without advancing
-  // write_ptr, so pending should never exceed slot_count. These counters are
-  // written by an untrusted producer (a device), though, so we clamp in all
-  // builds rather than trusting the contract: an overrun would make
-  // (read_ptr + n) & mask alias earlier slots and deliver the same record more
-  // than once. Report the dropped excess instead of aborting the host.
+  // Producer contract is drop-newest: a full ring drops the incoming record and
+  // bumps overflow_count WITHOUT advancing write_ptr, so a well-behaved producer
+  // never lets pending exceed slot_count. The clamp below is therefore not a
+  // recovery path -- it is a safety guard for the untrusted cross-agent
+  // boundary. If a buggy device advances write_ptr past read_ptr + slot_count
+  // anyway, an unclamped walk would let (read_ptr + n) & mask alias earlier
+  // slots and hand the same record to the callback more than once (silent
+  // duplicate instrumentation data); clamping the walk to the physical slots
+  // prevents that. dropped_overrun records the clamped excess purely as a debug
+  // signal that a producer broke contract -- we do NOT try to reconstruct which
+  // records survived or in what order, because once the contract is violated
+  // that ordering is undefined.
   if (pending > slot_count_) {
     stats.dropped_overrun = pending - slot_count_;
     pending = slot_count_;
@@ -146,16 +166,26 @@ DrainStats LogBuffer::drain(const LogRecordCallback &callback) {
   // walk stays correct even if the counters roll over.
   for (uint64_t n = 0; n < pending; ++n) {
     RjLogRecord &record = recs[(read_ptr + n) & mask];
-    if (record.valid == 1) {
-      if (callback)
-        callback(record);
-      record.valid = 0;
-      ++stats.records_drained;
-    } else {
+    if (record.valid != 1) {
       // Advertised by write_ptr but not published: a protocol error after
       // completion, not a race to spin on.
       ++stats.invalid_slots;
+      continue;
     }
+    // The header passing validate() does not vouch for individual records: the
+    // host writes the header while the embedded probe writes each record, so a
+    // probe built against a different layout can publish a mismatched record
+    // under a valid header. Decoding it with our offsets would be silently
+    // wrong, so drop it rather than hand it to the callback.
+    if (record.abi_version != kRjLogAbiVersion || record.record_size != kRjLogRecordSize) {
+      record.valid = 0;
+      ++stats.incompatible_records;
+      continue;
+    }
+    if (callback)
+      callback(record);
+    record.valid = 0;
+    ++stats.records_drained;
   }
 
   hdr->read_ptr = write_ptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/log_buffer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/log_buffer.cpp
@@ -42,8 +42,7 @@ void LogBuffer::AlignedStorageDeleter::operator()(void *p) const noexcept {
 LogBuffer::LogBuffer(void *storage, uint32_t slot_count, size_t total_bytes)
     : storage_(storage), slot_count_(slot_count), total_bytes_(total_bytes) {}
 
-std::unique_ptr<LogBuffer> LogBuffer::create_for_host_tests(uint32_t slot_count,
-                                                            std::string *error_out) {
+std::unique_ptr<LogBuffer> LogBuffer::create(uint32_t slot_count, std::string *error_out) {
   if (!util::is_power_of_2(slot_count)) {
     report(error_out, "slot_count must be a nonzero power of two");
     return nullptr;
@@ -54,10 +53,11 @@ std::unique_ptr<LogBuffer> LogBuffer::create_for_host_tests(uint32_t slot_count,
   const size_t total_bytes =
       sizeof(RjLogBufferHeader) + static_cast<size_t>(slot_count) * sizeof(RjLogRecord);
 
-  // Own the backing allocation via RAII immediately: the wrapper allocation
-  // below is a throwing new, and until ownership transfers into the LogBuffer a
-  // bare pointer would leak (and std::bad_alloc would escape) the factory's
-  // nullptr-on-failure contract if that throw fired.
+  // Own the backing allocation via RAII immediately so it cannot leak before
+  // ownership transfers into the LogBuffer. Both allocations below use
+  // non-throwing new -- failure is a nullptr return, not an exception -- so the
+  // guard's job is the null-return window: if the wrapper allocation fails, the
+  // early return must still free this backing buffer (see release() below).
   std::unique_ptr<void, AlignedStorageDeleter> storage(
       ::operator new(total_bytes, std::align_val_t{kBufferAlignment}, std::nothrow));
   if (storage == nullptr) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/log_buffer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/log_buffer.cpp
@@ -7,10 +7,8 @@
 
 #include "util/bit.h"
 
-#include <cassert>
-#include <cinttypes>
-#include <cstdio>
 #include <cstring>
+#include <format>
 #include <new>
 
 namespace rocjitsu {
@@ -18,6 +16,22 @@ namespace rocjitsu {
 namespace {
 
 constexpr std::size_t kBufferAlignment = alignof(RjLogBufferHeader); // 64
+
+// Stamp the self-describing control fields of a logging header. Factored out of
+// the allocator so a future device-shared factory can reuse it over an
+// externally-provided [header][slots] image. Assumes the reserved padding is
+// already zeroed; this sets every meaningful field explicitly.
+void init_header(RjLogBufferHeader *hdr, uint32_t slot_count) {
+  hdr->magic = kRjLogMagic;
+  hdr->abi_version = kRjLogAbiVersion;
+  hdr->header_size = static_cast<uint16_t>(sizeof(RjLogBufferHeader));
+  hdr->record_size = kRjLogRecordSize;
+  hdr->slot_count = slot_count;
+  hdr->flags = 0;
+  hdr->write_ptr = 0;
+  hdr->read_ptr = 0;
+  hdr->overflow_count = 0;
+}
 
 } // namespace
 
@@ -56,15 +70,7 @@ std::unique_ptr<LogBuffer> LogBuffer::create_for_host_tests(uint32_t slot_count,
 
   // std::unique_ptr private-ctor dance: construct, then initialize the header.
   auto buffer = std::unique_ptr<LogBuffer>(new LogBuffer(storage, slot_count, total_bytes));
-
-  RjLogBufferHeader *hdr = buffer->header();
-  hdr->magic = kRjLogMagic;
-  hdr->abi_version = kRjLogAbiVersion;
-  hdr->header_size = static_cast<uint16_t>(sizeof(RjLogBufferHeader));
-  hdr->record_size = kRjLogRecordSize;
-  hdr->slot_count = slot_count;
-  // flags and all counters are already zeroed by the memset above.
-
+  init_header(buffer->header(), slot_count);
   return buffer;
 }
 
@@ -88,6 +94,31 @@ uint64_t LogBuffer::overflow_count() const { return header()->overflow_count; }
 
 size_t LogBuffer::total_bytes() const { return total_bytes_; }
 
+bool LogBuffer::validate(std::string *error_out) const {
+  const RjLogBufferHeader *hdr = header();
+  if (hdr->magic != kRjLogMagic) {
+    report(error_out, "log buffer magic mismatch");
+    return false;
+  }
+  if (hdr->abi_version != kRjLogAbiVersion) {
+    report(error_out, "log buffer abi_version mismatch");
+    return false;
+  }
+  if (hdr->header_size != sizeof(RjLogBufferHeader)) {
+    report(error_out, "log buffer header_size mismatch");
+    return false;
+  }
+  if (hdr->record_size != kRjLogRecordSize) {
+    report(error_out, "log buffer record_size mismatch");
+    return false;
+  }
+  if (hdr->slot_count != slot_count_) {
+    report(error_out, "log buffer slot_count mismatch");
+    return false;
+  }
+  return true;
+}
+
 DrainStats LogBuffer::drain(const LogRecordCallback &callback) {
   DrainStats stats;
   RjLogBufferHeader *hdr = header();
@@ -98,13 +129,18 @@ DrainStats LogBuffer::drain(const LogRecordCallback &callback) {
   // final settled counter values (no concurrent producer to race).
   const uint64_t write_ptr = hdr->write_ptr;
   const uint64_t read_ptr = hdr->read_ptr;
-  const uint64_t pending = write_ptr - read_ptr;
+  uint64_t pending = write_ptr - read_ptr;
 
   // Producer contract: a full ring bumps overflow_count without advancing
-  // write_ptr, so pending never exceeds slot_count and the `pending` indices
-  // map to distinct live slots. Check in debug build.
-  assert(pending <= slot_count_ &&
-         "log ring producer overran the buffer: write_ptr - read_ptr > slot_count");
+  // write_ptr, so pending should never exceed slot_count. These counters are
+  // written by an untrusted producer (a device), though, so we clamp in all
+  // builds rather than trusting the contract: an overrun would make
+  // (read_ptr + n) & mask alias earlier slots and deliver the same record more
+  // than once. Report the dropped excess instead of aborting the host.
+  if (pending > slot_count_) {
+    stats.dropped_overrun = pending - slot_count_;
+    pending = slot_count_;
+  }
   // Walk `pending` monotonic indices, mapping each to its slot. The
   // `read_ptr + n` and `& mask` arithmetic is unsigned and wrap-safe so the
   // walk stays correct even if the counters roll over.
@@ -139,13 +175,9 @@ void LogBuffer::reinitialize() {
 }
 
 std::string format_log_line(const RjLogRecord &record) {
-  char buf[128];
-  std::snprintf(buf, sizeof(buf),
-                "rj-log record_type=%" PRIu32 " site=0x%" PRIx32 " wave=0x%" PRIx32 " lane=%" PRIu32
-                " payload=0x%" PRIx64,
-                record.record_type, record.site, record.wave_id, record.writer_lane,
-                record.payload);
-  return std::string(buf);
+  return std::format("rj-log record_type={} site=0x{:x} wave=0x{:x} lane={} payload=0x{:x}",
+                     record.record_type, record.site, record.wave_id, record.writer_lane,
+                     record.payload);
 }
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/log_buffer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/log_buffer.cpp
@@ -172,11 +172,12 @@ DrainStats LogBuffer::drain(const LogRecordCallback &callback) {
       ++stats.invalid_slots;
       continue;
     }
-    // The header passing validate() does not vouch for individual records: the
-    // host writes the header while the embedded probe writes each record, so a
-    // probe built against a different layout can publish a mismatched record
-    // under a valid header. Decoding it with our offsets would be silently
-    // wrong, so drop it rather than hand it to the callback.
+    // Defense-in-depth against a single corrupted record, not the primary layout
+    // guard: drain() strides by a fixed sizeof(RjLogRecord), so a wholesale
+    // record_size mismatch desyncs the stride itself and must be caught by
+    // validate() on the header (the required precondition). Past that, a record
+    // tripping this was built against a different layout -- decoding it with our
+    // offsets would be silently wrong, so drop it.
     if (record.abi_version != kRjLogAbiVersion || record.record_size != kRjLogRecordSize) {
       record.valid = 0;
       ++stats.incompatible_records;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/log_buffer.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/log_buffer.h
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file log_buffer.h
+/// @brief Host-side logging ring buffer over the logging ABI (log_abi.h).
+///
+/// This is CPU-only logging: it owns a single contiguous allocation
+/// ([header][slot_count * record]), initializes the header, and drains written
+/// records after a dispatch has completed. It has no dependency on HSA,
+/// the probe machinery, or GPU hardware.
+
+#pragma once
+
+#include "rocjitsu/code/patch/log_abi.h"
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace rocjitsu {
+
+/// @brief Callback invoked once per drained (valid) record.
+using LogRecordCallback = std::function<void(const RjLogRecord &)>;
+
+/// @brief Result of a single drain() pass.
+struct DrainStats {
+  uint64_t records_drained = 0; ///< Valid records passed to the callback.
+  uint64_t invalid_slots = 0;   ///< Slots advertised by write_ptr but whose
+                                ///< valid flag was 0 (a post-completion
+                                ///< protocol error, not an expected race).
+  uint64_t overflow_count = 0;  ///< Snapshot of header.overflow_count.
+};
+
+/// @brief Owns and drains a single logging ring buffer in host memory.
+///
+/// Ownership/lifetime: the buffer must outlive the dispatch it serves and must
+/// remain alive until drain() has consumed its records. Currently supports one
+/// controlled patched dispatch per buffer at a time; call reinitialize() before
+/// reusing the same instance for another dispatch.
+class LogBuffer final {
+public:
+  /// @brief Allocate a host-memory logging buffer sized for @p slot_count
+  ///        records.
+  /// @param slot_count  Number of record slots; must be a nonzero power of two.
+  /// @param error_out   Optional; assigned a single diagnostic on failure.
+  /// @returns The buffer, or nullptr if @p slot_count is zero or not a power of
+  ///          two, or if allocation fails.
+  [[nodiscard]] static std::unique_ptr<LogBuffer>
+  create_for_host_tests(uint32_t slot_count, std::string *error_out = nullptr);
+
+  ~LogBuffer();
+
+  LogBuffer(const LogBuffer &) = delete;
+  LogBuffer &operator=(const LogBuffer &) = delete;
+
+  /// @brief Pointer to the control header (start of the allocation).
+  [[nodiscard]] RjLogBufferHeader *header();
+  [[nodiscard]] const RjLogBufferHeader *header() const;
+
+  /// @brief Pointer to the first record slot (immediately after the header).
+  [[nodiscard]] RjLogRecord *records();
+  [[nodiscard]] const RjLogRecord *records() const;
+
+  /// @brief Number of record slots (power of two).
+  [[nodiscard]] uint32_t slot_count() const;
+
+  /// @brief Current overflow counter value from the header.
+  [[nodiscard]] uint64_t overflow_count() const;
+
+  /// @brief Total byte size of the owned allocation (header + all slots).
+  [[nodiscard]] size_t total_bytes() const;
+
+  /// @brief Drain all records in [read_ptr, write_ptr) after completion.
+  ///
+  /// For each advertised index the live slot is `index & (slot_count-1)`. A
+  /// slot with `valid == 1` is passed to @p callback, its `valid` flag is
+  /// cleared, and records_drained is incremented; a slot with `valid == 0` is
+  /// counted in invalid_slots and skipped. On return, read_ptr is advanced to
+  /// write_ptr.
+  ///
+  /// @note For now this is single-threaded and intended to run only after the
+  ///       producing dispatch has completed.
+  DrainStats drain(const LogRecordCallback &callback);
+
+  /// @brief Reset the buffer for reuse: zero the counters and all record
+  ///        `valid` flags while leaving the immutable header control fields
+  ///        intact.
+  void reinitialize();
+
+private:
+  LogBuffer(void *storage, uint32_t slot_count, size_t total_bytes);
+
+  /// @brief Custom deleter matching the aligned operator new used to allocate.
+  struct AlignedStorageDeleter {
+    void operator()(void *p) const noexcept;
+  };
+
+  std::unique_ptr<void, AlignedStorageDeleter> storage_;
+  uint32_t slot_count_ = 0;
+  size_t total_bytes_ = 0;
+};
+
+/// @brief Format a single record:
+///        `rj-log record_type=<n> site=0x<hex> wave=0x<hex> lane=<n>
+///        payload=0x<hex>`.
+[[nodiscard]] std::string format_log_line(const RjLogRecord &record);
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/log_buffer.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/log_buffer.h
@@ -30,6 +30,8 @@ struct DrainStats {
                                 ///< valid flag was 0 (a post-completion
                                 ///< protocol error, not an expected race).
   uint64_t overflow_count = 0;  ///< Snapshot of header.overflow_count.
+  uint64_t dropped_overrun = 0; ///< Advertised records dropped because the
+                                ///< producer overran the ring (see drain()).
 };
 
 /// @brief Owns and drains a single logging ring buffer in host memory.
@@ -71,6 +73,14 @@ public:
   /// @brief Total byte size of the owned allocation (header + all slots).
   [[nodiscard]] size_t total_bytes() const;
 
+  /// @brief Validate the header's self-describing fields before trusting it.
+  ///
+  /// Checks magic, abi_version, header_size, record_size, and slot_count against
+  /// the compiled-in ABI. Intended for buffers whose header was written by
+  /// another agent (a device or a shared allocation) before the first drain().
+  /// Returns false and sets @p error_out on the first mismatch.
+  [[nodiscard]] bool validate(std::string *error_out = nullptr) const;
+
   /// @brief Drain all records in [read_ptr, write_ptr) after completion.
   ///
   /// For each advertised index the live slot is `index & (slot_count-1)`. A
@@ -79,8 +89,18 @@ public:
   /// counted in invalid_slots and skipped. On return, read_ptr is advanced to
   /// write_ptr.
   ///
+  /// The number of advertised records (write_ptr - read_ptr) is clamped to
+  /// slot_count in all builds: the counters are written by an untrusted producer
+  /// (a device), and an overrun would otherwise alias physical slots and deliver
+  /// the same record more than once. Any excess is reported in
+  /// DrainStats::dropped_overrun.
+  ///
   /// @note For now this is single-threaded and intended to run only after the
-  ///       producing dispatch has completed.
+  ///       producing dispatch has completed. The invalid_slots hole-skip
+  ///       (advancing read_ptr past a valid==0 slot) is correct ONLY for this
+  ///       post-completion model; it would permanently drop a not-yet-published
+  ///       slot once producers publish `valid` concurrently, so this must be
+  ///       revisited before the host drains while a kernel is still running.
   DrainStats drain(const LogRecordCallback &callback);
 
   /// @brief Reset the buffer for reuse: zero the counters and all record

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/log_buffer.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/log_buffer.h
@@ -72,9 +72,11 @@ public:
   /// @brief Validate the header's self-describing fields before trusting it.
   ///
   /// Checks magic, abi_version, header_size, record_size, and slot_count against
-  /// the compiled-in ABI. Intended for buffers whose header was written by
-  /// another agent (a device or a shared allocation) before the first drain().
-  /// Returns false and sets @p error_out on the first mismatch.
+  /// the compiled-in ABI. Required precondition of drain() for any buffer whose
+  /// header was written by another agent (a device or a shared allocation):
+  /// drain() strides by a fixed sizeof(RjLogRecord) and cannot itself detect a
+  /// header describing a different record geometry. Returns false and sets
+  /// @p error_out on the first mismatch.
   [[nodiscard]] bool validate(std::string *error_out = nullptr) const;
 
   /// @brief Drain all records in [read_ptr, write_ptr) after completion.
@@ -86,10 +88,11 @@ public:
   /// write_ptr.
   ///
   /// A valid record whose per-record abi_version or record_size disagrees with
-  /// the compiled ABI was written by a probe built against a different layout;
-  /// decoding it with our offsets would be silently wrong. Such a record is
-  /// cleared, counted in incompatible_records, and not delivered to @p callback.
-  /// The header's own discriminants are separately checkable via validate().
+  /// the compiled ABI is cleared, counted in incompatible_records, and not
+  /// delivered to @p callback. This is defense-in-depth against a single
+  /// corrupted record, not the primary layout guard: drain() strides by a fixed
+  /// sizeof(RjLogRecord), so a wholesale record_size mismatch desyncs the stride
+  /// itself and must be caught by validate() on the header (see validate()).
   ///
   /// The producer contract is drop-newest: a full ring drops the incoming record
   /// and bumps overflow_count without advancing write_ptr, so a well-behaved

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/log_buffer.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/log_buffer.h
@@ -24,14 +24,27 @@ namespace rocjitsu {
 using LogRecordCallback = std::function<void(const RjLogRecord &)>;
 
 /// @brief Result of a single drain() pass.
+///
+/// TODO: the diagnostic counters below (dropped_overrun, invalid_slots,
+/// incompatible_records) are returned but not yet acted on -- the drain caller
+/// that wires up post-dispatch logging does not exist. When it lands, log these
+/// via Logger when nonzero so a misbehaving producer is visible instead of
+/// silently discarded.
 struct DrainStats {
-  uint64_t records_drained = 0; ///< Valid records passed to the callback.
-  uint64_t invalid_slots = 0;   ///< Slots advertised by write_ptr but whose
-                                ///< valid flag was 0 (a post-completion
-                                ///< protocol error, not an expected race).
-  uint64_t overflow_count = 0;  ///< Snapshot of header.overflow_count.
-  uint64_t dropped_overrun = 0; ///< Advertised records dropped because the
-                                ///< producer overran the ring (see drain()).
+  uint64_t records_drained = 0;      ///< Valid records passed to the callback.
+  uint64_t invalid_slots = 0;        ///< Slots advertised by write_ptr but whose
+                                     ///< valid flag was 0 (a post-completion
+                                     ///< protocol error, not an expected race).
+  uint64_t overflow_count = 0;       ///< Snapshot of header.overflow_count.
+  uint64_t dropped_overrun = 0;      ///< Debug signal: nonzero only when a
+                                     ///< producer broke the drop-newest contract
+                                     ///< and advanced write_ptr past
+                                     ///< read_ptr + slot_count. Counts the
+                                     ///< clamped excess; not a recovery path
+                                     ///< (see drain()).
+  uint64_t incompatible_records = 0; ///< Valid records skipped because their
+                                     ///< abi_version/record_size did not match
+                                     ///< the compiled ABI (see drain()).
 };
 
 /// @brief Owns and drains a single logging ring buffer in host memory.
@@ -89,11 +102,21 @@ public:
   /// counted in invalid_slots and skipped. On return, read_ptr is advanced to
   /// write_ptr.
   ///
-  /// The number of advertised records (write_ptr - read_ptr) is clamped to
-  /// slot_count in all builds: the counters are written by an untrusted producer
-  /// (a device), and an overrun would otherwise alias physical slots and deliver
-  /// the same record more than once. Any excess is reported in
-  /// DrainStats::dropped_overrun.
+  /// A valid record whose per-record abi_version or record_size disagrees with
+  /// the compiled ABI was written by a probe built against a different layout;
+  /// decoding it with our offsets would be silently wrong. Such a record is
+  /// cleared, counted in incompatible_records, and not delivered to @p callback.
+  /// The header's own discriminants are separately checkable via validate().
+  ///
+  /// The producer contract is drop-newest: a full ring drops the incoming record
+  /// and bumps overflow_count without advancing write_ptr, so a well-behaved
+  /// producer keeps (write_ptr - read_ptr) <= slot_count. Because the counters
+  /// come from an untrusted producer, drain still clamps the walk to slot_count
+  /// in all builds: a contract-violating producer that overran the ring would
+  /// otherwise alias physical slots and deliver the same record more than once.
+  /// The clamp only prevents that double-delivery -- it does not recover the
+  /// dropped records or define their order. The clamped excess is surfaced in
+  /// DrainStats::dropped_overrun as a debug signal that the contract was broken.
   ///
   /// @note For now this is single-threaded and intended to run only after the
   ///       producing dispatch has completed. The invalid_slots hole-skip

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/log_buffer.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/log_buffer.h
@@ -55,27 +55,10 @@ struct DrainStats {
 /// reusing the same instance for another dispatch.
 class LogBuffer final {
 public:
-  /// @brief Allocate a host-memory logging buffer sized for @p slot_count
-  ///        records.
-  /// @param slot_count  Number of record slots; must be a nonzero power of two.
-  /// @param error_out   Optional; assigned a single diagnostic on failure.
-  /// @returns The buffer, or nullptr if @p slot_count is zero or not a power of
-  ///          two, or if allocation fails.
-  [[nodiscard]] static std::unique_ptr<LogBuffer>
-  create_for_host_tests(uint32_t slot_count, std::string *error_out = nullptr);
-
   ~LogBuffer();
 
   LogBuffer(const LogBuffer &) = delete;
   LogBuffer &operator=(const LogBuffer &) = delete;
-
-  /// @brief Pointer to the control header (start of the allocation).
-  [[nodiscard]] RjLogBufferHeader *header();
-  [[nodiscard]] const RjLogBufferHeader *header() const;
-
-  /// @brief Pointer to the first record slot (immediately after the header).
-  [[nodiscard]] RjLogRecord *records();
-  [[nodiscard]] const RjLogRecord *records() const;
 
   /// @brief Number of record slots (power of two).
   [[nodiscard]] uint32_t slot_count() const;
@@ -132,6 +115,29 @@ public:
   void reinitialize();
 
 private:
+  // Construction and raw header/record access are test-only seams: no production
+  // consumer defines their contract yet, so they stay private and are reached in
+  // tests through the LogBufferTestAccess friend. A real drain caller uses the
+  // public validate()/drain()/reinitialize() API and never touches raw pointers.
+  friend struct LogBufferTestAccess;
+
+  /// @brief Allocate a host-memory logging buffer sized for @p slot_count
+  ///        records.
+  /// @param slot_count  Number of record slots; must be a nonzero power of two.
+  /// @param error_out   Optional; assigned a single diagnostic on failure.
+  /// @returns The buffer, or nullptr if @p slot_count is zero or not a power of
+  ///          two, or if allocation fails.
+  [[nodiscard]] static std::unique_ptr<LogBuffer> create(uint32_t slot_count,
+                                                         std::string *error_out = nullptr);
+
+  /// @brief Pointer to the control header (start of the allocation).
+  [[nodiscard]] RjLogBufferHeader *header();
+  [[nodiscard]] const RjLogBufferHeader *header() const;
+
+  /// @brief Pointer to the first record slot (immediately after the header).
+  [[nodiscard]] RjLogRecord *records();
+  [[nodiscard]] const RjLogRecord *records() const;
+
   LogBuffer(void *storage, uint32_t slot_count, size_t total_bytes);
 
   /// @brief Custom deleter matching the aligned operator new used to allocate.

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -445,6 +445,7 @@ add_executable(
     transcendental_test.cpp
     analysis/liveness_test.cpp
     patch/spill_manager_test.cpp
+    patch/log_buffer_test.cpp
     patch/instruction_builder_test.cpp
     patch/kernarg_extension_test.cpp
     patch/sidecar_metadata_test.cpp

--- a/emulation/rocjitsu/tests/patch/log_buffer_test.cpp
+++ b/emulation/rocjitsu/tests/patch/log_buffer_test.cpp
@@ -1,0 +1,340 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/code/patch/log_buffer.h"
+
+#include "rocjitsu/code/patch/log_abi.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace rocjitsu {
+namespace {
+
+// Simulate what a device producer does: write a record into the slot at the
+// current write_ptr, publish valid, then advance write_ptr. Host-side stand-in
+// used by the CPU-only tests (there is no atomic arbitration to model here
+// because these tests are single-threaded and post-completion).
+void publish_record(LogBuffer &buf, uint32_t record_type, uint32_t site, uint64_t payload) {
+  RjLogBufferHeader *hdr = buf.header();
+  RjLogRecord *recs = buf.records();
+  const uint64_t index = hdr->write_ptr;
+  RjLogRecord &rec = recs[index & (buf.slot_count() - 1)];
+  rec.abi_version = kRjLogAbiVersion;
+  rec.record_size = kRjLogRecordSize;
+  rec.record_type = record_type;
+  rec.site = site;
+  rec.payload = payload;
+  rec.writer_lane = 0;
+  rec.valid = 1;
+  hdr->write_ptr = index + 1;
+}
+
+std::vector<RjLogRecord> drain_all(LogBuffer &buf, DrainStats *stats_out) {
+  std::vector<RjLogRecord> out;
+  DrainStats stats = buf.drain([&](const RjLogRecord &r) { out.push_back(r); });
+  if (stats_out)
+    *stats_out = stats;
+  return out;
+}
+
+TEST(LogAbiTest, StructSizesAndAlignment) {
+  EXPECT_EQ(sizeof(RjLogBufferHeader), 256u);
+  EXPECT_EQ(alignof(RjLogBufferHeader), 64u);
+  EXPECT_EQ(sizeof(RjLogRecord), 64u);
+  EXPECT_EQ(alignof(RjLogRecord), 64u);
+  EXPECT_EQ(kRjLogRecordSize, 64u);
+}
+
+TEST(LogBufferTest, RejectsNonPowerOfTwoSlotCount) {
+  for (uint32_t bad : {0u, 3u, 6u, 7u, 100u}) {
+    std::string err;
+    auto buf = LogBuffer::create_for_host_tests(bad, &err);
+    EXPECT_EQ(buf, nullptr) << "slot_count=" << bad;
+    EXPECT_FALSE(err.empty()) << "slot_count=" << bad;
+  }
+}
+
+TEST(LogBufferTest, AcceptsPowerOfTwoSlotCount) {
+  for (uint32_t good : {1u, 2u, 8u, 1024u}) {
+    std::string err;
+    auto buf = LogBuffer::create_for_host_tests(good, &err);
+    ASSERT_NE(buf, nullptr) << "slot_count=" << good << " err=" << err;
+    EXPECT_EQ(buf->slot_count(), good);
+    EXPECT_TRUE(err.empty());
+  }
+}
+
+TEST(LogBufferTest, HeaderInitialized) {
+  auto buf = LogBuffer::create_for_host_tests(8);
+  ASSERT_NE(buf, nullptr);
+  const RjLogBufferHeader *hdr = buf->header();
+  EXPECT_EQ(hdr->magic, kRjLogMagic);
+  EXPECT_EQ(hdr->abi_version, kRjLogAbiVersion);
+  EXPECT_EQ(hdr->header_size, sizeof(RjLogBufferHeader));
+  EXPECT_EQ(hdr->record_size, kRjLogRecordSize);
+  EXPECT_EQ(hdr->slot_count, 8u);
+  EXPECT_EQ(hdr->flags, 0u);
+  EXPECT_EQ(hdr->write_ptr, 0u);
+  EXPECT_EQ(hdr->read_ptr, 0u);
+  EXPECT_EQ(hdr->overflow_count, 0u);
+}
+
+TEST(LogBufferTest, RecordsRegionFollowsHeader) {
+  auto buf = LogBuffer::create_for_host_tests(4);
+  ASSERT_NE(buf, nullptr);
+  const auto *hdr_end = reinterpret_cast<const char *>(buf->header()) + sizeof(RjLogBufferHeader);
+  EXPECT_EQ(reinterpret_cast<const char *>(buf->records()), hdr_end);
+  EXPECT_EQ(buf->total_bytes(), sizeof(RjLogBufferHeader) + 4u * sizeof(RjLogRecord));
+}
+
+TEST(LogBufferTest, SyntheticDrainInOrder) {
+  auto buf = LogBuffer::create_for_host_tests(8);
+  ASSERT_NE(buf, nullptr);
+  constexpr uint32_t kN = 5;
+  for (uint32_t i = 0; i < kN; ++i)
+    publish_record(*buf, /*record_type=*/1, /*site=*/0x100 + i, /*payload=*/i);
+
+  DrainStats stats;
+  auto drained = drain_all(*buf, &stats);
+  ASSERT_EQ(drained.size(), kN);
+  EXPECT_EQ(stats.records_drained, kN);
+  EXPECT_EQ(stats.invalid_slots, 0u);
+  EXPECT_EQ(stats.overflow_count, 0u);
+  for (uint32_t i = 0; i < kN; ++i) {
+    EXPECT_EQ(drained[i].record_type, 1u);
+    EXPECT_EQ(drained[i].site, 0x100u + i);
+    EXPECT_EQ(drained[i].payload, i);
+  }
+  // read_ptr caught up to write_ptr; a second drain yields nothing.
+  EXPECT_EQ(buf->header()->read_ptr, buf->header()->write_ptr);
+  auto again = drain_all(*buf, nullptr);
+  EXPECT_TRUE(again.empty());
+}
+
+TEST(LogBufferTest, DrainClearsValidFlags) {
+  auto buf = LogBuffer::create_for_host_tests(4);
+  ASSERT_NE(buf, nullptr);
+  publish_record(*buf, 1, 0x10, 0);
+  publish_record(*buf, 1, 0x20, 0);
+  drain_all(*buf, nullptr);
+  for (uint32_t i = 0; i < buf->slot_count(); ++i)
+    EXPECT_EQ(buf->records()[i].valid, 0u) << "slot " << i;
+}
+
+TEST(LogBufferTest, WraparoundReusesSlots) {
+  auto buf = LogBuffer::create_for_host_tests(4);
+  ASSERT_NE(buf, nullptr);
+
+  // First fill: indices 0..3 -> slots 0..3.
+  for (uint32_t i = 0; i < 4; ++i)
+    publish_record(*buf, 1, 0x200 + i, i);
+  auto first = drain_all(*buf, nullptr);
+  ASSERT_EQ(first.size(), 4u);
+
+  // Second fill: indices 4..7 -> slots 0..3 again.
+  for (uint32_t i = 0; i < 4; ++i)
+    publish_record(*buf, 2, 0x300 + i, 100 + i);
+  DrainStats stats;
+  auto second = drain_all(*buf, &stats);
+  ASSERT_EQ(second.size(), 4u);
+  EXPECT_EQ(stats.invalid_slots, 0u);
+  EXPECT_EQ(buf->header()->write_ptr, 8u);
+  for (uint32_t i = 0; i < 4; ++i) {
+    EXPECT_EQ(second[i].record_type, 2u);
+    EXPECT_EQ(second[i].site, 0x300u + i);
+    EXPECT_EQ(second[i].payload, 100u + i);
+  }
+}
+
+TEST(LogBufferTest, OverflowCountSurfaced) {
+  auto buf = LogBuffer::create_for_host_tests(4);
+  ASSERT_NE(buf, nullptr);
+  publish_record(*buf, 1, 0x10, 0);
+  // Simulate producers that dropped records on a full ring.
+  buf->header()->overflow_count = 7;
+
+  DrainStats stats;
+  auto drained = drain_all(*buf, &stats);
+  EXPECT_EQ(drained.size(), 1u);
+  EXPECT_EQ(stats.records_drained, 1u);
+  EXPECT_EQ(stats.overflow_count, 7u);
+  EXPECT_EQ(buf->overflow_count(), 7u);
+}
+
+TEST(LogBufferTest, InvalidAdvertisedSlotIsDiagnosedNotSpun) {
+  auto buf = LogBuffer::create_for_host_tests(4);
+  ASSERT_NE(buf, nullptr);
+  // write_ptr advertises two records, but only one was actually published.
+  publish_record(*buf, 1, 0x10, 42);
+  buf->header()->write_ptr = 2; // second slot left with valid == 0
+
+  DrainStats stats;
+  auto drained = drain_all(*buf, &stats);
+  EXPECT_EQ(drained.size(), 1u);
+  EXPECT_EQ(stats.records_drained, 1u);
+  EXPECT_EQ(stats.invalid_slots, 1u);
+  EXPECT_EQ(buf->header()->read_ptr, 2u); // still advances; no spin
+}
+
+TEST(LogBufferTest, ReinitializeResetsForReuse) {
+  auto buf = LogBuffer::create_for_host_tests(4);
+  ASSERT_NE(buf, nullptr);
+  publish_record(*buf, 1, 0x10, 0);
+  publish_record(*buf, 1, 0x20, 0);
+  buf->header()->overflow_count = 3;
+  drain_all(*buf, nullptr);
+
+  buf->reinitialize();
+  EXPECT_EQ(buf->header()->write_ptr, 0u);
+  EXPECT_EQ(buf->header()->read_ptr, 0u);
+  EXPECT_EQ(buf->overflow_count(), 0u);
+  for (uint32_t i = 0; i < buf->slot_count(); ++i)
+    EXPECT_EQ(buf->records()[i].valid, 0u);
+  // Header control fields survive reinitialization.
+  EXPECT_EQ(buf->header()->magic, kRjLogMagic);
+  EXPECT_EQ(buf->header()->slot_count, 4u);
+
+  // Buffer is usable again.
+  publish_record(*buf, 9, 0xabc, 5);
+  auto drained = drain_all(*buf, nullptr);
+  ASSERT_EQ(drained.size(), 1u);
+  EXPECT_EQ(drained[0].record_type, 9u);
+}
+
+TEST(LogBufferTest, EmptyDrainOnFreshBuffer) {
+  auto buf = LogBuffer::create_for_host_tests(8);
+  ASSERT_NE(buf, nullptr);
+  DrainStats stats;
+  auto drained = drain_all(*buf, &stats);
+  EXPECT_TRUE(drained.empty());
+  EXPECT_EQ(stats.records_drained, 0u);
+  EXPECT_EQ(stats.invalid_slots, 0u);
+  EXPECT_EQ(stats.overflow_count, 0u);
+  EXPECT_EQ(buf->header()->read_ptr, 0u);
+  EXPECT_EQ(buf->header()->write_ptr, 0u);
+}
+
+TEST(LogBufferTest, RecordsRegionIs64ByteAligned) {
+  auto buf = LogBuffer::create_for_host_tests(8);
+  ASSERT_NE(buf, nullptr);
+  EXPECT_EQ(reinterpret_cast<uintptr_t>(buf->header()) % 64u, 0u);
+  EXPECT_EQ(reinterpret_cast<uintptr_t>(buf->records()) % 64u, 0u);
+}
+
+TEST(LogBufferTest, NullCallbackStillDrainsAndClears) {
+  auto buf = LogBuffer::create_for_host_tests(4);
+  ASSERT_NE(buf, nullptr);
+  publish_record(*buf, 1, 0x10, 0);
+  publish_record(*buf, 1, 0x20, 0);
+
+  DrainStats stats = buf->drain(LogRecordCallback{}); // empty callback
+  EXPECT_EQ(stats.records_drained, 2u);
+  EXPECT_EQ(stats.invalid_slots, 0u);
+  EXPECT_EQ(buf->header()->read_ptr, buf->header()->write_ptr);
+  for (uint32_t i = 0; i < buf->slot_count(); ++i)
+    EXPECT_EQ(buf->records()[i].valid, 0u) << "slot " << i;
+}
+
+TEST(LogBufferTest, InvalidThenValidSlotBothHandled) {
+  auto buf = LogBuffer::create_for_host_tests(4);
+  ASSERT_NE(buf, nullptr);
+  // Leave index 0 unpublished (valid == 0), publish a real record at index 1.
+  buf->records()[0].valid = 0;
+  buf->records()[1] = RjLogRecord{};
+  buf->records()[1].record_type = 7;
+  buf->records()[1].site = 0x55;
+  buf->records()[1].valid = 1;
+  buf->header()->write_ptr = 2;
+
+  DrainStats stats;
+  auto drained = drain_all(*buf, &stats);
+  ASSERT_EQ(drained.size(), 1u);
+  EXPECT_EQ(stats.records_drained, 1u);
+  EXPECT_EQ(stats.invalid_slots, 1u);
+  EXPECT_EQ(drained[0].record_type, 7u); // the later valid record is delivered
+  EXPECT_EQ(drained[0].site, 0x55u);
+  EXPECT_EQ(buf->header()->read_ptr, 2u);
+}
+
+TEST(LogBufferTest, SingleSlotRingDrainsAcrossCycles) {
+  auto buf = LogBuffer::create_for_host_tests(1);
+  ASSERT_NE(buf, nullptr);
+  for (uint32_t cycle = 0; cycle < 5; ++cycle) {
+    publish_record(*buf, 1, 0x100 + cycle, cycle);
+    DrainStats stats;
+    auto drained = drain_all(*buf, &stats);
+    ASSERT_EQ(drained.size(), 1u) << "cycle " << cycle;
+    EXPECT_EQ(drained[0].site, 0x100u + cycle);
+    EXPECT_EQ(stats.invalid_slots, 0u);
+  }
+  EXPECT_EQ(buf->header()->write_ptr, 5u);
+}
+
+TEST(LogBufferTest, ExactFullDrainAtCapacity) {
+  auto buf = LogBuffer::create_for_host_tests(4);
+  ASSERT_NE(buf, nullptr);
+  for (uint32_t i = 0; i < 4; ++i) // write_ptr - read_ptr == slot_count
+    publish_record(*buf, 1, 0x10 + i, i);
+  DrainStats stats;
+  auto drained = drain_all(*buf, &stats);
+  EXPECT_EQ(drained.size(), 4u);
+  EXPECT_EQ(stats.invalid_slots, 0u);
+}
+
+TEST(LogBufferTest, Uint64IndexWraparound) {
+  auto buf = LogBuffer::create_for_host_tests(4);
+  ASSERT_NE(buf, nullptr);
+  // Position the monotonic counters two below the 64-bit boundary so the third
+  // published record wraps write_ptr through zero. Drain must still walk all
+  // three in order (count-based iteration is wrap-safe).
+  constexpr uint64_t kNearMax = 0xFFFFFFFFFFFFFFFEULL;
+  buf->header()->write_ptr = kNearMax;
+  buf->header()->read_ptr = kNearMax;
+  for (uint32_t i = 0; i < 3; ++i)
+    publish_record(*buf, 1, 0xA0 + i, i);
+  EXPECT_EQ(buf->header()->write_ptr, 1u); // wrapped: FE -> FF -> 00 -> 01
+
+  DrainStats stats;
+  auto drained = drain_all(*buf, &stats);
+  ASSERT_EQ(drained.size(), 3u);
+  EXPECT_EQ(stats.invalid_slots, 0u);
+  for (uint32_t i = 0; i < 3; ++i)
+    EXPECT_EQ(drained[i].site, 0xA0u + i);
+  EXPECT_EQ(buf->header()->read_ptr, 1u);
+}
+
+TEST(LogBufferTest, FormatLogLine) {
+  RjLogRecord rec{};
+  rec.record_type = 1;
+  rec.site = 0x140;
+  rec.wave_id = 0xabc;
+  rec.writer_lane = 0;
+  rec.payload = 0xdead;
+
+  const std::string line = format_log_line(rec);
+  EXPECT_NE(line.find("rj-log"), std::string::npos) << line;
+  EXPECT_NE(line.find("record_type=1"), std::string::npos) << line;
+  EXPECT_NE(line.find("site=0x140"), std::string::npos) << line;
+  EXPECT_NE(line.find("wave=0xabc"), std::string::npos) << line;
+  EXPECT_NE(line.find("lane=0"), std::string::npos) << line;
+  EXPECT_NE(line.find("payload=0xdead"), std::string::npos) << line;
+}
+
+TEST(LogBufferTest, FormatLogLineMaxValues) {
+  RjLogRecord rec{};
+  rec.record_type = 0xffffffffu;
+  rec.site = 0xffffffffu;
+  rec.wave_id = 0xffffffffu;
+  rec.writer_lane = 0xffffffffu;
+  rec.payload = 0xffffffffffffffffULL;
+  // Exact-string check locks the field mapping, hex widths, and buffer size.
+  EXPECT_EQ(format_log_line(rec), "rj-log record_type=4294967295 site=0xffffffff wave=0xffffffff "
+                                  "lane=4294967295 payload=0xffffffffffffffff");
+}
+
+} // namespace
+} // namespace rocjitsu

--- a/emulation/rocjitsu/tests/patch/log_buffer_test.cpp
+++ b/emulation/rocjitsu/tests/patch/log_buffer_test.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -245,6 +246,8 @@ TEST(LogBufferTest, InvalidThenValidSlotBothHandled) {
   // Leave index 0 unpublished (valid == 0), publish a real record at index 1.
   buf->records()[0].valid = 0;
   buf->records()[1] = RjLogRecord{};
+  buf->records()[1].abi_version = kRjLogAbiVersion;
+  buf->records()[1].record_size = kRjLogRecordSize;
   buf->records()[1].record_type = 7;
   buf->records()[1].site = 0x55;
   buf->records()[1].valid = 1;
@@ -366,9 +369,12 @@ TEST(LogBufferTest, DrainClampsProducerOverrun) {
   ASSERT_NE(buf, nullptr);
   for (uint32_t i = 0; i < 4; ++i)
     publish_record(*buf, 1, 0x10 + i, i);
-  // Simulate a buggy/untrusted producer that advanced write_ptr past
-  // read_ptr + slot_count. Without clamping, indices 4 and 5 would alias slots
-  // 0 and 1 and deliver those records a second time.
+  // Simulate a buggy/untrusted producer that broke the drop-newest contract and
+  // advanced write_ptr past read_ptr + slot_count. Without clamping, indices 4
+  // and 5 would alias slots 0 and 1 and deliver those records a second time.
+  // This checks only the clamp's guarantees -- no double-delivery and the excess
+  // reported in dropped_overrun. Survivor ordering after a contract violation is
+  // undefined by design and deliberately not asserted here.
   buf->header()->write_ptr = 6; // pending = 6 > slot_count (4)
 
   DrainStats stats;
@@ -376,9 +382,49 @@ TEST(LogBufferTest, DrainClampsProducerOverrun) {
   EXPECT_EQ(stats.dropped_overrun, 2u);
   EXPECT_EQ(stats.records_drained, 4u);
   EXPECT_EQ(stats.invalid_slots, 0u);
-  ASSERT_EQ(drained.size(), 4u); // no record delivered more than once
-  for (uint32_t i = 0; i < 4; ++i)
-    EXPECT_EQ(drained[i].site, 0x10u + i);
+  ASSERT_EQ(drained.size(), 4u);
+  // Assert contents order-independently
+  std::set<uint32_t> sites;
+  for (const RjLogRecord &record : drained)
+    sites.insert(record.site);
+  EXPECT_EQ(sites.size(), 4u);
+  EXPECT_EQ(sites, (std::set<uint32_t>{0x10u, 0x11u, 0x12u, 0x13u}));
+}
+
+TEST(LogBufferTest, DrainSkipsIncompatibleAbiVersion) {
+  auto buf = LogBuffer::create_for_host_tests(4);
+  ASSERT_NE(buf, nullptr);
+  publish_record(*buf, 1, 0x10, 1);
+  publish_record(*buf, 2, 0x20, 2);
+  // A probe built against a newer ABI publishes a record the host cannot decode.
+  buf->records()[1].abi_version = kRjLogAbiVersion + 1;
+
+  DrainStats stats;
+  auto drained = drain_all(*buf, &stats);
+  ASSERT_EQ(drained.size(), 1u);
+  EXPECT_EQ(drained[0].site, 0x10u);
+  EXPECT_EQ(stats.records_drained, 1u);
+  EXPECT_EQ(stats.incompatible_records, 1u);
+  EXPECT_EQ(stats.invalid_slots, 0u);
+  // Incompatible slots are cleared so a reused ring does not re-see them.
+  EXPECT_EQ(buf->records()[1].valid, 0u);
+}
+
+TEST(LogBufferTest, DrainSkipsIncompatibleRecordSize) {
+  auto buf = LogBuffer::create_for_host_tests(4);
+  ASSERT_NE(buf, nullptr);
+  publish_record(*buf, 1, 0x10, 1);
+  publish_record(*buf, 2, 0x20, 2);
+  buf->records()[1].record_size = kRjLogRecordSize * 2;
+
+  DrainStats stats;
+  auto drained = drain_all(*buf, &stats);
+  ASSERT_EQ(drained.size(), 1u);
+  EXPECT_EQ(drained[0].site, 0x10u);
+  EXPECT_EQ(stats.records_drained, 1u);
+  EXPECT_EQ(stats.incompatible_records, 1u);
+  EXPECT_EQ(stats.invalid_slots, 0u);
+  EXPECT_EQ(buf->records()[1].valid, 0u);
 }
 
 } // namespace

--- a/emulation/rocjitsu/tests/patch/log_buffer_test.cpp
+++ b/emulation/rocjitsu/tests/patch/log_buffer_test.cpp
@@ -336,5 +336,50 @@ TEST(LogBufferTest, FormatLogLineMaxValues) {
                                   "lane=4294967295 payload=0xffffffffffffffff");
 }
 
+TEST(LogBufferTest, ValidateAcceptsFreshBuffer) {
+  auto buf = LogBuffer::create_for_host_tests(8);
+  ASSERT_NE(buf, nullptr);
+  std::string err;
+  EXPECT_TRUE(buf->validate(&err)) << err;
+}
+
+TEST(LogBufferTest, ValidateRejectsWrongMagic) {
+  auto buf = LogBuffer::create_for_host_tests(8);
+  ASSERT_NE(buf, nullptr);
+  buf->header()->magic = 0xdeadbeef; // as if written by an incompatible producer
+  std::string err;
+  EXPECT_FALSE(buf->validate(&err));
+  EXPECT_NE(err.find("magic"), std::string::npos) << err;
+}
+
+TEST(LogBufferTest, ValidateRejectsWrongAbiVersion) {
+  auto buf = LogBuffer::create_for_host_tests(8);
+  ASSERT_NE(buf, nullptr);
+  buf->header()->abi_version = kRjLogAbiVersion + 1;
+  std::string err;
+  EXPECT_FALSE(buf->validate(&err));
+  EXPECT_NE(err.find("abi_version"), std::string::npos) << err;
+}
+
+TEST(LogBufferTest, DrainClampsProducerOverrun) {
+  auto buf = LogBuffer::create_for_host_tests(4);
+  ASSERT_NE(buf, nullptr);
+  for (uint32_t i = 0; i < 4; ++i)
+    publish_record(*buf, 1, 0x10 + i, i);
+  // Simulate a buggy/untrusted producer that advanced write_ptr past
+  // read_ptr + slot_count. Without clamping, indices 4 and 5 would alias slots
+  // 0 and 1 and deliver those records a second time.
+  buf->header()->write_ptr = 6; // pending = 6 > slot_count (4)
+
+  DrainStats stats;
+  auto drained = drain_all(*buf, &stats);
+  EXPECT_EQ(stats.dropped_overrun, 2u);
+  EXPECT_EQ(stats.records_drained, 4u);
+  EXPECT_EQ(stats.invalid_slots, 0u);
+  ASSERT_EQ(drained.size(), 4u); // no record delivered more than once
+  for (uint32_t i = 0; i < 4; ++i)
+    EXPECT_EQ(drained[i].site, 0x10u + i);
+}
+
 } // namespace
 } // namespace rocjitsu

--- a/emulation/rocjitsu/tests/patch/log_buffer_test.cpp
+++ b/emulation/rocjitsu/tests/patch/log_buffer_test.cpp
@@ -13,6 +13,21 @@
 #include <vector>
 
 namespace rocjitsu {
+
+// Test-only accessor. LogBuffer keeps its factory and raw header/record pointers
+// private because no production consumer defines their contract yet; the tests
+// reach those seams through this friend shim rather than through a public API
+// that would freeze prematurely. Must live in namespace rocjitsu (not the
+// anonymous namespace below) so it names the same type as the friend
+// declaration in LogBuffer.
+struct LogBufferTestAccess {
+  static std::unique_ptr<LogBuffer> create(uint32_t slot_count, std::string *error_out = nullptr) {
+    return LogBuffer::create(slot_count, error_out);
+  }
+  static RjLogBufferHeader *header(LogBuffer &buf) { return buf.header(); }
+  static RjLogRecord *records(LogBuffer &buf) { return buf.records(); }
+};
+
 namespace {
 
 // Simulate what a device producer does: write a record into the slot at the
@@ -20,8 +35,8 @@ namespace {
 // used by the CPU-only tests (there is no atomic arbitration to model here
 // because these tests are single-threaded and post-completion).
 void publish_record(LogBuffer &buf, uint32_t record_type, uint32_t site, uint64_t payload) {
-  RjLogBufferHeader *hdr = buf.header();
-  RjLogRecord *recs = buf.records();
+  RjLogBufferHeader *hdr = LogBufferTestAccess::header(buf);
+  RjLogRecord *recs = LogBufferTestAccess::records(buf);
   const uint64_t index = hdr->write_ptr;
   RjLogRecord &rec = recs[index & (buf.slot_count() - 1)];
   rec.abi_version = kRjLogAbiVersion;
@@ -53,7 +68,7 @@ TEST(LogAbiTest, StructSizesAndAlignment) {
 TEST(LogBufferTest, RejectsNonPowerOfTwoSlotCount) {
   for (uint32_t bad : {0u, 3u, 6u, 7u, 100u}) {
     std::string err;
-    auto buf = LogBuffer::create_for_host_tests(bad, &err);
+    auto buf = LogBufferTestAccess::create(bad, &err);
     EXPECT_EQ(buf, nullptr) << "slot_count=" << bad;
     EXPECT_FALSE(err.empty()) << "slot_count=" << bad;
   }
@@ -62,7 +77,7 @@ TEST(LogBufferTest, RejectsNonPowerOfTwoSlotCount) {
 TEST(LogBufferTest, AcceptsPowerOfTwoSlotCount) {
   for (uint32_t good : {1u, 2u, 8u, 1024u}) {
     std::string err;
-    auto buf = LogBuffer::create_for_host_tests(good, &err);
+    auto buf = LogBufferTestAccess::create(good, &err);
     ASSERT_NE(buf, nullptr) << "slot_count=" << good << " err=" << err;
     EXPECT_EQ(buf->slot_count(), good);
     EXPECT_TRUE(err.empty());
@@ -70,9 +85,9 @@ TEST(LogBufferTest, AcceptsPowerOfTwoSlotCount) {
 }
 
 TEST(LogBufferTest, HeaderInitialized) {
-  auto buf = LogBuffer::create_for_host_tests(8);
+  auto buf = LogBufferTestAccess::create(8);
   ASSERT_NE(buf, nullptr);
-  const RjLogBufferHeader *hdr = buf->header();
+  const RjLogBufferHeader *hdr = LogBufferTestAccess::header(*buf);
   EXPECT_EQ(hdr->magic, kRjLogMagic);
   EXPECT_EQ(hdr->abi_version, kRjLogAbiVersion);
   EXPECT_EQ(hdr->header_size, sizeof(RjLogBufferHeader));
@@ -85,15 +100,16 @@ TEST(LogBufferTest, HeaderInitialized) {
 }
 
 TEST(LogBufferTest, RecordsRegionFollowsHeader) {
-  auto buf = LogBuffer::create_for_host_tests(4);
+  auto buf = LogBufferTestAccess::create(4);
   ASSERT_NE(buf, nullptr);
-  const auto *hdr_end = reinterpret_cast<const char *>(buf->header()) + sizeof(RjLogBufferHeader);
-  EXPECT_EQ(reinterpret_cast<const char *>(buf->records()), hdr_end);
+  const auto *hdr_end =
+      reinterpret_cast<const char *>(LogBufferTestAccess::header(*buf)) + sizeof(RjLogBufferHeader);
+  EXPECT_EQ(reinterpret_cast<const char *>(LogBufferTestAccess::records(*buf)), hdr_end);
   EXPECT_EQ(buf->total_bytes(), sizeof(RjLogBufferHeader) + 4u * sizeof(RjLogRecord));
 }
 
 TEST(LogBufferTest, SyntheticDrainInOrder) {
-  auto buf = LogBuffer::create_for_host_tests(8);
+  auto buf = LogBufferTestAccess::create(8);
   ASSERT_NE(buf, nullptr);
   constexpr uint32_t kN = 5;
   for (uint32_t i = 0; i < kN; ++i)
@@ -111,23 +127,24 @@ TEST(LogBufferTest, SyntheticDrainInOrder) {
     EXPECT_EQ(drained[i].payload, i);
   }
   // read_ptr caught up to write_ptr; a second drain yields nothing.
-  EXPECT_EQ(buf->header()->read_ptr, buf->header()->write_ptr);
+  EXPECT_EQ(LogBufferTestAccess::header(*buf)->read_ptr,
+            LogBufferTestAccess::header(*buf)->write_ptr);
   auto again = drain_all(*buf, nullptr);
   EXPECT_TRUE(again.empty());
 }
 
 TEST(LogBufferTest, DrainClearsValidFlags) {
-  auto buf = LogBuffer::create_for_host_tests(4);
+  auto buf = LogBufferTestAccess::create(4);
   ASSERT_NE(buf, nullptr);
   publish_record(*buf, 1, 0x10, 0);
   publish_record(*buf, 1, 0x20, 0);
   drain_all(*buf, nullptr);
   for (uint32_t i = 0; i < buf->slot_count(); ++i)
-    EXPECT_EQ(buf->records()[i].valid, 0u) << "slot " << i;
+    EXPECT_EQ(LogBufferTestAccess::records(*buf)[i].valid, 0u) << "slot " << i;
 }
 
 TEST(LogBufferTest, WraparoundReusesSlots) {
-  auto buf = LogBuffer::create_for_host_tests(4);
+  auto buf = LogBufferTestAccess::create(4);
   ASSERT_NE(buf, nullptr);
 
   // First fill: indices 0..3 -> slots 0..3.
@@ -143,7 +160,7 @@ TEST(LogBufferTest, WraparoundReusesSlots) {
   auto second = drain_all(*buf, &stats);
   ASSERT_EQ(second.size(), 4u);
   EXPECT_EQ(stats.invalid_slots, 0u);
-  EXPECT_EQ(buf->header()->write_ptr, 8u);
+  EXPECT_EQ(LogBufferTestAccess::header(*buf)->write_ptr, 8u);
   for (uint32_t i = 0; i < 4; ++i) {
     EXPECT_EQ(second[i].record_type, 2u);
     EXPECT_EQ(second[i].site, 0x300u + i);
@@ -152,11 +169,11 @@ TEST(LogBufferTest, WraparoundReusesSlots) {
 }
 
 TEST(LogBufferTest, OverflowCountSurfaced) {
-  auto buf = LogBuffer::create_for_host_tests(4);
+  auto buf = LogBufferTestAccess::create(4);
   ASSERT_NE(buf, nullptr);
   publish_record(*buf, 1, 0x10, 0);
   // Simulate producers that dropped records on a full ring.
-  buf->header()->overflow_count = 7;
+  LogBufferTestAccess::header(*buf)->overflow_count = 7;
 
   DrainStats stats;
   auto drained = drain_all(*buf, &stats);
@@ -167,37 +184,37 @@ TEST(LogBufferTest, OverflowCountSurfaced) {
 }
 
 TEST(LogBufferTest, InvalidAdvertisedSlotIsDiagnosedNotSpun) {
-  auto buf = LogBuffer::create_for_host_tests(4);
+  auto buf = LogBufferTestAccess::create(4);
   ASSERT_NE(buf, nullptr);
   // write_ptr advertises two records, but only one was actually published.
   publish_record(*buf, 1, 0x10, 42);
-  buf->header()->write_ptr = 2; // second slot left with valid == 0
+  LogBufferTestAccess::header(*buf)->write_ptr = 2; // second slot left with valid == 0
 
   DrainStats stats;
   auto drained = drain_all(*buf, &stats);
   EXPECT_EQ(drained.size(), 1u);
   EXPECT_EQ(stats.records_drained, 1u);
   EXPECT_EQ(stats.invalid_slots, 1u);
-  EXPECT_EQ(buf->header()->read_ptr, 2u); // still advances; no spin
+  EXPECT_EQ(LogBufferTestAccess::header(*buf)->read_ptr, 2u); // still advances; no spin
 }
 
 TEST(LogBufferTest, ReinitializeResetsForReuse) {
-  auto buf = LogBuffer::create_for_host_tests(4);
+  auto buf = LogBufferTestAccess::create(4);
   ASSERT_NE(buf, nullptr);
   publish_record(*buf, 1, 0x10, 0);
   publish_record(*buf, 1, 0x20, 0);
-  buf->header()->overflow_count = 3;
+  LogBufferTestAccess::header(*buf)->overflow_count = 3;
   drain_all(*buf, nullptr);
 
   buf->reinitialize();
-  EXPECT_EQ(buf->header()->write_ptr, 0u);
-  EXPECT_EQ(buf->header()->read_ptr, 0u);
+  EXPECT_EQ(LogBufferTestAccess::header(*buf)->write_ptr, 0u);
+  EXPECT_EQ(LogBufferTestAccess::header(*buf)->read_ptr, 0u);
   EXPECT_EQ(buf->overflow_count(), 0u);
   for (uint32_t i = 0; i < buf->slot_count(); ++i)
-    EXPECT_EQ(buf->records()[i].valid, 0u);
+    EXPECT_EQ(LogBufferTestAccess::records(*buf)[i].valid, 0u);
   // Header control fields survive reinitialization.
-  EXPECT_EQ(buf->header()->magic, kRjLogMagic);
-  EXPECT_EQ(buf->header()->slot_count, 4u);
+  EXPECT_EQ(LogBufferTestAccess::header(*buf)->magic, kRjLogMagic);
+  EXPECT_EQ(LogBufferTestAccess::header(*buf)->slot_count, 4u);
 
   // Buffer is usable again.
   publish_record(*buf, 9, 0xabc, 5);
@@ -207,7 +224,7 @@ TEST(LogBufferTest, ReinitializeResetsForReuse) {
 }
 
 TEST(LogBufferTest, EmptyDrainOnFreshBuffer) {
-  auto buf = LogBuffer::create_for_host_tests(8);
+  auto buf = LogBufferTestAccess::create(8);
   ASSERT_NE(buf, nullptr);
   DrainStats stats;
   auto drained = drain_all(*buf, &stats);
@@ -215,19 +232,19 @@ TEST(LogBufferTest, EmptyDrainOnFreshBuffer) {
   EXPECT_EQ(stats.records_drained, 0u);
   EXPECT_EQ(stats.invalid_slots, 0u);
   EXPECT_EQ(stats.overflow_count, 0u);
-  EXPECT_EQ(buf->header()->read_ptr, 0u);
-  EXPECT_EQ(buf->header()->write_ptr, 0u);
+  EXPECT_EQ(LogBufferTestAccess::header(*buf)->read_ptr, 0u);
+  EXPECT_EQ(LogBufferTestAccess::header(*buf)->write_ptr, 0u);
 }
 
 TEST(LogBufferTest, RecordsRegionIs64ByteAligned) {
-  auto buf = LogBuffer::create_for_host_tests(8);
+  auto buf = LogBufferTestAccess::create(8);
   ASSERT_NE(buf, nullptr);
-  EXPECT_EQ(reinterpret_cast<uintptr_t>(buf->header()) % 64u, 0u);
-  EXPECT_EQ(reinterpret_cast<uintptr_t>(buf->records()) % 64u, 0u);
+  EXPECT_EQ(reinterpret_cast<uintptr_t>(LogBufferTestAccess::header(*buf)) % 64u, 0u);
+  EXPECT_EQ(reinterpret_cast<uintptr_t>(LogBufferTestAccess::records(*buf)) % 64u, 0u);
 }
 
 TEST(LogBufferTest, NullCallbackStillDrainsAndClears) {
-  auto buf = LogBuffer::create_for_host_tests(4);
+  auto buf = LogBufferTestAccess::create(4);
   ASSERT_NE(buf, nullptr);
   publish_record(*buf, 1, 0x10, 0);
   publish_record(*buf, 1, 0x20, 0);
@@ -235,23 +252,25 @@ TEST(LogBufferTest, NullCallbackStillDrainsAndClears) {
   DrainStats stats = buf->drain(LogRecordCallback{}); // empty callback
   EXPECT_EQ(stats.records_drained, 2u);
   EXPECT_EQ(stats.invalid_slots, 0u);
-  EXPECT_EQ(buf->header()->read_ptr, buf->header()->write_ptr);
+  EXPECT_EQ(LogBufferTestAccess::header(*buf)->read_ptr,
+            LogBufferTestAccess::header(*buf)->write_ptr);
   for (uint32_t i = 0; i < buf->slot_count(); ++i)
-    EXPECT_EQ(buf->records()[i].valid, 0u) << "slot " << i;
+    EXPECT_EQ(LogBufferTestAccess::records(*buf)[i].valid, 0u) << "slot " << i;
 }
 
 TEST(LogBufferTest, InvalidThenValidSlotBothHandled) {
-  auto buf = LogBuffer::create_for_host_tests(4);
+  auto buf = LogBufferTestAccess::create(4);
   ASSERT_NE(buf, nullptr);
+  RjLogRecord *recs = LogBufferTestAccess::records(*buf);
   // Leave index 0 unpublished (valid == 0), publish a real record at index 1.
-  buf->records()[0].valid = 0;
-  buf->records()[1] = RjLogRecord{};
-  buf->records()[1].abi_version = kRjLogAbiVersion;
-  buf->records()[1].record_size = kRjLogRecordSize;
-  buf->records()[1].record_type = 7;
-  buf->records()[1].site = 0x55;
-  buf->records()[1].valid = 1;
-  buf->header()->write_ptr = 2;
+  recs[0].valid = 0;
+  recs[1] = RjLogRecord{};
+  recs[1].abi_version = kRjLogAbiVersion;
+  recs[1].record_size = kRjLogRecordSize;
+  recs[1].record_type = 7;
+  recs[1].site = 0x55;
+  recs[1].valid = 1;
+  LogBufferTestAccess::header(*buf)->write_ptr = 2;
 
   DrainStats stats;
   auto drained = drain_all(*buf, &stats);
@@ -260,11 +279,11 @@ TEST(LogBufferTest, InvalidThenValidSlotBothHandled) {
   EXPECT_EQ(stats.invalid_slots, 1u);
   EXPECT_EQ(drained[0].record_type, 7u); // the later valid record is delivered
   EXPECT_EQ(drained[0].site, 0x55u);
-  EXPECT_EQ(buf->header()->read_ptr, 2u);
+  EXPECT_EQ(LogBufferTestAccess::header(*buf)->read_ptr, 2u);
 }
 
 TEST(LogBufferTest, SingleSlotRingDrainsAcrossCycles) {
-  auto buf = LogBuffer::create_for_host_tests(1);
+  auto buf = LogBufferTestAccess::create(1);
   ASSERT_NE(buf, nullptr);
   for (uint32_t cycle = 0; cycle < 5; ++cycle) {
     publish_record(*buf, 1, 0x100 + cycle, cycle);
@@ -274,11 +293,11 @@ TEST(LogBufferTest, SingleSlotRingDrainsAcrossCycles) {
     EXPECT_EQ(drained[0].site, 0x100u + cycle);
     EXPECT_EQ(stats.invalid_slots, 0u);
   }
-  EXPECT_EQ(buf->header()->write_ptr, 5u);
+  EXPECT_EQ(LogBufferTestAccess::header(*buf)->write_ptr, 5u);
 }
 
 TEST(LogBufferTest, ExactFullDrainAtCapacity) {
-  auto buf = LogBuffer::create_for_host_tests(4);
+  auto buf = LogBufferTestAccess::create(4);
   ASSERT_NE(buf, nullptr);
   for (uint32_t i = 0; i < 4; ++i) // write_ptr - read_ptr == slot_count
     publish_record(*buf, 1, 0x10 + i, i);
@@ -289,17 +308,17 @@ TEST(LogBufferTest, ExactFullDrainAtCapacity) {
 }
 
 TEST(LogBufferTest, Uint64IndexWraparound) {
-  auto buf = LogBuffer::create_for_host_tests(4);
+  auto buf = LogBufferTestAccess::create(4);
   ASSERT_NE(buf, nullptr);
   // Position the monotonic counters two below the 64-bit boundary so the third
   // published record wraps write_ptr through zero. Drain must still walk all
   // three in order (count-based iteration is wrap-safe).
   constexpr uint64_t kNearMax = 0xFFFFFFFFFFFFFFFEULL;
-  buf->header()->write_ptr = kNearMax;
-  buf->header()->read_ptr = kNearMax;
+  LogBufferTestAccess::header(*buf)->write_ptr = kNearMax;
+  LogBufferTestAccess::header(*buf)->read_ptr = kNearMax;
   for (uint32_t i = 0; i < 3; ++i)
     publish_record(*buf, 1, 0xA0 + i, i);
-  EXPECT_EQ(buf->header()->write_ptr, 1u); // wrapped: FE -> FF -> 00 -> 01
+  EXPECT_EQ(LogBufferTestAccess::header(*buf)->write_ptr, 1u); // wrapped: FE -> FF -> 00 -> 01
 
   DrainStats stats;
   auto drained = drain_all(*buf, &stats);
@@ -307,7 +326,7 @@ TEST(LogBufferTest, Uint64IndexWraparound) {
   EXPECT_EQ(stats.invalid_slots, 0u);
   for (uint32_t i = 0; i < 3; ++i)
     EXPECT_EQ(drained[i].site, 0xA0u + i);
-  EXPECT_EQ(buf->header()->read_ptr, 1u);
+  EXPECT_EQ(LogBufferTestAccess::header(*buf)->read_ptr, 1u);
 }
 
 TEST(LogBufferTest, FormatLogLine) {
@@ -340,32 +359,45 @@ TEST(LogBufferTest, FormatLogLineMaxValues) {
 }
 
 TEST(LogBufferTest, ValidateAcceptsFreshBuffer) {
-  auto buf = LogBuffer::create_for_host_tests(8);
+  auto buf = LogBufferTestAccess::create(8);
   ASSERT_NE(buf, nullptr);
   std::string err;
   EXPECT_TRUE(buf->validate(&err)) << err;
 }
 
-TEST(LogBufferTest, ValidateRejectsWrongMagic) {
-  auto buf = LogBuffer::create_for_host_tests(8);
-  ASSERT_NE(buf, nullptr);
-  buf->header()->magic = 0xdeadbeef; // as if written by an incompatible producer
-  std::string err;
-  EXPECT_FALSE(buf->validate(&err));
-  EXPECT_NE(err.find("magic"), std::string::npos) << err;
-}
+TEST(LogBufferTest, ValidateRejectsEachCorruptedSelfDescribingField) {
+  // One case per validate() rejection branch. Each corrupts a single
+  // self-describing header field on an otherwise-fresh buffer and checks both
+  // that validate() fails and that the diagnostic names the offending field.
+  // No-capture lambdas so the table entries stay plain function pointers.
+  struct Case {
+    const char *name;
+    void (*corrupt)(RjLogBufferHeader *);
+    const char *diagnostic_substr;
+  };
+  const Case cases[] = {
+      {"magic", [](RjLogBufferHeader *h) { h->magic = 0xdeadbeef; }, "magic"},
+      {"abi_version", [](RjLogBufferHeader *h) { h->abi_version = kRjLogAbiVersion + 1; },
+       "abi_version"},
+      {"header_size", [](RjLogBufferHeader *h) { h->header_size = sizeof(RjLogBufferHeader) + 1; },
+       "header_size"},
+      {"record_size", [](RjLogBufferHeader *h) { h->record_size = kRjLogRecordSize + 1; },
+       "record_size"},
+      {"slot_count", [](RjLogBufferHeader *h) { h->slot_count += 1; }, "slot_count"},
+  };
 
-TEST(LogBufferTest, ValidateRejectsWrongAbiVersion) {
-  auto buf = LogBuffer::create_for_host_tests(8);
-  ASSERT_NE(buf, nullptr);
-  buf->header()->abi_version = kRjLogAbiVersion + 1;
-  std::string err;
-  EXPECT_FALSE(buf->validate(&err));
-  EXPECT_NE(err.find("abi_version"), std::string::npos) << err;
+  for (const Case &c : cases) {
+    auto buf = LogBufferTestAccess::create(8);
+    ASSERT_NE(buf, nullptr) << c.name;
+    c.corrupt(LogBufferTestAccess::header(*buf)); // as if written by an incompatible producer
+    std::string err;
+    EXPECT_FALSE(buf->validate(&err)) << c.name;
+    EXPECT_NE(err.find(c.diagnostic_substr), std::string::npos) << c.name << ": " << err;
+  }
 }
 
 TEST(LogBufferTest, DrainClampsProducerOverrun) {
-  auto buf = LogBuffer::create_for_host_tests(4);
+  auto buf = LogBufferTestAccess::create(4);
   ASSERT_NE(buf, nullptr);
   for (uint32_t i = 0; i < 4; ++i)
     publish_record(*buf, 1, 0x10 + i, i);
@@ -375,7 +407,7 @@ TEST(LogBufferTest, DrainClampsProducerOverrun) {
   // This checks only the clamp's guarantees -- no double-delivery and the excess
   // reported in dropped_overrun. Survivor ordering after a contract violation is
   // undefined by design and deliberately not asserted here.
-  buf->header()->write_ptr = 6; // pending = 6 > slot_count (4)
+  LogBufferTestAccess::header(*buf)->write_ptr = 6; // pending = 6 > slot_count (4)
 
   DrainStats stats;
   auto drained = drain_all(*buf, &stats);
@@ -392,12 +424,12 @@ TEST(LogBufferTest, DrainClampsProducerOverrun) {
 }
 
 TEST(LogBufferTest, DrainSkipsIncompatibleAbiVersion) {
-  auto buf = LogBuffer::create_for_host_tests(4);
+  auto buf = LogBufferTestAccess::create(4);
   ASSERT_NE(buf, nullptr);
   publish_record(*buf, 1, 0x10, 1);
   publish_record(*buf, 2, 0x20, 2);
   // A probe built against a newer ABI publishes a record the host cannot decode.
-  buf->records()[1].abi_version = kRjLogAbiVersion + 1;
+  LogBufferTestAccess::records(*buf)[1].abi_version = kRjLogAbiVersion + 1;
 
   DrainStats stats;
   auto drained = drain_all(*buf, &stats);
@@ -407,15 +439,15 @@ TEST(LogBufferTest, DrainSkipsIncompatibleAbiVersion) {
   EXPECT_EQ(stats.incompatible_records, 1u);
   EXPECT_EQ(stats.invalid_slots, 0u);
   // Incompatible slots are cleared so a reused ring does not re-see them.
-  EXPECT_EQ(buf->records()[1].valid, 0u);
+  EXPECT_EQ(LogBufferTestAccess::records(*buf)[1].valid, 0u);
 }
 
 TEST(LogBufferTest, DrainSkipsIncompatibleRecordSize) {
-  auto buf = LogBuffer::create_for_host_tests(4);
+  auto buf = LogBufferTestAccess::create(4);
   ASSERT_NE(buf, nullptr);
   publish_record(*buf, 1, 0x10, 1);
   publish_record(*buf, 2, 0x20, 2);
-  buf->records()[1].record_size = kRjLogRecordSize * 2;
+  LogBufferTestAccess::records(*buf)[1].record_size = kRjLogRecordSize * 2;
 
   DrainStats stats;
   auto drained = drain_all(*buf, &stats);
@@ -424,7 +456,7 @@ TEST(LogBufferTest, DrainSkipsIncompatibleRecordSize) {
   EXPECT_EQ(stats.records_drained, 1u);
   EXPECT_EQ(stats.incompatible_records, 1u);
   EXPECT_EQ(stats.invalid_slots, 0u);
-  EXPECT_EQ(buf->records()[1].valid, 0u);
+  EXPECT_EQ(LogBufferTestAccess::records(*buf)[1].valid, 0u);
 }
 
 } // namespace


### PR DESCRIPTION
## Motivation

Adds the host-side logging ring buffer for eventual use by device probes to pass dynamic instrumentation data back to the host. Vague plan for complete implementation in Issue #8574.

## Technical Details

* Added an ABI in `log_abi.h`. Defines a `RjLogBufferHeader` which includes the buffer metadata (e.g. `read_ptr` and `write_ptr`) and a `RjLogRecord` which includes the pertinent information at an instrumentation point (`record_type`, `site`, and the actual `payload`). Currently includes a way to create versions for future compatibility issues.
* Added the logging buffer functionality in `log_buffer.{h,cpp}`. Currently assumes one dispatch at a time (will need to reinitialize for a second dispatch), single-threaded, AND that drain runs after dispatch is complete. The expectation is that we will add these improvements once everything is working.
* Added CPU-only tests

## Test Plan

* Added tests should pass
* All other tests should pass

## Test Result

* All tests pass

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
