### PR TITLE
fix(rocprofiler-systems): make MPI auto-detection not CWD-dependent

### DIFF
--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/details.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/details.cpp
@@ -564,7 +564,7 @@ find_undefined_function_symbol(const std::unordered_set<object_t*>& _objects,
         SymTab::Symtab* symtab = nullptr;
         if(!SymTab::Symtab::openFile(symtab, binary_path))
         {
-            verbprintf(2, "Failed to open Symtab for: %s\n", binary_path.c_str());
+            verbprintf(1, "Failed to open Symtab for: %s\n", binary_path.c_str());
             continue;
         }
 

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/details.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/details.cpp
@@ -558,12 +558,13 @@ find_undefined_function_symbol(const std::unordered_set<object_t*>& _objects,
     {
         if(!obj) continue;
 
-        std::string binary_path = obj->name();
+        std::string binary_path = obj->pathName();
+        if(binary_path.empty()) binary_path = obj->name();
         // Open Symtab directly for comprehensive symbol access
         SymTab::Symtab* symtab = nullptr;
         if(!SymTab::Symtab::openFile(symtab, binary_path))
         {
-            verbprintf(3, "Failed to open Symtab for: %s\n", binary_path.c_str());
+            verbprintf(2, "Failed to open Symtab for: %s\n", binary_path.c_str());
             continue;
         }
 

--- a/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/details.cpp
+++ b/projects/rocprofiler-systems/source/bin/rocprof-sys-instrument/details.cpp
@@ -559,7 +559,6 @@ find_undefined_function_symbol(const std::unordered_set<object_t*>& _objects,
         if(!obj) continue;
 
         std::string binary_path = obj->pathName();
-        if(binary_path.empty()) binary_path = obj->name();
         // Open Symtab directly for comprehensive symbol access
         SymTab::Symtab* symtab = nullptr;
         if(!SymTab::Symtab::openFile(symtab, binary_path))

--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/validators.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/validators.py
@@ -71,6 +71,7 @@ ROCPROFSYS_ABORT_FAIL_REGEX = [
     r"terminate called after throwing an instance",
     r"calling abort\.\. in ",
     r"Exit code: [1-9]",
+    r"Failed to open Symtab for",
 ]
 
 from rocprofsys.runners import TestResult

--- a/projects/rocprofiler-systems/tests/pytest/test_mpi.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_mpi.py
@@ -87,10 +87,13 @@ class TestMPI(RocprofsysTest):
             "--min-instructions",
             "0",
         ]
-        BINARY_REWRITE_PASS_REGEX = [r"perfetto-trace-0\.proto", r"wall_clock-0\.txt"]
+        BINARY_REWRITE_PASS_REGEX = [
+            r"perfetto-trace-0\.proto",
+            r"wall_clock-0\.txt",
+            r"Enabling MPI support\.\.\.",
+        ]
         BINARY_REWRITE_FAIL_REGEX = [
-            r"Outputting.*(perfetto-trace|trip_count|sampling_percent|sampling_cpu_clock|sampling_wall_clock|wall_clock)-[0-9][0-9]+.(json|txt|proto)",
-            "Failed to open Symtab for",
+            r"Outputting.*(perfetto-trace|trip_count|sampling_percent|sampling_cpu_clock|sampling_wall_clock|wall_clock)-[0-9][0-9]+.(json|txt|proto)"
         ]
         ENV = {"ROCPROFSYS_VERBOSE": "1"}
 

--- a/projects/rocprofiler-systems/tests/pytest/test_mpi.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_mpi.py
@@ -89,7 +89,8 @@ class TestMPI(RocprofsysTest):
         ]
         BINARY_REWRITE_PASS_REGEX = [r"perfetto-trace-0\.proto", r"wall_clock-0\.txt"]
         BINARY_REWRITE_FAIL_REGEX = [
-            r"Outputting.*(perfetto-trace|trip_count|sampling_percent|sampling_cpu_clock|sampling_wall_clock|wall_clock)-[0-9][0-9]+.(json|txt|proto)"
+            r"Outputting.*(perfetto-trace|trip_count|sampling_percent|sampling_cpu_clock|sampling_wall_clock|wall_clock)-[0-9][0-9]+.(json|txt|proto)",
+            "Failed to open Symtab for",
         ]
         ENV = {"ROCPROFSYS_VERBOSE": "1"}
 


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

When trying to enable MPI tests on TheRock, (after fixing other bugs), `mpi-binary-rewrite` and `mpi-flat-binary-rewrite` would fail. The reason being that the profiler does NOT treat the run as using MPI (we rely on auto-detection for this case). No rank output suffix and no MPI function wrapping.

`rocprof-sys-instrument` decides whether a target is MPI by scanning its symbols for `MPI_Init`... etc...
To do so, it uses the SymtabAPI to open the symtab of the object (in this case `mpi-example`). It gets that via:
```
std::string binary_path = obj->name();
```
which returned the basename, not a path, so `Symtab::openFile("mpi-example")` does not work unless the profiler was launched in the same directory as `mpi-example`, would not work as TheRock launches the instrument step with `cwd=rocprofsys_build_dir`, and on TheRock, the `mpi-example` lives under `share/rocprofiler-systems/examples`, so `openFile` fails, symbol search skipped, every MPI probe returns null, and thus `use_mpi=false`.

In fact, this problem also exists outside of TheRock. Running:
```
rocprof-sys-instrument -o /tmp/mpi-example.inst -v 3 --print-instrumented functions -- rocprof-sys-build/mpi-example  > log.log 2>&1
```

We see the `Failed to open Symtab`:
```
[rocprof-sys][exe] Failed to open Symtab for: mpi-example
[rocprof-sys][exe] Undefined function symbol: 'mpi_init_thread' ... not found
[rocprof-sys][exe] function: 'mpi_init_thread_' ... not found
[rocprof-sys][exe] Failed to open Symtab for: mpi-example
[rocprof-sys][exe] Undefined function symbol: 'mpi_init_thread_' ... not found
[rocprof-sys][exe] function: 'mpi_init_thread__' ... not found
[rocprof-sys][exe] Failed to open Symtab for: mpi-example
```

And no `Enabling MPI support...` is printed.


## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

 - We first try using `binary_path = obj->pathName()` first, then fallback to `obj->name()`.
 - We also REDUCE verbosity from `3` to `1` on the Symtab message
 - We add the Symtab message to `ROCPROFSYS_ABORT_FAIL_REGEX`.
 - Also add `Enabling MPI support...` to pass regex of `mpi-binary-rewrite` test.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

Jira ID: AIPROFSYST-524

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

TheRock manually.

## Test Result


MPI tests (with other fixes on TheRock, mainly choosing correct dyninst) finally all pass.
```
100% tests passed, 0 tests failed out of 26

Label Time Summary:
all               =  91.04 sec*proc (24 tests)
baseline          =   2.31 sec*proc (1 test)
binary_rewrite    =  55.56 sec*proc (10 tests)
cleanup           =   0.16 sec*proc (1 test)
full              =  91.04 sec*proc (24 tests)
global            =   0.56 sec*proc (2 tests)
mpi               =  91.04 sec*proc (24 tests)
prerequisite      =   0.41 sec*proc (1 test)
sampling          =  11.26 sec*proc (3 tests)
sys_run           =  21.90 sec*proc (10 tests)

Total Test time (real) =  91.62 sec
```

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
