### PR TITLE
refactor(rocr): Unify SDMA submission API

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_blit_sdma.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_blit_sdma.h
@@ -96,19 +96,10 @@ class BlitSdmaBase : public core::Blit {
       core::Signal& out_signal,
       bool profiling_enabled) = 0;
 
-  /// @brief Pack N linear copy packets back-to-back in a single SDMA ring
-  /// submission (linearB2BCopy path).  Each entry i copies srcs[i] -> dsts[i]
-  /// of sizes[i] bytes.  For the broadcast case (same src/size for all dsts),
-  /// the caller simply fills srcs and sizes with repeated values.
-  virtual hsa_status_t SubmitLinearCopyB2BCommand(
-      const std::vector<void*>& dsts, const std::vector<const void*>& srcs,
-      const std::vector<size_t>& sizes, std::vector<core::Signal*>& dep_signals,
-      core::Signal& out_signal) = 0;
-
   virtual bool BroadcastSupported() const = 0;
   virtual bool MulticastSupported() const = 0;
   virtual bool PlatformAtomicSupport() const = 0;
-  virtual bool IsGfx1250() const = 0;
+  virtual bool IsGfx125Plus() const = 0;
 
   /// @brief Maximum byte count a single linear copy packet can describe
   /// (the 30-bit count field, ~1 GiB).  Larger copies are split into multiple
