### PR TITLE
feat(rocshmem): Implement reduce scatter wave

### DIFF
--- a/projects/rocshmem/include/rocshmem/rocshmem_COLL.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem_COLL.hpp
@@ -913,6 +913,126 @@ __device__ ATTR_NO_INLINE int rocshmem_ctx_double_prod_reduce_scatter_wg(
     int nreduce);
 
 /**
+ * @name SHMEM_REDUCE_SCATTER_WAVE device-side (wave-level)
+ * @brief Wave-level reduce-scatter: PE i receives the element-wise reduction
+ * of source[i*nreduce..(i+1)*nreduce-1] across all PEs in the team.
+ * Only the wave (wavefront) participates. Returns ROCSHMEM_SUCCESS on success.
+ */
+__device__ ATTR_NO_INLINE int rocshmem_ctx_short_sum_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, short *dest, const short *source,
+    int nreduce);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_short_min_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, short *dest, const short *source,
+    int nreduce);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_short_max_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, short *dest, const short *source,
+    int nreduce);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_short_prod_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, short *dest, const short *source,
+    int nreduce);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_short_or_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, short *dest, const short *source,
+    int nreduce);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_short_and_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, short *dest, const short *source,
+    int nreduce);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_short_xor_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, short *dest, const short *source,
+    int nreduce);
+
+__device__ ATTR_NO_INLINE int rocshmem_ctx_int_sum_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, int *dest, const int *source,
+    int nreduce);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_int_min_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, int *dest, const int *source,
+    int nreduce);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_int_max_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, int *dest, const int *source,
+    int nreduce);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_int_prod_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, int *dest, const int *source,
+    int nreduce);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_int_or_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, int *dest, const int *source,
+    int nreduce);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_int_and_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, int *dest, const int *source,
+    int nreduce);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_int_xor_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, int *dest, const int *source,
+    int nreduce);
+
+__device__ ATTR_NO_INLINE int rocshmem_ctx_long_sum_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long *dest, const long *source,
+    int nreduce);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_long_min_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long *dest, const long *source,
+    int nreduce);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_long_max_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long *dest, const long *source,
+    int nreduce);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_long_prod_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long *dest, const long *source,
+    int nreduce);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_long_or_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long *dest, const long *source,
+    int nreduce);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_long_and_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long *dest, const long *source,
+    int nreduce);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_long_xor_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long *dest, const long *source,
+    int nreduce);
+
+__device__ ATTR_NO_INLINE int rocshmem_ctx_longlong_sum_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long long *dest, const long long *source,
+    int nreduce);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_longlong_min_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long long *dest, const long long *source,
+    int nreduce);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_longlong_max_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long long *dest, const long long *source,
+    int nreduce);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_longlong_prod_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long long *dest, const long long *source,
+    int nreduce);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_longlong_or_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long long *dest, const long long *source,
+    int nreduce);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_longlong_and_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long long *dest, const long long *source,
+    int nreduce);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_longlong_xor_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long long *dest, const long long *source,
+    int nreduce);
+
+__device__ ATTR_NO_INLINE int rocshmem_ctx_float_sum_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, float *dest, const float *source,
+    int nreduce);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_float_min_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, float *dest, const float *source,
+    int nreduce);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_float_max_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, float *dest, const float *source,
+    int nreduce);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_float_prod_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, float *dest, const float *source,
+    int nreduce);
+
+__device__ ATTR_NO_INLINE int rocshmem_ctx_double_sum_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, double *dest, const double *source,
+    int nreduce);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_double_min_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, double *dest, const double *source,
+    int nreduce);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_double_max_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, double *dest, const double *source,
+    int nreduce);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_double_prod_reduce_scatter_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, double *dest, const double *source,
+    int nreduce);
+
+/**
  * @name SHMEM_REDUCE_SCATTER host-side
  * @brief Host-side reduce-scatter: PE i receives the element-wise reduction
  * of source[i*nreduce..(i+1)*nreduce-1] across all PEs.

--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -168,6 +168,7 @@ declare -A TEST_NUMBERS=(
   ["alltoall_wave"]="151"
   ["fcollect_wave"]="152"
   ["reduce_wave"]="153"
+  ["teamreducescatterwave"]="154"
 )
 
 # Detect which runtime to use
@@ -761,6 +762,9 @@ TestColl() {
     ExecTest  "alltoall_wave"    2       1            $WAVE_SIZE        512
     ExecTest  "fcollect_wave"    2       1            $WAVE_SIZE        32768
     ExecTest  "reduce_wave"      2       1            $WAVE_SIZE        32768
+    ExecTest  "teamreducescatterwave" 2      1            $WAVE_SIZE   32768
+    ExecTest  "teamreducescatterwave" 4      1            $WAVE_SIZE   32768
+    ExecTest  "teamreducescatterwave" 8      1            $WAVE_SIZE   32768
   else echo "Skip:   *_wave (AIROCSHMEM-409: wave tests not supported on RO)"; fi
 }
 

--- a/projects/rocshmem/src/context.hpp
+++ b/projects/rocshmem/src/context.hpp
@@ -217,6 +217,9 @@ class Context {
 
   template <typename T, ROCSHMEM_OP Op>
   __device__ int reduce_wave(rocshmem_team_t team, T* dest, const T* source, int nreduce);
+  
+  template <typename T, ROCSHMEM_OP Op>
+  __device__ int reduce_scatter_wave(rocshmem_team_t team, T* dest, const T* source, int nreduce);
 
   template <typename T>
   __device__ void put(T* dest, const T* source, size_t nelems, int pe);

--- a/projects/rocshmem/src/context_tmpl_device.hpp
+++ b/projects/rocshmem/src/context_tmpl_device.hpp
@@ -125,6 +125,20 @@ __device__ int Context::reduce_wave(rocshmem_team_t team, T *dest,
   DISPATCH_RET(reduce_wave<PAIR(T, Op)>(team, dest, source, nreduce));
 }
 
+template <typename T, ROCSHMEM_OP Op>
+__device__ int Context::reduce_scatter_wave(rocshmem_team_t team, T *dest,
+                                            const T *source, int nreduce) {
+  if (nreduce == 0) {
+    return ROCSHMEM_SUCCESS;
+  }
+
+  if (is_thread_zero_in_wave()) {
+    ctxStats.incStat(NUM_REDUCE_SCATTER);
+  }
+
+  DISPATCH_RET(reduce_scatter_wave<PAIR(T, Op)>(team, dest, source, nreduce));
+}
+
 template <typename T>
 __device__ void Context::put(T *dest, const T *source, size_t nelems, int pe) {
   if (nelems == 0) {

--- a/projects/rocshmem/src/gda/context_gda_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_device.hpp
@@ -150,6 +150,10 @@ class GDAContext : public Context {
 
   template <typename T, ROCSHMEM_OP Op>
   __device__ int reduce_wave(rocshmem_team_t team, T *dest, const T *source, int nreduce);
+  
+  template <typename T, ROCSHMEM_OP Op>
+  __device__ int reduce_scatter_wave(rocshmem_team_t team, T *dest, const T *source,
+                                     int nreduce);
 
   template <typename T>
   __device__ void broadcast_wg(rocshmem_team_t team, T *dest, const T *source,

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -849,6 +849,92 @@ __device__ int GDAContext::reduce_scatter_wg(rocshmem_team_t team, T *dest,
   return ROCSHMEM_SUCCESS;
 }
 
+template <typename T, ROCSHMEM_OP Op>
+__device__ int GDAContext::reduce_scatter_wave(rocshmem_team_t team, T *dest,
+                                               const T *source, int nreduce) {
+  GDATeam *team_obj = reinterpret_cast<GDATeam *>(team);
+
+  int PE_size   = team_obj->tinfo_wrt_world->size;
+  int PE_start  = team_obj->tinfo_wrt_world->pe_start;
+  int stride    = team_obj->tinfo_wrt_world->stride;
+  int team_rank = (my_pe - PE_start) / stride;
+
+  long *pSync = team_obj->reduce_pSync;
+  T    *pWrk  = reinterpret_cast<T *>(team_obj->pWrk);
+
+  ActiveWFInfo wf_info(ctx_id_, ThreadScope::wave);
+
+  int wave_tid  = get_flat_block_id() % WF_SIZE;
+
+  int pWrk_elems = (int)(ROCSHMEM_REDUCE_MIN_WRKDATA_SIZE * sizeof(double) / sizeof(T));
+  int chunk_size = max(1, pWrk_elems / PE_size);
+  int n_chunks   = (nreduce + chunk_size - 1) / chunk_size;
+  int64_t flag_val = 1;
+  int finish = PE_start + stride * PE_size;
+
+  for (int c = 0; c < n_chunks; c++) {
+    int offset = c * chunk_size;
+    int count  = min(chunk_size, nreduce - offset);
+
+    // Seed dest[offset..offset+count) from my own contribution.
+    for (int j = wave_tid; j < count; j += WF_SIZE) {
+      dest[offset + j] = source[team_rank * nreduce + offset + j];
+    }
+    __builtin_amdgcn_wave_barrier();
+
+    // Send my contribution for each remote PE's output block, then signal.
+    for (int i = PE_start; i < finish; i += stride) {
+      if (i != my_pe) {
+        int remote_rank = (i - PE_start) / stride;
+        internal_putmem_wave(&pWrk[team_rank * chunk_size],
+                              reinterpret_cast<const void *>(
+                                  source + remote_rank * nreduce + offset),
+                              count * sizeof(T), i, i, wf_info);
+        if (is_thread_zero_in_wave()) {
+          fence();
+          internal_putmem(&pSync[team_rank], &flag_val, sizeof(*pSync), i, i, wf_info);
+        }
+      }
+    }
+    threadfence_system();
+    __builtin_amdgcn_wave_barrier();
+
+    // Wait for each remote PE's signal, then accumulate into dest.
+    for (int i = PE_start; i < finish; i += stride) {
+      if (i != my_pe) {
+        int remote_rank = (i - PE_start) / stride;
+        if (is_thread_zero_in_wave()) {
+          wait_until(&pSync[remote_rank], ROCSHMEM_CMP_EQ, flag_val);
+        }
+        T *src_chunk = &pWrk[remote_rank * chunk_size];
+        T *dst_chunk = dest + offset;
+        for (int j = wave_tid; j < count; j += WF_SIZE) {
+          OpWrap<Op>::Calc(src_chunk, dst_chunk, j);
+        }
+        threadfence_system();
+      }
+    }
+    __builtin_amdgcn_wave_barrier();
+
+    // Reset pSync before reuse.
+    for (int j = wave_tid; j < PE_size; j += WF_SIZE) {
+      pSync[j] = ROCSHMEM_SYNC_VALUE;
+    }
+    threadfence_system();
+    // Quiet all QPs used this chunk, then sync with wave 0 of other PEs.
+    if (is_thread_zero_in_wave()) {
+      for (int i = PE_start; i < finish; i += stride) {
+        if (i != my_pe) {
+          qps[i].quiet(wf_info);
+        }
+      }
+    sync_wave(team);
+    }
+  }
+
+  return ROCSHMEM_SUCCESS;
+}
+
 template <typename T>
 __device__ void GDAContext::internal_put_broadcast_wave(T *dst, const T *src,
     int nelems, int pe_root, int pe_start, int stride, int pe_size,

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -928,7 +928,7 @@ __device__ int GDAContext::reduce_scatter_wave(rocshmem_team_t team, T *dest,
           qps[i].quiet(wf_info);
         }
       }
-    sync_wave(team);
+      sync_wave(team);
     }
   }
 

--- a/projects/rocshmem/src/ipc/context_ipc_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device.hpp
@@ -146,6 +146,10 @@ class IPCContext : public Context {
 
   template <typename T, ROCSHMEM_OP Op>
   __device__ int reduce_wave(rocshmem_team_t team, T *dest, const T *source, int nreduce);
+  
+  template <typename T, ROCSHMEM_OP Op>
+  __device__ int reduce_scatter_wave(rocshmem_team_t team, T *dest, const T *source,
+                                     int nreduce);
 
   template <typename T>
   __device__ void broadcast_wg(rocshmem_team_t team, T *dest, const T *source,

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -679,18 +679,16 @@ __device__ int IPCContext::reduce_scatter_wave(rocshmem_team_t team, T *dest,
   int pWrk_elems = (int)(ROCSHMEM_REDUCE_MIN_WRKDATA_SIZE * sizeof(double) / sizeof(T));
   int chunk_size = max(1, pWrk_elems / PE_size);
   int n_chunks   = (nreduce + chunk_size - 1) / chunk_size;
-  int64_t flag_val = 1;
   int finish = PE_start + stride * PE_size;
   
   for (int c = 0; c < n_chunks; c++) {
     int offset = c * chunk_size;
     int count  = min(chunk_size, nreduce - offset);
-
+    int64_t flag_val = static_cast<int64_t>(c) + 1;
     // Seed dest[offset..offset+count) from my own contribution.
     for (int j = wave_tid; j < count; j += WF_SIZE) {
       dest[offset + j] = source[team_rank * nreduce + offset + j];
     }
-    __builtin_amdgcn_wave_barrier();
 
     // Send my contribution to each remote PE's pWrk slot, then signal.
     for (int i = PE_start; i < finish; i += stride) {
@@ -701,12 +699,11 @@ __device__ int IPCContext::reduce_scatter_wave(rocshmem_team_t team, T *dest,
                                   source + remote_rank * nreduce + offset),
                               count * sizeof(T), i);
         if (is_thread_zero_in_wave()) {
-          fence(i);
           internal_putmem(&pSync[team_rank], &flag_val, sizeof(*pSync), i);
         }
+	__builtin_amdgcn_wave_barrier();
       }
     }
-    threadfence_system();
     __builtin_amdgcn_wave_barrier();
 
     // Wait for each remote PE's signal, then accumulate into dest.
@@ -716,14 +713,17 @@ __device__ int IPCContext::reduce_scatter_wave(rocshmem_team_t team, T *dest,
         if (is_thread_zero_in_wave()) {
           wait_until(&pSync[remote_rank], ROCSHMEM_CMP_EQ, flag_val);
         }
+	__builtin_amdgcn_wave_barrier();
         T *src_chunk = &pWrk[remote_rank * chunk_size];
         T *dst_chunk = dest + offset;
         for (int j = wave_tid; j < count; j += WF_SIZE) {
           OpWrap<Op>::Calc(src_chunk, dst_chunk, j);
         }
-        threadfence_system();
+        // threadfence_system();
       }
     }
+
+    sync_wave(team);
     __builtin_amdgcn_wave_barrier();
 
     // Reset pSync before reuse.
@@ -733,6 +733,7 @@ __device__ int IPCContext::reduce_scatter_wave(rocshmem_team_t team, T *dest,
 
     // Sync with wave 0 of other PEs
     sync_wave(team);
+    __builtin_amdgcn_wave_barrier();
   }
 
   return ROCSHMEM_SUCCESS;

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -689,6 +689,7 @@ __device__ int IPCContext::reduce_scatter_wave(rocshmem_team_t team, T *dest,
     for (int j = wave_tid; j < count; j += WF_SIZE) {
       dest[offset + j] = source[team_rank * nreduce + offset + j];
     }
+	  __builtin_amdgcn_wave_barrier();
 
     // Send my contribution to each remote PE's pWrk slot, then signal.
     for (int i = PE_start; i < finish; i += stride) {
@@ -699,11 +700,12 @@ __device__ int IPCContext::reduce_scatter_wave(rocshmem_team_t team, T *dest,
                                   source + remote_rank * nreduce + offset),
                               count * sizeof(T), i);
         if (is_thread_zero_in_wave()) {
+          fence(i);
           internal_putmem(&pSync[team_rank], &flag_val, sizeof(*pSync), i);
         }
-	__builtin_amdgcn_wave_barrier();
       }
     }
+    threadfence_system();
     __builtin_amdgcn_wave_barrier();
 
     // Wait for each remote PE's signal, then accumulate into dest.
@@ -713,28 +715,29 @@ __device__ int IPCContext::reduce_scatter_wave(rocshmem_team_t team, T *dest,
         if (is_thread_zero_in_wave()) {
           wait_until(&pSync[remote_rank], ROCSHMEM_CMP_EQ, flag_val);
         }
-	__builtin_amdgcn_wave_barrier();
+	      __builtin_amdgcn_wave_barrier();
         T *src_chunk = &pWrk[remote_rank * chunk_size];
         T *dst_chunk = dest + offset;
         for (int j = wave_tid; j < count; j += WF_SIZE) {
           OpWrap<Op>::Calc(src_chunk, dst_chunk, j);
         }
-        // threadfence_system();
+        threadfence_system();
       }
     }
-
-    sync_wave(team);
-    __builtin_amdgcn_wave_barrier();
-
-    // Reset pSync before reuse.
-    for (int j = wave_tid; j < PE_size; j += WF_SIZE) {
-      pSync[j] = ROCSHMEM_SYNC_VALUE;
-    }
-
+    
     // Sync with wave 0 of other PEs
     sync_wave(team);
     __builtin_amdgcn_wave_barrier();
+
   }
+  // Reset pSync before reuse.
+  for (int j = wave_tid; j < PE_size; j += WF_SIZE) {
+    pSync[j] = ROCSHMEM_SYNC_VALUE;
+  }
+
+  sync_wave(team);
+  __builtin_amdgcn_wave_barrier();
+  barrier_wave(team);
 
   return ROCSHMEM_SUCCESS;
 }

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -661,6 +661,83 @@ __device__ int IPCContext::reduce_scatter_wg(rocshmem_team_t team, T *dest,
   return ROCSHMEM_SUCCESS;
 }
 
+template <typename T, ROCSHMEM_OP Op>
+__device__ int IPCContext::reduce_scatter_wave(rocshmem_team_t team, T *dest,
+                                               const T *source, int nreduce) {
+  IPCTeam *team_obj = reinterpret_cast<IPCTeam *>(team);
+
+  int PE_size   = team_obj->tinfo_wrt_world->size;
+  int PE_start  = team_obj->tinfo_wrt_world->pe_start;
+  int stride    = team_obj->tinfo_wrt_world->stride;
+  int team_rank = (my_pe - PE_start) / stride;
+
+  long  *pSync = team_obj->reduce_pSync;
+  T     *pWrk  = reinterpret_cast<T *>(team_obj->pWrk);
+
+  int wave_tid  = get_flat_block_id() % WF_SIZE;
+
+  int pWrk_elems = (int)(ROCSHMEM_REDUCE_MIN_WRKDATA_SIZE * sizeof(double) / sizeof(T));
+  int chunk_size = max(1, pWrk_elems / PE_size);
+  int n_chunks   = (nreduce + chunk_size - 1) / chunk_size;
+  int64_t flag_val = 1;
+  int finish = PE_start + stride * PE_size;
+  
+  for (int c = 0; c < n_chunks; c++) {
+    int offset = c * chunk_size;
+    int count  = min(chunk_size, nreduce - offset);
+
+    // Seed dest[offset..offset+count) from my own contribution.
+    for (int j = wave_tid; j < count; j += WF_SIZE) {
+      dest[offset + j] = source[team_rank * nreduce + offset + j];
+    }
+    __builtin_amdgcn_wave_barrier();
+
+    // Send my contribution to each remote PE's pWrk slot, then signal.
+    for (int i = PE_start; i < finish; i += stride) {
+      if (i != my_pe) {
+        int remote_rank = (i - PE_start) / stride;
+        internal_putmem_wave(&pWrk[team_rank * chunk_size],
+                              reinterpret_cast<const void *>(
+                                  source + remote_rank * nreduce + offset),
+                              count * sizeof(T), i);
+        if (is_thread_zero_in_wave()) {
+          fence(i);
+          internal_putmem(&pSync[team_rank], &flag_val, sizeof(*pSync), i);
+        }
+      }
+    }
+    threadfence_system();
+    __builtin_amdgcn_wave_barrier();
+
+    // Wait for each remote PE's signal, then accumulate into dest.
+    for (int i = PE_start; i < finish; i += stride) {
+      if (i != my_pe) {
+        int remote_rank = (i - PE_start) / stride;
+        if (is_thread_zero_in_wave()) {
+          wait_until(&pSync[remote_rank], ROCSHMEM_CMP_EQ, flag_val);
+        }
+        T *src_chunk = &pWrk[remote_rank * chunk_size];
+        T *dst_chunk = dest + offset;
+        for (int j = wave_tid; j < count; j += WF_SIZE) {
+          OpWrap<Op>::Calc(src_chunk, dst_chunk, j);
+        }
+        threadfence_system();
+      }
+    }
+    __builtin_amdgcn_wave_barrier();
+
+    // Reset pSync before reuse.
+    for (int j = wave_tid; j < PE_size; j += WF_SIZE) {
+      pSync[j] = ROCSHMEM_SYNC_VALUE;
+    }
+
+    // Sync with wave 0 of other PEs
+    sync_wave(team);
+  }
+
+  return ROCSHMEM_SUCCESS;
+}
+
 template <typename T>
 __device__ void IPCContext::internal_put_broadcast_wave(T *dst, const T *src, int nelems, int pe_root, int pe_start,
     int stride, int pe_size) {  // NOLINT(runtime/int)

--- a/projects/rocshmem/src/reverse_offload/context_ro_device.hpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_device.hpp
@@ -105,6 +105,10 @@ class ROContext : public Context {
   __device__ int reduce_wave(rocshmem_team_t team, T *dest, const T *source,
                              int nreduce);
 
+  template <typename T, ROCSHMEM_OP Op>
+  __device__ int reduce_scatter_wave(rocshmem_team_t team, T *dest, const T *source,
+                                     int nreduce);
+
   template <typename T>
   __device__ void put(T *dest, const T *source, size_t nelems, int pe);
 

--- a/projects/rocshmem/src/reverse_offload/context_ro_tmpl_device.hpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_tmpl_device.hpp
@@ -337,6 +337,15 @@ __device__ int ROContext::reduce_scatter_wg(rocshmem_team_t team, T *dest,
   return ROCSHMEM_SUCCESS;
 }
 
+template <typename T, ROCSHMEM_OP Op>
+__device__ int ROContext::reduce_scatter_wave([[maybe_unused]] rocshmem_team_t team,
+                                              [[maybe_unused]] T *dest,
+                                              [[maybe_unused]] const T *source,
+                                              [[maybe_unused]] int nreduce) {
+  LOGD_WARN("reduce_scatter_wave is not available on reverse offload backend");
+  return ROCSHMEM_ERROR;
+}
+
 template <typename T>
 __device__ void ROContext::broadcast_wg(rocshmem_team_t team, T *dest,
                                      const T *source, int nelems, int pe_root) {

--- a/projects/rocshmem/src/rocshmem_gpu.cpp
+++ b/projects/rocshmem/src/rocshmem_gpu.cpp
@@ -661,6 +661,16 @@ __device__ int rocshmem_reduce_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
   return get_internal_ctx(ctx)->reduce_wave<T, Op>(team, dest, source, nreduce);
 }
 
+template <typename T, ROCSHMEM_OP Op>
+__device__ int rocshmem_reduce_scatter_wave(rocshmem_ctx_t ctx,
+                                            rocshmem_team_t team, T *dest,
+                                            const T *source, int nreduce) {
+  LOGD_API("device::reduce_scatter_wave (ctx=%zd, team=%zd, dest=%p, source=%p, nreduce=%d",
+    ctx.ctx_opaque, team, dest, source, nreduce);
+
+  return get_internal_ctx(ctx)->reduce_scatter_wave<T, Op>(team, dest, source, nreduce);
+}
+
 template <typename T>
 __device__ void rocshmem_broadcast_wg(rocshmem_ctx_t ctx,
                                        rocshmem_team_t team, T *dest,
@@ -1472,6 +1482,9 @@ __device__ int rocshmem_team_translate_pe(rocshmem_team_t src_team,
       int nreduce);                                                            \
   template __device__ int rocshmem_reduce_wave<T, Op>(                         \
       rocshmem_ctx_t ctx, rocshmem_team_t team, T * dest, const T *source,     \
+      int nreduce);                                                            \
+  template __device__ int rocshmem_reduce_scatter_wave<T, Op>(                 \
+      rocshmem_ctx_t ctx, rocshmem_team_t team, T * dest, const T *source,     \
       int nreduce);
 
 /**
@@ -1713,23 +1726,37 @@ __device__ int rocshmem_team_translate_pe(rocshmem_team_t src_team,
     return rocshmem_reduce_scatter_wg<T, Op>(ctx, team, dest, source, nreduce); \
   }
 
-#define ARITH_REDUCTION_DEF_GEN(T, TNAME)                 \
-  REDUCTION_DEF_GEN(T, TNAME, sum, ROCSHMEM_SUM)         \
-  REDUCTION_DEF_GEN(T, TNAME, min, ROCSHMEM_MIN)         \
-  REDUCTION_DEF_GEN(T, TNAME, max, ROCSHMEM_MAX)         \
-  REDUCTION_DEF_GEN(T, TNAME, prod, ROCSHMEM_PROD)       \
-  REDUCE_SCATTER_DEF_GEN(T, TNAME, sum, ROCSHMEM_SUM)   \
-  REDUCE_SCATTER_DEF_GEN(T, TNAME, min, ROCSHMEM_MIN)   \
-  REDUCE_SCATTER_DEF_GEN(T, TNAME, max, ROCSHMEM_MAX)   \
-  REDUCE_SCATTER_DEF_GEN(T, TNAME, prod, ROCSHMEM_PROD)
+#define REDUCE_SCATTER_WAVE_DEF_GEN(T, TNAME, Op_API, Op)                       \
+  __device__ int rocshmem_ctx_##TNAME##_##Op_API##_reduce_scatter_wave(          \
+      rocshmem_ctx_t ctx, rocshmem_team_t team, T *dest, const T *source,        \
+      int nreduce) {                                                              \
+    return rocshmem_reduce_scatter_wave<T, Op>(ctx, team, dest, source, nreduce); \
+  }
 
-#define BITWISE_REDUCTION_DEF_GEN(T, TNAME)               \
-  REDUCTION_DEF_GEN(T, TNAME, or, ROCSHMEM_OR)           \
-  REDUCTION_DEF_GEN(T, TNAME, and, ROCSHMEM_AND)         \
-  REDUCTION_DEF_GEN(T, TNAME, xor, ROCSHMEM_XOR)         \
-  REDUCE_SCATTER_DEF_GEN(T, TNAME, or, ROCSHMEM_OR)     \
-  REDUCE_SCATTER_DEF_GEN(T, TNAME, and, ROCSHMEM_AND)   \
-  REDUCE_SCATTER_DEF_GEN(T, TNAME, xor, ROCSHMEM_XOR)
+#define ARITH_REDUCTION_DEF_GEN(T, TNAME)                        \
+  REDUCTION_DEF_GEN(T, TNAME, sum, ROCSHMEM_SUM)                \
+  REDUCTION_DEF_GEN(T, TNAME, min, ROCSHMEM_MIN)                \
+  REDUCTION_DEF_GEN(T, TNAME, max, ROCSHMEM_MAX)                \
+  REDUCTION_DEF_GEN(T, TNAME, prod, ROCSHMEM_PROD)              \
+  REDUCE_SCATTER_DEF_GEN(T, TNAME, sum, ROCSHMEM_SUM)          \
+  REDUCE_SCATTER_DEF_GEN(T, TNAME, min, ROCSHMEM_MIN)          \
+  REDUCE_SCATTER_DEF_GEN(T, TNAME, max, ROCSHMEM_MAX)          \
+  REDUCE_SCATTER_DEF_GEN(T, TNAME, prod, ROCSHMEM_PROD)        \
+  REDUCE_SCATTER_WAVE_DEF_GEN(T, TNAME, sum, ROCSHMEM_SUM)     \
+  REDUCE_SCATTER_WAVE_DEF_GEN(T, TNAME, min, ROCSHMEM_MIN)     \
+  REDUCE_SCATTER_WAVE_DEF_GEN(T, TNAME, max, ROCSHMEM_MAX)     \
+  REDUCE_SCATTER_WAVE_DEF_GEN(T, TNAME, prod, ROCSHMEM_PROD)
+
+#define BITWISE_REDUCTION_DEF_GEN(T, TNAME)                      \
+  REDUCTION_DEF_GEN(T, TNAME, or, ROCSHMEM_OR)                  \
+  REDUCTION_DEF_GEN(T, TNAME, and, ROCSHMEM_AND)                \
+  REDUCTION_DEF_GEN(T, TNAME, xor, ROCSHMEM_XOR)                \
+  REDUCE_SCATTER_DEF_GEN(T, TNAME, or, ROCSHMEM_OR)            \
+  REDUCE_SCATTER_DEF_GEN(T, TNAME, and, ROCSHMEM_AND)          \
+  REDUCE_SCATTER_DEF_GEN(T, TNAME, xor, ROCSHMEM_XOR)          \
+  REDUCE_SCATTER_WAVE_DEF_GEN(T, TNAME, or, ROCSHMEM_OR)       \
+  REDUCE_SCATTER_WAVE_DEF_GEN(T, TNAME, and, ROCSHMEM_AND)     \
+  REDUCE_SCATTER_WAVE_DEF_GEN(T, TNAME, xor, ROCSHMEM_XOR)
 
 #define INT_REDUCTION_DEF_GEN(T, TNAME) \
   ARITH_REDUCTION_DEF_GEN(T, TNAME)     \

--- a/projects/rocshmem/tests/functional_tests/CTestFunctionalTests.cmake
+++ b/projects/rocshmem/tests/functional_tests/CTestFunctionalTests.cmake
@@ -169,6 +169,7 @@ set(TEST_broadcast_wave 150)
 set(TEST_alltoall_wave 151)
 set(TEST_fcollect_wave 152)
 set(TEST_reduce_wave 153)
+set(TEST_teamreducescatterwave 154)
 
 # MPI should already be found by the parent CMakeLists.txt
 # Use standard CMake MPI variables set by find_package(MPI)
@@ -1076,6 +1077,9 @@ function(add_coll_tests)
         add_rocshmem_functional_test(NAME alltoall_wave RANKS 2 WORKGROUPS 1 THREADS 64 MAX_MSG_SIZE 512)
         add_rocshmem_functional_test(NAME fcollect_wave RANKS 2 WORKGROUPS 1 THREADS 64 MAX_MSG_SIZE 32768)
         add_rocshmem_functional_test(NAME reduce_wave RANKS 2 WORKGROUPS 1 THREADS 64 MAX_MSG_SIZE 32768)
+        add_rocshmem_functional_test(NAME teamreducescatterwave RANKS 2 WORKGROUPS 1 THREADS 64 MAX_MSG_SIZE 32768)
+        add_rocshmem_functional_test(NAME teamreducescatterwave RANKS 4 WORKGROUPS 1 THREADS 64 MAX_MSG_SIZE 32768)
+        add_rocshmem_functional_test(NAME teamreducescatterwave RANKS 8 WORKGROUPS 1 THREADS 64 MAX_MSG_SIZE 32768)
     end_test_group()
 endfunction()
 

--- a/projects/rocshmem/tests/functional_tests/reduce_wave_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/reduce_wave_tester.cpp
@@ -97,7 +97,8 @@ __global__ void ReduceWaveTest(int loop, int skip, long long int *start_time,
     if (i == skip && t_id % wf_size == 0) {
       start_time[flat_wf_id] = wall_clock64();
     }
-    wave_reduce<T1, T2>(ctx, teams[flat_wf_id], r_buf, s_buf, num_elems);
+    if (wf_id == 0)
+      wave_reduce<T1, T2>(ctx, teams[flat_wf_id], r_buf, s_buf, num_elems);
     __syncthreads();
   }
 

--- a/projects/rocshmem/tests/functional_tests/team_reduce_scatter_wave_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_reduce_scatter_wave_tester.cpp
@@ -1,0 +1,195 @@
+/******************************************************************************
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *****************************************************************************/
+
+using namespace rocshmem;
+
+/*
+ * reduce_scatter_wave(team, dest, source, nreduce):
+ *   - source has n_pes * nreduce elements per PE
+ *   - PE i receives the element-wise reduction of source[i*nreduce..(i+1)*nreduce-1]
+ *     from all PEs into dest[0..nreduce-1]
+ *
+ * Only wave 0 (wf_id == 0) within each workgroup calls the API.
+ * All threads sync afterward so timing is measured across the full WG.
+ */
+
+/* Generic stub — specializations below call the actual rocSHMEM API */
+template <typename T, ROCSHMEM_OP Op>
+__device__ int wave_team_reduce_scatter([[maybe_unused]] rocshmem_ctx_t ctx,
+                                        [[maybe_unused]] rocshmem_team_t team,
+                                        [[maybe_unused]] T *dest,
+                                        [[maybe_unused]] const T *source,
+                                        [[maybe_unused]] int nreduce) {
+  return ROCSHMEM_SUCCESS;
+}
+
+#define TEAM_REDUCE_SCATTER_WAVE_DEF_GEN(T, TNAME, Op_API, Op)                    \
+  template <>                                                                      \
+  __device__ int wave_team_reduce_scatter<T, Op>(rocshmem_ctx_t ctx,              \
+                                                 rocshmem_team_t team, T *dest,   \
+                                                 const T *source, int nreduce) {  \
+    return rocshmem_ctx_##TNAME##_##Op_API##_reduce_scatter_wave(ctx, team, dest, \
+                                                                  source, nreduce);\
+  }
+
+#define TEAM_ARITH_REDUCE_SCATTER_WAVE_DEF_GEN(T, TNAME)              \
+  TEAM_REDUCE_SCATTER_WAVE_DEF_GEN(T, TNAME, sum, ROCSHMEM_SUM)       \
+  TEAM_REDUCE_SCATTER_WAVE_DEF_GEN(T, TNAME, min, ROCSHMEM_MIN)       \
+  TEAM_REDUCE_SCATTER_WAVE_DEF_GEN(T, TNAME, max, ROCSHMEM_MAX)       \
+  TEAM_REDUCE_SCATTER_WAVE_DEF_GEN(T, TNAME, prod, ROCSHMEM_PROD)
+
+#define TEAM_BITWISE_REDUCE_SCATTER_WAVE_DEF_GEN(T, TNAME)            \
+  TEAM_REDUCE_SCATTER_WAVE_DEF_GEN(T, TNAME, or, ROCSHMEM_OR)         \
+  TEAM_REDUCE_SCATTER_WAVE_DEF_GEN(T, TNAME, and, ROCSHMEM_AND)       \
+  TEAM_REDUCE_SCATTER_WAVE_DEF_GEN(T, TNAME, xor, ROCSHMEM_XOR)
+
+#define TEAM_INT_REDUCE_SCATTER_WAVE_DEF_GEN(T, TNAME)  \
+  TEAM_ARITH_REDUCE_SCATTER_WAVE_DEF_GEN(T, TNAME)      \
+  TEAM_BITWISE_REDUCE_SCATTER_WAVE_DEF_GEN(T, TNAME)
+
+#define TEAM_FLOAT_REDUCE_SCATTER_WAVE_DEF_GEN(T, TNAME) \
+  TEAM_ARITH_REDUCE_SCATTER_WAVE_DEF_GEN(T, TNAME)
+
+TEAM_INT_REDUCE_SCATTER_WAVE_DEF_GEN(int, int)
+TEAM_INT_REDUCE_SCATTER_WAVE_DEF_GEN(short, short)
+TEAM_INT_REDUCE_SCATTER_WAVE_DEF_GEN(long, long)
+TEAM_INT_REDUCE_SCATTER_WAVE_DEF_GEN(long long, longlong)
+TEAM_FLOAT_REDUCE_SCATTER_WAVE_DEF_GEN(float, float)
+TEAM_FLOAT_REDUCE_SCATTER_WAVE_DEF_GEN(double, double)
+
+rocshmem_team_t team_reduce_scatter_wave_world_dup;
+
+/******************************************************************************
+ * DEVICE TEST KERNEL
+ *****************************************************************************/
+template <typename T1, ROCSHMEM_OP T2>
+__global__ void TeamReduceScatterWaveTest(int loop, int skip,
+                                          long long int *start_time,
+                                          long long int *end_time, T1 *s_buf,
+                                          T1 *r_buf, size_t size,
+                                          [[maybe_unused]] TestType type,
+                                          ShmemContextType ctx_type,
+                                          rocshmem_team_t team) {
+  __shared__ rocshmem_ctx_t ctx;
+  int wg_id = get_flat_grid_id();
+  int wf_id = get_flat_block_id() / WF_SIZE;
+
+  rocshmem_wg_team_create_ctx(team, ctx_type, &ctx);
+
+  __syncthreads();
+
+  for (int i = 0; i < loop + skip; i++) {
+    if (i == skip && hipThreadIdx_x == 0) {
+      start_time[wg_id] = wall_clock64();
+    }
+    // Only wave 0 in each workgroup calls the wave-level API.
+    if (wf_id == 0) {
+      wave_team_reduce_scatter<T1, T2>(ctx, team, r_buf, s_buf, size);
+    }
+    __syncthreads();
+  }
+
+  if (hipThreadIdx_x == 0) {
+    end_time[wg_id] = wall_clock64();
+  }
+
+  rocshmem_wg_ctx_destroy(&ctx);
+}
+
+/******************************************************************************
+ * HOST TESTER CLASS METHODS
+ *****************************************************************************/
+template <typename T1, ROCSHMEM_OP T2>
+TeamReduceScatterWaveTester<T1, T2>::TeamReduceScatterWaveTester(
+    TesterArguments args, std::function<void(T1 &, T1 &)> f1,
+    std::function<std::pair<bool, std::string>(const T1 &, const T1 &)> f2)
+    : Tester(args), init_buf{f1}, verify_buf{f2} {
+  my_pe = rocshmem_team_my_pe(ROCSHMEM_TEAM_WORLD);
+  n_pes = rocshmem_team_n_pes(ROCSHMEM_TEAM_WORLD);
+
+  // source buffer: n_pes * max_msg_size elements (on symmetric heap)
+  s_buf = (T1 *)alloc_test_buffer(n_pes * max_msg_size * sizeof(T1),
+                                  args.local_buf_type);
+  // dest buffer: max_msg_size elements (on symmetric heap)
+  r_buf = (T1 *)alloc_test_buffer(max_msg_size * sizeof(T1));
+}
+
+template <typename T1, ROCSHMEM_OP T2>
+TeamReduceScatterWaveTester<T1, T2>::~TeamReduceScatterWaveTester() {
+  free_test_buffer(s_buf, args.local_buf_type);
+  free_test_buffer(r_buf);
+}
+
+template <typename T1, ROCSHMEM_OP T2>
+void TeamReduceScatterWaveTester<T1, T2>::preLaunchKernel() {
+  bw_factor = n_pes;
+
+  team_reduce_scatter_wave_world_dup = ROCSHMEM_TEAM_INVALID;
+  rocshmem_team_split_strided(ROCSHMEM_TEAM_WORLD, 0, 1, n_pes, nullptr, 0,
+                               &team_reduce_scatter_wave_world_dup);
+}
+
+template <typename T1, ROCSHMEM_OP T2>
+void TeamReduceScatterWaveTester<T1, T2>::launchKernel(dim3 gridSize,
+                                                        dim3 blockSize,
+                                                        int loop,
+                                                        uint64_t size) {
+  size_t shared_bytes = 0;
+
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(TeamReduceScatterWaveTest<T1, T2>),
+                     gridSize, blockSize, shared_bytes, stream, loop, args.skip,
+                     start_time, end_time, s_buf, r_buf, size, _type,
+                     _shmem_context, team_reduce_scatter_wave_world_dup);
+
+  num_msgs = loop + args.skip;
+  num_timed_msgs = loop;
+}
+
+template <typename T1, ROCSHMEM_OP T2>
+void TeamReduceScatterWaveTester<T1, T2>::postLaunchKernel() {
+  rocshmem_team_destroy(team_reduce_scatter_wave_world_dup);
+}
+
+template <typename T1, ROCSHMEM_OP T2>
+void TeamReduceScatterWaveTester<T1, T2>::resetBuffers(
+    [[maybe_unused]] uint64_t size) {
+  for (uint64_t i = 0; i < (uint64_t)n_pes * max_msg_size; i++) {
+    s_buf[i] = static_cast<T1>(1);
+  }
+  for (uint64_t i = 0; i < max_msg_size; i++) {
+    r_buf[i] = static_cast<T1>(0);
+  }
+}
+
+template <typename T1, ROCSHMEM_OP T2>
+void TeamReduceScatterWaveTester<T1, T2>::verifyResults(uint64_t size) {
+  for (uint64_t i = 0; i < size; i++) {
+    auto r = verify_buf(r_buf[i], (T1)n_pes);
+    if (r.first == false) {
+      fprintf(stderr, "Data validation error at idx %lu\n", i);
+      fprintf(stderr, "%s.\n", r.second.c_str());
+      exit(-1);
+    }
+  }
+}

