### PR TITLE
fix(rocjitsu): support sanitizer interposition

### DIFF
--- a/emulation/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/CMakeLists.txt
@@ -169,9 +169,8 @@ if(_rj_sanitizer_count GREATER 0)
         # MSVC only supports AddressSanitizer; ubsan/tsan/msan are GCC/Clang-only.
         if(_rj_sanitizer_arg STREQUAL "address")
             list(APPEND RJ_SANITIZER_COMPILE_OPTIONS /fsanitize=address)
-            add_compile_options(${RJ_SANITIZER_COMPILE_OPTIONS})
             # /INCREMENTAL:NO is required when using MSVC ASAN.
-            add_link_options(/INCREMENTAL:NO)
+            list(APPEND RJ_SANITIZER_LINK_OPTIONS /INCREMENTAL:NO)
         else()
             message(FATAL_ERROR "Only RJ_ENABLE_ASAN is supported by MSVC.")
         endif()
@@ -181,6 +180,9 @@ if(_rj_sanitizer_count GREATER 0)
             -fsanitize=${_rj_sanitizer_arg}
         )
         list(APPEND RJ_SANITIZER_LINK_OPTIONS -fsanitize=${_rj_sanitizer_arg})
+        if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang")
+            list(APPEND RJ_SANITIZER_LINK_OPTIONS -shared-libsan)
+        endif()
         if(
             address IN_LIST _rj_sanitizer_kinds
             OR undefined IN_LIST _rj_sanitizer_kinds
@@ -188,13 +190,20 @@ if(_rj_sanitizer_count GREATER 0)
         )
             list(APPEND RJ_SANITIZER_COMPILE_OPTIONS -fno-omit-frame-pointer)
         endif()
-        add_compile_options(${RJ_SANITIZER_COMPILE_OPTIONS})
-        add_link_options(${RJ_SANITIZER_LINK_OPTIONS})
         if(address IN_LIST _rj_sanitizer_kinds)
             # GCC 13+ emits false-positive -Wmaybe-uninitialized in std_function.h
             # when ASAN is enabled. Suppress to avoid -Werror failures.
             if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-                add_compile_options(-Wno-maybe-uninitialized)
+                list(
+                    APPEND RJ_SANITIZER_COMPILE_OPTIONS
+                    -Wno-maybe-uninitialized
+                )
+            elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang")
+                # ROCm Clang's ASAN runtime reports duplicate string-literal
+                # ODR violations during startup for large static test binaries
+                # and still aborts with detect_odr_violation=0. Disable global
+                # object instrumentation while preserving stack/heap ASAN.
+                list(APPEND RJ_SANITIZER_COMPILE_OPTIONS -mllvm=-asan-globals=0)
             endif()
         endif()
     else()
@@ -203,10 +212,129 @@ if(_rj_sanitizer_count GREATER 0)
             "Sanitizers are not supported for compiler '${CMAKE_CXX_COMPILER_ID}'."
         )
     endif()
+
+    function(rj_define_sanitizer_runtime definition library_name)
+        execute_process(
+            COMMAND "${CMAKE_CXX_COMPILER}" "-print-file-name=${library_name}"
+            OUTPUT_VARIABLE _rj_sanitizer_runtime
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_QUIET
+        )
+        if(
+            _rj_sanitizer_runtime
+            AND NOT _rj_sanitizer_runtime STREQUAL "${library_name}"
+            AND EXISTS "${_rj_sanitizer_runtime}"
+        )
+            add_compile_definitions(
+                "${definition}=\"${_rj_sanitizer_runtime}\""
+            )
+            get_filename_component(
+                _rj_sanitizer_runtime_dir
+                "${_rj_sanitizer_runtime}"
+                DIRECTORY
+            )
+            set(RJ_SANITIZER_RUNTIME_DIRS
+                ${RJ_SANITIZER_RUNTIME_DIRS}
+                "${_rj_sanitizer_runtime_dir}"
+                PARENT_SCOPE
+            )
+            message(
+                STATUS
+                "Sanitizer runtime for ${definition}: ${_rj_sanitizer_runtime}"
+            )
+        endif()
+        unset(_rj_sanitizer_runtime_dir)
+        unset(_rj_sanitizer_runtime)
+    endfunction()
+
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang")
+        set(_rj_compiler_rt_arch "${CMAKE_SYSTEM_PROCESSOR}")
+        if(_rj_compiler_rt_arch MATCHES "^(x86_64|amd64|AMD64)$")
+            set(_rj_compiler_rt_arch "x86_64")
+        elseif(_rj_compiler_rt_arch MATCHES "^(aarch64|arm64|ARM64)$")
+            set(_rj_compiler_rt_arch "aarch64")
+        endif()
+        if(address IN_LIST _rj_sanitizer_kinds)
+            rj_define_sanitizer_runtime(
+                RJ_ASAN_RUNTIME_LIBRARY
+                "libclang_rt.asan-${_rj_compiler_rt_arch}.so"
+            )
+        endif()
+        if(undefined IN_LIST _rj_sanitizer_kinds)
+            rj_define_sanitizer_runtime(
+                RJ_UBSAN_RUNTIME_LIBRARY
+                "libclang_rt.ubsan_standalone-${_rj_compiler_rt_arch}.so"
+            )
+        endif()
+        if(thread IN_LIST _rj_sanitizer_kinds)
+            rj_define_sanitizer_runtime(
+                RJ_TSAN_RUNTIME_LIBRARY
+                "libclang_rt.tsan-${_rj_compiler_rt_arch}.so"
+            )
+        endif()
+        if(memory IN_LIST _rj_sanitizer_kinds)
+            rj_define_sanitizer_runtime(
+                RJ_MSAN_RUNTIME_LIBRARY
+                "libclang_rt.msan-${_rj_compiler_rt_arch}.so"
+            )
+        endif()
+        unset(_rj_compiler_rt_arch)
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        if(address IN_LIST _rj_sanitizer_kinds)
+            rj_define_sanitizer_runtime(RJ_ASAN_RUNTIME_LIBRARY libasan.so)
+        endif()
+        if(undefined IN_LIST _rj_sanitizer_kinds)
+            rj_define_sanitizer_runtime(RJ_UBSAN_RUNTIME_LIBRARY libubsan.so)
+        endif()
+        if(thread IN_LIST _rj_sanitizer_kinds)
+            rj_define_sanitizer_runtime(RJ_TSAN_RUNTIME_LIBRARY libtsan.so)
+        endif()
+    endif()
+    if(RJ_SANITIZER_RUNTIME_DIRS)
+        list(REMOVE_DUPLICATES RJ_SANITIZER_RUNTIME_DIRS)
+        foreach(_rj_sanitizer_runtime_dir IN LISTS RJ_SANITIZER_RUNTIME_DIRS)
+            if(NOT MSVC)
+                list(
+                    APPEND RJ_SANITIZER_LINK_OPTIONS
+                    "-Wl,-rpath,${_rj_sanitizer_runtime_dir}"
+                )
+            endif()
+        endforeach()
+        unset(_rj_sanitizer_runtime_dir)
+    endif()
     unset(_rj_sanitizer_arg)
 endif()
 unset(_rj_sanitizer_count)
 unset(_rj_sanitizer_kinds)
