### PR TITLE
test(RCCL): Add nccl4py pip build-smoke pytest harness

### DIFF
--- a/projects/rccl/test/nccl4py/.gitignore
+++ b/projects/rccl/test/nccl4py/.gitignore
@@ -1,0 +1,7 @@
+venv/
+.venv/
+logs/
+nccl4py_build/
+.pytest_cache/
+__pycache__/
+*.pyc

--- a/projects/rccl/test/nccl4py/README.md
+++ b/projects/rccl/test/nccl4py/README.md
@@ -1,0 +1,91 @@
+# RCCL nccl4py Build-Smoke Tests
+
+## Description
+
+This directory contains a pytest harness that validates the **supported ROCm
+install path** for nccl4py:
+
+```bash
+cd bindings/nccl4py && pip install -e .
+```
+
+The harness mirrors `test/ir-device`: it builds the package on demand from a
+session-scoped fixture and **skips with a clear reason** (rather than failing)
+when prerequisites are missing.
+
+It exercises the CPU-only smoke modules in `bindings/nccl4py/tests/`:
+
+| Module | What it checks |
+|--------|----------------|
+| `test_rocm_extensions.py` | RCCL-only wrappers (`all_reduce_with_bias`, `all_to_all_v`) fail controlled |
+| `test_shim_surface.py` | HIP `cuda.core` shim (optional; self-skips without visible GPUs) |
+
+The harness also runs an in-process ``import nccl.bindings`` check after
+``pip install -e .``. The ``test_loader_stubs.py`` module under
+``bindings/nccl4py/tests`` is RCCL-version-specific (it expects certain
+symbols to be absent) and is not part of this build-smoke suite.
+
+The upstream NVIDIA `bindings/nccl4py/CMakeLists.txt` (CUDA + `uv` wheel
+build) is **not** what this suite validates. On ROCm, `pip install` is the
+supported path.
+
+## Prerequisites
+
+Build RCCL once so `librccl.so` exists:
+
+```bash
+cmake -B build/release -DBUILD_TESTS=ON .
+cmake --build build/release --target rccl
+```
+
+## Configuration (environment variables)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RCCL_DIR` | repo root (derived) | RCCL source root |
+| `RCCL_BUILD` | `$RCCL_DIR/build/release` | RCCL CMake build dir (`librccl.so`) |
+| `ROCM_PATH` | `/opt/rocm` | ROCm install root |
+| `NCCL4PY_DIR` | `$RCCL_DIR/bindings/nccl4py` | nccl4py source tree |
+| `NCCL_LIBRARY` | (auto) | Explicit path to `librccl.so` |
+
+## Running
+
+```bash
+cd test/nccl4py
+python3 -m venv venv && source venv/bin/activate
+pip install -r requirements.txt
+
+# Build nccl4py via pip + run smoke modules
+pytest -v --cache-clear
+
+# CPU-only smoke (no GPU required)
+pytest -v -m nccl4py_cpu
+```
+
+Build and per-module logs are written to `logs/`.
+
+## CI / test_runner integration
+
+Register in a `test_runner` JSON config like `ir_device`:
+
+```json
+"nccl4py_build_smoke": {
+  "extends": "default",
+  "is_pytest": true,
+  "setup_venv": true,
+  "test_dir": "test/nccl4py",
+  "num_ranks": 1,
+  "num_nodes": 1,
+  "num_gpus": 0,
+  "timeout": 600,
+  "tests": [
+    {
+      "name": "NCCL4Py_BuildSmoke_All",
+      "description": "pip install -e nccl4py + CPU smoke pytest modules",
+      "test_filter": "ALL"
+    }
+  ]
+}
+```
+
+On runners without a prior RCCL build, every case auto-skips.

--- a/projects/rccl/test/nccl4py/pytest.ini
+++ b/projects/rccl/test/nccl4py/pytest.ini
@@ -1,0 +1,9 @@
+# pytest.ini
+[pytest]
+markers =
+    nccl4py: marks tests that build and exercise the nccl4py pip package
+    nccl4py_cpu: CPU-only smoke tests (no GPU required)
+    nccl4py_gpu: optional GPU-backed shim tests (self-skip without HIP devices)
+
+testpaths = tests
+addopts = --import-mode=importlib

--- a/projects/rccl/test/nccl4py/requirements.txt
+++ b/projects/rccl/test/nccl4py/requirements.txt
@@ -1,0 +1,2 @@
+# Testing dependencies for the nccl4py build-smoke harness
+pytest

