### PR TITLE
Simplify net_ib_cast recv matching scheme selection

### DIFF
--- a/projects/rccl/src/transport/net_ib_cast/common.cc
+++ b/projects/rccl/src/transport/net_ib_cast/common.cc
@@ -22,9 +22,7 @@ ncclProfilerCallback_t IbCastProfilerFunction;
 NCCL_PARAM(IbCastSplitDataOnQps, "IB_SPLIT_DATA_ON_QPS", 0);
 NCCL_PARAM(IbCastPrepostReceiveWorkRequests, "IB_PREPOST_RECEIVE_WORK_REQUESTS", -2);
 NCCL_PARAM(IbCastAsyncEvents,"IB_RETURN_ASYNC_EVENTS",1);
-extern int ncclParamIbCastReceiverSideMatchingScheme();
 extern int ncclParamIbCastOooRq();
-extern int ncclParamIbCastResiliencyPortFailover();
 
 
 ncclResult_t IbCastStatsCheckFatalCount(struct ncclIbStats* stat, const char* funcName) {
@@ -64,14 +62,6 @@ ncclResult_t IbCastBaseCommInit(struct ncclIbNetCommBase* baseComm, bool isSend)
   baseComm->ready = 0;
 
   NCCLCHECK(IbCastResiliencyInit(baseComm, &baseComm->resiliency));
-  baseComm->recvMatchingScheme = ncclParamIbCastReceiverSideMatchingScheme() == -2 ? BY_INDEX : ncclParamIbCastReceiverSideMatchingScheme();
-
-  if (ncclParamIbCastOooRq() || (ncclParamIbCastResiliencyPortFailover() == 1)) {
-    baseComm->recvMatchingScheme = BY_ID;
-    if (ncclParamIbCastReceiverSideMatchingScheme() == BY_INDEX) {
-      INFO(NCCL_NET, "NET/IB: %s: Overriding matching scheme to ID-based (%d)", __func__, BY_ID);
-    }
-  }
 
   return ncclSuccess;
 }

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -23,6 +23,8 @@ NCCL_PARAM(IbCastFifoTc, "IB_FIFO_TC", -1);
 NCCL_PARAM(IbCastEceEnable,"IB_ECE_ENABLE",1);
 
 extern int64_t ncclParamIbCastOooRq();
