### PR TITLE
fix(rocdbgapi): accept smaller entry_size from older KFD snapshots

### DIFF
--- a/projects/rocdbgapi/src/os_driver_kfd.cpp
+++ b/projects/rocdbgapi/src/os_driver_kfd.cpp
@@ -1443,7 +1443,7 @@ kfd_driver_t::kfd_agent_snapshot (kfd_dbg_device_info_entry *agents_infos,
   if (err == -ESRCH)
     return AMD_DBGAPI_STATUS_ERROR_PROCESS_EXITED;
   else if (args.device_snapshot.entry_size
-             != sizeof (kfd_dbg_device_info_entry)
+             > sizeof (kfd_dbg_device_info_entry)
            || err < 0)
     return AMD_DBGAPI_STATUS_ERROR;
 
@@ -1781,7 +1781,7 @@ kfd_driver_t::kfd_queue_snapshot (kfd_queue_snapshot_entry *snapshots,
   int err = kfd_dbg_trap_ioctl (KFD_IOC_DBG_TRAP_GET_QUEUE_SNAPSHOT, &args);
   if (err == -ESRCH)
     return AMD_DBGAPI_STATUS_ERROR_PROCESS_EXITED;
-  else if (args.queue_snapshot.entry_size != sizeof (kfd_queue_snapshot_entry)
+  else if (args.queue_snapshot.entry_size > sizeof (kfd_queue_snapshot_entry)
            || err < 0)
     return AMD_DBGAPI_STATUS_ERROR;
 


### PR DESCRIPTION
## Motivation

Per kfd_ioctl.h, entry_size is an IN/OUT field — the caller passes the size of its struct, and KFD writes back the number of bytes it actually populated. An older KFD driver will return a smaller value (it has a smaller struct), which is perfectly valid. The != check incorrectly treated that as an error.

## Technical Details

Fix: Changed != to > in both locations. This correctly accepts an older KFD returning fewer bytes (the unread fields in the caller's zero-initialized vector stay zero), and only errors if KFD somehow returned a larger entry size than the struct we know about.

JIRA ID : AIROCGDB-620