### PR TITLE
fix(rocprofiler-compute): Hard-exit when ROCm version cannot be detected

### DIFF
--- a/projects/rocprofiler-compute/src/utils/specs.py
+++ b/projects/rocprofiler-compute/src/utils/specs.py
@@ -93,12 +93,11 @@ def get_rocm_ver() -> str:
         )
         return rocm_ver_user
 
-    console_warning("Unable to detect a complete local ROCm installation.")
-    console_warning(
-        f"The expected {rocm_base_path}/.info/ versioning directory is missing."
+    console_error(
+        "Unable to detect a complete local ROCm installation. "
+        f"The expected {rocm_base_path}/.info/ versioning directory is missing. "
+        "Ensure you have a valid ROCm installation, or set ROCM_VER to override."
     )
-    console_error("Ensure you have valid ROCm installation.", exit=False)
-    return ""
 
 
 def total_sqc(archname: str, num_compute_units: str, num_shader_engines: str) -> int:

--- a/projects/rocprofiler-compute/tests/test_gpu_specs.py
+++ b/projects/rocprofiler-compute/tests/test_gpu_specs.py
@@ -605,3 +605,25 @@ def test_reconstruct_specs_from_sysinfo_missing_version_raises():
     """A sysinfo dict without a version key aborts via console_error/KeyError."""
     with pytest.raises((KeyError, SystemExit)):
         generate_machine_specs(None, {"gpu_arch": "gfx1151"})
+
+
+@pytest.mark.misc
+def test_get_rocm_ver_env_override(monkeypatch, tmp_path):
+    """ROCM_VER overrides detection when no .info/ directory is present."""
+    monkeypatch.setenv("ROCM_PATH", str(tmp_path))
+    monkeypatch.setenv("ROCM_VER", "6.9.9")
+    assert specs.get_rocm_ver() == "6.9.9"
+
+
+@pytest.mark.misc
+def test_get_rocm_ver_undetectable_errors(monkeypatch, tmp_path):
+    """Missing .info/ and unset ROCM_VER terminates via console_error."""
+    monkeypatch.setenv("ROCM_PATH", str(tmp_path))
+    monkeypatch.delenv("ROCM_VER", raising=False)
+    with patch.object(specs, "console_error") as console_error_mock:
+        specs.get_rocm_ver()
+    console_error_mock.assert_called_once()
+    assert (
+        "Unable to detect a complete local ROCm installation"
+        in (console_error_mock.call_args.args[0])
+    )


### PR DESCRIPTION
## Motivation

The ROCm version is needed during profiling to decide whether the native tool is supported (`__is_native_tool_supported` requires ROCm >= 7.x). `get_rocm_ver()` previously warned and returned an empty string when no local ROCm install was detected. That empty string flowed into `MachineSpecs.rocm_version` and then broke the version parse in `__is_native_tool_supported`, raising an opaque `ValueError` instead of a clear, actionable error.

## Technical Details

- `get_rocm_ver()`: collapse the two `console_warning` calls plus the soft `console_error(exit=False)` / empty-string return into a single hard `console_error`.
- The error fires only after the `ROCM_VER` env override is checked, so that escape hatch for installs without `.info/` is preserved.

Analyze mode does not use this path.

## JIRA ID

JIRA ID: N/A

## Test Plan

Ran `tests/test_gpu_specs.py`.

## Test Result

Passed.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.