### PR TITLE
(fix) (rocDecode) (ROCM-27712) (ASAN test fix) - Add gpu arch to all samples

### DIFF
--- a/projects/rocdecode/samples/rocdecDecode/CMakeLists.txt
+++ b/projects/rocdecode/samples/rocdecDecode/CMakeLists.txt
@@ -48,7 +48,7 @@ endif()
 
 project(rocdecdecode)
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../../cmake)
-list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/lib/cmake)
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/lib/cmake ${ROCM_PATH}/share/rocmcmakebuildtools/cmake)
 
 # rocdecode sample build type
 set(DEFAULT_BUILD_TYPE "Release")

--- a/projects/rocdecode/samples/rocdecDecode/CMakeLists.txt
+++ b/projects/rocdecode/samples/rocdecDecode/CMakeLists.txt
@@ -67,6 +67,42 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -DNDEBUG -fPIC -Wall")
 endif()
 
+# Set supported GPU Targets
+if(NOT GPU_TARGETS AND NOT AMDGPU_TARGETS)
+    find_package(ROCmCMakeBuildTools QUIET)
+    if(NOT ROCmCMakeBuildTools_FOUND)
+        find_package(ROCM QUIET)
+    endif()
+    include(ROCMCheckTargetIds OPTIONAL RESULT_VARIABLE HAS_ROCM_CHECK_TARGET_IDS)
+
+    set(OPTIONAL_GPU_TARGETS "gfx950;gfx1150;gfx1151;gfx1152;gfx1153;gfx1200;gfx1201;gfx1250")
+    if(HAS_ROCM_CHECK_TARGET_IDS)
+        rocm_check_target_ids(OPTIONAL_GPU_TARGETS_AVAILABLE TARGETS ${OPTIONAL_GPU_TARGETS})
+    else() # if we don't have rocm_check_target_ids, just assume the targets are available
+        set(OPTIONAL_GPU_TARGETS_AVAILABLE "${OPTIONAL_GPU_TARGETS}")
+    endif()
+    set(DEFAULT_GPU_TARGETS "gfx908;gfx90a;gfx942;gfx1030;gfx1031;gfx1032;gfx1100;gfx1101;gfx1102;${OPTIONAL_GPU_TARGETS_AVAILABLE}")
+endif()
+
+# Set AMD GPU_TARGETS
+if((AMDGPU_TARGETS OR DEFINED ENV{AMDGPU_TARGETS}) AND (NOT GPU_TARGETS))
+  message("-- ${Red}${PROJECT_NAME} DEPRECATION -- AMDGPU_TARGETS use is deprecated. Use GPU_TARGETS${ColourReset}")
+  if(DEFINED ENV{AMDGPU_TARGETS})
+    set(GPU_TARGETS $ENV{AMDGPU_TARGETS} CACHE STRING "List of specific machine types for library to target")
+  else()
+    set(GPU_TARGETS ${AMDGPU_TARGETS})
+  endif()
+endif()
+
+if(DEFINED ENV{GPU_ARCHS})
+  set(GPU_TARGETS $ENV{GPU_ARCHS} CACHE STRING "List of specific machine types for library to target")
+elseif(GPU_TARGETS)
+  message("-- ${White}${PROJECT_NAME} -- GPU_TARGETS set with -D option${ColourReset}")
+else()
+  set(GPU_TARGETS "${DEFAULT_GPU_TARGETS}" CACHE STRING "List of specific machine types for library to target")
+endif()
+message("-- ${White}${PROJECT_NAME} -- AMD GPU_TARGETS: ${GPU_TARGETS}${ColourReset}")
+
 set (HIP_PLATFORM amd CACHE STRING "HIP platform")
 find_package(HIP QUIET)
 find_package(FFmpeg QUIET)

--- a/projects/rocdecode/samples/videoDecode/CMakeLists.txt
+++ b/projects/rocdecode/samples/videoDecode/CMakeLists.txt
@@ -61,6 +61,42 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -DNDEBUG -fPIC")
 endif()
 
+# Set supported GPU Targets
+if(NOT GPU_TARGETS AND NOT AMDGPU_TARGETS)
+    find_package(ROCmCMakeBuildTools QUIET)
+    if(NOT ROCmCMakeBuildTools_FOUND)
+        find_package(ROCM QUIET)
+    endif()
+    include(ROCMCheckTargetIds OPTIONAL RESULT_VARIABLE HAS_ROCM_CHECK_TARGET_IDS)
+
+    set(OPTIONAL_GPU_TARGETS "gfx950;gfx1150;gfx1151;gfx1152;gfx1153;gfx1200;gfx1201;gfx1250")
+    if(HAS_ROCM_CHECK_TARGET_IDS)
+        rocm_check_target_ids(OPTIONAL_GPU_TARGETS_AVAILABLE TARGETS ${OPTIONAL_GPU_TARGETS})
+    else() # if we don't have rocm_check_target_ids, just assume the targets are available
+        set(OPTIONAL_GPU_TARGETS_AVAILABLE "${OPTIONAL_GPU_TARGETS}")
+    endif()
+    set(DEFAULT_GPU_TARGETS "gfx908;gfx90a;gfx942;gfx1030;gfx1031;gfx1032;gfx1100;gfx1101;gfx1102;${OPTIONAL_GPU_TARGETS_AVAILABLE}")
+endif()
+
+# Set AMD GPU_TARGETS
+if((AMDGPU_TARGETS OR DEFINED ENV{AMDGPU_TARGETS}) AND (NOT GPU_TARGETS))
+  message("-- ${Red}${PROJECT_NAME} DEPRECATION -- AMDGPU_TARGETS use is deprecated. Use GPU_TARGETS${ColourReset}")
+  if(DEFINED ENV{AMDGPU_TARGETS})
+    set(GPU_TARGETS $ENV{AMDGPU_TARGETS} CACHE STRING "List of specific machine types for library to target")
+  else()
+    set(GPU_TARGETS ${AMDGPU_TARGETS})
+  endif()
+endif()
+
+if(DEFINED ENV{GPU_ARCHS})
+  set(GPU_TARGETS $ENV{GPU_ARCHS} CACHE STRING "List of specific machine types for library to target")
+elseif(GPU_TARGETS)
+  message("-- ${White}${PROJECT_NAME} -- GPU_TARGETS set with -D option${ColourReset}")
+else()
+  set(GPU_TARGETS "${DEFAULT_GPU_TARGETS}" CACHE STRING "List of specific machine types for library to target")
+endif()
+message("-- ${White}${PROJECT_NAME} -- AMD GPU_TARGETS: ${GPU_TARGETS}${ColourReset}")
+
 set (HIP_PLATFORM amd CACHE STRING "HIP platform")
 find_package(HIP QUIET)
 find_package(rocdecode QUIET)

--- a/projects/rocdecode/samples/videoDecode/CMakeLists.txt
+++ b/projects/rocdecode/samples/videoDecode/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
 project(videodecode)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../../cmake)
-list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/lib/cmake)
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/lib/cmake ${ROCM_PATH}/share/rocmcmakebuildtools/cmake)
 
 # rocdecode sample build type
 set(DEFAULT_BUILD_TYPE "Release")

--- a/projects/rocdecode/samples/videoDecodeBatch/CMakeLists.txt
+++ b/projects/rocdecode/samples/videoDecodeBatch/CMakeLists.txt
@@ -61,6 +61,42 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -DNDEBUG -fPIC")
 endif()
 
