### PR TITLE
fix: Finddw from rocm sysdeps first

### DIFF
--- a/.github/workflows/rocprofiler-sdk-continuous_integration.yml
+++ b/.github/workflows/rocprofiler-sdk-continuous_integration.yml
@@ -205,7 +205,7 @@ jobs:
         run: |
           git config --global --add safe.directory '*'
           apt-get update
-          apt-get install -y g++-11 g++-12 cmake python3-pip libdw-dev libsqlite3-dev libdrm-dev file autoconf pkg-config rpm libzstd-dev
+          apt-get install -y g++-11 g++-12 cmake python3-pip libsqlite3-dev libdrm-dev file autoconf pkg-config rpm libzstd-dev
           update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 10 --slave /usr/bin/g++ g++ /usr/bin/g++-11 --slave /usr/bin/gcov gcov /usr/bin/gcov-11
           update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 20 --slave /usr/bin/g++ g++ /usr/bin/g++-12 --slave /usr/bin/gcov gcov /usr/bin/gcov-12
           python3 -m pip install -U --user -r requirements.txt
@@ -558,7 +558,7 @@ jobs:
       run: |
         git config --global --add safe.directory '*'
         apt-get update
-        apt-get install -y build-essential cmake python3-pip libasan8 libtsan2 software-properties-common clang-15 libdw-dev libsqlite3-dev libdrm-dev file autoconf pkg-config
+        apt-get install -y build-essential cmake python3-pip libasan8 libtsan2 software-properties-common clang-15 libsqlite3-dev libdrm-dev file autoconf pkg-config
         add-apt-repository ppa:ubuntu-toolchain-r/test
         apt-get update
         apt-get upgrade -y

--- a/.github/workflows/rocprofiler-sdk-docs.yml
+++ b/.github/workflows/rocprofiler-sdk-docs.yml
@@ -174,7 +174,7 @@ jobs:
         working-directory: projects/rocprofiler-sdk/
         run: |
           apt-get update
-          apt-get install -y cmake gcc g++ libdw-dev libsqlite3-dev rpm
+          apt-get install -y cmake gcc g++ libsqlite3-dev rpm
           python3 -m pip install -r requirements.txt
 
       - name: Build ROCProfiler SDK Dependencies

--- a/.github/workflows/rocprofiler-sdk-docs.yml
+++ b/.github/workflows/rocprofiler-sdk-docs.yml
@@ -174,7 +174,7 @@ jobs:
         working-directory: projects/rocprofiler-sdk/
         run: |
           apt-get update
-          apt-get install -y cmake gcc g++ libsqlite3-dev rpm
+          apt-get install -y cmake gcc g++ libdw-dev libsqlite3-dev rpm
           python3 -m pip install -r requirements.txt
 
       - name: Build ROCProfiler SDK Dependencies

--- a/projects/rocprofiler-sdk/cmake/Modules/Findlibdw.cmake
+++ b/projects/rocprofiler-sdk/cmake/Modules/Findlibdw.cmake
@@ -25,8 +25,7 @@
 #
 
 if(NOT libdw_ROOT)
