### PR TITLE
refactor(rocdbgapi): reorganize hierarchy for generic queues

### DIFF
--- a/projects/rocdbgapi/src/dispatch.h
+++ b/projects/rocdbgapi/src/dispatch.h
@@ -33,7 +33,7 @@ namespace amd::dbgapi
 
 class agent_t;
 class process_t;
-class compute_queue_t;
+class queue_t;
 
 /* AMD Debugger API Dispatch.  */
 
@@ -41,10 +41,10 @@ class dispatch_t : public detail::handle_object<amd_dbgapi_dispatch_id_t>
 {
 private:
   amd_dbgapi_os_queue_packet_id_t const m_os_queue_packet_id;
-  compute_queue_t &m_queue;
+  queue_t &m_queue;
 
 public:
-  dispatch_t (amd_dbgapi_dispatch_id_t dispatch_id, compute_queue_t &queue,
+  dispatch_t (amd_dbgapi_dispatch_id_t dispatch_id, queue_t &queue,
               amd_dbgapi_os_queue_packet_id_t os_queue_packet_id)
     : handle_object (dispatch_id), m_os_queue_packet_id (os_queue_packet_id),
       m_queue (queue)
@@ -65,7 +65,7 @@ public:
                          void *value) const
     = 0;
 
-  compute_queue_t &queue () const { return m_queue; }
+  queue_t &queue () const { return m_queue; }
   const agent_t &agent () const;
   process_t &process () const;
   const architecture_t &architecture () const;

--- a/projects/rocdbgapi/src/displaced_stepping.cpp
+++ b/projects/rocdbgapi/src/displaced_stepping.cpp
@@ -37,7 +37,7 @@ namespace amd::dbgapi
 displaced_stepping_t::displaced_stepping_t (
   amd_dbgapi_displaced_stepping_id_t displaced_stepping_id, queue_t &queue,
   instruction_t original_instruction, agent_address_t from,
-  std::optional<compute_queue_t::displaced_instruction_ptr_t> to)
+  std::optional<queue_t::displaced_instruction_ptr_t> to)
   : handle_object (displaced_stepping_id),
     m_original_instruction (std::move (original_instruction)), m_from (from),
     m_to (std::move (to)), m_queue (queue)

--- a/projects/rocdbgapi/src/displaced_stepping.h
+++ b/projects/rocdbgapi/src/displaced_stepping.h
@@ -44,7 +44,7 @@ private:
 
   instruction_t const m_original_instruction;
   agent_address_t const m_from;
-  std::optional<compute_queue_t::displaced_instruction_ptr_t> m_to;
+  std::optional<queue_t::displaced_instruction_ptr_t> m_to;
 
   queue_t &m_queue;
 
@@ -52,7 +52,7 @@ public:
   displaced_stepping_t (
     amd_dbgapi_displaced_stepping_id_t displaced_stepping_id, queue_t &queue,
     instruction_t original_instruction, agent_address_t from,
-    std::optional<compute_queue_t::displaced_instruction_ptr_t> to);
+    std::optional<queue_t::displaced_instruction_ptr_t> to);
 
   ~displaced_stepping_t ();
 

--- a/projects/rocdbgapi/src/queue.cpp
+++ b/projects/rocdbgapi/src/queue.cpp
@@ -95,7 +95,7 @@ compute_queue_t::terminating_instruction_address ()
   return m_terminating_instruction_ptr->get ();
 }
 
-compute_queue_t::displaced_instruction_ptr_t
+queue_t::displaced_instruction_ptr_t
 compute_queue_t::allocate_displaced_instruction (
   const instruction_t &instruction)
 {
@@ -565,7 +565,7 @@ compute_queue_t::refresh_scratch_on_suspend ()
 }
 
 std::pair<agent_address_t /* address */, amd_dbgapi_size_t /* size */>