--- a/projects/rocshmem/tests/functional_tests/team_reduce_scatter_wave_tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/team_reduce_scatter_wave_tester.hpp
@@ -1,0 +1,70 @@
+/******************************************************************************
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *****************************************************************************/
+
+#ifndef _TEAM_REDUCE_SCATTER_WAVE_TESTER_HPP_
+#define _TEAM_REDUCE_SCATTER_WAVE_TESTER_HPP_
+
+#include <functional>
+#include <utility>
+
+#include "tester.hpp"
+
+/******************************************************************************
+ * HOST TESTER CLASS
+ *****************************************************************************/
+template <typename T1, ROCSHMEM_OP T2>
+class TeamReduceScatterWaveTester : public Tester {
+ public:
+  explicit TeamReduceScatterWaveTester(
+      TesterArguments args, std::function<void(T1 &, T1 &)> f1,
+      std::function<std::pair<bool, std::string>(const T1 &, const T1 &)> f2);
+  virtual ~TeamReduceScatterWaveTester();
+
+ protected:
+  virtual void resetBuffers(uint64_t size) override;
+
+  virtual void preLaunchKernel() override;
+
+  virtual void launchKernel(dim3 gridSize, dim3 blockSize, int loop,
+                            uint64_t size) override;
+
+  virtual void postLaunchKernel() override;
+
+  virtual void verifyResults(uint64_t size) override;
+
+  T1 *s_buf;  // source: n_pes * size elements per PE
+  T1 *r_buf;  // dest:   size elements per PE
+
+ private:
+  int my_pe = 0;
+  int n_pes = 0;
+
+  std::function<void(T1 &, T1 &)> init_buf;
+  std::function<std::pair<bool, std::string>(const T1 &, const T1 &)>
+      verify_buf;
+};
+
+#include "team_reduce_scatter_wave_tester.cpp"
+
+#endif  // _TEAM_REDUCE_SCATTER_WAVE_TESTER_HPP_

