### PR TITLE
fix(rdc): address CPX review feedback and SPX partition-count quirk

### DIFF
--- a/projects/rdc/include/rdc_modules/rdc_rocp/RdcRocpBase.h
+++ b/projects/rdc/include/rdc_modules/rdc_rocp/RdcRocpBase.h
@@ -81,13 +81,15 @@ class RdcRocpBase {
  private:
   typedef std::pair<uint32_t, rdc_field_t> rdc_field_pair_t;
   /**
-   * @brief Tweak this to change for how long each metric is collected
+   * @brief Tweak this to change for how long each metric is collected.
+   * Widened from 10ms to 100ms: eval fields are counter rates divided by this fixed
+   * window, and the wider window averages out per-XCC dispatch jitter for a stable reading.
    */
   static const uint32_t collection_duration_us_k = 100000;
 
   /**
    * @brief SIMD_UTILIZATION is a derived metric (SQ_BUSY_CU_CYCLES/GRBM_COUNT/CU_NUM).
-   * The 10ms default window is too short for workloads with multi-second compute/idle
+   * Even the 100ms default window is too short for workloads with multi-second compute/idle
    * cycles and produces oscillating 0/0.2/0.4 readings. 500ms averages across those
    * cycles and matches the stable value reported by direct rocprofiler kernel tracing.
    */

--- a/projects/rdc/rdc_libs/rdc/src/RdcGroupSettingsImpl.cc
+++ b/projects/rdc/rdc_libs/rdc/src/RdcGroupSettingsImpl.cc
@@ -87,8 +87,9 @@ rdc_status_t RdcGroupSettingsImpl::rdc_group_gpu_add(rdc_gpu_group_t groupId, ui
   rdc_entity_info_t entity_info = rdc_get_info_from_entity_index(gpu_index);
 
   uint16_t num_partitions = 0;
-  rdc_status_t status =
-      partition_->rdc_get_num_partition_impl(entity_info.device_index, &num_partitions);
+  // Pass the full entity index so the partition helper resolves the correct socket for
+  // CPX partition instances (entity_info.device_index alone is only the socket index).
+  rdc_status_t status = partition_->rdc_get_num_partition_impl(gpu_index, &num_partitions);
   if (status != RDC_ST_OK) {
     RDC_LOG(RDC_ERROR, "rdc_group_gpu_add: get_num_partition failed for gpu_index="
                            << gpu_index << " device_index=" << entity_info.device_index

--- a/projects/rdc/rdc_libs/rdc/src/RdcMetricFetcherImpl.cc
+++ b/projects/rdc/rdc_libs/rdc/src/RdcMetricFetcherImpl.cc
@@ -786,8 +786,14 @@ rdc_status_t RdcMetricFetcherImpl::fetch_gpu_field_(uint32_t gpu_index, rdc_fiel
     case RDC_FI_GPU_COUNT: {
       const auto& table = get_flat_gpu_table();
       value->type = INTEGER;
-      value->status = AMDSMI_STATUS_SUCCESS;
-      value->value.l_int = static_cast<int64_t>(table.size());
+      // An empty table means SMI init / socket enumeration failed; surface that as an
+      // error instead of silently reporting a count of 0.
+      if (table.empty()) {
+        value->status = AMDSMI_STATUS_NOT_INIT;
+      } else {
+        value->status = AMDSMI_STATUS_SUCCESS;
+        value->value.l_int = static_cast<int64_t>(table.size());
+      }
     } break;
     case RDC_FI_GPU_PARTITION_COUNT: {
       uint32_t partition_count = 0;
@@ -1337,7 +1343,9 @@ rdc_status_t RdcMetricFetcherImpl::fetch_gpu_partition_field_(uint32_t gpu_index
                                                               rdc_field_value* value) {
   rdc_entity_info_t info = rdc_get_info_from_entity_index(gpu_index);
   uint16_t num_partitions = 0;
-  amdsmi_status_t st = get_num_partition(info.device_index, &num_partitions);
+  // Pass the full entity index so get_num_partition resolves the correct socket for CPX
+  // partition instances (info.device_index alone is only the socket index).
+  amdsmi_status_t st = get_num_partition(gpu_index, &num_partitions);
   if (st != AMDSMI_STATUS_SUCCESS) {
     RDC_LOG(RDC_ERROR, "Failed to get partition info for device " << info.device_index);
     return RDC_ST_UNKNOWN_ERROR;

--- a/projects/rdc/rdc_libs/rdc/src/SmiUtils.cc
+++ b/projects/rdc/rdc_libs/rdc/src/SmiUtils.cc
@@ -86,6 +86,10 @@ rdc_status_t Smi2RdcError(amdsmi_status_t rsmi) {
 // flat index where a socket index is expected.
 amdsmi_status_t get_processor_handle_from_id(uint32_t gpu_id,
                                              amdsmi_processor_handle* processor_handle) {
+  if (processor_handle == nullptr) {
+    return AMDSMI_STATUS_INVAL;
+  }
+
   const auto& table = get_flat_gpu_table();
   rdc_entity_info_t info = rdc_get_info_from_entity_index(gpu_id);
 
@@ -239,14 +243,26 @@ amdsmi_status_t get_num_partition(uint32_t index, uint16_t* num_partition) {
     return AMDSMI_STATUS_INVAL;
   }
 
-  // Use flat table to find the physical GPU (first processor in the socket)
+  // Decode the entity index so both bare flat indices and partition-instance entity
+  // indices resolve to the right socket (they diverge in CPX). See the dual-index note
+  // on get_processor_handle_from_id().
   const auto& table = get_flat_gpu_table();
-  if (index >= table.size()) {
-    return AMDSMI_STATUS_INPUT_OUT_OF_BOUNDS;
+  rdc_entity_info_t info = rdc_get_info_from_entity_index(index);
+
+  uint32_t target_socket = 0;
+  if (info.entity_role == RDC_DEVICE_ROLE_PHYSICAL && info.instance_index == 0) {
+    // Physical/instance-0: device_index is a flat index into the GPU table.
+    uint32_t flat_idx = info.device_index;
+    if (flat_idx >= table.size()) {
+      return AMDSMI_STATUS_INPUT_OUT_OF_BOUNDS;
+    }
+    target_socket = table[flat_idx].socket_index;
+  } else {
+    // Partition-instance: device_index is the socket index.
+    target_socket = info.device_index;
   }
 
   // Find the first processor in the same socket to query the physical GPU profile.
-  uint32_t target_socket = table[index].socket_index;
   amdsmi_processor_handle phys_handle = nullptr;
   for (const auto& entry : table) {
     if (entry.socket_index == target_socket) {
@@ -277,6 +293,21 @@ amdsmi_status_t get_num_partition(uint32_t index, uint16_t* num_partition) {
 
   if (partition_id != 0) {
     return AMDSMI_STATUS_UNEXPECTED_DATA;
+  }
+
+  // Some driver/amdsmi versions return the current profile with num_partitions set to an
+  // invalid sentinel (e.g. UINT32_MAX) even though the call succeeds. Fall back to the flat
+  // table, which enumerates exactly one entry per partition in a socket, so the count stays
+  // consistent with the rest of RDC's GPU view.
+  if (profile.num_partitions == 0 || profile.num_partitions > RDC_MAX_NUM_PARTITIONS) {
+    uint16_t socket_entries = 0;
+    for (const auto& entry : table) {
+      if (entry.socket_index == target_socket) {
+        socket_entries++;
+      }
+    }
+    *num_partition = socket_entries;
+    return AMDSMI_STATUS_SUCCESS;
   }
 
   *num_partition = profile.num_partitions;

--- a/projects/rdc/rdc_libs/rdc_modules/rdc_rocp/RdcRocpBase.cc
+++ b/projects/rdc/rdc_libs/rdc_modules/rdc_rocp/RdcRocpBase.cc
@@ -193,6 +193,17 @@ rdc_status_t RdcRocpBase::map_entity_to_profiler() {
         RDC_LOG(RDC_DEBUG, "Flat[" << flat_idx << "] <-> Profiler[" << prof_index << "] = KFD_ID["
                                    << prof_id << "]");
         entity_to_prof_map.insert({flat_idx, prof_index});
+
+        // Downstream telemetry may key lookups by the encoded partition-instance entity
+        // index (gS.P) rather than the bare flat index. Register that key too so CPX
+        // partition entities resolve. In SPX the two coincide and the duplicate insert is
+        // a no-op.
+        rdc_entity_info_t part_info{};
+        part_info.device_index = flat_table[flat_idx].socket_index;
+        part_info.instance_index = flat_table[flat_idx].proc_index;
+        part_info.entity_role = RDC_DEVICE_ROLE_PARTITION_INSTANCE;
+        uint32_t encoded_idx = rdc_get_entity_index_from_info(part_info);
+        entity_to_prof_map.insert({encoded_idx, prof_index});
         break;
       }
     }


### PR DESCRIPTION
Targets `users/dgalants/rdc-cpx-and-profiler-sample-time` to fold into #8526.

## Summary

Addresses the Copilot review comments on #8526 plus an amdsmi SPX quirk found while validating on MI308X:

- `SmiUtils::get_processor_handle_from_id`: reject a null out-pointer (comment 1).
- `SmiUtils::get_num_partition`: decode the entity index so both bare flat indices and CPX partition-instance entity indices resolve to the right socket; callers in `RdcMetricFetcherImpl` and `RdcGroupSettingsImpl` now pass the full entity index instead of `info.device_index` (comments 2/4/5).
- `RdcMetricFetcherImpl` `RDC_FI_GPU_COUNT`: surface an SMI error instead of silently reporting 0 when the flat GPU table is empty (comment 3).
- `RdcRocpBase::map_entity_to_profiler`: also register the encoded partition-instance entity index so CPX partition lookups resolve (comment 6).
- `RdcRocpBase.h`: correct the stale "10ms default window" comment (low-confidence note).
- `get_num_partition` robustness: some drivers return the current accelerator partition profile with `num_partitions` set to `UINT32_MAX` in SPX even on success; fall back to the flat-table socket count.

## Test plan

Validated on MI308X (ROCm 7.2.1), built with `-DBUILD_PROFILER=ON -DBUILD_TESTS=ON`:

- [x] `rdc_codec_tests`: 5/5 pass.
- [x] `rdc_unit_tests` (hardware): 7/7 pass in SPX (`get_num_partition`=1/socket) and CPX (`get_num_partition`=4/socket).
- [x] `rdci discovery`: 8 GPUs in SPX, 32 in CPX.
- [x] `rdci dmon` FLOPS_32: attributes only to the loaded GPU (SPX, ~27.5 GFLOP/ms) / partition (CPX partition 0, ~6.8 GFLOP/ms), stable across samples, with no `entity_to_prof_map` lookup errors.

Fixes for #8529.

Signed-off-by: Brian Chang <brichang@amd.com>