### PR TITLE
fix(rocprofiler-sdk): set GPU target initialization before source unit tests

### DIFF
--- a/projects/rocprofiler-sdk/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/CMakeLists.txt
@@ -108,6 +108,11 @@ include(rocprofiler_formatting) # formatting
 include(rocprofiler_linting) # clang-tidy
 include(rocprofiler_config_interfaces) # configure interface libraries
 
+if(ROCPROFILER_BUILD_TESTS)
+    # Source-level unit tests are configured before tests/common sets test GPU targets.
+    include("${PROJECT_SOURCE_DIR}/tests/cmake/rocprofiler_test_gpu_targets.cmake")
+endif()
+
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}")

--- a/projects/rocprofiler-sdk/tests/cmake/rocprofiler_test_gpu_targets.cmake
+++ b/projects/rocprofiler-sdk/tests/cmake/rocprofiler_test_gpu_targets.cmake
@@ -1,0 +1,29 @@
+include_guard(GLOBAL)
+
+set(ROCPROFILER_DEFAULT_GPU_TARGETS
+    "gfx900"
+    "gfx906"
+    "gfx908"
+    "gfx90a"
+    "gfx942"
+    "gfx950"
+    "gfx1030"
+    "gfx1010"
+    "gfx1100"
+    "gfx1101"
+    "gfx1102"
+    "gfx1151"
+    "gfx1152"
+    "gfx1250")
+
+if(NOT GPU_TARGETS)
+    set(GPU_TARGETS
+        "${ROCPROFILER_DEFAULT_GPU_TARGETS}"
+        CACHE STRING "GPU targets to compile for" FORCE)
+endif()
+
+set(AMDGPU_TARGETS
+    "${GPU_TARGETS}"
+    CACHE STRING
+          "GPU targets to compile for AMDGPUs (update GPU_TARGETS, not this variable)"
+          FORCE)

--- a/projects/rocprofiler-sdk/tests/common/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/common/CMakeLists.txt
@@ -12,31 +12,7 @@ set(ROCPROFILER_DEFAULT_FAIL_REGEX
     "threw an exception|Permission denied|Could not create logging file|failed with error code|Subprocess aborted"
     CACHE INTERNAL "Default FAIL_REGULAR_EXPRESSION for tests")
 
-set(DEFAULT_GPU_TARGETS
-    "gfx900"
-    "gfx906"
-    "gfx908"
-    "gfx90a"
-    "gfx942"
-    "gfx950"
-    "gfx1030"
-    "gfx1010"
-    "gfx1100"
-    "gfx1101"
-    "gfx1102"
-    "gfx1151"
-    "gfx1152"
-    "gfx1250")
-
-set(GPU_TARGETS
-    "${DEFAULT_GPU_TARGETS}"
-    CACHE STRING "GPU targets to compile for")
-
-set(AMDGPU_TARGETS
-    "${GPU_TARGETS}"
-    CACHE STRING
-          "GPU targets to compile for AMDGPUs (update GPU_TARGETS, not this variable)"
-          FORCE)
+include("${CMAKE_CURRENT_LIST_DIR}/../cmake/rocprofiler_test_gpu_targets.cmake")
 
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
     cmake_policy(SET CMP0135 NEW)


### PR DESCRIPTION
## Motivation

Counter unit tests can be configured before tests/common initializes GPU_TARGETS, causing required HSACO files like gfx942_agent_kernels.hsaco to be skipped and tests to fail at runtime.

## Technical Details

Adds a shared CMake helper for rocprofiler-sdk test GPU target defaults and includes it before source-level unit tests and from `tests/common`.

## JIRA ID

JIRA ID: ROCM-23909

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