+extern int64_t ncclParamIbCastResiliencyPortFailover();
+extern int64_t ncclParamIbCastReceiverSideMatchingScheme();
 
 struct ncclIbDevExtraProps {
   bool oooRq;
@@ -64,6 +66,27 @@ static bool nccl_channel_last_ud[MAX_IB_DEVS][ncclIbChannelTypeMax];
 
 static inline bool IbCastIsCtsOffloadEnabled(int isP2p) {
   return IbCastOffloadEnabled && !(isP2p && rcclParamIbCastP2pDisableCts());
+}
+
+static int IbCastResolveRecvMatchingScheme(bool useCtsOffload) {
+  // Order matters here:
+  // BY_ORDER -> ctsoffload
+  // BY_ID -> failover
+  // BY_INDEX -> default or user requested
+
+  if (useCtsOffload) {
+    return BY_ORDER;
+  }
+
+  if (ncclParamIbCastOooRq() || (ncclParamIbCastResiliencyPortFailover() == 1)) {
+    return BY_ID;
+  }
+
+  int64_t requested = ncclParamIbCastReceiverSideMatchingScheme();
+  if (requested == -2 || requested == BY_ORDER) {
+    return BY_INDEX;
+  }
+  return requested;
 }
 
 ncclResult_t IbCastInitCommDevBase(int ibDevN, struct ncclIbNetCommDevBase* base, void* cq_context, int cqSize) {
@@ -828,11 +851,10 @@ ib_recv_dev_list:
   // Read isP2p from handle
   isP2p = handle->isP2p;
   comm->useCtsOffload = IbCastIsCtsOffloadEnabled(isP2p) && !handle->isRMA;
-  if (comm->useCtsOffload) {
-    comm->base.recvMatchingScheme = BY_ORDER;
-  }
+  comm->base.recvMatchingScheme = IbCastResolveRecvMatchingScheme(comm->useCtsOffload);
 
-  INFO(NCCL_NET, "NET/IB: IbCastConnect isP2p=%d isRMA=%d", isP2p, handle->isRMA);
+  INFO(NCCL_NET, "NET/IB: IbCastConnect isP2p=%d isRMA=%d useCtsOffload=%d recvMatchingScheme=%d",
+       isP2p, handle->isRMA, comm->useCtsOffload, comm->base.recvMatchingScheme);
   comm->base.nqps = IbCastCalculateNqps(isP2p, comm->base.vProps.ndevs, 
                                          remoteVProps.ndevs, __func__);
   if (handle->isRMA) {
@@ -1389,10 +1411,9 @@ ib_recv:
   memcpy(&remMeta, stage->buffer, sizeof(struct ncclIbConnectionMetadata));
 
   rComm->useCtsOffload = IbCastIsCtsOffloadEnabled(remMeta.isP2p);
-  if (rComm->useCtsOffload) {
-    rComm->base.recvMatchingScheme = BY_ORDER;
-  }
-  INFO(NCCL_NET, "NET/IB: ncclIbAccept isP2p=%d useCtsOffload=%d (IbP2pDisableCts=%d)", remMeta.isP2p, rComm->useCtsOffload, rcclParamIbCastP2pDisableCts());
+  rComm->base.recvMatchingScheme = IbCastResolveRecvMatchingScheme(rComm->useCtsOffload);
+  INFO(NCCL_NET, "NET/IB: ncclIbAccept isP2p=%d useCtsOffload=%d (IbP2pDisableCts=%ld) recvMatchingScheme=%d",
+       remMeta.isP2p, rComm->useCtsOffload, rcclParamIbCastP2pDisableCts(), rComm->base.recvMatchingScheme);
   rComm->base.nqps = IbCastCalculateNqps(remMeta.isP2p, rComm->base.vProps.ndevs,
                                          remMeta.ndevs, __func__);
   rComm->base.nDataQps = std::max(rComm->base.vProps.ndevs, remMeta.ndevs);


### PR DESCRIPTION
## Motivation

net_ib_cast's `recvMatchingScheme` selection previously negotiated the scheme over the wire between peers and warned when the CTS-offload path overrode a user-requested scheme. This adds needless complexity: the scheme is fully determined by local state on each side of the connection (CTS offload availability, OOO RQ, port failover, and the `NCCL_IB_RECEIVER_SIDE_MATCHING_SCHEME` env knob), so there is no need to forward it over the wire or warn about overrides.

## Technical Details

- Resolve `recvMatchingScheme` purely from local state instead of negotiating it over the wire; removes the metadata forwarding and scheme-mismatch warnings.
- CTS offload always implies `BY_ORDER`, with no overrides or warnings.
- Without CTS offload, the scheme follows the requested env knob (default `BY_INDEX`). Requesting `BY_ORDER` without CTS offload is still not a valid combination — `BY_ORDER` relies on the CTS-offload single-QP, per-request `wr_id` posting path — so that case now silently falls back to `BY_INDEX` instead of warning.
- Removes the now-unused `IbCastMatchingSchemeStr` helper.
- Fixes the `ncclParamIbCastReceiverSideMatchingScheme` forward declaration to return `int64_t`, matching `NCCL_PARAM`'s actual signature.
- Fixes a pre-existing `%d`/`int64_t` format mismatch in the `ncclIbAccept` log line for `rcclParamIbCastP2pDisableCts()`.

## JIRA ID

no jira

## Test Plan

Ran `alltoall_perf` (rccl-tests) over real IB hardware across `NCCL_IB_RECEIVER_SIDE_MATCHING_SCHEME` = unset/BY_INDEX/BY_ID/BY_ORDER, with `RCCL_CTS_OFFLOAD_ENABLED` on and off, sweeping message sizes 1K→16G, and inspected `NCCL_DEBUG_SUBSYS=NET` logs to confirm the resolved `recvMatchingScheme` matched expectations in every combination (resiliency modes > CTS offload > user-requested env value > default).

## Test Result

All 6 scheme/offload combinations completed with `EXIT_CODE=0` and `Out of bounds values: 0 OK`:
- CTS offload on, default request → `recvMatchingScheme=2` (BY_ORDER)
- CTS offload off, BY_INDEX requested → `recvMatchingScheme=0` (BY_INDEX)
- CTS offload off, BY_ID requested → `recvMatchingScheme=1` (BY_ID)
- CTS offload off, BY_ORDER requested → falls back to `recvMatchingScheme=0` (BY_INDEX)
- CTS offload on, BY_INDEX requested → overridden to `recvMatchingScheme=2` (BY_ORDER)
- CTS offload on, BY_ORDER requested → `recvMatchingScheme=2` (BY_ORDER)

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.