### PR TITLE
fix(rocprofiler-sdk): fail cleanly when a PMC counter set exceeds hardware per-pass capacity

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -1429,9 +1429,22 @@ construct_counter_collection_profile(rocprofiler_agent_id_t       agent_id,
     if(!counters_v.empty())
     {
         auto profile_v = rocprofiler_counter_config_id_t{};
-        ROCPROFILER_CALL(rocprofiler_create_counter_config(
-                             agent_id, counters_v.data(), counters_v.size(), &profile_v),
-                         "Could not construct profile cfg");
+        auto status    = rocprofiler_create_counter_config(
+            agent_id, counters_v.data(), counters_v.size(), &profile_v);
+        if(status != ROCPROFILER_STATUS_SUCCESS)
+        {
+            // Unrecoverable config error (e.g. a pass exceeds the hardware counter
+            // capacity). Built up front (get_agent_profiles), so exit cleanly here
+            // instead of ROCP_FATAL-aborting inside the dispatch callback.
+            auto requested_counters =
+                fmt::format("{}", fmt::join(counters.begin(), counters.end(), ", "));
+            ROCP_ERROR << "Could not construct counter profile for agent " << agent_v->node_id
+                       << " (gpu-" << agent_v->gpu_index << ", " << agent_v->name << ") with ["
+                       << requested_counters << "]: " << rocprofiler_get_status_string(status)
+                       << ". This counter pass/group requests more counters than the hardware "
+                          "can collect in a single pass; reduce the number of counters in it.";
+            std::exit(EXIT_FAILURE);
+        }
         profile = profile_v;
     }
     return profile;
@@ -1459,11 +1472,20 @@ generate_agent_profiles()
     return agent_profiles{std::move(pos), tool::get_config().counter_groups_interval, profiles};
 }
 
-// this function creates a rocprofiler profile config on the first entry
+// Builds (once) and caches the per-agent counter profiles so tool_init can build
+// them up front (before any dispatch) and the dispatch callback reuses them.
+agent_profiles&
+get_agent_profiles()
+{
+    static agent_profiles profiles = generate_agent_profiles();
+    return profiles;
+}
+
+// returns the profile config to use for the current dispatch on this agent
 std::optional<rocprofiler_counter_config_id_t>
 get_device_counting_service(rocprofiler_agent_id_t agent_id)
 {
-    static auto agent_profiles = generate_agent_profiles();
+    auto& agent_profiles = get_agent_profiles();
 
     auto agent_iter = agent_profiles.current_iter.find(agent_id);
     if(agent_iter == agent_profiles.current_iter.end())
@@ -2869,6 +2891,10 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* tool_data)
                                                                      callbacks.counter_record,
                                                                      nullptr),
             "Could not setup counting service");
+
+        // Build counter profiles up front so an invalid/over-capacity config fails
+        // cleanly here instead of aborting mid-dispatch.
+        (void) get_agent_profiles();
 
         if(!defer_counter_start) start_context(counter_collection_ctx, "counter collection");
     }


### PR DESCRIPTION
## Motivation

When a PMC counter pass/group requests more counters than the hardware can collect in a single pass, `rocprofv3` aborted with `SIGABRT` from inside the first kernel-dispatch callback — after the target application was already running — orphaning the application and hanging the run (and able to wedge the GPU). This turns a common user mistake (too many counters in one pass) into a fatal, confusing hang instead of a clear error. The goal is to fail fast with an actionable message and a clean non-zero exit.

## Technical Details

`rocprofiler_create_counter_config` already returns `ROCPROFILER_STATUS_ERROR_EXCEEDS_HW_LIMIT` for an over-capacity counter set, but the tool built the per-agent counter profiles lazily on the first dispatch (`get_device_counting_service`) and routed the failure through `ROCP_FATAL` → `abort()`. This change builds the profiles eagerly during `tool_init` (before `start_context`, i.e. before any kernel dispatches) via a single cached accessor (`get_agent_profiles`), and on an unrecoverable counter-config error logs the agent, the requested counters, and the status, then exits non-zero instead of aborting. Only the dispatch counter-collection path (`--pmc` and `pmc_groups`/multiplex) is affected; the existing graceful "drop unresolved counters" behavior is unchanged. Confined to `source/lib/rocprofiler-sdk-tool/tool.cpp` (+41/-5).

## JIRA ID

N/A

## Test Plan

Built with `-Werror` and swapped the patched tool library into an installed ROCm on a gfx942 (MI300) node. Ran (1) an over-capacity set of 12 SQ-block counters both as `--pmc` and as a single `pmc_group`, (2) a normal fits-one-pass `--pmc` run, and (3) the full `rocprofv3` multiplex counter-collection ctest suite back-to-back.

## Test Result

Over-capacity `--pmc` and `pmc_groups` now exit non-zero in under a second with a clear "reduce the number of counters" message, no `SIGABRT`, no orphaned application, and no GPU hang (previously aborted and hung). Normal collection is unchanged (exit 0, counters collected). The multiplex counter-collection suite passed 57/57 back-to-back, including the invalid/empty-group graceful-degradation case. clang-format-clean; no new linter errors.

## Submission Checklist

- [V] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.