### PR TITLE
[rocprofiler-sdk] fix rejection of maximum valid stochastic sampling interval

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/config.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/config.hpp
@@ -148,7 +148,7 @@ struct config : output_config
     bool   spm_counter_collection        = get_env("ROCPROF_SPM_COUNTER_COLLECTION", false);
     bool   pc_sampling_host_trap         = false;
     bool   pc_sampling_stochastic        = false;
-    size_t pc_sampling_interval          = get_env("ROCPROF_PC_SAMPLING_INTERVAL", 1);
+    size_t pc_sampling_interval          = get_env<uint64_t>("ROCPROF_PC_SAMPLING_INTERVAL", 1);
     rocprofiler_pc_sampling_method_t pc_sampling_method_value = ROCPROFILER_PC_SAMPLING_METHOD_NONE;
     rocprofiler_pc_sampling_unit_t   pc_sampling_unit_value   = ROCPROFILER_PC_SAMPLING_UNIT_NONE;
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/config.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/config.hpp
@@ -148,7 +148,7 @@ struct config : output_config
     bool   spm_counter_collection        = get_env("ROCPROF_SPM_COUNTER_COLLECTION", false);
     bool   pc_sampling_host_trap         = false;
     bool   pc_sampling_stochastic        = false;
-    size_t pc_sampling_interval          = get_env<uint64_t>("ROCPROF_PC_SAMPLING_INTERVAL", 1);
+    size_t pc_sampling_interval          = get_env("ROCPROF_PC_SAMPLING_INTERVAL", 1);
     rocprofiler_pc_sampling_method_t pc_sampling_method_value = ROCPROFILER_PC_SAMPLING_METHOD_NONE;
     rocprofiler_pc_sampling_unit_t   pc_sampling_unit_value   = ROCPROFILER_PC_SAMPLING_UNIT_NONE;
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -2270,7 +2270,34 @@ configure_pc_sampling_on_all_agents(uint64_t                        buffer_size,
     }
     if(!config_match_found)
     {
-        ROCP_ERROR << "Given PC sampling configuration is not supported on any of the agents";
+        // If unsuccessful, get the supported interval range and output it
+        uint64_t supported_min = std::numeric_limits<uint64_t>::max();
+        uint64_t supported_max = 0;
+        for(auto& itr : agent_ptr_vec)
+        {
+            for(const auto& config :
+                CHECK_NOTNULL(tool_metadata)->get_pc_sample_config_info(itr->id))
+            {
+                if(config.method == method && config.unit == unit)
+                {
+                    supported_min = std::min<uint64_t>(supported_min, config.min_interval);
+                    supported_max = std::max<uint64_t>(supported_max, config.max_interval);
+                }
+            }
+        }
+
+        // True if there was at least one matching config, meaning the interval is bad
+        if(supported_max >= supported_min)
+        {
+            ROCP_ERROR << "Bad interval value (" << tool::get_config().pc_sampling_interval
+                       << "): Supported interval range is [" << supported_min << ", "
+                       << supported_max << "]";
+        }
+        // Otherwise, bad config
+        else
+        {
+            ROCP_ERROR << "Given PC sampling configuration is not supported on any of the agents";
+        }
         std::exit(EXIT_FAILURE);
     }
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -2270,34 +2270,8 @@ configure_pc_sampling_on_all_agents(uint64_t                        buffer_size,
     }
     if(!config_match_found)
     {
-        // If unsuccessful, get the supported interval range and output it
-        uint64_t supported_min = std::numeric_limits<uint64_t>::max();
-        uint64_t supported_max = 0;
-        for(auto& itr : agent_ptr_vec)
-        {
-            for(const auto& config :
-                CHECK_NOTNULL(tool_metadata)->get_pc_sample_config_info(itr->id))
-            {
-                if(config.method == method && config.unit == unit)
-                {
-                    supported_min = std::min<uint64_t>(supported_min, config.min_interval);
-                    supported_max = std::max<uint64_t>(supported_max, config.max_interval);
-                }
-            }
-        }
-
-        // True if there was at least one matching config, meaning the interval is bad
-        if(supported_max >= supported_min)
-        {
-            ROCP_ERROR << "Bad interval value (" << tool::get_config().pc_sampling_interval
-                       << "): Supported interval range is [" << supported_min << ", "
-                       << supported_max << "]";
-        }
-        // Otherwise, bad config
-        else
-        {
-            ROCP_ERROR << "Given PC sampling configuration is not supported on any of the agents";
-        }
+        ROCP_ERROR << "Given PC sampling configuration is not supported on any of the agents."
+                   << "See supported configurations with 'rocprofv3-avail info --pc-sampling'";
         std::exit(EXIT_FAILURE);
     }
 }

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/ioctl/ioctl_adapter.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/ioctl/ioctl_adapter.cpp
@@ -463,7 +463,7 @@ convert_ioctl_pcs_config_to_rocp(const rocprofiler_ioctl_pc_sampling_info_t& ioc
         // No one configured PC sampling on the corresponding device.
         // Read the values of min and max interval provided by the KFD
         rocp_pcs_config.min_interval = ioctl_pcs_config.interval_min;
-        rocp_pcs_config.max_interval = ioctl_pcs_config.interval_max;
+        rocp_pcs_config.max_interval = std::min(ioctl_pcs_config.interval_max, 1ul<<20);
     }
 
     rocp_pcs_config.flags = ioctl_pcs_config.flags;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/ioctl/ioctl_adapter.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/pc_sampling/ioctl/ioctl_adapter.cpp
@@ -463,7 +463,7 @@ convert_ioctl_pcs_config_to_rocp(const rocprofiler_ioctl_pc_sampling_info_t& ioc
         // No one configured PC sampling on the corresponding device.
         // Read the values of min and max interval provided by the KFD
         rocp_pcs_config.min_interval = ioctl_pcs_config.interval_min;
-        rocp_pcs_config.max_interval = std::min(ioctl_pcs_config.interval_max, 1ul<<20);
+        rocp_pcs_config.max_interval = std::min(ioctl_pcs_config.interval_max, 1ul << 20);
     }
 
     rocp_pcs_config.flags = ioctl_pcs_config.flags;


### PR DESCRIPTION
## Motivation

Some PCS interval values were not being accepted/rejected properly.

## Technical Details

Ensured we were only reporting valid interval ranges, and added log telling user how to find valid ranges on a config failure.

## JIRA ID

JIRA ID : AIPROFSDK-913.

## Test Plan

Ran profiler with intervals that were just below, at, and above the maximum supported interval value.

## Test Result

Profiler accepted maximum interval and rejected others.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
