### PR TITLE
fix(rccl): fix ASAN dealloc mismatch and GIN memory leak

### DIFF
--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -545,7 +545,8 @@ static ncclResult_t commFree(ncclComm_t comm) {
       CUDACHECK(cudaEventDestroy(comm->sharedRes->scratchEvent));
       NCCLCHECK(ncclProxyDestroy(comm));
       NCCLCHECK(ncclGinFinalize(comm));
-      delete comm->sharedRes;
+      // sharedRes is allocated with ncclCalloc (malloc); free() it here to avoid mismatch.
+      free(comm->sharedRes);
     }
   }
 

--- a/projects/rccl/src/plugin/gin.cc
+++ b/projects/rccl/src/plugin/gin.cc
@@ -132,6 +132,10 @@ static ncclResult_t ncclGinPluginInit(struct ncclComm* comm, ginPluginLib_t* plu
   }
   if (pluginLib->ncclGinPluginState == ncclGinPluginStateInitReady && pluginLib->ncclGin) {
     if (pluginLib->ncclGin->devices(&ndev) != ncclSuccess || ndev <= 0) {
+      // init() succeeded but plugin is unusable; release the context to avoid leaking it.
+      if (comm->ginContext && pluginLib->ncclGin->finalize(comm->ginContext) != ncclSuccess)
+        WARN("GIN plugin %s finalize failed while disabling after devices() check", pluginLib->name);
+      comm->ginContext = nullptr;
       pluginLib->ncclGinPluginState = ncclGinPluginStateDisabled;
     } else {
       pluginLib->ginPhysDevs = ndev;
@@ -147,6 +151,9 @@ static ncclResult_t ncclGinPluginInit(struct ncclComm* comm, ginPluginLib_t* plu
   }
   if (pluginLib->ncclRmaPluginState == ncclGinPluginStateInitReady && pluginLib->ncclRma) {
     if (pluginLib->ncclRma->devices(&ndev) != ncclSuccess || ndev <= 0) {
+      if (comm->rmaGinContext && pluginLib->ncclRma->finalize(comm->rmaGinContext) != ncclSuccess)
+        WARN("RMA plugin %s finalize failed while disabling after devices() check", pluginLib->name);
+      comm->rmaGinContext = nullptr;
       pluginLib->ncclRmaPluginState = ncclGinPluginStateDisabled;
     } else {
       pluginLib->ncclRmaPluginState = ncclGinPluginStateEnabled;


### PR DESCRIPTION
## Motivation

Under LLVM ASan, RCCL comm teardown reported an `alloc-dealloc-mismatch` abort and a GIN/RMA context memory leak.

## Technical Details

- `sharedRes` is allocated via `ncclCalloc` (malloc) but freed with `delete` in `commFree`; switched to `free()` to match the allocator.
- When a GIN or RMA plugin's `init()` succeeds but `devices()` reports the plugin unusable, `ncclGinPluginInit` disabled it without releasing the context `init()` allocated. Now it calls `finalize()` and clears the context/state on that path (logging, not early-returning, on a finalize error).

## JIRA ID

JIRA ID: ROCM-27870

## Test Plan

Ran the ASan collective repro across 4n/6n/8n on banff-cyxtera-mi300x and compared LeakSanitizer output before/after.

## Test Result

`alloc-dealloc-mismatch` abort fixed; the residual 8-byte GIN context leak surfaced after the free() fix is eliminated by the finalize change.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.