### PR TITLE
fix(amdsmi): open UALoE/IFoE session lazily to prevent amdsmi_init hang

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -109,6 +109,10 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ### Resolved Issues
 
+- **Fixed `amd-smi` hanging in `amdsmi_init()` on UALink systems when the IFoE driver is unresponsive**.  
+  - `AMDSmiGPUDevice` opened the per-GPU IFoE/UALoE generic-netlink session in its constructor, so `amdsmi_init(AMDSMI_INIT_AMD_GPUS)` (and every CLI verb) blocked in an uninterruptible netlink wait when the Broadcom IFoE driver was wedged, even for queries that never use fabric data.
+  - The UALoE session is now opened lazily on the first fabric query via `get_ualoe_handle()`, so initialization and non-fabric queries no longer touch the IFoE driver.
+
 - **Fixed `amd-smi set --power-cap` rejecting the minimum allowed value**.  
   - The lower bound is now inclusive, so setting the power cap to the exact minimum of the reported range (e.g. `210` when the range is 210-300W) succeeds instead of failing validation, matching the inclusive range shown in the error message.
 

--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_gpu_device.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_gpu_device.h
@@ -24,6 +24,7 @@
 #define AMD_SMI_INCLUDE_IMPL_AMD_SMI_GPU_DEVICE_H_
 
 #include <map>
+#include <mutex>
 #include <set>
 #include <string>
 #include <string_view>
