### PR TITLE
feat(rocprof-sys): Add hipFile GPU-direct storage I/O telemetry collection

### DIFF
--- a/projects/rocprofiler-systems/CHANGELOG.md
+++ b/projects/rocprofiler-systems/CHANGELOG.md
@@ -48,6 +48,21 @@ Full documentation for ROCm Systems Profiler is available at [https://rocm.docs.
   package installations automatically include this support. A `rocshmem` example
   demonstrating two-PE usage of all nine APIs is included under `examples/rocshmem`.
 
+### Added
+
+- hipFile GPU-direct storage I/O telemetry. A background sampler queries
+  hipFile's in-process statistics API and reports per-GPU I/O counters (read/write
+  bytes, total/fastpath/fallback/unaligned operation counts, errors, and
+  read/write bandwidth) in both Perfetto and RocPD outputs. The counters are
+  cumulative and the bandwidths are normalized to wall-clock time over the
+  sampling interval, matching the conventions of the existing AMD SMI PCIe, XGMI,
+  and AI NIC metrics. Select metrics with `ROCPROFSYS_HIPFILE_METRICS` and GPUs
+  with `ROCPROFSYS_SAMPLING_GPUS`. Build with `-DROCPROFSYS_USE_HIPFILE=ON`
+  (optional; disabled automatically when hipFile is not found) and enable at run
+  time with `ROCPROFSYS_USE_HIPFILE=ON` (requires a target application that uses
+  hipFile). See
+  [hipFile GPU-direct storage I/O telemetry](./docs/how-to/hipfile-telemetry.rst).
+
 ### Changed
 
 - `ROCPROFSYS_BUILD_TESTING` no longer implies `ROCPROFSYS_BUILD_EXAMPLES`.

