### PR TITLE
fix(amdsmi): clean up static profile and mem-carveout CLI output

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -17,6 +17,9 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 - **`amd-smi static` now omits `MEM_CARVEOUT` from default human-readable output on hardware without VRAM carveout support**.  
   - On a default run the human-readable output drops the section entirely instead of printing a verbose reason string; JSON and CSV keep a stable `N/A` key. An explicit `-m`/`--mem-carveout` always reports `N/A` in every format. VRAM carveout is only exposed on carveout-capable APUs.
 
+- **Expanded `amd-smi static --mem-carveout` CSV output**.  
+  - CSV previously exposed only the opaque `mem_carveout_index`. It now also emits `mem_carveout_current_desc` (the selected option's description) and `mem_carveout_num_options`, so a CSV consumer can interpret the index without the JSON `options` list.
+
 ### Fixed
 
 - **Fixed `amd-smi ras --cper --json` emitting nothing when there are no CPER entries**.

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -14,6 +14,9 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
   - Consumers that pass explicit `--gtest_filter` values should update those filters to the new suite names.
   - See the [AMD SMI test design](docs/conceptual/test-design.md#naming-conventions) for the suite naming convention and `--gtest_filter` usage.
 
+- **`amd-smi static` now omits `MEM_CARVEOUT` from default human-readable output on hardware without VRAM carveout support**.  
+  - On a default run the human-readable output drops the section entirely instead of printing a verbose reason string; JSON and CSV keep a stable `N/A` key. An explicit `-m`/`--mem-carveout` always reports `N/A` in every format. VRAM carveout is only exposed on carveout-capable APUs.
+
 ### Fixed
 
 - **Fixed `amd-smi ras --cper --json` emitting nothing when there are no CPER entries**.
@@ -36,6 +39,12 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 - **Fixed `amd-smi` hanging in `amdsmi_init()` on UALink systems when the IFoE driver is unresponsive**.  
   - `AMDSmiGPUDevice` opened the per-GPU IFoE/UALoE generic-netlink session in its constructor, so `amdsmi_init(AMDSMI_INIT_AMD_GPUS)` (and every CLI verb) blocked in an uninterruptible netlink wait when the Broadcom IFoE driver was wedged, even for queries that never use fabric data.
   - The UALoE session is now opened lazily on the first fabric query via `get_ualoe_handle()`, so initialization and non-fabric queries no longer touch the IFoE driver.
+
+- **Fixed mis-indented `amd-smi static --profile` list in human-readable output**.  
+  - The available power profiles rendered outdented below the following field; plain list items now nest correctly under their key. JSON and CSV output are unchanged.
+
+- **Fixed `amd-smi static --profile` printing a raw status-code string on unsupported devices**.  
+  - When the power-profile query fails, the section now reports `N/A` instead of the full error info string, matching every other `amd-smi static` field.
 
 ## amd_smi_lib for ROCm 7.14.0
 

--- a/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
@@ -390,8 +390,10 @@ class AMDSMILogger:
                 for item in value:
                     if isinstance(item, dict):
                         yaml_string += self.custom_dump(item, indent + 1)
-                    else:  # If the list is not a dictionary, print it as a string
-                        yaml_string += "  " * (indent + 1) + f"- {item}\n"
+                    else:
+                        # Scalar items carry no ':', so post-processing won't
+                        # double their indent; emit at the final 4-space level.
+                        yaml_string += "    " * (indent + 1) + f"{item}\n"
             else:
                 key_prefix = "  " * indent
                 if isinstance(value, str) and "\n" in value:

--- a/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
@@ -1518,7 +1518,7 @@ class AMDSMIParser(argparse.ArgumentParser):
         soc_pstate_help = "The available soc pstate policy"
         xgmi_plpd_help = "The available XGMI per-link power down policy"
         process_isolation_help = "The process isolation status"
-        profile_help = "Display current and available power profiles"
+        profile_help = "Displays current and available power profiles."
         clk_options = self.helpers.get_clock_types()[0]
         clk_options.remove("PCIE")
         clk_option_str = ", ".join(clk_options) + ", ALL"

--- a/projects/amdsmi/amdsmi_cli/subcommands/static.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/static.py
@@ -1155,8 +1155,21 @@ class StaticCommands:
                     }
                     static_dict["mem_carveout"] = carveout_dict
                 elif self.logger.is_csv_format():
-                    # CSV: show only current index
-                    static_dict["mem_carveout_index"] = uma_info.get("current_index", -1)
+                    # CSV is flat; emit scalar summaries since the options list
+                    # can't be a single column.
+                    options = uma_info.get("options", [])
+                    current_index = uma_info.get("current_index", -1)
+                    current_desc = next(
+                        (
+                            opt.get("description", "N/A")
+                            for opt in options
+                            if opt.get("index") == current_index
+                        ),
+                        "N/A",
+                    )
+                    static_dict["mem_carveout_index"] = current_index
+                    static_dict["mem_carveout_current_desc"] = current_desc
+                    static_dict["mem_carveout_num_options"] = uma_info.get("num_options", 0)
                 else:
                     # Human readable: show all options with current marked
                     options = uma_info.get("options", [])
@@ -1189,6 +1202,8 @@ class StaticCommands:
                     pass
                 elif self.logger.is_csv_format():
                     static_dict["mem_carveout_index"] = "N/A"
+                    static_dict["mem_carveout_current_desc"] = "N/A"
+                    static_dict["mem_carveout_num_options"] = "N/A"
                 else:
                     static_dict["mem_carveout"] = "N/A"
                 logging.debug(

--- a/projects/amdsmi/amdsmi_cli/subcommands/static.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/static.py
@@ -278,6 +278,13 @@ class StaticCommands:
             current_platform_args += ["dfc_ucode", "fb_info", "num_vf"]
             current_platform_values += [args.dfc_ucode, args.fb_info, args.num_vf]
 
+        # UMA carveout only exists on supported APUs. Capture whether the user
+        # explicitly asked for it before the "show everything" default fills
+        # every arg; the hasattr guard preserves it across the recursive
+        # multi-GPU re-entry, which reuses the same (already-defaulted) args.
+        if not hasattr(args, "mem_carveout_explicit"):
+            args.mem_carveout_explicit = bool(args.mem_carveout)
+
         if not any(current_platform_values):
             for arg in current_platform_args:
                 setattr(args, arg, True)
@@ -936,7 +943,7 @@ class StaticCommands:
                         "num_profiles": profile_status["num_profiles"],
                     }
                 except amdsmi_exception.AmdSmiLibraryException as e:
-                    static_dict["profile"] = e.get_error_info()
+                    static_dict["profile"] = "N/A"
                     logging.debug(
                         "Failed to get power profile info for gpu %s | %s",
                         gpu_id,
@@ -1165,22 +1172,21 @@ class StaticCommands:
                     else:
                         static_dict["mem_carveout"] = "N/A"
             except amdsmi_exception.AmdSmiLibraryException as e:
-                # UMA carveout is only exposed by APU VBIOSes that support
-                # ATCS function 0xA. On dGPUs and Instinct parts (including
-                # MI300A) the sysfs attribute does not exist and the library
-                # returns NOT_SUPPORTED; surface a clearer reason than bare N/A.
+                # UMA carveout only exists on supported APUs. On a default
+                # human-readable `amd-smi static` run, omit the section on
+                # everything else so the output stays clean; JSON/CSV keep a
+                # stable `N/A` key, and an explicit `-m/--mem-carveout` always
+                # reports N/A (the reason lives in the flag's help).
                 not_supported = (
                     e.get_error_code()
                     == amdsmi_interface.amdsmi_wrapper.AMDSMI_STATUS_NOT_SUPPORTED
                 )
-                if not_supported and not (
-                    self.logger.is_json_format() or self.logger.is_csv_format()
+                if (
+                    not_supported
+                    and not args.mem_carveout_explicit
+                    and self.logger.is_human_readable_format()
                 ):
-                    # Human-readable: give a descriptive reason. JSON/CSV
-                    # consumers keep the legacy bare "N/A" for back-compat.
-                    static_dict["mem_carveout"] = (
-                        "N/A (UMA carveout is not supported on this ASIC/VBIOS)"
-                    )
+                    pass
                 elif self.logger.is_csv_format():
                     static_dict["mem_carveout_index"] = "N/A"
                 else:

--- a/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
+++ b/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
@@ -1550,7 +1550,7 @@ interfaces (sysfs / modprobe.d) and do **not** require libdrm.
 | Feature | Hardware | Status |
 |---|---|---|
 | `--mem-carveout` (UMA carveout) | Strix and later APUs (gfx1150, gfx1151, gfx1152) whose VBIOS exposes ATCS 0xA | Supported |
-| `--mem-carveout` (UMA carveout) | Radeon dGPUs, Instinct MI-series (MI100, MI200, MI300, MI300A) | Not supported — reported as `MEM_CARVEOUT: N/A (UMA carveout is not supported on this ASIC/VBIOS)` |
+| `--mem-carveout` (UMA carveout) | Radeon dGPUs, Instinct MI-series (MI100, MI200, MI300, MI300A) | Not supported — omitted from default human-readable `amd-smi static` output (JSON/CSV keep an `N/A` key); `MEM_CARVEOUT: N/A` when queried explicitly with `-m`/`--mem-carveout` |
 | `--gtt` (TTM `pages_limit`) | Any amdgpu system, including Instinct MI300A (`amdttm` / `amd-ttm`) and Ryzen APUs (`ttm`) | Supported |
 
 ### Prerequisites
@@ -1558,14 +1558,18 @@ interfaces (sysfs / modprobe.d) and do **not** require libdrm.
 - **UMA carveout:** Linux kernel >= 7.0 (upstream commit [`685b711`](https://github.com/torvalds/linux/commit/685b711); some distros backport it to earlier kernels), an APU VBIOS that advertises ATCS 0xA + IGP info table v2.3, root, and a reboot after changing the index.
 - **GTT (TTM `pages_limit`):** root (to write `/etc/modprobe.d/<module>.conf`), optionally `dracut` (the tool will rebuild the initramfs automatically when `dracut` is present), and a reboot to apply the new limit. amd-smi auto-detects the TTM kernel module name (`ttm`, `amdttm`, or `amd-ttm`) and writes the matching `.conf`.
 
-### Troubleshooting: `MEM_CARVEOUT: N/A`
+### Troubleshooting: missing `MEM_CARVEOUT` section
 
 On MI300A (and every non-APU / pre-ATCS-0xA platform) the kernel does not
-create `/sys/class/drm/<card>/device/uma/`, so `amd-smi static --mem-carveout`
-prints
+create `/sys/class/drm/<card>/device/uma/`, so carveout is not supported. A
+default human-readable `amd-smi static` run omits the `MEM_CARVEOUT` section
+entirely on these platforms (JSON and CSV keep a stable `N/A` key). Querying
+it explicitly prints a plain `N/A`:
 
 ```text
-MEM_CARVEOUT: N/A (UMA carveout is not supported on this ASIC/VBIOS)
+amd-smi static --mem-carveout
+...
+MEM_CARVEOUT: N/A
 ```
 
 This is expected. Use `amd-smi node --gtt` / `amd-smi set --gtt` to tune

--- a/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
+++ b/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
@@ -1550,7 +1550,7 @@ interfaces (sysfs / modprobe.d) and do **not** require libdrm.
 | Feature | Hardware | Status |
 |---|---|---|
 | `--mem-carveout` (UMA carveout) | Strix and later APUs (gfx1150, gfx1151, gfx1152) whose VBIOS exposes ATCS 0xA | Supported |
-| `--mem-carveout` (UMA carveout) | Radeon dGPUs, Instinct MI-series (MI100, MI200, MI300, MI300A) | Not supported — omitted from default human-readable `amd-smi static` output (JSON/CSV keep an `N/A` key); `MEM_CARVEOUT: N/A` when queried explicitly with `-m`/`--mem-carveout` |
+| `--mem-carveout` (UMA carveout) | Radeon dGPUs, Instinct MI-series (MI100, MI200, MI300, MI300A) | Not supported — omitted from default human-readable `amd-smi static` output (JSON/CSV keep stable `N/A` fields); `MEM_CARVEOUT: N/A` when queried explicitly with `-m`/`--mem-carveout` |
 | `--gtt` (TTM `pages_limit`) | Any amdgpu system, including Instinct MI300A (`amdttm` / `amd-ttm`) and Ryzen APUs (`ttm`) | Supported |
 
 ### Prerequisites
@@ -1563,7 +1563,7 @@ interfaces (sysfs / modprobe.d) and do **not** require libdrm.
 On MI300A (and every non-APU / pre-ATCS-0xA platform) the kernel does not
 create `/sys/class/drm/<card>/device/uma/`, so carveout is not supported. A
 default human-readable `amd-smi static` run omits the `MEM_CARVEOUT` section
-entirely on these platforms (JSON and CSV keep a stable `N/A` key). Querying
+entirely on these platforms (JSON and CSV keep stable `N/A` fields). Querying
 it explicitly prints a plain `N/A`:
 
 ```text
@@ -1574,3 +1574,16 @@ MEM_CARVEOUT: N/A
 
 This is expected. Use `amd-smi node --gtt` / `amd-smi set --gtt` to tune
 shared GPU memory on those platforms instead.
+
+### CSV output fields
+
+Because CSV is flat, the carveout options list cannot be a single column, so
+CSV emits scalar summaries instead of the full JSON `options` list:
+
+| Field | Meaning |
+|---|---|
+| `mem_carveout_index` | Index of the currently selected carveout option |
+| `mem_carveout_current_desc` | Description of the selected option (e.g. `2 GB`) |
+| `mem_carveout_num_options` | Number of available carveout options |
+
+All three fields report `N/A` on hardware without carveout support.

--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -6013,7 +6013,7 @@ Refer to [amd_smi_partition_example.py](https://github.com/ROCm/rocm-systems/blo
 - **Not available** on dedicated GPUs or Instinct MI-series accelerators
   (including MI300A); the call returns `AMDSMI_STATUS_NOT_SUPPORTED`. A
   default human-readable `amd-smi static` run omits the `MEM_CARVEOUT`
-  section on these platforms (JSON and CSV keep a stable `N/A` key), and
+  section on these platforms (JSON and CSV keep stable `N/A` fields), and
   querying it explicitly with `--mem-carveout` prints `MEM_CARVEOUT: N/A`.
 - Requires Linux kernel >= 7.0 (upstream commit
   [`685b711`](https://github.com/torvalds/linux/commit/685b711); some

--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -6011,9 +6011,10 @@ Refer to [amd_smi_partition_example.py](https://github.com/ROCm/rocm-systems/blo
   at least v2.3. In practice this covers Strix and later APUs
   (gfx1150/gfx1151/gfx1152).
 - **Not available** on dedicated GPUs or Instinct MI-series accelerators
-  (including MI300A); the call returns `AMDSMI_STATUS_NOT_SUPPORTED` and
-  `amd-smi static --mem-carveout` prints
-  `MEM_CARVEOUT: N/A (UMA carveout is not supported on this ASIC/VBIOS)`.
+  (including MI300A); the call returns `AMDSMI_STATUS_NOT_SUPPORTED`. A
+  default human-readable `amd-smi static` run omits the `MEM_CARVEOUT`
+  section on these platforms (JSON and CSV keep a stable `N/A` key), and
+  querying it explicitly with `--mem-carveout` prints `MEM_CARVEOUT: N/A`.
 - Requires Linux kernel >= 7.0 (upstream commit
   [`685b711`](https://github.com/torvalds/linux/commit/685b711); some
   distros backport it to earlier kernels) and read access to

--- a/projects/amdsmi/tests/python/unit/gpu/test_logger_scalar_list_format.py
+++ b/projects/amdsmi/tests/python/unit/gpu/test_logger_scalar_list_format.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) Advanced Micro Devices. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""Mock-based unit tests for ``AMDSMILogger`` human-readable scalar-list output.
+
+Loads the installed ``amdsmi_logger`` with its ``amdsmi_helpers`` dependency
+stubbed, so the human-readable formatter is exercised without GPU hardware.
+Locks in the scalar-list rendering contract used by ``amd-smi static --profile``
+(and any section that emits a list of plain strings):
+
+* A scalar list item is indented strictly deeper than its own key.
+* Scalar list items are not prefixed with a ``- `` bullet.
+"""
+
+import importlib.util
+import os
+import sys
+import types
+import unittest
+
+from common.common import amdsmi_path
+
+_ROCM_ROOT = os.path.dirname(os.path.dirname(amdsmi_path))
+LOGGER_PATH = os.path.join(_ROCM_ROOT, "libexec", "amdsmi_cli", "amdsmi_logger.py")
+
+
+def _install_fake_helpers():
+    """Register a stub ``amdsmi_helpers`` so ``amdsmi_logger`` imports cleanly."""
+    module = types.ModuleType("amdsmi_helpers")
+    module.AMDSMIHelpers = type("AMDSMIHelpers", (), {})
+    sys.modules["amdsmi_helpers"] = module
+
+
+def _load_logger_module():
+    spec = importlib.util.spec_from_file_location("amdsmi_logger_under_test", LOGGER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _indent(line):
+    return len(line) - len(line.lstrip(" "))
+
+
+class TestHumanReadableScalarList(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.isfile(LOGGER_PATH):
+            raise unittest.SkipTest(f"amdsmi_logger not installed at {LOGGER_PATH}")
+        _install_fake_helpers()
+        cls.logger_mod = _load_logger_module()
+        cls.logger = cls.logger_mod.AMDSMILogger(format="human_readable")
+
+    def _render_profile(self, profiles):
+        return self.logger._convert_json_to_human_readable(
+            {"gpu": 0, "profile": {"available_profiles": profiles}}
+        )
+
+    def test_items_indented_deeper_than_key(self):
+        """Each item must sit deeper than its AVAILABLE_PROFILES key."""
+        profiles = ["CUSTOM", "VIDEO", "BOOTUP_DEFAULT"]
+        lines = self._render_profile(profiles).splitlines()
+
+        key_lines = [line for line in lines if line.strip() == "AVAILABLE_PROFILES:"]
+        self.assertEqual(len(key_lines), 1, "expected exactly one AVAILABLE_PROFILES key line")
+        key_indent = _indent(key_lines[0])
+
+        for name in profiles:
+            item_lines = [line for line in lines if line.strip() == name]
+            self.assertEqual(len(item_lines), 1, f"expected one line for profile {name}")
+            self.assertGreater(
+                _indent(item_lines[0]),
+                key_indent,
+                f"profile {name} should be indented deeper than its key",
+            )
+
+    def test_no_dash_bullets(self):
+        """Scalar list items must not render as ``- item`` bullets."""
+        lines = self._render_profile(["CUSTOM", "VIDEO"]).splitlines()
+        for line in lines:
+            self.assertFalse(
+                line.lstrip(" ").startswith("- "),
+                f"unexpected dash bullet in human-readable output: {line!r}",
+            )
+
+    def test_items_do_not_outdent_between_sibling_fields(self):
+        """Items nest under the list key while sibling scalars keep key-level indent."""
+        out = self.logger._convert_json_to_human_readable(
+            {
+                "gpu": 0,
+                "profile": {
+                    "available_profiles": ["CUSTOM", "VIDEO"],
+                    "current": "CUSTOM",
+                    "num_profiles": 2,
+                },
+            }
+        )
+        lines = out.splitlines()
+        key_indent = _indent(next(l for l in lines if l.strip() == "AVAILABLE_PROFILES:"))
+        current_indent = _indent(next(l for l in lines if l.strip().startswith("CURRENT:")))
+        self.assertEqual(
+            current_indent, key_indent, "sibling field CURRENT should share the list key's indent"
+        )
+        for name in ("CUSTOM", "VIDEO"):
+            item_indent = _indent(next(l for l in lines if l.strip() == name))
+            self.assertGreater(item_indent, current_indent)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Motivation

`amd-smi static --profile` rendered its available-profiles list mangled in human-readable output (items outdented below the following field), and every `amd-smi static` run printed a `MEM_CARVEOUT: N/A` line on hardware without VRAM carveout support. Tidy both.

## Technical Details

**Human-readable logger** (`amdsmi_cli/amdsmi_logger.py`):
- Render scalar list items nested under their key instead of as outdented `- item` bullets, fixing the root cause of the mangled `--profile` output

**static subcommand** (`amdsmi_cli/subcommands/static.py`):
- Drop the profile-specific human-readable workaround; profile now uses one plain list across human-readable, JSON, and CSV
- Omit `MEM_CARVEOUT` from default output on carveout-unsupported hardware; show it only with `-m`/`--mem-carveout` and report a plain `N/A`

**Parser** (`amdsmi_cli/amdsmi_parser.py`):
- Note Linux-Baremetal-only availability in the `--profile` help text

**Tests** (`tests/python_unittest/logger_format_unit_test.py`):
- Add a hardware-free regression test for the scalar-list formatter

## JIRA ID

JIRA ID: AILITOOLS-281

## Test Plan

- `python3 tests/python_unittest/logger_format_unit_test.py` (hardware-free)
- Manual `amd-smi static --profile` / `--json` / `--csv`, and `static` / `static -m`, on an MI210 + Navi31 host
- `pre-commit run` on all changed files

## Test Result

- New unit test: 3 passed
- Human-readable `--profile` list nests correctly; JSON/CSV unchanged
- `MEM_CARVEOUT` absent from default output; `-m` shows plain `N/A`; pre-commit clean

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
