### PR TITLE
fix(rocprofiler-compute): Resolve intermittent tarball issues

### DIFF
--- a/.github/workflows/rocprofiler-compute-continuous-integration.yml
+++ b/.github/workflows/rocprofiler-compute-continuous-integration.yml
@@ -103,6 +103,7 @@ jobs:
         --device /dev/dri
         --cap-add CAP_SYS_ADMIN
         --env-file /etc/podinfo/gha-gpu-isolation-settings
+        --pull always
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/rocprofiler-compute-continuous-integration.yml
+++ b/.github/workflows/rocprofiler-compute-continuous-integration.yml
@@ -144,7 +144,6 @@ jobs:
         run: |
           set -e
           mkdir ${{ env.ROCM_PATH }}
-          ls -l /opt/
           TARBALL_ROCM_VERSION=$(ls /opt/*.tar.gz | grep -Eo '*([0-9]+\.[0-9]+\.[0-9]+)*')
           tar -xf ${{ env.ROCM_PATH }}-${TARBALL_ROCM_VERSION}-multiarch.tar.gz -C ${{ env.ROCM_PATH }}
           rm ${{ env.ROCM_PATH }}-${TARBALL_ROCM_VERSION}-multiarch.tar.gz
@@ -154,7 +153,6 @@ jobs:
       - name: Output TheRock Manifest
         run: |
           cat ${{ env.ROCM_PATH }}/share/therock/therock_manifest.json
-          exit 1
 
       - name: Install Python Requirements
         working-directory: projects/rocprofiler-compute

--- a/.github/workflows/rocprofiler-compute-continuous-integration.yml
+++ b/.github/workflows/rocprofiler-compute-continuous-integration.yml
@@ -143,6 +143,7 @@ jobs:
         run: |
           set -e
           mkdir ${{ env.ROCM_PATH }}
+          ls -l /opt/
           TARBALL_ROCM_VERSION=$(ls /opt/*.tar.gz | grep -Eo '*([0-9]+\.[0-9]+\.[0-9]+)*')
           tar -xf ${{ env.ROCM_PATH }}-${TARBALL_ROCM_VERSION}-multiarch.tar.gz -C ${{ env.ROCM_PATH }}
           rm ${{ env.ROCM_PATH }}-${TARBALL_ROCM_VERSION}-multiarch.tar.gz

--- a/.github/workflows/rocprofiler-compute-continuous-integration.yml
+++ b/.github/workflows/rocprofiler-compute-continuous-integration.yml
@@ -153,6 +153,7 @@ jobs:
       - name: Output TheRock Manifest
         run: |
           cat ${{ env.ROCM_PATH }}/share/therock/therock_manifest.json
+          exit 1
 
       - name: Install Python Requirements
         working-directory: projects/rocprofiler-compute


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
We have been noticing that, occasionally, the version of TheRock installed on the gfx1151 runners is outdated by weeks. This issue does not appear to impact gfx94X and gfx950 runs.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Updated `.github/workflows/rocprofiler-compute-continuous-integration.yml` Docker options
  - Added `--pull always` option to ensure that we always pull from remote instead of referencing from local cache, which may contain an older version of the daily image which contains a previous version of TheRock

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
JIRA ID : AIPROFCOMP-717

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- Ensure that TheRock tarball version is consistent amongst every runner, including gfx1151
- No regression issues from change

## Test Result

<!-- Briefly summarize test outcomes. -->
- Consistent tarball versions across all instances
  - https://github.com/ROCm/rocm-systems/actions/runs/29266522150

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
