### PR TITLE
[CI] [Docs] Fix an edge case missed by update-docs.yml

### DIFF
--- a/.github/docs-config.json
+++ b/.github/docs-config.json
@@ -84,6 +84,11 @@
       "folder": "hipfile",
       "rtd_slug": "advanced-micro-devices-hipfile",
       "rtd_alias": "hipFile"
+    },
+    {
+      "folder": "rocdbgapi",
+      "rtd_slug": "advanced-micro-devices-rocdbgapi-docs",
+      "rtd_alias": "ROCdbgapi"
     }
   ]
 }

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -73,11 +73,16 @@ jobs:
           )
 
           for project in $changed_projects; do
-            slug="advanced-micro-devices-$project"
-            if echo "$project_list" | grep -Fxq "$slug"; then
+
+            # Load the map and look up the rtd_slug by project name (folder name)
+            project_slug=$(jq -r --arg folder_name "$project" \
+              '.projects[] | select(.folder == $folder_name) | .rtd_slug' \
+              .github/docs-config.json)
+
+            if echo "$project_list" | grep -Fxq "$project_slug"; then
               latest_branch=$(curl -s \
                   -H "Authorization: Token $RTD_TOKEN" \
-                  "https://app.readthedocs.com/api/v3/projects/$slug/" \
+                  "https://app.readthedocs.com/api/v3/projects/$project_slug/" \
                   | jq -r ".default_branch" \
                   | tr -d '[:space:]')
               echo "Latest branch for $project: $latest_branch"
@@ -85,7 +90,7 @@ jobs:
                 echo "Detected latest release branch, trigger builds for 'latest' version"
                 response=$(curl -f -s -X POST \
                       -H "Authorization: Token $RTD_TOKEN" \
-                      "https://readthedocs.com/api/v3/projects/$slug/versions/latest/builds/") || {
+                      "https://readthedocs.com/api/v3/projects/$project_slug/versions/latest/builds/") || {
                       echo "Failed to trigger RTD build for $project. Response: $response"
                       exit 1
                     }
@@ -94,7 +99,7 @@ jobs:
               echo "Triggering RTD build for $project, version: $version_slug"
               response=$(curl -f -s -X POST \
                   -H "Authorization: Token $RTD_TOKEN" \
-                  "https://readthedocs.com/api/v3/projects/$slug/versions/$version_slug/builds/") || {
+                  "https://readthedocs.com/api/v3/projects/$project_slug/versions/$version_slug/builds/") || {
                   echo "Failed to trigger RTD build for $project. Response: $response"
                   exit 1
               }


### PR DESCRIPTION
## Motivation

To resolve a "project not found" error from update-docs.yml: https://github.com/ROCm/rocm-systems/actions/runs/29004064811/job/86071296796

## Technical Details

The pipeline hardcoded project_slug uses `advanced-micro-device-` + project folder name. Works for most of the projects. However, in some edge cases (i.e. rocdbgapi), the formula fails.

To resolve this, added a lookup loop to extract `project_slug` through a pre-defined lookup table.

## JIRA ID

JIRA ID: AIROCDOC-4084

## Test Plan

Locally ran the added lookup code, check if output matches true project_slugs.

## Test Result

<img width="1649" height="49" alt="image" src="https://github.com/user-attachments/assets/2334d425-2527-4f4d-b18e-0b6b1c8aaa50" />


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
