### PR TITLE
[rocprofiler-sdk] address several hangs on bad input parameters

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/helper.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/helper.hpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/helper.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/helper.hpp
@@ -81,27 +81,20 @@
         }                                                                                          \
     }
 
-// Like ROCPROFILER_CALL, but intended for service-configuration calls that are
-// driven directly by user-supplied command-line options (e.g. ATT and
-// PC-sampling parameters). A failure here is almost always caused by an invalid
-// user parameter, so it must be reported as a clean, user-readable error with a
-// non-zero exit instead of aborting via a fatal log. Aborting would raise
-// SIGABRT and route through the process error/signal handler, which is both
-// hostile to users (no actionable message) and has historically deadlocked the
-// tool. ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT is treated as a user error;
-// any other unexpected status is still escalated as fatal for diagnosis.
+// Like ROCPROFILER_CALL, but reports bad arguments with ERROR instead of FATAL and informs the user
+// that there is a bad parameter.
 #define ROCPROFILER_CHECK_USER_CONFIG(result, msg)                                                 \
     {                                                                                              \
         rocprofiler_status_t ROCPROFILER_VARIABLE(USERCFGSTATUS, __LINE__) = result;               \
-        if(ROCPROFILER_VARIABLE(USERCFGSTATUS, __LINE__) ==                                         \
-           ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT)                                               \
+        if(ROCPROFILER_VARIABLE(USERCFGSTATUS, __LINE__) ==                                        \
+           ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT)                                              \
         {                                                                                          \
-            ROCP_ERROR << msg                                                                       \
+            ROCP_ERROR << msg                                                                      \
                        << " failed: one or more parameters are invalid. Please check the "         \
                           "corresponding command-line options and try again.";                     \
-            ::std::exit(EXIT_FAILURE);                                                              \
+            ::std::exit(EXIT_FAILURE);                                                             \
         }                                                                                          \
-        else if(ROCPROFILER_VARIABLE(USERCFGSTATUS, __LINE__) != ROCPROFILER_STATUS_SUCCESS)        \
+        else if(ROCPROFILER_VARIABLE(USERCFGSTATUS, __LINE__) != ROCPROFILER_STATUS_SUCCESS)       \
         {                                                                                          \
             std::string status_msg =                                                               \
                 rocprofiler_get_status_string(ROCPROFILER_VARIABLE(USERCFGSTATUS, __LINE__));      \

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/helper.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/helper.hpp
@@ -57,6 +57,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <cstdint>
+#include <cstdlib>
 #include <fstream>
 #include <iostream>
 #include <map>
@@ -77,6 +78,36 @@
             ROCP_FATAL << " :: [" << __FILE__ << ":" << __LINE__ << "]\n\t" << #result << "\n\n"   \
                        << msg << " failed with error code "                                        \
                        << ROCPROFILER_VARIABLE(CHECKSTATUS, __LINE__) << ": " << status_msg;       \
+        }                                                                                          \
+    }
+
+// Like ROCPROFILER_CALL, but intended for service-configuration calls that are
+// driven directly by user-supplied command-line options (e.g. ATT and
+// PC-sampling parameters). A failure here is almost always caused by an invalid
+// user parameter, so it must be reported as a clean, user-readable error with a
+// non-zero exit instead of aborting via a fatal log. Aborting would raise
+// SIGABRT and route through the process error/signal handler, which is both
+// hostile to users (no actionable message) and has historically deadlocked the
+// tool. ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT is treated as a user error;
+// any other unexpected status is still escalated as fatal for diagnosis.
+#define ROCPROFILER_CHECK_USER_CONFIG(result, msg)                                                 \
+    {                                                                                              \
+        rocprofiler_status_t ROCPROFILER_VARIABLE(USERCFGSTATUS, __LINE__) = result;               \
+        if(ROCPROFILER_VARIABLE(USERCFGSTATUS, __LINE__) ==                                         \
+           ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT)                                               \
+        {                                                                                          \
+            ROCP_ERROR << msg                                                                       \
+                       << " failed: one or more parameters are invalid. Please check the "         \
+                          "corresponding command-line options and try again.";                     \
+            ::std::exit(EXIT_FAILURE);                                                              \
+        }                                                                                          \
+        else if(ROCPROFILER_VARIABLE(USERCFGSTATUS, __LINE__) != ROCPROFILER_STATUS_SUCCESS)        \
+        {                                                                                          \
+            std::string status_msg =                                                               \
+                rocprofiler_get_status_string(ROCPROFILER_VARIABLE(USERCFGSTATUS, __LINE__));      \
+            ROCP_FATAL << " :: [" << __FILE__ << ":" << __LINE__ << "]\n\t" << #result << "\n\n"   \
+                       << msg << " failed with error code "                                        \
+                       << ROCPROFILER_VARIABLE(USERCFGSTATUS, __LINE__) << ": " << status_msg;     \
         }                                                                                          \
     }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -4106,6 +4106,10 @@ rocprofv3_error_signal_handler(int signo, siginfo_t* info, void* ucontext)
         ::_exit(128 + signo);
     }
 
