### PR TITLE
fix(rocjitsu): Fix high-output word selector for v_pk_mov_b32

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/__init__.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/__init__.py
@@ -261,7 +261,6 @@ def _register_handlers() -> None:
         c.dst_ops,
         c.src_ops,
         opsel_exprs=c.opsel_exprs,
-        use_gfx1250_helpers=c.arch_name == 'gfx1250',
     )
     DISPATCH['mad_mix_f32'] = lambda c: gen_mad_mix_f32(
         c.dst_ops,

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/packed.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/packed.py
@@ -515,7 +515,7 @@ def gen_pk_mov_b32(
     s1_lo = _pk_f32_word_expr('s1', 'lo', use_gfx1250_helpers)
     s1_hi = _pk_f32_word_expr('s1', 'hi', use_gfx1250_helpers)
     L.append(f'    uint32_t lo = ({opsel} & 1) ? {s0_hi} : {s0_lo};')
-    L.append(f'    uint32_t hi = ({opsel_hi} & 2) ? {s1_hi} : {s1_lo};')
+    L.append(f'    uint32_t hi = ({opsel} & 2) ? {s1_hi} : {s1_lo};')
     L.append(
         f'    {d}.write_lane64(wf, lane, static_cast<uint64_t>(lo) | (static_cast<uint64_t>(hi) << 32));'
     )

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/packed.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/packed.py
@@ -499,7 +499,6 @@ def gen_pk_mov_b32(
     dst: list[str],
     src: list[str],
     opsel_exprs: tuple[str, str] = ('', ''),
-    use_gfx1250_helpers: bool = False,
 ) -> str:
     """Generate V_PK_MOV_B32: move two 32-bit values based on op_sel."""
     d, s0, s1 = dst[0], src[0], src[1]
@@ -508,12 +507,16 @@ def gen_pk_mov_b32(
     L.append('  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {')
     L.append('    if (!(exec & (1ULL << lane))) continue;')
     for var, src in [('s0', s0), ('s1', s1)]:
-        _append_pk_f32_pair_read(L, var, src, use_gfx1250_helpers)
+        L.append(f'    uint64_t {var}_pair_w = {src}.read_lane64(wf, lane);')
+        L.append(f'    uint32_t {var}_lo_w = static_cast<uint32_t>({var}_pair_w);')
+        L.append(
+            f'    uint32_t {var}_hi_w = static_cast<uint32_t>({var}_pair_w >> 32);'
+        )
     opsel, opsel_hi = opsel_exprs
-    s0_lo = _pk_f32_word_expr('s0', 'lo', use_gfx1250_helpers)
-    s0_hi = _pk_f32_word_expr('s0', 'hi', use_gfx1250_helpers)
-    s1_lo = _pk_f32_word_expr('s1', 'lo', use_gfx1250_helpers)
-    s1_hi = _pk_f32_word_expr('s1', 'hi', use_gfx1250_helpers)
+    s0_lo = _pk_f32_word_expr('s0', 'lo')
+    s0_hi = _pk_f32_word_expr('s0', 'hi')
+    s1_lo = _pk_f32_word_expr('s1', 'lo')
+    s1_hi = _pk_f32_word_expr('s1', 'hi')
     L.append(f'    uint32_t lo = ({opsel} & 1) ? {s0_hi} : {s0_lo};')
     L.append(f'    uint32_t hi = ({opsel} & 2) ? {s1_hi} : {s1_lo};')
     L.append(

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
@@ -1243,10 +1243,9 @@ SIMD_VOP3P_PK_TERNARY_F32: dict[str, str] = {
     'v_pk_fma_f32_vop3p': '[](auto a, auto b, auto c) { return util::stdx::fma(a, b, c); }',
 }
 
-# v_pk_mov_b32 — each src is a 64-bit pair (consecutive VGPRs). op_sel[0]
-# selects the low output dword from src0 and op_sel[1] selects the high output
-# dword from src1. The fast path is limited to the assembler's default
-# op_sel_hi value.
+# v_pk_mov_b32 — each src is a 64-bit SGPR or VGPR pair. op_sel[0] selects the
+# low output dword from src0 and op_sel[1] selects the high output dword from
+# src1. The fast path is limited to the assembler's default op_sel_hi value.
 SIMD_VOP3P_MOV_B32: set[str] = {
     'v_pk_mov_b32_vop3p',
 }

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
@@ -1243,8 +1243,10 @@ SIMD_VOP3P_PK_TERNARY_F32: dict[str, str] = {
     'v_pk_fma_f32_vop3p': '[](auto a, auto b, auto c) { return util::stdx::fma(a, b, c); }',
 }
 
-# v_pk_mov_b32 — default-packing-only fast path. Each src is a 64-bit pair
-# (consecutive VGPRs), result is (src0_lo, src1_hi). Functorless / fixed-op.
+# v_pk_mov_b32 — each src is a 64-bit pair (consecutive VGPRs). op_sel[0]
+# selects the low output dword from src0 and op_sel[1] selects the high output
+# dword from src1. The fast path is limited to the assembler's default
+# op_sel_hi value.
 SIMD_VOP3P_MOV_B32: set[str] = {
     'v_pk_mov_b32_vop3p',
 }

--- a/emulation/rocjitsu/lib/python/amdisa/semantics.py
+++ b/emulation/rocjitsu/lib/python/amdisa/semantics.py
@@ -1534,7 +1534,7 @@ def _derive_vop3p(name: str) -> InstructionSemantics | None:
             name, 'pk_binop_f32', operation='add', data_type='f32'
         )
     if name == 'V_PK_MOV_B32':
-        return InstructionSemantics(name, 'pk_mov_b32', accvgpr_srcs=True)
+        return InstructionSemantics(name, 'pk_mov_b32')
 
     # Packed min3/max3 (CDNA4 / RDNA4)
     if name in ('V_PK_MINIMUM3_F16', 'V_PK_MAXIMUM3_F16'):

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -38,7 +38,11 @@ from amdisa.isa_profile import (
     Rdna4Profile,
 )
 from amdisa.parser import Parser
-from amdisa.semantics import InstructionSemantics, derive_all_semantics
+from amdisa.semantics import (
+    InstructionSemantics,
+    derive_all_semantics,
+    derive_semantics,
+)
 
 
 def _repo_root() -> Path:
@@ -386,6 +390,24 @@ def test_readlane_family_uses_source_vgpr_operand_type():
 
     assert codegen._constructor_operand_type(sem, src0) == 'OPR_SRC_VGPR'
     assert codegen._constructor_operand_type(sem, vdst) == 'OPR_VGPR'
+
+
+def test_pk_mov_b32_keeps_declared_scalar_or_vector_source_types():
+    codegen = object.__new__(CodeGenerator)
+    codegen.isa_spec = SimpleNamespace(
+        operand_types=[
+            'OPR_SRC_NOLIT',
+            'OPR_SRC_SIMPLE',
+            'OPR_SRC_VGPR_OR_ACCVGPR',
+        ]
+    )
+    sem = derive_semantics('V_PK_MOV_B32', 'ENC_VOP3P')
+    assert sem is not None
+    src0 = Operand('src0', 64, 'OPR_SRC_NOLIT', True, False, False, True, 1)
+    src1 = Operand('src1', 64, 'OPR_SRC_SIMPLE', True, False, False, True, 2)
+
+    assert codegen._constructor_operand_type(sem, src0) == 'OPR_SRC_NOLIT'
+    assert codegen._constructor_operand_type(sem, src1) == 'OPR_SRC_SIMPLE'
 
 
 def test_readlane_family_decodes_lane_selector_as_scalar_value():

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
@@ -23,7 +23,7 @@ from amdisa.codegen.execute.sema_lower import (
     RegClass,
     lower_sema_block,
 )
-from amdisa.codegen.execute.packed import gen_pk_binop, gen_pk_ternary
+from amdisa.codegen.execute.packed import gen_pk_binop, gen_pk_mov_b32, gen_pk_ternary
 from amdisa.codegen.execute.vector_special import (
     gen_cvt_fp8,
     gen_vector_cvt_pk,
@@ -1979,6 +1979,17 @@ class TestDerivePacked:
         sem = _FakeSem('V_PK_MOV_B32', 'pk_mov_b32')
         block = derive_sema_block(sem)
         assert block is not None
+
+    def test_pk_mov_b32_generator_uses_op_sel_for_both_outputs(self):
+        cpp = gen_pk_mov_b32(
+            ['inst.vdst'],
+            ['inst.src0', 'inst.src1'],
+            opsel_exprs=('inst.inst_.op_sel', 'inst.inst_.op_sel_hi'),
+        )
+
+        assert 'uint32_t lo = (inst.inst_.op_sel & 1)' in cpp
+        assert 'uint32_t hi = (inst.inst_.op_sel & 2)' in cpp
+        assert 'uint32_t hi = (inst.inst_.op_sel_hi & 2)' not in cpp
 
 
 class TestDeriveDot:

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
@@ -1990,6 +1990,9 @@ class TestDerivePacked:
         assert 'uint32_t lo = (inst.inst_.op_sel & 1)' in cpp
         assert 'uint32_t hi = (inst.inst_.op_sel & 2)' in cpp
         assert 'uint32_t hi = (inst.inst_.op_sel_hi & 2)' not in cpp
+        assert 'uint64_t s0_pair_w = inst.src0.read_lane64(wf, lane)' in cpp
+        assert 'uint64_t s1_pair_w = inst.src1.read_lane64(wf, lane)' in cpp
+        assert 'encoding_value_ >= 256' not in cpp
 
 
 class TestDeriveDot:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/vop3p.cpp
@@ -706,10 +706,8 @@ VPkMovB32Vop3p::VPkMovB32Vop3p(const MachineInst *inst)
     : Vop3p("v_pk_mov_b32", reinterpret_cast<const OpEncoding *>(inst),
             make_exec_fn<VPkMovB32Vop3p>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
-      src0(64, OperandType::OPR_SRC_VGPR_OR_ACCVGPR,
-           reinterpret_cast<const OpEncoding *>(inst)->src0),
-      src1(64, OperandType::OPR_SRC_VGPR_OR_ACCVGPR,
-           reinterpret_cast<const OpEncoding *>(inst)->src1) {
+      src0(64, OperandType::OPR_SRC_NOLIT, reinterpret_cast<const OpEncoding *>(inst)->src0),
+      src1(64, OperandType::OPR_SRC_SIMPLE, reinterpret_cast<const OpEncoding *>(inst)->src1) {
   dst_operands_[0] = &vdst;
   src_operands_[0] = &src0;
   src_operands_[1] = &src1;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/vop3p.cpp
@@ -664,10 +664,8 @@ VPkMovB32Vop3p::VPkMovB32Vop3p(const MachineInst *inst)
     : Vop3p("v_pk_mov_b32", reinterpret_cast<const OpEncoding *>(inst),
             make_exec_fn<VPkMovB32Vop3p>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
-      src0(64, OperandType::OPR_SRC_VGPR_OR_ACCVGPR,
-           reinterpret_cast<const OpEncoding *>(inst)->src0),
-      src1(64, OperandType::OPR_SRC_VGPR_OR_ACCVGPR,
-           reinterpret_cast<const OpEncoding *>(inst)->src1) {
+      src0(64, OperandType::OPR_SRC_NOLIT, reinterpret_cast<const OpEncoding *>(inst)->src0),
+      src1(64, OperandType::OPR_SRC_SIMPLE, reinterpret_cast<const OpEncoding *>(inst)->src1) {
   dst_operands_[0] = &vdst;
   src_operands_[0] = &src0;
   src_operands_[1] = &src1;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3p.cpp
@@ -763,10 +763,8 @@ VPkMovB32Vop3p::VPkMovB32Vop3p(const MachineInst *inst)
     : Vop3p("v_pk_mov_b32", reinterpret_cast<const OpEncoding *>(inst),
             make_exec_fn<VPkMovB32Vop3p>()),
       vdst(64, OperandType::OPR_VGPR, reinterpret_cast<const OpEncoding *>(inst)->vdst),
-      src0(64, OperandType::OPR_SRC_VGPR_OR_ACCVGPR,
-           reinterpret_cast<const OpEncoding *>(inst)->src0),
-      src1(64, OperandType::OPR_SRC_VGPR_OR_ACCVGPR,
-           reinterpret_cast<const OpEncoding *>(inst)->src1) {
+      src0(64, OperandType::OPR_SRC_NOLIT, reinterpret_cast<const OpEncoding *>(inst)->src0),
+      src1(64, OperandType::OPR_SRC_SIMPLE, reinterpret_cast<const OpEncoding *>(inst)->src1) {
   dst_operands_[0] = &vdst;
   src_operands_[0] = &src0;
   src_operands_[1] = &src1;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -16606,20 +16606,12 @@ inline void execute_v_pk_mov_b32_vop3p([[maybe_unused]] Inst &inst,
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    uint32_t s0_lo_w = inst.src0.read_lane(wf, lane);
-    uint32_t s0_hi_w = s0_lo_w;
-    if (inst.src0.encoding_value_ >= 256 && inst.src0.encoding_value_ <= 511) {
-      uint64_t s0_pair_w = inst.src0.read_lane64(wf, lane);
-      s0_lo_w = static_cast<uint32_t>(s0_pair_w);
-      s0_hi_w = static_cast<uint32_t>(s0_pair_w >> 32);
-    }
-    uint32_t s1_lo_w = inst.src1.read_lane(wf, lane);
-    uint32_t s1_hi_w = s1_lo_w;
-    if (inst.src1.encoding_value_ >= 256 && inst.src1.encoding_value_ <= 511) {
-      uint64_t s1_pair_w = inst.src1.read_lane64(wf, lane);
-      s1_lo_w = static_cast<uint32_t>(s1_pair_w);
-      s1_hi_w = static_cast<uint32_t>(s1_pair_w >> 32);
-    }
+    uint64_t s0_pair_w = inst.src0.read_lane64(wf, lane);
+    uint32_t s0_lo_w = static_cast<uint32_t>(s0_pair_w);
+    uint32_t s0_hi_w = static_cast<uint32_t>(s0_pair_w >> 32);
+    uint64_t s1_pair_w = inst.src1.read_lane64(wf, lane);
+    uint32_t s1_lo_w = static_cast<uint32_t>(s1_pair_w);
+    uint32_t s1_hi_w = static_cast<uint32_t>(s1_pair_w >> 32);
     uint32_t lo = (inst.inst_.op_sel & 1) ? s0_hi_w : s0_lo_w;
     uint32_t hi = (inst.inst_.op_sel & 2) ? s1_hi_w : s1_lo_w;
     inst.vdst.write_lane64(wf, lane, static_cast<uint64_t>(lo) | (static_cast<uint64_t>(hi) << 32));

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -16621,7 +16621,7 @@ inline void execute_v_pk_mov_b32_vop3p([[maybe_unused]] Inst &inst,
       s1_hi_w = static_cast<uint32_t>(s1_pair_w >> 32);
     }
     uint32_t lo = (inst.inst_.op_sel & 1) ? s0_hi_w : s0_lo_w;
-    uint32_t hi = (inst.inst_.op_sel_hi & 2) ? s1_hi_w : s1_lo_w;
+    uint32_t hi = (inst.inst_.op_sel & 2) ? s1_hi_w : s1_lo_w;
     inst.vdst.write_lane64(wf, lane, static_cast<uint64_t>(lo) | (static_cast<uint64_t>(hi) << 32));
   }
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
@@ -3621,21 +3621,20 @@ template <typename Inst, typename Op>
   return false;
 }
 
-/// VOP3P v_pk_mov_b32 SIMD fast path. Default packing only (op_sel == 0,
-/// op_sel_hi == 3): the result is a 64-bit pair `(src0_lo, src1_hi)`,
+/// VOP3P v_pk_mov_b32 SIMD fast path. Each src is a 64-bit pair
 /// where the per-source pair is the consecutive {base, base+1} VGPRs
 /// when the encoding points at the VGPR range. SGPR / literal sources
 /// broadcast both halves identically (handled by read_simd64's
-/// broadcast64 fallback). Reads each src as a 64-bit pair, picks the low
-/// half of src0 and the high half of src1 via mask, packs, writes via
-/// write_simd64. Functorless / fixed-op.
+/// broadcast64 fallback). op_sel[0] selects the low output dword from src0,
+/// and op_sel[1] selects the high output dword from src1. The fast path is
+/// limited to the assembler's default op_sel_hi value. Functorless / fixed-op.
 template <typename Inst>
   requires(util::has_stdx_simd)
 [[nodiscard]] inline bool try_execute_vop3p_mov_b32_simd(Inst &inst, Wavefront &wf) {
   if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable() ||
       !inst.vdst.simd_capable())
     return false;
-  if (inst.inst_.op_sel != 0u || inst.inst_.op_sel_hi != 3u)
+  if (inst.inst_.op_sel_hi != 3u)
     return false;
   constexpr std::size_t W = util::native_width64;
   const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
@@ -3649,7 +3648,9 @@ template <typename Inst>
       continue;
     const U64 s0 = read_simd64<uint64_t>(inst.src0, wf, base);
     const U64 s1 = read_simd64<uint64_t>(inst.src1, wf, base);
-    const U64 out = (s0 & kLoMask) | (s1 & kHiMask);
+    const U64 out_lo = (inst.inst_.op_sel & 1u) ? ((s0 >> 32) & kLoMask) : (s0 & kLoMask);
+    const U64 out_hi = (inst.inst_.op_sel & 2u) ? (s1 & kHiMask) : ((s1 & kLoMask) << 32);
+    const U64 out = out_lo | out_hi;
     write_simd64<uint64_t>(inst.vdst, wf, base, out, chunk);
   }
   return true;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
@@ -3621,13 +3621,11 @@ template <typename Inst, typename Op>
   return false;
 }
 
-/// VOP3P v_pk_mov_b32 SIMD fast path. Each src is a 64-bit pair
-/// where the per-source pair is the consecutive {base, base+1} VGPRs
-/// when the encoding points at the VGPR range. SGPR / literal sources
-/// broadcast both halves identically (handled by read_simd64's
-/// broadcast64 fallback). op_sel[0] selects the low output dword from src0,
-/// and op_sel[1] selects the high output dword from src1. The fast path is
-/// limited to the assembler's default op_sel_hi value. Functorless / fixed-op.
+/// VOP3P v_pk_mov_b32 SIMD fast path. Each src is a 64-bit SGPR or VGPR pair.
+/// SGPR pairs are broadcast across lanes by read_simd64's broadcast64 fallback.
+/// op_sel[0] selects the low output dword from src0, and op_sel[1] selects the
+/// high output dword from src1. The fast path is limited to the assembler's
+/// default op_sel_hi value. Functorless / fixed-op.
 template <typename Inst>
   requires(util::has_stdx_simd)
 [[nodiscard]] inline bool try_execute_vop3p_mov_b32_simd(Inst &inst, Wavefront &wf) {

--- a/emulation/rocjitsu/tests/simd_correctness/vop3p_mov_b32_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3p_mov_b32_simd_correctness_test.cpp
@@ -8,7 +8,8 @@
 /// op_sel[0] selects the low output dword from src0.{lo,hi}, and op_sel[1]
 /// selects the high output dword from src1.{lo,hi}. Each case runs twice in
 /// the same process -- once forcing the scalar body, once allowing the SIMD
-/// fast path -- and both paths must match the same golden 64-bit result.
+/// fast path -- and both paths must match the same golden 64-bit result. A
+/// mixed SGPR-pair/VGPR-pair case covers the legal scalar source encoding.
 /// In-process inactive lanes must keep the sentinel.
 
 #include "util/simd_test_hooks.h"
@@ -43,6 +44,10 @@ constexpr uint32_t SGPRS_PER_WF = 106;
 constexpr uint32_t VGPRS_PER_WF = 256;
 constexpr uint32_t kDstVgpr = 8; // pair occupies kDstVgpr..kDstVgpr+1
 constexpr uint32_t DST_SENTINEL = 0xCDCDCDCDu;
+constexpr uint32_t kMixedSgprLo = 0x11111111u;
+constexpr uint32_t kMixedSgprHi = 0x22222222u;
+constexpr uint32_t kMixedVgprLo = 0x55555555u;
+constexpr uint32_t kMixedVgprHi = 0x66666666u;
 
 struct ArchCase {
   rj_code_arch_t arch;
@@ -103,13 +108,18 @@ struct Fixture {
   }
 
   void seed_inputs(uint32_t rot, uint64_t exec) {
+    uint32_t sb = wf->sgpr_alloc().base;
     uint32_t vb = wf->vgpr_alloc().base;
+    cu->write_sgpr(sb + 0, kMixedSgprLo);
+    cu->write_sgpr(sb + 1, kMixedSgprHi);
     for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
       // src0 pair at v0:v1, src1 pair at v2:v3.
       cu->write_vgpr(vb + 0, lane, kVals[lane % kVals.size()]);
       cu->write_vgpr(vb + 1, lane, kVals[(lane + 1) % kVals.size()]);
       cu->write_vgpr(vb + 2, lane, kVals[(lane + rot) % kVals.size()]);
       cu->write_vgpr(vb + 3, lane, kVals[(lane + rot + 1) % kVals.size()]);
+      cu->write_vgpr(vb + 4, lane, kMixedVgprLo);
+      cu->write_vgpr(vb + 5, lane, kMixedVgprHi);
       cu->write_vgpr(vb + kDstVgpr + 0, lane, DST_SENTINEL);
       cu->write_vgpr(vb + kDstVgpr + 1, lane, DST_SENTINEL);
     }
@@ -256,6 +266,60 @@ TEST(Vop3pMovB32SimdCorrectness, PartialExec) {
     return;
   }
   check(/*exec=*/0xA5A5'F0F0'1234'8001ULL);
+}
+
+TEST(Vop3pMovB32SimdCorrectness, MixedSgprPairAndVgprPairGolden) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+
+  ForceScalarGuard gate_guard;
+  struct MixedSourceCase {
+    const char *name;
+    uint32_t src0;
+    uint32_t src1;
+    uint32_t op_sel;
+    uint64_t golden;
+  };
+  constexpr std::array<MixedSourceCase, 2> kCases{{
+      {"sgpr-vgpr", /*src0=*/0, /*src1=*/256 + 4, /*op_sel=*/1,
+       uint64_t{kMixedSgprHi} | (uint64_t{kMixedVgprLo} << 32)},
+      {"vgpr-sgpr", /*src0=*/256 + 4, /*src1=*/0, /*op_sel=*/2,
+       uint64_t{kMixedVgprLo} | (uint64_t{kMixedSgprHi} << 32)},
+  }};
+
+  auto run_mode = [&](const ArchCase &arch, const MixedSourceCase &test_case, bool force_scalar) {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx(arch);
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t words[2] = {0u, 0u};
+    vop3p_encode(/*op=*/51, kDstVgpr, test_case.src0, test_case.src1, test_case.op_sel, words);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << arch.name << " " << test_case.name
+                             << " v_pk_mov_b32_vop3p decode failed";
+    auto out = force_scalar
+                   ? fx.run(inst, /*rot=*/0, /*exec=*/~0ULL)
+                   : fx.run_simd_probe(inst, arch, /*rot=*/0, /*exec=*/~0ULL, test_case.op_sel);
+    delete inst;
+    return out;
+  };
+
+  for (const auto &arch : kArchCases) {
+    for (const auto &test_case : kCases) {
+      const auto scalar_out = run_mode(arch, test_case, /*force_scalar=*/true);
+      const auto simd_out = run_mode(arch, test_case, /*force_scalar=*/false);
+      for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+        EXPECT_EQ(scalar_out[lane], test_case.golden)
+            << arch.name << " " << test_case.name
+            << ": scalar mixed SGPR/VGPR result differs at lane " << lane;
+        EXPECT_EQ(simd_out[lane], test_case.golden)
+            << arch.name << " " << test_case.name
+            << ": SIMD mixed SGPR/VGPR result differs at lane " << lane;
+      }
+    }
+  }
 }
 
 } // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop3p_mov_b32_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3p_mov_b32_simd_correctness_test.cpp
@@ -14,7 +14,11 @@
 #include "util/simd_test_hooks.h"
 
 #include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/cdna2/vop3p.h"
+#include "rocjitsu/isa/arch/amdgpu/cdna3/vop3p.h"
+#include "rocjitsu/isa/arch/amdgpu/cdna4/vop3p.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
 #include "rocjitsu/isa/decoder.h"
 #include "rocjitsu/isa/instruction.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
@@ -115,6 +119,39 @@ struct Fixture {
   std::array<uint64_t, WF_SIZE> run(Instruction *inst, uint32_t rot, uint64_t exec) {
     seed_inputs(rot, exec);
     cu->execute_instruction(inst, *wf);
+    return read_output();
+  }
+
+  template <typename Inst>
+  std::array<uint64_t, WF_SIZE> run_simd_probe_impl(Instruction *inst, const ArchCase &arch,
+                                                    uint32_t rot, uint64_t exec, uint32_t op_sel) {
+    auto *typed_inst = dynamic_cast<Inst *>(inst);
+    EXPECT_NE(typed_inst, nullptr) << arch.name << " decoded unexpected instruction type";
+    if (typed_inst == nullptr)
+      return {};
+    seed_inputs(rot, exec);
+    EXPECT_TRUE(amdgpu::try_execute_vop3p_mov_b32_simd(*typed_inst, *wf))
+        << arch.name << " v_pk_mov_b32_vop3p op_sel=" << op_sel
+        << " did not take the SIMD fast path";
+    return read_output();
+  }
+
+  std::array<uint64_t, WF_SIZE> run_simd_probe(Instruction *inst, const ArchCase &arch,
+                                               uint32_t rot, uint64_t exec, uint32_t op_sel) {
+    switch (arch.arch) {
+    case ROCJITSU_CODE_ARCH_CDNA2:
+      return run_simd_probe_impl<cdna2::VPkMovB32Vop3p>(inst, arch, rot, exec, op_sel);
+    case ROCJITSU_CODE_ARCH_CDNA3:
+      return run_simd_probe_impl<cdna3::VPkMovB32Vop3p>(inst, arch, rot, exec, op_sel);
+    case ROCJITSU_CODE_ARCH_CDNA4:
+      return run_simd_probe_impl<cdna4::VPkMovB32Vop3p>(inst, arch, rot, exec, op_sel);
+    default:
+      ADD_FAILURE() << "unsupported arch case " << arch.name;
+      return {};
+    }
+  }
+
+  std::array<uint64_t, WF_SIZE> read_output() {
     std::array<uint64_t, WF_SIZE> out{};
     uint32_t vb = wf->vgpr_alloc().base;
     for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
@@ -168,7 +205,8 @@ void check(uint64_t exec) {
     vop3p_encode(/*op=*/51, kDstVgpr, /*src0=*/256, /*src1=*/258, op_sel, words);
     Instruction *inst = fx.decoder->decode(words);
     EXPECT_NE(inst, nullptr) << "v_pk_mov_b32_vop3p decode failed";
-    auto out = fx.run(inst, rot, exec);
+    auto out =
+        force_scalar ? fx.run(inst, rot, exec) : fx.run_simd_probe(inst, arch, rot, exec, op_sel);
     delete inst;
     return out;
   };
@@ -191,12 +229,12 @@ void check(uint64_t exec) {
           const bool active = (exec >> lane) & 1ULL;
           if (!active) {
             const uint64_t sentinel = uint64_t{DST_SENTINEL} | (uint64_t{DST_SENTINEL} << 32);
-            EXPECT_EQ(simd_out[lane], sentinel) << arch.name << " rot=" << rot
-                                                << " op_sel=" << op_sel
-                                                << ": clobbered inactive lane " << lane;
-            EXPECT_EQ(scalar_out[lane], sentinel) << arch.name << " rot=" << rot
-                                                  << " op_sel=" << op_sel
-                                                  << ": clobbered inactive lane " << lane;
+            EXPECT_EQ(simd_out[lane], sentinel)
+                << arch.name << " rot=" << rot << " op_sel=" << op_sel
+                << ": clobbered inactive lane " << lane;
+            EXPECT_EQ(scalar_out[lane], sentinel)
+                << arch.name << " rot=" << rot << " op_sel=" << op_sel
+                << ": clobbered inactive lane " << lane;
           }
         }
       }

--- a/emulation/rocjitsu/tests/simd_correctness/vop3p_mov_b32_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3p_mov_b32_simd_correctness_test.cpp
@@ -268,6 +268,34 @@ TEST(Vop3pMovB32SimdCorrectness, PartialExec) {
   check(/*exec=*/0xA5A5'F0F0'1234'8001ULL);
 }
 
+TEST(Vop3pMovB32SimdCorrectness, ProductionSimdDispatchGolden) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+
+  ForceScalarGuard gate_guard;
+  util::set_force_scalar_for_testing(false);
+  constexpr uint32_t kRot = 5;
+  constexpr uint32_t kOpSel = 3;
+  constexpr uint64_t kExec = 0xA5A5'F0F0'1234'8001ULL;
+  const auto golden = expected(kRot, kExec, kOpSel);
+
+  for (const auto &arch : kArchCases) {
+    Fixture fx(arch);
+    ASSERT_NE(fx.cu, nullptr);
+    ASSERT_NE(fx.wf, nullptr);
+    uint32_t words[2] = {0u, 0u};
+    vop3p_encode(/*op=*/51, kDstVgpr, /*src0=*/256, /*src1=*/258, kOpSel, words);
+    Instruction *inst = fx.decoder->decode(words);
+    ASSERT_NE(inst, nullptr) << arch.name << " v_pk_mov_b32_vop3p decode failed";
+    const auto out = fx.run(inst, kRot, kExec);
+    delete inst;
+
+    EXPECT_EQ(out, golden) << arch.name << ": production SIMD dispatch differed from golden";
+  }
+}
+
 TEST(Vop3pMovB32SimdCorrectness, MixedSgprPairAndVgprPairGolden) {
   if constexpr (!util::has_stdx_simd) {
     GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";

--- a/emulation/rocjitsu/tests/simd_correctness/vop3p_mov_b32_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3p_mov_b32_simd_correctness_test.cpp
@@ -2,15 +2,14 @@
 // SPDX-License-Identifier: MIT
 
 /// @file vop3p_mov_b32_simd_correctness_test.cpp
-/// @brief Bit-identity check (SIMD fast path vs scalar body) for
-/// v_pk_mov_b32_vop3p on CDNA4. Default packing only (op_sel=0,
-/// op_sel_hi=3): the 64-bit result is (src0_lo, src1_hi), where each src
-/// pair lives in consecutive VGPRs {base, base+1}. The SIMD path uses
-/// read_simd64/write_simd64 to fetch and store the 64-bit pair. Each case runs
-/// TWICE in the same process -- once forcing the scalar body, once the SIMD fast
-/// path, with identical inputs/EXEC -- and the 64-bit dst results are asserted
-/// equal with EXPECT_EQ (util::set_force_scalar_for_testing flips the gate
-/// in-process). In-process inactive lanes must keep the sentinel.
+/// @brief Golden selector check for v_pk_mov_b32_vop3p on CDNA targets.
+///
+/// Hardware-observed behavior for the assembler's default op_sel_hi value:
+/// op_sel[0] selects the low output dword from src0.{lo,hi}, and op_sel[1]
+/// selects the high output dword from src1.{lo,hi}. Each case runs twice in
+/// the same process -- once forcing the scalar body, once allowing the SIMD
+/// fast path -- and both paths must match the same golden 64-bit result.
+/// In-process inactive lanes must keep the sentinel.
 
 #include "util/simd_test_hooks.h"
 
@@ -41,10 +40,22 @@ constexpr uint32_t VGPRS_PER_WF = 256;
 constexpr uint32_t kDstVgpr = 8; // pair occupies kDstVgpr..kDstVgpr+1
 constexpr uint32_t DST_SENTINEL = 0xCDCDCDCDu;
 
+struct ArchCase {
+  rj_code_arch_t arch;
+  const char *name;
+};
+
+constexpr std::array<ArchCase, 3> kArchCases{{
+    {ROCJITSU_CODE_ARCH_CDNA2, "cdna2"},
+    {ROCJITSU_CODE_ARCH_CDNA3, "cdna3"},
+    {ROCJITSU_CODE_ARCH_CDNA4, "cdna4"},
+}};
+
 constexpr void vop3p_encode(uint32_t op, uint32_t vdst, uint32_t src0, uint32_t src1,
-                            uint32_t words[2]) {
-  // op_sel = 0, op_sel_hi = 3 (default packing). neg / neg_hi / clamp = 0.
-  words[0] = (vdst & 0xFFu) | ((op & 0x7Fu) << 16) | (0x1A7u << 23);
+                            uint32_t op_sel, uint32_t words[2]) {
+  // op_sel_hi = 3 is what LLVM emits for v_pk_mov_b32 op_sel:[x,y].
+  // neg / neg_hi / clamp = 0.
+  words[0] = (vdst & 0xFFu) | ((op_sel & 0x3u) << 11) | ((op & 0x7Fu) << 16) | (0x1A7u << 23);
   words[1] = (src0 & 0x1FFu) | ((src1 & 0x1FFu) << 9) | (0x3u << 27);
 }
 
@@ -72,15 +83,18 @@ struct Fixture {
   std::unique_ptr<Decoder> decoder;
   amdgpu::Wavefront *wf = nullptr;
 
-  Fixture() : gpu_mem("vop3p_mov_b32_mem"), l2("vop3p_mov_b32_l2") {
+  explicit Fixture(const ArchCase &arch)
+      : gpu_mem(std::string("vop3p_mov_b32_mem_") + arch.name),
+        l2(std::string("vop3p_mov_b32_l2_") + arch.name) {
     amdgpu::ComputeUnitCore::Config cfg{};
-    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.arch = arch.arch;
     cfg.num_wf_slots = 1;
     cfg.sgprs_per_wf = SGPRS_PER_WF;
     cfg.vgprs_per_wf = VGPRS_PER_WF;
     cfg.lds_size_kb = 64;
-    cu = amdgpu::ComputeUnitCore::create("cu_vop3p_mov_b32", cfg, &gpu_mem, &l2);
-    decoder = Decoder::create(ROCJITSU_CODE_ARCH_CDNA4);
+    cu = amdgpu::ComputeUnitCore::create(std::string("cu_vop3p_mov_b32_") + arch.name, cfg,
+                                         &gpu_mem, &l2);
+    decoder = Decoder::create(arch.arch);
     wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
   }
 
@@ -120,17 +134,38 @@ struct ForceScalarGuard {
   ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
 };
 
+std::array<uint64_t, WF_SIZE> expected(uint32_t rot, uint64_t exec, uint32_t op_sel) {
+  std::array<uint64_t, WF_SIZE> out{};
+  const uint64_t sentinel = uint64_t{DST_SENTINEL} | (uint64_t{DST_SENTINEL} << 32);
+  for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+    const bool active = (exec >> lane) & 1ULL;
+    if (!active) {
+      out[lane] = sentinel;
+      continue;
+    }
+    const uint32_t src0_lo = kVals[lane % kVals.size()];
+    const uint32_t src0_hi = kVals[(lane + 1) % kVals.size()];
+    const uint32_t src1_lo = kVals[(lane + rot) % kVals.size()];
+    const uint32_t src1_hi = kVals[(lane + rot + 1) % kVals.size()];
+    const uint32_t lo = (op_sel & 1u) ? src0_hi : src0_lo;
+    const uint32_t hi = (op_sel & 2u) ? src1_hi : src1_lo;
+    out[lane] = uint64_t{lo} | (uint64_t{hi} << 32);
+  }
+  return out;
+}
+
 void check(uint64_t exec) {
   ForceScalarGuard gate_guard;
 
-  auto run_mode = [&](bool force_scalar, uint32_t rot) -> std::array<uint64_t, WF_SIZE> {
+  auto run_mode = [&](const ArchCase &arch, bool force_scalar, uint32_t rot,
+                      uint32_t op_sel) -> std::array<uint64_t, WF_SIZE> {
     util::set_force_scalar_for_testing(force_scalar);
-    Fixture fx;
+    Fixture fx(arch);
     EXPECT_NE(fx.cu, nullptr);
     EXPECT_NE(fx.wf, nullptr);
     uint32_t words[2] = {0u, 0u};
     // src0 = VGPR 256 (pair v0:v1), src1 = VGPR 258 (pair v2:v3).
-    vop3p_encode(/*op=*/51, kDstVgpr, /*src0=*/256, /*src1=*/258, words);
+    vop3p_encode(/*op=*/51, kDstVgpr, /*src0=*/256, /*src1=*/258, op_sel, words);
     Instruction *inst = fx.decoder->decode(words);
     EXPECT_NE(inst, nullptr) << "v_pk_mov_b32_vop3p decode failed";
     auto out = fx.run(inst, rot, exec);
@@ -138,21 +173,32 @@ void check(uint64_t exec) {
     return out;
   };
 
-  for (uint32_t rot = 0; rot < kVals.size(); ++rot) {
-    const auto scalar_out = run_mode(/*force_scalar=*/true, rot);
-    const auto simd_out = run_mode(/*force_scalar=*/false, rot);
+  for (const auto &arch : kArchCases) {
+    for (uint32_t rot = 0; rot < kVals.size(); ++rot) {
+      for (uint32_t op_sel = 0; op_sel < 4; ++op_sel) {
+        const auto golden = expected(rot, exec, op_sel);
+        const auto scalar_out = run_mode(arch, /*force_scalar=*/true, rot, op_sel);
+        const auto simd_out = run_mode(arch, /*force_scalar=*/false, rot, op_sel);
 
-    EXPECT_EQ(scalar_out, simd_out)
-        << "v_pk_mov_b32_vop3p rot=" << rot << ": SIMD path diverged from scalar body";
+        EXPECT_EQ(scalar_out, golden)
+            << arch.name << " v_pk_mov_b32_vop3p rot=" << rot << " op_sel=" << op_sel
+            << ": scalar path diverged from hardware-observed semantics";
+        EXPECT_EQ(simd_out, golden)
+            << arch.name << " v_pk_mov_b32_vop3p rot=" << rot << " op_sel=" << op_sel
+            << ": SIMD path diverged from hardware-observed semantics";
 
-    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
-      const bool active = (exec >> lane) & 1ULL;
-      if (!active) {
-        const uint64_t sentinel = uint64_t{DST_SENTINEL} | (uint64_t{DST_SENTINEL} << 32);
-        EXPECT_EQ(simd_out[lane], sentinel)
-            << "rot=" << rot << ": clobbered inactive lane " << lane;
-        EXPECT_EQ(scalar_out[lane], sentinel)
-            << "rot=" << rot << ": clobbered inactive lane " << lane;
+        for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+          const bool active = (exec >> lane) & 1ULL;
+          if (!active) {
+            const uint64_t sentinel = uint64_t{DST_SENTINEL} | (uint64_t{DST_SENTINEL} << 32);
+            EXPECT_EQ(simd_out[lane], sentinel) << arch.name << " rot=" << rot
+                                                << " op_sel=" << op_sel
+                                                << ": clobbered inactive lane " << lane;
+            EXPECT_EQ(scalar_out[lane], sentinel) << arch.name << " rot=" << rot
+                                                  << " op_sel=" << op_sel
+                                                  << ": clobbered inactive lane " << lane;
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
## Motivation

This updates the packed move generator so the high 32-bit output is selected from `op_sel[1]`, matching the hardware-observed behavior for `v_pk_mov_b32` with the assembler default `op_sel_hi = 3`. The generated shared execution body now uses `op_sel` for both output dword selectors instead of mixing `op_sel` and `op_sel_hi`. This issue was exposed by the rocRAND test suite.

Despite being in the VOP3P family, `v_pk_mov_b32` does not use op_sel_hi to select input halves to compute the high output half. Instead, cdna3/4 ISA states that "The source operands are treated as 64 bit and are subject to alignment restrictions for both SGPR and VGPR. For two VGPR inputs this opcode can be used as an arbitrary gather by using OP_SEL to select either the even VGPR specified or the next odd VGPR." 
ISA example (op_sel determines the source for both the low and high half of output):
  `v_pk_mov_b32 v0, v2, v4 op_sel:[0,1] // evaluates v0 <- v2 and v1 <- v5`

## Technical Details

-_PK_MOV_B32` now treats `op_sel` as the selector for both output dwords: `op_sel[0]` selects `src0.lo/src0.hi` for the low result, and `op_sel[1]` selects `src1.lo/src1.hi` for the high result. `op_sel_hi` remains constrained to the assembler default value for the SIMD fast path.
- Widened SIMD implementation from default `op_sel == 0` to all four `op_sel` combinations.

## JIRA ID

N/A

## Test Plan

ctest and rocjitsu-test-suite

## Test Result

all pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
