### PR TITLE
test(amdsmi): [AILITOOLS-227] add monitor consistency tests

### DIFF
--- a/projects/amdsmi/tests/python/cli/test_monitor.py
+++ b/projects/amdsmi/tests/python/cli/test_monitor.py
@@ -2,12 +2,71 @@
 # Copyright Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-"""CLI leaf test: monitor command."""
+"""CLI leaf test: monitor command and its agreement with metric."""
+
+import json
+import os
+import signal
+import subprocess
+import time
+import unittest
+from collections import namedtuple
+
+import common.common as common
 
 from cli.base import TestCliBase
 
+# Live counters. Two samples of these legitimately differ, so only their
+# presence and units are cross-checked, never their values.
+VOLATILE_KEYS = (
+    "power_usage",
+    "hotspot_temperature",
+    "memory_temperature",
+    "gfx_clk",
+    "gfx",
+    "mem",
+)
+# Memory accounting. Both commands read it from the same driver call.
+STABLE_KEYS = ("vram_used", "vram_free", "vram_total")
+
+# Monitor column -> path into a metric gpu_data entry. The vram keys are
+# resolved separately because metric reports both the VRAM and GTT pools.
+METRIC_PATHS = {
+    "power_usage": ("power", "socket_power"),
+    "hotspot_temperature": ("temperature", "hotspot"),
+    "memory_temperature": ("temperature", "mem"),
+    "gfx_clk": ("clock", "gfx_0", "clk"),
+    "gfx": ("usage", "gfx_activity"),
+    "mem": ("usage", "umc_activity"),
+}
+
+Field = namedtuple("Field", "unit value")
+Result = namedtuple("Result", "gpu key passed message")
+
+NA = Field("N/A", None)
+
+
+def _field(container, *path):
+    """Resolve a {value, unit} node, yielding NA if any level is absent or "N/A"."""
+    node = container
+    for key in path:
+        if not isinstance(node, dict) or key not in node:
+            return NA
+        node = node[key]
+    if not isinstance(node, dict) or "value" not in node:
+        return NA
+    return Field(node.get("unit", ""), node["value"])
+
 
 class TestMonitor(TestCliBase):
+    # Only the columns the comparisons read; test_command covers the rest.
+    monitor_args = "--power-usage --temperature --gfx --mem --vram-usage"
+    tolerance = 0.1
+    # Counters a compute/memory workload is expected to move.
+    workload_keys = ("power_usage", "gfx", "mem")
+    # Config file, extra options, and the time the workload needs to ramp up.
+    rvs_configs = (("iet_single.conf", "", 5.0), ("mem.conf", "--numTimes 3", 1.0))
+
     def test_command(self):
         self.common.print_func_name("")
         msg = f"{self.tab}### amd-smi monitor"
@@ -21,4 +80,193 @@ class TestMonitor(TestCliBase):
             "Watch Arguments:",
         )
         self.RunCmds(cmds)
