### PR TITLE
feat(rccl): auto-enable CUMEM and MNNVL on gfx1250

### DIFF
--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -1420,7 +1420,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   {
     const int mnnvlEnable = ncclParamMNNVLEnable();
     const bool isGfx1250 = comm->archName && IsArchMatch(comm->archName, "gfx1250");
-    // Auto (default=2): multi-node, or single-node gfx1250 (UALoE/MI455).
+    // Auto (default=2): multi-node, or single-node gfx1250
     const bool mnnvlAutoScope = (nNodes > 1 || isGfx1250) && p2pLevel != 0;
     if (mnnvlEnable == 1 || (mnnvlEnable != 0 && mnnvlAutoScope)) {
       NCCLCHECKGOTO(ncclMnnvlCheck(comm), ret, fail);

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -1417,8 +1417,14 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
 
   // Check for MNNVL support
   NCCLCHECKGOTO(ncclGetUserP2pLevel(&p2pLevel), ret, fail);
-  if ((nNodes > 1 && ncclParamMNNVLEnable() != 0 && p2pLevel != 0) || ncclParamMNNVLEnable() == 1) {
-    NCCLCHECKGOTO(ncclMnnvlCheck(comm), ret, fail);
+  {
+    const int mnnvlEnable = ncclParamMNNVLEnable();
+    const bool isGfx1250 = comm->archName && IsArchMatch(comm->archName, "gfx1250");
+    // Auto (default=2): multi-node, or single-node gfx1250 (UALoE/MI455).
+    const bool mnnvlAutoScope = (nNodes > 1 || isGfx1250) && p2pLevel != 0;
+    if (mnnvlEnable == 1 || (mnnvlEnable != 0 && mnnvlAutoScope)) {
+      NCCLCHECKGOTO(ncclMnnvlCheck(comm), ret, fail);
+    }
   }
 
   do {

--- a/projects/rccl/src/misc/rocmwrap.cc
+++ b/projects/rccl/src/misc/rocmwrap.cc
@@ -37,7 +37,7 @@ static pthread_once_t initOnceControl = PTHREAD_ONCE_INIT;
 static ncclResult_t initResult;
 
 // This env var (NCCL_CUMEM_ENABLE) toggles cuMem API usage
-NCCL_PARAM(CuMemEnable, "CUMEM_ENABLE", 0);
+NCCL_PARAM(CuMemEnable, "CUMEM_ENABLE", -2);
 NCCL_PARAM(CuMemHostEnable, "CUMEM_HOST_ENABLE", -1);
 // Handle type used for cuMemCreate()
 CUmemAllocationHandleType ncclCuMemHandleType = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
@@ -107,6 +107,7 @@ error:
 
 int ncclCuMemEnable() {
 #if NCCL_CUMEM_VERSION_SUPPORTED(HIP_VERSION)
+  // NCCL_CUMEM_ENABLE=-2 means auto-detect CUMEM support
   int param = ncclParamCuMemEnable();
   return param >= 0 ? param : (param == -2 && ncclCuMemSupported);
 #else


### PR DESCRIPTION
## Motivation

Detect if RCCL can use CUMEM and MNNVL and auto-enable by default

## Technical Details

MNNVL only activates when CUMEM is supported and fabric checks pass. Users can still force override with NCCL_CUMEM_ENABLE and NCCL_MNNVL_ENABLE.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
