### PR TITLE
fix(rocjitsu): accept DBT continuation entries

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.cpp
@@ -238,6 +238,33 @@ constexpr uint16_t kTtmpRdna4GridX = 9;
   return std::nullopt;
 }
 
+[[nodiscard]] uint64_t executable_code_range_size(uint64_t text_vaddr, uint64_t text_size,
+                                                  const Elf64_Ehdr &ehdr, const Elf64_Shdr *shdr) {
+  constexpr uint64_t max_u64 = std::numeric_limits<uint64_t>::max();
+  if (text_vaddr > max_u64 - text_size)
+    return 0;
+
+  uint64_t code_end = text_vaddr + text_size;
+
+  // DBT places expansion bodies in .rj_translations and addresses them as a
+  // .text-relative continuation. Include executable sections at or after .text
+  // so a redirected kernel descriptor entry can still be parsed.
+  for (int i = 0; i < ehdr.e_shnum; ++i) {
+    constexpr uint64_t executable_load_flags = SHF_ALLOC | SHF_EXECINSTR;
+    if (shdr[i].sh_type != SHT_PROGBITS)
+      continue;
+    if ((shdr[i].sh_flags & executable_load_flags) != executable_load_flags)
+      continue;
+    if (shdr[i].sh_addr < text_vaddr)
+      continue;
+    if (shdr[i].sh_addr > max_u64 - shdr[i].sh_size)
+      continue;
+    code_end = std::max(code_end, shdr[i].sh_addr + shdr[i].sh_size);
+  }
+
+  return code_end - text_vaddr;
+}
+
 using KernelDescriptorVisitor = std::function<void(uint64_t descriptor_file_offset,
                                                    uint64_t entry_text_offset, const KD &desc)>;
 
@@ -254,10 +281,7 @@ void visit_kernel_descriptors(std::span<const uint8_t> image, uint64_t text_offs
   auto text_vaddr = text_vaddr_for_section(text_offset, text_size, *ehdr, shdr);
   if (!text_vaddr)
     return;
-  constexpr uint64_t max_u64 = std::numeric_limits<uint64_t>::max();
-  if (*text_vaddr > max_u64 - text_size)
-    return;
-  const uint64_t text_end = *text_vaddr + text_size;
+  const uint64_t code_range_size = executable_code_range_size(*text_vaddr, text_size, *ehdr, shdr);
 
   // .symtab and .dynsym may both describe the same descriptor. Translation is
   // keyed by descriptor bytes, so visit each file offset once.
@@ -305,7 +329,7 @@ void visit_kernel_descriptors(std::span<const uint8_t> image, uint64_t text_offs
       if (entry_vaddr_signed < 0)
         continue;
       const uint64_t entry_vaddr = static_cast<uint64_t>(entry_vaddr_signed);
-      if (entry_vaddr < *text_vaddr || entry_vaddr >= text_end)
+      if (entry_vaddr < *text_vaddr || entry_vaddr >= *text_vaddr + code_range_size)
         continue;
 
       const uint64_t entry_text_offset = entry_vaddr - *text_vaddr;

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -3067,3 +3067,30 @@ TEST(KernelDescriptorTranslator, IgnoresNonAllocExecutableSectionsForEntryRange)
   EXPECT_TRUE(translations.empty())
       << "non-loadable executable sections must not extend valid kernel entry range";
 }
+
+TEST(KernelDescriptorTranslator, AcceptsAllocExecutableContinuationForEntryRange) {
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text();
+  const auto ehdr = rocjitsu::read_elf_struct_for_test<rocjitsu::Elf64_Ehdr>(image, 0);
+  auto shdrs =
+      rocjitsu::read_elf_array_for_test<rocjitsu::Elf64_Shdr>(image, ehdr.e_shoff, ehdr.e_shnum);
+
+  constexpr uint64_t continuation_vaddr = 0x9000;
+  shdrs[5].sh_type = rocjitsu::SHT_PROGBITS;
+  shdrs[5].sh_flags = rocjitsu::SHF_ALLOC | rocjitsu::SHF_EXECINSTR;
+  shdrs[5].sh_addr = continuation_vaddr;
+  shdrs[5].sh_size = sizeof(uint32_t);
+  for (size_t i = 0; i < shdrs.size(); ++i)
+    rocjitsu::write_elf_struct_for_test(image, ehdr.e_shoff + i * sizeof(rocjitsu::Elf64_Shdr),
+                                        shdrs[i]);
+
+  rocjitsu::write_kernel_descriptor_entry_offset(image.data() + shdrs[2].sh_offset,
+                                                 static_cast<int64_t>(continuation_vaddr) -
+                                                     static_cast<int64_t>(shdrs[2].sh_addr));
+
+  rocjitsu::KernelDescriptorTranslator translator(ROCJITSU_CODE_ARCH_CDNA4,
+                                                  ROCJITSU_CODE_ARCH_RDNA4);
+  const auto translations = translator.translate_image(
+      image, shdrs[1].sh_offset, shdrs[1].sh_size, rocjitsu::KernelDescriptorTranslationOptions{});
+  ASSERT_EQ(translations.size(), 1u);
+  EXPECT_EQ(translations[0].entry_text_offset, continuation_vaddr - shdrs[1].sh_addr);
+}


### PR DESCRIPTION
ISSUE ID: #6447

## Summary

Split the DBT executable-continuation handling out of #6962 so the CPU-threading PR can remain focused.

### What changed

- Extend kernel-descriptor entry validation across loadable executable `SHT_PROGBITS` sections placed after `.text`.
- Keep non-loadable executable sections outside the accepted entry range.
- Add a positive regression for a descriptor redirected into a `.rj_translations`-style continuation.

### Why

DBT expansion bodies can live after `.text` while retaining `.text`-relative entry offsets. Treating only the original `.text` extent as executable causes those redirected kernel descriptors to be dropped.

## Validation

- `cmake --build build/rocjitsu-dbt-executable-range --target rocjitsu_tests -j16`
- `rocjitsu_tests --gtest_filter='KernelDescriptorTranslator.IgnoresNonAllocExecutableSectionsForEntryRange:KernelDescriptorTranslator.AcceptsAllocExecutableContinuationForEntryRange'`
- `pre-commit run --from-ref origin/develop --to-ref HEAD`
