### PR TITLE
fix(log): order ROCr logs with HIP and match thread ids

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -736,7 +736,9 @@ bool Device::create() {
     hsa_flag_set64(logMask, HSA_AMD_LOG_FLAG_AQL);
     hsa_flag_set64(logMask, HSA_AMD_LOG_FLAG_SDMA);
     hsa_flag_set64(logMask, HSA_AMD_LOG_FLAG_INFO);
-    Hsa::enable_logging(logMask, outFile);
+    // Route ROCr's logs through the ordered sink so they interleave correctly with
+    // CLR's async log entries instead of racing ahead via direct fflush.
+    Hsa::enable_logging(logMask, amd::GetRocrLogSink());
   }
 
   return true;

--- a/projects/clr/rocclr/utils/debug.cpp
+++ b/projects/clr/rocclr/utils/debug.cpp
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: MIT
  */
 
+// _GNU_SOURCE must be defined before any header so glibc declares fopencookie(),
+// which backs the ordered log sink handed to ROCr (see GetRocrLogSink below).
+#if defined(__linux__) && !defined(_GNU_SOURCE)
+#define _GNU_SOURCE
+#endif
+
 #include "top.hpp"
 #include "utils/debug.hpp"
 #include "os/os.hpp"
@@ -58,6 +64,7 @@ struct LogEntry {
   uint32_t tid;            //!< Thread ID (hash)
   uint64_t duration;       //!< Duration in microseconds (0 if not a duration log)
   bool hasDuration;        //!< True if this is a duration log entry
+  bool isRaw;              //!< True if message is a pre-formatted line to emit verbatim
   std::atomic<bool> valid; //!< Valid flag for lock-free synchronization
 
   LogEntry()
@@ -68,6 +75,7 @@ struct LogEntry {
         pid(0),
         duration(0),
         hasDuration(false),
+        isRaw(false),
         valid(false) {}
 };
 
@@ -157,6 +165,32 @@ class AsyncLogger {
         std::hash<std::thread::id>{}(std::this_thread::get_id()) & 0xFFFFF);
     entry.duration = duration;
     entry.hasDuration = hasDuration;
+    entry.isRaw = false;
+    entry.valid.store(true, std::memory_order_release);
+  }
+
+  // Enqueue a pre-formatted line (e.g. from ROCr) so it is emitted verbatim and
+  // in generation order relative to the structured entries from this logger.
+  void logRaw(std::string line) {
+    if (!enabled_.load(std::memory_order_relaxed)) {
+      // Async drained/disabled: emit directly so the line is not lost.
+      fwrite(line.data(), 1, line.size(), outFile);
+      fflush(outFile);
+      return;
+    }
+
+    size_t currentWrite = writeIndex_.fetch_add(1, std::memory_order_release);
+    size_t currentRead = readIndex_.load(std::memory_order_acquire);
+
+    while (currentWrite - currentRead >= kBufferSize) {
+      flush();
+      currentRead = readIndex_.load(std::memory_order_acquire);
+    }
+
+    LogEntry& entry = buffer_[currentWrite % kBufferSize];
+    entry.isRaw = true;
+    entry.hasDuration = false;
+    entry.message = std::move(line);
     entry.valid.store(true, std::memory_order_release);
   }
 
