### PR TITLE
fix(rocr): Dup dmabuf fd on VMemoryImportShareableHandle for deferred import

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/functional/virtual_memory.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/virtual_memory.cc
@@ -46,6 +46,7 @@
 
 #include <sys/mman.h>
 #include <fcntl.h>
+#include <unistd.h>
 #include <algorithm>
 #include <iostream>
 #include <string>
@@ -2485,4 +2486,82 @@ void VirtMemoryTestBasic::TestGpuAccessToHostMemoryAllocation(hsa_agent_t cpu_ag
   if (kernArgs) hsa_amd_memory_pool_free(kernArgs);
   if (signal.handle) hsa_signal_destroy(signal);
   if (queue) hsa_queue_destroy(queue);
+}
+
+void VirtMemoryTestBasic::ImportedShareableHandleSetAccessAfterFdClose(
+    hsa_agent_t gpu_agent, hsa_amd_memory_pool_t pool) {
+  rocrtst::pool_info_t pool_i;
+  ASSERT_SUCCESS(rocrtst::AcquirePoolInfo(pool, &pool_i));
+  if (!pool_i.alloc_allowed || pool_i.segment != HSA_AMD_SEGMENT_GLOBAL) return;
+
+  const size_t alloc_size = pool_i.alloc_granule * 10;
+  void* addr = nullptr;
+  hsa_amd_vmem_alloc_handle_t exported_handle;
+  ASSERT_SUCCESS(
+      hsa_amd_vmem_handle_create(pool, alloc_size, MEMORY_TYPE_NONE, 0, &exported_handle));
+
+  int dmabuf_fd = -1;
+  ASSERT_SUCCESS(hsa_amd_vmem_export_shareable_handle(&dmabuf_fd, exported_handle, 0));
+  ASSERT_GE(dmabuf_fd, 0);
+
+  hsa_amd_vmem_alloc_handle_t imported_handle;
+  ASSERT_SUCCESS(hsa_amd_vmem_import_shareable_handle(dmabuf_fd, &imported_handle));
+
+  /* Normal IPC ownership: the importer closes its fd right after import. Per-GPU import is
+   * deferred until set_access, so the runtime must keep its own dup of the fd alive. */
+  ASSERT_EQ(close(dmabuf_fd), 0);
+  dmabuf_fd = -1;
+
+  ASSERT_SUCCESS(hsa_amd_vmem_address_reserve(&addr, alloc_size, 0, 0));
+  ASSERT_SUCCESS(hsa_amd_vmem_map(addr, alloc_size, 0, imported_handle, 0));
+
+  /* Release the exporter handle before set_access, matching cross-process IPC where the
+   * importer does not retain the exporter's allocation handle. */
+  ASSERT_SUCCESS(hsa_amd_vmem_handle_release(exported_handle));
+
+  /* Peer GPU access only: imported shareable handles do not support CPU set_access
+   * (no mmap_offset on the dmabuf import path). */
+  hsa_amd_memory_access_desc_t access_desc = {HSA_ACCESS_PERMISSION_RW, gpu_agent};
+  ASSERT_SUCCESS(hsa_amd_vmem_set_access(addr, alloc_size, &access_desc, 1));
+
+  hsa_access_permission_t perm = HSA_ACCESS_PERMISSION_NONE;
+  ASSERT_SUCCESS(hsa_amd_vmem_get_access(addr, &perm, gpu_agent));
+  ASSERT_EQ(perm, HSA_ACCESS_PERMISSION_RW);
+
+  ASSERT_SUCCESS(hsa_amd_vmem_unmap(addr, alloc_size));
+  ASSERT_SUCCESS(hsa_amd_vmem_handle_release(imported_handle));
+  ASSERT_SUCCESS(hsa_amd_vmem_address_free(addr, alloc_size));
+}
+
+void VirtMemoryTestBasic::ImportedShareableHandleSetAccessAfterFdClose(void) {
+  if (verbosity() > 0) {
+    PrintMemorySubtestHeader("Imported Shareable Handle Set Access After FD Close");
+  }
+
+  bool supp = false;
+  ASSERT_SUCCESS(hsa_system_get_info(HSA_AMD_SYSTEM_INFO_VIRTUAL_MEM_API_SUPPORTED, (void*)&supp));
+  if (!supp) {
+    if (verbosity() > 0) {
+      std::cout << "    Virtual Memory API not supported on this system - Skipping." << std::endl;
+      std::cout << kSubTestSeparator << std::endl;
+    }
+    return;
+  }
+
+  std::vector<hsa_agent_t> gpus;
+  ASSERT_SUCCESS(hsa_iterate_agents(rocrtst::IterateGPUAgents, &gpus));
+  if (gpus.empty()) return;
+
+  for (unsigned int i = 0; i < gpus.size(); ++i) {
+    hsa_amd_memory_pool_t gpu_pool = {};
+    ASSERT_SUCCESS(
+        hsa_amd_agent_iterate_memory_pools(gpus[i], rocrtst::GetGlobalMemoryPool, &gpu_pool));
+    if (gpu_pool.handle == 0) continue;
+    ImportedShareableHandleSetAccessAfterFdClose(gpus[i], gpu_pool);
+  }
+
+  if (verbosity() > 0) {
+    std::cout << "    Subtest finished" << std::endl;
+    std::cout << kSubTestSeparator << std::endl;
+  }
 }

