### PR TITLE
docs(hip): Add execution context how-to guide

### DIFF
--- a/projects/hip/docs/how-to/hip_runtime_api.rst
+++ b/projects/hip/docs/how-to/hip_runtime_api.rst
@@ -33,5 +33,6 @@ Here are the various HIP Runtime API high level functions:
 * :doc:`./hip_runtime_api/hipgraph`
 * :doc:`./hip_runtime_api/call_stack`
 * :doc:`./hip_runtime_api/multi_device`
+* :doc:`./hip_runtime_api/execution_context`
 * :doc:`./hip_runtime_api/opengl_interop`
 * :doc:`./hip_runtime_api/external_interop`

--- a/projects/hip/docs/how-to/hip_runtime_api/execution_context.rst
+++ b/projects/hip/docs/how-to/hip_runtime_api/execution_context.rst
@@ -222,13 +222,15 @@ Three resource types are defined:
 
 ``hipDevResourceTypeInvalid`` marks an unset resource.
 
-Query a device with :cpp:func:`hipDeviceGetDevResource` and it reports all three:
-a CU resource covering every CU available to the process, a work queue
-configuration covering the device's work queues, and the matching work queue
-resource. You can also ask an execution context or a stream what resources it
-holds, using :cpp:func:`hipExecutionCtxGetDevResource` and
-:cpp:func:`hipStreamGetDevResource`. An execution context can hold several
-resource types at once; a stream only ever carries a CU resource.
+Query a device with :cpp:func:`hipDeviceGetDevResource` to obtain its resources: a
+CU resource covering every CU available to the process, and, on runtimes that
+support it, a work queue configuration covering the device's work queues and the
+matching work queue resource. Reading the work queue configuration from a device
+is not supported on every ROCm runtime, so check the returned status. You can also
+ask an execution context or a stream what resources it holds, using
+:cpp:func:`hipExecutionCtxGetDevResource` and :cpp:func:`hipStreamGetDevResource`.
+An execution context can hold several resource types at once; a stream only ever
+carries a CU resource.
 
 Compute unit resource
 -------------------------------------------------------------------------------
@@ -354,7 +356,9 @@ Reading a device's CUs looks like this:
    :language: cpp
    :dedent:
 
-Reading the work queue configuration is similar:
+Reading the work queue configuration follows the same pattern, but not every
+ROCm runtime supports querying it from a device. Check the returned status rather
+than aborting, and only use the configuration when the query succeeds:
 
 .. literalinclude:: ../../tools/example_codes/execution_context.hip
    :start-after: // [read-wq-config-start]
@@ -362,8 +366,8 @@ Reading the work queue configuration is similar:
    :language: cpp
    :dedent:
 
-For a device, ``wqConcurrencyLimit`` reflects ``GPU_MAX_HW_QUEUES`` or its
-default.
+When the query succeeds, ``wqConcurrencyLimit`` reflects ``GPU_MAX_HW_QUEUES`` or
+its default for the device.
 
 Step 2: Split the CU resource
 -------------------------------------------------------------------------------

--- a/projects/hip/docs/how-to/hip_runtime_api/execution_context.rst
+++ b/projects/hip/docs/how-to/hip_runtime_api/execution_context.rst
@@ -687,56 +687,145 @@ Worked example
 ===============================================================================
 
 This example reserves CUs for an urgent kernel so it is not blocked by a
-long-running one. Two kernels run on separate non-blocking streams: a
-long-running kernel starts first, and a short, critical kernel follows.
+long-running one, and measures the difference. A large background kernel runs
+concurrently with a small, latency-sensitive critical kernel, and the critical
+kernel's runtime is timed in two configurations:
 
-Without execution contexts, the critical kernel waits for the long-running
+- **Baseline**: both kernels run on ordinary streams and share all of the
+  device's CUs, so the critical kernel contends with the background kernel.
+- **Partitioned**: the CUs are split into two execution contexts, so the
+  critical kernel runs on its own CUs while the background kernel is confined to
+  the rest.
+
+Without execution contexts, the critical kernel waits for the background
 kernel's thread blocks to retire before CUs open up, even with a higher stream
 priority. With execution contexts, each kernel owns a distinct set of CUs, so the
 critical kernel starts right away. Both kernels give up access to the full GPU,
 so each may run slightly longer alone, but the critical kernel is no longer held
 back.
 
+A busy kernel stands in for a compute-bound workload. Oversubscribing the grid,
+launching many more thread blocks than the device runs at once, keeps every CU
+occupied for the whole measurement:
+
+.. code-block:: cpp
+
+    __global__ void busy_kernel(unsigned int* out, unsigned int iterations)
+    {
+        volatile unsigned int acc = 0;
+        for(unsigned int i = 0; i < iterations; ++i)
+        {
+            acc += i;
+        }
+        if(threadIdx.x == 0)
+        {
+            out[blockIdx.x] = acc;
+        }
+    }
+
+A helper launches the background kernel, then times the critical kernel with HIP
+events while the background kernel is still running. Passing two streams that
+belong to disjoint execution contexts confines each kernel to its own CUs;
+passing two ordinary streams lets them contend:
+
+.. code-block:: cpp
+
+    float time_critical_with_background(hipStream_t   background_stream,
+                                        hipStream_t   critical_stream,
+                                        unsigned int* d_out_background,
+                                        unsigned int* d_out_critical)
+    {
+        hipEvent_t start, stop;
+        HIP_CHECK(hipEventCreate(&start));
+        HIP_CHECK(hipEventCreate(&stop));
+
+        // Launch the background kernel; it keeps running on its own stream.
+        busy_kernel<<<background_grid, block_size, 0, background_stream>>>(
+            d_out_background, background_iterations);
+        HIP_CHECK(hipGetLastError());
+
+        // Time the critical kernel while the background kernel runs.
+        HIP_CHECK(hipEventRecord(start, critical_stream));
+        busy_kernel<<<critical_grid, block_size, 0, critical_stream>>>(
+            d_out_critical, critical_iterations);
+        HIP_CHECK(hipGetLastError());
+        HIP_CHECK(hipEventRecord(stop, critical_stream));
+        HIP_CHECK(hipEventSynchronize(stop));
+
+        float critical_ms = 0.0f;
+        HIP_CHECK(hipEventElapsedTime(&critical_ms, start, stop));
+        HIP_CHECK(hipStreamSynchronize(background_stream));
+
+        HIP_CHECK(hipEventDestroy(start));
+        HIP_CHECK(hipEventDestroy(stop));
+        return critical_ms;
+    }
+
+The baseline runs both kernels on ordinary non-blocking streams, so they share
+the whole device:
+
+.. code-block:: cpp
+
+    hipStream_t shared_background, shared_critical;
+    HIP_CHECK(hipStreamCreateWithFlags(&shared_background, hipStreamNonBlocking));
+    HIP_CHECK(hipStreamCreateWithFlags(&shared_critical, hipStreamNonBlocking));
+
+    float baseline_ms = time_critical_with_background(
+        shared_background, shared_critical, d_out_background, d_out_critical);
+
+    HIP_CHECK(hipStreamDestroy(shared_background));
+    HIP_CHECK(hipStreamDestroy(shared_critical));
+
+The partitioned run splits the CUs into a group for the background kernel and a
+disjoint group for the critical kernel, then follows the four-step setup: read
+the device's CUs, split them, wrap each group in a descriptor, and create an
+execution context per group. A stream on each context confines its kernel to that
+context's CUs:
+
 .. code-block:: cpp
 
     // Step 1: Read the device's CUs.
     hipDevResource cu_resources = {};
     HIP_CHECK(hipDeviceGetDevResource(0, &cu_resources, hipDevResourceTypeSm));
+    unsigned int total_cus    = cu_resources.sm.smCount;
+    unsigned int critical_cus = total_cus / 4;
 
-    // Step 2: Split into a large group and a small group.
+    // Step 2: Split into a background group and a smaller critical group.
     hipDevResource result[2] = {};
     hipDevSmResourceGroupParams group_params[2] = {
-        {/*smCount=*/112, 0, 0, 0},
-        {/*smCount=*/16,  0, 0, 0}};
+        {/*smCount=*/total_cus - critical_cus, 0, 0, 0},
+        {/*smCount=*/critical_cus,             0, 0, 0}};
     HIP_CHECK(hipDevSmResourceSplit(&result[0], 2, &cu_resources, nullptr, 0, &group_params[0]));
 
     // Step 3: Wrap each group in a descriptor.
-    hipDevResourceDesc_t desc_long = {};
-    hipDevResourceDesc_t desc_critical = {};
-    HIP_CHECK(hipDevResourceGenerateDesc(&desc_long, &result[0], 1));
+    hipDevResourceDesc_t desc_background = {};
+    hipDevResourceDesc_t desc_critical   = {};
+    HIP_CHECK(hipDevResourceGenerateDesc(&desc_background, &result[0], 1));
     HIP_CHECK(hipDevResourceGenerateDesc(&desc_critical, &result[1], 1));
 
     // Step 4: Create an execution context per group.
-    hipExecutionCtx_t ctx_long = {};
-    hipExecutionCtx_t ctx_critical = {};
-    HIP_CHECK(hipGreenCtxCreate(&ctx_long, desc_long, 0, 0));
+    hipExecutionCtx_t ctx_background = {};
+    hipExecutionCtx_t ctx_critical   = {};
+    HIP_CHECK(hipGreenCtxCreate(&ctx_background, desc_background, 0, 0));
     HIP_CHECK(hipGreenCtxCreate(&ctx_critical, desc_critical, 0, 0));
 
-    // A stream on each context, then launch each kernel on its stream.
-    hipStream_t strm_long, strm_critical;
-    HIP_CHECK(hipExecutionCtxStreamCreate(&strm_long, ctx_long, hipStreamDefault, 0));
+    // A stream on each context, then run the same timed measurement.
+    hipStream_t strm_background, strm_critical;
+    HIP_CHECK(hipExecutionCtxStreamCreate(&strm_background, ctx_background, hipStreamDefault, 0));
     HIP_CHECK(hipExecutionCtxStreamCreate(&strm_critical, ctx_critical, hipStreamDefault, 0));
 
-    long_running_kernel<<<grid_long, block_long, 0, strm_long>>>();
-    critical_kernel<<<grid_critical, block_critical, 0, strm_critical>>>();
-    HIP_CHECK(hipGetLastError());
+    float partitioned_ms = time_critical_with_background(
+        strm_background, strm_critical, d_out_background, d_out_critical);
 
     // Release everything.
-    HIP_CHECK(hipStreamDestroy(strm_long));
+    HIP_CHECK(hipStreamDestroy(strm_background));
     HIP_CHECK(hipStreamDestroy(strm_critical));
-    HIP_CHECK(hipExecutionCtxDestroy(ctx_long));
+    HIP_CHECK(hipExecutionCtxDestroy(ctx_background));
     HIP_CHECK(hipExecutionCtxDestroy(ctx_critical));
 
-Settle on the CU split by measuring your own workload. The
+Comparing ``baseline_ms`` with ``partitioned_ms`` shows the critical kernel
+finishing sooner once it has its own CUs. Settle on the CU split by measuring your
+own workload. The
 `HIP-Basic execution context example <https://github.com/ROCm/rocm-examples/tree/develop/HIP-Basic/execution_context>`_
-contains a complete, buildable version.
+contains a complete, buildable version that sweeps several partition sizes and
+also provides a CUDA green context backend.

--- a/projects/hip/docs/how-to/hip_runtime_api/execution_context.rst
+++ b/projects/hip/docs/how-to/hip_runtime_api/execution_context.rst
@@ -512,11 +512,12 @@ the architecture default, which matches the device's ``smCoscheduledAlignment``.
 To see the value that was chosen, read the ``groupParams`` entry back after a
 successful call.
 
-Adding a work queue resource
+Step 2.1 (optional): Add a work queue resource
 -------------------------------------------------------------------------------
 
-To configure work queues alongside CUs, fill in a work queue configuration
-resource yourself and place it next to the CU resources you plan to bundle:
+This step is optional. To configure work queues alongside CUs, fill in a work
+queue configuration resource yourself and place it next to the CU resources you
+plan to bundle:
 
 .. code-block:: cpp
 

--- a/projects/hip/docs/how-to/hip_runtime_api/execution_context.rst
+++ b/projects/hip/docs/how-to/hip_runtime_api/execution_context.rst
@@ -8,22 +8,25 @@
 Execution contexts
 *******************************************************************************
 
-By default, every kernel you launch uses the device's primary execution context,
-which the HIP runtime manages implicitly. In that primary context, kernels
-launched by the process compete for the GPU resources available to the process.
-The runtime decides which compute units (CUs) a kernel runs on, and kernels that
-run at the same time share the available pool of CUs and work queues.
+In the HIP runtime, an execution context is the scheduling domain used for GPU
+work submitted by a process. An execution context is either the device's primary
+context, which the HIP runtime manages implicitly, or a resource-partitioned
+context that you create with :cpp:func:`hipGreenCtxCreate`.
 
-In the HIP runtime, an execution context is either the device's primary context
-or a resource-partitioned context that you create with
-:cpp:func:`hipGreenCtxCreate`. A resource-partitioned execution context lets you
-define a fixed slice of the available GPU resources and bind work to it. Any
-kernel launched on a stream that belongs to that context is confined to the
-context's CU resources, regardless of the kernel launch configuration.
+By default, every kernel you launch uses the device's primary execution context.
+In the primary context, kernels launched by the process compete for the GPU
+resources available to the process. The runtime decides which compute units
+(CUs) a kernel runs on, and kernels that run at the same time share the available
+pool of CUs and work queues.
 
-You set up execution contexts entirely on the host. The kernel source does not
-change, and kernels are launched with the usual HIP launch syntax. This feature
-is analogous to CUDA green contexts.
+A resource-partitioned execution context lets you define a fixed slice of the
+available GPU resources and bind work to it. Any kernel launched on a stream that
+belongs to that context is confined to the context's CU resources, regardless of
+the kernel launch configuration.
+
+You set up resource-partitioned execution contexts entirely on the host. The
+kernel source does not change, and kernels are launched with the usual HIP
+launch syntax. This feature is analogous to CUDA green contexts.
 
 .. note::
 
@@ -71,10 +74,13 @@ If a kernel has more thread blocks than the context's CUs can run at once, the
 extra thread blocks wait and are scheduled onto the same CU partition as earlier
 thread blocks retire.
 
-Execution contexts are most useful when an application has multiple classes of
-work that need different resource allocations. They are less useful when the
-application runs one kernel at a time, or when all kernels have the same priority
-and maximum total throughput is the only goal.
+Execution contexts are useful when an application is intentionally designed to
+assign different classes of GPU work to different resource partitions. They are
+not a per-kernel launch option or an automatic scheduling behavior. To use them
+effectively, the application must create the CU partitions, build execution
+contexts from those partitions, create streams on those contexts, and launch each
+workload on the appropriate stream. Select and tune the partition sizes based on
+measured workload behavior.
 
 Benefits of execution contexts
 ===============================================================================

--- a/projects/hip/docs/how-to/hip_runtime_api/execution_context.rst
+++ b/projects/hip/docs/how-to/hip_runtime_api/execution_context.rst
@@ -8,48 +8,73 @@
 Execution contexts
 *******************************************************************************
 
-By default, every kernel you launch competes for the GPU resources available to
-the process. The runtime decides which compute units (CUs) a kernel runs on, and
-kernels that run at the same time share the available pool of CUs and work
-queues. This is efficient for throughput, but it means a small, time-critical
-kernel can be delayed by a large kernel that already occupies the device.
+By default, every kernel you launch uses the device's primary execution context,
+which the HIP runtime manages implicitly. In that primary context, kernels
+launched by the process compete for the GPU resources available to the process.
+The runtime decides which compute units (CUs) a kernel runs on, and kernels that
+run at the same time share the available pool of CUs and work queues.
 
-An execution context lets you define a fixed slice of the available GPU resources
-and bind work to it. When you create an execution context, you associate it with
-selected device resources, currently CUs and work queue configuration. Any kernel
-launched on a stream that belongs to that context is confined to the context's CU
-resources, regardless of the kernel launch configuration. Work queue
-configuration associated with the context guides how the driver dispatches work.
-You set this up entirely on the host; the kernel source does not change.
+In the HIP runtime, an execution context is either the device's primary context
+or a resource-partitioned context that you create with
+:cpp:func:`hipGreenCtxCreate`. A resource-partitioned execution context lets you
+define a fixed slice of the available GPU resources and bind work to it. Any
+kernel launched on a stream that belongs to that context is confined to the
+context's CU resources, regardless of the kernel launch configuration.
 
-Reserving resources this way is useful whenever you want predictable access to
-part of the GPU. For example, you can reserve a handful of CUs so a
-latency-sensitive kernel always has resources available when it launches, or you
-can cap a kernel to a smaller CU count to measure how it scales without changing
-its code.
-
-In the HIP runtime, an execution context is either the device's primary context,
-which the runtime uses implicitly, or a resource-partitioned context you create
-with :cpp:func:`hipGreenCtxCreate`. This feature is analogous to CUDA green
-contexts.
+You set up execution contexts entirely on the host. The kernel source does not
+change, and kernels are launched with the usual HIP launch syntax. This feature
+is analogous to CUDA green contexts.
 
 .. note::
 
-    The device resource structures use the field name ``smCount`` and the
-    resource type ``hipDevResourceTypeSm``. HIP keeps these ``sm`` (streaming
-    multiprocessor) identifiers so that code written against CUDA compiles
-    unchanged. On AMD GPUs, the equivalent physical resource is the compute unit.
-    This page writes "compute unit" or "CU" in the text and keeps the literal
-    identifiers in code.
+    Keep the following terminology and example-code details in mind:
 
-.. note::
+    - The device resource structures use the field name ``smCount`` and the
+      resource type ``hipDevResourceTypeSm``. HIP keeps these ``sm`` identifiers
+      so that code written against CUDA compiles unchanged. On AMD GPUs, the
+      equivalent physical resource is the compute unit. This page writes
+      "compute unit" or "CU" in the text and keeps the literal identifiers in
+      code.
 