+    // record the owning thread so that a recursive re-entry (e.g. a chained handler that re-raises
+    // the signal) is detected above instead of deadlocking in call_once.
+    _owner_tid.store(_self_tid, std::memory_order_release);
+
     ROCP_WARNING << fmt::format("[PPID={}][PID={}][TID={}][{}] rocprofv3 caught signal {}...",
                                 this_ppid,
                                 this_pid,
@@ -4115,11 +4119,6 @@ rocprofv3_error_signal_handler(int signo, siginfo_t* info, void* ucontext)
 
     static auto _once = std::once_flag{};
     std::call_once(_once, [&]() {
-        // record the owning thread so that a recursive re-entry (e.g. a chained
-        // handler that re-raises the signal) is detected at the top of the
-        // handler instead of deadlocking here.
-        _owner_tid.store(_self_tid, std::memory_order_release);
-
         auto get_children = [&this_pid]() {
             auto fname    = fmt::format("/proc/{}/task/{}/children", this_pid, this_pid);
             auto ifs      = std::ifstream{fname};

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -89,6 +89,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <algorithm>
+#include <atomic>
 #include <cassert>
 #include <cerrno>
 #include <chrono>
@@ -2257,7 +2258,7 @@ configure_pc_sampling_on_all_agents(uint64_t                        buffer_size,
         {
             config_match_found = true;
             int flags          = 0;
-            ROCPROFILER_CALL(
+            ROCPROFILER_CHECK_USER_CONFIG(
                 rocprofiler_configure_pc_sampling_service(get_client_ctx(),
                                                           itr->id,
                                                           method,
@@ -2945,7 +2946,15 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* tool_data)
         }
         else if(perfcounter_ctrl != 0 || !att_perf.empty())
         {
-            ROCP_FATAL << "ATT Perf requires setting both perfcounter_ctrl and perfcounter list!";
+            // Invalid user combination: only one of the two required perfcounter
+            // options was supplied. Report a clean, actionable error and exit
+            // non-zero instead of aborting (which would raise SIGABRT and go
+            // through the process error/signal handler).
+            ROCP_ERROR << "ATT perfcounter collection requires both '--att-perfcounters' (the "
+                          "perfcounter list) and '--att-perfcounter-ctrl' (the control value) to "
+                          "be set together; only one was provided. Please set both options or "
+                          "neither.";
+            std::exit(EXIT_FAILURE);
         }
 
         auto gpu_idx_set = std::set<uint64_t>{};
@@ -3040,7 +3049,7 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* tool_data)
             }
             else if(!handle_consecutive_kernels && !handle_marker_trace)
             {
-                ROCPROFILER_CALL(
+                ROCPROFILER_CHECK_USER_CONFIG(
                     rocprofiler_configure_dispatch_thread_trace_service(get_client_ctx(),
                                                                         id,
                                                                         agent_params.data(),
@@ -3052,7 +3061,7 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* tool_data)
             }
             else
             {
-                ROCPROFILER_CALL(
+                ROCPROFILER_CHECK_USER_CONFIG(
                     rocprofiler_configure_device_thread_trace_service(att_device_context,
                                                                       agent.id,
                                                                       agent_params.data(),
@@ -4091,6 +4100,23 @@ rocprofv3_error_signal_handler(int signo, siginfo_t* info, void* ucontext)
     auto this_tid  = common::get_tid();
     auto this_func = std::string_view{__FUNCTION__};
 
+    // Guard against same-thread re-entrancy. The cleanup below is not
+    // async-signal-safe (logging, finalize, executing chained handlers). If a
+    // chained handler re-raises the signal (e.g. glog/abseil re-aborting on
+    // SIGABRT after it has restored this handler), the handler is re-entered on
+    // the same thread. The std::call_once below would then deadlock (recursive
+    // call_once on the owning thread), so rocprofv3 hangs forever instead of
+    // exiting. On recursive entry, restore the default disposition and re-raise
+    // so the process terminates immediately rather than looping.
+    static std::atomic<long> _owner_tid{-1};
+    const auto               _self_tid = static_cast<long>(this_tid);
+    if(_owner_tid.load(std::memory_order_acquire) == _self_tid)
+    {
+        ::signal(signo, SIG_DFL);
+        ::raise(signo);
+        ::_exit(128 + signo);
+    }
+
     ROCP_WARNING << fmt::format("[PPID={}][PID={}][TID={}][{}] rocprofv3 caught signal {}...",
                                 this_ppid,
                                 this_pid,
@@ -4100,6 +4126,11 @@ rocprofv3_error_signal_handler(int signo, siginfo_t* info, void* ucontext)
 
     static auto _once = std::once_flag{};
     std::call_once(_once, [&]() {
+        // record the owning thread so that a recursive re-entry (e.g. a chained
+        // handler that re-raises the signal) is detected at the top of the
+        // handler instead of deadlocking here.
+        _owner_tid.store(_self_tid, std::memory_order_release);
+
         auto get_children = [&this_pid]() {
             auto fname    = fmt::format("/proc/{}/task/{}/children", this_pid, this_pid);
             auto ifs      = std::ifstream{fname};
@@ -4216,7 +4247,13 @@ rocprofv3_error_signal_handler(int signo, siginfo_t* info, void* ucontext)
 
     // below is for testing purposes. re-raising the signal causes CTest to ignore WILL_FAIL ON
     if(signal_handler_exit) ::quick_exit(signo);
+
+    // restore the default disposition before re-raising so that, even if a
+    // chained handler re-installed this handler during cleanup, the re-raise
+    // terminates the process instead of re-entering and looping.
+    ::signal(signo, SIG_DFL);
     ::raise(signo);
+    ::_exit(128 + signo);
 }
 
 int

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -2946,14 +2946,8 @@ tool_init(rocprofiler_client_finalize_t fini_func, void* tool_data)
         }
         else if(perfcounter_ctrl != 0 || !att_perf.empty())
         {
-            // Invalid user combination: only one of the two required perfcounter
-            // options was supplied. Report a clean, actionable error and exit
-            // non-zero instead of aborting (which would raise SIGABRT and go
-            // through the process error/signal handler).
-            ROCP_ERROR << "ATT perfcounter collection requires both '--att-perfcounters' (the "
-                          "perfcounter list) and '--att-perfcounter-ctrl' (the control value) to "
-                          "be set together; only one was provided. Please set both options or "
-                          "neither.";
+            ROCP_ERROR << "ATT perfcounter collection requires both '--att-perfcounters' and "
+                          "'--att-perfcounter-ctrl'. Set both options or neither.";
             std::exit(EXIT_FAILURE);
         }
 
@@ -4100,14 +4094,9 @@ rocprofv3_error_signal_handler(int signo, siginfo_t* info, void* ucontext)
     auto this_tid  = common::get_tid();
     auto this_func = std::string_view{__FUNCTION__};
 
-    // Guard against same-thread re-entrancy. The cleanup below is not
-    // async-signal-safe (logging, finalize, executing chained handlers). If a
-    // chained handler re-raises the signal (e.g. glog/abseil re-aborting on
-    // SIGABRT after it has restored this handler), the handler is re-entered on
-    // the same thread. The std::call_once below would then deadlock (recursive
-    // call_once on the owning thread), so rocprofv3 hangs forever instead of
-    // exiting. On recursive entry, restore the default disposition and re-raise
-    // so the process terminates immediately rather than looping.
+    // Guard against same-thread re-entrancy. If a chained handler re-raises the signal, the handler
+    // is re-entered on the same thread and the std::call_once below would deadlock, causing a hang.
+    // On recursive entry, restore the default disposition and re-raise so the process terminates.
     static std::atomic<long> _owner_tid{-1};
     const auto               _self_tid = static_cast<long>(this_tid);
     if(_owner_tid.load(std::memory_order_acquire) == _self_tid)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
@@ -108,24 +108,46 @@ thread_trace_callback(uint32_t shader, void* buffer, uint64_t size, void* callba
 bool
 thread_trace_parameter_pack::are_params_valid() const
 {
-    // Guard against the most common misconfigurations before touching HSA
-    // state so we can fail early with a descriptive message.
+    // Guard against the most common misconfigurations before touching HSA state
+    // so we can fail early with a descriptive message. These checks validate
+    // caller-supplied (user) input, so a failure must NOT be fatal: report a
+    // clear error and return false so the caller receives
+    // ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT and can reject the input
+    // cleanly. Using a fatal log here (e.g. under ROCPROFILER_CI) aborts the
+    // process on a mere bad parameter.
     if(shader_cb_fn == nullptr)
     {
-        ROCP_CI_LOG(WARNING) << "Callback cannot be null!";
+        ROCP_ERROR << "Thread trace shader callback cannot be null";
         return false;
     }
 
-    if(shader_engine_mask == 0) return false;
+    if(shader_engine_mask == 0)
+    {
+        ROCP_ERROR << "Invalid thread trace shader engine mask: 0 (must be non-zero)";
+        return false;
+    }
 
     if(buffer_size < MIN_BUFFER_SIZE)
     {
-        ROCP_CI_LOG(WARNING) << "Invalid buffer size: " << buffer_size;
+        ROCP_ERROR << "Invalid thread trace buffer size: " << buffer_size << " (minimum is "
+                   << MIN_BUFFER_SIZE << " bytes / 1 MB)";
         return false;
     }
 
-    if(target_cu > 0xF) return false;
-    if(simd_select > 0xF) return false;  // Only 16 CUs and 4 SIMDs
+    // Only 16 CUs (0x0-0xF) and 4 SIMDs (0x0-0xF) are addressable.
+    if(target_cu > 0xF)
+    {
+        ROCP_ERROR << "Invalid thread trace target CU: " << static_cast<uint32_t>(target_cu)
+                   << " (valid range is 0-15 / 0x0-0xF)";
+        return false;
+    }
+
+    if(simd_select > 0xF)
+    {
+        ROCP_ERROR << "Invalid thread trace SIMD select mask: " << static_cast<uint32_t>(simd_select)
+                   << " (valid range is 0x0-0xF)";
+        return false;
+    }
 
     return true;
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2024-2025 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -112,35 +112,35 @@ thread_trace_parameter_pack::are_params_valid() const
     // so we can fail early with a descriptive message.
     if(shader_cb_fn == nullptr)
     {
-        ROCP_ERROR << "Thread trace shader callback cannot be null";
+        ROCP_WARNING << "Thread trace shader callback cannot be null";
         return false;
     }
 
     if(shader_engine_mask == 0)
     {
-        ROCP_ERROR << "Invalid thread trace shader engine mask: 0 (must be non-zero)";
+        ROCP_WARNING << "Invalid thread trace shader engine mask: 0 (must be non-zero)";
         return false;
     }
 
     if(buffer_size < MIN_BUFFER_SIZE)
     {
-        ROCP_ERROR << "Invalid thread trace buffer size: " << buffer_size << " (minimum is "
-                   << MIN_BUFFER_SIZE << " bytes / 1 MB)";
+        ROCP_WARNING << "Invalid thread trace buffer size: " << buffer_size << " (minimum is "
+                     << MIN_BUFFER_SIZE << " bytes / 1 MB)";
         return false;
     }
 
     // Only 16 CUs (0x0-0xF) and 4 SIMDs (0x0-0xF) are addressable.
     if(target_cu > 0xF)
     {
-        ROCP_ERROR << "Invalid thread trace target CU: " << static_cast<uint32_t>(target_cu)
-                   << " (valid range is 0-15 / 0x0-0xF)";
+        ROCP_WARNING << "Invalid thread trace target CU: " << static_cast<uint32_t>(target_cu)
+                     << " (valid range is 0-15 / 0x0-0xF)";
         return false;
     }
 
     if(simd_select > 0xF)
     {
-        ROCP_ERROR << "Invalid thread trace SIMD select mask: "
-                   << static_cast<uint32_t>(simd_select) << " (valid range is 0x0-0xF)";
+        ROCP_WARNING << "Invalid thread trace SIMD select mask: "
+                     << static_cast<uint32_t>(simd_select) << " (valid range is 0x0-0xF)";
         return false;
     }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
@@ -144,8 +144,8 @@ thread_trace_parameter_pack::are_params_valid() const
 
     if(simd_select > 0xF)
     {
-        ROCP_ERROR << "Invalid thread trace SIMD select mask: " << static_cast<uint32_t>(simd_select)
-                   << " (valid range is 0x0-0xF)";
+        ROCP_ERROR << "Invalid thread trace SIMD select mask: "
+                   << static_cast<uint32_t>(simd_select) << " (valid range is 0x0-0xF)";
         return false;
     }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
@@ -112,35 +112,36 @@ thread_trace_parameter_pack::are_params_valid() const
     // so we can fail early with a descriptive message.
     if(shader_cb_fn == nullptr)
     {
-        ROCP_WARNING << "Thread trace shader callback cannot be null";
+        ROCP_CI_LOG(WARNING) << "Thread trace shader callback cannot be null";
         return false;
     }
 
     if(shader_engine_mask == 0)
     {
-        ROCP_WARNING << "Invalid thread trace shader engine mask: 0 (must be non-zero)";
+        ROCP_CI_LOG(WARNING) << "Invalid thread trace shader engine mask: 0 (must be non-zero)";
         return false;
     }
 
     if(buffer_size < MIN_BUFFER_SIZE)
     {
-        ROCP_WARNING << "Invalid thread trace buffer size: " << buffer_size << " (minimum is "
-                     << MIN_BUFFER_SIZE << " bytes / 1 MB)";
+        ROCP_CI_LOG(WARNING) << "Invalid thread trace buffer size: " << buffer_size
+                             << " (minimum is " << MIN_BUFFER_SIZE << " bytes / 1 MB)";
         return false;
     }
 
     // Only 16 CUs (0x0-0xF) and 4 SIMDs (0x0-0xF) are addressable.
     if(target_cu > 0xF)
     {
-        ROCP_WARNING << "Invalid thread trace target CU: " << static_cast<uint32_t>(target_cu)
-                     << " (valid range is 0-15 / 0x0-0xF)";
+        ROCP_CI_LOG(WARNING) << "Invalid thread trace target CU: "
+                             << static_cast<uint32_t>(target_cu)
+                             << " (valid range is 0-15 / 0x0-0xF)";
         return false;
     }
 
     if(simd_select > 0xF)
     {
-        ROCP_WARNING << "Invalid thread trace SIMD select mask: "
-                     << static_cast<uint32_t>(simd_select) << " (valid range is 0x0-0xF)";
+        ROCP_CI_LOG(WARNING) << "Invalid thread trace SIMD select mask: "
+                             << static_cast<uint32_t>(simd_select) << " (valid range is 0x0-0xF)";
         return false;
     }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
@@ -109,12 +109,7 @@ bool
 thread_trace_parameter_pack::are_params_valid() const
 {
     // Guard against the most common misconfigurations before touching HSA state
-    // so we can fail early with a descriptive message. These checks validate
-    // caller-supplied (user) input, so a failure must NOT be fatal: report a
-    // clear error and return false so the caller receives
-    // ROCPROFILER_STATUS_ERROR_INVALID_ARGUMENT and can reject the input
-    // cleanly. Using a fatal log here (e.g. under ROCPROFILER_CI) aborts the
-    // process on a mere bad parameter.
+    // so we can fail early with a descriptive message.
     if(shader_cb_fn == nullptr)
     {
         ROCP_ERROR << "Thread trace shader callback cannot be null";

--- a/projects/rocprofiler-sdk/tests/rocprofv3/advanced-thread-trace/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/advanced-thread-trace/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -287,6 +287,38 @@ rocprofiler_add_integration_execute_test(
     WILL_FAIL
     DISABLED ${IS_DISABLED}
     FAIL_REGULAR_EXPRESSION "Invalid GPU Device Index")
+
+# Check that invalid ATT parameters are rejected with a parameter-specific message and a
+# non-zero exit. The TIMEOUT guards against a regression of that hang (a deadlock trips
+# the timeout, which WILL_FAIL does not invert). FAIL_REGULAR_EXPRESSION checks that the
+# relevant diagnostic message is emitted.
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-att-target-cu-out-of-range-will-fail
+    COMMAND
+        $<TARGET_FILE:rocprofiler-sdk::rocprofv3> -d
+        ${CMAKE_CURRENT_BINARY_DIR}/att-bad-target-cu --att --att-target-cu 99999
+        --log-level warning -- $<TARGET_FILE:vector-ops>
+    DEPENDS vector-ops
+    TIMEOUT 45
+    LABELS "integration-tests;thread-trace"
+    WILL_FAIL
+    DISABLED ${IS_DISABLED}
+    ENVIRONMENT "ROCPROF_ATT_LIBRARY_PATH=${attdecoder_LIB_DIR}"
+    FAIL_REGULAR_EXPRESSION "Invalid thread trace target CU")
+
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-att-buffer-size-too-small-will-fail
+    COMMAND
+        $<TARGET_FILE:rocprofiler-sdk::rocprofv3> -d
+        ${CMAKE_CURRENT_BINARY_DIR}/att-bad-buffer-size --att --att-buffer-size 4096
+        --log-level warning -- $<TARGET_FILE:vector-ops>
+    DEPENDS vector-ops
+    TIMEOUT 45
+    LABELS "integration-tests;thread-trace"
+    WILL_FAIL
+    DISABLED ${IS_DISABLED}
+    ENVIRONMENT "ROCPROF_ATT_LIBRARY_PATH=${attdecoder_LIB_DIR}"
+    FAIL_REGULAR_EXPRESSION "Invalid thread trace buffer size")
 
 #
 # Test --att-perfcounter-target-cu option This test verifies that perfcounter events are


### PR DESCRIPTION
## Motivation

Several different invalid parameter configurations would cause rocprof to abort and hang instead of exiting with an error message.

## Technical Details

The signal handler uses a call_once(). If the signal handler ends up recursively calling itself, the second instance will cause call_once() to hang, since the thread will be waiting on the previous instance to complete (which is itself). To avoid this, the signal handler checks if the current thread is already executing the signal handler and calls _exit() if so.
Additionally, added a variant of the ROCPROFILER_CALL macro that logs an error message and cleanly exits when the error is a bad parameter, added some error messages in the parameter checking code, and added a couple ATT parameter tests.

## JIRA ID

JIRA ID : AIPROFSDK-912.

## Test Plan

Profiled test app with parameter configurations that previously caused hangs.

## Test Result

Profiler exited cleanly with an error message.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
