### PR TITLE
fix(rocDecode) (ROCM-27712)  : fix for memory_leak with ASAN build

### DIFF
--- a/projects/rocdecode/samples/videoDecodeRGB/videodecrgb.cpp
+++ b/projects/rocdecode/samples/videoDecodeRGB/videodecrgb.cpp
@@ -408,6 +408,13 @@ int main(int argc, char **argv) {
                 return -1;
             }
         }
+        if (p_resize_dev_mem != nullptr) {
+            hip_status = hipFree(p_resize_dev_mem);
+            if (hip_status != hipSuccess) {
+                std::cout << "ERROR: hipFree failed! (" << hip_status << ")" << std::endl;
+                return -1;
+            }
+        }
         for (int i = 0; i < frame_buffers_size; i++) {
             hip_status = hipFree(frame_buffers[i]);
             if (hip_status != hipSuccess) {


### PR DESCRIPTION
## Motivation

The ASAN build revealed a memory leak with hipMalloc() which was not freeing.
## Technical Details

Fixes the memory leak by adding hipFree() at the end of the main sample code

## JIRA ID :  ROCM-27712

## Test Plan

All tests should pass as before.
No new tests are needed. It is captured in existing test suite
## Test Result

Tests passing

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
