### PR TITLE
ci(rocprofiler-compute): Remove redundant generic test exclude key

### DIFF
--- a/projects/rocprofiler-compute/tests/test_categories.yaml
+++ b/projects/rocprofiler-compute/tests/test_categories.yaml
@@ -39,10 +39,6 @@ test_categories:
       - test-rocprofiler-compute-tool
       - test_soc_base
       - test-pc-sampling-collector
-    # Remove once ROCm/TheRock#6087 lands and the rocm-systems hash is bumped in TheRock; therock_ci_exclude replaces this.
-    exclude:
-      - test_profile_live_attach_detach
-      - test_metric_validation
     therock_ci_exclude:
       - test_profile_live_attach_detach
       - test_metric_validation
@@ -106,10 +102,6 @@ test_categories:
       - test-pc-sampling-collector
       - test_profile_torch_trace
       - test_profile_triton_trace
-      - test_profile_live_attach_detach
-      - test_metric_validation
-    # Remove once ROCm/TheRock#6087 lands and the rocm-systems hash is bumped in TheRock; therock_ci_exclude replaces this.
-    exclude:
       - test_profile_live_attach_detach
       - test_metric_validation
     therock_ci_exclude:
@@ -176,10 +168,6 @@ test_categories:
       - test_profile_triton_trace
       - test_profile_live_attach_detach
       - test_metric_validation
-    # Remove once ROCm/TheRock#6087 lands and the rocm-systems hash is bumped in TheRock; therock_ci_exclude replaces this.
-    exclude:
-      - test_profile_live_attach_detach
-      - test_metric_validation
     therock_ci_exclude:
       - test_profile_live_attach_detach
       - test_metric_validation
@@ -242,10 +230,6 @@ test_categories:
       - test-pc-sampling-collector
       - test_profile_torch_trace
       - test_profile_triton_trace
-      - test_profile_live_attach_detach
-      - test_metric_validation
-    # Remove once ROCm/TheRock#6087 lands and the rocm-systems hash is bumped in TheRock; therock_ci_exclude replaces this.
-    exclude:
       - test_profile_live_attach_detach
       - test_metric_validation
     therock_ci_exclude:


### PR DESCRIPTION
## Motivation

The generic `exclude` key in `tests/test_categories.yaml` is now redundant. It was a temporary duplicate of `therock_ci_exclude`, kept only until TheRock's CI learned to read the category-specific label.

## Technical Details

TheRock's unified `test_runner.py` now consumes `<category>_therock_ci_exclude` (ROCm/TheRock#6087, commit `6b3047b`). That commit landed in TheRock ref `99f48ca`, which was pulled into rocm-systems via #8209 (merged, base `develop`). `6b3047b` is an ancestor of `99f48ca`, so the CI running off `develop` already honors `therock_ci_exclude`.

Each category previously carried a comment: *"Remove once ROCm/TheRock#6087 lands and the rocm-systems hash is bumped in TheRock; therock_ci_exclude replaces this."* Both conditions are met, so this PR removes the generic `exclude` block (and comment) from `quick`, `standard`, `comprehensive`, and `full`, leaving `therock_ci_exclude` and `rocprofiler_compute_ci_exclude` as the active excludes.

Targets `develop` because TheRock CI reads the test-category definitions from `develop`; `rocprofiler-compute-develop` picks this up via merge commit.

## JIRA ID

N/A

## Test Plan

YAML validated with `yaml.safe_load`; confirmed no category retains an `exclude` key and no repo code references the generic key.

## Test Result

Parses cleanly; `therock_ci_exclude` / `rocprofiler_compute_ci_exclude` intact for all four categories.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.