### PR TITLE
rocr: Add debug logging for trampoline/managed variable investigation

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
@@ -67,6 +67,24 @@
 
 #include "AMDHSAKernelDescriptor.h"
 
+// Debug logging for trampoline/managed variable investigation
+// Enable with: ROCR_LOADER_DEBUG=1
+static bool IsLoaderDebugEnabled() {
+  static int enabled = -1;
+  if (enabled < 0) {
+    const char* env = getenv("ROCR_LOADER_DEBUG");
+    enabled = (env && strcmp(env, "1") == 0) ? 1 : 0;
+  }
+  return enabled == 1;
+}
+
+#define LOADER_DEBUG(fmt, ...) \
+  do { \
+    if (IsLoaderDebugEnabled()) { \
+      fprintf(stderr, "[LOADER_DEBUG] " fmt "\n", ##__VA_ARGS__); \
+    } \
+  } while (0)
+
 using namespace rocr::amd::hsa;
 using namespace rocr::amd::hsa::common;
 
@@ -1549,6 +1567,9 @@ hsa_status_t ExecutableImpl::InstallTrampolinesGfx125x(hsa_agent_t agent) {
   objects.push_back(tramp);               // freed via Destroy() in ~ExecutableImpl
   trampoline_segments_.push_back(tramp);  // frozen in ExecutableImpl::Freeze
 
+  LOADER_DEBUG("InstallTrampolinesGfx125x: installing %zu trampolines, pool_size=0x%lx",
+               n, (unsigned long)pool);
+
   for (size_t i = 0; i < n; ++i) {
     const KdFixup& f = kd_fixups_[i];
     const uint64_t stub_off = i * kTrampolineStubStride;
@@ -1558,12 +1579,30 @@ hsa_status_t ExecutableImpl::InstallTrampolinesGfx125x(hsa_agent_t agent) {
         reinterpret_cast<uint64_t>(f.code_seg->Address(f.kd_vaddr + f.entry_off));
     const uint64_t stub_dev = reinterpret_cast<uint64_t>(tramp->Address(stub_off));
 
+    LOADER_DEBUG("  Trampoline[%zu]: kd_vaddr=0x%lx kd_dev=0x%lx entry_off=0x%lx "
+                 "entry_dev=0x%lx stub_off=0x%lx stub_dev=0x%lx",
+                 i,
+                 (unsigned long)f.kd_vaddr,
+                 (unsigned long)kd_dev,
+                 (unsigned long)f.entry_off,
+                 (unsigned long)entry_dev,
+                 (unsigned long)stub_off,
+                 (unsigned long)stub_dev);
+
     uint8_t blob[kTrampolineStubStride];
     BuildTrampolineGfx1250(blob, entry_dev);    // stub jumps to the real entry
     tramp->Copy(stub_off, blob, sizeof(blob));  // -> trampoline host shadow
 
     // Redirect dispatch onto the stub: kernel_object(kd_dev) + new_off == stub.
     int64_t new_off = static_cast<int64_t>(stub_dev) - static_cast<int64_t>(kd_dev);
+
+    LOADER_DEBUG("  Trampoline[%zu]: REWRITING kernel_code_entry_byte_offset: "
+                 "old=0x%lx new=0x%lx (delta=0x%lx)",
+                 i,
+                 (unsigned long)f.entry_off,
+                 (long)new_off,
+                 (long)(new_off - f.entry_off));
+
     f.code_seg->Copy(f.kd_vaddr + llvm::amdhsa::KERNEL_CODE_ENTRY_BYTE_OFFSET_OFFSET, &new_off,
                      sizeof(new_off));  // -> code host shadow
   }
@@ -1657,6 +1696,15 @@ hsa_status_t ExecutableImpl::LoadDefinitionSymbol(hsa_agent_t agent,
                                     address);
     symbol = kernel_symbol;
   } else if (sym->IsVariableSymbol()) {
+    LOADER_DEBUG("LoadDefinitionSymbol VARIABLE: name=%s vaddr=0x%lx sec_off=0x%lx "
+                 "size=0x%lx address=0x%lx trampoline_enabled=%d",
+                 sym->GetSymbolName().c_str(),
+                 (unsigned long)sym->VAddr(),
+                 (unsigned long)sym->SectionOffset(),
+                 (unsigned long)sym->Size(),
+                 (unsigned long)address,
+                 trampoline_enabled_gfx125x_ ? 1 : 0);
+
     symbol = std::make_shared<VariableSymbol>(true,
                        sym->GetModuleName(),
                        sym->GetSymbolName(),
@@ -1763,17 +1811,46 @@ uint64_t ExecutableImpl::SymbolAddress(hsa_agent_t agent, code::Symbol* sym)
 {
   code::Section* sec = sym->GetSection();
   Segment* seg = SectionSegment(agent, sec);
-  return nullptr == seg ? 0 : (uint64_t) (uintptr_t) seg->Address(sym->VAddr());
+  uint64_t result = nullptr == seg ? 0 : (uint64_t) (uintptr_t) seg->Address(sym->VAddr());
+
+  LOADER_DEBUG("SymbolAddress(code::Symbol): name=%s vaddr=0x%lx sec_addr=0x%lx sec_off=0x%lx "
+               "seg_vaddr=0x%lx seg_ptr=%p result=0x%lx trampoline_enabled=%d",
+               sym->Name().c_str(),
+               (unsigned long)sym->VAddr(),
+               (unsigned long)(sec ? sec->addr() : 0),
+               (unsigned long)sym->SectionOffset(),
+               (unsigned long)(seg ? seg->VAddr() : 0),
+               seg ? seg->Ptr() : nullptr,
+               (unsigned long)result,
+               trampoline_enabled_gfx125x_ ? 1 : 0);
+
+  return result;
 }
 
 uint64_t ExecutableImpl::SymbolAddress(hsa_agent_t agent, elf::Symbol* sym)
 {
   elf::Section* sec = sym->section();
-  if(!sec) { return NULL; }
+  if(!sec) {
+    LOADER_DEBUG("SymbolAddress(elf::Symbol): name=%s NO SECTION", sym->name().c_str());
+    return NULL;
+  }
 
   Segment* seg = SectionSegment(agent, sec);
   uint64_t vaddr = sec->addr() + sym->value();
-  return nullptr == seg ? 0 : (uint64_t) (uintptr_t) seg->Address(vaddr);
+  uint64_t result = nullptr == seg ? 0 : (uint64_t) (uintptr_t) seg->Address(vaddr);
+
+  LOADER_DEBUG("SymbolAddress(elf::Symbol): name=%s sym_value=0x%lx sec_addr=0x%lx "
+               "vaddr=0x%lx seg_vaddr=0x%lx seg_ptr=%p result=0x%lx trampoline_enabled=%d",
+               sym->name().c_str(),
+               (unsigned long)sym->value(),
+               (unsigned long)sec->addr(),
+               (unsigned long)vaddr,
+               (unsigned long)(seg ? seg->VAddr() : 0),
+               seg ? seg->Ptr() : nullptr,
+               (unsigned long)result,
+               trampoline_enabled_gfx125x_ ? 1 : 0);
+
+  return result;
 }
 
 Segment* ExecutableImpl::SymbolSegment(hsa_agent_t agent, code::Symbol* sym)
@@ -1845,6 +1922,14 @@ hsa_status_t ExecutableImpl::ApplyStaticRelocation(hsa_agent_t agent, amd::hsa::
   code::Section* sec = rsec->targetSection();
   Segment* rseg = SectionSegment(agent, sec);
   size_t reladdr = sec->addr() + rel->offset();
+
+  LOADER_DEBUG("ApplyStaticRelocation: sym=%s type=%u reladdr=0x%lx offset=0x%lx addend=0x%lx",
+               sym ? sym->name().c_str() : "<null>",
+               rel->type(),
+               (unsigned long)reladdr,
+               (unsigned long)rel->offset(),
+               (long)rel->addend());
+
   switch (rel->type()) {
     case R_AMDGPU_V1_32_LOW:
     case R_AMDGPU_V1_32_HIGH:
@@ -1857,6 +1942,7 @@ hsa_status_t ExecutableImpl::ApplyStaticRelocation(hsa_agent_t agent, amd::hsa::
         case STT_AMDGPU_HSA_KERNEL:
         case STT_AMDGPU_HSA_INDIRECT_FUNCTION:
           addr = SymbolAddress(agent, sym);
+          LOADER_DEBUG("  -> sym_type=%u addr=0x%lx", sym->type(), (unsigned long)addr);
           if (!addr) { return HSA_STATUS_ERROR_INVALID_CODE_OBJECT; }
           break;
         case STT_COMMON: {
@@ -2011,6 +2097,16 @@ hsa_status_t ExecutableImpl::ApplyDynamicRelocation(hsa_agent_t agent, amd::hsa:
 {
   Segment* relSeg = VirtualAddressSegment(rel->offset());
   uint64_t symAddr = 0;
+
+  LOADER_DEBUG("ApplyDynamicRelocation: sym=%s sym_type=%u rel_type=%u "
+               "rel_offset=0x%lx addend=0x%lx sym_value=0x%lx",
+               rel->symbol() ? rel->symbol()->name().c_str() : "<null>",
+               rel->symbol() ? rel->symbol()->type() : 0,
+               rel->type(),
+               (unsigned long)rel->offset(),
+               (long)rel->addend(),
+               rel->symbol() ? (unsigned long)rel->symbol()->value() : 0);
+
   switch (rel->symbol()->type()) {
     case STT_OBJECT:
     case STT_AMDGPU_HSA_KERNEL:
@@ -2018,6 +2114,9 @@ hsa_status_t ExecutableImpl::ApplyDynamicRelocation(hsa_agent_t agent, amd::hsa:
     {
       Segment* symSeg = VirtualAddressSegment(rel->symbol()->value());
       symAddr = reinterpret_cast<uint64_t>(symSeg->Address(rel->symbol()->value()));
+      LOADER_DEBUG("  -> STT_OBJECT/KERNEL/FUNC: symSeg_vaddr=0x%lx symAddr=0x%lx",
+                   symSeg ? (unsigned long)symSeg->VAddr() : 0,
+                   (unsigned long)symAddr);
       break;
     }
 
@@ -2083,6 +2182,12 @@ hsa_status_t ExecutableImpl::ApplyDynamicRelocation(hsa_agent_t agent, amd::hsa:
         return HSA_STATUS_ERROR_VARIABLE_UNDEFINED;
       }
 
+      LOADER_DEBUG("  -> R_AMDGPU_ABS64: writing symAddr=0x%lx to rel_offset=0x%lx "
+                   "(device_addr=0x%lx)",
+                   (unsigned long)symAddr,
+                   (unsigned long)rel->offset(),
+                   relSeg ? (unsigned long)(uintptr_t)relSeg->Address(rel->offset()) : 0);
+
       relSeg->Copy(rel->offset(), &symAddr, sizeof(symAddr));
       break;
     }
@@ -2091,6 +2196,15 @@ hsa_status_t ExecutableImpl::ApplyDynamicRelocation(hsa_agent_t agent, amd::hsa:
     {
       int64_t baseDelta = reinterpret_cast<uint64_t>(relSeg->Address(0)) - relSeg->VAddr();
       uint64_t relocatedAddr = baseDelta + rel->addend();
+
+      LOADER_DEBUG("  -> R_AMDGPU_RELATIVE64: baseDelta=0x%lx addend=0x%lx "
+                   "relocatedAddr=0x%lx rel_offset=0x%lx (device_addr=0x%lx)",
+                   (long)baseDelta,
+                   (long)rel->addend(),
+                   (unsigned long)relocatedAddr,
+                   (unsigned long)rel->offset(),
+                   relSeg ? (unsigned long)(uintptr_t)relSeg->Address(rel->offset()) : 0);
+
       relSeg->Copy(rel->offset(), &relocatedAddr, sizeof(relocatedAddr));
       break;
     }


### PR DESCRIPTION
Add comprehensive debug instrumentation to trace managed variable address calculation when trampolines are enabled. Enable with ROCR_LOADER_DEBUG=1.

Logs added to:
- SymbolAddress(): vaddr, section addr/offset, segment info, result
- LoadDefinitionSymbol(): variable name, address, trampoline state
- InstallTrampolinesGfx125x(): kd_vaddr, entry_off, stub addresses, offset delta
- ApplyStaticRelocation(): symbol, type, reladdr, offset, addend
- ApplyDynamicRelocation(): symbol, rel_type, offset, addend, device_addr
- R_AMDGPU_ABS64/RELATIVE64: final symAddr and write location

This helps trace the 0x100 offset bug where managed variable addresses are miscalculated when trampolines modify kernel_code_entry_byte_offset.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
