### PR TITLE
[rocjitsu] Preserve vector memory transactions

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -3195,6 +3195,11 @@ class CodeGenerator:
         # Fallback: inline dispatch for classes not yet extracted.
         L = []  # output lines
 
+        # Sleep has no architectural register effect, but FUNCTIONAL execution
+        # must return to the event loop so peer CUs can make progress.
+        if cls == 'true_nop' and sem.name in ('S_SLEEP', 'S_SLEEP_VAR'):
+            return '  wf.cu().request_functional_yield();'
+
         if cls == 'true_nop':
             return '  (void)wf;'
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -2402,10 +2402,14 @@ inline void execute_s_sext_i32_i8_sop1([[maybe_unused]] Inst &inst,
 }
 
 template <typename Inst>
-inline void execute_s_sleep_sopp([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {}
+inline void execute_s_sleep_sopp([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
+  wf.cu().request_functional_yield();
+}
 
 template <typename Inst>
-inline void execute_s_sleep_var_sop1([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {}
+inline void execute_s_sleep_var_sop1([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
+  wf.cu().request_functional_yield();
+}
 
 template <typename Inst>
 inline void execute_s_sub_co_ci_u32_sop2([[maybe_unused]] Inst &inst,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -129,6 +129,12 @@ public:
   /// @brief Execute up to kFunctionalQuantum instructions, then yield.
   virtual bool advance() = 0;
 
+  /// @brief End the current functional-mode quantum after this instruction.
+  ///
+  /// Used by wait-like instructions such as s_sleep so other simulated
+  /// components can publish the state on which the wavefront is polling.
+  void request_functional_yield() { functional_yield_requested_ = true; }
+
   /// @brief Signal that work has been dispatched; begin processing.
   ///
   /// @details Schedules an engine event that calls advance() repeatedly
@@ -537,6 +543,7 @@ protected:
   simdojo::Port *cpl_ = nullptr; ///< Completer port: dispatch activation from CP.
   simdojo::Port *req_ = nullptr; ///< Requester port: L2 cache request (structural).
   uint64_t step_count_ = 0;
+  bool functional_yield_requested_ = false;
 };
 
 /// @brief Execution-mode-aware compute unit shell.
@@ -556,7 +563,11 @@ public:
   /// @brief Execute work up to the quantum limit, then yield.
   bool advance() override {
     if constexpr (Mode == simdojo::ExecMode::FUNCTIONAL) {
+      // A request left by direct step() execution must not shorten this quantum.
+      functional_yield_requested_ = false;
       for (uint32_t i = 0; i < kFunctionalQuantum && step(); ++i) {
+        if (std::exchange(functional_yield_requested_, false))
+          break;
       }
     } else {
       /// @todo: Support CLOCKED pipeline cycle.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
@@ -12,11 +12,13 @@
 #include "simdojo/sim/component.h"
 #include "util/log.h"
 
+#include <algorithm>
 #include <cstring>
 #include <format>
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
+#include <span>
 #include <string>
 #include <sys/uio.h>
 #include <unordered_map>
@@ -41,11 +43,9 @@ public:
       auto &hdr = msg->header();
       auto *data = reinterpret_cast<uint8_t *>(msg->payload());
       if (hdr.op == simdojo::MessageOp::READ) {
-        for (uint32_t i = 0; i < hdr.size_bytes; ++i)
-          data[i] = read8(hdr.addr + i, hdr.vmid);
+        read_block(hdr.addr, std::span<uint8_t>(data, hdr.size_bytes), hdr.vmid);
       } else if (hdr.op == simdojo::MessageOp::WRITE) {
-        for (uint32_t i = 0; i < hdr.size_bytes; ++i)
-          write8(hdr.addr + i, data[i], hdr.vmid);
+        write_block(hdr.addr, std::span<const uint8_t>(data, hdr.size_bytes), hdr.vmid);
       }
       hdr.op = simdojo::MessageOp::RESPONSE;
     });
@@ -106,6 +106,40 @@ public:
   }
 
   uint32_t fetch32(uint64_t addr, uint32_t vmid = 0) const { return read32(addr, vmid); }
+
+  /// @brief Read a contiguous range from simulated GPU memory.
+  /// @details Handles each page through mapped host memory, client memory, or
+  /// sparse backing memory.
+  void read_block(uint64_t addr, std::span<uint8_t> dst, uint32_t vmid = 0) const {
+    for_each_page_chunk(addr, dst.size(), [&](uint64_t ea, size_t offset, size_t chunk) {
+      auto out = dst.subspan(offset, chunk);
+      if (auto *p = translate(ea, vmid)) {
+        std::memcpy(out.data(), p + (ea & PAGE_MASK), chunk);
+        return;
+      }
+      if (vmid > 0 && read_client_memory(ea, out.data(), chunk, vmid))
+        return;
+      for (size_t i = 0; i < chunk; ++i)
+        out[i] = simdojo::SparseMemory::read8(ea + i);
+    });
+  }
+
+  /// @brief Write a contiguous range to simulated GPU memory.
+  /// @details Handles each page through mapped host memory, client memory, or
+  /// sparse backing memory.
+  void write_block(uint64_t addr, std::span<const uint8_t> src, uint32_t vmid = 0) {
+    for_each_page_chunk(addr, src.size(), [&](uint64_t ea, size_t offset, size_t chunk) {
+      auto in = src.subspan(offset, chunk);
+      if (auto *p = translate(ea, vmid)) {
+        std::memcpy(p + (ea & PAGE_MASK), in.data(), chunk);
+        return;
+      }
+      if (vmid > 0 && write_client_memory(ea, in.data(), chunk, vmid))
+        return;
+      for (size_t i = 0; i < chunk; ++i)
+        simdojo::SparseMemory::write8(ea + i, in[i]);
+    });
+  }
 
   uint8_t *translate_debug(uint64_t addr, uint32_t vmid) const { return translate(addr, vmid); }
 
@@ -217,6 +251,16 @@ public:
   }
 
 private:
+  template <typename F> static void for_each_page_chunk(uint64_t addr, size_t len, F &&fn) {
+    size_t offset = 0;
+    while (offset < len) {
+      const uint64_t ea = addr + offset;
+      const size_t chunk = std::min(len - offset, PAGE_SIZE - (ea & PAGE_MASK));
+      fn(ea, offset, chunk);
+      offset += chunk;
+    }
+  }
+
   struct VmidEntry {
     KfdProcess::PageTable *page_table = nullptr;
     std::shared_mutex *mutex = nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_vector_cache.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_vector_cache.cpp
@@ -18,8 +18,8 @@ namespace amdgpu {
 namespace {
 
 template <typename F>
-uint32_t for_each_coalesced_lane_run(const uint64_t *addrs, uint64_t lane_mask, uint32_t stride,
-                                     F &&fn) {
+uint32_t for_each_coalesced_lane_run(const uint64_t *addrs, uint64_t lane_mask, uint32_t wf_size,
+                                     uint32_t stride, F &&fn) {
   uint32_t run_count = 0;
   uint64_t remaining = lane_mask;
   while (remaining) {
@@ -27,7 +27,7 @@ uint32_t for_each_coalesced_lane_run(const uint64_t *addrs, uint64_t lane_mask, 
     remaining &= ~(uint64_t{1} << first_lane);
 
     uint32_t last_lane = first_lane;
-    while (last_lane < 63) {
+    while (last_lane + 1 < wf_size) {
       const uint32_t next_lane = last_lane + 1;
       const uint64_t next_bit = uint64_t{1} << next_lane;
       if (!(remaining & next_bit) || addrs[next_lane] != addrs[last_lane] + stride)
@@ -175,10 +175,10 @@ void L1VectorCache::write_bytes(uint64_t addr, const uint8_t *src, uint32_t size
 
 void L1VectorCache::load(const uint64_t *addrs, uint64_t lane_mask, uint32_t elem_size,
                          uint32_t num_elems, uint8_t *dst, Mtype mtype, bool non_temporal,
-                         bool request_l1_bypass, uint32_t vmid) {
+                         bool request_l1_bypass, uint32_t wf_size, uint32_t vmid) {
   uint32_t stride = num_elems * elem_size;
   for_each_coalesced_lane_run(
-      addrs, lane_mask, stride, [&](uint32_t first_lane, uint32_t run_lanes) {
+      addrs, lane_mask, wf_size, stride, [&](uint32_t first_lane, uint32_t run_lanes) {
         read_bytes(addrs[first_lane], dst + first_lane * stride, run_lanes * stride, mtype,
                    non_temporal, request_l1_bypass, vmid);
       });
@@ -186,14 +186,14 @@ void L1VectorCache::load(const uint64_t *addrs, uint64_t lane_mask, uint32_t ele
 
 void L1VectorCache::store(const uint64_t *addrs, uint64_t lane_mask, uint32_t elem_size,
                           uint32_t num_elems, const uint8_t *src, Mtype mtype, bool non_temporal,
-                          uint32_t vmid) {
+                          uint32_t wf_size, uint32_t vmid) {
   uint32_t stride = num_elems * elem_size;
   const uint32_t active_lanes = std::popcount(lane_mask);
   ++store_count_;
   if (active_lanes > 0)
     ++store_active_count_;
   store_l2_writes_ += for_each_coalesced_lane_run(
-      addrs, lane_mask, stride, [&](uint32_t first_lane, uint32_t run_lanes) {
+      addrs, lane_mask, wf_size, stride, [&](uint32_t first_lane, uint32_t run_lanes) {
         write_bytes(addrs[first_lane], src + first_lane * stride, run_lanes * stride, mtype,
                     non_temporal, vmid);
       });

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_vector_cache.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_vector_cache.cpp
@@ -15,6 +15,34 @@
 
 namespace rocjitsu {
 namespace amdgpu {
+namespace {
+
+template <typename F>
+uint32_t for_each_coalesced_lane_run(const uint64_t *addrs, uint64_t lane_mask, uint32_t stride,
+                                     F &&fn) {
+  uint32_t run_count = 0;
+  uint64_t remaining = lane_mask;
+  while (remaining) {
+    const uint32_t first_lane = std::countr_zero(remaining);
+    remaining &= ~(uint64_t{1} << first_lane);
+
+    uint32_t last_lane = first_lane;
+    while (last_lane < 63) {
+      const uint32_t next_lane = last_lane + 1;
+      const uint64_t next_bit = uint64_t{1} << next_lane;
+      if (!(remaining & next_bit) || addrs[next_lane] != addrs[last_lane] + stride)
+        break;
+      remaining &= ~next_bit;
+      last_lane = next_lane;
+    }
+
+    fn(first_lane, last_lane - first_lane + 1);
+    ++run_count;
+  }
+  return run_count;
+}
+
+} // namespace
 
 void L1VectorCache::ensure_line(uint64_t addr, uint32_t vmid) {
   if (cache_.lookup(addr, nullptr, vmid))
@@ -149,38 +177,26 @@ void L1VectorCache::load(const uint64_t *addrs, uint64_t lane_mask, uint32_t ele
                          uint32_t num_elems, uint8_t *dst, Mtype mtype, bool non_temporal,
                          bool request_l1_bypass, uint32_t vmid) {
   uint32_t stride = num_elems * elem_size;
-  uint64_t remaining = lane_mask;
-  while (remaining) {
-    uint32_t lane = std::countr_zero(remaining);
-    remaining &= remaining - 1;
-    uint64_t base = addrs[lane];
-    for (uint32_t e = 0; e < num_elems; ++e) {
-      uint64_t ea = base + e * elem_size;
-      read_bytes(ea, dst + lane * stride + e * elem_size, elem_size, mtype, non_temporal,
-                 request_l1_bypass, vmid);
-    }
-  }
+  for_each_coalesced_lane_run(
+      addrs, lane_mask, stride, [&](uint32_t first_lane, uint32_t run_lanes) {
+        read_bytes(addrs[first_lane], dst + first_lane * stride, run_lanes * stride, mtype,
+                   non_temporal, request_l1_bypass, vmid);
+      });
 }
 
 void L1VectorCache::store(const uint64_t *addrs, uint64_t lane_mask, uint32_t elem_size,
                           uint32_t num_elems, const uint8_t *src, Mtype mtype, bool non_temporal,
                           uint32_t vmid) {
   uint32_t stride = num_elems * elem_size;
-  uint32_t active_lanes = std::popcount(lane_mask);
+  const uint32_t active_lanes = std::popcount(lane_mask);
   ++store_count_;
   if (active_lanes > 0)
     ++store_active_count_;
-  store_l2_writes_ += active_lanes * num_elems;
-  uint64_t remaining = lane_mask;
-  while (remaining) {
-    uint32_t lane = std::countr_zero(remaining);
-    remaining &= remaining - 1;
-    uint64_t base = addrs[lane];
-    for (uint32_t e = 0; e < num_elems; ++e) {
-      uint64_t ea = base + e * elem_size;
-      write_bytes(ea, src + lane * stride + e * elem_size, elem_size, mtype, non_temporal, vmid);
-    }
-  }
+  store_l2_writes_ += for_each_coalesced_lane_run(
+      addrs, lane_mask, stride, [&](uint32_t first_lane, uint32_t run_lanes) {
+        write_bytes(addrs[first_lane], src + first_lane * stride, run_lanes * stride, mtype,
+                    non_temporal, vmid);
+      });
 }
 
 void L1VectorCache::flush_all() { cache_.invalidate_all(); }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_vector_cache.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_vector_cache.h
@@ -36,11 +36,12 @@ public:
   void set_l2(L2Cache *l2) { l2_ = l2; }
   void set_memory(GpuMemory *mem) { memory_ = mem; }
   void load(const uint64_t *addrs, uint64_t lane_mask, uint32_t elem_size, uint32_t num_elems,
-            uint8_t *dst, Mtype mtype, bool non_temporal, bool request_l1_bypass,
+            uint8_t *dst, Mtype mtype, bool non_temporal, bool request_l1_bypass, uint32_t wf_size,
             uint32_t vmid = 0);
 
   void store(const uint64_t *addrs, uint64_t lane_mask, uint32_t elem_size, uint32_t num_elems,
-             const uint8_t *src, Mtype mtype, bool non_temporal, uint32_t vmid = 0);
+             const uint8_t *src, Mtype mtype, bool non_temporal, uint32_t wf_size,
+             uint32_t vmid = 0);
 
   void invalidate(uint64_t addr, uint32_t vmid = 0) { cache_.invalidate(addr, vmid); }
   void invalidate_all() { cache_.invalidate_all(); }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.cpp
@@ -10,12 +10,17 @@
 #include <bit>
 #include <cassert>
 #include <cstring>
+#include <span>
 
 namespace rocjitsu {
 namespace amdgpu {
 
 void L2Cache::send_backing(uint64_t addr, uint8_t *data, uint32_t size, simdojo::MessageOp op,
                            uint32_t vmid) {
+  if (op == simdojo::MessageOp::WRITE)
+    backing_write_transactions_.fetch_add(1, std::memory_order_relaxed);
+  else
+    backing_read_transactions_.fetch_add(1, std::memory_order_relaxed);
   if (backing_memory_) {
     if (op == simdojo::MessageOp::WRITE) {
       static std::atomic<uint64_t> wb_count{0};
@@ -23,11 +28,9 @@ void L2Cache::send_backing(uint64_t addr, uint8_t *data, uint32_t size, simdojo:
       if (count <= 3)
         util::Logger::vm("L2 writeback(backing) #", count, " addr=0x", std::hex, addr,
                          " size=", std::dec, size);
-      for (uint32_t i = 0; i < size; ++i)
-        backing_memory_->write8(addr + i, data[i], vmid);
+      backing_memory_->write_block(addr, std::span<const uint8_t>(data, size), vmid);
     } else {
-      for (uint32_t i = 0; i < size; ++i)
-        data[i] = backing_memory_->read8(addr + i, vmid);
+      backing_memory_->read_block(addr, std::span<uint8_t>(data, size), vmid);
     }
     return;
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.h
@@ -13,6 +13,7 @@
 #include "simdojo/sim/message.h"
 
 #include <array>
+#include <atomic>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -79,6 +80,13 @@ public:
   /// @brief Set the backing memory for direct writeback in functional mode.
   /// @param mem GpuMemory instance (used when req_port_ has no link).
   void set_backing_memory(GpuMemory *mem) { backing_memory_ = mem; }
+
+  uint64_t backing_read_transactions() const {
+    return backing_read_transactions_.load(std::memory_order_relaxed);
+  }
+  uint64_t backing_write_transactions() const {
+    return backing_write_transactions_.load(std::memory_order_relaxed);
+  }
 
   /// @brief Read a cache line worth of data (or partial line).
   ///
@@ -202,6 +210,9 @@ private:
   std::array<std::mutex, ATOMIC_STRIPE_COUNT> atomic_stripes_;
   std::vector<simdojo::Port *> cpl_ports_;
   uint64_t write_count_ = 0; ///< Debug: total L2 writes (for trace).
+  // Relaxed atomics: striped atomic_rmw() calls can update these concurrently.
+  std::atomic<uint64_t> backing_read_transactions_{0};
+  std::atomic<uint64_t> backing_write_transactions_{0};
 };
 
 } // namespace amdgpu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
@@ -490,10 +490,10 @@ void GlobalMemPipeline::initiate_access(Instruction &inst, Wavefront &wf) {
   if (d.is_load) {
     d.response_data.resize(d.wf_size * d.num_elems * d.elem_size);
     l1_->load(d.per_lane_addr.data(), d.lane_mask, d.elem_size, d.num_elems, d.response_data.data(),
-              d.mtype, d.non_temporal, d.request_force_l1_bypass, wf.process_id());
+              d.mtype, d.non_temporal, d.request_force_l1_bypass, d.wf_size, wf.process_id());
   } else {
     l1_->store(d.per_lane_addr.data(), d.lane_mask, d.elem_size, d.num_elems, d.store_data.data(),
-               d.mtype, d.non_temporal, wf.process_id());
+               d.mtype, d.non_temporal, d.wf_size, wf.process_id());
   }
 }
 

--- a/emulation/rocjitsu/tests/decode_smoke_test.cpp
+++ b/emulation/rocjitsu/tests/decode_smoke_test.cpp
@@ -609,6 +609,40 @@ INSTANTIATE_TEST_SUITE_P(
       return std::string(info.param.arch_name);
     });
 
+void expect_sleep_yields_before_quantum_expires(rj_code_arch_t arch, uint32_t sleep_encoding) {
+  constexpr uint64_t kCodeAddress = 0x2000;
+
+  amdgpu::GpuMemory gpu_mem("functional_sleep_mem");
+  amdgpu::L2Cache l2("functional_sleep_l2");
+  gpu_mem.write32(kCodeAddress, sleep_encoding);
+  gpu_mem.write32(kCodeAddress + sizeof(uint32_t), S_NOP);
+
+  amdgpu::ComputeUnitCore::Config cfg{};
+  cfg.arch = arch;
+  cfg.num_wf_slots = 1;
+  cfg.sgprs_per_wf = 104;
+  cfg.vgprs_per_wf = 256;
+  cfg.lds_size_kb = 64;
+
+  auto cu = amdgpu::ComputeUnitCore::create("functional_sleep_cu", cfg, &gpu_mem, &l2);
+  ASSERT_NE(cu, nullptr);
+  auto *wf = cu->dispatch_wf(0, kCodeAddress, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
+  ASSERT_NE(wf, nullptr);
+
+  EXPECT_TRUE(cu->advance());
+  EXPECT_EQ(wf->pc, kCodeAddress + sizeof(uint32_t));
+}
+
+TEST(FunctionalSchedulingTest, SleepYieldsBeforeQuantumExpires) {
+  constexpr uint32_t kSleep = 0xBF8E0001u; // CDNA4 s_sleep 1
+  expect_sleep_yields_before_quantum_expires(ROCJITSU_CODE_ARCH_CDNA4, kSleep);
+}
+
+TEST(FunctionalSchedulingTest, SleepVarYieldsBeforeQuantumExpires) {
+  constexpr uint32_t kSleepVar = 0xBE805800u; // RDNA4 s_sleep_var s0
+  expect_sleep_yields_before_quantum_expires(ROCJITSU_CODE_ARCH_RDNA4, kSleepVar);
+}
+
 // ---------------------------------------------------------------------------
 // MUBUF lds modifier test: verify that buffer_load_dword with the lds bit set
 // (bit 16 of dword 0) produces a disassembly string containing " lds".

--- a/emulation/rocjitsu/tests/shared_infra_test.cpp
+++ b/emulation/rocjitsu/tests/shared_infra_test.cpp
@@ -1098,7 +1098,8 @@ TEST(L1VectorCacheTest, UcReadInvalidatesResidentLine) {
 
   mem.write32(kAddr, kOldValue);
   l1.load(addrs, /*lane_mask=*/0x1, /*elem_size=*/4, /*num_elems=*/1, bytes.data(),
-          amdgpu::Mtype::RW, /*non_temporal=*/false, /*request_l1_bypass=*/false);
+          amdgpu::Mtype::RW, /*non_temporal=*/false, /*request_l1_bypass=*/false,
+          cdna3::Isa::WF_SIZE);
   uint32_t value = 0;
   std::memcpy(&value, bytes.data(), sizeof(value));
   ASSERT_EQ(value, kOldValue);
@@ -1106,13 +1107,15 @@ TEST(L1VectorCacheTest, UcReadInvalidatesResidentLine) {
   mem.write32(kAddr, kNewValue);
   bytes.fill(0);
   l1.load(addrs, /*lane_mask=*/0x1, /*elem_size=*/4, /*num_elems=*/1, bytes.data(),
-          amdgpu::Mtype::UC, /*non_temporal=*/false, /*request_l1_bypass=*/false);
+          amdgpu::Mtype::UC, /*non_temporal=*/false, /*request_l1_bypass=*/false,
+          cdna3::Isa::WF_SIZE);
   std::memcpy(&value, bytes.data(), sizeof(value));
   ASSERT_EQ(value, kNewValue);
 
   bytes.fill(0);
   l1.load(addrs, /*lane_mask=*/0x1, /*elem_size=*/4, /*num_elems=*/1, bytes.data(),
-          amdgpu::Mtype::RW, /*non_temporal=*/false, /*request_l1_bypass=*/false);
+          amdgpu::Mtype::RW, /*non_temporal=*/false, /*request_l1_bypass=*/false,
+          cdna3::Isa::WF_SIZE);
   std::memcpy(&value, bytes.data(), sizeof(value));
   EXPECT_EQ(value, kNewValue);
 }
@@ -1197,13 +1200,14 @@ TEST(L1VectorCacheTest, UcDwordx4RoundTripPreservesVectorTransaction) {
   std::memcpy(store_bytes.data() + sizeof(kLane0), kLane1.data(), sizeof(kLane1));
 
   l1.store(addrs, /*lane_mask=*/0x3, /*elem_size=*/4, /*num_elems=*/4, store_bytes.data(),
-           amdgpu::Mtype::UC, /*non_temporal=*/false);
+           amdgpu::Mtype::UC, /*non_temporal=*/false, cdna3::Isa::WF_SIZE);
   EXPECT_EQ(l1.store_l2_writes(), 2u);
   EXPECT_EQ(l2.backing_write_transactions(), 2u);
 
   std::array<uint8_t, 64 * sizeof(kLane0)> load_bytes{};
   l1.load(addrs, /*lane_mask=*/0x3, /*elem_size=*/4, /*num_elems=*/4, load_bytes.data(),
-          amdgpu::Mtype::UC, /*non_temporal=*/false, /*request_l1_bypass=*/false);
+          amdgpu::Mtype::UC, /*non_temporal=*/false, /*request_l1_bypass=*/false,
+          cdna3::Isa::WF_SIZE);
   EXPECT_EQ(l2.backing_read_transactions(), 2u);
   EXPECT_EQ(std::memcmp(load_bytes.data(), kLane0.data(), sizeof(kLane0)), 0);
   EXPECT_EQ(std::memcmp(load_bytes.data() + sizeof(kLane0), kLane1.data(), sizeof(kLane1)), 0);
@@ -1226,13 +1230,14 @@ TEST(L1VectorCacheTest, UcDwordx4CoalescesAdjacentLanes) {
   std::memcpy(store_bytes.data() + sizeof(kLane0), kLane1.data(), sizeof(kLane1));
 
   l1.store(addrs, /*lane_mask=*/0x3, /*elem_size=*/4, /*num_elems=*/4, store_bytes.data(),
-           amdgpu::Mtype::UC, /*non_temporal=*/false);
+           amdgpu::Mtype::UC, /*non_temporal=*/false, cdna3::Isa::WF_SIZE);
   EXPECT_EQ(l1.store_l2_writes(), 1u);
   EXPECT_EQ(l2.backing_write_transactions(), 1u);
 
   std::array<uint8_t, 64 * sizeof(kLane0)> load_bytes{};
   l1.load(addrs, /*lane_mask=*/0x3, /*elem_size=*/4, /*num_elems=*/4, load_bytes.data(),
-          amdgpu::Mtype::UC, /*non_temporal=*/false, /*request_l1_bypass=*/false);
+          amdgpu::Mtype::UC, /*non_temporal=*/false, /*request_l1_bypass=*/false,
+          cdna3::Isa::WF_SIZE);
   EXPECT_EQ(l2.backing_read_transactions(), 1u);
   EXPECT_EQ(std::memcmp(load_bytes.data(), kLane0.data(), sizeof(kLane0)), 0);
   EXPECT_EQ(std::memcmp(load_bytes.data() + sizeof(kLane0), kLane1.data(), sizeof(kLane1)), 0);
@@ -1254,7 +1259,8 @@ TEST(L1VectorCacheTest, UcWriteInvalidatesResidentLine) {
 
   mem.write32(kAddr, kOldValue);
   l1.load(addrs, /*lane_mask=*/0x1, /*elem_size=*/4, /*num_elems=*/1, bytes.data(),
-          amdgpu::Mtype::RW, /*non_temporal=*/false, /*request_l1_bypass=*/false);
+          amdgpu::Mtype::RW, /*non_temporal=*/false, /*request_l1_bypass=*/false,
+          cdna3::Isa::WF_SIZE);
   uint32_t value = 0;
   std::memcpy(&value, bytes.data(), sizeof(value));
   ASSERT_EQ(value, kOldValue);
@@ -1262,11 +1268,12 @@ TEST(L1VectorCacheTest, UcWriteInvalidatesResidentLine) {
   std::array<uint8_t, 64 * sizeof(uint32_t)> store_bytes{};
   std::memcpy(store_bytes.data(), &kNewValue, sizeof(kNewValue));
   l1.store(addrs, /*lane_mask=*/0x1, /*elem_size=*/4, /*num_elems=*/1, store_bytes.data(),
-           amdgpu::Mtype::UC, /*non_temporal=*/false);
+           amdgpu::Mtype::UC, /*non_temporal=*/false, cdna3::Isa::WF_SIZE);
 
   bytes.fill(0);
   l1.load(addrs, /*lane_mask=*/0x1, /*elem_size=*/4, /*num_elems=*/1, bytes.data(),
-          amdgpu::Mtype::RW, /*non_temporal=*/false, /*request_l1_bypass=*/false);
+          amdgpu::Mtype::RW, /*non_temporal=*/false, /*request_l1_bypass=*/false,
+          cdna3::Isa::WF_SIZE);
   std::memcpy(&value, bytes.data(), sizeof(value));
   EXPECT_EQ(value, kNewValue);
 }
@@ -1287,7 +1294,8 @@ TEST(L1VectorCacheTest, NonTemporalReadInvalidatesResidentLine) {
 
   mem.write32(kAddr, kOldValue);
   l1.load(addrs, /*lane_mask=*/0x1, /*elem_size=*/4, /*num_elems=*/1, bytes.data(),
-          amdgpu::Mtype::RW, /*non_temporal=*/false, /*request_l1_bypass=*/false);
+          amdgpu::Mtype::RW, /*non_temporal=*/false, /*request_l1_bypass=*/false,
+          cdna3::Isa::WF_SIZE);
   uint32_t value = 0;
   std::memcpy(&value, bytes.data(), sizeof(value));
   ASSERT_EQ(value, kOldValue);
@@ -1297,13 +1305,15 @@ TEST(L1VectorCacheTest, NonTemporalReadInvalidatesResidentLine) {
 
   bytes.fill(0);
   l1.load(addrs, /*lane_mask=*/0x1, /*elem_size=*/4, /*num_elems=*/1, bytes.data(),
-          amdgpu::Mtype::RW, /*non_temporal=*/true, /*request_l1_bypass=*/false);
+          amdgpu::Mtype::RW, /*non_temporal=*/true, /*request_l1_bypass=*/false,
+          cdna3::Isa::WF_SIZE);
   std::memcpy(&value, bytes.data(), sizeof(value));
   ASSERT_EQ(value, kNewValue);
 
   bytes.fill(0);
   l1.load(addrs, /*lane_mask=*/0x1, /*elem_size=*/4, /*num_elems=*/1, bytes.data(),
-          amdgpu::Mtype::RW, /*non_temporal=*/false, /*request_l1_bypass=*/false);
+          amdgpu::Mtype::RW, /*non_temporal=*/false, /*request_l1_bypass=*/false,
+          cdna3::Isa::WF_SIZE);
   std::memcpy(&value, bytes.data(), sizeof(value));
   EXPECT_EQ(value, kNewValue);
 }
@@ -1324,7 +1334,8 @@ TEST(L1VectorCacheTest, L1BypassReadInvalidatesResidentLine) {
 
   mem.write32(kAddr, kOldValue);
   l1.load(addrs, /*lane_mask=*/0x1, /*elem_size=*/4, /*num_elems=*/1, bytes.data(),
-          amdgpu::Mtype::RW, /*non_temporal=*/false, /*request_l1_bypass=*/false);
+          amdgpu::Mtype::RW, /*non_temporal=*/false, /*request_l1_bypass=*/false,
+          cdna3::Isa::WF_SIZE);
   uint32_t value = 0;
   std::memcpy(&value, bytes.data(), sizeof(value));
   ASSERT_EQ(value, kOldValue);
@@ -1334,13 +1345,15 @@ TEST(L1VectorCacheTest, L1BypassReadInvalidatesResidentLine) {
 
   bytes.fill(0);
   l1.load(addrs, /*lane_mask=*/0x1, /*elem_size=*/4, /*num_elems=*/1, bytes.data(),
-          amdgpu::Mtype::RW, /*non_temporal=*/false, /*request_l1_bypass=*/true);
+          amdgpu::Mtype::RW, /*non_temporal=*/false, /*request_l1_bypass=*/true,
+          cdna3::Isa::WF_SIZE);
   std::memcpy(&value, bytes.data(), sizeof(value));
   ASSERT_EQ(value, kNewValue);
 
   bytes.fill(0);
   l1.load(addrs, /*lane_mask=*/0x1, /*elem_size=*/4, /*num_elems=*/1, bytes.data(),
-          amdgpu::Mtype::RW, /*non_temporal=*/false, /*request_l1_bypass=*/false);
+          amdgpu::Mtype::RW, /*non_temporal=*/false, /*request_l1_bypass=*/false,
+          cdna3::Isa::WF_SIZE);
   std::memcpy(&value, bytes.data(), sizeof(value));
   EXPECT_EQ(value, kNewValue);
 }
@@ -1361,7 +1374,8 @@ TEST(L1VectorCacheTest, NonTemporalWriteInvalidatesResidentLine) {
 
   mem.write32(kAddr, kOldValue);
   l1.load(addrs, /*lane_mask=*/0x1, /*elem_size=*/4, /*num_elems=*/1, bytes.data(),
-          amdgpu::Mtype::RW, /*non_temporal=*/false, /*request_l1_bypass=*/false);
+          amdgpu::Mtype::RW, /*non_temporal=*/false, /*request_l1_bypass=*/false,
+          cdna3::Isa::WF_SIZE);
   uint32_t value = 0;
   std::memcpy(&value, bytes.data(), sizeof(value));
   ASSERT_EQ(value, kOldValue);
@@ -1369,11 +1383,12 @@ TEST(L1VectorCacheTest, NonTemporalWriteInvalidatesResidentLine) {
   std::array<uint8_t, 64 * sizeof(uint32_t)> store_bytes{};
   std::memcpy(store_bytes.data(), &kNewValue, sizeof(kNewValue));
   l1.store(addrs, /*lane_mask=*/0x1, /*elem_size=*/4, /*num_elems=*/1, store_bytes.data(),
-           amdgpu::Mtype::RW, /*non_temporal=*/true);
+           amdgpu::Mtype::RW, /*non_temporal=*/true, cdna3::Isa::WF_SIZE);
 
   bytes.fill(0);
   l1.load(addrs, /*lane_mask=*/0x1, /*elem_size=*/4, /*num_elems=*/1, bytes.data(),
-          amdgpu::Mtype::RW, /*non_temporal=*/false, /*request_l1_bypass=*/false);
+          amdgpu::Mtype::RW, /*non_temporal=*/false, /*request_l1_bypass=*/false,
+          cdna3::Isa::WF_SIZE);
   std::memcpy(&value, bytes.data(), sizeof(value));
   EXPECT_EQ(value, kNewValue);
 }

--- a/emulation/rocjitsu/tests/shared_infra_test.cpp
+++ b/emulation/rocjitsu/tests/shared_infra_test.cpp
@@ -72,6 +72,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <array>
 #include <bit>
 #include <cstdint>
@@ -79,6 +80,7 @@
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
+#include <span>
 #include <string>
 #include <utility>
 
@@ -1113,6 +1115,127 @@ TEST(L1VectorCacheTest, UcReadInvalidatesResidentLine) {
           amdgpu::Mtype::RW, /*non_temporal=*/false, /*request_l1_bypass=*/false);
   std::memcpy(&value, bytes.data(), sizeof(value));
   EXPECT_EQ(value, kNewValue);
+}
+
+TEST(GpuMemoryTest, BlockAccessSpansSparseFallbackPages) {
+  amdgpu::GpuMemory mem("test_mem");
+  constexpr uint64_t kAddr = amdgpu::GpuMemory::PAGE_SIZE - 8;
+  constexpr std::array<uint8_t, 16> kData = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+                                             0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+
+  mem.write_block(kAddr, std::span<const uint8_t>(kData));
+  std::array<uint8_t, kData.size()> result{};
+  mem.read_block(kAddr, std::span<uint8_t>(result));
+
+  EXPECT_EQ(result, kData);
+}
+
+TEST(GpuMemoryTest, BlockAccessSpansMappedPages) {
+  amdgpu::GpuMemory mem("test_mem");
+  constexpr uint32_t kVmid = 8;
+  constexpr uint64_t kAddr = KfdProcess::kPageSize - 8;
+  constexpr std::array<uint8_t, 16> kData = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+                                             0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+
+  std::array<uint8_t, KfdProcess::kPageSize> first_page{};
+  std::array<uint8_t, KfdProcess::kPageSize> second_page{};
+  KfdProcess::PageTable page_table;
+  std::shared_mutex page_table_mutex;
+  page_table[0] = {first_page.data(), amdgpu::Mtype::RW};
+  page_table[1] = {second_page.data(), amdgpu::Mtype::RW};
+  mem.register_process(kVmid, &page_table, &page_table_mutex);
+
+  mem.write_block(kAddr, std::span<const uint8_t>(kData), kVmid);
+  std::array<uint8_t, kData.size()> result{};
+  mem.read_block(kAddr, std::span<uint8_t>(result), kVmid);
+
+  EXPECT_EQ(result, kData);
+}
+
+TEST(GpuMemoryTest, BlockAccessRechecksTranslationAfterSparseFallbackPage) {
+  amdgpu::GpuMemory mem("test_mem");
+  constexpr uint32_t kVmid = 9;
+  constexpr uint64_t kAddr = KfdProcess::kPageSize - 8;
+  constexpr std::array<uint8_t, 16> kReadData = {0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+                                                 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27};
+  constexpr std::array<uint8_t, 16> kWriteData = {0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+                                                  0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47};
+
+  std::array<uint8_t, KfdProcess::kPageSize> second_page{};
+  std::copy(kReadData.begin() + 8, kReadData.end(), second_page.begin());
+  KfdProcess::PageTable page_table;
+  std::shared_mutex page_table_mutex;
+  page_table[1] = {second_page.data(), amdgpu::Mtype::RW};
+  mem.register_process(kVmid, &page_table, &page_table_mutex);
+  for (size_t i = 0; i < 8; ++i)
+    mem.write8(kAddr + i, kReadData[i], kVmid);
+
+  std::array<uint8_t, kReadData.size()> result{};
+  mem.read_block(kAddr, std::span<uint8_t>(result), kVmid);
+  EXPECT_EQ(result, kReadData);
+
+  mem.write_block(kAddr, std::span<const uint8_t>(kWriteData), kVmid);
+  for (size_t i = 0; i < 8; ++i)
+    EXPECT_EQ(mem.read8(kAddr + i, kVmid), kWriteData[i]);
+  EXPECT_TRUE(std::equal(kWriteData.begin() + 8, kWriteData.end(), second_page.begin()));
+}
+
+TEST(L1VectorCacheTest, UcDwordx4RoundTripPreservesVectorTransaction) {
+  amdgpu::GpuMemory mem("test_mem");
+  amdgpu::L2Cache l2("test_l2");
+  amdgpu::L1VectorCache l1(&l2);
+  l2.set_backing_memory(&mem);
+
+  constexpr uint64_t kAddr = 0x7800;
+  constexpr std::array<uint32_t, 4> kLane0 = {0x01234567u, 0x89ABCDEFu, 0x76543210u, 0xFEDCBA98u};
+  constexpr std::array<uint32_t, 4> kLane1 = {0x11112222u, 0x33334444u, 0x55556666u, 0x77778888u};
+  uint64_t addrs[64] = {};
+  addrs[0] = kAddr;
+  addrs[1] = kAddr + 0x100;
+  std::array<uint8_t, 64 * sizeof(kLane0)> store_bytes{};
+  std::memcpy(store_bytes.data(), kLane0.data(), sizeof(kLane0));
+  std::memcpy(store_bytes.data() + sizeof(kLane0), kLane1.data(), sizeof(kLane1));
+
+  l1.store(addrs, /*lane_mask=*/0x3, /*elem_size=*/4, /*num_elems=*/4, store_bytes.data(),
+           amdgpu::Mtype::UC, /*non_temporal=*/false);
+  EXPECT_EQ(l1.store_l2_writes(), 2u);
+  EXPECT_EQ(l2.backing_write_transactions(), 2u);
+
+  std::array<uint8_t, 64 * sizeof(kLane0)> load_bytes{};
+  l1.load(addrs, /*lane_mask=*/0x3, /*elem_size=*/4, /*num_elems=*/4, load_bytes.data(),
+          amdgpu::Mtype::UC, /*non_temporal=*/false, /*request_l1_bypass=*/false);
+  EXPECT_EQ(l2.backing_read_transactions(), 2u);
+  EXPECT_EQ(std::memcmp(load_bytes.data(), kLane0.data(), sizeof(kLane0)), 0);
+  EXPECT_EQ(std::memcmp(load_bytes.data() + sizeof(kLane0), kLane1.data(), sizeof(kLane1)), 0);
+}
+
+TEST(L1VectorCacheTest, UcDwordx4CoalescesAdjacentLanes) {
+  amdgpu::GpuMemory mem("test_mem");
+  amdgpu::L2Cache l2("test_l2");
+  amdgpu::L1VectorCache l1(&l2);
+  l2.set_backing_memory(&mem);
+
+  constexpr uint64_t kAddr = 0x7900;
+  constexpr std::array<uint32_t, 4> kLane0 = {0x01234567u, 0x89ABCDEFu, 0x76543210u, 0xFEDCBA98u};
+  constexpr std::array<uint32_t, 4> kLane1 = {0x11112222u, 0x33334444u, 0x55556666u, 0x77778888u};
+  uint64_t addrs[64] = {};
+  addrs[0] = kAddr;
+  addrs[1] = kAddr + sizeof(kLane0);
+  std::array<uint8_t, 64 * sizeof(kLane0)> store_bytes{};
+  std::memcpy(store_bytes.data(), kLane0.data(), sizeof(kLane0));
+  std::memcpy(store_bytes.data() + sizeof(kLane0), kLane1.data(), sizeof(kLane1));
+
+  l1.store(addrs, /*lane_mask=*/0x3, /*elem_size=*/4, /*num_elems=*/4, store_bytes.data(),
+           amdgpu::Mtype::UC, /*non_temporal=*/false);
+  EXPECT_EQ(l1.store_l2_writes(), 1u);
+  EXPECT_EQ(l2.backing_write_transactions(), 1u);
+
+  std::array<uint8_t, 64 * sizeof(kLane0)> load_bytes{};
+  l1.load(addrs, /*lane_mask=*/0x3, /*elem_size=*/4, /*num_elems=*/4, load_bytes.data(),
+          amdgpu::Mtype::UC, /*non_temporal=*/false, /*request_l1_bypass=*/false);
+  EXPECT_EQ(l2.backing_read_transactions(), 1u);
+  EXPECT_EQ(std::memcmp(load_bytes.data(), kLane0.data(), sizeof(kLane0)), 0);
+  EXPECT_EQ(std::memcmp(load_bytes.data() + sizeof(kLane0), kLane1.data(), sizeof(kLane1)), 0);
 }
 
 TEST(L1VectorCacheTest, UcWriteInvalidatesResidentLine) {


### PR DESCRIPTION
## Motivation

Keep dwordxN accesses as one per-lane transaction through the functional memory hierarchy and make sleep instructions yield the functional quantum so communication kernels cannot monopolize a CU.

Preserve VMID translation priority at page boundaries, keep generated sleep behavior sourced from amdisa, and align transaction metrics and regression coverage with the coalesced path.

This is to fix timeouts on RCCL tests.

## Technical Details

RCCL tests using the default protocol were unusually slow and intermittently timed out under RocJITsu. Setting `NCCL_PROTO` avoided the problematic path, but that also reduced coverage of the behavior users receive by default.

The slowdown came from two simulator behaviors:
1. Vector memory operations were decomposed first into individual elements and then into individual bytes, greatly amplifying backing-memory traffic.
2. `s_sleep` was treated as a no-op, allowing polling and wait loops to consume an entire functional execution quantum instead of yielding to work on peer compute units.

This change fixes those simulator behaviors directly, so the default RCCL protocol can remain covered.

## JIRA ID

N/A

## Test Plan

Run unit tests.

## Test Result

RCCL tests take <9s each now and don't time out.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.