### PR TITLE
[AMD-SMI] Deferred hygiene and hardening items split from #7987

### DIFF
--- a/projects/amdsmi/.pre-commit-config.yaml
+++ b/projects/amdsmi/.pre-commit-config.yaml
@@ -58,6 +58,15 @@ repos:
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.4
     hooks:
+    # Lint for real logic bugs (bare except, redefinition, use-before-assign,
+    # mis-placed return/break, bad string formatting). Curated set kept at zero
+    # violations repo-wide so it never blocks an unrelated edit; expand as the
+    # codebase is cleaned up. Wildcard-import rules (F403/F405) and F821 are
+    # intentionally excluded for now (the public Python API re-exports via `*`).
+    -   id: ruff-check
+        args:
+        - --select=E722,F502,F602,F631,F632,F701,F702,F704,F706,F811,F823
+        exclude: ^py-interface/amdsmi_wrapper\.py$
     -   id: ruff-format
         exclude: ^py-interface/amdsmi_wrapper\.py$
 

--- a/projects/amdsmi/example/CMakeLists.txt
+++ b/projects/amdsmi/example/CMakeLists.txt
@@ -7,8 +7,13 @@ option(CMAKE_EXPORT_COMPILE_COMMANDS "Export compile commands for linters and au
 # Compiler flags
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -m64 -msse -msse2")
 
+# Security hardening for example targets
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-strong -fPIE")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie -Wl,-z,relro -Wl,-z,now")
+
+# _FORTIFY_SOURCE requires an optimized build; only enable it for Release (-O2)
 if("${CMAKE_BUILD_TYPE}" STREQUAL Release)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2 -D_FORTIFY_SOURCE=2")
 else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ggdb -O0 -DDEBUG")
 endif()

--- a/projects/amdsmi/example/amd_smi_cper_example.py
+++ b/projects/amdsmi/example/amd_smi_cper_example.py
@@ -48,7 +48,7 @@ def gpuid(device):
 
 def dump_cper_entry(entry, cper_data, key):
     try:
-        os.mkdir("/tmp/cper_dump", mode=0o777, dir_fd=None)
+        os.mkdir("/tmp/cper_dump", mode=0o700, dir_fd=None)
     except FileExistsError:
         pass
     cper_file = f"/tmp/cper_dump/cper_entry_{key}.bin"

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -20,8 +20,8 @@
  * THE SOFTWARE.
  */
 
-#ifndef __AMDSMI_H__
-#define __AMDSMI_H__
+#ifndef AMDSMI_H_
+#define AMDSMI_H_
 
 /**
  * @file amdsmi.h
@@ -2785,6 +2785,9 @@ typedef enum {
  * "P0", "P1", "P2", "P3", "P4", "G0", "G1", "G2", "G3", "G4"
  * "G5", "G6", "G7"
  * Valid bandwidth types 1(Aggregate_BW), 2 (Read BW), 4 (Write BW).
+ *
+ * @p link_name is a caller-owned, NUL-terminated input string; the library
+ * reads it for the duration of the call and never takes ownership or frees it.
  *
  * @cond @tag{cpu_bm} @endcond
  */
@@ -9781,4 +9784,4 @@ amdsmi_status_t amdsmi_reset_ttm_pages_limit(void);
 }
 #endif  // __cplusplus
 
-#endif  // __AMDSMI_H__
+#endif  // AMDSMI_H_

--- a/projects/amdsmi/py-interface/Dockerfile
+++ b/projects/amdsmi/py-interface/Dockerfile
@@ -9,6 +9,10 @@ ARG DEBCONF_NONINTERACTIVE_SEEN=true
 ENV TZ="America/Chicago"
 RUN ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && echo ${TZ} > /etc/timezone
 
+# Build-toolchain packages are intentionally left at the ubuntu:22.04 archive
+# versions: exact "=version" pins break when Ubuntu rotates point releases out
+# of the archive. Reproducibility is anchored on the base image tag and the
+# pinned pip toolchain (clang/ctypeslib2) below.
 RUN apt update --yes \
         && apt install --yes \
             build-essential \
@@ -21,7 +25,6 @@ RUN apt update --yes \
             libnl-genl-3-dev \
             libpython3-dev \
             lsb-release \
-            pkg-config \
             pkg-config \
             python3-pip \
             software-properties-common \