-compute_queue_t::scratch_memory_region (
+queue_t::scratch_memory_region (
   const architecture_t::cwsr_record_t &cwsr_record) const
 {
   if (!architecture ().has_architected_flat_scratch ())
@@ -1111,6 +1111,15 @@ public:
   void active_packets_bytes (amd_dbgapi_os_queue_packet_id_t read_packet_id,
                              amd_dbgapi_os_queue_packet_id_t write_packet_id,
                              void *memory, size_t memory_size) const override;
+
+  agent_address_t park_instruction_address () override;
+
+  agent_address_t terminating_instruction_address () override;
+
+  void wave_state_changed (const wave_t &wave) override;
+
+  displaced_instruction_ptr_t
+  allocate_displaced_instruction (const instruction_t &) override;
 };
 
 amd_dbgapi_os_queue_type_t
@@ -1149,6 +1158,30 @@ unsupported_queue_t::active_packets_bytes (
   amd_dbgapi_os_queue_packet_id_t /* read_packet_id  */,
   amd_dbgapi_os_queue_packet_id_t /* write_packet_id  */, void * /* memory  */,
   size_t /* memory_size  */) const
+{
+  throw api_error_t (AMD_DBGAPI_STATUS_ERROR_NOT_SUPPORTED);
+}
+
+agent_address_t
+unsupported_queue_t::park_instruction_address ()
+{
+  throw api_error_t (AMD_DBGAPI_STATUS_ERROR_NOT_SUPPORTED);
+}
+
+agent_address_t
+unsupported_queue_t::terminating_instruction_address ()
+{
+  throw api_error_t (AMD_DBGAPI_STATUS_ERROR_NOT_SUPPORTED);
+}
+
+void
+unsupported_queue_t::wave_state_changed (const wave_t &)
+{
+  throw api_error_t (AMD_DBGAPI_STATUS_ERROR_NOT_SUPPORTED);
+}
+
+queue_t::displaced_instruction_ptr_t
+unsupported_queue_t::allocate_displaced_instruction (const instruction_t &)
 {
   throw api_error_t (AMD_DBGAPI_STATUS_ERROR_NOT_SUPPORTED);
 }

--- a/projects/rocdbgapi/src/queue.h
+++ b/projects/rocdbgapi/src/queue.h
@@ -59,14 +59,60 @@ public:
     running    /* The queue is running.  */
   };
 
-protected:
-  os_queue_snapshot_entry_t m_os_queue_info;
+  /* A displaced instruction ptr holds the address of an instruction in
+     device accessible memory.  The address is returned to the queue when the
+     displaced instruction ptr is destructed.  */
+  using displaced_instruction_ptr_t
+    = utils::unique_resource_t<agent_address_t,
+                               std::function<void (agent_address_t)>>;
+
+  class dummy_dispatch_t : public dispatch_t
+  {
+  private:
+    class dummy_descriptor_t : public architecture_t::kernel_descriptor_t
+    {
+    public:
+      dummy_descriptor_t (process_t &process)
+        : architecture_t::kernel_descriptor_t (process, 0)
+      {
+      }
+      global_address_t entry_address () const override { return 0; }
+      bool is_at_kernel_entry (global_address_t /* pc  */) const override
+      {
+        return false;
+      }
+    } m_dummy_descriptor;
+
+  public:
+    dummy_dispatch_t (queue_t &queue)
+      : dispatch_t (AMD_DBGAPI_DISPATCH_NONE, queue, 0),
+        m_dummy_descriptor (queue.process ())
+    {
+    }
+
+    const architecture_t::kernel_descriptor_t &
+    kernel_descriptor () const override
+    {
+      return m_dummy_descriptor;
+    }
+
+    void get_info (amd_dbgapi_dispatch_info_t /* query  */,
+                   size_t /* value_size  */,
+                   void * /* value  */) const override
+    {
+      dbgapi_assert_not_reached ("should not call this");
+    }
+  };
 
 private:
   state_t m_state{ state_t::running };
   epoch_t m_mark{ 0 };
 
   const agent_t &m_agent;
+
+protected:
+  os_queue_snapshot_entry_t m_os_queue_info;
+  dummy_dispatch_t m_dummy_dispatch;
 
   /* Called whenever the queue changes state.  */
   virtual void queue_state_changed () {}
@@ -78,8 +124,8 @@ public:
 
   queue_t (amd_dbgapi_queue_id_t queue_id, const agent_t &agent,
            const os_queue_snapshot_entry_t &os_queue_info)
-    : handle_object (queue_id), m_os_queue_info (os_queue_info),
-      m_agent (agent)
+    : handle_object (queue_id), m_agent (agent),
+      m_os_queue_info (os_queue_info), m_dummy_dispatch (*this)
   {
   }
 
