### PR TITLE
fix(clr): Guard Event::awaitCompletion against dead worker thread

### DIFF
--- a/projects/clr/rocclr/platform/command.cpp
+++ b/projects/clr/rocclr/platform/command.cpp
@@ -283,7 +283,12 @@ bool Event::awaitCompletion() {
         lock_.wait();
       }
     }
-    ClPrint(LOG_DETAIL_DEBUG, LOG_WAIT, "Event %p wait completed", this);
+    if (status() == CL_COMPLETE) {
+      ClPrint(LOG_DETAIL_DEBUG, LOG_WAIT, "Event %p wait completed", this);
+    } else {
+      ClPrint(LOG_DETAIL_DEBUG, LOG_WAIT,
+              "Event %p wait aborted, worker thread no longer alive (status %d)", this, status());
+    }
   }
 
   return status() == CL_COMPLETE;

--- a/projects/clr/rocclr/platform/command.cpp
+++ b/projects/clr/rocclr/platform/command.cpp
@@ -256,14 +256,30 @@ bool Event::awaitCompletion() {
             this, status());
     auto* queue = command().queue();
     if ((queue != nullptr) && queue->vdev()->ActiveWait()) {
+      // Active wait: yield in a tight loop. Bail out if the queue's worker
+      // thread is no longer alive, otherwise this spins forever during
+      // process teardown -- on Windows ExitProcess terminates worker threads
+      // before DLL_PROCESS_DETACH, so __hipUnregisterFatBinary ->
+      // SyncAllStreams -> finish() reaches here with no thread left to signal
+      // completion (ROCm/TheRock#999). Only meaningful when a real worker
+      // thread exists (handle != nullptr); direct dispatch has none.
       while (status() > CL_COMPLETE) {
+        if (queue->thread().handle() != nullptr && !amd::Os::isThreadAlive(queue->thread())) {
+          break;
+        }
         amd::Os::yield();
       }
     } else {
       ScopedLock lock(lock_);
 
-      // Wait until the status becomes CL_COMPLETE or negative.
+      // Wait until the status becomes CL_COMPLETE or negative. Bail out if the
+      // worker thread is dead -- nobody would signal the condition variable
+      // and we would block forever during teardown (see comment above).
       while (status() > CL_COMPLETE) {
+        if (queue != nullptr && queue->thread().handle() != nullptr &&
+            !amd::Os::isThreadAlive(queue->thread())) {
+          break;
+        }
         lock_.wait();
       }
     }

--- a/projects/hip-tests/catch/config/configs/unit/stream.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/stream.yaml
@@ -182,6 +182,10 @@ stream:
     # Note: needs to be enabled when streamPerThread issues are fixed
     disabled: [amd_windows, amd_wsl]
     tags: [synchronization]
+  Unit_hipStreamKilledWorkerThread:
+    <<: *level_2
+    disabled: [amd_linux]
+    tags: [synchronization]
   Unit_hipStreamQuery_WithNoWork:
     <<: *level_2
     tags: [synchronization]

--- a/projects/hip-tests/catch/unit/stream/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/stream/CMakeLists.txt
@@ -42,6 +42,9 @@ if(HIP_PLATFORM MATCHES "amd")
                 hipStreamLegacy.cc
 
              )
