### PR TITLE
Fix MaxWavesPerSIMD calculation in DXG topology

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/dxg/topology.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/topology.cpp
@@ -769,6 +769,17 @@ HSAKMT_STATUS topology_sysfs_get_node_props(uint32_t node_id, HsaNodeProperties&
   }
   props.NumSIMDPerCU = device->SimdPerCu();
   props.MaxSlotsScratchCU = device->MaxScratchSlotsPerCu();
+
+  // MaxWavesPerSIMD = (waves per CU) / (SIMDs per CU)
+  // WKMI provides wave_per_cu which is the total waves per CU.
+  // We need to divide by NumSIMDPerCU to get waves per SIMD.
+  if (props.NumSIMDPerCU > 0) {
+    props.MaxWavesPerSIMD = device->WavePerCu() / props.NumSIMDPerCU;
+  } else {
+    pr_err("NumSIMDPerCU is 0 for node %u, cannot calculate MaxWavesPerSIMD\n", node_id);
+    return HSAKMT_STATUS_ERROR;
+  }
+
   props.VendorId = 0x1002;
   props.DeviceId = device->DeviceId();
   props.LocationId = device->PciBusAddr();

--- a/projects/rocr-runtime/libhsakmt/src/dxg/topology.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/topology.cpp
@@ -767,18 +767,13 @@ HSAKMT_STATUS topology_sysfs_get_node_props(uint32_t node_id, HsaNodeProperties&
   } else {
     props.NumCUPerArray = device->ComputeUnitCount() / props.NumArrays;
   }
-  props.NumSIMDPerCU = device->SimdPerCu();
+  props.NumSIMDPerCU = simd_per_cu;
   props.MaxSlotsScratchCU = device->MaxScratchSlotsPerCu();
 
   // MaxWavesPerSIMD = (waves per CU) / (SIMDs per CU)
   // WKMI provides wave_per_cu which is the total waves per CU.
   // We need to divide by NumSIMDPerCU to get waves per SIMD.
-  if (props.NumSIMDPerCU > 0) {
-    props.MaxWavesPerSIMD = device->WavePerCu() / props.NumSIMDPerCU;
-  } else {
-    pr_err("NumSIMDPerCU is 0 for node %u, cannot calculate MaxWavesPerSIMD\n", node_id);
-    return HSAKMT_STATUS_ERROR;
-  }
+  props.MaxWavesPerSIMD = device->WavePerCu() / simd_per_cu;
 
   props.VendorId = 0x1002;
   props.DeviceId = device->DeviceId();


### PR DESCRIPTION
## Motivation
Calculate MaxWavesPerSIMD by dividing WavePerCu by NumSIMDPerCU with proper validation to prevent division by zero

## Technical Details
hip-tests failing on rocr backend due to incorrect MaxWavesPerSIMD 


## JIRA ID
JIRA ID - AIRUNTIME-1992

## Test Plan
All tests pass on both pal and rocr backend

Tests that fail becasue of incorrect calculation 
Unit_hiprtc_devicemalloc
Unit_hipDeviceGetGraphMemAttribute_Functional
Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Positive_RangeValidation
Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Positive_TemplateInvocation
Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_chkRange
Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_Functor
Unit_hipOccupancyMaxPotBlkSizeVariableSMemWithFlags_Lambda
Unit_hipOccupancyAvailableDynamicSMemPerBlock_Positive
Unit_Printf_specifier_Sanity_Positive
Unit_Buffered_Printf_Flags
Unit_Buffered_Printf_Specifier
Unit_Host_Printf
Unit_deviceAllocation_SingKernels_MulThreads
Unit_deviceAllocationFollowedByDeviceReset
Unit_AccessMallocAcrossKernels

## Test Result
All tests pass on both pal and rocr backend


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
