### PR TITLE
fix(ci): Add env variable to avoid scheduling small kernels in multi-stream tests on a single stream

### DIFF
--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -56,6 +56,7 @@ jobs:
       OUTPUT_ARTIFACTS_DIR: "./build"
       THEROCK_BIN_DIR: "./build/bin"
       AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
+      DEBUG_HIP_GRAPH_MIN_OVERLAP: 0 # required for hip-tests to avoid optimizing out multi-stream tests
     steps:
       - name: "Fetch 'build_tools' from repository"
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
## Motivation
With the latest optimizations, multiple small kernels in multi-stream tests collapse into a single stream, effectively voiding the check. This PR enables the debug env variable to disable this optimization in testing
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Adds env variable DEBUG_HIP_GRAPH_MIN_OVERLAP to test_components step in TheRock CI.
<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
NA
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
WIP
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
WIP
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