+
+function(rj_apply_sanitizers target)
+    if(RJ_SANITIZER_COMPILE_OPTIONS)
+        target_compile_options(
+            ${target}
+            PRIVATE ${RJ_SANITIZER_COMPILE_OPTIONS}
+        )
+    endif()
+    if(RJ_SANITIZER_LINK_OPTIONS)
+        get_target_property(_rj_target_type ${target} TYPE)
+        if(
+            NOT _rj_target_type STREQUAL "OBJECT_LIBRARY"
+            AND NOT _rj_target_type STREQUAL "STATIC_LIBRARY"
+        )
+            if(MSVC)
+                target_link_options(
+                    ${target}
+                    PRIVATE ${RJ_SANITIZER_LINK_OPTIONS}
+                )
+            else()
+                target_link_libraries(
+                    ${target}
+                    PRIVATE ${RJ_SANITIZER_LINK_OPTIONS}
+                )
+            endif()
+        endif()
+        unset(_rj_target_type)
+    endif()
+endfunction()
 
 if(RJ_CLANG_TIDY)
     find_program(CLANG_TIDY_EXE NAMES clang-tidy)
@@ -297,6 +425,7 @@ target_include_directories(
     PRIVATE ${ROCJITSU_INCLUDE_DIR} ${ROCJITSU_SRC_DIR} ${GENERATED_DIR}
 )
 target_include_directories(rocjitsu_shared SYSTEM PRIVATE ${HSA_INCLUDE_DIR})
+rj_apply_sanitizers(rocjitsu_shared)
 
 # Linux-only: KMD interposer (LD_PRELOAD shim) and its dependencies.
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")

--- a/emulation/rocjitsu/cmake/rj_add_object_library.cmake
+++ b/emulation/rocjitsu/cmake/rj_add_object_library.cmake
@@ -22,4 +22,7 @@ function(rj_add_object_library name)
             PRIVATE -Wall -Wextra -Wpedantic -Werror -fvisibility=hidden
         )
     endif()
+    if(COMMAND rj_apply_sanitizers)
+        rj_apply_sanitizers(${name})
+    endif()
 endfunction()

--- a/emulation/rocjitsu/cmake/rj_configure_target.cmake
+++ b/emulation/rocjitsu/cmake/rj_configure_target.cmake
@@ -114,4 +114,8 @@ function(rj_configure_target target)
         )
         add_dependencies(${target} device_kernels)
     endif()
+
+    if(COMMAND rj_apply_sanitizers)
+        rj_apply_sanitizers(${target})
+    endif()
 endfunction()

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/CMakeLists.txt
@@ -40,3 +40,6 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
         PRIVATE -Wall -Wextra -Wpedantic -Werror
     )
 endif()
