### PR TITLE
fix(amdsmi): fix buffer overflow and add compile time checks

### DIFF
--- a/projects/amdsmi/CMakeLists.txt
+++ b/projects/amdsmi/CMakeLists.txt
@@ -275,6 +275,7 @@ endif()
 # Security options
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wconversion -Wcast-align")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wformat=2 -fno-common -Wstrict-overflow")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=format-overflow")
 # Intentionally leave out -Wsign-promo. It causes spurious warnings.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Woverloaded-virtual -Wreorder")
 

--- a/projects/amdsmi/CMakeLists.txt
+++ b/projects/amdsmi/CMakeLists.txt
@@ -275,7 +275,11 @@ endif()
 # Security options
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wconversion -Wcast-align")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wformat=2 -fno-common -Wstrict-overflow")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=format-overflow")
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag("-Werror=format-overflow" CXX_SUPPORTS_FORMAT_OVERFLOW)
+if(CXX_SUPPORTS_FORMAT_OVERFLOW)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=format-overflow")
+endif()
 # Intentionally leave out -Wsign-promo. It causes spurious warnings.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Woverloaded-virtual -Wreorder")
 

--- a/projects/amdsmi/cmake_modules/help_package.cmake
+++ b/projects/amdsmi/cmake_modules/help_package.cmake
@@ -65,6 +65,10 @@ function(generic_package)
         if(CXX_SUPPORTS_WTRAMPOLINES)
             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wtrampolines" PARENT_SCOPE)
         endif()
+        check_cxx_compiler_flag("-Werror=stringop-overflow" CXX_SUPPORTS_STRINGOP_OVERFLOW)
+        if(CXX_SUPPORTS_STRINGOP_OVERFLOW)
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=stringop-overflow" PARENT_SCOPE)
+        endif()
     endif()
 
     # Clang does not set the build-id

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_binary_parser.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_binary_parser.cc
@@ -78,9 +78,9 @@ static int parse_pmmetric_table(uint8_t* buf, struct metric_field* table, int32_
         *kv = reinterpret_cast<rsmi_name_value_t*>(realloc(*kv, kvsize * (sizeof **kv)));
       }
       if (table[x].field_arr_size == 1) {
-        sprintf((*kv)[*kvnum].name, "%s", table[x].field_name);
+        snprintf((*kv)[*kvnum].name, sizeof((*kv)[*kvnum].name), "%s", table[x].field_name);
       } else {
-        sprintf((*kv)[*kvnum].name, "%s[%d]", table[x].field_name, y);
+        snprintf((*kv)[*kvnum].name, sizeof((*kv)[*kvnum].name), "%s[%d]", table[x].field_name, y);
       }
       (*kv)[*kvnum].value = v1;
 
@@ -197,15 +197,19 @@ top:
         kvsize += 64;
         *kv = reinterpret_cast<rsmi_name_value_t*>(realloc(*kv, kvsize * (sizeof **kv)));
       }
-      sprintf((*kv)[*kvnum].name, "%s", table[x].field_name);
+      snprintf((*kv)[*kvnum].name, sizeof((*kv)[*kvnum].name), "%s", table[x].field_name);
       if (table[x].field_arr_size > 1) {
-        sprintf((*kv)[*kvnum].name + strlen((*kv)[*kvnum].name), "[%" PRId64 "]", y);
+        snprintf((*kv)[*kvnum].name + strlen((*kv)[*kvnum].name),
+                 sizeof((*kv)[*kvnum].name) - strlen((*kv)[*kvnum].name), "[%" PRId64 "]", y);
       }
       if (x >= instance_start)
-        sprintf((*kv)[*kvnum].name + strlen((*kv)[*kvnum].name), ".instance[%" PRId64 "]",
-                cur_instance);
+        snprintf((*kv)[*kvnum].name + strlen((*kv)[*kvnum].name),
+                 sizeof((*kv)[*kvnum].name) - strlen((*kv)[*kvnum].name), ".instance[%" PRId64 "]",
+                 cur_instance);
       if (x >= smn_start)
-        sprintf((*kv)[*kvnum].name + strlen((*kv)[*kvnum].name), ".smn[%" PRId64 "]", cur_smn);
+        snprintf((*kv)[*kvnum].name + strlen((*kv)[*kvnum].name),
+                 sizeof((*kv)[*kvnum].name) - strlen((*kv)[*kvnum].name), ".smn[%" PRId64 "]",
+                 cur_smn);
       (*kv)[*kvnum].value = v;
       ++(*kvnum);
     }

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_binary_parser.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_binary_parser.cc
@@ -200,15 +200,15 @@ top:
       snprintf((*kv)[*kvnum].name, sizeof((*kv)[*kvnum].name), "%s", table[x].field_name);
       if (table[x].field_arr_size > 1) {
         snprintf((*kv)[*kvnum].name + strlen((*kv)[*kvnum].name),
-                 sizeof((*kv)[*kvnum].name) - strlen((*kv)[*kvnum].name), "[%" PRId64 "]", y);
+                 sizeof((*kv)[*kvnum].name) - strlen((*kv)[*kvnum].name), "[%" PRIu64 "]", y);
       }
       if (x >= instance_start)
         snprintf((*kv)[*kvnum].name + strlen((*kv)[*kvnum].name),
-                 sizeof((*kv)[*kvnum].name) - strlen((*kv)[*kvnum].name), ".instance[%" PRId64 "]",
+                 sizeof((*kv)[*kvnum].name) - strlen((*kv)[*kvnum].name), ".instance[%" PRIu64 "]",
                  cur_instance);
       if (x >= smn_start)
         snprintf((*kv)[*kvnum].name + strlen((*kv)[*kvnum].name),
-                 sizeof((*kv)[*kvnum].name) - strlen((*kv)[*kvnum].name), ".smn[%" PRId64 "]",
+                 sizeof((*kv)[*kvnum].name) - strlen((*kv)[*kvnum].name), ".smn[%" PRIu64 "]",
                  cur_smn);
       (*kv)[*kvnum].value = v;
       ++(*kvnum);


### PR DESCRIPTION
## Motivation
Static code scan indicated potential buffer overflow.

## Technical Details
Fixed potential for overflow by changing sprintf to snprintf and adding additional compile time checks for buffer overflow.

## JIRA ID
JIRA ID : ROCM-26668
