### PR TITLE
fix (ROCM-27881): disable net-ib level fault injection by default

### DIFF
--- a/projects/rccl/src/misc/ibvwrap.cc
+++ b/projects/rccl/src/misc/ibvwrap.cc
@@ -26,6 +26,7 @@ struct ncclIbvSymbols ibvSymbols;
 #ifdef ENABLE_FAULT_INJECTION
 // Fault shims installed on the context's ops table at open/close time.
 #include "net_ib_ops_fault.h"
+RCCL_PARAM_DECLARE(InjectFaults);
 #endif
 
 #ifdef ENABLE_QP_TRACKING
@@ -158,20 +159,24 @@ const char *wrap_ibv_get_device_name(struct ibv_device *device) {
 
 ncclResult_t wrap_ibv_open_device(struct ibv_context **ret, struct ibv_device *device) { /*returns ncclResult_t (ncclSuccess on success)*/
 #ifdef ENABLE_FAULT_INJECTION
-  // Expand IBV_PTR_CHECK inline to install fault shims before returning.
-  CHECK_NOT_NULL(ibvSymbols, ibv_internal_open_device);
-  *ret = ibvSymbols.ibv_internal_open_device(device);
-  if (*ret == NULL) {
-    WARN("Call to ibv_open_device failed");
-    return ncclSystemError;
+  if (rcclParamInjectFaults() != 0) {
+    // Expand IBV_PTR_CHECK inline to install fault shims before returning.
+    CHECK_NOT_NULL(ibvSymbols, ibv_internal_open_device);
+    *ret = ibvSymbols.ibv_internal_open_device(device);
+    if (*ret == NULL) {
+      WARN("Call to ibv_open_device failed");
+      return ncclSystemError;
+    }
+    ncclResult_t installRes = ncclIbOpsFaultInstall(*ret);
+    if (installRes != ncclSuccess) {
+      ibvSymbols.ibv_internal_close_device(*ret);  // don't leak the opened device
+      *ret = NULL;
+      return installRes;
+    }
+    return ncclSuccess;
+  } else {
+    IBV_PTR_CHECK(ibvSymbols, ibv_internal_open_device, ibv_internal_open_device(device), *ret, NULL, "ibv_open_device");
   }
-  ncclResult_t installRes = ncclIbOpsFaultInstall(*ret);
-  if (installRes != ncclSuccess) {
-    ibvSymbols.ibv_internal_close_device(*ret);  // don't leak the opened device
-    *ret = NULL;
-    return installRes;
-  }
-  return ncclSuccess;
 #else
   IBV_PTR_CHECK(ibvSymbols, ibv_internal_open_device, ibv_internal_open_device(device), *ret, NULL, "ibv_open_device");
 #endif
@@ -180,7 +185,7 @@ ncclResult_t wrap_ibv_open_device(struct ibv_context **ret, struct ibv_device *d
 ncclResult_t wrap_ibv_close_device(struct ibv_context *context) { /*returns ncclResult_t (ncclSuccess on success)*/
 #ifdef ENABLE_FAULT_INJECTION
   // Restore original ops before closing so the real close sees a clean context.
-  if (context) NCCLCHECK(ncclIbOpsFaultRemove(context));
+  if (rcclParamInjectFaults() != 0 && context) NCCLCHECK(ncclIbOpsFaultRemove(context));
 #endif
   IBV_INT_CHECK(ibvSymbols, ibv_internal_close_device, ibv_internal_close_device(context), -1, "ibv_close_device");
 }

--- a/projects/rccl/src/misc/ibvwrap.cc
+++ b/projects/rccl/src/misc/ibvwrap.cc
@@ -26,7 +26,7 @@ struct ncclIbvSymbols ibvSymbols;
 #ifdef ENABLE_FAULT_INJECTION
 // Fault shims installed on the context's ops table at open/close time.
 #include "net_ib_ops_fault.h"
-RCCL_PARAM_DECLARE(InjectFaults);
+RCCL_PARAM(IbFaultInjection, "IB_FAULT_INJECTION", 0);
 #endif
 
 #ifdef ENABLE_QP_TRACKING
@@ -159,7 +159,7 @@ const char *wrap_ibv_get_device_name(struct ibv_device *device) {
 
 ncclResult_t wrap_ibv_open_device(struct ibv_context **ret, struct ibv_device *device) { /*returns ncclResult_t (ncclSuccess on success)*/
 #ifdef ENABLE_FAULT_INJECTION
-  if (rcclParamInjectFaults() != 0) {
+  if (rcclParamIbFaultInjection() != 0) {
     // Expand IBV_PTR_CHECK inline to install fault shims before returning.
     CHECK_NOT_NULL(ibvSymbols, ibv_internal_open_device);
     *ret = ibvSymbols.ibv_internal_open_device(device);
@@ -185,7 +185,7 @@ ncclResult_t wrap_ibv_open_device(struct ibv_context **ret, struct ibv_device *d
 ncclResult_t wrap_ibv_close_device(struct ibv_context *context) { /*returns ncclResult_t (ncclSuccess on success)*/
 #ifdef ENABLE_FAULT_INJECTION
   // Restore original ops before closing so the real close sees a clean context.
-  if (rcclParamInjectFaults() != 0 && context) NCCLCHECK(ncclIbOpsFaultRemove(context));
+  if (rcclParamIbFaultInjection() != 0 && context) NCCLCHECK(ncclIbOpsFaultRemove(context));
 #endif
   IBV_INT_CHECK(ibvSymbols, ibv_internal_close_device, ibv_internal_close_device(context), -1, "ibv_close_device");
 }


### PR DESCRIPTION
## Motivation

This PR disables net-ib fault-injection test layer by default.

## JIRA ID

ROCM-27881
AIRDEL-40

