### PR TITLE
fix(rdc): report PENDING_PAGE_NUM as 0 when no bad pages are present

### DIFF
--- a/projects/rdc/include/rdc_lib/impl/SmiUtils.h
+++ b/projects/rdc/include/rdc_lib/impl/SmiUtils.h
@@ -32,6 +32,9 @@ namespace amd {
 namespace rdc {
 
 rdc_status_t Smi2RdcError(amdsmi_status_t rsmi);
+// Count how many of the retired/bad-page records are pending retirement.
+// Returns 0 when records is null or count is 0.
+uint64_t count_pending_bad_pages(const amdsmi_retired_page_record_t* records, uint32_t count);
 amdsmi_status_t get_processor_handle_from_id(uint32_t gpu_id,
                                              amdsmi_processor_handle* processor_handle);
 amdsmi_status_t get_gpu_id_from_processor_handle(amdsmi_processor_handle processor_handle,

--- a/projects/rdc/rdc_libs/rdc/src/RdcMetricFetcherImpl.cc
+++ b/projects/rdc/rdc_libs/rdc/src/RdcMetricFetcherImpl.cc
@@ -1198,31 +1198,37 @@ rdc_status_t RdcMetricFetcherImpl::fetch_gpu_field_(uint32_t gpu_index, rdc_fiel
     case RDC_HEALTH_PENDING_PAGE_NUM: {
       uint32_t num_pages = 0;
       ret = amdsmi_get_gpu_bad_page_info(processor_handle, &num_pages, nullptr);
-      if (AMDSMI_STATUS_SUCCESS == ret) {
-        if (RDC_HEALTH_RETIRED_PAGE_NUM == field_id) {
+      if (AMDSMI_STATUS_SUCCESS != ret) {
+        value->status = Smi2RdcError(ret);
+        break;
+      }
+
+      value->type = INTEGER;
+
+      if (RDC_HEALTH_RETIRED_PAGE_NUM == field_id) {
+        value->status = Smi2RdcError(ret);
+        value->value.l_int = static_cast<int64_t>(num_pages);
+        break;
+      }
+
+      // RDC_HEALTH_PENDING_PAGE_NUM: count pages pending retirement. When there are no
+      // bad pages (num_pages == 0) the count is simply 0; report it as a valid value
+      // instead of leaving the default NOT_SUPPORTED status, which surfaced as N/A.
+      uint64_t pending_page_num = 0;
+      if (0 < num_pages) {
+        std::vector<amdsmi_retired_page_record_t> bad_page_info(num_pages);
+        ret = amdsmi_get_gpu_bad_page_info(processor_handle, &num_pages, bad_page_info.data());
+        if (AMDSMI_STATUS_SUCCESS != ret) {
           value->status = Smi2RdcError(ret);
-          value->type = INTEGER;
-          value->value.l_int = static_cast<int64_t>(num_pages);
           break;
         }
-
-        if ((0 < num_pages) && (RDC_HEALTH_PENDING_PAGE_NUM == field_id)) {
-          std::vector<amdsmi_retired_page_record_t> bad_page_info(num_pages);
-          ret = amdsmi_get_gpu_bad_page_info(processor_handle, &num_pages, bad_page_info.data());
-          value->status = Smi2RdcError(ret);
-          value->type = INTEGER;
-          if (AMDSMI_STATUS_SUCCESS == ret) {
-            uint64_t pending_page_num = 0;
-            for (uint32_t i = 0; i < num_pages; i++) {
-              if (AMDSMI_MEM_PAGE_STATUS_PENDING == bad_page_info[i].status) pending_page_num++;
-            }
-
-            value->value.l_int = static_cast<int64_t>(pending_page_num);
-          }
+        for (uint32_t i = 0; i < num_pages; i++) {
+          if (AMDSMI_MEM_PAGE_STATUS_PENDING == bad_page_info[i].status) pending_page_num++;
         }
-      } else {
-        value->status = Smi2RdcError(ret);
       }
+
+      value->status = Smi2RdcError(AMDSMI_STATUS_SUCCESS);
+      value->value.l_int = static_cast<int64_t>(pending_page_num);
       break;
     }
     case RDC_HEALTH_RETIRED_PAGE_LIMIT: {

--- a/projects/rdc/rdc_libs/rdc/src/RdcMetricFetcherImpl.cc
+++ b/projects/rdc/rdc_libs/rdc/src/RdcMetricFetcherImpl.cc
@@ -1222,9 +1222,7 @@ rdc_status_t RdcMetricFetcherImpl::fetch_gpu_field_(uint32_t gpu_index, rdc_fiel
           value->status = Smi2RdcError(ret);
           break;
         }
-        for (uint32_t i = 0; i < num_pages; i++) {
-          if (AMDSMI_MEM_PAGE_STATUS_PENDING == bad_page_info[i].status) pending_page_num++;
-        }
+        pending_page_num = count_pending_bad_pages(bad_page_info.data(), num_pages);
       }
 
       value->status = RDC_ST_OK;

--- a/projects/rdc/rdc_libs/rdc/src/RdcMetricFetcherImpl.cc
+++ b/projects/rdc/rdc_libs/rdc/src/RdcMetricFetcherImpl.cc
@@ -1206,7 +1206,7 @@ rdc_status_t RdcMetricFetcherImpl::fetch_gpu_field_(uint32_t gpu_index, rdc_fiel
       value->type = INTEGER;
 
       if (RDC_HEALTH_RETIRED_PAGE_NUM == field_id) {
-        value->status = Smi2RdcError(ret);
+        value->status = RDC_ST_OK;
         value->value.l_int = static_cast<int64_t>(num_pages);
         break;
       }
@@ -1227,7 +1227,7 @@ rdc_status_t RdcMetricFetcherImpl::fetch_gpu_field_(uint32_t gpu_index, rdc_fiel
         }
       }
 
-      value->status = Smi2RdcError(AMDSMI_STATUS_SUCCESS);
+      value->status = RDC_ST_OK;
       value->value.l_int = static_cast<int64_t>(pending_page_num);
       break;
     }

--- a/projects/rdc/rdc_libs/rdc/src/SmiUtils.cc
+++ b/projects/rdc/rdc_libs/rdc/src/SmiUtils.cc
@@ -259,5 +259,18 @@ amdsmi_status_t get_num_partition(uint32_t index, uint16_t* num_partition) {
   return ret;
 }
 
+uint64_t count_pending_bad_pages(const amdsmi_retired_page_record_t* records, uint32_t count) {
+  if (records == nullptr) {
+    return 0;
+  }
+  uint64_t pending = 0;
+  for (uint32_t i = 0; i < count; ++i) {
+    if (AMDSMI_MEM_PAGE_STATUS_PENDING == records[i].status) {
+      ++pending;
+    }
+  }
+  return pending;
+}
+
 }  // namespace rdc
 }  // namespace amd

--- a/projects/rdc/tests/rdc_tests/CMakeLists.txt
+++ b/projects/rdc/tests/rdc_tests/CMakeLists.txt
@@ -67,6 +67,7 @@ set(functionalSources
     ${SRC_DIR}/functional/rdci_group.cc
     ${SRC_DIR}/functional/rdci_stats.cc
     ${SRC_DIR}/functional/rdci_cpu_support.cc
+    ${SRC_DIR}/functional/test_bad_page.cc
 )
 
 link_directories(${ROCM_INSTALL_DIR} ${AMD_SMI_LIB_DIR})

--- a/projects/rdc/tests/rdc_tests/functional/test_bad_page.cc
+++ b/projects/rdc/tests/rdc_tests/functional/test_bad_page.cc
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2025 - present Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "amd_smi/amdsmi.h"
+#include "rdc_lib/impl/SmiUtils.h"
+
+namespace {
+
+amdsmi_retired_page_record_t MakeRecord(amdsmi_memory_page_status_t status) {
+  amdsmi_retired_page_record_t rec{};
+  rec.page_size = 4096;
+  rec.status = status;
+  return rec;
+}
+
+}  // namespace
+
+// A healthy GPU reports zero bad pages, which must count as zero pending
+// retirements. This is the exact case that previously surfaced as N/A for
+// RDC_HEALTH_PENDING_PAGE_NUM.
+TEST(BadPageTest, NoBadPagesYieldsZeroPending) {
+  EXPECT_EQ(0u, amd::rdc::count_pending_bad_pages(nullptr, 0));
+  std::vector<amdsmi_retired_page_record_t> empty;
+  EXPECT_EQ(0u, amd::rdc::count_pending_bad_pages(empty.data(), 0));
+}
+
+TEST(BadPageTest, CountsOnlyPendingRecords) {
+  std::vector<amdsmi_retired_page_record_t> records = {
+      MakeRecord(AMDSMI_MEM_PAGE_STATUS_PENDING),
+      MakeRecord(AMDSMI_MEM_PAGE_STATUS_RESERVED),
+      MakeRecord(AMDSMI_MEM_PAGE_STATUS_PENDING),
+      MakeRecord(AMDSMI_MEM_PAGE_STATUS_UNRESERVABLE),
+  };
+  EXPECT_EQ(
+      2u, amd::rdc::count_pending_bad_pages(records.data(), static_cast<uint32_t>(records.size())));
+}
+
+TEST(BadPageTest, NoPendingRecordsYieldsZero) {
+  std::vector<amdsmi_retired_page_record_t> records = {
+      MakeRecord(AMDSMI_MEM_PAGE_STATUS_RESERVED),
+      MakeRecord(AMDSMI_MEM_PAGE_STATUS_UNRESERVABLE),
+  };
+  EXPECT_EQ(
+      0u, amd::rdc::count_pending_bad_pages(records.data(), static_cast<uint32_t>(records.size())));
+}
+
+TEST(BadPageTest, AllPendingCountsAll) {
+  std::vector<amdsmi_retired_page_record_t> records(5, MakeRecord(AMDSMI_MEM_PAGE_STATUS_PENDING));
+  EXPECT_EQ(
+      5u, amd::rdc::count_pending_bad_pages(records.data(), static_cast<uint32_t>(records.size())));
+}


### PR DESCRIPTION
## Summary
`sudo rdci dmon -u -c 1 -e 2,3002,3003,3000 -i 0` reported **`PENDING_PAGE_NUM` as `N/A`** on healthy MI300X / MI355X (MI300/MI350-family) GPUs, even though `RETIRED_PAGE_NUM` from the same query correctly returned `0`.

JIRA ID: ROCM-27847

## Root cause
In `RdcMetricFetcherImpl::fetch_gpu_field_`, `value->status` defaults to `AMDSMI_STATUS_NOT_SUPPORTED`. In the shared `RDC_HEALTH_RETIRED_PAGE_NUM` / `RDC_HEALTH_PENDING_PAGE_NUM` case, the pending path only assigned status/value inside a `(0 < num_pages)` guard. When `amdsmi_get_gpu_bad_page_info()` succeeds with `num_pages == 0` (a healthy GPU with no bad pages), that guard is skipped, so `PENDING_PAGE_NUM` keeps the default `NOT_SUPPORTED` status and is rendered as `N/A` (the reported "rsmi error code 2").

## Fix
Restructure the case so any *successful* bad-page query always yields a value:
- On query failure, map the error via `Smi2RdcError` and stop.
- `RETIRED_PAGE_NUM` → total bad-page count.
- `PENDING_PAGE_NUM` → number of pages pending retirement, which is `0` when there are no bad pages.

## Testing
Built RDC standalone and ran the exact reproduction on an **MI308X** (MI300-family) box.

Before: `PENDING_PAGE_NUM` = `N/A`

After:
```
GPU  DEV_NAME             RETIRED_PAGE_NUM  PENDING_PAGE_NUM  XGMI_ERROR
0    AMD Instinct MI308X  0                 0                 N/A
```

Precondition confirmed on hardware: `amd-smi bad-pages` reports "No bad pages found" (i.e. `amdsmi_get_gpu_bad_page_info` succeeds with `num_pages == 0`).

## Out of scope
`XGMI_ERROR` still shows `N/A` on MI300/MI350-family GPUs because the `xgmi_error` sysfs node does not exist there, so `amdsmi_gpu_xgmi_error_status()` returns `NOT_SUPPORTED`. That is a hardware/driver limitation and is tracked separately, not addressed in this PR.

