### PR TITLE
feat(rocr): enforce required gfx1250 hotswap rewrites

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
@@ -277,6 +277,7 @@ TEST(HotswapRewriteDecision, A0RetargetsWithoutStrictModeRegardlessOfOptions) {
     EXPECT_EQ(decision->target_isa, kGfx1250A0Isa);
     EXPECT_FALSE(decision->request_entry_trampolines);
     EXPECT_FALSE(decision->request_strict_mode);
+    EXPECT_TRUE(decision->rewrite_required);
   }
 }
 
@@ -291,6 +292,7 @@ TEST(HotswapRewriteDecision, StrictModeDisabledDoesNotBlockA0Retarget) {
   EXPECT_EQ(decision->source_isa, kGfx1250B0Isa);
   EXPECT_EQ(decision->target_isa, kGfx1250A0Isa);
   EXPECT_FALSE(decision->request_strict_mode);
+  EXPECT_TRUE(decision->rewrite_required);
 }
 
 TEST(HotswapRewriteDecision, EntryTrampolinesDefaultOnRoutesNonA0Gfx1250) {
@@ -302,6 +304,7 @@ TEST(HotswapRewriteDecision, EntryTrampolinesDefaultOnRoutesNonA0Gfx1250) {
   EXPECT_EQ(decision->target_isa, kGfx1250B0Isa);
   EXPECT_TRUE(decision->request_entry_trampolines);
   EXPECT_FALSE(decision->request_strict_mode);
+  EXPECT_FALSE(decision->rewrite_required);
 }
 
 TEST(HotswapRewriteDecision, StrictModeEnabledRoutesNonA0Gfx1250Strict) {
@@ -316,6 +319,7 @@ TEST(HotswapRewriteDecision, StrictModeEnabledRoutesNonA0Gfx1250Strict) {
   EXPECT_EQ(decision->target_isa, kGfx1250B0Isa);
   EXPECT_TRUE(decision->request_entry_trampolines);
   EXPECT_TRUE(decision->request_strict_mode);
+  EXPECT_TRUE(decision->rewrite_required);
 }
 
 TEST(HotswapRewriteDecision, EntryTrampolinesDisabledKeepsNonA0Gfx1250StrictWhenEnabled) {
@@ -331,6 +335,7 @@ TEST(HotswapRewriteDecision, EntryTrampolinesDisabledKeepsNonA0Gfx1250StrictWhen
   EXPECT_EQ(decision->target_isa, kGfx1250B0Isa);
   EXPECT_FALSE(decision->request_entry_trampolines);
   EXPECT_TRUE(decision->request_strict_mode);
+  EXPECT_TRUE(decision->rewrite_required);
 }
 
 TEST(HotswapRewriteDecision, NonA0Gfx1250NoDecisionWhenEntryAndStrictDisabled) {
@@ -356,11 +361,13 @@ TEST(HotswapRewriteDecision, EntryTrampolinesRouteGfx12_5Family) {
   EXPECT_EQ(concrete->target_isa, kGfx1251Isa);
   EXPECT_TRUE(concrete->request_entry_trampolines);
   EXPECT_FALSE(concrete->request_strict_mode);
+  EXPECT_FALSE(concrete->rewrite_required);
   ASSERT_TRUE(generic.has_value());
   EXPECT_EQ(generic->source_isa, kGfx12_5GenericIsa);
   EXPECT_EQ(generic->target_isa, kGfx12_5GenericIsa);
   EXPECT_TRUE(generic->request_entry_trampolines);
   EXPECT_FALSE(generic->request_strict_mode);
+  EXPECT_FALSE(generic->rewrite_required);
 }
 
 TEST(HotswapRewriteDecision, EntryTrampolinesUseGenericSourceAsTarget) {
@@ -372,6 +379,7 @@ TEST(HotswapRewriteDecision, EntryTrampolinesUseGenericSourceAsTarget) {
   EXPECT_EQ(decision->target_isa, kGfx12_5GenericIsa);
   EXPECT_TRUE(decision->request_entry_trampolines);
   EXPECT_FALSE(decision->request_strict_mode);
+  EXPECT_FALSE(decision->rewrite_required);
 }
 
 TEST(HotswapRewriteDecision, EntryTrampolinesBlockNonGfx12_5) {
@@ -678,6 +686,25 @@ TEST(HotswapRewrite, RuntimeLoadRequiredStrictRewriteFailureReturnsError) {
   rocr::hotswap::ForceRetargetCodeObjectFailureForTesting(false);
 }
 
+TEST(HotswapRewrite, RuntimeLoadRequiredA0RewriteFailureReturnsError) {
+  ResetRuntimeTestEnv();
+  if (!ComgrHotswapOptionsApiAvailable()) return;
+  rocr::hotswap::ForceRetargetCodeObjectFailureForTesting(true);
+  LoadRecorder load;
+  const hsa_executable_t executable = MakeTestExecutable(0x512);
+
+  const hsa_status_t status = rocr::hotswap::LoadAgentCodeObjectWithHotswap(
+      executable, MakeTestAgent(), MakeRealCodeObjectView(), nullptr, nullptr,
+      MakeLoadCallbacks(&load));
+
+  EXPECT_EQ(status, HSA_STATUS_ERROR_INVALID_CODE_OBJECT);
+  EXPECT_TRUE(load.calls.empty());
+  EXPECT_EQ(
+      rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 0u);
+
+  rocr::hotswap::ForceRetargetCodeObjectFailureForTesting(false);
+}
+
 TEST(HotswapRewrite, RuntimeLoadOptionalRewrittenLoadFailureFallsBackToOriginal) {
   ResetRuntimeTestEnv();
   if (!ComgrHotswapOptionsApiAvailable()) return;
@@ -695,6 +722,24 @@ TEST(HotswapRewrite, RuntimeLoadOptionalRewrittenLoadFailureFallsBackToOriginal)
   EXPECT_EQ(load.calls[0].path, LoadPath::kRewritten);
   EXPECT_EQ(load.calls[1].path, LoadPath::kOriginal);
   EXPECT_EQ(load.calls[1].code_object, static_cast<const void*>(kGfx1250MinCo));
+  EXPECT_EQ(
+      rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 0u);
+}
+
+TEST(HotswapRewrite, RuntimeLoadRequiredA0RewrittenLoadFailureReturnsError) {
+  ResetRuntimeTestEnv();
+  if (!ComgrHotswapOptionsApiAvailable()) return;
+  LoadRecorder load;
+  load.rewritten_status = HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
+  const hsa_executable_t executable = MakeTestExecutable(0x513);
+
+  const hsa_status_t status = rocr::hotswap::LoadAgentCodeObjectWithHotswap(
+      executable, MakeTestAgent(), MakeRealCodeObjectView(), nullptr, nullptr,
+      MakeLoadCallbacks(&load));
+
+  EXPECT_EQ(status, HSA_STATUS_ERROR_INVALID_CODE_OBJECT);
+  ASSERT_EQ(load.calls.size(), 1u);
+  EXPECT_EQ(load.calls[0].path, LoadPath::kRewritten);
   EXPECT_EQ(
       rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 0u);
 }

--- a/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
@@ -298,8 +298,8 @@ TEST(HotswapRewriteDecision, EntryTrampolinesDefaultOnRoutesNonA0Gfx1250) {
       MakeRevision("gfx1250", 1), kGfx1250Isa, kGfx1250Isa, {});
 
   ASSERT_TRUE(decision.has_value());
-  EXPECT_EQ(decision->source_isa, kGfx1250Isa);
-  EXPECT_EQ(decision->target_isa, kGfx1250Isa);
+  EXPECT_EQ(decision->source_isa, kGfx1250B0Isa);
+  EXPECT_EQ(decision->target_isa, kGfx1250B0Isa);
   EXPECT_TRUE(decision->request_entry_trampolines);
   EXPECT_FALSE(decision->request_strict_mode);
 }

--- a/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
@@ -241,7 +241,7 @@ rocr::hotswap::AgentGfxRevision MakeRevision(const std::string& gfx_target,
   return revision;
 }
 
-TEST(HotswapRewriteDecision, A0RetargetsThroughStrictModeRegardlessOfOptions) {
+TEST(HotswapRewriteDecision, A0RetargetsWithoutStrictModeRegardlessOfOptions) {
   const rocr::hotswap::RewriteOptions options[] = {{}, {false}};
   for (const auto& option : options) {
     SCOPED_TRACE(option.gfx12_5_rewrite_enabled ? "entry trampolines enabled"
@@ -253,23 +253,40 @@ TEST(HotswapRewriteDecision, A0RetargetsThroughStrictModeRegardlessOfOptions) {
     EXPECT_EQ(decision->source_isa, kGfx1250B0Isa);
     EXPECT_EQ(decision->target_isa, kGfx1250A0Isa);
     EXPECT_FALSE(decision->request_entry_trampolines);
-    EXPECT_TRUE(decision->request_strict_mode);
+    EXPECT_FALSE(decision->request_strict_mode);
   }
 }
 
-TEST(HotswapRewriteDecision, StrictModeDisabledBlocksA0Retarget) {
+TEST(HotswapRewriteDecision, StrictModeDisabledDoesNotBlockA0Retarget) {
   rocr::hotswap::RewriteOptions options;
   options.strict_mode_enabled = false;
 
   const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
       MakeRevision("gfx1250", 0), kGfx1250Isa, kGfx1250Isa, options);
 
-  EXPECT_FALSE(decision.has_value());
+  ASSERT_TRUE(decision.has_value());
+  EXPECT_EQ(decision->source_isa, kGfx1250B0Isa);
+  EXPECT_EQ(decision->target_isa, kGfx1250A0Isa);
+  EXPECT_FALSE(decision->request_strict_mode);
 }
 
 TEST(HotswapRewriteDecision, EntryTrampolinesDefaultOnRoutesNonA0Gfx1250) {
   const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
       MakeRevision("gfx1250", 1), kGfx1250Isa, kGfx1250Isa, {});
+
+  ASSERT_TRUE(decision.has_value());
+  EXPECT_EQ(decision->source_isa, kGfx1250Isa);
+  EXPECT_EQ(decision->target_isa, kGfx1250Isa);
+  EXPECT_TRUE(decision->request_entry_trampolines);
+  EXPECT_FALSE(decision->request_strict_mode);
+}
+
+TEST(HotswapRewriteDecision, StrictModeEnabledRoutesNonA0Gfx1250Strict) {
+  rocr::hotswap::RewriteOptions options;
+  options.strict_mode_enabled = true;
+
+  const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
+      MakeRevision("gfx1250", 1), kGfx1250Isa, kGfx1250Isa, options);
 
   ASSERT_TRUE(decision.has_value());
   EXPECT_EQ(decision->source_isa, kGfx1250B0Isa);
@@ -278,15 +295,30 @@ TEST(HotswapRewriteDecision, EntryTrampolinesDefaultOnRoutesNonA0Gfx1250) {
   EXPECT_TRUE(decision->request_strict_mode);
 }
 
-TEST(HotswapRewriteDecision, EntryTrampolinesDisabledKeepsNonA0Gfx1250Strict) {
+TEST(HotswapRewriteDecision, EntryTrampolinesDisabledKeepsNonA0Gfx1250StrictWhenEnabled) {
+  rocr::hotswap::RewriteOptions options;
+  options.gfx12_5_rewrite_enabled = false;
+  options.strict_mode_enabled = true;
+
   const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
-      MakeRevision("gfx1250", 1), kGfx1250Isa, kGfx1250Isa, {false});
+      MakeRevision("gfx1250", 1), kGfx1250Isa, kGfx1250Isa, options);
 
   ASSERT_TRUE(decision.has_value());
   EXPECT_EQ(decision->source_isa, kGfx1250B0Isa);
   EXPECT_EQ(decision->target_isa, kGfx1250B0Isa);
   EXPECT_FALSE(decision->request_entry_trampolines);
   EXPECT_TRUE(decision->request_strict_mode);
+}
+
+TEST(HotswapRewriteDecision, NonA0Gfx1250NoDecisionWhenEntryAndStrictDisabled) {
+  rocr::hotswap::RewriteOptions options;
+  options.gfx12_5_rewrite_enabled = false;
+  options.strict_mode_enabled = false;
+
+  const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
+      MakeRevision("gfx1250", 1), kGfx1250Isa, kGfx1250Isa, options);
+
+  EXPECT_FALSE(decision.has_value());
 }
 
 TEST(HotswapRewriteDecision, EntryTrampolinesRouteGfx12_5Family) {
@@ -462,13 +494,34 @@ TEST(HotswapRewrite, RuntimeLoadNonA0UsesDefaultEntryTrampolines) {
       rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 0u);
 }
 
-TEST(HotswapRewrite, RuntimeLoadNonA0UsesStrictWhenEntryTrampolinesAreZero) {
+TEST(HotswapRewrite, RuntimeLoadNonA0FallsBackWhenEntryTrampolinesAreZeroAndStrictUnset) {
   ResetRuntimeTestEnv();
   if (!ComgrHotswapOptionsApiAvailable()) return;
   g_fake_hsa_env.asic_revision = 1;
   g_fake_env_vars["AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES"] = "0";
   LoadRecorder load;
   const hsa_executable_t executable = MakeTestExecutable(0x503);
+
+  const hsa_status_t status = rocr::hotswap::LoadAgentCodeObjectWithHotswap(
+      executable, MakeTestAgent(), MakeRealCodeObjectView(), nullptr, nullptr,
+      MakeLoadCallbacks(&load));
+
+  EXPECT_EQ(status, HSA_STATUS_SUCCESS);
+  ASSERT_EQ(load.calls.size(), 1u);
+  EXPECT_EQ(load.calls[0].path, LoadPath::kOriginal);
+  EXPECT_EQ(load.calls[0].code_object, static_cast<const void*>(kGfx1250MinCo));
+  EXPECT_EQ(
+      rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 0u);
+}
+
+TEST(HotswapRewrite, RuntimeLoadNonA0UsesStrictModeEnvWhenEntryTrampolinesAreZero) {
+  ResetRuntimeTestEnv();
+  if (!ComgrHotswapOptionsApiAvailable()) return;
+  g_fake_hsa_env.asic_revision = 1;
+  g_fake_env_vars["AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES"] = "0";
+  g_fake_env_vars["HSA_HOTSWAP_STRICT_MODE"] = "1";
+  LoadRecorder load;
+  const hsa_executable_t executable = MakeTestExecutable(0x504);
 
   const hsa_status_t status = rocr::hotswap::LoadAgentCodeObjectWithHotswap(
       executable, MakeTestAgent(), MakeRealCodeObjectView(), nullptr, nullptr,
@@ -490,7 +543,7 @@ TEST(HotswapRewrite, RuntimeLoadNonA0UsesStrictWhenEntryTrampolinesAreZero) {
 TEST(HotswapRewrite, RuntimeLoadNonA0UsesEntryTrampolinesUnlessEnvIsZero) {
   if (!ComgrHotswapOptionsApiAvailable()) return;
   const char* const env_values[] = {"false", ""};
-  uint64_t executable_handle = 0x504;
+  uint64_t executable_handle = 0x505;
   for (const char* env_value : env_values) {
     SCOPED_TRACE(env_value);
     ResetRuntimeTestEnv();
@@ -584,6 +637,8 @@ TEST(HotswapRewrite, RuntimeLoadOptionalRewriteFailureFallsBackToOriginal) {
 TEST(HotswapRewrite, RuntimeLoadRequiredStrictRewriteFailureReturnsError) {
   ResetRuntimeTestEnv();
   if (!ComgrHotswapOptionsApiAvailable()) return;
+  g_fake_hsa_env.asic_revision = 1;
+  g_fake_env_vars["HSA_HOTSWAP_STRICT_MODE"] = "1";
   rocr::hotswap::ForceRetargetCodeObjectFailureForTesting(true);
   LoadRecorder load;
   const hsa_executable_t executable = MakeTestExecutable(0x509);
@@ -624,6 +679,8 @@ TEST(HotswapRewrite, RuntimeLoadOptionalRewrittenLoadFailureFallsBackToOriginal)
 TEST(HotswapRewrite, RuntimeLoadRequiredStrictRewrittenLoadFailureReturnsError) {
   ResetRuntimeTestEnv();
   if (!ComgrHotswapOptionsApiAvailable()) return;
+  g_fake_hsa_env.asic_revision = 1;
+  g_fake_env_vars["HSA_HOTSWAP_STRICT_MODE"] = "1";
   LoadRecorder load;
   load.rewritten_status = HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
   const hsa_executable_t executable = MakeTestExecutable(0x511);

--- a/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
@@ -210,6 +210,22 @@ bool ComgrHotswapOptionsApiAvailable() {
   return false;
 }
 
+bool ComgrStrictModeApiAvailable() {
+  if (!ComgrHotswapOptionsApiAvailable()) return false;
+
+  rocr::hotswap::OwnedElfBuffer rewritten_elf_buffer(nullptr, &std::free);
+  size_t rewritten_elf_size = 0;
+  if (rocr::hotswap::RetargetCodeObject(
+          kGfx1250MinCo, sizeof(kGfx1250MinCo), kGfx1250B0Isa, kGfx1250B0Isa,
+          &rewritten_elf_buffer, &rewritten_elf_size,
+          false, true)) {
+    return true;
+  }
+
+  SUCCEED() << "requires COMGR accepting AMD_COMGR_HOTSWAP_REWRITE_FLAG_STRICT_MODE";
+  return false;
+}
+
 hsa_agent_t MakeTestAgent() {
   hsa_agent_t agent{};
   agent.handle = 1;
@@ -242,10 +258,17 @@ rocr::hotswap::AgentGfxRevision MakeRevision(const std::string& gfx_target,
 }
 
 TEST(HotswapRewriteDecision, A0RetargetsWithoutStrictModeRegardlessOfOptions) {
-  const rocr::hotswap::RewriteOptions options[] = {{}, {false}};
+  rocr::hotswap::RewriteOptions entry_trampolines_disabled;
+  entry_trampolines_disabled.gfx12_5_rewrite_enabled = false;
+  rocr::hotswap::RewriteOptions strict_mode_enabled;
+  strict_mode_enabled.strict_mode_enabled = true;
+  const rocr::hotswap::RewriteOptions options[] = {
+      {}, entry_trampolines_disabled, strict_mode_enabled};
   for (const auto& option : options) {
-    SCOPED_TRACE(option.gfx12_5_rewrite_enabled ? "entry trampolines enabled"
-                                                : "entry trampolines disabled");
+    SCOPED_TRACE(option.gfx12_5_rewrite_enabled
+                     ? (option.strict_mode_enabled ? "strict mode enabled"
+                                                   : "default options")
+                     : "entry trampolines disabled");
     const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
         MakeRevision("gfx1250", 0), kGfx1250Isa, kGfx1250Isa, option);
 
@@ -516,7 +539,7 @@ TEST(HotswapRewrite, RuntimeLoadNonA0FallsBackWhenEntryTrampolinesAreZeroAndStri
 
 TEST(HotswapRewrite, RuntimeLoadNonA0UsesStrictModeEnvWhenEntryTrampolinesAreZero) {
   ResetRuntimeTestEnv();
-  if (!ComgrHotswapOptionsApiAvailable()) return;
+  if (!ComgrStrictModeApiAvailable()) return;
   g_fake_hsa_env.asic_revision = 1;
   g_fake_env_vars["AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES"] = "0";
   g_fake_env_vars["HSA_HOTSWAP_STRICT_MODE"] = "1";
@@ -678,7 +701,7 @@ TEST(HotswapRewrite, RuntimeLoadOptionalRewrittenLoadFailureFallsBackToOriginal)
 
 TEST(HotswapRewrite, RuntimeLoadRequiredStrictRewrittenLoadFailureReturnsError) {
   ResetRuntimeTestEnv();
-  if (!ComgrHotswapOptionsApiAvailable()) return;
+  if (!ComgrStrictModeApiAvailable()) return;
   g_fake_hsa_env.asic_revision = 1;
   g_fake_env_vars["HSA_HOTSWAP_STRICT_MODE"] = "1";
   LoadRecorder load;

--- a/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
@@ -199,6 +199,7 @@ void ResetRuntimeTestEnv() {
   g_fake_hsa_env = FakeHsaEnv{};
   g_fake_env_vars.clear();
   rocr::hotswap::ResetAgentGfxRevisionCache();
+  rocr::hotswap::ForceRetargetCodeObjectFailureForTesting(false);
 }
 
 bool ComgrHotswapOptionsApiAvailable() {
@@ -558,12 +559,54 @@ TEST(HotswapRewrite, RuntimeLoadRewriteFailureFallsBackToOriginal) {
       rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 0u);
 }
 
-TEST(HotswapRewrite, RuntimeLoadRewrittenLoadFailureFallsBackToOriginal) {
+TEST(HotswapRewrite, RuntimeLoadOptionalRewriteFailureFallsBackToOriginal) {
   ResetRuntimeTestEnv();
   if (!ComgrHotswapOptionsApiAvailable()) return;
+  g_fake_hsa_env.isa_name = kGfx1251Isa;
+  rocr::hotswap::ForceRetargetCodeObjectFailureForTesting(true);
+  LoadRecorder load;
+  const hsa_executable_t executable = MakeTestExecutable(0x508);
+
+  const hsa_status_t status = rocr::hotswap::LoadAgentCodeObjectWithHotswap(
+      executable, MakeTestAgent(), MakeRealCodeObjectView(), nullptr, nullptr,
+      MakeLoadCallbacks(&load));
+
+  EXPECT_EQ(status, HSA_STATUS_SUCCESS);
+  ASSERT_EQ(load.calls.size(), 1u);
+  EXPECT_EQ(load.calls[0].path, LoadPath::kOriginal);
+  EXPECT_EQ(load.calls[0].code_object, static_cast<const void*>(kGfx1250MinCo));
+  EXPECT_EQ(
+      rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 0u);
+
+  rocr::hotswap::ForceRetargetCodeObjectFailureForTesting(false);
+}
+
+TEST(HotswapRewrite, RuntimeLoadRequiredStrictRewriteFailureReturnsError) {
+  ResetRuntimeTestEnv();
+  if (!ComgrHotswapOptionsApiAvailable()) return;
+  rocr::hotswap::ForceRetargetCodeObjectFailureForTesting(true);
+  LoadRecorder load;
+  const hsa_executable_t executable = MakeTestExecutable(0x509);
+
+  const hsa_status_t status = rocr::hotswap::LoadAgentCodeObjectWithHotswap(
+      executable, MakeTestAgent(), MakeRealCodeObjectView(), nullptr, nullptr,
+      MakeLoadCallbacks(&load));
+
+  EXPECT_EQ(status, HSA_STATUS_ERROR_INVALID_CODE_OBJECT);
+  EXPECT_TRUE(load.calls.empty());
+  EXPECT_EQ(
+      rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 0u);
+
+  rocr::hotswap::ForceRetargetCodeObjectFailureForTesting(false);
+}
+
+TEST(HotswapRewrite, RuntimeLoadOptionalRewrittenLoadFailureFallsBackToOriginal) {
+  ResetRuntimeTestEnv();
+  if (!ComgrHotswapOptionsApiAvailable()) return;
+  g_fake_hsa_env.isa_name = kGfx1251Isa;
   LoadRecorder load;
   load.rewritten_status = HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
-  const hsa_executable_t executable = MakeTestExecutable(0x508);
+  const hsa_executable_t executable = MakeTestExecutable(0x510);
 
   const hsa_status_t status = rocr::hotswap::LoadAgentCodeObjectWithHotswap(
       executable, MakeTestAgent(), MakeRealCodeObjectView(), nullptr, nullptr,
@@ -574,6 +617,24 @@ TEST(HotswapRewrite, RuntimeLoadRewrittenLoadFailureFallsBackToOriginal) {
   EXPECT_EQ(load.calls[0].path, LoadPath::kRewritten);
   EXPECT_EQ(load.calls[1].path, LoadPath::kOriginal);
   EXPECT_EQ(load.calls[1].code_object, static_cast<const void*>(kGfx1250MinCo));
+  EXPECT_EQ(
+      rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 0u);
+}
+
+TEST(HotswapRewrite, RuntimeLoadRequiredStrictRewrittenLoadFailureReturnsError) {
+  ResetRuntimeTestEnv();
+  if (!ComgrHotswapOptionsApiAvailable()) return;
+  LoadRecorder load;
+  load.rewritten_status = HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
+  const hsa_executable_t executable = MakeTestExecutable(0x511);
+
+  const hsa_status_t status = rocr::hotswap::LoadAgentCodeObjectWithHotswap(
+      executable, MakeTestAgent(), MakeRealCodeObjectView(), nullptr, nullptr,
+      MakeLoadCallbacks(&load));
+
+  EXPECT_EQ(status, HSA_STATUS_ERROR_INVALID_CODE_OBJECT);
+  ASSERT_EQ(load.calls.size(), 1u);
+  EXPECT_EQ(load.calls[0].path, LoadPath::kRewritten);
   EXPECT_EQ(
       rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 0u);
 }

--- a/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
@@ -258,17 +258,16 @@ rocr::hotswap::AgentGfxRevision MakeRevision(const std::string& gfx_target,
 }
 
 TEST(HotswapRewriteDecision, A0RetargetsWithoutStrictModeRegardlessOfOptions) {
-  rocr::hotswap::RewriteOptions entry_trampolines_disabled;
-  entry_trampolines_disabled.gfx12_5_rewrite_enabled = false;
+  rocr::hotswap::RewriteOptions entry_trampolines_enabled;
+  entry_trampolines_enabled.entry_trampolines_enabled = true;
   rocr::hotswap::RewriteOptions strict_mode_enabled;
   strict_mode_enabled.strict_mode_enabled = true;
   const rocr::hotswap::RewriteOptions options[] = {
-      {}, entry_trampolines_disabled, strict_mode_enabled};
+      {}, entry_trampolines_enabled, strict_mode_enabled};
   for (const auto& option : options) {
-    SCOPED_TRACE(option.gfx12_5_rewrite_enabled
-                     ? (option.strict_mode_enabled ? "strict mode enabled"
-                                                   : "default options")
-                     : "entry trampolines disabled");
+    SCOPED_TRACE(option.entry_trampolines_enabled
+                     ? "entry trampolines enabled"
+                     : (option.strict_mode_enabled ? "strict mode enabled" : "default options"));
     const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
         MakeRevision("gfx1250", 0), kGfx1250Isa, kGfx1250Isa, option);
 
@@ -295,9 +294,19 @@ TEST(HotswapRewriteDecision, StrictModeDisabledDoesNotBlockA0Retarget) {
   EXPECT_TRUE(decision->rewrite_required);
 }
 
-TEST(HotswapRewriteDecision, EntryTrampolinesDefaultOnRoutesNonA0Gfx1250) {
+TEST(HotswapRewriteDecision, EntryTrampolinesDefaultOffBlocksNonA0Gfx1250) {
   const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
       MakeRevision("gfx1250", 1), kGfx1250Isa, kGfx1250Isa, {});
+
+  EXPECT_FALSE(decision.has_value());
+}
+
+TEST(HotswapRewriteDecision, EntryTrampolinesEnabledRoutesNonA0Gfx1250) {
+  rocr::hotswap::RewriteOptions options;
+  options.entry_trampolines_enabled = true;
+
+  const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
+      MakeRevision("gfx1250", 1), kGfx1250Isa, kGfx1250Isa, options);
 
   ASSERT_TRUE(decision.has_value());
   EXPECT_EQ(decision->source_isa, kGfx1250B0Isa);
@@ -317,14 +326,14 @@ TEST(HotswapRewriteDecision, StrictModeEnabledRoutesNonA0Gfx1250Strict) {
   ASSERT_TRUE(decision.has_value());
   EXPECT_EQ(decision->source_isa, kGfx1250B0Isa);
   EXPECT_EQ(decision->target_isa, kGfx1250B0Isa);
-  EXPECT_TRUE(decision->request_entry_trampolines);
+  EXPECT_FALSE(decision->request_entry_trampolines);
   EXPECT_TRUE(decision->request_strict_mode);
   EXPECT_TRUE(decision->rewrite_required);
 }
 
-TEST(HotswapRewriteDecision, EntryTrampolinesDisabledKeepsNonA0Gfx1250StrictWhenEnabled) {
+TEST(HotswapRewriteDecision, EntryTrampolinesEnabledKeepsNonA0Gfx1250StrictWhenEnabled) {
   rocr::hotswap::RewriteOptions options;
-  options.gfx12_5_rewrite_enabled = false;
+  options.entry_trampolines_enabled = true;
   options.strict_mode_enabled = true;
 
   const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
@@ -333,14 +342,14 @@ TEST(HotswapRewriteDecision, EntryTrampolinesDisabledKeepsNonA0Gfx1250StrictWhen
   ASSERT_TRUE(decision.has_value());
   EXPECT_EQ(decision->source_isa, kGfx1250B0Isa);
   EXPECT_EQ(decision->target_isa, kGfx1250B0Isa);
-  EXPECT_FALSE(decision->request_entry_trampolines);
+  EXPECT_TRUE(decision->request_entry_trampolines);
   EXPECT_TRUE(decision->request_strict_mode);
   EXPECT_TRUE(decision->rewrite_required);
 }
 
 TEST(HotswapRewriteDecision, NonA0Gfx1250NoDecisionWhenEntryAndStrictDisabled) {
   rocr::hotswap::RewriteOptions options;
-  options.gfx12_5_rewrite_enabled = false;
+  options.entry_trampolines_enabled = false;
   options.strict_mode_enabled = false;
 
   const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
@@ -350,11 +359,12 @@ TEST(HotswapRewriteDecision, NonA0Gfx1250NoDecisionWhenEntryAndStrictDisabled) {
 }
 
 TEST(HotswapRewriteDecision, EntryTrampolinesRouteGfx12_5Family) {
+  rocr::hotswap::RewriteOptions options;
+  options.entry_trampolines_enabled = true;
   const auto concrete = rocr::hotswap::DecideHotswapRewriteForTesting(
-      MakeRevision("gfx1251", 1), kGfx1251Isa, kGfx1251Isa, {});
+      MakeRevision("gfx1251", 1), kGfx1251Isa, kGfx1251Isa, options);
   const auto generic = rocr::hotswap::DecideHotswapRewriteForTesting(
-      MakeRevision("gfx12-5-generic", 1), kGfx12_5GenericIsa,
-      kGfx12_5GenericIsa, {});
+      MakeRevision("gfx12-5-generic", 1), kGfx12_5GenericIsa, kGfx12_5GenericIsa, options);
 
   ASSERT_TRUE(concrete.has_value());
   EXPECT_EQ(concrete->source_isa, kGfx1251Isa);
@@ -371,8 +381,10 @@ TEST(HotswapRewriteDecision, EntryTrampolinesRouteGfx12_5Family) {
 }
 
 TEST(HotswapRewriteDecision, EntryTrampolinesUseGenericSourceAsTarget) {
+  rocr::hotswap::RewriteOptions options;
+  options.entry_trampolines_enabled = true;
   const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
-      MakeRevision("gfx1251", 1), kGfx12_5GenericIsa, kGfx1251Isa, {});
+      MakeRevision("gfx1251", 1), kGfx12_5GenericIsa, kGfx1251Isa, options);
 
   ASSERT_TRUE(decision.has_value());
   EXPECT_EQ(decision->source_isa, kGfx12_5GenericIsa);
@@ -383,8 +395,10 @@ TEST(HotswapRewriteDecision, EntryTrampolinesUseGenericSourceAsTarget) {
 }
 
 TEST(HotswapRewriteDecision, EntryTrampolinesBlockNonGfx12_5) {
+  rocr::hotswap::RewriteOptions options;
+  options.entry_trampolines_enabled = true;
   const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
-      MakeRevision("gfx942", 0), kGfx942Isa, kGfx942Isa, {});
+      MakeRevision("gfx942", 0), kGfx942Isa, kGfx942Isa, options);
 
   EXPECT_FALSE(decision.has_value());
 }
@@ -501,37 +515,11 @@ TEST(HotswapRewrite, RuntimeLoadUsesRewrittenCodeObject) {
       rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 0u);
 }
 
-TEST(HotswapRewrite, RuntimeLoadNonA0UsesDefaultEntryTrampolines) {
+TEST(HotswapRewrite, RuntimeLoadNonA0DefaultsToOriginalWhenEntryTrampolinesUnset) {
   ResetRuntimeTestEnv();
-  if (!ComgrHotswapOptionsApiAvailable()) return;
   g_fake_hsa_env.asic_revision = 1;
   LoadRecorder load;
   const hsa_executable_t executable = MakeTestExecutable(0x502);
-
-  const hsa_status_t status = rocr::hotswap::LoadAgentCodeObjectWithHotswap(
-      executable, MakeTestAgent(), MakeRealCodeObjectView(), nullptr, nullptr,
-      MakeLoadCallbacks(&load));
-
-  EXPECT_EQ(status, HSA_STATUS_SUCCESS);
-  ASSERT_EQ(load.calls.size(), 1u);
-  EXPECT_EQ(load.calls[0].path, LoadPath::kRewritten);
-  EXPECT_NE(load.calls[0].code_object, static_cast<const void*>(kGfx1250MinCo));
-  EXPECT_GT(load.calls[0].code_object_size, 0u);
-  EXPECT_EQ(
-      rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 1u);
-
-  rocr::hotswap::ReleaseRetainedRewrittenElfBuffers(executable);
-  EXPECT_EQ(
-      rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 0u);
-}
-
-TEST(HotswapRewrite, RuntimeLoadNonA0FallsBackWhenEntryTrampolinesAreZeroAndStrictUnset) {
-  ResetRuntimeTestEnv();
-  if (!ComgrHotswapOptionsApiAvailable()) return;
-  g_fake_hsa_env.asic_revision = 1;
-  g_fake_env_vars["AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES"] = "0";
-  LoadRecorder load;
-  const hsa_executable_t executable = MakeTestExecutable(0x503);
 
   const hsa_status_t status = rocr::hotswap::LoadAgentCodeObjectWithHotswap(
       executable, MakeTestAgent(), MakeRealCodeObjectView(), nullptr, nullptr,
@@ -543,6 +531,29 @@ TEST(HotswapRewrite, RuntimeLoadNonA0FallsBackWhenEntryTrampolinesAreZeroAndStri
   EXPECT_EQ(load.calls[0].code_object, static_cast<const void*>(kGfx1250MinCo));
   EXPECT_EQ(
       rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 0u);
+}
+
+TEST(HotswapRewrite, RuntimeLoadNonA0FallsBackWhenEntryTrampolinesDisabledAndStrictUnset) {
+  const char* const env_values[] = {"0", "false", "off", ""};
+  uint64_t executable_handle = 0x503;
+  for (const char* env_value : env_values) {
+    SCOPED_TRACE(env_value);
+    ResetRuntimeTestEnv();
+    g_fake_hsa_env.asic_revision = 1;
+    g_fake_env_vars["AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES"] = env_value;
+    LoadRecorder load;
+    const hsa_executable_t executable = MakeTestExecutable(executable_handle++);
+
+    const hsa_status_t status = rocr::hotswap::LoadAgentCodeObjectWithHotswap(
+        executable, MakeTestAgent(), MakeRealCodeObjectView(), nullptr, nullptr,
+        MakeLoadCallbacks(&load));
+
+    EXPECT_EQ(status, HSA_STATUS_SUCCESS);
+    ASSERT_EQ(load.calls.size(), 1u);
+    EXPECT_EQ(load.calls[0].path, LoadPath::kOriginal);
+    EXPECT_EQ(load.calls[0].code_object, static_cast<const void*>(kGfx1250MinCo));
+    EXPECT_EQ(rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 0u);
+  }
 }
 
 TEST(HotswapRewrite, RuntimeLoadNonA0UsesStrictModeEnvWhenEntryTrampolinesAreZero) {
@@ -571,10 +582,10 @@ TEST(HotswapRewrite, RuntimeLoadNonA0UsesStrictModeEnvWhenEntryTrampolinesAreZer
       rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 0u);
 }
 
-TEST(HotswapRewrite, RuntimeLoadNonA0UsesEntryTrampolinesUnlessEnvIsZero) {
+TEST(HotswapRewrite, RuntimeLoadNonA0UsesEntryTrampolinesWhenEnabled) {
   if (!ComgrHotswapOptionsApiAvailable()) return;
-  const char* const env_values[] = {"false", ""};
-  uint64_t executable_handle = 0x505;
+  const char* const env_values[] = {"1", "true", "on"};
+  uint64_t executable_handle = 0x507;
   for (const char* env_value : env_values) {
     SCOPED_TRACE(env_value);
     ResetRuntimeTestEnv();
@@ -647,6 +658,7 @@ TEST(HotswapRewrite, RuntimeLoadOptionalRewriteFailureFallsBackToOriginal) {
   ResetRuntimeTestEnv();
   if (!ComgrHotswapOptionsApiAvailable()) return;
   g_fake_hsa_env.isa_name = kGfx1251Isa;
+  g_fake_env_vars["AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES"] = "1";
   rocr::hotswap::ForceRetargetCodeObjectFailureForTesting(true);
   LoadRecorder load;
   const hsa_executable_t executable = MakeTestExecutable(0x508);
@@ -709,6 +721,7 @@ TEST(HotswapRewrite, RuntimeLoadOptionalRewrittenLoadFailureFallsBackToOriginal)
   ResetRuntimeTestEnv();
   if (!ComgrHotswapOptionsApiAvailable()) return;
   g_fake_hsa_env.isa_name = kGfx1251Isa;
+  g_fake_env_vars["AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES"] = "1";
   LoadRecorder load;
   load.rewritten_status = HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
   const hsa_executable_t executable = MakeTestExecutable(0x510);

--- a/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
@@ -201,8 +201,8 @@ void ResetRuntimeTestEnv() {
   rocr::hotswap::ResetAgentGfxRevisionCache();
 }
 
-bool NewComgrHotswapApiAvailable() {
-  if (rocr::hotswap::EntryTrampolineRewriteAvailableForTesting()) {
+bool ComgrHotswapOptionsApiAvailable() {
+  if (rocr::hotswap::HotswapRewriteWithOptionsAvailableForTesting()) {
     return true;
   }
   SUCCEED() << "requires COMGR with amd_comgr_hotswap_rewrite_with_options";
@@ -240,87 +240,87 @@ rocr::hotswap::AgentGfxRevision MakeRevision(const std::string& gfx_target,
   return revision;
 }
 
-TEST(HotswapRewriteDecision, A0RetargetsUsesLegacyPathUnlessOptedIn) {
-  struct TestCase {
-    rocr::hotswap::RewriteOptions options;
-    bool request_entry_trampolines;
-  };
-  // {entry_trampolines_enabled}.
-  const TestCase cases[] = {
-      {{}, false},       // default: B0->A0 legacy path
-      {{false}, false},  // explicitly disabled: legacy path
-      {{true}, true},    // opted in: entry trampolines
-  };
-  for (const TestCase& test_case : cases) {
-    SCOPED_TRACE(test_case.request_entry_trampolines
-                     ? "entry trampolines enabled"
-                     : "entry trampolines disabled");
+TEST(HotswapRewriteDecision, A0RetargetsThroughStrictModeRegardlessOfOptions) {
+  const rocr::hotswap::RewriteOptions options[] = {{}, {false}};
+  for (const auto& option : options) {
+    SCOPED_TRACE(option.gfx12_5_rewrite_enabled ? "entry trampolines enabled"
+                                                : "entry trampolines disabled");
     const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
-        MakeRevision("gfx1250", 0), kGfx1250Isa, kGfx1250Isa,
-        test_case.options);
+        MakeRevision("gfx1250", 0), kGfx1250Isa, kGfx1250Isa, option);
 
     ASSERT_TRUE(decision.has_value());
     EXPECT_EQ(decision->source_isa, kGfx1250B0Isa);
     EXPECT_EQ(decision->target_isa, kGfx1250A0Isa);
-    EXPECT_EQ(decision->request_entry_trampolines,
-              test_case.request_entry_trampolines);
+    EXPECT_FALSE(decision->request_entry_trampolines);
+    EXPECT_TRUE(decision->request_strict_mode);
   }
 }
 
-TEST(HotswapRewriteDecision, EntryTrampolinesDefaultOffBlocksNonA0Gfx1250) {
+TEST(HotswapRewriteDecision, StrictModeDisabledBlocksA0Retarget) {
+  rocr::hotswap::RewriteOptions options;
+  options.strict_mode_enabled = false;
+
   const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
-      MakeRevision("gfx1250", 1), kGfx1250Isa, kGfx1250Isa, {});
+      MakeRevision("gfx1250", 0), kGfx1250Isa, kGfx1250Isa, options);
 
   EXPECT_FALSE(decision.has_value());
 }
 
-TEST(HotswapRewriteDecision, EntryTrampolinesEnabledRoutesNonA0Gfx1250) {
+TEST(HotswapRewriteDecision, EntryTrampolinesDefaultOnRoutesNonA0Gfx1250) {
   const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
-      MakeRevision("gfx1250", 1), kGfx1250Isa, kGfx1250Isa, {true});
+      MakeRevision("gfx1250", 1), kGfx1250Isa, kGfx1250Isa, {});
 
   ASSERT_TRUE(decision.has_value());
   EXPECT_EQ(decision->source_isa, kGfx1250B0Isa);
   EXPECT_EQ(decision->target_isa, kGfx1250B0Isa);
   EXPECT_TRUE(decision->request_entry_trampolines);
+  EXPECT_TRUE(decision->request_strict_mode);
 }
 
-TEST(HotswapRewriteDecision, EntryTrampolinesDisabledBlocksNonA0Gfx1250) {
+TEST(HotswapRewriteDecision, EntryTrampolinesDisabledKeepsNonA0Gfx1250Strict) {
   const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
       MakeRevision("gfx1250", 1), kGfx1250Isa, kGfx1250Isa, {false});
 
-  EXPECT_FALSE(decision.has_value());
+  ASSERT_TRUE(decision.has_value());
+  EXPECT_EQ(decision->source_isa, kGfx1250B0Isa);
+  EXPECT_EQ(decision->target_isa, kGfx1250B0Isa);
+  EXPECT_FALSE(decision->request_entry_trampolines);
+  EXPECT_TRUE(decision->request_strict_mode);
 }
 
 TEST(HotswapRewriteDecision, EntryTrampolinesRouteGfx12_5Family) {
   const auto concrete = rocr::hotswap::DecideHotswapRewriteForTesting(
-      MakeRevision("gfx1251", 1), kGfx1251Isa, kGfx1251Isa, {true});
+      MakeRevision("gfx1251", 1), kGfx1251Isa, kGfx1251Isa, {});
   const auto generic = rocr::hotswap::DecideHotswapRewriteForTesting(
       MakeRevision("gfx12-5-generic", 1), kGfx12_5GenericIsa,
-      kGfx12_5GenericIsa, {true});
+      kGfx12_5GenericIsa, {});
 
   ASSERT_TRUE(concrete.has_value());
   EXPECT_EQ(concrete->source_isa, kGfx1251Isa);
   EXPECT_EQ(concrete->target_isa, kGfx1251Isa);
   EXPECT_TRUE(concrete->request_entry_trampolines);
+  EXPECT_FALSE(concrete->request_strict_mode);
   ASSERT_TRUE(generic.has_value());
   EXPECT_EQ(generic->source_isa, kGfx12_5GenericIsa);
   EXPECT_EQ(generic->target_isa, kGfx12_5GenericIsa);
   EXPECT_TRUE(generic->request_entry_trampolines);
+  EXPECT_FALSE(generic->request_strict_mode);
 }
 
 TEST(HotswapRewriteDecision, EntryTrampolinesUseGenericSourceAsTarget) {
   const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
-      MakeRevision("gfx1251", 1), kGfx12_5GenericIsa, kGfx1251Isa, {true});
+      MakeRevision("gfx1251", 1), kGfx12_5GenericIsa, kGfx1251Isa, {});
 
   ASSERT_TRUE(decision.has_value());
   EXPECT_EQ(decision->source_isa, kGfx12_5GenericIsa);
   EXPECT_EQ(decision->target_isa, kGfx12_5GenericIsa);
   EXPECT_TRUE(decision->request_entry_trampolines);
+  EXPECT_FALSE(decision->request_strict_mode);
 }
 
 TEST(HotswapRewriteDecision, EntryTrampolinesBlockNonGfx12_5) {
   const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
-      MakeRevision("gfx942", 0), kGfx942Isa, kGfx942Isa, {true});
+      MakeRevision("gfx942", 0), kGfx942Isa, kGfx942Isa, {});
 
   EXPECT_FALSE(decision.has_value());
 }
@@ -414,7 +414,7 @@ TEST(HotswapRewrite, RetargetNullSourceOrTarget) {
 
 TEST(HotswapRewrite, RuntimeLoadUsesRewrittenCodeObject) {
   ResetRuntimeTestEnv();
-  if (!NewComgrHotswapApiAvailable()) return;
+  if (!ComgrHotswapOptionsApiAvailable()) return;
   LoadRecorder load;
   hsa_loaded_code_object_t loaded{};
   const hsa_executable_t executable = MakeTestExecutable(0x501);
@@ -437,11 +437,12 @@ TEST(HotswapRewrite, RuntimeLoadUsesRewrittenCodeObject) {
       rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 0u);
 }
 
-TEST(HotswapRewrite, RuntimeLoadNonA0DefaultsToOriginalWhenEntryTrampolinesUnset) {
+TEST(HotswapRewrite, RuntimeLoadNonA0UsesDefaultEntryTrampolines) {
   ResetRuntimeTestEnv();
+  if (!ComgrHotswapOptionsApiAvailable()) return;
   g_fake_hsa_env.asic_revision = 1;
   LoadRecorder load;
-  const hsa_executable_t executable = MakeTestExecutable(0x504);
+  const hsa_executable_t executable = MakeTestExecutable(0x502);
 
   const hsa_status_t status = rocr::hotswap::LoadAgentCodeObjectWithHotswap(
       executable, MakeTestAgent(), MakeRealCodeObjectView(), nullptr, nullptr,
@@ -449,41 +450,46 @@ TEST(HotswapRewrite, RuntimeLoadNonA0DefaultsToOriginalWhenEntryTrampolinesUnset
 
   EXPECT_EQ(status, HSA_STATUS_SUCCESS);
   ASSERT_EQ(load.calls.size(), 1u);
-  EXPECT_EQ(load.calls[0].path, LoadPath::kOriginal);
-  EXPECT_EQ(load.calls[0].code_object, static_cast<const void*>(kGfx1250MinCo));
+  EXPECT_EQ(load.calls[0].path, LoadPath::kRewritten);
+  EXPECT_NE(load.calls[0].code_object, static_cast<const void*>(kGfx1250MinCo));
+  EXPECT_GT(load.calls[0].code_object_size, 0u);
+  EXPECT_EQ(
+      rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 1u);
+
+  rocr::hotswap::ReleaseRetainedRewrittenElfBuffers(executable);
   EXPECT_EQ(
       rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 0u);
 }
 
-TEST(HotswapRewrite, RuntimeLoadNonA0FallsBackWhenEntryTrampolinesDisabled) {
-  const char* const env_values[] = {"0", "false", "off", ""};
-  uint64_t executable_handle = 0x510;
-  for (const char* env_value : env_values) {
-    SCOPED_TRACE(env_value);
-    ResetRuntimeTestEnv();
-    g_fake_hsa_env.asic_revision = 1;
-    g_fake_env_vars["AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES"] = env_value;
-    LoadRecorder load;
-    const hsa_executable_t executable =
-        MakeTestExecutable(executable_handle++);
+TEST(HotswapRewrite, RuntimeLoadNonA0UsesStrictWhenEntryTrampolinesAreZero) {
+  ResetRuntimeTestEnv();
+  if (!ComgrHotswapOptionsApiAvailable()) return;
+  g_fake_hsa_env.asic_revision = 1;
+  g_fake_env_vars["AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES"] = "0";
+  LoadRecorder load;
+  const hsa_executable_t executable = MakeTestExecutable(0x503);
 
-    const hsa_status_t status = rocr::hotswap::LoadAgentCodeObjectWithHotswap(
-        executable, MakeTestAgent(), MakeRealCodeObjectView(), nullptr, nullptr,
-        MakeLoadCallbacks(&load));
+  const hsa_status_t status = rocr::hotswap::LoadAgentCodeObjectWithHotswap(
+      executable, MakeTestAgent(), MakeRealCodeObjectView(), nullptr, nullptr,
+      MakeLoadCallbacks(&load));
 
-    EXPECT_EQ(status, HSA_STATUS_SUCCESS);
-    ASSERT_EQ(load.calls.size(), 1u);
-    EXPECT_EQ(load.calls[0].path, LoadPath::kOriginal);
-    EXPECT_EQ(load.calls[0].code_object, static_cast<const void*>(kGfx1250MinCo));
-    EXPECT_EQ(
-        rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 0u);
-  }
+  EXPECT_EQ(status, HSA_STATUS_SUCCESS);
+  ASSERT_EQ(load.calls.size(), 1u);
+  EXPECT_EQ(load.calls[0].path, LoadPath::kRewritten);
+  EXPECT_NE(load.calls[0].code_object, static_cast<const void*>(kGfx1250MinCo));
+  EXPECT_GT(load.calls[0].code_object_size, 0u);
+  EXPECT_EQ(
+      rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 1u);
+
+  rocr::hotswap::ReleaseRetainedRewrittenElfBuffers(executable);
+  EXPECT_EQ(
+      rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 0u);
 }
 
-TEST(HotswapRewrite, RuntimeLoadNonA0UsesEntryTrampolinesWhenEnabled) {
-  if (!NewComgrHotswapApiAvailable()) return;
-  const char* const env_values[] = {"1", "true", "on"};
-  uint64_t executable_handle = 0x509;
+TEST(HotswapRewrite, RuntimeLoadNonA0UsesEntryTrampolinesUnlessEnvIsZero) {
+  if (!ComgrHotswapOptionsApiAvailable()) return;
+  const char* const env_values[] = {"false", ""};
+  uint64_t executable_handle = 0x504;
   for (const char* env_value : env_values) {
     SCOPED_TRACE(env_value);
     ResetRuntimeTestEnv();
@@ -554,7 +560,7 @@ TEST(HotswapRewrite, RuntimeLoadRewriteFailureFallsBackToOriginal) {
 
 TEST(HotswapRewrite, RuntimeLoadRewrittenLoadFailureFallsBackToOriginal) {
   ResetRuntimeTestEnv();
-  if (!NewComgrHotswapApiAvailable()) return;
+  if (!ComgrHotswapOptionsApiAvailable()) return;
   LoadRecorder load;
   load.rewritten_status = HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
   const hsa_executable_t executable = MakeTestExecutable(0x508);

--- a/projects/rocr-runtime/runtime/docs/data/env_variables.rst
+++ b/projects/rocr-runtime/runtime/docs/data/env_variables.rst
@@ -105,6 +105,12 @@
       - | 0, ``false``, ``off``, ``no``, ``n``, or ``f``: Disable HotSwap diagnostic logging.
         | Any other non-empty value: Enable HotSwap diagnostic logging.
 
+    * - | ``HSA_HOTSWAP_STRICT_MODE``
+        | Enables the opt-in HotSwap strict mask workaround request for non-A0 ``gfx1250`` targets.
+      - ``0``
+      - | 0, ``false``, ``off``, ``no``, ``n``, or ``f``: Disable strict mask workaround requests.
+        | Any other non-empty value: Request COMGR strict mask workarounds for non-A0 ``gfx1250`` HotSwap rewrites.
+
     * - | ``AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES``
         | Controls whether ROCr requests COMGR entry-trampoline HotSwap rewriting for gfx12.5 targets. Disabled by default.
       - ``0``

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap.hpp
@@ -65,20 +65,16 @@ struct CodeObjectView {
   std::string uri;
 };
 
-// Entry-trampoline hotswap rewriting for gfx12.5 targets (the generic
-// gfx12.5 rewrite path and the gfx1250 B0->A0 retarget) is opt-in: disabled
-// by default and enabled only when the caller sets
-// AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES to a truthy value.
-inline constexpr bool kDefaultEntryTrampolinesEnabled = false;
-
 struct RewriteOptions {
-  bool entry_trampolines_enabled = kDefaultEntryTrampolinesEnabled;
+  bool gfx12_5_rewrite_enabled = true;
+  bool strict_mode_enabled = true;
 };
 
 struct RewriteDecision {
   std::string source_isa;
   std::string target_isa;
   bool request_entry_trampolines = false;
+  bool request_strict_mode = false;
 };
 
 using LoadOriginalCodeObjectFn = hsa_status_t (*)(
@@ -102,7 +98,8 @@ std::string GetCodeObjectIsaName(const void* elf_data, size_t elf_size);
 bool RetargetCodeObject(const void* elf_data, size_t elf_size,
                         const char* source_isa, const char* target_isa,
                         OwnedElfBuffer* out_elf_buffer, size_t* out_elf_size,
-                        bool request_entry_trampolines = false);
+                        bool request_entry_trampolines = false,
+                        bool request_strict_mode = false);
 
 bool TryRetargetCodeObject(const CodeObjectView& code_object, hsa_agent_t agent,
                            OwnedElfBuffer* out_elf_buffer,
@@ -127,7 +124,7 @@ std::optional<RewriteDecision> DecideHotswapRewriteForTesting(
     const AgentGfxRevision& gfx, const std::string& source_isa,
     const std::string& target_isa, const RewriteOptions& options);
 size_t RetainedRewrittenElfBufferCountForTesting(hsa_executable_t executable);
-bool EntryTrampolineRewriteAvailableForTesting();
+bool HotswapRewriteWithOptionsAvailableForTesting();
 #endif
 
 }  // namespace hotswap

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap.hpp
@@ -75,6 +75,7 @@ struct RewriteDecision {
   std::string target_isa;
   bool request_entry_trampolines = false;
   bool request_strict_mode = false;
+  bool rewrite_required = false;
 };
 
 enum class RetargetCodeObjectStatus {
@@ -85,7 +86,7 @@ enum class RetargetCodeObjectStatus {
 
 struct RetargetCodeObjectResult {
   RetargetCodeObjectStatus status = RetargetCodeObjectStatus::kSkipped;
-  bool strict_mode_required = false;
+  bool rewrite_required = false;
 };
 
 using LoadOriginalCodeObjectFn = hsa_status_t (*)(

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap.hpp
@@ -67,7 +67,7 @@ struct CodeObjectView {
 
 struct RewriteOptions {
   bool gfx12_5_rewrite_enabled = true;
-  bool strict_mode_enabled = true;
+  bool strict_mode_enabled = false;
 };
 
 struct RewriteDecision {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap.hpp
@@ -65,8 +65,11 @@ struct CodeObjectView {
   std::string uri;
 };
 
+// Entry-trampoline rewriting is opt-in while validation is ongoing.
+inline constexpr bool kDefaultEntryTrampolinesEnabled = false;
+
 struct RewriteOptions {
-  bool gfx12_5_rewrite_enabled = true;
+  bool entry_trampolines_enabled = kDefaultEntryTrampolinesEnabled;
   bool strict_mode_enabled = false;
 };
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap.hpp
@@ -77,6 +77,17 @@ struct RewriteDecision {
   bool request_strict_mode = false;
 };
 
+enum class RetargetCodeObjectStatus {
+  kSkipped,
+  kRewritten,
+  kRequiredRewriteFailed,
+};
+
+struct RetargetCodeObjectResult {
+  RetargetCodeObjectStatus status = RetargetCodeObjectStatus::kSkipped;
+  bool strict_mode_required = false;
+};
+
 using LoadOriginalCodeObjectFn = hsa_status_t (*)(
     void* context, hsa_agent_t agent, hsa_code_object_t code_object,
     const char* options, const std::string& uri,
@@ -101,13 +112,13 @@ bool RetargetCodeObject(const void* elf_data, size_t elf_size,
                         bool request_entry_trampolines = false,
                         bool request_strict_mode = false);
 
-bool TryRetargetCodeObject(const CodeObjectView& code_object, hsa_agent_t agent,
-                           OwnedElfBuffer* out_elf_buffer,
-                           size_t* out_elf_size);
+RetargetCodeObjectResult TryRetargetCodeObject(
+    const CodeObjectView& code_object, hsa_agent_t agent,
+    OwnedElfBuffer* out_elf_buffer, size_t* out_elf_size);
 
-bool TryRetargetCodeObject(amd::hsa::loader::CodeObjectReaderImpl* reader,
-                           hsa_agent_t agent, OwnedElfBuffer* out_elf_buffer,
-                           size_t* out_elf_size);
+RetargetCodeObjectResult TryRetargetCodeObject(
+    amd::hsa::loader::CodeObjectReaderImpl* reader, hsa_agent_t agent,
+    OwnedElfBuffer* out_elf_buffer, size_t* out_elf_size);
 
 hsa_status_t LoadAgentCodeObjectWithHotswap(
     hsa_executable_t executable, hsa_agent_t agent,
@@ -125,6 +136,7 @@ std::optional<RewriteDecision> DecideHotswapRewriteForTesting(
     const std::string& target_isa, const RewriteOptions& options);
 size_t RetainedRewrittenElfBufferCountForTesting(hsa_executable_t executable);
 bool HotswapRewriteWithOptionsAvailableForTesting();
+void ForceRetargetCodeObjectFailureForTesting(bool force);
 #endif
 
 }  // namespace hotswap

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap.cpp
@@ -322,7 +322,7 @@ std::optional<RewriteDecision> DecideHotswapRewrite(
   RewriteDecision decision{source_isa, source_isa,
                            request_entry_trampolines,
                            request_strict_mode};
-  if (request_strict_mode) {
+  if (source_gfx == kGfx1250) {
     decision.source_isa =
         WithGfx1250SteppingFeature(source_isa, Gfx1250Stepping::kB0);
     decision.target_isa =

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap.cpp
@@ -96,15 +96,10 @@ bool IsEnvFlagEnabled(const char* name) {
 
 bool IsHotswapDisabledByEnv() { return IsEnvFlagEnabled("HSA_HOTSWAP_DISABLE"); }
 
-bool AreEntryTrampolinesRequested() {
-  // Entry-trampoline rewriting is opt-in: disabled unless the caller sets
-  // AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES to a truthy value. Unset falls back to
-  // the compiled-in default; false-like values keep it disabled.
+bool IsGfx12_5RewriteRequested() {
   constexpr char kEnvName[] = "AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES";
-  if (!os::IsEnvVarSet(kEnvName)) {
-    return kDefaultEntryTrampolinesEnabled;
-  }
-  return IsEnvFlagEnabled(kEnvName);
+  // Default-on policy owned by ROCR: only literal "0" opts out.
+  return !os::IsEnvVarSet(kEnvName) || os::GetEnvVar(kEnvName) != "0";
 }
 
 bool IsVerboseLoggingEnabled() {
@@ -131,6 +126,7 @@ struct ComgrHotswapRewriteOptions {
 constexpr int kComgrStatusSuccess = 0;
 constexpr int kComgrDataKindExecutable = 0x8;
 constexpr uint64_t kComgrHotswapRewriteFlagEntryTrampolines = 0x1;
+constexpr uint64_t kComgrHotswapRewriteFlagStrictMode = 0x2;
 
 struct ComgrApi {
   os::LibHandle lib = nullptr;
@@ -282,8 +278,9 @@ std::string WithGfx1250SteppingFeature(const std::string& isa_name,
 
 bool HasCandidateHotswapRewrite(const AgentGfxRevision& gfx,
                                 const RewriteOptions& options) {
-  return IsHotswapSupportedGfxRevision(gfx) ||
-      (options.entry_trampolines_enabled && IsGfx12_5Target(gfx.gfx_target));
+  return (options.strict_mode_enabled && gfx.gfx_target == kGfx1250) ||
+         (options.gfx12_5_rewrite_enabled &&
+          IsGfx12_5Target(gfx.gfx_target));
 }
 
 std::optional<RewriteDecision> DecideHotswapRewrite(
@@ -297,20 +294,30 @@ std::optional<RewriteDecision> DecideHotswapRewrite(
   const std::string target_gfx = ExtractGfxTarget(target_isa);
   if (IsHotswapSupportedGfxRevision(gfx) && source_gfx == kGfx1250 &&
       target_gfx == kGfx1250) {
-    // B0->A0 retarget defaults to the legacy (non entry-trampoline) rewrite
-    // path and only requests entry trampolines when explicitly opted in.
-    return RewriteDecision{WithGfx1250SteppingFeature(source_isa, Gfx1250Stepping::kB0),
-                           WithGfx1250SteppingFeature(target_isa, Gfx1250Stepping::kA0),
-                           options.entry_trampolines_enabled};
+    if (!options.strict_mode_enabled) {
+      return std::nullopt;
+    }
+    return RewriteDecision{
+        WithGfx1250SteppingFeature(source_isa, Gfx1250Stepping::kB0),
+        WithGfx1250SteppingFeature(target_isa, Gfx1250Stepping::kA0),
+        false,
+        true};
   }
 
-  if (!options.entry_trampolines_enabled || !IsGfx12_5Target(gfx.gfx_target) ||
-      !IsGfx12_5Target(source_gfx)) {
+  const bool request_entry_trampolines =
+      options.gfx12_5_rewrite_enabled &&
+      IsGfx12_5Target(gfx.gfx_target) && IsGfx12_5Target(source_gfx);
+  const bool request_strict_mode =
+      options.strict_mode_enabled && gfx.gfx_target == kGfx1250 &&
+      source_gfx == kGfx1250;
+  if (!request_entry_trampolines && !request_strict_mode) {
     return std::nullopt;
   }
 
-  RewriteDecision decision{source_isa, source_isa, true};
-  if (source_gfx == kGfx1250) {
+  RewriteDecision decision{source_isa, source_isa,
+                           request_entry_trampolines,
+                           request_strict_mode};
+  if (request_strict_mode) {
     decision.source_isa =
         WithGfx1250SteppingFeature(source_isa, Gfx1250Stepping::kB0);
     decision.target_isa =
@@ -372,7 +379,8 @@ void LogRewrittenCodeObjectLoadFailure(hsa_status_t status) {
 
 bool RetargetCodeObject(const void* elf_data, size_t elf_size, const char* source_isa,
                         const char* target_isa, OwnedElfBuffer* out_elf_buffer,
-                        size_t* out_elf_size, bool request_entry_trampolines) {
+                        size_t* out_elf_size, bool request_entry_trampolines,
+                        bool request_strict_mode) {
   ComgrApi* api = GetComgrApi();
   if (!api || !elf_data || elf_size == 0 || !source_isa || !target_isa || !out_elf_buffer ||
       !out_elf_size) {
@@ -391,15 +399,18 @@ bool RetargetCodeObject(const void* elf_data, size_t elf_size, const char* sourc
 
   ComgrData output = {};
   int status = kComgrStatusSuccess;
-  if (request_entry_trampolines) {
+  const uint64_t rewrite_flags =
+      (request_entry_trampolines ? kComgrHotswapRewriteFlagEntryTrampolines : 0) |
+      (request_strict_mode ? kComgrHotswapRewriteFlagStrictMode : 0);
+  if (rewrite_flags != 0) {
     if (!api->hotswap_rewrite_with_options) {
       api->release_data(input);
-      HOTSWAP_LOG("hotswap: COMGR entry-trampoline rewrite entry point unavailable\n");
+      HOTSWAP_LOG("hotswap: COMGR rewrite-with-options entry point unavailable\n");
       return false;
     }
     const ComgrHotswapRewriteOptions options{
         sizeof(ComgrHotswapRewriteOptions),
-        kComgrHotswapRewriteFlagEntryTrampolines};
+        rewrite_flags};
     status = api->hotswap_rewrite_with_options(input, source_isa, target_isa,
                                                &options, &output);
   } else {
@@ -444,7 +455,8 @@ bool TryRetargetCodeObject(const CodeObjectView& code_object, hsa_agent_t agent,
   }
 
   const AgentGfxRevision gfx = GetAgentGfxRevision(agent);
-  const RewriteOptions options{AreEntryTrampolinesRequested()};
+  RewriteOptions options;
+  options.gfx12_5_rewrite_enabled = IsGfx12_5RewriteRequested();
   if (!IsAgentEligibleForHotswap(gfx, options)) {
     return false;
   }
@@ -463,11 +475,13 @@ bool TryRetargetCodeObject(const CodeObjectView& code_object, hsa_agent_t agent,
       RetargetCodeObject(code_object.data, code_object.size,
                          decision->source_isa.c_str(), decision->target_isa.c_str(),
                          out_elf_buffer, out_elf_size,
-                         decision->request_entry_trampolines);
-  HOTSWAP_LOG("hotswap: rewrite src=%s tgt=%s entry_trampolines=%d in=%zu out=%zu changed=%d\n",
+                         decision->request_entry_trampolines,
+                         decision->request_strict_mode);
+  HOTSWAP_LOG("hotswap: rewrite src=%s tgt=%s entry_trampolines=%d strict=%d "
+              "in=%zu out=%zu changed=%d\n",
               decision->source_isa.c_str(), decision->target_isa.c_str(),
-              decision->request_entry_trampolines, code_object.size,
-              rewritten ? *out_elf_size : 0, rewritten ? 1 : 0);
+              decision->request_entry_trampolines, decision->request_strict_mode,
+              code_object.size, rewritten ? *out_elf_size : 0, rewritten ? 1 : 0);
   return rewritten;
 }
 
@@ -542,7 +556,7 @@ size_t RetainedRewrittenElfBufferCountForTesting(hsa_executable_t executable) {
   return it == g_retained_rewritten_elf_buffers.end() ? 0 : it->second.size();
 }
 
-bool EntryTrampolineRewriteAvailableForTesting() {
+bool HotswapRewriteWithOptionsAvailableForTesting() {
   ComgrApi* api = GetComgrApi();
   return api && api->hotswap_rewrite_with_options;
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap.cpp
@@ -68,6 +68,9 @@ namespace {
 
 std::mutex g_retained_rewritten_elf_buffers_mutex;
 std::unordered_map<uint64_t, std::vector<OwnedElfBuffer>> g_retained_rewritten_elf_buffers;
+#ifdef ROCR_HOTSWAP_TESTING
+bool g_force_retarget_code_object_failure_for_testing = false;
+#endif
 
 constexpr char kGfx1250[] = "gfx1250";
 constexpr char kGfx1250B0Feature[] = ":gfx1250-b0-specific+";
@@ -375,6 +378,17 @@ void LogRewrittenCodeObjectLoadFailure(hsa_status_t status) {
       static_cast<int>(status));
 }
 
+void LogRequiredRewriteFailure() {
+  HOTSWAP_LOG("hotswap: required strict-mode rewrite failed, not falling back to original "
+              "code object\n");
+}
+
+void LogRequiredRewrittenLoadFailure(hsa_status_t status) {
+  HOTSWAP_LOG("hotswap: required strict-mode rewritten load failed (status=%d), not falling "
+              "back to original code object\n",
+              static_cast<int>(status));
+}
+
 }  // namespace
 
 bool RetargetCodeObject(const void* elf_data, size_t elf_size, const char* source_isa,
@@ -448,17 +462,19 @@ bool RetargetCodeObject(const void* elf_data, size_t elf_size, const char* sourc
   return true;
 }
 
-bool TryRetargetCodeObject(const CodeObjectView& code_object, hsa_agent_t agent,
-                           OwnedElfBuffer* out_elf_buffer, size_t* out_elf_size) {
+RetargetCodeObjectResult TryRetargetCodeObject(const CodeObjectView& code_object,
+                                               hsa_agent_t agent,
+                                               OwnedElfBuffer* out_elf_buffer,
+                                               size_t* out_elf_size) {
   if (IsHotswapDisabledByEnv() || !code_object.data || code_object.size == 0) {
-    return false;
+    return {};
   }
 
   const AgentGfxRevision gfx = GetAgentGfxRevision(agent);
   RewriteOptions options;
   options.gfx12_5_rewrite_enabled = IsGfx12_5RewriteRequested();
   if (!IsAgentEligibleForHotswap(gfx, options)) {
-    return false;
+    return {};
   }
 
   const std::string source_isa = GetCodeObjectIsaName(code_object.data, code_object.size);
@@ -468,27 +484,42 @@ bool TryRetargetCodeObject(const CodeObjectView& code_object, hsa_agent_t agent,
   if (!decision) {
     HOTSWAP_LOG("hotswap: rewrite skipped, no decision (src='%s' tgt='%s')\n",
                 source_isa.c_str(), target_isa.c_str());
-    return false;
+    return {};
   }
 
-  const bool rewritten =
-      RetargetCodeObject(code_object.data, code_object.size,
-                         decision->source_isa.c_str(), decision->target_isa.c_str(),
-                         out_elf_buffer, out_elf_size,
-                         decision->request_entry_trampolines,
-                         decision->request_strict_mode);
+  bool rewritten = false;
+#ifdef ROCR_HOTSWAP_TESTING
+  if (g_force_retarget_code_object_failure_for_testing) {
+    HOTSWAP_LOG("hotswap: forcing retarget failure for test\n");
+  } else
+#endif
+  {
+    rewritten = RetargetCodeObject(code_object.data, code_object.size,
+                                   decision->source_isa.c_str(), decision->target_isa.c_str(),
+                                   out_elf_buffer, out_elf_size,
+                                   decision->request_entry_trampolines,
+                                   decision->request_strict_mode);
+  }
   HOTSWAP_LOG("hotswap: rewrite src=%s tgt=%s entry_trampolines=%d strict=%d "
               "in=%zu out=%zu changed=%d\n",
               decision->source_isa.c_str(), decision->target_isa.c_str(),
               decision->request_entry_trampolines, decision->request_strict_mode,
               code_object.size, rewritten ? *out_elf_size : 0, rewritten ? 1 : 0);
-  return rewritten;
+  if (rewritten) {
+    return {RetargetCodeObjectStatus::kRewritten,
+            decision->request_strict_mode};
+  }
+  if (decision->request_strict_mode) {
+    return {RetargetCodeObjectStatus::kRequiredRewriteFailed, true};
+  }
+  return {};
 }
 
-bool TryRetargetCodeObject(amd::hsa::loader::CodeObjectReaderImpl* reader, hsa_agent_t agent,
-                           OwnedElfBuffer* out_elf_buffer, size_t* out_elf_size) {
+RetargetCodeObjectResult TryRetargetCodeObject(
+    amd::hsa::loader::CodeObjectReaderImpl* reader, hsa_agent_t agent,
+    OwnedElfBuffer* out_elf_buffer, size_t* out_elf_size) {
   if (!reader) {
-    return false;
+    return {};
   }
 
   CodeObjectView code_object;
@@ -510,7 +541,9 @@ hsa_status_t LoadAgentCodeObjectWithHotswap(hsa_executable_t executable, hsa_age
 
   OwnedElfBuffer rewritten_elf_buffer(nullptr, &std::free);
   size_t rewritten_elf_size = 0;
-  if (TryRetargetCodeObject(code_object, agent, &rewritten_elf_buffer, &rewritten_elf_size)) {
+  const RetargetCodeObjectResult retarget_result =
+      TryRetargetCodeObject(code_object, agent, &rewritten_elf_buffer, &rewritten_elf_size);
+  if (retarget_result.status == RetargetCodeObjectStatus::kRewritten) {
     hsa_code_object_t rewritten_code_object = {
         reinterpret_cast<uint64_t>(rewritten_elf_buffer.get())};
     hsa_status_t status = callbacks.load_rewritten_code_object(
@@ -520,7 +553,15 @@ hsa_status_t LoadAgentCodeObjectWithHotswap(hsa_executable_t executable, hsa_age
       RetainRewrittenElfBuffer(executable, std::move(rewritten_elf_buffer));
       return status;
     }
+    if (retarget_result.strict_mode_required) {
+      LogRequiredRewrittenLoadFailure(status);
+      return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
+    }
     LogRewrittenCodeObjectLoadFailure(status);
+  } else if (retarget_result.status ==
+             RetargetCodeObjectStatus::kRequiredRewriteFailed) {
+    LogRequiredRewriteFailure();
+    return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
   }
 
   return callbacks.load_original_code_object(callbacks.context, agent, original_code_object,
@@ -559,6 +600,10 @@ size_t RetainedRewrittenElfBufferCountForTesting(hsa_executable_t executable) {
 bool HotswapRewriteWithOptionsAvailableForTesting() {
   ComgrApi* api = GetComgrApi();
   return api && api->hotswap_rewrite_with_options;
+}
+
+void ForceRetargetCodeObjectFailureForTesting(bool force) {
+  g_force_retarget_code_object_failure_for_testing = force;
 }
 #endif
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap.cpp
@@ -105,6 +105,10 @@ bool IsGfx12_5RewriteRequested() {
   return !os::IsEnvVarSet(kEnvName) || os::GetEnvVar(kEnvName) != "0";
 }
 
+bool IsStrictModeRequested() {
+  return IsEnvFlagEnabled("HSA_HOTSWAP_STRICT_MODE");
+}
+
 bool IsVerboseLoggingEnabled() {
   static const bool verbose = IsEnvFlagEnabled("HSA_HOTSWAP_VERBOSE");
   return verbose;
@@ -281,7 +285,8 @@ std::string WithGfx1250SteppingFeature(const std::string& isa_name,
 
 bool HasCandidateHotswapRewrite(const AgentGfxRevision& gfx,
                                 const RewriteOptions& options) {
-  return (options.strict_mode_enabled && gfx.gfx_target == kGfx1250) ||
+  return IsHotswapSupportedGfxRevision(gfx) ||
+         (options.strict_mode_enabled && gfx.gfx_target == kGfx1250) ||
          (options.gfx12_5_rewrite_enabled &&
           IsGfx12_5Target(gfx.gfx_target));
 }
@@ -297,14 +302,11 @@ std::optional<RewriteDecision> DecideHotswapRewrite(
   const std::string target_gfx = ExtractGfxTarget(target_isa);
   if (IsHotswapSupportedGfxRevision(gfx) && source_gfx == kGfx1250 &&
       target_gfx == kGfx1250) {
-    if (!options.strict_mode_enabled) {
-      return std::nullopt;
-    }
     return RewriteDecision{
         WithGfx1250SteppingFeature(source_isa, Gfx1250Stepping::kB0),
         WithGfx1250SteppingFeature(target_isa, Gfx1250Stepping::kA0),
         false,
-        true};
+        false};
   }
 
   const bool request_entry_trampolines =
@@ -473,6 +475,7 @@ RetargetCodeObjectResult TryRetargetCodeObject(const CodeObjectView& code_object
   const AgentGfxRevision gfx = GetAgentGfxRevision(agent);
   RewriteOptions options;
   options.gfx12_5_rewrite_enabled = IsGfx12_5RewriteRequested();
+  options.strict_mode_enabled = IsStrictModeRequested();
   if (!IsAgentEligibleForHotswap(gfx, options)) {
     return {};
   }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap.cpp
@@ -43,6 +43,7 @@
 #include "core/inc/hotswap.hpp"
 
 #include <algorithm>
+#include <atomic>
 #include <cctype>
 #include <cstdio>
 #include <cstdint>
@@ -69,7 +70,7 @@ namespace {
 std::mutex g_retained_rewritten_elf_buffers_mutex;
 std::unordered_map<uint64_t, std::vector<OwnedElfBuffer>> g_retained_rewritten_elf_buffers;
 #ifdef ROCR_HOTSWAP_TESTING
-bool g_force_retarget_code_object_failure_for_testing = false;
+std::atomic<bool> g_force_retarget_code_object_failure_for_testing{false};
 #endif
 
 constexpr char kGfx1250[] = "gfx1250";
@@ -302,6 +303,9 @@ std::optional<RewriteDecision> DecideHotswapRewrite(
   const std::string target_gfx = ExtractGfxTarget(target_isa);
   if (IsHotswapSupportedGfxRevision(gfx) && source_gfx == kGfx1250 &&
       target_gfx == kGfx1250) {
+    // Keep A0 retargeting on COMGR's legacy rewrite path. The B0 source and A0
+    // target ISA features select the required instruction patches without
+    // strict mode; B0 strict rewrites use hotswap_rewrite_with_options().
     RewriteDecision decision;
     decision.source_isa =
         WithGfx1250SteppingFeature(source_isa, Gfx1250Stepping::kB0);
@@ -497,7 +501,7 @@ RetargetCodeObjectResult TryRetargetCodeObject(const CodeObjectView& code_object
 
   bool rewritten = false;
 #ifdef ROCR_HOTSWAP_TESTING
-  if (g_force_retarget_code_object_failure_for_testing) {
+  if (g_force_retarget_code_object_failure_for_testing.load(std::memory_order_relaxed)) {
     HOTSWAP_LOG("hotswap: forcing retarget failure for test\n");
   } else
 #endif
@@ -612,7 +616,7 @@ bool HotswapRewriteWithOptionsAvailableForTesting() {
 }
 
 void ForceRetargetCodeObjectFailureForTesting(bool force) {
-  g_force_retarget_code_object_failure_for_testing = force;
+  g_force_retarget_code_object_failure_for_testing.store(force, std::memory_order_relaxed);
 }
 #endif
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap.cpp
@@ -100,10 +100,12 @@ bool IsEnvFlagEnabled(const char* name) {
 
 bool IsHotswapDisabledByEnv() { return IsEnvFlagEnabled("HSA_HOTSWAP_DISABLE"); }
 
-bool IsGfx12_5RewriteRequested() {
+bool AreEntryTrampolinesRequested() {
   constexpr char kEnvName[] = "AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES";
-  // Default-on policy owned by ROCR: only literal "0" opts out.
-  return !os::IsEnvVarSet(kEnvName) || os::GetEnvVar(kEnvName) != "0";
+  if (!os::IsEnvVarSet(kEnvName)) {
+    return kDefaultEntryTrampolinesEnabled;
+  }
+  return IsEnvFlagEnabled(kEnvName);
 }
 
 bool IsStrictModeRequested() {
@@ -287,9 +289,8 @@ std::string WithGfx1250SteppingFeature(const std::string& isa_name,
 bool HasCandidateHotswapRewrite(const AgentGfxRevision& gfx,
                                 const RewriteOptions& options) {
   return IsHotswapSupportedGfxRevision(gfx) ||
-         (options.strict_mode_enabled && gfx.gfx_target == kGfx1250) ||
-         (options.gfx12_5_rewrite_enabled &&
-          IsGfx12_5Target(gfx.gfx_target));
+      (options.strict_mode_enabled && gfx.gfx_target == kGfx1250) ||
+      (options.entry_trampolines_enabled && IsGfx12_5Target(gfx.gfx_target));
 }
 
 std::optional<RewriteDecision> DecideHotswapRewrite(
@@ -315,8 +316,7 @@ std::optional<RewriteDecision> DecideHotswapRewrite(
     return decision;
   }
 
-  const bool request_entry_trampolines =
-      options.gfx12_5_rewrite_enabled &&
+  const bool request_entry_trampolines = options.entry_trampolines_enabled &&
       IsGfx12_5Target(gfx.gfx_target) && IsGfx12_5Target(source_gfx);
   const bool request_strict_mode =
       options.strict_mode_enabled && gfx.gfx_target == kGfx1250 &&
@@ -483,7 +483,7 @@ RetargetCodeObjectResult TryRetargetCodeObject(const CodeObjectView& code_object
 
   const AgentGfxRevision gfx = GetAgentGfxRevision(agent);
   RewriteOptions options;
-  options.gfx12_5_rewrite_enabled = IsGfx12_5RewriteRequested();
+  options.entry_trampolines_enabled = AreEntryTrampolinesRequested();
   options.strict_mode_enabled = IsStrictModeRequested();
   if (!IsAgentEligibleForHotswap(gfx, options)) {
     return {};

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap.cpp
@@ -302,11 +302,13 @@ std::optional<RewriteDecision> DecideHotswapRewrite(
   const std::string target_gfx = ExtractGfxTarget(target_isa);
   if (IsHotswapSupportedGfxRevision(gfx) && source_gfx == kGfx1250 &&
       target_gfx == kGfx1250) {
-    return RewriteDecision{
-        WithGfx1250SteppingFeature(source_isa, Gfx1250Stepping::kB0),
-        WithGfx1250SteppingFeature(target_isa, Gfx1250Stepping::kA0),
-        false,
-        false};
+    RewriteDecision decision;
+    decision.source_isa =
+        WithGfx1250SteppingFeature(source_isa, Gfx1250Stepping::kB0);
+    decision.target_isa =
+        WithGfx1250SteppingFeature(target_isa, Gfx1250Stepping::kA0);
+    decision.rewrite_required = true;
+    return decision;
   }
 
   const bool request_entry_trampolines =
@@ -319,9 +321,12 @@ std::optional<RewriteDecision> DecideHotswapRewrite(
     return std::nullopt;
   }
 
-  RewriteDecision decision{source_isa, source_isa,
-                           request_entry_trampolines,
-                           request_strict_mode};
+  RewriteDecision decision;
+  decision.source_isa = source_isa;
+  decision.target_isa = source_isa;
+  decision.request_entry_trampolines = request_entry_trampolines;
+  decision.request_strict_mode = request_strict_mode;
+  decision.rewrite_required = request_strict_mode;
   if (source_gfx == kGfx1250) {
     decision.source_isa =
         WithGfx1250SteppingFeature(source_isa, Gfx1250Stepping::kB0);
@@ -381,12 +386,12 @@ void LogRewrittenCodeObjectLoadFailure(hsa_status_t status) {
 }
 
 void LogRequiredRewriteFailure() {
-  HOTSWAP_LOG("hotswap: required strict-mode rewrite failed, not falling back to original "
+  HOTSWAP_LOG("hotswap: required rewrite failed, not falling back to original "
               "code object\n");
 }
 
 void LogRequiredRewrittenLoadFailure(hsa_status_t status) {
-  HOTSWAP_LOG("hotswap: required strict-mode rewritten load failed (status=%d), not falling "
+  HOTSWAP_LOG("hotswap: required rewritten load failed (status=%d), not falling "
               "back to original code object\n",
               static_cast<int>(status));
 }
@@ -503,16 +508,17 @@ RetargetCodeObjectResult TryRetargetCodeObject(const CodeObjectView& code_object
                                    decision->request_entry_trampolines,
                                    decision->request_strict_mode);
   }
-  HOTSWAP_LOG("hotswap: rewrite src=%s tgt=%s entry_trampolines=%d strict=%d "
+  HOTSWAP_LOG("hotswap: rewrite src=%s tgt=%s entry_trampolines=%d strict=%d required=%d "
               "in=%zu out=%zu changed=%d\n",
               decision->source_isa.c_str(), decision->target_isa.c_str(),
               decision->request_entry_trampolines, decision->request_strict_mode,
-              code_object.size, rewritten ? *out_elf_size : 0, rewritten ? 1 : 0);
+              decision->rewrite_required, code_object.size, rewritten ? *out_elf_size : 0,
+              rewritten ? 1 : 0);
   if (rewritten) {
     return {RetargetCodeObjectStatus::kRewritten,
-            decision->request_strict_mode};
+            decision->rewrite_required};
   }
-  if (decision->request_strict_mode) {
+  if (decision->rewrite_required) {
     return {RetargetCodeObjectStatus::kRequiredRewriteFailed, true};
   }
   return {};
@@ -556,7 +562,7 @@ hsa_status_t LoadAgentCodeObjectWithHotswap(hsa_executable_t executable, hsa_age
       RetainRewrittenElfBuffer(executable, std::move(rewritten_elf_buffer));
       return status;
     }
-    if (retarget_result.strict_mode_required) {
+    if (retarget_result.rewrite_required) {
       LogRequiredRewrittenLoadFailure(status);
       return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
     }


### PR DESCRIPTION
## Summary
- Add `HSA_HOTSWAP_STRICT_MODE`, default off, to request COMGR `AMD_COMGR_HOTSWAP_REWRITE_FLAG_STRICT_MODE` for non-A0 `gfx1250` HotSwap rewrites.
- Keep A0 retargeting outside ROCR strict mode; A0 continues to use the normal B0-to-A0 hotswap path and does not set the COMGR strict flag.
- Treat required rewrites as non-fallback operations: A0 B0-to-A0 retargeting and opt-in B0 strict rewrites return `HSA_STATUS_ERROR_INVALID_CODE_OBJECT` if COMGR cannot produce the rewrite or the rewritten code object cannot be loaded.
- Keep entry-trampoline selection independent from strict-mode mask workarounds, so `AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES=0` only disables entry trampolines.
- Preserve the original fallback behavior for optional rewrites and no-decision paths.
- Document `HSA_HOTSWAP_STRICT_MODE` in the runtime environment variable table.
- Depends on ROCm/llvm-project#3312 for COMGR B0 strict mask workaround support.

## JIRA ID
JIRA ID : ROCM-27304
JIRA ID : PLAT-204339

## Testing
- `cmake --build build-rocrtst-hotswap-review --target hotswap_rewrite -j 8`
- `ctest --test-dir build-rocrtst-hotswap-review -R hotswap_rewrite --output-on-failure`
- Result: `hotswap_rewrite` 30/30 passed.