+# Set supported GPU Targets
+if(NOT GPU_TARGETS AND NOT AMDGPU_TARGETS)
+    find_package(ROCmCMakeBuildTools QUIET)
+    if(NOT ROCmCMakeBuildTools_FOUND)
+        find_package(ROCM QUIET)
+    endif()
+    include(ROCMCheckTargetIds OPTIONAL RESULT_VARIABLE HAS_ROCM_CHECK_TARGET_IDS)
+
+    set(OPTIONAL_GPU_TARGETS "gfx950;gfx1150;gfx1151;gfx1152;gfx1153;gfx1200;gfx1201;gfx1250")
+    if(HAS_ROCM_CHECK_TARGET_IDS)
+        rocm_check_target_ids(OPTIONAL_GPU_TARGETS_AVAILABLE TARGETS ${OPTIONAL_GPU_TARGETS})
+    else() # if we don't have rocm_check_target_ids, just assume the targets are available
+        set(OPTIONAL_GPU_TARGETS_AVAILABLE "${OPTIONAL_GPU_TARGETS}")
+    endif()
+    set(DEFAULT_GPU_TARGETS "gfx908;gfx90a;gfx942;gfx1030;gfx1031;gfx1032;gfx1100;gfx1101;gfx1102;${OPTIONAL_GPU_TARGETS_AVAILABLE}")
+endif()
+
+# Set AMD GPU_TARGETS
+if((AMDGPU_TARGETS OR DEFINED ENV{AMDGPU_TARGETS}) AND (NOT GPU_TARGETS))
+  message("-- ${Red}${PROJECT_NAME} DEPRECATION -- AMDGPU_TARGETS use is deprecated. Use GPU_TARGETS${ColourReset}")
+  if(DEFINED ENV{AMDGPU_TARGETS})
+    set(GPU_TARGETS $ENV{AMDGPU_TARGETS} CACHE STRING "List of specific machine types for library to target")
+  else()
+    set(GPU_TARGETS ${AMDGPU_TARGETS})
+  endif()
+endif()
+
+if(DEFINED ENV{GPU_ARCHS})
+  set(GPU_TARGETS $ENV{GPU_ARCHS} CACHE STRING "List of specific machine types for library to target")
+elseif(GPU_TARGETS)
+  message("-- ${White}${PROJECT_NAME} -- GPU_TARGETS set with -D option${ColourReset}")
+else()
+  set(GPU_TARGETS "${DEFAULT_GPU_TARGETS}" CACHE STRING "List of specific machine types for library to target")
+endif()
+message("-- ${White}${PROJECT_NAME} -- AMD GPU_TARGETS: ${GPU_TARGETS}${ColourReset}")
+
 set (HIP_PLATFORM amd CACHE STRING "HIP platform")
 find_package(HIP QUIET)
 find_package(rocdecode QUIET)

--- a/projects/rocdecode/samples/videoDecodeBatch/CMakeLists.txt
+++ b/projects/rocdecode/samples/videoDecodeBatch/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
 project(videodecodebatch)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../../cmake)
-list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/lib/cmake)
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/lib/cmake ${ROCM_PATH}/share/rocmcmakebuildtools/cmake)
 
 # rocdecode sample build type
 set(DEFAULT_BUILD_TYPE "Release")

--- a/projects/rocdecode/samples/videoDecodeMem/CMakeLists.txt
+++ b/projects/rocdecode/samples/videoDecodeMem/CMakeLists.txt
@@ -43,7 +43,7 @@ endif()
 project(videodecodemem)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../../cmake)
-list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/lib/cmake)
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/lib/cmake ${ROCM_PATH}/share/rocmcmakebuildtools/cmake)
 
 # rocdecode sample build type
 set(DEFAULT_BUILD_TYPE "Release")

--- a/projects/rocdecode/samples/videoDecodeMem/CMakeLists.txt
+++ b/projects/rocdecode/samples/videoDecodeMem/CMakeLists.txt
@@ -62,6 +62,42 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -DNDEBUG -fPIC")
 endif()
 
+# Set supported GPU Targets
+if(NOT GPU_TARGETS AND NOT AMDGPU_TARGETS)
+    find_package(ROCmCMakeBuildTools QUIET)
+    if(NOT ROCmCMakeBuildTools_FOUND)
+        find_package(ROCM QUIET)
+    endif()
+    include(ROCMCheckTargetIds OPTIONAL RESULT_VARIABLE HAS_ROCM_CHECK_TARGET_IDS)
+
+    set(OPTIONAL_GPU_TARGETS "gfx950;gfx1150;gfx1151;gfx1152;gfx1153;gfx1200;gfx1201;gfx1250")
+    if(HAS_ROCM_CHECK_TARGET_IDS)
+        rocm_check_target_ids(OPTIONAL_GPU_TARGETS_AVAILABLE TARGETS ${OPTIONAL_GPU_TARGETS})
+    else() # if we don't have rocm_check_target_ids, just assume the targets are available
+        set(OPTIONAL_GPU_TARGETS_AVAILABLE "${OPTIONAL_GPU_TARGETS}")
+    endif()
+    set(DEFAULT_GPU_TARGETS "gfx908;gfx90a;gfx942;gfx1030;gfx1031;gfx1032;gfx1100;gfx1101;gfx1102;${OPTIONAL_GPU_TARGETS_AVAILABLE}")
+endif()
+
+# Set AMD GPU_TARGETS
+if((AMDGPU_TARGETS OR DEFINED ENV{AMDGPU_TARGETS}) AND (NOT GPU_TARGETS))
+  message("-- ${Red}${PROJECT_NAME} DEPRECATION -- AMDGPU_TARGETS use is deprecated. Use GPU_TARGETS${ColourReset}")
+  if(DEFINED ENV{AMDGPU_TARGETS})
+    set(GPU_TARGETS $ENV{AMDGPU_TARGETS} CACHE STRING "List of specific machine types for library to target")
+  else()
+    set(GPU_TARGETS ${AMDGPU_TARGETS})
+  endif()
+endif()
+
+if(DEFINED ENV{GPU_ARCHS})
+  set(GPU_TARGETS $ENV{GPU_ARCHS} CACHE STRING "List of specific machine types for library to target")
+elseif(GPU_TARGETS)
+  message("-- ${White}${PROJECT_NAME} -- GPU_TARGETS set with -D option${ColourReset}")
+else()
+  set(GPU_TARGETS "${DEFAULT_GPU_TARGETS}" CACHE STRING "List of specific machine types for library to target")
+endif()
+message("-- ${White}${PROJECT_NAME} -- AMD GPU_TARGETS: ${GPU_TARGETS}${ColourReset}")
+
 set (HIP_PLATFORM amd CACHE STRING "HIP platform")
 find_package(HIP QUIET)
 find_package(rocdecode QUIET)

--- a/projects/rocdecode/samples/videoDecodeMultiFiles/CMakeLists.txt
+++ b/projects/rocdecode/samples/videoDecodeMultiFiles/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
 project(videodecodemultifiles)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../../cmake)
-list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/lib/cmake)
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/lib/cmake ${ROCM_PATH}/share/rocmcmakebuildtools/cmake)
 
 # rocdecode sample build type
 set(DEFAULT_BUILD_TYPE "Release")

--- a/projects/rocdecode/samples/videoDecodeMultiFiles/CMakeLists.txt
+++ b/projects/rocdecode/samples/videoDecodeMultiFiles/CMakeLists.txt
@@ -61,6 +61,42 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -DNDEBUG -fPIC")
 endif()
 
