### PR TITLE
fix(amdsmi): report partition info on CPX/NPS4 sub-partitions

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -211,7 +211,9 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 ### Resolved Issues
 
 - **Fixed partition information reporting `N/A` for sub-partitions in CPX/NPS4 mode** ([issue #100](https://github.com/ROCm/amdsmi/issues/100)).  
-  - `amdsmi_get_gpu_accelerator_partition_profile()`, `amdsmi_get_gpu_memory_partition()`, and `amdsmi_get_gpu_memory_partition_config()` now resolve the owning physical device and query its primary partition (`partition_id == 0`) when a secondary (sub-partition) node does not expose the whole-GPU partition interface. On an MI300X in CPX/NPS4 mode this makes `amd-smi partition` report the accelerator profile and memory partition type on all 64 logical GPUs instead of only the 8 primary partitions. Each partition continues to report its own `partition_id`.
+  - `amdsmi_get_gpu_compute_partition()`, `amdsmi_get_gpu_memory_partition()`, `amdsmi_get_gpu_memory_partition_config()`, and `amdsmi_get_gpu_accelerator_partition_profile()` now resolve the owning physical device and query its primary partition (`partition_id == 0`) when a secondary (sub-partition) node does not expose the whole-GPU partition interface.
+  - On an MI300X in CPX/NPS4 mode this makes `amd-smi partition` report the compute/accelerator profile and memory partition type on all 64 logical GPUs instead of only the 8 primary partitions.
+  - Each partition continues to report its own `partition_id`.
   - Documented that Docker `--device` passthrough operates on the per-partition `/dev/dri/renderD<N>` nodes (one per XCD since ROCm 6.4.1) in the [GPU partitioning guide](https://rocm.docs.amd.com/projects/amdsmi/en/latest/conceptual/partition.html).
 
 - **Fixed `amd-smi set --power-cap` rejecting the minimum allowed value**.  

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -4,6 +4,14 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ***All information listed below is for reference and subject to change.***
 
+## amd_smi_lib for ROCm 10.1
+
+### Resolved Issues
+
+- **Fixed partition information reporting `N/A` for sub-partitions in CPX/NPS4 mode** ([issue #100](https://github.com/ROCm/amdsmi/issues/100)).  
+  - `amdsmi_get_gpu_compute_partition()`, `amdsmi_get_gpu_compute_partition_mem_alloc_mode()`, `amdsmi_get_gpu_memory_partition()`, `amdsmi_get_gpu_memory_partition_config()`, and `amdsmi_get_gpu_accelerator_partition_profile()` now query the owning device's primary partition (`partition_id == 0`), which is the only node that exposes the whole-GPU partition interface.
+  - On an MI300X in CPX/NPS4 mode, `amd-smi partition` now reports the compute/accelerator profile and memory partition type on all 64 logical GPUs instead of only the 8 primary partitions. Each partition still reports its own `partition_id`.
+
 ## amd_smi_lib for ROCm 7.15.0
 
 ### Added
@@ -209,11 +217,6 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 - **Removed the unused `amdsmi_nic_link_type_t` enum from the public header**. No API or struct referenced it; NIC link types are reported through `amdsmi_link_type_t`, which gains `AMDSMI_LINK_TYPE_NUMA` and `AMDSMI_LINK_TYPE_XNUMA` in this release.
 
 ### Resolved Issues
-
-- **Fixed partition information reporting `N/A` for sub-partitions in CPX/NPS4 mode** ([issue #100](https://github.com/ROCm/amdsmi/issues/100)).  
-  - `amdsmi_get_gpu_compute_partition()`, `amdsmi_get_gpu_compute_partition_mem_alloc_mode()`, `amdsmi_get_gpu_memory_partition()`, `amdsmi_get_gpu_memory_partition_config()`, and `amdsmi_get_gpu_accelerator_partition_profile()` now resolve the owning physical device and query its primary partition (`partition_id == 0`) for a secondary (sub-partition) node that does not expose the whole-GPU partition interface.
-  - On an MI300X in CPX/NPS4 mode this makes `amd-smi partition` report the compute/accelerator profile and memory partition type on all 64 logical GPUs instead of only the 8 primary partitions.
-  - Each partition continues to report its own `partition_id`.
 
 - **Fixed `amd-smi set --power-cap` rejecting the minimum allowed value**.  
   - The lower bound is now inclusive, so setting the power cap to the exact minimum of the reported range (e.g. `210` when the range is 210-300W) succeeds instead of failing validation, matching the inclusive range shown in the error message.

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -214,7 +214,6 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
   - `amdsmi_get_gpu_compute_partition()`, `amdsmi_get_gpu_compute_partition_mem_alloc_mode()`, `amdsmi_get_gpu_memory_partition()`, `amdsmi_get_gpu_memory_partition_config()`, and `amdsmi_get_gpu_accelerator_partition_profile()` now resolve the owning physical device and query its primary partition (`partition_id == 0`) for a secondary (sub-partition) node that does not expose the whole-GPU partition interface.
   - On an MI300X in CPX/NPS4 mode this makes `amd-smi partition` report the compute/accelerator profile and memory partition type on all 64 logical GPUs instead of only the 8 primary partitions.
   - Each partition continues to report its own `partition_id`.
-  - Documented that Docker `--device` passthrough operates on the per-partition `/dev/dri/renderD<N>` nodes (one per XCD since ROCm 6.4.1) in the [GPU partitioning guide](https://rocm.docs.amd.com/projects/amdsmi/en/latest/conceptual/partition.html).
 
 - **Fixed `amd-smi set --power-cap` rejecting the minimum allowed value**.  
   - The lower bound is now inclusive, so setting the power cap to the exact minimum of the reported range (e.g. `210` when the range is 210-300W) succeeds instead of failing validation, matching the inclusive range shown in the error message.

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -210,6 +210,10 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ### Resolved Issues
 
+- **Fixed partition information reporting `N/A` for sub-partitions in CPX/NPS4 mode** ([issue #100](https://github.com/ROCm/amdsmi/issues/100)).  
+  - `amdsmi_get_gpu_accelerator_partition_profile()`, `amdsmi_get_gpu_memory_partition()`, and `amdsmi_get_gpu_memory_partition_config()` now resolve the owning physical device and query its primary partition (`partition_id == 0`) when a secondary (sub-partition) node does not expose the whole-GPU partition interface. On an MI300X in CPX/NPS4 mode this makes `amd-smi partition` report the accelerator profile and memory partition type on all 64 logical GPUs instead of only the 8 primary partitions. Each partition continues to report its own `partition_id`.
+  - Documented that Docker `--device` passthrough operates on the per-partition `/dev/dri/renderD<N>` nodes (one per XCD since ROCm 6.4.1) in the [GPU partitioning guide](https://rocm.docs.amd.com/projects/amdsmi/en/latest/conceptual/partition.html).
+
 - **Fixed `amd-smi set --power-cap` rejecting the minimum allowed value**.  
   - The lower bound is now inclusive, so setting the power cap to the exact minimum of the reported range (e.g. `210` when the range is 210-300W) succeeds instead of failing validation, matching the inclusive range shown in the error message.
 

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -211,7 +211,7 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 ### Resolved Issues
 
 - **Fixed partition information reporting `N/A` for sub-partitions in CPX/NPS4 mode** ([issue #100](https://github.com/ROCm/amdsmi/issues/100)).  
-  - `amdsmi_get_gpu_compute_partition()`, `amdsmi_get_gpu_memory_partition()`, `amdsmi_get_gpu_memory_partition_config()`, and `amdsmi_get_gpu_accelerator_partition_profile()` now resolve the owning physical device and query its primary partition (`partition_id == 0`) when a secondary (sub-partition) node does not expose the whole-GPU partition interface.
+  - `amdsmi_get_gpu_compute_partition()`, `amdsmi_get_gpu_compute_partition_mem_alloc_mode()`, `amdsmi_get_gpu_memory_partition()`, `amdsmi_get_gpu_memory_partition_config()`, and `amdsmi_get_gpu_accelerator_partition_profile()` now resolve the owning physical device and query its primary partition (`partition_id == 0`) for a secondary (sub-partition) node that does not expose the whole-GPU partition interface.
   - On an MI300X in CPX/NPS4 mode this makes `amd-smi partition` report the compute/accelerator profile and memory partition type on all 64 logical GPUs instead of only the 8 primary partitions.
   - Each partition continues to report its own `partition_id`.
   - Documented that Docker `--device` passthrough operates on the per-partition `/dev/dri/renderD<N>` nodes (one per XCD since ROCm 6.4.1) in the [GPU partitioning guide](https://rocm.docs.amd.com/projects/amdsmi/en/latest/conceptual/partition.html).

--- a/projects/amdsmi/docs/conceptual/partition.md
+++ b/projects/amdsmi/docs/conceptual/partition.md
@@ -434,38 +434,6 @@ In `/dev/dri`, each XCD partition appears as a separate render device. On an MI3
 mode, render devices start at `renderD128` and go up to `renderD135` (one per XCD). The next
 physical GPU starts at `renderD136`, and so on.
 
-### Container (Docker) device passthrough
-
-When exposing partitioned GPUs to a container, device passthrough operates on the DRM
-render nodes in `/dev/dri`, not on the AMD SMI processor handles. Since ROCm 6.4.1 each
-logical partition maps to its own render minor (see above), so the node you pass determines
-exactly which partitions the container can access:
-
-- Always pass the KFD control node, `/dev/kfd`, which is shared by all GPUs and partitions.
-- Pass one `--device=/dev/dri/renderD<N>` entry for **each partition** you want visible
-  inside the container. In CPX mode an eight-XCD MI300X exposes eight render nodes per
-  physical GPU (for example `renderD128`–`renderD135`); passing all of them exposes the
-  full physical GPU, while passing a subset exposes only those partitions.
-
-```shell
-# Expose one full MI300X (all 8 CPX partitions of the first physical GPU) to a container
-docker run --device=/dev/kfd \
-  --device=/dev/dri/renderD128 --device=/dev/dri/renderD129 \
-  --device=/dev/dri/renderD130 --device=/dev/dri/renderD131 \
-  --device=/dev/dri/renderD132 --device=/dev/dri/renderD133 \
-  --device=/dev/dri/renderD134 --device=/dev/dri/renderD135 \
-  <image>
-```
-
-```{note}
-Docker `--device` maps the render node's `major:minor` into the container's cgroup device
-allowlist. Passing `/dev/dri` wholesale (or using `--group-add video`/`render` with the
-whole directory) exposes **every** partition of **every** physical GPU on the host. To scope
-a container to specific partitions, enumerate the individual `renderD<N>` nodes as shown
-above. Use `amd-smi list --enumeration` to map each logical GPU to its `drm_render` node
-before selecting the devices to pass through.
-```
-
 ## Platform support
 
 | Operation | Bare Metal / Host | Linux Guest (SR-IOV VF) |

--- a/projects/amdsmi/docs/conceptual/partition.md
+++ b/projects/amdsmi/docs/conceptual/partition.md
@@ -135,6 +135,18 @@ their own resources.
   SR-IOV guest, each assigned VF appears as a separate processor handle, but the socket
   and physical-GPU-level information may be limited by the hypervisor.
 
+```{note}
+The **accelerator partition profile** and **memory partition mode** are properties of the
+whole physical GPU, and their backing sysfs nodes only respond on the primary partition
+(`partition_id == 0`). AMD SMI therefore transparently resolves the owning physical device
+for secondary partitions, so `amdsmi_get_gpu_accelerator_partition_profile()`,
+`amdsmi_get_gpu_memory_partition()`, `amdsmi_get_gpu_memory_partition_config()`, and
+`amd-smi partition` report the same partition type on every logical partition of a physical
+GPU. Each partition still reports its own `partition_id`. Prior releases returned `N/A` for
+the secondary (sub-partition) nodes because the query was issued directly against a node that
+does not expose the whole-GPU partition interface.
+```
+
 ### Default configuration
 
 In the default (SPX) mode, all XCCs are grouped into a single XCP and the OS sees one
@@ -421,6 +433,38 @@ minor path. This affects what data is readable and writable per partition node. 
 In `/dev/dri`, each XCD partition appears as a separate render device. On an MI300X in CPX
 mode, render devices start at `renderD128` and go up to `renderD135` (one per XCD). The next
 physical GPU starts at `renderD136`, and so on.
+
+### Container (Docker) device passthrough
+
+When exposing partitioned GPUs to a container, device passthrough operates on the DRM
+render nodes in `/dev/dri`, not on the AMD SMI processor handles. Since ROCm 6.4.1 each
+logical partition maps to its own render minor (see above), so the node you pass determines
+exactly which partitions the container can access:
+
+- Always pass the KFD control node, `/dev/kfd`, which is shared by all GPUs and partitions.
+- Pass one `--device=/dev/dri/renderD<N>` entry for **each partition** you want visible
+  inside the container. In CPX mode an eight-XCD MI300X exposes eight render nodes per
+  physical GPU (for example `renderD128`–`renderD135`); passing all of them exposes the
+  full physical GPU, while passing a subset exposes only those partitions.
+
+```shell
+# Expose one full MI300X (all 8 CPX partitions of the first physical GPU) to a container
+docker run --device=/dev/kfd \
+  --device=/dev/dri/renderD128 --device=/dev/dri/renderD129 \
+  --device=/dev/dri/renderD130 --device=/dev/dri/renderD131 \
+  --device=/dev/dri/renderD132 --device=/dev/dri/renderD133 \
+  --device=/dev/dri/renderD134 --device=/dev/dri/renderD135 \
+  <image>
+```
+
+```{note}
+Docker `--device` maps the render node's `major:minor` into the container's cgroup device
+allowlist. Passing `/dev/dri` wholesale (or using `--group-add video`/`render` with the
+whole directory) exposes **every** partition of **every** physical GPU on the host. To scope
+a container to specific partitions, enumerate the individual `renderD<N>` nodes as shown
+above. Use `amd-smi list --enumeration` to map each logical GPU to its `drm_render` node
+before selecting the devices to pass through.
+```
 
 ## Platform support
 

--- a/projects/amdsmi/docs/conceptual/partition.md
+++ b/projects/amdsmi/docs/conceptual/partition.md
@@ -137,14 +137,12 @@ their own resources.
 
 ```{note}
 The **accelerator partition profile** and **memory partition mode** are properties of the
-whole physical GPU, and their backing sysfs nodes only respond on the primary partition
-(`partition_id == 0`). AMD SMI therefore transparently resolves the owning physical device
-for secondary partitions, so `amdsmi_get_gpu_accelerator_partition_profile()`,
-`amdsmi_get_gpu_memory_partition()`, `amdsmi_get_gpu_memory_partition_config()`, and
-`amd-smi partition` report the same partition type on every logical partition of a physical
-GPU. Each partition still reports its own `partition_id`. Prior releases returned `N/A` for
-the secondary (sub-partition) nodes because the query was issued directly against a node that
-does not expose the whole-GPU partition interface.
+whole physical GPU, and their sysfs nodes only respond on the primary partition
+(`partition_id == 0`). AMD SMI resolves the owning device for secondary partitions, so
+`amdsmi_get_gpu_accelerator_partition_profile()`, `amdsmi_get_gpu_memory_partition()`,
+`amdsmi_get_gpu_memory_partition_config()`, and `amd-smi partition` report the same
+partition type on every logical partition of a physical GPU, while each partition still
+reports its own `partition_id`. Earlier releases reported `N/A` on the secondary nodes.
 ```
 
 ### Default configuration

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -3304,7 +3304,12 @@ amdsmi_status_t amdsmi_get_gpu_accelerator_partition_mem_alloc_mode(
     return AMDSMI_STATUS_INVAL;
   }
   std::ostringstream ss;
-  auto status = rsmi_wrapper(rsmi_dev_compute_partition_mem_alloc_mode_get, processor_handle, 0,
+  // The mem-alloc-mode sysfs node lives in the whole-GPU compute-partition config
+  // and only responds on the primary partition, so a sub-partition handle is
+  // redirected to its owning device's primary partition (all partitions share one
+  // mem-alloc mode).
+  amdsmi_processor_handle query_handle = resolve_partition_query_handle(processor_handle);
+  auto status = rsmi_wrapper(rsmi_dev_compute_partition_mem_alloc_mode_get, query_handle, 0,
                              reinterpret_cast<rsmi_compute_partition_mem_alloc_mode_t*>(mode));
   ss << __PRETTY_FUNCTION__ << " | rsmi_dev_compute_partition_mem_alloc_mode_get() returned: "
      << smi_amdgpu_get_status_string(status, false);
@@ -3497,6 +3502,11 @@ amdsmi_status_t amdsmi_get_gpu_accelerator_partition_profile_config(
   if (!amd::smi::is_sudo_user()) {
     return AMDSMI_STATUS_NO_PERM;
   }
+  // This enumerates the device's supported accelerator profiles (a whole-GPU
+  // capability) and probes them with internal partition-config writes. It is not
+  // part of the per-partition partition display fixed for issue #100, so the
+  // sub-partition redirect applied by the partition getters is intentionally not
+  // used here.
   std::ostringstream ss;
   ss << __PRETTY_FUNCTION__ << " | START ";
   // std::cout << ss.str() << std::endl;

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -3105,16 +3105,11 @@ amdsmi_status_t amdsmi_topo_get_p2p_status(amdsmi_processor_handle processor_han
 namespace amd {
 namespace smi {
 
-// Pure redirect decision factored out of get_primary_partition_handle() so it
-// can be unit tested without hardware.
-//
-// Given the partition ids of every logical GPU partition that shares a physical
-// device and the index of the querying partition within that list, return the
-// index of the primary partition (partition_id == 0) that partition-config
-// queries must be redirected to, or -1 when no redirect is needed: the device is
-// not split into multiple logical partitions, the querying partition is already
-// the primary, or no primary sibling exists. Siblings whose id could not be read
-// must be passed as UINT32_MAX so they are skipped.
+// Pure redirect decision factored out of get_primary_partition_handle() for
+// hardware-free unit testing. Returns the index of the primary partition
+// (partition_id == 0) that partition-config queries should redirect to, or -1
+// when no redirect is needed (single partition, caller is already primary, or no
+// primary sibling). Unreadable sibling ids must be passed as UINT32_MAX.
 int primary_partition_redirect_index(const std::vector<uint32_t>& partition_ids,
                                      size_t self_index) {
   // A physical device that exposes a single logical GPU has no separate primary
@@ -3136,19 +3131,14 @@ int primary_partition_redirect_index(const std::vector<uint32_t>& partition_ids,
 }  // namespace smi
 }  // namespace amd
 
-// On MI300-class accelerators that are split into multiple logical partitions
-// (for example CPX + NPS4), the compute- and memory-partition sysfs nodes only
-// respond on the primary partition (partition_id == 0) of each physical device.
-// Queries issued against a logical sub-partition handle (partition_id > 0)
-// therefore fail and the tool falls back to reporting "N/A". All logical
-// partitions of a physical device share the same partition configuration and are
-// grouped under the same AMDSmiSocket (keyed on the BD portion of the BDF), so
-// this helper walks the owning socket and returns the primary partition's handle
-// for a given sub-partition handle.
-//
-// Returns nullptr when the handle is already the primary partition, when the
-// device is not partitioned into multiple logical GPUs, or when no primary
-// sibling can be found.
+// On MI300-class accelerators split into multiple logical partitions (for
+// example CPX + NPS4), the compute-/memory-partition sysfs nodes only respond on
+// each physical device's primary partition (partition_id == 0); queries against a
+// sub-partition handle (partition_id > 0) fail and fall back to "N/A". All logical
+// partitions share one partition config and one AMDSmiSocket (keyed on the BD
+// portion of the BDF), so this walks the owning socket and returns the primary
+// partition's handle. Returns nullptr when the handle is already primary, the
+// device is not multi-partitioned, or no primary sibling exists.
 static amdsmi_processor_handle get_primary_partition_handle(
     amdsmi_processor_handle processor_handle) {
   amd::smi::AMDSmiProcessor* processor = nullptr;
@@ -3158,11 +3148,10 @@ static amdsmi_processor_handle get_primary_partition_handle(
     return nullptr;
   }
 
-  // Fast path: the primary partition (partition_id == 0) already answers
-  // partition-config queries directly, so it never needs a redirect. Reading the
-  // caller's own partition id first avoids the socket walk and the per-sibling
-  // sysfs reads below on every primary partition and every unpartitioned (SPX)
-  // device.
+  // Fast path: the primary partition (partition_id == 0) answers partition-config
+  // queries directly and never needs a redirect. Reading the caller's own
+  // partition id first avoids the socket walk and per-sibling sysfs reads on every
+  // primary and unpartitioned (SPX) device.
   uint32_t self_partition_id = std::numeric_limits<uint32_t>::max();
   if (rsmi_wrapper(rsmi_dev_partition_id_get, processor_handle, 0, &self_partition_id) ==
           AMDSMI_STATUS_SUCCESS &&
@@ -3187,10 +3176,9 @@ static amdsmi_processor_handle get_primary_partition_handle(
     return nullptr;
   }
 
-  // Collect the partition id of every logical GPU partition on this physical
-  // device (marking siblings whose id cannot be read as unqueryable) and locate
-  // this processor within that list, then defer the redirect decision to the
-  // pure helper above.
+  // Collect every logical partition's id on this physical device (unreadable
+  // siblings marked unqueryable), locate this processor in the list, and defer the
+  // redirect decision to the pure helper above.
   auto& siblings = owning_socket->get_processors(AMDSMI_PROCESSOR_TYPE_AMD_GPU);
   std::vector<uint32_t> partition_ids(siblings.size(), std::numeric_limits<uint32_t>::max());
   size_t self_index = siblings.size();
@@ -3225,10 +3213,9 @@ amdsmi_status_t amdsmi_get_gpu_compute_partition(amdsmi_processor_handle process
 
   auto status =
       rsmi_wrapper(rsmi_dev_compute_partition_get, processor_handle, 0, compute_partition, len);
-  // The compute-partition sysfs node only responds on the primary partition
-  // (partition_id == 0). For a logical sub-partition handle the query above fails,
-  // so retry against the owning physical device's primary partition handle. All
-  // partitions of a physical device share the same compute-partition mode.
+  // The compute-partition sysfs node only responds on the primary partition, so
+  // for a sub-partition handle the query above fails; retry against the owning
+  // device's primary handle (all partitions share one compute-partition mode).
   if (status != AMDSMI_STATUS_SUCCESS) {
     amdsmi_processor_handle primary_handle = get_primary_partition_handle(processor_handle);
     if (primary_handle != nullptr) {
@@ -3303,10 +3290,9 @@ amdsmi_status_t amdsmi_get_gpu_memory_partition(amdsmi_processor_handle processo
   AMDSMI_CHECK_INIT();
   amdsmi_status_t ret =
       rsmi_wrapper(rsmi_dev_memory_partition_get, processor_handle, 0, memory_partition, len);
-  // The memory-partition sysfs node only responds on the primary partition
-  // (partition_id == 0). For a logical sub-partition handle the query above fails,
-  // so retry against the owning physical device's primary partition handle. All
-  // partitions of a physical device share the same memory-partition (NPS) mode.
+  // The memory-partition sysfs node only responds on the primary partition, so
+  // for a sub-partition handle the query above fails; retry against the owning
+  // device's primary handle (all partitions share one memory-partition/NPS mode).
   if (ret != AMDSMI_STATUS_SUCCESS) {
     amdsmi_processor_handle primary_handle = get_primary_partition_handle(processor_handle);
     if (primary_handle != nullptr) {
@@ -3342,9 +3328,8 @@ amdsmi_status_t amdsmi_get_gpu_memory_partition_config(amdsmi_processor_handle p
   // TODO(amdsmi_team): Will BM/guest VMs have numa ranges?
   config->num_numa_ranges = 0;
 
-  // For a logical sub-partition handle (partition_id > 0) the partition-capability
-  // sysfs nodes only respond on the owning physical device's primary partition, so
-  // redirect capability queries there.
+  // A sub-partition handle's capability sysfs nodes only respond on the owning
+  // device's primary partition, so redirect capability queries there.
   amdsmi_processor_handle query_handle = processor_handle;
   amdsmi_processor_handle primary_handle = get_primary_partition_handle(processor_handle);
   if (primary_handle != nullptr) {
@@ -3887,12 +3872,10 @@ amdsmi_status_t amdsmi_get_gpu_accelerator_partition_profile(
   auto tmp_partition_id = uint32_t(0);
   amdsmi_status_t status = AMDSMI_STATUS_NOT_SUPPORTED;
 
-  // For a logical sub-partition handle (partition_id > 0) the partition-profile
-  // sysfs/ioctl interfaces only respond on the owning physical device's primary
-  // partition (partition_id == 0). Redirect the capability/profile queries there so
-  // sub-partitions report the same profile as their parent instead of "N/A". The
-  // reported partition_id below intentionally continues to use the original handle
-  // so each logical partition keeps its own identity.
+  // A sub-partition handle's partition-profile sysfs/ioctl interfaces only respond
+  // on the owning device's primary partition, so redirect the capability/profile
+  // queries there (otherwise sub-partitions report "N/A"). The reported partition_id
+  // below intentionally keeps the original handle so each partition keeps its identity.
   amdsmi_processor_handle query_handle = processor_handle;
   amdsmi_processor_handle primary_handle = get_primary_partition_handle(processor_handle);
   if (primary_handle != nullptr) {

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -307,10 +307,16 @@ amdsmi_status_t amdsmi_init(uint64_t flags) {
   return status;
 }
 
+// Defined with the partition-redirect cache further below; clears the memoized
+// sub-partition -> primary handle mappings before the processor objects backing
+// those handles are destroyed.
+static void clear_primary_partition_cache();
+
 amdsmi_status_t amdsmi_shut_down() {
   if (!amd::smi::amdsmi_library_init_ref_release()) {
     return AMDSMI_STATUS_SUCCESS;
   }
+  clear_primary_partition_cache();
   return amd::smi::AMDSmiSystem::getInstance().cleanup();
 }
 
@@ -3131,6 +3137,21 @@ int primary_partition_redirect_index(const std::vector<uint32_t>& partition_ids,
 }  // namespace smi
 }  // namespace amd
 
+namespace {
+
+// Memoizes each sub-partition handle to its owning device's primary-partition
+// handle. Resolving a redirect walks the owning socket and reads one partition-id
+// sysfs node per logical partition (up to 8 for an MI300X in CPX), so the result
+// is cached to keep repeated partition queries cheap. Partition topology is fixed
+// for an amdsmi_init()/amdsmi_shut_down() lifetime (mode changes require a driver
+// reload and device re-enumeration), so a cached entry cannot go stale; it is
+// cleared by clear_primary_partition_cache() on shutdown, before the processor
+// objects backing these handles are destroyed.
+std::mutex primary_partition_cache_mutex;
+std::map<amdsmi_processor_handle, amdsmi_processor_handle> primary_partition_cache;
+
+}  // namespace
+
 // On MI300-class accelerators split into multiple logical partitions (for
 // example CPX + NPS4), the compute-/memory-partition sysfs nodes only respond on
 // each physical device's primary partition (partition_id == 0); queries against a
@@ -3139,7 +3160,7 @@ int primary_partition_redirect_index(const std::vector<uint32_t>& partition_ids,
 // portion of the BDF), so this walks the owning socket and returns the primary
 // partition's handle. Returns nullptr when the handle is already primary, the
 // device is not multi-partitioned, or no primary sibling exists.
-static amdsmi_processor_handle get_primary_partition_handle(
+static amdsmi_processor_handle resolve_primary_partition_handle_uncached(
     amdsmi_processor_handle processor_handle) {
   amd::smi::AMDSmiProcessor* processor = nullptr;
   amdsmi_status_t status =
@@ -3204,6 +3225,40 @@ static amdsmi_processor_handle get_primary_partition_handle(
   return reinterpret_cast<amdsmi_processor_handle>(siblings[primary_index]);
 }
 
+// Cached wrapper around resolve_primary_partition_handle_uncached(). Returns the
+// owning device's primary-partition handle for a sub-partition, or nullptr when no
+// redirect is needed (primary, single-GPU, or unpartitioned device).
+static amdsmi_processor_handle get_primary_partition_handle(
+    amdsmi_processor_handle processor_handle) {
+  {
+    std::lock_guard<std::mutex> lock(primary_partition_cache_mutex);
+    auto it = primary_partition_cache.find(processor_handle);
+    if (it != primary_partition_cache.end()) {
+      return it->second;
+    }
+  }
+  amdsmi_processor_handle primary_handle =
+      resolve_primary_partition_handle_uncached(processor_handle);
+  std::lock_guard<std::mutex> lock(primary_partition_cache_mutex);
+  primary_partition_cache[processor_handle] = primary_handle;
+  return primary_handle;
+}
+
+// Resolves the handle that partition-config sysfs queries should target: the
+// owning device's primary partition when processor_handle is a sub-partition,
+// otherwise processor_handle itself. Every partition getter routes through this
+// one strategy so a sub-partition never queries its own empty partition nodes.
+static amdsmi_processor_handle resolve_partition_query_handle(
+    amdsmi_processor_handle processor_handle) {
+  amdsmi_processor_handle primary_handle = get_primary_partition_handle(processor_handle);
+  return primary_handle != nullptr ? primary_handle : processor_handle;
+}
+
+static void clear_primary_partition_cache() {
+  std::lock_guard<std::mutex> lock(primary_partition_cache_mutex);
+  primary_partition_cache.clear();
+}
+
 // Compute Partition functions
 // This API is deprecated, use amdsmi_get_gpu_accelerator_partition_profile() instead
 amdsmi_status_t amdsmi_get_gpu_compute_partition(amdsmi_processor_handle processor_handle,
@@ -3211,18 +3266,12 @@ amdsmi_status_t amdsmi_get_gpu_compute_partition(amdsmi_processor_handle process
   AMDSMI_CHECK_INIT();
   std::ostringstream ss;
 
+  // The compute-partition sysfs node only responds on the primary partition, so a
+  // sub-partition handle is redirected to its owning device's primary partition
+  // (all partitions share one compute-partition mode).
+  amdsmi_processor_handle query_handle = resolve_partition_query_handle(processor_handle);
   auto status =
-      rsmi_wrapper(rsmi_dev_compute_partition_get, processor_handle, 0, compute_partition, len);
-  // The compute-partition sysfs node only responds on the primary partition, so
-  // for a sub-partition handle the query above fails; retry against the owning
-  // device's primary handle (all partitions share one compute-partition mode).
-  if (status != AMDSMI_STATUS_SUCCESS) {
-    amdsmi_processor_handle primary_handle = get_primary_partition_handle(processor_handle);
-    if (primary_handle != nullptr) {
-      status =
-          rsmi_wrapper(rsmi_dev_compute_partition_get, primary_handle, 0, compute_partition, len);
-    }
-  }
+      rsmi_wrapper(rsmi_dev_compute_partition_get, query_handle, 0, compute_partition, len);
   ss << __PRETTY_FUNCTION__ << " |  rsmi_dev_compute_partition_get() returned: "
      << smi_amdgpu_get_status_string(status, false);
   LOG_INFO(ss);
@@ -3288,17 +3337,12 @@ amdsmi_status_t amdsmi_set_gpu_accelerator_partition_mem_alloc_mode(
 amdsmi_status_t amdsmi_get_gpu_memory_partition(amdsmi_processor_handle processor_handle,
                                                 char* memory_partition, uint32_t len) {
   AMDSMI_CHECK_INIT();
+  // The memory-partition sysfs node only responds on the primary partition, so a
+  // sub-partition handle is redirected to its owning device's primary partition
+  // (all partitions share one memory-partition/NPS mode).
+  amdsmi_processor_handle query_handle = resolve_partition_query_handle(processor_handle);
   amdsmi_status_t ret =
-      rsmi_wrapper(rsmi_dev_memory_partition_get, processor_handle, 0, memory_partition, len);
-  // The memory-partition sysfs node only responds on the primary partition, so
-  // for a sub-partition handle the query above fails; retry against the owning
-  // device's primary handle (all partitions share one memory-partition/NPS mode).
-  if (ret != AMDSMI_STATUS_SUCCESS) {
-    amdsmi_processor_handle primary_handle = get_primary_partition_handle(processor_handle);
-    if (primary_handle != nullptr) {
-      ret = rsmi_wrapper(rsmi_dev_memory_partition_get, primary_handle, 0, memory_partition, len);
-    }
-  }
+      rsmi_wrapper(rsmi_dev_memory_partition_get, query_handle, 0, memory_partition, len);
   return ret;
 }
 
@@ -3330,11 +3374,7 @@ amdsmi_status_t amdsmi_get_gpu_memory_partition_config(amdsmi_processor_handle p
 
   // A sub-partition handle's capability sysfs nodes only respond on the owning
   // device's primary partition, so redirect capability queries there.
-  amdsmi_processor_handle query_handle = processor_handle;
-  amdsmi_processor_handle primary_handle = get_primary_partition_handle(processor_handle);
-  if (primary_handle != nullptr) {
-    query_handle = primary_handle;
-  }
+  amdsmi_processor_handle query_handle = resolve_partition_query_handle(processor_handle);
 
   // current memory partition
   constexpr uint32_t kCurrentPartitionSize = 5;
@@ -3876,11 +3916,7 @@ amdsmi_status_t amdsmi_get_gpu_accelerator_partition_profile(
   // on the owning device's primary partition, so redirect the capability/profile
   // queries there (otherwise sub-partitions report "N/A"). The reported partition_id
   // below intentionally keeps the original handle so each partition keeps its identity.
-  amdsmi_processor_handle query_handle = processor_handle;
-  amdsmi_processor_handle primary_handle = get_primary_partition_handle(processor_handle);
-  if (primary_handle != nullptr) {
-    query_handle = primary_handle;
-  }
+  amdsmi_processor_handle query_handle = resolve_partition_query_handle(processor_handle);
 
   // TODO(amdsmi_team): should we do fallback?
   // Info doesn't populate properly if missing other files - CLI FIX?

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -307,9 +307,8 @@ amdsmi_status_t amdsmi_init(uint64_t flags) {
   return status;
 }
 
-// Defined with the partition-redirect cache further below; clears the memoized
-// sub-partition -> primary handle mappings before the processor objects backing
-// those handles are destroyed.
+// Defined with the partition-redirect cache below; must run before the processor
+// objects backing the cached handles are destroyed.
 static void clear_primary_partition_cache();
 
 amdsmi_status_t amdsmi_shut_down() {
@@ -3111,15 +3110,11 @@ amdsmi_status_t amdsmi_topo_get_p2p_status(amdsmi_processor_handle processor_han
 namespace amd {
 namespace smi {
 
-// Pure redirect decision factored out of get_primary_partition_handle() for
-// hardware-free unit testing. Returns the index of the primary partition
-// (partition_id == 0) that partition-config queries should redirect to, or -1
-// when no redirect is needed (single partition, caller is already primary, or no
-// primary sibling). Unreadable sibling ids must be passed as UINT32_MAX.
+// Index of the sibling with partition_id == 0, or -1 if no redirect is needed.
+// Unreadable sibling ids must be passed as UINT32_MAX. Split out of
+// get_primary_partition_handle() so it is unit-testable without hardware.
 int primary_partition_redirect_index(const std::vector<uint32_t>& partition_ids,
                                      size_t self_index) {
-  // A physical device that exposes a single logical GPU has no separate primary
-  // partition to redirect to.
   if (partition_ids.size() <= 1) {
     return -1;
   }
@@ -3139,27 +3134,18 @@ int primary_partition_redirect_index(const std::vector<uint32_t>& partition_ids,
 
 namespace {
 
-// Memoizes each sub-partition handle to its owning device's primary-partition
-// handle. Resolving a redirect walks the owning socket and reads one partition-id
-// sysfs node per logical partition (up to 8 for an MI300X in CPX), so the result
-// is cached to keep repeated partition queries cheap. Partition topology is fixed
-// for an amdsmi_init()/amdsmi_shut_down() lifetime (mode changes require a driver
-// reload and device re-enumeration), so a cached entry cannot go stale; it is
-// cleared by clear_primary_partition_cache() on shutdown, before the processor
-// objects backing these handles are destroyed.
+// Resolving a redirect reads one partition-id sysfs node per sibling, so results are
+// memoized. Partition topology is fixed for an init/shutdown lifetime (mode changes
+// need a driver reload), so entries cannot go stale.
 std::mutex primary_partition_cache_mutex;
 std::map<amdsmi_processor_handle, amdsmi_processor_handle> primary_partition_cache;
 
 }  // namespace
 
-// On MI300-class accelerators split into multiple logical partitions (for
-// example CPX + NPS4), the compute-/memory-partition sysfs nodes only respond on
-// each physical device's primary partition (partition_id == 0); queries against a
-// sub-partition handle (partition_id > 0) fail and fall back to "N/A". All logical
-// partitions share one partition config and one AMDSmiSocket (keyed on the BD
-// portion of the BDF), so this walks the owning socket and returns the primary
-// partition's handle. Returns nullptr when the handle is already primary, the
-// device is not multi-partitioned, or no primary sibling exists.
+// Partition sysfs nodes only respond on a device's primary partition
+// (partition_id == 0); sub-partition handles read back as "N/A". All partitions of a
+// physical device share one AMDSmiSocket, so walk the owning socket for the primary
+// sibling. Returns nullptr when no redirect applies.
 static amdsmi_processor_handle resolve_primary_partition_handle_uncached(
     amdsmi_processor_handle processor_handle) {
   amd::smi::AMDSmiProcessor* processor = nullptr;
@@ -3169,10 +3155,8 @@ static amdsmi_processor_handle resolve_primary_partition_handle_uncached(
     return nullptr;
   }
 
-  // Fast path: the primary partition (partition_id == 0) answers partition-config
-  // queries directly and never needs a redirect. Reading the caller's own
-  // partition id first avoids the socket walk and per-sibling sysfs reads on every
-  // primary and unpartitioned (SPX) device.
+  // Checking the caller's own id first skips the socket walk on primary and
+  // unpartitioned (SPX) devices.
   uint32_t self_partition_id = std::numeric_limits<uint32_t>::max();
   if (rsmi_wrapper(rsmi_dev_partition_id_get, processor_handle, 0, &self_partition_id) ==
           AMDSMI_STATUS_SUCCESS &&
@@ -3180,7 +3164,6 @@ static amdsmi_processor_handle resolve_primary_partition_handle_uncached(
     return nullptr;
   }
 
-  // Find the socket (physical device) that owns this processor.
   amd::smi::AMDSmiSocket* owning_socket = nullptr;
   for (auto* socket : amd::smi::AMDSmiSystem::getInstance().get_sockets()) {
     if (socket == nullptr) {
@@ -3197,9 +3180,7 @@ static amdsmi_processor_handle resolve_primary_partition_handle_uncached(
     return nullptr;
   }
 
-  // Collect every logical partition's id on this physical device (unreadable
-  // siblings marked unqueryable), locate this processor in the list, and defer the
-  // redirect decision to the pure helper above.
+  // Unreadable siblings stay UINT32_MAX so the helper skips them.
   auto& siblings = owning_socket->get_processors(AMDSMI_PROCESSOR_TYPE_AMD_GPU);
   std::vector<uint32_t> partition_ids(siblings.size(), std::numeric_limits<uint32_t>::max());
   size_t self_index = siblings.size();
@@ -3225,15 +3206,10 @@ static amdsmi_processor_handle resolve_primary_partition_handle_uncached(
   return reinterpret_cast<amdsmi_processor_handle>(siblings[primary_index]);
 }
 
-// Cached wrapper around resolve_primary_partition_handle_uncached(). Returns the
-// owning device's primary-partition handle for a sub-partition, or nullptr when no
-// redirect is needed (primary, single-GPU, or unpartitioned device).
 static amdsmi_processor_handle get_primary_partition_handle(
     amdsmi_processor_handle processor_handle) {
-  // Hold the lock across the resolve so concurrent first-time callers for the same
-  // handle fill the cache once instead of each repeating the socket walk. The walk is
-  // a one-time cost per handle (partition topology is fixed for an init/shutdown
-  // lifetime) and the resolver never re-enters this mutex, so serializing it is safe.
+  // Held across the resolve so concurrent first-time callers walk the socket once;
+  // the resolver never re-enters this mutex.
   std::lock_guard<std::mutex> lock(primary_partition_cache_mutex);
   auto it = primary_partition_cache.find(processor_handle);
   if (it != primary_partition_cache.end()) {
@@ -3245,10 +3221,8 @@ static amdsmi_processor_handle get_primary_partition_handle(
   return primary_handle;
 }
 
-// Resolves the handle that partition-config sysfs queries should target: the
-// owning device's primary partition when processor_handle is a sub-partition,
-// otherwise processor_handle itself. Every partition getter routes through this
-// one strategy so a sub-partition never queries its own empty partition nodes.
+// Handle every partition getter should query: the owning primary partition for a
+// sub-partition, otherwise processor_handle itself.
 static amdsmi_processor_handle resolve_partition_query_handle(
     amdsmi_processor_handle processor_handle) {
   amdsmi_processor_handle primary_handle = get_primary_partition_handle(processor_handle);
@@ -3267,9 +3241,7 @@ amdsmi_status_t amdsmi_get_gpu_compute_partition(amdsmi_processor_handle process
   AMDSMI_CHECK_INIT();
   std::ostringstream ss;
 
-  // The compute-partition sysfs node only responds on the primary partition, so a
-  // sub-partition handle is redirected to its owning device's primary partition
-  // (all partitions share one compute-partition mode).
+  // All partitions share one compute-partition mode, readable only on the primary.
   amdsmi_processor_handle query_handle = resolve_partition_query_handle(processor_handle);
   auto status =
       rsmi_wrapper(rsmi_dev_compute_partition_get, query_handle, 0, compute_partition, len);
@@ -3305,10 +3277,7 @@ amdsmi_status_t amdsmi_get_gpu_accelerator_partition_mem_alloc_mode(
     return AMDSMI_STATUS_INVAL;
   }
   std::ostringstream ss;
-  // The mem-alloc-mode sysfs node lives in the whole-GPU compute-partition config
-  // and only responds on the primary partition, so a sub-partition handle is
-  // redirected to its owning device's primary partition (all partitions share one
-  // mem-alloc mode).
+  // All partitions share one mem-alloc mode, readable only on the primary.
   amdsmi_processor_handle query_handle = resolve_partition_query_handle(processor_handle);
   auto status = rsmi_wrapper(rsmi_dev_compute_partition_mem_alloc_mode_get, query_handle, 0,
                              reinterpret_cast<rsmi_compute_partition_mem_alloc_mode_t*>(mode));
@@ -3343,9 +3312,7 @@ amdsmi_status_t amdsmi_set_gpu_accelerator_partition_mem_alloc_mode(
 amdsmi_status_t amdsmi_get_gpu_memory_partition(amdsmi_processor_handle processor_handle,
                                                 char* memory_partition, uint32_t len) {
   AMDSMI_CHECK_INIT();
-  // The memory-partition sysfs node only responds on the primary partition, so a
-  // sub-partition handle is redirected to its owning device's primary partition
-  // (all partitions share one memory-partition/NPS mode).
+  // All partitions share one memory-partition (NPS) mode, readable only on the primary.
   amdsmi_processor_handle query_handle = resolve_partition_query_handle(processor_handle);
   amdsmi_status_t ret =
       rsmi_wrapper(rsmi_dev_memory_partition_get, query_handle, 0, memory_partition, len);
@@ -3378,8 +3345,7 @@ amdsmi_status_t amdsmi_get_gpu_memory_partition_config(amdsmi_processor_handle p
   // TODO(amdsmi_team): Will BM/guest VMs have numa ranges?
   config->num_numa_ranges = 0;
 
-  // A sub-partition handle's capability sysfs nodes only respond on the owning
-  // device's primary partition, so redirect capability queries there.
+  // The capability nodes below only respond on the primary partition.
   amdsmi_processor_handle query_handle = resolve_partition_query_handle(processor_handle);
 
   // current memory partition
@@ -3503,11 +3469,8 @@ amdsmi_status_t amdsmi_get_gpu_accelerator_partition_profile_config(
   if (!amd::smi::is_sudo_user()) {
     return AMDSMI_STATUS_NO_PERM;
   }
-  // This enumerates the device's supported accelerator profiles (a whole-GPU
-  // capability) and probes them with internal partition-config writes. It is not
-  // part of the per-partition partition display fixed for issue #100, so the
-  // sub-partition redirect applied by the partition getters is intentionally not
-  // used here.
+  // No sub-partition redirect here: this probes supported profiles with internal
+  // partition-config writes rather than reading per-partition state.
   std::ostringstream ss;
   ss << __PRETTY_FUNCTION__ << " | START ";
   // std::cout << ss.str() << std::endl;
@@ -3923,14 +3886,10 @@ amdsmi_status_t amdsmi_get_gpu_accelerator_partition_profile(
   auto tmp_partition_id = uint32_t(0);
   amdsmi_status_t status = AMDSMI_STATUS_NOT_SUPPORTED;
 
-  // A sub-partition handle exposes none of this device's whole-GPU partition
-  // interfaces: the supported-config list, the current compute/memory partition, and
-  // the gpu_metrics / XCD-counter nodes used to derive num_partitions all only respond
-  // on the owning device's primary partition (verified on an MI300X in CPX mode, where
-  // every sub-partition with partition_id != 0 returns an error for those reads). So
-  // resolve the primary partition handle and query all of them through it; otherwise
-  // sub-partitions report "N/A". Only the reported partition_id below keeps the original
-  // handle, so each partition keeps its own identity.
+  // The supported-config list, current partition modes, and the gpu_metrics/XCD nodes
+  // used for num_partitions all only respond on the primary partition. Only
+  // partition_id below stays on the caller's handle, so each partition keeps its
+  // own identity.
   amdsmi_processor_handle query_handle = resolve_partition_query_handle(processor_handle);
 
   // TODO(amdsmi_team): should we do fallback?

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -3102,6 +3102,120 @@ amdsmi_status_t amdsmi_topo_get_p2p_status(amdsmi_processor_handle processor_han
   return amd::smi::rsmi_to_amdsmi_status(rstatus);
 }
 
+namespace amd {
+namespace smi {
+
+// Pure redirect decision factored out of get_primary_partition_handle() so it
+// can be unit tested without hardware.
+//
+// Given the partition ids of every logical GPU partition that shares a physical
+// device and the index of the querying partition within that list, return the
+// index of the primary partition (partition_id == 0) that partition-config
+// queries must be redirected to, or -1 when no redirect is needed: the device is
+// not split into multiple logical partitions, the querying partition is already
+// the primary, or no primary sibling exists. Siblings whose id could not be read
+// must be passed as UINT32_MAX so they are skipped.
+int primary_partition_redirect_index(const std::vector<uint32_t>& partition_ids,
+                                     size_t self_index) {
+  // A physical device that exposes a single logical GPU has no separate primary
+  // partition to redirect to.
+  if (partition_ids.size() <= 1) {
+    return -1;
+  }
+  for (size_t i = 0; i < partition_ids.size(); ++i) {
+    if (i == self_index) {
+      continue;
+    }
+    if (partition_ids[i] == 0) {
+      return static_cast<int>(i);
+    }
+  }
+  return -1;
+}
+
+}  // namespace smi
+}  // namespace amd
+
+// On MI300-class accelerators that are split into multiple logical partitions
+// (for example CPX + NPS4), the compute- and memory-partition sysfs nodes only
+// respond on the primary partition (partition_id == 0) of each physical device.
+// Queries issued against a logical sub-partition handle (partition_id > 0)
+// therefore fail and the tool falls back to reporting "N/A". All logical
+// partitions of a physical device share the same partition configuration and are
+// grouped under the same AMDSmiSocket (keyed on the BD portion of the BDF), so
+// this helper walks the owning socket and returns the primary partition's handle
+// for a given sub-partition handle.
+//
+// Returns nullptr when the handle is already the primary partition, when the
+// device is not partitioned into multiple logical GPUs, or when no primary
+// sibling can be found.
+static amdsmi_processor_handle get_primary_partition_handle(
+    amdsmi_processor_handle processor_handle) {
+  amd::smi::AMDSmiProcessor* processor = nullptr;
+  amdsmi_status_t status =
+      amd::smi::AMDSmiSystem::getInstance().handle_to_processor(processor_handle, &processor);
+  if (status != AMDSMI_STATUS_SUCCESS || processor == nullptr) {
+    return nullptr;
+  }
+
+  // Fast path: the primary partition (partition_id == 0) already answers
+  // partition-config queries directly, so it never needs a redirect. Reading the
+  // caller's own partition id first avoids the socket walk and the per-sibling
+  // sysfs reads below on every primary partition and every unpartitioned (SPX)
+  // device.
+  uint32_t self_partition_id = std::numeric_limits<uint32_t>::max();
+  if (rsmi_wrapper(rsmi_dev_partition_id_get, processor_handle, 0, &self_partition_id) ==
+          AMDSMI_STATUS_SUCCESS &&
+      self_partition_id == 0) {
+    return nullptr;
+  }
+
+  // Find the socket (physical device) that owns this processor.
+  amd::smi::AMDSmiSocket* owning_socket = nullptr;
+  for (auto* socket : amd::smi::AMDSmiSystem::getInstance().get_sockets()) {
+    if (socket == nullptr) {
+      continue;
+    }
+    auto& gpu_processors = socket->get_processors(AMDSMI_PROCESSOR_TYPE_AMD_GPU);
+    if (std::find(gpu_processors.begin(), gpu_processors.end(), processor) !=
+        gpu_processors.end()) {
+      owning_socket = socket;
+      break;
+    }
+  }
+  if (owning_socket == nullptr) {
+    return nullptr;
+  }
+
+  // Collect the partition id of every logical GPU partition on this physical
+  // device (marking siblings whose id cannot be read as unqueryable) and locate
+  // this processor within that list, then defer the redirect decision to the
+  // pure helper above.
+  auto& siblings = owning_socket->get_processors(AMDSMI_PROCESSOR_TYPE_AMD_GPU);
+  std::vector<uint32_t> partition_ids(siblings.size(), std::numeric_limits<uint32_t>::max());
+  size_t self_index = siblings.size();
+  for (size_t i = 0; i < siblings.size(); ++i) {
+    if (siblings[i] == processor) {
+      self_index = i;
+    }
+    if (siblings[i] == nullptr) {
+      continue;
+    }
+    auto sibling_handle = reinterpret_cast<amdsmi_processor_handle>(siblings[i]);
+    uint32_t sibling_partition_id = std::numeric_limits<uint32_t>::max();
+    if (rsmi_wrapper(rsmi_dev_partition_id_get, sibling_handle, 0, &sibling_partition_id) ==
+        AMDSMI_STATUS_SUCCESS) {
+      partition_ids[i] = sibling_partition_id;
+    }
+  }
+
+  int primary_index = amd::smi::primary_partition_redirect_index(partition_ids, self_index);
+  if (primary_index < 0) {
+    return nullptr;
+  }
+  return reinterpret_cast<amdsmi_processor_handle>(siblings[primary_index]);
+}
+
 // Compute Partition functions
 // This API is deprecated, use amdsmi_get_gpu_accelerator_partition_profile() instead
 amdsmi_status_t amdsmi_get_gpu_compute_partition(amdsmi_processor_handle processor_handle,
@@ -3111,6 +3225,17 @@ amdsmi_status_t amdsmi_get_gpu_compute_partition(amdsmi_processor_handle process
 
   auto status =
       rsmi_wrapper(rsmi_dev_compute_partition_get, processor_handle, 0, compute_partition, len);
+  // The compute-partition sysfs node only responds on the primary partition
+  // (partition_id == 0). For a logical sub-partition handle the query above fails,
+  // so retry against the owning physical device's primary partition handle. All
+  // partitions of a physical device share the same compute-partition mode.
+  if (status != AMDSMI_STATUS_SUCCESS) {
+    amdsmi_processor_handle primary_handle = get_primary_partition_handle(processor_handle);
+    if (primary_handle != nullptr) {
+      status =
+          rsmi_wrapper(rsmi_dev_compute_partition_get, primary_handle, 0, compute_partition, len);
+    }
+  }
   ss << __PRETTY_FUNCTION__ << " |  rsmi_dev_compute_partition_get() returned: "
      << smi_amdgpu_get_status_string(status, false);
   LOG_INFO(ss);
@@ -3178,6 +3303,16 @@ amdsmi_status_t amdsmi_get_gpu_memory_partition(amdsmi_processor_handle processo
   AMDSMI_CHECK_INIT();
   amdsmi_status_t ret =
       rsmi_wrapper(rsmi_dev_memory_partition_get, processor_handle, 0, memory_partition, len);
+  // The memory-partition sysfs node only responds on the primary partition
+  // (partition_id == 0). For a logical sub-partition handle the query above fails,
+  // so retry against the owning physical device's primary partition handle. All
+  // partitions of a physical device share the same memory-partition (NPS) mode.
+  if (ret != AMDSMI_STATUS_SUCCESS) {
+    amdsmi_processor_handle primary_handle = get_primary_partition_handle(processor_handle);
+    if (primary_handle != nullptr) {
+      ret = rsmi_wrapper(rsmi_dev_memory_partition_get, primary_handle, 0, memory_partition, len);
+    }
+  }
   return ret;
 }
 
@@ -3207,12 +3342,21 @@ amdsmi_status_t amdsmi_get_gpu_memory_partition_config(amdsmi_processor_handle p
   // TODO(amdsmi_team): Will BM/guest VMs have numa ranges?
   config->num_numa_ranges = 0;
 
+  // For a logical sub-partition handle (partition_id > 0) the partition-capability
+  // sysfs nodes only respond on the owning physical device's primary partition, so
+  // redirect capability queries there.
+  amdsmi_processor_handle query_handle = processor_handle;
+  amdsmi_processor_handle primary_handle = get_primary_partition_handle(processor_handle);
+  if (primary_handle != nullptr) {
+    query_handle = primary_handle;
+  }
+
   // current memory partition
   constexpr uint32_t kCurrentPartitionSize = 5;
   char current_mem_partition[kCurrentPartitionSize] = {};
   std::string current_mem_partition_str = "N/A";
-  amdsmi_status_t status = amdsmi_get_gpu_memory_partition(processor_handle, current_mem_partition,
-                                                           kCurrentPartitionSize);
+  amdsmi_status_t status =
+      amdsmi_get_gpu_memory_partition(query_handle, current_mem_partition, kCurrentPartitionSize);
   ss << __PRETTY_FUNCTION__ << " | amdsmi_get_gpu_memory_partition() current_partition = |"
      << current_mem_partition << "|";
   LOG_DEBUG(ss);
@@ -3232,8 +3376,8 @@ amdsmi_status_t amdsmi_get_gpu_memory_partition_config(amdsmi_processor_handle p
   // Add memory partition capabilities here
   constexpr uint32_t kLenCapsSize = 30;
   char memory_caps[kLenCapsSize] = {};
-  auto status_mem_caps = rsmi_wrapper(rsmi_dev_memory_partition_capabilities_get, processor_handle,
-                                      0, memory_caps, kLenCapsSize);
+  auto status_mem_caps = rsmi_wrapper(rsmi_dev_memory_partition_capabilities_get, query_handle, 0,
+                                      memory_caps, kLenCapsSize);
   ss << __PRETTY_FUNCTION__ << " | rsmi_dev_memory_partition_capabilities_get Returning: "
      << smi_amdgpu_get_status_string(status, false) << " | Type: memory_partition_capabilities"
      << " | Data: " << memory_caps;
@@ -3743,6 +3887,18 @@ amdsmi_status_t amdsmi_get_gpu_accelerator_partition_profile(
   auto tmp_partition_id = uint32_t(0);
   amdsmi_status_t status = AMDSMI_STATUS_NOT_SUPPORTED;
 
+  // For a logical sub-partition handle (partition_id > 0) the partition-profile
+  // sysfs/ioctl interfaces only respond on the owning physical device's primary
+  // partition (partition_id == 0). Redirect the capability/profile queries there so
+  // sub-partitions report the same profile as their parent instead of "N/A". The
+  // reported partition_id below intentionally continues to use the original handle
+  // so each logical partition keeps its own identity.
+  amdsmi_processor_handle query_handle = processor_handle;
+  amdsmi_processor_handle primary_handle = get_primary_partition_handle(processor_handle);
+  if (primary_handle != nullptr) {
+    query_handle = primary_handle;
+  }
+
   // TODO(amdsmi_team): should we do fallback?
   // Info doesn't populate properly if missing other files - CLI FIX?
   // Reason: older kernels do not support xcp_configs
@@ -3757,7 +3913,7 @@ amdsmi_status_t amdsmi_get_gpu_accelerator_partition_profile(
   constexpr uint32_t kLenXCPConfigSize = 30;
   char supported_xcp_configs[kLenXCPConfigSize];
   bool use_xcp_config = false;
-  status = rsmi_wrapper(rsmi_dev_compute_partition_supported_xcp_configs_get, processor_handle, 0,
+  status = rsmi_wrapper(rsmi_dev_compute_partition_supported_xcp_configs_get, query_handle, 0,
                         supported_xcp_configs, kLenXCPConfigSize);
   if (status == AMDSMI_STATUS_SUCCESS) {
     accelerator_capabilities.clear();
@@ -3795,7 +3951,7 @@ amdsmi_status_t amdsmi_get_gpu_accelerator_partition_profile(
   char current_partition[kCurrentPartitionSize] = {0};
   std::string current_partition_str = "N/A";
   amdsmi_status_t compute_status =
-      amdsmi_get_gpu_compute_partition(processor_handle, current_partition, kCurrentPartitionSize);
+      amdsmi_get_gpu_compute_partition(query_handle, current_partition, kCurrentPartitionSize);
   ss << __PRETTY_FUNCTION__ << " | amdsmi_get_gpu_compute_partition() current_partition = |"
      << current_partition << "|";
   LOG_DEBUG(ss);
@@ -3836,7 +3992,7 @@ amdsmi_status_t amdsmi_get_gpu_accelerator_partition_profile(
   }
 
   amdsmi_gpu_metrics_t metric_info = {};
-  status = amdsmi_get_gpu_metrics_info(processor_handle, &metric_info);
+  status = amdsmi_get_gpu_metrics_info(query_handle, &metric_info);
   if (status == AMDSMI_STATUS_SUCCESS &&
       metric_info.num_partition != std::numeric_limits<uint16_t>::max()) {
     profile->num_partitions = metric_info.num_partition;
@@ -3853,7 +4009,7 @@ amdsmi_status_t amdsmi_get_gpu_accelerator_partition_profile(
     } else if (profile->profile_type == AMDSMI_ACCELERATOR_PARTITION_CPX) {
       // Note: # of XCDs is max # of partitions CPX supports
       uint16_t tmp_xcd_count = 0;
-      amdsmi_status_t xcd_status = amdsmi_get_gpu_xcd_counter(processor_handle, &tmp_xcd_count);
+      amdsmi_status_t xcd_status = amdsmi_get_gpu_xcd_counter(query_handle, &tmp_xcd_count);
       if (xcd_status == AMDSMI_STATUS_SUCCESS) {
         profile->num_partitions = tmp_xcd_count;
       }
@@ -3887,8 +4043,8 @@ amdsmi_status_t amdsmi_get_gpu_accelerator_partition_profile(
   // Add memory partition capabilities here
   constexpr uint32_t kLenCapsSize = 30;
   char memory_caps[kLenCapsSize];
-  status = rsmi_wrapper(rsmi_dev_memory_partition_capabilities_get, processor_handle, 0,
-                        memory_caps, kLenCapsSize);
+  status = rsmi_wrapper(rsmi_dev_memory_partition_capabilities_get, query_handle, 0, memory_caps,
+                        kLenCapsSize);
   ss << __PRETTY_FUNCTION__ << " | rsmi_dev_memory_partition_capabilities_get Returning: "
      << smi_amdgpu_get_status_string(status, false) << " | Type: memory_partition_capabilities"
      << " | Data: " << memory_caps;

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -3230,16 +3230,17 @@ static amdsmi_processor_handle resolve_primary_partition_handle_uncached(
 // redirect is needed (primary, single-GPU, or unpartitioned device).
 static amdsmi_processor_handle get_primary_partition_handle(
     amdsmi_processor_handle processor_handle) {
-  {
-    std::lock_guard<std::mutex> lock(primary_partition_cache_mutex);
-    auto it = primary_partition_cache.find(processor_handle);
-    if (it != primary_partition_cache.end()) {
-      return it->second;
-    }
+  // Hold the lock across the resolve so concurrent first-time callers for the same
+  // handle fill the cache once instead of each repeating the socket walk. The walk is
+  // a one-time cost per handle (partition topology is fixed for an init/shutdown
+  // lifetime) and the resolver never re-enters this mutex, so serializing it is safe.
+  std::lock_guard<std::mutex> lock(primary_partition_cache_mutex);
+  auto it = primary_partition_cache.find(processor_handle);
+  if (it != primary_partition_cache.end()) {
+    return it->second;
   }
   amdsmi_processor_handle primary_handle =
       resolve_primary_partition_handle_uncached(processor_handle);
-  std::lock_guard<std::mutex> lock(primary_partition_cache_mutex);
   primary_partition_cache[processor_handle] = primary_handle;
   return primary_handle;
 }
@@ -3922,10 +3923,14 @@ amdsmi_status_t amdsmi_get_gpu_accelerator_partition_profile(
   auto tmp_partition_id = uint32_t(0);
   amdsmi_status_t status = AMDSMI_STATUS_NOT_SUPPORTED;
 
-  // A sub-partition handle's partition-profile sysfs/ioctl interfaces only respond
-  // on the owning device's primary partition, so redirect the capability/profile
-  // queries there (otherwise sub-partitions report "N/A"). The reported partition_id
-  // below intentionally keeps the original handle so each partition keeps its identity.
+  // A sub-partition handle exposes none of this device's whole-GPU partition
+  // interfaces: the supported-config list, the current compute/memory partition, and
+  // the gpu_metrics / XCD-counter nodes used to derive num_partitions all only respond
+  // on the owning device's primary partition (verified on an MI300X in CPX mode, where
+  // every sub-partition with partition_id != 0 returns an error for those reads). So
+  // resolve the primary partition handle and query all of them through it; otherwise
+  // sub-partitions report "N/A". Only the reported partition_id below keeps the original
+  // handle, so each partition keeps its own identity.
   amdsmi_processor_handle query_handle = resolve_partition_query_handle(processor_handle);
 
   // TODO(amdsmi_team): should we do fallback?

--- a/projects/amdsmi/tests/amd_smi_test/functional/partition_redirect_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/partition_redirect_test.cc
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// Hardware-free unit tests for the partition-redirect decision.
+//
+// On MI300-class accelerators split into multiple logical partitions (for
+// example CPX + NPS4) the compute-/memory-partition sysfs nodes only respond on
+// the primary partition (partition_id == 0). Queries against a logical
+// sub-partition handle must be redirected to that primary, otherwise the tool
+// reports "N/A". amdsmi.cc factors the redirect decision into the pure helper
+// exercised below so it can be verified without any GPU present.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+namespace amd::smi {
+
+// Forward declaration of the internal helper under test (defined in
+// src/amd_smi/amd_smi.cc).
+int primary_partition_redirect_index(const std::vector<uint32_t>& partition_ids, size_t self_index);
+
+}  // namespace amd::smi
+
+namespace {
+
+constexpr uint32_t kUnqueryable = std::numeric_limits<uint32_t>::max();
+
+}  // namespace
+
+// A device that exposes a single logical GPU has no separate primary partition,
+// so nothing is redirected.
+TEST(AmdSmiPartitionRedirectTest, SinglePartitionIsNotRedirected) {
+  EXPECT_EQ(amd::smi::primary_partition_redirect_index({0}, 0), -1);
+}
+
+// A device with no partitions is likewise never redirected.
+TEST(AmdSmiPartitionRedirectTest, EmptyDeviceIsNotRedirected) {
+  EXPECT_EQ(amd::smi::primary_partition_redirect_index({}, 0), -1);
+}
+
+// The primary partition already answers partition queries directly, so it is
+// not redirected to itself.
+TEST(AmdSmiPartitionRedirectTest, PrimaryPartitionIsNotRedirected) {
+  EXPECT_EQ(amd::smi::primary_partition_redirect_index({0, 1, 2, 3}, 0), -1);
+}
+
+// A logical sub-partition (partition_id > 0) is redirected to the primary
+// sibling's index.
+TEST(AmdSmiPartitionRedirectTest, SubPartitionRedirectsToPrimary) {
+  EXPECT_EQ(amd::smi::primary_partition_redirect_index({0, 1, 2, 3}, 3), 0);
+  EXPECT_EQ(amd::smi::primary_partition_redirect_index({0, 1, 2, 3}, 1), 0);
+}
+
+// The primary need not be the first entry; its actual index is returned.
+TEST(AmdSmiPartitionRedirectTest, PrimaryFoundAtNonZeroIndex) {
+  EXPECT_EQ(amd::smi::primary_partition_redirect_index({5, 0, 3}, 2), 1);
+}
+
+// When no sibling reports partition_id == 0 there is nothing to redirect to.
+TEST(AmdSmiPartitionRedirectTest, NoPrimaryPresentIsNotRedirected) {
+  EXPECT_EQ(amd::smi::primary_partition_redirect_index({1, 2, 3}, 0), -1);
+}
+
+// Siblings whose partition id could not be read (UINT32_MAX) are skipped and do
+// not shadow the real primary.
+TEST(AmdSmiPartitionRedirectTest, UnqueryableSiblingsAreSkipped) {
+  EXPECT_EQ(amd::smi::primary_partition_redirect_index({kUnqueryable, 0, kUnqueryable}, 0), 1);
+  EXPECT_EQ(amd::smi::primary_partition_redirect_index({kUnqueryable, kUnqueryable}, 0), -1);
+}
+
+// The querying partition is always skipped, so a device whose only primary is
+// the caller itself is not redirected.
+TEST(AmdSmiPartitionRedirectTest, SelfIsSkippedWhenLocatingPrimary) {
+  EXPECT_EQ(amd::smi::primary_partition_redirect_index({0, 5}, 0), -1);
+}

--- a/projects/amdsmi/tests/amd_smi_test/functional/partition_redirect_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/partition_redirect_test.cc
@@ -22,12 +22,11 @@
 
 // Hardware-free unit tests for the partition-redirect decision.
 //
-// On MI300-class accelerators split into multiple logical partitions (for
-// example CPX + NPS4) the compute-/memory-partition sysfs nodes only respond on
-// the primary partition (partition_id == 0). Queries against a logical
-// sub-partition handle must be redirected to that primary, otherwise the tool
-// reports "N/A". amdsmi.cc factors the redirect decision into the pure helper
-// exercised below so it can be verified without any GPU present.
+// On MI300-class accelerators split into multiple logical partitions (e.g. CPX +
+// NPS4) the compute-/memory-partition sysfs nodes only respond on the primary
+// partition (partition_id == 0), so queries against a sub-partition handle must
+// be redirected there or the tool reports "N/A". amd_smi.cc factors that decision
+// into the pure helper exercised below so it can be verified without a GPU.
 
 #include <gtest/gtest.h>
 

--- a/projects/amdsmi/tests/amd_smi_test/unit/gpu/partition_redirect_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/unit/gpu/partition_redirect_test.cc
@@ -20,13 +20,9 @@
  * THE SOFTWARE.
  */
 
-// Hardware-free unit tests for the partition-redirect decision.
-//
-// On MI300-class accelerators split into multiple logical partitions (e.g. CPX +
-// NPS4) the compute-/memory-partition sysfs nodes only respond on the primary
-// partition (partition_id == 0), so queries against a sub-partition handle must
-// be redirected there or the tool reports "N/A". amd_smi.cc factors that decision
-// into the pure helper exercised below so it can be verified without a GPU.
+// Hardware-free unit tests for the partition-redirect decision: which sibling
+// partition a partition query must be sent to, since only the primary
+// (partition_id == 0) answers on MI300-class multi-partition devices.
 
 #include <gtest/gtest.h>
 
@@ -36,12 +32,9 @@
 
 namespace amd::smi {
 
-// Forward declaration of the internal helper under test (defined in
-// src/amd_smi/amd_smi.cc). This symbol is internal to the library and is not part
-// of the exported amdsmi_* ABI (the shared-library version script keeps it
-// hidden), so the test resolves it through the static library. Building the test
-// suite turns on BUILD_BOTH_LIBS, which links amdsmitst against that static lib;
-// keep this declaration in sync with the definition's signature.
+// Defined in src/amd_smi/amd_smi.cc. The symbol is hidden by the shared library's
+// version script, so the test resolves it through the static library
+// (BUILD_BOTH_LIBS, enabled with the test suite).
 int primary_partition_redirect_index(const std::vector<uint32_t>& partition_ids, size_t self_index);
 
 }  // namespace amd::smi
@@ -52,49 +45,36 @@ constexpr uint32_t kUnqueryable = std::numeric_limits<uint32_t>::max();
 
 }  // namespace
 
-// A device that exposes a single logical GPU has no separate primary partition,
-// so nothing is redirected.
 TEST(GpuUnit, PartitionRedirectSinglePartitionIsNotRedirected) {
   EXPECT_EQ(amd::smi::primary_partition_redirect_index({0}, 0), -1);
 }
 
-// A device with no partitions is likewise never redirected.
 TEST(GpuUnit, PartitionRedirectEmptyDeviceIsNotRedirected) {
   EXPECT_EQ(amd::smi::primary_partition_redirect_index({}, 0), -1);
 }
 
-// The primary partition already answers partition queries directly, so it is
-// not redirected to itself.
 TEST(GpuUnit, PartitionRedirectPrimaryPartitionIsNotRedirected) {
   EXPECT_EQ(amd::smi::primary_partition_redirect_index({0, 1, 2, 3}, 0), -1);
 }
 
-// A logical sub-partition (partition_id > 0) is redirected to the primary
-// sibling's index.
 TEST(GpuUnit, PartitionRedirectSubPartitionRedirectsToPrimary) {
   EXPECT_EQ(amd::smi::primary_partition_redirect_index({0, 1, 2, 3}, 3), 0);
   EXPECT_EQ(amd::smi::primary_partition_redirect_index({0, 1, 2, 3}, 1), 0);
 }
 
-// The primary need not be the first entry; its actual index is returned.
 TEST(GpuUnit, PartitionRedirectPrimaryFoundAtNonZeroIndex) {
   EXPECT_EQ(amd::smi::primary_partition_redirect_index({5, 0, 3}, 2), 1);
 }
 
-// When no sibling reports partition_id == 0 there is nothing to redirect to.
 TEST(GpuUnit, PartitionRedirectNoPrimaryPresentIsNotRedirected) {
   EXPECT_EQ(amd::smi::primary_partition_redirect_index({1, 2, 3}, 0), -1);
 }
 
-// Siblings whose partition id could not be read (UINT32_MAX) are skipped and do
-// not shadow the real primary.
 TEST(GpuUnit, PartitionRedirectUnqueryableSiblingsAreSkipped) {
   EXPECT_EQ(amd::smi::primary_partition_redirect_index({kUnqueryable, 0, kUnqueryable}, 0), 1);
   EXPECT_EQ(amd::smi::primary_partition_redirect_index({kUnqueryable, kUnqueryable}, 0), -1);
 }
 
-// The querying partition is always skipped, so a device whose only primary is
-// the caller itself is not redirected.
 TEST(GpuUnit, PartitionRedirectSelfIsSkippedWhenLocatingPrimary) {
   EXPECT_EQ(amd::smi::primary_partition_redirect_index({0, 5}, 0), -1);
 }

--- a/projects/amdsmi/tests/amd_smi_test/unit/gpu/partition_redirect_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/unit/gpu/partition_redirect_test.cc
@@ -50,47 +50,47 @@ constexpr uint32_t kUnqueryable = std::numeric_limits<uint32_t>::max();
 
 // A device that exposes a single logical GPU has no separate primary partition,
 // so nothing is redirected.
-TEST(AmdSmiPartitionRedirectTest, SinglePartitionIsNotRedirected) {
+TEST(GpuUnit, PartitionRedirectSinglePartitionIsNotRedirected) {
   EXPECT_EQ(amd::smi::primary_partition_redirect_index({0}, 0), -1);
 }
 
 // A device with no partitions is likewise never redirected.
-TEST(AmdSmiPartitionRedirectTest, EmptyDeviceIsNotRedirected) {
+TEST(GpuUnit, PartitionRedirectEmptyDeviceIsNotRedirected) {
   EXPECT_EQ(amd::smi::primary_partition_redirect_index({}, 0), -1);
 }
 
 // The primary partition already answers partition queries directly, so it is
 // not redirected to itself.
-TEST(AmdSmiPartitionRedirectTest, PrimaryPartitionIsNotRedirected) {
+TEST(GpuUnit, PartitionRedirectPrimaryPartitionIsNotRedirected) {
   EXPECT_EQ(amd::smi::primary_partition_redirect_index({0, 1, 2, 3}, 0), -1);
 }
 
 // A logical sub-partition (partition_id > 0) is redirected to the primary
 // sibling's index.
-TEST(AmdSmiPartitionRedirectTest, SubPartitionRedirectsToPrimary) {
+TEST(GpuUnit, PartitionRedirectSubPartitionRedirectsToPrimary) {
   EXPECT_EQ(amd::smi::primary_partition_redirect_index({0, 1, 2, 3}, 3), 0);
   EXPECT_EQ(amd::smi::primary_partition_redirect_index({0, 1, 2, 3}, 1), 0);
 }
 
 // The primary need not be the first entry; its actual index is returned.
-TEST(AmdSmiPartitionRedirectTest, PrimaryFoundAtNonZeroIndex) {
+TEST(GpuUnit, PartitionRedirectPrimaryFoundAtNonZeroIndex) {
   EXPECT_EQ(amd::smi::primary_partition_redirect_index({5, 0, 3}, 2), 1);
 }
 
 // When no sibling reports partition_id == 0 there is nothing to redirect to.
-TEST(AmdSmiPartitionRedirectTest, NoPrimaryPresentIsNotRedirected) {
+TEST(GpuUnit, PartitionRedirectNoPrimaryPresentIsNotRedirected) {
   EXPECT_EQ(amd::smi::primary_partition_redirect_index({1, 2, 3}, 0), -1);
 }
 
 // Siblings whose partition id could not be read (UINT32_MAX) are skipped and do
 // not shadow the real primary.
-TEST(AmdSmiPartitionRedirectTest, UnqueryableSiblingsAreSkipped) {
+TEST(GpuUnit, PartitionRedirectUnqueryableSiblingsAreSkipped) {
   EXPECT_EQ(amd::smi::primary_partition_redirect_index({kUnqueryable, 0, kUnqueryable}, 0), 1);
   EXPECT_EQ(amd::smi::primary_partition_redirect_index({kUnqueryable, kUnqueryable}, 0), -1);
 }
 
 // The querying partition is always skipped, so a device whose only primary is
 // the caller itself is not redirected.
-TEST(AmdSmiPartitionRedirectTest, SelfIsSkippedWhenLocatingPrimary) {
+TEST(GpuUnit, PartitionRedirectSelfIsSkippedWhenLocatingPrimary) {
   EXPECT_EQ(amd::smi::primary_partition_redirect_index({0, 5}, 0), -1);
 }

--- a/projects/amdsmi/tests/amd_smi_test/unit/gpu/partition_redirect_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/unit/gpu/partition_redirect_test.cc
@@ -37,7 +37,11 @@
 namespace amd::smi {
 
 // Forward declaration of the internal helper under test (defined in
-// src/amd_smi/amd_smi.cc).
+// src/amd_smi/amd_smi.cc). This symbol is internal to the library and is not part
+// of the exported amdsmi_* ABI (the shared-library version script keeps it
+// hidden), so the test resolves it through the static library. Building the test
+// suite turns on BUILD_BOTH_LIBS, which links amdsmitst against that static lib;
+// keep this declaration in sync with the definition's signature.
 int primary_partition_redirect_index(const std::vector<uint32_t>& partition_ids, size_t self_index);
 
 }  // namespace amd::smi


### PR DESCRIPTION
## Motivation

- On MI300 GPUs in CPX/NPS4 mode, `amd-smi partition` showed `N/A` on every sub-partition because those sysfs nodes only respond on each device's primary partition (only 8 of 64 logical GPUs reported info). Closes ROCm/amdsmi#100.

## Technical Details

- Added `get_primary_partition_handle()`: a sub-partition query resolves the owning device and reads from its primary (`partition_id == 0`) handle, with a fast path for primary/SPX and a cached lookup.
- Wired it into the five partition getters via one `resolve_partition_query_handle()` path; each partition still reports its own `partition_id`. Added 8 hardware-free `GpuUnit` tests and a CHANGELOG entry.

## JIRA ID

Closes ROCm/amdsmi#100

## Test Plan

- Built `amdsmitst` with `-DBUILD_TESTS=ON`; ran `GpuUnit.*` and the profile getter across all logical GPUs on a live MI300X (CPX).

## Test Result

- 27/27 `GpuUnit` PASSED; MI300X CPX end-to-end: all 64 logical GPUs report the correct profile (`num_partitions=8`).

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
