### PR TITLE
[rocprofiler-compute] Exclude test_pc_sampling from TheRock CI

### DIFF
--- a/projects/rocprofiler-compute/tests/test_categories.yaml
+++ b/projects/rocprofiler-compute/tests/test_categories.yaml
@@ -42,6 +42,7 @@ test_categories:
     therock_ci_exclude:
       - test_profile_live_attach_detach
       - test_metric_validation
+      - test_pc_sampling
     rocprofiler_compute_ci_exclude:
       - test_profile_live_attach_detach
     labels:
@@ -107,6 +108,7 @@ test_categories:
     therock_ci_exclude:
       - test_profile_live_attach_detach
       - test_metric_validation
+      - test_pc_sampling
     rocprofiler_compute_ci_exclude:
       - test_profile_live_attach_detach
     labels:
@@ -171,6 +173,7 @@ test_categories:
     therock_ci_exclude:
       - test_profile_live_attach_detach
       - test_metric_validation
+      - test_pc_sampling
     rocprofiler_compute_ci_exclude:
       - test_profile_live_attach_detach
     labels:
@@ -235,6 +238,7 @@ test_categories:
     therock_ci_exclude:
       - test_profile_live_attach_detach
       - test_metric_validation
+      - test_pc_sampling
     rocprofiler_compute_ci_exclude:
       - test_profile_live_attach_detach
     labels:


### PR DESCRIPTION
## Motivation

`test_pc_sampling` hangs on TheRock's `gfx94X-dcgpu` runner. The pytest session collects its 6 items and then emits no output for the full 300s timeout window, so CTest kills it (`***Timeout 300 sec`). Because pytest runs with `-s`, any progress would stream live, so the hang is in the live-GPU PC-sampling collection path, not the test logic. All other pc_sampling tests pass on the same runner.

See failing run: https://github.com/ROCm/rocm-systems/actions/runs/29095324177/job/86410739053?pr=8348

Excluding it from TheRock CI unblocks the pipeline while the runner-side hang is investigated.

## Technical Details

- Add `test_pc_sampling` to `therock_ci_exclude` in the `quick`, `standard`, `comprehensive`, and `full` categories in `tests/test_categories.yaml`.
- Left running in rocprofiler-compute CI (`rocprofiler_compute_ci_exclude` unchanged).

## JIRA ID

N/A

## Test Plan

TheRock CI on the PR should no longer run `test_pc_sampling`; rocprofiler-compute CI continues to run it.

## Test Result

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.