### PR TITLE
ci(rocdbgapi): trigger Windows build on rocdbgapi changes

### DIFF
--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -111,6 +111,7 @@ trigger_windows_ci_for_subtrees_paths = [
     "projects/clr/*",
     "projects/hip/*",
     "projects/hip-tests/*",
+    "projects/rocdbgapi/*",
     "projects/rocr-runtime/*",
     "shared/amdgpu-windows-interop/**",
     ".github/*/therock*",


### PR DESCRIPTION
## Motivation

rocdbgapi PRs were skipping the Windows CI build job, as observed in #8562.
`projects/rocdbgapi/*` was missing from `trigger_windows_ci_for_subtrees_paths`,
causing the Windows job matrix to be empty and the job to be skipped.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.