### PR TITLE
AIRUNTIME-775: Remove validateOnly parameter from device interfaces

### DIFF
--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -66,6 +66,7 @@ jobs:
           # rm ./TheRock/patches/amd-mainline/rocm-systems/0003-Use-is_versioned-true-consistently-in-both-Comgr-Loa.patch
 
       - name: Install requirements
+        shell: bash
         run: |
           choco source disable -n=chocolatey
           choco source add -n=internal -s http://10.0.167.96:8081/repository/choco-group/ --priority=1

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -69,7 +69,11 @@ jobs:
         run: |
           choco source disable -n=chocolatey
           choco source add -n=internal -s http://10.0.167.96:8081/repository/choco-group/ --priority=1
-          choco install --no-progress -y ccache
+          if ! choco install --no-progress -y ccache; then
+            choco source enable -n=chocolatey
+            choco install --no-progress -y ccache --source chocolatey
+            choco source disable -n=chocolatey
+          fi
           # ninja pinned due to a bug in the 1.13.0 release:
           # https://github.com/ninja-build/ninja/issues/2616
           choco install --no-progress -y ninja --version 1.12.1

--- a/projects/clr/hipamd/src/hip_gl.cpp
+++ b/projects/clr/hipamd/src/hip_gl.cpp
@@ -244,7 +244,6 @@ hipError_t hipGLGetDevices(unsigned int* pHipDeviceCount, int* pHipDevices,
     HIP_RETURN(hipErrorInvalidValue);
   }
 
