### PR TITLE
docs(rocjitsu): document npi tasks inline

### DIFF
--- a/emulation/mirage/builtin/src/agents.rs
+++ b/emulation/mirage/builtin/src/agents.rs
@@ -22,6 +22,7 @@ pub fn agents() -> Vec<(&'static str, AgentDef)> {
         ("mi300x", mi300x()),
         ("mi350x", mi350x()),
         ("mi450x", mi450x()),
+        // \NPI new GPU: add a builtin agent mirroring its configs/<gpu>.json here.
     ]
 }
 

--- a/emulation/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/CMakeLists.txt
@@ -279,6 +279,7 @@ target_link_libraries(
         rocjitsu_isa_rdna3_5
         rocjitsu_isa_rdna4
         rocjitsu_isa_gfx1250
+        # \NPI new ISA family: link its rocjitsu_isa_<isa> object library here.
         rocjitsu_isa_risc_v
         simdojo
         rocjitsu_kmd

--- a/emulation/rocjitsu/README.md
+++ b/emulation/rocjitsu/README.md
@@ -28,6 +28,8 @@ real hardware. Supports three execution strategies:
 | gfx1250      | gfx1250 | GFX12 | Experimental | Experimental | Planned |
 | RISC-V | RV32IMAFDC | RV | Experimental | &mdash; | &mdash; |
 
+<!-- \NPI new GPU: add a row to the supported-architectures table above. -->
+
 ## Project layout
 
 ```

--- a/emulation/rocjitsu/docs/codegen.md
+++ b/emulation/rocjitsu/docs/codegen.md
@@ -70,6 +70,9 @@ python -m amdisa [--multi NAME:XML ...] [--gen-isas] [--gen-dbt]
 When neither `--gen-isas` nor `--gen-dbt` is specified, both are
 generated.
 
+<!-- \NPI new ISA family: add a `<isa>:$MRISA/amdgpu_isa_<isa>.xml` entry to
+     each `--multi` invocation in the commands below. -->
+
 ## Regenerating everything
 
 All commands are run from the rocjitsu project root. Set `MRISA` to the

--- a/emulation/rocjitsu/docs/codegen.md
+++ b/emulation/rocjitsu/docs/codegen.md
@@ -70,7 +70,7 @@ python -m amdisa [--multi NAME:XML ...] [--gen-isas] [--gen-dbt]
 When neither `--gen-isas` nor `--gen-dbt` is specified, both are
 generated.
 
-<!-- \NPI new ISA family: add a `<isa>:$MRISA/amdgpu_isa_<isa>.xml` entry to
+<!-- \NPI new ISA family: add a `<isa>:$MRISA/amdgpu_isa_<isa>.xml` entry to \
      each `--multi` invocation in the commands below. -->
 
 ## Regenerating everything

--- a/emulation/rocjitsu/docs/npi.md
+++ b/emulation/rocjitsu/docs/npi.md
@@ -6,13 +6,25 @@ This guide is not complete.
 
 Mark tasks that need to be done when introducing a new product with `\NPI` comment.
 
-Can do multi-line comments with
+Single-line markers use any comment leader (e.g. `//`):
 
 ```c
-/// \NPI I am a big complicated todo \
-/// that takes multiple lines to describe.
+// \NPI a one-line todo
 ```
-(no trailing space after the `\`)
+
+Multi-line markers use a `/* */` block comment, ending each continued line with a
+trailing `\` (a `//` comment ending in `\` is a line-continuation that GCC rejects
+under `-Werror=comment`):
+
+```c
+/*
+ * \NPI I am a big complicated todo \
+ * that takes multiple lines to describe.
+ */
+```
+
+`scripts/find-npi-tasks.sh` strips the comment leaders and joins the continued
+lines into a single task.
 
 ## Find npi tasks
 

--- a/emulation/rocjitsu/docs/npi.md
+++ b/emulation/rocjitsu/docs/npi.md
@@ -16,7 +16,7 @@ Can do multi-line comments with
 
 ## Find npi tasks
 
-use `scripts/find-npi-tasks.sh` to find tasks.
+Use `scripts/find-npi-tasks.sh` to find tasks.
 
 ## Extra Steps
 

--- a/emulation/rocjitsu/docs/npi.md
+++ b/emulation/rocjitsu/docs/npi.md
@@ -6,7 +6,7 @@ This guide is not complete.
 
 Mark tasks that need to be done when introducing a new product with `\NPI` comment.
 
-can do multi-line comments with
+Can do multi-line comments with
 
 ```c
 /// \NPI I am a big complicated todo \

--- a/emulation/rocjitsu/docs/npi.md
+++ b/emulation/rocjitsu/docs/npi.md
@@ -1,0 +1,36 @@
+# Adding a new GPU
+
+This guide is not complete.
+
+## Marking NPI tasks
+
+Mark tasks that need to be done when introducing a new product with `\NPI` comment.
+
+can do multi-line comments with
+
+```c
+/// \NPI I am a big complicated todo \
+/// that takes multiple lines to describe.
+```
+(no trailing space after the `\`)
+
+## Find npi tasks
+
+use `scripts/find-npi-tasks.sh` to find tasks.
+
+## Extra Steps
+
+What the grep can't point at are the "create a new thing" steps:
+
+- Construct a `configs/<gpu>.json` (plus the `_kmd` and any multi-GPU variant)
+  for the new device.
+- For a brand-new ISA family: sync `shared/machine-readable-isa` with
+  `download.py`, regenerate the ISA/DBT sources per [codegen.md](codegen.md),
+  and author the hand-written per-arch files (`isa.h`, `insts.h`, `mma_exec.h`,
+  `addr_calc.h/.cpp`, ...) under
+  `lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/<isa>/`.
+- Add HIP kernel coverage under `tests/kernels/`.
+
+## Reminder
+
+Don't leak new products.

--- a/emulation/rocjitsu/lib/python/amdisa/isa_profile.py
+++ b/emulation/rocjitsu/lib/python/amdisa/isa_profile.py
@@ -19,6 +19,10 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum, auto
 
+# \NPI new ISA family: (1) sync shared/machine-readable-isa via download.py and \
+# add amdgpu_isa_<isa>.xml, (2) add its profile in this module, (3) regenerate \
+# per docs/codegen.md, (4) author the hand-written isa.h / insts.h / mma_exec.h \
+# / addr_calc.* under lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/<isa>/.
 _FLOAT_NAME_MAP: dict[float, str] = {
     -0.5: 'NEG_HALF',
     -1.0: 'NEG_ONE',

--- a/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/code/rj_code.h
+++ b/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/code/rj_code.h
@@ -45,8 +45,10 @@ typedef enum rj_code_arch_e {
   ROCJITSU_CODE_ARCH_RV64I = 10,
   /// @brief gfx1250 ISA architecture.
   ROCJITSU_CODE_ARCH_GFX1250 = 11,
-  // \NPI a GPU that introduces a new ISA family needs a new arch id here; \
-  // give it the next value and keep NUM_ARCHS / INVALID last.
+  /*
+   * \NPI a GPU that introduces a new ISA family needs a new arch id here; \
+   * give it the next value and keep NUM_ARCHS / INVALID last.
+   */
   /// @brief Total number of supported architectures.
   ROCJITSU_CODE_ARCH_NUM_ARCHS = 12,
   /// @brief Sentinel value representing an invalid architecture.
@@ -112,8 +114,10 @@ typedef enum rj_code_target_id_t {
   ROCJITSU_CODE_TARGET_GFX1201,
   /// @brief gfx1250 target ID.
   ROCJITSU_CODE_TARGET_GFX1250,
-  // \NPI every new GPU needs a target id here (one per distinct gfxNNNN \
-  // variant); keep INVALID last.
+  /*
+   * \NPI every new GPU needs a target id here (one per distinct gfxNNNN \
+   * variant); keep INVALID last.
+   */
   /// @brief Sentinel value representing an invalid target.
   ROCJITSU_CODE_TARGET_INVALID
 } rj_code_target_id_t;

--- a/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/code/rj_code.h
+++ b/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/code/rj_code.h
@@ -45,6 +45,8 @@ typedef enum rj_code_arch_e {
   ROCJITSU_CODE_ARCH_RV64I = 10,
   /// @brief gfx1250 ISA architecture.
   ROCJITSU_CODE_ARCH_GFX1250 = 11,
+  // \NPI a GPU that introduces a new ISA family needs a new arch id here; \
+  // give it the next value and keep NUM_ARCHS / INVALID last.
   /// @brief Total number of supported architectures.
   ROCJITSU_CODE_ARCH_NUM_ARCHS = 12,
   /// @brief Sentinel value representing an invalid architecture.
@@ -110,6 +112,8 @@ typedef enum rj_code_target_id_t {
   ROCJITSU_CODE_TARGET_GFX1201,
   /// @brief gfx1250 target ID.
   ROCJITSU_CODE_TARGET_GFX1250,
+  // \NPI every new GPU needs a target id here (one per distinct gfxNNNN \
+  // variant); keep INVALID last.
   /// @brief Sentinel value representing an invalid target.
   ROCJITSU_CODE_TARGET_INVALID
 } rj_code_target_id_t;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_code_object.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_code_object.cpp
@@ -47,6 +47,8 @@ bool is_elf(const Elf64_Ehdr &ehdr) { return !std::memcmp(ehdr.e_ident, EI_MAGIC
 
 using detail::fits_in_bounds;
 
+// \NPI new GPU: map its MACH value and its gfxNNNN triple to a target id in \
+// both target_from_machine_flags() and target_from_triple() below.
 rj_code_target_id_t target_from_machine_flags(uint32_t flags) {
   uint32_t mach = flags & EF_AMDGPU_MACH;
   if (mach == EF_AMDGPU_MACH_AMDGCN_GFX90A)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_code_object.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_code_object.cpp
@@ -47,8 +47,10 @@ bool is_elf(const Elf64_Ehdr &ehdr) { return !std::memcmp(ehdr.e_ident, EI_MAGIC
 
 using detail::fits_in_bounds;
 
-// \NPI new GPU: map its MACH value and its gfxNNNN triple to a target id in \
-// both target_from_machine_flags() and target_from_triple() below.
+/*
+ * \NPI new GPU: map its MACH value and its gfxNNNN triple to a target id in \
+ * both target_from_machine_flags() and target_from_triple() below.
+ */
 rj_code_target_id_t target_from_machine_flags(uint32_t flags) {
   uint32_t mach = flags & EF_AMDGPU_MACH;
   if (mach == EF_AMDGPU_MACH_AMDGCN_GFX90A)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_elf.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_elf.h
@@ -64,9 +64,11 @@ inline constexpr uint32_t EF_AMDGPU_MACH_AMDGCN_GFX1200 = 0x48;
 inline constexpr uint32_t EF_AMDGPU_MACH_AMDGCN_GFX1250 = 0x49;
 inline constexpr uint32_t EF_AMDGPU_MACH_AMDGCN_GFX1201 = 0x4e;
 
-// \NPI new GPU: add its EF_AMDGPU_MACH_AMDGCN_* constant above (value from the \
-// LLVM AMDGPU backend), then handle it in elf_mach_for_arch, arch_for_elf_mach, \
-// and elf_mach_name below.
+/*
+ * \NPI new GPU: add its EF_AMDGPU_MACH_AMDGCN_* constant above (value from the \
+ * LLVM AMDGPU backend), then handle it in elf_mach_for_arch, arch_for_elf_mach, \
+ * and elf_mach_name below.
+ */
 inline constexpr uint32_t elf_mach_for_arch(rj_code_arch_t arch) {
   switch (arch) {
   case ROCJITSU_CODE_ARCH_CDNA1:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_elf.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_elf.h
@@ -64,6 +64,9 @@ inline constexpr uint32_t EF_AMDGPU_MACH_AMDGCN_GFX1200 = 0x48;
 inline constexpr uint32_t EF_AMDGPU_MACH_AMDGCN_GFX1250 = 0x49;
 inline constexpr uint32_t EF_AMDGPU_MACH_AMDGCN_GFX1201 = 0x4e;
 
+// \NPI new GPU: add its EF_AMDGPU_MACH_AMDGCN_* constant above (value from the \
+// LLVM AMDGPU backend), then handle it in elf_mach_for_arch, arch_for_elf_mach, \
+// and elf_mach_name below.
 inline constexpr uint32_t elf_mach_for_arch(rj_code_arch_t arch) {
   switch (arch) {
   case ROCJITSU_CODE_ARCH_CDNA1:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/rj_code.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/rj_code.cpp
@@ -11,8 +11,10 @@ using namespace rocjitsu;
 
 namespace {
 
-// \NPI new GPU: add its target -> Decoder mapping in create_decoder_for_target() \
-// and its target -> arch mapping in arch_for_target() below.
+/*
+ * \NPI new GPU: add its target -> Decoder mapping in create_decoder_for_target() \
+ * and its target -> arch mapping in arch_for_target() below.
+ */
 Decoder *create_decoder_for_target(rj_code_target_id_t target) {
   static thread_local std::unique_ptr<Decoder> cdna2_decoder;
   static thread_local std::unique_ptr<Decoder> cdna3_decoder;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/rj_code.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/rj_code.cpp
@@ -11,6 +11,8 @@ using namespace rocjitsu;
 
 namespace {
 
+// \NPI new GPU: add its target -> Decoder mapping in create_decoder_for_target() \
+// and its target -> arch mapping in arch_for_target() below.
 Decoder *create_decoder_for_target(rj_code_target_id_t target) {
   static thread_local std::unique_ptr<Decoder> cdna2_decoder;
   static thread_local std::unique_ptr<Decoder> cdna3_decoder;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.cpp
@@ -777,6 +777,7 @@ LoadedConfig build_from_fb(const rocjitsu::fb::SimulationConfig *fb_config) {
 } // namespace
 
 rj_code_arch_t parse_arch(const std::string &arch_str) {
+  // \NPI new ISA family: add its "arch" string here and in arch_to_string().
   if (arch_str == "cdna1")
     return ROCJITSU_CODE_ARCH_CDNA1;
   if (arch_str == "cdna2")

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/CMakeLists.txt
@@ -27,6 +27,7 @@ target_link_libraries(
         rocjitsu_isa_rdna3
         rocjitsu_isa_rdna3_5
         rocjitsu_isa_rdna4
+        # \NPI new ISA family: link its rocjitsu_isa_<isa> object library here.
         util
         simdojo
         Threads::Threads

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/CMakeLists.txt
@@ -18,4 +18,6 @@ add_subdirectory(arch/amdgpu/rdna3)
 add_subdirectory(arch/amdgpu/rdna3_5)
 add_subdirectory(arch/amdgpu/rdna4)
 add_subdirectory(arch/amdgpu/gfx1250)
+# \NPI new ISA family: create arch/amdgpu/<isa>/CMakeLists.txt \
+# (rj_add_object_library(rocjitsu_isa_<isa> ...)) and add_subdirectory() it here.
 add_subdirectory(arch/risc_v)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/decoder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/decoder.cpp
@@ -34,8 +34,10 @@ Instruction *Decoder::decode(const rj_code_binary_inst_t *inst, uint64_t src_loc
 }
 
 std::unique_ptr<Decoder> Decoder::create(rj_code_arch_t arch) {
-  // \NPI new ISA family: #include its arch/amdgpu/<isa>/isa.h above and add a \
-  // case returning std::make_unique<IsaDecoder<<isa>::Isa>>() here.
+  /*
+   * \NPI new ISA family: #include its arch/amdgpu/<isa>/isa.h above and add a \
+   * case returning std::make_unique<IsaDecoder<<isa>::Isa>>() here.
+   */
   switch (arch) {
   case ROCJITSU_CODE_ARCH_CDNA1:
     return std::make_unique<IsaDecoder<cdna1::Isa>>();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/decoder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/decoder.cpp
@@ -34,6 +34,8 @@ Instruction *Decoder::decode(const rj_code_binary_inst_t *inst, uint64_t src_loc
 }
 
 std::unique_ptr<Decoder> Decoder::create(rj_code_arch_t arch) {
+  // \NPI new ISA family: #include its arch/amdgpu/<isa>/isa.h above and add a \
+  // case returning std::make_unique<IsaDecoder<<isa>::Isa>>() here.
   switch (arch) {
   case ROCJITSU_CODE_ARCH_CDNA1:
     return std::make_unique<IsaDecoder<cdna1::Isa>>();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -148,6 +148,8 @@ bool sgpr_count_is_descriptor_encoded(rj_code_arch_t arch, uint32_t sgpr_gran) {
   if (sgpr_gran != 0)
     return true;
 
+  // \NPI new ISA family: classify the new arch for CP-visible behavior here \
+  // (RDNA-style encodings return false; CDNA-style fall through to the default).
   switch (arch) {
   case ROCJITSU_CODE_ARCH_RDNA1:
   case ROCJITSU_CODE_ARCH_RDNA2:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -148,8 +148,10 @@ bool sgpr_count_is_descriptor_encoded(rj_code_arch_t arch, uint32_t sgpr_gran) {
   if (sgpr_gran != 0)
     return true;
 
-  // \NPI new ISA family: classify the new arch for CP-visible behavior here \
-  // (RDNA-style encodings return false; CDNA-style fall through to the default).
+  /*
+   * \NPI new ISA family: classify the new arch for CP-visible behavior here \
+   * (RDNA-style encodings return false; CDNA-style fall through to the default).
+   */
   switch (arch) {
   case ROCJITSU_CODE_ARCH_RDNA1:
   case ROCJITSU_CODE_ARCH_RDNA2:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
@@ -74,6 +74,7 @@ std::unique_ptr<ComputeUnitCore> ComputeUnitCore::create(std::string name, const
     break
 
   switch (config.arch) {
+    // \NPI new ISA family: add ROCJITSU_CU_CASE(ROCJITSU_CODE_ARCH_<NAME>, <isa>::Isa);
     ROCJITSU_CU_CASE(ROCJITSU_CODE_ARCH_CDNA1, cdna1::Isa);
     ROCJITSU_CU_CASE(ROCJITSU_CODE_ARCH_CDNA2, cdna2::Isa);
     ROCJITSU_CU_CASE(ROCJITSU_CODE_ARCH_CDNA3, cdna3::Isa);

--- a/emulation/rocjitsu/schemas/simulation_config.fbs
+++ b/emulation/rocjitsu/schemas/simulation_config.fbs
@@ -51,6 +51,9 @@ table GpuMemoryConfig {
 ///   - GFX target versions: projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
 ///   - Real hardware values: `cat /sys/class/kfd/kfd/topology/nodes/*/properties` on a system
 ///     with the target GPU installed.
+///
+/// \NPI new GPU: add a configs/<gpu>.json (plus the _kmd and any multi-GPU \
+/// variant) that fills in these identity fields for the new device.
 table KfdDeviceInfo {
   gpu_id: uint32;                  // KFD GPU ID (e.g., 0x9500 for gfx950).
   gfx_target_version: uint32;     // Packed GFX version (e.g., 90500 for gfx950).

--- a/emulation/rocjitsu/schemas/simulation_config.fbs
+++ b/emulation/rocjitsu/schemas/simulation_config.fbs
@@ -52,8 +52,7 @@ table GpuMemoryConfig {
 ///   - Real hardware values: `cat /sys/class/kfd/kfd/topology/nodes/*/properties` on a system
 ///     with the target GPU installed.
 ///
-/// \NPI new GPU: add a configs/<gpu>.json (plus the _kmd and any multi-GPU \
-/// variant) that fills in these identity fields for the new device.
+/// \NPI new GPU: add a configs/<gpu>.json that fills in these identity fields for the new device.
 table KfdDeviceInfo {
   gpu_id: uint32;                  // KFD GPU ID (e.g., 0x9500 for gfx950).
   gfx_target_version: uint32;     // Packed GFX version (e.g., 90500 for gfx950).

--- a/emulation/rocjitsu/scripts/find-npi-tasks.sh
+++ b/emulation/rocjitsu/scripts/find-npi-tasks.sh
@@ -21,7 +21,7 @@
 #   path/to/file:LINE: I am a big complicated todo that takes multiple lines to describe.
 #
 # Usage:
-#   ./scripts/find-npi.sh [pathspec ...]
+#   ./scripts/find-npi-tasks.sh [pathspec ...]
 #
 # With no arguments it scans tracked files under emulation/. Any arguments are
 # forwarded to `git ls-files` as pathspecs (relative to the repository root).

--- a/emulation/rocjitsu/scripts/find-npi-tasks.sh
+++ b/emulation/rocjitsu/scripts/find-npi-tasks.sh
@@ -60,7 +60,7 @@ fi
 git ls-files -z -- "${pathspec[@]}" \
     ":(exclude)${self#"$repo_root"/}" \
     ":(exclude)${docs#"$repo_root"/}" \
-    | xargs -0 -r awk -v cfile="$c_file" -v cline="$c_line" -v creset="$c_reset" '
+    | xargs -0 awk -v cfile="$c_file" -v cline="$c_line" -v creset="$c_reset" '
 # A new file began while a multi-line task was still open: close it out first.
 FNR == 1 && open { flush() }
 

--- a/emulation/rocjitsu/scripts/find-npi-tasks.sh
+++ b/emulation/rocjitsu/scripts/find-npi-tasks.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# Find \NPI tasks (the markers left for "new product introduction" work) and
+# print them one per line as:
+#
+#   $FILE:$LINE: $TODO
+#
+# A marker may also span
+# multiple lines by ending each continued line with a trailing backslash; the
+# comment leader (//, ///, #, *) on continuation lines is stripped and the text
+# is joined with single spaces. For example:
+#
+#   /// \NPI I am a big complicated todo \
+#   /// that takes multiple lines to describe.
+#
+# is reported as:
+#
+#   path/to/file:LINE: I am a big complicated todo that takes multiple lines to describe.
+#
+# Usage:
+#   ./scripts/find-npi.sh [pathspec ...]
+#
+# With no arguments it scans tracked files under emulation/. Any arguments are
+# forwarded to `git ls-files` as pathspecs (relative to the repository root).
+
+set -euo pipefail
+
+# Resolve this script's own path. It documents the \NPI convention (and so
+# contains the marker), but it is not itself a task, so exclude it below.
+self="$(cd "$(dirname "$0")" && pwd -P)/$(basename "$0")"
+
+# docs/npi.md also documents the \NPI convention, carrying example markers
+# rather than real tasks, so exclude it as well.
+docs="$(cd "$(dirname "$0")/../docs" && pwd -P)/npi.md"
+
+# Run from the repository root so reported paths are root-relative (e.g.
+# emulation/rocjitsu/...), matching the paths git reports for tracked files.
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+# Default to the emulation/ tree; allow callers to narrow or widen the scope.
+pathspec=("$@")
+if [[ ${#pathspec[@]} -eq 0 ]]; then
+    pathspec=("emulation/")
+fi
+
+# Colorize output when FORCE_COLOR=1, or when stdout is a color-capable terminal
+# and NO_COLOR is unset/empty (https://force-color.org/). File paths are shown in
+# magenta and line numbers in green, matching grep's defaults.
+c_file='' c_line='' c_reset=''
+if [[ "${FORCE_COLOR:-}" == "1" ]] \
+    || { [[ -z "${NO_COLOR:-}" && -t 1 && "${TERM:-}" != "dumb" ]]; }; then
+    c_file=$'\033[35m' c_line=$'\033[32m' c_reset=$'\033[0m'
+fi
+
+# Scan tracked files, excluding this script and the convention's documentation.
+git ls-files -z -- "${pathspec[@]}" \
+    ":(exclude)${self#"$repo_root"/}" \
+    ":(exclude)${docs#"$repo_root"/}" \
+    | xargs -0 -r awk -v cfile="$c_file" -v cline="$c_line" -v creset="$c_reset" '
+# A new file began while a multi-line task was still open: close it out first.
+FNR == 1 && open { flush() }
+
+# Strip a trailing backslash (the continuation marker) and remember whether one
+# was present, so we know if the task carries on to the next line.
+{ cont = sub(/\\[ \t]*$/, "") }
+
+# Continuation line: drop the comment leader and append to the current task.
+open {
+    frag = $0
+    sub(/^[ \t]*/, "", frag)
+    sub(/^[\/#*]+[ \t]*/, "", frag)
+    text = text " " frag
+    if (!cont) flush()
+    next
+}
+
+# Start of a task: capture everything after the \NPI marker on this line.
+# Require whitespace or end-of-line after the marker so inline mentions such as
+# `\NPI` in prose or the '\NPI' grep example are not mistaken for tasks.
+/\\NPI([ \t]|$)/ {
+    text = $0
+    sub(/^.*\\NPI/, "", text)
+    file = FILENAME
+    line = FNR
+    open = 1
+    if (!cont) flush()
+    next
+}
+
+END { if (open) flush() }
+
+# Emit the accumulated task, collapsing internal whitespace to single spaces and
+# dropping a trailing comment closer (--> or */).
+function flush() {
+    gsub(/[ \t]+/, " ", text)
+    sub(/ *(-->|\*\/) *$/, "", text)
+    sub(/^ +/, "", text)
+    sub(/ +$/, "", text)
+    printf "%s%s%s:%s%d%s: %s\n", cfile, file, creset, cline, line, creset, text
+    open = 0
+    text = ""
+}
+'

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -22,6 +22,8 @@ set(RJ_OBJECT_LIBS
     rocjitsu_isa_rdna3_5
     rocjitsu_isa_rdna4
     rocjitsu_isa_gfx1250
+    # \NPI new ISA family: link its rocjitsu_isa_<isa> object library here, and \
+    # wire any new *_sim_test.cpp and kernels/ coverage into this file.
     rocjitsu_isa_risc_v
     simdojo
     rocjitsu_kmd

--- a/emulation/rocjitsu/tests/code/code_object_target_id_test.cpp
+++ b/emulation/rocjitsu/tests/code/code_object_target_id_test.cpp
@@ -14,6 +14,7 @@
 /// INVALID sentinel and prevent a future edit from silently aliasing one target
 /// onto another.
 
+// \NPI new GPU: extend these tests with its MACH/triple -> target mapping.
 #include "rocjitsu/code/amdgpu_code_object.h"
 #include "rocjitsu/code/amdgpu_elf.h"
 #include "rocjitsu/code/rj_code.h"

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -32,6 +32,7 @@ namespace {
 
 const std::string CONFIG_DIR_PATH = CONFIG_DIR;
 
+// \NPI new GPU: add a config-load test for its configs/<gpu>.json here.
 using namespace rocjitsu;
 
 TEST(ConfigLoaderTest, LoadCdna4Config) {

--- a/emulation/rocjitsu/tests/shared_infra_test.cpp
+++ b/emulation/rocjitsu/tests/shared_infra_test.cpp
@@ -86,6 +86,8 @@ using namespace rocjitsu;
 // Concept and trait verification (compile-time)
 // ---------------------------------------------------------------------------
 
+// \NPI new ISA family: add GpuIsa<<isa>::Isa> plus the relevant trait \
+// static_asserts (HasAccVgpr, HasMonolithicWaitcnt, ...) for it here.
 static_assert(GpuIsa<cdna3::Isa>);
 static_assert(GpuIsa<gfx1250::Isa>);
 static_assert(GpuIsa<rdna4::Isa>);

--- a/emulation/rocjitsu/tests/shared_infra_test.cpp
+++ b/emulation/rocjitsu/tests/shared_infra_test.cpp
@@ -86,8 +86,10 @@ using namespace rocjitsu;
 // Concept and trait verification (compile-time)
 // ---------------------------------------------------------------------------
 
-// \NPI new ISA family: add GpuIsa<<isa>::Isa> plus the relevant trait \
-// static_asserts (HasAccVgpr, HasMonolithicWaitcnt, ...) for it here.
+/*
+ * \NPI new ISA family: add GpuIsa<<isa>::Isa> plus the relevant trait \
+ * static_asserts (HasAccVgpr, HasMonolithicWaitcnt, ...) for it here.
+ */
 static_assert(GpuIsa<cdna3::Isa>);
 static_assert(GpuIsa<gfx1250::Isa>);
 static_assert(GpuIsa<rdna4::Isa>);

--- a/emulation/rocjitsu/tools/CMakeLists.txt
+++ b/emulation/rocjitsu/tools/CMakeLists.txt
@@ -17,6 +17,7 @@ set(RJ_TOOL_OBJECT_LIBS
     rocjitsu_isa_rdna3_5
     rocjitsu_isa_rdna4
     rocjitsu_isa_gfx1250
+    # \NPI new ISA family: link its rocjitsu_isa_<isa> object library here.
     # The DBT tool only needs generated AMDGPU decoders/disassemblers, but
     # those object files currently also contain instruction execute methods.
     # Until generated ISA decode/disassembly is split from VM execution, the

--- a/emulation/rocjitsu/tools/dbt_translate_main.cpp
+++ b/emulation/rocjitsu/tools/dbt_translate_main.cpp
@@ -38,8 +38,8 @@ struct TargetInfo {
   rj_code_target_id_t code_object_target;
 };
 
-// \NPI new GPU: add a {"gfxNNNN", ARCH, EF_MACH, TARGET} row here (and bump the \
-// std::array size) so the DBT tool can translate to/from it.
+// \NPI new GPU: add a {"gfxNNNN", ARCH, EF_MACH, TARGET} row here
+// (and bump the  std::array size) so the DBT tool can translate to/from it.
 constexpr std::array<TargetInfo, 4> kTargetInfos = {{
     {"gfx942", ROCJITSU_CODE_ARCH_CDNA3, EF_AMDGPU_MACH_AMDGCN_GFX942, ROCJITSU_CODE_TARGET_GFX942},
     {"gfx950", ROCJITSU_CODE_ARCH_CDNA4, EF_AMDGPU_MACH_AMDGCN_GFX950, ROCJITSU_CODE_TARGET_GFX950},

--- a/emulation/rocjitsu/tools/dbt_translate_main.cpp
+++ b/emulation/rocjitsu/tools/dbt_translate_main.cpp
@@ -38,6 +38,8 @@ struct TargetInfo {
   rj_code_target_id_t code_object_target;
 };
 
+// \NPI new GPU: add a {"gfxNNNN", ARCH, EF_MACH, TARGET} row here (and bump the \
+// std::array size) so the DBT tool can translate to/from it.
 constexpr std::array<TargetInfo, 4> kTargetInfos = {{
     {"gfx942", ROCJITSU_CODE_ARCH_CDNA3, EF_AMDGPU_MACH_AMDGCN_GFX942, ROCJITSU_CODE_TARGET_GFX942},
     {"gfx950", ROCJITSU_CODE_ARCH_CDNA4, EF_AMDGPU_MACH_AMDGCN_GFX950, ROCJITSU_CODE_TARGET_GFX950},

--- a/emulation/rocjitsu/tools/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/tools/rocjitsu/CMakeLists.txt
@@ -27,6 +27,7 @@ target_link_libraries(
         rocjitsu_isa_rdna3_5
         rocjitsu_isa_rdna4
         rocjitsu_isa_gfx1250
+        # \NPI new ISA family: link its rocjitsu_isa_<isa> object library here.
         rocjitsu_isa_risc_v
         simdojo
         rocjitsu_vm


### PR DESCRIPTION
## Motivation

to documenet what needs to happen for npi introduction

## Technical Details

```c
/// \NPI a simple task
```

```c
/// \NPI I am a big complicated todo \
/// that takes multiple lines to describe.
```

added such markers everwhere

created `scripts/find-npi-tasks.sh` that finds tasks.

## JIRA ID

Resolves #8267

## Test Plan

- 

## Test Result

- script works

```bash
emulation/mirage/builtin/src/agents.rs:25: new GPU: add a builtin agent mirroring its configs/<gpu>.json here.
emulation/rocjitsu/CMakeLists.txt:282: new ISA family: link its rocjitsu_isa_<isa> object library here.
emulation/rocjitsu/README.md:31: new GPU: add a row to the supported-architectures table above.
emulation/rocjitsu/docs/codegen.md:73: new ISA family: add a `<isa>:$MRISA/amdgpu_isa_<isa>.xml` entry to each `--multi` invocation in the commands below.
emulation/rocjitsu/lib/python/amdisa/isa_profile.py:22: new ISA family: (1) sync shared/machine-readable-isa via download.py and add amdgpu_isa_<isa>.xml, (2) add its profile in this module, (3) regenerate per docs/codegen.md, (4) author the hand-written isa.h / insts.h / mma_exec.h / addr_calc.* under lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/<isa>/.
emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/code/rj_code.h:48: a GPU that introduces a new ISA family needs a new arch id here; give it the next value and keep NUM_ARCHS / INVALID last.
emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/code/rj_code.h:115: every new GPU needs a target id here (one per distinct gfxNNNN variant); keep INVALID last.
emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_code_object.cpp:50: new GPU: map its MACH value and its gfxNNNN triple to a target id in both target_from_machine_flags() and target_from_triple() below.
emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/amdgpu_elf.h:67: new GPU: add its EF_AMDGPU_MACH_AMDGCN_* constant above (value from the LLVM AMDGPU backend), then handle it in elf_mach_for_arch, arch_for_elf_mach, and elf_mach_name below.
emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/rj_code.cpp:14: new GPU: add its target -> Decoder mapping in create_decoder_for_target() and its target -> arch mapping in arch_for_target() below.
emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.cpp:780: new ISA family: add its "arch" string here and in arch_to_string().
emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/CMakeLists.txt:30: new ISA family: link its rocjitsu_isa_<isa> object library here.
emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/CMakeLists.txt:21: new ISA family: create arch/amdgpu/<isa>/CMakeLists.txt (rj_add_object_library(rocjitsu_isa_<isa> ...)) and add_subdirectory() it here.
emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/decoder.cpp:37: new ISA family: #include its arch/amdgpu/<isa>/isa.h above and add a case returning std::make_unique<IsaDecoder<<isa>::Isa>>() here.
emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp:151: new ISA family: classify the new arch for CP-visible behavior here (RDNA-style encodings return false; CDNA-style fall through to the default).
emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp:77: new ISA family: add ROCJITSU_CU_CASE(ROCJITSU_CODE_ARCH_<NAME>, <isa>::Isa);
emulation/rocjitsu/schemas/simulation_config.fbs:55: new GPU: add a configs/<gpu>.json (plus the _kmd and any multi-GPU variant) that fills in these identity fields for the new device.
emulation/rocjitsu/tests/CMakeLists.txt:25: new ISA family: link its rocjitsu_isa_<isa> object library here, and wire any new *_sim_test.cpp and kernels/ coverage into this file.
emulation/rocjitsu/tests/code/code_object_target_id_test.cpp:17: new GPU: extend these tests with its MACH/triple -> target mapping.
emulation/rocjitsu/tests/config_test.cpp:35: new GPU: add a config-load test for its configs/<gpu>.json here.
emulation/rocjitsu/tests/shared_infra_test.cpp:89: new ISA family: add GpuIsa<<isa>::Isa> plus the relevant trait static_asserts (HasAccVgpr, HasMonolithicWaitcnt, ...) for it here.
emulation/rocjitsu/tools/CMakeLists.txt:20: new ISA family: link its rocjitsu_isa_<isa> object library here.
emulation/rocjitsu/tools/dbt_translate_main.cpp:41: new GPU: add a {"gfxNNNN", ARCH, EF_MACH, TARGET} row here
emulation/rocjitsu/tools/rocjitsu/CMakeLists.txt:30: new ISA family: link its rocjitsu_isa_<isa> object library here.
```


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