+if(COMMAND rj_apply_sanitizers)
+    rj_apply_sanitizers(rocjitsu_hooks)
+endif()

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -88,6 +88,16 @@ static int connect_to_daemon() {
 
 namespace {
 
+#if defined(__clang__) && defined(__has_attribute) &&                                              \
+    __has_attribute(disable_sanitizer_instrumentation)
+#define RJ_NO_SANITIZE_INTERPOSER __attribute__((disable_sanitizer_instrumentation))
+#elif defined(__GNUC__)
+#define RJ_NO_SANITIZE_INTERPOSER                                                                  \
+  __attribute__((no_sanitize_address, no_sanitize_thread, no_sanitize_undefined))
+#else
+#define RJ_NO_SANITIZE_INTERPOSER
+#endif
+
 void rj_sigsegv_handler(int, siginfo_t *, void *) {
   signal(SIGSEGV, SIG_DFL);
   raise(SIGSEGV);
@@ -126,7 +136,7 @@ public:
   ssize_t (*readlink_fn)(const char *, char *, size_t) = nullptr;
   pid_t (*fork)() = nullptr;
 
-  bool ready() const { return initialized_; }
+  RJ_NO_SANITIZE_INTERPOSER bool ready() const { return initialized_; }
 
   void resolve() {
     auto *handle = RTLD_NEXT;
@@ -546,7 +556,52 @@ alignas(16) uint8_t InterposerContext::storage_[sizeof(InterposerContext)];
 InterposerContext &InterposerContext::ctx =
     *reinterpret_cast<InterposerContext *>(InterposerContext::storage_);
 
+static void *(*real_dlsym_fn)(void *, const char *) = nullptr;
+
+RJ_NO_SANITIZE_INTERPOSER __attribute__((constructor(101))) static void resolve_real_dlsym() {
+  real_dlsym_fn =
+      reinterpret_cast<decltype(real_dlsym_fn)>(dlvsym(RTLD_NEXT, "dlsym", "GLIBC_2.34"));
+  if (!real_dlsym_fn)
+    real_dlsym_fn =
+        reinterpret_cast<decltype(real_dlsym_fn)>(dlvsym(RTLD_NEXT, "dlsym", "GLIBC_2.2.5"));
+  if (!real_dlsym_fn) {
+    fprintf(stderr, "rocjitsu: failed to resolve real dlsym\n");
+    abort();
+  }
+}
+
 __attribute__((constructor)) static void init_interposer() { InterposerContext::init(); }
+
+constexpr int DRM_NODE_PRIMARY = 0;
+constexpr int DRM_NODE_RENDER = 2;
+constexpr int DRM_BUS_PCI = 0;
+
+struct drmPciBusInfo {
+  uint16_t domain;
+  uint8_t bus;
+  uint8_t dev;
+  uint8_t func;
+};
+
+struct drmPciDeviceInfo {
+  uint16_t vendor_id;
+  uint16_t device_id;
+  uint16_t subvendor_id;
+  uint16_t subdevice_id;
+  uint8_t revision_id;
+};
+
+struct drmDevice {
+  char **nodes;
+  int available_nodes;
+  int bustype;
+  union {
+    drmPciBusInfo *pci;
+  } businfo;
+  union {
+    drmPciDeviceInfo *pci;
+  } deviceinfo;
+};
 
 } // namespace
 
@@ -1661,6 +1716,155 @@ RJ_INTERPOSER_EXPORT int __lxstat64(int ver, const char *path, struct stat64 *bu
   return real_lxstat64(ver, actual, buf);
 }
 
+// -- DRM device enumeration (direct PLT linkage consumers) --
+
+static std::unordered_set<void *> our_drm_allocs;
+static std::mutex drm_alloc_mutex;
+
+static drmDevice *alloc_drm_device(const Sysfs::GpuInfo &gpu, uint32_t card_idx) {
+  uint32_t render_minor = gpu.drm_render_minor;
+  char primary_path[64], render_path[64];
+  snprintf(primary_path, sizeof(primary_path), "/dev/dri/card%u", card_idx);
+  snprintf(render_path, sizeof(render_path), "/dev/dri/renderD%u", render_minor);
+
+  size_t primary_len = strlen(primary_path) + 1;
+  size_t render_len = strlen(render_path) + 1;
+  constexpr int kMaxNodeTypes = 3;
+
+  size_t alloc_size = sizeof(drmDevice) + kMaxNodeTypes * sizeof(char *) + primary_len +
+                      render_len + sizeof(drmPciBusInfo) + sizeof(drmPciDeviceInfo);
+  auto *mem = static_cast<uint8_t *>(calloc(1, alloc_size));
+  if (!mem)
+    return nullptr;
+
+  auto *dev = reinterpret_cast<drmDevice *>(mem);
+  auto *nodes = reinterpret_cast<char **>(mem + sizeof(drmDevice));
+  auto *str_buf = reinterpret_cast<char *>(nodes + kMaxNodeTypes);
+  auto *bus = reinterpret_cast<drmPciBusInfo *>(str_buf + primary_len + render_len);
+  auto *pci_dev = reinterpret_cast<drmPciDeviceInfo *>(bus + 1);
+
+  memcpy(str_buf, primary_path, primary_len);
+  memcpy(str_buf + primary_len, render_path, render_len);
+
+  nodes[DRM_NODE_PRIMARY] = str_buf;
+  nodes[DRM_NODE_RENDER] = str_buf + primary_len;
+  nodes[1] = nullptr;
+
+  uint32_t bus_num = (gpu.location_id >> 8) & 0xFF;
+  uint32_t dev_num = (gpu.location_id >> 3) & 0x1F;
+  uint32_t func_num = gpu.location_id & 0x7;
+
+  bus->domain = static_cast<uint16_t>(gpu.domain);
+  bus->bus = static_cast<uint8_t>(bus_num);
+  bus->dev = static_cast<uint8_t>(dev_num);
+  bus->func = static_cast<uint8_t>(func_num);
+
+  pci_dev->vendor_id = static_cast<uint16_t>(gpu.vendor_id);
+  pci_dev->device_id = static_cast<uint16_t>(gpu.device_id);
+  pci_dev->subvendor_id = static_cast<uint16_t>(gpu.vendor_id);
+  pci_dev->subdevice_id = static_cast<uint16_t>(gpu.device_id);
+  pci_dev->revision_id = static_cast<uint8_t>(gpu.pci_revision_id);
+
+  dev->nodes = nodes;
+  dev->available_nodes = (1 << DRM_NODE_PRIMARY) | (1 << DRM_NODE_RENDER);
+  dev->bustype = DRM_BUS_PCI;
+  dev->businfo.pci = bus;
+  dev->deviceinfo.pci = pci_dev;
+
+  {
+    std::lock_guard lock(drm_alloc_mutex);
+    our_drm_allocs.insert(mem);
+  }
+
+  return dev;
+}
+
+RJ_INTERPOSER_EXPORT void drmFreeDevice(drmDevice **device) {
+  if (!device || !*device)
+    return;
+  bool ours;
+  {
+    std::lock_guard lock(drm_alloc_mutex);
+    ours = our_drm_allocs.erase(*device) != 0;
+  }
+  if (ours) {
+    free(*device);
+    *device = nullptr;
+    return;
+  }
+  using fn_t = void (*)(drmDevice **);
+  static fn_t real_fn = util::lookup_symbol<fn_t>(RTLD_NEXT, "drmFreeDevice");
+  if (real_fn)
+    real_fn(device);
+}
+
+RJ_INTERPOSER_EXPORT void drmFreeDevices(drmDevice **devices, int count) {
+  for (int i = 0; i < count; ++i) {
+    if (devices[i])
+      drmFreeDevice(&devices[i]);
+  }
+}
+
+RJ_INTERPOSER_EXPORT int drmGetDevice(int fd, drmDevice **device) {
+  if (!device)
+    return -EINVAL;
+  *device = nullptr;
+  if (!InterposerContext::real.ready() || !InterposerContext::ctx.is_drm(fd))
+    return -ENODEV;
+  auto *gpu = interposer_gpu_info();
+  if (!gpu)
+    return -ENODEV;
+  *device = alloc_drm_device(*gpu, 0);
+  return *device ? 0 : -ENOMEM;
+}
+
+RJ_INTERPOSER_EXPORT int drmGetDevice2(int fd, uint32_t /*flags*/, drmDevice **device) {
+  return drmGetDevice(fd, device);
+}
+
+RJ_INTERPOSER_EXPORT int drmGetDevices(drmDevice **devices, int max_devices) {
+  if (!devices || max_devices <= 0)
+    return 0;
+  auto *gpu = interposer_gpu_info();
+  if (!gpu)
+    return 0;
+  devices[0] = alloc_drm_device(*gpu, 0);
+  return devices[0] ? 1 : 0;
+}
+
+RJ_INTERPOSER_EXPORT int drmGetDevices2(uint32_t /*flags*/, drmDevice **devices, int max_devices) {
+  return drmGetDevices(devices, max_devices);
+}
+
+// Intercept dlsym so that dlsym-based consumers (amdsmi) get our DRM
+// device query implementations instead of libdrm's.  Without this,
+// libdrm's internal drmGetDeviceFromDevId runs on our synthetic memfds
+// and produces a corrupted drmDevice that crashes in drmFreeDevice.
+// drmFreeDevice/drmFreeDevices are intentionally excluded: our own
+// drmFreeDevice fallback calls dlsym(RTLD_NEXT, "drmFreeDevice") and
+// including it here would cause infinite recursion.
+RJ_INTERPOSER_EXPORT RJ_NO_SANITIZE_INTERPOSER void *dlsym(void *handle, const char *symbol) {
+  if (!real_dlsym_fn) {
+    // Called before resolve_real_dlsym constructor runs (e.g., during
+    // dynamic linker symbol resolution at library load time). Resolve the real
+    // dlsym now before touching interposer state or sanitizer-initialized code.
+    resolve_real_dlsym();
+  }
+  auto symbol_addr = reinterpret_cast<uintptr_t>(symbol);
+  if (symbol_addr != 0 && InterposerContext::real.ready()) {
+    static const std::unordered_map<std::string_view, void *> overrides = {
+        {"drmGetDevice", reinterpret_cast<void *>(&drmGetDevice)},
+        {"drmGetDevice2", reinterpret_cast<void *>(&drmGetDevice2)},
+        {"drmGetDevices", reinterpret_cast<void *>(&drmGetDevices)},
+        {"drmGetDevices2", reinterpret_cast<void *>(&drmGetDevices2)},
+    };
+    auto it = overrides.find(symbol);
+    if (it != overrides.end())
+      return it->second;
+  }
+  return real_dlsym_fn(handle, symbol);
+}
+
 RJ_INTERPOSER_EXPORT pid_t fork() {
   assert(InterposerContext::real.ready());
   pid_t pid = InterposerContext::real.fork();
@@ -1670,3 +1874,5 @@ RJ_INTERPOSER_EXPORT pid_t fork() {
 }
 
 } // extern "C"
+
+#undef RJ_NO_SANITIZE_INTERPOSER

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -88,14 +88,30 @@ static int connect_to_daemon() {
 
 namespace {
 
-#if defined(__clang__) && defined(__has_attribute) &&                                              \
-    __has_attribute(disable_sanitizer_instrumentation)
+#ifndef __has_attribute
+#define __has_attribute(x) 0
+#endif
+
+#if __has_attribute(disable_sanitizer_instrumentation)
 #define RJ_NO_SANITIZE_INTERPOSER __attribute__((disable_sanitizer_instrumentation))
-#elif defined(__GNUC__)
-#define RJ_NO_SANITIZE_INTERPOSER                                                                  \
-  __attribute__((no_sanitize_address, no_sanitize_thread, no_sanitize_undefined))
 #else
-#define RJ_NO_SANITIZE_INTERPOSER
+#if __has_attribute(no_sanitize_address)
+#define RJ_NO_SANITIZE_ADDRESS __attribute__((no_sanitize_address))
+#else
+#define RJ_NO_SANITIZE_ADDRESS
+#endif
+#if __has_attribute(no_sanitize_thread)
+#define RJ_NO_SANITIZE_THREAD __attribute__((no_sanitize_thread))
+#else
+#define RJ_NO_SANITIZE_THREAD
+#endif
+#if __has_attribute(no_sanitize_undefined)
+#define RJ_NO_SANITIZE_UNDEFINED __attribute__((no_sanitize_undefined))
+#else
+#define RJ_NO_SANITIZE_UNDEFINED
+#endif
+#define RJ_NO_SANITIZE_INTERPOSER                                                                  \
+  RJ_NO_SANITIZE_ADDRESS RJ_NO_SANITIZE_THREAD RJ_NO_SANITIZE_UNDEFINED
 #endif
 
 void rj_sigsegv_handler(int, siginfo_t *, void *) {
@@ -189,6 +205,7 @@ public:
   /// the next open("/dev/kfd") creates a fresh connection.
   void reset_after_fork() {
     rj_vm_ = nullptr;
+    new (&engine_thread_) std::thread();
     remote_.store(nullptr, std::memory_order_relaxed);
     remote_kfd_fd_.store(-1, std::memory_order_relaxed);
     remote_open_refs_.store(0, std::memory_order_relaxed);
@@ -209,6 +226,24 @@ public:
   }
   bool initialized() const {
     return rj_vm_ != nullptr || remote_.load(std::memory_order_acquire) != nullptr;
+  }
+
+  void shutdown() {
+    rj_vm_t *vm = nullptr;
+    std::thread engine_thread;
+    {
+      std::lock_guard lock(init_mutex_);
+      vm = rj_vm_;
+      rj_vm_ = nullptr;
+      if (vm)
+        rj_vm_request_exit(vm, "interposer shutdown");
+      if (engine_thread_.joinable())
+        engine_thread = std::move(engine_thread_);
+    }
+    if (engine_thread.joinable())
+      engine_thread.join();
+    if (vm)
+      rj_vm_destroy(vm);
   }
 
   std::unique_lock<std::mutex> lock_remote() { return std::unique_lock(remote_mutex_); }
@@ -503,7 +538,7 @@ public:
         rj_vm_->soc->set_plugin_group(pg);
       }
 
-      std::thread([vm = rj_vm_]() { rj_vm_run(vm, nullptr); }).detach();
+      engine_thread_ = std::thread([vm = rj_vm_]() { rj_vm_run(vm, nullptr); });
       in_construction = false;
     }
     return driver();
@@ -523,6 +558,7 @@ public:
 
 private:
   rj_vm_t *rj_vm_ = nullptr;
+  std::thread engine_thread_;
   /// @brief Active daemon-mode remote driver, or nullptr in local mode.
   /// @details Stored atomically so lock-free readers (`remote()`,
   /// `remote_lookup()`, `initialized()`, the AMDKFD ioctl fallback, the mmap
@@ -549,9 +585,8 @@ private:
   alignas(16) static uint8_t storage_[];
 };
 
-// Storage for the singleton is never destructed. Using aligned raw storage
-// avoids __cxa_finalize destroying the object while the detached engine
-// thread is still running.
+// Storage for the singleton is never destructed. Shutdown is performed
+// explicitly from the interposer destructor hook after libc remains usable.
 alignas(16) uint8_t InterposerContext::storage_[sizeof(InterposerContext)];
 InterposerContext &InterposerContext::ctx =
     *reinterpret_cast<InterposerContext *>(InterposerContext::storage_);
@@ -853,7 +888,9 @@ RJ_INTERPOSER_EXPORT int close(int fd) {
   return static_cast<int>(InterposerContext::real.close(fd));
 }
 
-__attribute__((destructor(101))) void rj_interposer_shutdown() {}
+__attribute__((destructor(101))) void rj_interposer_shutdown() {
+  InterposerContext::ctx.shutdown();
+}
 
 RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
   assert(InterposerContext::real.ready());
@@ -1852,15 +1889,14 @@ RJ_INTERPOSER_EXPORT RJ_NO_SANITIZE_INTERPOSER void *dlsym(void *handle, const c
   }
   auto symbol_addr = reinterpret_cast<uintptr_t>(symbol);
   if (symbol_addr != 0 && InterposerContext::real.ready()) {
-    static const std::unordered_map<std::string_view, void *> overrides = {
-        {"drmGetDevice", reinterpret_cast<void *>(&drmGetDevice)},
-        {"drmGetDevice2", reinterpret_cast<void *>(&drmGetDevice2)},
-        {"drmGetDevices", reinterpret_cast<void *>(&drmGetDevices)},
-        {"drmGetDevices2", reinterpret_cast<void *>(&drmGetDevices2)},
-    };
-    auto it = overrides.find(symbol);
-    if (it != overrides.end())
-      return it->second;
+    if (std::strcmp(symbol, "drmGetDevice") == 0)
+      return reinterpret_cast<void *>(&drmGetDevice);
+    if (std::strcmp(symbol, "drmGetDevice2") == 0)
+      return reinterpret_cast<void *>(&drmGetDevice2);
+    if (std::strcmp(symbol, "drmGetDevices") == 0)
+      return reinterpret_cast<void *>(&drmGetDevices);
+    if (std::strcmp(symbol, "drmGetDevices2") == 0)
+      return reinterpret_cast<void *>(&drmGetDevices2);
   }
   return real_dlsym_fn(handle, symbol);
 }
@@ -1876,3 +1912,6 @@ RJ_INTERPOSER_EXPORT pid_t fork() {
 } // extern "C"
 
 #undef RJ_NO_SANITIZE_INTERPOSER
+#undef RJ_NO_SANITIZE_UNDEFINED
+#undef RJ_NO_SANITIZE_THREAD
+#undef RJ_NO_SANITIZE_ADDRESS

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/execution_plugin_group.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/execution_plugin_group.h
@@ -143,8 +143,11 @@ public:
   }
 
   static std::shared_ptr<ExecutionPluginGroup> empty_group() {
-    static auto instance = std::make_shared<ExecutionPluginGroup>();
-    return instance;
+    // Interposed clients can still have the VM engine thread winding down during
+    // process teardown. Keep the empty group available until process exit.
+    static const auto *instance =
+        new std::shared_ptr<ExecutionPluginGroup>(std::make_shared<ExecutionPluginGroup>());
+    return *instance;
   }
 
 protected:

--- a/emulation/rocjitsu/lib/simdojo/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/simdojo/CMakeLists.txt
@@ -19,3 +19,6 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
         PRIVATE -Wall -Wextra -Wpedantic -Werror -fvisibility=hidden
     )
 endif()
