### PR TITLE
prototype(rocjitsu): split interposer readiness from libc readiness

### DIFF
--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -147,6 +147,7 @@ jobs:
             "LoggingTest\.dispatch_logged"
             "ProfiledPluginTest\.hook_profile_output"
             "CvtNarrow\.AllTests"
+            "InterposerTest\..*"
             "RaceTest\..*"
           )
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -142,6 +142,7 @@ std::optional<std::string> child_config_path() {
 }
 
 void *raw_mmap_syscall(void *addr, size_t length, int prot, int flags, int fd, off_t offset) {
+  // syscall(2) is the libc wrapper: on kernel errors it returns -1 and sets errno.
   long rc = syscall(SYS_mmap, addr, length, prot, flags, fd, offset);
   if (rc == -1)
     return MAP_FAILED;
@@ -149,7 +150,9 @@ void *raw_mmap_syscall(void *addr, size_t length, int prot, int flags, int fd, o
 }
 
 int raw_munmap_syscall(void *addr, size_t length) {
-  return static_cast<int>(syscall(SYS_munmap, addr, length));
+  long rc = syscall(SYS_munmap, addr, length);
+  assert(rc == 0 || rc == -1);
+  return static_cast<int>(rc);
 }
 
 void rj_sigsegv_handler(int, siginfo_t *, void *) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -148,6 +148,10 @@ void *raw_mmap_syscall(void *addr, size_t length, int prot, int flags, int fd, o
   return reinterpret_cast<void *>(static_cast<uintptr_t>(rc));
 }
 
+int raw_munmap_syscall(void *addr, size_t length) {
+  return static_cast<int>(syscall(SYS_munmap, addr, length));
+}
+
 void rj_sigsegv_handler(int, siginfo_t *, void *) {
   signal(SIGSEGV, SIG_DFL);
   raise(SIGSEGV);
@@ -1247,6 +1251,9 @@ RJ_INTERPOSER_EXPORT int madvise(void *addr, size_t length, int advice) {
 }
 
 RJ_INTERPOSER_EXPORT int munmap(void *addr, size_t length) {
+  if (!InterposerContext::real().ready() || !InterposerContext::real().munmap)
+    return raw_munmap_syscall(addr, length);
+
   assert(InterposerContext::real().ready());
   if (auto *remote = InterposerContext::ctx.remote_lookup(InterposerContext::ctx.remote_kfd_fd())) {
     int ret = remote->munmap(addr, length);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -141,6 +141,13 @@ std::optional<std::string> child_config_path() {
   return std::string(cfg_buf);
 }
 
+void *raw_mmap_syscall(void *addr, size_t length, int prot, int flags, int fd, off_t offset) {
+  long rc = syscall(SYS_mmap, addr, length, prot, flags, fd, offset);
+  if (rc == -1)
+    return MAP_FAILED;
+  return reinterpret_cast<void *>(static_cast<uintptr_t>(rc));
+}
+
 void rj_sigsegv_handler(int, siginfo_t *, void *) {
   signal(SIGSEGV, SIG_DFL);
   raise(SIGSEGV);
@@ -1176,6 +1183,9 @@ RJ_INTERPOSER_EXPORT int fcntl64(int fd, int cmd, ...) {
 
 RJ_INTERPOSER_EXPORT void *mmap(void *addr, size_t length, int prot, int flags, int fd,
                                 off_t offset) {
+  if (!InterposerContext::real().ready() || !InterposerContext::real().mmap)
+    return raw_mmap_syscall(addr, length, prot, flags, fd, offset);
+
   assert(InterposerContext::real().ready());
   if (auto *remote = InterposerContext::ctx.remote_lookup(fd))
     return remote->mmap(addr, length, prot, flags, offset);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -177,7 +177,10 @@ public:
   static void init() {
     new (storage_) InterposerContext();
     real().resolve();
+    ready_.store(true, std::memory_order_release);
   }
+
+  static bool ready() { return ready_.load(std::memory_order_acquire); }
 
   /// @brief Reset interposer state in a forked child process.
   /// @details After fork(), the child inherits the parent's address space but
@@ -577,6 +580,7 @@ private:
   std::unordered_set<int> kfd_dup_fds_;
 
   alignas(16) static uint8_t storage_[];
+  static inline std::atomic<bool> ready_{false};
 };
 
 // Storage for the singleton is never destructed. Using aligned raw storage
@@ -688,7 +692,7 @@ RJ_INTERPOSER_EXPORT int open(const char *path, int flags, ...) {
     va_end(ap);
   }
 
-  assert(InterposerContext::real().ready());
+  assert(InterposerContext::ready());
   auto *volatile p = path;
   if (!p || InterposerContext::in_construction)
     return InterposerContext::real().openat(AT_FDCWD, path, flags, mode);
@@ -805,7 +809,7 @@ RJ_INTERPOSER_EXPORT int openat64(int dirfd, const char *path, int flags, ...) {
 }
 
 RJ_INTERPOSER_EXPORT int close(int fd) {
-  assert(InterposerContext::real().ready());
+  assert(InterposerContext::ready());
   if (InterposerContext::ctx.remote_lookup(fd)) {
     // Closing the primary remote KFD fd drops one open reference; the synthetic
     // fd and RPC connection are torn down only when the last reference is
@@ -835,7 +839,7 @@ RJ_INTERPOSER_EXPORT int close(int fd) {
 __attribute__((destructor(101))) void rj_interposer_shutdown() {}
 
 RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
-  assert(InterposerContext::real().ready());
+  assert(InterposerContext::ready());
   va_list ap;
   va_start(ap, request);
   void *arg = va_arg(ap, void *);
@@ -1011,7 +1015,7 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
 }
 
 RJ_INTERPOSER_EXPORT int dup(int oldfd) {
-  assert(InterposerContext::real().ready());
+  assert(InterposerContext::ready());
   int rc = InterposerContext::real().dup(oldfd);
   if (rc >= 0) {
     if (InterposerContext::ctx.is_kfd_tracked(oldfd))
@@ -1023,7 +1027,7 @@ RJ_INTERPOSER_EXPORT int dup(int oldfd) {
 }
 
 RJ_INTERPOSER_EXPORT int dup2(int oldfd, int newfd) {
-  assert(InterposerContext::real().ready());
+  assert(InterposerContext::ready());
   // dup2(fd, fd) is a POSIX no-op that leaves the descriptor live; mutating
   // tracking would drop a still-open ref. Forward without touching tracking.
   if (oldfd == newfd)
@@ -1043,7 +1047,7 @@ RJ_INTERPOSER_EXPORT int dup2(int oldfd, int newfd) {
 
 #ifdef SYS_dup3
 RJ_INTERPOSER_EXPORT int dup3(int oldfd, int newfd, int flags) {
-  assert(InterposerContext::real().ready());
+  assert(InterposerContext::ready());
   // dup3(fd, fd, ...) is required to fail with EINVAL without altering the
   // descriptor; do not mutate tracking before the syscall confirms that.
   int rc = InterposerContext::real().dup3(oldfd, newfd, flags);
@@ -1156,7 +1160,7 @@ int fcntl_impl(int fd, int cmd, void *ptr_arg, int int_arg) {
 } // namespace
 
 RJ_INTERPOSER_EXPORT int fcntl(int fd, int cmd, ...) {
-  assert(InterposerContext::real().ready());
+  assert(InterposerContext::ready());
   va_list ap;
   va_start(ap, cmd);
   FcntlArgKind kind = fcntl_arg_kind(cmd);
@@ -1174,7 +1178,7 @@ RJ_INTERPOSER_EXPORT int fcntl(int fd, int cmd, ...) {
 // interposed separately or libdrm's F_DUPFD_CLOEXEC on the render fd bypasses
 // our dup tracking and subsequent ioctls land on an untracked fd.
 RJ_INTERPOSER_EXPORT int fcntl64(int fd, int cmd, ...) {
-  assert(InterposerContext::real().ready());
+  assert(InterposerContext::ready());
   va_list ap;
   va_start(ap, cmd);
   FcntlArgKind kind = fcntl_arg_kind(cmd);
@@ -1190,10 +1194,9 @@ RJ_INTERPOSER_EXPORT int fcntl64(int fd, int cmd, ...) {
 
 RJ_INTERPOSER_EXPORT void *mmap(void *addr, size_t length, int prot, int flags, int fd,
                                 off_t offset) {
-  if (!InterposerContext::real().ready() || !InterposerContext::real().mmap)
+  if (!InterposerContext::ready())
     return raw_mmap_syscall(addr, length, prot, flags, fd, offset);
 
-  assert(InterposerContext::real().ready());
   if (auto *remote = InterposerContext::ctx.remote_lookup(fd))
     return remote->mmap(addr, length, prot, flags, offset);
 
@@ -1236,7 +1239,7 @@ RJ_INTERPOSER_EXPORT void *mmap(void *addr, size_t length, int prot, int flags, 
 }
 
 RJ_INTERPOSER_EXPORT int mprotect(void *addr, size_t length, int prot) {
-  assert(InterposerContext::real().ready());
+  assert(InterposerContext::ready());
   auto *drv = InterposerContext::ctx.driver();
   if (drv && drv->is_doorbell_range(addr, length)) {
     errno = EPERM;
@@ -1246,7 +1249,7 @@ RJ_INTERPOSER_EXPORT int mprotect(void *addr, size_t length, int prot) {
 }
 
 RJ_INTERPOSER_EXPORT int madvise(void *addr, size_t length, int advice) {
-  assert(InterposerContext::real().ready());
+  assert(InterposerContext::ready());
   if ((advice == MADV_HUGEPAGE || advice == MADV_DONTFORK) &&
       reinterpret_cast<uintptr_t>(addr) >= 0x1000000000ULL)
     return 0;
@@ -1254,10 +1257,9 @@ RJ_INTERPOSER_EXPORT int madvise(void *addr, size_t length, int advice) {
 }
 
 RJ_INTERPOSER_EXPORT int munmap(void *addr, size_t length) {
-  if (!InterposerContext::real().ready() || !InterposerContext::real().munmap)
+  if (!InterposerContext::ready())
     return raw_munmap_syscall(addr, length);
 
-  assert(InterposerContext::real().ready());
   if (auto *remote = InterposerContext::ctx.remote_lookup(InterposerContext::ctx.remote_kfd_fd())) {
     int ret = remote->munmap(addr, length);
     if (ret != -ENOENT)
@@ -1279,7 +1281,7 @@ extern "C" {
 // -- fopen / freopen interposition (sysfs redirect) --
 
 RJ_INTERPOSER_EXPORT FILE *fopen(const char *path, const char *mode) {
-  if (!InterposerContext::real().ready()) {
+  if (!InterposerContext::ready()) {
     auto fn = util::lookup_symbol<FILE *(*)(const char *, const char *)>(RTLD_NEXT, "fopen");
     return fn ? fn(path, mode) : nullptr;
   }
@@ -1323,13 +1325,13 @@ RJ_INTERPOSER_EXPORT FILE *freopen64(const char *path, const char *mode, FILE *s
 // -- stat/lstat/access interposition --
 
 static std::string redirect_sysfs_path(const char *path) {
-  if (!path || !InterposerContext::real().ready() || InterposerContext::in_construction)
+  if (!path || !InterposerContext::ready() || InterposerContext::in_construction)
     return {};
   return InterposerContext::ctx.redirect_sysfs_path(path);
 }
 
 static std::string redirect_sys_dev_char(const char *path) {
-  if (!path || !InterposerContext::real().ready() || InterposerContext::in_construction)
+  if (!path || !InterposerContext::ready() || InterposerContext::in_construction)
     return {};
   std::string_view sv(path);
   constexpr std::string_view prefix = "/sys/dev/char/";
@@ -1385,7 +1387,7 @@ static const Sysfs::GpuInfo *interposer_gpu_info(uint32_t render_minor) {
 }
 
 static std::string redirect_dev_dri(const char *path) {
-  if (!path || !InterposerContext::real().ready() || InterposerContext::in_construction)
+  if (!path || !InterposerContext::ready() || InterposerContext::in_construction)
     return {};
   std::string_view sv(path);
   // Redirect both the /dev/dri directory and individual node files
@@ -1418,7 +1420,7 @@ static std::string redirect_dev_dri(const char *path) {
 }
 
 RJ_INTERPOSER_EXPORT int stat(const char *path, struct stat *buf) {
-  if (!InterposerContext::real().ready()) {
+  if (!InterposerContext::ready()) {
     auto fn = util::lookup_symbol<int (*)(const char *, struct stat *)>(RTLD_NEXT, "stat");
     return fn ? fn(path, buf) : -1;
   }
@@ -1433,7 +1435,7 @@ RJ_INTERPOSER_EXPORT int stat(const char *path, struct stat *buf) {
 }
 
 RJ_INTERPOSER_EXPORT int lstat(const char *path, struct stat *buf) {
-  if (!InterposerContext::real().ready()) {
+  if (!InterposerContext::ready()) {
     auto fn = util::lookup_symbol<int (*)(const char *, struct stat *)>(RTLD_NEXT, "lstat");
     return fn ? fn(path, buf) : -1;
   }
@@ -1448,7 +1450,7 @@ RJ_INTERPOSER_EXPORT int lstat(const char *path, struct stat *buf) {
 }
 
 RJ_INTERPOSER_EXPORT int access(const char *path, int mode) {
-  if (!InterposerContext::real().ready()) {
+  if (!InterposerContext::ready()) {
     auto fn = util::lookup_symbol<int (*)(const char *, int)>(RTLD_NEXT, "access");
     return fn ? fn(path, mode) : -1;
   }
@@ -1465,7 +1467,7 @@ RJ_INTERPOSER_EXPORT int access(const char *path, int mode) {
 // -- opendir interposition --
 
 RJ_INTERPOSER_EXPORT DIR *opendir(const char *name) {
-  if (!InterposerContext::real().ready()) {
+  if (!InterposerContext::ready()) {
     auto fn = util::lookup_symbol<DIR *(*)(const char *)>(RTLD_NEXT, "opendir");
     return fn ? fn(name) : nullptr;
   }
@@ -1489,7 +1491,7 @@ RJ_INTERPOSER_EXPORT DIR *opendir(const char *name) {
 // -- fstat interposition (DRM memfd → synthetic st_rdev) --
 
 RJ_INTERPOSER_EXPORT int fstat(int fd, struct stat *buf) {
-  if (!InterposerContext::real().ready()) {
+  if (!InterposerContext::ready()) {
     auto fn = util::lookup_symbol<int (*)(int, struct stat *)>(RTLD_NEXT, "fstat");
     return fn ? fn(fd, buf) : -1;
   }
@@ -1508,7 +1510,7 @@ RJ_INTERPOSER_EXPORT int fstat64(int fd, struct stat64 *buf) {
   if (!real_fstat64)
     return -1;
   int rc = real_fstat64(fd, buf);
-  if (rc == 0 && InterposerContext::real().ready() && InterposerContext::ctx.is_drm(fd)) {
+  if (rc == 0 && InterposerContext::ready() && InterposerContext::ctx.is_drm(fd)) {
     uint32_t render_minor = InterposerContext::ctx.drm_render_minor(fd);
     buf->st_rdev = makedev(226, render_minor);
     buf->st_mode = (buf->st_mode & ~S_IFMT) | S_IFCHR;
@@ -1522,7 +1524,7 @@ RJ_INTERPOSER_EXPORT int __fxstat(int ver, int fd, struct stat *buf) {
   if (!real_fxstat)
     return -1;
   int rc = real_fxstat(ver, fd, buf);
-  if (rc == 0 && InterposerContext::real().ready() && InterposerContext::ctx.is_drm(fd)) {
+  if (rc == 0 && InterposerContext::ready() && InterposerContext::ctx.is_drm(fd)) {
     uint32_t render_minor = InterposerContext::ctx.drm_render_minor(fd);
     buf->st_rdev = makedev(226, render_minor);
     buf->st_mode = (buf->st_mode & ~S_IFMT) | S_IFCHR;
@@ -1536,7 +1538,7 @@ RJ_INTERPOSER_EXPORT int __fxstat64(int ver, int fd, struct stat64 *buf) {
   if (!real_fxstat64)
     return -1;
   int rc = real_fxstat64(ver, fd, buf);
-  if (rc == 0 && InterposerContext::real().ready() && InterposerContext::ctx.is_drm(fd)) {
+  if (rc == 0 && InterposerContext::ready() && InterposerContext::ctx.is_drm(fd)) {
     uint32_t render_minor = InterposerContext::ctx.drm_render_minor(fd);
     buf->st_rdev = makedev(226, render_minor);
     buf->st_mode = (buf->st_mode & ~S_IFMT) | S_IFCHR;
@@ -1547,7 +1549,7 @@ RJ_INTERPOSER_EXPORT int __fxstat64(int ver, int fd, struct stat64 *buf) {
 // -- readlink interposition (redirect /sys/dev/char/) --
 
 RJ_INTERPOSER_EXPORT ssize_t readlink(const char *path, char *buf, size_t bufsiz) {
-  if (!InterposerContext::real().ready()) {
+  if (!InterposerContext::ready()) {
     auto fn = util::lookup_symbol<ssize_t (*)(const char *, char *, size_t)>(RTLD_NEXT, "readlink");
     return fn ? fn(path, buf, bufsiz) : -1;
   }
@@ -1645,7 +1647,7 @@ RJ_INTERPOSER_EXPORT int __lxstat64(int ver, const char *path, struct stat64 *bu
 }
 
 RJ_INTERPOSER_EXPORT pid_t fork() {
-  assert(InterposerContext::real().ready());
+  assert(InterposerContext::ready());
   pid_t pid = InterposerContext::real().fork();
   if (pid == 0)
     InterposerContext::ctx.reset_after_fork();

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -687,7 +687,7 @@ set_tests_properties(
     "InterposerTest.EarlyMmapBeforeRocjitsuConstructor"
     PROPERTIES
         ENVIRONMENT
-            "LD_PRELOAD=$<TARGET_FILE:early_mmap_preload>:$<TARGET_FILE:rocjitsu_shared>"
+            "LD_PRELOAD=$<TARGET_FILE:rocjitsu_shared>:$<TARGET_FILE:early_mmap_preload>"
 )
 
 # --- rocminfo test (requires rocminfo binary + HSA runtime + CLI launcher) ---

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -670,6 +670,23 @@ target_link_libraries(
 rj_configure_target(hsa_hooks_unit_test TEST)
 gtest_discover_tests(hsa_hooks_unit_test)
 
+# --- Interposer loader initialization regression tests ---
+
+add_library(early_mmap_preload SHARED early_mmap_preload_test.cpp)
+rj_configure_target(early_mmap_preload TEST)
+add_dependencies(early_mmap_preload rocjitsu_kmd_shim)
+
+add_test(
+    NAME "InterposerTest.EarlyMmapBeforeRocjitsuConstructor"
+    COMMAND /bin/true
+)
+set_tests_properties(
+    "InterposerTest.EarlyMmapBeforeRocjitsuConstructor"
+    PROPERTIES
+        ENVIRONMENT
+            "LD_PRELOAD=$<TARGET_FILE:early_mmap_preload>:$<TARGET_FILE:rocjitsu_kmd_shim>"
+)
+
 # --- rocminfo test (requires rocminfo binary + HSA runtime + CLI launcher) ---
 # Spawns rocminfo via the rocjitsu CLI and validates output.
 

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -679,15 +679,27 @@ add_dependencies(early_mmap_preload rocjitsu_shared)
 add_executable(early_mmap_driver early_mmap_driver_test.cpp)
 rj_configure_target(early_mmap_driver TEST)
 
-add_test(
+if(RJ_INSTALL_TESTS)
+    rj_install_test_target(early_mmap_driver)
+    install(
+        TARGETS early_mmap_preload
+        LIBRARY DESTINATION ${RJ_INSTALL_TEST_BIN_DIR}
+    )
+endif()
+
+# Keep rocjitsu first in LD_PRELOAD. The loader maps it before
+# early_mmap_preload, but runs early_mmap_preload's constructor before
+# init_interposer(). That constructor calls mmap/munmap early enough to exercise
+# the pre-init fallback; verifying the exact path directly would require adding
+# observable test state to the interposer.
+rj_add_test(
     NAME "InterposerTest.EarlyMmapBeforeRocjitsuConstructor"
     COMMAND $<TARGET_FILE:early_mmap_driver>
-)
-set_tests_properties(
-    "InterposerTest.EarlyMmapBeforeRocjitsuConstructor"
-    PROPERTIES
-        ENVIRONMENT
-            "LD_PRELOAD=$<TARGET_FILE:rocjitsu_shared>:$<TARGET_FILE:early_mmap_preload>"
+    ENVIRONMENT
+        "LD_PRELOAD=$<TARGET_FILE:rocjitsu_shared>:$<TARGET_FILE:early_mmap_preload>"
+    INSTALL_COMMAND "bin/early_mmap_driver"
+    INSTALL_ENVIRONMENT
+        "LD_PRELOAD=\${RJ_INSTALLED_LIBDIR}/${CMAKE_SHARED_LIBRARY_PREFIX}rocjitsu${CMAKE_SHARED_LIBRARY_SUFFIX}:bin/${CMAKE_SHARED_LIBRARY_PREFIX}early_mmap_preload${CMAKE_SHARED_LIBRARY_SUFFIX}"
 )
 
 # --- rocminfo test (requires rocminfo binary + HSA runtime + CLI launcher) ---

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -674,17 +674,20 @@ gtest_discover_tests(hsa_hooks_unit_test)
 
 add_library(early_mmap_preload SHARED early_mmap_preload_test.cpp)
 rj_configure_target(early_mmap_preload TEST)
-add_dependencies(early_mmap_preload rocjitsu_kmd_shim)
+add_dependencies(early_mmap_preload rocjitsu_shared)
+
+add_executable(early_mmap_driver early_mmap_driver_test.cpp)
+rj_configure_target(early_mmap_driver TEST)
 
 add_test(
     NAME "InterposerTest.EarlyMmapBeforeRocjitsuConstructor"
-    COMMAND /bin/true
+    COMMAND $<TARGET_FILE:early_mmap_driver>
 )
 set_tests_properties(
     "InterposerTest.EarlyMmapBeforeRocjitsuConstructor"
     PROPERTIES
         ENVIRONMENT
-            "LD_PRELOAD=$<TARGET_FILE:early_mmap_preload>:$<TARGET_FILE:rocjitsu_kmd_shim>"
+            "LD_PRELOAD=$<TARGET_FILE:early_mmap_preload>:$<TARGET_FILE:rocjitsu_shared>"
 )
 
 # --- rocminfo test (requires rocminfo binary + HSA runtime + CLI launcher) ---

--- a/emulation/rocjitsu/tests/early_mmap_driver_test.cpp
+++ b/emulation/rocjitsu/tests/early_mmap_driver_test.cpp
@@ -1,0 +1,7 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file early_mmap_driver_test.cpp
+/// @brief Minimal executable used by the early-mmap preload regression test.
+
+int main() { return 0; }

--- a/emulation/rocjitsu/tests/early_mmap_preload_test.cpp
+++ b/emulation/rocjitsu/tests/early_mmap_preload_test.cpp
@@ -4,16 +4,36 @@
 /// @file early_mmap_preload_test.cpp
 /// @brief Test helper whose constructor calls mmap before rocjitsu initializes.
 
+#include <cerrno>
+#include <cstdlib>
 #include <sys/mman.h>
 #include <unistd.h>
 
+namespace {
+
+template <size_t N> [[noreturn]] void fail(const char (&message)[N]) {
+  static_cast<void>(write(STDERR_FILENO, message, N - 1));
+  _exit(EXIT_FAILURE);
+}
+
+} // namespace
+
 __attribute__((constructor)) static void early_mmap_constructor() {
+  errno = 0;
+  if (mmap(nullptr, 0, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0) != MAP_FAILED ||
+      errno != EINVAL)
+    fail("early mmap preload: zero-length mmap did not fail with EINVAL\n");
+
   void *ptr = mmap(nullptr, 4096, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
   if (ptr == MAP_FAILED)
-    _exit(101);
+    fail("early mmap preload: mmap failed\n");
 
   static_cast<char *>(ptr)[0] = 7;
 
+  errno = 0;
+  if (munmap(ptr, 0) == 0 || errno != EINVAL)
+    fail("early mmap preload: zero-length munmap did not fail with EINVAL\n");
+
   if (munmap(ptr, 4096) != 0)
-    _exit(102);
+    fail("early mmap preload: munmap failed\n");
 }

--- a/emulation/rocjitsu/tests/early_mmap_preload_test.cpp
+++ b/emulation/rocjitsu/tests/early_mmap_preload_test.cpp
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file early_mmap_preload_test.cpp
+/// @brief Test helper whose constructor calls mmap before rocjitsu initializes.
+
+#include <sys/mman.h>
+#include <unistd.h>
+
+__attribute__((constructor)) static void early_mmap_constructor() {
+  void *ptr = mmap(nullptr, 4096, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  if (ptr == MAP_FAILED)
+    _exit(101);
+
+  static_cast<char *>(ptr)[0] = 7;
+
+  if (munmap(ptr, 4096) != 0)
+    _exit(102);
+}

--- a/emulation/rocjitsu/tests/early_mmap_preload_test.cpp
+++ b/emulation/rocjitsu/tests/early_mmap_preload_test.cpp
@@ -12,7 +12,8 @@
 namespace {
 
 template <size_t N> [[noreturn]] void fail(const char (&message)[N]) {
-  static_cast<void>(write(STDERR_FILENO, message, N - 1));
+  ssize_t ignored = write(STDERR_FILENO, message, N - 1);
+  static_cast<void>(ignored);
   _exit(EXIT_FAILURE);
 }
 


### PR DESCRIPTION
ISSUE ID: #8037

## Summary

Prototype a smaller alternative to #8035 that addresses the review discussion there by separating interposer context readiness from libc passthrough readiness.

The `mmap()` and `munmap()` bootstrap fallback remains targeted, but the wrapper now checks an explicit `InterposerContext::ready()` flag before touching rocjitsu interposer state. Existing filesystem/stat fallback paths also use that context-readiness flag instead of treating `LibcPassthrough::ready()` as a proxy for safe `ctx` access.

## Notes

This is a draft comparison PR for the review thread on #8035. It is not necessarily the recommended final shape.

Tradeoff: this keeps the implementation close to the minimal fix, but it introduces an explicit lifecycle flag so the readiness model is less implicit.

## Testing

```bash
cmake --build <build-dir> --parallel 8 --target \
  rocjitsu_shared early_mmap_preload early_mmap_driver rocjitsu_bin

ctest --test-dir <build-dir> \
  -R 'InterposerTest\.EarlyMmapBeforeRocjitsuConstructor' \
  --output-on-failure

pre-commit run --files \
  emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp \
  emulation/rocjitsu/tests/early_mmap_preload_test.cpp
```

Also verified `hipblaslt-bench --help` exits successfully through the rocjitsu launcher.
