### PR TITLE
refactor(rocdbgapi): unify interface for make_gfx*_cwsr_record

### DIFF
--- a/projects/rocdbgapi/src/architecture.cpp
+++ b/projects/rocdbgapi/src/architecture.cpp
@@ -2496,13 +2496,14 @@ protected:
   };
 
   virtual std::unique_ptr<architecture_t::cwsr_record_t>
-  make_gfx9_cwsr_record (compute_queue_t &queue, uint32_t xcc_id,
-                         uint32_t compute_relaunch_wave,
-                         uint32_t compute_relaunch_state,
-                         agent_address_t context_save_address) const
+  make_cwsr_record (compute_queue_t &queue, uint32_t xcc_id,
+                    uint32_t compute_relaunch_wave,
+                    const std::vector<uint32_t> &compute_relaunch_state,
+                    agent_address_t context_save_address) const
   {
+    dbgapi_assert (compute_relaunch_state.size () == 1);
     return std::make_unique<cwsr_record_t> (
-      queue, xcc_id, compute_relaunch_wave, compute_relaunch_state,
+      queue, xcc_id, compute_relaunch_wave, compute_relaunch_state[0],
       context_save_address);
   }
 
@@ -3319,7 +3320,7 @@ gfx9_architecture_t::control_stack_iterate (
   const
 {
   size_t wave_count = 0;
-  uint32_t state = 0;
+  std::vector<uint32_t> state{ 0 };
 
   agent_address_t last_wave_area = wave_area_address;
 
@@ -3334,12 +3335,12 @@ gfx9_architecture_t::control_stack_iterate (
         }
       else if (compute_relaunch_is_state (relaunch))
         {
-          state = relaunch;
+          state[0] = relaunch;
         }
       else
         {
-          auto cwsr_record = make_gfx9_cwsr_record (
-            queue, xcc_id, relaunch, state, last_wave_area - 64);
+          auto cwsr_record = make_cwsr_record (queue, xcc_id, relaunch, state,
+                                               last_wave_area - 64);
 
           last_wave_area
             = cwsr_record->register_address (amdgpu_regnum_t::v0_64).value ();
@@ -3512,10 +3513,10 @@ protected:
   };
 
   std::unique_ptr<architecture_t::cwsr_record_t>
-  make_gfx9_cwsr_record (compute_queue_t &queue, uint32_t xcc_id,
-                         uint32_t compute_relaunch_wave,
-                         uint32_t compute_relaunch_state,
-                         agent_address_t context_save_address) const override
+  make_cwsr_record (compute_queue_t &queue, uint32_t xcc_id,
+                    uint32_t compute_relaunch_wave,
+                    const std::vector<uint32_t> &compute_relaunch_state,
+                    agent_address_t context_save_address) const override
     = 0;
 
   mi_architecture_t (elf_amdgpu_machine_t e_machine,
@@ -3661,13 +3662,14 @@ class gfx908_t final : public mi_architecture_t
   };
 
   std::unique_ptr<architecture_t::cwsr_record_t>
-  make_gfx9_cwsr_record (compute_queue_t &queue, uint32_t xcc_id,
-                         uint32_t compute_relaunch_wave,
-                         uint32_t compute_relaunch_state,
-                         agent_address_t context_save_address) const override
+  make_cwsr_record (compute_queue_t &queue, uint32_t xcc_id,
+                    uint32_t compute_relaunch_wave,
+                    const std::vector<uint32_t> &compute_relaunch_state,
+                    agent_address_t context_save_address) const override
   {
+    dbgapi_assert (compute_relaunch_state.size () == 1);
     return std::make_unique<cwsr_record_t> (
-      queue, xcc_id, compute_relaunch_wave, compute_relaunch_state,
+      queue, xcc_id, compute_relaunch_wave, compute_relaunch_state[0],
       context_save_address);
   }
 
@@ -3724,13 +3726,14 @@ protected:
   };
 
   std::unique_ptr<architecture_t::cwsr_record_t>
-  make_gfx9_cwsr_record (compute_queue_t &queue, uint32_t xcc_id,
-                         uint32_t compute_relaunch_wave,
-                         uint32_t compute_relaunch_state,
-                         agent_address_t context_save_address) const override
+  make_cwsr_record (compute_queue_t &queue, uint32_t xcc_id,
+                    uint32_t compute_relaunch_wave,
+                    const std::vector<uint32_t> &compute_relaunch_state,
+                    agent_address_t context_save_address) const override
   {
+    dbgapi_assert (compute_relaunch_state.size () == 1);
     return std::make_unique<cwsr_record_t> (
-      queue, xcc_id, compute_relaunch_wave, compute_relaunch_state,
+      queue, xcc_id, compute_relaunch_wave, compute_relaunch_state[0],
       context_save_address);
   }
 
@@ -3843,13 +3846,14 @@ protected:
   };
 
   std::unique_ptr<architecture_t::cwsr_record_t>