-    The snippets on this page are written to show the calling sequence. Build and
-    run them on a ROCm system before using them as the basis for production code.
-    A complete, buildable program is provided as the
-    `HIP-Basic execution context example <https://github.com/ROCm/rocm-examples/tree/develop/HIP-Basic/execution_context>`_.
+    - The snippets on this page are written to show the calling sequence. Build
+      and run them on a ROCm system before using them as the basis for production
+      code. A complete, buildable program is provided as the
+      `HIP-Basic execution context example <https://github.com/ROCm/rocm-examples/tree/develop/HIP-Basic/execution_context>`_.
 
 The full API listing is in :ref:`execution_context_management_reference`.
+
+Concepts of execution contexts
+===============================================================================
+
+An execution context is a host-created scheduling domain for GPU work. The
+context does not change the kernel code and it does not add a new kernel launch
+parameter. Instead, it changes the resources visible to streams created on that
+context.
+
+The usual flow is:
+
+#. Start with the CUs available to the process.
+#. Split that CU resource into one or more partitions.
+#. Bundle one or more resources into a descriptor.
+#. Create one execution context from each descriptor.
+#. Create streams from those contexts.
+#. Launch kernels on the context streams.
+
+A kernel launched on a context stream can only run on the CUs assigned to that
+context. A kernel launched on a regular stream outside an execution context uses
+the device's primary context and can use the CUs available to that primary
+context.
+
+The kernel's grid and block dimensions still control how much work the kernel
+contains. The execution context controls where that work is allowed to execute.
+If a kernel has more thread blocks than the context's CUs can run at once, the
+extra thread blocks wait and are scheduled onto the same CU partition as earlier
+thread blocks retire.
+
+Execution contexts are most useful when an application has multiple classes of
+work that need different resource allocations. They are less useful when the
+application runs one kernel at a time, or when all kernels have the same priority
+and maximum total throughput is the only goal.
 
 Benefits of execution contexts
 ===============================================================================
@@ -75,11 +100,11 @@ priority of the latency-sensitive kernel's stream can reduce this delay, but it
 cannot eliminate it, because the kernel must still wait for in-flight thread
 blocks to drain.
 
-Execution contexts address this contention by partitioning resources at the
-source. For example, the background kernel can be assigned to a context that uses
-most of the CUs, while the latency-sensitive kernel can be assigned to a separate
-context that uses a smaller, dedicated set of CUs. The background kernel cannot
-consume the CUs assigned to the latency-sensitive context, so the
+Execution contexts address this contention by partitioning resources before the
+work is launched. For example, the background kernel can be assigned to a context
+that uses most of the CUs, while the latency-sensitive kernel can be assigned to
+a separate context that uses a smaller, dedicated set of CUs. The background
+kernel cannot consume the CUs assigned to the latency-sensitive context, so the
 latency-sensitive kernel can start with less interference from the background
 workload.
 
@@ -87,6 +112,19 @@ This isolation involves a trade-off: neither kernel can use all available CUs,
 so each may run slightly longer when considered in isolation. In exchange, the
 latency-sensitive workload is no longer blocked by the background workload's use
 of shared CUs.
+
+Use execution contexts when your application design requires predictable access
+to a portion of the GPU. Resource partitioning is an explicit setup step: you
+decide how many CUs each workload should receive, create contexts from those
+partitions, and launch each workload on streams associated with the appropriate
+context.
+
+For example, a service can reserve a handful of CUs for a latency-sensitive
+kernel so that the kernel has resources available when it launches. Another
+application might deliberately cap a kernel to a smaller CU count to measure how
+performance scales as the available compute resources change. In both cases, the
+partition size is a design choice that should be measured and tuned for the
+workload.
 
 Partition sizing is workload dependent. Select the CU count for each execution
 context when the context is created, then tune the allocation based on measured
@@ -113,6 +151,13 @@ allows the application to specify how many concurrent stream-ordered workloads i
 expects. The driver treats this value as a hint and attempts to place work from
 different contexts onto separate queues. The device-wide upper bound on work
 queues is controlled by the ``GPU_MAX_HW_QUEUES`` environment variable.
+
+Work queue configuration is optional. A context can be created with only a CU
+resource. If you omit a work queue configuration resource, the context still
+limits kernels to its assigned CUs, but the driver uses the default work queue
+sharing behavior. Add a work queue configuration when you also want to give the
+driver a hint about how many independent stream-ordered workloads you expect and
+how work queues should be shared across contexts.
 
 .. note::
 
@@ -176,8 +221,8 @@ a CU resource covering every CU available to the process, a work queue
 configuration covering the device's work queues, and the matching work queue
 resource. You can also ask an execution context or a stream what resources it
 holds, using :cpp:func:`hipExecutionCtxGetDevResource` and
-:cpp:func:`hipStreamGetDevResource`. An execution context can hold several resource
-types at once; a stream only ever carries a CU resource.
+:cpp:func:`hipStreamGetDevResource`. An execution context can hold several
+resource types at once; a stream only ever carries a CU resource.
 
 Compute unit resource
 -------------------------------------------------------------------------------
@@ -193,14 +238,14 @@ The CU resource (``hipDevSmResource``) describes a group of compute units:
         unsigned int flags;                  // 0 (default) or hipDevSmResourceGroupBackfill
     } hipDevSmResource;
 
-You never fill these fields in yourself. :cpp:func:`hipDeviceGetDevResource` sets them
-when you query a device, and the split APIs set them on the resources they
+You never fill these fields in yourself. :cpp:func:`hipDeviceGetDevResource` sets
+them when you query a device, and the split APIs set them on the resources they
 produce. Treat ``minSmPartitionSize`` and ``smCoscheduledAlignment`` as
 architecture-dependent values to read at runtime, not constants to hard-code.
 
-The resource returned by :cpp:func:`hipDeviceGetDevResource` is intersected with any
-global CU mask set through the ``ROC_GLOBAL_CU_MASK`` environment variable, so it
-reflects the CUs your process can actually use.
+The resource returned by :cpp:func:`hipDeviceGetDevResource` is intersected with
+any global CU mask set through the ``ROC_GLOBAL_CU_MASK`` environment variable,
+so it reflects the CUs your process can actually use.
 
 Workgroup processor alignment
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
@@ -248,13 +293,13 @@ you populate directly:
 
 ``sharingScope`` takes one of two values. ``hipDevWorkqueueConfigScopeDeviceCtx``,
 the default, shares work queues across all contexts.
-``hipDevWorkqueueConfigScopeGreenCtxBalanced`` asks the driver to keep work queues
-from different execution contexts apart where it can, guided by
+``hipDevWorkqueueConfigScopeGreenCtxBalanced`` asks the driver to keep work
+queues from different execution contexts apart where it can, guided by
 ``wqConcurrencyLimit``.
 
 There is no split API for work queue resources: set the fields yourself, or read
-a device's configuration with :cpp:func:`hipDeviceGetDevResource`. The plain work queue
-resource (``hipDevResourceTypeWorkqueue``) exposes no fields you can set.
+a device's configuration with :cpp:func:`hipDeviceGetDevResource`. The plain work
+queue resource (``hipDevResourceTypeWorkqueue``) exposes no fields you can set.
 
 .. tip::
 
@@ -290,8 +335,8 @@ a stream:
     hipError_t hipStreamGetDevResource(hipStream_t hStream, hipDevResource* resource,
                                        hipDevResourceType type);
 
-Each accepts any resource type, except :cpp:func:`hipStreamGetDevResource`, which is
-limited to CU resources.
+Each accepts any resource type, except :cpp:func:`hipStreamGetDevResource`, which
+is limited to CU resources.
 
 Reading a device's CUs looks like this:
 
@@ -316,9 +361,10 @@ Step 2: Split the CU resource
 -------------------------------------------------------------------------------
 
 Divide the CU resource with one of two APIs. :cpp:func:`hipDevSmResourceSplitByCount`
-produces equal-sized partitions; :cpp:func:`hipDevSmResourceSplit` produces partitions of
-different sizes in a single call. Either way, CUs that do not fit the requested
-partitions land in an optional remainder. Both APIs only operate on CU resources.
+produces equal-sized partitions; :cpp:func:`hipDevSmResourceSplit` produces
+partitions of different sizes in a single call. Either way, CUs that do not fit
+the requested partitions land in an optional remainder. Both APIs only operate
+on CU resources.
 
 Equal-sized partitions
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
@@ -378,15 +424,16 @@ Points to keep in mind:
 
 .. note::
 
-    ``hipDevSmResourceSplitIgnoreSmCoscheduling`` is defined but not yet supported
-    by the runtime. Passing it returns ``hipErrorNotSupported``.
+    ``hipDevSmResourceSplitIgnoreSmCoscheduling`` is defined but not yet
+    supported by the runtime. Passing it returns ``hipErrorNotSupported``.
 
 Different-sized partitions
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-When contexts need different CU counts, one :cpp:func:`hipDevSmResourceSplitByCount` call
-is not enough, since it only makes equal groups. :cpp:func:`hipDevSmResourceSplit` builds
-groups of independent sizes at once:
+When contexts need different CU counts, one
+:cpp:func:`hipDevSmResourceSplitByCount` call is not enough, since it only makes
+equal groups. :cpp:func:`hipDevSmResourceSplit` builds groups of independent
+sizes at once:
 
 .. code-block:: cpp
 
@@ -507,17 +554,30 @@ A two-way uneven split:
     HIP_CHECK(hipDevSmResourceSplit(&result[0], 2, &cu_resources,
                                     nullptr /* remainder */, 0 /* flags */, &group_params[0]));
 
-Leaving ``coscheduledSmCount`` or ``preferredCoscheduledSmCount`` at zero requests
-the architecture default, which matches the device's ``smCoscheduledAlignment``.
-To see the value that was chosen, read the ``groupParams`` entry back after a
-successful call.
+Leaving ``coscheduledSmCount`` or ``preferredCoscheduledSmCount`` at zero
+requests the architecture default, which matches the device's
+``smCoscheduledAlignment``. To see the value that was chosen, read the
+``groupParams`` entry back after a successful call.
 
-Step 2.1 (optional): Add a work queue resource
+For a complete example that performs the full sequence -- query the device
+resource, split the CU resource, generate descriptors, create execution
+contexts, create streams, and launch kernels -- see the
+`HIP-Basic execution context example <https://github.com/ROCm/rocm-examples/tree/develop/HIP-Basic/execution_context>`_.
+The example uses separate contexts for a background kernel and a
+latency-sensitive kernel, which is the same setup pattern shown here.
+
+Step 2.1 (optional): Add work queue configuration
 -------------------------------------------------------------------------------
 
-This step is optional. To configure work queues alongside CUs, fill in a work
-queue configuration resource yourself and place it next to the CU resources you
-plan to bundle:
+This step is optional. A context can be created with only a CU resource. If you
+omit a work queue configuration resource, the context still limits kernels to
+its assigned CUs, but the driver uses the default work queue sharing behavior.
+Add a work queue configuration when you also want to give the driver a hint about
+how many independent stream-ordered workloads you expect and how work queues
+should be shared across contexts.
+
+To configure work queues alongside CUs, fill in a work queue configuration
+resource yourself and place it next to the CU resources you plan to bundle:
 
 .. code-block:: cpp
 
@@ -564,8 +624,8 @@ The call requires that:
 Step 4: Create the context
 -------------------------------------------------------------------------------
 
-Turn the descriptor into an execution context with :cpp:func:`hipGreenCtxCreate`. The
-context can use only the resources the descriptor holds:
+Turn the descriptor into an execution context with :cpp:func:`hipGreenCtxCreate`.
+The context can use only the resources the descriptor holds:
 
 .. code-block:: cpp
 
@@ -573,8 +633,8 @@ context can use only the resources the descriptor holds:
                                  int device, unsigned int flags);
 
 Pass ``0`` for ``flags``. Initialize the device's primary context first, with
-``hipInitDevice`` or :cpp:func:`hipSetDevice`, so that primary context setup does not add
-overhead to this call:
+``hipInitDevice`` or :cpp:func:`hipSetDevice`, so that primary context setup does
+not add overhead to this call:
 
 .. code-block:: cpp
 
@@ -587,20 +647,24 @@ overhead to this call:
     hipExecutionCtx_t exec_ctx = {};
     HIP_CHECK(hipGreenCtxCreate(&exec_ctx, desc, current_device, 0));
 
-To confirm what the context received, call :cpp:func:`hipExecutionCtxGetDevResource` on it
-for each resource type.
+To confirm what the context received, call
+:cpp:func:`hipExecutionCtxGetDevResource` on it for each resource type.
 
 You can create several contexts by repeating these steps. Usually each context
 uses a disjoint set of CUs, but you can also let two contexts share some CUs by
-including the same resource in both descriptors. Overlapping CUs like this is
-occasionally useful; apply it deliberately.
+including the same resource in both descriptors. Overlapping CUs can improve
+utilization when strict isolation is not required. For example, two contexts can
+share a small CU subset so that a background workload can use those CUs when the
+latency-sensitive workload is idle. When both contexts are active, however, the
+shared CUs can become a source of interference. Use overlapping partitions
+deliberately and validate the behavior with your workload.
 
 Running work on a context
 ===============================================================================
 
 To send a kernel to an execution context, create a stream on the context with
-:cpp:func:`hipExecutionCtxStreamCreate`. Anything launched on that stream is bound to the
-context's resources:
+:cpp:func:`hipExecutionCtxStreamCreate`. Anything launched on that stream is
+bound to the context's resources:
 
 .. code-block:: cpp
 
@@ -620,11 +684,12 @@ On an execution context, the default stream flag behaves like
 ``hipStreamNonBlocking``.
 
 You can query the CU partition backing any stream with
-:cpp:func:`hipStreamGetDevResource`. It returns the execution context's CU partition for
-a context stream, the explicit mask for a stream created with
-:cpp:func:`hipExtStreamCreateWithCUMask`, and the full available device resource for a
-stream created outside an execution context. Only ``hipDevResourceTypeSm`` is
-supported; other types return ``hipErrorInvalidResourceType``.
+:cpp:func:`hipStreamGetDevResource`. It returns the execution context's CU
+partition for a context stream, the explicit mask for a stream created with
+:cpp:func:`hipExtStreamCreateWithCUMask`, and the full available device resource
+for a stream created outside an execution context. Only
+``hipDevResourceTypeSm`` is supported; other types return
+``hipErrorInvalidResourceType``.
 
 Graphs
 -------------------------------------------------------------------------------
@@ -641,31 +706,32 @@ Thread block clusters
 
 A kernel that uses thread block clusters runs on an execution context stream like
 any other kernel and is bound to the context's CUs. Use the occupancy queries,
-:cpp:func:`hipOccupancyMaxPotentialClusterSize` and :cpp:func:`hipOccupancyMaxActiveClusters`, to
-size clusters. When you give one of these a launch configuration whose ``stream``
-belongs to an execution context, it accounts for that context's CUs.
+:cpp:func:`hipOccupancyMaxPotentialClusterSize` and
+:cpp:func:`hipOccupancyMaxActiveClusters`, to size clusters. When you give one
+of these a launch configuration whose ``stream`` belongs to an execution
+context, it accounts for that context's CUs.
 
 Other context operations
 ===============================================================================
 
 To synchronize with events across a whole context, use
-:cpp:func:`hipExecutionCtxRecordEvent` and :cpp:func:`hipExecutionCtxWaitEvent`. Recording
-captures all of the context's outstanding work in one event; waiting makes later
-work on the context depend on that event. When a context has several streams,
-this is simpler than recording or waiting on each stream separately.
+:cpp:func:`hipExecutionCtxRecordEvent` and :cpp:func:`hipExecutionCtxWaitEvent`.
+Recording captures all of the context's outstanding work in one event; waiting
+makes later work on the context depend on that event. When a context has several
+streams, this is simpler than recording or waiting on each stream separately.
 
-:cpp:func:`hipExecutionCtxSynchronize` blocks the host until the context finishes its
-work. Called on the device's primary context, obtained with
-:cpp:func:`hipDeviceGetExecutionCtx`, it also waits on every execution context created on
-that device.
+:cpp:func:`hipExecutionCtxSynchronize` blocks the host until the context finishes
+its work. Called on the device's primary context, obtained with
+:cpp:func:`hipDeviceGetExecutionCtx`, it also waits on every execution context
+created on that device.
 
 :cpp:func:`hipExecutionCtxGetDevice` returns the device behind a context, and
-:cpp:func:`hipExecutionCtxGetId` returns its unique identifier. Release a context you
-created with :cpp:func:`hipExecutionCtxDestroy`.
+:cpp:func:`hipExecutionCtxGetId` returns its unique identifier. Release a context
+you created with :cpp:func:`hipExecutionCtxDestroy`.
 
-Destroy a context's streams before the context itself. A stream whose context has
-been destroyed is orphaned: operations on it other than :cpp:func:`hipStreamDestroy`
-return ``hipErrorContextIsDestroyed``.
+Destroy a context's streams before the context itself. A stream whose context
+has been destroyed is orphaned: operations on it other than
+:cpp:func:`hipStreamDestroy` return ``hipErrorContextIsDestroyed``.
 
 Migrating from CUDA green contexts
 ===============================================================================
@@ -758,7 +824,7 @@ execution context, so they share the available device resources:
 
 The partitioned run splits the CUs into a group for the background kernel and a
 disjoint group for the critical kernel, then follows the four-step setup: read
-the device's CUs, split them, wrap each group in a descriptor, and create an
+the device's CUs, split them, bundle each group into a descriptor, and create an
 execution context per group. A stream on each context confines its kernel to that
 context's CUs. The ``time_partitioned_case`` helper carries out these steps for a
 requested critical-CU count and returns the same ``timings`` struct as the

--- a/projects/hip/docs/how-to/hip_runtime_api/execution_context.rst
+++ b/projects/hip/docs/how-to/hip_runtime_api/execution_context.rst
@@ -708,124 +708,49 @@ A busy kernel stands in for a compute-bound workload. Oversubscribing the grid,
 launching many more thread blocks than the device runs at once, keeps every CU
 occupied for the whole measurement:
 
