### PR TITLE
feat(ci): Move rocr runtime WSL build and nvidia build into component-ci

### DIFF
--- a/.github/scripts/configure_component_ci.py
+++ b/.github/scripts/configure_component_ci.py
@@ -1,0 +1,89 @@
+"""
+Determines which component CI jobs to run based on the GitHub event type
+and the files changed in the pull request or push.
+"""
+
+import logging
+import os
+import re
+import subprocess
+from typing import Mapping
+
+logging.basicConfig(level=logging.INFO)
+
+
+def set_github_output(d: Mapping[str, str]):
+    """Sets GITHUB_OUTPUT values.
+    See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/passing-information-between-jobs
+    """
+    logging.info(f"Setting github output:\n{d}")
+    step_output_file = os.environ.get("GITHUB_OUTPUT", "")
+    if not step_output_file:
+        logging.warning(
+            "Warning: GITHUB_OUTPUT env var not set, can't set github outputs"
+        )
+        return
+    with open(step_output_file, "a") as f:
+        f.writelines(f"{k}={v}" + "\n" for k, v in d.items())
+
+
+def get_changed_files(base_ref: str) -> list[str]:
+    result = subprocess.run(
+        ["git", "diff", "--name-only", base_ref],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.splitlines()
+
+
+def matches_any(files: list[str], pattern: str) -> bool:
+    regex = re.compile(pattern)
+    return any(regex.search(f) for f in files)
+
+
+def main():
+    event_name = os.environ.get("GITHUB_EVENT_NAME", "")
+    base_ref = os.environ.get("BASE_REF", "HEAD^")
+
+    nvidia = False
+    wsl = False
+    hip_contract_tests = False
+
+    if event_name == "workflow_dispatch":
+        nvidia = True
+        wsl = True
+        hip_contract_tests = True
+    else:
+        changed_files = get_changed_files(base_ref)
+        logging.info("Changed files:\n" + "\n".join(changed_files))
+
+        if matches_any(
+            changed_files,
+            r"^projects/(clr|hip|hip-tests|hipother)/|^\.github/workflows/(component-ci|hip-nvidia-ci)\.yml",
+        ):
+            nvidia = True
+
+        if matches_any(
+            changed_files,
+            r"^projects/(rocr-runtime|clr|hip|hip-tests)/|^\.github/workflows/(component-ci|rocr-runtime-wsl)\.yml|^shared/amdgpu-windows-interop/wkmi",
+        ):
+            wsl = True
+
+        if matches_any(
+            changed_files,
+            r"^projects/hip/include/hip/|^projects/hip-tests/catch/(contract|tools)/|^projects/hip-tests/catch/config/configs/contract\.yaml|^projects/hip-tests/catch/TEST_PLAN\.md|^\.github/workflows/(component-ci|hip-contract-coverage)\.yml",
+        ):
+            hip_contract_tests = True
+
+    set_github_output(
+        {
+            "nvidia": str(nvidia).lower(),
+            "wsl": str(wsl).lower(),
+            "hip-contract-tests": str(hip_contract_tests).lower(),
+        }
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/configure_component_ci.py
+++ b/.github/scripts/configure_component_ci.py
@@ -3,9 +3,9 @@ Determines which component CI jobs to run based on the GitHub event type
 and the files changed in the pull request or push.
 """
 
+import fnmatch
 import logging
 import os
-import re
 import subprocess
 from typing import Mapping
 
@@ -27,6 +27,38 @@ def set_github_output(d: Mapping[str, str]):
         f.writelines(f"{k}={v}" + "\n" for k, v in d.items())
 
 
+NVIDIA_PATTERNS = [
+    "projects/clr/*",
+    "projects/hip/*",
+    "projects/hip-tests/*",
+    "projects/hipother/*",
+    ".github/workflows/component-ci.yml",
+    ".github/workflows/hip-nvidia-ci.yml",
+]
+
+WSL_PATTERNS = [
+    "projects/rocr-runtime/*",
+    "projects/clr/*",
+    "projects/hip/*",
+    "projects/hip-tests/*",
+    "shared/amdgpu-windows-interop/wkmi*",
+    ".github/workflows/component-ci.yml",
+    ".github/workflows/rocr-runtime-wsl.yml",
+]
+
+HIP_CONTRACT_TESTS_PATTERNS = [
+    "projects/hip/include/hip/*",
+    "projects/hip-tests/catch/contract/*",
+    "projects/hip-tests/catch/tools/*",
+    "projects/hip-tests/catch/config/configs/contract.yaml",
+    "projects/hip-tests/catch/TEST_PLAN.md",
+    ".github/workflows/component-ci.yml",
+    ".github/workflows/hip-contract-coverage.yml",
+]
+
+ALL_JOBS = {"nvidia", "wsl", "hip-contract-tests"}
+
+
 def get_changed_files(base_ref: str) -> list[str]:
     result = subprocess.run(
         ["git", "diff", "--name-only", base_ref],
@@ -37,9 +69,8 @@ def get_changed_files(base_ref: str) -> list[str]:
     return result.stdout.splitlines()
 
 
-def matches_any(files: list[str], pattern: str) -> bool:
-    regex = re.compile(pattern)
-    return any(regex.search(f) for f in files)
+def matches_any(files: list[str], patterns: list[str]) -> bool:
+    return any(fnmatch.fnmatch(f, pattern) for f in files for pattern in patterns)
 
 
 def main():
@@ -51,30 +82,18 @@ def main():
     hip_contract_tests = False
 
     if event_name == "workflow_dispatch":
-        nvidia = True
-        wsl = True
-        hip_contract_tests = True
+        dispatch_jobs = os.environ.get("WORKFLOW_DISPATCH_JOBS", "all").strip()
+        requested = ALL_JOBS if dispatch_jobs == "all" else set(dispatch_jobs.split())
+        nvidia = "nvidia" in requested
+        wsl = "wsl" in requested
+        hip_contract_tests = "hip-contract-tests" in requested
     else:
         changed_files = get_changed_files(base_ref)
         logging.info("Changed files:\n" + "\n".join(changed_files))
 
-        if matches_any(
-            changed_files,
-            r"^projects/(clr|hip|hip-tests|hipother)/|^\.github/workflows/(component-ci|hip-nvidia-ci)\.yml",
-        ):
-            nvidia = True
-
-        if matches_any(
-            changed_files,
-            r"^projects/(rocr-runtime|clr|hip|hip-tests)/|^\.github/workflows/(component-ci|rocr-runtime-wsl)\.yml|^shared/amdgpu-windows-interop/wkmi",
-        ):
-            wsl = True
-
-        if matches_any(
-            changed_files,
-            r"^projects/hip/include/hip/|^projects/hip-tests/catch/(contract|tools)/|^projects/hip-tests/catch/config/configs/contract\.yaml|^projects/hip-tests/catch/TEST_PLAN\.md|^\.github/workflows/(component-ci|hip-contract-coverage)\.yml",
-        ):
-            hip_contract_tests = True
+        nvidia = matches_any(changed_files, NVIDIA_PATTERNS)
+        wsl = matches_any(changed_files, WSL_PATTERNS)
+        hip_contract_tests = matches_any(changed_files, HIP_CONTRACT_TESTS_PATTERNS)
 
     set_github_output(
         {

--- a/.github/scripts/tests/configure_component_ci_test.py
+++ b/.github/scripts/tests/configure_component_ci_test.py
@@ -1,0 +1,215 @@
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, os.fspath(Path(__file__).parent.parent))
+import configure_component_ci
+
+
+class WorkflowDispatchTest(unittest.TestCase):
+    def _run(self, dispatch_jobs):
+        env = {
+            "GITHUB_EVENT_NAME": "workflow_dispatch",
+            "WORKFLOW_DISPATCH_JOBS": dispatch_jobs,
+        }
+        with patch.dict(os.environ, env), patch(
+            "configure_component_ci.set_github_output"
+        ) as mock_output:
+            configure_component_ci.main()
+            return mock_output.call_args[0][0]
+
+    def test_all_runs_everything(self):
+        out = self._run("all")
+        self.assertEqual(out["nvidia"], "true")
+        self.assertEqual(out["wsl"], "true")
+        self.assertEqual(out["hip-contract-tests"], "true")
+
+    def test_single_job(self):
+        out = self._run("nvidia")
+        self.assertEqual(out["nvidia"], "true")
+        self.assertEqual(out["wsl"], "false")
+        self.assertEqual(out["hip-contract-tests"], "false")
+
+    def test_subset_of_jobs(self):
+        out = self._run("wsl hip-contract-tests")
+        self.assertEqual(out["nvidia"], "false")
+        self.assertEqual(out["wsl"], "true")
+        self.assertEqual(out["hip-contract-tests"], "true")
+
+    def test_empty_input_runs_nothing(self):
+        out = self._run("")
+        self.assertEqual(out["nvidia"], "false")
+        self.assertEqual(out["wsl"], "false")
+        self.assertEqual(out["hip-contract-tests"], "false")
+
+
+class NvidiaPatternTest(unittest.TestCase):
+    def _run(self, changed_files):
+        with patch(
+            "configure_component_ci.get_changed_files", return_value=changed_files
+        ), patch("configure_component_ci.set_github_output") as mock_output, patch.dict(
+            os.environ, {"GITHUB_EVENT_NAME": "pull_request"}
+        ):
+            configure_component_ci.main()
+            return mock_output.call_args[0][0]
+
+    def test_clr_change_triggers_nvidia(self):
+        self.assertEqual(self._run(["projects/clr/src/main.cpp"])["nvidia"], "true")
+
+    def test_hip_change_triggers_nvidia(self):
+        self.assertEqual(
+            self._run(["projects/hip/src/hip_runtime.cpp"])["nvidia"], "true"
+        )
+
+    def test_hip_tests_change_triggers_nvidia(self):
+        self.assertEqual(
+            self._run(["projects/hip-tests/catch/unit/test_hip.cpp"])["nvidia"], "true"
+        )
+
+    def test_hipother_change_triggers_nvidia(self):
+        self.assertEqual(
+            self._run(["projects/hipother/src/hipother.cpp"])["nvidia"], "true"
+        )
+
+    def test_hip_nvidia_ci_workflow_triggers_nvidia(self):
+        self.assertEqual(
+            self._run([".github/workflows/hip-nvidia-ci.yml"])["nvidia"], "true"
+        )
+
+    def test_unrelated_change_does_not_trigger_nvidia(self):
+        self.assertEqual(
+            self._run(["projects/rocminfo/src/main.cpp"])["nvidia"], "false"
+        )
+
+
+class WslPatternTest(unittest.TestCase):
+    def _run(self, changed_files):
+        with patch(
+            "configure_component_ci.get_changed_files", return_value=changed_files
+        ), patch("configure_component_ci.set_github_output") as mock_output, patch.dict(
+            os.environ, {"GITHUB_EVENT_NAME": "pull_request"}
+        ):
+            configure_component_ci.main()
+            return mock_output.call_args[0][0]
+
+    def test_rocr_runtime_change_triggers_wsl(self):
+        self.assertEqual(
+            self._run(["projects/rocr-runtime/src/runtime.cpp"])["wsl"], "true"
+        )
+
+    def test_wkmi_change_triggers_wsl(self):
+        self.assertEqual(
+            self._run(["shared/amdgpu-windows-interop/wkmi/src/wkmi.cpp"])["wsl"],
+            "true",
+        )
+
+    def test_rocr_runtime_wsl_workflow_triggers_wsl(self):
+        self.assertEqual(
+            self._run([".github/workflows/rocr-runtime-wsl.yml"])["wsl"], "true"
+        )
+
+    def test_unrelated_change_does_not_trigger_wsl(self):
+        self.assertEqual(
+            self._run(["projects/rocminfo/src/main.cpp"])["wsl"], "false"
+        )
+
+
+class HipContractTestsPatternTest(unittest.TestCase):
+    def _run(self, changed_files):
+        with patch(
+            "configure_component_ci.get_changed_files", return_value=changed_files
+        ), patch("configure_component_ci.set_github_output") as mock_output, patch.dict(
+            os.environ, {"GITHUB_EVENT_NAME": "pull_request"}
+        ):
+            configure_component_ci.main()
+            return mock_output.call_args[0][0]
+
+    def test_hip_include_change_triggers_contract_tests(self):
+        self.assertEqual(
+            self._run(["projects/hip/include/hip/hip_runtime.h"])[
+                "hip-contract-tests"
+            ],
+            "true",
+        )
+
+    def test_catch_contract_change_triggers_contract_tests(self):
+        self.assertEqual(
+            self._run(["projects/hip-tests/catch/contract/test_contract.cpp"])[
+                "hip-contract-tests"
+            ],
+            "true",
+        )
+
+    def test_catch_tools_change_triggers_contract_tests(self):
+        self.assertEqual(
+            self._run(["projects/hip-tests/catch/tools/tool.py"])[
+                "hip-contract-tests"
+            ],
+            "true",
+        )
+
+    def test_contract_yaml_triggers_contract_tests(self):
+        self.assertEqual(
+            self._run(["projects/hip-tests/catch/config/configs/contract.yaml"])[
+                "hip-contract-tests"
+            ],
+            "true",
+        )
+
+    def test_test_plan_md_triggers_contract_tests(self):
+        self.assertEqual(
+            self._run(["projects/hip-tests/catch/TEST_PLAN.md"])[
+                "hip-contract-tests"
+            ],
+            "true",
+        )
+
+    def test_hip_contract_coverage_workflow_triggers_contract_tests(self):
+        self.assertEqual(
+            self._run([".github/workflows/hip-contract-coverage.yml"])[
+                "hip-contract-tests"
+            ],
+            "true",
+        )
+
+    def test_unrelated_change_does_not_trigger_contract_tests(self):
+        self.assertEqual(
+            self._run(["projects/rocminfo/src/main.cpp"])["hip-contract-tests"],
+            "false",
+        )
+
+
+class OverlapTest(unittest.TestCase):
+    """Files that appear in multiple pattern lists should trigger multiple jobs."""
+
+    def _run(self, changed_files):
+        with patch(
+            "configure_component_ci.get_changed_files", return_value=changed_files
+        ), patch("configure_component_ci.set_github_output") as mock_output, patch.dict(
+            os.environ, {"GITHUB_EVENT_NAME": "pull_request"}
+        ):
+            configure_component_ci.main()
+            return mock_output.call_args[0][0]
+
+    def test_clr_triggers_both_nvidia_and_wsl(self):
+        out = self._run(["projects/clr/src/main.cpp"])
+        self.assertEqual(out["nvidia"], "true")
+        self.assertEqual(out["wsl"], "true")
+
+    def test_component_ci_workflow_triggers_all_jobs(self):
+        out = self._run([".github/workflows/component-ci.yml"])
+        self.assertEqual(out["nvidia"], "true")
+        self.assertEqual(out["wsl"], "true")
+        self.assertEqual(out["hip-contract-tests"], "true")
+
+    def test_empty_diff_triggers_nothing(self):
+        out = self._run([])
+        self.assertEqual(out["nvidia"], "false")
+        self.assertEqual(out["wsl"], "false")
+        self.assertEqual(out["hip-contract-tests"], "false")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/component-ci.yml
+++ b/.github/workflows/component-ci.yml
@@ -1,0 +1,91 @@
+name: Component CI
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+  push:
+    branches:
+      - develop
+      - release/therock-*
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    name: "Configure CI"
+    runs-on: ubuntu-24.04
+    env:
+      BASE_REF: HEAD^
+    outputs:
+      nvidia: ${{ steps.configure.outputs.nvidia }}
+      wsl: ${{ steps.configure.outputs.wsl }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 2
+
+      - name: Detect changed components
+        id: configure
+        run: |
+          NVIDIA=false
+          WSL=false
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            NVIDIA=true
+            WSL=true
+          else
+            CHANGED_FILES=$(git diff --name-only "${BASE_REF}")
+            echo "Changed files:"
+            echo "${CHANGED_FILES}"
+
+            if echo "${CHANGED_FILES}" | grep -qE '^projects/(clr|hip|hip-tests|hipother)/|^\.github/workflows/(component-ci|hip-nvidia-ci)\.yml'; then
+              NVIDIA=true
+            fi
+
+            if echo "${CHANGED_FILES}" | grep -qE '^projects/(rocr-runtime|clr|hip|hip-tests)/|^\.github/workflows/(component-ci|rocr-runtime-wsl)\.yml|^shared/amdgpu-windows-interop/wkmi'; then
+              WSL=true
+            fi
+          fi
+
+          echo "nvidia=${NVIDIA}" >> "${GITHUB_OUTPUT}"
+          echo "wsl=${WSL}" >> "${GITHUB_OUTPUT}"
+
+  nvidia:
+    name: "NVIDIA"
+    needs: changes
+    if: ${{ needs.changes.outputs.nvidia == 'true' }}
+    uses: ./.github/workflows/hip-nvidia-ci.yml
+
+  wsl:
+    name: "WSL"
+    needs: changes
+    if: ${{ needs.changes.outputs.wsl == 'true' }}
+    uses: ./.github/workflows/rocr-runtime-wsl.yml
+
+  component-ci-summary:
+    name: "Component CI Summary"
+    if: always()
+    needs: [changes, nvidia, wsl]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check results
+        run: |
+          echo '${{ toJson(needs) }}'
+          FAILED_JOBS="$(echo '${{ toJson(needs) }}' \
+            | jq --raw-output \
+            'map_values(select(.result != "success" and .result != "skipped")) | keys | join(",")'
+          )"
+          if [[ "${FAILED_JOBS}" != "" ]]; then
+            echo "The following jobs failed: ${FAILED_JOBS}"
+            exit 1
+          fi

--- a/.github/workflows/component-ci.yml
+++ b/.github/workflows/component-ci.yml
@@ -2,6 +2,11 @@ name: Component CI
 
 on:
   workflow_dispatch:
+    inputs:
+      jobs:
+        type: string
+        description: "Space-separated list of jobs to run, or 'all'. ex: 'nvidia wsl hip-contract-tests'"
+        default: "all"
   pull_request:
     types:
       - opened
@@ -39,6 +44,7 @@ jobs:
         id: configure
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_DISPATCH_JOBS: ${{ inputs.jobs }}
         run: python .github/scripts/configure_component_ci.py
 
   nvidia-build:

--- a/.github/workflows/component-ci.yml
+++ b/.github/workflows/component-ci.yml
@@ -37,38 +37,11 @@ jobs:
 
       - name: Detect changed components
         id: configure
-        run: |
-          NVIDIA=false
-          WSL=false
-          HIP_CONTRACT_TESTS=false
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+        run: python .github/scripts/configure_component_ci.py
 
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            NVIDIA=true
-            WSL=true
-            HIP_CONTRACT_TESTS=true
-          else
-            CHANGED_FILES=$(git diff --name-only "${BASE_REF}")
-            echo "Changed files:"
-            echo "${CHANGED_FILES}"
-
-            if echo "${CHANGED_FILES}" | grep -qE '^projects/(clr|hip|hip-tests|hipother)/|^\.github/workflows/(component-ci|hip-nvidia-ci)\.yml'; then
-              NVIDIA=true
-            fi
-
-            if echo "${CHANGED_FILES}" | grep -qE '^projects/(rocr-runtime|clr|hip|hip-tests)/|^\.github/workflows/(component-ci|rocr-runtime-wsl)\.yml|^shared/amdgpu-windows-interop/wkmi'; then
-              WSL=true
-            fi
-
-            if echo "${CHANGED_FILES}" | grep -qE '^projects/hip/include/hip/|^projects/hip-tests/catch/(contract|tools)/|^projects/hip-tests/catch/config/configs/contract\.yaml|^projects/hip-tests/catch/TEST_PLAN\.md|^\.github/workflows/(component-ci|hip-contract-coverage)\.yml'; then
-              HIP_CONTRACT_TESTS=true
-            fi
-          fi
-
-          echo "nvidia=${NVIDIA}" >> "${GITHUB_OUTPUT}"
-          echo "wsl=${WSL}" >> "${GITHUB_OUTPUT}"
-          echo "hip-contract-tests=${HIP_CONTRACT_TESTS}" >> "${GITHUB_OUTPUT}"
-
-  nvidia:
+  nvidia-build:
     name: "NVIDIA"
     needs: changes
     if: ${{ needs.changes.outputs.nvidia == 'true' }}

--- a/.github/workflows/component-ci.yml
+++ b/.github/workflows/component-ci.yml
@@ -28,6 +28,7 @@ jobs:
     outputs:
       nvidia: ${{ steps.configure.outputs.nvidia }}
       wsl: ${{ steps.configure.outputs.wsl }}
+      hip-contract-tests: ${{ steps.configure.outputs.hip-contract-tests }}
     steps:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -39,10 +40,12 @@ jobs:
         run: |
           NVIDIA=false
           WSL=false
+          HIP_CONTRACT_TESTS=false
 
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             NVIDIA=true
             WSL=true
+            HIP_CONTRACT_TESTS=true
           else
             CHANGED_FILES=$(git diff --name-only "${BASE_REF}")
             echo "Changed files:"
@@ -55,10 +58,15 @@ jobs:
             if echo "${CHANGED_FILES}" | grep -qE '^projects/(rocr-runtime|clr|hip|hip-tests)/|^\.github/workflows/(component-ci|rocr-runtime-wsl)\.yml|^shared/amdgpu-windows-interop/wkmi'; then
               WSL=true
             fi
+
+            if echo "${CHANGED_FILES}" | grep -qE '^projects/hip/include/hip/|^projects/hip-tests/catch/(contract|tools)/|^projects/hip-tests/catch/config/configs/contract\.yaml|^projects/hip-tests/catch/TEST_PLAN\.md|^\.github/workflows/(component-ci|hip-contract-coverage)\.yml'; then
+              HIP_CONTRACT_TESTS=true
+            fi
           fi
 
           echo "nvidia=${NVIDIA}" >> "${GITHUB_OUTPUT}"
           echo "wsl=${WSL}" >> "${GITHUB_OUTPUT}"
+          echo "hip-contract-tests=${HIP_CONTRACT_TESTS}" >> "${GITHUB_OUTPUT}"
 
   nvidia:
     name: "NVIDIA"
@@ -72,10 +80,16 @@ jobs:
     if: ${{ needs.changes.outputs.wsl == 'true' }}
     uses: ./.github/workflows/rocr-runtime-wsl.yml
 
+  hip-contract-tests:
+    name: "HIP contract tests"
+    needs: changes
+    if: ${{ needs.changes.outputs.hip-contract-tests == 'true' }}
+    uses: ./.github/workflows/hip-contract-coverage.yml
+
   component-ci-summary:
     name: "Component CI Summary"
     if: always()
-    needs: [changes, nvidia, wsl]
+    needs: [changes, nvidia, wsl, hip-contract-tests]
     runs-on: ubuntu-24.04
     steps:
       - name: Check results

--- a/.github/workflows/hip-contract-coverage.yml
+++ b/.github/workflows/hip-contract-coverage.yml
@@ -21,6 +21,7 @@ name: HIP contract-test coverage
 # test and keep all gates current.
 
 on:
+  workflow_call:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:

--- a/.github/workflows/hip-contract-coverage.yml
+++ b/.github/workflows/hip-contract-coverage.yml
@@ -17,6 +17,7 @@ name: HIP contract-test coverage
 # test and keep both current.
 
 on:
+  workflow_call:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:

--- a/.github/workflows/hip-nvidia-ci.yml
+++ b/.github/workflows/hip-nvidia-ci.yml
@@ -5,61 +5,15 @@
 name: HIP NVIDIA CI
 
 on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-  push:
-    branches:
-      - develop
-      - release/therock-*
+  workflow_call:
   workflow_dispatch:
 
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
-  cancel-in-progress: true
-
 jobs:
-  nvidia-clr-build-setup:
-    name: "Setup"
-    runs-on: ubuntu-24.04
-    env:
-      BASE_REF: HEAD^
-    outputs:
-      should_build: ${{ steps.check_paths.outputs.should_build }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          fetch-depth: 2
-
-      - name: Check if relevant paths changed
-        id: check_paths
-        run: |
-          SHOULD_BUILD=false
-
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            SHOULD_BUILD=true;
-          else
-            CHANGED_FILES=$(git diff --name-only "${BASE_REF}")
-            echo "Changed files:"
-            echo "${CHANGED_FILES}"
-            if echo "${CHANGED_FILES}" | grep -qE '^projects/(clr|hip|hip-tests|hipother)/|^\.github/workflows/hip-nvidia-ci\.yml'; then
-              SHOULD_BUILD=true
-            else
-              echo "No changes in clr/hip/hip-tests/hipother — skipping NVIDIA build"
-            fi
-          fi
-          echo "should_build=${SHOULD_BUILD}" >> "${GITHUB_OUTPUT}"
-
   nvidia-clr-build:
     name: "Build clr + hip-tests (NVIDIA)"
-    needs: nvidia-clr-build-setup
-    if: ${{ needs.nvidia-clr-build-setup.outputs.should_build == 'true' }}
     runs-on: azure-linux-scale-rocm
     container:
       # CUDA 13.2.0 devel Ubuntu 24.04
@@ -133,7 +87,7 @@ jobs:
   nvidia-clr-build-ci-summary:
     name: "HIP NVIDIA CI Summary"
     if: always()
-    needs: [nvidia-clr-build-setup, nvidia-clr-build]
+    needs: [nvidia-clr-build]
     runs-on: ubuntu-24.04
     steps:
       - name: Check results

--- a/.github/workflows/hip-nvidia-ci.yml
+++ b/.github/workflows/hip-nvidia-ci.yml
@@ -84,20 +84,3 @@ jobs:
       - name: Build hip-tests
         run: cmake --build "${BUILD_DIR}/hip-tests" --parallel
 
-  nvidia-clr-build-ci-summary:
-    name: "HIP NVIDIA CI Summary"
-    if: always()
-    needs: [nvidia-clr-build]
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Check results
-        run: |
-          echo '${{ toJson(needs) }}'
-          FAILED_JOBS="$(echo '${{ toJson(needs) }}' \
-            | jq --raw-output \
-            'map_values(select(.result != "success" and .result != "skipped")) | keys | join(",")'
-          )"
-          if [[ "${FAILED_JOBS}" != "" ]]; then
-            echo "The following jobs failed: ${FAILED_JOBS}"
-            exit 1
-          fi

--- a/.github/workflows/rocr-runtime-wsl.yml
+++ b/.github/workflows/rocr-runtime-wsl.yml
@@ -1,25 +1,8 @@
 name: ROCR Runtime WSL
 
 on:
+  workflow_call:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - "projects/rocr-runtime/**"
-      - "projects/clr/**"
-      - "projects/hip/**"
-      - "projects/hip-tests/**"
-      - ".github/workflows/rocr-runtime-wsl.yml"
-      - "shared/amdgpu-windows-interop/wkmi"
-  push:
-    branches:
-      - develop
-    paths:
-      - "projects/rocr-runtime/**"
-      - "projects/clr/**"
-      - "projects/hip/**"
-      - "projects/hip-tests/**"
-      - ".github/workflows/rocr-runtime-wsl.yml"
-      - "shared/amdgpu-windows-interop/wkmi"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Motivation
The ROCr runtime WSL Test is not currently a hard requirement for PRs impacting CLR or ROCr runtime projects. This allows for WSL path breaking code to [be merged into develop](https://github.com/ROCm/rocm-systems/issues/8340). With inclusion of the WSL ROCDXG in TheRock, we want to make it required
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Adds a new component-ci pipeline, which will include current path-based workflows (ROCr runtime WSL Test and HIP NVidia build) as its internal steps.
After merging, component-CI will replace NVidia pipeline as a required one
<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
NA
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
HIP Nvidia and ROCr Runtime WSL Test should run as steps within a single Component CI job and pass as expected.
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
Waiting for PSDB
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