+  if(WIN32)
+    set(TEST_SRC ${TEST_SRC} hipStreamKilledWorkerThread.cc)
+  endif()
 else()
   set(TEST_SRC
       ${TEST_SRC}
@@ -65,3 +68,13 @@ set_source_files_properties(hipStreamLegacy_exe.cc PROPERTIES LANGUAGE ${GPGPU_L
 
 add_dependencies(StreamTest hipStreamLegacy_exe)
 set_property(GLOBAL APPEND PROPERTY G_INSTALL_EXE_TARGETS hipStreamLegacy_exe)
+
+if(WIN32 AND HIP_PLATFORM MATCHES "amd")
+  add_executable(hipStreamKilledWorkerThread_exe EXCLUDE_FROM_ALL
+                 hipStreamKilledWorkerThread_exe.cc)
+  set_source_files_properties(hipStreamKilledWorkerThread_exe.cc PROPERTIES
+                              LANGUAGE ${GPGPU_LANGUAGE})
+  target_link_libraries(hipStreamKilledWorkerThread_exe ${GPGPU_LINKER_LIBRARIES})
+  add_dependencies(StreamTest hipStreamKilledWorkerThread_exe)
+  set_property(GLOBAL APPEND PROPERTY G_INSTALL_EXE_TARGETS hipStreamKilledWorkerThread_exe)
+endif()

--- a/projects/hip-tests/catch/unit/stream/hipStreamKilledWorkerThread.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamKilledWorkerThread.cc
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <hip_test_common.hh>
+#include <hip_test_process.hh>
+
+/**
+ * Test Description
+ * ------------------------
+ *  - A worker thread killed during teardown should not hang the process.
+ * Test source
+ * ------------------------
+ *  - catch\unit\stream\hipStreamKilledWorkerThread.cc
+ * Test requirements
+ * ------------------------
+ *  - Windows
+ */
+HIP_TEST_CASE(Unit_hipStreamKilledWorkerThread) {
+  hip::SpawnProc proc("hipStreamKilledWorkerThread_exe", true);
+  REQUIRE(proc.run() == 0);
+}

--- a/projects/hip-tests/catch/unit/stream/hipStreamKilledWorkerThread_exe.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamKilledWorkerThread_exe.cc
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <hip/hip_runtime.h>
+
+namespace {
+
+__global__ void NoopKernel() {}
+
+}  // namespace
+
+#if !defined(__HIP_DEVICE_COMPILE__)
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+#include <windows.h>
+#include <tlhelp32.h>
+
+#include <algorithm>
+#include <iostream>
+#include <vector>
+
+namespace {
+
+#define HIP_CHECK(error)                                                                           \
+  do {                                                                                             \
+    hipError_t local_error = error;                                                                \
+    if ((local_error != hipSuccess) && (local_error != hipErrorPeerAccessAlreadyEnabled)) {        \
+      std::cerr << #error << " failed with " << hipGetErrorString(local_error) << " ("             \
+                << local_error << ")" << std::endl;                                                \
+      return 1;                                                                                    \
+    }                                                                                              \
+  } while (0)
+
+constexpr DWORD kTerminateWorkerDelayMs = 1000;
+
+std::vector<DWORD> GetCurrentProcessThreadIds() {
+  std::vector<DWORD> thread_ids;
+  const DWORD current_process_id = GetCurrentProcessId();
+  HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
+  if (snapshot == INVALID_HANDLE_VALUE) {
+    return thread_ids;
+  }
+
+  THREADENTRY32 entry = {};
+  entry.dwSize = sizeof(entry);
+  if (Thread32First(snapshot, &entry)) {
+    do {
+      if (entry.th32OwnerProcessID == current_process_id &&
+          entry.th32ThreadID != GetCurrentThreadId()) {
+        thread_ids.push_back(entry.th32ThreadID);
+      }
+      entry.dwSize = sizeof(entry);
+    } while (Thread32Next(snapshot, &entry));
+  }
+  CloseHandle(snapshot);
+  return thread_ids;
+}
+
+std::vector<DWORD> GetNewThreadIds(const std::vector<DWORD>& before,
+                                   const std::vector<DWORD>& after) {
+  std::vector<DWORD> new_thread_ids;
+  for (DWORD thread_id : after) {
+    if (std::find(before.begin(), before.end(), thread_id) == before.end()) {
+      new_thread_ids.push_back(thread_id);
+    }
+  }
+  return new_thread_ids;
+}
+
+DWORD WINAPI TerminateWorkerThreadAfterDelay(LPVOID data) {
+  HANDLE worker_thread = static_cast<HANDLE>(data);
+  Sleep(kTerminateWorkerDelayMs);
+  const BOOL terminated = TerminateThread(worker_thread, 0);
+  if (terminated) {
+    WaitForSingleObject(worker_thread, 1000);
+  } else {
+    std::cerr << "Failed to terminate HIP worker thread after delay" << std::endl;
+  }
+  CloseHandle(worker_thread);
+  return terminated ? 0 : 1;
+}
+
+}  // namespace
+
+int main() {
+  HIP_CHECK(hipSetDevice(0));
+
+  const std::vector<DWORD> before_stream_create = GetCurrentProcessThreadIds();
+
+  hipStream_t stream = nullptr;
+  HIP_CHECK(hipStreamCreate(&stream));
+
+  const std::vector<DWORD> after_stream_create = GetCurrentProcessThreadIds();
+  const std::vector<DWORD> worker_thread_ids =
+      GetNewThreadIds(before_stream_create, after_stream_create);
+  if (worker_thread_ids.size() != 1) {
+    std::cerr << "Expected one HIP worker thread, found " << worker_thread_ids.size() << std::endl;
+    return 1;
+  }
+
+  HANDLE worker_thread = OpenThread(THREAD_TERMINATE | THREAD_SUSPEND_RESUME | SYNCHRONIZE, FALSE,
+                                    worker_thread_ids.front());
+  if (worker_thread == NULL) {
+    std::cerr << "Failed to open HIP worker thread " << worker_thread_ids.front() << std::endl;
+    return 1;
+  }
+
+  NoopKernel<<<1, 1, 0, stream>>>();
+  HIP_CHECK(hipGetLastError());
+  HIP_CHECK(hipStreamSynchronize(stream));
+
+  hipEvent_t event = nullptr;
+  HIP_CHECK(hipEventCreateWithFlags(&event, hipEventDisableTiming));
+
+  // Suspend worker so it cannot dequeue/process anything
+  if (SuspendThread(worker_thread) == static_cast<DWORD>(-1)) {
+    std::cerr << "Failed to suspend HIP worker thread " << worker_thread_ids.front() << std::endl;
+    CloseHandle(worker_thread);
+    return 1;
+  }
+
+  HIP_CHECK(hipEventRecord(event, stream));
+
+  HANDLE killer_thread =
+      CreateThread(nullptr, 0, TerminateWorkerThreadAfterDelay, worker_thread, 0, nullptr);
+  if (killer_thread == NULL) {
+    std::cerr << "Failed to create HIP worker killer thread" << std::endl;
+    CloseHandle(worker_thread);
+    return 1;
+  }
+  CloseHandle(killer_thread);
+
+  return 0;
+}
+
+#endif


### PR DESCRIPTION
## Motivation

PyTorch processes hang on exit on Windows until an external timeout fires. In CI, Windows PyTorch test jobs finish testing, print `Pytest finished with return code: N`, then never exit - hitting the 2h job timeout with the GPU idle and one CPU core pegged.

Example failing job - the "Run PyTorch tests" step runs the full 2h and is killed by the timeout: https://github.com/ROCm/rockrel/actions/runs/29139906087/job/86526456042

Stacktrace of the single hung thread at exit (captured live via cdb on gfx1151):

```
ntdll!NtDelayExecution / RtlDelayExecution
KERNELBASE!SwitchToThread                     <- amd::Os::yield()
amdhip64_7!amd::Event::awaitCompletion        <- ActiveWait spin loop
amdhip64_7!amd::HostQueue::finish
amdhip64_7!hip::Device::SyncAllStreams
amdhip64_7!__hipUnregisterFatBinary
<consumer DLL atexit handler> -> ucrtbase!execute_onexit_table
ntdll!LdrShutdownProcess -> RtlExitUserProcess -> ExitProcess
python
```

## Technical Details

On Windows, `ExitProcess` terminates all worker threads before running `DLL_PROCESS_DETACH`. A consumer DLL's atexit handler then calls `__hipUnregisterFatBinary` -> `Device::SyncAllStreams` -> `HostQueue::finish()` -> `Event::awaitCompletion()`. Both wait paths in `awaitCompletion()` - the `ActiveWait` `Os::yield()` spin loop and the condition-variable wait - loop forever because the worker thread that would set the event status to `CL_COMPLETE` is already gone.

PR #3790 added a guard only in `HostQueue::finish()`; a later teardown-ordering change re-exposed an unguarded path into `awaitCompletion()` (Regression from https://github.com/ROCm/rocm-systems/pull/5193). This fixes it at the root by adding an `Os::isThreadAlive(queue->thread())` check to both wait loops in `Event::awaitCompletion()`, matching the existing pattern in `HostQueue::terminate()`. The `handle() != nullptr` check skips the test in direct-dispatch mode, where there is no worker thread.

This revives the approach from the closed PR #3656 (broad, caller-independent fix).

## Test Plan

Windows 11, gfx1151 (Radeon 8060S), PyTorch ROCm nightly.

1. Local A/B: swap only the patched `amdhip64_7.dll` into an otherwise-identical repro venv and re-run the full PyTorch `test_cuda.py` suite.
2. TheRock CI: dispatch the Windows PyTorch build+test workflow.

## Test Result

| Test | Result |
|------|--------|
| Unpatched DLL, full `test_cuda.py` suite + exit | Hangs to timeout (100%) |
| Patched DLL, same suite + exit | Clean exit - prints return code then exits immediately |

CI verification:

- Patched ROCm built from source: https://github.com/ROCm/TheRock/actions/runs/28898683299
- Windows PyTorch test workflow on the patched build: https://github.com/ROCm/TheRock/actions/runs/28949959819 - the "Run PyTorch tests" step now **completes in ~17 min** instead of hanging to the 2h timeout. The process exits cleanly; remaining test-case failures are unrelated to the teardown hang.

Not applicable on Linux - the hang does not occur there (`exit()` runs atexit handlers before thread teardown; `AMD_DIRECT_DISPATCH` defaults to true).

Tracking:

- pytorch/pytorch#160759
- ROCm/TheRock#999

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
