### PR TITLE
Make DDA LL kernels HIP graph-capture safe

### DIFF
--- a/projects/rccl/src/dda_all_gather_fabric_ll.cu
+++ b/projects/rccl/src/dda_all_gather_fabric_ll.cu
@@ -10,6 +10,7 @@
 #include "algorithms/all_gather/all_gather_dda_fabric_ll.h"
 #include "checks.h"
 #include "comm.h"
+#include "dda_init_detail.h" // nccl_dda_detail::kDdaLLAgMaxBlocksPerPeer
 #include "debug.h"
 #include "fabric_gpu_barrier.h" // meta::comms::kDdaMaxNranks
 
@@ -23,6 +24,7 @@ namespace {
 using meta::comms::kDdaLLAgMaxPerRankBytes;
 using meta::comms::kDdaLLAgSlotStridePkts;
 using meta::comms::LLPacket16;
+using nccl_dda_detail::kDdaLLAgMaxBlocksPerPeer;
 
 // LL scratch: 2 banks * nRanks slots * kDdaLLAgSlotStridePkts * 16B.
 static inline size_t ddaLLAgScratchSize(int nRanks) {
@@ -35,8 +37,7 @@ static inline size_t ddaLLAgScratchSize(int nRanks) {
 //   blocksPerPeer = clamp(ceil(nPk / kDdaLLAgPktsPerBlock), 1, cap)
 //
 // 256 pkts/block is one packet per thread at 256 threads.
-constexpr size_t kDdaLLAgPktsPerBlock     = 256;
-constexpr int    kDdaLLAgMaxBlocksPerPeer = 8;
+constexpr size_t kDdaLLAgPktsPerBlock = 256;
 
 // Blocks per peer for a given per-rank payload.
 static inline int ddaLLAgBlocksPerPeer(size_t perRankBytes) {
@@ -60,15 +61,6 @@ static ncclResult_t ncclAllGatherDdaFabricLLTyped(
     cudaStream_t stream) {
   const int nRanks = comm->nRanks;
   const size_t perRankBytes = sendcount * sizeof(T);
-  const size_t bankStridePkts = (size_t)nRanks * kDdaLLAgSlotStridePkts;
-
-  // Epoch is uniform across ranks and blocks; never 0 (0 == cleared scratch).
-  uint32_t epoch = ++comm->ddaLLEpoch;
-  if (epoch == 0) {
-    epoch = comm->ddaLLEpoch = 1;
-  }
-  const uint32_t flag = epoch;
-  const size_t bankOffsetPkts = (size_t)(flag & 1u) * bankStridePkts;
 
   // grid.x == nRanks (peer), grid.y == blocksPerPeer (packet split, 1 for small
   // messages).
@@ -78,28 +70,30 @@ static ncclResult_t ncclAllGatherDdaFabricLLTyped(
   dim3 grid((unsigned)nRanks, (unsigned)blocksPerPeer);
 
   T** peers = reinterpret_cast<T**>(comm->ddaPeerPtrsDev);
+  uint32_t* epochDev = comm->ddaLLEpochDev;
+  const int epochLen = comm->ddaLLEpochLen;
 
   INFO(
       NCCL_COLL,
-      "DDA fabric AllGather LL: nRanks=%d perRankBytes=%zu grid=%ux%u block=%u epoch=%u (block-per-peer, bpp=%d)",
-      nRanks, perRankBytes, grid.x, grid.y, block.x, flag, blocksPerPeer);
+      "DDA fabric AllGather LL: nRanks=%d perRankBytes=%zu grid=%ux%u block=%u (block-per-peer, bpp=%d)",
+      nRanks, perRankBytes, grid.x, grid.y, block.x, blocksPerPeer);
 
   // NRANKS_CT 4/8: unrolled; 0: runtime fallback.
   switch (nRanks) {
   case 4:
     meta::comms::ddaAllGatherFabricLL<T, 4><<<grid, block, 0, stream>>>(
         peers, static_cast<T*>(recvbuff), static_cast<const T*>(sendbuff),
-        perRankBytes, comm->rank, nRanks, flag, bankOffsetPkts);
+        perRankBytes, comm->rank, nRanks, epochDev, epochLen);
     break;
   case 8:
     meta::comms::ddaAllGatherFabricLL<T, 8><<<grid, block, 0, stream>>>(
         peers, static_cast<T*>(recvbuff), static_cast<const T*>(sendbuff),
-        perRankBytes, comm->rank, nRanks, flag, bankOffsetPkts);
+        perRankBytes, comm->rank, nRanks, epochDev, epochLen);
     break;
   default:
     meta::comms::ddaAllGatherFabricLL<T, 0><<<grid, block, 0, stream>>>(
         peers, static_cast<T*>(recvbuff), static_cast<const T*>(sendbuff),
-        perRankBytes, comm->rank, nRanks, flag, bankOffsetPkts);
+        perRankBytes, comm->rank, nRanks, epochDev, epochLen);
     break;
   }
 

--- a/projects/rccl/src/dda_all_reduce_fabric_ll.cu
+++ b/projects/rccl/src/dda_all_reduce_fabric_ll.cu
@@ -42,15 +42,6 @@ static ncclResult_t ncclAllReduceDdaFabricLLTyped(
   const int nRanks = comm->nRanks;
   const size_t bytes = count * sizeof(T);
   const size_t nPk = bytes >> 3; // 8 payload bytes per packet
-  const size_t bankStridePkts = (size_t)nRanks * kDdaLLArSlotStridePkts;
-
-  // Epoch is uniform across ranks and blocks; never 0 (0 == cleared scratch).
-  uint32_t epoch = ++comm->ddaLLEpoch;
-  if (epoch == 0) {
-    epoch = comm->ddaLLEpoch = 1;
-  }
-  const uint32_t flag = epoch;
-  const size_t bankOffsetPkts = (size_t)(flag & 1u) * bankStridePkts;
 
   const unsigned threads = 256;
   int nBlocksMax = comm->ddaFabricMaxBlocks;
@@ -66,11 +57,13 @@ static ncclResult_t ncclAllReduceDdaFabricLLTyped(
   dim3 grid(blocks);
 
   T** peers = reinterpret_cast<T**>(comm->ddaPeerPtrsDev);
+  uint32_t* epochDev = comm->ddaLLEpochDev;
+  const int epochLen = comm->ddaLLEpochLen;
 
   INFO(
       NCCL_COLL,
-      "DDA fabric AllReduce LL: nRanks=%d bytes=%zu nPk=%zu grid=%u block=%u epoch=%u",
-      nRanks, bytes, nPk, grid.x, block.x, flag);
+      "DDA fabric AllReduce LL: nRanks=%d bytes=%zu nPk=%zu grid=%u block=%u",
+      nRanks, bytes, nPk, grid.x, block.x);
 
   // NRANKS_CT 4/8: unrolled reduce loop; 0: runtime fallback (up to
   // kDdaMaxNranks).
@@ -78,17 +71,17 @@ static ncclResult_t ncclAllReduceDdaFabricLLTyped(
   case 4:
     meta::comms::ddaAllReduceFlatLL<T, 4><<<grid, block, 0, stream>>>(
         peers, static_cast<T*>(recvbuff), static_cast<const T*>(sendbuff),
-        count, comm->rank, nRanks, flag, bankOffsetPkts);
+        count, comm->rank, nRanks, epochDev, epochLen);
     break;
   case 8:
     meta::comms::ddaAllReduceFlatLL<T, 8><<<grid, block, 0, stream>>>(
         peers, static_cast<T*>(recvbuff), static_cast<const T*>(sendbuff),
-        count, comm->rank, nRanks, flag, bankOffsetPkts);
+        count, comm->rank, nRanks, epochDev, epochLen);
     break;
   default:
     meta::comms::ddaAllReduceFlatLL<T, 0><<<grid, block, 0, stream>>>(
         peers, static_cast<T*>(recvbuff), static_cast<const T*>(sendbuff),
-        count, comm->rank, nRanks, flag, bankOffsetPkts);
+        count, comm->rank, nRanks, epochDev, epochLen);
     break;
   }
 

