### PR TITLE
fix(rocshmem): wave-broadcast tester fails on GDA backend

### DIFF
--- a/projects/rocshmem/tests/functional_tests/tester_arguments.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester_arguments.cpp
@@ -207,6 +207,7 @@ TesterArguments::TesterArguments(int argc, char *argv[]) {
     case TeamAllToAllTestType:
     case TeamAllToAllvTestType:
     case TeamBroadcastTestType:
+    case BroadcastWaveTestType:
       min_msg_size = 8;
       break;
     case TeamCtxInfraTestType:


### PR DESCRIPTION
## Motivation

CI failed: gfx90a mlx5

## Technical Details

min_msg_size for functional tester must be 8 so num_elems >= 1. 

## JIRA ID

JIRA ID: AIROCSHMEM-454

## Test Plan

Run functional test on CI node, check for pass.

## Test Result

All tests pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
