### PR TITLE
clr: Defer HostQueue teardown off the async-events thread

### DIFF
--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -2409,6 +2409,18 @@ class Device : public RuntimeObject {
   static bool IsGPUInError() { return (gpu_error_.load(std::memory_order_relaxed) != CL_SUCCESS); }
   static cl_int GetGPUError() { return gpu_error_.load(std::memory_order_relaxed); }
 
+  //! True if the calling thread is inside a device async completion handler,
+  //! where blocking on GPU completion self-deadlocks. Base returns false.
+  virtual bool isInAsyncSignalHandler() const { return false; }
+
+  //! Release `obj`, deferring to an app thread if called from an async handler
+  //! (where blocking teardown self-deadlocks). Base releases inline.
+  virtual void deferReleaseObject(ReferenceCountedObject* obj) {
+    if (obj != nullptr) {
+      obj->release();
+    }
+  }
+
   bool GetHandleForAddressRange(void* dev_ptr, size_t size, void* handle);
 
   // Registers a memory object allocated via hostcall for later cleanup.

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -228,7 +228,10 @@ Device::~Device() {
   delete xferQueue_;
   xferQueue_ = nullptr;
 
-  // Final drain of deferred destroys on the main thread before hsa_shut_down.
+  // Final drain before hsa_shut_down. Objects first: a deferred HostQueue
+  // teardown re-runs terminate() and may release HW queues that the destroy
+  // drain below then frees.
+  DrainDeferredObjectReleases();
   DrainDeferredQueueDestroys();
 
   for (auto& it : queuePool_) {
@@ -3240,10 +3243,12 @@ hsa_queue_t* Device::acquireQueue(uint32_t queue_size_hint, bool coop_queue,
                                   bool dedicated_queue, hsa_queue_t* preferred,
                                   const std::unordered_set<uint64_t>* excluded_ids,
                                   void** metadata_ring_buffer) {
-  // App-thread context: flush queues deferred from the async thread once they
-  // reach the batch threshold, bounding live deferred queues.
+  // App thread: bound deferred queues/objects by draining past a threshold.
   if (DeferredQueueCount() >= kDeferredQueueDrainThreshold) {
     DrainDeferredQueueDestroys();
+  }
+  if (DeferredObjectReleaseCount() >= kDeferredQueueDrainThreshold) {
+    DrainDeferredObjectReleases();
   }
 
   hsa_amd_queue_priority_t queue_priority;
@@ -3568,6 +3573,42 @@ void Device::DrainDeferredQueueDestroys() {
   for (hsa_queue_t* queue : pending) {
     ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Deleting deferred hardware queue %p", queue->base_address);
     Hsa::queue_destroy(queue);
+  }
+}
+
+// ================================================================================================
+void Device::deferReleaseObject(amd::ReferenceCountedObject* obj) {
+  if (obj == nullptr) {
+    return;
+  }
+  // On the async-events thread the last-reference drop can run blocking teardown
+  // that self-deadlocks; hand it to an app thread instead.
+  if (InAsyncSignalHandler()) {
+    ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Deferring object %p release from async handler", obj);
+    std::scoped_lock<std::mutex> lock(deferredObjectReleaseLock_);
+    deferredObjectRelease_.push_back(obj);
+    return;
+  }
+  obj->release();
+}
+
+// ================================================================================================
+size_t Device::DeferredObjectReleaseCount() {
+  std::scoped_lock<std::mutex> lock(deferredObjectReleaseLock_);
+  return deferredObjectRelease_.size();
+}
+
+// ================================================================================================
+void Device::DrainDeferredObjectReleases() {
+  // Swap out the batch under lock, then release without holding it: release() may
+  // run object destructors that take other locks or block (e.g. queue teardown).
+  std::vector<amd::ReferenceCountedObject*> pending;
+  {
+    std::scoped_lock<std::mutex> lock(deferredObjectReleaseLock_);
+    pending.swap(deferredObjectRelease_);
+  }
+  for (amd::ReferenceCountedObject* obj : pending) {
+    obj->release();
   }
 }
 

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -228,11 +228,10 @@ Device::~Device() {
   delete xferQueue_;
   xferQueue_ = nullptr;
 
-  // Final drain before hsa_shut_down. Objects first: a deferred HostQueue
-  // teardown re-runs terminate() and may release HW queues that the destroy
-  // drain below then frees.
-  DrainDeferredObjectReleases();
-  DrainDeferredQueueDestroys();
+  // Final drain of deferred cleanup on the main thread before hsa_shut_down.
+  // A deferred HostQueue teardown re-runs terminate() here; running on an app
+  // thread its HW-queue release destroys inline, so a single pass suffices.
+  DrainDeferredCleanup();
 
   for (auto& it : queuePool_) {
     for (auto qIter = it.begin(); qIter != it.end();) {
@@ -3243,12 +3242,9 @@ hsa_queue_t* Device::acquireQueue(uint32_t queue_size_hint, bool coop_queue,
                                   bool dedicated_queue, hsa_queue_t* preferred,
                                   const std::unordered_set<uint64_t>* excluded_ids,
                                   void** metadata_ring_buffer) {
-  // App thread: bound deferred queues/objects by draining past a threshold.
-  if (DeferredQueueCount() >= kDeferredQueueDrainThreshold) {
-    DrainDeferredQueueDestroys();
-  }
-  if (DeferredObjectReleaseCount() >= kDeferredQueueDrainThreshold) {
-    DrainDeferredObjectReleases();
+  // App thread: bound the deferred cleanup backlog by draining past a threshold.
+  if (DeferredCleanupCount() >= kDeferredCleanupThreshold) {
+    DrainDeferredCleanup();
   }
 
   hsa_amd_queue_priority_t queue_priority;
@@ -3547,8 +3543,11 @@ void Device::releaseQueue(hsa_queue_t* queue, const std::vector<uint32_t>& cuMas
     if (InAsyncSignalHandler() && !coop_queue) {
       ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Deferring CG enabled hardware queue %p destroy",
               queue->base_address);
-      std::scoped_lock<std::mutex> lock(deferredQueueDestroyLock_);
-      deferredQueueDestroy_.push_back(queue);
+      DeferCleanup([this, queue] {
+        ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Deleting deferred hardware queue %p",
+                queue->base_address);
+        Hsa::queue_destroy(queue);
+      });
     } else {
       ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Deleting CG enabled hardware queue %p ",
               queue->base_address);
@@ -3557,22 +3556,27 @@ void Device::releaseQueue(hsa_queue_t* queue, const std::vector<uint32_t>& cuMas
   }
 }
 
-size_t Device::DeferredQueueCount() {
-  std::scoped_lock<std::mutex> lock(deferredQueueDestroyLock_);
-  return deferredQueueDestroy_.size();
+void Device::DeferCleanup(std::function<void()> action) {
+  std::scoped_lock<std::mutex> lock(deferredCleanupLock_);
+  deferredCleanup_.push_back(std::move(action));
 }
 
-void Device::DrainDeferredQueueDestroys() {
-  // Swap out the batch under lock, then destroy without holding it: queue_destroy
-  // is blocking and may run runtime callbacks.
-  std::vector<hsa_queue_t*> pending;
+size_t Device::DeferredCleanupCount() {
+  std::scoped_lock<std::mutex> lock(deferredCleanupLock_);
+  return deferredCleanup_.size();
+}
+
+void Device::DrainDeferredCleanup() {
+  // Swap out the batch under lock, then run without holding it: actions block
+  // (queue_destroy, HostQueue teardown) and may take other locks. Running on an
+  // app thread, any nested release/destroy runs inline rather than re-deferring.
+  std::vector<std::function<void()>> pending;
   {
-    std::scoped_lock<std::mutex> lock(deferredQueueDestroyLock_);
-    pending.swap(deferredQueueDestroy_);
+    std::scoped_lock<std::mutex> lock(deferredCleanupLock_);
+    pending.swap(deferredCleanup_);
   }
-  for (hsa_queue_t* queue : pending) {
-    ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Deleting deferred hardware queue %p", queue->base_address);
-    Hsa::queue_destroy(queue);
+  for (auto& action : pending) {
+    action();
   }
 }
 
@@ -3585,31 +3589,10 @@ void Device::deferReleaseObject(amd::ReferenceCountedObject* obj) {
   // that self-deadlocks; hand it to an app thread instead.
   if (InAsyncSignalHandler()) {
     ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Deferring object %p release from async handler", obj);
-    std::scoped_lock<std::mutex> lock(deferredObjectReleaseLock_);
-    deferredObjectRelease_.push_back(obj);
+    DeferCleanup([obj] { obj->release(); });
     return;
   }
   obj->release();
-}
-
-// ================================================================================================
-size_t Device::DeferredObjectReleaseCount() {
-  std::scoped_lock<std::mutex> lock(deferredObjectReleaseLock_);
-  return deferredObjectRelease_.size();
-}
-
-// ================================================================================================
-void Device::DrainDeferredObjectReleases() {
-  // Swap out the batch under lock, then release without holding it: release() may
-  // run object destructors that take other locks or block (e.g. queue teardown).
-  std::vector<amd::ReferenceCountedObject*> pending;
-  {
-    std::scoped_lock<std::mutex> lock(deferredObjectReleaseLock_);
-    pending.swap(deferredObjectRelease_);
-  }
-  for (amd::ReferenceCountedObject* obj : pending) {
-    obj->release();
-  }
 }
 
 bool Device::findLinkInfo(const amd::Device& other_device, std::vector<LinkAttrType>* link_attrs) {

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -668,6 +668,19 @@ class Device : public NullDevice {
   //! Current number of queues pending deferred destroy.
   size_t DeferredQueueCount();
 
+  //! True while on the ROCr async-events thread (HsaAmdSignalHandler).
+  bool isInAsyncSignalHandler() const override { return InAsyncSignalHandler(); }
+
+  //! Release obj, or defer to an app thread if called from the async-events thread.
+  void deferReleaseObject(amd::ReferenceCountedObject* obj) override;
+
+  //! Release all objects whose release was deferred from the async-events
+  //! thread. Must only be called on an app thread (e.g. acquireQueue, ~Device).
+  void DrainDeferredObjectReleases();
+
+  //! Current number of objects pending deferred release.
+  size_t DeferredObjectReleaseCount();
+
  private:
   bool create();
 
@@ -680,6 +693,10 @@ class Device : public NullDevice {
   static constexpr size_t kDeferredQueueDrainThreshold = 8;
   std::vector<hsa_queue_t*> deferredQueueDestroy_;
   std::mutex deferredQueueDestroyLock_;
+
+  //! Objects whose release was deferred from an async handler, drained on app threads.
+  std::vector<amd::ReferenceCountedObject*> deferredObjectRelease_;
+  std::mutex deferredObjectReleaseLock_;
 
   bool SetSvmAttributesInt(const void* dev_ptr, size_t count, amd::MemoryAdvice advice,
                            bool first_alloc = false, bool use_cpu = false,

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -27,6 +27,7 @@
 
 
 #include <atomic>
+#include <functional>
 #include <iostream>
 #include <memory>
 #include <mutex>
@@ -661,25 +662,22 @@ class Device : public NullDevice {
   //! Waits until all VirtualGPU QueuedAsyncHandlers are zero (30s timeout).
   void WaitForHsaAsyncHandlersIdle() override;
 
-  //! Destroy all queues whose destroy was deferred from the async-events thread.
-  //! Must only be called on an app thread (e.g. acquireQueue, ~Device).
-  void DrainDeferredQueueDestroys();
+  //! Enqueue a cleanup action to run later on an app thread. Used to move
+  //! blocking teardown (HW-queue destroy, HostQueue release) off the
+  //! async-events thread, where it would self-deadlock.
+  void DeferCleanup(std::function<void()> action);
 
-  //! Current number of queues pending deferred destroy.
-  size_t DeferredQueueCount();
+  //! Run all deferred cleanup actions. App threads only (e.g. acquireQueue, ~Device).
+  void DrainDeferredCleanup();
+
+  //! Current number of pending deferred cleanup actions.
+  size_t DeferredCleanupCount();
 
   //! True while on the ROCr async-events thread (HsaAmdSignalHandler).
   bool isInAsyncSignalHandler() const override { return InAsyncSignalHandler(); }
 
   //! Release obj, or defer to an app thread if called from the async-events thread.
   void deferReleaseObject(amd::ReferenceCountedObject* obj) override;
-
-  //! Release all objects whose release was deferred from the async-events
-  //! thread. Must only be called on an app thread (e.g. acquireQueue, ~Device).
-  void DrainDeferredObjectReleases();
-
-  //! Current number of objects pending deferred release.
-  size_t DeferredObjectReleaseCount();
 
  private:
   bool create();
@@ -689,14 +687,11 @@ class Device : public NullDevice {
 
   static constexpr int kDefaultNumaNode = -1;
 
-  //! Queues with destroy deferred from an async-handler-driven ~VirtualGPU, drained on app threads.
-  static constexpr size_t kDeferredQueueDrainThreshold = 8;
-  std::vector<hsa_queue_t*> deferredQueueDestroy_;
-  std::mutex deferredQueueDestroyLock_;
-
-  //! Objects whose release was deferred from an async handler, drained on app threads.
-  std::vector<amd::ReferenceCountedObject*> deferredObjectRelease_;
-  std::mutex deferredObjectReleaseLock_;
+  //! Cleanup actions deferred from the async-events thread (HW-queue destroy,
+  //! HostQueue release), drained on app threads and bounded by the threshold.
+  static constexpr size_t kDeferredCleanupThreshold = 8;
+  std::vector<std::function<void()>> deferredCleanup_;
+  std::mutex deferredCleanupLock_;
 
   bool SetSvmAttributesInt(const void* dev_ptr, size_t count, amd::MemoryAdvice advice,
                            bool first_alloc = false, bool use_cpu = false,

--- a/projects/clr/rocclr/include/top.hpp
+++ b/projects/clr/rocclr/include/top.hpp
@@ -41,6 +41,7 @@
 #endif /*ATI_ARCH_X86*/
 
 #include <atomic>
+#include <cassert>
 #include <cstdint>
 #include <cstddef>
 #include <new>
@@ -158,6 +159,17 @@ class ReferenceCountedObject {
  protected:
   virtual ~ReferenceCountedObject() {}
   virtual bool terminate() { return true; }
+
+  //! Re-arm an object from within terminate(), which runs when release() drove
+  //! the count to 0. Unlike retain() (which asserts count != 0), this is valid
+  //! only at 0. Use only to defer teardown -- e.g. off an async handler where the
+  //! blocking drain would deadlock: re-arm, return false, and release() again
+  //! from a safe thread later.
+  void reArmReference() {
+    assert(referenceCount_.load(std::memory_order_relaxed) == 0 &&
+           "reArmReference is only valid at count 0, from within terminate()");
+    referenceCount_.store(1, std::memory_order_relaxed);
+  }
 
  public:
   ReferenceCountedObject() : referenceCount_(1) {}

--- a/projects/clr/rocclr/platform/commandqueue.cpp
+++ b/projects/clr/rocclr/platform/commandqueue.cpp
@@ -53,10 +53,11 @@ bool HostQueue::terminate() {
   if (AMD_DIRECT_DISPATCH) {
     if (!forceDestroy_ && vdev() != nullptr) {
       // The blocking drain below self-deadlocks if run on the async-events
-      // thread. Re-arm and hand to an app thread; return false gates off delete
-      // so it re-runs terminate() off the async thread.
+      // thread. Re-arm (valid here at count 0, unlike retain()) and hand to an
+      // app thread; return false gates off delete so it re-runs terminate() off
+      // the async thread.
       if (device().isInAsyncSignalHandler()) {
-        retain();
+        reArmReference();
         device().deferReleaseObject(this);
         return false;
       }

--- a/projects/clr/rocclr/platform/commandqueue.cpp
+++ b/projects/clr/rocclr/platform/commandqueue.cpp
@@ -52,6 +52,14 @@ bool HostQueue::terminate() {
   // In case of force destroy skip checking on the last command
   if (AMD_DIRECT_DISPATCH) {
     if (!forceDestroy_ && vdev() != nullptr) {
+      // The blocking drain below self-deadlocks if run on the async-events
+      // thread. Re-arm and hand to an app thread; return false gates off delete
+      // so it re-runs terminate() off the async thread.
+      if (device().isInAsyncSignalHandler()) {
+        retain();
+        device().deferReleaseObject(this);
+        return false;
+      }
       // If the queue still has the last command, then wait and release it
       // We must be in protected way to get last command when calling
       // awaitCompletion() where lastCommand will be released and possibly


### PR DESCRIPTION
## Motivation
Running the HIP graph test Unit_hipGraphAddMemAllocNode_Negative_With_Cloneed_Graph (and, more generally, any workload that destroys a GraphExec whose launch completion is signaled by ROCr) intermittently hangs at process shutdown.

Root cause — self-deadlock on the async-events thread
A graph launch completes. ROCr delivers that completion on its async-events thread (HsaAmdSignalHandler).
The completion callback cascades into ~GraphExec, which drops the last reference to the graph's internal HostQueue (stream).
Dropping the last reference calls ReferenceCountedObject::release() → HostQueue::terminate().
terminate() flushes a marker and calls awaitCompletion(), i.e. it blocks waiting for a queue completion to be signaled — but the thread that signals completions is the very async-events thread we are currently running on.
The thread ends up waiting on itself → deadlock, and the process never exits.

This is a lifetime/threading issue: the blocking drain in terminate() is correct on an app thread, but must never run on the async handler thread.

## Technical Details

Regression from https://github.com/ROCm/rocm-systems/commit/5de80e1c1c611c0ec6c4c8c0e59cbea8e51f3d6e.

Keep terminate()'s existing blocking drain, but never execute it on the async-events thread. When terminate() is entered from the async handler, re-arm the object and hand it to an app thread, which re-invokes terminate() off the async thread and completes the normal drain.

## JIRA ID

[ROCM-27565](https://amd-hub.atlassian.net/browse/ROCM-27565)

## Test Plan

Run Unit_hipGraphAddMemAllocNode_Negative_With_Cloneed_Graph for multiple times.

## Test Result

ran Unit_hipGraphAddMemAllocNode_Negative_With_Cloneed_Graph 30 times and it passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.


[ROCM-27565]: https://amd-hub.atlassian.net/browse/ROCM-27565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