### PR TITLE
feat(ci): Enable THEROCK_ENABLE_ALL for gfx125X (MI455) builds

### DIFF
--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -151,7 +151,8 @@ jobs:
     uses: ./.github/workflows/therock-ci-linux.yml
     secrets: inherit
     with:
-      cmake_options: ${{ matrix.projects.cmake_options }}
+      # For gfx125X (MI455), always build ALL projects instead of just core
+      cmake_options: ${{ contains(matrix.target_bundle.amdgpu_family, 'gfx125X') && '-DTHEROCK_ENABLE_ALL=ON' || matrix.projects.cmake_options }}
       projects_to_test: ${{ matrix.projects.projects_to_test }}
       package_version: ${{ needs.setup.outputs.package_version }}
       amdgpu_families: ${{ matrix.target_bundle.amdgpu_family }}


### PR DESCRIPTION
For MI455/gfx125X builds, always use -DTHEROCK_ENABLE_ALL=ON instead of the normal cmake_options. This ensures we build all projects for MI455 bringup rather than just core components.

Other architectures (gfx94X, gfx950, etc.) continue to use the cmake_options determined by therock_configure_ci.py based on which subtrees changed.
