### PR TITLE
fix(rccl): IR - Fix WarpSpan named-barrier LDS in bitcode

### DIFF
--- a/projects/rccl/bindings/ir/nccl_device_wrapper.h
+++ b/projects/rccl/bindings/ir/nccl_device_wrapper.h
@@ -114,7 +114,7 @@ struct ncclLsaBarrierSession_C {
 NCCL_IR_EXPORT void ncclCoopAnyInitThread(ncclCoopAny* coop);
 NCCL_IR_EXPORT void ncclCoopAnyInitWarp(ncclCoopAny* coop);
 NCCL_IR_EXPORT void ncclCoopAnyInitLanes(ncclCoopAny* coop, ncclCoopMask_t lane_mask);
-NCCL_IR_EXPORT void ncclCoopAnyInitWarpSpan(ncclCoopAny* coop, int warp0, int nWarps, int id);
+NCCL_IR_EXPORT void ncclCoopAnyInitWarpSpan(ncclCoopAny* coop, int warp0, int nWarps, int id, void* barrierLds);
 NCCL_IR_EXPORT void ncclCoopAnyInitCta(ncclCoopAny* coop);
 
 NCCL_IR_EXPORT int  ncclCoopThreadRank(const ncclCoopAny* coop);

--- a/projects/rccl/bindings/ir/nccl_device_wrapper__impl.h
+++ b/projects/rccl/bindings/ir/nccl_device_wrapper__impl.h
@@ -74,8 +74,16 @@ NCCL_IR_EXPORT void ncclCoopAnyInitWarp(ncclCoopAny* coop) {
 NCCL_IR_EXPORT void ncclCoopAnyInitLanes(ncclCoopAny* coop, ncclCoopMask_t lane_mask) {
   ::new (coop) ncclCoopAny(ncclCoopLanes(lane_mask));
 }
-NCCL_IR_EXPORT void ncclCoopAnyInitWarpSpan(ncclCoopAny* coop, int warp0, int nWarps, int id) {
+NCCL_IR_EXPORT void ncclCoopAnyInitWarpSpan(ncclCoopAny* coop, int warp0, int nWarps, int id, void* barrierLds) {
+#if defined(__HIP_PLATFORM_AMD__)
+  /* barrierLds is a kernel-owned __shared__ slot array; the bitcode build has no
+   * function-local LDS of its own (see coop.h), so the WarpSpan barrier uses this. */
+  ::new (coop) ncclCoopAny(ncclCoopWarpSpan(warp0, nWarps, id,
+                           static_cast<ncclCoopNamedBarrierSlot*>(barrierLds)));
+#else
+  (void)barrierLds;
   ::new (coop) ncclCoopAny(ncclCoopWarpSpan(warp0, nWarps, id));
+#endif
 }
 NCCL_IR_EXPORT void ncclCoopAnyInitCta(ncclCoopAny* coop) {
   ::new (coop) ncclCoopAny(ncclCoopCta{});

--- a/projects/rccl/bindings/ir/test/IR_test.cpp
+++ b/projects/rccl/bindings/ir/test/IR_test.cpp
@@ -214,7 +214,8 @@ __global__ void k_coop_lanes_r(CoopResult* out, uint64_t mask) {
 }
 
 __global__ void k_coop_warpspan_r(CoopResult* out, int warp0, int nWarps, int id) {
-  ncclCoopAny coop; ncclCoopAnyInitWarpSpan(&coop, warp0, nWarps, id);
+  /* Data-only kernel (size/rank accessors, no sync) -> no barrier scratch needed. */
+  ncclCoopAny coop; ncclCoopAnyInitWarpSpan(&coop, warp0, nWarps, id, /*barrierLds=*/nullptr);
   int tid = blockIdx.x * blockDim.x + threadIdx.x;
   out[tid] = { ncclCoopSize(&coop),
                ncclCoopThreadRank(&coop),
@@ -236,7 +237,14 @@ __global__ void k_coop_cta_r(CoopResult* out) {
 __global__ void k_sync_thread  (int* out)                               { ncclCoopAny c; ncclCoopAnyInitThread  (&c);                ncclCoopSync(&c); int t=blockIdx.x*blockDim.x+threadIdx.x; out[t]=1; }
 __global__ void k_sync_warp    (int* out)                               { ncclCoopAny c; ncclCoopAnyInitWarp    (&c);                ncclCoopSync(&c); int t=blockIdx.x*blockDim.x+threadIdx.x; out[t]=1; }
 __global__ void k_sync_lanes   (int* out, uint64_t mask)                { ncclCoopAny c; ncclCoopAnyInitLanes   (&c, mask);          ncclCoopSync(&c); int t=blockIdx.x*blockDim.x+threadIdx.x; out[t]=1; }
-__global__ void k_sync_warpspan(int* out, int warp0, int nWarps, int id){ ncclCoopAny c; ncclCoopAnyInitWarpSpan(&c,warp0,nWarps,id);ncclCoopSync(&c); int t=blockIdx.x*blockDim.x+threadIdx.x; out[t]=1; }
+__global__ void k_sync_warpspan(int* out, int warp0, int nWarps, int id){
+  /* Kernel owns the named-barrier LDS and hands it to the bitcode thunk, so the
+   * backend sizes it into THIS kernel's group segment (see coop.h rationale). */
+  __shared__ ncclCoopNamedBarrierSlot bar[ncclCoopNamedBarrierSlots];
+  ncclCoopNamedBarrierInit(bar);
+  ncclCoopAny c; ncclCoopAnyInitWarpSpan(&c, warp0, nWarps, id, bar);
+  ncclCoopSync(&c); int t=blockIdx.x*blockDim.x+threadIdx.x; out[t]=1;
+}
 __global__ void k_sync_cta     (int* out)                               { ncclCoopAny c; ncclCoopAnyInitCta     (&c);                ncclCoopSync(&c); int t=blockIdx.x*blockDim.x+threadIdx.x; out[t]=1; }
 
 /* =====================================================================

--- a/projects/rccl/src/include/nccl_device/coop.h
+++ b/projects/rccl/src/include/nccl_device/coop.h
@@ -153,26 +153,53 @@ struct ncclCoopLanes { // Some lanes of this warp.
 constexpr int ncclCoopNamedBarrierSlots = 16; // mirrors CUDA's 16 hardware named barriers (ids 0-15)
 struct ncclCoopNamedBarrierSlot { uint32_t arrive; uint32_t sense; };
 
+#if !defined(__clang_llvm_bitcode_lib__)
+// Native/in-tree path: function-local LDS. It is statically reachable from the
+// kernel that inlines this, so the backend sizes it into the kernel's group
+// segment. Compiled out of the bitcode library, where the only path to the
+// LDS-using sync() is an indirect (vtable) call the LDS-sizing pass can't see.
 NCCL_DEVICE_INLINE ncclCoopNamedBarrierSlot* ncclCoopNamedBarrierState() {
   __shared__ ncclCoopNamedBarrierSlot slots[ncclCoopNamedBarrierSlots];
   return slots;
 }
+#endif
 
-NCCL_DEVICE_INLINE void ncclCoopNamedBarrierInit() {
-  ncclCoopNamedBarrierSlot* slots = ncclCoopNamedBarrierState();
+// Zero caller-provided (kernel-owned) slots before first use. The bitcode
+// binding passes a kernel __shared__ pointer here so the LDS lives in the
+// launching kernel rather than in the indirectly-called thunk.
+NCCL_DEVICE_INLINE void ncclCoopNamedBarrierInit(ncclCoopNamedBarrierSlot* slots) {
   for (int i = threadIdx.x; i < ncclCoopNamedBarrierSlots; i += blockDim.x) { slots[i].arrive = 0; slots[i].sense = 0; }
   __syncthreads();
 }
+
+#if !defined(__clang_llvm_bitcode_lib__)
+// Back-compat no-arg form: existing in-tree kernels keep calling this unchanged.
+NCCL_DEVICE_INLINE void ncclCoopNamedBarrierInit() {
+  ncclCoopNamedBarrierInit(ncclCoopNamedBarrierState());
+}
+#endif
 #else
 NCCL_DEVICE_INLINE void ncclCoopNamedBarrierInit() {}
 #endif
 
 struct ncclCoopWarpSpan {
   uint32_t warp0:8, nWarps:8, id:8;
+#if defined(__HIP_PLATFORM_AMD__)
+  // Caller/kernel-owned named-barrier scratch. Optional on native AMD (sync()
+  // falls back to function-local LDS); supplied by the bitcode thunk, where a
+  // function-local __shared__ in this indirectly-called code can't be sized
+  // into the launching kernel's group segment (HSA exception 0x1016 otherwise).
+  ncclCoopNamedBarrierSlot* slots;
 
+  NCCL_DEVICE_INLINE constexpr ncclCoopWarpSpan(int warp0, int nWarps, int id,
+                                                ncclCoopNamedBarrierSlot* slots = nullptr):
+    warp0(warp0), nWarps(nWarps), id(id), slots(slots) {
+  }
+#else
   NCCL_DEVICE_INLINE constexpr ncclCoopWarpSpan(int warp0, int nWarps, int id):
     warp0(warp0), nWarps(nWarps), id(id) {
   }
+#endif
 
   NCCL_DEVICE_INLINE int thread_rank() const {
     return threadIdx.x - WARP_SIZE*warp0;
@@ -190,7 +217,11 @@ struct ncclCoopWarpSpan {
     // Single-warp span is lockstep: skip the shared atomic (hot path) and just fence.
     using Atom = cuda::atomic_ref<uint32_t, cuda::thread_scope_block>;
     if (nWarps <= 1) { cuda::atomic_thread_fence(cuda::memory_order_acq_rel, cuda::thread_scope_block); return; }
-    ncclCoopNamedBarrierSlot* slot = &ncclCoopNamedBarrierState()[id];
+  #if defined(__clang_llvm_bitcode_lib__)
+    ncclCoopNamedBarrierSlot* slot = &slots[id];                          // bitcode: caller-owned LDS only
+  #else
+    ncclCoopNamedBarrierSlot* slot = &(slots ? slots : ncclCoopNamedBarrierState())[id];
+  #endif
     cuda::atomic_thread_fence(cuda::memory_order_release, cuda::thread_scope_block);
     if ((threadIdx.x % WARP_SIZE) == 0) {  // one leader per warp
       uint32_t s = Atom{slot->sense}.load(cuda::memory_order_relaxed);
@@ -209,6 +240,11 @@ struct ncclCoopWarpSpan {
 #endif
   }
 };
+#if defined(__HIP_PLATFORM_AMD__)
+// The added scratch pointer must keep ncclCoopWarpSpan within ncclCoopAny's
+// type-erased Storage (16 bytes); this is tight (4B bitfield + 8B pointer).
+static_assert(sizeof(ncclCoopWarpSpan) <= 16, "ncclCoopWarpSpan must fit ncclCoopAny::Storage");
+#endif
 #endif
 
 #if NCCL_CHECK_CUDACC


### PR DESCRIPTION
Making ncclCoopWarpSpan named-barrier LDS kernel-owned in bitcode:
ncclCoopSync on a multi-warp WarpSpan aborted with HSA_STATUS_ERROR_EXCEPTION (0x1016) when driven through librccl_device.bc. The AMD software named barrier kept its scratch in a function-local __shared__ (ncclCoopNamedBarrierState), and in the bitcode binding that LDS-using sync() is reached only indirectly via the ncclCoopAny vtable. AMDGPU sizes a kernel's group segment from the static call graph, so an indirect-only path leaves the launching kernel with group_seg_size=0 and the runtime LDS access faults. Let the launching kernel own the named-barrier scratch and pass it in:
- coop.h: ncclCoopWarpSpan gains an (AMD-only, defaulted) slots pointer; sync() uses it directly in the bitcode build (__clang_llvm_bitcode_lib__) and the function-local __shared__ is compiled out there, so the .bc emits no __shared__ (LDS, addrspace(3)). Native/in-tree builds keep the internal LDS via a fallback, so existing kernels are unchanged. Adds a size static_assert.
- nccl_device_wrapper{,__impl}.h: ncclCoopAnyInitWarpSpan takes a barrierLds pointer and threads it into the coop.
- IR_test.cpp: k_sync_warpspan declares the __shared__ slots and passes them. Verified: rebuilt bitcode has 0 __shared__ (LDS, addrspace(3) globals; B6 CoopSync passes with a clean log; host librccl.so still links.

## Motivation

The RCCL device-API bitcode binding (librccl_device.bc) exposes ncclCoopSync so kernels can synchronize a cooperative group without inlining NCCL's device headers. On AMD GPUs a multi-warp ncclCoopWarpSpan sync is emulated with a software named barrier, and any kernel that drove that sync through the bitcode aborted with HSA_STATUS_ERROR_EXCEPTION (code 0x1016). A hard hardware fault that crashed the launching kernel and made the sub-block WarpSpan barrier unusable via the binding. This blocked the coop-sync unit test (B6_CoopSync) and, more importantly, any downstream consumer that relies on the bitcode for WarpSpan/CTA-level synchronization, so the binding could not be trusted for real multi-warp workloads.

## Technical Details

The named barrier kept its state in a function-local __shared__ array (ncclCoopNamedBarrierState), i.e. a shared-memory/LDS (addrspace(3)) global baked into the bitcode. Shared memory is a per-workgroup resource that must be reserved at launch (the group_seg_size field), and AMDGPU determines the amount by walking the static call graph from each kernel to every LDS variable it can reach. In the binding, ncclCoopAny is type-erased, so the LDS-using sync() is reached only through an indirect vtable function pointer; the static walk can't follow that edge, so the kernel launched with group_seg_size=0 and the barrier's shared-memory access ran off unreserved LDS, triggering 0x1016. The fix makes the launching kernel own the scratch: ncclCoopWarpSpan gains an (AMD-only, defaulted) slots pointer, ncclCoopAnyInitWarpSpan takes a barrierLds argument, and in the bitcode build (__clang_llvm_bitcode_lib__) sync() dereferences that caller-provided pointer while the internal __shared__ is compiled out — so the .bc emits no LDS global at all and there is nothing for the sizing pass to miss. Native/in-tree builds keep the function-local __shared__ via a fallback path (the pointer defaults to the internal state), leaving existing kernels and the CUDA path byte-for-byte unchanged; a static_assert guarantees the added pointer still fits ncclCoopAny's 16-byte type-erased storage.

## JIRA ID

JIRA ID : AICOMRCCL-1513

## Test Plan

-Build RCCL with the LLVM IR bitcode enabled (-DEMIT_LLVM_IR=ON -DBITCODE_LIB_ARCH=gfx942) so librccl_device.bc and the hipify-staged headers exist.
-Establish the baseline (pre-fix) failure by running the IR device suite and confirming B6_CoopSync faults on the multi-warp WarpSpan case.
-Apply the fix, re-stage the nccl_device headers, and rebuild the bitcode.
-Inspect the rebuilt librccl_device.bc to confirm it no longer contains a __shared__/LDS (addrspace(3)) global.
-Re-run the full IR device suite (pytest) on an MI300X (gfx942) and confirm all cases pass, with the B6_CoopSync log clean of the hardware fault.
-Rebuild the host librccl.so to confirm the modified coop.h still compiles on the native/in-tree path (unchanged behavior for existing kernels + the new static_assert holds).

## Test Result

Test results (MI300X, gfx942, ROCm 7.2, branch on latest develop)

-Baseline (before fix): 3 passed, 1 failed. B6_CoopSync failed on k_sync_warpspan with HSA_STATUS_ERROR_EXCEPTION code: 0x1016 and group_seg_size=0.
-Bitcode after fix: addrspace(3) global count = 0 (the __shared__/LDS global is gone from the .bc).
-IR device suite after fix: 4 passed, 0 failed — test_get_peer_pointer_team, test_coop_init_and_accessors, test_coop_sync (B6), test_lsa_barrier_session all PASS; B6_CoopSync log is clean of 0x1016.
-Host library: librccl.so re-links successfully; host translation units that include coop.h recompile cleanly, confirming the native fallback path and the static_assert(sizeof(ncclCoopWarpSpan) <= 16) both hold.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
