### PR TITLE
fix(rocjitsu): fix ubsan related errors

### DIFF
--- a/emulation/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/CMakeLists.txt
@@ -164,7 +164,6 @@ if(_rj_sanitizer_count GREATER 0)
     list(JOIN _rj_sanitizer_kinds "," _rj_sanitizer_arg)
     set(RJ_SANITIZER_COMPILE_OPTIONS)
     set(RJ_SANITIZER_LINK_OPTIONS)
-    list(APPEND RJ_SANITIZER_COMPILE_OPTIONS "-fno-sanitize-recover=all")
     message(STATUS "Sanitizer enabled: ${_rj_sanitizer_arg}")
     if(MSVC)
         # MSVC only supports AddressSanitizer; ubsan/tsan/msan are GCC/Clang-only.
@@ -177,6 +176,7 @@ if(_rj_sanitizer_count GREATER 0)
             message(FATAL_ERROR "Only RJ_ENABLE_ASAN is supported by MSVC.")
         endif()
     elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
+        list(APPEND RJ_SANITIZER_COMPILE_OPTIONS "-fno-sanitize-recover=all")
         list(
             APPEND RJ_SANITIZER_COMPILE_OPTIONS
             -fsanitize=${_rj_sanitizer_arg}

--- a/emulation/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/CMakeLists.txt
@@ -164,6 +164,7 @@ if(_rj_sanitizer_count GREATER 0)
     list(JOIN _rj_sanitizer_kinds "," _rj_sanitizer_arg)
     set(RJ_SANITIZER_COMPILE_OPTIONS)
     set(RJ_SANITIZER_LINK_OPTIONS)
+    list(APPEND RJ_SANITIZER_COMPILE_OPTIONS "-fno-sanitize-recover=all")
     message(STATUS "Sanitizer enabled: ${_rj_sanitizer_arg}")
     if(MSVC)
         # MSVC only supports AddressSanitizer; ubsan/tsan/msan are GCC/Clang-only.

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/sema_lower.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/sema_lower.py
@@ -1617,10 +1617,7 @@ _INLINE_TERNARY_OPS: dict[str, str] = {
     ' return static_cast<uint32_t>(a - b - c); }}()',
     'mad_u24': '(({0} & 0x00FFFFFFu) * ({1} & 0x00FFFFFFu) + {2})',
     'mad_i24': '::rocjitsu::amdgpu::mad_i24_u32({0}, {1}, {2})',
-    'mad_lo_u16': 'static_cast<uint32_t>(static_cast<uint16_t>('
-    'static_cast<uint32_t>(static_cast<uint16_t>({0})) * '
-    'static_cast<uint32_t>(static_cast<uint16_t>({1})) + '
-    'static_cast<uint32_t>(static_cast<uint16_t>({2}))))',
+    'mad_lo_u16': '::rocjitsu::amdgpu::mad_lo_u16({0}, {1}, {2})',
     'bfe_u': '[&]() {{ uint32_t src={0}; uint32_t off={1} & 31u; uint32_t w={2} & 31u;'
     ' if (w == 0) return 0u;'
     ' uint32_t mask = (w >= 32) ? ~0u : ((1u << w) - 1u);'

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/sema_lower.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/sema_lower.py
@@ -1617,6 +1617,10 @@ _INLINE_TERNARY_OPS: dict[str, str] = {
     ' return static_cast<uint32_t>(a - b - c); }}()',
     'mad_u24': '(({0} & 0x00FFFFFFu) * ({1} & 0x00FFFFFFu) + {2})',
     'mad_i24': '::rocjitsu::amdgpu::mad_i24_u32({0}, {1}, {2})',
+    'mad_lo_u16': 'static_cast<uint32_t>(static_cast<uint16_t>('
+    'static_cast<uint32_t>(static_cast<uint16_t>({0})) * '
+    'static_cast<uint32_t>(static_cast<uint16_t>({1})) + '
+    'static_cast<uint32_t>(static_cast<uint16_t>({2}))))',
     'bfe_u': '[&]() {{ uint32_t src={0}; uint32_t off={1} & 31u; uint32_t w={2} & 31u;'
     ' if (w == 0) return 0u;'
     ' uint32_t mask = (w >= 32) ? ~0u : ((1u << w) - 1u);'

--- a/emulation/rocjitsu/lib/python/amdisa/sema_derive.py
+++ b/emulation/rocjitsu/lib/python/amdisa/sema_derive.py
@@ -1206,6 +1206,22 @@ class _VectorTernary(_ScalarDeriver):
             body = _assign(_cast(_dst(0), ty), result)
             return SemaBlock(sem.name, ExecModel.VECTOR, body)
 
+        if op == 'mad' and dtype == 'u16':
+            result = SemaNode(
+                SemaNodeKind.CALL,
+                ty=ty,
+                call_name='mad_lo_u16',
+                children=(
+                    _id('mad_lo_u16'),
+                    _src(0),
+                    _src(1),
+                    _src(2),
+                ),
+            )
+            body = _assign(_cast(_dst(0), ty), result)
+            return SemaBlock(sem.name, ExecModel.VECTOR, body)
+
+
         if op in ('add_min', 'add_max') and dtype in ('i32', 'u32'):
             call_name = f'{op}_{dtype}'
             result = SemaNode(

--- a/emulation/rocjitsu/lib/python/amdisa/sema_derive.py
+++ b/emulation/rocjitsu/lib/python/amdisa/sema_derive.py
@@ -1221,7 +1221,6 @@ class _VectorTernary(_ScalarDeriver):
             body = _assign(_cast(_dst(0), ty), result)
             return SemaBlock(sem.name, ExecModel.VECTOR, body)
 
-
         if op in ('add_min', 'add_max') and dtype in ('i32', 'u32'):
             call_name = f'{op}_{dtype}'
             result = SemaNode(

--- a/emulation/rocjitsu/lib/python/amdisa/sema_derive.py
+++ b/emulation/rocjitsu/lib/python/amdisa/sema_derive.py
@@ -1163,6 +1163,18 @@ class _VectorBinop(_ScalarDeriver):
             body = _assign(_cast(_dst(0), ty), result)
             return SemaBlock(sem.name, ExecModel.VECTOR, body)
 
+        if op in ('add', 'sub', 'subrev', 'rsub') and ty.base == 'I':
+            # Integer vector ALU wraps in two's-complement; emit raw unsigned
+            # arithmetic so generated C++ has no signed-overflow UB.
+            u_ty = SemaType('U', ty.size)
+            src0 = _src(0, u_ty)
+            src1 = _src(1, u_ty)
+            lhs, rhs = (src1, src0) if op in ('subrev', 'rsub') else (src0, src1)
+            kind = SemaNodeKind.ADD if op == 'add' else SemaNodeKind.SUB
+            result = SemaNode(kind, ty=u_ty, children=(lhs, rhs))
+            body = _assign(_cast(_dst(0), ty), result)
+            return SemaBlock(sem.name, ExecModel.VECTOR, body)
+
         src0 = _cast(_src(0), ty)
         src1 = _cast(_src(1), ty)
         result = _vec_binop_expr(op, src0, src1, ty)

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
@@ -1179,6 +1179,14 @@ class TestDeriveVectorTernary:
         assert '::rocjitsu::amdgpu::mad_i24_u32' in cpp
         assert 'a * b' not in cpp
 
+    def test_u16_mad_widens_before_multiply(self):
+        sem = _FakeSem('V_MAD_LEGACY_U16', 'vector_ternary', 'mad', 'u16')
+        block = derive_sema_block(sem)
+        cpp = lower_sema_block(block)
+        assert 'static_cast<uint32_t>(static_cast<uint16_t>' in cpp
+        assert 'static_cast<uint16_t>(' in cpp
+        assert 'static_cast<uint16_t>(inst.src0.read_lane(wf, lane)) *' not in cpp
+
     def test_signed_bfe_keeps_braced_one_literal(self):
         sem = _FakeSem('V_BFE_I32', 'vector_ternary', 'bfe_i', 'i32')
         block = derive_sema_block(sem)

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
@@ -1042,6 +1042,42 @@ class TestDeriveVectorBinop:
         all_kinds = {n.kind for n in block.body.walk()}
         assert SemaNodeKind.SUB in all_kinds
 
+    def test_signed_add_sub_use_unsigned_operands_to_avoid_ub(self):
+        ops = [
+            ('add', SemaNodeKind.ADD, ('0', '1')),
+            ('sub', SemaNodeKind.SUB, ('0', '1')),
+            ('subrev', SemaNodeKind.SUB, ('1', '0')),
+            ('rsub', SemaNodeKind.SUB, ('1', '0')),
+        ]
+        dtypes = [
+            ('i16', SemaType('I', 16), SemaType('U', 16), 'int16_t'),
+            ('i32', SemaType.I32, SemaType.U32, 'int32_t'),
+        ]
+        for dtype, signed_ty, unsigned_ty, cpp_type in dtypes:
+            for op, kind, operand_order in ops:
+                sem = _FakeSem(
+                    f'V_{op.upper()}_{dtype.upper()}', 'vector_binop', op, dtype
+                )
+                block = derive_sema_block(sem)
+                assert block is not None
+
+                rhs = block.body.children[1]
+                assert block.body.children[0].cast_target == signed_ty
+                assert rhs.kind == kind
+                assert rhs.ty == unsigned_ty
+                assert [c.ty for c in rhs.children] == [unsigned_ty, unsigned_ty]
+                assert [c.children[1].lit_value for c in rhs.children] == list(
+                    operand_order
+                )
+
+                cpp = lower_sema_block(block)
+                assert (
+                    f'static_cast<{cpp_type}>(inst.src0.read_lane(wf, lane))' not in cpp
+                )
+                assert (
+                    f'static_cast<{cpp_type}>(inst.src1.read_lane(wf, lane))' not in cpp
+                )
+
     def test_lshlrev(self):
         sem = _FakeSem('V_LSHLREV_B32', 'vector_binop', 'lshlrev', 'b32')
         block = derive_sema_block(sem)
@@ -1183,9 +1219,22 @@ class TestDeriveVectorTernary:
         sem = _FakeSem('V_MAD_LEGACY_U16', 'vector_ternary', 'mad', 'u16')
         block = derive_sema_block(sem)
         cpp = lower_sema_block(block)
-        assert 'static_cast<uint32_t>(static_cast<uint16_t>' in cpp
-        assert 'static_cast<uint16_t>(' in cpp
+        assert '::rocjitsu::amdgpu::mad_lo_u16' in cpp
+        assert 'static_cast<uint32_t>(static_cast<uint16_t>(' in cpp
+        assert (
+            'static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>('
+            not in cpp
+        )
         assert 'static_cast<uint16_t>(inst.src0.read_lane(wf, lane)) *' not in cpp
+        assert 'static_cast<uint16_t>(inst.src1.read_lane(wf, lane))' not in cpp
+        assert 'static_cast<uint16_t>(inst.src2.read_lane(wf, lane))' not in cpp
+        compact_cpp = ''.join(cpp.split())
+        assert (
+            '::rocjitsu::amdgpu::mad_lo_u16('
+            'inst.src0.read_lane(wf,lane),'
+            'inst.src1.read_lane(wf,lane),'
+            'inst.src2.read_lane(wf,lane))' in compact_cpp
+        )
 
     def test_signed_bfe_keeps_braced_one_literal(self):
         sem = _FakeSem('V_BFE_I32', 'vector_ternary', 'bfe_i', 'i32')

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.cpp
@@ -297,9 +297,11 @@ void visit_kernel_descriptors(std::span<const uint8_t> image, uint64_t text_offs
       if (!seen_descriptor_offsets.insert(file_off).second)
         continue;
 
-      const auto *desc = reinterpret_cast<const KD *>(image.data() + file_off);
+      KD desc;
+      std::memcpy(&desc, image.data() + file_off, sizeof(desc));
       const int64_t entry_vaddr_signed =
-          static_cast<int64_t>(symtab[j].st_value) + desc->kernel_code_entry_byte_offset;
+          static_cast<int64_t>(symtab[j].st_value) + desc.kernel_code_entry_byte_offset;
+
       if (entry_vaddr_signed < 0)
         continue;
       const uint64_t entry_vaddr = static_cast<uint64_t>(entry_vaddr_signed);
@@ -307,7 +309,7 @@ void visit_kernel_descriptors(std::span<const uint8_t> image, uint64_t text_offs
         continue;
 
       const uint64_t entry_text_offset = entry_vaddr - *text_vaddr;
-      callback(file_off, entry_text_offset, *desc);
+      callback(file_off, entry_text_offset, desc);
     }
   }
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/code_object_patcher.cpp
@@ -589,11 +589,12 @@ bool CodeObjectPatcher::apply_kernel_descriptor_translation(const KdTranslation 
   if (!image_contains_range(image_.size(), translation.descriptor_file_offset, sizeof(KD)))
     return false;
 
-  auto *desc = reinterpret_cast<KD *>(image_.data() + translation.descriptor_file_offset);
+  KD desc;
+  std::memcpy(&desc, image_.data() + translation.descriptor_file_offset, sizeof(desc));
 
-  AMDHSA_BITS_SET(desc->compute_pgm_rsrc1, kd::COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT,
+  AMDHSA_BITS_SET(desc.compute_pgm_rsrc1, kd::COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT,
                   translation.target_vgpr_granulated);
-  AMDHSA_BITS_SET(desc->compute_pgm_rsrc1, kd::COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT,
+  AMDHSA_BITS_SET(desc.compute_pgm_rsrc1, kd::COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT,
                   translation.target_sgpr_granulated);
 
   if (target_uses_gfx90a_accum_offset(target_arch) && translation.target_accvgpr_base != 0) {
@@ -602,34 +603,34 @@ bool CodeObjectPatcher::apply_kernel_descriptor_translation(const KdTranslation 
     // lowering needs ordinary VGPR scratch above the source AccVGPR window, so
     // the patcher must write the recomputed base alongside the VGPR allocation.
     const uint32_t encoded_accum_offset = (translation.target_accvgpr_base / 4) - 1;
-    AMDHSA_BITS_SET(desc->compute_pgm_rsrc3, kd::COMPUTE_PGM_RSRC3_GFX90A_ACCUM_OFFSET,
+    AMDHSA_BITS_SET(desc.compute_pgm_rsrc3, kd::COMPUTE_PGM_RSRC3_GFX90A_ACCUM_OFFSET,
                     encoded_accum_offset);
   }
 
   if (target_uses_gfx10_plus_mode_bits(target_arch)) {
     if (target_clears_rsrc1_mode_bits(target_arch)) {
-      AMDHSA_BITS_SET(desc->compute_pgm_rsrc1, kd::COMPUTE_PGM_RSRC1_ENABLE_DX10_CLAMP, 0);
-      AMDHSA_BITS_SET(desc->compute_pgm_rsrc1, kd::COMPUTE_PGM_RSRC1_ENABLE_IEEE_MODE, 0);
+      AMDHSA_BITS_SET(desc.compute_pgm_rsrc1, kd::COMPUTE_PGM_RSRC1_ENABLE_DX10_CLAMP, 0);
+      AMDHSA_BITS_SET(desc.compute_pgm_rsrc1, kd::COMPUTE_PGM_RSRC1_ENABLE_IEEE_MODE, 0);
     }
     const uint32_t wgp_mode = target_uses_wgp_mode(target_arch) ? 1u : 0u;
-    AMDHSA_BITS_SET(desc->compute_pgm_rsrc1, kd::COMPUTE_PGM_RSRC1_WGP_MODE, wgp_mode);
-    AMDHSA_BITS_SET(desc->compute_pgm_rsrc1, kd::COMPUTE_PGM_RSRC1_MEM_ORDERED, 1);
-    AMDHSA_BITS_SET(desc->compute_pgm_rsrc1, kd::COMPUTE_PGM_RSRC1_FWD_PROGRESS, 1);
+    AMDHSA_BITS_SET(desc.compute_pgm_rsrc1, kd::COMPUTE_PGM_RSRC1_WGP_MODE, wgp_mode);
+    AMDHSA_BITS_SET(desc.compute_pgm_rsrc1, kd::COMPUTE_PGM_RSRC1_MEM_ORDERED, 1);
+    AMDHSA_BITS_SET(desc.compute_pgm_rsrc1, kd::COMPUTE_PGM_RSRC1_FWD_PROGRESS, 1);
   }
 
   if (target_supports_wave32(target_arch)) {
     const uint32_t wave32 = translation.target_wave_size == 32 ? 1u : 0u;
-    AMDHSA_BITS_SET(desc->kernel_code_properties, kd::KERNEL_CODE_PROPERTY_ENABLE_WAVEFRONT_SIZE32,
+    AMDHSA_BITS_SET(desc.kernel_code_properties, kd::KERNEL_CODE_PROPERTY_ENABLE_WAVEFRONT_SIZE32,
                     wave32);
   } else {
-    AMDHSA_BITS_SET(desc->kernel_code_properties, kd::KERNEL_CODE_PROPERTY_ENABLE_WAVEFRONT_SIZE32,
+    AMDHSA_BITS_SET(desc.kernel_code_properties, kd::KERNEL_CODE_PROPERTY_ENABLE_WAVEFRONT_SIZE32,
                     0);
   }
 
   if (target_uses_gfx10_plus_mode_bits(target_arch)) {
-    desc->compute_pgm_rsrc3 = 0;
+    desc.compute_pgm_rsrc3 = 0;
     if (const uint32_t inst_pref = target_default_inst_pref_size(target_arch); inst_pref != 0) {
-      AMDHSA_BITS_SET(desc->compute_pgm_rsrc3, kd::COMPUTE_PGM_RSRC3_GFX10_PLUS_INST_PREF_SIZE,
+      AMDHSA_BITS_SET(desc.compute_pgm_rsrc3, kd::COMPUTE_PGM_RSRC3_GFX10_PLUS_INST_PREF_SIZE,
                       inst_pref);
     }
   } else if (target_uses_gfx90a_accum_offset(target_arch) && translation.target_accvgpr_base != 0) {
@@ -640,18 +641,19 @@ bool CodeObjectPatcher::apply_kernel_descriptor_translation(const KdTranslation 
     assert(translation.target_accvgpr_base >= 4 &&
            "ACCUM_OFFSET base must encode at least 4 VGPRs");
     assert(translation.target_accvgpr_base % 4 == 0 && "ACCUM_OFFSET base must be 4-VGPR aligned");
-    AMDHSA_BITS_SET(desc->compute_pgm_rsrc3, kd::COMPUTE_PGM_RSRC3_GFX90A_ACCUM_OFFSET,
+    AMDHSA_BITS_SET(desc.compute_pgm_rsrc3, kd::COMPUTE_PGM_RSRC3_GFX90A_ACCUM_OFFSET,
                     (translation.target_accvgpr_base / 4 - 1));
   }
 
-  desc->private_segment_fixed_size = translation.target_private_size;
-  desc->group_segment_fixed_size = translation.target_lds_size;
-  AMDHSA_BITS_SET(desc->compute_pgm_rsrc2, kd::COMPUTE_PGM_RSRC2_USER_SGPR_COUNT,
+  desc.private_segment_fixed_size = translation.target_private_size;
+  desc.group_segment_fixed_size = translation.target_lds_size;
+  AMDHSA_BITS_SET(desc.compute_pgm_rsrc2, kd::COMPUTE_PGM_RSRC2_USER_SGPR_COUNT,
                   translation.target_user_sgpr_count);
   const uint32_t enable_private_segment = translation.target_private_size != 0 ? 1u : 0u;
-  AMDHSA_BITS_SET(desc->compute_pgm_rsrc2, kd::COMPUTE_PGM_RSRC2_ENABLE_PRIVATE_SEGMENT,
+  AMDHSA_BITS_SET(desc.compute_pgm_rsrc2, kd::COMPUTE_PGM_RSRC2_ENABLE_PRIVATE_SEGMENT,
                   enable_private_segment);
 
+  std::memcpy(image_.data() + translation.descriptor_file_offset, &desc, sizeof(desc));
   if (!redirect_kernel_entry(translation.descriptor_file_offset, translation.entry_text_offset,
                              translation.target_entry_text_offset))
     return false;
@@ -664,14 +666,16 @@ bool CodeObjectPatcher::redirect_kernel_entry(uint64_t descriptor_file_offset,
   if (!image_contains_range(image_.size(), descriptor_file_offset, sizeof(KD)))
     return false;
 
-  auto *desc = reinterpret_cast<KD *>(image_.data() + descriptor_file_offset);
+  KD desc;
+  std::memcpy(&desc, image_.data() + descriptor_file_offset, sizeof(desc));
   const int64_t delta =
       static_cast<int64_t>(new_entry_text_offset) - static_cast<int64_t>(old_entry_text_offset);
-  const int64_t redirected = static_cast<int64_t>(desc->kernel_code_entry_byte_offset) + delta;
+  const int64_t redirected = static_cast<int64_t>(desc.kernel_code_entry_byte_offset) + delta;
   // The descriptor field is signed because the entry point may be before or
   // after the descriptor in virtual address order. Preserve that signed value
   // when applying the text-relative delta.
-  desc->kernel_code_entry_byte_offset = redirected;
+  desc.kernel_code_entry_byte_offset = redirected;
+  std::memcpy(image_.data() + descriptor_file_offset, &desc, sizeof(desc));
   return true;
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_alu_2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_alu_2.cpp
@@ -413,14 +413,12 @@ void VAddNcI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half =
-          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
-              static_cast<int16_t>((static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                              ? (src0.read_lane(wf, lane) >> 16)
-                                                              : src0.read_lane(wf, lane))) +
-                                    static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                              ? (src1.read_lane(wf, lane) >> 16)
-                                                              : src1.read_lane(wf, lane)))))))));
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
+              (((amdgpu::vop3_opsel(inst_) & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                        : src0.read_lane(wf, lane)) +
+               ((amdgpu::vop3_opsel(inst_) & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                        : src1.read_lane(wf, lane))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }
@@ -519,14 +517,12 @@ void VSubNcI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half =
-          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
-              static_cast<int16_t>((static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                              ? (src0.read_lane(wf, lane) >> 16)
-                                                              : src0.read_lane(wf, lane))) -
-                                    static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                              ? (src1.read_lane(wf, lane) >> 16)
-                                                              : src1.read_lane(wf, lane)))))))));
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
+              (((amdgpu::vop3_opsel(inst_) & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                        : src0.read_lane(wf, lane)) -
+               ((amdgpu::vop3_opsel(inst_) & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                        : src1.read_lane(wf, lane))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_ternary.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_ternary.cpp
@@ -3938,16 +3938,17 @@ void VMadU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(
-          static_cast<uint16_t>(((static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                             ? (src0.read_lane(wf, lane) >> 16)
-                                                             : src0.read_lane(wf, lane))) *
-                                  static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                             ? (src1.read_lane(wf, lane) >> 16)
-                                                             : src1.read_lane(wf, lane)))) +
-                                 static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x4u) != 0
-                                                            ? (src2.read_lane(wf, lane) >> 16)
-                                                            : src2.read_lane(wf, lane))))))));
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(
+          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
+              static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
+                                                               ? (src0.read_lane(wf, lane) >> 16)
+                                                               : src0.read_lane(wf, lane)))) *
+                  static_cast<uint32_t>(static_cast<uint16_t>(
+                      ((amdgpu::vop3_opsel(inst_) & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                               : src1.read_lane(wf, lane)))) +
+              static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x4u) != 0
+                                                               ? (src2.read_lane(wf, lane) >> 16)
+                                                               : src2.read_lane(wf, lane))))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_ternary.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_ternary.cpp
@@ -3939,16 +3939,13 @@ void VMadU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     {
       uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(
-          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
-              static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                               ? (src0.read_lane(wf, lane) >> 16)
-                                                               : src0.read_lane(wf, lane)))) *
-                  static_cast<uint32_t>(static_cast<uint16_t>(
-                      ((amdgpu::vop3_opsel(inst_) & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
-                                                               : src1.read_lane(wf, lane)))) +
-              static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x4u) != 0
-                                                               ? (src2.read_lane(wf, lane) >> 16)
-                                                               : src2.read_lane(wf, lane))))))))));
+          static_cast<uint32_t>(static_cast<uint16_t>(::rocjitsu::amdgpu::mad_lo_u16(
+              ((amdgpu::vop3_opsel(inst_) & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                       : src0.read_lane(wf, lane)),
+              ((amdgpu::vop3_opsel(inst_) & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                       : src1.read_lane(wf, lane)),
+              ((amdgpu::vop3_opsel(inst_) & 0x4u) != 0 ? (src2.read_lane(wf, lane) >> 16)
+                                                       : src2.read_lane(wf, lane)))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/vop3.cpp
@@ -16127,14 +16127,12 @@ void VAddNcI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half =
-          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
-              static_cast<int16_t>((static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                              ? (src0.read_lane(wf, lane) >> 16)
-                                                              : src0.read_lane(wf, lane))) +
-                                    static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                              ? (src1.read_lane(wf, lane) >> 16)
-                                                              : src1.read_lane(wf, lane)))))))));
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
+              (((amdgpu::vop3_opsel(inst_) & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                        : src0.read_lane(wf, lane)) +
+               ((amdgpu::vop3_opsel(inst_) & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                        : src1.read_lane(wf, lane))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }
@@ -16216,14 +16214,12 @@ void VSubNcI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half =
-          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
-              static_cast<int16_t>((static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                              ? (src0.read_lane(wf, lane) >> 16)
-                                                              : src0.read_lane(wf, lane))) -
-                                    static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                              ? (src1.read_lane(wf, lane) >> 16)
-                                                              : src1.read_lane(wf, lane)))))))));
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
+              (((amdgpu::vop3_opsel(inst_) & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                        : src0.read_lane(wf, lane)) -
+               ((amdgpu::vop3_opsel(inst_) & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                        : src1.read_lane(wf, lane))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/vop3.cpp
@@ -11820,16 +11820,13 @@ void VMadU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     {
       uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(
-          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
-              static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                               ? (src0.read_lane(wf, lane) >> 16)
-                                                               : src0.read_lane(wf, lane)))) *
-                  static_cast<uint32_t>(static_cast<uint16_t>(
-                      ((amdgpu::vop3_opsel(inst_) & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
-                                                               : src1.read_lane(wf, lane)))) +
-              static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x4u) != 0
-                                                               ? (src2.read_lane(wf, lane) >> 16)
-                                                               : src2.read_lane(wf, lane))))))))));
+          static_cast<uint32_t>(static_cast<uint16_t>(::rocjitsu::amdgpu::mad_lo_u16(
+              ((amdgpu::vop3_opsel(inst_) & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                       : src0.read_lane(wf, lane)),
+              ((amdgpu::vop3_opsel(inst_) & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                       : src1.read_lane(wf, lane)),
+              ((amdgpu::vop3_opsel(inst_) & 0x4u) != 0 ? (src2.read_lane(wf, lane) >> 16)
+                                                       : src2.read_lane(wf, lane)))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/vop3.cpp
@@ -11819,16 +11819,17 @@ void VMadU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(
-          static_cast<uint16_t>(((static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                             ? (src0.read_lane(wf, lane) >> 16)
-                                                             : src0.read_lane(wf, lane))) *
-                                  static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                             ? (src1.read_lane(wf, lane) >> 16)
-                                                             : src1.read_lane(wf, lane)))) +
-                                 static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x4u) != 0
-                                                            ? (src2.read_lane(wf, lane) >> 16)
-                                                            : src2.read_lane(wf, lane))))))));
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(
+          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
+              static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
+                                                               ? (src0.read_lane(wf, lane) >> 16)
+                                                               : src0.read_lane(wf, lane)))) *
+                  static_cast<uint32_t>(static_cast<uint16_t>(
+                      ((amdgpu::vop3_opsel(inst_) & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                               : src1.read_lane(wf, lane)))) +
+              static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x4u) != 0
+                                                               ? (src2.read_lane(wf, lane) >> 16)
+                                                               : src2.read_lane(wf, lane))))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/vop3.cpp
@@ -16127,14 +16127,12 @@ void VAddNcI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half =
-          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
-              static_cast<int16_t>((static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                              ? (src0.read_lane(wf, lane) >> 16)
-                                                              : src0.read_lane(wf, lane))) +
-                                    static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                              ? (src1.read_lane(wf, lane) >> 16)
-                                                              : src1.read_lane(wf, lane)))))))));
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
+              (((amdgpu::vop3_opsel(inst_) & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                        : src0.read_lane(wf, lane)) +
+               ((amdgpu::vop3_opsel(inst_) & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                        : src1.read_lane(wf, lane))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }
@@ -16216,14 +16214,12 @@ void VSubNcI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half =
-          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
-              static_cast<int16_t>((static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                              ? (src0.read_lane(wf, lane) >> 16)
-                                                              : src0.read_lane(wf, lane))) -
-                                    static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                              ? (src1.read_lane(wf, lane) >> 16)
-                                                              : src1.read_lane(wf, lane)))))))));
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
+              (((amdgpu::vop3_opsel(inst_) & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                        : src0.read_lane(wf, lane)) -
+               ((amdgpu::vop3_opsel(inst_) & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                        : src1.read_lane(wf, lane))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/vop3.cpp
@@ -11820,16 +11820,13 @@ void VMadU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     {
       uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(
-          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
-              static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                               ? (src0.read_lane(wf, lane) >> 16)
-                                                               : src0.read_lane(wf, lane)))) *
-                  static_cast<uint32_t>(static_cast<uint16_t>(
-                      ((amdgpu::vop3_opsel(inst_) & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
-                                                               : src1.read_lane(wf, lane)))) +
-              static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x4u) != 0
-                                                               ? (src2.read_lane(wf, lane) >> 16)
-                                                               : src2.read_lane(wf, lane))))))))));
+          static_cast<uint32_t>(static_cast<uint16_t>(::rocjitsu::amdgpu::mad_lo_u16(
+              ((amdgpu::vop3_opsel(inst_) & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                       : src0.read_lane(wf, lane)),
+              ((amdgpu::vop3_opsel(inst_) & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                       : src1.read_lane(wf, lane)),
+              ((amdgpu::vop3_opsel(inst_) & 0x4u) != 0 ? (src2.read_lane(wf, lane) >> 16)
+                                                       : src2.read_lane(wf, lane)))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/vop3.cpp
@@ -11819,16 +11819,17 @@ void VMadU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(
-          static_cast<uint16_t>(((static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                             ? (src0.read_lane(wf, lane) >> 16)
-                                                             : src0.read_lane(wf, lane))) *
-                                  static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                             ? (src1.read_lane(wf, lane) >> 16)
-                                                             : src1.read_lane(wf, lane)))) +
-                                 static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x4u) != 0
-                                                            ? (src2.read_lane(wf, lane) >> 16)
-                                                            : src2.read_lane(wf, lane))))))));
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(
+          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
+              static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
+                                                               ? (src0.read_lane(wf, lane) >> 16)
+                                                               : src0.read_lane(wf, lane)))) *
+                  static_cast<uint32_t>(static_cast<uint16_t>(
+                      ((amdgpu::vop3_opsel(inst_) & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                               : src1.read_lane(wf, lane)))) +
+              static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x4u) != 0
+                                                               ? (src2.read_lane(wf, lane) >> 16)
+                                                               : src2.read_lane(wf, lane))))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/vop3.cpp
@@ -13257,16 +13257,17 @@ void VMadU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(
-          static_cast<uint16_t>(((static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                             ? (src0.read_lane(wf, lane) >> 16)
-                                                             : src0.read_lane(wf, lane))) *
-                                  static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                             ? (src1.read_lane(wf, lane) >> 16)
-                                                             : src1.read_lane(wf, lane)))) +
-                                 static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x4u) != 0
-                                                            ? (src2.read_lane(wf, lane) >> 16)
-                                                            : src2.read_lane(wf, lane))))))));
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(
+          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
+              static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
+                                                               ? (src0.read_lane(wf, lane) >> 16)
+                                                               : src0.read_lane(wf, lane)))) *
+                  static_cast<uint32_t>(static_cast<uint16_t>(
+                      ((amdgpu::vop3_opsel(inst_) & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                               : src1.read_lane(wf, lane)))) +
+              static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x4u) != 0
+                                                               ? (src2.read_lane(wf, lane) >> 16)
+                                                               : src2.read_lane(wf, lane))))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/vop3.cpp
@@ -13258,16 +13258,13 @@ void VMadU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     {
       uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(
-          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
-              static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                               ? (src0.read_lane(wf, lane) >> 16)
-                                                               : src0.read_lane(wf, lane)))) *
-                  static_cast<uint32_t>(static_cast<uint16_t>(
-                      ((amdgpu::vop3_opsel(inst_) & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
-                                                               : src1.read_lane(wf, lane)))) +
-              static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x4u) != 0
-                                                               ? (src2.read_lane(wf, lane) >> 16)
-                                                               : src2.read_lane(wf, lane))))))))));
+          static_cast<uint32_t>(static_cast<uint16_t>(::rocjitsu::amdgpu::mad_lo_u16(
+              ((amdgpu::vop3_opsel(inst_) & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                       : src0.read_lane(wf, lane)),
+              ((amdgpu::vop3_opsel(inst_) & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                       : src1.read_lane(wf, lane)),
+              ((amdgpu::vop3_opsel(inst_) & 0x4u) != 0 ? (src2.read_lane(wf, lane) >> 16)
+                                                       : src2.read_lane(wf, lane)))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/vop3.cpp
@@ -18367,14 +18367,12 @@ void VAddNcI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half =
-          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
-              static_cast<int16_t>((static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                              ? (src0.read_lane(wf, lane) >> 16)
-                                                              : src0.read_lane(wf, lane))) +
-                                    static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                              ? (src1.read_lane(wf, lane) >> 16)
-                                                              : src1.read_lane(wf, lane)))))))));
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
+              (((amdgpu::vop3_opsel(inst_) & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                        : src0.read_lane(wf, lane)) +
+               ((amdgpu::vop3_opsel(inst_) & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                        : src1.read_lane(wf, lane))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }
@@ -18456,14 +18454,12 @@ void VSubNcI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half =
-          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
-              static_cast<int16_t>((static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                              ? (src0.read_lane(wf, lane) >> 16)
-                                                              : src0.read_lane(wf, lane))) -
-                                    static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                              ? (src1.read_lane(wf, lane) >> 16)
-                                                              : src1.read_lane(wf, lane)))))))));
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
+              (((amdgpu::vop3_opsel(inst_) & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                        : src0.read_lane(wf, lane)) -
+               ((amdgpu::vop3_opsel(inst_) & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                        : src1.read_lane(wf, lane))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -13155,11 +13155,12 @@ inline void execute_v_mad_legacy_u16_vop3([[maybe_unused]] Inst &inst,
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane,
-                         static_cast<uint32_t>(static_cast<uint16_t>(
-                             ((static_cast<uint16_t>(inst.src0.read_lane(wf, lane)) *
-                               static_cast<uint16_t>(inst.src1.read_lane(wf, lane))) +
-                              static_cast<uint16_t>(inst.src2.read_lane(wf, lane))))));
+    inst.vdst.write_lane(
+        wf, lane,
+        static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
+            static_cast<uint32_t>(static_cast<uint16_t>(inst.src0.read_lane(wf, lane))) *
+                static_cast<uint32_t>(static_cast<uint16_t>(inst.src1.read_lane(wf, lane))) +
+            static_cast<uint32_t>(static_cast<uint16_t>(inst.src2.read_lane(wf, lane))))))));
   }
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -2951,8 +2951,7 @@ inline void execute_v_add_i16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]]
       continue;
     inst.vdst.write_lane(wf, lane,
                          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
-                             (static_cast<int16_t>(inst.src0.read_lane(wf, lane)) +
-                              static_cast<int16_t>(inst.src1.read_lane(wf, lane)))))));
+                             (inst.src0.read_lane(wf, lane) + inst.src1.read_lane(wf, lane))))));
   }
 }
 
