### PR TITLE
fix(rocr-runtime): add missing return *this in lazy_ptr move-assignment

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/CMakeLists.txt
+++ b/projects/rocr-runtime/runtime/hsa-runtime/CMakeLists.txt
@@ -455,6 +455,13 @@ if( NOT ${BUILD_SHARED_LIBS} )
   install ( TARGETS ${CORE_RUNTIME_NAME} EXPORT ${CORE_RUNTIME_NAME}Targets )
 endif()
 
+## Unit tests for header-only utilities (opt-in; requires GTest).
+option(BUILD_ROCR_TESTS "Build hsa-runtime unit tests" OFF)
+if (BUILD_ROCR_TESTS)
+  enable_testing()
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/core/util)
+endif()
+
 ## Set install information
 # Installs binaries and exports the library usage data to ${HSAKMT_TARGET}Targets
 if (NOT WIN32)

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/CMakeLists.txt
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/CMakeLists.txt
@@ -1,0 +1,68 @@
+################################################################################
+##
+## The University of Illinois/NCSA
+## Open Source License (NCSA)
+##
+## Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+##
+## Developed by:
+##
+##                 AMD Research and AMD HSA Software Development
+##
+##                 Advanced Micro Devices, Inc.
+##
+##                 www.amd.com
+##
+## Permission is hereby granted, free of charge, to any person obtaining a copy
+## of this software and associated documentation files (the "Software"), to
+## deal with the Software without restriction, including without limitation
+## the rights to use, copy, modify, merge, publish, distribute, sublicense,
+## and/or sell copies of the Software, and to permit persons to whom the
+## Software is furnished to do so, subject to the following conditions:
+##
+##  - Redistributions of source code must retain the above copyright notice,
+##    this list of conditions and the following disclaimers.
+##  - Redistributions in binary form must reproduce the above copyright
+##    notice, this list of conditions and the following disclaimers in
+##    the documentation and/or other materials provided with the distribution.
+##  - Neither the names of Advanced Micro Devices, Inc,
+##    nor the names of its contributors may be used to endorse or promote
+##    products derived from this Software without specific prior written
+##    permission.
+##
+## THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+## IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+## FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+## THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+## OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+## ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+## DEALINGS WITH THE SOFTWARE.
+##
+################################################################################
+
+## Unit tests for the header-only utilities in core/util.
+## Only lazy_ptr.h is exercised today; add sources here as more are covered.
+
+find_package(GTest QUIET)
+if(NOT GTest_FOUND)
+  message(STATUS "hsa-runtime64: GTest not found -- skipping core/util unit tests")
+  return()
+endif()
+
+include(GoogleTest)
+
+add_executable(lazy_ptr_test lazy_ptr_test.cpp)
+
+## The test only needs the header (core/util/lazy_ptr.h and its relative
+## includes), which resolve from the hsa-runtime source root. No link against
+## the runtime library is required.
+target_include_directories(lazy_ptr_test PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/../..)
+
+target_link_libraries(lazy_ptr_test PRIVATE
+  GTest::gtest
+  GTest::gtest_main
+  $<$<NOT:$<BOOL:${WIN32}>>:pthread>)
+
+gtest_discover_tests(lazy_ptr_test
+  PROPERTIES LABELS "unittests")

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/CMakeLists.txt
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/CMakeLists.txt
@@ -3,7 +3,7 @@
 ## The University of Illinois/NCSA
 ## Open Source License (NCSA)
 ##
-## Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+## Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
 ##
 ## Developed by:
 ##
@@ -43,10 +43,36 @@
 ## Unit tests for the header-only utilities in core/util.
 ## Only lazy_ptr.h is exercised today; add sources here as more are covered.
 
