### PR TITLE
feat(rocshmem): add _av targeted-ordering variants

### DIFF
--- a/projects/rocshmem/include/rocshmem/rocshmem.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem.hpp
@@ -882,6 +882,20 @@ __device__ ATTR_NO_INLINE void rocshmem_ctx_fence(rocshmem_ctx_t ctx, int pe);
 __device__ ATTR_NO_INLINE void rocshmem_fence(int pe);
 
 /**
+ * @brief Targeted fence variant: orders outstanding memory operations to the
+ * remote PE using fence_targeted() (s_waitcnt vmcnt(0)) without a full
+ * system-scope cache flush.  Use in place of rocshmem_fence() when the caller
+ * can guarantee that only the target PE needs to observe the write ordering.
+ */
+__device__ ATTR_NO_INLINE void rocshmem_ctx_fence_av(rocshmem_ctx_t ctx);
+
+__device__ ATTR_NO_INLINE void rocshmem_fence_av();
+
+__device__ ATTR_NO_INLINE void rocshmem_ctx_fence_av(rocshmem_ctx_t ctx, int pe);
+
+__device__ ATTR_NO_INLINE void rocshmem_fence_av(int pe);
+
+/**
  * @brief Completes all previous operations posted to this context.
  *
  * This function can be called from divergent control paths at per-thread

--- a/projects/rocshmem/include/rocshmem/rocshmem_P2P_SYNC.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem_P2P_SYNC.hpp
@@ -619,6 +619,29 @@ __host__ size_t rocshmem_uint64_wait_until_some_vector(
 
 
 /**
+ * @name SHMEM_WAIT_UNTIL_AV
+ * @brief Targeted variant of wait_until: spins until the condition is true,
+ * then completes with fence_targeted() (s_waitcnt vmcnt(0)) rather than a
+ * full system-scope acquire fence.  Use when only the signalling PE needs to
+ * observe prior writes.
+ */
+__device__ void rocshmem_float_wait_until_av(float *ivars, int cmp, float val);
+__device__ void rocshmem_double_wait_until_av(double *ivars, int cmp, double val);
+__device__ void rocshmem_char_wait_until_av(char *ivars, int cmp, char val);
+__device__ void rocshmem_schar_wait_until_av(signed char *ivars, int cmp, signed char val);
+__device__ void rocshmem_short_wait_until_av(short *ivars, int cmp, short val);
+__device__ void rocshmem_int_wait_until_av(int *ivars, int cmp, int val);
+__device__ void rocshmem_long_wait_until_av(long *ivars, int cmp, long val);
+__device__ void rocshmem_longlong_wait_until_av(long long *ivars, int cmp, long long val);
+__device__ void rocshmem_uchar_wait_until_av(unsigned char *ivars, int cmp, unsigned char val);
+__device__ void rocshmem_ushort_wait_until_av(unsigned short *ivars, int cmp, unsigned short val);
+__device__ void rocshmem_uint_wait_until_av(unsigned int *ivars, int cmp, unsigned int val);
+__device__ void rocshmem_ulong_wait_until_av(unsigned long *ivars, int cmp, unsigned long val);
+__device__ void rocshmem_ulonglong_wait_until_av(unsigned long long *ivars, int cmp, unsigned long long val);
+__device__ void rocshmem_uint64_wait_until_av(uint64_t *ivars, int cmp, uint64_t val);
+
+
+/**
  * @name SHMEM_TEST
  * @brief test if the condition (* \p ptr \p cmps \p val) is
  * true.

--- a/projects/rocshmem/include/rocshmem/rocshmem_RMA.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem_RMA.hpp
@@ -220,6 +220,24 @@ __device__ ATTR_NO_INLINE void rocshmem_ctx_putmem(rocshmem_ctx_t ctx,
 __device__ ATTR_NO_INLINE void rocshmem_putmem(void *dest, const void *source,
                                                 size_t nelems, int pe);
 
+/**
+ * @brief Targeted-ordering variant of rocshmem_ctx_putmem / rocshmem_putmem.
+ *
+ * Uses cache-bypassing (sc0 sc1) stores for NIC-visible WQE data and
+ * fence_targeted() (s_waitcnt vmcnt(0)) instead of system-scope release
+ * semantics for the doorbell, avoiding the L2 writeback (buffer_wbl2)
+ * that the standard put incurs.  Correct only when used with
+ * rocshmem_fence_av() or rocshmem_quiet() before the remote PE reads.
+ */
+__device__ ATTR_NO_INLINE void rocshmem_ctx_putmem_av(rocshmem_ctx_t ctx,
+                                                       void *dest,
+                                                       const void *source,
+                                                       size_t nelems, int pe);
+
+__device__ ATTR_NO_INLINE void rocshmem_putmem_av(void *dest,
+                                                   const void *source,
+                                                   size_t nelems, int pe);
+
 
 /**
  * @brief Writes contiguous data of \p nelems bytes from \p source on the
@@ -959,6 +977,33 @@ __device__ ATTR_NO_INLINE void rocshmem_ctx_putmem_nbi(rocshmem_ctx_t ctx,
 __device__ ATTR_NO_INLINE void rocshmem_putmem_nbi(void *dest,
                                                     const void *source,
                                                     size_t nelems, int pe);
+
+/**
+ * @brief Targeted-ordering non-blocking variant of rocshmem_putmem_nbi.
+ * See rocshmem_putmem_av for semantics.
+ */
+__device__ ATTR_NO_INLINE void rocshmem_ctx_putmem_nbi_av(rocshmem_ctx_t ctx,
+                                                           void *dest,
+                                                           const void *source,
+                                                           size_t nelems,
+                                                           int pe);
+
+__device__ ATTR_NO_INLINE void rocshmem_putmem_nbi_av(void *dest,
+                                                       const void *source,
+                                                       size_t nelems, int pe);
+
+/**
+ * @brief Targeted-ordering wave-level non-blocking put for signed char.
+ * Uses cache-bypassing WQE stores + fence_targeted doorbell on GDA/MLX5.
+ * Combine with cache-bypassing source buffer stores (sc0 sc1) for full
+ * correctness without a preceding system-scope L2 writeback.
+ */
+__device__ ATTR_NO_INLINE void rocshmem_ctx_schar_put_nbi_wave_av(
+    rocshmem_ctx_t ctx, signed char *dest, const signed char *source,
+    size_t nelems, int pe);
+
+__device__ ATTR_NO_INLINE void rocshmem_schar_put_nbi_wave_av(
+    signed char *dest, const signed char *source, size_t nelems, int pe);
 
 
 /**

--- a/projects/rocshmem/src/assembly.hpp
+++ b/projects/rocshmem/src/assembly.hpp
@@ -1498,18 +1498,6 @@ __device__ __forceinline__ void wait_on_vmem_and_lds([[maybe_unused]] int waits)
 #endif
 }
 
-/**
- * @brief Targeted fence: waits only for outstanding vector memory operations
- * to complete (s_waitcnt vmcnt(0)) without issuing a system-scope cache flush.
- *
- * Used by the _av variants of fence/wait_until to provide ordered visibility
- * to a specific remote PE without the cost of a full system-scope fence.
- */
-__device__ __forceinline__ void fence_targeted() {
-#if defined(__gfx90a__) || defined(__gfx942__) || defined(__gfx950__)
-  asm volatile("s_waitcnt vmcnt(0)" ::: "memory");
-#endif
-}
 
 }  // namespace rocshmem
 

--- a/projects/rocshmem/src/assembly.hpp
+++ b/projects/rocshmem/src/assembly.hpp
@@ -1498,6 +1498,19 @@ __device__ __forceinline__ void wait_on_vmem_and_lds([[maybe_unused]] int waits)
 #endif
 }
 
+/**
+ * @brief Targeted fence: waits only for outstanding vector memory operations
+ * to complete (s_waitcnt vmcnt(0)) without issuing a system-scope cache flush.
+ *
+ * Used by the _av variants of fence/wait_until to provide ordered visibility
+ * to a specific remote PE without the cost of a full system-scope fence.
+ */
+__device__ __forceinline__ void fence_targeted() {
+#if defined(__gfx90a__) || defined(__gfx942__) || defined(__gfx950__)
+  asm volatile("s_waitcnt vmcnt(0)" ::: "memory");
+#endif
+}
+
 }  // namespace rocshmem
 
 #endif  // LIBRARY_SRC_ASSEMBLY_HPP_

