### PR TITLE
feat(rccl): Lazily initialize PAT queue pairs

### DIFF
--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -651,7 +651,8 @@ ncclResult_t ncclPrepareTasks(struct ncclComm* comm, bool* algoNeedConnect, bool
     bool regNeedConnect = true;
     ncclRegisterCollNvlsBuffers(comm, task, regBufSend, regBufRecv, &planner->collCleanupQueue, &regNeedConnect);
 
-    if (comm->runtimeConn && comm->initAlgoChannels[task->algorithm] == false) {
+    // Connect PAT on demand even when runtimeConn is off (ROCm default), so PAT QPs are created lazily on first PAT collective.
+    if ((comm->runtimeConn || task->algorithm == NCCL_ALGO_PAT) && comm->initAlgoChannels[task->algorithm] == false) {
       if (task->algorithm == NCCL_ALGO_NVLS_TREE && comm->initAlgoChannels[NCCL_ALGO_NVLS] == false &&
           regNeedConnect == true) {
         comm->initAlgoChannels[NCCL_ALGO_NVLS] = true;

--- a/projects/rccl/src/group.cc
+++ b/projects/rccl/src/group.cc
@@ -229,7 +229,8 @@ ncclResult_t ncclPrepareTasksAndCollPreconnectFunc(struct ncclAsyncJob* job_) {
   CUDACHECK(cudaSetDevice(comm->cudaDev));
   if (!job_->isThreadMain && ncclOsCpuCount(comm->cpuAffinity)) ncclOsSetAffinity(comm->cpuAffinity);
   NCCLCHECK(ncclPrepareTasks(comm, algoNeedConnect, &needConnect, job->simInfo));
-  if (comm->cuMemSupport && needConnect) {
+  // Allow on-demand PAT connection without cuMem support (ROCm default), so PAT QPs can be created lazily.
+  if ((comm->cuMemSupport || algoNeedConnect[NCCL_ALGO_PAT]) && needConnect) {
     // Preconnect is not meant to be captured;
     // swap to relaxed mode so CUDA graph capture works correctly.
     cudaStreamCaptureMode mode = cudaStreamCaptureModeRelaxed;
@@ -650,7 +651,8 @@ static ncclResult_t ncclPrepareTasksAndCollPreconnect(
     CUDACHECK(cudaSetDevice(comm->cudaDev));
     NCCLCHECK(ncclPrepareTasks(comm, algoNeedConnect, &needConnect, simInfo));
 
-    if (comm->cuMemSupport && needConnect) {
+    // Allow on-demand PAT connection without cuMem support (ROCm default), so PAT QPs can be created lazily.
+    if ((comm->cuMemSupport || algoNeedConnect[NCCL_ALGO_PAT]) && needConnect) {
       ncclResult_t ret;
       struct ncclPreconnectJob* job;
       NEW_NOTHROW(job, ncclPreconnectJob);

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -115,6 +115,8 @@ NCCL_PARAM(GroupCudaStream, "GROUP_CUDA_STREAM", NCCL_GROUP_CUDA_STREAM);
 NCCL_PARAM(CheckPointers, "CHECK_POINTERS", 0);
 NCCL_PARAM(CommBlocking, "COMM_BLOCKING", NCCL_CONFIG_UNDEF_INT);
 NCCL_PARAM(RuntimeConnect, "RUNTIME_CONNECT", 0);
+// When enabled (default), defer PAT QP creation until PAT is first selected by an AG/RS; NCCL_PAT_LAZY_INIT=0 restores eager connect at init.
+NCCL_PARAM(PatLazyInit, "PAT_LAZY_INIT", 1);
 NCCL_PARAM(WinEnable, "WIN_ENABLE", 1);
 NCCL_PARAM(CollnetEnable, "COLLNET_ENABLE", NCCL_CONFIG_UNDEF_INT);
 NCCL_PARAM(CtaPolicy, "CTA_POLICY", NCCL_CONFIG_UNDEF_INT);
@@ -2179,8 +2181,15 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
     NCCLCHECKGOTO(ncclTransportTreeConnect(comm), ret, fail);
 
     // Connect PAT only for communicators with 1 GPU per node and PAT enabled
-    if (comm->maxLocalRanks == 1 && (ncclParamPatEnable() || comm->forcePatEnable))
-      NCCLCHECKGOTO(ncclTransportPatConnect(comm), ret, fail);
+    if (comm->maxLocalRanks == 1 && (ncclParamPatEnable() || comm->forcePatEnable)) {
+      if (ncclParamPatLazyInit()) {
+        // Leave initAlgoChannels[PAT] unset so ncclPrepareTasks() triggers the on-demand connect (see enqueue.cc / group.cc ncclCollPreconnect).
+        INFO(NCCL_INIT, "PAT lazy init enabled: deferring PAT QP creation until first PAT collective");
+      } else {
+        NCCLCHECKGOTO(ncclTransportPatConnect(comm), ret, fail);
+        comm->initAlgoChannels[NCCL_ALGO_PAT] = true;
+      }
+    }
 
     // Attempt to setup NVLS
     NCCLCHECKGOTO(ncclNvlsSetup(comm, parent), ret, fail);

--- a/projects/rccl/test/CommMPITests.cpp
+++ b/projects/rccl/test/CommMPITests.cpp
@@ -105,6 +105,67 @@ protected:
     }
 };
 
+class PatLazyInitMPITest : public MPITestBase
+{};
+
+TEST_F(PatLazyInitMPITest, DefersConnectionUntilFirstCollective)
+{
+    ASSERT_MPI_TRUE(validateTestPrerequisites(/*min_processes=*/4));
+
+    MPI_Comm local_comm;
+    ASSERT_MPI_EQ(MPI_SUCCESS,
+                  MPI_Comm_split_type(
+                      MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &local_comm));
+    int local_size = 0;
+    ASSERT_MPI_EQ(MPI_SUCCESS, MPI_Comm_size(local_comm, &local_size));
+    ASSERT_MPI_EQ(MPI_SUCCESS, MPI_Comm_free(&local_comm));
+    if(local_size != 1)
+    {
+        GTEST_SKIP() << "PAT requires exactly one MPI rank per node";
+    }
+
+    MPIHelpers::MpiEnvGuard debug("NCCL_DEBUG", "INFO");
+    MPIHelpers::MpiEnvGuard debug_subsys("NCCL_DEBUG_SUBSYS", "INIT");
+    MPIHelpers::MpiEnvGuard pat_enable("NCCL_PAT_ENABLE", "1");
+    MPIHelpers::MpiEnvGuard pat_lazy("NCCL_PAT_LAZY_INIT", "1");
+    MPIHelpers::MpiEnvGuard algorithm("NCCL_ALGO", "PAT");
+    MPIHelpers::MpiEnvGuard protocol("NCCL_PROTO", "SIMPLE");
+    MPIHelpers::MpiEnvGuard cumem("NCCL_CUMEM_ENABLE", "0");
+    MPIHelpers::TestLogAssertionContext log_ctx(
+        MPIHelpers::makeNcclDebugFileAssertionOptions(getTestMpiRank()));
+
+    ASSERT_MPI_EQ(ncclSuccess, createTestCommunicator());
+
+    ncclComm_t comm = getActiveCommunicator();
+    ASSERT_MPI_TRUE(comm != nullptr);
+    ASSERT_MPI_FALSE(comm->initAlgoChannels[NCCL_ALGO_PAT]);
+
+    const std::string init_log = log_ctx.readNcclDebugLog();
+    ASSERT_MPI_TRUE(init_log.find("PAT lazy init enabled") != std::string::npos);
+    ASSERT_MPI_TRUE(init_log.find("Connected binomial trees") == std::string::npos);
+
+    void* send_buffer = nullptr;
+    void* recv_buffer = nullptr;
+    ASSERT_MPI_EQ(hipSuccess, hipMalloc(&send_buffer, sizeof(uint8_t)));
+    auto send_guard = makeDeviceBufferAutoGuard(send_buffer);
+    ASSERT_MPI_EQ(hipSuccess,
+                  hipMalloc(&recv_buffer, sizeof(uint8_t) * MPIEnvironment::world_size));
+    auto recv_guard = makeDeviceBufferAutoGuard(recv_buffer);
+
+    ASSERT_MPI_EQ(ncclSuccess,
+                  ncclAllGather(send_buffer,
+                                recv_buffer,
+                                1,
+                                ncclUint8,
+                                comm,
+                                getActiveStream()));
+    ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(getActiveStream()));
+
+    ASSERT_MPI_TRUE(comm->initAlgoChannels[NCCL_ALGO_PAT]);
+    const std::string collective_log = log_ctx.readNcclDebugLog();
+    ASSERT_MPI_TRUE(collective_log.find("Connected binomial trees") != std::string::npos);
+}
+
 /**
  * @class TrafficClassMPITest
  * @brief Test fixture for Traffic Class (QoS) configuration via ncclConfig_t.


### PR DESCRIPTION
## Motivation

PAT queue pairs were created eagerly at communicator init for every PAT-eligible comm, even when PAT is never selected. This defers that cost to the first collective that actually uses PAT.

## Technical Details

PAT QPs are created on the first AG/RS that selects PAT via the existing ncclCollPreconnect -> ncclTransportPatConnect path.

## JIRA ID

JIRA ID : AICOMRCCL-1521

## Test Plan

RCCL + rccl-tests on MI350X/gfx950, ROCm 7.0.2.2 at 8/16/32/64 nodes. 

## Test Result

Correct at all scales (0 out-of-bounds)
patConnect == nNodes in both modes 
Latency and bus bandwidth match eager within run-to-run noise

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