+## gtest_discover_tests(... DISCOVERY_MODE PRE_TEST) requires CMake >= 3.18.
+## The user opted in via BUILD_ROCR_TESTS, so fail loudly rather than silently
+## producing no tests.
+if (CMAKE_VERSION VERSION_LESS 3.18)
+  message(FATAL_ERROR
+    "BUILD_ROCR_TESTS requires CMake >= 3.18 "
+    "(gtest_discover_tests DISCOVERY_MODE PRE_TEST); found ${CMAKE_VERSION}.")
+endif()
+
+## Threads::Threads is used explicitly (lazy_ptr uses std::mutex) and is also a
+## transitive dependency of GTest::gtest_main.
+find_package(Threads REQUIRED)
+
+## Locate GTest, or fetch it if the build image doesn't provide one. Because the
+## test is opt-in (BUILD_ROCR_TESTS), a missing GTest must NOT silently skip the
+## regression test — fall back to FetchContent, mirroring projects/aqlprofile.
 find_package(GTest QUIET)
 if(NOT GTest_FOUND)
-  message(STATUS "hsa-runtime64: GTest not found -- skipping core/util unit tests")
-  return()
+  message(STATUS "hsa-runtime64: GTest not found on system -- fetching via FetchContent")
+  include(FetchContent)
+  set(INSTALL_GTEST OFF CACHE BOOL "Disable GTest installation" FORCE)
+  if(MSVC)
+    set(gtest_force_shared_crt ON CACHE BOOL "Use shared CRT for GTest" FORCE)
+  endif()
+  FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG        v1.17.0
+  )
+  FetchContent_MakeAvailable(googletest)
 endif()
 
 include(GoogleTest)
@@ -62,7 +88,11 @@ target_include_directories(lazy_ptr_test PRIVATE
 target_link_libraries(lazy_ptr_test PRIVATE
   GTest::gtest
   GTest::gtest_main
-  $<$<NOT:$<BOOL:${WIN32}>>:pthread>)
+  Threads::Threads)
 
