### PR TITLE
clr: fix device-printf hostcall deadlock on lost doorbell (gfx1201/RDNA4)

### DIFF
--- a/projects/clr/rocclr/device/devhostcall.cpp
+++ b/projects/clr/rocclr/device/devhostcall.cpp
@@ -297,6 +297,18 @@ void HostcallListener::consumePackets() {
         timeout = std::max(kTimeoutFloor, timeout);
         break;
       }
+      // The doorbell wait timed out without observing a value change. On most
+      // architectures the device-side doorbell ring reliably wakes this wait,
+      // but if a doorbell notification is ever missed (observed on some
+      // RDNA4/gfx120X configurations, see ROCm/rocm-systems / TheRock #6357) the
+      // wait would keep timing out forever while a ready SERVICE_PRINTF packet
+      // sits unserviced -- the requesting wave never unblocks and
+      // hipDeviceSynchronize deadlocks. To harden the servicing path against a
+      // lost doorbell wakeup, poll the ready stacks on timeout as well;
+      // processPackets() is a cheap no-op when nothing is ready.
+      if (!idle()) {
+        break;
+      }
       // Increase the timeout since we dont need to check as frequently
       timeout = timeout << 0x1;
       timeout = std::min(kTimeoutCeil, timeout);


### PR DESCRIPTION
HostcallListener::consumePackets() only serviced hostcall packets (e.g. SERVICE_PRINTF) when the doorbell signal VALUE CHANGED. On a doorbell wait timeout it merely extended the backoff timeout and looped again, never inspecting the ready stacks. If a device-side doorbell ring is ever missed (observed on gfx1200/gfx1201 RDNA4 Linux, TheRock #6357 / test_hip_printf), a ready packet is never serviced, the requesting wave never unblocks, and hipDeviceSynchronize deadlocks forever (300s CI timeout, exit 124).

Poll the ready stacks on timeout as well by breaking out of the wait loop when the listener is not idle. processPackets() is a cheap no-op when nothing is ready, so the healthy value-change fast path and other archs are unaffected; only the missed-doorbell case is converted from an infinite hang into a bounded-latency poll.

Verified with a faithful control-flow model of the loop: original hangs on a lost doorbell, patched services the packet. Fixes ROCm/TheRock#6357.