-.. code-block:: cpp
-
-    __global__ void busy_kernel(unsigned int* out, unsigned int iterations)
-    {
-        volatile unsigned int acc = 0;
-        for(unsigned int i = 0; i < iterations; ++i)
-        {
-            acc += i;
-        }
-        if(threadIdx.x == 0)
-        {
-            out[blockIdx.x] = acc;
-        }
-    }
+.. literalinclude:: ../../tools/example_codes/execution_context.hip
+   :start-after: // [busy-kernel-start]
+   :end-before: // [busy-kernel-end]
+   :language: cpp
 
 A helper launches the background kernel, then times the critical kernel with HIP
-events while the background kernel is still running. Passing two streams that
-belong to disjoint execution contexts confines each kernel to its own CUs;
-passing two ordinary streams lets them contend:
+events while the background kernel is still running. It returns a ``timings``
+struct holding the measured GPU time of each kernel; the critical kernel's time
+is the latency of interest. Passing two streams that belong to disjoint execution
+contexts confines each kernel to its own CUs, while passing two ordinary streams
+lets them contend. The ``workload`` argument carries the grid sizes and iteration
+counts that size both kernels:
 
-.. code-block:: cpp
-
-    float time_critical_with_background(hipStream_t   background_stream,
-                                        hipStream_t   critical_stream,
-                                        unsigned int* d_out_background,
-                                        unsigned int* d_out_critical)
-    {
-        hipEvent_t start, stop;
-        HIP_CHECK(hipEventCreate(&start));
-        HIP_CHECK(hipEventCreate(&stop));
-
-        // Launch the background kernel; it keeps running on its own stream.
-        busy_kernel<<<background_grid, block_size, 0, background_stream>>>(
-            d_out_background, background_iterations);
-        HIP_CHECK(hipGetLastError());
-
-        // Time the critical kernel while the background kernel runs.
-        HIP_CHECK(hipEventRecord(start, critical_stream));
-        busy_kernel<<<critical_grid, block_size, 0, critical_stream>>>(
-            d_out_critical, critical_iterations);
-        HIP_CHECK(hipGetLastError());
-        HIP_CHECK(hipEventRecord(stop, critical_stream));
-        HIP_CHECK(hipEventSynchronize(stop));
-
-        float critical_ms = 0.0f;
-        HIP_CHECK(hipEventElapsedTime(&critical_ms, start, stop));
-        HIP_CHECK(hipStreamSynchronize(background_stream));
-
-        HIP_CHECK(hipEventDestroy(start));
-        HIP_CHECK(hipEventDestroy(stop));
-        return critical_ms;
-    }
+.. literalinclude:: ../../tools/example_codes/execution_context.hip
+   :start-after: // [timing-helper-start]
+   :end-before: // [timing-helper-end]
+   :language: cpp
 
 The baseline runs both kernels on ordinary non-blocking streams, so they share
 the whole device:
 
-.. code-block:: cpp
-
-    hipStream_t shared_background, shared_critical;
-    HIP_CHECK(hipStreamCreateWithFlags(&shared_background, hipStreamNonBlocking));
-    HIP_CHECK(hipStreamCreateWithFlags(&shared_critical, hipStreamNonBlocking));
-
-    float baseline_ms = time_critical_with_background(
-        shared_background, shared_critical, d_out_background, d_out_critical);
-
-    HIP_CHECK(hipStreamDestroy(shared_background));
-    HIP_CHECK(hipStreamDestroy(shared_critical));
+.. literalinclude:: ../../tools/example_codes/execution_context.hip
+   :start-after: // [baseline-start]
+   :end-before: // [baseline-end]
+   :language: cpp
 
 The partitioned run splits the CUs into a group for the background kernel and a
 disjoint group for the critical kernel, then follows the four-step setup: read
 the device's CUs, split them, wrap each group in a descriptor, and create an
 execution context per group. A stream on each context confines its kernel to that
-context's CUs:
+context's CUs. The ``time_partitioned_case`` helper carries out these steps for a
+requested critical-CU count and returns the same ``timings`` struct as the
+baseline, writing back the aligned CU counts the split actually produced:
 
-.. code-block:: cpp
+.. literalinclude:: ../../tools/example_codes/execution_context.hip
+   :start-after: // [partitioned-start]
+   :end-before: // [partitioned-end]
+   :language: cpp
 
-    // Step 1: Read the device's CUs.
-    hipDevResource cu_resources = {};
-    HIP_CHECK(hipDeviceGetDevResource(0, &cu_resources, hipDevResourceTypeSm));
-    unsigned int total_cus    = cu_resources.sm.smCount;
-    unsigned int critical_cus = total_cus / 4;
-
-    // Step 2: Split into a background group and a smaller critical group.
-    hipDevResource result[2] = {};
-    hipDevSmResourceGroupParams group_params[2] = {
-        {/*smCount=*/total_cus - critical_cus, 0, 0, 0},
-        {/*smCount=*/critical_cus,             0, 0, 0}};
-    HIP_CHECK(hipDevSmResourceSplit(&result[0], 2, &cu_resources, nullptr, 0, &group_params[0]));
-
-    // Step 3: Wrap each group in a descriptor.
-    hipDevResourceDesc_t desc_background = {};
-    hipDevResourceDesc_t desc_critical   = {};
-    HIP_CHECK(hipDevResourceGenerateDesc(&desc_background, &result[0], 1));
-    HIP_CHECK(hipDevResourceGenerateDesc(&desc_critical, &result[1], 1));
-
-    // Step 4: Create an execution context per group.
-    hipExecutionCtx_t ctx_background = {};
-    hipExecutionCtx_t ctx_critical   = {};
-    HIP_CHECK(hipGreenCtxCreate(&ctx_background, desc_background, 0, 0));
-    HIP_CHECK(hipGreenCtxCreate(&ctx_critical, desc_critical, 0, 0));
-
-    // A stream on each context, then run the same timed measurement.
-    hipStream_t strm_background, strm_critical;
-    HIP_CHECK(hipExecutionCtxStreamCreate(&strm_background, ctx_background, hipStreamDefault, 0));
-    HIP_CHECK(hipExecutionCtxStreamCreate(&strm_critical, ctx_critical, hipStreamDefault, 0));
-
-    float partitioned_ms = time_critical_with_background(
-        strm_background, strm_critical, d_out_background, d_out_critical);
-
-    // Release everything.
-    HIP_CHECK(hipStreamDestroy(strm_background));
-    HIP_CHECK(hipStreamDestroy(strm_critical));
-    HIP_CHECK(hipExecutionCtxDestroy(ctx_background));
-    HIP_CHECK(hipExecutionCtxDestroy(ctx_critical));
-
-Comparing ``baseline_ms`` with ``partitioned_ms`` shows the critical kernel
-finishing sooner once it has its own CUs. Settle on the CU split by measuring your
-own workload. The
+Comparing the baseline timing with the partitioned timing shows the critical
+kernel finishing sooner once it has its own CUs. Settle on the CU split by
+measuring your own workload. The
 `HIP-Basic execution context example <https://github.com/ROCm/rocm-examples/tree/develop/HIP-Basic/execution_context>`_
-contains a complete, buildable version that sweeps several partition sizes and
-also provides a CUDA green context backend.
+contains a complete, buildable version that sweeps several partition sizes (an
+eighth, a quarter, and half of the device) and also provides a CUDA green context
+backend.

--- a/projects/hip/docs/how-to/hip_runtime_api/execution_context.rst
+++ b/projects/hip/docs/how-to/hip_runtime_api/execution_context.rst
@@ -8,27 +8,29 @@
 Execution contexts
 *******************************************************************************
 
-By default, every kernel you launch competes for the whole GPU. The runtime
-decides which compute units (CUs) a kernel runs on, and kernels that run at the
-same time share the pool of CUs and work queues. This is efficient for
-throughput, but it means a small, time-critical kernel can be held up behind a
-large kernel that already occupies the device.
+By default, every kernel you launch competes for the GPU resources available to
+the process. The runtime decides which compute units (CUs) a kernel runs on, and
+kernels that run at the same time share the available pool of CUs and work
+queues. This is efficient for throughput, but it means a small, time-critical
+kernel can be delayed by a large kernel that already occupies the device.
 
-An execution context lets you carve out a fixed slice of the GPU and bind work
-to it. When you create an execution context, you attach it to a chosen set of
-device resources, currently CUs and work queues. Any kernel launched on a stream
-that belongs to that context is confined to those resources, no matter how the
-kernel is configured. You set this up entirely on the host; the kernel source
-does not change.
+An execution context lets you define a fixed slice of the available GPU resources
+and bind work to it. When you create an execution context, you associate it with
+selected device resources, currently CUs and work queue configuration. Any kernel
+launched on a stream that belongs to that context is confined to the context's CU
+resources, regardless of the kernel launch configuration. Work queue
+configuration associated with the context guides how the driver dispatches work.
+You set this up entirely on the host; the kernel source does not change.
 
 Reserving resources this way is useful whenever you want predictable access to
-part of the GPU. For example, you can hold back a handful of CUs so a latency
-sensitive kernel always has somewhere to start, or you can cap a kernel to a
-smaller CU count to measure how it scales, without touching its code.
+part of the GPU. For example, you can reserve a handful of CUs so a
+latency-sensitive kernel always has resources available when it launches, or you
+can cap a kernel to a smaller CU count to measure how it scales without changing
+its code.
 
 In the HIP runtime, an execution context is either the device's primary context,
 which the runtime uses implicitly, or a resource-partitioned context you create
-with :cpp:func:`hipGreenCtxCreate`. This feature corresponds to CUDA green
+with :cpp:func:`hipGreenCtxCreate`. This feature is analogous to CUDA green
 contexts.
 
 .. note::
@@ -36,87 +38,106 @@ contexts.
     The device resource structures use the field name ``smCount`` and the
     resource type ``hipDevResourceTypeSm``. HIP keeps these ``sm`` (streaming
     multiprocessor) identifiers so that code written against CUDA compiles
-    unchanged. On AMD GPUs the equivalent physical resource is the compute unit.
+    unchanged. On AMD GPUs, the equivalent physical resource is the compute unit.
     This page writes "compute unit" or "CU" in the text and keeps the literal
     identifiers in code.
 
 .. note::
 
     The snippets on this page are written to show the calling sequence. Build and
-    run them on a ROCm system before depending on them. A complete, buildable
-    program is provided as the
+    run them on a ROCm system before using them as the basis for production code.
+    A complete, buildable program is provided as the
     `HIP-Basic execution context example <https://github.com/ROCm/rocm-examples/tree/develop/HIP-Basic/execution_context>`_.
 
 The full API listing is in :ref:`execution_context_management_reference`.
 
-When execution contexts help
+Benefits of execution contexts
 ===============================================================================
 
-Two properties of normal kernel scheduling motivate execution contexts.
+Two characteristics of standard kernel scheduling motivate the use of execution
+contexts.
 
-First, you cannot ask for a specific number of CUs. The number a kernel ends up
-using follows indirectly from its grid and block dimensions and its per-CU
-occupancy. There is no launch parameter that says "run on N CUs."
+First, an application cannot directly request a specific number of CUs for a
+kernel launch. The number of CUs a kernel uses is determined indirectly by its
+grid and block dimensions, along with its per-CU occupancy. There is no launch
+parameter that specifies, for example, "run this kernel on N CUs."
 
-Second, kernels that overlap in time draw from the same shared CUs. If one kernel
-is already spread across the device when a second, more urgent kernel arrives,
-the urgent kernel has to wait for CUs to free up as the first kernel's thread
-blocks retire.
+Second, kernels that overlap in time draw from the same shared pool of available
+CUs. If one kernel already occupies the device and a second, higher-priority
+kernel is launched, the second kernel must wait until CUs become available as
+the first kernel's thread blocks retire.
 
-Picture a service that keeps a background kernel running continuously while
-occasionally needing to run a short, urgent kernel with minimal delay. If the
-background kernel is allowed to fill the GPU, the urgent kernel stalls until
-enough thread blocks of the background kernel finish. Raising the urgent kernel's
-stream priority helps, but it still waits for in-flight thread blocks to drain.
+Consider a service that continuously runs a background kernel while occasionally
+launching a short, latency-sensitive kernel. If the background kernel occupies
+the available GPU resources, the latency-sensitive kernel cannot begin execution
+until enough of the background kernel's thread blocks complete. Increasing the
+priority of the latency-sensitive kernel's stream can reduce this delay, but it
+cannot eliminate it, because the kernel must still wait for in-flight thread
+blocks to drain.
 
-Execution contexts remove the contention at its source. Put the background kernel
-on a context that owns most of the CUs, and the urgent kernel on a context that
-owns a small, separate set. The background kernel can never spill onto the urgent
-kernel's CUs, so the urgent kernel finds free resources the moment it launches.
-The trade-off is that neither kernel can use the entire GPU any longer, so each
-may take a little longer in isolation, but the urgent work stops being blocked.
+Execution contexts address this contention by partitioning resources at the
+source. For example, the background kernel can be assigned to a context that uses
+most of the CUs, while the latency-sensitive kernel can be assigned to a separate
+context that uses a smaller, dedicated set of CUs. The background kernel cannot
+consume the CUs assigned to the latency-sensitive context, so the
+latency-sensitive kernel can start with less interference from the background
+workload.
 
-The split is your decision and depends on the workload. Choose the CU counts for
-each context when you create it, and tune them by measurement.
+This isolation involves a trade-off: neither kernel can use all available CUs,
+so each may run slightly longer when considered in isolation. In exchange, the
+latency-sensitive workload is no longer blocked by the background workload's use
+of shared CUs.
+
+Partition sizing is workload dependent. Select the CU count for each execution
+context when the context is created, then tune the allocation based on measured
+performance.
 
 Work queues
 -------------------------------------------------------------------------------
 
-CUs are one kind of resource an execution context can own. Work queues are
-another. A work queue is an abstraction the driver uses to dispatch GPU work;
-tasks that land on the same work queue can end up serialized even when they are
-logically independent, because sharing a queue introduces an ordering dependency
-between them.
+CUs are one type of resource associated with an execution context. Work queue
+configuration is another.
 
-That matters because reserving CUs alone does not always guarantee overlap. If
-the urgent kernel and the background kernel are dispatched through the same work
-queue, the urgent kernel can still wait behind the background kernel even though
-it has its own CUs. You do not choose work queues directly, but an execution
-context lets you state how many concurrent stream-ordered workloads you expect.
-The driver treats that number as a hint and tries to keep work from different
-contexts on separate queues. The device-wide upper bound on work queues is
-controlled by the ``GPU_MAX_HW_QUEUES`` environment variable.
+A work queue is an abstraction used by the driver to dispatch GPU work. Tasks
+submitted to the same work queue may be serialized, even when they are logically
+independent, because sharing a queue introduces an ordering dependency between
+those tasks.
+
+This distinction is important because reserving CUs alone does not always
+guarantee overlap. If the latency-sensitive kernel and the background kernel are
+dispatched through the same work queue, the latency-sensitive kernel may still
+wait behind the background kernel even though it has dedicated CUs.
+
+Applications do not select work queues directly. Instead, an execution context
+allows the application to specify how many concurrent stream-ordered workloads it
+expects. The driver treats this value as a hint and attempts to place work from
+different contexts onto separate queues. The device-wide upper bound on work
+queues is controlled by the ``GPU_MAX_HW_QUEUES`` environment variable.
 
 .. note::
 
-    Partitioning CUs and work queues reduces the causes of interference between
-    contexts, but it does not force independent kernels to run at the same time.
-    Concurrency still depends on the workloads and the device state.
+    Partitioning CUs and configuring work queue usage reduces sources of
+    interference between contexts, but it does not force independent kernels to
+    execute concurrently. Actual concurrency still depends on the workloads and
+    the current device state.
 
 Relationship to hardware partitioning
 -------------------------------------------------------------------------------
 
-AMD Instinct accelerators can be split into logical devices through hardware
-compute partitioning modes such as SPX and CPX. That split happens at the system
-level, before an application starts, and is typically used to divide a GPU among
-separate applications.
+AMD Instinct GPUs can be divided into logical devices through hardware compute
+partitioning modes such as SPX and CPX. This partitioning is configured at the
+system level before an application starts, and is typically used to divide a GPU
+among separate applications.
 
-Execution contexts work at a finer grain and inside a single process. Hardware
-partitioning decides how the GPU is shared between applications; execution
-contexts decide how one application's streams share the CUs it has been given. On
-a GPU already running in a partitioned mode, an execution context draws from the
-CUs of whichever partition the application is using. HIP has no equivalent of a
-multi-process service; execution contexts are a within-process mechanism.
+Execution contexts operate at a finer granularity and within a single process.
+Hardware partitioning determines how the GPU is shared across applications,
+whereas execution contexts determine how one application's streams share the CUs
+available to that application.
+
+On a GPU that is already running in a hardware-partitioned mode, an execution
+context draws from the CUs in the partition assigned to the application. HIP
+execution contexts are not a multi-process service equivalent; they are a
+within-process resource-management mechanism.
 
 Device resources and descriptors
 ===============================================================================
@@ -150,13 +171,13 @@ Three resource types are defined:
 
 ``hipDevResourceTypeInvalid`` marks an unset resource.
 
-Query a device with ``hipDeviceGetDevResource`` and it reports all three:
-a CU resource covering every CU on the GPU, a work queue configuration covering
-all its work queues, and the matching work queue resource. You can also ask an
-execution context or a stream what resources it holds, using
-``hipExecutionCtxGetDevResource`` and ``hipStreamGetDevResource``. An execution
-context can hold several resource types at once; a stream only ever carries a
-CU resource.
+Query a device with :cpp:func:`hipDeviceGetDevResource` and it reports all three:
+a CU resource covering every CU available to the process, a work queue
+configuration covering the device's work queues, and the matching work queue
+resource. You can also ask an execution context or a stream what resources it
+holds, using :cpp:func:`hipExecutionCtxGetDevResource` and
+:cpp:func:`hipStreamGetDevResource`. An execution context can hold several resource
+types at once; a stream only ever carries a CU resource.
 
 Compute unit resource
 -------------------------------------------------------------------------------
