### PR TITLE
feat(amdsmi): implement unified amdsmi_get_link_topology on BM

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -134,6 +134,7 @@ GPU: 0
 - **Added unified `amdsmi_get_link_topology()` API (baremetal and host)**.  
   - New C API `amdsmi_get_link_topology()` returns a single `amdsmi_link_topology_t` aggregating link weight, link status, link type, hop count, and framebuffer-sharing capability between two GPUs.
   - New Python API `amdsmi_get_link_topology()` exposes the same data, mirroring the host interface for API parity.
+  - Behavior note for callers migrating from the component APIs: for a self-pair (identical source and destination), the call short-circuits to `link_type = AMDSMI_LINK_TYPE_INTERNAL`, `num_hops = 0`, `weight = 0`, `fb_sharing = 1`, and `link_status = AMDSMI_LINK_STATUS_ENABLED`. This is intentionally different from the underlying calls, where `amdsmi_topo_get_link_type(j, j)` reports PCIe with 2 hops and `amdsmi_topo_get_link_weight(j, j)` reports twice the NUMA node weight (typically 40).
 
 ### Changed
 

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -131,6 +131,10 @@ GPU: 0
   - Both are UALoE-backed and report `AMDSMI_STATUS_NOT_SUPPORTED` (or the `UINT32_MAX` sentinel for `physical_acc_id`) on systems without an active UALoE session.
   - CLI: `amd-smi static --asic` now includes `PHYSICAL_ACC_ID`; new `amd-smi node --tray`/`-T` flag prints tray type and accelerator count.
 
+- **Added unified `amdsmi_get_link_topology()` API (baremetal and host)**.  
+  - New C API `amdsmi_get_link_topology()` returns a single `amdsmi_link_topology_t` aggregating link weight, link status, link type, hop count, and framebuffer-sharing capability between two GPUs.
+  - New Python API `amdsmi_get_link_topology()` exposes the same data, mirroring the host interface for API parity.
+
 ### Changed
 
 - **Bumped the library major version to 27.0.0** (breaking).  

--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -5554,7 +5554,7 @@ Output:  Dictionary with fields:
 Field | Description
 ---|---
 `weight` | The link weight
-`link_status` | Link status as an int, derived from the resolved link type rather than live hardware state. On baremetal only `AMDSMI_LINK_STATUS_ENABLED` (0) and `AMDSMI_LINK_STATUS_DISABLED` (1) are produced; the enum also defines `AMDSMI_LINK_STATUS_INACTIVE` (2) and `AMDSMI_LINK_STATUS_ERROR` (3).
+`link_status` | Link status as an int, derived from the resolved link type rather than live hardware state. Every successful baremetal query resolves xGMI or PCIe, so a successful call always returns `AMDSMI_LINK_STATUS_ENABLED` (0); `AMDSMI_LINK_STATUS_DISABLED` (1) is only the initialized default returned with a failure status. The enum also defines `AMDSMI_LINK_STATUS_INACTIVE` (2) and `AMDSMI_LINK_STATUS_ERROR` (3), which are host-only.
 `link_type` | The connection type as an int. This should be translated according to the enum amdsmi_link_type_t. Refer to the example below for more details.
 `num_hops` | Number of hops
 `fb_sharing` | 1 if P2P framebuffer access is available between the two GPUs, 0 otherwise. Best-effort: 0 is also reported when the P2P query cannot be completed, which is indistinguishable from a genuine "not shared" result.

