### PR TITLE
fix(kfdtest): [AILIROCR-524] Exclude KFDEvictTest cases on vega 20

### DIFF
--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/scripts/kfdtest.exclude
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/scripts/kfdtest.exclude
@@ -200,7 +200,8 @@ FILTER[vega12]=\
 FILTER[vega20]=\
 "$BLACKLIST_ALL_ASICS:"\
 "$SDMA_BLACKLIST:"\
-"KFDQMTest.GPUDoorbellWrite"
+"KFDQMTest.GPUDoorbellWrite:"\
+"KFDEvictTest.*"
 
 FILTER[raven_dgpuFallback]=\
 "$BLACKLIST_ALL_ASICS:"\


### PR DESCRIPTION
KFDTest has been failing sparingly while running the KFDEvictTest* case on Vega 20. This task is to exclude these cases for now on this ASIC, until it can be investigated fully and fixed.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
JIRA ID: AILIROCR-524

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
