### PR TITLE
fix(rocprof-sys-python): restore -a annotations dropped by cache replay

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/regions.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/regions.cpp
@@ -25,20 +25,18 @@ namespace
 // must handle arbitrary caller types) these can be dispatched explicitly instead
 // of relying on a generic fmt::is_formattable/fmt::streamed fallback.
 template <typename Tp>
-std::string
+[[nodiscard]] std::string
 annotation_arg_type_name()
 {
     using value_type = std::decay_t<Tp>;
     if constexpr(concepts::is_string_type<value_type>::value)
         return "string";
-    else if constexpr(std::is_pointer<value_type>::value)
-        return "pointer";
     else
         return utility::demangle<value_type>();
 }
 
 template <typename Tp>
-std::string
+[[nodiscard]] std::string
 annotation_arg_value_string(Tp&& _val)
 {
     using value_type = std::decay_t<Tp>;
@@ -46,6 +44,8 @@ annotation_arg_value_string(Tp&& _val)
         return std::string{ std::string_view{ std::forward<Tp>(_val) } };
     else if constexpr(std::is_pointer<value_type>::value)
         return fmt::format("{:#x}", reinterpret_cast<std::uintptr_t>(_val));
+    else if constexpr(std::is_integral<value_type>::value)
+        return fmt::format_int{ _val }.str();
     else
         return fmt::format("{}", std::forward<Tp>(_val));
 }
