### PR TITLE
[hipfile] Enable rocprofiler-register support in hipfile by default

### DIFF
--- a/projects/hipfile/CMakeLists.txt
+++ b/projects/hipfile/CMakeLists.txt
@@ -159,11 +159,9 @@ list(APPEND CMAKE_PREFIX_PATH
     ${ROCM_PATH}/llvm
     ${ROCM_PATH}
     ${ROCM_PATH}/hip
-    ${ROCM_PATH}/lib/rocm_sysdeps
     /opt/rocm/llvm
     /opt/rocm
     /opt/rocm/hip
-    /opt/rocm/lib/rocm_sysdeps
 )
 
 # Set hipFile Install Path to the ROCm directory
@@ -278,13 +276,16 @@ else()
     message(NOTICE "find_package did NOT find hip")
 endif()
 
-if(HIPFILE_ROCPROFILER_REGISTER)
-    find_package(rocprofiler-register REQUIRED
-                 HINTS
-                     $ENV{rocprofiler_register_ROOT}
-                     $ENV{ROCPROFILER_REGISTER_ROOT}
-                     ${CMAKE_INSTALL_PREFIX}
-                 PATHS ${ROCM_PATH})
+if(HIPFILE_ROCPROFILER_REGISTER AND AIS_BUILD_AMD_DETAIL)
+  find_package(
+    rocprofiler-register
+    REQUIRED
+    HINTS
+      $ENV{rocprofiler_register_ROOT}
+      $ENV{ROCPROFILER_REGISTER_ROOT}
+      ${CMAKE_INSTALL_PREFIX}
+    PATHS
+      ${ROCM_PATH})
 endif()
 
 # Find the cuFile library and headers on NVIDIA

--- a/projects/hipfile/CMakeLists.txt
+++ b/projects/hipfile/CMakeLists.txt
@@ -159,9 +159,11 @@ list(APPEND CMAKE_PREFIX_PATH
     ${ROCM_PATH}/llvm
     ${ROCM_PATH}
     ${ROCM_PATH}/hip
+    ${ROCM_PATH}/lib/rocm_sysdeps
     /opt/rocm/llvm
     /opt/rocm
     /opt/rocm/hip
+    /opt/rocm/lib/rocm_sysdeps
 )
 
 # Set hipFile Install Path to the ROCm directory
@@ -235,6 +237,12 @@ option(AIS_INSTALL_EXAMPLES "Install example programs" ON)
 option(AIS_INSTALL_TOOLS "Install tool programs" ON)
 
 #------------------
+# rocprofiler-register integration
+#------------------
+option(HIPFILE_ROCPROFILER_REGISTER "Enable rocprofiler-register API table registration" ON)
+
+
+#------------------
 # Test programs
 #------------------
 # Whether to install the relocatable unit-test assets (binaries + ctest files)
@@ -268,6 +276,15 @@ if(${hip_FOUND})
     message(STATUS "hip found @  ${hip_DIR} ")
 else()
     message(NOTICE "find_package did NOT find hip")
+endif()
+
+if(HIPFILE_ROCPROFILER_REGISTER)
+    find_package(rocprofiler-register REQUIRED
+                 HINTS
+                     $ENV{rocprofiler_register_ROOT}
+                     $ENV{ROCPROFILER_REGISTER_ROOT}
+                     ${CMAKE_INSTALL_PREFIX}
+                 PATHS ${ROCM_PATH})
 endif()
 
 # Find the cuFile library and headers on NVIDIA

--- a/projects/hipfile/src/amd_detail/CMakeLists.txt
+++ b/projects/hipfile/src/amd_detail/CMakeLists.txt
@@ -32,14 +32,6 @@ set(HIPFILE_SOURCES
     sys.cpp
 )
 
-set(HIPFILE_AMD_SYSINCLS ${HIPFILE_AMD_SOURCE_PATH})
-foreach(_hipfile_sysdeps_prefix IN ITEMS "${ROCM_PATH}/lib/rocm_sysdeps" "/opt/rocm/lib/rocm_sysdeps")
-    if(EXISTS "${_hipfile_sysdeps_prefix}/include")
-        list(APPEND HIPFILE_AMD_SYSINCLS "${_hipfile_sysdeps_prefix}/include")
-    endif()
-endforeach()
-list(REMOVE_DUPLICATES HIPFILE_AMD_SYSINCLS)
-
 # Create hipfile target
 ais_add_libraries(
     NAME     hipfile
@@ -47,7 +39,7 @@ ais_add_libraries(
     LIBS     mount
     SRCS     ${HIPFILE_SOURCES}
     LIBINCL  ${HIPFILE_INCLUDE_PATH}
-    SYSINCLS ${HIPFILE_AMD_SYSINCLS}
+    SYSINCLS ${HIPFILE_AMD_SOURCE_PATH}
 )
 
 if(HIPFILE_ROCPROFILER_REGISTER)

--- a/projects/hipfile/src/amd_detail/CMakeLists.txt
+++ b/projects/hipfile/src/amd_detail/CMakeLists.txt
@@ -32,6 +32,14 @@ set(HIPFILE_SOURCES
     sys.cpp
 )
 
+set(HIPFILE_AMD_SYSINCLS ${HIPFILE_AMD_SOURCE_PATH})
+foreach(_hipfile_sysdeps_prefix IN ITEMS "${ROCM_PATH}/lib/rocm_sysdeps" "/opt/rocm/lib/rocm_sysdeps")
+    if(EXISTS "${_hipfile_sysdeps_prefix}/include")
+        list(APPEND HIPFILE_AMD_SYSINCLS "${_hipfile_sysdeps_prefix}/include")
+    endif()
+endforeach()
+list(REMOVE_DUPLICATES HIPFILE_AMD_SYSINCLS)
+
 # Create hipfile target
 ais_add_libraries(
     NAME     hipfile
@@ -39,5 +47,17 @@ ais_add_libraries(
     LIBS     mount
     SRCS     ${HIPFILE_SOURCES}
     LIBINCL  ${HIPFILE_INCLUDE_PATH}
-    SYSINCLS ${HIPFILE_AMD_SOURCE_PATH}
+    SYSINCLS ${HIPFILE_AMD_SYSINCLS}
 )
+
+if(HIPFILE_ROCPROFILER_REGISTER)
+    target_compile_definitions(
+        hipfile
+        PRIVATE
+            HIPFILE_ROCPROFILER_REGISTER=1
+            HIPFILE_ROCP_REG_VERSION_MAJOR=${AIS_LIBRARY_MAJOR}
+            HIPFILE_ROCP_REG_VERSION_MINOR=${AIS_LIBRARY_MINOR}
+            HIPFILE_ROCP_REG_VERSION_PATCH=${AIS_LIBRARY_PATCH})
+    target_link_libraries(hipfile PRIVATE rocprofiler-register::rocprofiler-register)
+    set_target_properties(hipfile PROPERTIES INSTALL_RPATH "\$ORIGIN")
+endif()


### PR DESCRIPTION
## Motivation

- hipfile builds its API dispatch table unconditionally, but the table is only registered with rocprofiler-register when HIPFILE_ROCPROFILER_REGISTER is enabled. Without that registration, rocprofiler-sdk can enumerate HIPFILE_API operation names but cannot capture hipfile callback or buffered trace records.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

JIRA ID - AIPROFSDK-5

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
