### PR TITLE
feat(rccl): add weekly PyTorch c10d distributed test to CI

### DIFF
--- a/.github/scripts/test_pytorch_c10d.py
+++ b/.github/scripts/test_pytorch_c10d.py
@@ -51,9 +51,9 @@ def find_rocm_lib_dir(artifact_dir: Path) -> Path | None:
 
 def setup_ld_library_path(rccl_lib_dir: Path, rocm_lib_dir: Path | None) -> str:
     """Prepend RCCL and ROCm lib dirs to LD_LIBRARY_PATH."""
-    parts = [str(rccl_lib_dir)]
+    parts = [str(rccl_lib_dir.resolve())]
     if rocm_lib_dir:
-        parts.append(str(rocm_lib_dir))
+        parts.append(str(rocm_lib_dir.resolve()))
     existing = os.environ.get("LD_LIBRARY_PATH", "")
     if existing:
         parts.append(existing)

--- a/.github/scripts/test_pytorch_c10d.py
+++ b/.github/scripts/test_pytorch_c10d.py
@@ -25,6 +25,31 @@ from pathlib import Path
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 log = logging.getLogger(__name__)
 
+SMOKE_TESTS = [
+    "test_all_reduce_coalesced_nccl",
+    "test_all_reduce_coalesced_manager_nccl",
+    "test_allgather_base",
+    "test_all_gather_into_tensor_coalesced_manager_nccl",
+    "test_broadcast_coalesced_nccl",
+    "test_broadcast_subgroup",
+    "test_reduce_scatter_base_k",
+    "test_reduce_scatter_tensor_coalesced",
+    "test_non_blocking_p2p",
+    "test_send_recv_subgroup",
+    "test_nccl_barrier_device_ids",
+    "test_reduce_subgroup",
+    "test_scatter_subgroup",
+    "test_gather_subgroup",
+    "test_all_to_all_single",
+    "test_init_wo_backend_str",
+    "test_new_group",
+    "test_pass_nccl_options_high_priority_stream",
+    "test_set_process_group_desc",
+    "test_tensor_dtype_complex",
+    "test_batch_send_recv_subgroup",
+    "test_collectives",
+]
+
 
 def find_rccl_library(artifact_dir: Path) -> Path:
     """Find librccl.so in the artifact directory tree."""
@@ -203,7 +228,7 @@ def print_environment_info() -> None:
     log.info("LD_LIBRARY_PATH: %s", os.environ.get("LD_LIBRARY_PATH", ""))
 
 
-def run_tests(pytorch_src: Path, results_log: Path) -> int:
+def run_tests(pytorch_src: Path, results_log: Path, test_scope: str = "smoke") -> int:
     """Run pytest on test_c10d_nccl.py and return the exit code."""
     miopen_cache = tempfile.mkdtemp(prefix="miopen_cache_")
     os.environ["MIOPEN_USER_DB_PATH"] = miopen_cache
@@ -211,16 +236,25 @@ def run_tests(pytorch_src: Path, results_log: Path) -> int:
     env = os.environ.copy()
     env["PYTHONPATH"] = str(pytorch_src / "test") + ":" + env.get("PYTHONPATH", "")
 
+    if test_scope == "smoke":
+        k_expr = " or ".join(SMOKE_TESTS)
+        timeout = "60"
+        log.info("Running smoke tests (%d tests)", len(SMOKE_TESTS))
+    else:
+        k_expr = "not NCCLTraceTestDumpOnTimeout"
+        timeout = "600"
+        log.info("Running all tests (excluding NCCLTraceTestDumpOnTimeout)")
+
     cmd = [
         sys.executable,
         "-m",
         "pytest",
         str(pytorch_src / "test" / "distributed" / "test_c10d_nccl.py"),
         "-v",
-        "--timeout=600",
+        f"--timeout={timeout}",
         "--tb=short",
         "-k",
-        "not NCCLTraceTestDumpOnTimeout",
+        k_expr,
     ]
     log.info("Running: %s", " ".join(cmd))
 
