### PR TITLE
feat(rocprofiler-sdk): resolve rocattach register symbols from target ELF

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
@@ -238,13 +238,8 @@ resolve_attach_tid(pid_t pid)
 }
 
 rocattach_status_t
-validate_target_tool_path(pid_t pid, std::string_view tool_lib_path)
+validate_target_absolute_tool_path(pid_t pid, const std::filesystem::path& tool_path)
 {
-    auto tool_path = std::filesystem::path{tool_lib_path};
-    if(tool_path.empty()) return ROCATTACH_STATUS_SUCCESS;
-
-    if(!tool_path.is_absolute()) return ROCATTACH_STATUS_SUCCESS;
-
     auto target_path =
         std::filesystem::path{fmt::format("/proc/{}/root", pid)} / tool_path.relative_path();
     std::error_code ec;
@@ -256,12 +251,12 @@ validate_target_tool_path(pid_t pid, std::string_view tool_lib_path)
             // restrictions, keep attachment best-effort and let target-side dlopen
             // report the final load failure.
             ROCP_WARNING << "[rocprofiler-sdk-rocattach] Could not validate tool library path '"
-                         << tool_lib_path << "' at " << target_path.string()
+                         << tool_path.string() << "' at " << target_path.string()
                          << " from the target process mount namespace: " << ec.message();
             return ROCATTACH_STATUS_SUCCESS;
         }
 
-        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Tool library path '" << tool_lib_path
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Tool library path '" << tool_path.string()
                    << "' is absolute but is not visible at " << target_path.string()
                    << " from the target process mount namespace. Attachment requires "
                       "ROCPROF_ATTACH_TOOL_LIBRARY to name a library path that target-side "
@@ -277,12 +272,12 @@ validate_target_tool_path(pid_t pid, std::string_view tool_lib_path)
             // restrictions, keep attachment best-effort and let target-side dlopen
             // report the final load failure.
             ROCP_WARNING << "[rocprofiler-sdk-rocattach] Could not validate tool library path '"
-                         << tool_lib_path << "' at " << target_path.string()
+                         << tool_path.string() << "' at " << target_path.string()
                          << " from the target process mount namespace: " << ec.message();
             return ROCATTACH_STATUS_SUCCESS;
         }
 
-        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Tool library path '" << tool_lib_path
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Tool library path '" << tool_path.string()
                    << "' is absolute but does not refer to a regular file at "
                    << target_path.string() << " from the target process mount namespace.";
         return ROCATTACH_STATUS_ERROR_INVALID_ARGUMENT;
@@ -325,10 +320,23 @@ setup(int pid)
     }
     const char* tool_lib_path = tool_lib_path_env.c_str();
     ROCP_TRACE << "[rocprofiler-sdk-rocattach] Tool library path: " << tool_lib_path;
-    status = validate_target_tool_path(pid, tool_lib_path_env);
-    if(status != ROCATTACH_STATUS_SUCCESS)
+
+    auto tool_path = std::filesystem::path{tool_lib_path_env};
+    if(tool_path.empty())
     {
-        return status;
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Tool library path must not be empty.";
+        return ROCATTACH_STATUS_ERROR_INVALID_ARGUMENT;
+    }
+
+    // Bare or relative library names must be resolved by dlopen in the target
+    // process using the target's loader search path and working directory.
+    if(tool_path.is_absolute())
+    {
+        status = validate_target_absolute_tool_path(pid, tool_path);
+        if(status != ROCATTACH_STATUS_SUCCESS)
+        {
+            return status;
+        }
     }
 
     auto*      sessions = CHECK_NOTNULL(get_sessions());

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
@@ -238,7 +238,7 @@ resolve_attach_tid(pid_t pid)
 }
 
 rocattach_status_t
-validate_target_tool_path(pid_t pid, const std::string& tool_lib_path)
+validate_target_tool_path(pid_t pid, std::string_view tool_lib_path)
 {
     auto tool_path = std::filesystem::path{tool_lib_path};
     if(tool_path.empty()) return ROCATTACH_STATUS_SUCCESS;
@@ -261,11 +261,11 @@ validate_target_tool_path(pid_t pid, const std::string& tool_lib_path)
             return ROCATTACH_STATUS_SUCCESS;
         }
 
-        ROCP_WARNING << "[rocprofiler-sdk-rocattach] Tool library path '" << tool_lib_path
-                     << "' is absolute but is not visible at " << target_path.string()
-                     << " from the target process mount namespace. Attachment requires "
-                        "ROCPROF_ATTACH_TOOL_LIBRARY to name a library path that target-side "
-                        "dlopen can resolve.";
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Tool library path '" << tool_lib_path
+                   << "' is absolute but is not visible at " << target_path.string()
+                   << " from the target process mount namespace. Attachment requires "
+                      "ROCPROF_ATTACH_TOOL_LIBRARY to name a library path that target-side "
+                      "dlopen can resolve.";
         return ROCATTACH_STATUS_ERROR_INVALID_ARGUMENT;
     }
 
@@ -282,9 +282,9 @@ validate_target_tool_path(pid_t pid, const std::string& tool_lib_path)
             return ROCATTACH_STATUS_SUCCESS;
         }
 
-        ROCP_WARNING << "[rocprofiler-sdk-rocattach] Tool library path '" << tool_lib_path
-                     << "' is absolute but does not refer to a regular file at "
-                     << target_path.string() << " from the target process mount namespace.";
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Tool library path '" << tool_lib_path
+                   << "' is absolute but does not refer to a regular file at "
+                   << target_path.string() << " from the target process mount namespace.";
         return ROCATTACH_STATUS_ERROR_INVALID_ARGUMENT;
     }
 
@@ -306,10 +306,23 @@ setup(int pid)
     // ROCPROF_ATTACH_TOOL_LIBRARY override in a secure-execution context (setuid/setgid,
     // file capabilities, etc.), so an unprivileged user cannot cause a privileged attach
     // helper to inject an arbitrary library.
-    auto        tool_lib_path_env = rocprofiler::common::is_at_secure()
-                                        ? std::string{"librocprofiler-sdk-tool.so"}
-                                        : rocprofiler::common::get_env("ROCPROF_ATTACH_TOOL_LIBRARY",
-                                                                "librocprofiler-sdk-tool.so");
+    constexpr auto default_tool_lib_path = std::string_view{"librocprofiler-sdk-tool.so"};
+    auto           tool_lib_path_env     = std::string{default_tool_lib_path};
+    auto           tool_lib_path_override =
+        rocprofiler::common::get_env_optional("ROCPROF_ATTACH_TOOL_LIBRARY");
+    if(rocprofiler::common::is_at_secure())
+    {
+        if(tool_lib_path_override)
+        {
+            ROCP_WARNING << "[rocprofiler-sdk-rocattach] Ignoring ROCPROF_ATTACH_TOOL_LIBRARY "
+                            "override in secure-execution context; using generic tool library "
+                         << default_tool_lib_path;
+        }
+    }
+    else if(tool_lib_path_override)
+    {
+        tool_lib_path_env = *tool_lib_path_override;
+    }
     const char* tool_lib_path     = tool_lib_path_env.c_str();
     ROCP_TRACE << "[rocprofiler-sdk-rocattach] Tool library path: " << tool_lib_path;
     status = validate_target_tool_path(pid, tool_lib_path_env);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
@@ -299,6 +299,25 @@ setup(int pid)
                   "for pid "
                << pid;
 
+    auto status = ROCATTACH_STATUS_SUCCESS;
+
+    // Build the tool library path before ptrace setup so invalid absolute paths
+    // fail before modifying target process state. Do not honor the user-controllable
+    // ROCPROF_ATTACH_TOOL_LIBRARY override in a secure-execution context (setuid/setgid,
+    // file capabilities, etc.), so an unprivileged user cannot cause a privileged attach
+    // helper to inject an arbitrary library.
+    auto        tool_lib_path_env = rocprofiler::common::is_at_secure()
+                                        ? std::string{"librocprofiler-sdk-tool.so"}
+                                        : rocprofiler::common::get_env("ROCPROF_ATTACH_TOOL_LIBRARY",
+                                                                "librocprofiler-sdk-tool.so");
+    const char* tool_lib_path     = tool_lib_path_env.c_str();
+    ROCP_TRACE << "[rocprofiler-sdk-rocattach] Tool library path: " << tool_lib_path;
+    status = validate_target_tool_path(pid, tool_lib_path_env);
+    if(status != ROCATTACH_STATUS_SUCCESS)
+    {
+        return status;
+    }
+
     auto*      sessions = CHECK_NOTNULL(get_sessions());
     session_t* session;
     {
@@ -328,7 +347,6 @@ setup(int pid)
         sessions->emplace(pid, target_tid);
         session = &(sessions->at(pid).session);
     }
-    auto status = ROCATTACH_STATUS_SUCCESS;
 
     ROCP_TRACE << "[rocprofiler-sdk-rocattach] Attempting attachment to pid " << pid;
     status = session->attach();
@@ -350,22 +368,7 @@ setup(int pid)
         return status;
     }
 
-    // Build and write tool library path to target process. Do not honor the
-    // user-controllable ROCPROF_ATTACH_TOOL_LIBRARY override in a secure-execution
-    // context (setuid/setgid, file capabilities, etc.), so an unprivileged user
-    // cannot cause a privileged attach helper to inject an arbitrary library.
-    auto        tool_lib_path_env = rocprofiler::common::is_at_secure()
-                                        ? std::string{"librocprofiler-sdk-tool.so"}
-                                        : rocprofiler::common::get_env("ROCPROF_ATTACH_TOOL_LIBRARY",
-                                                                "librocprofiler-sdk-tool.so");
-    const char* tool_lib_path     = tool_lib_path_env.c_str();
-    ROCP_TRACE << "[rocprofiler-sdk-rocattach] Tool library path: " << tool_lib_path;
-    status = validate_target_tool_path(pid, tool_lib_path_env);
-    if(status != ROCATTACH_STATUS_SUCCESS)
-    {
-        return status;
-    }
-
+    // Build and write tool library path to target process.
     size_t               tool_lib_path_len = strlen(tool_lib_path) + 1;
     std::vector<uint8_t> tool_lib_buffer(tool_lib_path, tool_lib_path + tool_lib_path_len);
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
@@ -252,6 +252,9 @@ validate_target_tool_path(pid_t pid, const std::string& tool_lib_path)
     {
         if(ec)
         {
+            // If host-side validation is blocked by procfs permissions or namespace
+            // restrictions, keep attachment best-effort and let target-side dlopen
+            // report the final load failure.
             ROCP_WARNING << "[rocprofiler-sdk-rocattach] Could not validate tool library path '"
                          << tool_lib_path << "' at " << target_path.string()
                          << " from the target process mount namespace: " << ec.message();
@@ -270,6 +273,9 @@ validate_target_tool_path(pid_t pid, const std::string& tool_lib_path)
     {
         if(ec)
         {
+            // If host-side validation is blocked by procfs permissions or namespace
+            // restrictions, keep attachment best-effort and let target-side dlopen
+            // report the final load failure.
             ROCP_WARNING << "[rocprofiler-sdk-rocattach] Could not validate tool library path '"
                          << tool_lib_path << "' at " << target_path.string()
                          << " from the target process mount namespace: " << ec.message();

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
@@ -323,7 +323,7 @@ setup(int pid)
     {
         tool_lib_path_env = *tool_lib_path_override;
     }
-    const char* tool_lib_path     = tool_lib_path_env.c_str();
+    const char* tool_lib_path = tool_lib_path_env.c_str();
     ROCP_TRACE << "[rocprofiler-sdk-rocattach] Tool library path: " << tool_lib_path;
     status = validate_target_tool_path(pid, tool_lib_path_env);
     if(status != ROCATTACH_STATUS_SUCCESS)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
@@ -237,6 +237,28 @@ resolve_attach_tid(pid_t pid)
     return -1;
 }
 
+void
+validate_target_tool_path(pid_t pid, const std::string& tool_lib_path)
+{
+    auto tool_path = std::filesystem::path{tool_lib_path};
+    if(tool_path.empty()) return;
+
+    if(!tool_path.is_absolute()) return;
+
+    auto target_path = std::filesystem::path{fmt::format("/proc/{}/root", pid)};
+    target_path += tool_path;
+    std::error_code ec;
+    if(!std::filesystem::exists(target_path, ec))
+    {
+        ROCP_WARNING << "[rocprofiler-sdk-rocattach] Tool library path '" << tool_lib_path
+                     << "' is absolute but is not visible at " << target_path.string()
+                     << " from the target process mount namespace. Attachment requires "
+                        "ROCPROF_ATTACH_TOOL_LIBRARY to name a library path that target-side "
+                        "dlopen can resolve.";
+        return;
+    }
+}
+
 rocattach_status_t
 setup(int pid)
 {
@@ -306,6 +328,7 @@ setup(int pid)
                                                                 "librocprofiler-sdk-tool.so");
     const char* tool_lib_path     = tool_lib_path_env.c_str();
     ROCP_TRACE << "[rocprofiler-sdk-rocattach] Tool library path: " << tool_lib_path;
+    validate_target_tool_path(pid, tool_lib_path_env);
 
     size_t               tool_lib_path_len = strlen(tool_lib_path) + 1;
     std::vector<uint8_t> tool_lib_buffer(tool_lib_path, tool_lib_path + tool_lib_path_len);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/rocattach.cpp
@@ -237,26 +237,52 @@ resolve_attach_tid(pid_t pid)
     return -1;
 }
 
-void
+rocattach_status_t
 validate_target_tool_path(pid_t pid, const std::string& tool_lib_path)
 {
     auto tool_path = std::filesystem::path{tool_lib_path};
-    if(tool_path.empty()) return;
+    if(tool_path.empty()) return ROCATTACH_STATUS_SUCCESS;
 
-    if(!tool_path.is_absolute()) return;
+    if(!tool_path.is_absolute()) return ROCATTACH_STATUS_SUCCESS;
 
-    auto target_path = std::filesystem::path{fmt::format("/proc/{}/root", pid)};
-    target_path += tool_path;
+    auto target_path =
+        std::filesystem::path{fmt::format("/proc/{}/root", pid)} / tool_path.relative_path();
     std::error_code ec;
     if(!std::filesystem::exists(target_path, ec))
     {
+        if(ec)
+        {
+            ROCP_WARNING << "[rocprofiler-sdk-rocattach] Could not validate tool library path '"
+                         << tool_lib_path << "' at " << target_path.string()
+                         << " from the target process mount namespace: " << ec.message();
+            return ROCATTACH_STATUS_SUCCESS;
+        }
+
         ROCP_WARNING << "[rocprofiler-sdk-rocattach] Tool library path '" << tool_lib_path
                      << "' is absolute but is not visible at " << target_path.string()
                      << " from the target process mount namespace. Attachment requires "
                         "ROCPROF_ATTACH_TOOL_LIBRARY to name a library path that target-side "
                         "dlopen can resolve.";
-        return;
+        return ROCATTACH_STATUS_ERROR_INVALID_ARGUMENT;
     }
+
+    if(!std::filesystem::is_regular_file(target_path, ec))
+    {
+        if(ec)
+        {
+            ROCP_WARNING << "[rocprofiler-sdk-rocattach] Could not validate tool library path '"
+                         << tool_lib_path << "' at " << target_path.string()
+                         << " from the target process mount namespace: " << ec.message();
+            return ROCATTACH_STATUS_SUCCESS;
+        }
+
+        ROCP_WARNING << "[rocprofiler-sdk-rocattach] Tool library path '" << tool_lib_path
+                     << "' is absolute but does not refer to a regular file at "
+                     << target_path.string() << " from the target process mount namespace.";
+        return ROCATTACH_STATUS_ERROR_INVALID_ARGUMENT;
+    }
+
+    return ROCATTACH_STATUS_SUCCESS;
 }
 
 rocattach_status_t
@@ -328,7 +354,11 @@ setup(int pid)
                                                                 "librocprofiler-sdk-tool.so");
     const char* tool_lib_path     = tool_lib_path_env.c_str();
     ROCP_TRACE << "[rocprofiler-sdk-rocattach] Tool library path: " << tool_lib_path;
-    validate_target_tool_path(pid, tool_lib_path_env);
+    status = validate_target_tool_path(pid, tool_lib_path_env);
+    if(status != ROCATTACH_STATUS_SUCCESS)
+    {
+        return status;
+    }
 
     size_t               tool_lib_path_len = strlen(tool_lib_path) + 1;
     std::vector<uint8_t> tool_lib_buffer(tool_lib_path, tool_lib_path + tool_lib_path_len);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
@@ -93,7 +93,11 @@ struct mapped_object_key
     uint32_t device_minor = 0;
     uint64_t inode        = 0;
 
-    bool operator==(const mapped_object_key&) const = default;
+    bool operator==(const mapped_object_key& rhs) const
+    {
+        return device_major == rhs.device_major && device_minor == rhs.device_minor &&
+               inode == rhs.inode;
+    }
 };
 
 struct mapped_object_key_hash
@@ -613,8 +617,6 @@ symbol_is_supported_function(const Elf64_Sym& sym)
 std::optional<uint64_t>
 lookup_symbol_from_sections(const target_elf& elf, std::string_view symbol_name)
 {
-    auto name = std::string{symbol_name};
-
     // Prefer section-backed .dynsym lookup when section headers are present;
     // sectionless files fall back to PT_DYNAMIC.
     for(const auto& section : elf.reader.sections)
@@ -622,18 +624,28 @@ lookup_symbol_from_sections(const target_elf& elf, std::string_view symbol_name)
         if(section == nullptr || section->get_type() != SHT_DYNSYM) continue;
 
         ELFIO::const_symbol_section_accessor symbols{elf.reader, section.get()};
-        if(symbols.get_symbols_num() > MAX_DYNAMIC_SYMBOLS) return std::nullopt;
+        auto                                 symbol_count = symbols.get_symbols_num();
+        if(symbol_count > MAX_DYNAMIC_SYMBOLS) return std::nullopt;
 
-        auto value = ELFIO::Elf64_Addr{0};
-        auto size  = ELFIO::Elf_Xword{0};
-        auto bind  = static_cast<unsigned char>(0);
-        auto type  = static_cast<unsigned char>(0);
-        auto index = ELFIO::Elf_Half{0};
-        auto other = static_cast<unsigned char>(0);
-        if(symbols.get_symbol(name, value, size, bind, type, index, other) &&
-           symbol_is_supported_function(bind, type, index, other))
+        for(ELFIO::Elf_Xword i = 0; i < symbol_count; ++i)
         {
-            return value;
+            auto name  = std::string{};
+            auto value = ELFIO::Elf64_Addr{0};
+            auto size  = ELFIO::Elf_Xword{0};
+            auto bind  = static_cast<unsigned char>(0);
+            auto type  = static_cast<unsigned char>(0);
+            auto index = ELFIO::Elf_Half{0};
+            auto other = static_cast<unsigned char>(0);
+
+            if(!symbols.get_symbol(i, name, value, size, bind, type, index, other))
+            {
+                continue;
+            }
+
+            if(name == symbol_name && symbol_is_supported_function(bind, type, index, other))
+            {
+                return value;
+            }
         }
     }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
@@ -27,12 +27,14 @@
 #include <fmt/format.h>
 
 #include <elf.h>
+#include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/sysmacros.h>
 #include <unistd.h>
 
 #include <algorithm>
 #include <cctype>
+#include <cerrno>
 #include <cstring>
 #include <exception>
 #include <fstream>
@@ -80,6 +82,47 @@ struct target_elf
     std::string             path          = {};
     std::vector<uint8_t>    data          = {};
     std::vector<Elf64_Phdr> load_segments = {};
+};
+
+class unique_fd
+{
+public:
+    explicit unique_fd(int fd)
+    : m_fd{fd}
+    {}
+
+    unique_fd(const unique_fd&) = delete;
+    unique_fd& operator=(const unique_fd&) = delete;
+
+    unique_fd(unique_fd&& other) noexcept
+    : m_fd{std::exchange(other.m_fd, -1)}
+    {}
+
+    unique_fd& operator=(unique_fd&& other) noexcept
+    {
+        if(this != &other)
+        {
+            reset();
+            m_fd = std::exchange(other.m_fd, -1);
+        }
+        return *this;
+    }
+
+    ~unique_fd() { reset(); }
+
+    int get() const { return m_fd; }
+
+    void reset()
+    {
+        if(m_fd >= 0)
+        {
+            ::close(m_fd);
+            m_fd = -1;
+        }
+    }
+
+private:
+    int m_fd = -1;
 };
 
 std::optional<uint64_t>
