### PR TITLE
feat(ci): using `ci-env` for TheRock hash updating

### DIFF
--- a/.github/actions/ci-env/action.yml
+++ b/.github/actions/ci-env/action.yml
@@ -1,0 +1,14 @@
+name: "CI Environment"
+description: "Single source of truth for shared CI constants (TheRock ref)"
+
+outputs:
+  therock-ref:
+    description: "TheRock commit hash to use"
+    value: "02b806948e0e1e5a1a2bf28dd3940a13c8939ccb" # 2026-07-01
+
+runs:
+  using: "composite"
+  steps:
+    - name: Export CI environment
+      shell: bash
+      run: echo "CI environment loaded"

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -3,6 +3,10 @@ name: TheRock CI Linux
 on:
   workflow_call:
     inputs:
+      therock_ref:
+        type: string
+        required: true
+        description: "TheRock commit hash to use"
       cmake_options:
         type: string
       projects_to_test:
@@ -54,7 +58,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 02b806948e0e1e5a1a2bf28dd3940a13c8939ccb # 2026-07-01
+          ref: ${{ inputs.therock_ref }}
 
       - name: Install python deps
         run: |
@@ -143,6 +147,7 @@ jobs:
     if: ${{ inputs.test_runs_on != '' && inputs.amdgpu_families != 'gfx950-dcgpu' }}
     uses: ./.github/workflows/therock-test-packages.yml
     with:
+      therock_ref: ${{ inputs.therock_ref }}
       projects_to_test: ${{ inputs.projects_to_test }}
       amdgpu_families: ${{ inputs.amdgpu_families }}
       test_runs_on: ${{ inputs.test_runs_on }}
@@ -157,6 +162,7 @@ jobs:
     if: ${{ inputs.amdgpu_families == 'gfx125X-dcgpu' && inputs.run_mi455_test == 'true' }}
     uses: ./.github/workflows/therock-test-packages.yml
     with:
+      therock_ref: ${{ inputs.therock_ref }}
       projects_to_test: "hip-tests, rocrtst"
       amdgpu_families: "gfx125X-dcgpu"
       test_runs_on: "linux-mi455-gpu-rocm"

--- a/.github/workflows/therock-ci-nightly.yml
+++ b/.github/workflows/therock-ci-nightly.yml
@@ -38,6 +38,7 @@ jobs:
       # parent will be the tip of the base branch.
       BASE_REF: HEAD^
     outputs:
+      therock_ref: ${{ steps.ci-env.outputs.therock-ref }}
       linux_projects: ${{ steps.linux_projects.outputs.projects }}
       windows_projects: ${{ steps.windows_projects.outputs.projects }}
       run_linux_rccl_ci: ${{ steps.linux_projects.outputs.run_linux_rccl_ci }}
@@ -54,12 +55,18 @@ jobs:
           sparse-checkout-cone-mode: true
           fetch-depth: 2
 
+      # Loads shared CI constants (TheRock ref) from the ci-env composite action
+      # so they are defined in one place.
+      - name: Load CI environment
+        id: ci-env
+        uses: ./.github/actions/ci-env
+
       - name: Checkout TheRock repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 02b806948e0e1e5a1a2bf28dd3940a13c8939ccb # 2026-07-01
+          ref: ${{ steps.ci-env.outputs.therock-ref }}
 
       - name: Checkout CI config
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -131,6 +138,7 @@ jobs:
     uses: ./.github/workflows/therock-ci-linux.yml
     secrets: inherit
     with:
+      therock_ref: ${{ needs.setup.outputs.therock_ref }}
       cmake_options: ${{ matrix.projects.cmake_options }}
       projects_to_test: ${{ matrix.projects.projects_to_test }}
       package_version: ${{ needs.setup.outputs.package_version }}
@@ -152,6 +160,7 @@ jobs:
     uses: ./.github/workflows/therock-rccl-ci-linux.yml
     secrets: inherit
     with:
+      therock_ref: ${{ needs.setup.outputs.therock_ref }}
       amdgpu_families: ${{ matrix.amdgpu_family }}
       artifact_group: ${{ matrix.amdgpu_family }}
       package_version: ${{ needs.setup.outputs.package_version }}
@@ -178,6 +187,7 @@ jobs:
     uses: ./.github/workflows/therock-ci-windows.yml
     secrets: inherit
     with:
+      therock_ref: ${{ needs.setup.outputs.therock_ref }}
       cmake_options: ${{ matrix.projects.cmake_options }}
       projects_to_test: ${{ matrix.projects.projects_to_test }}
       package_version: ${{ needs.setup.outputs.package_version }}

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -3,6 +3,10 @@ name: TheRock CI Windows
 on:
   workflow_call:
     inputs:
