### PR TITLE
feat(rocr): PC sampling trap handler refactor and lock-free MPSC queue

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
@@ -973,6 +973,46 @@ class GpuAgent : public GpuAgentInt {
   //   - Per-XCC mutex serializes XCC thread vs consumer thread for each XCC's buffer
   //   - Consumer thread aggregates data and delivers callbacks when SUM(pending) >= buffer_size
   //   - Callbacks contain data from whichever XCCs have pending samples at threshold time
+
+  // Lock-free MPSC (multi-producer single-consumer) queue for XCC flush notifications
+  // Used to communicate which XCCs have data ready, replacing the pending_flush_count counter.
+  // Multiple XCC threads enqueue their IDs, consumer thread dequeues and processes only those XCCs.
+
+  struct alignas(64) pcs_mpsc_queue_t {
+    static constexpr uint32_t CAPACITY = 64;
+    static constexpr uint32_t EMPTY_SLOT = UINT32_MAX;
+
+    std::atomic<uint32_t> buffer[CAPACITY];
+    alignas(64) std::atomic<uint32_t> write_pos;  // Cache-line isolated from buffer
+    uint32_t read_pos;  // Only accessed by consumer, no atomic needed
+
+    pcs_mpsc_queue_t() : write_pos(0), read_pos(0) {
+      for (uint32_t i = 0; i < CAPACITY; ++i) {
+        buffer[i].store(EMPTY_SLOT, std::memory_order_relaxed);
+      }
+    }
+
+    // Enqueue XCC ID - called by multiple producer threads (XCC flush threads)
+    // Returns true on success, false if queue is full (should not happen in practice)
+    bool enqueue(uint32_t xcc_id);
+
+    // Try to dequeue an XCC ID - called by single consumer thread
+    // Returns true and sets xcc_id on success, false if queue is empty
+    bool try_dequeue(uint32_t& xcc_id);
+
+    // Check if queue has data - called by consumer to check before sleeping
+    bool has_data() const;
+
+    // Reset queue to empty state - must be called before starting a new session
+    void reset() {
+      for (uint32_t i = 0; i < CAPACITY; ++i) {
+        buffer[i].store(EMPTY_SLOT, std::memory_order_relaxed);
+      }
+      write_pos.store(0, std::memory_order_relaxed);
+      read_pos = 0;
+    }
+  };
+
   struct alignas(64) per_xcc_pcs_data_t {
     pcs_sampling_data_t* device_data;         // This XCC's device buffer region
     os::Thread thread;                        // Thread handle for this XCC's flush thread
@@ -1017,10 +1057,10 @@ class GpuAgent : public GpuAgentInt {
 
     /* Consumer thread for aggregated callback delivery */
     std::thread consumer_thread;            // Aggregates data and delivers callbacks
-    std::mutex consumer_mutex;              // Protects consumer_cv and pending_flush_count
+    pcs_mpsc_queue_t flush_queue;           // Lock-free queue of XCC IDs with pending data
+    std::mutex consumer_wakeup_mutex;       // Protects consumer_cv (minimal lock for wakeup only)
     std::condition_variable consumer_cv;    // Wakes consumer when XCC threads have new data
     std::atomic<bool> consumer_exit;        // Signal consumer thread to exit
-    std::atomic<uint32_t> pending_flush_count;  // How many XCCs have notified consumer
     std::mutex delivery_mutex;              // Serializes callback delivery (consumer vs Flush)
 
     pcs::PcsRuntime::PcSamplingSession* session;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -4204,7 +4204,7 @@ hsa_status_t GpuAgent::PcSamplingStart(pcs::PcsRuntime::PcSamplingSession& sessi
     pcs_data->xcc_data[xcc_id].which_buffer = 0;
   }
   pcs_data->consumer_exit.store(false, std::memory_order_release);
-  pcs_data->pending_flush_count.store(0, std::memory_order_release);
+  pcs_data->flush_queue.reset();  // Clear any stale entries from previous session
 
   struct ThreadData {
     GpuAgent* agent;
@@ -4789,6 +4789,57 @@ hsa_status_t GpuAgent::PcSamplingFlushDeviceBuffersPerXCC_PM4(
   return HSA_STATUS_SUCCESS;
 }
 
+// ============================================================================
+// Lock-free MPSC Queue Implementation
+// ============================================================================
+// This queue allows XCC flush threads to notify the consumer thread which XCCs
+// have pending data, eliminating the need for a mutex-protected counter.
+// The queue uses fetch_add for concurrent writes and compare_exchange for reads.
+
+bool GpuAgent::pcs_mpsc_queue_t::enqueue(uint32_t xcc_id) {
+  // Reserve a slot using atomic fetch_add
+  uint32_t pos = write_pos.fetch_add(1, std::memory_order_acq_rel);
+  uint32_t slot = pos % CAPACITY;
+
+  // Wait for slot to be empty (should be immediate in normal operation)
+  uint32_t expected = EMPTY_SLOT;
+  int attempts = 0;
+  while (!buffer[slot].compare_exchange_weak(expected, xcc_id,
+                                             std::memory_order_release,
+                                             std::memory_order_relaxed)) {
+    if (++attempts > 100) {
+      std::this_thread::yield();
+    }
+    if (attempts > 10000) {
+      // Queue full - consumer is severely behind. Return failure to avoid hang.
+      return false;
+    }
+    expected = EMPTY_SLOT;
+  }
+  return true;
+}
+
+bool GpuAgent::pcs_mpsc_queue_t::try_dequeue(uint32_t& xcc_id) {
+  uint32_t slot = read_pos % CAPACITY;
+
+  // Read the value from the slot
+  uint32_t val = buffer[slot].load(std::memory_order_acquire);
+  if (val == EMPTY_SLOT) {
+    return false;  // Queue is empty
+  }
+
+  // Mark slot as empty and advance read position
+  buffer[slot].store(EMPTY_SLOT, std::memory_order_release);
+  read_pos++;
+  xcc_id = val;
+  return true;
+}
+
+bool GpuAgent::pcs_mpsc_queue_t::has_data() const {
+  uint32_t slot = read_pos % CAPACITY;
+  return buffer[slot].load(std::memory_order_acquire) != EMPTY_SLOT;
+}
+
 void GpuAgent::PcSamplingThreadPerXCC(pcs_data_t& pcs_data, uint32_t xcc_id,
                                       const char* thread_name) {
   try {
@@ -4807,9 +4858,12 @@ void GpuAgent::PcSamplingThreadPerXCC(pcs_data_t& pcs_data, uint32_t xcc_id,
           done_sig[which_buffer], HSA_SIGNAL_CONDITION_LT, 1, UINT64_MAX, HSA_WAIT_STATE_BLOCKED);
 
       if (val == -1) {
-        // Exit signal received - notify consumer and exit
-        pcs_data.pending_flush_count.fetch_add(1, std::memory_order_release);
-        pcs_data.consumer_cv.notify_one();
+        // Exit signal received - enqueue XCC ID to notify consumer and exit
+        pcs_data.flush_queue.enqueue(xcc_id);
+        {
+          std::lock_guard<std::mutex> lock(pcs_data.consumer_wakeup_mutex);
+          pcs_data.consumer_cv.notify_one();
+        }
         break;
       } else if (val != 0) {
         // Spurious wakeup - continue waiting
@@ -4833,9 +4887,12 @@ void GpuAgent::PcSamplingThreadPerXCC(pcs_data_t& pcs_data, uint32_t xcc_id,
         }
       }
 
-      // Notify consumer thread that new data is available
-      pcs_data.pending_flush_count.fetch_add(1, std::memory_order_release);
-      pcs_data.consumer_cv.notify_one();
+      // Notify consumer thread that this XCC has new data via lock-free queue
+      pcs_data.flush_queue.enqueue(xcc_id);
+      {
+        std::lock_guard<std::mutex> lock(pcs_data.consumer_wakeup_mutex);
+        pcs_data.consumer_cv.notify_one();
+      }
     }
 
     debug_print("%s (XCC %u)::Exiting\n", thread_name, xcc_id);
@@ -4927,22 +4984,31 @@ void GpuAgent::PcSamplingConsumerThread(pcs_data_t& pcs_data) {
     pcs::PcsRuntime::PcSamplingSession& session = *pcs_data.session;
 
     while (!pcs_data.consumer_exit.load(std::memory_order_acquire)) {
-      // Wait for XCC threads to notify us of new data
+      // Wait for XCC threads to notify us of new data via the MPSC queue
       {
-        std::unique_lock<std::mutex> lock(pcs_data.consumer_mutex);
+        std::unique_lock<std::mutex> lock(pcs_data.consumer_wakeup_mutex);
         pcs_data.consumer_cv.wait(lock, [&pcs_data]() {
-          return pcs_data.pending_flush_count.load(std::memory_order_acquire) > 0 ||
+          return pcs_data.flush_queue.has_data() ||
                  pcs_data.consumer_exit.load(std::memory_order_acquire);
         });
-        // Reset pending count - we'll check all XCCs
-        pcs_data.pending_flush_count.store(0, std::memory_order_release);
       }
 
       if (pcs_data.consumer_exit.load(std::memory_order_acquire)) {
         break;
       }
 
-      // Try to deliver aggregated samples (threshold check is inside)
+      // Drain the queue to clear notifications
+      uint32_t xcc_id;
+      bool had_data = false;
+      while (pcs_data.flush_queue.try_dequeue(xcc_id)) {
+        had_data = true;
+      }
+
+      if (!had_data) {
+        continue;  // Spurious wakeup
+      }
+
+      // Deliver aggregated samples (threshold check is inside)
       PcSamplingDeliverAggregatedSamples(pcs_data, session);
     }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/trap_handler/trap_handler.s
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/trap_handler/trap_handler.s
@@ -206,6 +206,66 @@
   .endif
  .endm
 
+ // ============================================================================
+ // GFX9.4+ PC Sampling Refactored Macros
+ // ============================================================================
+ // These macros unify duplicated code between hosttrap and stochastic paths.
+
+ // CALC_XCC_OFFSET_GFX94 - Calculate per-XCC buffer address for multi-XCC systems
+ // Input:
+ //   ttmp[2:3] = buffer base address
+ //   ttmp4     = per_xcc_size (stride per XCC)
+ //   ttmp5     = XCC_ID
+ // Output:
+ //   ttmp[14:15] = buffer_base + (XCC_ID * per_xcc_size)
+ // Clobbers: ttmp[14:15] (output), uses ttmp4, ttmp5
+ .macro CALC_XCC_OFFSET_GFX94
+  .if (.amdgcn.gfx_generation_minor >= 4)
+    s_mul_i32                             ttmp14, ttmp4, ttmp5            // ttmp14 = lo32(offset)
+    s_mul_hi_u32                          ttmp15, ttmp4, ttmp5            // ttmp15 = hi32(offset)
+    s_add_u32                             ttmp14, ttmp2, ttmp14           // ttmp14:15 = base + offset
+    s_addc_u32                            ttmp15, ttmp3, ttmp15
+  .endif
+ .endm
+
+ // FILL_SAMPLE_COMMON_GFX94 - Store common sample fields shared by hosttrap and stochastic
+ // This stores: timestamp, EXEC mask, workgroup IDs, wave_in_wg with chiplet, HW_ID
+ // Input:
+ //   ttmp[2:3] = pointer to sample buffer entry (&buffer[local_entry])
+ //   ttmp[4:5] = timestamp (from s_memrealtime, must be read before calling)
+ //   ttmp[8:9:10] = workgroup IDs (from ABI)
+ //   ttmp11 = wave_in_wg info (from ABI)
+ // Output:
+ //   Stores fields at offsets 0x08-0x20, 0x30 in sample structure
+ // Clobbers: ttmp4, ttmp5, ttmp6 (on gfx94x)
+ .macro FILL_SAMPLE_COMMON_GFX94
+  .if (.amdgcn.gfx_generation_minor >= 4)
+    // Store timestamp at offset 0x30
+    s_store_dwordx2                       ttmp[4:5], ttmp[2:3], 0x30
+
+    // Store EXEC mask at offset 0x08-0x0c
+    s_mov_b32                             ttmp6, exec_lo
+    s_store_dword                         ttmp6, ttmp[2:3], 0x8
+    s_mov_b32                             ttmp6, exec_hi
+    s_store_dword                         ttmp6, ttmp[2:3], 0xc
+
+    // Store workgroup IDs at offsets 0x10-0x18
+    s_store_dwordx2                       ttmp[8:9], ttmp[2:3], 0x10
+    s_store_dword                         ttmp10, ttmp[2:3], 0x18
+
+    // Store wave_in_wg and chiplet (XCC_ID) at offset 0x1c
+    s_getreg_b32                          ttmp4, hwreg(HW_REG_XCC_ID)
+    s_lshl_b32                            ttmp4, ttmp4, 8
+    s_and_b32                             ttmp5, ttmp11, TTMP11_WAVE_IN_WG_MASK
+    s_or_b32                              ttmp4, ttmp4, ttmp5
+    s_store_dword                         ttmp4, ttmp[2:3], 0x1c
+
+    // Store HW_ID at offset 0x20
+    s_getreg_b32                          ttmp4, hwreg(HW_REG_HW_ID)
+    s_store_dword                         ttmp4, ttmp[2:3], 0x20
+  .endif
+ .endm
+
 .endif
 
 // ABI between first and second level trap handler:
@@ -317,13 +377,8 @@ trap_entry:
   s_cmp_eq_u64                          ttmp[2:3], 0
   s_cbranch_scc1                        .exit_trap
 
-  // Calculate offset directly into ttmp14:15 (TMA2 pointer no longer needed after loads complete)
-  s_mul_i32                             ttmp14, ttmp4, ttmp5            // ttmp14 = lo32(offset)
-  s_mul_hi_u32                          ttmp15, ttmp4, ttmp5            // ttmp15 = hi32(offset)
-
-  // ttmp14:15 = base (ttmp2:3) + offset (ttmp14:15)
-  s_add_u32                             ttmp14, ttmp2, ttmp14
-  s_addc_u32                            ttmp15, ttmp3, ttmp15
+  // Calculate per-XCC buffer address: ttmp[14:15] = ttmp[2:3] + (ttmp4 * ttmp5)
+  CALC_XCC_OFFSET_GFX94
   s_branch                              .profile_trap_handlers_gfx9
 .else
   // GFX9.0-9.3 (single-XCC): Simple pointer copy, no per-XCC offset needed
@@ -383,13 +438,8 @@ trap_entry:
   s_cmp_eq_u64                          ttmp[2:3], 0
   s_cbranch_scc1                        .exit_trap
 
-  // Calculate offset directly into ttmp14:15 (TMA2 pointer no longer needed after loads complete)
-  s_mul_i32                             ttmp14, ttmp4, ttmp5            // ttmp14 = lo32(offset)
-  s_mul_hi_u32                          ttmp15, ttmp4, ttmp5            // ttmp15 = hi32(offset)
-
-  // ttmp14:15 = base (ttmp2:3) + offset (ttmp14:15)
-  s_add_u32                             ttmp14, ttmp2, ttmp14
-  s_addc_u32                            ttmp15, ttmp3, ttmp15
+  // Calculate per-XCC buffer address: ttmp[14:15] = ttmp[2:3] + (ttmp4 * ttmp5)
+  CALC_XCC_OFFSET_GFX94
   s_branch                              .profile_trap_handlers_gfx9      // Off to the profile handlers
 .else
   s_branch                              .no_skip_debugtrap
@@ -526,14 +576,25 @@ trap_entry:
   //    buf->correlation_id = get_correlation_id();
   // }
 .fill_sample_hosttrap:
+  // Calculate buffer entry address: ttmp[2:3] = &bufferX[local_entry]
   s_mul_i32                             ttmp2, ttmp7, 0x40              // offset into buffer for 64B objects
   s_mul_hi_u32                          ttmp3, ttmp7, 0x40              // ttmp[2:3] will contain byte ...
   s_add_u32                             ttmp2, ttmp2, ttmp4
   s_addc_u32                            ttmp3, ttmp3, ttmp5             // ttmp[2:3]=&bufferX[local_entry]
+
+  // Read timestamp and wait for it
   s_memrealtime                         ttmp[4:5]
+  s_waitcnt                             lgkmcnt(0)
+
+  // Store hosttrap-specific field: PC at offset 0x00
   s_and_b32                             ttmp1, ttmp1, 0xffff            // clear out extra data from PC_HI
   s_store_dwordx2                       ttmp[0:1], ttmp[2:3]            // store PC
-  s_waitcnt                             lgkmcnt(0)                      // wait for timestamp
+
+.if (.amdgcn.gfx_generation_number == 9 && .amdgcn.gfx_generation_minor >= 4)
+  // GFX9.4+: Use unified macro for common sample fields
+  FILL_SAMPLE_COMMON_GFX94
+.else
+  // GFX9.0-9.3: Store common fields inline (no XCC_ID, different register usage)
   S_MOV_B32_SRC_PCS_TTMP_REG1           exec_lo
   S_STORE_DWORD_PCS_TTMP_REG1           ttmp[2:3], 0x8                  // store EXEC_LO
   S_MOV_B32_SRC_PCS_TTMP_REG1           exec_hi
@@ -541,53 +602,36 @@ trap_entry:
   s_store_dwordx2                       ttmp[8:9], ttmp[2:3], 0x10      // store wg_id_x and wg_id_y
   s_store_dword                         ttmp10, ttmp[2:3], 0x18         // store wg_id_z
   s_store_dwordx2                       ttmp[4:5], ttmp[2:3], 0x30      // store timestamp
-
-.if (.amdgcn.gfx_generation_number == 9 && .amdgcn.gfx_generation_minor >= 4)
-  s_getreg_b32                          ttmp4, hwreg(HW_REG_XCC_ID)     //store XCC_ID
-  s_lshl_b32                            ttmp4, ttmp4, 8
-  s_and_b32                             ttmp5, ttmp11, TTMP11_WAVE_IN_WG_MASK
-  s_or_b32                              ttmp4, ttmp4, ttmp5
-  s_store_dword                         ttmp4, ttmp[2:3], 0x1c          // store wave_in_wg
-.else
   s_and_b32                             ttmp4, ttmp11, 0x3f
   s_store_dword                         ttmp4, ttmp[2:3], 0x1c          // store wave_in_wg
-.endif
   s_getreg_b32                          ttmp4, hwreg(HW_REG_HW_ID)
   s_store_dword                         ttmp4, ttmp[2:3], 0x20          // store HW_ID
+.endif
 
   s_branch                              .get_correlation_id
 
 .if .amdgcn.gfx_generation_number == 9 && .amdgcn.gfx_generation_minor >= 4
 .fill_sample_stochastic:
+  // Calculate buffer entry address: ttmp[2:3] = &buffer[local_entry]
   s_mul_i32                             ttmp2, ttmp7, 0x40              // offset into buffer for 64B objects
   s_mul_hi_u32                          ttmp3, ttmp7, 0x40
   s_add_u32                             ttmp2, ttmp2, ttmp4
   s_addc_u32                            ttmp3, ttmp3, ttmp5             // ttmp[2:3]=&buffer[local_entry]
+
+  // Read timestamp and wait for it
   s_memrealtime                         ttmp[4:5]
-  s_waitcnt                             lgkmcnt(0)                      // Wait for timestamp
-  s_store_dwordx2                       ttmp[4:5], ttmp[2:3] 0x30       // Store timestamp
+  s_waitcnt                             lgkmcnt(0)
 
-  s_getreg_b32                          ttmp4, hwreg(HW_REG_SQ_PERF_SNAPSHOT_PC_LO)
-  s_getreg_b32                          ttmp5, hwreg(HW_REG_SQ_PERF_SNAPSHOT_PC_HI)
-  s_store_dwordx2                       ttmp[4:5], ttmp[2:3] 0x00       // store snapshot data
-  s_getreg_b32                          ttmp5, hwreg(HW_REG_SQ_PERF_SNAPSHOT_DATA1)
-  s_getreg_b32                          ttmp4, hwreg(HW_REG_SQ_PERF_SNAPSHOT_DATA)
-  s_store_dwordx2                       ttmp[4:5], ttmp[2:3], 0x24            // store snapshot PC
+  // Store stochastic-specific fields: snapshot PC and data
+  s_getreg_b32                          ttmp6, hwreg(HW_REG_SQ_PERF_SNAPSHOT_PC_LO)
+  s_getreg_b32                          ttmp7, hwreg(HW_REG_SQ_PERF_SNAPSHOT_PC_HI)
+  s_store_dwordx2                       ttmp[6:7], ttmp[2:3] 0x00       // store snapshot PC at offset 0x00
+  s_getreg_b32                          ttmp7, hwreg(HW_REG_SQ_PERF_SNAPSHOT_DATA1)
+  s_getreg_b32                          ttmp6, hwreg(HW_REG_SQ_PERF_SNAPSHOT_DATA)
+  s_store_dwordx2                       ttmp[6:7], ttmp[2:3], 0x24      // store snapshot data at offset 0x24
 
-  s_mov_b32                             ttmp6, exec_lo
-  s_store_dword                         ttmp6, ttmp[2:3], 0x8           // store EXEC_LO
-  s_mov_b32                             ttmp6, exec_hi
-  s_store_dword                         ttmp6, ttmp[2:3], 0xc           // store EXEC_HI
-
-  s_store_dwordx2                       ttmp[8:9], ttmp[2:3], 0x10      // store wg_id_x and wg_id_y
-  s_store_dword                         ttmp10, ttmp[2:3], 0x18         // store wg_id_z
-  s_getreg_b32                          ttmp4, hwreg(HW_REG_XCC_ID)
-  s_lshl_b32                            ttmp4, ttmp4, 8
-  s_and_b32                             ttmp5, ttmp11, TTMP11_WAVE_IN_WG_MASK
-  s_or_b32                              ttmp4, ttmp4, ttmp5
-  s_store_dword                         ttmp4, ttmp[2:3], 0x1c          // store chiplet_and_wave_id
-  s_getreg_b32                          ttmp4, hwreg(HW_REG_HW_ID)
-  s_store_dword                         ttmp4, ttmp[2:3], 0x20          // store HW_ID
+  // Store common sample fields using unified macro
+  FILL_SAMPLE_COMMON_GFX94
   // ttmp[2:3]=&buffer[local_entry]; ttmp[4:5], ttmp[6:7] are free
   // ttmp[14:15]=ptr to ‘tma’ and is live out; ttmp11.b31 is buf_to_use, 0 or 1
   s_branch                              .get_correlation_id


### PR DESCRIPTION
## Motivation

  This PR addresses two related improvements to the PC sampling infrastructure:

  1. **Trap Handler Code Duplication** - The GFX9.4+ trap handler had duplicated assembly code
  between hosttrap and stochastic sampling paths, making maintenance error-prone and increasing
  binary size.

  2. **Threading Model Contention** - The consumer thread model used mutex-protected counters
  causing serialization across XCC threads and cache-line bouncing on multi-XCC systems (MI300X
  with 8 XCCs).

 GitHub Issues Resolved:

  1. Trap Handler Refactor:
    - https://github.com/ROCm/rocm-systems/issues/7648
  2. MPSC Queue / Threading Model:
    - https://github.com/ROCm/rocm-systems/issues/7611
    - https://github.com/ROCm/rocm-systems/issues/5563

  ## Technical Details

  ### Commit 1: Trap Handler Refactor
  - Added `CALC_XCC_OFFSET_GFX94` macro for unified per-XCC buffer address calculation
  - Added `FILL_SAMPLE_COMMON_GFX94` macro for shared sample field stores (timestamp, EXEC, WGID,
   HW_ID, wave_in_wg)
  - Eliminates 18 duplicated assembly instructions between hosttrap and stochastic paths
  - GFX9.0-9.3 code paths unchanged (protected by `.if .amdgcn.gfx_generation_minor >= 4`)

  ### Commit 2: Lock-Free MPSC Queue
  - Replaces `consumer_mutex` + `pending_flush_count` with lock-free MPSC (multi-producer
  single-consumer) queue
  - XCC threads enqueue their ID lock-free; consumer drains queue and knows exactly which XCCs
  have data
  - Cache-line aligned (`alignas(64)`) to prevent false sharing
  - Bounded retry (10,000 attempts) prevents infinite spin
  - Added `flush_queue.reset()` in `PcSamplingStart()` to prevent stale entries across sessions

  ## JIRA ID

  N/A

  ## Test Plan

  Validated on two systems:
  1. **Splinter (MI300X, gfx942, 8 XCCs)** - Stochastic PC sampling
     - VALU spamming kernel (compute-bound)
     - MatMul 8192x8192x8192 SGEMM (memory-bound)
     - Intervals: 1048576, 524288, 262144, 131072, 65536, 32768, 16384

  2. **nv48-ss (GFX12, gfx1201, 1 XCC)** - Host trap PC sampling
     - ROCR build verification
     - rocrtst64 core functional tests

  ## Test Result

  | System | GPU | Tests | Status |
  |--------|-----|-------|--------|
  | Splinter | MI300X (8 XCCs) | VALU + MatMul stochastic | **PASSED** |
  | nv48-ss | GFX12 (1 XCC) | ROCR build + core tests | **PASSED** |

  **MI300X Highlights:**
  - MatMul: 14.9M samples at interval 16384, 100% usable
  - VALU: Perfect XCC balance at low rates (768 samples/XCC at interval 1048576)
  - All 8 XCCs receiving samples with correct per-XCC buffer addressing
  - No deadlocks, hangs, or sample corruption with MPSC queue

  ## Submission Checklist

  - [x] Look over the contributing guidelines at
  https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
