### PR TITLE
hsa-runtime: fix UB in lazy_ptr move-assignment (missing return *this)

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/lazy_ptr.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/lazy_ptr.h
@@ -69,6 +69,7 @@ template <typename T> class lazy_ptr {
   lazy_ptr& operator=(lazy_ptr&& rhs) {
     obj = std::move(rhs.obj);
     func = std::move(rhs.func);
+    return *this;
   }
 
   lazy_ptr(lazy_ptr&) = delete;


### PR DESCRIPTION
lazy_ptr::operator=(lazy_ptr&&) was declared to return lazy_ptr& but had no return statement, which is undefined behavior (-Wreturn-type). The operator returns whatever garbage happens to be in the return register.

This is exercised during GpuAgent::InitDma() when the queues_/blits_ lazy_ptr elements are set up (std::vector relocation / std::swap invoke the move-assignment). The garbage return corrupts the internal std::function's _M_manager pointer. The subsequent lazy_ptr::reset() performs 'func = std::move(C)', which makes std::function::operator= destroy the previous target by calling the (now garbage) _M_manager, resulting in a jump to an invalid address and SIGSEGV.

On gfx1151 (Strix Halo, Radeon 8060S) with HSA runtime 1.21.0 this made rocminfo (and any hsa_init() caller) crash immediately after 'ROCk module is loaded'. Backtrace: RIP=0x100000001 in GpuAgent::InitDma -> PostToolsInit -> Runtime::Load -> Runtime::Acquire -> hsa_init.

Adding the missing 'return *this;' fixes the crash. Verified by rebuilding libhsa-runtime64.so.1.21.0 and re-running rocminfo, which now completes with exit 0 and enumerates the gfx1151 GPU agent.

Fixes: ROCm/TheRock#5985

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
