### PR TITLE
feat(rocprofiler-compute): correlate ISA with kernel names

### DIFF
--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/CMakeLists.txt
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(
     filesystem_wrapper.cpp
     code_object_translator.h
     code_object_translator.cpp
+    code_object_types.h
     code_object_writer.h
     code_object_writer.cpp
     source_snapshotter.h

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/code_object_translator.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/code_object_translator.h
@@ -1,6 +1,7 @@
 // Copyright (c) Advanced Micro Devices, Inc.
 // SPDX-License-Identifier:  MIT
 #pragma once
+#include "code_object_types.h"
 
 #include <cstddef>
 #include <cstdint>
@@ -16,23 +17,6 @@ class CodeobjAddressTranslate;
 
 namespace rocprofiler_compute_tool
 {
-struct symbol_t
-{
-    std::string name{};
-    uint64_t    code_object_offset = 0;
-    uint64_t    virtual_address    = 0;
-    uint64_t    size               = 0;
-};
-
-struct instruction_t
-{
-    std::string name{};
-    std::string comment{};
-    uint64_t    virtual_address = 0;
-    uint64_t    code_obj_offset = 0;
-    size_t      size{0};
-};
-
 class code_object_translator_t
 {
 public:

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/code_object_types.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/code_object_types.h
@@ -1,0 +1,33 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier:  MIT
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+namespace rocprofiler_compute_tool
+{
+struct symbol_t
+{
+    std::string name{};
+    uint64_t    code_object_offset = 0;
+    uint64_t    virtual_address    = 0;
+    uint64_t    size               = 0;
+};
+
+struct kernel_t
+{
+    uint64_t    kernel_id{};
+    std::string name{};
+};
+
+struct instruction_t
+{
+    std::string name{};
+    std::string comment{};
+    uint64_t    virtual_address = 0;
+    uint64_t    code_obj_offset = 0;
+    size_t      size{0};
+};
+}  // namespace rocprofiler_compute_tool

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/code_object_writer.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/code_object_writer.cpp
@@ -32,13 +32,13 @@ void code_object_writer_json_t::end_code_obj()
     m_symbols = nlohmann::json::array();
 }
 
-void code_object_writer_json_t::write_kernel(uint64_t kernel_id, const std::string& name)
+void code_object_writer_json_t::write_kernel(const kernel_t& kernel)
 {
     Expects(m_code_object_closure_count != 0);
 
     m_kernels.push_back(nlohmann::json::object({
-        {"kernel_id", kernel_id},
-        {"name", name},
+        {"kernel_id", kernel.kernel_id},
+        {"name", kernel.name},
     }));
 }
 

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/code_object_writer.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/code_object_writer.cpp
@@ -25,7 +25,20 @@ void code_object_writer_json_t::end_code_obj()
 
     m_code_objects.push_back(nlohmann::json::object({
         {"id", m_current_obj_id},
+        {"kernels", std::move(m_kernels)},
         {"symbols", std::move(m_symbols)},
+    }));
+    m_kernels = nlohmann::json::array();
+    m_symbols = nlohmann::json::array();
+}
+
+void code_object_writer_json_t::write_kernel(uint64_t kernel_id, const std::string& name)
+{
+    Expects(m_code_object_closure_count != 0);
+
+    m_kernels.push_back(nlohmann::json::object({
+        {"kernel_id", kernel_id},
+        {"name", name},
     }));
 }
 
@@ -50,6 +63,7 @@ void code_object_writer_json_t::end_symbol()
         {"size", m_current_symbol.size},
         {"instructions", std::move(m_instructions)},
     }));
+    m_instructions = nlohmann::json::array();
 }
 
 void code_object_writer_json_t::write_instruction(const instruction_t& inst)

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/code_object_writer.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/code_object_writer.h
@@ -1,7 +1,7 @@
 // Copyright (c) Advanced Micro Devices, Inc.
 // SPDX-License-Identifier:  MIT
 #pragma once
-#include "code_object_translator.h"
+#include "code_object_types.h"
 #include "nlohmann/json.hpp"
 
 #include <filesystem>
@@ -16,15 +16,16 @@ class code_object_writer_t
 public:
     using ptr = std::shared_ptr<code_object_writer_t>;
 
-    virtual ~code_object_writer_t()                                  = default;
-    virtual void        start_code_obj(size_t obj_id)                = 0;
-    virtual void        end_code_obj()                               = 0;
-    virtual void        start_symbol(const symbol_t& symbol)         = 0;
-    virtual void        end_symbol()                                 = 0;
-    virtual void        write_instruction(const instruction_t& inst) = 0;
-    virtual std::string get_result()                                 = 0;
-    virtual void        flush(const std::filesystem::path& string)   = 0;
-    virtual bool        empty() const                                = 0;
+    virtual ~code_object_writer_t()                                               = default;
+    virtual void        start_code_obj(size_t obj_id)                             = 0;
+    virtual void        end_code_obj()                                            = 0;
+    virtual void        write_kernel(uint64_t kernel_id, const std::string& name) = 0;
+    virtual void        start_symbol(const symbol_t& symbol)                      = 0;
+    virtual void        end_symbol()                                              = 0;
+    virtual void        write_instruction(const instruction_t& inst)              = 0;
+    virtual std::string get_result()                                              = 0;
+    virtual void        flush(const std::filesystem::path& string)                = 0;
+    virtual bool        empty() const                                             = 0;
 };
 
 class code_object_writer_json_t : public code_object_writer_t
@@ -32,6 +33,7 @@ class code_object_writer_json_t : public code_object_writer_t
 public:
     void        start_code_obj(size_t obj_id) override;
     void        end_code_obj() override;
+    void        write_kernel(uint64_t kernel_id, const std::string& name) override;
     void        start_symbol(const symbol_t& symbol) override;
     void        end_symbol() override;
     void        write_instruction(const instruction_t& inst) override;
@@ -48,6 +50,7 @@ private:
     size_t                  m_current_obj_id = 0;
     symbol_t                m_current_symbol{};
     nlohmann::json::array_t m_code_objects = nlohmann::json::array();
+    nlohmann::json::array_t m_kernels      = nlohmann::json::array();
     nlohmann::json::array_t m_symbols      = nlohmann::json::array();
     nlohmann::json::array_t m_instructions = nlohmann::json::array();
 };

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/code_object_writer.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/code_object_writer.h
@@ -16,16 +16,16 @@ class code_object_writer_t
 public:
     using ptr = std::shared_ptr<code_object_writer_t>;
 
-    virtual ~code_object_writer_t()                                               = default;
-    virtual void        start_code_obj(size_t obj_id)                             = 0;
-    virtual void        end_code_obj()                                            = 0;
-    virtual void        write_kernel(uint64_t kernel_id, const std::string& name) = 0;
-    virtual void        start_symbol(const symbol_t& symbol)                      = 0;
-    virtual void        end_symbol()                                              = 0;
-    virtual void        write_instruction(const instruction_t& inst)              = 0;
-    virtual std::string get_result()                                              = 0;
-    virtual void        flush(const std::filesystem::path& string)                = 0;
-    virtual bool        empty() const                                             = 0;
+    virtual ~code_object_writer_t()                                  = default;
+    virtual void        start_code_obj(size_t obj_id)                = 0;
+    virtual void        end_code_obj()                               = 0;
+    virtual void        write_kernel(const kernel_t& kernel)         = 0;
+    virtual void        start_symbol(const symbol_t& symbol)         = 0;
+    virtual void        end_symbol()                                 = 0;
+    virtual void        write_instruction(const instruction_t& inst) = 0;
+    virtual std::string get_result()                                 = 0;
+    virtual void        flush(const std::filesystem::path& string)   = 0;
+    virtual bool        empty() const                                = 0;
 };
 
 class code_object_writer_json_t : public code_object_writer_t
@@ -33,7 +33,7 @@ class code_object_writer_json_t : public code_object_writer_t
 public:
     void        start_code_obj(size_t obj_id) override;
     void        end_code_obj() override;
-    void        write_kernel(uint64_t kernel_id, const std::string& name) override;
+    void        write_kernel(const kernel_t& kernel) override;
     void        start_symbol(const symbol_t& symbol) override;
     void        end_symbol() override;
     void        write_instruction(const instruction_t& inst) override;

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sampling_collector.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sampling_collector.cpp
@@ -103,11 +103,25 @@ void pc_sampling_collector_impl_t::on_code_object_load(
     }
 }
 
+void pc_sampling_collector_impl_t::on_kernel_symbol_register(size_t             code_object_id,
+                                                             uint64_t           kernel_id,
+                                                             const std::string& name)
+{
+    m_kernels_by_obj[code_object_id].push_back({kernel_id, name});
+}
+
 void pc_sampling_collector_impl_t::finalize(code_object_writer_t& writer)
 {
     for (const auto& id : m_translator->get_code_object_ids())
     {
         writer.start_code_obj(id);
+        if (const auto kernels = m_kernels_by_obj.find(id); kernels != m_kernels_by_obj.end())
+        {
+            for (const auto& kernel : kernels->second)
+            {
+                writer.write_kernel(kernel.kernel_id, kernel.name);
+            }
+        }
         const auto& symbols = m_translator->get_symbols(id);
         for (const auto& sym : symbols)
         {

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sampling_collector.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sampling_collector.cpp
@@ -103,11 +103,9 @@ void pc_sampling_collector_impl_t::on_code_object_load(
     }
 }
 
-void pc_sampling_collector_impl_t::on_kernel_symbol_register(size_t             code_object_id,
-                                                             uint64_t           kernel_id,
-                                                             const std::string& name)
+void pc_sampling_collector_impl_t::on_kernel_symbol_register(size_t code_object_id, const kernel_t& kernel)
 {
-    m_kernels_by_obj[code_object_id].push_back({kernel_id, name});
+    m_kernels_by_obj[code_object_id].push_back(kernel);
 }
 
 void pc_sampling_collector_impl_t::finalize(code_object_writer_t& writer)
@@ -119,7 +117,7 @@ void pc_sampling_collector_impl_t::finalize(code_object_writer_t& writer)
         {
             for (const auto& kernel : kernels->second)
             {
-                writer.write_kernel(kernel.kernel_id, kernel.name);
+                writer.write_kernel(kernel);
             }
         }
         const auto& symbols = m_translator->get_symbols(id);

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sampling_collector.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sampling_collector.h
@@ -7,10 +7,14 @@
 
 #include <rocprofiler-sdk/rocprofiler.h>
 
+#include <cstddef>
 #include <filesystem>
+#include <map>
 #include <memory>
 #include <set>
+#include <string>
 #include <string_view>
+#include <vector>
 
 namespace rocprofiler_compute_tool
 {
@@ -30,8 +34,11 @@ public:
 
     virtual ~pc_sampling_collector_t() = default;
     virtual void on_code_object_load(const rocprofiler_callback_tracing_code_object_load_data_t& info) = 0;
-    virtual void                                   finalize(code_object_writer_t& writer) = 0;
-    virtual const std::set<std::filesystem::path>& get_source_paths() const               = 0;
+    virtual void on_kernel_symbol_register(size_t             code_object_id,
+                                           uint64_t           kernel_id,
+                                           const std::string& name)         = 0;
+    virtual void finalize(code_object_writer_t& writer)                     = 0;
+    virtual const std::set<std::filesystem::path>& get_source_paths() const = 0;
 };
 
 class pc_sampling_collector_impl_t : public pc_sampling_collector_t
@@ -40,6 +47,7 @@ public:
     pc_sampling_collector_impl_t(code_object_translator_t::ptr translator);
     pc_sampling_collector_impl_t(code_object_translator_t::ptr translator, sdk_wrapper_t::ptr sdk_wrapper);
     void on_code_object_load(const rocprofiler_callback_tracing_code_object_load_data_t& info) override;
+    void on_kernel_symbol_register(size_t code_object_id, uint64_t kernel_id, const std::string& name) override;
     void                                   finalize(code_object_writer_t& writer) override;
     const std::set<std::filesystem::path>& get_source_paths() const override;
 
@@ -50,8 +58,9 @@ private:
     void collect_source_paths_from_comment(std::string_view                 comment,
                                            std::set<std::filesystem::path>& source_paths) const;
 
-    code_object_translator_t::ptr   m_translator;
-    sdk_wrapper_t::ptr              m_sdk_wrapper;
-    std::set<std::filesystem::path> m_source_paths;
+    code_object_translator_t::ptr           m_translator;
+    sdk_wrapper_t::ptr                      m_sdk_wrapper;
+    std::set<std::filesystem::path>         m_source_paths;
+    std::map<size_t, std::vector<kernel_t>> m_kernels_by_obj;
 };
 }  // namespace rocprofiler_compute_tool

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sampling_collector.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/pc_sampling_collector.h
@@ -34,11 +34,9 @@ public:
 
     virtual ~pc_sampling_collector_t() = default;
     virtual void on_code_object_load(const rocprofiler_callback_tracing_code_object_load_data_t& info) = 0;
-    virtual void on_kernel_symbol_register(size_t             code_object_id,
-                                           uint64_t           kernel_id,
-                                           const std::string& name)         = 0;
-    virtual void finalize(code_object_writer_t& writer)                     = 0;
-    virtual const std::set<std::filesystem::path>& get_source_paths() const = 0;
+    virtual void on_kernel_symbol_register(size_t code_object_id, const kernel_t& kernel) = 0;
+    virtual void finalize(code_object_writer_t& writer)                                   = 0;
+    virtual const std::set<std::filesystem::path>& get_source_paths() const               = 0;
 };
 
 class pc_sampling_collector_impl_t : public pc_sampling_collector_t
