### PR TITLE
fix(amdsmi): process visibility, per-GPU attribution, table alignment

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -90,6 +90,14 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 - **Renamed "AINIC version" to "ionic version" in `amd-smi version` output**.  
   - The label now correctly reflects that it shows the ionic kernel driver version.
 
+### Fixed
+
+- **Fixed `amd-smi process` hiding compute processes owned by other users**.  
+  - A caller without permission to read another process's `/proc/<pid>/fd` was misdetected as running in a separate PID namespace, which caused the whole compute-process list to come back empty. Such processes are now listed with a redacted (`N/A`) name instead of being dropped.
+
+- **Fixed CU%/SDMA column alignment in the `amd-smi` process table**.  
+  - The `SDMA` header no longer sits a column left of its values, and valid `CU %`/`SDMA` values are no longer truncated.
+
 ### Removed
 
 - **Removed the non-functional `--decode` flag from `amd-smi ras`**. Out-of-band CPER decoding is available via `amd-smi ras --afid --cper-file <path>` or `--afid --folder <DIR>`.

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -98,6 +98,9 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 - **Fixed CU%/SDMA column alignment in the `amd-smi` process table**.  
   - The `SDMA` header no longer sits a column left of its values, and valid `CU %`/`SDMA` values are no longer truncated.
 
+- **Fixed compute processes being reported on every GPU**.  
+  - A process was attributed to a GPU whenever it had a KFD context on that GPU, so a job with queues on a single GPU appeared under every GPU. Attribution now uses the process's active KFD queues plus any GPU where it holds a non-zero VRAM allocation, so a process is listed only against the GPUs it actually uses.
+
 ### Removed
 
 - **Removed the non-functional `--decode` flag from `amd-smi ras`**. Out-of-band CPER decoding is available via `amd-smi ras --afid --cper-file <path>` or `--afid --folder <DIR>`.

--- a/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
@@ -1360,7 +1360,7 @@ class AMDSMILogger:
         # print process list of all GPUs last
         print(default_line_1)
         print("| Processes:                                                                   |")
-        print("|  GPU      PID  Process Name       GTT_MEM  VRAM_MEM  MEM_USAGE  CU %  SDMA   |")
+        print("|  GPU      PID  Process Name     GTT_MEM  VRAM_MEM  MEM_USAGE   CU %     SDMA |")
         print(default_line_5)
         elevated_permission_error = False
         if len(output["processes"]) != 0:
@@ -1368,9 +1368,9 @@ class AMDSMILogger:
                 gpu_id = str(process["gpu"]).rjust(4)
                 pid = str(process["pid"]).rjust(7)
                 if str(process["name"]) == "N/A":
-                    process_name = "N/A".ljust(16)
+                    process_name = "N/A".ljust(14)
                 else:
-                    process_name = str(process["name"]).split("/")[-1][:16].ljust(16)
+                    process_name = str(process["name"]).split("/")[-1][:14].ljust(14)
                 gtt_mem = str(process["gtt"]).rjust(8)
                 vram_mem = str(process["vram"]).rjust(8)
                 mem_usage = str(process["mem_usage"]).rjust(9)
@@ -1378,22 +1378,21 @@ class AMDSMILogger:
                     process["cu_occupancy"]["total_num_cu"] != "N/A"
                     and process["cu_occupancy"]["current_cu"] != "N/A"
                 ):