+        return
+
+    def _run_json(self, cmd, time_out=30.0):
+        """Run a CLI command, require a zero exit, and return its parsed JSON."""
+        rc, std_out, std_err = self.util.RunCmdSync(cmd, time_out=time_out)
+        self.assertEqual(rc, 0, f"{cmd}\n{self.tab}rc={rc} std_err={std_err}")
+        self.assertTrue(std_out, f"{cmd}\n{self.tab}produced no output")
+        return json.loads(std_out)
+
+    def _compare(self, gpu, key, left, right, component):
+        """Compare one field. Volatile counters are checked for shape, not value."""
+        if left.unit == "N/A" and right.unit == "N/A":
+            return None
+        if (left.unit == "N/A") != (right.unit == "N/A"):
+            return Result(gpu, key, False, f"reported by only one of Monitor/{component}")
+        if left.unit != right.unit:
+            return Result(gpu, key, False, f"unit {left.unit} != {right.unit}")
+        if key in VOLATILE_KEYS:
+            return Result(gpu, key, True, f"present in both ({left.unit})")
+        diff = abs(left.value - right.value)
+        max_diff = max(1.0, max(abs(left.value), abs(right.value)) * self.tolerance)
+        return Result(
+            gpu,
+            key,
+            diff <= max_diff,
+            f"{left.value:g} vs {right.value:g} {left.unit}: diff {diff:g} max {max_diff:g}",
+        )
+
+    def _compare_monitor_runs(self, monitor1, monitor2):
+        self.assertEqual(len(monitor1), len(monitor2), "monitor row count changed between runs")
+        results = []
+        for gpu, (row1, row2) in enumerate(zip(monitor1, monitor2)):
+            for key in VOLATILE_KEYS + STABLE_KEYS:
+                result = self._compare(gpu, key, _field(row1, key), _field(row2, key), "Monitor")
+                if result is not None:
+                    results.append(result)
+        return results
+
+    def _metric_vram_pool(self, monitor_row, metric_row):
+        """Metric reports both pools; pick the one whose total is what monitor chose."""
+        total = _field(monitor_row, "vram_total")
+        for pool in ("vram", "gtt"):
+            if _field(metric_row, "mem_usage", f"total_{pool}").value == total.value:
+                return pool
+        return None
+
+    def _compare_monitor_to_metric(self, monitor, metric):
+        gpu_data = metric["gpu_data"]
+        self.assertEqual(
+            len(monitor),
+            len(gpu_data),
+            f"monitor returned {len(monitor)} rows, metric returned {len(gpu_data)}",
+        )
+        results = []
+        for gpu, (row, metric_row) in enumerate(zip(monitor, gpu_data)):
+            for key, path in METRIC_PATHS.items():
+                result = self._compare(
+                    gpu, key, _field(row, key), _field(metric_row, *path), "Metric"
+                )
+                if result is not None:
+                    results.append(result)
+            pool = self._metric_vram_pool(row, metric_row)
+            if pool is None:
+                continue
+            for key in STABLE_KEYS:
+                metric_field = _field(metric_row, "mem_usage", f"{key[5:]}_{pool}")
+                result = self._compare(gpu, key, _field(row, key), metric_field, "Metric")
+                if result is not None:
+                    results.append(result)
+        return results
+
+    def _compare_under_load(self, baseline, loaded):
+        """A workload must move the responsive counters; other fields are ignored."""
+        self.assertEqual(len(baseline), len(loaded), "monitor row count changed under load")
+        results = []
+        for gpu, (base_row, load_row) in enumerate(zip(baseline, loaded)):
+            for key in self.workload_keys:
+                base = _field(base_row, key)
+                load = _field(load_row, key)
+                if base.unit == "N/A" or load.unit == "N/A":
+                    continue
+                diff = abs(load.value - base.value)
+                min_diff = max(1.0, abs(base.value) * self.tolerance)
+                results.append(
+                    Result(
+                        gpu,
+                        key,
+                        diff >= min_diff,
+                        f"{base.value:g} -> {load.value:g} {base.unit}: "
+                        f"diff {diff:g} min {min_diff:g}",
+                    )
+                )
+        return results
+
+    def _report_results(self, component, results):
+        """Print every comparison, then fail listing only the ones that did not hold."""
+        self.assertTrue(results, f"Monitor to {component}: no comparable fields")
+        width = max(len(result.key) for result in results)
+        lines = [
+            f"{self.tab}gpu={result.gpu} {result.key:>{width}s}: "
+            f"{'ok' if result.passed else 'FAIL'} {result.message}"
+            for result in results
+        ]
+        if common.verbose == common.VERBOSITY_VERBOSE:
+            self.common.print(f"{self.tab}Monitor to {component}\n" + "\n".join(lines))
+
+        failures = [line for line, result in zip(lines, results) if not result.passed]
+        if failures:
+            self.fail(f"Monitor to {component}:\n" + "\n".join(failures))
+        return
+
+    @staticmethod
+    def _start_workload(cmd):
+        """Own process group, so the whole workload process tree can be killed."""
+        return subprocess.Popen(
+            cmd.split(),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+
+    @staticmethod
+    def _stop_workload(proc):
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        proc.wait(timeout=10)
+        return
+
+    def test_monitor_repeatability(self):
+        self.common.print_func_name("")
+        msg = f"{self.tab}### amd-smi monitor repeatability"
+        self.common.print(msg)
+
+        cmd = f"amd-smi monitor {self.monitor_args} --json"
+        monitor1 = self._run_json(cmd)
+        monitor2 = self._run_json(cmd)
+        self._report_results("Monitor", self._compare_monitor_runs(monitor1, monitor2))
+        return
+
+    def test_monitor_metric(self):
+        self.common.print_func_name("")
+        msg = f"{self.tab}### amd-smi monitor metric"
+        self.common.print(msg)
+
+        monitor = self._run_json(f"amd-smi monitor {self.monitor_args} --json")
+        metric = self._run_json("amd-smi metric --json")
+        self._report_results("Metric", self._compare_monitor_to_metric(monitor, metric))
+        return
+
+    @unittest.skip("needs a reliable workload generator")
+    def test_monitor_with_workload(self):
+        self.common.print_func_name("")
+        msg = f"{self.tab}### amd-smi monitor with workload"
+        self.common.print(msg)
+
+        rocm_root = os.getenv("ROCM_HOME") or os.getenv("ROCM_PATH") or "/opt/rocm"
+        rvs_exe = os.path.join(rocm_root, "bin", "rvs")
+        conf_dir = os.path.join(rocm_root, "share", "rocm-validation-suite", "conf")
+
+        rc, _, _ = self.util.RunCmdSync(f"{rvs_exe} --version")
+        if rc != 0:
+            self.skipTest(f"workload generator {rvs_exe} not found")
+        missing = [
+            name
+            for name, _, _ in self.rvs_configs
+            if not os.path.exists(os.path.join(conf_dir, name))
+        ]
+        if missing:
+            self.skipTest(f"rvs configs not found in {conf_dir}: {', '.join(missing)}")
+
+        cmd_monitor = f"amd-smi monitor {self.monitor_args} --json"
+        baseline = self._run_json(cmd_monitor)
+
+        workloads = [
+            self._start_workload(
+                f"{rvs_exe} --config {os.path.join(conf_dir, name)} {options} --json --quiet"
+            )
+            for name, options, _ in self.rvs_configs
+        ]
+        try:
+            time.sleep(max(ramp for _, _, ramp in self.rvs_configs))
+            loaded = self._run_json(cmd_monitor)
+        finally:
+            for proc in workloads:
+                self._stop_workload(proc)
+
+        self._report_results("Workload", self._compare_under_load(baseline, loaded))
         return

--- a/projects/amdsmi/tests/python/cli/test_monitor.py
+++ b/projects/amdsmi/tests/python/cli/test_monitor.py
@@ -4,10 +4,18 @@
 
 """CLI leaf test: monitor command."""
 
+import json
+import multiprocessing
+import os
+import time
+
+import common
 from cli.base import TestCliBase
 
 
 class TestMonitor(TestCliBase):
+    monitor_args = "--power-usage --temperature --base-board-temps --gpu-board-temps --gfx --mem --encoder --decoder --ecc --vram-usage --pcie"
+
     def test_command(self):
         self.common.print_func_name("")
         msg = f"{self.tab}### amd-smi monitor"
@@ -21,4 +29,393 @@ class TestMonitor(TestCliBase):
             "Watch Arguments:",
         )
         self.RunCmds(cmds)
