### PR TITLE
test(rocjitsu): add execution quality gates

### DIFF
--- a/emulation/rocjitsu/docs/configuration.md
+++ b/emulation/rocjitsu/docs/configuration.md
@@ -48,16 +48,14 @@ Pre-built configs are in `configs/`:
 }
 ```
 
-The example above is intentionally minimal and single-threaded. Shipped
-multi-XCD KMD configs may set `num_threads` to the number of simulated XCD
-partitions.
+The example above is intentionally minimal and single-threaded.
 
 ### Top-level fields
 
 | Field | Type | Description |
 |---|---|---|
 | `max_ticks` | int | Maximum simulation ticks (0 = unlimited) |
-| `num_threads` | int | PDES engine partitions/worker threads. For partitioned multi-XCD configs this is typically one partition per XCD. |
+| `num_threads` | int | Number of PDES engine partitions/worker threads. |
 | `exec_mode` | string | `"functional"` or `"cycle"` |
 | `vm.arch` | string | Architecture: `cdna3`, `cdna4`, etc. |
 

--- a/emulation/rocjitsu/docs/configuration.md
+++ b/emulation/rocjitsu/docs/configuration.md
@@ -48,12 +48,16 @@ Pre-built configs are in `configs/`:
 }
 ```
 
+The example above is intentionally minimal and single-threaded. Shipped
+multi-XCD KMD configs may set `num_threads` to the number of simulated XCD
+partitions.
+
 ### Top-level fields
 
 | Field | Type | Description |
 |---|---|---|
 | `max_ticks` | int | Maximum simulation ticks (0 = unlimited) |
-| `num_threads` | int | Worker threads for PDES engine |
+| `num_threads` | int | PDES engine partitions/worker threads. For partitioned multi-XCD configs this is typically one partition per XCD. |
 | `exec_mode` | string | `"functional"` or `"cycle"` |
 | `vm.arch` | string | Architecture: `cdna3`, `cdna4`, etc. |
 

--- a/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
+++ b/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
@@ -179,6 +179,25 @@ inline bool should_skip_inst(std::string_view mn) {
   return false;
 }
 
+struct HarnessCoverageExpectation {
+  std::string_view arch_name;
+  double min_coverage;
+  size_t max_unimplemented;
+};
+
+constexpr HarnessCoverageExpectation HARNESS_COVERAGE_EXPECTATIONS[] = {
+    {"cdna1", 99.0, 1},  {"cdna2", 99.0, 1},    {"cdna3", 99.0, 1},  {"cdna4", 99.0, 1},
+    {"rdna1", 98.0, 3},  {"rdna2", 98.5, 2},    {"rdna3", 100.0, 0}, {"rdna3_5", 100.0, 0},
+    {"rdna4", 100.0, 0}, {"gfx1250", 100.0, 0},
+};
+
+const HarnessCoverageExpectation *harness_coverage_expectation(std::string_view arch_name) {
+  for (const auto &expectation : HARNESS_COVERAGE_EXPECTATIONS)
+    if (expectation.arch_name == arch_name)
+      return &expectation;
+  return nullptr;
+}
+
 /// @brief Helper to run all test encodings for a given ISA.
 void run_execution_harness(rj_code_arch_t arch, std::string_view arch_name,
                            const TestEncEntry *encodings, size_t num_encodings) {
@@ -274,12 +293,19 @@ void run_execution_harness(rj_code_arch_t arch, std::string_view arch_name,
     std::printf("\n");
   }
 
-  // Decode failures are expected for sub-decoded encodings where the
-  // synthesized test word doesn't match the decoder's sub-dispatch path.
-  // The primary coverage metric is: of the instructions that DO decode,
-  // how many execute without throwing UnimplementedInst?
+  // Decode failures are a hard regression: every listed test encoding should
+  // decode for its target architecture. The primary coverage metric is: of the
+  // instructions that decode, how many execute without throwing
+  // UnimplementedInst?
   // Unimplemented instructions are tracked in coverage_exceptions files.
   EXPECT_GT(decoded, 0u) << "No instructions decoded for " << arch_name;
+  if (const auto *expectation = harness_coverage_expectation(arch_name)) {
+    EXPECT_GE(coverage, expectation->min_coverage)
+        << arch_name << " instruction execution harness coverage regressed";
+    EXPECT_LE(unimplemented, expectation->max_unimplemented)
+        << arch_name << " gained new unimplemented instructions";
+    EXPECT_EQ(decode_fail_list.size(), 0u) << arch_name << " gained decode failures";
+  }
 }
 
 // --- Parameterized tests per ISA ---