+## DISCOVERY_MODE PRE_TEST defers test enumeration to ctest run time instead of
+## executing the freshly built binary during the build, which would break
+## cross-compilation (the binary targets a different architecture).
 gtest_discover_tests(lazy_ptr_test
+  DISCOVERY_MODE PRE_TEST
   PROPERTIES LABELS "unittests")

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/lazy_ptr.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/lazy_ptr.h
@@ -67,6 +67,10 @@ template <typename T> class lazy_ptr {
   }
 
   lazy_ptr& operator=(lazy_ptr&& rhs) {
+    // Guard against self move-assignment. Without this, p = std::move(p) would
+    // reduce to obj = std::move(obj) on a std::unique_ptr, which is UB per
+    // [res.on.arguments]. The guard makes the operation well-defined.
+    if (&rhs == this) return *this;
     obj = std::move(rhs.obj);
     func = std::move(rhs.func);
     return *this;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/lazy_ptr.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/lazy_ptr.h
@@ -68,8 +68,9 @@ template <typename T> class lazy_ptr {
 
   lazy_ptr& operator=(lazy_ptr&& rhs) {
     // Guard against self move-assignment. Without this, p = std::move(p) would
-    // reduce to obj = std::move(obj) on a std::unique_ptr, which is UB per
-    // [res.on.arguments]. The guard makes the operation well-defined.
+    // reduce to obj/func self-move-assignment; std::function self-move leaves it
+    // in a valid-but-unspecified state ([res.on.arguments]), so created()/empty()
+    // could then report garbage. The guard keeps self-assignment a no-op.
     if (&rhs == this) return *this;
     obj = std::move(rhs.obj);
     func = std::move(rhs.func);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/lazy_ptr.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/lazy_ptr.h
@@ -69,6 +69,7 @@ template <typename T> class lazy_ptr {
   lazy_ptr& operator=(lazy_ptr&& rhs) {
     obj = std::move(rhs.obj);
     func = std::move(rhs.func);
+    return *this;
   }
 
   lazy_ptr(lazy_ptr&) = delete;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/lazy_ptr_test.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/lazy_ptr_test.cpp
@@ -1,0 +1,120 @@
+////////////////////////////////////////////////////////////////////////////////
+//
+// The University of Illinois/NCSA
+// Open Source License (NCSA)
+//
+// Copyright (c) 2014-2020, Advanced Micro Devices, Inc. All rights reserved.
+//
+// Developed by:
+//
+//                 AMD Research and AMD HSA Software Development
+//
+//                 Advanced Micro Devices, Inc.
+//
+//                 www.amd.com
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal with the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+//  - Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimers.
+//  - Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimers in
+//    the documentation and/or other materials provided with the distribution.
+//  - Neither the names of Advanced Micro Devices, Inc,
+//    nor the names of its contributors may be used to endorse or promote
+//    products derived from this Software without specific prior written
+//    permission.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS WITH THE SOFTWARE.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+// Regression test for the lazy_ptr<T> move-assignment operator.
+//
+// lazy_ptr::operator=(lazy_ptr&&) is declared to return lazy_ptr& but
+// historically had no `return` statement. Falling off the end of a non-void
+// function is undefined behavior: the returned reference is whatever garbage
+// is in the return register. When the result is subsequently used (e.g. the
+// std::vector relocation done during GpuAgent::InitDma()), a later reset()
+// operates on a corrupted std::function and jumps to an invalid address,
+// crashing hsa_init(). See ROCm/TheRock#5985.
+//
+// These tests pin the observable contract of move-assignment so the missing
+// `return *this;` cannot regress silently.
+
+#include "gtest/gtest.h"
+
+#include "core/util/lazy_ptr.h"
+
+namespace rocr {
+namespace {
+
+struct Widget {
+  explicit Widget(int v) : value(v) {}
+  int value;
+};
+
+// The core regression: operator= must return a reference to the assigned-to
+// object. With the missing `return *this;` the returned reference points at
+// garbage, so its address does not match &dst.
+TEST(LazyPtrTest, MoveAssignReturnsSelf) {
+  lazy_ptr<Widget> dst;
+  lazy_ptr<Widget> src([]() { return new Widget(7); });
+
+  lazy_ptr<Widget>& result = (dst = std::move(src));
+
+  EXPECT_EQ(&result, &dst);
+}
+
+// Feeding the result of one move-assignment into another relies on the
+// returned reference being the real object. If operator= returns garbage,
+// std::move(dst = ...) reads a bogus obj/func and the second assignment
+// corrupts or crashes.
+TEST(LazyPtrTest, MoveAssignResultIsUsable) {
+  lazy_ptr<Widget> a;
+  lazy_ptr<Widget> b;
+  lazy_ptr<Widget> c([]() { return new Widget(42); });
+
+  a = std::move(b = std::move(c));
+
+  EXPECT_TRUE(a.empty());          // constructor not yet run
+  EXPECT_EQ((*a)->value, 42);      // forces construction; must not crash
+}
+
+// Reproduces the crashing sequence: move-assign into a target, then reset().
+// A garbage return corrupts the internal std::function such that the reset()
+// (which does `func = std::move(...)` and destroys the prior target) faults.
+TEST(LazyPtrTest, ResetAfterMoveAssignIsSafe) {
+  lazy_ptr<Widget> dst;
+  lazy_ptr<Widget> src([]() { return new Widget(1); });
+
+  dst = std::move(src);
+  dst.reset([]() { return new Widget(2); });
+
+  ASSERT_TRUE(dst.empty());        // constructor not yet run
+  EXPECT_EQ((*dst)->value, 2);     // forces construction; must not crash
+  EXPECT_TRUE(dst.created());
+}
+
+// Self move-assignment must remain well-formed and return self.
+TEST(LazyPtrTest, SelfMoveAssignReturnsSelf) {
+  lazy_ptr<Widget> p([]() { return new Widget(3); });
+
+  lazy_ptr<Widget>& result = (p = std::move(p));
+
+  EXPECT_EQ(&result, &p);
+}
+
+}  // namespace
+}  // namespace rocr

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/lazy_ptr_test.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/lazy_ptr_test.cpp
@@ -107,13 +107,29 @@ TEST(LazyPtrTest, ResetAfterMoveAssignIsSafe) {
   EXPECT_TRUE(dst.created());
 }
 
-// Self move-assignment must remain well-formed and return self.
+// Self move-assignment must remain well-formed and return self. operator=
+// guards against self-assignment (&rhs == this), so p = std::move(p) does not
+// reduce to a UB self-move of the underlying std::unique_ptr.
 TEST(LazyPtrTest, SelfMoveAssignReturnsSelf) {
   lazy_ptr<Widget> p([]() { return new Widget(3); });
 
+  // The self-move is deliberate here; -Wself-move would otherwise flag it.
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wself-move"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wself-move"
+#endif
   lazy_ptr<Widget>& result = (p = std::move(p));
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
   EXPECT_EQ(&result, &p);
+  EXPECT_EQ((*p)->value, 3);  // guard preserved the object across self-move
 }
 
 }  // namespace

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/lazy_ptr_test.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/lazy_ptr_test.cpp
@@ -109,22 +109,25 @@ TEST(LazyPtrTest, ResetAfterMoveAssignIsSafe) {
 
 // Self move-assignment must remain well-formed and return self. operator=
 // guards against self-assignment (&rhs == this), so p = std::move(p) does not
-// reduce to a UB self-move of the underlying std::unique_ptr.
+// reduce to a self-move of the underlying obj/func (which would leave func in a
+// valid-but-unspecified state).
 TEST(LazyPtrTest, SelfMoveAssignReturnsSelf) {
   lazy_ptr<Widget> p([]() { return new Widget(3); });
 
   // The self-move is deliberate here; -Wself-move would otherwise flag it.
+  // GCC only knows -Wself-move from GCC 13; guard the version so older GCC does
+  // not emit a -Wpragmas "unknown option" warning (fatal under -Werror).
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wself-move"
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) && __GNUC__ >= 13
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wself-move"
 #endif
   lazy_ptr<Widget>& result = (p = std::move(p));
 #if defined(__clang__)
 #pragma clang diagnostic pop
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) && __GNUC__ >= 13
 #pragma GCC diagnostic pop
 #endif
 


### PR DESCRIPTION
## Motivation

`lazy_ptr::operator=(lazy_ptr&&)` was declared to return `lazy_ptr&` but had no `return` statement — undefined behavior (`-Wreturn-type`). It returns whatever garbage is in the return register.

## Technical Details

The move-assignment is exercised during `GpuAgent::InitDma()` when the `queues_`/`blits_` `lazy_ptr` elements are set up (`std::vector` relocation / `std::swap`). The garbage return corrupts the internal `std::function`'s `_M_manager` pointer. The subsequent `lazy_ptr::reset()` does `func = std::move(C)`, making `std::function::operator=` destroy the previous target via the (now garbage) `_M_manager` → jump to invalid address → SIGSEGV.

On gfx1151 (Strix Halo, Radeon 8060S) with HSA runtime 1.21.0 this made `rocminfo` (and any `hsa_init()` caller) crash immediately after 'ROCk module is loaded'. Backtrace: `RIP=0x100000001` in `GpuAgent::InitDma -> PostToolsInit -> Runtime::Load -> Runtime::Acquire -> hsa_init`.

Adding `return *this;` fixes it.

## Test Plan / Result

- Rebuilt `libhsa-runtime64.so.1.21.0` and re-ran `rocminfo`, which now exits 0 and enumerates the gfx1151 GPU agent.
- Added `lazy_ptr_test.cpp` pinning the move-assignment contract (returns `*this`, result is usable, `reset()`-after-move is safe, self-move-assign).

Fixes: ROCm/TheRock#5985

Supersedes #8201 (corrected branch name, Conventional Commits title, and added unit test).