### PR TITLE
fix(rocprofiler-sdk): re-enable Peak Tops Limiter after counter collection

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/controller.cpp
@@ -151,19 +151,7 @@ CounterController::configure_dispatch(rocprofiler_context_id_t                  
 
     if(!ctx.dispatch_counter_collection)
     {
-        // Disable PTL for all GPUs for dispatch counter collection
-        for(const auto& agent : agent::get_agents())
-        {
-            if(agent->type == ROCPROFILER_AGENT_TYPE_GPU)
-            {
-                if(counters::ptl_control_supported())
-                {
-                    counters::counter_collection_ptl_disable(
-                        rocprofiler::agent::get_agent(agent->id));
-                }
-            }
-        }
-
+        // PTL is toggled symmetrically in counters::start_context/stop_context.
         ctx.dispatch_counter_collection =
             std::make_unique<rocprofiler::context::dispatch_counter_collection_service>();
     }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/core.cpp
@@ -25,15 +25,18 @@
 #include "lib/common/container/small_vector.hpp"
 #include "lib/common/synchronized.hpp"
 #include "lib/common/utility.hpp"
+#include "lib/rocprofiler-sdk/agent.hpp"
 #include "lib/rocprofiler-sdk/aql/packet_construct.hpp"
 #include "lib/rocprofiler-sdk/context/context.hpp"
 #include "lib/rocprofiler-sdk/counters/dispatch_handlers.hpp"
+#include "lib/rocprofiler-sdk/counters/ioctl.hpp"
 #include "lib/rocprofiler-sdk/counters/sample_processing.hpp"
 #include "lib/rocprofiler-sdk/hsa/queue.hpp"
 #include "lib/rocprofiler-sdk/hsa/queue_controller.hpp"
 #include "lib/rocprofiler-sdk/kernel_dispatch/profiling_time.hpp"
 #include "lib/rocprofiler-sdk/registration.hpp"
 
+#include <rocprofiler-sdk/agent.h>
 #include <rocprofiler-sdk/fwd.h>
 
 namespace rocprofiler
@@ -144,6 +147,28 @@ counter_callback_info::get_packet(std::unique_ptr<rocprofiler::hsa::AQLPacket>& 
     return ROCPROFILER_STATUS_SUCCESS;
 }
 
+namespace
+{
+// Best-effort enable/disable of the power-throttling lock (PTL) on all GPUs,
+// toggled symmetrically around counter-collection start/stop.
+void
+set_dispatch_ptl(bool enable)
+{
+    if(!counters::ptl_control_supported()) return;
+
+    for(const auto& agent : agent::get_agents())
+    {
+        if(agent->type != ROCPROFILER_AGENT_TYPE_GPU) continue;
+
+        const auto* rocp_agent = rocprofiler::agent::get_agent(agent->id);
+        if(enable)
+            counters::counter_collection_ptl_enable(rocp_agent);
+        else
+            counters::counter_collection_ptl_disable(rocp_agent);
+    }
+}
+}  // namespace
+
 void
 start_context(const context::context* ctx)
 {
@@ -161,6 +186,8 @@ start_context(const context::context* ctx)
 
     if(!already_enabled)
     {
+        set_dispatch_ptl(false);
+
         callback_thread_start();
 
         for(auto& cb : ctx->dispatch_counter_collection->callbacks)
@@ -213,10 +240,14 @@ stop_context(const context::context* ctx)
 
     auto* controller = hsa::get_queue_controller();
 
+    bool was_enabled = false;
     ctx->dispatch_counter_collection->enabled.wlock([&](auto& enabled) {
         if(!enabled) return;
-        enabled = false;
+        was_enabled = true;
+        enabled     = false;
     });
+
+    if(was_enabled) set_dispatch_ptl(true);
 
     if(controller)
     {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/core.cpp
@@ -149,7 +149,7 @@ counter_callback_info::get_packet(std::unique_ptr<rocprofiler::hsa::AQLPacket>& 
 
 namespace
 {
-// Best-effort enable/disable of the power-throttling lock (PTL) on all GPUs,
+// Best-effort enable/disable of the Peak Tops Limiter (PTL) on all GPUs,
 // toggled symmetrically around counter-collection start/stop.
 void
 set_dispatch_ptl(bool enable)


### PR DESCRIPTION
## Motivation

Dispatch PMC counter collection disables the Peak Tops Limiter (PTL) at configuration time and never re-enables it. The disable loop is in `counters/controller.cpp` (`configure_dispatch`), and the only `counter_collection_ptl_enable` call site in the tree belongs to the device-counting path, so nothing in the dispatch path ever restores the setting. On any system where the KFD PTL ioctl is implemented, this leaves PTL disabled on every GPU after the run, at the KFD/firmware level and past process exit, since the ioctl is keyed by `gpu_id` rather than scoped to the file descriptor. The goal is to leave PTL in the state it was found in after every run.

## Technical Details

PTL is now toggled symmetrically around the collection lifecycle instead of at configure time. `counters/controller.cpp` (`configure_dispatch`) drops the configure-time PTL-disable loop. `counters/core.cpp` adds a `set_dispatch_ptl(bool)` helper that enables/disables PTL on all GPU agents (guarded by `ptl_control_supported()`, best-effort and non-fatal); `start_context` disables PTL on the enable transition and `stop_context` re-enables it on the disable transition (gated by a `was_enabled` flag).

Known limitations:

- The toggle is best-effort: a failed ioctl is logged at `ROCP_INFO` and ignored.
- PTL is not reference counted across concurrent contexts. This PR introduces the first dispatch-path code that re-enables PTL, and by inspection `stop_context` calls `set_dispatch_ptl(true)` unconditionally without consulting other services, so a dispatch context stopping while device counting or a second dispatch context is still collecting on the same agent will restore PTL mid-collection. Single-context rocprofv3, the dominant path, is unaffected. Fixing it also requires balancing two disables that have no matching enable (`device_counting.cpp` skips agents that were never given a profile; the legacy `use_device_lock_at_start()` path in `controller.cpp`), so it is tracked separately.
- The device-counting path is unchanged and does not reliably restore PTL: its two samples issue 3 disables / 2 enables and 1 disable / 0 enables respectively.

## JIRA ID

JIRA ID : AIROCVAL-186

## Test Plan

Built this branch, rebased onto develop, on a gfx942 (MI300X, 8 GPU) node: ROCm 7.2.3 userspace, amdgpu 7.1.1, KFD 1.23. Traced the KFD profiler ioctl with an `LD_PRELOAD` interposer on unpatched vs patched `rocprofv3 --pmc` runs, recording `KFD_IOC_PROFILER_PTL_CONTROL` calls, their `args.ptl.enable`, and their return codes. The request number is version-dependent (`get_profiler_ioctl_request_for_version` selects `0x28` on KFD >= 1.23, `0x86` otherwise), so the interposer matches both. Also ran the `rocprofv3` multiplex counter-collection layouts with output validation, and repeated a layout back-to-back.

## Test Result

Call symmetry is fixed: unpatched issues 8 PTL disable calls and 0 enables; patched issues 8 and 8.

**The runtime effect could not be verified on this hardware.** Every `PTL_CONTROL` ioctl on this node fails with `ENOTSUP` (errno 95) — confirmed both through the interposer during a real run (16 calls, 0 succeeded) and with a standalone probe against two different `gpu_id`s in both directions. So on this node the setting is never actually changed, and neither the leak nor its repair is observable. Note that `ptl_control_supported()` returns true here regardless, because it probes `KFD_IOC_PROFILER_VERSION` rather than the PTL operation itself. Claims about accumulation across runs, effects on subsequent workloads, or GPU hangs are therefore unverified on this system; they require a driver that implements the operation.

No regression: counter collection is unaffected (same run still produces its 64 PMC events), the multiplex counter-collection layouts (3-group interval 2, interval 4, oversubscription, and the invalid/empty-group graceful degradation case) all still collect the scheduled group per dispatch and pass validation, and 10 back-to-back multiplex runs completed with no failures, with rocm-smi reporting normal temperatures, power, and clocks throughout.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.