@@ -280,36 +323,84 @@ find_mapped_objects(pid_t pid, const std::string& library)
 }
 
 std::optional<std::vector<uint8_t>>
-read_file(const std::string& path)
+read_file_from_fd(int fd, const std::string& path, uint64_t size)
 {
-    auto input = std::ifstream{path, std::ios::binary};
-    if(!input) return std::nullopt;
-
-    input.seekg(0, std::ios::end);
-    auto size = input.tellg();
-    if(size <= 0) return std::nullopt;
-    if(static_cast<uint64_t>(size) > MAX_TARGET_ELF_SIZE)
+    if(size == 0 || size > MAX_TARGET_ELF_SIZE)
     {
         ROCP_ERROR << "[rocprofiler-sdk-rocattach] Refusing to read unusually large target ELF "
                    << path << " (" << size << " bytes)";
         return std::nullopt;
     }
-    input.seekg(0, std::ios::beg);
 
-    auto data = std::vector<uint8_t>(static_cast<size_t>(size));
-    if(!data.empty()) input.read(reinterpret_cast<char*>(data.data()), size);
-    if(!input && !input.eof()) return std::nullopt;
+    auto data       = std::vector<uint8_t>(static_cast<size_t>(size));
+    auto bytes_read = size_t{0};
+    while(bytes_read < data.size())
+    {
+        auto ret = ::read(fd, data.data() + bytes_read, data.size() - bytes_read);
+        if(ret < 0)
+        {
+            if(errno == EINTR) continue;
+            ROCP_WARNING << "[rocprofiler-sdk-rocattach] Failed reading target ELF " << path << ": "
+                         << std::strerror(errno);
+            return std::nullopt;
+        }
+        if(ret == 0) break;
+        bytes_read += static_cast<size_t>(ret);
+    }
+
+    if(bytes_read != data.size())
+    {
+        ROCP_WARNING << "[rocprofiler-sdk-rocattach] Short read while reading target ELF " << path
+                     << ": expected " << data.size() << " bytes, read " << bytes_read;
+        return std::nullopt;
+    }
+
     return data;
 }
 
-bool
-stat_matches_mapping(const std::string& path, const mapped_object& object)
+std::optional<target_elf>
+read_target_elf_file(const std::string& path, const mapped_object& object)
 {
     struct stat st
     {};
-    if(::stat(path.c_str(), &st) != 0) return false;
-    return major(st.st_dev) == object.device_major && minor(st.st_dev) == object.device_minor &&
-           static_cast<uint64_t>(st.st_ino) == object.inode;
+
+    auto raw_fd = ::open(path.c_str(), O_RDONLY | O_CLOEXEC);
+    if(raw_fd < 0) return std::nullopt;
+    auto fd = unique_fd{raw_fd};
+
+    if(::fstat(fd.get(), &st) != 0)
+    {
+        ROCP_WARNING << "[rocprofiler-sdk-rocattach] Could not stat opened target ELF " << path
+                     << ": " << std::strerror(errno);
+        return std::nullopt;
+    }
+
+    if(major(st.st_dev) != object.device_major || minor(st.st_dev) != object.device_minor ||
+       static_cast<uint64_t>(st.st_ino) != object.inode)
+    {
+        ROCP_WARNING << "[rocprofiler-sdk-rocattach] Refusing to use " << path
+                     << " because its opened device/inode does not match the mapped object";
+        return std::nullopt;
+    }
+
+    if(!S_ISREG(st.st_mode))
+    {
+        ROCP_WARNING << "[rocprofiler-sdk-rocattach] Refusing to use " << path
+                     << " because the opened target ELF is not a regular file";
+        return std::nullopt;
+    }
+
+    if(st.st_size <= 0)
+    {
+        ROCP_WARNING << "[rocprofiler-sdk-rocattach] Refusing to use " << path
+                     << " because the opened target ELF has invalid size " << st.st_size;
+        return std::nullopt;
+    }
+
+    auto data = read_file_from_fd(fd.get(), path, static_cast<uint64_t>(st.st_size));
+    if(!data || data->empty()) return std::nullopt;
+
+    return target_elf{path, std::move(*data), {}};
 }
 
 std::optional<target_elf>
@@ -321,14 +412,10 @@ open_target_elf(pid_t pid, const mapped_object& object)
                                           pid,
                                           static_cast<uint64_t>(mapping.start),
                                           static_cast<uint64_t>(mapping.end));
-        if(stat_matches_mapping(map_files_path, object))
+        if(auto elf = read_target_elf_file(map_files_path, object))
         {
-            if(auto data = read_file(map_files_path); data && !data->empty())
-            {
-                ROCP_TRACE << "[rocprofiler-sdk-rocattach] Opened target ELF via "
-                           << map_files_path;
-                return target_elf{map_files_path, std::move(*data), {}};
-            }
+            ROCP_TRACE << "[rocprofiler-sdk-rocattach] Opened target ELF via " << map_files_path;
+            return elf;
         }
     }
 
@@ -336,18 +423,10 @@ open_target_elf(pid_t pid, const mapped_object& object)
     if(!target_path.empty() && target_path.front() == '/')
     {
         auto root_path = fmt::format("/proc/{}/root{}", pid, target_path);
-        if(stat_matches_mapping(root_path, object))
+        if(auto elf = read_target_elf_file(root_path, object))
         {
-            if(auto data = read_file(root_path); data && !data->empty())
-            {
-                ROCP_TRACE << "[rocprofiler-sdk-rocattach] Opened target ELF via " << root_path;
-                return target_elf{root_path, std::move(*data), {}};
-            }
-        }
-        else
-        {
-            ROCP_WARNING << "[rocprofiler-sdk-rocattach] Refusing to use " << root_path
-                         << " because its device/inode does not match the mapped object";
+            ROCP_TRACE << "[rocprofiler-sdk-rocattach] Opened target ELF via " << root_path;
+            return elf;
         }
     }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
@@ -522,10 +522,10 @@ calculate_load_bias(const target_elf& elf, const mapped_object& object)
     auto page_size =
         (page_size_value > 0) ? static_cast<uint64_t>(page_size_value) : uint64_t{4096};
 
-    auto first_load_segment =
-        std::min_element(elf.load_segments.begin(),
-                         elf.load_segments.end(),
-                         [](const auto& lhs, const auto& rhs) { return lhs.p_vaddr < rhs.p_vaddr; });
+    auto first_load_segment = std::min_element(
+        elf.load_segments.begin(), elf.load_segments.end(), [](const auto& lhs, const auto& rhs) {
+            return lhs.p_vaddr < rhs.p_vaddr;
+        });
     if(first_load_segment == elf.load_segments.end())
     {
         ROCP_ERROR << "[rocprofiler-sdk-rocattach] Target ELF has no PT_LOAD segments: "
@@ -533,7 +533,7 @@ calculate_load_bias(const target_elf& elf, const mapped_object& object)
         return std::nullopt;
     }
 
-    auto first_mapping         = object.mappings.front();
+    auto first_mapping        = object.mappings.front();
     auto segment_file_page    = align_down(first_load_segment->p_offset, page_size);
     auto segment_virtual_page = align_down(first_load_segment->p_vaddr, page_size);
     // Match the maps entry to the PT_LOAD segment by file page before using it
@@ -609,12 +609,12 @@ lookup_symbol_from_sections(const target_elf& elf, std::string_view symbol_name)
         ELFIO::const_symbol_section_accessor symbols{elf.reader, section.get()};
         if(symbols.get_symbols_num() > MAX_DYNAMIC_SYMBOLS) return std::nullopt;
 
-        auto                                 value = ELFIO::Elf64_Addr{0};
-        auto                                 size  = ELFIO::Elf_Xword{0};
-        auto                                 bind  = static_cast<unsigned char>(0);
-        auto                                 type  = static_cast<unsigned char>(0);
-        auto                                 index = ELFIO::Elf_Half{0};
-        auto                                 other = static_cast<unsigned char>(0);
+        auto value = ELFIO::Elf64_Addr{0};
+        auto size  = ELFIO::Elf_Xword{0};
+        auto bind  = static_cast<unsigned char>(0);
+        auto type  = static_cast<unsigned char>(0);
+        auto index = ELFIO::Elf_Half{0};
+        auto other = static_cast<unsigned char>(0);
         if(symbols.get_symbol(name, value, size, bind, type, index, other) &&
            symbol_is_supported_function(bind, type, index, other))
         {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
@@ -25,6 +25,8 @@
 #include "lib/common/logging.hpp"
 
 #include <fmt/format.h>
+#include <elfio/elfio.hpp>
+#include <elfio/elfio_symbols.hpp>
 
 #include <elf.h>
 #include <fcntl.h>
@@ -87,6 +89,7 @@ struct target_elf
 {
     std::string             path          = {};
     std::vector<uint8_t>    data          = {};
+    ELFIO::elfio            reader        = {};
     std::vector<Elf64_Phdr> load_segments = {};
 };
 
@@ -173,6 +176,21 @@ read_as(const std::vector<uint8_t>& data, uint64_t offset)
     auto value = Tp{};
     std::memcpy(&value, data.data() + offset, sizeof(Tp));
     return value;
+}
+
+Elf64_Phdr
+to_phdr(const ELFIO::segment& segment)
+{
+    auto phdr     = Elf64_Phdr{};
+    phdr.p_type   = segment.get_type();
+    phdr.p_flags  = segment.get_flags();
+    phdr.p_offset = segment.get_offset();
+    phdr.p_vaddr  = segment.get_virtual_address();
+    phdr.p_paddr  = segment.get_physical_address();
+    phdr.p_filesz = segment.get_file_size();
+    phdr.p_memsz  = segment.get_memory_size();
+    phdr.p_align  = segment.get_align();
+    return phdr;
 }
 
 std::string
@@ -450,7 +468,10 @@ read_file_if_matches_mapping(const std::string& path, const mapped_object& objec
     auto data = read_file_from_fd(fd.get(), path, static_cast<uint64_t>(st.st_size));
     if(!data || data->empty()) return std::nullopt;
 
-    return target_elf{path, std::move(*data), {}};
+    auto elf = target_elf{};
+    elf.path = path;
+    elf.data = std::move(*data);
+    return elf;
 }
 
 std::optional<target_elf>
@@ -488,37 +509,29 @@ open_target_elf(pid_t pid, const mapped_object& object)
 }
 
 bool
-parse_elf_headers(target_elf& elf)
+parse_target_elf(target_elf& elf)
 {
-    auto ehdr = read_as<Elf64_Ehdr>(elf.data, 0);
-    if(!ehdr)
+    auto elf_bytes = std::string{reinterpret_cast<const char*>(elf.data.data()), elf.data.size()};
+    auto stream    = std::istringstream{elf_bytes, std::ios::binary};
+    if(!elf.reader.load(stream))
     {
-        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Target ELF is too small: " << elf.path;
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Failed to parse target ELF: " << elf.path;
         return false;
     }
 
-    if(std::memcmp(ehdr->e_ident, ELFMAG, SELFMAG) != 0 || ehdr->e_ident[EI_CLASS] != ELFCLASS64 ||
-       ehdr->e_ident[EI_DATA] != ELFDATA2LSB || ehdr->e_machine != EM_X86_64 ||
-       ehdr->e_phentsize != sizeof(Elf64_Phdr))
+    if(elf.reader.get_class() != ELFCLASS64 || elf.reader.get_encoding() != ELFDATA2LSB ||
+       elf.reader.get_machine() != EM_X86_64 || elf.reader.get_type() != ET_DYN)
     {
         ROCP_ERROR << "[rocprofiler-sdk-rocattach] Unsupported target ELF format: " << elf.path;
         return false;
     }
 
-    auto phdr_table_size = checked_mul(ehdr->e_phnum, sizeof(Elf64_Phdr));
-    if(ehdr->e_phnum == 0 || !phdr_table_size ||
-       !has_range(elf.data.size(), ehdr->e_phoff, *phdr_table_size))
-    {
-        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Invalid program header table in " << elf.path;
-        return false;
-    }
-
     elf.load_segments.clear();
-    for(size_t i = 0; i < ehdr->e_phnum; ++i)
+    for(const auto& segment : elf.reader.segments)
     {
-        auto phdr = read_as<Elf64_Phdr>(elf.data, ehdr->e_phoff + i * sizeof(Elf64_Phdr));
-        if(!phdr) return false;
-        if(phdr->p_type == PT_LOAD) elf.load_segments.emplace_back(*phdr);
+        if(segment == nullptr || segment->get_type() != PT_LOAD) continue;
+
+        elf.load_segments.emplace_back(to_phdr(*segment));
     }
 
     if(elf.load_segments.empty())
@@ -631,63 +644,45 @@ vaddr_to_offset(const target_elf& elf, uint64_t vaddr, uint64_t size)
 }
 
 bool
-symbol_is_supported_function(const Elf64_Sym& sym)
+symbol_is_supported_function(unsigned char bind,
+                             unsigned char type,
+                             Elf64_Section section_index,
+                             unsigned char other)
 {
-    auto type       = ELF64_ST_TYPE(sym.st_info);
-    auto bind       = ELF64_ST_BIND(sym.st_info);
-    auto visibility = ELF64_ST_VISIBILITY(sym.st_other);
+    auto visibility = ELF64_ST_VISIBILITY(other);
 
-    return sym.st_shndx != SHN_UNDEF && type == STT_FUNC &&
+    return section_index != SHN_UNDEF && section_index != SHN_ABS && type == STT_FUNC &&
            (bind == STB_GLOBAL || bind == STB_WEAK) &&
            (visibility == STV_DEFAULT || visibility == STV_PROTECTED);
 }
 
-std::optional<Elf64_Sym>
+bool
+symbol_is_supported_function(const Elf64_Sym& sym)
+{
+    return symbol_is_supported_function(
+        ELF64_ST_BIND(sym.st_info), ELF64_ST_TYPE(sym.st_info), sym.st_shndx, sym.st_other);
+}
+
+std::optional<uint64_t>
 lookup_symbol_from_sections(const target_elf& elf, std::string_view symbol_name)
 {
-    auto ehdr            = read_as<Elf64_Ehdr>(elf.data, 0);
-    auto shdr_table_size = ehdr ? checked_mul(ehdr->e_shnum, sizeof(Elf64_Shdr)) : std::nullopt;
-    if(!ehdr || ehdr->e_shoff == 0 || ehdr->e_shnum == 0 ||
-       ehdr->e_shentsize != sizeof(Elf64_Shdr) || !shdr_table_size ||
-       !has_range(elf.data.size(), ehdr->e_shoff, *shdr_table_size))
+    auto name = std::string{symbol_name};
+
+    for(const auto& section : elf.reader.sections)
     {
-        return std::nullopt;
-    }
+        if(section == nullptr || section->get_type() != SHT_DYNSYM) continue;
 
-    for(size_t i = 0; i < ehdr->e_shnum; ++i)
-    {
-        auto shdr = read_as<Elf64_Shdr>(elf.data, ehdr->e_shoff + i * sizeof(Elf64_Shdr));
-        if(!shdr || shdr->sh_type != SHT_DYNSYM || shdr->sh_entsize < sizeof(Elf64_Sym))
+        ELFIO::const_symbol_section_accessor symbols{elf.reader, section.get()};
+        auto                                 value = ELFIO::Elf64_Addr{0};
+        auto                                 size  = ELFIO::Elf_Xword{0};
+        auto                                 bind  = static_cast<unsigned char>(0);
+        auto                                 type  = static_cast<unsigned char>(0);
+        auto                                 index = ELFIO::Elf_Half{0};
+        auto                                 other = static_cast<unsigned char>(0);
+        if(symbols.get_symbol(name, value, size, bind, type, index, other) &&
+           symbol_is_supported_function(bind, type, index, other))
         {
-            continue;
-        }
-        if(shdr->sh_link >= ehdr->e_shnum) continue;
-
-        auto strtab =
-            read_as<Elf64_Shdr>(elf.data, ehdr->e_shoff + shdr->sh_link * sizeof(Elf64_Shdr));
-        if(!strtab || !has_range(elf.data.size(), strtab->sh_offset, strtab->sh_size) ||
-           !has_range(elf.data.size(), shdr->sh_offset, shdr->sh_size))
-        {
-            continue;
-        }
-
-        auto symbol_count = shdr->sh_size / shdr->sh_entsize;
-        if(symbol_count > MAX_DYNAMIC_SYMBOLS) return std::nullopt;
-        for(size_t idx = 0; idx < symbol_count; ++idx)
-        {
-            auto sym_delta  = checked_mul(idx, shdr->sh_entsize);
-            auto sym_offset = sym_delta ? checked_add(shdr->sh_offset, *sym_delta) : std::nullopt;
-            if(!sym_offset) return std::nullopt;
-            auto sym = read_as<Elf64_Sym>(elf.data, *sym_offset);
-            if(!sym || sym->st_name >= strtab->sh_size) continue;
-            const auto* name =
-                reinterpret_cast<const char*>(elf.data.data() + strtab->sh_offset + sym->st_name);
-            auto max_name_len = strtab->sh_size - sym->st_name;
-            if(std::string_view{name, strnlen(name, max_name_len)} == symbol_name &&
-               symbol_is_supported_function(*sym))
-            {
-                return sym;
-            }
+            return value;
         }
     }
 
@@ -764,19 +759,16 @@ symbol_count_from_gnu_hash(const target_elf& elf, uint64_t hash_vaddr)
     return std::nullopt;
 }
 
-std::optional<Elf64_Sym>
-lookup_symbol_from_dynamic(const target_elf& elf, std::string_view symbol_name)
+std::optional<uint64_t>
+lookup_symbol_from_pt_dynamic(const target_elf& elf, std::string_view symbol_name)
 {
     auto dynamic_segment = std::optional<Elf64_Phdr>{};
-    auto ehdr            = read_as<Elf64_Ehdr>(elf.data, 0);
-    if(!ehdr) return std::nullopt;
 
-    for(size_t i = 0; i < ehdr->e_phnum; ++i)
+    for(const auto& segment : elf.reader.segments)
     {
-        auto phdr = read_as<Elf64_Phdr>(elf.data, ehdr->e_phoff + i * sizeof(Elf64_Phdr));
-        if(phdr && phdr->p_type == PT_DYNAMIC)
+        if(segment != nullptr && segment->get_type() == PT_DYNAMIC)
         {
-            dynamic_segment = *phdr;
+            dynamic_segment = to_phdr(*segment);
             break;
         }
     }
@@ -841,18 +833,18 @@ lookup_symbol_from_dynamic(const target_elf& elf, std::string_view symbol_name)
         if(std::string_view{name, strnlen(name, max_name_len)} == symbol_name &&
            symbol_is_supported_function(*sym))
         {
-            return sym;
+            return sym->st_value;
         }
     }
 
     return std::nullopt;
 }
 
-std::optional<Elf64_Sym>
+std::optional<uint64_t>
 lookup_dynamic_symbol(const target_elf& elf, std::string_view symbol_name)
 {
     if(auto sym = lookup_symbol_from_sections(elf, symbol_name)) return sym;
-    return lookup_symbol_from_dynamic(elf, symbol_name);
+    return lookup_symbol_from_pt_dynamic(elf, symbol_name);
 }
 
 bool