+        return
+
+    def _get_monitor_metric_data(self, monitor1, monitor2, metric, exclude=False):
+        data = []
+        for i in range(len(monitor1)):
+            data.append(
+                {
+                    "power_usage": None,
+                    "hotspot_temperature": None,
+                    "memory_temperature": None,
+                    "gfx_clk": None,
+                    "gfx": None,
+                    "mem": None,
+                    "vram_used": None,
+                }
+            )
+            if not exclude:
+                data[i]["vram_free"] = None
+                data[i]["vram_total"] = None
+            # Find the larger of the two amounts
+            if metric is not None:
+                total_gtt = int(metric["gpu_data"][i]["mem_usage"]["total_gtt"]["value"])
+                total_vram = int(metric["gpu_data"][i]["mem_usage"]["total_vram"]["value"])
+                if total_gtt > total_vram:
+                    vram_key = "gtt"
+                else:
+                    vram_key = "vram"
+            for key in data[i]:
+                # monitor1 and monitor2 come from the same source amd-smi monitor
+                # Meaning if monitor1 is N/A, then monitor2 will be N/A and by extension
+                # the  units for both will always be the same
+                if isinstance(monitor1[i][key], str) and monitor1[i][key] == "N/A":
+                    unit = "N/A"
+                    data1 = 0
+                    data2 = 0
+                else:
+                    unit = monitor1[i][key]["unit"]
+                    data1 = int(monitor1[i][key]["value"])
+                    if monitor2 is not None:
+                        if isinstance(monitor2[i][key], str) and monitor2[i][key] == "N/A":
+                            unit = "N/A"
+                            data2 = 0
+                        else:
+                            data2 = int(monitor2[i][key]["value"])
+                    else:
+                        if key == "power_usage":
+                            data2 = int(metric["gpu_data"][i]["power"]["socket_power"]["value"])
+                        elif key == "hotspot_temperature":
+                            data2 = int(metric["gpu_data"][i]["temperature"]["hotspot"]["value"])
+                        elif key == "memory_temperature":
+                            data2 = int(metric["gpu_data"][i]["temperature"]["mem"]["value"])
+                        elif key == "gfx_clk":
+                            data2 = int(metric["gpu_data"][i]["clock"]["gfx_0"]["clk"]["value"])
+                        elif key == "gfx":
+                            data2 = int(metric["gpu_data"][i]["usage"]["gfx_activity"]["value"])
+                        elif key == "mem":
+                            data2 = int(metric["gpu_data"][i]["usage"]["mm_activity"]["value"])
+                        elif key == "vram_used":
+                            data2 = int(
+                                metric["gpu_data"][i]["mem_usage"][f"used_{vram_key}"]["value"]
+                            )
+                        elif key == "vram_free":
+                            data2 = int(
+                                metric["gpu_data"][i]["mem_usage"][f"free_{vram_key}"]["value"]
+                            )
+                        elif key == "vram_total":
+                            data2 = int(
+                                metric["gpu_data"][i]["mem_usage"][f"total_{vram_key}"]["value"]
+                            )
+                data[i][key] = [data1, data2, abs(data1 - data2), unit]
+        return data
+
+    def _compare_monitor_metric_data(self, component, data, data_baseline=None):
+        failures = []
+        successes = []
+        diff_percent = 0.1
+        for i in range(len(data)):
+            msg_title = f"Monitor to {component}: gpu={i}"
+            msg_header = f"{'key':>20s} ({'Unit':>4s}): {'Monitor':>8s} {component:>8s}  {'Diff':>8s}   {'Threshold':>8s} {'Status':>7s}"
+            for key in data[i]:
+                if data[i][key][3] == "N/A":
+                    continue
+                # Calculate measurement tolerance
+                if data_baseline is not None:
+                    max_diff = max(data_baseline[i][key][0], data_baseline[i][key][1])
+                else:
+                    max_diff = max(data[i][key][0], data[i][key][1])
+                max_diff *= diff_percent
+                # Allow for some measurement error
+                if max_diff < 1.0:
+                    max_diff = 1.0
+
+                if data[i][key][2] > max_diff:
+                    status = "Failure"
+                    compare = ">"
+                else:
+                    status = "Success"
+                    compare = "<"
+                _msg = f"{key:>20s} ({data[i][key][3]:>4s}): {data[i][key][0]:>8d} {data[i][key][1]:>8d} ({data[i][key][2]:>8d} {compare} {max_diff:>8.2f}) {status:>7s}"
+                if status == "Failure":
+                    if len(failures) == 0:
+                        failures.append(("", f"Compare {msg_title}"))
+                        failures.append(("*" * len(msg_title), msg_header))
+                    failures.append((msg_title, _msg))
+                else:
+                    if len(successes) == 0:
+                        successes.append(("", f"Compare {msg_title}"))
+                        successes.append(("*" * len(msg_title), msg_header))
+                    successes.append((msg_title, _msg))
+        return (failures, successes)
+
+    def _print_monitor_results(self, results, fail_on_results=False):
+        if results:
+            cmd_len = 0
+            for cmd, _ in results:
+                num = len(cmd)
+                if num > cmd_len:
+                    cmd_len = num
+            cmd_len += 2
+
+            msg = ""
+            for cmd, cmd_out in results:
+                if cmd:
+                    msg += f"\n{self.tab}{cmd:{cmd_len}s} : {cmd_out}"
+                else:
+                    msg += f"\n{cmd_out}"
+            msg = msg.strip()
+            msg = f"{self.tab}{msg}"
+
+            # Output to std_out
+            if common.verbose == common.VERBOSITY_VERBOSE:
+                self.common.print(msg)
+
+            # Output to std_err
+            if fail_on_results:
+                self.fail(f"Fail:\n\n{msg}")
+        return
+
+    def _worker(self, q, start_time: multiprocessing.Value, name: str, cmd: str, timeout: int):
+        pid = os.getpid()
+        if self.Debug:
+            print(f"[{name}] PID={pid} ready, waiting for start time... {start_time.value}")
+
+        # Busy-wait until the shared start time is reached
+        while True:
+            now = time.perf_counter()
+            if now >= start_time.value:
+                break
+            time.sleep(max(0, start_time.value - now))
+
+        # Record actual start time
+        actual_start = time.perf_counter()
+        if self.Debug:
+            print(
+                f"[{name}] Started at {actual_start:.9f} (Δ={actual_start - start_time.value:.9f}s)"
+            )
+
+        (rc, std_out, std_err) = self.util.RunCmdSync(cmd, time_out=timeout)
+
+        now = time.perf_counter()
+        q.put((name, pid, now, std_out))
+        if self.Debug:
+            print(f"[{name}] Finished work at {now:.9f}")
+        return
+
+    def _multiprocess_commands(self, cmds):
+        # Setup queue between processes
+        q = multiprocessing.Queue()
+
+        max_timeout = 0
+        processes = []
+        for name, cmd, time_start_delta, time_out in cmds:
+            # Set start time slightly in the future
+            future_time = time.perf_counter() + time_start_delta
+            # Shared start time (high precision)
+            start_time = multiprocessing.Value("d", future_time)
+            processes.append(
+                multiprocessing.Process(
+                    target=self._worker, args=(q, start_time, name, cmd, time_out)
+                )
+            )
+            max_timeout = max(max_timeout, time_out)
+            if self.Debug:
+                print(
+                    f"[Main] Process {name} will start at {future_time:.9f} and time out in {time_out}"
+                )
+
+        # Start all processes
+        for p in processes:
+            p.start()
+
+        # Give processes time to initialize
+        time.sleep(1.0)
+
+        # Wait for all to finish
+        worker_datas = []
+        for p in processes:
+            worker_datas.append(q.get(timeout=max_timeout))
+            p.join(timeout=max_timeout)
+
+        if self.Debug:
+            for worker_data in worker_datas:
+                name, pid, time_stamp, data = worker_data
+                print(f"name={name} pid={pid} time_stamp={time_stamp}")
+            print("[Main] All processes completed.")
+
+        return worker_datas
+
+    def test_monitor_monitor(self):
+        self.common.print_func_name("")
+        msg = f"{self.tab}### amd-smi monitor monitor"
+        self.common.print(msg)
+
+        # Ensure start time delta is adequate for process to initialize and start
+        # and adequate time for time_out to complete process
+        time_out = 5.0
+        time_start_delta = 2.0
+        cmd = f"amd-smi monitor {self.monitor_args} --json"
+        cmds = [
+            ("monitor1", cmd, time_start_delta, time_out),
+            ("monitor2", cmd, time_start_delta, time_out),
+        ]
+        # Both commands should complete successfully and produce the same results
+        worker_datas = self._multiprocess_commands(cmds)
+
+        # Data from monitor1 and monitor2 should be the same
+        name, pid, time_stamp, data = worker_datas[0]
+        monitor1 = json.loads(data)
+        name, pid, time_stamp, data = worker_datas[1]
+        monitor2 = json.loads(data)
+        data = self._get_monitor_metric_data(monitor1, monitor2, None)
+        monitor_failures, monitor_successes = self._compare_monitor_metric_data("Monitor", data)
+
+        # Report results
+        self._print_monitor_results(monitor_successes)
+        self._print_monitor_results(monitor_failures, fail_on_results=True)
+        return
+
+    def test_monitor_metric(self):
+        self.common.print_func_name("")
+        msg = f"{self.tab}### amd-smi monitor metric"
+        self.common.print(msg)
+
+        # Ensure start time delta is adequate for process to initialize and start
+        # and adequate time for time_out to complete process
+        time_out = 5.0
+        time_start_delta = 2.0
+        cmd_monitor = f"amd-smi monitor {self.monitor_args} --json"
+        cmd_metric = "amd-smi metric --json"
+        cmds = [
+            ("monitor", cmd_monitor, time_start_delta, time_out),
+            ("metric", cmd_metric, time_start_delta, time_out),
+        ]
+        # Both commands should complete successfully and produce the same results
+        worker_datas = self._multiprocess_commands(cmds)
+
+        # Data from monitor1 and metric1 should be the same
+        if worker_datas[0][0] == "metric":
+            _, _, time_stamp, data = worker_datas[0]
+            metric1 = json.loads(data)
+            _, _, time_stamp, data = worker_datas[1]
+            monitor1 = json.loads(data)
+        else:
+            _, _, time_stamp, data = worker_datas[0]
+            monitor1 = json.loads(data)
+            _, _, time_stamp, data = worker_datas[1]
+            metric1 = json.loads(data)
+        data = self._get_monitor_metric_data(monitor1, None, metric1)
+        monitor_failures, monitor_successes = self._compare_monitor_metric_data("Monitor", data)
+
+        # Report results
+        self._print_monitor_results(monitor_successes)
+        self._print_monitor_results(monitor_failures, fail_on_results=True)
+        return
+
+    def test_monitor_with_workload(self):
+        self.common.print_func_name("")
+        msg = f"{self.tab}### amd-smi monitor with workload"
+        self.common.print(msg)
+
+        self.rvs_exe = "rvs"
+        self.rvs_config_folder = "/opt/rocm/share/rocm-validation-suite/conf"
+        # name, options, ramp_time
+        # rvs_configs is a list of tuples containing:
+        # configuration file name, additional options, the ramp time for the workload
+        self.rvs_configs = []
+        self.rvs_configs.append(("iet_single.conf", "", 5.0))
+        self.rvs_configs.append(("mem.conf", "--numTimes 3", 1.0))
+
+        # Check for workload generator, skip test if not found
+        cmd = f"{self.rvs_exe} --version"
+        (rc, _, _) = self.util.RunCmdSync(cmd)
+        if rc != 0:
+            msg = f"{self.tab}rvs not found, skipping test_monitor_with_workload"
+            self.common.print(msg)
+            self.skipTest(msg)
+        # Check for workload generator configuration scripts, skip test if not found
+        msgs = []
+        for conf_file, _, ramp_time in self.rvs_configs:
+            conf_path = f"{self.rvs_config_folder}/{conf_file}"
+            if not os.path.exists(conf_path):
+                if len(msgs) == 0:
+                    msgs.append(f"{self.tab}Skipping test_monitor_with_workload")
+                msgs.append(f"\n{self.tab}rvs conf {conf_file} not found")
+        if len(msgs) > 0:
+            self.common.print(msgs)
+            self.skipTest(msgs)
+
+        # Get first baseline results
+        cmd_monitor = f"amd-smi monitor {self.monitor_args} --json"
+        (rc, data_baseline, std_err) = self.util.RunCmdSync(cmd_monitor)
+        if rc != 0:
+            msg = f"{self.tab}Monitor with workload test failed, rc={rc}, std_err={std_err}"
+            self.common.print(msg)
+            self.fail(msg)
+        monitor_baseline1 = json.loads(data_baseline)
+
+        # Get second baseline results
+        cmd_monitor = f"amd-smi monitor {self.monitor_args} --json"
+        (rc, data_baseline, std_err) = self.util.RunCmdSync(cmd_monitor)
+        if rc != 0:
+            msg = f"{self.tab}Monitor with workload test failed, rc={rc}, std_err={std_err}"
+            self.common.print(msg)
+            self.fail(msg)
+        monitor_baseline2 = json.loads(data_baseline)
+
+        # Get differences between the two baselines
+        data_baseline = self._get_monitor_metric_data(
+            monitor_baseline1, monitor_baseline2, None, exclude=True
+        )
+
+        # Monitor has a delayed start that allows the workload time to initialize and start running.
+        # Workload is started immediately and times out after workload has had time to finish
+        max_ramp_time = 0.0
+        for _, _, ramp_time in self.rvs_configs:
+            max_ramp_time = max(max_ramp_time, ramp_time)
+        time_out = max_ramp_time + 5.0
+        time_start_delta = max_ramp_time + 1.0
+
+        cmds = [("monitor", cmd_monitor, time_start_delta, time_out)]
+        time_start_delta = 0.0
+        for index, configs in enumerate(self.rvs_configs):
+            conf_file, options, ramp_time = configs
+            conf_path = f"{self.rvs_config_folder}/{conf_file}"
+            cmd_workload = f"{self.rvs_exe} --config {conf_path} {options} --json --quiet"
+            cmds.append((f"workload_{index}", cmd_workload, time_start_delta, time_out))
+        # Monitor command should complete successfully
+        # Worlkload command will timeout and be killed.
+        # Workload output is not needed, only the monitor command output is needed for comparison
+        worker_datas = self._multiprocess_commands(cmds)
+
+        # Data from monitor_baseline and monitor_workload should not be the same
+        monitor_workload = None
+        for worker_data in worker_datas:
+            if worker_data[0] == "monitor":
+                name, pid, time_stamp, data = worker_data
+                monitor_workload = json.loads(data)
+        if monitor_workload is None:
+            msg = f"{self.tab}Monitor with workload test failed, could not get monitor data"
+            self.common.print(msg)
+            self.fail(msg)
+
+        data = self._get_monitor_metric_data(
+            monitor_baseline1, monitor_workload, None, exclude=True
+        )
+        monitor_failures, monitor_successes = self._compare_monitor_metric_data(
+            "Workload", data, data_baseline
+        )
+        # Results are opposite, want differences in values
+        # So switch failure and success criterion
+        for index, cmd_data in enumerate(monitor_failures):
+            if "Failure" in cmd_data[1]:
+                monitor_failures[index] = (
+                    cmd_data[0],
+                    cmd_data[1].replace("Failure", "Success", 1),
+                )
+        for index, cmd_data in enumerate(monitor_successes):
+            if "Success" in cmd_data[1]:
+                monitor_successes[index] = (
+                    cmd_data[0],
+                    cmd_data[1].replace("Success", "Failure", 1),
+                )
+        tmp = monitor_failures
+        monitor_failures = monitor_successes
+        monitor_successes = tmp
+
+        # Report results
+        self._print_monitor_results(monitor_successes)
+        self._print_monitor_results(monitor_failures, fail_on_results=True)
         return


