### PR TITLE
feat(ci): expand TheRock CI build coverage to all supported GFX architectures on PRs

### DIFF
--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Fetch Linux targets for build and test
         env:
           THEROCK_PACKAGE_PLATFORM: "linux"
-          AMDGPU_FAMILIES: ${{ inputs.linux_amdgpu_families || 'gfx94X, gfx950, gfx125X' }}
+          AMDGPU_FAMILIES: ${{ inputs.linux_amdgpu_families || 'gfx94X, gfx950, gfx110X, gfx1151, gfx120X, gfx125X, gfx900, gfx906, gfx908, gfx90a, gfx101X, gfx103X, gfx1150, gfx1152, gfx1153' }}
           CI_CONFIG_PATH: ci-config
         id: configure_linux
         run: python ./TheRock/build_tools/github_actions/fetch_package_targets.py
@@ -131,7 +131,7 @@ jobs:
       - name: Fetch Windows targets for build and test
         env:
           THEROCK_PACKAGE_PLATFORM: "windows"
-          AMDGPU_FAMILIES: ${{ inputs.windows_amdgpu_families || 'gfx1151' }}
+          AMDGPU_FAMILIES: ${{ inputs.windows_amdgpu_families || 'gfx110X, gfx1151, gfx120X, gfx900, gfx906, gfx908, gfx90a, gfx101X, gfx103X, gfx1150, gfx1152, gfx1153' }}
           CI_CONFIG_PATH: ci-config
         id: configure_windows
         run: python ./TheRock/build_tools/github_actions/fetch_package_targets.py


### PR DESCRIPTION
## Motivation

 Expands the default AMDGPU_FAMILIES list in therock-ci.yml to include all supported GFX architectures on every PR, for both Linux and Windows.

  Before:
  - **Linux:** gfx94X, gfx950, gfx125X (3 families)
  - **Windows:** gfx1151 (1 family)

  After:
  - **Linux**: gfx94X, gfx950, gfx110X, gfx1151, gfx120X, gfx125X, gfx900, gfx906, gfx908, gfx90a, gfx101X, gfx103X, gfx1150, gfx1152, gfx1153 (15 families)
  - **Windows:** gfx110X, gfx1151, gfx120X, gfx900, gfx906, gfx908, gfx90a, gfx101X, gfx103X, gfx1150, gfx1152, gfx1153 (12 families)

  **Tests are not affected — this is build-only expansion:**
  - Architectures marked **nightly_check_only_for_family: True** in TheRock's amdgpu_family_matrix.py (**gfx110X, gfx1151, gfx120X, gfx90a, gfx103X, gfx1150,
  gfx1152, gfx1153**) will build but skip tests.
  - Architectures with no hardware (**gfx900, gfx906, gfx908, gfx101X, gfx1152, gfx125X**) will build but have no test runner.

## Test Result

Waiting for CI results

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
