### PR TITLE
fix(rocr): Remove LogPrint from DmaBufClose for rocdxg WSL link

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
@@ -884,7 +884,6 @@ hsa_status_t DmaBufClose(int* dmabuf) {
   if (dmabuf == nullptr) return HSA_STATUS_ERROR_INVALID_ARGUMENT;
   if (*dmabuf < 0) return HSA_STATUS_SUCCESS;
   if (::close(*dmabuf) != 0) {
-    LogPrint(HSA_AMD_LOG_FLAG_INFO, "close dmabuf failed: %s", strerror(errno));
     *dmabuf = -1;
     return HSA_STATUS_ERROR_RESOURCE_FREE;
   }


### PR DESCRIPTION
## Summary

Fixes WSL CI link failures for `librocdxg.so` introduced when `DmaBufClose` started calling `LogPrint` in #7803.

`os_linux.cpp` is compiled into both `libhsa-runtime64` and `librocdxg`, but the rocdxg target does not link `rocr::log_printf` / `rocr::log_flags`. Remove the close-failure log line so rocdxg links cleanly while preserving the fd invalidation and error status behavior.

Closes #8340

## Test plan

- [ ] WSL rocr-runtime CI (`rocr-runtime-wsl.yml`) links `librocdxg.so` successfully
- [ ] `DmaBufClose` still invalidates the fd and returns `HSA_STATUS_ERROR_RESOURCE_FREE` on close failure


Made with [Cursor](https://cursor.com)