+if(COMMAND rj_apply_sanitizers)
+    rj_apply_sanitizers(simdojo)
+endif()

--- a/emulation/rocjitsu/lib/util/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/util/CMakeLists.txt
@@ -4,3 +4,6 @@
 add_library(util STATIC src/simd.cpp)
 target_include_directories(util PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 set_target_properties(util PROPERTIES POSITION_INDEPENDENT_CODE ON)
+if(COMMAND rj_apply_sanitizers)
+    rj_apply_sanitizers(util)
+endif()

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -477,6 +477,7 @@ if(ROCMINFO_EXECUTABLE)
             RJ_INSTALLED_CONFIG_PATH="${_rj_installed_cdna4_kmd_config}"
     )
     target_link_libraries(rocminfo_test PRIVATE GTest::gtest_main)
+    rj_apply_sanitizers(rocminfo_test)
     add_dependencies(rocminfo_test rocjitsu_bin rocjitsu_shared)
 
     if(RJ_INSTALL_TESTS)
@@ -534,6 +535,7 @@ if(HSA_RUNTIME64)
     )
     target_link_libraries(hsa_init_test PRIVATE ${HSA_RUNTIME64} GTest::gtest)
     target_link_options(hsa_init_test PRIVATE -Wl,-rpath,${RJ_HSA_LIBRARY_DIR})
