### PR TITLE
[rocprofiler-sdk] Bypass idle inline queue interposition without active consumers (#8093)

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/context/context.cpp
@@ -28,6 +28,7 @@
 #include "lib/common/utility.hpp"
 #include "lib/rocprofiler-sdk/buffer.hpp"
 #include "lib/rocprofiler-sdk/counters/core.hpp"
+#include "lib/rocprofiler-sdk/hsa/queue_interposition.hpp"
 #include "lib/rocprofiler-sdk/pc_sampling/service.hpp"
 #include "lib/rocprofiler-sdk/thread_trace/core.hpp"
 
@@ -325,6 +326,8 @@ start_context(rocprofiler_context_id_t context_id)
         get_num_active_contexts().fetch_add(1, std::memory_order_release);
     }
 
+    rocprofiler::hsa::queue_interposition::notify_queue_interposition_consumer_context_started(cfg);
+
     // atomic swap the pointer into the "active" array used internally
     const context* _expected = nullptr;
     bool           success   = active_contexts.at(idx).compare_exchange_strong(
@@ -332,6 +335,8 @@ start_context(rocprofiler_context_id_t context_id)
 
     if(!success)
     {
+        rocprofiler::hsa::queue_interposition::notify_queue_interposition_consumer_context_stopped(
+            cfg);
         get_num_active_contexts().fetch_sub(1, std::memory_order_release);
         return ROCPROFILER_STATUS_ERROR_CONTEXT_NOT_STARTED;
     }
@@ -381,6 +386,9 @@ stop_context(rocprofiler_context_id_t idx)
                 if(_expected->device_thread_trace) _expected->device_thread_trace->stop_context();
                 if(_expected->dispatch_thread_trace)
                     _expected->dispatch_thread_trace->stop_context();
+
+                rocprofiler::hsa::queue_interposition::
+                    notify_queue_interposition_consumer_context_stopped(_expected);
 
                 if(_expected->device_counter_collection)
                 {
@@ -440,12 +448,17 @@ stop_client_contexts(rocprofiler_client_id_t client_id)
 void
 deactivate_client_contexts(rocprofiler_client_id_t client_id)
 {
+    auto _lk = std::unique_lock<std::mutex>{get_contexts_mutex()};
     for(auto& itr : get_active_contexts_impl())
     {
-        const auto* itr_v = itr.load();
+        const context* itr_v = itr.load(std::memory_order_acquire);
         if(itr_v && itr_v->client_idx == client_id.handle)
         {
-            itr.store(nullptr);
+            if(itr.compare_exchange_strong(itr_v, nullptr))
+            {
+                rocprofiler::hsa::queue_interposition::
+                    notify_queue_interposition_consumer_context_stopped(itr_v);
+            }
         }
     }
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
@@ -568,6 +568,15 @@ enable_queue_intercept()
     return false;
 }
 
+bool
+context_needs_queue_interposition_tracing(const context::context* ctx)
+{
+    return ctx != nullptr && ctx->is_tracing_one_of(ROCPROFILER_CALLBACK_TRACING_KERNEL_DISPATCH,
+                                                    ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH,
+                                                    ROCPROFILER_CALLBACK_TRACING_SCRATCH_MEMORY,
+                                                    ROCPROFILER_BUFFER_TRACING_SCRATCH_MEMORY);
+}
+
 void
 queue_controller_init(HsaApiTable* table)
 {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.hpp
@@ -38,6 +38,10 @@
 
 namespace rocprofiler
 {
+namespace context
+{
+struct context;
+}
 namespace hsa
 {
 // Tracks and manages HSA queues
@@ -124,6 +128,9 @@ get_queue_controller();
 
 bool
 enable_queue_intercept();
+
+bool
+context_needs_queue_interposition_tracing(const context::context* ctx);
 
 void
 queue_controller_init(HsaApiTable* table);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.cpp
@@ -32,6 +32,7 @@
 #include "lib/rocprofiler-sdk/hsa/queue_interposition.hpp"
 #include "lib/common/container/pool.hpp"
 #include "lib/common/container/pool_object.hpp"
+#include "lib/common/container/static_vector.hpp"
 #include "lib/common/environment.hpp"
 #include "lib/common/logging.hpp"
 #include "lib/common/static_object.hpp"
@@ -55,6 +56,7 @@
 #include <hsa/hsa_api_trace.h>
 #include <pthread.h>
 
+#include <array>
 #include <atomic>
 #include <cstring>
 #include <thread>
@@ -68,6 +70,8 @@ namespace queue_interposition
 {
 namespace
 {
+auto s_active_queue_interposition_consumers = std::atomic<uint32_t>{0};
+
 // NOTE:
 //  - "installed" is for checking whether HSA functions have been passed
 //  - "active" is for controlling whether wrappers are intercepting or passing through
@@ -78,13 +82,19 @@ auto s_intercept_active    = std::atomic<bool>{false};  // actively intercepting
 auto s_intercept_dynamic   = std::atomic<bool>{false};  // dynamically add queue states
 
 bool
+has_active_queue_interposition_consumers()
+{
+    return s_active_queue_interposition_consumers.load(std::memory_order_relaxed) > 0;
+}
+
+bool
 should_bypass_inline_intercept()
 {
     return (!s_intercept_installed.load(std::memory_order_acquire) ||
             !s_intercept_active.load(std::memory_order_acquire) ||
             registration::get_fini_status() != 0 ||
             // TODO: debug and enable queue interposition for attachment
-            registration::supports_attachment());
+            registration::supports_attachment() || !has_active_queue_interposition_consumers());
 }
 
 auto*&
@@ -219,7 +229,8 @@ publish_submitted_packets(QueueState* state, uint64_t submit_pos)
         << ") regressed below last_published_submit_pos (" << tls.last_published_submit_pos << ")";
 
     __atomic_store_n(state->real_wdid, submit_pos, __ATOMIC_RELEASE);
-    (*tls.ring_doorbell)(state->doorbell_signal, static_cast<hsa_signal_value_t>(submit_pos - 1));
+    const auto doorbell_idx = static_cast<hsa_signal_value_t>(submit_pos - 1);
+    (*tls.ring_doorbell)(state->doorbell_signal, doorbell_idx);
     tls.last_published_submit_pos = submit_pos;
 }
 
@@ -720,27 +731,47 @@ process_doorbell_impl(const queue_state_ptr_t& state,
         return;
     }
 
-    static thread_local auto snapshot_storage = std::vector<char>{};
-    const uint64_t           max_bytes        = (wptr_end - scan_pos) * state_ptr->pkt_size;
-    if(snapshot_storage.size() < max_bytes) snapshot_storage.resize(max_bytes);
-    char* const source_snapshot = snapshot_storage.data();
+    constexpr size_t kSnapshotMaxPkts = 16;
+    const uint64_t   max_pkts         = wptr_end - scan_pos;
+    const auto       pkt_size         = state_ptr->pkt_size;
+
+    using snapshot_pkt_t = std::array<char, 64>;
+    common::container::static_vector<snapshot_pkt_t, kSnapshotMaxPkts> snapshot;
+    std::vector<char>                                                  overflow_snapshot;
+    char*                                                              source_snapshot = nullptr;
+
+    if(max_pkts > kSnapshotMaxPkts)
+    {
+        overflow_snapshot.resize(max_pkts * pkt_size);
+        source_snapshot = overflow_snapshot.data();
+    }
 
     uint64_t drained = 0;
     for(uint64_t pos = scan_pos; pos < wptr_end; ++pos)
     {
         const auto  ring_slot = pos & state_ptr->ring_mask;
-        char* const slot_base =
-            static_cast<char*>(state_ptr->ring_buf) + (ring_slot * state_ptr->pkt_size);
-        auto* const hdr_ptr = reinterpret_cast<volatile uint16_t*>(slot_base);
+        char* const slot_base = static_cast<char*>(state_ptr->ring_buf) + (ring_slot * pkt_size);
+        auto* const hdr_ptr   = reinterpret_cast<volatile uint16_t*>(slot_base);
 
         if((__atomic_load_n(hdr_ptr, __ATOMIC_ACQUIRE) & 0xFFu) ==
            static_cast<unsigned>(HSA_PACKET_TYPE_INVALID))
             break;
 
-        ::memcpy(source_snapshot + (drained * state_ptr->pkt_size), slot_base, state_ptr->pkt_size);
+        char* dst = nullptr;
+        if(source_snapshot)
+        {
+            dst = source_snapshot + (drained * pkt_size);
+        }
+        else
+        {
+            dst = snapshot.emplace_back().data();
+        }
+        ::memcpy(dst, slot_base, pkt_size);
         __atomic_store_n(hdr_ptr, static_cast<uint16_t>(HSA_PACKET_TYPE_INVALID), __ATOMIC_RELEASE);
         ++drained;
     }
+
+    if(!source_snapshot) source_snapshot = reinterpret_cast<char*>(snapshot.data());
 
     if(drained == 0)
     {
@@ -978,6 +1009,56 @@ bool
 supports_queue_interposition()
 {
     return s_intercept_installed.load(std::memory_order_acquire);
+}
+
+namespace
+{
+void
+resync_queue_shadow_state(QueueState* state)
+{
+    if(!state || !state->real_wdid) return;
+
+    const uint64_t wdid = __atomic_load_n(state->real_wdid, __ATOMIC_ACQUIRE);
+    state->virtual_wptr.store(wdid, std::memory_order_release);
+    state->next_scan_pos   = wdid;
+    state->next_submit_pos = wdid;
+}
+
+void
+resync_all_queue_shadow_states()
+{
+    get_queue_registry().rlock([](const auto& registry) {
+        for(const auto& entry : registry)
+            resync_queue_shadow_state(entry.second.get());
+    });
+}
+}  // namespace
+
+void
+notify_queue_interposition_consumer_context_started(const context::context* ctx)
+{
+    if(!context_needs_queue_interposition_tracing(ctx)) return;
+
+    const auto prev = s_active_queue_interposition_consumers.load(std::memory_order_acquire);
+    if(prev == 0 && s_intercept_installed.load(std::memory_order_acquire))
+        resync_all_queue_shadow_states();
+
+    s_active_queue_interposition_consumers.fetch_add(1, std::memory_order_release);
+}
+
+void
+notify_queue_interposition_consumer_context_stopped(const context::context* ctx)
+{
+    if(!context_needs_queue_interposition_tracing(ctx)) return;
+    auto cur = s_active_queue_interposition_consumers.load(std::memory_order_relaxed);
+    while(cur > 0)
+    {
+        if(s_active_queue_interposition_consumers.compare_exchange_weak(
+               cur, cur - 1, std::memory_order_release, std::memory_order_relaxed))
+        {
+            return;
+        }
+    }
 }
 
 void

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_interposition.hpp
@@ -36,6 +36,10 @@
 
 namespace rocprofiler
 {
+namespace context
+{
+struct context;
+}
 namespace hsa
 {
 namespace queue_interposition
@@ -215,6 +219,12 @@ destroy_queue_state(const hsa_queue_t* queue);
  */
 bool
 supports_queue_interposition();
+
+void
+notify_queue_interposition_consumer_context_started(const context::context* ctx);
+
+void
+notify_queue_interposition_consumer_context_stopped(const context::context* ctx);
 
 /**
  * @brief Install interposition wrappers into the HSA core API table


### PR DESCRIPTION
## Summary

Cherry-pick of 6168477 (#8093) from `develop` onto `release/therock-7.14`.

Fixes ROCM-27116 by bypassing queue interposition (QI) on the hot path when no active profiling context needs kernel-dispatch or scratch-memory tracing. This prevents idle QI from virtualizing write indices and processing doorbells when auto-registered clients only use code-object callbacks.

## Changes

- `queue_interposition.cpp` / `queue_interposition.hpp` — track active queue-interposition consumers with an atomic counter; extend `should_bypass_inline_intercept()` to passthrough when the count is zero
- `queue_controller.cpp` / `queue_controller.hpp` — add `context_needs_queue_interposition_tracing()` helper
- `context.cpp` — increment/decrement the counter on context start/stop and on `deactivate_client_contexts()`

Also bundled in this change (surfaced during review/testing of the above):
- Saturating CAS-loop decrement for the consumer counter (avoids underflow on unbalanced stop notifications)
- Resync of `virtual_wptr`/`next_scan_pos`/`next_submit_pos` to the real write-dispatch-id when the consumer count transitions 0→1, so QI doesn't publish against stale bookkeeping after bypass doorbells advanced the real queue
- Ordering fix for context start/stop notifications relative to active-context publish, and CAS-based slot claiming in `deactivate_client_contexts()`, to close a consumer-count race
- Replace the persistent `thread_local` doorbell snapshot buffer with a fixed-capacity inline snapshot (falling back to a local vector for rare large batches), removing a heap buffer implicated in the ROCM-27116 crash

## Motivation

PyTorch auto-registration installs QI by default even when only code-object tracing is registered. In a fork+exec child that inherits `ROCPROFILER_REGISTER_LIBRARY`, idle QI still intercepts HSA queue write-index and doorbell operations during minimal GPU work, corrupting the heap before exit (`corrupted double-linked list` / SIGABRT). Setting `ROCPROFILER_QUEUE_INTERPOSITION=0` avoids the crash; this change makes that behavior automatic when no QI consumer is active.

## Testing

Cherry-picked cleanly from `develop` (auto-merged, no conflicts). Original testing (from #8093):
- Built `librocprofiler-sdk.so` on banff (MI325X) and deployed into `rocm27116-parallel` PyTorch container
- PyTorch fork+exec repro (`torch.cuda.synchronize()` → `subprocess` child with `env=None` → `torch.rand`) 15/15 pass
- Stock image reproduces ~90%+ crash rate without the fix
- Full local build + `ctest` (gfx1200): 378/379 unit tests pass (1 pre-existing, unrelated failure: `unit.rocprofiler_lib.agent`); all queue-interposition/queue-controller/context/intercept-table tests and HSA multiqueue integration tests pass

## Related Issues

JIRA ID : ROCM-27116

Original PR: #8093
Original commit: 6168477bc5d2f5f1a0ca533f6deef136c44327d1