### PR TITLE
feat(rocr-runtime): Add DRM/libdrm backend for SVM (set/get attributes, prefetch)

### DIFF
--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -102,7 +102,9 @@ enum MemoryAdvice : uint32_t {
                                ///< the amount of page faults
   UnsetAccessedBy = 6,         ///< HMM decides on the page faulting policy for the specified device
   SetCoarseGrain = 100,        ///< Change cache policy to improve performance (disables coherency)
-  UnsetCoarseGrain = 101       ///< Restore coherent cache policy at the cost of some performance
+  UnsetCoarseGrain = 101,      ///< Restore coherent cache policy at the cost of some performance
+  ResetAttributes = 200        ///< Internal: reset all SVM attributes for the range to defaults
+                               ///< (maps to hsa_amd_svm_attributes_set with attribute_count == 0)
 };
 
 enum MemRangeAttribute : uint32_t {

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -2793,7 +2793,8 @@ amd::Memory* Device::ImportShareableVMMHandle(void* osHandle, amd::Memory::Handl
 // ================================================================================================
 bool Device::SetSvmAttributesInt(const void* dev_ptr, size_t count, amd::MemoryAdvice advice,
                                  bool first_alloc, bool use_cpu, int numa_id) const {
-  if ((settings().hmmFlags_ & Settings::Hmm::EnableSvmTracking) && !first_alloc) {
+  if ((settings().hmmFlags_ & Settings::Hmm::EnableSvmTracking) && !first_alloc &&
+      advice != amd::MemoryAdvice::ResetAttributes) {
     amd::Memory* svm_mem = amd::MemObjMap::FindMemObj(dev_ptr);
     if ((nullptr == svm_mem) || ((svm_mem->getMemFlags() & CL_MEM_ALLOC_HOST_PTR) == 0) ||
         // Validate the range of provided memory
@@ -2855,6 +2856,10 @@ bool Device::SetSvmAttributesInt(const void* dev_ptr, size_t count, amd::MemoryA
         break;
       case amd::MemoryAdvice::UnsetCoarseGrain:
         attr.push_back({HSA_AMD_SVM_ATTRIB_GLOBAL_FLAG, HSA_AMD_SVM_GLOBAL_FLAG_FINE_GRAINED});
+        break;
+      case amd::MemoryAdvice::ResetAttributes:
+        // Leave attr empty: an attribute_count of 0 is the ROCr sentinel that
+        // resets all SVM attributes for the range back to defaults.
         break;
       default:
         return false;

--- a/projects/clr/rocclr/platform/context.cpp
+++ b/projects/clr/rocclr/platform/context.cpp
@@ -374,6 +374,15 @@ void Context::svmFree(void* ptr) const {
   // The actual HSA free (release) is deferred until after all devices have
   // iterated, so KFD cannot reuse the VA during the loop.
   amd::Memory* svmMem = amd::MemObjMap::FindAndRemoveMemObj(ptr);
+
+  // Reset kernel SVM attributes before the underlying munmap to prevent
+  // residual attributes from leaking to future allocations that reuse
+  // the same virtual address range.
+  if (svmMem != nullptr && !svmAllocDevice_.empty()) {
+    svmAllocDevice_.front()->SetSvmAttributes(ptr, svmMem->getSize(),
+                                              amd::MemoryAdvice::ResetAttributes);
+  }
+
   for (const auto& dev : svmAllocDevice_) {
     dev->svmFree(ptr);  // FindMemObj returns nullptr → no-op for GPU path
   }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/drm/amd_drm_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/drm/amd_drm_driver.cpp
@@ -434,6 +434,18 @@ hsa_status_t DrmDriver::SvmSetAttr(void* base, size_t size,
   if (gpu_agents.empty())
     return HSA_STATUS_ERROR;
 
+  // if count is 0, reset all attributes to default values
+  if (count == 0) {
+    for (core::Agent* agent : gpu_agents) {
+      amdgpu_device_handle dev = static_cast<GpuAgent*>(agent)->libDrmDev();
+      if (dev == nullptr)
+        continue;
+      if (amdgpu_svm_reset_attr(dev, reinterpret_cast<uint64_t>(base), size))
+        return HSA_STATUS_ERROR;
+    }
+    return HSA_STATUS_SUCCESS;
+  }
+
   std::vector<drm_amdgpu_svm_attribute> common;
   std::unordered_map<core::Agent*, std::vector<drm_amdgpu_svm_attribute>> per_device;
   // Bitmasks of boolean DRM attributes to set (=1) or clear (=0), indexed by

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/drm/amd_drm_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/drm/amd_drm_driver.cpp
@@ -7,10 +7,15 @@
 
 #include <cerrno>
 #include <cstring>
+#include <algorithm>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 #include "core/inc/amd_drm_driver.h"
 #include "core/inc/amd_aql_queue.h"
 #include "core/inc/amd_gpu_agent.h"
+#include "core/inc/exceptions.h"
 
 namespace rocr {
 namespace AMD {
@@ -389,6 +394,434 @@ hsa_status_t DrmDriver::AllocQueueGWS(HSA_QUEUEID queue_id, uint32_t num_gws,
 hsa_status_t DrmDriver::DestroyQueue(HSA_QUEUEID queue_id) const {
   if (HSAKMT_CALL(hsaKmtDestroyQueue(queue_id)) != HSAKMT_STATUS_SUCCESS) {
     return HSA_STATUS_ERROR;
+  }
+  return HSA_STATUS_SUCCESS;
+}
+
+namespace {
+
+// Boolean DRM SVM attributes occupy the contiguous enum range
+// [AMDGPU_SVM_ATTR_HOST_ACCESS, AMDGPU_SVM_ATTR_GPU_READ_MOSTLY]. Their enum
+// values double as bit positions in the set/clear masks used below.
+constexpr uint32_t kFirstDrmBoolAttr = AMDGPU_SVM_ATTR_HOST_ACCESS;
+constexpr uint32_t kLastDrmBoolAttr = AMDGPU_SVM_ATTR_GPU_READ_MOSTLY;
+
+// Guard against UB if DRM enum grows past 31 (shift would overflow uint32_t).
+static_assert(kLastDrmBoolAttr < 32,
+              "DRM boolean attributes exceed 32; DrmFlagBit would overflow");
+
+constexpr uint32_t DrmFlagBit(uint32_t drm_attr) { return 1u << drm_attr; }
+
+// Boolean DRM SVM attributes that SvmGetAttr can read back. AMDGPU_SVM_ATTR_GPU_EXEC
+// is settable but not reported, so it is intentionally omitted.
+constexpr uint32_t kReportedDrmFlags[] = {
+    AMDGPU_SVM_ATTR_HOST_ACCESS,  AMDGPU_SVM_ATTR_COHERENT,
+    AMDGPU_SVM_ATTR_EXT_COHERENT, AMDGPU_SVM_ATTR_HIVE_LOCAL,
+    AMDGPU_SVM_ATTR_GPU_RO,       AMDGPU_SVM_ATTR_GPU_READ_MOSTLY,
+};
+
+// SVM location value meaning "this GPU/VRAM". The kernel's SVM model is one
+// context per device, so it only distinguishes SYSMEM(0), UNDEFINED(0xffffffff),
+// and "any other value => the device that received the ioctl".
+constexpr uint32_t kSvmLocationThisGpu = 1u;
+
+}  // namespace
+
+hsa_status_t DrmDriver::SvmSetAttr(void* base, size_t size,
+                                   const hsa_amd_svm_attribute_pair_t* attribs, size_t count) {
+  const auto& gpu_agents = core::Runtime::runtime_singleton_->gpu_agents();
+
+  if (gpu_agents.empty())
+    return HSA_STATUS_ERROR;
+
+  std::vector<drm_amdgpu_svm_attribute> common;
+  std::unordered_map<core::Agent*, std::vector<drm_amdgpu_svm_attribute>> per_device;
+  // Bitmasks of boolean DRM attributes to set (=1) or clear (=0), indexed by
+  // the DRM attribute enum value (see DrmFlagBit).
+  uint32_t set_mask = 0, clr_mask = 0;
+
+  SvmAttrParser parser("DrmDriver::SvmSetAttr");
+
+  // Route an access policy for a specific agent to that GPU's context.
+  auto PushAccess = [&](core::Agent* agent, uint32_t policy) {
+    per_device[agent].push_back({AMDGPU_SVM_ATTR_ACCESS, policy});
+  };
+
+  for (size_t i = 0; i < count; ++i) {
+    const auto attrib = attribs[i].attribute;
+    const auto value = attribs[i].value;
+
+    switch (attrib) {
+      case HSA_AMD_SVM_ATTRIB_GLOBAL_FLAG: {
+        parser.CheckOnce(attrib);
+        switch (value) {
+          case HSA_AMD_SVM_GLOBAL_FLAG_FINE_GRAINED:
+            set_mask |= DrmFlagBit(AMDGPU_SVM_ATTR_COHERENT);
+            break;
+          case HSA_AMD_SVM_GLOBAL_FLAG_COARSE_GRAINED:
+            clr_mask |= DrmFlagBit(AMDGPU_SVM_ATTR_COHERENT);
+            break;
+          default:
+            throw hsa_exception(HSA_STATUS_ERROR_INVALID_ARGUMENT,
+                                "Invalid HSA_AMD_SVM_ATTRIB_GLOBAL_FLAG value.");
+        }
+        break;
+      }
+      case HSA_AMD_SVM_ATTRIB_READ_ONLY:
+        parser.CheckOnce(attrib);
+        (value ? set_mask : clr_mask) |= DrmFlagBit(AMDGPU_SVM_ATTR_GPU_RO);
+        break;
+      case HSA_AMD_SVM_ATTRIB_HIVE_LOCAL:
+        parser.CheckOnce(attrib);
+        (value ? set_mask : clr_mask) |= DrmFlagBit(AMDGPU_SVM_ATTR_HIVE_LOCAL);
+        break;
+      case HSA_AMD_SVM_ATTRIB_READ_MOSTLY:
+        parser.CheckOnce(attrib);
+        (value ? set_mask : clr_mask) |= DrmFlagBit(AMDGPU_SVM_ATTR_GPU_READ_MOSTLY);
+        break;
+      case HSA_AMD_SVM_ATTRIB_GPU_EXEC:
+        parser.CheckOnce(attrib);
+        (value ? set_mask : clr_mask) |= DrmFlagBit(AMDGPU_SVM_ATTR_GPU_EXEC);
+        break;
+      case HSA_AMD_SVM_ATTRIB_MIGRATION_GRANULARITY: {
+        parser.CheckOnce(attrib);
+        uint32_t granularity = value;
+        // Max migration size is 1GB.
+        if (granularity > 18) granularity = 18;
+        common.push_back({AMDGPU_SVM_ATTR_GRANULARITY, granularity});
+        break;
+      }
+      case HSA_AMD_SVM_ATTRIB_PREFERRED_LOCATION: {
+        parser.CheckOnce(attrib);
+        core::Agent* agent = parser.ConvertAllowNull(value);
+        if (agent == nullptr)
+          common.push_back({AMDGPU_SVM_ATTR_PREFERRED_LOC, AMDGPU_SVM_LOCATION_UNDEFINED});
+        else if (agent->device_type() == core::Agent::kAmdGpuDevice)
+          per_device[agent].push_back(
+              {AMDGPU_SVM_ATTR_PREFERRED_LOC, kSvmLocationThisGpu});
+        else
+          common.push_back({AMDGPU_SVM_ATTR_PREFERRED_LOC, AMDGPU_SVM_LOCATION_SYSMEM});
+        break;
+      }
+      case HSA_AMD_SVM_ATTRIB_AGENT_ACCESSIBLE: {
+        core::Agent* agent = parser.Convert(value);
+        parser.ConfirmNew(agent);
+        if (agent->device_type() == core::Agent::kAmdCpuDevice)
+          set_mask |= DrmFlagBit(AMDGPU_SVM_ATTR_HOST_ACCESS);
+        else
+          PushAccess(agent, AMDGPU_SVM_ACCESS_ALLOW_MIGRATE);
+        break;
+      }
+      case HSA_AMD_SVM_ATTRIB_AGENT_ACCESSIBLE_IN_PLACE: {
+        core::Agent* agent = parser.Convert(value);
+        parser.ConfirmNew(agent);
+        if (agent->device_type() == core::Agent::kAmdCpuDevice)
+          set_mask |= DrmFlagBit(AMDGPU_SVM_ATTR_HOST_ACCESS);
+        else
+          PushAccess(agent, AMDGPU_SVM_ACCESS_IN_PLACE);
+        break;
+      }
+      case HSA_AMD_SVM_ATTRIB_AGENT_NO_ACCESS: {
+        core::Agent* agent = parser.Convert(value);
+        parser.ConfirmNew(agent);
+        if (agent->device_type() == core::Agent::kAmdCpuDevice)
+          clr_mask |= DrmFlagBit(AMDGPU_SVM_ATTR_HOST_ACCESS);
+        else
+          PushAccess(agent, AMDGPU_SVM_ACCESS_INACCESSIBLE);
+        break;
+      }
+      default:
+        throw hsa_exception(HSA_STATUS_ERROR_INVALID_ARGUMENT,
+                            "Illegal or invalid attribute in DrmDriver::SvmSetAttr");
+    }
+  }
+
+  // Merge CPU access properties - grant access if any CPU needs access.
+  if (set_mask & DrmFlagBit(AMDGPU_SVM_ATTR_HOST_ACCESS))
+    clr_mask &= ~DrmFlagBit(AMDGPU_SVM_ATTR_HOST_ACCESS);
+
+  for (uint32_t attr = kFirstDrmBoolAttr; attr <= kLastDrmBoolAttr; ++attr) {
+    if (set_mask & DrmFlagBit(attr))
+      common.push_back({attr, 1});
+    else if (clr_mask & DrmFlagBit(attr))
+      common.push_back({attr, 0});
+  }
+
+  // Issue one ioctl per GPU with the shared entries plus that GPU's own ones.
+  for (core::Agent* agent : gpu_agents) {
+    amdgpu_device_handle dev = static_cast<GpuAgent*>(agent)->libDrmDev();
+    if (dev == nullptr)
+      continue;
+
+    std::vector<drm_amdgpu_svm_attribute> attrs = common;
+    auto it = per_device.find(agent);
+    if (it != per_device.end())
+      attrs.insert(attrs.end(), it->second.begin(), it->second.end());
+
+    if (attrs.empty())
+      continue;
+
+    /* TODO: Handle partial failure.
+     * If amdgpu_svm_set_attr succeeds for some devices but fails for a later
+     * one, SVM attributes are left inconsistent across GPUs.
+     * Two possible recovery strategies:
+     *   1. Retry: On transient errors (e.g. EBUSY), retry the ioctl for the
+     *      failing device with exponential back-off before giving up.
+     *   2. Rollback: On unrecoverable errors, re-issue amdgpu_svm_set_attr
+     *      with the original values on already-updated devices to restore a
+     *      consistent state before returning an error.
+     */
+    if (amdgpu_svm_set_attr(dev, reinterpret_cast<uint64_t>(base), size,
+                            static_cast<uint32_t>(attrs.size()), attrs.data()) != 0)
+      return HSA_STATUS_ERROR;
+  }
+
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t DrmDriver::SvmGetAttr(void* base, size_t size,
+                                   hsa_amd_svm_attribute_pair_t* attribs, size_t count) {
+  const auto& gpu_agents = core::Runtime::runtime_singleton_->gpu_agents();
+  if (gpu_agents.empty())
+    return HSA_STATUS_ERROR;
+
+  SvmAttrParser parser("DrmDriver::SvmGetAttr");
+
+  // Boolean flags and migration granularity are range properties shared
+  // across devices, so they are read from a representative device (gpu_agents[0]);
+  // preferred/prefetch locations must be scanned across all GPUs; per-agent
+  // access is read from that agent's device. A first pass determines what is
+  // needed, then a single batched amdgpu_svm_get_attr per device collects it.
+  bool need_flags = false;
+  bool need_gran = false;
+  bool need_pref = false;
+  bool need_prefetch = false;
+  std::unordered_set<core::Agent*> access_agents;
+
+  for (size_t i = 0; i < count; ++i) {
+    switch (attribs[i].attribute) {
+      case HSA_AMD_SVM_ATTRIB_GLOBAL_FLAG:
+      case HSA_AMD_SVM_ATTRIB_READ_ONLY:
+      case HSA_AMD_SVM_ATTRIB_HIVE_LOCAL:
+      case HSA_AMD_SVM_ATTRIB_READ_MOSTLY:
+        need_flags = true;
+        break;
+      case HSA_AMD_SVM_ATTRIB_MIGRATION_GRANULARITY:
+        need_gran = true;
+        break;
+      case HSA_AMD_SVM_ATTRIB_PREFERRED_LOCATION:
+        need_pref = true;
+        break;
+      case HSA_AMD_SVM_ATTRIB_PREFETCH_LOCATION:
+        need_prefetch = true;
+        break;
+      case HSA_AMD_SVM_ATTRIB_ACCESS_QUERY: {
+        core::Agent* agent = parser.Convert(attribs[i].value);
+        if (agent->device_type() == core::Agent::kAmdCpuDevice)
+          need_flags = true;
+        else
+          access_agents.insert(agent);
+        break;
+      }
+      default:
+        throw hsa_exception(HSA_STATUS_ERROR_INVALID_ARGUMENT,
+                            "Illegal or invalid attribute in DrmDriver::SvmGetAttr.");
+    }
+  }
+
+  // agent -> (DRM attribute type -> value), populated only for successful reads.
+  std::unordered_map<core::Agent*, std::unordered_map<uint32_t, uint32_t>> node_vals;
+
+  for (core::Agent* agent : gpu_agents) {
+    std::vector<drm_amdgpu_svm_attribute> req;
+    if (agent == gpu_agents[0]) {
+      if (need_flags)
+        for (uint32_t drm_attr : kReportedDrmFlags)
+          req.push_back({drm_attr, 0});
+      if (need_gran)
+        req.push_back({AMDGPU_SVM_ATTR_GRANULARITY, 0});
+    }
+    if (need_pref)
+      req.push_back({AMDGPU_SVM_ATTR_PREFERRED_LOC, 0});
+    if (need_prefetch)
+      req.push_back({AMDGPU_SVM_ATTR_PREFETCH_LOC, 0});
+    if (access_agents.count(agent))
+      req.push_back({AMDGPU_SVM_ATTR_ACCESS, 0});
+
+    if (req.empty())
+      continue;
+
+    amdgpu_device_handle dev = static_cast<GpuAgent*>(agent)->libDrmDev();
+    if (dev == nullptr)
+      continue;
+
+    if (amdgpu_svm_get_attr(dev, reinterpret_cast<uint64_t>(base), size,
+                            static_cast<uint32_t>(req.size()), req.data()) != 0)
+      continue;
+
+    auto& vals = node_vals[agent];
+    for (const auto& a : req)
+      vals[a.type] = a.value;
+  }
+
+  // Look up a cached attribute value for an agent. Returns false if the agent
+  // was not queried successfully or did not report the attribute.
+  auto node_val = [&](core::Agent* agent, uint32_t drm_attr, uint32_t& out) -> bool {
+    auto nit = node_vals.find(agent);
+    if (nit == node_vals.end())
+      return false;
+    auto vit = nit->second.find(drm_attr);
+    if (vit == nit->second.end())
+      return false;
+    out = vit->second;
+    return true;
+  };
+
+  // Reconstruct the boolean-flag bitmask (indexed by DRM attribute enum value,
+  // see DrmFlagBit) from the representative device's cached values.
+  auto flags = [&]() -> uint32_t {
+    uint32_t f = 0;
+    uint32_t v = 0;
+    for (uint32_t drm_attr : kReportedDrmFlags)
+      if (node_val(gpu_agents[0], drm_attr, v) && v)
+        f |= DrmFlagBit(drm_attr);
+    return f;
+  };
+
+  // Resolve a preferred/prefetch location to a public agent handle (handle 0
+  // when the range has no or a mixed destination), scanning cached per-agent
+  // values.
+  auto location_handle = [&](uint32_t drm_type) -> uint64_t {
+    core::Agent* result = nullptr;
+    bool sysmem_seen = false;
+    for (core::Agent* agent : gpu_agents) {
+      uint32_t v = 0;
+      if (!node_val(agent, drm_type, v))
+        continue;
+      if (v == AMDGPU_SVM_LOCATION_UNDEFINED) continue;
+      if (v == AMDGPU_SVM_LOCATION_SYSMEM) {
+        sysmem_seen = true;
+        continue;
+      }
+      // Not sysmem and not undefined => the range lives on this GPU.
+      result = agent;
+      break;
+    }
+    // No GPU claims the range but some device reported sysmem => resolve to the
+    // system-memory (CPU) agent at node 0.
+    if (result == nullptr && sysmem_seen)
+      result = core::Runtime::runtime_singleton_->agent_by_nodeid(0);
+
+    return core::Agent::Convert(result).handle;
+  };
+
+  for (size_t i = 0; i < count; ++i) {
+    auto& attrib = attribs[i].attribute;
+    auto& value = attribs[i].value;
+
+    switch (attrib) {
+      case HSA_AMD_SVM_ATTRIB_GLOBAL_FLAG: {
+        value = (flags() & DrmFlagBit(AMDGPU_SVM_ATTR_COHERENT))
+                    ? HSA_AMD_SVM_GLOBAL_FLAG_FINE_GRAINED
+                    : HSA_AMD_SVM_GLOBAL_FLAG_COARSE_GRAINED;
+        break;
+      }
+      case HSA_AMD_SVM_ATTRIB_READ_ONLY: {
+        value = (flags() & DrmFlagBit(AMDGPU_SVM_ATTR_GPU_RO)) ? 1 : 0;
+        break;
+      }
+      case HSA_AMD_SVM_ATTRIB_HIVE_LOCAL: {
+        value = (flags() & DrmFlagBit(AMDGPU_SVM_ATTR_HIVE_LOCAL)) ? 1 : 0;
+        break;
+      }
+      case HSA_AMD_SVM_ATTRIB_READ_MOSTLY: {
+        value = (flags() & DrmFlagBit(AMDGPU_SVM_ATTR_GPU_READ_MOSTLY)) ? 1 : 0;
+        break;
+      }
+      case HSA_AMD_SVM_ATTRIB_MIGRATION_GRANULARITY: {
+        uint32_t v = 0;
+        if (node_val(gpu_agents[0], AMDGPU_SVM_ATTR_GRANULARITY, v))
+          value = v;
+        break;
+      }
+      case HSA_AMD_SVM_ATTRIB_PREFERRED_LOCATION: {
+        value = location_handle(AMDGPU_SVM_ATTR_PREFERRED_LOC);
+        break;
+      }
+      case HSA_AMD_SVM_ATTRIB_PREFETCH_LOCATION: {
+        value = location_handle(AMDGPU_SVM_ATTR_PREFETCH_LOC);
+        break;
+      }
+      case HSA_AMD_SVM_ATTRIB_ACCESS_QUERY: {
+        core::Agent* agent = parser.Convert(value);
+        if (agent->device_type() == core::Agent::kAmdCpuDevice) {
+          attrib = (flags() & DrmFlagBit(AMDGPU_SVM_ATTR_HOST_ACCESS))
+                       ? HSA_AMD_SVM_ATTRIB_AGENT_ACCESSIBLE
+                       : HSA_AMD_SVM_ATTRIB_AGENT_NO_ACCESS;
+          break;
+        }
+        uint32_t v = 0;
+        if (node_val(agent, AMDGPU_SVM_ATTR_ACCESS, v)) {
+          switch (v) {
+            case AMDGPU_SVM_ACCESS_IN_PLACE:
+              attrib = HSA_AMD_SVM_ATTRIB_AGENT_ACCESSIBLE_IN_PLACE;
+              break;
+            case AMDGPU_SVM_ACCESS_INACCESSIBLE:
+              attrib = HSA_AMD_SVM_ATTRIB_AGENT_NO_ACCESS;
+              break;
+            case AMDGPU_SVM_ACCESS_ALLOW_MIGRATE:
+            default:
+              attrib = HSA_AMD_SVM_ATTRIB_AGENT_ACCESSIBLE;
+              break;
+          }
+        }
+        break;
+      }
+      default:
+        throw hsa_exception(HSA_STATUS_ERROR_INVALID_ARGUMENT,
+                            "Illegal or invalid attribute in DrmDriver::SvmGetAttr.");
+    }
+  }
+
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t DrmDriver::SvmPrefetch(const core::Agent& dstAgent, void* base, size_t size) {
+  if (dstAgent.device_type() == core::Agent::kAmdGpuDevice) {
+    // Migrate to a specific GPU: prefetch on that GPU's fd only.
+    amdgpu_device_handle dev = static_cast<const GpuAgent&>(dstAgent).libDrmDev();
+    if (dev == nullptr)
+      return HSA_STATUS_ERROR;
+
+    drm_amdgpu_svm_attribute attr{AMDGPU_SVM_ATTR_PREFETCH_LOC, kSvmLocationThisGpu};
+    if (amdgpu_svm_set_attr(dev, reinterpret_cast<uint64_t>(base), size, 1, &attr) != 0)
+      return HSA_STATUS_ERROR;
+
+    return HSA_STATUS_SUCCESS;
+  }
+
+  const auto& gpu_agents = core::Runtime::runtime_singleton_->gpu_agents();
+  if (gpu_agents.empty())
+    return HSA_STATUS_ERROR;
+
+  // Prefetch to system memory: every GPU's independent SVM context must be
+  // updated, so issue the ioctl on each device's fd.
+  /* TODO: NUMA awareness - the AMDGPU_SVM_ATTR_PREFETCH_LOC value for system
+   * memory should reflect the NUMA node, rather than always using a fixed
+   * SYSMEM location. This requires selecting the appropriate CPU agent (i.e.
+   * the one whose NUMA node is nearest to the current GPU agent) and encoding
+   * its NUMA node ID into the prefetch location attribute. Without this,
+   * prefetched pages may land on a remote NUMA node, incurring higher memory
+   * latency for the GPU.
+   */
+  drm_amdgpu_svm_attribute attr{AMDGPU_SVM_ATTR_PREFETCH_LOC, AMDGPU_SVM_LOCATION_SYSMEM};
+
+  for (core::Agent* agent : gpu_agents) {
+    amdgpu_device_handle dev = static_cast<GpuAgent*>(agent)->libDrmDev();
+    if (dev == nullptr)
+      continue;
+
+    amdgpu_svm_set_attr(dev, reinterpret_cast<uint64_t>(base), size, 1, &attr);
   }
   return HSA_STATUS_SUCCESS;
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -964,6 +964,10 @@ hsa_status_t KfdDriver::SvmSetAttr(void* base, size_t size,
   uint32_t set_flags = 0;
   uint32_t clear_flags = 0;
 
+    //do not set any attributes if count is 0, just return success
+  if (count == 0)
+    return HSA_STATUS_SUCCESS;
+
   auto kmtPair = [](uint32_t attrib, uint32_t value) {
     HSA_SVM_ATTRIBUTE pair = {attrib, value};
     return pair;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -51,10 +51,13 @@
     #include <amdgpu_drm.h>
 #endif
 
+#include <unordered_set>
+
 #include "hsakmt/hsakmt.h"
 
 #include "core/inc/amd_gpu_agent.h"
 #include "core/inc/amd_memory_region.h"
+#include "core/inc/exceptions.h"
 #include "core/inc/runtime.h"
 #include "core/util/os.h"
 
@@ -919,6 +922,319 @@ hsa_status_t KfdDriver::GetDeviceFd(uint32_t node_id, int *fd) const {
     return HSA_STATUS_ERROR;
 
   return HSA_STATUS_SUCCESS;
+}
+
+core::Agent* KfdDriver::SvmAttrParser::Convert(uint64_t value) const {
+  hsa_agent_t handle = {value};
+  core::Agent* agent = core::Agent::Convert(handle);
+  if ((agent == nullptr) || !agent->IsValid())
+    throw hsa_exception(HSA_STATUS_ERROR_INVALID_AGENT,
+                        (std::string("Invalid agent handle in ") + context_ + ".").c_str());
+  return agent;
+}
+
+core::Agent* KfdDriver::SvmAttrParser::ConvertAllowNull(uint64_t value) const {
+  hsa_agent_t handle = {value};
+  core::Agent* agent = core::Agent::Convert(handle);
+  if ((agent != nullptr) && (!agent->IsValid()))
+    throw hsa_exception(HSA_STATUS_ERROR_INVALID_AGENT,
+                        (std::string("Invalid agent handle in ") + context_ + ".").c_str());
+  return agent;
+}
+
+void KfdDriver::SvmAttrParser::ConfirmNew(core::Agent* agent) {
+  if (!agent_seen_.insert(agent->node_id()).second)
+    throw hsa_exception(
+        HSA_STATUS_ERROR_INCOMPATIBLE_ARGUMENTS,
+        (std::string("Multiple attributes given for the same agent in ") + context_ + ".").c_str());
+}
+
+void KfdDriver::SvmAttrParser::CheckOnce(uint64_t attrib) {
+  if (set_attribs_ & (1 << attrib))
+    throw hsa_exception(HSA_STATUS_ERROR_INCOMPATIBLE_ARGUMENTS,
+                        (std::string("Attribute given multiple times in ") + context_ + ".").c_str());
+  set_attribs_ |= (1 << attrib);
+}
+
+hsa_status_t KfdDriver::SvmSetAttr(void* base, size_t size,
+                                   const hsa_amd_svm_attribute_pair_t* attribs, size_t count) {
+  SvmAttrParser parser("KfdDriver::SvmSetAttr");
+  std::vector<HSA_SVM_ATTRIBUTE> kmt_attribs;
+  kmt_attribs.reserve(count);
+  uint32_t set_flags = 0;
+  uint32_t clear_flags = 0;
+
+  auto kmtPair = [](uint32_t attrib, uint32_t value) {
+    HSA_SVM_ATTRIBUTE pair = {attrib, value};
+    return pair;
+  };
+
+  for (uint32_t i = 0; i < count; i++) {
+    auto attrib = attribs[i].attribute;
+    auto value = attribs[i].value;
+
+    switch (attrib) {
+      case HSA_AMD_SVM_ATTRIB_GLOBAL_FLAG: {
+        parser.CheckOnce(attrib);
+        switch (value) {
+          case HSA_AMD_SVM_GLOBAL_FLAG_FINE_GRAINED:
+            set_flags |= HSA_SVM_FLAG_COHERENT;
+            break;
+          case HSA_AMD_SVM_GLOBAL_FLAG_COARSE_GRAINED:
+            clear_flags |= HSA_SVM_FLAG_COHERENT;
+            break;
+          default:
+            throw hsa_exception(HSA_STATUS_ERROR_INVALID_ARGUMENT,
+                                "Invalid HSA_AMD_SVM_ATTRIB_GLOBAL_FLAG value.");
+        }
+        break;
+      }
+      case HSA_AMD_SVM_ATTRIB_READ_ONLY: {
+        parser.CheckOnce(attrib);
+        (value ? set_flags : clear_flags) |= HSA_SVM_FLAG_GPU_RO;
+        break;
+      }
+      case HSA_AMD_SVM_ATTRIB_HIVE_LOCAL: {
+        parser.CheckOnce(attrib);
+        (value ? set_flags : clear_flags) |= HSA_SVM_FLAG_HIVE_LOCAL;
+        break;
+      }
+      case HSA_AMD_SVM_ATTRIB_MIGRATION_GRANULARITY: {
+        parser.CheckOnce(attrib);
+        // Max migration size is 1GB.
+        if (value > 18) value = 18;
+        kmt_attribs.push_back(kmtPair(HSA_SVM_ATTR_GRANULARITY, value));
+        break;
+      }
+      case HSA_AMD_SVM_ATTRIB_PREFERRED_LOCATION: {
+        parser.CheckOnce(attrib);
+        core::Agent* agent = parser.ConvertAllowNull(value);
+        uint32_t node_id = (agent == nullptr) ? INVALID_NODEID : agent->node_id();
+        kmt_attribs.push_back(kmtPair(HSA_SVM_ATTR_PREFERRED_LOC, node_id));
+        break;
+      }
+      case HSA_AMD_SVM_ATTRIB_READ_MOSTLY: {
+        parser.CheckOnce(attrib);
+        (value ? set_flags : clear_flags) |= HSA_SVM_FLAG_GPU_READ_MOSTLY;
+        break;
+      }
+      case HSA_AMD_SVM_ATTRIB_GPU_EXEC: {
+        parser.CheckOnce(attrib);
+        (value ? set_flags : clear_flags) |= HSA_SVM_FLAG_GPU_EXEC;
+        break;
+      }
+      case HSA_AMD_SVM_ATTRIB_AGENT_ACCESSIBLE: {
+        core::Agent* agent = parser.Convert(value);
+        parser.ConfirmNew(agent);
+        if (agent->device_type() == core::Agent::kAmdCpuDevice) {
+          set_flags |= HSA_SVM_FLAG_HOST_ACCESS;
+        } else {
+          kmt_attribs.push_back(kmtPair(HSA_SVM_ATTR_ACCESS, agent->node_id()));
+        }
+        break;
+      }
+      case HSA_AMD_SVM_ATTRIB_AGENT_ACCESSIBLE_IN_PLACE: {
+        core::Agent* agent = parser.Convert(value);
+        parser.ConfirmNew(agent);
+        if (agent->device_type() == core::Agent::kAmdCpuDevice) {
+          set_flags |= HSA_SVM_FLAG_HOST_ACCESS;
+        } else {
+          kmt_attribs.push_back(kmtPair(HSA_SVM_ATTR_ACCESS_IN_PLACE, agent->node_id()));
+        }
+        break;
+      }
+      case HSA_AMD_SVM_ATTRIB_AGENT_NO_ACCESS: {
+        core::Agent* agent = parser.Convert(value);
+        parser.ConfirmNew(agent);
+        if (agent->device_type() == core::Agent::kAmdCpuDevice) {
+          clear_flags |= HSA_SVM_FLAG_HOST_ACCESS;
+        } else {
+          kmt_attribs.push_back(kmtPair(HSA_SVM_ATTR_NO_ACCESS, agent->node_id()));
+        }
+        break;
+      }
+      default:
+        throw hsa_exception(HSA_STATUS_ERROR_INVALID_ARGUMENT,
+                            "Illegal or invalid attribute in KfdDriver::SvmSetAttr");
+    }
+  }
+
+  // Merge CPU access properties - grant access if any CPU needs access.
+  // Probably wrong.
+  if (set_flags & HSA_SVM_FLAG_HOST_ACCESS) clear_flags &= ~HSA_SVM_FLAG_HOST_ACCESS;
+
+  // Add flag updates
+  if (clear_flags) kmt_attribs.push_back(kmtPair(HSA_SVM_ATTR_CLR_FLAGS, clear_flags));
+  if (set_flags) kmt_attribs.push_back(kmtPair(HSA_SVM_ATTR_SET_FLAGS, set_flags));
+
+  HSAKMT_STATUS error = HSAKMT_CALL(
+      hsaKmtSVMSetAttr(base, size, kmt_attribs.size(), &kmt_attribs[0]));
+
+  return error == HSAKMT_STATUS_SUCCESS ? HSA_STATUS_SUCCESS : HSA_STATUS_ERROR;
+}
+
+hsa_status_t KfdDriver::SvmGetAttr(void* base, size_t size,
+                                   hsa_amd_svm_attribute_pair_t* attribs, size_t count) {
+  SvmAttrParser parser("KfdDriver::SvmGetAttr");
+  std::vector<HSA_SVM_ATTRIBUTE> kmt_attribs;
+  kmt_attribs.reserve(count);
+
+  std::vector<int> kmtIndices(count);
+
+  bool getFlags = false;
+
+  auto kmtPair = [](uint32_t attrib, uint32_t value) {
+    HSA_SVM_ATTRIBUTE pair = {attrib, value};
+    return pair;
+  };
+
+  for (uint32_t i = 0; i < count; i++) {
+    auto& attrib = attribs[i].attribute;
+    auto& value = attribs[i].value;
+
+    switch (attrib) {
+      case HSA_AMD_SVM_ATTRIB_GLOBAL_FLAG:
+      case HSA_AMD_SVM_ATTRIB_READ_ONLY:
+      case HSA_AMD_SVM_ATTRIB_HIVE_LOCAL:
+      case HSA_AMD_SVM_ATTRIB_READ_MOSTLY: {
+        getFlags = true;
+        kmtIndices[i] = -1;
+        break;
+      }
+      case HSA_AMD_SVM_ATTRIB_MIGRATION_GRANULARITY: {
+        kmtIndices[i] = kmt_attribs.size();
+        kmt_attribs.push_back(kmtPair(HSA_SVM_ATTR_GRANULARITY, 0));
+        break;
+      }
+      case HSA_AMD_SVM_ATTRIB_PREFERRED_LOCATION: {
+        kmtIndices[i] = kmt_attribs.size();
+        kmt_attribs.push_back(kmtPair(HSA_SVM_ATTR_PREFERRED_LOC, 0));
+        break;
+      }
+      case HSA_AMD_SVM_ATTRIB_PREFETCH_LOCATION: {
+        kmtIndices[i] = kmt_attribs.size();
+        kmt_attribs.push_back(kmtPair(HSA_SVM_ATTR_PREFETCH_LOC, 0));
+        break;
+      }
+      case HSA_AMD_SVM_ATTRIB_ACCESS_QUERY: {
+        core::Agent* agent = parser.Convert(value);
+        if (agent->device_type() == core::Agent::kAmdCpuDevice) {
+          getFlags = true;
+          kmtIndices[i] = -1;
+        } else {
+          kmtIndices[i] = kmt_attribs.size();
+          kmt_attribs.push_back(kmtPair(HSA_SVM_ATTR_ACCESS, agent->node_id()));
+        }
+        break;
+      }
+      default:
+        throw hsa_exception(HSA_STATUS_ERROR_INVALID_ARGUMENT,
+                            "Illegal or invalid attribute in KfdDriver::SvmGetAttr.");
+    }
+  }
+
+  if (getFlags) {
+    // Order is important to later code.
+    kmt_attribs.push_back(kmtPair(HSA_SVM_ATTR_CLR_FLAGS, 0));
+    kmt_attribs.push_back(kmtPair(HSA_SVM_ATTR_SET_FLAGS, 0));
+  }
+
+  if (kmt_attribs.size() != 0) {
+    HSAKMT_STATUS error = HSAKMT_CALL(
+        hsaKmtSVMGetAttr(base, size, kmt_attribs.size(), &kmt_attribs[0]));
+    if (error != HSAKMT_STATUS_SUCCESS)
+      return HSA_STATUS_ERROR;
+  }
+
+  for (uint32_t i = 0; i < count; i++) {
+    auto& attrib = attribs[i].attribute;
+    auto& value = attribs[i].value;
+
+    switch (attrib) {
+      case HSA_AMD_SVM_ATTRIB_GLOBAL_FLAG: {
+        if (kmt_attribs[kmt_attribs.size() - 1].value & HSA_SVM_FLAG_COHERENT) {
+          value = HSA_AMD_SVM_GLOBAL_FLAG_FINE_GRAINED;
+          break;
+        }
+        if (kmt_attribs[kmt_attribs.size() - 2].value & HSA_SVM_FLAG_COHERENT)
+          value = HSA_AMD_SVM_GLOBAL_FLAG_COARSE_GRAINED;
+        else
+          value = HSA_AMD_SVM_GLOBAL_FLAG_INDETERMINATE;
+        break;
+      }
+      case HSA_AMD_SVM_ATTRIB_READ_ONLY: {
+        value = (kmt_attribs[kmt_attribs.size() - 1].value & HSA_SVM_FLAG_GPU_RO);
+        break;
+      }
+      case HSA_AMD_SVM_ATTRIB_HIVE_LOCAL: {
+        value = (kmt_attribs[kmt_attribs.size() - 1].value & HSA_SVM_FLAG_HIVE_LOCAL);
+        break;
+      }
+      case HSA_AMD_SVM_ATTRIB_MIGRATION_GRANULARITY: {
+        value = kmt_attribs[kmtIndices[i]].value;
+        break;
+      }
+      case HSA_AMD_SVM_ATTRIB_PREFERRED_LOCATION: {
+        uint64_t node = kmt_attribs[kmtIndices[i]].value;
+        core::Agent* agent = nullptr;
+        if (node != INVALID_NODEID)
+          agent = core::Runtime::runtime_singleton_->agent_by_nodeid(node);
+        value = core::Agent::Convert(agent).handle;
+        break;
+      }
+      case HSA_AMD_SVM_ATTRIB_PREFETCH_LOCATION: {
+        uint64_t node = kmt_attribs[kmtIndices[i]].value;
+        core::Agent* agent = nullptr;
+        if (node != INVALID_NODEID)
+          agent = core::Runtime::runtime_singleton_->agent_by_nodeid(node);
+        value = core::Agent::Convert(agent).handle;
+        break;
+      }
+      case HSA_AMD_SVM_ATTRIB_READ_MOSTLY: {
+        value = (kmt_attribs[kmt_attribs.size() - 1].value & HSA_SVM_FLAG_GPU_READ_MOSTLY);
+        break;
+      }
+      case HSA_AMD_SVM_ATTRIB_ACCESS_QUERY: {
+        if (kmtIndices[i] == -1) {
+          // CPU agent access is stored as a flag, not as an attribute
+          if (kmt_attribs[kmt_attribs.size() - 1].value & HSA_SVM_FLAG_HOST_ACCESS)
+            attrib = HSA_AMD_SVM_ATTRIB_AGENT_ACCESSIBLE;
+          else
+            attrib = HSA_AMD_SVM_ATTRIB_AGENT_NO_ACCESS;
+        } else {
+          switch (kmt_attribs[kmtIndices[i]].type) {
+            case HSA_SVM_ATTR_ACCESS:
+              attrib = HSA_AMD_SVM_ATTRIB_AGENT_ACCESSIBLE;
+              break;
+            case HSA_SVM_ATTR_ACCESS_IN_PLACE:
+              attrib = HSA_AMD_SVM_ATTRIB_AGENT_ACCESSIBLE_IN_PLACE;
+              break;
+            case HSA_SVM_ATTR_NO_ACCESS:
+              attrib = HSA_AMD_SVM_ATTRIB_AGENT_NO_ACCESS;
+              break;
+            default:
+              assert(false && "Bad agent accessibility from KFD.");
+          }
+        }
+        break;
+      }
+      default:
+        throw hsa_exception(HSA_STATUS_ERROR_INVALID_ARGUMENT,
+                            "Illegal or invalid attribute in KfdDriver::SvmGetAttr.");
+    }
+  }
+
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t KfdDriver::SvmPrefetch(const core::Agent& dstAgent, void* base, size_t size) {
+  HSA_SVM_ATTRIBUTE attrib;
+
+  attrib.type = HSA_SVM_ATTR_PREFETCH_LOC;
+  attrib.value = dstAgent.node_id();
+  HSAKMT_STATUS error = HSAKMT_CALL(hsaKmtSVMSetAttr(base, size, 1, &attrib));
+
+  return error == HSAKMT_STATUS_SUCCESS ? HSA_STATUS_SUCCESS : HSA_STATUS_ERROR;
 }
 
 hsa_status_t KfdDriver::GetClockCounters(uint32_t node_id, HsaClockCounters* clock_counter) const {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_drm_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_drm_driver.h
@@ -193,6 +193,13 @@ public:
   static uint32_t MapHsaPriorityToHqd(
       HSA_QUEUE_PRIORITY hsa_priority);
 
+  /// @brief DRM ("one svm one gpu") SVM backend overrides.
+  hsa_status_t SvmSetAttr(void* base, size_t size,
+                          const hsa_amd_svm_attribute_pair_t* attribs, size_t count) override;
+  hsa_status_t SvmGetAttr(void* base, size_t size,
+                          hsa_amd_svm_attribute_pair_t* attribs, size_t count) override;
+  hsa_status_t SvmPrefetch(const core::Agent& dstAgent, void* base, size_t size) override;
+
   private:
   /// @brief Allocate (if needed) doorbell memory
   ///

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
@@ -45,6 +45,7 @@
 
 #include <memory>
 #include <string>
+#include <unordered_set>
 
 #include "hsakmt/hsakmt.h"
 
@@ -55,6 +56,7 @@ namespace rocr {
 
 namespace core {
 
+class Agent;
 class Queue;
 
 }
@@ -128,6 +130,11 @@ public:
   hsa_status_t SetSigbusDelay(uint32_t node_id, uint32_t delay_ms) const override;
   hsa_status_t GetDeviceHandle(uint32_t node_id, void** device_handle) const override;
   hsa_status_t GetDeviceFd(uint32_t node_id, int *fd) const override;
+  hsa_status_t SvmSetAttr(void* base, size_t size,
+                          const hsa_amd_svm_attribute_pair_t* attribs, size_t count) override;
+  hsa_status_t SvmGetAttr(void* base, size_t size,
+                          hsa_amd_svm_attribute_pair_t* attribs, size_t count) override;
+  hsa_status_t SvmPrefetch(const core::Agent& dstAgent, void* base, size_t size) override;
   hsa_status_t GetClockCounters(uint32_t node_id, HsaClockCounters* clock_counter) const override;
   hsa_status_t GetTileConfig(uint32_t node_id, HsaGpuTileConfig* config) const override;
   hsa_status_t GetWallclockFrequency(uint32_t node_id, uint64_t* frequency) const override;
@@ -162,6 +169,37 @@ public:
   /// @brief Constructor for subclasses (e.g. DrmDriver) to register under a
   /// specific DriverType while reusing the KFD driver implementation.
   KfdDriver(core::DriverType type, std::string devnode_name);
+
+  /// @brief Shared validation/deduplication logic for SvmSetAttr.
+  ///
+  /// @details Both KfdDriver::SvmSetAttr and DrmDriver::SvmSetAttr must convert
+  /// agent handles, reject duplicate agents, and reject attributes given more
+  /// than once. This helper encapsulates that common logic together with the
+  /// per-call bookkeeping state so the two backends do not duplicate it. The
+  /// @p context string is embedded in thrown hsa_exception messages so the
+  /// originating backend/function remains identifiable.
+  class SvmAttrParser {
+   public:
+    explicit SvmAttrParser(const char* context) : context_(context) {}
+
+    /// @brief Convert an agent handle, requiring a valid, non-null agent.
+    core::Agent* Convert(uint64_t value) const;
+
+    /// @brief Convert an agent handle, allowing null but rejecting an invalid
+    /// (non-null) handle.
+    core::Agent* ConvertAllowNull(uint64_t value) const;
+
+    /// @brief Throw if @p agent was already given an attribute in this call.
+    void ConfirmNew(core::Agent* agent);
+
+    /// @brief Throw if @p attrib was already specified in this call.
+    void CheckOnce(uint64_t attrib);
+
+   private:
+    const char* context_;
+    std::unordered_set<uint32_t> agent_seen_;
+    uint32_t set_attribs_ = 0;
+  };
 
  private:
   /// @brief Flags for @ref ExportMemoryHandleImpl.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
@@ -408,6 +408,37 @@ public:
   /// @return HSA_STATUS_SUCCESS if the driver successfully returns the file descriptor
   virtual hsa_status_t GetDeviceFd(uint32_t node_id, int *fd) const = 0;
 
+  /// @brief Set SVM attributes for an address range.
+  /// @param[in] base Start address of the range.
+  /// @param[in] size Size of the range in bytes.
+  /// @param[in] attribs hsa_amd_svm_attribute_pair_t list.
+  /// @param[in] count Number of entries in @p attribs.
+  /// @return HSA_STATUS_SUCCESS on success.
+  virtual hsa_status_t SvmSetAttr(void* base, size_t size,
+                                  const hsa_amd_svm_attribute_pair_t* attribs, size_t count) {
+    return HSA_STATUS_ERROR_INVALID_AGENT;
+  }
+
+  /// @brief Query SVM attributes for an address range.
+  /// @param[in] base Start address of the range.
+  /// @param[in] size Size of the range in bytes.
+  /// @param[in,out] attribs hsa_amd_svm_attribute_pair_t list.
+  /// @param[in] count Number of entries in @p attribs.
+  /// @return HSA_STATUS_SUCCESS on success.
+  virtual hsa_status_t SvmGetAttr(void* base, size_t size,
+                                  hsa_amd_svm_attribute_pair_t* attribs, size_t count) {
+    return HSA_STATUS_ERROR_INVALID_AGENT;
+  }
+
+  /// @brief Prefetch (migrate) an SVM range to @p dstAgent.
+  /// @param[in] dstAgent Target agent (a GPU, or a CPU/sysmem agent).
+  /// @param[in] base Start address of the range.
+  /// @param[in] size Size of the range in bytes.
+  /// @return HSA_STATUS_SUCCESS on success.
+  virtual hsa_status_t SvmPrefetch(const core::Agent& dstAgent, void* base, size_t size) {
+    return HSA_STATUS_ERROR_INVALID_AGENT;
+  }
+
   /// @brief Gets clock counters for particular Node
   /// @param[in] node_id Node ID of the agent
   /// @param[out] clock_counter Clock counter

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
@@ -492,6 +492,40 @@ class Runtime {
 
   Agent* agent_by_gpuid(uint32_t gpuid) { return agents_by_gpuid_[gpuid]; }
 
+  Agent* agent_by_nodeid(uint32_t node_id) {
+    auto it = agents_by_node_.find(node_id);
+    return (it != agents_by_node_.end() && !it->second.empty()) ? it->second[0] : nullptr;
+  }
+
+  /// @brief Select the driver bound to a representative GPU agent.
+  ///
+  /// Returns the driver managing the GPU node @p node_id, or, when no id is
+  /// given (or the id is not a GPU node), the driver of the first GPU agent.
+  Driver& AgentDriver(uint32_t node_id = INVALID_NODEID) {
+    if (node_id != INVALID_NODEID) {
+      Agent* agent = agent_by_nodeid(node_id);
+      if (agent && agent->device_type() == Agent::kAmdGpuDevice)
+        return agent->driver();
+    }
+
+    if (gpu_agents_.empty())
+      throw AMD::hsa_exception(HSA_STATUS_ERROR_INVALID_AGENT,
+                               "No GPU agent available.");
+
+    // The no-hint path returns a representative GPU's driver. This assumes
+    // every GPU shares the same kernel backend (all KFD or all DRM); a
+    // heterogeneous KFD/DRM mix is not supported because each backend only
+    // manages its own GPUs.
+    ifdebug {
+      const DriverType backend = gpu_agents_[0]->driver().kernel_driver_type_;
+      for (const Agent* agent : gpu_agents_)
+        assert(agent->driver().kernel_driver_type_ == backend &&
+               "Heterogeneous KFD/DRM GPU backends are not supported.");
+    }
+
+    return gpu_agents_[0]->driver();
+  }
+
   Agent* region_gpu() { return region_gpu_; }
 
   const std::vector<std::shared_ptr<const MemoryRegion>>& system_regions_fine() const {
@@ -796,7 +830,7 @@ class Runtime {
   struct PrefetchOp {
     void* base;
     size_t size;
-    uint32_t node_id;
+    core::Agent* dst_agent;
     int remaining_deps;
     hsa_signal_t completion;
     std::vector<hsa_signal_t> dep_signals;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -3172,171 +3172,14 @@ void Runtime::InternalQueueCreateNotify(const hsa_queue_t* queue, hsa_agent_t ag
 hsa_status_t Runtime::SetSvmAttrib(void* ptr, size_t size,
                                    hsa_amd_svm_attribute_pair_t* attribute_list,
                                    size_t attribute_count) {
-  uint32_t set_attribs = 0;
-  std::vector<bool> agent_seen(max_node_id() + 1, false);
-
-  std::vector<HSA_SVM_ATTRIBUTE> attribs;
-  attribs.reserve(attribute_count);
-  uint32_t set_flags = 0;
-  uint32_t clear_flags = 0;
-
-  auto Convert = [&](uint64_t value) -> Agent* {
-    hsa_agent_t handle = {value};
-    Agent* agent = Agent::Convert(handle);
-    if ((agent == nullptr) || !agent->IsValid())
-      throw AMD::hsa_exception(HSA_STATUS_ERROR_INVALID_AGENT,
-                               "Invalid agent handle in Runtime::SetSvmAttrib.");
-    return agent;
-  };
-
-  auto ConvertAllowNull = [&](uint64_t value) -> Agent* {
-    hsa_agent_t handle = {value};
-    Agent* agent = Agent::Convert(handle);
-    if ((agent != nullptr) && (!agent->IsValid()))
-      throw AMD::hsa_exception(HSA_STATUS_ERROR_INVALID_AGENT,
-                               "Invalid agent handle in Runtime::SetSvmAttrib.");
-    return agent;
-  };
-
-  auto ConfirmNew = [&](Agent* agent) {
-    if (agent_seen[agent->node_id()])
-      throw AMD::hsa_exception(
-          HSA_STATUS_ERROR_INCOMPATIBLE_ARGUMENTS,
-          "Multiple attributes given for the same agent in Runtime::SetSvmAttrib.");
-    agent_seen[agent->node_id()] = true;
-  };
-
-  auto Check = [&](uint64_t attrib) {
-    if (set_attribs & (1 << attrib))
-      throw AMD::hsa_exception(HSA_STATUS_ERROR_INCOMPATIBLE_ARGUMENTS,
-                               "Attribute given multiple times in Runtime::SetSvmAttrib.");
-    set_attribs |= (1 << attrib);
-  };
-
-  auto kmtPair = [](uint32_t attrib, uint32_t value) {
-    HSA_SVM_ATTRIBUTE pair = {attrib, value};
-    return pair;
-  };
-
-  for (uint32_t i = 0; i < attribute_count; i++) {
-    auto attrib = attribute_list[i].attribute;
-    auto value = attribute_list[i].value;
-
-    switch (attrib) {
-      case HSA_AMD_SVM_ATTRIB_GLOBAL_FLAG: {
-        Check(attrib);
-        switch (value) {
-          case HSA_AMD_SVM_GLOBAL_FLAG_FINE_GRAINED:
-            set_flags |= HSA_SVM_FLAG_COHERENT;
-            break;
-          case HSA_AMD_SVM_GLOBAL_FLAG_COARSE_GRAINED:
-            clear_flags |= HSA_SVM_FLAG_COHERENT;
-            break;
-          default:
-            throw AMD::hsa_exception(HSA_STATUS_ERROR_INVALID_ARGUMENT,
-                                     "Invalid HSA_AMD_SVM_ATTRIB_GLOBAL_FLAG value.");
-        }
-        break;
-      }
-      case HSA_AMD_SVM_ATTRIB_READ_ONLY: {
-        Check(attrib);
-        if (value)
-          set_flags |= HSA_SVM_FLAG_GPU_RO;
-        else
-          clear_flags |= HSA_SVM_FLAG_GPU_RO;
-        break;
-      }
-      case HSA_AMD_SVM_ATTRIB_HIVE_LOCAL: {
-        Check(attrib);
-        if (value)
-          set_flags |= HSA_SVM_FLAG_HIVE_LOCAL;
-        else
-          clear_flags |= HSA_SVM_FLAG_HIVE_LOCAL;
-        break;
-      }
-      case HSA_AMD_SVM_ATTRIB_MIGRATION_GRANULARITY: {
-        Check(attrib);
-        // Max migration size is 1GB.
-        if (value > 18) value = 18;
-        attribs.push_back(kmtPair(HSA_SVM_ATTR_GRANULARITY, value));
-        break;
-      }
-      case HSA_AMD_SVM_ATTRIB_PREFERRED_LOCATION: {
-        Check(attrib);
-        Agent* agent = ConvertAllowNull(value);
-        if (agent == nullptr)
-          attribs.push_back(kmtPair(HSA_SVM_ATTR_PREFERRED_LOC, INVALID_NODEID));
-        else
-          attribs.push_back(kmtPair(HSA_SVM_ATTR_PREFERRED_LOC, agent->node_id()));
-        break;
-      }
-      case HSA_AMD_SVM_ATTRIB_READ_MOSTLY: {
-        Check(attrib);
-        if (value)
-          set_flags |= HSA_SVM_FLAG_GPU_READ_MOSTLY;
-        else
-          clear_flags |= HSA_SVM_FLAG_GPU_READ_MOSTLY;
-        break;
-      }
-      case HSA_AMD_SVM_ATTRIB_GPU_EXEC: {
-        Check(attrib);
-        if (value)
-          set_flags |= HSA_SVM_FLAG_GPU_EXEC;
-        else
-          clear_flags |= HSA_SVM_FLAG_GPU_EXEC;
-        break;
-      }
-      case HSA_AMD_SVM_ATTRIB_AGENT_ACCESSIBLE: {
-        Agent* agent = Convert(value);
-        ConfirmNew(agent);
-        if (agent->device_type() == Agent::kAmdCpuDevice) {
-          set_flags |= HSA_SVM_FLAG_HOST_ACCESS;
-        } else {
-          attribs.push_back(kmtPair(HSA_SVM_ATTR_ACCESS, agent->node_id()));
-        }
-        break;
-      }
-      case HSA_AMD_SVM_ATTRIB_AGENT_ACCESSIBLE_IN_PLACE: {
-        Agent* agent = Convert(value);
-        ConfirmNew(agent);
-        if (agent->device_type() == Agent::kAmdCpuDevice) {
-          set_flags |= HSA_SVM_FLAG_HOST_ACCESS;
-        } else {
-          attribs.push_back(kmtPair(HSA_SVM_ATTR_ACCESS_IN_PLACE, agent->node_id()));
-        }
-        break;
-      }
-      case HSA_AMD_SVM_ATTRIB_AGENT_NO_ACCESS: {
-        Agent* agent = Convert(value);
-        ConfirmNew(agent);
-        if (agent->device_type() == Agent::kAmdCpuDevice) {
-          clear_flags |= HSA_SVM_FLAG_HOST_ACCESS;
-        } else {
-          attribs.push_back(kmtPair(HSA_SVM_ATTR_NO_ACCESS, agent->node_id()));
-        }
-        break;
-      }
-      default:
-        throw AMD::hsa_exception(HSA_STATUS_ERROR_INVALID_ARGUMENT,
-                                 "Illegal or invalid attribute in Runtime::SetSvmAttrib");
-    }
-  }
-
-  // Merge CPU access properties - grant access if any CPU needs access.
-  // Probably wrong.
-  if (set_flags & HSA_SVM_FLAG_HOST_ACCESS) clear_flags &= ~HSA_SVM_FLAG_HOST_ACCESS;
-
-  // Add flag updates
-  if (clear_flags) attribs.push_back(kmtPair(HSA_SVM_ATTR_CLR_FLAGS, clear_flags));
-  if (set_flags) attribs.push_back(kmtPair(HSA_SVM_ATTR_SET_FLAGS, set_flags));
-
   const size_t pageSize = os::PageSize();
   uint8_t* base = AlignDown((uint8_t*)ptr, pageSize);
   uint8_t* end = AlignUp((uint8_t*)ptr + size, pageSize);
   size_t len = end - base;
-  HSAKMT_STATUS error = HSAKMT_CALL(hsaKmtSVMSetAttr(base, len, attribs.size(), &attribs[0]));
-  if (error != HSAKMT_STATUS_SUCCESS)
-    throw AMD::hsa_exception(HSA_STATUS_ERROR, "hsaKmtSVMSetAttr failed.");
+
+  hsa_status_t error = AgentDriver().SvmSetAttr(base, len, attribute_list, attribute_count);
+  if (error != HSA_STATUS_SUCCESS)
+    throw AMD::hsa_exception(HSA_STATUS_ERROR, "SVM set attributes failed.");
 
   return HSA_STATUS_SUCCESS;
 }
@@ -3344,158 +3187,69 @@ hsa_status_t Runtime::SetSvmAttrib(void* ptr, size_t size,
 hsa_status_t Runtime::GetSvmAttrib(void* ptr, size_t size,
                                    hsa_amd_svm_attribute_pair_t* attribute_list,
                                    size_t attribute_count) {
-  std::vector<HSA_SVM_ATTRIBUTE> attribs;
-  attribs.reserve(attribute_count);
-
-  std::vector<int> kmtIndices(attribute_count);
-
-  bool getFlags = false;
-
-  auto Convert = [&](uint64_t value) -> Agent* {
-    hsa_agent_t handle = {value};
-    Agent* agent = Agent::Convert(handle);
-    if ((agent == nullptr) || !agent->IsValid())
-      throw AMD::hsa_exception(HSA_STATUS_ERROR_INVALID_AGENT,
-                               "Invalid agent handle in Runtime::GetSvmAttrib.");
-    return agent;
-  };
-
-  auto kmtPair = [](uint32_t attrib, uint32_t value) {
-    HSA_SVM_ATTRIBUTE pair = {attrib, value};
-    return pair;
-  };
-
-  for (uint32_t i = 0; i < attribute_count; i++) {
-    auto& attrib = attribute_list[i].attribute;
-    auto& value = attribute_list[i].value;
-
-    switch (attrib) {
-      case HSA_AMD_SVM_ATTRIB_GLOBAL_FLAG:
-      case HSA_AMD_SVM_ATTRIB_READ_ONLY:
-      case HSA_AMD_SVM_ATTRIB_HIVE_LOCAL:
-      case HSA_AMD_SVM_ATTRIB_READ_MOSTLY: {
-        getFlags = true;
-        kmtIndices[i] = -1;
-        break;
-      }
-      case HSA_AMD_SVM_ATTRIB_MIGRATION_GRANULARITY: {
-        kmtIndices[i] = attribs.size();
-        attribs.push_back(kmtPair(HSA_SVM_ATTR_GRANULARITY, 0));
-        break;
-      }
-      case HSA_AMD_SVM_ATTRIB_PREFERRED_LOCATION: {
-        kmtIndices[i] = attribs.size();
-        attribs.push_back(kmtPair(HSA_SVM_ATTR_PREFERRED_LOC, 0));
-        break;
-      }
-      case HSA_AMD_SVM_ATTRIB_PREFETCH_LOCATION: {
-        value = Agent::Convert(GetSVMPrefetchAgent(ptr, size)).handle;
-        kmtIndices[i] = -1;
-        break;
-      }
-      case HSA_AMD_SVM_ATTRIB_ACCESS_QUERY: {
-        Agent* agent = Convert(value);
-        if (agent->device_type() == Agent::kAmdCpuDevice) {
-          getFlags = true;
-          kmtIndices[i] = -1;
-        } else {
-          kmtIndices[i] = attribs.size();
-          attribs.push_back(kmtPair(HSA_SVM_ATTR_ACCESS, agent->node_id()));
-        }
-        break;
-      }
-      default:
-        throw AMD::hsa_exception(HSA_STATUS_ERROR_INVALID_ARGUMENT,
-                                 "Illegal or invalid attribute in Runtime::SetSvmAttrib");
-    }
-  }
-
-  if (getFlags) {
-    // Order is important to later code.
-    attribs.push_back(kmtPair(HSA_SVM_ATTR_CLR_FLAGS, 0));
-    attribs.push_back(kmtPair(HSA_SVM_ATTR_SET_FLAGS, 0));
-  }
-
   const size_t pageSize = os::PageSize();
   uint8_t* base = AlignDown((uint8_t*)ptr, pageSize);
   uint8_t* end = AlignUp((uint8_t*)ptr + size, pageSize);
   size_t len = end - base;
-  if (attribs.size() != 0) {
-    HSAKMT_STATUS error = HSAKMT_CALL(hsaKmtSVMGetAttr(base, len, attribs.size(), &attribs[0]));
-    if (error != HSAKMT_STATUS_SUCCESS)
-      throw AMD::hsa_exception(HSA_STATUS_ERROR, "hsaKmtSVMGetAttr failed.");
+
+  // The prefetch location is tracked by the runtime (prefetch_map_), which
+  // reflects pending async prefetches not yet visible to the backend. Resolve
+  // it here and do NOT forward PREFETCH_LOCATION to the backend: the backend
+  // would perform its own prefetch query whose result is immediately discarded.
+  bool has_prefetch = false;
+  for (uint32_t i = 0; i < attribute_count; i++) {
+    if (attribute_list[i].attribute == HSA_AMD_SVM_ATTRIB_PREFETCH_LOCATION) {
+      has_prefetch = true;
+      break;
+    }
   }
 
-  for (uint32_t i = 0; i < attribute_count; i++) {
-    auto& attrib = attribute_list[i].attribute;
-    auto& value = attribute_list[i].value;
+  // Common case: no PREFETCH_LOCATION requested, forward the caller's list as-is.
+  if (!has_prefetch) {
+    hsa_status_t error = AgentDriver().SvmGetAttr(base, len, attribute_list, attribute_count);
+    if (error != HSA_STATUS_SUCCESS)
+      throw AMD::hsa_exception(HSA_STATUS_ERROR, "SVM get attributes failed.");
+    return HSA_STATUS_SUCCESS;
+  }
 
-    switch (attrib) {
-      case HSA_AMD_SVM_ATTRIB_GLOBAL_FLAG: {
-        if (attribs[attribs.size() - 1].value & HSA_SVM_FLAG_COHERENT) {
-          value = HSA_AMD_SVM_GLOBAL_FLAG_FINE_GRAINED;
-          break;
-        }
-        if (attribs[attribs.size() - 2].value & HSA_SVM_FLAG_COHERENT)
-          value = HSA_AMD_SVM_GLOBAL_FLAG_COARSE_GRAINED;
-        else
-          value = HSA_AMD_SVM_GLOBAL_FLAG_INDETERMINATE;
-        break;
+  // Otherwise resolve prefetch entries locally and forward only the rest.
+  if (has_prefetch && attribute_count == 1) {
+    // Special case: only PREFETCH_LOCATION requested
+    attribute_list[0].value = Agent::Convert(GetSVMPrefetchAgent(ptr, size)).handle;
+    return HSA_STATUS_SUCCESS;
+  }
+
+  std::vector<hsa_amd_svm_attribute_pair_t> forwarded;
+  std::vector<size_t> forwarded_index;
+  forwarded.reserve(attribute_count);
+  forwarded_index.reserve(attribute_count);
+
+  bool prefetch_resolved = false;
+  uint64_t prefetch_value = 0;
+
+  for (uint32_t i = 0; i < attribute_count; i++) {
+    if (attribute_list[i].attribute == HSA_AMD_SVM_ATTRIB_PREFETCH_LOCATION) {
+      if (!prefetch_resolved) {
+        prefetch_value = Agent::Convert(GetSVMPrefetchAgent(ptr, size)).handle;
+        prefetch_resolved = true;
       }
-      case HSA_AMD_SVM_ATTRIB_READ_ONLY: {
-        value = (attribs[attribs.size() - 1].value & HSA_SVM_FLAG_GPU_RO);
-        break;
-      }
-      case HSA_AMD_SVM_ATTRIB_HIVE_LOCAL: {
-        value = (attribs[attribs.size() - 1].value & HSA_SVM_FLAG_HIVE_LOCAL);
-        break;
-      }
-      case HSA_AMD_SVM_ATTRIB_MIGRATION_GRANULARITY: {
-        value = attribs[kmtIndices[i]].value;
-        break;
-      }
-      case HSA_AMD_SVM_ATTRIB_PREFERRED_LOCATION: {
-        uint64_t node = attribs[kmtIndices[i]].value;
-        Agent* agent = nullptr;
-        if (node != INVALID_NODEID) agent = agents_by_node_[node][0];
-        value = Agent::Convert(agent).handle;
-        break;
-      }
-      case HSA_AMD_SVM_ATTRIB_PREFETCH_LOCATION: {
-        break;
-      }
-      case HSA_AMD_SVM_ATTRIB_READ_MOSTLY: {
-        value = (attribs[attribs.size() - 1].value & HSA_SVM_FLAG_GPU_READ_MOSTLY);
-        break;
-      }
-      case HSA_AMD_SVM_ATTRIB_ACCESS_QUERY: {
-        if (kmtIndices[i] == -1) {
-          // CPU agent access is stored as a flag, not as an attribute
-          if (attribs[attribs.size() - 1].value & HSA_SVM_FLAG_HOST_ACCESS)
-            attrib = HSA_AMD_SVM_ATTRIB_AGENT_ACCESSIBLE;
-          else
-            attrib = HSA_AMD_SVM_ATTRIB_AGENT_NO_ACCESS;
-        } else {
-          switch (attribs[kmtIndices[i]].type) {
-            case HSA_SVM_ATTR_ACCESS:
-              attrib = HSA_AMD_SVM_ATTRIB_AGENT_ACCESSIBLE;
-              break;
-            case HSA_SVM_ATTR_ACCESS_IN_PLACE:
-              attrib = HSA_AMD_SVM_ATTRIB_AGENT_ACCESSIBLE_IN_PLACE;
-              break;
-            case HSA_SVM_ATTR_NO_ACCESS:
-              attrib = HSA_AMD_SVM_ATTRIB_AGENT_NO_ACCESS;
-              break;
-            default:
-              assert(false && "Bad agent accessibility from KFD.");
-          }
-        }
-        break;
-      }
-      default:
-        throw AMD::hsa_exception(HSA_STATUS_ERROR_INVALID_ARGUMENT,
-                                 "Illegal or invalid attribute in Runtime::GetSvmAttrib");
+      attribute_list[i].value = prefetch_value;
+    } else {
+      forwarded.push_back(attribute_list[i]);
+      forwarded_index.push_back(i);
     }
+  }
+
+  if (!forwarded.empty()) {
+    hsa_status_t error =
+        AgentDriver().SvmGetAttr(base, len, forwarded.data(), forwarded.size());
+    if (error != HSA_STATUS_SUCCESS)
+      throw AMD::hsa_exception(HSA_STATUS_ERROR, "SVM get attributes failed.");
+
+    // Write results back to their original slots. This also propagates the
+    // attribute-field rewrite that ACCESS_QUERY performs in place.
+    for (size_t j = 0; j < forwarded.size(); j++)
+      attribute_list[forwarded_index[j]] = forwarded[j];
   }
 
   return HSA_STATUS_SUCCESS;
@@ -3513,7 +3267,7 @@ hsa_status_t Runtime::SvmPrefetch(void* ptr, size_t size, hsa_agent_t agent,
   MAKE_NAMED_SCOPE_GUARD(OpGuard, [&]() { delete op; });
 
   Agent* dest = Agent::Convert(agent);
-  op->node_id = dest->node_id();
+  op->dst_agent = dest;
 
   op->base = reinterpret_cast<void*>(base);
   op->size = len;
@@ -3601,6 +3355,7 @@ hsa_status_t Runtime::SvmPrefetch(void* ptr, size_t size, hsa_agent_t agent,
   // Prefetch Signal handler for synchronization.
   static hsa_amd_signal_handler signal_handler = [](hsa_signal_value_t value, void* arg) {
     PrefetchOp* op = reinterpret_cast<PrefetchOp*>(arg);
+    core::Agent* agent = op->dst_agent;
 
     if (op->remaining_deps > 0) {
       op->remaining_deps--;
@@ -3609,11 +3364,8 @@ hsa_status_t Runtime::SvmPrefetch(void* ptr, size_t size, hsa_agent_t agent,
       return false;
     }
 
-    HSA_SVM_ATTRIBUTE attrib;
-    attrib.type = HSA_SVM_ATTR_PREFETCH_LOC;
-    attrib.value = op->node_id;
-    HSAKMT_STATUS error = HSAKMT_CALL(hsaKmtSVMSetAttr(op->base, op->size, 1, &attrib));
-    assert(error == HSAKMT_STATUS_SUCCESS && "KFD Prefetch failed.");
+    hsa_status_t error = agent->driver().SvmPrefetch(*agent, op->base, op->size);
+    assert(error == HSA_STATUS_SUCCESS && "KFD Prefetch failed.");
     (void)error;
 
     removePrefetchRanges(op);
@@ -3653,10 +3405,12 @@ Agent* Runtime::GetSVMPrefetchAgent(void* ptr, size_t size) {
   if (start != prefetch_map_.begin()) start--;
   auto stop = prefetch_map_.lower_bound(end);
 
-  // KFD returns -1 for no or mixed destinations.
-  uint32_t prefetch_node = -2;
+  // The single prefetch destination shared by the whole query, or nullptr
+  // until the first overlapping range establishes it. A null/mixed destination
+  // triggers an early return, so it is never stored here.
+  Agent* prefetch_agent = nullptr;
   if (start != stop) {
-    prefetch_node = start->second.op->node_id;
+    prefetch_agent = start->second.op->dst_agent;
   }
 
   while (start != stop) {
@@ -3668,7 +3422,7 @@ Agent* Runtime::GetSVMPrefetchAgent(void* ptr, size_t size) {
     // Check for intersection with the query
     if (ibase < iend) {
       // If prefetch locations are different then we report null agent.
-      if (prefetch_node != start->second.op->node_id) return nullptr;
+      if (prefetch_agent != start->second.op->dst_agent) return nullptr;
 
       // Push leading gap to an array for checking KFD.
       if (base < ibase) holes.push_back(std::make_pair(base, ibase - base));
@@ -3680,22 +3434,25 @@ Agent* Runtime::GetSVMPrefetchAgent(void* ptr, size_t size) {
   }
   if (base < end) holes.push_back(std::make_pair(base, end - base));
 
-  HSA_SVM_ATTRIBUTE attrib;
-  attrib.type = HSA_SVM_ATTR_PREFETCH_LOC;
+  hsa_amd_svm_attribute_pair_t attrib;
+  attrib.attribute = HSA_AMD_SVM_ATTRIB_PREFETCH_LOCATION;
   for (auto& range : holes) {
-    HSAKMT_STATUS error =
-        HSAKMT_CALL(hsaKmtSVMGetAttr(reinterpret_cast<void*>(range.first), range.second, 1, &attrib));
-    assert(error == HSAKMT_STATUS_SUCCESS && "KFD prefetch query failed.");
+    attrib.value = 0;
+    hsa_status_t error =
+        AgentDriver().SvmGetAttr(reinterpret_cast<void*>(range.first), range.second, &attrib, 1);
+    assert(error == HSA_STATUS_SUCCESS && "SVM prefetch query failed.");
     (void)error;
 
-    if (attrib.value == -1) return nullptr;
-    if (prefetch_node == -2) prefetch_node = attrib.value;
-    if (prefetch_node != attrib.value) return nullptr;
+    // The backend reports the prefetch location as an agent handle; a null
+    // handle means no or mixed destination for this range.
+    Agent* range_agent = Agent::Convert(hsa_agent_t{attrib.value});
+    if (range_agent == nullptr) return nullptr;
+    if (prefetch_agent == nullptr) prefetch_agent = range_agent;
+    if (prefetch_agent != range_agent) return nullptr;
   }
 
-  assert(prefetch_node != -2 && "prefetch_node was not updated.");
-  assert(prefetch_node != -1 && "Should have already returned.");
-  return agents_by_node_[prefetch_node][0];
+  assert(prefetch_agent != nullptr && "prefetch_agent was not updated.");
+  return prefetch_agent;
 }
 
 hsa_status_t Runtime::SvmBatchDiscard(void** ptrs, size_t* sizes, uint32_t count,
@@ -3728,7 +3485,7 @@ hsa_status_t Runtime::SvmBatchDiscard(void** ptrs, size_t* sizes, uint32_t count
 
   // Discard operation context
   struct DiscardOp {
-    std::vector<uint32_t> target_cpus;
+    std::vector<core::Agent*> target_cpus;
     std::vector<std::pair<void*, size_t>> regions;
     std::atomic<uint32_t> remaining_deps;
     hsa_signal_t completion;
@@ -3750,20 +3507,20 @@ hsa_status_t Runtime::SvmBatchDiscard(void** ptrs, size_t* sizes, uint32_t count
     op->regions.emplace_back(std::make_pair(reinterpret_cast<void*>(base), len));
 
     // Query the nearest cpu agent for the region
-    HSA_SVM_ATTRIBUTE attr;
-    attr.type = HSA_SVM_ATTR_PREFERRED_LOC;
+    hsa_amd_svm_attribute_pair_t attr;
+    attr.attribute = HSA_AMD_SVM_ATTRIB_PREFERRED_LOCATION;
     attr.value = 0;
 
     Agent* cpu_agent = nullptr;
-    HSAKMT_STATUS status = HSAKMT_CALL(hsaKmtSVMGetAttr(base, len, 1, &attr));
+    hsa_status_t status = AgentDriver().SvmGetAttr(base, len, &attr, 1);
 
-    if (status == HSAKMT_STATUS_SUCCESS &&
-        (attr.value != 0xFFFFFFFF && attr.value != INVALID_NODEID)) {
-      core::Agent* agent = agents_by_node_[attr.value][0];
-
+    // The backend reports the preferred location as an agent handle.
+    core::Agent* agent =
+        (status == HSA_STATUS_SUCCESS) ? Agent::Convert(hsa_agent_t{attr.value}) : nullptr;
+    if (agent != nullptr) {
       if (agent->device_type() == core::Agent::kAmdCpuDevice) {
         // Already on a CPU agent; skip prefetch for this region
-        op->target_cpus.push_back(UINT32_MAX);
+        op->target_cpus.push_back(nullptr);
         continue;
       } else {
         cpu_agent = agent->GetNearestCpuAgent();
@@ -3774,7 +3531,7 @@ hsa_status_t Runtime::SvmBatchDiscard(void** ptrs, size_t* sizes, uint32_t count
       // Fallback to use first available CPU agent when nearest fails
       cpu_agent = cpu_agents_[0];
     }
-    op->target_cpus.push_back(cpu_agent->node_id());
+    op->target_cpus.push_back(cpu_agent);
   }
 
   // Dependancy signals already at 0 need not be monitored.
@@ -3792,15 +3549,11 @@ hsa_status_t Runtime::SvmBatchDiscard(void** ptrs, size_t* sizes, uint32_t count
     for (size_t i = 0; i < op->regions.size(); i++) {
       void* base = op->regions[i].first;
       size_t size = op->regions[i].second;
-      uint32_t target_cpu = op->target_cpus[i];
+      core::Agent* target_cpu = op->target_cpus[i];
 
-      if (target_cpu != UINT32_MAX) {
-        HSA_SVM_ATTRIBUTE attr;
-        attr.type = HSA_SVM_ATTR_PREFETCH_LOC;
-        attr.value = target_cpu;
-
-        HSAKMT_STATUS err = HSAKMT_CALL(hsaKmtSVMSetAttr(base, size, 1, &attr));
-        if (err != HSAKMT_STATUS_SUCCESS) {
+      if (target_cpu != nullptr) {
+        hsa_status_t err = target_cpu->driver().SvmPrefetch(*target_cpu, base, size);
+        if (err != HSA_STATUS_SUCCESS) {
           debug_warning(false && "hsaKmtSVMSetAttr prefetch failed in SvmBatchDiscard");
         }
       }

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
@@ -4172,13 +4172,23 @@ typedef struct hsa_amd_svm_attribute_pair_s {
  * Attributes HSA_AMD_SVM_ATTRIB_ACCESS_QUERY and HSA_AMD_SVM_ATTRIB_PREFETCH_LOCATION
  * may not be used with this API.
  *
+ * Passing @p attribute_count == 0 (with @p attribute_list ignored, and may be
+ * NULL) is a sentinel that resets ALL SVM attributes for the address range back
+ * to their defaults, atomically clearing any previously set attributes
+ * (including per-agent access) for the range.
+ * Note: older ROCr runtimes treat @p attribute_count == 0
+ * as a no-op, so callers relying on the reset semantic should ensure a runtime
+ * that documents this behavior.
+ *
  * @param[in] ptr Will be aligned down to nearest page boundary.
  *
  * @param[in] size Will be aligned up to nearest page boundary.
  *
  * @param[in] attribute_list List of attributes to set for the address range.
+ *            Ignored when @p attribute_count is 0.
  *
- * @param[in] attribute_count Length of @p attribute_list.
+ * @param[in] attribute_count Length of @p attribute_list. A value of 0 resets
+ *            all SVM attributes for the range to defaults (see above).
  */
 hsa_status_t hsa_amd_svm_attributes_set(void* ptr, size_t size,
                                         hsa_amd_svm_attribute_pair_t* attribute_list,


### PR DESCRIPTION
## Motivation

ROCr's SVM functionality (`hsa_amd_svm_attributes_set` / `_get` / `hsa_amd_svm_prefetch_async`) is currently implemented only against the KFD (`/dev/kfd`) SVM ioctls. This PR adds an alternative **DRM (libdrm/amdgpu) backend** so the same HSA-level SVM operations can run through the amdgpu DRM `svm_set_attr` / `svm_get_attr` ioctls, enabling SVM on the DRM path while preserving identical HSA semantics. The backend is gated behind the existing `enable_drm` flag and does not change default (KFD) behavior.

## Technical Details

- **Driver abstraction.** SVM entry points (`SvmSetAttr` / `SvmGetAttr` / `SvmPrefetch`) are virtual methods on `core::Driver`. `DrmDriver` derives from `KfdDriver` (via a new protected `KfdDriver(DriverType, devnode)` constructor), overrides only the SVM and DRM-specific queue paths, and inherits everything else — delegating back to KFD where DRM has no equivalent yet. GPU targets are identified by `core::Agent` rather than raw node ids: dispatch to the owning backend happens at the call site via `agent->driver()`, and each backend then reads only what it needs from the agent (KFD: `node_id()`; DRM: `device_type()` + `GpuAgent::libDrmDev()`), so the DRM backend never has to reverse-map a node id back to a device.

- **Per-device kernel model.** The amdgpu DRM SVM model maintains one independent context per device; an operation spanning "all devices" is expressed as one ioctl per participating GPU, issued on that GPU's fd (obtained from the agent's `GpuAgent::libDrmDev()`). The target device is chosen by which fd the ioctl is sent on, not by a node ID in the payload. Location fields are sentinels (SYSMEM=0, UNDEFINED=0xffffffff, any other value = "the device that received this ioctl"), so a fixed `kSvmLocationThisGpu = 1u` constant is used together with fd routing.

- **common vs per_device attributes.** `SvmSetAttr` splits attributes into range-wide (`common`) and device-specific (`per_device[agent]`, keyed by `core::Agent*`) buckets and fans them out per GPU agent (iterating `gpu_agents()`, reaching each context through `GpuAgent::libDrmDev()`). Boolean flags are accumulated as `set_mask`/`clr_mask` and materialized once. CPU accessibility maps to the range-wide HOST_ACCESS flag.

- **Attribute reset (count == 0).** HSA defines `hsa_amd_svm_attributes_set` with a zero-length attribute list as "restore this range to default attributes." The two backends realize this differently because their kernel models differ. KFD keeps no persistent per-range attribute state that the runtime must unwind, so `KfdDriver::SvmSetAttr` treats `count == 0` as a no-op that returns success. The amdgpu DRM model, by contrast, stores explicit attribute ranges per SVM context, so defaults must be re-established actively: `DrmDriver::SvmSetAttr` fans a dedicated `amdgpu_svm_reset_attr` ioctl out to every participating GPU (one call per fd, resolved via each GPU agent's `GpuAgent::libDrmDev()`), before any attribute parsing. On the kernel side the reset is deliberately lightweight — `amdgpu_svm_attr_reset` simply clears the attribute ranges over `[base, base+size)` rather than materializing default entries, relying on the invariant that "no attr node" is equivalent to "default attrs" for the GET, SET, and fault paths. Because it only touches attribute metadata (not GPU mappings), no mapping invalidation is issued. Consistent with the other set paths, the reset fails fast: any per-device ioctl error aborts the whole call with `HSA_STATUS_ERROR`.

- **Batched read-back.** `SvmGetAttr` reconstructs HSA answers in three phases (plan → collect one batched `amdgpu_svm_get_attr` per GPU agent → resolve), including ACCESS_QUERY rewriting the entry's attribute field to AGENT_ACCESSIBLE / _IN_PLACE / AGENT_NO_ACCESS. Preferred/prefetch locations resolved to a GPU are mapped back to the corresponding `core::Agent`.

- **Prefetch.** `SvmPrefetch` takes the destination `core::Agent&`. A GPU destination prefetches on that agent's fd only (`GpuAgent::libDrmDev()`, `device_type() == kAmdGpuDevice`); a CPU/sysmem destination fans a SYSMEM prefetch out to every GPU agent's fd, since each device's independent context must be updated.

- **Shared validation.** Per-call agent-handle conversion and de-duplication is factored into a short-lived `KfdDriver::SvmAttrParser` helper, reused by both backends and both set/get paths.

- **Error semantics.** `SvmSetAttr` and GPU-destination `SvmPrefetch` fail fast: any per-device ioctl error aborts the whole call with `HSA_STATUS_ERROR`. Sysmem-destination `SvmPrefetch` and get-collection are best-effort per device. Because the amdgpu SVM model has no cross-device atomic transaction and prefetch has no clean rollback, **any multi-device operation that fails partway leaves some contexts updated and others not — neither fail-fast nor best-effort can avoid this partial state.** The two paths therefore make a deliberate, workload-driven trade-off:

     - **GPU-destination prefetch** targets a single device, so fail-fast is unambiguous and surfaces errors directly (matching `SvmSetAttr`).
     - **Sysmem-destination prefetch** must fan out to *every* GPU context; the goal is to drive the range toward system memory as broadly as possible, so it attempts all devices rather than stopping at the first failure. Since prefetch is a migration *hint* (pages stay valid and are re-migrated on demand by the fault path), a partial sysmem prefetch is a performance concern, not a correctness/coherence violation — making best-effort the appropriate choice here.


A companion design document is included at:
-  [Design: DRM/libdrm Backend for ROCr SVM](https://amd.atlassian.net/wiki/spaces/ASLGP/pages/1743456343/Design+DRM+libdrm+Backend+for+ROCr+SVM)
- [Per-SVM-Per-Device Multi-GPU Attribute Consistency Analysis](https://amd.atlassian.net/wiki/spaces/ASLGP/pages/1798326999/Per-SVM-Per-Device+Multi-GPU+Attribute+Consistency+Analysis).
## Dependencies

This is part of a systematic, cross-component effort. This PR depends on:

- **Kernel** — the amd-unified-interface + DRM SVM branch: <https://gerrit-git.amd.com/plugins/gitiles/brahma/ec/linux/+/refs/heads/junhshen/drm-svm-on-unified-interface>
- **libdrm** — the amdgpu DRM SVM branch: <https://gerrit-git.amd.com/plugins/gitiles/brahma/ec/drm/+/refs/heads/junhshen/amdgpu-drm-svm>


## Test Plan

- rocrtst

## Test Result
- rocrtst `SvmMemory` subtests pass on gfx906 via the DRM backend.
- Note: current runs pin `ROCR_VISIBLE_DEVICES=0`, so validation is single-GPU; the multi-GPU fan-out paths should be exercised with ≥2 visible GPUs before merge.

## Note

This is a **draft** intended primarily to solicit feedback on:
- The **driver-interface design** (the `core::Driver` SVM abstraction and its KFD/DRM subclassing) and on whether the **runtime-layer integration** is reasonable.
- The implementation details still need further validation — in particular the split between **common (range-wide) attributes** and **per-device attributes**, and the model for **fanning these out into per-GPU ioctls**. Feedback on that model is especially welcome.

