### PR TITLE
fix(rccl): AICOMRCCL-1180:  MPI tests for relaxed symmetric buffer registration

### DIFF
--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -352,6 +352,7 @@ if(BUILD_TESTS)
       GrowMPITests.cpp
       GinNcclTimeoutMPITests.cpp
       SymmetricKernelMPITests.cpp
+      SymmetricWindowMPITests.cpp
     )
 
     add_executable(rccl-UnitTestsMPI ${MPI_TEST_SOURCE_FILES})

--- a/projects/rccl/test/SymmetricWindowMPITests.cpp
+++ b/projects/rccl/test/SymmetricWindowMPITests.cpp
@@ -613,17 +613,16 @@ TEST_F(SymWin_WindowLifecycle, MultipleWindows)
 
     for (int i = 0; i < numWindows; i++) {
         void* buf = allocNcclBuf(bufSize);
-        ASSERT_MPI_NE(buf, nullptr) << "Failed to allocate buffer " << i;
+        ASSERT_MPI_NE(buf, nullptr);
 
         wins[i] = registerWindow(comm, buf, bufSize);
-        ASSERT_MPI_NE(wins[i], nullptr) << "Failed to register window " << i;
+        ASSERT_MPI_NE(wins[i], nullptr);
     }
 
     // Verify all windows are unique
     for (int i = 0; i < numWindows; i++) {
         for (int j = i + 1; j < numWindows; j++) {
-            ASSERT_MPI_NE(wins[i], wins[j])
-                << "Windows " << i << " and " << j << " are not unique";
+            ASSERT_MPI_NE(wins[i], wins[j]);
         }
     }
 
@@ -648,12 +647,10 @@ TEST_F(SymWin_WindowLifecycle, RepeatedRegisterDeregister)
     for (int i = 0; i < iterations; i++) {
         ncclWindow_t win = nullptr;
         ASSERT_MPI_EQ(ncclSuccess,
-            ncclCommWindowRegister(comm, buf, bufSize, &win, NCCL_WIN_COLL_SYMMETRIC))
-            << "Registration failed on iteration " << i;
+            ncclCommWindowRegister(comm, buf, bufSize, &win, NCCL_WIN_COLL_SYMMETRIC));
         ASSERT_MPI_NE(win, nullptr);
 
-        ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowDeregister(comm, win))
-            << "Deregistration failed on iteration " << i;
+        ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowDeregister(comm, win));
     }
 
     TEST_INFO("Rank %d: RepeatedRegisterDeregister passed (%d iterations)",

--- a/projects/rccl/test/SymmetricWindowMPITests.cpp
+++ b/projects/rccl/test/SymmetricWindowMPITests.cpp
@@ -32,7 +32,6 @@
 #include "ResourceGuards.hpp"
 #include "TestChecks.hpp"
 #include <cstdlib>
-#include <memory>
 #include <vector>
 
 #ifdef MPI_TESTS_ENABLED
@@ -63,15 +62,12 @@ protected:
         ncclComm_t comm = nullptr;
     };
 
-    std::unique_ptr<MPIHelpers::MpiEnvGuard> cuMemGuard_;
     std::vector<NcclBufInfo> allocatedBufs_;
     std::vector<WinInfo> registeredWins_;
 
     void SetUp() override
     {
         MPITestBase::SetUp();
-        cuMemGuard_ = std::make_unique<MPIHelpers::MpiEnvGuard>(
-            "NCCL_CUMEM_ENABLE", "1");
     }
 
     void TearDown() override
@@ -90,7 +86,6 @@ protected:
         }
         allocatedBufs_.clear();
 
-        cuMemGuard_.reset();
         MPITestBase::TearDown();
     }
 
@@ -115,6 +110,9 @@ protected:
 
     bool setupForSymmetric(int minRanks = MIN_RANKS)
     {
+        const char* cuMemEnv = std::getenv("NCCL_CUMEM_ENABLE");
+        if (!cuMemEnv || std::string(cuMemEnv) != "1") return false;
+
         if (!validateTestPrerequisites(minRanks)) return false;
         if (createTestCommunicator() != ncclSuccess) return false;
 

--- a/projects/rccl/test/SymmetricWindowMPITests.cpp
+++ b/projects/rccl/test/SymmetricWindowMPITests.cpp
@@ -16,6 +16,7 @@
  * - In-place operations with a single window
  *
  * REQUIRED Environment Variables:
+ *   NCCL_CUMEM_ENABLE=1          Enables cuMem API for symmetric support
  *   NCCL_DEBUG=INFO              Enables debug logging to observe kernel path
  *   HSA_NO_SCRATCH_RECLAIM=1     Required for multi-GPU RCCL tests
  *
@@ -31,6 +32,8 @@
 #include "ResourceGuards.hpp"
 #include "TestChecks.hpp"
 #include <cstdlib>
+#include <memory>
+#include <vector>
 
 #ifdef MPI_TESTS_ENABLED
 
@@ -60,8 +63,16 @@ protected:
         ncclComm_t comm = nullptr;
     };
 
+    std::unique_ptr<MPIHelpers::MpiEnvGuard> cuMemGuard_;
     std::vector<NcclBufInfo> allocatedBufs_;
     std::vector<WinInfo> registeredWins_;
