### PR TITLE
rocr: Preserve metadata through intercept queues

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/functional/intercept_queue_metadata_test.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/intercept_queue_metadata_test.cc
@@ -1,0 +1,839 @@
+//===- intercept_queue_metadata_test.cc - InterceptQueue metadata tests --===//
+//
+// SPDX-License-Identifier: NCSA
+//
+//===----------------------------------------------------------------------===//
+
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+#include "core/inc/intercept_queue.h"
+#include "core/util/atomic_helpers.h"
+#include "gtest/gtest.h"
+#include "inc/amd_hsa_signal.h"
+
+namespace rocr {
+namespace core {
+
+// The host-only target constructs DoorbellSignal without the runtime signal
+// implementation. It never exposes or destroys that signal through HSA.
+Signal::~Signal() {}
+void Signal::registerIpc() {}
+void SharedSignalPool_t::clear() {}
+SharedSignal* SharedSignalPool_t::alloc() { return nullptr; }
+void SharedSignalPool_t::free(SharedSignal*) {}
+
+}  // namespace core
+}  // namespace rocr
+
+namespace {
+
+using AqlPacket = rocr::core::AqlPacket;
+using MetadataPacket = rocr::core::AqlMetadataPrefetchPacket;
+using Queue = rocr::core::Queue;
+using SharedQueue = rocr::core::SharedQueue;
+
+constexpr uint32_t kQueueSize = 8;
+
+class QueueStorage {
+ protected:
+  SharedQueue storage_{};
+};
+
+class FakeQueue final : private QueueStorage, public Queue {
+ public:
+  explicit FakeQueue(bool metadata_supported = true)
+      : Queue(&storage_, 0, nullptr), metadata_supported_(metadata_supported) {
+    ring_.resize(kQueueSize);
+    metadata_ring_.resize(kQueueSize);
+    amd_queue_.hsa_queue.size = kQueueSize;
+    amd_queue_.hsa_queue.base_address = ring_.data();
+    for (auto& metadata : metadata_ring_) metadata = NoopMetadata();
+  }
+
+  hsa_status_t Inactivate() override { return HSA_STATUS_SUCCESS; }
+  hsa_status_t SetPriority(rocr::HSA::hsa_amd_queue_priority_internal_t) override {
+    return HSA_STATUS_SUCCESS;
+  }
+  uint64_t LoadReadIndexAcquire() override { return read_index_; }
+  uint64_t LoadReadIndexRelaxed() override { return read_index_; }
+  uint64_t LoadWriteIndexAcquire() override { return write_index_; }
+  uint64_t LoadWriteIndexRelaxed() override { return write_index_; }
+  void StoreReadIndexRelaxed(uint64_t value) override { read_index_ = value; }
+  void StoreReadIndexRelease(uint64_t value) override { read_index_ = value; }
+  void StoreWriteIndexRelaxed(uint64_t value) override { write_index_ = value; }
+  void StoreWriteIndexRelease(uint64_t value) override { write_index_ = value; }
+  uint64_t CasWriteIndexAcqRel(uint64_t expected, uint64_t value) override {
+    return CasWriteIndexRelaxed(expected, value);
+  }
+  uint64_t CasWriteIndexAcquire(uint64_t expected, uint64_t value) override {
+    return CasWriteIndexRelaxed(expected, value);
+  }
+  uint64_t CasWriteIndexRelaxed(uint64_t expected, uint64_t value) override {
+    const uint64_t previous = write_index_;
+    if (previous == expected) write_index_ = value;
+    return previous;
+  }
+  uint64_t CasWriteIndexRelease(uint64_t expected, uint64_t value) override {
+    return CasWriteIndexRelaxed(expected, value);
+  }
+  uint64_t AddWriteIndexAcqRel(uint64_t value) override { return AddWriteIndexRelaxed(value); }
+  uint64_t AddWriteIndexAcquire(uint64_t value) override { return AddWriteIndexRelaxed(value); }
+  uint64_t AddWriteIndexRelaxed(uint64_t value) override {
+    const uint64_t previous = write_index_;
+    write_index_ += value;
+    return previous;
+  }
+  uint64_t AddWriteIndexRelease(uint64_t value) override { return AddWriteIndexRelaxed(value); }
+  hsa_status_t SetCUMasking(uint32_t, const uint32_t*) override { return HSA_STATUS_SUCCESS; }
+  hsa_status_t GetCUMasking(uint32_t, uint32_t*) override { return HSA_STATUS_SUCCESS; }
+  void ExecutePM4(uint32_t*, size_t, hsa_fence_scope_t, hsa_fence_scope_t, hsa_signal_t*) override {
+  }
+  void SetProfiling(bool) override {}
+
+  hsa_status_t GetInfo(hsa_queue_info_attribute_t attribute, void* value) override {
+    switch (attribute) {
+      case HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_DISPATCH_PKT_VERSION_MAJOR:
+        *reinterpret_cast<uint8_t*>(value) = 0x11;
+        return HSA_STATUS_SUCCESS;
+      case HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_DISPATCH_PKT_VERSION_MINOR:
+        *reinterpret_cast<uint8_t*>(value) = 0x22;
+        return HSA_STATUS_SUCCESS;
+      case HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_BARRIER_PKT_VERSION_MAJOR:
+        *reinterpret_cast<uint8_t*>(value) = 0x33;
+        return HSA_STATUS_SUCCESS;
+      case HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_BARRIER_PKT_VERSION_MINOR:
+        *reinterpret_cast<uint8_t*>(value) = 0x44;
+        return HSA_STATUS_SUCCESS;
+      case HSA_AMD_QUEUE_INFO_PROPERTIES:
+        std::memset(value, 0x55, 8);
+        return HSA_STATUS_SUCCESS;
+      case HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_RING_BUFFER:
+        if (metadata_supported_) {
+          *reinterpret_cast<uint64_t*>(value) = reinterpret_cast<uint64_t>(metadata_ring_.data());
+          return HSA_STATUS_SUCCESS;
+        }
+      default:
+        return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+    }
+  }
+
+  MetadataPacket& MetadataAt(uint64_t index) { return metadata_ring_[index & (kQueueSize - 1)]; }
+  void Consume(uint64_t count) { read_index_ += count; }
+
+ protected:
+  bool _IsA(rtti_t) const override { return false; }
+
+ private:
+  static MetadataPacket NoopMetadata() {
+    MetadataPacket metadata{};
+    metadata.packet.header0.type = HSA_PACKET_TYPE_INVALID;
+    metadata.packet.header1.type = HSA_PACKET_TYPE_INVALID;
+    metadata.packet.header2.type = HSA_PACKET_TYPE_INVALID;
+    metadata.packet.header3.type = HSA_PACKET_TYPE_INVALID;
+    return metadata;
+  }
+
+  bool metadata_supported_;
+  std::vector<AqlPacket> ring_;
+  std::vector<MetadataPacket> metadata_ring_;
+  uint64_t read_index_ = 0;
+  uint64_t write_index_ = 0;
+};
+
+class InterceptQueueStorage {
+ protected:
+  SharedQueue storage_{};
+};
+
+class TestInterceptQueue final : private InterceptQueueStorage, public rocr::core::InterceptQueue {
+ public:
+  explicit TestInterceptQueue(std::unique_ptr<Queue> queue)
+      : InterceptQueue(std::move(queue), &storage_) {}
+};
+
+class InterceptQueueMetadataTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    rocr::core::BaseShared::SetAllocateAndFree(
+        [](size_t size, size_t alignment, uint32_t, int) {
+          void* memory = nullptr;
+          return posix_memalign(&memory, alignment, size) == 0 ? memory : nullptr;
+        },
+        [](void* memory) { std::free(memory); });
+  }
+};
+
+uint16_t PacketHeader(hsa_packet_type_t type, uint16_t flags = 0) {
+  return (type << HSA_PACKET_HEADER_TYPE) | flags;
+}
+
+hsa_signal_t MakeSignal(amd_signal_t& signal, uint32_t event_id) {
+  std::memset(&signal, 0, sizeof(signal));
+  signal.event_id = event_id;
+  return {reinterpret_cast<uint64_t>(&signal)};
+}
+
+AqlPacket MakeDispatch(uint64_t kernel_object, hsa_signal_t completion_signal = {0}) {
+  AqlPacket packet{};
+  packet.dispatch.header = PacketHeader(HSA_PACKET_TYPE_KERNEL_DISPATCH);
+  packet.dispatch.workgroup_size_x = 64;
+  packet.dispatch.grid_size_x = 64;
+  packet.dispatch.kernel_object = kernel_object;
+  packet.dispatch.completion_signal = completion_signal;
+  return packet;
+}
+
+AqlPacket MakeBarrier() {
+  AqlPacket packet{};
+  packet.barrier_and.header = PacketHeader(HSA_PACKET_TYPE_BARRIER_AND);
+  return packet;
+}
+
+AqlPacket MakeExtDispatch(hsa_signal_t completion_signal = {0}) {
+  AqlPacket packet{};
+  packet.ext_dispatch.header = PacketHeader(HSA_PACKET_TYPE_VENDOR_SPECIFIC);
+  packet.ext_dispatch.amd_format = HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH;
+  packet.ext_dispatch.completion_signal = completion_signal;
+  return packet;
+}
+
+AqlPacket MakeBarrierValue(hsa_signal_t completion_signal = {0}) {
+  hsa_amd_barrier_value_packet_t barrier{};
+  barrier.header.header = PacketHeader(HSA_PACKET_TYPE_VENDOR_SPECIFIC);
+  barrier.header.AmdFormat = HSA_AMD_PACKET_TYPE_BARRIER_VALUE;
+  barrier.completion_signal = completion_signal;
+  static_assert(sizeof(barrier) == sizeof(AqlPacket), "Unexpected barrier-value packet size");
+
+  AqlPacket packet{};
+  std::memcpy(&packet, &barrier, sizeof(packet));
+  return packet;
+}
+
+AqlPacket MakeAgentDispatch() {
+  AqlPacket packet{};
+  packet.agent.header = PacketHeader(HSA_PACKET_TYPE_AGENT_DISPATCH);
+  packet.agent.completion_signal = {1};
+  return packet;
+}
+
+MetadataPacket MakeMetadata(uint8_t seed, uint32_t event_id) {
+  MetadataPacket metadata;
+  std::memset(&metadata, seed, sizeof(metadata));
+  metadata.packet.header0.type = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+  metadata.packet.header1.type = HSA_PACKET_TYPE_BARRIER_AND;
+  metadata.packet.header2.type = HSA_PACKET_TYPE_BARRIER_OR;
+  metadata.packet.header3.type = HSA_PACKET_TYPE_VENDOR_SPECIFIC;
+  metadata.packet.event_id = event_id;
+  return metadata;
+}
+
+MetadataPacket NoopMetadata() {
+  MetadataPacket metadata{};
+  metadata.packet.header0.type = HSA_PACKET_TYPE_INVALID;
+  metadata.packet.header1.type = HSA_PACKET_TYPE_INVALID;
+  metadata.packet.header2.type = HSA_PACKET_TYPE_INVALID;
+  metadata.packet.header3.type = HSA_PACKET_TYPE_INVALID;
+  return metadata;
+}
+
+void ExpectMetadataEq(const MetadataPacket& actual, const MetadataPacket& expected) {
+  EXPECT_EQ(std::memcmp(&actual, &expected, sizeof(actual)), 0);
+}
+
+void ExpectNoopMetadata(const MetadataPacket& metadata) {
+  ExpectMetadataEq(metadata, NoopMetadata());
+}
+
+AqlPacket* ProxyRing(TestInterceptQueue& queue) {
+  return reinterpret_cast<AqlPacket*>(queue.amd_queue_.hsa_queue.base_address);
+}
+
+MetadataPacket* ProxyMetadataRing(TestInterceptQueue& queue) {
+  uint64_t metadata_ring = 0;
+  EXPECT_EQ(queue.GetInfo(HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_RING_BUFFER, &metadata_ring),
+            HSA_STATUS_SUCCESS);
+  return reinterpret_cast<MetadataPacket*>(metadata_ring);
+}
+
+void WriteProxyPacket(TestInterceptQueue& queue, uint64_t index, const AqlPacket& packet) {
+  const uint64_t slot = index & (queue.amd_queue_.hsa_queue.size - 1);
+  ProxyRing(queue)[slot] = packet;
+  rocr::atomic::Store(&ProxyRing(queue)[slot].packet.header, packet.packet.header,
+                      std::memory_order_release);
+}
+
+void PassThrough(const void* packets, uint64_t count, uint64_t, void*,
+                 hsa_amd_queue_intercept_packet_writer writer) {
+  writer(packets, count);
+}
+
+void InsertBarrier(const void* packets, uint64_t count, uint64_t, void*,
+                   hsa_amd_queue_intercept_packet_writer writer) {
+  std::vector<AqlPacket> output;
+  output.reserve(count * 2);
+  for (const auto* input = static_cast<const AqlPacket*>(packets); count-- != 0; ++input) {
+    output.push_back(MakeBarrier());
+    output.push_back(*input);
+  }
+  writer(output.data(), output.size());
+}
+
+struct SignalReplacement {
+  hsa_signal_t signal;
+};
+
+void ReplaceSignal(const void* packets, uint64_t count, uint64_t, void* data,
+                   hsa_amd_queue_intercept_packet_writer writer) {
+  std::vector<AqlPacket> output(static_cast<const AqlPacket*>(packets),
+                                static_cast<const AqlPacket*>(packets) + count);
+  const auto signal = static_cast<SignalReplacement*>(data)->signal;
+  for (auto& packet : output) {
+    switch (AqlPacket::type(packet.packet.header)) {
+      case HSA_PACKET_TYPE_KERNEL_DISPATCH:
+        packet.dispatch.completion_signal = signal;
+        break;
+      case HSA_PACKET_TYPE_VENDOR_SPECIFIC:
+        if (packet.amd_vendor.format == HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH) {
+          packet.ext_dispatch.completion_signal = signal;
+        } else if (packet.amd_vendor.format == HSA_AMD_PACKET_TYPE_BARRIER_VALUE) {
+          reinterpret_cast<hsa_amd_barrier_value_packet_t*>(&packet)->completion_signal = signal;
+        }
+        break;
+      default:
+        break;
+    }
+  }
+  writer(output.data(), output.size());
+}
+
+void ReversePackets(const void* packets, uint64_t count, uint64_t, void*,
+                    hsa_amd_queue_intercept_packet_writer writer) {
+  const auto* input = static_cast<const AqlPacket*>(packets);
+  ASSERT_EQ(count, 2u);
+  AqlPacket output[] = {input[1], input[0]};
+  writer(output, 2);
+}
+
+void DropFirstPacket(const void* packets, uint64_t count, uint64_t, void*,
+                     hsa_amd_queue_intercept_packet_writer writer) {
+  ASSERT_GT(count, 1u);
+  writer(static_cast<const AqlPacket*>(packets) + 1, count - 1);
+}
+
+void ReplaceWithBarrier(const void*, uint64_t count, uint64_t, void*,
+                        hsa_amd_queue_intercept_packet_writer writer) {
+  std::vector<AqlPacket> output(count, MakeBarrier());
+  writer(output.data(), output.size());
+}
+
+void ChangeHeaderFlags(const void* packets, uint64_t count, uint64_t, void*,
+                       hsa_amd_queue_intercept_packet_writer writer) {
+  std::vector<AqlPacket> output(static_cast<const AqlPacket*>(packets),
+                                static_cast<const AqlPacket*>(packets) + count);
+  output.front().packet.header =
+      PacketHeader(HSA_PACKET_TYPE_KERNEL_DISPATCH,
+                   (1 << HSA_PACKET_HEADER_BARRIER) |
+                       (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_ACQUIRE_FENCE_SCOPE) |
+                       (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_RELEASE_FENCE_SCOPE));
+  writer(output.data(), output.size());
+}
+
+void ChangePacketType(const void* packets, uint64_t count, uint64_t, void*,
+                      hsa_amd_queue_intercept_packet_writer writer) {
+  std::vector<AqlPacket> output(static_cast<const AqlPacket*>(packets),
+                                static_cast<const AqlPacket*>(packets) + count);
+  output.front().barrier_and.header = PacketHeader(HSA_PACKET_TYPE_BARRIER_AND);
+  output.front().barrier_and.completion_signal = {0};
+  writer(output.data(), output.size());
+}
+
+void ChangeReservedHeaderBit(const void* packets, uint64_t count, uint64_t, void*,
+                             hsa_amd_queue_intercept_packet_writer writer) {
+  std::vector<AqlPacket> output(static_cast<const AqlPacket*>(packets),
+                                static_cast<const AqlPacket*>(packets) + count);
+  output.front().packet.header |= 1u << 13;
+  writer(output.data(), output.size());
+}
+
+void WriteNothing(const void* packets, uint64_t, uint64_t, void*,
+                  hsa_amd_queue_intercept_packet_writer writer) {
+  writer(packets, 0);
+}
+
+void ExpandPacket(const void* packets, uint64_t count, uint64_t, void*,
+                  hsa_amd_queue_intercept_packet_writer writer) {
+  ASSERT_EQ(count, 1u);
+  const auto* input = static_cast<const AqlPacket*>(packets);
+  AqlPacket output[] = {MakeBarrier(), input[0], MakeBarrier()};
+  writer(output, 3);
+}
+
+bool marker_callback_fired = false;
+uint64_t marker_packet_index = 0;
+
+void MarkerCallback(const amd_aql_intercept_marker_t*, hsa_queue_t*, uint64_t packet_index) {
+  marker_callback_fired = true;
+  marker_packet_index = packet_index;
+}
+
+void InsertMarker(const void* packets, uint64_t count, uint64_t, void*,
+                  hsa_amd_queue_intercept_packet_writer writer) {
+  ASSERT_EQ(count, 1u);
+  amd_aql_intercept_marker_t marker{};
+  marker.header = PacketHeader(HSA_PACKET_TYPE_VENDOR_SPECIFIC);
+  marker.format = AMD_AQL_FORMAT_INTERCEPT_MARKER;
+  marker.callback = MarkerCallback;
+  AqlPacket output[2] = {};
+  static_assert(sizeof(marker) == sizeof(AqlPacket), "Unexpected intercept marker size");
+  std::memcpy(&output[0], &marker, sizeof(marker));
+  output[1] = *static_cast<const AqlPacket*>(packets);
+  writer(output, 2);
+}
+
+TEST_F(InterceptQueueMetadataTest, PassthroughPreservesFullMetadata) {
+  auto fake = std::make_unique<FakeQueue>();
+  auto* fake_queue = fake.get();
+  TestInterceptQueue queue(std::move(fake));
+  queue.AddInterceptor(PassThrough, nullptr);
+
+  amd_signal_t signal{};
+  const MetadataPacket metadata = MakeMetadata(0x11, 41);
+  ProxyMetadataRing(queue)[0] = metadata;
+  WriteProxyPacket(queue, 0, MakeDispatch(0x1000, MakeSignal(signal, 41)));
+  queue.StoreWriteIndexRelaxed(1);
+  queue.StoreRelaxed(0);
+
+  EXPECT_EQ(fake_queue->LoadWriteIndexRelaxed(), 1u);
+  ExpectMetadataEq(fake_queue->MetadataAt(0), metadata);
+}
+
+TEST_F(InterceptQueueMetadataTest, InsertedPacketsGetNoopMetadata) {
+  auto fake = std::make_unique<FakeQueue>();
+  auto* fake_queue = fake.get();
+  TestInterceptQueue queue(std::move(fake));
+  queue.AddInterceptor(InsertBarrier, nullptr);
+
+  const MetadataPacket metadata = MakeMetadata(0x22, 0);
+  ProxyMetadataRing(queue)[0] = metadata;
+  WriteProxyPacket(queue, 0, MakeDispatch(0x2000));
+  queue.StoreWriteIndexRelaxed(1);
+  queue.StoreRelaxed(0);
+
+  EXPECT_EQ(fake_queue->LoadWriteIndexRelaxed(), 2u);
+  ExpectNoopMetadata(fake_queue->MetadataAt(0));
+  ExpectMetadataEq(fake_queue->MetadataAt(1), metadata);
+}
+
+TEST_F(InterceptQueueMetadataTest, SignalReplacementUpdatesEventId) {
+  auto fake = std::make_unique<FakeQueue>();
+  auto* fake_queue = fake.get();
+  TestInterceptQueue queue(std::move(fake));
+
+  amd_signal_t original_signal{};
+  amd_signal_t replacement_signal{};
+  SignalReplacement replacement{MakeSignal(replacement_signal, 99)};
+  queue.AddInterceptor(ReplaceSignal, &replacement);
+
+  const MetadataPacket metadata = MakeMetadata(0x33, 7);
+  ProxyMetadataRing(queue)[0] = metadata;
+  WriteProxyPacket(queue, 0, MakeDispatch(0x3000, MakeSignal(original_signal, 7)));
+  queue.StoreWriteIndexRelaxed(1);
+  queue.StoreRelaxed(0);
+
+  MetadataPacket expected = metadata;
+  expected.packet.event_id = 99;
+  ExpectMetadataEq(fake_queue->MetadataAt(0), expected);
+}
+
+TEST_F(InterceptQueueMetadataTest, ReorderedPacketsFollowMetadata) {
+  auto fake = std::make_unique<FakeQueue>();
+  auto* fake_queue = fake.get();
+  TestInterceptQueue queue(std::move(fake));
+  queue.AddInterceptor(ReversePackets, nullptr);
+
+  amd_signal_t first_signal{};
+  amd_signal_t second_signal{};
+  const MetadataPacket first = MakeMetadata(0x44, 10);
+  const MetadataPacket second = MakeMetadata(0x55, 20);
+  ProxyMetadataRing(queue)[0] = first;
+  ProxyMetadataRing(queue)[1] = second;
+  WriteProxyPacket(queue, 0, MakeDispatch(0x4000, MakeSignal(first_signal, 10)));
+  WriteProxyPacket(queue, 1, MakeDispatch(0x5000, MakeSignal(second_signal, 20)));
+  queue.StoreWriteIndexRelaxed(2);
+  queue.StoreRelaxed(0);
+
+  ExpectMetadataEq(fake_queue->MetadataAt(0), second);
+  ExpectMetadataEq(fake_queue->MetadataAt(1), first);
+}
+
+TEST_F(InterceptQueueMetadataTest, MetadataInfoAttributesAreForwarded) {
+  TestInterceptQueue queue(std::make_unique<FakeQueue>());
+
+  const hsa_queue_info_attribute_t attributes[] = {
+      HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_DISPATCH_PKT_VERSION_MAJOR,
+      HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_DISPATCH_PKT_VERSION_MINOR,
+      HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_BARRIER_PKT_VERSION_MAJOR,
+      HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_BARRIER_PKT_VERSION_MINOR};
+  const uint8_t expected[] = {0x11, 0x22, 0x33, 0x44};
+  for (size_t i = 0; i < sizeof(attributes) / sizeof(attributes[0]); ++i) {
+    uint8_t value = 0;
+    EXPECT_EQ(queue.GetInfo(attributes[i], &value), HSA_STATUS_SUCCESS);
+    EXPECT_EQ(value, expected[i]);
+  }
+
+  uint8_t properties[8] = {};
+  EXPECT_EQ(queue.GetInfo(HSA_AMD_QUEUE_INFO_PROPERTIES, properties), HSA_STATUS_SUCCESS);
+  for (uint8_t property : properties) EXPECT_EQ(property, 0x55);
+}
+
+TEST_F(InterceptQueueMetadataTest, DeletedPacketsDoNotShiftMetadata) {
+  auto fake = std::make_unique<FakeQueue>();
+  auto* fake_queue = fake.get();
+  TestInterceptQueue queue(std::move(fake));
+  queue.AddInterceptor(DropFirstPacket, nullptr);
+
+  amd_signal_t first_signal{};
+  amd_signal_t second_signal{};
+  ProxyMetadataRing(queue)[0] = MakeMetadata(0x66, 30);
+  const MetadataPacket expected = MakeMetadata(0x77, 40);
+  ProxyMetadataRing(queue)[1] = expected;
+  WriteProxyPacket(queue, 0, MakeDispatch(0x6000, MakeSignal(first_signal, 30)));
+  WriteProxyPacket(queue, 1, MakeDispatch(0x7000, MakeSignal(second_signal, 40)));
+  queue.StoreWriteIndexRelaxed(2);
+  queue.StoreRelaxed(0);
+
+  EXPECT_EQ(fake_queue->LoadWriteIndexRelaxed(), 1u);
+  ExpectMetadataEq(fake_queue->MetadataAt(0), expected);
+}
+
+TEST_F(InterceptQueueMetadataTest, ReplacedPacketsGetNoopMetadata) {
+  auto fake = std::make_unique<FakeQueue>();
+  auto* fake_queue = fake.get();
+  TestInterceptQueue queue(std::move(fake));
+  queue.AddInterceptor(ReplaceWithBarrier, nullptr);
+
+  ProxyMetadataRing(queue)[0] = MakeMetadata(0x88, 0);
+  WriteProxyPacket(queue, 0, MakeDispatch(0x8000));
+  queue.StoreWriteIndexRelaxed(1);
+  queue.StoreRelaxed(0);
+
+  ExpectNoopMetadata(fake_queue->MetadataAt(0));
+}
+
+TEST_F(InterceptQueueMetadataTest, MutableHeaderFlagsDoNotBreakMatching) {
+  auto fake = std::make_unique<FakeQueue>();
+  auto* fake_queue = fake.get();
+  TestInterceptQueue queue(std::move(fake));
+  queue.AddInterceptor(ChangeHeaderFlags, nullptr);
+
+  amd_signal_t signal{};
+  const MetadataPacket metadata = MakeMetadata(0x99, 50);
+  ProxyMetadataRing(queue)[0] = metadata;
+  WriteProxyPacket(queue, 0, MakeDispatch(0x9000, MakeSignal(signal, 50)));
+  queue.StoreWriteIndexRelaxed(1);
+  queue.StoreRelaxed(0);
+
+  ExpectMetadataEq(fake_queue->MetadataAt(0), metadata);
+}
+
+TEST_F(InterceptQueueMetadataTest, CompletionSignalDoesNotBreakMatching) {
+  auto fake = std::make_unique<FakeQueue>();
+  auto* fake_queue = fake.get();
+  TestInterceptQueue queue(std::move(fake));
+
+  amd_signal_t original_signal{};
+  amd_signal_t replacement_signal{};
+  SignalReplacement replacement{MakeSignal(replacement_signal, 61)};
+  queue.AddInterceptor(ReplaceSignal, &replacement);
+
+  const MetadataPacket metadata = MakeMetadata(0xaa, 60);
+  ProxyMetadataRing(queue)[0] = metadata;
+  WriteProxyPacket(queue, 0, MakeDispatch(0xa000, MakeSignal(original_signal, 60)));
+  queue.StoreWriteIndexRelaxed(1);
+  queue.StoreRelaxed(0);
+
+  MetadataPacket expected = metadata;
+  expected.packet.event_id = 61;
+  ExpectMetadataEq(fake_queue->MetadataAt(0), expected);
+}
+
+TEST_F(InterceptQueueMetadataTest, PacketTypeMismatchDoesNotMatch) {
+  auto fake = std::make_unique<FakeQueue>();
+  auto* fake_queue = fake.get();
+  TestInterceptQueue queue(std::move(fake));
+  queue.AddInterceptor(ChangePacketType, nullptr);
+
+  ProxyMetadataRing(queue)[0] = MakeMetadata(0xbb, 0);
+  WriteProxyPacket(queue, 0, MakeDispatch(0xb000));
+  queue.StoreWriteIndexRelaxed(1);
+  queue.StoreRelaxed(0);
+
+  ExpectNoopMetadata(fake_queue->MetadataAt(0));
+}
+
+TEST_F(InterceptQueueMetadataTest, ReservedHeaderBitsDoNotMatch) {
+  auto fake = std::make_unique<FakeQueue>();
+  auto* fake_queue = fake.get();
+  TestInterceptQueue queue(std::move(fake));
+  queue.AddInterceptor(ChangeReservedHeaderBit, nullptr);
+
+  ProxyMetadataRing(queue)[0] = MakeMetadata(0xbc, 0);
+  WriteProxyPacket(queue, 0, MakeDispatch(0xb100));
+  queue.StoreWriteIndexRelaxed(1);
+  queue.StoreRelaxed(0);
+
+  ExpectNoopMetadata(fake_queue->MetadataAt(0));
+}
+
+TEST_F(InterceptQueueMetadataTest, ZeroCountSubmissionProducesNoOutput) {
+  auto fake = std::make_unique<FakeQueue>();
+  auto* fake_queue = fake.get();
+  TestInterceptQueue queue(std::move(fake));
+  queue.AddInterceptor(WriteNothing, nullptr);
+
+  ProxyMetadataRing(queue)[0] = MakeMetadata(0xcc, 0);
+  WriteProxyPacket(queue, 0, MakeDispatch(0xc000));
+  queue.StoreWriteIndexRelaxed(1);
+  queue.StoreRelaxed(0);
+
+  EXPECT_EQ(fake_queue->LoadWriteIndexRelaxed(), 0u);
+}
+
+TEST_F(InterceptQueueMetadataTest, MultipleDoorbellBatchesPreserveMetadata) {
+  auto fake = std::make_unique<FakeQueue>();
+  auto* fake_queue = fake.get();
+  TestInterceptQueue queue(std::move(fake));
+  queue.AddInterceptor(PassThrough, nullptr);
+
+  const MetadataPacket first = MakeMetadata(0xdd, 0);
+  ProxyMetadataRing(queue)[0] = first;
+  WriteProxyPacket(queue, 0, MakeDispatch(0xd000));
+  queue.StoreWriteIndexRelaxed(1);
+  queue.StoreRelaxed(0);
+  ExpectMetadataEq(fake_queue->MetadataAt(0), first);
+
+  fake_queue->Consume(1);
+  const MetadataPacket second = MakeMetadata(0xee, 0);
+  ProxyMetadataRing(queue)[1] = second;
+  WriteProxyPacket(queue, 1, MakeDispatch(0xe000));
+  queue.StoreWriteIndexRelaxed(2);
+  queue.StoreRelaxed(0);
+  ExpectMetadataEq(fake_queue->MetadataAt(1), second);
+}
+
+TEST_F(InterceptQueueMetadataTest, RingWraparoundUsesCurrentProxyMetadata) {
+  auto fake = std::make_unique<FakeQueue>();
+  auto* fake_queue = fake.get();
+  TestInterceptQueue queue(std::move(fake));
+  queue.AddInterceptor(PassThrough, nullptr);
+
+  for (uint64_t i = 0; i < kQueueSize - 1; ++i) {
+    ProxyMetadataRing(queue)[i] = MakeMetadata(static_cast<uint8_t>(i), 0);
+    WriteProxyPacket(queue, i, MakeDispatch(0xf000 + i));
+  }
+  queue.StoreWriteIndexRelaxed(kQueueSize - 1);
+  queue.StoreRelaxed(0);
+  fake_queue->Consume(kQueueSize - 1);
+
+  const MetadataPacket before_wrap = MakeMetadata(0x12, 0);
+  const MetadataPacket after_wrap = MakeMetadata(0x34, 0);
+  ProxyMetadataRing(queue)[kQueueSize - 1] = before_wrap;
+  ProxyMetadataRing(queue)[0] = after_wrap;
+  WriteProxyPacket(queue, kQueueSize - 1, MakeDispatch(0x10000));
+  WriteProxyPacket(queue, kQueueSize, MakeDispatch(0x10001));
+  queue.StoreWriteIndexRelaxed(kQueueSize + 1);
+  queue.StoreRelaxed(0);
+
+  ExpectMetadataEq(fake_queue->MetadataAt(kQueueSize - 1), before_wrap);
+  ExpectMetadataEq(fake_queue->MetadataAt(kQueueSize), after_wrap);
+}
+
+TEST_F(InterceptQueueMetadataTest, ReusedProxySlotsRequireFreshMetadata) {
+  auto fake = std::make_unique<FakeQueue>();
+  auto* fake_queue = fake.get();
+  TestInterceptQueue queue(std::move(fake));
+  queue.AddInterceptor(ReplaceWithBarrier, nullptr);
+
+  const MetadataPacket stale_metadata = MakeMetadata(0x39, 0);
+  for (uint64_t i = 0; i < kQueueSize; ++i) {
+    if (i == 0)
+      ProxyMetadataRing(queue)[i] = stale_metadata;
+    else
+      ProxyMetadataRing(queue)[i] = NoopMetadata();
+    WriteProxyPacket(queue, i, MakeDispatch(0x10100 + i));
+    queue.StoreWriteIndexRelaxed(i + 1);
+    queue.StoreRelaxed(0);
+    fake_queue->Consume(1);
+  }
+
+  // Producers with metadata must write it before publishing the AQL header.
+  // This reused barrier intentionally has no fresh metadata.
+  WriteProxyPacket(queue, kQueueSize, MakeBarrier());
+  queue.StoreWriteIndexRelaxed(kQueueSize + 1);
+  queue.StoreRelaxed(0);
+
+  ExpectNoopMetadata(fake_queue->MetadataAt(kQueueSize));
+}
+
+TEST_F(InterceptQueueMetadataTest, OverflowRetryPreservesMetadata) {
+  auto fake = std::make_unique<FakeQueue>();
+  auto* fake_queue = fake.get();
+  fake_queue->StoreWriteIndexRelaxed(6);
+  TestInterceptQueue queue(std::move(fake));
+  queue.AddInterceptor(ExpandPacket, nullptr);
+
+  const MetadataPacket metadata = MakeMetadata(0x45, 0);
+  ProxyMetadataRing(queue)[0] = metadata;
+  WriteProxyPacket(queue, 0, MakeDispatch(0x11000));
+  queue.StoreWriteIndexRelaxed(1);
+  queue.StoreRelaxed(0);
+
+  EXPECT_EQ(fake_queue->LoadWriteIndexRelaxed(), 7u);
+  ExpectNoopMetadata(fake_queue->MetadataAt(6));
+
+  fake_queue->Consume(7);
+  queue.StoreRelaxed(0);
+
+  EXPECT_EQ(fake_queue->LoadWriteIndexRelaxed(), 10u);
+  ExpectNoopMetadata(fake_queue->MetadataAt(7));
+  ExpectMetadataEq(fake_queue->MetadataAt(8), metadata);
+  ExpectNoopMetadata(fake_queue->MetadataAt(9));
+}
+
+TEST_F(InterceptQueueMetadataTest, UnsupportedMetadataRingIsPassedThrough) {
+  auto fake = std::make_unique<FakeQueue>(false);
+  auto* fake_queue = fake.get();
+  TestInterceptQueue queue(std::move(fake));
+
+  uint64_t metadata_ring = 0xfeedface;
+  EXPECT_EQ(queue.GetInfo(HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_RING_BUFFER, &metadata_ring),
+            HSA_STATUS_ERROR_INVALID_ARGUMENT);
+  EXPECT_EQ(metadata_ring, 0xfeedfaceu);
+
+  WriteProxyPacket(queue, 0, MakeDispatch(0x12000));
+  queue.StoreWriteIndexRelaxed(1);
+  queue.StoreRelaxed(0);
+
+  EXPECT_EQ(fake_queue->LoadWriteIndexRelaxed(), 1u);
+  ExpectNoopMetadata(fake_queue->MetadataAt(0));
+}
+
+TEST_F(InterceptQueueMetadataTest, NullCompletionSignalClearsEventId) {
+  auto fake = std::make_unique<FakeQueue>();
+  auto* fake_queue = fake.get();
+  TestInterceptQueue queue(std::move(fake));
+
+  ProxyMetadataRing(queue)[0] = MakeMetadata(0x56, 0x1234);
+  WriteProxyPacket(queue, 0, MakeDispatch(0x13000));
+  queue.StoreWriteIndexRelaxed(1);
+  queue.StoreRelaxed(0);
+
+  MetadataPacket expected = MakeMetadata(0x56, 0);
+  ExpectMetadataEq(fake_queue->MetadataAt(0), expected);
+}
+
+TEST_F(InterceptQueueMetadataTest, VendorPacketSignalReplacementUpdatesEventId) {
+  auto fake = std::make_unique<FakeQueue>();
+  auto* fake_queue = fake.get();
+  TestInterceptQueue queue(std::move(fake));
+
+  amd_signal_t original_signal{};
+  amd_signal_t replacement_signal{};
+  SignalReplacement replacement{MakeSignal(replacement_signal, 91)};
+  queue.AddInterceptor(ReplaceSignal, &replacement);
+
+  const MetadataPacket metadata = MakeMetadata(0x57, 90);
+  ProxyMetadataRing(queue)[0] = metadata;
+  WriteProxyPacket(queue, 0, MakeExtDispatch(MakeSignal(original_signal, 90)));
+  queue.StoreWriteIndexRelaxed(1);
+  queue.StoreRelaxed(0);
+
+  MetadataPacket expected = metadata;
+  expected.packet.event_id = 91;
+  ExpectMetadataEq(fake_queue->MetadataAt(0), expected);
+
+  fake_queue->Consume(1);
+  ProxyMetadataRing(queue)[1] = metadata;
+  WriteProxyPacket(queue, 1, MakeBarrierValue(MakeSignal(original_signal, 90)));
+  queue.StoreWriteIndexRelaxed(2);
+  queue.StoreRelaxed(0);
+  ExpectMetadataEq(fake_queue->MetadataAt(1), expected);
+}
+
+TEST_F(InterceptQueueMetadataTest, NullVendorCompletionSignalsClearEventId) {
+  auto fake = std::make_unique<FakeQueue>();
+  auto* fake_queue = fake.get();
+  TestInterceptQueue queue(std::move(fake));
+
+  ProxyMetadataRing(queue)[0] = MakeMetadata(0x58, 0x1234);
+  ProxyMetadataRing(queue)[1] = MakeMetadata(0x59, 0x5678);
+  WriteProxyPacket(queue, 0, MakeExtDispatch());
+  WriteProxyPacket(queue, 1, MakeBarrierValue());
+  queue.StoreWriteIndexRelaxed(2);
+  queue.StoreRelaxed(0);
+
+  ExpectMetadataEq(fake_queue->MetadataAt(0), MakeMetadata(0x58, 0));
+  ExpectMetadataEq(fake_queue->MetadataAt(1), MakeMetadata(0x59, 0));
+}
+
+TEST_F(InterceptQueueMetadataTest, AgentPacketsDoNotDereferenceCompletionSignals) {
+  auto fake = std::make_unique<FakeQueue>();
+  auto* fake_queue = fake.get();
+  TestInterceptQueue queue(std::move(fake));
+
+  const MetadataPacket metadata = MakeMetadata(0x5a, 0x1234);
+  ProxyMetadataRing(queue)[0] = metadata;
+  WriteProxyPacket(queue, 0, MakeAgentDispatch());
+  queue.StoreWriteIndexRelaxed(1);
+  queue.StoreRelaxed(0);
+
+  ExpectMetadataEq(fake_queue->MetadataAt(0), metadata);
+}
+
+TEST_F(InterceptQueueMetadataTest, ReorderedNormalizedPacketsFollowMetadata) {
+  auto fake = std::make_unique<FakeQueue>();
+  auto* fake_queue = fake.get();
+  TestInterceptQueue queue(std::move(fake));
+  queue.AddInterceptor(ReversePackets, nullptr);
+
+  amd_signal_t first_signal{};
+  amd_signal_t second_signal{};
+  const MetadataPacket first = MakeMetadata(0x67, 71);
+  const MetadataPacket second = MakeMetadata(0x78, 72);
+  ProxyMetadataRing(queue)[0] = first;
+  ProxyMetadataRing(queue)[1] = second;
+  WriteProxyPacket(queue, 0, MakeDispatch(0x14000, MakeSignal(first_signal, 71)));
+  WriteProxyPacket(queue, 1, MakeDispatch(0x14000, MakeSignal(second_signal, 72)));
+  queue.StoreWriteIndexRelaxed(2);
+  queue.StoreRelaxed(0);
+
+  ExpectMetadataEq(fake_queue->MetadataAt(0), second);
+  ExpectMetadataEq(fake_queue->MetadataAt(1), first);
+}
+
+TEST_F(InterceptQueueMetadataTest, MarkerPacketsDoNotConsumeMetadataSlots) {
+  marker_callback_fired = false;
+  marker_packet_index = 0;
+
+  auto fake = std::make_unique<FakeQueue>();
+  auto* fake_queue = fake.get();
+  TestInterceptQueue queue(std::move(fake));
+  queue.AddInterceptor(InsertMarker, nullptr);
+
+  amd_signal_t signal{};
+  const MetadataPacket metadata = MakeMetadata(0x89, 81);
+  ProxyMetadataRing(queue)[0] = metadata;
+  WriteProxyPacket(queue, 0, MakeDispatch(0x15000, MakeSignal(signal, 81)));
+  queue.StoreWriteIndexRelaxed(1);
+  queue.StoreRelaxed(0);
+
+  EXPECT_TRUE(marker_callback_fired);
+  EXPECT_EQ(marker_packet_index, 0u);
+  EXPECT_EQ(fake_queue->LoadWriteIndexRelaxed(), 1u);
+  ExpectMetadataEq(fake_queue->MetadataAt(0), metadata);
+}
+
+}  // namespace

