### PR TITLE
feat(rocr): round-robin SDMA copies across PCIe and xGMI engines

### DIFF
--- a/projects/rocr-runtime/rocrtst/common/utils_test/CMakeLists.txt
+++ b/projects/rocr-runtime/rocrtst/common/utils_test/CMakeLists.txt
@@ -4,6 +4,7 @@
 set (rocrtstUtilsTestSrcs utils_timer_gtest.cpp)
 set (rocrtstUtilsTestSrcs ${rocrtstUtilsTestSrcs} utils_timer_test.cpp)
 set (rocrtstUtilsTestSrcs ${rocrtstUtilsTestSrcs} utils_cpp11_gtest.cpp)
+set (rocrtstUtilsTestSrcs ${rocrtstUtilsTestSrcs} sdma_round_robin_test.cpp)
 
 #
 # Header files include path(s).
@@ -11,6 +12,8 @@ set (rocrtstUtilsTestSrcs ${rocrtstUtilsTestSrcs} utils_cpp11_gtest.cpp)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${PROJECT_SOURCE_DIR}/utils)
 include_directories(${PROJECT_SOURCE_DIR}/gtest/include)
+# hsa-runtime core headers (core/util/flag.h) for internal flag parsing tests
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../../runtime/hsa-runtime)
 
 #
 # Build rule to build an executable object

--- a/projects/rocr-runtime/rocrtst/common/utils_test/sdma_round_robin_test.cpp
+++ b/projects/rocr-runtime/rocrtst/common/utils_test/sdma_round_robin_test.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <cstdlib>
+#include <string>
+
+#include "gtest/gtest.h"
+
+#include "core/util/flag.h"
+
+// Unit test for the ROCR_SDMA_ROUND_ROBIN environment-variable parsing added to
+// rocr::Flag. rocr::Flag::Refresh() maps the variable onto an SDMA_OVERRIDE
+// tri-state with the rule:
+//   "1"           -> SDMA_ENABLE
+//   "0"           -> SDMA_DISABLE
+//   unset / other -> SDMA_DEFAULT
+// The internal environment accessors (rocr::os::GetEnvVar) are not exported from
+// libhsa-runtime64, so this test reproduces the exact parse against the real
+// rocr::Flag::SDMA_OVERRIDE enum. It locks the contract that amd_gpu_agent.cpp
+// relies on when deciding whether to round-robin host<->device SDMA copies
+// across engines.
+
+namespace {
+
+rocr::Flag::SDMA_OVERRIDE ParseSdmaRoundRobin(const char* raw) {
+  const std::string var = (raw != nullptr) ? std::string(raw) : std::string();
+  return (var == "1") ? rocr::Flag::SDMA_ENABLE
+                      : ((var == "0") ? rocr::Flag::SDMA_DISABLE : rocr::Flag::SDMA_DEFAULT);
+}
+
+rocr::Flag::SDMA_OVERRIDE ParseFromEnv() {
+  return ParseSdmaRoundRobin(std::getenv("ROCR_SDMA_ROUND_ROBIN"));
+}
+
+}  // namespace
+
+TEST(RocrSdmaRoundRobin, EnabledWhenOne) {
+  ASSERT_EQ(0, setenv("ROCR_SDMA_ROUND_ROBIN", "1", 1));
+  EXPECT_EQ(rocr::Flag::SDMA_ENABLE, ParseFromEnv());
+  unsetenv("ROCR_SDMA_ROUND_ROBIN");
+}
+
+TEST(RocrSdmaRoundRobin, DisabledWhenZero) {
+  ASSERT_EQ(0, setenv("ROCR_SDMA_ROUND_ROBIN", "0", 1));
+  EXPECT_EQ(rocr::Flag::SDMA_DISABLE, ParseFromEnv());
+  unsetenv("ROCR_SDMA_ROUND_ROBIN");
+}
+
+TEST(RocrSdmaRoundRobin, DefaultWhenUnset) {
+  unsetenv("ROCR_SDMA_ROUND_ROBIN");
+  EXPECT_EQ(rocr::Flag::SDMA_DEFAULT, ParseFromEnv());
+}
+
+TEST(RocrSdmaRoundRobin, DefaultForUnrecognizedValue) {
+  ASSERT_EQ(0, setenv("ROCR_SDMA_ROUND_ROBIN", "yes", 1));
+  EXPECT_EQ(rocr::Flag::SDMA_DEFAULT, ParseFromEnv());
+  unsetenv("ROCR_SDMA_ROUND_ROBIN");
+}

--- a/projects/rocr-runtime/rocrtst/common/utils_test/sdma_round_robin_test.cpp
+++ b/projects/rocr-runtime/rocrtst/common/utils_test/sdma_round_robin_test.cpp
@@ -178,12 +178,8 @@ bool ParseNonNegInt(const std::string& s, int64_t& out) {
 }
 
 const char* const kLocalRankVars[] = {
-    "LOCAL_RANK",
-    "OMPI_COMM_WORLD_LOCAL_RANK",
-    "MPI_LOCALRANKID",
-    "PMI_LOCAL_RANK",
-    "MV2_COMM_WORLD_LOCAL_RANK",
-    "SLURM_LOCALID"};
+    "LOCAL_RANK",     "OMPI_COMM_WORLD_LOCAL_RANK", "MPI_LOCALRANKID",
+    "PMI_LOCAL_RANK", "MV2_COMM_WORLD_LOCAL_RANK",  "SLURM_LOCALID"};
 
 // Resolves the seed offset (>=0) and its source name; source is "" when the
 // result is -1 (getpid() fallback).

--- a/projects/rocr-runtime/rocrtst/common/utils_test/sdma_round_robin_test.cpp
+++ b/projects/rocr-runtime/rocrtst/common/utils_test/sdma_round_robin_test.cpp
@@ -12,7 +12,7 @@
 
 #include "core/util/flag.h"
 
-// Unit test for the ROCR_SDMA_ROUND_ROBIN and ROCR_SDMA_ROUND_ROBIN_PCIE_XGMI
+// Unit test for the HSA_SDMA_ROUND_ROBIN and HSA_SDMA_ROUND_ROBIN_PCIE_XGMI
 // environment-variable parsing added to rocr::Flag. rocr::Flag::Refresh() maps
 // each variable onto an SDMA_OVERRIDE
 // tri-state with the rule:
@@ -34,62 +34,62 @@ rocr::Flag::SDMA_OVERRIDE ParseSdmaRoundRobin(const char* raw) {
 }
 
 rocr::Flag::SDMA_OVERRIDE ParseFromEnv() {
-  return ParseSdmaRoundRobin(std::getenv("ROCR_SDMA_ROUND_ROBIN"));
+  return ParseSdmaRoundRobin(std::getenv("HSA_SDMA_ROUND_ROBIN"));
 }
 
 rocr::Flag::SDMA_OVERRIDE ParseFromEnvPcieXgmi() {
-  return ParseSdmaRoundRobin(std::getenv("ROCR_SDMA_ROUND_ROBIN_PCIE_XGMI"));
+  return ParseSdmaRoundRobin(std::getenv("HSA_SDMA_ROUND_ROBIN_PCIE_XGMI"));
 }
 
 }  // namespace
 
 TEST(RocrSdmaRoundRobin, EnabledWhenOne) {
-  ASSERT_EQ(0, setenv("ROCR_SDMA_ROUND_ROBIN", "1", 1));
+  ASSERT_EQ(0, setenv("HSA_SDMA_ROUND_ROBIN", "1", 1));
   EXPECT_EQ(rocr::Flag::SDMA_ENABLE, ParseFromEnv());
-  unsetenv("ROCR_SDMA_ROUND_ROBIN");
+  unsetenv("HSA_SDMA_ROUND_ROBIN");
 }
 
 TEST(RocrSdmaRoundRobin, DisabledWhenZero) {
-  ASSERT_EQ(0, setenv("ROCR_SDMA_ROUND_ROBIN", "0", 1));
+  ASSERT_EQ(0, setenv("HSA_SDMA_ROUND_ROBIN", "0", 1));
   EXPECT_EQ(rocr::Flag::SDMA_DISABLE, ParseFromEnv());
-  unsetenv("ROCR_SDMA_ROUND_ROBIN");
+  unsetenv("HSA_SDMA_ROUND_ROBIN");
 }
 
 TEST(RocrSdmaRoundRobin, DefaultWhenUnset) {
-  unsetenv("ROCR_SDMA_ROUND_ROBIN");
+  unsetenv("HSA_SDMA_ROUND_ROBIN");
   EXPECT_EQ(rocr::Flag::SDMA_DEFAULT, ParseFromEnv());
 }
 
 TEST(RocrSdmaRoundRobin, DefaultForUnrecognizedValue) {
-  ASSERT_EQ(0, setenv("ROCR_SDMA_ROUND_ROBIN", "yes", 1));
+  ASSERT_EQ(0, setenv("HSA_SDMA_ROUND_ROBIN", "yes", 1));
   EXPECT_EQ(rocr::Flag::SDMA_DEFAULT, ParseFromEnv());
-  unsetenv("ROCR_SDMA_ROUND_ROBIN");
+  unsetenv("HSA_SDMA_ROUND_ROBIN");
 }
 
 TEST(RocrSdmaRoundRobinPcieXgmi, EnabledWhenOne) {
-  ASSERT_EQ(0, setenv("ROCR_SDMA_ROUND_ROBIN_PCIE_XGMI", "1", 1));
+  ASSERT_EQ(0, setenv("HSA_SDMA_ROUND_ROBIN_PCIE_XGMI", "1", 1));
   EXPECT_EQ(rocr::Flag::SDMA_ENABLE, ParseFromEnvPcieXgmi());
-  unsetenv("ROCR_SDMA_ROUND_ROBIN_PCIE_XGMI");
+  unsetenv("HSA_SDMA_ROUND_ROBIN_PCIE_XGMI");
 }
 
 TEST(RocrSdmaRoundRobinPcieXgmi, DisabledWhenZero) {
-  ASSERT_EQ(0, setenv("ROCR_SDMA_ROUND_ROBIN_PCIE_XGMI", "0", 1));
+  ASSERT_EQ(0, setenv("HSA_SDMA_ROUND_ROBIN_PCIE_XGMI", "0", 1));
   EXPECT_EQ(rocr::Flag::SDMA_DISABLE, ParseFromEnvPcieXgmi());
-  unsetenv("ROCR_SDMA_ROUND_ROBIN_PCIE_XGMI");
+  unsetenv("HSA_SDMA_ROUND_ROBIN_PCIE_XGMI");
 }
 
 TEST(RocrSdmaRoundRobinPcieXgmi, DefaultWhenUnset) {
-  unsetenv("ROCR_SDMA_ROUND_ROBIN_PCIE_XGMI");
+  unsetenv("HSA_SDMA_ROUND_ROBIN_PCIE_XGMI");
   EXPECT_EQ(rocr::Flag::SDMA_DEFAULT, ParseFromEnvPcieXgmi());
 }
 
 TEST(RocrSdmaRoundRobinPcieXgmi, DefaultForUnrecognizedValue) {
-  ASSERT_EQ(0, setenv("ROCR_SDMA_ROUND_ROBIN_PCIE_XGMI", "yes", 1));
+  ASSERT_EQ(0, setenv("HSA_SDMA_ROUND_ROBIN_PCIE_XGMI", "yes", 1));
   EXPECT_EQ(rocr::Flag::SDMA_DEFAULT, ParseFromEnvPcieXgmi());
-  unsetenv("ROCR_SDMA_ROUND_ROBIN_PCIE_XGMI");
+  unsetenv("HSA_SDMA_ROUND_ROBIN_PCIE_XGMI");
 }
 
-// ROCR_SDMA_ENGINE_ID_OFFSET lets a launcher pass an explicit non-negative
+// HSA_SDMA_ENGINE_ID_OFFSET lets a launcher pass an explicit non-negative
 // engine-id offset that replaces the getpid() seed in the round-robin pick,
 // so concurrent processes do not alias onto the same engine. The parse mirrors
 // rocr::Flag::Refresh(): a value of 0 is a valid explicit offset; unset,
@@ -116,49 +116,49 @@ int64_t ParseSdmaEngineIdOffset(const char* raw) {
 }
 
 int64_t ParseOffsetFromEnv() {
-  return ParseSdmaEngineIdOffset(std::getenv("ROCR_SDMA_ENGINE_ID_OFFSET"));
+  return ParseSdmaEngineIdOffset(std::getenv("HSA_SDMA_ENGINE_ID_OFFSET"));
 }
 
 }  // namespace
 
 TEST(RocrSdmaEngineIdOffset, UnsetIsSentinel) {
-  unsetenv("ROCR_SDMA_ENGINE_ID_OFFSET");
+  unsetenv("HSA_SDMA_ENGINE_ID_OFFSET");
   EXPECT_EQ(static_cast<int64_t>(-1), ParseOffsetFromEnv());
 }
 
 TEST(RocrSdmaEngineIdOffset, ZeroIsExplicit) {
-  ASSERT_EQ(0, setenv("ROCR_SDMA_ENGINE_ID_OFFSET", "0", 1));
+  ASSERT_EQ(0, setenv("HSA_SDMA_ENGINE_ID_OFFSET", "0", 1));
   EXPECT_EQ(static_cast<int64_t>(0), ParseOffsetFromEnv());
-  unsetenv("ROCR_SDMA_ENGINE_ID_OFFSET");
+  unsetenv("HSA_SDMA_ENGINE_ID_OFFSET");
 }
 
 TEST(RocrSdmaEngineIdOffset, PositiveValue) {
-  ASSERT_EQ(0, setenv("ROCR_SDMA_ENGINE_ID_OFFSET", "5", 1));
+  ASSERT_EQ(0, setenv("HSA_SDMA_ENGINE_ID_OFFSET", "5", 1));
   EXPECT_EQ(static_cast<int64_t>(5), ParseOffsetFromEnv());
-  unsetenv("ROCR_SDMA_ENGINE_ID_OFFSET");
+  unsetenv("HSA_SDMA_ENGINE_ID_OFFSET");
 }
 
 TEST(RocrSdmaEngineIdOffset, NonNumericFallsBack) {
-  ASSERT_EQ(0, setenv("ROCR_SDMA_ENGINE_ID_OFFSET", "abc", 1));
+  ASSERT_EQ(0, setenv("HSA_SDMA_ENGINE_ID_OFFSET", "abc", 1));
   EXPECT_EQ(static_cast<int64_t>(-1), ParseOffsetFromEnv());
-  unsetenv("ROCR_SDMA_ENGINE_ID_OFFSET");
+  unsetenv("HSA_SDMA_ENGINE_ID_OFFSET");
 }
 
 TEST(RocrSdmaEngineIdOffset, NegativeFallsBack) {
-  ASSERT_EQ(0, setenv("ROCR_SDMA_ENGINE_ID_OFFSET", "-3", 1));
+  ASSERT_EQ(0, setenv("HSA_SDMA_ENGINE_ID_OFFSET", "-3", 1));
   EXPECT_EQ(static_cast<int64_t>(-1), ParseOffsetFromEnv());
-  unsetenv("ROCR_SDMA_ENGINE_ID_OFFSET");
+  unsetenv("HSA_SDMA_ENGINE_ID_OFFSET");
 }
 
 TEST(RocrSdmaEngineIdOffset, OutOfRangeFallsBack) {
-  ASSERT_EQ(0, setenv("ROCR_SDMA_ENGINE_ID_OFFSET", "99999999999", 1));
+  ASSERT_EQ(0, setenv("HSA_SDMA_ENGINE_ID_OFFSET", "99999999999", 1));
   EXPECT_EQ(static_cast<int64_t>(-1), ParseOffsetFromEnv());
-  unsetenv("ROCR_SDMA_ENGINE_ID_OFFSET");
+  unsetenv("HSA_SDMA_ENGINE_ID_OFFSET");
 }
 
 // Method A: launcher local-rank seed detection. The final round-robin seed
 // offset is resolved in priority order (mirroring rocr::Flag::Refresh()):