-  make_gfx9_cwsr_record (compute_queue_t &queue, uint32_t xcc_id,
-                         uint32_t compute_relaunch_wave,
-                         uint32_t compute_relaunch_state,
-                         agent_address_t context_save_address) const override
+  make_cwsr_record (compute_queue_t &queue, uint32_t xcc_id,
+                    uint32_t compute_relaunch_wave,
+                    const std::vector<uint32_t> &compute_relaunch_state,
+                    agent_address_t context_save_address) const override
   {
+    dbgapi_assert (compute_relaunch_state.size () == 1);
     return std::make_unique<cwsr_record_t> (
-      queue, xcc_id, compute_relaunch_wave, compute_relaunch_state,
+      queue, xcc_id, compute_relaunch_wave, compute_relaunch_state[0],
       context_save_address);
   }
 
@@ -4266,13 +4270,14 @@ protected:
   };
 
   std::unique_ptr<architecture_t::cwsr_record_t>
-  make_gfx9_cwsr_record (compute_queue_t &queue, uint32_t xcc_id,
-                         uint32_t compute_relaunch_wave,
-                         uint32_t compute_relaunch_state,
-                         agent_address_t context_save_address) const override
+  make_cwsr_record (compute_queue_t &queue, uint32_t xcc_id,
+                    uint32_t compute_relaunch_wave,
+                    const std::vector<uint32_t> &compute_relaunch_state,
+                    agent_address_t context_save_address) const override
   {
+    dbgapi_assert (compute_relaunch_state.size () == 1);
     return std::make_unique<cwsr_record_t> (
-      queue, xcc_id, compute_relaunch_wave, compute_relaunch_state,
+      queue, xcc_id, compute_relaunch_wave, compute_relaunch_state[0],
       context_save_address);
   }
 
@@ -4374,16 +4379,16 @@ protected:
     register_address (amdgpu_regnum_t regnum) const override;
   };
 
-  virtual std::unique_ptr<architecture_t::cwsr_record_t>
-  make_gfx1x_cwsr_record (compute_queue_t &queue, uint32_t xcc_id,
-                          uint32_t compute_relaunch_wave,
-                          uint32_t compute_relaunch_state,
-                          uint32_t compute_relaunch2_state,
-                          agent_address_t context_save_address) const
+  std::unique_ptr<architecture_t::cwsr_record_t>
+  make_cwsr_record (compute_queue_t &queue, uint32_t xcc_id,
+                    uint32_t compute_relaunch_wave,
+                    const std::vector<uint32_t> &compute_relaunch_state,
+                    agent_address_t context_save_address) const override
   {
+    dbgapi_assert (compute_relaunch_state.size () == 2);
     return std::make_unique<cwsr_record_t> (
-      queue, xcc_id, compute_relaunch_wave, compute_relaunch_state,
-      compute_relaunch2_state, context_save_address);
+      queue, xcc_id, compute_relaunch_wave, compute_relaunch_state[0],
+      compute_relaunch_state[1], context_save_address);
   }
 
   std::optional<amdgpu_regnum_t>
