### PR TITLE
ci(rocprofiler-systems): Print the reason tests were skipped in workflows

### DIFF
--- a/projects/rocprofiler-systems/scripts/run-ci.py
+++ b/projects/rocprofiler-systems/scripts/run-ci.py
@@ -334,9 +334,17 @@ def summarize_skipped_tests(binary_dir):
     import zlib
     import xml.etree.ElementTree as ET
 
-    xml_files = sorted(glob.glob(os.path.join(binary_dir, "Testing", "*", "Test.xml")))
-    if not xml_files:
+    # Only inspect the current run's Test.xml. CTest records the run's
+    # subdirectory in Testing/TAG (its first line)
+    testing_dir = os.path.join(binary_dir, "Testing")
+    try:
+        with open(os.path.join(testing_dir, "TAG"), encoding="utf-8") as tag_fh:
+            tag = tag_fh.readline().strip()
+    except OSError:
         return
+    if not tag:
+        return
+    xml_files = [os.path.join(testing_dir, tag, "Test.xml")]
 
     def decoded_value(value_el):
         """Return the text of a <Value>, decoding CTest's base64/gzip output.
@@ -389,7 +397,7 @@ def summarize_skipped_tests(binary_dir):
                     reason = (nm.findtext("Value") or "").strip()
                     break
             if not reason or reason.startswith("SKIP_RETURN_CODE"):
-                output = "".join(decoded_value(v) for v in test.iter("Value"))
+                output = "\n".join(decoded_value(v) for v in test.iter("Value"))
                 for skip_re in skip_res:
                     match = skip_re.search(output)
                     if match:

--- a/projects/rocprofiler-systems/scripts/run-ci.py
+++ b/projects/rocprofiler-systems/scripts/run-ci.py
@@ -322,6 +322,89 @@ def run(*args, **kwargs):
     return subprocess.run(*args, **kwargs)
 
 
+def summarize_skipped_tests(binary_dir):
+    """Print a concise "test -> skip reason" section from CTest's Test.xml.
+
+    Avoids having to query CDash for skip reasons: the reason is taken from the
+    "Completion Status" measurement (populated via the <CTestDetails> tag emitted
+    by the pytest harness), falling back to the "SKIPPED (<reason>)" line in the
+    captured test output.
+    """
+    import base64
+    import zlib
+    import xml.etree.ElementTree as ET
+
+    xml_files = sorted(glob.glob(os.path.join(binary_dir, "Testing", "*", "Test.xml")))
+    if not xml_files:
+        return
+
+    def decoded_value(value_el):
+        """Return the text of a <Value>, decoding CTest's base64/gzip output.
+
+        CTest stores the captured stdout in a <Measurement><Value> that is
+        base64-encoded and (usually) gzip-compressed; plain NamedMeasurement
+        values have no encoding attributes and are returned as-is.
+        """
+        text = value_el.text or ""
+        if value_el.get("encoding") != "base64":
+            return text
+        try:
+            raw = base64.b64decode(text)
+        except (ValueError, TypeError):
+            return ""
+        if value_el.get("compression"):
+            for wbits in (zlib.MAX_WBITS | 16, zlib.MAX_WBITS, -zlib.MAX_WBITS):
+                try:
+                    raw = zlib.decompress(raw, wbits)
+                    break
+                except zlib.error:
+                    continue
+            else:
+                return ""
+        return raw.decode("utf-8", errors="replace")
+
+    # Prefer pytest's "short test summary info" line, which carries the full
+    # reason ("SKIPPED [1] file:line: reason"), over the verbose progress line
+    # ("foo SKIPPED (reason)") which pytest truncates with "..." to fit the
+    # terminal width.
+    skip_res = (
+        re.compile(r"SKIPPED \[\d+\][^:]*:\d+:\s*(.+)"),
+        re.compile(r"SKIPPED \(([^)]*)\)"),
+    )
+    reasons = {}  # test name -> reason (last occurrence wins)
+    for xml_file in xml_files:
+        try:
+            root = ET.parse(xml_file).getroot()
+        except ET.ParseError:
+            continue
+        for test in root.iter("Test"):
+            if test.get("Status") != "notrun":
+                continue
+            name = test.findtext("Name") or "<unknown>"
+            reason = ""
+            for nm in test.iter("NamedMeasurement"):
+                if nm.get("name") == "Completion Status":
+                    reason = (nm.findtext("Value") or "").strip()
+                    break
+            if not reason or reason.startswith("SKIP_RETURN_CODE"):
+                output = "".join(decoded_value(v) for v in test.iter("Value"))
+                for skip_re in skip_res:
+                    match = skip_re.search(output)
+                    if match:
+                        reason = match.group(1).strip()
+                        break
+            reasons[name] = reason or "(no reason captured)"
+
+    if not reasons:
+        return
+
+    log_group_start(f"Skipped tests ({len(reasons)})")
+    width = max(len(name) for name in reasons)
+    for name in sorted(reasons):
+        log(f"{name.ljust(width)}  {reasons[name]}")
+    log_group_end()
+
+
 def set_python_hints_from_cmake_args(cmake_args):
     """Extract ROCPROFSYS_PYTHON_PREFIX and ROCPROFSYS_PYTHON_ENVS from cmake args
     to build ROCPROFSYS_PYTHON_HINTS for CTest's find_program calls."""
