### PR TITLE
fix(amdsmi): report VRAM total from KFD topology on APUs

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -98,6 +98,10 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ### Resolved Issues
 
+- **Fixed VRAM total under-reported as the BIOS carveout on APUs**.  
+  - On APUs (for example gfx1151 / Strix Halo), `amdsmi_get_gpu_memory_total()` / `rsmi_dev_memory_total_get()` returned the small dedicated VRAM carveout from sysfs `mem_info_vram_total` (512 MiB) instead of the unified memory the GPU actually addresses. KFD `mem_banks` already reports the true size (for example 110 GiB), matching the GTT total and what HIP reports as the device total.
+  - The VRAM total is now sourced from the KFD topology whenever KFD reports a larger total than sysfs. On discrete GPUs the two sources agree, so their behavior is unchanged.
+
 - **Fixed `amd-smi set --power-cap` rejecting the minimum allowed value**.  
   - The lower bound is now inclusive, so setting the power cap to the exact minimum of the reported range (e.g. `210` when the range is 210-300W) succeeds instead of failing validation, matching the inclusive range shown in the error message.
 

--- a/projects/amdsmi/rocm_smi/src/rocm_smi.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi.cc
@@ -4259,10 +4259,31 @@ rsmi_status_t rsmi_dev_memory_total_get(uint32_t dv_ind, rsmi_memory_type_t mem_
   // This is needed to avoid returning garbage value in case of failure
   ret = get_dev_value_int(mem_type_file, dv_ind, total);
 
-  // Fallback to KFD reported memory if VRAM total is 0 or sysfs read fails
-  if (mem_type == RSMI_MEM_TYPE_VRAM && (*total == 0 || ret != RSMI_STATUS_SUCCESS)) {
-    GET_DEV_AND_KFDNODE_FROM_INDX
-    if (kfd_node->get_total_memory(total) == 0 && *total > 0) {
+  // Prefer the KFD-reported VRAM total when it is larger than the sysfs value.
+  //
+  // This covers two cases:
+  //   1. The sysfs read failed or returned 0 (previous behavior).
+  //   2. sysfs under-reports. On APUs (e.g. gfx1151 / Strix Halo) the sysfs
+  //      mem_info_vram_total only exposes the small BIOS VRAM carveout
+  //      (512 MiB) while the GPU actually addresses the unified pool that KFD
+  //      mem_banks reports (e.g. 110 GiB), so callers size their memory budget
+  //      against 0.5 GiB instead of the real capacity.
+  //
+  // On discrete GPUs the two sources agree, so the sysfs value is kept unchanged.
+  //
+  // The KFD node is looked up directly rather than through
+  // GET_DEV_AND_KFDNODE_FROM_INDX: that macro returns RSMI_INITIALIZATION_ERROR
+  // when no KFD node exists, which would now discard an otherwise valid sysfs
+  // value. Here a missing node simply leaves the sysfs value in place.
+  if (mem_type == RSMI_MEM_TYPE_VRAM) {
+    const uint64_t sysfs_total = (ret == RSMI_STATUS_SUCCESS) ? *total : 0;
+    GET_DEV_FROM_INDX
+    auto& kfd_nodes = smi.kfd_node_map();
+    auto kfd_it = kfd_nodes.find(dev->kfd_gpu_id());
+    uint64_t kfd_total = 0;
+    if (kfd_it != kfd_nodes.end() && kfd_it->second->get_total_memory(&kfd_total) == 0 &&
+        kfd_total > sysfs_total) {
+      *total = kfd_total;
       ss << __PRETTY_FUNCTION__ << " | inside success fallback... "
          << " | Device #: " << std::to_string(dv_ind)
          << " | Type = " << amd::smi::Device::get_type_string(mem_type_file)


### PR DESCRIPTION
## Motivation

On AMD APUs, `amdsmi_get_gpu_memory_total()` / `rsmi_dev_memory_total_get()` report the VRAM total as the small dedicated BIOS carveout instead of the memory the GPU can actually address.

Measured on a Ryzen AI MAX+ 395 (Radeon 8060S, **gfx1151** / Strix Halo), ROCm 7.2.4, amd_smi 26.2.2, 128 GB unified memory:

| source | total |
|---|---|
| `amdsmi_get_gpu_memory_total(VRAM)` | **536,870,912** (0.50 GiB) |
| `amdsmi_get_gpu_memory_total(GTT)` | 118,111,600,640 (110.00 GiB) |
| KFD `mem_banks/0` `size_in_bytes` | 118,111,600,640 (110.00 GiB) |
| HIP (`hipDeviceProp_t::totalGlobalMem`) | 118,111,600,640 (110.00 GiB) |

sysfs `mem_info_vram_total` reports the 512 MiB BIOS VRAM carveout, while KFD `mem_banks` already reports the true unified size — the same value HIP reports as the device total.

Consumers that size a memory budget from the VRAM total therefore see **0.5 GiB on a 110 GiB device**. Concretely, vLLM's ROCm platform calls `amdsmi_get_gpu_memory_total(..., VRAM)` in `RocmPlatform.get_device_total_memory()`, which is used for engine memory heuristics.

## Technical Details

`rsmi_dev_memory_total_get()` already prefers the KFD topology total — but only when the sysfs read *fails or returns 0*. On APUs the sysfs read **succeeds** with the carveout value, so KFD is never consulted.

This broadens the preference: for `RSMI_MEM_TYPE_VRAM`, use the KFD `mem_banks` total whenever it is **larger** than the sysfs value.

| device | sysfs | KFD | result |
|---|---|---|---|
| discrete (e.g. MI300X, RX) | VRAM | same VRAM | sysfs kept — **unchanged** |
| sysfs read fails / returns 0 | 0 | > 0 | KFD — **unchanged** (previous behavior) |
| **APU (gfx1151)** | 0.5 GiB | 110 GiB | **KFD wins — fixed** |
| no KFD node present | VRAM | n/a | sysfs kept — **no error** |

The KFD node is looked up directly rather than through `GET_DEV_AND_KFDNODE_FROM_INDX`. That macro returns `RSMI_INITIALIZATION_ERROR` when no KFD node exists; since the block now runs on every VRAM query (not only after a sysfs failure), using the macro would discard an otherwise valid sysfs value. A missing node now simply leaves the sysfs value in place.

## Relationship to #8419

#8419 fixes the **mirror-image** case in this same function: on MI300A in CPX/DPX/TPX/QPX modes sysfs *over*-reports and KFD is authoritative. This PR fixes the *under*-reporting case (APU carveout). They are complementary and do not collide:

- #8419's condition keys on the compute-partition mode; an APU never matches it.
- This PR's condition (`kfd_total > sysfs_total`) is false in the partition case, where KFD reports *less* than sysfs.

Both reduce to the same principle: **the KFD topology is the driver's truth for VRAM total.**

If maintainers prefer a single change, I am happy to rebase this onto #8419 and fold the condition into `vram_total_prefer_kfd()` instead.

## Testing

- Verified the underlying data on real hardware (gfx1151, ROCm 7.2.4): amdsmi VRAM = 0.50 GiB, while amdsmi GTT, KFD `mem_banks/0`, and HIP all agree on 110.00 GiB. With the KFD value substituted, the reported total matches HIP exactly.
- **Caveat, stated plainly:** I have not been able to compile `libamd_smi` locally (no amdsmi build environment on this machine), so the C++ change itself is not build-tested — only the data and the logic are verified. Please treat CI as the build gate; happy to iterate on any review or build feedback.

## Related

- #8419 — VRAM total from KFD topology (multi-partition case)
- #8190 — `rocr`: "APU devices with no device-local memory" (gfx1151)
- ROCm/ROCm#6035 — `amd-smi` reports N/A for monitoring metrics on gfx1151

## AI assistance disclosure

This change was prepared with AI assistance (Claude, Anthropic). The investigation, the measurements above, and the proposed patch were produced with that assistance; I have reviewed the change and am responsible for it. Flagging it explicitly in the interest of transparency.
