### PR TITLE
fix(rocprofiler-sdk): code object cb ordering

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/code_object_registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/code_object_registration.cpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -114,11 +114,14 @@ executable_destroy(hsa_executable_t executable)
     // Fire callbacks after erasing from the collection but before calling the real destroy.
     // Erasing first prevents double-destroy races. Calling the real destroy last ensures the
     // handle remains valid during callbacks, and that any handle still in code_objects is live.
-    for(auto& entry : snapshot)
+    // Iterate in reverse (LIFO) to mirror the SDK chaining convention: the most recently registered
+    // handler runs first and calls the chained destroy callback after its own work, effectively
+    // reversing the order of callbacks from freeze/create
+    for(auto it = snapshot.rbegin(); it != snapshot.rend(); ++it)
     {
-        if(entry.cb)
+        if(it->cb)
         {
-            entry.cb(executable, ROCPROFILER_ATTACH_CODE_OBJECT_DESTROYED, entry.data);
+            it->cb(executable, ROCPROFILER_ATTACH_CODE_OBJECT_DESTROYED, it->data);
         }
     }
 


### PR DESCRIPTION
- Attach library now calls destroy callbacks in reverse order of registration
- Matches existing behavior of SDK
- Fixes an issue in PC sampling where code object data was never deleted

## Motivation

Fixes an issue where PC sampling code objects were never deleted found during validation of AIPROFSDK-856. Patches bug introduced by new features in #3933
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

In typical initialization, when PC sampling is enabled, initialize will replace the hsa_executable_freeze and hsa_executable_destroy after code object initialization. The destroy implementation in particular expects this order. The attach library reversed this order, which caused the code object destroy callback to run first. The destroy would remove code objects from the shared storage and then the pc sampling callback would be unable to find the entry and fail. 
<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

JIRA ID: AIPROFSDK-856
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Existing CI
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
