### PR TITLE
Add IFH null-submit and gfx1250 ASIC-revision masquerade for hardware-free hotswap profiling

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
@@ -312,6 +312,13 @@ class AqlQueue : public core::Queue, private core::LocalSignal, public core::Doo
   /// @brief Fill queue properties
   void GetInfoProperties(uint8_t value[8]) const;
 
+  /// @brief IFH (In-Function Hardware) null-submit support. Instead of ringing
+  /// the doorbell, walk the packets the caller just enqueued and complete each
+  /// packet's completion signal on the host so waiters make progress without
+  /// the GPU executing anything. Host-side profiling aid only (enabled via
+  /// HSA_ENABLE_IFH); kernels never run so results are meaningless.
+  void CompleteSubmittedPacketsIFH();
+
   // AQL packet ring buffer
   void* ring_buf_;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -479,7 +479,57 @@ uint64_t AqlQueue::AddWriteIndexRelease(uint64_t value) {
                      std::memory_order_release);
 }
 
+void AqlQueue::CompleteSubmittedPacketsIFH() {
+  core::AqlPacket* ring =
+      reinterpret_cast<core::AqlPacket*>(amd_queue_.hsa_queue.base_address);
+  const uint32_t size = amd_queue_.hsa_queue.size;
+  if (ring == nullptr || size == 0) {
+    return;
+  }
+  const uint32_t mask = size - 1;
+
+  const uint64_t write = atomic::Load(&amd_queue_.write_dispatch_id, std::memory_order_acquire);
+  uint64_t read = atomic::Load(&amd_queue_.read_dispatch_id, std::memory_order_relaxed);
+
+  for (; read < write; ++read) {
+    const core::AqlPacket& pkt = ring[read & mask];
+    const uint16_t header = pkt.packet.header;
+    if (!core::AqlPacket::IsValid(header)) {
+      continue;
+    }
+
+    // Every 64-byte AQL packet the runtime places on the ring carries its
+    // completion_signal in the last 8 bytes (offset 56): kernel dispatch,
+    // barrier-and/or, agent dispatch, ext kernel dispatch, and AMD
+    // vendor-specific packets such as the PM4 IB packet emitted by
+    // ExecutePM4() during queue/scratch setup. Read it generically -- missing
+    // the PM4 IB packet leaves ExecutePM4's ACTIVE wait spinning forever, which
+    // hangs queue initialization under IFH. dispatch.completion_signal aliases
+    // that offset for all of these packet layouts.
+    const hsa_signal_t completion = pkt.dispatch.completion_signal;
+
+    if (completion.handle != 0) {
+      core::Signal* signal = core::Signal::Convert(completion);
+      if (signal != nullptr) {
+        signal->SubRelease(1);
+      }
+    }
+  }
+
+  // Mark every submitted packet as consumed so the queue looks drained, exactly
+  // as the GPU would advance the read index after executing them.
+  atomic::Store(&amd_queue_.read_dispatch_id, write, std::memory_order_release);
+}
+
 void AqlQueue::StoreRelaxed(hsa_signal_value_t value) {
+  if (core::Runtime::runtime_singleton_->flag().enable_ifh()) {
+    // IFH null-submit: skip the doorbell entirely and complete the just-enqueued
+    // packets on the host so waiters unblock without any GPU execution. This is
+    // a host-side profiling aid, not a correctness path.
+    CompleteSubmittedPacketsIFH();
+    return;
+  }
+
   if (core::Runtime::runtime_singleton_->thunkLoader()->IsDTIF() ||
         core::Runtime::runtime_singleton_->thunkLoader()->IsDXG()) {
     HSAKMT_CALL(hsaKmtQueueRingDoorbell(queue_id_, value));

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
@@ -398,6 +398,20 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitCommand(const void* cmd, size_
                                              const std::vector<core::Signal*>& dep_signals,
                                              core::Signal& out_signal,
                                              std::vector<core::Signal*>& gang_signals) {
+  if (core::Runtime::runtime_singleton_->flag().enable_ifh()) {
+    // IFH null-submit: do not build/submit any SDMA commands. Complete the
+    // copy's completion signal (and any gang signals) on the host so waiters
+    // unblock without moving any data. Host-side profiling aid only -- the copy
+    // does not actually happen, so destination contents are meaningless.
+    out_signal.SubRelease(1);
+    for (core::Signal* gang_signal : gang_signals) {
+      if (gang_signal != nullptr) {
+        gang_signal->SubRelease(1);
+      }
+    }
+    return HSA_STATUS_SUCCESS;
+  }
+
   uint32_t num_poll_command = 0;
   uint32_t num_poll_signals = 0;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap_gfx_query.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap_gfx_query.cpp
@@ -45,13 +45,47 @@
 #include <algorithm>
 #include <cctype>
 #include <cstddef>
+#include <cstdlib>
 #include <mutex>
+#include <string>
 #include <unordered_map>
 
 #include "core/inc/hsa_internal.h"
+#include "core/util/os.h"
 
 namespace rocr {
 namespace hotswap {
+
+namespace {
+
+// GPU masquerading: allow the reported gfx target / ASIC revision that feeds
+// the hotswap rewrite decision to be overridden via environment variables. This
+// lets the B0->A0 rewrite path (and its host-side load/rewrite cost) be
+// exercised on hardware that does not actually report gfx1250 A0 -- e.g. for
+// host-side profiling on a B0 box or an emulation backend. It only affects the
+// hotswap decision; nothing else in the runtime observes the faked values.
+void ApplyMasqueradeOverrides(AgentGfxRevision& revision) {
+  if (os::IsEnvVarSet("HSA_HOTSWAP_FORCE_GFX")) {
+    std::string forced = os::GetEnvVar("HSA_HOTSWAP_FORCE_GFX");
+    if (!forced.empty()) {
+      revision.gfx_target = forced;
+    }
+  }
+
+  if (os::IsEnvVarSet("HSA_HOTSWAP_FORCE_ASIC_REVISION")) {
+    std::string forced = os::GetEnvVar("HSA_HOTSWAP_FORCE_ASIC_REVISION");
+    if (!forced.empty()) {
+      char* end = nullptr;
+      const unsigned long parsed = std::strtoul(forced.c_str(), &end, 10);
+      if (end != forced.c_str()) {
+        revision.asic_revision = static_cast<uint32_t>(parsed);
+        revision.has_asic_revision = true;
+      }
+    }
+  }
+}
+
+}  // namespace
 
 std::string GetAgentIsaName(hsa_agent_t agent) {
   std::string name;
@@ -134,6 +168,8 @@ AgentGfxRevision GetAgentGfxRevision(hsa_agent_t agent) {
     revision.asic_revision = asic_revision;
     revision.has_asic_revision = true;
   }
+
+  ApplyMasqueradeOverrides(revision);
 
   {
     std::scoped_lock lock(g_agent_gfx_revision_cache_mutex);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
@@ -313,6 +313,16 @@ class Flag {
     var = os::GetEnvVar("HSA_ENABLE_DTIF");
     enable_dtif_ = (var == "1") ? true : false;
 
+    // In-Function Hardware (IFH) null-submit mode. When enabled, packet
+    // submissions (compute dispatch doorbells and blit copies) are not sent to
+    // the GPU; instead the runtime completes each packet's completion signal on
+    // the host so waiters make progress. This is a host-side profiling aid (it
+    // isolates code-object load / hotswap-rewrite cost from real kernel
+    // execution) and is NOT a correctness path: kernels never run, so any
+    // computed results are meaningless. Disabled unless HSA_ENABLE_IFH=1.
+    var = os::GetEnvVar("HSA_ENABLE_IFH");
+    enable_ifh_ = (var == "1") ? true : false;
+
     // This allows detecting if the dxg driver is loaded.
     var = os::GetEnvVar("HSA_ENABLE_DXG_DETECTION");
     enable_dxg_detection_ = (var == "0") ? false : true;
@@ -489,6 +499,8 @@ class Flag {
 
   bool enable_dtif() const { return enable_dtif_; }
 
+  bool enable_ifh() const { return enable_ifh_; }
+
   bool enable_dxg_detection() const { return enable_dxg_detection_; }
 
   SDMA_OVERRIDE sdma_linear_b2b() const { return sdma_linear_b2b_; }
@@ -573,6 +585,7 @@ class Flag {
   int  async_events_thread_priority_;
   bool enable_3d_swizzle_ = false;
   bool enable_dtif_;
+  bool enable_ifh_ = false;
   bool enable_dxg_detection_;
   SDMA_OVERRIDE sdma_linear_b2b_ = SDMA_DEFAULT;
 


### PR DESCRIPTION
## What is it
Two opt-in, env-gated runtime knobs that let you exercise and profile the gfx1250 hotswap
code-object rewrite paths (including the B0 entry-trampoline path) on A0 hardware, with no B0
silicon:

- **IFH (In-Function Hardware) null-submit** — instead of ringing the GPU doorbell, the host
  completes each AQL/SDMA packet's `completion_signal` itself (generic offset-56 read, so it also
  covers the PM4 IB packet used during queue setup) and advances the read index. Code objects load,
  parse, and rewrite to completion without any GPU execution.
- **ASIC masquerade** — overrides the reported gfx1250 stepping / gfx target so the hotswap decision
  selects the desired rewrite path (A0 b0a0-downgrade vs B0 entry-trampoline).

Both are off by default: no behavior change unless explicitly enabled.

## How to build
Standard rocr-runtime build; produces `libhsa-runtime64.so`:

```bash
cmake -G Ninja -S projects/rocr-runtime -B build \
  -DCMAKE_BUILD_TYPE=Release \
  -DCMAKE_PREFIX_PATH="<rocm-llvm-dist>/lib/llvm;<rocm-llvm-dist>" \
  -DBUILD_SHARED_LIBS=ON
ninja -C build
```

Then point the app at the built library (overlay via `LD_LIBRARY_PATH`, ahead of the system ROCr):

```bash
export LD_LIBRARY_PATH=<build>/lib:$LD_LIBRARY_PATH
```

## How to use
Enable via environment variables:

| Env var | Values | Purpose |
|---|---|---|
| `HSA_ENABLE_IFH` | `1` | Complete fences on the host; never submit to the GPU |
| `HSA_HOTSWAP_FORCE_ASIC_REVISION` | `0`=A0, `1`=B0 | Fake the reported stepping (selects the rewrite path) |
| `HSA_HOTSWAP_FORCE_GFX` | e.g. `gfx1250` | Force the reported gfx target |

Example — profile the B0 entry-trampoline rewrite on an A0 box:

```bash
HSA_ENABLE_IFH=1 \
HSA_HOTSWAP_FORCE_ASIC_REVISION=1 HSA_HOTSWAP_FORCE_GFX=gfx1250 \
AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES=1 \
<your workload>
```

**Notes:** IFH runs no kernels, so numeric results are invalid (correctness tests fail as expected)
and workloads that spin on device-computed data will hang — this is for load/parse/rewrite
profiling, not execution. Masquerade only affects gfx1250.