@@ -172,12 +193,12 @@ The CU resource (``hipDevSmResource``) describes a group of compute units:
         unsigned int flags;                  // 0 (default) or hipDevSmResourceGroupBackfill
     } hipDevSmResource;
 
-You never fill these fields in yourself. ``hipDeviceGetDevResource`` sets them
+You never fill these fields in yourself. :cpp:func:`hipDeviceGetDevResource` sets them
 when you query a device, and the split APIs set them on the resources they
 produce. Treat ``minSmPartitionSize`` and ``smCoscheduledAlignment`` as
 architecture-dependent values to read at runtime, not constants to hard-code.
 
-The resource returned by ``hipDeviceGetDevResource`` is intersected with any
+The resource returned by :cpp:func:`hipDeviceGetDevResource` is intersected with any
 global CU mask set through the ``ROC_GLOBAL_CU_MASK`` environment variable, so it
 reflects the CUs your process can actually use.
 
@@ -193,21 +214,23 @@ which is also the minimum partition granularity:
 
     * - Mode
       - ``smCoscheduledAlignment``
-    * - WGP mode (typical on RDNA and recent CDNA)
+    * - WGP mode, typical on RDNA and recent CDNA
       - 2 CUs
     * - CU mode
       - 1 CU
 
-When the alignment is 2, request CU counts in multiples of two to avoid wasting
-units. Read ``smCoscheduledAlignment`` at runtime rather than assuming a value,
-since it depends on the device and its mode.
+When the alignment is greater than one, request CU counts in multiples of
+``smCoscheduledAlignment`` to avoid wasting units. Read
+``smCoscheduledAlignment`` at runtime rather than assuming a value, since it
+depends on the device and its mode.
 
 .. note::
 
-    Creating an execution context does not, by itself, stop other work from
-    running on the same CUs; the partitions are not hardware-enforced as mutually
-    exclusive. To isolate workloads, split the device into disjoint partitions
-    and confine each workload to its own context.
+    Creating an execution context does not automatically prevent other contexts
+    or streams created outside an execution context from using the same CUs. To
+    isolate workloads, split the available CU resource into disjoint partitions
+    and launch each workload only on streams associated with its assigned
+    execution context.
 
 Work queue configuration resource
 -------------------------------------------------------------------------------
@@ -230,7 +253,7 @@ from different execution contexts apart where it can, guided by
 ``wqConcurrencyLimit``.
 
 There is no split API for work queue resources: set the fields yourself, or read
-a device's configuration with ``hipDeviceGetDevResource``. The plain work queue
+a device's configuration with :cpp:func:`hipDeviceGetDevResource`. The plain work queue
 resource (``hipDevResourceTypeWorkqueue``) exposes no fields you can set.
 
 .. tip::
@@ -242,14 +265,15 @@ Creating an execution context
 
 Building an execution context takes four steps:
 
-#. Read the resources you want to start from, usually the device's full set.
+#. Read the resources you want to start from, usually the device's full available
+   set.
 #. Split the CU resource into the partitions you need.
 #. Bundle the resulting resources into a descriptor.
 #. Create the execution context from that descriptor.
 
-Once the context exists, create a stream on it. Work you launch on that
-stream, including a kernel launched with the triple-chevron syntax, is limited to
-the context's resources.
+Once the context exists, create a stream on it. Work you launch on that stream,
+including a kernel launched with the triple-chevron syntax, is limited to the
+context's resources.
 
 Step 1: Read the available resources
 -------------------------------------------------------------------------------
@@ -266,32 +290,24 @@ a stream:
     hipError_t hipStreamGetDevResource(hipStream_t hStream, hipDevResource* resource,
                                        hipDevResourceType type);
 
-Each accepts any resource type, except ``hipStreamGetDevResource``, which is
+Each accepts any resource type, except :cpp:func:`hipStreamGetDevResource`, which is
 limited to CU resources.
 
 Reading a device's CUs looks like this:
 
-.. code-block:: cpp
-
-    int current_device = 0;
-    HIP_CHECK(hipSetDevice(current_device));
-
-    hipDevResource cu_resources = {};
-    HIP_CHECK(hipDeviceGetDevResource(current_device, &cu_resources, hipDevResourceTypeSm));
-
-    std::cout << "Available CUs: " << cu_resources.sm.smCount << "\n";
-    std::cout << "Min. partition size: " << cu_resources.sm.minSmPartitionSize << "\n";
-    std::cout << "Co-scheduled alignment: " << cu_resources.sm.smCoscheduledAlignment << "\n";
+.. literalinclude:: ../../tools/example_codes/execution_context.hip
+   :start-after: // [read-cu-resource-start]
+   :end-before: // [read-cu-resource-end]
+   :language: cpp
+   :dedent:
 
 Reading the work queue configuration is similar:
 
-.. code-block:: cpp
-
-    hipDevResource wq_config = {};
-    HIP_CHECK(hipDeviceGetDevResource(current_device, &wq_config, hipDevResourceTypeWorkqueueConfig));
-
-    std::cout << "WQ concurrency limit: " << wq_config.wqConfig.wqConcurrencyLimit << "\n";
-    std::cout << "WQ sharing scope: " << wq_config.wqConfig.sharingScope << "\n";
+.. literalinclude:: ../../tools/example_codes/execution_context.hip
+   :start-after: // [read-wq-config-start]
+   :end-before: // [read-wq-config-end]
+   :language: cpp
+   :dedent:
 
 For a device, ``wqConcurrencyLimit`` reflects ``GPU_MAX_HW_QUEUES`` or its
 default.
@@ -299,8 +315,8 @@ default.
 Step 2: Split the CU resource
 -------------------------------------------------------------------------------
 
-Divide the CU resource with one of two APIs. ``hipDevSmResourceSplitByCount``
-produces equal-sized partitions; ``hipDevSmResourceSplit`` produces partitions of
+Divide the CU resource with one of two APIs. :cpp:func:`hipDevSmResourceSplitByCount`
+produces equal-sized partitions; :cpp:func:`hipDevSmResourceSplit` produces partitions of
 different sizes in a single call. Either way, CUs that do not fit the requested
 partitions land in an optional remainder. Both APIs only operate on CU resources.
 
@@ -353,11 +369,12 @@ Points to keep in mind:
 - Pass ``result = nullptr`` to find out how many groups you would get, without
   producing them.
 - Pass ``remainder = nullptr`` to discard the leftover CUs.
-- The remainder does not carry the same guarantees as the equal-sized groups.
+- The remainder is not guaranteed to have the same size or scheduling properties
+  as the equal-sized groups.
 - ``flags`` is ``0`` by default. ``hipDevSmResourceSplitIgnoreSmCoscheduling`` and
   ``hipDevSmResourceSplitMaxPotentialClusterSize`` are also defined.
 - To repartition a resulting resource, first turn it into a descriptor and an
-  execution context (steps 3 and 4).
+  execution context using steps 3 and 4.
 
 .. note::
 
@@ -367,8 +384,8 @@ Points to keep in mind:
 Different-sized partitions
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-When contexts need different CU counts, one ``hipDevSmResourceSplitByCount`` call
-is not enough, since it only makes equal groups. ``hipDevSmResourceSplit`` builds
+When contexts need different CU counts, one :cpp:func:`hipDevSmResourceSplitByCount` call
+is not enough, since it only makes equal groups. :cpp:func:`hipDevSmResourceSplit` builds
 groups of independent sizes at once:
 
 .. code-block:: cpp
@@ -378,8 +395,8 @@ groups of independent sizes at once:
                                      unsigned int flags, hipDevSmResourceGroupParams* groupParams);
 
 Each of the ``nbGroups`` output resources is shaped by a matching
-``groupParams`` entry. A remainder is optional. Every produced group has at least
-some CUs; a group is never empty.
+``groupParams`` entry. A remainder is optional. Each produced group contains at
+least one valid scheduling granule; a group is never empty.
 
 .. code-block:: cpp
 
@@ -390,12 +407,13 @@ some CUs; a group is never empty.
         unsigned int flags;                       // 0 or hipDevSmResourceGroupBackfill
     } hipDevSmResourceGroupParams;
 
-Give each group an ``smCount`` that is a multiple of two. If your kernels use
-thread block clusters, set ``coscheduledSmCount`` to the largest cluster the
-group must support, since a cluster's thread blocks are always co-scheduled.
-``preferredCoscheduledSmCount`` is a hint to fold groups into larger ones when
-possible, and setting ``flags`` to ``hipDevSmResourceGroupBackfill`` lets a group
-absorb extra CUs beyond its requested size.
+Give each group an ``smCount`` that is a multiple of the device's
+``smCoscheduledAlignment``. If your kernels use thread block clusters, set
+``coscheduledSmCount`` to the largest cluster the group must support, since a
+cluster's thread blocks are always co-scheduled. ``preferredCoscheduledSmCount``
+is a hint to fold groups into larger ones when possible, and setting ``flags`` to
+``hipDevSmResourceGroupBackfill`` lets a group absorb extra CUs beyond its
+requested size.
 
 To let the runtime pick a size, use discovery mode: set an entry's ``smCount`` to
 zero, and the call fills in a valid count. Entries are processed in order, from
@@ -434,7 +452,8 @@ What the return value means depends on ``result``:
   device allows.
 
 When the call succeeds with a valid ``result``, each ``result[i].sm.smCount`` is
-an even number in the range ``[2, input.sm.smCount]``.
+aligned to the device's ``smCoscheduledAlignment`` and is within the valid range
+for the input resource.
 
 The table below sketches ``groupParams`` for a few common goals, with CU counts
 left as placeholders you fill in for your device.
@@ -448,13 +467,13 @@ left as placeholders you fill in for your device.
       - ``smCount``
       - ``coscheduledSmCount``
       - ``flags``
-    * - One group of X CUs, discard the rest. Clusters allowed.
+    * - One group of X CUs, with remaining CUs discarded. Clusters allowed.
       - 1
       - ``nullptr``
       - X
       - 0
       - 0
-    * - One group of X CUs, the rest kept as remainder. No clusters.
+    * - One group of X CUs, with remaining CUs returned as a remainder. No clusters.
       - 1
       - not ``nullptr``
       - X
@@ -469,7 +488,7 @@ left as placeholders you fill in for your device.
     * - As many CUs as possible in one group, plus a remainder.
       - 1
       - not ``nullptr``
-      - 0 (discovery)
+      - 0, discovery
       - chosen size
       - 0
 
@@ -496,17 +515,17 @@ successful call.
 Adding a work queue resource
 -------------------------------------------------------------------------------
 
-To reserve work queues alongside CUs, fill in a work queue configuration resource
-yourself and place it next to the CU resources you plan to bundle:
+To configure work queues alongside CUs, fill in a work queue configuration
+resource yourself and place it next to the CU resources you plan to bundle:
 
 .. code-block:: cpp
 
     hipDevResource resources[2] = {};
     // Populate resources[0] with a split API (one group).
 
-    resources[1].type                       = hipDevResourceTypeWorkqueueConfig;
-    resources[1].wqConfig.device            = 0;
-    resources[1].wqConfig.sharingScope      = hipDevWorkqueueConfigScopeGreenCtxBalanced;
+    resources[1].type                        = hipDevResourceTypeWorkqueueConfig;
+    resources[1].wqConfig.device             = 0;
+    resources[1].wqConfig.sharingScope       = hipDevWorkqueueConfigScopeGreenCtxBalanced;
     resources[1].wqConfig.wqConcurrencyLimit = 4;
 
 A concurrency limit of four tells the driver you expect up to four concurrent
@@ -517,7 +536,7 @@ Step 3: Build a descriptor
 -------------------------------------------------------------------------------
 
 Gather the resources for the context into a descriptor with
-``hipDevResourceGenerateDesc``:
+:cpp:func:`hipDevResourceGenerateDesc`:
 
 .. code-block:: cpp
 
@@ -544,7 +563,7 @@ The call requires that:
 Step 4: Create the context
 -------------------------------------------------------------------------------
 
-Turn the descriptor into an execution context with ``hipGreenCtxCreate``. The
+Turn the descriptor into an execution context with :cpp:func:`hipGreenCtxCreate`. The
 context can use only the resources the descriptor holds:
 
 .. code-block:: cpp
@@ -553,7 +572,7 @@ context can use only the resources the descriptor holds:
                                  int device, unsigned int flags);
 
 Pass ``0`` for ``flags``. Initialize the device's primary context first, with
-``hipInitDevice`` or ``hipSetDevice``, so that primary context setup does not add
+``hipInitDevice`` or :cpp:func:`hipSetDevice`, so that primary context setup does not add
 overhead to this call:
 
 .. code-block:: cpp
@@ -567,11 +586,11 @@ overhead to this call:
     hipExecutionCtx_t exec_ctx = {};
     HIP_CHECK(hipGreenCtxCreate(&exec_ctx, desc, current_device, 0));
 
-To confirm what the context received, call ``hipExecutionCtxGetDevResource`` on it
+To confirm what the context received, call :cpp:func:`hipExecutionCtxGetDevResource` on it
 for each resource type.
 
 You can create several contexts by repeating these steps. Usually each context
-owns a disjoint set of CUs, but you can also let two contexts share some CUs by
+uses a disjoint set of CUs, but you can also let two contexts share some CUs by
 including the same resource in both descriptors. Overlapping CUs like this is
 occasionally useful; apply it deliberately.
 
@@ -579,7 +598,7 @@ Running work on a context
 ===============================================================================
 
 To send a kernel to an execution context, create a stream on the context with
-``hipExecutionCtxStreamCreate``. Anything launched on that stream is bound to the
+:cpp:func:`hipExecutionCtxStreamCreate`. Anything launched on that stream is bound to the
 context's resources:
 
 .. code-block:: cpp
@@ -600,11 +619,11 @@ On an execution context, the default stream flag behaves like
 ``hipStreamNonBlocking``.
 
 You can query the CU partition backing any stream with
-``hipStreamGetDevResource``. It returns the execution context's CU partition for
+:cpp:func:`hipStreamGetDevResource`. It returns the execution context's CU partition for
 a context stream, the explicit mask for a stream created with
-``hipExtStreamCreateWithCUMask``, and the full device resource for an ordinary
-stream. Only ``hipDevResourceTypeSm`` is supported; other types return
-``hipErrorInvalidResourceType``.
+:cpp:func:`hipExtStreamCreateWithCUMask`, and the full available device resource for a
+stream created outside an execution context. Only ``hipDevResourceTypeSm`` is
+supported; other types return ``hipErrorInvalidResourceType``.
 
 Graphs
 -------------------------------------------------------------------------------
@@ -621,7 +640,7 @@ Thread block clusters
 
 A kernel that uses thread block clusters runs on an execution context stream like
 any other kernel and is bound to the context's CUs. Use the occupancy queries,
-``hipOccupancyMaxPotentialClusterSize`` and ``hipOccupancyMaxActiveClusters``, to
+:cpp:func:`hipOccupancyMaxPotentialClusterSize` and :cpp:func:`hipOccupancyMaxActiveClusters`, to
 size clusters. When you give one of these a launch configuration whose ``stream``
 belongs to an execution context, it accounts for that context's CUs.
 
@@ -629,22 +648,22 @@ Other context operations
 ===============================================================================
 
 To synchronize with events across a whole context, use
-``hipExecutionCtxRecordEvent`` and ``hipExecutionCtxWaitEvent``. Recording
+:cpp:func:`hipExecutionCtxRecordEvent` and :cpp:func:`hipExecutionCtxWaitEvent`. Recording
 captures all of the context's outstanding work in one event; waiting makes later
 work on the context depend on that event. When a context has several streams,
 this is simpler than recording or waiting on each stream separately.
 
-``hipExecutionCtxSynchronize`` blocks the host until the context finishes its
+:cpp:func:`hipExecutionCtxSynchronize` blocks the host until the context finishes its
 work. Called on the device's primary context, obtained with
-``hipDeviceGetExecutionCtx``, it also waits on every execution context created on
+:cpp:func:`hipDeviceGetExecutionCtx`, it also waits on every execution context created on
 that device.
 
-``hipExecutionCtxGetDevice`` returns the device behind a context, and
-``hipExecutionCtxGetId`` returns its unique identifier. Release a context you
-created with ``hipExecutionCtxDestroy``.
+:cpp:func:`hipExecutionCtxGetDevice` returns the device behind a context, and
+:cpp:func:`hipExecutionCtxGetId` returns its unique identifier. Release a context you
+created with :cpp:func:`hipExecutionCtxDestroy`.
 
-Destroy a context's streams before the context itself. A stream created from a
-destroyed context is orphaned: operations on it other than ``hipStreamDestroy``
+Destroy a context's streams before the context itself. A stream whose context has
+been destroyed is orphaned: operations on it other than :cpp:func:`hipStreamDestroy`
 return ``hipErrorContextIsDestroyed``.
 
 Migrating from CUDA green contexts
@@ -660,30 +679,31 @@ uses ``CUgreenCtx``. The main function correspondences are:
     * - CUDA
       - HIP
     * - ``cuDeviceGetDevResource``
-      - ``hipDeviceGetDevResource``
+      - :cpp:func:`hipDeviceGetDevResource`
     * - ``cuDevSmResourceSplitByCount``
-      - ``hipDevSmResourceSplitByCount``
+      - :cpp:func:`hipDevSmResourceSplitByCount`
     * - ``cuDevResourceGenerateDesc``
-      - ``hipDevResourceGenerateDesc``
+      - :cpp:func:`hipDevResourceGenerateDesc`
     * - ``cuGreenCtxCreate``
-      - ``hipGreenCtxCreate``
+      - :cpp:func:`hipGreenCtxCreate`
     * - ``cuGreenCtxDestroy``
-      - ``hipExecutionCtxDestroy``
+      - :cpp:func:`hipExecutionCtxDestroy`
     * - ``cuGreenCtxStreamCreate``
