### PR TITLE
refactor(rocm): unify metadata prefetch path and fix ext dispatch han…

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -731,7 +731,7 @@ bool Device::create() {
     return false;
   }
 
-  if (AMD_LOG_LEVEL >= LOG_EXTRA_DEBUG) {
+  if (AMD_LOG_LEVEL >= LOG_EXTRA_EXTRA_DEBUG) {
     uint8_t logMask[8] = {0};
     hsa_flag_set64(logMask, HSA_AMD_LOG_FLAG_AQL);
     hsa_flag_set64(logMask, HSA_AMD_LOG_FLAG_SDMA);

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -171,9 +171,44 @@ static inline void logAqlDispatchPacket(const Device& dev, const hsa_queue_t* qu
           rptr, wptr);
 }
 
+static inline void logAqlMetadataPacket(const Device& dev, const hsa_queue_t* queue,
+                                        const hsa_amd_metadata_kernel_dispatch_packet_t* meta,
+                                        uint64_t wptr) {
+  if (meta == nullptr) {
+    return;
+  }
+  const auto& desc = meta->kernel_descriptor;
+
+  // Dump the launch descriptor as a raw dword blob (13 dwords / 52 bytes).
+  constexpr size_t kNumLaunchDescriptorDwords =
+      sizeof(meta->launch_descriptor) / sizeof(uint32_t);
+  const uint32_t* launchDwords = reinterpret_cast<const uint32_t*>(&meta->launch_descriptor);
+  char launchDescriptorBlob[kNumLaunchDescriptorDwords * 11 + 1];
+  size_t offset = 0;
+  for (size_t dword_idx = 0; dword_idx < kNumLaunchDescriptorDwords; ++dword_idx) {
+    offset += snprintf(launchDescriptorBlob + offset, sizeof(launchDescriptorBlob) - offset,
+                       "%s0x%08x", (dword_idx == 0) ? "" : " ", launchDwords[dword_idx]);
+  }
+
+  ClPrint(amd::LOG_EXTRA_DEBUG, amd::LOG_AQL,
+          "SWq=0x%zx, HWq=0x%zx, id=%d, Metadata Packet [wptr=%" PRIu64 "]: "
+          "header=[0x%x, 0x%x, 0x%x, 0x%x], event_id=0x%x, "
+          "kernel_code_entry_byte_offset=0x%llx, compute_pgm_rsrc1=0x%x, compute_pgm_rsrc2=0x%x, "
+          "compute_pgm_rsrc3=0x%x, kernel_code_properties=0x%x, "
+          "kernarg_preload=[length=%u, offset=%u], launch_descriptor=[%s]",
+          queue, queue->base_address, queue->id, wptr,
+          meta->header0, meta->header1, meta->header2, meta->header3, meta->event_id,
+          static_cast<unsigned long long>(desc.kernel_code_entry_byte_offset),
+          desc.compute_pgm_rsrc1, desc.compute_pgm_rsrc2, desc.compute_pgm_rsrc3,
+          desc.kernel_code_properties, desc.kernarg_preload.length, desc.kernarg_preload.offset,
+          launchDescriptorBlob);
+}
+
 static inline void logAqlDispatchPacketExtended(
     const Device& dev, const hsa_queue_t* queue, uint16_t header,
-    const hsa_amd_ext_kernel_dispatch_packet_t* pkt, uint64_t wptr, amd::CommandQueue::Priority priority) {
+    const hsa_amd_ext_kernel_dispatch_packet_t* pkt, uint64_t wptr,
+    amd::CommandQueue::Priority priority,
+    const hsa_amd_metadata_kernel_dispatch_packet_t* meta = nullptr) {
   char buf[32];
   const char* prefix = formatVirtualPipePrefix(buf, sizeof(buf), dev, queue);
   const uint64_t rptr = Hsa::queue_load_read_index_relaxed(queue);
@@ -197,6 +232,8 @@ static inline void logAqlDispatchPacketExtended(
           pkt->workgroup_size_y, pkt->workgroup_size_z, pkt->private_segment_size,
           pkt->group_segment_size, pkt->kernel_object, pkt->kernarg_address,
           pkt->dep_signal.handle, pkt->completion_signal.handle, rptr, wptr);
+
+  logAqlMetadataPacket(dev, queue, meta, wptr);
 }
 
 static inline void logAqlBarrierPacket(const Device& dev, const hsa_queue_t* queue,
@@ -1334,45 +1371,22 @@ bool VirtualGPU::dispatchGenericAqlPacket(AqlPacket* packet, uint16_t header, ui
 
   // Check for queue full and wait if needed.
   uint64_t index = Hsa::queue_add_write_index_screlease(gpu_queue_, 1);
-  setFenceDirty(true);
-
-  if (addSystemScope_) {
-    header &= ~(HSA_FENCE_SCOPE_AGENT << HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE |
-                HSA_FENCE_SCOPE_AGENT << HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE);
-    header |= (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE |
-               HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE);
-    addSystemScope_ = false;
-  }
-
-  auto expected_fence_state = extractAqlBits(header, HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE,
-                                             HSA_PACKET_HEADER_WIDTH_SCRELEASE_FENCE_SCOPE);
-
-  // Reset fence_dirty_ flag if we submit a packet with system scopes
-  if (expected_fence_state == amd::Device::kCacheStateSystem) {
-    setFenceDirty(false);
-  }
-
-  // Dirty optimization to save on consequent dispatch packets which have requested flushes
-  if (fence_state_ == amd::Device::kCacheStateSystem &&
-      expected_fence_state == amd::Device::kCacheStateSystem) {
-    header = dispatchPacketHeader_;
-    setFenceDirty(true);
-  }
-
-  fence_state_ = static_cast<Device::CacheState>(expected_fence_state);
+  adjustHeader(header);
 
   bool attachSignal = timestamp_ != nullptr || attach_signal;
   // Get active signal for current dispatch if profiling is necessary
   packet->completion_signal =
       Barriers().ActiveSignal(kInitSignalValueOne, timestamp_, attachSignal);
 
-  if (std::is_same<decltype(packet), hsa_kernel_dispatch_packet_t*>::value &&
-      timestamp_ != nullptr) {
-    // If profiling is enabled, store the correlation ID in the dispatch packet. The profiler can
-    // retrieve this correlation ID to attribute waves to specific dispatch locations.
-    if (amd::activity_prof::IsEnabled(OP_ID_DISPATCH) && !dev().settings().ext_dispatch_packet_) {
-      auto dispatchPacket = reinterpret_cast<hsa_kernel_dispatch_packet_t*>(packet);
-      dispatchPacket->reserved2 = timestamp_->command().profilingInfo().correlation_id_;
+  if (timestamp_ != nullptr) {
+    // If profiling is enabled, store the correlation ID in the dispatch packet. The profiler
+    // can retrieve this correlation ID to attribute waves to specific dispatch locations.
+    // reserved2 exists only on the standard (non-ext) dispatch packet.
+    if constexpr (std::is_same_v<AqlPacket, hsa_kernel_dispatch_packet_t>) {
+      if (amd::activity_prof::IsEnabled(OP_ID_DISPATCH) &&
+          !dev().settings().ext_dispatch_packet_) {
+        packet->reserved2 = timestamp_->command().profilingInfo().correlation_id_;
+      }
     }
 
     ProfilingSignal* current_signal = Barriers().GetLastSignal();
@@ -1405,7 +1419,8 @@ bool VirtualGPU::dispatchGenericAqlPacket(AqlPacket* packet, uint16_t header, ui
     if (dev().settings().ext_dispatch_packet_) {
       logAqlDispatchPacketExtended(
           roc_device_, gpu_queue_, header,
-          reinterpret_cast<hsa_amd_ext_kernel_dispatch_packet_t*>(packet), index, priority_);
+          reinterpret_cast<hsa_amd_ext_kernel_dispatch_packet_t*>(packet), index, priority_,
+          metadata_preloader_.GetMetadataPacket(index & queueMask));
     } else {
       logAqlDispatchPacket(roc_device_, gpu_queue_, header,
                            reinterpret_cast<hsa_kernel_dispatch_packet_t*>(packet), index,
@@ -1443,6 +1458,34 @@ bool VirtualGPU::dispatchGenericAqlPacket(AqlPacket* packet, uint16_t header, ui
 }
 
 // ================================================================================================
+void VirtualGPU::adjustHeader(uint16_t& header) {
+  setFenceDirty(true);
+
+  if (addSystemScope_) {
+    header &= ~(HSA_FENCE_SCOPE_AGENT << HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE |
+                HSA_FENCE_SCOPE_AGENT << HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE);
+    header |= (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE |
+               HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE);
+    addSystemScope_ = false;
+  }
+
+  auto expected_fence_state = extractAqlBits(header, HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE,
+                                             HSA_PACKET_HEADER_WIDTH_SCRELEASE_FENCE_SCOPE);
+
+  if (expected_fence_state == amd::Device::kCacheStateSystem) {
+    setFenceDirty(false);
+  }
+
+  if (fence_state_ == amd::Device::kCacheStateSystem &&
+      expected_fence_state == amd::Device::kCacheStateSystem) {
+    header = dispatchPacketHeader_;
+    setFenceDirty(true);
+  }
+
+  fence_state_ = static_cast<Device::CacheState>(expected_fence_state);
+}
+
+// ================================================================================================
 void VirtualGPU::dispatchBlockingWait(hsa_kernel_dispatch_packet_t* packet) {
   auto wait_signals = Barriers().WaitingSignal();
   if (dev().settings().ext_dispatch_packet_ && wait_signals.size() == 1 && packet != nullptr) {
@@ -1464,26 +1507,23 @@ void VirtualGPU::dispatchBlockingWait(hsa_kernel_dispatch_packet_t* packet) {
 }
 
 // ================================================================================================
-bool VirtualGPU::dispatchAqlPacket(hsa_kernel_dispatch_packet_t* packet, uint16_t header,
-                                   uint16_t rest, bool blocking, bool capturing,
-                                   const uint8_t* aqlPacket, bool attach_signal) {
-  if (capturing == true) {
-    if (dev().settings().ext_dispatch_packet_) {
+template <typename AqlPacket>
+bool VirtualGPU::dispatchAqlPacket(AqlPacket* packet, uint16_t header,
+                                   uint16_t rest, bool blocking, bool attach_signal) {
+  if (command_ != nullptr && command_->getPktCapturingState()) {
+    adjustHeader(header);
+    packet->header = header;
+    if constexpr (std::is_same_v<AqlPacket, hsa_amd_ext_kernel_dispatch_packet_t>) {
       // For ext dispatch packets the first 32 bits are {header(16), amd_format(8), setup(8)}.
       // rest already encodes (amd_format | (setup << 8)).
-      auto* ext_packet = reinterpret_cast<hsa_amd_ext_kernel_dispatch_packet_t*>(packet);
-      ext_packet->header = header;
-      ext_packet->amd_format =
-          static_cast<hsa_amd_packet_type8_t>(rest & 0xFF);
-      ext_packet->setup = static_cast<uint8_t>((rest >> 8) & 0xFF);
+      packet->amd_format = static_cast<hsa_amd_packet_type8_t>(rest & 0xFF);
+      packet->setup = static_cast<uint8_t>((rest >> 8) & 0xFF);
     } else {
-      packet->header = header;
       packet->setup = rest;
     }
-    std::memcpy(const_cast<uint8_t*>(aqlPacket), packet, sizeof(hsa_kernel_dispatch_packet_t));
+    std::memcpy(const_cast<uint8_t*>(command_->getAqlPacket()), packet, sizeof(AqlPacket));
 
-    // Capture the metadata prefetch packet into a host buffer (if supported).
-    if (metadata_preloader_.HasMetadataQueue() && command_ != nullptr) {
+    if (metadata_preloader_.HasMetadataQueue()) {
       uint8_t* metaBuf = command_->getMetadataPacket();
       if (metaBuf != nullptr) {
         metadata_preloader_.CaptureMetadata(packet, header, metaBuf);
@@ -1491,7 +1531,7 @@ bool VirtualGPU::dispatchAqlPacket(hsa_kernel_dispatch_packet_t* packet, uint16_
     }
     return true;
   } else {
-    dispatchBlockingWait(packet);
+    dispatchBlockingWait(reinterpret_cast<hsa_kernel_dispatch_packet_t*>(packet));
     return dispatchGenericAqlPacket(packet, header, rest, blocking, attach_signal);
   }
 }
@@ -4766,18 +4806,13 @@ bool VirtualGPU::submitKernelInternal(const amd::NDRangeContainer& sizes, const 
                                         gpuKernel.MetadataPreloadLength(),
                                         gpuKernel.MetadataPreloadOffset());
 
-    if (isGraphCapture) {
-      // Dispatch the packet
-      if (!dispatchAqlPacket(&dispatchPacket, aqlHeaderWithOrder, rest,
-                             GPU_FLUSH_ON_EXECUTION, command_->getPktCapturingState(),
-                             command_->getAqlPacket())) {
-        return false;
-      }
-    } else {
-      if (!dispatchAqlPacket(&dispatchPacket, aqlHeaderWithOrder, rest,
-                             GPU_FLUSH_ON_EXECUTION, false, nullptr, attach_signal)) {
-        return false;
-      }
+    bool dispatched = extDispatchPacket
+        ? dispatchAqlPacket(&dispatchPacketUnion.extKernelDispatch, aqlHeaderWithOrder, rest,
+                            GPU_FLUSH_ON_EXECUTION, attach_signal)
+        : dispatchAqlPacket(&dispatchPacket, aqlHeaderWithOrder, rest,
+                            GPU_FLUSH_ON_EXECUTION, attach_signal);
+    if (!dispatched) {
+      return false;
     }
 
   // Output printf buffer

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -351,21 +351,8 @@ class VirtualGPU : public device::VirtualDevice {
         if (!IsAttached()) {
           return;
         }
-        if constexpr (std::is_same_v<AqlPacket, hsa_kernel_dispatch_packet_t>) {
-          if (pending_descriptor_ == nullptr) {
-            return;
-          }
-          hsa_amd_metadata_kernel_dispatch_packet_t* queue_metadata_packet =
-               &(reinterpret_cast<hsa_amd_metadata_kernel_dispatch_packet_t*>(
-                   queue_base_))[index];
-          SetPacket(packet, header, queue_metadata_packet);
-        } else if constexpr (std::is_same_v<AqlPacket, hsa_barrier_and_packet_t> ||
-                             std::is_same_v<AqlPacket, hsa_amd_barrier_value_packet_t>) {
-          hsa_amd_metadata_barrier_packet_t* queue_metadata_packet =
-               &(reinterpret_cast<hsa_amd_metadata_barrier_packet_t*>(
-                   queue_base_))[index];
-          SetPacket(packet, header, queue_metadata_packet);
-        }
+        FillMetadata(packet, header,
+                     static_cast<uint8_t*>(queue_base_) + index * kMetadataPacketSize);
       }
 
       //! Set the launch descriptor version (called once from VirtualGPU::create)
@@ -394,6 +381,16 @@ class VirtualGPU : public device::VirtualDevice {
       //! Returns the metadata ring buffer base (nullptr if not attached)
       void* GetQueueBase() const { return queue_base_; }
 
+      //! Returns the metadata packet slot for the given (masked) queue index,
+      //! or nullptr if no metadata queue is attached. For logging/diagnostics.
+      const hsa_amd_metadata_kernel_dispatch_packet_t* GetMetadataPacket(uint64_t index) const {
+        if (!IsAttached()) {
+          return nullptr;
+        }
+        return reinterpret_cast<const hsa_amd_metadata_kernel_dispatch_packet_t*>(
+            static_cast<uint8_t*>(queue_base_) + index * kMetadataPacketSize);
+      }
+
       //! Capture a metadata packet into a host buffer (for graph capture).
       //! Fills the 256-byte buffer with the same content that Set() would write
       //! to the queue metadata ring, but targets an arbitrary host pointer instead.
@@ -402,24 +399,40 @@ class VirtualGPU : public device::VirtualDevice {
         if (host_metadata == nullptr || !IsAttached()) {
           return;
         }
-        if constexpr (std::is_same_v<AqlPacket, hsa_kernel_dispatch_packet_t>) {
-          if (pending_descriptor_ == nullptr) {
-            return;
-          }
-          auto* metadata = reinterpret_cast<hsa_amd_metadata_kernel_dispatch_packet_t*>(
-              host_metadata);
-          SetPacket(packet, header, metadata);
-        } else if constexpr (std::is_same_v<AqlPacket, hsa_barrier_and_packet_t> ||
-                             std::is_same_v<AqlPacket, hsa_amd_barrier_value_packet_t>) {
-          auto* metadata = reinterpret_cast<hsa_amd_metadata_barrier_packet_t*>(
-              host_metadata);
-          SetPacket(packet, header, metadata);
-        }
+        FillMetadata(packet, header, host_metadata);
       }
 
     private:
+      //! Dispatch and barrier metadata packets share the ring, so their slot size
+      //! must be identical for uniform indexing.
+      static_assert(sizeof(hsa_amd_metadata_kernel_dispatch_packet_t) ==
+                        sizeof(hsa_amd_metadata_barrier_packet_t),
+                    "metadata packet types must share a uniform ring slot size");
+      static constexpr size_t kMetadataPacketSize =
+          sizeof(hsa_amd_metadata_kernel_dispatch_packet_t);
+
       //! Return whether the loader is attached to a gpu queue
       bool IsAttached() const { return queue_base_ != nullptr; }
+
+      //! Populate the metadata packet at `dst` from the given aql packet. Shared by
+      //! Set() (ring destination) and CaptureMetadata() (host buffer destination).
+      template <class AqlPacket>
+      void FillMetadata(AqlPacket* packet, uint16_t header, uint8_t* dst) {
+        if constexpr (std::is_same_v<AqlPacket, hsa_kernel_dispatch_packet_t> ||
+                     std::is_same_v<AqlPacket, hsa_amd_ext_kernel_dispatch_packet_t>) {
+          if (pending_descriptor_ == nullptr) {
+            return;
+          }
+          auto* metadata = reinterpret_cast<hsa_amd_metadata_kernel_dispatch_packet_t*>(dst);
+          auto* dispatch_packet = reinterpret_cast<hsa_kernel_dispatch_packet_t*>(packet);
+          SetPacket(dispatch_packet, header, metadata);
+        } else if constexpr (std::is_same_v<AqlPacket, hsa_barrier_and_packet_t> ||
+                             std::is_same_v<AqlPacket, hsa_barrier_or_packet_t> ||
+                             std::is_same_v<AqlPacket, hsa_amd_barrier_value_packet_t>) {
+          auto* metadata = reinterpret_cast<hsa_amd_metadata_barrier_packet_t*>(dst);
+          SetPacket(packet, header, metadata);
+        }
+      }
 
       //! Get type from aql packet header
       uint8_t GetType(uint16_t header) const {
@@ -650,12 +663,18 @@ class VirtualGPU : public device::VirtualDevice {
   //! Release pinned memory after previously submitted work on the queue has completed.
   void SchedulePinnedMemoryRelease(amd::HostQueue& queue, std::vector<amd::Memory*> pinned_memory);
 
+  //! Apply fence-scope adjustments to the AQL header (system scope promotion,
+  //! consecutive-system-scope optimization, fence_state_ tracking).
+  void adjustHeader(uint16_t& header);
+
   //! Dispatches a barrier with blocking HSA signals
   void dispatchBlockingWait(hsa_kernel_dispatch_packet_t* packet);
 
-  bool dispatchAqlPacket(hsa_kernel_dispatch_packet_t* packet, uint16_t header, uint16_t rest,
-                         bool blocking = true, bool capturing = false,
-                         const uint8_t* aqlPacket = nullptr, bool attach_signal = false);
+  //! Dispatch (or capture, when graph-capturing) a kernel dispatch packet.
+  //! Handles both hsa_kernel_dispatch_packet_t and hsa_amd_ext_kernel_dispatch_packet_t.
+  template <typename AqlPacket>
+  bool dispatchAqlPacket(AqlPacket* packet, uint16_t header, uint16_t rest,
+                         bool blocking = true, bool attach_signal = false);
   bool dispatchAqlPacket(hsa_barrier_and_packet_t* packet, uint16_t header, uint16_t rest,
                          bool blocking = true, bool attach_signal = false);
 

--- a/projects/clr/rocclr/utils/debug.hpp
+++ b/projects/clr/rocclr/utils/debug.hpp
@@ -28,7 +28,8 @@ enum LogLevel {
   LOG_INFO = 3,
   LOG_DEBUG = 4,
   LOG_DETAIL_DEBUG = 5,
-  LOG_EXTRA_DEBUG = 6
+  LOG_EXTRA_DEBUG = 6,
+  LOG_EXTRA_EXTRA_DEBUG = 7
 };
 
 enum LogMask {


### PR DESCRIPTION
…dling

Route AMD extended kernel dispatch packets through their own type end to end instead of treating them as standard dispatch packets:

- Make dispatchAqlPacket a template so standard and ext dispatch packets share one code path, with compile-time (if constexpr) branching for the fields that differ. Drop the duplicate overloads.
- Fix isPacketDispatch_ / profiling signal flagging for ext dispatch packets, which was previously skipped for the ext variant.
- Add the missing hsa_barrier_or_packet_t case to the metadata packet type checks so OR-barriers are no longer silently skipped.

Deduplicate the metadata ring-buffer writers:

- Consolidate Set() and CaptureMetadata() into a shared FillMetadata helper in MetaDataPreloader and add a GetMetadataPacket(index) accessor.
- Extract the header fence-scope fixups into adjustHeader() and call it from the capture paths so captured packets get the same header adjustments (setFenceDirty) as dispatched ones.

Improve dispatch logging:

- Log metadata packets (kernel dispatch and barrier) including the full launch descriptor as a space-separated hex dword blob.
- Add LOG_EXTRA_EXTRA_DEBUG level; log metadata at LOG_EXTRA_DEBUG and gate verbose ROCr internal logs to LOG_EXTRA_EXTRA_DEBUG.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

JIRA ID : AIRUNTIME-0

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