+# Set supported GPU Targets
+if(NOT GPU_TARGETS AND NOT AMDGPU_TARGETS)
+    find_package(ROCmCMakeBuildTools QUIET)
+    if(NOT ROCmCMakeBuildTools_FOUND)
+        find_package(ROCM QUIET)
+    endif()
+    include(ROCMCheckTargetIds OPTIONAL RESULT_VARIABLE HAS_ROCM_CHECK_TARGET_IDS)
+
+    set(OPTIONAL_GPU_TARGETS "gfx950;gfx1150;gfx1151;gfx1152;gfx1153;gfx1200;gfx1201;gfx1250")
+    if(HAS_ROCM_CHECK_TARGET_IDS)
+        rocm_check_target_ids(OPTIONAL_GPU_TARGETS_AVAILABLE TARGETS ${OPTIONAL_GPU_TARGETS})
+    else() # if we don't have rocm_check_target_ids, just assume the targets are available
+        set(OPTIONAL_GPU_TARGETS_AVAILABLE "${OPTIONAL_GPU_TARGETS}")
+    endif()
+    set(DEFAULT_GPU_TARGETS "gfx908;gfx90a;gfx942;gfx1030;gfx1031;gfx1032;gfx1100;gfx1101;gfx1102;${OPTIONAL_GPU_TARGETS_AVAILABLE}")
+endif()
+
+# Set AMD GPU_TARGETS
+if((AMDGPU_TARGETS OR DEFINED ENV{AMDGPU_TARGETS}) AND (NOT GPU_TARGETS))
+  message("-- ${Red}${PROJECT_NAME} DEPRECATION -- AMDGPU_TARGETS use is deprecated. Use GPU_TARGETS${ColourReset}")
+  if(DEFINED ENV{AMDGPU_TARGETS})
+    set(GPU_TARGETS $ENV{AMDGPU_TARGETS} CACHE STRING "List of specific machine types for library to target")
+  else()
+    set(GPU_TARGETS ${AMDGPU_TARGETS})
+  endif()
+endif()
+
+if(DEFINED ENV{GPU_ARCHS})
+  set(GPU_TARGETS $ENV{GPU_ARCHS} CACHE STRING "List of specific machine types for library to target")
+elseif(GPU_TARGETS)
+  message("-- ${White}${PROJECT_NAME} -- GPU_TARGETS set with -D option${ColourReset}")
+else()
+  set(GPU_TARGETS "${DEFAULT_GPU_TARGETS}" CACHE STRING "List of specific machine types for library to target")
+endif()
+message("-- ${White}${PROJECT_NAME} -- AMD GPU_TARGETS: ${GPU_TARGETS}${ColourReset}")
+
 set (HIP_PLATFORM amd CACHE STRING "HIP platform")
 find_package(HIP QUIET)
 find_package(rocdecode QUIET)

--- a/projects/rocdecode/samples/videoDecodePerf/CMakeLists.txt
+++ b/projects/rocdecode/samples/videoDecodePerf/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
 project(videodecodeperf)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../../cmake)
-list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/lib/cmake)
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/lib/cmake ${ROCM_PATH}/share/rocmcmakebuildtools/cmake)
 
 # rocdecode sample build type
 set(DEFAULT_BUILD_TYPE "Release")

--- a/projects/rocdecode/samples/videoDecodePerf/CMakeLists.txt
+++ b/projects/rocdecode/samples/videoDecodePerf/CMakeLists.txt
@@ -61,6 +61,42 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -DNDEBUG -fPIC")
 endif()
 
+# Set supported GPU Targets
+if(NOT GPU_TARGETS AND NOT AMDGPU_TARGETS)
+    find_package(ROCmCMakeBuildTools QUIET)
+    if(NOT ROCmCMakeBuildTools_FOUND)
+        find_package(ROCM QUIET)
+    endif()
+    include(ROCMCheckTargetIds OPTIONAL RESULT_VARIABLE HAS_ROCM_CHECK_TARGET_IDS)
+
+    set(OPTIONAL_GPU_TARGETS "gfx950;gfx1150;gfx1151;gfx1152;gfx1153;gfx1200;gfx1201;gfx1250")
+    if(HAS_ROCM_CHECK_TARGET_IDS)
+        rocm_check_target_ids(OPTIONAL_GPU_TARGETS_AVAILABLE TARGETS ${OPTIONAL_GPU_TARGETS})
+    else() # if we don't have rocm_check_target_ids, just assume the targets are available
+        set(OPTIONAL_GPU_TARGETS_AVAILABLE "${OPTIONAL_GPU_TARGETS}")
+    endif()
+    set(DEFAULT_GPU_TARGETS "gfx908;gfx90a;gfx942;gfx1030;gfx1031;gfx1032;gfx1100;gfx1101;gfx1102;${OPTIONAL_GPU_TARGETS_AVAILABLE}")
+endif()
+
+# Set AMD GPU_TARGETS
+if((AMDGPU_TARGETS OR DEFINED ENV{AMDGPU_TARGETS}) AND (NOT GPU_TARGETS))
+  message("-- ${Red}${PROJECT_NAME} DEPRECATION -- AMDGPU_TARGETS use is deprecated. Use GPU_TARGETS${ColourReset}")
+  if(DEFINED ENV{AMDGPU_TARGETS})
+    set(GPU_TARGETS $ENV{AMDGPU_TARGETS} CACHE STRING "List of specific machine types for library to target")
+  else()
+    set(GPU_TARGETS ${AMDGPU_TARGETS})
+  endif()
+endif()
+
+if(DEFINED ENV{GPU_ARCHS})
+  set(GPU_TARGETS $ENV{GPU_ARCHS} CACHE STRING "List of specific machine types for library to target")
+elseif(GPU_TARGETS)
+  message("-- ${White}${PROJECT_NAME} -- GPU_TARGETS set with -D option${ColourReset}")
+else()
+  set(GPU_TARGETS "${DEFAULT_GPU_TARGETS}" CACHE STRING "List of specific machine types for library to target")
+endif()
+message("-- ${White}${PROJECT_NAME} -- AMD GPU_TARGETS: ${GPU_TARGETS}${ColourReset}")
+
 set (HIP_PLATFORM amd CACHE STRING "HIP platform")
 find_package(HIP QUIET)
 find_package(rocdecode QUIET)

--- a/projects/rocdecode/samples/videoDecodePicFiles/CMakeLists.txt
+++ b/projects/rocdecode/samples/videoDecodePicFiles/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
 project(videodecodepicfiles)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../../cmake)
-list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/lib/cmake)
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/lib/cmake ${ROCM_PATH}/share/rocmcmakebuildtools/cmake)
 
 # rocdecode sample build type
 set(DEFAULT_BUILD_TYPE "Release")

--- a/projects/rocdecode/samples/videoDecodePicFiles/CMakeLists.txt
+++ b/projects/rocdecode/samples/videoDecodePicFiles/CMakeLists.txt
@@ -61,6 +61,42 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -DNDEBUG -fPIC")
 endif()
 
+# Set supported GPU Targets
+if(NOT GPU_TARGETS AND NOT AMDGPU_TARGETS)
+    find_package(ROCmCMakeBuildTools QUIET)
+    if(NOT ROCmCMakeBuildTools_FOUND)
+        find_package(ROCM QUIET)
+    endif()
+    include(ROCMCheckTargetIds OPTIONAL RESULT_VARIABLE HAS_ROCM_CHECK_TARGET_IDS)
+
+    set(OPTIONAL_GPU_TARGETS "gfx950;gfx1150;gfx1151;gfx1152;gfx1153;gfx1200;gfx1201;gfx1250")
+    if(HAS_ROCM_CHECK_TARGET_IDS)
+        rocm_check_target_ids(OPTIONAL_GPU_TARGETS_AVAILABLE TARGETS ${OPTIONAL_GPU_TARGETS})
+    else() # if we don't have rocm_check_target_ids, just assume the targets are available
+        set(OPTIONAL_GPU_TARGETS_AVAILABLE "${OPTIONAL_GPU_TARGETS}")
+    endif()
+    set(DEFAULT_GPU_TARGETS "gfx908;gfx90a;gfx942;gfx1030;gfx1031;gfx1032;gfx1100;gfx1101;gfx1102;${OPTIONAL_GPU_TARGETS_AVAILABLE}")
+endif()
+
+# Set AMD GPU_TARGETS
+if((AMDGPU_TARGETS OR DEFINED ENV{AMDGPU_TARGETS}) AND (NOT GPU_TARGETS))
+  message("-- ${Red}${PROJECT_NAME} DEPRECATION -- AMDGPU_TARGETS use is deprecated. Use GPU_TARGETS${ColourReset}")
+  if(DEFINED ENV{AMDGPU_TARGETS})
+    set(GPU_TARGETS $ENV{AMDGPU_TARGETS} CACHE STRING "List of specific machine types for library to target")
+  else()
+    set(GPU_TARGETS ${AMDGPU_TARGETS})
+  endif()
+endif()
+
+if(DEFINED ENV{GPU_ARCHS})
+  set(GPU_TARGETS $ENV{GPU_ARCHS} CACHE STRING "List of specific machine types for library to target")
+elseif(GPU_TARGETS)
+  message("-- ${White}${PROJECT_NAME} -- GPU_TARGETS set with -D option${ColourReset}")
+else()
+  set(GPU_TARGETS "${DEFAULT_GPU_TARGETS}" CACHE STRING "List of specific machine types for library to target")
+endif()
+message("-- ${White}${PROJECT_NAME} -- AMD GPU_TARGETS: ${GPU_TARGETS}${ColourReset}")
+
 set (HIP_PLATFORM amd CACHE STRING "HIP platform")
 find_package(HIP QUIET)
 find_package(rocdecode QUIET)

