### PR TITLE
[ATT] Improved buffer management: per-agent shared trace buffers

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/aql_packet.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/aql_packet.cpp
@@ -168,7 +168,9 @@ TraceMemoryPool::Alloc(void** ptr, size_t size, desc_t flags, void* data)
     }
 
     // Device (SQTT output) buffer: the shared manager is the single source, handing out
-    // one buffer per ring slot (output_buffer_index), reused across contexts.
+    // one buffer per ring slot (output_buffer_index), reused across contexts. Marker and
+    // control packets allocate only host memory (above), so this device path is used
+    // solely for SQTT output slots and never aliases them with other allocations.
     const size_t index  = pool.output_buffer_index++;
     void*        shared = thread_trace::acquire_shared_buffer(pool, index, size);
     if(shared == nullptr) return HSA_STATUS_ERROR;
@@ -180,6 +182,8 @@ TraceMemoryPool::Alloc(void** ptr, size_t size, desc_t flags, void* data)
 void
 TraceMemoryPool::Free(void* ptr, void* data)
 {
+    if(ptr == nullptr) return;
+
     // Shared device buffers are owned by the manager (freed once in free_shared_buffers());
     // skip them here to avoid a double free. Only per-call host buffers are freed.
     if(thread_trace::is_shared_buffer(ptr)) return;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/aql_packet.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/aql_packet.cpp
@@ -157,43 +157,31 @@ TraceMemoryPool::Alloc(void** ptr, size_t size, desc_t flags, void* data)
 
     if(!pool.allocate_fn || !pool.free_fn || !pool.allow_access_fn) return HSA_STATUS_ERROR;
 
-    hsa_status_t status = HSA_STATUS_ERROR;
     if(flags.host_access)
     {
-        status = pool.allocate_fn(pool.cpu_pool_, size, hsa_amd_memory_pool_executable_flag, ptr);
+        auto status =
+            pool.allocate_fn(pool.cpu_pool_, size, hsa_amd_memory_pool_executable_flag, ptr);
 
         if(status == HSA_STATUS_SUCCESS)
             status = pool.allow_access_fn(1, &pool.gpu_agent, nullptr, *ptr);
+        return status;
     }
-    else
-    {
-        // Device (SQTT output) buffer: reuse the per-agent shared buffer across
-        // contexts (one per ring slot via output_buffer_index), falling back to
-        // a private allocation if unavailable.
-        if(thread_trace::has_shared_buffer(pool.gpu_agent))
-        {
-            const size_t index  = pool.output_buffer_index++;
-            void*        shared = thread_trace::acquire_shared_buffer(pool, index);
-            if(shared != nullptr)
-            {
-                *ptr = shared;
-                return HSA_STATUS_SUCCESS;
-            }
-        }
 
-        // Return page aligned data to avoid cache flush overlap
-        status = pool.allocate_fn(
-            pool.gpu_pool_, size + 0x2000, hsa_amd_memory_pool_executable_flag, ptr);
-        *ptr = (void*) ((uintptr_t(*ptr) + 0xFFF) & ~0xFFFul);  // NOLINT(performance-no-int-to-ptr)
-    }
-    return status;
+    // Device (SQTT output) buffer: the shared manager is the single source, handing out
+    // one buffer per ring slot (output_buffer_index), reused across contexts.
+    const size_t index  = pool.output_buffer_index++;
+    void*        shared = thread_trace::acquire_shared_buffer(pool, index, size);
+    if(shared == nullptr) return HSA_STATUS_ERROR;
+
+    *ptr = shared;
+    return HSA_STATUS_SUCCESS;
 }
 
 void
 TraceMemoryPool::Free(void* ptr, void* data)
 {
-    // Shared buffers are owned by the manager and freed once at finalize(); skip
-    // them here to avoid a double-free across the contexts that reuse them.
+    // Shared device buffers are owned by the manager (freed once in free_shared_buffers());
+    // skip them here to avoid a double free. Only per-call host buffers are freed.
     if(thread_trace::is_shared_buffer(ptr)) return;
 
     assert(data);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/aql_packet.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/aql_packet.cpp
@@ -26,6 +26,7 @@
 #include "lib/rocprofiler-sdk/spm/decode.hpp"
 #include "lib/rocprofiler-sdk/spm/interface.hpp"
 #include "lib/rocprofiler-sdk/thread_trace/dl.hpp"
+#include "lib/rocprofiler-sdk/thread_trace/shared_trace_buffer.hpp"
 
 #include <fmt/core.h>
 #include <cstddef>
@@ -166,6 +167,20 @@ TraceMemoryPool::Alloc(void** ptr, size_t size, desc_t flags, void* data)
     }
     else
     {
+        // Device (SQTT output) buffer: reuse the per-agent shared buffer across
+        // contexts (one per ring slot via output_buffer_index), falling back to
+        // a private allocation if unavailable.
+        if(thread_trace::has_shared_buffer(pool.gpu_agent))
+        {
+            const size_t index  = pool.output_buffer_index++;
+            void*        shared = thread_trace::acquire_shared_buffer(pool, index);
+            if(shared != nullptr)
+            {
+                *ptr = shared;
+                return HSA_STATUS_SUCCESS;
+            }
+        }
+
         // Return page aligned data to avoid cache flush overlap
         status = pool.allocate_fn(
             pool.gpu_pool_, size + 0x2000, hsa_amd_memory_pool_executable_flag, ptr);
@@ -177,6 +192,10 @@ TraceMemoryPool::Alloc(void** ptr, size_t size, desc_t flags, void* data)
 void
 TraceMemoryPool::Free(void* ptr, void* data)
 {
+    // Shared buffers are owned by the manager and freed once at finalize(); skip
+    // them here to avoid a double-free across the contexts that reuse them.
+    if(thread_trace::is_shared_buffer(ptr)) return;
+
     assert(data);
     auto& pool = *reinterpret_cast<TraceMemoryPool*>(data);
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/aql_packet.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/aql_packet.hpp
@@ -193,7 +193,9 @@ struct TraceMemoryPool
     aqlprofile_handle_t handle;
 
     // Ring-slot counter: each device Alloc hands out the next shared buffer slot
-    // (0 = primary, 1.. = double/triple-buffer slots).
+    // (0 = primary, 1.. = double/triple-buffer slots). Each context's control packet gets
+    // its own value copy of TraceMemoryPool, so this restarts at 0 for every context --
+    // that is what maps every context's slot i onto the same shared per-agent buffer.
     uint32_t output_buffer_index = 0;
 
     ~TraceMemoryPool() { aqlprofile_att_delete_packets(this->handle); };

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/aql_packet.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/aql_packet.hpp
@@ -192,8 +192,9 @@ struct TraceMemoryPool
 
     aqlprofile_handle_t handle;
 
-    // Ring-slot counter so shared buffers are handed out one per output buffer.
-    mutable uint32_t output_buffer_index = 0;
+    // Ring-slot counter: each device Alloc hands out the next shared buffer slot
+    // (0 = primary, 1.. = double/triple-buffer slots).
+    uint32_t output_buffer_index = 0;
 
     ~TraceMemoryPool() { aqlprofile_att_delete_packets(this->handle); };
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/aql_packet.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/aql_packet.hpp
@@ -35,6 +35,7 @@
 
 #include <atomic>
 #include <cstddef>
+#include <cstdint>
 #include <optional>
 
 namespace rocprofiler
@@ -190,6 +191,10 @@ struct TraceMemoryPool
     decltype(hsa_memory_copy)*              api_copy_fn;
 
     aqlprofile_handle_t handle;
+
+    // Ring-slot counter so shared buffers are handed out one per output buffer.
+    mutable uint32_t output_buffer_index = 0;
+
     ~TraceMemoryPool() { aqlprofile_att_delete_packets(this->handle); };
 
     static hsa_status_t Alloc(void** ptr, size_t size, desc_t flags, void* data);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/CMakeLists.txt
@@ -1,9 +1,16 @@
 set(ROCPROFILER_LIB_THREAD_TRACE_SOURCES
-    core.cpp service.cpp code_object.cpp decode.cpp dl.cpp threading.cpp hsa_util.cpp
-    shared_trace_buffer.cpp)
+    core.cpp
+    service.cpp
+    code_object.cpp
+    decode.cpp
+    dl.cpp
+    threading.cpp
+    hsa_util.cpp
+    shared_trace_buffer.cpp
+    shared_trace_lease.cpp)
 set(ROCPROFILER_LIB_THREAD_TRACE_HEADERS
     core.hpp code_object.hpp dl.hpp threading.hpp hsa_util.hpp trace_decoder_api.h
-    shared_trace_buffer.hpp)
+    shared_trace_buffer.hpp shared_trace_lease.hpp)
 target_sources(
     rocprofiler-sdk-object-library PRIVATE ${ROCPROFILER_LIB_THREAD_TRACE_SOURCES}
                                            ${ROCPROFILER_LIB_THREAD_TRACE_HEADERS})

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/CMakeLists.txt
@@ -1,7 +1,9 @@
-set(ROCPROFILER_LIB_THREAD_TRACE_SOURCES core.cpp service.cpp code_object.cpp decode.cpp
-                                         dl.cpp threading.cpp hsa_util.cpp)
-set(ROCPROFILER_LIB_THREAD_TRACE_HEADERS core.hpp code_object.hpp dl.hpp threading.hpp
-                                         hsa_util.hpp trace_decoder_api.h)
+set(ROCPROFILER_LIB_THREAD_TRACE_SOURCES
+    core.cpp service.cpp code_object.cpp decode.cpp dl.cpp threading.cpp hsa_util.cpp
+    shared_trace_buffer.cpp)
+set(ROCPROFILER_LIB_THREAD_TRACE_HEADERS
+    core.hpp code_object.hpp dl.hpp threading.hpp hsa_util.hpp trace_decoder_api.h
+    shared_trace_buffer.hpp)
 target_sources(
     rocprofiler-sdk-object-library PRIVATE ${ROCPROFILER_LIB_THREAD_TRACE_SOURCES}
                                            ${ROCPROFILER_LIB_THREAD_TRACE_HEADERS})

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
@@ -24,6 +24,7 @@
 // iteration, and integration with the public API surface.
 #include "lib/rocprofiler-sdk/thread_trace/core.hpp"
 #include "lib/rocprofiler-sdk/thread_trace/shared_trace_buffer.hpp"
