### PR TITLE
[rocprofiler-compute] Add gfx1250 FP16 WMMA GEMM profiling sample

### DIFF
--- a/projects/rocprofiler-compute/sample/wmma_gemm_fp16/Makefile
+++ b/projects/rocprofiler-compute/sample/wmma_gemm_fp16/Makefile
@@ -1,0 +1,34 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# FP16 WMMA GEMM sample for gfx1250 (MI450) metric health profiling.
+
+HIPCC      ?= hipcc
+GPU_ARCH   ?= gfx1250
+HIPCC_FLAGS = -O2 -g -std=c++17 -Wall -Wextra -fPIC
+INCLUDES    = -I.
+
+TARGET      = wmma_gemm_fp16
+KERNEL_SRC  = wmma_gemm_fp16.hip
+HOST_SRC    = main.cpp
+
+.PHONY: all clean run help
+
+all: $(TARGET)
+
+$(TARGET): $(KERNEL_SRC) $(HOST_SRC) wmma_gemm_fp16_config.hpp wmma_gemm_fp16.hpp
+	@echo "Building $(TARGET) for $(GPU_ARCH)..."
+	$(HIPCC) $(HIPCC_FLAGS) --offload-arch=$(GPU_ARCH) $(INCLUDES) -o $@ $(HOST_SRC) $(KERNEL_SRC)
+	@echo "Build complete: $@"
+
+run: $(TARGET)
+	./$(TARGET)
+
+clean:
+	rm -f $(TARGET)
+
+help:
+	@echo "Targets:"
+	@echo "  make            Build for gfx1250 (override: GPU_ARCH=gfx1250)"
+	@echo "  make run        Build and run with defaults"
+	@echo "  make clean      Remove binary"