@@ -64,13 +64,13 @@ append_annotation_arg(function_args_t& _args, const rocprofsys_annotation_t& _an
         using type = tracing::annotation_value_type_t<Idx>;
         if constexpr(std::is_pointer<type>::value)
         {
-            auto _value = reinterpret_cast<type>(_annotation.value);
+            const auto _value = reinterpret_cast<type>(_annotation.value);
             _args.push_back({ _arg_number, annotation_arg_type_name<type>(),
                               _annotation.name, annotation_arg_value_string(_value) });
         }
         else
         {
-            auto* _value = reinterpret_cast<type*>(_annotation.value);
+            const auto* _value = reinterpret_cast<type*>(_annotation.value);
             _args.push_back({ _arg_number, annotation_arg_type_name<type>(),
                               _annotation.name, annotation_arg_value_string(*_value) });
         }
@@ -86,7 +86,7 @@ append_annotation_arg(function_args_t& _args, const rocprofsys_annotation_t& _an
 // rocprofsys_push_category_region) into the trace-cache args wire format, so
 // annotations attached to a region survive cache-replay (Perfetto + rocpd)
 // instead of only appearing on the live-instrumentation path.
-function_args_t
+[[nodiscard]] function_args_t
 annotations_to_function_args(const rocprofsys_annotation_t* _annotations, size_t _count)
 {
     function_args_t _args;
@@ -96,8 +96,8 @@ annotations_to_function_args(const rocprofsys_annotation_t* _annotations, size_t
     for(size_t i = 0; i < _count; ++i)
     {
         const auto& _annotation = _annotations[i];
-        if(_annotation.name == nullptr || _annotation.type == ROCPROFSYS_VALUE_NONE ||
-           _annotation.value == nullptr)
+        if(_annotation.name == nullptr || _annotation.type <= ROCPROFSYS_VALUE_NONE ||
+           _annotation.type >= ROCPROFSYS_VALUE_LAST || _annotation.value == nullptr)
             continue;
 
         append_annotation_arg(

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/regions.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/regions.cpp
@@ -6,6 +6,7 @@
 #include "core/config.hpp"
 #include "library/components/category_region.hpp"
 #include "library/tracing.hpp"
+#include <cstdint>
 
 #if defined(__GNUC__) && (__GNUC__ == 7)
 #    pragma GCC diagnostic push
@@ -18,6 +19,94 @@ namespace impl
 {
 namespace
 {
+// The annotation type enum (ROCPROFSYS_ANNOTATION_TYPE) only ever resolves to the
+// fixed scalar set registered via ROCPROFSYS_DEFINE_ANNOTATION_TYPE in
+// annotation.hpp, so (unlike category_region's gotcha-arg serialization, which
+// must handle arbitrary caller types) these can be dispatched explicitly instead
+// of relying on a generic fmt::is_formattable/fmt::streamed fallback.
+template <typename Tp>
+std::string
+annotation_arg_type_name()
+{
+    using value_type = std::decay_t<Tp>;
+    if constexpr(concepts::is_string_type<value_type>::value)
+        return "string";
+    else if constexpr(std::is_pointer<value_type>::value)
+        return "pointer";
+    else
+        return utility::demangle<value_type>();
+}
+
+template <typename Tp>
+std::string
+annotation_arg_value_string(Tp&& _val)
+{
+    using value_type = std::decay_t<Tp>;
+    if constexpr(concepts::is_string_type<value_type>::value)
+        return std::string{ std::string_view{ std::forward<Tp>(_val) } };
+    else if constexpr(std::is_pointer<value_type>::value)
+        return fmt::format("{:#x}", reinterpret_cast<std::uintptr_t>(_val));
+    else
+        return fmt::format("{}", std::forward<Tp>(_val));
+}
+
+template <size_t Idx, size_t... Tail>
+void
+append_annotation_arg(function_args_t& _args, const rocprofsys_annotation_t& _annotation,
+                      std::uint32_t _arg_number, std::index_sequence<Idx, Tail...>)
+{
+    static_assert(Idx > ROCPROFSYS_VALUE_NONE && Idx < ROCPROFSYS_VALUE_LAST,
+                  "Error! index sequence should only contain values which are greater "
+                  "than ROCPROFSYS_VALUE_NONE and less than ROCPROFSYS_VALUE_LAST");
+
+    if(_annotation.type == Idx)
+    {
+        using type = tracing::annotation_value_type_t<Idx>;
+        if constexpr(std::is_pointer<type>::value)
+        {
+            auto _value = reinterpret_cast<type>(_annotation.value);
+            _args.push_back({ _arg_number, annotation_arg_type_name<type>(),
+                              _annotation.name, annotation_arg_value_string(_value) });
+        }
+        else
+        {
+            auto* _value = reinterpret_cast<type*>(_annotation.value);
+            _args.push_back({ _arg_number, annotation_arg_type_name<type>(),
+                              _annotation.name, annotation_arg_value_string(*_value) });
+        }
+    }
+    else if constexpr(sizeof...(Tail) > 0)
+    {
+        append_annotation_arg(_args, _annotation, _arg_number,
+                              std::index_sequence<Tail...>{});
+    }
+}
+
+// Converts a rocprofsys_annotation_t array (as passed to
+// rocprofsys_push_category_region) into the trace-cache args wire format, so
+// annotations attached to a region survive cache-replay (Perfetto + rocpd)
+// instead of only appearing on the live-instrumentation path.
+function_args_t
+annotations_to_function_args(const rocprofsys_annotation_t* _annotations, size_t _count)
+{
+    function_args_t _args;
+    if(_annotations == nullptr || _count == 0) return _args;
+
+    _args.reserve(_count);
+    for(size_t i = 0; i < _count; ++i)
+    {
+        const auto& _annotation = _annotations[i];
+        if(_annotation.name == nullptr || _annotation.type == ROCPROFSYS_VALUE_NONE ||
+           _annotation.value == nullptr)
+            continue;
+
+        append_annotation_arg(
+            _args, _annotation, static_cast<std::uint32_t>(_args.size()),
+            utility::make_index_sequence_range<1, ROCPROFSYS_VALUE_LAST>{});
+    }
+    return _args;
+}
+
 template <size_t Idx, size_t... Tail>
 void
 invoke_category_region_start(rocprofsys_category_t _category, const char* name,
@@ -43,6 +132,17 @@ invoke_category_region_start(rocprofsys_category_t _category, const char* name,
                         tracing::add_perfetto_annotation(ctx, _annotations[i]);
                 }
             });
+
+        // Cache the annotations into the trace-cache args wire format so
+        // cache-replay handlers (perfetto + rocpd) re-emit them. The lambda
+        // above only reaches the live-instrumentation output, which the final
+        // trace does not use when cache replay is active.
+        if(_annotations != nullptr && _annotation_count > 0)
+        {
+            component::category_region<category_type>::append_cache_args(
+                name, get_args_string(
+                          annotations_to_function_args(_annotations, _annotation_count)));
+        }
     }
     else
     {

--- a/projects/rocprofiler-systems/tests/pytest/test_python.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_python.py
@@ -38,6 +38,14 @@ def python_builtin_rocpd_rules(validation_rules_dir: Path) -> list[Path]:
     ]
 
 
+@pytest.fixture
+def python_builtin_annotated_rocpd_rules(validation_rules_dir: Path) -> list[Path]:
+    rules_dir = validation_rules_dir / "python"
+    return [
+        rules_dir / "python-builtin-annotated-rules.json",
+    ]
+
+
 @pytest.fixture(scope="session")
 def get_cat_command() -> list[str]:
     """Get a command to concatenate files (like Unix cat).
@@ -117,6 +125,17 @@ class TestPython(RocprofsysTest):
         "depths": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1],
     }
 
+    # Per-function debug annotations that -a/--annotate-trace attaches to every
+    # profiled python region (see libpyrocprofsys.cpp's config::annotations).
+    PYTHON_ANNOTATE_DEBUG_KEYS = [
+        "file",
+        "line",
+        "lasti",
+        "argcount",
+        "nlocals",
+        "stacksize",
+    ]
+
     @pytest.mark.timeout(120)
     @pytest.mark.parametrize(
         "annotated, exclude",
@@ -165,11 +184,18 @@ class TestPython(RocprofsysTest):
         "annotated",
         [
             pytest.param(False, marks=pytest.mark.rocpd("python_rocpd_env")),
-            pytest.param(True, id="annotated"),
+            pytest.param(
+                True, id="annotated", marks=pytest.mark.rocpd("python_rocpd_env")
+            ),
         ],
     )
     def test_builtin(
-        self, python_version, annotated, python_rocpd_env, python_builtin_rocpd_rules
+        self,
+        python_version,
+        annotated,
+        python_rocpd_env,
+        python_builtin_rocpd_rules,
+        python_builtin_annotated_rocpd_rules,
     ):
         result = self.run_test(
             "python",
@@ -204,6 +230,29 @@ class TestPython(RocprofsysTest):
             self.assert_rocpd(
                 result,
                 rules_files=python_builtin_rocpd_rules,
+            )
+            # regression: without -a, no per-function debug annotations should
+            # reach the trace (see test below for the annotated=True counterpart)
+            self.assert_perfetto(
+                result,
+                key_names=self.PYTHON_ANNOTATE_DEBUG_KEYS,
+                key_counts=[0] * len(self.PYTHON_ANNOTATE_DEBUG_KEYS),
+            )
+        else:
+            # regression: -a/--annotate-trace annotations were dropped by
+            # trace-cache replay (only debug.begin_ns/debug.corr_id ever reached
+            # the perfetto trace, identical with or without -a). Every profiled
+            # python region carries all six annotation fields, so each key's
+            # count must equal the total number of profiled slices.
+            total_slices = sum(self.PYTHON_BUILTIN_GENERAL["counts"])
+            self.assert_perfetto(
+                result,
+                key_names=self.PYTHON_ANNOTATE_DEBUG_KEYS,
+                key_counts=[total_slices] * len(self.PYTHON_ANNOTATE_DEBUG_KEYS),
+            )
+            self.assert_rocpd(
+                result,
+                rules_files=python_builtin_annotated_rocpd_rules,
             )
 
     @pytest.mark.timeout(120)

--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/python/python-builtin-annotated-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/python/python-builtin-annotated-rules.json
@@ -1,0 +1,66 @@
+{
+    "required_tables": [
+        {
+            "commit": "Validation rules for python-builtin -a/--annotate-trace regression test",
+            "name": "region_args",
+            "required_columns": [
+                "id",
+                "guid",
+                "name",
+                "type",
+                "value"
+            ],
+            "validation_queries": [
+                {
+                    "comparison": "equals",
+                    "description": "Verify 'file' annotation reaches rocpd for every profiled region (5+5+10+20+40+80+160+260+220+80+10+5 = 895 slices).",
+                    "error_message": "'file' annotation arg count does not match the total profiled region count.",
+                    "expected_result": 895,
+                    "query": "SELECT COUNT(*) FROM region_args WHERE name = 'file';"
+                },
+                {
+                    "comparison": "equals",
+                    "description": "Verify 'line' annotation reaches rocpd for every profiled region.",
+                    "error_message": "'line' annotation arg count does not match the total profiled region count.",
+                    "expected_result": 895,
+                    "query": "SELECT COUNT(*) FROM region_args WHERE name = 'line';"
+                },
+                {
+                    "comparison": "equals",
+                    "description": "Verify 'lasti' annotation reaches rocpd for every profiled region.",
+                    "error_message": "'lasti' annotation arg count does not match the total profiled region count.",
+                    "expected_result": 895,
+                    "query": "SELECT COUNT(*) FROM region_args WHERE name = 'lasti';"
+                },
+                {
+                    "comparison": "equals",
+                    "description": "Verify 'argcount' annotation reaches rocpd for every profiled region.",
+                    "error_message": "'argcount' annotation arg count does not match the total profiled region count.",
+                    "expected_result": 895,
+                    "query": "SELECT COUNT(*) FROM region_args WHERE name = 'argcount';"
+                },
+                {
+                    "comparison": "equals",
+                    "description": "Verify 'nlocals' annotation reaches rocpd for every profiled region.",
+                    "error_message": "'nlocals' annotation arg count does not match the total profiled region count.",
+                    "expected_result": 895,
+                    "query": "SELECT COUNT(*) FROM region_args WHERE name = 'nlocals';"
+                },
+                {
+                    "comparison": "equals",
+                    "description": "Verify 'stacksize' annotation reaches rocpd for every profiled region.",
+                    "error_message": "'stacksize' annotation arg count does not match the total profiled region count.",
+                    "expected_result": 895,
+                    "query": "SELECT COUNT(*) FROM region_args WHERE name = 'stacksize';"
+                },
+                {
+                    "comparison": "equals",
+                    "description": "Verify 'file' annotation args are typed as string.",
+                    "error_message": "'file' annotation arg type is not 'string' as expected.",
+                    "expected_result": "string",
+                    "query": "SELECT DISTINCT type FROM region_args WHERE name = 'file';"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION

## Motivation

- `rocprof-sys-python --help` advertises `-a`/`--annotate-trace` ("Add detailed annotations to the trace"), but passing it silently produced a Perfetto trace that was byte-for-byte equivalent to a run without it. No error, no warning, just a documented flag doing nothing.

## Technical Details

- The Perfetto trace is no longer written by the live instrumentation path; it's rebuilt during finalization from cached region_sample` records (`cache_manager::post_process_bulk`). The `-a` flag passes a `rocprofsys_annotation_t*` array into `rocprofsys_push_category_region`, and `regions.cpp`'s `invoke_category_region_start` turned that array into a Perfetto `EventContext` lambda for the *live* path only, hence, it was never serialized into the trace-cache args wire format, so cache replay reconstructed each region with empty args regardless of `-a`.

- PR #7618 fixed the equivalent problem for gotcha args (e.g. `pthread_create`) by routing them through `append_cache_args`, but left the annotation-array path which is used by `rocprof-sys-python -a`, and any other C-API caller passing annotations.

- This PR adds a small converter in `regions.cpp` that turns the annotation array into the same `function_args_t` wire format and routes it through the existing `append_cache_args` channel, so `perfetto_processor_t::handle(region_sample)` and `rocpd_processor_t::handle(region_sample)`, which already re-emit `args_str`, pick it up on replay. 

## JIRA ID

Resolves AIPROFSYST-579

## Test Plan

- Strengthened `tests/pytest/test_python.py::TestPython::test_builtin` so the `annotated=True`/`False` parametrization actually asserts something: the six per-function debug keys (`file`, `line`, `lasti`, `argcount`, `nlocals`, `stacksize`) are present with the expected count when `-a` is passed, and absent (count 0) otherwise — for both the Perfetto trace and `rocpd.db`.
- Added `tests/rocpd-validation-rules/python/python-builtin-annotated-rules.json` validating the same six annotations land in `rocpd.db`'s `region_args` table with correct types.
- Verified fail-before/pass-after: stashed the fix, reran the strengthened tests, confirmed they fail with "0 entries" where 895 were expected; restored the fix and confirmed they pass.
- Manually reproduced the original report's exact repro workload and inspected the resulting `.proto` with Perfetto's `trace_processor`.
- Ran the full `rocprof-sys-unit-tests` binary and the full `test_python.py`/`test_annotate.py` pytest suites to check for regressions.

## Test Result

- Manual repro: annotated run now has 8 distinct `debug.*` keys (`begin_ns`, `corr_id`, `file`, `line`, `lasti`, `argcount`, `nlocals`, `stacksize`) vs. 2 before the fix; non-annotated run unchanged at 2 keys.
- `rocprof-sys-unit-tests`: 1062/1062 passed (unchanged from baseline).
- `test_python.py`: 9/9 tests, 22/22 subtests passed.
- `test_annotate.py` (native-tool annotation path): unaffected, all passing.


## Before/After

- Before fix when annotation was set we would still get the output that looked like this:
<img width="1548" height="208" alt="image" src="https://github.com/user-attachments/assets/6e372a3c-ad24-44c9-8502-100d99cf3d2f" />

- After applying the fix the annotations are clearly visible in the slice:
<img width="1568" height="295" alt="image" src="https://github.com/user-attachments/assets/9b820d4b-606d-4320-afa6-b617c96be0d8" />


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
