### PR TITLE
fix(cuid): corrected CPU fingerprint formulation

### DIFF
--- a/projects/cuid/README.md
+++ b/projects/cuid/README.md
@@ -52,7 +52,7 @@ revision_id=01
 family=0019
 model=0074
 unit_id=0004
-package_core_id=0:0
+package_id=0
 last_update=6980d761
 
 [NIC:0]
@@ -71,7 +71,7 @@ last_update=1753987166
 ```
 
 - **GPU:** `device_node` links the CUID to hardware.
-- **CPU:** `package_core_id` identifies cores (`package_id:core_id`).
+- **CPU:** `package_id` identifies physical CPU package, akin to the socket.
 - **NIC:** `device_node` links to the network device.
 - **PLATFORM:** Only the derived CUID is listed.
 

--- a/projects/cuid/docs/conceptual/cuid_file.rst
+++ b/projects/cuid/docs/conceptual/cuid_file.rst
@@ -36,7 +36,7 @@ Here's a sample CUID file for your reference:
   family=0019
   model=0074
   unit_id=0004
-  package_core_id=0:0
+  package_id=0
   last_update=6980d761
 
   [NIC:0]
@@ -59,7 +59,7 @@ Depending on the device type, different device attributes (present in the CUID f
 
 - **GPU:** The ``device_node`` links the derived CUID to the hardware.
 
-- **CPU:** The ``package_core_id`` consists of two components: physical ID and core ID, as ``physical_id:core_id``. This helps to identify CPU cores in multi-CPU systems.
+- **CPU:** The ``package_id`` identifies the physical CPU package, which is akin to a socket ID. CPUs will also display a ``device_node`` which represents the first logical CPU core of the physical CPU package. The derived CUID is associated with the physical CPU package, not the logical CPU core.
 
 - **NIC:** The ``device_node`` links the derived CUID to the network device.
 

--- a/projects/cuid/docs/conceptual/cuid_file.rst
+++ b/projects/cuid/docs/conceptual/cuid_file.rst
@@ -59,7 +59,7 @@ Depending on the device type, different device attributes (present in the CUID f
 
 - **GPU:** The ``device_node`` links the derived CUID to the hardware.
 
- - **CPU:** The ``package_id`` identifies the physical CPU package, which is akin to a socket ID. CPUs will also display a ``device_node`` which represents the representative logical CPU for that package (currently selected as the lowest APIC ID seen for the socket). The derived CUID is associated with the physical CPU package, not the logical CPU core.
+- **CPU:** The ``package_id`` identifies the physical CPU package, which is akin to a socket ID. CPUs will also display a ``device_node`` which represents the representative logical CPU for that package (currently selected as the lowest APIC ID seen for the socket). The derived CUID is associated with the physical CPU package, not the logical CPU core.
 
 - **NIC:** The ``device_node`` links the derived CUID to the network device.
 

--- a/projects/cuid/docs/conceptual/cuid_file.rst
+++ b/projects/cuid/docs/conceptual/cuid_file.rst
@@ -59,7 +59,7 @@ Depending on the device type, different device attributes (present in the CUID f
 
 - **GPU:** The ``device_node`` links the derived CUID to the hardware.
 
-- **CPU:** The ``package_id`` identifies the physical CPU package, which is akin to a socket ID. CPUs will also display a ``device_node`` which represents the first logical CPU core of the physical CPU package. The derived CUID is associated with the physical CPU package, not the logical CPU core.
+ - **CPU:** The ``package_id`` identifies the physical CPU package, which is akin to a socket ID. CPUs will also display a ``device_node`` which represents the representative logical CPU for that package (currently selected as the lowest APIC ID seen for the socket). The derived CUID is associated with the physical CPU package, not the logical CPU core.
 
 - **NIC:** The ``device_node`` links the derived CUID to the network device.
 

--- a/projects/cuid/lib/include/amd_cuid.h
+++ b/projects/cuid/lib/include/amd_cuid.h
@@ -46,7 +46,7 @@ extern "C" {
 #define AMDCUID_LIB_VERSION_MINOR 4
 
 //! Patch version should be updated for each bug fix or non-API change
-#define AMDCUID_LIB_VERSION_PATCH 0
+#define AMDCUID_LIB_VERSION_PATCH 1
 
 /**
  * @brief Retrieve the version of the CUID library.

--- a/projects/cuid/lib/src/cuid_cpu.cc
+++ b/projects/cuid/lib/src/cuid_cpu.cc
@@ -242,8 +242,8 @@ amdcuid_status_t CuidCpu::discover(std::vector<DevicePtr> &cpus) {
     // representative used by firmware to identify the socket.
     info.header.fields.cpu.unit_id = static_cast<uint16_t>(rep->apic_id);
     info.header.fields.cpu.physical_id = static_cast<uint16_t>(kv.first);
-    // core is not meaningful at socket granularity
-    info.header.fields.cpu.core = 0;
+    info.header.fields.cpu.core =
+        static_cast<uint16_t>(rep->processor); // logical CPU number
 
     // device_node points to the representative logical CPU's sysfs path.
     info.device_node =
@@ -382,7 +382,7 @@ CuidCpu::get_hardware_fingerprint(uint64_t &fingerprint) const {
   // PPIN is an eFuse-burned per-socket serial number — the spec's primary
   // identifier. The core argument only selects which MSR fd to open.
   uint64_t ppin = 0;
-  if (try_read_ppin(ppin, m_info.header.fields.cpu.unit_id)) {
+  if (try_read_ppin(ppin, m_info.header.fields.cpu.core)) {
     fingerprint = ppin;
     return AMDCUID_STATUS_SUCCESS;
   }

--- a/projects/cuid/lib/src/cuid_cpu.cc
+++ b/projects/cuid/lib/src/cuid_cpu.cc
@@ -21,9 +21,10 @@
  */
 
 #include "src/cuid_cpu.h"
-#include "src/acpi_parser.h"
 #include "src/cuid_file.h"
 #include "src/cuid_util.h"
+#include "src/hmac.h"
+#include "src/smbios_util.h"
 #include <cstring>
 #include <fstream>
 #include <iostream>
@@ -203,15 +204,25 @@ amdcuid_status_t CuidCpu::discover(std::vector<DevicePtr> &cpus) {
   bool cpuid_available =
       get_cpuid_info(vendor_id, family, model, device_id, stepping);
 
-  // Create CPU device for each logical processor
+  // Group logical processors by physical package (socket). For each socket,
+  // pick the representative entry with the lowest APIC ID — this is the
+  // bootstrap processor convention used by firmware to represent the package.
+  std::map<int, const ProcCpuInfo *> socket_rep;
   for (const auto &proc_info : proc_cpus) {
+    auto it = socket_rep.find(proc_info.physical_id);
+    if (it == socket_rep.end() || proc_info.apic_id < it->second->apic_id) {
+      socket_rep[proc_info.physical_id] = &proc_info;
+    }
+  }
+
+  // Create one CPU device per physical socket using the representative entry.
+  for (const auto &kv : socket_rep) {
+    const ProcCpuInfo *rep = kv.second;
     amdcuid_cpu_info info{};
     std::memset(&info.header, 0, sizeof(info.header));
 
-    // Set device type
     info.header.device_type = AMDCUID_DEVICE_TYPE_CPU;
 
-    // Fill CPU fields per CUID design spec
     if (cpuid_available) {
       info.header.fields.cpu.vendor_id = vendor_id;
       info.header.fields.cpu.family = family;
@@ -219,31 +230,26 @@ amdcuid_status_t CuidCpu::discover(std::vector<DevicePtr> &cpus) {
       info.header.fields.cpu.device_id = device_id;
       info.header.fields.cpu.revision_id = stepping;
     } else {
-      // Fallback to /proc/cpuinfo values
-      info.header.fields.cpu.vendor_id = proc_info.is_amd ? 0x1022 : 0x8086;
-      info.header.fields.cpu.family = static_cast<uint16_t>(proc_info.family);
-      info.header.fields.cpu.model = static_cast<uint16_t>(proc_info.model);
+      info.header.fields.cpu.vendor_id = rep->is_amd ? 0x1022 : 0x8086;
+      info.header.fields.cpu.family = static_cast<uint16_t>(rep->family);
+      info.header.fields.cpu.model = static_cast<uint16_t>(rep->model);
       info.header.fields.cpu.device_id =
-          static_cast<uint16_t>((proc_info.family << 8) | proc_info.model);
-      info.header.fields.cpu.revision_id =
-          static_cast<uint8_t>(proc_info.stepping);
+          static_cast<uint16_t>((rep->family << 8) | rep->model);
+      info.header.fields.cpu.revision_id = static_cast<uint8_t>(rep->stepping);
     }
 
-    // UnitID from APIC ID (from /proc/cpuinfo, similar to MADT)
-    info.header.fields.cpu.unit_id = static_cast<uint16_t>(proc_info.apic_id);
+    // unit_id is the lowest APIC ID in this package — the bootstrap processor
+    // representative used by firmware to identify the socket.
+    info.header.fields.cpu.unit_id = static_cast<uint16_t>(rep->apic_id);
+    info.header.fields.cpu.physical_id = static_cast<uint16_t>(kv.first);
+    // core is not meaningful at socket granularity
+    info.header.fields.cpu.core = 0;
 
-    // Core and physical_id from /proc/cpuinfo
-    info.header.fields.cpu.core = static_cast<uint16_t>(proc_info.core_id);
-    info.header.fields.cpu.physical_id =
-        static_cast<uint16_t>(proc_info.physical_id);
-
-    // Store the sysfs device path using the logical processor number
-    // (not the APIC ID, which may differ on SMT systems)
+    // device_node points to the representative logical CPU's sysfs path.
     info.device_node =
-        "/sys/devices/system/cpu/cpu" + std::to_string(proc_info.processor);
+        "/sys/devices/system/cpu/cpu" + std::to_string(rep->processor);
 
-    auto cpu = std::make_shared<CuidCpu>(info);
-    cpus.emplace_back(cpu);
+    cpus.emplace_back(std::make_shared<CuidCpu>(info));
   }
 
   return AMDCUID_STATUS_SUCCESS;
@@ -362,45 +368,48 @@ static bool try_read_ppin(uint64_t &ppin, uint32_t core_id) {
 }
 
 /**
- * @brief Get hardware fingerprint for CPU, optionally with ACPI MADT data
+ * @brief Get hardware fingerprint for CPU at socket granularity.
  *
- * Requires root privileges for:
- * - ACPI MADT parsing (for processor UID)
- * - PPIN reading (from MSR)
+ * Priority:
+ * 1. PPIN (per-socket eFuse serial, requires root + firmware enablement)
+ * 2. SMBIOS system uuid + physical_id (platform-level, requires root)
+ *
+ * Both tiers produce a per-socket fingerprint consistent with the spec's
+ * intent that CPU identity is tied to the physical package, not logical cores.
  */
 amdcuid_status_t
 CuidCpu::get_hardware_fingerprint(uint64_t &fingerprint) const {
-  // Try to get PPIN (Protected Processor Inventory Number) if available
+  // PPIN is an eFuse-burned per-socket serial number — the spec's primary
+  // identifier. The core argument only selects which MSR fd to open.
   uint64_t ppin = 0;
-  if (try_read_ppin(ppin, m_info.header.fields.cpu.core)) {
-    fingerprint = ppin; // Use PPIN as primary fingerprint if available
+  if (try_read_ppin(ppin, m_info.header.fields.cpu.unit_id)) {
+    fingerprint = ppin;
     return AMDCUID_STATUS_SUCCESS;
   }
 
-  // Try to get processor UID from ACPI MADT table
-  // This requires root to read /sys/firmware/acpi/tables/APIC
-  std::vector<AcpiCpuInfo> acpi_cpus;
-  amdcuid_status_t status = AcpiParser::parse_madt(acpi_cpus);
-
-  if (status == AMDCUID_STATUS_SUCCESS) {
-    // Find matching CPU by APIC ID
-    uint32_t target_apic_id = m_info.header.fields.cpu.unit_id;
-    for (const auto &acpi_info : acpi_cpus) {
-      if (acpi_info.apic_id == target_apic_id) {
-        // Use processor UID from ACPI as fingerprint
-        fingerprint = static_cast<uint64_t>(acpi_info.processor_uid) |
-                      (static_cast<uint64_t>(acpi_info.apic_id) << 32);
-        return AMDCUID_STATUS_SUCCESS;
-      }
-    }
+  // Fallback: SMBIOS system uuid hashed with the socket index (physical_id).
+  // physical_id combined with the platform uuid uniquely identifies
+  // "socket N on this board" for per-package scope.
+  uint8_t smbios_uuid[16] = {};
+  amdcuid_status_t status = SmbiosUtil::get_system_uuid(smbios_uuid);
+  if (status != AMDCUID_STATUS_SUCCESS) {
+    return status;
   }
 
-  // Fallback: Use combination of APIC ID and core/physical_id
-  fingerprint =
-      static_cast<uint64_t>(m_info.header.fields.cpu.core) |
-      (static_cast<uint64_t>(m_info.header.fields.cpu.unit_id) << 16) |
-      (static_cast<uint64_t>(m_info.header.fields.cpu.physical_id) << 32);
+  // Append physical_id as little-endian uint16_t so each socket on the same
+  // board produces distinct fingerprint.
+  uint16_t phys_id = m_info.header.fields.cpu.physical_id;
+  uint8_t input[18];
+  std::memcpy(input, smbios_uuid, 16);
+  std::memcpy(input + 16, &phys_id, sizeof(phys_id));
 
+  uint8_t digest[32];
+  status = sha256_unkeyed(input, sizeof(input), digest);
+  if (status != AMDCUID_STATUS_SUCCESS) {
+    return status;
+  }
+
+  std::memcpy(&fingerprint, digest, sizeof(fingerprint));
   return AMDCUID_STATUS_SUCCESS;
 }
 
@@ -418,9 +427,8 @@ amdcuid_status_t CuidCpu::get_primary_cuid(amdcuid_primary_id &id) const {
 
     CuidFileEntry entry;
 
-    // First, try lookup by device_node which is unique per logical CPU
-    // (package_core_id is not unique on SMT systems where sibling threads
-    // share the same physical_id:core_id)
+    // Primary lookup: device_node points to the representative logical CPU
+    // sysfs path for this socket (set during discover()).
     if (!m_info.device_node.empty()) {
       status = primary_file.find_by_device_node(m_info.device_node, entry);
       if (status == AMDCUID_STATUS_SUCCESS && entry.is_temporary == false) {
@@ -431,33 +439,27 @@ amdcuid_status_t CuidCpu::get_primary_cuid(amdcuid_primary_id &id) const {
       }
     }
 
-    // Fallback: try lookup by package_core_id for backward compatibility
-    // with files that don't have device_node for CPU entries
-    std::string package_core_id =
-        std::to_string(m_info.header.fields.cpu.physical_id) + ":" +
-        std::to_string(m_info.header.fields.cpu.core);
-    status = primary_file.find_by_package_core_id(package_core_id, entry);
+    status = primary_file.find_by_package_id(
+        m_info.header.fields.cpu.physical_id, entry);
     if (status == AMDCUID_STATUS_SUCCESS && entry.is_temporary == false) {
       id.UUIDv8_representation = entry.primary_cuid;
       CuidUtilities::remove_UUIDv8_bits(&id.UUIDv8_representation, id.raw_bits);
       return AMDCUID_STATUS_SUCCESS;
     }
 
-    // Get hardware fingerprint (PPIN, ACPI UID, or fallback)
+    // Get hardware fingerprint (PPIN or SMBIOS serial + socket index)
     status = get_hardware_fingerprint(fingerprint);
   }
   if (geteuid() != 0 || status != AMDCUID_STATUS_SUCCESS) {
-    // if hardware fingerprint is not available, use physical_id + core +
-    // machine_id as fallback, but set a flag bit to indicate it's not a true
-    // hardware fingerprint
-    std::ifstream machine_id_file("/etc/machine-id");
-    if (!machine_id_file.is_open()) {
+    // Non-root or fingerprint unavailable: use socket index + machine-id as
+    // a stable but non-hardware fallback, flagged as temporary.
+    std::string socket_id =
+        "socket:" + std::to_string(m_info.header.fields.cpu.physical_id);
+    amdcuid_status_t fb_status =
+        CuidUtilities::make_fallback_fingerprint(socket_id, fingerprint);
+    if (fb_status != AMDCUID_STATUS_SUCCESS) {
       return AMDCUID_STATUS_HW_FINGERPRINT_NOT_FOUND;
     }
-    std::string physical_core_id =
-        std::to_string(m_info.header.fields.cpu.physical_id) + ":" +
-        std::to_string(m_info.header.fields.cpu.core);
-    CuidUtilities::make_fallback_fingerprint(physical_core_id, fingerprint);
     temp = true;
   }
 

--- a/projects/cuid/lib/src/cuid_device.cc
+++ b/projects/cuid/lib/src/cuid_device.cc
@@ -98,38 +98,30 @@ amdcuid_status_t CuidDevice::get_derived_cuid(amdcuid_derived_id &id,
         }
       }
       break;
-    case AMDCUID_DEVICE_TYPE_CPU:
-      // search by device_node first (unique per logical CPU),
-      // then fall back to package_core_id for backward compatibility
-      {
-        auto cpu = reinterpret_cast<CuidCpu *>(const_cast<CuidDevice *>(this));
-        if (cpu) {
-          // Try device_node first - unique per logical CPU on SMT systems
-          std::string device_path;
-          if (cpu->get_device_path(device_path) == AMDCUID_STATUS_SUCCESS &&
-              !device_path.empty()) {
-            CuidFileEntry entry;
-            status = derived_file.find_by_device_node(device_path, entry);
-            if (status == AMDCUID_STATUS_SUCCESS) {
-              build_derived_id_from_file_entry(entry, id);
-              return AMDCUID_STATUS_SUCCESS;
-            }
-          }
-          // Fallback: package_core_id (not unique on SMT, but needed
-          // for backward compatibility with old CUID files)
-          const auto &info = cpu->get_info();
-          std::string core_id =
-              std::to_string(info.header.fields.cpu.physical_id) + ":" +
-              std::to_string(info.header.fields.cpu.core);
+    case AMDCUID_DEVICE_TYPE_CPU: {
+      auto cpu = reinterpret_cast<CuidCpu *>(const_cast<CuidDevice *>(this));
+      if (cpu) {
+        // Try device_node first - unique per logical CPU on SMT systems
+        std::string device_path;
+        if (cpu->get_device_path(device_path) == AMDCUID_STATUS_SUCCESS &&
+            !device_path.empty()) {
           CuidFileEntry entry;
-          status = derived_file.find_by_package_core_id(core_id, entry);
+          status = derived_file.find_by_device_node(device_path, entry);
           if (status == AMDCUID_STATUS_SUCCESS) {
             build_derived_id_from_file_entry(entry, id);
             return AMDCUID_STATUS_SUCCESS;
           }
         }
+        const auto &info = cpu->get_info();
+        CuidFileEntry entry;
+        status = derived_file.find_by_package_id(
+            info.header.fields.cpu.physical_id, entry);
+        if (status == AMDCUID_STATUS_SUCCESS) {
+          build_derived_id_from_file_entry(entry, id);
+          return AMDCUID_STATUS_SUCCESS;
+        }
       }
-      break;
+    } break;
     case AMDCUID_DEVICE_TYPE_NIC:
       // search by device node
       {
@@ -174,7 +166,7 @@ amdcuid_status_t CuidDevice::get_derived_cuid(amdcuid_derived_id &id,
   // check the temporary bit in the primary CUID to determine whether to use the
   // real HMAC key or the temp key for derived CUID generation
   bool temp = primary.raw_bits[14] &
-              0x04; // check the temp indicator bit in the reserved bits
+              0x20; // check the temp indicator bit in the reserved bits
   if (temp) {
     // machine id is what needs to be protected and under HMAC system, message
     // is not guaranteed protection when output is well known so use machine id
@@ -213,7 +205,6 @@ amdcuid_status_t CuidDevice::is_temporary_cuid(bool *is_temp) const {
   if (!is_temp) {
     return AMDCUID_STATUS_INVALID_ARGUMENT;
   }
-  *is_temp = false;
   // Check the temporary bit in the primary CUID to determine if the CUID is
   // temporary
   amdcuid_primary_id primary;

--- a/projects/cuid/lib/src/cuid_device_manager.cc
+++ b/projects/cuid/lib/src/cuid_device_manager.cc
@@ -234,20 +234,8 @@ void _convert_entry_to_device(CuidFileEntry &entry, DevicePtr &device) {
     cpu_info.header.fields.cpu.device_id = entry.device_id;
     cpu_info.header.fields.cpu.revision_id = entry.revision_id;
     cpu_info.header.fields.cpu.unit_id = entry.unit_id;
-
-    // Split package_core_id by colon into package and core
-    uint16_t package = 0;
-    uint16_t core = 0;
-    size_t colon_pos = entry.package_core_id.find(':');
-    if (colon_pos != std::string::npos) {
-      package = static_cast<uint16_t>(
-          std::stoul(entry.package_core_id.substr(0, colon_pos)));
-      core = static_cast<uint16_t>(
-          std::stoul(entry.package_core_id.substr(colon_pos + 1)));
-    }
-
-    cpu_info.header.fields.cpu.physical_id = package;
-    cpu_info.header.fields.cpu.core = core;
+    cpu_info.header.fields.cpu.physical_id = entry.package_id;
+    cpu_info.header.fields.cpu.core = entry.core_id;
     // Restore device_node for unique CPU identification (needed for SMT)
     cpu_info.device_node = entry.device_node;
     device = std::make_shared<CuidCpu>(cpu_info);

--- a/projects/cuid/lib/src/cuid_file.cc
+++ b/projects/cuid/lib/src/cuid_file.cc
@@ -577,47 +577,50 @@ amdcuid_status_t CuidFile::save() {
 
       // Write hardware fingerprint (privileged file only)
       if (is_privileged_) {
-        file << "hardware_fingerprint=" << std::hex << std::setw(16)
+        file << "hardware_fingerprint=0x" << std::hex << std::setw(16)
              << std::setfill('0') << entry.hardware_fingerprint << "\n";
       }
 
       // Write device-specific fields
       if (entry.vendor_id != 0) {
-        file << "vendor_id=" << std::hex << std::setw(4) << std::setfill('0')
+        file << "vendor_id=0x" << std::hex << std::setw(4) << std::setfill('0')
              << entry.vendor_id << "\n";
       }
       if (entry.device_id != 0) {
-        file << "device_id=" << std::hex << std::setw(4) << std::setfill('0')
+        file << "device_id=0x" << std::hex << std::setw(4) << std::setfill('0')
              << entry.device_id << "\n";
       }
       if (entry.revision_id != 0) {
-        file << "revision_id=" << std::hex << std::setw(2) << std::setfill('0')
-             << static_cast<uint16_t>(entry.revision_id) << "\n";
+        file << "revision_id=0x" << std::hex << std::setw(2)
+             << std::setfill('0') << static_cast<uint16_t>(entry.revision_id)
+             << "\n";
       }
       if (entry.family != 0) {
-        file << "family=" << std::hex << std::setw(4) << std::setfill('0')
+        file << "family=0x" << std::hex << std::setw(4) << std::setfill('0')
              << entry.family << "\n";
       }
       if (entry.model != 0) {
-        file << "model=" << std::hex << std::setw(4) << std::setfill('0')
+        file << "model=0x" << std::hex << std::setw(4) << std::setfill('0')
              << entry.model << "\n";
       }
       if (entry.pci_class != 0) {
-        file << "pci_class=" << std::hex << std::setw(4) << std::setfill('0')
+        file << "pci_class=0x" << std::hex << std::setw(4) << std::setfill('0')
              << entry.pci_class << "\n";
       }
-      if (entry.unit_id != 0) {
-        file << "unit_id=" << std::hex << std::setw(4) << std::setfill('0')
+      if (entry.unit_id != std::numeric_limits<uint16_t>::max()) {
+        file << "unit_id=0x" << std::hex << std::setw(4) << std::setfill('0')
              << entry.unit_id << "\n";
       }
       if (!entry.device_node.empty()) {
         file << "device_node=" << entry.device_node << "\n";
       }
       if (entry.package_id != std::numeric_limits<uint16_t>::max()) {
-        file << "package_id=" << entry.package_id << "\n";
+        file << "package_id=0x" << std::hex << std::setw(4) << std::setfill('0')
+             << entry.package_id << "\n";
       }
       if (entry.core_id != std::numeric_limits<uint16_t>::max()) {
-        file << "core_id=" << entry.core_id << "\n";
+        file << "core_id=0x" << std::hex << std::setw(4) << std::setfill('0')
+             << entry.core_id << "\n";
       }
       if (!entry.bdf.empty()) {
         file << "bdf=" << entry.bdf << "\n";

--- a/projects/cuid/lib/src/cuid_file.cc
+++ b/projects/cuid/lib/src/cuid_file.cc
@@ -37,6 +37,7 @@
 #include <fcntl.h>
 #include <fstream>
 #include <iomanip>
+#include <limits>
 #include <sstream>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -456,8 +457,12 @@ amdcuid_status_t CuidFile::load() {
           current_entry.derived_cuid = string_to_cuid(value);
         } else if (key == "device_node") {
           current_entry.device_node = value;
-        } else if (key == "package_core_id") {
-          current_entry.package_core_id = value;
+        } else if (key == "package_id") {
+          current_entry.package_id =
+              static_cast<uint16_t>(std::stoul(value, nullptr, 16));
+        } else if (key == "core_id") {
+          current_entry.core_id =
+              static_cast<uint16_t>(std::stoul(value, nullptr, 16));
         } else if (key == "bdf") {
           current_entry.bdf = value;
         } else if (key == "mac_address") {
@@ -608,8 +613,11 @@ amdcuid_status_t CuidFile::save() {
       if (!entry.device_node.empty()) {
         file << "device_node=" << entry.device_node << "\n";
       }
-      if (!entry.package_core_id.empty()) {
-        file << "package_core_id=" << entry.package_core_id << "\n";
+      if (entry.package_id != std::numeric_limits<uint16_t>::max()) {
+        file << "package_id=" << entry.package_id << "\n";
+      }
+      if (entry.core_id != std::numeric_limits<uint16_t>::max()) {
+        file << "core_id=" << entry.core_id << "\n";
       }
       if (!entry.bdf.empty()) {
         file << "bdf=" << entry.bdf << "\n";
@@ -697,11 +705,10 @@ amdcuid_status_t CuidFile::find_by_bdf(const std::string &bdf,
   return AMDCUID_STATUS_DEVICE_NOT_FOUND;
 }
 
-amdcuid_status_t
-CuidFile::find_by_package_core_id(const std::string &package_core_id,
-                                  CuidFileEntry &entry) const {
+amdcuid_status_t CuidFile::find_by_package_id(uint16_t package_id,
+                                              CuidFileEntry &entry) const {
   for (const auto &e : entries_) {
-    if (e.package_core_id == package_core_id) {
+    if (e.package_id == package_id) {
       entry = e;
       return AMDCUID_STATUS_SUCCESS;
     }
@@ -847,20 +854,18 @@ generate_from_devices(const std::vector<std::shared_ptr<CuidDevice>> &devices,
         entry.family = info.header.fields.cpu.family;
         entry.model = info.header.fields.cpu.model;
         entry.unit_id = info.header.fields.cpu.unit_id;
-        // Format: package:core
-        entry.package_core_id =
-            std::to_string(info.header.fields.cpu.physical_id) + ":" +
-            std::to_string(info.header.fields.cpu.core);
+        entry.package_id = info.header.fields.cpu.physical_id;
+        entry.core_id = info.header.fields.cpu.core;
         // Store device path (unique per logical CPU, needed for SMT)
         std::string cpu_device_path;
         if (cpu->get_device_path(cpu_device_path) == AMDCUID_STATUS_SUCCESS) {
           entry.device_node = cpu_device_path;
         }
         // if temp CUID, make the fallback fingerprint based on the CPU's
-        // package:core
+        // package
         if (is_temporary) {
-          CuidUtilities::make_fallback_fingerprint(entry.package_core_id,
-                                                   entry.hardware_fingerprint);
+          CuidUtilities::make_fallback_fingerprint(
+              std::to_string(entry.package_id), entry.hardware_fingerprint);
         }
       }
       break;

--- a/projects/cuid/lib/src/cuid_file.h
+++ b/projects/cuid/lib/src/cuid_file.h
@@ -145,10 +145,10 @@ struct CuidFileEntry {
   uint8_t revision_id = 0;
 
   // Device-specific information
-  uint16_t family = 0;     // For CPU
-  uint16_t model = 0;      // For CPU
-  uint16_t pci_class = 0;  // For PCIe devices (GPU, NIC)
-  uint16_t unit_id = 0;    // For CPU and GPU
+  uint16_t family = 0;    // For CPU
+  uint16_t model = 0;     // For CPU
+  uint16_t pci_class = 0; // For PCIe devices (GPU, NIC)
+  uint16_t unit_id = std::numeric_limits<uint16_t>::max(); // For CPU and GPU
   std::string device_node; // For GPU: /sys/class/drm/renderD128, NIC:
                            // /sys/class/net/eth0
   uint16_t package_id =

--- a/projects/cuid/lib/src/cuid_file.h
+++ b/projects/cuid/lib/src/cuid_file.h
@@ -29,6 +29,7 @@
 #include <cstring>
 #include <ctime>
 #include <fcntl.h>
+#include <limits>
 #include <map>
 #include <memory>
 #include <string>
@@ -144,15 +145,20 @@ struct CuidFileEntry {
   uint8_t revision_id = 0;
 
   // Device-specific information
-  uint16_t family = 0;         // For CPU
-  uint16_t model = 0;          // For CPU
-  uint16_t pci_class = 0;      // For PCIe devices (GPU, NIC)
-  uint16_t unit_id = 0;        // For CPU and GPU
-  std::string device_node;     // For GPU: /sys/class/drm/renderD128, NIC:
-                               // /sys/class/net/eth0
-  std::string package_core_id; // For CPU: "0:0" (package:core)
-  std::string bdf;             // PCIe Bus:Device.Function
-  std::string mac_address;     // For NIC
+  uint16_t family = 0;     // For CPU
+  uint16_t model = 0;      // For CPU
+  uint16_t pci_class = 0;  // For PCIe devices (GPU, NIC)
+  uint16_t unit_id = 0;    // For CPU and GPU
+  std::string device_node; // For GPU: /sys/class/drm/renderD128, NIC:
+                           // /sys/class/net/eth0
+  uint16_t package_id =
+      std::numeric_limits<uint16_t>::max(); // For CPU, aka physical id, akin to
+                                            // socket id
+  uint16_t core_id =
+      std::numeric_limits<uint16_t>::max(); // For CPU, aka core id within the
+                                            // package
+  std::string bdf;                          // PCIe Bus:Device.Function
+  std::string mac_address;                  // For NIC
 
   bool is_temporary = false; // Indicates if the CUID is temporary (not derived
                              // from a true hardware fingerprint)
@@ -190,8 +196,8 @@ public:
                                        CuidFileEntry &entry) const;
   amdcuid_status_t find_by_bdf(const std::string &bdf,
                                CuidFileEntry &entry) const;
-  amdcuid_status_t find_by_package_core_id(const std::string &package_core_id,
-                                           CuidFileEntry &entry) const;
+  amdcuid_status_t find_by_package_id(uint16_t package_id,
+                                      CuidFileEntry &entry) const;
   amdcuid_status_t find_by_device_type(amdcuid_device_type_t device_type,
                                        CuidFileEntry &entry) const;
   amdcuid_status_t find_by_derived_cuid(const amdcuid_id_t &derived_cuid,

--- a/projects/cuid/lib/src/cuid_util.cc
+++ b/projects/cuid/lib/src/cuid_util.cc
@@ -388,20 +388,14 @@ CuidUtilities::make_fallback_fingerprint(const std::string &id,
   std::string system_id;
   amdcuid_status_t status = AMDCUID_STATUS_SUCCESS;
 
-  if (geteuid() == 0) {
-    // If running as root, get platform serial number
-    status = SmbiosUtil::get_system_serial(system_id);
-  }
-  if (geteuid() != 0 || system_id.empty() || status != AMDCUID_STATUS_SUCCESS) {
-    std::ifstream machine_id_file("/etc/machine-id");
-    if (machine_id_file.is_open())
-      std::getline(machine_id_file, system_id);
+  std::ifstream machine_id_file("/etc/machine-id");
+  if (machine_id_file.is_open())
+    std::getline(machine_id_file, system_id);
 
-    if (system_id.empty()) {
-      std::ifstream hostname_file("/etc/hostname");
-      if (hostname_file.is_open())
-        std::getline(hostname_file, system_id);
-    }
+  if (system_id.empty()) {
+    std::ifstream hostname_file("/etc/hostname");
+    if (hostname_file.is_open())
+      std::getline(hostname_file, system_id);
   }
 
   std::string id_hex;


### PR DESCRIPTION
## Motivation
CPU fingerprints were being generated incorrectly at the core level rather than at the package level which created fingerprints that were highly simplistic.

## Technical Details
Redesigned finger print formulation to correctly represent CPUs at the package level rather than at the logical core level.

## JIRA ID
JIRA ID : AILITOOLS-230

## Test Plan
Ran unit tests to ensure no regressions and confirmed that fingerprints were being created at the package level rather than logical core level.

## Test Result
Unit tests:
<img width="583" height="64" alt="image" src="https://github.com/user-attachments/assets/85bfeee2-73ad-41dd-9b6b-f880814ceb80" />