+    rj_apply_sanitizers(hsa_init_test)
     add_dependencies(hsa_init_test rocjitsu_bin rocjitsu_shared)
     if(RJ_INSTALL_TESTS)
         rj_install_test_target(hsa_init_test)
@@ -1083,6 +1085,7 @@ if(RJ_ENABLE_HIP_TESTS)
             RJ_INSTALLED_HIP_RCCL_BIN="hip_rccl_test"
     )
     target_link_libraries(daemon_test PRIVATE GTest::gtest_main)
+    rj_apply_sanitizers(daemon_test)
     add_dependencies(
         daemon_test
         rocjitsu_bin

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -278,6 +278,7 @@ add_executable(
     matmul_test.cpp
     vector_add_test.cpp
     gfx1250_sim_test.cpp
+    rocjitsu_cli_test.cpp
     simdojo_sim_test.cpp
     simulated_driver_test.cpp
     decode_smoke_test.cpp
@@ -377,6 +378,7 @@ target_link_libraries(
         Threads::Threads
         GTest::gtest_main
 )
+target_include_directories(rocjitsu_tests PRIVATE ${RJ_VERSION_INCLUDE_DIR})
 rj_configure_target(rocjitsu_tests TEST)
 # Benchmarks are timing tools, not correctness tests; keep them out of the
 # default ctest run (invoke them directly via

--- a/emulation/rocjitsu/tests/daemon_test.cpp
+++ b/emulation/rocjitsu/tests/daemon_test.cpp
@@ -28,6 +28,19 @@
 #include <unistd.h>
 #include <vector>
 
+#ifndef RJ_ASAN_RUNTIME_LIBRARY
+#define RJ_ASAN_RUNTIME_LIBRARY ""
+#endif
+#ifndef RJ_UBSAN_RUNTIME_LIBRARY
+#define RJ_UBSAN_RUNTIME_LIBRARY ""
+#endif
+#ifndef RJ_TSAN_RUNTIME_LIBRARY
+#define RJ_TSAN_RUNTIME_LIBRARY ""
+#endif
+#ifndef RJ_MSAN_RUNTIME_LIBRARY
+#define RJ_MSAN_RUNTIME_LIBRARY ""
+#endif
+
 namespace {
 
 struct ProcessResult {
@@ -121,6 +134,24 @@ const char *hip_memcpy_bin() { return test_paths().hip_memcpy_bin.c_str(); }
 
 const char *hip_rccl_bin() { return test_paths().hip_rccl_bin.c_str(); }
 
+void append_preload_entry(std::string &preload, const char *entry) {
+  if (!entry || !entry[0])
+    return;
+  if (!preload.empty())
+    preload += ':';
+  preload += entry;
+}
+
+std::string client_ld_preload() {
+  std::string preload;
+  append_preload_entry(preload, RJ_ASAN_RUNTIME_LIBRARY);
+  append_preload_entry(preload, RJ_UBSAN_RUNTIME_LIBRARY);
+  append_preload_entry(preload, RJ_TSAN_RUNTIME_LIBRARY);
+  append_preload_entry(preload, RJ_MSAN_RUNTIME_LIBRARY);
+  append_preload_entry(preload, preload_lib());
+  return preload;
+}
+
 class DaemonTest : public ::testing::Test {
 protected:
   void SetUp() override {
@@ -170,7 +201,7 @@ protected:
     std::string cmd = "XDG_RUNTIME_DIR=";
     cmd += tmp_dir_;
     cmd += " LD_PRELOAD=";
-    cmd += preload_lib();
+    cmd += client_ld_preload();
     cmd += " HSA_ENABLE_SDMA=1 ";
     cmd += binary;
     if (gtest_filter && gtest_filter[0]) {

--- a/emulation/rocjitsu/tests/rocjitsu_cli_test.cpp
+++ b/emulation/rocjitsu/tests/rocjitsu_cli_test.cpp
@@ -39,18 +39,6 @@ private:
   std::optional<std::string> prior_;
 };
 
-std::vector<std::string> split_preload(std::string_view preload) {
-  std::vector<std::string> entries;
-  while (!preload.empty()) {
-    auto pos = preload.find(':');
-    entries.emplace_back(preload.substr(0, pos));
-    if (pos == std::string_view::npos)
-      break;
-    preload.remove_prefix(pos + 1);
-  }
-  return entries;
-}
-
 size_t find_entry(const std::vector<std::string> &entries, std::string_view needle) {
   auto it = std::find(entries.begin(), entries.end(), needle);
   return it == entries.end() ? entries.size() : static_cast<size_t>(it - entries.begin());
@@ -73,9 +61,9 @@ TEST(RocjitsuCliTest, BuildsDeduplicatedPreloadWithInterposerBeforeExistingEntri
   constexpr const char *kExisting = "/tmp/existing.so";
   constexpr const char *kExtra = "/tmp/extra.so";
   ScopedEnv preload("LD_PRELOAD",
-                    "/tmp/existing.so:/tmp/librocjitsu.so::/tmp/extra.so:/tmp/existing.so");
+                    "/tmp/existing.so /tmp/librocjitsu.so::\t/tmp/extra.so:/tmp/existing.so");
 
-  auto entries = split_preload(build_ld_preload(kInterposer));
+  auto entries = split_ld_preload(build_ld_preload(kInterposer));
 
   EXPECT_EQ(std::count(entries.begin(), entries.end(), kInterposer), 1);
   EXPECT_EQ(std::count(entries.begin(), entries.end(), kExisting), 1);
@@ -89,6 +77,16 @@ TEST(RocjitsuCliTest, BuildsDeduplicatedPreloadWithInterposerBeforeExistingEntri
   ASSERT_NE(extra_pos, entries.size());
   EXPECT_LT(interposer_pos, existing_pos);
   EXPECT_LT(existing_pos, extra_pos);
+}
+
+TEST(RocjitsuCliTest, SplitsPreloadOnColonsAndWhitespace) {
+  auto entries = split_ld_preload("  /tmp/a.so:/tmp/b.so\t/tmp/c.so\n\n/tmp/d.so:: ");
+
+  ASSERT_EQ(entries.size(), 4u);
+  EXPECT_EQ(entries[0], "/tmp/a.so");
+  EXPECT_EQ(entries[1], "/tmp/b.so");
+  EXPECT_EQ(entries[2], "/tmp/c.so");
+  EXPECT_EQ(entries[3], "/tmp/d.so");
 }
 
 } // namespace

--- a/emulation/rocjitsu/tests/rocjitsu_cli_test.cpp
+++ b/emulation/rocjitsu/tests/rocjitsu_cli_test.cpp
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#define main rocjitsu_cli_main_for_test
+#include "../tools/rocjitsu/main.cpp"
+#undef main
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdlib>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+
+class ScopedEnv {
+public:
+  ScopedEnv(const char *name, const char *value) : name_(name) {
+    if (const char *prior = std::getenv(name_.c_str()))
+      prior_ = prior;
+    if (value)
+      setenv(name_.c_str(), value, 1);
+    else
+      unsetenv(name_.c_str());
+  }
+
+  ~ScopedEnv() {
+    if (prior_)
+      setenv(name_.c_str(), prior_->c_str(), 1);
+    else
+      unsetenv(name_.c_str());
+  }
+
+private:
+  std::string name_;
+  std::optional<std::string> prior_;
+};
+
+std::vector<std::string> split_preload(std::string_view preload) {
+  std::vector<std::string> entries;
+  while (!preload.empty()) {
+    auto pos = preload.find(':');
+    entries.emplace_back(preload.substr(0, pos));
+    if (pos == std::string_view::npos)
+      break;
+    preload.remove_prefix(pos + 1);
+  }
+  return entries;
+}
+
+size_t find_entry(const std::vector<std::string> &entries, std::string_view needle) {
+  auto it = std::find(entries.begin(), entries.end(), needle);
+  return it == entries.end() ? entries.size() : static_cast<size_t>(it - entries.begin());
+}
+
+TEST(RocjitsuCliTest, DetectsSanitizerRuntimeBasenames) {
+  EXPECT_TRUE(is_sanitizer_runtime("libclang_rt.asan-x86_64.so"));
+  EXPECT_TRUE(is_sanitizer_runtime("libclang_rt.tsan-x86_64.so"));
+  EXPECT_TRUE(is_sanitizer_runtime("libclang_rt.ubsan_standalone-x86_64.so"));
+  EXPECT_TRUE(is_sanitizer_runtime("libasan.so.8"));
+  EXPECT_TRUE(is_sanitizer_runtime("libtsan.so.2"));
+  EXPECT_TRUE(is_sanitizer_runtime("libubsan.so.1"));
+
+  EXPECT_FALSE(is_sanitizer_runtime("libhsa-runtime64.so"));
+  EXPECT_FALSE(is_sanitizer_runtime("librocjitsu.so"));
+}
+
+TEST(RocjitsuCliTest, BuildsDeduplicatedPreloadWithInterposerBeforeExistingEntries) {
+  constexpr const char *kInterposer = "/tmp/librocjitsu.so";
+  constexpr const char *kExisting = "/tmp/existing.so";
+  constexpr const char *kExtra = "/tmp/extra.so";
+  ScopedEnv preload("LD_PRELOAD",
+                    "/tmp/existing.so:/tmp/librocjitsu.so::/tmp/extra.so:/tmp/existing.so");
+
+  auto entries = split_preload(build_ld_preload(kInterposer));
+
+  EXPECT_EQ(std::count(entries.begin(), entries.end(), kInterposer), 1);
+  EXPECT_EQ(std::count(entries.begin(), entries.end(), kExisting), 1);
+  EXPECT_EQ(std::count(entries.begin(), entries.end(), kExtra), 1);
+
+  const size_t interposer_pos = find_entry(entries, kInterposer);
+  const size_t existing_pos = find_entry(entries, kExisting);
+  const size_t extra_pos = find_entry(entries, kExtra);
+  ASSERT_NE(interposer_pos, entries.size());
+  ASSERT_NE(existing_pos, entries.size());
+  ASSERT_NE(extra_pos, entries.size());
+  EXPECT_LT(interposer_pos, existing_pos);
+  EXPECT_LT(existing_pos, extra_pos);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tools/rocjitsu/main.cpp
+++ b/emulation/rocjitsu/tools/rocjitsu/main.cpp
@@ -31,11 +31,25 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <sys/wait.h>
+#include <system_error>
 #include <thread>
 #include <unistd.h>
 #include <vector>
 
 using namespace rocjitsu;
+
+#ifndef RJ_ASAN_RUNTIME_LIBRARY
+#define RJ_ASAN_RUNTIME_LIBRARY ""
+#endif
+#ifndef RJ_UBSAN_RUNTIME_LIBRARY
+#define RJ_UBSAN_RUNTIME_LIBRARY ""
+#endif
+#ifndef RJ_TSAN_RUNTIME_LIBRARY
+#define RJ_TSAN_RUNTIME_LIBRARY ""
+#endif
+#ifndef RJ_MSAN_RUNTIME_LIBRARY
+#define RJ_MSAN_RUNTIME_LIBRARY ""
+#endif
 
 static pid_t peer_pid_for_socket(int fd) {
   struct ucred cred {};
@@ -325,6 +339,39 @@ static void append_preload_entry(std::vector<std::string> &entries, std::string 
   entries.push_back(std::move(entry));
 }
 
+static std::vector<std::string> split_ld_preload(std::string_view preload) {
+  std::vector<std::string> entries;
+  while (!preload.empty()) {
+    auto start = preload.find_first_not_of(" \f\n\r\t\v:");
+    if (start == std::string_view::npos)
+      break;
+    preload.remove_prefix(start);
+
+    auto end = preload.find_first_of(" \f\n\r\t\v:");
+    entries.emplace_back(preload.substr(0, end));
+    if (end == std::string_view::npos)
+      break;
+    preload.remove_prefix(end + 1);
+  }
+  return entries;
+}
+
+static void append_preload_entries(std::vector<std::string> &entries, std::string_view preload) {
+  for (auto &entry : split_ld_preload(preload))
+    append_preload_entry(entries, std::move(entry));
+}
+
+static void append_configured_sanitizer_runtime(std::vector<std::string> &entries,
+                                                const char *runtime) {
+  if (!runtime || !*runtime)
+    return;
+  std::error_code ec;
+  auto path = std::filesystem::canonical(runtime, ec);
+  if (ec || path.empty())
+    return;
+  append_preload_entry(entries, path.string());
+}
+
 static std::vector<std::string> loaded_sanitizer_runtimes() {
   std::vector<std::string> entries;
   dl_iterate_phdr(
@@ -339,6 +386,10 @@ static std::vector<std::string> loaded_sanitizer_runtimes() {
         return 0;
       },
       &entries);
+  append_configured_sanitizer_runtime(entries, RJ_ASAN_RUNTIME_LIBRARY);
+  append_configured_sanitizer_runtime(entries, RJ_UBSAN_RUNTIME_LIBRARY);
+  append_configured_sanitizer_runtime(entries, RJ_TSAN_RUNTIME_LIBRARY);
+  append_configured_sanitizer_runtime(entries, RJ_MSAN_RUNTIME_LIBRARY);
   return entries;
 }
 
@@ -347,15 +398,7 @@ static std::string build_ld_preload(const std::string &interposer_lib) {
   append_preload_entry(entries, interposer_lib);
 
   if (const char *existing = std::getenv("LD_PRELOAD")) {
-    std::string_view preload(existing);
-    while (!preload.empty()) {
-      auto pos = preload.find(':');
-      auto entry = preload.substr(0, pos);
-      append_preload_entry(entries, std::string(entry));
-      if (pos == std::string_view::npos)
-        break;
-      preload.remove_prefix(pos + 1);
-    }
+    append_preload_entries(entries, existing);
   }
 
   std::string result;

--- a/emulation/rocjitsu/tools/rocjitsu/main.cpp
+++ b/emulation/rocjitsu/tools/rocjitsu/main.cpp
@@ -16,12 +16,15 @@
 
 #include <cerrno>
 #include <csignal>
+#include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <format>
 #include <fstream>
 #include <iostream>
+#include <link.h>
 #include <stop_token>
+#include <string>
 #include <string_view>
 #include <sys/mman.h>
 #include <sys/prctl.h>
@@ -303,6 +306,67 @@ static std::string find_interposer_lib() {
   return {};
 }
 
+static bool is_sanitizer_runtime(std::string_view basename) {
+  for (std::string_view needle : {"libclang_rt.asan", "libclang_rt.tsan", "libclang_rt.ubsan",
+                                  "libasan.", "libtsan.", "libubsan."}) {
+    if (basename.find(needle) != std::string_view::npos)
+      return true;
+  }
+  return false;
+}
+
+static void append_preload_entry(std::vector<std::string> &entries, std::string entry) {
+  if (entry.empty())
+    return;
+  for (auto &existing : entries) {
+    if (existing == entry)
+      return;
+  }
+  entries.push_back(std::move(entry));
+}
+
+static std::vector<std::string> loaded_sanitizer_runtimes() {
+  std::vector<std::string> entries;
+  dl_iterate_phdr(
+      [](dl_phdr_info *info, size_t, void *data) {
+        auto *entries = static_cast<std::vector<std::string> *>(data);
+        if (!info->dlpi_name || !*info->dlpi_name)
+          return 0;
+        std::string path(info->dlpi_name);
+        auto basename = std::filesystem::path(path).filename().string();
+        if (is_sanitizer_runtime(basename))
+          append_preload_entry(*entries, std::move(path));
+        return 0;
+      },
+      &entries);
+  return entries;
+}
+
+static std::string build_ld_preload(const std::string &interposer_lib) {
+  auto entries = loaded_sanitizer_runtimes();
+  append_preload_entry(entries, interposer_lib);
+
+  if (const char *existing = std::getenv("LD_PRELOAD")) {
+    std::string_view preload(existing);
+    while (!preload.empty()) {
+      auto pos = preload.find(':');
+      auto entry = preload.substr(0, pos);
+      append_preload_entry(entries, std::string(entry));
+      if (pos == std::string_view::npos)
+        break;
+      preload.remove_prefix(pos + 1);
+    }
+  }
+
+  std::string result;
+  for (auto &entry : entries) {
+    if (!result.empty())
+      result += ':';
+    result += entry;
+  }
+  return result;
+}
+
 static bool write_config_file(const std::string &config_path) {
   auto cfg_file = rpc_default_config_file_path();
   std::filesystem::create_directories(std::filesystem::path(cfg_file).parent_path());
@@ -437,7 +501,8 @@ int main(int argc, char *argv[]) {
     }
   }
 
-  setenv("LD_PRELOAD", lib_path.c_str(), 1);
+  auto preload = build_ld_preload(lib_path);
+  setenv("LD_PRELOAD", preload.c_str(), 1);
   execvp(app_argv[0], app_argv);
 
   std::cerr << std::format("rocjitsu: execvp failed: {}\n", strerror(errno));


### PR DESCRIPTION
## Summary

Changes:
* Make the rocjitsu launcher composes `LD_PRELOAD` with existing entries instead of replacing them, deduplicates repeated libraries, and keeps the rocjitsu interposer ordered so HSA calls remain visible.
* The Linux KMD interposer now cooperates with sanitizer preload wrappers and can continue resolving the real HSA entry points behind those wrappers.
* Testings: a focused rocjitsu CLI test covers sanitizer runtime detection and preload-list construction so the launcher behavior is protected against regressions.

Rationale:
* To add sanitizer support, which is useful for debugging rocjitsu
* Sanitizer runtimes and rocjitsu both rely on dynamic interposition. Without explicit preload composition, one layer can hide the symbols the other layer needs, making sanitized rocjitsu runs unreliable.

## Validation

- pre-commit run --files emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp emulation/rocjitsu/tools/rocjitsu/main.cpp emulation/rocjitsu/tests/CMakeLists.txt emulation/rocjitsu/tests/rocjitsu_cli_test.cpp
- cmake -S emulation/rocjitsu -B build/rocjitsu -G Ninja -DCMAKE_BUILD_TYPE=Release
- cmake --build build/rocjitsu --target rocjitsu_tests -j 8
- build/rocjitsu/tests/rocjitsu_tests --gtest_filter='RocjitsuCliTest.*'

ISSUE ID : #6962