@@ -2963,9 +2962,7 @@ inline void execute_v_add_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]]
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane,
-                         (static_cast<int32_t>(inst.src0.read_lane(wf, lane)) +
-                          static_cast<int32_t>(inst.src1.read_lane(wf, lane))));
+    inst.vdst.write_lane(wf, lane, (inst.src0.read_lane(wf, lane) + inst.src1.read_lane(wf, lane)));
   }
 }
 
@@ -2993,8 +2990,7 @@ inline void execute_v_add_nc_i16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
       continue;
     inst.vdst.write_lane(wf, lane,
                          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
-                             (static_cast<int16_t>(inst.src0.read_lane(wf, lane)) +
-                              static_cast<int16_t>(inst.src1.read_lane(wf, lane)))))));
+                             (inst.src0.read_lane(wf, lane) + inst.src1.read_lane(wf, lane))))));
   }
 }
 
@@ -3005,9 +3001,7 @@ inline void execute_v_add_nc_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane,
-                         (static_cast<int32_t>(inst.src0.read_lane(wf, lane)) +
-                          static_cast<int32_t>(inst.src1.read_lane(wf, lane))));
+    inst.vdst.write_lane(wf, lane, (inst.src0.read_lane(wf, lane) + inst.src1.read_lane(wf, lane)));
   }
 }
 