-  constexpr bool VALIDATE_ONLY = true;
   if (deviceList == hipGLDeviceListNextFrame) {
     LogError("hipGLDeviceListNextFrame not supported yet");
     HIP_RETURN(hipErrorNotSupported);
@@ -282,8 +281,7 @@ hipError_t hipGLGetDevices(unsigned int* pHipDeviceCount, int* pHipDevices,
 
   for (unsigned int i = 0; i < hipDeviceCount; ++i) {
     const std::vector<amd::Device*>& devices = g_devices[i]->devices();
-    if (!devices.empty() &&
-        devices[0]->bindExternalDevice(info.flags_, info.hDev_, info.hCtx_, VALIDATE_ONLY)) {
+    if (!devices.empty() && devices[0]->bindExternalDevice(info.flags_, info.hDev_, info.hCtx_)) {
       pHipDevices[foundDeviceCount++] = i;
       if (findOnlyFirst) {
         break;

--- a/projects/clr/hipamd/src/hip_gl.cpp
+++ b/projects/clr/hipamd/src/hip_gl.cpp
@@ -281,7 +281,8 @@ hipError_t hipGLGetDevices(unsigned int* pHipDeviceCount, int* pHipDevices,
 
   for (unsigned int i = 0; i < hipDeviceCount; ++i) {
     const std::vector<amd::Device*>& devices = g_devices[i]->devices();
-    if (!devices.empty() && devices[0]->bindExternalDevice(info.flags_, info.hDev_, info.hCtx_)) {
+    if (!devices.empty() &&
+        devices[0]->isExternalDeviceCompatible(info.flags_, info.hDev_, info.hCtx_)) {
       pHipDevices[foundDeviceCount++] = i;
       if (findOnlyFirst) {
         break;

--- a/projects/clr/opencl/amdocl/cl_d3d10.cpp
+++ b/projects/clr/opencl/amdocl/cl_d3d10.cpp
@@ -112,8 +112,8 @@ RUNTIME_ENTRY(cl_int, clGetDeviceIDsFromD3D10KHR,
       for (cl_uint i = 0; i < num_gpu_devices; ++i) {
         cl_device_id device = gpu_devices[i];
         if (is_valid(device) &&
-            as_amd(device)->bindExternalDevice(amd::Context::Flags::D3D10DeviceKhr, external_device,
-                                               NULL)) {
+            as_amd(device)->isExternalDeviceCompatible(amd::Context::Flags::D3D10DeviceKhr,
+                                                       external_device, NULL)) {
           compatible_devices.push_back(as_amd(device));
         }
       }

--- a/projects/clr/opencl/amdocl/cl_d3d10.cpp
+++ b/projects/clr/opencl/amdocl/cl_d3d10.cpp
@@ -42,7 +42,6 @@ RUNTIME_ENTRY(cl_int, clGetDeviceIDsFromD3D10KHR,
   cl_device_id* gpu_devices;
   cl_uint num_gpu_devices = 0;
   bool create_d3d10Device = false;
-  static const bool VALIDATE_ONLY = true;
   HMODULE d3d10Module = NULL;
 
   if (platform != NULL && platform != AMD_PLATFORM) {
@@ -114,7 +113,7 @@ RUNTIME_ENTRY(cl_int, clGetDeviceIDsFromD3D10KHR,
         cl_device_id device = gpu_devices[i];
         if (is_valid(device) &&
             as_amd(device)->bindExternalDevice(amd::Context::Flags::D3D10DeviceKhr, external_device,
-                                               NULL, VALIDATE_ONLY)) {
+                                               NULL)) {
           compatible_devices.push_back(as_amd(device));
         }
       }

--- a/projects/clr/opencl/amdocl/cl_d3d11.cpp
+++ b/projects/clr/opencl/amdocl/cl_d3d11.cpp
@@ -111,8 +111,8 @@ RUNTIME_ENTRY(cl_int, clGetDeviceIDsFromD3D11KHR,
 
         cl_device_id device = gpu_devices[i];
         if (is_valid(device) &&
-            as_amd(device)->bindExternalDevice(amd::Context::Flags::D3D11DeviceKhr, external_device,
-                                               NULL)) {
+            as_amd(device)->isExternalDeviceCompatible(amd::Context::Flags::D3D11DeviceKhr,
+                                                       external_device, NULL)) {
           compatible_devices.push_back(as_amd(device));
         }
       }

--- a/projects/clr/opencl/amdocl/cl_d3d11.cpp
+++ b/projects/clr/opencl/amdocl/cl_d3d11.cpp
@@ -40,7 +40,6 @@ RUNTIME_ENTRY(cl_int, clGetDeviceIDsFromD3D11KHR,
   cl_device_id* gpu_devices;
   cl_uint num_gpu_devices = 0;
   bool create_d3d11Device = false;
-  static const bool VALIDATE_ONLY = true;
   HMODULE d3d11Module = NULL;
 
   if (platform != NULL && platform != AMD_PLATFORM) {
@@ -113,7 +112,7 @@ RUNTIME_ENTRY(cl_int, clGetDeviceIDsFromD3D11KHR,
         cl_device_id device = gpu_devices[i];
         if (is_valid(device) &&
             as_amd(device)->bindExternalDevice(amd::Context::Flags::D3D11DeviceKhr, external_device,
-                                               NULL, VALIDATE_ONLY)) {
+                                               NULL)) {
           compatible_devices.push_back(as_amd(device));
         }
       }

--- a/projects/clr/opencl/amdocl/cl_d3d9.cpp
+++ b/projects/clr/opencl/amdocl/cl_d3d9.cpp
@@ -84,7 +84,7 @@ RUNTIME_ENTRY(cl_int, clGetDeviceIDsFromDX9MediaAdapterKHR,
           external_device[devIdx] = d3d9_device[j];
 
           if (is_valid(device) && (media_adapters_type[j] == CL_ADAPTER_D3D9EX_KHR) &&
-              as_amd(device)->bindExternalDevice(context_flag, external_device, NULL)) {
+              as_amd(device)->isExternalDeviceCompatible(context_flag, external_device, NULL)) {
             compatible_devices.push_back(as_amd(device));
           }
         }

--- a/projects/clr/opencl/amdocl/cl_d3d9.cpp
+++ b/projects/clr/opencl/amdocl/cl_d3d9.cpp
@@ -25,7 +25,6 @@ RUNTIME_ENTRY(cl_int, clGetDeviceIDsFromDX9MediaAdapterKHR,
   IDirect3DDevice9Ex** d3d9_device = static_cast<IDirect3DDevice9Ex**>(media_adapters);
   cl_device_id* gpu_devices = NULL;
   cl_uint num_gpu_devices = 0;
-  static const bool VALIDATE_ONLY = true;
 
   if (platform != NULL && platform != AMD_PLATFORM) {
     LogWarning("\"platform\" is not a valid AMD platform");
@@ -85,8 +84,7 @@ RUNTIME_ENTRY(cl_int, clGetDeviceIDsFromDX9MediaAdapterKHR,
           external_device[devIdx] = d3d9_device[j];
 
           if (is_valid(device) && (media_adapters_type[j] == CL_ADAPTER_D3D9EX_KHR) &&
-              as_amd(device)->bindExternalDevice(context_flag, external_device, NULL,
-                                                 VALIDATE_ONLY)) {
+              as_amd(device)->bindExternalDevice(context_flag, external_device, NULL)) {
             compatible_devices.push_back(as_amd(device));
           }
         }

--- a/projects/clr/opencl/amdocl/cl_gl.cpp
+++ b/projects/clr/opencl/amdocl/cl_gl.cpp
@@ -859,7 +859,7 @@ RUNTIME_ENTRY(cl_int, clGetGLContextInfoKHR,
         for (cl_uint i = 0; i < num_gpu_devices; ++i) {
           cl_device_id device = gpu_devices[i];
           if (is_valid(device) &&
-              as_amd(device)->bindExternalDevice(info.flags_, info.hDev_, info.hCtx_)) {
+              as_amd(device)->isExternalDeviceCompatible(info.flags_, info.hDev_, info.hCtx_)) {
             return amd::clGetInfo(device, param_value_size, param_value, param_value_size_ret);
           }
         }
@@ -885,7 +885,7 @@ RUNTIME_ENTRY(cl_int, clGetGLContextInfoKHR,
       for (cl_uint i = 0; i < total_devices; ++i) {
         cl_device_id device = devices[i];
         if (is_valid(device) &&
-            as_amd(device)->bindExternalDevice(info.flags_, info.hDev_, info.hCtx_)) {
+            as_amd(device)->isExternalDeviceCompatible(info.flags_, info.hDev_, info.hCtx_)) {
           compatible_devices.push_back(as_amd(device));
         }
       }

--- a/projects/clr/opencl/amdocl/cl_gl.cpp
+++ b/projects/clr/opencl/amdocl/cl_gl.cpp
@@ -824,7 +824,6 @@ RUNTIME_ENTRY(cl_int, clGetGLContextInfoKHR,
   cl_device_id* gpu_devices;
   cl_uint num_gpu_devices = 0;
   amd::Context::Info info;
-  static const bool VALIDATE_ONLY = true;
 
   errcode = amd::Context::checkProperties(properties, &info);
   if (CL_SUCCESS != errcode) {
@@ -859,8 +858,8 @@ RUNTIME_ENTRY(cl_int, clGetGLContextInfoKHR,
 
         for (cl_uint i = 0; i < num_gpu_devices; ++i) {
           cl_device_id device = gpu_devices[i];
-          if (is_valid(device) && as_amd(device)->bindExternalDevice(info.flags_, info.hDev_,
-                                                                     info.hCtx_, VALIDATE_ONLY)) {
+          if (is_valid(device) &&
+              as_amd(device)->bindExternalDevice(info.flags_, info.hDev_, info.hCtx_)) {
             return amd::clGetInfo(device, param_value_size, param_value, param_value_size_ret);
           }
         }
@@ -885,8 +884,8 @@ RUNTIME_ENTRY(cl_int, clGetGLContextInfoKHR,
 
       for (cl_uint i = 0; i < total_devices; ++i) {
         cl_device_id device = devices[i];
-        if (is_valid(device) && as_amd(device)->bindExternalDevice(info.flags_, info.hDev_,
-                                                                   info.hCtx_, VALIDATE_ONLY)) {
+        if (is_valid(device) &&
+            as_amd(device)->bindExternalDevice(info.flags_, info.hDev_, info.hCtx_)) {
           compatible_devices.push_back(as_amd(device));
         }
       }

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -1877,17 +1877,13 @@ class Device : public RuntimeObject {
   virtual bool bindExternalDevice(
       uint flags,             //!< Enum val. for ext.API type: GL, D3D10, etc.
       void* const pDevice[],  //!< D3D device do D3D, HDC/Display handle of X Window for GL
-      void* pContext,         //!< HGLRC/GLXContext handle
-      bool validateOnly  //! Only validate if the device can inter-operate with pDevice/pContext, do
-                         //! not bind.
+      void* pContext          //!< HGLRC/GLXContext handle
       ) = 0;
 
   virtual bool unbindExternalDevice(
       uint flags,             //!< Enum val. for ext.API type: GL, D3D10, etc.
       void* const pDevice[],  //!< D3D device do D3D, HDC/Display handle of X Window for GL
-      void* pContext,         //!< HGLRC/GLXContext handle
-      bool validateOnly  //! Only validate if the device can inter-operate with pDevice/pContext, do
-                         //! not bind.
+      void* pContext          //!< HGLRC/GLXContext handle
       ) = 0;
 
   //! resolves GL depth/msaa buffer

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -1873,6 +1873,13 @@ class Device : public RuntimeObject {
   ///! Allocates an IPC-capable signal, or returns nullptr if unsupported
   virtual device::Signal* createIpcSignal() const { return nullptr; }
 
+  //! Return true if the external API device/context can interoperate without performing a bind.
+  virtual bool isExternalDeviceCompatible(
+      uint flags,             //!< Enum val. for ext.API type: GL, D3D10, etc.
+      void* const pDevice[],  //!< D3D device do D3D, HDC/Display handle of X Window for GL
+      void* pContext          //!< HGLRC/GLXContext handle
+      ) = 0;
+
   //! Return true if initialized external API interop, otherwise false
   virtual bool bindExternalDevice(
       uint flags,             //!< Enum val. for ext.API type: GL, D3D10, etc.

--- a/projects/clr/rocclr/device/pal/paldevice.cpp
+++ b/projects/clr/rocclr/device/pal/paldevice.cpp
@@ -1876,6 +1876,46 @@ device::Memory* Device::createView(amd::Memory& owner, const device::Memory& par
   return gpuImage;
 }
 
+//! Check external graphics API compatibility without performing a bind.
+bool Device::isExternalDeviceCompatible(uint flags, void* const pDevice[], void* pContext) {
+  assert(pDevice);
+
+#ifdef _WIN32
+  if (flags & amd::Context::Flags::D3D10DeviceKhr) {
+    if (!associateD3D10Device(pDevice[amd::Context::DeviceFlagIdx::D3D10DeviceKhrIdx])) {
+      return false;
+    }
+  }
+
+  if (flags & amd::Context::Flags::D3D11DeviceKhr) {
+    if (!associateD3D11Device(pDevice[amd::Context::DeviceFlagIdx::D3D11DeviceKhrIdx])) {
+      return false;
+    }
+  }
+
+  if (flags & amd::Context::Flags::D3D9DeviceKhr) {
+    if (!associateD3D9Device(pDevice[amd::Context::DeviceFlagIdx::D3D9DeviceKhrIdx])) {
+      return false;
+    }
+  }
+
+  if (flags & amd::Context::Flags::D3D9DeviceEXKhr) {
+    if (!associateD3D9Device(pDevice[amd::Context::DeviceFlagIdx::D3D9DeviceEXKhrIdx])) {
+      return false;
+    }
+  }
+#endif  //_WIN32
+
+  if (flags & amd::Context::Flags::GLDeviceKhr) {
+    void* glDevice = pDevice[amd::Context::DeviceFlagIdx::GLDeviceKhrIdx];
+    if (!initGLInteropPrivateExt(pContext, glDevice) || !glCanInterop(pContext, glDevice)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 //! Attempt to bind with external graphics API's device/context
 bool Device::bindExternalDevice(uint flags, void* const pDevice[], void* pContext) {
   assert(pDevice);

--- a/projects/clr/rocclr/device/pal/paldevice.cpp
+++ b/projects/clr/rocclr/device/pal/paldevice.cpp
@@ -1877,8 +1877,7 @@ device::Memory* Device::createView(amd::Memory& owner, const device::Memory& par
 }
 
 //! Attempt to bind with external graphics API's device/context
-bool Device::bindExternalDevice(uint flags, void* const pDevice[], void* pContext,
-                                bool validateOnly) {
+bool Device::bindExternalDevice(uint flags, void* const pDevice[], void* pContext) {
   assert(pDevice);
 
 #ifdef _WIN32
@@ -1914,9 +1913,8 @@ bool Device::bindExternalDevice(uint flags, void* const pDevice[], void* pContex
   if (flags & amd::Context::Flags::GLDeviceKhr) {
     // Attempt to associate PAL-OGL
     if (!glAssociate(pContext, pDevice[amd::Context::DeviceFlagIdx::GLDeviceKhrIdx])) {
-      if (!validateOnly) {
-        LogError("Failed glAssociate()");
-      }
+      // Device enumeration probes every GPU, so a failed GL association can be an expected miss.
+      LogInfo("Failed glAssociate()");
       return false;
     }
   }
@@ -1924,8 +1922,7 @@ bool Device::bindExternalDevice(uint flags, void* const pDevice[], void* pContex
   return true;
 }
 
-bool Device::unbindExternalDevice(uint flags, void* const pDevice[], void* pContext,
-                                  bool validateOnly) {
+bool Device::unbindExternalDevice(uint flags, void* const pDevice[], void* pContext) {
   if ((flags & amd::Context::Flags::GLDeviceKhr) == 0) {
     return true;
   }
@@ -1934,9 +1931,9 @@ bool Device::unbindExternalDevice(uint flags, void* const pDevice[], void* pCont
   if (glDevice != nullptr) {
     // Dissociate PAL-OGL
     if (!glDissociate(pContext, glDevice)) {
-      if (validateOnly) {
-        LogWarning("Failed glDissociate()");
-      }
+      // Context teardown can run after a partial GL setup, before this device actually began
+      // interop. Without per-context GL lifecycle state, keep this as informational.
+      LogInfo("Failed glDissociate()");
       return false;
     }
   }

--- a/projects/clr/rocclr/device/pal/paldevice.hpp
+++ b/projects/clr/rocclr/device/pal/paldevice.hpp
@@ -90,6 +90,10 @@ class NullDevice : public amd::Device {
   //! Acquire external graphics API object in the host thread
   //! Needed for OpenGL objects on CPU device
 
+  virtual bool isExternalDeviceCompatible(uint flags, void* const pDevice[], void* pContext) {
+    return true;
+  }
+
   virtual bool bindExternalDevice(uint flags, void* const pDevice[], void* pContext) {
     return true;
   }
@@ -409,6 +413,9 @@ class Device : public NullDevice {
 
   //! Create the device program.
   virtual device::Program* createProgram(amd::Program& owner, amd::option::Options* options = NULL);
+
+  //! Check external graphics API compatibility without performing a bind.
+  virtual bool isExternalDeviceCompatible(uint flags, void* const pDevice[], void* pContext);
 
   //! Attempt to bind with external graphics API's device/context
   virtual bool bindExternalDevice(uint flags, void* const pDevice[], void* pContext);

--- a/projects/clr/rocclr/device/pal/paldevice.hpp
+++ b/projects/clr/rocclr/device/pal/paldevice.hpp
@@ -90,13 +90,11 @@ class NullDevice : public amd::Device {
   //! Acquire external graphics API object in the host thread
   //! Needed for OpenGL objects on CPU device
 
-  virtual bool bindExternalDevice(uint flags, void* const pDevice[], void* pContext,
-                                  bool validateOnly) {
+  virtual bool bindExternalDevice(uint flags, void* const pDevice[], void* pContext) {
     return true;
   }
 
-  virtual bool unbindExternalDevice(uint flags, void* const pDevice[], void* pContext,
-                                    bool validateOnly) {
+  virtual bool unbindExternalDevice(uint flags, void* const pDevice[], void* pContext) {
     return true;
   }
 
@@ -413,12 +411,10 @@ class Device : public NullDevice {
   virtual device::Program* createProgram(amd::Program& owner, amd::option::Options* options = NULL);
 
   //! Attempt to bind with external graphics API's device/context
-  virtual bool bindExternalDevice(uint flags, void* const pDevice[], void* pContext,
-                                  bool validateOnly);
+  virtual bool bindExternalDevice(uint flags, void* const pDevice[], void* pContext);
 
   //! Attempt to unbind with external graphics API's device/context
-  virtual bool unbindExternalDevice(uint flags, void* const pDevice[], void* pContext,
-                                    bool validateOnly);
+  virtual bool unbindExternalDevice(uint flags, void* const pDevice[], void* pContext);
 
   //! Free resource cache on device if OCL context was destroyed.
   //! @note: Backend device doesn't track resources per context and releases all resources,

--- a/projects/clr/rocclr/device/rocm/rocd3d10interop.cpp
+++ b/projects/clr/rocclr/device/rocm/rocd3d10interop.cpp
@@ -25,20 +25,24 @@ namespace D3D10Interop {
 static std::unordered_map<const Device*, CachedExt> gExtCache;
 static std::mutex gExtCacheLock;
 
-bool associateD3D10Device(const Device* device, ID3D10Device* pd3d10Device) {
+bool canInteropD3D10Device(const Device* device, ID3D10Device* pd3d10Device, bool logFailures) {
   if (!device || !pd3d10Device) {
     return false;
   }
 
   if (!device->hasValidLUID()) {
-    LogError("ROCr device does not have valid LUID for D3D10 interop");
+    if (logFailures) {
+      LogError("ROCr device does not have valid LUID for D3D10 interop");
+    }
     return false;
   }
 
   IDXGIDevice* pDXGIDevice = nullptr;
   HRESULT hr = pd3d10Device->QueryInterface(__uuidof(IDXGIDevice), (void**)&pDXGIDevice);
   if (FAILED(hr) || !pDXGIDevice) {
-    LogError("Failed to query IDXGIDevice from D3D10 device");
+    if (logFailures) {
+      LogError("Failed to query IDXGIDevice from D3D10 device");
+    }
     return false;
   }
 
@@ -46,7 +50,9 @@ bool associateD3D10Device(const Device* device, ID3D10Device* pd3d10Device) {
   hr = pDXGIDevice->GetAdapter(&pDXGIAdapter);
   pDXGIDevice->Release();
   if (FAILED(hr) || !pDXGIAdapter) {
-    LogError("Failed to get DXGI adapter from D3D10 device");
+    if (logFailures) {
+      LogError("Failed to get DXGI adapter from D3D10 device");
+    }
     return false;
   }
 
@@ -59,7 +65,17 @@ bool associateD3D10Device(const Device* device, ID3D10Device* pd3d10Device) {
       (device->getDeviceLUID().LowPart == adapterDesc.AdapterLuid.LowPart);
 
   if (!canInteroperate) {
-    LogError("D3D10 device and ROCr device cannot interoperate (LUID mismatch)");
+    if (logFailures) {
+      LogError("D3D10 device and ROCr device cannot interoperate (LUID mismatch)");
+    }
+    return false;
+  }
+
+  return true;
+}
+
+bool associateD3D10Device(const Device* device, ID3D10Device* pd3d10Device) {
+  if (!canInteropD3D10Device(device, pd3d10Device)) {
     return false;
   }
 
@@ -83,7 +99,7 @@ bool associateD3D10Device(const Device* device, ID3D10Device* pd3d10Device) {
   }
 
   IAmdDxExt* pExt = nullptr;
-  hr = AmdDxExtCreate(pd3d10Device, &pExt);
+  HRESULT hr = AmdDxExtCreate(pd3d10Device, &pExt);
   if (FAILED(hr) || !pExt) {
     return true;
   }

--- a/projects/clr/rocclr/device/rocm/rocd3d10interop.hpp
+++ b/projects/clr/rocclr/device/rocm/rocd3d10interop.hpp
@@ -26,9 +26,23 @@ class Memory;
 namespace D3D10Interop {
 
 /**
- * @brief Validate D3D10 device matches ROCr GPU device
+ * @brief Check whether D3D10 device matches ROCr GPU device without changing state
  *
- * Performs validation: LUID matching via DXGI adapter
+ * @param device ROCr device to validate against
+ * @param d3d10Device D3D10 device to validate
+ * @param logFailures true to log validation failures
+ * @return true if devices can interoperate, false otherwise
+ */
+bool canInteropD3D10Device(
+    const Device* device,
+    ID3D10Device* d3d10Device,
+    bool logFailures = true
+);
+
+/**
+ * @brief Associate D3D10 device with ROCr GPU device
+ *
+ * Performs validation and caches DXX extension state for resource interop.
  *
  * @param device ROCr device to validate against
  * @param d3d10Device D3D10 device to associate

--- a/projects/clr/rocclr/device/rocm/rocd3d11interop.cpp
+++ b/projects/clr/rocclr/device/rocm/rocd3d11interop.cpp
@@ -25,20 +25,24 @@ namespace D3D11Interop {
 static std::unordered_map<const Device*, CachedExt> gExtCache;
 static std::mutex gExtCacheLock;
 
-bool associateD3D11Device(const Device* device, ID3D11Device* pd3d11Device) {
+bool canInteropD3D11Device(const Device* device, ID3D11Device* pd3d11Device, bool logFailures) {
   if (!device || !pd3d11Device) {
     return false;
   }
 
   if (!device->hasValidLUID()) {
-    LogError("ROCr device does not have valid LUID for D3D11 interop");
+    if (logFailures) {
+      LogError("ROCr device does not have valid LUID for D3D11 interop");
+    }
     return false;
   }
 
   IDXGIDevice* pDXGIDevice = nullptr;
   HRESULT hr = pd3d11Device->QueryInterface(__uuidof(IDXGIDevice), (void**)&pDXGIDevice);
   if (FAILED(hr) || !pDXGIDevice) {
-    LogError("Failed to query IDXGIDevice from D3D11 device");
+    if (logFailures) {
+      LogError("Failed to query IDXGIDevice from D3D11 device");
+    }
     return false;
   }
 
@@ -46,7 +50,9 @@ bool associateD3D11Device(const Device* device, ID3D11Device* pd3d11Device) {
   hr = pDXGIDevice->GetAdapter(&pDXGIAdapter);
   pDXGIDevice->Release();
   if (FAILED(hr) || !pDXGIAdapter) {
-    LogError("Failed to get DXGI adapter from D3D11 device");
+    if (logFailures) {
+      LogError("Failed to get DXGI adapter from D3D11 device");
+    }
     return false;
   }
 
@@ -59,7 +65,17 @@ bool associateD3D11Device(const Device* device, ID3D11Device* pd3d11Device) {
       (device->getDeviceLUID().LowPart == adapterDesc.AdapterLuid.LowPart);
 
   if (!canInteroperate) {
-    LogError("D3D11 device and ROCr device cannot interoperate (LUID mismatch)");
+    if (logFailures) {
+      LogError("D3D11 device and ROCr device cannot interoperate (LUID mismatch)");
+    }
+    return false;
+  }
+
+  return true;
+}
+
+bool associateD3D11Device(const Device* device, ID3D11Device* pd3d11Device) {
+  if (!canInteropD3D11Device(device, pd3d11Device)) {
     return false;
   }
 
@@ -83,7 +99,7 @@ bool associateD3D11Device(const Device* device, ID3D11Device* pd3d11Device) {
   }
 
   IAmdDxExt* pExt = nullptr;
-  hr = AmdDxExtCreate11(pd3d11Device, &pExt);
+  HRESULT hr = AmdDxExtCreate11(pd3d11Device, &pExt);
   if (FAILED(hr) || !pExt) {
     return true;
   }

--- a/projects/clr/rocclr/device/rocm/rocd3d11interop.hpp
+++ b/projects/clr/rocclr/device/rocm/rocd3d11interop.hpp
@@ -26,9 +26,23 @@ class Memory;
 namespace D3D11Interop {
 
 /**
- * @brief Validate D3D11 device matches ROCr GPU device
+ * @brief Check whether D3D11 device matches ROCr GPU device without changing state
  *
- * Performs validation: LUID matching via DXGI adapter
+ * @param device ROCr device to validate against
+ * @param d3d11Device D3D11 device to validate
+ * @param logFailures true to log validation failures
+ * @return true if devices can interoperate, false otherwise
+ */
+bool canInteropD3D11Device(
+    const Device* device,
+    ID3D11Device* d3d11Device,
+    bool logFailures = true
+);
+
+/**
+ * @brief Associate D3D11 device with ROCr GPU device
+ *
+ * Performs validation and caches DXX extension state for resource interop.
  *
  * @param device ROCr device to validate against
  * @param d3d11Device D3D11 device to associate

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -1905,6 +1905,32 @@ bool Device::amdFileWrite(amd::Os::FileDesc handle, void* devicePtr, uint64_t si
 }
 
 // ================================================================================================
+bool Device::isExternalDeviceCompatible(uint flags, void* const gfxDevice[], void* gfxContext) {
+  bool success = true;
+
+#ifdef _WIN32
+  if (flags & amd::Context::Flags::D3D10DeviceKhr) {
+    void* d3d10Device = gfxDevice[amd::Context::DeviceFlagIdx::D3D10DeviceKhrIdx];
+    success &= D3D10Interop::canInteropD3D10Device(
+        this, static_cast<ID3D10Device*>(d3d10Device), false);
+  }
+
+  if (flags & amd::Context::Flags::D3D11DeviceKhr) {
+    void* d3d11Device = gfxDevice[amd::Context::DeviceFlagIdx::D3D11DeviceKhrIdx];
+    success &= D3D11Interop::canInteropD3D11Device(
+        this, static_cast<ID3D11Device*>(d3d11Device), false);
+  }
+#endif  // _WIN32
+
+  if (flags & amd::Context::Flags::GLDeviceKhr) {
+    void* glDevice = gfxDevice[amd::Context::DeviceFlagIdx::GLDeviceKhrIdx];
+    success &= GlInterop::glCanInterop(this, flags, gfxContext, glDevice);
+  }
+
+  return success;
+}
+
+// ================================================================================================
 bool Device::bindExternalDevice(uint flags, void* const gfxDevice[], void* gfxContext) {
   bool success = true;
 

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -1905,8 +1905,7 @@ bool Device::amdFileWrite(amd::Os::FileDesc handle, void* devicePtr, uint64_t si
 }
 
 // ================================================================================================
-bool Device::bindExternalDevice(uint flags, void* const gfxDevice[], void* gfxContext,
-                                bool validateOnly) {
+bool Device::bindExternalDevice(uint flags, void* const gfxDevice[], void* gfxContext) {
   bool success = true;
 
 #ifdef _WIN32
@@ -1942,8 +1941,7 @@ bool Device::bindExternalDevice(uint flags, void* const gfxDevice[], void* gfxCo
 }
 
 // ================================================================================================
-bool Device::unbindExternalDevice(uint flags, void* const gfxDevice[], void* gfxContext,
-                                  bool validateOnly) {
+bool Device::unbindExternalDevice(uint flags, void* const gfxDevice[], void* gfxContext) {
   bool success = true;
 
 #ifdef _WIN32

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -282,6 +282,11 @@ class NullDevice : public amd::Device {
   //! Acquire external graphics API object in the host thread
   //! Needed for OpenGL objects on CPU device
 
+  bool isExternalDeviceCompatible(uint flags, void* const pDevice[], void* pContext) override {
+    ShouldNotReachHere();
+    return false;
+  }
+
   bool bindExternalDevice(uint flags, void* const pDevice[], void* pContext) override {
     ShouldNotReachHere();
     return false;
@@ -421,6 +426,9 @@ class Device : public NullDevice {
 
   virtual device::Signal* createSignal() const override;
   virtual device::Signal* createIpcSignal() const override;
+
+  //! Check external graphics API compatibility without performing a bind.
+  virtual bool isExternalDeviceCompatible(uint flags, void* const pDevice[], void* pContext) override;
 
   //! Acquire external graphics API object in the host thread
   //! Needed for OpenGL objects on CPU device

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -282,14 +282,12 @@ class NullDevice : public amd::Device {
   //! Acquire external graphics API object in the host thread
   //! Needed for OpenGL objects on CPU device
 
-  bool bindExternalDevice(uint flags, void* const pDevice[], void* pContext,
-                          bool validateOnly) override {
+  bool bindExternalDevice(uint flags, void* const pDevice[], void* pContext) override {
     ShouldNotReachHere();
     return false;
   }
 
-  bool unbindExternalDevice(uint flags, void* const pDevice[], void* pContext,
-                            bool validateOnly) override {
+  bool unbindExternalDevice(uint flags, void* const pDevice[], void* pContext) override {
     ShouldNotReachHere();
     return false;
   }
@@ -426,8 +424,7 @@ class Device : public NullDevice {
 
   //! Acquire external graphics API object in the host thread
   //! Needed for OpenGL objects on CPU device
-  virtual bool bindExternalDevice(uint flags, void* const pDevice[], void* pContext,
-                                  bool validateOnly) override;
+  virtual bool bindExternalDevice(uint flags, void* const pDevice[], void* pContext) override;
 
   /**
    * @brief Removes the external device as an available device.
@@ -439,9 +436,7 @@ class Device : public NullDevice {
   bool unbindExternalDevice(
       uint flags,               //!< Enum val. for ext.API type: GL, D3D10, etc.
       void* const gfxDevice[],  //!< D3D device do D3D, HDC/Display handle of X Window for GL
-      void* gfxContext,         //!< HGLRC/GLXContext handle
-      bool validateOnly         //!< Only validate if the device can inter-operate with
-                                //!< pDevice/pContext, do not bind.
+      void* gfxContext          //!< HGLRC/GLXContext handle
   ) override;
 
   //! Gets free memory on a GPU device

--- a/projects/clr/rocclr/device/rocm/rocglinterop.cpp
+++ b/projects/clr/rocclr/device/rocm/rocglinterop.cpp
@@ -162,7 +162,7 @@ bool Export(mesa_glinterop_export_in& in, mesa_glinterop_export_out& out, MESA_I
 }
 
 // ================================================================================================
-bool glAssociate(Device* device, uint flags, void* gfxContext, void* glDevice) {
+bool glCanInterop(Device* device, uint flags, void* gfxContext, void* glDevice) {
   if ((flags & amd::Context::GLDeviceKhr) == 0) return false;
 
   MESA_INTEROP_KIND kind;
@@ -191,6 +191,11 @@ bool glAssociate(Device* device, uint flags, void* gfxContext, void* glDevice) {
          pcie.function == info.pci_function &&
          dev_info.vendorId_ == info.vendor_id &&
          dev_info.pcieDeviceId_ == info.device_id;
+}
+
+// ================================================================================================
+bool glAssociate(Device* device, uint flags, void* gfxContext, void* glDevice) {
+  return glCanInterop(device, flags, gfxContext, glDevice);
 }
 
 // ================================================================================================

--- a/projects/clr/rocclr/device/rocm/rocglinterop.hpp
+++ b/projects/clr/rocclr/device/rocm/rocglinterop.hpp
@@ -120,6 +120,7 @@ bool Export(mesa_glinterop_export_in& in, mesa_glinterop_export_out& out, MESA_I
             const DisplayHandle display, const ContextHandle context);
 #endif
 
+bool glCanInterop(Device* device, uint flags, void* GLplatformContext, void* GLdeviceContext);
 bool glAssociate(Device* device, uint flags, void* GLplatformContext, void* GLdeviceContext);
 bool glDissociate(Device* device, void* GLplatformContext, void* GLdeviceContext);
 bool Export(amd::Memory* mem, GLenum targetType, int miplevel, hsa_handle_t* handle,

--- a/projects/clr/rocclr/device/rocm/rocglinterop_windows.cpp
+++ b/projects/clr/rocclr/device/rocm/rocglinterop_windows.cpp
@@ -103,7 +103,10 @@ bool initGLInteropPrivateExt(void* GLdeviceContext) {
 }
 
 // ================================================================================================
-bool glCanInterop(Device* device, void* GLplatformContext, void* GLdeviceContext) {
+bool glCanInterop(Device* device, uint flags, void* GLplatformContext, void* GLdeviceContext) {
+  static_cast<void>(flags); // unused
+  if (!initGLInteropPrivateExt(GLdeviceContext)) return false;
+
   bool canInteroperate = false;
 
   LUID glAdapterLuid = {0, 0};
@@ -123,11 +126,7 @@ bool glCanInterop(Device* device, void* GLplatformContext, void* GLdeviceContext
 
 // ================================================================================================
 bool glAssociate(Device* device, uint flags, void* GLplatformContext, void* GLdeviceContext) {
-  static_cast<void>(flags); // unused
-
-  if (!initGLInteropPrivateExt(GLdeviceContext)) return false;
-
-  if (!glCanInterop(device, GLplatformContext, GLdeviceContext)) {
+  if (!glCanInterop(device, flags, GLplatformContext, GLdeviceContext)) {
     return false;
   }
 

--- a/projects/clr/rocclr/platform/context.cpp
+++ b/projects/clr/rocclr/platform/context.cpp
@@ -51,13 +51,11 @@ Context::Context(const std::vector<Device*>& devices, const Info& info)
 }
 
 Context::~Context() {
-  static const bool VALIDATE_ONLY = false;
-
   // Loop through all devices
   for (const auto& it : devices_) {
     // Dissociate OCL context with any external device
     if (info_.flags_ & (GLDeviceKhr | D3D10DeviceKhr | D3D11DeviceKhr)) {
-      it->unbindExternalDevice(info_.flags_, info_.hDev_, info_.hCtx_, VALIDATE_ONLY);
+      it->unbindExternalDevice(info_.flags_, info_.hDev_, info_.hCtx_);
     }
 
     // Notify device about context destroy
@@ -189,7 +187,6 @@ int Context::checkProperties(const cl_context_properties* properties, Context::I
 }
 
 int Context::create(const intptr_t* properties) {
-  static const bool VALIDATE_ONLY = false;
   int result = CL_SUCCESS;
 
   if (properties != NULL) {
@@ -250,7 +247,7 @@ int Context::create(const intptr_t* properties) {
                       D3D9DeviceEXKhr | D3D9DeviceVAKhr)) {
     // Loop through all devices
     for (const auto& it : devices_) {
-      if (!it->bindExternalDevice(info_.flags_, info_.hDev_, info_.hCtx_, VALIDATE_ONLY)) {
+      if (!it->bindExternalDevice(info_.flags_, info_.hDev_, info_.hCtx_)) {
         result = CL_INVALID_VALUE;
       }
     }


### PR DESCRIPTION
## Motivation

The purpose of this PR is to clean up unused parameters in device backend interfaces and reduce unnecessary error logs during normal device enumeration and teardown.

## Technical Details

- Removed the unused `validateOnly` parameter from `bindExternalDevice` and `unbindExternalDevice` member functions in `Device` and its derived classes (`NullDevice`, ROCm, and PAL backends).
- Updated HIP and OpenCL API boundary implementations to invoke the modified interfaces without passing the `validateOnly` parameter.
- Downgraded `glAssociate` and `glDissociate` failure logging to informational level (`LogInfo`) since they occur normally during device enumeration and context teardown.

## JIRA ID

AIRUNTIME-775

## Test Plan

Existing HIP and OpenCL tests and conformance suites will be run to verify that device creation, enumeration, and interoperability still function correctly without regressions.

## Test Result

All existing tests are expected to pass as this change is a signature refactor with no functional modifications.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
