### PR TITLE
docs(rocprofiler-systems): move unshipped 7.14 changelog entry to 7.15

### DIFF
--- a/projects/rocprofiler-systems/CHANGELOG.md
+++ b/projects/rocprofiler-systems/CHANGELOG.md
@@ -6,6 +6,10 @@ Full documentation for ROCm Systems Profiler is available at [https://rocm.docs.
 
 ## ROCm Systems Profiler 1.8.0 for ROCm 7.15.0 (unreleased)
 
+### Changed
+
+- `ROCPROFSYS_BUILD_TESTING` no longer implies `ROCPROFSYS_BUILD_EXAMPLES`.
+
 ### Removed
 
 - Removed the `-p` / `--pid` option from `rocprof-sys-instrument` for attaching to
@@ -84,7 +88,6 @@ Full documentation for ROCm Systems Profiler is available at [https://rocm.docs.
   v1.17.0 (bundled fmt v12).
 - Supported environment variables for rank detection: removed MPI_RANK and
   MPI_LOCALRANKID, added PMI_RANK and SLURM_PROCID.
-- `ROCPROFSYS_BUILD_TESTING` no longer implies `ROCPROFSYS_BUILD_EXAMPLES`.
 
 ### Resolved issues
 


### PR DESCRIPTION
## Motivation

The `release/therock-7.14` branch is missing a change that's documented under the ROCm Systems Profiler 1.7.0 / ROCm 7.14.0 section of the CHANGELOG. Since that entry never actually shipped in 7.14, the changelog was inaccurate.

## Technical Details

- The `ROCPROFSYS_BUILD_TESTING` no longer implies `ROCPROFSYS_BUILD_EXAMPLES` entry (from #7149) landed on `develop` after `release/therock-7.14` was cut, and is confirmed not present in that branch's history.
- Moved the entry from the 1.7.0/7.14.0 "Changed" section to the 1.8.0/7.15.0 (unreleased) "Changed" section.

## JIRA ID

N/A

## Test Plan

Docs-only change; verified via `git merge-base --is-ancestor` that the source commit for the moved entry is not an ancestor of the `release/therock-7.14` branch tip.

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.