### PR TITLE
fix(rocprofiler-sdk): Missing gfx942_agent_kernels in unit tests

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/CMakeLists.txt
@@ -30,6 +30,31 @@ function(generate_hsaco TARGET_ID INPUT_FILE OUTPUT_FILE)
         PARENT_SCOPE)
 endfunction(generate_hsaco)
 
+# GPU_TARGETS is normally populated by tests/common/CMakeLists.txt, which is only pulled
+# in when building the integration test tree (add_subdirectory(tests) from the top-level
+# CMakeLists.txt). When this unit test directory is configured on its own (e.g. building
+# only the library + unit tests, without the integration tests), GPU_TARGETS may be unset,
+# silently skipping generation/installation of the *_agent_kernels.hsaco files that these
+# tests require at runtime. Fall back to the same defaults used by the integration test
+# tree so the required code objects are always built.
+if(NOT GPU_TARGETS)
+    set(GPU_TARGETS
+        "gfx900"
+        "gfx906"
+        "gfx908"
+        "gfx90a"
+        "gfx942"
+        "gfx950"
+        "gfx1030"
+        "gfx1010"
+        "gfx1100"
+        "gfx1101"
+        "gfx1102"
+        "gfx1151"
+        "gfx1152"
+        "gfx1250")
+endif()
+
 foreach(target_id ${GPU_TARGETS})
     # generate kernel bitcodes
     generate_hsaco(${target_id} ${CMAKE_CURRENT_SOURCE_DIR}/agent_kernels.cl


### PR DESCRIPTION
## Summary
Fixes #8303: `device_counting_service_test.*` unit tests fail with `Could not load code object gfx942_agent_kernels.hsaco` when the counters unit-test directory is configured/built independently of the integration test tree.

## Root Cause
`GPU_TARGETS` is normally populated (from `DEFAULT_GPU_TARGETS`) by `tests/common/CMakeLists.txt`, which is only pulled in via the integration-test tree (`add_subdirectory(tests)` from the top-level `CMakeLists.txt`). When `source/lib/rocprofiler-sdk/counters/tests/CMakeLists.txt` is configured without that integration-test tree, `GPU_TARGETS` can be unset. The `foreach(target_id ${GPU_TARGETS})` loop then does nothing, so `gfx942_agent_kernels.hsaco` (and the other per-arch HSACOs) never get built or installed to `share/rocprofiler-sdk/tests/unit-tests/bin/`. At runtime, `device_counting_service_test` aborts with:

```
F0708 ... code_object_loader.cpp:41] Could not load code object gfx942_agent_kernels.hsaco
```

All 7 affected tests (`sync_counters`, `async_counters`, `sync_grbm_verify`, `sync_gpu_util_verify`, `sync_sq_waves_verify`, `sync_sq_waves_verify_non_intercept`, `raw_sq_waves_verify`) fail identically at initialization, before hardware counters are ever exercised.

## Changes

### Modified Files
- `projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/CMakeLists.txt` - Added a fallback: if `GPU_TARGETS` is unset when this file is processed, default it to the same GPU target list used by the integration test tree (`tests/common/CMakeLists.txt`), so the required `.hsaco` files are always generated/installed regardless of how (or whether) `GPU_TARGETS` is propagated by the caller.

## Testing
- Verified the file is `cmake-format` clean (`cmake-format --check` passes, `cmake-format -i` produces no diff).
- Cherry-picked this commit onto the head of PR #4788 in a separate verification branch and manually dispatched `therock-ci.yml` (`workflow_dispatch`) scoped to `projects/rocprofiler-sdk` on `gfx94X`. Result: 905/905 tests passed, including all previously-failing `device_counting_service_test.*` cases, with no occurrence of the `gfx942_agent_kernels.hsaco` / "Could not load code object" error in the logs. CI run: https://github.com/ROCm/rocm-systems/actions/runs/29041716799

## Related Issues
Fixes #8303