### PR DESCRIPTION
## Motivation

The amd-smi monitor CLI had no automated check that its reported telemetry is self-consistent, agrees with the metric command, or actually responds to GPU load. Add functional tests so regressions in monitor's power, thermal, clock, activity, and VRAM reporting are caught on real hardware.

## Technical Details

CLI tests

- Add a shared monitor_args covering power, base-board/GPU temps, gfx/mem activity, encoder/decoder, ECC, VRAM usage, and PCIe
- Add a multiprocessing harness (_multiprocess_commands / _worker) that launches commands against a shared high-precision start time so readings are captured near-simultaneously
- Add _get_monitor_metric_data to normalize monitor and metric [--json] output into per-GPU [[value, other, diff, unit]] tuples (selecting GTT vs VRAM by larger capacity)
- Add _compare_monitor_metric_data / _print_monitor_results for tolerance-based comparison and pass/fail reporting 

- test_monitor_monitor: two concurrent monitor runs must agree within tolerance 
- test_monitor_metric: monitor and metric readings must agree within tolerance
- test_monitor_with_workload: monitor values must shift under an rvs workload versus an idle two-sample baseline; skips cleanly when rvs or its config files are absent

## JIRA ID

JIRA ID : AILITOOLS-270

## Test Plan

Run python cli tests, cli_unit_test.py -v -k test_monitor

## Test Result

Unit passed as expected
