### PR TITLE
fix(rccl) [JIRA ID ROCM-25479]  LL128: generate separate kernels for UBR

### DIFF
--- a/projects/rccl/cmake/scripts/add_unroll.sh
+++ b/projects/rccl/cmake/scripts/add_unroll.sh
@@ -37,6 +37,34 @@ if [[ "$HIP_FILE" =~ .*/src/device/.*\.h ]]; then
   perl -pi -e 's/(runRing<T, RedOp, Proto, USE_ACC, COLL_UNROLL.*?)>/\1, Pipeline>/' "$HIP_FILE"
   perl -pi -e 's/(runTreeSplit<T, RedOp, Proto, USE_ACC, COLL_UNROLL.*?)>/\1, Pipeline>/' "$HIP_FILE"
   perl -pi -e 's/(runTreeUpDown<T, RedOp, Proto, USE_ACC, COLL_UNROLL.*?)>/\1, Pipeline>/' "$HIP_FILE"
-  sed -i "s/\\(struct RunWorkBatch<ncclFunc[^>]*\\)>*/\\1, USE_ACC, COLL_UNROLL, Pipeline>/" "$HIP_FILE"
-  sed -i "s/\\(RunWorkColl<[^,]*,[^,]*,[^,]*,[^,]*,[^>]*\\)>/\\1, USE_ACC, COLL_UNROLL, Pipeline>/" "$HIP_FILE"
+  sed -i "s/\\(struct RunWorkBatch<ncclFunc[^>]*\\)>*/\\1, USE_ACC, COLL_UNROLL, Pipeline, UserRegMode>/" "$HIP_FILE"
+  sed -i "s/\\(RunWorkColl<[^,]*,[^,]*,[^,]*,[^,]*,[^>]*\\)>/\\1, USE_ACC, COLL_UNROLL, Pipeline, UserRegMode>/" "$HIP_FILE"
+
+  # Declare the UserRegMode template parameter on RunWorkColl / RunWorkBatch
+  # partial specialization headers (those immediately followed by a
+  # `struct RunWork...`). Partial specializations may not carry default template
+  # arguments, so this is added without a default (the primary templates in
+  # common.h provide the default). Must run after the USE_ACC/COLL_UNROLL/Pipeline
+  # header expansion above. The optional params between RedOp and USE_ACC cover
+  # specializations that carry an extra `int Proto` (e.g. AllGatherV).
+  perl -0777 -pi -e 's/(template<typename T, typename RedOp[^>]*?, int USE_ACC, int COLL_UNROLL, int Pipeline)>(\s*\nstruct RunWork)/\1, int UserRegMode>\2/g' "$HIP_FILE"
+
+  # Thread a compile-time UserRegMode parameter onto runRing so LL/LL128 can select
+  # their user-buffer access path (0=runtime, 1=registered, 2=non-registered)
+  # without a runtime dual code path. Append it (defaulted) to every (already
+  # expanded) runRing/runTree header, right after the Pipeline / isNetOffload tail.
+  perl -pi -e 's/(template<typename T, typename RedOp, typename Proto[^>]*int Pipeline[^>]*)>/\1, int UserRegMode = 0>/g' "$HIP_FILE"
+
+  # LL128 reg/noreg split: LL (ProtoLL) keeps the baseline single runtime path and
+  # LL128 is generated as two separate kernels (see generate.py). The RunWorkColl
+  # specialization is instantiated per UserRegMode, so these dispatch helpers just
+  # forward the compile-time UserRegMode template parameter into runRing/runTreeSplit.
+  #   all_reduce ring : <T, RedOp, Proto, RCCLMetadata, USE_ACC, COLL_UNROLL, Pipeline, UserRegMode>
+  #   all_reduce tree : <T, RedOp, Proto, USE_ACC, COLL_UNROLL, Pipeline, UserRegMode>
+  #   all_gather ring : <T, RedOp, Proto, USE_ACC, COLL_UNROLL, Pipeline, isNetOffload, UserRegMode>
+  #   broadcast  ring : <T, RedOp, Proto, USE_ACC, COLL_UNROLL, Pipeline, UserRegMode>
+  perl -pi -e 's/runARRingLL128<T, RedOp>\(/runRing<T, RedOp, ProtoLL128, RCCL_METADATA_EMPTY, USE_ACC, COLL_UNROLL, 0, UserRegMode>(/g' "$HIP_FILE"
+  perl -pi -e 's/runARTreeLL128<T, RedOp>\(/runTreeSplit<T, RedOp, ProtoLL128, USE_ACC, COLL_UNROLL, 0, UserRegMode>(/g' "$HIP_FILE"
+  perl -pi -e 's/runAGRingLL128<T, RedOp>\(/runRing<T, RedOp, ProtoLL128, USE_ACC, COLL_UNROLL, 0, false, UserRegMode>(/g' "$HIP_FILE"
+  perl -pi -e 's/runBcastRingLL128<T, RedOp>\(/runRing<T, RedOp, ProtoLL128, USE_ACC, COLL_UNROLL, 0, UserRegMode>(/g' "$HIP_FILE"
 fi

