### PR TITLE
fix(rocr): shader-blit fallback for DmaCopyBatch multi-entry LINEAR

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
@@ -814,6 +814,21 @@ class GpuAgent : public GpuAgentInt {
       const hsa_amd_memory_copy_op_t& op,
       std::vector<core::Signal*>& dep_signals);
 
+  // Multi-linear copy: LINEAR op with num_entries > 0, independent copies
+  // (different src/dst/size per entry) sharing a single completion signal.
+  // Uses prologue/body/epilogue fan-out across available SDMA engines.
+  hsa_status_t DmaCopyMulti(
+      const hsa_amd_memory_copy_op_t& op,
+      std::vector<core::Signal*>& dep_signals);
+
+  // SDMA-disabled shader-blit fallback for a single DmaCopyBatch op.  Selects
+  // the blit shader based on op type: plain LINEAR uses the BlitDevToDev linear
+  // copy shader (one entry at a time).  Broadcast/swap/indirect have no shader
+  // equivalent yet and are rejected until those shaders are added.
+  hsa_status_t DmaCopyBatchFallback(
+      const hsa_amd_memory_copy_op_t& op,
+      std::vector<core::Signal*>& dep_signals);
+
   // Linear swap: exchanges the contents of src and dst buffers.
   // Only supported on gfx94X / gfx95X.  Uses DmaCopyFanOutOp with
   // HSA_AMD_MEMORY_COPY_OP_LINEAR_SWAP.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -1965,6 +1965,44 @@ hsa_status_t GpuAgent::DmaCopyIndirect(
                          op.dst_list, op.dst_agent_list, op.size_list);
 }
 
