### PR TITLE
fix(libhsakmt): route primary-ctx render device init through model-aware w…

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/fmm.c
+++ b/projects/rocr-runtime/libhsakmt/src/fmm.c
@@ -2403,7 +2403,7 @@ int hsakmt_open_drm_render_device(HsaKFDContext *ctx, int minor)
 	 *    its own VM space).
 	*/
 	if (ctx->hsakmt_is_primary_ctx) {
-		dev_init_ret = amdgpu_device_initialize(fd, &major_drm, &minor_drm, device_handle);
+		dev_init_ret = hsakmt_amdgpu_device_initialize(fd, &major_drm, &minor_drm, device_handle);
 	} else if (hsakmt_fn_amdgpu_device_initialize2) {
 		dev_init_ret = hsakmt_fn_amdgpu_device_initialize2(fd, false, &major_drm, &minor_drm,
 						    (HsaAMDGPUDeviceHandle *)device_handle);


### PR DESCRIPTION
## Motivation

In hsakmt_open_drm_render_device(), the primary-context path called libdrm's amdgpu_device_initialize() directly. This triggers a printing on ffm:

    _amdgpu_device_initialize: amdgpu_get_auth (1) failed (-1)

Use the existing model-aware wrapper hsakmt_amdgpu_device_initialize() instead.

## JIRA ID

N/A

## Test Plan

    kfdtest

