### PR TITLE
fix(rocprof-systems): Fix transpose to work under MPI

### DIFF
--- a/projects/rocprofiler-systems/examples/transpose/transpose.cpp
+++ b/projects/rocprofiler-systems/examples/transpose/transpose.cpp
@@ -107,8 +107,14 @@ size_t nsync    = 10;
 }  // namespace
 
 void
-run(int rank, int tid, hipStream_t stream, int argc, char** argv)
+run(int rank, int tid, int devid, hipStream_t stream, int argc, char** argv)
 {
+    // HIP tracks the active device per host thread, so each worker thread must
+    // select the same device its stream was created on. Otherwise kernel
+    // launches fail with "invalid resource handle" whenever a rank is mapped to
+    // a non-zero device (e.g. rank 1 -> device 1 under MPI).
+    HIP_API_CALL(hipSetDevice(devid));
+
     unsigned int M = 4960 * 2;
     unsigned int N = 4960 * 2;
     if(argc > 2) nitr = atoll(argv[2]);
@@ -228,7 +234,9 @@ main(int argc, char** argv)
 #else
     (void) size;
 #endif
-    // this is a temporary workaround in rocprof-sys when HIP + MPI is enabled
+    // Map each rank round-robin onto the available GPUs. When there are more
+    // ranks than devices, multiple ranks share a device (e.g. 2 ranks on 1 GPU
+    // both use device 0), so every rank performs GPU work under MPI.
     int ndevice = 0;
     int devid   = rank;
     HIP_API_CALL(hipGetDeviceCount(&ndevice));
@@ -238,16 +246,14 @@ main(int argc, char** argv)
         devid = rank % ndevice;
         HIP_API_CALL(hipSetDevice(devid));
         printf("[transpose] Rank %i assigned to device %i\n", rank, devid);
-    }
-    if(rank == devid && rank < ndevice)
-    {
+
         std::vector<std::thread> _threads{};
         std::vector<hipStream_t> _streams(nthreads);
         for(size_t i = 0; i < nthreads; ++i)
             HIP_API_CALL(hipStreamCreate(&_streams.at(i)));
         for(size_t i = 1; i < nthreads; ++i)
-            _threads.emplace_back(run, rank, i, _streams.at(i), argc, argv);
-        run(rank, 0, _streams.at(0), argc, argv);
+            _threads.emplace_back(run, rank, i, devid, _streams.at(i), argc, argv);
+        run(rank, 0, devid, _streams.at(0), argc, argv);
         for(auto& itr : _threads)
             itr.join();
         for(size_t i = 0; i < nthreads; ++i)

--- a/projects/rocprofiler-systems/tests/pytest/test_transpose.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_transpose.py
@@ -4,7 +4,7 @@
 """
 Tests for the transpose example.
 Equivalent to rocprof-sys-rocm-tests.cmake
-    Note: MPI is not yet supported
+    Note: MPI multi-process execution is exercised if built with MPI support.
 
 This module tests the transpose HIP example with various instrumentation modes:
 - Baseline execution (no instrumentation)


### PR DESCRIPTION
## Motivation

Under MPI, transpose only ran GPU work on ranks mapped 1:1 to a distinct device, and worker threads never selected their stream's device — so ranks bound to a non-zero GPU crashed with "invalid resource handle" and ranks beyond the device count did no GPU work at all.

## Technical Details

- **Per-thread device selection**: added `hipSetDevice(devid)` at the start of `run()`. HIP tracks the active device per host thread, and freshly spawned `std::thread` workers default to device 0; without this they launched kernels on a stream owned by a different device and failed with "invalid resource handle" whenever a rank was mapped to a non-zero device (e.g. rank 1 → device 1).
- **Round-robin GPU sharing**: replaced the restrictive guard `if(rank == devid && rank < ndevice)` with `if(ndevice > 0)`, so ranks map round-robin via `devid = rank % ndevice` and ranks beyond the device count share a GPU (e.g. 2 ranks on 1 GPU both use device 0) instead of skipping GPU work.
- Removed the stale "temporary workaround in rocprof-sys when HIP + MPI is enabled" comment; the underlying limitation no longer applies — verified that multiple ranks sharing a single GPU each collect full HW counter data.
 - Thread wiring: the device id is now threaded through to every worker `(run(rank, i, devid, stream, ...))` and the main-thread invocation, and the device-assignment + GPU-work blocks are merged into a single `if(ndevice > 0)` block

## JIRA ID

JIRA ID : AIPROFSYST-622

## Test Plan

Manual and CI test.

## Test Result

Pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
