### PR TITLE
[rocjitsu] Fix RDNA dispatch work-item state

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.cpp
@@ -438,9 +438,12 @@ std::unordered_map<std::string, FactoryFn> &factories() {
                arch == ROCJITSU_CODE_ARCH_RDNA4)
         gran = 8;
       cp->set_vgpr_granularity(gran);
-      bool packed = (arch == ROCJITSU_CODE_ARCH_CDNA3 || arch == ROCJITSU_CODE_ARCH_CDNA4 ||
-                     arch == ROCJITSU_CODE_ARCH_RDNA3 || arch == ROCJITSU_CODE_ARCH_RDNA3_5 ||
-                     arch == ROCJITSU_CODE_ARCH_RDNA4 || arch == ROCJITSU_CODE_ARCH_GFX1250);
+      // Matches LLVM's FeaturePackedTID: gfx90a and later CDNA targets, plus
+      // GFX11 and later RDNA targets, receive work-item IDs packed in v0.
+      bool packed = (arch == ROCJITSU_CODE_ARCH_CDNA2 || arch == ROCJITSU_CODE_ARCH_CDNA3 ||
+                     arch == ROCJITSU_CODE_ARCH_CDNA4 || arch == ROCJITSU_CODE_ARCH_RDNA3 ||
+                     arch == ROCJITSU_CODE_ARCH_RDNA3_5 || arch == ROCJITSU_CODE_ARCH_RDNA4 ||
+                     arch == ROCJITSU_CODE_ARCH_GFX1250);
       cp->set_packed_tid(packed);
       amdgpu::SdmaPacketDialect sdma_dialect = amdgpu::SdmaPacketDialect::Legacy;
       if (arch == ROCJITSU_CODE_ARCH_GFX1250)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.cpp
