### PR TITLE
fix(rocprofiler-system): bypass pthread wrap at thread limit

### DIFF
--- a/projects/rocprofiler-systems/CMakeLists.txt
+++ b/projects/rocprofiler-systems/CMakeLists.txt
@@ -312,8 +312,8 @@ endif()
 include(ProcessorCount)
 ProcessorCount(ROCPROFSYS_PROCESSOR_COUNT)
 
-if(ROCPROFSYS_PROCESSOR_COUNT LESS 8)
-    set(ROCPROFSYS_THREAD_COUNT 128)
+if(ROCPROFSYS_PROCESSOR_COUNT LESS 128)
+    set(ROCPROFSYS_THREAD_COUNT 2048)
 else()
     math(EXPR ROCPROFSYS_THREAD_COUNT "16 * ${ROCPROFSYS_PROCESSOR_COUNT}")
     compute_pow2_ceil(ROCPROFSYS_THREAD_COUNT "16 * ${ROCPROFSYS_PROCESSOR_COUNT}")
@@ -335,7 +335,7 @@ set(ROCPROFSYS_MAX_THREADS
 )
 rocprofiler_systems_add_feature(
     ROCPROFSYS_MAX_THREADS
-    "Maximum number of total threads supported in the host application (default: max of 128 or 16 * nproc)"
+    "Maximum number of total threads supported in the host application (default: max of 2048 or 16 * nproc)"
 )
 
 compute_pow2_ceil(_MAX_THREADS "${ROCPROFSYS_MAX_THREADS}")

--- a/projects/rocprofiler-systems/docs/reference/development-guide.rst
+++ b/projects/rocprofiler-systems/docs/reference/development-guide.rst
@@ -341,7 +341,7 @@ Configuring thread limits
 
 ROCm Systems Profiler uses a single CMake configuration option to control thread-related memory allocation:
 
-* ``ROCPROFSYS_MAX_THREADS``: Maximum number of threads supported (default if not explicitly set: ``128`` if nproc < 8, otherwise ``pow2_ceil(16 * nproc)``; must be a power of 2)
+* ``ROCPROFSYS_MAX_THREADS``: Maximum number of threads supported (default if not explicitly set: ``2048`` if nproc < 128, otherwise ``pow2_ceil(16 * nproc)``; must be a power of 2)
 
 This setting controls:
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_create_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_create_gotcha.cpp
@@ -130,6 +130,21 @@ using native_handle_set_t = std::set<pthread_create_gotcha::native_handle_t>;
 auto native_handles          = native_handle_set_t{};
 auto internal_native_handles = native_handle_set_t{};
 auto native_handles_mutex    = locking::atomic_mutex{};
+
+// Shared across the parent interceptor and the child wrapper so the thread-limit
+// warning is emitted exactly once per process, regardless of which gate trips first.
+std::once_flag thread_limit_warning_flag;
+
+inline void
+warn_thread_limit_once()
+{
+    std::call_once(thread_limit_warning_flag, []() {
+        LOG_WARNING(
+            "Maximum allowed thread limit ({}) reached. Further thread creation and "
+            "profiling will be disabled to prevent resource exhaustion.",
+            static_cast<size_t>(ROCPROFSYS_MAX_THREADS));
+    });
+}
 }  // namespace
 
 //--------------------------------------------------------------------------------------//