--- a/projects/rocdecode/samples/videoDecodeRaw/CMakeLists.txt
+++ b/projects/rocdecode/samples/videoDecodeRaw/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
 project(videodecoderaw)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../../cmake)
-list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/lib/cmake)
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/lib/cmake ${ROCM_PATH}/share/rocmcmakebuildtools/cmake)
 
 # rocdecode sample build type
 set(DEFAULT_BUILD_TYPE "Release")

--- a/projects/rocdecode/samples/videoDecodeRaw/CMakeLists.txt
+++ b/projects/rocdecode/samples/videoDecodeRaw/CMakeLists.txt
@@ -61,6 +61,42 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -DNDEBUG -fPIC")
 endif()
 
+# Set supported GPU Targets
+if(NOT GPU_TARGETS AND NOT AMDGPU_TARGETS)
+    find_package(ROCmCMakeBuildTools QUIET)
+    if(NOT ROCmCMakeBuildTools_FOUND)
+        find_package(ROCM QUIET)
+    endif()
+    include(ROCMCheckTargetIds OPTIONAL RESULT_VARIABLE HAS_ROCM_CHECK_TARGET_IDS)
+
+    set(OPTIONAL_GPU_TARGETS "gfx950;gfx1150;gfx1151;gfx1152;gfx1153;gfx1200;gfx1201;gfx1250")
+    if(HAS_ROCM_CHECK_TARGET_IDS)
+        rocm_check_target_ids(OPTIONAL_GPU_TARGETS_AVAILABLE TARGETS ${OPTIONAL_GPU_TARGETS})
+    else() # if we don't have rocm_check_target_ids, just assume the targets are available
+        set(OPTIONAL_GPU_TARGETS_AVAILABLE "${OPTIONAL_GPU_TARGETS}")
+    endif()
+    set(DEFAULT_GPU_TARGETS "gfx908;gfx90a;gfx942;gfx1030;gfx1031;gfx1032;gfx1100;gfx1101;gfx1102;${OPTIONAL_GPU_TARGETS_AVAILABLE}")
+endif()
+
+# Set AMD GPU_TARGETS
+if((AMDGPU_TARGETS OR DEFINED ENV{AMDGPU_TARGETS}) AND (NOT GPU_TARGETS))
+  message("-- ${Red}${PROJECT_NAME} DEPRECATION -- AMDGPU_TARGETS use is deprecated. Use GPU_TARGETS${ColourReset}")
+  if(DEFINED ENV{AMDGPU_TARGETS})
+    set(GPU_TARGETS $ENV{AMDGPU_TARGETS} CACHE STRING "List of specific machine types for library to target")
+  else()
+    set(GPU_TARGETS ${AMDGPU_TARGETS})
+  endif()
+endif()
+
+if(DEFINED ENV{GPU_ARCHS})
+  set(GPU_TARGETS $ENV{GPU_ARCHS} CACHE STRING "List of specific machine types for library to target")
+elseif(GPU_TARGETS)
+  message("-- ${White}${PROJECT_NAME} -- GPU_TARGETS set with -D option${ColourReset}")
+else()
+  set(GPU_TARGETS "${DEFAULT_GPU_TARGETS}" CACHE STRING "List of specific machine types for library to target")
+endif()
+message("-- ${White}${PROJECT_NAME} -- AMD GPU_TARGETS: ${GPU_TARGETS}${ColourReset}")
+
 set (HIP_PLATFORM amd CACHE STRING "HIP platform")
 find_package(HIP QUIET)
 find_package(rocdecode QUIET)

--- a/projects/rocdecode/samples/videoToSequence/CMakeLists.txt
+++ b/projects/rocdecode/samples/videoToSequence/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
 project(videotosequence)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../../cmake)
-list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/lib/cmake)
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/lib/cmake ${ROCM_PATH}/share/rocmcmakebuildtools/cmake)
 
 # rocdecode sample build type
 set(DEFAULT_BUILD_TYPE "Release")

--- a/projects/rocdecode/samples/videoToSequence/CMakeLists.txt
+++ b/projects/rocdecode/samples/videoToSequence/CMakeLists.txt
@@ -61,6 +61,42 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -DNDEBUG -fPIC")
 endif()
 
+# Set supported GPU Targets
+if(NOT GPU_TARGETS AND NOT AMDGPU_TARGETS)
+    find_package(ROCmCMakeBuildTools QUIET)
+    if(NOT ROCmCMakeBuildTools_FOUND)
+        find_package(ROCM QUIET)
+    endif()
+    include(ROCMCheckTargetIds OPTIONAL RESULT_VARIABLE HAS_ROCM_CHECK_TARGET_IDS)
+
+    set(OPTIONAL_GPU_TARGETS "gfx950;gfx1150;gfx1151;gfx1152;gfx1153;gfx1200;gfx1201;gfx1250")
+    if(HAS_ROCM_CHECK_TARGET_IDS)
+        rocm_check_target_ids(OPTIONAL_GPU_TARGETS_AVAILABLE TARGETS ${OPTIONAL_GPU_TARGETS})
+    else() # if we don't have rocm_check_target_ids, just assume the targets are available
+        set(OPTIONAL_GPU_TARGETS_AVAILABLE "${OPTIONAL_GPU_TARGETS}")
+    endif()
+    set(DEFAULT_GPU_TARGETS "gfx908;gfx90a;gfx942;gfx1030;gfx1031;gfx1032;gfx1100;gfx1101;gfx1102;${OPTIONAL_GPU_TARGETS_AVAILABLE}")
+endif()
+
+# Set AMD GPU_TARGETS
+if((AMDGPU_TARGETS OR DEFINED ENV{AMDGPU_TARGETS}) AND (NOT GPU_TARGETS))
+  message("-- ${Red}${PROJECT_NAME} DEPRECATION -- AMDGPU_TARGETS use is deprecated. Use GPU_TARGETS${ColourReset}")
+  if(DEFINED ENV{AMDGPU_TARGETS})
+    set(GPU_TARGETS $ENV{AMDGPU_TARGETS} CACHE STRING "List of specific machine types for library to target")
+  else()
+    set(GPU_TARGETS ${AMDGPU_TARGETS})
+  endif()
+endif()
+
+if(DEFINED ENV{GPU_ARCHS})
+  set(GPU_TARGETS $ENV{GPU_ARCHS} CACHE STRING "List of specific machine types for library to target")
+elseif(GPU_TARGETS)
+  message("-- ${White}${PROJECT_NAME} -- GPU_TARGETS set with -D option${ColourReset}")
+else()
+  set(GPU_TARGETS "${DEFAULT_GPU_TARGETS}" CACHE STRING "List of specific machine types for library to target")
+endif()
+message("-- ${White}${PROJECT_NAME} -- AMD GPU_TARGETS: ${GPU_TARGETS}${ColourReset}")
+
 set (HIP_PLATFORM amd CACHE STRING "HIP platform")
 find_package(HIP QUIET)
 find_package(rocdecode QUIET)

--- a/projects/rocdecode/test/rocDecodeNegativeApiTests/CMakeLists.txt
+++ b/projects/rocdecode/test/rocDecodeNegativeApiTests/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
 project(rocdecodenegativetest)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../../cmake)