@@ -241,6 +275,12 @@ class AsyncLogger {
   }
 
   void writeToFile(const LogEntry& entry) {
+    if (entry.isRaw) {
+      // Already fully formatted (including the trailing newline) by the producer.
+      fwrite(entry.message.data(), 1, entry.message.size(), outFile);
+      return;
+    }
+
     char pidtid[64] = "";
     if (AMD_LOG_LEVEL >= 4) {
       snprintf(pidtid, sizeof(pidtid), "[pid:%u tid: 0x%05x]", entry.pid, entry.tid);
@@ -268,6 +308,75 @@ static void crashFlushCallback() {
 static AsyncLogger& getAsyncLogger() {
   static AsyncLogger instance;
   return instance;
+}
+
+// ================================================================================================
+// Ordered log sink for ROCr
+//
+// ROCr writes its own already-formatted log lines synchronously to whatever FILE*
+// it is handed via hsa_amd_enable_logging(). When this logger runs asynchronously,
+// those direct writes race ahead of the buffered entries still sitting in our ring,
+// scrambling the interleaving in the combined log. To keep a single global ordering
+// we hand ROCr a cookie stream whose writes are funneled, line by line, into the same
+// async ring as raw entries. The one worker thread then drains everything in
+// generation order.
+#if defined(__linux__)
+namespace {
+
+struct RocrCookieContext {
+  std::string partial;  //!< Holds a not-yet-terminated line across writes.
+};
+
+// Called by stdio (under the stream lock) whenever ROCr flushes to the cookie stream.
+ssize_t RocrCookieWrite(void* cookie, const char* buf, size_t size) {
+  auto* context = static_cast<RocrCookieContext*>(cookie);
+  context->partial.append(buf, size);
+
+  size_t line_start = 0;
+  size_t newline_pos;
+  while ((newline_pos = context->partial.find('\n', line_start)) != std::string::npos) {
+    getAsyncLogger().logRaw(context->partial.substr(line_start, newline_pos - line_start + 1));
+    line_start = newline_pos + 1;
+  }
+  context->partial.erase(0, line_start);
+  return static_cast<ssize_t>(size);
+}
+
+int RocrCookieClose(void* cookie) {
+  auto* context = static_cast<RocrCookieContext*>(cookie);
+  if (!context->partial.empty()) {
+    getAsyncLogger().logRaw(std::move(context->partial));
+  }
+  delete context;
+  return 0;
+}
+
+}  // namespace
+#endif  // __linux__
+
+FILE* GetRocrLogSink() {
+#if defined(__linux__)
+  // Only interpose when async logging is active; otherwise ROCr writing straight to
+  // outFile is already correctly ordered with our synchronous path.
+  if (getAsyncLogger().isEnabled()) {
+    static FILE* sink = [] () -> FILE* {
+      cookie_io_functions_t io_funcs = {};
+      io_funcs.write = RocrCookieWrite;
+      io_funcs.close = RocrCookieClose;
+      auto* context = new RocrCookieContext();
+      FILE* stream = fopencookie(context, "w", io_funcs);
+      if (stream == nullptr) {
+        delete context;
+        return outFile;
+      }
+      // Unbuffered so each ROCr fprintf/fflush surfaces as a complete line promptly.
+      setvbuf(stream, nullptr, _IONBF, 0);
+      return stream;
+    }();
+    return sink;
+  }
+#endif  // __linux__
+  return outFile;
 }
 
 // ================================================================================================

--- a/projects/clr/rocclr/utils/debug.hpp
+++ b/projects/clr/rocclr/utils/debug.hpp
@@ -87,6 +87,11 @@ extern void FlushAsyncLogs();
 //! \brief Force flush of pending async log entries in the current thread (synchronous).
 extern void FlushAsyncLogsInCurrentThread();
 
+//! \brief FILE* that ROCr should log through so its output stays ordered with ours.
+//! When async logging is active this returns a sink that funnels ROCr's lines into
+//! the async ring buffer; otherwise it returns outFile (direct, already ordered).
+extern FILE* GetRocrLogSink();
+
 /*@}*/  // namespace amd
 }  // namespace amd
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.cpp
@@ -57,16 +57,18 @@ uint8_t log_flags[8];
 
 void log_printf(const char* file, int line, const char* format, ...) {
   va_list ap;
-  std::stringstream pidtid;
-  pidtid << "[pid:" << os::GetProcessId() << " tid: 0x" ;
-  pidtid << std::hex << std::setw(5) << std::this_thread::get_id() << "]";
+  // Match HIP's thread-id rendering exactly
+  size_t tid_hash = std::hash<std::thread::id>{}(std::this_thread::get_id());
+  char pidtid[64] = "";
+  snprintf(pidtid, sizeof(pidtid), "[pid:%u tid: 0x%05zx]",
+           static_cast<unsigned>(os::GetProcessId()), tid_hash & 0xFFFFF);
   va_start(ap, format);
   char message[4096];
   vsnprintf(message, sizeof(message), format, ap);
   va_end(ap);
   fprintf(log_file, ":7:%-25s:%-4d: %010lld us: %s [***rocr***] %s\n",
           file, line, os::ReadAccurateClock()/1000ULL,
-          pidtid.str().c_str(), message);
+          pidtid, message);
   fflush(log_file);
 }
 


### PR DESCRIPTION
Route ROCr's log output through CLR's async ring buffer via a cookie sink so ROCr and HIP lines share one ordered stream instead of ROCr's direct fflush racing ahead. Also render ROCr's thread id with the same masked std::thread::id hash as CLR so ids match across the two layers.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

JIRA ID : AIRUNTIME-0

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