--- a/projects/rocshmem/src/context.hpp
+++ b/projects/rocshmem/src/context.hpp
@@ -75,6 +75,9 @@ class Context {
   /**************************************************************************
    ***************************** DEVICE METHODS *****************************
    *************************************************************************/
+  template <typename T, OrderingMode Mode = OrderingMode::Standard>
+  __device__ void wait_until_impl(T *ivars, int cmp, T val);
+
   template <typename T>
   __device__ void wait_until(T *ivars, int cmp, T val);
 
@@ -177,6 +180,9 @@ class Context {
 
   template <typename T>
   __device__ void amo_add(void* dst, T value, int pe);
+
+  template <typename T, OrderingMode Mode = OrderingMode::Standard>
+  __device__ void amo_set_impl(void* dst, T value, int pe);
 
   template <typename T>
   __device__ void amo_set(void* dst, T value, int pe);

--- a/projects/rocshmem/src/context.hpp
+++ b/projects/rocshmem/src/context.hpp
@@ -79,6 +79,9 @@ class Context {
   __device__ void wait_until(T *ivars, int cmp, T val);
 
   template <typename T>
+  __device__ void wait_until_av(T *ivars, int cmp, T val);
+
+  template <typename T>
   __device__ void wait_until_all(T *ivars, size_t nelems,
                                  const int *status,
                                  int cmp, T val);
@@ -122,12 +125,22 @@ class Context {
   __device__ void putmem_nbi(void* dest, const void* source, size_t nelems,
                              int pe);
 
+  __device__ void putmem_av(void* dest, const void* source, size_t nelems,
+                            int pe);
+
+  __device__ void putmem_nbi_av(void* dest, const void* source, size_t nelems,
+                                int pe);
+
   __device__ void getmem_nbi(void* dest, const void* source, size_t size,
                              int pe);
 
   __device__ void fence();
 
   __device__ void fence(int pe);
+
+  __device__ void fence_av();
+
+  __device__ void fence_av(int pe);
 
   __device__ void quiet();
 
@@ -167,6 +180,9 @@ class Context {
 
   template <typename T>
   __device__ void amo_set(void* dst, T value, int pe);
+
+  template <typename T>
+  __device__ void amo_set_av(void* dst, T value, int pe);
 
   template <typename T>
   __device__ T amo_swap(void* dst, T value, int pe);
@@ -264,6 +280,9 @@ class Context {
   __device__ void putmem_wg(void* dest, const void* source, size_t nelems,
                             int pe);
 
+  __device__ void putmem_wg_av(void* dest, const void* source, size_t nelems,
+                               int pe);
+
   __device__ void getmem_wg(void* dest, const void* source, size_t nelems,
                             int pe);
 
@@ -302,6 +321,9 @@ class Context {
 
   template <typename T>
   __device__ void put_nbi_wave(T* dest, const T* source, size_t nelems, int pe);
+
+  template <typename T>
+  __device__ void put_nbi_wave_av(T* dest, const T* source, size_t nelems, int pe);
 
   template <typename T>
   __device__ void get_wave(T* dest, const T* source, size_t nelems, int pe);

--- a/projects/rocshmem/src/context_device.cpp
+++ b/projects/rocshmem/src/context_device.cpp
@@ -92,6 +92,28 @@ __device__ void Context::putmem_nbi(void* dest, const void* source,
   DISPATCH(putmem_nbi(dest, source, nelems, pe));
 }
 
+__device__ void Context::putmem_av(void* dest, const void* source,
+                                   size_t nelems, int pe) {
+  if (nelems == 0) {
+    return;
+  }
+
+  ctxStats.incStat(NUM_PUT);
+
+  DISPATCH(putmem_av(dest, source, nelems, pe));
+}
+
+__device__ void Context::putmem_nbi_av(void* dest, const void* source,
+                                       size_t nelems, int pe) {
+  if (nelems == 0) {
+    return;
+  }
+
+  ctxStats.incStat(NUM_PUT_NBI);
+
+  DISPATCH(putmem_nbi_av(dest, source, nelems, pe));
+}
+
 __device__ void Context::getmem_nbi(void* dest, const void* source, size_t size,
                                     int pe) {
   if (size == 0) {
@@ -113,6 +135,18 @@ __device__ void Context::fence(int pe) {
   ctxStats.incStat(NUM_FENCE);
 
   DISPATCH(fence(pe));
+}
+
+__device__ void Context::fence_av() {
+  ctxStats.incStat(NUM_FENCE);
+
+  DISPATCH(fence_av());
+}
+
+__device__ void Context::fence_av(int pe) {
+  ctxStats.incStat(NUM_FENCE);
+
+  DISPATCH(fence_av(pe));
 }
 
 __device__ void Context::quiet() {
@@ -203,6 +237,17 @@ __device__ void Context::sync_wg(rocshmem_team_t team) {
   ctxStats.incStat(NUM_SYNC_WG);
 
   DISPATCH(sync_wg(team));
+}
+
+__device__ void Context::putmem_wg_av(void* dest, const void* source,
+                                      size_t nelems, int pe) {
+  if (nelems == 0) {
+    return;
+  }
+
+  ctxStats.incStat(NUM_PUT_WG);
+
+  DISPATCH(putmem_wg_av(dest, source, nelems, pe));
 }
 
 __device__ void Context::putmem_wg(void* dest, const void* source,

--- a/projects/rocshmem/src/context_tmpl_device.hpp
+++ b/projects/rocshmem/src/context_tmpl_device.hpp
@@ -237,7 +237,8 @@ __device__ __forceinline__ void Context::wait_until(T *ivars, int cmp,
                                                     T val) {
   while (!test(ivars, cmp, val)) {
   }
-  __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "");
+  detail::atomic::threadfence<detail::atomic::memory_scope_system,
+                               detail::atomic::memory_order_acquire>();
 }
 
 template <typename T>
@@ -245,7 +246,7 @@ __device__ __forceinline__ void Context::wait_until_av(T *ivars, int cmp,
                                                        T val) {
   while (!test(ivars, cmp, val)) {
   }
-  fence_targeted();
+  wait_on_vmem(0);
 }
 
 __device__ __forceinline__ size_t status_entry(size_t nelems,

--- a/projects/rocshmem/src/context_tmpl_device.hpp
+++ b/projects/rocshmem/src/context_tmpl_device.hpp
@@ -237,6 +237,15 @@ __device__ __forceinline__ void Context::wait_until(T *ivars, int cmp,
                                                     T val) {
   while (!test(ivars, cmp, val)) {
   }
+  __builtin_amdgcn_fence(__ATOMIC_ACQUIRE, "");
+}
+
+template <typename T>
+__device__ __forceinline__ void Context::wait_until_av(T *ivars, int cmp,
+                                                       T val) {
+  while (!test(ivars, cmp, val)) {
+  }
+  fence_targeted();
 }
 
 __device__ __forceinline__ size_t status_entry(size_t nelems,
@@ -550,6 +559,18 @@ __device__ void Context::put_nbi_wave(T *dest, const T *source, size_t nelems,
 }
 
 template <typename T>
+__device__ void Context::put_nbi_wave_av(T *dest, const T *source, size_t nelems,
+                                         int pe) {
+  if (nelems == 0) {
+    return;
+  }
+
+  ctxStats.incStat(NUM_PUT_NBI_WAVE);
+
+  DISPATCH(put_nbi_wave_av(dest, source, nelems, pe));
+}
+
+template <typename T>
 __device__ void Context::get_wave(T *dest, const T *source, size_t nelems,
                                   int pe) {
   if (nelems == 0) {
@@ -592,6 +613,13 @@ __device__ void Context::amo_set(void *dst, T value, int pe) {
   ctxStats.incStat(NUM_ATOMIC_SET);
 
   DISPATCH(amo_set(dst, value, pe));
+}
+
+template <typename T>
+__device__ void Context::amo_set_av(void *dst, T value, int pe) {
+  ctxStats.incStat(NUM_ATOMIC_SET);
+
+  DISPATCH(amo_set_av(dst, value, pe));
 }
 
 template <typename T>

--- a/projects/rocshmem/src/context_tmpl_device.hpp
+++ b/projects/rocshmem/src/context_tmpl_device.hpp
@@ -25,7 +25,8 @@
 #ifndef LIBRARY_SRC_CONTEXT_TMPL_DEVICE_HPP_
 #define LIBRARY_SRC_CONTEXT_TMPL_DEVICE_HPP_
 
-#include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)
+#include "rocshmem/rocshmem_config.h"
+#include "util.hpp"  // NOLINT(build/include_subdir)
 #include "backend_type.hpp"
 #if defined(USE_GDA)
 #include "gda/context_gda_device.hpp"
@@ -232,21 +233,27 @@ __device__ void Context::broadcast_wg(T *dest, const T *source, int nelems,
                         pe_size, p_sync));
 }
 
-template <typename T>
-__device__ __forceinline__ void Context::wait_until(T *ivars, int cmp,
-                                                    T val) {
+template <typename T, OrderingMode Mode>
+__device__ __forceinline__ void Context::wait_until_impl(T *ivars, int cmp,
+                                                         T val) {
   while (!test(ivars, cmp, val)) {
   }
-  detail::atomic::threadfence<detail::atomic::memory_scope_system,
-                               detail::atomic::memory_order_acquire>();
+  if constexpr (is_targeted(Mode)) {
+    wait_on_vmem(0);
+  } else {
+    detail::atomic::threadfence<detail::atomic::memory_scope_system,
+                                detail::atomic::memory_order_acquire>();
+  }
 }
 
 template <typename T>
-__device__ __forceinline__ void Context::wait_until_av(T *ivars, int cmp,
-                                                       T val) {
-  while (!test(ivars, cmp, val)) {
-  }
-  wait_on_vmem(0);
+__device__ __forceinline__ void Context::wait_until(T *ivars, int cmp, T val) {
+  wait_until_impl<T, OrderingMode::Standard>(ivars, cmp, val);
+}
+
+template <typename T>
+__device__ __forceinline__ void Context::wait_until_av(T *ivars, int cmp, T val) {
+  wait_until_impl<T, OrderingMode::Targeted>(ivars, cmp, val);
 }
 
 __device__ __forceinline__ size_t status_entry(size_t nelems,
@@ -609,18 +616,21 @@ __device__ void Context::amo_add(void *dst, T value, int pe) {
   DISPATCH(amo_add(dst, value, pe));
 }
 
-template <typename T>
-__device__ void Context::amo_set(void *dst, T value, int pe) {
+template <typename T, OrderingMode Mode>
+__device__ void Context::amo_set_impl(void *dst, T value, int pe) {
   ctxStats.incStat(NUM_ATOMIC_SET);
 
-  DISPATCH(amo_set(dst, value, pe));
+  DISPATCH(amo_set_impl<PAIR(T, Mode)>(dst, value, pe));
+}
+
+template <typename T>
+__device__ void Context::amo_set(void *dst, T value, int pe) {
+  amo_set_impl<T, OrderingMode::Standard>(dst, value, pe);
 }
 
 template <typename T>
 __device__ void Context::amo_set_av(void *dst, T value, int pe) {
-  ctxStats.incStat(NUM_ATOMIC_SET);
-
-  DISPATCH(amo_set_av(dst, value, pe));
+  amo_set_impl<T, OrderingMode::Targeted>(dst, value, pe);
 }
 
 template <typename T>

--- a/projects/rocshmem/src/device/rocshmem_wrapper.cc
+++ b/projects/rocshmem/src/device/rocshmem_wrapper.cc
@@ -211,6 +211,17 @@ ROCSHMEM_DEVICE_API void rocshmem_putmem_nbi(void *dest, const void *source,
   rocshmem::rocshmem_putmem_nbi(dest, source, nelems, pe);
 }
 
+ROCSHMEM_DEVICE_API void rocshmem_putmem_av(void *dest, const void *source,
+                                            size_t nelems, int pe) {
+  rocshmem::rocshmem_putmem_av(dest, source, nelems, pe);
+}
+
+ROCSHMEM_DEVICE_API void rocshmem_putmem_nbi_av(void *dest,
+                                                 const void *source,
+                                                 size_t nelems, int pe) {
+  rocshmem::rocshmem_putmem_nbi_av(dest, source, nelems, pe);
+}
+
 ROCSHMEM_DEVICE_API void rocshmem_putmem_nbi_wave(void *dest,
                                                   const void *source,
                                                   size_t nelems, int pe) {
@@ -341,6 +352,14 @@ ROCSHMEM_DEVICE_API void rocshmem_fence() {
 
 ROCSHMEM_DEVICE_API void rocshmem_fence_pe(int pe) {
   rocshmem::rocshmem_fence(pe);
+}
+
+ROCSHMEM_DEVICE_API void rocshmem_fence_av() {
+  rocshmem::rocshmem_fence_av();
+}
+
+ROCSHMEM_DEVICE_API void rocshmem_fence_av_pe(int pe) {
+  rocshmem::rocshmem_fence_av(pe);
 }
 
 ROCSHMEM_DEVICE_API void rocshmem_quiet() {
@@ -642,6 +661,28 @@ WRAP_WAIT(unsigned int, uint)
 WRAP_WAIT(unsigned long, ulong)
 WRAP_WAIT(unsigned long long, ulonglong)
 WRAP_WAIT(uint64_t, uint64)
+
+#define WRAP_WAIT_AV(T, TNAME)                                                 \
+  ROCSHMEM_DEVICE_API void rocshmem_##TNAME##_wait_until_av(                  \
+      T *ivars, int cmp, T val) {                                              \
+    rocshmem::rocshmem_##TNAME##_wait_until_av(ivars, cmp, val);              \
+  }
+
+WRAP_WAIT_AV(float, float)
+WRAP_WAIT_AV(double, double)
+WRAP_WAIT_AV(char, char)
+WRAP_WAIT_AV(signed char, schar)
+WRAP_WAIT_AV(short, short)
+WRAP_WAIT_AV(int, int)
+WRAP_WAIT_AV(long, long)
+WRAP_WAIT_AV(long long, longlong)
+WRAP_WAIT_AV(unsigned char, uchar)
+WRAP_WAIT_AV(unsigned short, ushort)
+WRAP_WAIT_AV(unsigned int, uint)
+WRAP_WAIT_AV(unsigned long, ulong)
+WRAP_WAIT_AV(unsigned long long, ulonglong)
+WRAP_WAIT_AV(uint64_t, uint64)
+
 // Only support reduce on team = 0 (ROCSHMEM_TEAM_WORLD)
 #define WRAP_REDUCE_OP(T, TNAME, OP)                                           \
   ROCSHMEM_DEVICE_API int rocshmem_##TNAME##_##OP##_reduce_wg(                 \

--- a/projects/rocshmem/src/envvar.cpp
+++ b/projects/rocshmem/src/envvar.cpp
@@ -143,6 +143,9 @@ namespace envvar {
     const var<bool> disable_ipc("DISABLE_IPC",
       "DEPRECATED: Synonym for ROCSHMEM_DISABLE_MIXED_IPC. Force using network conduit even when IPC is available",
       false);
+    const var<bool> bypass_lane_stores("BYPASS_LANE_STORES",
+      "Use cache-bypassing (sc0 sc1 / glc slc) stores in the large multi-thread memcpy_lane put path instead of cached writes followed by a system-scope release fence. Enabling this avoids the fence at the cost of bypassing the L1/L2 caches on every store. Default: 0 (disabled, use cached writes + fence).",
+      false);
     const var<size_t> max_wavefront_buffers("MAX_WF_BUFFERS",
       "Maximum number of wavefront buffer arrays in default context (determines size of status, return, and atomic return buffers)",
       1024);

--- a/projects/rocshmem/src/envvar.hpp
+++ b/projects/rocshmem/src/envvar.hpp
@@ -533,6 +533,12 @@ namespace envvar {
      * be honored by other backends as they gain symmetric-registration support.
      */
     extern const var<size_t> max_symm_regions;
+
+    /**
+     * @brief Use cache-bypassing stores in the large multi-thread memcpy_lane
+     * put path (ROCSHMEM_BYPASS_LANE_STORES).
+     */
+    extern const var<bool> bypass_lane_stores;
   }  // inline namespace _base
 
   namespace bootstrap {

--- a/projects/rocshmem/src/gda/context_gda_device.cpp
+++ b/projects/rocshmem/src/gda/context_gda_device.cpp
@@ -170,43 +170,84 @@ __device__ void GDAContext::getmem_nbi(void *dest, const void *source,
 
 __device__ void GDAContext::fence() {
   /**
-   * Matches the sc26 targeted_order reference implementation.
+   * Operations issued by this context may use two backends: RDMA QPs
+   * for remote PEs and the IPC fast path, when enabled, for shm-local
+   * peers. The fence must order writes across both paths.
    *
-   * rocSHMEM uses one QP per PE per context by default
-   * (ROCSHMEM_GDA_NUM_QPS_PER_PE_DEFAULT_CTX=1).  With a single QP all
-   * puts to a given PE travel in order through the same NIC queue, so
-   * NIC in-order delivery guarantees payload visibility before the count
-   * signal without any explicit CQ drain.  A GPU-side system release
-   * fence (buffer_wbl2) is sufficient to order WQE postings and IPC
-   * writes for all paths.
+   * RDMA: A single QP already orders its own traffic through in-order
+   * delivery; only the multi-QP case requires an explicit per-QP quiet.
    *
    * For the targeted-ordering path see fence_av() which uses
-   * fence_targeted() (s_waitcnt vmcnt(0)) instead.
+   * wait_on_vmem(0) instead.
    */
-  __builtin_amdgcn_fence(__ATOMIC_RELEASE, "");
+  if (num_qps_per_pe > 1) {
+    ActiveWFInfo wf_info(ctx_id_);
+    for (uint32_t i = 0; i < num_qps; i++) {
+      qps[i].quiet(wf_info);
+    }
+  }
+
+  /**
+   * IPC: Skip when there are no shm-local peers. Otherwise, issue a
+   * system-scope release fence to ensure prior IPC writes are visible
+   * to peer ranks.
+   */
+  if (constmem.ipc_shm_size != 0) {
+    ipcImpl_.ipcFence();
+  }
 }
 
 __device__ void GDAContext::fence_av() {
   /**
    * Targeted-ordering fence for the GDA context.
    *
-   * Replaces the standard fence's expensive per-QP quiet + system-scope
-   * ipcFence() with fence_targeted() (s_waitcnt vmcnt(0)):
+   * Uses wait_on_vmem(0) — a portable drain of all in-flight vector memory
+   * operations — in place of the standard ipcFence<system, release>() which
+   * emits a system-scope L2 writeback (buffer_wbl2):
    *  - RDMA path: a single QP delivers writes in order; no CQ drain needed
    *    to establish ordering, only a GPU-side VMEM completion wait.
-   *  - IPC path: fence_targeted() replaces ipcImpl_.ipcFence() (which emits
-   *    buffer_wbl2) when prior stores already used sc0 sc1 cache bypass.
+   *  - IPC path: prior stores used sc0 sc1 cache bypass, so no L2 writeback
+   *    is required; wait_on_vmem(0) is sufficient.
+   *
+   * wait_on_vmem(0) lowers to s_waitcnt vmcnt(0) on GFX9/GFX9.5 and to the
+   * equivalent split load/store waits on GFX12, avoiding arch-specific asm.
    */
-  fence_targeted();
+  wait_on_vmem(0);
 }
 
 __device__ void GDAContext::fence_av(int pe) {
-  fence_targeted();
+  wait_on_vmem(0);
 }
 
 __device__ void GDAContext::fence(int pe) {
-  // With a single QP per PE, NIC in-order delivery handles per-PE ordering.
-  fence();
+  /**
+   * Operations targeting `pe` may use two backends: RDMA QPs for remote
+   * PEs and the IPC fast path, when enabled, for shm-local peers. The
+   * fence must order writes to `pe` across both paths.
+   *
+   * RDMA: A single QP per PE already orders its own traffic through
+   * in-order delivery; only the multi-QP-per-PE case requires an explicit
+   * quiet on each QP associated with `pe`.
+   */
+  if (num_qps_per_pe > 1) {
+    ActiveWFInfo wf_info(ctx_id_);
+    for (uint32_t i = 0; i < num_qps_per_pe; i++) {
+      int qp_index = i * constmem.num_pes + pe;
+      qps[qp_index].quiet(wf_info);
+    }
+  }
+
+  /**
+   * IPC: Skip when `pe` is not shm-local. Otherwise, issue a
+   * system-scope release fence so prior IPC writes to `pe` are visible
+   * to that peer rank. Passing `local_pe` lets the SDMA-enabled policy
+   * quiet only the channels associated with `pe` instead of falling
+   * back to sdmaQuietAll().
+   */
+  int local_pe;
+  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
+    ipcImpl_.ipcFence(local_pe);
+  }
 }
 
 __device__ void GDAContext::quiet() {

--- a/projects/rocshmem/src/gda/context_gda_device.cpp
+++ b/projects/rocshmem/src/gda/context_gda_device.cpp
@@ -77,19 +77,27 @@ __host__ GDAContext::~GDAContext() {
   CHECK_HIP(hipFree(qps));
 }
 
-__device__ void GDAContext::putmem(void *dest, const void *source, size_t nelems,
-                                   int pe) {
+template <OrderingMode Mode>
+__device__ void GDAContext::putmem_impl(void *dest, const void *source, size_t nelems,
+                                        int pe) {
   int local_pe{-1};
   if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
     uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
+    // IPC path: ipcCopy<PutBlocking> uses system-scope stores on both modes;
+    // the _av relaxation only affects RDMA doorbells, not IPC copies.
     ipcImpl_.ipcCopy<MemcpyKind::PutBlocking>(ipcImpl_.ipc_bases[local_pe] + L_offset, const_cast<void *>(source), nelems, local_pe);
     return;
   }
   ActiveWFInfo wf_info(pe);
   int qp_index = get_qp_index(pe, wf_info);
   uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[constmem.my_pe];
-  qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, wf_info);
+  qps[qp_index].put_nbi_impl<Mode>(base_heap[pe] + L_offset, source, nelems, wf_info);
   qps[qp_index].quiet(wf_info);
+}
+
+__device__ void GDAContext::putmem(void *dest, const void *source, size_t nelems,
+                                   int pe) {
+  putmem_impl<OrderingMode::Standard>(dest, source, nelems, pe);
 }
 
 __device__ void GDAContext::getmem(void *dest, const void *source, size_t nelems,
@@ -108,8 +116,9 @@ __device__ void GDAContext::getmem(void *dest, const void *source, size_t nelems
   qps[qp_index].quiet(wf_info);
 }
 
-__device__ void GDAContext::putmem_nbi(void *dest, const void *source,
-                                       size_t nelems, int pe) {
+template <OrderingMode Mode>
+__device__ void GDAContext::putmem_nbi_impl(void *dest, const void *source,
+                                            size_t nelems, int pe) {
   int local_pe{-1};
   if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
     uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
@@ -119,38 +128,22 @@ __device__ void GDAContext::putmem_nbi(void *dest, const void *source,
   ActiveWFInfo wf_info(pe);
   int qp_index = get_qp_index(pe, wf_info);
   uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[constmem.my_pe];
-  qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, wf_info);
+  qps[qp_index].put_nbi_impl<Mode>(base_heap[pe] + L_offset, source, nelems, wf_info);
+}
+
+__device__ void GDAContext::putmem_nbi(void *dest, const void *source,
+                                       size_t nelems, int pe) {
+  putmem_nbi_impl<OrderingMode::Standard>(dest, source, nelems, pe);
 }
 
 __device__ void GDAContext::putmem_av(void *dest, const void *source,
                                      size_t nelems, int pe) {
-  int local_pe{-1};
-  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
-    // IPC path: cache-bypassing stores already used by ipcCopy (SystemScope);
-    // no change needed for the _av variant on the IPC fast path.
-    uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
-    ipcImpl_.ipcCopy<MemcpyKind::PutBlocking>(ipcImpl_.ipc_bases[local_pe] + L_offset, const_cast<void *>(source), nelems, local_pe);
-    return;
-  }
-  ActiveWFInfo wf_info(pe);
-  int qp_index = get_qp_index(pe, wf_info);
-  uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[constmem.my_pe];
-  qps[qp_index].put_nbi_av(base_heap[pe] + L_offset, source, nelems, wf_info);
-  qps[qp_index].quiet(wf_info);
+  putmem_impl<OrderingMode::Targeted>(dest, source, nelems, pe);
 }
 
 __device__ void GDAContext::putmem_nbi_av(void *dest, const void *source,
                                           size_t nelems, int pe) {
-  int local_pe{-1};
-  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
-    uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
-    ipcImpl_.ipcCopy<MemcpyKind::Put>(ipcImpl_.ipc_bases[local_pe] + L_offset, const_cast<void *>(source), nelems, local_pe);
-    return;
-  }
-  ActiveWFInfo wf_info(pe);
-  int qp_index = get_qp_index(pe, wf_info);
-  uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[constmem.my_pe];
-  qps[qp_index].put_nbi_av(base_heap[pe] + L_offset, source, nelems, wf_info);
+  putmem_nbi_impl<OrderingMode::Targeted>(dest, source, nelems, pe);
 }
 
 __device__ void GDAContext::getmem_nbi(void *dest, const void *source,
@@ -168,87 +161,57 @@ __device__ void GDAContext::getmem_nbi(void *dest, const void *source,
   qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, wf_info);
 }
 
-__device__ void GDAContext::fence() {
-  /**
-   * Operations issued by this context may use two backends: RDMA QPs
-   * for remote PEs and the IPC fast path, when enabled, for shm-local
-   * peers. The fence must order writes across both paths.
-   *
-   * RDMA: A single QP already orders its own traffic through in-order
-   * delivery; only the multi-QP case requires an explicit per-QP quiet.
-   *
-   * For the targeted-ordering path see fence_av() which uses
-   * wait_on_vmem(0) instead.
-   */
-  if (num_qps_per_pe > 1) {
-    ActiveWFInfo wf_info(ctx_id_);
-    for (uint32_t i = 0; i < num_qps; i++) {
-      qps[i].quiet(wf_info);
+/**
+ * @brief Fence across all backends used by this context.
+ *
+ * OrderingMode::Standard  — drains any multi-QP RDMA traffic (when
+ *   ROCSHMEM_GDA_NUM_QPS_PER_PE > 1) and issues a system-scope release
+ *   fence (ipcFence, i.e. buffer_wbl2) for any IPC peers.
+ *
+ * OrderingMode::Targeted  — prior puts used cache-bypassing stores;
+ *   wait_on_vmem(0) is sufficient for both RDMA and IPC paths — no L2
+ *   writeback is needed and a single QP delivers writes in order.
+ */
+template <OrderingMode Mode>
+__device__ void GDAContext::fence_impl() {
+  if constexpr (is_targeted(Mode)) {
+    wait_on_vmem(0);
+  } else {
+    if (num_qps_per_pe > 1) {
+      ActiveWFInfo wf_info(ctx_id_);
+      for (uint32_t i = 0; i < num_qps; i++) {
+        qps[i].quiet(wf_info);
+      }
+    }
+    if (constmem.ipc_shm_size != 0) {
+      ipcImpl_.ipcFence();
     }
   }
-
-  /**
-   * IPC: Skip when there are no shm-local peers. Otherwise, issue a
-   * system-scope release fence to ensure prior IPC writes are visible
-   * to peer ranks.
-   */
-  if (constmem.ipc_shm_size != 0) {
-    ipcImpl_.ipcFence();
-  }
 }
 
-__device__ void GDAContext::fence_av() {
-  /**
-   * Targeted-ordering fence for the GDA context.
-   *
-   * Uses wait_on_vmem(0) — a portable drain of all in-flight vector memory
-   * operations — in place of the standard ipcFence<system, release>() which
-   * emits a system-scope L2 writeback (buffer_wbl2):
-   *  - RDMA path: a single QP delivers writes in order; no CQ drain needed
-   *    to establish ordering, only a GPU-side VMEM completion wait.
-   *  - IPC path: prior stores used sc0 sc1 cache bypass, so no L2 writeback
-   *    is required; wait_on_vmem(0) is sufficient.
-   *
-   * wait_on_vmem(0) lowers to s_waitcnt vmcnt(0) on GFX9/GFX9.5 and to the
-   * equivalent split load/store waits on GFX12, avoiding arch-specific asm.
-   */
-  wait_on_vmem(0);
-}
-
-__device__ void GDAContext::fence_av(int pe) {
-  wait_on_vmem(0);
-}
-
-__device__ void GDAContext::fence(int pe) {
-  /**
-   * Operations targeting `pe` may use two backends: RDMA QPs for remote
-   * PEs and the IPC fast path, when enabled, for shm-local peers. The
-   * fence must order writes to `pe` across both paths.
-   *
-   * RDMA: A single QP per PE already orders its own traffic through
-   * in-order delivery; only the multi-QP-per-PE case requires an explicit
-   * quiet on each QP associated with `pe`.
-   */
-  if (num_qps_per_pe > 1) {
-    ActiveWFInfo wf_info(ctx_id_);
-    for (uint32_t i = 0; i < num_qps_per_pe; i++) {
-      int qp_index = i * constmem.num_pes + pe;
-      qps[qp_index].quiet(wf_info);
+template <OrderingMode Mode>
+__device__ void GDAContext::fence_impl(int pe) {
+  if constexpr (is_targeted(Mode)) {
+    wait_on_vmem(0);
+  } else {
+    if (num_qps_per_pe > 1) {
+      ActiveWFInfo wf_info(ctx_id_);
+      for (uint32_t i = 0; i < num_qps_per_pe; i++) {
+        int qp_index = i * constmem.num_pes + pe;
+        qps[qp_index].quiet(wf_info);
+      }
+    }
+    int local_pe;
+    if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
+      ipcImpl_.ipcFence(local_pe);
     }
   }
-
-  /**
-   * IPC: Skip when `pe` is not shm-local. Otherwise, issue a
-   * system-scope release fence so prior IPC writes to `pe` are visible
-   * to that peer rank. Passing `local_pe` lets the SDMA-enabled policy
-   * quiet only the channels associated with `pe` instead of falling
-   * back to sdmaQuietAll().
-   */
-  int local_pe;
-  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
-    ipcImpl_.ipcFence(local_pe);
-  }
 }
+
+__device__ void GDAContext::fence()          { fence_impl<OrderingMode::Standard>(); }
+__device__ void GDAContext::fence_av()       { fence_impl<OrderingMode::Targeted>(); }
+__device__ void GDAContext::fence(int pe)    { fence_impl<OrderingMode::Standard>(pe); }
+__device__ void GDAContext::fence_av(int pe) { fence_impl<OrderingMode::Targeted>(pe); }
 
 __device__ void GDAContext::quiet() {
   ActiveWFInfo wf_info(ctx_id_);
@@ -282,10 +245,14 @@ __device__ void *GDAContext::shmem_ptr(const void *dest, int pe) {
   return ret;
 }
 
-__device__ void GDAContext::putmem_wg(void *dest, const void *source,
-                                      size_t nelems, int pe) {
+template <OrderingMode Mode>
+__device__ void GDAContext::putmem_wg_impl(void *dest, const void *source,
+                                           size_t nelems, int pe) {
   int local_pe{-1};
   if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
+    // IPC path: handled by IPCContext::putmem_wg_impl via dispatch.
+    // GDA RDMA path uses the standard WG put on both modes; the QP delivers
+    // writes in order so no extra cache action is needed for targeted ordering.
     uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
     ipcImpl_.ipcCopy_wg<MemcpyKind::PutBlocking>(ipcImpl_.ipc_bases[local_pe] + L_offset, const_cast<void *>(source), nelems, local_pe);
     return;
@@ -294,17 +261,19 @@ __device__ void GDAContext::putmem_wg(void *dest, const void *source,
     uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[constmem.my_pe];
     ActiveWFInfo wf_info(pe, ThreadScope::wg);
     int qp_index = get_qp_index(pe, wf_info);
-    qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, wf_info);
+    qps[qp_index].put_nbi_impl<Mode>(base_heap[pe] + L_offset, source, nelems, wf_info);
     qps[qp_index].quiet(wf_info);
   }
 }
 
+__device__ void GDAContext::putmem_wg(void *dest, const void *source,
+                                      size_t nelems, int pe) {
+  putmem_wg_impl<OrderingMode::Standard>(dest, source, nelems, pe);
+}
+
 __device__ void GDAContext::putmem_wg_av(void *dest, const void *source,
-                                        size_t nelems, int pe) {
-  // IPC path: handled by IPCContext::putmem_wg_av via dispatch.
-  // GDA RDMA path: the QP maintains in-order delivery; fall back to the
-  // standard blocking WG put which already uses sc0 sc1 stores.
-  putmem_wg(dest, source, nelems, pe);
+                                         size_t nelems, int pe) {
+  putmem_wg_impl<OrderingMode::Targeted>(dest, source, nelems, pe);
 }
 
 __device__ void GDAContext::getmem_wg(void *dest, const void *source,
@@ -750,5 +719,17 @@ __device__ int GDAContext::tile_collective_wait([[maybe_unused]] rocshmem_team_t
   LOGD_WARN("Tile API not implemented for GDA backend");
   return ROCSHMEM_ERROR;
 }
+
+// Explicit device template instantiations (required with -fgpu-rdc)
+template __device__ void GDAContext::fence_impl<OrderingMode::Standard>();
+template __device__ void GDAContext::fence_impl<OrderingMode::Targeted>();
+template __device__ void GDAContext::fence_impl<OrderingMode::Standard>(int);
+template __device__ void GDAContext::fence_impl<OrderingMode::Targeted>(int);
+template __device__ void GDAContext::putmem_impl<OrderingMode::Standard>(void*, const void*, size_t, int);
+template __device__ void GDAContext::putmem_impl<OrderingMode::Targeted>(void*, const void*, size_t, int);
+template __device__ void GDAContext::putmem_nbi_impl<OrderingMode::Standard>(void*, const void*, size_t, int);
+template __device__ void GDAContext::putmem_nbi_impl<OrderingMode::Targeted>(void*, const void*, size_t, int);
+template __device__ void GDAContext::putmem_wg_impl<OrderingMode::Standard>(void*, const void*, size_t, int);
+template __device__ void GDAContext::putmem_wg_impl<OrderingMode::Targeted>(void*, const void*, size_t, int);
 
 }  // namespace rocshmem

--- a/projects/rocshmem/src/gda/context_gda_device.cpp
+++ b/projects/rocshmem/src/gda/context_gda_device.cpp
@@ -122,6 +122,37 @@ __device__ void GDAContext::putmem_nbi(void *dest, const void *source,
   qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, wf_info);
 }
 
+__device__ void GDAContext::putmem_av(void *dest, const void *source,
+                                     size_t nelems, int pe) {
+  int local_pe{-1};
+  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
+    // IPC path: cache-bypassing stores already used by ipcCopy (SystemScope);
+    // no change needed for the _av variant on the IPC fast path.
+    uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
+    ipcImpl_.ipcCopy<MemcpyKind::PutBlocking>(ipcImpl_.ipc_bases[local_pe] + L_offset, const_cast<void *>(source), nelems, local_pe);
+    return;
+  }
+  ActiveWFInfo wf_info(pe);
+  int qp_index = get_qp_index(pe, wf_info);
+  uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[constmem.my_pe];
+  qps[qp_index].put_nbi_av(base_heap[pe] + L_offset, source, nelems, wf_info);
+  qps[qp_index].quiet(wf_info);
+}
+
+__device__ void GDAContext::putmem_nbi_av(void *dest, const void *source,
+                                          size_t nelems, int pe) {
+  int local_pe{-1};
+  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
+    uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
+    ipcImpl_.ipcCopy<MemcpyKind::Put>(ipcImpl_.ipc_bases[local_pe] + L_offset, const_cast<void *>(source), nelems, local_pe);
+    return;
+  }
+  ActiveWFInfo wf_info(pe);
+  int qp_index = get_qp_index(pe, wf_info);
+  uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[constmem.my_pe];
+  qps[qp_index].put_nbi_av(base_heap[pe] + L_offset, source, nelems, wf_info);
+}
+
 __device__ void GDAContext::getmem_nbi(void *dest, const void *source,
                                        size_t nelems, int pe) {
   const char *src_typed = reinterpret_cast<const char *>(source);
@@ -139,59 +170,43 @@ __device__ void GDAContext::getmem_nbi(void *dest, const void *source,
 
 __device__ void GDAContext::fence() {
   /**
-   * Operations issued by this context may use two backends: RDMA QPs
-   * for remote PEs and the IPC fast path, when enabled, for shm-local
-   * peers. The fence must order writes across both paths.
+   * Matches the sc26 targeted_order reference implementation.
    *
-   * RDMA: A single QP already orders its own traffic through in-order
-   * delivery; only the multi-QP case requires an explicit per-QP quiet.
+   * rocSHMEM uses one QP per PE per context by default
+   * (ROCSHMEM_GDA_NUM_QPS_PER_PE_DEFAULT_CTX=1).  With a single QP all
+   * puts to a given PE travel in order through the same NIC queue, so
+   * NIC in-order delivery guarantees payload visibility before the count
+   * signal without any explicit CQ drain.  A GPU-side system release
+   * fence (buffer_wbl2) is sufficient to order WQE postings and IPC
+   * writes for all paths.
+   *
+   * For the targeted-ordering path see fence_av() which uses
+   * fence_targeted() (s_waitcnt vmcnt(0)) instead.
    */
-  if (num_qps_per_pe > 1) {
-    ActiveWFInfo wf_info(ctx_id_);
-    for (uint32_t i = 0; i < num_qps; i++) {
-      qps[i].quiet(wf_info);
-    }
-  }
+  __builtin_amdgcn_fence(__ATOMIC_RELEASE, "");
+}
 
+__device__ void GDAContext::fence_av() {
   /**
-   * IPC: Skip when there are no shm-local peers. Otherwise, issue a
-   * system-scope release fence to ensure prior IPC writes are visible
-   * to peer ranks.
+   * Targeted-ordering fence for the GDA context.
+   *
+   * Replaces the standard fence's expensive per-QP quiet + system-scope
+   * ipcFence() with fence_targeted() (s_waitcnt vmcnt(0)):
+   *  - RDMA path: a single QP delivers writes in order; no CQ drain needed
+   *    to establish ordering, only a GPU-side VMEM completion wait.
+   *  - IPC path: fence_targeted() replaces ipcImpl_.ipcFence() (which emits
+   *    buffer_wbl2) when prior stores already used sc0 sc1 cache bypass.
    */
-  if (constmem.ipc_shm_size != 0) {
-    ipcImpl_.ipcFence();
-  }
+  fence_targeted();
+}
+
+__device__ void GDAContext::fence_av(int pe) {
+  fence_targeted();
 }
 
 __device__ void GDAContext::fence(int pe) {
-  /**
-   * Operations targeting `pe` may use two backends: RDMA QPs for remote
-   * PEs and the IPC fast path, when enabled, for shm-local peers. The
-   * fence must order writes to `pe` across both paths.
-   *
-   * RDMA: A single QP per PE already orders its own traffic through
-   * in-order delivery; only the multi-QP-per-PE case requires an explicit
-   * quiet on each QP associated with `pe`.
-   */
-  if (num_qps_per_pe > 1) {
-    ActiveWFInfo wf_info(ctx_id_);
-    for(uint32_t i = 0; i < num_qps_per_pe; i++) {
-      int qp_index = i * constmem.num_pes + pe;
-      qps[qp_index].quiet(wf_info);
-    }
-  }
-
-  /**
-   * IPC: Skip when `pe` is not shm-local. Otherwise, issue a
-   * system-scope release fence so prior IPC writes to `pe` are visible
-   * to that peer rank. Passing `local_pe` lets the SDMA-enabled policy
-   * quiet only the channels associated with `pe` instead of falling
-   * back to sdmaQuietAll().
-   */
-  int local_pe;
-  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
-    ipcImpl_.ipcFence(local_pe);
-  }
+  // With a single QP per PE, NIC in-order delivery handles per-PE ordering.
+  fence();
 }
 
 __device__ void GDAContext::quiet() {
@@ -241,6 +256,14 @@ __device__ void GDAContext::putmem_wg(void *dest, const void *source,
     qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, wf_info);
     qps[qp_index].quiet(wf_info);
   }
+}
+
+__device__ void GDAContext::putmem_wg_av(void *dest, const void *source,
+                                        size_t nelems, int pe) {
+  // IPC path: handled by IPCContext::putmem_wg_av via dispatch.
+  // GDA RDMA path: the QP maintains in-order delivery; fall back to the
+  // standard blocking WG put which already uses sc0 sc1 stores.
+  putmem_wg(dest, source, nelems, pe);
 }
 
 __device__ void GDAContext::getmem_wg(void *dest, const void *source,
@@ -342,6 +365,24 @@ __device__ void GDAContext::putmem_nbi_wave(void *dest, const void *source,
     int qp_index = get_qp_index(pe, wf_info);
     uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[constmem.my_pe];
     qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, wf_info);
+  }
+}
+
+__device__ void GDAContext::putmem_nbi_wave_av(void *dest, const void *source,
+                                              size_t nelems, int pe) {
+  int local_pe{-1};
+  if (ipcImpl_.isIpcAvailable(constmem.my_pe, pe, &local_pe)) {
+    // IPC path: ipcCopy_wave already uses cache-bypassing (sc0 sc1) stores;
+    // no additional change needed for _av on the intranode path.
+    uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[ipcImpl_.shm_rank];
+    ipcImpl_.ipcCopy_wave<MemcpyKind::Put>(ipcImpl_.ipc_bases[local_pe] + L_offset, const_cast<void *>(source), nelems, local_pe);
+    return;
+  }
+  if (is_thread_zero_in_wave()) {
+    ActiveWFInfo wf_info(pe, ThreadScope::wave);
+    int qp_index = get_qp_index(pe, wf_info);
+    uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[constmem.my_pe];
+    qps[qp_index].put_nbi_av(base_heap[pe] + L_offset, source, nelems, wf_info);
   }
 }
 

--- a/projects/rocshmem/src/gda/context_gda_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_device.hpp
@@ -26,6 +26,7 @@
 #define LIBRARY_SRC_GDA_CONTEXT_DEVICE_HPP_
 
 #include "context.hpp"
+#include "util.hpp"
 #include "team.hpp"
 #include "queue_pair.hpp"
 
@@ -41,9 +42,15 @@ class GDAContext : public Context {
 
   __device__ GDAContext(Backend *b, unsigned int ctx_id); //TODO is this used?
 
+  template <OrderingMode Mode = OrderingMode::Standard>
+  __device__ void putmem_impl(void *dest, const void *source, size_t nelems, int pe);
+
   __device__ void putmem(void *dest, const void *source, size_t nelems, int pe);
 
   __device__ void getmem(void *dest, const void *source, size_t nelems, int pe);
+
+  template <OrderingMode Mode = OrderingMode::Standard>
+  __device__ void putmem_nbi_impl(void *dest, const void *source, size_t nelems, int pe);
 
   __device__ void putmem_nbi(void *dest, const void *source, size_t nelems,
                              int pe);
@@ -57,17 +64,12 @@ class GDAContext : public Context {
   __device__ void putmem_nbi_av(void *dest, const void *source, size_t nelems,
                                 int pe);
 
+  template <OrderingMode Mode> __device__ void fence_impl();
+  template <OrderingMode Mode> __device__ void fence_impl(int pe);
+
   __device__ void fence();
-
   __device__ void fence(int pe);
-
-  /**
-   * @brief Targeted-ordering fence: uses wait_on_vmem(0)
-   * in place of the expensive per-QP quiet + system-scope L2 writeback.
-   * Correct when prior puts used cache-bypassing stores (sc0 sc1).
-   */
   __device__ void fence_av();
-
   __device__ void fence_av(int pe);
 
   __device__ void quiet();
@@ -121,6 +123,9 @@ class GDAContext : public Context {
   // Atomic operations
   template <typename T>
   __device__ void amo_add(void *dst, T value, int pe);
+
+  template <typename T, OrderingMode Mode = OrderingMode::Standard>
+  __device__ void amo_set_impl(void *dst, T value, int pe);
 
   template <typename T>
   __device__ void amo_set(void *dst, T value, int pe);
@@ -211,6 +216,9 @@ class GDAContext : public Context {
 
 
   // Block/wave functions
+  template <OrderingMode Mode = OrderingMode::Standard>
+  __device__ void putmem_wg_impl(void *dest, const void *source, size_t nelems, int pe);
+
   __device__ void putmem_wg(void *dest, const void *source, size_t nelems,
                             int pe);
 

--- a/projects/rocshmem/src/gda/context_gda_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_device.hpp
@@ -51,9 +51,24 @@ class GDAContext : public Context {
   __device__ void getmem_nbi(void *dest, const void *source, size_t size,
                              int pe);
 
+  __device__ void putmem_av(void *dest, const void *source, size_t nelems,
+                            int pe);
+
+  __device__ void putmem_nbi_av(void *dest, const void *source, size_t nelems,
+                                int pe);
+
   __device__ void fence();
 
   __device__ void fence(int pe);
+
+  /**
+   * @brief Targeted-ordering fence: uses fence_targeted() (s_waitcnt vmcnt(0))
+   * in place of the expensive per-QP quiet + system-scope L2 writeback.
+   * Correct when prior puts used cache-bypassing stores (sc0 sc1).
+   */
+  __device__ void fence_av();
+
+  __device__ void fence_av(int pe);
 
   __device__ void quiet();
 
@@ -109,6 +124,9 @@ class GDAContext : public Context {
 
   template <typename T>
   __device__ void amo_set(void *dst, T value, int pe);
+
+  template <typename T>
+  __device__ void amo_set_av(void *dst, T value, int pe);
 
   template <typename T>
   __device__ T amo_swap(void *dst, T value, int pe);
@@ -196,6 +214,9 @@ class GDAContext : public Context {
   __device__ void putmem_wg(void *dest, const void *source, size_t nelems,
                             int pe);
 
+  __device__ void putmem_wg_av(void *dest, const void *source, size_t nelems,
+                               int pe);
+
   __device__ void getmem_wg(void *dest, const void *source, size_t nelems,
                             int pe);
 
@@ -213,6 +234,13 @@ class GDAContext : public Context {
 
   __device__ void putmem_nbi_wave(void *dest, const void *source, size_t nelems,
                                   int pe);
+
+  /** _av variant: uses mlx5_post_wqe_rma_av (cache-bypassing WQE + fence_targeted doorbell). */
+  __device__ void putmem_nbi_wave_av(void *dest, const void *source,
+                                     size_t nelems, int pe);
+
+  template <typename T>
+  __device__ void put_nbi_wave_av(T *dest, const T *source, size_t nelems, int pe);
 
   __device__ void getmem_nbi_wave(void *dest, const void *source, size_t size,
                                   int pe);

--- a/projects/rocshmem/src/gda/context_gda_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_device.hpp
@@ -62,7 +62,7 @@ class GDAContext : public Context {
   __device__ void fence(int pe);
 
   /**
-   * @brief Targeted-ordering fence: uses fence_targeted() (s_waitcnt vmcnt(0))
+   * @brief Targeted-ordering fence: uses wait_on_vmem(0)
    * in place of the expensive per-QP quiet + system-scope L2 writeback.
    * Correct when prior puts used cache-bypassing stores (sc0 sc1).
    */
@@ -235,7 +235,7 @@ class GDAContext : public Context {
   __device__ void putmem_nbi_wave(void *dest, const void *source, size_t nelems,
                                   int pe);
 
-  /** _av variant: uses mlx5_post_wqe_rma_av (cache-bypassing WQE + fence_targeted doorbell). */
+  /** _av variant: uses mlx5_post_wqe_rma_av (cache-bypassing WQE + wait_on_vmem(0) doorbell). */
   __device__ void putmem_nbi_wave_av(void *dest, const void *source,
                                      size_t nelems, int pe);
 

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -116,6 +116,14 @@ __device__ void GDAContext::amo_set(void *dst, T value, int pe) {
 }
 
 template <typename T>
+__device__ void GDAContext::amo_set_av(void *dst, T value, int pe) {
+  // GDA AMO set goes through the NIC; the relaxation is an IPC-specific
+  // optimisation. Fall back to the standard path for RDMA targets; IPC
+  // targets are handled by the IPC fast-path check inside amo_set.
+  amo_set(dst, value, pe);
+}
+
+template <typename T>
 __device__ T GDAContext::amo_swap(void *dst, T value, int pe) {
   if constexpr (sizeof(T) != 8) { LOGD_ERROR_ABORT("gda::amo_set not implemented for non-64bit types"); }//TODO:support for non-uint64t
   uint64_t L_offset = reinterpret_cast<char *>(dst) - base_heap[constmem.my_pe];
@@ -1032,6 +1040,11 @@ __device__ void GDAContext::put_wave(T *dest, const T *source, size_t nelems, in
 template <typename T>
 __device__ void GDAContext::put_nbi_wave(T *dest, const T *source, size_t nelems, int pe) {
   putmem_nbi_wave(dest, source, nelems * sizeof(T), pe);
+}
+
+template <typename T>
+__device__ void GDAContext::put_nbi_wave_av(T *dest, const T *source, size_t nelems, int pe) {
+  putmem_nbi_wave_av(dest, source, nelems * sizeof(T), pe);
 }
 
 template <typename T>

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -110,17 +110,22 @@ __device__ void GDAContext::amo_add(void *dst, T value, int pe) {
   }
 }
 
-template <typename T>
-__device__ void GDAContext::amo_set(void *dst, T value, int pe) {
+template <typename T, OrderingMode Mode>
+__device__ void GDAContext::amo_set_impl(void *dst, T value, int pe) {
+  // GDA AMO set goes through the NIC; targeted-ordering relaxation applies
+  // only to IPC peers (handled inside amo_set). For RDMA targets both modes
+  // share the same NIC-routed CAS path.
   amo_swap(dst, value, pe);
 }
 
 template <typename T>
+__device__ void GDAContext::amo_set(void *dst, T value, int pe) {
+  amo_set_impl<T, OrderingMode::Standard>(dst, value, pe);
+}
+
+template <typename T>
 __device__ void GDAContext::amo_set_av(void *dst, T value, int pe) {
-  // GDA AMO set goes through the NIC; the relaxation is an IPC-specific
-  // optimisation. Fall back to the standard path for RDMA targets; IPC
-  // targets are handled by the IPC fast-path check inside amo_set.
-  amo_set(dst, value, pe);
+  amo_set_impl<T, OrderingMode::Targeted>(dst, value, pe);
 }
 
 template <typename T>

--- a/projects/rocshmem/src/gda/mlx5/queue_pair_mlx5.cpp
+++ b/projects/rocshmem/src/gda/mlx5/queue_pair_mlx5.cpp
@@ -78,54 +78,45 @@ __device__ static inline uint16_t mlx5_sq_idx(const gda_mlx5_device_sq& sq, uint
   return wqe_idx & sq.depth_mask;
 }
 
-__device__ void QueuePair::mlx5_ring_doorbell(uint64_t sq_post, const gda_mlx5_wqe& wqe) {
-  // sq_wqebb_counter is the least significant bits of the post counter
+/**
+ * @brief Ring the MLX5 SQ doorbell.
+ *
+ * OrderingMode::Standard  — system-scope release stores for dbrec and the
+ *   BlueFlame register; the implicit buffer_wbl2 ensures prior WQE stores
+ *   (which may be cached) are visible to the NIC before the doorbell.
+ *
+ * OrderingMode::Targeted  — prior WQE stores used cache-bypassing sc0 sc1
+ *   access (CachePolicy::SystemScope) and are already in HBM.  A
+ *   wait_on_vmem(0) drain before each relaxed system-scope store is
+ *   sufficient; no L2 writeback is needed.
+ */
+template <OrderingMode Mode>
+__device__ void QueuePair::mlx5_ring_doorbell_impl(uint64_t sq_post, const gda_mlx5_wqe& wqe) {
   uint16_t sq_wqebb_counter = static_cast<uint16_t>(sq_post);
-  // gda_mlx5_db_register constructor extracts first 8 bytes of WQE
   gda_mlx5_db_register db_val{wqe};
   __be32 be_sq_wqebb_counter = endian::to_be<uint32_t>(sq_wqebb_counter);
-
-  // get BlueFlame buffer from SQ
   gda_mlx5_bf_buffer* bf = mlx5_sq.bf_buffer();
 
-  // store sq_wqebb_counter to doorbell record
-  __hip_atomic_store(mlx5_sq.dbrec, be_sq_wqebb_counter, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_SYSTEM);
-  // ring doorbell by storing first 8B of WQE to the doorbell register
-  __hip_atomic_store(&bf->db_reg, db_val, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_SYSTEM);
-
-  LOGD_TRACE("SQ: posted WQEs with dbrec(%p)=%x (%hu), dbreg(%p)=%lx (%x, %x)",
-             mlx5_sq.dbrec, be_sq_wqebb_counter, sq_wqebb_counter,
-             &bf->db_reg, db_val.val, db_val.wqe_header.opmod_idx_opcode, db_val.wqe_header.qpn_ds);
+  if constexpr (is_targeted(Mode)) {
+    wait_on_vmem(0);
+    __hip_atomic_store(mlx5_sq.dbrec, be_sq_wqebb_counter, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+    wait_on_vmem(0);
+    __hip_atomic_store(&bf->db_reg, db_val, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+  } else {
+    __hip_atomic_store(mlx5_sq.dbrec, be_sq_wqebb_counter, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_SYSTEM);
+    __hip_atomic_store(&bf->db_reg, db_val, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_SYSTEM);
+    LOGD_TRACE("SQ: posted WQEs with dbrec(%p)=%x (%hu), dbreg(%p)=%lx (%x, %x)",
+               mlx5_sq.dbrec, be_sq_wqebb_counter, sq_wqebb_counter,
+               &bf->db_reg, db_val.val, db_val.wqe_header.opmod_idx_opcode, db_val.wqe_header.qpn_ds);
+  }
 }
 
-/**
- * @brief Targeted-ordering variant of mlx5_ring_doorbell.
- *
- * Replaces system-scope release stores with wait_on_vmem(0) +
- * relaxed system-scope stores:
- *   - wait_on_vmem(0) before dbrec: drains all in-flight VMEM ops (including
- *     cache-bypassing WQE stores) so they are committed to HBM before the
- *     NIC reads the doorbell record.  Portable across GFX9/GFX10/GFX12.
- *   - Relaxed system-scope store for dbrec (sc0 sc1, no L2 writeback needed
- *     because preceding WQE stores used cache bypass).
- *   - wait_on_vmem(0) between dbrec and doorbell register: ensures the dbrec
- *     store is complete before the NIC is notified via the BlueFlame write.
- *   - Relaxed system-scope store for the doorbell register (MMIO, uncacheable).
- */
+__device__ void QueuePair::mlx5_ring_doorbell(uint64_t sq_post, const gda_mlx5_wqe& wqe) {
+  mlx5_ring_doorbell_impl<OrderingMode::Standard>(sq_post, wqe);
+}
+
 __device__ void QueuePair::mlx5_ring_doorbell_av(uint64_t sq_post, const gda_mlx5_wqe& wqe) {
-  uint16_t sq_wqebb_counter = static_cast<uint16_t>(sq_post);
-  gda_mlx5_db_register db_val{wqe};
-  __be32 be_sq_wqebb_counter = endian::to_be<uint32_t>(sq_wqebb_counter);
-
-  gda_mlx5_bf_buffer* bf = mlx5_sq.bf_buffer();
-
-  // Drain all outstanding VMEM ops (including WQE cache-bypassing stores)
-  // before making the doorbell record visible to the NIC.
-  wait_on_vmem(0);
-  __hip_atomic_store(mlx5_sq.dbrec, be_sq_wqebb_counter, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
-  // Order dbrec store before the doorbell register write.
-  wait_on_vmem(0);
-  __hip_atomic_store(&bf->db_reg, db_val, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+  mlx5_ring_doorbell_impl<OrderingMode::Targeted>(sq_post, wqe);
 }
 
 [[maybe_unused]] __attribute__((noinline))
@@ -291,53 +282,26 @@ __device__ void QueuePair::mlx5_quiet_single() {
 __device__ void QueuePair::mlx5_post_wqe_rma(int32_t length, uintptr_t raddr,
     uint32_t rkey, uintptr_t laddr, uint32_t lkey,
     uint8_t opcode, ActiveWFInfo &wf_info, bool ring_db) {
-  if (wf_info.is_pe_group_last) {
-    // get SQ lock
-    acquire_lock(&mlx5_sq.lock);
-    // poll until we have enough WQEBB for all lanes using this QP
-    mlx5_poll_cq_until(wf_info.num_pe_group_lanes);
-  }
-
-  // wqe_idx is the logical WQE id that wraps at 0xFFFF, sq_idx is the index into the actual SQ
-  uint16_t wqe_idx = mlx5_wqe_idx(mlx5_sq, wf_info.pe_group_logical_lane_id);
-  uint16_t sq_idx = mlx5_sq_idx(mlx5_sq, wqe_idx);
-
-  // can we inline the data into the WQE?
-  bool send_inline = gda_mlx5_wqe_rma::can_inline(opcode, length, inline_threshold);
-
-  // construct the WQE on the stack
-  gda_mlx5_wqe wqe{wqe_idx, opcode, qp_num, MLX5_WQE_CTRL_CQ_UPDATE,
-                   raddr, byteswap<uint32_t>(rkey), laddr, byteswap<uint32_t>(lkey),
-                   static_cast<uint32_t>(length), send_inline};
-
-  // copy to SQ
-  mlx5_sq.buf[sq_idx] = wqe;
-
-  if (wf_info.is_pe_group_last) {
-    // increment post counter
-    mlx5_sq.post += wf_info.num_pe_group_lanes;
-    // we are the last thread in the wavefront, so we have the last WQE posted
-    if (ring_db) {
-      mlx5_ring_doorbell(mlx5_sq.post, wqe);
-    }
-    // release SQ lock
-    release_lock(&mlx5_sq.lock);
-  }
+  mlx5_post_wqe_rma_impl<OrderingMode::Standard>(length, raddr, rkey, laddr, lkey, opcode, wf_info, ring_db);
 }
 
 /**
- * @brief Targeted-ordering variant of mlx5_post_wqe_rma.
+ * @brief Post an RMA WQE to the MLX5 SQ and optionally ring the doorbell.
  *
- * Uses cache-bypassing stores (sc0 sc1) for the WQE copy so data is
- * written directly to HBM without populating the GPU's L1/L2 cache.
- * This is required so that wait_on_vmem(0) is
- * sufficient to guarantee NIC visibility before the doorbell is rung.
+ * OrderingMode::Standard  — the WQE is copied to the SQ buffer using the
+ *   default (cached) store path; the subsequent system-scope release doorbell
+ *   (mlx5_ring_doorbell_impl<Standard>) emits buffer_wbl2 to flush those
+ *   lines before the NIC reads them.
  *
- * Variables used only for GPU thread synchronisation (lock, sq.post,
- * sq.depth_mask) retain their existing store semantics — they are not
- * read by the NIC and do not require cache bypassing.
+ * OrderingMode::Targeted  — the WQE is copied using cache-bypassing
+ *   (CachePolicy::SystemScope / sc0 sc1) stores so HBM receives the data
+ *   directly.  mlx5_ring_doorbell_impl<Targeted> then uses wait_on_vmem(0)
+ *   instead of a full release fence to order the doorbell, since no L2
+ *   writeback is needed.  GPU-side bookkeeping fields (lock, sq.post) retain
+ *   their existing store semantics.
  */
-__device__ void QueuePair::mlx5_post_wqe_rma_av(int32_t length, uintptr_t raddr,
+template <OrderingMode Mode>
+__device__ void QueuePair::mlx5_post_wqe_rma_impl(int32_t length, uintptr_t raddr,
     uint32_t rkey, uintptr_t laddr, uint32_t lkey,
     uint8_t opcode, ActiveWFInfo &wf_info, bool ring_db) {
   if (wf_info.is_pe_group_last) {
@@ -346,41 +310,40 @@ __device__ void QueuePair::mlx5_post_wqe_rma_av(int32_t length, uintptr_t raddr,
   }
 
   uint16_t wqe_idx = mlx5_wqe_idx(mlx5_sq, wf_info.pe_group_logical_lane_id);
-  uint16_t sq_idx = mlx5_sq_idx(mlx5_sq, wqe_idx);
-
+  uint16_t sq_idx  = mlx5_sq_idx(mlx5_sq, wqe_idx);
   bool send_inline = gda_mlx5_wqe_rma::can_inline(opcode, length, inline_threshold);
 
-  // construct WQE on the stack (unchanged)
   gda_mlx5_wqe wqe{wqe_idx, opcode, qp_num, MLX5_WQE_CTRL_CQ_UPDATE,
                    raddr, byteswap<uint32_t>(rkey), laddr, byteswap<uint32_t>(lkey),
                    static_cast<uint32_t>(length), send_inline};
 
-  // Copy WQE to SQ using cache-bypassing (SystemScope) stores so HBM
-  // receives the data directly.  The NIC will DMA-read from HBM, and
-  // wait_on_vmem(0) in mlx5_ring_doorbell_av() ensures these stores are
-  // complete before the doorbell is visible to the NIC.
-  //
-  // The WQE is a stack-local value; load each 16-byte chunk with standard
-  // (cached) policy, then store to the SQ buffer with SystemScope (sc0 sc1)
-  // to bypass L1/L2 and write directly to HBM.
-  static_assert(sizeof(gda_mlx5_wqe) == 64, "WQE must be 64 bytes");
-  using Chunk = typename AsmAccess<16>::type;
-  auto* dst = reinterpret_cast<uint8_t*>(&mlx5_sq.buf[sq_idx]);
-  auto* src = reinterpret_cast<const uint8_t*>(&wqe);
-  for (int i = 0; i < 4; ++i) {
-    Chunk val = *reinterpret_cast<const Chunk*>(src + i * 16);
-    AsmAccess<16, CachePolicy::Standard,
-              CachePolicy::SystemScope>::store(dst + i * 16, val);
+  if constexpr (is_targeted(Mode)) {
+    // Store each 16-byte WQE chunk directly to HBM via cache-bypassing stores.
+    static_assert(sizeof(gda_mlx5_wqe) == 64, "WQE must be 64 bytes");
+    using Chunk = typename AsmAccess<16>::type;
+    auto* dst = reinterpret_cast<uint8_t*>(&mlx5_sq.buf[sq_idx]);
+    auto* src = reinterpret_cast<const uint8_t*>(&wqe);
+    for (int i = 0; i < 4; ++i) {
+      Chunk val = *reinterpret_cast<const Chunk*>(src + i * 16);
+      AsmAccess<16, CachePolicy::Standard, CachePolicy::SystemScope>::store(dst + i * 16, val);
+    }
+  } else {
+    mlx5_sq.buf[sq_idx] = wqe;
   }
 
   if (wf_info.is_pe_group_last) {
-    // sq.post is GPU-side bookkeeping only — plain store is fine.
     mlx5_sq.post += wf_info.num_pe_group_lanes;
     if (ring_db) {
-      mlx5_ring_doorbell_av(mlx5_sq.post, wqe);
+      mlx5_ring_doorbell_impl<Mode>(mlx5_sq.post, wqe);
     }
     release_lock(&mlx5_sq.lock);
   }
+}
+
+__device__ void QueuePair::mlx5_post_wqe_rma_av(int32_t length, uintptr_t raddr,
+    uint32_t rkey, uintptr_t laddr, uint32_t lkey,
+    uint8_t opcode, ActiveWFInfo &wf_info, bool ring_db) {
+  mlx5_post_wqe_rma_impl<OrderingMode::Targeted>(length, raddr, rkey, laddr, lkey, opcode, wf_info, ring_db);
 }
 
 // precondition: called with all active lanes using different QPs
@@ -525,5 +488,11 @@ __device__ uint64_t QueuePair::mlx5_post_wqe_amo_single(uintptr_t raddr,
 
   return fetching ? *atomic_laddr : 0;
 }
+
+// Explicit device template instantiations (required with -fgpu-rdc)
+template __device__ void QueuePair::mlx5_ring_doorbell_impl<OrderingMode::Standard>(uint64_t, const gda_mlx5_wqe&);
+template __device__ void QueuePair::mlx5_ring_doorbell_impl<OrderingMode::Targeted>(uint64_t, const gda_mlx5_wqe&);
+template __device__ void QueuePair::mlx5_post_wqe_rma_impl<OrderingMode::Standard>(int32_t, uintptr_t, uint32_t, uintptr_t, uint32_t, uint8_t, ActiveWFInfo&, bool);
+template __device__ void QueuePair::mlx5_post_wqe_rma_impl<OrderingMode::Targeted>(int32_t, uintptr_t, uint32_t, uintptr_t, uint32_t, uint8_t, ActiveWFInfo&, bool);
 
 }  // namespace rocshmem

--- a/projects/rocshmem/src/gda/mlx5/queue_pair_mlx5.cpp
+++ b/projects/rocshmem/src/gda/mlx5/queue_pair_mlx5.cpp
@@ -98,6 +98,35 @@ __device__ void QueuePair::mlx5_ring_doorbell(uint64_t sq_post, const gda_mlx5_w
              &bf->db_reg, db_val.val, db_val.wqe_header.opmod_idx_opcode, db_val.wqe_header.qpn_ds);
 }
 
+/**
+ * @brief Targeted-ordering variant of mlx5_ring_doorbell.
+ *
+ * Replaces system-scope release stores with fence_targeted() +
+ * relaxed system-scope stores:
+ *   - fence_targeted() (s_waitcnt vmcnt(0)) before dbrec: ensures all
+ *     preceding cache-bypassing WQE stores have reached HBM before the
+ *     NIC reads the doorbell record.
+ *   - Relaxed system-scope store for dbrec (sc0 sc1, no preceding buffer_wbl2).
+ *   - fence_targeted() between dbrec and doorbell register: ensures dbrec
+ *     is visible before the NIC is notified via the BlueFlame write.
+ *   - Relaxed system-scope store for the doorbell register (MMIO, uncacheable).
+ */
+__device__ void QueuePair::mlx5_ring_doorbell_av(uint64_t sq_post, const gda_mlx5_wqe& wqe) {
+  uint16_t sq_wqebb_counter = static_cast<uint16_t>(sq_post);
+  gda_mlx5_db_register db_val{wqe};
+  __be32 be_sq_wqebb_counter = endian::to_be<uint32_t>(sq_wqebb_counter);
+
+  gda_mlx5_bf_buffer* bf = mlx5_sq.bf_buffer();
+
+  // Drain all outstanding VMEM ops (including WQE cache-bypassing stores)
+  // before making the doorbell record visible to the NIC.
+  fence_targeted();
+  __hip_atomic_store(mlx5_sq.dbrec, be_sq_wqebb_counter, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+  // Order dbrec store before the doorbell register write.
+  fence_targeted();
+  __hip_atomic_store(&bf->db_reg, db_val, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+}
+
 [[maybe_unused]] __attribute__((noinline))
 __device__ void QueuePair::mlx5_print_cqe_error(const mlx5_cqe64* cqe, uint8_t opcode) {
   const mlx5_err_cqe* err_cqe = reinterpret_cast<const mlx5_err_cqe*>(cqe);
@@ -291,6 +320,64 @@ __device__ void QueuePair::mlx5_post_wqe_rma(int32_t length, uintptr_t raddr,
       mlx5_ring_doorbell(mlx5_sq.post, wqe);
     }
     // release SQ lock
+    release_lock(&mlx5_sq.lock);
+  }
+}
+
+/**
+ * @brief Targeted-ordering variant of mlx5_post_wqe_rma.
+ *
+ * Uses cache-bypassing stores (sc0 sc1) for the WQE copy so data is
+ * written directly to HBM without populating the GPU's L1/L2 cache.
+ * This is required so that fence_targeted() (s_waitcnt vmcnt(0)) is
+ * sufficient to guarantee NIC visibility before the doorbell is rung.
+ *
+ * Variables used only for GPU thread synchronisation (lock, sq.post,
+ * sq.depth_mask) retain their existing store semantics — they are not
+ * read by the NIC and do not require cache bypassing.
+ */
+__device__ void QueuePair::mlx5_post_wqe_rma_av(int32_t length, uintptr_t raddr,
+    uint32_t rkey, uintptr_t laddr, uint32_t lkey,
+    uint8_t opcode, ActiveWFInfo &wf_info, bool ring_db) {
+  if (wf_info.is_pe_group_last) {
+    acquire_lock(&mlx5_sq.lock);
+    mlx5_poll_cq_until(wf_info.num_pe_group_lanes);
+  }
+
+  uint16_t wqe_idx = mlx5_wqe_idx(mlx5_sq, wf_info.pe_group_logical_lane_id);
+  uint16_t sq_idx = mlx5_sq_idx(mlx5_sq, wqe_idx);
+
+  bool send_inline = gda_mlx5_wqe_rma::can_inline(opcode, length, inline_threshold);
+
+  // construct WQE on the stack (unchanged)
+  gda_mlx5_wqe wqe{wqe_idx, opcode, qp_num, MLX5_WQE_CTRL_CQ_UPDATE,
+                   raddr, byteswap<uint32_t>(rkey), laddr, byteswap<uint32_t>(lkey),
+                   static_cast<uint32_t>(length), send_inline};
+
+  // Copy WQE to SQ using cache-bypassing (SystemScope) stores so HBM
+  // receives the data directly.  The NIC will DMA-read from HBM, and
+  // fence_targeted() in mlx5_ring_doorbell_av() ensures these stores are
+  // complete before the doorbell is visible to the NIC.
+  //
+  // The WQE is a stack-local value; load each 16-byte chunk with standard
+  // (cached) policy, then store to the SQ buffer with SystemScope (sc0 sc1)
+  // to bypass L1/L2 and write directly to HBM.
+  static_assert(sizeof(gda_mlx5_wqe) == 64, "WQE must be 64 bytes");
+  using Chunk = typename AsmAccess<16>::type;
+  auto* dst = reinterpret_cast<uint8_t*>(&mlx5_sq.buf[sq_idx]);
+  auto* src = reinterpret_cast<const uint8_t*>(&wqe);
+  for (int i = 0; i < 4; ++i) {
+    Chunk val = *reinterpret_cast<const Chunk*>(src + i * 16);
+    AsmAccess<16, CachePolicy::Standard,
+              CachePolicy::SystemScope>::store(dst + i * 16, val);
+  }
+
+  if (wf_info.is_pe_group_last) {
+    // sq.post is GPU-side bookkeeping only — plain store is fine.
+    mlx5_sq.post += wf_info.num_pe_group_lanes;
+    if (ring_db) {
+      mlx5_ring_doorbell_av(mlx5_sq.post, wqe);
+    }
     release_lock(&mlx5_sq.lock);
   }
 }

--- a/projects/rocshmem/src/gda/mlx5/queue_pair_mlx5.cpp
+++ b/projects/rocshmem/src/gda/mlx5/queue_pair_mlx5.cpp
@@ -101,14 +101,15 @@ __device__ void QueuePair::mlx5_ring_doorbell(uint64_t sq_post, const gda_mlx5_w
 /**
  * @brief Targeted-ordering variant of mlx5_ring_doorbell.
  *
- * Replaces system-scope release stores with fence_targeted() +
+ * Replaces system-scope release stores with wait_on_vmem(0) +
  * relaxed system-scope stores:
- *   - fence_targeted() (s_waitcnt vmcnt(0)) before dbrec: ensures all
- *     preceding cache-bypassing WQE stores have reached HBM before the
- *     NIC reads the doorbell record.
- *   - Relaxed system-scope store for dbrec (sc0 sc1, no preceding buffer_wbl2).
- *   - fence_targeted() between dbrec and doorbell register: ensures dbrec
- *     is visible before the NIC is notified via the BlueFlame write.
+ *   - wait_on_vmem(0) before dbrec: drains all in-flight VMEM ops (including
+ *     cache-bypassing WQE stores) so they are committed to HBM before the
+ *     NIC reads the doorbell record.  Portable across GFX9/GFX10/GFX12.
+ *   - Relaxed system-scope store for dbrec (sc0 sc1, no L2 writeback needed
+ *     because preceding WQE stores used cache bypass).
+ *   - wait_on_vmem(0) between dbrec and doorbell register: ensures the dbrec
+ *     store is complete before the NIC is notified via the BlueFlame write.
  *   - Relaxed system-scope store for the doorbell register (MMIO, uncacheable).
  */
 __device__ void QueuePair::mlx5_ring_doorbell_av(uint64_t sq_post, const gda_mlx5_wqe& wqe) {
@@ -120,10 +121,10 @@ __device__ void QueuePair::mlx5_ring_doorbell_av(uint64_t sq_post, const gda_mlx
 
   // Drain all outstanding VMEM ops (including WQE cache-bypassing stores)
   // before making the doorbell record visible to the NIC.
-  fence_targeted();
+  wait_on_vmem(0);
   __hip_atomic_store(mlx5_sq.dbrec, be_sq_wqebb_counter, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
   // Order dbrec store before the doorbell register write.
-  fence_targeted();
+  wait_on_vmem(0);
   __hip_atomic_store(&bf->db_reg, db_val, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
 }
 
@@ -329,7 +330,7 @@ __device__ void QueuePair::mlx5_post_wqe_rma(int32_t length, uintptr_t raddr,
  *
  * Uses cache-bypassing stores (sc0 sc1) for the WQE copy so data is
  * written directly to HBM without populating the GPU's L1/L2 cache.
- * This is required so that fence_targeted() (s_waitcnt vmcnt(0)) is
+ * This is required so that wait_on_vmem(0) is
  * sufficient to guarantee NIC visibility before the doorbell is rung.
  *
  * Variables used only for GPU thread synchronisation (lock, sq.post,
@@ -356,7 +357,7 @@ __device__ void QueuePair::mlx5_post_wqe_rma_av(int32_t length, uintptr_t raddr,
 
   // Copy WQE to SQ using cache-bypassing (SystemScope) stores so HBM
   // receives the data directly.  The NIC will DMA-read from HBM, and
-  // fence_targeted() in mlx5_ring_doorbell_av() ensures these stores are
+  // wait_on_vmem(0) in mlx5_ring_doorbell_av() ensures these stores are
   // complete before the doorbell is visible to the NIC.
   //
   // The WQE is a stack-local value; load each 16-byte chunk with standard

--- a/projects/rocshmem/src/gda/queue_pair.cpp
+++ b/projects/rocshmem/src/gda/queue_pair.cpp
@@ -167,6 +167,24 @@ __device__ void QueuePair::post_wqe_rma(
   }
 }
 
+__device__ void QueuePair::post_wqe_rma_av(
+    int32_t length, uintptr_t raddr, uint32_t rkey,
+    uintptr_t laddr, uint32_t lkey,
+    uint8_t opcode, ActiveWFInfo &wf_info, bool ring_db) {
+  switch (constmem.gda_provider) {
+#if defined(GDA_MLX5)
+  case GDAProvider::MLX5:
+    mlx5_post_wqe_rma_av(length, raddr, rkey, laddr, lkey, opcode, wf_info, ring_db);
+    return;
+#endif
+  default:
+    // _av optimisation not implemented for this provider; fall back to
+    // standard semantics which are always correct.
+    post_wqe_rma(length, raddr, rkey, laddr, lkey, opcode, wf_info, ring_db);
+    return;
+  }
+}
+
 __device__ void QueuePair::post_wqe_rma_single(int32_t length,
     uintptr_t laddr, uint32_t lkey, uintptr_t raddr, uint32_t rkey,
     uint8_t opcode, bool ring_db) {
@@ -309,6 +327,17 @@ __device__ void QueuePair::put_nbi(void *raddr, uint32_t rkey,
 }
 
 // Used in all to all
+__device__ void QueuePair::put_nbi_av(void *dest, const void *source,
+    size_t length, ActiveWFInfo &wf_info) {
+  uint32_t dst_rkey = rkey;
+  uint32_t src_lkey = (static_cast<int32_t>(length) <= static_cast<int32_t>(inline_threshold))
+      ? 0 : get_lkey(reinterpret_cast<uintptr_t>(source));
+  uintptr_t l = reinterpret_cast<uintptr_t>(source);
+  uintptr_t r = reinterpret_cast<uintptr_t>(dest);
+  post_wqe_rma_av(static_cast<int32_t>(length), r, dst_rkey, l, src_lkey,
+                  gda_op_rdma_write, wf_info, /*ring_db=*/true);
+}
+
 __device__ void QueuePair::put_nbi_single(void *dest, const void *source,
     size_t length, bool ring_db) {
   uintptr_t src = reinterpret_cast<uintptr_t>(source);

--- a/projects/rocshmem/src/gda/queue_pair.cpp
+++ b/projects/rocshmem/src/gda/queue_pair.cpp
@@ -141,24 +141,27 @@ __device__ uint64_t QueuePair::get_same_qp_lane_mask() {
 /******************************************************************************
  ************************ PROVIDER-SPECIFIC HELPERS ***************************
  *****************************************************************************/
-__device__ void QueuePair::post_wqe_rma(
+template <OrderingMode Mode>
+__device__ void QueuePair::post_wqe_rma_impl(
     int32_t length, uintptr_t raddr, uint32_t rkey,
     uintptr_t laddr, uint32_t lkey,
     uint8_t opcode, ActiveWFInfo &wf_info, bool ring_db) {
   switch (constmem.gda_provider) {
+#if defined(GDA_MLX5)
+  case GDAProvider::MLX5:
+    mlx5_post_wqe_rma_impl<Mode>(length, raddr, rkey, laddr, lkey, opcode, wf_info, ring_db);
+    return;
+#endif
 #if defined(GDA_IONIC)
   case GDAProvider::IONIC:
+    // IONIC does not implement targeted ordering; Standard semantics are used.
     ionic_post_wqe_rma(length, raddr, rkey, laddr, lkey, opcode, wf_info, ring_db);
     return;
 #endif
 #if defined(GDA_BNXT)
   case GDAProvider::BNXT:
+    // BNXT does not implement targeted ordering; Standard semantics are used.
     bnxt_post_wqe_rma(length, raddr, rkey, laddr, lkey, opcode, wf_info, ring_db);
-    return;
-#endif
-#if defined(GDA_MLX5)
-  case GDAProvider::MLX5:
-    mlx5_post_wqe_rma(length, raddr, rkey, laddr, lkey, opcode, wf_info, ring_db);
     return;
 #endif
   default:
@@ -167,22 +170,18 @@ __device__ void QueuePair::post_wqe_rma(
   }
 }
 
+__device__ void QueuePair::post_wqe_rma(
+    int32_t length, uintptr_t raddr, uint32_t rkey,
+    uintptr_t laddr, uint32_t lkey,
+    uint8_t opcode, ActiveWFInfo &wf_info, bool ring_db) {
+  post_wqe_rma_impl<OrderingMode::Standard>(length, raddr, rkey, laddr, lkey, opcode, wf_info, ring_db);
+}
+
 __device__ void QueuePair::post_wqe_rma_av(
     int32_t length, uintptr_t raddr, uint32_t rkey,
     uintptr_t laddr, uint32_t lkey,
     uint8_t opcode, ActiveWFInfo &wf_info, bool ring_db) {
-  switch (constmem.gda_provider) {
-#if defined(GDA_MLX5)
-  case GDAProvider::MLX5:
-    mlx5_post_wqe_rma_av(length, raddr, rkey, laddr, lkey, opcode, wf_info, ring_db);
-    return;
-#endif
-  default:
-    // _av optimisation not implemented for this provider; fall back to
-    // standard semantics which are always correct.
-    post_wqe_rma(length, raddr, rkey, laddr, lkey, opcode, wf_info, ring_db);
-    return;
-  }
+  post_wqe_rma_impl<OrderingMode::Targeted>(length, raddr, rkey, laddr, lkey, opcode, wf_info, ring_db);
 }
 
 __device__ void QueuePair::post_wqe_rma_single(int32_t length,
@@ -309,12 +308,21 @@ __device__ void QueuePair::quiet_single() {
 /******************************************************************************
  ****************************** SHMEM INTERFACE *******************************
  *****************************************************************************/
-__device__ void QueuePair::put_nbi(void *dest, const void *source,
+template <OrderingMode Mode>
+__device__ void QueuePair::put_nbi_impl(void *dest, const void *source,
     size_t length, ActiveWFInfo &wf_info) {
   uint32_t dst_rkey = rkey;
   uint32_t src_lkey = (static_cast<int32_t>(length) <= static_cast<int32_t>(inline_threshold))
       ? 0 : get_lkey(reinterpret_cast<uintptr_t>(source));
-  put_nbi(dest, dst_rkey, source, src_lkey, length, wf_info);
+  uintptr_t l = reinterpret_cast<uintptr_t>(source);
+  uintptr_t r = reinterpret_cast<uintptr_t>(dest);
+  post_wqe_rma_impl<Mode>(static_cast<int32_t>(length), r, dst_rkey, l, src_lkey,
+                          gda_op_rdma_write, wf_info, /*ring_db=*/true);
+}
+
+__device__ void QueuePair::put_nbi(void *dest, const void *source,
+    size_t length, ActiveWFInfo &wf_info) {
+  put_nbi_impl<OrderingMode::Standard>(dest, source, length, wf_info);
 }
 
 __device__ void QueuePair::put_nbi(void *raddr, uint32_t rkey,
@@ -322,20 +330,13 @@ __device__ void QueuePair::put_nbi(void *raddr, uint32_t rkey,
     size_t length, ActiveWFInfo &wf_info, bool ring_db) {
   uintptr_t l = reinterpret_cast<uintptr_t>(laddr);
   uintptr_t r = reinterpret_cast<uintptr_t>(raddr);
-  post_wqe_rma(static_cast<int32_t>(length), r, rkey, l, lkey,
-               gda_op_rdma_write, wf_info, ring_db);
+  post_wqe_rma_impl<OrderingMode::Standard>(static_cast<int32_t>(length), r, rkey, l, lkey,
+                                            gda_op_rdma_write, wf_info, ring_db);
 }
 
-// Used in all to all
 __device__ void QueuePair::put_nbi_av(void *dest, const void *source,
     size_t length, ActiveWFInfo &wf_info) {
-  uint32_t dst_rkey = rkey;
-  uint32_t src_lkey = (static_cast<int32_t>(length) <= static_cast<int32_t>(inline_threshold))
-      ? 0 : get_lkey(reinterpret_cast<uintptr_t>(source));
-  uintptr_t l = reinterpret_cast<uintptr_t>(source);
-  uintptr_t r = reinterpret_cast<uintptr_t>(dest);
-  post_wqe_rma_av(static_cast<int32_t>(length), r, dst_rkey, l, src_lkey,
-                  gda_op_rdma_write, wf_info, /*ring_db=*/true);
+  put_nbi_impl<OrderingMode::Targeted>(dest, source, length, wf_info);
 }
 
 __device__ void QueuePair::put_nbi_single(void *dest, const void *source,
@@ -512,6 +513,12 @@ __device__ uint32_t QueuePair::get_lkey(uintptr_t addr) {
   LOGD_ERROR_ABORT("Valid lkey buffer not found");
   return 0;
 }
+
+// Explicit device template instantiations (required with -fgpu-rdc)
+template __device__ void QueuePair::post_wqe_rma_impl<OrderingMode::Standard>(int32_t, uintptr_t, uint32_t, uintptr_t, uint32_t, uint8_t, ActiveWFInfo&, bool);
+template __device__ void QueuePair::post_wqe_rma_impl<OrderingMode::Targeted>(int32_t, uintptr_t, uint32_t, uintptr_t, uint32_t, uint8_t, ActiveWFInfo&, bool);
+template __device__ void QueuePair::put_nbi_impl<OrderingMode::Standard>(void*, const void*, size_t, ActiveWFInfo&);
+template __device__ void QueuePair::put_nbi_impl<OrderingMode::Targeted>(void*, const void*, size_t, ActiveWFInfo&);
 
 }  // namespace rocshmem
 

--- a/projects/rocshmem/src/gda/queue_pair.hpp
+++ b/projects/rocshmem/src/gda/queue_pair.hpp
@@ -168,6 +168,10 @@ class QueuePair {
    * @param[in] length Size in bytes of data transmission.
    * @param[in] wf_info Wavefront information.
    */
+  template <OrderingMode Mode = OrderingMode::Standard>
+  __device__ void put_nbi_impl(void *dest, const void *source, size_t length,
+      ActiveWFInfo &wf_info);
+
   __device__ void put_nbi(void *dest, const void *source, size_t length,
       ActiveWFInfo &wf_info);
 
@@ -348,12 +352,17 @@ class QueuePair {
    * @param[in] wf_info Wavefront information.
    * @param[in] ring_db Ring doorbell after posting.
    */
+  template <OrderingMode Mode>
+  __device__ __attribute__((noinline)) void
+  post_wqe_rma_impl(int32_t length, uintptr_t raddr, uint32_t rkey,
+      uintptr_t laddr, uint32_t lkey,
+      uint8_t opcode, ActiveWFInfo &wf_info, bool ring_db);
+
   __device__ __attribute__((noinline)) void
   post_wqe_rma(int32_t length, uintptr_t raddr, uint32_t rkey,
       uintptr_t laddr, uint32_t lkey,
       uint8_t opcode, ActiveWFInfo &wf_info, bool ring_db);
 
-  /** Targeted-ordering variant: dispatches to mlx5_post_wqe_rma_av on MLX5. */
   __device__ __attribute__((noinline)) void
   post_wqe_rma_av(int32_t length, uintptr_t raddr, uint32_t rkey,
       uintptr_t laddr, uint32_t lkey,
@@ -419,8 +428,15 @@ class QueuePair {
    * @param[in] db_val Doorbell value is written by method.
    */
 #if defined(GDA_MLX5)
+  template <OrderingMode Mode>
+  __device__ void mlx5_ring_doorbell_impl(uint64_t sq_post, const gda_mlx5_wqe& wqe);
   __device__ void mlx5_ring_doorbell(uint64_t sq_post, const gda_mlx5_wqe& wqe);
   __device__ void mlx5_ring_doorbell_av(uint64_t sq_post, const gda_mlx5_wqe& wqe);
+
+  template <OrderingMode Mode>
+  __device__ void mlx5_post_wqe_rma_impl(int32_t length, uintptr_t raddr,
+      uint32_t rkey, uintptr_t laddr, uint32_t lkey,
+      uint8_t opcode, ActiveWFInfo &wf_info, bool ring_db);
 #endif
 #if defined(GDA_BNXT)
   __device__ void bnxt_ring_doorbell(uint32_t slot_idx);

--- a/projects/rocshmem/src/gda/queue_pair.hpp
+++ b/projects/rocshmem/src/gda/queue_pair.hpp
@@ -171,7 +171,7 @@ class QueuePair {
   __device__ void put_nbi(void *dest, const void *source, size_t length,
       ActiveWFInfo &wf_info);
 
-  /** Targeted-ordering variant: cache-bypassing WQE stores + fence_targeted doorbell. */
+  /** Targeted-ordering variant: cache-bypassing WQE stores + wait_on_vmem(0) doorbell. */
   __device__ void put_nbi_av(void *dest, const void *source, size_t length,
       ActiveWFInfo &wf_info);
 

--- a/projects/rocshmem/src/gda/queue_pair.hpp
+++ b/projects/rocshmem/src/gda/queue_pair.hpp
@@ -171,6 +171,10 @@ class QueuePair {
   __device__ void put_nbi(void *dest, const void *source, size_t length,
       ActiveWFInfo &wf_info);
 
+  /** Targeted-ordering variant: cache-bypassing WQE stores + fence_targeted doorbell. */
+  __device__ void put_nbi_av(void *dest, const void *source, size_t length,
+      ActiveWFInfo &wf_info);
+
   __device__ void put_nbi_single(void *dest, const void *source, size_t length,
       bool ring_db);
 
@@ -349,6 +353,12 @@ class QueuePair {
       uintptr_t laddr, uint32_t lkey,
       uint8_t opcode, ActiveWFInfo &wf_info, bool ring_db);
 
+  /** Targeted-ordering variant: dispatches to mlx5_post_wqe_rma_av on MLX5. */
+  __device__ __attribute__((noinline)) void
+  post_wqe_rma_av(int32_t length, uintptr_t raddr, uint32_t rkey,
+      uintptr_t laddr, uint32_t lkey,
+      uint8_t opcode, ActiveWFInfo &wf_info, bool ring_db);
+
   __device__ __attribute__((noinline)) void
   post_wqe_rma_single(int32_t length, uintptr_t laddr, uint32_t lkey,
       uintptr_t raddr, uint32_t rkey, uint8_t opcode, bool ring_db);
@@ -361,6 +371,9 @@ class QueuePair {
       uint32_t lkey, uintptr_t raddr, uint32_t rkey,
       uint8_t opcode, bool ring_db);
   __device__ void mlx5_post_wqe_rma(int32_t length, uintptr_t raddr,
+      uint32_t rkey, uintptr_t laddr, uint32_t lkey,
+      uint8_t opcode, ActiveWFInfo &wf_info, bool ring_db);
+  __device__ void mlx5_post_wqe_rma_av(int32_t length, uintptr_t raddr,
       uint32_t rkey, uintptr_t laddr, uint32_t lkey,
       uint8_t opcode, ActiveWFInfo &wf_info, bool ring_db);
   __device__ void mlx5_quiet();
@@ -407,6 +420,7 @@ class QueuePair {
    */
 #if defined(GDA_MLX5)
   __device__ void mlx5_ring_doorbell(uint64_t sq_post, const gda_mlx5_wqe& wqe);
+  __device__ void mlx5_ring_doorbell_av(uint64_t sq_post, const gda_mlx5_wqe& wqe);
 #endif
 #if defined(GDA_BNXT)
   __device__ void bnxt_ring_doorbell(uint32_t slot_idx);

--- a/projects/rocshmem/src/ipc/backend_ipc.cpp
+++ b/projects/rocshmem/src/ipc/backend_ipc.cpp
@@ -382,6 +382,7 @@ void IPCBackend::initIPC() {
   ipcImpl.ipcHostInit(my_pe, heap_bases,
                       backend_comm);
   ipcImpl.heap_size = heap.get_size();
+  ipcImpl.bypass_lane_stores = envvar::bypass_lane_stores;
 }
 
 void IPCBackend::initIPC(TcpBootstrap *bootstr) {
@@ -390,6 +391,7 @@ void IPCBackend::initIPC(TcpBootstrap *bootstr) {
   ipcImpl.ipcHostInit(my_pe, heap_bases,
                       bootstr);
   ipcImpl.heap_size = heap.get_size();
+  ipcImpl.bypass_lane_stores = envvar::bypass_lane_stores;
 }
 
 void IPCBackend::global_exit(int status) {

--- a/projects/rocshmem/src/ipc/context_ipc_device.cpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device.cpp
@@ -75,12 +75,26 @@ __device__ void IPCContext::getmem_nbi(void *dest, const void *source,
 }
 
 __device__ void IPCContext::fence() {
-  ipcImpl_.ipcFence();
+  __builtin_amdgcn_fence(__ATOMIC_RELEASE, "");
 }
 
 __device__ void IPCContext::fence(int pe) {
-  ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
-                    detail::atomic::memory_order_release>(pe);
+  __builtin_amdgcn_fence(__ATOMIC_RELEASE, "");
+}
+
+__device__ void IPCContext::putmem_nbi_wave_av(void *dest, const void *source,
+                                              size_t nelems, int pe) {
+  // IPC wave puts already use cache-bypassing stores in ipcCopy_wave;
+  // no additional _av semantics required on the intranode path.
+  putmem_nbi_wave(dest, source, nelems, pe);
+}
+
+__device__ void IPCContext::fence_av() {
+  fence_targeted();
+}
+
+__device__ void IPCContext::fence_av(int pe) {
+  fence_targeted();
 }
 
 __device__ void IPCContext::quiet() {
@@ -101,6 +115,24 @@ __device__ void IPCContext::putmem_wg(void *dest, const void *source,
   ipcImpl_.ipcCopy_wg<MemcpyKind::PutBlocking>(
       remote, const_cast<void *>(source), nelems, pe);
   __builtin_amdgcn_s_barrier();
+}
+
+__device__ void IPCContext::putmem_wg_av(void *dest, const void *source,
+                                        size_t nelems, int pe) {
+  /**
+   * Targeted-ordering blocking WG put.
+   *
+   * Uses ipcCopy_wg<Put> (non-blocking, sc0 sc1 stores) + s_barrier +
+   * fence_targeted() in place of ipcCopy_wg<PutBlocking> which internally
+   * issues a full system-scope release fence.  fence_targeted() =
+   * s_waitcnt vmcnt(0) is sufficient because the sc0 sc1 stores write
+   * directly to HBM without populating the L2 cache.
+   */
+  uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[my_pe];
+  ipcImpl_.ipcCopy_wg<MemcpyKind::Put>(
+      ipcImpl_.ipc_bases[pe] + L_offset, const_cast<void *>(source), nelems, pe);
+  __builtin_amdgcn_s_barrier();
+  fence_targeted();
 }
 
 __device__ void IPCContext::getmem_wg(void *dest, const void *source,

--- a/projects/rocshmem/src/ipc/context_ipc_device.cpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device.cpp
@@ -75,11 +75,12 @@ __device__ void IPCContext::getmem_nbi(void *dest, const void *source,
 }
 
 __device__ void IPCContext::fence() {
-  __builtin_amdgcn_fence(__ATOMIC_RELEASE, "");
+  ipcImpl_.ipcFence();
 }
 
 __device__ void IPCContext::fence(int pe) {
-  __builtin_amdgcn_fence(__ATOMIC_RELEASE, "");
+  ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
+                    detail::atomic::memory_order_release>(pe);
 }
 
 __device__ void IPCContext::putmem_nbi_wave_av(void *dest, const void *source,
@@ -90,11 +91,11 @@ __device__ void IPCContext::putmem_nbi_wave_av(void *dest, const void *source,
 }
 
 __device__ void IPCContext::fence_av() {
-  fence_targeted();
+  wait_on_vmem(0);
 }
 
 __device__ void IPCContext::fence_av(int pe) {
-  fence_targeted();
+  wait_on_vmem(0);
 }
 
 __device__ void IPCContext::quiet() {
@@ -123,8 +124,8 @@ __device__ void IPCContext::putmem_wg_av(void *dest, const void *source,
    * Targeted-ordering blocking WG put.
    *
    * Uses ipcCopy_wg<Put> (non-blocking, sc0 sc1 stores) + s_barrier +
-   * fence_targeted() in place of ipcCopy_wg<PutBlocking> which internally
-   * issues a full system-scope release fence.  fence_targeted() =
+   * wait_on_vmem(0) in place of ipcCopy_wg<PutBlocking> which internally
+   * issues a full system-scope release fence.  wait_on_vmem(0) =
    * s_waitcnt vmcnt(0) is sufficient because the sc0 sc1 stores write
    * directly to HBM without populating the L2 cache.
    */
@@ -132,7 +133,7 @@ __device__ void IPCContext::putmem_wg_av(void *dest, const void *source,
   ipcImpl_.ipcCopy_wg<MemcpyKind::Put>(
       ipcImpl_.ipc_bases[pe] + L_offset, const_cast<void *>(source), nelems, pe);
   __builtin_amdgcn_s_barrier();
-  fence_targeted();
+  wait_on_vmem(0);
 }
 
 __device__ void IPCContext::getmem_wg(void *dest, const void *source,

--- a/projects/rocshmem/src/ipc/context_ipc_device.cpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device.cpp
@@ -74,14 +74,29 @@ __device__ void IPCContext::getmem_nbi(void *dest, const void *source,
   ipcImpl_.ipcCopy<MemcpyKind::Get>(dest, remote, nelems, pe);
 }
 
-__device__ void IPCContext::fence() {
-  ipcImpl_.ipcFence();
+template <OrderingMode Mode>
+__device__ void IPCContext::fence_impl() {
+  if constexpr (is_targeted(Mode)) {
+    wait_on_vmem(0);
+  } else {
+    ipcImpl_.ipcFence();
+  }
 }
 
-__device__ void IPCContext::fence(int pe) {
-  ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
-                    detail::atomic::memory_order_release>(pe);
+template <OrderingMode Mode>
+__device__ void IPCContext::fence_impl(int pe) {
+  if constexpr (is_targeted(Mode)) {
+    wait_on_vmem(0);
+  } else {
+    ipcImpl_.ipcFence<detail::atomic::memory_scope_system,
+                      detail::atomic::memory_order_release>(pe);
+  }
 }
+
+__device__ void IPCContext::fence()          { fence_impl<OrderingMode::Standard>(); }
+__device__ void IPCContext::fence(int pe)    { fence_impl<OrderingMode::Standard>(pe); }
+__device__ void IPCContext::fence_av()       { fence_impl<OrderingMode::Targeted>(); }
+__device__ void IPCContext::fence_av(int pe) { fence_impl<OrderingMode::Targeted>(pe); }
 
 __device__ void IPCContext::putmem_nbi_wave_av(void *dest, const void *source,
                                               size_t nelems, int pe) {
@@ -90,13 +105,6 @@ __device__ void IPCContext::putmem_nbi_wave_av(void *dest, const void *source,
   putmem_nbi_wave(dest, source, nelems, pe);
 }
 
-__device__ void IPCContext::fence_av() {
-  wait_on_vmem(0);
-}
-
-__device__ void IPCContext::fence_av(int pe) {
-  wait_on_vmem(0);
-}
 
 __device__ void IPCContext::quiet() {
   ipcImpl_.ipcQuiet();
@@ -110,30 +118,41 @@ __device__ void *IPCContext::shmem_ptr(const void *dest, int pe) {
   return ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe);
 }
 
+/**
+ * @brief Blocking WG put to an IPC-local peer.
+ *
+ * OrderingMode::Standard  — ipcCopy_wg<PutBlocking> which issues a full
+ *   system-scope release fence after the copy.
+ *
+ * OrderingMode::Targeted  — ipcCopy_wg<Put> (cache-bypassing sc0 sc1 stores,
+ *   non-blocking) followed by s_barrier + wait_on_vmem(0); no L2 writeback
+ *   needed since data went directly to HBM.
+ */
+template <OrderingMode Mode>
+__device__ void IPCContext::putmem_wg_impl(void *dest, const void *source,
+                                           size_t nelems, int pe) {
+  if constexpr (is_targeted(Mode)) {
+    uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[my_pe];
+    ipcImpl_.ipcCopy_wg<MemcpyKind::Put>(
+        ipcImpl_.ipc_bases[pe] + L_offset, const_cast<void *>(source), nelems, pe);
+    __builtin_amdgcn_s_barrier();
+    wait_on_vmem(0);
+  } else {
+    char *remote = ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe);
+    ipcImpl_.ipcCopy_wg<MemcpyKind::PutBlocking>(
+        remote, const_cast<void *>(source), nelems, pe);
+    __builtin_amdgcn_s_barrier();
+  }
+}
+
 __device__ void IPCContext::putmem_wg(void *dest, const void *source,
                                      size_t nelems, int pe) {
-  char *remote = ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe);
-  ipcImpl_.ipcCopy_wg<MemcpyKind::PutBlocking>(
-      remote, const_cast<void *>(source), nelems, pe);
-  __builtin_amdgcn_s_barrier();
+  putmem_wg_impl<OrderingMode::Standard>(dest, source, nelems, pe);
 }
 
 __device__ void IPCContext::putmem_wg_av(void *dest, const void *source,
-                                        size_t nelems, int pe) {
-  /**
-   * Targeted-ordering blocking WG put.
-   *
-   * Uses ipcCopy_wg<Put> (non-blocking, sc0 sc1 stores) + s_barrier +
-   * wait_on_vmem(0) in place of ipcCopy_wg<PutBlocking> which internally
-   * issues a full system-scope release fence.  wait_on_vmem(0) =
-   * s_waitcnt vmcnt(0) is sufficient because the sc0 sc1 stores write
-   * directly to HBM without populating the L2 cache.
-   */
-  uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[my_pe];
-  ipcImpl_.ipcCopy_wg<MemcpyKind::Put>(
-      ipcImpl_.ipc_bases[pe] + L_offset, const_cast<void *>(source), nelems, pe);
-  __builtin_amdgcn_s_barrier();
-  wait_on_vmem(0);
+                                         size_t nelems, int pe) {
+  putmem_wg_impl<OrderingMode::Targeted>(dest, source, nelems, pe);
 }
 
 __device__ void IPCContext::getmem_wg(void *dest, const void *source,
@@ -334,5 +353,13 @@ __device__ int IPCContext::tile_collective_wait([[maybe_unused]] rocshmem_team_t
   LOGD_WARN("Tile API not implemented for IPC backend");
   return ROCSHMEM_ERROR;
 }
+
+// Explicit device template instantiations (required with -fgpu-rdc)
+template __device__ void IPCContext::fence_impl<OrderingMode::Standard>();
+template __device__ void IPCContext::fence_impl<OrderingMode::Targeted>();
+template __device__ void IPCContext::fence_impl<OrderingMode::Standard>(int);
+template __device__ void IPCContext::fence_impl<OrderingMode::Targeted>(int);
+template __device__ void IPCContext::putmem_wg_impl<OrderingMode::Standard>(void*, const void*, size_t, int);
+template __device__ void IPCContext::putmem_wg_impl<OrderingMode::Targeted>(void*, const void*, size_t, int);
 
 }  // namespace rocshmem

--- a/projects/rocshmem/src/ipc/context_ipc_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device.hpp
@@ -51,6 +51,16 @@ class IPCContext : public Context {
 
   __device__ void fence(int pe);
 
+  __device__ void fence_av();
+
+  __device__ void fence_av(int pe);
+
+  __device__ void putmem_nbi_wave_av(void *dest, const void *source,
+                                     size_t nelems, int pe);
+
+  template <typename T>
+  __device__ void put_nbi_wave_av(T *dest, const T *source, size_t nelems, int pe);
+
   __device__ void quiet();
 
   __device__ void pe_quiet(size_t pe);
@@ -105,6 +115,9 @@ class IPCContext : public Context {
 
   template <typename T>
   __device__ void amo_set(void *dst, T value, int pe);
+
+  template <typename T>
+  __device__ void amo_set_av(void *dst, T value, int pe);
 
   template <typename T>
   __device__ T amo_swap(void *dst, T value, int pe);
@@ -177,6 +190,9 @@ class IPCContext : public Context {
   // Block/wave functions
   __device__ void putmem_wg(void *dest, const void *source, size_t nelems,
                             int pe);
+
+  __device__ void putmem_wg_av(void *dest, const void *source, size_t nelems,
+                               int pe);
 
   __device__ void getmem_wg(void *dest, const void *source, size_t nelems,
                             int pe);

--- a/projects/rocshmem/src/ipc/context_ipc_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device.hpp
@@ -26,6 +26,7 @@
 #define LIBRARY_SRC_IPC_CONTEXT_DEVICE_HPP_
 
 #include "context.hpp"
+#include "util.hpp"
 #include "atomic.hpp"
 #include "team.hpp"
 
@@ -47,12 +48,12 @@ class IPCContext : public Context {
   __device__ void getmem_nbi(void *dest, const void *source, size_t size,
                              int pe);
 
+  template <OrderingMode Mode> __device__ void fence_impl();
+  template <OrderingMode Mode> __device__ void fence_impl(int pe);
+
   __device__ void fence();
-
   __device__ void fence(int pe);
-
   __device__ void fence_av();
-
   __device__ void fence_av(int pe);
 
   __device__ void putmem_nbi_wave_av(void *dest, const void *source,
@@ -112,6 +113,9 @@ class IPCContext : public Context {
   // Atomic operations
   template <typename T>
   __device__ void amo_add(void *dst, T value, int pe);
+
+  template <typename T, OrderingMode Mode = OrderingMode::Standard>
+  __device__ void amo_set_impl(void *dst, T value, int pe);
 
   template <typename T>
   __device__ void amo_set(void *dst, T value, int pe);
@@ -188,9 +192,11 @@ class IPCContext : public Context {
 
 
   // Block/wave functions
+  template <OrderingMode Mode>
+  __device__ void putmem_wg_impl(void *dest, const void *source, size_t nelems,
+                                 int pe);
   __device__ void putmem_wg(void *dest, const void *source, size_t nelems,
                             int pe);
-
   __device__ void putmem_wg_av(void *dest, const void *source, size_t nelems,
                                int pe);
 

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -85,6 +85,12 @@ __device__ void IPCContext::amo_set(void *dest, T value, int pe) {
 }
 
 template <typename T>
+__device__ void IPCContext::amo_set_av(void *dest, T value, int pe) {
+  uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[my_pe];
+  ipcImpl_.ipcAMOSet_av(reinterpret_cast<T *>(ipcImpl_.ipc_bases[pe] + L_offset), value);
+}
+
+template <typename T>
 __device__ T IPCContext::amo_swap(void *dest, T value, int pe) {
   return ipcImpl_.ipcAMOSwap(
       reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe)), value);
@@ -696,6 +702,11 @@ __device__ void IPCContext::put_wave(T *dest, const T *source, size_t nelems, in
 template <typename T>
 __device__ void IPCContext::put_nbi_wave(T *dest, const T *source, size_t nelems, int pe) {
   putmem_nbi_wave(dest, source, nelems * sizeof(T), pe);
+}
+
+template <typename T>
+__device__ void IPCContext::put_nbi_wave_av(T *dest, const T *source, size_t nelems, int pe) {
+  putmem_nbi_wave_av(dest, source, nelems * sizeof(T), pe);
 }
 
 template <typename T>

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -79,15 +79,24 @@ __device__ void IPCContext::amo_add(void *dest, T value, int pe) {
   ipcImpl_.ipcAMOAdd(reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe)), value);
 }
 
+template <typename T, OrderingMode Mode>
+__device__ void IPCContext::amo_set_impl(void *dest, T value, int pe) {
+  if constexpr (is_targeted(Mode)) {
+    uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[my_pe];
+    ipcImpl_.ipcAMOSet_av(reinterpret_cast<T *>(ipcImpl_.ipc_bases[pe] + L_offset), value);
+  } else {
+    ipcImpl_.ipcAMOSet(reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe)), value);
+  }
+}
+
 template <typename T>
 __device__ void IPCContext::amo_set(void *dest, T value, int pe) {
-  ipcImpl_.ipcAMOSet(reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe)), value);
+  amo_set_impl<T, OrderingMode::Standard>(dest, value, pe);
 }
 
 template <typename T>
 __device__ void IPCContext::amo_set_av(void *dest, T value, int pe) {
-  uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[my_pe];
-  ipcImpl_.ipcAMOSet_av(reinterpret_cast<T *>(ipcImpl_.ipc_bases[pe] + L_offset), value);
+  amo_set_impl<T, OrderingMode::Targeted>(dest, value, pe);
 }
 
 template <typename T>

--- a/projects/rocshmem/src/ipc_policy.hpp
+++ b/projects/rocshmem/src/ipc_policy.hpp
@@ -257,9 +257,16 @@ class IpcOnImpl {
 
   __device__ void ipcGpuInit(Backend *gpu_backend, Context *ctx, int thread_id);
 
+  /**
+   * @brief When true, the large multi-thread memcpy_lane put path uses
+   * cache-bypassing (SystemScope) stores instead of cached writes + fence.
+   * Propagated from ROCSHMEM_BYPASS_LANE_STORES at backend init time.
+   */
+  bool bypass_lane_stores{false};
+
   template <MemcpyKind Kind = MemcpyKind::Put>
   __device__ void ipcCopy(void *dst, void *src, size_t size, [[maybe_unused]] int local_pe) {
-    memcpy_lane<Kind>(dst, src, size);
+    memcpy_lane<Kind>(dst, src, size, bypass_lane_stores);
   }
 
   template <MemcpyKind Kind = MemcpyKind::Put>
@@ -324,6 +331,19 @@ class IpcOnImpl {
   template <typename T>
   __device__ void ipcAMOSet(T *val, T value) {
     __hip_atomic_store(val, value, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_SYSTEM);
+  }
+
+  /**
+   * @brief Targeted-ordering variant of ipcAMOSet.
+   *
+   * Uses __ATOMIC_RELAXED instead of __ATOMIC_SEQ_CST, omitting the
+   * implicit buffer_wbl2 + buffer_inv that SEQ_CST implies on gfx942.
+   * Safe to use after a preceding fence_av() / fence_targeted() that
+   * has already ensured all prior writes are visible to system scope.
+   */
+  template <typename T>
+  __device__ void ipcAMOSet_av(T *val, T value) {
+    __hip_atomic_store(val, value, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
   }
 
   template <typename T>
@@ -568,6 +588,9 @@ class IpcOffImpl {
 
   template <typename T>
   __device__ void ipcAMOSet(T *val, T value) {}
+
+  template <typename T>
+  __device__ void ipcAMOSet_av(T *val, T value) {}
 
   template <typename T>
   __device__ void ipcAMOCas(T *val, T cond, T value) {}

--- a/projects/rocshmem/src/ipc_policy.hpp
+++ b/projects/rocshmem/src/ipc_policy.hpp
@@ -338,7 +338,7 @@ class IpcOnImpl {
    *
    * Uses __ATOMIC_RELAXED instead of __ATOMIC_SEQ_CST, omitting the
    * implicit buffer_wbl2 + buffer_inv that SEQ_CST implies on gfx942.
-   * Safe to use after a preceding fence_av() / fence_targeted() that
+   * Safe to use after a preceding fence_av() / wait_on_vmem(0) that
    * has already ensured all prior writes are visible to system scope.
    */
   template <typename T>

--- a/projects/rocshmem/src/ipc_policy.hpp
+++ b/projects/rocshmem/src/ipc_policy.hpp
@@ -328,22 +328,23 @@ class IpcOnImpl {
     return cond;
   }
 
-  template <typename T>
-  __device__ void ipcAMOSet(T *val, T value) {
-    __hip_atomic_store(val, value, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_SYSTEM);
+  template <typename T, OrderingMode Mode = OrderingMode::Standard>
+  __device__ void ipcAMOSet_impl(T *val, T value) {
+    if constexpr (is_targeted(Mode)) {
+      __hip_atomic_store(val, value, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+    } else {
+      __hip_atomic_store(val, value, __ATOMIC_SEQ_CST, __HIP_MEMORY_SCOPE_SYSTEM);
+    }
   }
 
-  /**
-   * @brief Targeted-ordering variant of ipcAMOSet.
-   *
-   * Uses __ATOMIC_RELAXED instead of __ATOMIC_SEQ_CST, omitting the
-   * implicit buffer_wbl2 + buffer_inv that SEQ_CST implies on gfx942.
-   * Safe to use after a preceding fence_av() / wait_on_vmem(0) that
-   * has already ensured all prior writes are visible to system scope.
-   */
+  template <typename T>
+  __device__ void ipcAMOSet(T *val, T value) {
+    ipcAMOSet_impl<T, OrderingMode::Standard>(val, value);
+  }
+
   template <typename T>
   __device__ void ipcAMOSet_av(T *val, T value) {
-    __hip_atomic_store(val, value, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
+    ipcAMOSet_impl<T, OrderingMode::Targeted>(val, value);
   }
 
   template <typename T>

--- a/projects/rocshmem/src/rocshmem_gpu.cpp
+++ b/projects/rocshmem/src/rocshmem_gpu.cpp
@@ -506,6 +506,21 @@ __device__ void rocshmem_ctx_putmem(rocshmem_ctx_t ctx, void *dest,
   get_internal_ctx(ctx)->putmem(dest, source, nelems, pe_in_world);
 }
 
+__device__ void rocshmem_ctx_putmem_av(rocshmem_ctx_t ctx, void *dest,
+                                        const void *source, size_t nelems,
+                                        int pe) {
+  int pe_in_world = translate_pe(ctx, pe);
+  LOGD_API("device::ctx_putmem_av (ctx=%zd, dest=%p, source=%p, nelems=%zd, pe=%d w%d)",
+    ctx.ctx_opaque, dest, source, nelems, pe, pe_in_world);
+
+  get_internal_ctx(ctx)->putmem_av(dest, source, nelems, pe_in_world);
+}
+
+__device__ void rocshmem_putmem_av(void *dest, const void *source,
+                                    size_t nelems, int pe) {
+  rocshmem_ctx_putmem_av(ROCSHMEM_CTX_DEFAULT, dest, source, nelems, pe);
+}
+
 template <typename T>
 __device__ void rocshmem_put(rocshmem_ctx_t ctx, T *dest, const T *source,
                               size_t nelems, int pe) {
@@ -564,6 +579,21 @@ __device__ void rocshmem_ctx_putmem_nbi(rocshmem_ctx_t ctx, void *dest,
   get_internal_ctx(ctx)->putmem_nbi(dest, source, nelems, pe_in_world);
 }
 
+__device__ void rocshmem_ctx_putmem_nbi_av(rocshmem_ctx_t ctx, void *dest,
+                                            const void *source, size_t nelems,
+                                            int pe) {
+  int pe_in_world = translate_pe(ctx, pe);
+  LOGD_API("device::ctx_putmem_nbi_av (ctx=%zd, dest=%p, source=%p, nelems=%zd, pe=%d w%d)",
+    ctx.ctx_opaque, dest, source, nelems, pe, pe_in_world);
+
+  get_internal_ctx(ctx)->putmem_nbi_av(dest, source, nelems, pe_in_world);
+}
+
+__device__ void rocshmem_putmem_nbi_av(void *dest, const void *source,
+                                        size_t nelems, int pe) {
+  rocshmem_ctx_putmem_nbi_av(ROCSHMEM_CTX_DEFAULT, dest, source, nelems, pe);
+}
+
 template <typename T>
 __device__ void rocshmem_put_nbi(rocshmem_ctx_t ctx, T *dest, const T *source,
                                   size_t nelems, int pe) {
@@ -607,6 +637,28 @@ __device__ void rocshmem_ctx_fence(rocshmem_ctx_t ctx, int pe) {
     ctx.ctx_opaque, pe, pe_in_world);
 
   get_internal_ctx(ctx)->fence(pe_in_world);
+}
+
+__device__ void rocshmem_ctx_fence_av(rocshmem_ctx_t ctx) {
+  LOGD_API("device::ctx_fence_av (ctx=%zd)", ctx.ctx_opaque);
+
+  get_internal_ctx(ctx)->fence_av();
+}
+
+__device__ void rocshmem_fence_av() {
+  rocshmem_ctx_fence_av(ROCSHMEM_CTX_DEFAULT);
+}
+
+__device__ void rocshmem_ctx_fence_av(rocshmem_ctx_t ctx, int pe) {
+  int pe_in_world = translate_pe(ctx, pe);
+  LOGD_API("device::ctx_fence_av (ctx=%zd, pe=%d w%d))",
+    ctx.ctx_opaque, pe, pe_in_world);
+
+  get_internal_ctx(ctx)->fence_av(pe_in_world);
+}
+
+__device__ void rocshmem_fence_av(int pe) {
+  rocshmem_ctx_fence_av(ROCSHMEM_CTX_DEFAULT, pe);
 }
 
 __device__ void rocshmem_ctx_quiet(rocshmem_ctx_t ctx) {
@@ -1217,6 +1269,32 @@ __device__ void rocshmem_ctx_putmem_nbi_wave(rocshmem_ctx_t ctx, void *dest,
     ctx.ctx_opaque, dest, source, nelems, pe, translate_pe(ctx, pe));
 
   get_internal_ctx(ctx)->putmem_nbi_wave(dest, source, nelems, pe);
+}
+
+template <typename T>
+__device__ void rocshmem_put_nbi_wave_av(rocshmem_ctx_t ctx, T *dest,
+                                          const T *source, size_t nelems, int pe) {
+  int pe_in_world = translate_pe(ctx, pe);
+  get_internal_ctx(ctx)->put_nbi_wave_av(dest, source, nelems, pe_in_world);
+}
+
+template <typename T>
+__device__ void rocshmem_put_nbi_wave_av(T *dest, const T *source,
+                                          size_t nelems, int pe) {
+  rocshmem_put_nbi_wave_av(ROCSHMEM_CTX_DEFAULT, dest, source, nelems, pe);
+}
+
+__device__ void rocshmem_ctx_schar_put_nbi_wave_av(rocshmem_ctx_t ctx,
+                                                    signed char *dest,
+                                                    const signed char *source,
+                                                    size_t nelems, int pe) {
+  rocshmem_put_nbi_wave_av<signed char>(ctx, dest, source, nelems, pe);
+}
+
+__device__ void rocshmem_schar_put_nbi_wave_av(signed char *dest,
+                                               const signed char *source,
+                                               size_t nelems, int pe) {
+  rocshmem_put_nbi_wave_av<signed char>(dest, source, nelems, pe);
 }
 
 __device__ void rocshmem_ctx_putmem_nbi_wg(rocshmem_ctx_t ctx, void *dest,
@@ -1972,6 +2050,37 @@ __device__ int rocshmem_team_translate_pe(rocshmem_team_t src_team,
   __device__ int rocshmem_##TNAME##_test(T *ivars, int cmp, T val) {          \
     return rocshmem_test<T>(ivars, cmp, val);                                 \
   }
+
+template <typename T>
+__device__ void rocshmem_wait_until_av(T *ivars, int cmp, T val) {
+  LOGD_API("device::wait_until_av (ivars=%p, cmp=%d, val=%g)",
+    ivars, cmp, (double)val);
+
+  Context *ctx_internal = get_internal_ctx(ROCSHMEM_CTX_DEFAULT);
+  ctx_internal->ctxStats.incStat(NUM_WAIT_UNTIL);
+  ctx_internal->wait_until_av(ivars, cmp, val);
+}
+
+#define WAIT_AV_DEF_GEN(T, TNAME)                                             \
+  __device__ void rocshmem_##TNAME##_wait_until_av(T *ivars, int cmp,        \
+                                                    T val) {                  \
+    rocshmem_wait_until_av<T>(ivars, cmp, val);                               \
+  }
+
+WAIT_AV_DEF_GEN(float, float)
+WAIT_AV_DEF_GEN(double, double)
+WAIT_AV_DEF_GEN(char, char)
+WAIT_AV_DEF_GEN(signed char, schar)
+WAIT_AV_DEF_GEN(short, short)
+WAIT_AV_DEF_GEN(int, int)
+WAIT_AV_DEF_GEN(long, long)
+WAIT_AV_DEF_GEN(long long, longlong)
+WAIT_AV_DEF_GEN(unsigned char, uchar)
+WAIT_AV_DEF_GEN(unsigned short, ushort)
+WAIT_AV_DEF_GEN(unsigned int, uint)
+WAIT_AV_DEF_GEN(unsigned long, ulong)
+WAIT_AV_DEF_GEN(unsigned long long, ulonglong)
+WAIT_AV_DEF_GEN(uint64_t, uint64)
 
 #define RMA_SIGNAL_SUFFIX_DEC(SUFFIX)                                                    \
   template <typename T>                                                                  \

--- a/projects/rocshmem/src/util.hpp
+++ b/projects/rocshmem/src/util.hpp
@@ -498,7 +498,8 @@ __device__ __forceinline__ void copy_remainder(uint8_t* dst,
 // Blocking variants additionally drain all in-flight VMEM ops before returning.
 template <MemcpyKind Kind = MemcpyKind::Put>
 [[maybe_unused]] __device__ __forceinline__ void memcpy_lane(void* dst, void* src,
-                                                             size_t size) {
+                                                             size_t size,
+                                                             bool bypass_stores = false) {
   if (size == 0) return;
 
   constexpr int ChunkSize = 16;
@@ -511,24 +512,48 @@ template <MemcpyKind Kind = MemcpyKind::Put>
   int remainder = static_cast<int>(size % ChunkSize);
 
   if (size >= 16 && get_flat_block_size() > 4) {
-    // Many threads, large transfer: use cached Standard policy.
-    // Fences are direction-specific to maintain system-scope coherence.
+    // Many threads, large transfer.
+    // For gets: issue an acquire fence before loading to ensure prior remote
+    // writes are visible (unchanged regardless of bypass_stores).
     if constexpr (!is_put(Kind)) {
       detail::atomic::threadfence<detail::atomic::memory_scope_system,
                                   detail::atomic::memory_order_acquire>();
     }
 
-    if (n_chunks > 0) {
-      copy_bulk<ChunkSize, CachePolicy::Standard, CachePolicy::Standard, 8>(
-          dst, src, n_chunks, 0, 1);
-    }
-    copy_remainder<CachePolicy::Standard, CachePolicy::Standard>(
-        static_cast<uint8_t*>(dst) + n_chunks * ChunkSize,
-        static_cast<uint8_t*>(src) + n_chunks * ChunkSize, remainder);
-
     if constexpr (is_put(Kind)) {
-      detail::atomic::threadfence<detail::atomic::memory_scope_system,
-                                  detail::atomic::memory_order_release>();
+      if (bypass_stores) {
+        // ROCSHMEM_BYPASS_LANE_STORES=1: use cache-bypassing SystemScope stores
+        // (sc0 sc1 / glc slc). Data is directly visible at system scope without
+        // a subsequent fence.
+        if (n_chunks > 0) {
+          copy_bulk<ChunkSize, CachePolicy::Standard, CachePolicy::SystemScope, 8>(
+              dst, src, n_chunks, 0, 1);
+        }
+        copy_remainder<CachePolicy::Standard, CachePolicy::SystemScope>(
+            static_cast<uint8_t*>(dst) + n_chunks * ChunkSize,
+            static_cast<uint8_t*>(src) + n_chunks * ChunkSize, remainder);
+      } else {
+        // Default: cached Standard stores followed by a system-scope release
+        // fence to flush dirty lines to HBM/fabric.
+        if (n_chunks > 0) {
+          copy_bulk<ChunkSize, CachePolicy::Standard, CachePolicy::Standard, 8>(
+              dst, src, n_chunks, 0, 1);
+        }
+        copy_remainder<CachePolicy::Standard, CachePolicy::Standard>(
+            static_cast<uint8_t*>(dst) + n_chunks * ChunkSize,
+            static_cast<uint8_t*>(src) + n_chunks * ChunkSize, remainder);
+        detail::atomic::threadfence<detail::atomic::memory_scope_system,
+                                    detail::atomic::memory_order_release>();
+      }
+    } else {
+      // Get direction: load policy unchanged, store to local dst is Standard.
+      if (n_chunks > 0) {
+        copy_bulk<ChunkSize, CachePolicy::Standard, CachePolicy::Standard, 8>(
+            dst, src, n_chunks, 0, 1);
+      }
+      copy_remainder<CachePolicy::Standard, CachePolicy::Standard>(
+          static_cast<uint8_t*>(dst) + n_chunks * ChunkSize,
+          static_cast<uint8_t*>(src) + n_chunks * ChunkSize, remainder);
     }
   } else {
     // Small transfer or single-lane: cache-bypass policy provides direct

--- a/projects/rocshmem/src/util.hpp
+++ b/projects/rocshmem/src/util.hpp
@@ -401,6 +401,26 @@ constexpr bool is_blocking(MemcpyKind k) {
   return k == MemcpyKind::PutBlocking || k == MemcpyKind::GetBlocking;
 }
 
+/**
+ * @brief Selects the cache-coherence overhead associated with a rocshmem
+ * fence or synchronisation operation.
+ *
+ * Standard ordering follows the full AMD GPU LLVM memory model: fences emit
+ * system-scope cache actions (L2 writeback / invalidate) in addition to the
+ * hardware completion wait, and atomic operations use SEQ_CST scope.
+ *
+ * Targeted ordering drops the cache actions.  It relies on prior stores
+ * having used cache-bypassing (sc0 sc1 / CachePolicy::SystemScope) access so
+ * that data is already in HBM; a simple wait_on_vmem(0) is then sufficient
+ * to establish ordering.  This corresponds to the "availability/visibility"
+ * (av) relaxation in the AMDGPU memory model documentation.
+ */
+enum class OrderingMode { Standard, Targeted };
+
+constexpr bool is_targeted(OrderingMode m) noexcept {
+  return m == OrderingMode::Targeted;
+}
+
 template <int ChunkSize, CachePolicy LoadPolicy, CachePolicy StorePolicy, int Unroll>
 __device__ __forceinline__ void copy_bulk(void* dst, void* src,
                                           int n_chunks, int tid, int stride) {


### PR DESCRIPTION
Adds _av-suffix variants of rocshmem operations that relax MakeAvailable/ MakeVisible ordering semantics. When enabled, rocshmem operations still establish hb ordering, but they don't establish availability/visibility as defined in the AMD GPU LLVM memory model
(https://llvm.org/docs/AMDGPUMemoryModel.html#availability-and-visibility). Practically, this means that ordering semantics like fences are lowered to a blocking waitcnt rather than a waitcnt plus cache actions (L1/L2 flush or invalidate), but it also requires that accesses that are ordered by these semantics use cache-bypassing available/visible semantics to avoid data races.

- fence_av() / fence_av(int pe): GDA context fence with relaxed ordering
- putmem_nbi_wave_av / put_nbi_wave_av: wave-level NBI put variants
- putmem_wg_av: WG-level blocking put with targeted ordering
- ipcAMOSet_av: IPC AMO set with relaxed store semantics
- wait_until_av: P2P sync wait with targeted ordering
- ROCSHMEM_BYPASS_LANE_STORES env var for large memcpy_lane puts
- queue_pair_mlx5: cache-bypassing WQE store path for _av puts

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

JIRA ID: <AIROCSHMEM-#>

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
