### PR TITLE
ci: invert .github/workflows path filter for TheRock CI skip

### DIFF
--- a/.github/scripts/tests/therock_configure_ci_test.py
+++ b/.github/scripts/tests/therock_configure_ci_test.py
@@ -123,6 +123,22 @@ class ConfigureCITest(unittest.TestCase):
             therock_configure_ci.is_path_skippable(".github/workflows/labeler.yml")
         )
 
+        # Workflow/script files unrelated to TheRock CI are skippable without
+        # needing to be enumerated (issue #7849).
+        self.assertTrue(
+            therock_configure_ci.is_path_skippable(".github/workflows/rdc-ci.yml")
+        )
+        self.assertTrue(
+            therock_configure_ci.is_path_skippable(
+                ".github/workflows/amdsmi-manylinux-build.yml"
+            )
+        )
+        self.assertTrue(
+            therock_configure_ci.is_path_skippable(
+                ".github/workflows/rocjitsu-corpus-tests.yml"
+            )
+        )
+
         # Test non-skippable patterns
         self.assertFalse(
             therock_configure_ci.is_path_skippable("projects/rocminfo/src/main.cpp")
@@ -130,6 +146,17 @@ class ConfigureCITest(unittest.TestCase):
         self.assertFalse(therock_configure_ci.is_path_skippable("CMakeLists.txt"))
         self.assertFalse(
             therock_configure_ci.is_path_skippable("projects/rocminfo/test/test.cpp")
+        )
+
+        # TheRock CI workflow and script files are non-skippable so changes to
+        # them still trigger CI.
+        self.assertFalse(
+            therock_configure_ci.is_path_skippable(".github/workflows/therock-ci.yml")
+        )
+        self.assertFalse(
+            therock_configure_ci.is_path_skippable(
+                ".github/scripts/therock_configure_ci.py"
+            )
         )
 
     def test_check_for_non_skippable_path(self):

--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -144,14 +144,17 @@ SKIPPABLE_PATH_PATTERNS = [
     "experimental/python/perfxpert/*",
     ".github/CODEOWNERS",
     ".github/label*.yml",
-    ".github/workflows/labeler.yml",
-    ".github/workflows/amdsmi-manylinux-build.yml",
-    ".github/workflows/rocjitsu-corpus-tests.yml",
 ]
 
 
 def is_path_skippable(path: str) -> bool:
     """Determines if a given relative path to a file matches any skippable patterns."""
+    # A .github/workflows/ file only affects TheRock CI when it matches the
+    # CI-related patterns. Treat every other workflow file as skippable so
+    # unrelated workflows never trigger CI and don't need to be enumerated one
+    # by one.
+    if path.startswith(".github/workflows/"):
+        return not is_path_workflow_file_related_to_ci(path)
     return any(fnmatch.fnmatch(path, pattern) for pattern in SKIPPABLE_PATH_PATTERNS)
 
 


### PR DESCRIPTION
## Motivation

New non-TheRock workflows added under `.github/workflows/` (e.g. `rdc-ci.yml`) incorrectly trigger TheRock CI and block PRs, because CI-skip logic uses a hand-maintained blocklist that must be extended for every new workflow. This has been reported repeatedly. Inverting the check (only run CI for known-related workflow files) fixes the class of problem permanently.

## Technical Details

**CI path filter** (`.github/scripts/therock_configure_ci.py`):
- `is_path_skippable()` now treats any `.github/workflows/` file as skippable unless it matches the existing CI patterns (`therock*`), reusing `is_path_workflow_file_related_to_ci()`
- Removed the redundant `labeler.yml`, `amdsmi-manylinux-build.yml`, and `rocjitsu-corpus-tests.yml` entries from `SKIPPABLE_PATH_PATTERNS`
- Scope limited to `.github/workflows/` only; `.github/scripts/` behavior is unchanged so CI-gating scripts still trigger CI

**Tests** (`.github/scripts/tests/therock_configure_ci_test.py`):
- Added cases asserting unrelated workflows are skippable and TheRock CI workflow/script files are non-skippable

## JIRA ID

Closes #7849

## Test Plan

- `python3 -m pytest .github/scripts/tests/therock_configure_ci_test.py`

## Test Result

- 28 passed
