### PR TITLE
prototype(rocjitsu): lazy libc passthrough for early interposer calls

### DIFF
--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -147,6 +147,7 @@ jobs:
             "LoggingTest\.dispatch_logged"
             "ProfiledPluginTest\.hook_profile_output"
             "CvtNarrow\.AllTests"
+            "InterposerTest\..*"
             "RaceTest\..*"
           )
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -142,6 +142,7 @@ std::optional<std::string> child_config_path() {
 }
 
 void *raw_mmap_syscall(void *addr, size_t length, int prot, int flags, int fd, off_t offset) {
+  // syscall(2) is the libc wrapper: on kernel errors it returns -1 and sets errno.
   long rc = syscall(SYS_mmap, addr, length, prot, flags, fd, offset);
   if (rc == -1)
     return MAP_FAILED;
@@ -149,7 +150,9 @@ void *raw_mmap_syscall(void *addr, size_t length, int prot, int flags, int fd, o
 }
 
 int raw_munmap_syscall(void *addr, size_t length) {
-  return static_cast<int>(syscall(SYS_munmap, addr, length));
+  long rc = syscall(SYS_munmap, addr, length);
+  assert(rc == 0 || rc == -1);
+  return static_cast<int>(rc);
 }
 
 void rj_sigsegv_handler(int, siginfo_t *, void *) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -148,6 +148,10 @@ void *raw_mmap_syscall(void *addr, size_t length, int prot, int flags, int fd, o
   return reinterpret_cast<void *>(static_cast<uintptr_t>(rc));
 }
 
+int raw_munmap_syscall(void *addr, size_t length) {
+  return static_cast<int>(syscall(SYS_munmap, addr, length));
+}
+
 void rj_sigsegv_handler(int, siginfo_t *, void *) {
   signal(SIGSEGV, SIG_DFL);
   raise(SIGSEGV);
@@ -1247,6 +1251,9 @@ RJ_INTERPOSER_EXPORT int madvise(void *addr, size_t length, int advice) {
 }
 
 RJ_INTERPOSER_EXPORT int munmap(void *addr, size_t length) {
+  if (!InterposerContext::real().ready() || !InterposerContext::real().munmap)
+    return raw_munmap_syscall(addr, length);
+
   assert(InterposerContext::real().ready());
   if (auto *remote = InterposerContext::ctx.remote_lookup(InterposerContext::ctx.remote_kfd_fd())) {
     int ret = remote->munmap(addr, length);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -141,6 +141,13 @@ std::optional<std::string> child_config_path() {
   return std::string(cfg_buf);
 }
 
+void *raw_mmap_syscall(void *addr, size_t length, int prot, int flags, int fd, off_t offset) {
+  long rc = syscall(SYS_mmap, addr, length, prot, flags, fd, offset);
+  if (rc == -1)
+    return MAP_FAILED;
+  return reinterpret_cast<void *>(static_cast<uintptr_t>(rc));
+}
+
 void rj_sigsegv_handler(int, siginfo_t *, void *) {
   signal(SIGSEGV, SIG_DFL);
   raise(SIGSEGV);
@@ -1176,6 +1183,9 @@ RJ_INTERPOSER_EXPORT int fcntl64(int fd, int cmd, ...) {
 
 RJ_INTERPOSER_EXPORT void *mmap(void *addr, size_t length, int prot, int flags, int fd,
                                 off_t offset) {
+  if (!InterposerContext::real().ready() || !InterposerContext::real().mmap)
+    return raw_mmap_syscall(addr, length, prot, flags, fd, offset);
+
   assert(InterposerContext::real().ready());
   if (auto *remote = InterposerContext::ctx.remote_lookup(fd))
     return remote->mmap(addr, length, prot, flags, offset);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -141,20 +141,6 @@ std::optional<std::string> child_config_path() {
   return std::string(cfg_buf);
 }
 
-void *raw_mmap_syscall(void *addr, size_t length, int prot, int flags, int fd, off_t offset) {
-  // syscall(2) is the libc wrapper: on kernel errors it returns -1 and sets errno.
-  long rc = syscall(SYS_mmap, addr, length, prot, flags, fd, offset);
-  if (rc == -1)
-    return MAP_FAILED;
-  return reinterpret_cast<void *>(static_cast<uintptr_t>(rc));
-}
-
-int raw_munmap_syscall(void *addr, size_t length) {
-  long rc = syscall(SYS_munmap, addr, length);
-  assert(rc == 0 || rc == -1);
-  return static_cast<int>(rc);
-}
-
 void rj_sigsegv_handler(int, siginfo_t *, void *) {
   signal(SIGSEGV, SIG_DFL);
   raise(SIGSEGV);
@@ -177,7 +163,10 @@ public:
   static void init() {
     new (storage_) InterposerContext();
     real().resolve();
+    ready_.store(true, std::memory_order_release);
   }
+
+  static bool ready() { return ready_.load(std::memory_order_acquire); }
 
   /// @brief Reset interposer state in a forked child process.
   /// @details After fork(), the child inherits the parent's address space but
@@ -577,6 +566,7 @@ private:
   std::unordered_set<int> kfd_dup_fds_;
 
   alignas(16) static uint8_t storage_[];
+  static inline std::atomic<bool> ready_{false};
 };
 
 // Storage for the singleton is never destructed. Using aligned raw storage
@@ -688,9 +678,8 @@ RJ_INTERPOSER_EXPORT int open(const char *path, int flags, ...) {
     va_end(ap);
   }
 
-  assert(InterposerContext::real().ready());
   auto *volatile p = path;
-  if (!p || InterposerContext::in_construction)
+  if (!InterposerContext::ready() || !p || InterposerContext::in_construction)
     return InterposerContext::real().openat(AT_FDCWD, path, flags, mode);
 
   if (auto drm_fd = open_synthetic_drm_fd(path); drm_fd.handled)
@@ -761,7 +750,7 @@ RJ_INTERPOSER_EXPORT int openat(int dirfd, const char *path, int flags, ...) {
   }
 
   auto *volatile p_at = path;
-  if (!p_at)
+  if (!InterposerContext::ready() || !p_at)
     return InterposerContext::real().openat(dirfd, path, flags, mode);
   if (InterposerContext::in_construction)
     return InterposerContext::real().openat(dirfd, path, flags, mode);
@@ -805,7 +794,8 @@ RJ_INTERPOSER_EXPORT int openat64(int dirfd, const char *path, int flags, ...) {
 }
 
 RJ_INTERPOSER_EXPORT int close(int fd) {
-  assert(InterposerContext::real().ready());
+  if (!InterposerContext::ready())
+    return InterposerContext::real().close(fd);
   if (InterposerContext::ctx.remote_lookup(fd)) {
     // Closing the primary remote KFD fd drops one open reference; the synthetic
     // fd and RPC connection are torn down only when the last reference is
@@ -835,11 +825,13 @@ RJ_INTERPOSER_EXPORT int close(int fd) {
 __attribute__((destructor(101))) void rj_interposer_shutdown() {}
 
 RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
-  assert(InterposerContext::real().ready());
   va_list ap;
   va_start(ap, request);
   void *arg = va_arg(ap, void *);
   va_end(ap);
+
+  if (!InterposerContext::ready())
+    return InterposerContext::real().ioctl(fd, request, arg);
 
   constexpr unsigned kDrmIoctlType = 'd';
   constexpr unsigned kDrmIoctlNrVersion = 0x00;
@@ -1011,8 +1003,9 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
 }
 
 RJ_INTERPOSER_EXPORT int dup(int oldfd) {
-  assert(InterposerContext::real().ready());
   int rc = InterposerContext::real().dup(oldfd);
+  if (!InterposerContext::ready())
+    return rc;
   if (rc >= 0) {
     if (InterposerContext::ctx.is_kfd_tracked(oldfd))
       InterposerContext::ctx.track_dup(rc);
@@ -1023,12 +1016,13 @@ RJ_INTERPOSER_EXPORT int dup(int oldfd) {
 }
 
 RJ_INTERPOSER_EXPORT int dup2(int oldfd, int newfd) {
-  assert(InterposerContext::real().ready());
   // dup2(fd, fd) is a POSIX no-op that leaves the descriptor live; mutating
   // tracking would drop a still-open ref. Forward without touching tracking.
   if (oldfd == newfd)
     return InterposerContext::real().dup2(oldfd, newfd);
   int rc = InterposerContext::real().dup2(oldfd, newfd);
+  if (!InterposerContext::ready())
+    return rc;
   if (rc < 0)
     return rc;
   // newfd was atomically closed and replaced; reconcile its tracking only now.
@@ -1043,10 +1037,11 @@ RJ_INTERPOSER_EXPORT int dup2(int oldfd, int newfd) {
 
 #ifdef SYS_dup3
 RJ_INTERPOSER_EXPORT int dup3(int oldfd, int newfd, int flags) {
-  assert(InterposerContext::real().ready());
   // dup3(fd, fd, ...) is required to fail with EINVAL without altering the
   // descriptor; do not mutate tracking before the syscall confirms that.
   int rc = InterposerContext::real().dup3(oldfd, newfd, flags);
+  if (!InterposerContext::ready())
+    return rc;
   if (rc < 0)
     return rc;
   InterposerContext::ctx.untrack_sysfs(newfd);
@@ -1138,7 +1133,7 @@ int fcntl_impl(int fd, int cmd, void *ptr_arg, int int_arg) {
     break;
   }
 
-  if (rc >= 0 && (cmd == F_DUPFD || cmd == F_DUPFD_CLOEXEC)) {
+  if (InterposerContext::ready() && rc >= 0 && (cmd == F_DUPFD || cmd == F_DUPFD_CLOEXEC)) {
     if (InterposerContext::ctx.is_kfd_tracked(fd))
       InterposerContext::ctx.track_dup(static_cast<int>(rc));
     else
@@ -1156,7 +1151,6 @@ int fcntl_impl(int fd, int cmd, void *ptr_arg, int int_arg) {
 } // namespace
 
 RJ_INTERPOSER_EXPORT int fcntl(int fd, int cmd, ...) {
-  assert(InterposerContext::real().ready());
   va_list ap;
   va_start(ap, cmd);
   FcntlArgKind kind = fcntl_arg_kind(cmd);
@@ -1174,7 +1168,6 @@ RJ_INTERPOSER_EXPORT int fcntl(int fd, int cmd, ...) {
 // interposed separately or libdrm's F_DUPFD_CLOEXEC on the render fd bypasses
 // our dup tracking and subsequent ioctls land on an untracked fd.
 RJ_INTERPOSER_EXPORT int fcntl64(int fd, int cmd, ...) {
-  assert(InterposerContext::real().ready());
   va_list ap;
   va_start(ap, cmd);
   FcntlArgKind kind = fcntl_arg_kind(cmd);
@@ -1190,10 +1183,9 @@ RJ_INTERPOSER_EXPORT int fcntl64(int fd, int cmd, ...) {
 
 RJ_INTERPOSER_EXPORT void *mmap(void *addr, size_t length, int prot, int flags, int fd,
                                 off_t offset) {
-  if (!InterposerContext::real().ready() || !InterposerContext::real().mmap)
-    return raw_mmap_syscall(addr, length, prot, flags, fd, offset);
+  if (!InterposerContext::ready())
+    return InterposerContext::real().mmap(addr, length, prot, flags, fd, offset);
 
-  assert(InterposerContext::real().ready());
   if (auto *remote = InterposerContext::ctx.remote_lookup(fd))
     return remote->mmap(addr, length, prot, flags, offset);
 
@@ -1236,7 +1228,8 @@ RJ_INTERPOSER_EXPORT void *mmap(void *addr, size_t length, int prot, int flags, 
 }
 
 RJ_INTERPOSER_EXPORT int mprotect(void *addr, size_t length, int prot) {
-  assert(InterposerContext::real().ready());
+  if (!InterposerContext::ready())
+    return InterposerContext::real().mprotect(addr, length, prot);
   auto *drv = InterposerContext::ctx.driver();
   if (drv && drv->is_doorbell_range(addr, length)) {
     errno = EPERM;
@@ -1246,7 +1239,8 @@ RJ_INTERPOSER_EXPORT int mprotect(void *addr, size_t length, int prot) {
 }
 
 RJ_INTERPOSER_EXPORT int madvise(void *addr, size_t length, int advice) {
-  assert(InterposerContext::real().ready());
+  if (!InterposerContext::ready())
+    return InterposerContext::real().madvise(addr, length, advice);
   if ((advice == MADV_HUGEPAGE || advice == MADV_DONTFORK) &&
       reinterpret_cast<uintptr_t>(addr) >= 0x1000000000ULL)
     return 0;
@@ -1254,10 +1248,9 @@ RJ_INTERPOSER_EXPORT int madvise(void *addr, size_t length, int advice) {
 }
 
 RJ_INTERPOSER_EXPORT int munmap(void *addr, size_t length) {
-  if (!InterposerContext::real().ready() || !InterposerContext::real().munmap)
-    return raw_munmap_syscall(addr, length);
+  if (!InterposerContext::ready())
+    return InterposerContext::real().munmap(addr, length);
 
-  assert(InterposerContext::real().ready());
   if (auto *remote = InterposerContext::ctx.remote_lookup(InterposerContext::ctx.remote_kfd_fd())) {
     int ret = remote->munmap(addr, length);
     if (ret != -ENOENT)
@@ -1279,12 +1272,10 @@ extern "C" {
 // -- fopen / freopen interposition (sysfs redirect) --
 
 RJ_INTERPOSER_EXPORT FILE *fopen(const char *path, const char *mode) {
-  if (!InterposerContext::real().ready()) {
-    auto fn = util::lookup_symbol<FILE *(*)(const char *, const char *)>(RTLD_NEXT, "fopen");
-    return fn ? fn(path, mode) : nullptr;
-  }
   if (!path || !mode)
     return nullptr;
+  if (!InterposerContext::ready())
+    return InterposerContext::real().fopen(path, mode);
 
   const char *actual = path;
   std::string redirected;
@@ -1323,13 +1314,13 @@ RJ_INTERPOSER_EXPORT FILE *freopen64(const char *path, const char *mode, FILE *s
 // -- stat/lstat/access interposition --
 
 static std::string redirect_sysfs_path(const char *path) {
-  if (!path || !InterposerContext::real().ready() || InterposerContext::in_construction)
+  if (!path || !InterposerContext::ready() || InterposerContext::in_construction)
     return {};
   return InterposerContext::ctx.redirect_sysfs_path(path);
 }
 
 static std::string redirect_sys_dev_char(const char *path) {
-  if (!path || !InterposerContext::real().ready() || InterposerContext::in_construction)
+  if (!path || !InterposerContext::ready() || InterposerContext::in_construction)
     return {};
   std::string_view sv(path);
   constexpr std::string_view prefix = "/sys/dev/char/";
@@ -1385,7 +1376,7 @@ static const Sysfs::GpuInfo *interposer_gpu_info(uint32_t render_minor) {
 }
 
 static std::string redirect_dev_dri(const char *path) {
-  if (!path || !InterposerContext::real().ready() || InterposerContext::in_construction)
+  if (!path || !InterposerContext::ready() || InterposerContext::in_construction)
     return {};
   std::string_view sv(path);
   // Redirect both the /dev/dri directory and individual node files
@@ -1418,10 +1409,8 @@ static std::string redirect_dev_dri(const char *path) {
 }
 
 RJ_INTERPOSER_EXPORT int stat(const char *path, struct stat *buf) {
-  if (!InterposerContext::real().ready()) {
-    auto fn = util::lookup_symbol<int (*)(const char *, struct stat *)>(RTLD_NEXT, "stat");
-    return fn ? fn(path, buf) : -1;
-  }
+  if (!InterposerContext::ready())
+    return InterposerContext::real().stat(path, buf);
   auto redirected = redirect_sysfs_path(path);
   if (redirected.empty())
     redirected = redirect_sys_dev_char(path);
@@ -1433,10 +1422,8 @@ RJ_INTERPOSER_EXPORT int stat(const char *path, struct stat *buf) {
 }
 
 RJ_INTERPOSER_EXPORT int lstat(const char *path, struct stat *buf) {
-  if (!InterposerContext::real().ready()) {
-    auto fn = util::lookup_symbol<int (*)(const char *, struct stat *)>(RTLD_NEXT, "lstat");
-    return fn ? fn(path, buf) : -1;
-  }
+  if (!InterposerContext::ready())
+    return InterposerContext::real().lstat(path, buf);
   auto redirected = redirect_sysfs_path(path);
   if (redirected.empty())
     redirected = redirect_sys_dev_char(path);
@@ -1448,10 +1435,8 @@ RJ_INTERPOSER_EXPORT int lstat(const char *path, struct stat *buf) {
 }
 
 RJ_INTERPOSER_EXPORT int access(const char *path, int mode) {
-  if (!InterposerContext::real().ready()) {
-    auto fn = util::lookup_symbol<int (*)(const char *, int)>(RTLD_NEXT, "access");
-    return fn ? fn(path, mode) : -1;
-  }
+  if (!InterposerContext::ready())
+    return InterposerContext::real().access(path, mode);
   auto redirected = redirect_sysfs_path(path);
   if (redirected.empty())
     redirected = redirect_sys_dev_char(path);
@@ -1465,15 +1450,13 @@ RJ_INTERPOSER_EXPORT int access(const char *path, int mode) {
 // -- opendir interposition --
 
 RJ_INTERPOSER_EXPORT DIR *opendir(const char *name) {
-  if (!InterposerContext::real().ready()) {
-    auto fn = util::lookup_symbol<DIR *(*)(const char *)>(RTLD_NEXT, "opendir");
-    return fn ? fn(name) : nullptr;
-  }
   auto *volatile p_od = name;
   if (!p_od) {
     errno = EINVAL;
     return nullptr;
   }
+  if (!InterposerContext::ready())
+    return InterposerContext::real().opendir(name);
   if (!InterposerContext::in_construction) {
     std::string redirected = InterposerContext::ctx.redirect_sysfs_path(name);
     if (redirected.empty())
@@ -1489,12 +1472,8 @@ RJ_INTERPOSER_EXPORT DIR *opendir(const char *name) {
 // -- fstat interposition (DRM memfd → synthetic st_rdev) --
 
 RJ_INTERPOSER_EXPORT int fstat(int fd, struct stat *buf) {
-  if (!InterposerContext::real().ready()) {
-    auto fn = util::lookup_symbol<int (*)(int, struct stat *)>(RTLD_NEXT, "fstat");
-    return fn ? fn(fd, buf) : -1;
-  }
   int rc = InterposerContext::real().fstat_fn(fd, buf);
-  if (rc == 0 && InterposerContext::ctx.is_drm(fd)) {
+  if (rc == 0 && InterposerContext::ready() && InterposerContext::ctx.is_drm(fd)) {
     uint32_t render_minor = InterposerContext::ctx.drm_render_minor(fd);
     buf->st_rdev = makedev(226, render_minor);
     buf->st_mode = (buf->st_mode & ~S_IFMT) | S_IFCHR;
@@ -1508,7 +1487,7 @@ RJ_INTERPOSER_EXPORT int fstat64(int fd, struct stat64 *buf) {
   if (!real_fstat64)
     return -1;
   int rc = real_fstat64(fd, buf);
-  if (rc == 0 && InterposerContext::real().ready() && InterposerContext::ctx.is_drm(fd)) {
+  if (rc == 0 && InterposerContext::ready() && InterposerContext::ctx.is_drm(fd)) {
     uint32_t render_minor = InterposerContext::ctx.drm_render_minor(fd);
     buf->st_rdev = makedev(226, render_minor);
     buf->st_mode = (buf->st_mode & ~S_IFMT) | S_IFCHR;
@@ -1522,7 +1501,7 @@ RJ_INTERPOSER_EXPORT int __fxstat(int ver, int fd, struct stat *buf) {
   if (!real_fxstat)
     return -1;
   int rc = real_fxstat(ver, fd, buf);
-  if (rc == 0 && InterposerContext::real().ready() && InterposerContext::ctx.is_drm(fd)) {
+  if (rc == 0 && InterposerContext::ready() && InterposerContext::ctx.is_drm(fd)) {
     uint32_t render_minor = InterposerContext::ctx.drm_render_minor(fd);
     buf->st_rdev = makedev(226, render_minor);
     buf->st_mode = (buf->st_mode & ~S_IFMT) | S_IFCHR;
@@ -1536,7 +1515,7 @@ RJ_INTERPOSER_EXPORT int __fxstat64(int ver, int fd, struct stat64 *buf) {
   if (!real_fxstat64)
     return -1;
   int rc = real_fxstat64(ver, fd, buf);
-  if (rc == 0 && InterposerContext::real().ready() && InterposerContext::ctx.is_drm(fd)) {
+  if (rc == 0 && InterposerContext::ready() && InterposerContext::ctx.is_drm(fd)) {
     uint32_t render_minor = InterposerContext::ctx.drm_render_minor(fd);
     buf->st_rdev = makedev(226, render_minor);
     buf->st_mode = (buf->st_mode & ~S_IFMT) | S_IFCHR;
@@ -1547,10 +1526,8 @@ RJ_INTERPOSER_EXPORT int __fxstat64(int ver, int fd, struct stat64 *buf) {
 // -- readlink interposition (redirect /sys/dev/char/) --
 
 RJ_INTERPOSER_EXPORT ssize_t readlink(const char *path, char *buf, size_t bufsiz) {
-  if (!InterposerContext::real().ready()) {
-    auto fn = util::lookup_symbol<ssize_t (*)(const char *, char *, size_t)>(RTLD_NEXT, "readlink");
-    return fn ? fn(path, buf, bufsiz) : -1;
-  }
+  if (!InterposerContext::ready())
+    return InterposerContext::real().readlink_fn(path, buf, bufsiz);
   auto redirected = redirect_sys_dev_char(path);
   if (redirected.empty())
     redirected = redirect_sysfs_path(path);
@@ -1645,9 +1622,8 @@ RJ_INTERPOSER_EXPORT int __lxstat64(int ver, const char *path, struct stat64 *bu
 }
 
 RJ_INTERPOSER_EXPORT pid_t fork() {
-  assert(InterposerContext::real().ready());
   pid_t pid = InterposerContext::real().fork();
-  if (pid == 0)
+  if (pid == 0 && InterposerContext::ready())
     InterposerContext::ctx.reset_after_fork();
   return pid;
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/libc_passthrough.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/libc_passthrough.cpp
@@ -120,9 +120,7 @@ int LibcPassthrough::memfd_create(const char *name, unsigned int flags) {
 
 int LibcPassthrough::dup(int oldfd) { return resolve(dup_, "dup")(oldfd); }
 
-int LibcPassthrough::dup2(int oldfd, int newfd) {
-  return resolve(dup2_, "dup2")(oldfd, newfd);
-}
+int LibcPassthrough::dup2(int oldfd, int newfd) { return resolve(dup2_, "dup2")(oldfd, newfd); }
 
 int LibcPassthrough::dup3(int oldfd, int newfd, int flags) {
   return resolve(dup3_, "dup3")(oldfd, newfd, flags);
@@ -148,13 +146,9 @@ FILE *LibcPassthrough::freopen(const char *path, const char *mode, FILE *stream)
   return resolve(freopen_, "freopen")(path, mode, stream);
 }
 
-DIR *LibcPassthrough::opendir(const char *name) {
-  return resolve(opendir_, "opendir")(name);
-}
+DIR *LibcPassthrough::opendir(const char *name) { return resolve(opendir_, "opendir")(name); }
 
-struct dirent *LibcPassthrough::readdir(DIR *dirp) {
-  return resolve(readdir_, "readdir")(dirp);
-}
+struct dirent *LibcPassthrough::readdir(DIR *dirp) { return resolve(readdir_, "readdir")(dirp); }
 
 int LibcPassthrough::closedir(DIR *dirp) { return resolve(closedir_, "closedir")(dirp); }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/libc_passthrough.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/libc_passthrough.cpp
@@ -9,50 +9,176 @@
 #include "util/dynamic_loader.h"
 
 #include <cassert>
+#include <cstdint>
 #include <dlfcn.h>
+#include <sys/mman.h>
+#include <sys/syscall.h>
+#include <unistd.h>
 
 namespace rocjitsu {
 
+namespace {
+
+void *raw_mmap_syscall(void *addr, size_t length, int prot, int flags, int fd, off_t offset) {
+  // syscall(2) is the libc wrapper: on kernel errors it returns -1 and sets errno.
+  long rc = syscall(SYS_mmap, addr, length, prot, flags, fd, offset);
+  if (rc == -1)
+    return MAP_FAILED;
+  return reinterpret_cast<void *>(static_cast<uintptr_t>(rc));
+}
+
+int raw_munmap_syscall(void *addr, size_t length) {
+  long rc = syscall(SYS_munmap, addr, length);
+  assert(rc == 0 || rc == -1);
+  return static_cast<int>(rc);
+}
+
+} // namespace
+
+template <typename Fn> Fn LibcPassthrough::resolve(std::atomic<Fn> &slot, const char *name) {
+  if (auto fn = slot.load(std::memory_order_acquire))
+    return fn;
+  auto fn = util::lookup_symbol<Fn>(RTLD_NEXT, name);
+  assert(fn);
+  slot.store(fn, std::memory_order_release);
+  return fn;
+}
+
 void LibcPassthrough::resolve() {
-  if (initialized_)
+  if (ready())
     return;
 
-  auto *handle = RTLD_NEXT;
-  openat = util::lookup_symbol<decltype(openat)>(handle, "openat");
-  close = util::lookup_symbol<decltype(close)>(handle, "close");
-  read = util::lookup_symbol<decltype(read)>(handle, "read");
-  write = util::lookup_symbol<decltype(write)>(handle, "write");
-  ioctl = util::lookup_symbol<decltype(ioctl)>(handle, "ioctl");
-  mmap = util::lookup_symbol<decltype(mmap)>(handle, "mmap");
-  munmap = util::lookup_symbol<decltype(munmap)>(handle, "munmap");
-  mprotect = util::lookup_symbol<decltype(mprotect)>(handle, "mprotect");
-  madvise = util::lookup_symbol<decltype(madvise)>(handle, "madvise");
-  memfd_create = util::lookup_symbol<decltype(memfd_create)>(handle, "memfd_create");
-  dup = util::lookup_symbol<decltype(dup)>(handle, "dup");
-  dup2 = util::lookup_symbol<decltype(dup2)>(handle, "dup2");
-  dup3 = util::lookup_symbol<decltype(dup3)>(handle, "dup3");
-  fcntl = util::lookup_symbol<decltype(fcntl)>(handle, "fcntl");
-  fopen = util::lookup_symbol<decltype(fopen)>(handle, "fopen");
-  freopen = util::lookup_symbol<decltype(freopen)>(handle, "freopen");
-  opendir = util::lookup_symbol<decltype(opendir)>(handle, "opendir");
-  readdir = util::lookup_symbol<decltype(readdir)>(handle, "readdir");
-  closedir = util::lookup_symbol<decltype(closedir)>(handle, "closedir");
-  stat = util::lookup_symbol<decltype(stat)>(handle, "stat");
-  lstat = util::lookup_symbol<decltype(lstat)>(handle, "lstat");
-  access = util::lookup_symbol<decltype(access)>(handle, "access");
-  fstat_fn = util::lookup_symbol<decltype(fstat_fn)>(handle, "fstat");
-  readlink_fn = util::lookup_symbol<decltype(readlink_fn)>(handle, "readlink");
-  fork = util::lookup_symbol<decltype(fork)>(handle, "fork");
-  // Keep ready() false unless every required interposed libc entry point was
-  // resolved. In release builds the asserts disappear, so the boolean must not
-  // claim readiness while any later call would dereference a null function
-  // pointer.
-  initialized_ = openat && close && read && write && ioctl && mmap && munmap && mprotect &&
-                 madvise && memfd_create && dup && dup2 && dup3 && fcntl && fopen && freopen &&
-                 opendir && readdir && closedir && stat && lstat && access && fstat_fn &&
-                 readlink_fn && fork;
-  assert(initialized_);
+  static_cast<void>(resolve(openat_, "openat"));
+  static_cast<void>(resolve(close_, "close"));
+  static_cast<void>(resolve(read_, "read"));
+  static_cast<void>(resolve(write_, "write"));
+  static_cast<void>(resolve(ioctl_, "ioctl"));
+  static_cast<void>(resolve(mmap_, "mmap"));
+  static_cast<void>(resolve(munmap_, "munmap"));
+  static_cast<void>(resolve(mprotect_, "mprotect"));
+  static_cast<void>(resolve(madvise_, "madvise"));
+  static_cast<void>(resolve(memfd_create_, "memfd_create"));
+  static_cast<void>(resolve(dup_, "dup"));
+  static_cast<void>(resolve(dup2_, "dup2"));
+  static_cast<void>(resolve(dup3_, "dup3"));
+  static_cast<void>(resolve(fcntl_, "fcntl"));
+  static_cast<void>(resolve(fopen_, "fopen"));
+  static_cast<void>(resolve(freopen_, "freopen"));
+  static_cast<void>(resolve(opendir_, "opendir"));
+  static_cast<void>(resolve(readdir_, "readdir"));
+  static_cast<void>(resolve(closedir_, "closedir"));
+  static_cast<void>(resolve(stat_, "stat"));
+  static_cast<void>(resolve(lstat_, "lstat"));
+  static_cast<void>(resolve(access_, "access"));
+  static_cast<void>(resolve(fstat_, "fstat"));
+  static_cast<void>(resolve(readlink_, "readlink"));
+  static_cast<void>(resolve(fork_, "fork"));
+  initialized_.store(true, std::memory_order_release);
 }
+
+int LibcPassthrough::openat(int dirfd, const char *path, int flags, mode_t mode) {
+  return resolve(openat_, "openat")(dirfd, path, flags, mode);
+}
+
+int LibcPassthrough::close(int fd) { return resolve(close_, "close")(fd); }
+
+ssize_t LibcPassthrough::read(int fd, void *buf, size_t count) {
+  return resolve(read_, "read")(fd, buf, count);
+}
+
+ssize_t LibcPassthrough::write(int fd, const void *buf, size_t count) {
+  return resolve(write_, "write")(fd, buf, count);
+}
+
+int LibcPassthrough::ioctl(int fd, unsigned long request, void *arg) {
+  return resolve(ioctl_, "ioctl")(fd, request, arg);
+}
+
+void *LibcPassthrough::mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) {
+  if (auto fn = mmap_.load(std::memory_order_acquire))
+    return fn(addr, length, prot, flags, fd, offset);
+  return raw_mmap_syscall(addr, length, prot, flags, fd, offset);
+}
+
+int LibcPassthrough::munmap(void *addr, size_t length) {
+  if (auto fn = munmap_.load(std::memory_order_acquire))
+    return fn(addr, length);
+  return raw_munmap_syscall(addr, length);
+}
+
+int LibcPassthrough::mprotect(void *addr, size_t length, int prot) {
+  return resolve(mprotect_, "mprotect")(addr, length, prot);
+}
+
+int LibcPassthrough::madvise(void *addr, size_t length, int advice) {
+  return resolve(madvise_, "madvise")(addr, length, advice);
+}
+
+int LibcPassthrough::memfd_create(const char *name, unsigned int flags) {
+  return resolve(memfd_create_, "memfd_create")(name, flags);
+}
+
+int LibcPassthrough::dup(int oldfd) { return resolve(dup_, "dup")(oldfd); }
+
+int LibcPassthrough::dup2(int oldfd, int newfd) {
+  return resolve(dup2_, "dup2")(oldfd, newfd);
+}
+
+int LibcPassthrough::dup3(int oldfd, int newfd, int flags) {
+  return resolve(dup3_, "dup3")(oldfd, newfd, flags);
+}
+
+int LibcPassthrough::fcntl(int fd, int cmd, int arg) {
+  return resolve(fcntl_, "fcntl")(fd, cmd, arg);
+}
+
+int LibcPassthrough::fcntl(int fd, int cmd, long arg) {
+  return resolve(fcntl_, "fcntl")(fd, cmd, arg);
+}
+
+int LibcPassthrough::fcntl(int fd, int cmd, void *arg) {
+  return resolve(fcntl_, "fcntl")(fd, cmd, arg);
+}
+
+FILE *LibcPassthrough::fopen(const char *path, const char *mode) {
+  return resolve(fopen_, "fopen")(path, mode);
+}
+
+FILE *LibcPassthrough::freopen(const char *path, const char *mode, FILE *stream) {
+  return resolve(freopen_, "freopen")(path, mode, stream);
+}
+
+DIR *LibcPassthrough::opendir(const char *name) {
+  return resolve(opendir_, "opendir")(name);
+}
+
+struct dirent *LibcPassthrough::readdir(DIR *dirp) {
+  return resolve(readdir_, "readdir")(dirp);
+}
+
+int LibcPassthrough::closedir(DIR *dirp) { return resolve(closedir_, "closedir")(dirp); }
+
+int LibcPassthrough::stat(const char *path, struct stat *buf) {
+  return resolve(stat_, "stat")(path, buf);
+}
+
+int LibcPassthrough::lstat(const char *path, struct stat *buf) {
+  return resolve(lstat_, "lstat")(path, buf);
+}
+
+int LibcPassthrough::access(const char *path, int mode) {
+  return resolve(access_, "access")(path, mode);
+}
+
+int LibcPassthrough::fstat_fn(int fd, struct stat *buf) {
+  return resolve(fstat_, "fstat")(fd, buf);
+}
+
+ssize_t LibcPassthrough::readlink_fn(const char *path, char *buf, size_t bufsiz) {
+  return resolve(readlink_, "readlink")(path, buf, bufsiz);
+}
+
+pid_t LibcPassthrough::fork() { return resolve(fork_, "fork")(); }
 
 LibcPassthrough &libc_passthrough() {
   static LibcPassthrough real;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/libc_passthrough.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/libc_passthrough.h
@@ -31,7 +31,7 @@ public:
   /// @brief Resolve the real libc functions from the next dynamic object.
   void resolve();
 
-  int openat(int dirfd, const char *path, int flags, mode_t mode);
+  int openat(int dirfd, const char *path, int flags, mode_t mode = 0);
   int close(int fd);
   ssize_t read(int fd, void *buf, size_t count);
   ssize_t write(int fd, const void *buf, size_t count);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/libc_passthrough.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/libc_passthrough.h
@@ -7,6 +7,7 @@
 #ifndef ROCJITSU_KMD_LINUX_LIBC_PASSTHROUGH_H_
 #define ROCJITSU_KMD_LINUX_LIBC_PASSTHROUGH_H_
 
+#include <atomic>
 #include <cstddef>
 #include <cstdio>
 #include <dirent.h>
@@ -24,40 +25,95 @@ namespace rocjitsu {
 /// the wrappers.
 class LibcPassthrough {
 public:
-  int (*openat)(int, const char *, int, ...) = nullptr;
-  int (*close)(int) = nullptr;
-  ssize_t (*read)(int, void *, size_t) = nullptr;
-  ssize_t (*write)(int, const void *, size_t) = nullptr;
-  int (*ioctl)(int, unsigned long, ...) = nullptr;
-  void *(*mmap)(void *, size_t, int, int, int, off_t) = nullptr;
-  int (*munmap)(void *, size_t) = nullptr;
-  int (*mprotect)(void *, size_t, int) = nullptr;
-  int (*madvise)(void *, size_t, int) = nullptr;
-  int (*memfd_create)(const char *, unsigned int) = nullptr;
-  int (*dup)(int) = nullptr;
-  int (*dup2)(int, int) = nullptr;
-  int (*dup3)(int, int, int) = nullptr;
-  int (*fcntl)(int, int, ...) = nullptr;
-  FILE *(*fopen)(const char *, const char *) = nullptr;
-  FILE *(*freopen)(const char *, const char *, FILE *) = nullptr;
-  DIR *(*opendir)(const char *) = nullptr;
-  struct dirent *(*readdir)(DIR *) = nullptr;
-  int (*closedir)(DIR *) = nullptr;
-  int (*stat)(const char *, struct stat *) = nullptr;
-  int (*lstat)(const char *, struct stat *) = nullptr;
-  int (*access)(const char *, int) = nullptr;
-  int (*fstat_fn)(int, struct stat *) = nullptr;
-  ssize_t (*readlink_fn)(const char *, char *, size_t) = nullptr;
-  pid_t (*fork)() = nullptr;
-
   /// @brief Return true after all required symbols have been resolved.
-  [[nodiscard]] bool ready() const { return initialized_; }
+  [[nodiscard]] bool ready() const { return initialized_.load(std::memory_order_acquire); }
 
   /// @brief Resolve the real libc functions from the next dynamic object.
   void resolve();
 
+  int openat(int dirfd, const char *path, int flags, mode_t mode);
+  int close(int fd);
+  ssize_t read(int fd, void *buf, size_t count);
+  ssize_t write(int fd, const void *buf, size_t count);
+  int ioctl(int fd, unsigned long request, void *arg);
+  void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset);
+  int munmap(void *addr, size_t length);
+  int mprotect(void *addr, size_t length, int prot);
+  int madvise(void *addr, size_t length, int advice);
+  int memfd_create(const char *name, unsigned int flags);
+  int dup(int oldfd);
+  int dup2(int oldfd, int newfd);
+  int dup3(int oldfd, int newfd, int flags);
+  int fcntl(int fd, int cmd, int arg);
+  int fcntl(int fd, int cmd, long arg);
+  int fcntl(int fd, int cmd, void *arg);
+  FILE *fopen(const char *path, const char *mode);
+  FILE *freopen(const char *path, const char *mode, FILE *stream);
+  DIR *opendir(const char *name);
+  struct dirent *readdir(DIR *dirp);
+  int closedir(DIR *dirp);
+  int stat(const char *path, struct stat *buf);
+  int lstat(const char *path, struct stat *buf);
+  int access(const char *path, int mode);
+  int fstat_fn(int fd, struct stat *buf);
+  ssize_t readlink_fn(const char *path, char *buf, size_t bufsiz);
+  pid_t fork();
+
 private:
-  bool initialized_ = false;
+  using OpenatFn = int (*)(int, const char *, int, ...);
+  using CloseFn = int (*)(int);
+  using ReadFn = ssize_t (*)(int, void *, size_t);
+  using WriteFn = ssize_t (*)(int, const void *, size_t);
+  using IoctlFn = int (*)(int, unsigned long, ...);
+  using MmapFn = void *(*)(void *, size_t, int, int, int, off_t);
+  using MunmapFn = int (*)(void *, size_t);
+  using MprotectFn = int (*)(void *, size_t, int);
+  using MadviseFn = int (*)(void *, size_t, int);
+  using MemfdCreateFn = int (*)(const char *, unsigned int);
+  using DupFn = int (*)(int);
+  using Dup2Fn = int (*)(int, int);
+  using Dup3Fn = int (*)(int, int, int);
+  using FcntlFn = int (*)(int, int, ...);
+  using FopenFn = FILE *(*)(const char *, const char *);
+  using FreopenFn = FILE *(*)(const char *, const char *, FILE *);
+  using OpendirFn = DIR *(*)(const char *);
+  using ReaddirFn = struct dirent *(*)(DIR *);
+  using ClosedirFn = int (*)(DIR *);
+  using StatFn = int (*)(const char *, struct stat *);
+  using LstatFn = int (*)(const char *, struct stat *);
+  using AccessFn = int (*)(const char *, int);
+  using FstatFn = int (*)(int, struct stat *);
+  using ReadlinkFn = ssize_t (*)(const char *, char *, size_t);
+  using ForkFn = pid_t (*)();
+
+  template <typename Fn> static Fn resolve(std::atomic<Fn> &slot, const char *name);
+
+  std::atomic<OpenatFn> openat_{nullptr};
+  std::atomic<CloseFn> close_{nullptr};
+  std::atomic<ReadFn> read_{nullptr};
+  std::atomic<WriteFn> write_{nullptr};
+  std::atomic<IoctlFn> ioctl_{nullptr};
+  std::atomic<MmapFn> mmap_{nullptr};
+  std::atomic<MunmapFn> munmap_{nullptr};
+  std::atomic<MprotectFn> mprotect_{nullptr};
+  std::atomic<MadviseFn> madvise_{nullptr};
+  std::atomic<MemfdCreateFn> memfd_create_{nullptr};
+  std::atomic<DupFn> dup_{nullptr};
+  std::atomic<Dup2Fn> dup2_{nullptr};
+  std::atomic<Dup3Fn> dup3_{nullptr};
+  std::atomic<FcntlFn> fcntl_{nullptr};
+  std::atomic<FopenFn> fopen_{nullptr};
+  std::atomic<FreopenFn> freopen_{nullptr};
+  std::atomic<OpendirFn> opendir_{nullptr};
+  std::atomic<ReaddirFn> readdir_{nullptr};
+  std::atomic<ClosedirFn> closedir_{nullptr};
+  std::atomic<StatFn> stat_{nullptr};
+  std::atomic<LstatFn> lstat_{nullptr};
+  std::atomic<AccessFn> access_{nullptr};
+  std::atomic<FstatFn> fstat_{nullptr};
+  std::atomic<ReadlinkFn> readlink_{nullptr};
+  std::atomic<ForkFn> fork_{nullptr};
+  std::atomic<bool> initialized_{false};
 };
 
 /// @brief Return the process-wide libc pass-through table.

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -687,7 +687,7 @@ set_tests_properties(
     "InterposerTest.EarlyMmapBeforeRocjitsuConstructor"
     PROPERTIES
         ENVIRONMENT
-            "LD_PRELOAD=$<TARGET_FILE:early_mmap_preload>:$<TARGET_FILE:rocjitsu_shared>"
+            "LD_PRELOAD=$<TARGET_FILE:rocjitsu_shared>:$<TARGET_FILE:early_mmap_preload>"
 )
 
 # --- rocminfo test (requires rocminfo binary + HSA runtime + CLI launcher) ---

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -670,6 +670,23 @@ target_link_libraries(
 rj_configure_target(hsa_hooks_unit_test TEST)
 gtest_discover_tests(hsa_hooks_unit_test)
 
+# --- Interposer loader initialization regression tests ---
+
+add_library(early_mmap_preload SHARED early_mmap_preload_test.cpp)
+rj_configure_target(early_mmap_preload TEST)
+add_dependencies(early_mmap_preload rocjitsu_kmd_shim)
+
+add_test(
+    NAME "InterposerTest.EarlyMmapBeforeRocjitsuConstructor"
+    COMMAND /bin/true
+)
+set_tests_properties(
+    "InterposerTest.EarlyMmapBeforeRocjitsuConstructor"
+    PROPERTIES
+        ENVIRONMENT
+            "LD_PRELOAD=$<TARGET_FILE:early_mmap_preload>:$<TARGET_FILE:rocjitsu_kmd_shim>"
+)
+
 # --- rocminfo test (requires rocminfo binary + HSA runtime + CLI launcher) ---
 # Spawns rocminfo via the rocjitsu CLI and validates output.
 

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -679,15 +679,27 @@ add_dependencies(early_mmap_preload rocjitsu_shared)
 add_executable(early_mmap_driver early_mmap_driver_test.cpp)
 rj_configure_target(early_mmap_driver TEST)
 
-add_test(
+if(RJ_INSTALL_TESTS)
+    rj_install_test_target(early_mmap_driver)
+    install(
+        TARGETS early_mmap_preload
+        LIBRARY DESTINATION ${RJ_INSTALL_TEST_BIN_DIR}
+    )
+endif()
+
+# Keep rocjitsu first in LD_PRELOAD. The loader maps it before
+# early_mmap_preload, but runs early_mmap_preload's constructor before
+# init_interposer(). That constructor calls mmap/munmap early enough to exercise
+# the pre-init fallback; verifying the exact path directly would require adding
+# observable test state to the interposer.
+rj_add_test(
     NAME "InterposerTest.EarlyMmapBeforeRocjitsuConstructor"
     COMMAND $<TARGET_FILE:early_mmap_driver>
-)
-set_tests_properties(
-    "InterposerTest.EarlyMmapBeforeRocjitsuConstructor"
-    PROPERTIES
-        ENVIRONMENT
-            "LD_PRELOAD=$<TARGET_FILE:rocjitsu_shared>:$<TARGET_FILE:early_mmap_preload>"
+    ENVIRONMENT
+        "LD_PRELOAD=$<TARGET_FILE:rocjitsu_shared>:$<TARGET_FILE:early_mmap_preload>"
+    INSTALL_COMMAND "bin/early_mmap_driver"
+    INSTALL_ENVIRONMENT
+        "LD_PRELOAD=\${RJ_INSTALLED_LIBDIR}/${CMAKE_SHARED_LIBRARY_PREFIX}rocjitsu${CMAKE_SHARED_LIBRARY_SUFFIX}:bin/${CMAKE_SHARED_LIBRARY_PREFIX}early_mmap_preload${CMAKE_SHARED_LIBRARY_SUFFIX}"
 )
 
 # --- rocminfo test (requires rocminfo binary + HSA runtime + CLI launcher) ---

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -674,17 +674,20 @@ gtest_discover_tests(hsa_hooks_unit_test)
 
 add_library(early_mmap_preload SHARED early_mmap_preload_test.cpp)
 rj_configure_target(early_mmap_preload TEST)
-add_dependencies(early_mmap_preload rocjitsu_kmd_shim)
+add_dependencies(early_mmap_preload rocjitsu_shared)
+
+add_executable(early_mmap_driver early_mmap_driver_test.cpp)
+rj_configure_target(early_mmap_driver TEST)
 
 add_test(
     NAME "InterposerTest.EarlyMmapBeforeRocjitsuConstructor"
-    COMMAND /bin/true
+    COMMAND $<TARGET_FILE:early_mmap_driver>
 )
 set_tests_properties(
     "InterposerTest.EarlyMmapBeforeRocjitsuConstructor"
     PROPERTIES
         ENVIRONMENT
-            "LD_PRELOAD=$<TARGET_FILE:early_mmap_preload>:$<TARGET_FILE:rocjitsu_kmd_shim>"
+            "LD_PRELOAD=$<TARGET_FILE:early_mmap_preload>:$<TARGET_FILE:rocjitsu_shared>"
 )
 
 # --- rocminfo test (requires rocminfo binary + HSA runtime + CLI launcher) ---

--- a/emulation/rocjitsu/tests/early_mmap_driver_test.cpp
+++ b/emulation/rocjitsu/tests/early_mmap_driver_test.cpp
@@ -1,0 +1,7 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file early_mmap_driver_test.cpp
+/// @brief Minimal executable used by the early-mmap preload regression test.
+
+int main() { return 0; }

--- a/emulation/rocjitsu/tests/early_mmap_preload_test.cpp
+++ b/emulation/rocjitsu/tests/early_mmap_preload_test.cpp
@@ -4,16 +4,36 @@
 /// @file early_mmap_preload_test.cpp
 /// @brief Test helper whose constructor calls mmap before rocjitsu initializes.
 
+#include <cerrno>
+#include <cstdlib>
 #include <sys/mman.h>
 #include <unistd.h>
 
+namespace {
+
+template <size_t N> [[noreturn]] void fail(const char (&message)[N]) {
+  static_cast<void>(write(STDERR_FILENO, message, N - 1));
+  _exit(EXIT_FAILURE);
+}
+
+} // namespace
+
 __attribute__((constructor)) static void early_mmap_constructor() {
+  errno = 0;
+  if (mmap(nullptr, 0, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0) != MAP_FAILED ||
+      errno != EINVAL)
+    fail("early mmap preload: zero-length mmap did not fail with EINVAL\n");
+
   void *ptr = mmap(nullptr, 4096, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
   if (ptr == MAP_FAILED)
-    _exit(101);
+    fail("early mmap preload: mmap failed\n");
 
   static_cast<char *>(ptr)[0] = 7;
 
+  errno = 0;
+  if (munmap(ptr, 0) == 0 || errno != EINVAL)
+    fail("early mmap preload: zero-length munmap did not fail with EINVAL\n");
+
   if (munmap(ptr, 4096) != 0)
-    _exit(102);
+    fail("early mmap preload: munmap failed\n");
 }

--- a/emulation/rocjitsu/tests/early_mmap_preload_test.cpp
+++ b/emulation/rocjitsu/tests/early_mmap_preload_test.cpp
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file early_mmap_preload_test.cpp
+/// @brief Test helper whose constructor calls mmap before rocjitsu initializes.
+
+#include <sys/mman.h>
+#include <unistd.h>
+
+__attribute__((constructor)) static void early_mmap_constructor() {
+  void *ptr = mmap(nullptr, 4096, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  if (ptr == MAP_FAILED)
+    _exit(101);
+
+  static_cast<char *>(ptr)[0] = 7;
+
+  if (munmap(ptr, 4096) != 0)
+    _exit(102);
+}

--- a/emulation/rocjitsu/tests/early_mmap_preload_test.cpp
+++ b/emulation/rocjitsu/tests/early_mmap_preload_test.cpp
@@ -6,7 +6,9 @@
 
 #include <cerrno>
 #include <cstdlib>
+#include <fcntl.h>
 #include <sys/mman.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 namespace {
@@ -19,6 +21,31 @@ template <size_t N> [[noreturn]] void fail(const char (&message)[N]) {
 } // namespace
 
 __attribute__((constructor)) static void early_mmap_constructor() {
+  struct stat st {};
+  if (stat("/dev/null", &st) != 0)
+    fail("early mmap preload: stat failed\n");
+  if (access("/dev/null", R_OK) != 0)
+    fail("early mmap preload: access failed\n");
+
+  char link_target[256]{};
+  if (readlink("/proc/self/exe", link_target, sizeof(link_target)) <= 0)
+    fail("early mmap preload: readlink failed\n");
+
+  int fd = open("/dev/null", O_RDONLY | O_CLOEXEC);
+  if (fd < 0)
+    fail("early mmap preload: open failed\n");
+  if (fstat(fd, &st) != 0)
+    fail("early mmap preload: fstat failed\n");
+  int dup_fd = dup(fd);
+  if (dup_fd < 0)
+    fail("early mmap preload: dup failed\n");
+  if (fcntl(dup_fd, F_GETFD, 0) < 0)
+    fail("early mmap preload: fcntl failed\n");
+  if (close(dup_fd) != 0)
+    fail("early mmap preload: close dup failed\n");
+  if (close(fd) != 0)
+    fail("early mmap preload: close fd failed\n");
+
   errno = 0;
   if (mmap(nullptr, 0, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0) != MAP_FAILED ||
       errno != EINVAL)

--- a/emulation/rocjitsu/tests/early_mmap_preload_test.cpp
+++ b/emulation/rocjitsu/tests/early_mmap_preload_test.cpp
@@ -14,7 +14,8 @@
 namespace {
 
 template <size_t N> [[noreturn]] void fail(const char (&message)[N]) {
-  static_cast<void>(write(STDERR_FILENO, message, N - 1));
+  ssize_t ignored = write(STDERR_FILENO, message, N - 1);
+  static_cast<void>(ignored);
   _exit(EXIT_FAILURE);
 }
 


### PR DESCRIPTION
ISSUE ID: #8037

## Summary

Prototype an alternative to #8035 that addresses the review discussion there by making libc passthroughs lazy and self-resolving.

Most wrappers resolve their real libc target on first use. `mmap()` and `munmap()` stay special because `dlsym()` may allocate, so their pre-resolution path uses the existing raw `syscall(2)` fallback.

This also separates libc symbol readiness from interposer context readiness, so early libc passthrough calls do not touch rocjitsu interposer state before the context is ready.

## Notes

This is a draft comparison PR for the review thread on #8035. It is not necessarily the recommended final shape.

Tradeoff: the lifecycle model is cleaner, but this adds a typed accessor layer around `LibcPassthrough`.

## Testing

```bash
cmake --build <build-dir> --parallel 8 --target \
  rocjitsu_shared early_mmap_preload early_mmap_driver rocjitsu_bin

ctest --test-dir <build-dir> \
  -R 'InterposerTest\.EarlyMmapBeforeRocjitsuConstructor' \
  --output-on-failure

pre-commit run --files \
  emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp \
  emulation/rocjitsu/tests/early_mmap_preload_test.cpp
```

Also verified `hipblaslt-bench --help` exits successfully through the rocjitsu launcher.