--- a/projects/rocr-runtime/rocrtst/suites/test_common/CMakeLists.txt
+++ b/projects/rocr-runtime/rocrtst/suites/test_common/CMakeLists.txt
@@ -450,6 +450,7 @@ aux_source_directory(${ROCRTST_ROOT}/suites/functional functionalSources)
 aux_source_directory(${ROCRTST_ROOT}/suites/negative negativeSources)
 aux_source_directory(${ROCRTST_ROOT}/suites/stress stressSources)
 aux_source_directory(${ROCRTST_ROOT}/suites/test_common testCommonSources)
+list(FILTER functionalSources EXCLUDE REGEX ".*intercept_queue_metadata_test\\.cc$")
 
 # Optional: enable NUMA async copy test (memory_async_copy_numa.cc)
 # Force disabled by default to avoid building the NUMA test source.
@@ -866,6 +867,25 @@ set_tests_properties(hotswap_gfx_query PROPERTIES
   LABELS "quick;standard;pr;pre-commit;hotswap"
   TIMEOUT 60)
 
+pkg_check_modules(DRM REQUIRED libdrm)
+add_executable(intercept_queue_metadata
+  ${ROCRTST_ROOT}/suites/functional/intercept_queue_metadata_test.cc
+  ${HSA_RUNTIME_ROOT}/core/runtime/intercept_queue.cpp)
+target_include_directories(intercept_queue_metadata PRIVATE
+  ${HSA_RUNTIME_ROOT}
+  ${HSA_RUNTIME_ROOT}/inc
+  ${ROCRTST_ROOT}/../libhsakmt/include
+  ${ROCRTST_ROOT}/gtest/include)
+target_include_directories(intercept_queue_metadata SYSTEM PRIVATE ${DRM_INCLUDE_DIRS})
+target_compile_definitions(intercept_queue_metadata PRIVATE ROCR_INTERCEPT_QUEUE_TESTING)
+target_compile_options(intercept_queue_metadata PRIVATE -ffunction-sections -fdata-sections)
+set_property(TARGET intercept_queue_metadata APPEND_STRING PROPERTY LINK_FLAGS " -Wl,--gc-sections")
+target_link_libraries(intercept_queue_metadata ${GOOGLE_TEST_FRWK_NAME} pthread)
+add_test(NAME intercept_queue_metadata COMMAND intercept_queue_metadata)
+set_tests_properties(intercept_queue_metadata PROPERTIES
+  LABELS "quick;standard;pr;pre-commit;intercept-queue"
+  TIMEOUT 60)
+
 add_executable(hotswap_rewrite
   ${HOTSWAP_TEST_ROOT}/hotswap_rewrite_test.cc
   ${HSA_RUNTIME_ROOT}/core/runtime/hotswap.cpp
@@ -911,8 +931,8 @@ install(TARGETS ${ROCRTST}
         LIBRARY DESTINATION lib
         RUNTIME DESTINATION bin)
 
-install(TARGETS hotswap_gfx_query hotswap_rewrite
-        RUNTIME DESTINATION bin)
+install(TARGETS hotswap_gfx_query intercept_queue_metadata hotswap_rewrite
+         RUNTIME DESTINATION bin)
 
 # Install platform configuration file
 install(FILES ${ROCRTST_ROOT}/config/platform_config.yaml
@@ -966,6 +986,8 @@ if(EXISTS "${TEST_CATEGORIES_CMAKE}" AND EXISTS "${TEST_CATEGORIES_YAML}")
         "\n"
         "add_test(hotswap_gfx_query \"../hotswap_gfx_query\")\n"
         "set_tests_properties(hotswap_gfx_query PROPERTIES LABELS \"quick;standard;pr;pre-commit;hotswap\" TIMEOUT 60)\n\n"
+        "add_test(intercept_queue_metadata \"../intercept_queue_metadata\")\n"
+        "set_tests_properties(intercept_queue_metadata PROPERTIES LABELS \"quick;standard;pr;pre-commit;intercept-queue\" TIMEOUT 60)\n\n"
         "add_test(hotswap_rewrite \"../hotswap_rewrite\")\n"
         "set_tests_properties(hotswap_rewrite PROPERTIES LABELS \"quick;standard;pr;pre-commit;hotswap\" TIMEOUT 120)\n\n"
     )

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/intercept_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/intercept_queue.h
@@ -73,7 +73,9 @@ class QueueWrapper : public Queue {
   }
 
   ~QueueWrapper() {
+#ifndef ROCR_INTERCEPT_QUEUE_TESTING
     if (shared_queue_) core::Runtime::runtime_singleton_->system_deallocator()(shared_queue_);
+#endif
   }
 
   hsa_status_t Inactivate() override { return wrapped->Inactivate(); }
@@ -135,6 +137,15 @@ class QueueWrapper : public Queue {
   void SetProfiling(bool enabled) override { wrapped->SetProfiling(enabled); }
 
  protected:
+#ifdef ROCR_INTERCEPT_QUEUE_TESTING
+  // Test seam: the caller retains ownership of the supplied SharedQueue.
+  QueueWrapper(std::unique_ptr<Queue> queue, SharedQueue* shared_queue)
+      : Queue(shared_queue, 0, nullptr), wrapped(std::move(queue)) {
+    memcpy(&amd_queue_, &wrapped->amd_queue_, sizeof(amd_queue_));
+    wrapped->set_public_handle(wrapped.get(), public_handle_);
+  }
+#endif
+
   void do_set_public_handle(hsa_queue_t* handle) override {
     public_handle_ = handle;
     wrapped->set_public_handle(wrapped.get(), handle);
@@ -148,6 +159,14 @@ class QueueWrapper : public Queue {
 class QueueProxy : public QueueWrapper {
  public:
   explicit QueueProxy(std::unique_ptr<Queue> queue) : QueueWrapper(std::move(queue)) {}
+
+#ifdef ROCR_INTERCEPT_QUEUE_TESTING
+ protected:
+  QueueProxy(std::unique_ptr<Queue> queue, SharedQueue* shared_queue)
+      : QueueWrapper(std::move(queue), shared_queue) {}
+
+ public:
+#endif
 
   uint64_t LoadReadIndexAcquire() override {
     return atomic::Load(&amd_queue_.read_dispatch_id, std::memory_order_acquire);
@@ -221,8 +240,22 @@ class InterceptQueue : public QueueProxy, private LocalSignal, public DoorbellSi
   // Largest processed packet index.
   uint64_t next_packet_;
 
+  struct PacketWithMetadata {
+    AqlPacket aql;
+    AqlMetadataPrefetchPacket metadata;
+  };
+
+  struct OriginalPacketInfo {
+    AqlPacket aql;
+    AqlMetadataPrefetchPacket metadata;
+    bool matched;
+  };
+
   // Post interception packet overflow buffer
-  std::vector<AqlPacket> overflow_;
+  std::vector<PacketWithMetadata> overflow_;
+
+  // Originals used to associate rewritten packets with proxy metadata.
+  std::vector<OriginalPacketInfo> originals_;
 
   // Index at which async intercept processing was scheduled.
   uint64_t retry_index_;
@@ -244,6 +277,15 @@ class InterceptQueue : public QueueProxy, private LocalSignal, public DoorbellSi
   // Pre-allocated staging buffer for wrap-around cases
   std::vector<AqlPacket> staging_buffer_;
 
+  // Reusable overflow and metadata scratch buffers.
+  std::vector<AqlPacket> aql_scratch_;
+  std::vector<AqlMetadataPrefetchPacket> metadata_scratch_;
+
+  // Metadata rings are paired with the AQL rings of the wrapped and proxy queues.
+  // Producers must write a proxy metadata slot before publishing its AQL header.
+  void* metadata_ring_buf_ = nullptr;
+  std::vector<AqlMetadataPrefetchPacket> proxy_metadata_buf_;
+
   // Packet transform callbacks
   std::vector<std::pair<AMD::callback_t<hsa_amd_queue_intercept_handler>, void*>> interceptors;
 
@@ -254,7 +296,12 @@ class InterceptQueue : public QueueProxy, private LocalSignal, public DoorbellSi
 
   // Submit packets to the wrapped queue and return number of packets that were
   // submitted.
-  uint64_t Submit(const AqlPacket* packets, uint64_t count);
+  uint64_t Submit(const AqlPacket* packets, uint64_t count,
+                  const AqlMetadataPrefetchPacket* metadata = nullptr);
+
+  void Initialize();
+  void NotifyWrappedDoorbell(uint64_t new_index);
+  hsa_signal_t GetRetryCompletionSignal();
 
   // Used as the final packet rewriter that submits the packets to the wrapped
   // queue.
@@ -286,6 +333,10 @@ class InterceptQueue : public QueueProxy, private LocalSignal, public DoorbellSi
 
  protected:
   bool _IsA(Queue::rtti_t id) const override { return id == &rtti_id(); }
+
+#ifdef ROCR_INTERCEPT_QUEUE_TESTING
+  InterceptQueue(std::unique_ptr<Queue> queue, SharedQueue* shared_queue);
+#endif
 
  private:
   static __forceinline int& rtti_id() {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/intercept_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/intercept_queue.cpp
@@ -44,12 +44,22 @@
 #include "core/inc/amd_aql_queue.h"
 #include "core/inc/default_signal.h"
 #include "core/util/utils.h"
+#include "inc/amd_hsa_signal.h"
 #include "inc/hsa_api_trace.h"
 
 namespace rocr {
 namespace core {
 
 namespace {
+
+using MetadataPacket = AqlMetadataPrefetchPacket;
+
+constexpr uint16_t kMutableAqlHeaderFlags = ((1u << HSA_PACKET_HEADER_WIDTH_BARRIER) - 1)
+        << HSA_PACKET_HEADER_BARRIER |
+    ((1u << HSA_PACKET_HEADER_WIDTH_ACQUIRE_FENCE_SCOPE) - 1)
+        << HSA_PACKET_HEADER_ACQUIRE_FENCE_SCOPE |
+    ((1u << HSA_PACKET_HEADER_WIDTH_RELEASE_FENCE_SCOPE) - 1)
+        << HSA_PACKET_HEADER_RELEASE_FENCE_SCOPE;
 
 // Determine if a packet is the AMD_AQL_FORMAT_INTERCEPT_MARKER packet. Loads
 // the packet header non-atomically. That is permissable if the calling thread
@@ -59,6 +69,87 @@ namespace {
 bool inline IsInterceptMarkerPacket(const AqlPacket* packet) {
   return (AqlPacket::type(packet->packet.header) == HSA_PACKET_TYPE_VENDOR_SPECIFIC) &&
       (packet->amd_vendor.format == AMD_AQL_FORMAT_INTERCEPT_MARKER);
+}
+
+void FillNoopMetadata(MetadataPacket& metadata) {
+  metadata = {};
+  metadata.packet.header0.type = HSA_PACKET_TYPE_INVALID;
+  metadata.packet.header1.type = HSA_PACKET_TYPE_INVALID;
+  metadata.packet.header2.type = HSA_PACKET_TYPE_INVALID;
+  metadata.packet.header3.type = HSA_PACKET_TYPE_INVALID;
+}
+
+void WriteMetadataSlot(void* metadata_ring, uint64_t slot_index, uint64_t mask,
+                       const MetadataPacket& metadata) {
+  reinterpret_cast<MetadataPacket*>(metadata_ring)[slot_index & mask] = metadata;
+}
+
+bool MaskedPacketMatch(const AqlPacket& a, const AqlPacket& b) {
+  return AqlPacket::type(a.packet.header) == AqlPacket::type(b.packet.header) &&
+      (a.packet.header & ~kMutableAqlHeaderFlags) == (b.packet.header & ~kMutableAqlHeaderFlags) &&
+      memcmp(reinterpret_cast<const uint8_t*>(&a) + 2, reinterpret_cast<const uint8_t*>(&b) + 2,
+             54) == 0;
+}
+
+bool CompletionSignalMatch(const AqlPacket& a, const AqlPacket& b) {
+  constexpr size_t kCompletionSignalOffset = sizeof(AqlPacket) - sizeof(hsa_signal_t);
+  return memcmp(reinterpret_cast<const uint8_t*>(&a) + kCompletionSignalOffset,
+                reinterpret_cast<const uint8_t*>(&b) + kCompletionSignalOffset,
+                sizeof(hsa_signal_t)) == 0;
+}
+
+uint32_t GetSignalEventId(hsa_signal_t signal) {
+  if (signal.handle == 0) return 0;
+  return reinterpret_cast<const amd_signal_t*>(signal.handle)->event_id;
+}
+
+void UpdateMetadataEventId(const AqlPacket& packet, MetadataPacket& metadata) {
+  switch (AqlPacket::type(packet.packet.header)) {
+    case HSA_PACKET_TYPE_KERNEL_DISPATCH:
+      metadata.packet.event_id = GetSignalEventId(packet.dispatch.completion_signal);
+      break;
+    case HSA_PACKET_TYPE_BARRIER_AND:
+      metadata.packet.event_id = GetSignalEventId(packet.barrier_and.completion_signal);
+      break;
+    case HSA_PACKET_TYPE_BARRIER_OR:
+      metadata.packet.event_id = GetSignalEventId(packet.barrier_or.completion_signal);
+      break;
+    case HSA_PACKET_TYPE_VENDOR_SPECIFIC:
+      if (packet.amd_vendor.format == HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH) {
+        metadata.packet.event_id = GetSignalEventId(packet.ext_dispatch.completion_signal);
+      } else if (packet.amd_vendor.format == HSA_AMD_PACKET_TYPE_BARRIER_VALUE) {
+        const auto* barrier = reinterpret_cast<const hsa_amd_barrier_value_packet_t*>(&packet);
+        metadata.packet.event_id = GetSignalEventId(barrier->completion_signal);
+      }
+      break;
+    default:
+      break;
+  }
+}
+
+template <typename Overflow>
+void AppendOverflowPackets(Overflow& overflow, const AqlPacket* packets, uint64_t begin,
+                           uint64_t end, const MetadataPacket* metadata) {
+  for (uint64_t i = begin; i < end; ++i) {
+    typename Overflow::value_type packet{};
+    packet.aql = packets[i];
+    if (metadata)
+      packet.metadata = metadata[i];
+    else
+      FillNoopMetadata(packet.metadata);
+    overflow.push_back(packet);
+  }
+}
+
+template <typename Overflow>
+void CopyOverflowToScratch(const Overflow& overflow, std::vector<AqlPacket>& aql,
+                           std::vector<MetadataPacket>& metadata) {
+  aql.resize(overflow.size());
+  metadata.resize(overflow.size());
+  for (uint64_t i = 0; i < overflow.size(); ++i) {
+    aql[i] = overflow[i].aql;
+    metadata[i] = overflow[i].metadata;
+  }
 }
 
 }  // namespace
@@ -111,14 +202,7 @@ bool InterceptQueue::IsPendingRetryPoint(uint64_t wrapped_current_read_index) co
   return retry_index_ > wrapped_current_read_index;
 }
 
-InterceptQueue::InterceptQueue(std::unique_ptr<Queue> queue)
-    : QueueProxy(std::move(queue)),
-      LocalSignal(0, false),
-      DoorbellSignal(signal()),
-      next_packet_(0),
-      retry_index_(0),
-      quit_(false),
-      active_(true) {
+void InterceptQueue::Initialize() {
   // Initial retry_index_ value must ensure that
   // InterceptQueue::IsPendingRetryPoint will return false before the first
   // retry barrier packet is inserted.
@@ -129,6 +213,8 @@ InterceptQueue::InterceptQueue(std::unique_ptr<Queue> queue)
 
   // Pre-allocate staging buffer with queue size
   staging_buffer_.resize(wrapped->amd_queue_.hsa_queue.size);
+  aql_scratch_.resize(wrapped->amd_queue_.hsa_queue.size);
+  metadata_scratch_.resize(wrapped->amd_queue_.hsa_queue.size);
 
   // Fill the ring buffer with invalid packet headers.
   // Leave packet content uninitialized to help trigger application errors.
@@ -136,7 +222,32 @@ InterceptQueue::InterceptQueue(std::unique_ptr<Queue> queue)
     buffer_[pkt_id].packet.header = HSA_PACKET_TYPE_INVALID;
   }
 
-  // Match the queue's signal ABI block to async_doorbell_'s
+  uint64_t metadata_ring = 0;
+  if (wrapped->GetInfo(HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_RING_BUFFER, &metadata_ring) ==
+          HSA_STATUS_SUCCESS &&
+      metadata_ring != 0) {
+    metadata_ring_buf_ = reinterpret_cast<void*>(metadata_ring);
+    proxy_metadata_buf_.resize(wrapped->amd_queue_.hsa_queue.size);
+    for (auto& metadata : proxy_metadata_buf_) FillNoopMetadata(metadata);
+  }
+
+  // Install copy submission interceptor.
+  AddInterceptor(Submit, this);
+}
+
+#ifndef ROCR_INTERCEPT_QUEUE_TESTING
+InterceptQueue::InterceptQueue(std::unique_ptr<Queue> queue)
+    : QueueProxy(std::move(queue)),
+      LocalSignal(0, false),
+      DoorbellSignal(signal()),
+      next_packet_(0),
+      retry_index_(0),
+      async_doorbell_(nullptr),
+      quit_(false),
+      active_(true) {
+  Initialize();
+
+  // Match the queue's signal ABI block to async_doorbell_'s.
   // This allows us to use the queue's signal ABI block from devices to trigger async_doorbell while
   // host side use jumps directly to the queue's signal implementation.
   if (!core::g_use_interrupt_wait)
@@ -154,15 +265,29 @@ InterceptQueue::InterceptQueue(std::unique_ptr<Queue> queue)
   if (err != HSA_STATUS_SUCCESS)
     throw AMD::hsa_exception(err, "Doorbell handler registration failed.\n");
 
-  // Install copy submission interceptor.
-  AddInterceptor(Submit, this);
-
   sigGuard.Dismiss();
 }
+#endif
+
+#ifdef ROCR_INTERCEPT_QUEUE_TESTING
+InterceptQueue::InterceptQueue(std::unique_ptr<Queue> queue, SharedQueue* shared_queue)
+    : QueueProxy(std::move(queue), shared_queue),
+      LocalSignal(0),
+      DoorbellSignal(signal()),
+      next_packet_(0),
+      retry_index_(0),
+      async_doorbell_(nullptr),
+      quit_(false),
+      active_(true) {
+  amd_queue_.hsa_queue.doorbell_signal = Signal::Convert(this);
+  Initialize();
+}
+#endif
 
 InterceptQueue::~InterceptQueue() {
   active_ = false;
 
+#ifndef ROCR_INTERCEPT_QUEUE_TESTING
   // Kill the async doorbell handler
   // Doorbell may not be used during or after queue destroy, however an interrupt may be in flight.
   // Ensure doorbell value is not 0, mark for exit, wake handler and wait for termination value.
@@ -172,6 +297,17 @@ InterceptQueue::~InterceptQueue() {
   if (val != 0)
     async_doorbell_->WaitRelaxed(HSA_SIGNAL_CONDITION_EQ, 0, -1, HSA_WAIT_STATE_BLOCKED);
   async_doorbell_->DestroySignal();
+#endif
+}
+
+void InterceptQueue::NotifyWrappedDoorbell(uint64_t new_index) {
+#ifndef ROCR_INTERCEPT_QUEUE_TESTING
+  HSA::hsa_signal_store_screlease(wrapped->amd_queue_.hsa_queue.doorbell_signal, new_index);
+#endif
+}
+
+hsa_signal_t InterceptQueue::GetRetryCompletionSignal() {
+  return async_doorbell_ ? Signal::Convert(async_doorbell_) : hsa_signal_t{0};
 }
 
 bool InterceptQueue::HandleAsyncDoorbell(hsa_signal_value_t value, void* arg) {
@@ -200,17 +336,48 @@ void InterceptQueue::Submit(const void* pkts, uint64_t pkt_count, uint64_t user_
   InterceptQueue* queue = reinterpret_cast<InterceptQueue*>(data);
   const AqlPacket* packets = (const AqlPacket*)pkts;
 
+  const MetadataPacket* metadata = nullptr;
+  if (queue->metadata_ring_buf_) {
+    queue->metadata_scratch_.resize(pkt_count);
+    for (uint64_t i = 0; i < pkt_count; ++i) {
+      OriginalPacketInfo* match = nullptr;
+      for (auto& original : queue->originals_) {
+        if (!original.matched && MaskedPacketMatch(packets[i], original.aql) &&
+            CompletionSignalMatch(packets[i], original.aql)) {
+          match = &original;
+          break;
+        }
+      }
+      if (match == nullptr) {
+        for (auto& original : queue->originals_) {
+          if (!original.matched && MaskedPacketMatch(packets[i], original.aql)) {
+            match = &original;
+            break;
+          }
+        }
+      }
+      if (match != nullptr) {
+        queue->metadata_scratch_[i] = match->metadata;
+        match->matched = true;
+      } else {
+        FillNoopMetadata(queue->metadata_scratch_[i]);
+      }
+      UpdateMetadataEventId(packets[i], queue->metadata_scratch_[i]);
+    }
+    metadata = queue->metadata_scratch_.data();
+  }
+
   // Submit final packet transform to hardware.
-  uint64_t submitted_count = queue->Submit(packets, pkt_count);
+  uint64_t submitted_count = queue->Submit(packets, pkt_count, metadata);
   if (submitted_count == pkt_count) return;
 
   // Could not submit all the final packets, stash unsubmitted ones for later.
   assert(queue->overflow_.empty() && "Packet intercept error: overflow buffer not empty.\n");
-  for (uint64_t i = submitted_count; i < pkt_count; i++)
-    queue->overflow_.push_back(packets[i]);
+  AppendOverflowPackets(queue->overflow_, packets, submitted_count, pkt_count, metadata);
 }
 
-uint64_t InterceptQueue::Submit(const AqlPacket* packets, uint64_t count) {
+uint64_t InterceptQueue::Submit(const AqlPacket* packets, uint64_t count,
+                                const AqlMetadataPrefetchPacket* metadata) {
   if (count == 0) return 0;
 
   uint64_t marker_count = 0;
@@ -268,7 +435,12 @@ uint64_t InterceptQueue::Submit(const AqlPacket* packets, uint64_t count) {
 
       // Submit barrier which will wake async queue processing.
       ring[barrier & mask].packet.body = {};
-      ring[barrier & mask].barrier_and.completion_signal = Signal::Convert(async_doorbell_);
+      if (metadata_ring_buf_) {
+        MetadataPacket noop;
+        FillNoopMetadata(noop);
+        WriteMetadataSlot(metadata_ring_buf_, barrier, mask, noop);
+      }
+      ring[barrier & mask].barrier_and.completion_signal = GetRetryCompletionSignal();
       if (wrapped->IsDeviceMemRingBuf() && needsPcieOrdering()) {
         // Ensure the packet body is written as header may get reordered when writing over PCIE
         _mm_sfence();
@@ -276,7 +448,7 @@ uint64_t InterceptQueue::Submit(const AqlPacket* packets, uint64_t count) {
       atomic::Store(&ring[barrier & mask].barrier_and.header, kBarrierHeader,
                     std::memory_order_release);
       // Update the wrapped queue's doorbell so it knows there is a new packet in the queue.
-      HSA::hsa_signal_store_screlease(wrapped->amd_queue_.hsa_queue.doorbell_signal, barrier);
+      NotifyWrappedDoorbell(barrier);
 
       // Record the retry point
       retry_index_ = barrier;
@@ -291,7 +463,10 @@ uint64_t InterceptQueue::Submit(const AqlPacket* packets, uint64_t count) {
       uint64_t packets_index = 0;
       uint64_t write_index = 0;
       uint64_t first_written_packet_index;
-      while (submitted_count > 0 || (packets_index < count && IsInterceptMarkerPacket(&packets[packets_index]))) {
+      MetadataPacket noop;
+      FillNoopMetadata(noop);
+      while (submitted_count > 0 ||
+             (packets_index < count && IsInterceptMarkerPacket(&packets[packets_index]))) {
         // Ensure the marker packet callback is invoked before following
         // packets are made available for the packet processor.
         if (IsInterceptMarkerPacket(&packets[packets_index])) {
@@ -306,8 +481,14 @@ uint64_t InterceptQueue::Submit(const AqlPacket* packets, uint64_t count) {
             // been written and the first packet header atomically store
             // released.
             ring[(write + write_index) & mask].packet.body = packets[packets_index].packet.body;
+            if (metadata_ring_buf_)
+              WriteMetadataSlot(metadata_ring_buf_, write + write_index, mask,
+                                metadata ? metadata[packets_index] : noop);
             first_written_packet_index = packets_index;
           } else {
+            if (metadata_ring_buf_)
+              WriteMetadataSlot(metadata_ring_buf_, write + write_index, mask,
+                                metadata ? metadata[packets_index] : noop);
             ring[(write + write_index) & mask] = packets[packets_index];
           }
           ++write_index;
@@ -320,10 +501,9 @@ uint64_t InterceptQueue::Submit(const AqlPacket* packets, uint64_t count) {
           // Ensure the packet body is written as header may get reordered when writing over PCIE
           _mm_sfence();
         }
-        atomic::Store(&ring[write & mask].packet.header, packets[first_written_packet_index].packet.header,
-                      std::memory_order_release);
-        HSA::hsa_signal_store_screlease(wrapped->amd_queue_.hsa_queue.doorbell_signal,
-                                        write + write_index - 1);
+        atomic::Store(&ring[write & mask].packet.header,
+                      packets[first_written_packet_index].packet.header, std::memory_order_release);
+        NotifyWrappedDoorbell(write + write_index - 1);
       }
       return packets_index;
     }
@@ -344,7 +524,9 @@ void InterceptQueue::StoreRelaxed(hsa_signal_value_t value) {
 
   // Submit overflow packets.
   if (!overflow_.empty()) {
-    uint64_t submitted_count = Submit(&overflow_[0], overflow_.size());
+    CopyOverflowToScratch(overflow_, aql_scratch_, metadata_scratch_);
+    uint64_t submitted_count = Submit(aql_scratch_.data(), overflow_.size(),
+                                      metadata_ring_buf_ ? metadata_scratch_.data() : nullptr);
 
     if (submitted_count < overflow_.size()) {
       overflow_.erase(overflow_.begin(), overflow_.begin() + submitted_count);
@@ -404,18 +586,28 @@ void InterceptQueue::StoreRelaxed(hsa_signal_value_t value) {
 
     // Check if packets wrap around the ring buffer boundary using unmasked indices.
     // The interceptor callback expects packets to be contiguous in memory.
+    const AqlPacket* interceptor_input;
     if ((next_packet_ + packet_count) > ((next_packet_ & ~mask) + amd_queue_.hsa_queue.size)) {
       // Packets wrap around - use pre-allocated staging buffer
       for (uint64_t j = 0; j < packet_count; ++j) {
         staging_buffer_[j] = ring[(next_packet_ + j) & mask];
       }
-      handler.first(staging_buffer_.data(), packet_count, next_packet_,
-                    handler.second, PacketWriter);
+      interceptor_input = staging_buffer_.data();
     } else {
       // Packets are contiguous in the ring buffer
-      handler.first(&ring[next_packet_ & mask], packet_count, next_packet_,
-                                                 handler.second, PacketWriter);
+      interceptor_input = &ring[next_packet_ & mask];
     }
+
+    if (metadata_ring_buf_) {
+      originals_.resize(packet_count);
+      for (uint64_t j = 0; j < packet_count; ++j) {
+        originals_[j].aql = interceptor_input[j];
+        originals_[j].metadata = proxy_metadata_buf_[(next_packet_ + j) & mask];
+        originals_[j].matched = false;
+      }
+    }
+
+    handler.first(interceptor_input, packet_count, next_packet_, handler.second, PacketWriter);
 
     if (IsDeviceMemRingBuf() && needsPcieOrdering()) {
       // Ensure the packet body is written as header may get reordered when writing over PCIE
@@ -425,6 +617,7 @@ void InterceptQueue::StoreRelaxed(hsa_signal_value_t value) {
   i = next_packet_;
   while (i < std::min(end, invalid_header_i)) {
     // Invalidate consumed packets.
+    if (metadata_ring_buf_) FillNoopMetadata(proxy_metadata_buf_[i & mask]);
     atomic::Store(&ring[i & mask].packet.header, kInvalidHeader, std::memory_order_release);
     // Packet has now been processed so advance the read index.
     ++i;
@@ -437,8 +630,18 @@ void InterceptQueue::StoreRelaxed(hsa_signal_value_t value) {
 
 hsa_status_t InterceptQueue::GetInfo(hsa_queue_info_attribute_t attribute, void* value) {
   switch (attribute) {
+    case HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_RING_BUFFER:
+      if (metadata_ring_buf_ == nullptr) return wrapped->GetInfo(attribute, value);
+      *reinterpret_cast<uint64_t*>(value) = reinterpret_cast<uint64_t>(proxy_metadata_buf_.data());
+      return HSA_STATUS_SUCCESS;
+    case HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_DISPATCH_PKT_VERSION_MAJOR:
+    case HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_DISPATCH_PKT_VERSION_MINOR:
+    case HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_BARRIER_PKT_VERSION_MAJOR:
+    case HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_BARRIER_PKT_VERSION_MINOR:
+    case HSA_AMD_QUEUE_INFO_PROPERTIES:
+      return wrapped->GetInfo(attribute, value);
     case HSA_AMD_QUEUE_INFO_AGENT:
-    case HSA_AMD_QUEUE_INFO_DOORBELL_ID: 
+    case HSA_AMD_QUEUE_INFO_DOORBELL_ID:
     case HSA_QUEUE_INFO_USE_COUNT:
     case HSA_QUEUE_INFO_HW_ID: {
       if (!AMD::AqlQueue::IsType(wrapped.get())) return HSA_STATUS_ERROR_INVALID_QUEUE;
@@ -446,6 +649,8 @@ hsa_status_t InterceptQueue::GetInfo(hsa_queue_info_attribute_t attribute, void*
       AMD::AqlQueue* aqlQueue = static_cast<AMD::AqlQueue*>(wrapped.get());
       return aqlQueue->GetInfo(attribute, value);
     }
+    default:
+      break;
   }
   return HSA_STATUS_ERROR_INVALID_ARGUMENT;
 }


### PR DESCRIPTION
## Summary
Preserve AMD metadata-prefetch packets when HSA queues are wrapped by `InterceptQueue`, so profiler/interceptor paths do not silently drop metadata needed by supported hardware.

## Changes

- `projects/rocr-runtime/runtime/hsa-runtime/core/inc/intercept_queue.h`
  - Add paired AQL/metadata storage for overflow and pre-interceptor snapshots.
  - Add proxy metadata-ring state and the host-only test construction seam.
- `projects/rocr-runtime/runtime/hsa-runtime/core/runtime/intercept_queue.cpp`
  - Reuse the public `AqlMetadataPrefetchPacket` representation.
  - Redirect metadata-ring queries to the intercept queue's proxy ring.
  - Match rewritten packets to original metadata using exact completion-signal matching followed by signal-agnostic fallback.
  - Preserve metadata through insertion, deletion, reorder, replacement, overflow, and retry-barrier paths.
  - Update event IDs for standard and AMD vendor dispatch/barrier packets.
  - Reset consumed proxy metadata slots to prevent stale metadata after ring reuse.
  - Forward metadata version and queue-property queries.
- `projects/rocr-runtime/rocrtst/suites/functional/intercept_queue_metadata_test.cc`
  - Add 23 host-only GTest cases covering metadata preservation, packet transformations, event IDs, vendor packets, wraparound, stale-slot reset, overflow/retry, unsupported metadata, null signals, and intercept markers.
- `projects/rocr-runtime/rocrtst/suites/test_common/CMakeLists.txt`
  - Add the standalone test target, exclude it from the aggregate source list, and register/install it with CTest.

## Design

- No new public HSA API or ABI-table changes.
- Uses the current public `core::AqlMetadataPrefetchPacket` type; no duplicate metadata definitions are added.
- Metadata is written before the wrapped AQL packet header is published.
- Unmatched inserted/replaced packets receive four-invalid-header no-op metadata.

## Testing

- `clang-format -style=file --dry-run --Werror` on all changed C++ files.
- Production syntax check for `intercept_queue.cpp` with `clang++ -fsyntax-only`.
- Standalone `intercept_queue_metadata` target build with `/usr/bin/cmake --build`.
- `ctest -R '^intercept_queue_metadata$' -j1 --output-on-failure`.
- Direct GTest execution: 23/23 tests passed.

## Limitations

Full ROCR runtime build/install and GPU-backed validation were not available in the development environment. This draft is intended for review of the implementation and host-side coverage before device validation.