### PR TITLE
docs(rocm-smi-lib): warn about XGMI/PCIe/KFD scope of --gpureset

### DIFF
--- a/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
+++ b/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
@@ -726,6 +726,10 @@ Reset options for specified devices.
 * On systems with XGMI/Infinity Fabric (for example, AMD Instinct MI Series), resetting one
   GPU resets all GPUs in the same XGMI hive. Use `amd-smi xgmi` or `amd-smi topology` to find the XGMI link connected GPUs or check `/sys/class/drm/card*/device/xgmi_info/xgmi_hive_id` to identify GPUs having the same hive id, before issuing a reset.
 
+* On systems where GPUs share an upstream PCIe switch, resetting one GPU may trigger a
+  Secondary Bus Reset (SBR) on the upstream switch port, affecting all GPUs behind the same
+  switch, independent of XGMI hive membership.
+
 * Any process with an open `/dev/kfd` handle will be terminated when a GPU reset occurs,
   even if that process is not using the GPU being reset. GPU isolation techniques using the
   environment variables `ROCR_VISIBLE_DEVICES` and `HIP_VISIBLE_DEVICES` do not

--- a/projects/rocm-smi-lib/docs/how-to/use-python.rst
+++ b/projects/rocm-smi-lib/docs/how-to/use-python.rst
@@ -438,6 +438,10 @@ Clock type descriptions
    * On systems with XGMI/Infinity Fabric (for example, AMD Instinct MI Series), resetting one
      GPU resets all GPUs in the same XGMI hive. Use ``rocm-smi --showtopo`` to find the XGMI link connected GPUs or check ``/sys/class/drm/card*/device/xgmi_info/xgmi_hive_id`` to identify GPUs having the same hive id, before issuing a reset.
 
+   * On systems where GPUs share an upstream PCIe switch, resetting one GPU may trigger a
+     Secondary Bus Reset (SBR) on the upstream switch port, affecting all GPUs behind the same
+     switch, independent of XGMI hive membership.
+
    * Any process with an open ``/dev/kfd`` handle will be terminated when a GPU reset occurs,
      even if that process is not using the GPU being reset. GPU isolation techniques using the
      environment variables ``ROCR_VISIBLE_DEVICES`` and ``HIP_VISIBLE_DEVICES`` do not

--- a/projects/rocm-smi-lib/python_smi_tools/README.md
+++ b/projects/rocm-smi-lib/python_smi_tools/README.md
@@ -387,6 +387,18 @@ This flag will attempt to reset the GPU for a specified device. This will invoke
 the kernel debugfs file amdgpu_gpu_recover. Note that GPU reset will not always work, depending on the
 manner in which the GPU is hung.
 
+WARNING:
+* On systems with XGMI/Infinity Fabric (for example, AMD Instinct MI Series), resetting one GPU resets
+  all GPUs in the same XGMI hive. Use `rocm-smi --showtopo` to find the XGMI link connected GPUs or check
+  `/sys/class/drm/card*/device/xgmi_info/xgmi_hive_id` to identify GPUs having the same hive id, before
+  issuing a reset.
+* On systems where GPUs share an upstream PCIe switch, resetting one GPU may trigger a Secondary Bus
+  Reset (SBR) on the upstream switch port, affecting all GPUs behind the same switch, independent of
+  XGMI hive membership.
+* Any process with an open `/dev/kfd` handle will be terminated when a GPU reset occurs, even if that
+  process is not using the GPU being reset. GPU isolation techniques using the environment variables
+  `ROCR_VISIBLE_DEVICES` and `HIP_VISIBLE_DEVICES` do not prevent this.
+
 --showdriverversion:
 This flag will print out the AMDGPU module version for amdgpu-pro or ROCm kernels. For other kernels,
 it will simply print out the name of the kernel (`uname -r`)


### PR DESCRIPTION
The --gpureset docs implied single-GPU scope. Document the real reset domain: an XGMI hive reset affects all peer GPUs; a shared PCIe switch can propagate a Secondary Bus Reset (SBR) to all GPUs behind it; and any process holding /dev/kfd is terminated regardless of ROCR_VISIBLE_DEVICES/HIP_VISIBLE_DEVICES.

Adds the PCIe-switch note to use-python.rst (which already had the XGMI and KFD warnings) and all three warnings to the python_smi_tools README.

## Motivation

The `--gpureset` documentation described the reset as scoped to a single specified device. On multi-GPU platforms the actual reset domain is wider, so users need to understand the blast radius before issuing a reset.

## Technical Details

Documentation-only change (no code or API changes):

- `docs/how-to/use-python.rst`: added a PCIe-switch (SBR) bullet to the existing `--gpureset` `.. warning::` block, which already documented the XGMI-hive reset and `/dev/kfd` teardown behavior.
- `python_smi_tools/README.md`: added a `WARNING` block under `--gpureset` covering all three cases (XGMI hive, PCIe switch / SBR, and KFD process teardown), matching the reST docs.

## JIRA ID

JIRA ID: ROCM-26924
JIRA ID: ROCM-26923

## Test Plan

Documentation-only. `docs/` and `*.rst`/`*.md` are excluded from the repository pre-commit hooks. The new reST bullet reuses the indentation of the existing warning bullets, so the `.. warning::` admonition stays well-formed. Rendered the `--gpureset` sections in both files to confirm all three warnings display.

## Test Result

N/A. Documentation-only change; no functional testing required.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