@@ -439,7 +439,8 @@ std::unordered_map<std::string, FactoryFn> &factories() {
         gran = 8;
       cp->set_vgpr_granularity(gran);
       bool packed = (arch == ROCJITSU_CODE_ARCH_CDNA3 || arch == ROCJITSU_CODE_ARCH_CDNA4 ||
-                     arch == ROCJITSU_CODE_ARCH_GFX1250);
+                     arch == ROCJITSU_CODE_ARCH_RDNA3 || arch == ROCJITSU_CODE_ARCH_RDNA3_5 ||
+                     arch == ROCJITSU_CODE_ARCH_RDNA4 || arch == ROCJITSU_CODE_ARCH_GFX1250);
       cp->set_packed_tid(packed);
       amdgpu::SdmaPacketDialect sdma_dialect = amdgpu::SdmaPacketDialect::Legacy;
       if (arch == ROCJITSU_CODE_ARCH_GFX1250)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -309,12 +309,7 @@ void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
   for (uint32_t lane = 0; lane < cu->wf_size(); ++lane) {
     const WorkitemCoord id = workitem_local_coord(pkt, wf_index_in_wg, lane, cu->wf_size());
     if (packed_tid_) {
-      uint32_t packed = id.x & 0x3FFu;
-      if (pkt.enable_vgpr_workitem_id >= 1)
-        packed |= (id.y & 0x3FFu) << 10;
-      if (pkt.enable_vgpr_workitem_id >= 2)
-        packed |= (id.z & 0x3FFu) << 20;
-      cu->write_vgpr(vbase, lane, packed);
+      cu->write_vgpr(vbase, lane, pack_workitem_id(id, pkt.enable_vgpr_workitem_id));
     } else {
       cu->write_vgpr(vbase, lane, id.x);
       if (pkt.enable_vgpr_workitem_id >= 1)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -302,28 +302,25 @@ void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
   //   0 = v0 only (workitem_id_x)
   //   1 = v0 + v1 (workitem_id_x, workitem_id_y)
   //   2 = v0 + v1 + v2 (workitem_id_x, workitem_id_y, workitem_id_z)
-  // On packed-TID targets (CDNA3/4 and gfx1250): v0[9:0]=X,
-  // v0[19:10]=Y, v0[29:20]=Z. v1/v2 are not written. Kernel extracts
-  // components via bit masks.
+  // On packed-TID targets (CDNA3/4 and GFX11+): v0[9:0]=X, v0[19:10]=Y,
+  // v0[29:20]=Z. TIDIG_COMP_CNT controls which components the SPI supplies;
+  // unused packed components are zero.
   uint32_t vbase = wf->vgpr_alloc().base;
-  uint32_t workitem_base = wf_index_in_wg * cu->wf_size();
-  uint32_t wg_x = pkt.workgroup_size_x > 0 ? pkt.workgroup_size_x : 1;
-  uint32_t wg_y = pkt.workgroup_size_y > 0 ? pkt.workgroup_size_y : 1;
-  uint32_t wg_xy = wg_x * wg_y;
   for (uint32_t lane = 0; lane < cu->wf_size(); ++lane) {
-    uint32_t flat_id = workitem_base + lane;
-    uint32_t id_x = flat_id % wg_x;
-    uint32_t id_y = (flat_id / wg_x) % wg_y;
-    uint32_t id_z = flat_id / wg_xy;
-    if (packed_tid_ && pkt.enable_vgpr_workitem_id > 0) {
-      uint32_t packed = (id_x & 0x3FFu) | ((id_y & 0x3FFu) << 10) | ((id_z & 0x3FFu) << 20);
+    const WorkitemCoord id = workitem_local_coord(pkt, wf_index_in_wg, lane, cu->wf_size());
+    if (packed_tid_) {
+      uint32_t packed = id.x & 0x3FFu;
+      if (pkt.enable_vgpr_workitem_id >= 1)
+        packed |= (id.y & 0x3FFu) << 10;
+      if (pkt.enable_vgpr_workitem_id >= 2)
+        packed |= (id.z & 0x3FFu) << 20;
       cu->write_vgpr(vbase, lane, packed);
     } else {
-      cu->write_vgpr(vbase, lane, id_x);
+      cu->write_vgpr(vbase, lane, id.x);
       if (pkt.enable_vgpr_workitem_id >= 1)
-        cu->write_vgpr(vbase + 1, lane, id_y);
+        cu->write_vgpr(vbase + 1, lane, id.y);
       if (pkt.enable_vgpr_workitem_id >= 2)
-        cu->write_vgpr(vbase + 2, lane, id_z);
+        cu->write_vgpr(vbase + 2, lane, id.z);
     }
   }
 
@@ -722,7 +719,7 @@ uint32_t CommandProcessor::dispatch_workgroups(DispatchEntry &entry) {
       wf->set_lds(placement.lds);
       wf->set_dispatch_id(entry.dispatch_id);
       wf->set_process_id(entry.process_id);
-      wf->set_exec(initial_exec_mask_for_wave(entry, w, cu->wf_size()));
+      wf->set_exec(initial_exec_mask_for_wave(entry, global_wg_id, w, cu->wf_size()));
       wf->set_cluster_info(entry.cluster_rank_for_local_wg(local_wg_id), entry.cluster_size());
       init_wavefront_regs(cu, wf, entry, global_wg_id, w);
       wg_wavefronts.push_back(wf);
@@ -1020,6 +1017,9 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
   }
 
   dp.workgroup_id_offset = workgroup_id_offset_;
+  dp.grid_size_x = pkt.grid_size_x;
+  dp.grid_size_y = (num_dims >= 2) ? pkt.grid_size_y : 1;
+  dp.grid_size_z = (num_dims >= 3) ? pkt.grid_size_z : 1;
   // For WG ID decomposition, use the dispatch dimensionality (setup field).
   // A 1D dispatch flattens the entire grid into workgroup_id_x.
   dp.grid_wgs_x = (num_dims <= 1) ? total_wgs : grid_wgs_x;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
@@ -207,6 +207,7 @@ inline constexpr uint32_t kPackedTidZShift = 20;
                                                          uint32_t global_wg_id,
                                                          uint32_t wf_index_in_wg,
                                                          uint32_t wave_size) {
+  assert(wave_size <= 64 && "AMDGPU wave size must not exceed 64 lanes");
   assert(entry.grid_size_x != 0 && entry.grid_size_y != 0 && entry.grid_size_z != 0 &&
          "kernel dispatch grid dimensions must be nonzero");
   const uint32_t relative_wg_id = global_wg_id >= entry.workgroup_id_offset

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
@@ -25,6 +25,12 @@ struct WorkgroupCoord {
   uint32_t z = 0;
 };
 
+struct WorkitemCoord {
+  uint32_t x = 0;
+  uint32_t y = 0;
+  uint32_t z = 0;
+};
+
 struct ClusterDispatchShape {
   uint32_t count_x = 0;
   uint32_t count_y = 0;
@@ -52,6 +58,11 @@ struct DispatchEntry {
   uint64_t dispatch_ptr = 0;
   uint64_t queue_ptr = 0;
   uint32_t workgroup_id_offset = 0;
+  // Actual AQL grid extents. Kernel dispatch producers must initialize all
+  // dimensions to nonzero values before launching any workgroups.
+  uint32_t grid_size_x = 0;
+  uint32_t grid_size_y = 1;
+  uint32_t grid_size_z = 1;
   uint32_t grid_wgs_x = 0;
   uint32_t grid_wgs_y = 1;
   uint32_t grid_wgs_z = 1;
@@ -165,28 +176,49 @@ struct DispatchEntry {
   }
 };
 
-inline uint32_t dispatch_workgroup_size(const DispatchEntry &entry) {
-  auto dim = [](uint16_t value) -> uint32_t { return value == 0 ? 1u : value; };
-  return dim(entry.workgroup_size_x) * dim(entry.workgroup_size_y) * dim(entry.workgroup_size_z);
+inline uint32_t dispatch_dim(uint32_t value) { return value == 0 ? 1u : value; }
+
+inline uint32_t dispatch_wg_dim(uint16_t value) { return value == 0 ? 1u : value; }
+
+inline WorkitemCoord workitem_local_coord(const DispatchEntry &entry, uint32_t wf_index_in_wg,
+                                          uint32_t lane, uint32_t wave_size) {
+  const uint32_t workgroup_size_x = dispatch_wg_dim(entry.workgroup_size_x);
+  const uint32_t workgroup_size_y = dispatch_wg_dim(entry.workgroup_size_y);
+  const uint32_t flat_id = wf_index_in_wg * wave_size + lane;
+  return {flat_id % workgroup_size_x, (flat_id / workgroup_size_x) % workgroup_size_y,
+          flat_id / (workgroup_size_x * workgroup_size_y)};
 }
 
-inline uint64_t wave_lane_mask(uint32_t wave_size) {
-  if (wave_size >= 64)
-    return ~0ULL;
-  if (wave_size == 0)
-    return 0;
-  return (1ULL << wave_size) - 1;
-}
+inline uint64_t initial_exec_mask_for_wave(const DispatchEntry &entry, uint32_t global_wg_id,
+                                           uint32_t wf_index_in_wg, uint32_t wave_size) {
+  assert(entry.grid_size_x != 0 && entry.grid_size_y != 0 && entry.grid_size_z != 0 &&
+         "kernel dispatch grid dimensions must be nonzero");
+  const uint32_t relative_wg_id = global_wg_id >= entry.workgroup_id_offset
+                                      ? global_wg_id - entry.workgroup_id_offset
+                                      : global_wg_id;
+  const uint32_t grid_wgs_x = dispatch_dim(entry.grid_wgs_x);
+  const uint32_t grid_wgs_y = dispatch_dim(entry.grid_wgs_y);
+  const uint32_t wg_x = relative_wg_id % grid_wgs_x;
+  const uint32_t wg_y = (relative_wg_id / grid_wgs_x) % grid_wgs_y;
+  const uint32_t wg_z = relative_wg_id / (grid_wgs_x * grid_wgs_y);
+  const uint32_t workgroup_size_x = dispatch_wg_dim(entry.workgroup_size_x);
+  const uint32_t workgroup_size_y = dispatch_wg_dim(entry.workgroup_size_y);
+  const uint32_t workgroup_size_z = dispatch_wg_dim(entry.workgroup_size_z);
 
-inline uint64_t initial_exec_mask_for_wave(const DispatchEntry &entry, uint32_t wf_index_in_wg,
-                                           uint32_t wave_size) {
-  uint32_t wg_size = dispatch_workgroup_size(entry);
-  uint32_t first_lane = wf_index_in_wg * wave_size;
-  if (first_lane >= wg_size)
-    return 0;
-  uint32_t remaining = wg_size - first_lane;
-  uint32_t active_lanes = remaining < wave_size ? remaining : wave_size;
-  return wave_lane_mask(active_lanes);
+  uint64_t mask = 0;
+  const uint32_t lanes = wave_size > 64 ? 64 : wave_size;
+  for (uint32_t lane = 0; lane < lanes; ++lane) {
+    const WorkitemCoord id = workitem_local_coord(entry, wf_index_in_wg, lane, wave_size);
+    if (id.z >= workgroup_size_z)
+      continue;
+    const uint64_t global_x = static_cast<uint64_t>(wg_x) * workgroup_size_x + id.x;
+    const uint64_t global_y = static_cast<uint64_t>(wg_y) * workgroup_size_y + id.y;
+    const uint64_t global_z = static_cast<uint64_t>(wg_z) * workgroup_size_z + id.z;
+    if (global_x < entry.grid_size_x && global_y < entry.grid_size_y &&
+        global_z < entry.grid_size_z)
+      mask |= 1ULL << lane;
+  }
+  return mask;
 }
 
 /// @brief Per-queue state for the command processor.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
@@ -58,9 +58,8 @@ struct DispatchEntry {
   uint64_t dispatch_ptr = 0;
   uint64_t queue_ptr = 0;
   uint32_t workgroup_id_offset = 0;
-  // Actual AQL grid extents. Kernel dispatch producers must initialize all
-  // dimensions to nonzero values before launching any workgroups.
-  uint32_t grid_size_x = 0;
+  // Actual AQL grid extents.
+  uint32_t grid_size_x = 1;
   uint32_t grid_size_y = 1;
   uint32_t grid_size_z = 1;
   uint32_t grid_wgs_x = 0;
@@ -176,34 +175,51 @@ struct DispatchEntry {
   }
 };
 
-inline uint32_t dispatch_dim(uint32_t value) { return value == 0 ? 1u : value; }
+template <typename T> [[nodiscard]] inline constexpr uint32_t nonzero_dim(T value) {
+  return value == 0 ? 1u : static_cast<uint32_t>(value);
+}
 
-inline uint32_t dispatch_wg_dim(uint16_t value) { return value == 0 ? 1u : value; }
+inline constexpr uint32_t kPackedTidMask = 0x3FFu;
+inline constexpr uint32_t kPackedTidYShift = 10;
+inline constexpr uint32_t kPackedTidZShift = 20;
 
-inline WorkitemCoord workitem_local_coord(const DispatchEntry &entry, uint32_t wf_index_in_wg,
-                                          uint32_t lane, uint32_t wave_size) {
-  const uint32_t workgroup_size_x = dispatch_wg_dim(entry.workgroup_size_x);
-  const uint32_t workgroup_size_y = dispatch_wg_dim(entry.workgroup_size_y);
+[[nodiscard]] inline constexpr uint32_t pack_workitem_id(WorkitemCoord id,
+                                                         uint32_t component_count) {
+  uint32_t packed = id.x & kPackedTidMask;
+  if (component_count >= 1)
+    packed |= (id.y & kPackedTidMask) << kPackedTidYShift;
+  if (component_count >= 2)
+    packed |= (id.z & kPackedTidMask) << kPackedTidZShift;
+  return packed;
+}
+
+[[nodiscard]] inline WorkitemCoord workitem_local_coord(const DispatchEntry &entry,
+                                                        uint32_t wf_index_in_wg, uint32_t lane,
+                                                        uint32_t wave_size) {
+  const uint32_t workgroup_size_x = nonzero_dim(entry.workgroup_size_x);
+  const uint32_t workgroup_size_y = nonzero_dim(entry.workgroup_size_y);
   const uint32_t flat_id = wf_index_in_wg * wave_size + lane;
   return {flat_id % workgroup_size_x, (flat_id / workgroup_size_x) % workgroup_size_y,
           flat_id / (workgroup_size_x * workgroup_size_y)};
 }
 
-inline uint64_t initial_exec_mask_for_wave(const DispatchEntry &entry, uint32_t global_wg_id,
-                                           uint32_t wf_index_in_wg, uint32_t wave_size) {
+[[nodiscard]] inline uint64_t initial_exec_mask_for_wave(const DispatchEntry &entry,
+                                                         uint32_t global_wg_id,
+                                                         uint32_t wf_index_in_wg,
+                                                         uint32_t wave_size) {
   assert(entry.grid_size_x != 0 && entry.grid_size_y != 0 && entry.grid_size_z != 0 &&
          "kernel dispatch grid dimensions must be nonzero");
   const uint32_t relative_wg_id = global_wg_id >= entry.workgroup_id_offset
                                       ? global_wg_id - entry.workgroup_id_offset
                                       : global_wg_id;
-  const uint32_t grid_wgs_x = dispatch_dim(entry.grid_wgs_x);
-  const uint32_t grid_wgs_y = dispatch_dim(entry.grid_wgs_y);
+  const uint32_t grid_wgs_x = nonzero_dim(entry.grid_wgs_x);
+  const uint32_t grid_wgs_y = nonzero_dim(entry.grid_wgs_y);
   const uint32_t wg_x = relative_wg_id % grid_wgs_x;
   const uint32_t wg_y = (relative_wg_id / grid_wgs_x) % grid_wgs_y;
   const uint32_t wg_z = relative_wg_id / (grid_wgs_x * grid_wgs_y);
-  const uint32_t workgroup_size_x = dispatch_wg_dim(entry.workgroup_size_x);
-  const uint32_t workgroup_size_y = dispatch_wg_dim(entry.workgroup_size_y);
-  const uint32_t workgroup_size_z = dispatch_wg_dim(entry.workgroup_size_z);
+  const uint32_t workgroup_size_x = nonzero_dim(entry.workgroup_size_x);
+  const uint32_t workgroup_size_y = nonzero_dim(entry.workgroup_size_y);
+  const uint32_t workgroup_size_z = nonzero_dim(entry.workgroup_size_z);
 
   uint64_t mask = 0;
   const uint32_t lanes = wave_size > 64 ? 64 : wave_size;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/spi.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/spi.h
@@ -114,7 +114,7 @@ public:
         wf->set_lds(placement->lds);
         wf->set_dispatch_id(wg.entry->dispatch_id);
         wf->set_process_id(wg.entry->process_id);
-        wf->set_exec(initial_exec_mask_for_wave(*wg.entry, w, cu->wf_size()));
+        wf->set_exec(initial_exec_mask_for_wave(*wg.entry, wg.global_wg_id, w, cu->wf_size()));
         init_wf(cu, wf, *wg.entry, wg.global_wg_id, w);
         wg_wfs.push_back(wf);
       }

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -8,6 +8,7 @@
 #include "rocjitsu/isa/arch/amdgpu/cdna4/vop3p.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/mma_exec.h"
 #include "rocjitsu/kmd/linux/kfd_process.h"
+#include "rocjitsu/vm/amdgpu/dispatch_entry.h"
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
 #include "rocjitsu/vm/amdgpu/l1_scalar_cache.h"
 #include "rocjitsu/vm/amdgpu/l2_cache.h"
@@ -101,7 +102,8 @@ struct VmFixture {
   /// Returns the kernel_object address.
   uint64_t write_kernel(uint64_t addr, const void *code, size_t code_size, uint32_t sgprs = 104,
                         uint32_t vgprs = 256, uint32_t user_sgprs = 2,
-                        uint32_t group_segment_fixed_size = 0, bool wgp_mode = false) {
+                        uint32_t group_segment_fixed_size = 0, bool wgp_mode = false,
+                        uint32_t enable_vgpr_workitem_id = 0) {
     using namespace rocr::llvm::amdhsa;
     kernel_descriptor_t kd{};
     kd.kernel_code_entry_byte_offset = sizeof(kernel_descriptor_t);
@@ -112,6 +114,8 @@ struct VmFixture {
     AMDHSA_BITS_SET(kd.compute_pgm_rsrc2, COMPUTE_PGM_RSRC2_USER_SGPR_COUNT, user_sgprs);
     AMDHSA_BITS_SET(kd.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_WGP_MODE, (wgp_mode ? 1u : 0u));
     kd.group_segment_fixed_size = group_segment_fixed_size;
+    AMDHSA_BITS_SET(kd.compute_pgm_rsrc2, COMPUTE_PGM_RSRC2_ENABLE_VGPR_WORKITEM_ID,
+                    enable_vgpr_workitem_id);
 
     mem()->load_image(reinterpret_cast<const uint8_t *>(&kd), sizeof(kd), addr);
     mem()->load_image(static_cast<const uint8_t *>(code), code_size,
@@ -388,6 +392,80 @@ TEST_P(IsaTest, RegisterAccess) {
   EXPECT_EQ(cu->read_vgpr(vb + 1, 0), 100u);
   EXPECT_EQ(cu->read_vgpr(vb + 1, 63), 200u);
   EXPECT_EQ(cu->read_vgpr(vb + 1, 1), 0u);
+}
+
+TEST(RdnaDispatchTest, PackedTidHonorsRequestedComponents) {
+  const uint32_t code[] = {SOPP_S_ENDPGM};
+
+  for (const std::string &arch :
+       {std::string("rdna3"), std::string("rdna3_5"), std::string("rdna4")}) {
+    for (uint32_t component_count = 0; component_count <= 2; ++component_count) {
+      SCOPED_TRACE(arch + " component_count=" + std::to_string(component_count));
+      VmFixture f(arch, 1, 10, /*lds_size_kb=*/64, /*sgprs_per_wf=*/128);
+      uint64_t ko =
+          f.write_kernel(0x1000, code, sizeof(code), 104, 32, 2, 0, false, component_count);
+
+      test::AqlQueue queue(f.mem(), f.cp());
+      hsa_kernel_dispatch_packet_t pkt{};
+      pkt.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+      pkt.setup = 3;
+      pkt.workgroup_size_x = 8;
+      pkt.workgroup_size_y = 4;
+      pkt.workgroup_size_z = 2;
+      pkt.grid_size_x = 8;
+      pkt.grid_size_y = 4;
+      pkt.grid_size_z = 2;
+      pkt.kernel_object = ko;
+      queue.submit(pkt);
+      step_until_halted(*f.engine, {f.cu()});
+
+      ASSERT_EQ(f.cu()->num_wfs(), 2u);
+      auto *wf0 = f.cu()->wf(0);
+      auto *wf1 = f.cu()->wf(1);
+      ASSERT_NE(wf0, nullptr);
+      ASSERT_NE(wf1, nullptr);
+      const uint32_t vbase0 = wf0->vgpr_alloc().base;
+      const uint32_t vbase1 = wf1->vgpr_alloc().base;
+      auto packed = [component_count](uint32_t x, uint32_t y, uint32_t z) {
+        uint32_t value = x;
+        if (component_count >= 1)
+          value |= y << 10;
+        if (component_count >= 2)
+          value |= z << 20;
+        return value;
+      };
+      EXPECT_EQ(f.cu()->read_vgpr(vbase0, 0), packed(0, 0, 0));
+      EXPECT_EQ(f.cu()->read_vgpr(vbase0, 9), packed(1, 1, 0));
+      EXPECT_EQ(f.cu()->read_vgpr(vbase1, 8), packed(0, 1, 1));
+      EXPECT_EQ(f.cu()->read_vgpr(vbase1, 31), packed(7, 3, 1));
+    }
+  }
+}
+
+TEST(DispatchEntryTest, InitialExecMaskSupportsWave64GridTail) {
+  amdgpu::DispatchEntry entry{};
+  entry.grid_size_x = 65;
+  entry.grid_wgs_x = 2;
+  entry.workgroup_size_x = 64;
+
+  EXPECT_EQ(amdgpu::initial_exec_mask_for_wave(entry, 0, 0, 64), ~0ULL);
+  EXPECT_EQ(amdgpu::initial_exec_mask_for_wave(entry, 1, 0, 64), 1ULL);
+}
+
+TEST(DispatchEntryTest, InitialExecMaskHandles3DTailWithWorkgroupOffset) {
+  amdgpu::DispatchEntry entry{};
+  entry.workgroup_id_offset = 100;
+  entry.grid_size_x = 4;
+  entry.grid_size_y = 3;
+  entry.grid_size_z = 3;
+  entry.grid_wgs_x = 1;
+  entry.grid_wgs_y = 2;
+  entry.grid_wgs_z = 2;
+  entry.workgroup_size_x = 4;
+  entry.workgroup_size_y = 2;
+  entry.workgroup_size_z = 2;
+
+  EXPECT_EQ(amdgpu::initial_exec_mask_for_wave(entry, 103, 0, 64), 0xFULL);
 }
 
 TEST_P(IsaTest, RegisterFileIsolation) {

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -426,19 +426,110 @@ TEST(RdnaDispatchTest, PackedTidHonorsRequestedComponents) {
       ASSERT_NE(wf1, nullptr);
       const uint32_t vbase0 = wf0->vgpr_alloc().base;
       const uint32_t vbase1 = wf1->vgpr_alloc().base;
-      auto packed = [component_count](uint32_t x, uint32_t y, uint32_t z) {
-        uint32_t value = x;
-        if (component_count >= 1)
-          value |= y << 10;
-        if (component_count >= 2)
-          value |= z << 20;
-        return value;
-      };
-      EXPECT_EQ(f.cu()->read_vgpr(vbase0, 0), packed(0, 0, 0));
-      EXPECT_EQ(f.cu()->read_vgpr(vbase0, 9), packed(1, 1, 0));
-      EXPECT_EQ(f.cu()->read_vgpr(vbase1, 8), packed(0, 1, 1));
-      EXPECT_EQ(f.cu()->read_vgpr(vbase1, 31), packed(7, 3, 1));
+      EXPECT_EQ(f.cu()->read_vgpr(vbase0, 0), amdgpu::pack_workitem_id({0, 0, 0}, component_count));
+      EXPECT_EQ(f.cu()->read_vgpr(vbase0, 9), amdgpu::pack_workitem_id({1, 1, 0}, component_count));
+      EXPECT_EQ(f.cu()->read_vgpr(vbase1, 8), amdgpu::pack_workitem_id({0, 1, 1}, component_count));
+      EXPECT_EQ(f.cu()->read_vgpr(vbase1, 31),
+                amdgpu::pack_workitem_id({7, 3, 1}, component_count));
     }
+  }
+}
+
+TEST(CdnaDispatchTest, Wave64PackedTidHonorsRequestedComponents) {
+  const uint32_t code[] = {SOPP_S_ENDPGM};
+
+  for (uint32_t component_count = 0; component_count <= 2; ++component_count) {
+    SCOPED_TRACE("component_count=" + std::to_string(component_count));
+    VmFixture f("cdna3");
+    ASSERT_TRUE(f.cp()->packed_tid());
+    uint64_t ko =
+        f.write_kernel(0x1000, code, sizeof(code), 104, 256, 2, 0, false, component_count);
+
+    test::AqlQueue queue(f.mem(), f.cp());
+    hsa_kernel_dispatch_packet_t pkt{};
+    pkt.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+    pkt.setup = 3;
+    pkt.workgroup_size_x = 8;
+    pkt.workgroup_size_y = 4;
+    pkt.workgroup_size_z = 2;
+    pkt.grid_size_x = 8;
+    pkt.grid_size_y = 4;
+    pkt.grid_size_z = 2;
+    pkt.kernel_object = ko;
+    queue.submit(pkt);
+    step_until_halted(*f.engine, {f.cu()});
+
+    ASSERT_EQ(f.cu()->num_wfs(), 1u);
+    auto *wf = f.cu()->wf(0);
+    ASSERT_NE(wf, nullptr);
+    EXPECT_EQ(wf->wf_size(), 64u);
+    const uint32_t vbase = wf->vgpr_alloc().base;
+    EXPECT_EQ(f.cu()->read_vgpr(vbase, 40), amdgpu::pack_workitem_id({0, 1, 1}, component_count));
+    EXPECT_EQ(f.cu()->read_vgpr(vbase, 63), amdgpu::pack_workitem_id({7, 3, 1}, component_count));
+  }
+}
+
+TEST(CdnaDispatchTest, Wave64MasksMultidimensionalGridTailAcrossLane32) {
+  VmFixture f("cdna3");
+  const uint32_t code[] = {SOPP_S_ENDPGM};
+  uint64_t ko = f.write_kernel(0x1000, code, sizeof(code));
+
+  test::AqlQueue queue(f.mem(), f.cp());
+  hsa_kernel_dispatch_packet_t pkt{};
+  pkt.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+  pkt.setup = 2;
+  pkt.workgroup_size_x = 8;
+  pkt.workgroup_size_y = 6;
+  pkt.workgroup_size_z = 1;
+  pkt.grid_size_x = 5;
+  pkt.grid_size_y = 5;
+  pkt.grid_size_z = 1;
+  pkt.kernel_object = ko;
+  queue.submit(pkt);
+  step_until_halted(*f.engine, {f.cu()});
+
+  ASSERT_EQ(f.cu()->num_wfs(), 1u);
+  auto *wf = f.cu()->wf(0);
+  ASSERT_NE(wf, nullptr);
+  EXPECT_EQ(wf->wf_size(), 64u);
+  // Five active X lanes in each of five Y rows. The final active row starts
+  // at lane 32; lanes 40-47 are past grid_size_y, and lanes 48-63 map beyond
+  // workgroup_size_z.
+  EXPECT_EQ(wf->exec(), 0x0000'001F'1F1F'1F1FULL);
+}
+
+TEST(CdnaDispatchTest, UnpackedTidHonorsRequestedComponents) {
+  const uint32_t code[] = {SOPP_S_ENDPGM};
+
+  for (uint32_t component_count = 0; component_count <= 2; ++component_count) {
+    SCOPED_TRACE("component_count=" + std::to_string(component_count));
+    VmFixture f("cdna2");
+    ASSERT_FALSE(f.cp()->packed_tid());
+    uint64_t ko =
+        f.write_kernel(0x1000, code, sizeof(code), 104, 256, 2, 0, false, component_count);
+
+    test::AqlQueue queue(f.mem(), f.cp());
+    hsa_kernel_dispatch_packet_t pkt{};
+    pkt.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+    pkt.setup = 3;
+    pkt.workgroup_size_x = 8;
+    pkt.workgroup_size_y = 4;
+    pkt.workgroup_size_z = 2;
+    pkt.grid_size_x = 8;
+    pkt.grid_size_y = 4;
+    pkt.grid_size_z = 2;
+    pkt.kernel_object = ko;
+    queue.submit(pkt);
+    step_until_halted(*f.engine, {f.cu()});
+
+    ASSERT_EQ(f.cu()->num_wfs(), 1u);
+    auto *wf = f.cu()->wf(0);
+    ASSERT_NE(wf, nullptr);
+    EXPECT_EQ(wf->wf_size(), 64u);
+    const uint32_t vbase = wf->vgpr_alloc().base;
+    EXPECT_EQ(f.cu()->read_vgpr(vbase, 63), 7u);
+    EXPECT_EQ(f.cu()->read_vgpr(vbase + 1, 63), component_count >= 1 ? 3u : 0u);
+    EXPECT_EQ(f.cu()->read_vgpr(vbase + 2, 63), component_count >= 2 ? 1u : 0u);
   }
 }
 

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -438,34 +438,37 @@ TEST(RdnaDispatchTest, PackedTidHonorsRequestedComponents) {
 TEST(CdnaDispatchTest, Wave64PackedTidHonorsRequestedComponents) {
   const uint32_t code[] = {SOPP_S_ENDPGM};
 
-  for (uint32_t component_count = 0; component_count <= 2; ++component_count) {
-    SCOPED_TRACE("component_count=" + std::to_string(component_count));
-    VmFixture f("cdna3");
-    ASSERT_TRUE(f.cp()->packed_tid());
-    uint64_t ko =
-        f.write_kernel(0x1000, code, sizeof(code), 104, 256, 2, 0, false, component_count);
+  for (const std::string &arch :
+       {std::string("cdna2"), std::string("cdna3"), std::string("cdna4")}) {
+    for (uint32_t component_count = 0; component_count <= 2; ++component_count) {
+      SCOPED_TRACE(arch + " component_count=" + std::to_string(component_count));
+      VmFixture f(arch);
+      ASSERT_TRUE(f.cp()->packed_tid());
+      uint64_t ko =
+          f.write_kernel(0x1000, code, sizeof(code), 104, 256, 2, 0, false, component_count);
 
-    test::AqlQueue queue(f.mem(), f.cp());
-    hsa_kernel_dispatch_packet_t pkt{};
-    pkt.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
-    pkt.setup = 3;
-    pkt.workgroup_size_x = 8;
-    pkt.workgroup_size_y = 4;
-    pkt.workgroup_size_z = 2;
-    pkt.grid_size_x = 8;
-    pkt.grid_size_y = 4;
-    pkt.grid_size_z = 2;
-    pkt.kernel_object = ko;
-    queue.submit(pkt);
-    step_until_halted(*f.engine, {f.cu()});
+      test::AqlQueue queue(f.mem(), f.cp());
+      hsa_kernel_dispatch_packet_t pkt{};
+      pkt.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+      pkt.setup = 3;
+      pkt.workgroup_size_x = 8;
+      pkt.workgroup_size_y = 4;
+      pkt.workgroup_size_z = 2;
+      pkt.grid_size_x = 8;
+      pkt.grid_size_y = 4;
+      pkt.grid_size_z = 2;
+      pkt.kernel_object = ko;
+      queue.submit(pkt);
+      step_until_halted(*f.engine, {f.cu()});
 
-    ASSERT_EQ(f.cu()->num_wfs(), 1u);
-    auto *wf = f.cu()->wf(0);
-    ASSERT_NE(wf, nullptr);
-    EXPECT_EQ(wf->wf_size(), 64u);
-    const uint32_t vbase = wf->vgpr_alloc().base;
-    EXPECT_EQ(f.cu()->read_vgpr(vbase, 40), amdgpu::pack_workitem_id({0, 1, 1}, component_count));
-    EXPECT_EQ(f.cu()->read_vgpr(vbase, 63), amdgpu::pack_workitem_id({7, 3, 1}, component_count));
+      ASSERT_EQ(f.cu()->num_wfs(), 1u);
+      auto *wf = f.cu()->wf(0);
+      ASSERT_NE(wf, nullptr);
+      EXPECT_EQ(wf->wf_size(), 64u);
+      const uint32_t vbase = wf->vgpr_alloc().base;
+      EXPECT_EQ(f.cu()->read_vgpr(vbase, 40), amdgpu::pack_workitem_id({0, 1, 1}, component_count));
+      EXPECT_EQ(f.cu()->read_vgpr(vbase, 63), amdgpu::pack_workitem_id({7, 3, 1}, component_count));
+    }
   }
 }
 
@@ -498,12 +501,12 @@ TEST(CdnaDispatchTest, Wave64MasksMultidimensionalGridTailAcrossLane32) {
   EXPECT_EQ(wf->exec(), 0x0000'001F'1F1F'1F1FULL);
 }
 
-TEST(CdnaDispatchTest, UnpackedTidHonorsRequestedComponents) {
+TEST(CdnaDispatchTest, Cdna1UnpackedTidHonorsRequestedComponents) {
   const uint32_t code[] = {SOPP_S_ENDPGM};
 
   for (uint32_t component_count = 0; component_count <= 2; ++component_count) {
     SCOPED_TRACE("component_count=" + std::to_string(component_count));
-    VmFixture f("cdna2");
+    VmFixture f("cdna1");
     ASSERT_FALSE(f.cp()->packed_tid());
     uint64_t ko =
         f.write_kernel(0x1000, code, sizeof(code), 104, 256, 2, 0, false, component_count);

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -32,6 +32,7 @@ RJ_DIAGNOSTIC_POP
 #include <limits>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace {
@@ -47,7 +48,7 @@ struct VmFixture {
   SoC *soc_ptr = nullptr;
   amdgpu::GpuMemory *gpu_mem = nullptr;
 
-  VmFixture(const std::string &arch = "cdna3", uint32_t num_cus = 1, uint32_t num_wf_slots = 10,
+  VmFixture(std::string_view arch = "cdna3", uint32_t num_cus = 1, uint32_t num_wf_slots = 10,
             uint32_t lds_size_kb = 64, uint32_t sgprs_per_wf = 104) {
     std::string cu_range = "cu[0:" + std::to_string(num_cus) + "]";
     std::string links;
@@ -60,7 +61,7 @@ struct VmFixture {
                std::to_string(i) + R"(","latency":1,"weight":10})";
     }
 
-    std::string json = R"({"max_ticks":10000,"num_threads":1,"vm":{"arch":")" + arch +
+    std::string json = R"({"max_ticks":10000,"num_threads":1,"vm":{"arch":")" + std::string(arch) +
                        R"("},)"
                        R"("topology":{"root":{"name":"soc","type":"soc","children":[)"
                        R"({"name":"vram","type":"gpu_memory"},)"
@@ -438,10 +439,9 @@ TEST(RdnaDispatchTest, PackedTidHonorsRequestedComponents) {
 TEST(CdnaDispatchTest, Wave64PackedTidHonorsRequestedComponents) {
   const uint32_t code[] = {SOPP_S_ENDPGM};
 
-  for (const std::string &arch :
-       {std::string("cdna2"), std::string("cdna3"), std::string("cdna4")}) {
+  for (std::string_view arch : {"cdna2", "cdna3", "cdna4"}) {
     for (uint32_t component_count = 0; component_count <= 2; ++component_count) {
-      SCOPED_TRACE(arch + " component_count=" + std::to_string(component_count));
+      SCOPED_TRACE(::testing::Message() << arch << " component_count=" << component_count);
       VmFixture f(arch);
       ASSERT_TRUE(f.cp()->packed_tid());
       uint64_t ko =

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -102,7 +102,7 @@ TEST(ConfigLoaderTest, LoadRdnaKmdConfigs) {
   EXPECT_EQ(rdna4.soc()->num_xcds(), 1u);
   EXPECT_EQ(rdna4.soc()->xcd(0)->num_shader_engines(), 4u);
   EXPECT_EQ(rdna4.soc()->xcd(0)->shader_engine(0)->num_compute_units(), 16u);
-  EXPECT_FALSE(rdna4.soc()->xcd(0)->command_processor()->packed_tid());
+  EXPECT_TRUE(rdna4.soc()->xcd(0)->command_processor()->packed_tid());
   EXPECT_EQ(rdna4.soc()->xcd(0)->command_processor()->sdma_packet_dialect(),
             amdgpu::SdmaPacketDialect::Gfx11Plus);
 
@@ -136,7 +136,7 @@ TEST(ConfigLoaderTest, LoadRdnaKmdConfigs) {
   EXPECT_EQ(rdna3.soc()->num_xcds(), 1u);
   EXPECT_EQ(rdna3.soc()->xcd(0)->num_shader_engines(), 6u);
   EXPECT_EQ(rdna3.soc()->xcd(0)->shader_engine(0)->num_compute_units(), 16u);
-  EXPECT_FALSE(rdna3.soc()->xcd(0)->command_processor()->packed_tid());
+  EXPECT_TRUE(rdna3.soc()->xcd(0)->command_processor()->packed_tid());
   EXPECT_EQ(rdna3.soc()->xcd(0)->command_processor()->sdma_packet_dialect(),
             amdgpu::SdmaPacketDialect::Gfx11Plus);
 
@@ -170,7 +170,7 @@ TEST(ConfigLoaderTest, LoadRdnaKmdConfigs) {
   EXPECT_EQ(rdna35.soc()->num_xcds(), 1u);
   EXPECT_EQ(rdna35.soc()->xcd(0)->num_shader_engines(), 2u);
   EXPECT_EQ(rdna35.soc()->xcd(0)->shader_engine(0)->num_compute_units(), 16u);
-  EXPECT_FALSE(rdna35.soc()->xcd(0)->command_processor()->packed_tid());
+  EXPECT_TRUE(rdna35.soc()->xcd(0)->command_processor()->packed_tid());
   EXPECT_EQ(rdna35.soc()->xcd(0)->command_processor()->sdma_packet_dialect(),
             amdgpu::SdmaPacketDialect::Gfx11Plus);
 }

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -3393,61 +3393,58 @@ TEST(Gfx1250SimulationTest, DispatchesEndpgmThroughConfig) {
   EXPECT_TRUE(sim.cu()->wf(0)->is_halted());
 }
 
-TEST(Gfx1250SimulationTest, MultiWaveDispatchPacksWorkitemIdsInV0) {
-  Gfx1250Sim sim;
+TEST(Gfx1250SimulationTest, MultiWaveDispatchHonorsPackedTidComponentCount) {
   const uint32_t code[] = {S_ENDPGM_GFX12};
-  uint64_t kernel_object = sim.write_kernel(0x10000, code, std::size(code), 104, 32, 2, false,
-                                            false, false, 0, 0, 0, 0, 1);
 
-  test::AqlQueue queue(sim.memory, sim.cp());
-  hsa_kernel_dispatch_packet_t pkt{};
-  pkt.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
-  pkt.setup = 2;
-  pkt.workgroup_size_x = 32;
-  pkt.workgroup_size_y = 4;
-  pkt.workgroup_size_z = 1;
-  pkt.grid_size_x = 32;
-  pkt.grid_size_y = 4;
-  pkt.grid_size_z = 1;
-  pkt.kernel_object = kernel_object;
-  queue.submit(pkt);
-  step_until_xcd_halted(sim);
+  for (uint32_t component_count = 0; component_count <= 1; ++component_count) {
+    SCOPED_TRACE("component_count=" + std::to_string(component_count));
+    Gfx1250Sim sim;
+    uint64_t kernel_object = sim.write_kernel(0x10000, code, std::size(code), 104, 32, 2, false,
+                                              false, false, 0, 0, 0, 0, component_count);
 
-  std::vector<uint32_t> lane0_values;
-  std::vector<uint32_t> lane31_values;
-  for (uint32_t se_idx = 0; se_idx < sim.xcd()->num_shader_engines(); ++se_idx) {
-    auto *se = sim.xcd()->shader_engine(se_idx);
-    for (uint32_t cu_idx = 0; cu_idx < se->num_compute_units(); ++cu_idx) {
-      auto *cu = se->compute_unit(cu_idx);
-      for (uint32_t wf_idx = 0; wf_idx < cu->num_wf_slots(); ++wf_idx) {
-        auto *wf = cu->wf(wf_idx);
-        if (!wf || wf->sgpr_alloc().count == 0)
-          continue;
-        const uint32_t vbase = wf->vgpr_alloc().base;
-        lane0_values.push_back(cu->read_vgpr(vbase, 0));
-        lane31_values.push_back(cu->read_vgpr(vbase, 31));
+    test::AqlQueue queue(sim.memory, sim.cp());
+    hsa_kernel_dispatch_packet_t pkt{};
+    pkt.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+    pkt.setup = 2;
+    pkt.workgroup_size_x = 32;
+    pkt.workgroup_size_y = 4;
+    pkt.workgroup_size_z = 1;
+    pkt.grid_size_x = 32;
+    pkt.grid_size_y = 4;
+    pkt.grid_size_z = 1;
+    pkt.kernel_object = kernel_object;
+    queue.submit(pkt);
+    step_until_xcd_halted(sim);
+
+    std::vector<uint32_t> lane0_values;
+    std::vector<uint32_t> lane31_values;
+    for (uint32_t se_idx = 0; se_idx < sim.xcd()->num_shader_engines(); ++se_idx) {
+      auto *se = sim.xcd()->shader_engine(se_idx);
+      for (uint32_t cu_idx = 0; cu_idx < se->num_compute_units(); ++cu_idx) {
+        auto *cu = se->compute_unit(cu_idx);
+        for (uint32_t wf_idx = 0; wf_idx < cu->num_wf_slots(); ++wf_idx) {
+          auto *wf = cu->wf(wf_idx);
+          if (!wf || wf->sgpr_alloc().count == 0)
+            continue;
+          const uint32_t vbase = wf->vgpr_alloc().base;
+          lane0_values.push_back(cu->read_vgpr(vbase, 0));
+          lane31_values.push_back(cu->read_vgpr(vbase, 31));
+        }
       }
     }
-  }
 
-  std::sort(lane0_values.begin(), lane0_values.end());
-  std::sort(lane31_values.begin(), lane31_values.end());
-  const std::vector<uint32_t> expected_lane0{0u, 1u << 10, 2u << 10, 3u << 10};
-  const std::vector<uint32_t> expected_lane31{31u, 31u | (1u << 10), 31u | (2u << 10),
-                                              31u | (3u << 10)};
-  EXPECT_EQ(lane0_values, expected_lane0);
-  EXPECT_EQ(lane31_values, expected_lane31);
+    std::sort(lane0_values.begin(), lane0_values.end());
+    std::sort(lane31_values.begin(), lane31_values.end());
+    const uint32_t y_scale = component_count >= 1 ? 1u << 10 : 0;
+    const std::vector<uint32_t> expected_lane0{0u, y_scale, 2 * y_scale, 3 * y_scale};
+    const std::vector<uint32_t> expected_lane31{31u, 31u | y_scale, 31u | (2 * y_scale),
+                                                31u | (3 * y_scale)};
+    EXPECT_EQ(lane0_values, expected_lane0);
+    EXPECT_EQ(lane31_values, expected_lane31);
+  }
 }
 
-TEST(Gfx1250SimulationTest, PartialWorkgroupMasksTailWaveExec) {
-  Gfx1250Sim sim;
-  const uint32_t code[] = {S_ENDPGM_GFX12};
-  uint64_t kernel_object = sim.write_kernel(0x10000, code, std::size(code));
-
-  test::AqlQueue queue(sim.memory, sim.cp());
-  queue.dispatch(kernel_object, 33, 33);
-  step_until_xcd_halted(sim);
-
+std::vector<uint64_t> collect_active_exec_masks(Gfx1250Sim &sim) {
   std::vector<uint64_t> exec_masks;
   for (uint32_t se_idx = 0; se_idx < sim.xcd()->num_shader_engines(); ++se_idx) {
     auto *se = sim.xcd()->shader_engine(se_idx);
@@ -3460,10 +3457,22 @@ TEST(Gfx1250SimulationTest, PartialWorkgroupMasksTailWaveExec) {
       }
     }
   }
-
   std::sort(exec_masks.begin(), exec_masks.end());
+  return exec_masks;
+}
+
+TEST(Gfx1250SimulationTest, PartialWorkgroupMasksTailWaveExec) {
+  Gfx1250Sim sim;
+  const uint32_t code[] = {S_ENDPGM_GFX12};
+  uint64_t kernel_object = sim.write_kernel(0x10000, code, std::size(code));
+
+  test::AqlQueue queue(sim.memory, sim.cp());
+  queue.dispatch(kernel_object, 33, 33);
+  step_until_xcd_halted(sim);
+
+  // One 33-thread workgroup exercises the intra-workgroup tail wave.
   const std::vector<uint64_t> expected{1ULL, 0xFFFFFFFFULL};
-  EXPECT_EQ(exec_masks, expected);
+  EXPECT_EQ(collect_active_exec_masks(sim), expected);
 }
 
 // Count the distinct workgroup ids across all wavefronts activated for the
@@ -3522,6 +3531,44 @@ TEST(Gfx1250SimulationTest, PartialFinalWorkgroupRoundsUpDispatchCount2D) {
   step_until_xcd_halted(sim);
 
   EXPECT_EQ(count_dispatched_workgroups(sim), 9u);
+}
+
+TEST(Gfx1250SimulationTest, PartialGridTailMasksFinalWorkgroupExec) {
+  Gfx1250Sim sim;
+  const uint32_t code[] = {S_ENDPGM_GFX12};
+  uint64_t kernel_object = sim.write_kernel(0x10000, code, std::size(code));
+
+  test::AqlQueue queue(sim.memory, sim.cp());
+  queue.dispatch(kernel_object, 33, 32);
+  step_until_xcd_halted(sim);
+
+  // Unlike PartialWorkgroupMasksTailWaveExec, this uses two full-size
+  // workgroups and exercises the grid-bounds mask on the final workgroup.
+  const std::vector<uint64_t> expected{1ULL, 0xFFFFFFFFULL};
+  EXPECT_EQ(collect_active_exec_masks(sim), expected);
+}
+
+TEST(Gfx1250SimulationTest, Partial2DGridTailMasksNonContiguousExecLanes) {
+  Gfx1250Sim sim;
+  const uint32_t code[] = {S_ENDPGM_GFX12};
+  uint64_t kernel_object = sim.write_kernel(0x10000, code, std::size(code));
+
+  test::AqlQueue queue(sim.memory, sim.cp());
+  hsa_kernel_dispatch_packet_t pkt{};
+  pkt.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+  pkt.setup = 2;
+  pkt.workgroup_size_x = 8;
+  pkt.workgroup_size_y = 2;
+  pkt.workgroup_size_z = 1;
+  pkt.grid_size_x = 13;
+  pkt.grid_size_y = 2;
+  pkt.grid_size_z = 1;
+  pkt.kernel_object = kernel_object;
+  queue.submit(pkt);
+  step_until_xcd_halted(sim);
+
+  const std::vector<uint64_t> expected{0x1F1FULL, 0xFFFFULL};
+  EXPECT_EQ(collect_active_exec_masks(sim), expected);
 }
 
 TEST(Gfx1250SimulationTest, DispatchPreloadsKernargDwordsIntoUserSgprs) {


### PR DESCRIPTION
## Motivation

Honor packed work-item ID component counts, share work-item coordinate calculation, and initialize EXEC for partial dispatches. Extend coverage for wave64 and multidimensional grid tails.

Discovered during gfx1250->rdna4 dbt over simulated target enablement.

## Technical Details

RDNA3+ dispatches were using the unpacked work-item-ID layout even though GFX11+ supplies packed IDs in `v0`. Packed targets also populated components that were not requested by `TIDIG_COMP_CNT`.

Additionally, the initial EXEC mask accounted for incomplete waves within a workgroup, but not lanes outside the actual grid in a partial final workgroup. This could leave out-of-grid lanes active.

## JIRA ID

N/A

## Test Plan

ctest + dbt tests

## Test Result

OK

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
