### PR TITLE
[ROCDXG] Update librocdxg to latest b164fa43ace6e4c35da573cd5b6479a50…

### DIFF
--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt.h
@@ -1423,7 +1423,7 @@ HSAKMTAPI
 hsaKmtMemoryGetCpuAddr(
   HsaAMDGPUDeviceHandle DeviceHandle,
   HsaMemoryObjectHandle MemoryHandle,
-  HSAuint64* cpu_addr // OUT
+  HSAuint64* cpu_addr // OUT for newer ROCr; legacy ROCr passes HSAint32* fd here
 );
 
 HSAKMT_STATUS

--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmttypes.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmttypes.h
@@ -1586,7 +1586,7 @@ typedef struct _HsaHandleImportFlags {
 typedef struct _HsaStructureSizes {
   HSAuint16 StructureSizes;           // sizeof(HsaStructureSizes) used for check overflow
   HSAuint16 SizeOfHsaNodeProperties;  // sizeof(HsaNodeProperties)
-  HSAuint16 SizeOfHsaExternalHandleDesc; // sizeof(HsaExternalHandleDesc)
+  HSAuint16 SizeOfHsaExternalHandleDesc; // Historical name; sizeof(HsaHandleImportDesc)
   HSAuint16 Reserved[5];
 } HsaStructureSizes;
 

--- a/projects/rocr-runtime/libhsakmt/src/dxg/topology.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/topology.cpp
@@ -741,14 +741,32 @@ HSAKMT_STATUS topology_sysfs_get_node_props(uint32_t node_id, HsaNodeProperties&
   props.CComputeIdLo = 0;
   props.FComputeIdLo = 0;
   props.Capability.ui32.ASICRevision = device->AsicRevision();
-  props.Capability.ui32.WatchPointsTotalBits = std::log2(device->WatchPointsNum());
-  props.MaxWavesPerSIMD = device->WavePerCu() / device->SimdPerCu();
+  uint32_t watch_points_num = device->WatchPointsNum();
+  if (watch_points_num == 0) {
+    pr_warn(
+        "WatchPointsNum is 0 for node %u, forcing WatchPointsTotalBits to 0\n",
+        node_id);
+    props.Capability.ui32.WatchPointsTotalBits = 0;
+  } else {
+    props.Capability.ui32.WatchPointsTotalBits = std::log2(watch_points_num);
+  }
+  uint32_t simd_per_cu = device->SimdPerCu();
+  if (simd_per_cu == 0){
+    pr_err("SimdPerCU is 0 for node %u\n", node_id);
+    return HSAKMT_STATUS_ERROR;
+  }
   props.LDSSizeInKB = device->LdsSize() / 1024;
   props.GDSSizeInKB = 0;
   props.WaveFrontSize = device->WavefrontSize();
   props.NumShaderBanks = device->NumShaderEngine();
   props.NumArrays = device->ShaderArrayPerShaderEngine();
-  props.NumCUPerArray = device->ComputeUnitCount() / props.NumArrays;
+  if (props.NumArrays == 0) {
+    pr_warn("NumArrays is 0 for node %u, forcing NumCUPerArray to 0\n",
+            node_id);
+    props.NumCUPerArray = 0;
+  } else {
+    props.NumCUPerArray = device->ComputeUnitCount() / props.NumArrays;
+  }
   props.NumSIMDPerCU = device->SimdPerCu();
   props.MaxSlotsScratchCU = device->MaxScratchSlotsPerCu();
   props.VendorId = 0x1002;


### PR DESCRIPTION
Cherry pick eb8aa55 into 7.14 release branch.

## Motivation
This PR updates librocdxg subproject from original ROCm/librocdxg commit c71c16dd7d90ef90965b62bc53b62277176b5b41 to commit b164fa43ace6e4c35da573cd5b6479a503f5b56c <!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical details
Improves error handling by introducing additional guards in topology_sysfs_get_node_props:
  - WatchPointsNum == 0: warn, set WatchPointsTotalBits = 0
  - SimdPerCu == 0: hard fail with HSAKMT_STATUS_ERROR
  - NumArrays == 0: warn, set NumCUPerArray = 0 <!-- Explain the changes along with any relevant GitHub links. -->

## JIRA-ID
ROCM-27124
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test plan
Already tested in mainline
<!-- Explain any relevant testing done to verify this PR. -->

## Test results
NA
<!-- Briefly summarize test outcomes. -->

## Submission Checklist
- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.