-      - ``hipExecutionCtxStreamCreate``
+      - :cpp:func:`hipExecutionCtxStreamCreate`
     * - ``cuGreenCtxRecordEvent``
-      - ``hipExecutionCtxRecordEvent``
+      - :cpp:func:`hipExecutionCtxRecordEvent`
     * - ``cuGreenCtxWaitEvent``
-      - ``hipExecutionCtxWaitEvent``
+      - :cpp:func:`hipExecutionCtxWaitEvent`
     * - ``cuStreamGetGreenCtx``
-      - ``hipStreamGetDevResource``
+      - :cpp:func:`hipStreamGetDevResource`
 
 The most important behavioral difference is alignment. CUDA aligns partitions to
-SM granularity, while HIP aligns to the WGP granularity reported by
-``smCoscheduledAlignment``, which is 2 CUs in WGP mode. Query this value and size
-partitions accordingly instead of porting fixed SM counts directly.
+SM granularity, while HIP aligns partitions to the granularity reported by
+``smCoscheduledAlignment``, which is typically 2 CUs in WGP mode. Query this
+value and size partitions accordingly instead of porting fixed SM counts
+directly.
 
-Worked example
+Example: reserving CUs for a critical kernel
 ===============================================================================
 
 This example reserves CUs for an urgent kernel so it is not blocked by a
@@ -691,18 +711,19 @@ long-running one, and measures the difference. A large background kernel runs
 concurrently with a small, latency-sensitive critical kernel, and the critical
 kernel's runtime is timed in two configurations:
 
-- **Baseline**: both kernels run on ordinary streams and share all of the
-  device's CUs, so the critical kernel contends with the background kernel.
+- **Baseline**: both kernels run on streams created outside an execution context
+  and share all available CUs, so the critical kernel contends with the
+  background kernel.
 - **Partitioned**: the CUs are split into two execution contexts, so the
   critical kernel runs on its own CUs while the background kernel is confined to
   the rest.
 
 Without execution contexts, the critical kernel waits for the background
 kernel's thread blocks to retire before CUs open up, even with a higher stream
-priority. With execution contexts, each kernel owns a distinct set of CUs, so the
-critical kernel starts right away. Both kernels give up access to the full GPU,
-so each may run slightly longer alone, but the critical kernel is no longer held
-back.
+priority. With execution contexts, each kernel uses a distinct set of CUs, so the
+critical kernel can start with less interference. Both kernels give up access to
+the full available CU set, so each may run slightly longer alone, but the
+critical kernel is no longer held back by the background workload.
 
 A busy kernel stands in for a compute-bound workload. Oversubscribing the grid,
 launching many more thread blocks than the device runs at once, keeps every CU
@@ -717,17 +738,17 @@ A helper launches the background kernel, then times the critical kernel with HIP
 events while the background kernel is still running. It returns a ``timings``
 struct holding the measured GPU time of each kernel; the critical kernel's time
 is the latency of interest. Passing two streams that belong to disjoint execution
-contexts confines each kernel to its own CUs, while passing two ordinary streams
-lets them contend. The ``workload`` argument carries the grid sizes and iteration
-counts that size both kernels:
+contexts confines each kernel to its own CUs, while passing two streams created
+outside an execution context lets them contend. The ``workload`` argument carries
+the grid sizes and iteration counts that size both kernels:
 
 .. literalinclude:: ../../tools/example_codes/execution_context.hip
    :start-after: // [timing-helper-start]
    :end-before: // [timing-helper-end]
    :language: cpp
 
-The baseline runs both kernels on ordinary non-blocking streams, so they share
-the whole device:
+The baseline runs both kernels on non-blocking streams created outside an
+execution context, so they share the available device resources:
 
 .. literalinclude:: ../../tools/example_codes/execution_context.hip
    :start-after: // [baseline-start]
@@ -751,6 +772,6 @@ Comparing the baseline timing with the partitioned timing shows the critical
 kernel finishing sooner once it has its own CUs. Settle on the CU split by
 measuring your own workload. The
 `HIP-Basic execution context example <https://github.com/ROCm/rocm-examples/tree/develop/HIP-Basic/execution_context>`_
-contains a complete, buildable version that sweeps several partition sizes (an
-eighth, a quarter, and half of the device) and also provides a CUDA green context
-backend.
+contains a complete, buildable version that sweeps several partition sizes, such
+as an eighth, a quarter, and half of the device, and also provides a CUDA green
+context backend.

--- a/projects/hip/docs/how-to/hip_runtime_api/execution_context.rst
+++ b/projects/hip/docs/how-to/hip_runtime_api/execution_context.rst
@@ -275,7 +275,9 @@ depends on the device and its mode.
     or streams created outside an execution context from using the same CUs. To
     isolate workloads, split the available CU resource into disjoint partitions
     and launch each workload only on streams associated with its assigned
-    execution context.
+    execution context. The :ref:`execution_context_example` demonstrates this
+    pattern with separate contexts for a background kernel and a
+    latency-sensitive kernel.
 
 Work queue configuration resource
 -------------------------------------------------------------------------------
@@ -593,7 +595,7 @@ A concurrency limit of four tells the driver you expect up to four concurrent
 stream-ordered workloads, and it assigns work queues to respect that where it
 can.
 
-Step 3: Build a descriptor
+Step 3: Bundle resources into a descriptor
 -------------------------------------------------------------------------------
 
 Gather the resources for the context into a descriptor with
@@ -619,7 +621,8 @@ The call requires that:
 - Every resource belongs to the same device.
 - CU resources combined together come from the same split call and share the same
   ``coscheduledSmCount``, unless they are remainders.
-- At most one work queue configuration or work queue resource is present.
+- Work queue configuration is optional. If included, the descriptor can contain
+  either one work queue configuration resource or one work queue resource.
 
 Step 4: Create the context
 -------------------------------------------------------------------------------
@@ -651,13 +654,14 @@ To confirm what the context received, call
 :cpp:func:`hipExecutionCtxGetDevResource` on it for each resource type.
 
 You can create several contexts by repeating these steps. Usually each context
-uses a disjoint set of CUs, but you can also let two contexts share some CUs by
-including the same resource in both descriptors. Overlapping CUs can improve
-utilization when strict isolation is not required. For example, two contexts can
-share a small CU subset so that a background workload can use those CUs when the
-latency-sensitive workload is idle. When both contexts are active, however, the
-shared CUs can become a source of interference. Use overlapping partitions
-deliberately and validate the behavior with your workload.
+uses a disjoint set of CUs, which gives the clearest isolation between workloads.
+You can also deliberately include the same CU resource in more than one
+descriptor, creating an overlapping region. This can improve utilization when
+one workload is bursty: for example, a background context can use a small shared
+CU group while a latency-sensitive context is idle, while the latency-sensitive
+context still has its own private CUs when it becomes active. When both contexts
+are active, the shared CUs can become a source of interference, so use
+overlapping partitions only when that trade-off is acceptable.
 
 Running work on a context
 ===============================================================================
@@ -769,6 +773,8 @@ SM granularity, while HIP aligns partitions to the granularity reported by
 ``smCoscheduledAlignment``, which is typically 2 CUs in WGP mode. Query this
 value and size partitions accordingly instead of porting fixed SM counts
 directly.
+
+.. _execution_context_example:
 
 Example: reserving CUs for a critical kernel
 ===============================================================================

--- a/projects/hip/docs/how-to/hip_runtime_api/execution_context.rst
+++ b/projects/hip/docs/how-to/hip_runtime_api/execution_context.rst
@@ -177,6 +177,38 @@ when you query a device, and the split APIs set them on the resources they
 produce. Treat ``minSmPartitionSize`` and ``smCoscheduledAlignment`` as
 architecture-dependent values to read at runtime, not constants to hard-code.
 
+The resource returned by ``hipDeviceGetDevResource`` is intersected with any
+global CU mask set through the ``ROC_GLOBAL_CU_MASK`` environment variable, so it
+reflects the CUs your process can actually use.
+
+Workgroup processor alignment
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+On AMD GPUs, CUs are grouped into workgroup processors (WGPs), and cooperating
+CUs are scheduled together. ``smCoscheduledAlignment`` reports this granularity,
+which is also the minimum partition granularity:
+
+.. list-table::
+    :header-rows: 1
+
+    * - Mode
+      - ``smCoscheduledAlignment``
+    * - WGP mode (typical on RDNA and recent CDNA)
+      - 2 CUs
+    * - CU mode
+      - 1 CU
+
+When the alignment is 2, request CU counts in multiples of two to avoid wasting
+units. Read ``smCoscheduledAlignment`` at runtime rather than assuming a value,
+since it depends on the device and its mode.
+
+.. note::
+
+    Creating an execution context does not, by itself, stop other work from
+    running on the same CUs; the partitions are not hardware-enforced as mutually
+    exclusive. To isolate workloads, split the device into disjoint partitions
+    and confine each workload to its own context.
+
 Work queue configuration resource
 -------------------------------------------------------------------------------
 
@@ -567,6 +599,13 @@ context's resources:
 On an execution context, the default stream flag behaves like
 ``hipStreamNonBlocking``.
 
+You can query the CU partition backing any stream with
+``hipStreamGetDevResource``. It returns the execution context's CU partition for
+a context stream, the explicit mask for a stream created with
+``hipExtStreamCreateWithCUMask``, and the full device resource for an ordinary
+stream. Only ``hipDevResourceTypeSm`` is supported; other types return
+``hipErrorInvalidResourceType``.
+
 Graphs
 -------------------------------------------------------------------------------
 
@@ -603,6 +642,46 @@ that device.
 ``hipExecutionCtxGetDevice`` returns the device behind a context, and
 ``hipExecutionCtxGetId`` returns its unique identifier. Release a context you
 created with ``hipExecutionCtxDestroy``.
+
+Destroy a context's streams before the context itself. A stream created from a
+destroyed context is orphaned: operations on it other than ``hipStreamDestroy``
+return ``hipErrorContextIsDestroyed``.
+
+Migrating from CUDA green contexts
+===============================================================================
+
+HIP execution contexts follow the CUDA green context model, so ports are mostly
+mechanical. The handle type differs: HIP uses ``hipExecutionCtx_t`` where CUDA
+uses ``CUgreenCtx``. The main function correspondences are:
+
+.. list-table::
+    :header-rows: 1
+
+    * - CUDA
+      - HIP
+    * - ``cuDeviceGetDevResource``
+      - ``hipDeviceGetDevResource``
+    * - ``cuDevSmResourceSplitByCount``
+      - ``hipDevSmResourceSplitByCount``
+    * - ``cuDevResourceGenerateDesc``
+      - ``hipDevResourceGenerateDesc``
+    * - ``cuGreenCtxCreate``
+      - ``hipGreenCtxCreate``
+    * - ``cuGreenCtxDestroy``
+      - ``hipExecutionCtxDestroy``
+    * - ``cuGreenCtxStreamCreate``
+      - ``hipExecutionCtxStreamCreate``
+    * - ``cuGreenCtxRecordEvent``
+      - ``hipExecutionCtxRecordEvent``
+    * - ``cuGreenCtxWaitEvent``
+      - ``hipExecutionCtxWaitEvent``
+    * - ``cuStreamGetGreenCtx``
+      - ``hipStreamGetDevResource``
+
+The most important behavioral difference is alignment. CUDA aligns partitions to
+SM granularity, while HIP aligns to the WGP granularity reported by
+``smCoscheduledAlignment``, which is 2 CUs in WGP mode. Query this value and size
+partitions accordingly instead of porting fixed SM counts directly.
 
 Worked example
 ===============================================================================