@@ -47,8 +45,8 @@ public:
     pc_sampling_collector_impl_t(code_object_translator_t::ptr translator);
     pc_sampling_collector_impl_t(code_object_translator_t::ptr translator, sdk_wrapper_t::ptr sdk_wrapper);
     void on_code_object_load(const rocprofiler_callback_tracing_code_object_load_data_t& info) override;
-    void on_kernel_symbol_register(size_t code_object_id, uint64_t kernel_id, const std::string& name) override;
-    void                                   finalize(code_object_writer_t& writer) override;
+    void on_kernel_symbol_register(size_t code_object_id, const kernel_t& kernel) override;
+    void finalize(code_object_writer_t& writer) override;
     const std::set<std::filesystem::path>& get_source_paths() const override;
 
 private:

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/mocks.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/mocks.cpp
@@ -92,6 +92,8 @@ void mock_code_object_writer_t::end_code_obj()
     ++m_ended_code_obj_count;
 }
 
+void mock_code_object_writer_t::write_kernel(uint64_t, const std::string&) {}
+
 void mock_code_object_writer_t::start_symbol(const symbol_t& symbol)
 {
     m_symbol_descriptions.push_back(symbol);

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/mocks.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/mocks.cpp
@@ -93,9 +93,9 @@ void mock_code_object_writer_t::end_code_obj()
     ++m_ended_code_obj_count;
 }
 
-void mock_code_object_writer_t::write_kernel(uint64_t kernel_id, const std::string& name)
+void mock_code_object_writer_t::write_kernel(const kernel_t& kernel)
 {
-    m_kernel_descriptions.push_back({m_current_code_obj_id, kernel_id, name});
+    m_kernel_descriptions.push_back({m_current_code_obj_id, kernel.kernel_id, kernel.name});
 }
 
 void mock_code_object_writer_t::start_symbol(const symbol_t& symbol)

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/mocks.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/mocks.cpp
@@ -84,6 +84,7 @@ const std::vector<std::pair<size_t, uint64_t>>& mock_code_object_translator_t::g
 
 void mock_code_object_writer_t::start_code_obj(size_t obj_id)
 {
+    m_current_code_obj_id = obj_id;
     m_started_code_obj_ids.push_back(obj_id);
 }
 
@@ -92,7 +93,10 @@ void mock_code_object_writer_t::end_code_obj()
     ++m_ended_code_obj_count;
 }
 