+hsa_status_t GpuAgent::DmaCopyBatchFallback(
+    const hsa_amd_memory_copy_op_t& op,
+    std::vector<core::Signal*>& dep_signals) {
+  core::Signal& out_signal = *core::Signal::Convert(op.completion_signal);
+
+  switch (op.type) {
+  case HSA_AMD_MEMORY_COPY_OP_LINEAR: {
+    // BlitDevToDev linear copy shader, one entry at a time. Covers both the
+    // multi-entry batch (hipMemcpyBatchAsync H2D/D2H) and the single scalar op.
+    for (core::Signal* sig : dep_signals)
+      sig->WaitRelaxed(HSA_SIGNAL_CONDITION_EQ, 0, UINT64_MAX,
+                       HSA_WAIT_STATE_BLOCKED);
+    hsa_status_t status = HSA_STATUS_SUCCESS;
+    if (op.num_entries > 0) {
+      for (uint16_t d = 0; d < op.num_entries; ++d) {
+        status = DmaCopy(op.dst_list[d], op.src_list[d], op.size_list[d]);
+        if (status != HSA_STATUS_SUCCESS) break;
+      }
+    } else {
+      status = DmaCopy(op.dst, op.src, op.size);
+    }
+    out_signal.SubRelaxed(1);
+    return status;
+  }
+  case HSA_AMD_MEMORY_COPY_OP_LINEAR_BROADCAST:
+  case HSA_AMD_MEMORY_COPY_OP_LINEAR_SWAP:
+  case HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRC:
+  case HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_DST:
+  case HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRCDST:
+    // No shader-blit equivalent for broadcast/swap/indirect yet; these are the
+    // slots for the 1-to-N / swap / indirect blit shaders once added. Until
+    // then, reject under SDMA=0 (same as the SDMA fan-out path would).
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  default:
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  }
+}
+
 hsa_status_t GpuAgent::DmaCopyBatch(const hsa_amd_memory_copy_op_t* ops,
                                     uint32_t num_ops,
                                     std::vector<core::Signal*>& dep_signals) {
@@ -1978,6 +2016,17 @@ hsa_status_t GpuAgent::DmaCopyBatch(const hsa_amd_memory_copy_op_t* ops,
     core::Signal& out_signal = *out_signal_obj;
 
     hsa_status_t status;
+
+    // SDMA disabled: route the op through the shader-blit fallback helper,
+    // which selects the appropriate blit shader per op type (or rejects ops
+    // with no shader equivalent yet). Done before the switch so all SDMA=0
+    // shader-selection lives in one place.
+    if (!GetBlitObject(BlitHostToDev)->isSDMA()) {
+      status = DmaCopyBatchFallback(op, dep_signals);
+      if (status != HSA_STATUS_SUCCESS)
+        return status;
+      continue;
+    }
 
     switch (op.type) {
     case HSA_AMD_MEMORY_COPY_OP_LINEAR: {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -1974,20 +1974,32 @@ hsa_status_t GpuAgent::DmaCopyBatchFallback(
   case HSA_AMD_MEMORY_COPY_OP_LINEAR: {
     // BlitDevToDev linear copy shader, one entry at a time. Covers both the
     // multi-entry batch (hipMemcpyBatchAsync H2D/D2H) and the single scalar op.
+    // The 3-arg DmaCopy issues blits_[BlitDevToDev] synchronously; under SDMA=0
+    // this is the same shader the single-entry LINEAR path lands on, since
+    // DmaCopyOnEngine forces engine_offset = BlitDevToDev when SDMA is disabled
+    // (covering local H2D/D2H as well as peer entries the copy agent can map).
     for (core::Signal* sig : dep_signals)
       sig->WaitRelaxed(HSA_SIGNAL_CONDITION_EQ, 0, UINT64_MAX,
                        HSA_WAIT_STATE_BLOCKED);
-    hsa_status_t status = HSA_STATUS_SUCCESS;
     if (op.num_entries > 0) {
       for (uint16_t d = 0; d < op.num_entries; ++d) {
-        status = DmaCopy(op.dst_list[d], op.src_list[d], op.size_list[d]);
-        if (status != HSA_STATUS_SUCCESS) break;
+        hsa_status_t status =
+            DmaCopy(op.dst_list[d], op.src_list[d], op.size_list[d]);
+        // On error, leave the completion signal untouched and return, matching
+        // the normal DmaCopyBatch switch (callee resolves the signal only on
+        // success; the caller propagates the error). Decrementing here would
+        // signal completion for a copy that did not happen.
+        if (status != HSA_STATUS_SUCCESS) return status;
       }
     } else {
-      status = DmaCopy(op.dst, op.src, op.size);
+      hsa_status_t status = DmaCopy(op.dst, op.src, op.size);
+      if (status != HSA_STATUS_SUCCESS) return status;
     }
-    out_signal.SubRelaxed(1);
-    return status;
+    // Release edge so a consumer waiting on the completion signal with
+    // scacquire is guaranteed to observe the copied bytes (mirrors the
+    // synchronous copy-then-signal pattern in CpuAgent::DmaCopy).
+    out_signal.SubRelease(1);
+    return HSA_STATUS_SUCCESS;
   }
   case HSA_AMD_MEMORY_COPY_OP_LINEAR_BROADCAST:
   case HSA_AMD_MEMORY_COPY_OP_LINEAR_SWAP:
@@ -1996,11 +2008,15 @@ hsa_status_t GpuAgent::DmaCopyBatchFallback(
   case HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRCDST:
     // No shader-blit equivalent for broadcast/swap/indirect yet; these are the
     // slots for the 1-to-N / swap / indirect blit shaders once added. Until
-    // then, reject under SDMA=0 (same as the SDMA fan-out path would).
-    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
-  default:
+    // then, reject under SDMA=0 (same as the SDMA fan-out path would), leaving
+    // the completion signal untouched as above.
     return HSA_STATUS_ERROR_INVALID_ARGUMENT;
   }
+
+  // No default case: keep the switch exhaustive over hsa_amd_memory_copy_op_t
+  // so a newly added op type triggers a compiler warning here instead of being
+  // silently rejected.
+  return HSA_STATUS_ERROR_INVALID_ARGUMENT;
 }
 
 hsa_status_t GpuAgent::DmaCopyBatch(const hsa_amd_memory_copy_op_t* ops,
@@ -2021,6 +2037,11 @@ hsa_status_t GpuAgent::DmaCopyBatch(const hsa_amd_memory_copy_op_t* ops,
     // which selects the appropriate blit shader per op type (or rejects ops
     // with no shader equivalent yet). Done before the switch so all SDMA=0
     // shader-selection lives in one place.
+    //
+    // The H2D blit is used as the SDMA-availability probe on the assumption
+    // that SDMA is enabled/disabled globally (the HSA_ENABLE_SDMA=0 case this
+    // fallback targets). If per-direction SDMA availability ever diverges this
+    // probe would need to move per-entry, but today all blits share one state.
     if (!GetBlitObject(BlitHostToDev)->isSDMA()) {
       status = DmaCopyBatchFallback(op, dep_signals);
       if (status != HSA_STATUS_SUCCESS)


### PR DESCRIPTION
## Summary

Under `HSA_ENABLE_SDMA=0`, multi-entry LINEAR batch copies (`hipMemcpyBatchAsync` H2D/D2H and `hsa_amd_memory_async_batch_copy`) routed through `DmaCopyMulti` → `DmaCopyFanOutOp` fail with `HSA_STATUS_ERROR_INVALID_ARGUMENT` because no SDMA engine is available. Single-entry LINEAR copies already fall back to the BlitDevToDev shader via `DmaCopyOnEngine`, but the multi-entry batch path had no equivalent.

Add `DmaCopyBatchFallback`, invoked at the top of `DmaCopyBatch` when SDMA is disabled:
- **LINEAR**: per-entry synchronous `DmaCopy` (BlitDevToDev shader), covering both multi-entry batches and single scalar ops
- **BROADCAST / SWAP / INDIRECT**: no shader equivalent yet; explicit reject (same as SDMA fan-out would)

### Review follow-ups (addressed)
- Completion signal is decremented with `SubRelease(1)` (not `SubRelaxed`) so a consumer waiting with `scacquire` is guaranteed to observe the copied bytes.
- The completion signal is resolved only on success; on a per-entry failure the helper returns the error without decrementing, matching the normal `DmaCopyBatch` switch and its caller (callee resolves only on success).
- Dropped the `default:` case so the switch stays exhaustive over `hsa_amd_memory_copy_op_t` and a newly added op type triggers a compiler warning instead of being silently rejected.
- Documented the BlitDevToDev shader-selection rationale (SDMA=0 forces `BlitDevToDev` in `DmaCopyOnEngine` anyway) and the global-SDMA probe assumption.

## JIRA ID

JIRA ID : ROCM-27858

## Test plan

Validated on b8-3 (gfx1250) against a TheRock `/opt/rocm` toolchain, comparing stock vs patched `libhsa-runtime64` with an 8-entry LINEAR `hipMemcpyBatchAsync` repro (H2D/D2H/D2D, with data verification):

- [x] Stock runtime, `HSA_ENABLE_SDMA=0`: H2D/D2H fail (silent corruption, ret=0), D2D passes — bug reproduced
- [x] Stock runtime, default SDMA: all pass
- [x] Patched runtime, `HSA_ENABLE_SDMA=0`: H2D/D2H/D2D all pass — fix validated
- [x] Patched runtime, default SDMA: all pass — no regression

Made with [Cursor](https://cursor.com)
