### PR TITLE
[RCCL] Restrict DDA alltoall threshold to 4MB on MI350

### DIFF
--- a/projects/rccl/src/collectives.cc
+++ b/projects/rccl/src/collectives.cc
@@ -129,15 +129,16 @@ RCCL_PARAM(DdaThreshold, "DDA_THRESHOLD", (size_t)(67108864));
 
 // Returns true when the DDA fast path should be attempted for a collective
 // with the given total byte count.  gfx942Default is the per-collective
-// threshold for gfx942; gfx950 uses the user-configurable rcclParamDdaThreshold();
-// all other architectures return false (threshold 0).
-static bool rcclDdaEnabled(const ncclComm* comm, size_t totalBytes, size_t gfx942Default) {
+// threshold for gfx942 (MI300).  gfx950Default optionally caps MI350; when 0,
+// gfx950 uses the user-configurable rcclParamDdaThreshold().
+// All other architectures return false (threshold 0).
+static bool rcclDdaEnabled(const ncclComm* comm, size_t totalBytes, size_t gfx942Default, size_t gfx950Default = 0) {
   if (!rcclParamDdaEnable() || ncclParamLaunchOrderImplicit() || ncclGroupDepth != 0 || comm->nRanks < 8 || comm->symmetricSupport) return false;
   size_t threshold;
   if (IsArchMatch(comm->archName, "gfx942")) {
     threshold = gfx942Default;
   } else if (IsArchMatch(comm->archName, "gfx950")) {
-    threshold = (size_t)rcclParamDdaThreshold();
+    threshold = gfx950Default ? gfx950Default : (size_t)rcclParamDdaThreshold();
   } else {
     return false;
   }
@@ -306,7 +307,7 @@ ncclResult_t ncclAlltoAll_impl(const void* sendbuff, void* recvbuff, size_t coun
       }
       #endif // ENABLE_ROCSHMEM
 
-    if (rcclDdaEnabled(comm, comm->nRanks * count * ncclTypeSize(datatype), 4194304) &&
+    if (rcclDdaEnabled(comm, comm->nRanks * count * ncclTypeSize(datatype), 4194304, 4194304) &&
         ncclAllToAllDdaIpcEligible(comm, sendbuff, recvbuff, count, datatype)) {
       NCCLCHECK(ncclAllToAllDdaIpc(
         sendbuff,

--- a/projects/rccl/src/dda_alltoall_ipc.cu
+++ b/projects/rccl/src/dda_alltoall_ipc.cu
@@ -61,7 +61,13 @@ static ncclResult_t ncclAllToAllDdaIpcTyped(
 
   void* peerPtrsDev = comm->ddaIpcPeerPtrsDev;
   T** d_ipcbuffs = reinterpret_cast<T**>(peerPtrsDev);
-
+  
+  CUDACHECK(cudaMemcpyAsync(
+        comm->ddaIpcScratch,
+        sendbuff,
+        totalCount * sizeof(T),
+        cudaMemcpyDeviceToDevice,
+        stream));
   meta::comms::ddaAllToAllIpc<T, kDdaNranks, false>
       <<<grid, block, 0, stream>>>(
           d_ipcbuffs,

--- a/projects/rccl/src/include/algorithms/alltoall/alltoall_dda.h
+++ b/projects/rccl/src/include/algorithms/alltoall/alltoall_dda.h
@@ -26,6 +26,10 @@ __launch_bounds__(512)
         const T* __restrict__ sendbuff,
         int selfRank,
         IpcGpuBarrier barrier) {
+  barrier.syncOnSameBlockIdx<
+      false /* hasPreviousMemAccess */,
+      true /* hasSubsequentMemAccess */>();
+ 
   // use uint4 to do 16-byte loads to maximize memory efficiency
   // We assume that count % countPerThread == 0. This assumption is enforced
   // before kernel launch
@@ -36,17 +40,7 @@ __launch_bounds__(512)
 
   const auto idxStart = gtIdx * countPerThread;
   const auto idxEnd = countPerRank;
-  const size_t copyCount = count * NRANKS;
   const auto idxStride = gridDim.x * blockDim.x * countPerThread;
-
-  // It is expensive to launch hipMemcpyAsync on ROCm
-  // Move data copy here. Each block copies part of sendbuff data
-  copyFromSrcToDest<T>(
-      sendbuff, ipcbuffs[selfRank], idxStart, copyCount, idxStride);
-
-  barrier.syncOnSameBlockIdx<
-      true /* hasPreviousMemAccess */,
-      true /* hasSubsequentMemAccess */>();
 
   for (size_t idx = idxStart; idx < idxEnd; idx += idxStride) {
 #pragma unroll NRANKS


### PR DESCRIPTION
## Motivation

The PR restricts the DDA AlltoAll threshold to 4MB on MI350. It also fixes a bug in DDA AlltoAll kernel.

## Technical Details
1. Add a separate threshold for MI350
2. Fix the race condition in barrier; use memcpy instead for kernel copy for the send buffer 


## JIRA ID
AICOMRCCL-1514


## Test Plan
RCCL alltoall test


## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
