### PR TITLE
Fix managed and pageable memories handling in prefetchBatch

### DIFF
--- a/projects/clr/hipamd/src/hip_hmm.cpp
+++ b/projects/clr/hipamd/src/hip_hmm.cpp
@@ -7,6 +7,7 @@
 #include <hip/hip_runtime.h>
 #include "hip_internal.hpp"
 #include "hip_conversions.hpp"
+#include "hip_platform.hpp"
 #include "platform/context.hpp"
 #include "platform/command.hpp"
 #include "platform/memory.hpp"
@@ -630,14 +631,27 @@ hipError_t ihipMemPrefetchBatchAsync(void** dev_ptrs, size_t* sizes, size_t coun
       amd::Memory* mem_obj = mem_objs[op_idx];
       size_t offset = offsets[op_idx];
 
-      if ((mem_obj == nullptr) || (size > (mem_obj->getSize() - offset))) {
-        return hipErrorInvalidValue;
+      if (mem_obj == nullptr) {
+        hip::Var* deferred_var = PlatformState::Instance().StatCO().FindDeferredManagedVar(dev_ptr);
+        if (deferred_var != nullptr) {
+          hipError_t status = deferred_var->AllocateManagedVarPtr();
+          if (status != hipSuccess) {
+            return status;
+          }
+          mem_obj = getMemoryObject(hip::getCurrentDevice(), dev_ptr, offset);
+        }
       }
 
-      const bool is_managed_memory =
-          (mem_obj->getMemFlags() & (CL_MEM_SVM_FINE_GRAIN_BUFFER | CL_MEM_ALLOC_HOST_PTR)) != 0;
-
-      requires_pageable_support |= !is_managed_memory;
+      if (mem_obj != nullptr) {
+        if (size > (mem_obj->getSize() - offset)) {
+          return hipErrorInvalidValue;
+        }
+        if (!IsManagedMemory(mem_obj->getMemFlags())) {
+          return hipErrorInvalidValue;
+        }
+      } else {
+        requires_pageable_support = true;
+      }
 
       if (current_loc + 1 < num_prefetch_locs && op_idx >= prefetch_loc_idxs[current_loc + 1]) {
         current_loc++;

--- a/projects/clr/hipamd/src/hip_internal.hpp
+++ b/projects/clr/hipamd/src/hip_internal.hpp
@@ -751,7 +751,7 @@ namespace hip {
   extern hipError_t ihipMemGetInfo(size_t* free, size_t* total);
   extern amd::Memory* getMemoryObject(hip::Device* device, const void* ptr, size_t& offset,
                                        size_t size = 0);
-  extern bool IsManagedMemory(unsigned int flags);
+  extern bool IsManagedMemory(cl_mem_flags flags);
   extern std::vector<amd::Memory*> getMemoryObjectBatch(hip::Device* device, void* const* ptrs,
                                                          size_t count,
                                                          std::vector<size_t>& offsets);

--- a/projects/clr/hipamd/src/hip_internal.hpp
+++ b/projects/clr/hipamd/src/hip_internal.hpp
@@ -751,6 +751,7 @@ namespace hip {
   extern hipError_t ihipMemGetInfo(size_t* free, size_t* total);
   extern amd::Memory* getMemoryObject(hip::Device* device, const void* ptr, size_t& offset,
                                        size_t size = 0);
+  extern bool IsManagedMemory(unsigned int flags);
   extern std::vector<amd::Memory*> getMemoryObjectBatch(hip::Device* device, void* const* ptrs,
                                                          size_t count,
                                                          std::vector<size_t>& offsets);

--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -130,6 +130,15 @@ hipMemoryType getMemoryType(const amd::Memory* memory) {
 }
 
 // ================================================================================================
+bool IsManagedMemory(unsigned int flags) {
+  constexpr unsigned int kHipMallocManagedFlags =
+      CL_MEM_SVM_FINE_GRAIN_BUFFER | CL_MEM_ALLOC_HOST_PTR;
+  constexpr unsigned int kManagedVarFlags = CL_MEM_SVM_FINE_GRAIN_BUFFER | CL_MEM_USE_HOST_PTR;
+  return ((flags & kHipMallocManagedFlags) == kHipMallocManagedFlags) ||
+         ((flags & kManagedVarFlags) == kManagedVarFlags);
+}
+
+// ================================================================================================
 amd::Memory* getMemoryObjectWithOffset(hip::Device* device, const void* ptr, const size_t size) {
   size_t offset = 0;
   amd::Memory* memObj = getMemoryObject(device, ptr, offset);
@@ -3949,13 +3958,7 @@ hipError_t hipPointerGetAttributes(hipPointerAttribute_t* attributes, const void
     }
 
     attributes->devicePointer = reinterpret_cast<char*>(devMem->virtualAddress() + offset);
-    constexpr uint32_t kHipMallocManagedFlags =
-        CL_MEM_SVM_FINE_GRAIN_BUFFER | CL_MEM_ALLOC_HOST_PTR;
-    constexpr uint32_t kManagedVarFlags =
-        CL_MEM_SVM_FINE_GRAIN_BUFFER | CL_MEM_USE_HOST_PTR;
-    const auto memFlags = memObj->getMemFlags();
-    attributes->isManaged = ((memFlags & kHipMallocManagedFlags) == kHipMallocManagedFlags) ||
-                            ((memFlags & kManagedVarFlags) == kManagedVarFlags);
+    attributes->isManaged = IsManagedMemory(memObj->getMemFlags());
     attributes->allocationFlags = memObj->getUserData().flags;
     attributes->device = memObj->getUserData().deviceId;
     if (attributes->isManaged) {
@@ -4011,10 +4014,6 @@ hipError_t ihipPointerGetAttributes(void* data, hipPointer_attribute attribute,
   size_t offset = 0;
   amd::Memory* memObj = getMemoryObject(hip::getCurrentDevice(), ptr, offset);
   amd::Memory* vaddr_mem_obj = amd::MemObjMap::FindVirtualMemObj(ptr);
-  constexpr uint32_t kHipMallocManagedFlags =
-      CL_MEM_SVM_FINE_GRAIN_BUFFER | CL_MEM_ALLOC_HOST_PTR;
-  constexpr uint32_t kManagedVarFlags =
-      CL_MEM_SVM_FINE_GRAIN_BUFFER | CL_MEM_USE_HOST_PTR;
 
   hipError_t status = hipSuccess;
 
@@ -4143,10 +4142,7 @@ hipError_t ihipPointerGetAttributes(void* data, hipPointer_attribute attribute,
     }
     case HIP_POINTER_ATTRIBUTE_IS_MANAGED: {
       if (memObj) {
-        const auto memFlags = memObj->getMemFlags();
-        *reinterpret_cast<bool*>(data) =
-            ((memFlags & kHipMallocManagedFlags) == kHipMallocManagedFlags) ||
-            ((memFlags & kManagedVarFlags) == kManagedVarFlags);
+        *reinterpret_cast<bool*>(data) = IsManagedMemory(memObj->getMemFlags());
       } else {
         *reinterpret_cast<bool*>(data) = false;
         return hipErrorInvalidValue;
@@ -4168,8 +4164,7 @@ hipError_t ihipPointerGetAttributes(void* data, hipPointer_attribute attribute,
         if (getMemoryType(memObj) == hipMemoryTypeHost) {
           // host pointer, pinned or registered memory
           *reinterpret_cast<int*>(data) = 0;
-        } else if (((memObj->getMemFlags() & kHipMallocManagedFlags) == kHipMallocManagedFlags) ||
-                   ((memObj->getMemFlags() & kManagedVarFlags) == kManagedVarFlags)) {
+        } else if (IsManagedMemory(memObj->getMemFlags())) {
           // managed allocation
           *reinterpret_cast<int*>(data) = 0;
         } else if (vaddr_mem_obj) {

--- a/projects/clr/hipamd/src/hip_memory.cpp
+++ b/projects/clr/hipamd/src/hip_memory.cpp
@@ -130,10 +130,10 @@ hipMemoryType getMemoryType(const amd::Memory* memory) {
 }
 
 // ================================================================================================
-bool IsManagedMemory(unsigned int flags) {
-  constexpr unsigned int kHipMallocManagedFlags =
+bool IsManagedMemory(cl_mem_flags flags) {
+  constexpr cl_mem_flags kHipMallocManagedFlags =
       CL_MEM_SVM_FINE_GRAIN_BUFFER | CL_MEM_ALLOC_HOST_PTR;
-  constexpr unsigned int kManagedVarFlags = CL_MEM_SVM_FINE_GRAIN_BUFFER | CL_MEM_USE_HOST_PTR;
+  constexpr cl_mem_flags kManagedVarFlags = CL_MEM_SVM_FINE_GRAIN_BUFFER | CL_MEM_USE_HOST_PTR;
   return ((flags & kHipMallocManagedFlags) == kHipMallocManagedFlags) ||
          ((flags & kManagedVarFlags) == kManagedVarFlags);
 }

--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -1986,6 +1986,9 @@ memory:
   Unit_hipMemPrefetchBatchAsync_MultiDevice:
     <<: *level_2
     tags: [query]
+  Unit_hipMemPrefetchBatchAsync_ManagedGlobalVariable:
+    <<: *level_2
+    tags: [query]
   Unit_hipMemDiscardBatchAsync_NegativeTests:
     <<: *level_2
     tags: [query]

--- a/projects/hip-tests/catch/unit/memory/hipMemPrefetchBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPrefetchBatchAsync.cc
@@ -33,6 +33,8 @@ constexpr int kTestValueBase = 100;
 constexpr size_t kTestBufferElements = 1024;
 constexpr size_t kTestBufferBytes = kTestBufferElements * sizeof(int);
 
+__managed__ int g_managed_prefetch_data[kTestBufferElements];
+
 // Macro for tests requiring managed access support
 #define REQUIRE_MANAGED_ACCESS_DEVICE(device_var)                                                  \
   int device_var = 0;                                                                              \
@@ -283,8 +285,9 @@ HIP_TEST_CASE(Unit_hipMemPrefetchBatchAsync_RoundTripDataIntegrity) {
 /**
  * Test Description
  * ------------------------
- *  - Test NULL dptrs, sizes, prefetchLocs, prefetchLocIdxs arrays and freed memory pointers
- *  - Verify API returns appropriate error for invalid NULL parameters and invalid pointers
+ *  - Test NULL dptrs, sizes, prefetchLocs, prefetchLocIdxs arrays and invalid pointers
+ *  - Verify API returns appropriate error for invalid NULL parameters, hipMalloc memory,
+ *    and other non-managed pointers
  */
 HIP_TEST_CASE(Unit_hipMemPrefetchBatchAsync_Negative_NullAndInvalidPointers) {
   REQUIRE_MANAGED_ACCESS_DEVICE(device);
@@ -330,18 +333,15 @@ HIP_TEST_CASE(Unit_hipMemPrefetchBatchAsync_Negative_NullAndInvalidPointers) {
                     hipErrorInvalidValue);
   }
 
-  SECTION("Freed memory pointer") {
-    int* freed_ptr = nullptr;
-    HIP_CHECK(hipMallocManaged(&freed_ptr, kTestBufferBytes));
-    HIP_CHECK(hipFree(freed_ptr));
+  SECTION("hipMalloc device memory") {
+    LinearAllocGuard<int> device_memory(LinearAllocs::hipMalloc, kTestBufferBytes);
+    std::array<void*, 1> device_ptrs = {device_memory.ptr()};
 
-    std::array<void*, 1> freed_ptrs = {freed_ptr};
-    std::array<size_t, 1> freed_sizes = {kTestBufferBytes};
-
-    HIP_CHECK_ERROR(hipMemPrefetchBatchAsync(
-                        freed_ptrs.data(), freed_sizes.data(), freed_ptrs.size(), locations.data(),
-                        location_indices.data(), locations.size(), flags, stream_guard.stream()),
-                    hipErrorInvalidValue);
+    HIP_CHECK_ERROR(
+        hipMemPrefetchBatchAsync(device_ptrs.data(), buffer_sizes.data(), device_ptrs.size(),
+                                 locations.data(), location_indices.data(), locations.size(), flags,
+                                 stream_guard.stream()),
+        hipErrorInvalidValue);
   }
 }
 
@@ -635,4 +635,36 @@ HIP_TEST_CASE(Unit_hipMemPrefetchBatchAsync_MultiDevice) {
   for (size_t op = 0; op < num_operations; op++) {
     HIP_CHECK(hipFree(managed_ptrs[op]));
   }
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Verify hipMemPrefetchBatchAsync works with a __managed__ global variable.
+ */
+HIP_TEST_CASE(Unit_hipMemPrefetchBatchAsync_ManagedGlobalVariable) {
+  REQUIRE_MANAGED_ACCESS_DEVICE(device);
+
+  std::fill_n(g_managed_prefetch_data, kTestBufferElements, kTestValueBase);
+
+  StreamGuard stream_guard(Streams::created);
+
+  void* managed_ptr = g_managed_prefetch_data;
+  size_t buffer_size = kTestBufferBytes;
+  hipMemLocation location{};
+  location.type = hipMemLocationTypeDevice;
+  location.id = device;
+  size_t location_index = 0;
+  constexpr unsigned long long flags = 0;
+
+  HIP_CHECK(hipMemPrefetchBatchAsync(&managed_ptr, &buffer_size, 1, &location, &location_index, 1,
+                                     flags, stream_guard.stream()));
+
+  HIP_CHECK(hipStreamSynchronize(stream_guard.stream()));
+
+  int last_prefetch_location = -1;
+  HIP_CHECK(hipMemRangeGetAttribute(&last_prefetch_location, sizeof(int),
+                                    hipMemRangeAttributeLastPrefetchLocation,
+                                    g_managed_prefetch_data, kTestBufferBytes));
+  REQUIRE(last_prefetch_location == device);
 }

--- a/projects/hip-tests/catch/unit/memory/hipMemPrefetchBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPrefetchBatchAsync.cc
@@ -285,9 +285,8 @@ HIP_TEST_CASE(Unit_hipMemPrefetchBatchAsync_RoundTripDataIntegrity) {
 /**
  * Test Description
  * ------------------------
- *  - Test NULL dptrs, sizes, prefetchLocs, prefetchLocIdxs arrays and invalid pointers
- *  - Verify API returns appropriate error for invalid NULL parameters, hipMalloc memory,
- *    and other non-managed pointers
+ *  - Test NULL dptrs, sizes, prefetchLocs, and prefetchLocIdxs arrays
+ *  - Verify API returns hipErrorInvalidValue for NULL parameters and hipMalloc device memory
  */
 HIP_TEST_CASE(Unit_hipMemPrefetchBatchAsync_Negative_NullAndInvalidPointers) {
   REQUIRE_MANAGED_ACCESS_DEVICE(device);


### PR DESCRIPTION
## Motivation

- Test Unit_hipMemPrefetchBatchAsync_Negative_NullAndInvalidPointers is failing with XNACK=1
- Test Unit_hipMemPrefetchBatchAsync_ManagedGlobalVariable is failing

## Technical Details

- Managed variables do not have MemObjMap entries until they are promoted (on first kernel launch), but they should still be allowed to prefetch.
- Pageable host memory should be allowed to prefetch when all devices support pageable memory access.

## JIRA ID

ROCM-26100

## Test Plan

Run tests:
- Unit_hipMemPrefetchBatchAsync_Negative_NullAndInvalidPointers,
- Unit_hipMemPrefetchBatchAsync_ManagedGlobalVariable 

## Test Result

All tests passed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