--- a/projects/rocprofiler-compute/sample/wmma_gemm_fp16/main.cpp
+++ b/projects/rocprofiler-compute/sample/wmma_gemm_fp16/main.cpp
@@ -1,0 +1,208 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <chrono>
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "../common.h"
+#include "wmma_gemm_fp16.hpp"
+
+using namespace wmma_gemm_fp16;
+
+namespace {
+
+struct Options {
+    uint32_t m     = kDefaultM;
+    uint32_t n     = kDefaultN;
+    uint32_t k     = kDefaultK;
+    uint32_t iters = kDefaultIters;
+    uint32_t warmup = kDefaultWarmup;
+    int device   = 0;
+};
+
+void usage()
+{
+    std::cout
+        << "Usage: wmma_gemm_fp16 [OPTIONS]\n"
+        << "  FP16 WMMA GEMM for gfx1250 WMMA/XDL metric health profiling.\n\n"
+        << "Optional:\n"
+        << "  -m, --m <value>       Rows of A / D [default: " << kDefaultM << "]\n"
+        << "  -n, --n <value>       Cols of B / D [default: " << kDefaultN << "]\n"
+        << "  -k, --k <value>       Inner dimension K (multiple of 32) [default: "
+        << kDefaultK << "]\n"
+        << "  -i, --iter <value>    Kernel iterations [default: " << kDefaultIters
+        << "]\n"
+        << "  -w, --warmup <value>  Warmup iterations [default: " << kDefaultWarmup
+        << "]\n"
+        << "  -d, --device <id>     HIP device id [default: 0]\n"
+        << "  -h, --help            Show this help\n";
+    std::exit(EXIT_SUCCESS);
+}
+
+Options parse_args(int argc, char* argv[])
+{
+    Options opts;
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        auto need_value       = [&](const char* flag) {
+            if (i + 1 >= argc) {
+                std::cerr << "Missing value for " << flag << "\n";
+                usage();
+            }
+            return std::string(argv[++i]);
+        };
+
+        if (arg == "-h" || arg == "--help") {
+            usage();
+        } else if (arg == "-m" || arg == "--m") {
+            opts.m = static_cast<uint32_t>(std::stoul(need_value(arg.c_str())));
+        } else if (arg == "-n" || arg == "--n") {
+            opts.n = static_cast<uint32_t>(std::stoul(need_value(arg.c_str())));
+        } else if (arg == "-k" || arg == "--k") {
+            opts.k = static_cast<uint32_t>(std::stoul(need_value(arg.c_str())));
+        } else if (arg == "-i" || arg == "--iter") {
+            opts.iters = static_cast<uint32_t>(std::stoul(need_value(arg.c_str())));
+        } else if (arg == "-w" || arg == "--warmup") {
+            opts.warmup = static_cast<uint32_t>(std::stoul(need_value(arg.c_str())));
+        } else if (arg == "-d" || arg == "--device") {
+            opts.device = std::stoi(need_value(arg.c_str()));
+        } else {
+            std::cerr << "Unknown argument: " << arg << "\n";
+            usage();
+        }
+    }
+    return opts;
+}
+
+void fill_matrix(std::vector<_Float16>& mat, uint32_t rows, uint32_t cols)
+{
+    std::mt19937 rng(1337);
+    std::uniform_real_distribution<float> dist(0.5f, 2.0f);
+    mat.resize(static_cast<size_t>(rows) * cols);
+    for (auto& value : mat) {
+        value = static_cast<_Float16>(dist(rng));
+    }
+}
+
+bool smoke_check(const std::vector<_Float16>& d, uint32_t m, uint32_t n)
+{
+    for (uint32_t row = 0; row < std::min(m, 64u); ++row) {
+        for (uint32_t col = 0; col < std::min(n, 64u); ++col) {
+            const float value = static_cast<float>(d[static_cast<size_t>(row) * n + col]);
+            if (value != 0.0f && std::isfinite(value)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+}  // namespace
+
+int main(int argc, char* argv[])
+{
+    const Options opts = parse_args(argc, argv);
+
+    if (opts.m == 0 || opts.n == 0 || opts.k == 0) {
+        std::cerr << "M, N, and K must be positive.\n";
+        return EXIT_FAILURE;
+    }
+    if (opts.k % kBlockK != 0) {
+        std::cerr << "K must be a multiple of " << kBlockK << " for 16x16x32 WMMA tiles.\n";
+        return EXIT_FAILURE;
+    }
+    if (opts.m % kBlockM != 0 || opts.n % kBlockN != 0) {
+        std::cerr << "M and N must be multiples of " << kBlockM << ".\n";
+        return EXIT_FAILURE;
+    }
+
+    hipCheck(hipSetDevice(opts.device));
+
+    hipDeviceProp_t props{};
+    hipCheck(hipGetDeviceProperties(&props, opts.device));
+    std::cout << "Device: " << props.name << " (" << props.gcnArchName << ")\n";
+    std::cout << "Problem: M=" << opts.m << " N=" << opts.n << " K=" << opts.k
+              << " iters=" << opts.iters << "\n";
+
+    std::vector<_Float16> h_a;
+    std::vector<_Float16> h_b;
+    std::vector<_Float16> h_d(static_cast<size_t>(opts.m) * opts.n, _Float16(0));
+
+    fill_matrix(h_a, opts.m, opts.k);
+    fill_matrix(h_b, opts.n, opts.k);
+
+    _Float16 *d_a = nullptr;
+    _Float16 *d_b = nullptr;
+    _Float16 *d_d = nullptr;
+
+    const size_t bytes_a = h_a.size() * sizeof(_Float16);
+    const size_t bytes_b = h_b.size() * sizeof(_Float16);
+    const size_t bytes_d = h_d.size() * sizeof(_Float16);
+
+    hipCheck(hipMalloc(&d_a, bytes_a));
+    hipCheck(hipMalloc(&d_b, bytes_b));
+    hipCheck(hipMalloc(&d_d, bytes_d));
+
+    hipCheck(hipMemcpy(d_a, h_a.data(), bytes_a, hipMemcpyHostToDevice));
+    hipCheck(hipMemcpy(d_b, h_b.data(), bytes_b, hipMemcpyHostToDevice));
+    hipCheck(hipMemcpy(d_d, h_d.data(), bytes_d, hipMemcpyHostToDevice));
+
+    const dim3 block_dim(kThreadsX, kThreadsY);
+    const dim3 grid_dim(DivUp(static_cast<int>(opts.m), static_cast<int>(kBlockM)),
+                        DivUp(static_cast<int>(opts.n), static_cast<int>(kBlockN)),
+                        1);
+
+    std::cout << "Launch grid=(" << grid_dim.x << "," << grid_dim.y << ") block=("
+              << block_dim.x << "," << block_dim.y << ")\n";
+
+    auto launch = [&]() {
+        hipLaunchKernelGGL(gemm_wmma_fp16,
+                           grid_dim,
+                           block_dim,
+                           0,
+                           0,
+                           opts.m,
+                           opts.n,
+                           opts.k,
+                           d_a,
+                           d_b,
+                           d_d);
+        hipCheck(hipGetLastError());
+    };
+
+    for (uint32_t i = 0; i < opts.warmup; ++i) {
+        launch();
+    }
+    hipCheck(hipDeviceSynchronize());
+
+    const auto start = std::chrono::steady_clock::now();
+    for (uint32_t i = 0; i < opts.iters; ++i) {
+        launch();
+    }
+    hipCheck(hipDeviceSynchronize());
+    const auto end = std::chrono::steady_clock::now();
+
+    const double elapsed_ms =
+        std::chrono::duration<double, std::milli>(end - start).count();
+    const double gflops =
+        2.0 * static_cast<double>(opts.m) * opts.n * opts.k * opts.iters * 1e-9;
+    const double tflops_per_s = gflops / elapsed_ms;
+
+    hipCheck(hipMemcpy(h_d.data(), d_d, bytes_d, hipMemcpyDeviceToHost));
+
+    const bool passed = smoke_check(h_d, opts.m, opts.n);
+    std::cout << "Elapsed: " << elapsed_ms << " ms (" << opts.iters << " iterations)\n";
+    std::cout << "Throughput: " << tflops_per_s << " TFLOP/s (FP16 GEMM convention)\n";
+    std::cout << "Smoke check: " << (passed ? "PASS (non-zero output)" : "FAIL") << "\n";
+
+    hipCheck(hipFree(d_a));
+    hipCheck(hipFree(d_b));
+    hipCheck(hipFree(d_d));
+
+    return passed ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/projects/rocprofiler-compute/sample/wmma_gemm_fp16/wmma_gemm_fp16.hip
+++ b/projects/rocprofiler-compute/sample/wmma_gemm_fp16/wmma_gemm_fp16.hip
@@ -1,0 +1,153 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+// Sustained FP16 WMMA GEMM for gfx1250 metric health profiling.
+// Adapted from hipNPIKernels WMMA_gemm fp16_16x16x32 (native16x16x32).
+
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+
+#include "wmma_gemm_fp16_config.hpp"
+
+using namespace wmma_gemm_fp16;
+
+using Float16x4  = _Float16 __attribute__((ext_vector_type(4)));
+using Float16x8  = _Float16 __attribute__((ext_vector_type(8)));
+using Float16x16 = _Float16 __attribute__((ext_vector_type(16)));
+using Floatx8    = float __attribute__((ext_vector_type(8)));
+
+__device__ inline uint32_t lane_id() { return static_cast<uint32_t>(threadIdx.x); }
+
+__device__ inline void load_row_major(Float16x16& regs,
+                                      uint32_t row,
+                                      uint32_t k_start,
+                                      uint32_t row_len,
+                                      const _Float16* __restrict__ buffer)
+{
+    const uint32_t low_high = lane_id() / 16;
+    const uint32_t row_addr = row + (lane_id() % 16);
+
+    const uint32_t col1 = k_start + low_high * 16;
+    const uint32_t col2 = k_start + 4 + low_high * 16;
+    const uint32_t col3 = k_start + 8 + low_high * 16;
+    const uint32_t col4 = k_start + 12 + low_high * 16;
+
+    auto* p_regs = reinterpret_cast<Float16x4*>(&regs);
+    p_regs[0]    = *reinterpret_cast<const Float16x4*>(buffer + row_addr * row_len + col1);
+    p_regs[1]    = *reinterpret_cast<const Float16x4*>(buffer + row_addr * row_len + col2);
+    p_regs[2]    = *reinterpret_cast<const Float16x4*>(buffer + row_addr * row_len + col3);
+    p_regs[3]    = *reinterpret_cast<const Float16x4*>(buffer + row_addr * row_len + col4);
+}
+
+__device__ inline void write_output(const Float16x8& frag,
+                                    uint32_t wave_row,
+                                    uint32_t wave_col,
+                                    uint32_t row_len,
+                                    _Float16* __restrict__ d)
+{
+    const uint32_t out_col = (lane_id() >= 16) ? 8 : 0;
+    const uint32_t out_row = lane_id() % 16;
+    const uint32_t row     = wave_row + out_row;
+    const uint32_t col     = wave_col + out_col;
+    *reinterpret_cast<Float16x8*>(d + row * row_len + col) = frag;
+}
+
+__device__ inline void inner_gemm(uint32_t sub_m_start,
+                                  uint32_t sub_n_start,
+                                  uint32_t m,
+                                  uint32_t n,
+                                  uint32_t k,
+                                  const _Float16* __restrict__ a,
+                                  const _Float16* __restrict__ b,
+                                  _Float16* __restrict__ d)
+{
+#if !__has_builtin(__builtin_amdgcn_wmma_f32_16x16x32_f16)
+    (void)sub_m_start;
+    (void)sub_n_start;
+    (void)m;
+    (void)n;
+    (void)k;
+    (void)a;
+    (void)b;
+    if (threadIdx.x == 0 && blockIdx.x == 0 && blockIdx.y == 0) {
+        d[0] = _Float16(0);
+    }
+    return;
+#else
+    Floatx8 frag_acc = {};
+
+    const uint32_t major_wave = __builtin_amdgcn_readfirstlane(threadIdx.x / kWaveSize);
+    const uint32_t minor_wave = threadIdx.y;
+
+    const uint32_t wave_row = major_wave * kWmmaM + sub_m_start;
+    const uint32_t wave_col = minor_wave * kWmmaN + sub_n_start;
+
+    const bool full_block =
+        (sub_m_start + kBlockM <= m) && (sub_n_start + kBlockN <= n) && (k >= kBlockK);
+
+    if (!full_block) {
+        return;
+    }
+
+    const uint32_t k_tiles = k / kBlockK;
+    uint32_t k_iter        = 0;
+
+    Float16x16 reg_a = {};
+    Float16x16 reg_b = {};
+
+    load_row_major(reg_a, wave_row, 0, k, a);
+    load_row_major(reg_b, wave_col, 0, k, b);
+
+    if (k_tiles > 1) {
+        do {
+            const uint32_t next_k = (k_iter + 1) * kBlockK;
+
+            Float16x16 next_a = {};
+            Float16x16 next_b = {};
+
+            load_row_major(next_a, wave_row, next_k, k, a);
+            load_row_major(next_b, wave_col, next_k, k, b);
+
+            __builtin_amdgcn_sched_barrier(0);
+            frag_acc = __builtin_amdgcn_wmma_f32_16x16x32_f16(
+                0, reg_b, 0, reg_a, 0, frag_acc, 0, 0);
+            __builtin_amdgcn_sched_barrier(0);
+
+            reg_a = next_a;
+            reg_b = next_b;
+            ++k_iter;
+        } while (k_iter < (k_tiles - 1));
+    }
+
+    frag_acc = __builtin_amdgcn_wmma_f32_16x16x32_f16(0, reg_b, 0, reg_a, 0, frag_acc, 0, 0);
+
+    Float16x8 frag_d = {};
+    for (int i = 0; i < 8; ++i) {
+        frag_d[i] = static_cast<_Float16>(frag_acc[i]);
+    }
+
+    write_output(frag_d, wave_row, wave_col, n, d);
+#endif
+}
+
+__attribute__((amdgpu_flat_work_group_size(1, kFlatWorkgroupSize)))
+extern "C" __global__ void gemm_wmma_fp16(uint32_t m,
+                                          uint32_t n,
+                                          uint32_t k,
+                                          const _Float16* __restrict__ a,
+                                          const _Float16* __restrict__ b,
+                                          _Float16* __restrict__ d)
+{
+    const uint32_t block_count_m = DivUp(static_cast<int>(m), static_cast<int>(kBlockM));
+    const uint32_t block_count_n = DivUp(static_cast<int>(n), static_cast<int>(kBlockN));
+
+    for (uint32_t bm = blockIdx.x; bm < block_count_m; bm += gridDim.x) {
+        for (uint32_t bn = blockIdx.y; bn < block_count_n; bn += gridDim.y) {
+            const uint32_t block_m = bm * kBlockM;
+            const uint32_t block_n = bn * kBlockN;
+            if (block_m < m && block_n < n) {
+                inner_gemm(block_m, block_n, m, n, k, a, b, d);
+            }
+        }
+    }
+}

--- a/projects/rocprofiler-compute/sample/wmma_gemm_fp16/wmma_gemm_fp16.hpp
+++ b/projects/rocprofiler-compute/sample/wmma_gemm_fp16/wmma_gemm_fp16.hpp
@@ -1,0 +1,19 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cstdint>
+
+#include <hip/hip_runtime.h>
+
+#include "wmma_gemm_fp16_config.hpp"
+
+// FP16 WMMA GEMM for gfx1250 (MI450). Kernel adapted from hipNPIKernels
+// WMMA_gemm/src/fp16/gfx1250/fp16_16x16x32/native16x16x32.cpp.
+extern "C" __global__ void gemm_wmma_fp16(uint32_t m,
+                                          uint32_t n,
+                                          uint32_t k,
+                                          const _Float16* __restrict__ a,
+                                          const _Float16* __restrict__ b,
+                                          _Float16* __restrict__ d);

--- a/projects/rocprofiler-compute/sample/wmma_gemm_fp16/wmma_gemm_fp16_config.hpp
+++ b/projects/rocprofiler-compute/sample/wmma_gemm_fp16/wmma_gemm_fp16_config.hpp
@@ -1,0 +1,31 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cstdint>
+
+namespace wmma_gemm_fp16 {
+
+constexpr uint32_t kWmmaM = 16;
+constexpr uint32_t kWmmaN = 16;
+constexpr uint32_t kWmmaK = 32;
+
+constexpr uint32_t kWaveSize = 32;
+constexpr uint32_t kBlockM = 16;
+constexpr uint32_t kBlockN = 16;
+constexpr uint32_t kBlockK = 32;
+
+constexpr uint32_t kThreadsX = 1 * kWaveSize;
+constexpr uint32_t kThreadsY = 1;
+constexpr uint32_t kFlatWorkgroupSize = kThreadsX * kThreadsY;
+
+constexpr uint32_t kDefaultM = 4096;
+constexpr uint32_t kDefaultN = 4096;
+constexpr uint32_t kDefaultK = 1024;
+constexpr uint32_t kDefaultIters = 50;
+constexpr uint32_t kDefaultWarmup = 5;
+
+constexpr int DivUp(int a, int b) { return (a + b - 1) / b; }
+
+}  // namespace wmma_gemm_fp16


### PR DESCRIPTION
## Motivation

Add a gfx1250 WMMA workload sample for rocprofiler-compute metric health profiling and WMMA/XDL counter validation.

## Technical Details

- Add `sample/wmma_gemm_fp16/` HIP sample with configurable M/N/K, warmup, and timed iterations.
- Build for `gfx1250` via Makefile (`hipcc --offload-arch=gfx1250`).
- Intended for use with rocprof-compute profile/analyze health test suites.

## JIRA ID



## Test Plan

- `cd projects/rocprofiler-compute/sample/wmma_gemm_fp16 && make clean && make GPU_ARCH=gfx1250`
- `./wmma_gemm_fp16` on gfx1250 hardware
- Profile with rocprof-compute and verify WMMA/XDL metrics populate

## Test Result



## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

Made with [Cursor](https://cursor.com)