@@ -18341,8 +18335,7 @@ inline void execute_v_sub_i16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]]
       continue;
     inst.vdst.write_lane(wf, lane,
                          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
-                             (static_cast<int16_t>(inst.src0.read_lane(wf, lane)) -
-                              static_cast<int16_t>(inst.src1.read_lane(wf, lane)))))));
+                             (inst.src0.read_lane(wf, lane) - inst.src1.read_lane(wf, lane))))));
   }
 }
 
@@ -18353,9 +18346,7 @@ inline void execute_v_sub_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]]
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane,
-                         (static_cast<int32_t>(inst.src0.read_lane(wf, lane)) -
-                          static_cast<int32_t>(inst.src1.read_lane(wf, lane))));
+    inst.vdst.write_lane(wf, lane, (inst.src0.read_lane(wf, lane) - inst.src1.read_lane(wf, lane)));
   }
 }
 
@@ -18367,8 +18358,7 @@ inline void execute_v_sub_nc_i16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
       continue;
     inst.vdst.write_lane(wf, lane,
                          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
-                             (static_cast<int16_t>(inst.src0.read_lane(wf, lane)) -
-                              static_cast<int16_t>(inst.src1.read_lane(wf, lane)))))));
+                             (inst.src0.read_lane(wf, lane) - inst.src1.read_lane(wf, lane))))));
   }
 }
 
