### PR TITLE
[HIP][Graph] Fix shutdown deadlock by dropping GraphExec device pin.

### DIFF
--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -1152,7 +1152,6 @@ void GraphExecSegmented::FindStreamsReqPerDevForSegments() {
 
     if (graphExec != this && graphExec->captureDeviceId_ == -1) {
       graphExec->captureDeviceId_ = captureDeviceId_;
-      static_cast<amd::ReferenceCountedObject*>(g_devices[captureDeviceId_])->retain();
     }
 
     for (const auto& [level, segment_ids] : graphExec->segments_per_level_) {
@@ -1547,7 +1546,6 @@ hipError_t GraphExecClassic::Init() {
 
     if (max_streams_dev_.size() == 1) {
       captureDeviceId_ = max_streams_dev_.begin()->first;
-      static_cast<amd::ReferenceCountedObject*>(g_devices[captureDeviceId_])->retain();
     } else if (max_streams_dev_.size() > 1) {
       ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
               "[hipGraph] Multi-device graph is not supported for classic scheduling path");
@@ -1728,7 +1726,6 @@ hipError_t GraphExecSegmented::Init() {
     }
   }
 
-  static_cast<ReferenceCountedObject*>(g_devices[captureDeviceId_])->retain();
   return status;
 }
 
@@ -2021,13 +2018,8 @@ hipError_t GraphExecSegmented::CaptureAndFormPacketsForGraph() {
     if (segment.child_graph_ptr != nullptr) {
       auto childGraphExec = dynamic_cast<GraphExecSegmented*>(segment.child_graph_ptr);
       if (childGraphExec != nullptr) {
-        // Propagate instantiation device ID so BuildSyncPlan can
-        // access the device for barrier packet creation.
-        // Retain balances the release in ~Graph destructor.
         if (childGraphExec->captureDeviceId_ == -1) {
           childGraphExec->captureDeviceId_ = captureDeviceId_;
-          static_cast<amd::ReferenceCountedObject*>(
-              g_devices[captureDeviceId_])->retain();
         }
 
         // Child graphs share the same kernel arg manager as parent

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -652,9 +652,6 @@ class Graph {
     }
     graphUserObj_.clear();
     memAllocNodePtrs_.clear();
-    if (captureDeviceId_ != -1) {
-      static_cast<amd::ReferenceCountedObject*>(g_devices[captureDeviceId_])->release();
-    }
   }
 
   void AddManualNodeDuringCapture(GraphNode* node) { capturedNodes_.insert(node); }
@@ -1019,6 +1016,17 @@ class GraphExecBase : public amd::ReferenceCountedObject, public Graph {
   }
 
   ~GraphExecBase() {
+    for (auto& streams : parallel_streams_) {
+      for (auto stream : streams.second) {
+        if (stream != nullptr) {
+          stream->finish();
+          stream->vdev()->UnpinQueue();
+          constexpr bool kForceDestroy = true;
+          hip::Stream::Destroy(stream, kForceDestroy);
+        }
+      }
+    }
+    parallel_streams_.clear();
     std::scoped_lock lock(graphExecSetLock_);
     // Normally erased in hipGraphExecDestroy(), but child graph nodes use delete directly.
     graphExecSet_.erase(this);
@@ -1070,19 +1078,7 @@ class GraphExecClassic : public GraphExecBase {
  public:
   bool graph_dumped_ = false;
   GraphExecClassic(uint64_t flags = 0) : GraphExecBase(flags) {}
-  ~GraphExecClassic() {
-    for (auto& streams : parallel_streams_) {
-      for (auto stream : streams.second) {
-        if (stream != nullptr) {
-          stream->finish();
-          stream->vdev()->UnpinQueue();
-          constexpr bool kForceDestroy = true;
-          hip::Stream::Destroy(stream, kForceDestroy);
-        }
-      }
-    }
-    parallel_streams_.clear();
-  }
+  ~GraphExecClassic() {}
 
   hipError_t Init() override;
   hipError_t Run(hip::Stream* launch_stream) override;


### PR DESCRIPTION
## Motivation

Running Unit_hipGraphAddMemAllocNode_Negative_With_Cloneed_Graph intermittently hangs at process exit (~25% of runs). The stack shows HostQueue::terminate() → awaitCompletion() blocking on the ROCr async-events thread (HsaAmdSignalHandler).

Root cause: GraphExec/Graph held an extra reference on the capture device (g_devices[captureDeviceId_]). Because GraphExec's last reference is released by the async completion handler (AccumulateCommand completion → ~GraphExec), that path also dropped the device's last reference, so ~Device executed on the async handler thread. ~Device begins with WaitForHsaAsyncHandlersIdle(), which waits for outstanding async handlers to finish — but it was itself running inside one, so it waited on itself → self-deadlock. Whether the handler happened to own the last device ref is timing-dependent, hence the intermittent hang.

## Technical Details
Regression from https://github.com/ROCm/rocm-systems/commit/5de80e1c1c611c0ec6c4c8c0e59cbea8e51f3d6e.

- Drop the GraphExec → device pin : remove the four retain() calls on g_devices[captureDeviceId_] (GraphExecClassic::Init, GraphExecSegmented::Init, FindStreamsReqPerDevForSegments, CaptureAndFormPacketsForGraph) and the matching release() in ~Graph. The device is already owned for the whole process by amd::RuntimeTearDown::RegisterObject(device) (released on the main thread at teardown). Correctness is preserved by the existing async-handler drain: QueuedAsyncHandlers is incremented before a handler is armed and decremented only after updateCommandsState() runs the completion that destroys the graph; ~Device blocks in WaitForHsaAsyncHandlersIdle() until that count reaches 0 before freeing any device resources. This is a strict happens-before, so handler-driven ~Graph/~GraphExec always touch a live device. With the pin gone, ~Device now runs on the main thread and can actually wait for the (separate) handler thread — no self-wait.
- Move parallel_streams_ teardown to the base dtor : previously only ~GraphExecClassic freed the internal streams; the segmented path (used on Linux/ROCm) never did, leaking HW queues. Moved the finish()/UnpinQueue()/Stream::Destroy() loop into ~GraphExecBase so both paths clean up. The blocking finish()/Destroy() run before taking graphExecSetLock_; the lock now guards only graphExecSet_.erase(this).

## JIRA ID

[ROCM-27565](https://amd-hub.atlassian.net/browse/ROCM-27565)

## Test Plan

Unit_hipGraphAddMemAllocNode_Negative_With_Cloneed_Graph 

## Test Result

Ran Unit_hipGraphAddMemAllocNode_Negative_With_Cloneed_Graph  for 40 times and passed without hang.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.


[ROCM-27565]: https://amd-hub.atlassian.net/browse/ROCM-27565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