+#include "lib/rocprofiler-sdk/thread_trace/shared_trace_lease.hpp"
 #include "lib/rocprofiler-sdk/thread_trace/threading.hpp"
 
 #include "lib/common/container/stable_vector.hpp"
@@ -145,6 +146,8 @@ ThreadTracerAgent::ThreadTracerAgent(thread_trace_parameter_pack _params,
     const auto* agent =
         CHECK_NOTNULL(rocprofiler::agent::get_agent_cache(rocprofiler::agent::get_agent(agent_id)));
 
+    hw_agent = agent->get_hsa_agent();
+
     size_t staging_size = (params.num_buffers > 1) ? params.buffer_size : 0ul;
     size_t staging_n    = (params.num_buffers > 1) ? params.num_buffers : 0ul;
     queue               = make_att_queue(*agent, staging_size, staging_n);
@@ -174,6 +177,11 @@ ThreadTracerAgent::~ThreadTracerAgent()
 
     if(auto flag = worker_flag) flag->store(WORKER_FLAG_DESTRUCTOR);
     stop_thread_trace();
+
+    // Safety net for the abnormal destroy-while-active path: a single-buffer trace's
+    // lease is normally released in iterate_data, which will not run now. No-op if this
+    // tracer no longer holds the lease.
+    release_agent_lease(hw_agent, this);
 }
 
 /**
@@ -183,12 +191,34 @@ ThreadTracerAgent::~ThreadTracerAgent()
 std::unique_ptr<hsa::TraceControlAQLPacket>
 ThreadTracerAgent::get_control(bool bStart)
 {
+    // Clone the control packet first so callers can safely mutate state without racing
+    // with concurrent dispatches, and so a throwing clone leaves active_traces and the
+    // per-agent lease untouched (exception safety).
     auto active_resources = std::make_unique<hsa::TraceControlAQLPacket>(*control_packet);
-    // Clone the control packet so callers can safely mutate state without
-    // racing with concurrent dispatches.
     active_resources->clear();
 
-    if(bStart) active_traces.fetch_add(1);
+    if(bStart)
+    {
+        // The first active trace on this agent takes the per-agent lease so no other
+        // context can touch the shared buffer/queue while we trace; it is re-entrant
+        // for this tracer's own overlapping traces. Fail-fast (skip this trace) if
+        // another context already holds the agent rather than corrupting the shared
+        // buffer. Callers treat a null return as "do not trace".
+        if(active_traces.fetch_add(1) == 0 && !try_acquire_agent_lease(hw_agent, this))
+        {
+            active_traces.fetch_sub(1);
+            // get_control runs on the per-kernel dispatch path; log once per tracer so a
+            // context that keeps losing the lease doesn't flood the log every dispatch.
+            if(!lease_contention_logged)
+            {
+                lease_contention_logged = true;
+                ROCP_WARNING << "Agent " << agent_id.handle
+                             << " is already being traced by another context; skipping"
+                                " its traces until the agent is free";
+            }
+            return nullptr;
+        }
+    }
 
     return active_resources;
 }
@@ -219,7 +249,9 @@ ThreadTracerAgent::iterate_data(aqlprofile_handle_t handle, rocprofiler_user_dat
     else if(status != HSA_STATUS_SUCCESS)
         ROCP_CI_LOG(ERROR) << "Failed to iterate ATT data: " << status;
 
-    active_traces.fetch_sub(1);
+    // Last in-flight trace on this agent: release the per-agent lease so another
+    // context may use the shared buffer/queue.
+    if(active_traces.fetch_sub(1) == 1) release_agent_lease(hw_agent, this);
 }
 
 void
@@ -271,6 +303,12 @@ ThreadTracerAgent::start_thread_trace(std::shared_ptr<std::atomic<int>> _flag)
     worker_flag = std::move(_flag);
 
     auto control_packet_copy = get_control(true);
+    if(!control_packet_copy)
+    {
+        // Another context holds this agent's trace lease; skip starting on this agent.
+        // DeviceThreadTracer::start_context tolerates a null signal.
+        return nullptr;
+    }
     control_packet_copy->clear();
     control_packet_copy->populate_before();
     control_packet_copy->populate_after();
@@ -365,7 +403,7 @@ ThreadTracerAgent::stop_thread_trace()
         for(auto& t : consumers)
             if(t.joinable()) t.join();
         consumers.clear();
-        active_traces.fetch_sub(1);
+        if(active_traces.fetch_sub(1) == 1) release_agent_lease(hw_agent, this);
         worker_flag = nullptr;
         return nullptr;
     }
@@ -469,6 +507,12 @@ DispatchThreadTracer::pre_kernel_call(const hsa::Queue&              queue,
         return {nullptr, parameters.bSerialize};
 
     auto packet = agent.get_start_packet();
+    if(!packet)
+    {
+        // Agent's trace lease is held by another context; run the kernel untraced
+        // rather than sharing (and corrupting) the agent's buffer.
+        return {nullptr, parameters.bSerialize};
+    }
     post_move_data.fetch_add(1);
     packet->populate_before();
     packet->populate_after();
@@ -633,8 +677,10 @@ DeviceThreadTracer::start_context()
     for(auto& [_, tracer] : agents)
         wait_list.emplace_back(tracer->start_thread_trace(worker_flag));
 
+    // A null signal means the agent was skipped (its lease is held by another
+    // context); only wait on agents that actually started a trace.
     for(auto& sig : wait_list)
-        signal_wait(*CHECK_NOTNULL(sig));
+        if(sig) signal_wait(*sig);
 }
 
 void
@@ -719,8 +765,10 @@ finalize()
         if(ctx->dispatch_thread_trace) ctx->dispatch_thread_trace->resource_deinit();
     }
 
-    // ThreadTracerAgents and their packets are gone; release the shared buffers.
+    // ThreadTracerAgents and their packets are gone; release the shared buffers and
+    // per-agent leases (all safe to destroy now that no agent can submit).
     free_shared_buffers();
+    free_agent_leases();
 
     code_object::finalize();
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
@@ -23,6 +23,7 @@
 // Implements the core coordination logic for thread trace start/stop, buffer
 // iteration, and integration with the public API surface.
 #include "lib/rocprofiler-sdk/thread_trace/core.hpp"
+#include "lib/rocprofiler-sdk/thread_trace/shared_trace_buffer.hpp"
 #include "lib/rocprofiler-sdk/thread_trace/threading.hpp"
 
 #include "lib/common/container/stable_vector.hpp"
@@ -416,6 +417,17 @@ DispatchThreadTracer::resource_deinit()
     agents.clear();
 }
 
+void
+DispatchThreadTracer::register_shared_buffer_sizes()
+{
+    auto lk = std::unique_lock{agents_map_mut};
+    for(const auto& [agent_id, pack] : params)
+    {
+        auto hsa_agent = rocprofiler::agent::get_hsa_agent(agent_id);
+        if(hsa_agent.has_value()) register_shared_buffer_size(*hsa_agent, pack.buffer_size);
+    }
+}
+
 /**
  * Callback we get from HSA interceptor when a kernel packet is being enqueued.
  * We return an AQLPacket containing the start/stop/read packets for injection.
@@ -580,6 +592,17 @@ DeviceThreadTracer::resource_deinit()
 }
 
 void
+DeviceThreadTracer::register_shared_buffer_sizes()
+{
+    std::unique_lock<std::mutex> lk(agent_mut);
+    for(const auto& [agent_id, pack] : params)
+    {
+        auto hsa_agent = rocprofiler::agent::get_hsa_agent(agent_id);
+        if(hsa_agent.has_value()) register_shared_buffer_size(*hsa_agent, pack.buffer_size);
+    }
+}
+
+void
 DeviceThreadTracer::start_context()
 {
     // Per-agent resources don't exist until HSA is registered; the request is
@@ -645,6 +668,14 @@ initialize(HsaApiTable* table)
 {
     ROCP_FATAL_IF(!table->core_ || !table->amd_ext_);
 
+    // Register every context's buffer sizes before resource_init builds buffers,
+    // so the shared per-agent buffers are sized to the max requested size.
+    for(auto& ctx : context::get_registered_contexts())
+    {
+        if(ctx->device_thread_trace) ctx->device_thread_trace->register_shared_buffer_sizes();
+        if(ctx->dispatch_thread_trace) ctx->dispatch_thread_trace->register_shared_buffer_sizes();
+    }
+
     for(auto& ctx : context::get_registered_contexts())
     {
         if(ctx->device_thread_trace) ctx->device_thread_trace->resource_init();
@@ -687,6 +718,9 @@ finalize()
         if(ctx->device_thread_trace) ctx->device_thread_trace->resource_deinit();
         if(ctx->dispatch_thread_trace) ctx->dispatch_thread_trace->resource_deinit();
     }
+
+    // ThreadTracerAgents and their packets are gone; release the shared buffers.
+    free_shared_buffers();
 
     code_object::finalize();
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.hpp
@@ -157,6 +157,9 @@ public:
     void resource_init();
     void resource_deinit();
 
+    /// Report this context's per-agent buffer sizes to the shared buffer manager.
+    void register_shared_buffer_sizes();
+
     void add_agent(rocprofiler_agent_id_t agent, thread_trace_parameter_pack pack)
     {
         auto lk       = std::unique_lock{agents_map_mut};
@@ -193,6 +196,9 @@ public:
     void stop_context();
     void resource_init();
     void resource_deinit();
+
+    /// Report this context's per-agent buffer sizes to the shared buffer manager.
+    void register_shared_buffer_sizes();
 
     void add_agent(rocprofiler_agent_id_t id, thread_trace_parameter_pack _params)
     {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.hpp
@@ -130,8 +130,16 @@ private:
 
     att_queue_ptr_t queue{};
 
+    // Hardware agent this tracer drives; keys the per-agent trace lease so no two
+    // contexts use the same agent's shared buffer/queue concurrently.
+    hsa_agent_t hw_agent{};
+
     std::atomic<int> active_traces{0};
     std::mutex       trace_resources_mut{};
+
+    // Log lease contention (this agent already traced by another context) only once per
+    // tracer instead of on every skipped dispatch. Guarded by trace_resources_mut.
+    bool lease_contention_logged{false};
 
     std::unique_ptr<hsa::TraceControlAQLPacket>           control_packet{nullptr};
     std::unique_ptr<code_object::CodeobjCallbackRegistry> codeobj_reg{nullptr};

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/shared_trace_buffer.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/shared_trace_buffer.cpp
@@ -23,6 +23,7 @@
 #include "lib/rocprofiler-sdk/thread_trace/shared_trace_buffer.hpp"
 
 #include "lib/common/logging.hpp"
+#include "lib/common/static_object.hpp"
 #include "lib/common/synchronized.hpp"
 #include "lib/rocprofiler-sdk/hsa/aql_packet.hpp"
 
@@ -66,9 +67,11 @@ struct shared_state_t
     decltype(hsa_amd_memory_pool_free)* free_fn     = nullptr;  // captured for shutdown free
 };
 
-// Namespace-scope so it outlives finalize() (see shared_trace_lease.cpp for the full
-// rationale). Freed once via free_shared_buffers().
-common::Synchronized<shared_state_t> g_buffer_state{};
+// Held in a static_object (see shared_trace_lease.cpp for the rationale) so it stays alive
+// through registration::finalize() on the attach path, without leaking. free_shared_buffers()
+// frees the contents.
+common::Synchronized<shared_state_t>& g_buffer_state =
+    *common::static_object<common::Synchronized<shared_state_t>>::construct();
 }  // namespace
 
 void

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/shared_trace_buffer.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/shared_trace_buffer.cpp
@@ -23,6 +23,8 @@
 #include "lib/rocprofiler-sdk/thread_trace/shared_trace_buffer.hpp"
 
 #include "lib/common/logging.hpp"
+#include "lib/common/static_object.hpp"
+#include "lib/common/synchronized.hpp"
 #include "lib/rocprofiler-sdk/hsa/aql_packet.hpp"
 
 #include <hsa/hsa_ext_amd.h>
@@ -30,7 +32,6 @@
 #include <algorithm>
 #include <cstdint>
 #include <map>
-#include <mutex>
 #include <unordered_set>
 #include <vector>
 
@@ -40,14 +41,15 @@ namespace thread_trace
 {
 namespace
 {
-// Padding + mask to page-align the returned pointer, matching TraceMemoryPool::Alloc.
+// Padding + mask to page-align the returned pointer.
 constexpr size_t PAGE_ALIGN_PADDING = 0x2000;
 constexpr size_t PAGE_ALIGN_MASK    = 0xFFFul;
 
 struct shared_buffer_t
 {
-    void* raw     = nullptr;  // as returned by the allocator (used to free)
-    void* aligned = nullptr;  // page-aligned pointer handed out
+    void*    raw     = nullptr;  // as returned by the allocator (used to free)
+    void*    aligned = nullptr;  // page-aligned pointer handed out
+    uint64_t size    = 0;        // allocated size, so reuse can verify it fits
 };
 
 struct agent_buffers_t
@@ -63,99 +65,88 @@ struct shared_state_t
     decltype(hsa_amd_memory_pool_free)* free_fn     = nullptr;  // captured for shutdown free
 };
 
-std::mutex&
-get_mutex()
-{
-    static auto* _mutex = new std::mutex{};
-    return *_mutex;
-}
+using locked_state_t = common::Synchronized<shared_state_t>;
 
-shared_state_t&
+locked_state_t&
 get_state()
 {
-    static auto* _state = new shared_state_t{};
-    return *_state;
+    static auto*& _state = common::static_object<locked_state_t>::construct();
+    return *CHECK_NOTNULL(_state);
 }
 }  // namespace
 
 void
 register_shared_buffer_size(hsa_agent_t agent, uint64_t buffer_size)
 {
-    auto  lock            = std::unique_lock{get_mutex()};
-    auto& entry           = get_state().agents[agent.handle];
-    entry.max_buffer_size = std::max(entry.max_buffer_size, buffer_size);
-}
-
-bool
-has_shared_buffer(hsa_agent_t agent)
-{
-    auto lock = std::unique_lock{get_mutex()};
-    return get_state().agents.find(agent.handle) != get_state().agents.end();
+    get_state().wlock([&](shared_state_t& state) {
+        auto& entry           = state.agents[agent.handle];
+        entry.max_buffer_size = std::max(entry.max_buffer_size, buffer_size);
+    });
 }
 
 void*
-acquire_shared_buffer(const hsa::TraceMemoryPool& pool, size_t index)
+acquire_shared_buffer(const hsa::TraceMemoryPool& pool, size_t index, uint64_t size)
 {
-    auto  lock  = std::unique_lock{get_mutex()};
-    auto& state = get_state();
+    return get_state().wlock([&](shared_state_t& state) -> void* {
+        // Self-register in case the pre-pass didn't: acquire is the single buffer source.
+        auto& entry           = state.agents[pool.gpu_agent.handle];
+        entry.max_buffer_size = std::max(entry.max_buffer_size, size);
 
-    auto it = state.agents.find(pool.gpu_agent.handle);
-    if(it == state.agents.end()) return nullptr;
+        if(entry.buffers.size() <= index) entry.buffers.resize(index + 1);
 
-    auto& entry = it->second;
-    if(entry.buffers.size() <= index) entry.buffers.resize(index + 1);
+        // Reuse the slot's buffer; the pre-pass sizes it to the agent max up front.
+        auto& buf = entry.buffers.at(index);
+        if(buf.aligned != nullptr && buf.size >= size) return buf.aligned;
 
-    auto& buf = entry.buffers.at(index);
-    if(buf.aligned != nullptr) return buf.aligned;
+        if(!pool.allocate_fn) return nullptr;
 
-    if(!pool.allocate_fn) return nullptr;
+        void* raw    = nullptr;
+        auto  status = pool.allocate_fn(pool.gpu_pool_,
+                                       entry.max_buffer_size + PAGE_ALIGN_PADDING,
+                                       hsa::hsa_amd_memory_pool_executable_flag,
+                                       &raw);
+        if(status != HSA_STATUS_SUCCESS || raw == nullptr)
+        {
+            ROCP_ERROR << "Failed to allocate shared thread trace buffer: " << status;
+            return nullptr;
+        }
 
-    void* raw    = nullptr;
-    auto  status = pool.allocate_fn(pool.gpu_pool_,
-                                   entry.max_buffer_size + PAGE_ALIGN_PADDING,
-                                   hsa::hsa_amd_memory_pool_executable_flag,
-                                   &raw);
-    if(status != HSA_STATUS_SUCCESS || raw == nullptr)
-    {
-        ROCP_ERROR << "Failed to allocate shared thread trace buffer: " << status;
-        return nullptr;
-    }
+        // Page-align to avoid cache flush overlap.
+        void* aligned = reinterpret_cast<void*>(  // NOLINT(performance-no-int-to-ptr)
+            (reinterpret_cast<uintptr_t>(raw) + PAGE_ALIGN_MASK) & ~PAGE_ALIGN_MASK);
 
-    // Page-align to avoid cache flush overlap, matching the non-shared path.
-    void* aligned = reinterpret_cast<void*>(  // NOLINT(performance-no-int-to-ptr)
-        (reinterpret_cast<uintptr_t>(raw) + PAGE_ALIGN_MASK) & ~PAGE_ALIGN_MASK);
-
-    buf.raw       = raw;
-    buf.aligned   = aligned;
-    state.free_fn = pool.free_fn;
-    state.shared_ptrs.insert(aligned);
-    return aligned;
+        buf.raw       = raw;
+        buf.aligned   = aligned;
+        buf.size      = entry.max_buffer_size;
+        state.free_fn = pool.free_fn;
+        state.shared_ptrs.insert(aligned);
+        return aligned;
+    });
 }
 
 bool
 is_shared_buffer(void* ptr)
 {
     if(ptr == nullptr) return false;
-    auto lock = std::unique_lock{get_mutex()};
-    return get_state().shared_ptrs.count(ptr) != 0;
+    return get_state().rlock(
+        [&](const shared_state_t& state) { return state.shared_ptrs.count(ptr) != 0; });
 }
 
 void
 free_shared_buffers()
 {
-    auto  lock  = std::unique_lock{get_mutex()};
-    auto& state = get_state();
+    get_state().wlock([](shared_state_t& state) {
+        if(state.free_fn != nullptr)
+        {
+            for(auto& [_, entry] : state.agents)
+                for(auto& buf : entry.buffers)
+                    if(buf.raw != nullptr) state.free_fn(buf.raw);
+        }
 
-    if(state.free_fn != nullptr)
-    {
-        for(auto& [_, entry] : state.agents)
-            for(auto& buf : entry.buffers)
-                if(buf.raw != nullptr) state.free_fn(buf.raw);
-    }
-
-    state.agents.clear();
-    state.shared_ptrs.clear();
-    state.free_fn = nullptr;
+        state.agents.clear();
+        state.shared_ptrs.clear();
+        state.free_fn = nullptr;
+    });
 }
 
 }  // namespace thread_trace

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/shared_trace_buffer.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/shared_trace_buffer.cpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -23,7 +23,6 @@
 #include "lib/rocprofiler-sdk/thread_trace/shared_trace_buffer.hpp"
 
 #include "lib/common/logging.hpp"
-#include "lib/common/static_object.hpp"
 #include "lib/common/synchronized.hpp"
 #include "lib/rocprofiler-sdk/hsa/aql_packet.hpp"
 
@@ -41,9 +40,11 @@ namespace thread_trace
 {
 namespace
 {
-// Padding + mask to page-align the returned pointer.
-constexpr size_t PAGE_ALIGN_PADDING = 0x2000;
-constexpr size_t PAGE_ALIGN_MASK    = 0xFFFul;
+// Over-allocate, then round the returned pointer up to a 4K page. The round-up consumes
+// up to one page of the padding; the second padding page is a tail guard so cache-flush
+// operations at the end of the buffer cannot spill into the next allocation.
+constexpr size_t PAGE_ALIGN_PADDING = 0x2000;   // 2 pages: align slack + tail guard
+constexpr size_t PAGE_ALIGN_MASK    = 0xFFFul;  // align to a 4K page
 
 struct shared_buffer_t
 {
@@ -65,20 +66,15 @@ struct shared_state_t
     decltype(hsa_amd_memory_pool_free)* free_fn     = nullptr;  // captured for shutdown free
 };
 
-using locked_state_t = common::Synchronized<shared_state_t>;
-
-locked_state_t&
-get_state()
-{
-    static auto*& _state = common::static_object<locked_state_t>::construct();
-    return *CHECK_NOTNULL(_state);
-}
+// Namespace-scope so it outlives finalize() (see shared_trace_lease.cpp for the full
+// rationale). Freed once via free_shared_buffers().
+common::Synchronized<shared_state_t> g_buffer_state{};
 }  // namespace
 
 void
 register_shared_buffer_size(hsa_agent_t agent, uint64_t buffer_size)
 {
-    get_state().wlock([&](shared_state_t& state) {
+    g_buffer_state.wlock([&](shared_state_t& state) {
         auto& entry           = state.agents[agent.handle];
         entry.max_buffer_size = std::max(entry.max_buffer_size, buffer_size);
     });
@@ -87,7 +83,7 @@ register_shared_buffer_size(hsa_agent_t agent, uint64_t buffer_size)
 void*
 acquire_shared_buffer(const hsa::TraceMemoryPool& pool, size_t index, uint64_t size)
 {
-    return get_state().wlock([&](shared_state_t& state) -> void* {
+    return g_buffer_state.wlock([&](shared_state_t& state) -> void* {
         // Self-register in case the pre-pass didn't: acquire is the single buffer source.
         auto& entry           = state.agents[pool.gpu_agent.handle];
         entry.max_buffer_size = std::max(entry.max_buffer_size, size);
@@ -97,6 +93,17 @@ acquire_shared_buffer(const hsa::TraceMemoryPool& pool, size_t index, uint64_t s
         // Reuse the slot's buffer; the pre-pass sizes it to the agent max up front.
         auto& buf = entry.buffers.at(index);
         if(buf.aligned != nullptr && buf.size >= size) return buf.aligned;
+
+        // Re-allocating an existing (too-small) slot: release the old buffer first so we
+        // neither leak it nor leave a stale aligned pointer registered as shared. In the
+        // normal flow the pre-pass fixes max_buffer_size before any acquire, so this only
+        // runs if a larger size ever arrives after a slot was first sized.
+        if(buf.raw != nullptr)
+        {
+            if(pool.free_fn) pool.free_fn(buf.raw);
+            state.shared_ptrs.erase(buf.aligned);
+            buf = shared_buffer_t{};
+        }
 
         if(!pool.allocate_fn) return nullptr;
 
@@ -128,14 +135,14 @@ bool
 is_shared_buffer(void* ptr)
 {
     if(ptr == nullptr) return false;
-    return get_state().rlock(
+    return g_buffer_state.rlock(
         [&](const shared_state_t& state) { return state.shared_ptrs.count(ptr) != 0; });
 }
 
 void
 free_shared_buffers()
 {
-    get_state().wlock([](shared_state_t& state) {
+    g_buffer_state.wlock([](shared_state_t& state) {
         if(state.free_fn != nullptr)
         {
             for(auto& [_, entry] : state.agents)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/shared_trace_buffer.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/shared_trace_buffer.cpp
@@ -1,0 +1,162 @@
+// MIT License
+//
+// Copyright (c) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "lib/rocprofiler-sdk/thread_trace/shared_trace_buffer.hpp"
+
+#include "lib/common/logging.hpp"
+#include "lib/rocprofiler-sdk/hsa/aql_packet.hpp"
+
+#include <hsa/hsa_ext_amd.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <map>
+#include <mutex>
+#include <unordered_set>
+#include <vector>
+
+namespace rocprofiler
+{
+namespace thread_trace
+{
+namespace
+{
+// Padding + mask to page-align the returned pointer, matching TraceMemoryPool::Alloc.
+constexpr size_t PAGE_ALIGN_PADDING = 0x2000;
+constexpr size_t PAGE_ALIGN_MASK    = 0xFFFul;
+
+struct shared_buffer_t
+{
+    void* raw     = nullptr;  // as returned by the allocator (used to free)
+    void* aligned = nullptr;  // page-aligned pointer handed out
+};
+
+struct agent_buffers_t
+{
+    uint64_t                     max_buffer_size = 0;
+    std::vector<shared_buffer_t> buffers         = {};
+};
+
+struct shared_state_t
+{
+    std::map<uint64_t, agent_buffers_t> agents      = {};       // keyed by hsa_agent_t.handle
+    std::unordered_set<void*>           shared_ptrs = {};       // aligned pointers handed out
+    decltype(hsa_amd_memory_pool_free)* free_fn     = nullptr;  // captured for shutdown free
+};
+
+std::mutex&
+get_mutex()
+{
+    static auto* _mutex = new std::mutex{};
+    return *_mutex;
+}
+
+shared_state_t&
+get_state()
+{
+    static auto* _state = new shared_state_t{};
+    return *_state;
+}
+}  // namespace
+
+void
+register_shared_buffer_size(hsa_agent_t agent, uint64_t buffer_size)
+{
+    auto  lock            = std::unique_lock{get_mutex()};
+    auto& entry           = get_state().agents[agent.handle];
+    entry.max_buffer_size = std::max(entry.max_buffer_size, buffer_size);
+}
+
+bool
+has_shared_buffer(hsa_agent_t agent)
+{
+    auto lock = std::unique_lock{get_mutex()};
+    return get_state().agents.find(agent.handle) != get_state().agents.end();
+}
+
+void*
+acquire_shared_buffer(const hsa::TraceMemoryPool& pool, size_t index)
+{
+    auto  lock  = std::unique_lock{get_mutex()};
+    auto& state = get_state();
+
+    auto it = state.agents.find(pool.gpu_agent.handle);
+    if(it == state.agents.end()) return nullptr;
+
+    auto& entry = it->second;
+    if(entry.buffers.size() <= index) entry.buffers.resize(index + 1);
+
+    auto& buf = entry.buffers.at(index);
+    if(buf.aligned != nullptr) return buf.aligned;
+
+    if(!pool.allocate_fn) return nullptr;
+
+    void* raw    = nullptr;
+    auto  status = pool.allocate_fn(pool.gpu_pool_,
+                                   entry.max_buffer_size + PAGE_ALIGN_PADDING,
+                                   hsa::hsa_amd_memory_pool_executable_flag,
+                                   &raw);
+    if(status != HSA_STATUS_SUCCESS || raw == nullptr)
+    {
+        ROCP_ERROR << "Failed to allocate shared thread trace buffer: " << status;
+        return nullptr;
+    }
+
+    // Page-align to avoid cache flush overlap, matching the non-shared path.
+    void* aligned = reinterpret_cast<void*>(  // NOLINT(performance-no-int-to-ptr)
+        (reinterpret_cast<uintptr_t>(raw) + PAGE_ALIGN_MASK) & ~PAGE_ALIGN_MASK);
+
+    buf.raw       = raw;
+    buf.aligned   = aligned;
+    state.free_fn = pool.free_fn;
+    state.shared_ptrs.insert(aligned);
+    return aligned;
+}
+
+bool
+is_shared_buffer(void* ptr)
+{
+    if(ptr == nullptr) return false;
+    auto lock = std::unique_lock{get_mutex()};
+    return get_state().shared_ptrs.count(ptr) != 0;
+}
+
+void
+free_shared_buffers()
+{
+    auto  lock  = std::unique_lock{get_mutex()};
+    auto& state = get_state();
+
+    if(state.free_fn != nullptr)
+    {
+        for(auto& [_, entry] : state.agents)
+            for(auto& buf : entry.buffers)
+                if(buf.raw != nullptr) state.free_fn(buf.raw);
+    }
+
+    state.agents.clear();
+    state.shared_ptrs.clear();
+    state.free_fn = nullptr;
+}
+
+}  // namespace thread_trace
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/shared_trace_buffer.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/shared_trace_buffer.hpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/shared_trace_buffer.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/shared_trace_buffer.hpp
@@ -36,26 +36,22 @@ struct TraceMemoryPool;
 
 namespace thread_trace
 {
-// Process-global manager of per-agent SQTT (thread trace) output buffers. Only
-// one trace can be active per agent at a time, so all contexts on an agent
-// share the same device buffer(s), sized to the largest requested buffer_size.
-// Triple buffering uses several ring slots, one buffer each.
+// Process-global manager of per-agent SQTT output buffers: one trace is active per
+// agent at a time, so all contexts on an agent share the same buffer(s), sized to the
+// largest requested buffer_size. Triple buffering uses one ring slot per buffer.
 
-/// Record the max buffer size for @p agent; call for every context before any
-/// buffer is built so the shared buffers fit all contexts.
+/// Record the max buffer size for @p agent; call for every context before the first
+/// acquire so the shared buffer fits all contexts.
 void
 register_shared_buffer_size(hsa_agent_t agent, uint64_t buffer_size);
 
-/// Whether a shared buffer (a registered max size) exists for @p agent.
-bool
-has_shared_buffer(hsa_agent_t agent);
-
-/// Return the @p index -th shared device buffer for @p pool's agent, allocating
-/// it (sized to the registered max) on first use. nullptr if unavailable.
+/// Return @p pool's agent's @p index -th shared buffer, allocating it (sized to the
+/// agent max, at least @p size) on first use and reusing it after. nullptr on failure.
 void*
-acquire_shared_buffer(const hsa::TraceMemoryPool& pool, size_t index);
+acquire_shared_buffer(const hsa::TraceMemoryPool& pool, size_t index, uint64_t size);
 
-/// Whether @p ptr is a shared buffer (callers skip the real free).
+/// Whether @p ptr is a manager-owned shared buffer; TraceMemoryPool::Free uses this to
+/// skip it (freed once in free_shared_buffers()).
 bool
 is_shared_buffer(void* ptr);
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/shared_trace_buffer.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/shared_trace_buffer.hpp
@@ -1,0 +1,67 @@
+// MIT License
+//
+// Copyright (c) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <hsa/hsa.h>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace rocprofiler
+{
+namespace hsa
+{
+struct TraceMemoryPool;
+}  // namespace hsa
+
+namespace thread_trace
+{
+// Process-global manager of per-agent SQTT (thread trace) output buffers. Only
+// one trace can be active per agent at a time, so all contexts on an agent
+// share the same device buffer(s), sized to the largest requested buffer_size.
+// Triple buffering uses several ring slots, one buffer each.
+
+/// Record the max buffer size for @p agent; call for every context before any
+/// buffer is built so the shared buffers fit all contexts.
+void
+register_shared_buffer_size(hsa_agent_t agent, uint64_t buffer_size);
+
+/// Whether a shared buffer (a registered max size) exists for @p agent.
+bool
+has_shared_buffer(hsa_agent_t agent);
+
+/// Return the @p index -th shared device buffer for @p pool's agent, allocating
+/// it (sized to the registered max) on first use. nullptr if unavailable.
+void*
+acquire_shared_buffer(const hsa::TraceMemoryPool& pool, size_t index);
+
+/// Whether @p ptr is a shared buffer (callers skip the real free).
+bool
+is_shared_buffer(void* ptr);
+
+/// Free all shared per-agent buffers. Called from thread_trace::finalize().
+void
+free_shared_buffers();
+
+}  // namespace thread_trace
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/shared_trace_lease.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/shared_trace_lease.cpp
@@ -22,6 +22,7 @@
 
 #include "lib/rocprofiler-sdk/thread_trace/shared_trace_lease.hpp"
 
+#include "lib/common/static_object.hpp"
 #include "lib/common/synchronized.hpp"
 
 #include <cstdint>
@@ -44,12 +45,12 @@ struct lease_state_t
     std::map<uint64_t, agent_lease_t> agents = {};  // keyed by hsa_agent_t.handle
 };
 
-// Namespace-scope (constructed during dynamic initialization) so it outlives finalize(),
-// which runs as an atexit handler registered later, during the run, and calls
-// free_agent_leases() at process exit; a function-local static could be destroyed before
-// finalize() runs and crash it. Mirrors the `client` global in core.cpp. The buffer and
-// queue managers use this same pattern and refer back to this note.
-common::Synchronized<lease_state_t> g_lease_state{};
+// Held in a static_object, not a plain namespace-scope global: on the attach path the global's
+// destructor can run before finalize() frees it (via free_agent_leases()) -- a use-after-free.
+// static_object is destroyed after finalize() (by destroy_static_objects()), so it outlives
+// teardown without leaking. The buffer and queue managers mirror this.
+common::Synchronized<lease_state_t>& g_lease_state =
+    *common::static_object<common::Synchronized<lease_state_t>>::construct();
 }  // namespace
 
 bool

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/shared_trace_lease.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/shared_trace_lease.cpp
@@ -1,0 +1,96 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "lib/rocprofiler-sdk/thread_trace/shared_trace_lease.hpp"
+
+#include "lib/common/synchronized.hpp"
+
+#include <cstdint>
+#include <map>
+
+namespace rocprofiler
+{
+namespace thread_trace
+{
+namespace
+{
+struct agent_lease_t
+{
+    const void* owner    = nullptr;  // the ThreadTracerAgent that currently holds it
+    uint64_t    refcount = 0;        // overlapping traces from that same owner
+};
+
+struct lease_state_t
+{
+    std::map<uint64_t, agent_lease_t> agents = {};  // keyed by hsa_agent_t.handle
+};
+
+// Namespace-scope (constructed during dynamic initialization) so it outlives finalize(),
+// which runs as an atexit handler registered later, during the run, and calls
+// free_agent_leases() at process exit; a function-local static could be destroyed before
+// finalize() runs and crash it. Mirrors the `client` global in core.cpp. The buffer and
+// queue managers use this same pattern and refer back to this note.
+common::Synchronized<lease_state_t> g_lease_state{};
+}  // namespace
+
+bool
+try_acquire_agent_lease(hsa_agent_t agent, const void* owner)
+{
+    return g_lease_state.wlock([&](lease_state_t& state) {
+        auto& lease = state.agents[agent.handle];
+        if(lease.refcount == 0)
+        {
+            lease.owner    = owner;
+            lease.refcount = 1;
+            return true;
+        }
+        if(lease.owner == owner)
+        {
+            ++lease.refcount;
+            return true;
+        }
+        return false;  // held by a different owner
+    });
+}
+
+void
+release_agent_lease(hsa_agent_t agent, const void* owner)
+{
+    g_lease_state.wlock([&](lease_state_t& state) {
+        auto it = state.agents.find(agent.handle);
+        if(it == state.agents.end()) return;
+
+        auto& lease = it->second;
+        if(lease.owner != owner || lease.refcount == 0) return;
+
+        if(--lease.refcount == 0) lease.owner = nullptr;
+    });
+}
+
+void
+free_agent_leases()
+{
+    g_lease_state.wlock([](lease_state_t& state) { state.agents.clear(); });
+}
+
+}  // namespace thread_trace
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/shared_trace_lease.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/shared_trace_lease.hpp
@@ -1,0 +1,61 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <hsa/hsa.h>
+
+namespace rocprofiler
+{
+namespace thread_trace
+{
+// Process-global per-agent exclusive trace lease. The shared output buffer and
+// submission queue for an agent are safe to share only because at most one trace is
+// active per agent at a time. This lease enforces that invariant directly instead of
+// relying on higher-level context management: while one owner (a ThreadTracerAgent)
+// holds an agent's lease, another owner's acquire fails, so two contexts can never
+// use the same shared buffer/queue concurrently (e.g. a dispatch trace still draining
+// in-flight while a device trace starts on the same agent).
+//
+// Reference counted per owner so a same-owner handoff -- one trace's release interleaving
+// with the next trace's acquire -- only decrements and never frees the lease out from
+// under the owner. Overlapping traces are counted by ThreadTracerAgent::active_traces, not
+// here. It is a common enforcement point a future CPU staging-buffer change can reuse.
+
+/// Take or extend the lease on @p agent for @p owner. Returns true if @p owner now
+/// holds it (freshly acquired, or already held and reference count incremented).
+/// Returns false without side effects if a different owner currently holds it.
+bool
+try_acquire_agent_lease(hsa_agent_t agent, const void* owner);
+
+/// Release one reference held by @p owner on @p agent's lease. The lease becomes free
+/// once the owner's reference count reaches zero. No-op if @p owner is not the holder.
+void
+release_agent_lease(hsa_agent_t agent, const void* owner);
+
+/// Drop all lease state. Called from thread_trace::finalize() once every tracer is
+/// destroyed.
+void
+free_agent_leases();
+
+}  // namespace thread_trace
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/tests/att_packet_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/tests/att_packet_test.cpp
@@ -178,21 +178,22 @@ TEST(thread_trace, shared_buffer_reuse)
     // Two contexts with different sizes; shared buffer is sized to the max.
     thread_trace::register_shared_buffer_size(agent.get_hsa_agent(), 0x1000000);
     thread_trace::register_shared_buffer_size(agent.get_hsa_agent(), 0x2000000);
-    ASSERT_TRUE(thread_trace::has_shared_buffer(agent.get_hsa_agent()));
 
     auto pool_a = make_pool();
     auto pool_b = make_pool();
 
+    constexpr uint64_t kSize = 0x2000000;
+
     // First context requests two ring slots (e.g. triple buffering).
-    void* a0 = thread_trace::acquire_shared_buffer(pool_a, 0);
-    void* a1 = thread_trace::acquire_shared_buffer(pool_a, 1);
+    void* a0 = thread_trace::acquire_shared_buffer(pool_a, 0, kSize);
+    void* a1 = thread_trace::acquire_shared_buffer(pool_a, 1, kSize);
     ASSERT_NE(a0, nullptr);
     ASSERT_NE(a1, nullptr);
     EXPECT_NE(a0, a1) << "distinct ring slots must be distinct buffers";
 
     // Second context reuses the same physical buffers per slot.
-    void* b0 = thread_trace::acquire_shared_buffer(pool_b, 0);
-    void* b1 = thread_trace::acquire_shared_buffer(pool_b, 1);
+    void* b0 = thread_trace::acquire_shared_buffer(pool_b, 0, kSize);
+    void* b1 = thread_trace::acquire_shared_buffer(pool_b, 1, kSize);
     EXPECT_EQ(a0, b0) << "same ring slot must be shared across contexts";
     EXPECT_EQ(a1, b1) << "same ring slot must be shared across contexts";
 
@@ -202,7 +203,6 @@ TEST(thread_trace, shared_buffer_reuse)
 
     thread_trace::free_shared_buffers();
     EXPECT_FALSE(thread_trace::is_shared_buffer(a0));
-    EXPECT_FALSE(thread_trace::has_shared_buffer(agent.get_hsa_agent()));
 }
 
 TEST(thread_trace, configure_test)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/tests/att_packet_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/tests/att_packet_test.cpp
@@ -33,6 +33,7 @@
 #include "lib/rocprofiler-sdk/hsa/queue_controller.hpp"
 #include "lib/rocprofiler-sdk/registration.hpp"
 #include "lib/rocprofiler-sdk/thread_trace/core.hpp"
+#include "lib/rocprofiler-sdk/thread_trace/shared_trace_buffer.hpp"
 
 #include <gtest/gtest.h>
 #include "lib/common/logging.hpp"
@@ -143,6 +144,65 @@ TEST(thread_trace, resource_creation)
 
         tracer.resource_deinit();
     }
+}
+
+// Shared buffers are reused across contexts (same slot -> same pointer) and
+// distinct per ring slot.
+TEST(thread_trace, shared_buffer_reuse)
+{
+    ASSERT_EQ(hsa_init(), HSA_STATUS_SUCCESS);
+    test_init();
+
+    registration::init_logging();
+    registration::set_init_status(-1);
+
+    // Isolate from any prior test that may have populated the manager.
+    thread_trace::free_shared_buffers();
+
+    auto agents = hsa::get_queue_controller()->get_supported_agents();
+    ASSERT_GT(agents.size(), 0);
+
+    const auto& agent = begin(agents)->second;
+
+    // Build a TraceMemoryPool the same way ThreadTraceAQLPacketFactory does.
+    auto make_pool = [&agent]() {
+        hsa::TraceMemoryPool pool{};
+        pool.allocate_fn     = get_ext_table().hsa_amd_memory_pool_allocate_fn;
+        pool.allow_access_fn = get_ext_table().hsa_amd_agents_allow_access_fn;
+        pool.free_fn         = get_ext_table().hsa_amd_memory_pool_free_fn;
+        pool.gpu_agent       = agent.get_hsa_agent();
+        pool.gpu_pool_       = agent.gpu_pool();
+        return pool;
+    };
+
+    // Two contexts with different sizes; shared buffer is sized to the max.
+    thread_trace::register_shared_buffer_size(agent.get_hsa_agent(), 0x1000000);
+    thread_trace::register_shared_buffer_size(agent.get_hsa_agent(), 0x2000000);
+    ASSERT_TRUE(thread_trace::has_shared_buffer(agent.get_hsa_agent()));
+
+    auto pool_a = make_pool();
+    auto pool_b = make_pool();
+
+    // First context requests two ring slots (e.g. triple buffering).
+    void* a0 = thread_trace::acquire_shared_buffer(pool_a, 0);
+    void* a1 = thread_trace::acquire_shared_buffer(pool_a, 1);
+    ASSERT_NE(a0, nullptr);
+    ASSERT_NE(a1, nullptr);
+    EXPECT_NE(a0, a1) << "distinct ring slots must be distinct buffers";
+
+    // Second context reuses the same physical buffers per slot.
+    void* b0 = thread_trace::acquire_shared_buffer(pool_b, 0);
+    void* b1 = thread_trace::acquire_shared_buffer(pool_b, 1);
+    EXPECT_EQ(a0, b0) << "same ring slot must be shared across contexts";
+    EXPECT_EQ(a1, b1) << "same ring slot must be shared across contexts";
+
+    EXPECT_TRUE(thread_trace::is_shared_buffer(a0));
+    EXPECT_TRUE(thread_trace::is_shared_buffer(a1));
+    EXPECT_FALSE(thread_trace::is_shared_buffer(nullptr));
+
+    thread_trace::free_shared_buffers();
+    EXPECT_FALSE(thread_trace::is_shared_buffer(a0));
+    EXPECT_FALSE(thread_trace::has_shared_buffer(agent.get_hsa_agent()));
 }
 
 TEST(thread_trace, configure_test)


### PR DESCRIPTION
## Motivation

Thread trace (ATT) allocated a separate GPU output buffer for every context on each agent (default 128 MB each), even though only one trace can be active per agent at a time. With multiple contexts on the same agent this wastes large amounts of device memory. This PR makes all contexts on an agent share a single output buffer sized to the largest requested `buffer_size`, and adds a per-agent lease so that at most one context traces a given agent at a time — a second, concurrent request runs untraced rather than writing into the shared buffer.

## Technical Details

- Adds a process-global per-agent buffer manager in `source/lib/rocprofiler-sdk/thread_trace/shared_trace_buffer.{hpp,cpp}`.
- `thread_trace::initialize()` runs a pre-pass that registers every context's per-agent `buffer_size` before any buffer is built, so the shared buffer is sized to the max; `finalize()` frees the buffers once.
- `TraceMemoryPool::Alloc` returns the shared device buffer (one per ring slot via `output_buffer_index`, so triple buffering keeps distinct slots); `TraceMemoryPool::Free` skips shared buffers to avoid a double-free across the contexts that reuse them.
- Adds a per-agent trace lease in `source/lib/rocprofiler-sdk/thread_trace/shared_trace_lease.{hpp,cpp}` enforcing the "one active trace per agent" invariant the shared buffer relies on: the first active trace on an agent atomically claims it (owner-keyed, re-entrant refcount) in `get_control()`, and a different context requesting a trace while the agent is held fails fast — `get_control()` returns null and that context runs untraced instead of concurrently writing the shared buffer. The lease is released when the agent's last in-flight trace ends (`iterate_data` / `stop` / destructor).
- The buffer and lease managers keep their process-global state in `common::static_object` rather than plain namespace-scope globals: the state is freed by `finalize()` (a `registration::finalize()` `atexit` handler), and on the attach path a plain global's destructor can run before `finalize()` — a use-after-free. `static_object` is destroyed by `destroy_static_objects()` (sequenced after `finalize()`), so the state outlives teardown without leaking.

## JIRA ID

JIRA ID : AIPROFSDK-102

## Test Plan

- Unit: `thread-trace-packet-test` (including a new `shared_buffer_reuse` case covering cross-context reuse, distinct ring slots, and max sizing) and `thread-trace-producer-consumer-test`.
- Integration: ATT single, multi, agent, large-buffer, before-hsa-init, and triple-buffer (consistency, hammer, slow, multiple-cmds) on MI300, ROCm 7.2.3.
- Flakiness: repeated reruns via `ctest --repeat until-fail:10`.

## Test Result

Unit tests pass reliably across repeated runs on MI300 (ROCm 7.2.3): `thread-trace-producer-consumer-test` 25/25 and `thread-trace-packet-test` 10/10. Integration tests single/multi/agent/large-buffer/before-hsa-init and triple-buffer slow/multiple-cmds pass 10/10 repeats each. The `triple-buffer-consistency` and `triple-buffer-hammer` tests can intermittently hit the pre-existing SQTT shutdown GPU hang tracked in AILIKFD-39; this was verified to reproduce on `develop` without this change (identical `reason :GPU Hang`), so it is unrelated to the buffer-sharing rework and is not addressed here.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.