### PR TITLE
fix(roctracer): sanitize plugin library name

### DIFF
--- a/projects/roctracer/src/tracer_tool/tracer_tool.cpp
+++ b/projects/roctracer/src/tracer_tool/tracer_tool.cpp
@@ -44,6 +44,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/auxv.h>
 #include <sys/syscall.h> /* SYS_xxx definitions */
 #include <sys/types.h>
 #include <unistd.h> /* usleep */
@@ -693,7 +694,13 @@ ROCTRACER_EXPORT bool OnLoad(HsaApiTable* table, uint64_t runtime_version,
   }
 
   // Load output plugin
-  const char* plugin_name = getenv("ROCTRACER_PLUGIN_LIB");
+  const char* plugin_name = nullptr;
+  if (getauxval(AT_SECURE) == 0)
+    plugin_name = getenv("ROCTRACER_PLUGIN_LIB");
+  if (plugin_name != nullptr && strchr(plugin_name, '/') != nullptr) {
+    warning("ROCTRACER_PLUGIN_LIB must be a filename, not a path; ignoring");
+    plugin_name = nullptr;
+  }
   if (plugin_name == nullptr) plugin_name = "libfile_plugin.so";
   if (Dl_info dl_info; dladdr((void*)tool_load, &dl_info) != 0) {
     if (!plugin.emplace(fs::path(dl_info.dli_fname).replace_filename(plugin_name)).is_valid())


### PR DESCRIPTION
- Security fix
- Require ROCTRACER_PLUGIN_LIB to be set to a filename, no paths allowed
- Check AT_SECURE and don't use the environment if true

## Motivation

Found during security sweep. This is somewhat low risk; a threat actor that can modify ROCTRACER_PLUGIN_LIB can almost certainly modify LD_PRELOAD to do the same.

Respecting AT_SECURE is good security hygiene but doesn't represent much of a threat on its own.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

Changes usage of ROCTRACER_PLUGIN_LIB to discard paths and not be used when AT_SECURE is true.

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

JIRA ID: ROCM-26869

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Ran roctracer test suite on local machine.

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