@@ -18379,9 +18369,7 @@ inline void execute_v_sub_nc_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane,
-                         (static_cast<int32_t>(inst.src0.read_lane(wf, lane)) -
-                          static_cast<int32_t>(inst.src1.read_lane(wf, lane))));
+    inst.vdst.write_lane(wf, lane, (inst.src0.read_lane(wf, lane) - inst.src1.read_lane(wf, lane)));
   }
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -13155,12 +13155,10 @@ inline void execute_v_mad_legacy_u16_vop3([[maybe_unused]] Inst &inst,
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(
-        wf, lane,
-        static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
-            static_cast<uint32_t>(static_cast<uint16_t>(inst.src0.read_lane(wf, lane))) *
-                static_cast<uint32_t>(static_cast<uint16_t>(inst.src1.read_lane(wf, lane))) +
-            static_cast<uint32_t>(static_cast<uint16_t>(inst.src2.read_lane(wf, lane))))))));
+    inst.vdst.write_lane(wf, lane,
+                         static_cast<uint32_t>(static_cast<uint16_t>(::rocjitsu::amdgpu::mad_lo_u16(
+                             inst.src0.read_lane(wf, lane), inst.src1.read_lane(wf, lane),
+                             inst.src2.read_lane(wf, lane)))));
   }
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
@@ -70,6 +70,13 @@ inline uint32_t mad_i24_u32(uint32_t lhs, uint32_t rhs, uint32_t addend) {
   return mul_i24_u32(lhs, rhs) + addend;
 }
 
