### PR TITLE
fix(rocr): Large BAR detection for APU devices with no device-local memory

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -263,7 +263,7 @@ GpuAgent::GpuAgent(HSAuint32 node, const HsaNodeProperties& node_props, bool xna
   auto link_info = core::Runtime::runtime_singleton_->GetLinkInfo(first_cpu->node_id(), node_id());
   xgmi_cpu_gpu_ = (link_info.info.link_type == HSA_AMD_LINK_INFO_TYPE_XGMI);
 
-  if (link_info.num_hop >= 1) {
+  if (link_info.num_hop >= 1 && !properties_.Integrated) {
     large_bar_enabled_ = true;
   }
 


### PR DESCRIPTION
## Motivation

Without this fix the following rocrtst tests fail on gfx1151 (Strix Point):
```
  rocrtstFunc.Queue_Create_DeviceMem_RingBuf_Test
  rocrtstFunc.Queue_Create_Batch_Test
```
Both time out after 5 s waiting for a completion signal because the GPU CP cannot fetch packets from the incorrectly-placed ring buffer.

## Technical Details
`GpuAgent` currently sets `large_bar_enabled_` solely from the CPU->GPU link hop count (`num_hop >= 1`). On APU devices such as gfx1151 (Strix Point), the CPU and GPU may appear on separate NUMA nodes, so `num_hop == 1`, but there is no discrete-GPU VRAM behind a PCIe BAR: memory is system RAM shared on-die.

This causes `hsa_amd_queue_create` requests using device-memory queue placement flags to be accepted because `LargeBarEnabled()` returns `true`. In particular, `HSA_AMD_QUEUE_CREATE_DEVICE_MEM_RING_BUF` can allocate the ring buffer from the coarse-grain device-memory region even on a zero-local-memory APU. The GPU command processor then cannot fetch packets from that memory, so kernel dispatch through the queue times out after 5 s. These requests should instead be rejected up front with `HSA_STATUS_ERROR_INVALID_QUEUE_CREATION`.

Using `link_type` is not sufficient here: modern AMD APUs (gfx11.5+) can report `HSA_AMD_LINK_INFO_TYPE_PCIE` in KFD topology even though the GPU is on-die. Similarly, the existing `is_apu_node` heuristic based on `NumCPUCores > 0` does not reliably identify this case, because in SPX compute-partition mode gfx1151 can expose `cpu_cores_count == 0` in KFD node properties.

`HsaNodeProperties::LocalMemSize > 0` is a better runtime discriminator for allowing device-memory queue placement. Large BAR is only meaningful when the GPU exposes device-local memory (VRAM); on APUs in SPX mode, `local_mem_size` is reported as 0 because there is no dedicated VRAM.

This change therefore restricts `large_bar_enabled_` to GPUs that are CPU-reachable and also report nonzero local memory, which causes unsupported device-memory queue-placement requests to fail early instead of succeeding and hanging later. Because `LargeBarEnabled()` is the common gate for device-memory queue placement, this affects both `HSA_AMD_QUEUE_CREATE_DEVICE_MEM_RING_BUF` and `HSA_AMD_QUEUE_CREATE_DEVICE_MEM_QUEUE_DESCRIPTOR`.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Running rocrtst ([rocr-runtime~git20260702.34b11ec813](https://launchpad.net/~bullwinkle-team/+archive/ubuntu/rocm-exp)) on Ubuntu Resolute machine with gfx1151 before and after the patch.

## Test Result

Before the patch
```
  rocrtstFunc.Queue_Create_DeviceMem_RingBuf_Test
  rocrtstFunc.Queue_Create_Batch_Test
```  
are failing, while after the patch:
```
[ RUN      ] rocrtstFunc.Queue_Create_DeviceMem_RingBuf_Test
###############################################################################

	#### TEST NAME ####
RocR Queue Create API Test

	#### TEST DESCRIPTION ####
Tests hsa_amd_queue_create with various device-memory placement flags:
system memory (default) and device-resident ring buffer.

	#### TEST SETUP ####

	#### TEST EXECUTION ####
The gpu device name is gfx1151
Target HW Profile is HSA_PROFILE_BASE
Test can run on any profile. OK.
  DeviceMemRingBufQueueTest: SKIPPED (agent does not support device-memory ring buffers or Large BAR is unavailable)

	#### TEST RESULTS ####

	#### TEST CLEAN UP ####
[       OK ] rocrtstFunc.Queue_Create_DeviceMem_RingBuf_Test (470 ms)
[ RUN      ] rocrtstFunc.Queue_Create_Batch_Test
###############################################################################

	#### TEST NAME ####
RocR Queue Create API Test

	#### TEST DESCRIPTION ####
Tests hsa_amd_queue_create with various device-memory placement flags:
system memory (default) and device-resident ring buffer.

	#### TEST SETUP ####

	#### TEST EXECUTION ####
The gpu device name is gfx1151
Target HW Profile is HSA_PROFILE_BASE
Test can run on any profile. OK.
  BatchQueueCreateTest: SKIPPED (agent does not support device-memory flags or Large BAR is unavailable)

	#### TEST RESULTS ####

	#### TEST CLEAN UP ####
[       OK ] rocrtstFunc.Queue_Create_Batch_Test (473 ms)
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