--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -5540,6 +5540,65 @@ finally:
     amdsmi.amdsmi_shut_down()
 ```
 
+### amdsmi_get_link_topology
+
+Description: Retrieve the unified link topology information between 2 GPUs. This aggregates the link weight, link status, link type, hop count, and framebuffer sharing capability into a single call, mirroring the host interface.
+
+Input parameters:
+
+* `processor_handle_src` the source device handle
+* `processor_handle_dst` the destination device handle
+
+Output:  Dictionary with fields:
+
+Field | Description
+---|---
+`weight` | The link weight
+`link_status` | Link status as an int, derived from the resolved link type rather than live hardware state. On baremetal only `AMDSMI_LINK_STATUS_ENABLED` (0) and `AMDSMI_LINK_STATUS_DISABLED` (1) are produced; the enum also defines `AMDSMI_LINK_STATUS_INACTIVE` (2) and `AMDSMI_LINK_STATUS_ERROR` (3).
+`link_type` | The connection type as an int. This should be translated according to the enum amdsmi_link_type_t. Refer to the example below for more details.
+`num_hops` | Number of hops
+`fb_sharing` | 1 if P2P framebuffer access is available between the two GPUs, 0 otherwise. Best-effort: 0 is also reported when the P2P query cannot be completed, which is indistinguishable from a genuine "not shared" result.
+
+Exceptions that can be thrown by `amdsmi_get_link_topology` function:
+
+* `AmdSmiLibraryException`
+* `AmdSmiParameterException`
+
+#### Possible Library Exceptions
+
+- `AMDSMI_STATUS_NOT_INIT` - Library not initialized
+- `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported
+- `AMDSMI_STATUS_INVAL` - Invalid parameters
+
+Example:
+
+```python
+import amdsmi
+try:
+    amdsmi.amdsmi_init()
+    devices = amdsmi.amdsmi_get_processor_handles()
+    if len(devices) == 0:
+        print("No GPUs on machine")
+    elif len(devices) == 1:
+        print("Only 1 GPU on machine")
+    else:
+        processor_handle_src = devices[0]
+        processor_handle_dst = devices[1]
+        topology = amdsmi.amdsmi_get_link_topology(processor_handle_src, processor_handle_dst)
+        print(topology['weight'])
+        print(topology['num_hops'])
+        print(topology['fb_sharing'])
+        print(topology['link_status'])
+        if topology['link_type'] == amdsmi.AmdSmiLinkType.AMDSMI_LINK_TYPE_XGMI:
+            print('xgmi')
+        if topology['link_type'] == amdsmi.AmdSmiLinkType.AMDSMI_LINK_TYPE_PCIE:
+            print('pcie')
+except amdsmi.AmdSmiException as e:
+    print(e)
+finally:
+    amdsmi.amdsmi_shut_down()
+```
+
 ### amdsmi_topo_get_p2p_status
 
 Description: Retrieve the connection type and P2P capabilities between 2 GPUs

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -6894,9 +6894,11 @@ amdsmi_status_t amdsmi_topo_get_link_type(amdsmi_processor_handle processor_hand
  *  ::amdsmi_topo_get_link_type, not the number of physical xGMI links.
  *
  *  @note On @platform{gpu_bm_linux}, @p link_status is derived from the resolved
- *  link type, not live hardware state. The source only resolves a concrete type
- *  on success, so a successful call always reports ::AMDSMI_LINK_STATUS_ENABLED;
- *  the DISABLED, INACTIVE, and ERROR states are not produced on baremetal.
+ *  link type, not live hardware state. Every successful query resolves either
+ *  xGMI or PCIe, so a successful call always reports ::AMDSMI_LINK_STATUS_ENABLED.
+ *  ::AMDSMI_LINK_STATUS_DISABLED is only the initialized default returned with a
+ *  failure status; ::AMDSMI_LINK_STATUS_INACTIVE and ::AMDSMI_LINK_STATUS_ERROR
+ *  are host-only and never produced on baremetal.
  *
  *  @note @p fb_sharing is best-effort: a P2P query that cannot complete is
  *  reported as 0, indistinguishable from a genuine "not shared" result.

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -1276,6 +1276,20 @@ typedef enum {
 } amdsmi_link_status_t;
 
 /**
+ * @brief Unified link topology information between two processors
+ *
+ * @cond @tag{gpu_bm_linux} @tag{host} @endcond
+ */
+typedef struct {
+  uint64_t weight;                   //!< link weight
+  amdsmi_link_status_t link_status;  //!< link status, derived from link type (not live HW status)
+  amdsmi_link_type_t link_type;      //!< type of the link
+  uint8_t num_hops;                  //!< number of hops
+  uint8_t fb_sharing;                //!< 1 if P2P framebuffer access is available, 0 otherwise
+  uint32_t reserved[10];
+} amdsmi_link_topology_t;
+
+/**
  * @brief Link Metrics
  *
  * @cond @tag{gpu_bm_linux} @tag{host} @endcond
@@ -6863,6 +6877,51 @@ amdsmi_status_t amdsmi_get_minmax_bandwidth_between_processors(
 amdsmi_status_t amdsmi_topo_get_link_type(amdsmi_processor_handle processor_handle_src,
                                           amdsmi_processor_handle processor_handle_dst,
                                           uint64_t* hops, amdsmi_link_type_t* type);
+
+/**
+ *  @brief Retrieve the unified link topology information between 2 GPUs
+ *
+ *  @ingroup tagHWTopology
+ *
+ *  @platform{gpu_bm_linux} @platform{host}
+ *
+ *  @details Writes the link weight, status, type, abstracted hop count, and
+ *  framebuffer sharing flag for the connection between @p processor_handle_src
+ *  and @p processor_handle_dst into @p topology_info.
+ *
+ *  This is the unified topology query that aggregates the information
+ *  otherwise obtained from ::amdsmi_topo_get_link_type and
+ *  ::amdsmi_topo_get_link_weight into a single ::amdsmi_link_topology_t
+ *  structure, matching the host interface.
+ *
+ *  @note The @p num_hops value is the abstracted topology step count reported
+ *  by ::amdsmi_topo_get_link_type, not the number of physical xGMI links.
+ *
+ *  @note On @platform{gpu_bm_linux}, the @p link_status is derived from link-type
+ *  resolvability rather than live hardware state: it is reported as
+ *  ::AMDSMI_LINK_STATUS_ENABLED when the connection resolves to a concrete link
+ *  type and ::AMDSMI_LINK_STATUS_DISABLED otherwise. The
+ *  ::AMDSMI_LINK_STATUS_INACTIVE and ::AMDSMI_LINK_STATUS_ERROR states are not
+ *  produced on baremetal.
+ *
+ *  @note The @p fb_sharing flag reflects whether the two devices can directly
+ *  access each other's framebuffer over P2P. It is best-effort: if the
+ *  underlying P2P-accessibility query cannot be completed @p fb_sharing is
+ *  reported as 0 (not shared), which is indistinguishable from a genuine
+ *  "not shared" result.
+ *
+ *  @param[in] processor_handle_src the source processor handle
+ *
+ *  @param[in] processor_handle_dst the destination processor handle
+ *
+ *  @param[out] topology_info A pointer to an ::amdsmi_link_topology_t to
+ *  which the link topology information should be written.
+ *
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
+ */
+amdsmi_status_t amdsmi_get_link_topology(amdsmi_processor_handle processor_handle_src,
+                                         amdsmi_processor_handle processor_handle_dst,
+                                         amdsmi_link_topology_t* topology_info);
 
 /**
  *  @brief Retrieve the set of GPUs that are nearest to a given device

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -6885,35 +6885,24 @@ amdsmi_status_t amdsmi_topo_get_link_type(amdsmi_processor_handle processor_hand
  *
  *  @platform{gpu_bm_linux} @platform{host}
  *
- *  @details Writes the link weight, status, type, abstracted hop count, and
- *  framebuffer sharing flag for the connection between @p processor_handle_src
- *  and @p processor_handle_dst into @p topology_info.
+ *  @details Aggregates the link weight, status, type, abstracted hop count, and
+ *  framebuffer-sharing flag for the connection between @p processor_handle_src
+ *  and @p processor_handle_dst into a single ::amdsmi_link_topology_t, mirroring
+ *  the host interface.
  *
- *  This is the unified topology query that aggregates the information
- *  otherwise obtained from ::amdsmi_topo_get_link_type and
- *  ::amdsmi_topo_get_link_weight into a single ::amdsmi_link_topology_t
- *  structure, matching the host interface.
+ *  @note @p num_hops is the abstracted topology step count from
+ *  ::amdsmi_topo_get_link_type, not the number of physical xGMI links.
  *
- *  @note The @p num_hops value is the abstracted topology step count reported
- *  by ::amdsmi_topo_get_link_type, not the number of physical xGMI links.
+ *  @note On @platform{gpu_bm_linux}, @p link_status is derived from the resolved
+ *  link type, not live hardware state. The source only resolves a concrete type
+ *  on success, so a successful call always reports ::AMDSMI_LINK_STATUS_ENABLED;
+ *  the DISABLED, INACTIVE, and ERROR states are not produced on baremetal.
  *
- *  @note On @platform{gpu_bm_linux}, the @p link_status is derived from link-type
- *  resolvability rather than live hardware state: it is reported as
- *  ::AMDSMI_LINK_STATUS_ENABLED when the connection resolves to a concrete link
- *  type and ::AMDSMI_LINK_STATUS_DISABLED otherwise. The
- *  ::AMDSMI_LINK_STATUS_INACTIVE and ::AMDSMI_LINK_STATUS_ERROR states are not
- *  produced on baremetal.
+ *  @note @p fb_sharing is best-effort: a P2P query that cannot complete is
+ *  reported as 0, indistinguishable from a genuine "not shared" result.
  *
- *  @note The @p fb_sharing flag reflects whether the two devices can directly
- *  access each other's framebuffer over P2P. It is best-effort: if the
- *  underlying P2P-accessibility query cannot be completed @p fb_sharing is
- *  reported as 0 (not shared), which is indistinguishable from a genuine
- *  "not shared" result.
- *
- *  @note The link type, weight, and framebuffer-sharing values are queried
- *  sequentially and not atomically, so a concurrent topology change between the
- *  individual queries may leave the returned fields reflecting slightly
- *  different points in time.
+ *  @note link type, weight, and fb_sharing are queried sequentially, not
+ *  atomically, so a concurrent topology change may skew the returned fields.
  *
  *  @param[in] processor_handle_src the source processor handle
  *

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -6910,6 +6910,11 @@ amdsmi_status_t amdsmi_topo_get_link_type(amdsmi_processor_handle processor_hand
  *  reported as 0 (not shared), which is indistinguishable from a genuine
  *  "not shared" result.
  *
+ *  @note The link type, weight, and framebuffer-sharing values are queried
+ *  sequentially and not atomically, so a concurrent topology change between the
+ *  individual queries may leave the returned fields reflecting slightly
+ *  different points in time.
+ *
  *  @param[in] processor_handle_src the source processor handle
  *
  *  @param[in] processor_handle_dst the destination processor handle

--- a/projects/amdsmi/py-interface/__init__.py
+++ b/projects/amdsmi/py-interface/__init__.py
@@ -258,6 +258,7 @@ from .amdsmi_interface import amdsmi_topo_get_link_weight
 from .amdsmi_interface import amdsmi_get_minmax_bandwidth_between_processors
 from .amdsmi_interface import amdsmi_get_link_metrics
 from .amdsmi_interface import amdsmi_topo_get_link_type
+from .amdsmi_interface import amdsmi_get_link_topology
 from .amdsmi_interface import amdsmi_topo_get_p2p_status
 from .amdsmi_interface import amdsmi_is_P2P_accessible
 from .amdsmi_interface import amdsmi_get_xgmi_info

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -4326,6 +4326,49 @@ def amdsmi_topo_get_link_type(
     return {"hops": hops_64.value, "type": type_32.value}
 
 
+def amdsmi_get_link_topology(
+    processor_handle_src: processor_handle_t, processor_handle_dst: processor_handle_t
+):
+    """Return the unified link topology information between two GPUs.
+
+    Aggregates link weight, link status, link type, abstracted hop count, and
+    the framebuffer-sharing flag into a single result, matching the host
+    ``amdsmi_get_link_topology`` interface.
+
+    Returns:
+        dict: ``{"weight": int, "link_status": int, "link_type": int,
+        "num_hops": int, "fb_sharing": int}`` where ``link_status`` is one of
+        the ``AMDSMI_LINK_STATUS_*`` values and ``link_type`` is one of the
+        ``AMDSMI_LINK_TYPE_*`` values.
+
+    Note:
+        ``fb_sharing`` is best-effort: it reports 0 both when P2P framebuffer
+        access is unavailable and when the underlying P2P query could not be
+        completed. The two cases are indistinguishable.
+    """
+    if not isinstance(processor_handle_src, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(processor_handle_src, amdsmi_wrapper.amdsmi_processor_handle)
+
+    if not isinstance(processor_handle_dst, amdsmi_wrapper.amdsmi_processor_handle):
+        raise AmdSmiParameterException(processor_handle_dst, amdsmi_wrapper.amdsmi_processor_handle)
+
+    topology_info = amdsmi_wrapper.amdsmi_link_topology_t()
+
+    _check_res(
+        amdsmi_wrapper.amdsmi_get_link_topology(
+            processor_handle_src, processor_handle_dst, ctypes.byref(topology_info)
+        )
+    )
+
+    return {
+        "weight": topology_info.weight,
+        "link_status": topology_info.link_status,
+        "link_type": topology_info.link_type,
+        "num_hops": topology_info.num_hops,
+        "fb_sharing": topology_info.fb_sharing,
+    }
+
+
 def amdsmi_topo_get_p2p_status(
     processor_handle_src: processor_handle_t, processor_handle_dst: processor_handle_t
 ):

--- a/projects/amdsmi/py-interface/amdsmi_wrapper.py
+++ b/projects/amdsmi/py-interface/amdsmi_wrapper.py
@@ -1445,6 +1445,23 @@ AMDSMI_LINK_STATUS_DISABLED = 1
 AMDSMI_LINK_STATUS_INACTIVE = 2
 AMDSMI_LINK_STATUS_ERROR = 3
 amdsmi_link_status_t = ctypes.c_uint32 # enum
+class struct_amdsmi_link_topology_t(Structure):
+    pass
+
+struct_amdsmi_link_topology_t._pack_ = 1 # source:False
+struct_amdsmi_link_topology_t._layout_ = 'ms'
+struct_amdsmi_link_topology_t._fields_ = [
+    ('weight', ctypes.c_uint64),
+    ('link_status', amdsmi_link_status_t),
+    ('link_type', amdsmi_link_type_t),
+    ('num_hops', ctypes.c_ubyte),
+    ('fb_sharing', ctypes.c_ubyte),
+    ('PADDING_0', ctypes.c_ubyte * 2),
+    ('reserved', ctypes.c_uint32 * 10),
+    ('PADDING_1', ctypes.c_ubyte * 4),
+]
+
+amdsmi_link_topology_t = struct_amdsmi_link_topology_t
 class struct_amdsmi_link_metrics_t(Structure):
     pass
 
@@ -4164,6 +4181,12 @@ try:
 except AttributeError:
     pass
 try:
+    amdsmi_get_link_topology = _libraries['libamd_smi.so'].amdsmi_get_link_topology
+    amdsmi_get_link_topology.restype = amdsmi_status_t
+    amdsmi_get_link_topology.argtypes = [amdsmi_processor_handle, amdsmi_processor_handle, ctypes.POINTER(struct_amdsmi_link_topology_t)]
+except AttributeError:
+    pass
+try:
     amdsmi_get_link_topology_nearest = _libraries['libamd_smi.so'].amdsmi_get_link_topology_nearest
     amdsmi_get_link_topology_nearest.restype = amdsmi_status_t
     amdsmi_get_link_topology_nearest.argtypes = [amdsmi_processor_handle, amdsmi_link_type_t, ctypes.POINTER(struct_amdsmi_topology_nearest_t)]
@@ -5456,7 +5479,8 @@ __all__ = \
     'amdsmi_get_gpu_xcd_counter', 'amdsmi_get_gpu_xgmi_link_status',
     'amdsmi_get_hsmp_metrics_table',
     'amdsmi_get_hsmp_metrics_table_version', 'amdsmi_get_lib_version',
-    'amdsmi_get_link_metrics', 'amdsmi_get_link_topology_nearest',
+    'amdsmi_get_link_metrics', 'amdsmi_get_link_topology',
+    'amdsmi_get_link_topology_nearest',
     'amdsmi_get_minmax_bandwidth_between_processors',
     'amdsmi_get_nic_asic_info', 'amdsmi_get_nic_bus_info',
     'amdsmi_get_nic_device_bdf', 'amdsmi_get_nic_driver_info',
@@ -5492,8 +5516,9 @@ __all__ = \
     'amdsmi_io_bw_encoding_t', 'amdsmi_is_P2P_accessible',
     'amdsmi_is_gpu_power_management_enabled', 'amdsmi_kfd_info_t',
     'amdsmi_link_id_bw_type_t', 'amdsmi_link_metrics_t',
-    'amdsmi_link_status_t', 'amdsmi_link_type_t',
-    'amdsmi_memory_page_status_t', 'amdsmi_memory_partition_config_t',
+    'amdsmi_link_status_t', 'amdsmi_link_topology_t',
+    'amdsmi_link_type_t', 'amdsmi_memory_page_status_t',
+    'amdsmi_memory_partition_config_t',
     'amdsmi_memory_partition_type_t', 'amdsmi_memory_type_t',
     'amdsmi_mm_ip_t', 'amdsmi_name_value_t', 'amdsmi_nic_asic_info_t',
     'amdsmi_nic_bus_info_t', 'amdsmi_nic_driver_info_t',
@@ -5596,6 +5621,7 @@ __all__ = \
     'struct_amdsmi_hsmp_driver_version_t',
     'struct_amdsmi_hsmp_metrics_table_t', 'struct_amdsmi_kfd_info_t',
     'struct_amdsmi_link_id_bw_type_t', 'struct_amdsmi_link_metrics_t',
+    'struct_amdsmi_link_topology_t',
     'struct_amdsmi_memory_partition_config_t',
     'struct_amdsmi_name_value_t', 'struct_amdsmi_nic_asic_info_t',
     'struct_amdsmi_nic_bus_info_t', 'struct_amdsmi_nic_driver_info_t',

--- a/projects/amdsmi/rust-interface/src/amdsmi.rs
+++ b/projects/amdsmi/rust-interface/src/amdsmi.rs
@@ -6223,6 +6223,62 @@ pub fn amdsmi_get_link_topology_nearest(
     Ok(topology_nearest_info)
 }
 
+/// Retrieve the unified link topology information between two processors.
+///
+/// This function retrieves the link weight, status, type, hop count, and framebuffer sharing flag for the connection between the source and destination processor handles.
+///
+/// # Arguments
+///
+/// * `processor_handle_src` - A handle to the source processor.
+/// * `processor_handle_dst` - A handle to the destination processor.
+///
+/// # Returns
+///
+/// * `AmdsmiResult<AmdsmiLinkTopologyT>` - Returns `Ok(AmdsmiLinkTopologyT)` containing the [`AmdsmiLinkTopologyT`] if successful, or an error if it fails.
+///
+/// # Example
+///
+/// ```rust
+/// # use amdsmi::*;
+/// #
+/// # fn main() {
+/// #   // Initialize the AMD SMI library
+/// #   amdsmi_init(AmdsmiInitFlagsT::AmdsmiInitAmdGpus).expect("Failed to initialize AMD SMI");
+/// #
+///     // Example processor handles, assuming the number of processors is greater than zero
+///     let processor_handles = amdsmi_get_processor_handles!();
+///     let processor_handle_src = processor_handles[0];
+///     let processor_handle_dst = processor_handles[processor_handles.len() - 1];
+///
+///     match amdsmi_get_link_topology(processor_handle_src, processor_handle_dst) {
+///         Ok(info) => {
+///             println!("Link Topology Info: {:?}", info);
+///         },
+///         Err(e) => println!("Failed to retrieve link topology information: {}", e),
+///     }
+/// #
+/// #   // Shut down the AMD SMI library
+/// #   amdsmi_shut_down().expect("Failed to shut down AMD SMI");
+/// # }
+/// ```
+///
+/// # Errors
+///
+/// This function will return the error in [`AmdsmiStatusT`] if the underlying `amdsmi_wrapper::amdsmi_get_link_topology` call fails.
+pub fn amdsmi_get_link_topology(
+    processor_handle_src: AmdsmiProcessorHandle,
+    processor_handle_dst: AmdsmiProcessorHandle,
+) -> AmdsmiResult<AmdsmiLinkTopologyT> {
+    let mut topology_info = MaybeUninit::<AmdsmiLinkTopologyT>::uninit();
+    call_unsafe!(amdsmi_wrapper::amdsmi_get_link_topology(
+        processor_handle_src,
+        processor_handle_dst,
+        topology_info.as_mut_ptr()
+    ));
+    let topology_info = unsafe { topology_info.assume_init() };
+    Ok(topology_info)
+}
+
 /// A macro to get all the GPU processor handles directly.
 ///
 /// This macro retrieves all the GPU processor handles by first getting the socket handles

--- a/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
+++ b/projects/amdsmi/rust-interface/src/amdsmi_wrapper.rs
@@ -1584,6 +1584,33 @@ pub enum AmdsmiLinkStatusT {
     AmdsmiLinkStatusError = 3,
 }
 #[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct AmdsmiLinkTopologyT {
+    pub weight: u64,
+    pub link_status: AmdsmiLinkStatusT,
+    pub link_type: AmdsmiLinkTypeT,
+    pub num_hops: u8,
+    pub fb_sharing: u8,
+    pub reserved: [u32; 10usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of AmdsmiLinkTopologyT"][::std::mem::size_of::<AmdsmiLinkTopologyT>() - 64usize];
+    ["Alignment of AmdsmiLinkTopologyT"][::std::mem::align_of::<AmdsmiLinkTopologyT>() - 8usize];
+    ["Offset of field: AmdsmiLinkTopologyT::weight"]
+        [::std::mem::offset_of!(AmdsmiLinkTopologyT, weight) - 0usize];
+    ["Offset of field: AmdsmiLinkTopologyT::link_status"]
+        [::std::mem::offset_of!(AmdsmiLinkTopologyT, link_status) - 8usize];
+    ["Offset of field: AmdsmiLinkTopologyT::link_type"]
+        [::std::mem::offset_of!(AmdsmiLinkTopologyT, link_type) - 12usize];
+    ["Offset of field: AmdsmiLinkTopologyT::num_hops"]
+        [::std::mem::offset_of!(AmdsmiLinkTopologyT, num_hops) - 16usize];
+    ["Offset of field: AmdsmiLinkTopologyT::fb_sharing"]
+        [::std::mem::offset_of!(AmdsmiLinkTopologyT, fb_sharing) - 17usize];
+    ["Offset of field: AmdsmiLinkTopologyT::reserved"]
+        [::std::mem::offset_of!(AmdsmiLinkTopologyT, reserved) - 20usize];
+};
+#[repr(C)]
 #[derive(Copy, Clone)]
 pub struct AmdsmiLinkMetricsT {
     pub num_links: u32,
@@ -4918,6 +4945,13 @@ extern "C" {
         processor_handle_dst: AmdsmiProcessorHandle,
         hops: *mut u64,
         type_: *mut AmdsmiLinkTypeT,
+    ) -> AmdsmiStatusT;
+}
+extern "C" {
+    pub fn amdsmi_get_link_topology(
+        processor_handle_src: AmdsmiProcessorHandle,
+        processor_handle_dst: AmdsmiProcessorHandle,
+        topology_info: *mut AmdsmiLinkTopologyT,
     ) -> AmdsmiStatusT;
 }
 extern "C" {

--- a/projects/amdsmi/rust-interface/src/utils.rs
+++ b/projects/amdsmi/rust-interface/src/utils.rs
@@ -24,7 +24,7 @@ pub use crate::amdsmi_wrapper::{
     AmdsmiDriverInfoT, AmdsmiEngineUsageT, AmdsmiErrorCountT, AmdsmiEvtNotificationDataT,
     AmdsmiFreqVoltRegionT, AmdsmiFrequenciesT, AmdsmiFrequencyRangeT, AmdsmiFwInfoT,
     AmdsmiGpuCacheInfoT, AmdsmiGpuCacheInfoTCache, AmdsmiGpuMetricsT, AmdsmiKfdInfoT,
-    AmdsmiLinkMetricsT, AmdsmiLinkMetricsTLinks, AmdsmiNameValueT,
+    AmdsmiLinkMetricsT, AmdsmiLinkMetricsTLinks, AmdsmiLinkTopologyT, AmdsmiNameValueT,
     AmdsmiOdVoltFreqDataT, AmdsmiP2pCapabilityT, AmdsmiPcieBandwidthT, AmdsmiPcieInfoT,
     AmdsmiPcieInfoTPcieMetric, AmdsmiPcieInfoTPcieStatic, AmdsmiPowerCapInfoT, AmdsmiPowerInfoT,
     AmdsmiPowerProfileStatusT, AmdsmiProcInfoT, AmdsmiProcInfoTEngineUsage,

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -3276,6 +3276,23 @@ amdsmi_status_t amdsmi_get_link_topology(amdsmi_processor_handle processor_handl
   uint32_t src_id = src_device->get_gpu_id();
   uint32_t dst_id = dst_device->get_gpu_id();
 
+#ifdef ENABLE_WSL_BACKEND
+  // WSL exposes a single WDDM adapter with no xGMI fabric, so the native sysfs
+  // topology calls below do not apply. Mirror amdsmi_topo_get_link_type here: a
+  // self-pair is INTERNAL, any peer is a single PCIe hop.
+  if (src_device->backend() || dst_device->backend()) {
+    if (src_device == dst_device) {
+      topology_info->link_type = AMDSMI_LINK_TYPE_INTERNAL;
+      topology_info->fb_sharing = 1;
+    } else {
+      topology_info->link_type = AMDSMI_LINK_TYPE_PCIE;
+      topology_info->num_hops = 1;
+    }
+    topology_info->link_status = AMDSMI_LINK_STATUS_ENABLED;
+    return AMDSMI_STATUS_SUCCESS;
+  }
+#endif
+
   // A device has no link to itself; report a trivial internal, shared result.
   if (src_id == dst_id) {
     topology_info->link_type = AMDSMI_LINK_TYPE_INTERNAL;

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -154,6 +154,24 @@ static_assert(offsetof(rsmi_gpu_metrics_t, apu_metrics) ==
                   offsetof(amdsmi_gpu_metrics_t, apu_metrics),
               "GPU metrics: apu_metrics (last field) offset mismatch");
 
+// amdsmi_link_topology_t crosses the baremetal/host ABI boundary and is consumed
+// by the generated Python bindings, so its 64-byte layout must stay in lockstep
+// with the host definition; guard the size and field offsets at compile time.
+static_assert(sizeof(amdsmi_link_topology_t) == 64,
+              "amdsmi_link_topology_t must remain 64 bytes to match the published ABI");
+static_assert(offsetof(amdsmi_link_topology_t, weight) == 0,
+              "amdsmi_link_topology_t: weight offset mismatch");
+static_assert(offsetof(amdsmi_link_topology_t, link_status) == 8,
+              "amdsmi_link_topology_t: link_status offset mismatch");
+static_assert(offsetof(amdsmi_link_topology_t, link_type) == 12,
+              "amdsmi_link_topology_t: link_type offset mismatch");
+static_assert(offsetof(amdsmi_link_topology_t, num_hops) == 16,
+              "amdsmi_link_topology_t: num_hops offset mismatch");
+static_assert(offsetof(amdsmi_link_topology_t, fb_sharing) == 17,
+              "amdsmi_link_topology_t: fb_sharing offset mismatch");
+static_assert(offsetof(amdsmi_link_topology_t, reserved) == 20,
+              "amdsmi_link_topology_t: reserved offset mismatch");
+
 static void copy_rsmi_gpu_metrics_to_amdsmi(const rsmi_gpu_metrics_t& rsmi_metrics,
                                             amdsmi_gpu_metrics_t* amdsmi_metrics) {
   if (amdsmi_metrics == nullptr) return;
@@ -3233,6 +3251,72 @@ amdsmi_status_t amdsmi_topo_get_p2p_status(amdsmi_processor_handle processor_han
                                           reinterpret_cast<RSMI_IO_LINK_TYPE*>(type),
                                           reinterpret_cast<rsmi_p2p_capability_t*>(cap));
   return amd::smi::rsmi_to_amdsmi_status(rstatus);
+}
+
+amdsmi_status_t amdsmi_get_link_topology(amdsmi_processor_handle processor_handle_src,
+                                         amdsmi_processor_handle processor_handle_dst,
+                                         amdsmi_link_topology_t* topology_info) {
+  AMDSMI_CHECK_INIT();
+
+  if (topology_info == nullptr) {
+    return AMDSMI_STATUS_INVAL;
+  }
+
+  // Zero-initialize up front so every error path leaves the caller with a
+  // well-defined topology rather than a partially filled one.
+  *topology_info = {};
+  topology_info->link_type = AMDSMI_LINK_TYPE_UNKNOWN;
+  topology_info->link_status = AMDSMI_LINK_STATUS_DISABLED;
+
+  amd::smi::AMDSmiGPUDevice* src_device = nullptr;
+  amd::smi::AMDSmiGPUDevice* dst_device = nullptr;
+  amdsmi_status_t r = get_gpu_device_from_handle(processor_handle_src, &src_device);
+  if (r != AMDSMI_STATUS_SUCCESS) return r;
+  r = get_gpu_device_from_handle(processor_handle_dst, &dst_device);
+  if (r != AMDSMI_STATUS_SUCCESS) return r;
+
+  uint32_t src_id = src_device->get_gpu_id();
+  uint32_t dst_id = dst_device->get_gpu_id();
+
+  // rsmi_topo_get_link_type writes an RSMI_IO_LINK_TYPE through the cast below, so
+  // amdsmi_link_type_t must be at least as wide to avoid an out-of-bounds write.
+  static_assert(sizeof(amdsmi_link_type_t) >= sizeof(RSMI_IO_LINK_TYPE),
+                "amdsmi_link_type_t must be at least as wide as RSMI_IO_LINK_TYPE");
+
+  uint64_t hops = 0;
+  amdsmi_link_type_t link_type = AMDSMI_LINK_TYPE_UNKNOWN;
+  amdsmi_status_t status = amd::smi::rsmi_to_amdsmi_status(rsmi_topo_get_link_type(
+      src_id, dst_id, &hops, reinterpret_cast<RSMI_IO_LINK_TYPE*>(&link_type)));
+  if (status != AMDSMI_STATUS_SUCCESS) return status;
+
+  uint64_t weight = 0;
+  status = amd::smi::rsmi_to_amdsmi_status(rsmi_topo_get_link_weight(src_id, dst_id, &weight));
+  if (status != AMDSMI_STATUS_SUCCESS) return status;
+
+  // Framebuffer sharing: two GPUs can share framebuffer memory when they are
+  // P2P-accessible (e.g. same xGMI hive). Best-effort: a missing P2P result
+  // must not fail the query.
+  uint8_t fb_sharing = 0;
+  bool accessible = false;
+  if (amd::smi::rsmi_to_amdsmi_status(rsmi_is_P2P_accessible(src_id, dst_id, &accessible)) ==
+      AMDSMI_STATUS_SUCCESS) {
+    fb_sharing = accessible ? 1 : 0;
+  }
+
+  topology_info->link_type = link_type;
+  // num_hops is a small step count; clamp to the uint8_t range instead of
+  // wrapping.
+  topology_info->num_hops = hops > 255 ? 255 : static_cast<uint8_t>(hops);
+  topology_info->weight = weight;
+  // link_status is derived, not read from hardware: a concrete resolved type is
+  // ENABLED; NOT_APPLICABLE and UNKNOWN map to DISABLED.
+  topology_info->link_status =
+      (link_type == AMDSMI_LINK_TYPE_NOT_APPLICABLE || link_type == AMDSMI_LINK_TYPE_UNKNOWN)
+          ? AMDSMI_LINK_STATUS_DISABLED
+          : AMDSMI_LINK_STATUS_ENABLED;
+  topology_info->fb_sharing = fb_sharing;
+
+  return AMDSMI_STATUS_SUCCESS;
 }
 
 // Compute Partition functions

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -3295,7 +3295,9 @@ amdsmi_status_t amdsmi_get_link_topology(amdsmi_processor_handle processor_handl
 
   // Framebuffer sharing: two GPUs can share framebuffer memory when they are
   // P2P-accessible (e.g. same xGMI hive). Best-effort: a missing P2P result
-  // must not fail the query.
+  // must not fail the query. A failed or unsupported P2P query is reported the
+  // same as "not shared" (fb_sharing = 0); callers that must tell the two apart
+  // should call amdsmi_is_P2P_accessible() directly.
   uint8_t fb_sharing = 0;
   bool accessible = false;
   if (amd::smi::rsmi_to_amdsmi_status(rsmi_is_P2P_accessible(src_id, dst_id, &accessible)) ==

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -154,9 +154,8 @@ static_assert(offsetof(rsmi_gpu_metrics_t, apu_metrics) ==
                   offsetof(amdsmi_gpu_metrics_t, apu_metrics),
               "GPU metrics: apu_metrics (last field) offset mismatch");
 
-// amdsmi_link_topology_t crosses the baremetal/host ABI boundary and is consumed
-// by the generated Python bindings, so its 64-byte layout must stay in lockstep
-// with the host definition; guard the size and field offsets at compile time.
+// amdsmi_link_topology_t is part of the published ABI; guard its size and field
+// offsets so the layout stays in lockstep with the host definition.
 static_assert(sizeof(amdsmi_link_topology_t) == 64,
               "amdsmi_link_topology_t must remain 64 bytes to match the published ABI");
 static_assert(offsetof(amdsmi_link_topology_t, weight) == 0,
@@ -3262,8 +3261,7 @@ amdsmi_status_t amdsmi_get_link_topology(amdsmi_processor_handle processor_handl
     return AMDSMI_STATUS_INVAL;
   }
 
-  // Zero-initialize up front so every error path leaves the caller with a
-  // well-defined topology rather than a partially filled one.
+  // Well-defined defaults so every error path leaves a coherent result.
   *topology_info = {};
   topology_info->link_type = AMDSMI_LINK_TYPE_UNKNOWN;
   topology_info->link_status = AMDSMI_LINK_STATUS_DISABLED;
@@ -3278,26 +3276,40 @@ amdsmi_status_t amdsmi_get_link_topology(amdsmi_processor_handle processor_handl
   uint32_t src_id = src_device->get_gpu_id();
   uint32_t dst_id = dst_device->get_gpu_id();
 
-  // rsmi_topo_get_link_type writes an RSMI_IO_LINK_TYPE through the cast below, so
-  // amdsmi_link_type_t must be at least as wide to avoid an out-of-bounds write.
-  static_assert(sizeof(amdsmi_link_type_t) >= sizeof(RSMI_IO_LINK_TYPE),
-                "amdsmi_link_type_t must be at least as wide as RSMI_IO_LINK_TYPE");
+  // A device has no link to itself; report a trivial internal, shared result.
+  if (src_id == dst_id) {
+    topology_info->link_type = AMDSMI_LINK_TYPE_INTERNAL;
+    topology_info->link_status = AMDSMI_LINK_STATUS_ENABLED;
+    topology_info->fb_sharing = 1;
+    return AMDSMI_STATUS_SUCCESS;
+  }
 
   uint64_t hops = 0;
-  amdsmi_link_type_t link_type = AMDSMI_LINK_TYPE_UNKNOWN;
-  amdsmi_status_t status = amd::smi::rsmi_to_amdsmi_status(rsmi_topo_get_link_type(
-      src_id, dst_id, &hops, reinterpret_cast<RSMI_IO_LINK_TYPE*>(&link_type)));
+  RSMI_IO_LINK_TYPE rsmi_type = RSMI_IOLINK_TYPE_UNDEFINED;
+  amdsmi_status_t status =
+      amd::smi::rsmi_to_amdsmi_status(rsmi_topo_get_link_type(src_id, dst_id, &hops, &rsmi_type));
   if (status != AMDSMI_STATUS_SUCCESS) return status;
+
+  // Map explicitly: only PCIe and xGMI share values between the rsmi and amdsmi
+  // link-type enums, so a reinterpret cast would misread the other enumerators.
+  amdsmi_link_type_t link_type;
+  switch (rsmi_type) {
+    case RSMI_IOLINK_TYPE_PCIEXPRESS:
+      link_type = AMDSMI_LINK_TYPE_PCIE;
+      break;
+    case RSMI_IOLINK_TYPE_XGMI:
+      link_type = AMDSMI_LINK_TYPE_XGMI;
+      break;
+    default:
+      link_type = AMDSMI_LINK_TYPE_UNKNOWN;
+      break;
+  }
 
   uint64_t weight = 0;
   status = amd::smi::rsmi_to_amdsmi_status(rsmi_topo_get_link_weight(src_id, dst_id, &weight));
   if (status != AMDSMI_STATUS_SUCCESS) return status;
 
-  // Framebuffer sharing: two GPUs can share framebuffer memory when they are
-  // P2P-accessible (e.g. same xGMI hive). Best-effort: a missing P2P result
-  // must not fail the query. A failed or unsupported P2P query is reported the
-  // same as "not shared" (fb_sharing = 0); callers that must tell the two apart
-  // should call amdsmi_is_P2P_accessible() directly.
+  // Best-effort P2P framebuffer sharing; a failed query stays 0 (not shared).
   uint8_t fb_sharing = 0;
   bool accessible = false;
   if (amd::smi::rsmi_to_amdsmi_status(rsmi_is_P2P_accessible(src_id, dst_id, &accessible)) ==
@@ -3306,16 +3318,11 @@ amdsmi_status_t amdsmi_get_link_topology(amdsmi_processor_handle processor_handl
   }
 
   topology_info->link_type = link_type;
-  // num_hops is a small step count; clamp to the uint8_t range instead of
-  // wrapping.
-  topology_info->num_hops = hops > 255 ? 255 : static_cast<uint8_t>(hops);
+  topology_info->num_hops = hops > 255 ? 255 : static_cast<uint8_t>(hops);  // clamp to uint8_t
   topology_info->weight = weight;
-  // link_status is derived, not read from hardware: a concrete resolved type is
-  // ENABLED; NOT_APPLICABLE and UNKNOWN map to DISABLED.
-  topology_info->link_status =
-      (link_type == AMDSMI_LINK_TYPE_NOT_APPLICABLE || link_type == AMDSMI_LINK_TYPE_UNKNOWN)
-          ? AMDSMI_LINK_STATUS_DISABLED
-          : AMDSMI_LINK_STATUS_ENABLED;
+  // Derived, not read from hardware: a concrete type is ENABLED, UNKNOWN is DISABLED.
+  topology_info->link_status = (link_type == AMDSMI_LINK_TYPE_UNKNOWN) ? AMDSMI_LINK_STATUS_DISABLED
+                                                                       : AMDSMI_LINK_STATUS_ENABLED;
   topology_info->fb_sharing = fb_sharing;
 
   return AMDSMI_STATUS_SUCCESS;

--- a/projects/amdsmi/tests/amd_smi_test/functional/system/hw_topology_read_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/system/hw_topology_read_test.cc
@@ -107,12 +107,34 @@ void TestHWTopologyRead::Run(void) {
     for (uint32_t dv_ind_dst = 0; dv_ind_dst < num_devices; dv_ind_dst++) {
       if (dv_ind_src == dv_ind_dst) {
         gpu_links[dv_ind_src][dv_ind_dst].type = "X";
-        gpu_links[dv_ind_src][dv_ind_dst].link_type = AMDSMI_LINK_TYPE_UNKNOWN;
+        gpu_links[dv_ind_src][dv_ind_dst].link_type = AMDSMI_LINK_TYPE_INTERNAL;
         gpu_links[dv_ind_src][dv_ind_dst].hops = 0;
         gpu_links[dv_ind_src][dv_ind_dst].weight = 0;
         gpu_links[dv_ind_src][dv_ind_dst].accessible = true;
         gpu_links[dv_ind_src][dv_ind_dst].cap = {UINT8_MAX, UINT8_MAX, UINT8_MAX, UINT8_MAX,
                                                  UINT8_MAX};
+
+        // Self-pair: the unified API short-circuits a device to itself.
+        amdsmi_link_topology_t self_topology = {};
+        DISPLAY_AMDSMI_API("amdsmi_get_link_topology",
+                           "gpu=" + std::to_string(dv_ind_src) + "," + std::to_string(dv_ind_dst),
+                           VERB(STANDARD));
+        err = amdsmi_get_link_topology(processor_handles_[dv_ind_src],
+                                       processor_handles_[dv_ind_dst], &self_topology);
+        DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, err, AMDSMI_STATUS_SUCCESS);
+        if (err != AMDSMI_STATUS_SUCCESS) {
+          if (err == AMDSMI_STATUS_NOT_SUPPORTED) {
+            return;
+          } else {
+            CHK_ERR_ASRT(err)
+          }
+        } else {
+          EXPECT_EQ(self_topology.link_type, AMDSMI_LINK_TYPE_INTERNAL);
+          EXPECT_EQ(self_topology.link_status, AMDSMI_LINK_STATUS_ENABLED);
+          EXPECT_EQ(self_topology.num_hops, 0);
+          EXPECT_EQ(self_topology.weight, static_cast<uint64_t>(0));
+          EXPECT_EQ(self_topology.fb_sharing, 1);
+        }
       } else {
         amdsmi_link_type_t type;
         DISPLAY_AMDSMI_API("amdsmi_topo_get_link_type",

--- a/projects/amdsmi/tests/amd_smi_test/functional/system/hw_topology_read_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/system/hw_topology_read_test.cc
@@ -18,6 +18,7 @@
 
 typedef struct {
   std::string type;
+  amdsmi_link_type_t link_type;
   uint64_t hops;
   uint64_t weight;
   bool accessible;
@@ -106,6 +107,7 @@ void TestHWTopologyRead::Run(void) {
     for (uint32_t dv_ind_dst = 0; dv_ind_dst < num_devices; dv_ind_dst++) {
       if (dv_ind_src == dv_ind_dst) {
         gpu_links[dv_ind_src][dv_ind_dst].type = "X";
+        gpu_links[dv_ind_src][dv_ind_dst].link_type = AMDSMI_LINK_TYPE_UNKNOWN;
         gpu_links[dv_ind_src][dv_ind_dst].hops = 0;
         gpu_links[dv_ind_src][dv_ind_dst].weight = 0;
         gpu_links[dv_ind_src][dv_ind_dst].accessible = true;
@@ -127,6 +129,7 @@ void TestHWTopologyRead::Run(void) {
             CHK_ERR_ASRT(err)
           }
         } else {
+          gpu_links[dv_ind_src][dv_ind_dst].link_type = type;
           switch (type) {
             case AMDSMI_LINK_TYPE_PCIE:
               gpu_links[dv_ind_src][dv_ind_dst].type = "PCIE";
@@ -217,6 +220,7 @@ void TestHWTopologyRead::Run(void) {
           // The unified API must agree with the component queries it aggregates.
           const gpu_link_t& link = gpu_links[dv_ind_src][dv_ind_dst];
           EXPECT_EQ(topology.weight, link.weight);
+          EXPECT_EQ(topology.link_type, link.link_type);
           EXPECT_EQ(topology.num_hops, link.hops > 255 ? 255 : static_cast<uint8_t>(link.hops));
           EXPECT_EQ(topology.fb_sharing, link.accessible ? 1 : 0);
           if (topology.link_type == AMDSMI_LINK_TYPE_NOT_APPLICABLE ||

--- a/projects/amdsmi/tests/amd_smi_test/functional/system/hw_topology_read_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/system/hw_topology_read_test.cc
@@ -201,8 +201,7 @@ void TestHWTopologyRead::Run(void) {
           }
         }
 
-        // Unified topology query: exercises amdsmi_get_link_topology on real
-        // hardware and cross-checks it against the individual queries above.
+        // Unified query: cross-check amdsmi_get_link_topology against the components.
         amdsmi_link_topology_t topology = {};
         DISPLAY_AMDSMI_API("amdsmi_get_link_topology",
                            "gpu=" + std::to_string(dv_ind_src) + "," + std::to_string(dv_ind_dst),
@@ -223,12 +222,11 @@ void TestHWTopologyRead::Run(void) {
           EXPECT_EQ(topology.link_type, link.link_type);
           EXPECT_EQ(topology.num_hops, link.hops > 255 ? 255 : static_cast<uint8_t>(link.hops));
           EXPECT_EQ(topology.fb_sharing, link.accessible ? 1 : 0);
-          if (topology.link_type == AMDSMI_LINK_TYPE_NOT_APPLICABLE ||
-              topology.link_type == AMDSMI_LINK_TYPE_UNKNOWN) {
-            EXPECT_EQ(topology.link_status, AMDSMI_LINK_STATUS_DISABLED);
-          } else {
-            EXPECT_EQ(topology.link_status, AMDSMI_LINK_STATUS_ENABLED);
-          }
+          // A successful query resolves PCIe or xGMI, so status must be ENABLED.
+          // This fires if the code ever resolves another type on success.
+          EXPECT_TRUE(topology.link_type == AMDSMI_LINK_TYPE_PCIE ||
+                      topology.link_type == AMDSMI_LINK_TYPE_XGMI);
+          EXPECT_EQ(topology.link_status, AMDSMI_LINK_STATUS_ENABLED);
         }
       }
     }

--- a/projects/amdsmi/tests/amd_smi_test/functional/system/hw_topology_read_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/system/hw_topology_read_test.cc
@@ -197,6 +197,35 @@ void TestHWTopologyRead::Run(void) {
             CHK_ERR_ASRT(err)
           }
         }
+
+        // Unified topology query: exercises amdsmi_get_link_topology on real
+        // hardware and cross-checks it against the individual queries above.
+        amdsmi_link_topology_t topology = {};
+        DISPLAY_AMDSMI_API("amdsmi_get_link_topology",
+                           "gpu=" + std::to_string(dv_ind_src) + "," + std::to_string(dv_ind_dst),
+                           VERB(STANDARD));
+        err = amdsmi_get_link_topology(processor_handles_[dv_ind_src],
+                                       processor_handles_[dv_ind_dst], &topology);
+        DISPLAY_AMDSMI_STATUS(VERB(STANDARD), __FILE__, __LINE__, err, AMDSMI_STATUS_SUCCESS);
+        if (err != AMDSMI_STATUS_SUCCESS) {
+          if (err == AMDSMI_STATUS_NOT_SUPPORTED) {
+            return;
+          } else {
+            CHK_ERR_ASRT(err)
+          }
+        } else {
+          // The unified API must agree with the component queries it aggregates.
+          const gpu_link_t& link = gpu_links[dv_ind_src][dv_ind_dst];
+          EXPECT_EQ(topology.weight, link.weight);
+          EXPECT_EQ(topology.num_hops, link.hops > 255 ? 255 : static_cast<uint8_t>(link.hops));
+          EXPECT_EQ(topology.fb_sharing, link.accessible ? 1 : 0);
+          if (topology.link_type == AMDSMI_LINK_TYPE_NOT_APPLICABLE ||
+              topology.link_type == AMDSMI_LINK_TYPE_UNKNOWN) {
+            EXPECT_EQ(topology.link_status, AMDSMI_LINK_STATUS_DISABLED);
+          } else {
+            EXPECT_EQ(topology.link_status, AMDSMI_LINK_STATUS_ENABLED);
+          }
+        }
       }
     }
   }

--- a/projects/amdsmi/tests/python/unit/system/test_link_topology.py
+++ b/projects/amdsmi/tests/python/unit/system/test_link_topology.py
@@ -88,28 +88,3 @@ class TestLinkTopology(unittest.TestCase):
         self.assertEqual(result["link_type"], 2)
         self.assertEqual(result["num_hops"], 3)
         self.assertEqual(result["fb_sharing"], 1)
-
-    def test_disabled_link_maps_status_and_capped_hops(self):
-        # Complements the enabled case: disabled mapping and capped (255) hops.
-        src = amdsmi.amdsmi_wrapper.amdsmi_processor_handle()
-        dst = amdsmi.amdsmi_wrapper.amdsmi_processor_handle()
-
-        def _fill(_src, _dst, topology_ref):
-            topology = topology_ref._obj
-            topology.weight = 0
-            topology.link_status = amdsmi.amdsmi_wrapper.AMDSMI_LINK_STATUS_DISABLED
-            topology.link_type = amdsmi.amdsmi_wrapper.AMDSMI_LINK_TYPE_NOT_APPLICABLE
-            topology.num_hops = 255
-            topology.fb_sharing = 0
-            return 0
-
-        with mock.patch.object(
-            amdsmi.amdsmi_wrapper, "amdsmi_get_link_topology", side_effect=_fill
-        ):
-            result = amdsmi.amdsmi_interface.amdsmi_get_link_topology(src, dst)
-
-        self.assertEqual(result["link_status"], amdsmi.amdsmi_wrapper.AMDSMI_LINK_STATUS_DISABLED)
-        self.assertEqual(result["link_type"], amdsmi.amdsmi_wrapper.AMDSMI_LINK_TYPE_NOT_APPLICABLE)
-        self.assertEqual(result["num_hops"], 255)
-        self.assertEqual(result["fb_sharing"], 0)
-        self.assertEqual(result["weight"], 0)

--- a/projects/amdsmi/tests/python/unit/system/test_link_topology.py
+++ b/projects/amdsmi/tests/python/unit/system/test_link_topology.py
@@ -1,23 +1,7 @@
 #!/usr/bin/env python3
-#
-# Copyright (C) Advanced Micro Devices. All rights reserved.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy of
-# this software and associated documentation files (the "Software"), to deal in
-# the Software without restriction, including without limitation the rights to
-# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-# the Software, and to permit persons to whom the Software is furnished to do so,
-# subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+# Copyright Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
 """Unified ``amdsmi_get_link_topology`` binding unit tests.
 
 Hardware independent: validates that the ctypes ``amdsmi_link_topology_t``

--- a/projects/amdsmi/tests/python/unit/system/test_link_topology.py
+++ b/projects/amdsmi/tests/python/unit/system/test_link_topology.py
@@ -19,8 +19,7 @@ from common.common import amdsmi
 
 class TestLinkTopology(unittest.TestCase):
     def test_struct_size_matches_host_abi(self):
-        # The unified struct must be 64 bytes so the baremetal and host
-        # interfaces are binary compatible.
+        # 64 bytes keeps the baremetal and host interfaces binary compatible.
         self.assertEqual(ctypes.sizeof(amdsmi.amdsmi_wrapper.amdsmi_link_topology_t), 64)
 
     def test_struct_fields(self):
@@ -36,8 +35,7 @@ class TestLinkTopology(unittest.TestCase):
         ):
             self.assertIn(expected, field_names)
 
-        # Field offsets must match the C ABI exactly; a reorder that preserves
-        # the 64-byte size would otherwise pass silently and break host ABI.
+        # Offsets must match the C ABI; a same-size reorder would break it silently.
         self.assertEqual(struct_type.weight.offset, 0)
         self.assertEqual(struct_type.link_status.offset, 8)
         self.assertEqual(struct_type.link_type.offset, 12)
@@ -51,31 +49,26 @@ class TestLinkTopology(unittest.TestCase):
         self.assertTrue(hasattr(amdsmi, "amdsmi_get_link_topology"))
 
     def test_rejects_non_handle_arguments(self):
-        # Argument validation happens before any library call, so this raises
-        # without needing a GPU present.
+        # Validation happens before any library call, so no GPU is needed.
         with self.assertRaises(amdsmi.amdsmi_interface.AmdSmiParameterException):
             amdsmi.amdsmi_interface.amdsmi_get_link_topology("not-a-handle", "also-bad")
 
     def test_rejects_bad_destination_handle(self):
-        # The both-bad case above trips on the first argument, so a valid source
-        # with an invalid destination is what exercises the second-argument guard.
+        # A valid source with a bad destination exercises the second-argument guard.
         src = amdsmi.amdsmi_wrapper.amdsmi_processor_handle()
         with self.assertRaises(amdsmi.amdsmi_interface.AmdSmiParameterException):
             amdsmi.amdsmi_interface.amdsmi_get_link_topology(src, "also-bad")
 
     def test_success_path_returns_mapped_dict(self):
-        # Mock the ctypes entry point so the success path runs without a GPU,
-        # locking the struct-to-dict mapping.
+        # Mock the entry point so the success path runs without a GPU.
         src = amdsmi.amdsmi_wrapper.amdsmi_processor_handle()
         dst = amdsmi.amdsmi_wrapper.amdsmi_processor_handle()
 
         def _fill(_src, _dst, topology_ref):
-            # topology_ref is the ctypes byref() argument; ._obj is the
-            # underlying amdsmi_link_topology_t the binding reads back.
+            # ._obj is the underlying struct the binding reads back.
             topology = topology_ref._obj
             topology.weight = 42
-            # link_type XGMI (2) is a concrete type, so a coherent result pairs
-            # it with link_status ENABLED (0).
+            # XGMI (2) is a concrete type, so pair it with link_status ENABLED (0).
             topology.link_status = 0
             topology.link_type = 2
             topology.num_hops = 3
@@ -97,8 +90,7 @@ class TestLinkTopology(unittest.TestCase):
         self.assertEqual(result["fb_sharing"], 1)
 
     def test_disabled_link_maps_status_and_capped_hops(self):
-        # Complements the enabled case: locks the disabled/not-applicable
-        # mapping and the uint8_t-capped (255) num_hops passing through.
+        # Complements the enabled case: disabled mapping and capped (255) hops.
         src = amdsmi.amdsmi_wrapper.amdsmi_processor_handle()
         dst = amdsmi.amdsmi_wrapper.amdsmi_processor_handle()
 

--- a/projects/amdsmi/tests/python/unit/system/test_link_topology.py
+++ b/projects/amdsmi/tests/python/unit/system/test_link_topology.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) Advanced Micro Devices. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""Unified ``amdsmi_get_link_topology`` binding unit tests.
+
+Hardware independent: validates that the ctypes ``amdsmi_link_topology_t``
+structure matches the C ABI (64 bytes, matching the host struct), that the
+high-level ``amdsmi_get_link_topology`` symbol is exported, and that argument
+validation and the success-path dict mapping behave without a GPU present.
+"""
+
+import ctypes
+import unittest
+from unittest import mock
+
+from common.common import amdsmi
+
+
+class TestLinkTopology(unittest.TestCase):
+    def test_struct_size_matches_host_abi(self):
+        # The unified struct must be 64 bytes so the baremetal and host
+        # interfaces are binary compatible.
+        self.assertEqual(ctypes.sizeof(amdsmi.amdsmi_wrapper.amdsmi_link_topology_t), 64)
+
+    def test_struct_fields(self):
+        struct_type = amdsmi.amdsmi_wrapper.amdsmi_link_topology_t
+        field_names = [name for name, *_ in struct_type._fields_]
+        for expected in (
+            "weight",
+            "link_status",
+            "link_type",
+            "num_hops",
+            "fb_sharing",
+            "reserved",
+        ):
+            self.assertIn(expected, field_names)
+
+        # Field offsets must match the C ABI exactly; a reorder that preserves
+        # the 64-byte size would otherwise pass silently and break host ABI.
+        self.assertEqual(struct_type.weight.offset, 0)
+        self.assertEqual(struct_type.link_status.offset, 8)
+        self.assertEqual(struct_type.link_type.offset, 12)
+        self.assertEqual(struct_type.num_hops.offset, 16)
+        self.assertEqual(struct_type.fb_sharing.offset, 17)
+        self.assertEqual(struct_type.reserved.offset, 20)
+        instance = struct_type()
+        self.assertEqual(len(instance.reserved), 10)
+
+    def test_symbol_is_exported(self):
+        self.assertTrue(hasattr(amdsmi, "amdsmi_get_link_topology"))
+
+    def test_rejects_non_handle_arguments(self):
+        # Argument validation happens before any library call, so this raises
+        # without needing a GPU present.
+        with self.assertRaises(amdsmi.amdsmi_interface.AmdSmiParameterException):
+            amdsmi.amdsmi_interface.amdsmi_get_link_topology("not-a-handle", "also-bad")
+
+    def test_rejects_bad_destination_handle(self):
+        # The both-bad case above trips on the first argument, so a valid source
+        # with an invalid destination is what exercises the second-argument guard.
+        src = amdsmi.amdsmi_wrapper.amdsmi_processor_handle()
+        with self.assertRaises(amdsmi.amdsmi_interface.AmdSmiParameterException):
+            amdsmi.amdsmi_interface.amdsmi_get_link_topology(src, "also-bad")
+
+    def test_success_path_returns_mapped_dict(self):
+        # Mock the ctypes entry point so the success path runs without a GPU,
+        # locking the struct-to-dict mapping.
+        src = amdsmi.amdsmi_wrapper.amdsmi_processor_handle()
+        dst = amdsmi.amdsmi_wrapper.amdsmi_processor_handle()
+
+        def _fill(_src, _dst, topology_ref):
+            # topology_ref is the ctypes byref() argument; ._obj is the
+            # underlying amdsmi_link_topology_t the binding reads back.
+            topology = topology_ref._obj
+            topology.weight = 42
+            # link_type XGMI (2) is a concrete type, so a coherent result pairs
+            # it with link_status ENABLED (0).
+            topology.link_status = 0
+            topology.link_type = 2
+            topology.num_hops = 3
+            topology.fb_sharing = 1
+            return 0
+
+        with mock.patch.object(
+            amdsmi.amdsmi_wrapper, "amdsmi_get_link_topology", side_effect=_fill
+        ):
+            result = amdsmi.amdsmi_interface.amdsmi_get_link_topology(src, dst)
+
+        self.assertEqual(
+            set(result), {"weight", "link_status", "link_type", "num_hops", "fb_sharing"}
+        )
+        self.assertEqual(result["weight"], 42)
+        self.assertEqual(result["link_status"], 0)
+        self.assertEqual(result["link_type"], 2)
+        self.assertEqual(result["num_hops"], 3)
+        self.assertEqual(result["fb_sharing"], 1)

--- a/projects/amdsmi/tests/python/unit/system/test_link_topology.py
+++ b/projects/amdsmi/tests/python/unit/system/test_link_topology.py
@@ -111,3 +111,29 @@ class TestLinkTopology(unittest.TestCase):
         self.assertEqual(result["link_type"], 2)
         self.assertEqual(result["num_hops"], 3)
         self.assertEqual(result["fb_sharing"], 1)
+
+    def test_disabled_link_maps_status_and_capped_hops(self):
+        # Complements the enabled case: locks the disabled/not-applicable
+        # mapping and the uint8_t-capped (255) num_hops passing through.
+        src = amdsmi.amdsmi_wrapper.amdsmi_processor_handle()
+        dst = amdsmi.amdsmi_wrapper.amdsmi_processor_handle()
+
+        def _fill(_src, _dst, topology_ref):
+            topology = topology_ref._obj
+            topology.weight = 0
+            topology.link_status = amdsmi.amdsmi_wrapper.AMDSMI_LINK_STATUS_DISABLED
+            topology.link_type = amdsmi.amdsmi_wrapper.AMDSMI_LINK_TYPE_NOT_APPLICABLE
+            topology.num_hops = 255
+            topology.fb_sharing = 0
+            return 0
+
+        with mock.patch.object(
+            amdsmi.amdsmi_wrapper, "amdsmi_get_link_topology", side_effect=_fill
+        ):
+            result = amdsmi.amdsmi_interface.amdsmi_get_link_topology(src, dst)
+
+        self.assertEqual(result["link_status"], amdsmi.amdsmi_wrapper.AMDSMI_LINK_STATUS_DISABLED)
+        self.assertEqual(result["link_type"], amdsmi.amdsmi_wrapper.AMDSMI_LINK_TYPE_NOT_APPLICABLE)
+        self.assertEqual(result["num_hops"], 255)
+        self.assertEqual(result["fb_sharing"], 0)
+        self.assertEqual(result["weight"], 0)


### PR DESCRIPTION
## Motivation

BM lacked the unified `amdsmi_get_link_topology` API that already exists on the host. This PR adds it to BM with the identical signature and `amdsmi_link_topology_t` return struct, giving callers consistent GPU-to-GPU link topology (type, weight, hops, status, FB sharing) across host and BM.

## Technical Details

- Added the `amdsmi_link_topology_t` struct and `amdsmi_get_link_topology()` in `amdsmi.h`/`amd_smi.cc`, wrapping the `rsmi_topo_*` link type/weight calls plus `rsmi_is_P2P_accessible` for FB sharing.
- Added Python bindings (`amdsmi_wrapper.py`, `amdsmi_interface.py`, `__init__.py`) with an ABI-matching 64-byte ctypes struct.
- Documented the API in `amdsmi-py-api.md` and added a hardware-independent unit test in `test_link_topology.py`.

## JIRA ID

JIRA ID : AILITOOLS-276

## Test Plan

- Built the library (`cmake --build ... --target amd_smi`) on a 2-GPU host (Navi31 + Navi48).
- Ran a runtime check calling `amdsmi_get_link_topology` between the GPUs.
- Ran the new unit test via the amdsmi python unit-test runner: `unit_tests.py -k link_topology -v`.

## Test Result

- API returned correct values: PCIE link type, `num_hops=2`, `weight=40`, `fb_sharing=1`, `sizeof(amdsmi_link_topology_t)==64` matching the host struct.
- Unit test: 7/7 passed.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
