### PR TITLE
fix(hip): correct local L1 cache comment typo

### DIFF
--- a/projects/hip/include/hip/hip_runtime_api.h
+++ b/projects/hip/include/hip/hip_runtime_api.h
@@ -166,7 +166,7 @@ typedef struct hipDeviceProp_t {
   int maxThreadsPerMultiProcessor;  ///< Maximum resident threads per multi-processor.
   int streamPrioritiesSupported;    ///< Device supports stream priority
   int globalL1CacheSupported;       ///< Indicates globals are cached in L1
-  int localL1CacheSupported;        ///< Locals are cahced in L1
+  int localL1CacheSupported;        ///< Locals are cached in L1
   size_t sharedMemPerMultiprocessor;  ///< Amount of shared memory available per multiprocessor.
   int regsPerMultiprocessor;          ///< registers available per multiprocessor
   int managedMemory;                  ///< Device supports allocating managed memory on this system

--- a/projects/hip/test_hip_runtime_api_docs.py
+++ b/projects/hip/test_hip_runtime_api_docs.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from pathlib import Path
+
+
+def test_local_l1_cache_comment_spelling() -> None:
+    header = Path(__file__).parent / "include" / "hip" / "hip_runtime_api.h"
+    text = header.read_text(encoding="utf-8")
+
+    assert "Locals are cached in L1" in text
+    assert "Locals are cahced in L1" not in text


### PR DESCRIPTION
## Summary

- Fixes a typo in the `hipDeviceProp_t` documentation comment for `localL1CacheSupported`.

## Issue

Fixes #7156.

## Verification

- `git diff --check`
- `rg -n "cahced|Locals are cached in L1|localL1CacheSupported" projects/hip/include/hip/hip_runtime_api.h`

This is a comment-only documentation typo fix, so I did not run a full ROCm build.
