### PR TITLE
fix(rocprofiler-systems): build PAPI with -std=gnu17 (glibc 2.43 / C23)

### DIFF
--- a/projects/rocprofiler-systems/cmake/PAPI.cmake
+++ b/projects/rocprofiler-systems/cmake/PAPI.cmake
@@ -212,6 +212,11 @@ if(CMAKE_C_COMPILER_IS_CLANG)
 endif()
 set(PAPI_C_COMPILER ${_PAPI_C_COMPILER} CACHE FILEPATH "C compiler used to compile PAPI")
 
+# The vendored libpfm4 is C17: pfmlib_common.c assigns the result of strpbrk() to a
+# `char *`. glibc >= 2.43 declares strpbrk() and friends as const-preserving macros
+# under __GLIBC_USE (ISOC23), and GCC >= 15 enables those by defaulting to -std=gnu23,
+# so this fails under libpfm4's own -Werror. Pin the dialect. See ROCm/TheRock#3515.
+
 include(ExternalProject)
 ExternalProject_Add(
     rocprofiler-systems-papi-build
@@ -220,20 +225,20 @@ ExternalProject_Add(
     BUILD_IN_SOURCE 1
     PATCH_COMMAND
         ${CMAKE_COMMAND} -E env CC=${PAPI_C_COMPILER}
-        CFLAGS=-fPIC\ -O3\ -Wno-stringop-truncation\ -Wno-use-after-free LIBS=-lrt
-        LDFLAGS=-lrt ${ROCPROFSYS_PAPI_EXTRA_ENV} <SOURCE_DIR>/configure --quiet
+        CFLAGS=-fPIC\ -O3\ -std=gnu17\ -Wno-stringop-truncation\ -Wno-use-after-free
+        LIBS=-lrt LDFLAGS=-lrt ${ROCPROFSYS_PAPI_EXTRA_ENV} <SOURCE_DIR>/configure --quiet
         --prefix=${ROCPROFSYS_PAPI_INSTALL_DIR} --with-static-lib=yes --with-shared-lib=no
         --with-perf-events --with-tests=no
         --with-components=${_ROCPROFSYS_PAPI_COMPONENTS}
         --libdir=${ROCPROFSYS_PAPI_INSTALL_DIR}/lib
     CONFIGURE_COMMAND
         ${CMAKE_COMMAND} -E env CC=${PAPI_C_COMPILER}
-        CFLAGS=-fPIC\ -O3\ -Wno-stringop-truncation\ -Wno-use-after-free
+        CFLAGS=-fPIC\ -O3\ -std=gnu17\ -Wno-stringop-truncation\ -Wno-use-after-free
         ${ROCPROFSYS_PAPI_EXTRA_ENV} ${MAKE_EXECUTABLE} static install -s -j
         ${ROCPROFSYS_PAPI_CONFIGURE_JOBS}
     BUILD_COMMAND
         ${CMAKE_COMMAND} -E env CC=${PAPI_C_COMPILER}
-        CFLAGS=-fPIC\ -O3\ -Wno-stringop-truncation\ -Wno-use-after-free
+        CFLAGS=-fPIC\ -O3\ -std=gnu17\ -Wno-stringop-truncation\ -Wno-use-after-free
         ${ROCPROFSYS_PAPI_EXTRA_ENV} ${MAKE_EXECUTABLE} utils install-utils -s
     INSTALL_COMMAND ""
     BUILD_BYPRODUCTS "${_ROCPROFSYS_PAPI_BUILD_BYPRODUCTS}"
@@ -244,11 +249,11 @@ add_custom_target(
     rocprofiler-systems-papi-install
     COMMAND
         ${CMAKE_COMMAND} -E env CC=${PAPI_C_COMPILER}
-        CFLAGS=-fPIC\ -O3\ -Wno-stringop-truncation\ -Wno-use-after-free
+        CFLAGS=-fPIC\ -O3\ -std=gnu17\ -Wno-stringop-truncation\ -Wno-use-after-free
         ${ROCPROFSYS_PAPI_EXTRA_ENV} ${MAKE_EXECUTABLE} static install -s
     COMMAND
         ${CMAKE_COMMAND} -E env CC=${PAPI_C_COMPILER}
-        CFLAGS=-fPIC\ -O3\ -Wno-stringop-truncation\ -Wno-use-after-free
+        CFLAGS=-fPIC\ -O3\ -std=gnu17\ -Wno-stringop-truncation\ -Wno-use-after-free
         ${ROCPROFSYS_PAPI_EXTRA_ENV} ${MAKE_EXECUTABLE} utils install-utils -s
     WORKING_DIRECTORY ${ROCPROFSYS_PAPI_SOURCE_DIR}/src
     COMMENT "Installing PAPI..."


### PR DESCRIPTION
## Motivation

`rocprofiler-systems` fails to build on hosts with **glibc >= 2.43** and a compiler defaulting to C23
(e.g. Ubuntu 25.10/26.04, Fedora 42+). PAPI dies at `make utils install-utils` because libpfm4 cannot
compile `pfmlib_common.o`:

```
pfmlib_common.c:1891:11: error: assignment discards ‘const’ qualifier from pointer target type
                                [-Werror=discarded-qualifiers]
 1891 |         p = strpbrk(event, PFMLIB_EVENT_DELIM);
cc1: all warnings being treated as errors
```

`libpfm.a` is then never produced and PAPI's utils fail to link (`undefined reference to
pfm_get_event_info`, `pfm_initialize`, ...). Reported as ROCm/TheRock#3515.

## Technical Details

The trigger is **glibc 2.43** (released 2026-01-23), not any particular compiler version. For ISO C23,
glibc now declares `strpbrk`, `strchr`, `strstr`, `memchr`, `bsearch` and friends as *const-preserving
macros*: given a `const char *` argument they yield a `const char *`. In `<string.h>`:

```c
# if __GLIBC_USE (ISOC23) && defined __glibc_const_generic && !defined _LIBC
```

The vendored libpfm4 is C17 code that assigns that result to a plain `char *`, which trips libpfm4's own
`-Werror` (`libpfm4/config.mk`: `DBG?=-g -Wall -Werror`).

Two ingredients are required, and GCC 15 supplies the second by defaulting to `-std=gnu23`, which is what
sets `__GLIBC_USE (ISOC23)`:

| glibc | C dialect | `pfmlib_common.c` |
| --- | --- | --- |
| < 2.43 | any | builds (macros do not exist) |
| >= 2.43 | C17 (`gnu17`) | builds |
| >= 2.43 | **C23** (gcc 15 default) | **fails** |

This is why CI does not currently catch it: `rhel-compiler-check (8.10, 7.2, 15, Release)` runs
**gcc 15.2.1** — the same compiler version that fails for me — and is green, because RHEL 8.10's glibc
predates the const-generic macros. The failure will appear in CI as soon as any image moves to a
glibc-2.43 distro. It is not compiler-specific either: clang with `-std=c23` on glibc 2.43 fails the
same way.

This adds `-std=gnu17` to the `CFLAGS` already passed to PAPI, alongside the existing `-Wno-*` flags.
Pinning the dialect keeps `__GLIBC_USE (ISOC23)` off, so it covers the whole family of const-generic
functions rather than requiring a new `-Wno-error=` each time one surfaces. libpfm4's `-Werror` is left
as upstream intends it. This matches how the wider ecosystem is handling glibc 2.43 (cf. grub, pv).

Note this is not addressed by moving the PAPI pin: the effective pin is the submodule gitlink
(`papi-7-2-0-t-183`, 2026-03-16), and the break reproduces there. (I suggested a pin bump on #3515
earlier — that was wrong; this supersedes it.)

`-std=gnu17` is accepted by GCC 8+ and by clang, so it is safe on the clang-based toolchains that
`PAPI_C_COMPILER` can resolve to.

## JIRA ID

N/A (external contributor)

## Test Plan

Built via TheRock, `THEROCK_AMDGPU_FAMILIES=gfx1102;gfx1103`, `BUILD_TESTING=ON`, on
Ubuntu 26.04 / glibc 2.43 / GCC 15.2.0 / CMake 4.2.3 / x86_64. A/B with the patch as the only variable.

## Test Result

| PAPI fix | furthest target | result |
| --- | --- | --- |
| **applied** | **687/688** | `rocprofiler-systems SUCCEEDED`, 0 errors |
| reverted | 102/688 | `FAILED` — `pfmlib_common.c:1891` const-discard |

With the fix, `libpfm.a` and `libpfm.so.4.13.0` are produced, PAPI's utils link, and the full ROCm
build completes with `rocprof-sys-run`, `rocprof-sys-sample` and `rocprof-sys-avail` installed.

Not tested on Cray (cf. #4758), aarch64, or non-Linux.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