+
+    void SetUp() override
+    {
+        MPITestBase::SetUp();
+        cuMemGuard_ = std::make_unique<MPIHelpers::MpiEnvGuard>(
+            "NCCL_CUMEM_ENABLE", "1");
+    }
 
     void TearDown() override
     {
@@ -79,6 +90,7 @@ protected:
         }
         allocatedBufs_.clear();
 
+        cuMemGuard_.reset();
         MPITestBase::TearDown();
     }
 
@@ -187,38 +199,6 @@ TEST_F(SymWin_AllReduce, BothWindows_OutOfPlace)
 
     ASSERT_TRUE(checkAllReduceResult<T>(recvBuf, count, nRanks));
     TEST_INFO("Rank %d: BothWindows_OutOfPlace passed", rank);
-}
-
-TEST_F(SymWin_AllReduce, BothWindows_InPlace)
-{
-    if (!setupForSymmetric()) {
-        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
-    }
-
-    using T = float;
-    const size_t count = DEFAULT_COUNT;
-    const size_t bufSize = count * sizeof(T);
-
-    ncclComm_t comm = getActiveCommunicator();
-    hipStream_t stream = getActiveStream();
-    int rank, nRanks;
-    ncclCommUserRank(comm, &rank);
-    ncclCommCount(comm, &nRanks);
-
-    void* buf = allocNcclBuf(bufSize);
-    ASSERT_MPI_NE(buf, nullptr);
-
-    ncclWindow_t win = registerWindow(comm, buf, bufSize);
-    ASSERT_MPI_NE(win, nullptr);
-
-    initSendBuffer<T>(buf, count, rank);
-
-    ASSERT_MPI_EQ(ncclSuccess,
-        ncclAllReduce(buf, buf, count, ncclFloat, ncclSum, comm, stream));
-    ASSERT_EQ(hipSuccess, hipStreamSynchronize(stream));
-
-    ASSERT_TRUE(checkAllReduceResult<T>(buf, count, nRanks));
-    TEST_INFO("Rank %d: BothWindows_InPlace passed", rank);
 }
 
 TEST_F(SymWin_AllReduce, OnlySendWindow_OutOfPlace)
@@ -606,20 +586,13 @@ TEST_F(SymWin_WindowLifecycle, RegisterDeregister_Basic)
     void* buf = allocNcclBuf(bufSize);
     ASSERT_MPI_NE(buf, nullptr);
 
-    ncclWindow_t win = nullptr;
-    ASSERT_MPI_EQ(ncclSuccess,
-        ncclCommWindowRegister(comm, buf, bufSize, &win, NCCL_WIN_COLL_SYMMETRIC));
+    ncclWindow_t win = registerWindow(comm, buf, bufSize);
     ASSERT_MPI_NE(win, nullptr);
 
     ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowDeregister(comm, win));
 
-    // Remove from auto-cleanup since we already deregistered
-    for (auto it = registeredWins_.begin(); it != registeredWins_.end(); ++it) {
-        if (it->win == win) {
-            it->win = nullptr;
-            break;
-        }
-    }
+    // Null out tracked entry so TearDown skips double-deregister
+    registeredWins_.back().win = nullptr;
 
     TEST_INFO("Rank %d: RegisterDeregister_Basic passed", rank);
 }