-void mock_code_object_writer_t::write_kernel(uint64_t, const std::string&) {}
+void mock_code_object_writer_t::write_kernel(uint64_t kernel_id, const std::string& name)
+{
+    m_kernel_descriptions.push_back({m_current_code_obj_id, kernel_id, name});
+}
 
 void mock_code_object_writer_t::start_symbol(const symbol_t& symbol)
 {
@@ -129,6 +133,12 @@ const std::vector<size_t>& mock_code_object_writer_t::get_start_code_obj_ids() c
 uint32_t mock_code_object_writer_t::get_end_code_obj_count() const
 {
     return m_ended_code_obj_count;
+}
+
+const std::vector<mock_code_object_writer_t::kernel_description_t>&
+    mock_code_object_writer_t::get_kernel_descriptions() const
+{
+    return m_kernel_descriptions;
 }
 
 const std::vector<symbol_t>& mock_code_object_writer_t::get_symbol_descriptions() const

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/mocks.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/mocks.h
@@ -78,7 +78,7 @@ public:
 
     void        start_code_obj(size_t obj_id) override;
     void        end_code_obj() override;
-    void        write_kernel(uint64_t kernel_id, const std::string& name) override;
+    void        write_kernel(const rocprofiler_compute_tool::kernel_t& kernel) override;
     void        start_symbol(const rocprofiler_compute_tool::symbol_t& symbol) override;
     void        end_symbol() override;
     void        write_instruction(const rocprofiler_compute_tool::instruction_t& inst) override;

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/mocks.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/mocks.h
@@ -69,6 +69,13 @@ private:
 class mock_code_object_writer_t : public rocprofiler_compute_tool::code_object_writer_t
 {
 public:
+    struct kernel_description_t
+    {
+        size_t      code_object_id = 0;
+        uint64_t    kernel_id      = 0;
+        std::string name;
+    };
+
     void        start_code_obj(size_t obj_id) override;
     void        end_code_obj() override;
     void        write_kernel(uint64_t kernel_id, const std::string& name) override;
@@ -81,6 +88,7 @@ public:
 
     const std::vector<size_t>&                             get_start_code_obj_ids() const;
     uint32_t                                               get_end_code_obj_count() const;
+    const std::vector<kernel_description_t>&               get_kernel_descriptions() const;
     const std::vector<rocprofiler_compute_tool::symbol_t>& get_symbol_descriptions() const;
     const std::vector<rocprofiler_compute_tool::instruction_t>& get_instruction_descriptions() const;
     uint32_t get_end_symbol_count() const;
@@ -88,6 +96,8 @@ public:
 private:
     std::vector<size_t>                                  m_started_code_obj_ids;
     uint32_t                                             m_ended_code_obj_count = 0;
+    size_t                                               m_current_code_obj_id  = 0;
+    std::vector<kernel_description_t>                    m_kernel_descriptions;
     std::vector<rocprofiler_compute_tool::symbol_t>      m_symbol_descriptions;
     std::vector<rocprofiler_compute_tool::instruction_t> m_instructions;
     uint32_t                                             m_end_symbol_count = 0;

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/mocks.h
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/mocks.h
@@ -71,6 +71,7 @@ class mock_code_object_writer_t : public rocprofiler_compute_tool::code_object_w
 public:
     void        start_code_obj(size_t obj_id) override;
     void        end_code_obj() override;
+    void        write_kernel(uint64_t kernel_id, const std::string& name) override;
     void        start_symbol(const rocprofiler_compute_tool::symbol_t& symbol) override;
     void        end_symbol() override;
     void        write_instruction(const rocprofiler_compute_tool::instruction_t& inst) override;

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_code_object_writer.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_code_object_writer.cpp
@@ -112,6 +112,18 @@ TEST_F(test_code_object_writer_t, ProvidedWriteInstructionAfterEndCodeObj_Throws
                  std::runtime_error);
 }
 
+TEST_F(test_code_object_writer_t, ProvidedWriteKernelWithoutAnyScope_Throws)
+{
+    EXPECT_THROW(m_writer.write_kernel(1, "kernel0"), std::runtime_error);
+}
+
+TEST_F(test_code_object_writer_t, ProvidedWriteKernelAfterEndCodeObj_Throws)
+{
+    m_writer.start_code_obj(0);
+    m_writer.end_code_obj();
+    EXPECT_THROW(m_writer.write_kernel(1, "kernel0"), std::runtime_error);
+}
+
 TEST_F(test_code_object_writer_t, ProvidedCodeObjDesc_SerializesIt)
 {
     constexpr uint32_t id0 = 10;
@@ -135,6 +147,76 @@ TEST_F(test_code_object_writer_t, ProvidedNoSymbols_SerializesEmptySymbolsArray)
     ASSERT_TRUE(json["code_objects"][0].contains("symbols"));
     EXPECT_TRUE(json["code_objects"][0]["symbols"].is_array());
     EXPECT_EQ(json["code_objects"][0]["symbols"].size(), 0);
+}
+
+TEST_F(test_code_object_writer_t, ProvidedNoKernels_SerializesEmptyKernelsArray)
+{
+    m_writer.start_code_obj(1);
+    m_writer.end_code_obj();
+
+    const auto json = nlohmann::json::parse(m_writer.get_result());
+    ASSERT_TRUE(json["code_objects"][0].contains("kernels"));
+    EXPECT_TRUE(json["code_objects"][0]["kernels"].is_array());
+    EXPECT_EQ(json["code_objects"][0]["kernels"].size(), 0);
+}
+
+TEST_F(test_code_object_writer_t, ProvidedKernel_SerializesItInsideCodeObj)
+{
+    constexpr uint64_t kernel_id = 42;
+    const std::string  name      = "kernel0";
+
+    m_writer.start_code_obj(1);
+    m_writer.write_kernel(kernel_id, name);
+    m_writer.end_code_obj();
+
+    const auto  json    = nlohmann::json::parse(m_writer.get_result());
+    const auto& kernels = json["code_objects"][0]["kernels"];
+    ASSERT_EQ(kernels.size(), 1);
+    EXPECT_EQ(kernels[0]["kernel_id"].get<uint64_t>(), kernel_id);
+    EXPECT_EQ(kernels[0]["name"].get<std::string>(), name);
+}
+
+TEST_F(test_code_object_writer_t, ProvidedMultipleKernels_SerializesAllInOrder)
+{
+    m_writer.start_code_obj(1);
+    m_writer.write_kernel(42, "kernel0");
+    m_writer.write_kernel(43, "kernel1");
+    m_writer.end_code_obj();
+
+    const auto  json    = nlohmann::json::parse(m_writer.get_result());
+    const auto& kernels = json["code_objects"][0]["kernels"];
+    ASSERT_EQ(kernels.size(), 2);
+    EXPECT_EQ(kernels[0]["kernel_id"].get<uint64_t>(), 42);
+    EXPECT_EQ(kernels[0]["name"].get<std::string>(), "kernel0");
+    EXPECT_EQ(kernels[1]["kernel_id"].get<uint64_t>(), 43);
+    EXPECT_EQ(kernels[1]["name"].get<std::string>(), "kernel1");
+}
+
+TEST_F(test_code_object_writer_t, ProvidedKernelsInDifferentCodeObjs_SerializesUnderRespectiveOwners)
+{
+    m_writer.start_code_obj(100);
+    m_writer.write_kernel(42, "kernel0");
+    m_writer.write_kernel(43, "kernel1");
+    m_writer.end_code_obj();
+
+    m_writer.start_code_obj(200);
+    m_writer.write_kernel(44, "kernel2");
+    m_writer.end_code_obj();
+
+    const auto json = nlohmann::json::parse(m_writer.get_result());
+    ASSERT_EQ(json["code_objects"].size(), 2u);
+
+    EXPECT_EQ(json["code_objects"][0]["id"], 100);
+    ASSERT_EQ(json["code_objects"][0]["kernels"].size(), 2);
+    EXPECT_EQ(json["code_objects"][0]["kernels"][0]["kernel_id"].get<uint64_t>(), 42);
+    EXPECT_EQ(json["code_objects"][0]["kernels"][0]["name"].get<std::string>(), "kernel0");
+    EXPECT_EQ(json["code_objects"][0]["kernels"][1]["kernel_id"].get<uint64_t>(), 43);
+    EXPECT_EQ(json["code_objects"][0]["kernels"][1]["name"].get<std::string>(), "kernel1");
+
+    EXPECT_EQ(json["code_objects"][1]["id"], 200);
+    ASSERT_EQ(json["code_objects"][1]["kernels"].size(), 1);
+    EXPECT_EQ(json["code_objects"][1]["kernels"][0]["kernel_id"].get<uint64_t>(), 44);
+    EXPECT_EQ(json["code_objects"][1]["kernels"][0]["name"].get<std::string>(), "kernel2");
 }
 
 TEST_F(test_code_object_writer_t, ProvidedSymbol_SerializesItInsideCodeObj)
@@ -219,6 +301,34 @@ TEST_F(test_code_object_writer_t, ProvidedInstruction_SerializesItInsideSymbol)
 
     const auto  json         = nlohmann::json::parse(m_writer.get_result());
     const auto& instructions = json["code_objects"][0]["symbols"][0]["instructions"];
+    ASSERT_EQ(instructions.size(), 1);
+    EXPECT_EQ(instructions[0]["name"], m_inst0.name);
+    EXPECT_EQ(instructions[0]["comment"], m_inst0.comment);
+    EXPECT_EQ(instructions[0]["virtual_address"], m_inst0.virtual_address);
+    EXPECT_EQ(instructions[0]["code_obj_offset"], m_inst0.code_obj_offset);
+    EXPECT_EQ(instructions[0]["size"], m_inst0.size);
+}
+
+TEST_F(test_code_object_writer_t, ProvidedKernelAndInstruction_PreservesInstructionOutput)
+{
+    m_writer.start_code_obj(1);
+    m_writer.write_kernel(42, "kernel0");
+    m_writer.start_symbol(m_symbol0);
+    m_writer.write_instruction(m_inst0);
+    m_writer.end_symbol();
+    m_writer.end_code_obj();
+
+    const auto  json    = nlohmann::json::parse(m_writer.get_result());
+    const auto& obj     = json["code_objects"][0];
+    const auto& symbols = obj["symbols"];
+    ASSERT_EQ(obj["kernels"].size(), 1);
+    ASSERT_EQ(symbols.size(), 1);
+    EXPECT_EQ(symbols[0]["name"], m_symbol0.name);
+    EXPECT_EQ(symbols[0]["code_object_offset"], m_symbol0.code_object_offset);
+    EXPECT_EQ(symbols[0]["virtual_address"], m_symbol0.virtual_address);
+    EXPECT_EQ(symbols[0]["size"], m_symbol0.size);
+
+    const auto& instructions = symbols[0]["instructions"];
     ASSERT_EQ(instructions.size(), 1);
     EXPECT_EQ(instructions[0]["name"], m_inst0.name);
     EXPECT_EQ(instructions[0]["comment"], m_inst0.comment);

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_code_object_writer.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_code_object_writer.cpp
@@ -142,14 +142,16 @@ TEST_F(test_code_object_writer_t, ProvidedWriteInstructionAfterEndCodeObj_Throws
 
 TEST_F(test_code_object_writer_t, ProvidedWriteKernelWithoutAnyScope_Throws)
 {
-    expect_runtime_throw([&]() { m_writer.write_kernel(1, "kernel0"); });
+    expect_runtime_throw(
+        [&]() { m_writer.write_kernel(rocprofiler_compute_tool::kernel_t{1, "kernel0"}); });
 }
 
 TEST_F(test_code_object_writer_t, ProvidedWriteKernelAfterEndCodeObj_Throws)
 {
     m_writer.start_code_obj(0);
     m_writer.end_code_obj();
-    expect_runtime_throw([&]() { m_writer.write_kernel(1, "kernel0"); });
+    expect_runtime_throw(
+        [&]() { m_writer.write_kernel(rocprofiler_compute_tool::kernel_t{1, "kernel0"}); });
 }
 
 TEST_F(test_code_object_writer_t, ProvidedCodeObjDesc_SerializesIt)
@@ -190,24 +192,23 @@ TEST_F(test_code_object_writer_t, ProvidedNoKernels_SerializesEmptyKernelsArray)
 
 TEST_F(test_code_object_writer_t, ProvidedKernel_SerializesItInsideCodeObj)
 {
-    constexpr uint64_t kernel_id = 42;
-    const std::string  name      = "kernel0";
+    const rocprofiler_compute_tool::kernel_t kernel{42, "kernel0"};
 
     m_writer.start_code_obj(1);
-    m_writer.write_kernel(kernel_id, name);
+    m_writer.write_kernel(kernel);
     m_writer.end_code_obj();
 
     const auto  json    = nlohmann::json::parse(m_writer.get_result());
     const auto& kernels = json["code_objects"][0]["kernels"];
     ASSERT_EQ(kernels.size(), 1);
-    expect_kernel_json(kernels[0], kernel_id, name);
+    expect_kernel_json(kernels[0], kernel.kernel_id, kernel.name);
 }
 
 TEST_F(test_code_object_writer_t, ProvidedMultipleKernels_SerializesAllInOrder)
 {
     m_writer.start_code_obj(1);
-    m_writer.write_kernel(42, "kernel0");
-    m_writer.write_kernel(43, "kernel1");
+    m_writer.write_kernel(rocprofiler_compute_tool::kernel_t{42, "kernel0"});
+    m_writer.write_kernel(rocprofiler_compute_tool::kernel_t{43, "kernel1"});
     m_writer.end_code_obj();
 
     const auto  json    = nlohmann::json::parse(m_writer.get_result());
@@ -220,12 +221,12 @@ TEST_F(test_code_object_writer_t, ProvidedMultipleKernels_SerializesAllInOrder)
 TEST_F(test_code_object_writer_t, ProvidedKernelsInDifferentCodeObjs_SerializesUnderRespectiveOwners)
 {
     m_writer.start_code_obj(100);
-    m_writer.write_kernel(42, "kernel0");
-    m_writer.write_kernel(43, "kernel1");
+    m_writer.write_kernel(rocprofiler_compute_tool::kernel_t{42, "kernel0"});
+    m_writer.write_kernel(rocprofiler_compute_tool::kernel_t{43, "kernel1"});
     m_writer.end_code_obj();
 
     m_writer.start_code_obj(200);
-    m_writer.write_kernel(44, "kernel2");
+    m_writer.write_kernel(rocprofiler_compute_tool::kernel_t{44, "kernel2"});
     m_writer.end_code_obj();
 
     const auto json = nlohmann::json::parse(m_writer.get_result());
@@ -330,7 +331,7 @@ TEST_F(test_code_object_writer_t, ProvidedInstruction_SerializesItInsideSymbol)
 TEST_F(test_code_object_writer_t, ProvidedKernelAndInstruction_PreservesInstructionOutput)
 {
     m_writer.start_code_obj(1);
-    m_writer.write_kernel(42, "kernel0");
+    m_writer.write_kernel(rocprofiler_compute_tool::kernel_t{42, "kernel0"});
     m_writer.start_symbol(m_symbol0);
     m_writer.write_instruction(m_inst0);
     m_writer.end_symbol();

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_code_object_writer.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_code_object_writer.cpp
@@ -4,6 +4,34 @@
 
 #include "nlohmann/json.hpp"
 
+#include <string>
+#include <string_view>
+
+namespace
+{
+template<typename Operation>
+void expect_runtime_throw(Operation operation)
+{
+    EXPECT_THROW(operation(), std::runtime_error);
+}
+
+void expect_kernel_json(const nlohmann::json& kernel, uint64_t id, std::string_view name)
+{
+    EXPECT_EQ(kernel["kernel_id"].get<uint64_t>(), id);
+    EXPECT_EQ(kernel["name"].get<std::string>(), std::string{name});
+}
+
+void expect_instruction_json(const nlohmann::json&                          instruction,
+                             const rocprofiler_compute_tool::instruction_t& expected)
+{
+    EXPECT_EQ(instruction["name"], expected.name);
+    EXPECT_EQ(instruction["comment"], expected.comment);
+    EXPECT_EQ(instruction["virtual_address"], expected.virtual_address);
+    EXPECT_EQ(instruction["code_obj_offset"], expected.code_obj_offset);
+    EXPECT_EQ(instruction["size"], expected.size);
+}
+}  // namespace
+
 TEST_F(test_code_object_writer_t, ProvidedNoData_ReturnsMinimalJson)
 {
     const auto& result = m_writer.get_result();
@@ -26,45 +54,45 @@ TEST_F(test_code_object_writer_t, ProvidedCodeObject_IsNotEmpty)
 TEST_F(test_code_object_writer_t, ProvidedStartCodeObjWithoutEnd_Throws)
 {
     m_writer.start_code_obj(0);
-    EXPECT_THROW(m_writer.get_result(), std::runtime_error);
+    expect_runtime_throw([&]() { m_writer.get_result(); });
 }
 
 TEST_F(test_code_object_writer_t, ProvidedEndCodeObjWithoutStart_Throws)
 {
-    EXPECT_THROW(m_writer.end_code_obj(), std::runtime_error);
+    expect_runtime_throw([&]() { m_writer.end_code_obj(); });
 }
 
 TEST_F(test_code_object_writer_t, ProvidedTwoStartCodeObjCalls_Throws)
 {
     m_writer.start_code_obj(0);
-    EXPECT_THROW(m_writer.start_code_obj(1), std::runtime_error);
+    expect_runtime_throw([&]() { m_writer.start_code_obj(1); });
 }
 
 TEST_F(test_code_object_writer_t, ProvidedTwoEndCodeObjCalls_Throws)
 {
     m_writer.start_code_obj(0);
     m_writer.end_code_obj();
-    EXPECT_THROW(m_writer.end_code_obj(), std::runtime_error);
+    expect_runtime_throw([&]() { m_writer.end_code_obj(); });
 }
 
 TEST_F(test_code_object_writer_t, ProvidedStartSymbolWithoutEnd_Throws)
 {
     m_writer.start_code_obj(0);
     m_writer.start_symbol(rocprofiler_compute_tool::symbol_t{});
-    EXPECT_THROW(m_writer.get_result(), std::runtime_error);
+    expect_runtime_throw([&]() { m_writer.get_result(); });
 }
 
 TEST_F(test_code_object_writer_t, ProvidedEndSymbolWithoutStart_Throws)
 {
     m_writer.start_code_obj(0);
-    EXPECT_THROW(m_writer.end_symbol(), std::runtime_error);
+    expect_runtime_throw([&]() { m_writer.end_symbol(); });
 }
 
 TEST_F(test_code_object_writer_t, ProvidedTwoStartSymbolCalls_Throws)
 {
     m_writer.start_code_obj(0);
     m_writer.start_symbol(rocprofiler_compute_tool::symbol_t{});
-    EXPECT_THROW(m_writer.start_symbol(rocprofiler_compute_tool::symbol_t{}), std::runtime_error);
+    expect_runtime_throw([&]() { m_writer.start_symbol(rocprofiler_compute_tool::symbol_t{}); });
 }
 
 TEST_F(test_code_object_writer_t, ProvidedTwoEndSymbolCalls_Throws)
@@ -72,25 +100,25 @@ TEST_F(test_code_object_writer_t, ProvidedTwoEndSymbolCalls_Throws)
     m_writer.start_code_obj(0);
     m_writer.start_symbol(rocprofiler_compute_tool::symbol_t{});
     m_writer.end_symbol();
-    EXPECT_THROW(m_writer.end_symbol(), std::runtime_error);
+    expect_runtime_throw([&]() { m_writer.end_symbol(); });
 }
 
 TEST_F(test_code_object_writer_t, ProvidedSymbolCallWithoutStartCodeObj_Throws)
 {
-    EXPECT_THROW(m_writer.start_symbol(rocprofiler_compute_tool::symbol_t{}), std::runtime_error);
+    expect_runtime_throw([&]() { m_writer.start_symbol(rocprofiler_compute_tool::symbol_t{}); });
 }
 
 TEST_F(test_code_object_writer_t, ProvidedWriteInstructionWithoutAnyScope_Throws)
 {
-    EXPECT_THROW(m_writer.write_instruction(rocprofiler_compute_tool::instruction_t{}),
-                 std::runtime_error);
+    expect_runtime_throw([&]()
+                         { m_writer.write_instruction(rocprofiler_compute_tool::instruction_t{}); });
 }
 
 TEST_F(test_code_object_writer_t, ProvidedWriteInstructionInsideCodeObjWithoutSymbol_Throws)
 {
     m_writer.start_code_obj(0);
-    EXPECT_THROW(m_writer.write_instruction(rocprofiler_compute_tool::instruction_t{}),
-                 std::runtime_error);
+    expect_runtime_throw([&]()
+                         { m_writer.write_instruction(rocprofiler_compute_tool::instruction_t{}); });
 }
 
 TEST_F(test_code_object_writer_t, ProvidedWriteInstructionAfterEndSymbol_Throws)
@@ -98,8 +126,8 @@ TEST_F(test_code_object_writer_t, ProvidedWriteInstructionAfterEndSymbol_Throws)
     m_writer.start_code_obj(0);
     m_writer.start_symbol(rocprofiler_compute_tool::symbol_t{});
     m_writer.end_symbol();
-    EXPECT_THROW(m_writer.write_instruction(rocprofiler_compute_tool::instruction_t{}),
-                 std::runtime_error);
+    expect_runtime_throw([&]()
+                         { m_writer.write_instruction(rocprofiler_compute_tool::instruction_t{}); });
 }
 
 TEST_F(test_code_object_writer_t, ProvidedWriteInstructionAfterEndCodeObj_Throws)
@@ -108,20 +136,20 @@ TEST_F(test_code_object_writer_t, ProvidedWriteInstructionAfterEndCodeObj_Throws
     m_writer.start_symbol(rocprofiler_compute_tool::symbol_t{});
     m_writer.end_symbol();
     m_writer.end_code_obj();
-    EXPECT_THROW(m_writer.write_instruction(rocprofiler_compute_tool::instruction_t{}),
-                 std::runtime_error);
+    expect_runtime_throw([&]()
+                         { m_writer.write_instruction(rocprofiler_compute_tool::instruction_t{}); });
 }
 
 TEST_F(test_code_object_writer_t, ProvidedWriteKernelWithoutAnyScope_Throws)
 {
-    EXPECT_THROW(m_writer.write_kernel(1, "kernel0"), std::runtime_error);
+    expect_runtime_throw([&]() { m_writer.write_kernel(1, "kernel0"); });
 }
 
 TEST_F(test_code_object_writer_t, ProvidedWriteKernelAfterEndCodeObj_Throws)
 {
     m_writer.start_code_obj(0);
     m_writer.end_code_obj();
-    EXPECT_THROW(m_writer.write_kernel(1, "kernel0"), std::runtime_error);
+    expect_runtime_throw([&]() { m_writer.write_kernel(1, "kernel0"); });
 }
 
 TEST_F(test_code_object_writer_t, ProvidedCodeObjDesc_SerializesIt)
@@ -172,8 +200,7 @@ TEST_F(test_code_object_writer_t, ProvidedKernel_SerializesItInsideCodeObj)
     const auto  json    = nlohmann::json::parse(m_writer.get_result());
     const auto& kernels = json["code_objects"][0]["kernels"];
     ASSERT_EQ(kernels.size(), 1);
-    EXPECT_EQ(kernels[0]["kernel_id"].get<uint64_t>(), kernel_id);
-    EXPECT_EQ(kernels[0]["name"].get<std::string>(), name);
+    expect_kernel_json(kernels[0], kernel_id, name);
 }
 
 TEST_F(test_code_object_writer_t, ProvidedMultipleKernels_SerializesAllInOrder)
@@ -186,10 +213,8 @@ TEST_F(test_code_object_writer_t, ProvidedMultipleKernels_SerializesAllInOrder)
     const auto  json    = nlohmann::json::parse(m_writer.get_result());
     const auto& kernels = json["code_objects"][0]["kernels"];
     ASSERT_EQ(kernels.size(), 2);
-    EXPECT_EQ(kernels[0]["kernel_id"].get<uint64_t>(), 42);
-    EXPECT_EQ(kernels[0]["name"].get<std::string>(), "kernel0");
-    EXPECT_EQ(kernels[1]["kernel_id"].get<uint64_t>(), 43);
-    EXPECT_EQ(kernels[1]["name"].get<std::string>(), "kernel1");
+    expect_kernel_json(kernels[0], 42, "kernel0");
+    expect_kernel_json(kernels[1], 43, "kernel1");
 }
 
 TEST_F(test_code_object_writer_t, ProvidedKernelsInDifferentCodeObjs_SerializesUnderRespectiveOwners)
@@ -208,15 +233,12 @@ TEST_F(test_code_object_writer_t, ProvidedKernelsInDifferentCodeObjs_SerializesU
 
     EXPECT_EQ(json["code_objects"][0]["id"], 100);
     ASSERT_EQ(json["code_objects"][0]["kernels"].size(), 2);
-    EXPECT_EQ(json["code_objects"][0]["kernels"][0]["kernel_id"].get<uint64_t>(), 42);
-    EXPECT_EQ(json["code_objects"][0]["kernels"][0]["name"].get<std::string>(), "kernel0");
-    EXPECT_EQ(json["code_objects"][0]["kernels"][1]["kernel_id"].get<uint64_t>(), 43);
-    EXPECT_EQ(json["code_objects"][0]["kernels"][1]["name"].get<std::string>(), "kernel1");
+    expect_kernel_json(json["code_objects"][0]["kernels"][0], 42, "kernel0");
+    expect_kernel_json(json["code_objects"][0]["kernels"][1], 43, "kernel1");
 
     EXPECT_EQ(json["code_objects"][1]["id"], 200);
     ASSERT_EQ(json["code_objects"][1]["kernels"].size(), 1);
-    EXPECT_EQ(json["code_objects"][1]["kernels"][0]["kernel_id"].get<uint64_t>(), 44);
-    EXPECT_EQ(json["code_objects"][1]["kernels"][0]["name"].get<std::string>(), "kernel2");
+    expect_kernel_json(json["code_objects"][1]["kernels"][0], 44, "kernel2");
 }
 
 TEST_F(test_code_object_writer_t, ProvidedSymbol_SerializesItInsideCodeObj)
@@ -302,11 +324,7 @@ TEST_F(test_code_object_writer_t, ProvidedInstruction_SerializesItInsideSymbol)
     const auto  json         = nlohmann::json::parse(m_writer.get_result());
     const auto& instructions = json["code_objects"][0]["symbols"][0]["instructions"];
     ASSERT_EQ(instructions.size(), 1);
-    EXPECT_EQ(instructions[0]["name"], m_inst0.name);
-    EXPECT_EQ(instructions[0]["comment"], m_inst0.comment);
-    EXPECT_EQ(instructions[0]["virtual_address"], m_inst0.virtual_address);
-    EXPECT_EQ(instructions[0]["code_obj_offset"], m_inst0.code_obj_offset);
-    EXPECT_EQ(instructions[0]["size"], m_inst0.size);
+    expect_instruction_json(instructions[0], m_inst0);
 }
 
 TEST_F(test_code_object_writer_t, ProvidedKernelAndInstruction_PreservesInstructionOutput)
@@ -330,11 +348,7 @@ TEST_F(test_code_object_writer_t, ProvidedKernelAndInstruction_PreservesInstruct
 
     const auto& instructions = symbols[0]["instructions"];
     ASSERT_EQ(instructions.size(), 1);
-    EXPECT_EQ(instructions[0]["name"], m_inst0.name);
-    EXPECT_EQ(instructions[0]["comment"], m_inst0.comment);
-    EXPECT_EQ(instructions[0]["virtual_address"], m_inst0.virtual_address);
-    EXPECT_EQ(instructions[0]["code_obj_offset"], m_inst0.code_obj_offset);
-    EXPECT_EQ(instructions[0]["size"], m_inst0.size);
+    expect_instruction_json(instructions[0], m_inst0);
 }
 
 TEST_F(test_code_object_writer_t, ProvidedMultipleInstructions_SerializesAllInOrder)
@@ -349,8 +363,8 @@ TEST_F(test_code_object_writer_t, ProvidedMultipleInstructions_SerializesAllInOr
     const auto  json         = nlohmann::json::parse(m_writer.get_result());
     const auto& instructions = json["code_objects"][0]["symbols"][0]["instructions"];
     ASSERT_EQ(instructions.size(), 2);
-    EXPECT_EQ(instructions[0]["name"], m_inst0.name);
-    EXPECT_EQ(instructions[1]["name"], m_inst1.name);
+    expect_instruction_json(instructions[0], m_inst0);
+    expect_instruction_json(instructions[1], m_inst1);
 }
 
 TEST_F(test_code_object_writer_t, ProvidedInstructionsInDifferentSymbols_SerializesUnderRespectiveOwners)
@@ -380,5 +394,5 @@ TEST_F(test_code_object_writer_t, ProvidedInstructionsInDifferentSymbols_Seriali
 
 TEST_F(test_code_object_writer_t, ProvidedEmptyOutputFilePath_Throws)
 {
-    EXPECT_THROW(m_writer.flush(""), std::runtime_error);
+    expect_runtime_throw([&]() { m_writer.flush(""); });
 }

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_sampling_collector.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_sampling_collector.cpp
@@ -67,6 +67,67 @@ TEST_F(test_pc_sampling_collector_t, ProvidedCodeObjects_WritesTheirIds)
     EXPECT_EQ(m_writer->get_start_code_obj_ids()[1], m_mem_info.code_object_id);
 }
 
+TEST_F(test_pc_sampling_collector_t, ProvidedKernelSymbols_WritesThemUnderCodeObjects)
+{
+    m_pc_sampling_collector->on_code_object_load(m_file_info);
+    m_pc_sampling_collector->on_code_object_load(m_mem_info);
+    m_pc_sampling_collector->on_kernel_symbol_register(m_mem_info.code_object_id, 100, "kernel1");
+    m_pc_sampling_collector->on_kernel_symbol_register(m_file_info.code_object_id, 99, "kernel0");
+
+    m_pc_sampling_collector->finalize(*m_writer);
+
+    const auto& kernels = m_writer->get_kernel_descriptions();
+    ASSERT_EQ(kernels.size(), 2);
+    EXPECT_EQ(kernels[0].code_object_id, m_file_info.code_object_id);
+    EXPECT_EQ(kernels[0].kernel_id, 99);
+    EXPECT_EQ(kernels[0].name, "kernel0");
+    EXPECT_EQ(kernels[1].code_object_id, m_mem_info.code_object_id);
+    EXPECT_EQ(kernels[1].kernel_id, 100);
+    EXPECT_EQ(kernels[1].name, "kernel1");
+}
+
+TEST_F(test_pc_sampling_collector_t, ProvidedOrphanKernelSymbol_DoesNotWriteIt)
+{
+    m_pc_sampling_collector->on_code_object_load(m_file_info);
+    m_pc_sampling_collector->on_kernel_symbol_register(999, 100, "orphan");
+
+    m_pc_sampling_collector->finalize(*m_writer);
+
+    EXPECT_TRUE(m_writer->get_kernel_descriptions().empty());
+}
+
+TEST_F(test_pc_sampling_collector_t, ProvidedCodeObjectsWithoutKernelSymbols_WriteNoKernels)
+{
+    m_pc_sampling_collector->on_code_object_load(m_file_info);
+    m_pc_sampling_collector->on_code_object_load(m_mem_info);
+
+    m_pc_sampling_collector->finalize(*m_writer);
+
+    EXPECT_TRUE(m_writer->get_kernel_descriptions().empty());
+}
+
+TEST_F(test_pc_sampling_collector_t, ProvidedMultipleKernelSymbols_PreservesOrder)
+{
+    m_pc_sampling_collector->on_code_object_load(m_file_info);
+    m_pc_sampling_collector->on_kernel_symbol_register(m_file_info.code_object_id, 99, "kernel0");
+    m_pc_sampling_collector->on_kernel_symbol_register(m_file_info.code_object_id, 100, "kernel1");
+    m_pc_sampling_collector->on_kernel_symbol_register(m_file_info.code_object_id, 101, "kernel2");
+
+    m_pc_sampling_collector->finalize(*m_writer);
+
+    const auto& kernels = m_writer->get_kernel_descriptions();
+    ASSERT_EQ(kernels.size(), 3);
+    EXPECT_EQ(kernels[0].code_object_id, m_file_info.code_object_id);
+    EXPECT_EQ(kernels[0].kernel_id, 99);
+    EXPECT_EQ(kernels[0].name, "kernel0");
+    EXPECT_EQ(kernels[1].code_object_id, m_file_info.code_object_id);
+    EXPECT_EQ(kernels[1].kernel_id, 100);
+    EXPECT_EQ(kernels[1].name, "kernel1");
+    EXPECT_EQ(kernels[2].code_object_id, m_file_info.code_object_id);
+    EXPECT_EQ(kernels[2].kernel_id, 101);
+    EXPECT_EQ(kernels[2].name, "kernel2");
+}
+
 TEST_F(test_pc_sampling_collector_t, ProvidedCodeObjectSymbols_WritesThem)
 {
     m_pc_sampling_collector->on_code_object_load(m_file_info);

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_sampling_collector.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_sampling_collector.cpp
@@ -99,8 +99,10 @@ TEST_F(test_pc_sampling_collector_t, ProvidedKernelSymbols_WritesThemUnderCodeOb
 {
     m_pc_sampling_collector->on_code_object_load(m_file_info);
     m_pc_sampling_collector->on_code_object_load(m_mem_info);
-    m_pc_sampling_collector->on_kernel_symbol_register(m_mem_info.code_object_id, 100, "kernel1");
-    m_pc_sampling_collector->on_kernel_symbol_register(m_file_info.code_object_id, 99, "kernel0");
+    m_pc_sampling_collector->on_kernel_symbol_register(m_mem_info.code_object_id,
+                                                       kernel_t{100, "kernel1"});
+    m_pc_sampling_collector->on_kernel_symbol_register(m_file_info.code_object_id,
+                                                       kernel_t{99, "kernel0"});
 
     m_pc_sampling_collector->finalize(*m_writer);
 
@@ -113,7 +115,7 @@ TEST_F(test_pc_sampling_collector_t, ProvidedKernelSymbols_WritesThemUnderCodeOb
 TEST_F(test_pc_sampling_collector_t, ProvidedOrphanKernelSymbol_DoesNotWriteIt)
 {
     m_pc_sampling_collector->on_code_object_load(m_file_info);
-    m_pc_sampling_collector->on_kernel_symbol_register(999, 100, "orphan");
+    m_pc_sampling_collector->on_kernel_symbol_register(999, kernel_t{100, "orphan"});
 
     m_pc_sampling_collector->finalize(*m_writer);
 
@@ -133,9 +135,12 @@ TEST_F(test_pc_sampling_collector_t, ProvidedCodeObjectsWithoutKernelSymbols_Wri
 TEST_F(test_pc_sampling_collector_t, ProvidedMultipleKernelSymbols_PreservesOrder)
 {
     m_pc_sampling_collector->on_code_object_load(m_file_info);
-    m_pc_sampling_collector->on_kernel_symbol_register(m_file_info.code_object_id, 99, "kernel0");
-    m_pc_sampling_collector->on_kernel_symbol_register(m_file_info.code_object_id, 100, "kernel1");
-    m_pc_sampling_collector->on_kernel_symbol_register(m_file_info.code_object_id, 101, "kernel2");
+    m_pc_sampling_collector->on_kernel_symbol_register(m_file_info.code_object_id,
+                                                       kernel_t{99, "kernel0"});
+    m_pc_sampling_collector->on_kernel_symbol_register(m_file_info.code_object_id,
+                                                       kernel_t{100, "kernel1"});
+    m_pc_sampling_collector->on_kernel_symbol_register(m_file_info.code_object_id,
+                                                       kernel_t{101, "kernel2"});
 
     m_pc_sampling_collector->finalize(*m_writer);
 

--- a/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_sampling_collector.cpp
+++ b/projects/rocprofiler-compute/src/lib/pc_sampling_collector/tests/test_pc_sampling_collector.cpp
@@ -27,6 +27,34 @@ std::set<std::filesystem::path> collect_source_paths_from_comment(std::string co
     collector->finalize(*writer);
     return collector->get_source_paths();
 }
+
+void expect_kernel(const mock_code_object_writer_t::kernel_description_t& kernel,
+                   size_t                                                 code_object_id,
+                   uint64_t                                               kernel_id,
+                   const std::string&                                     name)
+{
+    EXPECT_EQ(kernel.code_object_id, code_object_id);
+    EXPECT_EQ(kernel.kernel_id, kernel_id);
+    EXPECT_EQ(kernel.name, name);
+}
+
+struct source_path_test_params_t
+{
+    std::string                     test_name;
+    std::string                     comment;
+    std::set<std::filesystem::path> expected_paths;
+    std::string                     separator = " -> ";
+};
+
+class test_pc_sampling_collector_source_paths_t
+    : public ::testing::TestWithParam<source_path_test_params_t>
+{
+};
+
+std::string source_path_test_name(const ::testing::TestParamInfo<source_path_test_params_t>& info)
+{
+    return info.param.test_name;
+}
 }  // namespace
 
 TEST_F(test_pc_sampling_collector_t, ProvidedFileCodeObject_PassesItToDecode)
@@ -78,12 +106,8 @@ TEST_F(test_pc_sampling_collector_t, ProvidedKernelSymbols_WritesThemUnderCodeOb
 
     const auto& kernels = m_writer->get_kernel_descriptions();
     ASSERT_EQ(kernels.size(), 2);
-    EXPECT_EQ(kernels[0].code_object_id, m_file_info.code_object_id);
-    EXPECT_EQ(kernels[0].kernel_id, 99);
-    EXPECT_EQ(kernels[0].name, "kernel0");
-    EXPECT_EQ(kernels[1].code_object_id, m_mem_info.code_object_id);
-    EXPECT_EQ(kernels[1].kernel_id, 100);
-    EXPECT_EQ(kernels[1].name, "kernel1");
+    expect_kernel(kernels[0], m_file_info.code_object_id, 99, "kernel0");
+    expect_kernel(kernels[1], m_mem_info.code_object_id, 100, "kernel1");
 }
 
 TEST_F(test_pc_sampling_collector_t, ProvidedOrphanKernelSymbol_DoesNotWriteIt)
@@ -117,15 +141,9 @@ TEST_F(test_pc_sampling_collector_t, ProvidedMultipleKernelSymbols_PreservesOrde
 
     const auto& kernels = m_writer->get_kernel_descriptions();
     ASSERT_EQ(kernels.size(), 3);
-    EXPECT_EQ(kernels[0].code_object_id, m_file_info.code_object_id);
-    EXPECT_EQ(kernels[0].kernel_id, 99);
-    EXPECT_EQ(kernels[0].name, "kernel0");
-    EXPECT_EQ(kernels[1].code_object_id, m_file_info.code_object_id);
-    EXPECT_EQ(kernels[1].kernel_id, 100);
-    EXPECT_EQ(kernels[1].name, "kernel1");
-    EXPECT_EQ(kernels[2].code_object_id, m_file_info.code_object_id);
-    EXPECT_EQ(kernels[2].kernel_id, 101);
-    EXPECT_EQ(kernels[2].name, "kernel2");
+    expect_kernel(kernels[0], m_file_info.code_object_id, 99, "kernel0");
+    expect_kernel(kernels[1], m_file_info.code_object_id, 100, "kernel1");
+    expect_kernel(kernels[2], m_file_info.code_object_id, 101, "kernel2");
 }
 
 TEST_F(test_pc_sampling_collector_t, ProvidedCodeObjectSymbols_WritesThem)
@@ -188,80 +206,11 @@ TEST_F(test_pc_sampling_collector_t, ProvidedSymbolInstructionSizeZero_Throws)
     EXPECT_THROW(m_pc_sampling_collector->finalize(*m_writer), std::runtime_error);
 }
 
-TEST(test_pc_sampling_collector_source_paths_t, ProvidedEmptyComment_ReturnsNoPaths)
+TEST_P(test_pc_sampling_collector_source_paths_t, ReturnsExpectedPaths)
 {
-    const auto paths = collect_source_paths_from_comment("");
-    EXPECT_TRUE(paths.empty());
-}
-
-TEST(test_pc_sampling_collector_source_paths_t, ProvidedSingleFileLine_ReturnsFilePath)
-{
-    const auto paths = collect_source_paths_from_comment("kernel.cpp:42");
-    const std::set<std::filesystem::path> expected = {"kernel.cpp"};
-    EXPECT_EQ(paths, expected);
-}
-
-TEST(test_pc_sampling_collector_source_paths_t, ProvidedMultipleFrames_ReturnsAllFilePaths)
-{
-    const auto paths = collect_source_paths_from_comment("kernel.cpp:42 -> header.h:8");
-    const std::set<std::filesystem::path> expected = {"header.h", "kernel.cpp"};
-    EXPECT_EQ(paths, expected);
-}
-
-TEST(test_pc_sampling_collector_source_paths_t, ProvidedInjectedFrameSeparator_ReturnsAllFilePaths)
-{
-    const auto paths = collect_source_paths_from_comment("kernel.cpp:42 | header.h:8", " | ");
-    const std::set<std::filesystem::path> expected = {"header.h", "kernel.cpp"};
-    EXPECT_EQ(paths, expected);
-}
-
-TEST(test_pc_sampling_collector_source_paths_t, ProvidedUnknownLineToken_ReturnsFilePath)
-{
-    const auto                            paths = collect_source_paths_from_comment("kernel.cpp:?");
-    const std::set<std::filesystem::path> expected = {"kernel.cpp"};
-    EXPECT_EQ(paths, expected);
-}
-
-TEST(test_pc_sampling_collector_source_paths_t, ProvidedNoColonFrame_ReturnsWholeFrame)
-{
-    const auto                            paths = collect_source_paths_from_comment("kernel.cpp");
-    const std::set<std::filesystem::path> expected = {"kernel.cpp"};
-    EXPECT_EQ(paths, expected);
-}
-
-TEST(test_pc_sampling_collector_source_paths_t, ProvidedTrailingColon_ReturnsWholeFrame)
-{
-    const auto                            paths = collect_source_paths_from_comment("kernel.cpp:");
-    const std::set<std::filesystem::path> expected = {"kernel.cpp:"};
-    EXPECT_EQ(paths, expected);
-}
-
-TEST(test_pc_sampling_collector_source_paths_t, ProvidedDuplicateFrames_ReturnsDeduplicatedPaths)
-{
-    const auto paths = collect_source_paths_from_comment("kernel.cpp:42 -> kernel.cpp:42");
-    const std::set<std::filesystem::path> expected = {"kernel.cpp"};
-    EXPECT_EQ(paths, expected);
-}
-
-TEST(test_pc_sampling_collector_source_paths_t, ProvidedPathWithDirectories_ReturnsDirectoryPath)
-{
-    const auto paths = collect_source_paths_from_comment("/tmp/project/include/header.h:8");
-    const std::set<std::filesystem::path> expected = {"/tmp/project/include/header.h"};
-    EXPECT_EQ(paths, expected);
-}
-
-TEST(test_pc_sampling_collector_source_paths_t, ProvidedTrailingSeparator_IgnoresEmptyFrame)
-{
-    const auto paths = collect_source_paths_from_comment("kernel.cpp:42 -> ");
-    const std::set<std::filesystem::path> expected = {"kernel.cpp"};
-    EXPECT_EQ(paths, expected);
-}
-
-TEST(test_pc_sampling_collector_source_paths_t, ProvidedNonNumericColonSuffix_ReturnsWholeFrame)
-{
-    const auto paths = collect_source_paths_from_comment("kernel.cpp:label");
-    const std::set<std::filesystem::path> expected = {"kernel.cpp:label"};
-    EXPECT_EQ(paths, expected);
+    const auto& params = GetParam();
+    const auto  paths  = collect_source_paths_from_comment(params.comment, params.separator);
+    EXPECT_EQ(paths, params.expected_paths);
 }
 
 TEST_F(test_pc_sampling_collector_t, ProvidedSymbolsAndInstructions_CollectsDeduplicatedSourcePaths)
@@ -308,3 +257,25 @@ void test_pc_sampling_collector_t::SetUp()
     m_file_info.load_base      = 0x1000;
     m_file_info.load_size      = 0x2000;
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    SourcePaths,
+    test_pc_sampling_collector_source_paths_t,
+    ::testing::Values(
+        source_path_test_params_t{"EmptyComment", "", {}},
+        source_path_test_params_t{"SingleFileLine", "kernel.cpp:42", {"kernel.cpp"}},
+        source_path_test_params_t{"MultipleFrames", "kernel.cpp:42 -> header.h:8", {"header.h", "kernel.cpp"}},
+        source_path_test_params_t{"InjectedFrameSeparator",
+                                  "kernel.cpp:42 | header.h:8",
+                                  {"header.h", "kernel.cpp"},
+                                  " | "},
+        source_path_test_params_t{"UnknownLineToken", "kernel.cpp:?", {"kernel.cpp"}},
+        source_path_test_params_t{"NoColonFrame", "kernel.cpp", {"kernel.cpp"}},
+        source_path_test_params_t{"DuplicateFrames", "kernel.cpp:42 -> kernel.cpp:42", {"kernel.cpp"}},
+        source_path_test_params_t{"PathWithDirectories",
+                                  "/tmp/project/include/header.h:8",
+                                  {"/tmp/project/include/header.h"}},
+        source_path_test_params_t{"TrailingColon", "kernel.cpp:", {"kernel.cpp:"}},
+        source_path_test_params_t{"TrailingSeparator", "kernel.cpp:42 -> ", {"kernel.cpp"}},
+        source_path_test_params_t{"NonNumericColonSuffix", "kernel.cpp:label", {"kernel.cpp:label"}}),
+    source_path_test_name);

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/pc_sampling_feature.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/pc_sampling_feature.cpp
@@ -61,6 +61,13 @@ void pc_sampling_feature_t::on_code_object_load(const rocprofiler_callback_traci
     m_collector->on_code_object_load(info);
 }
 
+void pc_sampling_feature_t::on_kernel_symbol_register(size_t             code_object_id,
+                                                      uint64_t           kernel_id,
+                                                      const std::string& name)
+{
+    m_collector->on_kernel_symbol_register(code_object_id, kernel_id, name);
+}
+
 void pc_sampling_feature_t::finalize()
 {
     m_collector->finalize(*m_writer);

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/pc_sampling_feature.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/pc_sampling_feature.cpp
@@ -61,11 +61,9 @@ void pc_sampling_feature_t::on_code_object_load(const rocprofiler_callback_traci
     m_collector->on_code_object_load(info);
 }
 
-void pc_sampling_feature_t::on_kernel_symbol_register(size_t             code_object_id,
-                                                      uint64_t           kernel_id,
-                                                      const std::string& name)
+void pc_sampling_feature_t::on_kernel_symbol_register(size_t code_object_id, const kernel_t& kernel)
 {
-    m_collector->on_kernel_symbol_register(code_object_id, kernel_id, name);
+    m_collector->on_kernel_symbol_register(code_object_id, kernel);
 }
 
 void pc_sampling_feature_t::finalize()

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/pc_sampling_feature.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/pc_sampling_feature.h
@@ -42,7 +42,7 @@ public:
     const std::filesystem::path& source_snapshot_path() const { return m_source_snapshot_path; }
 
     void on_code_object_load(const rocprofiler_callback_tracing_code_object_load_data_t& info);
-    void on_kernel_symbol_register(size_t code_object_id, uint64_t kernel_id, const std::string& name);
+    void on_kernel_symbol_register(size_t code_object_id, const kernel_t& kernel);
     void finalize();
 
 private:

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/pc_sampling_feature.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/pc_sampling_feature.h
@@ -5,6 +5,8 @@
 #include "pc_sampling_collector.h"
 #include "source_snapshotter.h"
 
+#include <cstddef>
+#include <cstdint>
 #include <filesystem>
 #include <string>
 
@@ -40,6 +42,7 @@ public:
     const std::filesystem::path& source_snapshot_path() const { return m_source_snapshot_path; }
 
     void on_code_object_load(const rocprofiler_callback_tracing_code_object_load_data_t& info);
+    void on_kernel_symbol_register(size_t code_object_id, uint64_t kernel_id, const std::string& name);
     void finalize();
 
 private:

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/sdk_callbacks.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/sdk_callbacks.cpp
@@ -341,14 +341,21 @@ void SdkCallbacksImpl::tool_tracing_callback(rocprofiler_callback_tracing_record
         // if matches store kernel id
         // Lock before modifying target_kernel_ids
         std::lock_guard<std::mutex> lock(tool->mut);
-        if (!tool->kernel_filter_include_regex.empty())
+        const bool                  pc_sampling_enabled = tool->pc_sampling.enabled();
+        const bool                  filtering_by_name = !tool->kernel_filter_include_regex.empty();
+
+        std::string kernel_name;
+        if (pc_sampling_enabled || filtering_by_name)
+        {
+            const char* raw_kernel_name = data->kernel_name == nullptr ? "" : data->kernel_name;
+            int         demangle_status = 0;
+            kernel_name = truncate_name(cxa_demangle(raw_kernel_name, &demangle_status));
+        }
+
+        if (filtering_by_name)
         {
             try
             {
-                int  demangle_status = 0;
-                auto kernel_name     = cxa_demangle(data->kernel_name, &demangle_status);
-                kernel_name          = truncate_name(kernel_name);
-
                 std::regex re(tool->kernel_filter_include_regex);
                 if (!kernel_name.empty() && std::regex_search(kernel_name, re))
                 {
@@ -366,6 +373,13 @@ void SdkCallbacksImpl::tool_tracing_callback(rocprofiler_callback_tracing_record
         else
         {
             tool->target_kernel_ids.insert(data->kernel_id);
+        }
+
+        if (pc_sampling_enabled)
+        {
+            tool->pc_sampling.on_kernel_symbol_register(static_cast<size_t>(data->code_object_id),
+                                                        data->kernel_id,
+                                                        kernel_name);
         }
     }
 }

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/sdk_callbacks.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/sdk_callbacks.cpp
@@ -344,16 +344,13 @@ void SdkCallbacksImpl::tool_tracing_callback(rocprofiler_callback_tracing_record
         const bool                  pc_sampling_enabled = tool->pc_sampling.enabled();
         const bool                  filtering_by_name = !tool->kernel_filter_include_regex.empty();
 
-        std::string kernel_name;
-        if (pc_sampling_enabled || filtering_by_name)
-        {
-            const char* raw_kernel_name = data->kernel_name == nullptr ? "" : data->kernel_name;
-            int         demangle_status = 0;
-            kernel_name = truncate_name(cxa_demangle(raw_kernel_name, &demangle_status));
-        }
+        const char* raw_kernel_name = data->kernel_name == nullptr ? "" : data->kernel_name;
 
         if (filtering_by_name)
         {
+            const auto stripped_kernel_name = strip_kd_suffix(raw_kernel_name);
+            int        demangle_status      = 0;
+            const auto kernel_name = truncate_name(cxa_demangle(stripped_kernel_name, &demangle_status));
             try
             {
                 std::regex re(tool->kernel_filter_include_regex);
@@ -377,6 +374,7 @@ void SdkCallbacksImpl::tool_tracing_callback(rocprofiler_callback_tracing_record
 
         if (pc_sampling_enabled)
         {
+            const auto kernel_name = truncate_name(strip_kd_suffix(raw_kernel_name));
             tool->pc_sampling.on_kernel_symbol_register(static_cast<size_t>(data->code_object_id),
                                                         data->kernel_id,
                                                         kernel_name);
@@ -436,6 +434,16 @@ std::string SdkCallbacksImpl::truncate_name(std::string_view name)
     while ((rit != rend) && (*rit != ' ') && (*rit != ':'))
         rit++;
     return std::string{name.substr(rend - rit, rit - rbeg)};
+}
+
+std::string SdkCallbacksImpl::strip_kd_suffix(std::string_view name)
+{
+    constexpr std::string_view kd_suffix = ".kd";
+    if (name.size() >= kd_suffix.size() && name.substr(name.size() - kd_suffix.size()) == kd_suffix)
+    {
+        name.remove_suffix(kd_suffix.size());
+    }
+    return std::string{name};
 }
 
 std::string SdkCallbacksImpl::cxa_demangle(const std::string& mangled_name, int* status)

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/sdk_callbacks.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/sdk_callbacks.cpp
@@ -376,8 +376,7 @@ void SdkCallbacksImpl::tool_tracing_callback(rocprofiler_callback_tracing_record
         {
             const auto kernel_name = truncate_name(strip_kd_suffix(raw_kernel_name));
             tool->pc_sampling.on_kernel_symbol_register(static_cast<size_t>(data->code_object_id),
-                                                        data->kernel_id,
-                                                        kernel_name);
+                                                        kernel_t{data->kernel_id, kernel_name});
         }
     }
 }

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/sdk_callbacks.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/sdk_callbacks.h
@@ -138,6 +138,7 @@ private:
     std::unordered_map<uint64_t, iteration_multiplexing_dispatch_record_t> m_iteration_multiplexing_per_agent = {};
 
     static std::string truncate_name(std::string_view name);
+    static std::string strip_kd_suffix(std::string_view name);
     static std::string cxa_demangle(const std::string& mangled_name, int* status);
     static std::vector<std::string> split_by_regex(const std::string& s, const std::string& regex_pattern);
 };

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.cpp
@@ -265,7 +265,7 @@ void MockCodeObjectWriter::start_code_obj(size_t obj_id)
 
 void MockCodeObjectWriter::end_code_obj() {}
 
-void MockCodeObjectWriter::write_kernel(uint64_t, const std::string&)
+void MockCodeObjectWriter::write_kernel(const rocprofiler_compute_tool::kernel_t& /*kernel*/)
 {
     m_empty = false;
 }
@@ -313,11 +313,10 @@ void MockPcSamplingCollector::on_code_object_load(
     ++load_count;
 }
 
-void MockPcSamplingCollector::on_kernel_symbol_register(size_t             code_object_id,
-                                                        uint64_t           kernel_id,
-                                                        const std::string& name)
+void MockPcSamplingCollector::on_kernel_symbol_register(size_t code_object_id,
+                                                        const rocprofiler_compute_tool::kernel_t& kernel)
 {
-    m_kernel_symbol_register_calls.push_back({code_object_id, kernel_id, name});
+    m_kernel_symbol_register_calls.push_back({code_object_id, kernel.kernel_id, kernel.name});
 }
 
 void MockPcSamplingCollector::finalize(rocprofiler_compute_tool::code_object_writer_t& writer)

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.cpp
@@ -265,6 +265,11 @@ void MockCodeObjectWriter::start_code_obj(size_t obj_id)
 
 void MockCodeObjectWriter::end_code_obj() {}
 
+void MockCodeObjectWriter::write_kernel(uint64_t, const std::string&)
+{
+    m_empty = false;
+}
+
 void MockCodeObjectWriter::start_symbol(const rocprofiler_compute_tool::symbol_t& /*symbol*/)
 {
     m_empty = false;
@@ -308,6 +313,13 @@ void MockPcSamplingCollector::on_code_object_load(
     ++load_count;
 }
 
+void MockPcSamplingCollector::on_kernel_symbol_register(size_t             code_object_id,
+                                                        uint64_t           kernel_id,
+                                                        const std::string& name)
+{
+    m_kernel_symbol_register_calls.push_back({code_object_id, kernel_id, name});
+}
+
 void MockPcSamplingCollector::finalize(rocprofiler_compute_tool::code_object_writer_t& writer)
 {
     ++finalize_count;
@@ -331,6 +343,12 @@ const std::set<std::filesystem::path>& MockPcSamplingCollector::get_source_paths
 void MockPcSamplingCollector::set_source_paths(const std::set<std::filesystem::path>& source_paths)
 {
     m_source_paths = source_paths;
+}
+
+const std::vector<MockPcSamplingCollector::kernel_symbol_register_call_t>&
+    MockPcSamplingCollector::get_kernel_symbol_register_calls() const
+{
+    return m_kernel_symbol_register_calls;
 }
 
 void MockSourceSnapshotter::snapshot(const std::set<std::filesystem::path>& source_paths,

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.h
@@ -159,7 +159,7 @@ class MockCodeObjectWriter : public rocprofiler_compute_tool::code_object_writer
 public:
     void        start_code_obj(size_t obj_id) override;
     void        end_code_obj() override;
-    void        write_kernel(uint64_t kernel_id, const std::string& name) override;
+    void        write_kernel(const rocprofiler_compute_tool::kernel_t& kernel) override;
     void        start_symbol(const rocprofiler_compute_tool::symbol_t& symbol) override;
     void        end_symbol() override;
     void        write_instruction(const rocprofiler_compute_tool::instruction_t& inst) override;
@@ -187,7 +187,8 @@ public:
     };
 
     void on_code_object_load(const rocprofiler_callback_tracing_code_object_load_data_t& info) override;
-    void on_kernel_symbol_register(size_t code_object_id, uint64_t kernel_id, const std::string& name) override;
+    void on_kernel_symbol_register(size_t                                    code_object_id,
+                                   const rocprofiler_compute_tool::kernel_t& kernel) override;
     void finalize(rocprofiler_compute_tool::code_object_writer_t& writer) override;
     const std::set<std::filesystem::path>& get_source_paths() const override;
 

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/mocks.h
@@ -159,6 +159,7 @@ class MockCodeObjectWriter : public rocprofiler_compute_tool::code_object_writer
 public:
     void        start_code_obj(size_t obj_id) override;
     void        end_code_obj() override;
+    void        write_kernel(uint64_t kernel_id, const std::string& name) override;
     void        start_symbol(const rocprofiler_compute_tool::symbol_t& symbol) override;
     void        end_symbol() override;
     void        write_instruction(const rocprofiler_compute_tool::instruction_t& inst) override;
@@ -178,19 +179,29 @@ private:
 class MockPcSamplingCollector : public rocprofiler_compute_tool::pc_sampling_collector_t
 {
 public:
+    struct kernel_symbol_register_call_t
+    {
+        size_t      code_object_id = 0;
+        uint64_t    kernel_id      = 0;
+        std::string name;
+    };
+
     void on_code_object_load(const rocprofiler_callback_tracing_code_object_load_data_t& info) override;
+    void on_kernel_symbol_register(size_t code_object_id, uint64_t kernel_id, const std::string& name) override;
     void finalize(rocprofiler_compute_tool::code_object_writer_t& writer) override;
     const std::set<std::filesystem::path>& get_source_paths() const override;
 
     void set_has_code_objects(bool has_code_objects);
     void set_source_paths(const std::set<std::filesystem::path>& source_paths);
+    const std::vector<kernel_symbol_register_call_t>& get_kernel_symbol_register_calls() const;
 
     int load_count     = 0;
     int finalize_count = 0;
 
 private:
-    bool                            m_has_code_objects = false;
-    std::set<std::filesystem::path> m_source_paths;
+    bool                                       m_has_code_objects = false;
+    std::set<std::filesystem::path>            m_source_paths;
+    std::vector<kernel_symbol_register_call_t> m_kernel_symbol_register_calls;
 };
 
 class MockSourceSnapshotter : public rocprofiler_compute_tool::source_snapshotter_t

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_pc_sampling_feature.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_pc_sampling_feature.cpp
@@ -41,17 +41,16 @@ TEST_F(TestPcSamplingFeature, OnKernelSymbolRegister_ForwardsToCollector)
 {
     auto feature = create_feature();
 
-    constexpr size_t   code_object_id = 222;
-    constexpr uint64_t kernel_id      = 99;
-    const std::string  name           = "kernel0";
+    constexpr size_t code_object_id = 222;
+    const kernel_t   kernel{99, "kernel0"};
 
-    feature.on_kernel_symbol_register(code_object_id, kernel_id, name);
+    feature.on_kernel_symbol_register(code_object_id, kernel);
 
     const auto& calls = m_collector->get_kernel_symbol_register_calls();
     ASSERT_EQ(calls.size(), 1);
     EXPECT_EQ(calls[0].code_object_id, code_object_id);
-    EXPECT_EQ(calls[0].kernel_id, kernel_id);
-    EXPECT_EQ(calls[0].name, name);
+    EXPECT_EQ(calls[0].kernel_id, kernel.kernel_id);
+    EXPECT_EQ(calls[0].name, kernel.name);
 }
 
 TEST_F(TestPcSamplingFeature, Finalize_WritesCollectorAndSnapshotsCollectorSourcePaths)

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_pc_sampling_feature.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_pc_sampling_feature.cpp
@@ -3,6 +3,7 @@
 #include "test_pc_sampling_feature.h"
 
 #include <set>
+#include <string>
 
 using namespace rocprofiler_compute_tool;
 
@@ -34,6 +35,23 @@ TEST_F(TestPcSamplingFeature, OnCodeObjectLoad_ForwardsToCollector)
     feature.on_code_object_load(payload);
 
     EXPECT_EQ(m_collector->load_count, 1);
+}
+
+TEST_F(TestPcSamplingFeature, OnKernelSymbolRegister_ForwardsToCollector)
+{
+    auto feature = create_feature();
+
+    constexpr size_t   code_object_id = 222;
+    constexpr uint64_t kernel_id      = 99;
+    const std::string  name           = "kernel0";
+
+    feature.on_kernel_symbol_register(code_object_id, kernel_id, name);
+
+    const auto& calls = m_collector->get_kernel_symbol_register_calls();
+    ASSERT_EQ(calls.size(), 1);
+    EXPECT_EQ(calls[0].code_object_id, code_object_id);
+    EXPECT_EQ(calls[0].kernel_id, kernel_id);
+    EXPECT_EQ(calls[0].name, name);
 }
 
 TEST_F(TestPcSamplingFeature, Finalize_WritesCollectorAndSnapshotsCollectorSourcePaths)

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_sdk_callbacks.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_sdk_callbacks.cpp
@@ -187,6 +187,42 @@ TEST_F(TestSdkCallbacks, ProvidedCodeObjectLoadWithPcSamplingEnabled_ForwardsToC
     EXPECT_EQ(collector->load_count, 1);
 }
 
+TEST_F(TestSdkCallbacks, ProvidedKernelSymbolRegisterWithPcSamplingEnabled_ForwardsToCollector)
+{
+    constexpr size_t   code_object_id = 123;
+    constexpr uint64_t kernel_id      = 10;
+    const std::string  kernel_name    = "_Z9my_kernelv";
+
+    auto collector           = std::make_shared<MockPcSamplingCollector>();
+    auto snapshotter         = std::make_shared<MockSourceSnapshotter>();
+    m_tool_data->pc_sampling = pc_sampling_feature_t{PcSamplingMode::HostTrap,
+                                                     "unused.json",
+                                                     "unused_sources",
+                                                     collector,
+                                                     snapshotter};
+
+    rocprofiler_callback_tracing_record_t                                  record  = {};
+    rocprofiler_callback_tracing_code_object_kernel_symbol_register_data_t payload = {};
+    record.phase     = ROCPROFILER_CALLBACK_PHASE_LOAD;
+    record.kind      = ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT;
+    record.operation = ROCPROFILER_CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER;
+    record.payload   = &payload;
+
+    payload.code_object_id = code_object_id;
+    payload.kernel_id      = kernel_id;
+    payload.kernel_name    = kernel_name.c_str();
+
+    m_sdk_callbacks->tool_tracing_callback(record, &m_tool_data);
+
+    const auto& calls = collector->get_kernel_symbol_register_calls();
+    ASSERT_EQ(calls.size(), 1);
+    EXPECT_EQ(calls[0].code_object_id, code_object_id);
+    EXPECT_EQ(calls[0].kernel_id, kernel_id);
+    EXPECT_EQ(calls[0].name, "my_kernel");
+    ASSERT_EQ(m_tool_data->target_kernel_ids.size(), 1);
+    EXPECT_EQ(*m_tool_data->target_kernel_ids.cbegin(), kernel_id);
+}
+
 TEST_P(TestSdkCallbacksKernelFiltering, ProvidedKernelFilteringEnabled_ReturnsKernelIdsOnlyForMathing)
 {
     constexpr uint64_t kernel_id_0           = 10;

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_sdk_callbacks.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_sdk_callbacks.cpp
@@ -7,6 +7,15 @@
 
 using namespace rocprofiler_compute_tool;
 
+namespace
+{
+std::string kernel_symbol_register_test_name(
+    const ::testing::TestParamInfo<kernel_symbol_register_test_params_t>& info)
+{
+    return info.param.kernel_name == nullptr ? "NullName" : "DemangledName";
+}
+}  // namespace
+
 TEST_F(TestSdkCallbacks, ProvidedSameKernelWithMultiplexingDisabled_DispatchCbReturnsFirstPmc)
 {
     m_tool_data->iteration_multiplexing_mode = iteration_multiplexing_mode_t::DISABLED;
@@ -167,13 +176,7 @@ TEST_F(TestSdkCallbacks, ProvidedTracingRecord_ToolTracingCbReturnsKernelIdsFrom
 
 TEST_F(TestSdkCallbacks, ProvidedCodeObjectLoadWithPcSamplingEnabled_ForwardsToCollector)
 {
-    auto collector           = std::make_shared<MockPcSamplingCollector>();
-    auto snapshotter         = std::make_shared<MockSourceSnapshotter>();
-    m_tool_data->pc_sampling = pc_sampling_feature_t{PcSamplingMode::HostTrap,
-                                                     "unused.json",
-                                                     "unused_sources",
-                                                     collector,
-                                                     snapshotter};
+    auto& collector = enable_pc_sampling();
 
     rocprofiler_callback_tracing_record_t                record  = {};
     rocprofiler_callback_tracing_code_object_load_data_t payload = {};
@@ -184,76 +187,24 @@ TEST_F(TestSdkCallbacks, ProvidedCodeObjectLoadWithPcSamplingEnabled_ForwardsToC
 
     m_sdk_callbacks->tool_tracing_callback(record, &m_tool_data);
 
-    EXPECT_EQ(collector->load_count, 1);
+    EXPECT_EQ(collector.load_count, 1);
 }
 
-TEST_F(TestSdkCallbacks, ProvidedKernelSymbolRegisterWithPcSamplingEnabled_ForwardsToCollector)
+TEST_P(TestSdkCallbacksKernelSymbolRegister, ProvidedKernelSymbolRegister_ForwardsToCollector)
 {
     constexpr size_t   code_object_id = 123;
     constexpr uint64_t kernel_id      = 10;
-    const std::string  kernel_name    = "_Z9my_kernelv";
+    const auto         params         = GetParam();
 
-    auto collector           = std::make_shared<MockPcSamplingCollector>();
-    auto snapshotter         = std::make_shared<MockSourceSnapshotter>();
-    m_tool_data->pc_sampling = pc_sampling_feature_t{PcSamplingMode::HostTrap,
-                                                     "unused.json",
-                                                     "unused_sources",
-                                                     collector,
-                                                     snapshotter};
+    auto& collector = enable_pc_sampling();
 
-    rocprofiler_callback_tracing_record_t                                  record  = {};
-    rocprofiler_callback_tracing_code_object_kernel_symbol_register_data_t payload = {};
-    record.phase     = ROCPROFILER_CALLBACK_PHASE_LOAD;
-    record.kind      = ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT;
-    record.operation = ROCPROFILER_CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER;
-    record.payload   = &payload;
+    invoke_kernel_symbol_register(code_object_id, kernel_id, params.kernel_name);
 
-    payload.code_object_id = code_object_id;
-    payload.kernel_id      = kernel_id;
-    payload.kernel_name    = kernel_name.c_str();
-
-    m_sdk_callbacks->tool_tracing_callback(record, &m_tool_data);
-
-    const auto& calls = collector->get_kernel_symbol_register_calls();
+    const auto& calls = collector.get_kernel_symbol_register_calls();
     ASSERT_EQ(calls.size(), 1);
     EXPECT_EQ(calls[0].code_object_id, code_object_id);
     EXPECT_EQ(calls[0].kernel_id, kernel_id);
-    EXPECT_EQ(calls[0].name, "my_kernel");
-    ASSERT_EQ(m_tool_data->target_kernel_ids.size(), 1);
-    EXPECT_EQ(*m_tool_data->target_kernel_ids.cbegin(), kernel_id);
-}
-
-TEST_F(TestSdkCallbacks, ProvidedKernelSymbolRegisterWithNullName_ForwardsEmptyName)
-{
-    constexpr size_t   code_object_id = 123;
-    constexpr uint64_t kernel_id      = 10;
-
-    auto collector           = std::make_shared<MockPcSamplingCollector>();
-    auto snapshotter         = std::make_shared<MockSourceSnapshotter>();
-    m_tool_data->pc_sampling = pc_sampling_feature_t{PcSamplingMode::HostTrap,
-                                                     "unused.json",
-                                                     "unused_sources",
-                                                     collector,
-                                                     snapshotter};
-
-    rocprofiler_callback_tracing_record_t                                  record  = {};
-    rocprofiler_callback_tracing_code_object_kernel_symbol_register_data_t payload = {};
-    record.phase     = ROCPROFILER_CALLBACK_PHASE_LOAD;
-    record.kind      = ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT;
-    record.operation = ROCPROFILER_CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER;
-    record.payload   = &payload;
-
-    payload.code_object_id = code_object_id;
-    payload.kernel_id      = kernel_id;
-    payload.kernel_name    = nullptr;
-
-    m_sdk_callbacks->tool_tracing_callback(record, &m_tool_data);
-
-    const auto& calls = collector->get_kernel_symbol_register_calls();
-    ASSERT_EQ(calls.size(), 1);
-    EXPECT_EQ(calls[0].code_object_id, code_object_id);
-    EXPECT_EQ(calls[0].kernel_id, kernel_id);
-    EXPECT_TRUE(calls[0].name.empty());
+    EXPECT_EQ(calls[0].name, params.expected_name);
     ASSERT_EQ(m_tool_data->target_kernel_ids.size(), 1);
     EXPECT_EQ(*m_tool_data->target_kernel_ids.cbegin(), kernel_id);
 }
@@ -281,6 +232,18 @@ void TestSdkCallbacks::SetUp()
     test_knobs::set_sdk_wrapper(m_sdk_wrapper);
     m_sdk_callbacks = std::make_shared<SdkCallbacksImpl>(m_sdk_wrapper);
     m_tool_data     = std::make_unique<tool_data_t>();
+}
+
+MockPcSamplingCollector& TestSdkCallbacks::enable_pc_sampling()
+{
+    m_pc_sampling_collector  = std::make_shared<MockPcSamplingCollector>();
+    m_source_snapshotter     = std::make_shared<MockSourceSnapshotter>();
+    m_tool_data->pc_sampling = pc_sampling_feature_t{PcSamplingMode::HostTrap,
+                                                     "unused.json",
+                                                     "unused_sources",
+                                                     m_pc_sampling_collector,
+                                                     m_source_snapshotter};
+    return *m_pc_sampling_collector;
 }
 
 uint64_t TestSdkCallbacks::dispatch_kernel_with_dispatch_info(const kernel_dispatch_info_t& dispatch_info,
@@ -341,6 +304,13 @@ void TestSdkCallbacks::invoke_record_callback(uint64_t           counter_id,
 
 void TestSdkCallbacks::invoke_tool_tracing_callback(uint64_t kernel_id, const std::string& kernel_name)
 {
+    invoke_kernel_symbol_register(0, kernel_id, kernel_name.c_str());
+}
+
+void TestSdkCallbacks::invoke_kernel_symbol_register(size_t      code_object_id,
+                                                     uint64_t    kernel_id,
+                                                     const char* kernel_name)
+{
     rocprofiler_callback_tracing_record_t                                  record  = {};
     rocprofiler_callback_tracing_code_object_kernel_symbol_register_data_t payload = {};
     record.phase     = ROCPROFILER_CALLBACK_PHASE_LOAD;
@@ -348,8 +318,9 @@ void TestSdkCallbacks::invoke_tool_tracing_callback(uint64_t kernel_id, const st
     record.operation = ROCPROFILER_CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER;
     record.payload   = &payload;
 
-    payload.kernel_id   = kernel_id;
-    payload.kernel_name = kernel_name.c_str();
+    payload.code_object_id = code_object_id;
+    payload.kernel_id      = kernel_id;
+    payload.kernel_name    = kernel_name;
     m_sdk_callbacks->tool_tracing_callback(record, &m_tool_data);
 }
 
@@ -410,6 +381,14 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(rocprofiler_compute_tool::iteration_multiplexing_mode_t::DISABLED,
                       rocprofiler_compute_tool::iteration_multiplexing_mode_t::KERNEL,
                       rocprofiler_compute_tool::iteration_multiplexing_mode_t::LAUNCH));
+
+//////////////////////////////////////////////////////////////////////////
+/// TestSdkCallbacksKernelSymbolRegister
+INSTANTIATE_TEST_SUITE_P(KernelSymbolRegister,
+                         TestSdkCallbacksKernelSymbolRegister,
+                         ::testing::Values(kernel_symbol_register_test_params_t{"_Z9my_kernelv", "my_kernel"},
+                                           kernel_symbol_register_test_params_t{nullptr, ""}),
+                         kernel_symbol_register_test_name);
 
 //////////////////////////////////////////////////////////////////////////
 /// TestSdkCallbacksKernelFiltering

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_sdk_callbacks.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_sdk_callbacks.cpp
@@ -223,6 +223,41 @@ TEST_F(TestSdkCallbacks, ProvidedKernelSymbolRegisterWithPcSamplingEnabled_Forwa
     EXPECT_EQ(*m_tool_data->target_kernel_ids.cbegin(), kernel_id);
 }
 
+TEST_F(TestSdkCallbacks, ProvidedKernelSymbolRegisterWithNullName_ForwardsEmptyName)
+{
+    constexpr size_t   code_object_id = 123;
+    constexpr uint64_t kernel_id      = 10;
+
+    auto collector           = std::make_shared<MockPcSamplingCollector>();
+    auto snapshotter         = std::make_shared<MockSourceSnapshotter>();
+    m_tool_data->pc_sampling = pc_sampling_feature_t{PcSamplingMode::HostTrap,
+                                                     "unused.json",
+                                                     "unused_sources",
+                                                     collector,
+                                                     snapshotter};
+
+    rocprofiler_callback_tracing_record_t                                  record  = {};
+    rocprofiler_callback_tracing_code_object_kernel_symbol_register_data_t payload = {};
+    record.phase     = ROCPROFILER_CALLBACK_PHASE_LOAD;
+    record.kind      = ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT;
+    record.operation = ROCPROFILER_CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER;
+    record.payload   = &payload;
+
+    payload.code_object_id = code_object_id;
+    payload.kernel_id      = kernel_id;
+    payload.kernel_name    = nullptr;
+
+    m_sdk_callbacks->tool_tracing_callback(record, &m_tool_data);
+
+    const auto& calls = collector->get_kernel_symbol_register_calls();
+    ASSERT_EQ(calls.size(), 1);
+    EXPECT_EQ(calls[0].code_object_id, code_object_id);
+    EXPECT_EQ(calls[0].kernel_id, kernel_id);
+    EXPECT_TRUE(calls[0].name.empty());
+    ASSERT_EQ(m_tool_data->target_kernel_ids.size(), 1);
+    EXPECT_EQ(*m_tool_data->target_kernel_ids.cbegin(), kernel_id);
+}
+
 TEST_P(TestSdkCallbacksKernelFiltering, ProvidedKernelFilteringEnabled_ReturnsKernelIdsOnlyForMathing)
 {
     constexpr uint64_t kernel_id_0           = 10;

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_sdk_callbacks.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_sdk_callbacks.cpp
@@ -12,11 +12,7 @@ namespace
 std::string kernel_symbol_register_test_name(
     const ::testing::TestParamInfo<kernel_symbol_register_test_params_t>& info)
 {
-    if (info.param.kernel_name == nullptr)
-        return "NullName";
-
-    const std::string kernel_name = info.param.kernel_name;
-    return !kernel_name.empty() && kernel_name.front() == '_' ? "DemangledName" : "PlainName";
+    return fmt::format("KernelNameCase{}", info.index);
 }
 }  // namespace
 
@@ -233,10 +229,89 @@ TEST_F(TestSdkCallbacks, ProvidedPcSamplingAndKernelFilteringEnabled_ForwardsAll
     ASSERT_EQ(calls.size(), 2);
     EXPECT_EQ(calls[0].code_object_id, matching_code_object_id);
     EXPECT_EQ(calls[0].kernel_id, matching_kernel_id);
-    EXPECT_EQ(calls[0].name, "my_kernel");
+    EXPECT_EQ(calls[0].name, "_Z9my_kernelv");
     EXPECT_EQ(calls[1].code_object_id, nonmatching_code_object_id);
     EXPECT_EQ(calls[1].kernel_id, nonmatching_kernel_id);
-    EXPECT_EQ(calls[1].name, "other_kernel");
+    EXPECT_EQ(calls[1].name, "_Z12other_kernelv");
+}
+
+TEST_F(TestSdkCallbacks, ProvidedMangledKernelName_FilterMatchesDemangledPcSamplingKeepsMangled)
+{
+    constexpr size_t   code_object_id = 123;
+    constexpr uint64_t kernel_id      = 10;
+
+    auto& collector                          = enable_pc_sampling();
+    m_tool_data->kernel_filter_include_regex = ".*jacobi_iteration.*";
+
+    invoke_kernel_symbol_register(code_object_id, kernel_id, "_Z16jacobi_iterationPfPKfi");
+
+    ASSERT_EQ(m_tool_data->target_kernel_ids.size(), 1);
+    EXPECT_TRUE(m_tool_data->target_kernel_ids.count(kernel_id));
+
+    const auto& calls = collector.get_kernel_symbol_register_calls();
+    ASSERT_EQ(calls.size(), 1);
+    EXPECT_EQ(calls[0].code_object_id, code_object_id);
+    EXPECT_EQ(calls[0].kernel_id, kernel_id);
+    EXPECT_EQ(calls[0].name, "_Z16jacobi_iterationPfPKfi");
+}
+
+TEST_F(TestSdkCallbacks, ProvidedKdSuffix_FilterAndPcSamplingUseStrippedName)
+{
+    constexpr size_t   code_object_id = 123;
+    constexpr uint64_t kernel_id      = 10;
+
+    auto& collector                          = enable_pc_sampling();
+    m_tool_data->kernel_filter_include_regex = ".*streamOpsWrite$";
+
+    invoke_kernel_symbol_register(code_object_id, kernel_id, "__amd_rocclr_streamOpsWrite.kd");
+
+    ASSERT_EQ(m_tool_data->target_kernel_ids.size(), 1);
+    EXPECT_TRUE(m_tool_data->target_kernel_ids.count(kernel_id));
+
+    const auto& calls = collector.get_kernel_symbol_register_calls();
+    ASSERT_EQ(calls.size(), 1);
+    EXPECT_EQ(calls[0].code_object_id, code_object_id);
+    EXPECT_EQ(calls[0].kernel_id, kernel_id);
+    EXPECT_EQ(calls[0].name, "__amd_rocclr_streamOpsWrite");
+}
+
+TEST_F(TestSdkCallbacks, ProvidedInternalKd_FilterAndPcSamplingKeepInternalKd)
+{
+    constexpr size_t   code_object_id = 123;
+    constexpr uint64_t kernel_id      = 10;
+
+    auto& collector                          = enable_pc_sampling();
+    m_tool_data->kernel_filter_include_regex = R"(.*\.kd\.middle$)";
+
+    invoke_kernel_symbol_register(code_object_id, kernel_id, "prefix.kd.middle");
+
+    ASSERT_EQ(m_tool_data->target_kernel_ids.size(), 1);
+    EXPECT_TRUE(m_tool_data->target_kernel_ids.count(kernel_id));
+
+    const auto& calls = collector.get_kernel_symbol_register_calls();
+    ASSERT_EQ(calls.size(), 1);
+    EXPECT_EQ(calls[0].code_object_id, code_object_id);
+    EXPECT_EQ(calls[0].kernel_id, kernel_id);
+    EXPECT_EQ(calls[0].name, "prefix.kd.middle");
+}
+
+TEST_F(TestSdkCallbacks, ProvidedEmptyKernelName_FilterDoesNotTargetAndPcSamplingForwardsEmpty)
+{
+    constexpr size_t   code_object_id = 123;
+    constexpr uint64_t kernel_id      = 10;
+
+    auto& collector                          = enable_pc_sampling();
+    m_tool_data->kernel_filter_include_regex = ".*";
+
+    invoke_kernel_symbol_register(code_object_id, kernel_id, "");
+
+    EXPECT_TRUE(m_tool_data->target_kernel_ids.empty());
+
+    const auto& calls = collector.get_kernel_symbol_register_calls();
+    ASSERT_EQ(calls.size(), 1);
+    EXPECT_EQ(calls[0].code_object_id, code_object_id);
+    EXPECT_EQ(calls[0].kernel_id, kernel_id);
+    EXPECT_TRUE(calls[0].name.empty());
 }
 
 TEST_P(TestSdkCallbacksKernelFiltering, ProvidedKernelFilteringEnabled_ReturnsKernelIdsOnlyForMathing)
@@ -417,8 +492,14 @@ INSTANTIATE_TEST_SUITE_P(
 INSTANTIATE_TEST_SUITE_P(
     KernelSymbolRegister,
     TestSdkCallbacksKernelSymbolRegister,
-    ::testing::Values(kernel_symbol_register_test_params_t{"_Z9my_kernelv", "my_kernel"},
+    ::testing::Values(kernel_symbol_register_test_params_t{"_Z9my_kernelv", "_Z9my_kernelv"},
+                      kernel_symbol_register_test_params_t{"_Z16jacobi_iterationPfPKfi",
+                                                           "_Z16jacobi_iterationPfPKfi"},
                       kernel_symbol_register_test_params_t{"plain_kernel", "plain_kernel"},
+                      kernel_symbol_register_test_params_t{"", ""},
+                      kernel_symbol_register_test_params_t{"__amd_rocclr_streamOpsWrite.kd",
+                                                           "__amd_rocclr_streamOpsWrite"},
+                      kernel_symbol_register_test_params_t{"prefix.kd.middle", "prefix.kd.middle"},
                       kernel_symbol_register_test_params_t{nullptr, ""}),
     kernel_symbol_register_test_name);
 
@@ -437,6 +518,10 @@ INSTANTIATE_TEST_SUITE_P(
         kernel_filtering_test_params_t{"_Z10my_kernel", "my_kernel()", ".*my_kernel.*"},
         kernel_filtering_test_params_t{"_ZN3hip12vector_add_1Ev", "hip::vector_add_1()", ".*vector_add.*"},
         kernel_filtering_test_params_t{"_Z6kernelIiEvv", "void kernel<int>()", ".*kernel.*"},
+        kernel_filtering_test_params_t{"__amd_rocclr_streamOpsWrite.kd",
+                                       "__amd_rocclr_streamOpsWrite",
+                                       ".*streamOpsWrite$"},
+        kernel_filtering_test_params_t{"prefix.kd.middle", "prefix.kd.middle", R"(.*\.kd\.middle$)"},
         kernel_filtering_test_params_t{
             "_ZN2at6native18elementwise_kernelILi128ELi4EZNS0_15gpu_kernel_implIZZZNS0_31direct_"
             "copy_"

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_sdk_callbacks.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_sdk_callbacks.cpp
@@ -12,7 +12,11 @@ namespace
 std::string kernel_symbol_register_test_name(
     const ::testing::TestParamInfo<kernel_symbol_register_test_params_t>& info)
 {
-    return info.param.kernel_name == nullptr ? "NullName" : "DemangledName";
+    if (info.param.kernel_name == nullptr)
+        return "NullName";
+
+    const std::string kernel_name = info.param.kernel_name;
+    return !kernel_name.empty() && kernel_name.front() == '_' ? "DemangledName" : "PlainName";
 }
 }  // namespace
 
@@ -209,6 +213,32 @@ TEST_P(TestSdkCallbacksKernelSymbolRegister, ProvidedKernelSymbolRegister_Forwar
     EXPECT_EQ(*m_tool_data->target_kernel_ids.cbegin(), kernel_id);
 }
 
+TEST_F(TestSdkCallbacks, ProvidedPcSamplingAndKernelFilteringEnabled_ForwardsAllKernelSymbols)
+{
+    constexpr size_t   matching_code_object_id    = 123;
+    constexpr size_t   nonmatching_code_object_id = 456;
+    constexpr uint64_t matching_kernel_id         = 10;
+    constexpr uint64_t nonmatching_kernel_id      = 20;
+
+    auto& collector                          = enable_pc_sampling();
+    m_tool_data->kernel_filter_include_regex = ".*my_kernel.*";
+
+    invoke_kernel_symbol_register(matching_code_object_id, matching_kernel_id, "_Z9my_kernelv");
+    invoke_kernel_symbol_register(nonmatching_code_object_id, nonmatching_kernel_id, "_Z12other_kernelv");
+
+    EXPECT_EQ(m_tool_data->target_kernel_ids.size(), 1);
+    EXPECT_TRUE(m_tool_data->target_kernel_ids.count(matching_kernel_id));
+
+    const auto& calls = collector.get_kernel_symbol_register_calls();
+    ASSERT_EQ(calls.size(), 2);
+    EXPECT_EQ(calls[0].code_object_id, matching_code_object_id);
+    EXPECT_EQ(calls[0].kernel_id, matching_kernel_id);
+    EXPECT_EQ(calls[0].name, "my_kernel");
+    EXPECT_EQ(calls[1].code_object_id, nonmatching_code_object_id);
+    EXPECT_EQ(calls[1].kernel_id, nonmatching_kernel_id);
+    EXPECT_EQ(calls[1].name, "other_kernel");
+}
+
 TEST_P(TestSdkCallbacksKernelFiltering, ProvidedKernelFilteringEnabled_ReturnsKernelIdsOnlyForMathing)
 {
     constexpr uint64_t kernel_id_0           = 10;
@@ -384,11 +414,13 @@ INSTANTIATE_TEST_SUITE_P(
 
 //////////////////////////////////////////////////////////////////////////
 /// TestSdkCallbacksKernelSymbolRegister
-INSTANTIATE_TEST_SUITE_P(KernelSymbolRegister,
-                         TestSdkCallbacksKernelSymbolRegister,
-                         ::testing::Values(kernel_symbol_register_test_params_t{"_Z9my_kernelv", "my_kernel"},
-                                           kernel_symbol_register_test_params_t{nullptr, ""}),
-                         kernel_symbol_register_test_name);
+INSTANTIATE_TEST_SUITE_P(
+    KernelSymbolRegister,
+    TestSdkCallbacksKernelSymbolRegister,
+    ::testing::Values(kernel_symbol_register_test_params_t{"_Z9my_kernelv", "my_kernel"},
+                      kernel_symbol_register_test_params_t{"plain_kernel", "plain_kernel"},
+                      kernel_symbol_register_test_params_t{nullptr, ""}),
+    kernel_symbol_register_test_name);
 
 //////////////////////////////////////////////////////////////////////////
 /// TestSdkCallbacksKernelFiltering

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_sdk_callbacks.h
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_sdk_callbacks.h
@@ -6,7 +6,8 @@
 class TestSdkCallbacks : public ::testing::Test
 {
 protected:
-    void SetUp() override;
+    void                     SetUp() override;
+    MockPcSamplingCollector& enable_pc_sampling();
     uint64_t dispatch_kernel_with_dispatch_info(const rocprofiler_compute_tool::kernel_dispatch_info_t& dispatch_info,
                                                 const std::vector<std::string>& counters_pmc0,
                                                 const std::vector<std::string>& counters_pmc1);
@@ -16,6 +17,7 @@ protected:
                                      const std::vector<std::string>& counters_pmc1 = {});
     void invoke_record_callback(uint64_t counter_id, const std::string& counter_name, double counter_value);
     void invoke_tool_tracing_callback(uint64_t kernel_id, const std::string& kernel_name = "default");
+    void invoke_kernel_symbol_register(size_t code_object_id, uint64_t kernel_id, const char* kernel_name);
 
     static std::string convert_counters_per_pmc_to_str(const std::vector<std::vector<std::string>>& counters_per_pmc);
     static std::string convert_counters_to_str(const std::vector<std::string>& counters);
@@ -25,10 +27,24 @@ protected:
 
     std::shared_ptr<MockSdkWrapper>                             m_sdk_wrapper;
     std::shared_ptr<rocprofiler_compute_tool::SdkCallbacksImpl> m_sdk_callbacks;
+    std::shared_ptr<MockPcSamplingCollector>                    m_pc_sampling_collector;
+    std::shared_ptr<MockSourceSnapshotter>                      m_source_snapshotter;
     std::unique_ptr<rocprofiler_compute_tool::tool_data_t>      m_tool_data;
     const std::vector<std::string> m_counters_pmc0     = {"counter0", "counter1"};
     const std::vector<std::string> m_counters_pmc1     = {"counter2"};
     const uint64_t                 m_invalid_config_id = ~0u;
+};
+
+struct kernel_symbol_register_test_params_t
+{
+    const char* kernel_name = nullptr;
+    std::string expected_name;
+};
+
+class TestSdkCallbacksKernelSymbolRegister
+    : public TestSdkCallbacks
+    , public ::testing::WithParamInterface<kernel_symbol_register_test_params_t>
+{
 };
 
 class TestSdkCallbacksMultiplexing


### PR DESCRIPTION
## Motivation

Record the SDK kernel-symbol registration mapping so PC sampling code-object ISA output can be correlated to kernel ids and display names without lossy name matching.

## Technical Details

- Add `kernel_t` and a `kernels` array to code object JSON output.
- Record `code_object_id -> kernel_t` mappings in the PC sampling collector and emit kernels during finalize.
- Kernel filtering and PC sampling use separate name forms: filter uses `.kd`-stripped demangled/truncated names, while PC sampling emits `.kd`-stripped truncated raw symbols.
- Thread `kernel_t` through `pc_sampling_feature_t`, `pc_sampling_collector_t`, and `code_object_writer_t` to match the symbol/instruction struct interfaces.
- Add writer, collector, feature, and callback unit coverage for kernel serialization, name-form handling, and forwarding.

JIRA ID : AIPROFCOMP-701

## Test Plan

- [x] Run ctests

## Test Result

- [x] Ctests pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
