### PR TITLE
feat(rocshmem): [scripts] add --variant-dir option to run_perf_compare.sh

### DIFF
--- a/projects/rocshmem/scripts/functional_tests/run_perf_compare.sh
+++ b/projects/rocshmem/scripts/functional_tests/run_perf_compare.sh
@@ -16,9 +16,9 @@
 #   --cmake-args   ARGS   Extra cmake args for all builds (quoted string)
 #   --branch-args  ARGS   Extra cmake args for the branch build only (quoted string)
 #   --variant-args SPEC   Additional named variant: NAME:ENV1=V1,...:cmake-args
-#                         NAME       - label used in plots and directory name
-#                         ENV1=V1,…  - comma-separated env vars set at runtime
-#                         cmake-args - extra cmake args for this variant's build
+#                         NAME       - Label used in plots and directory name
+#                         ENV1=V1,…  - Comma-separated environment variables to set at runtime
+#                         cmake-args - Extra CMake arguments for this variant's build
 #                         May be repeated for multiple variants.
 #                         Example: --variant-args "sdma-on:ROCSHMEM_SDMA_ENABLED=1:-DUSE_SDMA=ON"
 #   --pr           NUM    Compare GitHub PR NUM against origin/develop baseline.
@@ -27,12 +27,13 @@
 #   --baseline-dir PATH   Use PATH as pre-built baseline (skips baseline build).
 #                         Use with --skip-baseline to also skip baseline test runs.
 #   --branch-dir   PATH   Use PATH as pre-built branch build (skips branch build).
+#                         Use with --skip-branch to also skip branch test runs.
 #   --variant-dir  SPEC   Additional named variant: NAME:ENV1=V1,...:PATH
-#                         NAME       - label used in plots and directory name
-#                         ENV1=V1,…  - comma-separated env vars set at runtime
-#                         PATH       - PATH to use as pre-build variant build (skips variant build)
+#                         NAME       - Label used in plots
+#                         ENV1=V1,…  - Comma-separated environment variables to set at runtime
+#                         PATH       - Use PATH as pre-built variant build (skips variant build)
 #                         May be repeated for multiple variants.
-#                         Example: --variant-path "sdma-on:ROCSHMEM_SDMA_ENABLED=1:build/sdma"
+#                         Example: --variant-dir "sdma-on:ROCSHMEM_SDMA_ENABLED=1:build/sdma"
 #   --skip-build          Skip all build steps (reuse existing builds)
 #   --skip-baseline       Skip baseline build and test runs (reuse existing logs)
 #   --skip-develop        Alias for --skip-baseline

--- a/projects/rocshmem/scripts/functional_tests/run_perf_compare.sh
+++ b/projects/rocshmem/scripts/functional_tests/run_perf_compare.sh
@@ -9,25 +9,25 @@
 #   ./scripts/functional_tests/run_perf_compare.sh [OPTIONS]
 #
 # Options:
-#   --iterations N        Number of test iterations per config (default: 10)
-#   --suite SUITE         Test suite: "heatmap", "all", "rma", etc (default: heatmap)
+#   --iterations   N      Number of test iterations per config (default: 10)
+#   --suite        SUITE  Test suite: "heatmap", "all", "rma", etc (default: heatmap)
 #   --build-config CFG    Build config script name under scripts/build_configs/
 #                         (default: all_backends)
-#   --cmake-args ARGS     Extra cmake args for all builds (quoted string)
-#   --branch-args ARGS    Extra cmake args for the branch build only (quoted string)
+#   --cmake-args   ARGS   Extra cmake args for all builds (quoted string)
+#   --branch-args  ARGS   Extra cmake args for the branch build only (quoted string)
 #   --variant-args SPEC   Additional named variant: NAME:ENV1=V1,...:cmake-args
-#                         NAME      - label used in plots and directory name
-#                         ENV1=V1,… - comma-separated env vars set at runtime
+#                         NAME       - label used in plots and directory name
+#                         ENV1=V1,…  - comma-separated env vars set at runtime
 #                         cmake-args - extra cmake args for this variant's build
 #                         May be repeated for multiple variants.
 #                         Example: --variant-args "sdma-on:ROCSHMEM_SDMA_ENABLED=1:-DUSE_SDMA=ON"
-#   --pr NUM              Compare GitHub PR NUM against origin/develop baseline.
+#   --pr           NUM    Compare GitHub PR NUM against origin/develop baseline.
 #                         Fetches the PR branch, builds it, and names it "pr<NUM>".
-#   --base-branch NAME    Base branch to compare against (default: origin/develop)
+#   --base-branch  NAME   Base branch to compare against (default: origin/develop)
 #   --baseline-dir PATH   Use PATH as pre-built baseline (skips baseline build).
 #                         Use with --skip-baseline to also skip baseline test runs.