+inline uint32_t mad_lo_u16(uint32_t lhs, uint32_t rhs, uint32_t addend) {
+  const uint32_t a = lhs & 0xffffu;
+  const uint32_t b = rhs & 0xffffu;
+  const uint32_t c = addend & 0xffffu;
+  return (a * b + c) & 0xffffu;
+}
+
 /// Return whether signed integer add/sub overflows. The unsigned parameter type
 /// is deduced, so the same helper serves 32- and 64-bit scalar add/sub.
 template <typename U> inline bool signed_add_overflows(U a, U b) {

--- a/emulation/rocjitsu/tests/corpus/gfx1100_skip_tests.json
+++ b/emulation/rocjitsu/tests/corpus/gfx1100_skip_tests.json
@@ -1,5 +1,7 @@
 {
-  "iree": [],
+  "iree": [
+    "iree.gfx1100.e2e.pack_i8.static_pack_vnni_lhs_large"
+  ],
   "cts": [
     "cts.gfx1100.fpsan.fpsan_wmma_gfx11_w64_test",
     "cts.gfx1100.fpsan.fpsan_xlane_w64_test",

--- a/emulation/rocjitsu/tests/corpus/gfx1201_skip_tests.json
+++ b/emulation/rocjitsu/tests/corpus/gfx1201_skip_tests.json
@@ -1,5 +1,7 @@
 {
-  "iree": [],
+  "iree": [
+    "iree.gfx1201.e2e.pack_i8.static_pack_vnni_lhs_large"
+  ],
   "cts": [
     "cts.gfx1201.fpsan.fpsan_atomic_test",
     "cts.gfx1201.fpsan.fpsan_classify_test",

--- a/emulation/rocjitsu/tests/corpus/gfx1250_skip_tests.json
+++ b/emulation/rocjitsu/tests/corpus/gfx1250_skip_tests.json
@@ -20,6 +20,7 @@
     "iree.gfx1250.e2e.map_store.copy_like",
     "iree.gfx1250.e2e.map_store.expand_shape_shape_like",
     "iree.gfx1250.e2e.map_store.extract_slice_like",
+    "iree.gfx1250.e2e.pack_i8.static_pack_vnni_lhs_large",
     "iree.gfx1250.e2e.scatter.scatter_2d_batch",
     "iree.gfx1250.e2e.scatter.scatter_2d_multiple",
     "iree.gfx1250.e2e.scatter.scatter_2d_offset",

--- a/emulation/rocjitsu/tests/corpus/gfx942_skip_tests.json
+++ b/emulation/rocjitsu/tests/corpus/gfx942_skip_tests.json
@@ -1,5 +1,7 @@
 {
-  "iree": [],
+  "iree": [
+    "iree.gfx942.e2e.pack_i8.static_pack_vnni_lhs_large"
+  ],
   "cts": [
     "cts.gfx942.fpsan.fpsan_smfmac_cdna3_test",
     "cts.gfx942.fpsan.fpsan_atomic_test",

--- a/emulation/rocjitsu/tests/corpus/gfx950_skip_tests.json
+++ b/emulation/rocjitsu/tests/corpus/gfx950_skip_tests.json
@@ -1,5 +1,7 @@
 {
-  "iree": [],
+  "iree": [
+    "iree.gfx950.e2e.pack_i8.static_pack_vnni_lhs_large"
+  ],
   "cts": [
     "cts.gfx950.fpsan.fpsan_mfma_gfx950_test",
     "cts.gfx950.fpsan.fpsan_cvt_gfx950_test",

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -155,6 +155,16 @@ int64_t read_kernel_descriptor_entry_offset(const void *descriptor) {
   return entry_offset;
 }
 
+TestKernelDescriptor read_kernel_descriptor_for_test(const void *descriptor) {
+  TestKernelDescriptor kd{};
+  std::memcpy(&kd, descriptor, sizeof(kd));
+  return kd;
+}
+
+void write_kernel_descriptor_for_test(void *descriptor, const TestKernelDescriptor &kd) {
+  std::memcpy(descriptor, &kd, sizeof(kd));
+}
+
 std::vector<uint8_t> make_kernel_descriptor_bytes(int64_t entry_offset) {
   std::vector<uint8_t> descriptor(kKernelDescriptorSize, 0);
   write_kernel_descriptor_entry_offset(descriptor.data(), entry_offset);
@@ -1189,9 +1199,9 @@ TEST(CodeObjectPatcher, AppliesArchSpecificWgpModeBit) {
       return std::nullopt;
 
     const auto patched_image = patcher.emit();
-    const auto *kd = reinterpret_cast<const kernel_descriptor_t *>(
-        patched_image.data() + translation.descriptor_file_offset);
-    return kd->compute_pgm_rsrc1;
+    const auto kd =
+        read_kernel_descriptor_for_test(patched_image.data() + translation.descriptor_file_offset);
+    return kd.compute_pgm_rsrc1;
   };
 
   const auto cdna3_rsrc1 = patched_rsrc1(ROCJITSU_CODE_ARCH_CDNA3);
@@ -1411,9 +1421,9 @@ TEST(BinaryTranslator, SynthesizesKernargPreloadEntrySkipWindow) {
   ASSERT_NE(source_rodata, nullptr);
   ASSERT_GE(source_rodata->size(), sizeof(rocr::llvm::amdhsa::kernel_descriptor_t));
 
-  auto *source_kd = reinterpret_cast<rocr::llvm::amdhsa::kernel_descriptor_t *>(
-      image.data() + source_rodata->sectionOffset());
-  AMDHSA_BITS_SET(source_kd->kernarg_preload, rocr::llvm::amdhsa::KERNARG_PRELOAD_SPEC_LENGTH, 1);
+  auto source_kd = read_kernel_descriptor_for_test(image.data() + source_rodata->sectionOffset());
+  AMDHSA_BITS_SET(source_kd.kernarg_preload, rocr::llvm::amdhsa::KERNARG_PRELOAD_SPEC_LENGTH, 1);
+  write_kernel_descriptor_for_test(image.data() + source_rodata->sectionOffset(), source_kd);
 
   const auto *source_text = source_layout.text_sections()[0];
   auto *source_words = reinterpret_cast<uint32_t *>(image.data() + source_text->sectionOffset());
@@ -1453,9 +1463,9 @@ TEST(BinaryTranslator, SynthesizesKernargPreloadEntrySkipWindow) {
   const auto *target_rodata = find_section(translated, ".rodata");
   ASSERT_NE(target_rodata, nullptr);
   ASSERT_GE(target_rodata->size(), sizeof(rocr::llvm::amdhsa::kernel_descriptor_t));
-  const auto *target_kd = reinterpret_cast<const rocr::llvm::amdhsa::kernel_descriptor_t *>(
-      translated.image_data() + target_rodata->sectionOffset());
-  EXPECT_EQ(target_kd->kernel_code_entry_byte_offset, source_kd->kernel_code_entry_byte_offset)
+  const auto target_kd =
+      read_kernel_descriptor_for_test(translated.image_data() + target_rodata->sectionOffset());
+  EXPECT_EQ(target_kd.kernel_code_entry_byte_offset, source_kd.kernel_code_entry_byte_offset)
       << "the descriptor is redirected to the synthesized compatibility entry; compatible "
          "firmware still reaches the synthesized +256 entry by adding the ABI skip";
 }
@@ -1485,12 +1495,12 @@ TEST(BinaryTranslator, SynthesizesKernargPreloadEntrySkipWindowWithDescriptorPro
   ASSERT_NE(source_rodata, nullptr);
   ASSERT_GE(source_rodata->size(), sizeof(rocr::llvm::amdhsa::kernel_descriptor_t));
 
-  auto *source_kd = reinterpret_cast<rocr::llvm::amdhsa::kernel_descriptor_t *>(
-      image.data() + source_rodata->sectionOffset());
-  AMDHSA_BITS_SET(source_kd->kernarg_preload, rocr::llvm::amdhsa::KERNARG_PRELOAD_SPEC_LENGTH, 1);
-  source_kd->kernel_code_entry_byte_offset =
+  auto source_kd = read_kernel_descriptor_for_test(image.data() + source_rodata->sectionOffset());
+  AMDHSA_BITS_SET(source_kd.kernarg_preload, rocr::llvm::amdhsa::KERNARG_PRELOAD_SPEC_LENGTH, 1);
+  source_kd.kernel_code_entry_byte_offset =
       static_cast<int64_t>(source_text->vaddr() + kSourceEntryBytes) -
       static_cast<int64_t>(source_rodata->vaddr());
+  write_kernel_descriptor_for_test(image.data() + source_rodata->sectionOffset(), source_kd);
 
   AmdGpuCodeObject co(image.data(), image.size());
   ASSERT_TRUE(co.is_valid());
@@ -1531,15 +1541,15 @@ TEST(BinaryTranslator, SynthesizesKernargPreloadEntrySkipWindowWithDescriptorPro
   const auto *target_rodata = find_section(translated, ".rodata");
   ASSERT_NE(target_rodata, nullptr);
   ASSERT_GE(target_rodata->size(), sizeof(rocr::llvm::amdhsa::kernel_descriptor_t));
-  const auto *target_kd = reinterpret_cast<const rocr::llvm::amdhsa::kernel_descriptor_t *>(
-      translated.image_data() + target_rodata->sectionOffset());
+  const auto target_kd =
+      read_kernel_descriptor_for_test(translated.image_data() + target_rodata->sectionOffset());
   const int64_t target_entry_text_offset = static_cast<int64_t>(target_rodata->vaddr()) +
-                                           target_kd->kernel_code_entry_byte_offset -
+                                           target_kd.kernel_code_entry_byte_offset -
                                            static_cast<int64_t>(text->vaddr());
   EXPECT_EQ(target_entry_text_offset, 0)
       << "the descriptor must be redirected from the moved source entry to the synthesized "
          "compatibility launch stub";
-  EXPECT_NE(target_kd->kernel_code_entry_byte_offset, source_kd->kernel_code_entry_byte_offset)
+  EXPECT_NE(target_kd.kernel_code_entry_byte_offset, source_kd.kernel_code_entry_byte_offset)
       << "the source descriptor entry is deliberately nonzero, so this assertion proves the "
          "descriptor was repointed rather than passing because both entries were zero";
 }
@@ -2492,9 +2502,11 @@ TEST(BinaryTranslatorE2E, RelocatedKernelCompactsReachableBlocksAfterEntry) {
   const auto *source_rodata = rocjitsu::find_section(source_layout, ".rodata");
   ASSERT_NE(source_rodata, nullptr);
   ASSERT_GE(source_rodata->size(), sizeof(rocr::llvm::amdhsa::kernel_descriptor_t));
-  auto *source_kd = reinterpret_cast<rocr::llvm::amdhsa::kernel_descriptor_t *>(
-      image.data() + source_rodata->sectionOffset());
-  AMDHSA_BITS_SET(source_kd->kernarg_preload, rocr::llvm::amdhsa::KERNARG_PRELOAD_SPEC_LENGTH, 1);
+  auto source_kd =
+      rocjitsu::read_kernel_descriptor_for_test(image.data() + source_rodata->sectionOffset());
+  AMDHSA_BITS_SET(source_kd.kernarg_preload, rocr::llvm::amdhsa::KERNARG_PRELOAD_SPEC_LENGTH, 1);
+  rocjitsu::write_kernel_descriptor_for_test(image.data() + source_rodata->sectionOffset(),
+                                             source_kd);
 
   rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
   ASSERT_TRUE(source.is_valid());

--- a/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
+++ b/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
@@ -70,6 +70,7 @@ protected:
     auto root = loaded_.take_root();
     auto *soc = dynamic_cast<rocjitsu::SoC *>(root.get());
     ASSERT_NE(soc, nullptr);
+    soc_ = soc;
     auto num_xcds = soc->num_xcds();
 
     loaded_.engine_config.max_ticks = 0;
@@ -98,6 +99,7 @@ protected:
 
   rocjitsu::config::LoadedConfig loaded_;
   std::unique_ptr<simdojo::SimulationEngine> engine_;
+  rocjitsu::SoC *soc_ = nullptr;
   rocjitsu::SimulatedDriver *driver_ = nullptr;
 };
 
@@ -190,7 +192,8 @@ TEST_F(KfdIoctlTest, GetTileConfigRejectsUnknownGpuId) {
 }
 
 TEST_F(KfdIoctlTest, GetTileConfigReturnsUnsupportedInDaemonMode) {
-  rocjitsu::SimulatedDriver daemon_driver(*loaded_.soc(), true);
+  ASSERT_NE(soc_, nullptr);
+  rocjitsu::SimulatedDriver daemon_driver(*soc_, true);
   uint32_t process_id = daemon_driver.open_process();
   ASSERT_NE(process_id, 0u);
 


### PR DESCRIPTION
## Motivation

Using ubsan with `-fno-sanitize-recover=all` revealed additional undefined behaviour. 

## Technical Details

Overflows in the autogenerated code and unaligned accesses on DBI/DBT code.

## JIRA ID

https://github.com/ROCm/rocm-systems/issues/7891

## Test Plan

Test on CI, add `-fno-sanitize-recover=all` to CI.

## Test Result

Test passes.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