@@ -118,64 +109,79 @@ class BlitSdmaBase : public core::Blit {
   /// larger than this limit.
   virtual size_t MaxSingleLinearCopySize() const = 0;
 
-  virtual hsa_status_t SubmitPrologue(const std::vector<core::Signal*>& dep_signals,
-                                      core::Signal& out_signal,
-                                      core::Signal& prologue_signal) = 0;
-
-  virtual hsa_status_t SubmitBody(const void* cmd, size_t cmd_size, uint64_t size,
-                                  core::Signal& prologue_signal,
-                                  core::Signal& body_signal) = 0;
-
-  /// @brief Submit epilogue that waits for bodies, then performs GCR writeback,
-  /// end timestamp, and sets out_signal to its final value.
-  /// When body_signals is non-empty, polls each body signal for 0 (non-atomic path).
-  /// When body_signals is empty, polls out_signal for body_complete_value (atomic path).
-  virtual hsa_status_t SubmitEpilogue(core::Signal& out_signal,
-                                      hsa_signal_value_t body_complete_value,
-                                      const std::vector<core::Signal*>& body_signals = {}) = 0;
-
-  virtual hsa_status_t SubmitLinearCopyBody(void* dst, const void* src, size_t size,
-                                            core::Signal& prologue_signal,
-                                            core::Signal& body_signal) = 0;
-
-  virtual hsa_status_t SubmitLinearSwapBody(void* addr_a, void* addr_b, size_t size,
-                                            core::Signal& prologue_signal,
-                                            core::Signal& body_signal) = 0;
-
-  /// @brief Emit a fused wait/copy/signal linear copy.  @p dep_signals[0] folds
-  /// into the packet WAIT and @p out_signal is decremented by the packet SIGNAL
-  /// on the final chunk (large copies are chunked internally).  When
-  /// @p fused_notify is true the GCR invalidate (prologue) and GCR writeback +
-  /// mailbox notify (epilogue) are emitted in the same ring reservation, so a
-  /// standalone single-engine copy needs only one reserve/release instead of
-  /// three; the fan-out path leaves it false and drives notify separately across
-  /// engines.
+  /// @brief Single-doorbell fused WaitSignal copy for gfx125+ single copies.
+  /// Emits GCR invalidate + dep polls + N fused WaitSignal+Copy packets +
+  /// GCR writeback + mailbox/trap — all in one ring reservation.
+  /// Each chunk carries wait+copy+signal dec inline; no prologue signal needed.
   virtual hsa_status_t SubmitLinearCopyBodyWaitSignal(
       void* dst, const void* src, size_t size,
       const std::vector<core::Signal*>& dep_signals,
       core::Signal& out_signal,
       bool fused_notify = true) = 0;
 
-  virtual hsa_status_t SubmitLinearSwapBodyWaitSignal(
-      void* addr_a, void* addr_b, size_t size_a, size_t size_b,
+  /// @brief Unified prologue: dep polls, HDP flush, start timestamp, GCR
+  /// invalidate, and prologue_signal decrement — emitted conditionally based on
+  /// @p fused_bodies and the internal profiling_enabled() state.
+  ///   fused + !profiling: only GCR invalidate + prologue_signal dec (bodies WAIT
+  ///     on deps themselves).
+  ///   !fused or profiling: dep polls + HDP flush + [start timestamp] + GCR + dec.
+  virtual hsa_status_t SubmitPrologue(
       const std::vector<core::Signal*>& dep_signals,
-      core::Signal& out_signal) = 0;
+      core::Signal& out_signal,
+      core::Signal& prologue_signal,
+      bool fused_bodies) = 0;
 
-  // Linear copy body with optional source and/or destination address
-  // indirection, combined wait+signal.  The SDMA engine dereferences
-  // @p src (when @p indirect_src) and/or @p dst (when @p indirect_dst)
-  // to obtain the real copy pointers before performing the transfer.
-  // At least one of @p indirect_src or @p indirect_dst must be true.
-  // Only available on gfx1250.
-  virtual hsa_status_t SubmitLinearCopyBodyIndirectWaitSignal(
-      void* dst, const void* src, size_t size,
+  /// @brief Unified epilogue: drain bodies, GCR writeback, end timestamp (if
+  /// profiling), final out_signal write to 0, mailbox + trap interrupt.
+  /// When platform atomics are available (body_signals empty): polls out_signal
+  /// for 1 (bodies decremented it from N+1 to 1).
+  /// When platform atomics are absent (body_signals non-empty): polls each
+  /// body_signal for 0 (bodies fenced them), then fences out_signal to 0.
+  virtual hsa_status_t SubmitEpilogue(
+      core::Signal& out_signal,
+      const std::vector<core::Signal*>& body_signals = {}) = 0;
+
+  /// @brief Single-doorbell fused submission for the coordinator engine: packs
+  /// prologue (if needed) + body entries + epilogue into one ring reservation.
+  /// Saves 1-2 doorbells vs separate Submit{Prologue,Bodies,Epilogue} calls when
+  /// the coordinator engine also carries body entries.
+  /// @param prologue_signal  If non-null, prologue logic fires this signal after
+  ///   dep handling; other engines' bodies can poll on it.
+  /// @param body_deps  Dependencies for the body WaitSignal packets on this ring.
+  ///   When prologue is on the same ring, these are satisfied in-order (the wait
+  ///   resolves immediately), but are still encoded for packet correctness.
+  virtual hsa_status_t SubmitFusedCoordinator(
+      const std::vector<core::Signal*>& dep_signals,
+      core::Signal& out_signal,
+      core::Signal* prologue_signal,
+      bool fused_bodies,
+      hsa_amd_memory_copy_op_type_t op,
+      const std::vector<void*>& dsts,
+      const std::vector<const void*>& srcs,
+      const std::vector<size_t>& sizes_a,
+      const std::vector<size_t>& sizes_b,
+      bool indirect_src, bool indirect_dst,
+      const std::vector<core::Signal*>& body_deps) = 0;
+
+  /// @brief Unified body submission: one ring reservation (one doorbell) for all
+  /// entries in an engine group.  Dispatches internally to copy / swap / indirect
+  /// packet builders based on @p op.  Every chunk waits on dep_signals[0] and
+  /// decrements out_signal via fused WaitSignal packets; dep_signals[1..] are
+  /// leading 64b polls.  Arms out_signal for chunk extras:
+  /// AddRelaxed(total_chunks - num_entries).
+  /// @param body_signal  When non-null (!platform_atomic_support_ classic path),
+  ///   the body fences this signal to 0 on completion instead of atomic-
+  ///   decrementing out_signal.  Caller allocates one per engine group.
+  virtual hsa_status_t SubmitBodies(
+      hsa_amd_memory_copy_op_type_t op,
+      const std::vector<void*>& dsts,
+      const std::vector<const void*>& srcs,
+      const std::vector<size_t>& sizes_a,
+      const std::vector<size_t>& sizes_b,
       bool indirect_src, bool indirect_dst,
       const std::vector<core::Signal*>& dep_signals,
-      core::Signal& out_signal) = 0;
-
-  virtual hsa_status_t SubmitNotifyPrologue(
-      core::Signal* prologue_signal = nullptr) = 0;
-  virtual hsa_status_t SubmitNotifyEpilogue(core::Signal& out_signal) = 0;
+      core::Signal& out_signal,
+      core::Signal* body_signal = nullptr) = 0;
 
   virtual bool SwapSupported() const = 0;
   virtual bool IndirectCopySupported() const = 0;
@@ -258,11 +264,6 @@ template <bool useGCR, bool scopeFields> class BlitSdma : public BlitSdmaBase {
       core::Signal& out_signal,
       bool profiling_enabled) override;
 
-  hsa_status_t SubmitLinearCopyB2BCommand(
-      const std::vector<void*>& dsts, const std::vector<const void*>& srcs,
-      const std::vector<size_t>& sizes, std::vector<core::Signal*>& dep_signals,
-      core::Signal& out_signal) override;
-
   /// @brief Submit a linear fill command to the queue buffer
   ///
   /// @param ptr Memory address of the fill destination.
@@ -279,51 +280,50 @@ template <bool useGCR, bool scopeFields> class BlitSdma : public BlitSdmaBase {
   bool BroadcastSupported() const override { return broadcast_supported_; }
   bool MulticastSupported() const override { return multicast_supported_; }
   bool PlatformAtomicSupport() const override { return platform_atomic_support_; }
-  bool IsGfx1250() const override { return is_gfx1250_; }
+  bool IsGfx125Plus() const override { return is_gfx125plus_; }
   size_t MaxSingleLinearCopySize() const override {
     return max_single_linear_copy_size_ ? max_single_linear_copy_size_ : kMaxSingleCopySize;
   }
-
-  hsa_status_t SubmitPrologue(const std::vector<core::Signal*>& dep_signals,
-                              core::Signal& out_signal,
-                              core::Signal& prologue_signal) override;
-
-  hsa_status_t SubmitBody(const void* cmd, size_t cmd_size, uint64_t size,
-                          core::Signal& prologue_signal,
-                          core::Signal& body_signal) override;
-
-  hsa_status_t SubmitEpilogue(core::Signal& out_signal,
-                              hsa_signal_value_t body_complete_value,
-                              const std::vector<core::Signal*>& body_signals = {}) override;
-
-  hsa_status_t SubmitLinearCopyBody(void* dst, const void* src, size_t size,
-                                    core::Signal& prologue_signal,
-                                    core::Signal& body_signal) override;
-
-  hsa_status_t SubmitLinearSwapBody(void* addr_a, void* addr_b, size_t size,
-                                    core::Signal& prologue_signal,
-                                    core::Signal& body_signal) override;
 
   hsa_status_t SubmitLinearCopyBodyWaitSignal(
       void* dst, const void* src, size_t size,
       const std::vector<core::Signal*>& dep_signals,
       core::Signal& out_signal,
-      bool fused_notify) override;
+      bool fused_notify = true) override;
 
-  hsa_status_t SubmitLinearSwapBodyWaitSignal(
-      void* addr_a, void* addr_b, size_t size_a, size_t size_b,
+  hsa_status_t SubmitPrologue(
       const std::vector<core::Signal*>& dep_signals,
-      core::Signal& out_signal) override;
+      core::Signal& out_signal,
+      core::Signal& prologue_signal,
+      bool fused_bodies) override;
 
-  hsa_status_t SubmitLinearCopyBodyIndirectWaitSignal(
-      void* dst, const void* src, size_t size,
+  hsa_status_t SubmitEpilogue(
+      core::Signal& out_signal,
+      const std::vector<core::Signal*>& body_signals = {}) override;
+
+  hsa_status_t SubmitFusedCoordinator(
+      const std::vector<core::Signal*>& dep_signals,
+      core::Signal& out_signal,
+      core::Signal* prologue_signal,
+      bool fused_bodies,
+      hsa_amd_memory_copy_op_type_t op,
+      const std::vector<void*>& dsts,
+      const std::vector<const void*>& srcs,
+      const std::vector<size_t>& sizes_a,
+      const std::vector<size_t>& sizes_b,
+      bool indirect_src, bool indirect_dst,
+      const std::vector<core::Signal*>& body_deps) override;
+
+  hsa_status_t SubmitBodies(
+      hsa_amd_memory_copy_op_type_t op,
+      const std::vector<void*>& dsts,
+      const std::vector<const void*>& srcs,
+      const std::vector<size_t>& sizes_a,
+      const std::vector<size_t>& sizes_b,
       bool indirect_src, bool indirect_dst,
       const std::vector<core::Signal*>& dep_signals,
-      core::Signal& out_signal) override;
-
-  hsa_status_t SubmitNotifyPrologue(
-      core::Signal* prologue_signal = nullptr) override;
-  hsa_status_t SubmitNotifyEpilogue(core::Signal& out_signal) override;
+      core::Signal& out_signal,
+      core::Signal* body_signal = nullptr) override;
 
   bool SwapSupported() const override { return swap_supported_; }
   bool IndirectCopySupported() const override { return indirect_copy_supported_; }
@@ -552,16 +552,16 @@ template <bool useGCR, bool scopeFields> class BlitSdma : public BlitSdmaBase {
   /// True if SDMA supports broadcast linear copy (one src -> two dst).
   bool broadcast_supported_;
 
-  /// True if SDMA supports multicast linear copy (one src -> N dst), gfx1250+.
+  /// True if SDMA supports multicast linear copy (one src -> N dst), gfx125+.
   bool multicast_supported_;
 
-  /// True for gfx1250 (major=12 minor=5): multicast, wait/signal packets, 64b poll/fence.
-  bool is_gfx1250_;
+  /// True for gfx125+ (major=12 minor>=5): multicast, wait/signal packets, 64b poll/fence.
+  bool is_gfx125plus_;
 
   /// True if SDMA supports linear swap copy (gfx94X+).
   bool swap_supported_;
 
-  /// True if SDMA supports the linear wait/signal-indirect copy packet (gfx1250).
+  /// True if SDMA supports the linear wait/signal-indirect copy packet (gfx125+).
   bool indirect_copy_supported_;
 };
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_blit_sdma.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_blit_sdma.h
@@ -169,15 +169,20 @@ class BlitSdmaBase : public core::Blit {
   /// decrements out_signal via fused WaitSignal packets; dep_signals[1..] are
   /// leading 64b polls.  Arms out_signal for chunk extras:
   /// AddRelaxed(total_chunks - num_entries).
+  ///
+  /// Entries are gathered directly from the caller's master @p dst_list /
+  /// @p src_list / @p size_list arrays via @p indices, avoiding per-engine
+  /// temporary copies at the call site.
+  /// @param indices  Master-list indices of the entries this engine handles.
   /// @param body_signal  When non-null (!platform_atomic_support_ classic path),
   ///   the body fences this signal to 0 on completion instead of atomic-
   ///   decrementing out_signal.  Caller allocates one per engine group.
   virtual hsa_status_t SubmitBodies(
       hsa_amd_memory_copy_op_type_t op,
-      const std::vector<void*>& dsts,
-      const std::vector<const void*>& srcs,
-      const std::vector<size_t>& sizes_a,
-      const std::vector<size_t>& sizes_b,
+      void* const* dst_list,
+      const void* const* src_list,
+      const size_t* size_list,
+      const std::vector<uint32_t>& indices,
       bool indirect_src, bool indirect_dst,
       const std::vector<core::Signal*>& dep_signals,
       core::Signal& out_signal,
@@ -316,10 +321,10 @@ template <bool useGCR, bool scopeFields> class BlitSdma : public BlitSdmaBase {
 
   hsa_status_t SubmitBodies(
       hsa_amd_memory_copy_op_type_t op,
-      const std::vector<void*>& dsts,
-      const std::vector<const void*>& srcs,
-      const std::vector<size_t>& sizes_a,
-      const std::vector<size_t>& sizes_b,
+      void* const* dst_list,
+      const void* const* src_list,
+      const size_t* size_list,
+      const std::vector<uint32_t>& indices,
       bool indirect_src, bool indirect_dst,
       const std::vector<core::Signal*>& dep_signals,
       core::Signal& out_signal,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
@@ -813,13 +813,6 @@ class GpuAgent : public GpuAgentInt {
       const hsa_amd_memory_copy_op_t& op,
       std::vector<core::Signal*>& dep_signals);
 
-  // Multi-linear copy: LINEAR op with num_entries > 0, independent copies
-  // (different src/dst/size per entry) sharing a single completion signal.
-  // Uses prologue/body/epilogue fan-out across available SDMA engines.
-  hsa_status_t DmaCopyMulti(
-      const hsa_amd_memory_copy_op_t& op,
-      std::vector<core::Signal*>& dep_signals);
-
   // Linear swap: exchanges the contents of src and dst buffers.
   // Only supported on gfx94X / gfx95X.  Uses DmaCopyFanOutOp with
   // HSA_AMD_MEMORY_COPY_OP_LINEAR_SWAP.
@@ -838,7 +831,7 @@ class GpuAgent : public GpuAgentInt {
       const hsa_amd_memory_copy_op_t& op,
       std::vector<core::Signal*>& dep_signals);
 
-  // Common fan-out implementation shared by DmaCopyBroadcast, DmaCopyMulti,
+  // Common fan-out implementation shared by DmaCopyBroadcast, DmaCopyBatch,
   // swap and indirect operations.  Submits prologue, per-entry bodies
   // (selected by @p op), and epilogue with one signal.
   // @p op is the hsa_amd_memory_copy_op_type_t from the public API;
@@ -853,7 +846,9 @@ class GpuAgent : public GpuAgentInt {
       const void* const* src_list,
       void* const* dst_list,
       const hsa_agent_t* dst_agent_list,
-      const size_t* size_list);
+      const size_t* size_list,
+      uint32_t coord_engine = 0,
+      uint32_t max_engines = 0);
 
   // Bind index of peer device that is connected via xGMI links
   lazy_ptr<core::Blit>& GetXgmiBlit(const core::Agent& peer_agent);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
@@ -1289,18 +1289,17 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitFusedCoordinator(
 template <bool useGCR, bool scopeFields>
 hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitBodies(
     hsa_amd_memory_copy_op_type_t op,
-    const std::vector<void*>& dsts,
-    const std::vector<const void*>& srcs,
-    const std::vector<size_t>& sizes_a,
-    const std::vector<size_t>& sizes_b,
+    void* const* dst_list,
+    const void* const* src_list,
+    const size_t* size_list,
+    const std::vector<uint32_t>& indices,
     bool indirect_src, bool indirect_dst,
     const std::vector<core::Signal*>& dep_signals,
     core::Signal& out_signal,
     core::Signal* body_signal) {
 
-  const size_t num_entries = dsts.size();
-  if (num_entries == 0 || srcs.size() != num_entries || sizes_a.size() != num_entries)
-    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  const size_t num_entries = indices.size();
+  if (num_entries == 0) return HSA_STATUS_ERROR_INVALID_ARGUMENT;
 
   const bool is_swap = (op == HSA_AMD_MEMORY_COPY_OP_LINEAR_SWAP);
   const bool is_indirect = (indirect_src || indirect_dst);
@@ -1314,8 +1313,9 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitBodies(
   if (is_swap) {
     constexpr size_t kAlign = SDMA_PKT_COPY_LINEAR_SWAP_WAITSIGNAL_GFX1250::kAlignment_;
     for (size_t i = 0; i < num_entries; ++i) {
-      if ((reinterpret_cast<uintptr_t>(dsts[i]) & (kAlign - 1)) != 0 ||
-          (reinterpret_cast<uintptr_t>(srcs[i]) & (kAlign - 1)) != 0)
+      const uint32_t d = indices[i];
+      if ((reinterpret_cast<uintptr_t>(dst_list[d]) & (kAlign - 1)) != 0 ||
+          (reinterpret_cast<uintptr_t>(src_list[d]) & (kAlign - 1)) != 0)
         return HSA_STATUS_ERROR_INVALID_ARGUMENT;
     }
   }
@@ -1333,9 +1333,7 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitBodies(
     uint32_t total_chunks = 0;
     uint64_t total_bytes = 0;
     for (size_t i = 0; i < num_entries; ++i) {
-      const size_t entry_size = is_swap
-          ? std::max(sizes_a[i], sizes_b[i])
-          : sizes_a[i];
+      const size_t entry_size = size_list[indices[i]];
       if (is_indirect && entry_size > max_copy_size)
         return HSA_STATUS_ERROR_INVALID_ARGUMENT;
       chunks[i] = is_indirect ? 1
@@ -1383,19 +1381,20 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitBodies(
     const uint32_t copy_start = wrapped_index;
 
     for (size_t i = 0; i < num_entries; ++i) {
+      const uint32_t d = indices[i];
       if (is_indirect) {
         BuildWaitSignalIndirectCopyCommand(command_addr,
-            dsts[i], srcs[i], sizes_a[i],
+            dst_list[d], src_list[d], size_list[d],
             indirect_src, indirect_dst,
             wait_sig, &out_signal);
       } else if (is_swap) {
         BuildWaitSignalSwapCommand(command_addr, chunks[i],
-            dsts[i], const_cast<void*>(srcs[i]),
-            sizes_a[i], sizes_b[i],
+            dst_list[d], const_cast<void*>(src_list[d]),
+            size_list[d], size_list[d],
             wait_sig, &out_signal);
       } else {
         BuildWaitSignalCopyCommand(command_addr, chunks[i],
-            dsts[i], srcs[i], sizes_a[i],
+            dst_list[d], src_list[d], size_list[d],
             wait_sig, &out_signal);
       }
       const uint32_t entry_bytes = chunks[i] * per_pkt_dws * sizeof(uint32_t);
@@ -1432,7 +1431,7 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitBodies(
     uint32_t total_copy_bytes = 0;
     uint64_t total_bytes = 0;
     for (size_t i = 0; i < num_entries; ++i) {
-      const size_t entry_size = sizes_a[i];
+      const size_t entry_size = size_list[indices[i]];
       chunks[i] = static_cast<uint32_t>((entry_size + classic_max - 1) / classic_max);
       total_copy_bytes += chunks[i] * per_pkt_dws * sizeof(uint32_t);
       total_bytes += entry_size;
@@ -1469,13 +1468,14 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitBodies(
     // Copy packets (all entries, serialized).
     const uint32_t copy_start = wrapped_index;
     for (size_t i = 0; i < num_entries; ++i) {
+      const uint32_t d = indices[i];
       const uint32_t entry_copy_bytes = chunks[i] * per_pkt_dws * sizeof(uint32_t);
 
       if (is_swap) {
         BuildSwapCopyCommand(command_addr, chunks[i],
-                             dsts[i], const_cast<void*>(srcs[i]), sizes_a[i]);
+                             dst_list[d], const_cast<void*>(src_list[d]), size_list[d]);
       } else {
-        BuildCopyCommand(command_addr, chunks[i], dsts[i], srcs[i], sizes_a[i]);
+        BuildCopyCommand(command_addr, chunks[i], dst_list[d], src_list[d], size_list[d]);
       }
       command_addr += entry_copy_bytes;
       wrapped_index += entry_copy_bytes;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
@@ -115,7 +115,7 @@ const uint32_t BlitSdma<useGCR, scopeFields>::poll_64b_command_size_ = sizeof(SD
 
 template <bool useGCR,bool scopeFields>
 uint32_t BlitSdma<useGCR, scopeFields>::gcr_command_size() {
-  if (is_gfx1250_) {
+  if (is_gfx125plus_) {
     return sizeof(SDMA_PKT_GCR_GFX1250);
   }
   return sizeof(SDMA_PKT_GCR);
@@ -144,7 +144,7 @@ BlitSdma<useGCR, scopeFields>::BlitSdma()
       queue_doorbell_(nullptr),
       broadcast_supported_(false),
       multicast_supported_(false),
-      is_gfx1250_(false),
+      is_gfx125plus_(false),
       swap_supported_(false),
       indirect_copy_supported_(false) {
   std::memset(&queue_resource_, 0, sizeof(queue_resource_));
@@ -201,13 +201,13 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::Initialize(const core::Agent& agent,
     hdp_flush_support_ = link.info.link_type != HSA_AMD_LINK_INFO_TYPE_XGMI;
   }
 
-  is_gfx1250_ = (major == 12 && minor == 5);
+  is_gfx125plus_ = (major == 12 && minor >= 5);
 
-  // The linear wait/signal-indirect copy packet is available on gfx1250.
-  indirect_copy_supported_ = is_gfx1250_;
+  // The linear wait/signal-indirect copy packet is available on gfx125+.
+  indirect_copy_supported_ = is_gfx125plus_;
 
-  // Multicast (one src -> N dst) linear copy packet is gfx1250-specific.
-  multicast_supported_ = is_gfx1250_;
+  // Multicast (one src -> N dst) linear copy packet is gfx125+.
+  multicast_supported_ = is_gfx125plus_;
 
   // Broadcast linear copy supported on MI200+ and all SDMA 5.x/6.x+.
   if (major >= 10) {
@@ -664,556 +664,6 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitCommand(const void* cmd, size_
 }
 
 template <bool useGCR, bool scopeFields>
-hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitPrologue(
-    const std::vector<core::Signal*>& dep_signals,
-    core::Signal& out_signal,
-    core::Signal& prologue_signal) {
-
-  uint32_t num_poll_command = 0;
-  uint64_t dep_signals_value[HSA_MAX_DEP_SIGNALS];
-
-  for (size_t i = 0; i < dep_signals.size(); ++i) {
-    dep_signals_value[i] = dep_signals[i]->LoadRelaxed();
-    if (dep_signals_value[i]) {
-      if (is_gfx1250_) {
-        // 64b poll handles full 64-bit value in a single command.
-        num_poll_command++;
-      } else {
-        num_poll_command++;
-        if (dep_signals_value[i] >> 32)
-          num_poll_command++;
-      }
-    }
-  }
-
-  const uint32_t per_poll_size = (is_gfx1250_) ? poll_64b_command_size_ : poll_command_size_;
-  const uint32_t total_poll_command_size = num_poll_command * per_poll_size;
-  const bool profiling_enabled = agent_->profiling_enabled();
-
-  uint64_t* start_ts_addr = nullptr;
-  uint64_t* end_ts_addr = nullptr;
-  uint32_t total_timestamp_command_size = 0;
-
-  if (profiling_enabled) {
-    out_signal.GetSdmaTsAddresses(start_ts_addr, end_ts_addr);
-    total_timestamp_command_size = timestamp_command_size_;
-  }
-
-  uint32_t flush_cmd_size = 0;
-  if (core::Runtime::runtime_singleton_->flag().enable_sdma_hdp_flush()) {
-    if (hdp_flush_support_)
-      flush_cmd_size = flush_command_size_;
-  }
-  if (useGCR) flush_cmd_size += gcr_command_size();
-
-  // Prologue signal release: prefer atomic dec, else 64b fence on gfx1250, else 32b fence.
-  const size_t prologue_signal_cmd_size = platform_atomic_support_
-      ? atomic_command_size_
-      : ((is_gfx1250_) ? fence_64b_command_size_ : fence_command_size_);
-
-  const uint32_t total_command_size = total_poll_command_size +
-      total_timestamp_command_size + flush_cmd_size + prologue_signal_cmd_size;
-  const uint32_t pad_size = total_command_size < min_submission_size_
-      ? min_submission_size_ - total_command_size
-      : core::Runtime::runtime_singleton_->thunkLoader()->IsDXG()
-            ? AlignUp(total_command_size, 64) - total_command_size : 0;
-
-  uint64_t curr_index;
-  char* command_addr;
-  uint64_t prior_bytes;
-  {
-    std::lock_guard<std::mutex> lock(reservation_lock_);
-    command_addr = AcquireWriteAddress(total_command_size + pad_size, curr_index);
-    if (command_addr == nullptr)
-      return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
-    prior_bytes = bytes_queued_;
-  }
-  uint32_t wrapped_index = WrapIntoRing(curr_index);
-
-  // Dependency signal polls.
-  for (size_t i = 0; i < dep_signals.size(); ++i) {
-    if (dep_signals_value[i]) {
-      if (is_gfx1250_) {
-        BuildPoll64bCommand(command_addr, dep_signals[i]->ValueLocation(), 0);
-        command_addr += poll_64b_command_size_;
-        bytes_written_[wrapped_index] = prior_bytes;
-        wrapped_index += poll_64b_command_size_;
-      } else {
-        uint32_t* signal_addr =
-            reinterpret_cast<uint32_t*>(dep_signals[i]->ValueLocation());
-
-        if (dep_signals_value[i] >> 32) {
-          BuildPollCommand(command_addr, &signal_addr[1], 0);
-          command_addr += poll_command_size_;
-          bytes_written_[wrapped_index] = prior_bytes;
-          wrapped_index += poll_command_size_;
-        }
-        BuildPollCommand(command_addr, &signal_addr[0], 0);
-        command_addr += poll_command_size_;
-        bytes_written_[wrapped_index] = prior_bytes;
-        wrapped_index += poll_command_size_;
-      }
-    }
-  }
-
-  // Start profiling timestamp.
-  if (profiling_enabled) {
-    BuildGetGlobalTimestampCommand(command_addr, reinterpret_cast<void*>(start_ts_addr));
-    command_addr += timestamp_command_size_;
-    bytes_written_[wrapped_index] = prior_bytes;
-    wrapped_index += timestamp_command_size_;
-  }
-
-  // HDP flush.
-  if (core::Runtime::runtime_singleton_->flag().enable_sdma_hdp_flush()) {
-    if (hdp_flush_support_) {
-      BuildHdpFlushCommand(command_addr);
-      command_addr += flush_command_size_;
-      bytes_written_[wrapped_index] = prior_bytes;
-      wrapped_index += flush_command_size_;
-    }
-  }
-
-  // GCR cache invalidate.
-  if (useGCR) {
-    BuildGCRCommand(command_addr, true);
-    command_addr += gcr_command_size();
-    bytes_written_[wrapped_index] = prior_bytes;
-    wrapped_index += gcr_command_size();
-  }
-
-  // Decrement prologue_signal to notify body engines that setup is complete.
-  if (platform_atomic_support_) {
-    BuildAtomicDecrementCommand(command_addr, prologue_signal.ValueLocation());
-    command_addr += atomic_command_size_;
-    bytes_written_[wrapped_index] = prior_bytes;
-    wrapped_index += atomic_command_size_;
-  } else if (is_gfx1250_) {
-    BuildFence64bCommand(command_addr, prologue_signal.ValueLocation(), 0);
-    command_addr += fence_64b_command_size_;
-    bytes_written_[wrapped_index] = prior_bytes;
-    wrapped_index += fence_64b_command_size_;
-  } else {
-    uint32_t* sig_loc = reinterpret_cast<uint32_t*>(prologue_signal.ValueLocation());
-    BuildFenceCommand(command_addr, sig_loc, 0);
-    command_addr += fence_command_size_;
-    bytes_written_[wrapped_index] = prior_bytes;
-    wrapped_index += fence_command_size_;
-  }
-
-  if (pad_size) {
-    memset(command_addr, 0, pad_size);
-    uint32_t* dword_command_addr = reinterpret_cast<uint32_t*>(command_addr);
-    dword_command_addr[0] = (pad_size / 4 - 1) << 16;
-  }
-
-  ReleaseWriteAddress(curr_index, total_command_size + pad_size);
-  return HSA_STATUS_SUCCESS;
-}
-
-template <bool useGCR, bool scopeFields>
-hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitBody(
-    const void* cmd, size_t cmd_size, uint64_t size,
-    core::Signal& prologue_signal,
-    core::Signal& body_signal) {
-
-  // One poll on the prologue signal (lower 32 bits reaching 0).
-  const uint32_t poll_size = poll_command_size_;
-
-  // Body signal decrement to notify the epilogue.
-  const size_t body_signal_cmd_size = platform_atomic_support_
-      ? atomic_command_size_ : fence_command_size_;
-
-  const uint32_t total_command_size = poll_size + cmd_size + body_signal_cmd_size;
-  const uint32_t pad_size = total_command_size < min_submission_size_
-      ? min_submission_size_ - total_command_size
-      : core::Runtime::runtime_singleton_->thunkLoader()->IsDXG()
-            ? AlignUp(total_command_size, 64) - total_command_size : 0;
-
-  uint64_t curr_index;
-  char* command_addr;
-  uint64_t prior_bytes, post_bytes;
-  {
-    std::lock_guard<std::mutex> lock(reservation_lock_);
-    command_addr = AcquireWriteAddress(total_command_size + pad_size, curr_index);
-    if (command_addr == nullptr)
-      return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
-    prior_bytes = bytes_queued_;
-    bytes_queued_ += size;
-    post_bytes = bytes_queued_;
-  }
-  uint32_t wrapped_index = WrapIntoRing(curr_index);
-
-  // Wait for prologue to complete.
-  uint32_t* prologue_addr =
-      reinterpret_cast<uint32_t*>(prologue_signal.ValueLocation());
-  BuildPollCommand(command_addr, &prologue_addr[0], 0);
-  command_addr += poll_command_size_;
-  bytes_written_[wrapped_index] = prior_bytes;
-  wrapped_index += poll_command_size_;
-
-  // The copy command.
-  memcpy(command_addr, cmd, cmd_size);
-  command_addr += cmd_size;
-  bytes_written_.fill(wrapped_index, wrapped_index + cmd_size, prior_bytes);
-  wrapped_index += cmd_size;
-
-  // Decrement body_signal to notify epilogue that this body is done.
-  if (platform_atomic_support_) {
-    BuildAtomicDecrementCommand(command_addr, body_signal.ValueLocation());
-    command_addr += atomic_command_size_;
-    bytes_written_[wrapped_index] = post_bytes;
-    wrapped_index += atomic_command_size_;
-  } else {
-    uint32_t* sig_loc = reinterpret_cast<uint32_t*>(body_signal.ValueLocation());
-    BuildFenceCommand(command_addr, sig_loc, 0);
-    command_addr += fence_command_size_;
-    bytes_written_[wrapped_index] = post_bytes;
-    wrapped_index += fence_command_size_;
-  }
-
-  if (pad_size) {
-    memset(command_addr, 0, pad_size);
-    uint32_t* dword_command_addr = reinterpret_cast<uint32_t*>(command_addr);
-    dword_command_addr[0] = (pad_size / 4 - 1) << 16;
-  }
-
-  ReleaseWriteAddress(curr_index, total_command_size + pad_size);
-  return HSA_STATUS_SUCCESS;
-}
-
-template <bool useGCR, bool scopeFields>
-hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitEpilogue(
-    core::Signal& out_signal,
-    hsa_signal_value_t body_complete_value,
-    const std::vector<core::Signal*>& body_signals) {
-
-  const bool use_body_signals = !body_signals.empty();
-  const bool profiling_enabled = agent_->profiling_enabled();
-
-  uint64_t* start_ts_addr = nullptr;
-  uint64_t* end_ts_addr = nullptr;
-  uint32_t total_timestamp_command_size = 0;
-
-  if (profiling_enabled) {
-    out_signal.GetSdmaTsAddresses(start_ts_addr, end_ts_addr);
-    total_timestamp_command_size = timestamp_command_size_;
-  }
-
-  const uint32_t per_poll_size = (is_gfx1250_) ? poll_64b_command_size_ : poll_command_size_;
-  const uint32_t body_poll_size = use_body_signals
-      ? static_cast<uint32_t>(body_signals.size()) * per_poll_size
-      : per_poll_size;
-
-  uint32_t gcr_cmd_size = 0;
-  if (useGCR) gcr_cmd_size = gcr_command_size();
-
-  const uint64_t completion_signal_value = use_body_signals
-      ? 0
-      : static_cast<uint64_t>(body_complete_value - 1);
-
-  size_t sync_command_size;
-  if (platform_atomic_support_) {
-    sync_command_size = atomic_command_size_;
-  } else if (is_gfx1250_) {
-    sync_command_size = fence_64b_command_size_;
-  } else {
-    sync_command_size = (completion_signal_value > UINT32_MAX)
-        ? 2 * fence_command_size_
-        : fence_command_size_;
-  }
-
-  const size_t interrupt_command_size =
-      (out_signal.signal_.event_mailbox_ptr != 0)
-          ? (fence_command_size_ + trap_command_size_)
-          : 0;
-
-  const uint32_t total_command_size = body_poll_size + gcr_cmd_size +
-      total_timestamp_command_size + sync_command_size + interrupt_command_size;
-  const uint32_t pad_size = total_command_size < min_submission_size_
-      ? min_submission_size_ - total_command_size
-      : core::Runtime::runtime_singleton_->thunkLoader()->IsDXG()
-            ? AlignUp(total_command_size, 64) - total_command_size : 0;
-
-  uint64_t curr_index;
-  char* command_addr;
-  uint64_t prior_bytes;
-  {
-    std::lock_guard<std::mutex> lock(reservation_lock_);
-    command_addr = AcquireWriteAddress(total_command_size + pad_size, curr_index);
-    if (command_addr == nullptr)
-      return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
-    prior_bytes = bytes_queued_;
-  }
-  uint32_t wrapped_index = WrapIntoRing(curr_index);
-
-  if (use_body_signals) {
-    for (size_t i = 0; i < body_signals.size(); ++i) {
-      if (is_gfx1250_) {
-        BuildPoll64bCommand(command_addr, body_signals[i]->ValueLocation(), 0);
-        command_addr += poll_64b_command_size_;
-        bytes_written_[wrapped_index] = prior_bytes;
-        wrapped_index += poll_64b_command_size_;
-      } else {
-        uint32_t* body_addr =
-            reinterpret_cast<uint32_t*>(body_signals[i]->ValueLocation());
-        BuildPollCommand(command_addr, &body_addr[0], 0);
-        command_addr += poll_command_size_;
-        bytes_written_[wrapped_index] = prior_bytes;
-        wrapped_index += poll_command_size_;
-      }
-    }
-  } else {
-    if (is_gfx1250_) {
-      BuildPoll64bCommand(command_addr, out_signal.ValueLocation(),
-                          static_cast<uint64_t>(body_complete_value));
-      command_addr += poll_64b_command_size_;
-      bytes_written_[wrapped_index] = prior_bytes;
-      wrapped_index += poll_64b_command_size_;
-    } else {
-      uint32_t* out_addr = reinterpret_cast<uint32_t*>(out_signal.ValueLocation());
-      BuildPollCommand(command_addr, &out_addr[0],
-                       static_cast<uint32_t>(body_complete_value));
-      command_addr += poll_command_size_;
-      bytes_written_[wrapped_index] = prior_bytes;
-      wrapped_index += poll_command_size_;
-    }
-  }
-
-  // GCR cache writeback.
-  if (useGCR) {
-    BuildGCRCommand(command_addr, false);
-    command_addr += gcr_command_size();
-    bytes_written_[wrapped_index] = prior_bytes;
-    wrapped_index += gcr_command_size();
-  }
-
-  // End profiling timestamp.
-  if (profiling_enabled) {
-    assert(IsMultipleOf(end_ts_addr, 32));
-    BuildGetGlobalTimestampCommand(command_addr,
-                                   reinterpret_cast<void*>(end_ts_addr));
-    command_addr += timestamp_command_size_;
-    bytes_written_[wrapped_index] = prior_bytes;
-    wrapped_index += timestamp_command_size_;
-  }
-
-  // Set completion signal to final value.
-  if (platform_atomic_support_) {
-    BuildAtomicDecrementCommand(command_addr, out_signal.ValueLocation());
-    command_addr += atomic_command_size_;
-    bytes_written_[wrapped_index] = prior_bytes;
-    wrapped_index += atomic_command_size_;
-  } else if (is_gfx1250_) {
-    BuildFence64bCommand(command_addr, out_signal.ValueLocation(),
-                         completion_signal_value);
-    command_addr += fence_64b_command_size_;
-    bytes_written_[wrapped_index] = prior_bytes;
-    wrapped_index += fence_64b_command_size_;
-  } else {
-    uint32_t* signal_value_location =
-        reinterpret_cast<uint32_t*>(out_signal.ValueLocation());
-    if (completion_signal_value > UINT32_MAX) {
-      BuildFenceCommand(command_addr, signal_value_location + 1,
-                        static_cast<uint32_t>(completion_signal_value >> 32));
-      command_addr += fence_command_size_;
-      bytes_written_[wrapped_index] = prior_bytes;
-      wrapped_index += fence_command_size_;
-    }
-
-    BuildFenceCommand(command_addr, signal_value_location,
-                      static_cast<uint32_t>(completion_signal_value));
-    command_addr += fence_command_size_;
-    bytes_written_[wrapped_index] = prior_bytes;
-    wrapped_index += fence_command_size_;
-  }
-
-  // Interrupt mailbox and trap.
-  if (out_signal.signal_.event_mailbox_ptr != 0) {
-    BuildFenceCommand(command_addr,
-                      reinterpret_cast<uint32_t*>(out_signal.signal_.event_mailbox_ptr),
-                      static_cast<uint32_t>(out_signal.signal_.event_id));
-    command_addr += fence_command_size_;
-    bytes_written_[wrapped_index] = prior_bytes;
-    wrapped_index += fence_command_size_;
-
-    BuildTrapCommand(command_addr, out_signal.signal_.event_id);
-    command_addr += trap_command_size_;
-    bytes_written_[wrapped_index] = prior_bytes;
-    wrapped_index += trap_command_size_;
-  }
-
-  if (pad_size) {
-    memset(command_addr, 0, pad_size);
-    uint32_t* dword_command_addr = reinterpret_cast<uint32_t*>(command_addr);
-    dword_command_addr[0] = (pad_size / 4 - 1) << 16;
-  }
-
-  ReleaseWriteAddress(curr_index, total_command_size + pad_size);
-  return HSA_STATUS_SUCCESS;
-}
-
-template <bool useGCR, bool scopeFields>
-hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitNotifyPrologue(
-    core::Signal* prologue_signal) {
-  if (!useGCR) return HSA_STATUS_SUCCESS;
-
-  // When prologue_signal is provided (fan-out case), emit an atomic decrement
-  // after GCR invalidate so bodies on other engines can wait on it.
-  uint32_t total_command_size = gcr_command_size();
-  if (prologue_signal) total_command_size += atomic_command_size_;
-
-  const uint32_t pad_size = total_command_size < min_submission_size_
-      ? min_submission_size_ - total_command_size
-      : is_dxg_ ? AlignUp(total_command_size, 64) - total_command_size : 0;
-
-  uint64_t curr_index;
-  char* command_addr;
-  uint64_t prior_bytes;
-  {
-    std::lock_guard<std::mutex> lock(reservation_lock_);
-    command_addr = AcquireWriteAddress(total_command_size + pad_size, curr_index);
-    if (command_addr == nullptr)
-      return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
-    prior_bytes = bytes_queued_;
-  }
-  uint32_t wrapped_index = WrapIntoRing(curr_index);
-
-  BuildGCRCommand(command_addr, true);
-  command_addr += gcr_command_size();
-  bytes_written_[wrapped_index] = prior_bytes;
-  wrapped_index += gcr_command_size();
-
-  if (prologue_signal) {
-    BuildAtomicDecrementCommand(command_addr, prologue_signal->ValueLocation());
-    command_addr += atomic_command_size_;
-    bytes_written_[wrapped_index] = prior_bytes;
-    wrapped_index += atomic_command_size_;
-  }
-
-  if (pad_size) {
-    memset(command_addr, 0, pad_size);
-    uint32_t* dword_command_addr = reinterpret_cast<uint32_t*>(command_addr);
-    dword_command_addr[0] = (pad_size / 4 - 1) << 16;
-  }
-
-  ReleaseWriteAddress(curr_index, total_command_size + pad_size);
-  return HSA_STATUS_SUCCESS;
-}
-
-template <bool useGCR, bool scopeFields>
-hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitNotifyEpilogue(
-    core::Signal& out_signal) {
-
-  const bool has_mailbox = (out_signal.signal_.event_mailbox_ptr != 0);
-  if (!useGCR && !has_mailbox)
-    return HSA_STATUS_SUCCESS;
-
-  uint32_t total_command_size = poll_64b_command_size_;
-  if (useGCR) total_command_size += gcr_command_size();
-  if (has_mailbox) total_command_size += fence_command_size_ + trap_command_size_;
-
-  const uint32_t pad_size = total_command_size < min_submission_size_
-      ? min_submission_size_ - total_command_size
-      : is_dxg_ ? AlignUp(total_command_size, 64) - total_command_size : 0;
-
-  uint64_t curr_index;
-  char* command_addr;
-  uint64_t prior_bytes;
-  {
-    std::lock_guard<std::mutex> lock(reservation_lock_);
-    command_addr = AcquireWriteAddress(total_command_size + pad_size, curr_index);
-    if (command_addr == nullptr)
-      return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
-    prior_bytes = bytes_queued_;
-  }
-  uint32_t wrapped_index = WrapIntoRing(curr_index);
-
-  // Wait for all bodies to complete.
-  BuildPoll64bCommand(command_addr, out_signal.ValueLocation(), 0);
-  command_addr += poll_64b_command_size_;
-  bytes_written_[wrapped_index] = prior_bytes;
-  wrapped_index += poll_64b_command_size_;
-
-  // GCR writeback after all copies are done.
-  if (useGCR) {
-    BuildGCRCommand(command_addr, false);
-    command_addr += gcr_command_size();
-    bytes_written_[wrapped_index] = prior_bytes;
-    wrapped_index += gcr_command_size();
-  }
-
-  // Notify KFD via mailbox doorbell + trap interrupt.
-  if (has_mailbox) {
-    BuildFenceCommand(command_addr,
-                      reinterpret_cast<uint32_t*>(out_signal.signal_.event_mailbox_ptr),
-                      static_cast<uint32_t>(out_signal.signal_.event_id));
-    command_addr += fence_command_size_;
-    bytes_written_[wrapped_index] = prior_bytes;
-    wrapped_index += fence_command_size_;
-
-    BuildTrapCommand(command_addr, out_signal.signal_.event_id);
-    command_addr += trap_command_size_;
-    bytes_written_[wrapped_index] = prior_bytes;
-    wrapped_index += trap_command_size_;
-  }
-
-  if (pad_size) {
-    memset(command_addr, 0, pad_size);
-    uint32_t* dword_command_addr = reinterpret_cast<uint32_t*>(command_addr);
-    dword_command_addr[0] = (pad_size / 4 - 1) << 16;
-  }
-
-  ReleaseWriteAddress(curr_index, total_command_size + pad_size);
-  return HSA_STATUS_SUCCESS;
-}
-
-template <bool useGCR, bool scopeFields>
-hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitLinearCopyBody(
-    void* dst, const void* src, size_t size,
-    core::Signal& prologue_signal,
-    core::Signal& body_signal) {
-
-  const size_t max_copy_size = max_single_linear_copy_size_ ? max_single_linear_copy_size_ :
-                               kMaxSingleCopySize;
-  const uint32_t num_copy_command =
-      static_cast<uint32_t>((size + max_copy_size - 1) / max_copy_size);
-
-  std::vector<SDMA_PKT_COPY_LINEAR> buff(num_copy_command);
-  BuildCopyCommand(reinterpret_cast<char*>(&buff[0]), num_copy_command, dst, src, size);
-
-  return SubmitBody(&buff[0], buff.size() * sizeof(SDMA_PKT_COPY_LINEAR), size,
-                    prologue_signal, body_signal);
-}
-
-template <bool useGCR, bool scopeFields>
-hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitLinearSwapBody(
-    void* addr_a, void* addr_b, size_t size,
-    core::Signal& prologue_signal,
-    core::Signal& body_signal) {
-
-  if (!swap_supported_)
-    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
-
-  // Addresses must be aligned for SWAP operation. Make this check here to
-  // avoid SDMA blit creation at top level.
-  constexpr size_t kAlign = SDMA_PKT_COPY_LINEAR_SWAP::kAlignment_;
-  if ((reinterpret_cast<uintptr_t>(addr_a) & (kAlign - 1)) != 0 ||
-      (reinterpret_cast<uintptr_t>(addr_b) & (kAlign - 1)) != 0)
-    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
-
-  const size_t max_copy_size = SDMA_PKT_COPY_LINEAR_SWAP::kMaxSize_;
-  const uint32_t num_copy_command =
-      static_cast<uint32_t>((size + max_copy_size - 1) / max_copy_size);
-
-  std::vector<SDMA_PKT_COPY_LINEAR_SWAP> buff(num_copy_command);
-  BuildSwapCopyCommand(reinterpret_cast<char*>(&buff[0]), num_copy_command, addr_a, addr_b, size);
-
-  return SubmitBody(&buff[0], buff.size() * sizeof(SDMA_PKT_COPY_LINEAR_SWAP), size,
-                    prologue_signal, body_signal);
-}
-
-template <bool useGCR, bool scopeFields>
 hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitLinearCopyBodyWaitSignal(
     void* dst, const void* src, size_t size,
     const std::vector<core::Signal*>& dep_signals,
@@ -1225,25 +675,16 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitLinearCopyBodyWaitSignal(
   const uint32_t num_copy_command =
       static_cast<uint32_t>((size + max_copy_size - 1) / max_copy_size);
 
-  // Option (b): every chunk carries wait (if there is a dep) + copy + signal.
-  // Per packet: 1 header + up to 7 wait + 6 copy + 5 signal.  The WAIT block is
-  // reserved only when there is a dep to fold in, matching the builder's
-  // compaction; the SIGNAL block is always present (out_signal is non-null).
   const uint32_t wait_dws = dep_signals.empty() ? 0 : 7;
   const uint32_t per_pkt_dws = 1 + wait_dws + 6 + 5;
   const uint32_t total_copy_dws = num_copy_command * per_pkt_dws;
 
-  // Extra 64b poll commands for dep_signals[1..N-1].
   const uint32_t extra_polls = (dep_signals.size() > 1)
       ? static_cast<uint32_t>(dep_signals.size() - 1) : 0;
   const uint32_t extra_poll_bytes = extra_polls * poll_64b_command_size_;
 
   const uint32_t copy_bytes = total_copy_dws * sizeof(uint32_t);
 
-  // Standalone single-engine path folds the notify prologue (GCR invalidate)
-  // and epilogue (poll out_signal, GCR writeback, mailbox + trap) into the same
-  // ring reservation as the copy.  The ring is in-order, so no cross-engine
-  // signalling is required.  Mirrors SubmitNotifyPrologue/SubmitNotifyEpilogue.
   const bool has_mailbox = (out_signal.signal_.event_mailbox_ptr != 0);
   const bool emit_prologue = fused_notify && useGCR;
   const bool emit_epilogue = fused_notify && (useGCR || has_mailbox);
@@ -1276,14 +717,9 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitLinearCopyBodyWaitSignal(
   }
   uint32_t wrapped_index = WrapIntoRing(curr_index);
 
-  // Each of the N chunks decrements out_signal, so pre-load it by
-  // N-1 (it starts at 1 here / is shared and pre-armed in the fan-out path).
-  // Must happen before the doorbell (ReleaseWriteAddress) so a waiter never sees
-  // a transient 0 between chunk signals.
   if (num_copy_command > 1)
     out_signal.AddRelaxed(num_copy_command - 1);
 
-  // Prologue: GCR invalidate before the copy.
   if (emit_prologue) {
     BuildGCRCommand(command_addr, true);
     command_addr += gcr_command_size();
@@ -1303,15 +739,10 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitLinearCopyBodyWaitSignal(
                              dst, src, size,
                              wait_sig, &out_signal);
   bytes_written_.fill(wrapped_index, wrapped_index + copy_bytes, prior_bytes);
-  // Last packet's signal marks the post-copy bytes.
   bytes_written_[wrapped_index + copy_bytes - sizeof(uint32_t)] = post_bytes;
   command_addr += copy_bytes;
   wrapped_index += copy_bytes;
 
-  // Epilogue: GCR writeback (if any), then notify KFD.  No self-poll on
-  // out_signal: the ring is in-order and the WaitSignal packet's inline SIGNAL
-  // already executes after its copy, so the copy is drained here.  (The poll was
-  // redundant for linear and outright deadlocks the multicast engine.)
   if (emit_epilogue) {
     if (useGCR) {
       BuildGCRCommand(command_addr, false);
@@ -1346,76 +777,130 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitLinearCopyBodyWaitSignal(
 }
 
 template <bool useGCR, bool scopeFields>
-hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitLinearCopyBodyIndirectWaitSignal(
-    void* dst, const void* src, size_t size,
-    bool indirect_src, bool indirect_dst,
+hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitPrologue(
     const std::vector<core::Signal*>& dep_signals,
-    core::Signal& out_signal) {
+    core::Signal& out_signal,
+    core::Signal& prologue_signal,
+    bool fused_bodies) {
 
-  if (!indirect_copy_supported_)
-    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
-  if (!indirect_src && !indirect_dst)
-    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  const bool profiling_enabled = agent_->profiling_enabled();
+  const bool emit_deps = !fused_bodies || profiling_enabled;
 
-  const size_t max_copy_size = max_single_linear_copy_size_ ? max_single_linear_copy_size_
-                                                            : kMaxSingleCopySize;
+  uint32_t num_poll_command = 0;
+  uint64_t dep_signals_value[HSA_MAX_DEP_SIGNALS];
 
-  // This function emits one indirect SDMA packet against the caller-supplied
-  // pointer slot(s), so it cannot chunk a single large copy: the indirect
-  // packet format (SDMA_PKT_COPY_LINEAR_WAITSIGNAL_INDIRECT_GFX1250) has no
-  // field for an offset into the resolved buffer — every packet against the
-  // same slot would copy starting from *slot.  Callers that need to chunk
-  // should supply multiple pre-offset slots.
-  if (size > max_copy_size)
-    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  if (emit_deps) {
+    for (size_t i = 0; i < dep_signals.size(); ++i) {
+      dep_signals_value[i] = dep_signals[i]->LoadRelaxed();
+      if (dep_signals_value[i]) {
+        if (is_gfx125plus_) {
+          num_poll_command++;
+        } else {
+          num_poll_command++;
+          if (dep_signals_value[i] >> 32)
+            num_poll_command++;
+        }
+      }
+    }
+  }
 
-  // Single packet: header (DW0) + wait block (DW1..DW7) + copy (DW8..DW13) +
-  // signal block (DW14..DW18) = 19 DWs total.
-  const uint32_t total_copy_dws = 1 + 7 + 6 + 5;
+  const uint32_t per_poll_size = (is_gfx125plus_) ? poll_64b_command_size_ : poll_command_size_;
+  const uint32_t total_poll_command_size = num_poll_command * per_poll_size;
 
-  // Extra 64b poll commands are emitted for dep_signals[1..N-1]; dep_signals[0]
-  // is folded into the packet's hardware WAIT field.
-  const uint32_t extra_polls = (dep_signals.size() > 1)
-      ? static_cast<uint32_t>(dep_signals.size() - 1) : 0;
-  const uint32_t extra_poll_bytes = extra_polls * poll_64b_command_size_;
+  uint64_t* start_ts_addr = nullptr;
+  uint64_t* end_ts_addr = nullptr;
+  uint32_t total_timestamp_command_size = 0;
 
-  const uint32_t copy_bytes = total_copy_dws * sizeof(uint32_t);
-  const uint32_t total_command_size = extra_poll_bytes + copy_bytes;
+  if (profiling_enabled) {
+    out_signal.GetSdmaTsAddresses(start_ts_addr, end_ts_addr);
+    total_timestamp_command_size = timestamp_command_size_;
+  }
 
+  uint32_t flush_cmd_size = 0;
+  if (emit_deps && enable_sdma_hdp_flush_ && hdp_flush_support_)
+    flush_cmd_size = flush_command_size_;
+  if (useGCR) flush_cmd_size += gcr_command_size();
+
+  const size_t prologue_signal_cmd_size =
+      is_gfx125plus_ ? fence_64b_command_size_ : fence_command_size_;
+
+  const uint32_t total_command_size = total_poll_command_size +
+      total_timestamp_command_size + flush_cmd_size + prologue_signal_cmd_size;
   const uint32_t pad_size = total_command_size < min_submission_size_
       ? min_submission_size_ - total_command_size
       : is_dxg_ ? AlignUp(total_command_size, 64) - total_command_size : 0;
 
   uint64_t curr_index;
   char* command_addr;
-  uint64_t prior_bytes, post_bytes;
+  uint64_t prior_bytes;
   {
     std::lock_guard<std::mutex> lock(reservation_lock_);
     command_addr = AcquireWriteAddress(total_command_size + pad_size, curr_index);
     if (command_addr == nullptr)
       return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
     prior_bytes = bytes_queued_;
-    bytes_queued_ += size;
-    post_bytes = bytes_queued_;
   }
   uint32_t wrapped_index = WrapIntoRing(curr_index);
 
-  for (uint32_t i = 1; i < dep_signals.size(); ++i) {
-    BuildPoll64bCommand(command_addr, dep_signals[i]->ValueLocation(), 0);
-    command_addr += poll_64b_command_size_;
-    bytes_written_[wrapped_index] = prior_bytes;
-    wrapped_index += poll_64b_command_size_;
+  if (emit_deps) {
+    for (size_t i = 0; i < dep_signals.size(); ++i) {
+      if (dep_signals_value[i]) {
+        if (is_gfx125plus_) {
+          BuildPoll64bCommand(command_addr, dep_signals[i]->ValueLocation(), 0);
+          command_addr += poll_64b_command_size_;
+          bytes_written_[wrapped_index] = prior_bytes;
+          wrapped_index += poll_64b_command_size_;
+        } else {
+          uint32_t* signal_addr =
+              reinterpret_cast<uint32_t*>(dep_signals[i]->ValueLocation());
+          if (dep_signals_value[i] >> 32) {
+            BuildPollCommand(command_addr, &signal_addr[1], 0);
+            command_addr += poll_command_size_;
+            bytes_written_[wrapped_index] = prior_bytes;
+            wrapped_index += poll_command_size_;
+          }
+          BuildPollCommand(command_addr, &signal_addr[0], 0);
+          command_addr += poll_command_size_;
+          bytes_written_[wrapped_index] = prior_bytes;
+          wrapped_index += poll_command_size_;
+        }
+      }
+    }
   }
 
-  const core::Signal* wait_sig = dep_signals.empty() ? nullptr : dep_signals[0];
-  BuildWaitSignalIndirectCopyCommand(command_addr,
-                                     dst, src, size,
-                                     indirect_src, indirect_dst,
-                                     wait_sig, &out_signal);
-  bytes_written_.fill(wrapped_index, wrapped_index + copy_bytes, prior_bytes);
-  bytes_written_[wrapped_index + copy_bytes - sizeof(uint32_t)] = post_bytes;
-  command_addr += copy_bytes;
-  wrapped_index += copy_bytes;
+  if (profiling_enabled) {
+    BuildGetGlobalTimestampCommand(command_addr, reinterpret_cast<void*>(start_ts_addr));
+    command_addr += timestamp_command_size_;
+    bytes_written_[wrapped_index] = prior_bytes;
+    wrapped_index += timestamp_command_size_;
+  }
+
+  if (emit_deps && enable_sdma_hdp_flush_ && hdp_flush_support_) {
+    BuildHdpFlushCommand(command_addr);
+    command_addr += flush_command_size_;
+    bytes_written_[wrapped_index] = prior_bytes;
+    wrapped_index += flush_command_size_;
+  }
+
+  if (useGCR) {
+    BuildGCRCommand(command_addr, true);
+    command_addr += gcr_command_size();
+    bytes_written_[wrapped_index] = prior_bytes;
+    wrapped_index += gcr_command_size();
+  }
+
+  if (is_gfx125plus_) {
+    BuildFence64bCommand(command_addr, prologue_signal.ValueLocation(), 0);
+    command_addr += fence_64b_command_size_;
+    bytes_written_[wrapped_index] = prior_bytes;
+    wrapped_index += fence_64b_command_size_;
+  } else {
+    uint32_t* sig_loc = reinterpret_cast<uint32_t*>(prologue_signal.ValueLocation());
+    BuildFenceCommand(command_addr, sig_loc, 0);
+    command_addr += fence_command_size_;
+    bytes_written_[wrapped_index] = prior_bytes;
+    wrapped_index += fence_command_size_;
+  }
 
   if (pad_size) {
     memset(command_addr, 0, pad_size);
@@ -1428,40 +913,225 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitLinearCopyBodyIndirectWaitSign
 }
 
 template <bool useGCR, bool scopeFields>
-hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitLinearSwapBodyWaitSignal(
-    void* addr_a, void* addr_b, size_t size_a, size_t size_b,
+hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitEpilogue(
+    core::Signal& out_signal,
+    const std::vector<core::Signal*>& body_signals) {
+
+  const bool profiling_enabled = agent_->profiling_enabled();
+
+  uint64_t* start_ts_addr = nullptr;
+  uint64_t* end_ts_addr = nullptr;
+  uint32_t total_timestamp_command_size = 0;
+
+  if (profiling_enabled) {
+    out_signal.GetSdmaTsAddresses(start_ts_addr, end_ts_addr);
+    total_timestamp_command_size = timestamp_command_size_;
+  }
+
+  // Drain poll size: with platform atomics poll out_signal for 1 (one poll).
+  // Without platform atomics poll each body_signal for 0 (N polls).
+  const uint32_t single_poll_size = is_gfx125plus_
+      ? poll_64b_command_size_
+      : poll_command_size_;
+  const uint32_t body_poll_size = body_signals.empty()
+      ? single_poll_size
+      : static_cast<uint32_t>(body_signals.size()) * single_poll_size;
+
+  uint32_t gcr_cmd_size = 0;
+  if (useGCR) gcr_cmd_size = gcr_command_size();
+
+  // Final signal write: epilogue drives out_signal to 0.
+  const size_t sync_command_size = is_gfx125plus_
+      ? fence_64b_command_size_
+      : (platform_atomic_support_ ? atomic_command_size_ : fence_command_size_);
+
+  const size_t interrupt_command_size =
+      (out_signal.signal_.event_mailbox_ptr != 0)
+          ? (fence_command_size_ + trap_command_size_)
+          : 0;
+
+  const uint32_t total_command_size = body_poll_size + gcr_cmd_size +
+      total_timestamp_command_size + sync_command_size + interrupt_command_size;
+  const uint32_t pad_size = total_command_size < min_submission_size_
+      ? min_submission_size_ - total_command_size
+      : is_dxg_ ? AlignUp(total_command_size, 64) - total_command_size : 0;
+
+  uint64_t curr_index;
+  char* command_addr;
+  uint64_t prior_bytes;
+  {
+    std::lock_guard<std::mutex> lock(reservation_lock_);
+    command_addr = AcquireWriteAddress(total_command_size + pad_size, curr_index);
+    if (command_addr == nullptr)
+      return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+    prior_bytes = bytes_queued_;
+  }
+  uint32_t wrapped_index = WrapIntoRing(curr_index);
+
+  // Drain: wait for bodies to finish.
+  if (body_signals.empty()) {
+    // Platform atomics: bodies decremented out_signal; poll for 1.
+    if (is_gfx125plus_) {
+      BuildPoll64bCommand(command_addr, out_signal.ValueLocation(), 1);
+      command_addr += poll_64b_command_size_;
+    } else {
+      uint32_t* sig_lo = reinterpret_cast<uint32_t*>(out_signal.ValueLocation());
+      BuildPollCommand(command_addr, &sig_lo[0], 1);
+      command_addr += poll_command_size_;
+    }
+  } else {
+    // No platform atomics (never gfx125+): bodies fenced body_signals to 0.
+    for (core::Signal* bs : body_signals) {
+      uint32_t* sig_lo = reinterpret_cast<uint32_t*>(bs->ValueLocation());
+      BuildPollCommand(command_addr, &sig_lo[0], 0);
+      command_addr += poll_command_size_;
+    }
+  }
+  bytes_written_[wrapped_index] = prior_bytes;
+  wrapped_index += body_poll_size;
+
+  if (useGCR) {
+    BuildGCRCommand(command_addr, false);
+    command_addr += gcr_command_size();
+    bytes_written_[wrapped_index] = prior_bytes;
+    wrapped_index += gcr_command_size();
+  }
+
+  if (profiling_enabled) {
+    assert(IsMultipleOf(end_ts_addr, 32));
+    BuildGetGlobalTimestampCommand(command_addr,
+                                   reinterpret_cast<void*>(end_ts_addr));
+    command_addr += timestamp_command_size_;
+    bytes_written_[wrapped_index] = prior_bytes;
+    wrapped_index += timestamp_command_size_;
+  }
+
+  // Write out_signal to 0 (final completion).
+  if (is_gfx125plus_) {
+    BuildFence64bCommand(command_addr, out_signal.ValueLocation(), 0);
+    command_addr += fence_64b_command_size_;
+  } else if (platform_atomic_support_) {
+    BuildAtomicDecrementCommand(command_addr, out_signal.ValueLocation());
+    command_addr += atomic_command_size_;
+  } else {
+    uint32_t* sig_lo = reinterpret_cast<uint32_t*>(out_signal.ValueLocation());
+    BuildFenceCommand(command_addr, sig_lo, 0);
+    command_addr += fence_command_size_;
+  }
+  bytes_written_[wrapped_index] = prior_bytes;
+  wrapped_index += sync_command_size;
+
+  if (out_signal.signal_.event_mailbox_ptr != 0) {
+    BuildFenceCommand(command_addr,
+                      reinterpret_cast<uint32_t*>(out_signal.signal_.event_mailbox_ptr),
+                      static_cast<uint32_t>(out_signal.signal_.event_id));
+    command_addr += fence_command_size_;
+    bytes_written_[wrapped_index] = prior_bytes;
+    wrapped_index += fence_command_size_;
+
+    BuildTrapCommand(command_addr, out_signal.signal_.event_id);
+    command_addr += trap_command_size_;
+    bytes_written_[wrapped_index] = prior_bytes;
+    wrapped_index += trap_command_size_;
+  }
+
+  if (pad_size) {
+    memset(command_addr, 0, pad_size);
+    uint32_t* dword_command_addr = reinterpret_cast<uint32_t*>(command_addr);
+    dword_command_addr[0] = (pad_size / 4 - 1) << 16;
+  }
+
+  ReleaseWriteAddress(curr_index, total_command_size + pad_size);
+  return HSA_STATUS_SUCCESS;
+}
+
+template <bool useGCR, bool scopeFields>
+hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitFusedCoordinator(
     const std::vector<core::Signal*>& dep_signals,
-    core::Signal& out_signal) {
+    core::Signal& out_signal,
+    core::Signal* prologue_signal,
+    bool fused_bodies,
+    hsa_amd_memory_copy_op_type_t op,
+    const std::vector<void*>& dsts,
+    const std::vector<const void*>& srcs,
+    const std::vector<size_t>& sizes_a,
+    const std::vector<size_t>& sizes_b,
+    bool indirect_src, bool indirect_dst,
+    const std::vector<core::Signal*>& body_deps) {
 
-  if (!swap_supported_ && !is_gfx1250_)
-    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  const size_t num_entries = dsts.size();
+  const bool profiling_enabled = agent_->profiling_enabled();
+  const bool need_prologue = prologue_signal != nullptr;
+  const bool is_swap = (op == HSA_AMD_MEMORY_COPY_OP_LINEAR_SWAP);
+  const bool is_indirect = (indirect_src || indirect_dst);
 
-  constexpr size_t kAlign = SDMA_PKT_COPY_LINEAR_SWAP_WAITSIGNAL_GFX1250::kAlignment_;
-  if ((reinterpret_cast<uintptr_t>(addr_a) & (kAlign - 1)) != 0 ||
-      (reinterpret_cast<uintptr_t>(addr_b) & (kAlign - 1)) != 0)
-    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  // --- Prologue size computation ---
+  uint32_t prologue_size = 0;
+  uint32_t num_poll_command = 0;
+  uint64_t dep_signals_value[HSA_MAX_DEP_SIGNALS];
 
-  // For asymmetric swap, chunk count is driven by the larger side.
-  const size_t size_max = std::max(size_a, size_b);
-  const size_t max_copy_size = SDMA_PKT_COPY_LINEAR_SWAP_WAITSIGNAL_GFX1250::kMaxSize_;
-  const uint32_t num_copy_command =
-      static_cast<uint32_t>((size_max + max_copy_size - 1) / max_copy_size);
+  if (need_prologue) {
+    const bool emit_deps = !fused_bodies || profiling_enabled;
+    if (emit_deps) {
+      for (size_t i = 0; i < dep_signals.size(); ++i) {
+        dep_signals_value[i] = dep_signals[i]->LoadRelaxed();
+        if (dep_signals_value[i]) num_poll_command++;
+      }
+    }
 
-  // Option (b): every chunk carries wait (if there is a dep) + copy + signal.
-  // The WAIT block is reserved only when there is a dep to fold in, matching the
-  // builder's compaction; the SIGNAL block is always present.
-  const uint32_t wait_dws = dep_signals.empty() ? 0 : 7;
-  const uint32_t copy_body_dws = 6;
-  const uint32_t per_pkt_dws = 1 + wait_dws + copy_body_dws + 5;
-  const uint32_t total_copy_dws = num_copy_command * per_pkt_dws;
+    prologue_size += num_poll_command * poll_64b_command_size_;
 
-  const uint32_t extra_polls = (dep_signals.size() > 1)
-      ? static_cast<uint32_t>(dep_signals.size() - 1) : 0;
-  const uint32_t extra_poll_bytes = extra_polls * poll_64b_command_size_;
+    if (profiling_enabled) prologue_size += timestamp_command_size_;
 
-  const uint32_t copy_bytes = total_copy_dws * sizeof(uint32_t);
-  const uint32_t total_command_size = extra_poll_bytes + copy_bytes;
+    if (emit_deps && enable_sdma_hdp_flush_ && hdp_flush_support_)
+      prologue_size += flush_command_size_;
+    if (useGCR) prologue_size += gcr_command_size();
 
+    prologue_size += fence_64b_command_size_;
+  }
+
+  // --- Body size computation (gfx125+ fused WaitSignal path) ---
+  const size_t max_copy_size = is_swap
+      ? SDMA_PKT_COPY_LINEAR_SWAP_WAITSIGNAL_GFX1250::kMaxSize_
+      : (max_single_linear_copy_size_ ? max_single_linear_copy_size_ : kMaxSingleCopySize);
+
+  const uint32_t wait_dws = body_deps.empty() ? 0 : 7;
+  const uint32_t per_pkt_dws = 1 + wait_dws + 6 + 5;
+
+  std::vector<uint32_t> chunks(num_entries);
+  uint32_t total_chunks = 0;
+  uint64_t total_bytes = 0;
+  for (size_t i = 0; i < num_entries; ++i) {
+    const size_t entry_size = is_swap
+        ? std::max(sizes_a[i], sizes_b[i]) : sizes_a[i];
+    chunks[i] = is_indirect ? 1
+        : static_cast<uint32_t>((entry_size + max_copy_size - 1) / max_copy_size);
+    total_chunks += chunks[i];
+    total_bytes += entry_size;
+  }
+  const uint32_t body_copy_bytes = total_chunks * per_pkt_dws * sizeof(uint32_t);
+
+  const uint32_t body_extra_polls = (body_deps.size() > 1)
+      ? static_cast<uint32_t>(body_deps.size() - 1) : 0;
+  const uint32_t body_extra_poll_bytes = body_extra_polls * poll_64b_command_size_;
+
+  const uint32_t body_size = body_extra_poll_bytes + body_copy_bytes;
+
+  // --- Epilogue size computation ---
+  uint32_t epilogue_size = 0;
+
+  epilogue_size += poll_64b_command_size_;
+
+  if (useGCR) epilogue_size += gcr_command_size();
+  if (profiling_enabled) epilogue_size += timestamp_command_size_;
+
+  epilogue_size += fence_64b_command_size_;
+
+  if (out_signal.signal_.event_mailbox_ptr != 0)
+    epilogue_size += fence_command_size_ + trap_command_size_;
+
+  // --- Total reservation ---
+  const uint32_t total_command_size = prologue_size + body_size + epilogue_size;
   const uint32_t pad_size = total_command_size < min_submission_size_
       ? min_submission_size_ - total_command_size
       : is_dxg_ ? AlignUp(total_command_size, 64) - total_command_size : 0;
@@ -1475,31 +1145,136 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitLinearSwapBodyWaitSignal(
     if (command_addr == nullptr)
       return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
     prior_bytes = bytes_queued_;
-    bytes_queued_ += size_max;
+    bytes_queued_ += total_bytes;
     post_bytes = bytes_queued_;
   }
   uint32_t wrapped_index = WrapIntoRing(curr_index);
 
-  // Option (b): each of the N chunks decrements out_signal, so pre-load it by
-  // N-1 before the doorbell (the fan-out coordinator pre-arms the base count).
-  if (num_copy_command > 1)
-    out_signal.AddRelaxed(num_copy_command - 1);
+  // Arm out_signal for multi-chunk body entries (same as SubmitBodies).
+  if (total_chunks > num_entries)
+    out_signal.AddRelaxed(total_chunks - num_entries);
 
-  for (uint32_t i = 1; i < dep_signals.size(); ++i) {
-    BuildPoll64bCommand(command_addr, dep_signals[i]->ValueLocation(), 0);
+  // === PROLOGUE SECTION ===
+  if (need_prologue) {
+    const bool emit_deps = !fused_bodies || profiling_enabled;
+
+    if (emit_deps) {
+      for (size_t i = 0; i < dep_signals.size(); ++i) {
+        if (dep_signals_value[i]) {
+          BuildPoll64bCommand(command_addr, dep_signals[i]->ValueLocation(), 0);
+          command_addr += poll_64b_command_size_;
+          bytes_written_[wrapped_index] = prior_bytes;
+          wrapped_index += poll_64b_command_size_;
+        }
+      }
+    }
+
+    if (profiling_enabled) {
+      uint64_t* start_ts_addr = nullptr;
+      uint64_t* end_ts_addr = nullptr;
+      out_signal.GetSdmaTsAddresses(start_ts_addr, end_ts_addr);
+      BuildGetGlobalTimestampCommand(command_addr, reinterpret_cast<void*>(start_ts_addr));
+      command_addr += timestamp_command_size_;
+      bytes_written_[wrapped_index] = prior_bytes;
+      wrapped_index += timestamp_command_size_;
+    }
+
+    if (emit_deps && enable_sdma_hdp_flush_ && hdp_flush_support_) {
+      BuildHdpFlushCommand(command_addr);
+      command_addr += flush_command_size_;
+      bytes_written_[wrapped_index] = prior_bytes;
+      wrapped_index += flush_command_size_;
+    }
+
+    if (useGCR) {
+      BuildGCRCommand(command_addr, true);
+      command_addr += gcr_command_size();
+      bytes_written_[wrapped_index] = prior_bytes;
+      wrapped_index += gcr_command_size();
+    }
+
+    BuildFence64bCommand(command_addr, prologue_signal->ValueLocation(), 0);
+    command_addr += fence_64b_command_size_;
+    bytes_written_[wrapped_index] = prior_bytes;
+    wrapped_index += fence_64b_command_size_;
+  }
+
+  // === BODY SECTION (fused WaitSignal path) ===
+  for (uint32_t i = 1; i < body_deps.size(); ++i) {
+    BuildPoll64bCommand(command_addr, body_deps[i]->ValueLocation(), 0);
     command_addr += poll_64b_command_size_;
     bytes_written_[wrapped_index] = prior_bytes;
     wrapped_index += poll_64b_command_size_;
   }
 
-  const core::Signal* wait_sig = dep_signals.empty() ? nullptr : dep_signals[0];
-  BuildWaitSignalSwapCommand(command_addr, num_copy_command,
-                             addr_a, addr_b, size_a, size_b,
-                             wait_sig, &out_signal);
-  bytes_written_.fill(wrapped_index, wrapped_index + copy_bytes, prior_bytes);
-  bytes_written_[wrapped_index + copy_bytes - sizeof(uint32_t)] = post_bytes;
-  command_addr += copy_bytes;
-  wrapped_index += copy_bytes;
+  const core::Signal* wait_sig = body_deps.empty() ? nullptr : body_deps[0];
+  const uint32_t copy_start = wrapped_index;
+
+  for (size_t i = 0; i < num_entries; ++i) {
+    if (is_indirect) {
+      BuildWaitSignalIndirectCopyCommand(command_addr,
+          dsts[i], srcs[i], sizes_a[i],
+          indirect_src, indirect_dst,
+          wait_sig, &out_signal);
+    } else if (is_swap) {
+      BuildWaitSignalSwapCommand(command_addr, chunks[i],
+          dsts[i], const_cast<void*>(srcs[i]),
+          sizes_a[i], sizes_b[i],
+          wait_sig, &out_signal);
+    } else {
+      BuildWaitSignalCopyCommand(command_addr, chunks[i],
+          dsts[i], srcs[i], sizes_a[i],
+          wait_sig, &out_signal);
+    }
+    const uint32_t entry_bytes = chunks[i] * per_pkt_dws * sizeof(uint32_t);
+    command_addr += entry_bytes;
+    wrapped_index += entry_bytes;
+  }
+  bytes_written_.fill(copy_start, copy_start + body_copy_bytes, prior_bytes);
+  bytes_written_[copy_start + body_copy_bytes - sizeof(uint32_t)] = post_bytes;
+
+  // === EPILOGUE SECTION ===
+  BuildPoll64bCommand(command_addr, out_signal.ValueLocation(), 1);
+  command_addr += poll_64b_command_size_;
+  bytes_written_[wrapped_index] = post_bytes;
+  wrapped_index += poll_64b_command_size_;
+
+  if (useGCR) {
+    BuildGCRCommand(command_addr, false);
+    command_addr += gcr_command_size();
+    bytes_written_[wrapped_index] = post_bytes;
+    wrapped_index += gcr_command_size();
+  }
+
+  if (profiling_enabled) {
+    uint64_t* start_ts_addr = nullptr;
+    uint64_t* end_ts_addr = nullptr;
+    out_signal.GetSdmaTsAddresses(start_ts_addr, end_ts_addr);
+    assert(IsMultipleOf(end_ts_addr, 32));
+    BuildGetGlobalTimestampCommand(command_addr, reinterpret_cast<void*>(end_ts_addr));
+    command_addr += timestamp_command_size_;
+    bytes_written_[wrapped_index] = post_bytes;
+    wrapped_index += timestamp_command_size_;
+  }
+
+  BuildFence64bCommand(command_addr, out_signal.ValueLocation(), 0);
+  command_addr += fence_64b_command_size_;
+  bytes_written_[wrapped_index] = post_bytes;
+  wrapped_index += fence_64b_command_size_;
+
+  if (out_signal.signal_.event_mailbox_ptr != 0) {
+    BuildFenceCommand(command_addr,
+                      reinterpret_cast<uint32_t*>(out_signal.signal_.event_mailbox_ptr),
+                      static_cast<uint32_t>(out_signal.signal_.event_id));
+    command_addr += fence_command_size_;
+    bytes_written_[wrapped_index] = post_bytes;
+    wrapped_index += fence_command_size_;
+
+    BuildTrapCommand(command_addr, out_signal.signal_.event_id);
+    command_addr += trap_command_size_;
+    bytes_written_[wrapped_index] = post_bytes;
+    wrapped_index += trap_command_size_;
+  }
 
   if (pad_size) {
     memset(command_addr, 0, pad_size);
@@ -1508,6 +1283,228 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitLinearSwapBodyWaitSignal(
   }
 
   ReleaseWriteAddress(curr_index, total_command_size + pad_size);
+  return HSA_STATUS_SUCCESS;
+}
+
+template <bool useGCR, bool scopeFields>
+hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitBodies(
+    hsa_amd_memory_copy_op_type_t op,
+    const std::vector<void*>& dsts,
+    const std::vector<const void*>& srcs,
+    const std::vector<size_t>& sizes_a,
+    const std::vector<size_t>& sizes_b,
+    bool indirect_src, bool indirect_dst,
+    const std::vector<core::Signal*>& dep_signals,
+    core::Signal& out_signal,
+    core::Signal* body_signal) {
+
+  const size_t num_entries = dsts.size();
+  if (num_entries == 0 || srcs.size() != num_entries || sizes_a.size() != num_entries)
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+
+  const bool is_swap = (op == HSA_AMD_MEMORY_COPY_OP_LINEAR_SWAP);
+  const bool is_indirect = (indirect_src || indirect_dst);
+
+  if (is_indirect && !indirect_copy_supported_)
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+
+  if (is_swap && !swap_supported_ && !is_gfx125plus_)
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+
+  if (is_swap) {
+    constexpr size_t kAlign = SDMA_PKT_COPY_LINEAR_SWAP_WAITSIGNAL_GFX1250::kAlignment_;
+    for (size_t i = 0; i < num_entries; ++i) {
+      if ((reinterpret_cast<uintptr_t>(dsts[i]) & (kAlign - 1)) != 0 ||
+          (reinterpret_cast<uintptr_t>(srcs[i]) & (kAlign - 1)) != 0)
+        return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+    }
+  }
+
+  const size_t max_copy_size = is_swap
+      ? SDMA_PKT_COPY_LINEAR_SWAP_WAITSIGNAL_GFX1250::kMaxSize_
+      : (max_single_linear_copy_size_ ? max_single_linear_copy_size_ : kMaxSingleCopySize);
+
+  if (is_gfx125plus_) {
+    // --- Fused WaitSignal path: every chunk carries wait+copy+signal in one packet ---
+    const uint32_t wait_dws = dep_signals.empty() ? 0 : 7;
+    const uint32_t per_pkt_dws = 1 + wait_dws + 6 + 5;
+
+    std::vector<uint32_t> chunks(num_entries);
+    uint32_t total_chunks = 0;
+    uint64_t total_bytes = 0;
+    for (size_t i = 0; i < num_entries; ++i) {
+      const size_t entry_size = is_swap
+          ? std::max(sizes_a[i], sizes_b[i])
+          : sizes_a[i];
+      if (is_indirect && entry_size > max_copy_size)
+        return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+      chunks[i] = is_indirect ? 1
+          : static_cast<uint32_t>((entry_size + max_copy_size - 1) / max_copy_size);
+      total_chunks += chunks[i];
+      total_bytes += entry_size;
+    }
+    const uint32_t total_copy_dws = total_chunks * per_pkt_dws;
+    const uint32_t copy_bytes = total_copy_dws * sizeof(uint32_t);
+
+    const uint32_t extra_polls = (dep_signals.size() > 1)
+        ? static_cast<uint32_t>(dep_signals.size() - 1) : 0;
+    const uint32_t extra_poll_bytes = extra_polls * poll_64b_command_size_;
+
+    const uint32_t total_command_size = extra_poll_bytes + copy_bytes;
+    const uint32_t pad_size = total_command_size < min_submission_size_
+        ? min_submission_size_ - total_command_size
+        : is_dxg_ ? AlignUp(total_command_size, 64) - total_command_size : 0;
+
+    uint64_t curr_index;
+    char* command_addr;
+    uint64_t prior_bytes, post_bytes;
+    {
+      std::lock_guard<std::mutex> lock(reservation_lock_);
+      command_addr = AcquireWriteAddress(total_command_size + pad_size, curr_index);
+      if (command_addr == nullptr)
+        return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+      prior_bytes = bytes_queued_;
+      bytes_queued_ += total_bytes;
+      post_bytes = bytes_queued_;
+    }
+    uint32_t wrapped_index = WrapIntoRing(curr_index);
+
+    if (total_chunks > num_entries)
+      out_signal.AddRelaxed(total_chunks - num_entries);
+
+    for (uint32_t i = 1; i < dep_signals.size(); ++i) {
+      BuildPoll64bCommand(command_addr, dep_signals[i]->ValueLocation(), 0);
+      command_addr += poll_64b_command_size_;
+      bytes_written_[wrapped_index] = prior_bytes;
+      wrapped_index += poll_64b_command_size_;
+    }
+
+    const core::Signal* wait_sig = dep_signals.empty() ? nullptr : dep_signals[0];
+    const uint32_t copy_start = wrapped_index;
+
+    for (size_t i = 0; i < num_entries; ++i) {
+      if (is_indirect) {
+        BuildWaitSignalIndirectCopyCommand(command_addr,
+            dsts[i], srcs[i], sizes_a[i],
+            indirect_src, indirect_dst,
+            wait_sig, &out_signal);
+      } else if (is_swap) {
+        BuildWaitSignalSwapCommand(command_addr, chunks[i],
+            dsts[i], const_cast<void*>(srcs[i]),
+            sizes_a[i], sizes_b[i],
+            wait_sig, &out_signal);
+      } else {
+        BuildWaitSignalCopyCommand(command_addr, chunks[i],
+            dsts[i], srcs[i], sizes_a[i],
+            wait_sig, &out_signal);
+      }
+      const uint32_t entry_bytes = chunks[i] * per_pkt_dws * sizeof(uint32_t);
+      command_addr += entry_bytes;
+      wrapped_index += entry_bytes;
+    }
+    bytes_written_.fill(copy_start, copy_start + copy_bytes, prior_bytes);
+    bytes_written_[copy_start + copy_bytes - sizeof(uint32_t)] = post_bytes;
+
+    if (pad_size) {
+      memset(command_addr, 0, pad_size);
+      uint32_t* dword_command_addr = reinterpret_cast<uint32_t*>(command_addr);
+      dword_command_addr[0] = (pad_size / 4 - 1) << 16;
+    }
+
+    ReleaseWriteAddress(curr_index, total_command_size + pad_size);
+  } else {
+    // --- Classic path: single reservation, poll + copies + signal completion ---
+    // Entries are serialized on one engine.  With platform atomics: single
+    // atomic dec of out_signal.  Without: fence body_signal to 0 (epilogue
+    // polls body_signals then fences out_signal).
+    const size_t classic_max = is_swap
+        ? SDMA_PKT_COPY_LINEAR_SWAP::kMaxSize_
+        : (max_single_linear_copy_size_ ? max_single_linear_copy_size_ : kMaxSingleCopySize);
+
+    core::Signal* prologue_sig = dep_signals.empty() ? nullptr : dep_signals[0];
+    const uint32_t poll_size = poll_command_size_;
+
+    const uint32_t per_pkt_dws = is_swap
+        ? static_cast<uint32_t>(sizeof(SDMA_PKT_COPY_LINEAR_SWAP) / sizeof(uint32_t))
+        : static_cast<uint32_t>(sizeof(SDMA_PKT_COPY_LINEAR) / sizeof(uint32_t));
+
+    std::vector<uint32_t> chunks(num_entries);
+    uint32_t total_copy_bytes = 0;
+    uint64_t total_bytes = 0;
+    for (size_t i = 0; i < num_entries; ++i) {
+      const size_t entry_size = sizes_a[i];
+      chunks[i] = static_cast<uint32_t>((entry_size + classic_max - 1) / classic_max);
+      total_copy_bytes += chunks[i] * per_pkt_dws * sizeof(uint32_t);
+      total_bytes += entry_size;
+    }
+
+    const uint32_t signal_cmd_size = platform_atomic_support_
+        ? atomic_command_size_ : fence_command_size_;
+    const uint32_t total_command_size = poll_size + total_copy_bytes + signal_cmd_size;
+    const uint32_t pad_size = total_command_size < min_submission_size_
+        ? min_submission_size_ - total_command_size
+        : is_dxg_ ? AlignUp(total_command_size, 64) - total_command_size : 0;
+
+    uint64_t curr_index;
+    char* command_addr;
+    uint64_t prior_bytes, post_bytes;
+    {
+      std::lock_guard<std::mutex> lock(reservation_lock_);
+      command_addr = AcquireWriteAddress(total_command_size + pad_size, curr_index);
+      if (command_addr == nullptr)
+        return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+      prior_bytes = bytes_queued_;
+      bytes_queued_ += total_bytes;
+      post_bytes = bytes_queued_;
+    }
+    uint32_t wrapped_index = WrapIntoRing(curr_index);
+
+    // Poll prologue signal.
+    uint32_t* poll_addr = reinterpret_cast<uint32_t*>(prologue_sig->ValueLocation());
+    BuildPollCommand(command_addr, &poll_addr[0], 0);
+    command_addr += poll_command_size_;
+    bytes_written_[wrapped_index] = prior_bytes;
+    wrapped_index += poll_command_size_;
+
+    // Copy packets (all entries, serialized).
+    const uint32_t copy_start = wrapped_index;
+    for (size_t i = 0; i < num_entries; ++i) {
+      const uint32_t entry_copy_bytes = chunks[i] * per_pkt_dws * sizeof(uint32_t);
+
+      if (is_swap) {
+        BuildSwapCopyCommand(command_addr, chunks[i],
+                             dsts[i], const_cast<void*>(srcs[i]), sizes_a[i]);
+      } else {
+        BuildCopyCommand(command_addr, chunks[i], dsts[i], srcs[i], sizes_a[i]);
+      }
+      command_addr += entry_copy_bytes;
+      wrapped_index += entry_copy_bytes;
+    }
+
+    // Signal body completion.
+    if (platform_atomic_support_) {
+      BuildAtomicDecrementCommand(command_addr, out_signal.ValueLocation());
+      command_addr += atomic_command_size_;
+    } else {
+      uint32_t* sig_lo = reinterpret_cast<uint32_t*>(body_signal->ValueLocation());
+      BuildFenceCommand(command_addr, sig_lo, 0);
+      command_addr += fence_command_size_;
+    }
+    wrapped_index += signal_cmd_size;
+
+    bytes_written_.fill(copy_start, copy_start + total_copy_bytes +
+        signal_cmd_size, prior_bytes);
+    bytes_written_[wrapped_index - sizeof(uint32_t)] = post_bytes;
+
+    if (pad_size) {
+      memset(command_addr, 0, pad_size);
+      uint32_t* dword_command_addr = reinterpret_cast<uint32_t*>(command_addr);
+      dword_command_addr[0] = (pad_size / 4 - 1) << 16;
+    }
+
+    ReleaseWriteAddress(curr_index, total_command_size + pad_size);
+  }
+
   return HSA_STATUS_SUCCESS;
 }
 
@@ -1678,7 +1675,7 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitLinearCopyMulticastCommand(
   // Multicast is always issued standalone on a single engine, so the notify
   // prologue (GCR invalidate) and epilogue (poll out_signal, GCR writeback,
   // mailbox + trap) are folded into this same reservation.  Mirrors the linear
-  // SubmitLinearCopyBodyWaitSignal fused_notify path.
+  // SubmitBodies fused path.
   const bool has_mailbox = (out_signal.signal_.event_mailbox_ptr != 0);
   const uint32_t prologue_bytes = useGCR ? gcr_command_size() : 0;
   uint32_t epilogue_bytes = 0;
@@ -1770,41 +1767,6 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitLinearCopyMulticastCommand(
 
   ReleaseWriteAddress(curr_index, total_command_size + pad_size);
   return HSA_STATUS_SUCCESS;
-}
-
-template <bool useGCR, bool scopeFields>
-hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitLinearCopyB2BCommand(
-    const std::vector<void*>& dsts, const std::vector<const void*>& srcs,
-    const std::vector<size_t>& sizes, std::vector<core::Signal*>& dep_signals,
-    core::Signal& out_signal) {
-
-  const size_t num_entries = srcs.size();
-  if (num_entries == 0 || dsts.size() != num_entries || sizes.size() != num_entries) {
-    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
-  }
-
-  const size_t max_copy_size = max_single_linear_copy_size_ ? max_single_linear_copy_size_
-                                                             : kMaxSingleCopySize;
-
-  std::vector<uint32_t> chunks(num_entries);
-  size_t total_cmd_size = 0;
-  uint64_t total_bytes_moved = 0;
-  for (size_t i = 0; i < num_entries; i++) {
-    chunks[i] = static_cast<uint32_t>((sizes[i] + max_copy_size - 1) / max_copy_size);
-    total_cmd_size += static_cast<size_t>(chunks[i]) * linear_copy_command_size_;
-    total_bytes_moved += sizes[i];
-  }
-
-  std::vector<char> cmd_buf(total_cmd_size);
-  char* cmd_ptr = cmd_buf.data();
-  for (size_t i = 0; i < num_entries; i++) {
-    BuildCopyCommand(cmd_ptr, chunks[i], dsts[i], srcs[i], sizes[i]);
-    cmd_ptr += static_cast<size_t>(chunks[i]) * linear_copy_command_size_;
-  }
-
-  std::vector<core::Signal*> no_gang;
-  return SubmitCommand(cmd_buf.data(), total_cmd_size, total_bytes_moved,
-                       dep_signals, out_signal, no_gang);
 }
 
 template <bool useGCR, bool scopeFields>
@@ -1998,6 +1960,10 @@ void BlitSdma<useGCR, scopeFields>::ReleaseWriteAddress(uint64_t curr_index, uin
     assert(false && "cmd_addr is outside the queue buffer range");
     return;
   }
+
+  LogPrint(HSA_AMD_LOG_FLAG_SDMA,
+           "SDMA ReleaseWrite: QueueId=%u, cmd_size=%u, wptr=0x%lx->0x%lx",
+           queue_resource_.QueueId, cmd_size, curr_index, curr_index + cmd_size);
 
   UpdateWriteAndDoorbellRegister(curr_index, curr_index + cmd_size);
 }
@@ -2324,10 +2290,10 @@ void BlitSdma<useGCR, scopeFields>::BuildSwapCopyCommand(char* cmd_addr, uint32_
   // gfx1250 uses a dedicated swap packet that carries per-operand cache scope
   // (the mechanism that replaces GCR cache invalidate/writeback); other archs
   // use the legacy swap packet. The two are the same size, so they share the
-  // swap_copy_command_size_ stride and the SubmitLinearSwapBody buffer.
+  // swap_copy_command_size_ stride and the classic body swap buffer.
   static_assert(sizeof(SDMA_PKT_COPY_LINEAR_SWAP_GFX1250) == sizeof(SDMA_PKT_COPY_LINEAR_SWAP),
                 "gfx1250 swap packet must match legacy swap packet size for shared stride");
-  const bool use_gfx1250 = scopeFields && is_gfx1250_;
+  const bool use_gfx1250 = scopeFields && is_gfx125plus_;
 
   const size_t kAlign = use_gfx1250 ? SDMA_PKT_COPY_LINEAR_SWAP_GFX1250::kAlignment_
                                     : SDMA_PKT_COPY_LINEAR_SWAP::kAlignment_;
@@ -2673,9 +2639,9 @@ void BlitSdma<useGCR, scopeFields>::BuildWaitSignalCopyCommand(
 
     // Option (b) chunk synchronization: every chunk waits on the same input
     // signal and decrements the same output signal.  This is correct even when
-    // the HW overlaps chunk copies (MI450+), since out_signal only reaches 0
-    // once all chunks have signalled (the caller pre-loads it by N-1).  A scheme
-    // that signals only on the last chunk could complete early under overlap.
+    // the HW overlaps chunk copies, since out_signal only reaches 0 once all
+    // chunks have signalled (the caller pre-loads it by N-1).  A scheme that
+    // signals only on the last chunk could complete early under overlap.
     const bool do_wait = (wait_signal != nullptr);
     const bool do_signal = (signal_signal != nullptr);
 
@@ -2927,7 +2893,7 @@ template <bool useGCR, bool scopeFields> void BlitSdma<useGCR, scopeFields>::Bui
   assert(cmd_addr != NULL);
   assert(useGCR && "Unsupported SDMA command - GCR.");
 
-  if (is_gfx1250_) {
+  if (is_gfx125plus_) {
     SDMA_PKT_GCR_GFX1250* addr = reinterpret_cast<SDMA_PKT_GCR_GFX1250*>(cmd_addr);
     memset(addr, 0, sizeof(SDMA_PKT_GCR_TAG_GFX1250));
     addr->HEADER_UNION.op = SDMA_OP_GCR;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -1288,7 +1288,7 @@ hsa_status_t GpuAgent::DmaCopyOnEngine(void* dst, core::Agent& dst_agent,
     // On platforms with dedicated xGMI SDMA engines, a P2P copy MUST target one of
     // those engines: a host-facing SDMA engine physically cannot drive the xGMI link,
     // so targeting an H2D/D2H engine for P2P is a hardware error. On platforms without
-    // dedicated xGMI engines (e.g. gfx1250) every SDMA engine is equivalent and
+    // dedicated xGMI engines (e.g. gfx125+) every SDMA engine is equivalent and
     // P2P-capable, so the H2D/D2H-vs-P2P split is only a load-balancing preference
     // (steered via DmaPreferredEngine) and must not be enforced as a hard rejection.
     bool p2p_engine_is_mandatory = use_p2p_engines && properties_.NumSdmaXgmiEngines;
@@ -1318,12 +1318,11 @@ hsa_status_t GpuAgent::DmaCopyOnEngine(void* dst, core::Agent& dst_agent,
     out_signal.async_copy_agent(core::Agent::Convert(this->public_handle()));
   }
 
-  // gfx1250 fast path: fuse GCR invalidate, poll+copy+signal and the GCR
-  // writeback + mailbox notify into one ring submission (single reserve/release).
-  // The packet builder chunks large copies internally, so any size is eligible.
-  if (!profiling_enabled() && blit->isSDMA()) {
+  // gfx125+ fast path: single fused WaitSignal packet (one doorbell).
+  // Each chunk carries wait+copy+signal inline; no prologue signal needed.
+  if (blit->isSDMA()) {
     BlitSdmaBase* sdma_blit = static_cast<BlitSdmaBase*>((*blit).get());
-    if (sdma_blit->IsGfx1250()) {
+    if (sdma_blit->IsGfx125Plus()) {
       return sdma_blit->SubmitLinearCopyBodyWaitSignal(
           dst, src, size, dep_signals, out_signal);
     }
@@ -1360,7 +1359,7 @@ hsa_status_t GpuAgent::DmaCopyStatus(core::Agent& dst_agent, core::Agent& src_ag
                      dst_agent.HiveId() && src_agent.HiveId() == dst_agent.HiveId() &&
                        num_p2p_engines_ > 0) {
     //Find a free p2p SDMA engine
-    // Without dedicated xGMI engines (e.g. gfx1250) every SDMA engine is P2P-capable,
+    // Without dedicated xGMI engines (e.g. gfx125+) every SDMA engine is P2P-capable,
     // so advertise all free engines rather than only the preferred P2P band. The
     // preference toward the P2P engines is still expressed via DmaPreferredEngine;
     // here we report the full set of engines a P2P copy may legally run on.
@@ -1409,18 +1408,10 @@ hsa_status_t GpuAgent::DmaCopyStatus(core::Agent& dst_agent, core::Agent& src_ag
 
 hsa_status_t GpuAgent::DmaPreferredEngine(core::Agent& dst_agent, core::Agent& src_agent,
                                           uint32_t *recommended_ids_mask) {
-  // gfx1250+: all SDMA engines are equivalent and there are no XGMI engines, we prefer first 2 engines
-  // for h2d/d2h and remaining for p2p.
+  // gfx125+: all SDMA engines are equivalent — return all engines regardless of direction.
   if (supported_isas()[0]->GetMajorVersion() == 12 && supported_isas()[0]->GetMinorVersion() >= 5) {
-    bool is_p2p = (src_agent.device_type() == core::Agent::kAmdGpuDevice &&
-                  dst_agent.device_type() == core::Agent::kAmdGpuDevice);
-
-    if (is_p2p) {
-      *recommended_ids_mask = ((1u << num_p2p_engines_) - 1) << (DefaultBlitCount - 1);
-    } else {
-      *recommended_ids_mask = (1u << num_h2d_d2h_engines_) - 1;
-    }
-
+    uint32_t total = num_h2d_d2h_engines_ + num_p2p_engines_;
+    *recommended_ids_mask = (1u << total) - 1;
     return HSA_STATUS_SUCCESS;
   }
 
@@ -1459,7 +1450,9 @@ hsa_status_t GpuAgent::DmaCopyFanOutOp(
     const void* const* src_list,
     void* const* dst_list,
     const hsa_agent_t* dst_agent_list,
-    const size_t* size_list) {
+    const size_t* size_list,
+    uint32_t coord_engine,
+    uint32_t max_engines) {
 
   SetCopyRequestRefCount(true);
   MAKE_SCOPE_GUARD([&]() { SetCopyRequestRefCount(false); });
@@ -1470,16 +1463,14 @@ hsa_status_t GpuAgent::DmaCopyFanOutOp(
   // Resolve per-entry SDMA engines.
   const uint32_t total_sdma = num_h2d_d2h_engines_ + num_p2p_engines_;
 
-  // Select the coordinator engine. For gfx1250, all engines are
-  // equivalent so we rotate the coordinator via PeekSdmaEngine (read-only peek
-  // at the round-robin counter) to spread GCR prologue/epilogue workload across
-  // engines over successive fan-out calls. The counter is NOT incremented here
-  // so body assignments start from the same position and coordinator selection
-  // is independent of body distribution.
-  // For all other architectures the coordinator is always BlitHostToDev (the
-  // dedicated H2D/P2P engine that owns the prologue/epilogue).
-  uint32_t coord_idx = BlitHostToDev;
-  {
+  uint32_t coord_idx = coord_engine ? coord_engine : BlitHostToDev;
+  BlitSdmaBase* coordinator = nullptr;
+
+  struct EngineSlot { BlitSdmaBase* blit; uint32_t idx; };
+  std::vector<EngineSlot> engines(num_entries);
+
+  // Resolve coordinator from topology when not explicitly supplied.
+  if (!coord_engine) {
     uint32_t eng_mask = 0;
     DmaPreferredEngine(*this, *this, &eng_mask);
     if (eng_mask && total_sdma > 0) {
@@ -1491,10 +1482,76 @@ hsa_status_t GpuAgent::DmaCopyFanOutOp(
   lazy_ptr<core::Blit>& coord_blit = GetBlitObject(coord_idx);
   if (!coord_blit->isSDMA())
     return HSA_STATUS_ERROR_INVALID_ARGUMENT;
-  BlitSdmaBase* coordinator = static_cast<BlitSdmaBase*>((*coord_blit).get());
+  coordinator = static_cast<BlitSdmaBase*>((*coord_blit).get());
+
+  std::fill(engines.begin(), engines.end(), EngineSlot{coordinator, coord_idx});
+
+  // Fan out body entries across multiple engines unless capped to 1.
+  if (!max_engines || max_engines > 1) {
+    if ((coordinator->IsGfx125Plus()) && total_sdma > 0) {
+      uint32_t eng_mask = 0;
+      DmaPreferredEngine(*this, *this, &eng_mask);
+      uint32_t assigned = 0;
+      for (uint32_t d = 0; d < num_entries; ++d) {
+        uint32_t eng_idx = PickSdmaEngine(eng_mask);
+        if (eng_idx) {
+          lazy_ptr<core::Blit>& blit = GetBlitObject(eng_idx);
+          if (blit->isSDMA()) {
+            engines[d] = {static_cast<BlitSdmaBase*>((*blit).get()), eng_idx};
+            ++assigned;
+          }
+        }
+        if (max_engines && assigned >= max_engines) break;
+      }
+    } else if (dst_agent_list) {
+      std::set<uint32_t> usedEngines;
+      std::vector<uint32_t> unresolved;
+
+      for (uint32_t d = 0; d < num_entries; ++d) {
+        if (max_engines && usedEngines.size() >= max_engines) {
+          unresolved.push_back(d);
+          continue;
+        }
+        core::Agent* dst_agent = core::Agent::Convert(dst_agent_list[d]);
+        uint32_t rec_mask = 0;
+        DmaPreferredEngine(*dst_agent, *this, &rec_mask);
+        int rec_eng = PickSdmaEngine(rec_mask);
+        if (rec_eng) {
+          lazy_ptr<core::Blit>& blit = GetBlitObject(rec_eng);
+          if (blit->isSDMA()) {
+            engines[d] = {static_cast<BlitSdmaBase*>((*blit).get()),
+                          static_cast<uint32_t>(rec_eng)};
+            usedEngines.insert(static_cast<uint32_t>(rec_eng));
+          }
+        } else {
+          unresolved.push_back(d);
+        }
+      }
+
+      for (uint32_t d : unresolved) {
+        if (total_sdma == 0) continue;
+        int picked = 0;
+        for (uint32_t e = 0; e < total_sdma; ++e) {
+          uint32_t candidate = BlitHostToDev + e;
+          if (usedEngines.find(candidate) == usedEngines.end()) {
+            picked = candidate;
+            break;
+          }
+        }
+        if (!picked)
+          picked = BlitHostToDev + (d % total_sdma);
+        lazy_ptr<core::Blit>& blit = GetBlitObject(picked);
+        if (blit->isSDMA()) {
+          engines[d] = {static_cast<BlitSdmaBase*>((*blit).get()),
+                        static_cast<uint32_t>(picked)};
+          usedEngines.insert(static_cast<uint32_t>(picked));
+        }
+      }
+    }
+  }
 
   if (op == HSA_AMD_MEMORY_COPY_OP_LINEAR_SWAP &&
-      !coordinator->SwapSupported() && !coordinator->IsGfx1250())
+      !coordinator->SwapSupported() && !coordinator->IsGfx125Plus())
     return HSA_STATUS_ERROR_INVALID_ARGUMENT;
 
   const bool is_indirect =
@@ -1505,11 +1562,6 @@ hsa_status_t GpuAgent::DmaCopyFanOutOp(
   if (is_indirect && !coordinator->IndirectCopySupported())
     return HSA_STATUS_ERROR_INVALID_ARGUMENT;
 
-  // Only indirect copies cannot chunk a large entry: the indirect packet has no
-  // offset field into the resolved buffer, so a single >max entry must fall back
-  // (and is ultimately rejected, since the indirect body rejects size > max).
-  // Linear copy and swap fused WaitSignal builders chunk internally via
-  // num_copy_command, so large entries stay on the fused path.
   bool requires_multi_packet = false;
   if (is_indirect) {
     const size_t max_single_copy = coordinator->MaxSingleLinearCopySize();
@@ -1521,294 +1573,232 @@ hsa_status_t GpuAgent::DmaCopyFanOutOp(
     }
   }
 
-  struct EngineSlot { BlitSdmaBase* blit; uint32_t idx; };
-  std::vector<EngineSlot> engines(num_entries, {coordinator, coord_idx});
-
-  if ((coordinator->IsGfx1250()) && total_sdma > 0) {
-    // gfx1250: all engines equivalent — round-robin via PickSdmaEngine.
-    uint32_t eng_mask = 0;
-    DmaPreferredEngine(*this, *this, &eng_mask);
-    for (uint32_t d = 0; d < num_entries; ++d) {
-      uint32_t eng_idx = PickSdmaEngine(eng_mask);
-      if (eng_idx) {
-        lazy_ptr<core::Blit>& blit = GetBlitObject(eng_idx);
-        if (blit->isSDMA())
-          engines[d] = {static_cast<BlitSdmaBase*>((*blit).get()), eng_idx};
-      }
-    }
-  } else {
-    std::set<uint32_t> usedEngines;
-    std::vector<uint32_t> unresolved;
-
-    // Assign recommended engines to entries that have one.
-    for (uint32_t d = 0; d < num_entries; ++d) {
-      core::Agent* dst_agent = core::Agent::Convert(dst_agent_list[d]);
-      uint32_t rec_mask = 0;
-      DmaPreferredEngine(*dst_agent, *this, &rec_mask);
-      int rec_eng = PickSdmaEngine(rec_mask);
-      if (rec_eng) {
-        lazy_ptr<core::Blit>& blit = GetBlitObject(rec_eng);
-        if (blit->isSDMA()) {
-          engines[d] = {static_cast<BlitSdmaBase*>((*blit).get()),
-                        static_cast<uint32_t>(rec_eng)};
-          usedEngines.insert(static_cast<uint32_t>(rec_eng));
-        }
-      } else {
-        unresolved.push_back(d);
-      }
-    }
-
-    // Assign exclusive engines to remaining entries
-    for (uint32_t d : unresolved) {
-      if (total_sdma == 0) continue;
-      int picked = 0;
-      for (uint32_t e = 0; e < total_sdma; ++e) {
-        uint32_t candidate = BlitHostToDev + e;
-        if (usedEngines.find(candidate) == usedEngines.end()) {
-          picked = candidate;
-          break;
-        }
-      }
-      if (!picked)
-        picked = BlitHostToDev + (d % total_sdma);
-      lazy_ptr<core::Blit>& blit = GetBlitObject(picked);
-      if (blit->isSDMA()) {
-        engines[d] = {static_cast<BlitSdmaBase*>((*blit).get()),
-                      static_cast<uint32_t>(picked)};
-        usedEngines.insert(static_cast<uint32_t>(picked));
-      }
-    }
-  }
-
   const char* op_name =
       (op == HSA_AMD_MEMORY_COPY_OP_LINEAR_SWAP) ? "Swap" :
       is_indirect ? "Indirect" : "Copy";
 
-  // GFX1250+ fast path: use wait/signal packets so bodies directly wait on
-  // dep_signals and signal out_signal, avoiding per-body prologue/epilogue
-  // timestamp collection. GCR/mailbox synchronization is still issued via the
-  // coordinator's SubmitNotifyPrologue/Epilogue below; only the profiling
-  // timestamp path is skipped.
-  if ((coordinator->IsGfx1250()) && !profiling_enabled() && !requires_multi_packet) {
-    // N bodies each do a 64b-sub of 1 on out_signal. Initial value is 1,
-    // so bump by (N-1) so the final value after all decrements is 0.
-    out_signal.AddRelaxed(num_entries - 1);
+  // Indirect copies that can't chunk a >max entry are rejected: the indirect
+  // packet has no offset field, so the classic body has no indirect variant.
+  if (requires_multi_packet) return HSA_STATUS_ERROR_INVALID_ARGUMENT;
 
-    // When GCR is active, issue a GCR invalidate on the coordinator engine
-    // before bodies start.  Since bodies run on different engines, allocate a
-    // prologue_signal that the prologue decrements after GCR completes.
-    // Bodies wait on it before copying.  Without GCR, bodies use the user's
-    // dep_signals directly — no extra signal needed.
-    const bool needs_gcr = coordinator->UsesGCR();
-    core::unique_signal_ptr prologue_signal;
+  const bool fused = coordinator->IsGfx125Plus();
+  const bool need_prologue = !fused || profiling_enabled();
 
-    if (needs_gcr) {
-      prologue_signal.reset(new core::DefaultSignal(1));
-      if (!prologue_signal->IsValid()) return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+  // Derive indirection flags from op for SubmitBodies.
+  const bool ind_src = (op == HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRC) ||
+                       (op == HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRCDST);
+  const bool ind_dst = (op == HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_DST) ||
+                       (op == HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRCDST);
+
+  // --- Signal allocation ---
+  core::unique_signal_ptr prologue_signal;
+  if (need_prologue) {
+    prologue_signal.reset(new core::DefaultSignal(1));
+    if (!prologue_signal->IsValid()) return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+  }
+
+  // Body deps:
+  // - fused + profiling: prologue waited on user deps, bodies just wait on prologue_signal.
+  // - fused + !profiling: no prologue, bodies wait on user dep_signals directly.
+  // - classic (!fused): bodies poll prologue_signal + user deps (classic only reads [0]).
+  std::vector<core::Signal*> body_deps;
+  if (need_prologue) {
+    if (fused) {
+      body_deps.push_back(prologue_signal.get());
+    } else {
+      body_deps.reserve(1 + dep_signals.size());
+      body_deps.push_back(prologue_signal.get());
+      body_deps.insert(body_deps.end(), dep_signals.begin(), dep_signals.end());
+    }
+  } else {
+    body_deps = dep_signals;
+  }
+
+  // --- Group entries by engine ---
+  std::map<uint32_t, std::vector<uint32_t>> engine_groups;
+  for (uint32_t d = 0; d < num_entries; ++d)
+    engine_groups[engines[d].idx].push_back(d);
+
+  // Classic path without platform atomics: allocate one body signal per group.
+  // Bodies fence their body_signal to 0; epilogue polls them instead of
+  // relying on atomic decrements of out_signal.
+  const bool use_body_signals = !fused && !coordinator->PlatformAtomicSupport();
+  std::vector<core::unique_signal_ptr> body_signal_ptrs;
+  std::vector<core::Signal*> body_signals_raw;
+
+  hsa_status_t stat;
+
+  if (fused) {
+    // === gfx125+ fused path: SubmitFusedCoordinator (1 doorbell for coord) ===
+
+    // Arm: each entry decrements out_signal independently.
+    out_signal.AddRelaxed(num_entries);
+
+    // Gather coordinator group entries.
+    std::vector<void*> coord_dsts;
+    std::vector<const void*> coord_srcs;
+    std::vector<size_t> coord_sizes_a, coord_sizes_b;
+    {
+      auto it = engine_groups.find(coord_idx);
+      if (it != engine_groups.end()) {
+        const auto& idxs = it->second;
+        coord_dsts.reserve(idxs.size());
+        coord_srcs.reserve(idxs.size());
+        coord_sizes_a.reserve(idxs.size());
+        coord_sizes_b.reserve(idxs.size());
+        for (uint32_t d : idxs) {
+          coord_dsts.push_back(dst_list[d]);
+          coord_srcs.push_back(src_list[d]);
+          coord_sizes_a.push_back(size_list[d]);
+          coord_sizes_b.push_back(size_list[d]);
+        }
+      }
     }
 
-    hsa_status_t stat = coordinator->SubmitNotifyPrologue(
-        needs_gcr ? prologue_signal.get() : nullptr);
-    if (stat != HSA_STATUS_SUCCESS) return stat;
-
-    // Build body deps: prepend prologue_signal (if GCR) so it becomes
-    // dep_signals[0] inside SubmitLinearCopy/SwapBodyWaitSignal, mapping
-    // to the WaitSignal packet's hardware WAIT field.  The SDMA engine
-    // won't start the copy until prologue_signal reaches 0.
-    // Without GCR, bodies use the original dep_signals unchanged.
-    const std::vector<core::Signal*>* body_deps_ptr = &dep_signals;
-    std::vector<core::Signal*> body_deps_with_prologue;
-    if (needs_gcr) {
-      body_deps_with_prologue.reserve(1 + dep_signals.size());
-      body_deps_with_prologue.push_back(prologue_signal.get());
-      body_deps_with_prologue.insert(body_deps_with_prologue.end(),
-                                     dep_signals.begin(), dep_signals.end());
-      body_deps_ptr = &body_deps_with_prologue;
-    }
-
-    for (uint32_t d = 0; d < num_entries; ++d) {
+    // Submit non-coordinator engine bodies first (they start working while
+    // the coordinator's epilogue poll waits for them).
+    for (const auto& grp : engine_groups) {
+      if (grp.first == coord_idx) continue;
+      const std::vector<uint32_t>& idxs = grp.second;
+      std::vector<void*> g_dsts;
+      std::vector<const void*> g_srcs;
+      std::vector<size_t> g_sizes_a, g_sizes_b;
+      g_dsts.reserve(idxs.size());
+      g_srcs.reserve(idxs.size());
+      g_sizes_a.reserve(idxs.size());
+      g_sizes_b.reserve(idxs.size());
+      for (uint32_t d : idxs) {
+        g_dsts.push_back(dst_list[d]);
+        g_srcs.push_back(src_list[d]);
+        g_sizes_a.push_back(size_list[d]);
+        g_sizes_b.push_back(size_list[d]);
+      }
       LogPrint(HSA_AMD_LOG_FLAG_SDMA,
-               "SDMA FanOut(%s) WaitSignalBody[%u/%u]: engine %02u, src=%p, dst=%p, "
-               "size=%zu, completion_signal=0x%zx",
-               op_name,
-               d + 1, num_entries, engines[d].idx, src_list[d], dst_list[d],
-               size_list[d],
+               "SDMA FanOut(%s) Bodies: engine %02u, entries=%zu, "
+               "completion_signal=0x%zx",
+               op_name, grp.first, idxs.size(),
                core::Signal::Convert(&out_signal).handle);
-      switch (op) {
-      case HSA_AMD_MEMORY_COPY_OP_LINEAR_SWAP:
-        stat = engines[d].blit->SubmitLinearSwapBodyWaitSignal(
-            dst_list[d], const_cast<void*>(src_list[d]),
-            size_list[d], size_list[d],
-            *body_deps_ptr, out_signal);
-        break;
-      case HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRC:
-      case HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_DST:
-      case HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRCDST: {
-        const bool ind_src = (op == HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRC) ||
-                             (op == HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRCDST);
-        const bool ind_dst = (op == HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_DST) ||
-                             (op == HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRCDST);
-        stat = engines[d].blit->SubmitLinearCopyBodyIndirectWaitSignal(
-            dst_list[d], src_list[d], size_list[d],
-            ind_src, ind_dst,
-            *body_deps_ptr, out_signal);
-        break;
-      }
-      default:
-        stat = engines[d].blit->SubmitLinearCopyBodyWaitSignal(
-            dst_list[d], src_list[d], size_list[d],
-            *body_deps_ptr, out_signal, /*fused_notify=*/false);
-        break;
-      }
+      stat = engines[idxs[0]].blit->SubmitBodies(
+          op, g_dsts, g_srcs, g_sizes_a, g_sizes_b,
+          ind_src, ind_dst, body_deps, out_signal, nullptr);
       if (stat != HSA_STATUS_SUCCESS) return stat;
     }
 
-    // Clean up prologue_signal asynchronously when out_signal reaches 0.
-    if (needs_gcr) {
-      core::Signal* prol_raw = prologue_signal.release();
+    // Fused coordinator: prologue + coord bodies + epilogue in one doorbell.
+    LogPrint(HSA_AMD_LOG_FLAG_SDMA,
+             "SDMA FanOut(%s) FusedCoord: engine %02u, coord_entries=%zu, "
+             "other_groups=%zu, completion_signal=0x%zx, prologue_signal=%p",
+             op_name, coord_idx, coord_dsts.size(),
+             engine_groups.size() - (engine_groups.count(coord_idx) ? 1 : 0),
+             core::Signal::Convert(&out_signal).handle,
+             prologue_signal ? prologue_signal.get() : nullptr);
+    stat = coordinator->SubmitFusedCoordinator(
+        dep_signals, out_signal,
+        prologue_signal.get(), fused,
+        op, coord_dsts, coord_srcs, coord_sizes_a, coord_sizes_b,
+        ind_src, ind_dst, body_deps);
+    if (stat != HSA_STATUS_SUCCESS) return stat;
+
+  } else {
+    // === Classic path (gfx942 etc.): separate prologue/bodies/epilogue ===
+
+    if (use_body_signals) {
+      body_signal_ptrs.reserve(engine_groups.size());
+      body_signals_raw.reserve(engine_groups.size());
+      for (size_t i = 0; i < engine_groups.size(); ++i) {
+        body_signal_ptrs.emplace_back(new core::DefaultSignal(1));
+        if (!body_signal_ptrs.back()->IsValid())
+          return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+        body_signals_raw.push_back(body_signal_ptrs.back().get());
+      }
+    } else {
+      out_signal.AddRelaxed(static_cast<uint32_t>(engine_groups.size()));
+    }
+
+    // Prologue
+    if (need_prologue) {
+      LogPrint(HSA_AMD_LOG_FLAG_SDMA,
+               "SDMA FanOut(%s) Prologue: coordinator %02u, num_entries=%u, "
+               "use_body_signals=%d, completion_signal=0x%zx, prologue_signal=0x%zx",
+               op_name, coord_idx, num_entries, use_body_signals,
+               core::Signal::Convert(&out_signal).handle,
+               core::Signal::Convert(prologue_signal.get()).handle);
+      stat = coordinator->SubmitPrologue(dep_signals, out_signal,
+                                         *prologue_signal, fused);
+      if (stat != HSA_STATUS_SUCCESS) return stat;
+    }
+
+    // Bodies: one SubmitBodies call per engine group
+    size_t grp_idx = 0;
+    for (const auto& grp : engine_groups) {
+      const std::vector<uint32_t>& idxs = grp.second;
+      std::vector<void*> g_dsts;
+      std::vector<const void*> g_srcs;
+      std::vector<size_t> g_sizes_a, g_sizes_b;
+      g_dsts.reserve(idxs.size());
+      g_srcs.reserve(idxs.size());
+      g_sizes_a.reserve(idxs.size());
+      g_sizes_b.reserve(idxs.size());
+      for (uint32_t d : idxs) {
+        g_dsts.push_back(dst_list[d]);
+        g_srcs.push_back(src_list[d]);
+        g_sizes_a.push_back(size_list[d]);
+        g_sizes_b.push_back(size_list[d]);
+      }
+      core::Signal* body_sig = use_body_signals ? body_signals_raw[grp_idx] : nullptr;
+      LogPrint(HSA_AMD_LOG_FLAG_SDMA,
+               "SDMA FanOut(%s) Bodies: engine %02u, entries=%zu, "
+               "completion_signal=0x%zx, body_signal=%p",
+               op_name, grp.first, idxs.size(),
+               core::Signal::Convert(&out_signal).handle,
+               body_sig);
+      stat = engines[idxs[0]].blit->SubmitBodies(
+          op, g_dsts, g_srcs, g_sizes_a, g_sizes_b,
+          ind_src, ind_dst, body_deps, out_signal, body_sig);
+      if (stat != HSA_STATUS_SUCCESS) return stat;
+      ++grp_idx;
+    }
+
+    // Epilogue
+    LogPrint(HSA_AMD_LOG_FLAG_SDMA,
+             "SDMA FanOut(%s) Epilogue: coordinator %02u, completion_signal=0x%zx, "
+             "body_signals=%zu",
+             op_name, coord_idx, core::Signal::Convert(&out_signal).handle,
+             body_signals_raw.size());
+    stat = coordinator->SubmitEpilogue(out_signal, body_signals_raw);
+    if (stat != HSA_STATUS_SUCCESS) return stat;
+  }
+
+  // --- Async cleanup: destroy prologue_signal and body_signals when done ---
+  {
+    struct CleanupCtx {
+      core::Signal* prologue = nullptr;
+      std::vector<core::Signal*> bodies;
+    };
+    auto* ctx = new CleanupCtx{};
+    if (prologue_signal)
+      ctx->prologue = prologue_signal.release();
+    for (auto& bp : body_signal_ptrs)
+      ctx->bodies.push_back(bp.release());
+
+    if (ctx->prologue || !ctx->bodies.empty()) {
       core::Runtime::runtime_singleton_->SetAsyncSignalHandler(
           core::Signal::Convert(&out_signal),
           HSA_SIGNAL_CONDITION_EQ, 0,
           [](hsa_signal_value_t, void* arg) -> bool {
-            reinterpret_cast<core::Signal*>(arg)->DestroySignal();
+            auto* c = reinterpret_cast<CleanupCtx*>(arg);
+            if (c->prologue) c->prologue->DestroySignal();
+            for (auto* s : c->bodies) s->DestroySignal();
+            delete c;
             return false;
           },
-          reinterpret_cast<void*>(prol_raw));
-    }
-
-    // Lightweight notify: poll out_signal==0, GCR writeback, mailbox + trap.
-    return coordinator->SubmitNotifyEpilogue(out_signal);
-  }
-
-  // Legacy Path: prologue -> body -> epilogue path.
-
-  bool use_body_signals = !coordinator->PlatformAtomicSupport();
-
-  // On gfx1250 with shared out_signal, use WaitSignal body to fuse
-  // poll+copy+signal per body; the builder chunks large entries internally.
-  // Only indirect bodies can't chunk (requires_multi_packet), so they fall back
-  // to the classic path here and are rejected just below.
-  const bool waitsignal_body =
-      coordinator->IsGfx1250() && !use_body_signals && !requires_multi_packet;
-
-  // Indirect bodies only implement fused packets
-  if (is_indirect && !waitsignal_body) return HSA_STATUS_ERROR_INVALID_ARGUMENT;
-
-  // Allocate prologue synchronization signal
-  core::unique_signal_ptr prologue_signal(new core::DefaultSignal(1));
-  if (!prologue_signal->IsValid()) return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
-
-  // Without platform atomic support, bodies cannot atomically decrement a
-  // shared signal. Allocate per-body signals so each body writes to its own
-  // and the epilogue polls all of them.
-  std::vector<core::unique_signal_ptr> body_signals;
-  if (use_body_signals) {
-    body_signals.reserve(num_entries);
-    for (uint32_t d = 0; d < num_entries; ++d) {
-      core::unique_signal_ptr sig(new core::DefaultSignal(1));
-      if (!sig->IsValid())
-        return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
-      body_signals.push_back(std::move(sig));
+          reinterpret_cast<void*>(ctx));
+    } else {
+      delete ctx;
     }
   }
 
-  core::Signal* prologue_raw = prologue_signal.get();
-  std::vector<core::Signal*> body_raw;
-  for (auto& s : body_signals) body_raw.push_back(s.get());
-
-  auto cleanup_signals = std::make_unique<std::vector<core::Signal*>>();
-  cleanup_signals->push_back(prologue_signal.release());
-  for (auto& s : body_signals) cleanup_signals->push_back(s.release());
-
-  core::Runtime::runtime_singleton_->SetAsyncSignalHandler(
-      core::Signal::Convert(&out_signal),
-      HSA_SIGNAL_CONDITION_EQ, 0,
-      [](hsa_signal_value_t, void* arg) -> bool {
-        auto* sigs = reinterpret_cast<std::vector<core::Signal*>*>(arg);
-        for (auto* s : *sigs) s->DestroySignal();
-        delete sigs;
-        return false;
-      },
-      reinterpret_cast<void*>(cleanup_signals.release()));
-
-  // Since each engine will decrement the out_signal, we need to add the #entries
-  if (!use_body_signals) {
-    out_signal.AddRelaxed(num_entries);
-  }
-
-  // Prologue: dep polls, HDP flush, GCR invalidate, decrement prologue_signal.
-  LogPrint(HSA_AMD_LOG_FLAG_SDMA,
-           "SDMA FanOut(%s) Prologue: engine %02u, num_entries=%u, dep_signal=0x%zx, "
-           "completion_signal=0x%zx, prologue_signal=0x%zx",
-           op_name, coord_idx, num_entries,
-           dep_signals.empty() ? 0 : core::Signal::Convert(dep_signals[0]).handle,
-           core::Signal::Convert(&out_signal).handle,
-           core::Signal::Convert(prologue_raw).handle);
-  hsa_status_t stat = coordinator->SubmitPrologue(dep_signals, out_signal,
-                                                  *prologue_raw);
-  if (stat != HSA_STATUS_SUCCESS) return stat;
-
-  // Fan out: one body per entry on its resolved engine.
-  const std::vector<core::Signal*> body_deps = waitsignal_body
-      ? std::vector<core::Signal*>{prologue_raw} : std::vector<core::Signal*>{};
-
-  for (uint32_t d = 0; d < num_entries; ++d) {
-    core::Signal& body_sig = use_body_signals ? *body_raw[d] : out_signal;
-    LogPrint(HSA_AMD_LOG_FLAG_SDMA,
-             "SDMA FanOut(%s) Body[%u/%u]: engine %02u, src=%p, dst=%p, size=%zu, "
-             "prologue_signal=0x%zx, body_signal=0x%zx",
-             op_name,
-             d + 1, num_entries, engines[d].idx, src_list[d], dst_list[d],
-             size_list[d],
-             core::Signal::Convert(prologue_raw).handle,
-             core::Signal::Convert(&body_sig).handle);
-    switch (op) {
-    case HSA_AMD_MEMORY_COPY_OP_LINEAR_SWAP:
-      stat = waitsignal_body
-          ? engines[d].blit->SubmitLinearSwapBodyWaitSignal(
-                dst_list[d], const_cast<void*>(src_list[d]),
-                size_list[d], size_list[d],
-                body_deps, out_signal)
-          : engines[d].blit->SubmitLinearSwapBody(
-                dst_list[d], const_cast<void*>(src_list[d]), size_list[d],
-                *prologue_raw, body_sig);
-      break;
-    case HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRC:
-    case HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_DST:
-    case HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRCDST: {
-      const bool ind_src =
-          (op == HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRC) ||
-          (op == HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRCDST);
-      const bool ind_dst =
-          (op == HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_DST) ||
-          (op == HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRCDST);
-      stat = engines[d].blit->SubmitLinearCopyBodyIndirectWaitSignal(
-          dst_list[d], src_list[d], size_list[d], ind_src, ind_dst,
-          body_deps, out_signal);
-      break;
-    }
-    default: // Default is Linear Copy
-      stat = waitsignal_body
-          ? engines[d].blit->SubmitLinearCopyBodyWaitSignal(
-                dst_list[d], src_list[d], size_list[d],
-                body_deps, out_signal, /*fused_notify=*/false)
-          : engines[d].blit->SubmitLinearCopyBody(
-                dst_list[d], src_list[d], size_list[d],
-                *prologue_raw, body_sig);
-      break;
-    }
-    if (stat != HSA_STATUS_SUCCESS) return stat;
-  }
-
-  // Epilogue: waits for all bodies, GCR writeback, end timestamp, signal -> 0.
-  LogPrint(HSA_AMD_LOG_FLAG_SDMA,
-           "SDMA FanOut(%s) Epilogue: engine %02u, completion_signal=0x%zx, "
-           "num_body_signals=%zu",
-           op_name, coord_idx,
-           core::Signal::Convert(&out_signal).handle,
-           body_raw.size());
-  constexpr hsa_signal_value_t kWaitValue = 1;
-  return coordinator->SubmitEpilogue(out_signal, kWaitValue, body_raw);
+  return HSA_STATUS_SUCCESS;
 }
 
 // Formats a destination pointer list for SDMA debug logging. Only called from
@@ -1838,16 +1828,16 @@ hsa_status_t GpuAgent::DmaCopyBroadcast(
   const uint16_t num_entries = op.num_entries;
 
   // Size thresholds for multi-destination copy path selection.
-  // kMulticastMaxSize: gfx1250 multicast/fan-out crossover (8 MB).
+  // kMulticastMaxSize: gfx125+ multicast/fan-out crossover (8 MB).
   //   Below this the single-engine multicast packet wins; above it fan-out
   //   across multiple SDMA engines delivers higher aggregate bandwidth.
-  // kB2BMinSize/kB2BMaxSize: per-copy size window for linearB2B on non-gfx1250.
+  // kB2BMinSize/kB2BMaxSize: per-copy size window for linearB2B on non-gfx125+.
   //   Below kB2BMinSize the broadcast packet (2-dst) is used instead; above
   //   kB2BMaxSize fan-out parallelises across engines. Kept consistent with
-  //   DmaCopyMulti and independent of the gfx1250 multicast threshold.
+  //   DmaCopyMulti and independent of the gfx125+ multicast threshold.
   constexpr size_t kMulticastMaxSize = 8 * 1024 * 1024;
   constexpr size_t kB2BMinSize = 16 * 1024;
-  constexpr size_t kB2BMaxSize = 256 * 1024;
+  constexpr size_t kB2BMaxSize = 64 * 1024;
 
   // Try HW broadcast/multicast or linearB2B on one engine.
   {
@@ -1862,8 +1852,8 @@ hsa_status_t GpuAgent::DmaCopyBroadcast(
       if (profiling_enabled())
         out_signal.async_copy_agent(core::Agent::Convert(this->public_handle()));
 
-      if (sdma_blit->IsGfx1250()) {
-        // gfx1250: multicast for copies <= 8 MB. Below this threshold the
+      if (sdma_blit->IsGfx125Plus()) {
+        // gfx125+: multicast for copies <= 8 MB. Below this threshold the
         // single-engine multicast packet matches or beats fan-out (saves
         // per-destination signal overhead). Above 8 MB, fan-out across
         // multiple SDMA engines delivers ~15% higher aggregate bandwidth.
@@ -1887,7 +1877,7 @@ hsa_status_t GpuAgent::DmaCopyBroadcast(
         }
         // Larger than the multicast limit: fall through to fan-out below.
       } else {
-        // Non-gfx1250: linearB2B for [16KB, 256KB], broadcast for < 16KB,
+        // Non-gfx125+: linearB2B for [16KB, 256KB], broadcast for < 16KB,
         // else fall through to fan-out which parallelises across engines.
         // HSA_SDMA_LINEAR_B2B: 1=force B2B, 0=force broadcast, unset=auto
         // (kept consistent with DmaCopyMulti, which honors the same override).
@@ -1904,11 +1894,12 @@ hsa_status_t GpuAgent::DmaCopyBroadcast(
                    FormatDstList(op.dst_list, num_entries).c_str(),
                    dep_signals.empty() ? 0 : core::Signal::Convert(dep_signals[0]).handle,
                    core::Signal::Convert(out_signal_obj).handle);
-          std::vector<void*> dsts(op.dst_list, op.dst_list + num_entries);
           std::vector<const void*> srcs(num_entries, op.src);
           std::vector<size_t> sizes(num_entries, op.size);
-          return sdma_blit->SubmitLinearCopyB2BCommand(
-              dsts, srcs, sizes, dep_signals, out_signal);
+          return DmaCopyFanOutOp(HSA_AMD_MEMORY_COPY_OP_LINEAR, out_signal,
+                                 dep_signals, num_entries, srcs.data(),
+                                 op.dst_list, nullptr, sizes.data(),
+                                 BlitHostToDev, 1);
         }
 
         if (sdma_blit->BroadcastSupported() && op.size < kB2BMinSize) {
@@ -1936,63 +1927,6 @@ hsa_status_t GpuAgent::DmaCopyBroadcast(
                          op.dst_agent_list, sizes.data());
 }
 
-hsa_status_t GpuAgent::DmaCopyMulti(
-    const hsa_amd_memory_copy_op_t& op,
-    std::vector<core::Signal*>& dep_signals) {
-
-  core::Signal* out_signal_obj = core::Signal::Convert(op.completion_signal);
-  core::Signal& out_signal = *out_signal_obj;
-
-  const uint16_t num_entries = op.num_entries;
-  constexpr size_t kB2BMaxSize = 256 * 1024;
-  constexpr size_t kB2BMinSize = 16 * 1024;
-
-  // LinearB2B: pack all entries as back-to-back SDMA linear copy packets in
-  // one ring submission to avoid fan-out signal overhead.  Per-entry size must
-  // be in [kB2BMinSize, kB2BMaxSize] unless the flag forces B2B on.
-  // For large entries the fan-out path parallelises across engines.
-  {
-    SetCopyRequestRefCount(true);
-    MAKE_SCOPE_GUARD([&]() { SetCopyRequestRefCount(false); });
-
-    lazy_ptr<core::Blit>& blit = GetBlitObject(BlitHostToDev);
-    if (blit->isSDMA()) {
-      BlitSdmaBase* sdma_blit = static_cast<BlitSdmaBase*>((*blit).get());
-      const auto b2b_flag = core::Runtime::runtime_singleton_->flag().sdma_linear_b2b();
-
-      bool all_qualify = true;
-      for (uint16_t i = 0; i < num_entries; i++) {
-        const size_t sz = op.size_list[i];
-        if (b2b_flag != Flag::SDMA_ENABLE &&
-            !(b2b_flag == Flag::SDMA_DEFAULT &&
-              sz >= kB2BMinSize && sz <= kB2BMaxSize)) {
-          all_qualify = false;
-          break;
-        }
-      }
-
-      if (all_qualify) {
-        if (profiling_enabled())
-          out_signal.async_copy_agent(core::Agent::Convert(this->public_handle()));
-        LogPrint(HSA_AMD_LOG_FLAG_SDMA,
-                 "SDMA linearB2B engine %02u, num_entries=%u, "
-                 "dep_signal=0x%zx, completion_signal=0x%zx",
-                 BlitHostToDev, num_entries,
-                 dep_signals.empty() ? 0 : core::Signal::Convert(dep_signals[0]).handle,
-                 out_signal_obj->signal_);
-        std::vector<void*> dsts(op.dst_list, op.dst_list + num_entries);
-        std::vector<const void*> srcs(op.src_list, op.src_list + num_entries);
-        std::vector<size_t> sizes(op.size_list, op.size_list + num_entries);
-        return sdma_blit->SubmitLinearCopyB2BCommand(dsts, srcs, sizes,
-                                                     dep_signals, out_signal);
-      }
-    }
-  }
-
-  return DmaCopyFanOutOp(HSA_AMD_MEMORY_COPY_OP_LINEAR, out_signal, dep_signals,
-                         num_entries, const_cast<const void* const*>(op.src_list),
-                         op.dst_list, op.dst_agent_list, op.size_list);
-}
 
 hsa_status_t GpuAgent::DmaCopySwap(
     const hsa_amd_memory_copy_op_t& op,
@@ -2065,7 +1999,32 @@ hsa_status_t GpuAgent::DmaCopyBatch(const hsa_amd_memory_copy_op_t* ops,
     switch (op.type) {
     case HSA_AMD_MEMORY_COPY_OP_LINEAR: {
       if (op.num_entries > 0) {
-        status = DmaCopyMulti(op, dep_signals);
+        // Multi-entry linear: check if all entries qualify for B2B (serialize
+        // on one engine) or use full fan-out across engines.
+        constexpr size_t kB2BMinSize = 16 * 1024;
+        constexpr size_t kB2BMaxSize = 64 * 1024;
+        const auto b2b_flag = core::Runtime::runtime_singleton_->flag().sdma_linear_b2b();
+        bool all_b2b = true;
+        for (uint16_t e = 0; e < op.num_entries; e++) {
+          if (b2b_flag != Flag::SDMA_ENABLE &&
+              !(b2b_flag == Flag::SDMA_DEFAULT &&
+                op.size_list[e] >= kB2BMinSize && op.size_list[e] <= kB2BMaxSize)) {
+            all_b2b = false;
+            break;
+          }
+        }
+        if (all_b2b) {
+          status = DmaCopyFanOutOp(HSA_AMD_MEMORY_COPY_OP_LINEAR, out_signal,
+                                   dep_signals, op.num_entries,
+                                   const_cast<const void* const*>(op.src_list),
+                                   op.dst_list, nullptr, op.size_list,
+                                   BlitHostToDev, 1);
+        } else {
+          status = DmaCopyFanOutOp(HSA_AMD_MEMORY_COPY_OP_LINEAR, out_signal,
+                                   dep_signals, op.num_entries,
+                                   const_cast<const void* const*>(op.src_list),
+                                   op.dst_list, op.dst_agent_list, op.size_list);
+        }
       } else {
         core::Agent* dst_agent = core::Agent::Convert(op.dst_agent);
         core::Agent* src_agent = core::Agent::Convert(op.src_agent);
@@ -2597,10 +2556,10 @@ hsa_status_t GpuAgent::GetInfo(hsa_agent_info_t attribute, void* value) const {
         *((uint32_t*)value) = 0;
       }
       break;
-    case HSA_AMD_AGENT_INFO_HOST_ALLOC_DMABUF_SUPPORTED:                                                                                                                                        
-      // GPU agents can participate in host memory DMA-BUF export if the system supports virtual memory APIs                                                                                                                                         
-      *static_cast<bool*>(value) = core::Runtime::runtime_singleton_->VirtualMemApiSupported();                                                                                           
-      break; 
+    case HSA_AMD_AGENT_INFO_HOST_ALLOC_DMABUF_SUPPORTED:
+      // GPU agents can participate in host memory DMA-BUF export if the system supports virtual memory APIs
+      *static_cast<bool*>(value) = core::Runtime::runtime_singleton_->VirtualMemApiSupported();
+      break;
     default:
       return HSA_STATUS_ERROR_INVALID_ARGUMENT;
       break;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -1660,26 +1660,13 @@ hsa_status_t GpuAgent::DmaCopyFanOutOp(
     for (const auto& grp : engine_groups) {
       if (grp.first == coord_idx) continue;
       const std::vector<uint32_t>& idxs = grp.second;
-      std::vector<void*> g_dsts;
-      std::vector<const void*> g_srcs;
-      std::vector<size_t> g_sizes_a, g_sizes_b;
-      g_dsts.reserve(idxs.size());
-      g_srcs.reserve(idxs.size());
-      g_sizes_a.reserve(idxs.size());
-      g_sizes_b.reserve(idxs.size());
-      for (uint32_t d : idxs) {
-        g_dsts.push_back(dst_list[d]);
-        g_srcs.push_back(src_list[d]);
-        g_sizes_a.push_back(size_list[d]);
-        g_sizes_b.push_back(size_list[d]);
-      }
       LogPrint(HSA_AMD_LOG_FLAG_SDMA,
                "SDMA FanOut(%s) Bodies: engine %02u, entries=%zu, "
                "completion_signal=0x%zx",
                op_name, grp.first, idxs.size(),
                core::Signal::Convert(&out_signal).handle);
       stat = engines[idxs[0]].blit->SubmitBodies(
-          op, g_dsts, g_srcs, g_sizes_a, g_sizes_b,
+          op, dst_list, src_list, size_list, idxs,
           ind_src, ind_dst, body_deps, out_signal, nullptr);
       if (stat != HSA_STATUS_SUCCESS) return stat;
     }
@@ -1732,19 +1719,6 @@ hsa_status_t GpuAgent::DmaCopyFanOutOp(
     size_t grp_idx = 0;
     for (const auto& grp : engine_groups) {
       const std::vector<uint32_t>& idxs = grp.second;
-      std::vector<void*> g_dsts;
-      std::vector<const void*> g_srcs;
-      std::vector<size_t> g_sizes_a, g_sizes_b;
-      g_dsts.reserve(idxs.size());
-      g_srcs.reserve(idxs.size());
-      g_sizes_a.reserve(idxs.size());
-      g_sizes_b.reserve(idxs.size());
-      for (uint32_t d : idxs) {
-        g_dsts.push_back(dst_list[d]);
-        g_srcs.push_back(src_list[d]);
-        g_sizes_a.push_back(size_list[d]);
-        g_sizes_b.push_back(size_list[d]);
-      }
       core::Signal* body_sig = use_body_signals ? body_signals_raw[grp_idx] : nullptr;
       LogPrint(HSA_AMD_LOG_FLAG_SDMA,
                "SDMA FanOut(%s) Bodies: engine %02u, entries=%zu, "
@@ -1753,7 +1727,7 @@ hsa_status_t GpuAgent::DmaCopyFanOutOp(
                core::Signal::Convert(&out_signal).handle,
                body_sig);
       stat = engines[idxs[0]].blit->SubmitBodies(
-          op, g_dsts, g_srcs, g_sizes_a, g_sizes_b,
+          op, dst_list, src_list, size_list, idxs,
           ind_src, ind_dst, body_deps, out_signal, body_sig);
       if (stat != HSA_STATUS_SUCCESS) return stat;
       ++grp_idx;


### PR DESCRIPTION
- Restructure SubmitBodies: both fused (gfx125+) and classic paths now use a single ring reservation for all entries (one doorbell per engine group). Classic path assumes platform atomics and decrements out_signal directly per entry—no per-body signals needed.

- Simplify SubmitPrologue/SubmitEpilogue: remove atomic-decrement branches where the signal value is known (prologue signal is always 1, epilogue polls then fences to 0). Remove body_signals parameter and drain_bodies_individually logic from the epilogue.

- Eliminate heap allocation in classic body path: copy packets are formed in-place in the ring buffer instead of staging through a temporary std::vector + memcpy.

- Consolidate linearB2B paths into DmaCopyFanOutOp with coord_engine and max_engines parameters. Drop engine_mask; existing topology resolution handles engine selection, capped by max_engines.

- Add SubmitFusedCoordinator for gfx125+: packs prologue + body entries + epilogue into a single ring reservation (one doorbell) for the coordinator engine, reducing doorbell overhead in multi-engine fan-out submissions.

- Remove dead code from SubmitFusedCoordinator: strip pre-gfx125+ fallback branches (split-word polls, 32-bit fences, atomic decrements) that are unreachable since the function is exclusively called on gfx125+ instances. Remove vestigial epilogue_body_signals parameter.

- Gather SubmitBodies entries from master lists: take the caller's master dst/src/size arrays plus an index vector and gather each engine's entries internally, instead of receiving pre-built per-engine vectors. Removes four std::vector allocations per engine group on every fan-out submission. Collapse sizes_a/sizes_b into a single size_list.

- **Rotate SDMA engines within a single copy, not across API calls:** remove the persistent per-agent round-robin counter (`sdma_rr_index_`) and `PickSdmaEngine`. Engine assignment now uses `NthSdmaEngine(mask, k)` driven by the per-entry index, so a fan-out spreads across engines within the copy while the engine set stays deterministic per call and no longer marches across successive copies.

- **gfx125+ fused-coordinator epilogue fast-path:** when the completion signal has no event mailbox and GCR/profiling are off, skip the epilogue poll+fence entirely. Every body packet's SIGNAL stage already atomically subtracts 1 after its copy (SDMA is in-order per engine), so the last chunk's sub is the ordered completion edge on its own; the signal target is shifted down by one so that final sub lands on the done value. Collapses the coordinator submission to the same single-body packet the worker engines emit.

- **Revert gfx1250 multicast crossover 8MB → 256KB:** a single-engine multicast serialises the writes to all destinations and becomes bandwidth-bound well before 8MB, so multi-destination copies above 256KB now fan out across engines for higher aggregate bandwidth. Fixes a large-copy regression in broadcast copies. The `HSA_SDMA_MULTICAST` override is unchanged.

- Tune linearB2B serialization threshold: lower kB2BMaxSize from 256KB to 64KB to eliminate latency blips at ~2MB sizes in multi-entry batch copies.

- **Serialize the ReleaseWrite debug log:** move it into `UpdateWriteAndDoorbellRegister` under the doorbell serialization and log the written wptr plus the live rptr (instead of the old→new wptr), so it can't report a wptr ordering that never happened under concurrent submission.

## Motivation

Reduce SDMA submission overhead (doorbell rings, heap allocations, branch complexity) for both single-engine and multi-engine copy paths. The fused coordinator path on gfx125+ saves 1-2 doorbells per fan-out submission by coalescing prologue, body copies, and epilogue into one contiguous ring write. The multicast crossover revert and within-copy engine rotation restore multi-destination bandwidth at large sizes.

## Technical Details

- `SubmitFusedCoordinator`: single AcquireWriteAddress/ReleaseWriteAddress pair emits all coordinator packets; the epilogue is dropped on the fast path when no interrupt mailbox / GCR / profiling is needed.
- `DmaCopyFanOutOp`: `if (fused)` / `else` branches -- fused path calls SubmitFusedCoordinator for the coordinator group and SubmitBodies for others; classic path retains separate SubmitPrologue/SubmitBodies/SubmitEpilogue calls.
- Engine selection: `NthSdmaEngine(mask, k)` replaces the global round-robin `PickSdmaEngine`; `sdma_rr_index_` removed.
- `kMulticastMaxSize` restored to 256 KB (gfx1250); copies above it fan out across engines.

## JIRA ID

JIRA ID: AIRUNTIME-0

## Test Plan

- MPI-based allgather batch test (`hip-allgather-batch`, 8 GPUs, 23 size tiers 1KB-4GB) on gfx942 (MI300X) -- correctness and performance.
- gfx125+ (MI450) validation still required for the fused-coordinator epilogue fast-path, within-copy rotation, and the multicast crossover revert (these paths are gfx125+-only and cannot be exercised on gfx942).

## Test Result

All 23 size tiers pass cleanly on gfx942 (MI300X), no hangs or errors. Smooth latency curve with no anomalous blips at the 2MB boundary. gfx125+ validation pending.

## Submission Checklist

- Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