--- a/projects/rccl/test/SymmetricWindowMPITests.cpp
+++ b/projects/rccl/test/SymmetricWindowMPITests.cpp
@@ -1,0 +1,690 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+/**
+ * @file SymmetricWindowMPITests.cpp
+ * @brief Tests for relaxed symmetric buffer registration (one-buffer path)
+ *
+ * Validates that symmetric kernels work correctly across different window
+ * registration patterns:
+ * - Both send and recv buffers registered (baseline)
+ * - Only one buffer registered (relaxed / one-buffer path)
+ * - No buffers registered (non-symmetric fallback)
+ * - In-place operations with a single window
+ *
+ * REQUIRED Environment Variables:
+ *   NCCL_DEBUG=INFO              Enables debug logging to observe kernel path
+ *   HSA_NO_SCRATCH_RECLAIM=1     Required for multi-GPU RCCL tests
+ *
+ * Run examples:
+ *   mpirun -np 2 --bind-to none ./rccl-UnitTestsMPI --gtest_filter=SymWin_*
+ *   mpirun -np 8 --bind-to none -x NCCL_DEBUG=INFO \
+ *     ./rccl-UnitTestsMPI --gtest_filter=SymWin_AllReduce.*
+ */
+
+#include "DeviceBufferHelpers.hpp"
+#include "MPITestBase.hpp"
+#include "MPIHelpers.hpp"
+#include "ResourceGuards.hpp"
+#include "TestChecks.hpp"
+#include <cstdlib>
+
+#ifdef MPI_TESTS_ENABLED
+
+using namespace MPITestConstants;
+using namespace RCCLTestGuards;
+using namespace RCCLTestHelpers;
+
+namespace {
+    constexpr size_t DEFAULT_COUNT = 256 * 1024;
+    constexpr int MIN_RANKS = 2;
+}
+
+// ============================================================================
+// Base class for symmetric window tests
+// ============================================================================
+
+class SymmetricWindowTestBase : public MPITestBase
+{
+protected:
+    struct NcclBufInfo {
+        void* ptr = nullptr;
+        size_t size = 0;
+    };
+
+    struct WinInfo {
+        ncclWindow_t win = nullptr;
+        ncclComm_t comm = nullptr;
+    };
+
+    std::vector<NcclBufInfo> allocatedBufs_;
+    std::vector<WinInfo> registeredWins_;
+
+    void TearDown() override
+    {
+        for (auto it = registeredWins_.rbegin(); it != registeredWins_.rend(); ++it) {
+            if (it->win && it->comm) {
+                ncclCommWindowDeregister(it->comm, it->win);
+            }
+        }
+        registeredWins_.clear();
+
+        for (auto it = allocatedBufs_.rbegin(); it != allocatedBufs_.rend(); ++it) {
+            if (it->ptr) {
+                ncclMemFree(it->ptr);
+            }
+        }
+        allocatedBufs_.clear();
+
+        MPITestBase::TearDown();
+    }
+
+    void* allocNcclBuf(size_t size)
+    {
+        void* ptr = nullptr;
+        ncclResult_t res = ncclMemAlloc(&ptr, size);
+        if (res != ncclSuccess || ptr == nullptr) return nullptr;
+        allocatedBufs_.push_back({ptr, size});
+        return ptr;
+    }
+
+    ncclWindow_t registerWindow(ncclComm_t comm, void* buf, size_t size,
+                                int flags = NCCL_WIN_COLL_SYMMETRIC)
+    {
+        ncclWindow_t win = nullptr;
+        ncclResult_t res = ncclCommWindowRegister(comm, buf, size, &win, flags);
+        if (res != ncclSuccess) return nullptr;
+        registeredWins_.push_back({win, comm});
+        return win;
+    }
+
+    bool setupForSymmetric(int minRanks = MIN_RANKS)
+    {
+        if (!validateTestPrerequisites(minRanks)) return false;
+        if (createTestCommunicator() != ncclSuccess) return false;
+
+        // Verify ncclMemAlloc works (proxy check for VMM/symmetric support)
+        void* testBuf = nullptr;
+        ncclResult_t res = ncclMemAlloc(&testBuf, 4096);
+        if (res != ncclSuccess || testBuf == nullptr) return false;
+        ncclMemFree(testBuf);
+
+        return true;
+    }
+
+    template<typename T>
+    void initSendBuffer(void* buffer, size_t count, int rank)
+    {
+        ASSERT_MPI_EQ(hipSuccess, initializeBufferWithPattern<T>(buffer, count,
+            [rank](size_t) { return static_cast<T>(static_cast<float>(rank + 1)); }));
+    }
+
+    template<typename T>
+    bool checkAllReduceResult(void* buffer, size_t count, int nRanks)
+    {
+        T expected = static_cast<T>(static_cast<float>(nRanks * (nRanks + 1) / 2));
+        return verifyBufferData<T>(buffer, count, [expected](size_t) { return expected; });
+    }
+
+    template<typename T>
+    bool checkReduceScatterResult(void* buffer, size_t count, int nRanks)
+    {
+        T expected = static_cast<T>(static_cast<float>(nRanks * (nRanks + 1) / 2));
+        return verifyBufferData<T>(buffer, count, [expected](size_t) { return expected; });
+    }
+
+    template<typename T>
+    bool checkAllGatherResult(void* buffer, size_t countPerRank, int nRanks)
+    {
+        return verifyBufferData<T>(buffer, countPerRank * nRanks,
+            [countPerRank](size_t i) {
+                int srcRank = i / countPerRank;
+                return static_cast<T>(static_cast<float>(srcRank + 1));
+            });
+    }
+};
+
+// ============================================================================
+// AllReduce with symmetric windows
+// ============================================================================
+
+class SymWin_AllReduce : public SymmetricWindowTestBase {};
+
+TEST_F(SymWin_AllReduce, BothWindows_OutOfPlace)
+{
+    if (!setupForSymmetric()) {
+        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+    }
+
+    using T = float;
+    const size_t count = DEFAULT_COUNT;
+    const size_t bufSize = count * sizeof(T);
+
+    ncclComm_t comm = getActiveCommunicator();
+    hipStream_t stream = getActiveStream();
+    int rank, nRanks;
+    ncclCommUserRank(comm, &rank);
+    ncclCommCount(comm, &nRanks);
+
+    void* sendBuf = allocNcclBuf(bufSize);
+    void* recvBuf = allocNcclBuf(bufSize);
+    ASSERT_MPI_NE(sendBuf, nullptr);
+    ASSERT_MPI_NE(recvBuf, nullptr);
+
+    ncclWindow_t sendWin = registerWindow(comm, sendBuf, bufSize);
+    ncclWindow_t recvWin = registerWindow(comm, recvBuf, bufSize);
+    ASSERT_MPI_NE(sendWin, nullptr);
+    ASSERT_MPI_NE(recvWin, nullptr);
+
+    initSendBuffer<T>(sendBuf, count, rank);
+
+    ASSERT_MPI_EQ(ncclSuccess,
+        ncclAllReduce(sendBuf, recvBuf, count, ncclFloat, ncclSum, comm, stream));
+    ASSERT_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+    ASSERT_TRUE(checkAllReduceResult<T>(recvBuf, count, nRanks));
+    TEST_INFO("Rank %d: BothWindows_OutOfPlace passed", rank);
+}
+
+TEST_F(SymWin_AllReduce, BothWindows_InPlace)
+{
+    if (!setupForSymmetric()) {
+        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+    }
+
+    using T = float;
+    const size_t count = DEFAULT_COUNT;
+    const size_t bufSize = count * sizeof(T);
+
+    ncclComm_t comm = getActiveCommunicator();
+    hipStream_t stream = getActiveStream();
+    int rank, nRanks;
+    ncclCommUserRank(comm, &rank);
+    ncclCommCount(comm, &nRanks);
+
+    void* buf = allocNcclBuf(bufSize);
+    ASSERT_MPI_NE(buf, nullptr);
+
+    ncclWindow_t win = registerWindow(comm, buf, bufSize);
+    ASSERT_MPI_NE(win, nullptr);
+
+    initSendBuffer<T>(buf, count, rank);
+
+    ASSERT_MPI_EQ(ncclSuccess,
+        ncclAllReduce(buf, buf, count, ncclFloat, ncclSum, comm, stream));
+    ASSERT_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+    ASSERT_TRUE(checkAllReduceResult<T>(buf, count, nRanks));
+    TEST_INFO("Rank %d: BothWindows_InPlace passed", rank);
+}
+
+TEST_F(SymWin_AllReduce, OnlySendWindow_OutOfPlace)
+{
+    if (!setupForSymmetric()) {
+        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+    }
+
+    using T = float;
+    const size_t count = DEFAULT_COUNT;
+    const size_t bufSize = count * sizeof(T);
+
+    ncclComm_t comm = getActiveCommunicator();
+    hipStream_t stream = getActiveStream();
+    int rank, nRanks;
+    ncclCommUserRank(comm, &rank);
+    ncclCommCount(comm, &nRanks);
+
+    void* sendBuf = allocNcclBuf(bufSize);
+    void* recvBuf = allocNcclBuf(bufSize);
+    ASSERT_MPI_NE(sendBuf, nullptr);
+    ASSERT_MPI_NE(recvBuf, nullptr);
+
+    // Register ONLY send buffer
+    ncclWindow_t sendWin = registerWindow(comm, sendBuf, bufSize);
+    ASSERT_MPI_NE(sendWin, nullptr);
+    // recvBuf intentionally NOT registered
+
+    initSendBuffer<T>(sendBuf, count, rank);
+
+    ASSERT_MPI_EQ(ncclSuccess,
+        ncclAllReduce(sendBuf, recvBuf, count, ncclFloat, ncclSum, comm, stream));
+    ASSERT_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+    ASSERT_TRUE(checkAllReduceResult<T>(recvBuf, count, nRanks));
+    TEST_INFO("Rank %d: OnlySendWindow_OutOfPlace passed (relaxed path)", rank);
+}
+
+TEST_F(SymWin_AllReduce, OnlyRecvWindow_OutOfPlace)
+{
+    if (!setupForSymmetric()) {
+        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+    }
+
+    using T = float;
+    const size_t count = DEFAULT_COUNT;
+    const size_t bufSize = count * sizeof(T);
+
+    ncclComm_t comm = getActiveCommunicator();
+    hipStream_t stream = getActiveStream();
+    int rank, nRanks;
+    ncclCommUserRank(comm, &rank);
+    ncclCommCount(comm, &nRanks);
+
+    void* sendBuf = allocNcclBuf(bufSize);
+    void* recvBuf = allocNcclBuf(bufSize);
+    ASSERT_MPI_NE(sendBuf, nullptr);
+    ASSERT_MPI_NE(recvBuf, nullptr);
+
+    // Register ONLY recv buffer
+    // sendBuf intentionally NOT registered
+    ncclWindow_t recvWin = registerWindow(comm, recvBuf, bufSize);
+    ASSERT_MPI_NE(recvWin, nullptr);
+
+    initSendBuffer<T>(sendBuf, count, rank);
+
+    ASSERT_MPI_EQ(ncclSuccess,
+        ncclAllReduce(sendBuf, recvBuf, count, ncclFloat, ncclSum, comm, stream));
+    ASSERT_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+    ASSERT_TRUE(checkAllReduceResult<T>(recvBuf, count, nRanks));
+    TEST_INFO("Rank %d: OnlyRecvWindow_OutOfPlace passed (relaxed path)", rank);
+}
+
+TEST_F(SymWin_AllReduce, NoWindows_OutOfPlace)
+{
+    if (!setupForSymmetric()) {
+        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+    }
+
+    using T = float;
+    const size_t count = DEFAULT_COUNT;
+    const size_t bufSize = count * sizeof(T);
+
+    ncclComm_t comm = getActiveCommunicator();
+    hipStream_t stream = getActiveStream();
+    int rank, nRanks;
+    ncclCommUserRank(comm, &rank);
+    ncclCommCount(comm, &nRanks);
+
+    void* sendBuf = allocNcclBuf(bufSize);
+    void* recvBuf = allocNcclBuf(bufSize);
+    ASSERT_MPI_NE(sendBuf, nullptr);
+    ASSERT_MPI_NE(recvBuf, nullptr);
+
+    // No window registration — non-symmetric fallback path
+    initSendBuffer<T>(sendBuf, count, rank);
+
+    ASSERT_MPI_EQ(ncclSuccess,
+        ncclAllReduce(sendBuf, recvBuf, count, ncclFloat, ncclSum, comm, stream));
+    ASSERT_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+    ASSERT_TRUE(checkAllReduceResult<T>(recvBuf, count, nRanks));
+    TEST_INFO("Rank %d: NoWindows_OutOfPlace passed (non-symmetric fallback)", rank);
+}
+
+TEST_F(SymWin_AllReduce, SingleWindow_InPlace)
+{
+    if (!setupForSymmetric()) {
+        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+    }
+
+    using T = float;
+    const size_t count = DEFAULT_COUNT;
+    const size_t bufSize = count * sizeof(T);
+
+    ncclComm_t comm = getActiveCommunicator();
+    hipStream_t stream = getActiveStream();
+    int rank, nRanks;
+    ncclCommUserRank(comm, &rank);
+    ncclCommCount(comm, &nRanks);
+
+    void* buf = allocNcclBuf(bufSize);
+    ASSERT_MPI_NE(buf, nullptr);
+
+    // Single window registration, in-place operation — primary one-buffer use case
+    ncclWindow_t win = registerWindow(comm, buf, bufSize);
+    ASSERT_MPI_NE(win, nullptr);
+
+    initSendBuffer<T>(buf, count, rank);
+
+    ASSERT_MPI_EQ(ncclSuccess,
+        ncclAllReduce(buf, buf, count, ncclFloat, ncclSum, comm, stream));
+    ASSERT_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+    ASSERT_TRUE(checkAllReduceResult<T>(buf, count, nRanks));
+    TEST_INFO("Rank %d: SingleWindow_InPlace passed (one-buffer path)", rank);
+}
+
+// ============================================================================
+// ReduceScatter with symmetric windows
+// ============================================================================
+
+class SymWin_ReduceScatter : public SymmetricWindowTestBase {};
+
+TEST_F(SymWin_ReduceScatter, BothWindows)
+{
+    if (!setupForSymmetric()) {
+        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+    }
+
+    using T = float;
+    const size_t countPerRank = DEFAULT_COUNT;
+
+    ncclComm_t comm = getActiveCommunicator();
+    hipStream_t stream = getActiveStream();
+    int rank, nRanks;
+    ncclCommUserRank(comm, &rank);
+    ncclCommCount(comm, &nRanks);
+
+    const size_t sendSize = countPerRank * nRanks * sizeof(T);
+    const size_t recvSize = countPerRank * sizeof(T);
+
+    void* sendBuf = allocNcclBuf(sendSize);
+    void* recvBuf = allocNcclBuf(recvSize);
+    ASSERT_MPI_NE(sendBuf, nullptr);
+    ASSERT_MPI_NE(recvBuf, nullptr);
+
+    ncclWindow_t sendWin = registerWindow(comm, sendBuf, sendSize);
+    ncclWindow_t recvWin = registerWindow(comm, recvBuf, recvSize);
+    ASSERT_MPI_NE(sendWin, nullptr);
+    ASSERT_MPI_NE(recvWin, nullptr);
+
+    initSendBuffer<T>(sendBuf, countPerRank * nRanks, rank);
+
+    ASSERT_MPI_EQ(ncclSuccess,
+        ncclReduceScatter(sendBuf, recvBuf, countPerRank, ncclFloat, ncclSum, comm, stream));
+    ASSERT_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+    ASSERT_TRUE(checkReduceScatterResult<T>(recvBuf, countPerRank, nRanks));
+    TEST_INFO("Rank %d: ReduceScatter BothWindows passed", rank);
+}
+
+TEST_F(SymWin_ReduceScatter, OnlySendWindow)
+{
+    if (!setupForSymmetric()) {
+        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+    }
+
+    using T = float;
+    const size_t countPerRank = DEFAULT_COUNT;
+
+    ncclComm_t comm = getActiveCommunicator();
+    hipStream_t stream = getActiveStream();
+    int rank, nRanks;
+    ncclCommUserRank(comm, &rank);
+    ncclCommCount(comm, &nRanks);
+
+    const size_t sendSize = countPerRank * nRanks * sizeof(T);
+    const size_t recvSize = countPerRank * sizeof(T);
+
+    void* sendBuf = allocNcclBuf(sendSize);
+    void* recvBuf = allocNcclBuf(recvSize);
+    ASSERT_MPI_NE(sendBuf, nullptr);
+    ASSERT_MPI_NE(recvBuf, nullptr);
+
+    // Only send buffer registered
+    ncclWindow_t sendWin = registerWindow(comm, sendBuf, sendSize);
+    ASSERT_MPI_NE(sendWin, nullptr);
+
+    initSendBuffer<T>(sendBuf, countPerRank * nRanks, rank);
+
+    ASSERT_MPI_EQ(ncclSuccess,
+        ncclReduceScatter(sendBuf, recvBuf, countPerRank, ncclFloat, ncclSum, comm, stream));
+    ASSERT_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+    ASSERT_TRUE(checkReduceScatterResult<T>(recvBuf, countPerRank, nRanks));
+    TEST_INFO("Rank %d: ReduceScatter OnlySendWindow passed (relaxed path)", rank);
+}
+
+TEST_F(SymWin_ReduceScatter, NoWindows)
+{
+    if (!setupForSymmetric()) {
+        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+    }
+
+    using T = float;
+    const size_t countPerRank = DEFAULT_COUNT;
+
+    ncclComm_t comm = getActiveCommunicator();
+    hipStream_t stream = getActiveStream();
+    int rank, nRanks;
+    ncclCommUserRank(comm, &rank);
+    ncclCommCount(comm, &nRanks);
+
+    const size_t sendSize = countPerRank * nRanks * sizeof(T);
+    const size_t recvSize = countPerRank * sizeof(T);
+
+    void* sendBuf = allocNcclBuf(sendSize);
+    void* recvBuf = allocNcclBuf(recvSize);
+    ASSERT_MPI_NE(sendBuf, nullptr);
+    ASSERT_MPI_NE(recvBuf, nullptr);
+
+    initSendBuffer<T>(sendBuf, countPerRank * nRanks, rank);
+
+    ASSERT_MPI_EQ(ncclSuccess,
+        ncclReduceScatter(sendBuf, recvBuf, countPerRank, ncclFloat, ncclSum, comm, stream));
+    ASSERT_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+    ASSERT_TRUE(checkReduceScatterResult<T>(recvBuf, countPerRank, nRanks));
+    TEST_INFO("Rank %d: ReduceScatter NoWindows passed (non-symmetric fallback)", rank);
+}
+
+// ============================================================================
+// AllGather with symmetric windows
+// ============================================================================
+
+class SymWin_AllGather : public SymmetricWindowTestBase {};
+
+TEST_F(SymWin_AllGather, BothWindows)
+{
+    if (!setupForSymmetric()) {
+        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+    }
+
+    using T = float;
+    const size_t countPerRank = DEFAULT_COUNT;
+
+    ncclComm_t comm = getActiveCommunicator();
+    hipStream_t stream = getActiveStream();
+    int rank, nRanks;
+    ncclCommUserRank(comm, &rank);
+    ncclCommCount(comm, &nRanks);
+
+    const size_t sendSize = countPerRank * sizeof(T);
+    const size_t recvSize = countPerRank * nRanks * sizeof(T);
+
+    void* sendBuf = allocNcclBuf(sendSize);
+    void* recvBuf = allocNcclBuf(recvSize);
+    ASSERT_MPI_NE(sendBuf, nullptr);
+    ASSERT_MPI_NE(recvBuf, nullptr);
+
+    ncclWindow_t sendWin = registerWindow(comm, sendBuf, sendSize);
+    ncclWindow_t recvWin = registerWindow(comm, recvBuf, recvSize);
+    ASSERT_MPI_NE(sendWin, nullptr);
+    ASSERT_MPI_NE(recvWin, nullptr);
+
+    initSendBuffer<T>(sendBuf, countPerRank, rank);
+
+    ASSERT_MPI_EQ(ncclSuccess,
+        ncclAllGather(sendBuf, recvBuf, countPerRank, ncclFloat, comm, stream));
+    ASSERT_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+    ASSERT_TRUE(checkAllGatherResult<T>(recvBuf, countPerRank, nRanks));
+    TEST_INFO("Rank %d: AllGather BothWindows passed", rank);
+}
+
+TEST_F(SymWin_AllGather, OnlyRecvWindow)
+{
+    if (!setupForSymmetric()) {
+        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+    }
+
+    using T = float;
+    const size_t countPerRank = DEFAULT_COUNT;
+
+    ncclComm_t comm = getActiveCommunicator();
+    hipStream_t stream = getActiveStream();
+    int rank, nRanks;
+    ncclCommUserRank(comm, &rank);
+    ncclCommCount(comm, &nRanks);
+
+    const size_t sendSize = countPerRank * sizeof(T);
+    const size_t recvSize = countPerRank * nRanks * sizeof(T);
+
+    void* sendBuf = allocNcclBuf(sendSize);
+    void* recvBuf = allocNcclBuf(recvSize);
+    ASSERT_MPI_NE(sendBuf, nullptr);
+    ASSERT_MPI_NE(recvBuf, nullptr);
+
+    // Only recv buffer registered
+    ncclWindow_t recvWin = registerWindow(comm, recvBuf, recvSize);
+    ASSERT_MPI_NE(recvWin, nullptr);
+
+    initSendBuffer<T>(sendBuf, countPerRank, rank);
+
+    ASSERT_MPI_EQ(ncclSuccess,
+        ncclAllGather(sendBuf, recvBuf, countPerRank, ncclFloat, comm, stream));
+    ASSERT_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+    ASSERT_TRUE(checkAllGatherResult<T>(recvBuf, countPerRank, nRanks));
+    TEST_INFO("Rank %d: AllGather OnlyRecvWindow passed (relaxed path)", rank);
+}
+
+TEST_F(SymWin_AllGather, NoWindows)
+{
+    if (!setupForSymmetric()) {
+        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+    }
+
+    using T = float;
+    const size_t countPerRank = DEFAULT_COUNT;
+
+    ncclComm_t comm = getActiveCommunicator();
+    hipStream_t stream = getActiveStream();
+    int rank, nRanks;
+    ncclCommUserRank(comm, &rank);
+    ncclCommCount(comm, &nRanks);
+
+    const size_t sendSize = countPerRank * sizeof(T);
+    const size_t recvSize = countPerRank * nRanks * sizeof(T);
+
+    void* sendBuf = allocNcclBuf(sendSize);
+    void* recvBuf = allocNcclBuf(recvSize);
+    ASSERT_MPI_NE(sendBuf, nullptr);
+    ASSERT_MPI_NE(recvBuf, nullptr);
+
+    initSendBuffer<T>(sendBuf, countPerRank, rank);
+
+    ASSERT_MPI_EQ(ncclSuccess,
+        ncclAllGather(sendBuf, recvBuf, countPerRank, ncclFloat, comm, stream));
+    ASSERT_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+    ASSERT_TRUE(checkAllGatherResult<T>(recvBuf, countPerRank, nRanks));
+    TEST_INFO("Rank %d: AllGather NoWindows passed (non-symmetric fallback)", rank);
+}
+
+// ============================================================================
+// Window lifecycle tests
+// ============================================================================
+
+class SymWin_WindowLifecycle : public SymmetricWindowTestBase {};
+
+TEST_F(SymWin_WindowLifecycle, RegisterDeregister_Basic)
+{
+    if (!setupForSymmetric()) {
+        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+    }
+
+    ncclComm_t comm = getActiveCommunicator();
+    int rank;
+    ncclCommUserRank(comm, &rank);
+
+    const size_t bufSize = 1024 * 1024;
+    void* buf = allocNcclBuf(bufSize);
+    ASSERT_MPI_NE(buf, nullptr);
+
+    ncclWindow_t win = nullptr;
+    ASSERT_MPI_EQ(ncclSuccess,
+        ncclCommWindowRegister(comm, buf, bufSize, &win, NCCL_WIN_COLL_SYMMETRIC));
+    ASSERT_MPI_NE(win, nullptr);
+
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowDeregister(comm, win));
+
+    // Remove from auto-cleanup since we already deregistered
+    for (auto it = registeredWins_.begin(); it != registeredWins_.end(); ++it) {
+        if (it->win == win) {
+            it->win = nullptr;
+            break;
+        }
+    }
+
+    TEST_INFO("Rank %d: RegisterDeregister_Basic passed", rank);
+}
+
+TEST_F(SymWin_WindowLifecycle, MultipleWindows)
+{
+    if (!setupForSymmetric()) {
+        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+    }
+
+    ncclComm_t comm = getActiveCommunicator();
+    int rank;
+    ncclCommUserRank(comm, &rank);
+
+    const int numWindows = 4;
+    const size_t bufSize = 256 * 1024;
+    std::vector<ncclWindow_t> wins(numWindows);
+
+    for (int i = 0; i < numWindows; i++) {
+        void* buf = allocNcclBuf(bufSize);
+        ASSERT_MPI_NE(buf, nullptr) << "Failed to allocate buffer " << i;
+
+        wins[i] = registerWindow(comm, buf, bufSize);
+        ASSERT_MPI_NE(wins[i], nullptr) << "Failed to register window " << i;
+    }
+
+    // Verify all windows are unique
+    for (int i = 0; i < numWindows; i++) {
+        for (int j = i + 1; j < numWindows; j++) {
+            ASSERT_MPI_NE(wins[i], wins[j])
+                << "Windows " << i << " and " << j << " are not unique";
+        }
+    }
+
+    TEST_INFO("Rank %d: MultipleWindows passed (%d windows)", rank, numWindows);
+}
+
+TEST_F(SymWin_WindowLifecycle, RepeatedRegisterDeregister)
+{
+    if (!setupForSymmetric()) {
+        GTEST_SKIP() << "Requires symmetric support with 2+ ranks";
+    }
+
+    ncclComm_t comm = getActiveCommunicator();
+    int rank;
+    ncclCommUserRank(comm, &rank);
+
+    const size_t bufSize = 512 * 1024;
+    void* buf = allocNcclBuf(bufSize);
+    ASSERT_MPI_NE(buf, nullptr);
+
+    const int iterations = 3;
+    for (int i = 0; i < iterations; i++) {
+        ncclWindow_t win = nullptr;
+        ASSERT_MPI_EQ(ncclSuccess,
+            ncclCommWindowRegister(comm, buf, bufSize, &win, NCCL_WIN_COLL_SYMMETRIC))
+            << "Registration failed on iteration " << i;
+        ASSERT_MPI_NE(win, nullptr);
+
+        ASSERT_MPI_EQ(ncclSuccess, ncclCommWindowDeregister(comm, win))
+            << "Deregistration failed on iteration " << i;
+    }
+
+    TEST_INFO("Rank %d: RepeatedRegisterDeregister passed (%d iterations)",
+              rank, iterations);
+}
+
+#endif // MPI_TESTS_ENABLED

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -1361,6 +1361,96 @@
       ]
     },
 