--- a/projects/hip/docs/how-to/hip_runtime_api/execution_context.rst
+++ b/projects/hip/docs/how-to/hip_runtime_api/execution_context.rst
@@ -1,0 +1,663 @@
+.. meta::
+    :description: How to use HIP execution contexts to partition GPU compute resources
+    :keywords: AMD, ROCm, HIP, execution context, compute unit, CU, resource partitioning, work queue
+
+.. _execution_context:
+
+*******************************************************************************
+Execution contexts
+*******************************************************************************
+
+By default, every kernel you launch competes for the whole GPU. The runtime
+decides which compute units (CUs) a kernel runs on, and kernels that run at the
+same time share the pool of CUs and work queues. This is efficient for
+throughput, but it means a small, time-critical kernel can be held up behind a
+large kernel that already occupies the device.
+
+An execution context lets you carve out a fixed slice of the GPU and bind work
+to it. When you create an execution context, you attach it to a chosen set of
+device resources, currently CUs and work queues. Any kernel launched on a stream
+that belongs to that context is confined to those resources, no matter how the
+kernel is configured. You set this up entirely on the host; the kernel source
+does not change.
+
+Reserving resources this way is useful whenever you want predictable access to
+part of the GPU. For example, you can hold back a handful of CUs so a latency
+sensitive kernel always has somewhere to start, or you can cap a kernel to a
+smaller CU count to measure how it scales, without touching its code.
+
+In the HIP runtime, an execution context is either the device's primary context,
+which the runtime uses implicitly, or a resource-partitioned context you create
+with :cpp:func:`hipGreenCtxCreate`. This feature corresponds to CUDA green
+contexts.
+
+.. note::
+
+    The device resource structures use the field name ``smCount`` and the
+    resource type ``hipDevResourceTypeSm``. HIP keeps these ``sm`` (streaming
+    multiprocessor) identifiers so that code written against CUDA compiles
+    unchanged. On AMD GPUs the equivalent physical resource is the compute unit.
+    This page writes "compute unit" or "CU" in the text and keeps the literal
+    identifiers in code.
+
+.. note::
+
+    The snippets on this page are written to show the calling sequence. Build and
+    run them on a ROCm system before depending on them. A complete, buildable
+    program is provided as the
+    `HIP-Basic execution context example <https://github.com/ROCm/rocm-examples/tree/develop/HIP-Basic/execution_context>`_.
+
+The full API listing is in :ref:`execution_context_management_reference`.
+
+When execution contexts help
+===============================================================================
+
+Two properties of normal kernel scheduling motivate execution contexts.
+
+First, you cannot ask for a specific number of CUs. The number a kernel ends up
+using follows indirectly from its grid and block dimensions and its per-CU
+occupancy. There is no launch parameter that says "run on N CUs."
+
+Second, kernels that overlap in time draw from the same shared CUs. If one kernel
+is already spread across the device when a second, more urgent kernel arrives,
+the urgent kernel has to wait for CUs to free up as the first kernel's thread
+blocks retire.
+
+Picture a service that keeps a background kernel running continuously while
+occasionally needing to run a short, urgent kernel with minimal delay. If the
+background kernel is allowed to fill the GPU, the urgent kernel stalls until
+enough thread blocks of the background kernel finish. Raising the urgent kernel's
+stream priority helps, but it still waits for in-flight thread blocks to drain.
+
+Execution contexts remove the contention at its source. Put the background kernel
+on a context that owns most of the CUs, and the urgent kernel on a context that
+owns a small, separate set. The background kernel can never spill onto the urgent
+kernel's CUs, so the urgent kernel finds free resources the moment it launches.
+The trade-off is that neither kernel can use the entire GPU any longer, so each
+may take a little longer in isolation, but the urgent work stops being blocked.
+
+The split is your decision and depends on the workload. Choose the CU counts for
+each context when you create it, and tune them by measurement.
+
+Work queues
+-------------------------------------------------------------------------------
+
+CUs are one kind of resource an execution context can own. Work queues are
+another. A work queue is an abstraction the driver uses to dispatch GPU work;
+tasks that land on the same work queue can end up serialized even when they are
+logically independent, because sharing a queue introduces an ordering dependency
+between them.
+
+That matters because reserving CUs alone does not always guarantee overlap. If
+the urgent kernel and the background kernel are dispatched through the same work
+queue, the urgent kernel can still wait behind the background kernel even though
+it has its own CUs. You do not choose work queues directly, but an execution
+context lets you state how many concurrent stream-ordered workloads you expect.
+The driver treats that number as a hint and tries to keep work from different
+contexts on separate queues. The device-wide upper bound on work queues is
+controlled by the ``GPU_MAX_HW_QUEUES`` environment variable.
+
+.. note::
+
+    Partitioning CUs and work queues reduces the causes of interference between
+    contexts, but it does not force independent kernels to run at the same time.
+    Concurrency still depends on the workloads and the device state.
+
+Relationship to hardware partitioning
+-------------------------------------------------------------------------------
+
+AMD Instinct accelerators can be split into logical devices through hardware
+compute partitioning modes such as SPX and CPX. That split happens at the system
+level, before an application starts, and is typically used to divide a GPU among
+separate applications.
+
+Execution contexts work at a finer grain and inside a single process. Hardware
+partitioning decides how the GPU is shared between applications; execution
+contexts decide how one application's streams share the CUs it has been given. On
+a GPU already running in a partitioned mode, an execution context draws from the
+CUs of whichever partition the application is using. HIP has no equivalent of a
+multi-process service; execution contexts are a within-process mechanism.
+
+Device resources and descriptors
+===============================================================================
+
+An execution context is built from device resources. A device resource
+(``hipDevResource``) names a slice of a specific GPU, and a resource descriptor
+(``hipDevResourceDesc_t``) bundles one or more resources together. The execution
+context you create from a descriptor can use exactly the resources that
+descriptor holds, and nothing else.
+
+The ``hipDevResource`` structure carries a single resource, tagged by type:
+
+.. code-block:: cpp
+
+    typedef struct hipDevResource_st {
+        hipDevResourceType type;
+        // internal padding
+        union {
+            hipDevSmResource              sm;
+            hipDevWorkqueueConfigResource wqConfig;
+            hipDevWorkqueueResource       wq;
+        };
+        struct hipDevResource_st* nextResource;
+    } hipDevResource;
+
+Three resource types are defined:
+
+- ``hipDevResourceTypeSm`` for a set of compute units.
+- ``hipDevResourceTypeWorkqueueConfig`` for a work queue configuration.
+- ``hipDevResourceTypeWorkqueue`` for an existing work queue resource.
+
+``hipDevResourceTypeInvalid`` marks an unset resource.
+
+Query a device with ``hipDeviceGetDevResource`` and it reports all three:
+a CU resource covering every CU on the GPU, a work queue configuration covering
+all its work queues, and the matching work queue resource. You can also ask an
+execution context or a stream what resources it holds, using
+``hipExecutionCtxGetDevResource`` and ``hipStreamGetDevResource``. An execution
+context can hold several resource types at once; a stream only ever carries a
+CU resource.
+
+Compute unit resource
+-------------------------------------------------------------------------------
+
+The CU resource (``hipDevSmResource``) describes a group of compute units:
+
+.. code-block:: cpp
+
+    typedef struct hipDevSmResource {
+        unsigned int smCount;                // number of CUs in this resource
+        unsigned int minSmPartitionSize;     // smallest CU count this resource can be split into
+        unsigned int smCoscheduledAlignment; // CUs guaranteed to be co-scheduled together
+        unsigned int flags;                  // 0 (default) or hipDevSmResourceGroupBackfill
+    } hipDevSmResource;
+
+You never fill these fields in yourself. ``hipDeviceGetDevResource`` sets them
+when you query a device, and the split APIs set them on the resources they
+produce. Treat ``minSmPartitionSize`` and ``smCoscheduledAlignment`` as
+architecture-dependent values to read at runtime, not constants to hard-code.
+
+Work queue configuration resource
+-------------------------------------------------------------------------------
+
+The work queue configuration resource (``hipDevWorkqueueConfigResource``) is one
+you populate directly:
+
+.. code-block:: cpp
+
+    typedef struct hipDevWorkqueueConfigResource {
+        int                        device;             // device that owns the work queues
+        unsigned int               wqConcurrencyLimit; // expected concurrent stream-ordered workloads
+        hipDevWorkqueueConfigScope sharingScope;       // how work queues are shared
+    } hipDevWorkqueueConfigResource;
+
+``sharingScope`` takes one of two values. ``hipDevWorkqueueConfigScopeDeviceCtx``,
+the default, shares work queues across all contexts.
+``hipDevWorkqueueConfigScopeGreenCtxBalanced`` asks the driver to keep work queues
+from different execution contexts apart where it can, guided by
+``wqConcurrencyLimit``.
+
+There is no split API for work queue resources: set the fields yourself, or read
+a device's configuration with ``hipDeviceGetDevResource``. The plain work queue
+resource (``hipDevResourceTypeWorkqueue``) exposes no fields you can set.
+
+.. tip::
+
+    Zero-initialize every device resource structure before you use it.
+
+Creating an execution context
+===============================================================================
+
+Building an execution context takes four steps:
+
+#. Read the resources you want to start from, usually the device's full set.
+#. Split the CU resource into the partitions you need.
+#. Bundle the resulting resources into a descriptor.
+#. Create the execution context from that descriptor.
+
+Once the context exists, create a stream on it. Work you launch on that
+stream, including a kernel launched with the triple-chevron syntax, is limited to
+the context's resources.
+
+Step 1: Read the available resources
+-------------------------------------------------------------------------------
+
+Start by populating a ``hipDevResource`` from a device, an execution context, or
+a stream:
+
+.. code-block:: cpp
+
+    hipError_t hipDeviceGetDevResource(hipDevice_t device, hipDevResource* resource,
+                                       hipDevResourceType type);
+    hipError_t hipExecutionCtxGetDevResource(hipExecutionCtx_t ctx, hipDevResource* resource,
+                                             hipDevResourceType type);
+    hipError_t hipStreamGetDevResource(hipStream_t hStream, hipDevResource* resource,
+                                       hipDevResourceType type);
+
+Each accepts any resource type, except ``hipStreamGetDevResource``, which is
+limited to CU resources.
+
+Reading a device's CUs looks like this:
+
+.. code-block:: cpp
+
+    int current_device = 0;
+    HIP_CHECK(hipSetDevice(current_device));
+
+    hipDevResource cu_resources = {};
+    HIP_CHECK(hipDeviceGetDevResource(current_device, &cu_resources, hipDevResourceTypeSm));
+
+    std::cout << "Available CUs: " << cu_resources.sm.smCount << "\n";
+    std::cout << "Min. partition size: " << cu_resources.sm.minSmPartitionSize << "\n";
+    std::cout << "Co-scheduled alignment: " << cu_resources.sm.smCoscheduledAlignment << "\n";
+
+Reading the work queue configuration is similar:
+
+.. code-block:: cpp
+
+    hipDevResource wq_config = {};
+    HIP_CHECK(hipDeviceGetDevResource(current_device, &wq_config, hipDevResourceTypeWorkqueueConfig));
+
+    std::cout << "WQ concurrency limit: " << wq_config.wqConfig.wqConcurrencyLimit << "\n";
+    std::cout << "WQ sharing scope: " << wq_config.wqConfig.sharingScope << "\n";
+
+For a device, ``wqConcurrencyLimit`` reflects ``GPU_MAX_HW_QUEUES`` or its
+default.
+
+Step 2: Split the CU resource
+-------------------------------------------------------------------------------
+
+Divide the CU resource with one of two APIs. ``hipDevSmResourceSplitByCount``
+produces equal-sized partitions; ``hipDevSmResourceSplit`` produces partitions of
+different sizes in a single call. Either way, CUs that do not fit the requested
+partitions land in an optional remainder. Both APIs only operate on CU resources.
+
+Equal-sized partitions
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+.. code-block:: cpp
+
+    hipError_t hipDevSmResourceSplitByCount(hipDevResource* result, unsigned int* nbGroups,
+                                            const hipDevResource* input, hipDevResource* remainder,
+                                            unsigned int flags, unsigned int minCount);
+
+You pass in the number of groups you want (``*nbGroups``) and the minimum CUs per
+group (``minCount``). The call may return fewer groups than you asked for, each
+with at least ``minCount`` CUs, because the hardware imposes granularity and
+alignment rules. The exact rounding depends on the device's
+``minSmPartitionSize`` and ``smCoscheduledAlignment``, so read those at runtime.
+
+.. list-table:: Why the result can differ from the request
+    :header-rows: 1
+
+    * - Situation
+      - Outcome
+    * - You request more groups than fit at ``minCount``
+      - The count is reduced to what fits; leftover CUs go to the remainder.
+    * - ``minCount`` is not a multiple of the alignment
+      - Each group is rounded up to a valid size; fewer CUs remain.
+
+A request for five groups:
+
+.. code-block:: cpp
+
+    hipDevResource avail = {};
+    // Populate avail with hipDeviceGetDevResource.
+
+    unsigned int min_cu_count = 8;
+    unsigned int group_count  = 5; // may be lowered by the call
+
+    hipDevResource result[5] = {};
+    hipDevResource remaining = {};
+
+    HIP_CHECK(hipDevSmResourceSplitByCount(&result[0], &group_count, &avail,
+                                           &remaining, 0 /* flags */, min_cu_count));
+
+    std::cout << "Got " << group_count << " groups of " << result[0].sm.smCount
+              << " CUs, " << remaining.sm.smCount << " CUs left over\n";
+
+Points to keep in mind:
+
+- Pass ``result = nullptr`` to find out how many groups you would get, without
+  producing them.
+- Pass ``remainder = nullptr`` to discard the leftover CUs.
+- The remainder does not carry the same guarantees as the equal-sized groups.
+- ``flags`` is ``0`` by default. ``hipDevSmResourceSplitIgnoreSmCoscheduling`` and
+  ``hipDevSmResourceSplitMaxPotentialClusterSize`` are also defined.
+- To repartition a resulting resource, first turn it into a descriptor and an
+  execution context (steps 3 and 4).
+
+.. note::
+
+    ``hipDevSmResourceSplitIgnoreSmCoscheduling`` is defined but not yet supported
+    by the runtime. Passing it returns ``hipErrorNotSupported``.
+
+Different-sized partitions
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+When contexts need different CU counts, one ``hipDevSmResourceSplitByCount`` call
+is not enough, since it only makes equal groups. ``hipDevSmResourceSplit`` builds
+groups of independent sizes at once:
+
+.. code-block:: cpp
+
+    hipError_t hipDevSmResourceSplit(hipDevResource* result, unsigned int nbGroups,
+                                     const hipDevResource* input, hipDevResource* remainder,
+                                     unsigned int flags, hipDevSmResourceGroupParams* groupParams);
+
+Each of the ``nbGroups`` output resources is shaped by a matching
+``groupParams`` entry. A remainder is optional. Every produced group has at least
+some CUs; a group is never empty.
+
+.. code-block:: cpp
+
+    typedef struct hipDevSmResourceGroupParams_st {
+        unsigned int smCount;                     // CU count, or 0 for discovery mode
+        unsigned int coscheduledSmCount;          // co-scheduled CU count for clusters
+        unsigned int preferredCoscheduledSmCount; // preferred co-scheduled CU count (hint)
+        unsigned int flags;                       // 0 or hipDevSmResourceGroupBackfill
+    } hipDevSmResourceGroupParams;
+
+Give each group an ``smCount`` that is a multiple of two. If your kernels use
+thread block clusters, set ``coscheduledSmCount`` to the largest cluster the
+group must support, since a cluster's thread blocks are always co-scheduled.
+``preferredCoscheduledSmCount`` is a hint to fold groups into larger ones when
+possible, and setting ``flags`` to ``hipDevSmResourceGroupBackfill`` lets a group
+absorb extra CUs beyond its requested size.
+
+To let the runtime pick a size, use discovery mode: set an entry's ``smCount`` to
+zero, and the call fills in a valid count. Entries are processed in order, from
+index 0 to ``nbGroups - 1``, so earlier entries claim CUs first.
+
+.. list-table:: hipDevSmResourceSplit arguments
+    :header-rows: 1
+
+    * - Argument
+      - Meaning
+    * - ``result``
+      - ``nullptr`` for a dry run, or a valid pointer to receive the groups.
+    * - ``nbGroups``
+      - How many groups to create.
+    * - ``input``
+      - The CU resource being split.
+    * - ``remainder``
+      - ``nullptr`` to drop leftover CUs.
+    * - ``flags``
+      - ``0``.
+    * - ``groupParams[i].smCount``
+      - ``0`` for discovery, or a specific CU count.
+    * - ``groupParams[i].coscheduledSmCount``
+      - ``0`` for the default, or a co-scheduled CU count.
+    * - ``groupParams[i].preferredCoscheduledSmCount``
+      - ``0`` for the default, or a preferred co-scheduled CU count.
+    * - ``groupParams[i].flags``
+      - ``0`` or ``hipDevSmResourceGroupBackfill``.
+
+What the return value means depends on ``result``:
+
+- With a valid ``result``, the call succeeds only if every requested group was
+  created; otherwise it returns an error.
+- With ``result = nullptr``, the call can report success even for a
+  configuration that would fail with a real output. Use this to probe what the
+  device allows.
+
+When the call succeeds with a valid ``result``, each ``result[i].sm.smCount`` is
+an even number in the range ``[2, input.sm.smCount]``.
+
+The table below sketches ``groupParams`` for a few common goals, with CU counts
+left as placeholders you fill in for your device.
+
+.. list-table:: Example splits
+    :header-rows: 1
+
+    * - Goal
+      - ``nbGroups``
+      - ``remainder``
+      - ``smCount``
+      - ``coscheduledSmCount``
+      - ``flags``
+    * - One group of X CUs, discard the rest. Clusters allowed.
+      - 1
+      - ``nullptr``
+      - X
+      - 0
+      - 0
+    * - One group of X CUs, the rest kept as remainder. No clusters.
+      - 1
+      - not ``nullptr``
+      - X
+      - 2
+      - 0
+    * - Two groups of X and Y CUs with clusters of a chosen size.
+      - 2
+      - ``nullptr``
+      - X, then Y
+      - chosen size
+      - 0
+    * - As many CUs as possible in one group, plus a remainder.
+      - 1
+      - not ``nullptr``
+      - 0 (discovery)
+      - chosen size
+      - 0
+
+A two-way uneven split:
+
+.. code-block:: cpp
+
+    hipDevResource cu_resources = {};
+    HIP_CHECK(hipDeviceGetDevResource(0, &cu_resources, hipDevResourceTypeSm));
+
+    hipDevResource result[2] = {};
+    hipDevSmResourceGroupParams group_params[2] = {
+        {/*smCount=*/16, /*coscheduledSmCount=*/0, /*preferredCoscheduledSmCount=*/0, /*flags=*/0},
+        {/*smCount=*/8,  /*coscheduledSmCount=*/0, /*preferredCoscheduledSmCount=*/0, /*flags=*/0}};
+
+    HIP_CHECK(hipDevSmResourceSplit(&result[0], 2, &cu_resources,
+                                    nullptr /* remainder */, 0 /* flags */, &group_params[0]));
+
+Leaving ``coscheduledSmCount`` or ``preferredCoscheduledSmCount`` at zero requests
+the architecture default, which matches the device's ``smCoscheduledAlignment``.
+To see the value that was chosen, read the ``groupParams`` entry back after a
+successful call.
+
+Adding a work queue resource
+-------------------------------------------------------------------------------
+
+To reserve work queues alongside CUs, fill in a work queue configuration resource
+yourself and place it next to the CU resources you plan to bundle:
+
+.. code-block:: cpp
+
+    hipDevResource resources[2] = {};
+    // Populate resources[0] with a split API (one group).
+
+    resources[1].type                       = hipDevResourceTypeWorkqueueConfig;
+    resources[1].wqConfig.device            = 0;
+    resources[1].wqConfig.sharingScope      = hipDevWorkqueueConfigScopeGreenCtxBalanced;
+    resources[1].wqConfig.wqConcurrencyLimit = 4;
+
+A concurrency limit of four tells the driver you expect up to four concurrent
+stream-ordered workloads, and it assigns work queues to respect that where it
+can.
+
+Step 3: Build a descriptor
+-------------------------------------------------------------------------------
+
+Gather the resources for the context into a descriptor with
+``hipDevResourceGenerateDesc``:
+
+.. code-block:: cpp
+
+    hipError_t hipDevResourceGenerateDesc(hipDevResourceDesc_t* phDesc,
+                                          hipDevResource* resources, unsigned int nbResources);
+
+The resources you bundle must sit next to each other in the array:
+
+.. code-block:: cpp
+
+    hipDevResource result[5] = {};
+    // Populate result with a split API.
+
+    hipDevResourceDesc_t desc = {};
+    HIP_CHECK(hipDevResourceGenerateDesc(&desc, &result[2], 3)); // bundles result[2], [3], [4]
+
+The call requires that:
+
+- Every resource belongs to the same device.
+- CU resources combined together come from the same split call and share the same
+  ``coscheduledSmCount``, unless they are remainders.
+- At most one work queue configuration or work queue resource is present.
+
+Step 4: Create the context
+-------------------------------------------------------------------------------
+
+Turn the descriptor into an execution context with ``hipGreenCtxCreate``. The
+context can use only the resources the descriptor holds:
+
+.. code-block:: cpp
+
+    hipError_t hipGreenCtxCreate(hipExecutionCtx_t* ctx, hipDevResourceDesc_t desc,
+                                 int device, unsigned int flags);
+
+Pass ``0`` for ``flags``. Initialize the device's primary context first, with
+``hipInitDevice`` or ``hipSetDevice``, so that primary context setup does not add
+overhead to this call:
+
+.. code-block:: cpp
+
+    int current_device = 0;
+    HIP_CHECK(hipSetDevice(current_device));
+
+    hipDevResourceDesc_t desc = {};
+    // Generate desc with hipDevResourceGenerateDesc.
+
+    hipExecutionCtx_t exec_ctx = {};
+    HIP_CHECK(hipGreenCtxCreate(&exec_ctx, desc, current_device, 0));
+
+To confirm what the context received, call ``hipExecutionCtxGetDevResource`` on it
+for each resource type.
+
+You can create several contexts by repeating these steps. Usually each context
+owns a disjoint set of CUs, but you can also let two contexts share some CUs by
+including the same resource in both descriptors. Overlapping CUs like this is
+occasionally useful; apply it deliberately.
+
+Running work on a context
+===============================================================================
+
+To send a kernel to an execution context, create a stream on the context with
+``hipExecutionCtxStreamCreate``. Anything launched on that stream is bound to the
+context's resources:
+
+.. code-block:: cpp
+
+    hipError_t hipExecutionCtxStreamCreate(hipStream_t* stream, hipExecutionCtx_t ctx,
+                                           unsigned int flags, int priority);
+
+.. code-block:: cpp
+
+    hipStream_t stream;
+    int priority = 0;
+    HIP_CHECK(hipExecutionCtxStreamCreate(&stream, exec_ctx, hipStreamDefault, priority));
+
+    my_kernel<<<grid_dim, block_dim, 0, stream>>>();
+    HIP_CHECK(hipGetLastError());
+
+On an execution context, the default stream flag behaves like
+``hipStreamNonBlocking``.
+
+Graphs
+-------------------------------------------------------------------------------
+
+With a :doc:`graph <./hipgraph>`, the stream you launch the graph on does not
+decide the resources, unlike a direct launch; that stream only tracks
+dependencies. Instead, each node's execution context is fixed when the node is
+created. Under stream capture, a node inherits the execution context of the
+captured stream. When you build a graph through the graph APIs, set the execution
+context on each node explicitly.
+
+Thread block clusters
+-------------------------------------------------------------------------------
+
+A kernel that uses thread block clusters runs on an execution context stream like
+any other kernel and is bound to the context's CUs. Use the occupancy queries,
+``hipOccupancyMaxPotentialClusterSize`` and ``hipOccupancyMaxActiveClusters``, to
+size clusters. When you give one of these a launch configuration whose ``stream``
+belongs to an execution context, it accounts for that context's CUs.
+
+Other context operations
+===============================================================================
+
+To synchronize with events across a whole context, use
+``hipExecutionCtxRecordEvent`` and ``hipExecutionCtxWaitEvent``. Recording
+captures all of the context's outstanding work in one event; waiting makes later
+work on the context depend on that event. When a context has several streams,
+this is simpler than recording or waiting on each stream separately.
+
+``hipExecutionCtxSynchronize`` blocks the host until the context finishes its
+work. Called on the device's primary context, obtained with
+``hipDeviceGetExecutionCtx``, it also waits on every execution context created on
+that device.
+
+``hipExecutionCtxGetDevice`` returns the device behind a context, and
+``hipExecutionCtxGetId`` returns its unique identifier. Release a context you
+created with ``hipExecutionCtxDestroy``.
+
+Worked example
+===============================================================================
+
+This example reserves CUs for an urgent kernel so it is not blocked by a
+long-running one. Two kernels run on separate non-blocking streams: a
+long-running kernel starts first, and a short, critical kernel follows.
+
+Without execution contexts, the critical kernel waits for the long-running
+kernel's thread blocks to retire before CUs open up, even with a higher stream
+priority. With execution contexts, each kernel owns a distinct set of CUs, so the
+critical kernel starts right away. Both kernels give up access to the full GPU,
+so each may run slightly longer alone, but the critical kernel is no longer held
+back.
+
+.. code-block:: cpp
+
+    // Step 1: Read the device's CUs.
+    hipDevResource cu_resources = {};
+    HIP_CHECK(hipDeviceGetDevResource(0, &cu_resources, hipDevResourceTypeSm));
+
+    // Step 2: Split into a large group and a small group.
+    hipDevResource result[2] = {};
+    hipDevSmResourceGroupParams group_params[2] = {
+        {/*smCount=*/112, 0, 0, 0},
+        {/*smCount=*/16,  0, 0, 0}};
+    HIP_CHECK(hipDevSmResourceSplit(&result[0], 2, &cu_resources, nullptr, 0, &group_params[0]));
+
+    // Step 3: Wrap each group in a descriptor.
+    hipDevResourceDesc_t desc_long = {};
+    hipDevResourceDesc_t desc_critical = {};
+    HIP_CHECK(hipDevResourceGenerateDesc(&desc_long, &result[0], 1));
+    HIP_CHECK(hipDevResourceGenerateDesc(&desc_critical, &result[1], 1));
+
+    // Step 4: Create an execution context per group.
+    hipExecutionCtx_t ctx_long = {};
+    hipExecutionCtx_t ctx_critical = {};
+    HIP_CHECK(hipGreenCtxCreate(&ctx_long, desc_long, 0, 0));
+    HIP_CHECK(hipGreenCtxCreate(&ctx_critical, desc_critical, 0, 0));
+
+    // A stream on each context, then launch each kernel on its stream.
+    hipStream_t strm_long, strm_critical;
+    HIP_CHECK(hipExecutionCtxStreamCreate(&strm_long, ctx_long, hipStreamDefault, 0));
+    HIP_CHECK(hipExecutionCtxStreamCreate(&strm_critical, ctx_critical, hipStreamDefault, 0));
+
+    long_running_kernel<<<grid_long, block_long, 0, strm_long>>>();
+    critical_kernel<<<grid_critical, block_critical, 0, strm_critical>>>();
+    HIP_CHECK(hipGetLastError());
+
+    // Release everything.
+    HIP_CHECK(hipStreamDestroy(strm_long));
+    HIP_CHECK(hipStreamDestroy(strm_critical));
+    HIP_CHECK(hipExecutionCtxDestroy(ctx_long));
+    HIP_CHECK(hipExecutionCtxDestroy(ctx_critical));
+
+Settle on the CU split by measuring your own workload. The
+`HIP-Basic execution context example <https://github.com/ROCm/rocm-examples/tree/develop/HIP-Basic/execution_context>`_
+contains a complete, buildable version.