@@ -367,6 +393,78 @@ TEST(InstructionExecutionHarness, Gfx1250) {
 }
 
 #undef RUN_HARNESS
+
+TEST(Gfx1250MemoryExecutionHarness, ExecutesRepresentativeValidAddressStores) {
+  amdgpu::GpuMemory gpu_mem("gfx1250_memory_harness_mem");
+  amdgpu::L2Cache l2("gfx1250_memory_harness_l2");
+
+  amdgpu::ComputeUnitCore::Config cfg{};
+  cfg.arch = ROCJITSU_CODE_ARCH_GFX1250;
+  cfg.num_wf_slots = 1;
+  cfg.sgprs_per_wf = 106;
+  cfg.vgprs_per_wf = 256;
+  cfg.lds_size_kb = 64;
+
+  Gfx1250MemoryTestCu cu("gfx1250", cfg, &gpu_mem, &l2);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+
+  auto *wf = cu.dispatch_wf(0, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(0x3u);
+
+  constexpr uint64_t kGlobalAddr = 0x2000;
+  const uint32_t sb = wf->sgpr_alloc().base;
+  const uint32_t vb = wf->vgpr_alloc().base;
+
+  cu.write_sgpr(sb + 4, static_cast<uint32_t>(kGlobalAddr));
+  cu.write_sgpr(sb + 5, static_cast<uint32_t>(kGlobalAddr >> 32));
+  for (uint32_t lane = 0; lane < 2; ++lane) {
+    gpu_mem.write32(kGlobalAddr + lane * sizeof(uint32_t), 0u);
+    cu.write_vgpr(vb + 0, lane, lane * sizeof(uint32_t));
+    cu.write_vgpr(vb + 1, lane, 0x11000000u + lane);
+  }
+
+  // global_store_b32 v0, v1, s[4:5]
+  const uint32_t global_store_words[] = {0xEE068004u, 0x00800000u, 0x00000000u};
+  std::unique_ptr<Instruction> global_store(decoder->decode(global_store_words));
+  ASSERT_NE(global_store, nullptr);
+  ASSERT_EQ(std::string_view(global_store->mnemonic()), "global_store_b32");
+  cu.execute_and_route(global_store.release(), *wf);
+  cu.flush_all();
+
+  EXPECT_EQ(gpu_mem.read32(kGlobalAddr), 0x11000000u);
+  EXPECT_EQ(gpu_mem.read32(kGlobalAddr + sizeof(uint32_t)), 0x11000001u);
+
+  constexpr uint64_t kBufferAddr = 0x3000;
+  cu.write_sgpr(sb + 4, static_cast<uint32_t>(kBufferAddr));
+  cu.write_sgpr(sb + 5, static_cast<uint32_t>(kBufferAddr >> 32));
+  cu.write_sgpr(sb + 6, 0x1000u);
+  cu.write_sgpr(sb + 7, 0u);
+  wf->set_m0(16u);
+  for (uint32_t lane = 0; lane < 2; ++lane) {
+    gpu_mem.write32(kBufferAddr + lane * 32, 0u);
+    gpu_mem.write32(kBufferAddr + 16 + lane * 32, 0u);
+    cu.write_vgpr(vb + 0, lane, 0x22000000u + lane);
+    cu.write_vgpr(vb + 5, lane, lane * 32);
+  }
+
+  // buffer_store_b32 v0, v5, s[4:7], m0 offen
+  const uint32_t buffer_store_words[] = {0xC406807Du, 0x40800800u, 0x00000005u};
+  std::unique_ptr<Instruction> buffer_store(decoder->decode(buffer_store_words));
+  ASSERT_NE(buffer_store, nullptr);
+  ASSERT_EQ(std::string_view(buffer_store->mnemonic()), "buffer_store_b32");
+  cu.execute_and_route(buffer_store.release(), *wf);
+  cu.flush_all();
+
+  EXPECT_EQ(gpu_mem.read32(kBufferAddr), 0u);
+  EXPECT_EQ(gpu_mem.read32(kBufferAddr + 16), 0x22000000u);
+  EXPECT_EQ(gpu_mem.read32(kBufferAddr + 32), 0u);
+  EXPECT_EQ(gpu_mem.read32(kBufferAddr + 48), 0x22000001u);
+
+  cu.reset_all_wf();
+}
 
 TEST(Rdna4ScalarSccTest, AddSubCoI32UseSignedOverflow) {
   amdgpu::GpuMemory gpu_mem("rdna4_scc_i32_overflow_mem");

--- a/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
+++ b/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 /// @file instruction_execution_harness_test.cpp
-/// @brief Phase E parameterized test: execute every instruction on every ISA.
+/// @brief Phase E parameterized test: execute safe scalar encodings on every ISA.
 ///
 /// For each ISA, iterates auto-generated encodings that are safe to execute on
 /// a zeroed wavefront, decodes them, and calls execute(). Decode failures are

--- a/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
+++ b/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
@@ -4,10 +4,10 @@
 /// @file instruction_execution_harness_test.cpp
 /// @brief Phase E parameterized test: execute every instruction on every ISA.
 ///
-/// For each ISA, iterates all auto-generated test encodings, decodes the
-/// instruction, and calls execute() on a zeroed wavefront.  Instructions that
-/// throw UnimplementedInst are recorded as coverage exceptions; the test
-/// reports a per-ISA coverage percentage.
+/// For each ISA, iterates auto-generated encodings that are safe to execute on
+/// a zeroed wavefront, decodes them, and calls execute(). Decode failures are
+/// rejected, and UnimplementedInst results must exactly match the explicit
+/// expectation for that ISA.
 
 #include "rocjitsu/base/rj_compiler.h"
 #include "rocjitsu/code/rj_code.h"
@@ -39,11 +39,14 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <array>
 #include <bit>
 #include <cmath>
 #include <cstdint>
+#include <exception>
 #include <memory>
+#include <span>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -179,20 +182,28 @@ inline bool should_skip_inst(std::string_view mn) {
   return false;
 }
 
-struct HarnessCoverageExpectation {
+constexpr std::array<std::string_view, 1> EXPECTED_CDNA_UNIMPLEMENTED = {"s_setvskip"};
+constexpr std::array<std::string_view, 3> EXPECTED_RDNA1_UNIMPLEMENTED = {
+    "s_subvector_loop_begin", "s_subvector_loop_end", "s_get_waveid_in_workgroup"};
+constexpr std::array<std::string_view, 2> EXPECTED_RDNA2_UNIMPLEMENTED = {"s_subvector_loop_begin",
+                                                                          "s_subvector_loop_end"};
+constexpr std::array<std::string_view, 0> EXPECTED_NO_UNIMPLEMENTED = {};
+
+struct HarnessExpectation {
   std::string_view arch_name;
-  double min_coverage;
-  size_t max_unimplemented;
+  std::span<const std::string_view> unimplemented;
 };
 
-constexpr HarnessCoverageExpectation HARNESS_COVERAGE_EXPECTATIONS[] = {
-    {"cdna1", 99.0, 1},  {"cdna2", 99.0, 1},    {"cdna3", 99.0, 1},  {"cdna4", 99.0, 1},
-    {"rdna1", 98.0, 3},  {"rdna2", 98.5, 2},    {"rdna3", 100.0, 0}, {"rdna3_5", 100.0, 0},
-    {"rdna4", 100.0, 0}, {"gfx1250", 100.0, 0},
+constexpr HarnessExpectation HARNESS_EXPECTATIONS[] = {
+    {"cdna1", EXPECTED_CDNA_UNIMPLEMENTED},  {"cdna2", EXPECTED_CDNA_UNIMPLEMENTED},
+    {"cdna3", EXPECTED_CDNA_UNIMPLEMENTED},  {"cdna4", EXPECTED_CDNA_UNIMPLEMENTED},
+    {"rdna1", EXPECTED_RDNA1_UNIMPLEMENTED}, {"rdna2", EXPECTED_RDNA2_UNIMPLEMENTED},
+    {"rdna3", EXPECTED_NO_UNIMPLEMENTED},    {"rdna3_5", EXPECTED_NO_UNIMPLEMENTED},
+    {"rdna4", EXPECTED_NO_UNIMPLEMENTED},    {"gfx1250", EXPECTED_NO_UNIMPLEMENTED},
 };
 
-const HarnessCoverageExpectation *harness_coverage_expectation(std::string_view arch_name) {
-  for (const auto &expectation : HARNESS_COVERAGE_EXPECTATIONS)
+const HarnessExpectation *harness_expectation(std::string_view arch_name) {
+  for (const auto &expectation : HARNESS_EXPECTATIONS)
     if (expectation.arch_name == arch_name)
       return &expectation;
   return nullptr;
@@ -219,12 +230,12 @@ void run_execution_harness(rj_code_arch_t arch, std::string_view arch_name,
   ASSERT_NE(decoder, nullptr) << "Failed to create decoder for " << arch_name;
 
   size_t total = num_encodings;
-  [[maybe_unused]] size_t decoded = 0;
+  size_t decoded = 0;
   size_t executed = 0;
-  size_t unimplemented = 0;
-  size_t skipped_mem = 0;
-  std::vector<std::string> unimpl_list;
+  size_t skipped = 0;
+  std::vector<std::string_view> unimpl_list;
   std::vector<std::string> decode_fail_list;
+  std::vector<std::string> execution_fail_list;
 
   for (size_t i = 0; i < total; ++i) {
     const auto &te = encodings[i];
@@ -232,7 +243,7 @@ void run_execution_harness(rj_code_arch_t arch, std::string_view arch_name,
     // Skip memory instructions — they require valid addresses and will
     // crash or hang when executed on zeroed wavefront/memory state.
     if (should_skip_inst(te.mnemonic)) {
-      ++skipped_mem;
+      ++skipped;
       continue;
     }
 
@@ -267,45 +278,50 @@ void run_execution_harness(rj_code_arch_t arch, std::string_view arch_name,
       cu->execute_instruction(inst.get(), *wf);
       ++executed;
     } catch (const util::UnimplementedInst &) {
-      ++unimplemented;
       unimpl_list.emplace_back(te.mnemonic);
+    } catch (const std::exception &error) {
+      execution_fail_list.emplace_back(std::string(te.mnemonic).append(": ").append(error.what()));
     } catch (...) {
-      ++executed; // Other exceptions are acceptable on zeroed state.
+      execution_fail_list.emplace_back(te.mnemonic);
     }
 
     // Reset the wavefront for the next instruction.
     cu->reset_all_wf();
   }
 
-  size_t testable = total - skipped_mem;
-  double coverage = testable > 0 ? 100.0 * executed / testable : 0.0;
-  std::printf(
-      "\n  %.*s: %zu/%zu executed (%.1f%%), %zu unimplemented, %zu decode fail, %zu mem skipped\n",
-      static_cast<int>(arch_name.size()), arch_name.data(), executed, testable, coverage,
-      unimplemented, decode_fail_list.size(), skipped_mem);
+  size_t testable = total - skipped;
+  std::printf("\n  %.*s: %zu/%zu testable encodings executed, %zu unimplemented, "
+              "%zu decode fail, %zu execution fail, %zu skipped\n",
+              static_cast<int>(arch_name.size()), arch_name.data(), executed, testable,
+              unimpl_list.size(), decode_fail_list.size(), execution_fail_list.size(), skipped);
 
   if (!unimpl_list.empty()) {
     std::printf("  Unimplemented (%zu):", unimpl_list.size());
-    for (size_t i = 0; i < std::min(unimpl_list.size(), size_t{20}); ++i)
-      std::printf(" %s", unimpl_list[i].c_str());
+    for (size_t i = 0; i < std::min(unimpl_list.size(), size_t{20}); ++i) {
+      const auto mnemonic = unimpl_list[i];
+      std::printf(" %.*s", static_cast<int>(mnemonic.size()), mnemonic.data());
+    }
     if (unimpl_list.size() > 20)
       std::printf(" ... +%zu more", unimpl_list.size() - 20);
     std::printf("\n");
   }
 
-  // Decode failures are a hard regression: every listed test encoding should
-  // decode for its target architecture. The primary coverage metric is: of the
-  // instructions that decode, how many execute without throwing
-  // UnimplementedInst?
-  // Unimplemented instructions are tracked in coverage_exceptions files.
+  // Every encoding admitted by should_skip_inst must decode. Known
+  // UnimplementedInst results are named explicitly so failures identify the
+  // exact instruction that regressed instead of only crossing a numeric
+  // coverage threshold.
   EXPECT_GT(decoded, 0u) << "No instructions decoded for " << arch_name;
-  if (const auto *expectation = harness_coverage_expectation(arch_name)) {
-    EXPECT_GE(coverage, expectation->min_coverage)
-        << arch_name << " instruction execution harness coverage regressed";
-    EXPECT_LE(unimplemented, expectation->max_unimplemented)
-        << arch_name << " gained new unimplemented instructions";
-    EXPECT_EQ(decode_fail_list.size(), 0u) << arch_name << " gained decode failures";
-  }
+  EXPECT_EQ(decode_fail_list.size(), 0u) << arch_name << " gained decode failures";
+  EXPECT_EQ(execution_fail_list.size(), 0u)
+      << arch_name << " failed to execute implemented instructions";
+
+  const auto *expectation = harness_expectation(arch_name);
+  ASSERT_NE(expectation, nullptr) << "Missing harness expectation for " << arch_name;
+  std::sort(unimpl_list.begin(), unimpl_list.end());
+  std::vector<std::string_view> expected(expectation->unimplemented.begin(),
+                                         expectation->unimplemented.end());
+  std::sort(expected.begin(), expected.end());
+  EXPECT_EQ(unimpl_list, expected) << arch_name << " unimplemented instruction set changed";
 }
 
 // --- Parameterized tests per ISA ---

--- a/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
+++ b/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
@@ -235,6 +235,7 @@ void run_execution_harness(rj_code_arch_t arch, std::string_view arch_name,
   size_t skipped = 0;
   std::vector<std::string_view> unimpl_list;
   std::vector<std::string> decode_fail_list;
+  std::vector<std::string> mnemonic_mismatch_list;
   std::vector<std::string> execution_fail_list;
 
   for (size_t i = 0; i < total; ++i) {
@@ -260,6 +261,13 @@ void run_execution_harness(rj_code_arch_t arch, std::string_view arch_name,
     }
     if (!inst) {
       decode_fail_list.emplace_back(te.mnemonic);
+      continue;
+    }
+
+    const std::string_view decoded_mnemonic = inst->mnemonic();
+    if (decoded_mnemonic != te.mnemonic) {
+      mnemonic_mismatch_list.emplace_back(
+          std::string(te.mnemonic).append(" decoded as ").append(decoded_mnemonic));
       continue;
     }
     ++decoded;
@@ -312,6 +320,9 @@ void run_execution_harness(rj_code_arch_t arch, std::string_view arch_name,
   // coverage threshold.
   EXPECT_GT(decoded, 0u) << "No instructions decoded for " << arch_name;
   EXPECT_EQ(decode_fail_list.size(), 0u) << arch_name << " gained decode failures";
+  EXPECT_TRUE(mnemonic_mismatch_list.empty())
+      << arch_name << " encodings decoded as a different instruction: "
+      << ::testing::PrintToString(mnemonic_mismatch_list);
   EXPECT_EQ(execution_fail_list.size(), 0u)
       << arch_name << " failed to execute implemented instructions";
 

--- a/emulation/rocjitsu/tests/race-detector/hip_race_gfx950_test.hip
+++ b/emulation/rocjitsu/tests/race-detector/hip_race_gfx950_test.hip
@@ -16,13 +16,6 @@
 //   _race suffix = expects race, no suffix = expects no race.
 //   Paired tests share a base name (e.g. vgpr_waitcnt / vgpr_waitcnt_race).
 //
-// TODO: Add wave-32 (RDNA 3.5) cross-wave LDS test. Requires:
-//   1. A gfx1150_rdna3_5_kmd.json config with wave_front_size=32
-//   2. Compiling with --offload-arch=gfx1150 (or similar RDNA 3.5 target)
-//   3. A separate ctest entry pointing at the RDNA 3.5 config
-//   The test itself is the same lds_cross_wave pattern but with the
-//   cross-wave boundary at lane 32 instead of 64.
-
 #include <gtest/gtest.h>
 #include <hip/hip_runtime.h>
 

--- a/emulation/rocjitsu/tests/race-detector/hip_race_gfx950_test.hip
+++ b/emulation/rocjitsu/tests/race-detector/hip_race_gfx950_test.hip
@@ -16,6 +16,13 @@
 //   _race suffix = expects race, no suffix = expects no race.
 //   Paired tests share a base name (e.g. vgpr_waitcnt / vgpr_waitcnt_race).
 //
+// TODO: Add wave-32 (RDNA 3.5) cross-wave LDS test. Requires:
+//   1. A gfx1150_rdna3_5_kmd.json config with wave_front_size=32
+//   2. Compiling with --offload-arch=gfx1150 (or similar RDNA 3.5 target)
+//   3. A separate ctest entry pointing at the RDNA 3.5 config
+//   The test itself is the same lds_cross_wave pattern but with the
+//   cross-wave boundary at lane 32 instead of 64.
+
 #include <gtest/gtest.h>
 #include <hip/hip_runtime.h>
 


### PR DESCRIPTION
## Summary

Add rocjitsu quality gates for safe scalar instruction execution and representative valid-address memory execution. The VGPR read-observation and D16 masked-read work has been split out to users/lialan/rocjitsu_8075_read_observation_split.

## Changes

- Require every safe scalar encoding to decode and execute without unexpected failures, with exact per-ISA expected unimplemented-instruction lists.
- Add a gfx1250 valid-address memory execution harness.
- Document dispatch/thread configuration fields without changing the shipped gfx950 CDNA4 KMD config.

## Validation

- pre-commit run --files emulation/rocjitsu/docs/configuration.md emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
- git diff --check
- cmake --build /tmp/rocjitsu-pr8177-rework-20260707-213115-build -j 16
- ctest --test-dir /tmp/rocjitsu-pr8177-rework-20260707-213115-build -R '^(InstructionExecutionHarness\.|Gfx1250MemoryExecutionHarness\.)' --output-on-failure

ISSUE ID : #6447
