### PR TITLE
fix(rccl/net_ib_cast): Address CTS FIFO inline data handling gaps for AINIC

### DIFF
--- a/projects/rccl/src/transport/net_ib_cast/common_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/common_cast.h
@@ -144,7 +144,7 @@ extern bool IbCastUseInline;
 #define WR_IMM_SIZE_MASK 0x007fffff
 extern int IbCastGdrFlushDisable;
 extern bool IbCastAinicRoce;
-extern bool rcclCtsInlineData;
+extern bool IbCastAinicCtsInlineData;
 extern bool IbCastOffloadEnabled;
 extern int64_t rcclParamIbCastP2pDisableCts();
 
@@ -366,10 +366,10 @@ struct alignas(32) ncclIbSendFifoCtsInline {
   uint32_t rkeys[1];
   int size;
   uint8_t nreqs;
-  uint16_t rxReqIndex;
+  uint8_t rxReqIndex; // num req is max 256
   uint16_t tag;
   uint32_t idx;
-  char padding[9];
+  char padding[8];
 } __attribute__((packed));
 
 struct ncclIbQpInitAttr {
@@ -578,6 +578,12 @@ struct ncclIbSendComm {
   // issuing a (multi-)receive request). Each row in the 2D array corresponds
   // to a single CTS message but can describe multiple recv-requests issued
   // on the receiver side.
+  // Note: for AINIC when CTS offload and/or Inline CTS is enabled,
+  // it uses 32B data type (ncclIbSendFifoCtsInline) for CTS messages.
+  // In that case, the ctsFifo for a given slot which holds the CTS messages
+  // for multi-receive requests will be used as a contiguous buffer of
+  // 32B element (instead of 64B) and not used as a 2D array with
+  // with each element of size 64B.
   struct ncclIbSendFifo ctsFifo[NET_IB_MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
   struct ibv_sge sges[NCCL_NET_IB_MAX_RECVS];
   struct ibv_send_wr wrs[NCCL_NET_IB_MAX_RECVS + 1];
@@ -605,7 +611,9 @@ static_assert((offsetof(struct ncclIbSendComm, ctsFifo) % 32) == 0, "ncclIbSendC
 static_assert((sizeof(struct ncclIbSendFifo) % 32) == 0, "ncclIbSendFifo element size must be 32-byte multiples");
 static_assert(sizeof(struct ncclIbSendFifo) <= 64, "struct ncclIbSendFifo should fit one cache line");
 static_assert((sizeof(struct ncclIbSendFifoCtsInline) % 32) == 0,
-              "ncclIbSendFifoCtsInline element size must be 32-byte multiples");
+              "ncclIbSendFifoCtsInline element size must be 32-byte aligned");
+static_assert((sizeof(struct ncclIbSendFifoCtsInline) <=32),
+               "struct ncclIbSendFifoCtsInline should fit within 32-bytes");
 static_assert((offsetof(struct ncclIbSendComm, sges) % 32) == 0, "sges must be 32-byte aligned");
 static_assert((offsetof(struct ncclIbSendComm, wrs) % 32) == 0, "wrs must be 32-byte aligned");
 
@@ -625,6 +633,12 @@ struct ncclIbRemCtsFifo {
   // the CTS FIFO locally on its side. Receiver uses this memory to place the
   // CTS messages and populates the RDMA message "gather address" with the
   // memory of the CTS message that is sent.
+  // Note: for AINIC when CTS offload and/or Inline CTS is enabled,
+  // it uses 32B data type (ncclIbSendFifoCtsInline) for CTS messages.
+  // In that case, the ctsFifo for a given slot which holds the CTS messages
+  // for multi-receive requests will be used as a contiguous buffer of
+  // 32B element (instead of 64B) and not used as a 2D array with
+  // with each element of size 64B.
   struct ncclIbSendFifo elems[NET_IB_MAX_REQUESTS][NCCL_NET_IB_MAX_RECVS];
   uint64_t addr;
   // Array of RKeys (one RKey per device) from which the receiver chooses the

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -413,9 +413,14 @@ static ncclResult_t ncclIbCreateQpIonic(struct ncclIbQpCreateAttr* createQpAttrs
   qpInitAttr.cap.max_send_wr = createQpAttrs->maxSendWorkRequest;
   qpInitAttr.cap.max_send_sge = 1;
   qpInitAttr.cap.max_recv_sge = 1;
-  qpInitAttr.cap.max_inline_data = IbCastUseInline ? sizeof(struct ncclIbSendFifo) * NCCL_NET_IB_MAX_RECVS : 0;
   if (createQpAttrs->isCtsEnabled) {
     qpInitAttr.cap.max_inline_data = MAX_INLINE_DATA_SIZE;
+  } else {
+    // for multi-receive scenarios, the inline payload will be a
+    // multiple of 32B ncclIbSendFifoCtsInline elements and hence
+    // effectively inline handling will be disabled. So limit the
+    // max_inline_data to single request size.
+    qpInitAttr.cap.max_inline_data = IbCastAinicCtsInlineData ? sizeof(struct ncclIbSendFifoCtsInline) : 0;
   }
   qpInitAttr.sq_sig_all |= (1 << 16);
   if (createQpAttrs->isDataQp) {
@@ -1573,7 +1578,7 @@ ib_recv:
                   ret, fail);
     meta.devs[i].rkey = rCommDev->cmplsRecordsMr->rkey;
   }
-  if (IbCastUseInline && (!IbCastAinicRoce || rComm->useCtsOffload)) rComm->remCtsFifo.flags = IBV_SEND_INLINE;
+  if (IbCastUseInline) rComm->remCtsFifo.flags = IBV_SEND_INLINE;
 
   for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
     rCommDev = rComm->devs + i;

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -20,6 +20,7 @@ RCCL_PARAM(IbCastP2pDisableCts, "IB_P2P_DISABLE_CTS", 1);
 bool IbCastAinicRoce = 0;
 bool IbCastOffloadEnabled = 0;
 bool IbCastUseInline = 0;
+bool IbCastAinicCtsInlineData = 0;
 int IbCastGdrFlushDisable = 0;
 extern int64_t rcclParamAinicRoce();
 extern int64_t ncclParamIbCastUseInline();
@@ -550,18 +551,26 @@ ncclResult_t IbCastInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
 
       // CTS Offload and CTS Inline are mutually dependent — both must be
       // enabled for either to function. Disable both if either is missing.
+      if (IbCastOffloadEnabled && !IbCastUseInline) {
+        INFO(NCCL_INIT|NCCL_NET, "NET/IB : IB Use Inline is disabled and CTS Offload is enabled - enabling IB Use Inline Data");
+        IbCastUseInline = true;
+      }
       if (IbCastOffloadEnabled && rcclUseIbCastQpSched()) {
         INFO(NCCL_INIT | NCCL_NET,
              "NET/IB : CAST enabled - disabling CTS Inline Data and CTS Offload (not yet supported with CAST)");
         IbCastOffloadEnabled = false;
+        IbCastUseInline = false;
       }
-      // for AINIC IbUseInline is enabled by default always
-      IbCastUseInline = true;
+      // flag IbCastAinicCtsInlineData is used specifically to identify UseInline for Ainic
+      IbCastAinicCtsInlineData = IbCastUseInline;
 
       INFO(NCCL_INIT | NCCL_NET,
            "NET/IB : AINIC RoCEv2 optimizations enabled: CTS Inline Data: %s; CTS Offload: %s; "
-           "IB Use Inline: enabled; GDR Flush: disabled",
-           IbCastUseInline ? "Enabled" : "Disabled", IbCastOffloadEnabled ? "Enabled" : "Disabled");
+           "IB Use Inline: %s; GDR Flush: %s",
+           IbCastAinicCtsInlineData ? "Enabled": "Disabled",
+           IbCastOffloadEnabled ? "Enabled": "Disabled",
+           IbCastUseInline ? "Enabled": "Disabled",
+           IbCastGdrFlushDisable ? "Disabled": "Enabled");
     }
   }
 exit:
@@ -574,9 +583,12 @@ exit:
   }
   if (ret == ncclSuccess && IbCastOffloadEnabled &&
       (ncclParamIbCastResiliencyPortFailover() || ncclParamIbCastResiliencyPortRecovery())) {
-    INFO(NCCL_INIT | NCCL_NET, "NET/IB : PORT_FAILOVER/RECOVERY enabled - disabling CTS offload "
-                               "(not compatible with resiliency)");
+    INFO(NCCL_INIT | NCCL_NET,
+         "NET/IB : PORT_FAILOVER/RECOVERY enabled - disabling CTS offload, Inline Data "
+         "(not compatible with resiliency)");
     IbCastOffloadEnabled = false;
+    IbCastUseInline = false;
+    IbCastAinicCtsInlineData = false;
   }
   return ret;
 fail:
@@ -625,8 +637,9 @@ ncclResult_t IbCastGetPhysProperties(int dev, ncclNetProperties_t* props) {
   props->latency = 0; // Not set
   props->port = ibDev->portNum + ibDev->realPort;
   props->maxComms = ibDev->maxQp;
+  // AINIC with CTS offload enabled supports max of 1 recv only.
   if (IbCastOffloadEnabled && !rcclParamIbCastP2pDisableCts()) {
-    props->maxRecvs = 1;
+    props->maxRecvs = 1; 
   } else {
     props->maxRecvs = NCCL_NET_IB_MAX_RECVS;
   }

--- a/projects/rccl/src/transport/net_ib_cast/p2p.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p.cc
@@ -93,8 +93,8 @@ static ncclResult_t IbCastPrintWr(struct ibv_send_wr* wr, char* wrStr) {
 ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, int startQpIndex, bool wrrSched,
                              bool useWriteOp) {
   struct ncclIbRequest** reqs = comm->sendReqs[slot];
-  volatile struct ncclIbSendFifo* slots = comm->ctsFifo[slot];
-  int nreqs = comm->useCtsOffload ? 1 : slots[0].nreqs;
+  volatile void* slots = (volatile void*)comm->ctsFifo[slot];
+  int nreqs = comm->useCtsOffload ? 1 : ctsFifoNreqs(slots, 0);
   uint64_t nowNs = 0;
   if (nreqs > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
 
@@ -110,7 +110,7 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
     sge->addr = (uintptr_t)reqs[r]->send.data;
     wr->opcode = IBV_WR_RDMA_WRITE;
     wr->send_flags = 0;
-    wr->wr.rdma.remote_addr = comm->useCtsOffload ? 0xdeadbeef : slots[r].addr;
+    wr->wr.rdma.remote_addr = comm->useCtsOffload ? 0xdeadbeef : ctsFifoAddr(slots, r);
     wr->next = wr + 1;
     wr_id += (uint64_t)(slot & 0xff) << (r * 8);
     wr->wr_id = wr_id;
@@ -142,7 +142,7 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
     if (comm->base.recvMatchingScheme != BY_INDEX) {
       immData = (uint32_t)(reqs[0]->id % UINT32_MAX);
     } else {
-      uint32_t rxReqIdx = (uint32_t)slots[0].rxReqIndex;
+      uint32_t rxReqIdx = (uint32_t)ctsFifoRxReqIndex(slots, 0);
       immData = (rxReqIdx << WR_IMM_RX_REQ_IDX_SHIFT);
       if (nqps > 1) {
         immData |= WR_IMM_SPLIT_DATA_FLAG;
@@ -198,7 +198,7 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
       // IbCastAddEvent(reqs[r], devIndex);
 
       // Select proper rkey (needed even for 0-size send)
-      comm->wrs[r].wr.rdma.rkey = comm->useCtsOffload ? 0xbade : slots[r].rkeys[qp->remDevIdx];
+      comm->wrs[r].wr.rdma.rkey = comm->useCtsOffload ? 0xbade : ctsFifoRkey(slots, r, qp->remDevIdx);
 
       int chunkSize, length;
       if ((nqps > 1) && reqs[r]->desc.parms.enable && comm->base.qpTxSchedInit) {
@@ -365,36 +365,37 @@ ncclResult_t IbCastIsend(void* sendComm, void* data, size_t size, int tag, void*
   struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*)mhandle;
   // Wait for the receiver to have posted the corresponding receive
   int nreqs = 1;
-  volatile struct ncclIbSendFifo* slots;
-
   int slot = comm->base.fifoHead % NET_IB_MAX_REQUESTS;
   struct ncclIbRequest** reqs = comm->sendReqs[slot];
+  volatile void* slots = (volatile void*)comm->ctsFifo[slot];
+
   if (!comm->useCtsOffload) {
-    slots = comm->ctsFifo[slot];
-    uint32_t idx = (uint32_t)(comm->base.fifoHead + 1);
-    if (slots[0].idx != idx) {
+    uint32_t idx = (uint32_t)(comm->base.fifoHead+1);
+    if (ctsFifoIdx(slots, 0) != idx) {
       *request = NULL;
       return ncclSuccess;
     }
-    nreqs = slots[0].nreqs;
+    nreqs = ctsFifoNreqs(slots, 0);
     // Wait until all data has arrived
-    for (int r = 1; r < nreqs; r++)
-      while (slots[r].idx != idx);
+    for (int r=1; r<nreqs; r++)
+      while(ctsFifoIdx(slots, r) != idx);
     std::atomic_thread_fence(std::memory_order_seq_cst); // order the nreqsPtr load against tag/rkey/addr loads below
   }
 
   for (int r = 0; r < nreqs; r++) {
     if (!comm->useCtsOffload) {
-      if (reqs[r] != NULL || slots[r].tag != tag) continue;
+      if (reqs[r] != NULL || (int)ctsFifoTag(slots, r) != tag) continue;
 
-      if (size > slots[r].size) size = slots[r].size;
+      size_t slotSize = ctsFifoSize(slots, r);
+      if (size > slotSize) size = slotSize;
       // Sanity checks
-      if (slots[r].size < 0 || slots[r].addr == 0 || slots[r].rkeys[0] == 0) {
+      if (slotSize < 0 || ctsFifoAddr(slots, r) == 0 || ctsFifoRkey(slots, r, 0) == 0) {
         char line[SOCKET_NAME_MAXLEN + 1];
         union ncclSocketAddress addr;
         ncclSocketGetAddr(&comm->base.sock, &addr);
-        WARN("NET/IB : req %d/%d tag %x peer %s posted incorrect receive info: size %ld addr %lx rkeys[0]=%x", r, nreqs,
-             tag, ncclSocketToString(&addr, line), slots[r].size, slots[r].addr, slots[r].rkeys[0]);
+        WARN("NET/IB : req %d/%d tag %x peer %s posted incorrect receive info: size %ld addr %lx rkeys[0]=%x",
+             r, nreqs, tag, ncclSocketToString(&addr, line), ctsFifoSize(slots, r),
+             ctsFifoAddr(slots, r), ctsFifoRkey(slots, r, 0));
         return ncclInternalError;
       }
     }
@@ -495,6 +496,7 @@ ncclResult_t IbCastPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* r
 
   struct ibv_send_wr wr;
   memset(&wr, 0, sizeof(wr));
+  // return the CTS fifo slot base address, which is based on the array of ncclIbSendFifo(64B) data type
   wr.wr.rdma.remote_addr = comm->remCtsFifo.addr + slot * NCCL_NET_IB_MAX_RECVS * sizeof(struct ncclIbSendFifo);
 
   // Lookup the correct rkey
@@ -505,11 +507,25 @@ ncclResult_t IbCastPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* r
   struct ncclIbSendFifo* localElem = comm->remCtsFifo.elems[slot];
   wr.sg_list = &(comm->devs[ctsQp->devIndex].sge);
   wr.sg_list[0].addr = (uint64_t)localElem;
-  wr.sg_list[0].length = comm->useCtsOffload ? MAX_INLINE_DATA_SIZE : n * sizeof(struct ncclIbSendFifo);
+
+  // for multi-receive requests, don't treat it as inline data
+  if (comm->useCtsOffload) {
+    wr.sg_list[0].length = MAX_INLINE_DATA_SIZE;
+  } else {
+    wr.sg_list[0].length =
+      n * (IbCastAinicCtsInlineData ?
+             sizeof(struct ncclIbSendFifoCtsInline) :
+             sizeof(struct ncclIbSendFifo));
+  }
   wr.num_sge = 1;
 
   wr.opcode = IBV_WR_RDMA_WRITE;
   wr.send_flags = comm->remCtsFifo.flags; // IBV_SEND_INLINE
+  // for multi-receive requests, reset inline flag in send_flags as 
+  // QP max_inline_data attribute limits the inline data to 1 request. 
+  if (IbCastAinicCtsInlineData && n > 1) {
+    wr.send_flags &= ~(IBV_SEND_INLINE);
+  }
 
   // We need to occasionally post a request with the IBV_SEND_SIGNALED flag, otherwise
   // the send queue will never empty.
@@ -651,15 +667,17 @@ ncclResult_t IbCastIrecv(void* recvComm, int n, void** data, size_t* sizes, int*
   }
 
   struct ncclIbSendFifo* localElem = comm->remCtsFifo.elems[slot];
+  struct ncclIbSendFifoCtsInline* localElemInline = (struct ncclIbSendFifoCtsInline*)localElem;
   for (int i = 0; i < n; i++) {
     struct ncclIbMrHandle* mhandleWrapper = (struct ncclIbMrHandle*)mhandles[i];
-    if (comm->useCtsOffload) {
-      struct ncclIbSendFifoCtsInline* localElemCtsInline = (struct ncclIbSendFifoCtsInline*)&localElem[i];
-      localElemCtsInline[i].addr = (uint64_t)data[i];
-      localElemCtsInline[i].rkeys[0] = mhandleWrapper->mrs[0]->rkey;
-      localElemCtsInline[i].nreqs = n;
-      localElemCtsInline[i].size = sizes[i]; // Sanity/Debugging
-      localElemCtsInline[i].tag = tags[i];
+    if (IbCastAinicCtsInlineData) {
+      localElemInline[i].addr = (uint64_t)data[i];
+      localElemInline[i].rkeys[0] = mhandleWrapper->mrs[0]->rkey;
+      localElemInline[i].nreqs = (uint8_t)n;
+      localElemInline[i].size = sizes[i]; // Sanity/Debugging
+      localElemInline[i].tag = (uint16_t)tags[i];
+      localElemInline[i].idx = (uint32_t)(comm->base.fifoHead+1);
+      localElemInline[i].rxReqIndex = (uint8_t)rxReqIndex;
     } else {
       localElem[i].addr = (uint64_t)data[i];
       // Send all applicable rkeys

--- a/projects/rccl/src/transport/net_ib_cast/p2p_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_cast.h
@@ -44,4 +44,55 @@ static inline ncclResult_t IbCastRequestRetrieveAsIndex(ncclIbRequest* reqs, uin
   return ncclSuccess;
 }
 
+// CTS FIFO element and stride helpers.
+// The CTS FIFO buffers are declared as 2D array elements of
+// ncclIbSendFifo (64B), but when IbCastAinicCtsInlineData
+// is true, then the CTS FIFO buffer for each slot (which holds
+// CTS messages upto MAX_RECV requests) is used as a contiguous
+// buffer of the 32-byte of ncclIbSendFifoCtsInline type.
+//
+// Callers resolve the correct row pointer (slots) accessing the
+// base address of CTS fifo for a given slot as
+//   slot_base = comm->ctsFifo[slot];
+// The accessors below take that pre-resolved row pointer (volatile void*)
+// and only index by rxReqId within the row using the correct element type.
+
+// --- Field accessors (layout-aware, row-based) ---
+static inline uint32_t ctsFifoNreqs(volatile void* slotBase, uint32_t rxReqId) {
+  if (IbCastAinicCtsInlineData)
+    return (uint32_t)((volatile struct ncclIbSendFifoCtsInline*)slotBase)[rxReqId].nreqs;
+  return ((volatile struct ncclIbSendFifo*)slotBase)[rxReqId].nreqs;
+}
+static inline uint64_t ctsFifoAddr(volatile void* slotBase, uint32_t rxReqId) {
+  if (IbCastAinicCtsInlineData)
+    return ((volatile struct ncclIbSendFifoCtsInline*)slotBase)[rxReqId].addr;
+  return ((volatile struct ncclIbSendFifo*)slotBase)[rxReqId].addr;
+}
+static inline uint16_t ctsFifoRxReqIndex(volatile void* slotBase, uint32_t rxReqId) {
+  if (IbCastAinicCtsInlineData)
+    return (uint16_t)((volatile struct ncclIbSendFifoCtsInline*)slotBase)[rxReqId].rxReqIndex;
+  return ((volatile struct ncclIbSendFifo*)slotBase)[rxReqId].rxReqIndex;
+}
+static inline uint32_t ctsFifoRkey(volatile void* slotBase, uint32_t rxReqId, int devIdx) {
+  if (IbCastAinicCtsInlineData)
+    // in SendFifoCtsInline only 1 key stored
+    return ((volatile struct ncclIbSendFifoCtsInline*)slotBase)[rxReqId].rkeys[0];
+  return ((volatile struct ncclIbSendFifo*)slotBase)[rxReqId].rkeys[devIdx];
+}
+static inline uint32_t ctsFifoIdx(volatile void* slotBase, uint32_t rxReqId) {
+  if (IbCastAinicCtsInlineData)
+    return ((volatile struct ncclIbSendFifoCtsInline*)slotBase)[rxReqId].idx;
+  return ((volatile struct ncclIbSendFifo*)slotBase)[rxReqId].idx;
+}
+static inline size_t ctsFifoSize(volatile void* slotBase, uint32_t rxReqId) {
+  if (IbCastAinicCtsInlineData)
+    return (size_t)((volatile struct ncclIbSendFifoCtsInline*)slotBase)[rxReqId].size;
+  return (size_t)((volatile struct ncclIbSendFifo*)slotBase)[rxReqId].size;
+}
+static inline uint32_t ctsFifoTag(volatile void* slotBase, uint32_t rxReqId) {
+  if (IbCastAinicCtsInlineData)
+    return (uint32_t)((volatile struct ncclIbSendFifoCtsInline*)slotBase)[rxReqId].tag;
+  return ((volatile struct ncclIbSendFifo*)slotBase)[rxReqId].tag;
+}
+
 #endif // NET_IB_P2P_H_


### PR DESCRIPTION
## Motivation
    fix(rccl/net_ib_cast): correct CTS FIFO inline data handling for AINIC

### Problem

     fix(rccl/net_ib_cast): correct CTS FIFO inline data handling for AINIC
    
    For AINIC (IbCastAinicRoce), the CTS FIFO supports two data layouts:
    a 64-byte ncclIbSendFifo (standard) and a 32-byte ncclIbSendFifoCtsInline
    (compact, for inline data). When IbCastAinicCtsInlineData is true, each
    slot's buffer is reinterpreted as a contiguous array of 32-byte elements
    rather than 64-byte elements. The code had several issues preventing
    correct operation in the 32-byte layout:
    
    - ncclIbSendFifoCtsInline.rxReqIndex was uint16_t with 9 bytes padding,
      exceeding the 32-byte struct target.
    
    - IbCastMultiSend and IbCastIsend directly dereferenced ctsFifo entries
      via slots[r].addr, slots[r].rkeys, slots[r].nreqs, etc. using the
      64-byte ncclIbSendFifo layout unconditionally — reading wrong memory
      offsets when the 32-byte layout was active.
    
    - IbCastIrecv had a double-indexing bug: localElemCtsInline was set to
      &localElem[i] (already at offset i), then accessed as
      localElemCtsInline[i] — writing at offset 2*i instead of i for i > 0.
    
    - IbCastIrecv used comm->useCtsOffload as the condition for selecting
      the inline type, missing the case where IbCastUseInline is enabled
      without CTS Offload on AINIC.
    
    - IbCastIrecv's inline path did not populate idx and rxReqIndex fields,
      which the sender reads, causing stale/zero values.
    
    - IbCastPostFifo SGE length was keyed on useCtsOffload instead of the
      inline data flag, and did not account for multi-recv with n > 1
      exceeding the QP's max_inline_data limit.
    
    - ncclIbCreateQpIonic set max_inline_data without distinguishing between
      CTS QPs and data QPs for AINIC inline sizing.
    
    - IBV_SEND_INLINE on remCtsFifo had an extra guard preventing it from
      being set in AINIC inline-without-offload scenarios.
    
    - IbCastUseInline was unconditionally forced to true for AINIC, and the
      CAST-scheduler and PORT_FAILOVER/RECOVERY disable paths did not clear
      it consistently.
    
    - The extern declaration used rcclCtsInlineData instead of
      IbCastAinicCtsInlineData.


## Technical Details

### Fix

    common_cast.h:
      - Rename extern rcclCtsInlineData → IbCastAinicCtsInlineData
      - Fix ncclIbSendFifoCtsInline.rxReqIndex: uint16_t → uint8_t, padding
        9 → 8 bytes to fit within 32 bytes
      - Add static_assert that ncclIbSendFifoCtsInline fits within 32 bytes
      - Add comments on ctsFifo and elems arrays documenting the 32-byte
        reinterpretation when IbCastAinicCtsInlineData is true
    
    init.cc:
      - Add IbCastAinicCtsInlineData global, derived from IbCastUseInline
        when AINIC is active (instead of forcing IbCastUseInline=true)
      - Auto-enable IbCastUseInline when CTS Offload is enabled without it
      - Clear IbCastUseInline alongside IbCastOffloadEnabled when CAST
        scheduler is active or PORT_FAILOVER/RECOVERY resiliency is enabled
      - Fix INFO log to print actual CTS Inline Data, IB Use Inline, and
        GDR Flush states (were previously hardcoded)
    
    connect.cc:
      - CTS QPs: max_inline_data = MAX_INLINE_DATA_SIZE (24B) via
        createQpAttrs->isCtsEnabled
      - Non-CTS QPs: max_inline_data = sizeof(ncclIbSendFifoCtsInline) (32B)
        when IbCastAinicCtsInlineData is true, 0 otherwise — sized for a
        single element since multi-recv disables inline
      - Simplify IBV_SEND_INLINE flag: set whenever IbCastUseInline is true
        (remove extra AINIC/offload guard)
    
    p2p_cast.h:
      - Add 7 layout-aware row-based field accessor functions (ctsFifoNreqs,
        ctsFifoAddr, ctsFifoRxReqIndex, ctsFifoRkey, ctsFifoIdx, ctsFifoSize,
        ctsFifoTag) that take a pre-resolved slot row pointer (volatile void*)
        and cast to the correct struct type based on IbCastAinicCtsInlineData

    p2p.cc — IbCastMultiSend / IbCastIsend:
      - Set slots pointer unconditionally to comm->ctsFifo[slot] (the base
        address is the same regardless of inline mode — only the intra-slot
        element stride differs)
      - Replace all direct slots[r].field accesses with accessor functions
    
    p2p.cc — IbCastPostFifo:
      - SGE addr always uses localElem (elems[slot] base address)
      - SGE length: MAX_INLINE_DATA_SIZE for CTS offload, otherwise
        n * sizeof(ncclIbSendFifoCtsInline) or n * sizeof(ncclIbSendFifo)
        based on IbCastAinicCtsInlineData
      - Clear IBV_SEND_INLINE when IbCastAinicCtsInlineData && n > 1,
        since QP max_inline_data is sized for a single 32B element
    
    p2p.cc — IbCastIrecv:
      - Change condition from useCtsOffload to IbCastAinicCtsInlineData
      - Access inline elements via direct cast (ncclIbSendFifoCtsInline*)
        with single indexing (fixes double-indexing bug)
      - Populate missing idx and rxReqIndex fields
      - Add narrowing casts matching ncclIbSendFifoCtsInline field widths

`JIRA ID : AICOMRCCL-1558` 
This also fixes JIRA ROCM-29123

## Test Plan
    Test matrix (RCCL test combinations to exercise the changed paths):
    -------------------------------------------------------------------
    All AINIC tests target Pollara nodes with NCCL_IB_AINIC_ROCE=1.
    
    1. AINIC + Inline (default AINIC path):
       RCCL_AINIC_ROCE=1 NCCL_IB_USE_INLINE=1
       rccl-tests: all_reduce_perf, all_gather_perf, sendrecv_perf
       → 32-byte CTS layout, accessor functions, idx/rxReqIndex population
    
    2. AINIC + CTS Offload (Inline auto-enabled):
       RCCL_AINIC_ROCE=1 RCCL_IB_CTS_OFFLOAD_ENABLED=1
       rccl-tests: all_reduce_perf, reduce_scatter_perf
       → CTS offload + inline, IbCastPostFifo with 32B stride
    
    3. AINIC + Inline disabled:
       RCCL_AINIC_ROCE=1 NCCL_IB_USE_INLINE=0 RCCL_IB_CTS_OFFLOAD_ENABLED=0
       rccl-tests: all_reduce_perf, all_gather_perf
       → 64-byte CTS layout, no-regression on AINIC without inline
    
    For all tests, vary message sizes (-b 1K -e 1G -f 2) to cover small (inline-eligible) and large transfer paths.
  

## Test Result

[RCCL_comparison_TOT_vs_inline-change_CTS-OFF-ENA_IB-INLINE-ENA_10aug.html](https://github.com/user-attachments/files/30945964/RCCL_comparison_TOT_vs_inline-change_CTS-OFF-ENA_IB-INLINE-ENA_10aug.html)
[RCCL_comparison_TOT_vs_inline-change_CTS-OFF-DIS_IB-INLINE-DIS_10aug.html](https://github.com/user-attachments/files/30945967/RCCL_comparison_TOT_vs_inline-change_CTS-OFF-DIS_IB-INLINE-DIS_10aug.html)

Note: In the report attached, for some collectives/msg sizes (like gather 256M or 2G/all_gather 64M) it would seem like perf reduced with the change; but that's an anomaly. Seeing run to run variation with those collectives and thus showed up as perf drop during the runs with the fix. Upon rerunning those collectives/msg sizes separately, I could see the same run to run variation even for tot (without the change).

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