--- a/projects/rccl/src/device/all_gather.h
+++ b/projects/rccl/src/device/all_gather.h
@@ -55,7 +55,7 @@ namespace {
       // Coverity reports that the callee treats &ring->next as an array.  However, due to the use of
       // FanSymmetric<1>, only the first element is ever accessed, so it's fine.
       // coverity[callee_ptr_arith:FALSE]
-      Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0, isNetOffload> prims
+      Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0, isNetOffload, RCCL_METADATA_EMPTY, 0, 0, UserRegMode> prims
         (tid, workNthreads, &ring->prev, &ring->next, inputBuf, outputBuf, work->redOpArg, 0, work->connIndex, work->connIndex, work, nullptr, isNetOffload ? NCCL_MAX_NET_SIZE : 0);
 
       for (size_t elemOffset = 0; elemOffset < partCount; elemOffset += chunkCount) {
@@ -149,7 +149,9 @@ struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL> {
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllGather, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL128> {
   __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
-    runRing<T, RedOp, ProtoLL128>(tid, nthreads, work);
+    // LL128 is generated as separate registered/non-registered kernels; the
+    // compile-time UserRegMode is forwarded by cmake/scripts/add_unroll.sh.
+    runAGRingLL128<T, RedOp>(tid, nthreads, work);
   }
 };
 

--- a/projects/rccl/src/device/all_reduce.h
+++ b/projects/rccl/src/device/all_reduce.h
@@ -10,6 +10,10 @@
 #include "primitives.h"
 
 namespace {
+  // NOTE: the build-time transformer cmake/scripts/add_unroll.sh appends
+  // ", int USE_ACC, int COLL_UNROLL, int Pipeline, int UserRegMode = 0" to this
+  // template header. UserRegMode selects the LL128 user-buffer access path at
+  // compile time (see prims_ll128.h): 0=runtime, 1=registered, 2=non-registered.
   template<typename T, typename RedOp, typename Proto, int RCCLMetadata>
 #if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
   __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
@@ -44,7 +48,7 @@ namespace {
     // Coverity reports that the callee treats &ring->next as an array.  However, due to the use of
     // FanSymmetric<1>, only the first element is ever accessed, so it's fine.
     // coverity[callee_ptr_arith:FALSE]
-    Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0, false, RCCLMetadata, Pipeline, USE_ACC> prims
+    Primitives<T, RedOp, FanSymmetric<1>, /*Direct=*/1, Proto, 0, false, RCCLMetadata, Pipeline, USE_ACC, UserRegMode> prims
       (tid, nthreads, &ring->prev, &ring->next, work->sendbuff, work->recvbuff, work->redOpArg, 0, work->connIndex, work->connIndex, work);
 
     for (ssize_t elemOffset = 0; elemOffset < channelCount; elemOffset += loopCount) {
@@ -204,7 +208,7 @@ namespace {
 
     if (tree->up == -1) {
       // Reduce and broadcast. Max number of recv is 2, max number of send is 2
-      Primitives<T, RedOp, FanSymmetric<NCCL_MAX_DEV_ARITY>, /*Direct=*/1, Proto, 0, false, 0, Pipeline, USE_ACC>
+      Primitives<T, RedOp, FanSymmetric<NCCL_MAX_DEV_ARITY>, /*Direct=*/1, Proto, 0, false, 0, Pipeline, USE_ACC, UserRegMode>
         prims(tid, nthreads, tree->down, tree->down, work->sendbuff, work->recvbuff, work->redOpArg, 0, 0, 0, work);
 
       for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
@@ -226,7 +230,7 @@ namespace {
       // Coverity reports that the callee treats &tree->up as an array.  However, due to the use of
       // FanAsymmetric<n, 1>, only the first element is ever accessed, so it's fine.
       // coverity[callee_ptr_arith:FALSE]
-      Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_DEV_ARITY, 1>, /*Direct=*/1, Proto, 0, false, 0, Pipeline, USE_ACC>
+      Primitives<T, RedOp, FanAsymmetric<NCCL_MAX_DEV_ARITY, 1>, /*Direct=*/1, Proto, 0, false, 0, Pipeline, USE_ACC, UserRegMode>
         prims(tid, nthreadsSplit, tree->down, &tree->up, work->sendbuff, work->recvbuff, work->redOpArg, 0*Proto::MaxGroupWidth, 0, 0, work);
 
       if (tree->down[0] == -1) {
@@ -250,7 +254,7 @@ namespace {
       // Coverity reports that the callee treats &tree->up as an array.  However, due to the use of
       // FanAsymmetric<1, n>, only the first element is ever accessed, so it's fine.
       // coverity[callee_ptr_arith:FALSE]
-      Primitives<T, RedOp, FanAsymmetric<1, NCCL_MAX_DEV_ARITY>, /*Direct=*/1, Proto, 0, false, 0, Pipeline, USE_ACC>
+      Primitives<T, RedOp, FanAsymmetric<1, NCCL_MAX_DEV_ARITY>, /*Direct=*/1, Proto, 0, false, 0, Pipeline, USE_ACC, UserRegMode>
         prims(tid-nthreadsSplit, nthreads-nthreadsSplit, &tree->up, tree->down, work->sendbuff, work->recvbuff,
             work->redOpArg, 1*Proto::MaxGroupWidth, 0, 0, work);
 
@@ -845,13 +849,17 @@ struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_TREE, NCCL_PROTO_LL> {
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL128> {
   __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
-    runRing<T, RedOp, ProtoLL128, RCCL_METADATA_EMPTY>(tid, nthreads, work);
+    // LL128 is generated as separate registered/non-registered kernels; the
+    // compile-time UserRegMode is forwarded by cmake/scripts/add_unroll.sh into
+    // runRing<..., USE_ACC, COLL_UNROLL, /*Pipeline=*/0, UserRegMode>.
+    runARRingLL128<T, RedOp>(tid, nthreads, work);
   }
 };
 
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncAllReduce, T, RedOp, NCCL_ALGO_TREE, NCCL_PROTO_LL128> {
   __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
-    runTreeSplit<T, RedOp, ProtoLL128>(tid, nthreads, work);
+    // See the LL128 ring note above; add_unroll.sh forwards UserRegMode.
+    runARTreeLL128<T, RedOp>(tid, nthreads, work);
   }
 };

--- a/projects/rccl/src/device/broadcast.h
+++ b/projects/rccl/src/device/broadcast.h
@@ -49,7 +49,7 @@ namespace {
       // Coverity reports that the callee treats &ring->next as an array.  However, due to the use of
       // FanSymmetric<1>, only the first element is ever accessed, so it's fine.
       // coverity[callee_ptr_arith:FALSE]
-      Primitives<T, RedOp, FanSymmetric<1>, 1, Proto, 0>
+      Primitives<T, RedOp, FanSymmetric<1>, 1, Proto, 0, false, RCCL_METADATA_EMPTY, 0, 0, UserRegMode>
         prims(tid, workNthreads, &ring->prev, &ring->next, inputBuf, outputBuf, work->redOpArg, 0, work->connIndex, work->connIndex, work);
 
       for (size_t elemOffset = 0; elemOffset < channelCount; elemOffset += chunkCount) {
@@ -98,6 +98,8 @@ struct RunWorkColl<ncclFuncBroadcast, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL> {
 template<typename T, typename RedOp>
 struct RunWorkColl<ncclFuncBroadcast, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_LL128> {
   __device__ __forceinline__ void run(int tid, int nthreads, struct ncclDevWorkColl* work) {
-    runRing<T, RedOp, ProtoLL128>(tid, nthreads, work);
+    // LL128 is generated as separate registered/non-registered kernels; the
+    // compile-time UserRegMode is forwarded by cmake/scripts/add_unroll.sh.
+    runBcastRingLL128<T, RedOp>(tid, nthreads, work);
   }
 };

--- a/projects/rccl/src/device/common.h
+++ b/projects/rccl/src/device/common.h
@@ -321,14 +321,14 @@ __device__ __forceinline__ unsigned long long int globaltimer() {
 #endif
 }
 
-template<ncclFunc_t Fn, typename T, typename RedOp, int Algo, int Proto, int USE_ACC, int COLL_UNROLL, int Pipeline>
+template<ncclFunc_t Fn, typename T, typename RedOp, int Algo, int Proto, int USE_ACC, int COLL_UNROLL, int Pipeline, int UserRegMode = 0>
 struct RunWorkColl {
   __device__ void run(int tid, int tn, struct ncclDevWorkColl* work) {
     // Put NOT IMPLEMENTED behavior here.
   }
 };
 
-template<ncclFunc_t Fn, typename T, typename RedOp, int Algo, int Proto, int USE_ACC, int COLL_UNROLL, int Pipeline>
+template<ncclFunc_t Fn, typename T, typename RedOp, int Algo, int Proto, int USE_ACC, int COLL_UNROLL, int Pipeline, int UserRegMode = 0>
 struct RunWorkBatch;
 
 // Specialized for P2p in sendrecv.h
@@ -339,7 +339,7 @@ template<typename T, typename RedOp, int Proto>
 struct RunWorkBatch<ncclFuncAllGatherV, T, RedOp, NCCL_ALGO_RING, Proto>;
 
 // Specialized here for non-P2p (Coll and CollReg)
-template<ncclFunc_t Fn, typename T, typename RedOp, int Algo, int Proto,  int USE_ACC, int COLL_UNROLL, int Pipeline>
+template<ncclFunc_t Fn, typename T, typename RedOp, int Algo, int Proto,  int USE_ACC, int COLL_UNROLL, int Pipeline, int UserRegMode>
 struct RunWorkBatch {
   // This __forceinline__ is necessary. The compiler was inserting a function call
   // here from the LL ncclKernel.
@@ -606,14 +606,14 @@ __global__ void ncclDevKernel_Generic_4(ncclDevKernelArgsDefaultStorage NCCL_GRI
 
 // noinline iff RCCL_DEVICE_LINKER (each devfunc is a standalone shard).
 #ifdef RCCL_DEVICE_LINKER
-#define DEFINE_ncclDevFunc(suffix, coll, redop, ty, algo, proto, acc, pipeline, unroll) \
+#define DEFINE_ncclDevFunc(suffix, coll, redop, ty, algo, proto, acc, pipeline, unroll, userreg) \
   __device__ __attribute__((noinline)) void ncclDevFunc_##suffix() { \
-    RunWorkBatch<coll, ty, redop<ty>, algo, proto, acc, unroll, pipeline>().run(); \
+    RunWorkBatch<coll, ty, redop<ty>, algo, proto, acc, unroll, pipeline, userreg>().run(); \
   }
 #else
-#define DEFINE_ncclDevFunc(suffix, coll, redop, ty, algo, proto, acc, pipeline, unroll) \
+#define DEFINE_ncclDevFunc(suffix, coll, redop, ty, algo, proto, acc, pipeline, unroll, userreg) \
   __device__ void ncclDevFunc_##suffix() { \
-    RunWorkBatch<coll, ty, redop<ty>, algo, proto, acc, unroll, pipeline>().run(); \
+    RunWorkBatch<coll, ty, redop<ty>, algo, proto, acc, unroll, pipeline, userreg>().run(); \
   }
 #endif
 

--- a/projects/rccl/src/device/generate.py
+++ b/projects/rccl/src/device/generate.py
@@ -15,8 +15,27 @@ all_algos     = ["TREE","RING", "", "", "", "", "PAT"]
 all_accs      = ["0", "1"]
 all_pipelines = ["0", "1"]
 all_unrolls   = ["1", "2", "4"]
+# User-buffer registration mode (compile-time UserRegMode template parameter):
+#   "0" = runtime / not-applicable (single kernel, current behavior)
+#   "1" = registered user buffer   (LL128 Direct path bypasses cache)
+#   "2" = non-registered user buffer (LL128 Direct path uses plain/non-temporal)
+# Only LL128 for the collectives in `ll128_reg_variant_colls` is split into the
+# "1"/"2" pair; everything else stays a single "0" kernel.
+all_regs      = ["0", "1", "2"]
 
-all_params = [all_colls, all_algos, all_protos, all_redops, all_tys, all_accs, all_pipelines, all_unrolls]
+all_params = [all_colls, all_algos, all_protos, all_redops, all_tys, all_accs, all_pipelines, all_unrolls, all_regs]
+
+# Collectives whose LL128 kernels are specialized into separate registered /
+# non-registered variants (their LL128 user-buffer path is Direct=1, so the
+# compile-time split removes a runtime branch and its dead code). Keep this in
+# sync with `ncclDevFuncIsLL128RegVariant()` in src/include/device.h and the
+# selection logic in src/enqueue.cc.
+ll128_reg_variant_colls = {"AllReduce", "AllGather", "Broadcast"}
+
+def reg_values_of(coll, proto):
+  if proto == "LL128" and coll in ll128_reg_variant_colls:
+    return ["1", "2"]
+  return ["0"]
 
 ################################################################################
 # The first command line argument is the path to the directory to generate and
@@ -189,9 +208,10 @@ class Fn:
   acc: str
   pipeline: str
   unroll: str
+  reg: str
 
   def __iter__(self):
-    return iter((self.coll, self.algo, self.proto, self.redop, self.ty, self.acc, self.pipeline, self.unroll))
+    return iter((self.coll, self.algo, self.proto, self.redop, self.ty, self.acc, self.pipeline, self.unroll, self.reg))
 
 def calc_unroll_and_pipeline_for_local_arch():
 
@@ -242,7 +262,7 @@ local_unroll, local_pipeline = calc_unroll_and_pipeline_for_local_arch()
 gda_colls = {"AlltoAllGda", "AlltoAllvGda"}
 
 # Helper function to check if the conditions for the collective is being met
-def func_validate(coll, algo, proto, redop, ty, acc,  pipeline, unroll):
+def func_validate(coll, algo, proto, redop, ty, acc,  pipeline, unroll, reg):
   if redop == "SumPostDiv" and ty[0] not in ("i","u"):
     return False
   if coll == "" or algo == "":
@@ -256,7 +276,8 @@ def func_validate(coll, algo, proto, redop, ty, acc,  pipeline, unroll):
       acc not in acc_of_coll[coll] or
       pipeline not in pipelines_of_coll[coll] or (pipeline in ["1"] and ty not in pipelined_types) or
       pipeline not in local_pipeline or
-      unroll not in local_unroll):
+      unroll not in local_unroll or
+      reg not in reg_values_of(coll, proto)):
     return False
   return True
 
@@ -301,9 +322,9 @@ def func_filter(function_params, current_idx, item_list=None):
         # For each loop layer remove the last element in item_list
         item_list.pop()
   else:
-    coll, algo, proto, redop, ty, acc, pipeline, unroll = item_list
-    if func_validate(coll, algo, proto, redop, ty, acc, pipeline, unroll):
-      yield(coll, algo, proto, redop, ty, acc, pipeline, unroll)
+    coll, algo, proto, redop, ty, acc, pipeline, unroll, reg = item_list
+    if func_validate(coll, algo, proto, redop, ty, acc, pipeline, unroll, reg):
+      yield(coll, algo, proto, redop, ty, acc, pipeline, unroll, reg)
 
 
 # Parse ONLY_FUNCS input and feed it to func_filter
@@ -324,7 +345,7 @@ def parse_input(func_pattern):
 
 # Maps functions to the chosen representative for the equivalence class it
 # belongs to. For instance (sum, signed int) maps to (sum, unsigned int).
-def equivalent_primary(coll, algo, proto, redop, ty, acc, pipeline, unroll):
+def equivalent_primary(coll, algo, proto, redop, ty, acc, pipeline, unroll, reg):
   if coll in ("AllReduce", "Reduce", "ReduceScatter"):
     # map signed integer sum/prod to unsigned
     if redop in ("Sum","Prod","PreMulSum","SumPostDiv") and ty[0]=="i":
@@ -336,7 +357,7 @@ def equivalent_primary(coll, algo, proto, redop, ty, acc, pipeline, unroll):
     if (pipeline != "0" and proto != "SIMPLE"):
       pipeline = "0"
 
-  return (coll, algo, proto, redop, ty, acc, pipeline, unroll)
+  return (coll, algo, proto, redop, ty, acc, pipeline, unroll, reg)
 
 # Order rows are enumerated must match formula of `ncclDevFuncId()`:
 # outermost loop should be for unroll factor; refer to host_table section
@@ -349,8 +370,9 @@ def enumerate_func_rows():
             for ty in all_tys:
               for acc in all_accs:
                 for pipeline in local_pipeline:
-                  if func_validate(coll, algo, proto, redop, ty, acc, pipeline, unroll):
-                    yield (coll, algo, proto, redop, ty, acc, pipeline, unroll)
+                  for reg in all_regs:
+                    if func_validate(coll, algo, proto, redop, ty, acc, pipeline, unroll, reg):
+                      yield (coll, algo, proto, redop, ty, acc, pipeline, unroll, reg)
 
 # Sort the hashmap based on custom key <coll> <algo> <proto> <redop> <ty>
 def custom_sort_key(fn: Fn):
@@ -362,7 +384,8 @@ def custom_sort_key(fn: Fn):
         all_redops.index(fn.redop),
         all_tys.index(fn.ty),
         all_accs.index(fn.acc),
-        local_pipeline.index(fn.pipeline)
+        local_pipeline.index(fn.pipeline),
+        all_regs.index(fn.reg)
     )
 
 def get_arch_guard(fn):
@@ -376,6 +399,13 @@ def get_arch_guard(fn):
       cond = "defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1250__)"
 
   return cond
+
+# Build the mangled function symbol suffix. The user-buffer registration mode is
+# only appended when it is meaningful (LL128 reg-variant kernels, reg == "1"/"2")
+# so that all other kernels keep their historical names.
+def fn_sym(fn):
+  reg = fn.reg if fn.reg != "0" else None
+  return paste("_", fn.coll, fn.algo, fn.proto, fn.redop, fn.ty, fn.acc, fn.pipeline, fn.unroll, reg)
 
 ################################################################################
 
@@ -401,7 +431,7 @@ with open(os.path.join(gensrc, "device_table.h"), "w") as f:
   # Plain forward declarations; noinline (device-linker only) is controlled
   # solely by DEFINE_ncclDevFunc in common.h.
   for fn in primary_funcs:
-    sym = paste("_", "ncclDevFunc", *fn)
+    sym = "ncclDevFunc_" + fn_sym(fn)
     guard = get_arch_guard(fn)
     if guard:
       out("#if %s\n__device__ void %s();\n#endif\n" % (guard, sym))
@@ -420,7 +450,7 @@ with open(os.path.join(gensrc, "device_table.h"), "w") as f:
     out("static __device__ ncclDevFuncPtr_t const ncclDevFuncTable_%s[] = {\n" % unroll)
     for fn in primary_funcs:
       if fn.unroll != unroll: continue
-      sym = paste("_", "ncclDevFunc", *fn)
+      sym = "ncclDevFunc_" + fn_sym(fn)
       guard = get_arch_guard(fn)
       if guard:
         out("#if %s\n/*%4d*/ %s,\n#else\n/*%4d*/ nullptr,\n#endif\n" % (guard, index[unroll], sym, index[unroll]))
@@ -486,6 +516,7 @@ with open(os.path.join(gensrc, "host_table.cpp"), "w") as f:
   out("//   bits 16-19:  ty index\n")
   out("//   bits 20-23:  accumulator index\n")
   out("//   bits 24-27:  pipeline index\n")
+  out("//   bits 28-31:  user-buffer registration mode index (LL128 reg/noreg)\n")
   out("#include <unordered_map>\n")
   out("std::unordered_map<uint64_t, int> ncclDevFuncNameToId = {\n")
 
@@ -507,6 +538,7 @@ with open(os.path.join(gensrc, "host_table.cpp"), "w") as f:
       ty_idx = all_tys.index(fn.ty)
       acc_idx = all_accs.index(fn.acc)
       pipeline_idx = all_pipelines.index(fn.pipeline)
+      reg_idx = all_regs.index(fn.reg)
       # Assert that 4 bits (16 values) is enough to map all_colls, all_algos, etc.
       assert len(all_colls) <= 16, "Error: all_colls has more than 16 values, which exceeds 4-bit capacity."
       assert len(all_algos) <= 16, "Error: all_algos has more than 16 values, which exceeds 4-bit capacity."
@@ -515,6 +547,7 @@ with open(os.path.join(gensrc, "host_table.cpp"), "w") as f:
       assert len(all_tys) <= 16, "Error: all_tys has more than 16 values, which exceeds 4-bit capacity."
       assert len(all_accs) <= 16, "Error: all_accs has more than 16 values, which exceeds 4-bit capacity."
       assert len(all_pipelines) <= 16, "Error: all_pipelines has more than 16 values, which exceeds 4-bit capacity."
+      assert len(all_regs) <= 16, "Error: all_regs has more than 16 values, which exceeds 4-bit capacity."
       # Create a 64-bit unsigned integer key and pack the indices into 4 bits each
       key = (
         (coll_idx & 0xF)
@@ -524,9 +557,10 @@ with open(os.path.join(gensrc, "host_table.cpp"), "w") as f:
         | ((ty_idx & 0xF) << 16)
         | ((acc_idx & 0xF) << 20)
         | ((pipeline_idx & 0xF) << 24)
+        | ((reg_idx & 0xF) << 28)
       )
       if fn.coll == "Broadcast":
-        key = ((coll_idx & 0x3F) | ((proto_idx & 0x3F) << 8))
+        key = ((coll_idx & 0x3F) | ((proto_idx & 0x3F) << 8) | ((reg_idx & 0xF) << 28))
       if fn.coll in ["SendRecv", "AlltoAllPivot", "AlltoAllGda", "AlltoAllvGda"]:
         key = ((coll_idx & 0x3F))
       
@@ -536,7 +570,7 @@ with open(os.path.join(gensrc, "host_table.cpp"), "w") as f:
 # Maps to .cu filename which implements this func. The only constraint is that
 # "coll" is reflected in the name: formally that no two funcs having different
 # coll's map to the same filename.
-def impl_filename(coll, algo, proto, redop, ty, acc, pipeline, unroll):
+def impl_filename(coll, algo, proto, redop, ty, acc, pipeline, unroll, reg):
   return "%s.cpp" % paste("_", coll_camel_to_lower[coll], redop and redop.lower(), ty)
 
 # Partition the functions and kernels to the .cu filenames. The partition is
@@ -592,14 +626,14 @@ for name in name_to_funcs.keys():
     )
 
     for fn in fns:
-      sym = paste("_", fn.coll, fn.algo, fn.proto, fn.redop, fn.ty, fn.acc, fn.pipeline, fn.unroll)
+      sym = fn_sym(fn)
       guard = get_arch_guard(fn)
       if guard:
         out("#if %s\n" % guard)
       out(
-        "DEFINE_ncclDevFunc({sym}, ncclFunc{coll}, {redop_cxx}, {ty_cxx}, NCCL_ALGO_{algo}, NCCL_PROTO_{proto}, {acc}, {pipeline}, {unroll})\n"
+        "DEFINE_ncclDevFunc({sym}, ncclFunc{coll}, {redop_cxx}, {ty_cxx}, NCCL_ALGO_{algo}, NCCL_PROTO_{proto}, {acc}, {pipeline}, {unroll}, {reg})\n"
         .format(sym=sym, coll=fn.coll, redop_cxx=redop_to_cxx[fn.redop], ty_cxx=ty_to_cxx[fn.ty],
-                algo=(fn.algo or "RING"), proto=(fn.proto or "SIMPLE"), acc=fn.acc, pipeline=fn.pipeline, unroll=fn.unroll)
+                algo=(fn.algo or "RING"), proto=(fn.proto or "SIMPLE"), acc=fn.acc, pipeline=fn.pipeline, unroll=fn.unroll, reg=fn.reg)
       )
       if guard: 
         out("#endif\n")
@@ -621,7 +655,7 @@ specialized_filelist = []
 for fn in primary_funcs:
   if fn.coll == "Nop":
     continue
-  sym = paste("_", fn.coll, fn.algo, fn.proto, fn.redop, fn.ty, fn.acc, fn.pipeline, fn.unroll)
+  sym = fn_sym(fn)
   func_name = "ncclDevFunc_" + sym
   lower_coll = coll_camel_to_lower[fn.coll]
   guard = get_arch_guard(fn)
@@ -638,7 +672,7 @@ for fn in primary_funcs:
       out("#if %s\n" % guard)
     out(
       "DEFINE_ncclDevFunc({sym}, ncclFunc{coll}, {redop_cxx}, {ty_cxx}, "
-      "NCCL_ALGO_{algo}, NCCL_PROTO_{proto}, {acc}, {pipeline}, {unroll})\n\n"
+      "NCCL_ALGO_{algo}, NCCL_PROTO_{proto}, {acc}, {pipeline}, {unroll}, {reg})\n\n"
       "__launch_bounds__(NCCL_MAX_NTHREADS, 1)\n"
       "__global__ void ncclDevKernel_{sym}_Specialized(\n"
       "    ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {{\n"
@@ -648,7 +682,7 @@ for fn in primary_funcs:
       .format(sym=sym, coll=fn.coll, redop_cxx=redop_to_cxx[fn.redop],
               ty_cxx=ty_to_cxx[fn.ty], algo=(fn.algo or "RING"),
               proto=(fn.proto or "SIMPLE"), acc=fn.acc, pipeline=fn.pipeline,
-              unroll=fn.unroll, func_name=func_name)
+              unroll=fn.unroll, reg=fn.reg, func_name=func_name)
     )
     if guard:
       out("#endif\n")

--- a/projects/rccl/src/device/primitives.h
+++ b/projects/rccl/src/device/primitives.h
@@ -137,7 +137,15 @@ struct FanSymmetric {
 };
 
 // The primitives class. Specialized per protocol in the other headers.
-template<typename T, typename RedOp, typename Fan, int Direct, typename Proto, int P2p, bool isNetOffload = false, int Metadata = RCCL_METADATA_EMPTY, int Pipeline = 0, int useAcc = 0>
+// UserRegMode selects how the LL128 direct user-buffer accesses decide between
+// the system-scope cache-bypass path and the register-friendly plain/non-temporal
+// path at compile time:
+//   0 = runtime  (read the per-op userRegUsed member; keeps a dual code path)
+//   1 = forced registered     (always system-scope cache-bypass, single path)
+//   2 = forced non-registered (always plain/non-temporal, single path)
+// Defaulting to 0 preserves the behavior of every existing instantiation; only
+// the collectives that opt into 1/2 get the specialized single-path kernels.
+template<typename T, typename RedOp, typename Fan, int Direct, typename Proto, int P2p, bool isNetOffload = false, int Metadata = RCCL_METADATA_EMPTY, int Pipeline = 0, int useAcc = 0, int UserRegMode = 0>
 class Primitives;
 
 // Used by LL & LL128 to implement direct members in the naive way.

--- a/projects/rccl/src/device/prims_ll.h
+++ b/projects/rccl/src/device/prims_ll.h
@@ -7,9 +7,12 @@
  ************************************************************************/
 
 #include "rccl_ptr.h"
-template<typename T, typename RedOp, typename Fan, int Direct, int P2p, bool isNetOffload, int Metadata, int Pipeline, int useAcc>
-class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pipeline, useAcc>:
-    public PrimitivesWithoutDirect<Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pipeline, useAcc>> {
+// UserRegMode is accepted only to match the Primitives primary template (which
+// carries it for LL128, see primitives.h/prims_ll128.h). The LL protocol path is
+// unchanged from the baseline and ignores it.
+template<typename T, typename RedOp, typename Fan, int Direct, int P2p, bool isNetOffload, int Metadata, int Pipeline, int useAcc, int UserRegMode>
+class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pipeline, useAcc, UserRegMode>:
+    public PrimitivesWithoutDirect<Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pipeline, useAcc, UserRegMode>> {
 
   // In the case of Fan::MaxRecv == 0, we need to force MaxRecv to 1 for this to compile
   // This is because of a recv buffer which is allocated to MaxRecv length in send-only cases.

--- a/projects/rccl/src/device/prims_ll128.h
+++ b/projects/rccl/src/device/prims_ll128.h
@@ -16,9 +16,31 @@
 #endif
 #endif
 
-template<typename T, typename RedOp, typename Fan, int Direct, int P2p, bool isNetOffload, int Metadata, int Pipeline, int useAcc>
-class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata, Pipeline, useAcc>:
-  public PrimitivesWithoutDirect<Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata, Pipeline, useAcc>> {
+// Non-temporal 128-bit load/store for LL128 communication (FIFO) buffers.
+// Comm buffers are already allocated uncached, so there is no cache to bypass;
+// using the plain non-temporal path here (the pre-cache-bypass behavior) avoids
+// the extra register pressure that the system-scope global_load/store_b128
+// builtins introduce in the LL128 reduce kernels. The cache-bypassing load128/
+// store128 remain in use for user buffers (loadRegsBegin/storeRegs).
+inline __device__ void load128NT(const uint64_t* ptr, uint64_t &v0, uint64_t &v1) {
+  v0 = __builtin_nontemporal_load((u64_gptr) ptr);
+  v1 = __builtin_nontemporal_load((u64_gptr) ptr+1);
+}
+
+// Plain (cacheable) 128-bit store. This is the pre-cache-bypass February store
+// behavior: comm-FIFO writes and non-registered user-buffer writes go through
+// the normal cache with ordinary global_store_dwordx4, which delivers higher
+// store throughput and lower register pressure than the non-temporal or
+// system-scope variants. Reads remain non-temporal (load128NT) so the LL128
+// flag poll never observes a stale cache line.
+inline __device__ void store128Plain(uint64_t* ptr, uint64_t v0, uint64_t v1) {
+  *((u64_gptr) ptr) = v0;
+  *((u64_gptr) ptr + 1) = v1;
+}
+
+template<typename T, typename RedOp, typename Fan, int Direct, int P2p, bool isNetOffload, int Metadata, int Pipeline, int useAcc, int UserRegMode>
+class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata, Pipeline, useAcc, UserRegMode>:
+  public PrimitivesWithoutDirect<Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata, Pipeline, useAcc, UserRegMode>> {
 
   static constexpr int MaxRecv = Fan::MaxRecv, MaxSend = Fan::MaxSend;
   static constexpr int Input=0, Output=1, Acc=2;;
@@ -34,6 +56,7 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata,
   const int threadsPerBlock;
   Fan fan;
   T *userBufs[3];
+  bool userRegUsed = false; // runtime: user buffers registered (cacheable) -> need cache-bypass
   struct ncclConnInfo* recvConn = NULL;
   volatile uint64_t* recvConnHeadPtr = NULL;
   uint64_t recvConnHead;
@@ -125,6 +148,37 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata,
     }
   }
 
+  // User-buffer 128-bit access mode selection.
+  // Cache-bypassing (system-scope) loads/stores are only required when this op
+  // accesses a registered, potentially-cached user buffer directly. That needs
+  // both Direct != 0 (compile-time: this instantiation supports direct access)
+  // and registration actually being in use.
+  //
+  // Whether registration is in use can be resolved at compile time via the
+  // UserRegMode template parameter, which lets the caller instantiate clean
+  // single-path kernels:
+  //   UserRegMode==2 -> never registered: always plain/non-temporal, so the
+  //                     system-scope load128/store128 code is never emitted and
+  //                     the kernel keeps February-level occupancy.
+  //   UserRegMode==1 -> always registered: always system-scope cache-bypass.
+  //   UserRegMode==0 -> unknown at compile time: fall back to the per-op
+  //                     userRegUsed member (dual path, legacy behavior).
+  // When Direct == 0 the bypass folds away entirely regardless of UserRegMode.
+  __device__ __forceinline__ bool userBypass() const {
+    if (!Direct) return false;
+    if (UserRegMode == 1) return true;
+    if (UserRegMode == 2) return false;
+    return userRegUsed;
+  }
+  __device__ __forceinline__ void loadUser128(const uint64_t* ptr, uint64_t &v0, uint64_t &v1) {
+    if (userBypass()) load128(ptr, v0, v1); else load128NT(ptr, v0, v1);
+  }
+  __device__ __forceinline__ void storeUser128(uint64_t* ptr, uint64_t v0, uint64_t v1) {
+    // Non-registered stores use the plain cacheable path (February behavior) to
+    // recover store throughput; only the registered path keeps system-scope.
+    if (userBypass()) store128(ptr, v0, v1); else store128Plain(ptr, v0, v1);
+  }
+
   template<int WordPerThread>
   __device__ __forceinline__ void loadRegsBegin(uint64_t(&regs)[WordPerThread], T const *src, int eltN) {
     constexpr int EltPer16B = 16/sizeof(T);
@@ -151,7 +205,7 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata,
       for(int g=0; g < WordPerThread/2; g++) {
         if(!flagThread || g%2==0) {
           if(ix[g]*EltPer16B < eltN)
-            load128((uint64_t*)(src + ix[g]*EltPer16B), regs[2*g+0], regs[2*g+1]);
+            loadUser128((uint64_t*)(src + ix[g]*EltPer16B), regs[2*g+0], regs[2*g+1]);
         }
       }
     }
@@ -164,7 +218,7 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata,
       #pragma unroll
       for(int g=0; g < WordPerThread/2; g++)
         if((g*WARP_SIZE + wid)*16 < misalignment + eltN*sizeof(T))
-          load128(src8 + 2*(g*WARP_SIZE + wid), regs[2*g+0], regs[2*g+1]);
+          loadUser128(src8 + 2*(g*WARP_SIZE + wid), regs[2*g+0], regs[2*g+1]);
       #pragma unroll
       for(int g=0; g < WordPerThread/2; g++)
         storeShmem128(shm8 + 2*(g*WARP_SIZE + wid), regs[2*g+0], regs[2*g+1]);
@@ -213,7 +267,7 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata,
       int ix = g*WARP_SIZE - LineSkip*(g/2) + wid - (g%2)*(wid/(LineElems/2));
       if (!flagThread || g%2==0) {
         if(misalignment == 0 && (ix+1)*EltPer16B <= eltN)
-          store128((uint64_t*)(dst + ix*EltPer16B), regs[2*g+0], regs[2*g+1]);
+          storeUser128((uint64_t*)(dst + ix*EltPer16B), regs[2*g+0], regs[2*g+1]);
         else
           storeShmem128(shm8+2*ix, regs[2*g+0], regs[2*g+1]);
       }
@@ -245,14 +299,14 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata,
         needReload = false;
         #pragma unroll
         for (int u=0; u<ELEMS_PER_THREAD; u+=2) {
-          load128(ptr+u*WARP_SIZE, vr[u], vr[u+1]);
+          load128NT(ptr+u*WARP_SIZE, vr[u], vr[u+1]);
           needReload |= flagThread && (vr[u+1] != flag);
         }
         needReload &= (0 == checkAbort(abort, 1, spins));
       } while (__any(needReload));
       #pragma unroll
       for (int u=0; u<ELEMS_PER_THREAD; u+=2)
-        load128(ptr+u*WARP_SIZE, vr[u], vr[u+1]);
+        load128NT(ptr+u*WARP_SIZE, vr[u], vr[u+1]);
     }
 
     /************* Finish register load **************/
@@ -291,7 +345,7 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata,
           needReload = false;
           #pragma unroll
           for (int u=0; u<ELEMS_PER_THREAD; u+=2) {
-            load128(ptr+u*WARP_SIZE, vr[u], vr[u+1]);
+            load128NT(ptr+u*WARP_SIZE, vr[u], vr[u+1]);
             needReload |= flagThread && (vr[u+1] != flag);
           }
           needReload &= (0 == checkAbort(abort, 1, spins));
@@ -299,7 +353,7 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata,
 
         #pragma unroll
         for (int u=0; u<ELEMS_PER_THREAD; u+=2)
-          load128(ptr+u*WARP_SIZE, vr[u], vr[u+1]);
+          load128NT(ptr+u*WARP_SIZE, vr[u], vr[u+1]);
 
         #pragma unroll
         for (int u=0; u<ELEMS_PER_THREAD; u+=2) {
@@ -330,14 +384,14 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata,
         uint64_t* ptr = sendPtr(i)+ll128Offset;
         #pragma unroll
         for (int u=0; u<ELEMS_PER_THREAD; u+=2) {
-          store128(ptr+u*WARP_SIZE, v[u], flagThread ? flag : v[u+1]);
+          store128Plain(ptr+u*WARP_SIZE, v[u], flagThread ? flag : v[u+1]);
         }
       }
       uint64_t flag = sendFlag(0);
       uint64_t* ptr = sendPtr(0)+ll128Offset;
       #pragma unroll
       for (int u=0; u<ELEMS_PER_THREAD; u+=2) {
-        store128(ptr+u*WARP_SIZE, v[u], flagThread ? flag : v[u+1]);
+        store128Plain(ptr+u*WARP_SIZE, v[u], flagThread ? flag : v[u+1]);
       }
     }
     /********************** End Send ************************/
@@ -466,6 +520,7 @@ public:
     loadRecvSync();
     // coverity[var_deref_model:FALSE]
     loadSendSync();
+    userRegUsed = (e != nullptr) && (e->regUsed || e->netRegUsed);
     setDataPtrs(inputBuf, outputBuf, e != nullptr ? e->acc : nullptr);
 #if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
     skip_fence = !ncclShmem.comm.gfx9CheapFenceOff;

--- a/projects/rccl/src/device/prims_simple.h
+++ b/projects/rccl/src/device/prims_simple.h
@@ -17,9 +17,9 @@ enum primsMode {
 };
 
 template<typename T, typename RedOp, typename Fan, int Direct,
-         int SlicePerChunk, int StepPerSlice, int Unroll, int P2p, int MultimemSrcs, int MultimemDsts, bool isNetOffload, int Metadata, int Pipeline, int useAcc>
+         int SlicePerChunk, int StepPerSlice, int Unroll, int P2p, int MultimemSrcs, int MultimemDsts, bool isNetOffload, int Metadata, int Pipeline, int useAcc, int UserRegMode>
 class Primitives<
-    T, RedOp, Fan, Direct, ProtoSimple<SlicePerChunk, StepPerSlice, useAcc, Unroll, MultimemSrcs, MultimemDsts>, P2p, isNetOffload, Metadata, Pipeline, useAcc
+    T, RedOp, Fan, Direct, ProtoSimple<SlicePerChunk, StepPerSlice, useAcc, Unroll, MultimemSrcs, MultimemDsts>, P2p, isNetOffload, Metadata, Pipeline, useAcc, UserRegMode
   > {
   static constexpr int MaxRecv = Fan::MaxRecv, MaxSend = Fan::MaxSend;
   static constexpr int Input=0, Output=1;

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -470,6 +470,16 @@ ncclResult_t ncclTasksRegAndEnqueue(struct ncclComm* comm) {
     if (task->regBufType & (NCCL_IPC_REG_BUFFER | NCCL_NVLS_REG_BUFFER))
       devWork.regUsed = 1;
 
+    // LL128 for the reg-variant collectives is compiled as two separate kernels
+    // (registered vs non-registered user buffer). Now that registration status is
+    // known, select the matching device function index.
+    if (ncclDevFuncIsLL128RegVariant(task->func, task->protocol)) {
+      int accFlag = (task->func == ncclFuncAllReduce && task->acc != nullptr) ? 1 : 0;
+      int regMode = (devWork.regUsed || devWork.netRegUsed) ? 1 : 2;
+      int id = ncclDevFuncId(task->func, task->opDev.op, task->datatype, task->algorithm, task->protocol, accFlag, task->pipeline, regMode);
+      if (id >= 0) task->devFuncId = id;
+    }
+
     if (task->regBufType & NCCL_NVLS_REG_BUFFER) {
       struct ncclDevWorkCollReg workReg = {};
       workReg.coll = devWork; // C++ struct assignment
@@ -572,10 +582,14 @@ ncclResult_t ncclPrepareTasks(struct ncclComm* comm, bool* algoNeedConnect, bool
       }
 
       NCCLCHECK(getAlgoInfo(comm, &agg, collNetSupport, nvlsSupport, nTasksPerChannel, simInfo));
+      // LL128 reg-variant collectives have no UserRegMode=0 kernel; use the
+      // non-registered (2) variant as a valid placeholder here. The final choice
+      // is made in ncclTasksRegAndEnqueue() once registration status is known.
+      int reg0 = ncclDevFuncIsLL128RegVariant(agg.func, agg.protocol) ? 2 : 0;
       if(agg.func==ncclFuncAllReduce && agg.acc != nullptr)
-        agg.devFuncId = ncclDevFuncId(agg.func, agg.opDev.op, agg.datatype, agg.algorithm, agg.protocol, 1, agg.pipeline);
+        agg.devFuncId = ncclDevFuncId(agg.func, agg.opDev.op, agg.datatype, agg.algorithm, agg.protocol, 1, agg.pipeline, reg0);
       else
-        agg.devFuncId = ncclDevFuncId(agg.func, agg.opDev.op, agg.datatype, agg.algorithm, agg.protocol, 0, agg.pipeline);
+        agg.devFuncId = ncclDevFuncId(agg.func, agg.opDev.op, agg.datatype, agg.algorithm, agg.protocol, 0, agg.pipeline, reg0);
       if (agg.devFuncId < 0) {
         WARN("%s: unsupported collective. Please ensure the collective has been enabled in build.", __func__);
         return ncclInvalidUsage;

--- a/projects/rccl/src/include/device.h
+++ b/projects/rccl/src/include/device.h
@@ -211,6 +211,7 @@ static_assert(NCCL_LL_CLEAN_MASK % NCCL_STEPS == 0, "Invalid NCCL_LL_CLEAN_MASK 
 #define RCCL_DTYPE_SHIFT 16
 #define RCCL_ACC_SHIFT 20
 #define RCCL_PIPELINE_SHIFT 24
+#define RCCL_REG_SHIFT 28
 
 struct ncclConnInfo {
   // Regular comm mechanism
@@ -775,16 +776,27 @@ inline bool ncclNvlsSupported(int devRedOp, int type) {
 // Map the uint64_t key to funcIdx
 extern std::unordered_map<uint64_t, int> ncclDevFuncNameToId;
 
+// LL128 for these collectives is generated as two separate kernels selected by
+// user-buffer registration mode (UserRegMode 1=registered, 2=non-registered).
+// Keep in sync with `ll128_reg_variant_colls` in src/device/generate.py.
+inline bool ncclDevFuncIsLL128RegVariant(int coll, int proto) {
+  return proto == NCCL_PROTO_LL128 &&
+         (coll == ncclFuncAllReduce || coll == ncclFuncAllGather || coll == ncclFuncBroadcast);
+}
+
 // `ncclDevFuncId()` needs to be in sync with 'all_colls' in generate.py
-inline int ncclDevFuncId(int coll, int devRedOp, int type, int algo, int proto, int acc = 0, int pipeline = 0) {
+// `reg` is the user-buffer registration mode (0=n/a, 1=registered, 2=non-registered)
+// and is only used to distinguish the LL128 reg-variant collectives.
+inline int ncclDevFuncId(int coll, int devRedOp, int type, int algo, int proto, int acc = 0, int pipeline = 0, int reg = 0) {
   int row = -1;
   uint64_t key;
   // Pack 4-bit fields from right (LSB) to left in order:
-  // coll, algo, proto, devRedOp, type, acc, pipeline
+  // coll, algo, proto, devRedOp, type, acc, pipeline, reg
   // This logic must be in sync with the key generation logic in generate.py
   if (coll == ncclFuncBroadcast) {
     key = ((uint64_t)(coll     & RCCL_FUNC_ID_MASK) << RCCL_COLL_SHIFT ) |
-          ((uint64_t)(proto    & RCCL_FUNC_ID_MASK) << RCCL_PROTO_SHIFT);
+          ((uint64_t)(proto    & RCCL_FUNC_ID_MASK) << RCCL_PROTO_SHIFT) |
+          ((uint64_t)(reg      & RCCL_FUNC_ID_MASK) << RCCL_REG_SHIFT);
   } else if (coll == ncclFuncSendRecv || coll == ncclFuncAlltoAllPivot || coll == ncclFuncAlltoAllGda || coll == ncclFuncAlltoAllvGda) {
     key = ((uint64_t)(coll     & RCCL_FUNC_ID_MASK) << RCCL_COLL_SHIFT );
   } else {
@@ -794,14 +806,15 @@ inline int ncclDevFuncId(int coll, int devRedOp, int type, int algo, int proto, 
           ((uint64_t)(devRedOp & RCCL_FUNC_ID_MASK) << RCCL_REDOP_SHIFT) |
           ((uint64_t)(type     & RCCL_FUNC_ID_MASK) << RCCL_DTYPE_SHIFT) |
           ((uint64_t)(acc      & RCCL_FUNC_ID_MASK) << RCCL_ACC_SHIFT)   |
-          ((uint64_t)(pipeline & RCCL_FUNC_ID_MASK) << RCCL_PIPELINE_SHIFT);
+          ((uint64_t)(pipeline & RCCL_FUNC_ID_MASK) << RCCL_PIPELINE_SHIFT) |
+          ((uint64_t)(reg      & RCCL_FUNC_ID_MASK) << RCCL_REG_SHIFT);
   }
   auto it = ncclDevFuncNameToId.find(key);
   if (it != ncclDevFuncNameToId.end()) {
     row = it->second;
   }
   if(row < 0) {
-    WARN("Fatal error: ncclDevFuncId: %lu not found for coll: %d, algo: %d, proto: %d, devRedOp: %d, type: %d, acc: %d, pipeline: %d", key, coll, algo, proto, devRedOp, type, acc, pipeline);
+    WARN("Fatal error: ncclDevFuncId: %lu not found for coll: %d, algo: %d, proto: %d, devRedOp: %d, type: %d, acc: %d, pipeline: %d, reg: %d", key, coll, algo, proto, devRedOp, type, acc, pipeline, reg);
     return -1;
   }
   return row;

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -267,6 +267,7 @@ if(BUILD_TESTS)
       BootstrapBidirTests.cpp
       DdaIpcEligibilityTests.cpp
       EnqueueTests.cpp
+      LL128RegVariantKernel_test.cpp
       IpcsocketTests.cpp
       TopoEnvPolicyTests.cpp
       NetSocketTests.cpp

--- a/projects/rccl/test/LL128RegVariantKernel_test.cpp
+++ b/projects/rccl/test/LL128RegVariantKernel_test.cpp
@@ -1,0 +1,117 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+#include <gtest/gtest.h>
+#include <hip/hip_runtime.h>
+
+#include "device.h"
+
+// Verifies the LL128 registered / non-registered kernel split.
+//
+// For the "reg-variant" collectives (AllReduce, AllGather, Broadcast) the LL128
+// protocol is generated as TWO separate device functions selected at launch by
+// the compile-time UserRegMode template parameter:
+//   UserRegMode == 1 : registered user buffer     (Direct path, system-scope
+//                      cache-bypassing load/store)
+//   UserRegMode == 2 : non-registered user buffer  (plain / non-temporal path)
+// Every other collective / protocol stays a single kernel (UserRegMode == 0).
+//
+// Source of truth: ncclDevFuncIsLL128RegVariant() and the func-id key packing in
+// src/include/device.h, mirrored by `ll128_reg_variant_colls` / `reg_values_of`
+// in src/device/generate.py. These tests pin that contract so the two code
+// paths cannot silently collapse back into one kernel.
+
+namespace RcclUnitTesting
+{
+
+namespace
+{
+constexpr int kRegMode0        = 0;  // not-applicable / single kernel
+constexpr int kRegistered      = 1;  // UserRegMode = registered user buffer
+constexpr int kNonRegistered   = 2;  // UserRegMode = non-registered user buffer
+
+// Resolve the generated device function-table row for a single kernel key.
+// Returns -1 when no such kernel was generated.
+int FuncId(int coll, int devRedOp, int type, int algo, int proto, int reg)
+{
+    return ncclDevFuncId(coll, devRedOp, type, algo, proto,
+                         /*acc=*/0, /*pipeline=*/0, reg);
+}
+} // namespace
+
+class LL128RegVariantKernelTests : public ::testing::Test
+{
+};
+
+// The core guarantee: each reg-variant collective emits two *distinct* LL128
+// kernels (registered vs non-registered), both present in the device table.
+TEST_F(LL128RegVariantKernelTests, TwoDistinctLL128KernelsPerRegVariantCollective)
+{
+    struct Case
+    {
+        const char* name;
+        int         coll;
+        int         redop;
+        int         type;
+        int         algo;
+    };
+
+    const Case cases[] = {
+        {"AllReduce/RING/Sum/f32", ncclFuncAllReduce, ncclDevSum, ncclFloat32, NCCL_ALGO_RING},
+        {"AllReduce/TREE/Sum/f32", ncclFuncAllReduce, ncclDevSum, ncclFloat32, NCCL_ALGO_TREE},
+        {"AllGather/RING/Sum/i8",  ncclFuncAllGather, ncclDevSum, ncclInt8,    NCCL_ALGO_RING},
+        {"Broadcast/RING/Sum/i8",  ncclFuncBroadcast, ncclDevSum, ncclInt8,    NCCL_ALGO_RING},
+    };
+
+    for (const auto& c : cases)
+    {
+        SCOPED_TRACE(c.name);
+
+        int idReg    = FuncId(c.coll, c.redop, c.type, c.algo, NCCL_PROTO_LL128, kRegistered);
+        int idNonReg = FuncId(c.coll, c.redop, c.type, c.algo, NCCL_PROTO_LL128, kNonRegistered);
+
+        // Both variants must have been generated into the device function table.
+        EXPECT_GE(idReg, 0)    << "registered (UserRegMode=1) LL128 kernel not generated";
+        EXPECT_GE(idNonReg, 0) << "non-registered (UserRegMode=2) LL128 kernel not generated";
+
+        // ...and they must be two different kernels -- the entire point of the split.
+        EXPECT_NE(idReg, idNonReg)
+            << "registered and non-registered LL128 map to the same kernel id";
+    }
+}
+
+// The classifier that gates the split must agree with the generated set.
+TEST_F(LL128RegVariantKernelTests, ClassificationMatchesRegVariantSet)
+{
+    // Reg-variant collectives, only at LL128.
+    EXPECT_TRUE(ncclDevFuncIsLL128RegVariant(ncclFuncAllReduce, NCCL_PROTO_LL128));
+    EXPECT_TRUE(ncclDevFuncIsLL128RegVariant(ncclFuncAllGather, NCCL_PROTO_LL128));
+    EXPECT_TRUE(ncclDevFuncIsLL128RegVariant(ncclFuncBroadcast, NCCL_PROTO_LL128));
+
+    // Same collectives are NOT split at other protocols.
+    EXPECT_FALSE(ncclDevFuncIsLL128RegVariant(ncclFuncAllReduce, NCCL_PROTO_SIMPLE));
+    EXPECT_FALSE(ncclDevFuncIsLL128RegVariant(ncclFuncAllReduce, NCCL_PROTO_LL));
+
+    // Non-reg-variant collectives are not split even at LL128.
+    EXPECT_FALSE(ncclDevFuncIsLL128RegVariant(ncclFuncReduceScatter, NCCL_PROTO_LL128));
+    EXPECT_FALSE(ncclDevFuncIsLL128RegVariant(ncclFuncReduce, NCCL_PROTO_LL128));
+}
+
+// Negative control: kernels outside the reg-variant set are a single (reg=0)
+// kernel, confirming the split is scoped and did not leak into other paths.
+TEST_F(LL128RegVariantKernelTests, NonRegVariantEmitsSingleKernel)
+{
+    // Non-reg-variant collective at LL128: single kernel keyed with reg=0.
+    int rsLL128 = FuncId(ncclFuncReduceScatter, ncclDevSum, ncclFloat32,
+                         NCCL_ALGO_RING, NCCL_PROTO_LL128, kRegMode0);
+    EXPECT_GE(rsLL128, 0) << "ReduceScatter RING LL128 kernel not generated";
+
+    // Reg-variant collective at SIMPLE: also a single kernel keyed with reg=0.
+    int arSimple = FuncId(ncclFuncAllReduce, ncclDevSum, ncclFloat32,
+                          NCCL_ALGO_RING, NCCL_PROTO_SIMPLE, kRegMode0);
+    EXPECT_GE(arSimple, 0) << "AllReduce RING SIMPLE kernel not generated";
+}
+
+} // namespace RcclUnitTesting


### PR DESCRIPTION
## Motivation

LL128: generate separate registered / non-registered user-buffer kernels

## Technical Details

    Registered user buffers must be accessed with system-scope cache-bypassing
    loads/stores for cross-GPU coherence, but that path forces the compiler into
    heavy AGPR usage and spilling. Non-registered buffers only need the cheaper
    plain/non-temporal path. Selecting between them at runtime kept both code paths
    (and the AGPR-spilling one) live in every LL128 kernel, hurting occupancy.

    Make user-buffer registration a compile-time dimension for LL128 so each launch
    runs a single, clean code path:

    - device.h / generate.py: add a UserRegMode kernel dimension (1=registered,
      2=non-registered) and emit two LL128 variants per collective (ring + tree for
      AllReduce, ring for AllGather/Broadcast/Reduce/ReduceScatter). Kernel key
      packing, device/host tables and the total function count are updated
      accordingly.
    - enqueue.cc: pick the registered vs non-registered LL128 function id at launch
      time from work->regUsed / netRegUsed.
    - primitives.h / prims_ll128.h: thread UserRegMode through Primitives; the
      registered specialization keeps the system-scope cache-bypass path, the
      non-registered specialization compiles only the plain/non-temporal path (no
      dead cache-bypass code, no AGPR spill).
    - common.h / add_unroll.sh: forward UserRegMode through RunWorkBatch/RunWorkColl
      and the runRing/runTreeSplit dispatch helpers.

    Result on gfx950: the common non-registered LL128 kernels drop from AGPR=13-32
    to AGPR=1 and shed ~30 VGPR (e.g. AllReduce ring f32 197->165, AllGather i8
    245->181), improving occupancy, while the registered specialization retains the
    required system-scope path in isolation.

    LL (ProtoLL) is intentionally left at the f2af4e8 baseline: it does not benefit
    from the split and the non-temporal FIFO / runtime-split experiments regressed
    it, so its user-buffer and FIFO accesses are unchanged.

## JIRA ID

ROCM-25479

## Test Plan

    Adds LL128RegVariantKernelTests validating that reg-variant LL128
    collectives (AllReduce, AllGather, Broadcast) generate two distinct
    device functions (registered vs non-registered user buffer) with
    unique function IDs, that ncclDevFuncIsLL128RegVariant() agrees with
    the reg-variant collective set, and that non-reg-variant collectives
    emit a single kernel (reg=0).

    The suite is added to the Debug-only fixtures target because the
    ncclDevFuncNameToId lookup table is a local symbol in release builds
    and only gains default visibility under Debug.

## Test Result

Build: ./install.sh --debug-fast -l -t with ONLY_FUNCS="AllReduce|AllGather|Broadcast|ReduceScatter" completed successfully. Both test targets linked (rccl-UnitTestsFixtures and rccl-UnitTestsFixturesDebug), and LL128RegVariantKernelTests.cpp.o compiled with no errors.

Direct confirmation of the split during codegen — the two reg variants were emitted as separate device objects (suffix _1 = non-registered, _2 = registered):

specialized_broadcast_ring_ll128_sum_i8_0_0_1_1.o
specialized_broadcast_ring_ll128_sum_i8_0_0_1_2.o
specialized_allgather_ring_ll128_sum_i8_0_0_1_1.o
specialized_allgather_ring_ll128_sum_i8_0_0_1_2.o
Test run (LL128RegVariantKernelTests.*):

[  PASSED  ] 3 tests.
  - TwoDistinctLL128KernelsPerRegVariantCollective   OK
  - ClassificationMatchesRegVariantSet               OK
  - NonRegVariantEmitsSingleKernel                   OK
So the new test verifies, against the actual generated host dispatch table, that:

Each reg-variant LL128 collective (AllReduce, AllGather, Broadcast) resolves to two distinct function IDs (registered vs non-registered user buffer).
ncclDevFuncIsLL128RegVariant() agrees with the reg-variant collective set.
Non-reg-variant collectives still produce a single kernel (reg=0).
The only warning in the log (llvm-readobj --offloading at 98%) is an unrelated offload-bundle inspection step, not a compile/link error for the test.

Note on placement: the suite lives in the Debug-only rccl-UnitTestsFixturesDebug target because ncclDevFuncNameToId is a local symbol (b) in release builds and only gets default visibility (linkable) under Debug — so this test can't be run from a release build by design.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
