### PR TITLE
rccl: rename net-ib fault injection knob

### DIFF
--- a/projects/rccl/src/misc/ibvwrap.cc
+++ b/projects/rccl/src/misc/ibvwrap.cc
@@ -26,7 +26,7 @@ struct ncclIbvSymbols ibvSymbols;
 #ifdef ENABLE_FAULT_INJECTION
 // Fault shims installed on the context's ops table at open/close time.
 #include "net_ib_ops_fault.h"
-RCCL_PARAM_DECLARE(InjectFaults);
+RCCL_PARAM(IbFaultInjection, "IB_FAULT_INJECTION", 0);
 #endif
 
 #ifdef ENABLE_QP_TRACKING
@@ -159,7 +159,7 @@ const char *wrap_ibv_get_device_name(struct ibv_device *device) {
 
 ncclResult_t wrap_ibv_open_device(struct ibv_context **ret, struct ibv_device *device) { /*returns ncclResult_t (ncclSuccess on success)*/
 #ifdef ENABLE_FAULT_INJECTION
-  if (rcclParamInjectFaults() != 0) {
+  if (rcclParamIbFaultInjection() != 0) {
     // Expand IBV_PTR_CHECK inline to install fault shims before returning.
     CHECK_NOT_NULL(ibvSymbols, ibv_internal_open_device);
     *ret = ibvSymbols.ibv_internal_open_device(device);
@@ -185,7 +185,7 @@ ncclResult_t wrap_ibv_open_device(struct ibv_context **ret, struct ibv_device *d
 ncclResult_t wrap_ibv_close_device(struct ibv_context *context) { /*returns ncclResult_t (ncclSuccess on success)*/
 #ifdef ENABLE_FAULT_INJECTION
   // Restore original ops before closing so the real close sees a clean context.
-  if (rcclParamInjectFaults() != 0 && context) NCCLCHECK(ncclIbOpsFaultRemove(context));
+  if (rcclParamIbFaultInjection() != 0 && context) NCCLCHECK(ncclIbOpsFaultRemove(context));
 #endif
   IBV_INT_CHECK(ibvSymbols, ibv_internal_close_device, ibv_internal_close_device(context), -1, "ibv_close_device");
 }

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300_mellanox_ib_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300_mellanox_ib_func.json
@@ -598,7 +598,8 @@
         "RCCL_IB_QP_SCHED_UPDATE_INTERVAL": "100",
         "RCCL_IB_QP_SCHED_RESET_INTERVAL": "1000",
         "RCCL_IB_QP_SCHED_SPLIT_DATA_MIN": "2000",
-        "NCCL_IB_RETURN_ASYNC_EVENTS": "1"
+        "NCCL_IB_RETURN_ASYNC_EVENTS": "1",
+        "RCCL_IB_FAULT_INJECTION":     "1"
       },
       "tests": [
         {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -1191,7 +1191,8 @@
         "RCCL_IB_QP_SCHED_UPDATE_INTERVAL":   "100",
         "RCCL_IB_QP_SCHED_RESET_INTERVAL":    "1000",
         "RCCL_IB_QP_SCHED_SPLIT_DATA_MIN":    "2000",
-        "NCCL_IB_RETURN_ASYNC_EVENTS":         "1"
+        "NCCL_IB_RETURN_ASYNC_EVENTS":         "1",
+        "RCCL_IB_FAULT_INJECTION":             "1"
       },
       "tests": [
         {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce.json
@@ -1060,7 +1060,8 @@
         "RCCL_IB_QP_SCHED_UPDATE_INTERVAL":   "100",
         "RCCL_IB_QP_SCHED_RESET_INTERVAL":    "1000",
         "RCCL_IB_QP_SCHED_SPLIT_DATA_MIN":    "2000",
-        "NCCL_IB_RETURN_ASYNC_EVENTS":         "1"
+        "NCCL_IB_RETURN_ASYNC_EVENTS":         "1",
+        "RCCL_IB_FAULT_INJECTION":             "1"
       },
       "tests": [
         {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi355x_thor2_roce_func.json
@@ -604,7 +604,8 @@
         "RCCL_IB_QP_SCHED_UPDATE_INTERVAL": "100",
         "RCCL_IB_QP_SCHED_RESET_INTERVAL": "1000",
         "RCCL_IB_QP_SCHED_SPLIT_DATA_MIN": "2000",
-        "NCCL_IB_RETURN_ASYNC_EVENTS": "1"
+        "NCCL_IB_RETURN_ASYNC_EVENTS": "1",
+        "RCCL_IB_FAULT_INJECTION":     "1"
       },
       "tests": [
         {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce.json
@@ -613,7 +613,8 @@
         "RCCL_IB_QP_SCHED_UPDATE_INTERVAL": "100",
         "RCCL_IB_QP_SCHED_RESET_INTERVAL": "1000",
         "RCCL_IB_QP_SCHED_SPLIT_DATA_MIN": "2000",
-        "NCCL_IB_RETURN_ASYNC_EVENTS": "1"
+        "NCCL_IB_RETURN_ASYNC_EVENTS": "1",
+        "RCCL_IB_FAULT_INJECTION":     "1"
       },
       "tests": [
         {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce_func.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi455_ainic_roce_func.json
@@ -598,7 +598,8 @@
         "RCCL_IB_QP_SCHED_UPDATE_INTERVAL": "100",
         "RCCL_IB_QP_SCHED_RESET_INTERVAL": "1000",
         "RCCL_IB_QP_SCHED_SPLIT_DATA_MIN": "2000",
-        "NCCL_IB_RETURN_ASYNC_EVENTS": "1"
+        "NCCL_IB_RETURN_ASYNC_EVENTS": "1",
+        "RCCL_IB_FAULT_INJECTION":     "1"
       },
       "tests": [
         {

--- a/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/net_ib_transport.json
@@ -625,7 +625,8 @@
         "RCCL_IB_QP_SCHED_UPDATE_INTERVAL":   "100",
         "RCCL_IB_QP_SCHED_RESET_INTERVAL":    "1000",
         "RCCL_IB_QP_SCHED_SPLIT_DATA_MIN":    "2000",
-        "NCCL_IB_RETURN_ASYNC_EVENTS":         "1"
+        "NCCL_IB_RETURN_ASYNC_EVENTS":         "1",
+        "RCCL_IB_FAULT_INJECTION":             "1"
       },
       "tests": [
         {


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

This PR renames net_ib_cast FAULT INJECTION runtime gating env variable to separate it from kernel Fault injection

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
