### PR TITLE
chore(rocshmem): [gda] remove mlx5 code from generic GDABackend::create_cqs path

### DIFF
--- a/projects/rocshmem/src/gda/backend_gda.cpp
+++ b/projects/rocshmem/src/gda/backend_gda.cpp
@@ -1685,18 +1685,6 @@ void GDABackend::create_cqs(int cqe) {
   cq_attr.comp_vector   = 0;
   cq_attr.flags         = 0;
   cq_attr.comp_mask     = IBV_CQ_INIT_ATTR_MASK_PD;
-  /* enable mlx5 CQ collapsing by setting CQ length to 1 and enabling CQ overrun ignore:
-   *  - mlx5 driver sets mlx5_ifc_cqc_bits::oi bit when IBV_CREATE_CQ_ATTR_IGNORE_OVERRUN is set
-   *    this has the hardware ignore CQ overruns; CQ consumer counter doorbells should not be rung
-   *  - see Mellanox Adapters Programmer’s Reference Manual Rev 0.40, §7.12.8, Tables 75-76
-   *    and linux/include/linux/mlx5/mlx5_ifc.h for Completion Queue Context definition
-   *  - see also rdma-core/libibverbs/cmd_cq.c and linux/drivers/infiniband/hw/mlx5/cq.c
-   *    for how this flag sets the bit */
-  if (gda_provider == GDAProvider::MLX5) {
-    cq_attr.cqe         = 1;
-    cq_attr.comp_mask  |= IBV_CQ_INIT_ATTR_MASK_FLAGS;
-    cq_attr.flags      |= IBV_CREATE_CQ_ATTR_IGNORE_OVERRUN;
-  }
 
   for (size_t i = 0; i < qps.size(); i++) {
     NicDevice &nic = nic_for_qp(i);


### PR DESCRIPTION
## Motivation
Since #4431, mlx5 CQs are created using DevX rather than standard ibverbs. The generic ibverbs code path has some mlx5-specific code that is now dead code.

## Technical Details
Remove the mlx5-specific dead code from the ibverbs code path in `GDABackend::create_cqs`.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