--- a/projects/hip/docs/how-to/hip_runtime_api/execution_context.rst
+++ b/projects/hip/docs/how-to/hip_runtime_api/execution_context.rst
@@ -42,7 +42,7 @@ launch syntax. This feature is analogous to CUDA green contexts.
     - The snippets on this page are written to show the calling sequence. Build
       and run them on a ROCm system before using them as the basis for production
       code. A complete, buildable program is provided as the
-      `HIP-Basic execution context example <https://github.com/ROCm/rocm-examples/tree/develop/HIP-Basic/execution_context>`_.
+      `HIP-Basic execution context example <https://github.com/ROCm/rocm-examples/tree/amd-staging/HIP-Basic/execution_context>`_.
 
 The full API listing is in :ref:`execution_context_management_reference`.
 
@@ -574,7 +574,7 @@ requests the architecture default, which matches the device's
 For a complete example that performs the full sequence -- query the device
 resource, split the CU resource, generate descriptors, create execution
 contexts, create streams, and launch kernels -- see the
-`HIP-Basic execution context example <https://github.com/ROCm/rocm-examples/tree/develop/HIP-Basic/execution_context>`_.
+`HIP-Basic execution context example <https://github.com/ROCm/rocm-examples/tree/amd-staging/HIP-Basic/execution_context>`_.
 The example uses separate contexts for a background kernel and a
 latency-sensitive kernel, which is the same setup pattern shown here.
 
@@ -854,7 +854,7 @@ baseline, writing back the aligned CU counts the split actually produced:
 Comparing the baseline timing with the partitioned timing shows the critical
 kernel finishing sooner once it has its own CUs. Settle on the CU split by
 measuring your own workload. The
-`HIP-Basic execution context example <https://github.com/ROCm/rocm-examples/tree/develop/HIP-Basic/execution_context>`_
+`HIP-Basic execution context example <https://github.com/ROCm/rocm-examples/tree/amd-staging/HIP-Basic/execution_context>`_
 contains a complete, buildable version that sweeps several partition sizes, such
 as an eighth, a quarter, and half of the device, and also provides a CUDA green
 context backend.

--- a/projects/hip/docs/sphinx/_toc.yml.in
+++ b/projects/hip/docs/sphinx/_toc.yml.in
@@ -48,6 +48,7 @@ subtrees:
       - file: how-to/hip_runtime_api/hipgraph
       - file: how-to/hip_runtime_api/cooperative_groups
       - file: how-to/hip_runtime_api/multi_device
+      - file: how-to/hip_runtime_api/execution_context
       - file: how-to/hip_runtime_api/opengl_interop
       - file: how-to/hip_runtime_api/external_interop
   - file: how-to/hip_cpp_language_extensions

--- a/projects/hip/docs/tools/example_codes/execution_context.hip
+++ b/projects/hip/docs/tools/example_codes/execution_context.hip
@@ -302,6 +302,35 @@ timings time_partitioned_case(int             device_id,
 }
 #endif
 
+#ifdef __HIP_PLATFORM_AMD__
+/// \brief Reads and prints a device's compute-unit resource and its work queue
+/// configuration. These read-only queries are the starting point before
+/// partitioning a device into execution contexts.
+void demonstrate_reading_resources()
+{
+    // [read-cu-resource-start]
+    int current_device = 0;
+    HIP_CHECK(hipSetDevice(current_device));
+
+    hipDevResource cu_resources = {};
+    HIP_CHECK(hipDeviceGetDevResource(current_device, &cu_resources, hipDevResourceTypeSm));
+
+    std::cout << "Device ID: " << current_device << "\n";
+    std::cout << "Available CUs: " << cu_resources.sm.smCount << "\n";
+    std::cout << "Min. partition size: " << cu_resources.sm.minSmPartitionSize << "\n";
+    std::cout << "Co-scheduled alignment: " << cu_resources.sm.smCoscheduledAlignment << "\n";
+    // [read-cu-resource-end]
+
+    // [read-wq-config-start]
+    hipDevResource wq_config = {};
+    HIP_CHECK(hipDeviceGetDevResource(current_device, &wq_config, hipDevResourceTypeWorkqueueConfig));
+
+    std::cout << "WQ concurrency limit: " << wq_config.wqConfig.wqConcurrencyLimit << "\n";
+    std::cout << "WQ sharing scope: " << wq_config.wqConfig.sharingScope << "\n";
+    // [read-wq-config-end]
+}
+#endif
+
 /// \brief Prints one row of the results table.
 void print_row(const std::string& configuration,
                const std::string& critical_cus,
@@ -336,6 +365,9 @@ int main()
     // Query the total number of CUs through the device resource.
     HIP_CHECK(hipDeviceGetDevResource(device_id, &all_cu_resources, hipDevResourceTypeSm));
     total_cus = all_cu_resources.sm.smCount;
+
+    // Show the read-only resource queries that precede partitioning.
+    demonstrate_reading_resources();
 #else
     // The CUDA green-context flow uses the driver API. Initialize it, get a
     // driver device handle, and query its SM resource, which is the whole-device
@@ -345,9 +377,9 @@ int main()
     CU_CHECK(cuDeviceGet(&cu_device, device_id));
     CU_CHECK(cuDeviceGetDevResource(cu_device, &all_cu_resources, CU_DEV_RESOURCE_TYPE_SM));
     total_cus = all_cu_resources.sm.smCount;
-#endif
 
     std::cout << "Compute units on device " << device_id << ": " << total_cus << std::endl;
+#endif
 
     constexpr unsigned int min_required_cus = 4;
     if(total_cus < min_required_cus)

--- a/projects/hip/docs/tools/example_codes/execution_context.hip
+++ b/projects/hip/docs/tools/example_codes/execution_context.hip
@@ -322,11 +322,23 @@ void demonstrate_reading_resources()
     // [read-cu-resource-end]
 
     // [read-wq-config-start]
-    hipDevResource wq_config = {};
-    HIP_CHECK(hipDeviceGetDevResource(current_device, &wq_config, hipDevResourceTypeWorkqueueConfig));
+    // Reading the work queue configuration from a device is not supported on
+    // every ROCm runtime. Capture the status instead of aborting, and only print
+    // the configuration when the query succeeds.
+    hipDevResource   wq_config = {};
+    const hipError_t wq_status
+        = hipDeviceGetDevResource(current_device, &wq_config, hipDevResourceTypeWorkqueueConfig);
 
-    std::cout << "WQ concurrency limit: " << wq_config.wqConfig.wqConcurrencyLimit << "\n";
-    std::cout << "WQ sharing scope: " << wq_config.wqConfig.sharingScope << "\n";
+    if(wq_status == hipSuccess)
+    {
+        std::cout << "WQ concurrency limit: " << wq_config.wqConfig.wqConcurrencyLimit << "\n";
+        std::cout << "WQ sharing scope: " << wq_config.wqConfig.sharingScope << "\n";
+    }
+    else
+    {
+        std::cout << "Work queue configuration query is not supported on this runtime ("
+                  << hipGetErrorString(wq_status) << ").\n";
+    }
     // [read-wq-config-end]
 }
 #endif

--- a/projects/hip/docs/tools/example_codes/execution_context.hip
+++ b/projects/hip/docs/tools/example_codes/execution_context.hip
@@ -338,6 +338,11 @@ void demonstrate_reading_resources()
     {
         std::cout << "Work queue configuration query is not supported on this runtime ("
                   << hipGetErrorString(wq_status) << ").\n";
+
+        // A failed call leaves its error in the thread's sticky last-error state.
+        // Clear it with hipGetLastError so a later hipGetLastError check does not
+        // misattribute this error to an unrelated, successful launch.
+        (void)hipGetLastError();
     }
     // [read-wq-config-end]
 }

