### PR TITLE
fix (rocr):  resolve BO handles per-agent / driver

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/functional/virtual_memory.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/virtual_memory.cc
@@ -2365,7 +2365,7 @@ void VirtMemoryTestBasic::TestGpuAccessToHostMemoryAllocation(hsa_agent_t cpu_ag
   // Create memory handle from system memory
   hsa_amd_vmem_alloc_handle_t mem_handle;
   ASSERT_SUCCESS(hsa_amd_vmem_handle_create(cpu_pool, vmem_alloc_size, MEMORY_TYPE_NONE, 0, &mem_handle));
-  
+
   // Map the reserved VA to above memory only handle
   ASSERT_SUCCESS(hsa_amd_vmem_map(vmem_data, vmem_alloc_size, 0, mem_handle, 0));
 
@@ -2488,8 +2488,8 @@ void VirtMemoryTestBasic::TestGpuAccessToHostMemoryAllocation(hsa_agent_t cpu_ag
   if (queue) hsa_queue_destroy(queue);
 }
 
-void VirtMemoryTestBasic::ImportedShareableHandleSetAccessAfterFdClose(
-    hsa_agent_t gpu_agent, hsa_amd_memory_pool_t pool) {
+void VirtMemoryTestBasic::ImportedShareableHandleSetAccessAfterFdClose(hsa_agent_t agent,
+                                                                       hsa_amd_memory_pool_t pool) {
   rocrtst::pool_info_t pool_i;
   ASSERT_SUCCESS(rocrtst::AcquirePoolInfo(pool, &pool_i));
   if (!pool_i.alloc_allowed || pool_i.segment != HSA_AMD_SEGMENT_GLOBAL) return;
@@ -2519,13 +2519,13 @@ void VirtMemoryTestBasic::ImportedShareableHandleSetAccessAfterFdClose(
    * importer does not retain the exporter's allocation handle. */
   ASSERT_SUCCESS(hsa_amd_vmem_handle_release(exported_handle));
 
-  /* Peer GPU access only: imported shareable handles do not support CPU set_access
+  /* Peer agent access only: imported shareable handles do not support CPU set_access
    * (no mmap_offset on the dmabuf import path). */
-  hsa_amd_memory_access_desc_t access_desc = {HSA_ACCESS_PERMISSION_RW, gpu_agent};
+  hsa_amd_memory_access_desc_t access_desc = {HSA_ACCESS_PERMISSION_RW, agent};
   ASSERT_SUCCESS(hsa_amd_vmem_set_access(addr, alloc_size, &access_desc, 1));
 
   hsa_access_permission_t perm = HSA_ACCESS_PERMISSION_NONE;
-  ASSERT_SUCCESS(hsa_amd_vmem_get_access(addr, &perm, gpu_agent));
+  ASSERT_SUCCESS(hsa_amd_vmem_get_access(addr, &perm, agent));
   ASSERT_EQ(perm, HSA_ACCESS_PERMISSION_RW);
 
   ASSERT_SUCCESS(hsa_amd_vmem_unmap(addr, alloc_size));
@@ -2558,6 +2558,16 @@ void VirtMemoryTestBasic::ImportedShareableHandleSetAccessAfterFdClose(void) {
         hsa_amd_agent_iterate_memory_pools(gpus[i], rocrtst::GetGlobalMemoryPool, &gpu_pool));
     if (gpu_pool.handle == 0) continue;
     ImportedShareableHandleSetAccessAfterFdClose(gpus[i], gpu_pool);
+  }
+
+  std::vector<hsa_agent_t> aies;
+  ASSERT_SUCCESS(hsa_iterate_agents(rocrtst::IterateAIEAgents, &aies));
+  for (unsigned int i = 0; i < aies.size(); ++i) {
+    hsa_amd_memory_pool_t aie_pool = {};
+    ASSERT_SUCCESS(
+        hsa_amd_agent_iterate_memory_pools(aies[i], rocrtst::GetGlobalMemoryPool, &aie_pool));
+    if (aie_pool.handle == 0) continue;
+    ImportedShareableHandleSetAccessAfterFdClose(aies[i], aie_pool);
   }
 
   if (verbosity() > 0) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -224,12 +224,21 @@ hsa_status_t KfdDriver::GetCacheProperties(uint32_t node_id, uint32_t processor_
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t
-KfdDriver::AllocateMemory(const core::MemoryRegion &mem_region,
-                          core::MemoryRegion::AllocateFlags alloc_flags,
-                          void **mem, size_t size, uint32_t agent_node_id) {
+hsa_status_t KfdDriver::AllocateMemory(const core::MemoryRegion& mem_region,
+                                       core::MemoryRegion::AllocateFlags alloc_flags, void** mem,
+                                       size_t size, uint32_t agent_node_id,
+                                       core::DriverMemoryHandle* handle) {
   const MemoryRegion &m_region(static_cast<const MemoryRegion &>(mem_region));
   HsaMemFlags kmt_alloc_flags(m_region.mem_flags());
+
+  // Fills the caller's handle from whatever *mem holds: a VA for fragment and
+  // mapped allocations, or the opaque memory-only handle for NoAddress
+  // allocations. For KFD both are the allocation word reinterpreted as uint64_t.
+  // Export-only fields stay at their defaults and are filled lazily on export.
+  auto populate_handle = [&]() {
+    handle->handle = reinterpret_cast<uint64_t>(*mem);
+    handle->size = size;
+  };
 
   kmt_alloc_flags.ui32.ExecuteAccess =
       (alloc_flags & core::MemoryRegion::AllocateExecutable ? 1 : 0);
@@ -304,6 +313,7 @@ KfdDriver::AllocateMemory(const core::MemoryRegion &mem_region,
         return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
       }
 
+      populate_handle();
       return HSA_STATUS_SUCCESS;
     }
   }
@@ -327,7 +337,8 @@ KfdDriver::AllocateMemory(const core::MemoryRegion &mem_region,
   }
   if (status == HSAKMT_STATUS_SUCCESS) {
     if (kmt_alloc_flags.ui32.NoAddress) {
-      // returns mem
+      // returns mem (opaque memory-only handle, no virtual address)
+      populate_handle();
       return HSA_STATUS_SUCCESS;
     }
 
@@ -349,12 +360,14 @@ KfdDriver::AllocateMemory(const core::MemoryRegion &mem_region,
 
         if (map_node_count == 0) {
           // No need to pin since no GPU in the platform.
+          populate_handle();
           return HSA_STATUS_SUCCESS;
         }
 
         map_node_id = &core::Runtime::runtime_singleton_->gpu_ids()[0];
       } else {
         // No need to pin it for CPU exclusive access.
+        populate_handle();
         return HSA_STATUS_SUCCESS;
       }
     }
@@ -391,15 +404,19 @@ KfdDriver::AllocateMemory(const core::MemoryRegion &mem_region,
     }
 
     memoryGuard.Dismiss();
+    populate_handle();
     return HSA_STATUS_SUCCESS;
   }
 
   return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
 }
 
-hsa_status_t KfdDriver::FreeMemory(void *mem, size_t size) {
-  HSAKMT_CALL(hsaKmtUnmapMemoryToGPU(const_cast<void *>(mem)));
-  return (HSAKMT_CALL(hsaKmtFreeMemory(mem, size)) == HSAKMT_STATUS_SUCCESS) ? HSA_STATUS_SUCCESS : HSA_STATUS_ERROR;
+hsa_status_t KfdDriver::FreeMemory(const core::DriverMemoryHandle& handle) {
+  void* mem = reinterpret_cast<void*>(handle.handle);
+  HSAKMT_CALL(hsaKmtUnmapMemoryToGPU(mem));
+  return (HSAKMT_CALL(hsaKmtFreeMemory(mem, handle.size)) == HSAKMT_STATUS_SUCCESS)
+      ? HSA_STATUS_SUCCESS
+      : HSA_STATUS_ERROR;
 }
 
 hsa_status_t KfdDriver::CreateQueue(uint32_t node_id, HSA_QUEUE_TYPE type, uint32_t queue_pct,
@@ -612,11 +629,14 @@ hsa_status_t KfdDriver::Unmap(const core::DriverMemoryHandle& handle, void *mem,
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t KfdDriver::CreateShareableHandle(void* va, void* mem, size_t size,
-                                              const core::Agent& agent,
-                                              core::DriverMemoryHandle* handle, uint64_t* offset) {
+hsa_status_t KfdDriver::CreateShareableHandle(core::DriverMemoryHandle* handle,
+                                              const core::Agent& agent, uint64_t* offset) {
   // Create handle by exporting and importing the memory from the owning agent.
-  (void)va;
+
+  // On input, handle is the allocation handle. For KFD the native allocation id is the
+  // allocation's virtual address.
+  void* mem = reinterpret_cast<void*>(handle->handle);
+  const size_t size = handle->size;
 
   int source_fd = -1;
 
@@ -628,7 +648,7 @@ hsa_status_t KfdDriver::CreateShareableHandle(void* va, void* mem, size_t size,
    */
 
   core::DriverMemoryHandle kfd_alloc = {};
-  kfd_alloc.handle = reinterpret_cast<uint64_t>(mem);
+  kfd_alloc.handle = handle->handle;
   kfd_alloc.size = size;
   if (ExportMemoryHandleImpl(agent, kfd_alloc, core::ShareType::DMABUF_FD,
                              EXPORT_MEMORY_FLAGS_KFD_DMABUF, &source_fd,
@@ -667,13 +687,13 @@ hsa_status_t KfdDriver::CreateShareableHandle(void* va, void* mem, size_t size,
     return HSA_STATUS_ERROR;
   }
 
+  // handle->handle is replaced by the imported BO; handle->size carries over from allocation.
   handle->handle = targetHandle.handle;
   /*
    * Do not hold a shareable dmabuf_fd open for the lifetime of the handle. It is created lazily
    * (and closed again) when access is set in Runtime::VMemorySetAccessPerHandle.
    */
   handle->dmabuf_fd = -1;
-  handle->size = size;
   return HSA_STATUS_SUCCESS;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -225,18 +225,19 @@ hsa_status_t KfdDriver::GetCacheProperties(uint32_t node_id, uint32_t processor_
 }
 
 hsa_status_t KfdDriver::AllocateMemory(const core::MemoryRegion& mem_region,
-                                       core::MemoryRegion::AllocateFlags alloc_flags, void** mem,
-                                       size_t size, uint32_t agent_node_id,
-                                       core::DriverMemoryHandle* handle) {
+                                       core::MemoryRegion::AllocateFlags alloc_flags, size_t size,
+                                       uint32_t agent_node_id, core::DriverMemoryHandle* handle) {
   const MemoryRegion &m_region(static_cast<const MemoryRegion &>(mem_region));
   HsaMemFlags kmt_alloc_flags(m_region.mem_flags());
+  void* mem = nullptr;
 
-  // Fills the caller's handle from whatever *mem holds: a VA for fragment and
+  // Fills the caller's handle from whatever mem holds: a VA for fragment and
   // mapped allocations, or the opaque memory-only handle for NoAddress
   // allocations. For KFD both are the allocation word reinterpreted as uint64_t.
   // Export-only fields stay at their defaults and are filled lazily on export.
   auto populate_handle = [&]() {
-    handle->handle = reinterpret_cast<uint64_t>(*mem);
+    handle->handle = reinterpret_cast<uint64_t>(mem);
+    handle->vaddr = mem;
     handle->size = size;
   };
 
@@ -304,12 +305,11 @@ hsa_status_t KfdDriver::AllocateMemory(const core::MemoryRegion& mem_region,
         ((alloc_flags & (~core::MemoryRegion::AllocateRestrict)) == 0);
 
     if (useSubAlloc) {
-      *mem = m_region.fragment_alloc(size);
+      mem = m_region.fragment_alloc(size);
 
       if ((alloc_flags & core::MemoryRegion::AllocateAsan) &&
-          HSAKMT_CALL(hsaKmtReplaceAsanHeaderPage(*mem)) != HSAKMT_STATUS_SUCCESS) {
-        m_region.fragment_free(*mem);
-        *mem = nullptr;
+          HSAKMT_CALL(hsaKmtReplaceAsanHeaderPage(mem)) != HSAKMT_STATUS_SUCCESS) {
+        m_region.fragment_free(mem);
         return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
       }
 
@@ -330,10 +330,10 @@ hsa_status_t KfdDriver::AllocateMemory(const core::MemoryRegion& mem_region,
   //// Allocate memory.
   //// If it fails attempt to release memory from the block allocator and retry.
 
-  auto status = HSAKMT_CALL(hsaKmtAllocMemory(node_id, size, kmt_alloc_flags, mem));
+  auto status = HSAKMT_CALL(hsaKmtAllocMemory(node_id, size, kmt_alloc_flags, &mem));
   if (status == HSAKMT_STATUS_NO_MEMORY) {
     m_region.owner()->Trim();
-    status = HSAKMT_CALL(hsaKmtAllocMemory(node_id, size, kmt_alloc_flags, mem));
+    status = HSAKMT_CALL(hsaKmtAllocMemory(node_id, size, kmt_alloc_flags, &mem));
   }
   if (status == HSAKMT_STATUS_SUCCESS) {
     if (kmt_alloc_flags.ui32.NoAddress) {
@@ -373,17 +373,17 @@ hsa_status_t KfdDriver::AllocateMemory(const core::MemoryRegion& mem_region,
     }
 
     MAKE_NAMED_SCOPE_GUARD(memoryGuard, [&]() {
-      if (*mem != nullptr) {
-        HSAKMT_CALL(hsaKmtFreeMemory(*mem, size));
-        *mem = nullptr;
+      if (mem != nullptr) {
+        HSAKMT_CALL(hsaKmtFreeMemory(mem, size));
+        mem = nullptr;
       }
     });
 
     uint64_t alternate_va = 0;
 
-    const bool is_resident =
-      (HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes(*mem, size, &alternate_va, map_flag,
-                                             map_node_count, const_cast<uint32_t*>(map_node_id))) == HSAKMT_STATUS_SUCCESS);
+    const bool is_resident = (HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes(
+                                  mem, size, &alternate_va, map_flag, map_node_count,
+                                  const_cast<uint32_t*>(map_node_id))) == HSAKMT_STATUS_SUCCESS);
 
     // On Windows/DXG, allow allocations to succeed even if MakeResident
     // is best-effort; WDDM will demand-page on GPU access.
@@ -399,7 +399,7 @@ hsa_status_t KfdDriver::AllocateMemory(const core::MemoryRegion& mem_region,
     }
 
     if ((alloc_flags & core::MemoryRegion::AllocateAsan) &&
-        HSAKMT_CALL(hsaKmtReplaceAsanHeaderPage(*mem)) != HSAKMT_STATUS_SUCCESS) {
+        HSAKMT_CALL(hsaKmtReplaceAsanHeaderPage(mem)) != HSAKMT_STATUS_SUCCESS) {
       return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
     }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/virtio/amd_kfd_virtio_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/virtio/amd_kfd_virtio_driver.cpp
@@ -222,10 +222,19 @@ hsa_status_t KfdVirtioDriver::SetTrapHandler(uint32_t node_id, const void* base,
 
 hsa_status_t KfdVirtioDriver::AllocateMemory(const core::MemoryRegion& mem_region,
                                              core::MemoryRegion::AllocateFlags alloc_flags,
-                                             void** mem, size_t size, uint32_t agent_node_id) {
+                                             void** mem, size_t size, uint32_t agent_node_id,
+                                             core::DriverMemoryHandle* handle) {
   const MemoryRegion& m_region(static_cast<const MemoryRegion&>(mem_region));
   HsaMemFlags kmt_alloc_flags(m_region.mem_flags());
   HSAKMT_STATUS ret;
+
+  // Fills the caller's handle from whatever *mem holds: a VA for fragment and
+  // mapped allocations, or the opaque memory-only handle for NoAddress
+  // allocations. Both are the allocation word reinterpreted as uint64_t.
+  auto populate_handle = [&]() {
+    handle->handle = reinterpret_cast<uint64_t>(*mem);
+    handle->size = size;
+  };
 
   kmt_alloc_flags.ui32.ExecuteAccess =
       (alloc_flags & core::MemoryRegion::AllocateExecutable ? 1 : 0);
@@ -275,6 +284,7 @@ hsa_status_t KfdVirtioDriver::AllocateMemory(const core::MemoryRegion& mem_regio
         return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
       }
 
+      populate_handle();
       return HSA_STATUS_SUCCESS;
     }
   }
@@ -299,7 +309,10 @@ hsa_status_t KfdVirtioDriver::AllocateMemory(const core::MemoryRegion& mem_regio
   }
 
   if (*mem != nullptr) {
-    if (kmt_alloc_flags.ui32.NoAddress) return HSA_STATUS_SUCCESS;
+    if (kmt_alloc_flags.ui32.NoAddress) {
+      populate_handle();
+      return HSA_STATUS_SUCCESS;
+    }
 
     // Commit the memory.
     // For system memory, on non-restricted allocation, map it to all GPUs. On
@@ -319,12 +332,14 @@ hsa_status_t KfdVirtioDriver::AllocateMemory(const core::MemoryRegion& mem_regio
 
         if (map_node_count == 0) {
           // No need to pin since no GPU in the platform.
+          populate_handle();
           return HSA_STATUS_SUCCESS;
         }
 
         map_node_id = &core::Runtime::runtime_singleton_->gpu_ids()[0];
       } else {
         // No need to pin it for CPU exclusive access.
+        populate_handle();
         return HSA_STATUS_SUCCESS;
       }
     }
@@ -347,16 +362,18 @@ hsa_status_t KfdVirtioDriver::AllocateMemory(const core::MemoryRegion& mem_regio
       // TODO: Implement ASAN support for VIRTIO driver
       return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
     }
+    populate_handle();
     return HSA_STATUS_SUCCESS;
   }
 
   return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
 }
 
-hsa_status_t KfdVirtioDriver::FreeMemory(void* mem, size_t size) {
+hsa_status_t KfdVirtioDriver::FreeMemory(const core::DriverMemoryHandle& handle) {
+  void* mem = reinterpret_cast<void*>(handle.handle);
   MakeMemoryUnresident(mem);
-  return vhsaKmtFreeMemory(mem, size) == HSAKMT_STATUS_SUCCESS ? HSA_STATUS_SUCCESS
-                                                               : HSA_STATUS_ERROR;
+  return vhsaKmtFreeMemory(mem, handle.size) == HSAKMT_STATUS_SUCCESS ? HSA_STATUS_SUCCESS
+                                                                      : HSA_STATUS_ERROR;
 }
 
 hsa_status_t KfdVirtioDriver::AllocateScratchMemory(uint32_t node_id, uint64_t size,
@@ -547,9 +564,8 @@ hsa_status_t KfdVirtioDriver::Unmap(const core::DriverMemoryHandle& handle, void
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t KfdVirtioDriver::CreateShareableHandle(void* va, void* mem, size_t size,
-                                                    const core::Agent& agent,
-                                                    core::DriverMemoryHandle* handle, uint64_t* offset) {
+hsa_status_t KfdVirtioDriver::CreateShareableHandle(core::DriverMemoryHandle* handle,
+                                                    const core::Agent& agent, uint64_t* offset) {
   return HSA_STATUS_ERROR;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/virtio/amd_kfd_virtio_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/virtio/amd_kfd_virtio_driver.cpp
@@ -222,17 +222,19 @@ hsa_status_t KfdVirtioDriver::SetTrapHandler(uint32_t node_id, const void* base,
 
 hsa_status_t KfdVirtioDriver::AllocateMemory(const core::MemoryRegion& mem_region,
                                              core::MemoryRegion::AllocateFlags alloc_flags,
-                                             void** mem, size_t size, uint32_t agent_node_id,
+                                             size_t size, uint32_t agent_node_id,
                                              core::DriverMemoryHandle* handle) {
   const MemoryRegion& m_region(static_cast<const MemoryRegion&>(mem_region));
   HsaMemFlags kmt_alloc_flags(m_region.mem_flags());
   HSAKMT_STATUS ret;
+  void* mem = nullptr;
 
-  // Fills the caller's handle from whatever *mem holds: a VA for fragment and
+  // Fills the caller's handle from whatever mem holds: a VA for fragment and
   // mapped allocations, or the opaque memory-only handle for NoAddress
   // allocations. Both are the allocation word reinterpreted as uint64_t.
   auto populate_handle = [&]() {
-    handle->handle = reinterpret_cast<uint64_t>(*mem);
+    handle->handle = reinterpret_cast<uint64_t>(mem);
+    handle->vaddr = mem;
     handle->size = size;
   };
 
@@ -277,7 +279,7 @@ hsa_status_t KfdVirtioDriver::AllocateMemory(const core::MemoryRegion& mem_regio
     useSubAlloc &= ((alloc_flags & (~core::MemoryRegion::AllocateRestrict)) == 0);
 
     if (useSubAlloc) {
-      *mem = m_region.fragment_alloc(size);
+      mem = m_region.fragment_alloc(size);
 
       if ((alloc_flags & core::MemoryRegion::AllocateAsan)) {
         // TODO: Implement ASAN support for VIRTIO driver
@@ -295,20 +297,20 @@ hsa_status_t KfdVirtioDriver::AllocateMemory(const core::MemoryRegion& mem_regio
 
   //// Allocate memory.
   //// If it fails attempt to release memory from the block allocator and retry.
-  ret = vhsaKmtAllocMemory(node_id, size, kmt_alloc_flags, mem);
+  ret = vhsaKmtAllocMemory(node_id, size, kmt_alloc_flags, &mem);
   if (ret != HSAKMT_STATUS_SUCCESS) {
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
 
-  if (*mem == nullptr) {
+  if (mem == nullptr) {
     m_region.owner()->Trim();
-    ret = vhsaKmtAllocMemory(node_id, size, kmt_alloc_flags, mem);
+    ret = vhsaKmtAllocMemory(node_id, size, kmt_alloc_flags, &mem);
     if (ret != HSAKMT_STATUS_SUCCESS) {
       return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
     }
   }
 
-  if (*mem != nullptr) {
+  if (mem != nullptr) {
     if (kmt_alloc_flags.ui32.NoAddress) {
       populate_handle();
       return HSA_STATUS_SUCCESS;
@@ -346,15 +348,14 @@ hsa_status_t KfdVirtioDriver::AllocateMemory(const core::MemoryRegion& mem_regio
 
     uint64_t alternate_va = 0;
     const bool is_resident =
-        (MakeMemoryResident(*mem, size, &alternate_va, &map_flag, map_node_count, map_node_id) ==
+        (MakeMemoryResident(mem, size, &alternate_va, &map_flag, map_node_count, map_node_id) ==
          HSA_STATUS_SUCCESS);
 
     const bool require_pinning =
         (!m_region.full_profile() || m_region.IsLocalMemory() || m_region.IsScratch());
 
     if (require_pinning && !is_resident) {
-      vhsaKmtFreeMemory(*mem, size);
-      *mem = nullptr;
+      vhsaKmtFreeMemory(mem, size);
       return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
     }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -686,9 +686,8 @@ hsa_status_t XdnaDriver::GetCacheProperties(uint32_t node_id, uint32_t processor
 }
 
 hsa_status_t XdnaDriver::AllocateMemory(const core::MemoryRegion& mem_region,
-                                        core::MemoryRegion::AllocateFlags alloc_flags, void** mem,
-                                        size_t size, uint32_t node_id,
-                                        core::DriverMemoryHandle* handle) {
+                                        core::MemoryRegion::AllocateFlags alloc_flags, size_t size,
+                                        uint32_t node_id, core::DriverMemoryHandle* handle) {
   const MemoryRegion& m_region = static_cast<const MemoryRegion&>(mem_region);
 
   if (!m_region.IsSystem()) {
@@ -749,8 +748,6 @@ hsa_status_t XdnaDriver::AllocateMemory(const core::MemoryRegion& mem_region,
   }
 
   bo_guard.Dismiss();
-
-  *mem = bo_handle.vaddr;
 
   // The handle word is the driver-native BO id. vaddr is set only when the driver
   // owns the mapping (share BOs), so FreeMemory unmaps exactly those; dev-SVM

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -490,6 +490,32 @@ static hsa_status_t WaitCommand(int fd, ert_start_kernel_cmd* cmd, uint32_t hw_c
   return HSA_STATUS_SUCCESS;
 }
 
+/**
+ * @brief Resolves a virtual address to the BO handle, along with its allocation base and size.
+ *
+ * @param[in] mem virtual address to resolve
+ * @param[in] agent agent that owns the memory pool associated with the virtual address
+ * @param[out] bo_handle pointer to store the BO handle associated with the allocation
+ * @param[out] base pointer to store the base address of the allocation (optional)
+ * @param[out] size pointer to store the size of the allocation (optional)
+ *
+ * @return @c HSA_STATUS_SUCCESS on success, or an error status if the address does not belong to
+ * an allocation accessible to the agent
+ */
+static hsa_status_t ResolveBOHandle(void* mem, const core::Agent& agent, uint32_t* bo_handle,
+                                    void** base, size_t* size) {
+  void* local_base = nullptr;
+  core::DriverMemoryHandle handle{};
+  if (core::Runtime::runtime_singleton_->FindDriverMemoryHandle(mem, &agent, &local_base,
+                                                                &handle) != HSA_STATUS_SUCCESS) {
+    return HSA_STATUS_ERROR_INVALID_ALLOCATION;
+  }
+  if (base != nullptr) *base = local_base;
+  if (size != nullptr) *size = handle.size;
+  *bo_handle = static_cast<uint32_t>(handle.handle);
+  return HSA_STATUS_SUCCESS;
+}
+
 
 XdnaDriver::XdnaDriver(std::string devnode_name)
     : core::Driver(core::DriverType::XDNA, std::move(devnode_name)) {}
@@ -659,10 +685,10 @@ hsa_status_t XdnaDriver::GetCacheProperties(uint32_t node_id, uint32_t processor
   return HSA_STATUS_ERROR_INVALID_CACHE;
 }
 
-hsa_status_t
-XdnaDriver::AllocateMemory(const core::MemoryRegion &mem_region,
-                           core::MemoryRegion::AllocateFlags alloc_flags,
-                           void **mem, size_t size, uint32_t node_id) {
+hsa_status_t XdnaDriver::AllocateMemory(const core::MemoryRegion& mem_region,
+                                        core::MemoryRegion::AllocateFlags alloc_flags, void** mem,
+                                        size_t size, uint32_t node_id,
+                                        core::DriverMemoryHandle* handle) {
   const MemoryRegion& m_region = static_cast<const MemoryRegion&>(mem_region);
 
   if (!m_region.IsSystem()) {
@@ -706,50 +732,51 @@ XdnaDriver::AllocateMemory(const core::MemoryRegion &mem_region,
 
   if (use_bo_share) {
     if (alloc_flags & core::MemoryRegion::AllocateMemoryOnly) {
-      /// TODO: We create an anonymous mapping to get a unique virtual address since the memory
-      /// handle mapping, i.e., Runtime::memory_handle_map_, is indexed using DriverHandle which is
-      /// driver-agnostic and just a pointer to the virtual address space. We waste a page, but it
-      /// ensures uniqueness across drivers.
-      bo_handle.vaddr =
-          mmap(nullptr, MemoryRegion::GetPageSize(), PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-      if (bo_handle.vaddr == MAP_FAILED) {
-        return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
-      }
+      bo_handle.vaddr = nullptr;
+      bo_handle.unmap_vaddr = false;
     } else {
       bo_handle.vaddr =
           mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd_, get_bo_info_args.map_offset);
       if (bo_handle.vaddr == MAP_FAILED) {
         return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
       }
+      bo_handle.unmap_vaddr = true;
     }
-    bo_handle.unmap_vaddr = true;
   } else {
     /// This is dev heap and is already mapped. See InitDeviceHeap().
     bo_handle.vaddr = reinterpret_cast<void*>(get_bo_info_args.vaddr);
     bo_handle.unmap_vaddr = false;
   }
 
-  // We keep a mapping from VA memory addresses to BO handles because some operations, e.g.,
-  // FreeMemory, pass only the memory address and not a BO handle.
-  vmem_addr_mappings.emplace(bo_handle.vaddr, bo_handle);
-
   bo_guard.Dismiss();
 
   *mem = bo_handle.vaddr;
 
+  // The handle word is the driver-native BO id. vaddr is set only when the driver
+  // owns the mapping (share BOs), so FreeMemory unmaps exactly those; dev-SVM
+  // allocations share the device-heap mapping and leave vaddr null. Export-only
+  // fields stay at defaults.
+  handle->handle = bo_handle.handle;
+  handle->vaddr = bo_handle.unmap_vaddr ? bo_handle.vaddr : nullptr;
+  handle->size = size;
+
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t XdnaDriver::FreeMemory(void* mem, size_t size) {
-  auto it = vmem_addr_mappings.find(mem);
-  if (it == vmem_addr_mappings.end()) {
+hsa_status_t XdnaDriver::FreeMemory(const core::DriverMemoryHandle& handle) {
+  if (handle.handle == AMDXDNA_INVALID_BO_HANDLE) {
     return HSA_STATUS_ERROR_INVALID_ALLOCATION;
   }
 
-  auto& bo_handle = it->second;
-  hsa_status_t err = DestroyBOHandle(bo_handle);
-  vmem_addr_mappings.erase(it);
-  return err;
+  BOHandle bo_handle;
+  bo_handle.handle = static_cast<uint32_t>(handle.handle);
+  bo_handle.size = handle.size;
+  // vaddr is set only when the driver owns the mapping; DestroyBOHandle unmaps
+  // exactly those.
+  bo_handle.vaddr = handle.vaddr;
+  bo_handle.unmap_vaddr = handle.vaddr != nullptr;
+
+  return DestroyBOHandle(bo_handle);
 }
 
 hsa_status_t XdnaDriver::CreateQueue(uint32_t node_id, HSA_QUEUE_TYPE type, uint32_t queue_pct,
@@ -824,8 +851,7 @@ hsa_status_t XdnaDriver::ExportMemoryHandle(const core::Agent& agent,
 
   switch (type) {
   case core::ShareType::DMABUF_FD: {
-    // handle.handle is the kernel BO handle populated by CreateShareableHandle.
-    if (!handle.IsValid()) {
+    if (handle.handle == AMDXDNA_INVALID_BO_HANDLE) {
       return HSA_STATUS_ERROR_INVALID_ALLOCATION;
     }
 
@@ -913,21 +939,20 @@ hsa_status_t XdnaDriver::Unmap(const core::DriverMemoryHandle& handle, void *mem
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t XdnaDriver::CreateShareableHandle(void* va, void* mem, size_t size,
-                                               const core::Agent& agent,
-                                               core::DriverMemoryHandle* handle, uint64_t* offset) {
-  (void)va;
+hsa_status_t XdnaDriver::CreateShareableHandle(core::DriverMemoryHandle* handle,
+                                               const core::Agent& agent, uint64_t* offset) {
   (void)agent;
 
-  // Find BO handle; mem is the BO handle; see AllocateMemory.
-  auto bo_handle = FindBOHandle(mem);
-  if (!bo_handle.IsValid()) {
+  // On input, handle is the allocation handle whose native id is the BO handle (see
+  // AllocateMemory).
+  const auto bo_handle = static_cast<uint32_t>(handle->handle);
+  if (bo_handle == AMDXDNA_INVALID_BO_HANDLE) {
     return HSA_STATUS_ERROR_INVALID_ALLOCATION;
   }
 
   // Get offset.
   amdxdna_drm_get_bo_info get_bo_info_args = {};
-  get_bo_info_args.handle = bo_handle.handle;
+  get_bo_info_args.handle = bo_handle;
   hsa_status_t err = xdna_ioctl(fd_, DRM_IOCTL_AMDXDNA_GET_BO_INFO, &get_bo_info_args);
   if (err != HSA_STATUS_SUCCESS) {
     return err;
@@ -935,7 +960,7 @@ hsa_status_t XdnaDriver::CreateShareableHandle(void* va, void* mem, size_t size,
 
   // Get fd associated with the handle.
   drm_prime_handle params = {};
-  params.handle = bo_handle.handle;
+  params.handle = bo_handle;
   params.flags = DRM_RDWR;
   params.fd = -1;
   err = xdna_ioctl(fd_, DRM_IOCTL_PRIME_HANDLE_TO_FD, &params);
@@ -943,10 +968,10 @@ hsa_status_t XdnaDriver::CreateShareableHandle(void* va, void* mem, size_t size,
     return err;
   }
 
-  handle->handle = bo_handle.handle;
+  // handle->handle and handle->size carry over from allocation
   handle->dmabuf_fd = params.fd;
   handle->mmap_offset = get_bo_info_args.map_offset;
-  handle->size = size;
+
   *offset = 0;
 
   return HSA_STATUS_SUCCESS;
@@ -1080,7 +1105,7 @@ hsa_status_t XdnaDriver::CreateCmdBO(uint32_t size, BOHandle& cmd_bo_handle) con
 
 hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, void* queue_metadata,
                                         uint64_t first_pkt_idx, uint64_t num_pkts,
-                                        uint32_t num_core_tiles) {
+                                        uint32_t num_core_tiles, const core::Agent& agent) {
   auto kmq_metadata = static_cast<KmqMetadata*>(queue_metadata);
 
   // Instruction and arguments BOs (performance hint: up to 3 argument BOs per packet).
@@ -1109,14 +1134,17 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, void* queue_metadata,
 
     // Determine if the PDI is cached, if not it will be added to the PDI cache and the hardware
     // context will be reconfigured.
-    auto pdi_bo_handle = FindBOHandle(pkt->pdi_addr);
-    if (!pdi_bo_handle.IsValid()) {
-      return HSA_STATUS_ERROR_INVALID_ALLOCATION;
+    void* pdi_base = nullptr;
+    size_t pdi_size = 0;
+    uint32_t pdi_handle = AMDXDNA_INVALID_BO_HANDLE;
+    hsa_status_t err = ResolveBOHandle(pkt->pdi_addr, agent, &pdi_handle, &pdi_base, &pdi_size);
+    if (err != HSA_STATUS_SUCCESS) {
+      return err;
     }
-    auto cached_pdi_index = kmq_metadata->pdi_cache.GetIndex(pdi_bo_handle.handle);
+    auto cached_pdi_index = kmq_metadata->pdi_cache.GetIndex(pdi_handle);
     if (cached_pdi_index == PDICache::NotFound) {
-      FlushCpuCache(pdi_bo_handle.vaddr, 0, pdi_bo_handle.size);
-      hsa_status_t err = kmq_metadata->pdi_cache.SetNext(pdi_bo_handle.handle, cached_pdi_index);
+      FlushCpuCache(pdi_base, 0, pdi_size);
+      err = kmq_metadata->pdi_cache.SetNext(pdi_handle, cached_pdi_index);
       if (err != HSA_STATUS_SUCCESS) {
         assert(false && "Failed to set PDI in cache.");
         return err;
@@ -1127,24 +1155,26 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, void* queue_metadata,
     // Add the instruction sequence BO handle to bo_handles and flush cache.
     void* insts_addr =
         reinterpret_cast<void*>(Concat<uint64_t>(pkt->insts_addr_high, pkt->insts_addr_low));
-    auto instr_bo_handle = FindBOHandle(insts_addr);
-    if (!instr_bo_handle.IsValid()) {
+    uint32_t instr_handle = AMDXDNA_INVALID_BO_HANDLE;
+    err = ResolveBOHandle(insts_addr, agent, &instr_handle, nullptr, nullptr);
+    if (err != HSA_STATUS_SUCCESS) {
       assert(false && "Failed to find instruction sequence BO for command packet.");
-      return HSA_STATUS_ERROR_INVALID_ALLOCATION;
+      return err;
     }
-    bo_handles.push_back(instr_bo_handle.handle);
+    bo_handles.push_back(instr_handle);
     FlushCpuCache(insts_addr, 0, pkt->insts_size);
 
     // Add the argument BO handles to bo_handles.
     auto* kernarg_address = static_cast<uint64_t*>(pkt->kernarg_address);
     for (uint32_t kernarg_idx = 0; kernarg_idx < pkt->num_kernargs; ++kernarg_idx) {
       void* ptr = reinterpret_cast<void*>(kernarg_address[kernarg_idx]);
-      auto bo_handle = FindBOHandle(ptr);
-      if (!bo_handle.IsValid()) {
+      uint32_t arg_handle = AMDXDNA_INVALID_BO_HANDLE;
+      err = ResolveBOHandle(ptr, agent, &arg_handle, nullptr, nullptr);
+      if (err != HSA_STATUS_SUCCESS) {
         assert(false && "Failed to find argument BO for command packet.");
-        return HSA_STATUS_ERROR_INVALID_ALLOCATION;
+        return err;
       }
-      bo_handles.push_back(bo_handle.handle);
+      bo_handles.push_back(arg_handle);
     }
 
     // Create command for the kernel.
@@ -1155,7 +1185,7 @@ hsa_status_t XdnaDriver::SubmitCmdChain(hsa_queue_t& q, void* queue_metadata,
     const uint32_t cmd_data_bytesize = cmd_dwords * sizeof(uint32_t);
     const uint32_t cmd_bytesize = sizeof(ert_start_kernel_cmd) + cmd_data_bytesize;
     BOHandle cmd_bo_handle;
-    hsa_status_t err = CreateCmdBO(cmd_bytesize, cmd_bo_handle);
+    err = CreateCmdBO(cmd_bytesize, cmd_bo_handle);
     if (err != HSA_STATUS_SUCCESS) {
       assert(false && "Failed to create command BO.");
       return err;
@@ -1346,36 +1376,6 @@ hsa_status_t XdnaDriver::DestroyBOHandle(BOHandle& bo_handle) const {
     return ioctl_err;
   }
   return unmap_err;
-}
-
-XdnaDriver::BOHandle XdnaDriver::FindBOHandle(void* mem) const {
-  auto it = vmem_addr_mappings.lower_bound(mem);
-  if (it == vmem_addr_mappings.cend()) {
-    // Exact address not found or is larger than the largest address.
-    return BOHandle{};
-  }
-
-  if (it->first == mem) {
-    // Exact address found.
-    return it->second;
-  }
-
-  if (it == vmem_addr_mappings.cbegin()) {
-    // Address is smaller than the smallest registered address.
-    return BOHandle{};
-  }
-
-  // Go back one element, since lower_bound returns an iterator to the element that is equal or
-  // greater.
-  --it;
-
-  assert(it->first < mem);
-  if (mem >= (static_cast<char*>(it->first) + it->second.size)) {
-    // Address is not from this allocation.
-    return BOHandle{};
-  }
-
-  return it->second;
 }
 
 hsa_status_t XdnaDriver::SetTrapHandler(uint32_t node_id, const void* base, uint64_t base_size,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
@@ -92,9 +92,8 @@ public:
   hsa_status_t GetCacheProperties(uint32_t node_id, uint32_t processor_id,
                                   std::vector<HsaCacheProperties>& cache_props) const override;
   hsa_status_t AllocateMemory(const core::MemoryRegion& mem_region,
-                              core::MemoryRegion::AllocateFlags alloc_flags, void** mem,
-                              size_t size, uint32_t node_id,
-                              core::DriverMemoryHandle* handle) override;
+                              core::MemoryRegion::AllocateFlags alloc_flags, size_t size,
+                              uint32_t node_id, core::DriverMemoryHandle* handle) override;
   hsa_status_t FreeMemory(const core::DriverMemoryHandle& handle) override;
   hsa_status_t CreateQueue(uint32_t node_id, HSA_QUEUE_TYPE type, uint32_t queue_pct,
                            HSA::hsa_amd_queue_priority_internal_t priority, uint32_t sdma_engine_id, void* queue_addr,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
@@ -91,11 +91,11 @@ public:
                                    std::vector<HsaMemoryProperties>& mem_props) const override;
   hsa_status_t GetCacheProperties(uint32_t node_id, uint32_t processor_id,
                                   std::vector<HsaCacheProperties>& cache_props) const override;
-  hsa_status_t AllocateMemory(const core::MemoryRegion &mem_region,
-                              core::MemoryRegion::AllocateFlags alloc_flags,
-                              void **mem, size_t size,
-                              uint32_t node_id) override;
-  hsa_status_t FreeMemory(void *mem, size_t size) override;
+  hsa_status_t AllocateMemory(const core::MemoryRegion& mem_region,
+                              core::MemoryRegion::AllocateFlags alloc_flags, void** mem,
+                              size_t size, uint32_t node_id,
+                              core::DriverMemoryHandle* handle) override;
+  hsa_status_t FreeMemory(const core::DriverMemoryHandle& handle) override;
   hsa_status_t CreateQueue(uint32_t node_id, HSA_QUEUE_TYPE type, uint32_t queue_pct,
                            HSA::hsa_amd_queue_priority_internal_t priority, uint32_t sdma_engine_id, void* queue_addr,
                            uint64_t queue_size_bytes, uint64_t queue_metadata_size_bytes, HsaEvent* event,
@@ -116,8 +116,8 @@ public:
                    size_t size, hsa_access_permission_t perms,uint32_t node_id) override;
   hsa_status_t Unmap(const core::DriverMemoryHandle& handle, void *mem, size_t offset,
                      size_t size, uint32_t node_id) override;
-  hsa_status_t CreateShareableHandle(void* va, void* mem, size_t size, const core::Agent& agent,
-                                     core::DriverMemoryHandle* handle, uint64_t* offset) override;
+  hsa_status_t CreateShareableHandle(core::DriverMemoryHandle* handle, const core::Agent& agent,
+                                     uint64_t* offset) override;
   hsa_status_t DestroyMemoryHandle(core::DriverMemoryHandle* handle) override;
   hsa_status_t SPMAcquire(uint32_t preferred_node_id) const override;
   hsa_status_t SPMRelease(uint32_t preferred_node_id) const override;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_memory_region.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_memory_region.h
@@ -82,8 +82,8 @@ class MemoryRegion : public core::MemoryRegion {
 
   ~MemoryRegion();
 
-  hsa_status_t Allocate(size_t& size, AllocateFlags alloc_flags, void** address,
-                        uint32_t agent_node_id, core::DriverMemoryHandle* handle) const override;
+  hsa_status_t Allocate(size_t& size, AllocateFlags alloc_flags, uint32_t agent_node_id,
+                        core::DriverMemoryHandle* handle) const override;
 
   hsa_status_t Free(const core::DriverMemoryHandle& handle) const override;
 
@@ -197,8 +197,8 @@ private:
                                              const core::Runtime::LinkInfo& link_info) const;
 
   // Operational body for Allocate.  Recursive.
-  hsa_status_t AllocateImpl(size_t& size, AllocateFlags alloc_flags, void** address,
-                            uint32_t agent_node_id, core::DriverMemoryHandle* handle) const;
+  hsa_status_t AllocateImpl(size_t& size, AllocateFlags alloc_flags, uint32_t agent_node_id,
+                            core::DriverMemoryHandle* handle) const;
 
   // Operational body for Free.  Recursive.
   hsa_status_t FreeImpl(const core::DriverMemoryHandle& handle) const;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_memory_region.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_memory_region.h
@@ -82,9 +82,10 @@ class MemoryRegion : public core::MemoryRegion {
 
   ~MemoryRegion();
 
-  hsa_status_t Allocate(size_t& size, AllocateFlags alloc_flags, void** address, int agent_node_id = 0) const;
+  hsa_status_t Allocate(size_t& size, AllocateFlags alloc_flags, void** address,
+                        uint32_t agent_node_id, core::DriverMemoryHandle* handle) const override;
 
-  hsa_status_t Free(void* address, size_t size) const;
+  hsa_status_t Free(const core::DriverMemoryHandle& handle) const override;
 
   hsa_status_t IPCFragmentExport(void* address) const;
 
@@ -196,10 +197,11 @@ private:
                                              const core::Runtime::LinkInfo& link_info) const;
 
   // Operational body for Allocate.  Recursive.
-  hsa_status_t AllocateImpl(size_t& size, AllocateFlags alloc_flags, void** address, int agent_node_id) const;
+  hsa_status_t AllocateImpl(size_t& size, AllocateFlags alloc_flags, void** address,
+                            uint32_t agent_node_id, core::DriverMemoryHandle* handle) const;
 
   // Operational body for Free.  Recursive.
-  hsa_status_t FreeImpl(void* address, size_t size) const;
+  hsa_status_t FreeImpl(const core::DriverMemoryHandle& handle) const;
 
   class BlockAllocator {
    private:
@@ -208,7 +210,14 @@ private:
    public:
     explicit BlockAllocator(MemoryRegion& region) : region_(region) {}
     void* alloc(size_t request_size, size_t& allocated_size) const;
-    void free(void* ptr, size_t length) const { region_.FreeImpl(ptr, length); }
+    void free(void* ptr, size_t length) const {
+      // Fragment blocks are KFD/virtio-only; for those backends the driver handle
+      // word is the block's virtual address, which routes the fragment-allocator probe.
+      core::DriverMemoryHandle handle{};
+      handle.handle = reinterpret_cast<uint64_t>(ptr);
+      handle.size = length;
+      region_.FreeImpl(handle);
+    }
     size_t block_size() const { return block_size_; }
   };
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_virtio_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_virtio_driver.h
@@ -80,8 +80,9 @@ class KfdVirtioDriver final : public core::Driver {
                               const void* buffer_base, uint64_t buffer_base_size) const;
   hsa_status_t AllocateMemory(const core::MemoryRegion& mem_region,
                               core::MemoryRegion::AllocateFlags alloc_flags, void** mem,
-                              size_t size, uint32_t agent_node_id) override;
-  hsa_status_t FreeMemory(void* mem, size_t size) override;
+                              size_t size, uint32_t agent_node_id,
+                              core::DriverMemoryHandle* handle) override;
+  hsa_status_t FreeMemory(const core::DriverMemoryHandle& handle) override;
   hsa_status_t AllocateScratchMemory(uint32_t node_id, uint64_t size, void** mem) const;
   hsa_status_t RegisterMemory(void* ptr, uint64_t size, HsaMemFlags mem_flags) const override;
   hsa_status_t DeregisterMemory(void* ptr) const override;
@@ -109,8 +110,8 @@ class KfdVirtioDriver final : public core::Driver {
   hsa_status_t Map(const core::DriverMemoryHandle& handle, void* mem, size_t offset, size_t size,
                    hsa_access_permission_t perms, uint32_t node_id) override;
   hsa_status_t Unmap(const core::DriverMemoryHandle& handle, void* mem, size_t offset, size_t size, uint32_t node_id) override;
-  hsa_status_t CreateShareableHandle(void* va, void* mem, size_t size, const core::Agent& agent,
-                                     core::DriverMemoryHandle* handle, uint64_t* offset) override;
+  hsa_status_t CreateShareableHandle(core::DriverMemoryHandle* handle, const core::Agent& agent,
+                                     uint64_t* offset) override;
   hsa_status_t DestroyMemoryHandle(core::DriverMemoryHandle* handle) override;
   hsa_status_t GetTileConfig(uint32_t node_id, HsaGpuTileConfig* config) const;
   hsa_status_t SPMAcquire(uint32_t node_id) const override;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_virtio_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_virtio_driver.h
@@ -79,9 +79,8 @@ class KfdVirtioDriver final : public core::Driver {
   hsa_status_t SetTrapHandler(uint32_t node_id, const void* base, uint64_t base_size,
                               const void* buffer_base, uint64_t buffer_base_size) const;
   hsa_status_t AllocateMemory(const core::MemoryRegion& mem_region,
-                              core::MemoryRegion::AllocateFlags alloc_flags, void** mem,
-                              size_t size, uint32_t agent_node_id,
-                              core::DriverMemoryHandle* handle) override;
+                              core::MemoryRegion::AllocateFlags alloc_flags, size_t size,
+                              uint32_t agent_node_id, core::DriverMemoryHandle* handle) override;
   hsa_status_t FreeMemory(const core::DriverMemoryHandle& handle) override;
   hsa_status_t AllocateScratchMemory(uint32_t node_id, uint64_t size, void** mem) const;
   hsa_status_t RegisterMemory(void* ptr, uint64_t size, HsaMemFlags mem_flags) const override;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -103,9 +103,8 @@ public:
   hsa_status_t GetCacheProperties(uint32_t node_id, uint32_t processor_id,
                                   std::vector<HsaCacheProperties>& cache_props) const override;
   hsa_status_t AllocateMemory(const core::MemoryRegion& mem_region,
-                              core::MemoryRegion::AllocateFlags alloc_flags, void** mem,
-                              size_t size, uint32_t node_id,
-                              core::DriverMemoryHandle* handle) override;
+                              core::MemoryRegion::AllocateFlags alloc_flags, size_t size,
+                              uint32_t node_id, core::DriverMemoryHandle* handle) override;
   hsa_status_t FreeMemory(const core::DriverMemoryHandle& handle) override;
   hsa_status_t CreateQueue(uint32_t node_id, HSA_QUEUE_TYPE type, uint32_t queue_pct,
                            HSA::hsa_amd_queue_priority_internal_t priority, uint32_t sdma_engine_id, void* queue_addr,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -102,11 +102,11 @@ public:
                                    std::vector<HsaMemoryProperties>& mem_props) const override;
   hsa_status_t GetCacheProperties(uint32_t node_id, uint32_t processor_id,
                                   std::vector<HsaCacheProperties>& cache_props) const override;
-  hsa_status_t AllocateMemory(const core::MemoryRegion &mem_region,
-                              core::MemoryRegion::AllocateFlags alloc_flags,
-                              void **mem, size_t size,/* uint64_t* mmap_offset, */
-                              uint32_t node_id) override;
-  hsa_status_t FreeMemory(void *mem, size_t size) override;
+  hsa_status_t AllocateMemory(const core::MemoryRegion& mem_region,
+                              core::MemoryRegion::AllocateFlags alloc_flags, void** mem,
+                              size_t size, uint32_t node_id,
+                              core::DriverMemoryHandle* handle) override;
+  hsa_status_t FreeMemory(const core::DriverMemoryHandle& handle) override;
   hsa_status_t CreateQueue(uint32_t node_id, HSA_QUEUE_TYPE type, uint32_t queue_pct,
                            HSA::hsa_amd_queue_priority_internal_t priority, uint32_t sdma_engine_id, void* queue_addr,
                            uint64_t queue_size_bytes, uint64_t queue_metadata_size_bytes, HsaEvent* event,
@@ -144,8 +144,8 @@ public:
                    size_t size, hsa_access_permission_t perms, uint32_t node_id) override;
   hsa_status_t Unmap(const core::DriverMemoryHandle& handle, void *mem, size_t offset,
                      size_t size, uint32_t node_id) override;
-  hsa_status_t CreateShareableHandle(void* va, void* mem, size_t size, const core::Agent& agent,
-                                     core::DriverMemoryHandle* handle, uint64_t* offset) override;
+  hsa_status_t CreateShareableHandle(core::DriverMemoryHandle* handle, const core::Agent& agent,
+                                     uint64_t* offset) override;
   hsa_status_t DestroyMemoryHandle(core::DriverMemoryHandle* handle) override;
 
   /// @brief Submits packets to the driver for execution.
@@ -158,8 +158,9 @@ public:
   /// @param[in] first_pkt_idx index of the first packet in the queue
   /// @param[in] num_pkts number of packets in the queue to be submitted. Must be greater than 0.
   /// @param[in] num_core_tiles number of core tiles in the AIE device
+  /// @param[in] agent agent that owns the queue
   hsa_status_t SubmitCmdChain(hsa_queue_t& q, void* queue_metadata, uint64_t first_pkt_idx,
-                              uint64_t num_pkts, uint32_t num_core_tiles);
+                              uint64_t num_pkts, uint32_t num_core_tiles, const core::Agent& agent);
 
   hsa_status_t SPMAcquire(uint32_t preferred_node_id) const override;
   hsa_status_t SPMRelease(uint32_t preferred_node_id) const override;
@@ -194,11 +195,6 @@ public:
   /// @param[in,out] bo_handle BO handle to destroy.
   hsa_status_t DestroyBOHandle(BOHandle& bo_handle) const;
 
-  /// @brief Returns the BO associated with the address.
-  ///
-  /// @param[in] mem virtual address to query.
-  BOHandle FindBOHandle(void* mem) const;
-
   /// @brief Queries the driver version and updates internal state.
   hsa_status_t QueryDriverVersion();
 
@@ -213,8 +209,6 @@ public:
   /// @param[in] size size of memory to allocate
   /// @param[out] bo_info allocated BO
   hsa_status_t CreateCmdBO(uint32_t size, BOHandle& bo_info) const;
-
-  std::map<void*, BOHandle> vmem_addr_mappings;
 
   /// @brief Virtual address range allocated for the device heap.
   ///

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
@@ -160,8 +160,6 @@ public:
                                           std::vector<HsaCacheProperties>& cache_props) const = 0;
 
   /// @brief Allocate agent-accessible memory (system or agent-local memory).
-  /// @param[out] mem pointer to newly allocated memory (virtual address), or the
-  /// opaque memory-only handle when AllocateMemoryOnly is set.
   /// @param[out] handle driver identity for this allocation. The handle word and
   /// size are populated; export-only fields (dmabuf_fd/mmap_offset/fabric_handle)
   /// are left unset and filled lazily by ExportMemoryHandle/CreateShareableHandle.
@@ -169,9 +167,8 @@ public:
   /// @retval HSA_STATUS_SUCCESS if memory was successfully allocated or
   /// hsa_status_t error code if the memory allocation failed.
   virtual hsa_status_t AllocateMemory(const MemoryRegion& mem_region,
-                                      MemoryRegion::AllocateFlags alloc_flags, void** mem,
-                                      size_t size, uint32_t node_id,
-                                      DriverMemoryHandle* handle) = 0;
+                                      MemoryRegion::AllocateFlags alloc_flags, size_t size,
+                                      uint32_t node_id, DriverMemoryHandle* handle) = 0;
 
   /// @brief Free memory allocated by @ref AllocateMemory.
   /// @param[in] handle driver identity returned by @ref AllocateMemory.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
@@ -68,15 +68,19 @@ enum class DriverType {
   NUM_DRIVER_TYPES
 };
 
-/// @brief Handle for exported / imported memory.
+/// @brief Handle for a driver memory allocation and export / import.
 struct DriverMemoryHandle {
+  /// @brief Driver-native allocation id
+  /// - allocation address / thunk buffer handle for @ref KfdDriver
+  /// - XDNA BO handle for @ref XdnaDriver
   uint64_t handle{};
+  /// Virtual address mmap'd by the driver for this allocation, or nullptr if the
+  /// driver does not own a mapping. When set, FreeMemory unmaps it.
+  void* vaddr{};
   int dmabuf_fd{-1};
   uint64_t mmap_offset{0};
   size_t size{0};
   hsa_fabric_handle_t fabric_handle{};
-
-  bool IsValid() const { return handle != 0; }
 
   bool operator<(const DriverMemoryHandle& b) const { return handle < b.handle; }
   bool operator==(const DriverMemoryHandle& b) const { return handle == b.handle; }
@@ -156,16 +160,22 @@ public:
                                           std::vector<HsaCacheProperties>& cache_props) const = 0;
 
   /// @brief Allocate agent-accessible memory (system or agent-local memory).
-  /// @param[out] mem pointer to newly allocated memory.
+  /// @param[out] mem pointer to newly allocated memory (virtual address), or the
+  /// opaque memory-only handle when AllocateMemoryOnly is set.
+  /// @param[out] handle driver identity for this allocation. The handle word and
+  /// size are populated; export-only fields (dmabuf_fd/mmap_offset/fabric_handle)
+  /// are left unset and filled lazily by ExportMemoryHandle/CreateShareableHandle.
+  /// The handle must be passed to @ref FreeMemory to release the allocation.
   /// @retval HSA_STATUS_SUCCESS if memory was successfully allocated or
   /// hsa_status_t error code if the memory allocation failed.
-  virtual hsa_status_t AllocateMemory(const MemoryRegion &mem_region,
-                                      MemoryRegion::AllocateFlags alloc_flags,
-                                      void **mem, size_t size,
-                                      uint32_t node_id) = 0;
+  virtual hsa_status_t AllocateMemory(const MemoryRegion& mem_region,
+                                      MemoryRegion::AllocateFlags alloc_flags, void** mem,
+                                      size_t size, uint32_t node_id,
+                                      DriverMemoryHandle* handle) = 0;
 
   /// @brief Free memory allocated by @ref AllocateMemory.
-  virtual hsa_status_t FreeMemory(void *mem, size_t size) = 0;
+  /// @param[in] handle driver identity returned by @ref AllocateMemory.
+  virtual hsa_status_t FreeMemory(const DriverMemoryHandle& handle) = 0;
 
   /// @brief Create an agent dispatch queue with user-mode access rights.
   /// @param[in] node_id Node ID of the agent on which the queue is being created.
@@ -270,15 +280,13 @@ public:
   ///
   /// @note The handle must be destroyed with @ref DestroyMemoryHandle.
   ///
-  /// @param[in] va virtual address
-  /// @param[in] mem physical memory handle
-  /// @param[in] size memory size in bytes
-  /// @param[in] agent agent associated with @p mem
-  /// @param[out] handle handle of the memory object
+  /// @param[in,out] handle on input, the allocation handle from @ref AllocateMemory whose native id
+  /// and size identify the memory to share; on success, transformed in place into the shareable
+  /// memory handle (which must be destroyed with @ref DestroyMemoryHandle). Left unchanged on
+  /// failure.
+  /// @param[in] agent agent associated with the allocation
   /// @param[out] offset memory offset in bytes
-  virtual hsa_status_t CreateShareableHandle(void* va, void* mem, size_t size,
-                                             const core::Agent& agent,
-                                             core::DriverMemoryHandle* handle,
+  virtual hsa_status_t CreateShareableHandle(DriverMemoryHandle* handle, const core::Agent& agent,
                                              uint64_t* offset) = 0;
 
   /// @brief Destroys the handle created during @ref CreateShareableHandle.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/memory_region.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/memory_region.h
@@ -116,8 +116,8 @@ class MemoryRegion : public Checked<0x9C961F19EE175BB3> {
 
   typedef uint32_t AllocateFlags;
 
-  virtual hsa_status_t Allocate(size_t& size, AllocateFlags alloc_flags, void** address,
-                                uint32_t agent_node_id, DriverMemoryHandle* handle) const = 0;
+  virtual hsa_status_t Allocate(size_t& size, AllocateFlags alloc_flags, uint32_t agent_node_id,
+                                DriverMemoryHandle* handle) const = 0;
 
   virtual hsa_status_t Free(const DriverMemoryHandle& handle) const = 0;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/memory_region.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/memory_region.h
@@ -54,6 +54,7 @@
 namespace rocr {
 namespace core {
 class Agent;
+struct DriverMemoryHandle;
 
 class MemoryRegion : public Checked<0x9C961F19EE175BB3> {
  public:
@@ -115,9 +116,10 @@ class MemoryRegion : public Checked<0x9C961F19EE175BB3> {
 
   typedef uint32_t AllocateFlags;
 
-  virtual hsa_status_t Allocate(size_t& size, AllocateFlags alloc_flags, void** address, int agent_node_id) const = 0;
+  virtual hsa_status_t Allocate(size_t& size, AllocateFlags alloc_flags, void** address,
+                                uint32_t agent_node_id, DriverMemoryHandle* handle) const = 0;
 
-  virtual hsa_status_t Free(void* address, size_t size) const = 0;
+  virtual hsa_status_t Free(const DriverMemoryHandle& handle) const = 0;
 
   // Prepares suballocated memory for IPC export.
   virtual hsa_status_t IPCFragmentExport(void* address) const = 0;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
@@ -250,6 +250,30 @@ class Runtime {
   /// @retval ::HSA_STATUS_SUCCESS if @p ptr is successfully released.
   hsa_status_t FreeMemory(void* ptr);
 
+  /// @brief Resolve a pointer to the driver handle usable by a requesting agent.
+  ///
+  /// Looks up the allocation in @ref allocation_map_ or @ref mapped_handle_map_ that contains
+  /// @p ptr and returns its base address and a DriverMemoryHandle whose native id is meaningful to
+  /// @p requesting_agent's driver. Lets a driver recover the native allocation id, e.g. a BO
+  /// handle, from a virtual address without maintaining its own address table.
+  ///
+  /// The handle word is driver-specific (a virtual address for KFD, a GEM BO for XDNA), so the
+  /// resolved handle must match the requesting agent's driver:
+  /// - Same driver as the owner: returns the owner's allocation handle.
+  /// - Different driver (vmem only): returns the per-agent handle imported for
+  ///   @p requesting_agent by @ref hsa_amd_vmem_set_access. If @p ptr was not shared to that
+  ///   agent, resolution fails.
+  ///
+  /// @param[in] ptr Address within an allocation (need not be the base).
+  /// @param[in] requesting_agent Agent whose driver will consume the handle.
+  /// @param[out] base Base address of the containing allocation.
+  /// @param[out] handle Driver handle of the containing allocation.
+  /// @retval ::HSA_STATUS_SUCCESS if a containing allocation accessible to @p requesting_agent
+  /// was found.
+  /// @retval ::HSA_STATUS_ERROR_INVALID_ALLOCATION otherwise.
+  hsa_status_t FindDriverMemoryHandle(const void* ptr, const Agent* requesting_agent, void** base,
+                                      DriverMemoryHandle* handle);
+
   hsa_status_t RegisterReleaseNotifier(void* ptr, hsa_amd_deallocation_callback_t callback,
                                        void* user_data);
 
@@ -596,15 +620,18 @@ class Runtime {
           user_ptr(nullptr),
           thunk_bo(nullptr),
           thunk_node_id(-1) {}
+
     AllocationRegion(const MemoryRegion* region_arg, size_t size_arg, size_t size_requested,
-                     MemoryRegion::AllocateFlags alloc_flags)
+                     MemoryRegion::AllocateFlags alloc_flags,
+                     DriverMemoryHandle driver_handle_arg = {})
         : region(region_arg),
           size(size_arg),
           size_requested(size_requested),
           alloc_flags(alloc_flags),
           user_ptr(nullptr),
           thunk_bo(nullptr),
-          thunk_node_id(-1) {}
+          thunk_node_id(-1),
+          driver_handle(driver_handle_arg) {}
 
     struct notifier_t {
       void* ptr;
@@ -620,6 +647,7 @@ class Runtime {
     std::unique_ptr<std::vector<notifier_t>> notifiers;
     HsaMemoryObjectHandle thunk_bo;
     HSAuint32 thunk_node_id;
+    DriverMemoryHandle driver_handle;
   };
 
   struct AsyncEventsInfo;
@@ -1039,8 +1067,8 @@ class Runtime {
 
     __forceinline core::Agent* agentOwner() const { return region->owner(); }
 
-    /** 
-     * @brief For host owned memory, resolve to the GPU agent that imported the memory. 
+    /**
+     * @brief For host owned memory, resolve to the GPU agent that imported the memory.
      * For device owned memory, return the agent that owns the memory.
      */
     __forceinline core::Agent* drmAgent() const {
@@ -1054,7 +1082,7 @@ class Runtime {
     bool imported; // True if this BO was imported from another process
     bool is_fabric_handle;
     MemoryRegion::AllocateFlags alloc_flag;
-    core::Agent* drm_owner; // Gpu agent used for import of host memory, NULL for device memory/imported handles 
+    core::Agent* drm_owner; // Gpu agent used for import of host memory, NULL for device memory/imported handles
   };
   // hsa_amd_vmem_alloc_handle_t (MemoryHandle*) to MemoryHandle mapping. Owns MemoryHandle
   // lifetime. Uniqueness is guaranteed by the runtime, independent of any driver-supplied

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
@@ -1082,7 +1082,8 @@ class Runtime {
     bool imported; // True if this BO was imported from another process
     bool is_fabric_handle;
     MemoryRegion::AllocateFlags alloc_flag;
-    core::Agent* drm_owner; // Gpu agent used for import of host memory, NULL for device memory/imported handles
+    core::Agent* drm_owner;  // Gpu agent used for import of host memory, NULL for device
+                             // memory/imported handles
   };
   // hsa_amd_vmem_alloc_handle_t (MemoryHandle*) to MemoryHandle mapping. Owns MemoryHandle
   // lifetime. Uniqueness is guaranteed by the runtime, independent of any driver-supplied

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
@@ -222,7 +222,7 @@ void AieAqlQueue::SubmitPackets() {
 
   const auto num_pkts = last_pkt_idx - first_pkt_idx;
   hsa_status_t err = driver.SubmitCmdChain(amd_queue_.hsa_queue, kmq_metadata_, first_pkt_idx,
-                                           num_pkts, agent.properties().NumNeuralCores);
+                                           num_pkts, agent.properties().NumNeuralCores, agent);
   if (err != HSA_STATUS_SUCCESS) {
     throw hsa_exception(err, "Could not submit packets");
   }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -1056,7 +1056,10 @@ void GpuAgent::ReleaseResources() {
     scratch_cache_.free_reserve();
 
     if (scratch_pool_.base() != NULL) {
-      driver().FreeMemory(scratch_pool_.base(), scratch_pool_.size());
+      core::DriverMemoryHandle scratch_handle{};
+      scratch_handle.handle = reinterpret_cast<uint64_t>(scratch_pool_.base());
+      scratch_handle.size = scratch_pool_.size();
+      driver().FreeMemory(scratch_handle);
     }
 
     for (int i = 0; i < QueueCount; i++)

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_memory_region.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_memory_region.cpp
@@ -133,17 +133,16 @@ MemoryRegion::MemoryRegion(bool fine_grain, bool kernarg, bool full_profile,
 
 MemoryRegion::~MemoryRegion() {}
 
-hsa_status_t MemoryRegion::Allocate(size_t& size, AllocateFlags alloc_flags, void** mem,
-                                    uint32_t agent_node_id,
+hsa_status_t MemoryRegion::Allocate(size_t& size, AllocateFlags alloc_flags, uint32_t agent_node_id,
                                     core::DriverMemoryHandle* handle) const {
   std::lock_guard<std::recursive_mutex> lock(owner()->agent_memory_lock_);
-  return AllocateImpl(size, alloc_flags, mem, agent_node_id, handle);
+  return AllocateImpl(size, alloc_flags, agent_node_id, handle);
 }
 
-hsa_status_t MemoryRegion::AllocateImpl(size_t& size, AllocateFlags alloc_flags, void** mem,
+hsa_status_t MemoryRegion::AllocateImpl(size_t& size, AllocateFlags alloc_flags,
                                         uint32_t agent_node_id,
                                         core::DriverMemoryHandle* handle) const {
-  if (mem == NULL) {
+  if (handle == nullptr) {
     return HSA_STATUS_ERROR_INVALID_ARGUMENT;
   }
 
@@ -163,7 +162,7 @@ hsa_status_t MemoryRegion::AllocateImpl(size_t& size, AllocateFlags alloc_flags,
 
   size = AlignUp(size, GetPageSize());
 
-  return owner()->driver().AllocateMemory(*this, alloc_flags, mem, size, agent_node_id, handle);
+  return owner()->driver().AllocateMemory(*this, alloc_flags, size, agent_node_id, handle);
 }
 
 hsa_status_t MemoryRegion::Free(const core::DriverMemoryHandle& handle) const {
@@ -647,21 +646,19 @@ hsa_status_t MemoryRegion::AssignAgent(void* ptr, size_t size,
 void MemoryRegion::Trim() const { fragment_allocator_.trim(); }
 
 void* MemoryRegion::BlockAllocator::alloc(size_t request_size, size_t& allocated_size) const {
-  void* ret;
   size_t bsize = AlignUp(request_size, block_size());
 
   // The block's driver identity is reconstructed from base address and length
   // on free (see BlockAllocator::free), so the handle is not retained here.
   core::DriverMemoryHandle handle{};
   hsa_status_t err = region_.AllocateImpl(
-      bsize, core::MemoryRegion::AllocateRestrict | core::MemoryRegion::AllocateDirect, &ret, 0,
-      &handle);
+      bsize, core::MemoryRegion::AllocateRestrict | core::MemoryRegion::AllocateDirect, 0, &handle);
   if (err != HSA_STATUS_SUCCESS)
     throw AMD::hsa_exception(err, "MemoryRegion::BlockAllocator::alloc failed.");
-  assert(ret != nullptr && "Region returned nullptr on success.");
+  assert(handle.vaddr != nullptr && "Region returned nullptr on success.");
 
   allocated_size = bsize;
-  return ret;
+  return handle.vaddr;
 }
 
 }  // namespace amd

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_memory_region.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_memory_region.cpp
@@ -133,13 +133,16 @@ MemoryRegion::MemoryRegion(bool fine_grain, bool kernarg, bool full_profile,
 
 MemoryRegion::~MemoryRegion() {}
 
-hsa_status_t MemoryRegion::Allocate(size_t& size, AllocateFlags alloc_flags, void** mem, int agent_node_id) const {
+hsa_status_t MemoryRegion::Allocate(size_t& size, AllocateFlags alloc_flags, void** mem,
+                                    uint32_t agent_node_id,
+                                    core::DriverMemoryHandle* handle) const {
   std::lock_guard<std::recursive_mutex> lock(owner()->agent_memory_lock_);
-  return AllocateImpl(size, alloc_flags, mem, agent_node_id);
+  return AllocateImpl(size, alloc_flags, mem, agent_node_id, handle);
 }
 
-hsa_status_t MemoryRegion::AllocateImpl(size_t& size, AllocateFlags alloc_flags,
-                                        void** mem, int agent_node_id) const {
+hsa_status_t MemoryRegion::AllocateImpl(size_t& size, AllocateFlags alloc_flags, void** mem,
+                                        uint32_t agent_node_id,
+                                        core::DriverMemoryHandle* handle) const {
   if (mem == NULL) {
     return HSA_STATUS_ERROR_INVALID_ARGUMENT;
   }
@@ -160,18 +163,21 @@ hsa_status_t MemoryRegion::AllocateImpl(size_t& size, AllocateFlags alloc_flags,
 
   size = AlignUp(size, GetPageSize());
 
-  return owner()->driver().AllocateMemory(*this, alloc_flags, mem, size, agent_node_id);
+  return owner()->driver().AllocateMemory(*this, alloc_flags, mem, size, agent_node_id, handle);
 }
 
-hsa_status_t MemoryRegion::Free(void* address, size_t size) const {
+hsa_status_t MemoryRegion::Free(const core::DriverMemoryHandle& handle) const {
   std::lock_guard<std::recursive_mutex> lock(owner()->agent_memory_lock_);
-  return FreeImpl(address, size);
+  return FreeImpl(handle);
 }
 
-hsa_status_t MemoryRegion::FreeImpl(void* address, size_t size) const {
-  if (fragment_allocator_.free(address)) return HSA_STATUS_SUCCESS;
+hsa_status_t MemoryRegion::FreeImpl(const core::DriverMemoryHandle& handle) const {
+  // The fragment allocator (KFD/virtio only) keys on the allocation's virtual
+  // address, which is the driver handle word for those backends. Other drivers, e.g., XDNA, do not
+  // use the fragment allocator.
+  if (fragment_allocator_.free(reinterpret_cast<void*>(handle.handle))) return HSA_STATUS_SUCCESS;
 
-  return owner()->driver().FreeMemory(address, size);
+  return owner()->driver().FreeMemory(handle);
 }
 
 // TODO:  Look into a better name and/or making this process transparent to exporting.
@@ -644,8 +650,12 @@ void* MemoryRegion::BlockAllocator::alloc(size_t request_size, size_t& allocated
   void* ret;
   size_t bsize = AlignUp(request_size, block_size());
 
+  // The block's driver identity is reconstructed from base address and length
+  // on free (see BlockAllocator::free), so the handle is not retained here.
+  core::DriverMemoryHandle handle{};
   hsa_status_t err = region_.AllocateImpl(
-      bsize, core::MemoryRegion::AllocateRestrict | core::MemoryRegion::AllocateDirect, &ret, 0);
+      bsize, core::MemoryRegion::AllocateRestrict | core::MemoryRegion::AllocateDirect, &ret, 0,
+      &handle);
   if (err != HSA_STATUS_SUCCESS)
     throw AMD::hsa_exception(err, "MemoryRegion::BlockAllocator::alloc failed.");
   assert(ret != nullptr && "Region returned nullptr on success.");

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -40,14 +40,13 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <cassert>
 #include <algorithm>
+#include <cassert>
 #include <chrono>
 #include <thread>
 #include <cstring>
 #include <regex>
 #include <string>
-#include <algorithm>
 #if defined(__linux__)
 #include <link.h>
 #include <dlfcn.h>
@@ -338,11 +337,13 @@ hsa_status_t Runtime::AllocateMemory(const MemoryRegion* region, size_t size,
                                      MemoryRegion::AllocateFlags alloc_flags,
                                      void** address, int agent_node_id) {
   size_t size_requested = size;  // region->Allocate(...) may align-up size to granularity
-  hsa_status_t status = region->Allocate(size, alloc_flags, address, agent_node_id);
+  DriverMemoryHandle driver_handle{};
+  hsa_status_t status = region->Allocate(size, alloc_flags, address, agent_node_id, &driver_handle);
   // Track the allocation result so that it could be freed properly.
   if (status == HSA_STATUS_SUCCESS) {
     std::lock_guard<std::shared_mutex> lock(memory_lock_);
-    allocation_map_[*address] = AllocationRegion(region, size, size_requested, alloc_flags);
+    allocation_map_[*address] =
+        AllocationRegion(region, size, size_requested, alloc_flags, driver_handle);
   }
 
   return status;
@@ -354,9 +355,9 @@ hsa_status_t Runtime::FreeMemory(void* ptr) {
   }
 
   const MemoryRegion* region = nullptr;
-  size_t size = 0;
   std::unique_ptr<std::vector<AllocationRegion::notifier_t>> notifiers;
   MemoryRegion::AllocateFlags alloc_flags = core::MemoryRegion::AllocateNoFlags;
+  DriverMemoryHandle driver_handle{};
 
   {
     std::lock_guard<std::shared_mutex> lock(memory_lock_);
@@ -368,8 +369,8 @@ hsa_status_t Runtime::FreeMemory(void* ptr) {
       return HSA_STATUS_ERROR_INVALID_ALLOCATION;
     }
     region = it->second.region;
-    size = it->second.size;
     alloc_flags = it->second.alloc_flags;
+    driver_handle = it->second.driver_handle;
 
     // Imported fragments can't be released with FreeMemory.
     if (region == nullptr) {
@@ -430,7 +431,7 @@ hsa_status_t Runtime::FreeMemory(void* ptr) {
     UNUSED(asan_status);
   }
 
-  const hsa_status_t err = region->Free(ptr, size);
+  const hsa_status_t err = region->Free(driver_handle);
   if (err != HSA_STATUS_SUCCESS) {
     // hsaKmtFreeMemory failed to free this pointer. Throw a memory error event
 
@@ -477,6 +478,68 @@ hsa_status_t Runtime::FreeMemory(void* ptr) {
   }
 
   return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t Runtime::FindDriverMemoryHandle(const void* ptr, const Agent* requesting_agent,
+                                             void** base, DriverMemoryHandle* handle) {
+  if (ptr == nullptr || requesting_agent == nullptr || base == nullptr || handle == nullptr) {
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  }
+
+  const DriverType requesting_driver = requesting_agent->driver().kernel_driver_type_;
+
+  std::shared_lock<std::shared_mutex> lock(memory_lock_);
+
+  // Check classic allocations (hsa_amd_memory_pool_allocate). These carry only the owner's driver
+  // handle and have no per-agent imports, so they resolve only for the owning driver.
+  auto it = allocation_map_.upper_bound(ptr);
+  if (it != allocation_map_.begin()) {
+    --it;
+    // ptr must fall within [base, base + size) of the preceding allocation.
+    const auto* alloc_base = reinterpret_cast<const uint8_t*>(it->first);
+    if (ptr >= alloc_base && ptr < alloc_base + it->second.size) {
+      const MemoryRegion* region = it->second.region;
+      const Agent* owner = region ? region->owner() : nullptr;
+      if (owner != nullptr && owner->driver().kernel_driver_type_ == requesting_driver) {
+        *base = const_cast<void*>(it->first);
+        *handle = it->second.driver_handle;
+        return HSA_STATUS_SUCCESS;
+      }
+      return HSA_STATUS_ERROR_INVALID_ALLOCATION;
+    }
+  }
+
+  // Check VMM-mapped allocations (hsa_amd_vmem_map). These are mapped at a reserved VA and do not
+  // appear in allocation_map_. The owner's handle lives on the backing MemoryHandle; for an agent
+  // on a different driver, the handle imported for that agent by hsa_amd_vmem_set_access lives in
+  // the MappedHandle's per-agent allowed_agents entry.
+  auto mapped_it = mapped_handle_map_.upper_bound(ptr);
+  if (mapped_it != mapped_handle_map_.begin()) {
+    --mapped_it;
+    const MappedHandle& mappedHandle = mapped_it->second;
+    const auto* mapped_base = reinterpret_cast<const uint8_t*>(mapped_it->first);
+    if (ptr >= mapped_base && ptr < mapped_base + mappedHandle.size) {
+      // Imported handles have no owning region, so resolve the owner null-safely.
+      const MemoryRegion* owner_region = mappedHandle.mem_handle->region;
+      const Agent* owner = owner_region ? owner_region->owner() : nullptr;
+      if (owner != nullptr && owner->driver().kernel_driver_type_ == requesting_driver) {
+        *base = const_cast<void*>(mapped_it->first);
+        *handle = mappedHandle.mem_handle->driver_handle;
+        return HSA_STATUS_SUCCESS;
+      }
+
+      // Cross-driver: use the handle imported for the requesting agent, if access was granted.
+      auto agentIt = mappedHandle.allowed_agents.find(const_cast<Agent*>(requesting_agent));
+      if (agentIt != mappedHandle.allowed_agents.end()) {
+        *base = const_cast<void*>(mapped_it->first);
+        *handle = agentIt->second.driver_handle;
+        return HSA_STATUS_SUCCESS;
+      }
+      return HSA_STATUS_ERROR_INVALID_ALLOCATION;
+    }
+  }
+
+  return HSA_STATUS_ERROR_INVALID_ALLOCATION;
 }
 
 hsa_status_t Runtime::RegisterReleaseNotifier(void* ptr, hsa_amd_deallocation_callback_t callback,
@@ -3920,15 +3983,15 @@ hsa_status_t Runtime::VMemoryHandleCreate(const MemoryRegion* region, size_t siz
 
   std::lock_guard<std::shared_mutex> lock(memory_lock_);
   void *mem;
+  core::DriverMemoryHandle driver_handle = {};
 
-  hsa_status_t status = region->Allocate(size, alloc_flags, &mem, 0);
+  hsa_status_t status = region->Allocate(size, alloc_flags, &mem, 0, &driver_handle);
   if (status == HSA_STATUS_SUCCESS) {
     // TODO: Combine the Allocate and CreateShareableHandle into a single function.
     uint64_t offset;
-    core::DriverMemoryHandle driver_handle = {};
     auto agentOwner = region->owner();
 
-    /* For CPU-owned memory, DRM operations require a GPU agent. Select 
+    /* For CPU-owned memory, DRM operations require a GPU agent. Select
     the first available GPU agent before calling CreateShareableHandle.
     For device memory, use owner agent. */
     core::Agent* agent_for_drm = agentOwner;
@@ -3936,16 +3999,20 @@ hsa_status_t Runtime::VMemoryHandleCreate(const MemoryRegion* region, size_t siz
     if (agentOwner->device_type() == core::Agent::DeviceType::kAmdCpuDevice) {
       const auto& gpus = core::Runtime::runtime_singleton_->gpu_agents();
       if (gpus.empty()) {
-        region->Free(mem, size);
+        region->Free(driver_handle);
         return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
       }
       agent_for_drm = gpus.front();
       drm_owner = agent_for_drm;
     }
 
-    auto ret = agent_for_drm->driver().CreateShareableHandle(nullptr, mem, size, *agent_for_drm, &driver_handle, &offset);
+    // alloc_handle goes in as the allocation handle and is transformed in place into the shareable
+    // memory handle. This lets the driver recover the allocation from its native id (no virtual
+    // address, which may be null for memory-only allocations) without a pointer lookup.
+    auto ret =
+        agent_for_drm->driver().CreateShareableHandle(&driver_handle, *agent_for_drm, &offset);
     if (ret != HSA_STATUS_SUCCESS) {
-      region->Free(mem, size);
+      region->Free(driver_handle);
       return ret;
     }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -338,9 +338,10 @@ hsa_status_t Runtime::AllocateMemory(const MemoryRegion* region, size_t size,
                                      void** address, int agent_node_id) {
   size_t size_requested = size;  // region->Allocate(...) may align-up size to granularity
   DriverMemoryHandle driver_handle{};
-  hsa_status_t status = region->Allocate(size, alloc_flags, address, agent_node_id, &driver_handle);
+  hsa_status_t status = region->Allocate(size, alloc_flags, agent_node_id, &driver_handle);
   // Track the allocation result so that it could be freed properly.
   if (status == HSA_STATUS_SUCCESS) {
+    *address = driver_handle.vaddr;
     std::lock_guard<std::shared_mutex> lock(memory_lock_);
     allocation_map_[*address] =
         AllocationRegion(region, size, size_requested, alloc_flags, driver_handle);
@@ -3982,10 +3983,9 @@ hsa_status_t Runtime::VMemoryHandleCreate(const MemoryRegion* region, size_t siz
   }
 
   std::lock_guard<std::shared_mutex> lock(memory_lock_);
-  void *mem;
   core::DriverMemoryHandle driver_handle = {};
 
-  hsa_status_t status = region->Allocate(size, alloc_flags, &mem, 0, &driver_handle);
+  hsa_status_t status = region->Allocate(size, alloc_flags, 0, &driver_handle);
   if (status == HSA_STATUS_SUCCESS) {
     // TODO: Combine the Allocate and CreateShareableHandle into a single function.
     uint64_t offset;


### PR DESCRIPTION
## Motivation

Memory-handle resolution in rocr-runtime assumed a single driver/agent context, so when multiple drivers are involved (GPU + XDNA), handles could be resolved or created against the wrong agent's driver.

Solves #8448 

## Technical Details

- Refactored memory management interfaces to pass DriverMemoryHandle by reference instead of by value/raw handle, so allocation metadata (handle + size) flows through consistently instead of being re-derived.
- Runtime now resolve driver memory handles per requesting agent, not per allocation-owner alone - needed because a BO can be allocated by one agent (e.g., GPU) but accessed/mapped through another's driver (e.g., AIE).

## JIRA ID

NA

## Test Plan

Added AIE tests to VirtMemoryBasic.

Additional tests run from https://github.com/ROCm/rocm-systems/tree/users/ypapadop-amd/aie-tests

## Test Result

Success.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