-#   --branch-dir PATH     Use PATH as pre-built branch build (skips branch build).
-#   --variant-dir SPEC    Additional named variant: NAME:ENV1=V1,...:PATH
+#   --branch-dir   PATH   Use PATH as pre-built branch build (skips branch build).
+#   --variant-dir  SPEC   Additional named variant: NAME:ENV1=V1,...:PATH
 #                         NAME       - label used in plots and directory name
 #                         ENV1=V1,…  - comma-separated env vars set at runtime
 #                         PATH       - PATH to use as pre-build variant build (skips variant build)
@@ -37,7 +37,7 @@
 #   --skip-baseline       Skip baseline build and test runs (reuse existing logs)
 #   --skip-develop        Alias for --skip-baseline
 #   --skip-branch         Skip branch/PR build and test runs (reuse existing logs)
-#   --outdir DIR          Output directory for plots (default: auto-generated)
+#   --outdir       DIR    Output directory for plots (default: auto-generated)
 #
 # Prerequisites:
 #   - Open MPI in PATH (or set OMPI_HOME)
@@ -60,7 +60,7 @@ SUITE=heatmap
 BUILD_CONFIG=all_backends
 CMAKE_ARGS=""
 BRANCH_ARGS=""
-VARIANT_SPECS=()   # array of "name:env1=v1,...:cmake-args"
+VARIANT_SPECS=()     # array of "name:env1=v1,...:cmake-args"
 PR_NUM=""
 VARIANT_DIR_SPECS=() # array of "name:env1=v1,...:build-dir"
 SKIP_BUILD=0

--- a/projects/rocshmem/scripts/functional_tests/run_perf_compare.sh
+++ b/projects/rocshmem/scripts/functional_tests/run_perf_compare.sh
@@ -235,7 +235,9 @@ if [[ $SKIP_BUILD -eq 0 ]]; then
   fi
 
   # Build baseline
-  if [[ $SKIP_BASELINE -eq 0 && -z "$BASELINE_DIR" ]]; then
+  if [[ $SKIP_BASELINE -eq 1 ]]; then
+    echo "--- Skipping baseline build ---"
+  elif [[ -z "$BASELINE_DIR" ]]; then
     echo "--- Building baseline ---"
     WORKTREE="/tmp/rocshmem-baseline-$$"
 
@@ -259,7 +261,7 @@ if [[ $SKIP_BUILD -eq 0 ]]; then
     (cd "$BUILD_BASELINE" && "$BASELINE_CONFIG" $CMAKE_ARGS)
     git -C "$ROCSHMEM_DIR" worktree remove "$WORKTREE" 2>/dev/null || true
   else
-    echo "--- Skipping baseline build ---"
+    echo "--- Using pre-built baseline dir: $BASELINE_DIR ---"
   fi
 
   # Build branch
@@ -286,7 +288,7 @@ if [[ $SKIP_BUILD -eq 0 ]]; then
       (cd "$BUILD_BRANCH" && "$BUILD_CONFIG_SCRIPT" $CMAKE_ARGS $BRANCH_ARGS)
     fi
   else
-    echo "--- Using pre-built branch dir: $BRANCH_DIR ---"
+    echo "--- Using pre-built branch dir:   $BRANCH_DIR ---"
   fi
 
   # Build additional variants

--- a/projects/rocshmem/scripts/functional_tests/run_perf_compare.sh
+++ b/projects/rocshmem/scripts/functional_tests/run_perf_compare.sh
@@ -27,6 +27,12 @@
 #   --baseline-dir PATH   Use PATH as pre-built baseline (skips baseline build).
 #                         Use with --skip-baseline to also skip baseline test runs.
 #   --branch-dir PATH     Use PATH as pre-built branch build (skips branch build).
+#   --variant-dir SPEC    Additional named variant: NAME:ENV1=V1,...:PATH
+#                         NAME       - label used in plots and directory name
+#                         ENV1=V1,…  - comma-separated env vars set at runtime
+#                         PATH       - PATH to use as pre-build variant build (skips variant build)
+#                         May be repeated for multiple variants.
+#                         Example: --variant-path "sdma-on:ROCSHMEM_SDMA_ENABLED=1:build/sdma"
 #   --skip-build          Skip all build steps (reuse existing builds)
 #   --skip-baseline       Skip baseline build and test runs (reuse existing logs)
 #   --skip-develop        Alias for --skip-baseline
@@ -56,6 +62,7 @@ CMAKE_ARGS=""
 BRANCH_ARGS=""
 VARIANT_SPECS=()   # array of "name:env1=v1,...:cmake-args"
 PR_NUM=""
