### PR TITLE
test(rccl): add env variable NCCL_NO_CACHE test and documentation

### DIFF
--- a/projects/rccl/docs/api-reference/env-variables.rst
+++ b/projects/rccl/docs/api-reference/env-variables.rst
@@ -258,6 +258,21 @@ intended for debugging and development purposes.
       - | ``0``: Memory manager enabled (default).
         | ``1``: Memory manager disabled.
 
+    * - | ``NCCL_NO_CACHE``
+        | Disables caching for selected RCCL environment parameters so their
+          values are re-read from the environment on each access. By default,
+          RCCL caches parameter values after the first read for performance.
+          This variable is intended for testing and debugging when parameters
+          need to be changed without restarting the process. The value is
+          parsed once on first use, so it must be set before RCCL reads any
+          parameters. ``NCCL_NO_CACHE`` itself is always cached and cannot
+          be listed.
+      - | Unset (default): all parameters are cached after first read.
+        | Comma-separated list of parameter names (for example,
+          ``NCCL_DEBUG,NCCL_ALGO``): disable caching for those keys only.
+        | ``ALL``: disable caching for every parameter except
+          ``NCCL_NO_CACHE``.
+
 Multi-communicator ordering
 ===========================
 

--- a/projects/rccl/test/ParamTests.cpp
+++ b/projects/rccl/test/ParamTests.cpp
@@ -3,8 +3,6 @@
 
 #include "param.h"
 #include <gtest/gtest.h>
-#include <cstdint>
-#include <cstdlib>
 #include <rccl/rccl.h>
 #include "common/ProcessIsolatedTestRunner.hpp"
 #include "graph/topo.h"

--- a/projects/rccl/test/ParamTests.cpp
+++ b/projects/rccl/test/ParamTests.cpp
@@ -3,9 +3,16 @@
 
 #include "param.h"
 #include <gtest/gtest.h>
+#include <cstdint>
+#include <cstdlib>
 #include <rccl/rccl.h>
 #include "common/ProcessIsolatedTestRunner.hpp"
 #include "graph/topo.h"
