### PR TITLE
[RCCL] Increase default per-test timeout for DPX+NPS2 mode

### DIFF
--- a/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
+++ b/projects/rccl/test/common/ProcessIsolatedTestRunner.cpp
@@ -70,7 +70,15 @@ static constexpr int kPollBlockIndefinitely = -1;
 static constexpr int kDisabledFd = -1;
 
 // Default test timeout (seconds) if none is specified in TestConfig.
-static constexpr int kDefaultTestTimeoutSeconds = 30;
+// Raised from 30s to 300s to accommodate slow-running collective tests in
+// DPX+NPS2 mode:
+//  - gfx1250 (DPX+NPS2): some tests currently take ~133s
+//  - gfx950 (DPX+NPS2): some tests currently take ~68s
+//  ~2x headroom over the observed worst case is intentional to avoid
+//  flaky false-positive timeouts
+//
+// TODO: Reduce this (toward ~70s) once gfx1250's runtime comes down
+static constexpr int kDefaultTestTimeoutSeconds = 300;
 
 // Unset process ID — used before a child is forked or when fork fails.
 static constexpr pid_t kInvalidPid = -1;


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
In DPX+NPS2 mode, some process-isolated tests currently run up to ~133s on gfx1250 and ~68s on gfx950; 30s caused false-positive timeouts. Raised the timeout to 300s (~2x headroom).

JIRA ID: ROCM-27742
## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
Resolves ROCM-27742
## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