@@ -145,14 +160,20 @@ void*
 pthread_create_gotcha::wrapper::operator()() const
 {
     using thread_bundle_data_t = thread_data<thread_bundle_t>;
-
+    auto _child_internal_tid   = utility::get_thread_index();
+    if(static_cast<size_t>(_child_internal_tid) >= ROCPROFSYS_MAX_THREADS ||
+       thread_info::get_initialized_thread() >= ROCPROFSYS_MAX_THREADS)
+    {
+        warn_thread_limit_once();
+        if(m_config.promise) m_config.promise->set_value();
+        return m_routine(m_arg);
+    }
     if(is_shutdown && *is_shutdown)
     {
         if(m_config.promise) m_config.promise->set_value();
         // execute the original function
         return m_routine(m_arg);
     }
-
     push_thread_state(ThreadState::Internal);
 
     std::int64_t _tid         = -1;
@@ -163,16 +184,9 @@ pthread_create_gotcha::wrapper::operator()() const
     auto         _coverage    = (get_mode() == Mode::Coverage);
     const auto&  _parent_info = thread_info::get(m_config.parent_tid, InternalTID);
     const auto&  _info        = thread_info::init(m_config.offset);
-    auto _sequent_value       = _info->index_data ? _info->index_data->sequent_value : -1;
-    if(static_cast<size_t>(_sequent_value) >= ROCPROFSYS_MAX_THREADS)
+    if(!_info)
     {
-        static std::once_flag thread_limit_warning_flag;
-        std::call_once(thread_limit_warning_flag, []() {
-            LOG_WARNING(
-                "Maximum allowed thread limit ({}) reached. Further thread creation and "
-                "profiling will be disabled to prevent resource exhaustion.",
-                static_cast<size_t>(ROCPROFSYS_MAX_THREADS));
-        });
+        if(m_config.promise) m_config.promise->set_value();
         return m_routine(m_arg);
     }
     auto _dtor = [&]() {
@@ -564,7 +578,13 @@ pthread_create_gotcha::operator()(pthread_t* thread, const pthread_attr_t* attr,
         return (*m_wrappee)(thread, attr, func, arg);
     }
 
-    auto        _tid          = utility::get_thread_index();
+    auto _tid = utility::get_thread_index();
+    if(static_cast<size_t>(_tid) >= ROCPROFSYS_MAX_THREADS ||
+       thread_info::get_initialized_thread() >= ROCPROFSYS_MAX_THREADS)
+    {
+        warn_thread_limit_once();
+        return (*m_wrappee)(thread, attr, func, arg);
+    }
     auto        _thr_state    = get_thread_state();
     auto        _glob_state   = get_state();
     auto        _mode         = get_mode();
@@ -574,6 +594,11 @@ pthread_create_gotcha::operator()(pthread_t* thread, const pthread_attr_t* attr,
     auto        _sample_child = sampling_enabled_on_child_threads();
     auto        _active = (_glob_state == ::rocprofsys::State::Active && !_disabled);
     const auto& _info   = thread_info::init(!_active || !_sample_child || _disabled);
+    if(!_info)
+    {
+        // Untracked parent threads cannot safely create wrapped/profiled child threads.
+        return (*m_wrappee)(thread, attr, func, arg);
+    }
 
     ROCPROFSYS_SCOPED_THREAD_STATE(ThreadState::Internal);
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_create_gotcha.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/components/pthread_create_gotcha.cpp
@@ -139,10 +139,12 @@ inline void
 warn_thread_limit_once()
 {
     std::call_once(thread_limit_warning_flag, []() {
-        LOG_WARNING(
-            "Maximum allowed thread limit ({}) reached. Further thread creation and "
-            "profiling will be disabled to prevent resource exhaustion.",
-            static_cast<size_t>(ROCPROFSYS_MAX_THREADS));
+        LOG_WARNING("Maximum allowed thread limit ({}) reached. Further profiling will "
+                    "be disabled "
+                    "to prevent resource exhaustion. Consider increasing the limit at "
+                    "compile time "
+                    "using the ROCPROFSYS_MAX_THREADS CMake option.",
+                    static_cast<size_t>(ROCPROFSYS_MAX_THREADS));
     });
 }
 }  // namespace

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/thread_info.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/thread_info.cpp
@@ -131,6 +131,8 @@ grow_data(std::int64_t _tid)
         return peak_num_threads;
     }
 
+    // Unreachable code: peak_num_threads is already max_supported_threads,
+    // and _tid >= max_supported_threads returns above. Retained for future use.
     if(_tid >= peak_num_threads)
     {
         ROCPROFSYS_SCOPED_THREAD_STATE(ThreadState::Internal);

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/thread_info.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/thread_info.cpp
@@ -41,16 +41,33 @@ get_index_data()
     return _v;
 }
 
+// Returns a reference to a per-thread empty optional, used as a safe fallback for
+// out-of-range / uninitialized thread indices instead of throwing from .at().
+template <typename Tp>
+std::optional<Tp>&
+empty_thread_local()
+{
+    static thread_local auto _dummy = std::optional<Tp>{};
+    _dummy.reset();
+    return _dummy;
+}
+
 auto&
 get_info_data(std::int64_t _tid)
 {
-    return get_info_data()->at(_tid);
+    auto& _v = get_info_data();
+    if(!_v || _tid < 0 || static_cast<size_t>(_tid) >= max_supported_threads)
+        return empty_thread_local<thread_info>();
+    return _v->at(_tid);
 }
 
 auto&
 get_index_data(std::int64_t _tid)
 {
-    return get_index_data()->at(_tid);
+    auto& _v = get_index_data();
+    if(!_v || _tid < 0 || static_cast<size_t>(_tid) >= max_supported_threads)
+        return empty_thread_local<thread_index_data>();
+    return _v->at(_tid);
 }
 
 auto
@@ -69,7 +86,7 @@ init_index_data(std::int64_t _tid, bool _offset = false)
                             "thread {} on thread {}\n",
                             _tid, itr->internal_value));
         }