--- a/projects/hip/docs/tools/example_codes/execution_context.hip
+++ b/projects/hip/docs/tools/example_codes/execution_context.hip
@@ -1,0 +1,515 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "example_utils.hpp"
+
+#include <hip/hip_runtime.h>
+
+#ifndef __HIP_PLATFORM_AMD__
+    // On the CUDA backend, execution contexts map to CUDA green contexts, which
+    // are provided by the CUDA driver API (this header requires linking the CUDA
+    // driver library, -lcuda).
+    #include <cuda.h>
+#endif
+
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <string>
+
+#ifndef __HIP_PLATFORM_AMD__
+/// \brief Aborts on a failed CUDA driver API call, mirroring HIP_CHECK.
+#define CU_CHECK(condition)                                                                    \
+    {                                                                                          \
+        const CUresult error = (condition);                                                    \
+        if(error != CUDA_SUCCESS)                                                              \
+        {                                                                                      \
+            const char* name = nullptr;                                                        \
+            const char* desc = nullptr;                                                        \
+            cuGetErrorName(error, &name);                                                       \
+            cuGetErrorString(error, &desc);                                                     \
+            std::cerr << "CUDA driver error: " << (name ? name : "?") << " ("                   \
+                      << (desc ? desc : "?") << ") at " << __FILE__ << ':' << __LINE__          \
+                      << std::endl;                                                             \
+            std::exit(error_exit_code);                                                         \
+        }                                                                                      \
+    }
+#endif
+
+// The device SM/CU resource type differs between backends but is used the same
+// way, so alias it to keep the partitioning code uniform.
+#ifdef __HIP_PLATFORM_AMD__
+using device_sm_resource = hipDevResource;
+#else
+using device_sm_resource = CUdevResource;
+#endif
+
+// [busy-kernel-start]
+/// \brief A kernel that keeps every thread block busy for a fixed number of
+/// iterations. It is used as a proxy for a compute-bound workload. The volatile
+/// accumulator prevents the compiler from optimizing the loop away.
+__global__ void busy_kernel(unsigned int* out, const unsigned int iterations)
+{
+    const unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+    volatile unsigned int acc = 0;
+    for(unsigned int i = 0; i < iterations; ++i)
+    {
+        acc += i;
+    }
+
+    // Write the result so the loop has an observable side effect.
+    if(threadIdx.x == 0)
+    {
+        out[blockIdx.x] = acc;
+    }
+}
+// [busy-kernel-end]
+
+/// \brief Sizing of the two concurrent workloads. The background kernel is a
+/// large, device-saturating job; the critical kernel is a small,
+/// latency-sensitive job whose completion time is what the example measures.
+struct workload
+{
+    unsigned int block_size;
+    unsigned int background_grid_size;
+    unsigned int critical_grid_size;
+    unsigned int background_iterations;
+    unsigned int critical_iterations;
+};
+
+/// \brief GPU time in milliseconds for each of the two concurrent kernels.
+struct timings
+{
+    float background_ms;
+    float critical_ms;
+};
+
+// [timing-helper-start]
+/// \brief Launches the long-running background kernel and the shorter critical
+/// kernel on two separate streams so they execute concurrently, and returns the
+/// GPU time each kernel takes. The critical kernel's time is the latency of
+/// interest: when the two streams share the device's compute units it contends
+/// with the background kernel, but when the streams belong to execution contexts
+/// backed by disjoint compute units it runs undisturbed.
+timings time_critical_with_background(hipStream_t     background_stream,
+                                      hipStream_t     critical_stream,
+                                      unsigned int*   d_out_background,
+                                      unsigned int*   d_out_critical,
+                                      const workload& wl)
+{
+    hipEvent_t bg_start, bg_stop, crit_start, crit_stop;
+    HIP_CHECK(hipEventCreate(&bg_start));
+    HIP_CHECK(hipEventCreate(&bg_stop));
+    HIP_CHECK(hipEventCreate(&crit_start));
+    HIP_CHECK(hipEventCreate(&crit_stop));
+
+    // Launch and time the long-running background kernel. The launch returns
+    // immediately and the kernel keeps executing on its own stream, occupying
+    // the device while the critical kernel below runs concurrently.
+    HIP_CHECK(hipEventRecord(bg_start, background_stream));
+    busy_kernel<<<dim3(wl.background_grid_size), dim3(wl.block_size), 0, background_stream>>>(
+        d_out_background,
+        wl.background_iterations);
+    HIP_CHECK(hipGetLastError());
+    HIP_CHECK(hipEventRecord(bg_stop, background_stream));
+
+    // Time the critical kernel on its stream while the background kernel runs.
+    // The elapsed time includes any wait for compute units, which is exactly the
+    // latency the partitioned path is meant to remove.
+    HIP_CHECK(hipEventRecord(crit_start, critical_stream));
+    busy_kernel<<<dim3(wl.critical_grid_size), dim3(wl.block_size), 0, critical_stream>>>(
+        d_out_critical,
+        wl.critical_iterations);
+    HIP_CHECK(hipGetLastError());
+    HIP_CHECK(hipEventRecord(crit_stop, critical_stream));
+
+    // Wait for both kernels to finish before reading the timers.
+    HIP_CHECK(hipEventSynchronize(crit_stop));
+    HIP_CHECK(hipEventSynchronize(bg_stop));
+
+    timings result = {};
+    HIP_CHECK(hipEventElapsedTime(&result.background_ms, bg_start, bg_stop));
+    HIP_CHECK(hipEventElapsedTime(&result.critical_ms, crit_start, crit_stop));
+
+    HIP_CHECK(hipEventDestroy(bg_start));
+    HIP_CHECK(hipEventDestroy(bg_stop));
+    HIP_CHECK(hipEventDestroy(crit_start));
+    HIP_CHECK(hipEventDestroy(crit_stop));
+
+    return result;
+}
+// [timing-helper-end]
+
+#ifdef __HIP_PLATFORM_AMD__
+// [partitioned-start]
+/// \brief Runs one partitioned measurement. Splits the device's CUs into a
+/// background group and a critical group of (about) requested_critical_cus CUs,
+/// creates an execution context and stream for each, times the critical kernel
+/// while the background kernel runs, then tears the contexts down. The actual CU
+/// counts (which the split API may adjust for alignment) are written back
+/// through out_background_cus and out_critical_cus.
+timings time_partitioned_case(int             device_id,
+                              hipDevResource& all_cu_resources,
+                              unsigned int    total_cus,
+                              unsigned int    requested_critical_cus,
+                              const workload& wl,
+                              unsigned int*   d_out_background,
+                              unsigned int*   d_out_critical,
+                              unsigned int&   out_background_cus,
+                              unsigned int&   out_critical_cus)
+{
+    // Split the CUs into two groups: the rest for the background kernel and
+    // requested_critical_cus for the critical kernel. The split API can adjust
+    // the counts to satisfy architecture alignment requirements.
+    hipDevResource              groups[2]       = {};
+    hipDevSmResourceGroupParams group_params[2] = {
+        {/*smCount=*/total_cus - requested_critical_cus, 0, 0, 0},
+        {/*smCount=*/requested_critical_cus, 0, 0, 0}};
+
+    HIP_CHECK(hipDevSmResourceSplit(&groups[0],
+                                    2,
+                                    &all_cu_resources,
+                                    nullptr /* remainder */,
+                                    0 /* flags */,
+                                    &group_params[0]));
+
+    out_background_cus = groups[0].sm.smCount;
+    out_critical_cus   = groups[1].sm.smCount;
+
+    // Wrap each group in a descriptor and create an execution context from it.
+    hipDevResourceDesc_t desc_background = {};
+    hipDevResourceDesc_t desc_critical   = {};
+    HIP_CHECK(hipDevResourceGenerateDesc(&desc_background, &groups[0], 1));
+    HIP_CHECK(hipDevResourceGenerateDesc(&desc_critical, &groups[1], 1));
+
+    hipExecutionCtx_t ctx_background = {};
+    hipExecutionCtx_t ctx_critical   = {};
+    HIP_CHECK(hipGreenCtxCreate(&ctx_background, desc_background, device_id, 0));
+    HIP_CHECK(hipGreenCtxCreate(&ctx_critical, desc_critical, device_id, 0));
+
+    // A stream created on a context keeps its kernels inside that context's CUs.
+    hipStream_t background_stream, critical_stream;
+    HIP_CHECK(hipExecutionCtxStreamCreate(&background_stream, ctx_background, hipStreamDefault, 0));
+    HIP_CHECK(hipExecutionCtxStreamCreate(&critical_stream, ctx_critical, hipStreamDefault, 0));
+
+    const timings result = time_critical_with_background(background_stream,
+                                                         critical_stream,
+                                                         d_out_background,
+                                                         d_out_critical,
+                                                         wl);
+
+    HIP_CHECK(hipStreamDestroy(background_stream));
+    HIP_CHECK(hipStreamDestroy(critical_stream));
+    HIP_CHECK(hipExecutionCtxDestroy(ctx_background));
+    HIP_CHECK(hipExecutionCtxDestroy(ctx_critical));
+
+    return result;
+}
+// [partitioned-end]
+#else
+/// \brief Creates a CUDA green context from a single SM resource group and a
+/// non-blocking stream on it. The stream is returned as a cudaStream_t so the
+/// runtime-API kernel launches (<<<>>>) and events used by the timing helper
+/// work unchanged.
+CUgreenCtx make_green_context(CUdevice cu_device, CUdevResource& group, cudaStream_t& out_stream)
+{
+    CUdevResourceDesc desc = {};
+    CU_CHECK(cuDevResourceGenerateDesc(&desc, &group, 1));
+
+    CUgreenCtx green_ctx = {};
+    CU_CHECK(cuGreenCtxCreate(&green_ctx, desc, cu_device, CU_GREEN_CTX_DEFAULT_STREAM));
+
+    CUstream cu_stream = {};
+    CU_CHECK(cuGreenCtxStreamCreate(&cu_stream, green_ctx, CU_STREAM_NON_BLOCKING, 0));
+    out_stream = reinterpret_cast<cudaStream_t>(cu_stream);
+
+    return green_ctx;
+}
+
+/// \brief CUDA counterpart of the partitioned measurement. Splits the device's
+/// SMs into two disjoint groups using green contexts - a critical group of
+/// (about) requested_critical_cus SMs and the remainder for the background
+/// kernel - times the critical kernel while the background kernel runs, then
+/// tears the green contexts down. The actual SM counts (which the split API may
+/// round for alignment) are written back through out_background_cus and
+/// out_critical_cus.
+timings time_partitioned_case(int             device_id,
+                              CUdevResource&  all_cu_resources,
+                              unsigned int    total_cus,
+                              unsigned int    requested_critical_cus,
+                              const workload& wl,
+                              unsigned int*   d_out_background,
+                              unsigned int*   d_out_critical,
+                              unsigned int&   out_background_cus,
+                              unsigned int&   out_critical_cus)
+{
+    (void)total_cus;
+
+    CUdevice cu_device;
+    CU_CHECK(cuDeviceGet(&cu_device, device_id));
+
+    // A single split carves the device into a critical group of the requested
+    // size and a disjoint remainder for the background kernel, so the two green
+    // contexts never share SMs.
+    CUdevResource critical_group   = {};
+    CUdevResource background_group = {};
+    unsigned int  group_count      = 1;
+    CU_CHECK(cuDevSmResourceSplitByCount(&critical_group,
+                                         &group_count,
+                                         &all_cu_resources,
+                                         &background_group /* remaining */,
+                                         0 /* flags */,
+                                         requested_critical_cus));
+    out_critical_cus   = critical_group.sm.smCount;
+    out_background_cus = background_group.sm.smCount;
+
+    cudaStream_t background_stream, critical_stream;
+    CUgreenCtx   ctx_background = make_green_context(cu_device, background_group, background_stream);
+    CUgreenCtx   ctx_critical   = make_green_context(cu_device, critical_group, critical_stream);
+
+    const timings result = time_critical_with_background(background_stream,
+                                                         critical_stream,
+                                                         d_out_background,
+                                                         d_out_critical,
+                                                         wl);
+
+    CU_CHECK(cuStreamDestroy(reinterpret_cast<CUstream>(background_stream)));
+    CU_CHECK(cuStreamDestroy(reinterpret_cast<CUstream>(critical_stream)));
+    CU_CHECK(cuGreenCtxDestroy(ctx_background));
+    CU_CHECK(cuGreenCtxDestroy(ctx_critical));
+
+    return result;
+}
+#endif
+
+/// \brief Prints one row of the results table.
+void print_row(const std::string& configuration,
+               const std::string& critical_cus,
+               const std::string& background_cus,
+               float              critical_ms,
+               float              background_ms,
+               float              speedup)
+{
+    std::cout << "  " << std::left << std::setw(20) << configuration << std::setw(14)
+              << critical_cus << std::setw(16) << background_cus << std::setw(16)
+              << (double_precision(critical_ms, 2) + " ms") << std::setw(16)
+              << (double_precision(background_ms, 2) + " ms") << double_precision(speedup, 2) << "x"
+              << std::endl;
+}
+
+int main()
+{
+    constexpr int device_id = 0;
+    HIP_CHECK(hipSetDevice(device_id));
+
+    // Determine the number of compute units (CUs, called SMs on NVIDIA) on the
+    // device. This count drives both how the resources are partitioned and how
+    // the launch grids are sized.
+    unsigned int total_cus = 0;
+
+    // The device SM/CU resource that partitioning is carved from. On AMD the
+    // field is named smCount for CUDA source compatibility; there it represents
+    // compute units.
+    device_sm_resource all_cu_resources = {};
+
+#ifdef __HIP_PLATFORM_AMD__
+    // Query the total number of CUs through the device resource.
+    HIP_CHECK(hipDeviceGetDevResource(device_id, &all_cu_resources, hipDevResourceTypeSm));
+    total_cus = all_cu_resources.sm.smCount;
+#else
+    // The CUDA green-context flow uses the driver API. Initialize it, get a
+    // driver device handle, and query its SM resource, which is the whole-device
+    // resource that the partition sweep splits below.
+    CU_CHECK(cuInit(0));
+    CUdevice cu_device;
+    CU_CHECK(cuDeviceGet(&cu_device, device_id));
+    CU_CHECK(cuDeviceGetDevResource(cu_device, &all_cu_resources, CU_DEV_RESOURCE_TYPE_SM));
+    total_cus = all_cu_resources.sm.smCount;
+#endif
+
+    std::cout << "Compute units on device " << device_id << ": " << total_cus << std::endl;
+
+    constexpr unsigned int min_required_cus = 4;
+    if(total_cus < min_required_cus)
+    {
+        std::cout << "Device has too few compute units (" << total_cus << ") for this example. "
+                  << "At least " << min_required_cus << " are required." << std::endl;
+        return 0;
+    }
+
+    // Partitions must be a multiple of the device's co-scheduled CU alignment.
+    // Requesting an unaligned count makes the split fail, so snap requests to it.
+#ifdef __HIP_PLATFORM_AMD__
+    // On AMD this is the WGP granularity (typically 2), reported by the resource.
+    unsigned int cu_alignment = all_cu_resources.sm.smCoscheduledAlignment;
+#else
+    // The CUDA SM resource does not expose an alignment field, and
+    // cuDevSmResourceSplitByCount rounds internally, so use 1 (no snapping).
+    unsigned int cu_alignment = 1;
+#endif
+    if(cu_alignment < 1)
+    {
+        cu_alignment = 1;
+    }
+
+    // Workload sizing. The background kernel launches many more blocks than the
+    // device can run at once (deep oversubscription) and each block runs for a
+    // long time, so it keeps every CU busy for the whole measurement. The
+    // critical kernel is kept small - a couple of thread blocks - so it fits
+    // inside even the smallest partition without oversubscribing it; that way its
+    // runtime reflects how long it waits for CUs, not how many CUs it has.
+    workload wl;
+    wl.block_size            = 256;
+    wl.background_grid_size   = total_cus * 16;
+    wl.critical_grid_size     = 2 * cu_alignment; // small, fits the smallest partition
+    wl.background_iterations  = 2000000;
+    wl.critical_iterations    = 500000; // fixed critical work across all cases
+
+    std::cout
+        << "\nThis example runs a small, latency-sensitive \"critical\" kernel at the same time\n"
+           "as a large \"background\" kernel that saturates the GPU, and measures how long the\n"
+           "critical kernel takes to complete. It first runs a baseline where both kernels share\n"
+           "all CUs, then sweeps several execution-context partitions that give the critical\n"
+           "kernel a growing slice of dedicated CUs. As the critical kernel gets more of its own\n"
+           "CUs, its latency drops well below the contended baseline.\n"
+        << std::endl;
+
+    // The critical buffer only needs one entry per critical block; the critical
+    // grid size is fixed, so this size is reused across every case.
+    unsigned int* d_out_background = nullptr;
+    unsigned int* d_out_critical   = nullptr;
+    HIP_CHECK(hipMalloc(&d_out_background, sizeof(unsigned int) * wl.background_grid_size));
+    HIP_CHECK(hipMalloc(&d_out_critical, sizeof(unsigned int) * wl.critical_grid_size));
+
+    // Warm up the GPU so one-time costs (module load, first-launch setup) are not
+    // charged to the first measured case. Write into the background buffer, which
+    // is large enough for a full-device grid. The result is discarded.
+    {
+        hipStream_t warmup;
+        HIP_CHECK(hipStreamCreateWithFlags(&warmup, hipStreamNonBlocking));
+        busy_kernel<<<dim3(total_cus), dim3(wl.block_size), 0, warmup>>>(d_out_background, 1000);
+        HIP_CHECK(hipGetLastError());
+        HIP_CHECK(hipStreamSynchronize(warmup));
+        HIP_CHECK(hipStreamDestroy(warmup));
+    }
+
+    // [baseline-start]
+    // Baseline: both kernels share all of the device's CUs. Two ordinary
+    // non-blocking streams let them run concurrently and contend for CUs.
+    hipStream_t shared_background, shared_critical;
+    HIP_CHECK(hipStreamCreateWithFlags(&shared_background, hipStreamNonBlocking));
+    HIP_CHECK(hipStreamCreateWithFlags(&shared_critical, hipStreamNonBlocking));
+
+    const timings baseline = time_critical_with_background(shared_background,
+                                                           shared_critical,
+                                                           d_out_background,
+                                                           d_out_critical,
+                                                           wl);
+
+    HIP_CHECK(hipStreamDestroy(shared_background));
+    HIP_CHECK(hipStreamDestroy(shared_critical));
+    // [baseline-end]
+
+    // Make sure the device is fully idle before the first partitioned case
+    // creates and destroys execution contexts.
+    HIP_CHECK(hipDeviceSynchronize());
+
+    // Header for the results table.
+    std::cout << "Kernel runtimes while both kernels run concurrently:\n" << std::endl;
+    std::cout << "  " << std::left << std::setw(20) << "Configuration" << std::setw(14)
+              << "Critical CUs" << std::setw(16) << "Background CUs" << std::setw(16)
+              << "Critical" << std::setw(16) << "Background" << "Speedup" << std::endl;
+    print_row("Baseline (shared)",
+              "all (" + std::to_string(total_cus) + ")",
+              "all (" + std::to_string(total_cus) + ")",
+              baseline.critical_ms,
+              baseline.background_ms,
+              1.0f);
+
+    // Sweep several partition sizes for the critical kernel: an eighth, a
+    // quarter, and half of the device. Each request is snapped to the CU
+    // alignment and clamped so both groups keep at least one aligned block of
+    // CUs; duplicates (on small devices) are skipped.
+    const unsigned int candidates[]  = {total_cus / 8, total_cus / 4, total_cus / 2};
+    unsigned int       last_critical = 0;
+
+    for(const unsigned int candidate : candidates)
+    {
+        // Round the request up to a multiple of the alignment, keeping at least
+        // one aligned block for the critical group and one for the background
+        // group.
+        unsigned int requested = ((candidate + cu_alignment - 1) / cu_alignment) * cu_alignment;
+        if(requested < cu_alignment)
+        {
+            requested = cu_alignment;
+        }
+        if(requested > total_cus - cu_alignment)
+        {
+            requested = total_cus - cu_alignment;
+        }
+        // Skip a request that resolves to the same size as the previous one.
+        if(requested == last_critical)
+        {
+            continue;
+        }
+        last_critical = requested;
+
+        unsigned int  background_cus = 0;
+        unsigned int  critical_cus   = 0;
+        const timings result         = time_partitioned_case(device_id,
+                                                     all_cu_resources,
+                                                     total_cus,
+                                                     requested,
+                                                     wl,
+                                                     d_out_background,
+                                                     d_out_critical,
+                                                     background_cus,
+                                                     critical_cus);
+
+        const float speedup
+            = result.critical_ms > 0.0f ? baseline.critical_ms / result.critical_ms : 0.0f;
+        print_row("Partitioned",
+                  std::to_string(critical_cus),
+                  std::to_string(background_cus),
+                  result.critical_ms,
+                  result.background_ms,
+                  speedup);
+
+        // Return the device to an idle state before the next case tears down and
+        // rebuilds execution contexts.
+        HIP_CHECK(hipDeviceSynchronize());
+    }
+
+    std::cout << "\nThe baseline critical kernel waits behind the background kernel for the shared\n"
+                 "CUs. With an execution context it runs on its own CUs and finishes sooner; the\n"
+                 "more CUs the partition holds, the lower its latency. The background kernel is\n"
+                 "confined to fewer CUs as the critical partition grows, so its runtime rises."
+              << std::endl;
+
+    HIP_CHECK(hipFree(d_out_background));
+    HIP_CHECK(hipFree(d_out_critical));
+
+    std::cout << "\nExecution context example completed successfully." << std::endl;
+
+    return 0;
+}

--- a/projects/hip/docs/tools/update_example_codes.py
+++ b/projects/hip/docs/tools/update_example_codes.py
@@ -130,6 +130,13 @@ urllib.request.urlretrieve(
     "docs/tools/example_codes/sequential_kernel_execution.hip"
 )
 
+# Using-HIP-Runtime-API / Execution-Context
+# TODO: switch branch from execution_context to amd-staging once the example is merged.
+urllib.request.urlretrieve(
+    "https://raw.githubusercontent.com/ROCm/rocm-examples/refs/heads/execution_context/HIP-Basic/execution_context/main.hip",
+    "docs/tools/example_codes/execution_context.hip"
+)
+
 # Using-HIP-Runtime-API / Call-Stack
 urllib.request.urlretrieve(
     "https://raw.githubusercontent.com/ROCm/rocm-examples/amd-staging/HIP-Doc/Programming-Guide/Using-HIP-Runtime-API/Call-Stack/call_stack_management/main.cpp",

--- a/projects/hip/docs/tools/update_example_codes.py
+++ b/projects/hip/docs/tools/update_example_codes.py
@@ -133,7 +133,7 @@ urllib.request.urlretrieve(
 # Using-HIP-Runtime-API / Execution-Context
 # TODO: switch branch from execution_context to amd-staging once the example is merged.
 urllib.request.urlretrieve(
-    "https://raw.githubusercontent.com/ROCm/rocm-examples/refs/heads/execution_context/HIP-Basic/execution_context/main.hip",
+    "https://raw.githubusercontent.com/ROCm/rocm-examples/refs/heads/amd-staging/HIP-Basic/execution_context/main.hip",
     "docs/tools/example_codes/execution_context.hip"
 )
 


### PR DESCRIPTION
## Motivation

HIP supports partitioning a GPU's compute units and work queues into execution contexts (analogous to CUDA green contexts), letting an application reserve a dedicated slice of the device for a latency-sensitive kernel so it isn't blocked behind a long-running one. This capability had no conceptual documentation. This PR adds a how-to guide that explains when and how to use execution contexts, so users can adopt the feature without reverse-engineering it from the API reference.

## Technical Details

Add a conceptual guide for HIP execution contexts, covering resource partitioning of compute units and work queues, the four-step context creation workflow, launching work, and the supporting device resource and split APIs. Register the page in the runtime API index and toc.

Additional details:
- CI-tested code snippets. All code samples are sourced via literalinclude from a buildable example (HIP-Basic/execution_context), rather than inline code blocks, so they are compiled and executed in CI and cannot silently drift from the API. This covers the worked baseline-vs-partitioned timing comparison and the resource-query snippets.
- API cross-references. Function references use :cpp:func: roles so they link to the API reference. Type and enum references are intentionally left as literals, since HIP's Doxygen output emits no standalone typedef/enum definition targets for them to link to (verified against the built site).
- Example sync. tools/update_example_codes.py pulls execution_context.hip from the companion example. It currently points at the execution_context branch of ROCm/rocm-examples with a TODO to switch to amd-staging once that example merges.

## JIRA ID

JIRA ID : AIROCDOC-4091

## Test Plan

Example code is tested with CI, documentation will be reviewed.

## Test Result

Documentation built and can be found in the PR.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