+VARIANT_DIR_SPECS=() # array of "name:env1=v1,...:build-dir"
 SKIP_BUILD=0
 SKIP_BASELINE=0
 SKIP_BRANCH=0
@@ -76,6 +83,7 @@ while [[ $# -gt 0 ]]; do
     --base-branch)   BASE_BRANCH="$2";                     shift 2 ;;
     --baseline-dir)  BASELINE_DIR="$2";                    shift 2 ;;
     --branch-dir)    BRANCH_DIR="$2";                      shift 2 ;;
+    --variant-dir)   VARIANT_DIR_SPECS+=("$2");            shift 2 ;;
     --skip-build)    SKIP_BUILD=1;                         shift ;;
     --skip-baseline) SKIP_BASELINE=1;                      shift ;;
     --skip-develop)  SKIP_BASELINE=1;                      shift ;;
@@ -290,6 +298,12 @@ if [[ $SKIP_BUILD -eq 0 ]]; then
     (cd "$vdir" && "$BUILD_CONFIG_SCRIPT" $CMAKE_ARGS $vcmake)
   done
 
+  # Additional pre-built variants
+  for dir_spec in "${VARIANT_DIR_SPECS[@]}"; do
+    IFS=':' read -r vname venv vdir <<< "$dir_spec"
+    echo "--- Using pre-built variant dir:  $vdir ---"
+  done
+
   echo ">>> Builds complete"
 else
   echo ""
@@ -345,6 +359,16 @@ for spec in "${VARIANT_SPECS[@]}"; do
   run_iterations "$vdir" "logs-${SUITE}" "$vname" "$env_prefix"
 done
 
+for dir_spec in "${VARIANT_DIR_SPECS[@]}"; do
+  IFS=':' read -r vname venv vdir <<< "$dir_spec"
+  env_prefix=""
+  IFS=',' read -ra pairs <<< "$venv"
+  for pair in "${pairs[@]}"; do
+    [[ -n "$pair" ]] && env_prefix+="export $pair; "
+  done
+  run_iterations "$vdir" "logs-${SUITE}" "$vname" "$env_prefix"
+done
+
 echo ">>> All test runs complete"
 
 # ---------------------------------------------------------------------------
@@ -358,6 +382,10 @@ VARIANT_ARGS=("${BRANCH_LABEL}:$BUILD_BRANCH/logs-${SUITE}-*")
 for spec in "${VARIANT_SPECS[@]}"; do
   IFS=':' read -r vname venv vcmake <<< "$spec"
   vdir="$PROJECTS_DIR/build-${BRANCH_SAFE}-${vname}"
+  VARIANT_ARGS+=("${vname}:${vdir}/logs-${SUITE}-*")
+done
+for dir_spec in "${VARIANT_DIR_SPECS[@]}"; do
+  IFS=':' read -r vname venv vdir <<< "$dir_spec"
   VARIANT_ARGS+=("${vname}:${vdir}/logs-${SUITE}-*")
 done
 

--- a/projects/rocshmem/scripts/functional_tests/run_perf_compare.sh
+++ b/projects/rocshmem/scripts/functional_tests/run_perf_compare.sh
@@ -90,7 +90,13 @@ while [[ $# -gt 0 ]]; do
     --skip-branch)   SKIP_BRANCH=1;                        shift ;;
     --outdir)        OUTDIR="$2";                          shift 2 ;;
     -h|--help)
-      sed -n '2,/^###$/p' "$0" | head -n -1
+      # /^##\+$/,/^##\+$/ : match lines between those filled with two or more #s
+      # {                 : and execute the following command sequence
+      #    /^##\+$/d;     : match lines filled with two or more #s and delete them
+      #    s/^# \?//;     : match all lines and substitute an initial # (and optional ' ') with ''
+      #    p;             : match all lines and print them
+      # }                 : end the command sequence
+      sed -n '/^##\+$/,/^##\+$/ { /^##\+$/d; s/^# \?//; p; }' "$0"
       exit 0 ;;
     *) echo "Unknown option: $1" >&2; exit 1 ;;
   esac

--- a/projects/rocshmem/scripts/functional_tests/run_perf_compare.sh
+++ b/projects/rocshmem/scripts/functional_tests/run_perf_compare.sh
@@ -293,7 +293,7 @@ if [[ $SKIP_BUILD -eq 0 ]]; then
 
   # Build additional variants
   for spec in "${VARIANT_SPECS[@]}"; do
-    IFS=':' read -r vname _venv vcmake <<< "$spec"
+    IFS=':' read -r vname venv vcmake <<< "$spec"
     vdir="$PROJECTS_DIR/build-${BRANCH_SAFE}-${vname}"
     echo "--- Building variant: $vname ---"
     mkdir -p "$vdir"
