### PR TITLE
fix(clr): multi-GPU fine-grain SVM peer maps VA.

### DIFF
--- a/projects/clr/rocclr/device/pal/paldevice.cpp
+++ b/projects/clr/rocclr/device/pal/paldevice.cpp
@@ -1582,8 +1582,22 @@ pal::Memory* Device::createBuffer(amd::Memory& owner, bool directAccess) const {
         }
         remoteAlloc = true;
       }
+      // Multi-GPU fine-grain SVM (e.g. __managed__ / hipMallocManaged, which use
+      // CL_MEM_ALLOC_HOST_PTR | CL_MEM_SVM_FINE_GRAIN_BUFFER) must be addressable
+      // at the SAME canonical VA on every device. The pinned path maps the shared
+      // host pages at a device-local Default-range VA that differs from the owner's
+      // SVM VA, so a peer kernel using the canonical pointer faults or reads the
+      // wrong memory (observed as a dev1 GPU fault accessing a __managed__ var).
+      // For these, skip pinning on the peer and fall through to the reserved-VA SVM
+      // path so the peer reserves the canonical VA (same as a regular fine-grain
+      // hipHostAlloc peer). This also keeps the per-device suballocator free-lists
+      // symmetric, which is required for consistent intra-chunk offsets.
+      const bool mgpuFineGrainSvm =
+          (owner.getMemFlags() & CL_MEM_ALLOC_HOST_PTR) &&
+          (owner.getMemFlags() & CL_MEM_SVM_FINE_GRAIN_BUFFER) &&
+          (owner.getSvmPtr() != nullptr) && (owner.getContext().devices().size() > 1);
       // Make sure owner has a valid hostmem pointer and it's not COPY