-                    cu_occupancy = (
-                        str(
-                            round(
-                                process["cu_occupancy"]["current_cu"]
-                                / process["cu_occupancy"]["total_num_cu"]
-                                * 100,
-                                1,
-                            )
+                    # Unit is conveyed by the "CU %" header; keep the value numeric so
+                    # it fits its column and stays aligned with the "N/A" case.
+                    cu_occupancy = str(
+                        round(
+                            process["cu_occupancy"]["current_cu"]
+                            / process["cu_occupancy"]["total_num_cu"]
+                            * 100,
+                            1,
                         )
-                        + " %"
                     ).rjust(5)
                 else:
                     cu_occupancy = "N/A".rjust(5)
-                sdma_usage = str(process["sdma_usage"]).rjust(5)
+                sdma_usage = str(process["sdma_usage"]).rjust(7)
                 print(
-                    "| {0:4.4s}  {1:7.7s}  {2:16.16s}  {3:8.8s}  {4:8.8s}  {5:9.9s}  {6:5.5s}  {7:5.5s} |".format(
+                    "| {0:4.4s}  {1:7.7s}  {2:14.14s}  {3:8.8s}  {4:8.8s}  {5:9.9s}  {6:5.5s}  {7:7.7s} |".format(
                         gpu_id,
                         pid,
                         process_name,

--- a/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_logger.py
@@ -1189,6 +1189,44 @@ class AMDSMILogger:
                     output_file.write(primary_table + "\n")
                     output_file.write(secondary_table)
 
+    # Header and row share one set of column widths so the labels stay above
+    # their right-justified values inside the fixed 80-character box.
+    PROCESS_TABLE_HEADER = (
+        "|  GPU      PID  Process Name     GTT_MEM  VRAM_MEM  MEM_USAGE   CU %     SDMA |"
+    )
+
+    @staticmethod
+    def _format_process_row(process):
+        gpu_id = str(process["gpu"]).rjust(4)
+        pid = str(process["pid"]).rjust(7)
+        if str(process["name"]) == "N/A":
+            process_name = "N/A".ljust(14)
+        else:
+            process_name = str(process["name"]).split("/")[-1][:14].ljust(14)
+        gtt_mem = str(process["gtt"]).rjust(8)
+        vram_mem = str(process["vram"]).rjust(8)
+        mem_usage = str(process["mem_usage"]).rjust(9)
+        if (
+            process["cu_occupancy"]["total_num_cu"] != "N/A"
+            and process["cu_occupancy"]["current_cu"] != "N/A"
+        ):
+            # Unit is conveyed by the "CU %" header; keep the value numeric so
+            # it fits its column and stays aligned with the "N/A" case.
+            cu_occupancy = str(
+                round(
+                    process["cu_occupancy"]["current_cu"]
+                    / process["cu_occupancy"]["total_num_cu"]
+                    * 100,
+                    1,
+                )
+            ).rjust(5)
+        else:
+            cu_occupancy = "N/A".rjust(5)
+        sdma_usage = str(process["sdma_usage"]).rjust(7)
+        return "| {0:4.4s}  {1:7.7s}  {2:14.14s}  {3:8.8s}  {4:8.8s}  {5:9.9s}  {6:5.5s}  {7:7.7s} |".format(
+            gpu_id, pid, process_name, gtt_mem, vram_mem, mem_usage, cu_occupancy, sdma_usage
+        )
+
     def print_default_output(self, output: Dict):
         # some template lines
         default_line_1 = (
@@ -1360,49 +1398,12 @@ class AMDSMILogger:
         # print process list of all GPUs last
         print(default_line_1)
         print("| Processes:                                                                   |")
-        print("|  GPU      PID  Process Name     GTT_MEM  VRAM_MEM  MEM_USAGE   CU %     SDMA |")
+        print(self.PROCESS_TABLE_HEADER)
         print(default_line_5)
         elevated_permission_error = False
         if len(output["processes"]) != 0:
             for process in output["processes"]:
-                gpu_id = str(process["gpu"]).rjust(4)
-                pid = str(process["pid"]).rjust(7)
-                if str(process["name"]) == "N/A":
-                    process_name = "N/A".ljust(14)
-                else:
-                    process_name = str(process["name"]).split("/")[-1][:14].ljust(14)
-                gtt_mem = str(process["gtt"]).rjust(8)
-                vram_mem = str(process["vram"]).rjust(8)
-                mem_usage = str(process["mem_usage"]).rjust(9)
-                if (
-                    process["cu_occupancy"]["total_num_cu"] != "N/A"
-                    and process["cu_occupancy"]["current_cu"] != "N/A"
-                ):
-                    # Unit is conveyed by the "CU %" header; keep the value numeric so
-                    # it fits its column and stays aligned with the "N/A" case.
-                    cu_occupancy = str(
-                        round(
-                            process["cu_occupancy"]["current_cu"]
-                            / process["cu_occupancy"]["total_num_cu"]
-                            * 100,
-                            1,
-                        )
-                    ).rjust(5)
-                else:
-                    cu_occupancy = "N/A".rjust(5)
-                sdma_usage = str(process["sdma_usage"]).rjust(7)
-                print(
-                    "| {0:4.4s}  {1:7.7s}  {2:14.14s}  {3:8.8s}  {4:8.8s}  {5:9.9s}  {6:5.5s}  {7:7.7s} |".format(
-                        gpu_id,
-                        pid,
-                        process_name,
-                        gtt_mem,
-                        vram_mem,
-                        mem_usage,
-                        cu_occupancy,
-                        sdma_usage,
-                    )
-                )
+                print(self._format_process_row(process))
                 if process["name"] == "N/A":
                     elevated_permission_error = True
         else:

--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_kfd.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi_kfd.h
@@ -109,6 +109,7 @@ int ReadKFDDeviceProperties(uint32_t dev_id, std::vector<std::string>* retVec);
 int read_node_properties(uint32_t node, std::string property_name, uint64_t* val);
 int get_gpu_id(uint32_t node, uint64_t* gpu_id);
 
+// Replaces the contents of *out with the KFD GPU ids for pid (clears first).
 int GetKfdGpuIdsForPid(long pid, std::unordered_set<uint64_t>* out);
 
 }  // namespace amd::smi

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
@@ -57,11 +57,18 @@ static const char* kKFDProcPathRoot = "/sys/class/kfd/kfd/proc";
 static const char* kKFDNodesPathRoot = "/sys/class/kfd/kfd/topology/nodes";
 static const char* kKFDVramPrefix = "vram_";
 
-// Check whether a given PID has /dev/kfd open by scanning its fd links.
-static bool PidHasKfdOpen(const std::string& pid_str) {
+// Tri-state result of inspecting a PID's open file descriptors for /dev/kfd.
+// kInaccessible means we could not read /proc/<pid>/fd at all (the process
+// belongs to another user, or exited) — the outcome is unknown, not negative.
+enum class KfdOpenState { kHasKfd, kNoKfd, kInaccessible };
+
+// Inspect a PID's fd links to determine whether it has /dev/kfd open.
+static KfdOpenState PidKfdOpenState(const std::string& pid_str) {
   std::string fd_dir_path = "/proc/" + pid_str + "/fd";
   DIR* fd_dir = opendir(fd_dir_path.c_str());
-  if (!fd_dir) return false;
+  // EACCES/EPERM (another user's process) or ENOENT (process exited) leave the
+  // answer undetermined; callers must not treat this as "no KFD open".
+  if (!fd_dir) return KfdOpenState::kInaccessible;
 
   bool found = false;
   struct dirent* fd_entry;
@@ -79,20 +86,27 @@ static bool PidHasKfdOpen(const std::string& pid_str) {
     }
   }
   closedir(fd_dir);
-  return found;
+  return found ? KfdOpenState::kHasKfd : KfdOpenState::kNoKfd;
+}
+
+// Check whether a given PID definitively has /dev/kfd open.
+static bool PidHasKfdOpen(const std::string& pid_str) {
+  return PidKfdOpenState(pid_str) == KfdOpenState::kHasKfd;
 }
 
 // Detect whether KFD sysfs PIDs are in a different PID namespace from ours.
 // When running inside a container with PID namespace isolation, KFD sysfs
 // reports host PIDs that are not visible in the container's /proc. We detect
 // this by checking numeric entries under kKFDProcPathRoot against /proc.
-// For each KFD PID we check three cases:
+// For each KFD PID we check these cases:
 //   1. PID exists in /proc AND has /dev/kfd open → same namespace (not namespaced).
 //   2. PID exists in /proc but does NOT have /dev/kfd open → different namespace.
 //   3. PID does NOT exist in /proc → inconclusive (process may have exited);
 //      skip to the next entry to avoid a false positive from a short-lived process.
-// If all KFD entries are inconclusive (all exited), we conservatively assume
-// we are not namespaced (the KFD entries will be cleaned up shortly anyway).
+//   4. PID's /proc/<pid>/fd is unreadable (owned by another user) → inconclusive;
+//      permission denial is not evidence of a different namespace, so skip it.
+// If all KFD entries are inconclusive, we conservatively assume we are not
+// namespaced (the KFD entries will be cleaned up shortly anyway).
 // Result is cached for the lifetime of the process; PID namespace is assumed stable.
 static bool IsKfdPidNamespaced() {
   static std::atomic<int> cached{-1};
@@ -120,9 +134,16 @@ static bool IsKfdPidNamespaced() {
       continue;
     }
     // PID exists in /proc; check whether the same process has /dev/kfd open.
-    // If it does, we share the same PID namespace. If not, a different
-    // container-local process coincidentally has the same PID number.
-    if (!PidHasKfdOpen(name)) {
+    KfdOpenState state = PidKfdOpenState(name);
+    if (state == KfdOpenState::kInaccessible) {
+      // /proc/<pid>/fd unreadable (another user's process, e.g. a root-owned
+      // GPU job seen by a non-root caller). Cannot determine namespace from
+      // this entry, so skip it rather than falsely flagging namespaced.
+      continue;
+    }
+    // We could read the fd set: presence of /dev/kfd means same namespace,
+    // absence means a different container-local process reused this PID number.
+    if (state == KfdOpenState::kNoKfd) {
       namespaced = true;
     }
     determined = true;
@@ -130,7 +151,7 @@ static bool IsKfdPidNamespaced() {
   }
   closedir(kfd_dir);
 
-  // If every KFD entry was inconclusive (all processes exited), conservatively
+  // If every KFD entry was inconclusive (exited or unreadable), conservatively
   // assume we are not namespaced — the stale KFD entries will be reaped soon.
   if (!determined) {
     namespaced = false;

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
@@ -98,13 +98,11 @@ static bool PidHasKfdOpen(const std::string& pid_str) {
 // When running inside a container with PID namespace isolation, KFD sysfs
 // reports host PIDs that are not visible in the container's /proc. We detect
 // this by checking numeric entries under kKFDProcPathRoot against /proc.
-// For each KFD PID we check these cases:
-//   1. PID exists in /proc AND has /dev/kfd open → same namespace (not namespaced).
-//   2. PID exists in /proc but does NOT have /dev/kfd open → different namespace.
-//   3. PID does NOT exist in /proc → inconclusive (process may have exited);
-//      skip to the next entry to avoid a false positive from a short-lived process.
-//   4. PID's /proc/<pid>/fd is unreadable (owned by another user) → inconclusive;
-//      permission denial is not evidence of a different namespace, so skip it.
+// For each numeric KFD PID: if it exists in /proc and has /dev/kfd open we
+// share its namespace; if it exists but lacks /dev/kfd, a container-local PID
+// reused the number (namespaced). A PID that is gone (exited) or whose fd dir
+// is unreadable (another user's process) is inconclusive and skipped, so a
+// permission error is never mistaken for namespace isolation.
 // If all KFD entries are inconclusive, we conservatively assume we are not
 // namespaced (the KFD entries will be cleaned up shortly anyway).
 // Result is cached for the lifetime of the process; PID namespace is assumed stable.
@@ -141,8 +139,8 @@ static bool IsKfdPidNamespaced() {
       // this entry, so skip it rather than falsely flagging namespaced.
       continue;
     }
-    // We could read the fd set: presence of /dev/kfd means same namespace,
-    // absence means a different container-local process reused this PID number.
+    // Absence of /dev/kfd here means a container-local process reused this host
+    // PID number, i.e. a different namespace.
     if (state == KfdOpenState::kNoKfd) {
       namespaced = true;
     }

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_kfd.cc
@@ -751,10 +751,34 @@ int GetProcessGPUs(uint32_t pid, std::unordered_set<uint64_t>* gpu_set) {
     closedir(proc_root);
   }
 
-  // if no queues were present, fallback to grab KFD GPU IDs from parent dir names
-  int kfd_ret = GetKfdGpuIdsForPid(pid, gpu_set);
-  if (kfd_ret != 0) {
-    return kfd_ret;
+  // Active queues are the authoritative signal for GPUs a process is actively
+  // running work on. A process can also hold a VRAM allocation on a GPU without
+  // a live queue (e.g. memory staged before/after a kernel), so also attribute
+  // it to any GPU whose per-node vram_<gpuid> file reports a non-zero size.
+  // The stats/counters/sdma per-node files are deliberately not used: opening
+  // /dev/kfd creates them for the whole topology, so they exist (as zero) for
+  // every GPU and would attribute an idle process to all of them.
+  {
+    DIR* pd = opendir(proc_path.c_str());
+    if (pd) {
+      struct dirent* de;
+      while ((de = readdir(pd))) {
+        if (strncmp(de->d_name, kKFDVramPrefix, strlen(kKFDVramPrefix)) != 0) continue;
+        std::string gpu_id_str = de->d_name + strlen(kKFDVramPrefix);
+        if (gpu_id_str.empty() || !is_number(gpu_id_str)) continue;
+
+        std::string vram_bytes;
+        if (ReadSysfsStr(std::string(proc_path) + "/" + de->d_name, &vram_bytes) != 0) continue;
+        try {
+          if (std::stoull(vram_bytes) > 0) {
+            gpu_set->insert(strtoull(gpu_id_str.c_str(), nullptr, 10));
+          }
+        } catch (...) {
+          // Unreadable/garbage size: skip, treat as no allocation.
+        }
+      }
+      closedir(pd);
+    }
   }
 
   // PID namespace: fall back to discovering GPU IDs from KFD vram_* files.

--- a/projects/amdsmi/tests/python/unit/gpu/test_kfd_process_gpus.py
+++ b/projects/amdsmi/tests/python/unit/gpu/test_kfd_process_gpus.py
@@ -66,7 +66,13 @@ def _resolve_process_gpus(proc_dir):
 
 class TestKfdProcessGpuResolution(unittest.TestCase):
     """Regression coverage for processes being reported on every GPU instead of
-    only the GPUs they actually use (active queue or VRAM allocation)."""
+    only the GPUs they actually use (active queue or VRAM allocation).
+
+    This pins the queue/VRAM attribution algorithm as an executable spec. The
+    other-user visibility fix (IsKfdPidNamespaced skipping inaccessible PIDs)
+    lives in a hardcoded-/proc-path C++ path that is validated on hardware
+    (see PR test plan), not reproducible in this hardware-free harness.
+    """
 
     ALL_GPUS = (56179, 9367, 45514, 39772)
 
@@ -113,6 +119,17 @@ class TestKfdProcessGpuResolution(unittest.TestCase):
         # Queue on one GPU, VRAM on another -> both, not all four.
         proc_dir = self._make_proc_dir(queue_gpus=[45514], vram_gpus={9367: 1024})
         self.assertEqual(_resolve_process_gpus(proc_dir), {45514, 9367})
+
+    def test_unreadable_vram_file_is_skipped(self):
+        # A vram_<gpuid> entry that cannot be read must be skipped rather than
+        # attributed, mirroring the C++ `ReadSysfsStr(...) != 0` continue. A
+        # directory in place of the file makes open() fail on any uid (root
+        # included), unlike chmod which root would bypass.
+        proc_dir = self._make_proc_dir(queue_gpus=[])
+        target = os.path.join(proc_dir, f"vram_{self.ALL_GPUS[0]}")
+        os.remove(target)
+        os.makedirs(target)
+        self.assertEqual(_resolve_process_gpus(proc_dir), set())
 
 
 if __name__ == "__main__":

--- a/projects/amdsmi/tests/python/unit/gpu/test_kfd_process_gpus.py
+++ b/projects/amdsmi/tests/python/unit/gpu/test_kfd_process_gpus.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) Advanced Micro Devices. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""KFD process-to-GPU attribution unit tests (hardware-free)."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+import unittest
+
+
+def _resolve_process_gpus(proc_dir):
+    """Resolve the KFD GPU ids a process runs on from its sysfs proc dir.
+
+    Executable spec mirroring GetProcessGPUs() in rocm_smi/src/rocm_smi_kfd.cc
+    (non-container path). A process is attributed to a GPU when it has an active
+    queue on it (queues/<qid>/gpuid) or a non-zero VRAM allocation on it
+    (vram_<gpuid>). The stats_/counters_/sdma_<gpuid> files are deliberately not
+    consulted: opening /dev/kfd creates them (as zero) for every GPU, so using
+    them would attribute an idle process to the whole topology.
+    """
+    gpu_ids = set()
+    queues_dir = os.path.join(proc_dir, "queues")
+    if os.path.isdir(queues_dir):
+        for qid in os.listdir(queues_dir):
+            gpuid_file = os.path.join(queues_dir, qid, "gpuid")
+            try:
+                with open(gpuid_file) as f:
+                    gpu_ids.add(int(f.read().strip()))
+            except (OSError, ValueError):
+                continue
+
+    for name in os.listdir(proc_dir):
+        if not name.startswith("vram_"):
+            continue
+        suffix = name[len("vram_") :]
+        if not suffix.isdigit():
+            continue
+        try:
+            with open(os.path.join(proc_dir, name)) as f:
+                if int(f.read().strip() or "0") > 0:
+                    gpu_ids.add(int(suffix))
+        except (OSError, ValueError):
+            continue
+    return gpu_ids
+
+
+class TestKfdProcessGpuResolution(unittest.TestCase):
+    """Regression coverage for processes being reported on every GPU instead of
+    only the GPUs they actually use (active queue or VRAM allocation)."""
+
+    ALL_GPUS = (56179, 9367, 45514, 39772)
+
+    def _make_proc_dir(self, queue_gpus, vram_gpus=None):
+        """Build a fake KFD proc dir: per-node files on ALL_GPUS (VRAM 0 unless
+        listed in vram_gpus), queues on the subset in queue_gpus."""
+        vram_gpus = vram_gpus or {}
+        proc_dir = tempfile.mkdtemp(prefix="kfd_proc_")
+        self.addCleanup(shutil.rmtree, proc_dir, ignore_errors=True)
+        for gid in self.ALL_GPUS:
+            for prefix in ("stats_", "counters_", "sdma_", "ais_"):
+                open(os.path.join(proc_dir, f"{prefix}{gid}"), "w").close()
+            with open(os.path.join(proc_dir, f"vram_{gid}"), "w") as f:
+                f.write(str(vram_gpus.get(gid, 0)))
+        for idx, gid in enumerate(queue_gpus):
+            qdir = os.path.join(proc_dir, "queues", str(idx))
+            os.makedirs(qdir)
+            with open(os.path.join(qdir, "gpuid"), "w") as f:
+                f.write(str(gid))
+        return proc_dir
+
+    def test_single_queue_gpu_not_reported_on_all(self):
+        # Queues on one GPU, per-node files on all four -> only the queue GPU.
+        proc_dir = self._make_proc_dir(queue_gpus=[45514])
+        self.assertEqual(_resolve_process_gpus(proc_dir), {45514})
+
+    def test_multiple_queue_gpus(self):
+        # Queues on two GPUs -> exactly those two, not all four.
+        proc_dir = self._make_proc_dir(queue_gpus=[45514, 9367])
+        self.assertEqual(_resolve_process_gpus(proc_dir), {45514, 9367})
+
+    def test_no_queues_no_vram_reports_no_gpus(self):
+        # No queues and all VRAM zero -> no GPUs, matching rocm-smi --showpids
+        # (0). Per-node context files must not inflate this to all GPUs.
+        proc_dir = self._make_proc_dir(queue_gpus=[])
+        self.assertEqual(_resolve_process_gpus(proc_dir), set())
+
+    def test_vram_allocation_without_queue_is_attributed(self):
+        # A GPU with a VRAM allocation but no queue is still the process's GPU.
+        proc_dir = self._make_proc_dir(queue_gpus=[], vram_gpus={56179: 271622705152})
+        self.assertEqual(_resolve_process_gpus(proc_dir), {56179})
+
+    def test_queue_and_vram_union(self):
+        # Queue on one GPU, VRAM on another -> both, not all four.
+        proc_dir = self._make_proc_dir(queue_gpus=[45514], vram_gpus={9367: 1024})
+        self.assertEqual(_resolve_process_gpus(proc_dir), {45514, 9367})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/projects/amdsmi/tests/python/unit/gpu/test_process_table_format.py
+++ b/projects/amdsmi/tests/python/unit/gpu/test_process_table_format.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) Advanced Micro Devices. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""Unit tests for the ``amd-smi`` default-output process-table formatting.
+
+Loads the installed ``amdsmi_logger`` with its only non-stdlib dependency
+(``amdsmi_helpers``) stubbed, so the column-alignment logic is exercised
+without GPU hardware or the compiled ``amdsmi`` package. Pins the fix that
+aligned the ``CU %``/``SDMA`` columns and dropped the redundant ``%`` suffix.
+"""
+
+import importlib.util
+import os
+import sys
+import types
+import unittest
+
+from common.common import amdsmi_path
+
+_ROCM_ROOT = os.path.dirname(os.path.dirname(amdsmi_path))
+LOGGER_PATH = os.path.join(_ROCM_ROOT, "libexec", "amdsmi_cli", "amdsmi_logger.py")
+
+# Fixed inner width of the default-output box (between the two '|' borders).
+_BOX_INNER_WIDTH = 78
+
+
+def _install_fake_helpers():
+    """Register a stub ``amdsmi_helpers`` so ``amdsmi_logger`` imports cleanly."""
+    module = types.ModuleType("amdsmi_helpers")
+    module.AMDSMIHelpers = type("AMDSMIHelpers", (), {})
+    sys.modules["amdsmi_helpers"] = module
+
+
+def _load_logger_module():
+    spec = importlib.util.spec_from_file_location("amdsmi_logger_under_test", LOGGER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _process(name="python3", cu=None, sdma="0", gpu="0", pid="12345"):
+    """Build a minimal process dict matching the default-output payload."""
+    if cu is None:
+        cu_occupancy = {"total_num_cu": "N/A", "current_cu": "N/A"}
+    else:
+        cu_occupancy = {"total_num_cu": 100, "current_cu": cu}
+    return {
+        "gpu": gpu,
+        "pid": pid,
+        "name": name,
+        "gtt": "0",
+        "vram": "0",
+        "mem_usage": "0",
+        "cu_occupancy": cu_occupancy,
+        "sdma_usage": sdma,
+    }
+
+
+class TestProcessTableFormat(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.isfile(LOGGER_PATH):
+            raise unittest.SkipTest(f"amdsmi_logger not installed at {LOGGER_PATH}")
+        _install_fake_helpers()
+        cls.logger = _load_logger_module()
+
+    def _assert_boxed(self, line):
+        self.assertTrue(line.startswith("|") and line.endswith("|"), line)
+        self.assertEqual(len(line), _BOX_INNER_WIDTH + 2, f"line width {len(line)}: {line!r}")
+
+    def test_header_fits_box(self):
+        self._assert_boxed(self.logger.AMDSMILogger.PROCESS_TABLE_HEADER)
+
+    def test_row_fits_box(self):
+        row = self.logger.AMDSMILogger._format_process_row(_process())
+        self._assert_boxed(row)
+
+    def test_na_row_fits_box(self):
+        row = self.logger.AMDSMILogger._format_process_row(_process(name="N/A"))
+        self._assert_boxed(row)
+
+    def test_cu_value_has_no_percent_suffix(self):
+        # 12.5% must render as "12.5", not "12.5 %" (which overflowed the column).
+        row = self.logger.AMDSMILogger._format_process_row(_process(cu=12.5))
+        self.assertIn("12.5", row)
+        self.assertNotIn("%", row)
+        self._assert_boxed(row)
+
+    def test_sdma_and_cu_columns_align_with_header(self):
+        # Header labels must sit over the value fields. Locate the value column
+        # spans from the format widths and confirm the header keyword sits there.
+        header = self.logger.AMDSMILogger.PROCESS_TABLE_HEADER
+        # Sentinels chosen to not collide with the fixed pid ("40002") elsewhere.
+        row = self.logger.AMDSMILogger._format_process_row(
+            _process(cu=99.9, sdma="765", pid="40002")
+        )
+        # CU value 99.9 and SDMA value 765 must both be present and sit at or
+        # right of their respective header labels (right-justified in-column).
+        self.assertIn("99.9", row)
+        self.assertIn("765", row)
+        self.assertLessEqual(header.index("CU %"), row.index("99.9"))
+        self.assertLessEqual(header.index("SDMA"), row.index("765"))
+        self._assert_boxed(row)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Three defects in `amd-smi process` (and the process table in default `amd-smi`
output):

1. It could return "No running processes detected" for a caller that lacks
   permission to inspect the running GPU jobs, even though the jobs were clearly
   using the GPUs.
2. The same compute process was reported under **every** GPU, rather than only
   the GPU(s) it actually uses.
3. The compute-process table mis-rendered its `CU %` and `SDMA` columns.

## Technical Details

- `rocm_smi/src/rocm_smi_kfd.cc`
  - `IsKfdPidNamespaced()` inspected the first KFD PID via `PidHasKfdOpen()`,
    which opens `/proc/<pid>/fd`. When that PID belongs to another user, the
    directory is unreadable and the helper returned `false`, which was
    misinterpreted as evidence of a separate PID namespace. Enumeration then
    fell back to scanning `/proc`, where the same unreadable fd set dropped the
    process entirely, so the caller saw an empty list.
  - Add a tri-state `PidKfdOpenState()` distinguishing "has `/dev/kfd` open",
    "definitely does not", and "inaccessible" (another user's process, or the
    process already exited). Permission failures are now treated as inconclusive
    and skipped rather than flagged as namespaced, so such processes are listed
    with a redacted (`N/A`) name instead of disappearing.
  - `GetProcessGPUs()` ran the per-node KFD context-file fallback
    (`GetKfdGpuIdsForPid()`) unconditionally. Opening `/dev/kfd` creates
    `vram_/stats_/counters_/sdma_<gpuid>` files for the whole GPU topology, so a
    job with queues on a single GPU (or none) was attributed to every GPU.
    Attribute a process to a GPU only when it has an active KFD queue on it, or
    a non-zero `vram_<gpuid>` allocation on it. The zero-valued
    `stats_/counters_/sdma_` per-node files are ignored. This lists a process
    against the GPUs it actually uses, aligning with `rocm-smi --showpids`. The
    container (PID-namespace) `vram_*` fallback is unchanged.

- `amdsmi_cli/amdsmi_logger.py`
  - Rebuild the process-table header so labels sit over their right-justified
    value columns (the `SDMA` header was one column too far left), drop the
    redundant `%` suffix from the CU value (the unit is in the `CU %` header),
    and widen `SDMA` to fit its unit by reclaiming two characters from the
    process-name column. The row stays within the fixed 80-character box. The
    row rendering is extracted into `AMDSMILogger._format_process_row` /
    `PROCESS_TABLE_HEADER` so the widths can be unit-tested.

- `tests/python/unit/gpu/`
  - `test_kfd_process_gpus.py`: hardware-free spec pinning the queue + non-zero
    VRAM attribution (including that an unreadable `vram_*` entry is skipped).
  - `test_process_table_format.py`: hardware-free coverage for the process-table
    column widths (80-character box, dropped `%` suffix, header-over-value
    alignment).

## JIRA ID

JIRA ID: AILITOOLS-283
JIRA ID: ROCM-26000

## Test Plan

- On multi-GPU hosts running a compute workload, ran `amd-smi process` and the
  default `amd-smi` process table as a **non-root** user and as **root**, with
  the installed library and with the fixed library, cross-checking against the
  ground-truth KFD queue `gpuid`s in `/sys/class/kfd/kfd/proc/<pid>/queues/` and
  the `vram_<gpuid>` allocations.
- Verified column alignment for both the `N/A` and populated `CU %`/`SDMA` cases.
- Ran the hardware-free unit tests.

## Test Result

- Non-root now lists the root-owned process (previously non-root saw "No running
  processes detected"), with the process name redacted to `N/A`.
- Per-GPU attribution: on multi-GPU MI300 hosts, a job with queues + VRAM on a
  single GPU is now listed only on that GPU (confirmed against RVS on a gfx125X
  host: RVS with queues/VRAM on one GPU appeared under all 4 GPUs before the fix
  and only the correct GPU after, matching `rocm-smi --showpids` GPU(s)=1).
- `CU %` and `SDMA` headers align over their values within the 80-character box;
  valid values are no longer truncated.
- `tests/python/unit/gpu/test_kfd_process_gpus.py` and `test_process_table_format.py`
  pass.