@@ -113,6 +159,25 @@ public:
   /* Return the address of the memory holding the queue packets.  */
   std::variant<host_address_t, agent_address_t> address () const;
 
+  virtual void wave_state_changed (const wave_t &wave) = 0;
+
+  /* Return the address of a park instruction.  */
+  virtual agent_address_t park_instruction_address () = 0;
+  /* Return the address of a terminating instruction.  */
+  virtual agent_address_t terminating_instruction_address () = 0;
+
+  /* Return the wave's scratch memory region (address and size).  */
+  virtual std::pair<agent_address_t /* address */,
+                    amd_dbgapi_size_t /* size */>
+  scratch_memory_region (
+    const architecture_t::cwsr_record_t &cwsr_record) const;
+
+  /* Return a pointer to device accessible memory containing the given
+     instruction bytes.  */
+  virtual displaced_instruction_ptr_t
+  allocate_displaced_instruction (const instruction_t &instruction)
+    = 0;
+
   /* Return the size of the memory holding the queue packets.  */
   amd_dbgapi_size_t size () const;
 
@@ -137,6 +202,8 @@ public:
   void get_info (amd_dbgapi_queue_info_t query, size_t value_size,
                  void *value) const;
 
+  dummy_dispatch_t &dummy_dispatch () { return m_dummy_dispatch; }
+
   const agent_t &agent () const { return m_agent; }
   process_t &process () const;
   const architecture_t &architecture () const;