+    "symmetric_window_tests": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 2,
+      "num_nodes": 1,
+      "num_gpus": 2,
+      "timeout": 180,
+      "env_variables": {
+        "NCCL_DEBUG": "INFO",
+        "NCCL_CUMEM_ENABLE": "1"
+      },
+      "tests": [
+        {
+          "name": "SymWin_AllReduce_BothWindows_OutOfPlace",
+          "description": "AllReduce with both send and recv windows registered (symmetric baseline)",
+          "test_filter": "SymWin_AllReduce.BothWindows_OutOfPlace"
+        },
+        {
+          "name": "SymWin_AllReduce_BothWindows_InPlace",
+          "description": "AllReduce in-place with single buffer registered as window",
+          "test_filter": "SymWin_AllReduce.BothWindows_InPlace"
+        },
+        {
+          "name": "SymWin_AllReduce_OnlySendWindow",
+          "description": "AllReduce with only send buffer registered (relaxed one-buffer path)",
+          "test_filter": "SymWin_AllReduce.OnlySendWindow_OutOfPlace"
+        },
+        {
+          "name": "SymWin_AllReduce_OnlyRecvWindow",
+          "description": "AllReduce with only recv buffer registered (relaxed one-buffer path)",
+          "test_filter": "SymWin_AllReduce.OnlyRecvWindow_OutOfPlace"
+        },
+        {
+          "name": "SymWin_AllReduce_NoWindows",
+          "description": "AllReduce without window registration (non-symmetric fallback)",
+          "test_filter": "SymWin_AllReduce.NoWindows_OutOfPlace"
+        },
+        {
+          "name": "SymWin_AllReduce_SingleWindow_InPlace",
+          "description": "AllReduce in-place with single window (primary one-buffer use case)",
+          "test_filter": "SymWin_AllReduce.SingleWindow_InPlace"
+        },
+        {
+          "name": "SymWin_ReduceScatter_BothWindows",
+          "description": "ReduceScatter with both windows registered",
+          "test_filter": "SymWin_ReduceScatter.BothWindows"
+        },
+        {
+          "name": "SymWin_ReduceScatter_OnlySendWindow",
+          "description": "ReduceScatter with only send window (relaxed path)",
+          "test_filter": "SymWin_ReduceScatter.OnlySendWindow"
+        },
+        {
+          "name": "SymWin_ReduceScatter_NoWindows",
+          "description": "ReduceScatter without windows (fallback)",
+          "test_filter": "SymWin_ReduceScatter.NoWindows"
+        },
+        {
+          "name": "SymWin_AllGather_BothWindows",
+          "description": "AllGather with both windows registered",
+          "test_filter": "SymWin_AllGather.BothWindows"
+        },
+        {
+          "name": "SymWin_AllGather_OnlyRecvWindow",
+          "description": "AllGather with only recv window (relaxed path)",
+          "test_filter": "SymWin_AllGather.OnlyRecvWindow"
+        },
+        {
+          "name": "SymWin_AllGather_NoWindows",
+          "description": "AllGather without windows (fallback)",
+          "test_filter": "SymWin_AllGather.NoWindows"
+        },
+        {
+          "name": "SymWin_WindowLifecycle_Basic",
+          "description": "Basic window register/deregister lifecycle",
+          "test_filter": "SymWin_WindowLifecycle.RegisterDeregister_Basic"
+        },
+        {
+          "name": "SymWin_WindowLifecycle_Multiple",
+          "description": "Multiple independent window registrations",
+          "test_filter": "SymWin_WindowLifecycle.MultipleWindows"
+        },
+        {
+          "name": "SymWin_WindowLifecycle_Repeated",
+          "description": "Repeated register/deregister cycles",
+          "test_filter": "SymWin_WindowLifecycle.RepeatedRegisterDeregister"
+        }
+      ]
+    },
     "net_ib_branch_coverage": {
       "extends": "net_ib_base",
       "timeout": 60,
@@ -3626,6 +3716,12 @@
       "name": "Host API Tests - Default",
       "description": "Host API tests with default memory support",
       "config": "host_api_tests_default",
+      "enabled": true
+    },
+    {
+      "name": "Symmetric Window Tests - Single Node",
+      "description": "Symmetric window registration tests for relaxed one-buffer path validation",
+      "config": "symmetric_window_tests",
       "enabled": true
     }
   ]

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -1380,11 +1380,6 @@
           "test_filter": "SymWin_AllReduce.BothWindows_OutOfPlace"
         },
         {
-          "name": "SymWin_AllReduce_BothWindows_InPlace",
-          "description": "AllReduce in-place with single buffer registered as window",
-          "test_filter": "SymWin_AllReduce.BothWindows_InPlace"
-        },
-        {
           "name": "SymWin_AllReduce_OnlySendWindow",
           "description": "AllReduce with only send buffer registered (relaxed one-buffer path)",
           "test_filter": "SymWin_AllReduce.OnlySendWindow_OutOfPlace"


### PR DESCRIPTION
## Summary
- Adds 15 MPI-based tests validating symmetric window registration across all buffer registration patterns: both-registered (baseline), one-registered (relaxed/one-buffer path), none-registered (non-symmetric fallback), and in-place operations
- Covers AllReduce, ReduceScatter, and AllGather collectives plus window lifecycle tests (register/deregister, multiple windows, repeated cycles)
- Registers tests in CMakeLists.txt and adds test runner config entries in `mi300x_mellanox_ib.json`
- Sets `NCCL_CUMEM_ENABLE=1` in test config so `comm->symmetricSupport` is enabled and tests exercise the symmetric kernel path (addresses review feedback from #8088)

Replaces #8088 (rebased cleanly onto develop without the NCCL sync merge commit)

JIRA ID: AICOMRCCL-1180

## Test plan
- [ ] Build with `./install.sh --debug -t -l --enable-mpi-tests`
- [ ] Run: `mpirun -np 2 --bind-to none -x NCCL_DEBUG=INFO -x NCCL_CUMEM_ENABLE=1 ./build/debug/test/rccl-UnitTestsMPI --gtest_filter="SymWin_*"`
- [ ] Verify "both-windows" tests use symmetric kernel path (check NCCL_DEBUG output)
- [ ] Verify "no-windows" tests fall back to non-symmetric path
- [ ] Verify "one-window" tests produce correct results (will use symmetric path once relaxed registration is ported)

AICOMRCCL-1180

🤖 Generated with [Claude Code](https://claude.com/claude-code)