--- a/projects/rccl/src/fabric_init.cu
+++ b/projects/rccl/src/fabric_init.cu
@@ -22,6 +22,7 @@
 
 using meta::comms::kDdaMaxNranks;
 using nccl_dda_detail::ddaFabricMaxNBlocksForScratch;
+using nccl_dda_detail::ddaLLEpochCount;
 using nccl_dda_detail::DdaFabricBarrierState;
 
 bool ncclDdaUseFabricPath(ncclComm* comm) {
@@ -67,8 +68,10 @@ ncclResult_t ncclDdaFabricCommInit(ncclComm* comm) {
   ncclFabricMemHandler* handler = nullptr;
   void* peerDev = nullptr;
   DdaFabricBarrierState* barrierState = nullptr;
+  uint32_t* epochDev = nullptr;
   std::vector<void*> h_ptrs(nRanks, nullptr);
   const int nBlocksMax = ddaFabricMaxNBlocksForScratch();
+  const size_t epochLen = ddaLLEpochCount(nRanks, nBlocksMax);
   ncclResult_t res = ncclSuccess;
 
   res = ncclCuMemAlloc(
@@ -131,6 +134,13 @@ ncclResult_t ncclDdaFabricCommInit(ncclComm* comm) {
   // 2-bank layout rather than re-zeroing.
   CUDACHECKGOTO(cudaMemset(scratch, 0, bytes), res, fail);
 
+  // Device epoch cells for the LL collectives: zero-initialised
+  // so the first device-derived flag is 1. Bumped on the device every LL launch.
+  CUDACHECKGOTO(
+      cudaMalloc(&epochDev, epochLen * sizeof(uint32_t)), res, fail);
+  CUDACHECKGOTO(
+      cudaMemset(epochDev, 0, epochLen * sizeof(uint32_t)), res, fail);
+
   // Success: hand ownership of every resource to comm.
   comm->ddaFabricMemHandler = handler;
   comm->ddaScratch = scratch;
@@ -139,7 +149,8 @@ ncclResult_t ncclDdaFabricCommInit(ncclComm* comm) {
   comm->ddaPeerPtrsDev = peerDev;
   comm->ddaFabricBarrierState = barrierState;
   comm->ddaFabricMaxBlocks = nBlocksMax;
-  comm->ddaLLEpoch = 0;
+  comm->ddaLLEpochDev = epochDev;
+  comm->ddaLLEpochLen = (int)epochLen;
   INFO(
       NCCL_INIT,
       "ncclDdaFabricCommInit: nRanks %d, scratch %zu bytes (vmm), FabricGpuBarrier nBlocks=%d, peer table on device",
@@ -151,6 +162,9 @@ ncclResult_t ncclDdaFabricCommInit(ncclComm* comm) {
 fail:
   if (barrierState != nullptr) {
     delete barrierState;
+  }
+  if (epochDev != nullptr) {
+    CUDACHECKIGNORE(cudaFree(epochDev));
   }
   if (peerDev != nullptr) {
     CUDACHECKIGNORE(cudaFree(peerDev));
@@ -174,6 +188,9 @@ ncclResult_t ncclDdaFabricCommFini(ncclComm* comm) {
   }
   CUDACHECKIGNORE(cudaFree(comm->ddaPeerPtrsDev));
   comm->ddaPeerPtrsDev = nullptr;
+  CUDACHECKIGNORE(cudaFree(comm->ddaLLEpochDev));
+  comm->ddaLLEpochDev = nullptr;
+  comm->ddaLLEpochLen = 0;
   // Destroying the fabric handler unmaps/frees the imported peer scratch buffers.
   if (comm->ddaFabricMemHandler != nullptr) {
     delete static_cast<ncclFabricMemHandler*>(comm->ddaFabricMemHandler);

--- a/projects/rccl/src/include/algorithms/all_gather/all_gather_dda_fabric_ll.h
+++ b/projects/rccl/src/include/algorithms/all_gather/all_gather_dda_fabric_ll.h
@@ -52,8 +52,8 @@ __global__ void ddaAllGatherFabricLL(
     size_t perRankBytes,                   // per-rank payload; multiple of 16
     int selfRank,
     int nRanksRt,
-    uint32_t flag,                         // == epoch; never 0
-    size_t bankOffsetPkts) {               // (epoch & 1) * nRanks * slotStride
+    uint32_t* __restrict__ epochDev,       // per-block LL epoch cells
+    int epochLen) {                        // number of cells in epochDev
 
   const int nRanks = NRANKS_CT ? NRANKS_CT : nRanksRt;
   const int peer = blockIdx.x;             // grid.x == nRanks: one column/peer
@@ -65,14 +65,29 @@ __global__ void ddaAllGatherFabricLL(
   const size_t nPk = perRankBytes >> 3;    // 8 payload bytes per packet
   const size_t slot = kDdaLLAgSlotStridePkts;
 
+  // Flat block id + total launched blocks. tid 0 reads our own epoch cell (all
+  // cells hold the same value) and derives this launch's flag on the device, so
+  // nothing is baked into a HIP graph capture. bank = flag & 1.
+  const int flatBlockId = blockIdx.x * gridDim.y + blockIdx.y;
+  const int total = gridDim.x * gridDim.y;
+  __shared__ uint32_t s_flag;
+  if (tid == 0) {
+    uint32_t f = epochDev[flatBlockId] + 1u;
+    if (f == 0u) f = 2u;                   // skip 0 sentinel; keep bank parity
+    s_flag = f;
+  }
+  __syncthreads();
+  const uint32_t flag = s_flag;
+  const size_t bankOffsetPkts = (size_t)(flag & 1u) * (size_t)nRanks * slot;
+
   // This block's packet range [pkBegin, pkEnd); [0, nPk) when nChunks == 1.
   const size_t pkPerChunk = (nPk + (size_t)nChunks - 1) / (size_t)nChunks;
   const size_t pkBegin = (size_t)chunk * pkPerChunk;
   size_t pkEnd = pkBegin + pkPerChunk;
   if (pkEnd > nPk) pkEnd = nPk;
 
-  // self column: local copy sendbuff -> recvbuff[self].
   if (peer == selfRank) {
+    // self column: local copy sendbuff -> recvbuff[self].
     const uint4* s4 = reinterpret_cast<const uint4*>(sendbuff);
     uint4* d4 = reinterpret_cast<uint4*>(
         reinterpret_cast<char*>(recvbuff) + (size_t)selfRank * perRankBytes);
@@ -95,34 +110,39 @@ __global__ void ddaAllGatherFabricLL(
       __builtin_nontemporal_store(v.z, &q->z);
       __builtin_nontemporal_store(v.w, &q->w);
     }
-    return;
+  } else {
+    // scatter: write my payload into peer's slot (== selfRank).
+    const uint32_t* sw = reinterpret_cast<const uint32_t*>(sendbuff);
+    LLPacket16* dst = reinterpret_cast<LLPacket16*>(peerScratch[peer]) +
+        (size_t)selfRank * slot + bankOffsetPkts;
+    for (size_t pk = pkBegin + tid; pk < pkEnd; pk += nthreads) {
+      ddaLLStoreLineB128(
+          reinterpret_cast<uint32_t*>(&dst[pk]),
+          sw[2 * pk], flag, sw[2 * pk + 1], flag);
+    }
+
+    // gather: poll my slot for peer, unpack into recvbuff[peer].
+    volatile LLPacket16* src =
+        reinterpret_cast<LLPacket16*>(peerScratch[selfRank]) + bankOffsetPkts +
+        (size_t)peer * slot;
+    uint32_t* out = reinterpret_cast<uint32_t*>(
+        reinterpret_cast<char*>(recvbuff) + (size_t)peer * perRankBytes);
+    for (size_t pk = pkBegin + tid; pk < pkEnd; pk += nthreads) {
+      uint32_t d0, f0, d1, f1;
+      do {
+        ddaLLLoadLineB128(
+            reinterpret_cast<const uint32_t*>(const_cast<LLPacket16*>(&src[pk])),
+            d0, f0, d1, f1);
+      } while (f0 != flag || f1 != flag);
+      out[2 * pk] = d0;
+      out[2 * pk + 1] = d1;
+    }
   }
 
-  // scatter: write my payload into peer's slot (== selfRank).
-  const uint32_t* sw = reinterpret_cast<const uint32_t*>(sendbuff);
-  LLPacket16* dst = reinterpret_cast<LLPacket16*>(peerScratch[peer]) +
-      (size_t)selfRank * slot + bankOffsetPkts;
-  for (size_t pk = pkBegin + tid; pk < pkEnd; pk += nthreads) {
-    ddaLLStoreLineB128(
-        reinterpret_cast<uint32_t*>(&dst[pk]),
-        sw[2 * pk], flag, sw[2 * pk + 1], flag);
-  }
-
-  // gather: poll my slot for peer, unpack into recvbuff[peer].
-  volatile LLPacket16* src =
-      reinterpret_cast<LLPacket16*>(peerScratch[selfRank]) + bankOffsetPkts +
-      (size_t)peer * slot;
-  uint32_t* out = reinterpret_cast<uint32_t*>(
-      reinterpret_cast<char*>(recvbuff) + (size_t)peer * perRankBytes);
-  for (size_t pk = pkBegin + tid; pk < pkEnd; pk += nthreads) {
-    uint32_t d0, f0, d1, f1;
-    do {
-      ddaLLLoadLineB128(
-          reinterpret_cast<const uint32_t*>(const_cast<LLPacket16*>(&src[pk])),
-          d0, f0, d1, f1);
-    } while (f0 != flag || f1 != flag);
-    out[2 * pk] = d0;
-    out[2 * pk + 1] = d1;
+  if (tid == 0) {
+    for (int e = flatBlockId; e < epochLen; e += total) {
+      epochDev[e] = flag;
+    }
   }
 }
 

--- a/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_ll.h
+++ b/projects/rccl/src/include/algorithms/all_reduce/all_reduce_dda_ll.h
@@ -61,13 +61,28 @@ __global__ void ddaAllReduceFlatLL(
     size_t count,                          // full-message element count
     int selfRank,
     int nRanksRt,
-    uint32_t flag,                         // == epoch; never 0
-    size_t bankOffsetPkts) {               // (epoch & 1) * nRanks * slotStride
+    uint32_t* __restrict__ epochDev,       // per-block LL epoch cells (shared AG+AR)
+    int epochLen) {                        // number of cells in epochDev
 
   const int nRanks = NRANKS_CT ? NRANKS_CT : nRanksRt;
   const size_t bytes = count * sizeof(T);
   const size_t nPk = bytes >> 3;           // 8 payload bytes per packet
   const size_t slot = kDdaLLArSlotStridePkts;
+
+  // Flat block id + total launched blocks. tid 0 reads our own epoch cell (all
+  // cells hold the same value) and derives this launch's flag on the device, so
+  // nothing is baked into a HIP graph capture. bank = flag & 1.
+  const int flatBlockId = blockIdx.x;
+  const int total = gridDim.x;
+  __shared__ uint32_t s_flag;
+  if (threadIdx.x == 0) {
+    uint32_t f = epochDev[flatBlockId] + 1u;
+    if (f == 0u) f = 2u;                   // skip 0 sentinel; keep bank parity
+    s_flag = f;
+  }
+  __syncthreads();
+  const uint32_t flag = s_flag;
+  const size_t bankOffsetPkts = (size_t)(flag & 1u) * (size_t)nRanks * slot;
 
   const size_t gtid = (size_t)blockIdx.x * blockDim.x + threadIdx.x;
   const size_t stride = (size_t)gridDim.x * blockDim.x;
@@ -111,6 +126,12 @@ __global__ void ddaAllReduceFlatLL(
     }
     out[2 * pk] = acc0;
     out[2 * pk + 1] = acc1;
+  }
+
+  if (threadIdx.x == 0) {
+    for (int e = flatBlockId; e < epochLen; e += total) {
+      epochDev[e] = flag;
+    }
   }
 }
 

--- a/projects/rccl/src/include/comm.h
+++ b/projects/rccl/src/include/comm.h
@@ -641,9 +641,9 @@ struct ncclComm {
   // True when ddaScratch is VMM (cuMem) backed (fabric path); selects the
   // matching deallocator at teardown.
   bool ddaScratchIsVmm;
-  // Monotonic epoch/flag for the LL-protocol DDA all-gather.
-  // Incremented once per LL collective; bank = epoch & 1.
-  uint32_t ddaLLEpoch;
+  // Device-resident per-block epoch cells for the LL-protocol DDA collectives,
+  uint32_t* ddaLLEpochDev;
+  int ddaLLEpochLen;
 
   // Bitmasks for ncclTransportP2pSetup
   struct channelMasks* connectSend;

--- a/projects/rccl/src/include/dda_init_detail.h
+++ b/projects/rccl/src/include/dda_init_detail.h
@@ -61,4 +61,14 @@ inline int ddaFabricMaxNBlocksForScratch() {
   return maxBlocks;
 }
 
+constexpr int kDdaLLAgMaxBlocksPerPeer = 8;
+
+// Number of device epoch cells for the LL collectives. it is sized for the larger of the two
+// max(AG total blocks, AR total blocks).
+inline size_t ddaLLEpochCount(int nRanks, int arMaxBlocks) {
+  const size_t ag = (size_t)nRanks * (size_t)kDdaLLAgMaxBlocksPerPeer;
+  const size_t ar = (size_t)arMaxBlocks;
+  return ag > ar ? ag : ar;
+}
+
 } // namespace nccl_dda_detail

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -673,6 +673,8 @@ static ncclResult_t commAlloc(struct ncclComm* comm, struct ncclComm* parent, in
   comm->ddaFabricBarrierState = nullptr;
   comm->ddaFabricMemHandler = nullptr;
   comm->ddaFabricMaxBlocks = 0;
+  comm->ddaLLEpochDev = nullptr;
+  comm->ddaLLEpochLen = 0;
 
   comm->rank = rank;
   comm->nRanks = ndev;

--- a/projects/rccl/src/ipc_init.cu
+++ b/projects/rccl/src/ipc_init.cu
@@ -197,7 +197,6 @@ ncclResult_t ncclDdaIpcCommInit(ncclComm* comm) {
   comm->ddaScratchBytes = bytes;
   comm->ddaPeerPtrsDev = peerDev;
   comm->ddaIpcBarrierState = barrierState;
-  comm->ddaLLEpoch = 0;
   INFO(
       NCCL_INIT,
       "ncclDdaIpcCommInit: scratch %zu bytes, IpcGpuBarrier nBlocks=%d, peer IPC table on device",


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Move LL flag to a device-resident, per-block epoch array, so the flag and bank are derived on-device and advance monotonically across graph replays.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
