### PR TITLE
Revert "fix(libhsakmt): Define _GNU_SOURCE before libhsakmt.h include"

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/hsakmtmodel.c
+++ b/projects/rocr-runtime/libhsakmt/src/hsakmtmodel.c
@@ -23,13 +23,13 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-#define _GNU_SOURCE
-
 #include "hsakmt/hsakmtmodel.h"
 #include "hsakmt/hsakmt_drm.h"
 #include "libhsakmt.h"
 #include "hsakmt/hsakmttypes.h"
 #include "hsakmt/hsakmtmodeliface.h"
+#define _GNU_SOURCE
+#define __USE_GNU
 #include <assert.h>
 #include <errno.h>
 #include <inttypes.h>


### PR DESCRIPTION
Reverts ROCm/rocm-systems#8555