@@ -146,14 +213,6 @@ public:
 
 class compute_queue_t : public queue_t
 {
-public:
-  /* A displaced instruction ptr holds the address of an instruction in
-     device accessible memory.  The address is returned to the queue when the
-     displaced instruction ptr is destructed.  */
-  using displaced_instruction_ptr_t
-    = utils::unique_resource_t<agent_address_t,
-                               std::function<void (agent_address_t)>>;
-
 protected:
   struct context_save_area_header_s
   {
@@ -165,44 +224,6 @@ protected:
     uint32_t debugger_memory_size;
   };
 
-  class dummy_dispatch_t : public dispatch_t
-  {
-  private:
-    class dummy_descriptor_t : public architecture_t::kernel_descriptor_t
-    {
-    public:
-      dummy_descriptor_t (process_t &process)
-        : architecture_t::kernel_descriptor_t (process, 0)
-      {
-      }
-      global_address_t entry_address () const override { return 0; }
-      bool is_at_kernel_entry (global_address_t /* pc  */) const override
-      {
-        return false;
-      }
-    } m_dummy_descriptor;
-
-  public:
-    dummy_dispatch_t (compute_queue_t &queue)
-      : dispatch_t (AMD_DBGAPI_DISPATCH_NONE, queue, 0),
-        m_dummy_descriptor (queue.process ())
-    {
-    }
-
-    const architecture_t::kernel_descriptor_t &
-    kernel_descriptor () const override
-    {
-      return m_dummy_descriptor;
-    }
-
-    void get_info (amd_dbgapi_dispatch_info_t /* query  */,
-                   size_t /* value_size  */,
-                   void * /* value  */) const override
-    {
-      dbgapi_assert_not_reached ("should not call this");
-    }
-  } m_dummy_dispatch;
-
   /* Number of waves in the running state.  Only holds a value when the queue
      is suspended.  */
   std::optional<size_t> m_waves_running{};
@@ -213,14 +234,14 @@ protected:
   uint16_t m_debugger_memory_next_chunk{ 0 };
   std::vector<uint16_t> m_debugger_memory_free_chunks{};
 
-  std::optional<displaced_instruction_ptr_t> m_park_instruction_ptr{};
-  std::optional<displaced_instruction_ptr_t> m_terminating_instruction_ptr{};
-
   /* The memory reserved by the thunk library for the debugger is used to store
      instruction buffers.  Instruction buffers are lazily allocated from the
      reserved memory, and when freed, their index is returned to a free list.
      Each wave is guaranteed its own unique instruction buffer.  */
   std::optional<agent_address_t> m_debugger_memory_base{};
+
+  std::optional<displaced_instruction_ptr_t> m_park_instruction_ptr{};
+  std::optional<displaced_instruction_ptr_t> m_terminating_instruction_ptr{};
 
   std::optional<amd_dbgapi_os_queue_packet_id_t> m_read_packet_id{};
   std::optional<amd_dbgapi_os_queue_packet_id_t> m_write_packet_id{};
@@ -247,29 +268,20 @@ protected:
 public:
   compute_queue_t (amd_dbgapi_queue_id_t queue_id, const agent_t &agent,
                    const os_queue_snapshot_entry_t &os_queue_info)
-    : queue_t (queue_id, agent, os_queue_info), m_dummy_dispatch (*this)
+    : queue_t (queue_id, agent, os_queue_info)
   {
   }
 
-  void wave_state_changed (const wave_t &wave);
+  void wave_state_changed (const wave_t &wave) override;
 
   bool is_all_stopped () const override;
 
-  /* Return the address of a park instruction.  */
-  virtual agent_address_t park_instruction_address ();
-  /* Return the address of a terminating instruction.  */
-  virtual agent_address_t terminating_instruction_address ();
+  agent_address_t park_instruction_address () override;
 
-  /* Return the wave's scratch memory region (address and size).  */
-  virtual std::pair<agent_address_t /* address */,
-                    amd_dbgapi_size_t /* size */>
-  scratch_memory_region (
-    const architecture_t::cwsr_record_t &cwsr_record) const;
+  agent_address_t terminating_instruction_address () override;
 
-  /* Return a pointer to device accessible memory containing the given
-     instruction bytes.  */
   virtual displaced_instruction_ptr_t
-  allocate_displaced_instruction (const instruction_t &instruction);
+  allocate_displaced_instruction (const instruction_t &instruction) override;
 
   amd_dbgapi_os_queue_type_t type () const override
   {

--- a/projects/rocdbgapi/src/wave.cpp
+++ b/projects/rocdbgapi/src/wave.cpp
@@ -75,7 +75,7 @@ wave_t::dispatch () const
   return m_workgroup.dispatch ();
 }
 
-compute_queue_t &
+queue_t &
 wave_t::queue () const
 {
   return dispatch ().queue ();
@@ -283,7 +283,7 @@ wave_t::displaced_stepping_start (const void *saved_instruction_bytes)
       instruction_t original_instruction (
         architecture (), std::move (original_instruction_bytes));
 
-      std::optional<compute_queue_t::displaced_instruction_ptr_t>
+      std::optional<queue_t::displaced_instruction_ptr_t>
         displaced_instruction_ptr;
 
       if (architecture ().can_simulate (*this, original_instruction))

--- a/projects/rocdbgapi/src/wave.h
+++ b/projects/rocdbgapi/src/wave.h
@@ -42,7 +42,7 @@ namespace amd::dbgapi
 {
 
 class agent_t;
-class compute_queue_t;
+class queue_t;
 class dispatch_t;
 class event_t;
 class displaced_stepping_t;
@@ -244,7 +244,7 @@ public:
 
   workgroup_t &workgroup () const { return m_workgroup; }
   const dispatch_t &dispatch () const;
-  compute_queue_t &queue () const;
+  queue_t &queue () const;
   const agent_t &agent () const;
   process_t &process () const;
   const architecture_t &architecture () const;

--- a/projects/rocdbgapi/src/workgroup.cpp
+++ b/projects/rocdbgapi/src/workgroup.cpp
@@ -28,7 +28,7 @@
 namespace amd::dbgapi
 {
 
-compute_queue_t &
+queue_t &
 workgroup_t::queue () const
 {
   return dispatch ().queue ();

--- a/projects/rocdbgapi/src/workgroup.h
+++ b/projects/rocdbgapi/src/workgroup.h
@@ -33,7 +33,7 @@ namespace amd::dbgapi
 class address_space_t;
 class agent_t;
 class architecture_t;
-class compute_queue_t;
+class queue_t;
 class dispatch_t;
 class process_t;
 
@@ -81,7 +81,7 @@ public:
                  void *value) const;
 
   const dispatch_t &dispatch () const { return m_dispatch; }
-  compute_queue_t &queue () const;
+  queue_t &queue () const;
   const agent_t &agent () const;
   process_t &process () const;
   const architecture_t &architecture () const;


### PR DESCRIPTION
## Motivation

Some objects in the rocdbgapi hierarchy had hard-coded references or getters for compute queues instead of the more generic queue_t type (dispatch, workgroup, etc.).

This commit moves some generic queues capabilities to the queue_t abstract type, and makes those objects manipulate queue_t references.

## Test Plan

No functional changes expected.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.