-//   1. ROCR_SDMA_ENGINE_ID_OFFSET (explicit, including 0)
+//   1. HSA_SDMA_ENGINE_ID_OFFSET (explicit, including 0)
 //   2. the first launcher local-rank env var that parses to a valid
 //      non-negative integer (LOCAL_RANK, OMPI_COMM_WORLD_LOCAL_RANK,
 //      MPI_LOCALRANKID, PMI_LOCAL_RANK, MV2_COMM_WORLD_LOCAL_RANK,
@@ -188,9 +188,9 @@ const char* const kLocalRankVars[] = {
 // Resolves the seed offset (>=0) and its source name; source is "" when the
 // result is -1 (getpid() fallback).
 int64_t ResolveSeedOffset(std::string* source) {
-  int64_t offset = ParseSdmaEngineIdOffset(std::getenv("ROCR_SDMA_ENGINE_ID_OFFSET"));
+  int64_t offset = ParseSdmaEngineIdOffset(std::getenv("HSA_SDMA_ENGINE_ID_OFFSET"));
   if (offset >= 0) {
-    if (source) *source = "ROCR_SDMA_ENGINE_ID_OFFSET";
+    if (source) *source = "HSA_SDMA_ENGINE_ID_OFFSET";
     return offset;
   }
   for (const char* name : kLocalRankVars) {
@@ -206,7 +206,7 @@ int64_t ResolveSeedOffset(std::string* source) {
 }
 
 void ClearSeedEnv() {
-  unsetenv("ROCR_SDMA_ENGINE_ID_OFFSET");
+  unsetenv("HSA_SDMA_ENGINE_ID_OFFSET");
   for (const char* name : kLocalRankVars) unsetenv(name);
 }
 
@@ -214,20 +214,20 @@ void ClearSeedEnv() {
 
 TEST(RocrSdmaSeedOffset, OffsetOnly) {
   ClearSeedEnv();
-  ASSERT_EQ(0, setenv("ROCR_SDMA_ENGINE_ID_OFFSET", "7", 1));
+  ASSERT_EQ(0, setenv("HSA_SDMA_ENGINE_ID_OFFSET", "7", 1));
   std::string src;
   EXPECT_EQ(static_cast<int64_t>(7), ResolveSeedOffset(&src));
-  EXPECT_EQ("ROCR_SDMA_ENGINE_ID_OFFSET", src);
+  EXPECT_EQ("HSA_SDMA_ENGINE_ID_OFFSET", src);
   ClearSeedEnv();
 }
 
 TEST(RocrSdmaSeedOffset, OffsetOverridesRank) {
   ClearSeedEnv();
-  ASSERT_EQ(0, setenv("ROCR_SDMA_ENGINE_ID_OFFSET", "2", 1));
+  ASSERT_EQ(0, setenv("HSA_SDMA_ENGINE_ID_OFFSET", "2", 1));
   ASSERT_EQ(0, setenv("OMPI_COMM_WORLD_LOCAL_RANK", "5", 1));
   std::string src;
   EXPECT_EQ(static_cast<int64_t>(2), ResolveSeedOffset(&src));
-  EXPECT_EQ("ROCR_SDMA_ENGINE_ID_OFFSET", src);
+  EXPECT_EQ("HSA_SDMA_ENGINE_ID_OFFSET", src);
   ClearSeedEnv();
 }
 
@@ -272,7 +272,7 @@ TEST(RocrSdmaSeedOffset, NoneFallsBackToPid) {
   ClearSeedEnv();
 }
 
-// Method D: ROCR_SDMA_D2H_ENGINE_LIMIT caps the D2H round-robin to the first N
+// Method D: HSA_SDMA_D2H_ENGINE_LIMIT caps the D2H round-robin to the first N
 // SDMA engines. Parse mirrors rocr::Flag::Refresh(): 0 / unset / malformed ->
 // 0 (no limit); a valid non-negative integer -> that value (amd_gpu_agent.cpp
 // clamps it to the engine count with std::min at queue-creation time).
@@ -286,38 +286,38 @@ int64_t ParseD2hEngineLimit(const char* raw) {
 }
 
 int64_t ParseD2hLimitFromEnv() {
-  return ParseD2hEngineLimit(std::getenv("ROCR_SDMA_D2H_ENGINE_LIMIT"));
+  return ParseD2hEngineLimit(std::getenv("HSA_SDMA_D2H_ENGINE_LIMIT"));
 }
 
 }  // namespace
 
 TEST(RocrSdmaD2hEngineLimit, UnsetIsZero) {
-  unsetenv("ROCR_SDMA_D2H_ENGINE_LIMIT");
+  unsetenv("HSA_SDMA_D2H_ENGINE_LIMIT");
   EXPECT_EQ(static_cast<int64_t>(0), ParseD2hLimitFromEnv());
 }
 
 TEST(RocrSdmaD2hEngineLimit, ZeroIsDisabled) {
-  ASSERT_EQ(0, setenv("ROCR_SDMA_D2H_ENGINE_LIMIT", "0", 1));
+  ASSERT_EQ(0, setenv("HSA_SDMA_D2H_ENGINE_LIMIT", "0", 1));
   EXPECT_EQ(static_cast<int64_t>(0), ParseD2hLimitFromEnv());
-  unsetenv("ROCR_SDMA_D2H_ENGINE_LIMIT");
+  unsetenv("HSA_SDMA_D2H_ENGINE_LIMIT");
 }
 
 TEST(RocrSdmaD2hEngineLimit, ValidValue) {
-  ASSERT_EQ(0, setenv("ROCR_SDMA_D2H_ENGINE_LIMIT", "8", 1));
+  ASSERT_EQ(0, setenv("HSA_SDMA_D2H_ENGINE_LIMIT", "8", 1));
   EXPECT_EQ(static_cast<int64_t>(8), ParseD2hLimitFromEnv());
-  unsetenv("ROCR_SDMA_D2H_ENGINE_LIMIT");
+  unsetenv("HSA_SDMA_D2H_ENGINE_LIMIT");
 }
 
 TEST(RocrSdmaD2hEngineLimit, LargeValueParsesForClamping) {
   // Values above the engine count still parse; amd_gpu_agent.cpp clamps them to
   // the available engine count via std::min at queue-creation time.
-  ASSERT_EQ(0, setenv("ROCR_SDMA_D2H_ENGINE_LIMIT", "64", 1));
+  ASSERT_EQ(0, setenv("HSA_SDMA_D2H_ENGINE_LIMIT", "64", 1));
   EXPECT_EQ(static_cast<int64_t>(64), ParseD2hLimitFromEnv());
-  unsetenv("ROCR_SDMA_D2H_ENGINE_LIMIT");
+  unsetenv("HSA_SDMA_D2H_ENGINE_LIMIT");
 }
 
 TEST(RocrSdmaD2hEngineLimit, MalformedIsZero) {
-  ASSERT_EQ(0, setenv("ROCR_SDMA_D2H_ENGINE_LIMIT", "abc", 1));
+  ASSERT_EQ(0, setenv("HSA_SDMA_D2H_ENGINE_LIMIT", "abc", 1));
   EXPECT_EQ(static_cast<int64_t>(0), ParseD2hLimitFromEnv());
-  unsetenv("ROCR_SDMA_D2H_ENGINE_LIMIT");
+  unsetenv("HSA_SDMA_D2H_ENGINE_LIMIT");
 }

--- a/projects/rocr-runtime/rocrtst/common/utils_test/sdma_round_robin_test.cpp
+++ b/projects/rocr-runtime/rocrtst/common/utils_test/sdma_round_robin_test.cpp
@@ -155,3 +155,169 @@ TEST(RocrSdmaEngineIdOffset, OutOfRangeFallsBack) {
   EXPECT_EQ(static_cast<int64_t>(-1), ParseOffsetFromEnv());
   unsetenv("ROCR_SDMA_ENGINE_ID_OFFSET");
 }
+
+// Method A: launcher local-rank seed detection. The final round-robin seed
+// offset is resolved in priority order (mirroring rocr::Flag::Refresh()):
+//   1. ROCR_SDMA_ENGINE_ID_OFFSET (explicit, including 0)
+//   2. the first launcher local-rank env var that parses to a valid
+//      non-negative integer (LOCAL_RANK, OMPI_COMM_WORLD_LOCAL_RANK,
+//      MPI_LOCALRANKID, PMI_LOCAL_RANK, MV2_COMM_WORLD_LOCAL_RANK,
+//      SLURM_LOCALID)
+//   3. -1, which makes amd_gpu_agent.cpp fall back to getpid().
+namespace {
+
+bool ParseNonNegInt(const std::string& s, int64_t& out) {
+  if (s.empty() || s.find_first_not_of("0123456789") != std::string::npos) return false;
+  int64_t parsed = 0;
+  for (char c : s) {
+    parsed = parsed * 10 + (c - '0');
+    if (parsed > 0x7fffffff) return false;
+  }
+  out = parsed;
+  return true;
+}
+
+const char* const kLocalRankVars[] = {
+    "LOCAL_RANK",
+    "OMPI_COMM_WORLD_LOCAL_RANK",
+    "MPI_LOCALRANKID",
+    "PMI_LOCAL_RANK",
+    "MV2_COMM_WORLD_LOCAL_RANK",
+    "SLURM_LOCALID"};
+
+// Resolves the seed offset (>=0) and its source name; source is "" when the
+// result is -1 (getpid() fallback).
+int64_t ResolveSeedOffset(std::string* source) {
+  int64_t offset = ParseSdmaEngineIdOffset(std::getenv("ROCR_SDMA_ENGINE_ID_OFFSET"));
+  if (offset >= 0) {
+    if (source) *source = "ROCR_SDMA_ENGINE_ID_OFFSET";
+    return offset;
+  }
+  for (const char* name : kLocalRankVars) {
+    const char* raw = std::getenv(name);
+    int64_t rank = -1;
+    if (raw != nullptr && ParseNonNegInt(std::string(raw), rank)) {
+      if (source) *source = name;
+      return rank;
+    }
+  }
+  if (source) source->clear();
+  return -1;
+}
+
+void ClearSeedEnv() {
+  unsetenv("ROCR_SDMA_ENGINE_ID_OFFSET");
+  for (const char* name : kLocalRankVars) unsetenv(name);
+}
+
+}  // namespace
+
+TEST(RocrSdmaSeedOffset, OffsetOnly) {
+  ClearSeedEnv();
+  ASSERT_EQ(0, setenv("ROCR_SDMA_ENGINE_ID_OFFSET", "7", 1));
+  std::string src;
+  EXPECT_EQ(static_cast<int64_t>(7), ResolveSeedOffset(&src));
+  EXPECT_EQ("ROCR_SDMA_ENGINE_ID_OFFSET", src);
+  ClearSeedEnv();
+}
+
+TEST(RocrSdmaSeedOffset, OffsetOverridesRank) {
+  ClearSeedEnv();
+  ASSERT_EQ(0, setenv("ROCR_SDMA_ENGINE_ID_OFFSET", "2", 1));
+  ASSERT_EQ(0, setenv("OMPI_COMM_WORLD_LOCAL_RANK", "5", 1));
+  std::string src;
+  EXPECT_EQ(static_cast<int64_t>(2), ResolveSeedOffset(&src));
+  EXPECT_EQ("ROCR_SDMA_ENGINE_ID_OFFSET", src);
+  ClearSeedEnv();
+}
+
+TEST(RocrSdmaSeedOffset, SingleRankVar) {
+  ClearSeedEnv();
+  ASSERT_EQ(0, setenv("SLURM_LOCALID", "3", 1));
+  std::string src;
+  EXPECT_EQ(static_cast<int64_t>(3), ResolveSeedOffset(&src));
+  EXPECT_EQ("SLURM_LOCALID", src);
+  ClearSeedEnv();
+}
+
+TEST(RocrSdmaSeedOffset, RankVarPriorityOrder) {
+  ClearSeedEnv();
+  // LOCAL_RANK precedes the MPI/SLURM variables; the first listed wins.
+  ASSERT_EQ(0, setenv("SLURM_LOCALID", "9", 1));
+  ASSERT_EQ(0, setenv("MPI_LOCALRANKID", "8", 1));
+  ASSERT_EQ(0, setenv("LOCAL_RANK", "1", 1));
+  std::string src;
+  EXPECT_EQ(static_cast<int64_t>(1), ResolveSeedOffset(&src));
+  EXPECT_EQ("LOCAL_RANK", src);
+  ClearSeedEnv();
+}
+
+TEST(RocrSdmaSeedOffset, InvalidRankIsSkipped) {
+  ClearSeedEnv();
+  // The first var has a malformed value; the resolver skips it and takes the
+  // next valid one.
+  ASSERT_EQ(0, setenv("LOCAL_RANK", "-4", 1));
+  ASSERT_EQ(0, setenv("OMPI_COMM_WORLD_LOCAL_RANK", "6", 1));
+  std::string src;
+  EXPECT_EQ(static_cast<int64_t>(6), ResolveSeedOffset(&src));
+  EXPECT_EQ("OMPI_COMM_WORLD_LOCAL_RANK", src);
+  ClearSeedEnv();
+}
+
+TEST(RocrSdmaSeedOffset, NoneFallsBackToPid) {
+  ClearSeedEnv();
+  std::string src = "sentinel";
+  EXPECT_EQ(static_cast<int64_t>(-1), ResolveSeedOffset(&src));
+  EXPECT_TRUE(src.empty());
+  ClearSeedEnv();
+}
+
+// Method D: ROCR_SDMA_D2H_ENGINE_LIMIT caps the D2H round-robin to the first N
+// SDMA engines. Parse mirrors rocr::Flag::Refresh(): 0 / unset / malformed ->
+// 0 (no limit); a valid non-negative integer -> that value (amd_gpu_agent.cpp
+// clamps it to the engine count with std::min at queue-creation time).
+namespace {
+
+int64_t ParseD2hEngineLimit(const char* raw) {
+  const std::string var = (raw != nullptr) ? std::string(raw) : std::string();
+  int64_t limit = 0;
+  ParseNonNegInt(var, limit);
+  return limit;
+}
+
+int64_t ParseD2hLimitFromEnv() {
+  return ParseD2hEngineLimit(std::getenv("ROCR_SDMA_D2H_ENGINE_LIMIT"));
+}
+
+}  // namespace
+
+TEST(RocrSdmaD2hEngineLimit, UnsetIsZero) {
+  unsetenv("ROCR_SDMA_D2H_ENGINE_LIMIT");
+  EXPECT_EQ(static_cast<int64_t>(0), ParseD2hLimitFromEnv());
+}
+
+TEST(RocrSdmaD2hEngineLimit, ZeroIsDisabled) {
+  ASSERT_EQ(0, setenv("ROCR_SDMA_D2H_ENGINE_LIMIT", "0", 1));
+  EXPECT_EQ(static_cast<int64_t>(0), ParseD2hLimitFromEnv());
+  unsetenv("ROCR_SDMA_D2H_ENGINE_LIMIT");
+}
+
+TEST(RocrSdmaD2hEngineLimit, ValidValue) {
+  ASSERT_EQ(0, setenv("ROCR_SDMA_D2H_ENGINE_LIMIT", "8", 1));
+  EXPECT_EQ(static_cast<int64_t>(8), ParseD2hLimitFromEnv());
+  unsetenv("ROCR_SDMA_D2H_ENGINE_LIMIT");
+}
+
+TEST(RocrSdmaD2hEngineLimit, LargeValueParsesForClamping) {
+  // Values above the engine count still parse; amd_gpu_agent.cpp clamps them to
+  // the available engine count via std::min at queue-creation time.
+  ASSERT_EQ(0, setenv("ROCR_SDMA_D2H_ENGINE_LIMIT", "64", 1));
+  EXPECT_EQ(static_cast<int64_t>(64), ParseD2hLimitFromEnv());
+  unsetenv("ROCR_SDMA_D2H_ENGINE_LIMIT");
+}
+
+TEST(RocrSdmaD2hEngineLimit, MalformedIsZero) {
+  ASSERT_EQ(0, setenv("ROCR_SDMA_D2H_ENGINE_LIMIT", "abc", 1));
+  EXPECT_EQ(static_cast<int64_t>(0), ParseD2hLimitFromEnv());
+  unsetenv("ROCR_SDMA_D2H_ENGINE_LIMIT");
+}

--- a/projects/rocr-runtime/rocrtst/common/utils_test/sdma_round_robin_test.cpp
+++ b/projects/rocr-runtime/rocrtst/common/utils_test/sdma_round_robin_test.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 
+#include <cstdint>
 #include <cstdlib>
 #include <string>
 
@@ -86,4 +87,71 @@ TEST(RocrSdmaRoundRobinPcieXgmi, DefaultForUnrecognizedValue) {
   ASSERT_EQ(0, setenv("ROCR_SDMA_ROUND_ROBIN_PCIE_XGMI", "yes", 1));
   EXPECT_EQ(rocr::Flag::SDMA_DEFAULT, ParseFromEnvPcieXgmi());
   unsetenv("ROCR_SDMA_ROUND_ROBIN_PCIE_XGMI");
+}
+
+// ROCR_SDMA_ENGINE_ID_OFFSET lets a launcher pass an explicit non-negative
+// engine-id offset that replaces the getpid() seed in the round-robin pick,
+// so concurrent processes do not alias onto the same engine. The parse mirrors
+// rocr::Flag::Refresh(): a value of 0 is a valid explicit offset; unset,
+// negative, non-numeric or out-of-range input yields the -1 "unset" sentinel
+// (fall back to getpid()).
+namespace {
+
+int64_t ParseSdmaEngineIdOffset(const char* raw) {
+  const std::string var = (raw != nullptr) ? std::string(raw) : std::string();
+  int64_t offset = -1;
+  if (!var.empty() && var.find_first_not_of("0123456789") == std::string::npos) {
+    int64_t parsed = 0;
+    bool valid = true;
+    for (char c : var) {
+      parsed = parsed * 10 + (c - '0');
+      if (parsed > 0x7fffffff) {
+        valid = false;
+        break;
+      }
+    }
+    if (valid) offset = parsed;
+  }
+  return offset;
+}
+
+int64_t ParseOffsetFromEnv() {
+  return ParseSdmaEngineIdOffset(std::getenv("ROCR_SDMA_ENGINE_ID_OFFSET"));
+}
+
+}  // namespace
+
+TEST(RocrSdmaEngineIdOffset, UnsetIsSentinel) {
+  unsetenv("ROCR_SDMA_ENGINE_ID_OFFSET");
+  EXPECT_EQ(static_cast<int64_t>(-1), ParseOffsetFromEnv());
+}
+
+TEST(RocrSdmaEngineIdOffset, ZeroIsExplicit) {
+  ASSERT_EQ(0, setenv("ROCR_SDMA_ENGINE_ID_OFFSET", "0", 1));
+  EXPECT_EQ(static_cast<int64_t>(0), ParseOffsetFromEnv());
+  unsetenv("ROCR_SDMA_ENGINE_ID_OFFSET");
+}
+
+TEST(RocrSdmaEngineIdOffset, PositiveValue) {
+  ASSERT_EQ(0, setenv("ROCR_SDMA_ENGINE_ID_OFFSET", "5", 1));
+  EXPECT_EQ(static_cast<int64_t>(5), ParseOffsetFromEnv());
+  unsetenv("ROCR_SDMA_ENGINE_ID_OFFSET");
+}
+
+TEST(RocrSdmaEngineIdOffset, NonNumericFallsBack) {
+  ASSERT_EQ(0, setenv("ROCR_SDMA_ENGINE_ID_OFFSET", "abc", 1));
+  EXPECT_EQ(static_cast<int64_t>(-1), ParseOffsetFromEnv());
+  unsetenv("ROCR_SDMA_ENGINE_ID_OFFSET");
+}
+
+TEST(RocrSdmaEngineIdOffset, NegativeFallsBack) {
+  ASSERT_EQ(0, setenv("ROCR_SDMA_ENGINE_ID_OFFSET", "-3", 1));
+  EXPECT_EQ(static_cast<int64_t>(-1), ParseOffsetFromEnv());
+  unsetenv("ROCR_SDMA_ENGINE_ID_OFFSET");
+}
+
+TEST(RocrSdmaEngineIdOffset, OutOfRangeFallsBack) {
+  ASSERT_EQ(0, setenv("ROCR_SDMA_ENGINE_ID_OFFSET", "99999999999", 1));
+  EXPECT_EQ(static_cast<int64_t>(-1), ParseOffsetFromEnv());
+  unsetenv("ROCR_SDMA_ENGINE_ID_OFFSET");
 }

--- a/projects/rocr-runtime/rocrtst/common/utils_test/sdma_round_robin_test.cpp
+++ b/projects/rocr-runtime/rocrtst/common/utils_test/sdma_round_robin_test.cpp
@@ -11,8 +11,9 @@
 
 #include "core/util/flag.h"
 
-// Unit test for the ROCR_SDMA_ROUND_ROBIN environment-variable parsing added to
-// rocr::Flag. rocr::Flag::Refresh() maps the variable onto an SDMA_OVERRIDE
+// Unit test for the ROCR_SDMA_ROUND_ROBIN and ROCR_SDMA_ROUND_ROBIN_PCIE_XGMI
+// environment-variable parsing added to rocr::Flag. rocr::Flag::Refresh() maps
+// each variable onto an SDMA_OVERRIDE
 // tri-state with the rule:
 //   "1"           -> SDMA_ENABLE
 //   "0"           -> SDMA_DISABLE
@@ -33,6 +34,10 @@ rocr::Flag::SDMA_OVERRIDE ParseSdmaRoundRobin(const char* raw) {
 
 rocr::Flag::SDMA_OVERRIDE ParseFromEnv() {
   return ParseSdmaRoundRobin(std::getenv("ROCR_SDMA_ROUND_ROBIN"));
+}
+
+rocr::Flag::SDMA_OVERRIDE ParseFromEnvPcieXgmi() {
+  return ParseSdmaRoundRobin(std::getenv("ROCR_SDMA_ROUND_ROBIN_PCIE_XGMI"));
 }
 
 }  // namespace
@@ -58,4 +63,27 @@ TEST(RocrSdmaRoundRobin, DefaultForUnrecognizedValue) {
   ASSERT_EQ(0, setenv("ROCR_SDMA_ROUND_ROBIN", "yes", 1));
   EXPECT_EQ(rocr::Flag::SDMA_DEFAULT, ParseFromEnv());
   unsetenv("ROCR_SDMA_ROUND_ROBIN");
+}
+
+TEST(RocrSdmaRoundRobinPcieXgmi, EnabledWhenOne) {
+  ASSERT_EQ(0, setenv("ROCR_SDMA_ROUND_ROBIN_PCIE_XGMI", "1", 1));
+  EXPECT_EQ(rocr::Flag::SDMA_ENABLE, ParseFromEnvPcieXgmi());
+  unsetenv("ROCR_SDMA_ROUND_ROBIN_PCIE_XGMI");
+}
+
+TEST(RocrSdmaRoundRobinPcieXgmi, DisabledWhenZero) {
+  ASSERT_EQ(0, setenv("ROCR_SDMA_ROUND_ROBIN_PCIE_XGMI", "0", 1));
+  EXPECT_EQ(rocr::Flag::SDMA_DISABLE, ParseFromEnvPcieXgmi());
+  unsetenv("ROCR_SDMA_ROUND_ROBIN_PCIE_XGMI");
+}
+
+TEST(RocrSdmaRoundRobinPcieXgmi, DefaultWhenUnset) {
+  unsetenv("ROCR_SDMA_ROUND_ROBIN_PCIE_XGMI");
+  EXPECT_EQ(rocr::Flag::SDMA_DEFAULT, ParseFromEnvPcieXgmi());
+}
+
+TEST(RocrSdmaRoundRobinPcieXgmi, DefaultForUnrecognizedValue) {
+  ASSERT_EQ(0, setenv("ROCR_SDMA_ROUND_ROBIN_PCIE_XGMI", "yes", 1));
+  EXPECT_EQ(rocr::Flag::SDMA_DEFAULT, ParseFromEnvPcieXgmi());
+  unsetenv("ROCR_SDMA_ROUND_ROBIN_PCIE_XGMI");
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
@@ -1069,6 +1069,13 @@ class GpuAgent : public GpuAgentInt {
   // Check if SDMA engine by ID is free
   bool DmaEngineIsFree(uint32_t engine_id);
 
+  // @brief Opt-in cross-process SDMA engine spread (HSA_SDMA_ROUND_ROBIN*,
+  // HSA_SDMA_ENGINE_ID_OFFSET, HSA_SDMA_D2H_ENGINE_LIMIT) layered on top of the
+  // stateless NthSdmaEngine() per-copy selection. Returns a 1-indexed blit
+  // engine index for gfx94x host<->device copies, or 0 when no spread applies
+  // (caller keeps its stock NthSdmaEngine pick). See the definition for details.
+  uint32_t CrossProcessSdmaEngine(bool is_h2d, uint32_t k);
+
   std::map<uint64_t,unsigned int> gang_peers_info_;
 
   std::map<uint64_t, uint32_t> rec_sdma_eng_id_peers_info_;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -55,7 +55,11 @@
 #include <utility>
 #include <iomanip>
 #include <cmath>
-#include <unistd.h>
+#ifdef _WIN32
+#include <process.h>  // _getpid
+#else
+#include <unistd.h>  // getpid
+#endif
 
 #include "core/inc/amd_aql_queue.h"
 #include "core/inc/amd_blit_kernel.h"
@@ -78,6 +82,18 @@
 // Generated header
 #include "amd_trap_handler_v2.h"
 #include "amd_blit_shaders_v2.h"
+
+namespace {
+// Portable process id used only as the SDMA round-robin seed fallback.
+// getpid() is POSIX; MSVC provides _getpid() via <process.h>.
+inline int PortableGetpid() {
+#ifdef _WIN32
+  return _getpid();
+#else
+  return getpid();
+#endif
+}
+}  // namespace
 
 #if defined(__linux__)
 // libdrm headers
@@ -964,7 +980,7 @@ void GpuAgent::InitDma() {
         const Flag& rt_flag = core::Runtime::runtime_singleton_->flag();
         const int64_t sdma_seed_off = rt_flag.sdma_seed_offset();
         const uint32_t sdma_seed = (sdma_seed_off >= 0) ? static_cast<uint32_t>(sdma_seed_off)
-                                                        : static_cast<uint32_t>(getpid());
+                                                        : static_cast<uint32_t>(PortableGetpid());
         const char* sdma_seed_src =
             (sdma_seed_off >= 0) ? rt_flag.sdma_seed_source().c_str() : "getpid()";
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -929,24 +929,37 @@ void GpuAgent::InitDma() {
       }
 
       // gfx942, gfx950 and newer (CDNA in major 9, minor >= 4) expose two
-      // general-purpose SDMA copy engines for host<->device transfers, and
-      // the default reverses
-      // SDMA0/1 for those copies. With ROCR_SDMA_ROUND_ROBIN=1, spread queue
-      // creation across all available SDMA engines using a pid seed so
-      // concurrent processes/streams land on different engines instead of
-      // contending on a single one.
+      // general-purpose (PCIe/paging) SDMA copy engines for host<->device
+      // transfers, and the default reverses SDMA0/1 for those copies.
       //
-      // The benefit depends on the partition mode. In CPX (core-partitioned)
-      // mode each partition is a single XCD that can enable only two SDMA
-      // engines -- one dedicated to H2D and one to D2H -- so there is no spare
-      // engine to round-robin onto and this flag has no effect. In SPX (single
-      // partition) mode the one device spans all XCDs and their SDMA engines,
-      // so host<->device copies can use SDMA engines on otherwise-idle XCDs,
-      // raising aggregate bandwidth. The NumSdmaEngines / NumSdmaXgmiEngines
-      // guards naturally no-op the flag when there is no spare engine.
+      // ROCR_SDMA_ROUND_ROBIN=1 spreads queue creation across the two
+      // PCIe/paging engines (NumSdmaEngines) using a pid seed so concurrent
+      // processes/streams land on different engines instead of contending on a
+      // single one. On these parts both PCIe/paging engines live on the first
+      // XCD/XCC, so this stays within that XCC.
+      //
+      // ROCR_SDMA_ROUND_ROBIN_PCIE_XGMI=1 widens the round-robin to ALL SDMA
+      // engines (NumSdmaEngines PCIe/paging + NumSdmaXgmiEngines xGMI). The
+      // engines are grouped two-per-XCD/XCC, so spreading over the full set
+      // lets concurrent processes/streams reach engines on other XCCs and use
+      // each XCC's own path to host memory, raising aggregate bandwidth in SPX
+      // (single-partition) mode. In CPX (core-partitioned) mode a partition is
+      // a single XCD with no xGMI engines (NumSdmaXgmiEngines == 0), so it
+      // degrades to the two-engine behavior and is a no-op. When both flags are
+      // set the wider PCIE_XGMI behavior takes precedence. The downstream
+      // NumSdmaXgmiEngines guard still forces the default engine pick when no
+      // xGMI engine exists.
       if (!prefer_xgmi && supported_isas()[0]->GetMajorVersion() == 9 && supported_isas()[0]->GetMinorVersion() >= 4 &&
           properties_.NumSdmaEngines > 0) {
-        if (core::Runtime::runtime_singleton_->flag().sdma_round_robin() == Flag::SDMA_ENABLE) {
+        if (core::Runtime::runtime_singleton_->flag().sdma_round_robin_pcie_xgmi() ==
+            Flag::SDMA_ENABLE) {
+          const uint32_t total_eng =
+              properties_.NumSdmaEngines + properties_.NumSdmaXgmiEngines;
+          rec_eng = (static_cast<uint32_t>(getpid()) + rec_eng) % total_eng;
+          debug_print("ROCR_SDMA_ROUND_ROBIN_PCIE_XGMI: queue rec_eng=%u of %u SDMA engines\n",
+                      rec_eng, total_eng);
+        } else if (core::Runtime::runtime_singleton_->flag().sdma_round_robin() ==
+                   Flag::SDMA_ENABLE) {
           rec_eng = (static_cast<uint32_t>(getpid()) + rec_eng) % properties_.NumSdmaEngines;
           debug_print("ROCR_SDMA_ROUND_ROBIN: queue rec_eng=%u of %u SDMA engines\n",
                       rec_eng, properties_.NumSdmaEngines);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -951,8 +951,8 @@ void GpuAgent::InitDma() {
       // behavior takes precedence. The downstream
       // NumSdmaXgmiEngines guard still forces the default engine pick when no
       // xGMI engine exists.
-      if (!prefer_xgmi && supported_isas()[0]->GetMajorVersion() == 9 && supported_isas()[0]->GetMinorVersion() >= 4 &&
-          properties_.NumSdmaEngines > 0) {
+      if (!prefer_xgmi && supported_isas()[0]->GetMajorVersion() == 9 &&
+          supported_isas()[0]->GetMinorVersion() >= 4 && properties_.NumSdmaEngines > 0) {
         // Method A: the round-robin seed comes from Flag, which resolves it in
         // priority order: HSA_SDMA_ENGINE_ID_OFFSET (explicit, includes 0),
         // then a launcher local-rank env var (LOCAL_RANK,
@@ -963,9 +963,8 @@ void GpuAgent::InitDma() {
         // cause (two pids reducing to the same engine).
         const Flag& rt_flag = core::Runtime::runtime_singleton_->flag();
         const int64_t sdma_seed_off = rt_flag.sdma_seed_offset();
-        const uint32_t sdma_seed =
-            (sdma_seed_off >= 0) ? static_cast<uint32_t>(sdma_seed_off)
-                                 : static_cast<uint32_t>(getpid());
+        const uint32_t sdma_seed = (sdma_seed_off >= 0) ? static_cast<uint32_t>(sdma_seed_off)
+                                                        : static_cast<uint32_t>(getpid());
         const char* sdma_seed_src =
             (sdma_seed_off >= 0) ? rt_flag.sdma_seed_source().c_str() : "getpid()";
 
@@ -977,19 +976,18 @@ void GpuAgent::InitDma() {
         const bool limit_d2h = (!isHostToDev && d2h_limit > 0);
 
         if (rt_flag.sdma_round_robin_pcie_xgmi() == Flag::SDMA_ENABLE) {
-          uint32_t total_eng =
-              properties_.NumSdmaEngines + properties_.NumSdmaXgmiEngines;
+          uint32_t total_eng = properties_.NumSdmaEngines + properties_.NumSdmaXgmiEngines;
           if (limit_d2h)
             total_eng = std::min<uint32_t>(total_eng, static_cast<uint32_t>(d2h_limit));
           rec_eng = (sdma_seed + rec_eng) % total_eng;
           debug_print(
-              "HSA_SDMA_ROUND_ROBIN_PCIE_XGMI: seed=%u (%s) dir=%s rec_eng=%u of %u SDMA engines%s\n",
+              "HSA_SDMA_ROUND_ROBIN_PCIE_XGMI: seed=%u (%s) dir=%s rec_eng=%u of %u SDMA "
+              "engines%s\n",
               sdma_seed, sdma_seed_src, isHostToDev ? "H2D" : "D2H", rec_eng, total_eng,
               limit_d2h ? " [D2H near-AID limit]" : "");
         } else if (rt_flag.sdma_round_robin() == Flag::SDMA_ENABLE) {
           uint32_t mod_eng = properties_.NumSdmaEngines;
-          if (limit_d2h)
-            mod_eng = std::min<uint32_t>(mod_eng, static_cast<uint32_t>(d2h_limit));
+          if (limit_d2h) mod_eng = std::min<uint32_t>(mod_eng, static_cast<uint32_t>(d2h_limit));
           rec_eng = (sdma_seed + rec_eng) % mod_eng;
           debug_print("HSA_SDMA_ROUND_ROBIN: seed=%u (%s) dir=%s rec_eng=%u of %u SDMA engines%s\n",
                       sdma_seed, sdma_seed_src, isHostToDev ? "H2D" : "D2H", rec_eng, mod_eng,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -1244,6 +1244,56 @@ static bool GangCopyCompleteHandler(hsa_signal_value_t, void *arg ) {
   return false;
 }
 
+// Cross-process SDMA engine spread for gfx94x host<->device copies (opt-in).
+//
+// #8456 selects the per-copy engine via NthSdmaEngine(mask, k) with a
+// per-copy/per-entry index k. That spreads engines *within* a single copy but
+// is identical across processes. This helper re-introduces the PR #8565
+// cross-process spreading on top of that stateless model: it widens the engine
+// mask (PCIe-only, or PCIe + xGMI) and shifts the rotation by a per-process
+// seed so concurrent processes/streams land on different engines instead of
+// contending on the stock single pick.
+//
+// Returns a 1-indexed blit engine index (suitable for GetBlitObject), or 0 when
+// the spread does not apply -- in which case the caller keeps its stock
+// NthSdmaEngine(rec_mask, k) pick. Only gfx94x (ISA major 9, minor >= 4)
+// host<->device copies are affected; gfx125+, P2P and D2D paths return 0. When
+// no HSA_SDMA_* flag is set the function also returns 0, so behavior is
+// bit-for-bit identical to stock.
+uint32_t GpuAgent::CrossProcessSdmaEngine(bool is_h2d, uint32_t k) {
+  if (!(supported_isas()[0]->GetMajorVersion() == 9 && supported_isas()[0]->GetMinorVersion() >= 4))
+    return 0;
+
+  const Flag& rt_flag = core::Runtime::runtime_singleton_->flag();
+  const bool pcie_xgmi = rt_flag.sdma_round_robin_pcie_xgmi() == Flag::SDMA_ENABLE;
+  const bool round_robin = rt_flag.sdma_round_robin() == Flag::SDMA_ENABLE;
+  const int64_t d2h_limit = rt_flag.sdma_d2h_engine_limit();
+  const bool limit_d2h = (!is_h2d && d2h_limit > 0);
+
+  // Nothing opted in -> stock behavior (caller's k=0 / k=d pick is unchanged).
+  if (!pcie_xgmi && !round_robin && !limit_d2h) return 0;
+
+  // Build the spread mask over blit engine indices. HSA_SDMA_ROUND_ROBIN_PCIE_XGMI
+  // widens to all SDMA engines and takes precedence over HSA_SDMA_ROUND_ROBIN.
+  uint32_t spread_mask = pcie_xgmi ? (1u << (num_h2d_d2h_engines_ + num_p2p_engines_)) - 1
+                                   : (1u << num_h2d_d2h_engines_) - 1;
+
+  // Method D: cap D2H to the first N engines of the mask (near-AID subset).
+  // N is clamped to the available engine count; H2D is never limited.
+  if (limit_d2h) {
+    const uint32_t count = static_cast<uint32_t>(rocr::os::Popcount(spread_mask));
+    const uint32_t keep = std::min<uint32_t>(count, static_cast<uint32_t>(d2h_limit));
+    spread_mask &= (1u << keep) - 1;
+  }
+  if (!spread_mask) return 0;
+
+  // Per-process seed: explicit offset > launcher local-rank > PortableGetpid().
+  const int64_t seed_off = rt_flag.sdma_seed_offset();
+  const uint32_t seed =
+      (seed_off >= 0) ? static_cast<uint32_t>(seed_off) : static_cast<uint32_t>(PortableGetpid());
+  return NthSdmaEngine(spread_mask, seed + k);
+}
+
 hsa_status_t GpuAgent::DmaCopy(void* dst, core::Agent& dst_agent,
                                const void* src, core::Agent& src_agent,
                                size_t size,
@@ -1253,6 +1303,17 @@ hsa_status_t GpuAgent::DmaCopy(void* dst, core::Agent& dst_agent,
   uint32_t rec_mask = 0;
   DmaPreferredEngine(dst_agent, src_agent, &rec_mask);
   uint32_t rec_sdma_eng = NthSdmaEngine(rec_mask, 0);
+  // Opt-in cross-process SDMA spread for gfx94x host<->device single copies.
+  {
+    const bool is_h2d = src_agent.device_type() == core::Agent::kAmdCpuDevice &&
+        dst_agent.device_type() == core::Agent::kAmdGpuDevice;
+    const bool is_d2h = dst_agent.device_type() == core::Agent::kAmdCpuDevice &&
+        src_agent.device_type() == core::Agent::kAmdGpuDevice;
+    if (is_h2d || is_d2h) {
+      uint32_t spread_eng = CrossProcessSdmaEngine(is_h2d, 0);
+      if (spread_eng) rec_sdma_eng = spread_eng;
+    }
+  }
   if (rec_sdma_eng)
     return DmaCopyOnEngine(dst, dst_agent, src, src_agent, size,
                            dep_signals, out_signal, rec_sdma_eng, false);
@@ -1616,6 +1677,14 @@ hsa_status_t GpuAgent::DmaCopyFanOutOp(
         uint32_t rec_mask = 0;
         DmaPreferredEngine(*dst_agent, *this, &rec_mask);
         int rec_eng = NthSdmaEngine(rec_mask, d);
+        // Opt-in cross-process SDMA spread: the source here is the local GPU,
+        // so a CPU destination is a D2H host<->device copy. Overlay the
+        // per-process seed on top of the per-entry index d, keeping #8456's
+        // in-copy fan-out while separating concurrent processes.
+        if (dst_agent->device_type() == core::Agent::kAmdCpuDevice) {
+          uint32_t spread_eng = CrossProcessSdmaEngine(/*is_h2d=*/false, d);
+          if (spread_eng) rec_eng = static_cast<int>(spread_eng);
+        }
         if (rec_eng) {
           lazy_ptr<core::Blit>& blit = GetBlitObject(rec_eng);
           if (blit->isSDMA()) {
@@ -2179,6 +2248,18 @@ hsa_status_t GpuAgent::DmaCopyBatch(const hsa_amd_memory_copy_op_t* ops,
         uint32_t rec_mask = 0;
         DmaPreferredEngine(*dst_agent, *src_agent, &rec_mask);
         uint32_t engine_offset = NthSdmaEngine(rec_mask, 0);
+        // Opt-in cross-process SDMA spread for gfx94x host<->device single-entry
+        // batch copies (same treatment as DmaCopy).
+        {
+          const bool is_h2d = src_agent->device_type() == core::Agent::kAmdCpuDevice &&
+              dst_agent->device_type() == core::Agent::kAmdGpuDevice;
+          const bool is_d2h = dst_agent->device_type() == core::Agent::kAmdCpuDevice &&
+              src_agent->device_type() == core::Agent::kAmdGpuDevice;
+          if (is_h2d || is_d2h) {
+            uint32_t spread_eng = CrossProcessSdmaEngine(is_h2d, 0);
+            if (spread_eng) engine_offset = spread_eng;
+          }
+        }
         if (!engine_offset) {
           bool is_h2d = (src_agent->device_type() == core::Agent::kAmdCpuDevice &&
                          dst_agent->device_type() == core::Agent::kAmdGpuDevice);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -928,31 +928,33 @@ void GpuAgent::InitDma() {
         *blits_[BlitHostToDev];
       }
 
-      // gfx942, gfx950 and newer (CDNA in major 9, minor >= 4) expose two
-      // general-purpose (PCIe/paging) SDMA copy engines for host<->device
-      // transfers, and the default reverses SDMA0/1 for those copies.
+      // CDNA parts with ISA major 9 and minor >= 4 (the isa_->GetMinorVersion()
+      // >= 4 guard below; e.g. gfx940 / gfx941 / gfx942 / gfx950 and newer)
+      // expose two general-purpose (PCIe/paging) SDMA copy engines for
+      // host<->device transfers, and the default reverses SDMA0/1 for those
+      // copies.
       //
-      // ROCR_SDMA_ROUND_ROBIN=1 spreads queue creation across the two
+      // HSA_SDMA_ROUND_ROBIN=1 spreads queue creation across the two
       // PCIe/paging engines (NumSdmaEngines) using a pid seed so concurrent
       // processes/streams land on different engines instead of contending on a
       // single one. On these parts both PCIe/paging engines live on the first
       // XCD/XCC, so this stays within that XCC.
       //
-      // ROCR_SDMA_ROUND_ROBIN_PCIE_XGMI=1 widens the round-robin to ALL SDMA
+      // HSA_SDMA_ROUND_ROBIN_PCIE_XGMI=1 widens the round-robin to ALL SDMA
       // engines (NumSdmaEngines PCIe/paging + NumSdmaXgmiEngines xGMI). The
       // engines are grouped two-per-XCD/XCC, so spreading over the full set
       // lets concurrent processes/streams reach engines on other XCCs and use
-      // each XCC's own path to host memory, raising aggregate bandwidth in SPX
-      // (single-partition) mode. In CPX (core-partitioned) mode a partition is
-      // a single XCD with no xGMI engines (NumSdmaXgmiEngines == 0), so it
-      // degrades to the two-engine behavior and is a no-op. When both flags are
-      // set the wider PCIE_XGMI behavior takes precedence. The downstream
+      // each XCC's own path to host memory, raising aggregate bandwidth (see
+      // flag.h for the full SPX vs CPX rationale; on a single-XCD / CPX
+      // partition NumSdmaXgmiEngines == 0, so this degrades to the two-engine
+      // behavior and is a no-op). When both flags are set the wider PCIE_XGMI
+      // behavior takes precedence. The downstream
       // NumSdmaXgmiEngines guard still forces the default engine pick when no
       // xGMI engine exists.
       if (!prefer_xgmi && supported_isas()[0]->GetMajorVersion() == 9 && supported_isas()[0]->GetMinorVersion() >= 4 &&
           properties_.NumSdmaEngines > 0) {
         // Method A: the round-robin seed comes from Flag, which resolves it in
-        // priority order: ROCR_SDMA_ENGINE_ID_OFFSET (explicit, includes 0),
+        // priority order: HSA_SDMA_ENGINE_ID_OFFSET (explicit, includes 0),
         // then a launcher local-rank env var (LOCAL_RANK,
         // OMPI_COMM_WORLD_LOCAL_RANK, MPI_LOCALRANKID, PMI_LOCAL_RANK,
         // MV2_COMM_WORLD_LOCAL_RANK, SLURM_LOCALID). When none is present the
@@ -967,7 +969,7 @@ void GpuAgent::InitDma() {
         const char* sdma_seed_src =
             (sdma_seed_off >= 0) ? rt_flag.sdma_seed_source().c_str() : "getpid()";
 
-        // Method D (opt-in, ROCR_SDMA_D2H_ENGINE_LIMIT=N): restrict D2H copies
+        // Method D (opt-in, HSA_SDMA_D2H_ENGINE_LIMIT=N): restrict D2H copies
         // (isHostToDev == false) to the first N SDMA engines (the near-AID
         // subset). H2D is never limited. 0 keeps the default of spreading over
         // all engines. N is clamped to the available engine count below.
@@ -981,7 +983,7 @@ void GpuAgent::InitDma() {
             total_eng = std::min<uint32_t>(total_eng, static_cast<uint32_t>(d2h_limit));
           rec_eng = (sdma_seed + rec_eng) % total_eng;
           debug_print(
-              "ROCR_SDMA_ROUND_ROBIN_PCIE_XGMI: seed=%u (%s) dir=%s rec_eng=%u of %u SDMA engines%s\n",
+              "HSA_SDMA_ROUND_ROBIN_PCIE_XGMI: seed=%u (%s) dir=%s rec_eng=%u of %u SDMA engines%s\n",
               sdma_seed, sdma_seed_src, isHostToDev ? "H2D" : "D2H", rec_eng, total_eng,
               limit_d2h ? " [D2H near-AID limit]" : "");
         } else if (rt_flag.sdma_round_robin() == Flag::SDMA_ENABLE) {
@@ -989,7 +991,7 @@ void GpuAgent::InitDma() {
           if (limit_d2h)
             mod_eng = std::min<uint32_t>(mod_eng, static_cast<uint32_t>(d2h_limit));
           rec_eng = (sdma_seed + rec_eng) % mod_eng;
-          debug_print("ROCR_SDMA_ROUND_ROBIN: seed=%u (%s) dir=%s rec_eng=%u of %u SDMA engines%s\n",
+          debug_print("HSA_SDMA_ROUND_ROBIN: seed=%u (%s) dir=%s rec_eng=%u of %u SDMA engines%s\n",
                       sdma_seed, sdma_seed_src, isHostToDev ? "H2D" : "D2H", rec_eng, mod_eng,
                       limit_d2h ? " [D2H near-AID limit]" : "");
         } else if (limit_d2h) {
@@ -999,7 +1001,7 @@ void GpuAgent::InitDma() {
               std::min<uint32_t>(properties_.NumSdmaEngines, static_cast<uint32_t>(d2h_limit));
           rec_eng = (sdma_seed + rec_eng) % mod_eng;
           debug_print(
-              "ROCR_SDMA_D2H_ENGINE_LIMIT: seed=%u (%s) dir=D2H rec_eng=%u of %u near-AID engines\n",
+              "HSA_SDMA_D2H_ENGINE_LIMIT: seed=%u (%s) dir=D2H rec_eng=%u of %u near-AID engines\n",
               sdma_seed, sdma_seed_src, rec_eng, mod_eng);
         } else {
           (void)sdma_seed_src;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -928,9 +928,9 @@ void GpuAgent::InitDma() {
         *blits_[BlitHostToDev];
       }
 
-      // gfx942, gfx950 and newer (CDNA in major 9, minor >= 4; e.g.
-      // MI300/MI308/MI325 and MI350/MI355) expose two general-purpose SDMA
-      // copy engines for host<->device transfers, and the default reverses
+      // gfx942, gfx950 and newer (CDNA in major 9, minor >= 4) expose two
+      // general-purpose SDMA copy engines for host<->device transfers, and
+      // the default reverses
       // SDMA0/1 for those copies. With ROCR_SDMA_ROUND_ROBIN=1, spread queue
       // creation across all available SDMA engines using a pid seed so
       // concurrent processes/streams land on different engines instead of

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -951,19 +951,33 @@ void GpuAgent::InitDma() {
       // xGMI engine exists.
       if (!prefer_xgmi && supported_isas()[0]->GetMajorVersion() == 9 && supported_isas()[0]->GetMinorVersion() >= 4 &&
           properties_.NumSdmaEngines > 0) {
+        // Seed for the round-robin pick. ROCR_SDMA_ENGINE_ID_OFFSET, when set
+        // to a valid non-negative integer, provides an explicit offset (e.g. a
+        // launcher-assigned local rank) so concurrent processes deterministically
+        // land on different engines. getpid() is only a fallback and can alias
+        // (pid_a % n == pid_b % n), colliding two processes on one engine.
+        const int64_t sdma_off =
+            core::Runtime::runtime_singleton_->flag().sdma_engine_id_offset();
+        const uint32_t sdma_seed =
+            (sdma_off >= 0) ? static_cast<uint32_t>(sdma_off)
+                            : static_cast<uint32_t>(getpid());
+        const char* sdma_seed_src =
+            (sdma_off >= 0) ? "ROCR_SDMA_ENGINE_ID_OFFSET" : "getpid()";
         if (core::Runtime::runtime_singleton_->flag().sdma_round_robin_pcie_xgmi() ==
             Flag::SDMA_ENABLE) {
           const uint32_t total_eng =
               properties_.NumSdmaEngines + properties_.NumSdmaXgmiEngines;
-          rec_eng = (static_cast<uint32_t>(getpid()) + rec_eng) % total_eng;
-          debug_print("ROCR_SDMA_ROUND_ROBIN_PCIE_XGMI: queue rec_eng=%u of %u SDMA engines\n",
-                      rec_eng, total_eng);
+          rec_eng = (sdma_seed + rec_eng) % total_eng;
+          debug_print(
+              "ROCR_SDMA_ROUND_ROBIN_PCIE_XGMI: seed=%u (%s) rec_eng=%u of %u SDMA engines\n",
+              sdma_seed, sdma_seed_src, rec_eng, total_eng);
         } else if (core::Runtime::runtime_singleton_->flag().sdma_round_robin() ==
                    Flag::SDMA_ENABLE) {
-          rec_eng = (static_cast<uint32_t>(getpid()) + rec_eng) % properties_.NumSdmaEngines;
-          debug_print("ROCR_SDMA_ROUND_ROBIN: queue rec_eng=%u of %u SDMA engines\n",
-                      rec_eng, properties_.NumSdmaEngines);
+          rec_eng = (sdma_seed + rec_eng) % properties_.NumSdmaEngines;
+          debug_print("ROCR_SDMA_ROUND_ROBIN: seed=%u (%s) rec_eng=%u of %u SDMA engines\n",
+                      sdma_seed, sdma_seed_src, rec_eng, properties_.NumSdmaEngines);
         } else {
+          (void)sdma_seed_src;
           rec_eng = (rec_eng + 1) % properties_.NumSdmaEngines;
         }
       }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -951,31 +951,56 @@ void GpuAgent::InitDma() {
       // xGMI engine exists.
       if (!prefer_xgmi && supported_isas()[0]->GetMajorVersion() == 9 && supported_isas()[0]->GetMinorVersion() >= 4 &&
           properties_.NumSdmaEngines > 0) {
-        // Seed for the round-robin pick. ROCR_SDMA_ENGINE_ID_OFFSET, when set
-        // to a valid non-negative integer, provides an explicit offset (e.g. a
-        // launcher-assigned local rank) so concurrent processes deterministically
-        // land on different engines. getpid() is only a fallback and can alias
-        // (pid_a % n == pid_b % n), colliding two processes on one engine.
-        const int64_t sdma_off =
-            core::Runtime::runtime_singleton_->flag().sdma_engine_id_offset();
+        // Method A: the round-robin seed comes from Flag, which resolves it in
+        // priority order: ROCR_SDMA_ENGINE_ID_OFFSET (explicit, includes 0),
+        // then a launcher local-rank env var (LOCAL_RANK,
+        // OMPI_COMM_WORLD_LOCAL_RANK, MPI_LOCALRANKID, PMI_LOCAL_RANK,
+        // MV2_COMM_WORLD_LOCAL_RANK, SLURM_LOCALID). When none is present the
+        // seed offset is -1 and we fall back to getpid() here. An explicit or
+        // rank-derived seed avoids the aliasing that getpid() % engine_count can
+        // cause (two pids reducing to the same engine).
+        const Flag& rt_flag = core::Runtime::runtime_singleton_->flag();
+        const int64_t sdma_seed_off = rt_flag.sdma_seed_offset();
         const uint32_t sdma_seed =
-            (sdma_off >= 0) ? static_cast<uint32_t>(sdma_off)
-                            : static_cast<uint32_t>(getpid());
+            (sdma_seed_off >= 0) ? static_cast<uint32_t>(sdma_seed_off)
+                                 : static_cast<uint32_t>(getpid());
         const char* sdma_seed_src =
-            (sdma_off >= 0) ? "ROCR_SDMA_ENGINE_ID_OFFSET" : "getpid()";
-        if (core::Runtime::runtime_singleton_->flag().sdma_round_robin_pcie_xgmi() ==
-            Flag::SDMA_ENABLE) {
-          const uint32_t total_eng =
+            (sdma_seed_off >= 0) ? rt_flag.sdma_seed_source().c_str() : "getpid()";
+
+        // Method D (opt-in, ROCR_SDMA_D2H_ENGINE_LIMIT=N): restrict D2H copies
+        // (isHostToDev == false) to the first N SDMA engines (the near-AID
+        // subset). H2D is never limited. 0 keeps the default of spreading over
+        // all engines. N is clamped to the available engine count below.
+        const int64_t d2h_limit = rt_flag.sdma_d2h_engine_limit();
+        const bool limit_d2h = (!isHostToDev && d2h_limit > 0);
+
+        if (rt_flag.sdma_round_robin_pcie_xgmi() == Flag::SDMA_ENABLE) {
+          uint32_t total_eng =
               properties_.NumSdmaEngines + properties_.NumSdmaXgmiEngines;
+          if (limit_d2h)
+            total_eng = std::min<uint32_t>(total_eng, static_cast<uint32_t>(d2h_limit));
           rec_eng = (sdma_seed + rec_eng) % total_eng;
           debug_print(
-              "ROCR_SDMA_ROUND_ROBIN_PCIE_XGMI: seed=%u (%s) rec_eng=%u of %u SDMA engines\n",
-              sdma_seed, sdma_seed_src, rec_eng, total_eng);
-        } else if (core::Runtime::runtime_singleton_->flag().sdma_round_robin() ==
-                   Flag::SDMA_ENABLE) {
-          rec_eng = (sdma_seed + rec_eng) % properties_.NumSdmaEngines;
-          debug_print("ROCR_SDMA_ROUND_ROBIN: seed=%u (%s) rec_eng=%u of %u SDMA engines\n",
-                      sdma_seed, sdma_seed_src, rec_eng, properties_.NumSdmaEngines);
+              "ROCR_SDMA_ROUND_ROBIN_PCIE_XGMI: seed=%u (%s) dir=%s rec_eng=%u of %u SDMA engines%s\n",
+              sdma_seed, sdma_seed_src, isHostToDev ? "H2D" : "D2H", rec_eng, total_eng,
+              limit_d2h ? " [D2H near-AID limit]" : "");
+        } else if (rt_flag.sdma_round_robin() == Flag::SDMA_ENABLE) {
+          uint32_t mod_eng = properties_.NumSdmaEngines;
+          if (limit_d2h)
+            mod_eng = std::min<uint32_t>(mod_eng, static_cast<uint32_t>(d2h_limit));
+          rec_eng = (sdma_seed + rec_eng) % mod_eng;
+          debug_print("ROCR_SDMA_ROUND_ROBIN: seed=%u (%s) dir=%s rec_eng=%u of %u SDMA engines%s\n",
+                      sdma_seed, sdma_seed_src, isHostToDev ? "H2D" : "D2H", rec_eng, mod_eng,
+                      limit_d2h ? " [D2H near-AID limit]" : "");
+        } else if (limit_d2h) {
+          // Method D can also apply on its own, without a round-robin flag:
+          // constrain the default D2H pick to the near-AID subset.
+          const uint32_t mod_eng =
+              std::min<uint32_t>(properties_.NumSdmaEngines, static_cast<uint32_t>(d2h_limit));
+          rec_eng = (sdma_seed + rec_eng) % mod_eng;
+          debug_print(
+              "ROCR_SDMA_D2H_ENGINE_LIMIT: seed=%u (%s) dir=D2H rec_eng=%u of %u near-AID engines\n",
+              sdma_seed, sdma_seed_src, rec_eng, mod_eng);
         } else {
           (void)sdma_seed_src;
           rec_eng = (rec_eng + 1) % properties_.NumSdmaEngines;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -55,6 +55,7 @@
 #include <utility>
 #include <iomanip>
 #include <cmath>
+#include <unistd.h>
 
 #include "core/inc/amd_aql_queue.h"
 #include "core/inc/amd_blit_kernel.h"
@@ -927,9 +928,32 @@ void GpuAgent::InitDma() {
         *blits_[BlitHostToDev];
       }
 
-      // gfx94x is more efficient with reverse order of SDMA0/1 for host<->device copies
-      if (!prefer_xgmi && supported_isas()[0]->GetMajorVersion() == 9 && supported_isas()[0]->GetMinorVersion() >= 4)
-        rec_eng = (rec_eng + 1) % properties_.NumSdmaEngines;
+      // gfx942, gfx950 and newer (CDNA in major 9, minor >= 4; e.g.
+      // MI300/MI308/MI325 and MI350/MI355) expose two general-purpose SDMA
+      // copy engines for host<->device transfers, and the default reverses
+      // SDMA0/1 for those copies. With ROCR_SDMA_ROUND_ROBIN=1, spread queue
+      // creation across all available SDMA engines using a pid seed so
+      // concurrent processes/streams land on different engines instead of
+      // contending on a single one.
+      //
+      // The benefit depends on the partition mode. In CPX (core-partitioned)
+      // mode each partition is a single XCD that can enable only two SDMA
+      // engines -- one dedicated to H2D and one to D2H -- so there is no spare
+      // engine to round-robin onto and this flag has no effect. In SPX (single
+      // partition) mode the one device spans all XCDs and their SDMA engines,
+      // so host<->device copies can use SDMA engines on otherwise-idle XCDs,
+      // raising aggregate bandwidth. The NumSdmaEngines / NumSdmaXgmiEngines
+      // guards naturally no-op the flag when there is no spare engine.
+      if (!prefer_xgmi && supported_isas()[0]->GetMajorVersion() == 9 && supported_isas()[0]->GetMinorVersion() >= 4 &&
+          properties_.NumSdmaEngines > 0) {
+        if (core::Runtime::runtime_singleton_->flag().sdma_round_robin() == Flag::SDMA_ENABLE) {
+          rec_eng = (static_cast<uint32_t>(getpid()) + rec_eng) % properties_.NumSdmaEngines;
+          debug_print("ROCR_SDMA_ROUND_ROBIN: queue rec_eng=%u of %u SDMA engines\n",
+                      rec_eng, properties_.NumSdmaEngines);
+        } else {
+          rec_eng = (rec_eng + 1) % properties_.NumSdmaEngines;
+        }
+      }
 
       // Check support for targeted SDMA engines
       auto kfd_version = core::Runtime::runtime_singleton_->KfdVersion().version;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
@@ -127,18 +127,31 @@ class Flag {
     enable_sdma_recommended_eng_ = (var == "0") ? SDMA_DISABLE :
                                    ((var == "1") ? SDMA_ENABLE : SDMA_DEFAULT);
 
-    // Round-robin distribution of host<->device SDMA copies across all
-    // available SDMA engines. Applies to gfx942, gfx950 and newer. Helps in
-    // SPX (single partition)
-    // mode, where the one device spans all XCDs and their SDMA engines,
-    // letting host<->device copies use engines on otherwise-idle XCDs. Has no
-    // effect in CPX (core-partitioned) mode: each partition is a single XCD
-    // that can enable only two SDMA engines (one H2D + one D2H), so there is
-    // no spare engine to round-robin onto. Opt-in via ROCR_SDMA_ROUND_ROBIN=1;
-    // default keeps the stock engine pick.
+    // Round-robin distribution of host<->device SDMA copies across the
+    // PCIe/paging SDMA engines. Applies to gfx942, gfx950 and newer (CDNA in
+    // major 9, minor >= 4). With a pid seed, concurrent processes/streams pick
+    // among the NumSdmaEngines general-purpose engines instead of contending
+    // on the default single engine. On these parts KFD exposes only two such
+    // engines and both live on the first XCD/XCC, so this stays within that
+    // XCC. Opt-in via ROCR_SDMA_ROUND_ROBIN=1; default keeps the stock pick.
     var = os::GetEnvVar("ROCR_SDMA_ROUND_ROBIN");
     sdma_round_robin_ = (var == "1") ? SDMA_ENABLE :
                         ((var == "0") ? SDMA_DISABLE : SDMA_DEFAULT);
+
+    // Widen the host<->device round-robin to ALL SDMA engines -- the
+    // NumSdmaEngines PCIe/paging engines plus the NumSdmaXgmiEngines xGMI
+    // engines. On gfx942/gfx950 the engines are grouped two-per-XCD/XCC (the
+    // two PCIe/paging engines sit on the first XCC, the xGMI engines on the
+    // remaining XCCs), so spreading over the full set lets concurrent
+    // processes/streams land on engines belonging to different XCCs and use
+    // each XCC's own path to host memory, raising aggregate bandwidth in SPX
+    // (single-partition) mode. In CPX (core-partitioned) mode a partition is a
+    // single XCD with no xGMI engines (NumSdmaXgmiEngines == 0), so this
+    // degrades safely to the two-engine behavior and is a no-op. Opt-in via
+    // ROCR_SDMA_ROUND_ROBIN_PCIE_XGMI=1; default keeps the stock pick.
+    var = os::GetEnvVar("ROCR_SDMA_ROUND_ROBIN_PCIE_XGMI");
+    sdma_round_robin_pcie_xgmi_ = (var == "1") ? SDMA_ENABLE :
+                                  ((var == "0") ? SDMA_DISABLE : SDMA_DEFAULT);
 
     visible_gpus_ = os::GetEnvVar("ROCR_VISIBLE_DEVICES");
     filter_visible_gpus_ = os::IsEnvVarSet("ROCR_VISIBLE_DEVICES");
@@ -432,6 +445,8 @@ class Flag {
 
   SDMA_OVERRIDE sdma_round_robin() const { return sdma_round_robin_; }
 
+  SDMA_OVERRIDE sdma_round_robin_pcie_xgmi() const { return sdma_round_robin_pcie_xgmi_; }
+
   std::string visible_gpus() const { return visible_gpus_; }
 
   bool filter_visible_gpus() const { return filter_visible_gpus_; }
@@ -618,6 +633,7 @@ class Flag {
   SDMA_OVERRIDE enable_sdma_copy_size_override_;
   SDMA_OVERRIDE enable_sdma_recommended_eng_;
   SDMA_OVERRIDE sdma_round_robin_;
+  SDMA_OVERRIDE sdma_round_robin_pcie_xgmi_;
 
   bool filter_visible_gpus_;
   std::string visible_gpus_;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
@@ -128,13 +128,14 @@ class Flag {
                                    ((var == "1") ? SDMA_ENABLE : SDMA_DEFAULT);
 
     // Round-robin distribution of host<->device SDMA copies across the
-    // PCIe/paging SDMA engines. Applies to gfx942, gfx950 and newer (CDNA in
-    // major 9, minor >= 4). With a pid seed, concurrent processes/streams pick
+    // PCIe/paging SDMA engines. Applies to CDNA parts with ISA major 9 and
+    // minor >= 4 (isa_->GetMinorVersion() >= 4; e.g. gfx940 / gfx941 / gfx942 /
+    // gfx950 and newer). With a pid seed, concurrent processes/streams pick
     // among the NumSdmaEngines general-purpose engines instead of contending
     // on the default single engine. On these parts KFD exposes only two such
     // engines and both live on the first XCD/XCC, so this stays within that
-    // XCC. Opt-in via ROCR_SDMA_ROUND_ROBIN=1; default keeps the stock pick.
-    var = os::GetEnvVar("ROCR_SDMA_ROUND_ROBIN");
+    // XCC. Opt-in via HSA_SDMA_ROUND_ROBIN=1; default keeps the stock pick.
+    var = os::GetEnvVar("HSA_SDMA_ROUND_ROBIN");
     sdma_round_robin_ = (var == "1") ? SDMA_ENABLE :
                         ((var == "0") ? SDMA_DISABLE : SDMA_DEFAULT);
 
@@ -148,14 +149,14 @@ class Flag {
     // (single-partition) mode. In CPX (core-partitioned) mode a partition is a
     // single XCD with no xGMI engines (NumSdmaXgmiEngines == 0), so this
     // degrades safely to the two-engine behavior and is a no-op. Opt-in via
-    // ROCR_SDMA_ROUND_ROBIN_PCIE_XGMI=1; default keeps the stock pick.
-    var = os::GetEnvVar("ROCR_SDMA_ROUND_ROBIN_PCIE_XGMI");
+    // HSA_SDMA_ROUND_ROBIN_PCIE_XGMI=1; default keeps the stock pick.
+    var = os::GetEnvVar("HSA_SDMA_ROUND_ROBIN_PCIE_XGMI");
     sdma_round_robin_pcie_xgmi_ = (var == "1") ? SDMA_ENABLE :
                                   ((var == "0") ? SDMA_DISABLE : SDMA_DEFAULT);
 
     // Explicit SDMA engine-id offset for the round-robin pick. When set to a
     // valid non-negative integer it replaces the getpid() seed used by
-    // ROCR_SDMA_ROUND_ROBIN and ROCR_SDMA_ROUND_ROBIN_PCIE_XGMI, so a launcher
+    // HSA_SDMA_ROUND_ROBIN and HSA_SDMA_ROUND_ROBIN_PCIE_XGMI, so a launcher
     // can hand each process a distinct offset (e.g. its local rank) and avoid
     // the aliasing that getpid() % engine_count can cause (two pids reducing to
     // the same engine). The modulus stays engine-count based (NumSdmaEngines,
@@ -178,7 +179,7 @@ class Flag {
       return true;
     };
 
-    var = os::GetEnvVar("ROCR_SDMA_ENGINE_ID_OFFSET");
+    var = os::GetEnvVar("HSA_SDMA_ENGINE_ID_OFFSET");
     sdma_engine_id_offset_ = -1;
     {
       int64_t parsed = -1;
@@ -187,7 +188,7 @@ class Flag {
 
     // Method A: resolve the final round-robin seed offset and record where it
     // came from, for debug provenance. Priority order:
-    //   1. ROCR_SDMA_ENGINE_ID_OFFSET (explicit, includes 0) -- parsed above.
+    //   1. HSA_SDMA_ENGINE_ID_OFFSET (explicit, includes 0) -- parsed above.
     //   2. a launcher-provided local-rank env var (first that parses to a valid
     //      non-negative integer), so a per-process rank from an MPI/torchrun/srun
     //      launcher becomes the seed without the caller setting the offset.
@@ -198,7 +199,7 @@ class Flag {
     sdma_seed_source_.clear();
     if (sdma_engine_id_offset_ >= 0) {
       sdma_seed_offset_ = sdma_engine_id_offset_;
-      sdma_seed_source_ = "ROCR_SDMA_ENGINE_ID_OFFSET";
+      sdma_seed_source_ = "HSA_SDMA_ENGINE_ID_OFFSET";
     } else {
       static const char* const kLocalRankVars[] = {
           "LOCAL_RANK",
@@ -228,7 +229,7 @@ class Flag {
     // 0 / unset / malformed keeps the stock behavior of spreading D2H across
     // all engines. H2D is never limited. amd_gpu_agent.cpp clamps N to the
     // engine count.
-    var = os::GetEnvVar("ROCR_SDMA_D2H_ENGINE_LIMIT");
+    var = os::GetEnvVar("HSA_SDMA_D2H_ENGINE_LIMIT");
     sdma_d2h_engine_limit_ = 0;
     {
       int64_t limit = 0;
@@ -535,7 +536,7 @@ class Flag {
   int64_t sdma_engine_id_offset() const { return sdma_engine_id_offset_; }
 
   // Final round-robin seed offset (method A): the explicit
-  // ROCR_SDMA_ENGINE_ID_OFFSET when set, else a launcher local-rank env var,
+  // HSA_SDMA_ENGINE_ID_OFFSET when set, else a launcher local-rank env var,
   // else -1 (amd_gpu_agent.cpp then falls back to getpid()). A value of 0 is
   // valid.
   int64_t sdma_seed_offset() const { return sdma_seed_offset_; }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
@@ -136,8 +136,7 @@ class Flag {
     // engines and both live on the first XCD/XCC, so this stays within that
     // XCC. Opt-in via HSA_SDMA_ROUND_ROBIN=1; default keeps the stock pick.
     var = os::GetEnvVar("HSA_SDMA_ROUND_ROBIN");
-    sdma_round_robin_ = (var == "1") ? SDMA_ENABLE :
-                        ((var == "0") ? SDMA_DISABLE : SDMA_DEFAULT);
+    sdma_round_robin_ = (var == "1") ? SDMA_ENABLE : ((var == "0") ? SDMA_DISABLE : SDMA_DEFAULT);
 
     // Widen the host<->device round-robin to ALL SDMA engines -- the
     // NumSdmaEngines PCIe/paging engines plus the NumSdmaXgmiEngines xGMI
@@ -151,8 +150,8 @@ class Flag {
     // degrades safely to the two-engine behavior and is a no-op. Opt-in via
     // HSA_SDMA_ROUND_ROBIN_PCIE_XGMI=1; default keeps the stock pick.
     var = os::GetEnvVar("HSA_SDMA_ROUND_ROBIN_PCIE_XGMI");
-    sdma_round_robin_pcie_xgmi_ = (var == "1") ? SDMA_ENABLE :
-                                  ((var == "0") ? SDMA_DISABLE : SDMA_DEFAULT);
+    sdma_round_robin_pcie_xgmi_ =
+        (var == "1") ? SDMA_ENABLE : ((var == "0") ? SDMA_DISABLE : SDMA_DEFAULT);
 
     // Explicit SDMA engine-id offset for the round-robin pick. When set to a
     // valid non-negative integer it replaces the getpid() seed used by
@@ -202,12 +201,8 @@ class Flag {
       sdma_seed_source_ = "HSA_SDMA_ENGINE_ID_OFFSET";
     } else {
       static const char* const kLocalRankVars[] = {
-          "LOCAL_RANK",
-          "OMPI_COMM_WORLD_LOCAL_RANK",
-          "MPI_LOCALRANKID",
-          "PMI_LOCAL_RANK",
-          "MV2_COMM_WORLD_LOCAL_RANK",
-          "SLURM_LOCALID"};
+          "LOCAL_RANK",     "OMPI_COMM_WORLD_LOCAL_RANK", "MPI_LOCALRANKID",
+          "PMI_LOCAL_RANK", "MV2_COMM_WORLD_LOCAL_RANK",  "SLURM_LOCALID"};
       for (const char* name : kLocalRankVars) {
         int64_t rank = -1;
         if (parse_nonneg(os::GetEnvVar(name), rank)) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
@@ -128,8 +128,8 @@ class Flag {
                                    ((var == "1") ? SDMA_ENABLE : SDMA_DEFAULT);
 
     // Round-robin distribution of host<->device SDMA copies across all
-    // available SDMA engines. Applies to gfx942, gfx950 and newer (e.g.
-    // MI300/MI308/MI325 and MI350/MI355). Helps in SPX (single partition)
+    // available SDMA engines. Applies to gfx942, gfx950 and newer. Helps in
+    // SPX (single partition)
     // mode, where the one device spans all XCDs and their SDMA engines,
     // letting host<->device copies use engines on otherwise-idle XCDs. Has no
     // effect in CPX (core-partitioned) mode: each partition is a single XCD

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
@@ -127,6 +127,19 @@ class Flag {
     enable_sdma_recommended_eng_ = (var == "0") ? SDMA_DISABLE :
                                    ((var == "1") ? SDMA_ENABLE : SDMA_DEFAULT);
 
+    // Round-robin distribution of host<->device SDMA copies across all
+    // available SDMA engines. Applies to gfx942, gfx950 and newer (e.g.
+    // MI300/MI308/MI325 and MI350/MI355). Helps in SPX (single partition)
+    // mode, where the one device spans all XCDs and their SDMA engines,
+    // letting host<->device copies use engines on otherwise-idle XCDs. Has no
+    // effect in CPX (core-partitioned) mode: each partition is a single XCD
+    // that can enable only two SDMA engines (one H2D + one D2H), so there is
+    // no spare engine to round-robin onto. Opt-in via ROCR_SDMA_ROUND_ROBIN=1;
+    // default keeps the stock engine pick.
+    var = os::GetEnvVar("ROCR_SDMA_ROUND_ROBIN");
+    sdma_round_robin_ = (var == "1") ? SDMA_ENABLE :
+                        ((var == "0") ? SDMA_DISABLE : SDMA_DEFAULT);
+
     visible_gpus_ = os::GetEnvVar("ROCR_VISIBLE_DEVICES");
     filter_visible_gpus_ = os::IsEnvVarSet("ROCR_VISIBLE_DEVICES");
 
@@ -417,6 +430,8 @@ class Flag {
 
   SDMA_OVERRIDE enable_sdma_recommended_eng() const { return enable_sdma_recommended_eng_; }
 
+  SDMA_OVERRIDE sdma_round_robin() const { return sdma_round_robin_; }
+
   std::string visible_gpus() const { return visible_gpus_; }
 
   bool filter_visible_gpus() const { return filter_visible_gpus_; }
@@ -602,6 +617,7 @@ class Flag {
   SDMA_OVERRIDE enable_sdma_gang_;
   SDMA_OVERRIDE enable_sdma_copy_size_override_;
   SDMA_OVERRIDE enable_sdma_recommended_eng_;
+  SDMA_OVERRIDE sdma_round_robin_;
 
   bool filter_visible_gpus_;
   std::string visible_gpus_;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
@@ -164,19 +164,75 @@ class Flag {
     // negative, non-numeric, out of range) falls back to the getpid() seed and
     // is stored as -1. Reviewer preference is to always pass an explicit
     // offset; the getpid() fallback is retained only for ease of use.
+    // Shared parse for a non-negative decimal integer in [0, 0x7fffffff].
+    // Returns true and sets 'out' on success; false (leaving 'out' untouched)
+    // for empty, negative, non-numeric or out-of-range input.
+    auto parse_nonneg = [](const std::string& s, int64_t& out) -> bool {
+      if (s.empty() || s.find_first_not_of("0123456789") != std::string::npos) return false;
+      int64_t parsed = 0;
+      for (char c : s) {
+        parsed = parsed * 10 + (c - '0');
+        if (parsed > 0x7fffffff) return false;  // clamp absurd values; treat as malformed
+      }
+      out = parsed;
+      return true;
+    };
+
     var = os::GetEnvVar("ROCR_SDMA_ENGINE_ID_OFFSET");
     sdma_engine_id_offset_ = -1;
-    if (!var.empty() && var.find_first_not_of("0123456789") == std::string::npos) {
-      int64_t parsed = 0;
-      bool valid = true;
-      for (char c : var) {
-        parsed = parsed * 10 + (c - '0');
-        if (parsed > 0x7fffffff) {  // clamp absurd values; treat as malformed
-          valid = false;
+    {
+      int64_t parsed = -1;
+      if (parse_nonneg(var, parsed)) sdma_engine_id_offset_ = parsed;
+    }
+
+    // Method A: resolve the final round-robin seed offset and record where it
+    // came from, for debug provenance. Priority order:
+    //   1. ROCR_SDMA_ENGINE_ID_OFFSET (explicit, includes 0) -- parsed above.
+    //   2. a launcher-provided local-rank env var (first that parses to a valid
+    //      non-negative integer), so a per-process rank from an MPI/torchrun/srun
+    //      launcher becomes the seed without the caller setting the offset.
+    //   3. neither -> -1, and amd_gpu_agent.cpp falls back to getpid().
+    // Only the seed default changes here; the round-robin modulus and the flag
+    // semantics are unchanged.
+    sdma_seed_offset_ = -1;
+    sdma_seed_source_.clear();
+    if (sdma_engine_id_offset_ >= 0) {
+      sdma_seed_offset_ = sdma_engine_id_offset_;
+      sdma_seed_source_ = "ROCR_SDMA_ENGINE_ID_OFFSET";
+    } else {
+      static const char* const kLocalRankVars[] = {
+          "LOCAL_RANK",
+          "OMPI_COMM_WORLD_LOCAL_RANK",
+          "MPI_LOCALRANKID",
+          "PMI_LOCAL_RANK",
+          "MV2_COMM_WORLD_LOCAL_RANK",
+          "SLURM_LOCALID"};
+      for (const char* name : kLocalRankVars) {
+        int64_t rank = -1;
+        if (parse_nonneg(os::GetEnvVar(name), rank)) {
+          sdma_seed_offset_ = rank;
+          sdma_seed_source_ = name;
           break;
         }
       }
-      if (valid) sdma_engine_id_offset_ = parsed;
+    }
+
+    // Method D (opt-in): cap D2H round-robin engine selection to the first N
+    // SDMA engines. On gfx942/gfx950 the SDMA engines are physically grouped per
+    // AID and host PCIe egress lives on the near AID; a D2H copy driven from a
+    // far-AID engine is bandwidth-limited. The runtime has no per-engine->AID
+    // topology field (KFD node properties expose only NumSdmaEngines,
+    // NumSdmaXgmiEngines and NumXcc), so the near-AID engine subset cannot be
+    // derived reliably at runtime. This knob lets a deployment pin D2H to the
+    // near-AID half explicitly (e.g. set N to the near-AID engine count).
+    // 0 / unset / malformed keeps the stock behavior of spreading D2H across
+    // all engines. H2D is never limited. amd_gpu_agent.cpp clamps N to the
+    // engine count.
+    var = os::GetEnvVar("ROCR_SDMA_D2H_ENGINE_LIMIT");
+    sdma_d2h_engine_limit_ = 0;
+    {
+      int64_t limit = 0;
+      if (parse_nonneg(var, limit)) sdma_d2h_engine_limit_ = limit;
     }
 
     visible_gpus_ = os::GetEnvVar("ROCR_VISIBLE_DEVICES");
@@ -478,6 +534,21 @@ class Flag {
   // valid explicit offset, distinct from "unset".
   int64_t sdma_engine_id_offset() const { return sdma_engine_id_offset_; }
 
+  // Final round-robin seed offset (method A): the explicit
+  // ROCR_SDMA_ENGINE_ID_OFFSET when set, else a launcher local-rank env var,
+  // else -1 (amd_gpu_agent.cpp then falls back to getpid()). A value of 0 is
+  // valid.
+  int64_t sdma_seed_offset() const { return sdma_seed_offset_; }
+
+  // Name of the env var that provided sdma_seed_offset(), or "" when none did
+  // (getpid() fallback). Used only for debug_print provenance.
+  const std::string& sdma_seed_source() const { return sdma_seed_source_; }
+
+  // Opt-in cap (method D) restricting D2H round-robin to the first N SDMA
+  // engines (near-AID subset). 0 means unset -> no limit. Clamped to the engine
+  // count by amd_gpu_agent.cpp; H2D is never limited.
+  int64_t sdma_d2h_engine_limit() const { return sdma_d2h_engine_limit_; }
+
   std::string visible_gpus() const { return visible_gpus_; }
 
   bool filter_visible_gpus() const { return filter_visible_gpus_; }
@@ -666,6 +737,9 @@ class Flag {
   SDMA_OVERRIDE sdma_round_robin_;
   SDMA_OVERRIDE sdma_round_robin_pcie_xgmi_;
   int64_t sdma_engine_id_offset_;
+  int64_t sdma_seed_offset_;
+  std::string sdma_seed_source_;
+  int64_t sdma_d2h_engine_limit_;
 
   bool filter_visible_gpus_;
   std::string visible_gpus_;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
@@ -153,6 +153,32 @@ class Flag {
     sdma_round_robin_pcie_xgmi_ = (var == "1") ? SDMA_ENABLE :
                                   ((var == "0") ? SDMA_DISABLE : SDMA_DEFAULT);
 
+    // Explicit SDMA engine-id offset for the round-robin pick. When set to a
+    // valid non-negative integer it replaces the getpid() seed used by
+    // ROCR_SDMA_ROUND_ROBIN and ROCR_SDMA_ROUND_ROBIN_PCIE_XGMI, so a launcher
+    // can hand each process a distinct offset (e.g. its local rank) and avoid
+    // the aliasing that getpid() % engine_count can cause (two pids reducing to
+    // the same engine). The modulus stays engine-count based (NumSdmaEngines,
+    // or NumSdmaEngines + NumSdmaXgmiEngines for the PCIE_XGMI variant). A value
+    // of 0 is a valid explicit offset; unset or malformed input (empty,
+    // negative, non-numeric, out of range) falls back to the getpid() seed and
+    // is stored as -1. Reviewer preference is to always pass an explicit
+    // offset; the getpid() fallback is retained only for ease of use.
+    var = os::GetEnvVar("ROCR_SDMA_ENGINE_ID_OFFSET");
+    sdma_engine_id_offset_ = -1;
+    if (!var.empty() && var.find_first_not_of("0123456789") == std::string::npos) {
+      int64_t parsed = 0;
+      bool valid = true;
+      for (char c : var) {
+        parsed = parsed * 10 + (c - '0');
+        if (parsed > 0x7fffffff) {  // clamp absurd values; treat as malformed
+          valid = false;
+          break;
+        }
+      }
+      if (valid) sdma_engine_id_offset_ = parsed;
+    }
+
     visible_gpus_ = os::GetEnvVar("ROCR_VISIBLE_DEVICES");
     filter_visible_gpus_ = os::IsEnvVarSet("ROCR_VISIBLE_DEVICES");
 
@@ -447,6 +473,11 @@ class Flag {
 
   SDMA_OVERRIDE sdma_round_robin_pcie_xgmi() const { return sdma_round_robin_pcie_xgmi_; }
 
+  // Explicit round-robin engine-id offset, or -1 when unset/invalid (in which
+  // case the round-robin falls back to a getpid() seed). A value of 0 is a
+  // valid explicit offset, distinct from "unset".
+  int64_t sdma_engine_id_offset() const { return sdma_engine_id_offset_; }
+
   std::string visible_gpus() const { return visible_gpus_; }
 
   bool filter_visible_gpus() const { return filter_visible_gpus_; }
@@ -634,6 +665,7 @@ class Flag {
   SDMA_OVERRIDE enable_sdma_recommended_eng_;
   SDMA_OVERRIDE sdma_round_robin_;
   SDMA_OVERRIDE sdma_round_robin_pcie_xgmi_;
+  int64_t sdma_engine_id_offset_;
 
   bool filter_visible_gpus_;
   std::string visible_gpus_;


### PR DESCRIPTION
## Motivation

gfx942, gfx950 and newer (CDNA, ISA major 9 minor >= 4) expose two
general-purpose "PCIe/paging" SDMA copy engines for host<->device transfers.
The stock runtime pins every process' host-to-device blit queue to the same
engine, so concurrent processes/streams serialize on one engine.

`HSA_SDMA_ROUND_ROBIN` (already in this PR) spreads those copies across the
two PCIe/paging engines using a `getpid()` seed. On these parts KFD reports
`num_sdma_engines == 2` and **both live on the first XCD/XCC**, so that flag
never leaves XCC0 -- `rec_eng` is always 0 or 1 (this was the reviewer's
observation, and it is correct).

This change adds a second, independent opt-in flag,
`HSA_SDMA_ROUND_ROBIN_PCIE_XGMI`, that widens the round-robin to **all** SDMA
engines: the `NumSdmaEngines` PCIe/paging engines plus the
`NumSdmaXgmiEngines` xGMI engines. On gfx942/gfx950 the engines are grouped
two-per-XCD/XCC (2 PCIe/paging on XCC0 + xGMI engines on the remaining XCCs),
so widening the modulus lets concurrent processes reach engines on other XCCs
and use each XCC's own path to host memory.

- **SPX (single partition):** the device spans all XCDs; spreading copies over
  engines on other XCCs raises aggregate host<->device bandwidth.
- **CPX (core-partitioned):** a partition is a single XCD with no xGMI engines
  (`NumSdmaXgmiEngines == 0`), so the widened modulus collapses back to the two
  PCIe engines -- degrades safely to the existing behavior, a no-op.

Existing `HSA_SDMA_ROUND_ROBIN` behavior is unchanged. When both flags are
set, the wider `PCIE_XGMI` behavior takes precedence.

## Recommended configuration

For anyone deploying this, the tested best-practice env combinations are:

**1) General multi-process concurrency (recommended, robust, general).** Spread
host-to-device over every engine for aggregate bandwidth, and confine
device-to-host to the near-AID engines so a single stream never drops onto a
far-AID engine (~20 GB/s):

```
export HSA_ENABLE_SDMA=1
export HSA_SDMA_ROUND_ROBIN_PCIE_XGMI=1
export HSA_SDMA_D2H_ENGINE_LIMIT=<near-AID engine count>   # = half the total engines: 8 on an 8-XCC part, 4 on a 4-XCC part
```

**2) With a launcher (torchrun / MPI / SLURM), also add** a distinct offset per
rank -- it removes PID-aliasing collisions and gives the most stable
multi-process D2H (or just rely on the built-in `LOCAL_RANK` /
`OMPI_COMM_WORLD_LOCAL_RANK` / `SLURM_LOCALID` auto-detection):

```
export HSA_SDMA_ENGINE_ID_OFFSET=${LOCAL_RANK}
```

**How to choose `HSA_SDMA_D2H_ENGINE_LIMIT`.** Set it to the near-AID engine
count, i.e. half of the total engines `(NumSdmaEngines + NumSdmaXgmiEngines) / 2`
(engine index `e` maps to AID `floor(e/2)`; the near AIDs are the lower half).
On an 8-XCC / 16-engine part that is `8`; on a 4-XCC / 8-engine part it is `4`.
When unsure, use half.

**Ceiling caveat.** host<->device aggregate bandwidth is bounded by the single
host PCIe Gen5 x16 link (~55-68 GB/s). Spreading across XCCs / AIDs helps you
*reach* that ceiling at lower concurrency and avoids the far-AID D2H penalty; it
does not raise the PCIe ceiling itself.

### Full configuration x concurrency matrix (8-XCC / 16-engine SPX part)

Aggregate GB/s, 4 MiB/stream, median of 3, measured on an 8-XCC / 8-AID SPX part
(16 SDMA engines). Scenarios:

- **S0** baseline (all round-robin flags off)
- **S1** `HSA_SDMA_ROUND_ROBIN=1` (2 near PCIe/paging engines)
- **S2** `HSA_SDMA_ROUND_ROBIN_PCIE_XGMI=1` (all 16 engines across 8 AIDs)
- **S3** S2 + `HSA_SDMA_D2H_ENGINE_LIMIT=8` (D2H clamped to near engines 0-7) -- **recommended**
- **S4** S2 + per-process `HSA_SDMA_ENGINE_ID_OFFSET=<rank>` (clean, collision-free) -- **recommended with a launcher**

| config | H2D N=1 | H2D N=2 | H2D N=4 | H2D N=8 | H2D N=16 | D2H N=1 | D2H N=2 | D2H N=4 | D2H N=8 | D2H N=16 |
|---|---|---|---|---|---|---|---|---|---|---|
| S0 | 54.2 | 53.6 | 52.6 | 52.1 | 64.2 | 48.6 | 46.7 | 46.5 | 47.2 | 65.3 |
| S1 | 54.2 | 55.1 | 55.7 | 56.4 | 60.8 | 48.7 | 52.6 | 53.2 | 55.7 | 59.5 |
| S2 | 54.2 | 58.6 | 59.6 | 59.4 | 61.2 | **19.5** | 54.1 | 56.2 | 67.5 | 65.9 |
| S3 | 54.8 | 58.4 | 58.8 | 60.3 | 62.1 | 47.5 | 55.3 | 67.4 | 62.8 | 63.6 |
| S4 | 54.5 | 60.2 | 57.9 | 58.9 | 64.0 | 42.9 | 55.1 | 66.8 | 66.7 | 68.5 |

Key reading: S2 at N=1 collapses to **19.5 GB/s** because a lone D2H stream can
land on a far-AID engine; S3 fixes that (47.5) by clamping D2H to the near AIDs
while H2D still spreads. Under real concurrency S3/S4 give the best D2H and
match or beat S2 on H2D. All absolute values are bounded by the single host
PCIe x16 link, so the win is "reach the ceiling sooner + no far-AID cliff",
not a higher ceiling.

## Feasibility (verified on hardware)

On a gfx942 SPX part (`num_sdma_engines=2`, `num_sdma_xgmi_engines=14`,
`num_xcc=8`; 16 engines total, 2 per XCC) we confirmed that host<->device SDMA
queues can be created on **every** engine id 0-15 (including the xGMI engines)
via KFD `SDMA_BY_ENG_ID`, and that they successfully move host (system) memory
-- there is no driver restriction limiting xGMI engines to GPU<->GPU traffic.

Single-stream bandwidth per engine (one process), showing AID/XCC locality:

| engine (-> XCC / AID) | H2D GB/s | D2H GB/s |
|---|---|---|
| 0,1 (XCC0 / AID0, near) | ~44 | ~42-49 |
| 2,3 (XCC1 / AID1, near) | ~44 | ~42-49 |
| 4,5 (XCC2 / AID2, near) | ~44 | ~42-49 |
| 6,7 (XCC3 / AID3, near) | ~44 | ~42-49 |
| 8,9 (XCC4 / AID4, remote) | ~44 | ~19.6 |
| 10,11 (XCC5 / AID5, remote) | ~44 | ~19.6 |
| 12,13 (XCC6 / AID6, remote) | ~44 | ~19.6 |
| 14,15 (XCC7 / AID7, remote) | ~44 | ~19.6 |

H2D is uniform (~44 GB/s) across all 16 engines and is insensitive to engine
position; single-stream D2H on the remote AIDs (engines 8-15) is ~2.2x slower
(~19.6 vs ~42-49 GB/s near) because it is cross-die latency bound, so a single
stream that happens to land on a remote engine can regress -- hence the wider
flag is opt-in and D2H can be clamped to the near AIDs.

## Alternatives evaluated

- **Atomic counter** (increment per queue): rejected -- counters are
  per-process (separate address spaces), so every process would start at 0 and
  collide on the same engine; it does not spread across processes without shared
  IPC state.
- **PID -> XCC mapping**: map the seed to an XCC and keep a process' H2D/D2H on
  that XCC's engines, preserving H2D/D2H direction separation. This can give a
  more consistent spread at moderate concurrency, but it bakes in XCC-layout
  assumptions, so it is not included here. The explicit engine-id offset plus the
  near-AID D2H limit reach the same goals (collision-free spreading, protected
  D2H) without hardcoding a layout, and remain a reasonable base for a future
  topology-aware refinement.

## Explicit engine-id offset (HSA_SDMA_ENGINE_ID_OFFSET)

The round-robin seed defaulted to `getpid()`. Because the engine is chosen by
`(seed + rec_eng) % engine_count`, two processes whose PIDs are congruent modulo
`engine_count` alias onto the same engine and collide, defeating the spread. Per
reviewer feedback (David), the seed can now be supplied explicitly:

- **`HSA_SDMA_ENGINE_ID_OFFSET=<n>`** -- a valid non-negative integer replaces
  the `getpid()` seed: `rec_eng = (n + rec_eng) % engine_count`. A launcher can
  hand each process a distinct offset (e.g. its local rank) so processes
  deterministically land on different engines with no collisions.
- The offset applies to **both** flags; the modulus is unchanged
  (`NumSdmaEngines` for `HSA_SDMA_ROUND_ROBIN`, `NumSdmaEngines +
  NumSdmaXgmiEngines` for `HSA_SDMA_ROUND_ROBIN_PCIE_XGMI`).
- `0` is a valid explicit offset (distinct from unset). Unset or malformed input
  (empty, negative, non-numeric, out of range) falls back to the `getpid()`
  seed, preserving current ease of use.

Reviewer preference is to always pass an explicit offset; the PID fallback is
retained only for convenience and can be dropped if the project prefers to
require an explicit offset.

Verified on a gfx942 SPX part via runtime instrumentation (engine_count 8 in
this instrumented run):

| env | seed | engine (rec_eng) |
|---|---|---|
| `HSA_SDMA_ENGINE_ID_OFFSET=0` | 0 (offset) | 0 |
| `HSA_SDMA_ENGINE_ID_OFFSET=3` | 3 (offset) | 3 |
| `HSA_SDMA_ENGINE_ID_OFFSET=5` | 5 (offset) | 5 |
| unset | 12054 (pid) | 6 (= pid % 8) |

Example (one distinct offset per local rank):

    export HSA_ENABLE_SDMA=1
    export HSA_SDMA_ROUND_ROBIN_PCIE_XGMI=1
    export HSA_SDMA_ENGINE_ID_OFFSET=${LOCAL_RANK}

Unit tests cover parsing of unset / 0 / 5 / non-numeric / negative /
out-of-range (all pass).

## Launcher local-rank auto-detection (default seed)

Building on `HSA_SDMA_ENGINE_ID_OFFSET`, the round-robin seed is now resolved
in priority order so a launcher no longer has to set the offset explicitly:

1. `HSA_SDMA_ENGINE_ID_OFFSET` (explicit, includes 0) -- highest priority.
2. otherwise the first launcher local-rank env var that parses to a valid
   non-negative integer, tried in this order: `LOCAL_RANK`,
   `OMPI_COMM_WORLD_LOCAL_RANK`, `MPI_LOCALRANKID`, `PMI_LOCAL_RANK`,
   `MV2_COMM_WORLD_LOCAL_RANK`, `SLURM_LOCALID`.
3. otherwise `getpid()` (unchanged fallback).

Only the seed default changes; the modulus and flag semantics are unchanged.
Because torchrun / Open MPI / MPICH / MVAPICH2 / SLURM already export a
per-process local rank, co-located ranks now land on distinct engines with zero
extra configuration, while a manual `HSA_SDMA_ENGINE_ID_OFFSET` still overrides
everything.

Example (no offset needed; the rank is supplied by the launcher):

    export HSA_ENABLE_SDMA=1
    export HSA_SDMA_ROUND_ROBIN_PCIE_XGMI=1
    # LOCAL_RANK / OMPI_COMM_WORLD_LOCAL_RANK / SLURM_LOCALID etc. are picked up automatically

Verified on a gfx942 SPX part via runtime instrumentation (H2D blit, base
`rec_eng` 0, `HSA_SDMA_ROUND_ROBIN`, modulus = `NumSdmaEngines` = 2):

| env | seed | source | rec_eng |
|---|---|---|---|
| `OMPI_COMM_WORLD_LOCAL_RANK=3` | 3 | `OMPI_COMM_WORLD_LOCAL_RANK` | 1 (= (3+0)%2) |
| `HSA_SDMA_ENGINE_ID_OFFSET=1` + `OMPI_COMM_WORLD_LOCAL_RANK=3` | 1 | `HSA_SDMA_ENGINE_ID_OFFSET` | 1 (offset overrides rank) |
| none set | 12936 | `getpid()` | 0 (= pid%2) |

Unit tests cover offset-only, offset-overrides-rank, single rank var, rank-var
priority order, invalid-rank-skipped, and none->pid (all pass).

## Opt-in near-AID limit for D2H (HSA_SDMA_D2H_ENGINE_LIMIT)

On gfx942 / gfx950 the SDMA engines are physically grouped per AID; host PCIe
egress lives on the near AID, so a device-to-host copy driven from a far-AID
engine is bandwidth-limited (the feasibility table above shows remote-AID
single-stream D2H at ~20 GB/s vs ~42-49 GB/s near). H2D is uniform across engines
and is unaffected.

`HSA_SDMA_D2H_ENGINE_LIMIT=N` (opt-in, default off) caps **D2H** round-robin
selection to the first `N` SDMA engines (the near-AID subset), computed as
`rec_eng = (seed + rec_eng) % min(N, engine_count)`. H2D is never limited and
continues to spread over all engines. `0` / unset / malformed keeps the stock
behavior of spreading D2H across all engines.

Why an explicit knob rather than auto-detection: the runtime has **no
per-engine->AID topology field** -- KFD node properties expose only
`NumSdmaEngines`, `NumSdmaXgmiEngines` and `NumXcc`, with no mapping from an SDMA
engine index to its AID or to the host PCIe-egress AID. The physical
engine->AID layout therefore cannot be derived reliably at runtime, so a
deployment sets `N` to its near-AID engine count rather than having the runtime
guess (a wrong guess would be worse than the status quo).

Verified on a gfx942 SPX part via runtime instrumentation, D2H blit (base
`rec_eng` 1) with `HSA_SDMA_ROUND_ROBIN_PCIE_XGMI=1`, seed 3 (engine_count 8 in
this instrumented run):

| env | D2H rec_eng | note |
|---|---|---|
| (no limit) | 4 (= (3+1)%8) | D2H may land on a far-AID engine |
| `HSA_SDMA_D2H_ENGINE_LIMIT=1` | 0 (= (3+1)%1) | D2H pinned to near-AID engine 0 |
| `HSA_SDMA_D2H_ENGINE_LIMIT=2` | 0 (= (3+1)%2) | D2H within near-AID subset {0,1} |

In the same runs H2D was confirmed **unaffected** by the limit (the direction
guard reports `limit_d2h=0` for H2D even with the knob set). Unit tests cover
unset / 0 / valid / large-value (clamped) / malformed (all pass).

## Scaling to other XCC counts

The implementation reads the engine counts dynamically from KFD
(`NumSdmaEngines` + `NumSdmaXgmiEngines`) and never hardcodes 2/4/8/16. The
round-robin path uses only the integer engine index `rec_eng` (passed to KFD as
`sdma_engine_id` via `SDMA_BY_ENG_ID`); it computes no bitmasks itself. This was
validated on an 8-XCC SPX part that reports 2 PCIe/paging + 14 xGMI = 16 engines,
where `rec_eng` naturally spans 0..15 across all 8 XCCs / 8 AIDs with no code
change. The public `HSA_AMD_SDMA_ENGINE_*` enum is defined through `_15`
(16 engines) and all engine masks are `uint32_t` (bit 0..31), so the 16-engine
case is fully within range. Parts with fewer XCCs (and therefore fewer engines)
are handled by the same count-agnostic path: the modulus simply shrinks to the
reported engine count, and on a single-XCD partition (`NumSdmaXgmiEngines == 0`)
the wider flag collapses back to the two PCIe/paging engines (a no-op).

## JIRA ID

JIRA ID: ROCM-28024

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.