--- a/projects/rccl/test/nccl4py/tests/conftest.py
+++ b/projects/rccl/test/nccl4py/tests/conftest.py
@@ -103,6 +103,21 @@ def _runtime_env() -> dict[str, str]:
     return env
 
 
+def _refresh_site_packages() -> None:
+    """Pick up editable-install .pth files added by a subprocess pip install.
+
+    Python only processes site-packages .pth files at interpreter startup, so
+    an in-process import after ``pip install -e`` in a child process needs this.
+    """
+    import importlib
+    import site
+
+    for d in site.getsitepackages():
+        if os.path.isdir(d):
+            site.addsitedir(d)
+    importlib.invalidate_caches()
+
+
 def _pip_install_editable() -> str:
     """``pip install -e`` the nccl4py tree; return the build log path."""
     os.makedirs(NCCL4PY_OUT, exist_ok=True)
@@ -145,6 +160,7 @@ def _pip_install_editable() -> str:
             check=False,
         )
     assert proc.returncode == 0, f"Failed to pip install nccl4py (see {build_log})"
+    _refresh_site_packages()
     return build_log
 
 

--- a/projects/rccl/test/nccl4py/tests/conftest.py
+++ b/projects/rccl/test/nccl4py/tests/conftest.py
@@ -1,0 +1,209 @@
+# *************************************************************************
+#  * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#  *
+#  * See LICENSE.txt for license information
+#  ************************************************************************
+"""Shared fixtures for the nccl4py build-smoke pytest harness.
+
+This mirrors test/ir-device: the supported ROCm install path (``pip install``)
+is exercised on demand from a session-scoped fixture, and the whole suite is
+skipped with a clear reason when prerequisites are missing.
+
+Prerequisites (environment variables, with sensible defaults):
+
+  RCCL_DIR      RCCL source root             (default: repo root, derived)
+  RCCL_BUILD    RCCL CMake build dir         (default: $RCCL_DIR/build/release)
+  ROCM_PATH     ROCm install root            (default: /opt/rocm)
+  NCCL4PY_DIR   nccl4py source tree          (default: $RCCL_DIR/bindings/nccl4py)
+  NCCL4PY_OUT   editable-install staging dir (default: <workdir>/nccl4py_build)
+
+RCCL must have been built at least once so ``librccl.so`` is discoverable from
+``$RCCL_BUILD`` or ``$ROCM_PATH/lib``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+logger = logging.getLogger(__name__)
+
+WORKDIR = os.getcwd()
+
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_DEFAULT_RCCL_DIR = os.path.abspath(os.path.join(_THIS_DIR, "..", "..", ".."))
+
+RCCL_DIR = os.path.abspath(os.environ.get("RCCL_DIR", _DEFAULT_RCCL_DIR))
+RCCL_BUILD = os.path.abspath(
+    os.environ.get("RCCL_BUILD", os.path.join(RCCL_DIR, "build", "release"))
+)
+ROCM_PATH = os.environ.get("ROCM_PATH", "/opt/rocm")
+NCCL4PY_DIR = os.path.abspath(
+    os.environ.get("NCCL4PY_DIR", os.path.join(RCCL_DIR, "bindings", "nccl4py"))
+)
+NCCL4PY_OUT = os.environ.get("NCCL4PY_OUT", os.path.join(WORKDIR, "nccl4py_build"))
+
+LOGDIR = os.path.join(WORKDIR, "logs")
+os.makedirs(LOGDIR, exist_ok=True)
+
+# CPU smoke module: accepts NotImplementedError or NCCLError depending on
+# which RCCL symbols are present in the loaded librccl.so.
+CPU_SMOKE_TESTS = ("tests/test_rocm_extensions.py",)
+
+# Optional GPU-backed shim surface; the module self-skips without HIP devices.
+GPU_SMOKE_TESTS = ("tests/test_shim_surface.py",)
+
+
+def _librccl_candidates():
+    yield os.path.join(RCCL_BUILD, "librccl.so")
+    yield os.path.join(ROCM_PATH, "lib", "librccl.so")
+    yield os.path.join(ROCM_PATH, "lib64", "librccl.so")
+
+
+def _find_librccl() -> str | None:
+    explicit = os.environ.get("NCCL_LIBRARY")
+    if explicit and os.path.isfile(explicit):
+        return explicit
+    for path in _librccl_candidates():
+        if os.path.isfile(path):
+            return path
+    return None
+
+
+def _missing_prerequisite() -> str | None:
+    if not os.path.isfile(os.path.join(NCCL4PY_DIR, "pyproject.toml")):
+        return f"nccl4py source not found at {NCCL4PY_DIR}"
+    if _find_librccl() is None:
+        return (
+            f"librccl.so not found under RCCL_BUILD={RCCL_BUILD} or "
+            f"ROCM_PATH={ROCM_PATH} (build RCCL once or set NCCL_LIBRARY)"
+        )
+    return None
+
+
+def _runtime_env() -> dict[str, str]:
+    env = os.environ.copy()
+    librccl = _find_librccl()
+    lib_dirs = []
+    if librccl:
+        env["NCCL_LIBRARY"] = librccl
+        lib_dirs.append(os.path.dirname(librccl))
+    for d in (os.path.join(RCCL_BUILD), os.path.join(ROCM_PATH, "lib"), os.path.join(ROCM_PATH, "lib64")):
+        if os.path.isdir(d) and d not in lib_dirs:
+            lib_dirs.append(d)
+    if lib_dirs:
+        existing = env.get("LD_LIBRARY_PATH", "")
+        prefix = ":".join(lib_dirs)
+        env["LD_LIBRARY_PATH"] = f"{prefix}:{existing}" if existing else prefix
+    return env
+
+
+def _pip_install_editable() -> str:
+    """``pip install -e`` the nccl4py tree; return the build log path."""
+    os.makedirs(NCCL4PY_OUT, exist_ok=True)
+    build_log = os.path.join(LOGDIR, "nccl4py_pip_install.log")
+    args = [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "--upgrade",
+        "pip",
+        "setuptools",
+        "wheel",
+        "Cython>=3.1",
+    ]
+    with open(build_log, "w") as log:
+        log.write("$ " + " ".join(args) + "\n\n")
+        log.flush()
+        proc = subprocess.run(
+            args,
+            cwd=NCCL4PY_DIR,
+            env=_runtime_env(),
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+            check=False,
+        )
+        if proc.returncode != 0:
+            raise AssertionError(f"Failed to install build deps (see {build_log})")
+
+        log.write("\n$ pip install -e .\n\n")
+        log.flush()
+        proc = subprocess.run(
+            [sys.executable, "-m", "pip", "install", "-e", "."],
+            cwd=NCCL4PY_DIR,
+            env=_runtime_env(),
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+            check=False,
+        )
+    assert proc.returncode == 0, f"Failed to pip install nccl4py (see {build_log})"
+    return build_log
+
+
+@pytest.fixture(scope="session")
+def nccl4py_installed():
+    """Build/install nccl4py via the supported ROCm path once per session."""
+    reason = _missing_prerequisite()
+    if reason:
+        pytest.skip(f"nccl4py build-smoke skipped: {reason}")
+
+    logger.info("pip install -e %s (ROCm path)...", NCCL4PY_DIR)
+    build_log = _pip_install_editable()
+    logger.info("nccl4py editable install complete (log: %s)", build_log)
+
+
+@pytest.fixture(scope="session")
+def paths():
+    return SimpleNamespace(
+        WORKDIR=WORKDIR,
+        RCCL_DIR=RCCL_DIR,
+        RCCL_BUILD=RCCL_BUILD,
+        ROCM_PATH=ROCM_PATH,
+        NCCL4PY_DIR=NCCL4PY_DIR,
+        NCCL4PY_OUT=NCCL4PY_OUT,
+        LOGDIR=LOGDIR,
+        LIBRCCL=_find_librccl(),
+    )
+
+
+@pytest.fixture(scope="session")
+def run_nccl4py_pytest(nccl4py_installed):
+    """Run a pytest module under bindings/nccl4py/tests and return (proc, log)."""
+
+    def _run(relative_test_path: str, log_name: str) -> tuple[subprocess.CompletedProcess, str]:
+        target = os.path.join(NCCL4PY_DIR, relative_test_path)
+        if not os.path.isfile(target):
+            raise FileNotFoundError(target)
+        args = [
+            sys.executable,
+            "-m",
+            "pytest",
+            relative_test_path,
+            "-q",
+            "--tb=short",
+            "--color=no",
+        ]
+        log_file = os.path.join(LOGDIR, log_name)
+        with open(log_file, "w") as log:
+            log.write("$ " + " ".join(args) + f"  (cwd={NCCL4PY_DIR})\n\n")
+            log.flush()
+            proc = subprocess.run(
+                args,
+                cwd=NCCL4PY_DIR,
+                env=_runtime_env(),
+                stdout=log,
+                stderr=subprocess.STDOUT,
+                universal_newlines=True,
+                timeout=300,
+            )
+        return proc, log_file
+
+    return _run

--- a/projects/rccl/test/nccl4py/tests/test_nccl4py_build_smoke.py
+++ b/projects/rccl/test/nccl4py/tests/test_nccl4py_build_smoke.py
@@ -1,0 +1,56 @@
+# *************************************************************************
+#  * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#  *
+#  * See LICENSE.txt for license information
+#  ************************************************************************
+"""Build and runtime smoke tests for the ROCm nccl4py pip install path.
+
+Each case validates that ``pip install -e .`` succeeds (via the session
+fixture in conftest.py) and that the CPU-only pytest modules under
+``bindings/nccl4py/tests`` pass against the installed package. GPU-backed
+shim tests are included as an optional case that self-skips when no HIP
+devices are visible.
+"""
+
+import pytest
+
+CPU_SMOKE_TESTS = ("tests/test_rocm_extensions.py",)
+
+GPU_SMOKE_TESTS = ("tests/test_shim_surface.py",)
+
+
+@pytest.mark.nccl4py
+@pytest.mark.nccl4py_cpu
+def test_import_nccl_bindings(nccl4py_installed):
+    """Editable pip install produced an importable nccl.bindings module."""
+    import nccl.bindings  # noqa: F401
+
+
+@pytest.mark.nccl4py
+@pytest.mark.nccl4py_cpu
+@pytest.mark.parametrize(
+    "relative_test_path",
+    CPU_SMOKE_TESTS,
+    ids=[p.split("/")[-1] for p in CPU_SMOKE_TESTS],
+)
+def test_cpu_smoke_modules(relative_test_path, run_nccl4py_pytest):
+    """Run CPU-only nccl4py smoke modules after editable pip install."""
+    log_name = relative_test_path.replace("/", "_").replace(".py", ".log")
+    proc, log = run_nccl4py_pytest(relative_test_path, log_name)
+    assert proc.returncode == 0, f"{relative_test_path} failed, see {log}"
+
+
+@pytest.mark.nccl4py
+@pytest.mark.nccl4py_gpu
+@pytest.mark.parametrize(
+    "relative_test_path",
+    GPU_SMOKE_TESTS,
+    ids=[p.split("/")[-1] for p in GPU_SMOKE_TESTS],
+)
+def test_gpu_smoke_modules(relative_test_path, run_nccl4py_pytest):
+    """Run optional GPU shim tests (module skips when no HIP devices)."""
+    log_name = relative_test_path.replace("/", "_").replace(".py", ".log")
+    proc, log = run_nccl4py_pytest(relative_test_path, log_name)
+    # Exit 0 means pass or skip-all; 5 is pytest's "no tests collected" which
+    # we treat as skip when the module bails at import time on CPU-only hosts.
+    assert proc.returncode in (0, 5), f"{relative_test_path} failed, see {log}"

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300_mellanox_ib_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300_mellanox_ib_func.json
@@ -2613,6 +2613,23 @@
           "test_filter": "ALL"
         }
       ]
+    },
+    "nccl4py_build_smoke": {
+      "extends": "default",
+      "is_pytest": true,
+      "setup_venv": true,
+      "test_dir": "test/nccl4py",
+      "num_ranks": 1,
+      "num_nodes": 1,
+      "num_gpus": 0,
+      "timeout": 600,
+      "tests": [
+        {
+          "name": "NCCL4Py_BuildSmoke_All",
+          "description": "pip install -e nccl4py + CPU smoke pytest modules; self-skips without librccl.so",
+          "test_filter": "ALL"
+        }
+      ]
     }
   },
   "test_suites": [
@@ -3028,6 +3045,12 @@
       "name": "IR Device Tests",
       "description": "librccl_device.bc (IR) device-API tests via pytest harness; builds artifacts on demand and self-skips when prerequisites are missing",
       "config": "ir_device",
+      "enabled": true
+    },
+    {
+      "name": "nccl4py Build Smoke",
+      "description": "pip install -e nccl4py + CPU smoke pytest modules; self-skips without librccl.so",
+      "config": "nccl4py_build_smoke",
       "enabled": true
     }
   ]


### PR DESCRIPTION
## Summary

Adds a pytest harness under `projects/rccl/test/nccl4py/` that validates the **supported ROCm install path** for nccl4py (`pip install -e .` in `bindings/nccl4py`). The design mirrors `test/ir-device`: build on demand from a session-scoped fixture, and **skip with a clear reason** when prerequisites are missing (no `librccl.so`, no nccl4py source tree).

Also wires the suite into `test_runner` on `mi300_mellanox_ib_func.json` as a CPU-only (`num_gpus: 0`) smoke step.

## Motivation

On ROCm, the supported nccl4py path is editable pip install — not the upstream NVIDIA `CMakeLists.txt` (CUDA + `uv` wheel build). We need CI-safe coverage that:

- Confirms `pip install -e .` succeeds against a built `librccl.so`
- Runs the existing CPU smoke modules in `bindings/nccl4py/tests/`
- Self-skips on runners without RCCL build artifacts

## Changes

### New harness (`projects/rccl/test/nccl4py/`)

| File | Purpose |
|------|---------|
| `tests/conftest.py` | Session fixtures: prerequisite checks, `pip install -e .`, subprocess runner for upstream smoke modules |
| `tests/test_nccl4py_build_smoke.py` | Three smoke cases (import, CPU modules, optional GPU shim) |
| `README.md` | Usage, env vars, local + CI integration docs |
| `pytest.ini` | Markers: `nccl4py`, `nccl4py_cpu`, `nccl4py_gpu` |
| `requirements.txt` | `pytest` only |
| `.gitignore` | `venv/`, `logs/`, build artifacts |

### What gets exercised (`bindings/nccl4py/tests/`)

| Module | Marker | Notes |
|--------|--------|-------|
| `test_rocm_extensions.py` | `nccl4py_cpu` | RCCL-only wrappers; accepts `NotImplementedError` or `NCCLError` |
| `test_shim_surface.py` | `nccl4py_gpu` | HIP `cuda.core` shim; self-skips without visible GPUs |
| `test_loader_stubs.py` | **excluded** | RCCL-version-specific (expects certain symbols absent); fails on current RCCL where symbols are present |

### CI wiring

- Adds `nccl4py_build_smoke` config block to `tools/scripts/test_runner/configs/mi300_mellanox_ib_func.json`
- Registers **nccl4py Build Smoke** test suite (`enabled: true`, `timeout: 600`)

### Bug fix (`ac66e9d`)

`test_import_nccl_bindings` failed on a **fresh venv** because the session fixture runs `pip install -e .` in a subprocess, and Python only processes editable-install `.pth` files at interpreter startup. Added `_refresh_site_packages()` after pip install so in-process `import nccl.bindings` works on first run.

## Commits

1. `369251b` — test(RCCL): Add nccl4py pip build-smoke pytest harness
2. `ac66e9d` — fix(RCCL): Refresh site-packages after nccl4py editable pip install

## Test plan

Verified locally on `users/shwetjha/nccl4py` from scratch:

- [x] Checked out branch and rebuilt RCCL: `cmake --build build/release --target rccl`
- [x] Clean harness dir (no pre-existing `venv/`, `logs/`, or nccl4py build artifacts)
- [x] Fresh venv + pytest:
  ```bash
  cd projects/rccl/test/nccl4py
  python3 -m venv venv && source venv/bin/activate
  pip install -r requirements.txt
  export RCCL_DIR=$PWD/../.. RCCL_BUILD=$RCCL_DIR/build/release
  pytest -v --cache-clear
  ```
  **Result: 3 passed in ~30s**
  - `test_import_nccl_bindings` — PASSED
  - `test_cpu_smoke_modules[test_rocm_extensions.py]` — PASSED (3/3 upstream)
  - `test_gpu_smoke_modules[test_shim_surface.py]` — PASSED (19 passed, 2 skipped)
- [x] CPU-only marker: `pytest -v -m nccl4py_cpu` — 2 passed, 1 deselected

## Notes for reviewers

- Harness follows the same pattern as `test/ir-device` (env vars, session fixture, `logs/` output, `test_runner` `is_pytest` + `setup_venv`).
- `ir_device` is registered in 6 test_runner configs; this PR only adds nccl4py to `mi300_mellanox_ib_func.json` since it is CPU-safe and intended as an initial func-CI gate. Happy to extend to other configs in a follow-up if desired.
- On runners without `librccl.so`, the entire suite auto-skips — safe to enable unconditionally.


Made with [Cursor](https://cursor.com)