--- a/projects/rocr-runtime/rocrtst/suites/functional/virtual_memory.h
+++ b/projects/rocr-runtime/rocrtst/suites/functional/virtual_memory.h
@@ -85,6 +85,8 @@ class VirtMemoryTestBasic : public TestBase {
 
   void TestGpuAccessToHostMemoryAllocation(void);
 
+  void ImportedShareableHandleSetAccessAfterFdClose(void);
+
  private:
   void TestCreateDestroy(hsa_agent_t agent, hsa_amd_memory_pool_t pool);
   void TestRefCount(hsa_agent_t agent, hsa_amd_memory_pool_t pool);
@@ -101,6 +103,8 @@ class VirtMemoryTestBasic : public TestBase {
   void MemoryAccountingTest(hsa_agent_t agent, hsa_amd_memory_pool_t pool);
   void TestGpuAccessToHostMemoryAllocation(hsa_agent_t cpu_agent, hsa_agent_t gpu_agent,
                                            hsa_amd_memory_pool_t cpu_pool);
+  void ImportedShareableHandleSetAccessAfterFdClose(hsa_agent_t gpu_agent,
+                                                    hsa_amd_memory_pool_t pool);
   void TestVirtAddressAlias(hsa_agent_t cpu_agent, hsa_agent_t gpu_agent,
                             hsa_amd_memory_pool_t pool);
   void TestVirtAddressAlias(hsa_agent_t agent, hsa_amd_memory_pool_t pool);

--- a/projects/rocr-runtime/rocrtst/suites/test_common/main.cc
+++ b/projects/rocr-runtime/rocrtst/suites/test_common/main.cc
@@ -551,6 +551,7 @@ TEST(rocrtstFunc, VirtMemory_Access_Test) {
     vmt.CPUAccessToGPUMemoryTest();
     vmt.GPUAccessToCPUMemoryTest();
     vmt.GPUAccessToGPUMemoryTest();
+    vmt.ImportedShareableHandleSetAccessAfterFdClose();
     RunCustomTestEpilog(&vmt);
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -4460,8 +4460,15 @@ hsa_status_t Runtime::VMemoryExportShareableHandle(int* dmabuf_fd,
 
 hsa_status_t Runtime::VMemoryImportShareableHandle(int dmabuf_fd,
                                                    hsa_amd_vmem_alloc_handle_t* memoryOnlyHandle) {
+  /* The per-GPU import of this dmabuf is deferred until hsa_amd_vmem_set_access is called, but the
+   * caller is free to close their fd as soon as this function returns. Duplicate the fd so the
+   * MemoryHandle owns a copy that stays valid until the deferred import. The MemoryHandle destructor
+   * closes this owned fd. */
+  int owned_fd = os::DmaBufDup(dmabuf_fd);
+  if (owned_fd < 0) return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+
   std::lock_guard<std::shared_mutex> lock(memory_lock_);
-  auto memoryHandle = std::make_unique<MemoryHandle>(dmabuf_fd);
+  auto memoryHandle = std::make_unique<MemoryHandle>(owned_fd);
   *memoryOnlyHandle = MemoryHandle::Convert(memoryHandle.get());
   memory_handles.emplace(*memoryOnlyHandle, std::move(memoryHandle));
   return HSA_STATUS_SUCCESS;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
@@ -892,6 +892,16 @@ hsa_status_t DmaBufClose(int* dmabuf) {
   return HSA_STATUS_SUCCESS;
 }
 
+int DmaBufDup(int dmabuf) {
+  if (dmabuf < 0) return -1;
+  int dup_fd = ::dup(dmabuf);
+  if (dup_fd < 0) {
+    LogPrint(HSA_AMD_LOG_FLAG_INFO, "dup dmabuf failed: %s", strerror(errno));
+    return -1;
+  }
+  return dup_fd;
+}
+
 void* ReserveMemory(void* start, size_t size, size_t alignment, MemProt prot) {
   size = AlignUp(size, PageSize());
   // check for invalid input size

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
@@ -896,7 +896,6 @@ int DmaBufDup(int dmabuf) {
   if (dmabuf < 0) return -1;
   int dup_fd = ::dup(dmabuf);
   if (dup_fd < 0) {
-    LogPrint(HSA_AMD_LOG_FLAG_INFO, "dup dmabuf failed: %s", strerror(errno));
     return -1;
   }
   return dup_fd;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/os.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/os.h
@@ -364,6 +364,9 @@ bool MapMemory(void* addr, size_t size, MemProt prot, int fd, uint64_t cpu_addr)
 /// Close a dmabuf file descriptor and set *dmabuf to -1.
 hsa_status_t DmaBufClose(int* dmabuf);
 
+/// Duplicate a dmabuf file descriptor. Returns the new fd, or -1 on failure.
+int DmaBufDup(int dmabuf);
+
 bool ProtectMemory(void* va, size_t size, MemProt perms);
 
 uint64_t HostTotalPhysicalMemory();

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/win/os_win.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/win/os_win.cpp
@@ -486,6 +486,12 @@ hsa_status_t DmaBufClose(int* dmabuf) {
   return HSA_STATUS_SUCCESS;
 }
 
+int DmaBufDup(int dmabuf) {
+  /* DMA-BUF is not supported on Windows; preserve pre-dup behavior by returning the caller fd. */
+  if (dmabuf < 0) return -1;
+  return dmabuf;
+}
+
 bool ProtectMemory(void* va, size_t size, MemProt perms) {
   if (perms == MEM_PROT_NONE) {
     return UncommitMemory(va, size);


### PR DESCRIPTION
## Summary

Re-land the dmabuf fd duplication fix from #8304, which was reverted in #8436 to unblock TheRock R-S bump.

After #6471 deferred per-GPU dmabuf import to `hsa_amd_vmem_set_access` time, `VMemoryImportShareableHandle` must own a dup of the caller's fd so deferred import still works after the caller closes its fd (normal IPC ownership). This restores correct behavior for multi-rank VMM/IPC peer-access flows (e.g. RCCL CE collectives).

Also removes `LogPrint` from `DmaBufDup` on Linux to avoid rocdxg WSL link issues (same pattern as #8436 follow-up).

Adds a rocrtst regression test that imports a shareable handle, closes the caller fd before `set_access`, and verifies GPU access succeeds.

## JIRA ID

JIRA ID : ROCM-27777

## Test plan

- [x] Run `ImportedShareableHandleSetAccessAfterFdClose` rocrtst subtest on Linux with VMM support
- [x] Verify HIP/RCCL multi-rank VMM peer-access reproducer from ROCM-27777 (hip-allgather-batch-cumem1.cpp)
- [x] Confirm WSL/rocdxg build succeeds without LogPrint link errors in `DmaBufDup`


Made with [Cursor](https://cursor.com)