@@ -156,8 +157,11 @@ class AMDSmiGPUDevice : public AMDSmiProcessor {
   std::vector<uint64_t> get_bitmask_from_numa_node(int32_t node_id, uint32_t size) const;
   std::vector<uint64_t> get_bitmask_from_local_cpulist(uint32_t drm_card, uint32_t size) const;
 
-  // Get the UALoE handle
-  ualoe_handle_t get_ualoe_handle() const { return ualoe_handle_; }
+  // Get the UALoE handle, opening the IFoE/UALoE session on first use.
+  // Deferred out of the constructor so amdsmi_init() and non-fabric queries
+  // never block on the IFoE driver; a wedged IFoE driver would otherwise hang
+  // initialization in an uninterruptible generic-netlink wait.
+  ualoe_handle_t get_ualoe_handle();
 
   /** UALoE fabric sysfs:
    *    - partial reads; see amdsmi_get_gpu_fabric_info() for status info
@@ -185,8 +189,10 @@ class AMDSmiGPUDevice : public AMDSmiProcessor {
   int32_t get_compute_process_list_impl(GPUComputeProcessList_t& compute_process_list,
                                         ComputeProcessListType_t list_type);
   void populate_ifoe_fabric_bdf_list();
-  // UALoE
+  // UALoE — session is opened lazily on the first get_ualoe_handle() call
+  void open_ualoe_session();
   ualoe_handle_t ualoe_handle_ = (-1);
+  std::once_flag ualoe_open_once_;
 };
 
 }  // namespace amd::smi

--- a/projects/amdsmi/src/amd_smi/amd_smi_gpu_device.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_gpu_device.cc
@@ -77,9 +77,7 @@ AMDSmiGPUDevice::AMDSmiGPUDevice(uint32_t gpu_id, AMDSmiDrm& drm)
   populate_ifoe_fabric_bdf_list();
 }
 
-// Open the IFoE/UALoE generic-netlink session for this device. Called lazily
-// (see get_ualoe_handle) so a wedged IFoE driver cannot hang amdsmi_init() or
-// any query that does not need fabric data.
+// Opens the IFoE/UALoE genl session; deferred (see get_ualoe_handle).
 void AMDSmiGPUDevice::open_ualoe_session() {
   if (has_ifoe_related_bdf() && device_has_ualink()) {
     auto ifoe_bdf_str = get_ifoe_bdf_string();

--- a/projects/amdsmi/src/amd_smi/amd_smi_gpu_device.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_gpu_device.cc
@@ -68,6 +68,19 @@ AMDSmiGPUDevice::AMDSmiGPUDevice(uint32_t gpu_id, std::string path, amdsmi_bdf_t
       bdf_(bdf),
       drm_(drm) {
   populate_ifoe_fabric_bdf_list();
+}
+
+AMDSmiGPUDevice::AMDSmiGPUDevice(uint32_t gpu_id, AMDSmiDrm& drm)
+    : AMDSmiProcessor(AMDSMI_PROCESSOR_TYPE_AMD_GPU), gpu_id_(gpu_id), drm_(drm) {
+  if (check_if_drm_is_supported()) this->get_drm_data();
+
+  populate_ifoe_fabric_bdf_list();
+}
+
+// Open the IFoE/UALoE generic-netlink session for this device. Called lazily
+// (see get_ualoe_handle) so a wedged IFoE driver cannot hang amdsmi_init() or
+// any query that does not need fabric data.
+void AMDSmiGPUDevice::open_ualoe_session() {
   if (has_ifoe_related_bdf() && device_has_ualink()) {
     auto ifoe_bdf_str = get_ifoe_bdf_string();
     if (auto ualoe_status = ualoe_open(ifoe_bdf_str.c_str(), &ualoe_handle_); ualoe_status != 0) {
@@ -76,17 +89,9 @@ AMDSmiGPUDevice::AMDSmiGPUDevice(uint32_t gpu_id, std::string path, amdsmi_bdf_t
   }
 }
 
-AMDSmiGPUDevice::AMDSmiGPUDevice(uint32_t gpu_id, AMDSmiDrm& drm)
-    : AMDSmiProcessor(AMDSMI_PROCESSOR_TYPE_AMD_GPU), gpu_id_(gpu_id), drm_(drm) {
-  if (check_if_drm_is_supported()) this->get_drm_data();
-
-  populate_ifoe_fabric_bdf_list();
-  if (has_ifoe_related_bdf() && device_has_ualink()) {
-    auto ifoe_bdf_str = get_ifoe_bdf_string();
-    if (auto ualoe_status = ualoe_open(ifoe_bdf_str.c_str(), &ualoe_handle_); ualoe_status != 0) {
-      ualoe_handle_ = (-1);
-    }
-  }
+ualoe_handle_t AMDSmiGPUDevice::get_ualoe_handle() {
+  std::call_once(ualoe_open_once_, [this]() { open_ualoe_session(); });
+  return ualoe_handle_;
 }
 
 AMDSmiGPUDevice::~AMDSmiGPUDevice() {

--- a/projects/amdsmi/src/ualoe_lib/CMakeLists.txt
+++ b/projects/amdsmi/src/ualoe_lib/CMakeLists.txt
@@ -1,12 +1,11 @@
 # SPDX-License-Identifier: MIT
 # UALOE Library CMake configuration
 
-# Find required dependencies
-if(PkgConfig_FOUND)
-    pkg_check_modules(LIBNL3 libnl-3.0)
-    pkg_check_modules(LIBNL3_GENL libnl-genl-3.0)
-    pkg_check_modules(LIBMNL libmnl)
-endif()
+# Netlink dependencies (LIBNL3/LIBNLGENL3/LIBMNL) are resolved by the top-level
+# CMakeLists.txt as pkg-config IMPORTED targets so their link search dirs travel
+# with the target. Do not re-run pkg_check_modules here without IMPORTED_TARGET:
+# raw *_LIBRARIES yield bare -lnl-3/-lmnl with no -L, which fails to link when
+# the libs live outside the default linker path (e.g. rocm_sysdeps).
 
 # Define source files for ualoe library
 set(UALOE_SRC_LIST ualoe_lib.c ualoe_cdev.c ualoe_cb.c ualoe_nl.c)
@@ -41,9 +40,10 @@ if(USING_BUNDLED_NETLINK)
     set(UALOE_DEPENDENCIES_FOUND TRUE PARENT_SCOPE)
     message(STATUS "UALOE using bundled netlink libraries")
 elseif(LIBNL3_FOUND AND LIBNLGENL3_FOUND AND LIBMNL_FOUND)
-    # Using system libraries via pkg-config
-    set(UALOE_COMPILE_FLAGS "${LIBNL3_CFLAGS} ${LIBNLGENL3_CFLAGS} ${LIBMNL_CFLAGS} -DUALOE_NETLINK" PARENT_SCOPE)
-    set(UALOE_LINK_LIBRARIES "${LIBNL3_LIBRARIES};${LIBNLGENL3_LIBRARIES};${LIBMNL_LIBRARIES}" PARENT_SCOPE)
+    # Using system libraries via pkg-config imported targets, which carry both
+    # the include dirs and the -L link search dirs.
+    set(UALOE_COMPILE_FLAGS "-DUALOE_NETLINK" PARENT_SCOPE)
+    set(UALOE_LINK_LIBRARIES "PkgConfig::LIBNL3;PkgConfig::LIBNLGENL3;PkgConfig::LIBMNL" PARENT_SCOPE)
     set(UALOE_DEPENDENCIES_FOUND TRUE PARENT_SCOPE)
     message(STATUS "UALOE using system netlink libraries")
 else()

--- a/projects/amdsmi/src/ualoe_lib/CMakeLists.txt
+++ b/projects/amdsmi/src/ualoe_lib/CMakeLists.txt
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: MIT
 # UALOE Library CMake configuration
 
-# Netlink dependencies (LIBNL3/LIBNLGENL3/LIBMNL) are resolved by the top-level
-# CMakeLists.txt as pkg-config IMPORTED targets so their link search dirs travel
-# with the target. Do not re-run pkg_check_modules here without IMPORTED_TARGET:
-# raw *_LIBRARIES yield bare -lnl-3/-lmnl with no -L, which fails to link when
-# the libs live outside the default linker path (e.g. rocm_sysdeps).
+# Netlink dependencies (LIBNL3/LIBNLGENL3/LIBMNL) are resolved once by the
+# top-level CMakeLists.txt via pkg_check_modules; its result variables
+# (*_CFLAGS, *_LINK_LIBRARIES) are reused below. Do not re-run pkg_check_modules
+# here: raw *_LIBRARIES yield bare -lnl-3/-lmnl with no -L, which fails to link
+# when the libs live outside the default linker path (e.g. rocm_sysdeps).
 
 # Define source files for ualoe library
 set(UALOE_SRC_LIST ualoe_lib.c ualoe_cdev.c ualoe_cb.c ualoe_nl.c)
@@ -40,10 +40,16 @@ if(USING_BUNDLED_NETLINK)
     set(UALOE_DEPENDENCIES_FOUND TRUE PARENT_SCOPE)
     message(STATUS "UALOE using bundled netlink libraries")
 elseif(LIBNL3_FOUND AND LIBNLGENL3_FOUND AND LIBMNL_FOUND)
-    # Using system libraries via pkg-config imported targets, which carry both
-    # the include dirs and the -L link search dirs.
-    set(UALOE_COMPILE_FLAGS "-DUALOE_NETLINK" PARENT_SCOPE)
-    set(UALOE_LINK_LIBRARIES "PkgConfig::LIBNL3;PkgConfig::LIBNLGENL3;PkgConfig::LIBMNL" PARENT_SCOPE)
+    # Link via pkg-config absolute library paths (*_LINK_LIBRARIES) rather than
+    # bare -lnl-3/-lmnl: the absolute paths resolve without a -L search dir when
+    # the libs live outside the default linker path (e.g. rocm_sysdeps), and
+    # unlike PkgConfig:: imported targets they remain valid in the exported
+    # amd_smi_static link interface for downstream find_package() consumers.
+    set(UALOE_COMPILE_FLAGS "${LIBNL3_CFLAGS} ${LIBNLGENL3_CFLAGS} ${LIBMNL_CFLAGS} -DUALOE_NETLINK" PARENT_SCOPE)
+    set(UALOE_LINK_LIBRARIES
+        "${LIBNL3_LINK_LIBRARIES};${LIBNLGENL3_LINK_LIBRARIES};${LIBMNL_LINK_LIBRARIES}"
+        PARENT_SCOPE
+    )
     set(UALOE_DEPENDENCIES_FOUND TRUE PARENT_SCOPE)
     message(STATUS "UALOE using system netlink libraries")
 else()

--- a/projects/amdsmi/tests/python/functional/ifoe/test_fabric_lazy_init.py
+++ b/projects/amdsmi/tests/python/functional/ifoe/test_fabric_lazy_init.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) Advanced Micro Devices. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""Guards the lazy UALoE/IFoE session behavior.
+
+The per-GPU IFoE/UALoE generic-netlink session used to be opened in the
+AMDSmiGPUDevice constructor, so amdsmi_init() and every non-fabric query
+touched the IFoE driver and hung indefinitely when that driver was wedged.
+The session is now opened lazily on the first fabric query. These tests assert
+that init and non-fabric queries succeed without any fabric access, and that
+the first fabric query resolves cleanly (data or a normal status) rather than
+blocking.
+
+Note: the original failure needs a wedged IFoE driver (UALink hardware), which
+CI cannot reproduce. On healthy hardware these run fast; the elapsed-time bound
+documents the intent that these paths must not block.
+"""
+
+import time
+import unittest
+
+import common.common as common
+from common.common import amdsmi
+
+# Generous upper bound: init plus a per-GPU query completes in well under a
+# second on healthy hardware. The bound documents that these paths are not
+# allowed to block, without being tight enough to flake on a busy CI host.
+MAX_SECONDS = 30.0
+
+
+class TestFabricLazyInit(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.common = common.Common(common.verbose)
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            amdsmi.amdsmi_shut_down()
+        except amdsmi.AmdSmiLibraryException:
+            pass
+
+    def setUp(self):
+        # Skips (via SkipTest) when no compatible AMD drivers are present.
+        self.common.amdsmi_smart_init()
+        self.common.processors = amdsmi.amdsmi_get_processor_handles()
+
+    def tearDown(self):
+        amdsmi.amdsmi_shut_down()
+
+    def test_non_fabric_query_needs_no_fabric_session(self):
+        """Init plus a non-fabric query must succeed for every GPU."""
+        self.common.print_func_name("")
+        if not self.common.processors:
+            self.skipTest("No GPU processors detected")
+
+        start = time.monotonic()
+        for i, gpu in enumerate(self.common.processors):
+            self.common.print_device_header(i)
+            # asic info is a plain sysfs/DRM read, unrelated to fabric.
+            asic = amdsmi.amdsmi_get_gpu_asic_info(gpu)
+            self.assertIsInstance(asic, dict)
+        elapsed = time.monotonic() - start
+        self.assertLess(elapsed, MAX_SECONDS, f"Non-fabric queries took {elapsed:.2f}s")
+
+    def test_fabric_query_resolves_without_hanging(self):
+        """The first fabric query must return data or a normal status, not block."""
+        self.common.print_func_name("")
+        if not self.common.processors:
+            self.skipTest("No GPU processors detected")
+
+        start = time.monotonic()
+        for i, gpu in enumerate(self.common.processors):
+            self.common.print_device_header(i)
+            try:
+                info = amdsmi.amdsmi_get_gpu_fabric_info(gpu)
+                self.assertIsInstance(info, dict)
+            except amdsmi.AmdSmiLibraryException:
+                # Unsupported / not-a-UALink device: a clean status, not a hang.
+                pass
+        elapsed = time.monotonic() - start
+        self.assertLess(elapsed, MAX_SECONDS, f"Fabric queries took {elapsed:.2f}s")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

On UALink systems, `AMDSmiGPUDevice` opened the per-GPU **IFoE/UALoE generic-netlink** session in its **constructor**. When the Broadcom Thor Ultra `ifoe` driver is wedged (its firmware/MCDI not responding, holding the global generic-netlink lock), that `genl_ctrl_resolve("ifoe-cfg")` handshake blocks in an **uninterruptible (`D`-state) wait**. As a result `amdsmi_init(AMDSMI_INIT_AMD_GPUS)` — and therefore every `amd-smi` CLI verb — hung indefinitely, even for queries that never use fabric data. `SIGKILL`/`timeout` cannot recover it.

This was root-caused where `amd-smi version`, `amd-smi list`, and a pure `amdsmi_init(INIT_AMD_GPUS)` all wedged in `genl_rcv_msg`, while GPU sysfs/`rocminfo`/KFD were healthy.

## Fix

Open the UALoE session **lazily** on the first fabric query via `get_ualoe_handle()` (guarded by `std::once_flag`) instead of in the constructor. Initialization and non-fabric queries no longer touch the `ifoe` driver. Only an explicit UALink fabric query (`amdsmi_get_gpu_fabric_info` UALoE path / fabric telemetry) attempts the genl handshake, and only that query could stall on a wedged NIC.

A socket receive/send timeout was considered and rejected: the block is an uninterruptible in-kernel genl-mutex wait, which userspace socket timeouts cannot break. Not touching the driver unless asked is the correct fix.

- `src/amd_smi/amd_smi_gpu_device.cc`: remove `ualoe_open` from both ctors; add `open_ualoe_session()` and lazy `get_ualoe_handle()`.
- `include/amd_smi/impl/amd_smi_gpu_device.h`: lazy non-const `get_ualoe_handle()`, `std::once_flag`, `<mutex>`.
- `CHANGELOG.md`: Resolved Issues entry.

## JIRA ID

JIRA ID : AILITOOLS-284

## How tested

- Builds clean (`libamd_smi.so.26.5.0` links).
- **Verified on the affected hardware**: with the rebuilt library, `amdsmi_init(AMDSMI_INIT_AMD_GPUS)` returns `ret=0` in `0.00s` and `amdsmi_shut_down()` succeeds, versus a permanent `D`-state hang with the stock library.
- Not unit-testable in CI: reproduction requires UALink hardware with a wedged `ifoe` driver.