### PR TITLE
[CLR] Fix race condition by only creation xferQueue once

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -3161,6 +3161,7 @@ VirtualGPU* Device::xferQueue() const {
     }
   });
   if (!xferQueue_) {
+    LogError("Couldn't create the device transfer manager!");
     return nullptr;
   }
   xferQueue_->enableSyncBlit();

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -3145,20 +3145,23 @@ void Device::svmFree(void* ptr) const {
 
 // ================================================================================================
 VirtualGPU* Device::xferQueue() const {
-  if (!xferQueue_) {
+  Device* thisDevice = const_cast<Device*>(this);
+  std::call_once(xferQueueOnce_, [thisDevice]() {
     // Create virtual device for internal memory transfer
-    Device* thisDevice = const_cast<Device*>(this);
     thisDevice->xferQueue_ = reinterpret_cast<VirtualGPU*>(thisDevice->createVirtualDevice());
-    if (!xferQueue_) {
+    if (!thisDevice->xferQueue_) {
       LogError("Couldn't create the device transfer manager!");
-      return nullptr;
+      return;
     }
-    if (xferQueue_->gpu_queue() == nullptr) {
+    if (thisDevice->xferQueue_->gpu_queue() == nullptr) {
       void* md_rb = nullptr;
       auto* queue = thisDevice->AcquireActiveQueue(amd::CommandQueue::Priority::Normal,
                                                    nullptr, nullptr, &md_rb);
-      xferQueue_->SetGpuQueue(queue, md_rb);
+      thisDevice->xferQueue_->SetGpuQueue(queue, md_rb);
     }
+  });
+  if (!xferQueue_) {
+    return nullptr;
   }
   xferQueue_->enableSyncBlit();
   return xferQueue_;

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -730,6 +730,7 @@ class Device : public NullDevice {
   size_t alloc_granularity_;
   static constexpr bool offlineDevice_ = false;
   VirtualGPU* xferQueue_;  //!< Transfer queue, created on demand
+  mutable std::once_flag xferQueueOnce_;  //!< Serialises lazy creation of xferQueue_
 
   std::atomic<size_t> freeMem_;       //!< Total of free memory available
   mutable std::recursive_mutex vgpusAccess_;  //!< Lock to serialise virtual gpu list access


### PR DESCRIPTION
## Motivation

Two threads can construct an xferQueue due to its lazy initalisation. This leads to a race condition where two queues are constructed for the Device. This leaks when the object is destroyed as only one of the queues is being tracked properly.

## Technical Details

Issue was found in testing for https://github.com/ROCm/rocm-systems/pull/8069

## JIRA ID

AIRUNTIME-2429

## Test Plan

Testing has been done in #8069, and resolves breaking test

## Test Result

Passes

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
