### PR TITLE
fix(clr) use MEMORY_TYPE_NONE for host-NUMA VMM allocations

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -2407,9 +2407,15 @@ uint64_t Device::hostVmemAlloc(size_t size, uint64_t flags, int numaNode) const 
     return 0;
   }
 
+  // Host/CPU-pool VMM handles must use MEMORY_TYPE_NONE, not MEMORY_TYPE_PINNED.
+  // With MEMORY_TYPE_PINNED the CPU mapping of the resulting host BO is not
+  // faultable on some kernel/driver stacks, so a direct CPU access to the mapped
+  // VA raises SIGBUS even though hsa_amd_vmem_set_access() succeeds. ROCr's own
+  // rocrtst host VMM tests create host-pool handles with MEMORY_TYPE_NONE; device
+  // pool allocations (deviceVmemAlloc) keep MEMORY_TYPE_PINNED.
   hsa_amd_vmem_alloc_handle_t hsa_vmem_handle{};
   hsa_status_t hsa_status =
-      Hsa::vmem_handle_create(pool, size, MEMORY_TYPE_PINNED, 0, &hsa_vmem_handle);
+      Hsa::vmem_handle_create(pool, size, MEMORY_TYPE_NONE, 0, &hsa_vmem_handle);
   if (hsa_status != HSA_STATUS_SUCCESS) {
     LogPrintfError("hostVmemAlloc: hsa_amd_vmem_handle_create failed with status: %d", hsa_status);
     return 0;

--- a/projects/hip-tests/catch/config/configs/unit/virtualMemoryManagement.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/virtualMemoryManagement.yaml
@@ -109,18 +109,12 @@ virtualMemoryManagement:
   Unit_hipMemCreate_HostNuma_ChkWithKerLaunch:
     <<: *level_2
     disabled: [amd_windows, amd_wsl]
-  # (amd_linux) These two are the only host-NUMA tests that directly dereference
-  # the mapped VA from the CPU. On the current CI kernel/driver stack that CPU
-  # access faults with SIGBUS even though hsa_amd_vmem_set_access() reports
-  # success; the allocation + GPU/DMA-access tests above are unaffected and stay
-  # enabled. Same code works on bare-metal gfx942/gfx950; ROCr is investigating.
-  # Re-enable on amd_linux once the runtime fix lands.
   Unit_hipMemCreate_HostNuma_HostAndDeviceAccess:
     <<: *level_2
-    disabled: [amd_windows, amd_wsl, amd_linux]
+    disabled: [amd_windows, amd_wsl]
   Unit_hipMemCreate_HostNuma_NumaTypedAccess:
     <<: *level_2
-    disabled: [amd_windows, amd_wsl, amd_linux]
+    disabled: [amd_windows, amd_wsl]
   Unit_hipMemCreate_HostNuma_Negative:
     <<: *level_2
     disabled: [amd_windows, amd_wsl]


### PR DESCRIPTION
## Motivation

use MEMORY_TYPE_NONE for host-NUMA VMM allocations

## Technical Details
hostVmemAlloc created host/CPU-pool VMM handles with MEMORY_TYPE_PINNED. On some kernel/driver stacks the CPU mapping of the resulting host BO is not faultable, so a direct CPU load/store to the mapped VA raises SIGBUS even though hsa_amd_vmem_set_access() reports success (observed on Linux CI; worked on bare-metal gfx942/gfx950). ROCr's own rocrtst host VMM tests create host-pool handles with MEMORY_TYPE_NONE.

Use MEMORY_TYPE_NONE for the host-NUMA CPU-pool path; deviceVmemAlloc keeps MEMORY_TYPE_PINNED. Re-enable the two direct-CPU-access host-NUMA tests on amd_linux (HostAndDeviceAccess, NumaTypedAccess).

## JIRA ID

JIRA ID : ROCM-25438

## Test Plan

Re-enabling the test, which should pass now

## Test Result

test passes locally, awaiting CI

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
