### PR TITLE
fix(rccl) [JIRA ROCM-27802] : use HIP host uncached memory for CUDA host alloc

### DIFF
--- a/projects/rccl/src/include/alloc.h
+++ b/projects/rccl/src/include/alloc.h
@@ -691,7 +691,7 @@ static inline ncclResult_t ncclCuMemFreeAddr(void *ptr, struct ncclMemManager* m
   return ncclInternalError;
 }
 
-static inline ncclResult_t ncclCuMemGetAddressRange(CUdeviceptr userBuff, size_t userBuffSize, CUdeviceptr* mappedPtrBase, size_t* totalMappedBufferSize, int* numSegments) {
+static inline ncclResult_t ncclCuMemGetAddressRange(CUdeviceptr userBuff, size_t userBuffSize, CUdeviceptr* mappedPtrBase, size_t* totalMappedBufferSize, int* numSegments, bool* hasSysmemSegment = nullptr) {
   WARN("CUMEM requires ROCM_VERSION >= 7.0.0");
   return ncclInternalError;
 }

--- a/projects/rccl/src/include/alloc.h
+++ b/projects/rccl/src/include/alloc.h
@@ -261,23 +261,12 @@ ncclResult_t ncclCudaHostCallocDebug(T** ptr, size_t nelem, const char *filefunc
   cudaStreamCaptureMode mode = cudaStreamCaptureModeRelaxed;
   *ptr = nullptr;
   CUDACHECK(cudaThreadExchangeStreamCaptureMode(&mode));
-  int managed = 0;
-  CUDACHECK(hipDeviceGetAttribute(&managed, hipDeviceAttributeDirectManagedMemAccessFromHost, 0));
-  if (nelem > 0) {
-    if (managed) {
-#if defined(HIP_UNCACHED_MEMORY)
-      CUDACHECKGOTO(hipExtMallocWithFlags((void**)ptr, nelem*ncclSizeOfT<T>(), hipDeviceMallocUncached), result, finish);
-#else
-      CUDACHECKGOTO(hipExtMallocWithFlags((void**)ptr, nelem*ncclSizeOfT<T>(), hipDeviceMallocFinegrained), result, finish);
-#endif
-    } else
 #if defined(HIP_HOST_UNCACHED_MEMORY)
-      CUDACHECKGOTO(hipHostMalloc(ptr, nelem*ncclSizeOfT<T>(), cudaHostAllocMapped | hipHostMallocUncached), result, finish);
+  CUDACHECKGOTO(hipHostMalloc(ptr, nelem*ncclSizeOfT<T>(), cudaHostAllocMapped | hipHostMallocUncached), result, finish);
 #else
-      CUDACHECKGOTO(hipHostMalloc(ptr, nelem*ncclSizeOfT<T>(), cudaHostAllocMapped), result, finish);
+  CUDACHECKGOTO(hipHostMalloc(ptr, nelem*ncclSizeOfT<T>(), cudaHostAllocMapped), result, finish);
 #endif
-    memset(*ptr, 0, nelem*ncclSizeOfT<T>());
-  }
+  memset(*ptr, 0, nelem*ncclSizeOfT<T>());
 finish:
   CUDACHECK(cudaThreadExchangeStreamCaptureMode(&mode));
   if (*ptr == nullptr && nelem > 0) WARN("Failed to CUDA host alloc %ld bytes", nelem*ncclSizeOfT<T>());

--- a/projects/rccl/test/AllocTests.cpp
+++ b/projects/rccl/test/AllocTests.cpp
@@ -139,6 +139,41 @@ TEST(Alloc, ncclCuMemFreeAddr)
 }
 #endif // ROCM_VERSION < 70000
 
+TEST(Alloc, ncclCudaHostCalloc)
+{
+    RUN_ISOLATED_TEST(
+        "ncclCudaHostCalloc",
+        []()
+        {
+            // Initialize HIP device in forked process
+            ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+            constexpr size_t N   = 256;
+            float*           ptr = nullptr;
+
+            ncclResult_t result = ncclCudaHostCalloc(&ptr, N);
+            ASSERT_EQ(result, ncclSuccess);
+            ASSERT_NE(ptr, nullptr);
+
+            // Verify the allocation is host (CPU) memory, not device memory.
+            hipPointerAttribute_t attr;
+            ASSERT_EQ(hipPointerGetAttributes(&attr, ptr), hipSuccess);
+            EXPECT_EQ(attr.type, hipMemoryTypeHost)
+                << "ncclCudaHostCalloc should allocate host (CPU) memory";
+
+            // The memory must be directly readable/writable from the CPU.
+            for(size_t i = 0; i < N; ++i)
+                EXPECT_EQ(ptr[i], 0.0f) << "Host memory not zero-initialized at index " << i;
+            for(size_t i = 0; i < N; ++i)
+                ptr[i] = static_cast<float>(i + 1);
+            for(size_t i = 0; i < N; ++i)
+                EXPECT_EQ(ptr[i], static_cast<float>(i + 1)) << "Host write/read mismatch at index " << i;
+
+            ASSERT_EQ(ncclCudaHostFree(ptr), ncclSuccess);
+        }
+    );
+}
+
 TEST(Alloc, NcclCudaMemcpy)
 {
     RUN_ISOLATED_TEST(


### PR DESCRIPTION
## Motivation

HIP host uncached memory is now available, so remove the previous DirectManagedMemAccessFromHost workaround that allocated device fine-grained/uncached memory. Always use hipHostMalloc to match the NCCL implementation.

## Technical Details

Use hipHostMalloc(ptr, nelem*ncclSizeOfT<T>(), cudaHostAllocMapped | hipHostMallocUncached) to match NCCL implementation.

## JIRA ID

ROCM-27802

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
