### PR TITLE
Simplify rocrCopyBufferBatch

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocblit.cpp
+++ b/projects/clr/rocclr/device/rocm/rocblit.cpp
@@ -775,10 +775,9 @@ bool DmaBlitManager::rocrCopyBufferBatch(const std::vector<hsa_amd_memory_copy_o
   // Submit each non-empty engine group as a separate batch with its own signal.
   // Within each group, ops are grouped by type (SWAP and each INDIRECT mode
   // each become one multi-entry op; see the bucket declarations below).
-  // LINEAR ops are further grouped by src_agent:
-  //  - Same (src, size) with multiple dsts (SdmaD2D) → BROADCAST
-  //  - Multiple remaining ops from same src_agent    → MULTI
-  //  - Single remaining op                           → LINEAR
+  // LINEAR ops share one src_agent per engine group.
+  // SdmaD2D only: same (src, size) with multiple dsts → BROADCAST.
+  // Remaining LINEAR ops → one MULTI or LINEAR.
   hsa_status_t status = HSA_STATUS_SUCCESS;
   std::vector<ProfilingSignal*> groupSignals;
 
@@ -788,7 +787,6 @@ bool DmaBlitManager::rocrCopyBufferBatch(const std::vector<hsa_amd_memory_copy_o
 
     HwQueueEngine engine = static_cast<HwQueueEngine>(e);
 
-    // Two-level grouping: first by src_agent, then by (src, size) for broadcast.
     struct BcastKey {
       const void* src;
       size_t size;
@@ -802,11 +800,7 @@ bool DmaBlitManager::rocrCopyBufferBatch(const std::vector<hsa_amd_memory_copy_o
       std::vector<void*> dsts;
       std::vector<hsa_agent_t> dst_agents;
     };
-    struct AgentGroup {
-      hsa_agent_t src_agent;
-      std::map<BcastKey, BcastEntry> sub_groups;
-    };
-    std::map<uint64_t, AgentGroup> agent_groups;
+    std::map<BcastKey, BcastEntry> broadcast_groups;
 
     struct MultiArrays {
       std::vector<void*> srcs;
@@ -817,6 +811,8 @@ bool DmaBlitManager::rocrCopyBufferBatch(const std::vector<hsa_amd_memory_copy_o
 
     MultiArrays swapPending;
     hsa_agent_t swapSrcAgent = {};
+    MultiArrays linear_pending;
+    hsa_agent_t linear_src_agent = {};
 
     // Indirect ops are bucketed by their indirect mode (SRC / DST / SRCDST)
     // into multi-entry HSA ops, one bucket per mode.  All entries in one
@@ -859,24 +855,30 @@ bool DmaBlitManager::rocrCopyBufferBatch(const std::vector<hsa_amd_memory_copy_o
         bucket.pending.sizes.push_back(op.size);
         continue;
       }
-      auto& ag = agent_groups[op.src_agent.handle];
-      ag.src_agent = op.src_agent;
-      BcastKey bkey{op.src, op.size};
-      auto& be = ag.sub_groups[bkey];
-      if (be.dsts.empty()) {
-        be.tmpl = op;
+      if (linear_pending.srcs.empty() && broadcast_groups.empty()) {
+        linear_src_agent = op.src_agent;
       }
-      be.dsts.push_back(op.dst);
-      be.dst_agents.push_back(op.dst_agent);
+      if (engine == HwQueueEngine::SdmaD2D) {
+        auto& broadcast_entry = broadcast_groups[BcastKey{op.src, op.size}];
+        if (broadcast_entry.dsts.empty()) {
+          broadcast_entry.tmpl = op;
+        }
+        broadcast_entry.dsts.push_back(op.dst);
+        broadcast_entry.dst_agents.push_back(op.dst_agent);
+      } else {
+        linear_pending.srcs.push_back(const_cast<void*>(op.src));
+        linear_pending.dsts.push_back(op.dst);
+        linear_pending.dst_agents.push_back(op.dst_agent);
+        linear_pending.sizes.push_back(op.size);
+      }
     }
 
     gpu().Barriers().SetActiveEngine(engine);
 
     std::vector<MultiArrays> multiStore;
     // Upper-bound entries that land in multiStore: one swap bucket + one
-    // multi bucket per src_agent group + one per populated indirect-mode
-    // bucket.
-    multiStore.reserve(1 + agent_groups.size() + indirectPending.size());
+    // multi bucket + one per populated indirect-mode bucket.
+    multiStore.reserve(1 + 1 + indirectPending.size());
 
     std::vector<hsa_amd_memory_copy_op_t> finalOps;
 
@@ -897,57 +899,53 @@ bool DmaBlitManager::rocrCopyBufferBatch(const std::vector<hsa_amd_memory_copy_o
       finalOps.push_back(swap);
     }
 
-    // --- Emit LINEAR / BROADCAST batches (one group per src_agent) ---
-    for (auto& [agent_handle, ag] : agent_groups) {
-      MultiArrays pending;
-
-      for (auto& [bkey, be] : ag.sub_groups) {
-        if (be.dsts.size() > 1 && engine == HwQueueEngine::SdmaD2D) {
-          hsa_amd_memory_copy_op_t bcast = {};
-          bcast.version = HSA_AMD_MEMORY_COPY_OP_VERSION;
-          bcast.type = HSA_AMD_MEMORY_COPY_OP_LINEAR_BROADCAST;
-          bcast.src = be.tmpl.src;
-          bcast.src_agent = ag.src_agent;
-          bcast.dst_list = be.dsts.data();
-          bcast.dst_agent_list = be.dst_agents.data();
-          bcast.num_entries = static_cast<uint16_t>(be.dsts.size());
-          bcast.size = be.tmpl.size;
-          finalOps.push_back(bcast);
-        } else {
-          for (size_t i = 0; i < be.dsts.size(); ++i) {
-            pending.srcs.push_back(const_cast<void*>(be.tmpl.src));
-            pending.dsts.push_back(be.dsts[i]);
-            pending.dst_agents.push_back(be.dst_agents[i]);
-            pending.sizes.push_back(be.tmpl.size);
-          }
+    // --- Emit LINEAR / BROADCAST batches ---
+    for (auto& [bcast_key, broadcast_entry] : broadcast_groups) {
+      if (broadcast_entry.dsts.size() > 1) {
+        hsa_amd_memory_copy_op_t bcast = {};
+        bcast.version = HSA_AMD_MEMORY_COPY_OP_VERSION;
+        bcast.type = HSA_AMD_MEMORY_COPY_OP_LINEAR_BROADCAST;
+        bcast.src = broadcast_entry.tmpl.src;
+        bcast.src_agent = linear_src_agent;
+        bcast.dst_list = broadcast_entry.dsts.data();
+        bcast.dst_agent_list = broadcast_entry.dst_agents.data();
+        bcast.num_entries = static_cast<uint16_t>(broadcast_entry.dsts.size());
+        bcast.size = broadcast_entry.tmpl.size;
+        finalOps.push_back(bcast);
+      } else {
+        for (size_t i = 0; i < broadcast_entry.dsts.size(); ++i) {
+          linear_pending.srcs.push_back(const_cast<void*>(broadcast_entry.tmpl.src));
+          linear_pending.dsts.push_back(broadcast_entry.dsts[i]);
+          linear_pending.dst_agents.push_back(broadcast_entry.dst_agents[i]);
+          linear_pending.sizes.push_back(broadcast_entry.tmpl.size);
         }
       }
+    }
 
-      if (pending.srcs.size() > 1) {
-        multiStore.push_back(std::move(pending));
-        auto& stored = multiStore.back();
+    if (linear_pending.srcs.size() > 1) {
+      multiStore.push_back(std::move(linear_pending));
+      auto& stored = multiStore.back();
 
-        hsa_amd_memory_copy_op_t multi = {};
-        multi.version = HSA_AMD_MEMORY_COPY_OP_VERSION;
-        multi.type = HSA_AMD_MEMORY_COPY_OP_LINEAR;
-        multi.src_list = stored.srcs.data();
-        multi.src_agent = ag.src_agent;
-        multi.dst_list = stored.dsts.data();
-        multi.dst_agent_list = stored.dst_agents.data();
-        multi.size_list = stored.sizes.data();
-        multi.num_entries = static_cast<uint16_t>(stored.srcs.size());
-        finalOps.push_back(multi);
-      } else if (pending.srcs.size() == 1) {
-        hsa_amd_memory_copy_op_t linear = {};
-        linear.version = HSA_AMD_MEMORY_COPY_OP_VERSION;
-        linear.type = HSA_AMD_MEMORY_COPY_OP_LINEAR;
-        linear.src = pending.srcs[0];
-        linear.src_agent = ag.src_agent;
-        linear.dst = pending.dsts[0];
-        linear.dst_agent = pending.dst_agents[0];
-        linear.size = pending.sizes[0];
-        finalOps.push_back(linear);
-      }
+      hsa_amd_memory_copy_op_t multi = {};
+      multi.version = HSA_AMD_MEMORY_COPY_OP_VERSION;
+      multi.type = HSA_AMD_MEMORY_COPY_OP_LINEAR;
+      multi.src_list = stored.srcs.data();
+      multi.src_agent = linear_src_agent;
+      multi.dst_list = stored.dsts.data();
+      multi.dst_agent_list = stored.dst_agents.data();
+      multi.size_list = stored.sizes.data();
+      multi.num_entries = static_cast<uint16_t>(stored.srcs.size());
+      finalOps.push_back(multi);
+    } else if (linear_pending.srcs.size() == 1) {
+      hsa_amd_memory_copy_op_t linear = {};
+      linear.version = HSA_AMD_MEMORY_COPY_OP_VERSION;
+      linear.type = HSA_AMD_MEMORY_COPY_OP_LINEAR;
+      linear.src = linear_pending.srcs[0];
+      linear.src_agent = linear_src_agent;
+      linear.dst = linear_pending.dsts[0];
+      linear.dst_agent = linear_pending.dst_agents[0];
+      linear.size = linear_pending.sizes[0];
+      finalOps.push_back(linear);
     }
 
     // --- Emit INDIRECT batches ---

--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -831,7 +831,7 @@ memory:
   Unit_hipMemcpyBatchAsync_Attrs_Negative:
     <<: *level_2
     tags: [transfer]
-  Unit_hipMemcpyBatchAsync_Attrs_Functional:
+  Unit_hipMemcpyBatchAsync_D2D_Swap:
     <<: *level_2
     tags: [transfer]
   Unit_hipMemcpyBatchAsync_H2D_Functional: *level_2
@@ -852,6 +852,12 @@ memory:
   Unit_hipMemcpyBatchAsync_P2P_Functional:
     <<: *level_2
     tags: [transfer, multigpu]
+  Unit_hipMemcpyBatchAsync_IndirectDst:
+    <<: *level_2
+    tags: [transfer]
+  Unit_hipMemcpyBatchAsync_IndirectSrc:
+    <<: *level_2
+    tags: [transfer]
   Unit_hipMemsetD2D8_BasicFunctional:
     <<: *level_2
     disabled: [amd_wsl]

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
@@ -455,7 +455,7 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_D2D_Functional) {
   std::vector<size_t> sizes(config.copy_count, config.copy_size);
   size_t attrs_idxs[1] = {0};
   hipMemcpyAttributes attr{
-      hipMemcpySrcAccessOrderStream, {}, {}, static_cast<unsigned int>(flag)};
+      hipMemcpySrcAccessOrderAny, {}, {}, static_cast<unsigned int>(flag)};
 
   if (pointer_pattern == PointerPattern::kBroadcastSource) {
     FillDeviceBuffers(src_ptrs, copy_size, kPatternValue);

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyBatchAsync.cc
@@ -46,11 +46,6 @@ enum class PointerPattern {
   kBroadcastSource,
 };
 
-size_t CopyElements(size_t copy_size) {
-  REQUIRE(copy_size % sizeof(int) == 0);
-  return copy_size / sizeof(int);
-}
-
 std::vector<std::pair<int, int>> GetPeerAccessibleDevicePairs() {
   if (HipTest::getDeviceCount() < 2) {
     HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
@@ -118,7 +113,7 @@ std::vector<void*> MakeBatchPtrs(std::vector<LinearAllocGuard<int>>& allocations
 }
 
 void FillDeviceBuffers(const std::vector<void*>& ptrs, size_t copy_size, int value) {
-  const size_t copy_elements = CopyElements(copy_size);
+  const size_t copy_elements = copy_size / sizeof(int);
   std::vector<int> source(copy_elements);
 
   for (size_t i = 0; i < ptrs.size(); ++i) {
@@ -129,7 +124,7 @@ void FillDeviceBuffers(const std::vector<void*>& ptrs, size_t copy_size, int val
 
 void FillHostBuffers(std::vector<LinearAllocGuard<int>>& buffers, size_t copy_size,
                      int value = kPatternValue) {
-  const size_t copy_elements = CopyElements(copy_size);
+  const size_t copy_elements = copy_size / sizeof(int);
 
   for (size_t i = 0; i < buffers.size(); ++i) {
     std::fill_n(buffers[i].host_ptr(), copy_elements, value + static_cast<int>(i));
@@ -156,7 +151,7 @@ void VerifyArrayFromBothEnds(const int* values, size_t copy_elements, int expect
 
 void VerifyDeviceBuffers(const std::vector<void*>& ptrs, size_t copy_size,
                          int expected = kPatternValue, bool add_index = true) {
-  const size_t copy_elements = CopyElements(copy_size);
+  const size_t copy_elements = copy_size / sizeof(int);
   std::vector<int> result(copy_elements);
 
   for (size_t i = 0; i < ptrs.size(); ++i) {
@@ -168,7 +163,7 @@ void VerifyDeviceBuffers(const std::vector<void*>& ptrs, size_t copy_size,
 
 void VerifyHostBuffers(std::vector<LinearAllocGuard<int>>& buffers, size_t copy_size,
                        int expected = kPatternValue) {
-  const size_t copy_elements = CopyElements(copy_size);
+  const size_t copy_elements = copy_size / sizeof(int);
 
   for (size_t i = 0; i < buffers.size(); ++i) {
     VerifyArrayFromBothEnds(buffers[i].host_ptr(), copy_elements, expected + static_cast<int>(i),
@@ -378,11 +373,11 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_Attrs_Negative) {
   }
 }
 
+#if HT_AMD
 /**
  * Test Description
  * ------------------------
- * - Verifies segmented host-source access attributes and swap attributes for
- * hipMemcpyBatchAsync.
+ * - Verifies D2D batch copies with hipMemcpyFlagExtOpSwap.
  * Test source
  * ------------------------
  * - catch/unit/memory/hipMemcpyBatchAsync.cc
@@ -390,81 +385,37 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_Attrs_Negative) {
  * ------------------------
  *  - HIP_VERSION >= 7.1
  */
-HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_Attrs_Functional) {
-  constexpr size_t kCopiesPerAttr = 3;
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_D2D_Swap) {
+  constexpr size_t copy_count = 3;
+  constexpr size_t copy_size = kSmallCopySize;
+  constexpr int kSwapSrcValue = 23;
+  constexpr int kSwapDstValue = 47;
+  BatchConfig config{copy_count, copy_size};
   StreamGuard stream_guard(Streams::created);
+  std::vector<LinearAllocGuard<int>> src = AllocateBatchBuffers(LinearAllocs::hipMalloc, config);
+  std::vector<LinearAllocGuard<int>> dst = AllocateBatchBuffers(LinearAllocs::hipMalloc, config);
+  std::vector<void*> src_ptrs = MakeBatchPtrs(src);
+  std::vector<void*> dst_ptrs = MakeBatchPtrs(dst);
+  std::vector<size_t> sizes(src_ptrs.size(), copy_size);
+  hipMemcpyAttributes attr{hipMemcpySrcAccessOrderStream, {}, {}, hipMemcpyFlagExtOpSwap};
+  size_t attrs_idxs[1] = {0};
 
-  SECTION("Regular attributes") {
-#if HT_AMD
-    std::array<hipMemcpyAttributes, 6> host_attrs{
-        hipMemcpyAttributes{hipMemcpySrcAccessOrderStream, {}, {}, hipMemcpyFlagDefault},
-        hipMemcpyAttributes{hipMemcpySrcAccessOrderStream, {}, {}, hipMemcpyFlagExtPreferCE},
-        hipMemcpyAttributes{hipMemcpySrcAccessOrderDuringApiCall, {}, {}, hipMemcpyFlagDefault},
-        hipMemcpyAttributes{hipMemcpySrcAccessOrderDuringApiCall, {}, {}, hipMemcpyFlagExtPreferCE},
-        hipMemcpyAttributes{hipMemcpySrcAccessOrderAny, {}, {}, hipMemcpyFlagDefault},
-        hipMemcpyAttributes{hipMemcpySrcAccessOrderAny, {}, {}, hipMemcpyFlagExtPreferCE},
-    };
-#else
-    std::array<hipMemcpyAttributes, 3> host_attrs{
-        hipMemcpyAttributes{hipMemcpySrcAccessOrderStream, {}, {}, hipMemcpyFlagDefault},
-        hipMemcpyAttributes{hipMemcpySrcAccessOrderDuringApiCall, {}, {}, hipMemcpyFlagDefault},
-        hipMemcpyAttributes{hipMemcpySrcAccessOrderAny, {}, {}, hipMemcpyFlagDefault},
-    };
-#endif
-    BatchConfig host_config{host_attrs.size() * kCopiesPerAttr, kSmallCopySize};
-    std::vector<LinearAllocGuard<int>> host_src =
-        AllocateBatchBuffers(LinearAllocs::hipHostMalloc, host_config);
-    std::vector<LinearAllocGuard<int>> dst =
-        AllocateBatchBuffers(LinearAllocs::hipMalloc, host_config);
-    std::vector<void*> host_src_ptrs = MakeBatchPtrs(host_src);
-    std::vector<void*> dst_ptrs = MakeBatchPtrs(dst);
-    std::vector<size_t> sizes(host_src_ptrs.size(), kSmallCopySize);
-    std::vector<size_t> attrs_idxs;
+  FillDeviceBuffers(src_ptrs, copy_size, kSwapSrcValue);
+  FillDeviceBuffers(dst_ptrs, copy_size, kSwapDstValue);
 
-    for (size_t attr_idx = 0; attr_idx < host_attrs.size(); ++attr_idx) {
-      attrs_idxs.push_back(attr_idx * kCopiesPerAttr);
-    }
-
-    FillHostBuffers(host_src, kSmallCopySize);
-
-    HIP_CHECK(hipMemcpyBatchAsync(dst_ptrs.data(), host_src_ptrs.data(), sizes.data(), sizes.size(),
-                                  host_attrs.data(), attrs_idxs.data(), attrs_idxs.size(), nullptr,
-                                  stream_guard.stream()));
+  hipError_t status =
+      hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), src_ptrs.size(), &attr,
+                          attrs_idxs, 1, nullptr, stream_guard.stream());
+  if (status == hipErrorNotSupported) {
+    SUCCEED("hipMemcpyFlagExtOpSwap is not supported on this device");
+  } else {
+    HIP_CHECK(status);
     HIP_CHECK(hipStreamSynchronize(stream_guard.stream()));
-    VerifyDeviceBuffers(dst_ptrs, kSmallCopySize);
+    VerifyDeviceBuffers(src_ptrs, copy_size, kSwapDstValue);
+    VerifyDeviceBuffers(dst_ptrs, copy_size, kSwapSrcValue);
   }
-
-#if HT_AMD
-  SECTION("Swap attribute") {
-    BatchConfig d2d_config{kCopiesPerAttr, kSmallCopySize};
-    std::vector<LinearAllocGuard<int>> d2d_src =
-        AllocateBatchBuffers(LinearAllocs::hipMalloc, d2d_config);
-    std::vector<LinearAllocGuard<int>> d2d_dst =
-        AllocateBatchBuffers(LinearAllocs::hipMalloc, d2d_config);
-    std::vector<void*> d2d_src_ptrs = MakeBatchPtrs(d2d_src);
-    std::vector<void*> d2d_dst_ptrs = MakeBatchPtrs(d2d_dst);
-    std::vector<size_t> sizes(d2d_src_ptrs.size(), kSmallCopySize);
-    hipMemcpyAttributes attr{hipMemcpySrcAccessOrderStream, {}, {}, hipMemcpyFlagExtOpSwap};
-    size_t attrs_idxs[1] = {0};
-    constexpr int kSwapSrcValue = 23;
-    constexpr int kSwapDstValue = 47;
-    FillDeviceBuffers(d2d_src_ptrs, kSmallCopySize, kSwapSrcValue);
-    FillDeviceBuffers(d2d_dst_ptrs, kSmallCopySize, kSwapDstValue);
-
-    hipError_t status = hipMemcpyBatchAsync(d2d_dst_ptrs.data(), d2d_src_ptrs.data(), sizes.data(),
-                                            d2d_src_ptrs.size(), &attr, attrs_idxs, 1, nullptr,
-                                            stream_guard.stream());
-    if (status == hipErrorNotSupported) {
-      SUCCEED("hipMemcpyFlagExtOpSwap is not supported on this device");
-    } else {
-      HIP_CHECK(status);
-      HIP_CHECK(hipStreamSynchronize(stream_guard.stream()));
-      VerifyDeviceBuffers(d2d_src_ptrs, kSmallCopySize, kSwapDstValue);
-      VerifyDeviceBuffers(d2d_dst_ptrs, kSmallCopySize, kSwapSrcValue);
-    }
-  }
-#endif
 }
+#endif
 
 /**
  * Test Description
@@ -718,7 +669,7 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_H2H_Functional) {
  */
 HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_Mixed_Functional) {
   constexpr size_t copy_size = kMediumCopySize;
-  const size_t copy_elements = CopyElements(copy_size);
+  const size_t copy_elements = copy_size / sizeof(int);
 
   if (HipTest::getDeviceCount() < 3) {
     HIP_SKIP_TEST("Test requires at least three GPUs.");
@@ -901,6 +852,96 @@ HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_P2P_Functional) {
   DisablePeerAccess(peer_pairs);
   HIP_CHECK(hipSetDevice(stream_device));
 }
+
+#if HT_AMD
+/**
+ * Test Description
+ * ------------------------
+ * - Verifies H2D hipMemcpyBatchAsync with hipMemcpyFlagExtOpIndirectSrc copies
+ * from the host buffer referenced by a pinned pointer slot.
+ * Test source
+ * ------------------------
+ * - catch/unit/memory/hipMemcpyBatchAsync.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.1
+ */
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_IndirectSrc) {
+  constexpr size_t copy_size = kSmallCopySize;
+
+  StreamGuard stream_guard(Streams::created);
+  LinearAllocGuard<int> src(LinearAllocs::hipHostMalloc, copy_size);
+  LinearAllocGuard<int> dst(LinearAllocs::hipMalloc, copy_size);
+  LinearAllocGuard<char> src_slot(LinearAllocs::hipHostMalloc, sizeof(void*));
+
+  const size_t copy_elements = copy_size / sizeof(int);
+  std::fill_n(src.host_ptr(), copy_elements, kPatternValue);
+
+  void* src_ptr = src.ptr();
+  std::memcpy(src_slot.ptr(), &src_ptr, sizeof(void*));
+
+  std::vector<void*> dst_ptrs{dst.ptr()};
+  std::vector<void*> src_ptrs{src_slot.ptr()};
+  std::vector<size_t> sizes{copy_size};
+  hipMemcpyAttributes attr{hipMemcpySrcAccessOrderStream, {}, {}, hipMemcpyFlagExtOpIndirectSrc};
+  size_t attrs_idx = 0;
+
+  hipError_t status = hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), 1, &attr,
+                                          &attrs_idx, 1, nullptr, stream_guard.stream());
+  if (status == hipErrorNotSupported) {
+    SUCCEED("hipMemcpyFlagExtOpIndirectSrc is not supported on this device");
+  } else {
+    HIP_CHECK(status);
+    HIP_CHECK(hipStreamSynchronize(stream_guard.stream()));
+    VerifyDeviceBuffers(dst_ptrs, copy_size);
+  }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ * - Verifies D2H hipMemcpyBatchAsync with hipMemcpyFlagExtOpIndirectDst copies
+ * into the host buffer referenced by a pinned pointer slot.
+ * Test source
+ * ------------------------
+ * - catch/unit/memory/hipMemcpyBatchAsync.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 7.1
+ */
+HIP_TEST_CASE(Unit_hipMemcpyBatchAsync_IndirectDst) {
+  constexpr size_t copy_size = kSmallCopySize;
+
+  StreamGuard stream_guard(Streams::created);
+  LinearAllocGuard<int> src(LinearAllocs::hipMalloc, copy_size);
+  LinearAllocGuard<int> dst(LinearAllocs::hipHostMalloc, copy_size);
+  LinearAllocGuard<char> dst_slot(LinearAllocs::hipHostMalloc, sizeof(void*));
+
+  const size_t copy_elements = copy_size / sizeof(int);
+  std::vector<int> host_pattern(copy_elements, kPatternValue);
+  HIP_CHECK(hipMemcpy(src.ptr(), host_pattern.data(), copy_size, hipMemcpyHostToDevice));
+  std::fill_n(dst.host_ptr(), copy_elements, 0);
+
+  void* dst_ptr = dst.ptr();
+  std::memcpy(dst_slot.ptr(), &dst_ptr, sizeof(void*));
+
+  std::vector<void*> src_ptrs{src.ptr()};
+  std::vector<void*> dst_ptrs{dst_slot.ptr()};
+  std::vector<size_t> sizes{copy_size};
+  hipMemcpyAttributes attr{hipMemcpySrcAccessOrderStream, {}, {}, hipMemcpyFlagExtOpIndirectDst};
+  size_t attrs_idx = 0;
+
+  hipError_t status = hipMemcpyBatchAsync(dst_ptrs.data(), src_ptrs.data(), sizes.data(), 1, &attr,
+                                          &attrs_idx, 1, nullptr, stream_guard.stream());
+  if (status == hipErrorNotSupported) {
+    SUCCEED("hipMemcpyFlagExtOpIndirectDst is not supported on this device");
+  } else {
+    HIP_CHECK(status);
+    HIP_CHECK(hipStreamSynchronize(stream_guard.stream()));
+    VerifyArrayFromBothEnds(dst.host_ptr(), copy_elements, kPatternValue, 0);
+  }
+}
+#endif
 
 /**
  * End doxygen group MemoryTest.


### PR DESCRIPTION
## Motivation

Improve the processing speed of the batch copy operations.

## Technical Details

The hipMemcpyBatchAsync is splitted into per-device batch commands. Each engine group (H2D, D2H, D2D) therefore shares one src_agent, which simplifies rocrCopyBufferBatch:
- Remove the outer AgentGroup / src_agent map; D2D broadcast grouping is keyed only by (src, size).
- Ingest H2D/D2H LINEAR ops directly instead of routing them through the broadcast map.

## JIRA ID

AIRUNTIME-2315

## Test Plan

Run batch copy tests

## Test Result

All batch copy tests passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
