### PR TITLE
fix(rocjitsu): Harden interposer concurrency

### DIFF
--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -147,7 +147,8 @@ jobs:
             "LoggingTest\.dispatch_logged"
             "ProfiledPluginTest\.hook_profile_output"
             "CvtNarrow\.AllTests"
-            "InterposerTest\..*"
+            "Interposer.*Test\..*"
+            "GuestKfd.*\..*"
             "RaceTest\..*"
           )
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.cpp
@@ -612,10 +612,37 @@ int GuestKfd::open() {
   }
 }
 
-void GuestKfd::retain_local_open() {
+bool GuestKfd::retain_local_open() {
   std::lock_guard lock(mutex_);
-  if (ready_.load(std::memory_order_acquire) && real_kfd_fd_.load(std::memory_order_acquire) >= 0)
+  if (ready_.load(std::memory_order_acquire) && real_kfd_fd_.load(std::memory_order_acquire) >= 0) {
     ++open_refs_;
+    return true;
+  }
+  return false;
+}
+
+LinuxKfd::PrimaryInvalidation GuestKfd::invalidate_primary_fd(int fd) {
+  if (fd < 0)
+    return PrimaryInvalidation::kNotPrimary;
+  std::lock_guard lock(mutex_);
+  // Compare-and-clear the hidden real fd number. Do NOT close it: dup2/dup3
+  // already atomically replaced whatever this number named, so closing it here
+  // would close the app's replacement. A concurrent overwrite that already
+  // cleared it is reported as kNotPrimary.
+  int expected = fd;
+  if (!real_kfd_fd_.compare_exchange_strong(expected, -1, std::memory_order_acq_rel))
+    return PrimaryInvalidation::kNotPrimary;
+  // Also drop out of the ready state (mirroring close()'s teardown, minus the
+  // fd close / overlay cleanup / ref decrement). This matters because GuestKfd
+  // forwards every ioctl/mmap through real_kfd_fd_: with the number now cleared,
+  // forward paths fail safe (ENODEV) instead of routing to whatever the app's
+  // dup2 installed, and the next ensure_ready() lazily reopens a fresh real
+  // /dev/kfd fd. KFD binds one process context per mm, so the reopened fd rejoins
+  // the same context and existing app-facing dup fds keep working transparently.
+  ready_.store(false, std::memory_order_release);
+  // The hidden real fd is kept alive by app-facing dup references, not by a
+  // counted "primary" reference, so the caller must NOT drop an open reference.
+  return PrimaryInvalidation::kClearedKeepRefs;
 }
 
 int GuestKfd::close() {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.h
@@ -87,7 +87,21 @@ public:
   bool prepare_for_discovery();
 
   /// @brief Add one open reference for a duplicated KFD fd.
-  void retain_local_open() override;
+  /// @retval true A reference was added.
+  /// @retval false No live guest process to retain.
+  [[nodiscard]] bool retain_local_open() override;
+
+  /// @brief Stop classifying the hidden real /dev/kfd fd number as KFD after a
+  /// dup2/dup3 overwrote it.
+  /// @details GuestKfd hands applications ordinary dup fds and keeps the real
+  /// /dev/kfd fd internal (real_kfd_fd_). If a dup2/dup3 target reuses that hidden
+  /// fd number, fd()/owns_fd() must stop reporting it as KFD so later ioctl/mmap/
+  /// close are not routed to whatever now occupies the number. The real fd is NOT
+  /// counted in open_refs_ (only app-facing dups are), so a match returns
+  /// kClearedKeepRefs — the interposer must clear the classification WITHOUT
+  /// dropping an open reference. Returns kNotPrimary if @p fd is not the current
+  /// hidden real fd.
+  [[nodiscard]] PrimaryInvalidation invalidate_primary_fd(int fd) override;
 
 private:
   class TopologyOverlay;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -76,8 +76,8 @@ RJ_DIAGNOSTIC_POP
 #include <thread>
 #include <unistd.h>
 #include <unordered_map>
-#include <unordered_set>
 #include <utility>
+#include <vector>
 
 extern "C" rocjitsu::ExecutionPlugin *createKernelLoggingPlugin();
 extern "C" rocjitsu::ExecutionPlugin *createRaceDetectorPlugin();
@@ -172,6 +172,9 @@ __attribute__((constructor)) void rj_install_signal_handler() {
 /// @brief All mutable interposer state.
 class InterposerContext {
 public:
+  /// @brief Which backend holds the open reference for a tracked KFD dup fd.
+  enum class DupBackend : uint8_t { Local, Remote };
+
   static inline thread_local bool in_construction = false;
   static rocjitsu::LibcPassthrough &real() { return rocjitsu::libc_passthrough(); }
   static InterposerContext &ctx;
@@ -192,6 +195,26 @@ public:
     if (guest_driver_)
       guest_driver_->reset_after_fork();
     guest_driver_.reset();
+    // Drop the child's reference to the inherited RemoteDriver. Storing nullptr
+    // releases this shared_ptr; if it was the last reference in the child, the
+    // child's ~RemoteDriver runs and closes only the child's inherited (dup'd)
+    // fds — it does not send RPC_CLOSE and cannot invalidate the parent's live
+    // connection, so this is safe in a forked child.
+    //
+    // Unlike the plain mutexes below, remote_ is NOT reinitialized via
+    // placement-new: re-constructing a live object over itself ends the current
+    // object's lifetime without running its destructor, which is UB for a
+    // non-trivial type like std::atomic<std::shared_ptr<>> (it leaks/By-passes the
+    // control-block bookkeeping). A plain store(nullptr) is the correct way to
+    // release it.
+    //
+    // Caveat: std::atomic<std::shared_ptr<>> may serialize on a libstdc++-internal
+    // pool spinlock. If a parent thread was mid remote_.load()/store() at fork(),
+    // the child inherits that lock held-by-a-dead-thread and this store() could
+    // block. reset_after_fork() therefore assumes no in-flight remote_ atomic
+    // access at the fork point (the common fork-then-exec / single-threaded-fork
+    // case) — placement-new would not sidestep this deadlock either (still UB),
+    // and leaving remote_ non-null would wrongly reuse the parent's connection.
     remote_.store(nullptr, std::memory_order_relaxed);
     remote_kfd_fd_.store(-1, std::memory_order_relaxed);
     remote_open_refs_.store(0, std::memory_order_relaxed);
@@ -214,75 +237,139 @@ public:
            remote_.load(std::memory_order_acquire) != nullptr;
   }
 
-  std::unique_lock<std::mutex> lock_remote() { return std::unique_lock(remote_mutex_); }
-
-  RemoteDriver *remote() { return remote_.load(std::memory_order_acquire); }
+  /// @brief Take a lifetime-extending snapshot of the active remote driver.
+  /// @details The returned shared_ptr keeps the RemoteDriver alive for as long as
+  /// the caller holds it, even if a concurrent teardown_remote() clears remote_.
+  std::shared_ptr<RemoteDriver> remote() { return remote_.load(std::memory_order_acquire); }
 
   int remote_kfd_fd() const { return remote_kfd_fd_.load(std::memory_order_acquire); }
 
-  RemoteDriver *remote_lookup(int fd) {
-    RemoteDriver *active_remote = remote_.load(std::memory_order_acquire);
+  std::shared_ptr<RemoteDriver> remote_lookup(int fd) {
+    auto active_remote = remote_.load(std::memory_order_acquire);
     return (fd >= 0 && fd == remote_kfd_fd_.load(std::memory_order_acquire) && active_remote)
                ? active_remote
                : nullptr;
   }
 
-  std::string remote_topology_path() {
-    std::lock_guard lock(remote_mutex_);
-    RemoteDriver *active_remote = remote_.load(std::memory_order_acquire);
-    return active_remote ? std::string(active_remote->topology_path()) : std::string{};
-  }
-
+  // No lock needed: the snapshot keeps the RemoteDriver alive, and its handshake
+  // metadata (topology/drm paths, gpu_info) is immutable after open() — close()
+  // does not clear it — so this read never races a concurrent teardown. Callers
+  // that need BOTH the topology and drm paths together must take a single
+  // remote() snapshot and read both from it (see redirect_sysfs_path), so the two
+  // paths can't come from different RemoteDrivers across a teardown/reconnect.
   std::string remote_drm_path() {
-    std::lock_guard lock(remote_mutex_);
-    RemoteDriver *active_remote = remote_.load(std::memory_order_acquire);
+    auto active_remote = remote_.load(std::memory_order_acquire);
     return active_remote ? std::string(active_remote->drm_path()) : std::string{};
   }
 
-  /// @brief True when a daemon-mode (remote) KFD connection is open.
-  bool is_remote_mode() const { return remote_open_refs_.load(std::memory_order_acquire) > 0; }
-
-  /// @brief Add one open reference for a remote (daemon-mode) KFD fd.
-  /// @details Each live remote KFD fd (the primary plus every dup) holds one
-  /// reference; the RPC connection is torn down only when the last reference is
-  /// dropped. Mirrors SimulatedKfd's local open refcount for the daemon path.
-  void retain_remote_open() { remote_open_refs_.fetch_add(1, std::memory_order_acq_rel); }
+  /// @brief Retain one remote open reference if a remote connection is live.
+  /// @details Combined check-and-retain under remote_mutex_ so a concurrent
+  /// last-release+teardown cannot slip between "is a remote live?" and the
+  /// increment and resurrect a torn-down connection. Returns true if a reference
+  /// was added (i.e. a remote is active). Mirrors the local path, which does the
+  /// same check-and-retain under process_mutex_.
+  bool retain_remote_open_if_active() {
+    std::lock_guard lock(remote_mutex_);
+    if (!remote_.load(std::memory_order_acquire))
+      return false;
+    remote_open_refs_.fetch_add(1, std::memory_order_acq_rel);
+    return true;
+  }
 
   /// @brief Drop one remote open reference, tearing down the connection on the
   /// last release.
   /// @details On the final release this sends RPC_CLOSE to the daemon (via
   /// RemoteDriver::close()) so the daemon frees this client's process state,
-  /// rather than leaking it until socket disconnect at process exit.
+  /// rather than leaking it until socket disconnect at process exit. The whole
+  /// decrement-and-maybe-teardown runs under remote_mutex_ so it is serialized
+  /// against retain and get_or_create_remote; retain can never observe a live
+  /// remote and add a reference in the window where this is tearing one down.
   void release_remote_open() {
-    int prev = remote_open_refs_.fetch_sub(1, std::memory_order_acq_rel);
-    assert(prev > 0 && "remote open refcount underflow");
-    if (prev == 1)
-      teardown_remote();
+    std::shared_ptr<RemoteDriver> dead;
+    {
+      std::lock_guard lock(remote_mutex_);
+      // Tolerate a spurious release after teardown already reset the count to 0:
+      // teardown_locked() clears kfd_dup_fds_ and zeroes the count together, so a
+      // dup close that lost the race can still land here. Only decrement a live
+      // reference.
+      int prev = remote_open_refs_.load(std::memory_order_acquire);
+      if (prev <= 0)
+        return;
+      remote_open_refs_.store(prev - 1, std::memory_order_release);
+      if (prev == 1)
+        dead = teardown_remote_locked();
+    }
+    // Perform the graceful RPC_CLOSE OUTSIDE remote_mutex_. The atomic shared_ptr
+    // already guarantees the driver's lifetime, so the (blocking) RPC shutdown
+    // does not need the lock; holding remote_mutex_ across a blocking send/recv
+    // would stall every other remote_mutex_ user behind an arbitrary-length RPC.
+    if (dead)
+      dead->close();
   }
 
-  RemoteDriver *get_or_create_remote() {
+  /// @brief Result of get_or_create_remote(): the live driver plus the primary
+  /// KFD fd number captured under remote_mutex_.
+  /// @details Returning the fd snapshot (rather than making the caller re-read
+  /// remote_kfd_fd() after the lock drops) closes a race where a concurrent
+  /// dup2/dup3 clears remote_kfd_fd_ between the helper returning and the caller
+  /// reading it, making open("/dev/kfd") return -1 or a reused non-KFD fd.
+  struct RemoteOpenResult {
+    std::shared_ptr<RemoteDriver> driver;
+    int fd = -1;
+    explicit operator bool() const { return static_cast<bool>(driver); }
+  };
+
+  RemoteOpenResult get_or_create_remote() {
     std::lock_guard lock(remote_mutex_);
-    RemoteDriver *active_remote = remote_.load(std::memory_order_acquire);
-    if (active_remote && remote_kfd_fd_.load(std::memory_order_acquire) >= 0) {
-      // Re-open of an already-connected daemon: each open holds one reference,
-      // mirroring SimulatedKfd::open() retaining the local process.
-      retain_remote_open();
-      return active_remote;
+    auto active_remote = remote_.load(std::memory_order_acquire);
+    if (active_remote) {
+      // The connection is already live: retain a reference and reuse it. Never
+      // re-open() a live RemoteDriver — that would re-handshake and leak a fresh
+      // socket/fd. remote_mutex_ is already held here, so increment directly
+      // (serialized with release).
+      remote_open_refs_.fetch_add(1, std::memory_order_acq_rel);
+      // If the cached primary fd number was lost (e.g. dup2 overwrote it while
+      // other refs kept the connection alive), mint a fresh synthetic primary fd
+      // WITHOUT reconnecting so open("/dev/kfd") still returns a valid fd.
+      int fd = remote_kfd_fd_.load(std::memory_order_acquire);
+      if (fd < 0) {
+        fd = active_remote->reissue_synthetic_kfd_fd();
+        if (fd < 0) {
+          // Roll back the reference taken above. remote_mutex_ is held, so
+          // decrement directly rather than via release_remote_open() (which would
+          // re-lock and deadlock).
+          remote_open_refs_.fetch_sub(1, std::memory_order_acq_rel);
+          return {};
+        }
+        remote_kfd_fd_.store(fd, std::memory_order_release);
+      }
+      // Return the fd captured under the lock so a concurrent invalidation
+      // cannot clear it before the caller uses it.
+      return {active_remote, fd};
     }
     int sock = connect_to_daemon();
     if (sock < 0)
-      return nullptr;
-    if (!active_remote) {
-      active_remote = new RemoteDriver(sock);
-      remote_.store(active_remote, std::memory_order_release);
-    }
+      return {};
+    // Build the driver and open its KFD connection BEFORE publishing remote_.
+    // Publishing early (then returning on open()<0) would leave remote_ non-null
+    // with remote_kfd_fd_ == -1, so initialized() would report success and gate
+    // out local-VM creation / a later remote retry. Only a fully-open driver is
+    // ever visible to lock-free readers.
+    if (!active_remote)
+      active_remote = std::make_shared<RemoteDriver>(sock);
     int fd = active_remote->open();
     if (fd < 0)
-      return nullptr;
+      return {};
+    // Publish the fd and open refcount BEFORE remote_. initialized() and the
+    // lock-free readers gate on remote_, so making the remote_ release-store the
+    // LAST step guarantees any thread that observes a non-null remote_ also sees
+    // a valid remote_kfd_fd_ and a nonzero open refcount — never a half-published
+    // remote whose fd/ref state has not landed yet.
     remote_kfd_fd_.store(fd, std::memory_order_release);
     // The primary remote KFD fd holds the first open reference.
     remote_open_refs_.store(1, std::memory_order_release);
-    return active_remote;
+    remote_.store(active_remote, std::memory_order_release);
+    return {active_remote, fd};
   }
 
   LinuxKfd *lookup(int fd) {
@@ -309,15 +396,24 @@ public:
         !sv.starts_with("/sys/class/kfd"))
       return {};
 
-    if (!remote_lookup(remote_kfd_fd()) && !initialized())
+    // initialized() already covers a live remote (remote_ != nullptr), which is
+    // the stable signal independent of the primary fd number; only create a local
+    // VM when nothing is initialized yet.
+    if (!initialized())
       get_or_create();
 
-    const std::string remote_topology = remote_topology_path();
-    if (!remote_topology.empty()) {
-      std::string redirected =
-          LinuxKfd::redirect_sysfs_root_path(path, remote_topology, remote_drm_path());
-      if (!redirected.empty())
-        return redirected;
+    // Read topology and drm paths from ONE remote snapshot so a concurrent
+    // teardown/reconnect between the two reads cannot combine a topology path from
+    // one RemoteDriver with a drm path from another (or an empty one). The
+    // metadata is immutable-after-open, so a single live snapshot is consistent.
+    if (auto remote = remote_.load(std::memory_order_acquire)) {
+      std::string remote_topology(remote->topology_path());
+      if (!remote_topology.empty()) {
+        std::string redirected = LinuxKfd::redirect_sysfs_root_path(
+            path, remote_topology, std::string(remote->drm_path()));
+        if (!redirected.empty())
+          return redirected;
+      }
     }
 
     return redirect(path);
@@ -338,82 +434,256 @@ public:
     if (fd < 0 || is_kfd_primary(fd))
       return;
     std::lock_guard lock(fd_mutex_);
-    // GuestKfd::open() already retained one driver reference before returning
-    // this app-facing dup fd. Track it so ioctl/mmap/close are routed through
-    // the driver without incrementing the reference count a second time.
-    kfd_dup_fds_.insert(fd);
+    // GuestKfd::open() already retained one driver (local) reference before
+    // returning this app-facing dup fd. Track it as a Local dup so ioctl/mmap/
+    // close route through the driver without incrementing the reference count a
+    // second time (unlike commit_dup(), which consumes a fresh reservation).
+    kfd_dup_fds_.emplace(fd, DupBackend::Local);
   }
 
-  void track_dup(int fd) {
-    if (fd < 0 || is_kfd_primary(fd))
+  /// @brief Resolve which backend a tracked KFD fd belongs to.
+  /// @details Returns the backend of the local/remote primary fd, or the backend
+  /// recorded for a tracked dup, or nullopt if the fd is not a tracked KFD fd.
+  /// A dup must inherit the SOURCE fd's backend rather than guessing from global
+  /// state: when local mode was created first and the daemon later becomes
+  /// active, both driver() and remote_ are non-null, so guessing would mis-tag a
+  /// dup of the remote fd as Local and release the wrong backend on close.
+  std::optional<DupBackend> kfd_backend_of(int fd) {
+    if (fd < 0)
+      return std::nullopt;
+    if (fd == driver_fd())
+      return DupBackend::Local;
+    if (fd == remote_kfd_fd_.load(std::memory_order_acquire))
+      return DupBackend::Remote;
+    std::lock_guard lock(fd_mutex_);
+    auto it = kfd_dup_fds_.find(fd);
+    if (it != kfd_dup_fds_.end())
+      return it->second;
+    return std::nullopt;
+  }
+
+  /// @brief Retain one open reference on a specific backend.
+  /// @returns true if a reference was acquired; false if that backend is no
+  /// longer active (local VM gone, or remote torn down). Mirrors release_backend.
+  bool retain_backend(DupBackend backend) {
+    if (backend == DupBackend::Local) {
+      auto *d = driver();
+      // retain_local_open() reports false if the local process was already torn
+      // down (a racing last-close), so a dup of a dying local fd is not falsely
+      // treated as retained.
+      return d && d->retain_local_open();
+    }
+    return retain_remote_open_if_active();
+  }
+
+  /// @brief Release one open reference on the backend recorded for a dup.
+  /// @details Local dups release the local process refcount; remote dups release
+  /// the daemon connection refcount. release_remote_open() is a no-op when no
+  /// remote reference is live, so a release that races a teardown is harmless.
+  void release_backend(DupBackend backend) {
+    if (backend == DupBackend::Local) {
+      if (auto *d = driver())
+        d->close();
+    } else {
+      release_remote_open();
+    }
+  }
+
+  /// @brief Reserve (retain) a reference on the backend that owns @p src_fd,
+  /// before duplicating it, so the backend cannot be torn down by a racing
+  /// last-close between the dup syscall and tracking the new fd.
+  /// @details Acquires the open reference on the source fd's backend FIRST; the
+  /// caller then performs the dup syscall and, on success, hands the reserved
+  /// backend to commit_dup() (which records the new fd tagged with that same
+  /// backend). Reserving before the syscall keeps the invariant "every entry in
+  /// kfd_dup_fds_ holds exactly one reference on its recorded backend" and passing
+  /// the source backend through (rather than rediscovering it from global state)
+  /// prevents mis-tagging a remote-fd dup as Local when both backends are active.
+  /// @returns The reserved backend, or nullopt if @p src_fd is not a tracked KFD
+  /// fd or its backend is no longer active. On a non-nullopt return the caller
+  /// MUST consume the reservation exactly once: commit_dup() on syscall success,
+  /// or release_backend() on syscall failure.
+  [[nodiscard]] std::optional<DupBackend> reserve_dup_backend(int src_fd) {
+    auto backend = kfd_backend_of(src_fd);
+    if (!backend)
+      return std::nullopt;
+    if (!retain_backend(*backend))
+      return std::nullopt; // backend went away before we could reserve.
+    return backend;
+  }
+
+  /// @brief Record a dup fd whose backend reference was already reserved via
+  /// reserve_dup_backend(). Consumes exactly that one reserved reference.
+  void commit_dup(int fd, DupBackend backend) {
+    if (fd < 0 || is_kfd_primary(fd)) {
+      // Cannot track this as a dup (invalid, or the number aliases a primary).
+      // Release the reserved reference to stay balanced.
+      release_backend(backend);
       return;
-    bool newly_tracked = false;
+    }
+    bool inserted = false;
     {
       std::lock_guard lock(fd_mutex_);
-      newly_tracked = kfd_dup_fds_.insert(fd).second;
+      inserted = kfd_dup_fds_.emplace(fd, backend).second;
     }
-    if (!newly_tracked)
-      return;
-    // Each live KFD fd (primary + every dup) holds one open reference, so the
-    // process/connection is torn down only when the last fd closes. Retain on
-    // whichever backend is active (local SimulatedKfd or remote daemon RPC).
-    if (auto *d = driver())
-      d->retain_local_open();
-    else if (is_remote_mode())
-      retain_remote_open();
+    if (!inserted)
+      // fd already tracked (dup returned a recycled number we still hold): undo
+      // the reserved reference so the count stays balanced.
+      release_backend(backend);
   }
 
   void untrack_dup(int fd) {
     if (fd < 0)
       return;
+    DupBackend backend;
     bool was_tracked = false;
     {
       std::lock_guard lock(fd_mutex_);
-      was_tracked = kfd_dup_fds_.erase(fd) != 0;
+      auto it = kfd_dup_fds_.find(fd);
+      if (it != kfd_dup_fds_.end()) {
+        backend = it->second;
+        kfd_dup_fds_.erase(it);
+        was_tracked = true;
+      }
     }
-    if (!was_tracked)
+    if (was_tracked)
+      release_backend(backend);
+  }
+
+  /// @brief Drop all KFD identity/references for an fd number that dup2/dup3 is
+  /// about to reuse (the syscall already atomically closed whatever it was).
+  /// @details Covers three cases so the reused number cannot keep routing to a
+  /// stale backend:
+  ///   - tracked KFD dup: release its recorded backend and erase its entry;
+  ///   - remote primary: clear remote_kfd_fd_ and drop its open reference;
+  ///   - local primary: forget the primary fd number and drop its open reference.
+  /// The primary paths mirror close()'s handling of the primary fd, minus the
+  /// real close() (dup2/dup3 already replaced the descriptor).
+  void invalidate_overwritten_kfd_fd(int fd) {
+    if (fd < 0)
       return;
-    if (auto *d = driver())
-      d->close();
-    else if (is_remote_mode())
-      release_remote_open();
+    // Remote primary? Compare-and-clear remote_kfd_fd_ under remote_mutex_ so the
+    // "is this the primary?" test and the clear are atomic with respect to
+    // get_or_create_remote() (which retains/reissues the fd under the same lock).
+    // Without the lock a racing open could observe the old fd number after this
+    // cleared it, and hand back a stale/invalidated descriptor.
+    if (invalidate_remote_primary(fd))
+      return;
+    // Local primary? Let invalidate_primary_fd() decide under the driver's own
+    // lock rather than pre-filtering on an unlocked fd() load: fd() can change
+    // between the check and the lock (a concurrent open()/re-mint), which could
+    // skip invalidating the overwritten primary and leave the reused number
+    // misclassified as KFD. The under-lock compare-and-clear is authoritative,
+    // and its result tells us whether to drop an open reference:
+    //   - kClearedDropRef: the primary held one counted open reference (e.g.
+    //     SimulatedKfd) — drop it via close();
+    //   - kClearedKeepRefs: the classification was cleared but the primary fd is
+    //     internal and NOT counted in the open-reference bookkeeping (e.g.
+    //     GuestKfd's hidden real fd, kept alive by app dups) — do NOT close();
+    //   - kNotPrimary: fall through to dup tracking.
+    if (auto *d = driver()) {
+      switch (d->invalidate_primary_fd(fd)) {
+      case LinuxKfd::PrimaryInvalidation::kClearedDropRef:
+        d->close(); // drop the primary open reference
+        return;
+      case LinuxKfd::PrimaryInvalidation::kClearedKeepRefs:
+        return; // classification cleared; no counted reference to drop
+      case LinuxKfd::PrimaryInvalidation::kNotPrimary:
+        break; // fall through to dup handling
+      }
+    }
+    // Otherwise, a tracked dup (or nothing).
+    untrack_dup(fd);
+  }
+
+  /// @brief If @p fd is the remote primary, clear it and drop its open reference.
+  /// @returns true if @p fd matched the remote primary (handled here); false so
+  /// the caller falls through to local-primary / dup handling.
+  /// @details The compare-and-clear and the reference drop run under
+  /// remote_mutex_, serialized with get_or_create_remote()'s retain/reissue. On
+  /// the last reference the connection is torn down and the (blocking) RPC_CLOSE
+  /// is run OUTSIDE the lock, mirroring release_remote_open().
+  bool invalidate_remote_primary(int fd) {
+    std::shared_ptr<RemoteDriver> dead;
+    {
+      std::lock_guard lock(remote_mutex_);
+      int expected = fd;
+      if (!remote_kfd_fd_.compare_exchange_strong(expected, -1, std::memory_order_acq_rel))
+        return false; // not the remote primary
+      // The number is being reused; it no longer names the synthetic remote KFD
+      // fd. Drop the primary's open reference (inlined from release_remote_open()
+      // because we already hold remote_mutex_). If other refs keep the connection
+      // alive, remote_ stays non-null with remote_kfd_fd_ == -1; routing then uses
+      // ctx.remote() (not the fd number) and a later open("/dev/kfd") re-mints a
+      // fresh primary fd via get_or_create_remote() without reconnecting.
+      int prev = remote_open_refs_.load(std::memory_order_acquire);
+      if (prev > 0) {
+        remote_open_refs_.store(prev - 1, std::memory_order_release);
+        if (prev == 1)
+          dead = teardown_remote_locked();
+      }
+    }
+    if (dead)
+      dead->close();
+    return true;
   }
 
   void clear_dups() {
-    size_t released = 0;
+    std::vector<DupBackend> released;
     {
       std::lock_guard lock(fd_mutex_);
-      released = kfd_dup_fds_.size();
+      released.reserve(kfd_dup_fds_.size());
+      for (auto &[fd, backend] : kfd_dup_fds_)
+        released.push_back(backend);
       kfd_dup_fds_.clear();
     }
-    // Drop the references the cleared dups were holding. Used when a fresh
-    // open() rebinds the local process; the just-opened reference is preserved
-    // because clear_dups runs before any new dups are tracked. Remote teardown
-    // releases its own references explicitly and never routes through here.
-    if (auto *d = driver())
-      for (size_t i = 0; i < released; ++i)
-        d->close();
+    // Drop the references the cleared dups were holding, each on the backend it
+    // was tracked against. Used when a fresh open() rebinds the local process;
+    // the just-opened reference is preserved because clear_dups runs before any
+    // new dups are tracked.
+    for (DupBackend backend : released)
+      release_backend(backend);
   }
 
-  /// @brief Tear down the remote (daemon) connection: send RPC_CLOSE, close the
-  /// synthetic primary fd, and drop daemon-redirect topology paths.
-  /// @details Invoked on the last remote open reference release. Any remaining
-  /// dup-tracked fds refer to the now-closed synthetic fd; clear the set so
-  /// their subsequent close()/ioctl calls fall through to the real syscall
-  /// instead of being misrouted to a dead RPC connection.
-  void teardown_remote() {
-    std::lock_guard lock(remote_mutex_);
-    RemoteDriver *active_remote = remote_.load(std::memory_order_acquire);
+  /// @brief Tear down the remote connection state. Caller MUST hold remote_mutex_.
+  /// @details Only invoked from release_remote_open() on the last reference, which
+  /// already holds remote_mutex_. Keeping the lock across the decrement, the
+  /// pointer/refcount reset, and the fd/dup cleanup makes the whole "last release
+  /// destroys" decision atomic with respect to retain_remote_open_if_active() and
+  /// get_or_create_remote(). Any remaining Remote-tagged dup fds refer to the
+  /// now-closed synthetic fd; erasing them makes their later close()/ioctl fall
+  /// through to the real syscall instead of a dead RPC connection.
+  /// @returns The extracted RemoteDriver so the caller can run the (blocking)
+  /// RPC_CLOSE shutdown OUTSIDE remote_mutex_; the shared_ptr keeps it alive.
+  [[nodiscard]] std::shared_ptr<RemoteDriver> teardown_remote_locked() {
+    auto active_remote = remote_.load(std::memory_order_acquire);
     if (!active_remote)
-      return;
-    active_remote->close();
+      return nullptr;
+    // Clear the published pointer first so no new reader can pick this driver up.
+    // The RemoteDriver is destroyed by the last shared_ptr: if a racing reader
+    // still holds a snapshot mid-ioctl/mmap, destruction (and socket close in
+    // ~RemoteDriver) is deferred until it releases, so there is no use-after-free.
     remote_.store(nullptr, std::memory_order_release);
-    delete active_remote;
+    // Reset the refcount to 0 under the lock. A concurrent
+    // retain_remote_open_if_active() serializes on remote_mutex_ and, seeing
+    // remote_ == nullptr, refuses to add a reference, so it cannot resurrect this
+    // torn-down connection.
+    remote_open_refs_.store(0, std::memory_order_release);
     int fd = remote_kfd_fd_.exchange(-1, std::memory_order_acq_rel);
     if (fd >= 0)
       InterposerContext::real().close(fd);
-    std::lock_guard fd_lock(fd_mutex_);
-    kfd_dup_fds_.clear();
+    // Erase ONLY the Remote-tagged dups. kfd_dup_fds_ can hold Local entries too
+    // (local + daemon mode simultaneously active); clearing the whole map would
+    // drop a live local dup's tracking without releasing its local open
+    // reference, leaking it and breaking its later close. The remote refcount is
+    // zero here, so every remaining Remote entry has already had its reference
+    // released via untrack_dup()/clear_dups(); we only drop stale tracking.
+    {
+      std::lock_guard fd_lock(fd_mutex_);
+      std::erase_if(kfd_dup_fds_,
+                    [](const auto &entry) { return entry.second == DupBackend::Remote; });
+    }
+    return active_remote;
   }
 
   void track_sysfs(int fd, const std::string &path) {
@@ -483,7 +753,6 @@ public:
         in_construction = false;
         return nullptr;
       }
-
       rj_vm_t *created_vm = nullptr;
       if (rj_vm_create(cfg_path->c_str(), RJ_VM_MODE_LOCAL, &created_vm) !=
           ROCJITSU_STATUS_SUCCESS) {
@@ -493,8 +762,7 @@ public:
       }
       rj_vm_ = created_vm;
 
-      // Set up execution plugins based on environment variables.
-      if (rj_vm_->soc) {
+      if (created_vm->soc) {
         std::shared_ptr<rocjitsu::ExecutionPluginGroup> pg;
         if (std::getenv("RJ_USE_PROFILED_EXECUTION_PLUGIN_GROUP"))
           pg = std::make_shared<rocjitsu::ProfiledExecutionPluginGroup>();
@@ -529,12 +797,18 @@ public:
           pg->add(std::unique_ptr<rocjitsu::ExecutionPlugin>(createRaceDetectorPlugin()));
           fprintf(stderr, "[rocjitsu] Race detection enabled (RJ_RACE)\n");
         }
-        rj_vm_->soc->set_plugin_group(pg);
+        created_vm->soc->set_plugin_group(pg);
       }
 
-      LinuxKfd *driver = rj_vm_->vm->driver();
+      // Publish the fully-constructed, not-yet-running driver BEFORE starting the
+      // engine thread: the release-store of active_driver_ pairs with acquire
+      // loads in driver()/initialized(), so any reader that observes the driver
+      // also observes all of the setup above (config, plugin group, sinks).
+      // Starting rj_vm_run() before the store would let the detached engine
+      // thread begin mutating the VM before it is published.
+      LinuxKfd *driver = created_vm->vm->driver();
       active_driver_.store(driver, std::memory_order_release);
-      std::thread([vm = rj_vm_]() { rj_vm_run(vm, nullptr); }).detach();
+      std::thread([vm = created_vm]() { rj_vm_run(vm, nullptr); }).detach();
       in_construction = false;
     }
     return driver();
@@ -557,13 +831,15 @@ private:
   std::unique_ptr<GuestKfd> guest_driver_;
   std::atomic<LinuxKfd *> active_driver_{nullptr};
   /// @brief Active daemon-mode remote driver, or nullptr in local mode.
-  /// @details Stored atomically so lock-free readers (`remote()`,
+  /// @details Held as an atomic shared_ptr so lock-free readers (`remote()`,
   /// `remote_lookup()`, `initialized()`, the AMDKFD ioctl fallback, the mmap
-  /// path) never race the writer that swaps it under `remote_mutex_` in
-  /// `get_or_create_remote()`/`teardown_remote()`. The mutex still serializes the
-  /// compound new+open and delete+clear sequences; the atomic only makes the
-  /// bare pointer read/write data-race-free.
-  std::atomic<RemoteDriver *> remote_{nullptr};
+  /// path) each take a lifetime-extending snapshot: a racing `teardown_remote()`
+  /// that stores nullptr cannot free the object while another thread still holds
+  /// a snapshot in `remote->ioctl()`/`remote->mmap()`. The object is destroyed by
+  /// the last shared_ptr, not by a manual delete, so there is no use-after-free.
+  /// `remote_mutex_` still serializes the compound create+open and clear
+  /// sequences; the atomic makes the pointer swap data-race-free.
+  std::atomic<std::shared_ptr<RemoteDriver>> remote_{nullptr};
   std::atomic<int> remote_kfd_fd_{-1};
   /// @brief Open-reference count for the remote (daemon-mode) KFD connection.
   /// @details The primary remote fd and every dup of it each hold one
@@ -576,7 +852,13 @@ private:
   std::mutex remote_mutex_;
   std::unordered_map<int, std::string> sysfs_fds_;
   std::unordered_map<int, uint32_t> drm_fds_;
-  std::unordered_set<int> kfd_dup_fds_;
+  /// @brief Tracked KFD dup fds → the backend that holds their open reference.
+  /// @details Each dup of a KFD fd retains one open reference. The backend is
+  /// captured at track time so untrack releases the SAME backend even if the
+  /// active backend changed (local↔remote) or was torn down in between; a dup is
+  /// recorded only if a reference was actually acquired, so track/untrack stay
+  /// balanced and can never over-release or resurrect the wrong connection.
+  std::unordered_map<int, DupBackend> kfd_dup_fds_;
 
   alignas(16) static uint8_t storage_[];
 };
@@ -596,7 +878,7 @@ extern "C" {
 
 static std::string redirect_sysfs_path(const char *path);
 static std::string redirect_sys_dev_char(const char *path);
-static const Sysfs::GpuInfo *interposer_gpu_info(uint32_t render_minor);
+static std::optional<Sysfs::GpuInfo> interposer_gpu_info(uint32_t render_minor);
 
 struct SyntheticDrmOpenResult {
   bool handled = false;
@@ -639,11 +921,14 @@ static SyntheticDrmOpenResult open_synthetic_drm_fd(const char *path) {
       path_view.find("/dev_dri/renderD") == std::string_view::npos)
     return {};
 
-  if (!InterposerContext::ctx.remote_lookup(InterposerContext::ctx.remote_kfd_fd()) &&
-      !InterposerContext::ctx.initialized())
+  if (!InterposerContext::ctx.initialized())
     InterposerContext::ctx.get_or_create();
 
-  if (InterposerContext::ctx.driver_fd() < 0 && InterposerContext::ctx.remote_kfd_fd() < 0)
+  // Snapshot the remote once; a live snapshot (not remote_kfd_fd() >= 0) is the
+  // stable signal that a daemon connection can service this render node, even if
+  // a dup2/dup3 cleared the primary fd number while other refs keep it alive.
+  auto remote = InterposerContext::ctx.remote();
+  if (InterposerContext::ctx.driver_fd() < 0 && !remote)
     return {};
 
   std::string drm_base;
@@ -661,7 +946,7 @@ static SyntheticDrmOpenResult open_synthetic_drm_fd(const char *path) {
 
   auto *drv = InterposerContext::ctx.driver();
   const bool local_handles_render = drv && drv->handles_drm_render_minor(render_minor);
-  const bool remote_handles_render = InterposerContext::ctx.remote_kfd_fd() >= 0;
+  const bool remote_handles_render = static_cast<bool>(remote);
   if (!local_handles_render && !remote_handles_render)
     return {};
 
@@ -669,7 +954,10 @@ static SyntheticDrmOpenResult open_synthetic_drm_fd(const char *path) {
   if (raw_drm_fd < 0)
     return {true, -1};
 
-  int high_fd = fcntl(raw_drm_fd, F_DUPFD_CLOEXEC, 512);
+  // Use real().fcntl, not the unqualified fcntl: this TU defines the interposed
+  // fcntl with external linkage, so an unqualified call would re-enter our own
+  // hook (reserve_dup_backend/untrack_dup, fd_mutex_) needlessly.
+  int high_fd = InterposerContext::real().fcntl(raw_drm_fd, F_DUPFD_CLOEXEC, 512);
   int saved_errno = errno;
   InterposerContext::real().close(raw_drm_fd);
   if (high_fd < 0) {
@@ -699,8 +987,11 @@ RJ_INTERPOSER_EXPORT int open(const char *path, int flags, ...) {
     return drm_fd.fd;
 
   if (std::strcmp(path, "/dev/kfd") == 0) {
-    if (InterposerContext::ctx.get_or_create_remote())
-      return InterposerContext::ctx.remote_kfd_fd();
+    // Use the fd captured under remote_mutex_ (not a fresh remote_kfd_fd() read),
+    // so a concurrent dup2/dup3 that invalidates the primary fd cannot make this
+    // return -1 or a reused non-KFD descriptor.
+    if (auto remote = InterposerContext::ctx.get_or_create_remote())
+      return remote.fd;
 
     auto *drv = InterposerContext::ctx.get_or_create();
     if (!drv) {
@@ -900,11 +1191,12 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
       //   READ_MMR_REG (gb_addr_cfg is mandatory for all families),
       //   VRAM_GTT, MEMORY. Failures (-1) abort device init.
       auto *info = static_cast<drm_amdgpu_info *>(arg);
-      auto *gpu = interposer_gpu_info(InterposerContext::ctx.drm_render_minor(fd));
-      if (!gpu) {
+      auto gpu_info = interposer_gpu_info(InterposerContext::ctx.drm_render_minor(fd));
+      if (!gpu_info) {
         errno = ENODEV;
         return -1;
       }
+      const Sysfs::GpuInfo *gpu = &*gpu_info;
       auto *out = info->return_pointer ? reinterpret_cast<void *>(info->return_pointer) : nullptr;
       if (!out || info->return_size == 0)
         return 0;
@@ -987,42 +1279,92 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
     return -1;
   }
 
-  if (auto *remote = InterposerContext::ctx.remote_lookup(fd))
+  if (auto remote = InterposerContext::ctx.remote_lookup(fd))
     return kfd_ioctl_ret(remote->ioctl(request, arg));
-  if (InterposerContext::ctx.is_kfd_dup(fd)) {
-    if (auto *remote = InterposerContext::ctx.remote_lookup(InterposerContext::ctx.remote_kfd_fd()))
-      return kfd_ioctl_ret(remote->ioctl(request, arg));
+  // Dispatch a tracked KFD fd by its RECORDED backend, not by "remote if any
+  // remote is live". In mixed local+daemon mode a Local-tagged dup must route to
+  // the local driver and a Remote-tagged dup to the remote connection; guessing
+  // remote would silently switch a local dup's backend.
+  if (auto backend = InterposerContext::ctx.kfd_backend_of(fd)) {
+    if (*backend == InterposerContext::DupBackend::Remote) {
+      // kfd_backend_of() already established this fd is Remote-backed, so route
+      // via the remote snapshot directly rather than remote_lookup(remote_kfd_fd_):
+      // the primary fd number may have been invalidated/reused while a remote
+      // shared_ptr snapshot is still live, and this dup still belongs to it.
+      if (auto remote = InterposerContext::ctx.remote())
+        return kfd_ioctl_ret(remote->ioctl(request, arg));
+    } else if (auto *drv = InterposerContext::ctx.driver()) {
+      return kfd_ioctl_ret(drv->ioctl(request, arg));
+    }
   }
   // Late-ioctl safety net: an AMDKFD ('K') ioctl may arrive on a tracked KFD fd
   // whose primary remote handle changed underneath it (e.g. a close/dup race in
-  // daemon mode). Forward only AMDKFD-typed ioctls, and only on fds we already
-  // track as KFD (primary or dup), so an arbitrary unrelated fd carrying a
-  // type-'K' ioctl is never misrouted to the remote KFD driver.
-  if (_IOC_TYPE(request) == AMDKFD_IOCTL_BASE && InterposerContext::ctx.is_kfd_tracked(fd)) {
-    if (auto *remote = InterposerContext::ctx.remote())
-      return kfd_ioctl_ret(remote->ioctl(request, arg));
+  // daemon mode). Forward only AMDKFD-typed ioctls, and only on fds whose backend
+  // is KNOWN to be Remote. Capture the backend once (a single locked lookup) and
+  // require it to hold a Remote value: this both excludes Local-backed fds (a
+  // Local dup whose driver() was transiently null above belongs to the local
+  // driver) and refuses to route when the backend is unknown/nullopt (e.g.
+  // tracking removed concurrently), so a type-'K' ioctl is never guessed onto the
+  // remote connection.
+  if (_IOC_TYPE(request) == AMDKFD_IOCTL_BASE) {
+    auto backend = InterposerContext::ctx.kfd_backend_of(fd);
+    if (backend == InterposerContext::DupBackend::Remote) {
+      if (auto remote = InterposerContext::ctx.remote())
+        return kfd_ioctl_ret(remote->ioctl(request, arg));
+    }
   }
 
-  auto *drv = InterposerContext::ctx.lookup(fd);
-  if (!drv && InterposerContext::ctx.is_kfd_dup(fd))
-    drv = InterposerContext::ctx.driver();
-  if (drv)
-    return kfd_ioctl_ret(drv->ioctl(request, arg));
-
+  // Every tracked KFD primary/dup is routed above by its recorded backend
+  // (remote_lookup / kfd_backend_of). Deliberately NO local-driver fallback for
+  // tracked dups here: a Remote-tagged dup observed during a remote teardown
+  // window (remote_ cleared but its kfd_dup_fds_ entry not yet erased) must fall
+  // through to the real ioctl, not be misrouted to a live local driver in mixed
+  // local+daemon mode.
   return InterposerContext::real().ioctl(fd, request, arg);
 }
 
 RJ_INTERPOSER_EXPORT int dup(int oldfd) {
   assert(InterposerContext::real().ready());
+  // Reserve the source backend's open reference BEFORE the syscall so a racing
+  // last-close cannot tear the backend down between the dup and tracking the new
+  // fd (which would leave a valid KFD dup untracked / unreferenced).
+  auto reserved = InterposerContext::ctx.reserve_dup_backend(oldfd);
   int rc = InterposerContext::real().dup(oldfd);
-  if (rc >= 0) {
-    if (InterposerContext::ctx.is_kfd_tracked(oldfd))
-      InterposerContext::ctx.track_dup(rc);
-    else
-      InterposerContext::ctx.untrack_dup(rc);
+  if (rc < 0) {
+    // Syscall failed: roll back the reservation.
+    if (reserved)
+      InterposerContext::ctx.release_backend(*reserved);
+    return rc;
   }
+  if (reserved)
+    InterposerContext::ctx.commit_dup(rc, *reserved);
+  else
+    InterposerContext::ctx.untrack_dup(rc);
   return rc;
 }
+
+namespace {
+// Reconcile interposer tracking after a successful dup2/dup3(oldfd -> newfd),
+// consuming a backend reservation taken (before the syscall) for oldfd.
+// dup2/dup3 atomically CLOSE newfd before installing the duplicate, so any
+// tracking/reference newfd previously held must be dropped before the
+// replacement is tracked:
+//   - stale sysfs/DRM tracking for newfd is removed;
+//   - if newfd was a tracked KFD dup, its reference is released and its stale
+//     kfd_dup_fds_ entry erased (otherwise commit_dup would see the stale entry
+//     and release the newly-reserved backend, leaving the OLD backend recorded);
+//   - if newfd was a PRIMARY KFD fd (local or remote), that primary identity is
+//     invalidated and its reference released, so the reused fd number no longer
+//     routes to the old backend.
+// Then the replacement is recorded on the reserved source backend.
+void reconcile_dup_target(int newfd, std::optional<InterposerContext::DupBackend> reserved) {
+  InterposerContext::ctx.untrack_sysfs(newfd);
+  InterposerContext::ctx.untrack_drm(newfd);
+  InterposerContext::ctx.invalidate_overwritten_kfd_fd(newfd);
+  if (reserved)
+    InterposerContext::ctx.commit_dup(newfd, *reserved);
+}
+} // namespace
 
 RJ_INTERPOSER_EXPORT int dup2(int oldfd, int newfd) {
   assert(InterposerContext::real().ready());
@@ -1030,16 +1372,15 @@ RJ_INTERPOSER_EXPORT int dup2(int oldfd, int newfd) {
   // tracking would drop a still-open ref. Forward without touching tracking.
   if (oldfd == newfd)
     return InterposerContext::real().dup2(oldfd, newfd);
+  // Reserve the source backend before the syscall (see dup()).
+  auto reserved = InterposerContext::ctx.reserve_dup_backend(oldfd);
   int rc = InterposerContext::real().dup2(oldfd, newfd);
-  if (rc < 0)
+  if (rc < 0) {
+    if (reserved)
+      InterposerContext::ctx.release_backend(*reserved);
     return rc;
-  // newfd was atomically closed and replaced; reconcile its tracking only now.
-  InterposerContext::ctx.untrack_sysfs(newfd);
-  InterposerContext::ctx.untrack_drm(newfd);
-  if (InterposerContext::ctx.is_kfd_tracked(oldfd))
-    InterposerContext::ctx.track_dup(rc);
-  else
-    InterposerContext::ctx.untrack_dup(rc);
+  }
+  reconcile_dup_target(rc, reserved);
   return rc;
 }
 
@@ -1048,15 +1389,14 @@ RJ_INTERPOSER_EXPORT int dup3(int oldfd, int newfd, int flags) {
   assert(InterposerContext::real().ready());
   // dup3(fd, fd, ...) is required to fail with EINVAL without altering the
   // descriptor; do not mutate tracking before the syscall confirms that.
+  auto reserved = InterposerContext::ctx.reserve_dup_backend(oldfd);
   int rc = InterposerContext::real().dup3(oldfd, newfd, flags);
-  if (rc < 0)
+  if (rc < 0) {
+    if (reserved)
+      InterposerContext::ctx.release_backend(*reserved);
     return rc;
-  InterposerContext::ctx.untrack_sysfs(newfd);
-  InterposerContext::ctx.untrack_drm(newfd);
-  if (InterposerContext::ctx.is_kfd_tracked(oldfd))
-    InterposerContext::ctx.track_dup(rc);
-  else
-    InterposerContext::ctx.untrack_dup(rc);
+  }
+  reconcile_dup_target(rc, reserved);
   return rc;
 }
 #endif
@@ -1126,6 +1466,15 @@ namespace {
 // ABI, so InterposerContext::real().fcntl services both.
 int fcntl_impl(int fd, int cmd, void *ptr_arg, int int_arg) {
   FcntlArgKind kind = fcntl_arg_kind(cmd);
+  // F_DUPFD/F_DUPFD_CLOEXEC create a new fd like dup(); reserve the source
+  // backend BEFORE the syscall so a racing last-close cannot tear it down
+  // between the dup and tracking the new fd. F_DUPFD does not overwrite an
+  // existing fd, so no primary/dup reconciliation of a target is needed.
+  const bool is_dupfd = (cmd == F_DUPFD || cmd == F_DUPFD_CLOEXEC);
+  std::optional<InterposerContext::DupBackend> reserved;
+  if (is_dupfd)
+    reserved = InterposerContext::ctx.reserve_dup_backend(fd);
+
   long rc = 0;
   switch (kind) {
   case FcntlArgKind::Int:
@@ -1140,18 +1489,24 @@ int fcntl_impl(int fd, int cmd, void *ptr_arg, int int_arg) {
     break;
   }
 
-  if (rc >= 0 && (cmd == F_DUPFD || cmd == F_DUPFD_CLOEXEC)) {
-    if (InterposerContext::ctx.is_kfd_tracked(fd))
-      InterposerContext::ctx.track_dup(static_cast<int>(rc));
-    else
-      InterposerContext::ctx.untrack_dup(static_cast<int>(rc));
-    // Propagate DRM render-node tracking across dup so ioctls on the duped fd
-    // are still recognized. libdrm's amdgpu_device_initialize duplicates the
-    // render fd (via fcntl64 F_DUPFD_CLOEXEC) and issues all AMDGPU_INFO ioctls
-    // on the copy.
-    if (InterposerContext::ctx.is_drm(fd))
-      InterposerContext::ctx.track_drm(static_cast<int>(rc),
-                                       InterposerContext::ctx.drm_render_minor(fd));
+  if (is_dupfd) {
+    if (rc < 0) {
+      // Syscall failed: roll back the reservation.
+      if (reserved)
+        InterposerContext::ctx.release_backend(*reserved);
+    } else {
+      if (reserved)
+        InterposerContext::ctx.commit_dup(static_cast<int>(rc), *reserved);
+      else
+        InterposerContext::ctx.untrack_dup(static_cast<int>(rc));
+      // Propagate DRM render-node tracking across dup so ioctls on the duped fd
+      // are still recognized. libdrm's amdgpu_device_initialize duplicates the
+      // render fd (via fcntl64 F_DUPFD_CLOEXEC) and issues all AMDGPU_INFO ioctls
+      // on the copy.
+      if (InterposerContext::ctx.is_drm(fd))
+        InterposerContext::ctx.track_drm(static_cast<int>(rc),
+                                         InterposerContext::ctx.drm_render_minor(fd));
+    }
   }
   return static_cast<int>(rc);
 }
@@ -1196,21 +1551,30 @@ RJ_INTERPOSER_EXPORT void *mmap(void *addr, size_t length, int prot, int flags, 
     return raw_mmap_syscall(addr, length, prot, flags, fd, offset);
 
   assert(InterposerContext::real().ready());
-  if (auto *remote = InterposerContext::ctx.remote_lookup(fd))
+  if (auto remote = InterposerContext::ctx.remote_lookup(fd))
     return remote->mmap(addr, length, prot, flags, offset);
 
   if (auto *drv = InterposerContext::ctx.lookup(fd))
     return drv->mmap(addr, length, prot, flags, offset);
 
-  if (InterposerContext::ctx.is_kfd_dup(fd)) {
-    if (auto *remote = InterposerContext::ctx.remote_lookup(InterposerContext::ctx.remote_kfd_fd()))
-      return remote->mmap(addr, length, prot, flags, offset);
-    if (auto *drv = InterposerContext::ctx.driver())
+  // Dispatch a tracked KFD dup by its RECORDED backend (as ioctl() does), not by
+  // "remote if any remote is live"; otherwise a Local-tagged dup would misroute
+  // to the remote in mixed local+daemon mode. For Remote, route via the remote
+  // snapshot directly so routing still works if the primary fd number changed.
+  if (auto backend = InterposerContext::ctx.kfd_backend_of(fd)) {
+    if (*backend == InterposerContext::DupBackend::Remote) {
+      if (auto remote = InterposerContext::ctx.remote())
+        return remote->mmap(addr, length, prot, flags, offset);
+    } else if (auto *drv = InterposerContext::ctx.driver()) {
       return drv->mmap(addr, length, prot, flags, offset);
+    }
   }
 
   if (InterposerContext::ctx.is_drm(fd)) {
-    if (auto *remote = InterposerContext::ctx.remote_lookup(InterposerContext::ctx.remote_kfd_fd()))
+    // Route via the remote snapshot (not remote_lookup(remote_kfd_fd())): a
+    // dup2/dup3 may have cleared the primary fd number while the connection is
+    // still live via other refs, and this DRM fd still belongs to that remote.
+    if (auto remote = InterposerContext::ctx.remote())
       return remote->mmap(addr, length, prot, flags, offset);
     if (auto *drv = InterposerContext::ctx.driver())
       return drv->mmap(addr, length, prot, flags, offset);
@@ -1219,18 +1583,40 @@ RJ_INTERPOSER_EXPORT void *mmap(void *addr, size_t length, int prot, int flags, 
   if (fd < 0 && (flags & MAP_FIXED) && prot != PROT_NONE && addr) {
     int memfd_out = -1;
     off_t memfd_offset = 0;
-    if (InterposerContext::ctx.remote() && InterposerContext::ctx.remote()->find_memfd_for_addr(
-                                               addr, length, &memfd_out, &memfd_offset)) {
-      auto total = static_cast<off_t>(length) + memfd_offset;
-      [[maybe_unused]] auto ft_rc = ftruncate(memfd_out, total);
-      fallocate(memfd_out, 0, memfd_offset, static_cast<off_t>(length));
-      auto *raw = InterposerContext::real().mmap(
-          addr, length, prot, (flags & ~MAP_ANONYMOUS) | MAP_SHARED, memfd_out, memfd_offset);
-      if (raw != MAP_FAILED) {
+    auto remote_memfd = InterposerContext::ctx.remote();
+    if (remote_memfd) {
+      auto lookup = remote_memfd->find_memfd_for_addr(addr, length, &memfd_out, &memfd_offset);
+      if (lookup == RemoteDriver::MemfdLookup::kDupFailed) {
+        // A daemon-shared range covered this address but we could not obtain a
+        // descriptor for it. Falling back to an anonymous mapping would silently
+        // detach it from the shared memory, so fail the mmap instead. Preserve
+        // the errno set by the failed dup (EMFILE/ENFILE/...) rather than
+        // clobbering it, so the caller sees the real failure cause.
+        return MAP_FAILED;
+      }
+      if (lookup == RemoteDriver::MemfdLookup::kFound) {
+        // memfd_out is a caller-owned dup; close it once we are done. Its
+        // validity is independent of a concurrent RemoteDriver teardown/close.
+        auto total = static_cast<off_t>(length) + memfd_offset;
+        [[maybe_unused]] auto ft_rc = ftruncate(memfd_out, total);
+        fallocate(memfd_out, 0, memfd_offset, static_cast<off_t>(length));
+        auto *raw = InterposerContext::real().mmap(
+            addr, length, prot, (flags & ~MAP_ANONYMOUS) | MAP_SHARED, memfd_out, memfd_offset);
+        // Preserve the mmap errno across close() (which may set its own).
+        int mmap_errno = errno;
+        InterposerContext::real().close(memfd_out);
+        if (raw != MAP_FAILED) {
 #ifdef MADV_POPULATE_WRITE
-        InterposerContext::real().madvise(raw, length, MADV_POPULATE_WRITE);
+          InterposerContext::real().madvise(raw, length, MADV_POPULATE_WRITE);
 #endif
-        return raw;
+          return raw;
+        }
+        // A daemon-shared range matched but the shared mapping failed. Fail
+        // closed with the real errno rather than falling through to an anonymous
+        // MAP_FIXED mapping, which would silently detach this GPUVM address from
+        // the daemon's shared memory (same invariant as kDupFailed above).
+        errno = mmap_errno;
+        return MAP_FAILED;
       }
     }
   }
@@ -1260,7 +1646,10 @@ RJ_INTERPOSER_EXPORT int munmap(void *addr, size_t length) {
     return raw_munmap_syscall(addr, length);
 
   assert(InterposerContext::real().ready());
-  if (auto *remote = InterposerContext::ctx.remote_lookup(InterposerContext::ctx.remote_kfd_fd())) {
+  // Address-based unmap: try the live remote snapshot regardless of whether the
+  // primary fd number is currently valid (a dup2/dup3 may have cleared it while
+  // the connection stays alive via other refs).
+  if (auto remote = InterposerContext::ctx.remote()) {
     int ret = remote->munmap(addr, length);
     if (ret != -ENOENT)
       return ret;
@@ -1377,13 +1766,23 @@ static std::string redirect_sys_dev_char(const char *path) {
   return drm_base + "/" + entry + suffix;
 }
 
-static const Sysfs::GpuInfo *interposer_gpu_info(uint32_t render_minor) {
+// Return the GPU metadata BY VALUE. Returning a raw pointer into the local
+// topology or the remote driver would dangle: the remote snapshot below is
+// destroyed when this function returns, so a concurrent teardown could free the
+// object while the caller still dereferenced the pointer. A copy is cheap and
+// severs that lifetime dependency.
+static std::optional<Sysfs::GpuInfo> interposer_gpu_info(uint32_t render_minor) {
   auto *drv = InterposerContext::ctx.driver();
-  if (drv)
-    return drv->gpu_info_for_render_minor(render_minor);
-  if (auto *remote = InterposerContext::ctx.remote_lookup(InterposerContext::ctx.remote_kfd_fd()))
-    return remote->gpu_info();
-  return nullptr;
+  if (drv) {
+    if (const Sysfs::GpuInfo *info = drv->gpu_info_for_render_minor(render_minor))
+      return *info;
+    return std::nullopt;
+  }
+  if (auto remote = InterposerContext::ctx.remote()) {
+    if (const Sysfs::GpuInfo *info = remote->gpu_info())
+      return *info;
+  }
+  return std::nullopt;
 }
 
 static std::string redirect_dev_dri(const char *path) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/linux_kfd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/linux_kfd.h
@@ -47,7 +47,43 @@ public:
   virtual void reset_after_fork() {}
 
   /// @brief Retain one duplicate open reference, if this driver tracks them.
-  virtual void retain_local_open() {}
+  /// @retval true A reference was added.
+  /// @retval false This driver does not track open references, or there is no
+  ///         live local process to retain (e.g. it was already torn down); the
+  ///         caller must NOT treat the fd as retained.
+  [[nodiscard]] virtual bool retain_local_open() { return false; }
+
+  /// @brief Outcome of invalidate_primary_fd(), telling the interposer how to
+  /// follow up on a dup2/dup3 that overwrote a primary KFD fd number.
+  enum class PrimaryInvalidation {
+    /// @brief @p fd is not this driver's primary (or a concurrent overwrite
+    /// already cleared it). The caller must NOT drop an open reference and should
+    /// fall through to its dup-tracking path.
+    kNotPrimary,
+    /// @brief The primary was cleared AND it held one open reference the caller
+    /// must now drop (via close()); used by drivers whose primary fd is counted
+    /// in their open-reference bookkeeping (e.g. SimulatedKfd).
+    kClearedDropRef,
+    /// @brief The primary classification was cleared, but the caller must NOT
+    /// drop an open reference: the driver's primary fd is internal and not part of
+    /// the app-facing open-reference count (e.g. GuestKfd's hidden real /dev/kfd
+    /// fd, which is kept alive by app dup references, not by the primary number).
+    kClearedKeepRefs,
+  };
+
+  /// @brief Forget the primary KFD fd number without touching process state.
+  /// @details Called by the interposer when dup2/dup3 atomically overwrites the
+  /// primary KFD fd number: the number no longer refers to this driver, so it
+  /// must stop reporting that number from fd()/owns_fd(). Default no-op for
+  /// drivers that do not expose a primary fd number this way.
+  /// @returns How the caller should follow up (see PrimaryInvalidation). Only
+  ///          kClearedDropRef asks the caller to drop the primary's open reference
+  ///          via close(), so a lost race or a driver whose primary carries no
+  ///          counted reference never triggers a double/spurious release.
+  [[nodiscard]] virtual PrimaryInvalidation invalidate_primary_fd(int fd) {
+    (void)fd;
+    return PrimaryInvalidation::kNotPrimary;
+  }
 
   /// @brief Return true when @p fd is owned internally by the driver.
   [[nodiscard]] virtual bool owns_fd(int fd) const = 0;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.cpp
@@ -112,20 +112,41 @@ Sysfs::GpuInfo gpu_info_from_rpc(const RpcGpuInfo &src) {
 
 } // namespace
 
-bool RemoteDriver::find_memfd_for_addr(void *addr, size_t length, int *memfd_out,
-                                       off_t *offset_out) {
+RemoteDriver::MemfdLookup RemoteDriver::find_memfd_for_addr(void *addr, size_t length,
+                                                            int *memfd_out, off_t *offset_out) {
   *memfd_out = -1;
   *offset_out = 0;
   auto target = reinterpret_cast<uint64_t>(addr);
   std::lock_guard<std::mutex> lock(rpc_mutex_);
   for (const auto &r : alloc_ranges_) {
-    if (target >= r.va && target + length <= r.va + r.size) {
-      *memfd_out = r.memfd;
+    // Overflow-safe containment test for [target, target+length) within
+    // [r.va, r.va+r.size). Rearranged to subtraction so neither target+length
+    // nor r.va+r.size can wrap uint64_t and admit an out-of-range address.
+    if (target >= r.va && length <= r.size && target - r.va <= r.size - length) {
+      // Return a DUP of the memfd, not the stored fd, so the caller owns a
+      // descriptor whose lifetime is independent of this RemoteDriver. Without
+      // this, a concurrent last-close -> RemoteDriver::close() (which closes the
+      // stored handle_memfds_ fds) could close the fd between this return and the
+      // caller's ftruncate/fallocate/mmap, operating on a closed/reused fd. The
+      // dup is taken under rpc_mutex_, the same lock close() holds, so the stored
+      // fd is guaranteed still open here. The caller MUST close the returned fd.
+      int dup_fd = static_cast<int>(syscall(SYS_fcntl, r.memfd, F_DUPFD_CLOEXEC, 0));
+      if (dup_fd < 0) {
+        // The range matched but we could not hand out a descriptor. Report this
+        // distinctly so the caller fails the mmap rather than silently falling
+        // back to an anonymous mapping and breaking the shared-memory invariant.
+        // The dup's errno (EMFILE/ENFILE/...) reaches the caller: the only code
+        // that runs before this returns is the rpc_mutex_ lock_guard unlock, and
+        // pthread_mutex_unlock does not touch errno on success. Do not add any
+        // errno-setting call after this point without saving/restoring it.
+        return MemfdLookup::kDupFailed;
+      }
+      *memfd_out = dup_fd;
       *offset_out = static_cast<off_t>(target - r.va);
-      return true;
+      return MemfdLookup::kFound;
     }
   }
-  return false;
+  return MemfdLookup::kNotFound;
 }
 
 RemoteDriver::RemoteDriver(int sock_fd) : sock_(sock_fd) {
@@ -200,6 +221,10 @@ int RemoteDriver::open() {
       return -1;
   }
 
+  return reissue_synthetic_kfd_fd();
+}
+
+int RemoteDriver::reissue_synthetic_kfd_fd() {
   // Create a high-numbered synthetic KFD fd to avoid collisions with ROCR's
   // internal fd lifecycle. Use the top of the current rlimit range (same
   // approach as SimulatedKfd::init_reserved_fd_range).
@@ -211,7 +236,10 @@ int RemoteDriver::open() {
   auto raw_fd = static_cast<int>(syscall(SYS_memfd_create, "rocjitsu_remote_kfd", MFD_CLOEXEC));
   if (raw_fd < 0)
     return -1;
-  int fd = fcntl(raw_fd, F_DUPFD_CLOEXEC, fd_min);
+  // Use the raw syscall, not fcntl(): this shared object exports an interposed
+  // fcntl with default visibility, so an unqualified call would re-enter the
+  // shim (reserve_dup_backend/untrack_dup, fd_mutex_) for a plain memfd dup.
+  int fd = static_cast<int>(syscall(SYS_fcntl, raw_fd, F_DUPFD_CLOEXEC, fd_min));
   syscall(SYS_close, raw_fd);
   return fd;
 }
@@ -243,18 +271,29 @@ int RemoteDriver::close() {
     }
     handle_memfds_.clear();
     alloc_ranges_.clear();
-    topology_path_.clear();
-    drm_path_.clear();
-    gpu_info_ = {};
-    has_gpu_info_ = false;
+    // Deliberately do NOT clear the handshake metadata (topology_path_,
+    // drm_path_, gpu_info_, has_gpu_info_). It is written once during open() and
+    // is immutable for the rest of the object's life. The interposer publishes
+    // this RemoteDriver via an atomic shared_ptr and lets lock-free readers take
+    // snapshots that call the accessors (topology_path(), drm_path(),
+    // gpu_info()); a racing teardown clears the atomic and calls close() while
+    // such a snapshot may still be live. Clearing these strings/structs here
+    // would be a data race against those readers. Keeping the metadata
+    // immutable-after-open makes the reads safe without a lock; the storage is
+    // reclaimed when the last shared_ptr drops.
   }
 
   return 0;
 }
 
 int RemoteDriver::ioctl(unsigned long request, void *arg) {
-  assert(sock_ >= 0 && "ioctl called on disconnected RemoteDriver");
   assert(arg && "ioctl called with null arg");
+  // Do NOT assert(sock_ >= 0) here: sock_ is guarded by rpc_mutex_ and a
+  // concurrent teardown_remote() -> close() can set it to -1 while another
+  // thread holds a live shared_ptr snapshot and is entering this call. Reading
+  // sock_ unlocked would be a data race (and would abort in Debug on exactly the
+  // teardown-vs-in-flight-ioctl race this design tolerates). The locked send
+  // path (send_ioctl) handles a closed socket gracefully by returning -1.
 
   // WAIT_EVENTS is handled client-side to avoid rpc_mutex_ contention.
   // Multiple ROCR threads poll WAIT_EVENTS concurrently during init. If each

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.h
@@ -46,16 +46,30 @@ public:
     return has_gpu_info_ ? &gpu_info_ : nullptr;
   }
 
+  /// @brief Outcome of find_memfd_for_addr(): distinguishes "no matching range"
+  /// from "range matched but the memfd dup failed".
+  /// @details The caller must treat these differently: kNotFound means fall back
+  /// to the normal (anonymous) mapping; kDupFailed means a daemon-shared range
+  /// DID cover the address but we could not hand out a descriptor for it (e.g.
+  /// EMFILE/ENFILE), so falling back to an anonymous mapping would silently break
+  /// the shared-memory invariant — the caller should fail the mmap instead.
+  enum class MemfdLookup { kNotFound, kFound, kDupFailed };
+
   /// @brief Find a stored memfd that covers the given GPUVM address.
   /// @details Used by the interposer to intercept anonymous MAP_FIXED at
   /// addresses that have daemon-shared memfd mappings.
   /// @param addr The target address to look up.
   /// @param length The mapping length.
-  /// @param[out] memfd_out The memfd covering this address.
-  /// @param[out] memfd_offset The offset within the memfd.
-  /// @returns true if a matching allocation was found.
-  [[nodiscard]] bool find_memfd_for_addr(void *addr, size_t length, int *memfd_out,
-                                         off_t *memfd_offset);
+  /// @param[out] memfd_out On kFound, a NEWLY DUP'd memfd covering this address.
+  ///             The caller OWNS this descriptor and MUST close() it after use;
+  ///             it is a dup (taken under the RPC lock) so its lifetime is
+  ///             independent of this RemoteDriver and a concurrent close() cannot
+  ///             invalidate it mid-use.
+  /// @param[out] memfd_offset On kFound, the offset within the memfd.
+  /// @returns kFound if a range matched and the dup succeeded; kDupFailed if a
+  ///          range matched but the dup failed; kNotFound if no range matched.
+  [[nodiscard]] MemfdLookup find_memfd_for_addr(void *addr, size_t length, int *memfd_out,
+                                                off_t *memfd_offset);
 
   /// @brief Perform the RPC handshake with the daemon.
   /// @details Sends RPC_HANDSHAKE, receives the topology path and gpu_id,
@@ -63,6 +77,14 @@ public:
   /// @retval >=0 Synthetic KFD fd on success.
   /// @retval -1 Handshake failed (socket error or daemon rejected).
   int open() override;
+
+  /// @brief Mint a fresh synthetic KFD fd WITHOUT reconnecting or re-handshaking.
+  /// @details Used when the interposer's cached primary fd number was lost (e.g.
+  /// dup2 overwrote it) but the RPC connection is still live and must keep a
+  /// valid primary fd number to hand back to open("/dev/kfd"). Unlike open(),
+  /// this performs no RPC and does not disturb the connection/metadata.
+  /// @retval >=0 A new synthetic KFD fd. @retval -1 memfd creation failed.
+  [[nodiscard]] int reissue_synthetic_kfd_fd();
 
   /// @brief Send RPC_CLOSE to the daemon.
   /// @retval 0 Success.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
@@ -190,6 +190,21 @@ bool SimulatedKfd::is_doorbell_range(const void *addr, size_t length) const {
   return query_base < end && query_end > base;
 }
 
+bool SimulatedKfd::ensure_fd_created() {
+  if (fd_.load(std::memory_order_acquire) >= 0)
+    return true;
+  int new_fd = static_cast<int>(syscall(SYS_memfd_create, "rocjitsu_kfd", 0));
+  if (new_fd < 0)
+    return false;
+  int expected = -1;
+  // CAS so only one racing opener publishes the backing memfd; a loser closes
+  // its own memfd and adopts the winner's, avoiding a double create / fd leak.
+  if (!fd_.compare_exchange_strong(expected, new_fd, std::memory_order_acq_rel,
+                                   std::memory_order_acquire))
+    syscall(SYS_close, new_fd);
+  return true;
+}
+
 int SimulatedKfd::open() {
   static std::once_flag raise_nofile_flag;
   std::call_once(raise_nofile_flag, [] {
@@ -200,16 +215,17 @@ int SimulatedKfd::open() {
     }
   });
 
-  if (fd_ < 0) {
-    fd_ = static_cast<int>(syscall(SYS_memfd_create, "rocjitsu_kfd", 0));
-    if (fd_ < 0)
-      return -1;
-  }
-
+  // Hold process_mutex_ across fd creation, process selection/retain, and the
+  // returned fd load so a racing dup2 (which invalidates fd_ via
+  // invalidate_primary_fd, also under process_mutex_) cannot clear fd_ between
+  // publishing it and returning it. Either open() completes and returns a valid
+  // fd, or invalidation wins first and ensure_fd_created() re-mints one below.
   std::lock_guard<std::mutex> lk(process_mutex_);
+  if (!ensure_fd_created())
+    return -1;
   if (!daemon_mode_ && local_process_id_ != 0 && processes_.contains(local_process_id_)) {
     processes_[local_process_id_]->retain_open();
-    return fd_;
+    return fd_.load(std::memory_order_acquire);
   }
   uint32_t pid = next_process_id_++;
   auto proc = std::make_shared<KfdProcess>(pid, static_cast<uint32_t>(gpus_.size()));
@@ -272,7 +288,7 @@ int SimulatedKfd::open() {
     g.cps_initialized = true;
   }
 
-  return fd_;
+  return fd_.load(std::memory_order_acquire);
 }
 
 void SimulatedKfd::set_process_client_pid(uint32_t process_id, pid_t client_pid) {
@@ -288,15 +304,15 @@ void SimulatedKfd::set_process_client_pid(uint32_t process_id, pid_t client_pid)
 }
 
 uint32_t SimulatedKfd::open_process(pid_t client_pid) {
-  if (fd_ < 0) {
-    fd_ = static_cast<int>(syscall(SYS_memfd_create, "rocjitsu_kfd", 0));
-    if (fd_ < 0)
-      return 0;
-  }
-
   uint32_t pid;
   {
     std::lock_guard<std::mutex> lk(process_mutex_);
+    // Create the backing fd under process_mutex_ so both entry points
+    // (open()/open_process()) serialize fd creation and never publish two
+    // different memfds; ensure_fd_created() itself CASes so it is also safe from
+    // any lock-free caller.
+    if (!ensure_fd_created())
+      return 0;
     // Client-PID process reuse (and its matching retain) is a daemon-mode
     // feature: multiple client opens of the same PID share one process and
     // balance against multiple close()/release_open() calls. Gating reuse on
@@ -377,13 +393,31 @@ uint32_t SimulatedKfd::open_process(pid_t client_pid) {
   return pid;
 }
 
-void SimulatedKfd::retain_local_open() {
+LinuxKfd::PrimaryInvalidation SimulatedKfd::invalidate_primary_fd(int fd) {
+  if (fd < 0)
+    return PrimaryInvalidation::kNotPrimary;
+  // Serialize with open()/open_process(), which hold process_mutex_ across fd
+  // creation and the returned-fd load, so this cannot clear fd_ mid-open.
+  std::lock_guard<std::mutex> lk(process_mutex_);
+  int expected = fd;
+  // The local primary fd holds one counted open reference, so on a successful
+  // clear the caller must drop it (kClearedDropRef). Report kNotPrimary if a
+  // concurrent overwrite already cleared fd_, so the caller does not double
+  // release.
+  if (fd_.compare_exchange_strong(expected, -1, std::memory_order_acq_rel))
+    return PrimaryInvalidation::kClearedDropRef;
+  return PrimaryInvalidation::kNotPrimary;
+}
+
+bool SimulatedKfd::retain_local_open() {
   std::lock_guard<std::mutex> lk(process_mutex_);
   if (local_process_id_ == 0)
-    return;
+    return false;
   auto it = processes_.find(local_process_id_);
-  if (it != processes_.end())
-    it->second->retain_open();
+  if (it == processes_.end())
+    return false;
+  it->second->retain_open();
+  return true;
 }
 
 uint32_t SimulatedKfd::local_open_ref_count() const {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.h
@@ -18,6 +18,7 @@ RJ_DIAGNOSTIC_IGNORE_PEDANTIC
 #include "linux/uapi/kfd_ioctl.h"
 RJ_DIAGNOSTIC_POP
 
+#include <atomic>
 #include <cstdint>
 #include <memory>
 #include <mutex>
@@ -81,8 +82,10 @@ public:
   /// @details Used by the interposer when an existing KFD fd is duplicated
   /// (dup/dup2/dup3/fcntl F_DUPFD). Each live fd holds one reference so the
   /// process is torn down only when the last fd is closed, not the first.
-  /// No-op when there is no local process (e.g. daemon/remote mode).
-  void retain_local_open() override;
+  /// @retval true A reference was added.
+  /// @retval false No local process to retain (e.g. it was already torn down, or
+  ///         daemon/remote mode); the caller must NOT treat the fd as retained.
+  [[nodiscard]] bool retain_local_open() override;
   int ioctl(unsigned long request, void *arg) override;
   void *mmap(void *addr, size_t length, int prot, int flags, off_t offset) override;
   int munmap(void *addr, size_t length) override;
@@ -117,8 +120,25 @@ public:
   const Sysfs &topology() const { return topology_; }
   std::string topology_path() const override { return topology_.path(); }
   std::string drm_path() const override { return topology_.drm_path(); }
-  [[nodiscard]] int fd() const override { return fd_; }
+  [[nodiscard]] int fd() const override { return fd_.load(std::memory_order_acquire); }
   [[nodiscard]] uint32_t local_process_id() const { return local_process_id_; }
+
+  /// @brief Forget the primary KFD fd number without touching the process.
+  /// @details Used by the interposer when dup2/dup3 atomically overwrites the
+  /// primary KFD fd number: the number no longer refers to this driver, so stop
+  /// classifying it as the local primary (fd() must no longer match it). Only
+  /// clears if @p fd matches the current primary, so a stale call is a no-op.
+  /// @returns kClearedDropRef if @p fd matched and was cleared (the local primary
+  ///          holds one counted open reference, so the caller drops it via
+  ///          close()); kNotPrimary if it did not match (a concurrent overwrite
+  ///          won the race), so the caller must not release a reference.
+  /// @details Runs under process_mutex_ so the CAS on fd_ is serialized with
+  /// open()'s fd creation/selection/return: a racing dup2 can no longer clear
+  /// fd_ in the window between open() publishing it and open() returning it, so
+  /// open() never hands back -1 or an already-overwritten descriptor. Lock-free
+  /// readers (driver_fd()/kfd_backend_of()/is_kfd_primary()) still observe fd_
+  /// atomically.
+  [[nodiscard]] PrimaryInvalidation invalidate_primary_fd(int fd) override;
 
   /// @brief Open-reference count of the local process, or 0 if none is alive.
   /// @details Introspection for tests/diagnostics. Each live KFD fd (the primary
@@ -202,9 +222,15 @@ private:
   int get_tile_config_ioctl(void *arg);
   bool allocate_scratch_backing(uint32_t process_id, uint64_t gpu_va, size_t size);
 
+  /// @brief Lazily create the backing memfd exactly once across racing opens.
+  /// @details CAS-publishes fd_ so concurrent open()/open_process() callers agree
+  /// on a single memfd; losers close their own and adopt the winner's.
+  /// @retval true fd_ holds a valid descriptor. @retval false memfd_create failed.
+  [[nodiscard]] bool ensure_fd_created();
+
   std::vector<GpuDevice> gpus_;
   bool daemon_mode_ = false;
-  int fd_ = -1;
+  std::atomic<int> fd_{-1};
 
   /// @brief Process table mapping process_id to KfdProcess.
   /// @details Protected by process_mutex_ for concurrent daemon access.

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -614,11 +614,21 @@ if(RJ_HAS_GFX1201_GPU)
             --gtest_filter=GuestKfdMemoryTest.GuestAllocationMmapOffsetIsRejected
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
+    add_test(
+        NAME "GuestKfdFdReuseTest.OverwritingHiddenRealFdKeepsRoutingCorrect"
+        COMMAND
+            ${RJ_CLI} --config
+            ${CMAKE_SOURCE_DIR}/configs/guest_gfx950_on_gfx1201.json --
+            $<TARGET_FILE:guest_kfd_test>
+            --gtest_filter=GuestKfdFdReuseTest.OverwritingHiddenRealFdKeepsRoutingCorrect
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
     set_tests_properties(
         "GuestKfdMultiprocessTest.ForkedChildrenDoNotRemoveParentOverlay"
         "GuestKfdMultiprocessTest.ForkedChildDropsInheritedGuestDriverBeforeReopen"
         "GuestKfdConcurrencyTest.ConcurrentOpenIoctlAndSysfsRedirect"
         "GuestKfdMemoryTest.GuestAllocationMmapOffsetIsRejected"
+        "GuestKfdFdReuseTest.OverwritingHiddenRealFdKeepsRoutingCorrect"
         PROPERTIES TIMEOUT 60 SKIP_REGULAR_EXPRESSION "\\[  SKIPPED \\]"
     )
     foreach(
@@ -629,6 +639,7 @@ if(RJ_HAS_GFX1201_GPU)
             "GuestKfdMultiprocessTest.ForkedChildDropsInheritedGuestDriverBeforeReopen"
             "GuestKfdConcurrencyTest.ConcurrentOpenIoctlAndSysfsRedirect"
             "GuestKfdMemoryTest.GuestAllocationMmapOffsetIsRejected"
+            "GuestKfdFdReuseTest.OverwritingHiddenRealFdKeepsRoutingCorrect"
     )
         rj_set_default_runtime_dir("${_guest_kfd_test}")
     endforeach()
@@ -701,6 +712,55 @@ rj_add_test(
     INSTALL_ENVIRONMENT
         "LD_PRELOAD=\${RJ_INSTALLED_LIBDIR}/${CMAKE_SHARED_LIBRARY_PREFIX}rocjitsu${CMAKE_SHARED_LIBRARY_SUFFIX}:bin/${CMAKE_SHARED_LIBRARY_PREFIX}early_mmap_preload${CMAKE_SHARED_LIBRARY_SUFFIX}"
 )
+
+# --- interposer dup/backend bookkeeping test (CLI launcher) ---
+# Runs a small gtest binary via the rocjitsu CLI launcher (which preloads the
+# interposer and writes the config_path file it reads) so open("/dev/kfd") is
+# serviced by the simulated driver, then exercises dup/dup2/dup3/fcntl(F_DUPFD)
+# fd tracking that the SimulatedKfd-level unit tests cannot reach.
+add_executable(interposer_dup_test interposer_dup_test.cpp)
+rj_configure_target(interposer_dup_test TEST)
+target_include_directories(
+    interposer_dup_test
+    PRIVATE ${CMAKE_SOURCE_DIR}/lib/rocjitsu/external_headers/hsa_headers
+)
+target_link_libraries(interposer_dup_test PRIVATE GTest::gtest_main)
+add_dependencies(interposer_dup_test rocjitsu_bin rocjitsu_shared)
+if(RJ_INSTALL_TESTS)
+    rj_install_test_target(interposer_dup_test)
+endif()
+foreach(
+    _interposer_dup_test
+    IN
+    ITEMS
+        DupKeepsKfdRoutingAfterPrimaryClose
+        FcntlDupfdKeepsKfdRouting
+        Dup2OverPrimaryInvalidatesKfdIdentity
+        Dup2OntoFreshFdRoutesKfd
+        Dup3RoutesKfdAndRejectsSameFd
+        ReopenAfterPrimaryOverwriteKeepsBackend
+        SerializedReopenUnderContentionStaysRoutable
+)
+    rj_add_test(
+        NAME "InterposerDupTest.${_interposer_dup_test}"
+        COMMAND
+            ${RJ_CLI}
+            --config
+            ${RJ_CDNA4_KMD_CONFIG}
+            --
+            $<TARGET_FILE:interposer_dup_test>
+            "--gtest_filter=InterposerDupTest.${_interposer_dup_test}"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        SKIP_REGULAR_EXPRESSION "\\[  SKIPPED \\]"
+        INSTALL_COMMAND
+            "\${RJ_INSTALLED_BINDIR}/rocjitsu"
+            "--config"
+            "\${RJ_INSTALLED_CONFIG_DIR}/${RJ_CDNA4_KMD_CONFIG_NAME}"
+            "--"
+            "bin/interposer_dup_test"
+            "--gtest_filter=InterposerDupTest.${_interposer_dup_test}"
+    )
+endforeach()
 
 # --- rocminfo test (requires rocminfo binary + HSA runtime + CLI launcher) ---
 # Spawns rocminfo via the rocjitsu CLI and validates output.
@@ -1471,6 +1531,7 @@ if(RJ_ENABLE_HIP_TESTS)
                 RJ_HIP_VECTOR_ADD_BIN="${CMAKE_CURRENT_BINARY_DIR}/hip_vector_add_test"
                 RJ_HIP_MEMCPY_BIN="${CMAKE_CURRENT_BINARY_DIR}/hip_memcpy_test"
                 RJ_HIP_RCCL_BIN="${CMAKE_CURRENT_BINARY_DIR}/hip_rccl_test"
+                RJ_INTERPOSER_DUP_BIN="$<TARGET_FILE:interposer_dup_test>"
                 RJ_INSTALLED_DAEMON_BIN="${_rj_installed_rocjitsu_bin}"
                 RJ_INSTALLED_DAEMON_CONFIG="${_rj_installed_daemon_config}"
                 RJ_INSTALLED_DAEMON_CONFIG_2GPU="${_rj_installed_daemon_config_2gpu}"
@@ -1478,6 +1539,7 @@ if(RJ_ENABLE_HIP_TESTS)
                 RJ_INSTALLED_HIP_VECTOR_ADD_BIN="hip_vector_add_test"
                 RJ_INSTALLED_HIP_MEMCPY_BIN="hip_memcpy_test"
                 RJ_INSTALLED_HIP_RCCL_BIN="hip_rccl_test"
+                RJ_INSTALLED_INTERPOSER_DUP_BIN="interposer_dup_test"
         )
         target_link_libraries(daemon_test PRIVATE GTest::gtest_main)
         add_dependencies(
@@ -1485,6 +1547,7 @@ if(RJ_ENABLE_HIP_TESTS)
             rocjitsu_bin
             hip_vector_add_test_target
             hip_memcpy_test_target
+            interposer_dup_test
         )
         if(RJ_INSTALL_TESTS)
             rj_install_test_target(daemon_test)
@@ -1495,6 +1558,10 @@ if(RJ_ENABLE_HIP_TESTS)
             DaemonTest.HipMemcpyRoundTripInt
             DaemonTest.HipMemcpyDeviceToDevice
             DaemonTest.TwoIndependentClients
+            DaemonTest.InterposerDupReopenAfterPrimaryOverwriteRemote
+            DaemonTest.InterposerDupSerializedReopenUnderContentionRemote
+            DaemonTest.InterposerDupKeepsRoutingAfterPrimaryCloseRemote
+            DaemonTest.InterposerDup2OverPrimaryInvalidatesRemote
         )
         foreach(TC IN LISTS RJ_DAEMON_TESTS)
             rj_add_test(

--- a/emulation/rocjitsu/tests/daemon_test.cpp
+++ b/emulation/rocjitsu/tests/daemon_test.cpp
@@ -55,6 +55,7 @@ struct TestPaths {
   std::string hip_vector_add_bin = RJ_HIP_VECTOR_ADD_BIN;
   std::string hip_memcpy_bin = RJ_HIP_MEMCPY_BIN;
   std::string hip_rccl_bin = RJ_HIP_RCCL_BIN;
+  std::string interposer_dup_bin = RJ_INTERPOSER_DUP_BIN;
 };
 
 std::filesystem::path resolve_relative_to_exe(const std::filesystem::path &exe_dir,
@@ -74,12 +75,18 @@ std::filesystem::path current_exe_dir() {
 }
 
 bool installed_paths_exist(const TestPaths &paths) {
+  // Only the UNCONDITIONALLY-built artifacts are required here. hip_rccl_bin is
+  // deliberately excluded: the RCCL test binary (and the RcclDaemonTest cases
+  // that use it) are built/registered only when RCCL_LIB is found at configure
+  // time, so requiring it would make this check fail on non-RCCL installs and
+  // wrongly fall back to build-tree paths that a pure install does not have.
   return std::filesystem::exists(paths.daemon_bin) &&
          std::filesystem::exists(paths.daemon_config) &&
          std::filesystem::exists(paths.daemon_config_2gpu) &&
          std::filesystem::exists(paths.preload_lib) &&
          std::filesystem::exists(paths.hip_vector_add_bin) &&
-         std::filesystem::exists(paths.hip_memcpy_bin);
+         std::filesystem::exists(paths.hip_memcpy_bin) &&
+         std::filesystem::exists(paths.interposer_dup_bin);
 }
 
 TestPaths installed_paths(const std::filesystem::path &exe_dir) {
@@ -91,6 +98,7 @@ TestPaths installed_paths(const std::filesystem::path &exe_dir) {
       resolve_relative_to_exe(exe_dir, RJ_INSTALLED_HIP_VECTOR_ADD_BIN).string(),
       resolve_relative_to_exe(exe_dir, RJ_INSTALLED_HIP_MEMCPY_BIN).string(),
       resolve_relative_to_exe(exe_dir, RJ_INSTALLED_HIP_RCCL_BIN).string(),
+      resolve_relative_to_exe(exe_dir, RJ_INSTALLED_INTERPOSER_DUP_BIN).string(),
   };
 }
 
@@ -120,6 +128,8 @@ const char *hip_vector_add_bin() { return test_paths().hip_vector_add_bin.c_str(
 const char *hip_memcpy_bin() { return test_paths().hip_memcpy_bin.c_str(); }
 
 const char *hip_rccl_bin() { return test_paths().hip_rccl_bin.c_str(); }
+
+const char *interposer_dup_bin() { return test_paths().interposer_dup_bin.c_str(); }
 
 class DaemonTest : public ::testing::Test {
 protected:
@@ -303,6 +313,39 @@ TEST_F(DaemonTest, TwoIndependentClients) {
 
   EXPECT_EQ(r1.exit_code, 0) << "Client 1 (vector_add):\n" << r1.output;
   EXPECT_EQ(r2.exit_code, 0) << "Client 2 (memcpy):\n" << r2.output;
+}
+
+// --- Remote-backend dup/backend bookkeeping ---
+//
+// Runs the interposer dup/dup2/dup3 regression binary against a live daemon, so
+// open("/dev/kfd") is serviced by the RemoteDriver (Remote backend) rather than
+// the in-process SimulatedKfd. This gives the fd/backend state machine coverage
+// on the remote path — the primary-fd re-mint (reissue_synthetic_kfd_fd) and the
+// invalidation-vs-open serialization — which the CLI-launched (local) variant of
+// the same tests cannot reach.
+
+TEST_F(DaemonTest, InterposerDupReopenAfterPrimaryOverwriteRemote) {
+  auto r = run_hip_test(interposer_dup_bin(),
+                        "InterposerDupTest.ReopenAfterPrimaryOverwriteKeepsBackend");
+  EXPECT_EQ(r.exit_code, 0) << r.output;
+}
+
+TEST_F(DaemonTest, InterposerDupSerializedReopenUnderContentionRemote) {
+  auto r = run_hip_test(interposer_dup_bin(),
+                        "InterposerDupTest.SerializedReopenUnderContentionStaysRoutable");
+  EXPECT_EQ(r.exit_code, 0) << r.output;
+}
+
+TEST_F(DaemonTest, InterposerDupKeepsRoutingAfterPrimaryCloseRemote) {
+  auto r =
+      run_hip_test(interposer_dup_bin(), "InterposerDupTest.DupKeepsKfdRoutingAfterPrimaryClose");
+  EXPECT_EQ(r.exit_code, 0) << r.output;
+}
+
+TEST_F(DaemonTest, InterposerDup2OverPrimaryInvalidatesRemote) {
+  auto r =
+      run_hip_test(interposer_dup_bin(), "InterposerDupTest.Dup2OverPrimaryInvalidatesKfdIdentity");
+  EXPECT_EQ(r.exit_code, 0) << r.output;
 }
 
 // --- RCCL collective tests (2-GPU daemon) ---

--- a/emulation/rocjitsu/tests/guest_kfd_test.cpp
+++ b/emulation/rocjitsu/tests/guest_kfd_test.cpp
@@ -271,4 +271,75 @@ TEST(GuestKfdMemoryTest, GuestAllocationMmapOffsetIsRejected) {
   close(fd);
 }
 
+// Overwriting the interposer's hidden real /dev/kfd fd number via dup2 must not
+// leave a stale KFD classification behind. In guest/DBT mode open("/dev/kfd")
+// returns an app-facing dup while the real fd stays internal; if some dup2/dup3
+// target reuses that hidden number, the interposer must stop routing KFD ioctls
+// on it (GuestKfd::invalidate_primary_fd clears real_kfd_fd_ + ready_), and app
+// dups plus fresh opens must keep working via a lazily reopened real fd.
+//
+// The hidden fd number is not directly observable, so this brute-forces the
+// candidate space: it dup2's a pipe end over every low fd number (skipping the
+// ones the test itself owns). Whichever number was the hidden real fd gets
+// overwritten; the invariant under test is that KFD routing stays correct
+// regardless of which number that was.
+TEST(GuestKfdFdReuseTest, OverwritingHiddenRealFdKeepsRoutingCorrect) {
+  if (access(kKfdPath, R_OK | W_OK) != 0)
+    GTEST_SKIP() << kKfdPath << " is not available: " << std::strerror(errno);
+
+  auto version_ok = [](int f) {
+    kfd_ioctl_get_version_args version{};
+    return ioctl(f, AMDKFD_IOC_GET_VERSION, &version) == 0;
+  };
+
+  int app_fd = open(kKfdPath, O_RDWR | O_CLOEXEC);
+  ASSERT_GE(app_fd, 0);
+  if (!guest_gpu_is_visible()) {
+    close(app_fd);
+    FAIL() << "guest GPU overlay is not visible";
+  }
+  ASSERT_TRUE(version_ok(app_fd));
+
+  // A second app-facing dup holds the guest process open across the overwrite.
+  int keeper = dup(app_fd);
+  ASSERT_GE(keeper, 0);
+  ASSERT_TRUE(version_ok(keeper));
+
+  int pipefd[2];
+  ASSERT_EQ(pipe(pipefd), 0);
+
+  // Overwrite every low fd number except the ones this test owns. Whichever
+  // number is the interposer's hidden real /dev/kfd fd gets clobbered here,
+  // driving invalidate_primary_fd() on that backend.
+  constexpr int kMaxProbeFd = 64;
+  for (int target = 3; target < kMaxProbeFd; ++target) {
+    if (target == app_fd || target == keeper || target == pipefd[0] || target == pipefd[1])
+      continue;
+    // dup2 onto an unopened number just creates a new dup of the pipe read end;
+    // onto an open number it atomically closes the old one first. Either way the
+    // target now names the pipe, not KFD.
+    if (dup2(pipefd[0], target) != target)
+      continue;
+    // The overwritten number must never route KFD ioctls.
+    EXPECT_FALSE(version_ok(target)) << "fd " << target << " still routed KFD after dup2 overwrite";
+    close(target);
+  }
+
+  // The surviving app dup must still route KFD, and a fresh open must succeed
+  // (the interposer lazily reopens the hidden real fd if it was the clobbered
+  // number), still seeing the guest overlay.
+  EXPECT_TRUE(version_ok(keeper)) << "keeper dup stopped routing after hidden-fd overwrite";
+
+  int reopened = open(kKfdPath, O_RDWR | O_CLOEXEC);
+  ASSERT_GE(reopened, 0) << "reopen after hidden-fd overwrite failed: " << std::strerror(errno);
+  EXPECT_TRUE(version_ok(reopened));
+  EXPECT_TRUE(guest_gpu_is_visible());
+
+  close(reopened);
+  close(keeper);
+  close(app_fd);
+  close(pipefd[0]);
+  close(pipefd[1]);
+}
+
 } // namespace

--- a/emulation/rocjitsu/tests/interposer_dup_test.cpp
+++ b/emulation/rocjitsu/tests/interposer_dup_test.cpp
@@ -1,0 +1,290 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file interposer_dup_test.cpp
+/// @brief LD_PRELOAD regression tests for the interposer's KFD fd/backend
+///        bookkeeping across dup / dup2 / dup3 / fcntl(F_DUPFD).
+///
+/// @details These run with librocjitsu.so preloaded (see the ENVIRONMENT set in
+/// tests/CMakeLists.txt) so that open("/dev/kfd") is serviced by the simulated
+/// KFD driver. AMDKFD_IOC_GET_VERSION is used purely as a routing probe: it
+/// succeeds (returns 0 and fills the version) only when the fd is routed to a
+/// KFD backend, and fails when the fd falls through to the real (non-KFD)
+/// descriptor. The SimulatedDriver-level unit tests (KfdIoctlTest) cannot catch
+/// these because they exercise the driver object directly, bypassing the fd
+/// tracking that lives in the interposer.
+
+#include "rocjitsu/base/rj_compiler.h"
+RJ_DIAGNOSTIC_PUSH
+RJ_DIAGNOSTIC_IGNORE_PEDANTIC
+#include "linux/uapi/kfd_ioctl.h"
+RJ_DIAGNOSTIC_POP
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cerrno>
+#include <chrono>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <thread>
+#include <unistd.h>
+
+namespace {
+
+// Issue AMDKFD_IOC_GET_VERSION on fd. Returns true if the fd routed to a KFD
+// backend (ioctl succeeded and reported the expected major version).
+bool kfd_version_ok(int fd) {
+  kfd_ioctl_get_version_args args{};
+  int rc = ioctl(fd, AMDKFD_IOC_GET_VERSION, &args);
+  return rc == 0 && args.major_version == KFD_IOCTL_MAJOR_VERSION;
+}
+
+int open_kfd() { return open("/dev/kfd", O_RDWR | O_CLOEXEC); }
+
+} // namespace
+
+// A plain dup() of the KFD fd must keep routing KFD ioctls to the driver, and
+// closing the original primary fd must not tear the process down while the dup
+// still holds a reference (dup keeps the backend alive).
+TEST(InterposerDupTest, DupKeepsKfdRoutingAfterPrimaryClose) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  EXPECT_TRUE(kfd_version_ok(kfd));
+
+  int dup_fd = dup(kfd);
+  ASSERT_GE(dup_fd, 0);
+  EXPECT_TRUE(kfd_version_ok(dup_fd));
+
+  // Close the primary; the dup must still route to the live KFD backend.
+  EXPECT_EQ(close(kfd), 0);
+  EXPECT_TRUE(kfd_version_ok(dup_fd));
+
+  EXPECT_EQ(close(dup_fd), 0);
+}
+
+// fcntl(F_DUPFD_CLOEXEC) is the dup path libdrm uses; it must also preserve KFD
+// routing on the duplicate.
+TEST(InterposerDupTest, FcntlDupfdKeepsKfdRouting) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+
+  int dup_fd = fcntl(kfd, F_DUPFD_CLOEXEC, 0);
+  ASSERT_GE(dup_fd, 0);
+  EXPECT_TRUE(kfd_version_ok(dup_fd));
+
+  EXPECT_EQ(close(dup_fd), 0);
+  // Original still routes.
+  EXPECT_TRUE(kfd_version_ok(kfd));
+  EXPECT_EQ(close(kfd), 0);
+}
+
+// dup2 that OVERWRITES the primary KFD fd number must invalidate the old primary
+// identity: after dup2(other, kfd) the kfd number now names 'other', so KFD
+// ioctls on it must NOT be routed to the (now-replaced) KFD backend, and closing
+// it must behave like closing a normal fd.
+TEST(InterposerDupTest, Dup2OverPrimaryInvalidatesKfdIdentity) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  EXPECT_TRUE(kfd_version_ok(kfd));
+
+  // A plain pipe fd to overwrite the primary KFD fd number with.
+  int pipefd[2];
+  ASSERT_EQ(pipe(pipefd), 0);
+
+  // Overwrite the KFD primary number with the read end of the pipe.
+  ASSERT_EQ(dup2(pipefd[0], kfd), kfd);
+
+  // The kfd number now refers to the pipe, not the KFD backend: a KFD ioctl must
+  // no longer succeed against it.
+  EXPECT_FALSE(kfd_version_ok(kfd));
+
+  // Cleanup. Closing the overwritten number closes the pipe read-end dup.
+  EXPECT_EQ(close(kfd), 0);
+  EXPECT_EQ(close(pipefd[0]), 0);
+  EXPECT_EQ(close(pipefd[1]), 0);
+}
+
+// dup2 of the KFD fd ONTO a fresh number must make the target route KFD ioctls,
+// and the reference bookkeeping must let both fds be closed without prematurely
+// destroying the backend.
+TEST(InterposerDupTest, Dup2OntoFreshFdRoutesKfd) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+
+  // Reserve a target fd number with a pipe end, then dup2 the KFD fd onto it.
+  int pipefd[2];
+  ASSERT_EQ(pipe(pipefd), 0);
+  int target = pipefd[0];
+
+  ASSERT_EQ(dup2(kfd, target), target);
+  EXPECT_TRUE(kfd_version_ok(target));
+
+  // Close the primary; the dup2 target keeps the backend alive.
+  EXPECT_EQ(close(kfd), 0);
+  EXPECT_TRUE(kfd_version_ok(target));
+
+  EXPECT_EQ(close(target), 0);
+  EXPECT_EQ(close(pipefd[1]), 0);
+}
+
+// dup3 of the KFD fd onto a fresh number must route KFD ioctls to the target,
+// and dup3(fd, fd, flags) must fail with EINVAL without disturbing tracking (the
+// interposer's reserve/reconcile path must roll back cleanly on that failure).
+TEST(InterposerDupTest, Dup3RoutesKfdAndRejectsSameFd) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  EXPECT_TRUE(kfd_version_ok(kfd));
+
+  // dup3(fd, fd, ...) is required to fail with EINVAL and leave fd untouched.
+  errno = 0;
+  EXPECT_EQ(dup3(kfd, kfd, O_CLOEXEC), -1);
+  EXPECT_EQ(errno, EINVAL);
+  // The primary must still route after the rejected dup3 (no tracking disturbed).
+  EXPECT_TRUE(kfd_version_ok(kfd));
+
+  // dup3 onto a fresh number routes KFD, and both fds close cleanly.
+  int pipefd[2];
+  ASSERT_EQ(pipe(pipefd), 0);
+  int target = pipefd[0];
+  ASSERT_EQ(dup3(kfd, target, O_CLOEXEC), target);
+  EXPECT_TRUE(kfd_version_ok(target));
+
+  EXPECT_EQ(close(kfd), 0);
+  EXPECT_TRUE(kfd_version_ok(target)); // dup3 target keeps the backend alive.
+
+  EXPECT_EQ(close(target), 0);
+  EXPECT_EQ(close(pipefd[1]), 0);
+}
+
+// Overwriting the primary KFD fd number via dup2 while a dup keeps the backend
+// alive must (a) leave the dup routing, and (b) let a fresh open("/dev/kfd")
+// return a valid, routable KFD fd. This is the reopen-after-overwrite path that
+// re-mints the primary fd number (remote: reissue_synthetic_kfd_fd under
+// remote_mutex_; local: ensure_fd_created under process_mutex_) without
+// disturbing the still-live backend the dup holds. Runs identically on the local
+// and daemon (remote) harnesses.
+TEST(InterposerDupTest, ReopenAfterPrimaryOverwriteKeepsBackend) {
+  int kfd = open_kfd();
+  ASSERT_GE(kfd, 0);
+  EXPECT_TRUE(kfd_version_ok(kfd));
+
+  // A dup keeps the backend alive across the primary's overwrite.
+  int keeper = dup(kfd);
+  ASSERT_GE(keeper, 0);
+  EXPECT_TRUE(kfd_version_ok(keeper));
+
+  // Overwrite the primary fd number with an unrelated pipe end. After dup2 the
+  // kfd number aliases the pipe read-end, so pipefd[0] is redundant and must be
+  // closed to avoid leaking a descriptor across the other tests in this process.
+  int pipefd[2];
+  ASSERT_EQ(pipe(pipefd), 0);
+  ASSERT_EQ(dup2(pipefd[0], kfd), kfd);
+  EXPECT_EQ(close(pipefd[0]), 0);
+  // The overwritten number now names the pipe, not the KFD backend.
+  EXPECT_FALSE(kfd_version_ok(kfd));
+  // The dup still routes: the backend stayed alive.
+  EXPECT_TRUE(kfd_version_ok(keeper));
+
+  // A fresh open must return a valid, routable KFD fd (re-minted primary).
+  int kfd2 = open_kfd();
+  ASSERT_GE(kfd2, 0) << "reopen after primary overwrite returned " << kfd2;
+  EXPECT_TRUE(kfd_version_ok(kfd2));
+
+  EXPECT_EQ(close(kfd2), 0);
+  EXPECT_EQ(close(keeper), 0);
+  EXPECT_EQ(close(kfd), 0); // closes the pipe-read dup installed over the number
+  EXPECT_EQ(close(pipefd[1]), 0);
+}
+
+// Serialized reopen-after-overwrite under contention. The interposer keeps a
+// single primary KFD fd slot, so a distinct dup (keeper) holds the backend alive
+// while the main thread repeatedly overwrites the primary fd number and reopens
+// "/dev/kfd" — always exactly one primary at a time, matching how a real client
+// uses /dev/kfd. A background thread churns dup/close on the keeper so backend
+// retain/release runs concurrently with invalidation + reopen. With invalidation
+// and open serialized on the same lock (remote_mutex_ / process_mutex_), every
+// reopen must return a routable KFD fd — never -1 or a reused non-KFD descriptor
+// (the ENOTTY case the review reproduced). This is the invariant asserted here,
+// and it holds on both the local (process_mutex_) and daemon/remote
+// (remote_mutex_) harnesses. Note: the keeper's own routability is deliberately
+// not asserted after the loop — on the local backend a reopen rebinds the shared
+// backing fd and untracks existing dups (clear_dups), which is expected
+// local-only behavior unrelated to the reopen-routability invariant under test.
+TEST(InterposerDupTest, SerializedReopenUnderContentionStaysRoutable) {
+  int primary = open_kfd();
+  ASSERT_GE(primary, 0);
+  ASSERT_TRUE(kfd_version_ok(primary));
+  int keeper = dup(primary); // distinct number; holds the backend across reopens
+  ASSERT_GE(keeper, 0);
+  ASSERT_TRUE(kfd_version_ok(keeper));
+
+  constexpr int kIters = 500;
+  std::atomic<bool> stop{false};
+
+  // Background churn: dup the keeper and close it, exercising backend
+  // retain/release concurrently with the reopen loop below. A short yield/sleep
+  // between iterations keeps the contention window open without spinning a full
+  // core (which would add CI flakiness/timeouts under parallel test runs).
+  std::thread churn([&] {
+    while (!stop.load(std::memory_order_relaxed)) {
+      int d = dup(keeper);
+      if (d >= 0)
+        close(d);
+      std::this_thread::sleep_for(std::chrono::microseconds(50));
+    }
+  });
+
+  // Use non-fatal checks (EXPECT_*/break) rather than ASSERT_* inside the loop:
+  // the churn thread is joinable here, so a fatal assertion that returned early
+  // would skip stop/join and terminate the process. Any setup failure breaks to
+  // the shutdown path below.
+  int bad = 0;
+  bool setup_failed = false;
+  for (int i = 0; i < kIters; ++i) {
+    // Overwrite the current primary fd number with a pipe end, releasing the
+    // primary's reference (keeper keeps the backend alive). This drives
+    // invalidate_overwritten_kfd_fd() concurrently with the churn thread. After
+    // dup2 the primary number aliases the pipe read-end, so close both the
+    // now-redundant pipefd[0] and the aliased primary number, plus pipefd[1].
+    int pipefd[2];
+    if (pipe(pipefd) != 0) {
+      setup_failed = true;
+      break;
+    }
+    if (dup2(pipefd[0], primary) != primary) {
+      setup_failed = true;
+      close(pipefd[0]);
+      close(pipefd[1]);
+      break;
+    }
+    close(primary); // now the pipe-read dup installed over the number
+    close(pipefd[0]);
+    close(pipefd[1]);
+
+    // Reopen: the slot was cleared, so this must re-mint a fresh, routable
+    // primary (a distinct number from the still-open keeper).
+    primary = open_kfd();
+    if (primary < 0) {
+      ++bad;
+      primary = dup(keeper); // recover so the loop can continue overwriting
+      if (primary < 0) {     // recovery also failed under fd pressure: stop.
+        setup_failed = true;
+        break;
+      }
+      continue;
+    }
+    if (!kfd_version_ok(primary))
+      ++bad;
+  }
+
+  stop.store(true);
+  churn.join();
+
+  EXPECT_FALSE(setup_failed) << "pipe()/dup2() failed under resource pressure";
+  EXPECT_EQ(bad, 0) << "a reopen returned -1 or a non-routable fd under contention";
+  if (primary >= 0) {
+    EXPECT_EQ(close(primary), 0);
+  }
+  EXPECT_EQ(close(keeper), 0);
+}

--- a/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
+++ b/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
@@ -318,9 +318,9 @@ TEST_F(KfdIoctlTest, OpenRefcountSurvivesDupThenPrimaryClose) {
   // SetUp() already performed the primary open().
   EXPECT_EQ(driver_->local_open_ref_count(), 1u);
 
-  // Two dups of the KFD fd.
-  driver_->retain_local_open();
-  driver_->retain_local_open();
+  // Two dups of the KFD fd. Each retain must succeed while the process is live.
+  EXPECT_TRUE(driver_->retain_local_open());
+  EXPECT_TRUE(driver_->retain_local_open());
   EXPECT_EQ(driver_->local_open_ref_count(), 3u);
 
   // Closing the primary fd first must NOT tear the process down.


### PR DESCRIPTION
## Motivation

Hardens and fixes several issues with interposer concurrency to make the KFD interposer and simulated driver safe under concurrent open/close/dup/dup2/dup3/fcntl and fork, and fix a shared-memory mmap fall-through that could silently detach a mapping from the daemon.

## Technical Details

Remote driver lifetime & fd tracking:
- Snapshot the active RemoteDriver through an atomic<shared_ptr> so
  ioctl/mmap/munmap dispatch holds a lifetime-extending reference rather
  than racing a concurrent teardown; handshake metadata (topology/drm/
  gpu_info) is immutable after open() so snapshots stay valid.
- Track dup/dup2/dup3/fcntl(F_DUPFD) KFD fds in a backend map
  (Local/Remote) with reserve-before-syscall then reconcile/rollback, so
  a dup keeps its backend alive after the primary closes and an
  overwriting dup2/dup3 invalidates the old primary identity.
- Serialize remote-primary invalidation with open under remote_mutex_:
  get_or_create_remote() returns the fd captured under the lock, and
  invalidate_overwritten_kfd_fd() compare-and-clears remote_kfd_fd_
  (with the reference drop and teardown) under the same lock, so a racing
  open("/dev/kfd") can no longer return -1 or a reused non-KFD fd.
- Route KFD/DRM ioctl and mmap dispatch strictly by recorded backend and
  by live remote() snapshot; drop the legacy local-driver fallback so a
  Remote-tagged dup is never misrouted to the local driver during a
  teardown window, and only route the late-ioctl safety net when the
  backend is positively known to be Remote.

Local driver:
- Make SimulatedKfd::fd_ atomic and CAS-publish the backing memfd once
  across racing open()/open_process(), closing the loser's fd to avoid a
  double memfd_create / fd leak.
- Serialize local-primary invalidation with open() under process_mutex_;
  invalidate_primary_fd() returns whether this call cleared the primary
  so the caller drops the open reference exactly once (no double-close).

Shared-memory mmap:
- Make RemoteDriver::find_memfd_for_addr() a tri-state (kNotFound/kFound/
  kDupFailed) with an overflow-safe range check. On a matched range whose
  dup or shared mmap fails, fail the mmap closed (preserving the real
  errno) instead of falling back to an anonymous MAP_FIXED mapping, which
  would silently detach the address from the daemon's shared memory.

Fork:
- Reset remote/guest state in a forked child via atomic store(nullptr)
  (not placement-new on the live atomic) and reinitialize mutexes.

Also: use real().fcntl / raw syscalls for internal memfd dups so the
interposer does not re-enter its own fcntl hook; take a single remote
snapshot when redirecting sysfs paths so topology and drm paths cannot
be combined from different RemoteDrivers.

Testing:
- Add LD_PRELOAD interposer_dup_test coverage for dup/dup2/dup3/fcntl KFD
  fd routing, reopen-after-primary-overwrite, and a threaded reopen-under-
  contention stress, plus daemon-backed (RemoteDriver) variants that
  exercise the remote reopen/re-mint and invalidation-vs-open paths the
  in-process harness cannot reach.

## JIRA ID

JIRA ID - N/A
PR #8232

## Test Plan

Run all CI tests

## Test Result

CI tests: PASSED

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