-list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/lib/cmake)
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/lib/cmake ${ROCM_PATH}/share/rocmcmakebuildtools/cmake)
 
 # rocdecode sample build type
 set(DEFAULT_BUILD_TYPE "Release")
@@ -60,6 +60,42 @@ else()
   # -fPIC     -- Generate position-independent code if possible
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -DNDEBUG -fPIC")
 endif()
+
+# Set supported GPU Targets
+if(NOT GPU_TARGETS AND NOT AMDGPU_TARGETS)
+    find_package(ROCmCMakeBuildTools QUIET)
+    if(NOT ROCmCMakeBuildTools_FOUND)
+        find_package(ROCM QUIET)
+    endif()
+    include(ROCMCheckTargetIds OPTIONAL RESULT_VARIABLE HAS_ROCM_CHECK_TARGET_IDS)
+
+    set(OPTIONAL_GPU_TARGETS "gfx950;gfx1150;gfx1151;gfx1152;gfx1153;gfx1200;gfx1201;gfx1250")
+    if(HAS_ROCM_CHECK_TARGET_IDS)
+        rocm_check_target_ids(OPTIONAL_GPU_TARGETS_AVAILABLE TARGETS ${OPTIONAL_GPU_TARGETS})
+    else() # if we don't have rocm_check_target_ids, just assume the targets are available
+        set(OPTIONAL_GPU_TARGETS_AVAILABLE "${OPTIONAL_GPU_TARGETS}")
+    endif()
+    set(DEFAULT_GPU_TARGETS "gfx908;gfx90a;gfx942;gfx1030;gfx1031;gfx1032;gfx1100;gfx1101;gfx1102;${OPTIONAL_GPU_TARGETS_AVAILABLE}")
+endif()
+
+# Set AMD GPU_TARGETS
+if((AMDGPU_TARGETS OR DEFINED ENV{AMDGPU_TARGETS}) AND (NOT GPU_TARGETS))
+  message("-- ${Red}${PROJECT_NAME} DEPRECATION -- AMDGPU_TARGETS use is deprecated. Use GPU_TARGETS${ColourReset}")
+  if(DEFINED ENV{AMDGPU_TARGETS})
+    set(GPU_TARGETS $ENV{AMDGPU_TARGETS} CACHE STRING "List of specific machine types for library to target")
+  else()
+    set(GPU_TARGETS ${AMDGPU_TARGETS})
+  endif()
+endif()
+
+if(DEFINED ENV{GPU_ARCHS})
+  set(GPU_TARGETS $ENV{GPU_ARCHS} CACHE STRING "List of specific machine types for library to target")
+elseif(GPU_TARGETS)
+  message("-- ${White}${PROJECT_NAME} -- GPU_TARGETS set with -D option${ColourReset}")
+else()
+  set(GPU_TARGETS "${DEFAULT_GPU_TARGETS}" CACHE STRING "List of specific machine types for library to target")
+endif()
+message("-- ${White}${PROJECT_NAME} -- AMD GPU_TARGETS: ${GPU_TARGETS}${ColourReset}")
 
 set (HIP_PLATFORM amd CACHE STRING "HIP platform")
 find_package(HIP QUIET)


### PR DESCRIPTION
## Motivation

The JIRA ticket shows GPU arch is needed from HIP side even if the sample does not have arch specific code. Implementing this PR to avoid ASAN failures when gpu arch is not mentioned.

## Technical Details

Add supported `GPU_TARGETS` for all samples

## JIRA ID

ROCM-27712

## Test Plan

ctests must pass

## Test Result

Test results on Navi31 system:

```
~/work/rocm-systems/projects/rocdecode/build$ ctest -VV
UpdateCTestConfiguration  from :/home/lakshmi/work/rocm-systems/projects/rocdecode/build/DartConfiguration.tcl
Parse Config file:/home/lakshmi/work/rocm-systems/projects/rocdecode/build/DartConfiguration.tcl
UpdateCTestConfiguration  from :/home/lakshmi/work/rocm-systems/projects/rocdecode/build/DartConfiguration.tcl
Parse Config file:/home/lakshmi/work/rocm-systems/projects/rocdecode/build/DartConfiguration.tcl
Test project /home/lakshmi/work/rocm-systems/projects/rocdecode/build
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 1
    Start 1: video_decodeRaw-HEVC

1: Test command: /usr/local/bin/ctest "--build-and-test" "/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/samples/videoDecodeRaw" "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-HEVC" "--build-generator" "Unix Makefiles" "--test-command" "videodecoderaw" "-i" "/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/video/AMD_driving_virtual_20-H265.265"
1: Working Directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test
1: Environment variables: 
1:  LD_PRELOAD=/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib/librocm_sysdeps_va.so.2:/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib/librocm_sysdeps_va-drm.so.2
1:  LIBVA_DRIVERS_PATH=/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib
1: Test timeout computed to be: 1500
1: Internal cmake changing into directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-HEVC
1: ======== CMake output     ======
1: The C compiler identification is Clang 23.0.0
1: The CXX compiler identification is Clang 23.0.0
1: Detecting C compiler ABI info
1: Detecting C compiler ABI info - done
1: Check for working C compiler: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/llvm/bin/amdclang - skipped
1: Detecting C compile features
1: Detecting C compile features - done
1: Detecting CXX compiler ABI info
1: Detecting CXX compiler ABI info - done
1: Check for working CXX compiler: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/llvm/bin/amdclang++ - skipped
1: Detecting CXX compile features
1: Detecting CXX compile features - done
1: -- videodecoderaw -- AMD GPU_TARGETS: gfx908;gfx90a;gfx942;gfx1030;gfx1031;gfx1032;gfx1100;gfx1101;gfx1102;gfx950;gfx1150;gfx1151;gfx1152;gfx1153;gfx1200;gfx1201;gfx1250
1: HIP: Using hipcc from relative path: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/bin/hipcc
1: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS
1: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS - Success
1: Configuring done
1: Generating done
1: Build files have been written to: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-HEVC
1: ======== End CMake output ======
1: Change Dir: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-HEVC
1: 
1: Run Clean Command:/usr/bin/gmake -f Makefile clean
1: 
1: Run Build Command(s):/usr/bin/gmake -f Makefile && [ 33%] Building CXX object CMakeFiles/videodecoderaw.dir/videodecoderaw.cpp.o
1: [ 66%] Building CXX object CMakeFiles/videodecoderaw.dir/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp.o
1: [100%] Linking CXX executable videodecoderaw
1: [100%] Built target videodecoderaw
1: 
1: Running test command: "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-HEVC/videodecoderaw" "-i" "/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/video/AMD_driving_virtual_20-H265.265"
1: info: Input file: AMD_driving_virtual_20-H265.265
1: info: Using built-in bitstream reader
1: info: Using GPU device 0 - AMD Radeon RX 7900 XT[gfx1100] on PCI bus 03:00.0
1: info: decoding started, please wait!
1: Input Video Information
1:      Codec        : H.265/HEVC
1:      Frame rate   : 30000/1001 = 29.97 fps
1:      Sequence     : Progressive
1:      Coded size   : [2048, 1024]
1:      Display area : [0, 0, 2048, 1024]
1:      Chroma       : YUV 420
1:      Bit depth    : 8
1: Video Decoding Params:
1:      Num Surfaces : 7
1:      Crop         : [0, 0, 2048, 1024]
1:      Resize       : 2048x1024
1: 
1: info: Total pictures decoded: 601
1: info: Total frames output/displayed: 601
1: info: avg decoding time per picture: 1.00809 ms
1: info: avg decode FPS: 991.976
1: info: avg output/display time per frame: 1.00809 ms
1: info: avg output/display FPS: 991.976
1: 
1/6 Test #1: video_decodeRaw-HEVC .............   Passed    3.89 sec
test 2
    Start 2: video_decodeRaw-AVC

2: Test command: /usr/local/bin/ctest "--build-and-test" "/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/samples/videoDecodeRaw" "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AVC" "--build-generator" "Unix Makefiles" "--test-command" "videodecoderaw" "-i" "/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/video/AMD_driving_virtual_20-H264.264"
2: Working Directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test
2: Environment variables: 
2:  LD_PRELOAD=/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib/librocm_sysdeps_va.so.2:/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib/librocm_sysdeps_va-drm.so.2
2:  LIBVA_DRIVERS_PATH=/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib
2: Test timeout computed to be: 1500
2: Internal cmake changing into directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AVC
2: ======== CMake output     ======
2: The C compiler identification is Clang 23.0.0
2: The CXX compiler identification is Clang 23.0.0
2: Detecting C compiler ABI info
2: Detecting C compiler ABI info - done
2: Check for working C compiler: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/llvm/bin/amdclang - skipped
2: Detecting C compile features
2: Detecting C compile features - done
2: Detecting CXX compiler ABI info
2: Detecting CXX compiler ABI info - done
2: Check for working CXX compiler: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/llvm/bin/amdclang++ - skipped
2: Detecting CXX compile features
2: Detecting CXX compile features - done
2: -- videodecoderaw -- AMD GPU_TARGETS: gfx908;gfx90a;gfx942;gfx1030;gfx1031;gfx1032;gfx1100;gfx1101;gfx1102;gfx950;gfx1150;gfx1151;gfx1152;gfx1153;gfx1200;gfx1201;gfx1250
2: HIP: Using hipcc from relative path: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/bin/hipcc
2: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS
2: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS - Success
2: Configuring done
2: Generating done
2: Build files have been written to: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AVC
2: ======== End CMake output ======
2: Change Dir: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AVC
2: 
2: Run Clean Command:/usr/bin/gmake -f Makefile clean
2: 
2: Run Build Command(s):/usr/bin/gmake -f Makefile && [ 33%] Building CXX object CMakeFiles/videodecoderaw.dir/videodecoderaw.cpp.o
2: [ 66%] Building CXX object CMakeFiles/videodecoderaw.dir/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp.o
2: [100%] Linking CXX executable videodecoderaw
2: [100%] Built target videodecoderaw
2: 
2: Running test command: "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AVC/videodecoderaw" "-i" "/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/video/AMD_driving_virtual_20-H264.264"
2: info: Input file: AMD_driving_virtual_20-H264.264
2: info: Using built-in bitstream reader
2: info: Using GPU device 0 - AMD Radeon RX 7900 XT[gfx1100] on PCI bus 03:00.0
2: info: decoding started, please wait!
2: Input Video Information
2:      Codec        : AVC/H.264
2:      Frame rate   : 60000/2002 = 29.97 fps
2:      Sequence     : Progressive
2:      Coded size   : [2048, 1024]
2:      Display area : [0, 0, 2048, 1024]
2:      Chroma       : YUV 420
2:      Bit depth    : 8
2: Video Decoding Params:
2:      Num Surfaces : 7
2:      Crop         : [0, 0, 2048, 1024]
2:      Resize       : 2048x1024
2: 
2: info: Total pictures decoded: 601
2: info: Total frames output/displayed: 601
2: info: avg decoding time per picture: 0.87877 ms
2: info: avg decode FPS: 1137.95
2: info: avg output/display time per frame: 0.87877 ms
2: info: avg output/display FPS: 1137.95
2: 
2/6 Test #2: video_decodeRaw-AVC ..............   Passed    3.81 sec
test 3
    Start 3: video_decodeRaw-AV1

3: Test command: /usr/local/bin/ctest "--build-and-test" "/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/samples/videoDecodeRaw" "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AV1" "--build-generator" "Unix Makefiles" "--test-command" "videodecoderaw" "-i" "/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/video/AMD_driving_virtual_20-AV1.ivf"
3: Working Directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test
3: Environment variables: 
3:  LD_PRELOAD=/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib/librocm_sysdeps_va.so.2:/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib/librocm_sysdeps_va-drm.so.2
3:  LIBVA_DRIVERS_PATH=/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib
3: Test timeout computed to be: 1500
3: Internal cmake changing into directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AV1
3: ======== CMake output     ======
3: The C compiler identification is Clang 23.0.0
3: The CXX compiler identification is Clang 23.0.0
3: Detecting C compiler ABI info
3: Detecting C compiler ABI info - done
3: Check for working C compiler: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/llvm/bin/amdclang - skipped
3: Detecting C compile features
3: Detecting C compile features - done
3: Detecting CXX compiler ABI info
3: Detecting CXX compiler ABI info - done
3: Check for working CXX compiler: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/llvm/bin/amdclang++ - skipped
3: Detecting CXX compile features
3: Detecting CXX compile features - done
3: -- videodecoderaw -- AMD GPU_TARGETS: gfx908;gfx90a;gfx942;gfx1030;gfx1031;gfx1032;gfx1100;gfx1101;gfx1102;gfx950;gfx1150;gfx1151;gfx1152;gfx1153;gfx1200;gfx1201;gfx1250
3: HIP: Using hipcc from relative path: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/bin/hipcc
3: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS
3: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS - Success
3: Configuring done
3: Generating done
3: Build files have been written to: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AV1
3: ======== End CMake output ======
3: Change Dir: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AV1
3: 
3: Run Clean Command:/usr/bin/gmake -f Makefile clean
3: 
3: Run Build Command(s):/usr/bin/gmake -f Makefile && [ 33%] Building CXX object CMakeFiles/videodecoderaw.dir/videodecoderaw.cpp.o
3: [ 66%] Building CXX object CMakeFiles/videodecoderaw.dir/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp.o
3: [100%] Linking CXX executable videodecoderaw
3: [100%] Built target videodecoderaw
3: 
3: Running test command: "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-AV1/videodecoderaw" "-i" "/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/video/AMD_driving_virtual_20-AV1.ivf"
3: info: Input file: AMD_driving_virtual_20-AV1.ivf
3: info: Using built-in bitstream reader
3: info: Using GPU device 0 - AMD Radeon RX 7900 XT[gfx1100] on PCI bus 03:00.0
3: info: decoding started, please wait!
3: Input Video Information
3:      Codec        : AV1
3:      Sequence     : Progressive
3:      Coded size   : [2048, 1024]
3:      Display area : [0, 0, 2048, 1024]
3:      Chroma       : YUV 420
3:      Bit depth    : 8
3: Video Decoding Params:
3:      Num Surfaces : 12
3:      Crop         : [0, 0, 2048, 1024]
3:      Resize       : 2048x1024
3: 
3: info: Total pictures decoded: 602
3: info: Total frames output/displayed: 601
3: info: avg decoding time per picture: 1.00368 ms
3: info: avg decode FPS: 996.33
3: info: avg output/display time per frame: 1.00535 ms
3: info: avg output/display FPS: 994.675
3: 
3/6 Test #3: video_decodeRaw-AV1 ..............   Passed    3.93 sec
test 4
    Start 4: video_decodeRaw-VP9

4: Test command: /usr/local/bin/ctest "--build-and-test" "/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/samples/videoDecodeRaw" "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-VP9" "--build-generator" "Unix Makefiles" "--test-command" "videodecoderaw" "-i" "/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/video/AMD_driving_virtual_20-VP9.ivf"
4: Working Directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test
4: Environment variables: 
4:  LD_PRELOAD=/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib/librocm_sysdeps_va.so.2:/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib/librocm_sysdeps_va-drm.so.2
4:  LIBVA_DRIVERS_PATH=/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib
4: Test timeout computed to be: 1500
4: Internal cmake changing into directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-VP9
4: ======== CMake output     ======
4: The C compiler identification is Clang 23.0.0
4: The CXX compiler identification is Clang 23.0.0
4: Detecting C compiler ABI info
4: Detecting C compiler ABI info - done
4: Check for working C compiler: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/llvm/bin/amdclang - skipped
4: Detecting C compile features
4: Detecting C compile features - done
4: Detecting CXX compiler ABI info
4: Detecting CXX compiler ABI info - done
4: Check for working CXX compiler: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/llvm/bin/amdclang++ - skipped
4: Detecting CXX compile features
4: Detecting CXX compile features - done
4: -- videodecoderaw -- AMD GPU_TARGETS: gfx908;gfx90a;gfx942;gfx1030;gfx1031;gfx1032;gfx1100;gfx1101;gfx1102;gfx950;gfx1150;gfx1151;gfx1152;gfx1153;gfx1200;gfx1201;gfx1250
4: HIP: Using hipcc from relative path: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/bin/hipcc
4: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS
4: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS - Success
4: Configuring done
4: Generating done
4: Build files have been written to: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-VP9
4: ======== End CMake output ======
4: Change Dir: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-VP9
4: 
4: Run Clean Command:/usr/bin/gmake -f Makefile clean
4: 
4: Run Build Command(s):/usr/bin/gmake -f Makefile && [ 33%] Building CXX object CMakeFiles/videodecoderaw.dir/videodecoderaw.cpp.o
4: [ 66%] Building CXX object CMakeFiles/videodecoderaw.dir/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp.o
4: [100%] Linking CXX executable videodecoderaw
4: [100%] Built target videodecoderaw
4: 
4: Running test command: "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/videoDecodeRaw-VP9/videodecoderaw" "-i" "/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/video/AMD_driving_virtual_20-VP9.ivf"
4: info: Input file: AMD_driving_virtual_20-VP9.ivf
4: info: Using built-in bitstream reader
4: info: Using GPU device 0 - AMD Radeon RX 7900 XT[gfx1100] on PCI bus 03:00.0
4: info: decoding started, please wait!
4: Input Video Information
4:      Codec        : VP9
4:      Sequence     : Progressive
4:      Coded size   : [2048, 1024]
4:      Display area : [0, 0, 2048, 1024]
4:      Chroma       : YUV 420
4:      Bit depth    : 8
4: Video Decoding Params:
4:      Num Surfaces : 12
4:      Crop         : [0, 0, 2048, 1024]
4:      Resize       : 2048x1024
4: 
4: info: Total pictures decoded: 601
4: info: Total frames output/displayed: 601
4: info: avg decoding time per picture: 1.08378 ms
4: info: avg decode FPS: 922.693
4: info: avg output/display time per frame: 1.08378 ms
4: info: avg output/display FPS: 922.693
4: 
4/6 Test #4: video_decodeRaw-VP9 ..............   Passed    3.96 sec
test 5
    Start 5: rocdec_Decode-HEVC

5: Test command: /usr/local/bin/ctest "--build-and-test" "/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/samples/rocdecDecode" "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecDecode" "--build-generator" "Unix Makefiles" "--test-command" "rocdecdecode" "-i" "/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/frames"
5: Working Directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test
5: Environment variables: 
5:  LD_PRELOAD=/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib/librocm_sysdeps_va.so.2:/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib/librocm_sysdeps_va-drm.so.2
5:  LIBVA_DRIVERS_PATH=/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib
5: Test timeout computed to be: 1500
5: Internal cmake changing into directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecDecode
5: ======== CMake output     ======
5: The C compiler identification is Clang 23.0.0
5: The CXX compiler identification is Clang 23.0.0
5: Detecting C compiler ABI info
5: Detecting C compiler ABI info - done
5: Check for working C compiler: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/llvm/bin/amdclang - skipped
5: Detecting C compile features
5: Detecting C compile features - done
5: Detecting CXX compiler ABI info
5: Detecting CXX compiler ABI info - done
5: Check for working CXX compiler: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/llvm/bin/amdclang++ - skipped
5: Detecting CXX compile features
5: Detecting CXX compile features - done
5: -- rocdecdecode -- AMD GPU_TARGETS: gfx908;gfx90a;gfx942;gfx1030;gfx1031;gfx1032;gfx1100;gfx1101;gfx1102;gfx950;gfx1150;gfx1151;gfx1152;gfx1153;gfx1200;gfx1201;gfx1250
5: HIP: Using hipcc from relative path: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/bin/hipcc
5: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS
5: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS - Success
5: Found PkgConfig: /usr/bin/pkg-config (found version "0.29.2") 
5: Checking for module 'libavcodec'
5:   Found libavcodec, version 58.134.100
5: Checking for module 'libavformat'
5:   Found libavformat, version 58.76.100
5: Checking for module 'libavutil'
5:   Found libavutil, version 56.70.100
5: -- Using FFMPEG -- 
5:      Libraries:/usr/lib/x86_64-linux-gnu/libavcodec.so;/usr/lib/x86_64-linux-gnu/libavformat.so;/usr/lib/x86_64-linux-gnu/libavutil.so 
5:      Includes:/usr/include/x86_64-linux-gnu
5: Configuring done
5: Generating done
5: Build files have been written to: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecDecode
5: ======== End CMake output ======
5: Change Dir: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecDecode
5: 
5: Run Clean Command:/usr/bin/gmake -f Makefile clean
5: 
5: Run Build Command(s):/usr/bin/gmake -f Makefile && [ 50%] Building CXX object CMakeFiles/rocdecdecode.dir/rocdecdecode.cpp.o
5: [100%] Linking CXX executable rocdecdecode
5: [100%] Built target rocdecdecode
5: 
5: Running test command: "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecDecode/rocdecdecode" "-i" "/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/frames"
5: Read 53 frames from disk.
5: Input Video Information
5:      Codec        : 4
5:      Frame rate   : 30000/1001 = 29.97 fps
5:      Sequence     : Progressive
5:      Coded size   : [2048, 1024]
5:      Display area : [0, 0, 2048, 1024]
5:      Bit depth    : 8
5: Total decoded frames in iteration 0: 53
5: Decoding time: 59182 microseconds
5: Success.
5: 
5: 
5: 
5/6 Test #5: rocdec_Decode-HEVC ...............   Passed    2.36 sec
test 6
    Start 6: rocDecode_Negative_API_Tests

6: Test command: /usr/local/bin/ctest "--build-and-test" "/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/test/rocDecodeNegativeApiTests" "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecodenegativetest" "--build-generator" "Unix Makefiles" "--test-command" "rocdecodenegativetest"
6: Working Directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test
6: Environment variables: 
6:  LD_PRELOAD=/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib/librocm_sysdeps_va.so.2:/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib/librocm_sysdeps_va-drm.so.2
6:  LIBVA_DRIVERS_PATH=/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib
6: Test timeout computed to be: 1500
6: Internal cmake changing into directory: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecodenegativetest
6: ======== CMake output     ======
6: The C compiler identification is Clang 23.0.0
6: The CXX compiler identification is Clang 23.0.0
6: Detecting C compiler ABI info
6: Detecting C compiler ABI info - done
6: Check for working C compiler: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/llvm/bin/amdclang - skipped
6: Detecting C compile features
6: Detecting C compile features - done
6: Detecting CXX compiler ABI info
6: Detecting CXX compiler ABI info - done
6: Check for working CXX compiler: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/llvm/bin/amdclang++ - skipped
6: Detecting CXX compile features
6: Detecting CXX compile features - done
6: HIP: Using hipcc from relative path: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/bin/hipcc
6: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS
6: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS - Success
6: Configuring done
6: Generating done
6: Build files have been written to: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecodenegativetest
6: ======== End CMake output ======
6: Change Dir: /home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecodenegativetest
6: 
6: Run Clean Command:/usr/bin/gmake -f Makefile clean
6: 
6: Run Build Command(s):/usr/bin/gmake -f Makefile && [ 33%] Building CXX object CMakeFiles/rocdecodenegativetest.dir/rocdecodenegativetest.cpp.o
6: [ 66%] Building CXX object CMakeFiles/rocdecodenegativetest.dir/rocdecode_api_negative_tests.cpp.o
6: [100%] Linking CXX executable rocdecodenegativetest
6: [100%] Built target rocdecodenegativetest
6: 
6: Running test command: "/home/lakshmi/work/rocm-systems/projects/rocdecode/build/test/rocdecodenegativetest/rocdecodenegativetest"
6: info: Executing negative test cases for the rocDecCreateDecoder API
6: [0, Critical] rocdecode_api.cpp:37: 1986415068739 us: [pid:1764967 tid:1764967 hashid:0x88f33] rocDecCreateDecoder(): Null pointer
6: [0, Critical] roc_decoder.cpp:51: 1986415068759 us: [pid:1764967 tid:1764967 hashid:0x88f33] InitializeDecoder(): Invalid number of decode surfaces.
6: [0, Critical] vaapi_videodecoder.cpp:1028: 1986415101069 us: [pid:1764967 tid:1764967 hashid:0x88f33] InitHIP(): ERROR: the requested device_id is not found!
6: [0, Critical] vaapi_videodecoder.cpp:686: 1986415101084 us: [pid:1764967 tid:1764967 hashid:0x88f33] GetVaContext(): Failed to initialize the HIP.
6: [0, Critical] vaapi_videodecoder.cpp:824: 1986415101091 us: [pid:1764967 tid:1764967 hashid:0x88f33] CheckDecCapForCodecType(): Failed to initialize.
6: [0, Critical] rocdecode_api.cpp:90: 1986415101096 us: [pid:1764967 tid:1764967 hashid:0x88f33] rocDecGetDecoderCaps(): Error: Failed to obtain decoder capabilities from driver.
6: [0, Critical] vaapi_videodecoder.cpp:130: 1986415101100 us: [pid:1764967 tid:1764967 hashid:0x88f33] InitializeDecoder(): The codec config combination is not supported.
6: [0, Critical] roc_decoder.cpp:61: 1986415101105 us: [pid:1764967 tid:1764967 hashid:0x88f33] InitializeDecoder(): Failed to initialize the VAAPI Video decoder.
6: [0, Critical] vaapi_videodecoder.cpp:130: 1986415102752 us: [pid:1764967 tid:1764967 hashid:0x88f33] InitializeDecoder(): The codec config combination is not supported.
6: [0, Critical] roc_decoder.cpp:61: 1986415102759 us: [pid:1764967 tid:1764967 hashid:0x88f33] InitializeDecoder(): Failed to initialize the VAAPI Video decoder.
6: [0, Critical] vaapi_videodecoder.cpp:130: 1986415102766 us: [pid:1764967 tid:1764967 hashid:0x88f33] InitializeDecoder(): The codec config combination is not supported.
6: [0, Critical] roc_decoder.cpp:61: 1986415102768 us: [pid:1764967 tid:1764967 hashid:0x88f33] InitializeDecoder(): Failed to initialize the VAAPI Video decoder.
6: [0, Critical] vaapi_videodecoder.cpp:130: 1986415102779 us: [pid:1764967 tid:1764967 hashid:0x88f33] InitializeDecoder(): The codec config combination is not supported.
6: [0, Critical] roc_decoder.cpp:61: 1986415102781 us: [pid:1764967 tid:1764967 hashid:0x88f33] InitializeDecoder(): Failed to initialize the VAAPI Video decoder.
6: [0, Critical] vaapi_videodecoder.cpp:894: 1986415102788 us: [pid:1764967 tid:1764967 hashid:0x88f33] CheckDecCapForCodecType(): VAAPI failure: vaCreateConfig(va_contexts_[va_ctx_id].va_display, va_contexts_[va_ctx_id].va_profile, VAEntrypointVLD, &va_config_attrib, 1, &va_contexts_[va_ctx_id].va_config_id) failed with 'status: 13: the requested VAEntryPoint is not supported' at /home/lakshmi/work/rocm-systems/projects/rocdecode/src/rocdecode/vaapi/vaapi_videodecoder.cpp:894
6: [0, Critical] rocdecode_api.cpp:90: 1986415102795 us: [pid:1764967 tid:1764967 hashid:0x88f33] rocDecGetDecoderCaps(): Error: Failed to obtain decoder capabilities from driver.
6: [0, Critical] vaapi_videodecoder.cpp:130: 1986415102798 us: [pid:1764967 tid:1764967 hashid:0x88f33] InitializeDecoder(): The codec config combination is not supported.
6: [0, Critical] roc_decoder.cpp:61: 1986415102800 us: [pid:1764967 tid:1764967 hashid:0x88f33] InitializeDecoder(): Failed to initialize the VAAPI Video decoder.
6: info: Executing negative test cases for the rocDecDestroyDecoder API
6: info: Executing negative test cases for the rocDecGetDecoderCaps API
6: info: Executing negative test cases for the rocDecDecodeFrame API
6: info: Executing negative test cases for the rocDecGetDecodeStatus API
6: info: Executing negative test cases for the rocDecReconfigureDecoder API
6: info: Executing negative test cases for the rocDecGetVideoFrame API
6: info: Executing negative test cases for the rocDecGetErrorName API
6: info: Executing negative test cases for the rocDecCreateVideoParser API
6: [0, Critical] roc_decoder.cpp:124: 1986415103702 us: [pid:1764967 tid:1764967 hashid:0x88f33] GetVideoFrame(): Invalid parameters.
6: [0, Critical] rocparser_api.cpp:44: 1986415103711 us: [pid:1764967 tid:1764967 hashid:0x88f33] rocDecCreateVideoParser(): Error: The current version of rocDecode officially supports only the H.265 (HEVC), H.264 (AVC), AV1 and VP9 codecs.
6: info: Executing negative test cases for the rocDecParseVideoData API
6: info: Executing negative test cases for the rocDecDestroyVideoParser API
6: info: Executing negative test cases for the rocDecCreateBitstreamReader API
6: info: Executing negative test cases for the rocDecGetBitstreamCodecType API
6: info: Executing negative test cases for the rocDecGetBitstreamBitDepth API
6: [0, Critical] roc_bs_reader_api.cpp:31: 1986415104198 us: [pid:1764967 tid:1764967 hashid:0x88f33] rocDecCreateBitstreamReader(): Null pointer
6: [0, Critical] roc_bs_reader_api.cpp:31: 1986415104202 us: [pid:1764967 tid:1764967 hashid:0x88f33] rocDecCreateBitstreamReader(): Null pointer
6: [0, Critical] roc_bs_reader_api.cpp:52: 1986415104206 us: [pid:1764967 tid:1764967 hashid:0x88f33] rocDecGetBitstreamCodecType(): Null pointer
6: [0, Critical] roc_bs_reader_api.cpp:52: 1986415104210 us: [pid:1764967 tid:1764967 hashid:0x88f33] rocDecGetBitstreamCodecType(): Null pointer
6: [0, Critical] roc_bs_reader_api.cpp:74: 1986415104214 us: [pid:1764967 tid:1764967 hashid:0x88f33] rocDecGetBitstreamBitDepth(): Null pointer
6: [0, Critical] roc_bs_reader_api.cpp:74: 1986415104217 us: [pid:1764967 tid:1764967 hashid:0x88f33] rocDecGetBitstreamBitDepth(): Null pointer
6: [0, Critical] roc_bs_reader_api.cpp:96: 1986415104222 us: [pid:1764967 tid:1764967 hashid:0x88f33] rocDecGetBitstreamPicData(): Null pointer
6: info: Executing negative test cases for the rocDecGetBitstreamPicData API
6: info: Executing negative test cases for the rocDecDestroyBitstreamReader API
6: Test Passed!
6: [0, Critical] roc_bs_reader_api.cpp:96: 1986415104225 us: [pid:1764967 tid:1764967 hashid:0x88f33] rocDecGetBitstreamPicData(): Null pointer
6: [0, Critical] roc_bs_reader_api.cpp:118: 1986415104229 us: [pid:1764967 tid:1764967 hashid:0x88f33] rocDecDestroyBitstreamReader(): Null pointer
6: 
6/6 Test #6: rocDecode_Negative_API_Tests .....   Passed    2.00 sec

100% tests passed, 0 tests failed out of 6

Total Test time (real) =  19.96 sec
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
