### PR TITLE
fix(rocr): Use recursive mutex for agent memory lock

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/agent.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/agent.h
@@ -433,7 +433,7 @@ protected:
   // Serial memory operations are needed to ensure, among other things, that allocation failures are
   // due to true OOM conditions and per region caching (Trim and Allocate must be serial and
   // exclusive to ensure this).
-  std::mutex agent_memory_lock_;
+  std::recursive_mutex agent_memory_lock_;
 
   // Forbid copying and moving of this object
   DISALLOW_COPY_AND_ASSIGN(Agent);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_memory_region.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_memory_region.h
@@ -201,28 +201,6 @@ private:
   // Operational body for Free.  Recursive.
   hsa_status_t FreeImpl(void* address, size_t size) const;
 
-#if defined(SANITIZER_AMDGPU)
-  // ASAN re-entrancy guard: avoid deadlock when ASAN quarantine evicts a GPU
-  // block while this thread already holds an agent_memory_lock_.  Defer the
-  // re-entrant free until the outermost critical section exits.
-  class ScopedAgentMemoryLock {
-    public:
-      explicit ScopedAgentMemoryLock(std::mutex& mutex);
-      ~ScopedAgentMemoryLock();
-
-    private:
-      std::mutex& mutex_;
-      DISALLOW_COPY_AND_ASSIGN(ScopedAgentMemoryLock);
-  };
-
-  // Queue free if an agent_memory_lock_ is already held by this thread; returns
-  // true if the free was deferred, false if the caller should free normally.
-  bool DeferFreeIfLockHeld(void* address, size_t size) const;
-
-  // Drain queued frees after the outermost lock release.
-  static void DrainDeferredFrees();
-#endif  // SANITIZER_AMDGPU
-
   class BlockAllocator {
    private:
     MemoryRegion& region_;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_memory_region.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_memory_region.cpp
@@ -48,9 +48,7 @@
 #include "core/inc/amd_memory_region.h"
 
 #include <algorithm>
-#include <cstdio>
 #include <mutex>
-#include <vector>
 #include <shared_mutex>
 
 #include "core/inc/runtime.h"
@@ -135,72 +133,8 @@ MemoryRegion::MemoryRegion(bool fine_grain, bool kernarg, bool full_profile,
 
 MemoryRegion::~MemoryRegion() {}
 
-#if defined(SANITIZER_AMDGPU)
-namespace {
-// Per-thread lock nesting depth; non-zero means this thread holds an
-// agent_memory_lock_.
-thread_local unsigned tls_agent_lock_depth = 0;
-
-// Deferred free: region pointer, address, and size.
-struct DeferredFree {
-  const MemoryRegion* region;
-  void* address;
-  size_t size;
-};
-
-// Per-thread queue of deferred frees, drained when outermost lock exits.
-thread_local std::vector<DeferredFree> tls_deferred_frees;
-}  // namespace
-
-MemoryRegion::ScopedAgentMemoryLock::ScopedAgentMemoryLock(std::mutex& mutex) : mutex_(mutex) {
-  mutex_.lock();
-  ++tls_agent_lock_depth;  // Mark this thread as holding the lock.
-}
-
-MemoryRegion::ScopedAgentMemoryLock::~ScopedAgentMemoryLock() {
-  --tls_agent_lock_depth;
-  mutex_.unlock();
-  if (tls_agent_lock_depth == 0) DrainDeferredFrees();
-}
-
-bool MemoryRegion::DeferFreeIfLockHeld(void* address, size_t size) const {
-  if (tls_agent_lock_depth == 0) return false;
-  // Thread already holds the lock; defer to avoid re-entrant deadlock.
-  tls_deferred_frees.push_back(DeferredFree{this, address, size});
-  return true;
-}
-
-void MemoryRegion::DrainDeferredFrees() {
-  // Replay queued frees under lock. Re-entrant frees (from ASAN quarantine) are
-  // appended to the queue and handled by loop iterations (no recursion).  The
-  // queue terminates because the quarantine evicts a bounded number of blocks.
-  while (!tls_deferred_frees.empty()) {
-    const DeferredFree item = tls_deferred_frees.back();
-    tls_deferred_frees.pop_back();
-
-    std::lock_guard<std::mutex> guard(item.region->owner()->agent_memory_lock_);
-    ++tls_agent_lock_depth;
-    MAKE_SCOPE_GUARD([&]() { --tls_agent_lock_depth; });
-
-    try {
-      hsa_status_t status = item.region->FreeImpl(item.address, item.size);
-      if (status != HSA_STATUS_SUCCESS) {
-        fprintf(stderr, "ROCR: Deferred free failed: %p size=%zu status=%d\n", item.address,
-                item.size, static_cast<int>(status));
-      }
-    } catch (...) {
-      fprintf(stderr, "ROCR: Deferred free threw: %p size=%zu\n", item.address, item.size);
-    }
-  }
-}
-#endif  // SANITIZER_AMDGPU
-
 hsa_status_t MemoryRegion::Allocate(size_t& size, AllocateFlags alloc_flags, void** mem, int agent_node_id) const {
-#if defined(SANITIZER_AMDGPU)
-  ScopedAgentMemoryLock lock(owner()->agent_memory_lock_);
-#else
-  std::lock_guard<std::mutex> lock(owner()->agent_memory_lock_);
-#endif
+  std::lock_guard<std::recursive_mutex> lock(owner()->agent_memory_lock_);
   return AllocateImpl(size, alloc_flags, mem, agent_node_id);
 }
 
@@ -230,13 +164,7 @@ hsa_status_t MemoryRegion::AllocateImpl(size_t& size, AllocateFlags alloc_flags,
 }
 
 hsa_status_t MemoryRegion::Free(void* address, size_t size) const {
-#if defined(SANITIZER_AMDGPU)
-  // If re-entrant (under ASAN), defer; otherwise take lock and free normally.
-  if (DeferFreeIfLockHeld(address, size)) return HSA_STATUS_SUCCESS;
-  ScopedAgentMemoryLock lock(owner()->agent_memory_lock_);
-#else
-  std::lock_guard<std::mutex> lock(owner()->agent_memory_lock_);
-#endif
+  std::lock_guard<std::recursive_mutex> lock(owner()->agent_memory_lock_);
   return FreeImpl(address, size);
 }
 
@@ -248,11 +176,7 @@ hsa_status_t MemoryRegion::FreeImpl(void* address, size_t size) const {
 
 // TODO:  Look into a better name and/or making this process transparent to exporting.
 hsa_status_t MemoryRegion::IPCFragmentExport(void* address) const {
-#if defined(SANITIZER_AMDGPU)
-  ScopedAgentMemoryLock lock(owner()->agent_memory_lock_);
-#else
-  std::lock_guard<std::mutex> lock(owner()->agent_memory_lock_);
-#endif
+  std::lock_guard<std::recursive_mutex> lock(owner()->agent_memory_lock_);
   if (!fragment_allocator_.discardBlock(address)) return HSA_STATUS_ERROR_INVALID_ALLOCATION;
   return HSA_STATUS_SUCCESS;
 }


### PR DESCRIPTION
## Summary

Replace the deferred-free re-entrancy workaround (PR #7492) with a `std::recursive_mutex` on `agent_memory_lock_`. When AddressSanitizer quarantine is enabled, an allocate can evict an older GPU block and re-enter `MemoryRegion::Free` on the same thread; a non-recursive mutex deadlocks. A recursive mutex allows the re-entrant free without the thread-local deferred-free queue.

Validated on s72-2 (gfx942) with TheRock 7.14 (`/home/amd/dayatsin/therock`):

- `Unit_Warp_Shfl_Down_Positive_Basic` (10 variants): **passed** with `ASAN_OPTIONS=quarantine_size_mb=600` and `HSA_XNACK=1`
- Full hip catch suite (recursive-mutex ROCr, no ASAN): **3371 passed / 6 failed / 1218 skipped** (99%)
- Full hip catch suite (recursive-mutex ROCr, ASAN + `HSA_XNACK=1`): **3357 passed / 36 failed / 1196 skipped** (99%)
- ASAN baseline (stock TheRock ROCr, same env): **3355 passed / 38 failed / 1196 skipped** (99%) — on par with recursive mutex (+2 pass / −2 fail); 28 common failures (managed-memory, prefetch, stream-attach, IPC); remaining diff is run-to-run timeout/flake noise, not a new failure class

## JIRA ID

JIRA ID : ROCM-26090

## Test plan

- [x] Built ROCr against TheRock `/home/amd/dayatsin/therock` on s72-2
- [x] `Unit_Warp_Shfl_Down_Positive_Basic` (10 variants) with `ASAN_OPTIONS=quarantine_size_mb=600`, `HSA_XNACK=1`
- [x] Full hip catch suite without ASAN/`HSA_XNACK` (3371 passed / 6 failed / 1218 skipped)
- [x] Full hip catch suite with `ASAN_OPTIONS=quarantine_size_mb=600`, `HSA_XNACK=1` (3357 passed / 36 failed / 1196 skipped)
- [x] ASAN baseline vs stock TheRock ROCr (3355 passed / 38 failed / 1196 skipped)