@@ -870,7 +862,7 @@ std::optional<uint64_t>
 resolve_target_symbol(pid_t pid, const mapped_object& object, std::string_view symbol)
 {
     auto elf = open_target_elf(pid, object);
-    if(!elf || !parse_elf_headers(*elf)) return std::nullopt;
+    if(!elf || !parse_target_elf(*elf)) return std::nullopt;
 
     auto load_bias = calculate_load_bias(*elf, object);
     if(!load_bias) return std::nullopt;
@@ -883,7 +875,7 @@ resolve_target_symbol(pid_t pid, const mapped_object& object, std::string_view s
         return std::nullopt;
     }
 
-    auto address = checked_add(*load_bias, sym->st_value);
+    auto address = checked_add(*load_bias, *sym);
     if(!address)
     {
         ROCP_ERROR << "[rocprofiler-sdk-rocattach] Resolved address for " << symbol << " in "

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
@@ -22,6 +22,7 @@
 
 #include "symbol_lookup.hpp"
 
+#include "lib/common/hasher.hpp"
 #include "lib/common/logging.hpp"
 #include "lib/common/scope_destructor.hpp"
 
@@ -84,6 +85,23 @@ struct mapped_object
     uint64_t                    inode        = 0;
     std::string                 path         = {};
     std::vector<memory_mapping> mappings     = {};
+};
+
+struct mapped_object_key
+{
+    uint32_t device_major = 0;
+    uint32_t device_minor = 0;
+    uint64_t inode        = 0;
+
+    bool operator==(const mapped_object_key&) const = default;
+};
+
+struct mapped_object_key_hash
+{
+    size_t operator()(const mapped_object_key& key) const
+    {
+        return common::fnv1a_hasher::combine(key.device_major, key.device_minor, key.inode);
+    }
 };
 
 struct target_elf
@@ -277,7 +295,7 @@ parse_maps(pid_t pid)
 std::vector<mapped_object>
 find_mapped_objects(pid_t pid, const std::string& library)
 {
-    auto objects = std::unordered_map<std::string, mapped_object>{};
+    auto objects = std::unordered_map<mapped_object_key, mapped_object, mapped_object_key_hash>{};
 
     for(const auto& mapping : parse_maps(pid))
     {
@@ -286,9 +304,8 @@ find_mapped_objects(pid_t pid, const std::string& library)
         // Multiple maps entries usually belong to the same ELF: readonly headers,
         // executable text, writable data, and so on. Device/inode is the stable key
         // for grouping those segments even when paths differ through namespaces.
-        auto key =
-            fmt::format("{}:{}:{}", mapping.device_major, mapping.device_minor, mapping.inode);
-        auto& object        = objects[key];
+        auto  key    = mapped_object_key{mapping.device_major, mapping.device_minor, mapping.inode};
+        auto& object = objects[key];
         object.device_major = mapping.device_major;
         object.device_minor = mapping.device_minor;
         object.inode        = mapping.inode;
@@ -444,19 +461,17 @@ std::optional<target_elf>
 open_target_elf(pid_t pid, const mapped_object& object)
 {
     // Prefer map_files because it is a kernel-provided handle to the exact file
-    // backing a VMA. If permissions block that path, fall back to the same path
-    // as seen through the target process root and still validate device/inode.
-    for(const auto& mapping : object.mappings)
+    // backing the mapped object. If permissions block that path, fall back to
+    // the same path as seen through the target root and still validate device/inode.
+    const auto& mapping        = object.mappings.front();
+    auto        map_files_path = fmt::format("/proc/{}/map_files/{:x}-{:x}",
+                                      pid,
+                                      static_cast<uint64_t>(mapping.start),
+                                      static_cast<uint64_t>(mapping.end));
+    if(auto elf = read_file_if_matches_mapping(map_files_path, object))
     {
-        auto map_files_path = fmt::format("/proc/{}/map_files/{:x}-{:x}",
-                                          pid,
-                                          static_cast<uint64_t>(mapping.start),
-                                          static_cast<uint64_t>(mapping.end));
-        if(auto elf = read_file_if_matches_mapping(map_files_path, object))
-        {
-            ROCP_TRACE << "[rocprofiler-sdk-rocattach] Opened target ELF via " << map_files_path;
-            return elf;
-        }
+        ROCP_TRACE << "[rocprofiler-sdk-rocattach] Opened target ELF via " << map_files_path;
+        return elf;
     }
 
     auto target_path = strip_deleted_suffix(object.path);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
@@ -35,6 +35,8 @@
 #include <algorithm>
 #include <cctype>
 #include <cerrno>
+#include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <exception>
 #include <filesystem>
@@ -42,6 +44,7 @@
 #include <limits>
 #include <optional>
 #include <sstream>
+#include <string>
 #include <string_view>
 #include <unordered_map>
 #include <utility>
@@ -619,7 +622,6 @@ vaddr_to_offset(const target_elf& elf, uint64_t vaddr, uint64_t size)
 {
     for(const auto& segment : elf.load_segments)
     {
-        if(segment.p_type != PT_LOAD) continue;
         if(vaddr < segment.p_vaddr) continue;
         auto delta = vaddr - segment.p_vaddr;
         if(delta > segment.p_filesz || size > segment.p_filesz - delta) continue;
@@ -881,13 +883,6 @@ resolve_target_symbol(pid_t pid, const mapped_object& object, std::string_view s
         return std::nullopt;
     }
 
-    if(!symbol_is_supported_function(*sym))
-    {
-        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Symbol " << symbol
-                   << " is not a supported exported function in " << elf->path;
-        return std::nullopt;
-    }
-
     auto address = checked_add(*load_bias, sym->st_value);
     if(!address)
     {
@@ -910,25 +905,6 @@ resolve_target_symbol(pid_t pid, const mapped_object& object, std::string_view s
     return address;
 }
 }  // namespace
-
-bool
-find_library(void*& addr, int inpid, const std::string& library)
-{
-    auto object = select_unique_mapped_object(inpid, library);
-    if(!object) return false;
-
-    for(const auto& mapping : object->mappings)
-    {
-        if(mapping.file_offset != 0) continue;
-        // NOLINTNEXTLINE(performance-no-int-to-ptr)
-        addr = reinterpret_cast<void*>(mapping.start);
-        return true;
-    }
-
-    ROCP_ERROR << "[rocprofiler-sdk-rocattach] Couldn't find library " << library
-               << " (with file offset 0) in /proc/" << inpid << "/maps";
-    return false;
-}
 
 bool
 find_symbol(int target_pid, void*& addr, const std::string& library, const std::string& symbol)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
@@ -36,6 +36,7 @@
 #include <cstring>
 #include <exception>
 #include <fstream>
+#include <limits>
 #include <optional>
 #include <sstream>
 #include <string_view>
@@ -49,6 +50,10 @@ namespace rocattach
 {
 namespace
 {
+constexpr auto MAX_TARGET_ELF_SIZE      = uint64_t{512} * 1024 * 1024;
+constexpr auto MAX_DYNAMIC_SYMBOLS      = size_t{1} << 24;
+constexpr auto MAX_GNU_HASH_CHAIN_STEPS = size_t{1} << 24;
+
 struct memory_mapping
 {
     uintptr_t   start        = 0;
@@ -76,6 +81,27 @@ struct target_elf
     std::vector<uint8_t>    data          = {};
     std::vector<Elf64_Phdr> load_segments = {};
 };
+
+std::optional<uint64_t>
+checked_add(uint64_t lhs, uint64_t rhs)
+{
+    if(lhs > std::numeric_limits<uint64_t>::max() - rhs) return std::nullopt;
+    return lhs + rhs;
+}
+
+std::optional<uint64_t>
+checked_sub(uint64_t lhs, uint64_t rhs)
+{
+    if(lhs < rhs) return std::nullopt;
+    return lhs - rhs;
+}
+
+std::optional<uint64_t>
+checked_mul(uint64_t lhs, uint64_t rhs)
+{
+    if(lhs != 0 && rhs > std::numeric_limits<uint64_t>::max() / lhs) return std::nullopt;
+    return lhs * rhs;
+}
 
 uint64_t
 align_down(uint64_t value, uint64_t alignment)
@@ -141,6 +167,19 @@ library_name_matches(const memory_mapping& mapping, const std::string& library)
     auto map_base = basename(clean_path);
     auto lib_base = basename(library);
     return map_base == lib_base || map_base.rfind(fmt::format("{}.", lib_base), 0) == 0;
+}
+
+bool
+library_path_matches_exactly(const mapped_object& object, const std::string& library)
+{
+    if(library.find('/') == std::string::npos) return false;
+
+    auto clean_library = strip_deleted_suffix(library);
+    for(const auto& mapping : object.mappings)
+    {
+        if(strip_deleted_suffix(mapping.path) == clean_library) return true;
+    }
+    return false;
 }
 
 std::optional<memory_mapping>
@@ -249,6 +288,12 @@ read_file(const std::string& path)
     input.seekg(0, std::ios::end);
     auto size = input.tellg();
     if(size < 0) return std::nullopt;
+    if(static_cast<uint64_t>(size) > MAX_TARGET_ELF_SIZE)
+    {
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Refusing to read unusually large target ELF "
+                   << path << " (" << size << " bytes)";
+        return std::nullopt;
+    }
     input.seekg(0, std::ios::beg);
 
     auto data = std::vector<uint8_t>(static_cast<size_t>(size));
@@ -329,9 +374,9 @@ parse_elf_headers(target_elf& elf)
         return false;
     }
 
-    if(ehdr->e_phnum == 0 || !has_range(elf.data.size(),
-                                        ehdr->e_phoff,
-                                        static_cast<uint64_t>(ehdr->e_phnum) * sizeof(Elf64_Phdr)))
+    auto phdr_table_size = checked_mul(ehdr->e_phnum, sizeof(Elf64_Phdr));
+    if(ehdr->e_phnum == 0 || !phdr_table_size ||
+       !has_range(elf.data.size(), ehdr->e_phoff, *phdr_table_size))
     {
         ROCP_ERROR << "[rocprofiler-sdk-rocattach] Invalid program header table in " << elf.path;
         return false;
@@ -358,8 +403,11 @@ parse_elf_headers(target_elf& elf)
 std::optional<uint64_t>
 calculate_load_bias(const target_elf& elf, const mapped_object& object)
 {
-    auto page_size = static_cast<uint64_t>(::sysconf(_SC_PAGESIZE));
-    if(page_size == 0) page_size = 4096;
+    auto page_size_value = ::sysconf(_SC_PAGESIZE);
+    auto page_size =
+        (page_size_value > 0) ? static_cast<uint64_t>(page_size_value) : uint64_t{4096};
+
+    auto load_bias = std::optional<uint64_t>{};
 
     for(const auto& mapping : object.mappings)
     {
@@ -369,11 +417,32 @@ calculate_load_bias(const target_elf& elf, const mapped_object& object)
             auto segment_virtual_page = align_down(segment.p_vaddr, page_size);
             if(mapping.file_offset != segment_file_page) continue;
 
-            auto load_bias = static_cast<uint64_t>(mapping.start) - segment_virtual_page;
-            ROCP_TRACE << "[rocprofiler-sdk-rocattach] Calculated target load bias for "
-                       << object.path << " as 0x" << std::hex << load_bias << std::dec;
-            return load_bias;
+            auto candidate =
+                checked_sub(static_cast<uint64_t>(mapping.start), segment_virtual_page);
+            if(!candidate)
+            {
+                ROCP_ERROR << "[rocprofiler-sdk-rocattach] Invalid target mapping/segment pair for "
+                           << object.path << ": mapping start is below segment virtual page";
+                return std::nullopt;
+            }
+
+            if(load_bias && *load_bias != *candidate)
+            {
+                ROCP_ERROR << "[rocprofiler-sdk-rocattach] Inconsistent target load-bias "
+                              "candidates for "
+                           << object.path << ": 0x" << std::hex << *load_bias << " and 0x"
+                           << *candidate << std::dec;
+                return std::nullopt;
+            }
+            load_bias = candidate;
         }
+    }
+
+    if(load_bias)
+    {
+        ROCP_TRACE << "[rocprofiler-sdk-rocattach] Calculated target load bias for " << object.path
+                   << " as 0x" << std::hex << *load_bias << std::dec;
+        return load_bias;
     }
 
     ROCP_ERROR << "[rocprofiler-sdk-rocattach] Could not match target mappings for " << object.path
@@ -390,7 +459,7 @@ vaddr_to_offset(const target_elf& elf, uint64_t vaddr, uint64_t size)
         if(vaddr < segment.p_vaddr) continue;
         auto delta = vaddr - segment.p_vaddr;
         if(delta > segment.p_filesz || size > segment.p_filesz - delta) continue;
-        return segment.p_offset + delta;
+        return checked_add(segment.p_offset, delta);
     }
     return std::nullopt;
 }
@@ -410,12 +479,11 @@ symbol_is_supported_function(const Elf64_Sym& sym)
 std::optional<Elf64_Sym>
 lookup_symbol_from_sections(const target_elf& elf, std::string_view symbol_name)
 {
-    auto ehdr = read_as<Elf64_Ehdr>(elf.data, 0);
+    auto ehdr            = read_as<Elf64_Ehdr>(elf.data, 0);
+    auto shdr_table_size = ehdr ? checked_mul(ehdr->e_shnum, sizeof(Elf64_Shdr)) : std::nullopt;
     if(!ehdr || ehdr->e_shoff == 0 || ehdr->e_shnum == 0 ||
-       ehdr->e_shentsize != sizeof(Elf64_Shdr) ||
-       !has_range(elf.data.size(),
-                  ehdr->e_shoff,
-                  static_cast<uint64_t>(ehdr->e_shnum) * sizeof(Elf64_Shdr)))
+       ehdr->e_shentsize != sizeof(Elf64_Shdr) || !shdr_table_size ||
+       !has_range(elf.data.size(), ehdr->e_shoff, *shdr_table_size))
     {
         return std::nullopt;
     }
@@ -438,14 +506,22 @@ lookup_symbol_from_sections(const target_elf& elf, std::string_view symbol_name)
         }
 
         auto symbol_count = shdr->sh_size / shdr->sh_entsize;
+        if(symbol_count > MAX_DYNAMIC_SYMBOLS) return std::nullopt;
         for(size_t idx = 0; idx < symbol_count; ++idx)
         {
-            auto sym = read_as<Elf64_Sym>(elf.data, shdr->sh_offset + idx * shdr->sh_entsize);
+            auto sym_delta  = checked_mul(idx, shdr->sh_entsize);
+            auto sym_offset = sym_delta ? checked_add(shdr->sh_offset, *sym_delta) : std::nullopt;
+            if(!sym_offset) return std::nullopt;
+            auto sym = read_as<Elf64_Sym>(elf.data, *sym_offset);
             if(!sym || sym->st_name >= strtab->sh_size) continue;
             const auto* name =
                 reinterpret_cast<const char*>(elf.data.data() + strtab->sh_offset + sym->st_name);
             auto max_name_len = strtab->sh_size - sym->st_name;
-            if(std::string_view{name, strnlen(name, max_name_len)} == symbol_name) return sym;
+            if(std::string_view{name, strnlen(name, max_name_len)} == symbol_name &&
+               symbol_is_supported_function(*sym))
+            {
+                return sym;
+            }
         }
     }
 
@@ -458,8 +534,11 @@ symbol_count_from_sysv_hash(const target_elf& elf, uint64_t hash_vaddr)
     auto hash_offset = vaddr_to_offset(elf, hash_vaddr, 2 * sizeof(uint32_t));
     if(!hash_offset) return std::nullopt;
 
-    auto nchain = read_as<uint32_t>(elf.data, *hash_offset + sizeof(uint32_t));
+    auto nchain_offset = checked_add(*hash_offset, sizeof(uint32_t));
+    if(!nchain_offset) return std::nullopt;
+    auto nchain = read_as<uint32_t>(elf.data, *nchain_offset);
     if(!nchain) return std::nullopt;
+    if(*nchain > MAX_DYNAMIC_SYMBOLS) return std::nullopt;
     return static_cast<size_t>(*nchain);
 }
 
@@ -469,15 +548,21 @@ symbol_count_from_gnu_hash(const target_elf& elf, uint64_t hash_vaddr)
     auto hash_offset = vaddr_to_offset(elf, hash_vaddr, 4 * sizeof(uint32_t));
     if(!hash_offset) return std::nullopt;
 
-    auto nbuckets  = read_as<uint32_t>(elf.data, *hash_offset);
-    auto symndx    = read_as<uint32_t>(elf.data, *hash_offset + sizeof(uint32_t));
-    auto maskwords = read_as<uint32_t>(elf.data, *hash_offset + 2 * sizeof(uint32_t));
+    auto nbuckets      = read_as<uint32_t>(elf.data, *hash_offset);
+    auto symndx_offset = checked_add(*hash_offset, sizeof(uint32_t));
+    auto mask_offset   = checked_add(*hash_offset, 2 * sizeof(uint32_t));
+    if(!symndx_offset || !mask_offset) return std::nullopt;
+    auto symndx    = read_as<uint32_t>(elf.data, *symndx_offset);
+    auto maskwords = read_as<uint32_t>(elf.data, *mask_offset);
     if(!nbuckets || !symndx || !maskwords) return std::nullopt;
 
+    auto bloom_size = checked_mul(*maskwords, sizeof(uint64_t));
+    auto bloom_base = checked_add(*hash_offset, 4 * sizeof(uint32_t));
     auto buckets_offset =
-        *hash_offset + 4 * sizeof(uint32_t) + static_cast<uint64_t>(*maskwords) * sizeof(uint64_t);
-    if(!has_range(
-           elf.data.size(), buckets_offset, static_cast<uint64_t>(*nbuckets) * sizeof(uint32_t)))
+        (bloom_base && bloom_size) ? checked_add(*bloom_base, *bloom_size) : std::nullopt;
+    auto buckets_size = checked_mul(*nbuckets, sizeof(uint32_t));
+    if(!buckets_offset || !buckets_size ||
+       !has_range(elf.data.size(), *buckets_offset, *buckets_size))
     {
         return std::nullopt;
     }
@@ -485,17 +570,27 @@ symbol_count_from_gnu_hash(const target_elf& elf, uint64_t hash_vaddr)
     auto max_bucket = uint32_t{0};
     for(uint32_t i = 0; i < *nbuckets; ++i)
     {
-        auto bucket = read_as<uint32_t>(elf.data, buckets_offset + i * sizeof(uint32_t));
+        auto bucket_delta = checked_mul(i, sizeof(uint32_t));
+        auto bucket_offset =
+            bucket_delta ? checked_add(*buckets_offset, *bucket_delta) : std::nullopt;
+        if(!bucket_offset) return std::nullopt;
+        auto bucket = read_as<uint32_t>(elf.data, *bucket_offset);
         if(bucket) max_bucket = std::max(max_bucket, *bucket);
     }
     if(max_bucket < *symndx) return *symndx;
 
-    auto chains_offset = buckets_offset + static_cast<uint64_t>(*nbuckets) * sizeof(uint32_t);
-    auto chain_index   = static_cast<uint64_t>(max_bucket - *symndx);
-    while(has_range(
-        elf.data.size(), chains_offset + chain_index * sizeof(uint32_t), sizeof(uint32_t)))
+    auto chains_offset = checked_add(*buckets_offset, *buckets_size);
+    if(!chains_offset) return std::nullopt;
+    auto chain_index = static_cast<uint64_t>(max_bucket - *symndx);
+    for(size_t steps = 0; steps < MAX_GNU_HASH_CHAIN_STEPS; ++steps)
     {
-        auto chain = read_as<uint32_t>(elf.data, chains_offset + chain_index * sizeof(uint32_t));
+        auto chain_delta  = checked_mul(chain_index, sizeof(uint32_t));
+        auto chain_offset = chain_delta ? checked_add(*chains_offset, *chain_delta) : std::nullopt;
+        if(!chain_offset || !has_range(elf.data.size(), *chain_offset, sizeof(uint32_t)))
+        {
+            return std::nullopt;
+        }
+        auto chain = read_as<uint32_t>(elf.data, *chain_offset);
         if(!chain) return std::nullopt;
         if((*chain & 1U) != 0) return static_cast<size_t>(*symndx + chain_index + 1);
         ++chain_index;
@@ -535,7 +630,11 @@ lookup_symbol_from_dynamic(const target_elf& elf, std::string_view symbol_name)
     auto entries = dynamic_segment->p_filesz / sizeof(Elf64_Dyn);
     for(size_t i = 0; i < entries; ++i)
     {
-        auto dyn = read_as<Elf64_Dyn>(elf.data, dynamic_segment->p_offset + i * sizeof(Elf64_Dyn));
+        auto dyn_delta = checked_mul(i, sizeof(Elf64_Dyn));
+        auto dyn_offset =
+            dyn_delta ? checked_add(dynamic_segment->p_offset, *dyn_delta) : std::nullopt;
+        if(!dyn_offset) return std::nullopt;
+        auto dyn = read_as<Elf64_Dyn>(elf.data, *dyn_offset);
         if(!dyn) return std::nullopt;
         if(dyn->d_tag == DT_NULL) break;
         if(dyn->d_tag == DT_SYMTAB) symtab_vaddr = dyn->d_un.d_ptr;
@@ -555,19 +654,29 @@ lookup_symbol_from_dynamic(const target_elf& elf, std::string_view symbol_name)
         symbol_count = symbol_count_from_gnu_hash(elf, *gnu_hash_vaddr);
     }
     if(!symbol_count) return std::nullopt;
+    if(*symbol_count > MAX_DYNAMIC_SYMBOLS) return std::nullopt;
 
-    auto symtab_offset = vaddr_to_offset(elf, *symtab_vaddr, *symbol_count * syment);
+    auto symtab_size = checked_mul(*symbol_count, syment);
+    if(!symtab_size) return std::nullopt;
+    auto symtab_offset = vaddr_to_offset(elf, *symtab_vaddr, *symtab_size);
     auto strtab_offset = vaddr_to_offset(elf, *strtab_vaddr, *strsz);
     if(!symtab_offset || !strtab_offset) return std::nullopt;
 
     for(size_t idx = 0; idx < *symbol_count; ++idx)
     {
-        auto sym = read_as<Elf64_Sym>(elf.data, *symtab_offset + idx * syment);
+        auto sym_delta  = checked_mul(idx, syment);
+        auto sym_offset = sym_delta ? checked_add(*symtab_offset, *sym_delta) : std::nullopt;
+        if(!sym_offset) return std::nullopt;
+        auto sym = read_as<Elf64_Sym>(elf.data, *sym_offset);
         if(!sym || sym->st_name >= *strsz) continue;
         const auto* name =
             reinterpret_cast<const char*>(elf.data.data() + *strtab_offset + sym->st_name);
         auto max_name_len = *strsz - sym->st_name;
-        if(std::string_view{name, strnlen(name, max_name_len)} == symbol_name) return sym;
+        if(std::string_view{name, strnlen(name, max_name_len)} == symbol_name &&
+           symbol_is_supported_function(*sym))
+        {
+            return sym;
+        }
     }
 
     return std::nullopt;
@@ -615,10 +724,16 @@ resolve_target_symbol(pid_t pid, const mapped_object& object, std::string_view s
         return std::nullopt;
     }
 
-    auto address = *load_bias + sym->st_value;
-    if(!address_in_executable_mapping(object, address))
+    auto address = checked_add(*load_bias, sym->st_value);
+    if(!address)
     {
-        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Resolved address 0x" << std::hex << address
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Resolved address for " << symbol << " in "
+                   << elf->path << " overflowed";
+        return std::nullopt;
+    }
+    if(!address_in_executable_mapping(object, *address))
+    {
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Resolved address 0x" << std::hex << *address
                    << std::dec << " for " << symbol << " is not inside an executable mapping for "
                    << object.path;
         return std::nullopt;
@@ -627,7 +742,7 @@ resolve_target_symbol(pid_t pid, const mapped_object& object, std::string_view s
     ROCP_INFO << "[rocprofiler-sdk-rocattach] Resolved " << symbol << " in target pid " << pid
               << " from " << elf->path << " (mapped as " << object.path << ", dev "
               << object.device_major << ":" << object.device_minor << ", inode " << object.inode
-              << ") at 0x" << std::hex << address << std::dec;
+              << ") at 0x" << std::hex << *address << std::dec;
     return address;
 }
 }  // namespace
@@ -635,7 +750,33 @@ resolve_target_symbol(pid_t pid, const mapped_object& object, std::string_view s
 bool
 find_library(void*& addr, int inpid, const std::string& library)
 {
-    for(const auto& object : find_mapped_objects(inpid, library))
+    auto objects = find_mapped_objects(inpid, library);
+    if(library.find('/') != std::string::npos)
+    {
+        objects.erase(std::remove_if(objects.begin(),
+                                     objects.end(),
+                                     [&](const auto& object) {
+                                         return !library_path_matches_exactly(object, library);
+                                     }),
+                      objects.end());
+    }
+
+    if(objects.size() > 1)
+    {
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Found multiple mapped target libraries matching "
+                   << library << " in /proc/" << inpid
+                   << "/maps; refusing to choose one implicitly";
+        for(const auto& object : objects)
+        {
+            ROCP_ERROR << "[rocprofiler-sdk-rocattach] Candidate mapped object: " << object.path
+                       << " dev " << object.device_major << ":" << object.device_minor << " inode "
+                       << object.inode << " load address 0x" << std::hex
+                       << object.mappings.front().start << std::dec;
+        }
+        return false;
+    }
+
+    for(const auto& object : objects)
     {
         for(const auto& mapping : object.mappings)
         {
@@ -657,10 +798,33 @@ find_symbol(int target_pid, void*& addr, const std::string& library, const std::
     addr = nullptr;
 
     auto objects = find_mapped_objects(target_pid, library);
+    if(library.find('/') != std::string::npos)
+    {
+        objects.erase(std::remove_if(objects.begin(),
+                                     objects.end(),
+                                     [&](const auto& object) {
+                                         return !library_path_matches_exactly(object, library);
+                                     }),
+                      objects.end());
+    }
     if(objects.empty())
     {
         ROCP_ERROR << "[rocprofiler-sdk-rocattach] Couldn't find mapped target library " << library
                    << " in /proc/" << target_pid << "/maps";
+        return false;
+    }
+    if(objects.size() > 1)
+    {
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Found multiple mapped target libraries matching "
+                   << library << " in /proc/" << target_pid
+                   << "/maps; refusing to choose one implicitly";
+        for(const auto& object : objects)
+        {
+            ROCP_ERROR << "[rocprofiler-sdk-rocattach] Candidate mapped object: " << object.path
+                       << " dev " << object.device_major << ":" << object.device_minor << " inode "
+                       << object.inode << " load address 0x" << std::hex
+                       << object.mappings.front().start << std::dec;
+        }
         return false;
     }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
@@ -287,7 +287,7 @@ read_file(const std::string& path)
 
     input.seekg(0, std::ios::end);
     auto size = input.tellg();
-    if(size < 0) return std::nullopt;
+    if(size <= 0) return std::nullopt;
     if(static_cast<uint64_t>(size) > MAX_TARGET_ELF_SIZE)
     {
         ROCP_ERROR << "[rocprofiler-sdk-rocattach] Refusing to read unusually large target ELF "

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
@@ -37,6 +37,7 @@
 #include <cerrno>
 #include <cstring>
 #include <exception>
+#include <filesystem>
 #include <fstream>
 #include <limits>
 #include <optional>
@@ -52,6 +53,8 @@ namespace rocattach
 {
 namespace
 {
+// Keep limits generous enough for debug builds, but bounded so malformed target
+// ELFs cannot force unbounded memory use or symbol/hash traversal.
 constexpr auto MAX_TARGET_ELF_SIZE      = uint64_t{512} * 1024 * 1024;
 constexpr auto MAX_DYNAMIC_SYMBOLS      = size_t{1} << 24;
 constexpr auto MAX_GNU_HASH_CHAIN_STEPS = size_t{1} << 24;
@@ -322,6 +325,50 @@ find_mapped_objects(pid_t pid, const std::string& library)
     return result;
 }
 
+void
+log_mapped_object_candidates(const std::vector<mapped_object>& objects)
+{
+    for(const auto& object : objects)
+    {
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Candidate mapped object: " << object.path
+                   << " dev " << object.device_major << ":" << object.device_minor << " inode "
+                   << object.inode << " load address 0x" << std::hex
+                   << object.mappings.front().start << std::dec;
+    }
+}
+
+std::optional<mapped_object>
+select_unique_mapped_object(pid_t pid, const std::string& library)
+{
+    auto objects = find_mapped_objects(pid, library);
+    if(library.find('/') != std::string::npos)
+    {
+        objects.erase(std::remove_if(objects.begin(),
+                                     objects.end(),
+                                     [&](const auto& object) {
+                                         return !library_path_matches_exactly(object, library);
+                                     }),
+                      objects.end());
+    }
+
+    if(objects.empty())
+    {
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Couldn't find mapped target library " << library
+                   << " in /proc/" << pid << "/maps";
+        return std::nullopt;
+    }
+
+    if(objects.size() > 1)
+    {
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Found multiple mapped target libraries matching "
+                   << library << " in /proc/" << pid << "/maps; refusing to choose one implicitly";
+        log_mapped_object_candidates(objects);
+        return std::nullopt;
+    }
+
+    return objects.front();
+}
+
 std::optional<std::vector<uint8_t>>
 read_file_from_fd(int fd, const std::string& path, uint64_t size)
 {
@@ -359,7 +406,7 @@ read_file_from_fd(int fd, const std::string& path, uint64_t size)
 }
 
 std::optional<target_elf>
-read_target_elf_file(const std::string& path, const mapped_object& object)
+read_file_if_matches_mapping(const std::string& path, const mapped_object& object)
 {
     struct stat st
     {};
@@ -412,7 +459,7 @@ open_target_elf(pid_t pid, const mapped_object& object)
                                           pid,
                                           static_cast<uint64_t>(mapping.start),
                                           static_cast<uint64_t>(mapping.end));
-        if(auto elf = read_target_elf_file(map_files_path, object))
+        if(auto elf = read_file_if_matches_mapping(map_files_path, object))
         {
             ROCP_TRACE << "[rocprofiler-sdk-rocattach] Opened target ELF via " << map_files_path;
             return elf;
@@ -422,8 +469,10 @@ open_target_elf(pid_t pid, const mapped_object& object)
     auto target_path = strip_deleted_suffix(object.path);
     if(!target_path.empty() && target_path.front() == '/')
     {
-        auto root_path = fmt::format("/proc/{}/root{}", pid, target_path);
-        if(auto elf = read_target_elf_file(root_path, object))
+        auto root_path = (std::filesystem::path{fmt::format("/proc/{}/root", pid)} /
+                          std::filesystem::path{target_path}.relative_path())
+                             .string();
+        if(auto elf = read_file_if_matches_mapping(root_path, object))
         {
             ROCP_TRACE << "[rocprofiler-sdk-rocattach] Opened target ELF via " << root_path;
             return elf;
@@ -854,10 +903,10 @@ resolve_target_symbol(pid_t pid, const mapped_object& object, std::string_view s
         return std::nullopt;
     }
 
-    ROCP_INFO << "[rocprofiler-sdk-rocattach] Resolved " << symbol << " in target pid " << pid
-              << " from " << elf->path << " (mapped as " << object.path << ", dev "
-              << object.device_major << ":" << object.device_minor << ", inode " << object.inode
-              << ") at 0x" << std::hex << *address << std::dec;
+    ROCP_TRACE << "[rocprofiler-sdk-rocattach] Resolved " << symbol << " in target pid " << pid
+               << " from " << elf->path << " (mapped as " << object.path << ", dev "
+               << object.device_major << ":" << object.device_minor << ", inode " << object.inode
+               << ") at 0x" << std::hex << *address << std::dec;
     return address;
 }
 }  // namespace
@@ -865,41 +914,15 @@ resolve_target_symbol(pid_t pid, const mapped_object& object, std::string_view s
 bool
 find_library(void*& addr, int inpid, const std::string& library)
 {
-    auto objects = find_mapped_objects(inpid, library);
-    if(library.find('/') != std::string::npos)
-    {
-        objects.erase(std::remove_if(objects.begin(),
-                                     objects.end(),
-                                     [&](const auto& object) {
-                                         return !library_path_matches_exactly(object, library);
-                                     }),
-                      objects.end());
-    }
+    auto object = select_unique_mapped_object(inpid, library);
+    if(!object) return false;
 
-    if(objects.size() > 1)
+    for(const auto& mapping : object->mappings)
     {
-        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Found multiple mapped target libraries matching "
-                   << library << " in /proc/" << inpid
-                   << "/maps; refusing to choose one implicitly";
-        for(const auto& object : objects)
-        {
-            ROCP_ERROR << "[rocprofiler-sdk-rocattach] Candidate mapped object: " << object.path
-                       << " dev " << object.device_major << ":" << object.device_minor << " inode "
-                       << object.inode << " load address 0x" << std::hex
-                       << object.mappings.front().start << std::dec;
-        }
-        return false;
-    }
-
-    for(const auto& object : objects)
-    {
-        for(const auto& mapping : object.mappings)
-        {
-            if(mapping.file_offset != 0) continue;
-            // NOLINTNEXTLINE(performance-no-int-to-ptr)
-            addr = reinterpret_cast<void*>(mapping.start);
-            return true;
-        }
+        if(mapping.file_offset != 0) continue;
+        // NOLINTNEXTLINE(performance-no-int-to-ptr)
+        addr = reinterpret_cast<void*>(mapping.start);
+        return true;
     }
 
     ROCP_ERROR << "[rocprofiler-sdk-rocattach] Couldn't find library " << library
@@ -912,45 +935,14 @@ find_symbol(int target_pid, void*& addr, const std::string& library, const std::
 {
     addr = nullptr;
 
-    auto objects = find_mapped_objects(target_pid, library);
-    if(library.find('/') != std::string::npos)
-    {
-        objects.erase(std::remove_if(objects.begin(),
-                                     objects.end(),
-                                     [&](const auto& object) {
-                                         return !library_path_matches_exactly(object, library);
-                                     }),
-                      objects.end());
-    }
-    if(objects.empty())
-    {
-        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Couldn't find mapped target library " << library
-                   << " in /proc/" << target_pid << "/maps";
-        return false;
-    }
-    if(objects.size() > 1)
-    {
-        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Found multiple mapped target libraries matching "
-                   << library << " in /proc/" << target_pid
-                   << "/maps; refusing to choose one implicitly";
-        for(const auto& object : objects)
-        {
-            ROCP_ERROR << "[rocprofiler-sdk-rocattach] Candidate mapped object: " << object.path
-                       << " dev " << object.device_major << ":" << object.device_minor << " inode "
-                       << object.inode << " load address 0x" << std::hex
-                       << object.mappings.front().start << std::dec;
-        }
-        return false;
-    }
+    auto object = select_unique_mapped_object(target_pid, library);
+    if(!object) return false;
 
-    for(const auto& object : objects)
+    if(auto resolved = resolve_target_symbol(target_pid, *object, symbol))
     {
-        if(auto resolved = resolve_target_symbol(target_pid, object, symbol))
-        {
-            // NOLINTNEXTLINE(performance-no-int-to-ptr)
-            addr = reinterpret_cast<void*>(*resolved);
-            return true;
-        }
+        // NOLINTNEXTLINE(performance-no-int-to-ptr)
+        addr = reinterpret_cast<void*>(*resolved);
+        return true;
     }
 
     ROCP_ERROR << "[rocprofiler-sdk-rocattach] Failed to resolve " << library << "::" << symbol

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
@@ -23,6 +23,7 @@
 #include "symbol_lookup.hpp"
 
 #include "lib/common/logging.hpp"
+#include "lib/common/scope_destructor.hpp"
 
 #include <fmt/format.h>
 #include <elfio/elfio.hpp>
@@ -91,47 +92,6 @@ struct target_elf
     std::vector<uint8_t>    data          = {};
     ELFIO::elfio            reader        = {};
     std::vector<Elf64_Phdr> load_segments = {};
-};
-
-class unique_fd
-{
-public:
-    explicit unique_fd(int fd)
-    : m_fd{fd}
-    {}
-
-    unique_fd(const unique_fd&) = delete;
-    unique_fd& operator=(const unique_fd&) = delete;
-
-    unique_fd(unique_fd&& other) noexcept
-    : m_fd{std::exchange(other.m_fd, -1)}
-    {}
-
-    unique_fd& operator=(unique_fd&& other) noexcept
-    {
-        if(this != &other)
-        {
-            reset();
-            m_fd = std::exchange(other.m_fd, -1);
-        }
-        return *this;
-    }
-
-    ~unique_fd() { reset(); }
-
-    int get() const { return m_fd; }
-
-    void reset()
-    {
-        if(m_fd >= 0)
-        {
-            ::close(m_fd);
-            m_fd = -1;
-        }
-    }
-
-private:
-    int m_fd = -1;
 };
 
 std::optional<uint64_t>
@@ -294,12 +254,15 @@ std::vector<memory_mapping>
 parse_maps(pid_t pid)
 {
     auto filename = fmt::format("/proc/{}/maps", pid);
+    errno         = 0;
     auto maps     = std::ifstream{filename};
+    auto open_err = errno;
     auto result   = std::vector<memory_mapping>{};
 
     if(!maps)
     {
-        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Couldn't open " << filename;
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Couldn't open " << filename << ": "
+                   << ((open_err != 0) ? std::strerror(open_err) : "unknown error");
         return result;
     }
 
@@ -320,6 +283,9 @@ find_mapped_objects(pid_t pid, const std::string& library)
     {
         if(mapping.inode == 0 || !library_name_matches(mapping, library)) continue;
 
+        // Multiple maps entries usually belong to the same ELF: readonly headers,
+        // executable text, writable data, and so on. Device/inode is the stable key
+        // for grouping those segments even when paths differ through namespaces.
         auto key =
             fmt::format("{}:{}:{}", mapping.device_major, mapping.device_minor, mapping.inode);
         auto& object        = objects[key];
@@ -432,11 +398,11 @@ read_file_if_matches_mapping(const std::string& path, const mapped_object& objec
     struct stat st
     {};
 
-    auto raw_fd = ::open(path.c_str(), O_RDONLY | O_CLOEXEC);
-    if(raw_fd < 0) return std::nullopt;
-    auto fd = unique_fd{raw_fd};
+    auto fd = ::open(path.c_str(), O_RDONLY | O_CLOEXEC);
+    if(fd < 0) return std::nullopt;
+    auto close_fd = common::scope_destructor{[fd]() { ::close(fd); }};
 
-    if(::fstat(fd.get(), &st) != 0)
+    if(::fstat(fd, &st) != 0)
     {
         ROCP_WARNING << "[rocprofiler-sdk-rocattach] Could not stat opened target ELF " << path
                      << ": " << std::strerror(errno);
@@ -465,7 +431,7 @@ read_file_if_matches_mapping(const std::string& path, const mapped_object& objec
         return std::nullopt;
     }
 
-    auto data = read_file_from_fd(fd.get(), path, static_cast<uint64_t>(st.st_size));
+    auto data = read_file_from_fd(fd, path, static_cast<uint64_t>(st.st_size));
     if(!data || data->empty()) return std::nullopt;
 
     auto elf = target_elf{};
@@ -477,6 +443,9 @@ read_file_if_matches_mapping(const std::string& path, const mapped_object& objec
 std::optional<target_elf>
 open_target_elf(pid_t pid, const mapped_object& object)
 {
+    // Prefer map_files because it is a kernel-provided handle to the exact file
+    // backing a VMA. If permissions block that path, fall back to the same path
+    // as seen through the target process root and still validate device/inode.
     for(const auto& mapping : object.mappings)
     {
         auto map_files_path = fmt::format("/proc/{}/map_files/{:x}-{:x}",
@@ -526,6 +495,8 @@ parse_target_elf(target_elf& elf)
         return false;
     }
 
+    // PT_LOAD segments are used later to translate ELF virtual addresses into
+    // target-process addresses.
     elf.load_segments.clear();
     for(const auto& segment : elf.reader.segments)
     {
@@ -551,83 +522,44 @@ calculate_load_bias(const target_elf& elf, const mapped_object& object)
     auto page_size =
         (page_size_value > 0) ? static_cast<uint64_t>(page_size_value) : uint64_t{4096};
 
-    auto candidates = std::vector<uint64_t>{};
-
-    for(const auto& mapping : object.mappings)
+    auto first_load_segment =
+        std::min_element(elf.load_segments.begin(),
+                         elf.load_segments.end(),
+                         [](const auto& lhs, const auto& rhs) { return lhs.p_vaddr < rhs.p_vaddr; });
+    if(first_load_segment == elf.load_segments.end())
     {
-        for(const auto& segment : elf.load_segments)
-        {
-            auto segment_file_page    = align_down(segment.p_offset, page_size);
-            auto segment_virtual_page = align_down(segment.p_vaddr, page_size);
-            if(mapping.file_offset != segment_file_page) continue;
-
-            auto candidate =
-                checked_sub(static_cast<uint64_t>(mapping.start), segment_virtual_page);
-            if(!candidate)
-            {
-                ROCP_ERROR << "[rocprofiler-sdk-rocattach] Invalid target mapping/segment pair for "
-                           << object.path << ": mapping start is below segment virtual page";
-                return std::nullopt;
-            }
-
-            if(std::find(candidates.begin(), candidates.end(), *candidate) == candidates.end())
-            {
-                candidates.emplace_back(*candidate);
-            }
-        }
-    }
-
-    auto best_bias  = std::optional<uint64_t>{};
-    auto best_score = size_t{0};
-    auto is_tied    = false;
-    for(auto candidate : candidates)
-    {
-        auto score = size_t{0};
-        for(const auto& segment : elf.load_segments)
-        {
-            auto segment_file_page    = align_down(segment.p_offset, page_size);
-            auto segment_virtual_page = align_down(segment.p_vaddr, page_size);
-            auto expected_start       = checked_add(candidate, segment_virtual_page);
-            if(!expected_start) continue;
-
-            auto mapping_itr = std::find_if(
-                object.mappings.begin(), object.mappings.end(), [&](const auto& mapping) {
-                    return mapping.file_offset == segment_file_page &&
-                           static_cast<uint64_t>(mapping.start) == *expected_start;
-                });
-            if(mapping_itr != object.mappings.end()) ++score;
-        }
-
-        if(score > best_score)
-        {
-            best_bias  = candidate;
-            best_score = score;
-            is_tied    = false;
-        }
-        else if(score == best_score && score > 0)
-        {
-            is_tied = true;
-        }
-    }
-
-    if(best_bias && !is_tied)
-    {
-        ROCP_TRACE << "[rocprofiler-sdk-rocattach] Calculated target load bias for " << object.path
-                   << " as 0x" << std::hex << *best_bias << std::dec << " using " << best_score
-                   << " PT_LOAD mapping matches";
-        return best_bias;
-    }
-
-    if(is_tied)
-    {
-        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Ambiguous target load-bias candidates for "
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Target ELF has no PT_LOAD segments: "
                    << object.path;
         return std::nullopt;
     }
 
-    ROCP_ERROR << "[rocprofiler-sdk-rocattach] Could not match target mappings for " << object.path
-               << " to ELF PT_LOAD segments";
-    return std::nullopt;
+    auto first_mapping         = object.mappings.front();
+    auto segment_file_page    = align_down(first_load_segment->p_offset, page_size);
+    auto segment_virtual_page = align_down(first_load_segment->p_vaddr, page_size);
+    // Match the maps entry to the PT_LOAD segment by file page before using it
+    // to derive the ET_DYN load bias.
+    if(first_mapping.file_offset != segment_file_page)
+    {
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] First target mapping for " << object.path
+                   << " has file offset 0x" << std::hex << first_mapping.file_offset
+                   << ", but the first PT_LOAD segment starts at file page 0x" << segment_file_page
+                   << std::dec;
+        return std::nullopt;
+    }
+
+    // For ET_DYN shared objects, load bias is runtime start minus page-aligned
+    // segment virtual address.
+    auto bias = checked_sub(static_cast<uint64_t>(first_mapping.start), segment_virtual_page);
+    if(!bias)
+    {
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Invalid target mapping/segment pair for "
+                   << object.path << ": mapping start is below segment virtual page";
+        return std::nullopt;
+    }
+
+    ROCP_TRACE << "[rocprofiler-sdk-rocattach] Calculated target load bias for " << object.path
+               << " as 0x" << std::hex << *bias << std::dec;
+    return bias;
 }
 
 std::optional<uint64_t>
@@ -668,11 +600,15 @@ lookup_symbol_from_sections(const target_elf& elf, std::string_view symbol_name)
 {
     auto name = std::string{symbol_name};
 
+    // Prefer section-backed .dynsym lookup when section headers are present;
+    // sectionless files fall back to PT_DYNAMIC.
     for(const auto& section : elf.reader.sections)
     {
         if(section == nullptr || section->get_type() != SHT_DYNSYM) continue;
 
         ELFIO::const_symbol_section_accessor symbols{elf.reader, section.get()};
+        if(symbols.get_symbols_num() > MAX_DYNAMIC_SYMBOLS) return std::nullopt;
+
         auto                                 value = ELFIO::Elf64_Addr{0};
         auto                                 size  = ELFIO::Elf_Xword{0};
         auto                                 bind  = static_cast<unsigned char>(0);
@@ -778,6 +714,8 @@ lookup_symbol_from_pt_dynamic(const target_elf& elf, std::string_view symbol_nam
         return std::nullopt;
     }
 
+    // Sectionless ELF files still carry dynamic-loader metadata in PT_DYNAMIC.
+    // The hash tables bound how many dynamic symbols we can scan safely.
     auto symtab_vaddr   = std::optional<uint64_t>{};
     auto strtab_vaddr   = std::optional<uint64_t>{};
     auto strsz          = std::optional<uint64_t>{};
@@ -875,6 +813,8 @@ resolve_target_symbol(pid_t pid, const mapped_object& object, std::string_view s
         return std::nullopt;
     }
 
+    // Dynamic symbol values are ELF virtual addresses; adding load bias yields
+    // the target-process address.
     auto address = checked_add(*load_bias, *sym);
     if(!address)
     {

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
@@ -407,7 +407,7 @@ calculate_load_bias(const target_elf& elf, const mapped_object& object)
     auto page_size =
         (page_size_value > 0) ? static_cast<uint64_t>(page_size_value) : uint64_t{4096};
 
-    auto load_bias = std::optional<uint64_t>{};
+    auto candidates = std::vector<uint64_t>{};
 
     for(const auto& mapping : object.mappings)
     {
@@ -426,23 +426,59 @@ calculate_load_bias(const target_elf& elf, const mapped_object& object)
                 return std::nullopt;
             }
 
-            if(load_bias && *load_bias != *candidate)
+            if(std::find(candidates.begin(), candidates.end(), *candidate) == candidates.end())
             {
-                ROCP_ERROR << "[rocprofiler-sdk-rocattach] Inconsistent target load-bias "
-                              "candidates for "
-                           << object.path << ": 0x" << std::hex << *load_bias << " and 0x"
-                           << *candidate << std::dec;
-                return std::nullopt;
+                candidates.emplace_back(*candidate);
             }
-            load_bias = candidate;
         }
     }
 
-    if(load_bias)
+    auto best_bias  = std::optional<uint64_t>{};
+    auto best_score = size_t{0};
+    auto is_tied    = false;
+    for(auto candidate : candidates)
+    {
+        auto score = size_t{0};
+        for(const auto& segment : elf.load_segments)
+        {
+            auto segment_file_page    = align_down(segment.p_offset, page_size);
+            auto segment_virtual_page = align_down(segment.p_vaddr, page_size);
+            auto expected_start       = checked_add(candidate, segment_virtual_page);
+            if(!expected_start) continue;
+
+            auto mapping_itr = std::find_if(
+                object.mappings.begin(), object.mappings.end(), [&](const auto& mapping) {
+                    return mapping.file_offset == segment_file_page &&
+                           static_cast<uint64_t>(mapping.start) == *expected_start;
+                });
+            if(mapping_itr != object.mappings.end()) ++score;
+        }
+
+        if(score > best_score)
+        {
+            best_bias  = candidate;
+            best_score = score;
+            is_tied    = false;
+        }
+        else if(score == best_score && score > 0)
+        {
+            is_tied = true;
+        }
+    }
+
+    if(best_bias && !is_tied)
     {
         ROCP_TRACE << "[rocprofiler-sdk-rocattach] Calculated target load bias for " << object.path
-                   << " as 0x" << std::hex << *load_bias << std::dec;
-        return load_bias;
+                   << " as 0x" << std::hex << *best_bias << std::dec << " using " << best_score
+                   << " PT_LOAD mapping matches";
+        return best_bias;
+    }
+
+    if(is_tied)
+    {
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Ambiguous target load-bias candidates for "
+                   << object.path;
+        return std::nullopt;
     }
 
     ROCP_ERROR << "[rocprofiler-sdk-rocattach] Could not match target mappings for " << object.path

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
@@ -22,24 +22,26 @@
 
 #include "symbol_lookup.hpp"
 
-#include "lib/common/dl.hpp"
-#include "lib/common/filesystem.hpp"
 #include "lib/common/logging.hpp"
 
-#include <rocprofiler-sdk/version.h>
-
 #include <fmt/format.h>
-#include <fmt/ranges.h>
 
-#include <dlfcn.h>
-#include <link.h>
+#include <elf.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+#include <unistd.h>
 
+#include <algorithm>
+#include <cctype>
+#include <cstring>
+#include <exception>
+#include <fstream>
 #include <optional>
 #include <sstream>
+#include <string_view>
 #include <unordered_map>
+#include <utility>
 #include <vector>
-
-namespace fs = rocprofiler::common::filesystem;
 
 namespace rocprofiler
 {
@@ -47,220 +49,634 @@ namespace rocattach
 {
 namespace
 {
-constexpr auto                         ROCATTACH_LIBRARY_NAME = "librocprofiler-sdk-rocattach.so";
-std::unordered_map<std::string, void*> m_target_library_addrs = {};
-std::unordered_map<std::string, void*> m_target_symbol_addrs  = {};
-
-auto
-get_this_library_path()
+struct memory_mapping
 {
-    const auto libnames = std::array<std::string, 3>{
-        fmt::format("{}.{}.{}.{}",
-                    ROCATTACH_LIBRARY_NAME,
-                    ROCPROFILER_VERSION_MAJOR,
-                    ROCPROFILER_VERSION_MINOR,
-                    ROCPROFILER_VERSION_PATCH),
-        fmt::format("{}.{}", ROCATTACH_LIBRARY_NAME, ROCPROFILER_SOVERSION),
-        fmt::format("{}", ROCATTACH_LIBRARY_NAME),
-    };
+    uintptr_t   start        = 0;
+    uintptr_t   end          = 0;
+    uint64_t    file_offset  = 0;
+    std::string permissions  = {};
+    uint32_t    device_major = 0;
+    uint32_t    device_minor = 0;
+    uint64_t    inode        = 0;
+    std::string path         = {};
+};
 
-    for(const auto& itr : libnames)
-    {
-        ROCP_INFO << fmt::format("Searching for {} library path", itr);
-        if(auto _this_lib_path =
-               rocprofiler::common::dl::get_linked_path(itr, {RTLD_NOLOAD | RTLD_LAZY});
-           _this_lib_path)
-        {
-            auto _val = fs::path{*_this_lib_path}.parent_path().string();
-            ROCP_INFO << fmt::format("Found {} library path: {}", itr, _val);
-            return _val;
-        }
-    }
+struct mapped_object
+{
+    uint32_t                    device_major = 0;
+    uint32_t                    device_minor = 0;
+    uint64_t                    inode        = 0;
+    std::string                 path         = {};
+    std::vector<memory_mapping> mappings     = {};
+};
 
-    ROCP_FATAL << fmt::format(
-        "{} could not locate itself in the list of loaded libraries. Tried: {}",
-        ROCATTACH_LIBRARY_NAME,
-        fmt::join(libnames, ", "));
-    return std::string{};
+struct target_elf
+{
+    std::string             path          = {};
+    std::vector<uint8_t>    data          = {};
+    std::vector<Elf64_Phdr> load_segments = {};
+};
+
+uint64_t
+align_down(uint64_t value, uint64_t alignment)
+{
+    return value - (value % alignment);
 }
 
-void*
-get_library_handle(std::string_view _lib_name)
+bool
+has_range(size_t file_size, uint64_t offset, uint64_t size)
 {
-    void* _lib_handle = nullptr;
+    return offset <= file_size && size <= file_size - offset;
+}
 
-    if(_lib_name.empty()) return nullptr;
+template <typename Tp>
+std::optional<Tp>
+read_as(const std::vector<uint8_t>& data, uint64_t offset)
+{
+    if(!has_range(data.size(), offset, sizeof(Tp))) return std::nullopt;
 
-    auto _lib_path       = fs::path{_lib_name};
-    auto _lib_path_fname = _lib_path.filename();
-    auto _lib_path_abs =
-        (_lib_path.is_absolute()) ? _lib_path : (fs::path{get_this_library_path()} / _lib_path);
+    auto value = Tp{};
+    std::memcpy(&value, data.data() + offset, sizeof(Tp));
+    return value;
+}
 
-    // check to see if the rocprofiler library is already loaded
-    _lib_handle = dlopen(_lib_path.c_str(), RTLD_NOLOAD | RTLD_LAZY);
+std::string
+trim_left(std::string value)
+{
+    value.erase(value.begin(), std::find_if(value.begin(), value.end(), [](unsigned char ch) {
+                    return !std::isspace(ch);
+                }));
+    return value;
+}
 
-    if(_lib_handle)
+std::string
+strip_deleted_suffix(std::string value)
+{
+    constexpr auto deleted_suffix = std::string_view{" (deleted)"};
+    if(value.size() >= deleted_suffix.size() &&
+       value.compare(value.size() - deleted_suffix.size(), deleted_suffix.size(), deleted_suffix) ==
+           0)
     {
-        LOG(INFO) << "[rocprofiler-sdk-rocattach] loaded " << _lib_name << " library at "
-                  << _lib_path.string() << " (handle=" << _lib_handle
-                  << ") via RTLD_NOLOAD | RTLD_LAZY";
+        value.resize(value.size() - deleted_suffix.size());
+    }
+    return value;
+}
+
+std::string
+basename(std::string path)
+{
+    path     = strip_deleted_suffix(std::move(path));
+    auto pos = path.find_last_of('/');
+    return (pos == std::string::npos) ? path : path.substr(pos + 1);
+}
+
+bool
+library_name_matches(const memory_mapping& mapping, const std::string& library)
+{
+    if(mapping.path.empty()) return false;
+
+    auto clean_path = strip_deleted_suffix(mapping.path);
+    if(clean_path == library) return true;
+
+    auto map_base = basename(clean_path);
+    auto lib_base = basename(library);
+    return map_base == lib_base || map_base.rfind(fmt::format("{}.", lib_base), 0) == 0;
+}
+
+std::optional<memory_mapping>
+parse_maps_line(const std::string& line)
+{
+    auto        iss = std::istringstream{line};
+    std::string range;
+    std::string offset;
+    std::string device;
+    auto        mapping = memory_mapping{};
+
+    if(!(iss >> range >> mapping.permissions >> offset >> device >> mapping.inode))
+    {
+        return std::nullopt;
     }
 
-    // try to load with the given path
-    if(!_lib_handle)
-    {
-        _lib_handle = dlopen(_lib_path.c_str(), RTLD_GLOBAL | RTLD_LAZY);
+    auto dash_pos = range.find('-');
+    auto dev_pos  = device.find(':');
+    if(dash_pos == std::string::npos || dev_pos == std::string::npos) return std::nullopt;
 
-        if(_lib_handle)
+    try
+    {
+        mapping.start = static_cast<uintptr_t>(std::stoull(range.substr(0, dash_pos), nullptr, 16));
+        mapping.end = static_cast<uintptr_t>(std::stoull(range.substr(dash_pos + 1), nullptr, 16));
+        mapping.file_offset = std::stoull(offset, nullptr, 16);
+        mapping.device_major =
+            static_cast<uint32_t>(std::stoul(device.substr(0, dev_pos), nullptr, 16));
+        mapping.device_minor =
+            static_cast<uint32_t>(std::stoul(device.substr(dev_pos + 1), nullptr, 16));
+
+        auto path = std::string{};
+        std::getline(iss, path);
+        mapping.path = trim_left(std::move(path));
+    } catch(const std::exception& e)
+    {
+        ROCP_TRACE << "[rocprofiler-sdk-rocattach] Failed to parse maps line: " << line
+                   << ". error: " << e.what();
+        return std::nullopt;
+    }
+
+    return mapping;
+}
+
+std::vector<memory_mapping>
+parse_maps(pid_t pid)
+{
+    auto filename = fmt::format("/proc/{}/maps", pid);
+    auto maps     = std::ifstream{filename};
+    auto result   = std::vector<memory_mapping>{};
+
+    if(!maps)
+    {
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Couldn't open " << filename;
+        return result;
+    }
+
+    auto line = std::string{};
+    while(std::getline(maps, line))
+    {
+        if(auto mapping = parse_maps_line(line); mapping) result.emplace_back(*mapping);
+    }
+    return result;
+}
+
+std::vector<mapped_object>
+find_mapped_objects(pid_t pid, const std::string& library)
+{
+    auto objects = std::unordered_map<std::string, mapped_object>{};
+
+    for(const auto& mapping : parse_maps(pid))
+    {
+        if(mapping.inode == 0 || !library_name_matches(mapping, library)) continue;
+
+        auto key =
+            fmt::format("{}:{}:{}", mapping.device_major, mapping.device_minor, mapping.inode);
+        auto& object        = objects[key];
+        object.device_major = mapping.device_major;
+        object.device_minor = mapping.device_minor;
+        object.inode        = mapping.inode;
+        if(object.path.empty()) object.path = mapping.path;
+        object.mappings.emplace_back(mapping);
+    }
+
+    auto result = std::vector<mapped_object>{};
+    result.reserve(objects.size());
+    for(auto& itr : objects)
+    {
+        std::sort(itr.second.mappings.begin(),
+                  itr.second.mappings.end(),
+                  [](const auto& lhs, const auto& rhs) { return lhs.start < rhs.start; });
+        result.emplace_back(std::move(itr.second));
+    }
+
+    std::sort(result.begin(), result.end(), [](const auto& lhs, const auto& rhs) {
+        return lhs.mappings.front().start < rhs.mappings.front().start;
+    });
+    return result;
+}
+
+std::optional<std::vector<uint8_t>>
+read_file(const std::string& path)
+{
+    auto input = std::ifstream{path, std::ios::binary};
+    if(!input) return std::nullopt;
+
+    input.seekg(0, std::ios::end);
+    auto size = input.tellg();
+    if(size < 0) return std::nullopt;
+    input.seekg(0, std::ios::beg);
+
+    auto data = std::vector<uint8_t>(static_cast<size_t>(size));
+    if(!data.empty()) input.read(reinterpret_cast<char*>(data.data()), size);
+    if(!input && !input.eof()) return std::nullopt;
+    return data;
+}
+
+bool
+stat_matches_mapping(const std::string& path, const mapped_object& object)
+{
+    struct stat st
+    {};
+    if(::stat(path.c_str(), &st) != 0) return false;
+    return major(st.st_dev) == object.device_major && minor(st.st_dev) == object.device_minor &&
+           static_cast<uint64_t>(st.st_ino) == object.inode;
+}
+
+std::optional<target_elf>
+open_target_elf(pid_t pid, const mapped_object& object)
+{
+    for(const auto& mapping : object.mappings)
+    {
+        auto map_files_path = fmt::format("/proc/{}/map_files/{:x}-{:x}",
+                                          pid,
+                                          static_cast<uint64_t>(mapping.start),
+                                          static_cast<uint64_t>(mapping.end));
+        if(stat_matches_mapping(map_files_path, object))
         {
-            LOG(INFO) << "[rocprofiler-sdk-rocattach] loaded " << _lib_name << " library at "
-                      << _lib_path.string() << " (handle=" << _lib_handle
-                      << ") via RTLD_GLOBAL | RTLD_LAZY";
+            if(auto data = read_file(map_files_path); data && !data->empty())
+            {
+                ROCP_TRACE << "[rocprofiler-sdk-rocattach] Opened target ELF via "
+                           << map_files_path;
+                return target_elf{map_files_path, std::move(*data), {}};
+            }
         }
     }
 
-    // try to load with the absolute path
-    if(!_lib_handle)
+    auto target_path = strip_deleted_suffix(object.path);
+    if(!target_path.empty() && target_path.front() == '/')
     {
-        _lib_path   = _lib_path_abs;
-        _lib_handle = dlopen(_lib_path.c_str(), RTLD_GLOBAL | RTLD_LAZY);
+        auto root_path = fmt::format("/proc/{}/root{}", pid, target_path);
+        if(stat_matches_mapping(root_path, object))
+        {
+            if(auto data = read_file(root_path); data && !data->empty())
+            {
+                ROCP_TRACE << "[rocprofiler-sdk-rocattach] Opened target ELF via " << root_path;
+                return target_elf{root_path, std::move(*data), {}};
+            }
+        }
+        else
+        {
+            ROCP_WARNING << "[rocprofiler-sdk-rocattach] Refusing to use " << root_path
+                         << " because its device/inode does not match the mapped object";
+        }
     }
 
-    // try to load with the basename path
-    if(!_lib_handle)
+    ROCP_ERROR << "[rocprofiler-sdk-rocattach] Could not open mapped target ELF for " << object.path
+               << " via /proc/" << pid << "/map_files or /proc/" << pid << "/root";
+    return std::nullopt;
+}
+
+bool
+parse_elf_headers(target_elf& elf)
+{
+    auto ehdr = read_as<Elf64_Ehdr>(elf.data, 0);
+    if(!ehdr)
     {
-        _lib_path   = _lib_path_fname;
-        _lib_handle = dlopen(_lib_path.c_str(), RTLD_GLOBAL | RTLD_LAZY);
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Target ELF is too small: " << elf.path;
+        return false;
     }
 
-    LOG(INFO) << "[rocprofiler-sdk-rocattach] loaded " << _lib_name << " library at "
-              << _lib_path.string() << " (handle=" << _lib_handle << ")";
+    if(std::memcmp(ehdr->e_ident, ELFMAG, SELFMAG) != 0 || ehdr->e_ident[EI_CLASS] != ELFCLASS64 ||
+       ehdr->e_ident[EI_DATA] != ELFDATA2LSB || ehdr->e_machine != EM_X86_64 ||
+       ehdr->e_phentsize != sizeof(Elf64_Phdr))
+    {
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Unsupported target ELF format: " << elf.path;
+        return false;
+    }
 
-    LOG_IF(WARNING, _lib_handle == nullptr) << _lib_name << " failed to load\n";
+    if(ehdr->e_phnum == 0 || !has_range(elf.data.size(),
+                                        ehdr->e_phoff,
+                                        static_cast<uint64_t>(ehdr->e_phnum) * sizeof(Elf64_Phdr)))
+    {
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Invalid program header table in " << elf.path;
+        return false;
+    }
 
-    return _lib_handle;
+    elf.load_segments.clear();
+    for(size_t i = 0; i < ehdr->e_phnum; ++i)
+    {
+        auto phdr = read_as<Elf64_Phdr>(elf.data, ehdr->e_phoff + i * sizeof(Elf64_Phdr));
+        if(!phdr) return false;
+        if(phdr->p_type == PT_LOAD) elf.load_segments.emplace_back(*phdr);
+    }
+
+    if(elf.load_segments.empty())
+    {
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Target ELF has no PT_LOAD segments: "
+                   << elf.path;
+        return false;
+    }
+
+    return true;
+}
+
+std::optional<uint64_t>
+calculate_load_bias(const target_elf& elf, const mapped_object& object)
+{
+    auto page_size = static_cast<uint64_t>(::sysconf(_SC_PAGESIZE));
+    if(page_size == 0) page_size = 4096;
+
+    for(const auto& mapping : object.mappings)
+    {
+        for(const auto& segment : elf.load_segments)
+        {
+            auto segment_file_page    = align_down(segment.p_offset, page_size);
+            auto segment_virtual_page = align_down(segment.p_vaddr, page_size);
+            if(mapping.file_offset != segment_file_page) continue;
+
+            auto load_bias = static_cast<uint64_t>(mapping.start) - segment_virtual_page;
+            ROCP_TRACE << "[rocprofiler-sdk-rocattach] Calculated target load bias for "
+                       << object.path << " as 0x" << std::hex << load_bias << std::dec;
+            return load_bias;
+        }
+    }
+
+    ROCP_ERROR << "[rocprofiler-sdk-rocattach] Could not match target mappings for " << object.path
+               << " to ELF PT_LOAD segments";
+    return std::nullopt;
+}
+
+std::optional<uint64_t>
+vaddr_to_offset(const target_elf& elf, uint64_t vaddr, uint64_t size)
+{
+    for(const auto& segment : elf.load_segments)
+    {
+        if(segment.p_type != PT_LOAD) continue;
+        if(vaddr < segment.p_vaddr) continue;
+        auto delta = vaddr - segment.p_vaddr;
+        if(delta > segment.p_filesz || size > segment.p_filesz - delta) continue;
+        return segment.p_offset + delta;
+    }
+    return std::nullopt;
+}
+
+bool
+symbol_is_supported_function(const Elf64_Sym& sym)
+{
+    auto type       = ELF64_ST_TYPE(sym.st_info);
+    auto bind       = ELF64_ST_BIND(sym.st_info);
+    auto visibility = ELF64_ST_VISIBILITY(sym.st_other);
+
+    return sym.st_shndx != SHN_UNDEF && type == STT_FUNC &&
+           (bind == STB_GLOBAL || bind == STB_WEAK) &&
+           (visibility == STV_DEFAULT || visibility == STV_PROTECTED);
+}
+
+std::optional<Elf64_Sym>
+lookup_symbol_from_sections(const target_elf& elf, std::string_view symbol_name)
+{
+    auto ehdr = read_as<Elf64_Ehdr>(elf.data, 0);
+    if(!ehdr || ehdr->e_shoff == 0 || ehdr->e_shnum == 0 ||
+       ehdr->e_shentsize != sizeof(Elf64_Shdr) ||
+       !has_range(elf.data.size(),
+                  ehdr->e_shoff,
+                  static_cast<uint64_t>(ehdr->e_shnum) * sizeof(Elf64_Shdr)))
+    {
+        return std::nullopt;
+    }
+
+    for(size_t i = 0; i < ehdr->e_shnum; ++i)
+    {
+        auto shdr = read_as<Elf64_Shdr>(elf.data, ehdr->e_shoff + i * sizeof(Elf64_Shdr));
+        if(!shdr || shdr->sh_type != SHT_DYNSYM || shdr->sh_entsize < sizeof(Elf64_Sym))
+        {
+            continue;
+        }
+        if(shdr->sh_link >= ehdr->e_shnum) continue;
+
+        auto strtab =
+            read_as<Elf64_Shdr>(elf.data, ehdr->e_shoff + shdr->sh_link * sizeof(Elf64_Shdr));
+        if(!strtab || !has_range(elf.data.size(), strtab->sh_offset, strtab->sh_size) ||
+           !has_range(elf.data.size(), shdr->sh_offset, shdr->sh_size))
+        {
+            continue;
+        }
+
+        auto symbol_count = shdr->sh_size / shdr->sh_entsize;
+        for(size_t idx = 0; idx < symbol_count; ++idx)
+        {
+            auto sym = read_as<Elf64_Sym>(elf.data, shdr->sh_offset + idx * shdr->sh_entsize);
+            if(!sym || sym->st_name >= strtab->sh_size) continue;
+            const auto* name =
+                reinterpret_cast<const char*>(elf.data.data() + strtab->sh_offset + sym->st_name);
+            auto max_name_len = strtab->sh_size - sym->st_name;
+            if(std::string_view{name, strnlen(name, max_name_len)} == symbol_name) return sym;
+        }
+    }
+
+    return std::nullopt;
+}
+
+std::optional<size_t>
+symbol_count_from_sysv_hash(const target_elf& elf, uint64_t hash_vaddr)
+{
+    auto hash_offset = vaddr_to_offset(elf, hash_vaddr, 2 * sizeof(uint32_t));
+    if(!hash_offset) return std::nullopt;
+
+    auto nchain = read_as<uint32_t>(elf.data, *hash_offset + sizeof(uint32_t));
+    if(!nchain) return std::nullopt;
+    return static_cast<size_t>(*nchain);
+}
+
+std::optional<size_t>
+symbol_count_from_gnu_hash(const target_elf& elf, uint64_t hash_vaddr)
+{
+    auto hash_offset = vaddr_to_offset(elf, hash_vaddr, 4 * sizeof(uint32_t));
+    if(!hash_offset) return std::nullopt;
+
+    auto nbuckets  = read_as<uint32_t>(elf.data, *hash_offset);
+    auto symndx    = read_as<uint32_t>(elf.data, *hash_offset + sizeof(uint32_t));
+    auto maskwords = read_as<uint32_t>(elf.data, *hash_offset + 2 * sizeof(uint32_t));
+    if(!nbuckets || !symndx || !maskwords) return std::nullopt;
+
+    auto buckets_offset =
+        *hash_offset + 4 * sizeof(uint32_t) + static_cast<uint64_t>(*maskwords) * sizeof(uint64_t);
+    if(!has_range(
+           elf.data.size(), buckets_offset, static_cast<uint64_t>(*nbuckets) * sizeof(uint32_t)))
+    {
+        return std::nullopt;
+    }
+
+    auto max_bucket = uint32_t{0};
+    for(uint32_t i = 0; i < *nbuckets; ++i)
+    {
+        auto bucket = read_as<uint32_t>(elf.data, buckets_offset + i * sizeof(uint32_t));
+        if(bucket) max_bucket = std::max(max_bucket, *bucket);
+    }
+    if(max_bucket < *symndx) return *symndx;
+
+    auto chains_offset = buckets_offset + static_cast<uint64_t>(*nbuckets) * sizeof(uint32_t);
+    auto chain_index   = static_cast<uint64_t>(max_bucket - *symndx);
+    while(has_range(
+        elf.data.size(), chains_offset + chain_index * sizeof(uint32_t), sizeof(uint32_t)))
+    {
+        auto chain = read_as<uint32_t>(elf.data, chains_offset + chain_index * sizeof(uint32_t));
+        if(!chain) return std::nullopt;
+        if((*chain & 1U) != 0) return static_cast<size_t>(*symndx + chain_index + 1);
+        ++chain_index;
+    }
+    return std::nullopt;
+}
+
+std::optional<Elf64_Sym>
+lookup_symbol_from_dynamic(const target_elf& elf, std::string_view symbol_name)
+{
+    auto dynamic_segment = std::optional<Elf64_Phdr>{};
+    auto ehdr            = read_as<Elf64_Ehdr>(elf.data, 0);
+    if(!ehdr) return std::nullopt;
+
+    for(size_t i = 0; i < ehdr->e_phnum; ++i)
+    {
+        auto phdr = read_as<Elf64_Phdr>(elf.data, ehdr->e_phoff + i * sizeof(Elf64_Phdr));
+        if(phdr && phdr->p_type == PT_DYNAMIC)
+        {
+            dynamic_segment = *phdr;
+            break;
+        }
+    }
+    if(!dynamic_segment ||
+       !has_range(elf.data.size(), dynamic_segment->p_offset, dynamic_segment->p_filesz))
+    {
+        return std::nullopt;
+    }
+
+    auto symtab_vaddr   = std::optional<uint64_t>{};
+    auto strtab_vaddr   = std::optional<uint64_t>{};
+    auto strsz          = std::optional<uint64_t>{};
+    auto syment         = uint64_t{sizeof(Elf64_Sym)};
+    auto hash_vaddr     = std::optional<uint64_t>{};
+    auto gnu_hash_vaddr = std::optional<uint64_t>{};
+
+    auto entries = dynamic_segment->p_filesz / sizeof(Elf64_Dyn);
+    for(size_t i = 0; i < entries; ++i)
+    {
+        auto dyn = read_as<Elf64_Dyn>(elf.data, dynamic_segment->p_offset + i * sizeof(Elf64_Dyn));
+        if(!dyn) return std::nullopt;
+        if(dyn->d_tag == DT_NULL) break;
+        if(dyn->d_tag == DT_SYMTAB) symtab_vaddr = dyn->d_un.d_ptr;
+        if(dyn->d_tag == DT_STRTAB) strtab_vaddr = dyn->d_un.d_ptr;
+        if(dyn->d_tag == DT_STRSZ) strsz = dyn->d_un.d_val;
+        if(dyn->d_tag == DT_SYMENT) syment = dyn->d_un.d_val;
+        if(dyn->d_tag == DT_HASH) hash_vaddr = dyn->d_un.d_ptr;
+        if(dyn->d_tag == DT_GNU_HASH) gnu_hash_vaddr = dyn->d_un.d_ptr;
+    }
+
+    if(!symtab_vaddr || !strtab_vaddr || !strsz || syment < sizeof(Elf64_Sym)) return std::nullopt;
+
+    auto symbol_count = std::optional<size_t>{};
+    if(hash_vaddr) symbol_count = symbol_count_from_sysv_hash(elf, *hash_vaddr);
+    if(!symbol_count && gnu_hash_vaddr)
+    {
+        symbol_count = symbol_count_from_gnu_hash(elf, *gnu_hash_vaddr);
+    }
+    if(!symbol_count) return std::nullopt;
+
+    auto symtab_offset = vaddr_to_offset(elf, *symtab_vaddr, *symbol_count * syment);
+    auto strtab_offset = vaddr_to_offset(elf, *strtab_vaddr, *strsz);
+    if(!symtab_offset || !strtab_offset) return std::nullopt;
+
+    for(size_t idx = 0; idx < *symbol_count; ++idx)
+    {
+        auto sym = read_as<Elf64_Sym>(elf.data, *symtab_offset + idx * syment);
+        if(!sym || sym->st_name >= *strsz) continue;
+        const auto* name =
+            reinterpret_cast<const char*>(elf.data.data() + *strtab_offset + sym->st_name);
+        auto max_name_len = *strsz - sym->st_name;
+        if(std::string_view{name, strnlen(name, max_name_len)} == symbol_name) return sym;
+    }
+
+    return std::nullopt;
+}
+
+std::optional<Elf64_Sym>
+lookup_dynamic_symbol(const target_elf& elf, std::string_view symbol_name)
+{
+    if(auto sym = lookup_symbol_from_sections(elf, symbol_name)) return sym;
+    return lookup_symbol_from_dynamic(elf, symbol_name);
+}
+
+bool
+address_in_executable_mapping(const mapped_object& object, uint64_t address)
+{
+    for(const auto& mapping : object.mappings)
+    {
+        if(mapping.permissions.find('x') == std::string::npos) continue;
+        if(address >= mapping.start && address < mapping.end) return true;
+    }
+    return false;
+}
+
+std::optional<uint64_t>
+resolve_target_symbol(pid_t pid, const mapped_object& object, std::string_view symbol)
+{
+    auto elf = open_target_elf(pid, object);
+    if(!elf || !parse_elf_headers(*elf)) return std::nullopt;
+
+    auto load_bias = calculate_load_bias(*elf, object);
+    if(!load_bias) return std::nullopt;
+
+    auto sym = lookup_dynamic_symbol(*elf, symbol);
+    if(!sym)
+    {
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Could not find dynamic symbol " << symbol
+                   << " in target ELF " << elf->path;
+        return std::nullopt;
+    }
+
+    if(!symbol_is_supported_function(*sym))
+    {
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Symbol " << symbol
+                   << " is not a supported exported function in " << elf->path;
+        return std::nullopt;
+    }
+
+    auto address = *load_bias + sym->st_value;
+    if(!address_in_executable_mapping(object, address))
+    {
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Resolved address 0x" << std::hex << address
+                   << std::dec << " for " << symbol << " is not inside an executable mapping for "
+                   << object.path;
+        return std::nullopt;
+    }
+
+    ROCP_INFO << "[rocprofiler-sdk-rocattach] Resolved " << symbol << " in target pid " << pid
+              << " from " << elf->path << " (mapped as " << object.path << ", dev "
+              << object.device_major << ":" << object.device_minor << ", inode " << object.inode
+              << ") at 0x" << std::hex << address << std::dec;
+    return address;
 }
 }  // namespace
 
 bool
 find_library(void*& addr, int inpid, const std::string& library)
 {
-    std::stringstream searchname;
-    searchname << inpid << "::" << library;
-    // TODO: add this back
-    // if (target_library_addrs.find(searchname.str()) != target_library_addrs.end())
-    //{
-    //    return target_library_addrs[searchname.str()];
-    //}
-
-    // uses "maps" file to find where library has been loaded in target process
-    // does not require this process to be attached
-    std::stringstream filename;
-    filename << "/proc/" << inpid << "/maps";
-    std::ifstream maps(filename.str().c_str());
-
-    if(!maps)
+    for(const auto& object : find_mapped_objects(inpid, library))
     {
-        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Couldn't open " << filename.str();
-        return false;
+        for(const auto& mapping : object.mappings)
+        {
+            if(mapping.file_offset != 0) continue;
+            // NOLINTNEXTLINE(performance-no-int-to-ptr)
+            addr = reinterpret_cast<void*>(mapping.start);
+            return true;
+        }
     }
 
-    std::string line;
-    bool        found = false;
-    while(std::getline(maps, line))
-    {
-        if(line.find(library) == std::string::npos) continue;
-
-        std::istringstream iss(line);
-        std::string        addr_range;
-        std::string        perms;
-        std::string        offset_str;
-        if(!(iss >> addr_range >> perms >> offset_str)) continue;
-        if(std::stoull(offset_str, nullptr, 16) != 0) continue;
-
-        ROCP_TRACE << "[rocprofiler-sdk-rocattach] Entry in pid " << inpid
-                   << " maps file is: " << line;
-        found = true;
-        break;
-    }
-
-    if(!found)
-    {
-        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Couldn't find library " << library
-                   << " (with file offset 0) in " << filename.str();
-        return false;
-    }
-
-    // NOLINTNEXTLINE(performance-no-int-to-ptr)
-    addr = reinterpret_cast<void*>(std::stoull(line, nullptr, 16));
-    //  target_library_addrs[searchname.str()] = addr;
-    return true;
+    ROCP_ERROR << "[rocprofiler-sdk-rocattach] Couldn't find library " << library
+               << " (with file offset 0) in /proc/" << inpid << "/maps";
+    return false;
 }
 
 bool
 find_symbol(int target_pid, void*& addr, const std::string& library, const std::string& symbol)
 {
-    auto searchname = std::stringstream{};
-    searchname << target_pid << "::" << library << "::" << symbol;
-    if(auto itr = m_target_symbol_addrs.find(searchname.str()); itr != m_target_symbol_addrs.end())
+    addr = nullptr;
+
+    auto objects = find_mapped_objects(target_pid, library);
+    if(objects.empty())
     {
-        ROCP_TRACE << "[rocprofiler-sdk-rocattach] Found symbol for " << searchname.str() << " at "
-                   << itr->second;
-        return itr->second != nullptr;
-    }
-
-    void* libraryaddr = nullptr;
-    void* symboladdr  = nullptr;
-
-    // Load the library in our process to determine the offset of the requested symbol from the
-    // start address of the library
-    addr        = nullptr;
-    libraryaddr = get_library_handle(library);
-
-    if(!libraryaddr)
-    {
-        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Host couldn't dlopen " << library;
+        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Couldn't find mapped target library " << library
+                   << " in /proc/" << target_pid << "/maps";
         return false;
     }
 
-    symboladdr = dlsym(libraryaddr, symbol.c_str());
-    if(!symboladdr)
+    for(const auto& object : objects)
     {
-        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Host couldn't dlsym " << symbol;
-        return false;
+        if(auto resolved = resolve_target_symbol(target_pid, object, symbol))
+        {
+            // NOLINTNEXTLINE(performance-no-int-to-ptr)
+            addr = reinterpret_cast<void*>(*resolved);
+            return true;
+        }
     }
 
-    // Find the start address of the library in our process
-    void* hostlibraryaddr;
-    if(!find_library(hostlibraryaddr, getpid(), library))
-    {
-        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Couldn't determine where " << library
-                   << " was loaded for host";
-        return false;
-    }
-
-    // Calculate the offset
-    size_t offset =
-        reinterpret_cast<size_t>(symboladdr) - reinterpret_cast<size_t>(hostlibraryaddr);
-    ROCP_TRACE << "[rocprofiler-sdk-rocattach] Offset of " << symbol << " into " << library
-               << " calculated as " << offset;
-
-    // Find the start address of the library in the target process
-    void* targetlibraryaddr;
-    if(!find_library(targetlibraryaddr, target_pid, library))
-    {
-        ROCP_ERROR << "[rocprofiler-sdk-rocattach] Couldn't determine where " << library
-                   << " was loaded for target";
-        return false;
-    }
-
-    // Calculate address of symbol in the target process using the offset
-    // NOLINTNEXTLINE(performance-no-int-to-ptr)
-    addr = reinterpret_cast<void*>(reinterpret_cast<size_t>(targetlibraryaddr) + offset);
-    m_target_symbol_addrs[searchname.str()] = addr;
-    ROCP_TRACE << "[rocprofiler-sdk-rocattach] Found symbol for " << searchname.str() << " at "
-               << addr;
-    return true;
+    ROCP_ERROR << "[rocprofiler-sdk-rocattach] Failed to resolve " << library << "::" << symbol
+               << " from target pid " << target_pid << " ELF mappings";
+    return false;
 }
 }  // namespace rocattach
 }  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach/symbol_lookup.hpp
@@ -29,9 +29,6 @@ namespace rocprofiler
 namespace rocattach
 {
 bool
-find_library(void*& addr, int inpid, const std::string& library);
-
-bool
 find_symbol(int target_pid, void*& addr, const std::string& library, const std::string& symbol);
 
 }  // namespace rocattach

--- a/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
@@ -75,12 +75,24 @@ target_compile_definitions(rocattach-symbol-lookup-fixture-shifted
 rocattach_add_symbol_lookup_fixture(rocattach-symbol-lookup-fixture-ambiguous-a 4 "")
 rocattach_add_symbol_lookup_fixture(rocattach-symbol-lookup-fixture-ambiguous-b 5 "")
 
+set(
+    ROCATTACH_SYMBOL_LOOKUP_SOURCE
+    "${CMAKE_CURRENT_LIST_DIR}/../../source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp"
+)
+
+install(
+    FILES "${ROCATTACH_SYMBOL_LOOKUP_SOURCE}"
+    DESTINATION
+        "${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach"
+    COMPONENT tests
+)
+
 add_executable(rocattach-symbol-lookup-test)
 target_sources(
     rocattach-symbol-lookup-test
     PRIVATE
         symbol_lookup_test.cpp
-        ${CMAKE_CURRENT_LIST_DIR}/../../source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
+        "${ROCATTACH_SYMBOL_LOOKUP_SOURCE}"
     )
 target_include_directories(
     rocattach-symbol-lookup-test

--- a/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
@@ -75,25 +75,19 @@ target_compile_definitions(rocattach-symbol-lookup-fixture-shifted
 rocattach_add_symbol_lookup_fixture(rocattach-symbol-lookup-fixture-ambiguous-a 4 "")
 rocattach_add_symbol_lookup_fixture(rocattach-symbol-lookup-fixture-ambiguous-b 5 "")
 
-set(
-    ROCATTACH_SYMBOL_LOOKUP_SOURCE
+set(ROCATTACH_SYMBOL_LOOKUP_SOURCE
     "${CMAKE_CURRENT_LIST_DIR}/../../source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp"
-)
+    )
 
 install(
     FILES "${ROCATTACH_SYMBOL_LOOKUP_SOURCE}"
     DESTINATION
         "${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach"
-    COMPONENT tests
-)
+    COMPONENT tests)
 
 add_executable(rocattach-symbol-lookup-test)
-target_sources(
-    rocattach-symbol-lookup-test
-    PRIVATE
-        symbol_lookup_test.cpp
-        "${ROCATTACH_SYMBOL_LOOKUP_SOURCE}"
-    )
+target_sources(rocattach-symbol-lookup-test PRIVATE symbol_lookup_test.cpp
+                                                    "${ROCATTACH_SYMBOL_LOOKUP_SOURCE}")
 target_include_directories(
     rocattach-symbol-lookup-test
     PRIVATE ${CMAKE_CURRENT_LIST_DIR}/../../source

--- a/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
@@ -79,10 +79,13 @@ set(ROCATTACH_SYMBOL_LOOKUP_SOURCE
     "${CMAKE_CURRENT_LIST_DIR}/../../source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp"
     )
 
+if(NOT EXISTS "${ROCATTACH_SYMBOL_LOOKUP_SOURCE}")
+    set(ROCATTACH_SYMBOL_LOOKUP_SOURCE "${CMAKE_CURRENT_LIST_DIR}/symbol_lookup.cpp")
+endif()
+
 install(
     FILES "${ROCATTACH_SYMBOL_LOOKUP_SOURCE}"
-    DESTINATION
-        "${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocattach"
+    DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-sdk/tests/rocattach"
     COMPONENT tests)
 
 add_executable(rocattach-symbol-lookup-test)

--- a/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
@@ -174,6 +174,18 @@ rocprofiler_add_integration_execute_test(
     PASS_REGULAR_EXPRESSION "does not refer to a regular file"
     FAIL_REGULAR_EXPRESSION "Expected ROCATTACH_STATUS_ERROR_INVALID_ARGUMENT")
 
+rocprofiler_add_integration_execute_test(
+    rocattach-empty-tool-path-test-execute
+    TARGET rocattach-tool-path-validation-test
+    ARGS --empty
+    TIMEOUT 5
+    LABELS "attachment"
+    ENVIRONMENT "${rocattach-test-env}"
+    DISABLED ${IS_DISABLED}
+    PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
+    PASS_REGULAR_EXPRESSION "Tool library path must not be empty"
+    FAIL_REGULAR_EXPRESSION "Expected ROCATTACH_STATUS_ERROR_INVALID_ARGUMENT")
+
 # Utilize rocattach to verify signals are correctly forwarded to a target application
 # during attachment
 rocprofiler_add_integration_execute_test(

--- a/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
@@ -47,6 +47,76 @@ target_link_libraries(
             rocprofiler-sdk::tests-common-library
             rocprofiler-sdk::rocprofiler-sdk-rocattach-shared-library)
 
+add_executable(rocattach-tool-path-validation-test)
+target_sources(rocattach-tool-path-validation-test PRIVATE tool_path_validation.cpp)
+target_link_libraries(
+    rocattach-tool-path-validation-test
+    PRIVATE rocprofiler-sdk::tests-build-flags
+            rocprofiler-sdk::rocprofiler-sdk-rocattach-shared-library)
+
+function(rocattach_add_symbol_lookup_fixture NAME VALUE HASH_STYLE)
+    add_library(${NAME} SHARED)
+    target_sources(${NAME} PRIVATE symbol_lookup_fixture.cpp)
+    target_compile_definitions(${NAME} PRIVATE ROCATTACH_FIXTURE_VALUE=${VALUE})
+    target_link_libraries(${NAME} PRIVATE rocprofiler-sdk::tests-build-flags)
+    set_target_properties(${NAME} PROPERTIES OUTPUT_NAME
+                                             "rocprofiler-register.so.${NAME}")
+    if(HASH_STYLE)
+        target_link_options(${NAME} PRIVATE "LINKER:--hash-style=${HASH_STYLE}")
+    endif()
+endfunction()
+
+rocattach_add_symbol_lookup_fixture(rocattach-symbol-lookup-fixture-normal 1 "")
+rocattach_add_symbol_lookup_fixture(rocattach-symbol-lookup-fixture-gnu 2 "gnu")
+rocattach_add_symbol_lookup_fixture(rocattach-symbol-lookup-fixture-sysv 3 "sysv")
+rocattach_add_symbol_lookup_fixture(rocattach-symbol-lookup-fixture-shifted 6 "")
+target_compile_definitions(rocattach-symbol-lookup-fixture-shifted
+                           PRIVATE ROCATTACH_FIXTURE_PADDED=1)
+rocattach_add_symbol_lookup_fixture(rocattach-symbol-lookup-fixture-ambiguous-a 4 "")
+rocattach_add_symbol_lookup_fixture(rocattach-symbol-lookup-fixture-ambiguous-b 5 "")
+
+add_executable(rocattach-symbol-lookup-test)
+target_sources(
+    rocattach-symbol-lookup-test
+    PRIVATE
+        symbol_lookup_test.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/../../source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp
+    )
+target_include_directories(
+    rocattach-symbol-lookup-test
+    PRIVATE ${CMAKE_CURRENT_LIST_DIR}/../../source
+            ${CMAKE_CURRENT_LIST_DIR}/../../source/lib/rocprofiler-sdk-rocattach)
+target_link_libraries(
+    rocattach-symbol-lookup-test
+    PRIVATE rocprofiler-sdk::rocprofiler-sdk-shared-library
+            rocprofiler-sdk::rocprofiler-sdk-headers
+            rocprofiler-sdk::rocprofiler-sdk-build-flags
+            rocprofiler-sdk::rocprofiler-sdk-common-library
+            ${CMAKE_DL_LIBS})
+add_dependencies(
+    rocattach-symbol-lookup-test
+    rocattach-symbol-lookup-fixture-normal
+    rocattach-symbol-lookup-fixture-gnu
+    rocattach-symbol-lookup-fixture-sysv
+    rocattach-symbol-lookup-fixture-shifted
+    rocattach-symbol-lookup-fixture-ambiguous-a
+    rocattach-symbol-lookup-fixture-ambiguous-b)
+
+rocprofiler_add_integration_execute_test(
+    rocattach-symbol-lookup-test-execute
+    TARGET rocattach-symbol-lookup-test
+    ARGS $<TARGET_FILE:rocattach-symbol-lookup-fixture-normal>
+         $<TARGET_FILE:rocattach-symbol-lookup-fixture-gnu>
+         $<TARGET_FILE:rocattach-symbol-lookup-fixture-sysv>
+         $<TARGET_FILE:rocattach-symbol-lookup-fixture-shifted>
+         $<TARGET_FILE:rocattach-symbol-lookup-fixture-ambiguous-a>
+         $<TARGET_FILE:rocattach-symbol-lookup-fixture-ambiguous-b>
+    TIMEOUT 30
+    LABELS "attachment"
+    PASS_REGULAR_EXPRESSION
+        "Test PASSED: target ELF resolver resolved exact mapped libraries and rejected ambiguous and malformed mappings"
+    FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
+
 # Utilize rocattach to use a generic C tool in a basic app
 rocprofiler_add_integration_execute_test(
     rocattach-parallel-attach-test-execute
@@ -60,6 +130,32 @@ rocprofiler_add_integration_execute_test(
     PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
     PASS_REGULAR_EXPRESSION "Test C tool \\(priority=0\\) is using rocprofiler-sdk v"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
+
+# Verify absolute tool library paths fail early when target-side dlopen could not resolve
+# them from the target mount namespace.
+rocprofiler_add_integration_execute_test(
+    rocattach-missing-tool-path-test-execute
+    TARGET rocattach-tool-path-validation-test
+    ARGS /tmp/rocattach-missing-tool-library-does-not-exist.so
+    TIMEOUT 5
+    LABELS "attachment"
+    ENVIRONMENT "${rocattach-test-env}"
+    DISABLED ${IS_DISABLED}
+    PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
+    PASS_REGULAR_EXPRESSION "is absolute but is not visible"
+    FAIL_REGULAR_EXPRESSION "Expected ROCATTACH_STATUS_ERROR_INVALID_ARGUMENT")
+
+rocprofiler_add_integration_execute_test(
+    rocattach-nonregular-tool-path-test-execute
+    TARGET rocattach-tool-path-validation-test
+    ARGS /tmp
+    TIMEOUT 5
+    LABELS "attachment"
+    ENVIRONMENT "${rocattach-test-env}"
+    DISABLED ${IS_DISABLED}
+    PRELOAD "${ROCPROFILER_MEMCHECK_PRELOAD_ENV_VALUE}"
+    PASS_REGULAR_EXPRESSION "does not refer to a regular file"
+    FAIL_REGULAR_EXPRESSION "Expected ROCATTACH_STATUS_ERROR_INVALID_ARGUMENT")
 
 # Utilize rocattach to verify signals are correctly forwarded to a target application
 # during attachment

--- a/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
@@ -54,78 +54,85 @@ target_link_libraries(
     PRIVATE rocprofiler-sdk::tests-build-flags
             rocprofiler-sdk::rocprofiler-sdk-rocattach-shared-library)
 
-function(rocattach_add_symbol_lookup_fixture NAME VALUE HASH_STYLE)
-    add_library(${NAME} SHARED)
-    target_sources(${NAME} PRIVATE symbol_lookup_fixture.cpp)
-    target_compile_definitions(${NAME} PRIVATE ROCATTACH_FIXTURE_VALUE=${VALUE})
-    target_link_libraries(${NAME} PRIVATE rocprofiler-sdk::tests-build-flags)
-    set_target_properties(${NAME} PROPERTIES OUTPUT_NAME
-                                             "rocprofiler-register.so.${NAME}")
-    if(HASH_STYLE)
-        target_link_options(${NAME} PRIVATE "LINKER:--hash-style=${HASH_STYLE}")
+if(TARGET rocprofiler-sdk::rocprofiler-sdk-build-flags
+   AND TARGET rocprofiler-sdk::rocprofiler-sdk-common-library)
+    set(ROCATTACH_SYMBOL_LOOKUP_SOURCE_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../source")
+    set(ROCATTACH_SYMBOL_LOOKUP_SOURCE
+        "${ROCATTACH_SYMBOL_LOOKUP_SOURCE_ROOT}/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp"
+        )
+
+    if(NOT EXISTS "${ROCATTACH_SYMBOL_LOOKUP_SOURCE}")
+        message(
+            FATAL_ERROR
+                "Missing rocattach symbol lookup source: ${ROCATTACH_SYMBOL_LOOKUP_SOURCE}"
+            )
     endif()
-endfunction()
 
-rocattach_add_symbol_lookup_fixture(rocattach-symbol-lookup-fixture-normal 1 "")
-rocattach_add_symbol_lookup_fixture(rocattach-symbol-lookup-fixture-gnu 2 "gnu")
-rocattach_add_symbol_lookup_fixture(rocattach-symbol-lookup-fixture-sysv 3 "sysv")
-rocattach_add_symbol_lookup_fixture(rocattach-symbol-lookup-fixture-shifted 6 "")
-target_compile_definitions(rocattach-symbol-lookup-fixture-shifted
-                           PRIVATE ROCATTACH_FIXTURE_PADDED=1)
-rocattach_add_symbol_lookup_fixture(rocattach-symbol-lookup-fixture-ambiguous-a 4 "")
-rocattach_add_symbol_lookup_fixture(rocattach-symbol-lookup-fixture-ambiguous-b 5 "")
+    function(rocattach_add_symbol_lookup_fixture NAME VALUE HASH_STYLE)
+        add_library(${NAME} SHARED)
+        target_sources(${NAME} PRIVATE symbol_lookup_fixture.cpp)
+        target_compile_definitions(${NAME} PRIVATE ROCATTACH_FIXTURE_VALUE=${VALUE})
+        target_link_libraries(${NAME} PRIVATE rocprofiler-sdk::tests-build-flags)
+        set_target_properties(${NAME} PROPERTIES OUTPUT_NAME
+                                                 "rocprofiler-register.so.${NAME}")
+        if(HASH_STYLE)
+            target_link_options(${NAME} PRIVATE "LINKER:--hash-style=${HASH_STYLE}")
+        endif()
+    endfunction()
 
-set(ROCATTACH_SYMBOL_LOOKUP_SOURCE
-    "${CMAKE_CURRENT_LIST_DIR}/../../source/lib/rocprofiler-sdk-rocattach/symbol_lookup.cpp"
-    )
+    rocattach_add_symbol_lookup_fixture(rocattach-symbol-lookup-fixture-normal 1 "")
+    rocattach_add_symbol_lookup_fixture(rocattach-symbol-lookup-fixture-gnu 2 "gnu")
+    rocattach_add_symbol_lookup_fixture(rocattach-symbol-lookup-fixture-sysv 3 "sysv")
+    rocattach_add_symbol_lookup_fixture(rocattach-symbol-lookup-fixture-shifted 6 "")
+    target_compile_definitions(rocattach-symbol-lookup-fixture-shifted
+                               PRIVATE ROCATTACH_FIXTURE_PADDED=1)
+    rocattach_add_symbol_lookup_fixture(rocattach-symbol-lookup-fixture-ambiguous-a 4 "")
+    rocattach_add_symbol_lookup_fixture(rocattach-symbol-lookup-fixture-ambiguous-b 5 "")
 
-if(NOT EXISTS "${ROCATTACH_SYMBOL_LOOKUP_SOURCE}")
-    set(ROCATTACH_SYMBOL_LOOKUP_SOURCE "${CMAKE_CURRENT_LIST_DIR}/symbol_lookup.cpp")
+    add_executable(rocattach-symbol-lookup-test)
+    target_sources(rocattach-symbol-lookup-test
+                   PRIVATE symbol_lookup_test.cpp "${ROCATTACH_SYMBOL_LOOKUP_SOURCE}")
+    target_include_directories(
+        rocattach-symbol-lookup-test
+        PRIVATE "${ROCATTACH_SYMBOL_LOOKUP_SOURCE_ROOT}"
+                "${ROCATTACH_SYMBOL_LOOKUP_SOURCE_ROOT}/lib/rocprofiler-sdk-rocattach")
+    target_link_libraries(
+        rocattach-symbol-lookup-test
+        PRIVATE rocprofiler-sdk::rocprofiler-sdk-shared-library
+                rocprofiler-sdk::rocprofiler-sdk-headers
+                rocprofiler-sdk::rocprofiler-sdk-build-flags
+                rocprofiler-sdk::rocprofiler-sdk-common-library
+                ${CMAKE_DL_LIBS})
+    add_dependencies(
+        rocattach-symbol-lookup-test
+        rocattach-symbol-lookup-fixture-normal
+        rocattach-symbol-lookup-fixture-gnu
+        rocattach-symbol-lookup-fixture-sysv
+        rocattach-symbol-lookup-fixture-shifted
+        rocattach-symbol-lookup-fixture-ambiguous-a
+        rocattach-symbol-lookup-fixture-ambiguous-b)
+
+    rocprofiler_add_integration_execute_test(
+        rocattach-symbol-lookup-test-execute
+        TARGET rocattach-symbol-lookup-test
+        ARGS $<TARGET_FILE:rocattach-symbol-lookup-fixture-normal>
+             $<TARGET_FILE:rocattach-symbol-lookup-fixture-gnu>
+             $<TARGET_FILE:rocattach-symbol-lookup-fixture-sysv>
+             $<TARGET_FILE:rocattach-symbol-lookup-fixture-shifted>
+             $<TARGET_FILE:rocattach-symbol-lookup-fixture-ambiguous-a>
+             $<TARGET_FILE:rocattach-symbol-lookup-fixture-ambiguous-b>
+        TIMEOUT 30
+        LABELS "attachment"
+        ENVIRONMENT "${rocattach-test-env}"
+        PASS_REGULAR_EXPRESSION
+            "Test PASSED: target ELF resolver resolved exact mapped libraries and rejected ambiguous and malformed mappings"
+        FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
+else()
+    message(
+        STATUS
+            "Skipping rocattach-symbol-lookup-test: internal rocprofiler-sdk targets are unavailable"
+        )
 endif()
-
-install(
-    FILES "${ROCATTACH_SYMBOL_LOOKUP_SOURCE}"
-    DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-sdk/tests/rocattach"
-    COMPONENT tests)
-
-add_executable(rocattach-symbol-lookup-test)
-target_sources(rocattach-symbol-lookup-test PRIVATE symbol_lookup_test.cpp
-                                                    "${ROCATTACH_SYMBOL_LOOKUP_SOURCE}")
-target_include_directories(
-    rocattach-symbol-lookup-test
-    PRIVATE ${CMAKE_CURRENT_LIST_DIR}/../../source
-            ${CMAKE_CURRENT_LIST_DIR}/../../source/lib/rocprofiler-sdk-rocattach)
-target_link_libraries(
-    rocattach-symbol-lookup-test
-    PRIVATE rocprofiler-sdk::rocprofiler-sdk-shared-library
-            rocprofiler-sdk::rocprofiler-sdk-headers
-            rocprofiler-sdk::rocprofiler-sdk-build-flags
-            rocprofiler-sdk::rocprofiler-sdk-common-library
-            ${CMAKE_DL_LIBS})
-add_dependencies(
-    rocattach-symbol-lookup-test
-    rocattach-symbol-lookup-fixture-normal
-    rocattach-symbol-lookup-fixture-gnu
-    rocattach-symbol-lookup-fixture-sysv
-    rocattach-symbol-lookup-fixture-shifted
-    rocattach-symbol-lookup-fixture-ambiguous-a
-    rocattach-symbol-lookup-fixture-ambiguous-b)
-
-rocprofiler_add_integration_execute_test(
-    rocattach-symbol-lookup-test-execute
-    TARGET rocattach-symbol-lookup-test
-    ARGS $<TARGET_FILE:rocattach-symbol-lookup-fixture-normal>
-         $<TARGET_FILE:rocattach-symbol-lookup-fixture-gnu>
-         $<TARGET_FILE:rocattach-symbol-lookup-fixture-sysv>
-         $<TARGET_FILE:rocattach-symbol-lookup-fixture-shifted>
-         $<TARGET_FILE:rocattach-symbol-lookup-fixture-ambiguous-a>
-         $<TARGET_FILE:rocattach-symbol-lookup-fixture-ambiguous-b>
-    TIMEOUT 30
-    LABELS "attachment"
-    ENVIRONMENT "${rocattach-test-env}"
-    PASS_REGULAR_EXPRESSION
-        "Test PASSED: target ELF resolver resolved exact mapped libraries and rejected ambiguous and malformed mappings"
-    FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")
 
 # Utilize rocattach to use a generic C tool in a basic app
 rocprofiler_add_integration_execute_test(

--- a/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocattach/CMakeLists.txt
@@ -122,6 +122,7 @@ rocprofiler_add_integration_execute_test(
          $<TARGET_FILE:rocattach-symbol-lookup-fixture-ambiguous-b>
     TIMEOUT 30
     LABELS "attachment"
+    ENVIRONMENT "${rocattach-test-env}"
     PASS_REGULAR_EXPRESSION
         "Test PASSED: target ELF resolver resolved exact mapped libraries and rejected ambiguous and malformed mappings"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")

--- a/projects/rocprofiler-sdk/tests/rocattach/symbol_lookup_fixture.cpp
+++ b/projects/rocprofiler-sdk/tests/rocattach/symbol_lookup_fixture.cpp
@@ -1,0 +1,52 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef ROCATTACH_FIXTURE_VALUE
+#    define ROCATTACH_FIXTURE_VALUE 0
+#endif
+
+#ifdef ROCATTACH_FIXTURE_PADDED
+// Force this fixture to place the attach symbol at a different offset than the
+// normal fixture, while keeping the exported attach ABI the same.
+extern "C" __attribute__((visibility("default"), noinline, used)) int
+rocattach_layout_padding_function(int value)
+{
+    volatile int result = value;
+    for(int i = 0; i < 1024; ++i)
+    {
+        result += i;
+    }
+    return result;
+}
+#endif
+
+extern "C" __attribute__((visibility("default"))) int
+rocprofiler_register_attach()
+{
+    return ROCATTACH_FIXTURE_VALUE;
+}
+
+extern "C" __attribute__((visibility("default"))) int
+rocprofiler_register_detach()
+{
+    return -ROCATTACH_FIXTURE_VALUE;
+}

--- a/projects/rocprofiler-sdk/tests/rocattach/symbol_lookup_test.cpp
+++ b/projects/rocprofiler-sdk/tests/rocattach/symbol_lookup_test.cpp
@@ -22,6 +22,8 @@
 
 #include "symbol_lookup.hpp"
 
+#include "lib/common/scope_destructor.hpp"
+
 #include <dlfcn.h>
 #include <elf.h>
 #include <fcntl.h>
@@ -46,9 +48,26 @@ constexpr auto ATTACH_SYMBOL_NAME    = "rocprofiler_register_attach";
 
 struct loaded_library
 {
-    std::string path   = {};
-    void*       handle = nullptr;
+    std::string path              = {};
+    void*       handle            = nullptr;
+    bool        remove_on_cleanup = false;
 };
+
+void
+cleanup_loaded_library(loaded_library& library)
+{
+    if(library.handle != nullptr)
+    {
+        dlclose(library.handle);
+        library.handle = nullptr;
+    }
+
+    if(library.remove_on_cleanup && !library.path.empty())
+    {
+        std::error_code ec;
+        std::filesystem::remove(library.path, ec);
+    }
+}
 
 loaded_library
 load_library(const char* path)
@@ -179,7 +198,9 @@ create_and_load_sectionless_copy(const loaded_library& source, std::string_view 
         std::exit(1);
     }
 
-    return load_library(path_buffer.c_str());
+    auto library              = load_library(path_buffer.c_str());
+    library.remove_on_cleanup = true;
+    return library;
 }
 
 void
@@ -252,12 +273,19 @@ main(int argc, char** argv)
     expect_resolves_to_dlsym(libraries.at(2));
     expect_resolves_to_dlsym(libraries.at(3));
     expect_different_symbol_offsets(libraries.at(0), libraries.at(3));
-    auto sectionless_normal = create_and_load_sectionless_copy(libraries.at(0), "normal");
-    auto sectionless_gnu    = create_and_load_sectionless_copy(libraries.at(1), "gnu");
-    auto sectionless_sysv   = create_and_load_sectionless_copy(libraries.at(2), "sysv");
-    expect_resolves_to_dlsym(sectionless_normal);
-    expect_resolves_to_dlsym(sectionless_gnu);
-    expect_resolves_to_dlsym(sectionless_sysv);
+    {
+        auto sectionless_normal  = create_and_load_sectionless_copy(libraries.at(0), "normal");
+        auto sectionless_gnu     = create_and_load_sectionless_copy(libraries.at(1), "gnu");
+        auto sectionless_sysv    = create_and_load_sectionless_copy(libraries.at(2), "sysv");
+        auto cleanup_sectionless = rocprofiler::common::scope_destructor{[&]() {
+            cleanup_loaded_library(sectionless_sysv);
+            cleanup_loaded_library(sectionless_gnu);
+            cleanup_loaded_library(sectionless_normal);
+        }};
+        expect_resolves_to_dlsym(sectionless_normal);
+        expect_resolves_to_dlsym(sectionless_gnu);
+        expect_resolves_to_dlsym(sectionless_sysv);
+    }
     expect_ambiguous_basename_fails();
     expect_malformed_mapped_elf_fails();
 

--- a/projects/rocprofiler-sdk/tests/rocattach/symbol_lookup_test.cpp
+++ b/projects/rocprofiler-sdk/tests/rocattach/symbol_lookup_test.cpp
@@ -36,6 +36,7 @@
 #include <fstream>
 #include <iostream>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace
@@ -136,10 +137,11 @@ expect_ambiguous_basename_fails()
 }
 
 loaded_library
-create_and_load_sectionless_copy(const loaded_library& source)
+create_and_load_sectionless_copy(const loaded_library& source, std::string_view label)
 {
-    auto path = std::filesystem::temp_directory_path() /
-                "librocprofiler-register.so.rocattach-sectionless-XXXXXX";
+    auto path =
+        std::filesystem::temp_directory_path() /
+        ("librocprofiler-register.so.rocattach-sectionless-" + std::string{label} + "-XXXXXX");
     auto path_buffer = path.string();
     auto fd          = mkstemp(path_buffer.data());
     if(fd < 0)
@@ -250,8 +252,12 @@ main(int argc, char** argv)
     expect_resolves_to_dlsym(libraries.at(2));
     expect_resolves_to_dlsym(libraries.at(3));
     expect_different_symbol_offsets(libraries.at(0), libraries.at(3));
-    auto sectionless = create_and_load_sectionless_copy(libraries.at(0));
-    expect_resolves_to_dlsym(sectionless);
+    auto sectionless_normal = create_and_load_sectionless_copy(libraries.at(0), "normal");
+    auto sectionless_gnu    = create_and_load_sectionless_copy(libraries.at(1), "gnu");
+    auto sectionless_sysv   = create_and_load_sectionless_copy(libraries.at(2), "sysv");
+    expect_resolves_to_dlsym(sectionless_normal);
+    expect_resolves_to_dlsym(sectionless_gnu);
+    expect_resolves_to_dlsym(sectionless_sysv);
     expect_ambiguous_basename_fails();
     expect_malformed_mapped_elf_fails();
 

--- a/projects/rocprofiler-sdk/tests/rocattach/symbol_lookup_test.cpp
+++ b/projects/rocprofiler-sdk/tests/rocattach/symbol_lookup_test.cpp
@@ -1,0 +1,261 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include "symbol_lookup.hpp"
+
+#include <dlfcn.h>
+#include <elf.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <array>
+#include <cstddef>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace
+{
+constexpr auto REGISTER_LIBRARY_NAME = "librocprofiler-register.so";
+constexpr auto ATTACH_SYMBOL_NAME    = "rocprofiler_register_attach";
+
+struct loaded_library
+{
+    std::string path   = {};
+    void*       handle = nullptr;
+};
+
+loaded_library
+load_library(const char* path)
+{
+    auto* handle = dlopen(path, RTLD_NOW | RTLD_LOCAL);
+    if(!handle)
+    {
+        std::cerr << "dlopen failed for " << path << ": " << dlerror() << '\n';
+        std::exit(1);
+    }
+    return loaded_library{path, handle};
+}
+
+uintptr_t
+symbol_offset(const loaded_library& library)
+{
+    auto* expected = dlsym(library.handle, ATTACH_SYMBOL_NAME);
+    if(!expected)
+    {
+        std::cerr << "dlsym failed for " << library.path << "::" << ATTACH_SYMBOL_NAME << ": "
+                  << dlerror() << '\n';
+        std::exit(1);
+    }
+
+    auto info = Dl_info{};
+    if(dladdr(expected, &info) == 0 || !info.dli_fbase)
+    {
+        std::cerr << "dladdr failed for " << library.path << "::" << ATTACH_SYMBOL_NAME << '\n';
+        std::exit(1);
+    }
+
+    return reinterpret_cast<uintptr_t>(expected) - reinterpret_cast<uintptr_t>(info.dli_fbase);
+}
+
+void
+expect_resolves_to_dlsym(const loaded_library& library)
+{
+    auto* expected = dlsym(library.handle, ATTACH_SYMBOL_NAME);
+    if(!expected)
+    {
+        std::cerr << "dlsym failed for " << library.path << "::" << ATTACH_SYMBOL_NAME << ": "
+                  << dlerror() << '\n';
+        std::exit(1);
+    }
+
+    void* resolved = nullptr;
+    if(!rocprofiler::rocattach::find_symbol(getpid(), resolved, library.path, ATTACH_SYMBOL_NAME))
+    {
+        std::cerr << "find_symbol failed for exact mapped path " << library.path << '\n';
+        std::exit(1);
+    }
+
+    if(resolved != expected)
+    {
+        std::cerr << "find_symbol returned " << resolved << " for " << library.path
+                  << ", expected dlsym address " << expected << '\n';
+        std::exit(1);
+    }
+}
+
+void
+expect_different_symbol_offsets(const loaded_library& first, const loaded_library& second)
+{
+    auto first_offset  = symbol_offset(first);
+    auto second_offset = symbol_offset(second);
+    if(first_offset == second_offset)
+    {
+        std::cerr << "Expected different symbol offsets for " << first.path << " and "
+                  << second.path << ", but both were 0x" << std::hex << first_offset << std::dec
+                  << '\n';
+        std::exit(1);
+    }
+}
+
+void
+expect_ambiguous_basename_fails()
+{
+    void* resolved = nullptr;
+    if(rocprofiler::rocattach::find_symbol(
+           getpid(), resolved, REGISTER_LIBRARY_NAME, ATTACH_SYMBOL_NAME))
+    {
+        std::cerr << "find_symbol unexpectedly resolved ambiguous " << REGISTER_LIBRARY_NAME
+                  << " to " << resolved << '\n';
+        std::exit(1);
+    }
+}
+
+loaded_library
+create_and_load_sectionless_copy(const loaded_library& source)
+{
+    auto path = std::filesystem::temp_directory_path() /
+                "librocprofiler-register.so.rocattach-sectionless-XXXXXX";
+    auto path_buffer = path.string();
+    auto fd          = mkstemp(path_buffer.data());
+    if(fd < 0)
+    {
+        std::cerr << "mkstemp failed for sectionless ELF fixture\n";
+        std::exit(1);
+    }
+    close(fd);
+
+    std::ifstream input{source.path, std::ios::binary};
+    std::ofstream output{path_buffer, std::ios::binary | std::ios::trunc};
+    output << input.rdbuf();
+    input.close();
+    output.close();
+
+    std::fstream elf{path_buffer, std::ios::binary | std::ios::in | std::ios::out};
+    if(!elf)
+    {
+        std::cerr << "failed to open sectionless ELF copy " << path_buffer << '\n';
+        std::exit(1);
+    }
+
+    const auto zero64 = uint64_t{0};
+    const auto zero16 = uint16_t{0};
+    // Make section-header lookup impossible so the resolver must use PT_DYNAMIC.
+    elf.seekp(offsetof(Elf64_Ehdr, e_shoff));
+    elf.write(reinterpret_cast<const char*>(&zero64), sizeof(zero64));
+    elf.seekp(offsetof(Elf64_Ehdr, e_shnum));
+    elf.write(reinterpret_cast<const char*>(&zero16), sizeof(zero16));
+    elf.seekp(offsetof(Elf64_Ehdr, e_shstrndx));
+    elf.write(reinterpret_cast<const char*>(&zero16), sizeof(zero16));
+    if(!elf)
+    {
+        std::cerr << "failed to patch section header fields in " << path_buffer << '\n';
+        std::exit(1);
+    }
+
+    return load_library(path_buffer.c_str());
+}
+
+void
+expect_malformed_mapped_elf_fails()
+{
+    auto path = std::filesystem::temp_directory_path() /
+                "librocprofiler-register.so.rocattach-malformed-XXXXXX";
+    auto path_buffer = path.string();
+    auto fd          = mkstemp(path_buffer.data());
+    if(fd < 0)
+    {
+        std::cerr << "mkstemp failed for malformed ELF fixture\n";
+        std::exit(1);
+    }
+
+    constexpr auto contents = std::string_view{"not-an-elf"};
+    if(write(fd, contents.data(), contents.size()) != static_cast<ssize_t>(contents.size()))
+    {
+        std::cerr << "write failed for malformed ELF fixture\n";
+        close(fd);
+        std::exit(1);
+    }
+
+    auto* mapping = mmap(nullptr, contents.size(), PROT_READ, MAP_PRIVATE, fd, 0);
+    close(fd);
+    if(mapping == MAP_FAILED)
+    {
+        std::cerr << "mmap failed for malformed ELF fixture\n";
+        std::exit(1);
+    }
+
+    // The resolver should inspect mapped files defensively and fail before
+    // treating arbitrary mapped bytes as an ELF shared object.
+    void* resolved = nullptr;
+    if(rocprofiler::rocattach::find_symbol(getpid(), resolved, path_buffer, ATTACH_SYMBOL_NAME))
+    {
+        std::cerr << "find_symbol unexpectedly resolved malformed mapped ELF " << path_buffer
+                  << " to " << resolved << '\n';
+        munmap(mapping, contents.size());
+        std::filesystem::remove(path_buffer);
+        std::exit(1);
+    }
+
+    munmap(mapping, contents.size());
+    std::filesystem::remove(path_buffer);
+}
+}  // namespace
+
+int
+main(int argc, char** argv)
+{
+    if(argc != 7)
+    {
+        std::cerr << "Usage: " << argv[0]
+                  << " <normal-lib> <gnu-hash-lib> <sysv-hash-lib> <shifted-lib> "
+                     "<ambiguous-a> <ambiguous-b>\n";
+        return 1;
+    }
+
+    auto libraries = std::vector<loaded_library>{};
+    libraries.reserve(6);
+    for(auto* path :
+        std::array<const char*, 6>{argv[1], argv[2], argv[3], argv[4], argv[5], argv[6]})
+    {
+        libraries.emplace_back(load_library(path));
+    }
+
+    expect_resolves_to_dlsym(libraries.at(0));
+    expect_resolves_to_dlsym(libraries.at(1));
+    expect_resolves_to_dlsym(libraries.at(2));
+    expect_resolves_to_dlsym(libraries.at(3));
+    expect_different_symbol_offsets(libraries.at(0), libraries.at(3));
+    auto sectionless = create_and_load_sectionless_copy(libraries.at(0));
+    expect_resolves_to_dlsym(sectionless);
+    expect_ambiguous_basename_fails();
+    expect_malformed_mapped_elf_fails();
+
+    std::cout << "Test PASSED: target ELF resolver resolved exact mapped libraries and rejected "
+                 "ambiguous and malformed mappings\n";
+    return 0;
+}

--- a/projects/rocprofiler-sdk/tests/rocattach/tool_path_validation.cpp
+++ b/projects/rocprofiler-sdk/tests/rocattach/tool_path_validation.cpp
@@ -25,17 +25,21 @@
 #include <unistd.h>
 
 #include <iostream>
+#include <string_view>
 
 int
 main(int argc, char** argv)
 {
     if(argc != 2)
     {
-        std::cerr << "Usage: " << argv[0] << " <tool-library-path>\n";
+        std::cerr << "Usage: " << argv[0] << " <tool-library-path|--empty>\n";
         return 1;
     }
 
-    setenv("ROCPROF_ATTACH_TOOL_LIBRARY", argv[1], 1);
+    auto tool_library_path = std::string_view{argv[1]};
+    if(tool_library_path == "--empty") tool_library_path = "";
+
+    setenv("ROCPROF_ATTACH_TOOL_LIBRARY", tool_library_path.data(), 1);
     // Invalid absolute paths should be rejected before rocattach needs a real
     // attach-enabled target thread, keeping this negative test fast.
     auto status = rocattach_attach(getpid());

--- a/projects/rocprofiler-sdk/tests/rocattach/tool_path_validation.cpp
+++ b/projects/rocprofiler-sdk/tests/rocattach/tool_path_validation.cpp
@@ -1,0 +1,50 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <rocprofiler-sdk-rocattach/rocattach.h>
+
+#include <unistd.h>
+
+#include <iostream>
+
+int
+main(int argc, char** argv)
+{
+    if(argc != 2)
+    {
+        std::cerr << "Usage: " << argv[0] << " <tool-library-path>\n";
+        return 1;
+    }
+
+    setenv("ROCPROF_ATTACH_TOOL_LIBRARY", argv[1], 1);
+    // Invalid absolute paths should be rejected before rocattach needs a real
+    // attach-enabled target thread, keeping this negative test fast.
+    auto status = rocattach_attach(getpid());
+    if(status != ROCATTACH_STATUS_ERROR_INVALID_ARGUMENT)
+    {
+        std::cerr << "Expected ROCATTACH_STATUS_ERROR_INVALID_ARGUMENT, got " << status << '\n';
+        return 1;
+    }
+
+    std::cout << "Test PASSED: invalid absolute tool library path rejected before attach setup\n";
+    return 0;
+}


### PR DESCRIPTION
## Motivation

This PR improves rocprofv3 attach support for containerized target processes. 

The current rocattach symbol resolution assumes the host and target `librocprofiler-register.so` have identical ELF layouts by calculating a symbol offset from the host library and applying it to the target mapping. This is fragile when attaching from the host to a process inside a container, where the target may use a different library path or binary layout.

The goal is to resolve attach entry points from the target process’s own mapped ELF and validate target-visible tool paths before injection.

## Technical Details

### `symbol_lookup.cpp` (Main changes)
The current symbol_lookup.cpp flow is:
```
find_symbol(pid, addr, library, symbol)
  -> select_unique_mapped_object(pid, library)
  -> resolve_target_symbol(pid, mapped_object, symbol)
       -> open_target_elf(pid, mapped_object)
       -> parse ELF headers and load segments with ELFIO
       -> calculate load bias from the mapped object
       -> look up the symbol through SHT_DYNSYM
          or fall back to PT_DYNAMIC for section-headerless ELF files
       -> address = load_bias + sym.st_value
       -> validate address is inside an executable mapping
```

- Resolve `rocprofiler_register_attach` / `rocprofiler_register_detach` from the target process’s mapped `librocprofiler-register.so` instead of using host-computed symbol offsets. 
- Parse `/proc/<pid>/maps` to identify mapped register libraries by device/inode. 
- Open the target mapped ELF through `/proc/<pid>/map_files`, with `/proc/<pid>/root` fallback. 
- Parse ELF dynamic symbol information w/ ELFIO, retain a bounded PT_DYNAMIC fallback for section-headerless ELF files, supporting both GNU and SysV hash metadata.
- Calculate target runtime addresses using target ELF load bias and symbol values. 
- Reject ambiguous matching libraries instead of selecting the first match.
- Validate resolved symbols against executable target mappings. 
- Add bounds checks and limits for ELF parsing to handle malformed inputs more safely.

### `rocattach.cpp`
- Validate absolute `ROCPROF_ATTACH_TOOL_LIBRARY` paths from the target process’s mount namespace using `/proc/<pid>/root`. 
- Fail early when the target-visible tool library path is missing or is not a regular file. 

### `tests/rocattach` 
- Add fixture shared libraries for normal, GNU-hash, SysV-hash, shifted-layout, and ambiguous-library test cases. 
- Add symbol lookup tests for target ELF resolution. 
- Add coverage for shifted symbol layout where the target attach symbol offset differs. 
- Add tests for ambiguous mapped library rejection. 
- Add malformed ELF failure handling tests. 
- Add target tool path validation tests for missing and non-regular paths.

This change removes the identical ELF-layout requirement between host and target `librocprofiler-register.so`, **while still assuming the same rocprofiler-register attach ABI.**

Requirements and Caveat:
- [ ] Document host-to-container attach requirements and ABI compatibility caveat.

## JIRA ID

JIRA ID : AIPROFSDK-907

## Test Plan

- Added rocattach symbol lookup tests with fixture shared libraries.
- Tested normal dynamic symbol lookup.
- Tested GNU-hash and SysV-hash symbol resolution.
- Tested shifted-layout fixture where the target attach symbol offset differs.
- Tested ambiguous mapped library rejection.
- Tested malformed mapped ELF failure handling.
- Tested absolute target tool path validation for missing and non-regular paths.

## Test Result

Existing and new tests pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
