### PR TITLE
[CLR] Fix hipMemUnmap segfault on multi-GPU: guard null device memory…

### DIFF
--- a/projects/clr/rocclr/device/pal/paldevice.cpp
+++ b/projects/clr/rocclr/device/pal/paldevice.cpp
@@ -2662,7 +2662,8 @@ bool Device::GetMemAccess(void* va_addr, VmmAccess* access_flags_ptr) const {
   // a side effect and can return nullptr, which was dereferenced below and crashed.
   device::Memory* phys_dev_mem = phys_mem_obj->getDeviceMemory(*this, false);
   if (phys_dev_mem == nullptr) {
-    // This device does not back the allocation; report no access rather than crashing.
+    LogPrintfError("Cannot find physical memory object for virtual address: 0x%x for device
+                    index: %d \n", va_addr, index());
     return false;
   }
   device::Memory::MemAccess mem_access = phys_dev_mem->GetAccess();

--- a/projects/clr/rocclr/device/pal/paldevice.cpp
+++ b/projects/clr/rocclr/device/pal/paldevice.cpp
@@ -2656,7 +2656,15 @@ bool Device::GetMemAccess(void* va_addr, VmmAccess* access_flags_ptr) const {
     return false;
   }
 
-  device::Memory* phys_dev_mem = phys_mem_obj->getDeviceMemory(*this);
+  // Query this device's backing without allocating. On multi-GPU the same VA can be
+  // probed on a device that does not physically back the allocation (e.g. hipMemUnmap
+  // iterates every device); getDeviceMemory() would otherwise attempt an allocation as
+  // a side effect and can return nullptr, which was dereferenced below and crashed.
+  device::Memory* phys_dev_mem = phys_mem_obj->getDeviceMemory(*this, false);
+  if (phys_dev_mem == nullptr) {
+    // This device does not back the allocation; report no access rather than crashing.
+    return false;
+  }
   device::Memory::MemAccess mem_access = phys_dev_mem->GetAccess();
   *access_flags_ptr = static_cast<VmmAccess>(mem_access);
 

--- a/projects/clr/rocclr/device/pal/paldevice.cpp
+++ b/projects/clr/rocclr/device/pal/paldevice.cpp
@@ -2658,13 +2658,19 @@ bool Device::GetMemAccess(void* va_addr, VmmAccess* access_flags_ptr) const {
 
   // Query this device's backing without allocating. On multi-GPU the same VA can be
   // probed on a device that does not physically back the allocation (e.g. hipMemUnmap
-  // iterates every device); getDeviceMemory() would otherwise attempt an allocation as
-  // a side effect and can return nullptr, which was dereferenced below and crashed.
+  // iterates every device, or hipMemGetAccess queries a non-owning device). Passing
+  // alloc=false avoids an allocate-on-query side effect; getDeviceMemory() would
+  // otherwise return nullptr for such a device, which was dereferenced below and crashed.
   device::Memory* phys_dev_mem = phys_mem_obj->getDeviceMemory(*this, false);
   if (phys_dev_mem == nullptr) {
-    LogPrintfError("Cannot find physical memory object for virtual address: 0x%x for device
-                    index: %d \n", va_addr, index());
-    return false;
+    // The VA is a valid mapped allocation, it is just not backed on this device, so it
+    // has no access here. Report "no access" (not an error) to match the documented
+    // hipMemGetAccess semantics (Unit_hipMemSetAccess_SetGet expects ProtNone for a
+    // device without access) and to keep the hipMemUnmap probe loop working.
+    LogPrintfInfo("Virtual address 0x%x is not backed on device index %d; reporting no access\n",
+                  va_addr, index());
+    *access_flags_ptr = static_cast<VmmAccess>(device::Memory::MemAccess::kMemAccessNone);
+    return true;
   }
   device::Memory::MemAccess mem_access = phys_dev_mem->GetAccess();
   *access_flags_ptr = static_cast<VmmAccess>(mem_access);


### PR DESCRIPTION
… in PAL GetMemAccess.

## Motivation

hipMemUnmap segfaults on Windows with 2 GPUs while passing with 1 GPU. Crash occurs inside pal::Device::GetMemAccess during the multi-device access-probe loop added for synchronous unmap.

## Technical Details

hipMemUnmap segfaults on Windows with 2 GPUs while passing with 1 GPU. Crash occurs inside pal::Device::GetMemAccess during the multi-device access-probe loop added for synchronous unmap.

## JIRA ID

ROCM-27508

## Test Plan

Seg faulting failures from reported tests.
        830 - Unit_hipMemVmm_Uncached (SEGFAULT)
        1141 - Unit_hipPointerGetAttribute_ipc_capable (SEGFAULT)
        2484 - Unit_hipMemRetainAllocationHandle_SetGet (SEGFAULT)
        2485 - Unit_hipMemRetainAllocationHandle_NegTst (SEGFAULT)
        2486 - Unit_hipMemRetainAllocationHandle_Capture (SEGFAULT)
        2487 - Unit_hipGetProcAddress_VMM (SEGFAULT)
        2492 - Unit_hipMemCreate_ChkDev2HstMemcpy_ReleaseHdlPostUnmap (SEGFAULT)
        2493 - Unit_hipMemCreate_ChkDev2HstMemcpy_ReleaseHdlPreUse (SEGFAULT)
        2494 - Unit_hipMemCreate_ChkWithMemset (SEGFAULT)
        2497 - Unit_hipMemSetAccess_SegmentsAccess (SEGFAULT)
        2498 - Unit_hipMemSetAccess_Vmm2PeerPeerMemCpy (SEGFAULT)
        2499 - Unit_hipMemSetGetAccess_Capture (SEGFAULT)
        2503 - Unit_hipMemMap_VMMMemoryReuse_SingleGPU (SEGFAULT)
        2504 - Unit_hipMemMap_MapPartialVMMMem (SEGFAULT)
        2505 - Unit_hipMemMap_Capture (SEGFAULT)
        2507 - Unit_hipMemMap_Retrieve_AllocationHandle (SEGFAULT)
        2508 - Unit_hipMemMap_Retrieve_MultiAllocationHandle (SEGFAULT)
        2509 - Unit_hipMemMap_CheckAddMemObj (SEGFAULT)
        2510 - Unit_hipMemMap_RoundTrip (SEGFAULT)
        2511 - Unit_hipMemMap_ConcurrentDisjointMapsNoDeadlock (SEGFAULT)
        2514 - Unit_hipMemUnmap_negative (SEGFAULT)
        2515 - Unit_hipMemUnmap_Capture (SEGFAULT)
        2516 - Unit_hipMemUnmap_CrossLinksTornDown (SEGFAULT)
        2517 - Unit_hipMemUnmap_RemapCrossLinks (SEGFAULT)
        2518 - Unit_hipMemUnmap_DirectPath_BasicRoundTrip (SEGFAULT)
        2519 - Unit_hipMemUnmap_DirectPath_InFlightKernelDrained (SEGFAULT)

## Test Result

Seg faulting failures from reported tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