-      if (!remoteAlloc && (owner.getHostMem() != nullptr)) {
+      if (!remoteAlloc && !mgpuFineGrainSvm && (owner.getHostMem() != nullptr)) {
         Resource::PinnedParams params;
         params.owner_ = &owner;
         params.gpu_ = reinterpret_cast<VirtualGPU*>(owner.getVirtualDevice());

--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -506,6 +506,9 @@ memory:
   Unit_hipManagedMultiGpuVaConsistency_MultiDevice:
     <<: *level_2
     tags: [alloc, multigpu]
+  Unit_hipManagedMultiGpuVaConsistency_HostAllocNoDivergence:
+    <<: *level_2
+    tags: [alloc, multigpu]
   Unit_hipMemset_Negative_InvalidPtr:
     <<: *level_2
     tags: [memset]

--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -503,6 +503,9 @@ memory:
     tags: [multigpu]
     # Note: Windows disabled
     disabled: [amd_windows, amd_wsl]
+  Unit_hipManagedMultiGpuVaConsistency_MultiDevice:
+    <<: *level_2
+    tags: [alloc, multigpu]
   Unit_hipMemset_Negative_InvalidPtr:
     <<: *level_2
     tags: [memset]

--- a/projects/hip-tests/catch/unit/memory/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/memory/CMakeLists.txt
@@ -49,6 +49,7 @@ set(TEST_SRC
     hipMallocHost.cc
     hipMemAllocHost.cc
     hipMallocManaged_MultiScenario.cc
+    hipManagedMultiGpuVaConsistency.cc
     hipMemsetNegative.cc
     hipMemset.cc
     hipMemset3D.cc

--- a/projects/hip-tests/catch/unit/memory/hipManagedMultiGpuVaConsistency.cc
+++ b/projects/hip-tests/catch/unit/memory/hipManagedMultiGpuVaConsistency.cc
@@ -40,7 +40,6 @@ static __global__ void read_into_out() { g_out = g_val; }
  * Test requirements
  * ------------------------
  *  - Multiple devices supporting managed memory
- *  - HIP_VERSION >= 5.2
  */
 HIP_TEST_CASE("Unit_hipManagedMultiGpuVaConsistency_MultiDevice") {
   int numDevices = 0;
@@ -62,7 +61,6 @@ HIP_TEST_CASE("Unit_hipManagedMultiGpuVaConsistency_MultiDevice") {
     const int sentinel = 0xA000 + d;
     HIP_CHECK(hipSetDevice(d));
     g_val = 0;
-    HIP_CHECK(hipDeviceSynchronize());
     write_val<<<1, 1>>>(sentinel);
     HIP_CHECK(hipGetLastError());
     HIP_CHECK(hipDeviceSynchronize());
@@ -77,7 +75,6 @@ HIP_TEST_CASE("Unit_hipManagedMultiGpuVaConsistency_MultiDevice") {
     HIP_CHECK(hipSetDevice(d));
     g_val = sentinel;
     g_out = 0;
-    HIP_CHECK(hipDeviceSynchronize());
     read_into_out<<<1, 1>>>();
     HIP_CHECK(hipGetLastError());
     HIP_CHECK(hipDeviceSynchronize());
@@ -91,7 +88,6 @@ HIP_TEST_CASE("Unit_hipManagedMultiGpuVaConsistency_MultiDevice") {
     const int sentinel = 0xC0DE;
     HIP_CHECK(hipSetDevice(1));
     g_val = 0;
-    HIP_CHECK(hipDeviceSynchronize());
     write_val<<<1, 1>>>(sentinel);
     HIP_CHECK(hipGetLastError());
     HIP_CHECK(hipDeviceSynchronize());
@@ -103,6 +99,75 @@ HIP_TEST_CASE("Unit_hipManagedMultiGpuVaConsistency_MultiDevice") {
     HIP_CHECK(hipDeviceSynchronize());
     INFO("device 1 wrote 0x" << std::hex << sentinel << ", device 0 read 0x" << g_out);
     REQUIRE(g_out == sentinel);
+  }
+
+  HIP_CHECK(hipSetDevice(0));
+}
+
+static __global__ void write_int_ptr(int* p, int v) { *p = v; }
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Verifies that, with a persistent __managed__ variable resident (g_val/g_out
+ *    above occupy the shared fine-grain SVM chunk), a multi-GPU fine-grain
+ *    hipHostMalloc remains reachable at its one canonical address on every
+ *    device. If a peer device's mapping diverged or aliased, a kernel on that
+ *    peer writing through the canonical pointer faults or lands elsewhere, so
+ *    the host reads back a stale value.
+ *  - For every fine-grain flag combo, and driven from every device in turn, a
+ *    device-side write through the canonical pointer must be visible at the host
+ *    pointer.
+ *  - Skips on single-GPU systems.
+ * Test source
+ * ------------------------
+ *  - unit/memory/hipManagedMultiGpuVaConsistency.cc
+ * Test requirements
+ * ------------------------
+ *  - Multiple devices
+ */
+HIP_TEST_CASE("Unit_hipManagedMultiGpuVaConsistency_HostAllocNoDivergence") {
+  int numDevices = 0;
+  HIP_CHECK(hipGetDeviceCount(&numDevices));
+  if (numDevices < 2) {
+    HIP_SKIP_TEST("Multi-device test requires at least 2 GPUs");
+    return;
+  }
+
+  // The file-scope __managed__ globals above are allocated at module load, so a
+  // persistent managed buffer already occupies the shared SVM chunk for the
+  // whole process; no explicit managed access is needed here.
+  const unsigned int flags[] = {
+      hipHostMallocDefault,
+      hipHostMallocPortable,
+      hipHostMallocMapped,
+      hipHostMallocWriteCombined,
+      hipHostMallocPortable | hipHostMallocMapped,
+      hipHostMallocPortable | hipHostMallocWriteCombined,
+      hipHostMallocMapped | hipHostMallocWriteCombined,
+      hipHostMallocPortable | hipHostMallocMapped | hipHostMallocWriteCombined,
+  };
+
+  for (unsigned int flag : flags) {
+    int* hostPtr = nullptr;
+    HIP_CHECK(hipHostMalloc(reinterpret_cast<void**>(&hostPtr), sizeof(int), flag));
+    REQUIRE(hostPtr != nullptr);
+
+    // The invariant: every device (including the peer) reaches this one
+    // canonical pointer and its write is host-visible.
+    for (int d = 0; d < numDevices; ++d) {
+      const int sentinel = 0xD000 + d * 0x100 + static_cast<int>(flag);
+      HIP_CHECK(hipSetDevice(d));
+      *hostPtr = 0;
+      write_int_ptr<<<1, 1>>>(hostPtr, sentinel);
+      HIP_CHECK(hipGetLastError());
+      HIP_CHECK(hipDeviceSynchronize());
+      INFO("flag 0x" << std::hex << flag << " device " << d << " ptr=" << hostPtr
+                     << " read 0x" << *hostPtr);
+      REQUIRE(*hostPtr == sentinel);
+    }
+
+    HIP_CHECK(hipFreeHost(hostPtr));
   }
 
   HIP_CHECK(hipSetDevice(0));

--- a/projects/hip-tests/catch/unit/memory/hipManagedMultiGpuVaConsistency.cc
+++ b/projects/hip-tests/catch/unit/memory/hipManagedMultiGpuVaConsistency.cc
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <hip_test_common.hh>
+
+/**
+ * @addtogroup managed managed
+ * @{
+ * Multi-GPU virtual-address consistency for __managed__ variables.
+ *
+ * A __managed__ variable is shared, coherent, cross-device memory: the single
+ * canonical pointer the app holds must resolve to the SAME allocation on every
+ * device in the context. On the multi-GPU PAL path a peer device's managed
+ * backing could be created at a device-local VA that diverged from the owner's
+ * canonical SVM VA; a kernel launched on that peer then faulted or accessed the
+ * wrong memory. This test pins that behavior down.
+ */
+
+__managed__ int g_val = 0;  // written by device, read by host / other device
+__managed__ int g_out = 0;  // device reads g_val into here for host to verify
+
+static __global__ void write_val(int v) { g_val = v; }
+static __global__ void read_into_out() { g_out = g_val; }
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Verifies a __managed__ variable is addressable at the same canonical VA on
+ *    every device, in both directions and cross-device:
+ *      1. device d writes the symbol  -> host reads it back
+ *      2. host writes the symbol      -> device d reads it into g_out
+ *      3. device 1 writes the symbol  -> device 0 reads it (cross-device coherence)
+ *  - Skips on single-GPU systems and on devices without managed-memory support.
+ * Test source
+ * ------------------------
+ *  - unit/memory/hipManagedMultiGpuVaConsistency.cc
+ * Test requirements
+ * ------------------------
+ *  - Multiple devices supporting managed memory
+ *  - HIP_VERSION >= 5.2
+ */
+HIP_TEST_CASE("Unit_hipManagedMultiGpuVaConsistency_MultiDevice") {
+  int numDevices = 0;
+  HIP_CHECK(hipGetDeviceCount(&numDevices));
+  if (numDevices < 2) {
+    HIP_SKIP_TEST("Multi-device test requires at least 2 GPUs");
+    return;
+  }
+  for (int d = 0; d < numDevices; ++d) {
+    if (!isManagedMemorySupportedOnDevice(d)) {
+      HIP_SKIP_TEST("Managed memory is not supported on all devices");
+      return;
+    }
+  }
+
+  // Direction 1: each device writes a device-unique sentinel through the
+  // canonical symbol; the host must read exactly that value back.
+  for (int d = 0; d < numDevices; ++d) {
+    const int sentinel = 0xA000 + d;
+    HIP_CHECK(hipSetDevice(d));
+    g_val = 0;
+    HIP_CHECK(hipDeviceSynchronize());
+    write_val<<<1, 1>>>(sentinel);
+    HIP_CHECK(hipGetLastError());
+    HIP_CHECK(hipDeviceSynchronize());
+    INFO("device " << d << " wrote 0x" << std::hex << sentinel << ", host read 0x" << g_val);
+    REQUIRE(g_val == sentinel);
+  }
+
+  // Direction 2: the host writes the sentinel; a kernel on device d copies
+  // g_val into g_out. A matching g_out proves device d sees the same VA.
+  for (int d = 0; d < numDevices; ++d) {
+    const int sentinel = 0xB000 + d;
+    HIP_CHECK(hipSetDevice(d));
+    g_val = sentinel;
+    g_out = 0;
+    HIP_CHECK(hipDeviceSynchronize());
+    read_into_out<<<1, 1>>>();
+    HIP_CHECK(hipGetLastError());
+    HIP_CHECK(hipDeviceSynchronize());
+    INFO("host wrote 0x" << std::hex << sentinel << ", device " << d << " read 0x" << g_out);
+    REQUIRE(g_out == sentinel);
+  }
+
+  // Direction 3: device 1 writes the symbol, device 0 reads it -> cross-device
+  // coherence through the shared canonical address.
+  {
+    const int sentinel = 0xC0DE;
+    HIP_CHECK(hipSetDevice(1));
+    g_val = 0;
+    HIP_CHECK(hipDeviceSynchronize());
+    write_val<<<1, 1>>>(sentinel);
+    HIP_CHECK(hipGetLastError());
+    HIP_CHECK(hipDeviceSynchronize());
+
+    HIP_CHECK(hipSetDevice(0));
+    g_out = 0;
+    read_into_out<<<1, 1>>>();
+    HIP_CHECK(hipGetLastError());
+    HIP_CHECK(hipDeviceSynchronize());
+    INFO("device 1 wrote 0x" << std::hex << sentinel << ", device 0 read 0x" << g_out);
+    REQUIRE(g_out == sentinel);
+  }
+
+  HIP_CHECK(hipSetDevice(0));
+}
+/**
+ * End doxygen group managed.
+ * @}
+ */

--- a/projects/hip-tests/catch/unit/memory/hipManagedMultiGpuVaConsistency.cc
+++ b/projects/hip-tests/catch/unit/memory/hipManagedMultiGpuVaConsistency.cc
@@ -41,7 +41,7 @@ static __global__ void read_into_out() { g_out = g_val; }
  * ------------------------
  *  - Multiple devices supporting managed memory
  */
-HIP_TEST_CASE("Unit_hipManagedMultiGpuVaConsistency_MultiDevice") {
+HIP_TEST_CASE(Unit_hipManagedMultiGpuVaConsistency_MultiDevice) {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices < 2) {
@@ -126,7 +126,7 @@ static __global__ void write_int_ptr(int* p, int v) { *p = v; }
  * ------------------------
  *  - Multiple devices
  */
-HIP_TEST_CASE("Unit_hipManagedMultiGpuVaConsistency_HostAllocNoDivergence") {
+HIP_TEST_CASE(Unit_hipManagedMultiGpuVaConsistency_HostAllocNoDivergence) {
   int numDevices = 0;
   HIP_CHECK(hipGetDeviceCount(&numDevices));
   if (numDevices < 2) {

--- a/projects/hip-tests/catch/unit/memory/hipManagedMultiGpuVaConsistency.cc
+++ b/projects/hip-tests/catch/unit/memory/hipManagedMultiGpuVaConsistency.cc
@@ -49,7 +49,7 @@ HIP_TEST_CASE(Unit_hipManagedMultiGpuVaConsistency_MultiDevice) {
     return;
   }
   for (int d = 0; d < numDevices; ++d) {
-    if (!isManagedMemorySupportedOnDevice(d)) {
+    if (!HipTest::isManagedMemorySupportedOnDevice(d)) {
       HIP_SKIP_TEST("Managed memory is not supported on all devices");
       return;
     }


### PR DESCRIPTION
## Motivation
The multi-GPU `MemoryTest2.exe` failures that surfaced after
[`c7a59f7` (#6308)](https://github.com/ROCm/rocm-systems/commit/c7a59f77c1) share this root cause.
That commit added a file-scope `__managed__` global to `hipPointerGetAttribute.cc`, which is
allocated at module load (`ihipMallocManaged ptr=0x304000000`) and pins offset 0 of the shared
fine-grain SVM chunk. That desyncs the per-device free-lists, so later `hipHostAlloc`/managed
allocations pick divergent per-GPU offsets and collide (`Memobj map already has an entry ...`),
failing tests like `Unit_hipHostAlloc_DataValidation`. #6308 is a valid test exposing this
pre-existing bug — this PR fixes it (no revert needed).

On a multi-GPU system (observed on 2-GPU Windows/PAL), fine-grain SVM allocations return one canonical pointer that must resolve to the same virtual address on every device. Two allocation types hit this path:
hipHostAlloc with the coherent/fine-grain flag combos — specifically hipHostMallocPortable, hipHostMallocWriteCombined, and Portable | WriteCombined (these map to CL_MEM_ALLOC_HOST_PTR | CL_MEM_SVM_FINE_GRAIN_BUFFER), and __managed__ variables / hipMallocManaged, which use the same flags.
The situation: Each device suballocates fine-grain SVM from its own buddy allocator inside a shared 64 MB reserved-VA chunk. The canonical VA is chunkBase + intra-chunk offset.

The persistent __managed__ buffer on dev0 lands inside that SVM chunk at offset 0. On dev1 it instead took the pinned/dedicated-VA path (not SVM), so dev1's SVM chunk was later lazily created empty by the first hipHostAlloc.
Result: the buddy free-lists are asymmetric across devices → each device picks a different intra-chunk offset → the canonical VA diverges. dev1's mapping for the shared pointer either doesn't exist (GPU fault) or aliases another live allocation in the global MemObjMap (silent corruption).

Concretely: a kernel on dev1 dereferencing a __managed__ symbol faulted (HIP error 719), and multi-GPU hipHostAlloc buffers collided.

The fix: for multi-GPU fine-grain SVM buffers, stop taking the pinned-host path on peer devices and fall through to the reserved-VA SVM path, so every device reserves + maps the one canonical VA the leader (dev0) chose — exactly like a regular fine-grain hipHostAlloc peer. This removes the free-list asymmetry (the __managed__ buffer now sits in the SVM chunk on every device), which fixes both the dev1 __managed__ fault and the downstream hipHostAlloc offset divergence.

Five candidate solutions evaluated (this PR is C):
A — force offset: add a PAL AllocateAtOffset so peers mirror the leader's exact intra-chunk offset (true root cause, keeps packing; requires a vendored-PAL/upstream change).
B — dedicated chunk: give each multi-GPU fine-grain SVM alloc its own reserved-VA chunk at offset 0 (robust, rocclr-only; loses suballocation packing).
C — peer reserve+map (this PR): route multi-GPU fine-grain SVM peers off the pinned path onto the reserved-VA SVM path so all devices map the same canonical VA and free-lists stay symmetric.
D — allocation symmetry: keep per-device allocation sequences lock-step so buddy allocators converge on the same offset, guarded by a drift assert (rocclr-only; fragile).
E — shared backing / allocate-once: model one canonical VA mapped by every device (mechanically coincides with B at the rocclr level).

## Technical Details
In pal::Device::createBuffer, detect a multi-GPU fine-grain SVM peer allocation: CL_MEM_ALLOC_HOST_PTR && CL_MEM_SVM_FINE_GRAIN_BUFFER && owner.getSvmPtr() != nullptr && context.devices().size() > 1.
For such buffers, skip the Resource::Pinned branch (add !mgpuFineGrainSvm to its guard). Control then falls through to the general create() path with params.svmBase_ = owner.svmBase(), dispatching to Resource::CreateSvm.
In CreateSvm, the peer (svmPtr != 0) already takes the reserved-VA branch (useReservedGpuVa = true, pReservedGpuVaOwner = svmBase_->iMem()), so it maps its own per-device IGpuMemory at dev0's canonical VA and installs that translation into dev1's page tables.
Scope is intentionally limited to devices().size() > 1; single-GPU keeps the existing pinned path (no peer exists, so the invariant is trivially satisfied and behavior is unchanged).

## JIRA ID

ROCM-27508

## Test Plan
Failing reported tests.
	935 - Unit_hipMemcpy_Positive_Basic (Failed)
        967 - Unit_hipMemcpyDtoH_Positive_Basic (Failed)
        970 - Unit_hipMemcpyHtoD_Positive_Basic (Failed)
        973 - Unit_hipMemcpyDtoD_Positive_Basic (Failed)
        976 - Unit_hipMemcpyAsync_Positive_Basic (Failed)
        992 - Unit_hipMemcpyDtoHAsync_Positive_Basic (Failed)
        994 - Unit_hipMemcpyHtoDAsync_Positive_Basic (Failed)
        996 - Unit_hipMemcpyDtoDAsync_Positive_Basic (Failed)
        1275 - Unit_hipHostAlloc_DataValidation (Failed)
        2790 - Unit_HRR_VMMRoundtrip (Failed)

## Test Result

Failing reported tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