@@ -401,6 +484,8 @@ if __name__ == "__main__":
         log(f"CTest dashboard failed: {e}", level="error")
         raise
     finally:
+        summarize_skipped_tests(args.binary_dir)
+
         log_group_start("Collecting test artifacts")
         if "-VV" not in ctest_args:
             for file in glob.glob(

--- a/projects/rocprofiler-systems/scripts/run-ci.py
+++ b/projects/rocprofiler-systems/scripts/run-ci.py
@@ -364,11 +364,13 @@ def summarize_skipped_tests(binary_dir):
         return raw.decode("utf-8", errors="replace")
 
     # Prefer pytest's "short test summary info" line, which carries the full
-    # reason ("SKIPPED [1] file:line: reason"), over the verbose progress line
-    # ("foo SKIPPED (reason)") which pytest truncates with "..." to fit the
-    # terminal width.
+    # reason, over the verbose progress line ("foo SKIPPED (reason)") which
+    # pytest truncates with "..." to fit the terminal width. The summary line
+    # is "SKIPPED [1] file:line: reason" for skips raised inside a test, but
+    # "SKIPPED [1] file: reason" (no line number) for skips added as markers
+    # during collection, so the line number is optional.
     skip_res = (
-        re.compile(r"SKIPPED \[\d+\][^:]*:\d+:\s*(.+)"),
+        re.compile(r"SKIPPED \[\d+\][^:\n]+:(?:\d+:)?\s*(.+)"),
         re.compile(r"SKIPPED \(([^)]*)\)"),
     )
     reasons = {}  # test name -> reason (last occurrence wins)


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Currently, if a test is skipped, all that is reported is:
```
The following tests were not run:
 some-test1 (Skipped)
 some-test2 (Skipped)
```
This is a CTest limitation. Instead, we print out the CDash output for the skipped test.
That way we get:
```
Skipped tests:
 some-test1: No Valid GPU Detected
 some-test2: MPI not available
```

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

 - Rewrote skipped-test reason extraction in `summarize_skipped_tests` (scripts/run-ci.py) so the CI log shows the real reason
 - Decode CTest's captured test output: `<Measurement>` values are `base64`-encoded and `gzip`-compressed. `NamedMeasurement` values pass through unchanged.
 - Prefer pytest's untruncated short test summary info line over the verbose progress line `(SKIPPED (reason...))`, which pytest truncates with `...` to terminal width.
 - Made the summary-line line number optional so both formats match: `file:line:` reason (skips raised in a test) and `file: reason` (skips added as collection-time markers)

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

Jira ID: AIPROFSYST-627

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Workflows. Locally, you can see why a test was skipped by examining `LastTestLog.log`.

## Test Result

In the gfx950 workflow, I see:
```
2026-07-13T20:28:05.5195116Z The following tests did not run:
2026-07-13T20:28:05.5195260Z 	165 - transferbench-sys-run (Skipped)
2026-07-13T20:28:05.5195400Z 	166 - jacobi-hip-sys-run (Skipped)
2026-07-13T20:28:05.5195537Z 	170 - julia-vecadd-sys-run (Skipped)
2026-07-13T20:28:05.5195676Z 	429 - scratch-memory-baseline (Skipped)
2026-07-13T20:28:05.5195823Z 	430 - scratch-memory-sampling (Skipped)
2026-07-13T20:28:05.5195971Z 	431 - scratch-memory-binary-rewrite (Skipped)
2026-07-13T20:28:05.5196120Z 	432 - scratch-memory-sys-run (Skipped)
2026-07-13T20:28:05.5196257Z 	433 - sdma-usage-sys-run (Skipped)
2026-07-13T20:28:05.5196392Z 	579 - video-decode-sampling (Skipped)
2026-07-13T20:28:05.5196536Z 	580 - video-decode-sys-run (Skipped)
```

And directly under it:
```
2026-07-13T20:28:06.2158699Z ##[group]Skipped tests (10)
2026-07-13T20:28:06.2158910Z jacobi-hip-sys-run             Test requires atleast 2 GPUs but system has 1
2026-07-13T20:28:06.2159119Z julia-vecadd-sys-run           Julia not available
2026-07-13T20:28:06.2159335Z scratch-memory-baseline        Test cannot run inside a Docker container
2026-07-13T20:28:06.2159569Z scratch-memory-binary-rewrite  Test cannot run inside a Docker container
2026-07-13T20:28:06.2159794Z scratch-memory-sampling        Test cannot run inside a Docker container
2026-07-13T20:28:06.2160011Z scratch-memory-sys-run         Test cannot run inside a Docker container
2026-07-13T20:28:06.2160218Z sdma-usage-sys-run             amdgpu 6.16.6 < required 6.19.14
2026-07-13T20:28:06.2160437Z transferbench-sys-run          Test requires atleast 2 GPUs but system has 1
2026-07-13T20:28:06.2160650Z video-decode-sampling          videodecode binary not found
2026-07-13T20:28:06.2160838Z video-decode-sys-run           videodecode binary not found
```

Or in https://github.com/ROCm/rocm-systems/actions/runs/29330655222/job/87077521334?pr=8478, we see:
```
2026-07-14T13:05:56.2383693Z annotate-parallel-overhead-binary-rewrite      Requires either perf_event_paranoid <= 2 or CAP_SYS_ADMIN to be available
2026-07-14T13:05:56.2384515Z annotate-parallel-overhead-sampling            Requires either perf_event_paranoid <= 2 or CAP_SYS_ADMIN to be available
2026-07-14T13:05:56.2385248Z annotate-parallel-overhead-sys-run             Requires either perf_event_paranoid <= 2 or CAP_SYS_ADMIN to be available
2026-07-14T13:05:56.2385980Z overflow-parallel-overhead-binary-rewrite      Requires either perf_event_paranoid <= 2 or CAP_SYS_ADMIN to be available
2026-07-14T13:05:56.2387381Z overflow-parallel-overhead-runtime-instrument  Requires either perf_event_paranoid <= 2 or CAP_SYS_ADMIN to be available
2026-07-14T13:05:56.2388139Z overflow-parallel-overhead-sampling            Requires either perf_event_paranoid <= 2 or CAP_SYS_ADMIN to be available
2026-07-14T13:05:56.2388848Z overflow-parallel-overhead-sys-run             Requires either perf_event_paranoid <= 2 or CAP_SYS_ADMIN to be available
2026-07-14T13:05:56.2389437Z shmem-pingpong-baseline                        oshrun version 4.1 < required 5.0
2026-07-14T13:05:56.2389936Z shmem-pingpong-sampling                        oshrun version 4.1 < required 5.0
2026-07-14T13:05:56.2390398Z shmem-pingpong-sys-run                         oshrun version 4.1 < required 5.0
```

Search for "Skipped tests" to find the section 

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
