### PR TITLE
fix(libhsakmt): Define _GNU_SOURCE before libhsakmt.h include

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/hsakmtmodel.c
+++ b/projects/rocr-runtime/libhsakmt/src/hsakmtmodel.c
@@ -30,7 +30,6 @@
 #include "libhsakmt.h"
 #include "hsakmt/hsakmttypes.h"
 #include "hsakmt/hsakmtmodeliface.h"
-#define __USE_GNU
 #include <assert.h>
 #include <errno.h>
 #include <inttypes.h>

--- a/projects/rocr-runtime/libhsakmt/src/hsakmtmodel.c
+++ b/projects/rocr-runtime/libhsakmt/src/hsakmtmodel.c
@@ -23,9 +23,10 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
+#define _GNU_SOURCE
+
 #include "hsakmt/hsakmtmodel.h"
 #include "hsakmt/hsakmt_drm.h"
-#define _GNU_SOURCE
 #include "libhsakmt.h"
 #include "hsakmt/hsakmttypes.h"
 #include "hsakmt/hsakmtmodeliface.h"

--- a/projects/rocr-runtime/libhsakmt/src/hsakmtmodel.c
+++ b/projects/rocr-runtime/libhsakmt/src/hsakmtmodel.c
@@ -25,10 +25,10 @@
 
 #include "hsakmt/hsakmtmodel.h"
 #include "hsakmt/hsakmt_drm.h"
+#define _GNU_SOURCE
 #include "libhsakmt.h"
 #include "hsakmt/hsakmttypes.h"
 #include "hsakmt/hsakmtmodeliface.h"
-#define _GNU_SOURCE
 #define __USE_GNU
 #include <assert.h>
 #include <errno.h>


### PR DESCRIPTION
## Summary

Move `#define _GNU_SOURCE` to the top of `hsakmtmodel.c`, before all includes, and remove the redundant `#define __USE_GNU`. `_GNU_SOURCE` must be defined before any system header is pulled in; `hsakmtmodel.h`, `hsakmt_drm.h`, and `libhsakmt.h` all transitively include libc/drm headers. Defining it after those includes breaks GNU extension visibility (e.g. `secure_getenv`) and causes compile errors in strict or sanitizer builds.

## JIRA ID

JIRA ID : ROCM-26861

## Test plan

Tested on **dayatsin-test-01** (Ubuntu 24.04, amdclang 23.0.0 from `/opt/rocm`), including after removing `__USE_GNU` (`c651d3f278`):

- [x] Build `libhsakmt` / `rocr-runtime` with ASAN enabled (`-DADDRESS_SANITIZER=ON -DTHEROCK_SANITIZER=ASAN`) — full build succeeded (`libhsa-runtime64.so` produced)
- [x] Build with amdclang from TheRock/ROCm toolchain — Release `hsakmt` target succeeded
- [x] Verify `hsakmtmodel.c` compiles without `_GNU_SOURCE` ordering warnings/errors — no errors in either ASAN or Release builds