+
+// Declared in src/include/param/utils.h (new param subsystem) as an
+// extern "C" exported symbol. Forward-declared here so the test can call it
+// without pulling in the new param headers / include paths.
+extern "C" bool ncclParamIsCacheDisabled(const char* key);
 
 namespace RcclUnitTesting {
 TEST(ParamTests, initEnv_ParseValidConfFile) {
@@ -66,6 +73,108 @@ TEST(ParamTests, ncclPxnC2cParam_DefaultOff) {
           // No-op on xGMI; default must stay off.
           unsetenv("NCCL_PXN_C2C");
           ASSERT_EQ(ncclParamPxnC2c(), 0);
+      }
+  );
+}
+
+// Key used by the NCCL_NO_CACHE tests below. The actual name is irrelevant as
+// long as it is not a real NCCL parameter; ncclLoadParam reads it via getenv.
+static constexpr const char* kNoCacheTestKey = "NCCL_TEST_NOCACHE_KEY";
+
+// Baseline: when NCCL_NO_CACHE is unset, ncclLoadParam caches the first value
+// it reads. A subsequent change to the environment must be ignored and the
+// originally cached value returned.
+TEST(ParamTests, NoCache_DefaultCachesValue) {
+  RUN_ISOLATED_TEST(
+      "NoCache_DefaultCachesValue",
+      []()
+      {
+          constexpr int64_t uninitialized = INT64_MIN;
+          int64_t cache = uninitialized;
+          int8_t  noCache = -1; // uninitialized sentinel, matches NCCL_PARAM macro
+
+          unsetenv("NCCL_NO_CACHE");
+
+          setenv(kNoCacheTestKey, "100", 1);
+          int64_t v1 = ncclLoadParam(kNoCacheTestKey, /*deftVal*/ 999, uninitialized, &cache, &noCache);
+          ASSERT_EQ(v1, 100);
+
+          // The environment changed, but the cached value must win.
+          setenv(kNoCacheTestKey, "200", 1);
+          int64_t v2 = ncclLoadParam(kNoCacheTestKey, /*deftVal*/ 999, uninitialized, &cache, &noCache);
+          ASSERT_EQ(v2, 100) << "value should stay cached when NCCL_NO_CACHE is unset";
+
+          unsetenv(kNoCacheTestKey);
+      }
+  );
+}
+
+// NCCL_NO_CACHE listing the specific key disables caching for it, so a later
+// environment change is observed on the next load.
+TEST(ParamTests, NoCache_PerKeyForcesReRead) {
+  RUN_ISOLATED_TEST(
+      "NoCache_PerKeyForcesReRead",
+      []()
+      {
+          constexpr int64_t uninitialized = INT64_MIN;
+          int64_t cache = uninitialized;
+          int8_t  noCache = -1;
+
+          // Must be set before the first ncclLoadParam call: ncclParamIsCacheDisabled
+          // parses NCCL_NO_CACHE exactly once (std::call_once).
+          setenv("NCCL_NO_CACHE", kNoCacheTestKey, 1);
+
+          setenv(kNoCacheTestKey, "100", 1);
+          int64_t v1 = ncclLoadParam(kNoCacheTestKey, /*deftVal*/ 999, uninitialized, &cache, &noCache);
+          ASSERT_EQ(v1, 100);
+
+          setenv(kNoCacheTestKey, "200", 1);
+          int64_t v2 = ncclLoadParam(kNoCacheTestKey, /*deftVal*/ 999, uninitialized, &cache, &noCache);
+          ASSERT_EQ(v2, 200) << "value should be re-read when the key is listed in NCCL_NO_CACHE";
+
+          unsetenv(kNoCacheTestKey);
+      }
+  );
+}
+
+// NCCL_NO_CACHE=ALL disables caching for every key.
+TEST(ParamTests, NoCache_AllForcesReRead) {
+  RUN_ISOLATED_TEST(
+      "NoCache_AllForcesReRead",
+      []()
+      {
+          constexpr int64_t uninitialized = INT64_MIN;
+          int64_t cache = uninitialized;
+          int8_t  noCache = -1;
+
+          setenv("NCCL_NO_CACHE", "ALL", 1);
+
+          setenv(kNoCacheTestKey, "100", 1);
+          int64_t v1 = ncclLoadParam(kNoCacheTestKey, /*deftVal*/ 999, uninitialized, &cache, &noCache);
+          ASSERT_EQ(v1, 100);
+
+          setenv(kNoCacheTestKey, "200", 1);
+          int64_t v2 = ncclLoadParam(kNoCacheTestKey, /*deftVal*/ 999, uninitialized, &cache, &noCache);
+          ASSERT_EQ(v2, 200) << "NCCL_NO_CACHE=ALL should disable caching for every key";
+
+          unsetenv(kNoCacheTestKey);
+      }
+  );
+}
+
+// NCCL_NO_CACHE must never disable caching for itself (would be a circular
+// dependency while resolving the list), even when set to ALL. Other keys are
+// still reported as cache-disabled.
+TEST(ParamTests, NoCache_SelfIsNeverDisabled) {
+  RUN_ISOLATED_TEST(
+      "NoCache_SelfIsNeverDisabled",
+      []()
+      {
+          setenv("NCCL_NO_CACHE", "ALL", 1);
+          ASSERT_FALSE(ncclParamIsCacheDisabled("NCCL_NO_CACHE"))
+              << "NCCL_NO_CACHE must never disable caching for itself";
+          ASSERT_TRUE(ncclParamIsCacheDisabled("NCCL_SOME_OTHER_KEY"))
+              << "ALL should still disable caching for arbitrary keys";
       }
   );
 }


### PR DESCRIPTION
Add ParamTests coverage for the NCCL_NO_CACHE env var, which forces ncclLoadParam to re-read selected params instead of caching them:

- NoCache_DefaultCachesValue: cached value wins when NCCL_NO_CACHE unset
- NoCache_PerKeyForcesReRead: per-key listing forces re-read
- NoCache_AllForcesReRead: NCCL_NO_CACHE=ALL disables caching for all keys
- NoCache_SelfIsNeverDisabled: NCCL_NO_CACHE never un-caches itself

Tests run in isolated processes since ncclParamIsCacheDisabled parses NCCL_NO_CACHE once via std::call_once.

## Motivation

This PR adds focused ParamTests coverage to lock in the expected NCCL_NO_CACHE semantics and improve coverage of previously untested paths in the param-loading code.


## JIRA ID

JIRA ID : AICOMRCCL-808

## Test Plan

Build RCCL in debug mode and run NCCL_NO_CACHE  tests.

## Test Result

Passed

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
