### PR TITLE
ROCM-26483: update changelog to reflect cooperative_groups::reduce() …

### DIFF
--- a/projects/clr/CHANGELOG.md
+++ b/projects/clr/CHANGELOG.md
@@ -81,7 +81,7 @@ The HIP runtime now includes the hostname, GPU index, and kernel name in GPU fau
 
 ## Known issues
 
-* `cooperative_groups::reduce` will not work correctly with block dimensions whose .y or .z component is different from one, leading to incorrect results or kernel launch failures.
+* Kernels using `cooperative_groups::reduce()` with block dimensions whose .y or .z component is different from 1 may produce incorrect results or fail to launch.
 
 ## HIP 7.13 for ROCm 7.13
 

--- a/projects/clr/CHANGELOG.md
+++ b/projects/clr/CHANGELOG.md
@@ -79,6 +79,10 @@ for accurate size validation. Additionally, the exec flag is propagated through 
 * Enhanced debug information for illegal memory access errors. In multi-node and multi-GPU environments, it can be difficult to identify the source of a fault.
 The HIP runtime now includes the hostname, GPU index, and kernel name in GPU fault error messages, improving issue identification and debugging.
 
+## Known issues
+
+* `cooperative_groups::reduce` will not work correctly with block dimensions whose .y or .z component is different from one, leading to incorrect results or kernel launch failures.
+
 ## HIP 7.13 for ROCm 7.13
 
 ### Added


### PR DESCRIPTION
## Motivation

Update change log due to `cooperative_groups::reduce()` known issue

## Technical Details

* There is a known bug on 7.14 in `cooperative_groups::reduce()` when block dimensions contain .y or .z components different from one

## JIRA ID

ROCM-26483

## Test Plan

N/A: only documentation

## Test Result

N/A: only documentation

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