--- a/projects/rocshmem/tests/functional_tests/tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester.cpp
@@ -66,6 +66,7 @@
 #include "team_reduction_tester.hpp"
 #include "team_reduce_scatter_tester.hpp"
 #include "reduce_wave_tester.hpp"
+#include "team_reduce_scatter_wave_tester.hpp"
 #include "wavefront_primitives.hpp"
 #include "workgroup_primitives.hpp"
 #include "flood_tester.hpp"
@@ -160,6 +161,7 @@ Tester::Tester(TesterArguments args) : args(args) {
       case BroadcastWaveTestType:
       case TeamReductionTestType:
       case TeamReduceScatterTestType:
+      case TeamReduceScatterWaveTestType:
       case TeamFCollectTestType:
       case FcollectWaveTestType:
       case CollectTestType:
@@ -328,6 +330,22 @@ std::vector<Tester*> Tester::create(TesterArguments args) {
           [](float& f1, float& f2) {
             f1 = 1;
             f2 = 1;
+          },
+          [](float v, float n_pes) {
+            return (v == n_pes)
+                       ? std::make_pair(true, "")
+                       : std::make_pair(false, "Got " + std::to_string(v) +
+                                                   ", Expect " +
+                                                   std::to_string(n_pes));
+          }));
+      break;
+    case TeamReduceScatterWaveTestType:
+      test_name = "Team-based Reduce-Scatter Wave";
+      testers.push_back(new TeamReduceScatterWaveTester<float, ROCSHMEM_SUM>(
+          args,
+          [](float& f1, float& f2) {
+            f1 = 1;
+            f2 = 0;
           },
           [](float v, float n_pes) {
             return (v == n_pes)
@@ -1037,6 +1055,7 @@ bool Tester::peLaunchesKernel() {
     case TeamReductionTestType:
     case TeamReduceScatterTestType:
     case ReduceWaveTestType:
+    case TeamReduceScatterWaveTestType:
     case TeamBroadcastTestType:
     case TeamCtxInfraTestType:
     case TeamCtxInfraSingleTestType:

--- a/projects/rocshmem/tests/functional_tests/tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/tester.hpp
@@ -195,8 +195,9 @@
   X(BroadcastWave,             150)  \
   X(AllToAllWave,              151)  \
   X(FcollectWave,              152)  \
-  X(ReduceWave,                153)
-
+  X(ReduceWave,                153)  \
+  X(TeamReduceScatterWave,     154)
+  
 #define _ROCSHMEM_ENUM_ENTRY(name, val) name##TestType = val,
 enum TestType {
   ROCSHMEM_FOREACH_TEST_TYPE(_ROCSHMEM_ENUM_ENTRY)

--- a/projects/rocshmem/tests/functional_tests/tester_arguments.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester_arguments.cpp
@@ -293,6 +293,7 @@ void TesterArguments::get_arguments() {
     case TeamReductionTestType:
     case TeamReduceScatterTestType:
     case ReduceWaveTestType:
+    case TeamReduceScatterWaveTestType:
     case TeamBroadcastTestType:
     case PingAllTestType:
     case TeamBarrierTestType:

--- a/projects/rocshmem/tests/test_categories.yaml
+++ b/projects/rocshmem/tests/test_categories.yaml
@@ -156,6 +156,7 @@ test_categories:
       - "broadcast_wave_.*"
       - "fcollect_wave_.*"
       - "reduce_wave_.*"
+      - "teamreducescatterwave_.*"
 
       # Extended signal operations
       - "wgputsignal_.*"


### PR DESCRIPTION
## Motivation

Develop `nvshmemx_##TYPE##_##OP##_reducescatter_warp()` to provide wave-level reduce scatter capabilities in rocSHMEM, matching NVSHMEM's API and semantics.

## Technical Details

add wave-level reduce implementation `nvshmemx_##TYPE##_##OP##_reducescatter_warp()`
- [x] Add IPC backend implementation
- [x] Add GDA backend implementation

## JIRA ID

JIRA ID: AIROCSHMEM-448

## Test Plan

- [x] build functional test for wave level reduce scatter and verify functionality

## Test Result

- [x] passing functional test

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.