@@ -5290,7 +5295,7 @@ gfx10_architecture_t::control_stack_iterate (
   const
 {
   size_t wave_count = 0;
-  uint32_t state0 = 0, state1 = 0;
+  std::vector<uint32_t> state{ 0, 0 };
 
   agent_address_t last_wave_area = wave_area_address;
 
@@ -5305,15 +5310,15 @@ gfx10_architecture_t::control_stack_iterate (
         }
       else if (compute_relaunch_is_state (relaunch))
         {
-          state0 = relaunch;
+          state[0] = relaunch;
           /* On gfx10 and gfx11, there are 2 COMPUTE_RELAUNCH registers for
              state.  */
-          state1 = control_stack[++i];
+          state[1] = control_stack[++i];
         }
       else
         {
-          auto cwsr_record = make_gfx1x_cwsr_record (
-            queue, xcc_id, relaunch, state0, state1, last_wave_area);
+          auto cwsr_record = make_cwsr_record (queue, xcc_id, relaunch, state,
+                                               last_wave_area);
 
           last_wave_area = cwsr_record->begin ();
           wave_callback (std::move (cwsr_record));
@@ -5474,14 +5479,16 @@ protected:
     uint32_t shader_engine_id () const override;
   };
 
-  std::unique_ptr<architecture_t::cwsr_record_t> make_gfx1x_cwsr_record (
-    compute_queue_t &queue, uint32_t xcc_id, uint32_t compute_relaunch_wave,
-    uint32_t compute_relaunch_state, uint32_t compute_relaunch2_state,
-    agent_address_t context_save_address) const override
+  std::unique_ptr<architecture_t::cwsr_record_t>
+  make_cwsr_record (compute_queue_t &queue, uint32_t xcc_id,
+                    uint32_t compute_relaunch_wave,
+                    const std::vector<uint32_t> &compute_relaunch_state,
+                    agent_address_t context_save_address) const override
   {
+    dbgapi_assert (compute_relaunch_state.size () == 2);
     return std::make_unique<cwsr_record_t> (
-      queue, xcc_id, compute_relaunch_wave, compute_relaunch_state,
-      compute_relaunch2_state, context_save_address);
+      queue, xcc_id, compute_relaunch_wave, compute_relaunch_state[0],
+      compute_relaunch_state[1], context_save_address);
   }
 
   std::optional<amdgpu_regnum_t>
@@ -6313,14 +6320,16 @@ protected:
     size_t lds_size () const override;
   };
 
-  std::unique_ptr<architecture_t::cwsr_record_t> make_gfx1x_cwsr_record (
-    compute_queue_t &queue, uint32_t xcc_id, uint32_t compute_relaunch_wave,
-    uint32_t compute_relaunch_state, uint32_t compute_relaunch2_state,
-    agent_address_t context_save_address) const override
+  std::unique_ptr<architecture_t::cwsr_record_t>
+  make_cwsr_record (compute_queue_t &queue, uint32_t xcc_id,
+                    uint32_t compute_relaunch_wave,
+                    const std::vector<uint32_t> &compute_relaunch_state,
+                    agent_address_t context_save_address) const override
   {
+    dbgapi_assert (compute_relaunch_state.size () == 2);
     return std::make_unique<cwsr_record_t> (
-      queue, xcc_id, compute_relaunch_wave, compute_relaunch_state,
-      compute_relaunch2_state, context_save_address);
+      queue, xcc_id, compute_relaunch_wave, compute_relaunch_state[0],
+      compute_relaunch_state[1], context_save_address);
   }
 
   gfx12_architecture_t (elf_amdgpu_machine_t e_machine,
@@ -7622,16 +7631,14 @@ protected:
   };
 
   std::unique_ptr<architecture_t::cwsr_record_t>
-  make_gfx1x_cwsr_record (compute_queue_t &queue,
-                          uint32_t xcc_id,
-                          uint32_t compute_relaunch_wave,
-                          uint32_t compute_relaunch_state,
-                          uint32_t compute_relaunch2_state,
-                          agent_address_t context_save_address) const override
+  make_cwsr_record (compute_queue_t &queue, uint32_t xcc_id,
+                    uint32_t compute_relaunch_wave,
+                    const std::vector<uint32_t> &compute_relaunch_state,
+                    agent_address_t context_save_address) const override
   {
     return std::make_unique<cwsr_record_t> (
-      queue, xcc_id, compute_relaunch_wave, compute_relaunch_state,
-      compute_relaunch2_state, context_save_address);
+      queue, xcc_id, compute_relaunch_wave, compute_relaunch_state[0],
+      compute_relaunch_state[1], context_save_address);
   }
 
   /* A note regarding all the register methods in this class:


### PR DESCRIPTION
## Motivation

In the current implementation, different architectures need to create CWSR record from different amount of data.  On gfx9, we have one dword of wave state, and one dword of common state (state common to multiple waves in a workgroup).  On gfx10 architectures, the common state is 2 dwords instead.  This lead to the introduction of two different functions: make_gfx9_cwsr_record and make_gfx1x_cwsr_record.

## Technical Details

This patch proposed to have a unified make_cwsr_record, which a const reference to a vector vector of dwords for shared state.  This way, the same interface can be used for all supported architectures.

Ideally, the interface should use a std::span, but this is c++20, so not available to us yet.  Instead the const ref to a vector is the closest approximation we have.

## JIRA ID

JIRA ID: AIROCGDB-1234

## Test Plan

Use ROCgdb's testsuite on gfx1031, and use CI to run on gfx940.

## Test Result

PASS for gfx1031, no observable change.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