+      therock_ref:
+        type: string
+        required: true
+        description: "TheRock commit hash to use"
       cmake_options:
         type: string
       projects_to_test:
@@ -49,7 +53,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 02b806948e0e1e5a1a2bf28dd3940a13c8939ccb # 2026-07-01
+          ref: ${{ inputs.therock_ref }}
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -44,6 +44,7 @@ jobs:
       # parent will be the tip of the base branch.
       BASE_REF: HEAD^
     outputs:
+      therock_ref: ${{ steps.ci-env.outputs.therock-ref }}
       linux_projects: ${{ steps.linux_projects.outputs.projects }}
       windows_projects: ${{ steps.windows_projects.outputs.projects }}
       run_linux_rccl_ci: ${{ steps.linux_projects.outputs.run_linux_rccl_ci }}
@@ -61,12 +62,18 @@ jobs:
           sparse-checkout-cone-mode: true
           fetch-depth: 2
 
+      # Loads shared CI constants (TheRock ref) from the ci-env composite action
+      # so they are defined in one place.
+      - name: Load CI environment
+        id: ci-env
+        uses: ./.github/actions/ci-env
+
       - name: Checkout TheRock repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 02b806948e0e1e5a1a2bf28dd3940a13c8939ccb # 2026-07-01
+          ref: ${{ steps.ci-env.outputs.therock-ref }}
 
       - name: Checkout CI config
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -151,6 +158,7 @@ jobs:
     uses: ./.github/workflows/therock-ci-linux.yml
     secrets: inherit
     with:
+      therock_ref: ${{ needs.setup.outputs.therock_ref }}
       cmake_options: ${{ matrix.projects.cmake_options }}
       projects_to_test: ${{ matrix.projects.projects_to_test }}
       package_version: ${{ needs.setup.outputs.package_version }}
@@ -175,6 +183,7 @@ jobs:
     uses: ./.github/workflows/therock-rccl-ci-linux.yml
     secrets: inherit
     with:
+      therock_ref: ${{ needs.setup.outputs.therock_ref }}
       amdgpu_families: ${{ matrix.amdgpu_family }}
       artifact_group: ${{ matrix.amdgpu_family }}
       package_version: ${{ needs.setup.outputs.package_version }}
@@ -201,6 +210,7 @@ jobs:
     uses: ./.github/workflows/therock-ci-windows.yml
     secrets: inherit
     with:
+      therock_ref: ${{ needs.setup.outputs.therock_ref }}
       cmake_options: ${{ matrix.projects.cmake_options }}
       projects_to_test: ${{ matrix.projects.projects_to_test }}
       package_version: ${{ needs.setup.outputs.package_version }}

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -3,6 +3,10 @@ name: TheRock CI Linux for rccl
 on:
   workflow_call:
     inputs:
+      therock_ref:
+        type: string
+        required: true
+        description: "TheRock commit hash to use"
       amdgpu_families:
         type: string
       artifact_group:
@@ -41,7 +45,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 02b806948e0e1e5a1a2bf28dd3940a13c8939ccb # 2026-07-01
+          ref: ${{ inputs.therock_ref }}
 
       - name: Install python deps
         run: |
@@ -135,6 +139,7 @@ jobs:
     needs: [therock-build-linux]
     uses: ./.github/workflows/therock-rccl-test-packages-multi-node.yml
     with:
+      therock_ref: ${{ inputs.therock_ref }}
       amdgpu_families: ${{ inputs.amdgpu_families }}
       artifact_group: ${{ inputs.artifact_group }}
       test_runs_on: ruby-linux-slurm-scale-runner
@@ -147,6 +152,7 @@ jobs:
     needs: [therock-build-linux]
     uses: ./.github/workflows/therock-rccl-test-packages-single-node.yml
     with:
+      therock_ref: ${{ inputs.therock_ref }}
       amdgpu_families: ${{ inputs.amdgpu_families }}
       artifact_group: ${{ inputs.artifact_group }}
       test_runs_on: linux-gfx942-8gpu-ossci-rocm

--- a/.github/workflows/therock-rccl-ci.yml
+++ b/.github/workflows/therock-rccl-ci.yml
@@ -22,6 +22,8 @@ jobs:
       # parent will be the tip of the base branch.
       BASE_REF: HEAD^
     outputs:
+      therock_ref: ${{ steps.ci-env.outputs.therock-ref }}
+      package_version: ${{ steps.rocm_package_version.outputs.rocm_package_version }}
       enable_therock_ci: ${{ steps.configure.outputs.enable_therock_ci }}
       run_linux_ci: ${{ steps.rccl_check.outputs.run_linux_ci }}
 
@@ -31,6 +33,29 @@ jobs:
         with:
           # We need the parent commit to do a diff
           fetch-depth: 2
+
+      # Loads shared CI constants (TheRock ref) from the ci-env composite action
+      # so they are defined in one place.
+      - name: Load CI environment
+        id: ci-env
+        uses: ./.github/actions/ci-env
+
+      - name: Checkout TheRock repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: "ROCm/TheRock"
+          path: TheRock
+          ref: ${{ steps.ci-env.outputs.therock-ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Compute package version
+        id: rocm_package_version
+        run: |
+          python TheRock/build_tools/compute_rocm_package_version.py --release-type=dev
 
       - name: "Configuring CI options"
         id: configure
@@ -65,8 +90,10 @@ jobs:
     uses: ./.github/workflows/therock-rccl-ci-linux.yml
     secrets: inherit
     with:
+      therock_ref: ${{ needs.setup.outputs.therock_ref }}
       amdgpu_families: ${{ matrix.amdgpu_family }}
       artifact_group: ${{ matrix.amdgpu_family }}
+      package_version: ${{ needs.setup.outputs.package_version }}
       cmake_options: >
         -DTHEROCK_ENABLE_ALL=OFF
         -DTHEROCK_BUILD_TESTING=ON

--- a/.github/workflows/therock-rccl-test-packages-multi-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-multi-node.yml
@@ -3,6 +3,9 @@ name: TheRock Test Packages multi-node for rccl
 on:
   workflow_call:
     inputs:
+      therock_ref:
+        type: string
+        description: "TheRock commit hash to use"
       amdgpu_families:
         type: string
       artifact_group:
@@ -49,7 +52,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 02b806948e0e1e5a1a2bf28dd3940a13c8939ccb # 2026-07-01
+          ref: ${{ inputs.therock_ref }}
 
       # Centralized arch-specific configuration
       - name: Set arch-specific paths

--- a/.github/workflows/therock-rccl-test-packages-single-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-single-node.yml
@@ -3,6 +3,9 @@ name: TheRock Test Packages single-node for rccl
 on:
   workflow_call:
     inputs:
+      therock_ref:
+        type: string
+        description: "TheRock commit hash to use"
       amdgpu_families:
         type: string
       artifact_group:
@@ -55,7 +58,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 02b806948e0e1e5a1a2bf28dd3940a13c8939ccb # 2026-07-01
+          ref: ${{ inputs.therock_ref }}
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -3,6 +3,9 @@ name: Test component
 on:
   workflow_call:
     inputs:
+      therock_ref:
+        type: string
+        description: "TheRock commit hash to use"
       artifact_run_id:
         type: string
         default: ""
@@ -78,7 +81,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 02b806948e0e1e5a1a2bf28dd3940a13c8939ccb # 2026-07-01
+          ref: ${{ inputs.therock_ref }}
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -3,6 +3,9 @@ name: TheRock Test Packages
 on:
   workflow_call:
     inputs:
+      therock_ref:
+        type: string
+        description: "TheRock commit hash to use"
       projects_to_test:
         type: string
       amdgpu_families:
@@ -49,7 +52,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 02b806948e0e1e5a1a2bf28dd3940a13c8939ccb # 2026-07-01
+          ref: ${{ inputs.therock_ref }}
 
       - name: Checkout CI config
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -92,6 +95,7 @@ jobs:
     needs: configure_test_matrix
     uses: './.github/workflows/therock-test-component.yml'
     with:
+      therock_ref: ${{ inputs.therock_ref }}
       artifact_run_id: ${{ inputs.artifact_run_id }}
       amdgpu_families: ${{ inputs.amdgpu_families }}
       # Use the runner selected by fetch_test_configurations.py
@@ -110,6 +114,7 @@ jobs:
         components: ${{ fromJSON(needs.configure_test_matrix.outputs.components) }}
     uses: './.github/workflows/therock-test-component.yml'
     with:
+      therock_ref: ${{ inputs.therock_ref }}
       artifact_run_id: ${{ inputs.artifact_run_id }}
       amdgpu_families: ${{ inputs.amdgpu_families }}
       # Route to the appropriate runner:


### PR DESCRIPTION
Similar to rocm-libraries, we are now going to use ci-env action to obtain TheRock hash. 

this makes it easier to update and test hashes and don't need to update ~ 10 separate files