-    foreach(_libdw_ROCM_ROOT
-            IN
+    foreach(_libdw_ROCM_ROOT IN
             ITEMS "${ROCM_PATH}" "$ENV{ROCM_PATH}" "${rocm_version_DIR}"
                   "${ROCPROFILER_DEFAULT_ROCM_PATH}" "/opt/rocm")
         set(_libdw_ROCM_SYSDEPS "${_libdw_ROCM_ROOT}/lib/rocm_sysdeps")

--- a/projects/rocprofiler-sdk/cmake/Modules/Findlibdw.cmake
+++ b/projects/rocprofiler-sdk/cmake/Modules/Findlibdw.cmake
@@ -10,6 +10,8 @@
 #  libdw_ROOT         Set this variable to the root installation of
 #                     libdw if the module has problems finding the
 #                     proper installation path.
+#                     By default, ROCm's rocm_sysdeps libdw is preferred
+#                     when it is available under ROCM_PATH or /opt/rocm.
 #
 # Variables defined by this module:
 #
@@ -22,9 +24,23 @@
 #   libdw::libdw
 #
 
+if(NOT libdw_ROOT)
+    foreach(_libdw_ROCM_ROOT
+            IN
+            ITEMS "${ROCM_PATH}" "$ENV{ROCM_PATH}" "${rocm_version_DIR}"
+                  "${ROCPROFILER_DEFAULT_ROCM_PATH}" "/opt/rocm")
+        set(_libdw_ROCM_SYSDEPS "${_libdw_ROCM_ROOT}/lib/rocm_sysdeps")
+        if(EXISTS "${_libdw_ROCM_SYSDEPS}/include/elfutils/libdw.h"
+           AND EXISTS "${_libdw_ROCM_SYSDEPS}/lib/libdw.so")
+            set(libdw_ROOT "${_libdw_ROCM_SYSDEPS}")
+            break()
+        endif()
+    endforeach()
+endif()
+
 find_package(PkgConfig)
 
-if(PkgConfig_FOUND)
+if(PkgConfig_FOUND AND NOT libdw_ROOT)
     set(ENV{PKG_CONFIG_SYSTEM_INCLUDE_PATH} "")
     pkg_check_modules(DW libdw)
 

--- a/projects/rocprofiler-sdk/cmake/rocprofiler_config_packaging.cmake
+++ b/projects/rocprofiler-sdk/cmake/rocprofiler_config_packaging.cmake
@@ -198,6 +198,11 @@ if(rocm_version_DIR)
     # since most ROCm packages do not set CPACK_DEBIAN_PACKAGE_GENERATE_SHLIBS=ON
     list(APPEND CPACK_DEBIAN_PACKAGE_SHLIBDEPS_PRIVATE_DIRS
          "${rocm_version_DIR}/${CMAKE_INSTALL_LIBDIR}")
+    set(_sysdeps_libdir "${rocm_version_DIR}/${CMAKE_INSTALL_LIBDIR}/rocm_sysdeps")
+    set(_sysdeps_libdir "${_sysdeps_libdir}/${CMAKE_INSTALL_LIBDIR}")
+    if(EXISTS "${_sysdeps_libdir}")
+        list(APPEND CPACK_DEBIAN_PACKAGE_SHLIBDEPS_PRIVATE_DIRS "${_sysdeps_libdir}")
+    endif()
 endif()
 if(DEFINED ENV{CPACK_DEBIAN_PACKAGE_RELEASE})
     set(CPACK_DEBIAN_PACKAGE_RELEASE

--- a/projects/rocprofiler-sdk/docker/Dockerfile.ci
+++ b/projects/rocprofiler-sdk/docker/Dockerfile.ci
@@ -21,7 +21,7 @@ ENV LD_LIBRARY_PATH=/opt/rocm/lib:/opt/rocm/llvm/lib:${LD_LIBRARY_PATH:-}
 RUN set-euo pipefail; \
     if [ -f /etc/debian_version ]; then \
         apt-get update && \
-        apt-get install -y curl wget gpg python3 python3-pip build-essential coreutils software-properties-common cmake g++-11 g++-12 libdw-dev libsqlite3-dev libdrm-dev file autoconf pkg-config rpm libzstd-dev && \
+        apt-get install -y curl wget gpg python3 python3-pip build-essential coreutils software-properties-common cmake g++-11 g++-12 libsqlite3-dev libdrm-dev file autoconf pkg-config rpm libzstd-dev && \
         add-apt-repository ppa:git-core/ppa && \
         mkdir -p /etc/apt/keyrings && \
         wget -N -P /tmp/ https://repo.radeon.com/amdgpu-install/7.2/ubuntu/jammy/amdgpu-install_7.2.70200-1_all.deb && \
@@ -58,7 +58,7 @@ RUN set -euo pipefail; \
             echo -e "[amdgpu]\nname=amdgpu\nbaseurl=https://repo.radeon.com/amdgpu/latest/rhel/9.6/main/x86_64/\nenabled=1\npriority=50\ngpgcheck=1\ngpgkey=https://repo.radeon.com/rocm/rocm.gpg.key" > /etc/yum.repos.d/amdgpu.repo; \
         fi; \
         dnf clean all; \
-        dnf install -y rocm-openmp rocm-openmp-sdk rocm-llvm-devel hipify-clang libsqlite3x-devel openmpi-devel elfutils-devel; \
+        dnf install -y rocm-openmp rocm-openmp-sdk rocm-llvm-devel hipify-clang libsqlite3x-devel openmpi-devel; \
         python3 -m pip install -U awscli pipx; \
         python3 -m venv rocprofiler-sdk; \
         source rocprofiler-sdk/bin/activate; \

--- a/projects/rocprofiler-sdk/samples/code_object_isa_decode/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/samples/code_object_isa_decode/CMakeLists.txt
@@ -48,10 +48,12 @@ target_link_libraries(
             amd_comgr rocprofiler-sdk::samples-build-flags)
 
 rocprofiler_samples_get_preload_env(PRELOAD_ENV)
+rocprofiler_samples_get_ld_library_path_env(LIBRARY_PATH_ENV)
+set(code-object-isa-decode-env ${PRELOAD_ENV} ${LIBRARY_PATH_ENV})
 
 add_test(NAME code-object-isa-decode COMMAND $<TARGET_FILE:code-object-isa-decode>)
 
 set_tests_properties(
     code-object-isa-decode
-    PROPERTIES TIMEOUT 45 LABELS "samples" ENVIRONMENT "${PRELOAD_ENV}"
+    PROPERTIES TIMEOUT 45 LABELS "samples" ENVIRONMENT "${code-object-isa-decode-env}"
                FAIL_REGULAR_EXPRESSION "threw an exception")

--- a/projects/rocprofiler-sdk/samples/code_object_tracing/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/samples/code_object_tracing/CMakeLists.txt
@@ -43,10 +43,12 @@ target_link_libraries(
     code-object-tracing PRIVATE code-object-tracing-client Threads::Threads
                                 rocprofiler-sdk::samples-build-flags)
 
+rocprofiler_samples_get_ld_library_path_env(LIBRARY_PATH_ENV)
+set(code-object-tracing-env ${ROCPROFILER_MEMCHECK_PRELOAD_ENV} ${LIBRARY_PATH_ENV})
+
 add_test(NAME code-object-tracing COMMAND $<TARGET_FILE:code-object-tracing>)
 
 set_tests_properties(
     code-object-tracing
-    PROPERTIES TIMEOUT 45 LABELS "samples" ENVIRONMENT
-               "${ROCPROFILER_MEMCHECK_PRELOAD_ENV}" FAIL_REGULAR_EXPRESSION
-               "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
+    PROPERTIES TIMEOUT 45 LABELS "samples" ENVIRONMENT "${code-object-tracing-env}"
+               FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")

--- a/projects/rocprofiler-sdk/samples/common/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/samples/common/CMakeLists.txt
@@ -84,6 +84,13 @@ function(rocprofiler_samples_get_ld_library_path_env _VAR)
         endif()
         string(APPEND _LDLIB_PATH "$<TARGET_FILE_DIR:${_TARG}>:")
     endforeach()
+    get_target_property(_LIBDW_LIBRARIES libdw::libdw INTERFACE_LINK_LIBRARIES)
+    foreach(_LIBDW_LIBRARY IN LISTS _LIBDW_LIBRARIES)
+        if(IS_ABSOLUTE "${_LIBDW_LIBRARY}" AND _LIBDW_LIBRARY MATCHES "/rocm_sysdeps/")
+            cmake_path(GET _LIBDW_LIBRARY PARENT_PATH _LIBDW_LIBRARY_DIR)
+            string(APPEND _LDLIB_PATH "${_LIBDW_LIBRARY_DIR}:")
+        endif()
+    endforeach()
     # append the environments current LD_LIBRARY_PATH
     string(APPEND _LDLIB_PATH "$ENV{LD_LIBRARY_PATH}")
 

--- a/projects/rocprofiler-sdk/samples/thread_trace/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/samples/thread_trace/CMakeLists.txt
@@ -79,8 +79,10 @@ if(attdecoder_FOUND)
 endif()
 
 rocprofiler_samples_get_preload_env(PRELOAD_ENV)
+rocprofiler_samples_get_ld_library_path_env(LIBRARY_PATH_ENV)
 list(APPEND PRELOAD_ENV "ROCPROFILER_TRACE_DECODER_LIB_PATH=${attdecoder_LIB_DIR}")
+set(thread-trace-sample-env ${PRELOAD_ENV} ${LIBRARY_PATH_ENV})
 
 set_tests_properties(
-    thread-trace-sample PROPERTIES TIMEOUT 60 ENVIRONMENT "${PRELOAD_ENV}" LABELS
-                                   "samples;thread-trace" DISABLED ${IS_DISABLED})
+    thread-trace-sample PROPERTIES TIMEOUT 60 ENVIRONMENT "${thread-trace-sample-env}"
+                                   LABELS "samples;thread-trace" DISABLED ${IS_DISABLED})


### PR DESCRIPTION
## Motivation

TheRock builds libdw.so in lib/rocm_sysdeps/lib.
Rocprofiler-sdk does not need to use the system library in that case.

JIRA ID : AIPROFSDK-957

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
