### PR TITLE
fix(rocjpeg): bind VA-API/VCN decode to the requested GPU by PCI BDF

### DIFF
--- a/projects/rocjpeg/src/rocjpeg_decoder.cpp
+++ b/projects/rocjpeg/src/rocjpeg_decoder.cpp
@@ -88,7 +88,10 @@ RocJpegStatus RocJpegDecoder::InitializeDecoder() {
     }
     if (backend_ == ROCJPEG_BACKEND_HARDWARE) {
         std::string gpu_uuid(hip_dev_prop_.uuid.bytes, sizeof(hip_dev_prop_.uuid.bytes));
-        rocjpeg_status = jpeg_vaapi_decoder_.InitializeDecoder(hip_dev_prop_.name, device_id_, gpu_uuid);
+        char pci_bus_id[64] = {0};
+        CHECK_HIP(hipDeviceGetPCIBusId(pci_bus_id, sizeof(pci_bus_id), device_id_));
+        std::string gpu_pci_bdf(pci_bus_id);
+        rocjpeg_status = jpeg_vaapi_decoder_.InitializeDecoder(hip_dev_prop_.name, device_id_, gpu_uuid, gpu_pci_bdf);
         if (rocjpeg_status != ROCJPEG_STATUS_SUCCESS) {
             CriticalLog(g_rocjpeg_logger, "Failed to initialize the VA-API JPEG decoder!");
             FunctionExitLog(g_rocjpeg_logger);

--- a/projects/rocjpeg/src/rocjpeg_vaapi_decoder.cpp
+++ b/projects/rocjpeg/src/rocjpeg_vaapi_decoder.cpp
@@ -22,6 +22,10 @@ THE SOFTWARE.
 
 #include "rocjpeg_vaapi_decoder.h"
 
+#include <algorithm>
+#include <cctype>
+#include <stdlib.h>
+
 /**
  * @brief Default constructor for RocJpegVaapiMemoryPool class.
  *
@@ -386,22 +390,59 @@ RocJpegVappiDecoder::~RocJpegVappiDecoder() {
  *
  * @param device_name The name of the device.
  * @param device_id The ID of the device.
- * @param gpu_uuid The UUID of the GPU.
+ * @param gpu_uuid The GPU UUID (fallback match).
+ * @param gpu_pci_bdf The GPU PCI BDF (primary match).
  * @return The status of the initialization process.
  */
-RocJpegStatus RocJpegVappiDecoder::InitializeDecoder(std::string device_name, int device_id, std::string& gpu_uuid) {
+RocJpegStatus RocJpegVappiDecoder::InitializeDecoder(const std::string& device_name, int device_id, const std::string& gpu_uuid, const std::string& gpu_pci_bdf) {
     device_id_ = device_id;
     std::vector<int> visible_devices;
     GetVisibleDevices(visible_devices);
     GetGpuUuids();
 
+    // Match by PCI BDF (consistent between HIP and sysfs), with unique_id as fallback.
+    std::string gpu_pci_bdf_lower = gpu_pci_bdf;
+    std::transform(gpu_pci_bdf_lower.begin(), gpu_pci_bdf_lower.end(), gpu_pci_bdf_lower.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    // Drop the PCI function suffix so partition children match their base BDF (offset picks the child).
+    size_t gpu_pci_bdf_dot_pos = gpu_pci_bdf_lower.find_last_of('.');
+    if (gpu_pci_bdf_dot_pos != std::string::npos) {
+        gpu_pci_bdf_lower = gpu_pci_bdf_lower.substr(0, gpu_pci_bdf_dot_pos);
+    }
+
     int offset = 0;
-    ComputePartition current_compute_partition = (gpu_uuids_to_compute_partition_map_.find(gpu_uuid) != gpu_uuids_to_compute_partition_map_.end()) ? gpu_uuids_to_compute_partition_map_[gpu_uuid] : kSpx;
+    ComputePartition current_compute_partition = kSpx;
+    auto bdf_partition_it = gpu_pci_bdf_to_compute_partition_map_.find(gpu_pci_bdf_lower);
+    if (bdf_partition_it != gpu_pci_bdf_to_compute_partition_map_.end()) {
+        current_compute_partition = bdf_partition_it->second;
+    } else {
+        auto uuid_partition_it = gpu_uuids_to_compute_partition_map_.find(gpu_uuid);
+        if (uuid_partition_it != gpu_uuids_to_compute_partition_map_.end()) {
+            current_compute_partition = uuid_partition_it->second;
+        }
+    }
     GetDrmNodeOffset(device_name, device_id_, visible_devices, current_compute_partition, offset);
 
-    std::string drm_node = "/dev/dri/renderD";
-    int render_node_id = (gpu_uuids_to_render_nodes_map_.find(gpu_uuid) != gpu_uuids_to_render_nodes_map_.end()) ? gpu_uuids_to_render_nodes_map_[gpu_uuid] : 128;
-    drm_node += std::to_string(render_node_id + offset);
+    int render_node_id = -1;
+    auto bdf_render_it = gpu_pci_bdf_to_render_nodes_map_.find(gpu_pci_bdf_lower);
+    if (bdf_render_it != gpu_pci_bdf_to_render_nodes_map_.end()) {
+        render_node_id = bdf_render_it->second;
+    } else {
+        auto uuid_render_it = gpu_uuids_to_render_nodes_map_.find(gpu_uuid);
+        if (uuid_render_it != gpu_uuids_to_render_nodes_map_.end()) {
+            render_node_id = uuid_render_it->second;
+        }
+    }
+
+    std::string drm_node;
+    if (render_node_id >= 0) {
+        drm_node = "/dev/dri/renderD" + std::to_string(render_node_id + offset);
+    } else {
+        drm_node = GetFirstAvailableDrmNode();
+        if (drm_node.empty()) {
+            drm_node = "/dev/dri/renderD128";
+        }
+    }
 
     if (g_rocjpeg_logger.GetLogLevel() >= kRocJpegLogInfo) {
         std::ostringstream oss;
@@ -415,6 +456,8 @@ RocJpegStatus RocJpegVappiDecoder::InitializeDecoder(std::string device_name, in
         oss << '}';
         InfoLog(g_rocjpeg_logger, "gpu_uuids_to_render_nodes_map_: " + oss.str());
         InfoLog(g_rocjpeg_logger, "Selected GPU UUID: " + gpu_uuid);
+        InfoLog(g_rocjpeg_logger, "Selected GPU BDF: " + gpu_pci_bdf_lower);
+        InfoLog(g_rocjpeg_logger, "Selected DRM node: " + drm_node);
     }
 
     CHECK_ROCJPEG(InitVAAPI(drm_node));
@@ -1085,6 +1128,10 @@ void RocJpegVappiDecoder::GetGpuUuids() {
                 std::string sys_device_path = "/sys/class/drm/" + filename + "/device";
                 struct stat info;
                 if (stat(sys_device_path.c_str(), &info) == 0) {
+                    std::string bus_id = GetRenderNodeBusId(filename);
+                    if (!bus_id.empty()) {
+                        gpu_pci_bdf_to_render_nodes_map_[bus_id] = render_id;
+                    }
                     std::string unique_id_path = sys_device_path + "/unique_id";
                     std::ifstream unique_id_file(unique_id_path);
                     std::string unique_id;
@@ -1115,6 +1162,9 @@ void RocJpegVappiDecoder::GetGpuUuids() {
                                 }
                                 // Map the unique GPU UUID to the compute partition
                                 gpu_uuids_to_compute_partition_map_[unique_id] = current_compute_partition;
+                                if (!bus_id.empty()) {
+                                    gpu_pci_bdf_to_compute_partition_map_[bus_id] = current_compute_partition;
+                                }
                             }
                         }
                         partition_file.close();
@@ -1124,4 +1174,55 @@ void RocJpegVappiDecoder::GetGpuUuids() {
         }
         closedir(dir);
     }
+}
+
+// Returns the lowercased PCI BDF (function suffix stripped) for a render node, or "" if not a PCI device.
+std::string RocJpegVappiDecoder::GetRenderNodeBusId(const std::string& render_node_name) {
+    std::string device_link = "/sys/class/drm/" + render_node_name + "/device";
+    char* resolved = realpath(device_link.c_str(), nullptr);
+    if (resolved == nullptr) {
+        return "";
+    }
+    std::string path(resolved);
+    free(resolved);
+    size_t pos = path.find_last_of('/');
+    std::string bus_id = (pos == std::string::npos) ? path : path.substr(pos + 1);
+    if (bus_id.find(':') == std::string::npos || bus_id.find('.') == std::string::npos) {
+        return "";
+    }
+    std::transform(bus_id.begin(), bus_id.end(), bus_id.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    size_t dot_pos = bus_id.find_last_of('.');
+    if (dot_pos != std::string::npos) {
+        bus_id = bus_id.substr(0, dot_pos);
+    }
+    return bus_id;
+}
+
+// Returns the lowest-numbered /dev/dri/renderD* node, or "" if none.
+std::string RocJpegVappiDecoder::GetFirstAvailableDrmNode() {
+    std::string dri_path = "/dev/dri";
+    DIR* dir = opendir(dri_path.c_str());
+    if (!dir) {
+        return "";
+    }
+    int min_render_id = -1;
+    struct dirent* entry;
+    while ((entry = readdir(dir)) != nullptr) {
+        std::string filename = entry->d_name;
+        if (filename.find("renderD") == 0 && filename.size() > 7) {
+            try {
+                int render_id = std::stoi(filename.substr(7));
+                if (min_render_id < 0 || render_id < min_render_id) {
+                    min_render_id = render_id;
+                }
+            } catch (...) {
+            }
+        }
+    }
+    closedir(dir);
+    if (min_render_id < 0) {
+        return "";
+    }
+    return "/dev/dri/renderD" + std::to_string(min_render_id);
 }

--- a/projects/rocjpeg/src/rocjpeg_vaapi_decoder.h
+++ b/projects/rocjpeg/src/rocjpeg_vaapi_decoder.h
@@ -279,10 +279,11 @@ public:
      * @brief Initializes the decoder with the specified device, GCN architecture, and device ID.
      * @param device_name The name of the device.
      * @param device_id The ID of the device.
-     * @param gpu_uuid The UUID of the GPU.
+     * @param gpu_uuid The GPU UUID (fallback match).
+     * @param gpu_pci_bdf The GPU PCI BDF (primary match).
      * @return The status of the initialization.
      */
-    RocJpegStatus InitializeDecoder(std::string device_name, int device_id, std::string& gpu_uuid);
+    RocJpegStatus InitializeDecoder(const std::string& device_name, int device_id, const std::string& gpu_uuid, const std::string& gpu_pci_bdf);
 
     /**
      * @brief Submits a JPEG stream for decoding.
@@ -371,6 +372,10 @@ private:
      * partitions based on the unique identifiers of GPUs.
      */
     std::unordered_map<std::string, ComputePartition> gpu_uuids_to_compute_partition_map_;
+
+    // GPU PCI BDF -> render node index / compute partition (primary match key).
+    std::unordered_map<std::string, int> gpu_pci_bdf_to_render_nodes_map_;
+    std::unordered_map<std::string, ComputePartition> gpu_pci_bdf_to_compute_partition_map_;
     /**
      * @brief Initializes the VAAPI with the specified DRM node.
      * @param drm_node The DRM node to use for VAAPI initialization.
@@ -418,9 +423,15 @@ private:
                                     ComputePartition current_compute_partitions,
                                     int &offset);
     /**
-     * @brief Retrieves GPU UUIDs and maps them to render node IDs.
+     * @brief Retrieves GPU UUIDs and PCI bus IDs and maps them to render node IDs and compute partitions.
     */
     void GetGpuUuids();
+
+    // Returns the lowercased PCI BDF (function suffix stripped) for a render node, or "" if not a PCI device.
+    std::string GetRenderNodeBusId(const std::string& render_node_name);
+
+    // Returns the lowest-numbered /dev/dri/renderD* node, or "" if none.
+    std::string GetFirstAvailableDrmNode();
 
     /**
      * @brief Retrieves the number of JPEG cores available.


### PR DESCRIPTION
## Summary
On architectures where the HIP device UUID (`hipDeviceProp_t.uuid`) and the amdgpu sysfs `unique_id` come from different namespaces (observed on **gfx950 / MI355X**), `RocJpegVappiDecoder::InitializeDecoder` never finds a match in `gpu_uuids_to_render_nodes_map_` (the map is keyed by `unique_id` but looked up by the HIP UUID) and hard-falls-back to `renderD128`. As a result **every `rocJpegCreate(HARDWARE, device_id)`, for any `device_id`, binds the VCN/JPEG decoder to `renderD128` = GPU 0** — all hardware JPEG decode is funneled onto a single GPU.

## Root cause
- `rocjpeg_decoder.cpp` builds the lookup key from the HIP UUID: `std::string gpu_uuid(hip_dev_prop_.uuid.bytes, ...)`.
- `rocjpeg_vaapi_decoder.cpp` `GetGpuUuids()` keys the map by the sysfs `unique_id`, and `InitializeDecoder()` does `render_node_id = map.count(gpu_uuid) ? map[gpu_uuid] : 128`.
- On gfx950 the two ID namespaces are disjoint, so the lookup always misses → `renderD128` (GPU 0).

## Fix
Select the DRM render node by matching the device's **PCI bus ID (BDF)** via `hipDeviceGetPCIBusId` &harr; `/sys/class/drm/renderD*/device`, which is consistent between the HIP runtime and the amdgpu sysfs nodes. The `unique_id` match is kept as a fallback (no behavior change where it already works, e.g. gfx942), and when nothing matches the first available render node is used instead of hard-coding `renderD128` (this also lets single-GPU containers that expose a non-default render node work).

## Relationship to prior work
This is the proper resolution of the issue #7349 tried to address by erroring out (`Error on GPU UUID mismatch instead of silently using wrong render node`), which was reverted in #7444 (issue #7442) because erroring broke `rocJpegCreate` for affected users. Matching by BDF binds to the **correct** GPU without erroring — it neither silently uses the wrong node nor fails initialization.

## Testing (8x AMD Instinct MI355X, gfx950, ROCm 7.2)
Built the `projects/rocjpeg` library (rocJPEG 1.6.0) from this branch and validated with per-GPU `amdgpu_fence_info` `jpeg_dec_*` counters (co-tenant-immune):
- Before (unmodified develop): decode requested on `cuda:0` / `cuda:4` / `cuda:7` &rarr; JPEG-ring activity all on **GPU 0**.
- After (this change): `cuda:0` &rarr; GPU 0, `cuda:4` &rarr; GPU 4, `cuda:7` &rarr; GPU 7; 8 concurrent decoders spread across all 8 GPUs.
- Output is byte-identical across devices and matches the CPU reference; single-GPU (`cuda:0`) behavior unchanged.

## Notes
- No public API/ABI change (the modified `InitializeDecoder` is the internal VA-API decoder method).
- The same fix applies to rocDecode, which shares this render-node selection pattern.
