### PR TITLE
Lazily parse dwarf information

### DIFF
--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/cxx/codeobj/code_printing.hpp
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/cxx/codeobj/code_printing.hpp
@@ -158,7 +158,7 @@ class CodeobjDecoderComponent
 
     void loadDebugLineInfo()
     {
-        if(!disassembly) throw std::exception();
+        if(!disassembly) throw std::runtime_error("No disassembly available!");
 
         ProtectedFd prot("");
         auto&       codeobj_data = disassembly->buffer;
@@ -382,7 +382,19 @@ public:
         inst->faddr = faddr;
         inst->vaddr = vaddr;
 
-        std::call_once(m_debug_line_info_once, [this]() { loadDebugLineInfo(); });
+        std::call_once(m_debug_line_info_once, [this]() {
+            try
+            {
+                loadDebugLineInfo();
+            } catch(std::exception& e)
+            {
+                std::cerr << "rocprofiler-sdk: failed to parse DWARF line info: " << e.what()
+                          << '\n';
+            } catch(...)
+            {
+                std::cerr << "rocprofiler-sdk: failed to parse DWARF line info\n";
+            }
+        });
 
         auto it = m_line_number_map.find({vaddr, 0, 0});
         if(it != m_line_number_map.end()) inst->comment = it->second;

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/cxx/codeobj/code_printing.hpp
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/cxx/codeobj/code_printing.hpp
@@ -37,6 +37,7 @@
 #include <limits>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -155,11 +156,14 @@ class CodeobjDecoderComponent
         int m_fd{-1};
     };
 
-public:
-    CodeobjDecoderComponent(const char* codeobj_data, uint64_t codeobj_size)
+    void loadDebugLineInfo()
     {
+        if(!disassembly) throw std::exception();
+
         ProtectedFd prot("");
-        if(::write(prot.m_fd, codeobj_data, codeobj_size) != static_cast<int64_t>(codeobj_size))
+        auto&       codeobj_data = disassembly->buffer;
+        if(::write(prot.m_fd, codeobj_data.data(), codeobj_data.size()) !=
+           static_cast<int64_t>(codeobj_data.size()))
             throw std::runtime_error("Could not write to temporary file!");
 
         ::lseek(prot.m_fd, 0, SEEK_SET);
@@ -276,7 +280,11 @@ public:
                 m_line_number_map.emplace(segment, std::move(entry.text));
             }
         }
+    }
 
+public:
+    CodeobjDecoderComponent(const char* codeobj_data, uint64_t codeobj_size)
+    {
         // Can throw
         disassembly = std::make_unique<DisassemblyInstance>(codeobj_data, codeobj_size);
         try
@@ -374,6 +382,8 @@ public:
         inst->faddr = faddr;
         inst->vaddr = vaddr;
 
+        std::call_once(m_debug_line_info_once, [this]() { loadDebugLineInfo(); });
+
         auto it = m_line_number_map.find({vaddr, 0, 0});
         if(it != m_line_number_map.end()) inst->comment = it->second;
 
@@ -390,6 +400,7 @@ public:
     std::unique_ptr<DisassemblyInstance>      disassembly{};
 
     std::map<segment::address_range_t, std::string> m_line_number_map{};
+    std::once_flag                                  m_debug_line_info_once{};
 };
 
 class LoadedCodeobjDecoder

--- a/projects/rocprofiler-sdk/source/lib/tests/codeobj/codeobj_library_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/tests/codeobj/codeobj_library_test.cpp
@@ -326,6 +326,7 @@ TEST(codeobj_library, inline_annotation)
 
     CodeobjDecoderComponent comp(objdata.data(), objdata.size());
     ASSERT_FALSE(comp.m_symbol_map.empty());
+    EXPECT_TRUE(comp.m_line_number_map.empty());
 
     constexpr size_t min_depth = 3;  // kernel -> barrier_wrapper -> HIP header(s)
     size_t           max_depth = 0;


### PR DESCRIPTION
## Motivation

Avoid parsing dwarf information for code objects that were never entered.
This is a performance optimization.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
