### PR TITLE
fix(rocprofiler-sdk): pc sampling service check

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/service.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/service.cpp
@@ -234,8 +234,11 @@ is_pc_sample_service_configured(rocprofiler_agent_id_t agent_id)
     // Require HSA-level init to be complete so that get_pcs_session_of() will succeed
     // and the ROCr session exists for every agent this function returns true for.
     if(!is_hsa_initialized().load()) return false;
-    return get_global_pc_sampling_sessions().rlock(
-        [agent_id](const auto& sessions) { return sessions.find(agent_id) != sessions.end(); });
+    return get_global_pc_sampling_sessions().rlock([agent_id](const auto& sessions) {
+        // If the agent_id is in the global sessions map,
+        // then the PC sampling service is configured on this agent.
+        return sessions.find(agent_id) != sessions.end();
+    });
 }
 
 PCSAgentSession*

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/service.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/service.cpp
@@ -231,12 +231,11 @@ configure_pc_sampling_service(context::context*                ctx,
 bool
 is_pc_sample_service_configured(rocprofiler_agent_id_t agent_id)
 {
-    return get_global_pc_sampling_sessions().rlock([agent_id](const auto& sessions) {
-        // Require hsa_agent to be set so that get_pcs_session_of() (which matches by
-        // hsa_agent handle) will succeed whenever this function returns true.
-        auto it = sessions.find(agent_id);
-        return it != sessions.end() && it->second->hsa_agent.has_value();
-    });
+    // Require HSA-level init to be complete so that get_pcs_session_of() will succeed
+    // and the ROCr session exists for every agent this function returns true for.
+    if(!is_hsa_initialized().load()) return false;
+    return get_global_pc_sampling_sessions().rlock(
+        [agent_id](const auto& sessions) { return sessions.find(agent_id) != sessions.end(); });
 }
 
 PCSAgentSession*

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/service.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/service.cpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023-2025 ROCm Developer Tools
+// Copyright (c) 2023-2026 ROCm Developer Tools
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -232,9 +232,10 @@ bool
 is_pc_sample_service_configured(rocprofiler_agent_id_t agent_id)
 {
     return get_global_pc_sampling_sessions().rlock([agent_id](const auto& sessions) {
-        // If the agent_id is in the global sessions map,
-        // then the PC sampling service is configured on this agent.
-        return sessions.find(agent_id) != sessions.end();
+        // Require hsa_agent to be set so that get_pcs_session_of() (which matches by
+        // hsa_agent handle) will succeed whenever this function returns true.
+        auto it = sessions.find(agent_id);
+        return it != sessions.end() && it->second->hsa_agent.has_value();
     });
 }
 


### PR DESCRIPTION
- Fixes implementation of is_pc_sample_service_configured
  - Now matches what is required for get_pcs_session_of()
- Fixes an issue in attach where combining kernel trace and pc sampling crashed
- WriteInterceptor now only adds the pc_sampling marker packet if its callback would succeed

## Motivation

Fixes a bug where combining pc sampling and kernel trace options in attach would crash.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

The bug is ultimately in WriteInterceptor in queue.cpp.

Without --kernel-trace, get_active_contexts (line 307) returns false and the write interceptor returns early, so the bug is never reached.

With --kernel-trace, the tool registers a kernel dispatch buffer/callback tracer, so get_active_contexts returns true, and the write interceptor proceeds into the packet transformation loop. Line 629 is reached where is_pc_sample_service_configured() returns true causing a marker callback to be registered. However, if pc_sampling_service_finish_configuration has not run yet, get_pcs_session_of() will return nullptr and the registered callback will ultimately assert (hsa_adapter.cpp:101).

This change blocks this by simply checking if get_pcs_session_of() will succeed as part of is_pc_sample_service_configured()

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

JIRA ID: ROCM-26595

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Existing CI

Will use reproducer from JIRA issue to verify

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Pending CI

Pending running reproducer

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
