### PR TITLE
fix(rocprofiler-compute): correct bandwidth unit label from Gb/s to GB/s

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_tui/widgets/charts.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_tui/widgets/charts.py
@@ -193,7 +193,7 @@ def px_simple_bar(
         range_color = [0, 100]
         xrange = [0, 110]
     if id == 1701.2:
-        label_txt = "Gb/s"
+        label_txt = "GB/s"
         range_color = [0, 1638]
         xrange = [0, 1638]
 

--- a/projects/rocprofiler-compute/src/utils/gui.py
+++ b/projects/rocprofiler-compute/src/utils/gui.py
@@ -107,7 +107,7 @@ def create_sol_charts(display_df: pd.DataFrame, table_id: int) -> list[px.bar]:
         hbm_row = display_df[display_df["Metric"] == "HBM Bandwidth"]
         if not hbm_row.empty:
             hbm_bw = float(hbm_row["Avg"].iloc[0])
-            gb_data = display_df[display_df["Unit"] == "Gb/s"]
+            gb_data = display_df[display_df["Unit"] == "GB/s"]
             charts.append(
                 px.bar(
                     gb_data,


### PR DESCRIPTION
## Summary
- The GUI and TUI display code used "Gb/s" (gigabits) instead of "GB/s" (gigabytes) for bandwidth metrics.
- The YAML metric definitions correctly use "GB/s", so the GUI dataframe filter on `Unit=="Gb/s"` also failed to match any rows, producing an empty bandwidth chart in the web UI.
- Fixes two files: `src/utils/gui.py` (filter match) and `src/rocprof_compute_tui/widgets/charts.py` (axis label).

## Test plan
- [ ] Verify the HBM Bandwidth bar chart renders correctly in the GUI (`rocprof-compute analyze` web view)
- [ ] Verify the TUI (`rocprof-compute analyze --tui`) shows "GB/s" on the L2 SoL bandwidth chart