@@ -274,6 +308,12 @@ def main() -> None:
         help="Path for test results log file",
     )
     parser.add_argument(
+        "--test-scope",
+        choices=["smoke", "all"],
+        default="smoke",
+        help="Run smoke tests (22 curated tests, ~3min) or all tests (default: smoke)",
+    )
+    parser.add_argument(
         "--discover-only",
         action="store_true",
         help="Only discover library paths and set GITHUB_OUTPUT, then exit",
@@ -303,7 +343,7 @@ def main() -> None:
     # Step 4: Patch missing modules, print environment info, and run tests
     patch_missing_torch_modules()
     print_environment_info()
-    exit_code = run_tests(args.pytorch_src, args.results_log)
+    exit_code = run_tests(args.pytorch_src, args.results_log, args.test_scope)
     sys.exit(exit_code)
 
 

--- a/.github/scripts/test_pytorch_c10d.py
+++ b/.github/scripts/test_pytorch_c10d.py
@@ -64,16 +64,19 @@ def setup_ld_library_path(rccl_lib_dir: Path, rocm_lib_dir: Path | None) -> str:
 
 
 def verify_rccl_override(rccl_lib_dir: Path) -> None:
-    """Verify that the CI-built librccl.so is loadable via LD_LIBRARY_PATH."""
-    try:
-        ctypes.CDLL("librccl.so")
-        log.info("Successfully loaded librccl.so via LD_LIBRARY_PATH")
-    except OSError as e:
-        log.error("Failed to load librccl.so: %s", e)
+    """Verify that the CI-built librccl.so exists and is loadable."""
+    ci_rccl = rccl_lib_dir.resolve() / "librccl.so"
+    if not ci_rccl.exists():
+        log.error("CI-built librccl.so not found at %s", ci_rccl)
         sys.exit(1)
-
-    ci_rccl = rccl_lib_dir / "librccl.so"
     log.info("CI-built RCCL: %s (%d bytes)", ci_rccl, ci_rccl.stat().st_size)
+
+    try:
+        ctypes.CDLL(str(ci_rccl))
+        log.info("Successfully loaded %s", ci_rccl)
+    except OSError as e:
+        log.error("Failed to load %s: %s", ci_rccl, e)
+        sys.exit(1)
 
     try:
         import torch

--- a/.github/scripts/test_pytorch_c10d.py
+++ b/.github/scripts/test_pytorch_c10d.py
@@ -72,41 +72,99 @@ def verify_rccl_override(rccl_lib_dir: Path) -> None:
 
 
 def clone_pytorch_test_sources(pytorch_src: Path) -> None:
-    """Sparse-clone PyTorch test sources matching the installed torch version."""
+    """Sparse-clone PyTorch test sources matching the installed torch version.
+
+    For release builds (e.g. 2.5.0), clones at the matching tag.
+    For nightly builds (e.g. 2.14.0a0+rocm7.15.0a20260712), clones using
+    --shallow-since to get commits around the build date, then checks out the
+    commit closest to that date so test sources match the installed wheel.
+    """
+    import re
+    from datetime import datetime, timedelta
+
     import torch
 
-    torch_version = torch.__version__.split("+")[0]
+    torch_version = torch.__version__
+    base_version = torch_version.split("+")[0]
     log.info("PyTorch version: %s", torch_version)
 
-    git_ref = f"v{torch_version}"
+    git_ref = f"v{base_version}"
     result = subprocess.run(
         ["git", "ls-remote", "--tags", "https://github.com/pytorch/pytorch.git", git_ref],
         capture_output=True,
         text=True,
     )
-    if not result.stdout.strip():
-        log.info("Tag %s not found, using nightly branch", git_ref)
+
+    date_match = re.search(r"(\d{8})", torch_version)
+    use_date_pinning = False
+
+    if result.stdout.strip():
+        log.info("Found tag %s", git_ref)
+    elif date_match:
+        build_date = date_match.group(1)
+        dt = datetime.strptime(build_date, "%Y%m%d")
+        shallow_since = (dt - timedelta(days=2)).strftime("%Y-%m-%d")
+        log.info("Tag %s not found; nightly build date %s", git_ref, build_date)
+        git_ref = "nightly"
+        use_date_pinning = True
+    else:
+        log.info("Tag %s not found, using nightly branch HEAD", git_ref)
         git_ref = "nightly"
 
-    log.info("Cloning PyTorch (ref=%s, sparse) into %s", git_ref, pytorch_src)
-    subprocess.run(
-        [
-            "git",
-            "clone",
-            "--depth=1",
-            f"--branch={git_ref}",
-            "--filter=blob:none",
-            "--sparse",
-            "https://github.com/pytorch/pytorch.git",
-            str(pytorch_src),
-        ],
-        check=True,
-    )
+    if use_date_pinning:
+        log.info("Cloning PyTorch (ref=%s, shallow-since=%s, sparse) into %s",
+                 git_ref, shallow_since, pytorch_src)
+        subprocess.run(
+            [
+                "git", "clone",
+                f"--branch={git_ref}",
+                f"--shallow-since={shallow_since}",
+                "--filter=blob:none",
+                "--sparse",
+                "https://github.com/pytorch/pytorch.git",
+                str(pytorch_src),
+            ],
+            check=True,
+        )
+    else:
+        log.info("Cloning PyTorch (ref=%s, depth=1, sparse) into %s", git_ref, pytorch_src)
+        subprocess.run(
+            [
+                "git", "clone",
+                "--depth=1",
+                f"--branch={git_ref}",
+                "--filter=blob:none",
+                "--sparse",
+                "https://github.com/pytorch/pytorch.git",
+                str(pytorch_src),
+            ],
+            check=True,
+        )
+
     subprocess.run(
         ["git", "sparse-checkout", "set", "test/", "torch/testing/"],
         cwd=pytorch_src,
         check=True,
     )
+
+    if use_date_pinning:
+        before = (dt + timedelta(days=1)).strftime("%Y-%m-%dT00:00:00")
+        result = subprocess.run(
+            ["git", "log", f"--before={before}", "--format=%H", "-1"],
+            cwd=pytorch_src,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            commit = result.stdout.strip()
+            log.info("Checking out commit %s (latest before %s)", commit[:12], before)
+            subprocess.run(
+                ["git", "checkout", commit],
+                cwd=pytorch_src,
+                check=True,
+            )
+        else:
+            log.warning("Could not find commit before %s, using HEAD of nightly", before)
 
     test_file = pytorch_src / "test" / "distributed" / "test_c10d_nccl.py"
     if not test_file.exists():

--- a/.github/scripts/test_pytorch_c10d.py
+++ b/.github/scripts/test_pytorch_c10d.py
@@ -63,7 +63,7 @@ def find_rccl_library(artifact_dir: Path) -> Path:
         log.error("librccl.so not found in %s", artifact_dir)
         log.error("Shared libraries found: %s", [str(f) for f in so_files])
         sys.exit(1)
-    lib_path = matches[0]
+    lib_path = matches[0].resolve()
     log.info("Found librccl.so at: %s", lib_path)
     return lib_path
 
@@ -265,6 +265,7 @@ def run_tests(pytorch_src: Path, results_log: Path, test_scope: str = "smoke") -
     passed_tests = []
     failed_tests = []
     summary_line = ""
+    current_test = ""
 
     with open(results_log, "w") as log_file:
         proc = subprocess.Popen(
@@ -280,18 +281,17 @@ def run_tests(pytorch_src: Path, results_log: Path, test_scope: str = "smoke") -
             sys.stdout.write(line)
             sys.stdout.flush()
             log_file.write(line)
-            if " PASSED" in line and "::" in line:
-                test_name = line.split("::")[1].split()[0] if "::" in line else line.strip()
-                duration = ""
+            test_header = re.match(r"test/.*?::([\w:]+)", line)
+            if test_header:
+                current_test = test_header.group(1)
+            if "PASSED" in line and re.search(r"PASSED\s+\[", line):
                 dur_match = re.search(r"\[(\d+\.\d+s)\]", line)
-                if dur_match:
-                    duration = dur_match.group(1)
-                passed_tests.append((test_name, duration))
-            elif " FAILED" in line and "::" in line:
-                test_name = line.split("::")[1].split()[0] if "::" in line else line.strip()
-                failed_tests.append(test_name)
-            elif "passed" in line and ("failed" in line or "deselected" in line or "error" in line or line.strip().startswith("=")):
-                summary_line = line.strip()
+                duration = dur_match.group(1) if dur_match else ""
+                passed_tests.append((current_test, duration))
+                current_test = ""
+            elif "FAILED" in line and re.search(r"FAILED\s+\[", line):
+                failed_tests.append(current_test)
+                current_test = ""
             elif line.strip().startswith("=") and "passed" in line:
                 summary_line = line.strip()
         proc.wait()

--- a/.github/scripts/test_pytorch_c10d.py
+++ b/.github/scripts/test_pytorch_c10d.py
@@ -179,11 +179,12 @@ def patch_missing_torch_modules() -> None:
 
     torch_dir = Path(torch.__file__).parent
     strobelight_dir = torch_dir / "_strobelight"
-    if not strobelight_dir.exists():
+    profiler_file = strobelight_dir / "compile_time_profiler.py"
+    if not profiler_file.exists():
         log.info("Creating stub for torch._strobelight (missing from nightly wheel)")
         strobelight_dir.mkdir(parents=True, exist_ok=True)
         (strobelight_dir / "__init__.py").write_text("")
-        (strobelight_dir / "compile_time_profiler.py").write_text(
+        profiler_file.write_text(
             "class StrobelightCompileTimeProfiler:\n"
             "    def __enter__(self): return self\n"
             "    def __exit__(self, *a): pass\n"

--- a/.github/scripts/test_pytorch_c10d.py
+++ b/.github/scripts/test_pytorch_c10d.py
@@ -225,17 +225,20 @@ def run_tests(pytorch_src: Path, results_log: Path) -> int:
     log.info("Running: %s", " ".join(cmd))
 
     with open(results_log, "w") as log_file:
-        proc = subprocess.run(
+        proc = subprocess.Popen(
             cmd,
             cwd=pytorch_src,
             env=env,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
+            bufsize=1,
         )
-        log_file.write(proc.stdout)
-        # Also print to stdout for CI log visibility
-        print(proc.stdout, end="")
+        for line in proc.stdout:
+            sys.stdout.write(line)
+            sys.stdout.flush()
+            log_file.write(line)
+        proc.wait()
 
     log.info("Test exit code: %d", proc.returncode)
     log.info("Results written to: %s", results_log)

--- a/.github/scripts/test_pytorch_c10d.py
+++ b/.github/scripts/test_pytorch_c10d.py
@@ -17,9 +17,13 @@ Usage from GitHub Actions:
 import argparse
 import logging
 import os
+import re
+import smtplib
 import subprocess
 import sys
 import tempfile
+from datetime import datetime, timezone
+from email.mime.text import MIMEText
 from pathlib import Path
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
@@ -228,8 +232,8 @@ def print_environment_info() -> None:
     log.info("LD_LIBRARY_PATH: %s", os.environ.get("LD_LIBRARY_PATH", ""))
 
 
-def run_tests(pytorch_src: Path, results_log: Path, test_scope: str = "smoke") -> int:
-    """Run pytest on test_c10d_nccl.py and return the exit code."""
+def run_tests(pytorch_src: Path, results_log: Path, test_scope: str = "smoke") -> tuple[int, dict]:
+    """Run pytest on test_c10d_nccl.py and return (exit_code, summary_dict)."""
     miopen_cache = tempfile.mkdtemp(prefix="miopen_cache_")
     os.environ["MIOPEN_USER_DB_PATH"] = miopen_cache
 
@@ -258,6 +262,10 @@ def run_tests(pytorch_src: Path, results_log: Path, test_scope: str = "smoke") -
     ]
     log.info("Running: %s", " ".join(cmd))
 
+    passed_tests = []
+    failed_tests = []
+    summary_line = ""
+
     with open(results_log, "w") as log_file:
         proc = subprocess.Popen(
             cmd,
@@ -272,11 +280,110 @@ def run_tests(pytorch_src: Path, results_log: Path, test_scope: str = "smoke") -
             sys.stdout.write(line)
             sys.stdout.flush()
             log_file.write(line)
+            if " PASSED" in line and "::" in line:
+                test_name = line.split("::")[1].split()[0] if "::" in line else line.strip()
+                duration = ""
+                dur_match = re.search(r"\[(\d+\.\d+s)\]", line)
+                if dur_match:
+                    duration = dur_match.group(1)
+                passed_tests.append((test_name, duration))
+            elif " FAILED" in line and "::" in line:
+                test_name = line.split("::")[1].split()[0] if "::" in line else line.strip()
+                failed_tests.append(test_name)
+            elif "passed" in line and ("failed" in line or "deselected" in line or "error" in line or line.strip().startswith("=")):
+                summary_line = line.strip()
+            elif line.strip().startswith("=") and "passed" in line:
+                summary_line = line.strip()
         proc.wait()
 
     log.info("Test exit code: %d", proc.returncode)
     log.info("Results written to: %s", results_log)
-    return proc.returncode
+
+    summary = {
+        "exit_code": proc.returncode,
+        "test_scope": test_scope,
+        "passed": passed_tests,
+        "failed": failed_tests,
+        "summary_line": summary_line.strip("= "),
+    }
+    return proc.returncode, summary
+
+
+def generate_summary_report(summary: dict, rccl_lib: Path) -> str:
+    """Generate a plain-text summary report."""
+    import torch
+
+    status = "PASSED" if summary["exit_code"] == 0 else "FAILED"
+    gpu_info = []
+    for i in range(torch.cuda.device_count()):
+        gpu_info.append(f"  GPU {i}: {torch.cuda.get_device_name(i)}")
+
+    lines = [
+        f"RCCL PyTorch c10d Test Report",
+        f"{'=' * 40}",
+        f"Status:     {status}",
+        f"Test scope: {summary['test_scope']}",
+        f"Date:       {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')}",
+        f"",
+        f"PyTorch:    {torch.__version__}",
+        f"RCCL:       {rccl_lib}",
+        f"GPUs:       {torch.cuda.device_count()}x {torch.cuda.get_device_name(0)}",
+        f"",
+        f"Results:    {summary['summary_line']}",
+        f"",
+    ]
+
+    if summary["failed"]:
+        lines.append(f"FAILED tests ({len(summary['failed'])}):")
+        for name in summary["failed"]:
+            lines.append(f"  FAIL  {name}")
+        lines.append("")
+
+    if summary["passed"]:
+        lines.append(f"PASSED tests ({len(summary['passed'])}):")
+        for name, duration in summary["passed"]:
+            lines.append(f"  OK    {name:60s} {duration}")
+        lines.append("")
+
+    run_url = os.environ.get("GITHUB_SERVER_URL", "")
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+    run_id = os.environ.get("GITHUB_RUN_ID", "")
+    if run_url and repo and run_id:
+        lines.append(f"CI run: {run_url}/{repo}/actions/runs/{run_id}")
+
+    return "\n".join(lines)
+
+
+def write_github_summary(report: str) -> None:
+    """Write report to GITHUB_STEP_SUMMARY if available."""
+    summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_file:
+        with open(summary_file, "a") as f:
+            f.write("```\n")
+            f.write(report)
+            f.write("\n```\n")
+        log.info("Summary written to GITHUB_STEP_SUMMARY")
+
+
+def send_email_report(report: str, recipient: str, status: str) -> None:
+    """Send the summary report via email."""
+    subject = f"RCCL PyTorch c10d Test: {status}"
+    msg = MIMEText(report)
+    msg["Subject"] = subject
+    msg["From"] = "rccl-ci@amd.com"
+    msg["To"] = recipient
+
+    smtp_servers = ["smtp.amd.com", "aussmtp.amd.com", "mail.amd.com", "localhost"]
+    for server in smtp_servers:
+        try:
+            with smtplib.SMTP(server, timeout=10) as s:
+                s.sendmail(msg["From"], [recipient], msg.as_string())
+            log.info("Email sent to %s via %s", recipient, server)
+            return
+        except Exception as e:
+            log.debug("SMTP %s failed: %s", server, e)
+            continue
+    log.warning("Could not send email to %s (tried: %s)", recipient, ", ".join(smtp_servers))
 
 
 def set_github_output(key: str, value: str) -> None:
@@ -314,6 +421,12 @@ def main() -> None:
         help="Run smoke tests (22 curated tests, ~3min) or all tests (default: smoke)",
     )
     parser.add_argument(
+        "--notify-email",
+        type=str,
+        default="",
+        help="Send summary report to this email address",
+    )
+    parser.add_argument(
         "--discover-only",
         action="store_true",
         help="Only discover library paths and set GITHUB_OUTPUT, then exit",
@@ -343,7 +456,21 @@ def main() -> None:
     # Step 4: Patch missing modules, print environment info, and run tests
     patch_missing_torch_modules()
     print_environment_info()
-    exit_code = run_tests(args.pytorch_src, args.results_log, args.test_scope)
+    exit_code, summary = run_tests(args.pytorch_src, args.results_log, args.test_scope)
+
+    # Step 5: Generate and distribute summary report
+    report = generate_summary_report(summary, rccl_lib)
+    log.info("\n%s", report)
+    write_github_summary(report)
+
+    summary_path = args.results_log.parent / "pytorch_c10d_summary.txt"
+    summary_path.write_text(report)
+    log.info("Summary written to: %s", summary_path)
+
+    if args.notify_email:
+        status = "PASSED" if exit_code == 0 else "FAILED"
+        send_email_report(report, args.notify_email, status)
+
     sys.exit(exit_code)
 
 

--- a/.github/scripts/test_pytorch_c10d.py
+++ b/.github/scripts/test_pytorch_c10d.py
@@ -15,7 +15,6 @@ Usage from GitHub Actions:
 """
 
 import argparse
-import ctypes
 import logging
 import os
 import subprocess
@@ -64,34 +63,12 @@ def setup_ld_library_path(rccl_lib_dir: Path, rocm_lib_dir: Path | None) -> str:
 
 
 def verify_rccl_override(rccl_lib_dir: Path) -> None:
-    """Verify that the CI-built librccl.so exists and is loadable."""
+    """Verify that the CI-built librccl.so exists on disk."""
     ci_rccl = rccl_lib_dir.resolve() / "librccl.so"
     if not ci_rccl.exists():
         log.error("CI-built librccl.so not found at %s", ci_rccl)
         sys.exit(1)
     log.info("CI-built RCCL: %s (%d bytes)", ci_rccl, ci_rccl.stat().st_size)
-
-    try:
-        ctypes.CDLL(str(ci_rccl))
-        log.info("Successfully loaded %s", ci_rccl)
-    except OSError as e:
-        log.error("Failed to load %s: %s", ci_rccl, e)
-        sys.exit(1)
-
-    try:
-        import torch
-
-        torch_rccl = Path(torch.__file__).parent / "lib" / "librccl.so"
-        if torch_rccl.exists():
-            log.info(
-                "PyTorch bundled RCCL: %s (%d bytes)",
-                torch_rccl,
-                torch_rccl.stat().st_size,
-            )
-        else:
-            log.info("PyTorch bundled RCCL: not found (device package may not bundle it)")
-    except ImportError:
-        log.warning("torch not yet installed, skipping bundled RCCL check")
 
 
 def clone_pytorch_test_sources(pytorch_src: Path) -> None:

--- a/.github/scripts/test_pytorch_c10d.py
+++ b/.github/scripts/test_pytorch_c10d.py
@@ -142,7 +142,7 @@ def clone_pytorch_test_sources(pytorch_src: Path) -> None:
         )
 
     subprocess.run(
-        ["git", "sparse-checkout", "set", "test/", "torch/testing/"],
+        ["git", "sparse-checkout", "set", "test/"],
         cwd=pytorch_src,
         check=True,
     )

--- a/.github/scripts/test_pytorch_c10d.py
+++ b/.github/scripts/test_pytorch_c10d.py
@@ -22,6 +22,7 @@ import smtplib
 import subprocess
 import sys
 import tempfile
+import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
 from email.mime.text import MIMEText
 from pathlib import Path
@@ -232,6 +233,53 @@ def print_environment_info() -> None:
     log.info("LD_LIBRARY_PATH: %s", os.environ.get("LD_LIBRARY_PATH", ""))
 
 
+def parse_junit_xml(xml_path: Path) -> dict:
+    """Parse JUnit XML and return structured results."""
+    tree = ET.parse(xml_path)
+    root = tree.getroot()
+
+    passed_tests = []
+    failed_tests = []
+    error_details = []
+    tests_run = 0
+    failures = 0
+    errors = 0
+
+    for suite in root.iter("testsuite"):
+        tests_run = int(suite.get("tests", 0))
+        failures = int(suite.get("failures", 0))
+        errors = int(suite.get("errors", 0))
+
+    for tc in root.iter("testcase"):
+        name = tc.get("name", "")
+        time_s = tc.get("time", "")
+        duration = f"{float(time_s):.2f}s" if time_s else ""
+
+        failure = tc.find("failure")
+        error = tc.find("error")
+        if failure is not None:
+            failed_tests.append(name)
+            error_details.append(
+                f"FAILED: {name}\n  {failure.get('message', '')}"
+            )
+        elif error is not None:
+            failed_tests.append(name)
+            error_details.append(
+                f"ERROR: {name}\n  {error.get('message', '')}"
+            )
+        else:
+            passed_tests.append((name, duration))
+
+    return {
+        "passed": passed_tests,
+        "failed": failed_tests,
+        "error_details": error_details,
+        "tests_run": tests_run,
+        "failures": failures,
+        "errors": errors,
+    }
+
+
 def run_tests(pytorch_src: Path, results_log: Path, test_scope: str = "smoke") -> tuple[int, dict]:
     """Run pytest on test_c10d_nccl.py and return (exit_code, summary_dict)."""
     miopen_cache = tempfile.mkdtemp(prefix="miopen_cache_")
@@ -239,6 +287,8 @@ def run_tests(pytorch_src: Path, results_log: Path, test_scope: str = "smoke") -
 
     env = os.environ.copy()
     env["PYTHONPATH"] = str(pytorch_src / "test") + ":" + env.get("PYTHONPATH", "")
+
+    junit_xml = results_log.parent / "pytorch_c10d_results.xml"
 
     if test_scope == "smoke":
         k_expr = " or ".join(SMOKE_TESTS)
@@ -257,15 +307,11 @@ def run_tests(pytorch_src: Path, results_log: Path, test_scope: str = "smoke") -
         "-v",
         f"--timeout={timeout}",
         "--tb=short",
+        f"--junitxml={junit_xml}",
         "-k",
         k_expr,
     ]
     log.info("Running: %s", " ".join(cmd))
-
-    passed_tests = []
-    failed_tests = []
-    summary_line = ""
-    current_test = ""
 
     with open(results_log, "w") as log_file:
         proc = subprocess.Popen(
@@ -281,32 +327,58 @@ def run_tests(pytorch_src: Path, results_log: Path, test_scope: str = "smoke") -
             sys.stdout.write(line)
             sys.stdout.flush()
             log_file.write(line)
-            test_header = re.match(r"test/.*?::([\w:]+)", line)
-            if test_header:
-                current_test = test_header.group(1)
-            if "PASSED" in line and re.search(r"PASSED\s+\[", line):
-                dur_match = re.search(r"\[(\d+\.\d+s)\]", line)
-                duration = dur_match.group(1) if dur_match else ""
-                passed_tests.append((current_test, duration))
-                current_test = ""
-            elif "FAILED" in line and re.search(r"FAILED\s+\[", line):
-                failed_tests.append(current_test)
-                current_test = ""
-            elif line.strip().startswith("=") and "passed" in line:
-                summary_line = line.strip()
         proc.wait()
 
     log.info("Test exit code: %d", proc.returncode)
     log.info("Results written to: %s", results_log)
 
+    exit_code = proc.returncode
+    passed_tests = []
+    failed_tests = []
+    error_details = []
+    tests_run = 0
+    summary_line = ""
+
+    if junit_xml.exists():
+        log.info("Parsing JUnit XML: %s", junit_xml)
+        junit = parse_junit_xml(junit_xml)
+        passed_tests = junit["passed"]
+        failed_tests = junit["failed"]
+        error_details = junit["error_details"]
+        tests_run = junit["tests_run"]
+        parts = []
+        if passed_tests:
+            parts.append(f"{len(passed_tests)} passed")
+        if failed_tests:
+            parts.append(f"{len(failed_tests)} failed")
+        summary_line = ", ".join(parts)
+
+        if error_details:
+            log.info("Failure/error details from JUnit XML:")
+            for detail in error_details:
+                log.info("  %s", detail)
+    else:
+        log.warning("JUnit XML not found at %s, falling back to exit code only", junit_xml)
+
+    if test_scope == "smoke" and tests_run < len(SMOKE_TESTS):
+        log.error(
+            "Expected %d smoke tests but only %d were collected — "
+            "test names may have changed in the nightly",
+            len(SMOKE_TESTS),
+            tests_run,
+        )
+        exit_code = 1
+
     summary = {
-        "exit_code": proc.returncode,
+        "exit_code": exit_code,
         "test_scope": test_scope,
         "passed": passed_tests,
         "failed": failed_tests,
-        "summary_line": summary_line.strip("= "),
+        "summary_line": summary_line,
+        "tests_run": tests_run,
+        "expected_tests": len(SMOKE_TESTS) if test_scope == "smoke" else None,
     }
-    return proc.returncode, summary
+    return exit_code, summary
 
 
 def generate_summary_report(summary: dict, rccl_lib: Path) -> str:
@@ -330,8 +402,11 @@ def generate_summary_report(summary: dict, rccl_lib: Path) -> str:
         f"GPUs:       {torch.cuda.device_count()}x {torch.cuda.get_device_name(0)}",
         f"",
         f"Results:    {summary['summary_line']}",
-        f"",
     ]
+
+    if summary.get("expected_tests") is not None:
+        lines.append(f"Collected:  {summary['tests_run']}/{summary['expected_tests']} expected smoke tests")
+    lines.append("")
 
     if summary["failed"]:
         lines.append(f"FAILED tests ({len(summary['failed'])}):")

--- a/.github/scripts/test_pytorch_c10d.py
+++ b/.github/scripts/test_pytorch_c10d.py
@@ -173,6 +173,23 @@ def clone_pytorch_test_sources(pytorch_src: Path) -> None:
     log.info("Test sources ready: %s", test_file)
 
 
+def patch_missing_torch_modules() -> None:
+    """Create stubs for internal torch modules missing from nightly wheels."""
+    import torch
+
+    torch_dir = Path(torch.__file__).parent
+    strobelight_dir = torch_dir / "_strobelight"
+    if not strobelight_dir.exists():
+        log.info("Creating stub for torch._strobelight (missing from nightly wheel)")
+        strobelight_dir.mkdir(parents=True, exist_ok=True)
+        (strobelight_dir / "__init__.py").write_text("")
+        (strobelight_dir / "compile_time_profiler.py").write_text(
+            "class StrobelightCompileTimeProfiler:\n"
+            "    def __enter__(self): return self\n"
+            "    def __exit__(self, *a): pass\n"
+        )
+
+
 def print_environment_info() -> None:
     """Print GPU and environment details for CI logs."""
     import torch
@@ -279,7 +296,8 @@ def main() -> None:
     # Step 3: Clone PyTorch test sources
     clone_pytorch_test_sources(args.pytorch_src)
 
-    # Step 4: Print environment info and run tests
+    # Step 4: Patch missing modules, print environment info, and run tests
+    patch_missing_torch_modules()
     print_environment_info()
     exit_code = run_tests(args.pytorch_src, args.results_log)
     sys.exit(exit_code)

--- a/.github/scripts/test_pytorch_c10d.py
+++ b/.github/scripts/test_pytorch_c10d.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Run PyTorch c10d NCCL distributed tests against CI-built RCCL.
+
+This script handles:
+  1. Discovering the CI-built librccl.so in the artifact directory
+  2. Verifying that LD_LIBRARY_PATH overrides PyTorch's bundled RCCL
+  3. Cloning the matching PyTorch test sources (sparse checkout)
+  4. Running pytest on test_c10d_nccl.py
+
+Usage from GitHub Actions:
+  python .github/scripts/test_pytorch_c10d.py \
+      --artifact-dir ./build \
+      --pytorch-src ./pytorch-src \
+      --results-log ./pytorch_c10d_results.log
+"""
+
+import argparse
+import ctypes
+import logging
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+log = logging.getLogger(__name__)
+
+
+def find_rccl_library(artifact_dir: Path) -> Path:
+    """Find librccl.so in the artifact directory tree."""
+    matches = list(artifact_dir.rglob("librccl.so"))
+    if not matches:
+        so_files = list(artifact_dir.rglob("*.so"))[:20]
+        log.error("librccl.so not found in %s", artifact_dir)
+        log.error("Shared libraries found: %s", [str(f) for f in so_files])
+        sys.exit(1)
+    lib_path = matches[0]
+    log.info("Found librccl.so at: %s", lib_path)
+    return lib_path
+
+
+def find_rocm_lib_dir(artifact_dir: Path) -> Path | None:
+    """Find the dist/rocm/lib directory in artifacts."""
+    for d in artifact_dir.rglob("dist/rocm/lib"):
+        if d.is_dir():
+            log.info("Found ROCm lib dir: %s", d)
+            return d
+    return None
+
+
+def setup_ld_library_path(rccl_lib_dir: Path, rocm_lib_dir: Path | None) -> str:
+    """Prepend RCCL and ROCm lib dirs to LD_LIBRARY_PATH."""
+    parts = [str(rccl_lib_dir)]
+    if rocm_lib_dir:
+        parts.append(str(rocm_lib_dir))
+    existing = os.environ.get("LD_LIBRARY_PATH", "")
+    if existing:
+        parts.append(existing)
+    new_path = ":".join(parts)
+    os.environ["LD_LIBRARY_PATH"] = new_path
+    log.info("LD_LIBRARY_PATH=%s", new_path)
+    return new_path
+
+
+def verify_rccl_override(rccl_lib_dir: Path) -> None:
+    """Verify that the CI-built librccl.so is loadable via LD_LIBRARY_PATH."""
+    try:
+        ctypes.CDLL("librccl.so")
+        log.info("Successfully loaded librccl.so via LD_LIBRARY_PATH")
+    except OSError as e:
+        log.error("Failed to load librccl.so: %s", e)
+        sys.exit(1)
+
+    ci_rccl = rccl_lib_dir / "librccl.so"
+    log.info("CI-built RCCL: %s (%d bytes)", ci_rccl, ci_rccl.stat().st_size)
+
+    try:
+        import torch
+
+        torch_rccl = Path(torch.__file__).parent / "lib" / "librccl.so"
+        if torch_rccl.exists():
+            log.info(
+                "PyTorch bundled RCCL: %s (%d bytes)",
+                torch_rccl,
+                torch_rccl.stat().st_size,
+            )
+        else:
+            log.info("PyTorch bundled RCCL: not found (device package may not bundle it)")
+    except ImportError:
+        log.warning("torch not yet installed, skipping bundled RCCL check")
+
+
+def clone_pytorch_test_sources(pytorch_src: Path) -> None:
+    """Sparse-clone PyTorch test sources matching the installed torch version."""
+    import torch
+
+    torch_version = torch.__version__.split("+")[0]
+    log.info("PyTorch version: %s", torch_version)
+
+    git_ref = f"v{torch_version}"
+    result = subprocess.run(
+        ["git", "ls-remote", "--tags", "https://github.com/pytorch/pytorch.git", git_ref],
+        capture_output=True,
+        text=True,
+    )
+    if not result.stdout.strip():
+        log.info("Tag %s not found, using nightly branch", git_ref)
+        git_ref = "nightly"
+
+    log.info("Cloning PyTorch (ref=%s, sparse) into %s", git_ref, pytorch_src)
+    subprocess.run(
+        [
+            "git",
+            "clone",
+            "--depth=1",
+            f"--branch={git_ref}",
+            "--filter=blob:none",
+            "--sparse",
+            "https://github.com/pytorch/pytorch.git",
+            str(pytorch_src),
+        ],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "sparse-checkout", "set", "test/", "torch/testing/"],
+        cwd=pytorch_src,
+        check=True,
+    )
+
+    test_file = pytorch_src / "test" / "distributed" / "test_c10d_nccl.py"
+    if not test_file.exists():
+        log.error("test_c10d_nccl.py not found after clone")
+        sys.exit(1)
+    log.info("Test sources ready: %s", test_file)
+
+
+def print_environment_info() -> None:
+    """Print GPU and environment details for CI logs."""
+    import torch
+
+    log.info("PyTorch: %s", torch.__version__)
+    log.info("CUDA/HIP available: %s", torch.cuda.is_available())
+    log.info("GPU count: %s", torch.cuda.device_count())
+    for i in range(torch.cuda.device_count()):
+        log.info("  GPU %d: %s", i, torch.cuda.get_device_name(i))
+    log.info("LD_LIBRARY_PATH: %s", os.environ.get("LD_LIBRARY_PATH", ""))
+
+
+def run_tests(pytorch_src: Path, results_log: Path) -> int:
+    """Run pytest on test_c10d_nccl.py and return the exit code."""
+    miopen_cache = tempfile.mkdtemp(prefix="miopen_cache_")
+    os.environ["MIOPEN_USER_DB_PATH"] = miopen_cache
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(pytorch_src / "test") + ":" + env.get("PYTHONPATH", "")
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "pytest",
+        str(pytorch_src / "test" / "distributed" / "test_c10d_nccl.py"),
+        "-v",
+        "--timeout=600",
+        "--tb=short",
+        "-k",
+        "not NCCLTraceTestDumpOnTimeout",
+    ]
+    log.info("Running: %s", " ".join(cmd))
+
+    with open(results_log, "w") as log_file:
+        proc = subprocess.run(
+            cmd,
+            cwd=pytorch_src,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        log_file.write(proc.stdout)
+        # Also print to stdout for CI log visibility
+        print(proc.stdout, end="")
+
+    log.info("Test exit code: %d", proc.returncode)
+    log.info("Results written to: %s", results_log)
+    return proc.returncode
+
+
+def set_github_output(key: str, value: str) -> None:
+    """Write a key=value pair to GITHUB_OUTPUT if available."""
+    output_file = os.environ.get("GITHUB_OUTPUT")
+    if output_file:
+        with open(output_file, "a") as f:
+            f.write(f"{key}={value}\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifact-dir",
+        type=Path,
+        required=True,
+        help="Directory containing CI-built artifacts",
+    )
+    parser.add_argument(
+        "--pytorch-src",
+        type=Path,
+        required=True,
+        help="Directory to clone PyTorch test sources into",
+    )
+    parser.add_argument(
+        "--results-log",
+        type=Path,
+        default=Path("pytorch_c10d_results.log"),
+        help="Path for test results log file",
+    )
+    parser.add_argument(
+        "--discover-only",
+        action="store_true",
+        help="Only discover library paths and set GITHUB_OUTPUT, then exit",
+    )
+
+    args = parser.parse_args()
+
+    # Step 1: Discover RCCL library path
+    rccl_lib = find_rccl_library(args.artifact_dir)
+    rccl_lib_dir = rccl_lib.parent
+    rocm_lib_dir = find_rocm_lib_dir(args.artifact_dir)
+
+    set_github_output("RCCL_LIB_DIR", str(rccl_lib_dir))
+    if rocm_lib_dir:
+        set_github_output("ROCM_LIB_DIR", str(rocm_lib_dir))
+
+    if args.discover_only:
+        return
+
+    # Step 2: Set up LD_LIBRARY_PATH and verify override
+    setup_ld_library_path(rccl_lib_dir, rocm_lib_dir)
+    verify_rccl_override(rccl_lib_dir)
+
+    # Step 3: Clone PyTorch test sources
+    clone_pytorch_test_sources(args.pytorch_src)
+
+    # Step 4: Print environment info and run tests
+    print_environment_info()
+    exit_code = run_tests(args.pytorch_src, args.results_log)
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -21,6 +21,9 @@ on:
       test_scope:
         type: string
         default: 'smoke'
+      notify_email:
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -173,3 +176,4 @@ jobs:
       test_runs_on: linux-gfx942-8gpu-ossci-rocm
       artifact_run_id: ${{ inputs.artifact_run_id || github.run_id }}
       test_scope: ${{ inputs.test_scope }}
+      notify_email: ${{ inputs.notify_email }}

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -15,6 +15,9 @@ on:
         required: true
       cmake_options:
         type: string
+      artifact_run_id:
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -22,6 +25,7 @@ permissions:
 jobs:
   therock-build-linux:
     name: Build Linux Packages
+    if: ${{ inputs.artifact_run_id == '' }}
     runs-on: azure-linux-scale-rocm
     permissions:
       id-token: write
@@ -141,27 +145,27 @@ jobs:
       amdgpu_families: ${{ inputs.amdgpu_families }}
       artifact_group: ${{ inputs.artifact_group }}
       test_runs_on: ruby-linux-slurm-scale-runner
-      artifact_run_id: ${{ github.run_id }}
+      artifact_run_id: ${{ inputs.artifact_run_id || github.run_id }}
 
   therock-test-linux-single-node:
     name: "Test single-node"
     # TODO(TheRock#3288): Re-enable gfx950-dcgpu runners once we get more capacity
-    if: ${{ inputs.amdgpu_families != 'gfx950-dcgpu' }}
+    if: ${{ !cancelled() && inputs.amdgpu_families != 'gfx950-dcgpu' }}
     needs: [therock-build-linux]
     uses: ./.github/workflows/therock-rccl-test-packages-single-node.yml
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
       artifact_group: ${{ inputs.artifact_group }}
       test_runs_on: linux-gfx942-8gpu-ossci-rocm
-      artifact_run_id: ${{ github.run_id }}
+      artifact_run_id: ${{ inputs.artifact_run_id || github.run_id }}
 
   therock-test-pytorch-distributed:
     name: "Test PyTorch distributed (scheduled)"
-    if: ${{ inputs.amdgpu_families != 'gfx950-dcgpu' && (inputs.event_name == 'schedule' || inputs.event_name == 'workflow_dispatch') }}
+    if: ${{ !cancelled() && inputs.amdgpu_families != 'gfx950-dcgpu' && (inputs.event_name == 'schedule' || inputs.event_name == 'workflow_dispatch') }}
     needs: [therock-build-linux]
     uses: ./.github/workflows/therock-rccl-test-pytorch-distributed.yml
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
       artifact_group: ${{ inputs.artifact_group }}
       test_runs_on: linux-gfx942-8gpu-ossci-rocm
-      artifact_run_id: ${{ github.run_id }}
+      artifact_run_id: ${{ inputs.artifact_run_id || github.run_id }}

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -7,9 +7,12 @@ on:
         type: string
       artifact_group:
         type: string
+      event_name:
+        type: string
+        default: ''
       package_version:
         type: string
-        required: true
+        default: 'ADHOCBUILD'
       cmake_options:
         type: string
 
@@ -146,6 +149,17 @@ jobs:
     if: ${{ inputs.amdgpu_families != 'gfx950-dcgpu' }}
     needs: [therock-build-linux]
     uses: ./.github/workflows/therock-rccl-test-packages-single-node.yml
+    with:
+      amdgpu_families: ${{ inputs.amdgpu_families }}
+      artifact_group: ${{ inputs.artifact_group }}
+      test_runs_on: linux-gfx942-8gpu-ossci-rocm
+      artifact_run_id: ${{ github.run_id }}
+
+  therock-test-pytorch-distributed:
+    name: "Test PyTorch distributed (scheduled)"
+    if: ${{ inputs.amdgpu_families != 'gfx950-dcgpu' && (inputs.event_name == 'schedule' || inputs.event_name == 'workflow_dispatch') }}
+    needs: [therock-build-linux]
+    uses: ./.github/workflows/therock-rccl-test-pytorch-distributed.yml
     with:
       amdgpu_families: ${{ inputs.amdgpu_families }}
       artifact_group: ${{ inputs.artifact_group }}

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -12,7 +12,7 @@ on:
         default: ''
       package_version:
         type: string
-        default: 'ADHOCBUILD'
+        required: true
       cmake_options:
         type: string
 

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -18,6 +18,9 @@ on:
       artifact_run_id:
         type: string
         default: ''
+      test_scope:
+        type: string
+        default: 'smoke'
 
 permissions:
   contents: read
@@ -169,3 +172,4 @@ jobs:
       artifact_group: ${{ inputs.artifact_group }}
       test_runs_on: linux-gfx942-8gpu-ossci-rocm
       artifact_run_id: ${{ inputs.artifact_run_id || github.run_id }}
+      test_scope: ${{ inputs.test_scope }}

--- a/.github/workflows/therock-rccl-ci.yml
+++ b/.github/workflows/therock-rccl-ci.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: '17 6 * * 0'  # Weekly, Sunday 06:17 UTC
   workflow_dispatch:
+    inputs:
+      artifact_run_id:
+        description: 'Reuse artifacts from a previous run ID (skips build)'
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -65,6 +70,7 @@ jobs:
       artifact_group: ${{ matrix.amdgpu_family }}
       event_name: ${{ github.event_name }}
       package_version: ADHOCBUILD
+      artifact_run_id: ${{ inputs.artifact_run_id }}
       cmake_options: >
         -DTHEROCK_ENABLE_ALL=OFF
         -DTHEROCK_BUILD_TESTING=ON

--- a/.github/workflows/therock-rccl-ci.yml
+++ b/.github/workflows/therock-rccl-ci.yml
@@ -16,7 +16,7 @@ on:
       notify_email:
         description: 'Email address to send test summary report'
         type: string
-        default: ''
+        default: 'prmuruge@amd.com'
 
 permissions:
   contents: read
@@ -80,7 +80,7 @@ jobs:
       package_version: ADHOCBUILD
       artifact_run_id: ${{ inputs.artifact_run_id }}
       test_scope: ${{ inputs.test_scope || 'smoke' }}
-      notify_email: ${{ inputs.notify_email }}
+      notify_email: ${{ inputs.notify_email || 'prmuruge@amd.com' }}
       cmake_options: >
         -DTHEROCK_ENABLE_ALL=OFF
         -DTHEROCK_BUILD_TESTING=ON

--- a/.github/workflows/therock-rccl-ci.yml
+++ b/.github/workflows/therock-rccl-ci.yml
@@ -19,12 +19,7 @@ concurrency:
 jobs:
   setup:
     runs-on: ubuntu-24.04
-    env:
-      # The commit being checked out is the merge commit for a PR. Its first
-      # parent will be the tip of the base branch.
-      BASE_REF: HEAD^
     outputs:
-      enable_therock_ci: ${{ steps.configure.outputs.enable_therock_ci }}
       run_linux_ci: ${{ steps.rccl_check.outputs.run_linux_ci }}
 
     steps:
@@ -33,10 +28,6 @@ jobs:
         with:
           # We need the parent commit to do a diff
           fetch-depth: 2
-
-      - name: "Configuring CI options"
-        id: configure
-        run: python .github/scripts/therock_configure_ci.py
 
       - name: "Detect RCCL file changes"
         id: rccl_check

--- a/.github/workflows/therock-rccl-ci.yml
+++ b/.github/workflows/therock-rccl-ci.yml
@@ -64,6 +64,7 @@ jobs:
       amdgpu_families: ${{ matrix.amdgpu_family }}
       artifact_group: ${{ matrix.amdgpu_family }}
       event_name: ${{ github.event_name }}
+      package_version: ADHOCBUILD
       cmake_options: >
         -DTHEROCK_ENABLE_ALL=OFF
         -DTHEROCK_BUILD_TESTING=ON

--- a/.github/workflows/therock-rccl-ci.yml
+++ b/.github/workflows/therock-rccl-ci.yml
@@ -9,6 +9,10 @@ on:
         description: 'Reuse artifacts from a previous run ID (skips build)'
         type: string
         default: ''
+      test_scope:
+        description: 'smoke (22 curated tests, ~3min) or all'
+        type: string
+        default: 'smoke'
 
 permissions:
   contents: read
@@ -71,6 +75,7 @@ jobs:
       event_name: ${{ github.event_name }}
       package_version: ADHOCBUILD
       artifact_run_id: ${{ inputs.artifact_run_id }}
+      test_scope: ${{ inputs.test_scope || 'smoke' }}
       cmake_options: >
         -DTHEROCK_ENABLE_ALL=OFF
         -DTHEROCK_BUILD_TESTING=ON

--- a/.github/workflows/therock-rccl-ci.yml
+++ b/.github/workflows/therock-rccl-ci.yml
@@ -1,6 +1,8 @@
 name: TheRock CI for rccl
 
 on:
+  schedule:
+    - cron: '17 6 * * 0'  # Weekly, Sunday 06:17 UTC
   workflow_dispatch:
 
 permissions:
@@ -43,7 +45,10 @@ jobs:
           echo "Changed files:"
           git diff --name-only HEAD^
 
-          if git diff --name-only HEAD^ | grep -q '^projects/rccl/'; then
+          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "run_linux_ci=true" >> "$GITHUB_OUTPUT"
+            echo "Scheduled/manual run — always run CI"
+          elif git diff --name-only HEAD^ | grep -q '^projects/rccl/'; then
             echo "run_linux_ci=true" >> "$GITHUB_OUTPUT"
             echo "RCCL changes detected"
           else
@@ -67,6 +72,7 @@ jobs:
     with:
       amdgpu_families: ${{ matrix.amdgpu_family }}
       artifact_group: ${{ matrix.amdgpu_family }}
+      event_name: ${{ github.event_name }}
       cmake_options: >
         -DTHEROCK_ENABLE_ALL=OFF
         -DTHEROCK_BUILD_TESTING=ON

--- a/.github/workflows/therock-rccl-ci.yml
+++ b/.github/workflows/therock-rccl-ci.yml
@@ -16,7 +16,7 @@ on:
       notify_email:
         description: 'Email address to send test summary report'
         type: string
-        default: 'prmuruge@amd.com'
+        default: 'collectives-ci@amd.com'
 
 permissions:
   contents: read
@@ -80,7 +80,7 @@ jobs:
       package_version: ADHOCBUILD
       artifact_run_id: ${{ inputs.artifact_run_id }}
       test_scope: ${{ inputs.test_scope || 'smoke' }}
-      notify_email: ${{ inputs.notify_email || 'prmuruge@amd.com' }}
+      notify_email: ${{ inputs.notify_email || 'collectives-ci@amd.com' }}
       cmake_options: >
         -DTHEROCK_ENABLE_ALL=OFF
         -DTHEROCK_BUILD_TESTING=ON

--- a/.github/workflows/therock-rccl-ci.yml
+++ b/.github/workflows/therock-rccl-ci.yml
@@ -13,6 +13,10 @@ on:
         description: 'smoke (22 curated tests, ~3min) or all'
         type: string
         default: 'smoke'
+      notify_email:
+        description: 'Email address to send test summary report'
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -76,6 +80,7 @@ jobs:
       package_version: ADHOCBUILD
       artifact_run_id: ${{ inputs.artifact_run_id }}
       test_scope: ${{ inputs.test_scope || 'smoke' }}
+      notify_email: ${{ inputs.notify_email }}
       cmake_options: >
         -DTHEROCK_ENABLE_ALL=OFF
         -DTHEROCK_BUILD_TESTING=ON

--- a/.github/workflows/therock-rccl-test-pytorch-distributed.yml
+++ b/.github/workflows/therock-rccl-test-pytorch-distributed.yml
@@ -14,6 +14,9 @@ on:
       test_scope:
         type: string
         default: 'smoke'
+      notify_email:
+        type: string
+        default: ''
   workflow_dispatch:
     inputs:
       amdgpu_families:
@@ -28,6 +31,10 @@ on:
         description: 'smoke (22 curated tests, ~3min) or all'
         type: string
         default: 'smoke'
+      notify_email:
+        description: 'Email address to send test summary report'
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -102,16 +109,23 @@ jobs:
           TORCH_NCCL_BLOCKING_WAIT: 1
           TORCH_NCCL_ASYNC_ERROR_HANDLING: 1
         run: |
+          NOTIFY_ARGS=""
+          if [ -n "${{ inputs.notify_email }}" ]; then
+            NOTIFY_ARGS="--notify-email ${{ inputs.notify_email }}"
+          fi
           python rocm-systems/.github/scripts/test_pytorch_c10d.py \
             --artifact-dir ${{ env.OUTPUT_ARTIFACTS_DIR }} \
             --pytorch-src ${{ env.PYTORCH_SRC }} \
             --results-log ${{ env.PYTORCH_SRC }}/pytorch_c10d_results.log \
-            --test-scope ${{ inputs.test_scope || 'smoke' }}
+            --test-scope ${{ inputs.test_scope || 'smoke' }} \
+            $NOTIFY_ARGS
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pytorch-c10d-results-${{ inputs.amdgpu_families }}
-          path: ${{ env.PYTORCH_SRC }}/pytorch_c10d_results.log
+          path: |
+            ${{ env.PYTORCH_SRC }}/pytorch_c10d_results.log
+            ${{ env.PYTORCH_SRC }}/pytorch_c10d_summary.txt
           retention-days: 14

--- a/.github/workflows/therock-rccl-test-pytorch-distributed.yml
+++ b/.github/workflows/therock-rccl-test-pytorch-distributed.yml
@@ -49,6 +49,7 @@ jobs:
       VENV_DIR: ${{ github.workspace }}/.venv
       ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id }}"
       OUTPUT_ARTIFACTS_DIR: "./build"
+      PYTORCH_SRC: ${{ github.workspace }}/pytorch-src
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -87,12 +88,20 @@ jobs:
             echo "ROCM_LIB_DIR=$ROCM_LIB_DIR" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Install PyTorch ROCm nightly
-        timeout-minutes: 10
+      - name: Install PyTorch and test dependencies
+        timeout-minutes: 15
         run: |
           source ${{ env.VENV_DIR }}/bin/activate
-          pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/rocm7.2
-          pip install pytest
+          pip install --pre \
+            "torch[device-gfx942]" \
+            --index-url https://rocm.nightlies.amd.com/whl-multi-arch/
+          pip install \
+            pytest \
+            pytest-timeout \
+            "expecttest>=0.3.0" \
+            hypothesis \
+            numpy \
+            psutil
 
       - name: Verify RCCL override
         run: |
@@ -110,25 +119,25 @@ jobs:
           echo "CI-built RCCL: $(ls -la $CI_RCCL)"
           echo "PyTorch bundled RCCL: $(ls -la $TORCH_RCCL 2>/dev/null || echo 'not found')"
 
-      - name: Fetch PyTorch test files
+      - name: Clone PyTorch test sources
         run: |
           source ${{ env.VENV_DIR }}/bin/activate
           TORCH_VERSION=$(python -c "import torch; print(torch.__version__.split('+')[0])")
           echo "PyTorch version: ${TORCH_VERSION}"
 
-          mkdir -p pytorch_tests
-          cd pytorch_tests
-
-          BASE_URL="https://raw.githubusercontent.com/pytorch/pytorch/v${TORCH_VERSION}"
-          if ! curl -sfL "${BASE_URL}/test/distributed/test_c10d_nccl.py" -o test_c10d_nccl.py; then
-            echo "Tag v${TORCH_VERSION} not found, using main branch"
-            BASE_URL="https://raw.githubusercontent.com/pytorch/pytorch/main"
-            curl -sfL "${BASE_URL}/test/distributed/test_c10d_nccl.py" -o test_c10d_nccl.py
+          GIT_REF="v${TORCH_VERSION}"
+          if ! git ls-remote --tags https://github.com/pytorch/pytorch.git "$GIT_REF" | grep -q .; then
+            echo "Tag ${GIT_REF} not found, using nightly branch"
+            GIT_REF="nightly"
           fi
-          curl -sfL "${BASE_URL}/test/distributed/test_c10d_common.py" -o test_c10d_common.py
 
-          echo "Downloaded test files:"
-          ls -la *.py
+          git clone --depth=1 --branch "$GIT_REF" --filter=blob:none \
+            --sparse https://github.com/pytorch/pytorch.git "${{ env.PYTORCH_SRC }}"
+          cd "${{ env.PYTORCH_SRC }}"
+          git sparse-checkout set test/ torch/testing/
+
+          echo "Test files:"
+          ls -la test/distributed/test_c10d_nccl.py test/distributed/test_c10d_common.py
 
       - name: Run PyTorch c10d NCCL tests
         timeout-minutes: 60
@@ -139,8 +148,12 @@ jobs:
         run: |
           set -o pipefail
           export LD_LIBRARY_PATH="${{ steps.rccl_path.outputs.RCCL_LIB_DIR }}:${{ steps.rccl_path.outputs.ROCM_LIB_DIR }}:${LD_LIBRARY_PATH}"
+          export MIOPEN_USER_DB_PATH="/tmp/miopen_cache_$$"
+          mkdir -p "$MIOPEN_USER_DB_PATH"
           source ${{ env.VENV_DIR }}/bin/activate
-          cd pytorch_tests
+
+          cd ${{ env.PYTORCH_SRC }}
+          export PYTHONPATH="${PWD}/test:${PYTHONPATH:-}"
 
           NUM_GPUS=$(python -c "import torch; print(torch.cuda.device_count())")
           echo "Detected GPUs: ${NUM_GPUS}"
@@ -153,14 +166,11 @@ jobs:
           print(f'LD_LIBRARY_PATH: {os.environ.get(\"LD_LIBRARY_PATH\", \"\")}')
           "
 
-          torchrun \
-            --nproc_per_node=${NUM_GPUS} \
-            --nnodes=1 \
-            --standalone \
-            test_c10d_nccl.py \
-            --use-pytest \
+          python -m pytest test/distributed/test_c10d_nccl.py \
             -v \
-            -k "test_allreduce or test_allgather_base or test_broadcast or test_reduce_scatter_base or test_barrier" \
+            --timeout=600 \
+            --tb=short \
+            -k "not NCCLTraceTestDumpOnTimeout" \
             2>&1 | tee pytorch_c10d_results.log
 
       - name: Upload test results
@@ -168,5 +178,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: pytorch-c10d-results-${{ inputs.amdgpu_families }}
-          path: pytorch_tests/pytorch_c10d_results.log
+          path: ${{ env.PYTORCH_SRC }}/pytorch_c10d_results.log
           retention-days: 14

--- a/.github/workflows/therock-rccl-test-pytorch-distributed.yml
+++ b/.github/workflows/therock-rccl-test-pytorch-distributed.yml
@@ -91,7 +91,7 @@ jobs:
         timeout-minutes: 10
         run: |
           source ${{ env.VENV_DIR }}/bin/activate
-          pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/rocm6.3
+          pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/rocm7.2
           pip install pytest
 
       - name: Verify RCCL override

--- a/.github/workflows/therock-rccl-test-pytorch-distributed.yml
+++ b/.github/workflows/therock-rccl-test-pytorch-distributed.yml
@@ -77,10 +77,10 @@ jobs:
       - name: Install PyTorch and test dependencies
         timeout-minutes: 15
         run: |
-          python -m pip install --pre \
+          uv pip install --prerelease=allow \
             "torch[device-gfx942]" \
             --index-url https://rocm.nightlies.amd.com/whl-multi-arch/
-          python -m pip install \
+          uv pip install \
             pytest \
             pytest-timeout \
             "expecttest>=0.3.0" \

--- a/.github/workflows/therock-rccl-test-pytorch-distributed.yml
+++ b/.github/workflows/therock-rccl-test-pytorch-distributed.yml
@@ -1,0 +1,133 @@
+name: TheRock Test PyTorch Distributed for rccl
+
+on:
+  workflow_call:
+    inputs:
+      amdgpu_families:
+        type: string
+      artifact_group:
+        type: string
+      test_runs_on:
+        type: string
+      artifact_run_id:
+        type: string
+  workflow_dispatch:
+    inputs:
+      amdgpu_families:
+        type: string
+      artifact_group:
+        type: string
+      test_runs_on:
+        type: string
+      artifact_run_id:
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  test_pytorch_distributed:
+    name: 'Test PyTorch c10d NCCL'
+    runs-on: ${{ inputs.test_runs_on }}
+    container:
+      image: ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:4150afe4759d14822f0e3f8930e1124f26e11f68b5c7b91ec9a02b20b1ebbb98
+      options: --ipc host
+        --group-add video
+        --device /dev/kfd
+        --device /dev/dri
+        --group-add 110
+        --group-add 993
+        --group-add 992
+        --ulimit memlock=-1:-1
+        --security-opt seccomp=unconfined
+        --env-file /etc/podinfo/gha-gpu-isolation-settings
+        --user 0:0
+    defaults:
+      run:
+        shell: bash
+    env:
+      VENV_DIR: ${{ github.workspace }}/.venv
+      ARTIFACT_RUN_ID: "${{ inputs.artifact_run_id }}"
+      OUTPUT_ARTIFACTS_DIR: "./build"
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: "ROCm/TheRock"
+          ref: 99f48ca9ecc4f3c92dadc2baef9e560e5e7d18b0 # 2026-07-07 commit
+
+      - name: Run setup test environment workflow
+        uses: './.github/actions/setup_test_environment'
+        with:
+          ARTIFACT_RUN_ID: ${{ env.ARTIFACT_RUN_ID }}
+          AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
+          ARTIFACT_GROUP: ${{ inputs.artifact_group }}
+          OUTPUT_ARTIFACTS_DIR: ${{ env.OUTPUT_ARTIFACTS_DIR }}
+          VENV_DIR: ${{ env.VENV_DIR }}
+          FETCH_ARTIFACT_ARGS: "--rccl --tests"
+          IS_PR_FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
+
+      - name: Install PyTorch ROCm nightly
+        timeout-minutes: 10
+        run: |
+          source ${{ env.VENV_DIR }}/bin/activate
+          pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/rocm6.3
+
+      - name: Fetch PyTorch test files
+        run: |
+          source ${{ env.VENV_DIR }}/bin/activate
+          TORCH_VERSION=$(python -c "import torch; print(torch.__version__.split('+')[0])")
+          echo "PyTorch version: ${TORCH_VERSION}"
+
+          mkdir -p pytorch_tests
+          cd pytorch_tests
+
+          BASE_URL="https://raw.githubusercontent.com/pytorch/pytorch/v${TORCH_VERSION}"
+          if ! curl -sfL "${BASE_URL}/test/distributed/test_c10d_nccl.py" -o test_c10d_nccl.py; then
+            echo "Tag v${TORCH_VERSION} not found, using main branch"
+            BASE_URL="https://raw.githubusercontent.com/pytorch/pytorch/main"
+            curl -sfL "${BASE_URL}/test/distributed/test_c10d_nccl.py" -o test_c10d_nccl.py
+          fi
+          curl -sfL "${BASE_URL}/test/distributed/test_c10d_common.py" -o test_c10d_common.py
+
+          echo "Downloaded test files:"
+          ls -la *.py
+
+      - name: Run PyTorch c10d NCCL tests
+        timeout-minutes: 60
+        env:
+          LD_LIBRARY_PATH: "${{ github.workspace }}/build/lib:${{ github.workspace }}/build/dist/rocm/lib:${LD_LIBRARY_PATH}"
+          NCCL_DEBUG: INFO
+          TORCH_NCCL_BLOCKING_WAIT: 1
+          TORCH_NCCL_ASYNC_ERROR_HANDLING: 1
+        run: |
+          source ${{ env.VENV_DIR }}/bin/activate
+          cd pytorch_tests
+
+          NUM_GPUS=$(python -c "import torch; print(torch.cuda.device_count())")
+          echo "Detected GPUs: ${NUM_GPUS}"
+
+          python -c "
+          import torch, os
+          print(f'PyTorch: {torch.__version__}')
+          print(f'CUDA/HIP available: {torch.cuda.is_available()}')
+          print(f'GPU count: {torch.cuda.device_count()}')
+          print(f'LD_LIBRARY_PATH: {os.environ.get(\"LD_LIBRARY_PATH\", \"\")}')
+          "
+
+          torchrun \
+            --nproc_per_node=${NUM_GPUS} \
+            --nnodes=1 \
+            --standalone \
+            test_c10d_nccl.py \
+            -v \
+            -k "test_allreduce or test_allgather_base or test_broadcast or test_reduce_scatter_base or test_barrier" \
+            2>&1 | tee pytorch_c10d_results.log
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytorch-c10d-results-${{ inputs.amdgpu_families }}
+          path: pytorch_tests/pytorch_c10d_results.log
+          retention-days: 14

--- a/.github/workflows/therock-rccl-test-pytorch-distributed.yml
+++ b/.github/workflows/therock-rccl-test-pytorch-distributed.yml
@@ -77,10 +77,10 @@ jobs:
       - name: Install PyTorch and test dependencies
         timeout-minutes: 15
         run: |
-          pip install --pre \
+          python -m pip install --pre \
             "torch[device-gfx942]" \
             --index-url https://rocm.nightlies.amd.com/whl-multi-arch/
-          pip install \
+          python -m pip install \
             pytest \
             pytest-timeout \
             "expecttest>=0.3.0" \

--- a/.github/workflows/therock-rccl-test-pytorch-distributed.yml
+++ b/.github/workflows/therock-rccl-test-pytorch-distributed.yml
@@ -77,7 +77,6 @@ jobs:
       - name: Install PyTorch and test dependencies
         timeout-minutes: 15
         run: |
-          source ${{ env.VENV_DIR }}/bin/activate
           pip install --pre \
             "torch[device-gfx942]" \
             --index-url https://rocm.nightlies.amd.com/whl-multi-arch/
@@ -96,7 +95,6 @@ jobs:
           TORCH_NCCL_BLOCKING_WAIT: 1
           TORCH_NCCL_ASYNC_ERROR_HANDLING: 1
         run: |
-          source ${{ env.VENV_DIR }}/bin/activate
           python rocm-systems/.github/scripts/test_pytorch_c10d.py \
             --artifact-dir ${{ env.OUTPUT_ARTIFACTS_DIR }} \
             --pytorch-src ${{ env.PYTORCH_SRC }} \

--- a/.github/workflows/therock-rccl-test-pytorch-distributed.yml
+++ b/.github/workflows/therock-rccl-test-pytorch-distributed.yml
@@ -95,9 +95,8 @@ jobs:
           pip install pytest
 
       - name: Verify RCCL override
-        env:
-          LD_LIBRARY_PATH: "${{ steps.rccl_path.outputs.RCCL_LIB_DIR }}:${{ steps.rccl_path.outputs.ROCM_LIB_DIR }}:${LD_LIBRARY_PATH}"
         run: |
+          export LD_LIBRARY_PATH="${{ steps.rccl_path.outputs.RCCL_LIB_DIR }}:${{ steps.rccl_path.outputs.ROCM_LIB_DIR }}:${LD_LIBRARY_PATH}"
           source ${{ env.VENV_DIR }}/bin/activate
           python -c "
           import ctypes, os
@@ -134,11 +133,12 @@ jobs:
       - name: Run PyTorch c10d NCCL tests
         timeout-minutes: 60
         env:
-          LD_LIBRARY_PATH: "${{ steps.rccl_path.outputs.RCCL_LIB_DIR }}:${{ steps.rccl_path.outputs.ROCM_LIB_DIR }}:${LD_LIBRARY_PATH}"
           NCCL_DEBUG: INFO
           TORCH_NCCL_BLOCKING_WAIT: 1
           TORCH_NCCL_ASYNC_ERROR_HANDLING: 1
         run: |
+          set -o pipefail
+          export LD_LIBRARY_PATH="${{ steps.rccl_path.outputs.RCCL_LIB_DIR }}:${{ steps.rccl_path.outputs.ROCM_LIB_DIR }}:${LD_LIBRARY_PATH}"
           source ${{ env.VENV_DIR }}/bin/activate
           cd pytorch_tests
 

--- a/.github/workflows/therock-rccl-test-pytorch-distributed.yml
+++ b/.github/workflows/therock-rccl-test-pytorch-distributed.yml
@@ -127,5 +127,6 @@ jobs:
           name: pytorch-c10d-results-${{ inputs.amdgpu_families }}
           path: |
             ${{ env.PYTORCH_SRC }}/pytorch_c10d_results.log
+            ${{ env.PYTORCH_SRC }}/pytorch_c10d_results.xml
             ${{ env.PYTORCH_SRC }}/pytorch_c10d_summary.txt
           retention-days: 14

--- a/.github/workflows/therock-rccl-test-pytorch-distributed.yml
+++ b/.github/workflows/therock-rccl-test-pytorch-distributed.yml
@@ -11,6 +11,9 @@ on:
         type: string
       artifact_run_id:
         type: string
+      test_scope:
+        type: string
+        default: 'smoke'
   workflow_dispatch:
     inputs:
       amdgpu_families:
@@ -21,6 +24,10 @@ on:
         type: string
       artifact_run_id:
         type: string
+      test_scope:
+        description: 'smoke (22 curated tests, ~3min) or all'
+        type: string
+        default: 'smoke'
 
 permissions:
   contents: read
@@ -98,7 +105,8 @@ jobs:
           python rocm-systems/.github/scripts/test_pytorch_c10d.py \
             --artifact-dir ${{ env.OUTPUT_ARTIFACTS_DIR }} \
             --pytorch-src ${{ env.PYTORCH_SRC }} \
-            --results-log ${{ env.PYTORCH_SRC }}/pytorch_c10d_results.log
+            --results-log ${{ env.PYTORCH_SRC }}/pytorch_c10d_results.log \
+            --test-scope ${{ inputs.test_scope || 'smoke' }}
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/therock-rccl-test-pytorch-distributed.yml
+++ b/.github/workflows/therock-rccl-test-pytorch-distributed.yml
@@ -67,11 +67,49 @@ jobs:
           FETCH_ARTIFACT_ARGS: "--rccl --tests"
           IS_PR_FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
 
+      - name: Discover RCCL library path
+        id: rccl_path
+        run: |
+          source ${{ env.VENV_DIR }}/bin/activate
+          RCCL_LIB=$(find ${{ env.OUTPUT_ARTIFACTS_DIR }} -name 'librccl.so' -type f | head -1)
+          if [ -z "$RCCL_LIB" ]; then
+            echo "ERROR: librccl.so not found in artifacts"
+            find ${{ env.OUTPUT_ARTIFACTS_DIR }} -name '*.so' | head -20
+            exit 1
+          fi
+          RCCL_LIB_DIR=$(dirname "$RCCL_LIB")
+          echo "Found librccl.so at: $RCCL_LIB"
+          echo "RCCL_LIB_DIR=$RCCL_LIB_DIR" >> "$GITHUB_OUTPUT"
+
+          ROCM_LIB_DIR=$(find ${{ env.OUTPUT_ARTIFACTS_DIR }} -path '*/dist/rocm/lib' -type d | head -1)
+          if [ -n "$ROCM_LIB_DIR" ]; then
+            echo "Found ROCm lib dir: $ROCM_LIB_DIR"
+            echo "ROCM_LIB_DIR=$ROCM_LIB_DIR" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Install PyTorch ROCm nightly
         timeout-minutes: 10
         run: |
           source ${{ env.VENV_DIR }}/bin/activate
           pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/rocm6.3
+          pip install pytest
+
+      - name: Verify RCCL override
+        env:
+          LD_LIBRARY_PATH: "${{ steps.rccl_path.outputs.RCCL_LIB_DIR }}:${{ steps.rccl_path.outputs.ROCM_LIB_DIR }}:${LD_LIBRARY_PATH}"
+        run: |
+          source ${{ env.VENV_DIR }}/bin/activate
+          python -c "
+          import ctypes, os
+          rccl = ctypes.CDLL('librccl.so')
+          print(f'Loaded librccl.so from LD_LIBRARY_PATH')
+          print(f'LD_LIBRARY_PATH: {os.environ.get(\"LD_LIBRARY_PATH\", \"\")}')
+          "
+
+          CI_RCCL="${{ steps.rccl_path.outputs.RCCL_LIB_DIR }}/librccl.so"
+          TORCH_RCCL=$(python -c "import torch; import os; print(os.path.join(os.path.dirname(torch.__file__), 'lib', 'librccl.so'))")
+          echo "CI-built RCCL: $(ls -la $CI_RCCL)"
+          echo "PyTorch bundled RCCL: $(ls -la $TORCH_RCCL 2>/dev/null || echo 'not found')"
 
       - name: Fetch PyTorch test files
         run: |
@@ -96,7 +134,7 @@ jobs:
       - name: Run PyTorch c10d NCCL tests
         timeout-minutes: 60
         env:
-          LD_LIBRARY_PATH: "${{ github.workspace }}/build/lib:${{ github.workspace }}/build/dist/rocm/lib:${LD_LIBRARY_PATH}"
+          LD_LIBRARY_PATH: "${{ steps.rccl_path.outputs.RCCL_LIB_DIR }}:${{ steps.rccl_path.outputs.ROCM_LIB_DIR }}:${LD_LIBRARY_PATH}"
           NCCL_DEBUG: INFO
           TORCH_NCCL_BLOCKING_WAIT: 1
           TORCH_NCCL_ASYNC_ERROR_HANDLING: 1
@@ -120,6 +158,7 @@ jobs:
             --nnodes=1 \
             --standalone \
             test_c10d_nccl.py \
+            --use-pytest \
             -v \
             -k "test_allreduce or test_allgather_base or test_broadcast or test_reduce_scatter_base or test_barrier" \
             2>&1 | tee pytorch_c10d_results.log

--- a/.github/workflows/therock-rccl-test-pytorch-distributed.yml
+++ b/.github/workflows/therock-rccl-test-pytorch-distributed.yml
@@ -57,6 +57,12 @@ jobs:
           repository: "ROCm/TheRock"
           ref: 99f48ca9ecc4f3c92dadc2baef9e560e5e7d18b0 # 2026-07-07 commit
 
+      - name: Checkout rocm-systems scripts
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          sparse-checkout: .github/scripts
+          path: rocm-systems
+
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'
         with:
@@ -67,26 +73,6 @@ jobs:
           VENV_DIR: ${{ env.VENV_DIR }}
           FETCH_ARTIFACT_ARGS: "--rccl --tests"
           IS_PR_FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
-
-      - name: Discover RCCL library path
-        id: rccl_path
-        run: |
-          source ${{ env.VENV_DIR }}/bin/activate
-          RCCL_LIB=$(find ${{ env.OUTPUT_ARTIFACTS_DIR }} -name 'librccl.so' -type f | head -1)
-          if [ -z "$RCCL_LIB" ]; then
-            echo "ERROR: librccl.so not found in artifacts"
-            find ${{ env.OUTPUT_ARTIFACTS_DIR }} -name '*.so' | head -20
-            exit 1
-          fi
-          RCCL_LIB_DIR=$(dirname "$RCCL_LIB")
-          echo "Found librccl.so at: $RCCL_LIB"
-          echo "RCCL_LIB_DIR=$RCCL_LIB_DIR" >> "$GITHUB_OUTPUT"
-
-          ROCM_LIB_DIR=$(find ${{ env.OUTPUT_ARTIFACTS_DIR }} -path '*/dist/rocm/lib' -type d | head -1)
-          if [ -n "$ROCM_LIB_DIR" ]; then
-            echo "Found ROCm lib dir: $ROCM_LIB_DIR"
-            echo "ROCM_LIB_DIR=$ROCM_LIB_DIR" >> "$GITHUB_OUTPUT"
-          fi
 
       - name: Install PyTorch and test dependencies
         timeout-minutes: 15
@@ -103,42 +89,6 @@ jobs:
             numpy \
             psutil
 
-      - name: Verify RCCL override
-        run: |
-          export LD_LIBRARY_PATH="${{ steps.rccl_path.outputs.RCCL_LIB_DIR }}:${{ steps.rccl_path.outputs.ROCM_LIB_DIR }}:${LD_LIBRARY_PATH}"
-          source ${{ env.VENV_DIR }}/bin/activate
-          python -c "
-          import ctypes, os
-          rccl = ctypes.CDLL('librccl.so')
-          print(f'Loaded librccl.so from LD_LIBRARY_PATH')
-          print(f'LD_LIBRARY_PATH: {os.environ.get(\"LD_LIBRARY_PATH\", \"\")}')
-          "
-
-          CI_RCCL="${{ steps.rccl_path.outputs.RCCL_LIB_DIR }}/librccl.so"
-          TORCH_RCCL=$(python -c "import torch; import os; print(os.path.join(os.path.dirname(torch.__file__), 'lib', 'librccl.so'))")
-          echo "CI-built RCCL: $(ls -la $CI_RCCL)"
-          echo "PyTorch bundled RCCL: $(ls -la $TORCH_RCCL 2>/dev/null || echo 'not found')"
-
-      - name: Clone PyTorch test sources
-        run: |
-          source ${{ env.VENV_DIR }}/bin/activate
-          TORCH_VERSION=$(python -c "import torch; print(torch.__version__.split('+')[0])")
-          echo "PyTorch version: ${TORCH_VERSION}"
-
-          GIT_REF="v${TORCH_VERSION}"
-          if ! git ls-remote --tags https://github.com/pytorch/pytorch.git "$GIT_REF" | grep -q .; then
-            echo "Tag ${GIT_REF} not found, using nightly branch"
-            GIT_REF="nightly"
-          fi
-
-          git clone --depth=1 --branch "$GIT_REF" --filter=blob:none \
-            --sparse https://github.com/pytorch/pytorch.git "${{ env.PYTORCH_SRC }}"
-          cd "${{ env.PYTORCH_SRC }}"
-          git sparse-checkout set test/ torch/testing/
-
-          echo "Test files:"
-          ls -la test/distributed/test_c10d_nccl.py test/distributed/test_c10d_common.py
-
       - name: Run PyTorch c10d NCCL tests
         timeout-minutes: 60
         env:
@@ -146,36 +96,15 @@ jobs:
           TORCH_NCCL_BLOCKING_WAIT: 1
           TORCH_NCCL_ASYNC_ERROR_HANDLING: 1
         run: |
-          set -o pipefail
-          export LD_LIBRARY_PATH="${{ steps.rccl_path.outputs.RCCL_LIB_DIR }}:${{ steps.rccl_path.outputs.ROCM_LIB_DIR }}:${LD_LIBRARY_PATH}"
-          export MIOPEN_USER_DB_PATH="/tmp/miopen_cache_$$"
-          mkdir -p "$MIOPEN_USER_DB_PATH"
           source ${{ env.VENV_DIR }}/bin/activate
-
-          cd ${{ env.PYTORCH_SRC }}
-          export PYTHONPATH="${PWD}/test:${PYTHONPATH:-}"
-
-          NUM_GPUS=$(python -c "import torch; print(torch.cuda.device_count())")
-          echo "Detected GPUs: ${NUM_GPUS}"
-
-          python -c "
-          import torch, os
-          print(f'PyTorch: {torch.__version__}')
-          print(f'CUDA/HIP available: {torch.cuda.is_available()}')
-          print(f'GPU count: {torch.cuda.device_count()}')
-          print(f'LD_LIBRARY_PATH: {os.environ.get(\"LD_LIBRARY_PATH\", \"\")}')
-          "
-
-          python -m pytest test/distributed/test_c10d_nccl.py \
-            -v \
-            --timeout=600 \
-            --tb=short \
-            -k "not NCCLTraceTestDumpOnTimeout" \
-            2>&1 | tee pytorch_c10d_results.log
+          python rocm-systems/.github/scripts/test_pytorch_c10d.py \
+            --artifact-dir ${{ env.OUTPUT_ARTIFACTS_DIR }} \
+            --pytorch-src ${{ env.PYTORCH_SRC }} \
+            --results-log ${{ env.PYTORCH_SRC }}/pytorch_c10d_results.log
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pytorch-c10d-results-${{ inputs.amdgpu_families }}
           path: ${{ env.PYTORCH_SRC }}/pytorch_c10d_results.log


### PR DESCRIPTION
## Summary

- Add a scheduled weekly run (Sunday 06:17 UTC) that exercises PyTorch's `test_c10d_nccl.py` against the CI-built RCCL on the MI325 4-GPU runner
- The PyTorch test job is gated on `schedule`/`workflow_dispatch` events so it never runs on PR builds
- Installs PyTorch ROCm nightly wheels, fetches matching test files, overrides RCCL via `LD_LIBRARY_PATH`, and runs a smoke subset of collective tests via `torchrun`

JIRA ID: AICOMRCCL-1506
 [AICOMRCCL-1506](https://amd-hub.atlassian.net/browse/AICOMRCCL-1506)
## Changes

- `therock-ci.yml`: add schedule trigger, pass `event_name` downstream
- `therock-ci-linux.yml`: accept `event_name` input, add conditional PyTorch test job
- `therock-test-pytorch-distributed.yml`: new reusable test workflow

## Test plan

- [ ] Trigger via `workflow_dispatch` to verify the PyTorch job runs
- [ ] Verify PyTorch nightly installs successfully in the container
- [ ] Verify RCCL override via `LD_LIBRARY_PATH` loads the CI-built RCCL
- [ ] Verify `torchrun` runs the c10d smoke tests to completion
- [ ] Verify the job is skipped on normal PR builds

[AICOMRCCL-1506]: https://amd-hub.atlassian.net/browse/AICOMRCCL-1506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