--- a/projects/rocprofiler-systems/CMakeLists.txt
+++ b/projects/rocprofiler-systems/CMakeLists.txt
@@ -222,6 +222,10 @@ rocprofiler_systems_add_option(CMAKE_CXX_STANDARD_REQUIRED
 rocprofiler_systems_add_option(ROCPROFSYS_USE_AINIC
     "Enable AI NIC profiling through AMD SMI" ON
 )
+rocprofiler_systems_add_option(ROCPROFSYS_USE_HIPFILE
+    "Enable hipFile GPU-direct storage I/O stats collection (requires hipFile headers)"
+    OFF
+)
 rocprofiler_systems_add_option(CMAKE_CXX_EXTENSIONS
     "Compiler specific language extensions" OFF
 )

--- a/projects/rocprofiler-systems/cmake/Packages.cmake
+++ b/projects/rocprofiler-systems/cmake/Packages.cmake
@@ -295,6 +295,43 @@ endif()
 
 # ----------------------------------------------------------------------------------------#
 #
+# hipFile (GPU-direct storage I/O stats)
+#
+# ----------------------------------------------------------------------------------------#
+
+# hipFile telemetry is optional and off unless the package is found. When it is built,
+# the backend links libhipfile through the hip::hipfile imported target (a DT_NEEDED
+# dependency), matching how the profiler consumes amd_smi and other ROCm libraries.
+# The collector's unit tests do not participate in that: they drive a mock wrapper with
+# test-local fake structs, so they build and run with this option OFF.
+set(ROCPROFSYS_BUILD_HIPFILE OFF CACHE INTERNAL "Build hipFile stats support" FORCE)
+if(ROCPROFSYS_USE_HIPFILE)
+    find_package(
+        hipfile
+        ${rocprofiler_systems_FIND_QUIETLY}
+        HINTS ${ROCMVersion_DIR} ${ROCM_PATH}
+        PATHS ${ROCMVersion_DIR} ${ROCM_PATH}
+    )
+    if(hipfile_FOUND)
+        set(ROCPROFSYS_BUILD_HIPFILE
+            ON
+            CACHE INTERNAL
+            "Build hipFile stats support"
+            FORCE
+        )
+        message(STATUS "hipFile stats support enabled (headers: ${hipfile_INCLUDE_DIRS})")
+    else()
+        message(
+            STATUS
+            "hipFile stats support disabled: hipfile package not found. Set "
+            "-Dhipfile_DIR=<prefix>/lib/cmake/hipfile or add the install prefix to "
+            "CMAKE_PREFIX_PATH."
+        )
+    endif()
+endif()
+
+# ----------------------------------------------------------------------------------------#
+#
 # Profiler Hub
 #
 # ----------------------------------------------------------------------------------------#

--- a/projects/rocprofiler-systems/docs/how-to/hipfile-telemetry.rst
+++ b/projects/rocprofiler-systems/docs/how-to/hipfile-telemetry.rst
@@ -1,0 +1,167 @@
+.. meta::
+   :description: ROCm Systems Profiler hipFile GPU-direct storage I/O telemetry
+   :keywords: rocprof-sys, rocprofiler-systems, ROCm, how to, profiler, hipFile, GPU-direct storage, GDS, I/O, telemetry, AMD
+
+********************************************
+hipFile GPU-direct storage I/O telemetry
+********************************************
+
+`ROCm Systems Profiler <https://github.com/ROCm/rocm-systems/tree/develop/projects/rocprofiler-systems>`_
+can collect GPU-direct storage I/O statistics from applications that use
+`hipFile <https://github.com/ROCm/hipFile>`_. A background sampler periodically
+queries hipFile's in-process statistics API and reports the results as per-GPU
+counter tracks in both the Perfetto trace and the RocPD database.
+
+Metrics collected
+==================
+
+All hipFile telemetry is per GPU, reported under tracks named
+``hipFile GPU<N> <metric>``:
+
+* **Read Bytes** / **Write Bytes** -- cumulative bytes transferred (``bytes``)
+* **Read Ops** / **Write Ops** -- cumulative read/write operations (``count``)
+* **Fastpath Reads** / **Fastpath Writes** -- operations that used hipFile's
+  GPU-direct fast path
+* **Fallback Reads** / **Fallback Writes** -- operations that used the POSIX
+  fallback path
+* **Unaligned Reads** / **Unaligned Writes** -- operations that were not aligned
+* **Read Errors** / **Write Errors** -- failed operations
+* **Read Bandwidth** / **Write Bandwidth** -- transfer rate over the sampling
+  interval (``bytes/s``)
+
+Interpreting the values
+-----------------------
+
+The counters are **cumulative** totals over the process lifetime, matching every
+other byte and operation counter the profiler reports (the AMD SMI PCIe bandwidth
+accumulator, the XGMI accumulators, and the AI NIC counters). To see activity per
+sampling window rather than the running total, switch the counter track to its
+delta view in the Perfetto UI.
+
+The bandwidth metrics are normalized to **wall-clock time** over the sampling
+interval, so they are directly comparable to the AMD SMI instantaneous PCIe
+bandwidth track on the same GPU. They are not derived from the time spent inside
+hipFile I/O calls, which would produce a rate that does not correspond to the
+timeline it is drawn against. The first sample of a run reports zero bandwidth,
+because no interval has elapsed yet.
+
+Note that hipFile also maintains process-scoped counters, such as file handle and
+buffer registrations. These are not GPU measurements, so they are not collected;
+attributing them to a specific GPU track would misreport them on multi-GPU runs.
+
+Requirements
+============
+
+* A ROCm release that includes hipFile (ROCm 7.15 or later), with the hipFile
+  runtime and development packages installed.
+* ROCm Systems Profiler built with hipFile support (see `Build support`_).
+* A target application that links and uses hipFile. The statistics API is
+  in-process, so telemetry is only produced when the profiled application
+  actually performs hipFile I/O.
+* A Linux kernel version 5.3 or later (required by hipFile's statistics server).
+
+Build support
+=============
+
+hipFile support is optional and controlled at build time by the
+``ROCPROFSYS_USE_HIPFILE`` CMake option. Configure the build with:
+
+.. code-block:: shell
+
+   cmake -D ROCPROFSYS_USE_HIPFILE=ON <other options> <path/to/source>
+
+If the hipFile package cannot be found, the option is disabled automatically and
+the rest of the profiler builds normally. To point CMake at a specific hipFile
+installation, pass ``-Dhipfile_DIR=<prefix>/lib/cmake/hipfile`` or add the
+installation prefix to ``CMAKE_PREFIX_PATH``.
+
+Enabling collection at run time
+===============================
+
+hipFile telemetry is disabled by default at run time. Enable it by setting
+``ROCPROFSYS_USE_HIPFILE=ON``. Collection runs on the process-sampling thread, so
+process sampling must also be enabled (it is on by default).
+
+.. code-block:: shell
+
+   ROCPROFSYS_USE_HIPFILE=ON
+   ROCPROFSYS_USE_PROCESS_SAMPLING=ON
+   ROCPROFSYS_PROCESS_SAMPLING_FREQ=100
+
+Details of the settings:
+
+* **ROCPROFSYS_USE_HIPFILE**: Enables the hipFile telemetry sampler.
+* **ROCPROFSYS_USE_PROCESS_SAMPLING**: Enables the background sampling thread
+  that drives the hipFile sampler (default ``ON``).
+* **ROCPROFSYS_PROCESS_SAMPLING_FREQ**: Samples per second. A higher frequency
+  captures short-lived I/O bursts more precisely.
+* **ROCPROFSYS_HIPFILE_METRICS**: Which hipFile metrics to collect. Accepts
+  ``all`` (the default), ``none``, or a comma-separated list of metric keys such
+  as ``read_bytes,write_bytes,read_bandwidth``.
+* **ROCPROFSYS_SAMPLING_GPUS**: Which GPUs to collect from. hipFile telemetry
+  honors the same GPU selection as the AMD SMI GPU metrics.
+
+When hipFile telemetry is enabled, the profiler sets ``HIPFILE_STATS_LEVEL=1``
+during configuration so that hipFile starts its statistics server. If you set
+``HIPFILE_STATS_LEVEL`` explicitly, your value is preserved.
+
+Running the profiler
+====================
+
+Run the target application under ``rocprof-sys-run`` (or ``rocprof-sys-sample``)
+with the settings above. For example:
+
+.. code-block:: shell
+
+   ROCPROFSYS_USE_HIPFILE=ON ROCPROFSYS_USE_PROCESS_SAMPLING=ON \
+     rocprof-sys-run -- ./my_hipfile_app --input data.bin
+
+You can also place the settings in a configuration file and point to it with
+``ROCPROFSYS_CONFIG_FILE``:
+
+.. code-block:: shell
+
+   ROCPROFSYS_USE_HIPFILE=ON
+   ROCPROFSYS_USE_PROCESS_SAMPLING=ON
+   ROCPROFSYS_PROCESS_SAMPLING_FREQ=100
+   ROCPROFSYS_TRACE=ON
+
+Visualize the results in Perfetto
+=================================
+
+To view the ``.proto`` file generated by the profiler:
+
+#. Open the `Perfetto UI page <https://ui.perfetto.dev/>`_.
+#. Click ``Open trace file`` and select the ``.proto`` file. The hipFile
+   counter tracks appear as ``hipFile GPU<N> <metric>``.
+
+Save the profiling output to RocPD
+==================================
+
+To save the output to RocPD, set ``ROCPROFSYS_USE_ROCPD=ON``:
+
+.. code-block:: shell
+
+   export ROCPROFSYS_USE_ROCPD=ON
+
+Running the profiler then produces a ``.db`` file. The hipFile metrics are stored
+as PMC descriptions (``rocpd_info_pmc``) and counter events
+(``rocpd_pmc_event``). You can view the generated file in
+`ROCm Optiq <https://rocm.docs.amd.com/projects/roc-optiq/en/latest/what-is-optiq.html>`_.
+
+Troubleshooting
+===============
+
+* **No hipFile tracks in the output**: Confirm that the profiler was built with
+  ``ROCPROFSYS_USE_HIPFILE=ON``, that ``ROCPROFSYS_USE_HIPFILE=ON`` is set at run
+  time, and that the target application actually performs hipFile I/O. If the
+  application never calls into hipFile, no statistics are produced.
+* **Counters are zero**: Verify that process sampling is enabled and that the
+  workload runs long enough to be sampled at least once during active I/O.
+* **A counter track looks flat**: The counters are cumulative, so a track that
+  stops climbing means I/O stopped, not that collection failed. Use the delta
+  view to see per-window activity.
+* **All operations are on the fallback path**: hipFile's fast path requires a
+  supported filesystem (ext4 with ordered journaling, or xfs) and ``O_DIRECT``.
+  When those conditions are not met, hipFile transparently uses POSIX I/O and
+  the **Fallback** counters climb while the **Fastpath** counters stay at zero.

--- a/projects/rocprofiler-systems/docs/index.rst
+++ b/projects/rocprofiler-systems/docs/index.rst
@@ -47,6 +47,7 @@ profiling, how it supports performance analysis, and how to leverage its capabil
       * :doc:`OpenMP performance profiling <./how-to/openmp-profiling>`
       * :doc:`VCN and JPEG sampling and tracing <./how-to/vcn-jpeg-sampling>`
       * :doc:`XGMI, PCIe, and SDMA metrics monitoring <./how-to/xgmi-pcie-sdma-sampling>`
+      * :doc:`hipFile GPU-direct storage I/O telemetry <./how-to/hipfile-telemetry>`
 
     * :doc:`Understanding the output <./how-to/understanding-rocprof-sys-output>`
     * :doc:`Use the preset profiles <./how-to/using-preset-profiles>`

--- a/projects/rocprofiler-systems/docs/sphinx/_toc.yml.in
+++ b/projects/rocprofiler-systems/docs/sphinx/_toc.yml.in
@@ -49,6 +49,8 @@ subtrees:
           title: VCN and JPEG sampling and tracing
         - file: how-to/xgmi-pcie-sdma-sampling.rst
           title: XGMI, PCIe, and SDMA metrics monitoring
+        - file: how-to/hipfile-telemetry.rst
+          title: hipFile GPU-direct storage I/O telemetry
     - file: how-to/understanding-rocprof-sys-output.rst
       title: Understanding the output
     - file: how-to/using-preset-profiles.rst

--- a/projects/rocprofiler-systems/examples/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/CMakeLists.txt
@@ -106,6 +106,12 @@ set(ROCPROFSYS_EXAMPLE_DIRS
     minimal
 )
 
+# hipFile telemetry workload; only buildable when rocprof-sys was configured
+# with hipFile support (ROCPROFSYS_BUILD_HIPFILE provides hip::hipfile).
+if(ROCPROFSYS_BUILD_HIPFILE)
+    list(APPEND ROCPROFSYS_EXAMPLE_DIRS hipfile-test)
+endif()
+
 foreach(_example_dir IN LISTS ROCPROFSYS_EXAMPLE_DIRS)
     if(NOT "${_example_dir}" IN_LIST ROCPROFSYS_DISABLE_EXAMPLES)
         add_subdirectory(${_example_dir})

--- a/projects/rocprofiler-systems/examples/hipfile-test/CMakeLists.txt
+++ b/projects/rocprofiler-systems/examples/hipfile-test/CMakeLists.txt
@@ -1,0 +1,48 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+cmake_minimum_required(VERSION 3.25 FATAL_ERROR)
+
+project(rocprofiler-systems-hipfile-test-example LANGUAGES CXX)
+
+# Support standalone builds
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    include(${CMAKE_CURRENT_LIST_DIR}/../cmake/standalone-helpers.cmake OPTIONAL)
+endif()
+
+find_package(hip QUIET HINTS ${ROCmVersion_DIR} PATHS ${ROCmVersion_DIR})
+
+# hip::hipfile is provided by the parent build's find_package(hipfile); for
+# standalone example builds, try to locate it directly.
+if(NOT TARGET hip::hipfile)
+    find_package(
+        hipfile
+        QUIET
+        HINTS ${ROCmVersion_DIR} ${ROCM_PATH}
+        PATHS ${ROCmVersion_DIR} ${ROCM_PATH}
+    )
+endif()
+
+if(NOT TARGET hip::host OR NOT TARGET hip::hipfile)
+    message(
+        AUTHOR_WARNING
+        "hipfile-test target could not be built (hip::host or hip::hipfile missing)"
+    )
+    return()
+endif()
+
+add_executable(hipfile-test hipfile-test.cpp)
+target_compile_options(hipfile-test PRIVATE -W -Wall)
+target_link_libraries(hipfile-test PRIVATE hip::host hip::hipfile)
+
+if("${CMAKE_BUILD_TYPE}" MATCHES "Release")
+    target_compile_options(hipfile-test PRIVATE -g1)
+endif()
+
+if(ROCPROFSYS_INSTALL_EXAMPLES AND TARGET hipfile-test)
+    install(
+        TARGETS hipfile-test
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/rocprofiler-systems/examples
+        COMPONENT rocprofiler-systems-examples
+    )
+endif()

--- a/projects/rocprofiler-systems/examples/hipfile-test/hipfile-test.cpp
+++ b/projects/rocprofiler-systems/examples/hipfile-test/hipfile-test.cpp
@@ -1,0 +1,121 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// Minimal hipFile workload used to exercise rocprofiler-systems' hipFile I/O
+// telemetry collection. Adapted from the hipFile project's basics examples
+// (examples/basics/roundtrip-verify.cpp): it registers a GPU buffer and a file
+// handle, then loops read/write for a fixed duration so that the profiler's
+// periodic process sampler observes the cumulative hipFile stats.
+//
+// The file is opened WITHOUT O_DIRECT so the workload runs on any filesystem
+// (it exercises hipFile's fallback backend); the goal is to validate the
+// telemetry pipeline, not the GPU-direct fast path.
+//
+// Usage: hipfile-test [FILE] [GPUID] [SECONDS]
+
+#include <hipfile.h>
+
+#include <hip/hip_runtime_api.h>
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <thread>
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+int
+main(int argc, char** argv)
+{
+    const char*  path    = (argc > 1) ? argv[1] : "hipfile-test.bin";
+    const int    gpu_id  = (argc > 2) ? atoi(argv[2]) : 0;
+    const int    seconds = (argc > 3) ? atoi(argv[3]) : 5;
+    const size_t bytes   = 1UL * 1024UL * 1024UL;  // 1 MiB per op
+
+    if(hipSetDevice(gpu_id) != hipSuccess)
+    {
+        fprintf(stderr, "hipSetDevice(%d) failed\n", gpu_id);
+        return EXIT_FAILURE;
+    }
+
+    void* devbuf = nullptr;
+    if(hipMalloc(&devbuf, bytes) != hipSuccess)
+    {
+        fprintf(stderr, "hipMalloc failed\n");
+        return EXIT_FAILURE;
+    }
+    (void) hipMemset(devbuf, 0xAB, bytes);
+
+    hipFileError_t err = hipFileBufRegister(devbuf, bytes, 0);
+    if(err.err != hipFileSuccess)
+    {
+        fprintf(stderr, "hipFileBufRegister failed (%s)\n",
+                hipFileGetOpErrorString(err.err));
+        return EXIT_FAILURE;
+    }
+
+    int fd = open(path, O_RDWR | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
+    if(fd < 0)
+    {
+        fprintf(stderr, "open(%s) failed (%s)\n", path, strerror(errno));
+        return EXIT_FAILURE;
+    }
+    if(ftruncate(fd, static_cast<off_t>(bytes)) != 0)
+    {
+        fprintf(stderr, "ftruncate failed (%s)\n", strerror(errno));
+        return EXIT_FAILURE;
+    }
+
+    hipFileHandle_t handle{};
+    hipFileDescr_t  descr{};
+    descr.type      = hipFileHandleTypeOpaqueFD;
+    descr.handle.fd = fd;
+    err             = hipFileHandleRegister(&handle, &descr);
+    if(err.err != hipFileSuccess)
+    {
+        fprintf(stderr, "hipFileHandleRegister failed (%s)\n",
+                hipFileGetOpErrorString(err.err));
+        return EXIT_FAILURE;
+    }
+
+    printf("hipfile-test: pid=%d looping hipFile I/O for %ds\n",
+           static_cast<int>(getpid()), seconds);
+    fflush(stdout);
+
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(seconds);
+    std::uint64_t iters = 0;
+    while(std::chrono::steady_clock::now() < deadline)
+    {
+        ssize_t nw = hipFileWrite(handle, devbuf, bytes, 0, 0);
+        if(nw < 0)
+        {
+            fprintf(stderr, "hipFileWrite failed (%zd)\n", nw);
+            break;
+        }
+        ssize_t nr = hipFileRead(handle, devbuf, bytes, 0, 0);
+        if(nr < 0)
+        {
+            fprintf(stderr, "hipFileRead failed (%zd)\n", nr);
+            break;
+        }
+        ++iters;
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+
+    printf("hipfile-test: completed %llu write+read iterations\n",
+           static_cast<unsigned long long>(iters));
+    fflush(stdout);
+
+    hipFileHandleDeregister(handle);
+    close(fd);
+    (void) hipFileBufDeregister(devbuf);
+    (void) hipFree(devbuf);
+    (void) unlink(path);
+    return EXIT_SUCCESS;
+}

--- a/projects/rocprofiler-systems/source/bin/common/json_config.cpp
+++ b/projects/rocprofiler-systems/source/bin/common/json_config.cpp
@@ -211,6 +211,19 @@ resolve_schema_config(const nlohmann::json& config)
         if(domains.contains("gpu"))
         {
             const auto& gpu = domains["gpu"];
+            // hipFile telemetry is independent of AMD SMI being enabled.
+            if(gpu.contains("hipfile"))
+            {
+                const auto& hipfile = gpu["hipfile"];
+                resolve_enabled(result, hipfile, "enabled", env_vars::USE_HIPFILE);
+                if(hipfile.contains("metrics"))
+                {
+                    auto enabled = collect_enabled_entry_names(hipfile["metrics"]);
+                    if(!enabled.empty())
+                        result[std::string{ env_vars::HIPFILE_METRICS }] =
+                            join_with(enabled, ',');
+                }
+            }
             if(gpu.contains("enabled") && gpu["enabled"].get<bool>())
             {
                 result[std::string{ env_vars::USE_AMD_SMI }]          = "true";
@@ -760,6 +773,12 @@ export_domain_gpu(nlohmann::json&                           config,
 
     if(auto v = lookup(env_map, env_vars::USE_PROCESS_SAMPLING))
         gpu["process_sampling"]["enabled"] = is_truthy(*v);
+
+    // hipFile GPU-direct storage I/O telemetry is independent of AMD SMI.
+    if(auto v = lookup(env_map, env_vars::USE_HIPFILE))
+        gpu["hipfile"]["enabled"] = is_truthy(*v);
+    if(auto metrics = lookup(env_map, env_vars::HIPFILE_METRICS))
+        csv_to_json_enabled_flags(gpu["hipfile"]["metrics"], *metrics);
 
     auto use_amd_smi = lookup(env_map, env_vars::USE_AMD_SMI);
     if(!use_amd_smi) return;

--- a/projects/rocprofiler-systems/source/lib/backends/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/backends/CMakeLists.txt
@@ -5,6 +5,14 @@ add_subdirectory(concepts)
 add_subdirectory(amd_smi)
 add_subdirectory(procfs)
 
+if(ROCPROFSYS_BUILD_HIPFILE)
+    add_subdirectory(hipfile)
+elseif(ROCPROFSYS_BUILD_TESTING)
+    # hipFile backend tests drive a mock wrapper and have no hipFile dependency, so
+    # they build even when the package was not found.
+    add_subdirectory(hipfile/tests)
+endif()
+
 if(
     (ROCPROFSYS_ROCM_VERSION_MAJOR GREATER 6)
     OR (

--- a/projects/rocprofiler-systems/source/lib/backends/hipfile/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/backends/hipfile/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+if(ROCPROFSYS_BUILD_TESTING)
+    add_subdirectory(tests)
+endif()
+
+add_library(rocprofiler-systems-hipfile-backend INTERFACE)
+add_library(
+    rocprofiler-systems::rocprofiler-systems-hipfile-backend
+    ALIAS rocprofiler-systems-hipfile-backend
+)
+
+# Link libhipfile directly via its imported target (hip::hipfile), which carries
+# both the public headers and the shared library. This matches how the profiler
+# consumes amd_smi and other ROCm libraries.
+target_link_libraries(
+    rocprofiler-systems-hipfile-backend
+    INTERFACE
+        rocprofiler-systems::rocprofiler-systems-headers
+        rocprofiler-systems::rocprofiler-systems-compile-definitions
+        rocprofiler-systems::rocprofiler-systems-rocm
+        hip::hipfile
+)
+
+target_compile_definitions(
+    rocprofiler-systems-hipfile-backend
+    INTERFACE ROCPROFSYS_BUILD_HIPFILE=1
+)

--- a/projects/rocprofiler-systems/source/lib/backends/hipfile/backend.hpp
+++ b/projects/rocprofiler-systems/source/lib/backends/hipfile/backend.hpp
@@ -1,0 +1,125 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "backends/hipfile/types.hpp"
+
+#include <algorithm>
+#include <concepts>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+namespace rocprofsys::backends::hipfile
+{
+
+/**
+ * @brief Contract a wrapper policy must satisfy.
+ *
+ * Checked where @c backend<T> or @c backend_factory<T> is instantiated, so a mismatch
+ * reports at the template boundary rather than deep inside the template body.
+ */
+template <typename T>
+concept wrapper_policy =
+    requires { typename T::stats_l3_t; } && requires(typename T::stats_l3_t* out) {
+        { T::get_stats_l3(out) } -> std::convertible_to<bool>;
+        { T::MAX_GPU_SLOTS } -> std::convertible_to<std::size_t>;
+    };
+
+/**
+ * @brief Session-level wrapper around hipFile's Level-3 stats query.
+ *
+ * Converts hipFile's raw struct into @c stats_snapshot and memoizes the result per
+ * sampling timestamp. Every GPU device shares one backend, so a sampling interval costs
+ * exactly one @c hipFileGetStatsL3 call regardless of GPU count, and every device in
+ * that interval observes the same coherent snapshot.
+ *
+ * A failed query is not an error to propagate: hipFile stats are frequently unavailable
+ * (the target never performed hipFile I/O), which is an expected steady state rather
+ * than a fault. The snapshot goes zero-filled and @c is_available() reports false, and
+ * the collector suppresses the sample rather than writing misleading zeros.
+ *
+ * @tparam Wrapper Raw hipFile C-API policy (e.g. @c wrapper).
+ */
+template <wrapper_policy Wrapper>
+class backend
+{
+public:
+    backend() noexcept = default;
+
+    /**
+     * @brief Level-3 snapshot for @p timestamp, querying hipFile at most once per
+     *        distinct timestamp.
+     *
+     * @param timestamp Sampling timestamp in nanoseconds; doubles as the memoization key.
+     */
+    [[nodiscard]] const stats_snapshot& get_stats(std::uint64_t timestamp)
+    {
+        if(!m_has_snapshot || m_timestamp != timestamp)
+        {
+            m_snapshot     = query();
+            m_timestamp    = timestamp;
+            m_has_snapshot = true;
+        }
+        return m_snapshot;
+    }
+
+    /// @brief Whether the most recent query succeeded.
+    [[nodiscard]] bool is_available() const noexcept { return m_available; }
+
+    void shutdown() noexcept {}
+
+private:
+    [[nodiscard]] stats_snapshot query()
+    {
+        typename Wrapper::stats_l3_t raw{};
+
+        m_available = Wrapper::get_stats_l3(&raw);
+
+        stats_snapshot out{};
+        if(!m_available) return out;
+
+        const auto slots = std::min<std::size_t>(Wrapper::MAX_GPU_SLOTS, MAX_GPUS);
+        for(std::size_t i = 0; i < slots; ++i)
+        {
+            const auto& src = raw.per_gpu_stats[i];
+            auto&       dst = out.per_gpu[i];
+
+            dst.read_bytes       = src.read_bytes;
+            dst.write_bytes      = src.write_bytes;
+            dst.read_ops         = src.n_total_reads;
+            dst.write_ops        = src.n_total_writes;
+            dst.fastpath_reads   = src.n_nvfs_reads;
+            dst.fastpath_writes  = src.n_nvfs_writes;
+            dst.fallback_reads   = src.n_posix_reads;
+            dst.fallback_writes  = src.n_posix_writes;
+            dst.unaligned_reads  = src.n_unaligned_reads;
+            dst.unaligned_writes = src.n_unaligned_writes;
+            dst.read_errors      = src.n_reads_err;
+            dst.write_errors     = src.n_writes_err;
+        }
+        return out;
+    }
+
+    stats_snapshot m_snapshot{};
+    std::uint64_t  m_timestamp    = 0;
+    bool           m_has_snapshot = false;
+    bool           m_available    = false;
+};
+
+/**
+ * @brief Factory for creating backend<Wrapper> session instances.
+ */
+template <wrapper_policy Wrapper>
+struct backend_factory
+{
+    using backend_t = backend<Wrapper>;
+
+    static std::shared_ptr<backend_t> create_backend()
+    {
+        return std::make_shared<backend_t>();
+    }
+};
+
+}  // namespace rocprofsys::backends::hipfile

--- a/projects/rocprofiler-systems/source/lib/backends/hipfile/tests/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/backends/hipfile/tests/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# Deliberately does not link rocprofiler-systems-hipfile-backend: that target pulls in
+# hip::hipfile and therefore <hipfile.h>. These tests drive backend<> through a mock
+# wrapper with test-local fake structs, so they build and run on machines with no
+# hipFile package installed.
+add_library(hipfile-backend-tests OBJECT test_backend.cpp)
+
+target_link_libraries(
+    hipfile-backend-tests
+    PUBLIC
+        rocprofiler-systems-googletest-library
+        rocprofiler-systems::rocprofiler-systems-headers
+        rocprofiler-systems::rocprofiler-systems-compile-definitions
+)
+
+target_include_directories(
+    hipfile-backend-tests
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+    PRIVATE ${PROJECT_SOURCE_DIR}/source/lib ${PROJECT_BINARY_DIR}/source/lib
+)

--- a/projects/rocprofiler-systems/source/lib/backends/hipfile/tests/mock_wrapper.hpp
+++ b/projects/rocprofiler-systems/source/lib/backends/hipfile/tests/mock_wrapper.hpp
@@ -1,0 +1,86 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "backends/hipfile/backend.hpp"
+
+#include <cstddef>
+#include <cstdint>
+
+namespace rocprofsys::backends::hipfile::testing
+{
+
+// ── Mock raw types ──────────────────────────────────────────────────────────
+// Field names mirror hipFilePerGpuStats_t / hipFileStatsLevel3_t exactly so that
+// backend<>::query() compiles against them unchanged. snake_case is intentional.
+// Nothing here includes <hipfile.h>, which is the point: these tests build and run
+// on machines with no hipFile package installed.
+// NOLINTBEGIN(readability-identifier-naming)
+
+struct mock_per_gpu_stats_t
+{
+    std::uint64_t read_bytes         = 0;
+    std::uint64_t read_duration_us   = 0;
+    std::uint64_t n_total_reads      = 0;
+    std::uint64_t n_nvfs_reads       = 0;
+    std::uint64_t n_posix_reads      = 0;
+    std::uint64_t n_unaligned_reads  = 0;
+    std::uint64_t n_reads_err        = 0;
+    std::uint64_t write_bytes        = 0;
+    std::uint64_t write_duration_us  = 0;
+    std::uint64_t n_total_writes     = 0;
+    std::uint64_t n_nvfs_writes      = 0;
+    std::uint64_t n_posix_writes     = 0;
+    std::uint64_t n_unaligned_writes = 0;
+    std::uint64_t n_writes_err       = 0;
+    std::uint64_t n_mmap             = 0;
+};
+
+struct mock_stats_l3_t
+{
+    std::uint32_t num_gpus = 0;
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
+    mock_per_gpu_stats_t per_gpu_stats[MAX_GPUS] = {};
+};
+
+// NOLINTEND(readability-identifier-naming)
+
+/**
+ * @brief Test double for the hipFile wrapper policy.
+ *
+ * The wrapper policy is a set of static functions, so the fake is driven through
+ * process-global state rather than gmock: tests set @c next_stats and @c query_succeeds,
+ * then read @c call_count to assert how often hipFile was queried. That count is what
+ * proves the backend's per-timestamp memoization actually holds.
+ */
+struct mock_wrapper
+{
+    using stats_l3_t = mock_stats_l3_t;
+
+    static constexpr std::size_t MAX_GPU_SLOTS = MAX_GPUS;
+
+    inline static stats_l3_t  next_stats{};
+    inline static bool        query_succeeds = true;
+    inline static std::size_t call_count     = 0;
+
+    static void reset()
+    {
+        next_stats     = stats_l3_t{};
+        query_succeeds = true;
+        call_count     = 0;
+    }
+
+    static bool get_stats_l3(stats_l3_t* out) noexcept
+    {
+        ++call_count;
+        *out = stats_l3_t{};
+        if(!query_succeeds) return false;
+        *out = next_stats;
+        return true;
+    }
+};
+
+using mock_backend = backend<mock_wrapper>;
+
+}  // namespace rocprofsys::backends::hipfile::testing

--- a/projects/rocprofiler-systems/source/lib/backends/hipfile/tests/test_backend.cpp
+++ b/projects/rocprofiler-systems/source/lib/backends/hipfile/tests/test_backend.cpp
@@ -1,0 +1,251 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "mock_wrapper.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+namespace rocprofsys::backends::hipfile::testing
+{
+namespace
+{
+class HipFileBackendTest : public ::testing::Test
+{
+protected:
+    void SetUp() override { mock_wrapper::reset(); }
+    void TearDown() override { mock_wrapper::reset(); }
+
+    static mock_per_gpu_stats_t& gpu(std::size_t ordinal)
+    {
+        return mock_wrapper::next_stats.per_gpu_stats[ordinal];
+    }
+};
+
+constexpr std::uint64_t TS_1 = 1'000'000'000;
+constexpr std::uint64_t TS_2 = 2'000'000'000;
+
+TEST_F(HipFileBackendTest, field_mapping_is_exhaustive)
+{
+    auto& src              = gpu(0);
+    src.read_bytes         = 4096;
+    src.write_bytes        = 8192;
+    src.n_total_reads      = 10;
+    src.n_total_writes     = 20;
+    src.n_nvfs_reads       = 7;
+    src.n_nvfs_writes      = 13;
+    src.n_posix_reads      = 3;
+    src.n_posix_writes     = 7;
+    src.n_unaligned_reads  = 1;
+    src.n_unaligned_writes = 2;
+    src.n_reads_err        = 5;
+    src.n_writes_err       = 6;
+
+    mock_backend backend{};
+    const auto&  out = backend.get_stats(TS_1).per_gpu[0];
+
+    // Every field distinct so a transposed or duplicated mapping cannot pass. This is
+    // the guard for the writes_bytes/write_bytes class of bug.
+    EXPECT_EQ(out.read_bytes, 4096U);
+    EXPECT_EQ(out.write_bytes, 8192U);
+    EXPECT_EQ(out.read_ops, 10U);
+    EXPECT_EQ(out.write_ops, 20U);
+    EXPECT_EQ(out.fastpath_reads, 7U);
+    EXPECT_EQ(out.fastpath_writes, 13U);
+    EXPECT_EQ(out.fallback_reads, 3U);
+    EXPECT_EQ(out.fallback_writes, 7U);
+    EXPECT_EQ(out.unaligned_reads, 1U);
+    EXPECT_EQ(out.unaligned_writes, 2U);
+    EXPECT_EQ(out.read_errors, 5U);
+    EXPECT_EQ(out.write_errors, 6U);
+}
+
+TEST_F(HipFileBackendTest, fastpath_only_reads)
+{
+    gpu(0).n_total_reads = 100;
+    gpu(0).n_nvfs_reads  = 100;
+    gpu(0).n_posix_reads = 0;
+
+    mock_backend backend{};
+    const auto&  out = backend.get_stats(TS_1).per_gpu[0];
+
+    EXPECT_EQ(out.fastpath_reads, 100U);
+    EXPECT_EQ(out.fallback_reads, 0U);
+}
+
+TEST_F(HipFileBackendTest, fallback_only_reads)
+{
+    // The unsupported-filesystem case: every read goes through POSIX.
+    gpu(0).n_total_reads = 100;
+    gpu(0).n_nvfs_reads  = 0;
+    gpu(0).n_posix_reads = 100;
+
+    mock_backend backend{};
+    const auto&  out = backend.get_stats(TS_1).per_gpu[0];
+
+    EXPECT_EQ(out.fastpath_reads, 0U);
+    EXPECT_EQ(out.fallback_reads, 100U);
+}
+
+TEST_F(HipFileBackendTest, fastpath_only_writes)
+{
+    gpu(0).n_total_writes = 50;
+    gpu(0).n_nvfs_writes  = 50;
+    gpu(0).n_posix_writes = 0;
+
+    mock_backend backend{};
+    const auto&  out = backend.get_stats(TS_1).per_gpu[0];
+
+    EXPECT_EQ(out.fastpath_writes, 50U);
+    EXPECT_EQ(out.fallback_writes, 0U);
+}
+
+TEST_F(HipFileBackendTest, fallback_only_writes)
+{
+    gpu(0).n_total_writes = 50;
+    gpu(0).n_nvfs_writes  = 0;
+    gpu(0).n_posix_writes = 50;
+
+    mock_backend backend{};
+    const auto&  out = backend.get_stats(TS_1).per_gpu[0];
+
+    EXPECT_EQ(out.fastpath_writes, 0U);
+    EXPECT_EQ(out.fallback_writes, 50U);
+}
+
+TEST_F(HipFileBackendTest, mixed_fastpath_fallback_totals_match)
+{
+    // hipFileGetStatsL3 sums n_total_* across both backends, so this invariant holds by
+    // construction upstream. Asserting it here catches a mapping that crosses the two.
+    gpu(0).n_total_reads = 100;
+    gpu(0).n_nvfs_reads  = 60;
+    gpu(0).n_posix_reads = 40;
+
+    mock_backend backend{};
+    const auto&  out = backend.get_stats(TS_1).per_gpu[0];
+
+    EXPECT_EQ(out.fastpath_reads + out.fallback_reads, out.read_ops);
+}
+
+TEST_F(HipFileBackendTest, snapshot_is_memoized_per_timestamp)
+{
+    gpu(0).read_bytes = 1024;
+
+    mock_backend backend{};
+    backend.get_stats(TS_1);
+    backend.get_stats(TS_1);
+    backend.get_stats(TS_1);
+
+    // One sampling interval must cost exactly one hipFile query no matter how many
+    // GPU devices read from the shared backend.
+    EXPECT_EQ(mock_wrapper::call_count, 1U);
+}
+
+TEST_F(HipFileBackendTest, new_timestamp_triggers_new_query)
+{
+    mock_backend backend{};
+
+    gpu(0).read_bytes = 1024;
+    EXPECT_EQ(backend.get_stats(TS_1).per_gpu[0].read_bytes, 1024U);
+
+    gpu(0).read_bytes = 4096;
+    EXPECT_EQ(backend.get_stats(TS_2).per_gpu[0].read_bytes, 4096U);
+
+    EXPECT_EQ(mock_wrapper::call_count, 2U);
+}
+
+TEST_F(HipFileBackendTest, snapshot_is_coherent_across_devices)
+{
+    gpu(0).read_bytes = 1000;
+    gpu(1).read_bytes = 2000;
+
+    mock_backend backend{};
+    const auto&  first = backend.get_stats(TS_1);
+
+    // Mutating the source between reads must not leak into the memoized snapshot,
+    // otherwise per-GPU values within one interval could come from different queries.
+    gpu(0).read_bytes = 999'999;
+
+    const auto& second = backend.get_stats(TS_1);
+
+    EXPECT_EQ(first.per_gpu[0].read_bytes, 1000U);
+    EXPECT_EQ(second.per_gpu[0].read_bytes, 1000U);
+    EXPECT_EQ(second.per_gpu[1].read_bytes, 2000U);
+}
+
+TEST_F(HipFileBackendTest, failed_query_reports_unavailable_and_zeros)
+{
+    gpu(0).read_bytes            = 4096;
+    mock_wrapper::query_succeeds = false;
+
+    mock_backend backend{};
+    const auto&  snapshot = backend.get_stats(TS_1);
+
+    EXPECT_FALSE(backend.is_available());
+    EXPECT_EQ(snapshot.per_gpu[0].read_bytes, 0U);
+}
+
+TEST_F(HipFileBackendTest, successful_query_reports_available)
+{
+    mock_backend backend{};
+    backend.get_stats(TS_1);
+
+    EXPECT_TRUE(backend.is_available());
+}
+
+TEST_F(HipFileBackendTest, availability_recovers_after_failure)
+{
+    mock_backend backend{};
+
+    mock_wrapper::query_succeeds = false;
+    backend.get_stats(TS_1);
+    EXPECT_FALSE(backend.is_available());
+
+    // hipFile stats become readable once the target initializes them, which happens
+    // after the collector is already running.
+    mock_wrapper::query_succeeds = true;
+    gpu(0).read_bytes            = 512;
+    EXPECT_EQ(backend.get_stats(TS_2).per_gpu[0].read_bytes, 512U);
+    EXPECT_TRUE(backend.is_available());
+}
+
+TEST_F(HipFileBackendTest, inactive_gpu_slots_are_zero_filled)
+{
+    gpu(3).read_bytes = 4096;
+
+    mock_backend backend{};
+    const auto&  snapshot = backend.get_stats(TS_1);
+
+    // per_gpu_stats is indexed by ordinal, not packed, so the populated slot must stay
+    // at its ordinal and every other slot must read zero rather than garbage.
+    EXPECT_EQ(snapshot.per_gpu[3].read_bytes, 4096U);
+    EXPECT_EQ(snapshot.per_gpu[0].read_bytes, 0U);
+    EXPECT_EQ(snapshot.per_gpu[2].read_bytes, 0U);
+    EXPECT_EQ(snapshot.per_gpu[4].read_bytes, 0U);
+}
+
+TEST_F(HipFileBackendTest, all_gpu_slots_are_readable)
+{
+    for(std::size_t i = 0; i < MAX_GPUS; ++i)
+        gpu(i).read_bytes = static_cast<std::uint64_t>(i) + 1;
+
+    mock_backend backend{};
+    const auto&  snapshot = backend.get_stats(TS_1);
+
+    for(std::size_t i = 0; i < MAX_GPUS; ++i)
+        EXPECT_EQ(snapshot.per_gpu[i].read_bytes, static_cast<std::uint64_t>(i) + 1)
+            << "GPU ordinal " << i;
+}
+
+TEST_F(HipFileBackendTest, factory_produces_usable_backend)
+{
+    auto backend = backend_factory<mock_wrapper>::create_backend();
+    ASSERT_NE(backend, nullptr);
+
+    gpu(0).read_bytes = 256;
+    EXPECT_EQ(backend->get_stats(TS_1).per_gpu[0].read_bytes, 256U);
+}
+
+}  // namespace
+}  // namespace rocprofsys::backends::hipfile::testing

--- a/projects/rocprofiler-systems/source/lib/backends/hipfile/types.hpp
+++ b/projects/rocprofiler-systems/source/lib/backends/hipfile/types.hpp
@@ -1,0 +1,56 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+namespace rocprofsys::backends::hipfile
+{
+
+/// Slots in a hipFile Level-3 snapshot. Mirrors HIPFILE_MAX_GPUS, duplicated so this
+/// header stays free of <hipfile.h>; wrapper.hpp static_asserts the two agree.
+inline constexpr std::size_t MAX_GPUS = 16;
+
+/**
+ * @brief Per-GPU hipFile I/O counters, cumulative over the process lifetime.
+ *
+ * Only fields hipFile genuinely tracks are carried. Large parts of the Level-1 and
+ * Level-3 structs are documented zero-filled stubs (batch_*, *_ops_per_sec, both size
+ * histograms, n_p2p_*, n_dr_*, uuid, *_utilization); surfacing one would produce a
+ * counter that reads a constant zero.
+ *
+ * The durations (read_duration_us / write_duration_us) are deliberately absent:
+ * bandwidth is normalised to wall clock so it is comparable to the AMD SMI PCIe
+ * bandwidth tracks, which makes hipFile's own I/O-time accounting unused.
+ */
+struct gpu_stats
+{
+    std::uint64_t read_bytes       = 0;
+    std::uint64_t write_bytes      = 0;
+    std::uint64_t read_ops         = 0;  ///< Reads across all backends
+    std::uint64_t write_ops        = 0;  ///< Writes across all backends
+    std::uint64_t fastpath_reads   = 0;  ///< Reads that took the AIS fastpath
+    std::uint64_t fastpath_writes  = 0;  ///< Writes that took the AIS fastpath
+    std::uint64_t fallback_reads   = 0;  ///< Reads that fell back to POSIX
+    std::uint64_t fallback_writes  = 0;  ///< Writes that fell back to POSIX
+    std::uint64_t unaligned_reads  = 0;
+    std::uint64_t unaligned_writes = 0;
+    std::uint64_t read_errors      = 0;
+    std::uint64_t write_errors     = 0;
+};
+
+/**
+ * @brief One hipFile Level-3 sample, indexed by GPU ordinal.
+ *
+ * @c per_gpu is not packed: entry @c i holds GPU @c i and slots for inactive GPUs stay
+ * zero-filled, so consumers index by ordinal rather than iterating a dense prefix.
+ */
+struct stats_snapshot
+{
+    std::array<gpu_stats, MAX_GPUS> per_gpu{};
+};
+
+}  // namespace rocprofsys::backends::hipfile

--- a/projects/rocprofiler-systems/source/lib/backends/hipfile/wrapper.hpp
+++ b/projects/rocprofiler-systems/source/lib/backends/hipfile/wrapper.hpp
@@ -1,0 +1,55 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "backends/hipfile/types.hpp"
+
+// The only file in the profiler that includes hipFile's public header. Everything
+// above this layer works against backends::hipfile::stats_snapshot, so the collector
+// and its tests build on machines with no hipFile package installed.
+//
+// The backend links libhipfile directly via the hip::hipfile imported target, matching
+// how the profiler consumes amd_smi and other ROCm libraries. hipFile's stats query
+// reads the calling process' own shared stats region, so this must run inside the
+// profiled process; the dynamic linker guarantees a single libhipfile instance per
+// process, so the profiler and the target application observe the same stats.
+#include <hipfile.h>
+
+#include <cstddef>
+
+namespace rocprofsys::backends::hipfile
+{
+
+/**
+ * @brief 1:1 thin wrapper around hipFile's public stats API.
+ *
+ * One method, one hipFile call, no error interpretation. This is a pure
+ * dependency-injection seam so @c backend<Wrapper> can be exercised against a fake
+ * without linking or including hipFile.
+ */
+struct wrapper
+{
+    using stats_l3_t = hipFileStatsLevel3_t;
+
+    static constexpr std::size_t MAX_GPU_SLOTS = HIPFILE_MAX_GPUS;
+
+    /**
+     * @brief Snapshot the Level-3 (per-GPU) stats for the calling process.
+     *
+     * @param out [out] zero-initialized first, populated on success.
+     * @return true on success. False means the target never initialized hipFile stats -
+     *         it performed no hipFile I/O, or HIPFILE_STATS_LEVEL is disabled.
+     */
+    static bool get_stats_l3(stats_l3_t* out) noexcept
+    {
+        *out = stats_l3_t{};
+        return hipFileGetStatsL3(out).err == hipFileSuccess;
+    }
+};
+
+static_assert(wrapper::MAX_GPU_SLOTS == MAX_GPUS,
+              "backends::hipfile::MAX_GPUS is out of sync with HIPFILE_MAX_GPUS; the "
+              "snapshot would silently drop or over-read per-GPU slots");
+
+}  // namespace rocprofsys::backends::hipfile

--- a/projects/rocprofiler-systems/source/lib/common/env_vars.hpp
+++ b/projects/rocprofiler-systems/source/lib/common/env_vars.hpp
@@ -116,6 +116,12 @@ inline constexpr const char* AMD_SMI_METRICS      = "ROCPROFSYS_AMD_SMI_METRICS"
 inline constexpr const char* AMD_SMI_FREQ         = "ROCPROFSYS_AMD_SMI_FREQ";
 inline constexpr const char* AMD_SMI_DEVICES      = "ROCPROFSYS_AMD_SMI_DEVICES";
 
+// --- Domains: hipFile (GPU-direct storage I/O stats) ---
+inline constexpr const char* USE_HIPFILE     = "ROCPROFSYS_USE_HIPFILE";
+inline constexpr const char* HIPFILE_METRICS = "ROCPROFSYS_HIPFILE_METRICS";
+// The environment variable read by libhipfile itself to enable its stats server.
+inline constexpr const char* HIPFILE_STATS_LEVEL = "HIPFILE_STATS_LEVEL";
+
 // --- Domains: ROCm ---
 inline constexpr const char* ROCM_DOMAINS        = "ROCPROFSYS_ROCM_DOMAINS";
 inline constexpr const char* ROCM_GROUP_BY_QUEUE = "ROCPROFSYS_ROCM_GROUP_BY_QUEUE";

--- a/projects/rocprofiler-systems/source/lib/core/categories.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/categories.hpp
@@ -96,6 +96,7 @@ ROCPROFSYS_DEFINE_CATEGORY(category, rocm_kfd_event_unmap_from_gpu, ROCPROFSYS_C
 ROCPROFSYS_DEFINE_CATEGORY(category, rocm_kfd_event_dropped_events, ROCPROFSYS_CATEGORY_ROCM_KFD_EVENT_DROPPED_EVENTS, "rocm_kfd_event_dropped_events", "KFD Dropped Events")
 ROCPROFSYS_DEFINE_CATEGORY(category, unified_memory_migration_throughput, ROCPROFSYS_CATEGORY_UNIFIED_MEMORY_MIGRATION_THROUGHPUT, "unified_memory_migration_throughput", "Unified Memory Migration Throughput")
 ROCPROFSYS_DEFINE_CATEGORY(category, unified_memory_fault_rate, ROCPROFSYS_CATEGORY_UNIFIED_MEMORY_FAULT_RATE, "unified_memory_fault_rate", "Unified Memory Page Fault Rate")
+ROCPROFSYS_DEFINE_CATEGORY(category, hipfile, ROCPROFSYS_CATEGORY_HIPFILE, "hipfile", "hipFile GPU-direct storage I/O statistics")
 ROCPROFSYS_DEFINE_CATEGORY(category, amd_smi, ROCPROFSYS_CATEGORY_AMD_SMI, "amd_smi", "AMD-SMI data")
 ROCPROFSYS_DEFINE_CATEGORY(category, amd_smi_nic, ROCPROFSYS_CATEGORY_AMD_SMI_AINIC, "amd_smi_nic", "AMD-SMI NIC data")
 ROCPROFSYS_DEFINE_CATEGORY(category, amd_smi_nic_rx_cnp_pkts, ROCPROFSYS_CATEGORY_AMD_SMI_AINIC_RX_CNP_PKTS, "nic_rx_cnp_pkts", "AI NIC RX CNP Packets")
@@ -264,6 +265,7 @@ using name = perfetto_category<Tp...>;
         ROCPROFSYS_PERFETTO_CATEGORY(category::overflow_sampling),                       \
         ROCPROFSYS_PERFETTO_CATEGORY(category::unified_memory_migration_throughput),     \
         ROCPROFSYS_PERFETTO_CATEGORY(category::unified_memory_fault_rate),               \
+        ROCPROFSYS_PERFETTO_CATEGORY(category::hipfile),                                 \
         ::perfetto::Category("timemory").SetDescription("Events from the timemory API")
 
 #if defined(TIMEMORY_USE_PERFETTO)

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -636,6 +636,13 @@ configure_settings(bool _init)
                               "vcn_activity, jpeg_activity and memory usage",
                               true, "backend", "amd_smi", "rocm", "process_sampling");
 
+    ROCPROFSYS_CONFIG_SETTING(
+        bool, env_vars::USE_HIPFILE,
+        "Enable periodic sampling of hipFile GPU-direct storage I/O statistics "
+        "(bytes, bandwidth, op counts, errors). Requires the target application to "
+        "use hipFile; sets HIPFILE_STATS_LEVEL=1 automatically.",
+        false, "backend", "hipfile", "rocm", "process_sampling");
+
     ROCPROFSYS_CONFIG_SETTING(bool, env_vars::USE_SAMPLING,
                               "Enable statistical sampling of call-stack", false,
                               "backend", "sampling");
@@ -1601,6 +1608,15 @@ configure_mode_settings(const std::shared_ptr<settings>& _config)
         _set(env_vars::USE_AMD_SMI, false);
     }
 
+    if(_config->get<bool>(std::string{ env_vars::USE_HIPFILE }))
+    {
+        // Ask libhipfile to enable its stats server. hipFile reads this once, the first
+        // time it initializes, so it has to be set during configuration rather than when
+        // the PMC sampler starts - by then the target may already have initialized
+        // hipFile and the setting would be ignored. Never overrides an explicit level.
+        rocprofsys::set_env(env_vars::HIPFILE_STATS_LEVEL, "1", 0);
+    }
+
     if(_config->get<bool>(std::string{ env_vars::USE_KOKKOSP }))
     {
         auto _current_kokkosp_lib = rocprofsys::get_env<std::string>("KOKKOS_TOOLS_LIBS");
@@ -2284,6 +2300,13 @@ bool
 get_use_amd_smi()
 {
     static auto _v = get_config()->find(std::string{ env_vars::USE_AMD_SMI });
+    return static_cast<tim::tsettings<bool>&>(*_v->second).get();
+}
+
+bool
+get_use_hipfile()
+{
+    static auto _v = get_config()->find(std::string{ env_vars::USE_HIPFILE });
     return static_cast<tim::tsettings<bool>&>(*_v->second).get();
 }
 

--- a/projects/rocprofiler-systems/source/lib/core/config.hpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.hpp
@@ -195,6 +195,9 @@ get_use_causal() ROCPROFSYS_HOT;
 bool
 get_use_amd_smi() ROCPROFSYS_HOT;
 
+bool
+get_use_hipfile() ROCPROFSYS_HOT;
+
 bool&
 get_use_sampling() ROCPROFSYS_HOT;
 

--- a/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/trace_cache/perfetto_processor.cpp
@@ -1089,6 +1089,7 @@ perfetto_processor_t::handle([[maybe_unused]] const pmc_event_with_sample& _pmc)
     using thread_hardware_counter_track =
         core::perfetto::counter_track<category::thread_hardware_counter>;
     using comm_data_track = core::perfetto::counter_track<category::comm_data>;
+    using hipfile_track   = core::perfetto::counter_track<category::hipfile>;
 
     static const std::unordered_map<size_t, pmc_track_info> PMC_TRACK_MAP = {
         { ROCPROFSYS_CATEGORY_ROCM_COUNTER_COLLECTION,
@@ -1166,6 +1167,14 @@ perfetto_processor_t::handle([[maybe_unused]] const pmc_event_with_sample& _pmc)
             [](auto id, auto idx, auto ts, auto val) {
                 TRACE_COUNTER(trait::name<category::comm_data>::value,
                               comm_data_track::at(id, idx), ts, val);
+            } } },
+
+        { ROCPROFSYS_CATEGORY_HIPFILE,
+          { "", [](auto id) { return hipfile_track::exists(id); },
+            [](auto id, auto& n, auto& u) { hipfile_track::emplace(id, n, u.c_str()); },
+            [](auto id, auto idx, auto ts, auto val) {
+                TRACE_COUNTER(trait::name<category::hipfile>::value,
+                              hipfile_track::at(id, idx), ts, val);
             } } }
     };
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys-user/rocprofiler-systems/categories.h
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys-user/rocprofiler-systems/categories.h
@@ -129,6 +129,7 @@ extern "C"
         ROCPROFSYS_CATEGORY_OVERFLOW_SAMPLING,
         ROCPROFSYS_CATEGORY_UNIFIED_MEMORY_MIGRATION_THROUGHPUT,
         ROCPROFSYS_CATEGORY_UNIFIED_MEMORY_FAULT_RATE,
+        ROCPROFSYS_CATEGORY_HIPFILE,
         ROCPROFSYS_CATEGORY_LAST
         // the value of below enum is used for iterating
         // over the enum in C++ templates. It MUST

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/CMakeLists.txt
@@ -68,6 +68,16 @@ target_link_libraries(
         rocprofiler-systems::rocprofiler-systems-binary
 )
 
+# The PMC objects (which reference hipFileGetStatsL3) are consumed via
+# $<TARGET_OBJECTS>, so link libhipfile onto the final libraries explicitly to
+# make it a DT_NEEDED dependency.
+if(ROCPROFSYS_BUILD_HIPFILE)
+    target_link_libraries(
+        rocprofiler-systems-static-library
+        PRIVATE rocprofiler-systems::rocprofiler-systems-hipfile-backend
+    )
+endif()
+
 set_target_properties(
     rocprofiler-systems-static-library
     PROPERTIES OUTPUT_NAME ${BINARY_NAME_PREFIX}
@@ -106,6 +116,13 @@ target_link_libraries(
         rocprofiler-systems::rocprofiler-systems-core
         rocprofiler-systems::rocprofiler-systems-binary
 )
+
+if(ROCPROFSYS_BUILD_HIPFILE)
+    target_link_libraries(
+        rocprofiler-systems-shared-library
+        PRIVATE rocprofiler-systems::rocprofiler-systems-hipfile-backend
+    )
+endif()
 
 target_link_options(
     rocprofiler-systems-shared-library

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/CMakeLists.txt
@@ -51,3 +51,10 @@ if(TARGET rocprofiler-systems::rocprofiler-systems-rocprofiler-sdk-backend)
         PRIVATE rocprofiler-systems::rocprofiler-systems-rocprofiler-sdk-backend
     )
 endif()
+
+if(ROCPROFSYS_BUILD_HIPFILE)
+    target_link_libraries(
+        rocprofiler-systems-pmc-library
+        PRIVATE rocprofiler-systems::rocprofiler-systems-hipfile-backend
+    )
+endif()

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/CMakeLists.txt
@@ -36,6 +36,18 @@ else()
     endif()
 endif()
 
+# Conditionally compile hipFile collector when the hipFile package was found
+# (ROCPROFSYS_BUILD_HIPFILE is set in cmake/Packages.cmake).
+if(ROCPROFSYS_BUILD_HIPFILE)
+    add_subdirectory(hipfile)
+else()
+    set(pmc_hipfile_sources "")
+    # hipFile collector tests use a mock backend with no hipFile dependency
+    if(ROCPROFSYS_BUILD_TESTING)
+        add_subdirectory(hipfile/tests)
+    endif()
+endif()
+
 # Collect all sources
 set(pmc_collectors_sources
     ${pmc_common_sources}
@@ -44,6 +56,7 @@ set(pmc_collectors_sources
     ${pmc_cpu_sources}
     ${pmc_gpu_perf_counter_sources}
     ${pmc_nic_sources}
+    ${pmc_hipfile_sources}
 )
 
 # Add to parent variable

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/common/settings.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/common/settings.hpp
@@ -9,11 +9,13 @@
 #include "library/pmc/collectors/cpu/types.hpp"
 #include "library/pmc/collectors/gpu/types.hpp"
 #include "library/pmc/collectors/gpu_perf_counter/types.hpp"
+#include "library/pmc/collectors/hipfile/types.hpp"
 #include "library/pmc/collectors/nic/types.hpp"
 #include "library/pmc/common/types.hpp"
 #include "logger/debug.hpp"
 
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <optional>
 #include <regex>
@@ -52,6 +54,14 @@ using ::rocprofsys::pmc::device_filter;
 using ::rocprofsys::pmc::device_selection_mode;
 using ::rocprofsys::pmc::collectors::cpu::enabled_metrics;
 }  // namespace cpu
+
+// Import hipFile types into collectors namespace
+namespace hipfile
+{
+using ::rocprofsys::pmc::collectors::hipfile::ALL_HIPFILE_METRICS;
+using ::rocprofsys::pmc::collectors::hipfile::enabled_metrics;
+using ::rocprofsys::pmc::collectors::hipfile::METRIC_TABLE;
+}  // namespace hipfile
 
 // GPU metric bitfield helpers: ENABLE_ALL_METRICS sets bits 0..NUM_GPU_METRIC_BITS-1
 inline constexpr std::uint32_t NUM_GPU_METRIC_BITS = 17;
@@ -104,6 +114,73 @@ struct settings_policy
     static std::optional<std::set<std::string>> get_visible_gpu_bdfs()
     {
         return rocprofsys::gpu::get_visible_gpu_bdfs();
+    }
+
+    /**
+     * @brief Number of GPUs the ROCm runtime exposes.
+     *
+     * Honors ROCR_VISIBLE_DEVICES / HIP_VISIBLE_DEVICES. Used by the hipFile collector,
+     * whose stats are indexed by GPU ordinal rather than discovered through an
+     * enumeration API.
+     *
+     * Derived from the same visible-BDF set the GPU collector filters on, so the two
+     * agree on which GPUs exist. std::nullopt means the runtime reported no agents at
+     * all, which is indistinguishable from having no GPUs as far as GPU-direct storage
+     * I/O is concerned, so it reports zero.
+     */
+    static std::size_t get_visible_gpu_count()
+    {
+        const auto visible = get_visible_gpu_bdfs();
+        return visible.has_value() ? visible->size() : 0U;
+    }
+
+    /**
+     * @brief hipFile metrics selected by ROCPROFSYS_HIPFILE_METRICS.
+     *
+     * Accepts "all"/"on" (default), "none"/"off", or a comma or semicolon separated list
+     * of the metric keys in METRIC_TABLE (e.g. "read_bytes,write_bytes").
+     */
+    static hipfile::enabled_metrics get_hipfile_enabled_metrics()
+    {
+        static auto _enabled_metrics = []() {
+            auto setting =
+                get_setting_value<std::string>(std::string{ env_vars::HIPFILE_METRICS });
+            return parse_hipfile_enabled_metrics(setting.value_or("all"));
+        }();
+        return _enabled_metrics;
+    }
+
+    static hipfile::enabled_metrics parse_hipfile_enabled_metrics(
+        const std::string& setting)
+    {
+        hipfile::enabled_metrics metrics;
+
+        if(setting.empty() || setting == "all" || setting == "on")
+        {
+            metrics.value = hipfile::ALL_HIPFILE_METRICS;
+            return metrics;
+        }
+        if(setting == "none" || setting == "off")
+        {
+            metrics.value = 0U;
+            return metrics;
+        }
+
+        for(const auto& token : parse_name_list(setting))
+        {
+            const auto found = std::find_if(
+                hipfile::METRIC_TABLE.begin(), hipfile::METRIC_TABLE.end(),
+                [&token](const auto& metric) { return token == metric.key; });
+
+            if(found == hipfile::METRIC_TABLE.end())
+            {
+                LOG_WARNING("Unknown hipFile metric '{}' in {}, ignoring", token,
+                            env_vars::HIPFILE_METRICS);
+                continue;
+            }
+            metrics.value |= (1U << found->bit);
+        }
+        return metrics;
     }
 
     static gpu::enabled_metrics get_enabled_metrics() noexcept

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/hipfile/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/hipfile/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+if(ROCPROFSYS_BUILD_TESTING)
+    add_subdirectory(tests)
+endif()
+
+# PMC hipFile Collector Sources (header-only)
+set(pmc_hipfile_sources
+    ${CMAKE_CURRENT_LIST_DIR}/types.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/device.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/hipfile_traits.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/cache_policy.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/perfetto_policy.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/collector.hpp
+)
+
+# Add to parent variable (used by collectors CMakeLists.txt)
+set(pmc_hipfile_sources ${pmc_hipfile_sources} PARENT_SCOPE)

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/hipfile/cache_policy.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/hipfile/cache_policy.hpp
@@ -1,0 +1,115 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "core/agent.hpp"
+#include "core/categories.hpp"
+#include "core/trace_cache/cache_manager.hpp"
+#include "core/trace_cache/cacheable.hpp"
+#include "core/trace_cache/metadata_registry.hpp"
+#include "core/trace_cache/sample_type.hpp"
+#include "library/pmc/collectors/hipfile/types.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+
+namespace rocprofsys::pmc::collectors::hipfile
+{
+
+/**
+ * @brief Output policy for writing hipFile samples to the trace cache.
+ *
+ * Every track is GPU-indexed. hipFile also exposes process-global counters (file and
+ * buffer registrations), but those are not GPU measurements and the profiler has no
+ * process-scoped device track to put them on; parking them on GPU 0, as an earlier
+ * revision did, made them read as GPU 0's activity. They are omitted rather than
+ * misattributed.
+ */
+struct cache_policy
+{
+    static void initialize_category_metadata()
+    {
+        trace_cache::get_metadata_registry().add_string(
+            trait::name<category::hipfile>::value);
+    }
+
+    /// Tracks are per GPU, so they are registered in initialize_pmc_metadata() once the
+    /// device set is known rather than as a fixed global list.
+    static void initialize_tracks_metadata() {}
+
+    /**
+     * @brief Register every hipFile track and its PMC metadata for one GPU.
+     *
+     * Runs at config() time for the whole enumerated device set, so track metadata no
+     * longer appears lazily on first activity.
+     *
+     * @param gpu_id GPU ordinal.
+     */
+    static void initialize_pmc_metadata(std::size_t gpu_id)
+    {
+        constexpr std::size_t EVENT_CODE       = 0;
+        constexpr std::size_t INSTANCE_ID      = 0;
+        constexpr const char* LONG_DESCRIPTION = "";
+        constexpr const char* COMPONENT        = "";
+        constexpr const char* BLOCK            = "";
+        constexpr const char* EXPRESSION       = "";
+        constexpr const char* TARGET_ARCH      = "GPU";
+
+        for(const auto& metric : METRIC_TABLE)
+        {
+            const auto name = track_name(gpu_id, metric.suffix);
+
+            trace_cache::get_metadata_registry().add_track({ name, std::nullopt, "{}" });
+
+            // ABSOLUTE is accurate for both shapes here: the counters are cumulative
+            // totals and the bandwidths are instantaneous rates. Neither is a delta.
+            trace_cache::get_metadata_registry().add_pmc_info(
+                { agent_type::GPU, gpu_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID, name,
+                  metric.suffix, trait::name<category::hipfile>::description,
+                  LONG_DESCRIPTION, COMPONENT, metric.unit,
+                  rocprofsys::trace_cache::ABSOLUTE, BLOCK, EXPRESSION, 0, 0, "{}" });
+        }
+    }
+
+    /**
+     * @brief Store one GPU's hipFile sample.
+     *
+     * @param device_id GPU ordinal.
+     * @param enabled_metrics_cfg Metrics enabled by configuration.
+     * @param supported_metrics Metrics this device can supply.
+     * @param metric_values Collected values.
+     * @param timestamp Sample timestamp in nanoseconds.
+     */
+    static void store_sample(std::size_t                         device_id,
+                             [[maybe_unused]] const std::string& device_name,
+                             const enabled_metrics&              enabled_metrics_cfg,
+                             const enabled_metrics&              supported_metrics,
+                             const metrics& metric_values, std::uint64_t timestamp)
+    {
+        // A failed hipFile query is not a measurement of zero, so it produces no sample.
+        // Note this is not the paused path: pause() emits a value-initialized metrics,
+        // which has query_failed false and so still drops the tracks to zero.
+        if(metric_values.query_failed) return;
+
+        const std::uint32_t active = enabled_metrics_cfg.value & supported_metrics.value;
+
+        for(const auto& metric : METRIC_TABLE)
+        {
+            if((active & (1U << metric.bit)) == 0U) continue;
+
+            const auto name = track_name(device_id, metric.suffix);
+
+            trace_cache::get_buffer_storage().store(trace_cache::pmc_event_with_sample{
+                static_cast<std::size_t>(category_enum_id<category::hipfile>::value),
+                name, timestamp, "{}", 0, 0, 0, "{}", "{}",
+                static_cast<std::uint32_t>(device_id),
+                static_cast<std::uint8_t>(agent_type::GPU), name,
+                metric.value(metric_values), std::nullopt });
+        }
+    }
+};
+
+}  // namespace rocprofsys::pmc::collectors::hipfile

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/hipfile/collector.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/hipfile/collector.hpp
@@ -1,0 +1,28 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "library/pmc/collectors/base/collector.hpp"
+#include "library/pmc/collectors/hipfile/hipfile_traits.hpp"
+
+namespace rocprofsys::pmc::collectors::hipfile
+{
+
+/**
+ * @brief hipFile GPU-direct storage I/O collector.
+ *
+ * Specializes the base collector template for hipFile. All hipFile-specific behaviour
+ * lives in hipfile_traits, so lifecycle, device disabling on repeated failure, sample
+ * accounting, and the zeroed pause sample are shared with the GPU, NIC, and CPU
+ * collectors rather than reimplemented here.
+ *
+ * @tparam DeviceProvider Type providing hipFile device enumeration and management
+ * @tparam DeviceType     Concrete device type, parameterized on its backend
+ * @tparam Config         Configuration policy providing settings and output policies
+ */
+template <typename DeviceProvider, typename DeviceType, typename Config>
+using collector =
+    base::collector<hipfile_traits<DeviceProvider, DeviceType>, DeviceProvider, Config>;
+
+}  // namespace rocprofsys::pmc::collectors::hipfile

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/hipfile/device.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/hipfile/device.hpp
@@ -1,0 +1,156 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "library/pmc/collectors/hipfile/types.hpp"
+
+#include <concepts>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+
+namespace rocprofsys::pmc::collectors::hipfile
+{
+
+// Contract the hipFile collector requires of its backend (the data producer).
+template <typename Backend>
+concept hipfile_backend_contract = requires(Backend backend, std::uint64_t timestamp) {
+    { backend.get_stats(timestamp) } -> std::convertible_to<const stats_snapshot&>;
+    { backend.is_available() } -> std::convertible_to<bool>;
+};
+
+/**
+ * @brief One GPU's view of the shared hipFile stats snapshot.
+ *
+ * Devices are addressed by GPU ordinal, which is how hipFile indexes @c per_gpu_stats.
+ * Every device shares one backend, so an interval costs one hipFile query and all
+ * devices in it observe the same snapshot.
+ *
+ * The device owns the only mutable state in the collector: the previous byte totals and
+ * timestamp needed to turn cumulative counters into a wall-clock bandwidth. The
+ * counters themselves need no history, since they are published cumulative.
+ *
+ * @tparam Backend hipFile backend session type (real or mock).
+ */
+template <hipfile_backend_contract Backend>
+class device
+{
+public:
+    using backend_type = Backend;
+
+    device(std::shared_ptr<Backend> backend, std::size_t gpu_ordinal)
+    : m_backend{ std::move(backend) }
+    , m_index{ gpu_ordinal }
+    , m_name{ "GPU " + std::to_string(gpu_ordinal) }
+    {}
+
+    [[nodiscard]] std::size_t get_index() const noexcept { return m_index; }
+
+    [[nodiscard]] const std::string& get_name() const noexcept { return m_name; }
+
+    /// @brief Whether this ordinal addresses a real slot in the hipFile snapshot.
+    [[nodiscard]] bool is_supported() const noexcept { return m_index < MAX_GPUS; }
+
+    [[nodiscard]] enabled_metrics get_supported_metrics() const noexcept
+    {
+        enabled_metrics supported;
+        supported.value = is_supported() ? ALL_HIPFILE_METRICS : 0U;
+        return supported;
+    }
+
+    /**
+     * @brief Read this GPU's counters and compute its bandwidth for the interval.
+     *
+     * @param timestamp Sample timestamp in nanoseconds. Doubles as the backend's
+     *                  memoization key and as the bandwidth denominator.
+     */
+    [[nodiscard]] metrics get_metrics(const enabled_metrics& /*enabled*/,
+                                      std::uint64_t timestamp)
+    {
+        metrics out{};
+
+        if(!is_supported())
+        {
+            out.query_failed = true;
+            return out;
+        }
+
+        const auto& snapshot = m_backend->get_stats(timestamp);
+        if(!m_backend->is_available())
+        {
+            // hipFile stats are unreadable: the target performed no hipFile I/O, or
+            // HIPFILE_STATS_LEVEL is off. Reporting zeros would be a measurement claim
+            // we cannot make, so the sample is suppressed instead.
+            out.query_failed = true;
+            return out;
+        }
+
+        const auto& stats = snapshot.per_gpu[m_index];
+
+        out.read_bytes       = stats.read_bytes;
+        out.write_bytes      = stats.write_bytes;
+        out.read_ops         = stats.read_ops;
+        out.write_ops        = stats.write_ops;
+        out.fastpath_reads   = stats.fastpath_reads;
+        out.fastpath_writes  = stats.fastpath_writes;
+        out.fallback_reads   = stats.fallback_reads;
+        out.fallback_writes  = stats.fallback_writes;
+        out.unaligned_reads  = stats.unaligned_reads;
+        out.unaligned_writes = stats.unaligned_writes;
+        out.read_errors      = stats.read_errors;
+        out.write_errors     = stats.write_errors;
+
+        // The first sample has no interval behind it, so it has no rate. Reporting the
+        // lifetime total over a zero interval would open every run with a false spike.
+        if(m_has_previous)
+        {
+            const auto elapsed_ns = timestamp - m_previous_timestamp;
+            out.read_bandwidth =
+                bandwidth(stats.read_bytes, m_previous_read_bytes, elapsed_ns);
+            out.write_bandwidth =
+                bandwidth(stats.write_bytes, m_previous_write_bytes, elapsed_ns);
+        }
+
+        m_previous_read_bytes  = stats.read_bytes;
+        m_previous_write_bytes = stats.write_bytes;
+        m_previous_timestamp   = timestamp;
+        m_has_previous         = true;
+
+        return out;
+    }
+
+private:
+    /**
+     * @brief Wall-clock bandwidth in bytes/sec over one sampling interval.
+     *
+     * Normalised by elapsed wall time rather than by hipFile's own I/O-call duration,
+     * so the track is directly comparable to the AMD SMI instantaneous PCIe bandwidth
+     * sitting beside it on the same GPU timeline.
+     *
+     * A counter that moved backwards means hipFile reset its stats; the interval is
+     * unmeasurable rather than negative, so it reports zero.
+     */
+    [[nodiscard]] static double bandwidth(std::uint64_t current, std::uint64_t previous,
+                                          std::uint64_t elapsed_ns) noexcept
+    {
+        if(elapsed_ns == 0 || current < previous) return 0.0;
+
+        constexpr double NS_PER_SEC = 1e9;
+        return static_cast<double>(current - previous) * NS_PER_SEC /
+               static_cast<double>(elapsed_ns);
+    }
+
+    std::shared_ptr<Backend> m_backend;
+    const std::size_t        m_index;
+    const std::string        m_name;
+
+    std::uint64_t m_previous_read_bytes  = 0;
+    std::uint64_t m_previous_write_bytes = 0;
+    std::uint64_t m_previous_timestamp   = 0;
+    bool          m_has_previous         = false;
+};
+
+}  // namespace rocprofsys::pmc::collectors::hipfile

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/hipfile/hipfile_traits.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/hipfile/hipfile_traits.hpp
@@ -1,0 +1,162 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "library/pmc/collectors/hipfile/device.hpp"
+#include "library/pmc/collectors/hipfile/types.hpp"
+#include "library/pmc/common/types.hpp"
+#include "logger/debug.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace rocprofsys::pmc::collectors::hipfile
+{
+
+using ::rocprofsys::pmc::device_filter;
+using ::rocprofsys::pmc::device_selection_mode;
+
+/**
+ * @brief Traits type for hipFile collector configuration.
+ *
+ * Bridges hipFile's GPU-direct storage I/O stats to base::collector.
+ *
+ * @note Unlike the AMD SMI collectors, enumeration does not probe the data source.
+ * hipFile stats only become readable once the target performs hipFile I/O, which
+ * generally happens after the sampler has started, so probing at setup() would find
+ * nothing and permanently disable the collector. Devices are instead enumerated from
+ * the ROCm-visible GPU set, and each sample decides for itself whether hipFile had
+ * anything to report.
+ *
+ * @tparam BackendProvider Device provider type.
+ * @tparam DeviceType      Concrete device type; exposes @c backend_type so the traits
+ *                         stay decoupled from the hipFile backend headers.
+ */
+template <typename BackendProvider, typename DeviceType>
+struct hipfile_traits
+{
+    using metrics_t         = pmc::collectors::hipfile::metrics;
+    using enabled_metrics_t = pmc::collectors::hipfile::enabled_metrics;
+    using backend_t         = typename DeviceType::backend_type;
+    using device_t          = DeviceType;
+    using device_ptr_t      = std::shared_ptr<device_t>;
+    using container_t       = std::vector<device_ptr_t>;
+
+    static constexpr const char* device_name = "hipFile";
+
+    struct device_entry
+    {
+        device_ptr_t      device;
+        enabled_metrics_t supported_metrics;
+    };
+
+    template <typename Settings>
+    [[nodiscard]] static device_filter get_device_filter()
+    {
+        // hipFile telemetry is per GPU, so it honours the same GPU selection as the
+        // AMD SMI GPU collector rather than introducing a second, divergent filter.
+        return Settings::get_gpu_device_filter();
+    }
+
+    template <typename Settings>
+    [[nodiscard]] static enabled_metrics_t get_enabled_metrics()
+    {
+        return Settings::get_hipfile_enabled_metrics();
+    }
+
+    template <typename Cache>
+    static void init_pmc_metadata(const device_ptr_t& device)
+    {
+        Cache::initialize_pmc_metadata(device->get_index());
+    }
+
+    // Perfetto customization points are no-ops: hipFile counter tracks reach Perfetto
+    // through the PMC path (pmc_event_with_sample), not the legacy per-collector
+    // Perfetto policy that the AMD SMI collectors still carry.
+    template <typename Perfetto, typename DeviceEntries>
+    static void init_perfetto_storage(const DeviceEntries& /*device_entries*/)
+    {}
+
+    template <typename Perfetto>
+    static void setup_counter_tracks(const device_ptr_t& /*device*/,
+                                     const enabled_metrics_t& /*enabled*/)
+    {}
+
+    template <typename Perfetto, typename DeviceEntries>
+    static void post_process_perfetto(const DeviceEntries& /*device_entries*/,
+                                      const enabled_metrics_t& /*enabled*/)
+    {}
+
+    [[nodiscard]] static metrics_t get_metrics(const device_ptr_t&      device,
+                                               const enabled_metrics_t& enabled,
+                                               std::uint64_t            timestamp)
+    {
+        return device->get_metrics(enabled, timestamp);
+    }
+
+    /**
+     * @brief Enumerate one device per ROCm-visible GPU ordinal.
+     *
+     * hipFile indexes its per-GPU stats by GPU ordinal, so the ordinals the ROCm runtime
+     * exposes are exactly the slots worth reading. Ordinals beyond the snapshot's
+     * capacity are dropped rather than silently aliased onto a valid slot.
+     */
+    template <typename Settings, typename Provider>
+    [[nodiscard]] static std::vector<device_entry> enumerate_devices(
+        std::shared_ptr<Provider> provider)
+    {
+        std::vector<device_entry> entries;
+
+        const auto filter = get_device_filter<Settings>();
+        if(filter.mode == device_selection_mode::NONE)
+        {
+            LOG_DEBUG("{} sampling disabled via configuration", device_name);
+            return entries;
+        }
+
+        const auto visible_gpus = Settings::get_visible_gpu_count();
+        if(visible_gpus == 0)
+        {
+            LOG_DEBUG("No ROCm-visible GPUs; {} sampling disabled", device_name);
+            return entries;
+        }
+
+        if(visible_gpus > MAX_GPUS)
+        {
+            LOG_WARNING("{} GPUs are visible but hipFile reports stats for at most {}; "
+                        "telemetry for the remaining GPUs is unavailable",
+                        visible_gpus, MAX_GPUS);
+        }
+
+        const auto slots   = std::min<std::size_t>(visible_gpus, MAX_GPUS);
+        auto       devices = provider->template get_devices<device_t>(slots);
+
+        for(auto& device : devices)
+        {
+            const auto index = device->get_index();
+
+            const bool should_include = (filter.mode == device_selection_mode::ALL) ||
+                                        (filter.mode == device_selection_mode::SPECIFIC &&
+                                         filter.indices.count(index) > 0);
+
+            if(!should_include)
+            {
+                LOG_DEBUG("{} GPU [{}] excluded by ROCPROFSYS_SAMPLING_GPUS filter",
+                          device_name, index);
+                continue;
+            }
+
+            auto supported = device->get_supported_metrics();
+            entries.push_back(device_entry{ std::move(device), supported });
+        }
+
+        LOG_DEBUG("Enabled {} GPU(s) for {} telemetry", entries.size(), device_name);
+        return entries;
+    }
+};
+
+}  // namespace rocprofsys::pmc::collectors::hipfile

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/hipfile/perfetto_policy.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/hipfile/perfetto_policy.hpp
@@ -1,0 +1,34 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "library/pmc/collectors/hipfile/types.hpp"
+
+#include <cstddef>
+#include <cstdint>
+
+namespace rocprofsys::pmc::collectors::hipfile
+{
+
+/**
+ * @brief No-op Perfetto policy for the hipFile collector.
+ *
+ * The AMD SMI GPU, NIC, and CPU collectors predate the PMC path and still write their
+ * Perfetto counter tracks directly through a per-collector Perfetto policy, gated on
+ * ROCPROFSYS_USE_PERFETTO. hipFile has no such legacy path: its tracks reach Perfetto
+ * as pmc_event_with_sample, the same records that populate RocPD, so there is exactly
+ * one producer per track.
+ *
+ * base::collector calls PerfettoApi::store_sample directly rather than through the
+ * traits, so this type exists to satisfy that call and do nothing. Without it, enabling
+ * Perfetto would emit each hipFile counter twice.
+ */
+struct perfetto_policy
+{
+    static void store_sample(std::size_t /*device_id*/, const metrics& /*values*/,
+                             std::uint64_t /*timestamp*/)
+    {}
+};
+
+}  // namespace rocprofsys::pmc::collectors::hipfile

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/hipfile/tests/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/hipfile/tests/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# Drives the collector through a mock backend and stub settings/cache policies, so no
+# hipFile package, no GPU-direct storage hardware, and no trace cache are required. This
+# is what makes the fastpath and fallback attribution verifiable in CI.
+add_library(
+    pmc-hipfile-collector-tests
+    OBJECT
+    test_device.cpp
+    test_hipfile_traits.cpp
+    test_collector_workflow.cpp
+)
+
+target_link_libraries(
+    pmc-hipfile-collector-tests
+    PRIVATE
+        rocprofiler-systems-googletest-library
+        rocprofiler-systems-logger
+        rocprofiler-systems::rocprofiler-systems-headers
+        rocprofiler-systems::rocprofiler-systems-rocm
+        rocprofiler-systems::rocprofiler-systems-compile-definitions
+)
+
+target_include_directories(
+    pmc-hipfile-collector-tests
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/source/lib
+        ${PROJECT_SOURCE_DIR}/source/lib/rocprof-sys
+        ${PROJECT_BINARY_DIR}/source/lib
+)

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/hipfile/tests/mock_backend.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/hipfile/tests/mock_backend.hpp
@@ -1,0 +1,76 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "library/pmc/collectors/hipfile/types.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace rocprofsys::pmc::collectors::hipfile::testing
+{
+
+/**
+ * @brief Programmable stand-in for the hipFile backend session.
+ *
+ * Satisfies hipfile_backend_contract with no hipFile dependency, so the collector's
+ * behaviour - fastpath vs fallback attribution, cumulative counters, wall-clock
+ * bandwidth, the unavailable path - is verifiable on any machine, with or without
+ * GPU-direct storage hardware.
+ */
+struct mock_backend
+{
+    stats_snapshot snapshot{};
+    bool           available  = true;
+    std::size_t    call_count = 0;
+
+    /// Timestamps passed to get_stats, in order. Lets a test assert the backend saw
+    /// exactly one query per interval.
+    std::vector<std::uint64_t> queried_timestamps{};
+
+    [[nodiscard]] const stats_snapshot& get_stats(std::uint64_t timestamp)
+    {
+        ++call_count;
+        queried_timestamps.push_back(timestamp);
+        return snapshot;
+    }
+
+    [[nodiscard]] bool is_available() const noexcept { return available; }
+
+    void shutdown() noexcept {}
+
+    /// @brief Convenience accessor for populating one GPU's slot.
+    [[nodiscard]] gpu_stats& gpu(std::size_t ordinal)
+    {
+        return snapshot.per_gpu[ordinal];
+    }
+};
+
+/**
+ * @brief Device provider stand-in handing out devices over a shared mock backend.
+ */
+struct mock_provider
+{
+    using backend_t = mock_backend;
+
+    std::shared_ptr<mock_backend> backend         = std::make_shared<mock_backend>();
+    bool                          shutdown_called = false;
+
+    template <typename Device>
+    [[nodiscard]] std::vector<std::shared_ptr<Device>> get_devices(std::size_t gpu_count)
+    {
+        std::vector<std::shared_ptr<Device>> devices;
+        devices.reserve(gpu_count);
+        for(std::size_t ordinal = 0; ordinal < gpu_count; ++ordinal)
+            devices.push_back(std::make_shared<Device>(backend, ordinal));
+        return devices;
+    }
+
+    void init() {}
+    void shutdown() { shutdown_called = true; }
+};
+
+}  // namespace rocprofsys::pmc::collectors::hipfile::testing

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/hipfile/tests/test_collector_workflow.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/hipfile/tests/test_collector_workflow.cpp
@@ -1,0 +1,396 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "mock_backend.hpp"
+
+#include "library/pmc/collectors/hipfile/collector.hpp"
+#include "library/pmc/collectors/hipfile/device.hpp"
+#include "library/pmc/collectors/hipfile/perfetto_policy.hpp"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace rocprofsys::pmc::collectors::hipfile::testing
+{
+namespace
+{
+using device_t = device<mock_backend>;
+
+/// One value written to the trace cache, flattened for assertion.
+struct recorded_sample
+{
+    std::size_t   device_id;
+    std::string   metric;
+    double        value;
+    std::uint64_t timestamp;
+};
+
+/**
+ * @brief Cache stand-in capturing what the collector would have written.
+ *
+ * Mirrors the real cache_policy's gating - a failed query writes nothing, and only
+ * metrics both enabled and supported are emitted - so the workflow tests exercise the
+ * same decisions without a trace cache behind them.
+ */
+struct stub_cache
+{
+    inline static std::vector<recorded_sample> samples{};
+    inline static std::vector<std::size_t>     metadata_gpus{};
+    inline static std::size_t                  category_init_count = 0;
+
+    static void reset()
+    {
+        samples.clear();
+        metadata_gpus.clear();
+        category_init_count = 0;
+    }
+
+    static void initialize_category_metadata() { ++category_init_count; }
+    static void initialize_tracks_metadata() {}
+    static void initialize_pmc_metadata(std::size_t gpu_id)
+    {
+        metadata_gpus.push_back(gpu_id);
+    }
+
+    static void store_sample(std::size_t device_id, const std::string& /*device_name*/,
+                             const enabled_metrics& enabled_cfg,
+                             const enabled_metrics& supported, const metrics& values,
+                             std::uint64_t timestamp)
+    {
+        if(values.query_failed) return;
+
+        const std::uint32_t active = enabled_cfg.value & supported.value;
+        for(const auto& metric : METRIC_TABLE)
+        {
+            if((active & (1U << metric.bit)) == 0U) continue;
+            samples.push_back(recorded_sample{ device_id, metric.suffix,
+                                               metric.value(values), timestamp });
+        }
+    }
+
+    [[nodiscard]] static std::vector<recorded_sample> for_metric(const std::string& name)
+    {
+        std::vector<recorded_sample> out;
+        std::copy_if(samples.begin(), samples.end(), std::back_inserter(out),
+                     [&name](const auto& s) { return s.metric == name; });
+        return out;
+    }
+};
+
+struct stub_settings
+{
+    inline static device_filter   gpu_filter{};
+    inline static std::size_t     visible_gpus = 0;
+    inline static enabled_metrics hipfile_metrics{};
+    inline static bool            perfetto_legacy = false;
+
+    static void reset()
+    {
+        gpu_filter            = device_filter{};
+        gpu_filter.mode       = device_selection_mode::ALL;
+        visible_gpus          = 2;
+        hipfile_metrics.value = ALL_HIPFILE_METRICS;
+        perfetto_legacy       = false;
+    }
+
+    static device_filter   get_gpu_device_filter() { return gpu_filter; }
+    static std::size_t     get_visible_gpu_count() { return visible_gpus; }
+    static enabled_metrics get_hipfile_enabled_metrics() { return hipfile_metrics; }
+    static bool            get_use_perfetto_legacy_metrics() { return perfetto_legacy; }
+};
+
+/// Counts the legacy Perfetto path, which must stay unused: hipFile tracks reach
+/// Perfetto through the PMC records, so a second producer here would double every value.
+struct stub_perfetto
+{
+    inline static std::size_t store_count = 0;
+
+    static void reset() { store_count = 0; }
+
+    static void store_sample(std::size_t /*device_id*/, const metrics& /*values*/,
+                             std::uint64_t /*timestamp*/)
+    {
+        ++store_count;
+    }
+};
+
+struct stub_config
+{
+    using SettingsApi = stub_settings;
+    using PerfettoApi = stub_perfetto;
+    using CacheApi    = stub_cache;
+};
+
+using collector_t = collector<mock_provider, device_t, stub_config>;
+
+constexpr std::uint64_t NS_PER_SEC = 1'000'000'000;
+constexpr std::uint64_t TS_1       = 1 * NS_PER_SEC;
+constexpr std::uint64_t TS_2       = 2 * NS_PER_SEC;
+
+class HipFileCollectorTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub_cache::reset();
+        stub_perfetto::reset();
+        stub_settings::reset();
+        m_provider  = std::make_shared<mock_provider>();
+        m_collector = std::make_unique<collector_t>(m_provider);
+    }
+
+    void setup_and_config()
+    {
+        m_collector->setup();
+        m_collector->config();
+    }
+
+    [[nodiscard]] mock_backend& backend() { return *m_provider->backend; }
+
+    std::shared_ptr<mock_provider> m_provider;
+    std::unique_ptr<collector_t>   m_collector;
+};
+
+// ── Lifecycle ───────────────────────────────────────────────────────────────
+
+TEST_F(HipFileCollectorTest, setup_enumerates_visible_gpus)
+{
+    stub_settings::visible_gpus = 3;
+
+    m_collector->setup();
+
+    EXPECT_EQ(m_collector->get_device_count(), 3U);
+}
+
+TEST_F(HipFileCollectorTest, config_registers_metadata_for_every_gpu)
+{
+    stub_settings::visible_gpus = 2;
+
+    setup_and_config();
+
+    // Registration happens once for the whole known device set, rather than lazily on
+    // first activity as the previous implementation did.
+    EXPECT_EQ(stub_cache::category_init_count, 1U);
+    EXPECT_EQ(stub_cache::metadata_gpus, (std::vector<std::size_t>{ 0, 1 }));
+}
+
+TEST_F(HipFileCollectorTest, sample_emits_every_metric_for_every_gpu)
+{
+    stub_settings::visible_gpus = 2;
+    setup_and_config();
+
+    m_collector->sample(static_cast<std::int64_t>(TS_1));
+
+    EXPECT_EQ(stub_cache::samples.size(), 2U * HIPFILE_METRICS_COUNT);
+}
+
+TEST_F(HipFileCollectorTest, shutdown_propagates_to_provider)
+{
+    setup_and_config();
+
+    m_collector->shutdown();
+
+    EXPECT_TRUE(m_provider->shutdown_called);
+}
+
+// ── Track scoping ───────────────────────────────────────────────────────────
+
+TEST_F(HipFileCollectorTest, every_track_is_gpu_indexed)
+{
+    stub_settings::visible_gpus = 2;
+    setup_and_config();
+
+    m_collector->sample(static_cast<std::int64_t>(TS_1));
+
+    // No sample may arrive without a GPU it belongs to. The process-scoped counters that
+    // used to ride along on GPU 0 are gone entirely.
+    for(const auto& sample : stub_cache::samples)
+        EXPECT_LT(sample.device_id, 2U);
+}
+
+TEST_F(HipFileCollectorTest, no_registration_tracks_are_emitted)
+{
+    setup_and_config();
+    m_collector->sample(static_cast<std::int64_t>(TS_1));
+
+    EXPECT_TRUE(stub_cache::for_metric("File Registrations").empty());
+    EXPECT_TRUE(stub_cache::for_metric("Buffer Registrations").empty());
+}
+
+TEST_F(HipFileCollectorTest, gpu_zero_carries_no_extra_tracks)
+{
+    stub_settings::visible_gpus = 2;
+    setup_and_config();
+
+    m_collector->sample(static_cast<std::int64_t>(TS_1));
+
+    const auto count_for = [](std::size_t gpu) {
+        return std::count_if(
+            stub_cache::samples.begin(), stub_cache::samples.end(),
+            [gpu](const auto& sample) { return sample.device_id == gpu; });
+    };
+
+    EXPECT_EQ(count_for(0), count_for(1));
+}
+
+// ── Enablement ──────────────────────────────────────────────────────────────
+
+TEST_F(HipFileCollectorTest, disabled_metrics_are_not_emitted)
+{
+    stub_settings::visible_gpus                    = 1;
+    stub_settings::hipfile_metrics.value           = 0U;
+    stub_settings::hipfile_metrics.bits.read_bytes = 1;
+
+    setup_and_config();
+    m_collector->sample(static_cast<std::int64_t>(TS_1));
+
+    ASSERT_EQ(stub_cache::samples.size(), 1U);
+    EXPECT_EQ(stub_cache::samples.front().metric, "Read Bytes");
+}
+
+TEST_F(HipFileCollectorTest, no_metrics_enabled_emits_nothing)
+{
+    stub_settings::hipfile_metrics.value = 0U;
+
+    setup_and_config();
+    m_collector->sample(static_cast<std::int64_t>(TS_1));
+
+    EXPECT_TRUE(stub_cache::samples.empty());
+}
+
+// ── Values through the full path ────────────────────────────────────────────
+
+TEST_F(HipFileCollectorTest, cumulative_values_reach_the_cache)
+{
+    stub_settings::visible_gpus = 1;
+    setup_and_config();
+
+    backend().gpu(0).read_bytes = 1000;
+    m_collector->sample(static_cast<std::int64_t>(TS_1));
+
+    backend().gpu(0).read_bytes = 3000;
+    m_collector->sample(static_cast<std::int64_t>(TS_2));
+
+    const auto read_bytes = stub_cache::for_metric("Read Bytes");
+    ASSERT_EQ(read_bytes.size(), 2U);
+    EXPECT_DOUBLE_EQ(read_bytes[0].value, 1000.0);
+    EXPECT_DOUBLE_EQ(read_bytes[1].value, 3000.0);
+}
+
+TEST_F(HipFileCollectorTest, bandwidth_reaches_the_cache_wall_clock_normalised)
+{
+    stub_settings::visible_gpus = 1;
+    setup_and_config();
+
+    backend().gpu(0).read_bytes = 0;
+    m_collector->sample(static_cast<std::int64_t>(TS_1));
+
+    backend().gpu(0).read_bytes = 4096;
+    m_collector->sample(static_cast<std::int64_t>(TS_2));
+
+    const auto bandwidth = stub_cache::for_metric("Read Bandwidth");
+    ASSERT_EQ(bandwidth.size(), 2U);
+    EXPECT_DOUBLE_EQ(bandwidth[0].value, 0.0);
+    EXPECT_DOUBLE_EQ(bandwidth[1].value, 4096.0);
+}
+
+// ── Unavailable backend ─────────────────────────────────────────────────────
+
+TEST_F(HipFileCollectorTest, unavailable_backend_emits_nothing)
+{
+    setup_and_config();
+    backend().available = false;
+
+    m_collector->sample(static_cast<std::int64_t>(TS_1));
+
+    // hipFile is simply not in use in this process. Writing zeros would claim a
+    // measurement that was never taken.
+    EXPECT_TRUE(stub_cache::samples.empty());
+}
+
+TEST_F(HipFileCollectorTest, devices_survive_an_unavailable_interval)
+{
+    setup_and_config();
+    const auto before = m_collector->get_device_count();
+
+    backend().available = false;
+    m_collector->sample(static_cast<std::int64_t>(TS_1));
+
+    // hipFile stats commonly become readable only after the target's first I/O, so an
+    // unavailable interval must not permanently disable the devices.
+    EXPECT_EQ(m_collector->get_device_count(), before);
+
+    backend().available         = true;
+    backend().gpu(0).read_bytes = 512;
+    m_collector->sample(static_cast<std::int64_t>(TS_2));
+
+    EXPECT_FALSE(stub_cache::samples.empty());
+}
+
+// ── Perfetto ────────────────────────────────────────────────────────────────
+
+TEST_F(HipFileCollectorTest, enabling_perfetto_does_not_change_pmc_output)
+{
+    stub_settings::visible_gpus    = 1;
+    stub_settings::perfetto_legacy = true;
+    setup_and_config();
+
+    m_collector->sample(static_cast<std::int64_t>(TS_1));
+
+    // base::collector routes to PerfettoApi once per device whenever the legacy path is
+    // on. hipFile plugs a no-op in there (perfetto_policy), because its tracks already
+    // reach Perfetto as PMC records; a real writer would put two producers on every
+    // track. What must hold either way is that the PMC output is unchanged.
+    EXPECT_EQ(stub_perfetto::store_count, 1U);
+    EXPECT_EQ(stub_cache::samples.size(), HIPFILE_METRICS_COUNT);
+}
+
+TEST_F(HipFileCollectorTest, production_perfetto_policy_is_inert)
+{
+    // Compiles against the same call base::collector makes, and does nothing.
+    metrics values{};
+    values.read_bytes = 4096;
+
+    perfetto_policy::store_sample(0, values, TS_1);
+
+    SUCCEED();
+}
+
+// ── Pause ───────────────────────────────────────────────────────────────────
+
+TEST_F(HipFileCollectorTest, pause_emits_zeros_for_every_track)
+{
+    stub_settings::visible_gpus = 1;
+    setup_and_config();
+
+    backend().gpu(0).read_bytes = 4096;
+    m_collector->sample(static_cast<std::int64_t>(TS_1));
+    stub_cache::reset();
+
+    m_collector->pause(static_cast<std::int64_t>(TS_2));
+
+    ASSERT_EQ(stub_cache::samples.size(), HIPFILE_METRICS_COUNT);
+    for(const auto& sample : stub_cache::samples)
+        EXPECT_DOUBLE_EQ(sample.value, 0.0) << sample.metric;
+}
+
+TEST_F(HipFileCollectorTest, pause_is_not_suppressed_as_a_failed_query)
+{
+    setup_and_config();
+    backend().available = false;
+
+    m_collector->pause(static_cast<std::int64_t>(TS_1));
+
+    // Pause writes a value-initialized metrics, which must not be mistaken for the
+    // unavailable path regardless of what the backend currently reports.
+    EXPECT_FALSE(stub_cache::samples.empty());
+}
+
+}  // namespace
+}  // namespace rocprofsys::pmc::collectors::hipfile::testing

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/hipfile/tests/test_device.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/hipfile/tests/test_device.cpp
@@ -1,0 +1,354 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "mock_backend.hpp"
+
+#include "library/pmc/collectors/hipfile/device.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+
+namespace rocprofsys::pmc::collectors::hipfile::testing
+{
+namespace
+{
+using device_t = device<mock_backend>;
+
+constexpr std::uint64_t NS_PER_SEC = 1'000'000'000;
+constexpr std::uint64_t TS_1       = 1 * NS_PER_SEC;
+constexpr std::uint64_t TS_2       = 2 * NS_PER_SEC;
+constexpr std::uint64_t TS_3       = 3 * NS_PER_SEC;
+
+class HipFileDeviceTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        m_backend       = std::make_shared<mock_backend>();
+        m_device        = std::make_shared<device_t>(m_backend, 0);
+        m_enabled.value = ALL_HIPFILE_METRICS;
+    }
+
+    [[nodiscard]] metrics sample(std::uint64_t timestamp)
+    {
+        return m_device->get_metrics(m_enabled, timestamp);
+    }
+
+    std::shared_ptr<mock_backend> m_backend;
+    std::shared_ptr<device_t>     m_device;
+    enabled_metrics               m_enabled{};
+};
+
+// ── Identity and metric set ─────────────────────────────────────────────────
+
+TEST_F(HipFileDeviceTest, index_and_name_track_the_gpu_ordinal)
+{
+    device_t third{ m_backend, 3 };
+
+    EXPECT_EQ(third.get_index(), 3U);
+    EXPECT_EQ(third.get_name(), "GPU 3");
+}
+
+TEST_F(HipFileDeviceTest, all_metrics_supported_for_valid_ordinal)
+{
+    EXPECT_EQ(m_device->get_supported_metrics().value, ALL_HIPFILE_METRICS);
+}
+
+TEST_F(HipFileDeviceTest, ordinal_beyond_snapshot_supports_nothing)
+{
+    // Guards the read that would otherwise run off the end of per_gpu.
+    device_t out_of_range{ m_backend, MAX_GPUS };
+
+    EXPECT_FALSE(out_of_range.is_supported());
+    EXPECT_EQ(out_of_range.get_supported_metrics().value, 0U);
+    EXPECT_TRUE(out_of_range.get_metrics(m_enabled, TS_1).query_failed);
+}
+
+// ── Cumulative counter semantics ────────────────────────────────────────────
+
+TEST_F(HipFileDeviceTest, counters_are_cumulative_not_deltas)
+{
+    m_backend->gpu(0).read_bytes = 1000;
+    EXPECT_EQ(sample(TS_1).read_bytes, 1000U);
+
+    m_backend->gpu(0).read_bytes = 2500;
+    const auto second            = sample(TS_2);
+
+    // The delta over this interval is 1500. Publishing that instead of the running
+    // total is what this test exists to prevent: every other byte counter the profiler
+    // ships (PCIe accumulator, XGMI, NIC) reports cumulative under ABSOLUTE.
+    EXPECT_EQ(second.read_bytes, 2500U);
+    EXPECT_NE(second.read_bytes, 1500U);
+}
+
+TEST_F(HipFileDeviceTest, all_counters_pass_through_unmodified)
+{
+    auto& stats            = m_backend->gpu(0);
+    stats.read_bytes       = 11;
+    stats.write_bytes      = 22;
+    stats.read_ops         = 33;
+    stats.write_ops        = 44;
+    stats.fastpath_reads   = 55;
+    stats.fastpath_writes  = 66;
+    stats.fallback_reads   = 77;
+    stats.fallback_writes  = 88;
+    stats.unaligned_reads  = 99;
+    stats.unaligned_writes = 110;
+    stats.read_errors      = 121;
+    stats.write_errors     = 132;
+
+    const auto out = sample(TS_1);
+
+    EXPECT_EQ(out.read_bytes, 11U);
+    EXPECT_EQ(out.write_bytes, 22U);
+    EXPECT_EQ(out.read_ops, 33U);
+    EXPECT_EQ(out.write_ops, 44U);
+    EXPECT_EQ(out.fastpath_reads, 55U);
+    EXPECT_EQ(out.fastpath_writes, 66U);
+    EXPECT_EQ(out.fallback_reads, 77U);
+    EXPECT_EQ(out.fallback_writes, 88U);
+    EXPECT_EQ(out.unaligned_reads, 99U);
+    EXPECT_EQ(out.unaligned_writes, 110U);
+    EXPECT_EQ(out.read_errors, 121U);
+    EXPECT_EQ(out.write_errors, 132U);
+}
+
+TEST_F(HipFileDeviceTest, counter_reset_is_not_clamped)
+{
+    m_backend->gpu(0).read_bytes = 5000;
+    sample(TS_1);
+
+    // hipFile reset its stats. The counter reports what hipFile reports; only the
+    // derived bandwidth needs to defend against the backwards step.
+    m_backend->gpu(0).read_bytes = 100;
+    EXPECT_EQ(sample(TS_2).read_bytes, 100U);
+}
+
+// ── Fastpath / fallback attribution ─────────────────────────────────────────
+
+TEST_F(HipFileDeviceTest, fastpath_and_fallback_reads_are_distinct)
+{
+    m_backend->gpu(0).read_ops       = 100;
+    m_backend->gpu(0).fastpath_reads = 70;
+    m_backend->gpu(0).fallback_reads = 30;
+
+    const auto out = sample(TS_1);
+
+    EXPECT_EQ(out.fastpath_reads, 70U);
+    EXPECT_EQ(out.fallback_reads, 30U);
+    EXPECT_EQ(out.fastpath_reads + out.fallback_reads, out.read_ops);
+}
+
+TEST_F(HipFileDeviceTest, compat_mode_reports_only_fallback)
+{
+    // What HIPFILE_FORCE_COMPAT_MODE looks like from the collector's side: every
+    // operation goes through POSIX, so the fastpath tracks must stay flat at zero.
+    m_backend->gpu(0).read_ops        = 40;
+    m_backend->gpu(0).fallback_reads  = 40;
+    m_backend->gpu(0).write_ops       = 20;
+    m_backend->gpu(0).fallback_writes = 20;
+
+    const auto out = sample(TS_1);
+
+    EXPECT_EQ(out.fallback_reads, 40U);
+    EXPECT_EQ(out.fallback_writes, 20U);
+    EXPECT_EQ(out.fastpath_reads, 0U);
+    EXPECT_EQ(out.fastpath_writes, 0U);
+}
+
+// ── Bandwidth: wall-clock normalisation ─────────────────────────────────────
+
+TEST_F(HipFileDeviceTest, bandwidth_first_sample_is_zero)
+{
+    m_backend->gpu(0).read_bytes = 1'000'000;
+
+    // No interval has elapsed yet, so there is no rate to report. Dividing the lifetime
+    // total by nothing would open every trace with a spike that never happened.
+    EXPECT_DOUBLE_EQ(sample(TS_1).read_bandwidth, 0.0);
+}
+
+TEST_F(HipFileDeviceTest, bandwidth_normalised_to_wall_clock)
+{
+    m_backend->gpu(0).read_bytes = 1000;
+    sample(TS_1);
+
+    // 1000 more bytes across a one-second interval.
+    m_backend->gpu(0).read_bytes = 2000;
+
+    EXPECT_DOUBLE_EQ(sample(TS_2).read_bandwidth, 1000.0);
+}
+
+TEST_F(HipFileDeviceTest, bandwidth_halves_when_interval_doubles)
+{
+    m_backend->gpu(0).read_bytes = 0;
+    sample(TS_1);
+
+    m_backend->gpu(0).read_bytes = 1000;
+    const auto one_second        = sample(TS_2).read_bandwidth;
+
+    m_backend->gpu(0).read_bytes = 2000;
+    const auto also_one_second   = sample(TS_3).read_bandwidth;
+
+    EXPECT_DOUBLE_EQ(one_second, 1000.0);
+    EXPECT_DOUBLE_EQ(also_one_second, 1000.0);
+
+    // Same bytes over a two-second interval must read half the rate.
+    device_t slow{ m_backend, 0 };
+    m_backend->gpu(0).read_bytes = 0;
+    slow.get_metrics(m_enabled, TS_1);
+    m_backend->gpu(0).read_bytes = 1000;
+    EXPECT_DOUBLE_EQ(slow.get_metrics(m_enabled, TS_3).read_bandwidth, 500.0);
+}
+
+TEST_F(HipFileDeviceTest, write_bandwidth_uses_write_bytes)
+{
+    m_backend->gpu(0).read_bytes  = 0;
+    m_backend->gpu(0).write_bytes = 0;
+    sample(TS_1);
+
+    m_backend->gpu(0).read_bytes  = 9'000;
+    m_backend->gpu(0).write_bytes = 4'000;
+
+    const auto out = sample(TS_2);
+
+    // Distinct values so a read/write transposition in the bandwidth path cannot pass.
+    EXPECT_DOUBLE_EQ(out.read_bandwidth, 9'000.0);
+    EXPECT_DOUBLE_EQ(out.write_bandwidth, 4'000.0);
+}
+
+TEST_F(HipFileDeviceTest, bandwidth_is_zero_when_no_io_occurred)
+{
+    m_backend->gpu(0).read_bytes = 4096;
+    sample(TS_1);
+
+    // Bytes unchanged: an idle interval reads as zero bandwidth, not as a repeat of
+    // the previous rate.
+    EXPECT_DOUBLE_EQ(sample(TS_2).read_bandwidth, 0.0);
+}
+
+TEST_F(HipFileDeviceTest, bandwidth_zero_elapsed_returns_zero)
+{
+    m_backend->gpu(0).read_bytes = 1000;
+    sample(TS_1);
+
+    m_backend->gpu(0).read_bytes = 2000;
+
+    // Two samples at the same timestamp would divide by zero.
+    EXPECT_DOUBLE_EQ(sample(TS_1).read_bandwidth, 0.0);
+}
+
+TEST_F(HipFileDeviceTest, bandwidth_survives_counter_reset)
+{
+    m_backend->gpu(0).read_bytes = 10'000;
+    sample(TS_1);
+
+    m_backend->gpu(0).read_bytes = 500;
+
+    // A backwards counter means an unmeasurable interval, not a negative rate.
+    EXPECT_DOUBLE_EQ(sample(TS_2).read_bandwidth, 0.0);
+}
+
+TEST_F(HipFileDeviceTest, bandwidth_ignores_io_duration)
+{
+    // The backend snapshot deliberately carries no duration fields, so bandwidth cannot
+    // silently regress to normalising by time-spent-in-I/O. If a duration is ever
+    // reintroduced to gpu_stats, this pairing of a 1-second wall interval with a large
+    // byte count keeps the expected value pinned to the wall-clock answer.
+    m_backend->gpu(0).read_bytes = 0;
+    sample(TS_1);
+
+    m_backend->gpu(0).read_bytes = 2'000'000;
+
+    EXPECT_DOUBLE_EQ(sample(TS_2).read_bandwidth, 2'000'000.0);
+}
+
+// ── Availability ────────────────────────────────────────────────────────────
+
+TEST_F(HipFileDeviceTest, unavailable_backend_marks_query_failed)
+{
+    m_backend->gpu(0).read_bytes = 4096;
+    m_backend->available         = false;
+
+    const auto out = sample(TS_1);
+
+    EXPECT_TRUE(out.query_failed);
+    EXPECT_EQ(out.read_bytes, 0U);
+}
+
+TEST_F(HipFileDeviceTest, available_backend_does_not_mark_query_failed)
+{
+    EXPECT_FALSE(sample(TS_1).query_failed);
+}
+
+TEST_F(HipFileDeviceTest, default_constructed_metrics_are_not_a_failed_query)
+{
+    // The paused collector emits a value-initialized metrics to drop tracks to zero.
+    // If that looked like a failed query it would be suppressed and the tracks would
+    // flatline at their last value instead.
+    const metrics paused{};
+
+    EXPECT_FALSE(paused.query_failed);
+}
+
+// ── Per-GPU isolation ───────────────────────────────────────────────────────
+
+TEST_F(HipFileDeviceTest, devices_read_their_own_ordinal)
+{
+    m_backend->gpu(0).read_bytes = 100;
+    m_backend->gpu(1).read_bytes = 200;
+    m_backend->gpu(2).read_bytes = 300;
+
+    device_t gpu1{ m_backend, 1 };
+    device_t gpu2{ m_backend, 2 };
+
+    EXPECT_EQ(sample(TS_1).read_bytes, 100U);
+    EXPECT_EQ(gpu1.get_metrics(m_enabled, TS_1).read_bytes, 200U);
+    EXPECT_EQ(gpu2.get_metrics(m_enabled, TS_1).read_bytes, 300U);
+}
+
+TEST_F(HipFileDeviceTest, bandwidth_state_is_per_device)
+{
+    device_t gpu1{ m_backend, 1 };
+
+    m_backend->gpu(0).read_bytes = 0;
+    m_backend->gpu(1).read_bytes = 0;
+    sample(TS_1);
+    gpu1.get_metrics(m_enabled, TS_1);
+
+    m_backend->gpu(0).read_bytes = 1000;
+    m_backend->gpu(1).read_bytes = 5000;
+
+    EXPECT_DOUBLE_EQ(sample(TS_2).read_bandwidth, 1000.0);
+    EXPECT_DOUBLE_EQ(gpu1.get_metrics(m_enabled, TS_2).read_bandwidth, 5000.0);
+}
+
+TEST_F(HipFileDeviceTest, inactive_gpu_reports_zeros)
+{
+    m_backend->gpu(0).read_bytes = 4096;
+
+    device_t   idle{ m_backend, 5 };
+    const auto out = idle.get_metrics(m_enabled, TS_1);
+
+    EXPECT_FALSE(out.query_failed);
+    EXPECT_EQ(out.read_bytes, 0U);
+    EXPECT_DOUBLE_EQ(out.read_bandwidth, 0.0);
+}
+
+TEST_F(HipFileDeviceTest, one_query_per_timestamp_across_devices)
+{
+    device_t gpu1{ m_backend, 1 };
+
+    sample(TS_1);
+    gpu1.get_metrics(m_enabled, TS_1);
+
+    // The devices share a backend; memoization there is what keeps an interval to one
+    // hipFile call. The device layer must not defeat it by querying out of band.
+    ASSERT_EQ(m_backend->queried_timestamps.size(), 2U);
+    EXPECT_EQ(m_backend->queried_timestamps[0], TS_1);
+    EXPECT_EQ(m_backend->queried_timestamps[1], TS_1);
+}
+
+}  // namespace
+}  // namespace rocprofsys::pmc::collectors::hipfile::testing

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/hipfile/tests/test_hipfile_traits.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/hipfile/tests/test_hipfile_traits.cpp
@@ -1,0 +1,164 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "mock_backend.hpp"
+
+#include "library/pmc/collectors/hipfile/device.hpp"
+#include "library/pmc/collectors/hipfile/hipfile_traits.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <memory>
+
+namespace rocprofsys::pmc::collectors::hipfile::testing
+{
+namespace
+{
+using device_t = device<mock_backend>;
+using traits_t = hipfile_traits<mock_provider, device_t>;
+
+/**
+ * @brief Settings stand-in, so enumeration is testable without env vars or a ROCm
+ *        runtime. Static state because the traits call these as static functions.
+ */
+struct stub_settings
+{
+    inline static device_filter   gpu_filter{};
+    inline static std::size_t     visible_gpus = 0;
+    inline static enabled_metrics hipfile_metrics{};
+
+    static void reset()
+    {
+        gpu_filter            = device_filter{};
+        gpu_filter.mode       = device_selection_mode::ALL;
+        visible_gpus          = 0;
+        hipfile_metrics.value = ALL_HIPFILE_METRICS;
+    }
+
+    static device_filter   get_gpu_device_filter() { return gpu_filter; }
+    static std::size_t     get_visible_gpu_count() { return visible_gpus; }
+    static enabled_metrics get_hipfile_enabled_metrics() { return hipfile_metrics; }
+};
+
+class HipFileTraitsTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        stub_settings::reset();
+        m_provider = std::make_shared<mock_provider>();
+    }
+
+    [[nodiscard]] auto enumerate()
+    {
+        return traits_t::enumerate_devices<stub_settings>(m_provider);
+    }
+
+    std::shared_ptr<mock_provider> m_provider;
+};
+
+TEST_F(HipFileTraitsTest, enumerates_one_device_per_visible_gpu)
+{
+    stub_settings::visible_gpus = 4;
+
+    const auto entries = enumerate();
+
+    ASSERT_EQ(entries.size(), 4U);
+    for(std::size_t i = 0; i < entries.size(); ++i)
+        EXPECT_EQ(entries[i].device->get_index(), i);
+}
+
+TEST_F(HipFileTraitsTest, gpu_zero_is_enumerated_like_any_other)
+{
+    stub_settings::visible_gpus = 2;
+
+    const auto entries = enumerate();
+
+    // GPU 0 previously carried a special case that kept it in the device set even with
+    // no activity, so that process-scoped counters had somewhere to live. Those counters
+    // are gone and GPU 0 is now ordinary.
+    ASSERT_FALSE(entries.empty());
+    EXPECT_EQ(entries.front().device->get_index(), 0U);
+    EXPECT_EQ(entries.front().supported_metrics.value, ALL_HIPFILE_METRICS);
+}
+
+TEST_F(HipFileTraitsTest, no_visible_gpus_enumerates_nothing)
+{
+    stub_settings::visible_gpus = 0;
+
+    EXPECT_TRUE(enumerate().empty());
+}
+
+TEST_F(HipFileTraitsTest, disabled_filter_enumerates_nothing)
+{
+    stub_settings::visible_gpus    = 4;
+    stub_settings::gpu_filter.mode = device_selection_mode::NONE;
+
+    EXPECT_TRUE(enumerate().empty());
+}
+
+TEST_F(HipFileTraitsTest, specific_filter_selects_requested_ordinals)
+{
+    stub_settings::visible_gpus       = 4;
+    stub_settings::gpu_filter.mode    = device_selection_mode::SPECIFIC;
+    stub_settings::gpu_filter.indices = { 1, 3 };
+
+    const auto entries = enumerate();
+
+    ASSERT_EQ(entries.size(), 2U);
+    EXPECT_EQ(entries[0].device->get_index(), 1U);
+    EXPECT_EQ(entries[1].device->get_index(), 3U);
+}
+
+TEST_F(HipFileTraitsTest, specific_filter_ignores_out_of_range_ordinals)
+{
+    stub_settings::visible_gpus       = 2;
+    stub_settings::gpu_filter.mode    = device_selection_mode::SPECIFIC;
+    stub_settings::gpu_filter.indices = { 0, 99 };
+
+    const auto entries = enumerate();
+
+    ASSERT_EQ(entries.size(), 1U);
+    EXPECT_EQ(entries[0].device->get_index(), 0U);
+}
+
+TEST_F(HipFileTraitsTest, visible_gpus_clamped_to_snapshot_capacity)
+{
+    stub_settings::visible_gpus = MAX_GPUS + 8;
+
+    const auto entries = enumerate();
+
+    // hipFile's snapshot has a fixed number of slots; enumerating past it would index
+    // out of bounds rather than report more GPUs.
+    EXPECT_EQ(entries.size(), MAX_GPUS);
+}
+
+TEST_F(HipFileTraitsTest, enabled_metrics_come_from_settings)
+{
+    stub_settings::hipfile_metrics.value           = 0U;
+    stub_settings::hipfile_metrics.bits.read_bytes = 1;
+
+    const auto enabled = traits_t::get_enabled_metrics<stub_settings>();
+
+    EXPECT_EQ(enabled.bits.read_bytes, 1U);
+    EXPECT_EQ(enabled.bits.write_bytes, 0U);
+}
+
+TEST_F(HipFileTraitsTest, get_metrics_delegates_to_device)
+{
+    stub_settings::visible_gpus            = 1;
+    m_provider->backend->gpu(0).read_bytes = 2048;
+
+    const auto entries = enumerate();
+    ASSERT_EQ(entries.size(), 1U);
+
+    enabled_metrics enabled;
+    enabled.value = ALL_HIPFILE_METRICS;
+
+    EXPECT_EQ(traits_t::get_metrics(entries[0].device, enabled, 1'000'000'000).read_bytes,
+              2048U);
+}
+
+}  // namespace
+}  // namespace rocprofsys::pmc::collectors::hipfile::testing

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/hipfile/types.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/hipfile/types.hpp
@@ -1,0 +1,152 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "backends/hipfile/types.hpp"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+namespace rocprofsys::pmc::collectors::hipfile
+{
+
+// Data types are owned by the backend layer (the producer); re-exported here so pmc
+// consumers keep their pmc::collectors::hipfile::* spellings.
+namespace backend = ::rocprofsys::backends::hipfile;
+
+using backend::gpu_stats;
+using backend::MAX_GPUS;
+using backend::stats_snapshot;
+
+/**
+ * @brief Bitfield for selecting which hipFile metrics to collect.
+ *
+ * Bit positions match the order of @c METRIC_TABLE below; @c metric_desc::bit is the
+ * single source of truth tying a metric to its bit.
+ */
+union enabled_metrics
+{
+    struct
+    {
+        std::uint32_t read_bytes       : 1;
+        std::uint32_t write_bytes      : 1;
+        std::uint32_t read_ops         : 1;
+        std::uint32_t write_ops        : 1;
+        std::uint32_t fastpath_reads   : 1;
+        std::uint32_t fastpath_writes  : 1;
+        std::uint32_t fallback_reads   : 1;
+        std::uint32_t fallback_writes  : 1;
+        std::uint32_t unaligned_reads  : 1;
+        std::uint32_t unaligned_writes : 1;
+        std::uint32_t read_errors      : 1;
+        std::uint32_t write_errors     : 1;
+        std::uint32_t read_bandwidth   : 1;
+        std::uint32_t write_bandwidth  : 1;
+    } bits;
+    std::uint32_t value = 0;
+};
+
+inline constexpr std::uint32_t HIPFILE_METRICS_COUNT = 14;
+inline constexpr std::uint32_t ALL_HIPFILE_METRICS   = (1U << HIPFILE_METRICS_COUNT) - 1U;
+
+/**
+ * @brief One per-GPU hipFile sample.
+ *
+ * The twelve counters are raw cumulative totals, reported exactly as hipFile maintains
+ * them. That matches every other byte counter in the profiler - AMD SMI's PCIe
+ * bandwidth accumulator, the XGMI accumulators, and the NIC byte counters all publish
+ * cumulative values under an ABSOLUTE value type - so a consumer reading `bytes` +
+ * ABSOLUTE gets the same thing here as it does there. Perfetto's delta view recovers
+ * the per-window signal for anyone who wants it.
+ *
+ * The two bandwidths are wall-clock rates over the sampling interval, matching AMD
+ * SMI's instantaneous PCIe bandwidth. They are deliberately not derived from hipFile's
+ * own read_bw_bytes_per_sec (lifetime-averaged, so it cannot show a burst) nor
+ * normalised by read_duration_us (time inside I/O calls, which would put a number on
+ * the timeline that does not correspond to the time axis it is drawn against).
+ */
+struct metrics
+{
+    std::uint64_t read_bytes       = 0;
+    std::uint64_t write_bytes      = 0;
+    std::uint64_t read_ops         = 0;
+    std::uint64_t write_ops        = 0;
+    std::uint64_t fastpath_reads   = 0;
+    std::uint64_t fastpath_writes  = 0;
+    std::uint64_t fallback_reads   = 0;
+    std::uint64_t fallback_writes  = 0;
+    std::uint64_t unaligned_reads  = 0;
+    std::uint64_t unaligned_writes = 0;
+    std::uint64_t read_errors      = 0;
+    std::uint64_t write_errors     = 0;
+
+    double read_bandwidth  = 0.0;  ///< bytes/sec over the sampling interval
+    double write_bandwidth = 0.0;  ///< bytes/sec over the sampling interval
+
+    /// Set when hipFile could not be queried, so the sample carries no measurement.
+    /// Default false, which is what a value-initialized `metrics{}` needs: the paused
+    /// collector emits exactly that to drop the counter tracks to zero.
+    bool query_failed = false;
+};
+
+/**
+ * @brief Describes one emitted metric: its track suffix, unit, bit, and accessor.
+ *
+ * Single source of truth for the metric set. Sampling, pause, metadata registration,
+ * and the settings parser all iterate this table, so adding a metric is a one-line
+ * change rather than an edit in four places.
+ */
+struct metric_desc
+{
+    const char*   suffix;  ///< Track name suffix, e.g. "Read Bytes"
+    const char*   unit;    ///< Matches the AMD SMI conventions: bytes, bytes/s, count
+    const char*   key;     ///< Token accepted by ROCPROFSYS_HIPFILE_METRICS
+    std::uint32_t bit;     ///< Position in enabled_metrics
+    double (*value)(const metrics&);  ///< Extractor, uniform over mixed field types
+};
+
+// Units follow the established collectors: `bytes` as AMD SMI's PCIe bandwidth
+// accumulator and the NIC byte counters use, `bytes/s` as AMD SMI's instantaneous PCIe
+// bandwidth uses, `count` as the CPU collector's context switches and page faults use.
+inline constexpr std::array<metric_desc, HIPFILE_METRICS_COUNT> METRIC_TABLE{
+    { { "Read Bytes", "bytes", "read_bytes", 0,
+        [](const metrics& m) { return static_cast<double>(m.read_bytes); } },
+      { "Write Bytes", "bytes", "write_bytes", 1,
+        [](const metrics& m) { return static_cast<double>(m.write_bytes); } },
+      { "Read Ops", "count", "read_ops", 2,
+        [](const metrics& m) { return static_cast<double>(m.read_ops); } },
+      { "Write Ops", "count", "write_ops", 3,
+        [](const metrics& m) { return static_cast<double>(m.write_ops); } },
+      { "Fastpath Reads", "count", "fastpath_reads", 4,
+        [](const metrics& m) { return static_cast<double>(m.fastpath_reads); } },
+      { "Fastpath Writes", "count", "fastpath_writes", 5,
+        [](const metrics& m) { return static_cast<double>(m.fastpath_writes); } },
+      { "Fallback Reads", "count", "fallback_reads", 6,
+        [](const metrics& m) { return static_cast<double>(m.fallback_reads); } },
+      { "Fallback Writes", "count", "fallback_writes", 7,
+        [](const metrics& m) { return static_cast<double>(m.fallback_writes); } },
+      { "Unaligned Reads", "count", "unaligned_reads", 8,
+        [](const metrics& m) { return static_cast<double>(m.unaligned_reads); } },
+      { "Unaligned Writes", "count", "unaligned_writes", 9,
+        [](const metrics& m) { return static_cast<double>(m.unaligned_writes); } },
+      { "Read Errors", "count", "read_errors", 10,
+        [](const metrics& m) { return static_cast<double>(m.read_errors); } },
+      { "Write Errors", "count", "write_errors", 11,
+        [](const metrics& m) { return static_cast<double>(m.write_errors); } },
+      { "Read Bandwidth", "bytes/s", "read_bandwidth", 12,
+        [](const metrics& m) { return m.read_bandwidth; } },
+      { "Write Bandwidth", "bytes/s", "write_bandwidth", 13,
+        [](const metrics& m) { return m.write_bandwidth; } } }
+};
+
+/// @brief Perfetto/RocPD track name for a metric on a given GPU.
+[[nodiscard]] inline std::string
+track_name(std::size_t gpu_id, const char* suffix)
+{
+    return "hipFile GPU" + std::to_string(gpu_id) + " " + suffix;
+}
+
+}  // namespace rocprofsys::pmc::collectors::hipfile

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/device_providers/hipfile/provider.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/device_providers/hipfile/provider.hpp
@@ -1,0 +1,84 @@
+// Copyright (c) Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "backends/hipfile/types.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+namespace rocprofsys::pmc::device_providers::hipfile
+{
+
+/**
+ * @brief Device provider for hipFile per-GPU telemetry.
+ *
+ * hipFile needs no enumeration API: its stats are indexed by GPU ordinal, so the
+ * provider hands out one device per requested ordinal. All devices share a single
+ * backend session, which is what lets one sampling interval cost one hipFile query
+ * and gives every device in that interval the same coherent snapshot.
+ *
+ * @tparam BackendFactory Factory for creating hipFile backend instances.
+ */
+template <typename BackendFactory>
+class provider
+{
+public:
+    using backend_t = typename BackendFactory::backend_t;
+
+    provider()
+    : m_backend(BackendFactory::create_backend())
+    {}
+
+    ~provider() = default;
+
+    provider(const provider&)            = delete;
+    provider& operator=(const provider&) = delete;
+    provider(provider&&)                 = default;
+    provider& operator=(provider&&)      = default;
+
+    /**
+     * @brief Create one device per GPU ordinal in [0, gpu_count).
+     *
+     * @param gpu_count Number of ordinals to expose; clamped to the snapshot capacity.
+     */
+    template <typename Device>
+    [[nodiscard]] std::vector<std::shared_ptr<Device>> get_devices(std::size_t gpu_count)
+    {
+        const auto slots = std::min<std::size_t>(gpu_count, backends::hipfile::MAX_GPUS);
+
+        std::vector<std::shared_ptr<Device>> devices;
+        devices.reserve(slots);
+        for(std::size_t ordinal = 0; ordinal < slots; ++ordinal)
+        {
+            devices.push_back(std::make_shared<Device>(m_backend, ordinal));
+        }
+        return devices;
+    }
+
+    void init() {}
+
+    void shutdown()
+    {
+        if(m_backend) m_backend->shutdown();
+    }
+
+private:
+    std::shared_ptr<backend_t> m_backend;
+};
+
+/**
+ * @brief Factory for creating hipFile provider instances.
+ */
+template <typename BackendFactory>
+struct provider_factory
+{
+    using provider_t = provider<BackendFactory>;
+
+    static std::shared_ptr<provider_t> create() { return std::make_shared<provider_t>(); }
+};
+
+}  // namespace rocprofsys::pmc::device_providers::hipfile

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/sampler.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/sampler.cpp
@@ -24,6 +24,16 @@
 #    include "library/pmc/collectors/nic/perfetto_policy.hpp"
 #endif
 
+#if defined(ROCPROFSYS_BUILD_HIPFILE)
+#    include "backends/hipfile/backend.hpp"
+#    include "backends/hipfile/wrapper.hpp"
+#    include "library/pmc/collectors/hipfile/cache_policy.hpp"
+#    include "library/pmc/collectors/hipfile/collector.hpp"
+#    include "library/pmc/collectors/hipfile/device.hpp"
+#    include "library/pmc/collectors/hipfile/perfetto_policy.hpp"
+#    include "library/pmc/device_providers/hipfile/provider.hpp"
+#endif
+
 #include "library/pmc/collectors/cpu/cache_policy.hpp"
 #include "library/pmc/collectors/cpu/collector.hpp"
 #include "library/pmc/collectors/cpu/perfetto_policy.hpp"
@@ -133,6 +143,25 @@ using cpu_provider_factory_t =
 using cpu_provider_t  = cpu_provider_factory_t::provider_t;
 using cpu_collector_t = collectors::cpu::collector<cpu_provider_t, cpu_production_config>;
 
+#if defined(ROCPROFSYS_BUILD_HIPFILE)
+struct hipfile_production_config
+{
+    using SettingsApi = collectors::settings_policy;
+    // hipFile counter tracks reach Perfetto through the PMC path, so the legacy
+    // per-collector Perfetto policy is a no-op rather than a second producer.
+    using PerfettoApi = collectors::hipfile::perfetto_policy;
+    using CacheApi    = collectors::hipfile::cache_policy;
+};
+
+using hipfile_provider_factory_t = device_providers::hipfile::provider_factory<
+    backends::hipfile::backend_factory<backends::hipfile::wrapper>>;
+using hipfile_provider_t = hipfile_provider_factory_t::provider_t;
+using hipfile_device_t   = collectors::hipfile::device<hipfile_provider_t::backend_t>;
+using hipfile_collector_t =
+    collectors::hipfile::collector<hipfile_provider_t, hipfile_device_t,
+                                   hipfile_production_config>;
+#endif
+
 std::shared_ptr<provider_t> g_device_provider;
 
 std::unique_ptr<gpu_collector_t> g_gpu_collector;
@@ -146,6 +175,11 @@ std::unique_ptr<nic_collector_t> g_nic_collector;
 
 std::shared_ptr<cpu_provider_t>  g_cpu_provider;
 std::unique_ptr<cpu_collector_t> g_cpu_collector;
+
+#if defined(ROCPROFSYS_BUILD_HIPFILE)
+std::shared_ptr<hipfile_provider_t>  g_hipfile_provider;
+std::unique_ptr<hipfile_collector_t> g_hipfile_collector;
+#endif
 
 std::vector<collectors::collector_slice> g_collector_slices;
 
@@ -291,6 +325,16 @@ setup()
 #endif
         }
 
+#if defined(ROCPROFSYS_BUILD_HIPFILE)
+        if(config::get_use_hipfile())
+        {
+            g_hipfile_provider = hipfile_provider_factory_t::create();
+            g_hipfile_collector =
+                std::make_unique<hipfile_collector_t>(g_hipfile_provider);
+            g_collector_slices.emplace_back(*g_hipfile_collector);
+        }
+#endif
+
         for(auto& slice : g_collector_slices)
         {
             slice.setup();
@@ -369,6 +413,10 @@ postfork_child_cleanup()
     g_gpu_collector.reset();
 #if defined(ROCPROFSYS_BUILD_AINIC)
     g_nic_collector.reset();
+#endif
+#if defined(ROCPROFSYS_BUILD_HIPFILE)
+    g_hipfile_collector.reset();
+    g_hipfile_provider.reset();
 #endif
     g_cpu_collector.reset();
     g_device_provider.reset();

--- a/projects/rocprofiler-systems/source/tests/CMakeLists.txt
+++ b/projects/rocprofiler-systems/source/tests/CMakeLists.txt
@@ -30,6 +30,8 @@ list(APPEND UNIT_TEST_OBJECTS $<TARGET_OBJECTS:pmc-gpu-collector-tests>)
 list(APPEND UNIT_TEST_OBJECTS $<TARGET_OBJECTS:pmc-nic-collector-tests>)
 list(APPEND UNIT_TEST_OBJECTS $<TARGET_OBJECTS:pmc-cpu-collector-tests>)
 list(APPEND UNIT_TEST_OBJECTS $<TARGET_OBJECTS:procfs-backend-tests>)
+list(APPEND UNIT_TEST_OBJECTS $<TARGET_OBJECTS:hipfile-backend-tests>)
+list(APPEND UNIT_TEST_OBJECTS $<TARGET_OBJECTS:pmc-hipfile-collector-tests>)
 list(
     APPEND UNIT_TEST_OBJECTS
     $<$<TARGET_EXISTS:rocprofiler-sdk-backend-tests>:$<TARGET_OBJECTS:rocprofiler-sdk-backend-tests>>

--- a/projects/rocprofiler-systems/tests/pytest/test_binaries.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_binaries.py
@@ -74,6 +74,7 @@ ENV_VAR_TO_JSON_PATH: dict[str, str] = {
     "ROCPROFSYS_AMD_SMI_METRICS": "domains.gpu.metrics",
     "ROCPROFSYS_USE_AINIC": "domains.gpu.ainic",
     "ROCPROFSYS_USE_UNIFIED_MEMORY_PROFILING": "domains.gpu.unified_memory_profiling",
+    "ROCPROFSYS_USE_HIPFILE": "domains.gpu.hipfile",
     "ROCPROFSYS_USE_PROCESS_SAMPLING": "domains.gpu.process_sampling",
     "ROCPROFSYS_PROCESS_SAMPLING_FREQ": "domains.gpu.process_sampling_freq",
     "ROCPROFSYS_PROCESS_SAMPLING_DURATION": "domains.gpu.process_sampling_duration",

--- a/projects/rocprofiler-systems/tests/pytest/test_storage_telemetry.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_storage_telemetry.py
@@ -1,0 +1,126 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+Tests for hipFile GPU-direct storage I/O telemetry.
+
+Runs the hipfile-test workload under rocprof-sys with ROCPROFSYS_USE_HIPFILE=ON
+and validates that the hipFile per-GPU I/O counters appear in the ROCPD database
+and Perfetto trace, as implemented by the hipFile PMC collector.
+
+Every hipFile track is GPU-indexed. hipFile also maintains process-scoped
+counters (file and buffer registrations), but those are not GPU measurements and
+are deliberately not collected, so no assertion here refers to them.
+
+The test is skipped automatically when rocprof-sys was not built with hipFile
+support (ROCPROFSYS_USE_HIPFILE=OFF), because the hipfile-test binary is only
+built in that configuration.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pathlib import Path
+
+from conftest import RocprofsysTest
+
+pytestmark = [pytest.mark.gpu]
+
+
+@pytest.fixture
+def hipfile_env() -> dict[str, str]:
+    """Environment enabling hipFile telemetry via process sampling."""
+    return {
+        "ROCPROFSYS_USE_HIPFILE": "ON",
+        "ROCPROFSYS_USE_PROCESS_SAMPLING": "ON",
+        # Sample frequently so the short-lived workload is captured many times.
+        "ROCPROFSYS_PROCESS_SAMPLING_FREQ": "100",
+        "ROCPROFSYS_ROCM_DOMAINS": "hip_runtime_api",
+    }
+
+
+@pytest.fixture
+def hipfile_fallback_env(hipfile_env: dict[str, str]) -> dict[str, str]:
+    """hipFile telemetry with the fastpath forced off."""
+    return {**hipfile_env, "HIPFILE_FORCE_COMPAT_MODE": "1"}
+
+
+@pytest.fixture
+def hipfile_rules(validation_rules_dir: Path) -> list[Path]:
+    """Validation rules for hipFile ROCPD output."""
+    rules_dir = validation_rules_dir / "storage-telemetry"
+    return [
+        rules_dir / "validation-rules.json",
+        rules_dir / "storage-telemetry-rules.json",
+    ]
+
+
+@pytest.mark.class_name("storage-telemetry")
+class TestStorageTelemetry(RocprofsysTest):
+    """Tests for hipFile I/O telemetry (Perfetto and ROCPD)."""
+
+    @pytest.mark.timeout(180)
+    @pytest.mark.parametrize(
+        "mode", [pytest.param("sys_run", marks=pytest.mark.rocpd("hipfile_env"))]
+    )
+    def test_telemetry(self, mode, hipfile_env, hipfile_rules):
+        """Run hipfile-test and validate hipFile counters in ROCPD + Perfetto."""
+        workload_file = self.test_output_dir / "hipfile-test.bin"
+        result = self.run_test(
+            mode,
+            "hipfile-test",
+            env=hipfile_env,
+            run_args=[str(workload_file), "0", "5"],
+        )
+        self.assert_regex(result)
+
+        if mode == "sys_run":
+            self.assert_rocpd(result, rules_files=hipfile_rules)
+            self.assert_perfetto(
+                result,
+                counter_names=[
+                    "hipFile GPU0 Read Bytes",
+                    "hipFile GPU0 Write Bytes",
+                    "hipFile GPU0 Read Ops",
+                    "hipFile GPU0 Write Ops",
+                    "hipFile GPU0 Read Bandwidth",
+                    "hipFile GPU0 Write Bandwidth",
+                ],
+                subtest_name="Perfetto hipFile counter validation",
+            )
+
+    @pytest.mark.timeout(180)
+    @pytest.mark.rocpd("hipfile_fallback_env")
+    def test_telemetry_fallback_path(self, hipfile_fallback_env, hipfile_rules):
+        """
+        Force hipFile's POSIX fallback and assert the split reflects it.
+
+        This is the only end-to-end assertion that can deterministically pin which
+        path an operation took: the fastpath needs ext4-with-ordered-journaling or
+        xfs plus O_DIRECT, none of which a test can guarantee on arbitrary CI
+        storage. Compat mode is guaranteed in the other direction, so it is what
+        proves the fastpath and fallback counters are not wired to the same source.
+        The fastpath side stays covered by the collector unit tests.
+        """
+        workload_file = self.test_output_dir / "hipfile-test-fallback.bin"
+        result = self.run_test(
+            "sys_run",
+            "hipfile-test",
+            env=hipfile_fallback_env,
+            run_args=[str(workload_file), "0", "5"],
+        )
+        self.assert_regex(result)
+
+        self.assert_rocpd(
+            result,
+            rules_files=hipfile_rules,
+            subtest_name="ROCPD hipFile fallback-path validation",
+        )
+        self.assert_perfetto(
+            result,
+            counter_names=[
+                "hipFile GPU0 Fallback Reads",
+                "hipFile GPU0 Fallback Writes",
+            ],
+            subtest_name="Perfetto hipFile fallback counter validation",
+        )

--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/storage-telemetry/storage-telemetry-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/storage-telemetry/storage-telemetry-rules.json
@@ -1,0 +1,100 @@
+{
+    "required_tables": [
+        {
+            "min_rows": 1,
+            "name_prefix": "rocpd_info_pmc",
+            "required_columns": [
+                "agent_id",
+                "target_arch",
+                "name",
+                "symbol",
+                "description",
+                "units",
+                "value_type"
+            ],
+            "validation_queries": [
+                {
+                    "comparison": "greater_than",
+                    "description": "Check for hipFile PMC metric descriptions",
+                    "error_message": "No hipFile PMC info rows found in rocpd_info_pmc",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE name LIKE 'hipFile GPU%'"
+                },
+                {
+                    "comparison": "greater_than",
+                    "description": "Check for hipFile per-GPU byte counter descriptions",
+                    "error_message": "hipFile 'Read Bytes' / 'Write Bytes' PMC info not found",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE symbol IN ('Read Bytes', 'Write Bytes')"
+                },
+                {
+                    "comparison": "greater_than",
+                    "description": "Check for the hipFile fastpath/fallback split",
+                    "error_message": "hipFile fastpath/fallback PMC info not found",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE symbol IN ('Fastpath Reads', 'Fallback Reads', 'Fastpath Writes', 'Fallback Writes')"
+                },
+                {
+                    "comparison": "equals",
+                    "description": "Check hipFile byte counters carry the same units as the other byte metrics",
+                    "error_message": "hipFile byte counters are not registered with units 'bytes'",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE symbol IN ('Read Bytes', 'Write Bytes') AND units != 'bytes'"
+                },
+                {
+                    "comparison": "equals",
+                    "description": "Check hipFile bandwidth carries the same units as PCIe instantaneous bandwidth",
+                    "error_message": "hipFile bandwidth is not registered with units 'bytes/s'",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE symbol IN ('Read Bandwidth', 'Write Bandwidth') AND units != 'bytes/s'"
+                },
+                {
+                    "comparison": "equals",
+                    "description": "Check no process-scoped hipFile counters are registered",
+                    "error_message": "hipFile process-scoped registration counters are still being registered; they were removed because they are not GPU measurements",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE symbol IN ('File Registrations', 'Buffer Registrations')"
+                }
+            ]
+        },
+        {
+            "min_rows": 1,
+            "name_prefix": "rocpd_pmc_event",
+            "required_columns": [
+                "event_id",
+                "pmc_id",
+                "value"
+            ],
+            "validation_queries": [
+                {
+                    "comparison": "greater_than",
+                    "description": "Check for hipFile PMC counter events in trace",
+                    "error_message": "No hipFile PMC events found in rocpd_pmc_event",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} event JOIN rocpd_info_pmc info ON event.pmc_id = info.id WHERE info.name LIKE 'hipFile GPU%'"
+                },
+                {
+                    "comparison": "greater_than",
+                    "description": "Check that at least one hipFile byte counter is non-zero",
+                    "error_message": "Every hipFile byte counter was zero: rows exist but no I/O was actually measured",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} event JOIN rocpd_info_pmc info ON event.pmc_id = info.id WHERE info.symbol IN ('Read Bytes', 'Write Bytes') AND event.value > 0"
+                },
+                {
+                    "comparison": "greater_than",
+                    "description": "Check that at least one hipFile operation counter is non-zero",
+                    "error_message": "Every hipFile operation counter was zero: no read or write operations were attributed to a GPU",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} event JOIN rocpd_info_pmc info ON event.pmc_id = info.id WHERE info.symbol IN ('Read Ops', 'Write Ops') AND event.value > 0"
+                },
+                {
+                    "comparison": "equals",
+                    "description": "Check hipFile byte counters never decrease between non-zero samples",
+                    "error_message": "A hipFile byte counter decreased between samples; the counters are published cumulative, so a drop means per-interval deltas were emitted instead",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM (SELECT event.value AS value, LAG(event.value) OVER (PARTITION BY event.pmc_id ORDER BY event.event_id) AS previous FROM {table_name} event JOIN rocpd_info_pmc info ON event.pmc_id = info.id WHERE info.symbol IN ('Read Bytes', 'Write Bytes') AND event.value > 0) WHERE previous IS NOT NULL AND value < previous"
+                }
+            ]
+        }
+    ]
+}

--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/storage-telemetry/validation-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/storage-telemetry/validation-rules.json
@@ -1,0 +1,25 @@
+{
+    "required_tables": [
+        {
+            "min_rows": 1,
+            "name": "rocpd_info_agent",
+            "required_columns": [
+                "id",
+                "guid",
+                "nid",
+                "pid",
+                "type",
+                "name"
+            ],
+            "validation_queries": [
+                {
+                    "comparison": "greater_than",
+                    "description": "Check that GPU agents are detected",
+                    "error_message": "No GPU agents found",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM rocpd_info_agent WHERE type = 'GPU'"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Motivation

ROCm Systems Profiler should be able to provide storage telemetry — letting users correlate file/buffer registrations, read/write throughput, fast-path vs. fallback usage, and I/O errors with GPU and application activity in a single Perfetto trace or RocPD database. This is increasingly important for GPU-direct storage workloads where the storage path is a common performance bottleneck that was previously invisible in the profiler.

Depends on:

- [ ]  https://github.com/ROCm/rocm-systems/pull/8252
- [ ] https://github.com/ROCm/rocm-systems/pull/9584

Todo:

- [ ] Ensure version gating for hipFile public API on 

## Technical Details

- **New optional hipfile backend** `(source/lib/backends/hipfile/`) that links libhipfile via the hip::hipfile imported target (consistent with how amd_smi and other ROCm libraries are consumed) and wraps hipFile's in-process hipFileGetStatsL3 query.
- **New PMC collector** (`pmc/collectors/hipfile/collector.hpp`) modeled on the AMD-SMI GPU collector. Because hipFile exposes a single process-wide call (rather than per-device enumeration), the collector snapshots hipFileGetStatsL3 once per sampling interval and emits per-GPU counters.
- **Metrics reported per GPU** (as `hipFile GPU<N> <metric>`tracks): read/write bytes, read/write bandwidth, total/fastpath/fallback/unaligned read & write op counts, and read/write errors; plus two process-global counters (file and buffer registrations) reported on GPU 0.
- **Per-interval deltas, not cumulative totals** — the collector keeps the previous snapshot and reports the change per interval (with reset-guarding); bandwidth is recomputed each interval as delta(bytes) / delta(duration) rather than delta-ing hipFile's lifetime average.
- Output via the existing `pmc_event_with_sample` path — no new trace-cache sample type or processor vtable changes. Added a hipfile category and a corresponding entry in the perfetto processor's PMC_TRACK_MAP so counters land in both Perfetto counter tracks and RocPD PMC tables.
- **Build-time gating**: new `ROCPROFSYS_USE_HIPFILE` CMake option (default OFF); find_package(hipfile) is optional, so builds against ROCm versions without hipFile degrade gracefully (no hard dependency). `ROCPROFSYS_BUILD_HIPFILE` drives conditional compilation.
- **Runtime gating**: new `ROCPROFSYS_USE_HIPFILE` setting (default disabled) drives the collector on the process-sampling thread; the collector auto-sets HIPFILE_STATS_LEVEL=1 in the target (without overriding a user-set value). Zero overhead when disabled or when the target doesn't use hipFile.
- **Automation test**: added a hipfile-test example workload (looped registration + read/write, adapted from hipFile's examples) plus tests/pytest/test_hipfile.py and RocPD validation rules, registered as the ctest hipfile-telemetry-sys-run; validates the counters in both RocPD and Perfetto (ctest -R hipfile).
- **Docs + changelog**: new how-to `docs/how-to/hipfile-telemetry.rs`t (wired into both TOCs) and a CHANGELOG.md entry under the unreleased 1.8.0 section.

## JIRA ID

Jira ID: 

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<img width="2474" height="1348" alt="image" src="https://github.com/user-attachments/assets/ccd51280-b74b-46d3-85de-7c3adfcdde2e" />

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