--- a/projects/amdsmi/src/amd_smi/amd_smi_gpu_device.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_gpu_device.cc
@@ -466,6 +466,11 @@ std::vector<uint64_t> AMDSmiGPUDevice::get_bitmask_from_numa_node(int32_t node_i
                                                                   uint32_t size) const {
   std::vector<uint64_t> bitmask(size, 0);
 
+  // Guard index 0 access when a zero-size cpu set is requested
+  if (bitmask.empty()) {
+    bitmask.resize(1, 0);
+  }
+
   if (node_id < 0) {
     bitmask[0] = std::numeric_limits<int32_t>::max();
     return bitmask;
@@ -500,6 +505,11 @@ std::vector<uint64_t> AMDSmiGPUDevice::get_bitmask_from_numa_node(int32_t node_i
 std::vector<uint64_t> AMDSmiGPUDevice::get_bitmask_from_local_cpulist(uint32_t drm_card,
                                                                       uint32_t size) const {
   std::vector<uint64_t> bitmask(size, 0);
+
+  // Guard index 0 access when a zero-size cpu set is requested
+  if (bitmask.empty()) {
+    bitmask.resize(1, 0);
+  }
 
   if (drm_card == std::numeric_limits<uint32_t>::max()) {
     bitmask[0] = std::numeric_limits<int32_t>::max();

--- a/projects/amdsmi/tests/amd_smi_test/functional/mem_page_info_read.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/mem_page_info_read.cc
@@ -109,6 +109,7 @@ void TestMemPageInfoRead::Run(void) {
       err = amdsmi_get_gpu_memory_reserved_pages(processor_handles_[i], &num_pages, records);
       DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, err, AMDSMI_STATUS_SUCCESS);
       if (err == AMDSMI_STATUS_NOT_SUPPORTED) {
+        delete[] records;
         continue;
       } else {
         CHK_ERR_ASRT(err)

--- a/projects/amdsmi/tests/amd_smi_test/functional/process_info_read.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/process_info_read.cc
@@ -114,6 +114,7 @@ void TestProcInfoRead::Run(void) {
           dumpProcess(&procs[i]);
         }
 
+        delete[] procs;
         return;
       }
     } else {

--- a/projects/amdsmi/tests/amd_smi_test/test_base.cc
+++ b/projects/amdsmi/tests/amd_smi_test/test_base.cc
@@ -26,6 +26,7 @@
 
 #include <cassert>
 #include <iomanip>
+#include <stdexcept>
 
 #include "amd_smi/amdsmi.h"
 #include "amd_smi/impl/amd_smi_utils.h"
@@ -421,7 +422,17 @@ uint32_t TestBase::promptNumDevicesToTest(uint32_t current_num_devices) {
     }
   } while (true);
 
-  return_value = std::stoi(devices_to_test);
+  if (devices_to_test.empty()) {
+    return 0;
+  }
+
+  try {
+    return_value = std::stoi(devices_to_test);
+  } catch (const std::exception&) {
+    std::cout << "Invalid input. Please enter a number between 0 and " << current_num_devices
+              << std::endl;
+    return 0;
+  }
   if (return_value > current_num_devices) {
     std::cout << "Invalid input. Please enter a number between 0 and " << current_num_devices
               << std::endl;


### PR DESCRIPTION
## Motivation

Follow-up to the code-hygiene/memory-safety audit (issue #3634). These items
were split out of #7987 because they are hardening/cleanup improvements rather
than fixes for reachable defects. Keeping them separate lets #7987 stay focused
on the reachable-bug fixes while these lower-priority changes are reviewed on
their own merits.

## Technical Details

**Pre-commit** (`.pre-commit-config.yaml`):
- Add a `ruff-check` hook with a curated logic-bug rule set (bare except,
  redefinition, use-before-assign, mis-placed return/break, bad string
  formatting), kept at zero violations repo-wide

**Public header** (`include/amd_smi/amdsmi.h`):
- Rename the reserved include guard `__AMDSMI_H__` to `AMDSMI_H_`
- Document `link_name` in `amdsmi_link_id_bw_type_t` as a caller-owned input

**Core library** (`src/amd_smi/amd_smi_gpu_device.cc`):
- Guard the zero-size CPU bitmask before writing index 0 in
  `get_bitmask_from_numa_node` and `get_bitmask_from_local_cpulist`

**Tests** (`tests/amd_smi_test/`):
- Free `procs`/`records` on the early-return and continue paths in the
  `process_info_read` and `mem_page_info_read` tests
- Guard `std::stoi` against empty input in `test_base`

**Example / Docker builds** (`example/`, `py-interface/Dockerfile`):
- Add stack-protector, PIE/RELRO, and `_FORTIFY_SOURCE` flags to the example
  build (FORTIFY only in Release)
- Restrict the CPER example dump directory permissions to `0700`
- Drop a duplicate `pkg-config` from the py-interface Dockerfile

## JIRA ID

Resolves AILITOOLS-278

## Test Plan

- `cmake --build build -j$(nproc)`
- `pre-commit run --all-files`

## Test Result

- Build succeeds (rc=0)
- Pre-commit hooks pass

## Submission Checklist

- [ ] The PR has been tested on relevant hardware
- [ ] The PR follows the coding style of the project
- [ ] The PR has been reviewed by at least one other developer