@@ -351,7 +351,7 @@ else
 fi
 
 for spec in "${VARIANT_SPECS[@]}"; do
-  IFS=':' read -r vname venv _vcmake <<< "$spec"
+  IFS=':' read -r vname venv vcmake <<< "$spec"
   vdir="$PROJECTS_DIR/build-${BRANCH_SAFE}-${vname}"
   env_prefix=""
   IFS=',' read -ra pairs <<< "$venv"

--- a/projects/rocshmem/scripts/functional_tests/run_perf_compare.sh
+++ b/projects/rocshmem/scripts/functional_tests/run_perf_compare.sh
@@ -90,13 +90,16 @@ while [[ $# -gt 0 ]]; do
     --skip-branch)   SKIP_BRANCH=1;                        shift ;;
     --outdir)        OUTDIR="$2";                          shift 2 ;;
     -h|--help)
-      # /^##\+$/,/^##\+$/ : match lines between those filled with two or more #s
-      # {                 : and execute the following command sequence
-      #    /^##\+$/d;     : match lines filled with two or more #s and delete them
-      #    s/^# \?//;     : match all lines and substitute an initial # (and optional ' ') with ''
-      #    p;             : match all lines and print them
-      # }                 : end the command sequence
-      sed -n '/^##\+$/,/^##\+$/ { /^##\+$/d; s/^# \?//; p; }' "$0"
+      # Print the help text embedded between the banner lines in the file header,
+      # stripping out the leading comment characters
+      #
+      # /^##+$/,/^##+$/ : match lines between those filled with 2+ '#'
+      # {               : and execute the following command sequence
+      #    /^##+$/d;    :   match lines filled with 2+ '#' and delete, then
+      #    s/^# ?//;    :   match all lines and strip out leading '#' or '# ', then
+      #    p;           :   match all lines and print
+      # }               : end the command sequence
+      sed -nE '/^##+$/,/^##+$/ { /^##+$/d; s/^# ?//; p; }' "$0"
       exit 0 ;;
     *) echo "Unknown option: $1" >&2; exit 1 ;;
   esac

--- a/projects/rocshmem/scripts/functional_tests/run_perf_compare.sh
+++ b/projects/rocshmem/scripts/functional_tests/run_perf_compare.sh
@@ -30,7 +30,7 @@
 #                         Use with --skip-branch to also skip branch test runs.
 #   --variant-dir  SPEC   Additional named variant: NAME:ENV1=V1,...:PATH
 #                         NAME       - Label used in plots
-#                         ENV1=V1,…  - Comma-separated environment variables to set at runtime
+#                         ENV1=V1,…  - Comma-separated environment variables to set at runtime (values must not contain ':')
 #                         PATH       - Use PATH as pre-built variant build (skips variant build)
 #                         May be repeated for multiple variants.
 #                         Example: --variant-dir "sdma-on:ROCSHMEM_SDMA_ENABLED=1:build/sdma"
@@ -372,7 +372,15 @@ for spec in "${VARIANT_SPECS[@]}"; do
 done
 
 for dir_spec in "${VARIANT_DIR_SPECS[@]}"; do
-  IFS=':' read -r vname venv vdir <<< "$dir_spec"
+  IFS=':' read -r vname venv vdir extra <<< "$dir_spec"
+  if [[ -z "$vname" || -z "$vdir" || -n "${extra:-}" ]]; then
+    echo "ERROR: Invalid --variant-dir SPEC (expected NAME:ENV1=V1,...:PATH): $dir_spec" >&2
+    exit 1
+  fi
+  if [[ ! -d "$vdir" ]]; then
+    echo "ERROR: --variant-dir PATH is not a directory: $vdir" >&2
+    exit 1
+  fi
   env_prefix=""
   IFS=',' read -ra pairs <<< "$venv"
   for pair in "${pairs[@]}"; do


### PR DESCRIPTION
## Motivation

The baseline and comparison branches could be input as pre-built directories to the `run_perf_compare.sh` script, but additional variants could not. Adding a `--variant-dir` option adds consistency and simplifies some workflows.

## Technical Details

* Add `--variant-dir SPEC` option to `run_perf_compare.sh`.
  Each `SPEC` is in the form `NAME:ENV1=V1,...:PATH`, where
  * `NAME` is the label used in plots
  * `ENV1=V1,...` is a list of comma-separate environment variables to set at runtime
  * PATH is the directory path containing the pre-built variant
* Fix handling of the `-h|--help` option to only print out the script's help text.

## Test Result

Testing using #7217 with a pre-built variant that builds only a single GDA provider.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