-
+        thread_info::initialized_threads.fetch_add(1, std::memory_order_relaxed);
         LOG_TRACE("Thread {} on PID {} (rank: {}) assigned rocprof-sys TID {} "
                   "(internal: {})",
                   itr->system_value, process::get_id(), dmp::rank(), itr->sequent_value,
@@ -90,6 +107,8 @@ const auto peak_num_threads_callback_registered = []() {
 }();
 }  // namespace
 
+std::atomic<size_t> thread_info::initialized_threads = 0;
+
 std::string
 thread_index_data::as_string() const
 {
@@ -104,6 +123,13 @@ grow_data(std::int64_t _tid)
 {
     struct data_growth
     {};
+
+    // Do not grow when _tid is greater than or equal to max_supported_threads
+    if(_tid >= static_cast<std::int64_t>(max_supported_threads))
+    {
+        // if thread limit exceeded, return current peak number of threads
+        return peak_num_threads;
+    }
 
     if(_tid >= peak_num_threads)
     {
@@ -144,6 +170,12 @@ thread_info::get_peak_num_threads()
     return peak_num_threads;
 }
 
+size_t
+thread_info::get_initialized_thread()
+{
+    return initialized_threads.load(std::memory_order_relaxed);
+}
+
 const std::optional<thread_info>&
 thread_info::init(bool _offset)
 {
@@ -151,11 +183,8 @@ thread_info::init(bool _offset)
     auto&                    _info_data = get_info_data();
     auto                     _tid       = utility::get_thread_index();
 
-    if(!_info_data)
-    {
-        static auto _dummy = std::optional<thread_info>{};
-        return (_dummy.reset(), _dummy);  // always reset for safety
-    }
+    if((!_info_data) || (_tid < 0 || static_cast<size_t>(_tid) >= max_supported_threads))
+        return empty_thread_local<thread_info>();
 
     if(!_once && (_once = true))
     {
@@ -181,11 +210,7 @@ thread_info::init(bool _offset)
 const std::optional<thread_info>&
 thread_info::get()
 {
-    if(!exists())
-    {
-        static thread_local auto _v = std::optional<thread_info>{};
-        return _v;
-    }
+    if(!exists()) return empty_thread_local<thread_info>();
     return get_info_data(utility::get_thread_index());
 }
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/thread_info.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/thread_info.hpp
@@ -9,6 +9,7 @@
 #include <thread>
 #include <timemory/backends/threading.hpp>
 
+#include <atomic>
 #include <cstdint>
 #include <optional>
 #include <ostream>
@@ -91,6 +92,7 @@ struct thread_info
 
     static bool                              exists();
     static size_t                            get_peak_num_threads();
+    static size_t                            get_initialized_thread();
     static const std::optional<thread_info>& init(bool _offset = false);
     static const std::optional<thread_info>& get();
     static const std::optional<thread_info>& get(native_handle_t&);
@@ -103,6 +105,8 @@ struct thread_info
     const std::int64_t* causal_count = nullptr;
     index_data_t        index_data   = {};
     lifetime_data_t     lifetime     = { 0, 0 };
+
+    static std::atomic<size_t> initialized_threads;
 
     friend std::ostream& operator<<(std::ostream& _os, const thread_info& _v)
     {

--- a/projects/rocprofiler-systems/tests/pytest/test_thread_limit.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_thread_limit.py
@@ -163,9 +163,10 @@ class TestThreadLimitLoadTest(RocprofsysTest):
         thread_limit = get_thread_limit()
         pass_value = get_expected_pass_value(thread_count, thread_limit)
         fail_value = get_expected_fail_value(thread_count, thread_limit)
+        warning_re = get_thread_limit_warning_regex(thread_limit)
         self.assert_regex(
             result,
             mode,
-            pass_regex=[f"\\|{pass_value}>>>"],
+            pass_regex=[f"\\|{pass_value}>>>", warning_re],
             fail_regex=[f"\\|{fail_value}>>>"],
         )

--- a/projects/rocprofiler-systems/tests/pytest/test_thread_limit.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_thread_limit.py
@@ -90,16 +90,9 @@ def get_thread_limit_warning_regex(thread_limit: int) -> str:
     """Regex for pthread_create_gotcha thread-limit warning in runner logs."""
     return (
         rf"\[warning\] Maximum allowed thread limit \({thread_limit}\) reached\. "
-        r"Further thread creation and profiling will be disabled to prevent "
-        r"resource exhaustion\."
-    )
-
-
-def get_thread_launched_regex(thread_index: int, max_threads: int) -> str:
-    """Regex for thread-limit workload launch log past the compile-time max."""
-    return (
-        rf"\[thread-limit\] launching thread {thread_index} "
-        rf"\(max: {max_threads}\)\.\.\."
+        r"Further profiling will be disabled to prevent resource exhaustion\. "
+        r"Consider increasing the limit at compile time using the "
+        r"ROCPROFSYS_MAX_THREADS CMake option\."
     )
 
 

--- a/projects/rocprofiler-systems/tests/pytest/test_thread_limit.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_thread_limit.py
@@ -11,6 +11,13 @@ from conftest import RocprofsysTest, get_rocprof_config
 
 pytestmark = [pytest.mark.thread_limit]
 
+# rocprof-sys may initialize internal/offset threads (sampling, ROCm, etc.)
+# that consume thread slots without appearing as workload thread rows. Expect the
+# highest profiled thread index to be at most thread_limit - INTERNAL_THREAD_OFFSET.
+# The half-thread case is far below the limit, so use the exact highest launched index.
+INTERNAL_THREAD_OFFSET = 20
+OVERFLOW_THREAD_LOAD_MULTIPLIER = 8
+
 # ============================================================================
 # Thread Limit Fixtures
 # ============================================================================
@@ -44,8 +51,8 @@ def get_thread_limit() -> int:
 
     rocprof_config = get_rocprof_config()
     num_procs = rocprof_config.capabilities.num_procs
-    if num_procs < 8:
-        thread_count = 128
+    if num_procs < 128:
+        thread_count = 2048
     else:
         # Round up to nearest power of 2
         n = 16 * num_procs - 1
@@ -59,6 +66,43 @@ def get_thread_limit() -> int:
     return thread_count
 
 
+def get_overflow_thread_load_count() -> int:
+    """Thread count for load test — scales with the configured thread limit."""
+    return get_thread_limit() * OVERFLOW_THREAD_LOAD_MULTIPLIER
+
+
+def get_expected_pass_value(thread_count: int, thread_limit: int) -> int:
+    """Highest profiled thread index expected after internal/offset overhead."""
+    max_profiled = min(thread_count - 1, thread_limit - 1)
+    if thread_count == thread_limit // 2:
+        return max_profiled
+    return max_profiled - INTERNAL_THREAD_OFFSET
+
+
+def get_expected_fail_value(thread_count: int, thread_limit: int) -> int:
+    """Thread index that must not appear in profile output."""
+    if thread_count >= thread_limit:
+        return thread_limit + 1
+    return thread_count + 1
+
+
+def get_thread_limit_warning_regex(thread_limit: int) -> str:
+    """Regex for pthread_create_gotcha thread-limit warning in runner logs."""
+    return (
+        rf"\[warning\] Maximum allowed thread limit \({thread_limit}\) reached\. "
+        r"Further thread creation and profiling will be disabled to prevent "
+        r"resource exhaustion\."
+    )
+
+
+def get_thread_launched_regex(thread_index: int, max_threads: int) -> str:
+    """Regex for thread-limit workload launch log past the compile-time max."""
+    return (
+        rf"\[thread-limit\] launching thread {thread_index} "
+        rf"\(max: {max_threads}\)\.\.\."
+    )
+
+
 # ============================================================================
 # Thread Limit Tests
 # ============================================================================
@@ -70,18 +114,18 @@ def get_thread_limit() -> int:
 @pytest.mark.parametrize(
     "thread_count",
     [
-        get_thread_limit() - 1,
-        get_thread_limit() + 24,
+        get_thread_limit() // 2,
         get_thread_limit(),
+        get_thread_limit() * 2,
     ],
-    ids=["below", "above", "at"],
+    ids=["half", "at", "double"],
 )
+@pytest.mark.timeout(480)
 @pytest.mark.class_name("thread-limit")
 class TestThreadLimit(RocprofsysTest):
     BINARY_REWRITE_ARGS = ["-e", "-v", "2", "-i", "1024", "--label", "return", "args"]
     RUNTIME_INSTRUMENT_ARGS = ["-e", "-v", "1", "-i", "1024", "--label", "return", "args"]
 
-    @pytest.mark.timeout(480)
     def test(self, mode, thread_count, thread_limit_env):
         result = self.run_test(
             mode,
@@ -92,12 +136,33 @@ class TestThreadLimit(RocprofsysTest):
             runtime_instrument_args=self.RUNTIME_INSTRUMENT_ARGS,
         )
         thread_limit = get_thread_limit()
-        pass_value = thread_count
-        fail_value = thread_count + 1
-        if thread_count >= thread_limit:
-            pass_value = thread_limit - 1
-            fail_value = thread_limit + 1
+        pass_value = get_expected_pass_value(thread_count, thread_limit)
+        fail_value = get_expected_fail_value(thread_count, thread_limit)
 
+        self.assert_regex(
+            result,
+            mode,
+            pass_regex=[f"\\|{pass_value}>>>"],
+            fail_regex=[f"\\|{fail_value}>>>"],
+        )
+
+
+@pytest.mark.parametrize("mode", ["sampling", "sys_run"])
+@pytest.mark.timeout(600)
+@pytest.mark.class_name("thread-limit-load-test")
+class TestThreadLimitLoadTest(RocprofsysTest):
+    def test(self, mode, thread_limit_env, rocprof_config):
+        concurrency = min(rocprof_config.capabilities.num_procs, 16)
+        thread_count = get_overflow_thread_load_count()
+        result = self.run_test(
+            mode,
+            "thread-limit",
+            env=thread_limit_env,
+            run_args=["30", str(concurrency), str(thread_count)],
+        )
+        thread_limit = get_thread_limit()
+        pass_value = get_expected_pass_value(thread_count, thread_limit)
+        fail_value = get_expected_fail_value(thread_count, thread_limit)
         self.assert_regex(
             result,
             mode,


### PR DESCRIPTION
## Motivation

When profiling thread-heavy apps (PyTorch CIFAR-100), rocprof-sys would hang after the number of threads exceeded the compile-time limit ROCPROFSYS_MAX_THREADS. It was noticed on aac6.
**What was the issue :** When profiling thread-heavy applications such as PyTorch training, rocprofiler-systems would hang once the number of threads exceeded the compile-time limit ROCPROFSYS_MAX_THREADS. Thread profiling data is stored in fixed-size arrays indexed by an internal thread ID, but the old code kept wrapping pthread_create, growing storage, and calling stable_vector. That led to, heavy lock and instrumentation overhead as thousands of threads were still launched, and the application appearing frozen because rocprof-sys never stopped profiling and fell back to normal thread creation. The fix adds an early bypass at the thread cap, safe handling for wrapping pthread_create, growing storage, and calling stable_vector.

**Additional info : Checked by testing ROCPROFSYS_SAMPLING_DELAY at 1, 2, 3, 4, 5, and 10 seconds on the PyTorch CIFAR-100 workload (ROCm 7.13 and Mainline, rocprof-sys v1.8.0). Increasing the sampling delay did not resolve the hang/deadlock.**

## Technical Details

- When the app tries to create a new thread and the profiler has already reached its maximum allowed thread count, stop intercepting that thread creation and let the operating system handle it normally.
- Show a single warning that the thread limit was reached, and do not try to record profiling data for any threads created after that point.
- Before using a thread’s slot in the profiler’s internal storage table, check that the slot number is within the built-in limit; if it is not, skip profiling for that thread instead of accessing invalid memory.
- Stop expanding the profiler’s thread storage tables once the maximum size is reached, so memory and locks are not kept growing without bound.
- Track how many threads have actually been initialized for profiling, and use that count as an additional signal to stop wrapping new threads.
- Raise the default built-in thread limit at compile time from a very small (128) value to 2048 on typical machines.
- Added automated tests that verify coverage for half/at/double/8 times(load test)scenarios.

## JIRA ID

JIRA ID : ROCM-25389

## Test Plan

Ran impacted tests. Added new coverage.

## Test Result

All impacted tests are passing locally.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
